### PR TITLE
Update docker-release workflow to tag image with release version

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -72,6 +72,8 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository }}:ubuntu
           ghcr.io/${{ github.repository }}:latest
+          ghcr.io/${{ github.repository }}:${{ env.TAG_NAME }}
+          ghcr.io/${{ github.repository }}:${{ env.TAG_NAME }}-ubuntu
           
         file: tools/docker/Dockerfile.ubuntu-prod
         cache-from: type=registry,ref=${{ github.repository }}:latest


### PR DESCRIPTION
Deploying components based purely on latest-tag is bad practice and might lead to problems down the line. Being able to use an immutable tag will make working with the container image more predictable.

Currently looking into writing a helm chart, and helm defaults to use the appVersion defined in the Chart.yaml as the image tag. Really don't want to hardcode the tag as latest :)