### PR TITLE
CI: Use v3 of Actions "upload-artifacts", "checkout" and "cache"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       #  username: ${{ github.repository_owner }}
       #  password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
     - name: Install dependencies
@@ -38,7 +38,7 @@ jobs:
           mkdir -p ${{github.workspace}}/build
     - name: Cache build deps
       id: cache-deps
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.ccache

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     
     - uses: dsaltares/fetch-gh-release-asset@master
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     name: Build aarch64 on ubuntu20.04
     needs: create-release
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
     - name: Cache build deps
@@ -80,7 +80,7 @@ jobs:
         echo finished
         ls -al
     - name: Upload
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: dragonfly-aarch64
         path: build-opt/dragonfly-*tar.gz
@@ -91,14 +91,14 @@ jobs:
     container:
       image: ghcr.io/romange/ubuntu-dev:20
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
     - name: Build artifacts
       run: |
           ./tools/release.sh
     - name: Upload
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: dragonfly-amd64
         path: build-opt/dragonfly-*tar.gz


### PR DESCRIPTION
This PR updates the GitHub Actions to latest major tags.
