### PR TITLE
Update build steps for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ git clone --recursive https://github.com/dragonflydb/dragonfly && cd dragonfly
 
 # to install dependencies
 sudo apt install ninja-build libunwind-dev libboost-fiber-dev libssl-dev \
-     autoconf-archive libtool
+     autoconf-archive libtool cmake g++
 
 # Configure the build
 ./helio/blaze.sh -release


### PR DESCRIPTION
`cmake` and `c++` compilers are required to build from source.

Otherwise, you'll enter errors like

```
$ ./helio/blaze.sh -release
Using launcher
+ cmake -L -B build-opt -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=
./helio/blaze.sh: line 51: cmake: command not found
```

or

```
$ ./helio/blaze.sh -release
Using launcher
+ cmake -L -B build-opt -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++ -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=
-- The C compiler identification is GNU 11.2.0
-- The CXX compiler identification is unknown
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
CMake Error at CMakeLists.txt:10 (project):
  The CMAKE_CXX_COMPILER:

    g++

  is not a full path and was not found in the PATH.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.

...
```

