### PR TITLE
docs: Fix a variable name for bucket in Dashtable section

### DIFF
--- a/doc/dashtable.md
+++ b/doc/dashtable.md
@@ -45,7 +45,7 @@ Similarly to a classic hashtable, dashtable (DT) also holds an array of pointers
 
 ![Dashtable Diagram](./dashtable.svg)
 
-In the diagram above you can see how dashtable looks like. Each segment is comprised of `N` buckets. For example, in our implementation a dashtable has 60 buckets per segment (it's a compile-time parameter that can be configured).
+In the diagram above you can see how dashtable looks like. Each segment is comprised of `K` buckets. For example, in our implementation a dashtable has 60 buckets per segment (it's a compile-time parameter that can be configured).
 
 ### Segment zoom-in
 


### PR DESCRIPTION
Hello, this is just a small typo fix.

In the [`dashtable.svg`](https://github.com/dragonflydb/dragonfly/blob/main/doc/dashtable.svg) diagram, the number segment is denoted by `N` while `K` is used for buckets (like bucket1, bucket2, ..., bucketK).