### PR TITLE
Fix Various Naming Conventions around `Subscriber`

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,3 +2,5 @@
 
 * **[Philipp Born](https://github.com/tamcore)**
   * Helm Chart
+* **[Ryan Russell](https://github.com/ryanrussell)**
+  * Docs & Code Readability

--- a/src/server/channel_slice.cc
+++ b/src/server/channel_slice.cc
@@ -55,21 +55,21 @@ auto ChannelSlice::FetchSubscribers(string_view channel) -> vector<Subscriber> {
   auto it = channels_.find(channel);
   if (it != channels_.end()) {
     res.reserve(it->second->subscribers.size());
-    CopySubsribers(it->second->subscribers, string{}, &res);
+    CopySubscribers(it->second->subscribers, string{}, &res);
   }
 
   for (const auto& k_v : patterns_) {
     const string& pat = k_v.first;
     // 1 - match
     if (stringmatchlen(pat.data(), pat.size(), channel.data(), channel.size(), 0) == 1) {
-      CopySubsribers(k_v.second->subscribers, pat, &res);
+      CopySubscribers(k_v.second->subscribers, pat, &res);
     }
   }
 
   return res;
 }
 
-void ChannelSlice::CopySubsribers(const SubscribeMap& src, const std::string& pattern,
+void ChannelSlice::CopySubscribers(const SubscribeMap& src, const std::string& pattern,
                                   vector<Subscriber>* dest) {
   for (const auto& sub : src) {
     Subscriber s(sub.first, sub.second.thread_id);

--- a/src/server/channel_slice.cc
+++ b/src/server/channel_slice.cc
@@ -69,7 +69,7 @@ auto ChannelSlice::FetchSubscribers(string_view channel) -> vector<Subscriber> {
   return res;
 }
 
-void ChannelSlice::CopySubsribers(const SubsribeMap& src, const std::string& pattern,
+void ChannelSlice::CopySubsribers(const SubscribeMap& src, const std::string& pattern,
                                   vector<Subscriber>* dest) {
   for (const auto& sub : src) {
     Subscriber s(sub.first, sub.second.thread_id);

--- a/src/server/channel_slice.h
+++ b/src/server/channel_slice.h
@@ -50,7 +50,7 @@ class ChannelSlice {
 
   using SubscribeMap = absl::flat_hash_map<ConnectionContext*, SubscriberInternal>;
 
-  static void CopySubsribers(const SubscribeMap& src, const std::string& pattern,
+  static void CopySubscribers(const SubscribeMap& src, const std::string& pattern,
                              std::vector<Subscriber>* dest);
 
   struct Channel {

--- a/src/server/channel_slice.h
+++ b/src/server/channel_slice.h
@@ -48,13 +48,13 @@ class ChannelSlice {
     }
   };
 
-  using SubsribeMap = absl::flat_hash_map<ConnectionContext*, SubscriberInternal>;
+  using SubscribeMap = absl::flat_hash_map<ConnectionContext*, SubscriberInternal>;
 
-  static void CopySubsribers(const SubsribeMap& src, const std::string& pattern,
+  static void CopySubsribers(const SubscribeMap& src, const std::string& pattern,
                              std::vector<Subscriber>* dest);
 
   struct Channel {
-    SubsribeMap subscribers;
+    SubscribeMap subscribers;
   };
 
   absl::flat_hash_map<std::string, std::unique_ptr<Channel>> channels_;

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -27,7 +27,7 @@ void ConnectionContext::ChangeSubscription(bool to_add, bool to_reply, CmdArgLis
       this->force_dispatch = true;
     }
 
-    // Gather all the channels we need to subsribe to / remove.
+    // Gather all the channels we need to subscribe to / remove.
     for (size_t i = 0; i < args.size(); ++i) {
       bool res = false;
       string_view channel = ArgS(args, i);
@@ -71,7 +71,7 @@ void ConnectionContext::ChangeSubscription(bool to_add, bool to_reply, CmdArgLis
     int32_t tid = util::ProactorBase::GetIndex();
     DCHECK_GE(tid, 0);
 
-    // Update the subsribers on publisher's side.
+    // Update the subscribers on publisher's side.
     auto cb = [&](EngineShard* shard) {
       ChannelSlice& cs = shard->channel_slice();
       unsigned start = shard_idx[shard->shard_id()];
@@ -100,8 +100,8 @@ void ConnectionContext::ChangeSubscription(bool to_add, bool to_reply, CmdArgLis
       (*this)->SendBulkString(action[to_add]);
       (*this)->SendBulkString(ArgS(args, i));  // channel
 
-      // number of subsribed channels for this connection *right after*
-      // we subsribe.
+      // number of subscribed channels for this connection *right after*
+      // we subscribe.
       (*this)->SendLong(result[i]);
     }
   }
@@ -121,7 +121,7 @@ void ConnectionContext::ChangePSub(bool to_add, bool to_reply, CmdArgList args) 
       this->force_dispatch = true;
     }
 
-    // Gather all the patterns we need to subsribe to / remove.
+    // Gather all the patterns we need to subscribe to / remove.
     for (size_t i = 0; i < args.size(); ++i) {
       bool res = false;
       string_view pattern = ArgS(args, i);
@@ -147,7 +147,7 @@ void ConnectionContext::ChangePSub(bool to_add, bool to_reply, CmdArgList args) 
     int32_t tid = util::ProactorBase::GetIndex();
     DCHECK_GE(tid, 0);
 
-    // Update the subsribers on publisher's side.
+    // Update the subscribers on publisher's side.
     auto cb = [&](EngineShard* shard) {
       ChannelSlice& cs = shard->channel_slice();
       for (string_view pattern : patterns) {

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -417,7 +417,7 @@ TEST_F(DflyEngineTest, PSubscribe) {
   resp = pp_->at(0)->Await([&] { return Run({"publish", "ab", "foo"}); });
   EXPECT_THAT(resp, IntArg(1));
 
-  ASSERT_EQ(1, SubsriberMessagesLen("IO1"));
+  ASSERT_EQ(1, SubscriberMessagesLen("IO1"));
 
   facade::Connection::PubMessage msg = GetPublishedMessage("IO1", 0);
   EXPECT_EQ("foo", msg.message);

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -936,7 +936,7 @@ void Service::Publish(CmdArgList args, ConnectionContext* cntx) {
     bc.Wait();  // Wait for all the messages to be sent.
   }
 
-  // If subsriber connections are closing they will wait
+  // If subscriber connections are closing they will wait
   // for the tokens to be reclaimed in OnClose(). This guarantees that subscribers we gathered
   // still exist till we finish publishing.
   for (auto& s : subscriber_arr) {

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -327,7 +327,7 @@ string BaseFamilyTest::GetId() const {
   return absl::StrCat("IO", id);
 }
 
-size_t BaseFamilyTest::SubsriberMessagesLen(string_view conn_id) const {
+size_t BaseFamilyTest::SubscriberMessagesLen(string_view conn_id) const {
   auto it = connections_.find(conn_id);
   if (it == connections_.end())
     return 0;

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -72,7 +72,7 @@ class BaseFamilyTest : public ::testing::Test {
   void UpdateTime(uint64_t ms);
 
   std::string GetId() const;
-  size_t SubsriberMessagesLen(std::string_view conn_id) const;
+  size_t SubscriberMessagesLen(std::string_view conn_id) const;
 
   // Returns message parts as returned by RESP:
   // pmessage, pattern, channel, message


### PR DESCRIPTION
There were various readability issues around variants of `Subscriber` in functions, variables, docs.

This splits resolving those into logical commits.

```bash
# Before
grep -ri subsrib | wc -l
27

# After
grep -ri subsrib | wc -l
0

```

Let me know if anything looks off to you. I separated them to make it easier to revert if something isn't correct.

Best,
Ryan