### PR TITLE
Helm chart updates (v0.1.1, init command override, TLS configuration, CRs for ServiceMonitor and PrometheusRule objects)

### DIFF
--- a/contrib/charts/dragonfly/Chart.yaml
+++ b/contrib/charts/dragonfly/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.1.0"
+appVersion: "v0.1.1"

--- a/contrib/charts/dragonfly/README.md
+++ b/contrib/charts/dragonfly/README.md
@@ -9,6 +9,7 @@ A Helm chart for Kubernetes
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity for pod assignment |
+| command.set | list | `[]` | Allow overriding the container's command |
 | extraArgs | list | `[]` | Extra arguments to pass to the dragonfly binary |
 | extraVolumeMounts | list | `[]` | Extra volume mounts corresponding to the volumes mounted above |
 | extraVolumes | list | `[]` | Extra volumes to mount into the pods |

--- a/contrib/charts/dragonfly/README.md
+++ b/contrib/charts/dragonfly/README.md
@@ -41,6 +41,10 @@ A Helm chart for Kubernetes
 | storage.enabled | bool | `false` | If /data should persist. This will provision a StatefulSet instead. |
 | storage.requests | string | `"128Mi"` | Volume size to request for the PVC |
 | storage.storageClassName | string | `""` | Global StorageClass for Persistent Volume(s) |
+| tls.cert | string | `""` | TLS certificate |
+| tls.enabled | bool | `false` | enable TLS |
+| tls.existing_secret | string | `""` | use TLS certificates from existing secret |
+| tls.key | string | `""` | TLS private key |
 | tolerations | list | `[]` | Tolerations for pod assignment |
 
 ----------------------------------------------

--- a/contrib/charts/dragonfly/README.md
+++ b/contrib/charts/dragonfly/README.md
@@ -22,6 +22,8 @@ A Helm chart for Kubernetes
 | nodeSelector | object | `{}` | Node labels for pod assignment |
 | podAnnotations | object | `{}` | Annotations for pods |
 | podSecurityContext | object | `{}` | Set securityContext for pod itself |
+| prometheusRule.enabled | bool | `false` | Deploy a PrometheusRule |
+| prometheusRule.spec | list | `[]` | PrometheusRule.Spec https://awesome-prometheus-alerts.grep.to/rules |
 | replicaCount | int | `1` | Number of replicas to deploy |
 | resources.limits | object | `{}` | The resource limits for the containers |
 | resources.requests | object | `{}` | The requested resources for the containers |

--- a/contrib/charts/dragonfly/README.md
+++ b/contrib/charts/dragonfly/README.md
@@ -26,11 +26,18 @@ A Helm chart for Kubernetes
 | resources.limits | object | `{}` | The resource limits for the containers |
 | resources.requests | object | `{}` | The requested resources for the containers |
 | securityContext | object | `{}` | Set securityContext for containers |
+| service.metrics.portName | string | `"metrics"` | name for the metrics port |
+| service.metrics.serviceType | string | `"ClusterIP"` | serviceType for the metrics service |
 | service.port | int | `6379` | Dragonfly service port |
 | service.type | string | `"ClusterIP"` | Service type to provision. Can be NodePort, ClusterIP or LoadBalancer |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| serviceMonitor.enabled | bool | `false` | If true, a ServiceMonitor CRD is created for a prometheus operator |
+| serviceMonitor.interval | string | `"10s"` | scrape interval |
+| serviceMonitor.labels | object | `{}` | additional labels to apply to the metrics |
+| serviceMonitor.namespace | string | `""` | namespace in which to deploy the ServiceMonitor CR. defaults to the application namespace |
+| serviceMonitor.scrapeTimeout | string | `"10s"` | scrape timeout |
 | storage.enabled | bool | `false` | If /data should persist. This will provision a StatefulSet instead. |
 | storage.requests | string | `"128Mi"` | Volume size to request for the PVC |
 | storage.storageClassName | string | `""` | Global StorageClass for Persistent Volume(s) |

--- a/contrib/charts/dragonfly/templates/deployment.yaml
+++ b/contrib/charts/dragonfly/templates/deployment.yaml
@@ -12,8 +12,13 @@ spec:
       {{- include "dragonfly.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+{{- if .Values.tls.enabled }}
+{{- if not .Values.tls.existing_secret }}
+        checksum/tls-secret: {{ include (print $.Template.BasePath "/tls-secret.yaml") . | sha256sum }}
+{{- end }}
+{{- end }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
@@ -60,10 +65,19 @@ spec:
           {{- if .Values.extraArgs }}
             {{- toYaml .Values.extraArgs | nindent 12 }}
           {{- end }}
+{{- if .Values.tls.enabled }}
+            - "--tls"
+            - "--tls_client_cert_file=/etc/dragonfly/tls/tls.crt"
+            - "--tls_client_key_file=/etc/dragonfly/tls/tls.key"
+{{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-{{- if .Values.extraVolumeMounts }}
           volumeMounts:
+            {{- if .Values.tls.enabled }}
+            - mountPath: /etc/dragonfly/tls
+              name: tls
+            {{- end }}
+{{- if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
 {{- end }}
       {{- with .Values.nodeSelector }}
@@ -78,8 +92,20 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- if .Values.extraVolumes }}
       volumes:
+{{- if .Values.tls.enabled }}
+  {{- if .Values.tls.existing_secret }}
+        - name: tls
+          secret:
+            secretName: {{ .Values.tls.existing_secret }}
+        {{- else }}
+        - name: tls
+          secret:
+            secretName: {{ include "dragonfly.fullname" . }}-tls
+  {{- end }}
+{{- end }}
+{{- if .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}
 {{- end }}
+
 {{- end }}

--- a/contrib/charts/dragonfly/templates/deployment.yaml
+++ b/contrib/charts/dragonfly/templates/deployment.yaml
@@ -60,6 +60,10 @@ spec:
             httpGet:
               path: /
               port: dragonfly
+          {{- if .Values.command.cmd }}
+          command:
+            {{ toYaml .Values.command.cmd | nindent 12 }}
+          {{- end }}
           args:
             - "--alsologtostderr"
           {{- if .Values.extraArgs }}

--- a/contrib/charts/dragonfly/templates/metrics-service.yaml
+++ b/contrib/charts/dragonfly/templates/metrics-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dragonfly.fullname" . }}-metrics
+  labels:
+    {{- include "dragonfly.labels" . | nindent 4 }}
+    type: metrics
+spec:
+  type: {{ .Values.service.metrics.serviceType }}
+  ports:
+    - name: {{ .Values.service.metrics.portName }}
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      protocol: TCP
+  selector:
+    {{- include "dragonfly.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/contrib/charts/dragonfly/templates/prometheusrule.yaml
+++ b/contrib/charts/dragonfly/templates/prometheusrule.yaml
@@ -1,0 +1,20 @@
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled .Values.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "dragonfly.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ template "dragonfly.chart" . }}
+    app: {{ template "dragonfly.name" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    {{- if .Values.serviceMonitor.labels }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+  - name: {{ template "dragonfly.name" . }}
+    rules:
+{{- toYaml .Values.prometheusRule.spec | nindent 4 }}
+{{- end }}

--- a/contrib/charts/dragonfly/templates/servicemonitor.yaml
+++ b/contrib/charts/dragonfly/templates/servicemonitor.yaml
@@ -23,7 +23,13 @@ spec:
       honorLabels: true
       port: {{ default "metrics" .Values.service.metrics.portName }}
       path: /metrics
+      {{- if .Values.tls.enabled }}
+      scheme: https
+      tls:
+        insecureSkipVerify: true
+      {{- else }}
       scheme: http
+      {{- end }}
   jobLabel: "{{ .Release.Name }}"
   selector:
     matchLabels:

--- a/contrib/charts/dragonfly/templates/servicemonitor.yaml
+++ b/contrib/charts/dragonfly/templates/servicemonitor.yaml
@@ -1,0 +1,35 @@
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "dragonfly.fullname" . }}-metrics
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    chart: {{ template "dragonfly.chart" . }}
+    app: {{ template "dragonfly.name" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    {{- if .Values.serviceMonitor.labels }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - interval: {{ .Values.serviceMonitor.interval }}
+      {{- if .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      honorLabels: true
+      port: {{ default "metrics" .Values.service.metrics.portName }}
+      path: /metrics
+      scheme: http
+  jobLabel: "{{ .Release.Name }}"
+  selector:
+    matchLabels:
+      {{- include "dragonfly.selectorLabels" . | nindent 6 }}
+      type: metrics
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/contrib/charts/dragonfly/templates/statefulset.yaml
+++ b/contrib/charts/dragonfly/templates/statefulset.yaml
@@ -63,6 +63,10 @@ spec:
             httpGet:
               path: /
               port: dragonfly
+          {{- if .Values.command.cmd }}
+          command:
+            {{ toYaml .Values.command.cmd | nindent 12 }}
+          {{- end }}
           args:
             - "--alsologtostderr"
           {{- if .Values.extraArgs }}

--- a/contrib/charts/dragonfly/templates/statefulset.yaml
+++ b/contrib/charts/dragonfly/templates/statefulset.yaml
@@ -13,8 +13,13 @@ spec:
       {{- include "dragonfly.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+{{- if .Values.tls.enabled }}
+{{- if not .Values.tls.existing_secret }}
+        checksum/tls-secret: {{ include (print $.Template.BasePath "/tls-secret.yaml") . | sha256sum }}
+{{- end }}
+{{- end }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
@@ -63,11 +68,20 @@ spec:
           {{- if .Values.extraArgs }}
             {{- toYaml .Values.extraArgs | nindent 12 }}
           {{- end }}
+{{- if .Values.tls.enabled }}
+            - "--tls"
+            - "--tls_client_cert_file=/etc/dragonfly/tls/tls.crt"
+            - "--tls_client_key_file=/etc/dragonfly/tls/tls.key"
+{{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /data
               name: "{{ .Release.Name }}-data"
+{{- if .Values.tls.enabled }}
+            - mountPath: /etc/dragonfly/tls
+              name: tls
+{{- end }}
 {{- if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
 {{- end }}
@@ -83,8 +97,19 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- if .Values.extraVolumes }}
       volumes:
+{{- if .Values.tls.enabled }}
+  {{- if .Values.tls.existing_secret }}
+        - name: tls
+          secret:
+            secretName: {{ .Values.tls.existing_secret }}
+        {{- else }}
+        - name: tls
+          secret:
+            secretName: {{ include "dragonfly.fullname" . }}-tls
+  {{- end }}
+{{- end }}
+{{- if .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}
 {{- end }}
   volumeClaimTemplates:

--- a/contrib/charts/dragonfly/templates/tls-secret.yaml
+++ b/contrib/charts/dragonfly/templates/tls-secret.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.tls.enabled .Values.tls.cert .Values.tls.key }}
+{{- if not .Values.tls.existing_secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "dragonfly.fullname" . }}-tls
+  labels:
+    {{- include "dragonfly.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ default "" .Values.tls.cert | b64enc | quote }}
+  tls.key: {{ default "" .Values.tls.key | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/contrib/charts/dragonfly/values.yaml
+++ b/contrib/charts/dragonfly/values.yaml
@@ -70,6 +70,13 @@ serviceMonitor:
   # -- scrape timeout
   scrapeTimeout: 10s
 
+prometheusRule:
+  # -- Deploy a PrometheusRule
+  enabled: false
+  # -- PrometheusRule.Spec
+  # https://awesome-prometheus-alerts.grep.to/rules
+  spec: []
+
 storage:
   # -- If /data should persist. This will provision a StatefulSet instead.
   enabled: false

--- a/contrib/charts/dragonfly/values.yaml
+++ b/contrib/charts/dragonfly/values.yaml
@@ -78,6 +78,30 @@ storage:
   # -- Volume size to request for the PVC
   requests: 128Mi
 
+tls:
+  # -- enable TLS
+  enabled: false
+  # -- use TLS certificates from existing secret
+  existing_secret: ""
+  # -- TLS certificate
+  cert: ""
+  # cert: |
+  #   -----BEGIN CERTIFICATE-----
+  #   MIIDazCCAlOgAwIBAgIUfV3ygaaVW3+yzK5Dq6Aw6TsZ494wDQYJKoZIhvcNAQEL
+  #   ...
+  #   BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+  #   zJAL4hNw4Tr6E52fqdmX
+  #   -----END CERTIFICATE-----
+  # -- TLS private key
+  key: ""
+  # key: |
+  #   -----BEGIN RSA PRIVATE KEY-----
+  #   MIIEpAIBAAKCAQEAxeD5iQGQpCUlksFvjzzAxPTw6DMJd3MpifV+HoBY4LiTyDer
+  #   ...
+  #   HLunol88AeTOcKfD6hBYGvcRfu5NV29jJxZCOBfbFQXjnNlnrhRCag==
+  #   -----END RSA PRIVATE KEY-----
+
+
 # -- Extra arguments to pass to the dragonfly binary
 extraArgs: []
 

--- a/contrib/charts/dragonfly/values.yaml
+++ b/contrib/charts/dragonfly/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- Dragonfly image pull policy
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
-  tag: "latest" # TODO: remove as soon as there's a properly tagged image available
+  tag: ""
 
 # -- Container Registry Secret names in an array
 imagePullSecrets: []
@@ -110,7 +110,7 @@ tls:
 
 
 command:
-  # -- Allow overriding the container's init command
+  # -- Allow overriding the container's command
   set: []
 
 # -- Extra arguments to pass to the dragonfly binary

--- a/contrib/charts/dragonfly/values.yaml
+++ b/contrib/charts/dragonfly/values.yaml
@@ -109,6 +109,10 @@ tls:
   #   -----END RSA PRIVATE KEY-----
 
 
+command:
+  # -- Allow overriding the container's init command
+  set: []
+
 # -- Extra arguments to pass to the dragonfly binary
 extraArgs: []
 

--- a/contrib/charts/dragonfly/values.yaml
+++ b/contrib/charts/dragonfly/values.yaml
@@ -52,6 +52,23 @@ service:
   type: ClusterIP
   # -- Dragonfly service port
   port: 6379
+  metrics:
+    # -- name for the metrics port
+    portName: metrics
+    # -- serviceType for the metrics service
+    serviceType: ClusterIP
+
+serviceMonitor:
+  # -- If true, a ServiceMonitor CRD is created for a prometheus operator
+  enabled: false
+  # -- namespace in which to deploy the ServiceMonitor CR. defaults to the application namespace
+  namespace: ""
+  # -- additional labels to apply to the metrics
+  labels: {}
+  # -- scrape interval
+  interval: 10s
+  # -- scrape timeout
+  scrapeTimeout: 10s
 
 storage:
   # -- If /data should persist. This will provision a StatefulSet instead.


### PR DESCRIPTION
This will
- bump the chart appVersion to v0.1.1 and remove the hardcoded reference to the latest tag from values.yaml
- add a parameter to override the container's init command
  - For something like (inspired by https://github.com/dragonflydb/dragonfly/issues/57#issuecomment-1145073128)
  - ```
    command:
      cmd:
        - '/bin/sh'
        - '-c'
        - 'ulimit -l unlimited && dragonfly'

    securityContext:
      privileged: true```
- implement parameters to enable the applications tls function
  - this was possible to be done before, but required fiddling with extraArgs, extraVolumes and extraVolumeMounts
- add CRs for ServiceMonitor and PrometheusRule objects, so the app can be monitored and alerting can be configured

Please feel free to squash and merge the PR on your end :) 