### PR TITLE
Support Pubsub (P)UNSUBSCRIBE commands without arguments

### DIFF
--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -175,8 +175,7 @@ void ConnectionContext::ChangePSub(bool to_add, bool to_reply, CmdArgList args) 
   }
 }
 void ConnectionContext::UnsubscribeAll(bool to_reply) {
-  if (to_reply && (!conn_state.subscribe_info ||
-                   conn_state.subscribe_info->channels.empty())) {
+  if (to_reply && (!conn_state.subscribe_info || conn_state.subscribe_info->channels.empty())) {
     return SendSubscriptionChangedResponse("unsubscribe", std::nullopt, 0);
   }
   StringVec channels(conn_state.subscribe_info->channels.begin(),
@@ -184,12 +183,10 @@ void ConnectionContext::UnsubscribeAll(bool to_reply) {
   CmdArgVec arg_vec(channels.begin(), channels.end());
 
   ChangeSubscription(false, to_reply, CmdArgList{arg_vec});
-
 }
 
 void ConnectionContext::PUnsubscribeAll(bool to_reply) {
-  if (to_reply && (!conn_state.subscribe_info ||
-                   conn_state.subscribe_info->patterns.empty())) {
+  if (to_reply && (!conn_state.subscribe_info || conn_state.subscribe_info->patterns.empty())) {
     return SendSubscriptionChangedResponse("punsubscribe", std::nullopt, 0);
   }
 
@@ -197,17 +194,18 @@ void ConnectionContext::PUnsubscribeAll(bool to_reply) {
                      conn_state.subscribe_info->patterns.end());
   CmdArgVec arg_vec(patterns.begin(), patterns.end());
   ChangePSub(false, to_reply, CmdArgList{arg_vec});
-
 }
 
-void ConnectionContext::SendSubscriptionChangedResponse(
-    string_view action, std::optional<string_view> topic, unsigned count) {
+void ConnectionContext::SendSubscriptionChangedResponse(string_view action,
+                                                        std::optional<string_view> topic,
+                                                        unsigned count) {
   (*this)->StartArray(3);
   (*this)->SendBulkString(action);
   topic.has_value() ? (*this)->SendBulkString(topic.value())
                     : (*this)->SendNull();
   (*this)->SendLong(count);
 }
+
 void ConnectionContext::OnClose() {
   if (!conn_state.subscribe_info) return;
 

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -201,8 +201,10 @@ void ConnectionContext::SendSubscriptionChangedResponse(string_view action,
                                                         unsigned count) {
   (*this)->StartArray(3);
   (*this)->SendBulkString(action);
-  topic.has_value() ? (*this)->SendBulkString(topic.value())
-                    : (*this)->SendNull();
+  if (topic.has_value())
+    (*this)->SendBulkString(topic.value());
+  else
+    (*this)->SendNull();
   (*this)->SendLong(count);
 }
 

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -92,8 +92,15 @@ class ConnectionContext : public facade::ConnectionContext {
 
   void ChangeSubscription(bool to_add, bool to_reply, CmdArgList args);
   void ChangePSub(bool to_add, bool to_reply, CmdArgList args);
+  void UnsubscribeAll(bool to_reply);
+  void PUnsubscribeAll(bool to_reply);
 
   bool is_replicating = false;
+
+ private:
+  void SendSubscriptionChangedResponse(std::string_view action,
+                                       std::optional<std::string_view> topic,
+                                       unsigned count);
 };
 
 }  // namespace dfly

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -441,34 +441,34 @@ TEST_F(DflyEngineTest, PSubscribe) {
   EXPECT_EQ("a*", msg.pattern);
 }
 TEST_F(DflyEngineTest, Unsubscribe) {
-  auto resp = pp_->at(1)->Await([&] { return Run({"unsubscribe", "a"}); });
+  auto resp = Run({"unsubscribe", "a"});
   EXPECT_THAT(resp.GetVec(), ElementsAre("unsubscribe", "a", IntArg(0)));
 
-  resp = pp_->at(1)->Await([&] { return Run({"unsubscribe"}); });
-  EXPECT_THAT(resp.GetVec(),
-              ElementsAre("unsubscribe", ArgType(RespExpr::NIL), IntArg(0)));
-  pp_->at(1)->Await([&] { return Run({"subscribe", "a", "b"}); });
+  resp = Run({"unsubscribe"});
+  EXPECT_THAT(resp.GetVec(), ElementsAre("unsubscribe", ArgType(RespExpr::NIL), IntArg(0)));
 
-  resp = pp_->at(1)->Await([&] { return Run({"unsubscribe", "a"}); });
+  Run({"subscribe", "a", "b"});
+
+  resp = Run({"unsubscribe", "a"});
   EXPECT_THAT(resp.GetVec(), ElementsAre("unsubscribe", "a", IntArg(1)));
 
-  resp = pp_->at(1)->Await([&] { return Run({"unsubscribe"}); });
+  resp = Run({"unsubscribe"});
   EXPECT_THAT(resp.GetVec(), ElementsAre("unsubscribe", "b", IntArg(0)));
 }
 
 TEST_F(DflyEngineTest, PUnsubscribe) {
-  auto resp = pp_->at(1)->Await([&] { return Run({"punsubscribe", "a*"}); });
+  auto resp = Run({"punsubscribe", "a*"});
   EXPECT_THAT(resp.GetVec(), ElementsAre("punsubscribe", "a*", IntArg(0)));
 
-  resp = pp_->at(1)->Await([&] { return Run({"punsubscribe"}); });
-  EXPECT_THAT(resp.GetVec(),
-              ElementsAre("punsubscribe", ArgType(RespExpr::NIL), IntArg(0)));
-  pp_->at(1)->Await([&] { return Run({"psubscribe", "a*", "b*"}); });
+  resp = Run({"punsubscribe"});
+  EXPECT_THAT(resp.GetVec(), ElementsAre("punsubscribe", ArgType(RespExpr::NIL), IntArg(0)));
 
-  resp = pp_->at(1)->Await([&] { return Run({"punsubscribe", "a*"}); });
+  Run({"psubscribe", "a*", "b*"});
+
+  resp = Run({"punsubscribe", "a*"});
   EXPECT_THAT(resp.GetVec(), ElementsAre("punsubscribe", "a*", IntArg(1)));
 
-  resp = pp_->at(1)->Await([&] { return Run({"punsubscribe"}); });
+  resp = Run({"punsubscribe"});
   EXPECT_THAT(resp.GetVec(), ElementsAre("punsubscribe", "b*", IntArg(0)));
 }
 

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -426,7 +426,9 @@ TEST_F(DflyEngineTest, OOM) {
 }
 
 TEST_F(DflyEngineTest, PSubscribe) {
-  auto resp = pp_->at(1)->Await([&] { return Run({"psubscribe", "a*", "b*"}); });
+  auto resp = pp_->at(1)->Await([&] {
+    return Run({"psubscribe", "a*", "b*"});
+  });
   EXPECT_THAT(resp, ArrLen(3));
   resp = pp_->at(0)->Await([&] { return Run({"publish", "ab", "foo"}); });
   EXPECT_THAT(resp, IntArg(1));
@@ -443,7 +445,8 @@ TEST_F(DflyEngineTest, Unsubscribe) {
   EXPECT_THAT(resp.GetVec(), ElementsAre("unsubscribe", "a", IntArg(0)));
 
   resp = pp_->at(1)->Await([&] { return Run({"unsubscribe"}); });
-  EXPECT_THAT(resp.GetVec(), ElementsAre("unsubscribe", ArgType(RespExpr::NIL), IntArg(0)));
+  EXPECT_THAT(resp.GetVec(),
+              ElementsAre("unsubscribe", ArgType(RespExpr::NIL), IntArg(0)));
   pp_->at(1)->Await([&] { return Run({"subscribe", "a", "b"}); });
 
   resp = pp_->at(1)->Await([&] { return Run({"unsubscribe", "a"}); });
@@ -458,7 +461,8 @@ TEST_F(DflyEngineTest, PUnsubscribe) {
   EXPECT_THAT(resp.GetVec(), ElementsAre("punsubscribe", "a*", IntArg(0)));
 
   resp = pp_->at(1)->Await([&] { return Run({"punsubscribe"}); });
-  EXPECT_THAT(resp.GetVec(), ElementsAre("punsubscribe", ArgType(RespExpr::NIL), IntArg(0)));
+  EXPECT_THAT(resp.GetVec(),
+              ElementsAre("punsubscribe", ArgType(RespExpr::NIL), IntArg(0)));
   pp_->at(1)->Await([&] { return Run({"psubscribe", "a*", "b*"}); });
 
   resp = pp_->at(1)->Await([&] { return Run({"punsubscribe", "a*"}); });

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -438,6 +438,35 @@ TEST_F(DflyEngineTest, PSubscribe) {
   EXPECT_EQ("ab", msg.channel);
   EXPECT_EQ("a*", msg.pattern);
 }
+TEST_F(DflyEngineTest, Unsubscribe) {
+  auto resp = pp_->at(1)->Await([&] { return Run({"unsubscribe", "a"}); });
+  EXPECT_THAT(resp.GetVec(), ElementsAre("unsubscribe", "a", IntArg(0)));
+
+  resp = pp_->at(1)->Await([&] { return Run({"unsubscribe"}); });
+  EXPECT_THAT(resp.GetVec(), ElementsAre("unsubscribe", ArgType(RespExpr::NIL), IntArg(0)));
+  pp_->at(1)->Await([&] { return Run({"subscribe", "a", "b"}); });
+
+  resp = pp_->at(1)->Await([&] { return Run({"unsubscribe", "a"}); });
+  EXPECT_THAT(resp.GetVec(), ElementsAre("unsubscribe", "a", IntArg(1)));
+
+  resp = pp_->at(1)->Await([&] { return Run({"unsubscribe"}); });
+  EXPECT_THAT(resp.GetVec(), ElementsAre("unsubscribe", "b", IntArg(0)));
+}
+
+TEST_F(DflyEngineTest, PUnsubscribe) {
+  auto resp = pp_->at(1)->Await([&] { return Run({"punsubscribe", "a*"}); });
+  EXPECT_THAT(resp.GetVec(), ElementsAre("punsubscribe", "a*", IntArg(0)));
+
+  resp = pp_->at(1)->Await([&] { return Run({"punsubscribe"}); });
+  EXPECT_THAT(resp.GetVec(), ElementsAre("punsubscribe", ArgType(RespExpr::NIL), IntArg(0)));
+  pp_->at(1)->Await([&] { return Run({"psubscribe", "a*", "b*"}); });
+
+  resp = pp_->at(1)->Await([&] { return Run({"punsubscribe", "a*"}); });
+  EXPECT_THAT(resp.GetVec(), ElementsAre("punsubscribe", "a*", IntArg(1)));
+
+  resp = pp_->at(1)->Await([&] { return Run({"punsubscribe"}); });
+  EXPECT_THAT(resp.GetVec(), ElementsAre("punsubscribe", "b*", IntArg(0)));
+}
 
 // TODO: to test transactions with a single shard since then all transactions become local.
 // To consider having a parameter in dragonfly engine controlling number of shards

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -955,7 +955,11 @@ void Service::Subscribe(CmdArgList args, ConnectionContext* cntx) {
 void Service::Unsubscribe(CmdArgList args, ConnectionContext* cntx) {
   args.remove_prefix(1);
 
-  cntx->ChangeSubscription(false, true, std::move(args));
+  if (args.size() == 0){
+    cntx->UnsubscribeAll(true);
+  }else{
+    cntx->ChangeSubscription(false, true, std::move(args));
+  }
 }
 
 void Service::PSubscribe(CmdArgList args, ConnectionContext* cntx) {
@@ -966,7 +970,11 @@ void Service::PSubscribe(CmdArgList args, ConnectionContext* cntx) {
 void Service::PUnsubscribe(CmdArgList args, ConnectionContext* cntx) {
   args.remove_prefix(1);
 
-  cntx->ChangePSub(false, true, args);
+  if (args.size() == 0) {
+    cntx->PUnsubscribeAll(true);
+  } else {
+    cntx->ChangePSub(false, true, args);
+  }
 }
 
 // Not a real implementation. Serves as a decorator to accept some function commands

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1033,9 +1033,9 @@ void Service::RegisterCommands() {
             << CI{"EXEC", kExecMask, 1, 0, 0, 0}.MFUNC(Exec)
             << CI{"PUBLISH", CO::LOADING | CO::FAST, 3, 0, 0, 0}.MFUNC(Publish)
             << CI{"SUBSCRIBE", CO::NOSCRIPT | CO::LOADING, -2, 0, 0, 0}.MFUNC(Subscribe)
-            << CI{"UNSUBSCRIBE", CO::NOSCRIPT | CO::LOADING, -2, 0, 0, 0}.MFUNC(Unsubscribe)
+            << CI{"UNSUBSCRIBE", CO::NOSCRIPT | CO::LOADING, -1, 0, 0, 0}.MFUNC(Unsubscribe)
             << CI{"PSUBSCRIBE", CO::NOSCRIPT | CO::LOADING, -2, 0, 0, 0}.MFUNC(PSubscribe)
-            << CI{"PUNSUBSCRIBE", CO::NOSCRIPT | CO::LOADING, -2, 0, 0, 0}.MFUNC(PUnsubscribe)
+            << CI{"PUNSUBSCRIBE", CO::NOSCRIPT | CO::LOADING, -1, 0, 0, 0}.MFUNC(PUnsubscribe)
             << CI{"FUNCTION", CO::NOSCRIPT, 2, 0, 0, 0}.MFUNC(Function);
 
   StringFamily::Register(&registry_);


### PR DESCRIPTION
# Description
Both `UNSUBSCRIBE` and `PUNSUBSCRIBE` have a command arity of -1 in the official redis implementation where no arguments implies that all channels (for `UNSUBSCRIBE`) or patterns (for `PUNSUBSCRIBE`) should be removed from the connections subscriptions.


## Side effects
- Extracted logic for unsubscribing "all" from `OnClose` into `UnsubscribeAll` and `PUnsubscribeAll`.
- Extracted common code for building `{subscribe, unsubscribe, psubscribe, punsubsribe}` responses into `SendSubscriptionChangedResponse` method.


## Manual test suggestions
1. CLI:
```bash
> echo UNSUBSCRIBE | redis-cli
1) "unsubscribe"
2) (nil)
3) (integer) 0


> echo PUNSUBSCRIBE | redis-cli
1) "punsubscribe"
2) (nil)
3) (integer) 0

```

2. Python 
```python
import redis
client = redis.Redis()
pubsub = client.pubsub()
pubsub.subscribe(f"channel{i}" for i in range(5))
pubsub.psubscribe(f"p{i}*" for i in range(5))
[pubsub.get_message(timeout=0.1)["data"] for _ in range(10)]
# [1, 2, 3, 4, 5, 1, 2, 3, 4, 5]
pubsub.unsubscribe("channel0", "channel1", "channel2")
pubsub.punsubscribe("p0*", "p1*", "p2*")
[pubsub.get_message(timeout=0.1)["data"] for _ in range(6)]
pubsub.unsubscribe()
{pubsub.get_message(timeout=0.1)["channel"] for _ in range(2)}
# {b'channel4', b'channel3'}
pubsub.punsubscribe()
{pubsub.get_message(timeout=0.1)["channel"] for _ in range(2)}
# {b'p4*', b'p3*'}

```

## Related issues
- #111 

## Note:
- Apologies in advance for any noob c++ mistakes - I haven't written any c++ code for a decade. Please feel free to give any and all feedback even if it's trivial/style related.
- The `count` response at the moment is inconsistent with the response from redis where the count is actually a sum of current channels + patterns instead. Changing that could/should perhaps be a separate PR if necessary.