### PR TITLE
Use sum instead of individual counts for channels/patterns

### DIFF
--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -38,7 +38,7 @@ void ConnectionContext::ChangeSubscription(bool to_add, bool to_reply, CmdArgLis
       }
 
       if (to_reply)
-        result[i] = conn_state.subscribe_info->channels.size();
+        result[i] = conn_state.subscribe_info->SubscriptionCount();
 
       if (res) {
         ShardId sid = Shard(channel, shard_set->size());
@@ -132,7 +132,7 @@ void ConnectionContext::ChangePSub(bool to_add, bool to_reply, CmdArgList args) 
       }
 
       if (to_reply)
-        result[i] = conn_state.subscribe_info->patterns.size();
+        result[i] = conn_state.subscribe_info->SubscriptionCount();
 
       if (res) {
         patterns.emplace_back(pattern);

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -58,6 +58,10 @@ struct ConnectionState {
       return channels.empty() && patterns.empty();
     }
 
+    unsigned SubscriptionCount() const {
+      return channels.size() + patterns.size();
+    }
+
     SubscribeInfo() : borrow_token(0) {
     }
   };


### PR DESCRIPTION
# Description
This issue was noted while testing the changes for #111. The reference redis implementation returns the total number of subscriptions for `{SUBSCRIBE, UNSUBSCRIBE, PSUBSCRIBE, PUNSUBSCRIBE}` commands ([reference](https://github.com/redis/redis/blob/805191c791e1f84618c1f69dacec27ac3fecd1e4/src/pubsub.c#L167)).

# Discussion
- [x] I haven't added any unit tests for this since I wasn't sure where the right place for this would be. Feels like an integration test for pubsub might fit the bill?