### PR TITLE
fix(zset): fixed zrevrange support WITHSCORES and add zrevrange test case (#106)

### DIFF
--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1889,7 +1889,7 @@ void ZSetFamily::Register(CommandRegistry* registry) {
             << CI{"ZREMRANGEBYRANK", CO::WRITE, 4, 1, 1, 1}.HFUNC(ZRemRangeByRank)
             << CI{"ZREMRANGEBYSCORE", CO::WRITE, 4, 1, 1, 1}.HFUNC(ZRemRangeByScore)
             << CI{"ZREMRANGEBYLEX", CO::WRITE, 4, 1, 1, 1}.HFUNC(ZRemRangeByLex)
-            << CI{"ZREVRANGE", CO::READONLY, 4, 1, 1, 1}.HFUNC(ZRevRange)
+            << CI{"ZREVRANGE", CO::READONLY, -4, 1, 1, 1}.HFUNC(ZRevRange)
             << CI{"ZREVRANGEBYSCORE", CO::READONLY, -4, 1, 1, 1}.HFUNC(ZRevRangeByScore)
             << CI{"ZREVRANK", CO::READONLY | CO::FAST, 3, 1, 1, 1}.HFUNC(ZRevRank)
             << CI{"ZSCAN", CO::READONLY | CO::RANDOM, -3, 1, 1, 1}.HFUNC(ZScan)

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -142,6 +142,14 @@ TEST_F(ZSetFamilyTest, ZRevRange) {
   resp = Run({"zrevrangebyscore", "key", "2", "-inf", "withscores"});
   ASSERT_THAT(resp, ArrLen(6));
   EXPECT_THAT(resp.GetVec(), ElementsAre("c", "2", "b", "1", "a", "-inf"));
+
+  resp = Run({"zrevrange", "key", "0", "2"});
+  ASSERT_THAT(resp, ArrLen(3));
+  EXPECT_THAT(resp.GetVec(), ElementsAre("c", "b", "a"));
+
+  resp = Run({"zrevrange", "key", "1", "2", "withscores"});
+  ASSERT_THAT(resp, ArrLen(4));
+  EXPECT_THAT(resp.GetVec(), ElementsAre("b", "1", "a", "-inf"));
 }
 
 TEST_F(ZSetFamilyTest, ZScan) {


### PR DESCRIPTION
### Description
1. fixed  zrevrange support WITHSCORES
2. add zrevrange test case

### Issues
Fixes https://github.com/dragonflydb/dragonfly/issues/106

### Output
```
127.0.0.1:6379> zadd test 8 "a" 7 "b" 2 "c" 3 "d" 6 "e"
(integer) 5
127.0.0.1:6379> zrevrange test 0 100 WITHSCORES
 1) "a"
 2) "8"
 3) "b"
 4) "7"
 5) "e"
 6) "6"
 7) "d"
 8) "3"
 9) "c"
10) "2"
```

### Test
```
[==========] Running 12 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 12 tests from ZSetFamilyTest
[ RUN      ] ZSetFamilyTest.Add
[       OK ] ZSetFamilyTest.Add (20 ms)
[ RUN      ] ZSetFamilyTest.ZRem
[       OK ] ZSetFamilyTest.ZRem (14 ms)
[ RUN      ] ZSetFamilyTest.ZRangeRank
[       OK ] ZSetFamilyTest.ZRangeRank (16 ms)
[ RUN      ] ZSetFamilyTest.ZRemRangeRank
[       OK ] ZSetFamilyTest.ZRemRangeRank (24 ms)
[ RUN      ] ZSetFamilyTest.ZRemRangeScore
[       OK ] ZSetFamilyTest.ZRemRangeScore (14 ms)
[ RUN      ] ZSetFamilyTest.IncrBy
[       OK ] ZSetFamilyTest.IncrBy (18 ms)
[ RUN      ] ZSetFamilyTest.ByLex
[       OK ] ZSetFamilyTest.ByLex (14 ms)
[ RUN      ] ZSetFamilyTest.ZRevRange
[       OK ] ZSetFamilyTest.ZRevRange (14 ms)
[ RUN      ] ZSetFamilyTest.ZScan
[       OK ] ZSetFamilyTest.ZScan (27 ms)
[ RUN      ] ZSetFamilyTest.ZUnionStore
[       OK ] ZSetFamilyTest.ZUnionStore (15 ms)
[ RUN      ] ZSetFamilyTest.ZUnionStoreOpts
[       OK ] ZSetFamilyTest.ZUnionStoreOpts (38 ms)
[ RUN      ] ZSetFamilyTest.ZInterStore
[       OK ] ZSetFamilyTest.ZInterStore (14 ms)
[----------] 12 tests from ZSetFamilyTest (235 ms total)

[----------] Global test environment tear-down
[==========] 12 tests from 1 test suite ran. (235 ms total)
[  PASSED  ] 12 tests.
```