### PR TITLE
docs(PR Template): Add PR Template Enforcing Conventional Commits #107

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!--
+**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
+  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
+  * Please follow the section on `pre-commit hooks`, a linter will validate before you push
+
+  Example PR Title: <type>(<scope>)!: <description>
+
+  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
+  * `!` = OPTIONAL: signals a breaking change
+  * `scope` = Optional when `type` is "chore" or "docs"
+  * `description` = short description of the change
+
+Examples:
+
+  * chore(examples): Clarify `docker` usage #120
+  * docs(readme): Fix Example Links #121
+  * feat(ingest)!: Add new ingest #122
+  * fix(ingest): Refactor for loop to list comprehension #123
+-->


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

This will reduce redundancy around asking new committers to signoff and follow conventional commits.