### PR TITLE
feat(server): Add support for CPU to Info family of commands (fixes #18)

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -954,6 +954,20 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
     }
   }
 
+  if (should_enter("CPU")) {
+      ADD_HEADER("# CPU");
+      struct rusage ru, cu, tu;
+      getrusage(RUSAGE_SELF, &ru);
+      getrusage(RUSAGE_CHILDREN, &cu);
+      getrusage(RUSAGE_THREAD, &tu);
+      append("used_cpu_sys", StrCat(ru.ru_stime.tv_sec, ".", ru.ru_stime.tv_usec));
+      append("used_cpu_user", StrCat(ru.ru_utime.tv_sec, ".", ru.ru_utime.tv_usec));
+      append("used_cpu_sys_children", StrCat(cu.ru_stime.tv_sec, ".", cu.ru_stime.tv_usec));
+      append("used_cpu_user_children", StrCat(cu.ru_utime.tv_sec, ".", cu.ru_utime.tv_usec));
+      append("used_cpu_sys_main_thread", StrCat(tu.ru_stime.tv_sec, ".", tu.ru_stime.tv_usec));
+      append("used_cpu_user_main_thread", StrCat(tu.ru_utime.tv_sec, ".", tu.ru_utime.tv_usec));
+  }
+
   (*cntx)->SendBulkString(info);
 }
 


### PR DESCRIPTION
### Description
Add support for INFO CPU based on the redis documentation found at https://redis.io/commands/info/

### Issues
Fixes #18 

### Output
```
127.0.0.1:25455> info cpu
# CPU
used_cpu_sys:23.13618
used_cpu_user:31.507270
used_cpu_sys_children:0.0
used_cpu_user_children:0.0
used_cpu_sys_main_thread:0.6184
used_cpu_user_main_thread:0.2086
```