### PR TITLE
chore(issues): Add issue templates with links to Discord/Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help Dragonfly DB improve
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Insert records using `command`
+2. Query records using `command`
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [ubuntu 20.04]
+ - Kernel: [MUST BE 5.10 or greater] # Command: `uname -a`
+ - Containerized?: [Bare Metal, Docker, Docker Compose, Docker Swarm, Kubernetes, Other]
+  - Version [e.g. 0.3.0]
+
+**Reproducible Code Snippet**
+```
+# Minimal code snippet to reproduce this bug
+```
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: true
+
+contact_links:
+  - name: Dragonfly DB Discord Channel
+    url: https://discord.gg/HsPjXGVH85
+    about: Get help! Ask questions, get support, and share ideas.
+
+  - name: GitHub Discussions
+    url: https://github.com/dragonflydb/dragonfly/discussions
+    about: Ask Questions. Benchmark Questions Belong here.
+
+  - name: Twitter
+    url: https://twitter.com/romanger
+    about: Follow Roman on Twitter

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for Dragonfly DB
+title: ''
+labels: 'feature request'
+assignees: ''
+
+---
+**Did you search GitHub Issues and GitHub Discussions First?**
+Many users may find their feature is already being discussed. Help us keep duplicates to a minimum by searching for your feature first to see if it is already in progress.
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

You probably still need to go into repo settings -> General and check `Template repository` (and check  `Require contributors to sign off on web-based commits` also) to get these to activate. 

After you do that, when you open a new issue, it should give them Bug/Feature as the only issue options.

They are also presented with Discord, Discussions(Where to put benchmark-ish things), and your Twitter :)

Let me know if there are any issues.