### PR TITLE
fix(transaction): Fix rare deadlock case - fixes #150.

### DIFF
--- a/src/core/tx_queue.h
+++ b/src/core/tx_queue.h
@@ -76,6 +76,10 @@ class TxQueue {
     return head_;
   }
 
+  Iterator Next(Iterator it) const {
+    return vec_[it].next;
+  }
+
  private:
   enum { TRANS_TAG = 0, UINT_TAG = 11, FREE_TAG = 12 };
 

--- a/src/facade/conn_context.h
+++ b/src/facade/conn_context.h
@@ -53,7 +53,7 @@ class ConnectionContext {
 
   virtual void OnClose() {}
 
-  std::string GetContextInfo() const { return std::string{}; }
+  virtual std::string GetContextInfo() const { return std::string{}; }
 
  private:
   Connection* owner_;

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -349,7 +349,9 @@ void Connection::ConnectionFlow(FiberSocketBase* peer) {
   // After the client disconnected.
   cc_->conn_closing = true;  // Signal dispatch to close.
   evc_.notify();
+  VLOG(1) << "Before dispatch_fb.join()";
   dispatch_fb.join();
+  VLOG(1) << "After dispatch_fb.join()";
   cc_->OnClose();
 
   stats->read_buf_capacity -= io_buf_.Capacity();

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(dragonfly_lib blocking_controller.cc channel_slice.cc command_regist
             set_family.cc stream_family.cc string_family.cc table.cc tiered_storage.cc
             transaction.cc zset_family.cc version.cc)
 
-cxx_link(dragonfly_lib dfly_core dfly_facade redis_lib strings_lib)
+cxx_link(dragonfly_lib dfly_core dfly_facade redis_lib strings_lib html_lib)
 
 add_library(dfly_test_lib test_utils.cc)
 cxx_link(dfly_test_lib dragonfly_lib facade_test gtest_main_ext)

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -232,4 +232,16 @@ void ConnectionContext::OnClose() {
   }
 }
 
+string ConnectionContext::GetContextInfo() const {
+  char buf[16] = {0};
+  unsigned index = 0;
+  if (async_dispatch)
+    buf[index++] = 'a';
+
+  if (conn_closing)
+    buf[index++] = 't';
+
+  return index ? absl::StrCat("flags:", buf) : string();
+}
+
 }  // namespace dfly

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -101,6 +101,8 @@ class ConnectionContext : public facade::ConnectionContext {
 
   bool is_replicating = false;
 
+  std::string GetContextInfo() const override;
+
  private:
   void SendSubscriptionChangedResponse(std::string_view action,
                                        std::optional<std::string_view> topic,

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -132,7 +132,9 @@ void EngineShard::DestroyThreadLocal() {
 // Is called by Transaction::ExecuteAsync in order to run transaction tasks.
 // Only runs in its own thread.
 void EngineShard::PollExecution(const char* context, Transaction* trans) {
-  DVLOG(1) << "PollExecution " << context << " " << (trans ? trans->DebugId() : "");
+  VLOG(2) << "PollExecution " << context << " " << (trans ? trans->DebugId() : "")
+          << " " << txq_.size() << " " << continuation_trans_;
+
   ShardId sid = shard_id();
 
   uint16_t trans_mask = trans ? trans->GetLocalMask(sid) : 0;
@@ -170,7 +172,7 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
       // The fact that Tx is in the queue, already means that coordinator fiber will not progress,
       // hence here it's enough to test for run_count and check local_mask.
       bool is_armed = head->IsArmedInShard(sid);
-      DVLOG(2) << "Considering head " << head->DebugId() << " isarmed: " << is_armed;
+      VLOG(2) << "Considering head " << head->DebugId() << " isarmed: " << is_armed;
 
       if (!is_armed)
         break;

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -629,7 +629,8 @@ void StreamFamily::XDel(CmdArgList args, ConnectionContext* cntx) {
   string_view key = ArgS(args, 1);
   args.remove_prefix(2);
 
-  absl::InlinedVector<streamID, 8> ids(ids.size());
+  absl::InlinedVector<streamID, 8> ids(args.size());
+
   for (size_t i = 0; i < args.size(); ++i) {
     ParsedStreamId parsed_id;
     string_view str_id = ArgS(args, i);

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -208,7 +208,7 @@ class Transaction {
   /// Runs in the shard thread.
   std::pair<bool, bool> ScheduleInShard(EngineShard* shard);
 
-  // Returns true if operation was cancelled for this shard. Runs in the shard thread.
+  // Returns true if we need to follow up with PollExecution on this shard.
   bool CancelShardCb(EngineShard* shard);
 
   // Shard callbacks used within Execute calls
@@ -332,7 +332,7 @@ class Transaction {
 };
 
 inline uint16_t trans_id(const Transaction* ptr) {
-  return intptr_t(ptr) & 0xFFFF;
+  return (intptr_t(ptr) >> 8) & 0xFFFF;
 }
 
 OpResult<KeyIndex> DetermineKeys(const CommandId* cid, CmdArgList args);

--- a/tests/async.py
+++ b/tests/async.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+"""
+This is the script that helped to reproduce https://github.com/dragonflydb/dragonfly/issues/150
+The outcome - stalled code with all its connections deadlocked.
+Reproduced only with dragonfly in release mode on multi-core machine.
+"""
+
+import asyncio
+import aioredis
+
+from loguru import logger as log
+import sys
+import random
+
+connection_pool = aioredis.ConnectionPool(host="localhost", port=6379,
+                                          db=1, decode_responses=True, max_connections=16)
+
+
+key_index = 1
+
+async def post_to_redis(sem, db_name, index):
+    global key_index
+    async with sem:
+        results = None
+        try:
+            redis_client = aioredis.Redis(connection_pool=connection_pool)
+            async with redis_client.pipeline(transaction=True) as pipe:
+                for i in range(1, 15):                    
+                    pipe.hsetnx(name=f"key_{key_index}", key="name", value="bla")
+                    key_index += 1
+                #log.info(f"after first half {key_index}")
+                for i in range(1, 15):
+                    pipe.hsetnx(name=f"bla_{key_index}", key="name2", value="bla")
+                    key_index += 1
+                assert len(pipe.command_stack) > 0
+                log.info(f"before pipe.execute {key_index}")
+                results = await pipe.execute()
+                log.info(f"after pipe.execute {key_index}")
+        finally:
+            # log.info(f"before close {index}")
+            await redis_client.close()
+            #log.info(f"after close {index} {len(results)}")
+ 
+
+async def do_concurrent(db_name):
+    tasks = []
+    sem = asyncio.Semaphore(10)
+    for i in range(1, 3000):
+        tasks.append(post_to_redis(sem, db_name, i))
+    res = await asyncio.gather(*tasks)
+   
+
+if __name__ == '__main__':
+    log.remove()
+    log.add(sys.stdout, enqueue=True, level='INFO')
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(do_concurrent("my_db"))


### PR DESCRIPTION
In rare cases a scheduled transaction is not scheduled correctly and we need
to remove it from the tx-queue in order to re-schedule. When we pull it from tx-queue
and it has been located at the head, we must poll-execute the next txs in the queue.

1. Fix the bug.
2. Improve verbosity loggings to make it easier to follow up on tx flow in release mode.
3. Introduce /txz handler that shows currently pending transactions in the queue.
4. Fix a typo in xdel() function.
5. Add a py-script that reproduces the bug.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->