### PR TITLE
feat(actions): bump helm-chart version when new container image is published

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -16,7 +16,8 @@ on:
 
 permissions:
   packages: write
-  contents: read
+  contents: write
+  id-token: write
 
 env:
   TAG_NAME: ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }}
@@ -104,3 +105,23 @@ jobs:
         file: tools/docker/Dockerfile.ubuntu-prod
         cache-from: type=registry,ref=${{ github.repository }}:latest
         cache-to: type=inline
+
+    - name: Configure Git
+      if: env.IS_PRERELEASE != 'true'
+      run: |
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+    - name: Update helm chart
+      if: env.IS_PRERELEASE != 'true'
+      run: |
+        sed -Ei \
+            -e 's/^(version\:) .*/\1 '${{ env.TAG_NAME }}'/g' \
+            -e 's/^(appVersion\:) .*/\1 "'${{ env.TAG_NAME }}'"/g' \
+            contrib/charts/dragonfly/Chart.yaml
+
+        git commit \
+          -m 'chore(helm-chart): update to ${{ env.TAG_NAME }}' \
+          contrib/charts/dragonfly/Chart.yaml
+
+        git push


### PR DESCRIPTION
This should fix #144. Once a new container image is built and successfully pushed, the file `contrib/charts/dragonfly/Chart.yaml` will be updated based on `env.TAG_NAME`. This will only be done for non-prerelease images.