### PR TITLE
chore(server): Improve the implementation of SendStringArr.

### DIFF
--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -7,7 +7,7 @@
 #include <string_view>
 
 #include "facade/op_status.h"
-#include "io/sync_stream_interface.h"
+#include "io/io.h"
 
 namespace facade {
 

--- a/src/redis/CMakeLists.txt
+++ b/src/redis/CMakeLists.txt
@@ -15,6 +15,8 @@ add_library(redis_lib crc64.c crcspeed.c debug.c dict.c intset.c
 
 cxx_link(redis_lib  ${ZMALLOC_DEPS})
 
+target_compile_options(redis_lib PRIVATE -Wno-maybe-uninitialized)
+
 if (REDIS_ZMALLOC_MI)
   target_compile_definitions(redis_lib PUBLIC USE_ZMALLOC_MI)
 endif()

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -290,10 +290,7 @@ void HSetFamily::HGetGeneric(CmdArgList args, ConnectionContext* cntx, uint8_t g
   OpResult<vector<string>> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
 
   if (result) {
-    (*cntx)->StartArray(result->size());
-    for (const auto& s : *result) {
-      (*cntx)->SendBulkString(s);
-    }
+    (*cntx)->SendStringArr(absl::Span<const string>{*result});
   } else {
     (*cntx)->SendError(result.status());
   }


### PR DESCRIPTION
1. Make it use vectorized send instead of concatenating everything into a single string.
2. vectorized SendStringArr could fail sending large arrays for lengths higher than 512 (returned EMSGSIZE).
   We improved the implementation so it would send those arrays in chunks of 256 items.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->