### PR TITLE
chore(rdb): move object creation during loading to shard threads.

### DIFF
--- a/src/server/error.h
+++ b/src/server/error.h
@@ -22,8 +22,10 @@ using facade::kDbIndOutOfRangeErr;
 #define RETURN_ON_ERR(x) \
   do {                   \
     auto __ec = (x);       \
-    if (__ec)              \
+    if (__ec) {            \
+      VLOG(1) << "Error " << __ec << " while calling " #x; \
       return __ec;         \
+    }                      \
   } while (0)
 
 #endif  // RETURN_ON_ERR

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -97,6 +97,9 @@ TEST_F(RdbTest, LoadSmall6) {
   EXPECT_THAT(StrArray(resp.GetVec()[1]),
               UnorderedElementsAre("list1", "hset_zl", "list2", "zset_sl", "intset", "set1",
                                    "zset_zl", "hset_ht", "intkey", "strkey"));
+  EXPECT_THAT(Run({"get", "intkey"}), "1234567");
+  EXPECT_THAT(Run({"get", "strkey"}), "abcdefghjjjjjjjjjj");
+
   resp = Run({"smembers", "intset"});
   ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
   EXPECT_THAT(resp.GetVec(),

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -1182,13 +1182,13 @@ uint32_t SetFamily::MaxIntsetEntries() {
   return kMaxIntSetEntries;
 }
 
-void SetFamily::ConvertTo(intset* src, dict* dest) {
+void SetFamily::ConvertTo(const intset* src, dict* dest) {
   int64_t intele;
   char buf[32];
 
   /* To add the elements we extract integers and create redis objects */
   int ii = 0;
-  while (intsetGet(src, ii++, &intele)) {
+  while (intsetGet(const_cast<intset*>(src), ii++, &intele)) {
     char* next = absl::numbers_internal::FastIntToBuffer(intele, buf);
     sds s = sdsnewlen(buf, next - buf);
     CHECK(dictAddRaw(dest, s, NULL));

--- a/src/server/set_family.h
+++ b/src/server/set_family.h
@@ -25,7 +25,7 @@ class SetFamily {
 
   static uint32_t MaxIntsetEntries();
 
-  static void ConvertTo(intset* src, dict* dest);
+  static void ConvertTo(const intset* src, dict* dest);
 
  private:
   static void SAdd(CmdArgList args,  ConnectionContext* cntx);


### PR DESCRIPTION
Related to #159. Before this change, rdb loading thread has been creating all the redis objects as well.
Now we separate rdb file parsing and objects creation. File parsing phase produces a load trace of one or more binary blobs.
Those blobs are then passed to the threads that are responsible to manage the objects.
The second phase is object creation based on the trace that was passed. Finally those binary blobs are destroyed.
As a result, each thread creates objects using the memory allocator it owns and memory stats become consistent.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->