### PR TITLE
fix(action): switch git push to dedicated action

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -35,6 +35,8 @@ jobs:
 
     - name: checkout
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - uses: dsaltares/fetch-gh-release-asset@master
       with:
@@ -115,6 +117,7 @@ jobs:
     - name: Update helm chart
       if: env.IS_PRERELEASE != 'true'
       run: |
+        git checkout main
         sed -Ei \
             -e 's/^(version\:) .*/\1 '${{ env.TAG_NAME }}'/g' \
             -e 's/^(appVersion\:) .*/\1 "'${{ env.TAG_NAME }}'"/g' \
@@ -124,4 +127,8 @@ jobs:
           -m 'chore(helm-chart): update to ${{ env.TAG_NAME }}' \
           contrib/charts/dragonfly/Chart.yaml
 
-        git push
+    - name: GitHub Push
+      uses: CasperWA/push-protected@v2
+      with:
+        token: ${{ secrets.DRAGONFLY_TOKEN }}
+        branch: main


### PR DESCRIPTION
Docker release pipeline can not push to protected main branch using
the service token. This switches to PAT secret.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->