### PR TITLE
feat(journal): Introduce basic journal support.

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -1,16 +1,20 @@
 add_executable(dragonfly dfly_main.cc)
 cxx_link(dragonfly base dragonfly_lib)
 
-add_library(dragonfly_lib blocking_controller.cc channel_slice.cc command_registry.cc
-            common.cc config_flags.cc
-            conn_context.cc db_slice.cc debugcmd.cc
-            engine_shard_set.cc generic_family.cc hset_family.cc io_mgr.cc
+add_library(dfly_transaction db_slice.cc engine_shard_set.cc blocking_controller.cc common.cc
+            io_mgr.cc journal/journal.cc journal/journal_shard.cc table.cc
+            tiered_storage.cc transaction.cc)
+cxx_link(dfly_transaction uring_fiber_lib dfly_core strings_lib)
+
+add_library(dragonfly_lib  channel_slice.cc command_registry.cc
+            config_flags.cc conn_context.cc debugcmd.cc dflycmd.cc
+            generic_family.cc hset_family.cc
             list_family.cc main_service.cc  rdb_load.cc rdb_save.cc replica.cc
             snapshot.cc script_mgr.cc server_family.cc
-            set_family.cc stream_family.cc string_family.cc table.cc tiered_storage.cc
-            transaction.cc zset_family.cc version.cc)
+            set_family.cc stream_family.cc string_family.cc
+            zset_family.cc version.cc)
 
-cxx_link(dragonfly_lib dfly_core dfly_facade redis_lib strings_lib html_lib)
+cxx_link(dragonfly_lib dfly_transaction dfly_facade redis_lib strings_lib html_lib)
 
 add_library(dfly_test_lib test_utils.cc)
 cxx_link(dfly_test_lib dragonfly_lib facade_test gtest_main_ext)

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -60,7 +60,8 @@ struct ObjInfo {
 
 void DoPopulateBatch(std::string_view prefix, size_t val_size, const SetCmd::SetParams& params,
                      const PopulateBatch& batch) {
-  SetCmd sg(&EngineShard::tlocal()->db_slice());
+  OpArgs op_args(EngineShard::tlocal(), 0, params.db_index);
+  SetCmd sg(op_args);
 
   for (unsigned i = 0; i < batch.sz; ++i) {
     string key = absl::StrCat(prefix, ":", batch.index[i]);

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -1,0 +1,124 @@
+// Copyright 2022, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+#include "server/dflycmd.h"
+
+#include <absl/strings/str_cat.h>
+#include <absl/strings/strip.h>
+
+#include "base/flags.h"
+#include "base/logging.h"
+#include "facade/dragonfly_connection.h"
+
+#include "server/engine_shard_set.h"
+#include "server/error.h"
+#include "server/journal/journal.h"
+#include "server/server_state.h"
+#include "server/transaction.h"
+
+using namespace std;
+
+ABSL_DECLARE_FLAG(string, dir);
+
+namespace dfly {
+
+using namespace facade;
+using namespace std;
+using util::ProactorBase;
+
+DflyCmd::DflyCmd(util::ListenerInterface* listener, journal::Journal* journal) : listener_(listener), journal_(journal) {
+}
+
+void DflyCmd::Run(CmdArgList args, ConnectionContext* cntx) {
+  DCHECK_GE(args.size(), 2u);
+
+  ToUpper(&args[1]);
+  RedisReplyBuilder* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+
+  std::string_view sub_cmd = ArgS(args, 1);
+  if (sub_cmd == "JOURNAL") {
+    if (args.size() < 3) {
+      return rb->SendError(WrongNumArgsError("DFLY JOURNAL"));
+    }
+    HandleJournal(args, cntx);
+    return;
+  }
+
+  if (sub_cmd == "THREAD") {
+    util::ProactorPool* pool = shard_set->pool();
+
+    if (args.size() == 2) {  // DFLY THREAD : returns connection thread index and number of threads.
+      rb->StartArray(2);
+      rb->SendLong(ProactorBase::GetIndex());
+      rb->SendLong(long(pool->size()));
+      return;
+    }
+
+    // DFLY THREAD to_thread : migrates current connection to a different thread.
+    std::string_view arg = ArgS(args, 2);
+    unsigned num_thread;
+    if (!absl::SimpleAtoi(arg, &num_thread)) {
+      return rb->SendError(kSyntaxErr);
+    }
+
+    if (num_thread < pool->size()) {
+      if (int(num_thread) != ProactorBase::GetIndex()) {
+        listener_->Migrate(cntx->owner(), pool->at(num_thread));
+      }
+
+      return rb->SendOk();
+    }
+
+    rb->SendError(kInvalidIntErr);
+    return;
+  }
+
+  rb->SendError(kSyntaxErr);
+}
+
+
+void DflyCmd::HandleJournal(CmdArgList args, ConnectionContext* cntx) {
+  DCHECK_GE(args.size(), 3u);
+  ToUpper(&args[2]);
+
+  std::string_view sub_cmd = ArgS(args, 2);
+  Transaction* trans = cntx->transaction;
+  DCHECK(trans);
+  RedisReplyBuilder* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+
+  if (sub_cmd == "START") {
+    unique_lock lk(mu_);
+    journal::Journal* journal = ServerState::tlocal()->journal();
+    if (!journal) {
+      string dir = absl::GetFlag(FLAGS_dir);
+      journal_->StartLogging(dir);
+      trans->Schedule();
+      auto barrier_cb = [](Transaction* t, EngineShard* shard) { return OpStatus::OK; };
+      trans->Execute(barrier_cb, true);
+
+      // tx id starting from which we may reliably fetch journal records.
+      journal_txid_ = trans->txid();
+    }
+
+    return rb->SendLong(journal_txid_);
+  }
+
+  if (sub_cmd == "STOP") {
+    unique_lock lk(mu_);
+    if (journal_->EnterLameDuck()) {
+      auto barrier_cb = [](Transaction* t, EngineShard* shard) { return OpStatus::OK; };
+      trans->ScheduleSingleHop(std::move(barrier_cb));
+
+      auto ec = journal_->Close();
+      LOG_IF(ERROR, ec) << "Error closing journal " << ec;
+      journal_txid_ = trans->txid();
+    }
+
+    return rb->SendLong(journal_txid_);
+  }
+
+  string reply = UnknownSubCmd(sub_cmd, "DFLY");
+  return rb->SendError(reply, kSyntaxErrType);
+}
+
+}  // namespace dfly

--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -1,0 +1,38 @@
+// Copyright 2022, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <absl/container/btree_map.h>
+
+#include "server/conn_context.h"
+
+namespace util {
+class ListenerInterface;
+}  // namespace util
+
+namespace dfly {
+
+class EngineShardSet;
+
+namespace journal {
+class Journal;
+}  // namespace journal
+
+class DflyCmd {
+ public:
+  DflyCmd(util::ListenerInterface* listener, journal::Journal* journal);
+
+  void Run(CmdArgList args, ConnectionContext* cntx);
+
+ private:
+  void HandleJournal(CmdArgList args, ConnectionContext* cntx);
+
+  util::ListenerInterface* listener_;
+  journal::Journal* journal_;
+  ::boost::fibers::mutex mu_;
+  TxId journal_txid_ = 0;
+};
+
+}  // namespace dfly

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -27,7 +27,9 @@ ABSL_FLAG(uint32_t, hz, 1000,
           "and performs other background tasks. Warning: not advised to decrease in production, "
           "because it can affect expiry precision for PSETEX etc.");
 
-ABSL_DECLARE_FLAG(bool, cache_mode);
+ABSL_FLAG(bool, cache_mode, false,
+          "If true, the backend behaves like a cache, "
+          "by evicting entries when getting close to maxmemory limit");
 
 namespace dfly {
 
@@ -42,8 +44,9 @@ vector<EngineShardSet::CachedStats> cached_stats;  // initialized in EngineShard
 
 }  // namespace
 
-thread_local EngineShard* EngineShard::shard_ = nullptr;
 constexpr size_t kQueueLen = 64;
+
+thread_local EngineShard* EngineShard::shard_ = nullptr;
 EngineShardSet* shard_set = nullptr;
 
 EngineShard::Stats& EngineShard::Stats::operator+=(const EngineShard::Stats& o) {

--- a/src/server/engine_shard_set.h
+++ b/src/server/engine_shard_set.h
@@ -26,6 +26,10 @@ extern "C" {
 
 namespace dfly {
 
+namespace journal {
+class Journal;
+}  // namespace journal
+
 class TieredStorage;
 class BlockingController;
 
@@ -134,6 +138,14 @@ class EngineShard {
     return counter_[unsigned(type)].SumTail();
   }
 
+  journal::Journal* journal() {
+    return journal_;
+  }
+
+  void set_journal(journal::Journal* j) {
+    journal_ = j;
+  }
+
   void TEST_EnableHeartbeat();
 
  private:
@@ -160,6 +172,7 @@ class EngineShard {
   // Logical ts used to order distributed transactions.
   TxId committed_txid_ = 0;
   Transaction* continuation_trans_ = nullptr;
+  journal::Journal* journal_ = nullptr;
   IntentLock shard_lock_;
 
   uint32_t periodic_task_ = 0;

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -99,7 +99,7 @@ void HSetFamily::HDel(CmdArgList args, ConnectionContext* cntx) {
 
   args.remove_prefix(2);
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpDel(OpArgs{shard, t->db_index()}, key, args);
+    return OpDel(t->GetOpArgs(shard), key, args);
   };
 
   OpResult<uint32_t> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
@@ -114,7 +114,7 @@ void HSetFamily::HLen(CmdArgList args, ConnectionContext* cntx) {
   string_view key = ArgS(args, 1);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpLen(OpArgs{shard, t->db_index()}, key);
+    return OpLen(t->GetOpArgs(shard), key);
   };
 
   OpResult<uint32_t> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
@@ -157,7 +157,7 @@ void HSetFamily::HMGet(CmdArgList args, ConnectionContext* cntx) {
 
   args.remove_prefix(2);
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpMGet(OpArgs{shard, t->db_index()}, key, args);
+    return OpMGet(t->GetOpArgs(shard), key, args);
   };
 
   OpResult<vector<OptStr>> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
@@ -186,7 +186,7 @@ void HSetFamily::HGet(CmdArgList args, ConnectionContext* cntx) {
   string_view field = ArgS(args, 2);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpGet(OpArgs{shard, t->db_index()}, key, field);
+    return OpGet(t->GetOpArgs(shard), key, field);
   };
 
   OpResult<string> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
@@ -214,7 +214,7 @@ void HSetFamily::HIncrBy(CmdArgList args, ConnectionContext* cntx) {
   IncrByParam param{ival};
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpIncrBy(OpArgs{shard, t->db_index()}, key, field, &param);
+    return OpIncrBy(t->GetOpArgs(shard), key, field, &param);
   };
 
   OpStatus status = cntx->transaction->ScheduleSingleHop(std::move(cb));
@@ -249,7 +249,7 @@ void HSetFamily::HIncrByFloat(CmdArgList args, ConnectionContext* cntx) {
   IncrByParam param{dval};
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpIncrBy(OpArgs{shard, t->db_index()}, key, field, &param);
+    return OpIncrBy(t->GetOpArgs(shard), key, field, &param);
   };
 
   OpStatus status = cntx->transaction->ScheduleSingleHop(std::move(cb));
@@ -284,7 +284,7 @@ void HSetFamily::HGetGeneric(CmdArgList args, ConnectionContext* cntx, uint8_t g
   string_view key = ArgS(args, 1);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpGetAll(OpArgs{shard, t->db_index()}, key, getall_mask);
+    return OpGetAll(t->GetOpArgs(shard), key, getall_mask);
   };
 
   OpResult<vector<string>> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
@@ -311,7 +311,7 @@ void HSetFamily::HScan(CmdArgList args, ConnectionContext* cntx) {
   }
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpScan(OpArgs{shard, t->db_index()}, key, &cursor);
+    return OpScan(t->GetOpArgs(shard), key, &cursor);
   };
 
   OpResult<StringVec> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
@@ -339,7 +339,7 @@ void HSetFamily::HSet(CmdArgList args, ConnectionContext* cntx) {
 
   args.remove_prefix(2);
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpSet(OpArgs{shard, t->db_index()}, key, args, false);
+    return OpSet(t->GetOpArgs(shard), key, args, false);
   };
 
   OpResult<uint32_t> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
@@ -355,7 +355,7 @@ void HSetFamily::HSetNx(CmdArgList args, ConnectionContext* cntx) {
 
   args.remove_prefix(2);
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpSet(OpArgs{shard, t->db_index()}, key, args, true);
+    return OpSet(t->GetOpArgs(shard), key, args, true);
   };
 
   OpResult<uint32_t> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
@@ -371,7 +371,7 @@ void HSetFamily::HStrLen(CmdArgList args, ConnectionContext* cntx) {
   string_view field = ArgS(args, 2);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpStrLen(OpArgs{shard, t->db_index()}, key, field);
+    return OpStrLen(t->GetOpArgs(shard), key, field);
   };
 
   OpResult<size_t> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));

--- a/src/server/journal/journal.cc
+++ b/src/server/journal/journal.cc
@@ -1,0 +1,126 @@
+// Copyright 2022, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "server/journal/journal.h"
+
+#include <filesystem>
+
+#include "base/logging.h"
+#include "server/engine_shard_set.h"
+#include "server/journal/journal_shard.h"
+#include "server/server_state.h"
+
+namespace dfly {
+namespace journal {
+
+namespace fs = std::filesystem;
+using namespace std;
+using namespace util;
+namespace fibers = boost::fibers;
+
+namespace {
+
+thread_local JournalShard journal_shard;
+
+}  // namespace
+
+Journal::Journal() {
+}
+
+error_code Journal::StartLogging(std::string_view dir) {
+  if (journal_shard.IsOpen()) {
+    return error_code{};
+  }
+
+  auto* pool = shard_set->pool();
+  atomic_uint32_t created{0};
+  lock_guard lk(state_mu_);
+
+  auto open_cb = [&](auto* pb) {
+    auto ec = journal_shard.Open(dir, unsigned(ProactorBase::GetIndex()));
+    if (ec) {
+      LOG(FATAL) << "Could not create journal " << ec;  // TODO
+    } else {
+      created.fetch_add(1, memory_order_relaxed);
+      ServerState::tlocal()->set_journal(this);
+      EngineShard* shard = EngineShard::tlocal();
+      if (shard) {
+        shard->set_journal(this);
+      }
+    }
+  };
+
+  pool->AwaitFiberOnAll(open_cb);
+
+  if (created.load(memory_order_acquire) != pool->size()) {
+    LOG(FATAL) << "TBD / revert";
+  }
+
+  return error_code{};
+}
+
+error_code Journal::Close() {
+  CHECK(lameduck_.load(memory_order_relaxed));
+
+  VLOG(1) << "Journal::Close";
+
+  fibers::mutex ec_mu;
+  error_code res;
+
+  lock_guard lk(state_mu_);
+  auto close_cb = [&](auto*) {
+    ServerState::tlocal()->set_journal(nullptr);
+    EngineShard* shard = EngineShard::tlocal();
+    if (shard) {
+      shard->set_journal(nullptr);
+    }
+
+    auto ec = journal_shard.Close();
+
+    if (ec) {
+      lock_guard lk2(ec_mu);
+      res = ec;
+    }
+  };
+
+  shard_set->pool()->AwaitFiberOnAll(close_cb);
+
+  return res;
+}
+
+bool Journal::SchedStartTx(TxId txid, unsigned num_keys, unsigned num_shards) {
+  if (!journal_shard.IsOpen() || lameduck_.load(memory_order_relaxed))
+    return false;
+
+  journal_shard.AddLogRecord(txid, unsigned(Op::SCHED));
+
+  return true;
+}
+
+LSN Journal::GetLsn() const {
+  return journal_shard.cur_lsn();
+}
+
+bool Journal::EnterLameDuck() {
+  if (!journal_shard.IsOpen()) {
+    return false;
+  }
+
+  bool val = false;
+  bool res = lameduck_.compare_exchange_strong(val, true, memory_order_acq_rel);
+  return res;
+}
+
+void Journal::OpArgs(TxId txid, Op opcode, Span keys) {
+  DCHECK(journal_shard.IsOpen());
+
+  journal_shard.AddLogRecord(txid, unsigned(opcode));
+}
+
+void Journal::RecordEntry(TxId txid, const PrimeKey& key, const PrimeValue& pval) {
+  journal_shard.AddLogRecord(txid, unsigned(Op::VAL));
+}
+
+}  // namespace journal
+}  // namespace dfly

--- a/src/server/journal/journal.h
+++ b/src/server/journal/journal.h
@@ -1,0 +1,73 @@
+// Copyright 2022, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include "server/common.h"
+#include "server/table.h"
+#include "util/proactor_pool.h"
+
+namespace dfly {
+
+class Transaction;
+
+namespace journal {
+
+enum class Op : uint8_t {
+  NOOP = 0,
+  LOCK = 1,
+  UNLOCK = 2,
+  LOCK_SHARD = 3,
+  UNLOCK_SHARD = 4,
+  SCHED = 5,
+  VAL = 10,
+  DEL,
+  MSET,
+};
+
+class Journal {
+ public:
+  using Span = absl::Span<const std::string_view>;
+
+  Journal();
+
+  std::error_code StartLogging(std::string_view dir);
+
+  // Returns true if journal has been active and changed its state to lameduck mode
+  // and false otherwise.
+  bool EnterLameDuck();  // still logs ongoing transactions but refuses to start new ones.
+
+  // Requires: journal is in lameduck mode.
+  std::error_code Close();
+
+  // Returns true if transaction was scheduled, false if journal is inactive
+  // or in lameduck mode and does not log new transactions.
+  bool SchedStartTx(TxId txid, unsigned num_keys, unsigned num_shards);
+
+  void AddCmd(TxId txid, Op opcode, Span args) {
+    OpArgs(txid, opcode, args);
+  }
+
+  void Lock(TxId txid, Span keys) {
+    OpArgs(txid, Op::LOCK, keys);
+  }
+
+  void Unlock(TxId txid, Span keys) {
+    OpArgs(txid, Op::UNLOCK, keys);
+  }
+
+  LSN GetLsn() const;
+
+  void RecordEntry(TxId txid, const PrimeKey& key, const PrimeValue& pval);
+
+ private:
+  void OpArgs(TxId id, Op opcode, Span keys);
+
+  mutable boost::fibers::mutex state_mu_;
+
+  std::atomic_bool lameduck_{false};
+};
+
+}  // namespace journal
+}  // namespace dfly

--- a/src/server/journal/journal_shard.cc
+++ b/src/server/journal/journal_shard.cc
@@ -1,0 +1,115 @@
+// Copyright 2022, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "server/journal/journal_shard.h"
+
+#include <fcntl.h>
+
+#include <absl/container/inlined_vector.h>
+#include <absl/strings/str_cat.h>
+
+#include <filesystem>
+
+#include "base/logging.h"
+#include "util/fibers/fibers_ext.h"
+
+namespace dfly {
+namespace journal {
+using namespace std;
+using namespace util;
+namespace fibers = boost::fibers;
+namespace fs = std::filesystem;
+
+namespace {
+
+string ShardName(std::string_view base, unsigned index) {
+  return absl::StrCat(base, "-", absl::Dec(index, absl::kZeroPad4), ".log");
+}
+
+}  // namespace
+
+#define CHECK_EC(x)                                                                 \
+  do {                                                                              \
+    auto __ec$ = (x);                                                               \
+    CHECK(!__ec$) << "Error: " << __ec$ << " " << __ec$.message() << " for " << #x; \
+  } while (false)
+
+
+
+JournalShard::JournalShard() {
+}
+
+JournalShard::~JournalShard() {
+  CHECK(!shard_file_);
+}
+
+std::error_code JournalShard::Open(const std::string_view dir, unsigned index) {
+  CHECK(!shard_file_);
+
+  fs::path dir_path;
+
+  if (dir.empty()) {
+  } else {
+    dir_path = dir;
+    error_code ec;
+
+    fs::file_status dir_status = fs::status(dir_path, ec);
+    if (ec) {
+      if (ec == errc::no_such_file_or_directory) {
+        fs::create_directory(dir_path, ec);
+        dir_status = fs::status(dir_path, ec);
+      }
+      if (ec)
+        return ec;
+    }
+    // LOG(INFO) << int(dir_status.type());
+  }
+  dir_path.append(ShardName("journal", index));
+  shard_path_ = dir_path;
+
+  // For file integrity guidelines see:
+  // https://lwn.net/Articles/457667/
+  // https://www.evanjones.ca/durability-filesystem.html
+  // NOTE: O_DSYNC is omited.
+  constexpr auto kJournalFlags = O_CLOEXEC | O_CREAT | O_TRUNC | O_RDWR;
+  io::Result<std::unique_ptr<uring::LinuxFile>> res =
+      uring::OpenLinux(shard_path_, kJournalFlags, 0666);
+  if (!res) {
+    return res.error();
+  }
+  DVLOG(1) << "Opened journal " << shard_path_;
+
+  shard_file_ = std::move(res).value();
+  shard_index_ = index;
+  file_offset_ = 0;
+  status_ec_.clear();
+
+  return error_code{};
+}
+
+error_code JournalShard::Close() {
+  VLOG(1) << "JournalShard::Close";
+
+  CHECK(shard_file_);
+  lameduck_ = true;
+
+  auto ec = shard_file_->Close();
+
+  DVLOG(1) << "Closing " << shard_path_;
+  LOG_IF(ERROR, ec) << "Error closing journal file " << ec;
+  shard_file_.reset();
+
+  return ec;
+}
+
+void JournalShard::AddLogRecord(TxId txid, unsigned opcode) {
+  string line = absl::StrCat(lsn_, " ", txid, " ", opcode, "\n");
+  error_code ec = shard_file_->Write(io::Buffer(line), file_offset_, 0);
+  CHECK_EC(ec);
+  file_offset_ += line.size();
+  ++lsn_;
+}
+
+}  // namespace journal
+}  // namespace dfly

--- a/src/server/journal/journal_shard.h
+++ b/src/server/journal/journal_shard.h
@@ -1,0 +1,56 @@
+// Copyright 2022, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <boost/fiber/condition_variable.hpp>
+#include <boost/fiber/fiber.hpp>
+#include <optional>
+#include <string_view>
+
+#include "server/common.h"
+#include "util/uring/uring_file.h"
+
+namespace dfly {
+namespace journal {
+
+class JournalShard {
+ public:
+  JournalShard();
+  ~JournalShard();
+
+  std::error_code Open(const std::string_view dir, unsigned index);
+
+  std::error_code Close();
+
+  LSN cur_lsn() const {
+    return lsn_;
+  }
+
+  std::error_code status() const {
+    return status_ec_;
+  }
+
+  bool IsOpen() const {
+    return bool(shard_file_);
+  }
+
+  void AddLogRecord(TxId txid, unsigned opcode);
+
+ private:
+  std::string shard_path_;
+  std::unique_ptr<util::uring::LinuxFile> shard_file_;
+
+  size_t file_offset_ = 0;
+  LSN lsn_ = 1;
+
+  unsigned shard_index_ = -1;
+
+  std::error_code status_ec_;
+
+  bool lameduck_ = false;
+};
+
+}  // namespace journal
+}  // namespace dfly

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -44,9 +44,6 @@ ABSL_FLAG(uint32_t, memcache_port, 0, "Memcached port");
 ABSL_FLAG(uint64_t, maxmemory, 0,
           "Limit on maximum-memory that is used by the database."
           "0 - means the program will automatically determine its maximum memory usage");
-ABSL_FLAG(bool, cache_mode, false,
-          "If true, the backend behaves like a cache, "
-          "by evicting entries when getting close to maxmemory limit");
 
 ABSL_DECLARE_FLAG(string, requirepass);
 

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -79,13 +79,6 @@ error_code Recv(FiberSocketBase* input, base::IoBuf* dest) {
 
 constexpr unsigned kRdbEofMarkSize = 40;
 
-// TODO: to remove usages of this macro and make code crash-less.
-#define CHECK_EC(x)                                                                 \
-  do {                                                                              \
-    auto __ec$ = (x);                                                               \
-    CHECK(!__ec$) << "Error: " << __ec$ << " " << __ec$.message() << " for " << #x; \
-  } while (false)
-
 }  // namespace
 
 Replica::Replica(string host, uint16_t port, Service* se)
@@ -510,7 +503,7 @@ error_code Replica::ConsumeRedisStream() {
 
   // Master waits for this command in order to start sending replication stream.
   serializer.SendCommand("REPLCONF ACK 0");
-  CHECK_EC(serializer.ec());
+  RETURN_ON_ERR(serializer.ec());
 
   VLOG(1) << "Before reading repl-log";
 

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -17,8 +17,13 @@ class HttpListenerBase;
 
 namespace dfly {
 
+namespace journal {
+class Journal;
+}  // namespace journal
+
 class ConnectionContext;
 class CommandRegistry;
+class DflyCmd;
 class Service;
 class Replica;
 class ScriptMgr;
@@ -41,9 +46,9 @@ struct Metrics {
 };
 
 struct LastSaveInfo {
-  time_t save_time;        // epoch time in seconds.
-  std::string file_name;  //
-  std::vector<std::pair<std::string_view, size_t>> freq_map; // RDB_TYPE_xxx -> count mapping.
+  time_t save_time;                                           // epoch time in seconds.
+  std::string file_name;                                      //
+  std::vector<std::pair<std::string_view, size_t>> freq_map;  // RDB_TYPE_xxx -> count mapping.
 };
 
 class ServerFamily {
@@ -91,6 +96,7 @@ class ServerFamily {
   void Config(CmdArgList args, ConnectionContext* cntx);
   void DbSize(CmdArgList args, ConnectionContext* cntx);
   void Debug(CmdArgList args, ConnectionContext* cntx);
+  void Dfly(CmdArgList args, ConnectionContext* cntx);
   void Memory(CmdArgList args, ConnectionContext* cntx);
   void FlushDb(CmdArgList args, ConnectionContext* cntx);
   void FlushAll(CmdArgList args, ConnectionContext* cntx);
@@ -111,7 +117,6 @@ class ServerFamily {
 
   void Load(const std::string& file_name);
 
-
   boost::fibers::fiber load_fiber_;
 
   uint32_t stats_caching_task_ = 0;
@@ -125,6 +130,8 @@ class ServerFamily {
   std::shared_ptr<Replica> replica_;  // protected by replica_of_mu_
 
   std::unique_ptr<ScriptMgr> script_mgr_;
+  std::unique_ptr<journal::Journal> journal_;
+  std::unique_ptr<DflyCmd> dfly_cmd_;
 
   time_t start_time_ = 0;  // in seconds, epoch time.
 

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -15,6 +15,10 @@ typedef struct mi_heap_s mi_heap_t;
 
 namespace dfly {
 
+namespace journal {
+class Journal;
+}  // namespace journal
+
 // Present in every server thread. This class differs from EngineShard. The latter manages
 // state around engine shards while the former represents coordinator/connection state.
 // There may be threads that handle engine shards but not IO, there may be threads that handle IO
@@ -58,6 +62,7 @@ class ServerState {  // public struct - to allow initialization.
   GlobalState gstate() const {
     return gstate_;
   }
+
   void set_gstate(GlobalState s) {
     gstate_ = s;
   }
@@ -66,7 +71,9 @@ class ServerState {  // public struct - to allow initialization.
 
   // Returns sum of all requests in the last 6 seconds
   // (not including the current one).
-  uint32_t MovingSum6() const { return qps_.SumTail(); }
+  uint32_t MovingSum6() const {
+    return qps_.SumTail();
+  }
 
   void RecordCmd() {
     ++connection_stats.command_cnt;
@@ -78,9 +85,18 @@ class ServerState {  // public struct - to allow initialization.
     return data_heap_;
   }
 
+  journal::Journal* journal() {
+    return journal_;
+  }
+
+  void set_journal(journal::Journal* j) {
+    journal_ = j;
+  }
+
  private:
   int64_t live_transactions_ = 0;
   mi_heap_t* data_heap_;
+  journal::Journal* journal_ = nullptr;
 
   std::optional<Interpreter> interpreter_;
   GlobalState gstate_ = GlobalState::ACTIVE;

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -494,8 +494,7 @@ void CreateGroup(CmdArgList args, string_view key, ConnectionContext* cntx) {
   opts.id = ArgS(args, 1);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    OpArgs op_args{shard, t->db_index()};
-    return OpCreate(op_args, key, opts);
+    return OpCreate(t->GetOpArgs(shard), key, opts);
   };
 
   OpStatus result = cntx->transaction->ScheduleSingleHop(std::move(cb));
@@ -509,8 +508,7 @@ void CreateGroup(CmdArgList args, string_view key, ConnectionContext* cntx) {
 
 void DestroyGroup(string_view key, string_view gname, ConnectionContext* cntx) {
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    OpArgs op_args{shard, t->db_index()};
-    return OpDestroyGroup(op_args, key, gname);
+    return OpDestroyGroup(t->GetOpArgs(shard), key, gname);
   };
 
   OpStatus result = cntx->transaction->ScheduleSingleHop(std::move(cb));
@@ -529,8 +527,7 @@ void DestroyGroup(string_view key, string_view gname, ConnectionContext* cntx) {
 void DelConsumer(string_view key, string_view gname, string_view consumer,
                  ConnectionContext* cntx) {
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    OpArgs op_args{shard, t->db_index()};
-    return OpDelConsumer(op_args, key, gname, consumer);
+    return OpDelConsumer(t->GetOpArgs(shard), key, gname, consumer);
   };
 
   OpResult<uint32_t> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
@@ -551,8 +548,7 @@ void SetId(string_view key, string_view gname, CmdArgList args, ConnectionContex
   string_view id = ArgS(args, 0);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    OpArgs op_args{shard, t->db_index()};
-    return OpSetId(op_args, key, gname, id);
+    return OpSetId(t->GetOpArgs(shard), key, gname, id);
   };
 
   OpStatus result = cntx->transaction->ScheduleSingleHop(std::move(cb));
@@ -607,8 +603,7 @@ void StreamFamily::XAdd(CmdArgList args, ConnectionContext* cntx) {
 
   args.remove_prefix(1);
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    OpArgs op_args{shard, t->db_index()};
-    return OpAdd(op_args, key, add_opts, args);
+    return OpAdd(t->GetOpArgs(shard), key, add_opts, args);
   };
 
   OpResult<streamID> add_result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
@@ -641,8 +636,7 @@ void StreamFamily::XDel(CmdArgList args, ConnectionContext* cntx) {
   }
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    OpArgs op_args{shard, t->db_index()};
-    return OpDel(op_args, key, absl::Span{ids.data(), ids.size()});
+    return OpDel(t->GetOpArgs(shard), key, absl::Span{ids.data(), ids.size()});
   };
 
   OpResult<uint32_t> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
@@ -751,8 +745,7 @@ void StreamFamily::XInfo(CmdArgList args, ConnectionContext* cntx) {
 void StreamFamily::XLen(CmdArgList args, ConnectionContext* cntx) {
   string_view key = ArgS(args, 1);
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    OpArgs op_args{shard, t->db_index()};
-    return OpLen(op_args, key);
+    return OpLen(t->GetOpArgs(shard), key);
   };
 
   OpResult<uint32_t> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
@@ -781,8 +774,7 @@ void StreamFamily::XSetId(CmdArgList args, ConnectionContext* cntx) {
   }
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    OpArgs op_args{shard, t->db_index()};
-    return OpSetId2(op_args, key, parsed_id.val);
+    return OpSetId2(t->GetOpArgs(shard), key, parsed_id.val);
   };
 
   OpStatus result = cntx->transaction->ScheduleSingleHop(std::move(cb));
@@ -835,8 +827,7 @@ void StreamFamily::XRangeGeneric(CmdArgList args, bool is_rev, ConnectionContext
   range_opts.is_rev = is_rev;
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    OpArgs op_args{shard, t->db_index()};
-    return OpRange(op_args, key, range_opts);
+    return OpRange(t->GetOpArgs(shard), key, range_opts);
   };
 
   OpResult<RecordVec> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));

--- a/src/server/string_family.h
+++ b/src/server/string_family.h
@@ -16,11 +16,10 @@ using facade::OpResult;
 using facade::OpStatus;
 
 class SetCmd {
-  DbSlice& db_slice_;
+  const OpArgs op_args_;
 
  public:
-  explicit SetCmd(DbSlice* db_slice);
-  ~SetCmd();
+  explicit SetCmd(const OpArgs& op_args) : op_args_(op_args) {}
 
   enum SetHow { SET_ALWAYS, SET_IF_NOTEXIST, SET_IF_EXISTS };
 
@@ -38,7 +37,7 @@ class SetCmd {
     }
   };
 
-  OpResult<void> Set(const SetParams& params, std::string_view key, std::string_view value);
+  OpStatus Set(const SetParams& params, std::string_view key, std::string_view value);
 
  private:
   OpStatus SetExisting(const SetParams& params, PrimeIterator it, ExpireIterator e_it,
@@ -86,24 +85,6 @@ class StringFamily {
   using MGetResponse = std::vector<std::optional<GetResp>>;
   static MGetResponse OpMGet(bool fetch_mcflag, bool fetch_mcver, const Transaction* t,
                              EngineShard* shard);
-
-  // Returns true if keys were set, false otherwise.
-  static OpStatus OpMSet(const OpArgs& op_args, ArgSlice args);
-
-  // if skip_on_missing - returns KEY_NOTFOUND.
-  static OpResult<int64_t> OpIncrBy(const OpArgs& op_args, std::string_view key, int64_t val,
-                                    bool skip_on_missing);
-  static OpResult<double> OpIncrFloat(const OpArgs& op_args, std::string_view key, double val);
-
-  // Returns the length of the extended string. if prepend is false - appends the val.
-  static OpResult<uint32_t> ExtendOrSet(const OpArgs& op_args, std::string_view key,
-                                        std::string_view val, bool prepend);
-
-  // Returns true if was extended, false if the key was not found.
-  static OpResult<bool> ExtendOrSkip(const OpArgs& op_args, std::string_view key,
-                                     std::string_view val, bool prepend);
-
-  static OpResult<std::string> OpGet(const OpArgs& op_args, std::string_view key);
 };
 
 }  // namespace dfly

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -179,6 +179,10 @@ class Transaction {
   //! Runs in the shard thread.
   KeyLockArgs GetLockArgs(ShardId sid) const;
 
+  OpArgs GetOpArgs(EngineShard* shard) const {
+    return OpArgs{shard, txid_, db_index_};
+  }
+
  private:
 
   struct LockCnt {


### PR DESCRIPTION
1. No entries data is written into a journal yet.
2. Introduced a state machine to start and stop journal using a new auxillary command "dfly".
3. string_family currently calls an universal command Journal::RecordEntry that should
   save the current key/value of that entry. Please note that we won't use it for all the operations
   because for some it's more efficient to record the action itself than the final value.
4. no locking information is recorded yet so atomicity of multi-key operations is not preserved for now.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->