### PR TITLE
feat(server): tighten memory checks when inseting a new object.

### DIFF
--- a/src/core/dash_internal.h
+++ b/src/core/dash_internal.h
@@ -174,6 +174,10 @@ template <unsigned NUM_SLOTS, unsigned NUM_STASH_FPS> class BucketBase {
     return slotb_.GetBusy();
   }
 
+  bool IsBusy(unsigned slot) const {
+    return (GetBusy() & (1u << slot)) != 0;
+  }
+
   // mask is saying which slots needs to be freed (1 - should clear).
   void ClearSlots(uint32_t mask) {
     slotb_.ClearSlots(mask);
@@ -664,8 +668,8 @@ class DashCursor {
   // | segment_id......| bucket_id
   // 40                8          0
   // By using depth we take most significant bits of segment_id if depth has decreased
-  // since the cursort was created, or extend the least significant bits with zeros if
-  // depth has increased.
+  // since the cursor has been created, or extend the least significant bits with zeros,
+  // if depth was increased.
   uint32_t segment_id(uint8_t depth) {
     return val_ >> (40 - depth);
   }

--- a/src/core/dash_test.cc
+++ b/src/core/dash_test.cc
@@ -512,7 +512,7 @@ TEST_F(DashTest, Traverse) {
     dt_.Insert(i, i);
   }
 
-  Dash64::cursor cursor;
+  Dash64::Cursor cursor;
   vector<unsigned> nums;
   auto tr_cb = [&](Dash64::iterator it) {
     nums.push_back(it->first);
@@ -536,7 +536,7 @@ TEST_F(DashTest, Bucket) {
   }
   std::vector<uint64_t> s;
   auto it = dt_.begin();
-  auto bucket_it = Dash64::bucket_it(it);
+  auto bucket_it = Dash64::BucketIt(it);
 
   dt_.TraverseBucket(it, [&](auto i) { s.push_back(i->first); });
 

--- a/src/facade/facade_test.h
+++ b/src/facade/facade_test.h
@@ -74,6 +74,14 @@ inline bool operator!=(const RespExpr& left, std::string_view s) {
   return !(left == s);
 }
 
+inline bool operator==(std::string_view s, const RespExpr& right) {
+  return right == s;
+}
+
+inline bool operator!=(std::string_view s, const RespExpr& right) {
+  return !(right == s);
+}
+
 void PrintTo(const RespExpr::Vec& vec, std::ostream* os);
 
 }  // namespace facade

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -502,20 +502,26 @@ TEST_F(DflyEngineTest, Bug207) {
 TEST_F(DflyEngineTest, StickyEviction) {
   shard_set->TEST_EnableHeartBeat();
   shard_set->TEST_EnableCacheMode();
-  max_memory_limit = 0;
+  max_memory_limit = 300000;
 
   string tmp_val(100, '.');
 
   ssize_t failed = -1;
   for (ssize_t i = 0; i < 5000; ++i) {
-    auto set_resp = Run({"set", StrCat("key", i), tmp_val});
-    auto stick_resp = Run({"stick", StrCat("key", i)});
+    string key = StrCat("volatile", i);
+    ASSERT_EQ("OK", Run({"set", key, tmp_val}));
+  }
+
+  for (ssize_t i = 0; i < 5000; ++i) {
+    string key = StrCat("key", i);
+    auto set_resp = Run({"set", key, tmp_val});
+    auto stick_resp = Run({"stick", key});
 
     if (set_resp != "OK") {
       failed = i;
       break;
     }
-    ASSERT_THAT(stick_resp, IntArg(1));
+    ASSERT_THAT(stick_resp, IntArg(1)) << i;
   }
 
   ASSERT_GE(failed, 0);

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -218,7 +218,7 @@ void OpScan(const OpArgs& op_args, const ScanOpts& scan_opts, uint64_t* cursor,
   VLOG(1) << "PrimeTable " << db_slice.shard_id() << "/" << op_args.db_ind << " has "
           << db_slice.DbSize(op_args.db_ind);
 
-  PrimeTable::cursor cur = *cursor;
+  PrimeTable::Cursor cur = *cursor;
   auto [prime_table, expire_table] = db_slice.GetTables(op_args.db_ind);
   do {
     cur = prime_table->Traverse(

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -1214,7 +1214,7 @@ void RdbLoader::LoadItemsBuffer(DbIndex db_ind, const ItemsBuf& ib) {
       break;
     }
 
-    auto [it, added] = db_slice.AddOrFind(db_ind, key, std::move(pv), item.expire_ms);
+    auto [it, added] = db_slice.AddEntry(db_ind, key, std::move(pv), item.expire_ms);
 
     if (!added) {
       LOG(WARNING) << "RDB has duplicated key '" << key << "' in DB " << db_ind;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -165,6 +165,9 @@ void ServerFamily::Init(util::AcceptServer* acceptor, util::ListenerInterface* m
   dfly_cmd_.reset(new DflyCmd(main_listener, journal_.get()));
 
   pb_task_ = shard_set->pool()->GetNextProactor();
+
+  // Unlike EngineShard::Heartbeat that runs independently in each shard thread,
+  // this callback runs in a single thread and it aggregates globally stats from all the shards.
   auto cache_cb = [] {
     uint64_t sum = 0;
     const auto& stats = EngineShardSet::GetCachedStats();
@@ -864,6 +867,7 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
     append("rejected_connections", -1);
     append("expired_keys", m.events.expired_keys);
     append("evicted_keys", m.events.evicted_keys);
+    append("hard_evictions", m.events.hard_evictions);
     append("garbage_checked", m.events.garbage_checked);
     append("garbage_collected", m.events.garbage_collected);
     append("bump_ups", m.events.bumpups);

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -75,7 +75,7 @@ void SliceSnapshot::SerializeSingleEntry(DbIndex db_indx, const PrimeKey& pk, co
 void SliceSnapshot::FiberFunc() {
   this_fiber::properties<FiberProps>().set_name(
       absl::StrCat("SliceSnapshot", ProactorBase::GetIndex()));
-  PrimeTable::cursor cursor;
+  PrimeTable::Cursor cursor;
 
   for (DbIndex db_indx = 0; db_indx < db_array_.size(); ++db_indx) {
     if (!db_array_[db_indx])
@@ -90,7 +90,7 @@ void SliceSnapshot::FiberFunc() {
     mu_.unlock();
 
     do {
-      PrimeTable::cursor next = pt->Traverse(cursor, [this](auto it) { this->SaveCb(move(it)); });
+      PrimeTable::Cursor next = pt->Traverse(cursor, [this](auto it) { this->SaveCb(move(it)); });
 
       cursor = next;
 

--- a/src/server/table.h
+++ b/src/server/table.h
@@ -65,7 +65,8 @@ struct DbTable : boost::intrusive_ref_counter<DbTable, boost::thread_unsafe_coun
   LockTable trans_locks;
 
   mutable DbTableStats stats;
-  ExpireTable::cursor expire_cursor;
+  ExpireTable::Cursor expire_cursor;
+  PrimeTable::Cursor prime_cursor;
 
   explicit DbTable(std::pmr::memory_resource* mr);
   ~DbTable();

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -329,7 +329,7 @@ void TieredStorage::FlushPending() {
   for (size_t i = 0; i < canonic_req.size(); ++i) {
     DbIndex db_ind = canonic_req[i].first;
     uint64_t cursor_val = canonic_req[i].second;
-    PrimeTable::cursor curs(cursor_val);
+    PrimeTable::Cursor curs(cursor_val);
     db_slice_.GetTables(db_ind).first->Traverse(curs, tr_cb);
 
     for (unsigned j = 0; j < batch_len; ++j) {


### PR DESCRIPTION
Before this change Dragonfly evicted items only when it was low on memory and had to grow its main dictionary.
It is not enough because in many cases Dragonfly can grow in memory even when the main dictionary does not grow.
For example, when its dictionary is less than 90% utilized but the newly added objects require lots of memory.

In addition, the dashtable could add additional segments when others had enough available slots to fill the rest of the free memory.

This change adds another layer of defense that allows evicting items even when dictionary segments are not full.
The eviction is still local with respect to a segment. On my tests it seems that it's much harder to cross maxmemory limit than before.

In addition we improved our heuristic that allowed the dashtable to grow. Now it takes into account the average bytes per item in order to
project how much memory the full table takes before adding to it new segments. This really tightens dashtable utilization.

Things to improve:
1. the eviction behavior is rough. Once an insert does the eviction it tries to free enough objects to bring memory back.
   This may result in very spiky insertion/eviction patterns.
2. The eviction procedure, even though it's limited to a single segment, is quite heavy because it goes over all buckets
   in the segment. This may result in weird artifacts where we evict just enough to be under the limit, then add and evict
   again and so on.
3. Therefore, we may need a periodic eviction that will complement this emergency eviction step.

Fixes #224 and partially addresses #256

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->