### PR TITLE
feat(packaging): create deb packaging #249

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,3 +24,5 @@ include_directories(helio)
 
 add_subdirectory(helio)
 add_subdirectory(src)
+
+include(cmake/Packing.cmake)

--- a/cmake/Packing.cmake
+++ b/cmake/Packing.cmake
@@ -1,0 +1,39 @@
+# Packages the dragonfly binary into a .deb package
+# Use this to generate .deb package from build directory
+#    cpack -G DEB
+#
+# Resulting packages can be found under _packages/
+
+set(CPACK_PACKAGE_NAME "dragonflydb"
+    CACHE STRING "dragonflydb"
+)
+
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "A modern replacement for Redis and Memcached"
+    CACHE STRING "A modern replacement for Redis and Memcached"
+)
+
+set(CPACK_PACKAGE_VENDOR "DragonflyDB")
+
+set(CPACK_OUTPUT_FILE_PREFIX "${CMAKE_SOURCE_DIR}/_packages")
+
+set(CPACK_PACKAGING_INSTALL_PREFIX "/usr/share/dragonfly")
+
+set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
+set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
+set(CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
+
+set(CPACK_PACKAGE_CONTACT "support@dragonflydb.io")
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "DragonflyDB maintainers")
+
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.md")
+set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
+
+set(CPACK_COMPONENTS_GROUPING ALL_COMPONENTS_IN_ONE)
+
+set(CPACK_DEB_COMPONENT_INSTALL YES)
+
+install(TARGETS dragonfly DESTINATION . COMPONENT dragonfly)
+
+set(CPACK_COMPONENTS_ALL dragonfly)
+
+include(CPack)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,6 @@ add_third_party(
   jsoncons
   URL https://github.com/danielaparker/jsoncons/archive/refs/tags/v0.168.7.tar.gz
   CMAKE_PASS_FLAGS "-DJSONCONS_BUILD_TESTS=OFF"
-  
   LIB "none"
 )
 


### PR DESCRIPTION
feat(packaging): create deb packaging #249

This allows creation of .deb package file after creating the dragonfly binary with ```ninja dragonfly```, using ```cpack -G DEB``` from ```./build-opts```
Dragonfly is installed to ```/usr/bin/dragonfly```