### PR TITLE
feat(server): bitcount commands support and unit tests  #213

### DIFF
--- a/docs/api_status.md
+++ b/docs/api_status.md
@@ -119,7 +119,7 @@ with respect to Memcached and Redis APIs.
   - [X] SETEX
   - [X] APPEND
   - [X] PREPEND (dragonfly specific)
-  - [ ] BITCOUNT
+  - [x] BITCOUNT
   - [ ] BITFIELD
   - [ ] BITOP
   - [ ] BITPOS

--- a/src/server/bitops_family.h
+++ b/src/server/bitops_family.h
@@ -1,4 +1,4 @@
-// Copyright 2021, Roman Gershman.  All rights reserved.
+// Copyright 2022, DragonflyDB authors.  All rights reserved.
 // See LICENSE for licensing terms.
 //
 

--- a/src/server/bitops_family_test.cc
+++ b/src/server/bitops_family_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2022, Roman Gershman.  All rights reserved.
+// Copyright 2022, DragonflyDB authors.  All rights reserved.
 // See LICENSE for licensing terms.
 //
 
@@ -74,6 +74,56 @@ TEST_F(BitOpsFamilyTest, SetBitMissingKey) {
   for (int32_t i = 0; i < ITERATIONS; i++) {
     EXPECT_EQ(1, CheckedInt({"getbit", "foo", std::to_string(i)}));
   }
+}
+
+const int32_t EXPECTED_VALUES_BYTES_BIT_COUNT[] = {  // got this from redis 0 as start index
+    4, 7, 11, 14, 17, 21, 21, 21, 21};
+
+const int32_t BYTES_EXPECTED_VALUE_LEN =
+    sizeof(EXPECTED_VALUES_BYTES_BIT_COUNT) / sizeof(EXPECTED_VALUES_BYTES_BIT_COUNT[0]);
+
+TEST_F(BitOpsFamilyTest, BitCountByte) {
+  // This would run without the bit flag - meaning it count on bytes boundaries
+  auto resp = Run({"set", "foo", "farbar"});
+  EXPECT_EQ(resp, "OK");
+  EXPECT_EQ(0, CheckedInt({"bitcount", "foo2"}));  // on none existing key we are expecting 0
+
+  for (int32_t i = 0; i < BYTES_EXPECTED_VALUE_LEN; i++) {
+    EXPECT_EQ(EXPECTED_VALUES_BYTES_BIT_COUNT[i],
+              CheckedInt({"bitcount", "foo", "0", std::to_string(i)}));
+  }
+  EXPECT_EQ(21, CheckedInt({"bitcount", "foo"}));  // the total number of bits in this value
+}
+
+TEST_F(BitOpsFamilyTest, BitCountByteSubRange) {
+  // This test test using some sub ranges of bit count on bytes
+  auto resp = Run({"set", "foo", "farbar"});
+  EXPECT_EQ(resp, "OK");
+  EXPECT_EQ(3, CheckedInt({"bitcount", "foo", "1", "1"}));
+  EXPECT_EQ(7, CheckedInt({"bitcount", "foo", "1", "2"}));
+  EXPECT_EQ(4, CheckedInt({"bitcount", "foo", "2", "2"}));
+  EXPECT_EQ(0, CheckedInt({"bitcount", "foo", "3", "2"}));  // illegal range
+  EXPECT_EQ(10, CheckedInt({"bitcount", "foo", "-3", "-1"}));
+  EXPECT_EQ(13, CheckedInt({"bitcount", "foo", "-5", "-2"}));
+  EXPECT_EQ(0, CheckedInt({"bitcount", "foo", "-1", "-2"}));  // illegal range
+}
+
+TEST_F(BitOpsFamilyTest, BitCountByteBitSubRange) {
+  // This test test using some sub ranges of bit count on bytes
+  auto resp = Run({"set", "foo", "abcdef"});
+  EXPECT_EQ(resp, "OK");
+  resp = Run({"bitcount", "foo", "bar", "BIT"});
+  ASSERT_THAT(resp, ErrArg("value is not an integer or out of range"));
+
+  EXPECT_EQ(1, CheckedInt({"bitcount", "foo", "1", "1", "BIT"}));
+  EXPECT_EQ(2, CheckedInt({"bitcount", "foo", "1", "2", "BIT"}));
+  EXPECT_EQ(1, CheckedInt({"bitcount", "foo", "2", "2", "BIT"}));
+  EXPECT_EQ(0, CheckedInt({"bitcount", "foo", "3", "2", "bit"}));  // illegal range
+  EXPECT_EQ(2, CheckedInt({"bitcount", "foo", "-3", "-1", "bit"}));
+  EXPECT_EQ(2, CheckedInt({"bitcount", "foo", "-5", "-2", "bit"}));
+  EXPECT_EQ(4, CheckedInt({"bitcount", "foo", "1", "9", "bit"}));
+  EXPECT_EQ(7, CheckedInt({"bitcount", "foo", "2", "19", "bit"}));
+  EXPECT_EQ(0, CheckedInt({"bitcount", "foo", "-1", "-2", "bit"}));  // illegal range
 }
 
 }  // end of namespace dfly


### PR DESCRIPTION

Signed-off-by: Boaz Sade <boaz@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
Support for the bitcount command:
- update api_status.md update license
* If key doesn't exists - return 0.
* If range illegal (start less than end or start larger than value length) return 0.
* if only key name is given return the number of bit set to 1 for all the key value.
* If only range is given, count number of bits set to 1 for the bytes in the range.
* if range is given and last argument is BIT count in bits range and not bytes range.