### PR TITLE
fix(server): dfly_main.cc now compiled with march=core2.

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -1,6 +1,12 @@
 add_executable(dragonfly dfly_main.cc)
 cxx_link(dragonfly base dragonfly_lib)
 
+if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" AND CMAKE_BUILD_TYPE STREQUAL "Release")
+  # Add core2 only to this file, thus avoiding instructions in this object file that
+  # can cause SIGILL.
+  set_source_files_properties(dfly_main.cc PROPERTIES COMPILE_FLAGS -march=core2)
+endif()
+
 add_library(dfly_transaction db_slice.cc engine_shard_set.cc blocking_controller.cc common.cc
             io_mgr.cc journal/journal.cc journal/journal_slice.cc table.cc
             tiered_storage.cc transaction.cc)


### PR DESCRIPTION
Fixes #325. Apparently, before the fix AVX instructions were produced right at the start, thus the server crashed before it had a chance to install sigill handler.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->