### PR TITLE
feat(server): Introduce transaction clock

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -39,4 +39,4 @@ cxx_test(json_family_test dfly_test_lib LABELS DFLY)
 add_custom_target(check_dfly WORKING_DIRECTORY .. COMMAND ctest -L DFLY)
 add_dependencies(check_dfly dragonfly_test json_family_test list_family_test
                  generic_family_test memcache_parser_test rdb_test
-                 redis_parser_test snapshot_test stream_family_test string_family_test bitops_family_test)
+                 redis_parser_test snapshot_test stream_family_test string_family_test bitops_family_test set_family_test zset_family_test)

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -69,15 +69,20 @@ struct KeyIndex {
   }
 };
 
+struct DbContext {
+  DbIndex db_index = 0;
+  uint64_t time_now_ms = 0;
+};
+
 struct OpArgs {
   EngineShard* shard;
   TxId txid;
-  DbIndex db_ind;
+  DbContext db_cntx;
 
-  OpArgs() : shard(nullptr), txid(0), db_ind(0) {
+  OpArgs() : shard(nullptr), txid(0) {
   }
 
-  OpArgs(EngineShard* s, TxId i, DbIndex d) : shard(s), txid(i), db_ind(d) {
+  OpArgs(EngineShard* s, TxId i, const DbContext& cntx) : shard(s), txid(i), db_cntx(cntx) {
   }
 };
 

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -612,7 +612,9 @@ TEST_F(DflyEngineTest, Watch) {
   // Check EXEC doesn't miss watched key expiration.
   Run({"watch", "a"});
   Run({"expire", "a", "1"});
-  UpdateTime(expire_now_ + 1000);
+
+  AdvanceTime(1000);
+
   Run({"multi"});
   ASSERT_THAT(Run({"exec"}), kExecFail);
 
@@ -637,7 +639,9 @@ TEST_F(DflyEngineTest, Watch) {
   Run({"watch", "a"});
   Run({"set", "c", "1"});
   Run({"expire", "a", "1"}); // a existed
-  UpdateTime(expire_now_ + 1000);
+
+  AdvanceTime(1000);
+
   Run({"multi"});
   ASSERT_THAT(Run({"exec"}), kExecFail);
 

--- a/src/server/engine_shard_set.h
+++ b/src/server/engine_shard_set.h
@@ -176,7 +176,6 @@ class EngineShard {
   IntentLock shard_lock_;
 
   uint32_t periodic_task_ = 0;
-  uint64_t task_iters_ = 0;
   std::unique_ptr<TieredStorage> tiered_storage_;
   std::unique_ptr<BlockingController> blocking_controller_;
 
@@ -284,6 +283,16 @@ template <typename U> void EngineShardSet::RunBlockingInParallel(U&& func) {
 inline ShardId Shard(std::string_view v, ShardId shard_num) {
   XXH64_hash_t hash = XXH64(v.data(), v.size(), 120577240643ULL);
   return hash % shard_num;
+}
+
+
+// absl::GetCurrentTimeNanos is twice faster than clock_gettime(CLOCK_REALTIME) on my laptop
+// and 4 times faster than on a VM. it takes 5-10ns to do a call.
+
+extern uint64_t TEST_current_time_ms;
+
+inline uint64_t GetCurrentTimeMs() {
+  return TEST_current_time_ms ? TEST_current_time_ms : absl::GetCurrentTimeNanos() / 1000000;
 }
 
 

--- a/src/server/generic_family.h
+++ b/src/server/generic_family.h
@@ -60,6 +60,7 @@ class GenericFamily {
   static void Echo(CmdArgList args, ConnectionContext* cntx);
   static void Select(CmdArgList args, ConnectionContext* cntx);
   static void Scan(CmdArgList args, ConnectionContext* cntx);
+  static void Time(CmdArgList args, ConnectionContext* cntx);
   static void Type(CmdArgList args, ConnectionContext* cntx);
 
   static OpResult<void> RenameGeneric(CmdArgList args, bool skip_exist_dest,

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -30,23 +30,23 @@ TEST_F(GenericFamilyTest, Expire) {
   auto resp = Run({"expire", "key", "1"});
 
   EXPECT_THAT(resp, IntArg(1));
-  UpdateTime(expire_now_ + 1000);
+  AdvanceTime(1000);
   resp = Run({"get", "key"});
   EXPECT_THAT(resp, ArgType(RespExpr::NIL));
 
   Run({"set", "key", "val"});
-  resp = Run({"pexpireat", "key", absl::StrCat(expire_now_ + 2000)});
+  resp = Run({"pexpireat", "key", absl::StrCat(TEST_current_time_ms + 2000)});
   EXPECT_THAT(resp, IntArg(1));
 
   // override
-  resp = Run({"pexpireat", "key", absl::StrCat(expire_now_ + 3000)});
+  resp = Run({"pexpireat", "key", absl::StrCat(TEST_current_time_ms + 3000)});
   EXPECT_THAT(resp, IntArg(1));
 
-  UpdateTime(expire_now_ + 2999);
+  AdvanceTime(2999);
   resp = Run({"get", "key"});
   EXPECT_THAT(resp, "val");
 
-  UpdateTime(expire_now_ + 3000);
+  AdvanceTime(1);
   resp = Run({"get", "key"});
   EXPECT_THAT(resp, ArgType(RespExpr::NIL));
 }
@@ -329,6 +329,30 @@ TEST_F(GenericFamilyTest, Sort) {
   // Test not convertible to double
   Run({"lpush", "list-2", "NOTADOUBLE"});
   ASSERT_THAT(Run({"sort", "list-2"}), ErrArg("One or more scores can't be converted into double"));
+}
+
+TEST_F(GenericFamilyTest, Time) {
+  auto resp = Run({"time"});
+  EXPECT_THAT(resp, ArrLen(2));
+  EXPECT_THAT(resp.GetVec()[0], ArgType(RespExpr::INT64));
+  EXPECT_THAT(resp.GetVec()[1], ArgType(RespExpr::INT64));
+
+  // Check that time is the same inside a transaction.
+  Run({"multi"});
+  Run({"time"});
+  usleep(2000);
+  Run({"time"});
+  resp = Run({"exec"});
+  EXPECT_THAT(resp, ArrLen(2));
+
+  ASSERT_THAT(resp.GetVec()[0], ArrLen(2));
+  ASSERT_THAT(resp.GetVec()[1], ArrLen(2));
+
+  for (int i = 0; i < 2; ++i) {
+    int64_t val0 = get<int64_t>(resp.GetVec()[0].GetVec()[i].u);
+    int64_t val1 = get<int64_t>(resp.GetVec()[1].GetVec()[i].u);
+    EXPECT_EQ(val0, val1);
+  }
 }
 
 }  // namespace dfly

--- a/src/server/list_family_test.cc
+++ b/src/server/list_family_test.cc
@@ -52,7 +52,8 @@ TEST_F(ListFamilyTest, Expire) {
   resp = Run({"expire", kKey1, "1"});
   EXPECT_THAT(resp, IntArg(1));
 
-  UpdateTime(expire_now_ + 1000);
+  AdvanceTime(1000);
+
   resp = Run({"lpush", kKey1, "1"});
   EXPECT_THAT(resp, IntArg(1));
 }

--- a/src/server/string_family.h
+++ b/src/server/string_family.h
@@ -26,16 +26,12 @@ class SetCmd {
 
   struct SetParams {
     SetHow how = SET_ALWAYS;
-    DbIndex db_index = 0;
 
     uint32_t memcache_flags = 0;
     // Relative value based on now. 0 means no expiration.
     uint64_t expire_after_ms = 0;
     mutable std::optional<std::string>* prev_val = nullptr;  // GETSET option
     bool keep_expire = false;                                // KEEPTTL - TODO: to implement it.
-
-    explicit SetParams(DbIndex dib) : db_index(dib) {
-    }
 
     constexpr bool IsConditionalSet() const {
       return how == SET_IF_NOTEXIST || how == SET_IF_EXISTS;
@@ -82,8 +78,6 @@ class StringFamily {
   static void IncrByGeneric(std::string_view key, int64_t val, ConnectionContext* cntx);
   static void ExtendGeneric(CmdArgList args, bool prepend, ConnectionContext* cntx);
   static void SetExGeneric(bool seconds, CmdArgList args, ConnectionContext* cntx);
-  static OpResult<void> SetGeneric(ConnectionContext* cntx, SetCmd::SetParams sparams,
-                                   std::string_view key, std::string_view value);
 
   struct GetResp {
     std::string value;

--- a/src/server/string_family_test.cc
+++ b/src/server/string_family_test.cc
@@ -70,6 +70,8 @@ TEST_F(StringFamilyTest, Incr) {
 
 TEST_F(StringFamilyTest, Append) {
   Run({"setex", "key", "100", "val"});
+  EXPECT_THAT(Run({"ttl", "key"}), IntArg(100));
+
   EXPECT_THAT(Run({"append", "key", "bar"}), IntArg(6));
   EXPECT_THAT(Run({"ttl", "key"}), IntArg(100));
 }
@@ -77,17 +79,17 @@ TEST_F(StringFamilyTest, Append) {
 TEST_F(StringFamilyTest, Expire) {
   ASSERT_EQ(Run({"set", "key", "val", "PX", "20"}), "OK");
 
-  UpdateTime(expire_now_ + 10);
+  AdvanceTime(10);
   EXPECT_EQ(Run({"get", "key"}), "val");
 
-  UpdateTime(expire_now_ + 20);
+  AdvanceTime(10);
 
   EXPECT_THAT(Run({"get", "key"}), ArgType(RespExpr::NIL));
 
   ASSERT_THAT(Run({"set", "i", "1", "PX", "10"}), "OK");
   ASSERT_THAT(Run({"incr", "i"}), IntArg(2));
 
-  UpdateTime(expire_now_ + 30);
+  AdvanceTime(10);
   ASSERT_THAT(Run({"incr", "i"}), IntArg(1));
 }
 

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -131,10 +131,9 @@ void BaseFamilyTest::SetUp() {
   opts.disable_time_update = true;
   service_->Init(nullptr, nullptr, opts);
 
-  expire_now_ = absl::GetCurrentTimeNanos() / 1000000;
+  TEST_current_time_ms = absl::GetCurrentTimeNanos() / 1000000;
   auto cb = [&](EngineShard* s) {
-    s->db_slice().UpdateExpireBase(expire_now_ - 1000, 0);
-    s->db_slice().UpdateExpireClock(expire_now_);
+    s->db_slice().UpdateExpireBase(TEST_current_time_ms - 1000, 0);
   };
   shard_set->RunBriefInParallel(cb);
 
@@ -149,12 +148,6 @@ void BaseFamilyTest::TearDown() {
 
   const TestInfo* const test_info = UnitTest::GetInstance()->current_test_info();
   LOG(INFO) << "Finishing " << test_info->name();
-}
-
-// ts is ms
-void BaseFamilyTest::UpdateTime(uint64_t ms) {
-  auto cb = [ms](EngineShard* s) { s->db_slice().UpdateExpireClock(ms); };
-  shard_set->RunBriefInParallel(cb);
 }
 
 void BaseFamilyTest::WaitUntilLocked(DbIndex db_index, string_view key, double timeout) {

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -68,8 +68,9 @@ class BaseFamilyTest : public ::testing::Test {
   TestConnWrapper* AddFindConn(Protocol proto, std::string_view id);
   static std::vector<std::string> StrArray(const RespExpr& expr);
 
-  // ts is ms
-  void UpdateTime(uint64_t ms);
+  void AdvanceTime(int64_t ms) {
+    TEST_current_time_ms += ms;
+  }
 
   // Wait for a locked key to unlock. Aborts after timeout seconds passed.
   void WaitUntilLocked(DbIndex db_index, std::string_view key, double timeout = 3);
@@ -88,7 +89,7 @@ class BaseFamilyTest : public ::testing::Test {
   absl::flat_hash_map<std::string, std::unique_ptr<TestConnWrapper>> connections_;
   ::boost::fibers::mutex mu_;
   ConnectionContext::DebugInfo last_cmd_dbg_info_;
-  uint64_t expire_now_;
+
   std::vector<RespVec*> resp_vec_;
   bool single_response_ = true;
 };


### PR DESCRIPTION
Partially implements #6.

Before, each shard lazily updated its clock used for the expiry evaluation.
Now, the clock value is set during the transaction scheduling phase and is assigned
to each transaction. From now on DbSlice methods use this value when checking whether
the entry is expired via passed DbContext argument.
 
Also, implemented transactionally consistent TIME command and
verify that time is the same during the transaction. See
https://ably.com/blog/redis-keys-do-not-expire-atomically for motivation.

Still have not implemented any lamport style updates for background processes
(not sure if it's the right way to proceed).
