### PR TITLE
feat(server): zrange family command support INF as case insensitive #326

### DIFF
--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -5,6 +5,7 @@
 #include "server/common.h"
 
 #include <absl/strings/charconv.h>
+#include <absl/strings/match.h>
 #include <absl/strings/str_cat.h>
 #include <mimalloc.h>
 
@@ -168,9 +169,9 @@ bool ParseDouble(string_view src, double* value) {
   if (src.empty())
     return false;
 
-  if (src == "-inf") {
+  if (absl::EqualsIgnoreCase(src, "-inf")) {
     *value = -HUGE_VAL;
-  } else if (src == "+inf") {
+  } else if (absl::EqualsIgnoreCase(src, "+inf")) {
     *value = HUGE_VAL;
   } else {
     absl::from_chars_result result = absl::from_chars(src.data(), src.end(), *value);

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -150,6 +150,16 @@ TEST_F(ZSetFamilyTest, ZRevRange) {
   resp = Run({"zrevrange", "key", "1", "2", "withscores"});
   ASSERT_THAT(resp, ArrLen(4));
   EXPECT_THAT(resp.GetVec(), ElementsAre("b", "1", "a", "-inf"));
+
+  // Make sure that when using with upper case it works as well (see
+  // https://github.com/dragonflydb/dragonfly/issues/326)
+  resp = Run({"zrevrangebyscore", "key", "2", "-INF"});
+  ASSERT_THAT(resp, ArrLen(3));
+  EXPECT_THAT(resp.GetVec(), ElementsAre("c", "b", "a"));
+
+  resp = Run({"zrevrangebyscore", "key", "2", "-INF", "withscores"});
+  ASSERT_THAT(resp, ArrLen(6));
+  EXPECT_THAT(resp.GetVec(), ElementsAre("c", "2", "b", "1", "a", "-inf"));
 }
 
 TEST_F(ZSetFamilyTest, ZScan) {


### PR DESCRIPTION
Signed-off-by: Boaz Sade <boaz@dragonflydb.io>

Fixes #326 

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
The zrange commands accepts limits to filter out the number of eleents. These can be -INF/+INF, but these INF should handled as case insensitive to match how redis process these commands. see #326 