### PR TITLE
feat(setfamily): Add SADDEX command

### DIFF
--- a/src/core/string_set_test.cc
+++ b/src/core/string_set_test.cc
@@ -263,9 +263,8 @@ TEST_F(StringSetTest, IntOnly) {
 
   size_t expected_seen = 0;
   auto scan_callback = [&](const sds ptr) {
-    sds s = (sds)ptr;
-    string_view str{s, sdslen(s)};
-    EXPECT_FALSE(removed.count(string(str)));
+    string str{ptr, sdslen(ptr)};
+    EXPECT_FALSE(removed.count(str));
 
     if (numbers.count(atoi(str.data()))) {
       ++expected_seen;
@@ -281,7 +280,7 @@ TEST_F(StringSetTest, IntOnly) {
     ss_->Add(to_string(val));
   } while (cursor != 0);
 
-  EXPECT_TRUE(expected_seen + removed.size() == num_ints);
+  EXPECT_GE(expected_seen + removed.size(), num_ints);
 }
 
 TEST_F(StringSetTest, XtremeScanGrow) {

--- a/src/server/set_family.h
+++ b/src/server/set_family.h
@@ -32,25 +32,6 @@ class SetFamily {
   static bool ConvertToStrSet(const intset* is, size_t expected_len, robj* dest);
 
  private:
-  static void SAdd(CmdArgList args,  ConnectionContext* cntx);
-  static void SIsMember(CmdArgList args,  ConnectionContext* cntx);
-  static void SRem(CmdArgList args,  ConnectionContext* cntx);
-  static void SCard(CmdArgList args,  ConnectionContext* cntx);
-  static void SPop(CmdArgList args,  ConnectionContext* cntx);
-  static void SUnion(CmdArgList args,  ConnectionContext* cntx);
-  static void SUnionStore(CmdArgList args,  ConnectionContext* cntx);
-  static void SDiff(CmdArgList args,  ConnectionContext* cntx);
-  static void SDiffStore(CmdArgList args,  ConnectionContext* cntx);
-  static void SMembers(CmdArgList args,  ConnectionContext* cntx);
-  static void SMove(CmdArgList args,  ConnectionContext* cntx);
-  static void SInter(CmdArgList args,  ConnectionContext* cntx);
-  static void SInterStore(CmdArgList args,  ConnectionContext* cntx);
-  static void SScan(CmdArgList args,  ConnectionContext* cntx);
-
-  // count - how many elements to pop.
-  static OpResult<StringVec> OpPop(const OpArgs& op_args, std::string_view key, unsigned count);
-  static OpResult<StringVec> OpScan(const OpArgs& op_args, std::string_view key, uint64_t* cursor);
-
 };
 
 }  // namespace dfly


### PR DESCRIPTION
Add `SADDEX <key> <seconds> member member ....`

Provides expiry semantics for set members with seconds resolution.

Some important things to note:
1. The expiry is passive only, so if nobody touches that set then its members are being kept.
2. SCARD provides an upper bound estimation of set size for sets holding the expiring members.
   The reason for this is because SCARD returns a cached size and does not go over all members
   to check whether they expired. For regular sets it's exact, of course.

Fixes #335
