### PR TITLE
fix(server): better support for the --help option

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -4,7 +4,7 @@ cxx_link(dragonfly base dragonfly_lib)
 if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" AND CMAKE_BUILD_TYPE STREQUAL "Release")
   # Add core2 only to this file, thus avoiding instructions in this object file that
   # can cause SIGILL.
-  set_source_files_properties(dfly_main.cc PROPERTIES COMPILE_FLAGS -march=core2)
+  set_source_files_properties(dfly_main.cc PROPERTIES COMPILE_FLAGS -march=core2 COMPILE_DEFINITIONS SOURCE_PATH_FROM_BUILD_ENV=${CMAKE_SOURCE_DIR})
 endif()
 
 add_library(dfly_transaction db_slice.cc engine_shard_set.cc blocking_controller.cc common.cc

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -29,6 +29,13 @@
 #include "util/uring/uring_pool.h"
 #include "util/varz.h"
 
+#define STRING_PP_NX(A) #A
+#define STRING_MAKE_PP(A) STRING_PP_NX(A)
+
+// This would create a string value from a "defined" location of the source code
+// Note that SOURCE_PATH_FROM_BUILD_ENV is taken from the build system
+#define BUILD_LOCATION_PATH STRING_MAKE_PP(SOURCE_PATH_FROM_BUILD_ENV)
+
 using namespace std;
 
 ABSL_DECLARE_FLAG(uint32_t, port);
@@ -92,10 +99,14 @@ bool HelpFlags(std::string_view f) {
 }
 
 string NormalizePaths(std::string_view path) {
-  if (absl::ConsumePrefix(&path, "../src/"))
+  const std::string FULL_PATH = BUILD_LOCATION_PATH;
+  const std::string FULL_PATH_SRC = FULL_PATH + "/src";
+  const std::string FULL_PATH_HELIO = FULL_PATH + "/helio";
+
+  if (absl::ConsumePrefix(&path, "../src/") || absl::ConsumePrefix(&path, FULL_PATH_SRC))
     return ColoredStr(TermColor::kGreen, path);
 
-  if (absl::ConsumePrefix(&path, "../"))
+  if (absl::ConsumePrefix(&path, "../") || absl::ConsumePrefix(&path, FULL_PATH_HELIO))
     return ColoredStr(TermColor::kYellow, path);
 
   if (absl::ConsumePrefix(&path, "_deps/"))


### PR DESCRIPTION
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
This would ensure that when running "./dragonfly --help" it would report correctly the help message.
Note that 
* unlike --helpful that is not filtering any flags in the output, the help is more restricted to what is reported.
* This can break in case the complied locations for the files at which is searches for flags to report in the help are either at full path or relative path. This would try to ensure that it would work in either case.