### PR TITLE
fix(server): support for dump command, API update #343

### DIFF
--- a/docs/api_status.md
+++ b/docs/api_status.md
@@ -173,7 +173,7 @@ with respect to Memcached and Redis APIs.
   - [X] SCAN
   - [X] PEXPIREAT
   - [ ] PEXPIRE
-  - [ ] DUMP
+  - [x] DUMP
   - [X] EVAL
   - [X] EVALSHA
   - [ ] OBJECT

--- a/src/server/generic_family.h
+++ b/src/server/generic_family.h
@@ -63,6 +63,7 @@ class GenericFamily {
   static void Scan(CmdArgList args, ConnectionContext* cntx);
   static void Time(CmdArgList args, ConnectionContext* cntx);
   static void Type(CmdArgList args, ConnectionContext* cntx);
+  static void Dump(CmdArgList args, ConnectionContext* cntx);
 
   static OpResult<void> RenameGeneric(CmdArgList args, bool skip_exist_dest,
                                       ConnectionContext* cntx);

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -21,6 +21,8 @@ typedef struct streamCG streamCG;
 
 namespace dfly {
 
+uint8_t RdbObjectType(unsigned type, unsigned encoding);
+
 class EngineShard;
 
 class AlignedBuffer : public ::io::Sink {
@@ -117,6 +119,12 @@ class RdbSerializer {
   std::error_code SaveLen(size_t len);
 
   std::error_code FlushMem();
+
+  // This would work for either string or an object.
+  // The arg pv is taken from it->second if accessing
+  // this by finding the key. This function is used
+  // for the dump command - thus it is public function
+  std::error_code SaveValue(const PrimeValue& pv);
 
  private:
   std::error_code SaveLzfBlob(const ::io::Bytes& src, size_t uncompressed_len);


### PR DESCRIPTION
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
Support for dump command.
* This was checked to be inline with the results produced by redis.
* Note that this would work only for version 9 of RDB, It seems that in the next version (10) the format is different (redis branch > 7).
* This support for list, hash, set, sorted set, stream and other types that we know how to generate RDB files for. 
* To make issue #343 cannot be closed until we are supporting restore as well.