### PR TITLE
build(ci): add discord message on docker release

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -132,3 +132,10 @@ jobs:
       with:
         token: ${{ secrets.DRAGONFLY_TOKEN }}
         branch: main
+
+    - name: Discord notification
+      env:
+        DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+      uses: Ilshidur/action-discord@0c4b27844ba47cb1c7bee539c8eead5284ce9fa9
+      with:
+        args: 'DragonflyDB version [${{ env.TAG_NAME }}](https://github.com/dragonflydb/dragonfly/releases/tag/v${{ env.TAG_NAME }}) has been released 🎉'


### PR DESCRIPTION
fixes https://github.com/dragonflydb/dragonfly/issues/309

Looks like this:
<img width="555" alt="Screen Shot 2022-10-10 at 8 26 30" src="https://user-images.githubusercontent.com/24767098/194803937-64426fec-1f74-4bb3-9af0-43f35c32b084.png">

To set up - first create a Discord webhook (make sure to put a nice avatar and name):
<img width="997" alt="Screen Shot 2022-10-10 at 8 25 59" src="https://user-images.githubusercontent.com/24767098/194804060-84e003cb-7475-4342-9696-9dc5a4802bb5.png">

Then, add a new repo secret in GitHub:
<img width="1126" alt="Screen Shot 2022-10-10 at 8 29 53" src="https://user-images.githubusercontent.com/24767098/194804088-8c8b18fc-57d2-4ac2-8055-17069d0d04bb.png">
