### PR TITLE
fix(server): remove double decrement of obj_memory_usage.

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -419,8 +419,6 @@ tuple<PrimeIterator, ExpireIterator, bool> DbSlice::AddOrFind2(const Context& cn
       // Keep the entry but reset the object.
       size_t value_heap_size = existing->second.MallocUsed();
       db.stats.obj_memory_usage -= value_heap_size;
-      if (existing->second.ObjType() == OBJ_STRING)
-        db.stats.obj_memory_usage -= value_heap_size;
 
       existing->second.Reset();
       events_.expired_keys++;

--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -57,6 +57,8 @@ void MemoryCmd::Run(CmdArgList args) {
 
 string MemoryCmd::MallocStats() {
   string str;
+
+  uint64_t start = absl::GetCurrentTimeNanos();
   absl::StrAppend(&str, "___ Begin mimalloc statistics ___\n");
   mi_stats_print_out(MiStatsCallback, &str);
 
@@ -73,7 +75,8 @@ string MemoryCmd::MallocStats() {
                     get<2>(k_v.first), " ", get<3>(k_v.first), "\n");
   }
 
-  absl::StrAppend(&str, "--- End mimalloc statistics ---\n");
+  uint64_t delta = (absl::GetCurrentTimeNanos() - start) / 1000;
+  absl::StrAppend(&str, "--- End mimalloc statistics, took ", delta, "us ---\n");
 
   return str;
 }


### PR DESCRIPTION
Also, add timing stats to malloc-stats command.
    
Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->