### PR TITLE
fix(hset): fix hset match bug

### DIFF
--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -17,7 +17,8 @@ namespace dfly {
 
 constexpr unsigned kEncodingIntSet = 0;
 constexpr unsigned kEncodingStrMap = 1;  // for set/map encodings of strings
-constexpr unsigned kEncodingStrMap2 = 2;
+constexpr unsigned kEncodingStrMap2 = 2;  // for set/map encodings of strings using DenseSet
+constexpr unsigned kEncodingListPack = 3;
 
 namespace detail {
 

--- a/src/core/compact_object_test.cc
+++ b/src/core/compact_object_test.cc
@@ -179,7 +179,7 @@ TEST_F(CompactObjectTest, HSet) {
   cobj_.ImportRObj(src);
 
   EXPECT_EQ(OBJ_HASH, cobj_.ObjType());
-  EXPECT_EQ(OBJ_ENCODING_LISTPACK, cobj_.Encoding());
+  EXPECT_EQ(kEncodingListPack, cobj_.Encoding());
 
   robj* os = cobj_.AsRObj();
 

--- a/src/server/container_utils.h
+++ b/src/server/container_utils.h
@@ -5,7 +5,6 @@
 
 #include "core/compact_object.h"
 #include "core/string_set.h"
-#include "server/common.h"
 #include "server/table.h"
 
 extern "C" {

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -31,9 +31,9 @@ struct ScanOpts {
   size_t limit = 10;
 
   constexpr bool Matches(std::string_view val_name) const {
-    return pattern.empty() ? true
-                           : stringmatchlen(pattern.data(), pattern.size(), val_name.data(),
-                                            val_name.size(), 0);
+    if (pattern.empty())
+      return true;
+    return stringmatchlen(pattern.data(), pattern.size(), val_name.data(), val_name.size(), 0) == 1;
   }
 
   static OpResult<ScanOpts> TryFrom(CmdArgList args);
@@ -94,6 +94,13 @@ string LpGetVal(uint8_t* lp_it) {
   return absl::StrCat(ele_len);
 }
 
+string_view LpGetView(uint8_t* lp_it, uint8_t int_buf[]) {
+  int64_t ele_len = 0;
+  uint8_t* elem = lpGet(lp_it, &ele_len, int_buf);
+  DCHECK(elem);
+  return string_view{reinterpret_cast<char*>(elem), size_t(ele_len)};
+}
+
 // returns a new pointer to lp. Returns true if field was inserted or false it it already existed.
 // skip_exists controls what happens if the field already existed. If skip_exists = true,
 // then val does not override the value and listpack is not changed. Otherwise, the corresponding
@@ -146,20 +153,20 @@ OpStatus OpIncrBy(const OpArgs& op_args, string_view key, string_view field, Inc
   robj* hset = nullptr;
   size_t lpb = 0;
 
+  PrimeValue& pv = it->second;
   if (inserted) {
-    hset = createHashObject();
-    it->second.ImportRObj(hset);
+    pv.InitRobj(OBJ_HASH, kEncodingListPack, lpNew(0));
     stats->listpack_blob_cnt++;
     hset = it->second.AsRObj();
   } else {
-    if (it->second.ObjType() != OBJ_HASH)
+    if (pv.ObjType() != OBJ_HASH)
       return OpStatus::WRONG_TYPE;
 
     db_slice.PreUpdate(op_args.db_cntx.db_index, it);
     hset = it->second.AsRObj();
 
-    if (hset->encoding == OBJ_ENCODING_LISTPACK) {
-      lpb = lpBytes((uint8_t*)hset->ptr);
+    if (pv.Encoding() == kEncodingListPack) {
+      lpb = lpBytes((uint8_t*)pv.RObjPtr());
       stats->listpack_bytes -= lpb;
 
       if (lpb >= kMaxListPackLen) {
@@ -169,7 +176,8 @@ OpStatus OpIncrBy(const OpArgs& op_args, string_view key, string_view field, Inc
     }
   }
 
-  unsigned char* vstr = NULL;
+  int enc = pv.Encoding();
+  uint8_t* vstr = NULL;
   unsigned int vlen = UINT_MAX;
   long long old_val = 0;
 
@@ -205,18 +213,19 @@ OpStatus OpIncrBy(const OpArgs& op_args, string_view key, string_view field, Inc
     char* str = RedisReplyBuilder::FormatDouble(value, buf, sizeof(buf));
     string_view sval{str};
 
-    if (hset->encoding == OBJ_ENCODING_LISTPACK) {
-      uint8_t* lp = (uint8_t*)hset->ptr;
+    if (enc == kEncodingListPack) {
+      uint8_t* lp = (uint8_t*)pv.RObjPtr();
 
       lp = LpInsert(lp, field, sval, false).first;
-      hset->ptr = lp;
+      pv.SetRObjPtr(lp);
       stats->listpack_bytes += lpBytes(lp);
     } else {
       sds news = sdsnewlen(str, sval.size());
       hashTypeSet(hset, op_args.shard->tmp_str1, news, HASH_SET_TAKE_VALUE);
+      pv.SyncRObj();
     }
     param->emplace<double>(value);
-  } else {
+  } else {  // integer increment
     if (exist_res == C_OK && vstr) {
       const char* exist_val = reinterpret_cast<char*>(vstr);
       if (!string2ll(exist_val, vlen, &old_val)) {
@@ -225,6 +234,7 @@ OpStatus OpIncrBy(const OpArgs& op_args, string_view key, string_view field, Inc
         return OpStatus::INVALID_VALUE;
       }
     }
+
     int64_t incr = get<int64_t>(*param);
     if ((incr < 0 && old_val < 0 && incr < (LLONG_MIN - old_val)) ||
         (incr > 0 && old_val > 0 && incr > (LLONG_MAX - old_val))) {
@@ -234,24 +244,24 @@ OpStatus OpIncrBy(const OpArgs& op_args, string_view key, string_view field, Inc
     }
 
     int64_t new_val = old_val + incr;
+    char buf[32];
+    char* next = absl::numbers_internal::FastIntToBuffer(new_val, buf);
+    string_view sval{buf, size_t(next - buf)};
 
-    if (hset->encoding == OBJ_ENCODING_LISTPACK) {
-      char buf[32];
-      char* next = absl::numbers_internal::FastIntToBuffer(new_val, buf);
-      string_view sval{buf, size_t(next - buf)};
-      uint8_t* lp = (uint8_t*)hset->ptr;
+    if (enc == kEncodingListPack) {
+      uint8_t* lp = (uint8_t*)pv.RObjPtr();
 
       lp = LpInsert(lp, field, sval, false).first;
-      hset->ptr = lp;
+      pv.SetRObjPtr(lp);
       stats->listpack_bytes += lpBytes(lp);
     } else {
       sds news = sdsfromlonglong(new_val);
       hashTypeSet(hset, op_args.shard->tmp_str1, news, HASH_SET_TAKE_VALUE);
+      pv.SyncRObj();
     }
     param->emplace<int64_t>(new_val);
   }
 
-  it->second.SyncRObj();
   db_slice.PostUpdate(op_args.db_cntx.db_index, it, key);
 
   return OpStatus::OK;
@@ -286,18 +296,21 @@ OpResult<StringVec> OpScan(const OpArgs& op_args, std::string_view key, uint64_t
 
     DCHECK(lp_elem);  // empty containers are not allowed.
 
-    int64_t ele_len;
     unsigned char intbuf[LP_INTBUF_SIZE];
 
     // We do single pass on listpack for this operation - ignore any limits.
     do {
-      uint8_t* elem = lpGet(lp_elem, &ele_len, intbuf);
-      DCHECK(elem);
-      if (scan_op.Matches({reinterpret_cast<char*>(elem), size_t(ele_len)})) {
-        res.emplace_back(reinterpret_cast<char*>(elem), size_t(ele_len));
-      }
+      string_view key = LpGetView(lp_elem, intbuf);
       lp_elem = lpNext(lp, lp_elem);  // switch to value
+      DCHECK(lp_elem);
+
+      if (scan_op.Matches(key)) {
+        res.emplace_back(key);
+        res.emplace_back(LpGetView(lp_elem, intbuf));
+      }
+      lp_elem = lpNext(lp, lp_elem);  // switch to next key
     } while (lp_elem);
+
     *cursor = 0;
   } else {
     dict* ht = (dict*)hset->ptr;
@@ -582,15 +595,13 @@ OpResult<uint32_t> OpSet(const OpArgs& op_args, string_view key, CmdArgList valu
 
   DbTableStats* stats = db_slice.MutableStats(op_args.db_cntx.db_index);
 
-  robj* hset = nullptr;
   uint8_t* lp = nullptr;
   PrimeIterator& it = add_res.first;
 
   if (add_res.second) {  // new key
-    hset = createHashObject();
-    lp = (uint8_t*)hset->ptr;
+    lp = lpNew(0);
+    it->second.InitRobj(OBJ_HASH, kEncodingListPack, lp);
 
-    it->second.ImportRObj(hset);
     stats->listpack_blob_cnt++;
     stats->listpack_bytes += lpBytes(lp);
   } else {
@@ -599,7 +610,7 @@ OpResult<uint32_t> OpSet(const OpArgs& op_args, string_view key, CmdArgList valu
 
     db_slice.PreUpdate(op_args.db_cntx.db_index, it);
   }
-  hset = it->second.AsRObj();
+  robj* hset = it->second.AsRObj();
 
   if (hset->encoding == OBJ_ENCODING_LISTPACK) {
     lp = (uint8_t*)hset->ptr;

--- a/src/server/hset_family_test.cc
+++ b/src/server/hset_family_test.cc
@@ -157,4 +157,10 @@ TEST_F(HSetFamilyTest, HScan) {
   EXPECT_LT(vec.size(), 60);
 }
 
+TEST_F(HSetFamilyTest, HScanLpMatchBug) {
+  Run({"HSET", "key", "1", "2"});
+  auto resp = Run({"hscan", "key", "0", "match", "1"});
+  EXPECT_THAT(resp, ArrLen(2));
+}
+
 }  // namespace dfly

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -143,9 +143,9 @@ uint8_t RdbObjectType(unsigned type, unsigned encoding) {
         return RDB_TYPE_ZSET_2;
       break;
     case OBJ_HASH:
-      if (encoding == OBJ_ENCODING_LISTPACK)
+      if (encoding == kEncodingListPack)
         return RDB_TYPE_HASH_ZIPLIST;
-      else if (encoding == OBJ_ENCODING_HT)
+      else if (encoding == kEncodingStrMap)
         return RDB_TYPE_HASH;
       break;
     case OBJ_STREAM:


### PR DESCRIPTION
The bug was that when the hset had listpack encoding, it returned only keys instead of returning keys and values.

In addition, in preparation to having our own denset encoding for hset, I cleaned up the code and introduced our own encoding constants for hset encoding.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->