### PR TITLE
feat(server): support for monitor command. This include some code

### DIFF
--- a/docs/api_status.md
+++ b/docs/api_status.md
@@ -104,7 +104,7 @@ with respect to Memcached and Redis APIs.
   - [X] ZSCORE
 - [ ] Other
   - [ ] BGREWRITEAOF
-  - [ ] MONITOR
+  - [x] MONITOR
   - [ ] RANDOMKEY
 
 ### API 2

--- a/src/facade/conn_context.h
+++ b/src/facade/conn_context.h
@@ -19,7 +19,8 @@ class ConnectionContext {
 
   // We won't have any virtual methods, probably. However, since we allocate a derived class,
   // we need to declare a virtual d-tor, so we could properly delete it from Connection code.
-  virtual ~ConnectionContext() {}
+  virtual ~ConnectionContext() {
+  }
 
   Connection* owner() {
     return owner_;
@@ -44,12 +45,19 @@ class ConnectionContext {
   }
 
   // connection state / properties.
-  bool async_dispatch: 1;  // whether this connection is currently handled by dispatch fiber.
-  bool conn_closing: 1;
-  bool req_auth: 1;
-  bool replica_conn: 1;
-  bool authenticated: 1;
-  bool force_dispatch: 1;   // whether we should route all requests to the dispatch fiber.
+  bool async_dispatch : 1;  // whether this connection is currently handled by dispatch fiber.
+  bool conn_closing : 1;
+  bool req_auth : 1;
+  bool replica_conn : 1;
+  bool authenticated : 1;
+  bool force_dispatch : 1;  // whether we should route all requests to the dispatch fiber.
+  bool monitor : 1;         // when the connection is monitor do not support most commands other
+                            // than quit and reset
+ protected:
+  void EnableMonitoring(bool enable) {
+    force_dispatch = enable;  // required to support the monitoring
+    monitor = enable;
+  }
 
  private:
   Connection* owner_;

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -63,7 +63,6 @@ string UnknownSubCmd(string_view subcmd, string_view cmd) {
                       cmd, " HELP.");
 }
 
-
 const char kSyntaxErr[] = "syntax error";
 const char kWrongTypeErr[] = "-WRONGTYPE Operation against a key holding the wrong kind of value";
 const char kKeyNotFoundErr[] = "no such key";
@@ -119,6 +118,7 @@ ConnectionContext::ConnectionContext(::io::Sink* stream, Connection* owner) : ow
   replica_conn = false;
   authenticated = false;
   force_dispatch = false;
+  monitor = false;
 }
 
 RedisReplyBuilder* ConnectionContext::operator->() {

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(dfly_transaction db_slice.cc engine_shard_set.cc blocking_controller
             tiered_storage.cc transaction.cc)
 cxx_link(dfly_transaction uring_fiber_lib dfly_core strings_lib)
 
-add_library(dragonfly_lib  channel_slice.cc command_registry.cc
+add_library(dragonfly_lib  channel_slice.cc server_state.cc command_registry.cc
             config_flags.cc conn_context.cc debugcmd.cc dflycmd.cc
             generic_family.cc hset_family.cc json_family.cc
             list_family.cc main_service.cc memory_cmd.cc rdb_load.cc rdb_save.cc replica.cc

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -102,7 +102,7 @@ class Service : public facade::ServiceInterface {
   void PSubscribe(CmdArgList args, ConnectionContext* cntx);
   void PUnsubscribe(CmdArgList args, ConnectionContext* cntx);
   void Function(CmdArgList args, ConnectionContext* cntx);
-
+  void Monitor(CmdArgList args, ConnectionContext* cntx);
   void Pubsub(CmdArgList args, ConnectionContext* cntx);
   void PubsubChannels(std::string_view pattern, ConnectionContext* cntx);
   void PubsubPatterns(ConnectionContext* cntx);

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -1,0 +1,62 @@
+// Copyright 2022, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "server/server_state.h"
+
+#include "base/logging.h"
+#include "server/conn_context.h"
+
+namespace dfly {
+
+MonitorsRepo::MonitorInfo::MonitorInfo(ConnectionContext* conn)
+    : connection(conn), token(conn->conn_state.monitor->borrow_token),
+      thread_id(util::ProactorBase::GetIndex()) {
+}
+
+void MonitorsRepo::MonitorInfo::Send(std::string_view msg, std::uint32_t tid,
+                                     util::fibers_ext::BlockingCounter borrows) {
+  if (tid == thread_id && connection) {
+    VLOG(1) << "thread " << tid << " sending monitor message '" << msg << "'";
+    token.Inc();
+    connection->SendMonitorMsg(msg, borrows);
+    VLOG(1) << "thread " << tid << " successfully finish to send the message";
+  }
+}
+
+void MonitorsRepo::Add(const MonitorInfo& info) {
+  VLOG(1) << "register connection "
+          << " at address 0x" << std::hex << (const void*)info.connection << " for thread "
+          << info.thread_id;
+
+  monitors_.push_back(info);
+}
+
+void MonitorsRepo::Send(std::string_view msg, util::fibers_ext::BlockingCounter borrows,
+                        std::uint32_t tid) {
+  std::for_each(monitors_.begin(), monitors_.end(),
+                [msg, tid, borrows](auto& monitor_conn) { monitor_conn.Send(msg, tid, borrows); });
+}
+
+void MonitorsRepo::Release(std::uint32_t tid) {
+  std::for_each(monitors_.begin(), monitors_.end(), [tid](auto& monitor_conn) {
+    if (monitor_conn.thread_id == tid) {
+      VLOG(1) << "thread " << tid << " releasing token";
+      monitor_conn.token.Dec();
+    }
+  });
+}
+
+void MonitorsRepo::Remove(const ConnectionContext* conn) {
+  auto it = std::find_if(monitors_.begin(), monitors_.end(),
+                         [&conn](const auto& val) { return val.connection == conn; });
+  if (it != monitors_.end()) {
+    VLOG(1) << "removing connection 0x" << std::hex << (const void*)conn << " releasing token";
+    monitors_.erase(it);
+  } else {
+    VLOG(1) << "no connection 0x" << std::hex << (const void*)conn
+            << " found in the registered list here";
+  }
+}
+
+}  // end of namespace dfly

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -15,9 +15,56 @@ typedef struct mi_heap_s mi_heap_t;
 
 namespace dfly {
 
+class ConnectionContext;
 namespace journal {
 class Journal;
 }  // namespace journal
+
+// This would be used as a thread local storage of sending
+// monitor messages.
+// Each thread will have its own list of all the connections that are
+// used for monitoring. When a connection is set to monitor it would register
+// itself to this list on all i/o threads. When a new command is dispatched,
+// and this list is not empty, it would send in the same thread context as then
+// thread that registered here the command.
+// Note about performance: we are assuming that we would not have many connections
+// that are registered here. This is not pub sub where it must be high performance
+// and may support many to many with tens or more of connections. It is assumed that
+// since monitoring is for debugging only, we would have less than 1 in most cases.
+// Also note that we holding this list on the thread level since this is the context
+// at which this would run. It also minimized the number of copied for this list.
+class MonitorsRepo {
+ public:
+  struct MonitorInfo {
+    ConnectionContext* connection = nullptr;
+    util::fibers_ext::BlockingCounter token;
+    std::uint32_t thread_id = 0;
+
+    explicit MonitorInfo(ConnectionContext* conn);
+
+    void Send(std::string_view msg, std::uint32_t tid, util::fibers_ext::BlockingCounter borrows);
+  };
+
+  void Add(const MonitorInfo& info);
+
+  void Send(std::string_view msg, util::fibers_ext::BlockingCounter borrows, std::uint32_t tid);
+
+  void Release(std::uint32_t tid);
+
+  void Remove(const ConnectionContext* conn);
+
+  bool Empty() const {
+    return monitors_.empty();
+  }
+
+  std::size_t Size() const {
+    return monitors_.size();
+  }
+
+ private:
+  using MonitorVec = std::vector<MonitorInfo>;
+  MonitorVec monitors_;
+};
 
 // Present in every server thread. This class differs from EngineShard. The latter manages
 // state around engine shards while the former represents coordinator/connection state.
@@ -94,6 +141,10 @@ class ServerState {  // public struct - to allow initialization.
     journal_ = j;
   }
 
+  constexpr MonitorsRepo& Monitors() {
+    return monitors_;
+  }
+
  private:
   int64_t live_transactions_ = 0;
   mi_heap_t* data_heap_;
@@ -104,6 +155,8 @@ class ServerState {  // public struct - to allow initialization.
 
   using Counter = util::SlidingCounter<7>;
   Counter qps_;
+
+  MonitorsRepo monitors_;
 
   static thread_local ServerState state_;
 };


### PR DESCRIPTION
refactor for the request message to dispatch async. (#344)

Signed-off-by: Boaz Sade <boaz@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
Supporting monitor command
This is still WIP.
Need to add support for ADMIN level commands
Need to correct the formatting of the output.
* Monitor command is handled.
* Refactor the the async message dispatch to support different types of messages.