### PR TITLE
feat(server): implement a variant of ZUNION command

### DIFF
--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -690,7 +690,7 @@ void InterScoredMap(ScoredMap* dest, ScoredMap* src, AggType agg_type) {
     dest->swap(*src);
 }
 
-template<typename SliceIt>
+template <typename SliceIt>
 ScoredMap UnionSliceResultScore(SliceIt start, SliceIt end, AggType agg_type) {
   ScoredMap result;
   for (auto it = start; it != end; ++it) {
@@ -711,19 +711,16 @@ ScoredMap UnionSliceResultScore(SliceIt start, SliceIt end, AggType agg_type) {
 using ScoredPI = pair<PrimeIterator, double>;
 using ScoredPIVec = vector<ScoredPI>;
 
-double SliceResultWeight(EngineShard* shard, Transaction* t,
-		            const vector<double>& weights,
-			    unsigned key_index, unsigned offset) {
-
+double SliceResultWeight(EngineShard* shard, Transaction* t, const vector<double>& weights,
+                         unsigned key_index, unsigned offset) {
   unsigned windex = t->ReverseArgIndex(shard->shard_id(), key_index) - offset;
   DCHECK_LT(windex, weights.size());
   return weights[windex];
 }
 
-OpResult<ScoredPIVec> FindSliceResult(EngineShard* shard, Transaction* t,
-				    const ArgSlice& keys,
-				    const vector<double>& weights,
-				    unsigned start, unsigned offset) {
+OpResult<ScoredPIVec> FindSliceResult(EngineShard* shard, Transaction* t, const ArgSlice& keys,
+                                      const vector<double>& weights, unsigned start,
+                                      unsigned offset) {
   auto& db_slice = shard->db_slice();
   vector<pair<PrimeIterator, double>> it_arr(keys.size() - start);
   for (unsigned j = start; j < keys.size(); ++j) {
@@ -923,8 +920,8 @@ OpResult<void> FillAggType(UnionArgs& union_args, CmdArgList args, unsigned arg_
   return OpStatus::OK;
 }
 
-OpResult<unsigned> ParseAggregate(UnionArgs& union_args, CmdArgList args,
-				unsigned arg_pos, bool store) {
+OpResult<unsigned> ParseAggregate(UnionArgs& union_args, CmdArgList args, unsigned arg_pos,
+                                  bool store) {
   if (store && arg_pos + 2 != args.size()) {
     return OpStatus::SYNTAX_ERR;
   }
@@ -938,8 +935,7 @@ OpResult<unsigned> ParseAggregate(UnionArgs& union_args, CmdArgList args,
   return arg_pos + 1;
 }
 
-OpResult<unsigned> ParseWeights(UnionArgs& union_args, CmdArgList args,
-				unsigned arg_pos) {
+OpResult<unsigned> ParseWeights(UnionArgs& union_args, CmdArgList args, unsigned arg_pos) {
   if (args.size() <= arg_pos + union_args.num_keys) {
     return OpStatus::SYNTAX_ERR;
   }
@@ -1003,7 +999,7 @@ OpResult<UnionArgs> ParseUnionArgs(CmdArgList args, bool store) {
       i = *parsed;
       // Commands with store capability does not offer WITHSCORES option
       if (store) {
-	break;
+        break;
       }
     } else if (!store && arg == "WITHSCORES") {
       const auto& parsed = ParseWithScores(union_args, args, i);

--- a/src/server/zset_family.h
+++ b/src/server/zset_family.h
@@ -79,6 +79,7 @@ class ZSetFamily {
   static void ZRevRangeByScore(CmdArgList args, ConnectionContext* cntx);
   static void ZRevRank(CmdArgList args, ConnectionContext* cntx);
   static void ZScan(CmdArgList args, ConnectionContext* cntx);
+  static void ZUnion(CmdArgList args, ConnectionContext* cntx);
   static void ZUnionStore(CmdArgList args, ConnectionContext* cntx);
 
   static void ZRangeByScoreInternal(CmdArgList args, bool reverse, ConnectionContext* cntx);

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -266,14 +266,14 @@ TEST_F(ZSetFamilyTest, ZScan) {
 
 TEST_F(ZSetFamilyTest, ZUnion) {
   RespExpr resp;
-  
+
   resp = Run({"zunion", "0"});
   EXPECT_THAT(resp, ErrArg("wrong number of arguments"));
 
   EXPECT_EQ(2, CheckedInt({"zadd", "z1", "1", "a", "3", "b"}));
   EXPECT_EQ(2, CheckedInt({"zadd", "z2", "3", "c", "2", "b"}));
   EXPECT_EQ(2, CheckedInt({"zadd", "z3", "1", "c", "1", "d"}));
-  
+
   resp = Run({"zunion", "z1", "z2", "z3", "weights", "1", "1", "k"});
   EXPECT_THAT(resp, ErrArg("weight value is not a float"));
 
@@ -290,18 +290,20 @@ TEST_F(ZSetFamilyTest, ZUnion) {
   EXPECT_THAT(resp, ErrArg("syntax error"));
 
   resp = Run({"zunion", "z1", "z2", "z3"});
-  EXPECT_THAT(resp.GetVec(), ElementsAre("a", "d", "c", "b")); 
+  EXPECT_THAT(resp.GetVec(), ElementsAre("a", "d", "c", "b"));
 
   resp = Run({"zunion", "z1", "z2", "z3", "weights", "1", "1", "2"});
   EXPECT_THAT(resp.GetVec(), ElementsAre("a", "d", "b", "c"));
-  
+
   resp = Run({"zunion", "z1", "z2", "z3", "weights", "1", "1", "2", "withscores"});
   EXPECT_THAT(resp.GetVec(), ElementsAre("a", "1", "d", "2", "b", "5", "c", "5"));
-  
-  resp = Run({"zunion", "z1", "z2", "z3", "weights", "1", "1", "2", "aggregate", "min", "withscores"});
+
+  resp =
+      Run({"zunion", "z1", "z2", "z3", "weights", "1", "1", "2", "aggregate", "min", "withscores"});
   EXPECT_THAT(resp.GetVec(), ElementsAre("a", "1", "b", "2", "c", "2", "d", "2"));
 
-  resp = Run({"zunion", "z1", "z2", "z3", "weights", "1", "1", "2", "aggregate", "max", "withscores"});
+  resp =
+      Run({"zunion", "z1", "z2", "z3", "weights", "1", "1", "2", "aggregate", "max", "withscores"});
   EXPECT_THAT(resp.GetVec(), ElementsAre("a", "1", "d", "2", "b", "3", "c", "3"));
 }
 

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -264,6 +264,47 @@ TEST_F(ZSetFamilyTest, ZScan) {
   EXPECT_EQ(100 * 2, scan_len);
 }
 
+TEST_F(ZSetFamilyTest, ZUnion) {
+  RespExpr resp;
+  
+  resp = Run({"zunion", "0"});
+  EXPECT_THAT(resp, ErrArg("wrong number of arguments"));
+
+  EXPECT_EQ(2, CheckedInt({"zadd", "z1", "1", "a", "3", "b"}));
+  EXPECT_EQ(2, CheckedInt({"zadd", "z2", "3", "c", "2", "b"}));
+  EXPECT_EQ(2, CheckedInt({"zadd", "z3", "1", "c", "1", "d"}));
+  
+  resp = Run({"zunion", "z1", "z2", "z3", "weights", "1", "1", "k"});
+  EXPECT_THAT(resp, ErrArg("weight value is not a float"));
+
+  resp = Run({"zunion", "z1", "z2", "z3", "weights", "1", "1", "2", "aggregate", "something"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
+
+  resp = Run({"zunion", "z1", "z2", "z3", "weights", "1", "2", "aggregate", "something"});
+  EXPECT_THAT(resp, ErrArg("weight value is not a float"));
+
+  resp = Run({"zunion", "z1", "z2", "z3", "aggregate", "sum", "somescore"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
+
+  resp = Run({"zunion", "z1", "z2", "z3", "withscores", "someargs"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
+
+  resp = Run({"zunion", "z1", "z2", "z3"});
+  EXPECT_THAT(resp.GetVec(), ElementsAre("a", "d", "c", "b")); 
+
+  resp = Run({"zunion", "z1", "z2", "z3", "weights", "1", "1", "2"});
+  EXPECT_THAT(resp.GetVec(), ElementsAre("a", "d", "b", "c"));
+  
+  resp = Run({"zunion", "z1", "z2", "z3", "weights", "1", "1", "2", "withscores"});
+  EXPECT_THAT(resp.GetVec(), ElementsAre("a", "1", "d", "2", "b", "5", "c", "5"));
+  
+  resp = Run({"zunion", "z1", "z2", "z3", "weights", "1", "1", "2", "aggregate", "min", "withscores"});
+  EXPECT_THAT(resp.GetVec(), ElementsAre("a", "1", "b", "2", "c", "2", "d", "2"));
+
+  resp = Run({"zunion", "z1", "z2", "z3", "weights", "1", "1", "2", "aggregate", "max", "withscores"});
+  EXPECT_THAT(resp.GetVec(), ElementsAre("a", "1", "d", "2", "b", "3", "c", "3"));
+}
+
 TEST_F(ZSetFamilyTest, ZUnionStore) {
   RespExpr resp;
 


### PR DESCRIPTION
This PR implements a variant of ZUNION command 

Due to the lack of support in the framework, this implementation does not offer API to specify `num_keys` argument.

Instead, it currently can accept exactly 3 keys. All the optional arguments are supported (`WEIGHTS`, `AGGREGATE`, `WITHSCORES`)

(partially implements #356)