### PR TITLE
feat(server): sending and dispatching of messages using different internals

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -70,11 +70,11 @@ bool MatchHttp11Line(string_view line) {
 constexpr size_t kMinReadSize = 256;
 constexpr size_t kMaxReadSize = 32_KB;
 
-struct AsyncMsg {
+struct PubMsgRecord {
   Connection::PubMessage pub_msg;
   fibers_ext::BlockingCounter bc;
 
-  AsyncMsg(const Connection::PubMessage& pmsg, fibers_ext::BlockingCounter b)
+  PubMsgRecord(const Connection::PubMessage& pmsg, fibers_ext::BlockingCounter b)
       : pub_msg(pmsg), bc(move(b)) {
   }
 };
@@ -101,20 +101,84 @@ struct Connection::Shutdown {
   }
 };
 
+// Used as custom deleter for Request object
+struct Connection::RequestDeleter {
+  void operator()(Request* req) const;
+};
+
+// Please note: The call to the Dtor is mandatory for this!!
+// This class contain types that don't have trivial destructed objects
 struct Connection::Request {
-  absl::FixedArray<MutableSlice, 6> args;
+  struct PipelineMsg {
+    absl::FixedArray<MutableSlice, 6> args;
 
-  // I do not use mi_heap_t explicitly but mi_stl_allocator at the end does the same job
-  // of using the thread's heap.
-  // The capacity is chosen so that we allocate a fully utilized (256 bytes) block.
-  absl::FixedArray<char, kReqStorageSize, mi_stl_allocator<char>> storage;
-  AsyncMsg* async_msg = nullptr;  // allocated and released via mi_malloc.
+    // I do not use mi_heap_t explicitly but mi_stl_allocator at the end does the same job
+    // of using the thread's heap.
+    // The capacity is chosen so that we allocate a fully utilized (256 bytes) block.
+    absl::FixedArray<char, kReqStorageSize, mi_stl_allocator<char>> storage;
 
-  Request(size_t nargs, size_t capacity) : args(nargs), storage(capacity) {
+    PipelineMsg(size_t nargs, size_t capacity) : args(nargs), storage(capacity) {
+    }
+  };
+
+ private:
+  using MessagePayload = std::variant<PipelineMsg, PubMsgRecord>;
+
+  Request(size_t nargs, size_t capacity) : payload(PipelineMsg{nargs, capacity}) {
+  }
+
+  Request(PubMsgRecord msg) : payload(std::move(msg)) {
   }
 
   Request(const Request&) = delete;
+
+ public:
+  // Overload to create the a new pipeline message
+  static RequestPtr New(mi_heap_t* heap, RespVec args, size_t capacity);
+
+  // overload to create a new pubsub message
+  static RequestPtr New(const PubMessage& pub_msg, fibers_ext::BlockingCounter bc);
+
+  MessagePayload payload;
 };
+
+Connection::RequestPtr Connection::Request::New(mi_heap_t* heap, RespVec args, size_t capacity) {
+  constexpr auto kReqSz = sizeof(Request);
+  void* ptr = mi_heap_malloc_small(heap, kReqSz);
+
+  // We must construct in place here, since there is a slice that uses memory locations
+  Request* req = new (ptr) Request(args.size(), capacity);
+
+  // At this point we know that we have PipelineMsg in Request so next op is safe.
+  Request::PipelineMsg& pipeline_msg = std::get<Request::PipelineMsg>(req->payload);
+  auto* next = pipeline_msg.storage.data();
+  for (size_t i = 0; i < args.size(); ++i) {
+    auto buf = args[i].GetBuf();
+    size_t s = buf.size();
+    memcpy(next, buf.data(), s);
+    pipeline_msg.args[i] = MutableSlice(next, s);
+    next += s;
+  }
+  return Connection::RequestPtr{req, Connection::RequestDeleter{}};
+}
+
+Connection::RequestPtr Connection::Request::New(const PubMessage& pub_msg,
+                                                fibers_ext::BlockingCounter bc) {
+  // This will generate a new request for pubsub message
+  // Please note that unlike the above case, we don't need to "protect", the internals here
+  // since we are currently using a borrow token for it - i.e. the BlockingCounter will
+  // ensure that the message is not deleted until we are finish sending it at the other
+  // side of the queue
+  PubMsgRecord new_msg{pub_msg, std::move(bc)};
+  void* ptr = mi_malloc(sizeof(Request));
+  Request* req = new (ptr) Request(std::move(new_msg));
+  return Connection::RequestPtr{req, Connection::RequestDeleter{}};
+}
+
+void Connection::RequestDeleter::operator()(Request* req) const {
+  req->~Request();
+  mi_free(req);
+}
 
 Connection::Connection(Protocol protocol, util::HttpListenerBase* http_listener, SSL_CTX* ctx,
                        ServiceInterface* service)
@@ -125,7 +189,6 @@ Connection::Connection(Protocol protocol, util::HttpListenerBase* http_listener,
 
   constexpr size_t kReqSz = sizeof(Connection::Request);
   static_assert(kReqSz <= 256 && kReqSz >= 232);
-  // LOG(INFO) << "kReqSz: " << kReqSz;
 
   switch (protocol) {
     case Protocol::REDIS:
@@ -270,14 +333,8 @@ void Connection::SendMsgVecAsync(const PubMessage& pub_msg, fibers_ext::Blocking
     bc.Dec();
     return;
   }
-
-  void* ptr = mi_malloc(sizeof(AsyncMsg));
-  AsyncMsg* amsg = new (ptr) AsyncMsg(pub_msg, move(bc));
-
-  ptr = mi_malloc(sizeof(Request));
-  Request* req = new (ptr) Request(0, 0);
-  req->async_msg = amsg;
-  dispatch_q_.push_back(req);
+  RequestPtr req = Request::New(pub_msg, std::move(bc));  // new (ptr) Request(0, 0);
+  dispatch_q_.push_back(std::move(req));
   if (dispatch_q_.size() == 1) {
     evc_.notify();
   }
@@ -437,9 +494,9 @@ auto Connection::ParseRedis() -> ParserStatus {
         VLOG(2) << "Dispatch async";
 
         // Dispatch via queue to speedup input reading.
-        Request* req = FromArgs(std::move(parse_args_), tlh);
+        RequestPtr req = FromArgs(std::move(parse_args_), tlh);
 
-        dispatch_q_.push_back(req);
+        dispatch_q_.push_back(std::move(req));
         if (dispatch_q_.size() == 1) {
           evc_.notify();
         } else if (dispatch_q_.size() > 10) {
@@ -596,79 +653,93 @@ auto Connection::IoLoop(util::FiberSocketBase* peer) -> variant<error_code, Pars
   return parse_status;
 }
 
+struct Connection::DispatchOperations {
+  DispatchOperations(SinkReplyBuilder* b, Connection* me)
+      : stats{me->service_->GetThreadLocalConnectionStats()}, builder{b},
+        empty{me->dispatch_q_.empty()}, self(me) {
+  }
+
+  void operator()(PubMsgRecord& msg);
+  void operator()(Request::PipelineMsg& msg);
+
+  ConnectionStats* stats = nullptr;
+  SinkReplyBuilder* builder = nullptr;
+  bool empty = false;
+  Connection* self = nullptr;
+};
+
+void Connection::DispatchOperations::operator()(PubMsgRecord& msg) {
+  RedisReplyBuilder* rbuilder = (RedisReplyBuilder*)builder;
+  ++stats->async_writes_cnt;
+  const PubMessage& pub_msg = msg.pub_msg;
+  string_view arr[4];
+  if (pub_msg.pattern.empty()) {
+    arr[0] = "message";
+    arr[1] = pub_msg.channel;
+    arr[2] = pub_msg.message;
+    rbuilder->SendStringArr(absl::Span<string_view>{arr, 3});
+  } else {
+    arr[0] = "pmessage";
+    arr[1] = pub_msg.pattern;
+    arr[2] = pub_msg.channel;
+    arr[3] = pub_msg.message;
+    rbuilder->SendStringArr(absl::Span<string_view>{arr, 4});
+  }
+  msg.bc.Dec();
+}
+
+void Connection::DispatchOperations::operator()(Request::PipelineMsg& msg) {
+  ++stats->pipelined_cmd_cnt;
+
+  builder->SetBatchMode(!empty);
+  self->cc_->async_dispatch = true;
+  self->service_->DispatchCommand(CmdArgList{msg.args.data(), msg.args.size()}, self->cc_.get());
+  self->last_interaction_ = time(nullptr);
+  self->cc_->async_dispatch = false;
+}
+
+struct Connection::DispatchCleanup {
+  void operator()(PubMsgRecord& msg) const {
+    msg.bc.Dec();
+  }
+
+  void operator()(const Connection::Request::PipelineMsg&) const {
+  }
+};
+
 // DispatchFiber handles commands coming from the InputLoop.
 // Thus, InputLoop can quickly read data from the input buffer, parse it and push
-// into the dispatch queue and DispatchFiber will run those commands asynchronously with InputLoop.
-// Note: in some cases, InputLoop may decide to dispatch directly and bypass the DispatchFiber.
+// into the dispatch queue and DispatchFiber will run those commands asynchronously with
+// InputLoop. Note: in some cases, InputLoop may decide to dispatch directly and bypass the
+// DispatchFiber.
 void Connection::DispatchFiber(util::FiberSocketBase* peer) {
   this_fiber::properties<FiberProps>().set_name("DispatchFiber");
 
-  ConnectionStats* stats = service_->GetThreadLocalConnectionStats();
   SinkReplyBuilder* builder = cc_->reply_builder();
+  DispatchOperations dispatch_op{builder, this};
 
   while (!builder->GetError()) {
     evc_.await([this] { return cc_->conn_closing || !dispatch_q_.empty(); });
     if (cc_->conn_closing)
       break;
 
-    Request* req = dispatch_q_.front();
+    RequestPtr req{std::move(dispatch_q_.front())};
     dispatch_q_.pop_front();
-
-    if (req->async_msg) {
-      ++stats->async_writes_cnt;
-
-      RedisReplyBuilder* rbuilder = (RedisReplyBuilder*)builder;
-      const PubMessage& pub_msg = req->async_msg->pub_msg;
-      string_view arr[4];
-
-      if (pub_msg.pattern.empty()) {
-        arr[0] = "message";
-        arr[1] = pub_msg.channel;
-        arr[2] = pub_msg.message;
-        rbuilder->SendStringArr(absl::Span<string_view>{arr, 3});
-      } else {
-        arr[0] = "pmessage";
-        arr[1] = pub_msg.pattern;
-        arr[2] = pub_msg.channel;
-        arr[3] = pub_msg.message;
-        rbuilder->SendStringArr(absl::Span<string_view>{arr, 4});
-      }
-
-      req->async_msg->bc.Dec();
-
-      req->async_msg->~AsyncMsg();
-      mi_free(req->async_msg);
-    } else {
-      ++stats->pipelined_cmd_cnt;
-
-      builder->SetBatchMode(!dispatch_q_.empty());
-      cc_->async_dispatch = true;
-      service_->DispatchCommand(CmdArgList{req->args.data(), req->args.size()}, cc_.get());
-      last_interaction_ = time(nullptr);
-      cc_->async_dispatch = false;
-    }
-    req->~Request();
-    mi_free(req);
+    std::visit(dispatch_op, req->payload);
   }
 
   cc_->conn_closing = true;
 
   // Clean up leftovers.
+  DispatchCleanup clean_op;
   while (!dispatch_q_.empty()) {
-    Request* req = dispatch_q_.front();
+    RequestPtr req{std::move(dispatch_q_.front())};
     dispatch_q_.pop_front();
-
-    if (req->async_msg) {
-      req->async_msg->bc.Dec();
-      req->async_msg->~AsyncMsg();
-      mi_free(req->async_msg);
-    }
-    req->~Request();
-    mi_free(req);
+    std::visit(clean_op, req->payload);
   }
 }
 
-auto Connection::FromArgs(RespVec args, mi_heap_t* heap) -> Request* {
+auto Connection::FromArgs(RespVec args, mi_heap_t* heap) -> RequestPtr {
   DCHECK(!args.empty());
   size_t backed_sz = 0;
   for (const auto& arg : args) {
@@ -680,22 +751,11 @@ auto Connection::FromArgs(RespVec args, mi_heap_t* heap) -> Request* {
   constexpr auto kReqSz = sizeof(Request);
   static_assert(kReqSz < MI_SMALL_SIZE_MAX);
   static_assert(alignof(Request) == 8);
-  void* ptr = mi_heap_malloc_small(heap, kReqSz);
 
-  Request* req = new (ptr) Request{args.size(), backed_sz};
-
-  auto* next = req->storage.data();
-  for (size_t i = 0; i < args.size(); ++i) {
-    auto buf = args[i].GetBuf();
-    size_t s = buf.size();
-    memcpy(next, buf.data(), s);
-    req->args[i] = MutableSlice(next, s);
-    next += s;
-  }
+  RequestPtr req = Request::New(heap, args, backed_sz);
 
   return req;
 }
-
 void Connection::ShutdownSelf() {
   util::Connection::Shutdown();
 }

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -116,11 +116,16 @@ class Connection : public util::Connection {
   std::unique_ptr<ConnectionContext> cc_;
 
   struct Request;
+  struct DispatchOperations;
+  struct DispatchCleanup;
+  struct RequestDeleter;
+
+  using RequestPtr = std::unique_ptr<Request, RequestDeleter>;
 
   // args are passed deliberately by value - to pass the ownership.
-  static Request* FromArgs(RespVec args, mi_heap_t* heap);
+  static RequestPtr FromArgs(RespVec args, mi_heap_t* heap);
 
-  std::deque<Request*> dispatch_q_;  // coordinated via evc_.
+  std::deque<RequestPtr> dispatch_q_;  // coordinated via evc_.
   util::fibers_ext::EventCount evc_;
 
   RespVec parse_args_;


### PR DESCRIPTION


Signed-off-by: Boaz Sade <boaz@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
The sending of messages that require async handling such as pub/sub and pipelines is now using different implementation that is based on explicit typing. 
currently it would have support for 2 explicit types:
* pipeline - this mode delegates command through the connection.
* Pub/sub messages - publishing command through the connection to a given subscriber
This change is required so that we would later be able to support more types and easily change this to make it simpler.
We would use this change to support issue #344 