### PR TITLE
Monitor command

### DIFF
--- a/docs/api_status.md
+++ b/docs/api_status.md
@@ -104,7 +104,7 @@ with respect to Memcached and Redis APIs.
   - [X] ZSCORE
 - [ ] Other
   - [ ] BGREWRITEAOF
-  - [ ] MONITOR
+  - [x] MONITOR
   - [ ] RANDOMKEY
 
 ### API 2

--- a/src/facade/conn_context.h
+++ b/src/facade/conn_context.h
@@ -19,7 +19,8 @@ class ConnectionContext {
 
   // We won't have any virtual methods, probably. However, since we allocate a derived class,
   // we need to declare a virtual d-tor, so we could properly delete it from Connection code.
-  virtual ~ConnectionContext() {}
+  virtual ~ConnectionContext() {
+  }
 
   Connection* owner() {
     return owner_;
@@ -44,12 +45,12 @@ class ConnectionContext {
   }
 
   // connection state / properties.
-  bool async_dispatch: 1;  // whether this connection is currently handled by dispatch fiber.
-  bool conn_closing: 1;
-  bool req_auth: 1;
-  bool replica_conn: 1;
-  bool authenticated: 1;
-  bool force_dispatch: 1;   // whether we should route all requests to the dispatch fiber.
+  bool async_dispatch : 1;  // whether this connection is currently handled by dispatch fiber.
+  bool conn_closing : 1;
+  bool req_auth : 1;
+  bool replica_conn : 1;
+  bool authenticated : 1;
+  bool force_dispatch : 1;  // whether we should route all requests to the dispatch fiber.
 
  private:
   Connection* owner_;

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -59,7 +59,14 @@ class Connection : public util::Connection {
     std::string_view message;
   };
 
+  // this function is overriden at test_utils TestConnection
   virtual void SendMsgVecAsync(const PubMessage& pub_msg, util::fibers_ext::BlockingCounter bc);
+
+  // Please note, this accept the message by value, since we really want to
+  // create a new copy here, so that we would not need to "worry" about memory
+  // management, we are assuming that we would not have many copy for this, and that
+  // we would not need in this way to sync on the lifetime of the message
+  void SendMonitorMsg(std::string monitor_msg);
 
   void SetName(std::string_view name) {
     CopyCharBuf(name, sizeof(name_), name_);
@@ -70,6 +77,7 @@ class Connection : public util::Connection {
   }
 
   std::string GetClientInfo() const;
+  std::string RemoteEndpointStr() const;
   uint32 GetClientId() const;
 
   void ShutdownSelf();

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -63,7 +63,6 @@ string UnknownSubCmd(string_view subcmd, string_view cmd) {
                       cmd, " HELP.");
 }
 
-
 const char kSyntaxErr[] = "syntax error";
 const char kWrongTypeErr[] = "-WRONGTYPE Operation against a key holding the wrong kind of value";
 const char kKeyNotFoundErr[] = "no such key";

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(dfly_transaction db_slice.cc engine_shard_set.cc blocking_controller
 cxx_link(dfly_transaction uring_fiber_lib dfly_core strings_lib)
 
 add_library(dragonfly_lib  channel_slice.cc command_registry.cc
-            config_flags.cc conn_context.cc debugcmd.cc dflycmd.cc
+            config_flags.cc conn_context.cc debugcmd.cc server_state.cc dflycmd.cc
             generic_family.cc hset_family.cc json_family.cc
             list_family.cc main_service.cc memory_cmd.cc rdb_load.cc rdb_save.cc replica.cc
             snapshot.cc script_mgr.cc server_family.cc malloc_stats.cc

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -6,11 +6,39 @@
 
 #include "base/logging.h"
 #include "server/engine_shard_set.h"
+#include "server/server_family.h"
+#include "server/server_state.h"
+#include "src/facade/dragonfly_connection.h"
 #include "util/proactor_base.h"
 
 namespace dfly {
 
 using namespace std;
+
+void ConnectionContext::SendMonitorMsg(std::string msg) {
+  CHECK(owner());
+
+  owner()->SendMonitorMsg(std::move(msg));
+}
+
+void ConnectionContext::ChangeMonitor(bool start) {
+  // This will either remove or register a new connection
+  // at the "top level" thread --> ServerState context
+  // note that we are registering/removing this connection to the thread at which at run
+  // then notify all other threads that there is a change in the number of monitors
+  auto& my_monitors = ServerState::tlocal()->Monitors();
+  if (start) {
+    my_monitors.Add(this);
+  } else {
+    VLOG(1) << "connection " << owner()->GetClientInfo()
+            << " no longer needs to be monitored - removing 0x" << std::hex << (const void*)this;
+    my_monitors.Remove(this);
+  }
+  // Tell other threads that about the change in the number of connection that we monitor
+  shard_set->pool()->Await(
+      [start](auto*) { ServerState::tlocal()->Monitors().NotifyChangeCount(start); });
+  EnableMonitoring(start);
+}
 
 void ConnectionContext::ChangeSubscription(bool to_add, bool to_reply, CmdArgList args) {
   vector<unsigned> result(to_reply ? args.size() : 0, 0);

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -32,7 +32,9 @@ struct ConnectionState {
     ExecInfo(ExecInfo&&) = delete;
 
     // Return true if ExecInfo is active (after MULTI)
-    bool IsActive() { return state != EXEC_INACTIVE; }
+    bool IsActive() {
+      return state != EXEC_INACTIVE;
+    }
 
     // Resets to blank state after EXEC or DISCARD
     void Clear();
@@ -117,17 +119,29 @@ class ConnectionContext : public facade::ConnectionContext {
     return conn_state.db_index;
   }
 
+  // Note that this is accepted by value for lifetime reasons
+  // we want to have our own copy since we are assuming that
+  // 1. there will be not to many connections that we in monitor state
+  // 2. we need to have for each of them each own copy for thread safe reasons
+  void SendMonitorMsg(std::string msg);
+
   void ChangeSubscription(bool to_add, bool to_reply, CmdArgList args);
   void ChangePSub(bool to_add, bool to_reply, CmdArgList args);
   void UnsubscribeAll(bool to_reply);
   void PUnsubscribeAll(bool to_reply);
+  void ChangeMonitor(bool start);  // either start or stop monitor on a given connection
 
   bool is_replicating = false;
+  bool monitor = false;  // when a monitor command is sent over a given connection, we need to aware
+                         // of it as a state for the connection
 
  private:
+  void EnableMonitoring(bool enable) {
+    force_dispatch = enable;  // required to support the monitoring
+    monitor = enable;
+  }
   void SendSubscriptionChangedResponse(std::string_view action,
-                                       std::optional<std::string_view> topic,
-                                       unsigned count);
+                                       std::optional<std::string_view> topic, unsigned count);
 };
 
 }  // namespace dfly

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -102,7 +102,7 @@ class Service : public facade::ServiceInterface {
   void PSubscribe(CmdArgList args, ConnectionContext* cntx);
   void PUnsubscribe(CmdArgList args, ConnectionContext* cntx);
   void Function(CmdArgList args, ConnectionContext* cntx);
-
+  void Monitor(CmdArgList args, ConnectionContext* cntx);
   void Pubsub(CmdArgList args, ConnectionContext* cntx);
   void PubsubChannels(std::string_view pattern, ConnectionContext* cntx);
   void PubsubPatterns(ConnectionContext* cntx);

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -1,0 +1,51 @@
+// Copyright 2022, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "server/server_state.h"
+
+#include "base/logging.h"
+#include "server/conn_context.h"
+
+namespace dfly {
+
+void MonitorsRepo::Add(ConnectionContext* connection) {
+  VLOG(1) << "register connection "
+          << " at address 0x" << std::hex << (const void*)connection << " for thread "
+          << util::ProactorBase::GetIndex();
+
+  monitors_.push_back(connection);
+}
+
+void MonitorsRepo::Send(const std::string& msg) {
+  if (!monitors_.empty()) {
+    VLOG(1) << "thread " << util::ProactorBase::GetIndex() << " sending monitor message '" << msg
+            << "' for " << monitors_.size();
+    for (auto monitor_conn : monitors_) {
+      monitor_conn->SendMonitorMsg(msg);
+    }
+  }
+}
+
+void MonitorsRepo::Remove(const ConnectionContext* conn) {
+  auto it = std::find_if(monitors_.begin(), monitors_.end(),
+                         [&conn](const auto& val) { return val == conn; });
+  if (it != monitors_.end()) {
+    VLOG(1) << "removing connection 0x" << std::hex << (const void*)conn << " releasing token";
+    monitors_.erase(it);
+  } else {
+    VLOG(1) << "no connection 0x" << std::hex << (const void*)conn
+            << " found in the registered list here";
+  }
+}
+
+void MonitorsRepo::NotifyChangeCount(bool added) {
+  if (added) {
+    ++global_count_;
+  } else {
+    DCHECK(global_count_ > 0);
+    --global_count_;
+  }
+}
+
+}  // end of namespace dfly

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -15,9 +15,63 @@ typedef struct mi_heap_s mi_heap_t;
 
 namespace dfly {
 
+class ConnectionContext;
 namespace journal {
 class Journal;
 }  // namespace journal
+
+// This would be used as a thread local storage of sending
+// monitor messages.
+// Each thread will have its own list of all the connections that are
+// used for monitoring. When a connection is set to monitor it would register
+// itself to this list on all i/o threads. When a new command is dispatched,
+// and this list is not empty, it would send in the same thread context as then
+// thread that registered here the command.
+// Note about performance: we are assuming that we would not have many connections
+// that are registered here. This is not pub sub where it must be high performance
+// and may support many to many with tens or more of connections. It is assumed that
+// since monitoring is for debugging only, we would have less than 1 in most cases.
+// Also note that we holding this list on the thread level since this is the context
+// at which this would run. It also minimized the number of copied for this list.
+class MonitorsRepo {
+ public:
+  // This function adds a new connection to be monitored. This function only add
+  // new connection that belong to this thread! Must not be called outside of this
+  // thread context
+  void Add(ConnectionContext* info);
+
+  // Note that this is accepted by value for lifetime reasons
+  // we want to have our own copy since we are assuming that
+  // 1. there will be not to many connections that we in monitor state
+  // 2. we need to have for each of them each own copy for thread safe reasons
+  void Send(const std::string& msg);
+
+  // This function remove a connection what was monitored. This function only removes
+  // a connection that belong to this thread! Must not be called outside of this
+  // thread context
+  void Remove(const ConnectionContext* conn);
+
+  // We have for each thread the total number of monitors in the application.
+  // So this call is thread safe since we hold a copy of this for each thread.
+  // If this return true, then we don't need to run the monitor operation at all.
+  bool Empty() const {
+    return global_count_ == 0u;
+  }
+
+  // This function is run on all threads to either increment or decrement the "shared" counter
+  // of the monitors - it must be called as part of removing a monitor (for example
+  // when a connection is closed).
+  void NotifyChangeCount(bool added);
+
+  std::size_t Size() const {
+    return monitors_.size();
+  }
+
+ private:
+  using MonitorVec = std::vector<ConnectionContext*>;
+  MonitorVec monitors_;            // save connections belonging to this thread only!
+  unsigned int global_count_ = 0;  // by global its means that we count the monitor for all threads
+};
 
 // Present in every server thread. This class differs from EngineShard. The latter manages
 // state around engine shards while the former represents coordinator/connection state.
@@ -94,6 +148,10 @@ class ServerState {  // public struct - to allow initialization.
     journal_ = j;
   }
 
+  constexpr MonitorsRepo& Monitors() {
+    return monitors_;
+  }
+
  private:
   int64_t live_transactions_ = 0;
   mi_heap_t* data_heap_;
@@ -104,6 +162,8 @@ class ServerState {  // public struct - to allow initialization.
 
   using Counter = util::SlidingCounter<7>;
   Counter qps_;
+
+  MonitorsRepo monitors_;
 
   static thread_local ServerState state_;
 };


### PR DESCRIPTION
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
Adding support for the monitor command.
The monitor command is a tool to debug other connections, by sending the command args to the connection which is set to mode 'monitor''.
For more details about the monitor command - [see redis monitor command doc here](https://redis.io/commands/monitor/).
Please note that:
- You can only send "QUIT" and "RESET" command while the connection is in monitor mode.
- For this implementation it is assumed that there will be limited number of connections that are in monitor mode - i.e. we are monitoring many connections into very few connections.
- The implementation ensure to work asynchronously and to verify that the connection is alive until the last message is sent it "borrow" the connection until the message is sent over to the socket.
- A later PR would covert this with tests to ensure that this working as part of later PRs as it can affect connections.