### PR TITLE
feat(server): Allow sampling arena stats from a specified thread

### DIFF
--- a/docs/dense_set.md
+++ b/docs/dense_set.md
@@ -49,9 +49,13 @@ At 100% utilization the Redis dictionary implementation uses approximately 32 by
 
 In comparison using the neighbour cell optimization, `DenseSet` has ~21% of spaces unused at full utilization resulting in $N\*8 + 0.2\*16N \approx 11.2N$ or ~12 bytes per record, yielding ~20 byte savings. The number of bytes per record saved grows as utilization decreases.
 
-Inserting 20M 10 byte strings into a set in chunks of 500 on an i5-8250U give the following results
+Command `memtier_benchmark -p 6379 --command "sadd __key__ __data__"   -n 10000000 --threads=1 -c 1 --command-key-pattern=R   --data-size=10     --key-prefix="key:"  --hide-histogram --random-data --key-maximum=1 --randomize --pipeline 20`
+produces two sets entries with lots of small records in them.
 
-|             | Dragonfly (DenseSet) | Dragonfly (Redis Dictionary) | Redis 7 |
-|-------------|----------------------|------------------------------|---------|
-| Time        |    44.1s             |            46.9s             |  50.3s  |
-| Memory used |    626.44MiB         |            1.27G             |  1.27G  |
+This is how memory usage looks like with DenseSet:
+
+| Server                | Memory (RSS) |
+|:---------------------:|:------:      |
+| Dragonfly/DenseSet    |  323MB 🟩    |
+| Redis                 |  586MB       |
+| Dragonfly/RedisDict   |  663MB       |

--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -47,7 +47,13 @@ void MemoryCmd::Run(CmdArgList args) {
     // dummy output, in practice not implemented yet.
     return (*cntx_)->SendLong(1);
   } else if (sub_cmd == "MALLOC-STATS") {
-    string res = shard_set->pool()->at(0)->AwaitBrief([this] { return MallocStats(); });
+    uint32_t tid = 0;
+    if (args.size() >= 3 && !absl::SimpleAtoi(ArgS(args, 2), &tid)) {
+      return (*cntx_)->SendError(kInvalidIntErr);
+    }
+    tid = tid % shard_set->pool()->size();
+    string res = shard_set->pool()->at(tid)->AwaitBrief([this] { return MallocStats(); });
+
     return (*cntx_)->SendBulkString(res);
   }
 


### PR DESCRIPTION
Also update dense_set.md with a reproducable test on how to see memory differences of DenseSet vs RedisDict.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->