### PR TITLE
feat(server): monitor command should return OK on creation (#344)

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -126,12 +126,12 @@ auto CmdEntryToMonitorFormat(std::string_view str) -> std::string {
 
 std::string MakeMonitorMessage(const ConnectionState& conn_state,
                                const facade::Connection* connection, CmdArgList args) {
-  std::string message = CreateMonitorTimestamp();
+  std::string message = absl::StrCat(CreateMonitorTimestamp(), " [", conn_state.db_index);
 
   if (conn_state.script_info.has_value()) {
-    absl::StrAppend(&message, "lua] ");
+    absl::StrAppend(&message, " lua] ");
   } else {
-    absl::StrAppend(&message, connection->RemoteEndpointStr());
+    absl::StrAppend(&message, " ", connection->RemoteEndpointStr(), "] ");
   }
   if (args.empty()) {
     absl::StrAppend(&message, "error - empty cmd list!");
@@ -1293,6 +1293,7 @@ void Service::Monitor(CmdArgList args, ConnectionContext* cntx) {
   VLOG(1) << "starting monitor on this connection: " << cntx->owner()->GetClientInfo();
   // we are registering the current connection for all threads so they will be aware of
   // this connection, to send to it any command
+  (*cntx)->SendOk();
   cntx->ChangeMonitor(true /* start */);
 }
 


### PR DESCRIPTION
Signed-off-by: Boaz Sade <boaz@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
This would address two issues:
- For some reason the documentation for the monitor command do say that we need to return OK after registering the connection for monitor
- The database index and square brackets around the connection string were missing.