### PR TITLE
fix: dragonfly compilation failure due to glibc version less than 2.30

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -50,6 +50,11 @@ ABSL_DECLARE_FLAG(string, requirepass);
 
 namespace dfly {
 
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
+#include <sys/syscall.h>
+#define gettid() syscall(SYS_gettid)
+#endif
+
 using namespace util;
 using base::VarzValue;
 using ::boost::intrusive_ptr;


### PR DESCRIPTION
Signed-off-by: Super-long <0x4f4f4f4f@gmail.com>

This is a problem to be solved, but not necessarily the final version. I encountered the following problem when compiling dragonfly：

<img width="1468" alt="截屏2022-10-25 19 24 19" src="https://user-images.githubusercontent.com/46051144/197763384-87e4e93e-1a0a-4b0f-8b93-039f3d2e6f05.png">

In the man documentation I found this description：
<img width="712" alt="截屏2022-10-25 19 36 47" src="https://user-images.githubusercontent.com/46051144/197763544-069db3e9-1dca-4369-9df4-34ab7f9247cb.png">

You can check the glibc version by running ldd --version, and on my machine I have the following output：
<img width="539" alt="截屏2022-10-25 19 38 29" src="https://user-images.githubusercontent.com/46051144/197763804-2851bdf8-f821-4231-84f4-94e54d64db62.png">

This is an issue that needs to be fixed in order to compile dragonfly more robustly.
Currently gettid appears in helio/util/uring/proactor_test.cc and src/server/main_service.cc, and in proactor_test.cc because of third_party/gperf/src/stacktrace_ instrument-inl.h(#include <gperftools/profiler.h>) defines #define gettid() syscall(__NR_gettid), so it compiles without error on my machine.

It looks like there are several fixes like this
1. Create a public file in helio where gettid is defined and dragonfly uses the definition in helio.
2. Define it directly in main_service.cc, like this PR.




