### PR TITLE
feat(server): monitor command - cover by tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -5,7 +5,22 @@
 
 The tests assume you have the "dragonfly" binary in `<root>/build-dbg` directory.
 You can override the location of the binary using `DRAGONFLY_HOME` environment var.
-
+### Before you start
+Please make sure that you have python 3 installed on you local host.
+If have more both python 2 and python 3 installed on you host, you can run the tests with the following command:
+```
+python3 -m pytest -xv dragonfly
+```
+It is advisable to use you python virtual environment: [python virtual environment](https://docs.python.org/3/library/venv.html).
+To activate it, run:
+```
+source <virtual env name>/bin/activate
+```
+Then install all the required dependencies for the tests:
+```
+pip install -r dragonfly/requirements.txt
+```
+### Running the tests
 to run pytest, run:
 `pytest -xv dragonfly`
 
@@ -38,7 +53,21 @@ Parameters can use environmental variables with a formatted string where `"{<VAR
 ### Test Examples
 - **[blpop_test](./dragonfly/blpop_test.py)**: Simple test case interacting with Dragonfly
 - **[snapshot_test](./dragonfly/snapshot_test.py)**: Example test using `@dfly_args`, environment variables and pre-test setup
-- **[key_limt_test](./dragonfly/key_limit_test.py)**: Example test using `@dfly_multi_test_args`
+- **[key_limit_test](./dragonfly/key_limit_test.py)**: Example test using `@dfly_multi_test_args`
+- **[connection_test](./dragonfly/connection_test.py)**: Example for testing running with asynchronous multiple connections. 
+
+### Writing your own fixtures
+The fixture functions located in [conftest.py](./dragonfly/conftest.py).
+You can write your own fixture inside this file, as seem fit. Just make sure, before adding new fixture that there maybe one already written.
+Try to make the fixture running at the smallest scope possible to ensure that the test can be independent of each other (this will ensure no side effect - match our policy of "share nothing").
+
+### Managing test environment
+Do forget to add any new dependency that you may created to [dragonfly/requirement.txt](./dragonfly/requirements.txt) file.
+You can do so by running
+```
+pip3 freeze > requirements.txt 
+```
+from [dragonfly](./dragonfly/) directory.
 
 # Integration tests
 To simplify running integration test each package should have its own Dockerfile. The Dockerfile should contain everything needed in order to test the package against Dragonfly. Docker can assume Dragonfly is running on localhost:6379.

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -1,0 +1,172 @@
+import asyncio
+import aioredis
+import async_timeout
+#from conftest import DATABASE_INDEX
+
+
+def verify_response(monitor_response: dict, key: str, value: str) -> bool:
+    if monitor_response is None:
+        return False
+    if monitor_response["db"] == 1 and monitor_response["client_type"] == "tcp":
+        return key in monitor_response["command"] and value in monitor_response["command"]
+    else:
+        return False
+
+
+async def monitor_cmd(mon: aioredis.client.Monitor, messages: dict):
+    success = None
+    async with mon as monitor:
+        try:
+            for key, value in messages.items():
+                try:
+                    async with async_timeout.timeout(1):
+                        response = await monitor.next_command()
+                        success = verify_response(
+                            response, key, value)
+                        if not success:
+                            return False, f"failed on the verification of the message {response} at {key}: {value}"
+                        await asyncio.sleep(0.01)
+                except asyncio.TimeoutError:
+                    pass
+            return True, "monitor is successfully done"
+        except Exception as e:
+            return False, f"stopping monitor on {e}"
+
+
+async def run_monitor(messages: dict, pool: aioredis.ConnectionPool):
+    cmd1 = aioredis.Redis(connection_pool=pool)
+    conn = aioredis.Redis(connection_pool=pool)
+    monitor = conn.monitor()
+    future = asyncio.create_task(monitor_cmd(monitor, messages))
+    success = True
+    for key, val in messages.items():
+        res = await cmd1.set(key, val)
+        if not res:
+            success = False
+            break
+        await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)
+    await future
+    status, message = future.result()
+    if status and success:
+        return True, "successfully completed all"
+    else:
+        return False, f"monitor result: {status}: {message}, set command success {success}"
+
+
+async def run_monitor_command(connection, messages):
+    res = await run_monitor(messages, connection)
+    print(f"finish test monitoring returning: {res}")
+    return res
+
+'''
+Test the monitor command.
+Open connection which is used for monitoring
+Then send on other connection commands to dragonfly instance
+Make sure that we are getting the commands in the monitor context
+'''
+
+
+def test_monitor_command(async_pool, event_loop):
+    def generate(max):
+        for i in range(max):
+            yield f"key{i}", f"value={i}"
+
+    messages = {a: b for a, b in generate(5)}
+
+    success, message = event_loop.run_until_complete(
+        run_monitor_command(messages=messages, connection=async_pool))
+
+    assert success == True, message
+
+
+async def run_pipeline_mode(pool, messages):
+    conn = aioredis.Redis(connection_pool=pool)
+    pipe = conn.pipeline()
+    for key, val in messages.items():
+        pipe.set(key, val)
+    result = await pipe.execute()
+
+    print(f"got result from the pipeline of {result} with len = {len(result)}")
+    if len(result) != len(messages):
+        return False, f"number of results from pipe {len(result)} != expected {len(messages)}"
+    elif False in result:
+        return False, "expecting to successfully get all result good, but some failed"
+    else:
+        return True, "all command processed successfully"
+
+
+'''
+Run test in pipeline mode.
+This is mostly how this is done with python - its more like a transaction that
+the connections is running all commands in its context
+'''
+
+
+def test_pipeline_support(async_pool, event_loop):
+    def generate(max):
+        for i in range(max):
+            yield f"key{i}", f"value={i}"
+
+    messages = {a: b for a, b in generate(5)}
+    success, message = event_loop.run_until_complete(
+        run_pipeline_mode(async_pool, messages))
+    assert success, message
+
+
+async def reader(channel: aioredis.client.PubSub, messages):
+
+    success = True
+    message_count = len(messages)
+    while message_count > 0:
+        try:
+            async with async_timeout.timeout(1):
+                message = await channel.get_message(ignore_subscribe_messages=True)
+                if message is not None:
+                    message_count = message_count - 1
+                    if message["data"] not in messages:
+                        return False, f"got unexpected message from pubsub - {message['data']}"
+                await asyncio.sleep(0.01)
+        except asyncio.TimeoutError:
+            pass
+    return True, "success"
+
+
+async def run_pubsub(pool, messages, channel_name):
+    conn = aioredis.Redis(connection_pool=pool)
+    pubsub = conn.pubsub()
+    await pubsub.subscribe(channel_name)
+
+    future = asyncio.create_task(reader(pubsub, messages))
+    success = True
+
+    for message in messages:
+        res = await conn.publish(channel_name, message)
+        if not res:
+            success = False
+            break
+
+    await future
+    status, message = future.result()
+    if status and success:
+        return True, "successfully completed all"
+    else:
+        return False, f"subscriber result: {status}: {message},  publisher publish: success {success}"
+
+''' 
+Test the pipeline command
+Open connection to the subscriber and publish on the other end messages
+Make sure that we are able to send all of them and that we are getting the
+expected results on the subscriber side
+'''
+
+
+def test_pubsub_command(async_pool, event_loop):
+    def generate(max):
+        for i in range(max):
+            yield f"message number {i}"
+
+    messages = [a for a in generate(5)]
+    success, message = event_loop.run_until_complete(
+        run_pubsub(async_pool, messages, "channel-1"))
+    assert success, message

--- a/tests/dragonfly/requirements.txt
+++ b/tests/dragonfly/requirements.txt
@@ -10,3 +10,5 @@ pytest==7.1.2
 redis==4.3.4
 tomli==2.0.1
 wrapt==1.14.1
+aioredis==2.0.1
+


### PR DESCRIPTION
feat(server): tests for pipeline and pubsub added

Signed-off-by: Boaz Sade <boaz@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
Add tests for:
- monitor command
- pipeline mode
- pub/sub
Please note that you would need to update the test env as the requirements have changed (pip install -r tests/dragonfly/requirement.txt)!