### PR TITLE
fix(facade): lowercases command when printing wrong num args error

### DIFF
--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -51,7 +51,7 @@ ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
 #undef ADD
 
 string WrongNumArgsError(string_view cmd) {
-  return absl::StrCat("wrong number of arguments for '", cmd, "' command");
+  return absl::StrCat("wrong number of arguments for '", tolower(cmd), "' command");
 }
 
 string InvalidExpireTime(string_view cmd) {


### PR DESCRIPTION
fix(facade): lowercases command when printing wrong num args 

Signed-off-by: Paco Sanchez <sanchezpaco3@gmail.com>

Lowercases cmd variable when printing wrong number of arguments error.

https://github.com/dragonflydb/dragonfly/issues/390