### PR TITLE
refactor(server): Separate start & stop in rdb save

### DIFF
--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -70,6 +70,13 @@ class RdbSaver {
 
   ~RdbSaver();
 
+  // Initiates the serialization in the shard's thread.
+  // TODO: to implement break functionality to allow stopping early.
+  void StartSnapshotInShard(bool stream_journal, EngineShard* shard);
+
+  // Stops serialization in journal streaming mode in the shard's thread.
+  void StopSnapshotInShard(EngineShard* shard);
+
   // Stores auxiliary (meta) values and lua scripts.
   std::error_code SaveHeader(const StringVec& lua_scripts);
 
@@ -77,10 +84,6 @@ class RdbSaver {
   // Fills freq_map with the histogram of rdb types.
   // freq_map can optionally be null.
   std::error_code SaveBody(RdbTypeFreqMap* freq_map);
-
-  // Initiates the serialization in the shard's thread.
-  // TODO: to implement break functionality to allow stopping early.
-  void StartSnapshotInShard(bool include_journal_changes, EngineShard* shard);
 
   SaveMode Mode() const { return save_mode_; }
 

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -34,8 +34,8 @@ SliceSnapshot::SliceSnapshot(DbSlice* slice, RecordChannel* dest) : db_slice_(sl
 SliceSnapshot::~SliceSnapshot() {
 }
 
-void SliceSnapshot::Start(bool include_journal_changes) {
-  DCHECK(!fb_.joinable());
+void SliceSnapshot::Start(bool stream_journal) {
+  DCHECK(!snapshot_fb_.joinable());
 
   auto on_change = [this](DbIndex db_index, const DbSlice::ChangeReq& req) {
     OnDbChange(db_index, req);
@@ -44,47 +44,45 @@ void SliceSnapshot::Start(bool include_journal_changes) {
   snapshot_version_ = db_slice_->RegisterOnChange(move(on_change));
   VLOG(1) << "DbSaver::Start - saving entries with version less than " << snapshot_version_;
 
-  if (include_journal_changes) {
+  if (stream_journal) {
     auto* journal = db_slice_->shard_owner()->journal();
     DCHECK(journal);
-    journal_cb_id_ = journal->RegisterOnChange(
-        [this](const journal::Entry& e) { OnJournalEntry(e); });
+    journal_cb_id_ =
+        journal->RegisterOnChange([this](const journal::Entry& e) { OnJournalEntry(e); });
   }
 
   sfile_.reset(new io::StringFile);
-
   rdb_serializer_.reset(new RdbSerializer(sfile_.get()));
 
-  fb_ = fiber([this] {
-    FiberFunc();
+  snapshot_fb_ = fiber([this, stream_journal] {
+    SerializeEntriesFb();
+    if (!stream_journal) {
+      CloseRecordChannel();
+    }
     db_slice_->UnregisterOnChange(snapshot_version_);
-    if (journal_cb_id_)
-      db_slice_->shard_owner()->journal()->Unregister(journal_cb_id_);
   });
 }
 
-void SliceSnapshot::Join() {
-  fb_.join();
-}
+void SliceSnapshot::Stop() {
+  // Wait for serialization to finish in any case.
+  Join();
 
-// This function should not block and should not preempt because it's called
-// from SerializePhysicalBucket which should execute atomically.
-void SliceSnapshot::SerializeSingleEntry(DbIndex db_indx, const PrimeKey& pk, const PrimeValue& pv,
-                                         RdbSerializer* serializer) {
-  time_t expire_time = 0;
-
-  if (pv.HasExpire()) {
-    auto eit = db_array_[db_indx]->expire.Find(pk);
-    expire_time = db_slice_->ExpireTime(eit);
+  if (journal_cb_id_) {
+    db_slice_->shard_owner()->journal()->Unregister(journal_cb_id_);
   }
 
-  io::Result<uint8_t> res = serializer->SaveEntry(pk, pv, expire_time);
-  CHECK(res);  // we write to StringFile.
-  ++type_freq_map_[*res];
+  FlushSfile(true);
+  CloseRecordChannel();
+}
+
+void SliceSnapshot::Join() {
+  // Fiber could have already been joined by Stop.
+  if (snapshot_fb_.joinable())
+    snapshot_fb_.join();
 }
 
 // Serializes all the entries with version less than snapshot_version_.
-void SliceSnapshot::FiberFunc() {
+void SliceSnapshot::SerializeEntriesFb() {
   this_fiber::properties<FiberProps>().set_name(
       absl::StrCat("SliceSnapshot", ProactorBase::GetIndex()));
   PrimeTable::Cursor cursor;
@@ -124,14 +122,36 @@ void SliceSnapshot::FiberFunc() {
     FlushSfile(true);
   }  // for (dbindex)
 
+  // Wait for SerializePhysicalBucket to finish.
+  mu_.lock();
+  mu_.unlock();
+
+  VLOG(1) << "Exit SnapshotSerializer (serialized/side_saved/cbcalls): " << serialized_ << "/"
+          << side_saved_ << "/" << savecb_calls_;
+}
+
+void SliceSnapshot::CloseRecordChannel() {
   // stupid barrier to make sure that SerializePhysicalBucket finished.
   // Can not think of anything more elegant.
   mu_.lock();
   mu_.unlock();
   dest_->StartClosing();
+}
 
-  VLOG(1) << "Exit SnapshotSerializer (serialized/side_saved/cbcalls): " << serialized_ << "/"
-          << side_saved_ << "/" << savecb_calls_;
+// This function should not block and should not preempt because it's called
+// from SerializePhysicalBucket which should execute atomically.
+void SliceSnapshot::SerializeSingleEntry(DbIndex db_indx, const PrimeKey& pk, const PrimeValue& pv,
+                                         RdbSerializer* serializer) {
+  time_t expire_time = 0;
+
+  if (pv.HasExpire()) {
+    auto eit = db_array_[db_indx]->expire.Find(pk);
+    expire_time = db_slice_->ExpireTime(eit);
+  }
+
+  io::Result<uint8_t> res = serializer->SaveEntry(pk, pv, expire_time);
+  CHECK(res);  // we write to StringFile.
+  ++type_freq_map_[*res];
 }
 
 bool SliceSnapshot::FlushSfile(bool force) {
@@ -217,15 +237,13 @@ void SliceSnapshot::OnJournalEntry(const journal::Entry& entry) {
 
   if (entry.db_ind == savecb_current_db_) {
     ++num_records_in_blob_;
-    io::Result<uint8_t> res =
-        rdb_serializer_->SaveEntry(pkey, *entry.pval_ptr, entry.expire_ms);
+    io::Result<uint8_t> res = rdb_serializer_->SaveEntry(pkey, *entry.pval_ptr, entry.expire_ms);
     CHECK(res);  // we write to StringFile.
   } else {
     io::StringFile sfile;
     RdbSerializer tmp_serializer(&sfile);
 
-    io::Result<uint8_t> res =
-        tmp_serializer.SaveEntry(pkey, *entry.pval_ptr, entry.expire_ms);
+    io::Result<uint8_t> res = tmp_serializer.SaveEntry(pkey, *entry.pval_ptr, entry.expire_ms);
     CHECK(res);  // we write to StringFile.
 
     error_code ec = tmp_serializer.FlushMem();

--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -36,7 +36,10 @@ class SliceSnapshot {
   SliceSnapshot(DbSlice* slice, RecordChannel* dest);
   ~SliceSnapshot();
 
-  void Start(bool include_journal_changes);
+  void Start(bool stream_journal);
+
+  void Stop(); // only needs to be called in journal streaming mode.
+
   void Join();
 
   uint64_t snapshot_version() const {
@@ -56,12 +59,16 @@ class SliceSnapshot {
   }
 
  private:
-  void FiberFunc();
-  bool FlushSfile(bool force);
+  void CloseRecordChannel();
+
+  void SerializeEntriesFb();
+  
   void SerializeSingleEntry(DbIndex db_index, const PrimeKey& pk, const PrimeValue& pv,
                             RdbSerializer* serializer);
 
+  bool FlushSfile(bool force);
   bool SaveCb(PrimeIterator it);
+
   void OnDbChange(DbIndex db_index, const DbSlice::ChangeReq& req);
   void OnJournalEntry(const journal::Entry& entry);
 
@@ -70,25 +77,27 @@ class SliceSnapshot {
   unsigned SerializePhysicalBucket(DbIndex db_index, PrimeTable::bucket_iterator it);
   DbRecord GetDbRecord(DbIndex db_index, std::string value, unsigned num_records);
 
-  ::boost::fibers::fiber fb_;
-
+  DbSlice* db_slice_;
   DbTableArray db_array_;
   RdbTypeFreqMap type_freq_map_;
 
   std::unique_ptr<io::StringFile> sfile_;
   std::unique_ptr<RdbSerializer> rdb_serializer_;
-  boost::fibers::mutex mu_;
+  RecordChannel* dest_;
 
+  boost::fibers::mutex mu_;
   // version upper bound for entries that should be saved (not included).
   uint64_t snapshot_version_ = 0;
-  DbSlice* db_slice_;
   DbIndex savecb_current_db_;  // used by SaveCb
-  RecordChannel* dest_;
-  ::size_t channel_bytes_ = 0;
+  
+  size_t channel_bytes_ = 0;
   size_t serialized_ = 0, skipped_ = 0, side_saved_ = 0, savecb_calls_ = 0;
   uint64_t rec_id_ = 0;
   uint32_t num_records_in_blob_ = 0;
+  
   uint32_t journal_cb_id_ = 0;
+
+  ::boost::fibers::fiber snapshot_fb_;
 };
 
 }  // namespace dfly


### PR DESCRIPTION
Migrating replication branch on main, part 3

Mixed implementation

* Split slice snapshot flow into start and optional stop
* Split rdb saver into start and optional stop
* Tidy code a bit

This two-phase snapshotting is needed by the stable state mvp