### PR TITLE
fix: "wrong number of arguments" must be in lower case

### DIFF
--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -51,7 +51,9 @@ ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
 #undef ADD
 
 string WrongNumArgsError(string_view cmd) {
-  return absl::StrCat("wrong number of arguments for '", cmd, "' command");
+  string lcmd(cmd);
+  absl::AsciiStrToLower(&lcmd);
+  return absl::StrCat("wrong number of arguments for '", lcmd, "' command");
 }
 
 string InvalidExpireTime(string_view cmd) {

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -55,7 +55,7 @@ string WrongNumArgsError(string_view cmd) {
 }
 
 string InvalidExpireTime(string_view cmd) {
-  return absl::StrCat("invalid expire time in '", cmd, "' command");
+  return absl::StrCat("invalid expire time in '", absl::AsciiStrToLower(cmd), "' command");
 }
 
 string UnknownSubCmd(string_view subcmd, string_view cmd) {

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -51,9 +51,7 @@ ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
 #undef ADD
 
 string WrongNumArgsError(string_view cmd) {
-  string lcmd(cmd);
-  absl::AsciiStrToLower(&lcmd);
-  return absl::StrCat("wrong number of arguments for '", lcmd, "' command");
+  return absl::StrCat("wrong number of arguments for '", absl::AsciiStrToLower(cmd), "' command");
 }
 
 string InvalidExpireTime(string_view cmd) {


### PR DESCRIPTION
Signed-off-by: Leonardo Mello <lsvmello@gmail.com>

This fixes https://github.com/dragonflydb/dragonfly/issues/390.

Since the print pointed out just the "wrong number of arguments" message I lowered the command just for the `WrongNumArgsError` function.

Should the command also be lowered on `InvalidExpireTime` and `UnknownSubCmd`? If that's the case then is it ok to create a `ToLower` function for `string_view` types on the `facade.cc` or is it better to put it on another file?

I couldn't execute the `facade_test` also, it compiles but doesn't create any executable.

First open source PR ever so if there is any improvement just say it and  I'll be glad work on it.