### PR TITLE
fix: "wrong number of arguments" must be in lower case

### DIFF
--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -51,11 +51,11 @@ ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
 #undef ADD
 
 string WrongNumArgsError(string_view cmd) {
-  return absl::StrCat("wrong number of arguments for '", cmd, "' command");
+  return absl::StrCat("wrong number of arguments for '", absl::AsciiStrToLower(cmd), "' command");
 }
 
 string InvalidExpireTime(string_view cmd) {
-  return absl::StrCat("invalid expire time in '", cmd, "' command");
+  return absl::StrCat("invalid expire time in '", absl::AsciiStrToLower(cmd), "' command");
 }
 
 string UnknownSubCmd(string_view subcmd, string_view cmd) {


### PR DESCRIPTION
Signed-off-by: Leonardo Mello [lsvmello@gmail.com](mailto:lsvmello@gmail.com)

This fixes https://github.com/dragonflydb/dragonfly/issues/390.

Created a new branch to join the commits as requested in https://github.com/dragonflydb/dragonfly/pull/438. I'm not confortable with `git rebase` yet, sorry.

Just as a recap: this sets the command name to lowercase on WrongNumArgsError and InvalidExpireTime functions.