### PR TITLE
feat(server): Support for LIMIT and REV in ZRANGE #422

### DIFF
--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1233,7 +1233,7 @@ void ZSetFamily::ZRange(CmdArgList args, ConnectionContext* cntx) {
       if (!SimpleAtoi(os, &range_params.offset) || !SimpleAtoi(cs, &range_params.limit)) {
         return (*cntx)->SendError(kInvalidIntErr);
       }
-      i += 3;
+      i += 2;
     } else {
       return cntx->reply_builder()->SendError(absl::StrCat("unsupported option ", cur_arg));
     }

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1625,7 +1625,7 @@ bool ZSetFamily::ParseRangeByScoreParams(CmdArgList args, RangeParams* params) {
     if (cur_arg == "WITHSCORES") {
       params->with_scores = true;
     } else if (cur_arg == "LIMIT") {
-      if (i + 3 != args.size())
+      if (i + 3 > args.size())
         return false;
 
       string_view os = ArgS(args, i + 1);
@@ -1633,7 +1633,7 @@ bool ZSetFamily::ParseRangeByScoreParams(CmdArgList args, RangeParams* params) {
 
       if (!SimpleAtoi(os, &params->offset) || !SimpleAtoi(cs, &params->limit))
         return false;
-      i += 3;
+      i += 2;
     } else {
       return false;
     }

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1225,7 +1225,7 @@ void ZSetFamily::ZRange(CmdArgList args, ConnectionContext* cntx) {
     } else if (cur_arg == "WITHSCORES") {
       range_params.with_scores = true;
     } else if (cur_arg == "LIMIT") {
-      if (i + 3 != args.size()) {
+      if (i + 3 > args.size()) {
         return (*cntx)->SendError(kSyntaxErr);
       }
       string_view os = ArgS(args, i + 1);

--- a/src/server/zset_family.h
+++ b/src/server/zset_family.h
@@ -29,7 +29,7 @@ class ZSetFamily {
 
   struct LexBound {
     std::string_view val;
-    enum Type {PLUS_INF, MINUS_INF, OPEN, CLOSED} type = CLOSED;
+    enum Type { PLUS_INF, MINUS_INF, OPEN, CLOSED } type = CLOSED;
   };
 
   using LexInterval = std::pair<LexBound, LexBound>;
@@ -41,6 +41,7 @@ class ZSetFamily {
     uint32_t limit = UINT32_MAX;
     bool with_scores = false;
     bool reverse = false;
+    enum INTERVALTYPE { LEX, RANK, SCORE } interval_type = RANK;
   };
 
   struct ZRangeSpec {
@@ -68,6 +69,8 @@ class ZSetFamily {
   static void ZScore(CmdArgList args, ConnectionContext* cntx);
   static void ZMScore(CmdArgList args, ConnectionContext* cntx);
   static void ZRangeByLex(CmdArgList args, ConnectionContext* cntx);
+  static void ZRevRangeByLex(CmdArgList args, ConnectionContext* cntx);
+  static void ZRangeByLexInternal(CmdArgList args, bool reverse, ConnectionContext* cntx);
   static void ZRangeByScore(CmdArgList args, ConnectionContext* cntx);
   static void ZRemRangeByRank(CmdArgList args, ConnectionContext* cntx);
   static void ZRemRangeByScore(CmdArgList args, ConnectionContext* cntx);
@@ -78,14 +81,12 @@ class ZSetFamily {
   static void ZScan(CmdArgList args, ConnectionContext* cntx);
   static void ZUnionStore(CmdArgList args, ConnectionContext* cntx);
 
-  static void ZRangeByScoreInternal(std::string_view key, std::string_view min_s,
-                                    std::string_view max_s, const RangeParams& params,
-                                    ConnectionContext* cntx);
+  static void ZRangeByScoreInternal(CmdArgList args, bool reverse, ConnectionContext* cntx);
   static void OutputScoredArrayResult(const OpResult<ScoredArray>& arr, const RangeParams& params,
                                       ConnectionContext* cntx);
   static void ZRemRangeGeneric(std::string_view key, const ZRangeSpec& range_spec,
                                ConnectionContext* cntx);
-  static void ZRangeGeneric(CmdArgList args, bool reverse, ConnectionContext* cntx);
+  static void ZRangeGeneric(CmdArgList args, RangeParams range_params, ConnectionContext* cntx);
   static void ZRankGeneric(CmdArgList args, bool reverse, ConnectionContext* cntx);
   static bool ParseRangeByScoreParams(CmdArgList args, RangeParams* params);
   static void ZPopMinMax(CmdArgList args, bool reverse, ConnectionContext* cntx);
@@ -96,7 +97,7 @@ class ZSetFamily {
                                   std::string_view member);
   using MScoreResponse = std::vector<std::optional<double>>;
   static OpResult<MScoreResponse> OpMScore(const OpArgs& op_args, std::string_view key,
-                                  ArgSlice members);
+                                           ArgSlice members);
   static OpResult<ScoredArray> OpPopCount(const ZRangeSpec& range_spec, const OpArgs& op_args,
                                           std::string_view key);
   static OpResult<ScoredArray> OpRange(const ZRangeSpec& range_spec, const OpArgs& op_args,
@@ -112,7 +113,6 @@ class ZSetFamily {
 
   static OpResult<unsigned> OpLexCount(const OpArgs& op_args, std::string_view key,
                                        const LexInterval& interval);
-
 };
 
 }  // namespace dfly

--- a/src/server/zset_family.h
+++ b/src/server/zset_family.h
@@ -41,7 +41,7 @@ class ZSetFamily {
     uint32_t limit = UINT32_MAX;
     bool with_scores = false;
     bool reverse = false;
-    enum INTERVALTYPE { LEX, RANK, SCORE } interval_type = RANK;
+    enum IntervalType { LEX, RANK, SCORE } interval_type = RANK;
   };
 
   struct ZRangeSpec {

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -78,7 +78,15 @@ TEST_F(ZSetFamilyTest, ZRangeRank) {
   EXPECT_THAT(Run({"zrangebyscore", "x", "0", "(1.1"}), ArrLen(0));
   EXPECT_THAT(Run({"zrangebyscore", "x", "-inf", "1.1", "limit", "0", "10"}), "a");
 
-  auto resp = Run({"zrevrangebyscore", "x", "+inf", "-inf", "limit", "0", "5"});
+  auto resp = Run({"zrangebyscore", "x", "-inf", "1.1", "limit", "0", "10", "WITHSCORES"});
+  ASSERT_THAT(resp, ArrLen(2));
+  ASSERT_THAT(resp.GetVec(), ElementsAre("a", "1.1"));
+
+  resp = Run({"zrangebyscore", "x", "-inf", "1.1", "WITHSCORES", "limit", "0", "10"});
+  ASSERT_THAT(resp, ArrLen(2));
+  ASSERT_THAT(resp.GetVec(), ElementsAre("a", "1.1"));
+
+  resp = Run({"zrevrangebyscore", "x", "+inf", "-inf", "limit", "0", "5"});
   ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
   ASSERT_THAT(resp.GetVec(), ElementsAre("b", "a"));
 

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -200,9 +200,9 @@ TEST_F(ZSetFamilyTest, ZRange) {
   ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
   EXPECT_THAT(resp.GetVec(), ElementsAre("great", "foo"));
 
-
   resp = Run({"zrange", "key", "+", "[cool", "BYLEX", "LIMIT", "2", "2", "REV"});
-  EXPECT_THAT(resp, ErrArg("syntax error"));
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  EXPECT_THAT(resp.GetVec(), ElementsAre("great", "foo"));
 }
 
 TEST_F(ZSetFamilyTest, ZRevRange) {


### PR DESCRIPTION
Closes #422

Since the new ZRange regroups all the other (now deprecated) ZRange functions, I did some refactoring to avoid duplicating code from these functions. This made it possible to have support for ZRevRangeByLex for free, since the visitor function already supported it.
Also spotted and corrected an error in ZRangeByLex when parsing the offset parameter.

There are some unrelated formatting changes that were added by clang-format.