### PR TITLE
ci: added clang pre-commit hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,31 @@ on:
   # push:
   # branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Debug
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-python@v3
+      - name: Install dependencies
+        run: |
+          python -m pip install pre-commit
+          python -m pip freeze --local
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Run pre-commit checks
+        run: pre-commit run --show-diff-on-failure --color=always --from-ref HEAD^ --to-ref HEAD
+        shell: bash
   build:
     # The CMake configure and build commands are platform agnostic and should work equally
     # well on Windows or Mac.  You can convert this to a matrix build if you need
@@ -22,45 +40,45 @@ jobs:
         # Test of these containers
         container: ["ubuntu-dev:20", "alpine-dev:latest"]
     timeout-minutes: 30
-    container: 
+    container:
       image: ghcr.io/romange/${{ matrix.container }}
       # credentials:
       #  username: ${{ github.repository_owner }}
       #  password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - name: Install dependencies
-      run: |
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Install dependencies
+        run: |
           uname -a
           cmake --version
           mkdir -p ${{github.workspace}}/build
-    - name: Cache build deps
-      id: cache-deps
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.ccache
-          ${{github.workspace}}/build/_deps
-        key: ${{ runner.os }}-deps-${{ github.base_ref }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-deps-${{ github.base_ref }}-
-          
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: |
+      - name: Cache build deps
+        id: cache-deps
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.ccache
+            ${{github.workspace}}/build/_deps
+          key: ${{ runner.os }}-deps-${{ github.base_ref }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-deps-${{ github.base_ref }}-
+
+      - name: Configure CMake
+        # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+        # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+        run: |
           cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           cd ${{github.workspace}}/build && pwd
           du -hcs _deps/
-    - name: Build & Test      
-      run: |
+      - name: Build & Test
+        run: |
           cd ${{github.workspace}}/build
           ninja src/all
           ccache --show-stats
           GLOG_logtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1 ctest -V -R rdb_test
           echo Run ctest -V -L DFLY
-          #GLOG_logtostderr=1 GLOG_vmodule=transaction=1,engine_shard_set=1 
+          #GLOG_logtostderr=1 GLOG_vmodule=transaction=1,engine_shard_set=1
           GLOG_logtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=2,snapshot=2 ctest -V -L DFLY
           # GLOG_logtostderr=1 GLOG_vmodule=transaction=1,engine_shard_set=1 CTEST_OUTPUT_ON_FAILURE=1 ninja server/test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+default_stages: [commit]
 repos:
   - repo: local
     hooks:
@@ -10,5 +11,11 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:
-    - id: trailing-whitespace
-    - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v14.0.6
+    hooks:
+      - id: clang-format
+        name: Clang formatting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,12 +23,15 @@ cd build-dbg && ninja dragonfly
 ```sh
 cd dragonfly   # project root
 
+# Make sure you have 'pre-commit' e 'clang-format' installed
+pip install pre-commit clang-format
+
 # IMPORTANT! Enable our pre-commit message hooks
 # This will ensure your commits match our formatting requirements
-pre-commit install --hook-type commit-msg
+pre-commit install
 ```
 
-This step must be done on each machine you wish to develop and contribute from to activate the `commit-msg` hook client-side.
+This step must be done on each machine you wish to develop and contribute from to activate the `commit-msg` and `commit` hooks client-side.
 
 Once you have done these things, we look forward to adding your contributions and improvements to the Dragonfly DB project.
 


### PR DESCRIPTION
Signed-off-by: Leonardo Mello <lsvmello@gmail.com>

Closes https://github.com/dragonflydb/dragonfly/issues/200

- Added `clang-format` in `.pre-commit-config.yaml`
- Updated `CONTRIBUTING.md` with  `pre-commit` and `clang-format` installation script 

I ran `pre-commit run --all-files` but it change more than 100 files, so I didn't commit that change.
The `pre-commit` runs only on staged files, so the fixes can be done incrementally.