### PR TITLE
fix(list): Fixes blpop failure.

### DIFF
--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -164,12 +164,18 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
     }
   }
 
-  bool has_awaked_trans = blocking_controller_ && blocking_controller_->HasAwakedTransaction();
   Transaction* head = nullptr;
   string dbg_id;
 
-  if (continuation_trans_ == nullptr && !has_awaked_trans) {
+  if (continuation_trans_ == nullptr) {
     while (!txq_.Empty()) {
+      // we must check every iteration so that if the current transaction awakens
+      // another transaction, the loop won't proceed further and will break, because we must run
+      // the notified transaction before all other transactions in the queue can proceed.
+      bool has_awaked_trans = blocking_controller_ && blocking_controller_->HasAwakedTransaction();
+      if (has_awaked_trans)
+        break;
+
       auto val = txq_.Front();
       head = absl::get<Transaction*>(val);
 
@@ -212,13 +218,12 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
         break;
       }
     }       // while(!txq_.Empty())
-  } else {  // if (continuation_trans_ == nullptr && !has_awaked_trans)
-    DVLOG(1) << "Skipped TxQueue " << continuation_trans_ << " " << has_awaked_trans;
+  } else {  // if (continuation_trans_ == nullptr)
+    DVLOG(1) << "Skipped TxQueue " << continuation_trans_;
   }
 
   // we need to run trans if it's OOO or when trans is blocked in this shard and should
   // be treated here as noop.
-  // trans is OOO, it it locked keys that previous transactions have not locked yet.
   bool should_run = trans_mask & (Transaction::OUT_OF_ORDER | Transaction::SUSPENDED_Q);
 
   // It may be that there are other transactions that touch those keys but they necessary ordered

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1137,7 +1137,8 @@ bool Transaction::NotifySuspended(TxId committed_txid, ShardId sid) {
     return false;
   }
 
-  DVLOG(1) << "NotifySuspended " << DebugId() << ", local_mask:" << local_mask;
+  DVLOG(1) << "NotifySuspended " << DebugId() << ", local_mask:" << local_mask
+           << " by " << committed_txid;
 
   // local_mask could be awaked (i.e. not suspended) if the transaction has been
   // awakened by another key or awakened by the same key multiple times.


### PR DESCRIPTION
The bug was that if two push operations where queued together in the tx queue, and the first push awakes pending blpop, then the PollExecution function would continue with the second push before switching to blpop, which contradicts the spec.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->