### PR TITLE
feat(server): simplify handling of the pub message handling

### DIFF
--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -56,11 +56,12 @@ class Connection : public util::Connection {
     // if empty - means its a regular message, otherwise it's pmessage.
     std::string_view pattern;
     std::string_view channel;
-    std::string_view message;
+    std::shared_ptr<const std::string> message;  // ensure that this message would out live passing
+                                                 // between different threads/fibers
   };
 
   // this function is overriden at test_utils TestConnection
-  virtual void SendMsgVecAsync(const PubMessage& pub_msg, util::fibers_ext::BlockingCounter bc);
+  virtual void SendMsgVecAsync(const PubMessage& pub_msg);
 
   // Please note, this accept the message by value, since we really want to
   // create a new copy here, so that we would not need to "worry" about memory

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -540,7 +540,7 @@ TEST_F(DflyEngineTest, PSubscribe) {
   ASSERT_EQ(1, SubscriberMessagesLen("IO1"));
 
   facade::Connection::PubMessage msg = GetPublishedMessage("IO1", 0);
-  EXPECT_EQ("foo", msg.message);
+  EXPECT_EQ("foo", *msg.message);
   EXPECT_EQ("ab", msg.channel);
   EXPECT_EQ("a*", msg.pattern);
 }
@@ -603,7 +603,7 @@ TEST_F(DflyEngineTest, Watch) {
 
   // Check watch on non-existent key.
   Run({"del", "b"});
-  EXPECT_EQ(Run({"watch", "b"}), "OK"); // didn't exist yet
+  EXPECT_EQ(Run({"watch", "b"}), "OK");  // didn't exist yet
   Run({"set", "b", "1"});
   Run({"multi"});
   ASSERT_THAT(Run({"exec"}), kExecFail);
@@ -634,10 +634,10 @@ TEST_F(DflyEngineTest, Watch) {
   // Check EXPIRE + new key.
   Run({"set", "a", "1"});
   Run({"del", "c"});
-  Run({"watch", "c"}); // didn't exist yet
+  Run({"watch", "c"});  // didn't exist yet
   Run({"watch", "a"});
   Run({"set", "c", "1"});
-  Run({"expire", "a", "1"}); // a existed
+  Run({"expire", "a", "1"});  // a existed
 
   AdvanceTime(1000);
 
@@ -664,7 +664,7 @@ TEST_F(DflyEngineTest, Watch) {
   Run({"set", "a", "1"});
   Run({"watch", "a"});
   Run({"select", "1"});
-  Run({"set", "a", "2"}); // changing a on db 1
+  Run({"set", "a", "2"});  // changing a on db 1
   Run({"select", "0"});
   Run({"multi"});
   ASSERT_THAT(Run({"exec"}), kExecSuccess);

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -16,14 +16,13 @@ extern "C" {
 #include "base/logging.h"
 #include "base/stl_util.h"
 #include "facade/dragonfly_connection.h"
-#include "util/uring/uring_pool.h"
 #include "util/epoll/epoll_pool.h"
+#include "util/uring/uring_pool.h"
 
 using namespace std;
 
 ABSL_DECLARE_FLAG(string, dbfilename);
 ABSL_FLAG(bool, force_epoll, false, "If true, uses epoll api instead iouring to run tests");
-
 
 namespace dfly {
 
@@ -47,21 +46,19 @@ TestConnection::TestConnection(Protocol protocol)
     : facade::Connection(protocol, nullptr, nullptr, nullptr) {
 }
 
-void TestConnection::SendMsgVecAsync(const PubMessage& pmsg, util::fibers_ext::BlockingCounter bc) {
+void TestConnection::SendMsgVecAsync(const PubMessage& pmsg) {
   backing_str_.emplace_back(new string(pmsg.channel));
   PubMessage dest;
   dest.channel = *backing_str_.back();
 
-  backing_str_.emplace_back(new string(pmsg.message));
-  dest.message = *backing_str_.back();
+  backing_str_.emplace_back(new string(*pmsg.message));
+  dest.message = pmsg.message;
 
   if (!pmsg.pattern.empty()) {
     backing_str_.emplace_back(new string(pmsg.pattern));
     dest.pattern = *backing_str_.back();
   }
   messages.push_back(dest);
-
-  bc.Dec();
 }
 
 class BaseFamilyTest::TestConnWrapper {
@@ -139,9 +136,7 @@ void BaseFamilyTest::SetUp() {
   service_->Init(nullptr, nullptr, opts);
 
   TEST_current_time_ms = absl::GetCurrentTimeNanos() / 1000000;
-  auto cb = [&](EngineShard* s) {
-    s->db_slice().UpdateExpireBase(TEST_current_time_ms - 1000, 0);
-  };
+  auto cb = [&](EngineShard* s) { s->db_slice().UpdateExpireBase(TEST_current_time_ms - 1000, 0); };
   shard_set->RunBriefInParallel(cb);
 
   const TestInfo* const test_info = UnitTest::GetInstance()->current_test_info();
@@ -159,7 +154,7 @@ void BaseFamilyTest::TearDown() {
 
 void BaseFamilyTest::WaitUntilLocked(DbIndex db_index, string_view key, double timeout) {
   auto step = 50us;
-  auto timeout_micro = chrono::duration_cast<chrono::microseconds> (1000ms * timeout);
+  auto timeout_micro = chrono::duration_cast<chrono::microseconds>(1000ms * timeout);
   int64_t steps = timeout_micro.count() / step.count();
   do {
     ::boost::this_fiber::sleep_for(step);

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -21,7 +21,7 @@ class TestConnection : public facade::Connection {
  public:
   TestConnection(Protocol protocol);
 
-  void SendMsgVecAsync(const PubMessage& pmsg, util::fibers_ext::BlockingCounter bc) final;
+  void SendMsgVecAsync(const PubMessage& pmsg) final;
 
   std::vector<PubMessage> messages;
 

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -1,3 +1,4 @@
+import random
 import pytest
 import asyncio
 import aioredis
@@ -30,21 +31,31 @@ def verify_response(monitor_response: dict, key: str, value: str) -> bool:
         return False
 
 
+async def process_cmd(monitor, key, value):
+    while True:
+        try:
+            async with async_timeout.timeout(1):
+                response = await monitor.next_command()
+                if "select" not in response["command"].lower():
+                    success = verify_response(response, key, value)
+                    if not success:
+                        print(f"failed to verfiy message {response} for {key}/{value}")
+                        return False, f"failed on the verification of the message {response} at {key}: {value}"
+                        #await asyncio.sleep(0.01)
+                    else:
+                        return True, None
+        except asyncio.TimeoutError:
+            pass
+
+
 async def monitor_cmd(mon: aioredis.client.Monitor, messages: dict):
     success = None
     async with mon as monitor:
         try:
             for key, value in messages.items():
-                try:
-                    async with async_timeout.timeout(1):
-                        response = await monitor.next_command()
-                        success = verify_response(
-                            response, key, value)
-                        if not success:
-                            return False, f"failed on the verification of the message {response} at {key}: {value}"
-                        await asyncio.sleep(0.01)
-                except asyncio.TimeoutError:
-                    pass
+                state, msg = await process_cmd(monitor, key, value)
+                if not state:
+                    return state, msg
             return True, "monitor is successfully done"
         except Exception as e:
             return False, f"stopping monitor on {e}"
@@ -56,12 +67,14 @@ async def run_monitor(messages: dict, pool: aioredis.ConnectionPool):
     monitor = conn.monitor()
     future = asyncio.create_task(monitor_cmd(monitor, messages))
     success = True
+
+    # make sure that the monitor task starts before we're sending anything else!
+    await asyncio.sleep(0.01)
     for key, val in messages.items():
         res = await cmd1.set(key, val)
         if not res:
             success = False
             break
-        await asyncio.sleep(0.01)
     await asyncio.sleep(0.01)
     await future
     status, message = future.result()
@@ -88,7 +101,7 @@ async def test_pipeline_support(async_client):
     assert await run_pipeline_mode(async_client, messages)
 
 
-async def reader(channel: aioredis.client.PubSub, messages):
+async def reader(channel: aioredis.client.PubSub, messages, max: int):
     message_count = len(messages)
     while message_count > 0:
         try:
@@ -141,7 +154,7 @@ async def run_pubsub(async_client, messages, channel_name):
     pubsub = async_client.pubsub()
     await pubsub.subscribe(channel_name)
 
-    future = asyncio.create_task(reader(pubsub, messages))
+    future = asyncio.create_task(reader(pubsub, messages, len(messages)))
     success = True
 
     for message in messages:
@@ -158,3 +171,53 @@ async def run_pubsub(async_client, messages, channel_name):
         return True, "successfully completed all"
     else:
         return False, f"subscriber result: {status}: {message},  publisher publish: success {success}"
+
+
+async def run_multi_pubsub(async_client, messages, channel_name):
+    subs = [async_client.pubsub() for i in range(5)]
+    for s in subs:
+        await s.subscribe(channel_name)
+
+    tasks = [
+        asyncio.create_task(reader(s, messages, random.randint(0, len(messages)))) for s in subs]
+
+    success = True
+
+    for message in messages:
+        res = await async_client.publish(channel_name, message)
+        if not res:
+            success = False
+            break
+
+    for f in tasks:
+        await f
+    results = [f.result() for f in tasks]
+
+    for s in subs:
+        await s.close()
+    if success:
+        for status, message in results:
+            if not status:
+                return False,  f"failed to process {message}"
+        return True, "success"
+    else:
+        return False, "failed to publish"
+
+
+'''
+Test with multiple subscribers for a channel
+We want to stress this to see if we have any issue
+with the pub sub code since we are "sharing" the message
+across multiple connections internally
+'''
+
+
+@pytest.mark.asyncio
+async def test_multi_pubsub(async_client):
+    def generate(max):
+        for i in range(max):
+            yield f"this is message number {i} from the publisher on the channel"
+    messages = [a for a in generate(500)]
+    state, message = await run_multi_pubsub(async_client, messages, "my-channel")
+
+    assert state, message


### PR DESCRIPTION
Signed-off-by: Boaz Sade <boaz@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
This remove the need to have "borrow tokens" to messages that are sending over pub channel.
It replaces it with a "simple share_ptr that would be cleaned once we are done with all the instances that are holding it.
Also added a system test that opens up few connections and subscribe to it and sending multiple messages to all subscribes.
This is done in hope that it would catch any memory issue that may happen in case there is an issue with this impl.