### PR TITLE
fix(server): reject eval inside transaction multi blocks #457

### DIFF
--- a/tests/dragonfly/server_family_test.py
+++ b/tests/dragonfly/server_family_test.py
@@ -20,3 +20,35 @@ def test_quit_after_sub(connection):
 
     with pytest.raises(redis.exceptions.ConnectionError) as e:
         connection.read_response()
+
+
+def test_multi_exec(client):
+    pipeline = client.pipeline()
+    pipeline.set("foo", "bar")
+    pipeline.get("foo")
+    val = pipeline.execute()
+    assert val == [True, "bar"]
+
+
+'''
+see https://github.com/dragonflydb/dragonfly/issues/457
+For now we would not allow for eval command inside multi
+As this would create to level transactions (in effect recursive call
+to Schedule function).
+When this issue is fully fixed, this test would failed, and then it should
+change to match the fact that we supporting this operation.
+For now we are expecting to get an error
+'''
+def test_multi_eval(client):
+    try:
+        pipeline = client.pipeline()
+        pipeline.set("foo", "bar")
+        pipeline.get("foo")
+        pipeline.eval("return 43", 0)
+        assert True, "This part should not executed due to issue #457"
+
+        val = pipeline.execute()
+        assert val == "foo"
+    except Exception as e:
+        msg = str(e)
+        assert "Dragonfly does not allow execution of" in msg

--- a/tests/integration/.patch_ioredis.sh
+++ b/tests/integration/.patch_ioredis.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-# This script is only temporary until issue https://github.com/luin/ioredis/issues/1671 is resolved (hopefully soon)
-# what we are doing here, is making sure that we would not compare the result case sensitive.
-sed -i 's/expect(args\[0\]).to.eql("get")/expect(args\[0\]).to.match(\/get\/i)/' $1
-sed -i 's/args\[0\] === "set"/args\[0\] === "set" || args\[0\] === "SET"/' $1

--- a/tests/integration/.run_ioredis_valid_test.sh
+++ b/tests/integration/.run_ioredis_valid_test.sh
@@ -2,15 +2,12 @@
 
 # The following tests are not supported
 #"should reconnect if reconnectOnError
-# should reload scripts on redis restart
-# should check and load uniq scripts only
 # supported in transaction blocks
-# rejects when monitor is disabled"
+# rejects when monitor is disabled
 # should resend unfulfilled commands to the correct
 # should set the name before any subscribe
 # should name the connection if options
 # scanStream
-# scripting
 # should affect the old way
 # should support Map
 # should support object
@@ -22,21 +19,14 @@
 # https://github.com/dragonflydb/dragonfly/issues/457
 # and https://github.com/dragonflydb/dragonfly/issues/458
 
-# The followng test will pass once https://github.com/luin/ioredis/issues/1671 is resolved:
-# should check and load uniq scripts only
-# should load scripts first before execution
-# should allow omitting callback
 
 # The follwing tests would pass once we support script flush command:
 # does not fallback to EVAL in manual transaction
 # does not fallback to EVAL in regular
-# should load scripts first before execution
 # should reload scripts on redis restart (reconnect)"
-
-
 
 
 TS_NODE_TRANSPILE_ONLY=true NODE_ENV=test mocha \
 "test/helpers/*.ts" "test/unit/**/*.ts" "test/functional/**/*.ts" \
--g "should reconnect if reconnectOnError|should reload scripts on redis restart|should check and load uniq scripts only|should be supported in transaction blocks|rejects when monitor is disabled|should resend unfulfilled commands to the correct|should set the name before any subscribe|should name the connection if options|scanStream|scripting|should affect the old way|should support Map|should support object|should batch all commands before ready event|should support key prefixing for sort|should be sent on the connect event" \
+-g "should reload scripts on redis restart|should reconnect if reconnectOnError|should be supported in transaction blocks|rejects when monitor is disabled|should resend unfulfilled commands to the correct|should set the name before any subscribe|should name the connection if options|scanStream|does not fallback to EVAL|should try to use EVALSHA and fallback to EVAL|should use evalsha when script|should affect the old way|should support Map|should support object|should batch all commands before ready event|should support key prefixing for sort|should be sent on the connect event" \
 --invert

--- a/tests/integration/ioredis.Dockerfile
+++ b/tests/integration/ioredis.Dockerfile
@@ -9,15 +9,13 @@ WORKDIR /app
 # Git
 RUN apt update -y && apt install -y git
 
-# Clone ioredis v5.2.3
-RUN git clone --branch v5.2.3 https://github.com/luin/ioredis
+# The latest version from io-redis contain changes that we need to have
+# to successfully run the tests
+RUN git clone https://github.com/luin/ioredis
 
 WORKDIR /app/ioredis
 
 RUN npm install
-
-# This is required until https://github.com/luin/ioredis/issues/1671 is resolved.
-ADD .patch_ioredis.sh patch_ioredis.sh
 
 # Script to run the tests that curretly pass successfully.
 # Note that in DF we still don't have support for cluster and we
@@ -26,9 +24,5 @@ ADD .patch_ioredis.sh patch_ioredis.sh
 # https://github.com/dragonflydb/dragonfly/issues/457
 # and https://github.com/dragonflydb/dragonfly/issues/458
 ADD .run_ioredis_valid_test.sh run_tests.sh
-
-# this would enable running monitor commands successfully
-# we may need to remove this incase we have other fix
-RUN ./patch_ioredis.sh test/functional/monitor.ts
 
 ENTRYPOINT [ "npm", "run", "env", "--", "TS_NODE_TRANSPILE_ONLY=true", "NODE_ENV=test" ]


### PR DESCRIPTION

Signed-off-by: Boaz Sade <boaz@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
This commit is meant to bypass issue #457 
This is not a fix but a workaround. There is a new issue #467 that is meat for fixing the root cause.
This one is only temporary solution of the issue. What it does is making sure that if we have "eval" inside "Multi" it would return an error to the user. The reason that this do not let users running scripts inside Multi is that this would cause transaction schedule function to be called recursively. This in turn will break the precondition for the function that is not to allow calling it from within the same schedule context. 
This PR just block this from happening by failing the multi in case the user sends eval in the list of commands.
This also update the list of the commands that we are processing for ioredis.
