### PR TITLE
feat(server): add support for KEEPTTL options with SET command #389

### DIFF
--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -383,7 +383,7 @@ OpStatus SetCmd::Set(const SetParams& params, string_view key, string_view value
   if (params.IsConditionalSet()) {
     const auto [it, expire_it] = db_slice.FindExt(op_args_.db_cntx, key);
     // Make sure that we have this key, and only add it if it does exists
-    if (params.how == SET_IF_EXISTS) {
+    if (params.flags & SET_IF_EXISTS) {
       if (IsValid(it)) {
         return SetExisting(params, it, expire_it, key, value);
       } else {
@@ -409,7 +409,7 @@ OpStatus SetCmd::Set(const SetParams& params, string_view key, string_view value
   if (!get<2>(add_res)) {  // Existing.
     return SetExisting(params, it, get<1>(add_res), key, value);
   }
-  //
+
   // Adding new value.
   PrimeValue tvalue{value};
   tvalue.SetFlag(params.memcache_flags != 0);
@@ -438,7 +438,7 @@ OpStatus SetCmd::Set(const SetParams& params, string_view key, string_view value
 
 OpStatus SetCmd::SetExisting(const SetParams& params, PrimeIterator it, ExpireIterator e_it,
                              string_view key, string_view value) {
-  if (params.how == SET_IF_NOTEXIST)
+  if (params.flags & SET_IF_NOTEXIST)
     return OpStatus::SKIPPED;
 
   PrimeValue& prime_value = it->second;
@@ -457,7 +457,7 @@ OpStatus SetCmd::SetExisting(const SetParams& params, PrimeIterator it, ExpireIt
       params.expire_after_ms ? params.expire_after_ms + op_args_.db_cntx.time_now_ms : 0;
   if (IsValid(e_it) && at_ms) {
     e_it->second = db_slice.FromAbsoluteTime(at_ms);
-  } else {
+  } else if (!(params.flags & SET_KEEP_EXPIRE)) {
     // We need to update expiry, or maybe erase the object if it was expired.
     bool changed = db_slice.UpdateExpire(op_args_.db_cntx.db_index, it, at_ms);
     if (changed && at_ms == 0)  // erased.
@@ -509,7 +509,10 @@ void StringFamily::Set(CmdArgList args, ConnectionContext* cntx) {
 
     string_view cur_arg = ArgS(args, i);
 
-    if (cur_arg == "EX" || cur_arg == "PX" || cur_arg == "EXAT" || cur_arg == "PXAT") {
+    if ((cur_arg == "EX" || cur_arg == "PX" || cur_arg == "EXAT" || cur_arg == "PXAT") &&
+        !(sparams.flags & SetCmd::SET_KEEP_EXPIRE) &&
+        !(sparams.flags & SetCmd::SET_EXPIRE_AFTER_MS)) {
+      sparams.flags |= SetCmd::SET_EXPIRE_AFTER_MS;
       bool is_ms = (cur_arg == "PX" || cur_arg == "PXAT");
       ++i;
       if (i == args.size()) {
@@ -546,12 +549,14 @@ void StringFamily::Set(CmdArgList args, ConnectionContext* cntx) {
         return builder->SendError(InvalidExpireTime("set"));
       }
       sparams.expire_after_ms = int_arg;
-    } else if (cur_arg == "NX") {
-      sparams.how = SetCmd::SET_IF_NOTEXIST;
-    } else if (cur_arg == "XX") {
-      sparams.how = SetCmd::SET_IF_EXISTS;
-    } else if (cur_arg == "KEEPTTL") {
-      sparams.keep_expire = true;  // TODO
+    } else if (cur_arg == "NX" && !(sparams.flags & SetCmd::SET_IF_EXISTS)) {
+      sparams.flags |= SetCmd::SET_IF_NOTEXIST;
+    } else if (cur_arg == "XX" && !(sparams.flags & SetCmd::SET_IF_NOTEXIST)) {
+      sparams.flags |= SetCmd::SET_IF_EXISTS;
+    } else if (cur_arg == "KEEPTTL" && !(sparams.flags & SetCmd::SET_EXPIRE_AFTER_MS)) {
+      sparams.flags |= SetCmd::SET_KEEP_EXPIRE;
+    } else if (cur_arg == "GET") {
+      sparams.flags |= SetCmd::SET_GET;
     } else {
       return builder->SendError(kSyntaxErr);
     }
@@ -585,7 +590,7 @@ void StringFamily::SetNx(CmdArgList args, ConnectionContext* cntx) {
   string_view value = ArgS(args, 2);
 
   SetCmd::SetParams sparams;
-  sparams.how = SetCmd::SET_IF_NOTEXIST;
+  sparams.flags |= SetCmd::SET_IF_NOTEXIST;
   sparams.memcache_flags = cntx->conn_state.memcache_flag;
   const auto results{SetGeneric(cntx, std::move(sparams), key, value)};
   SinkReplyBuilder* builder = cntx->reply_builder();

--- a/src/server/string_family.h
+++ b/src/server/string_family.h
@@ -22,19 +22,24 @@ class SetCmd {
   explicit SetCmd(const OpArgs& op_args) : op_args_(op_args) {
   }
 
-  enum SetHow { SET_ALWAYS, SET_IF_NOTEXIST, SET_IF_EXISTS };
+  enum SetFlags {
+    SET_ALWAYS = 0,
+    SET_IF_NOTEXIST = 1 << 0,    /* NX: Set if key not exists. */
+    SET_IF_EXISTS = 1 << 1,      /* XX: Set if key exists. */
+    SET_KEEP_EXPIRE = 1 << 2,    /* KEEPTTL: Set and keep the ttl */
+    SET_GET = 1 << 3,            /* GET: Set if want to get key before set */
+    SET_EXPIRE_AFTER_MS = 1 << 4 /* EX,PX,EXAT,PXAT: Expire after ms. */
+  };
 
   struct SetParams {
-    SetHow how = SET_ALWAYS;
-
-    uint32_t memcache_flags = 0;
+    uint16_t flags = SET_ALWAYS;
+    uint16_t memcache_flags = 0;
     // Relative value based on now. 0 means no expiration.
     uint64_t expire_after_ms = 0;
     mutable std::optional<std::string>* prev_val = nullptr;  // GETSET option
-    bool keep_expire = false;                                // KEEPTTL - TODO: to implement it.
 
     constexpr bool IsConditionalSet() const {
-      return how == SET_IF_NOTEXIST || how == SET_IF_EXISTS;
+      return flags & SET_IF_NOTEXIST || flags & SET_IF_EXISTS;
     }
   };
 

--- a/src/server/string_family_test.cc
+++ b/src/server/string_family_test.cc
@@ -92,6 +92,82 @@ TEST_F(StringFamilyTest, Expire) {
   ASSERT_THAT(Run({"incr", "i"}), IntArg(1));
 }
 
+TEST_F(StringFamilyTest, Keepttl) {
+  ASSERT_EQ(Run({"set", "key", "val", "EX", "100"}), "OK");
+  ASSERT_EQ(Run({"set", "key", "val"}), "OK");
+  auto resp = Run({"ttl", "key"});
+  auto actual = get<int64_t>(resp.u);
+  ASSERT_EQ(actual, -1);
+
+  resp = Run({"set", "key", "val", "EX", "200"});
+  ASSERT_EQ(Run({"set", "key", "val", "KEEPTTL"}), "OK");
+
+  resp = Run({"ttl", "key"});
+  actual = get<int64_t>(resp.u);
+
+  EXPECT_TRUE(actual > 0 && actual <= 200);
+}
+
+TEST_F(StringFamilyTest, SetOptionsSyntaxError) {
+  auto TEST_current_time_s = TEST_current_time_ms / 1000;
+
+  EXPECT_THAT(Run({"set", "key", "val", "EX", "1030", "PX", "1030"}), ErrArg("ERR syntax error"));
+  EXPECT_THAT(
+      Run({"set", "key", "val", "EX", "1030", "EXAT", absl::StrCat(TEST_current_time_s + 1030)}),
+      ErrArg("ERR syntax error"));
+  EXPECT_THAT(
+      Run({"set", "key", "val", "EX", "1030", "PXAT", absl::StrCat(TEST_current_time_ms + 1030)}),
+      ErrArg("ERR syntax error"));
+
+  EXPECT_THAT(Run({"set", "key", "val", "PX", "1030", "EX", "1030"}), ErrArg("ERR syntax error"));
+  EXPECT_THAT(
+      Run({"set", "key", "val", "PX", "1030", "EXAT", absl::StrCat(TEST_current_time_s + 1030)}),
+      ErrArg("ERR syntax error"));
+  EXPECT_THAT(
+      Run({"set", "key", "val", "PX", "1030", "PXAT", absl::StrCat(TEST_current_time_ms + 1030)}),
+      ErrArg("ERR syntax error"));
+  EXPECT_THAT(
+      Run({"set", "key", "val", "EXAT", absl::StrCat(TEST_current_time_s + 1030), "EX", "1030"}),
+      ErrArg("ERR syntax error"));
+  EXPECT_THAT(
+      Run({"set", "key", "val", "EXAT", absl::StrCat(TEST_current_time_s + 1030), "PX", "1030"}),
+      ErrArg("ERR syntax error"));
+  EXPECT_THAT(Run({"set", "key", "val", "EXAT", absl::StrCat(TEST_current_time_s + 1030), "PXAT",
+                   absl::StrCat(TEST_current_time_ms + 1030)}),
+              ErrArg("ERR syntax error"));
+
+  EXPECT_THAT(
+      Run({"set", "key", "val", "PXAT", absl::StrCat(TEST_current_time_ms + 1030), "EX", "1030"}),
+      ErrArg("ERR syntax error"));
+  EXPECT_THAT(
+      Run({"set", "key", "val", "PXAT", absl::StrCat(TEST_current_time_ms + 1030), "PX", "1030"}),
+      ErrArg("ERR syntax error"));
+  EXPECT_THAT(Run({"set", "key", "val", "PXAT", absl::StrCat(TEST_current_time_ms + 1030), "EXAT",
+                   absl::StrCat(TEST_current_time_s + 1030)}),
+              ErrArg("ERR syntax error"));
+
+  EXPECT_THAT(Run({"set", "key", "val", "EX", "1030", "KEEPTTL"}), ErrArg("ERR syntax error"));
+  EXPECT_THAT(Run({"set", "key", "val", "PX", "1030", "KEEPTTL"}), ErrArg("ERR syntax error"));
+  EXPECT_THAT(
+      Run({"set", "key", "val", "EXAT", absl::StrCat(TEST_current_time_s + 1030), "KEEPTTL"}),
+      ErrArg("ERR syntax error"));
+  EXPECT_THAT(
+      Run({"set", "key", "val", "PXAT", absl::StrCat(TEST_current_time_ms + 1030), "KEEPTTL"}),
+      ErrArg("ERR syntax error"));
+
+  EXPECT_THAT(Run({"set", "key", "val", "KEEPTTL", "PX", "1030"}), ErrArg("ERR syntax error"));
+  EXPECT_THAT(
+      Run({"set", "key", "val", "KEEPTTL", "PXAT", absl::StrCat(TEST_current_time_ms + 1030)}),
+      ErrArg("ERR syntax error"));
+  EXPECT_THAT(Run({"set", "key", "val", "KEEPTTL", "EX", "1030"}), ErrArg("ERR syntax error"));
+  EXPECT_THAT(
+      Run({"set", "key", "val", "KEEPTTL", "EXAT", absl::StrCat(TEST_current_time_s + 1030)}),
+      ErrArg("ERR syntax error"));
+
+  EXPECT_THAT(Run({"set", "key", "val", "NX", "XX"}), ErrArg("ERR syntax error"));
+  EXPECT_THAT(Run({"set", "key", "val", "XX", "NX"}), ErrArg("ERR syntax error"));
+}
+
 TEST_F(StringFamilyTest, Set) {
   auto resp = Run({"set", "foo", "bar", "XX"});
   EXPECT_THAT(resp, ArgType(RespExpr::NIL));
@@ -357,15 +433,12 @@ TEST_F(StringFamilyTest, SetNx) {
 }
 
 TEST_F(StringFamilyTest, SetPxAtExAt) {
-  using std::chrono::duration_cast;
-  using std::chrono::milliseconds;
-  using std::chrono::seconds;
-  using std::chrono::system_clock;
-
   // Expiration time as set at unix time
+  auto TEST_current_time_s = TEST_current_time_ms / 1000;
+
   auto resp = Run({"set", "foo", "bar", "EXAT", "-1"});
   ASSERT_THAT(resp, ErrArg("invalid expire time"));
-  resp = Run({"set", "foo", "bar", "EXAT", std::to_string(time(nullptr) - 1)});
+  resp = Run({"set", "foo", "bar", "EXAT", absl::StrCat(TEST_current_time_s - 1)});
   ASSERT_THAT(resp, "OK");  // it would return OK but will not set the value - expiration time is 0
                             // (checked with Redis)
   EXPECT_EQ(Run({"get", "foo"}).type, facade::RespExpr::NIL);
@@ -373,16 +446,15 @@ TEST_F(StringFamilyTest, SetPxAtExAt) {
   resp = Run({"set", "foo", "bar", "PXAT", "-1"});
   ASSERT_THAT(resp, ErrArg("invalid expire time"));
 
-  auto now = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
-  resp = Run({"set", "foo", "bar", "PXAT", std::to_string(now - 23)});
+  resp = Run({"set", "foo", "bar", "PXAT", absl::StrCat(TEST_current_time_ms - 23)});
   ASSERT_THAT(resp, "OK");  // it would return OK but will not set the value (checked with Redis)
   EXPECT_EQ(Run({"get", "foo"}).type, facade::RespExpr::NIL);
 
-  resp = Run({"set", "foo", "bar", "EXAT", std::to_string(time(nullptr) + 1)});
+  resp = Run({"set", "foo", "bar", "EXAT", absl::StrCat(TEST_current_time_s + 1)});
   ASSERT_THAT(resp, "OK");  // valid expiration time
   EXPECT_EQ(Run({"get", "foo"}), "bar");
 
-  resp = Run({"set", "foo2", "abc", "PXAT", std::to_string(now + 300)});
+  resp = Run({"set", "foo2", "abc", "PXAT", absl::StrCat(TEST_current_time_ms + 300)});
   ASSERT_THAT(resp, "OK");
   EXPECT_EQ(Run({"get", "foo2"}), "abc");
 }


### PR DESCRIPTION
This PR solves two problems.
1. implements KEEPTTL.
2. fixed the problem that StringFamily is not recognized when there is a conflict between options.

Two changes.
1. change SetParams.how/keep_expire to SetParams.flags.
2. Added conflict recognition between different options in StringFamily::Set.

Added two new tests.
1. KEEPTTL function test.
2. Conflict detection between different options in SetCommand.

The PR for the KEEPTTL option implementation in Redis is here: https://github.com/redis/redis/pull/6679/files
The part of Setcommand in redis that detects conflicts is at: https://github.com/redis/redis/blob/unstable/src/t_string.c#L201

PS：There is an incompatibility between the current implementation and redis.
1. set key value EX 100 EX 200 in df fails
2. redis executes set key value EX 100 EX 200 successfully, selecting 200 as the actual value

EX, PX, EXAT, PXAT have the same behavior.

