### PR TITLE
fix: DCHECK_NOTNULL gets WARNING when return value is not used.

### DIFF
--- a/src/core/dense_set.cc
+++ b/src/core/dense_set.cc
@@ -589,7 +589,7 @@ auto DenseSet::NewLink(void* data, DensePtr next) -> DenseLinkKey* {
 }
 
 bool DenseSet::ExpireIfNeeded(DensePtr* prev, DensePtr* node) const {
-  DCHECK_NOTNULL(node);
+  DCHECK(node != nullptr);
 
   bool deleted = false;
   while (node->HasTtl()) {


### PR DESCRIPTION
This is a simple fix for removing a warning during compilation.

<img width="1023" alt="截屏2022-11-13 12 01 39" src="https://user-images.githubusercontent.com/46051144/201505066-4b8b7015-4d51-4177-9430-e26da8fcfe86.png">
<img width="567" alt="截屏2022-11-13 12 01 51" src="https://user-images.githubusercontent.com/46051144/201505068-24c698e7-e355-4353-ae1d-e6c030889deb.png">
