### PR TITLE
feat(chart): push helm chart as OCI image

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -38,6 +38,9 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Install helm
+      uses: azure/setup-helm@v3
+
     - uses: dsaltares/fetch-gh-release-asset@master
       with:
         version: 'tags/${{ env.TAG_NAME }}'
@@ -126,6 +129,16 @@ jobs:
         git commit \
           -m 'chore(helm-chart): update to ${{ env.TAG_NAME }}' \
           contrib/charts/dragonfly/Chart.yaml
+
+    - name: Push Helm chart as OCI to Github
+      if: env.IS_PRERELEASE != 'true'
+      run: |
+        echo "${{ secrets.GITHUB_TOKEN }}" | \
+          helm registry login -u ${{ github.actor }} --password-stdin ghcr.io
+
+        helm package contrib/charts/dragonfly
+
+        helm push dragonfly-${{ env.TAG_NAME }}.tgz oci://ghcr.io/${{ github.repository }}/helm
 
     - name: GitHub Push
       uses: CasperWA/push-protected@v2


### PR DESCRIPTION
This change will push the helm chart as an OCI image to the ghcr.io registry.

Afterwards it can easily be consumed by helm using commands like
```
helm pull oci://ghcr.io/dragonfly/dragonfly/helm/dragonfly --version v0.11.0
```
to download the chart, 
```
helm template dragonfly oci://ghcr.io/dragonfly/dragonfly/helm/dragonfly --version v0.11.0
```
to template the chart, or
```
helm upgrade \
  --install \
  --namespace dragonfly \
  --create-namespace \
  --atomic --wait \
  dragonfly \
  oci://ghcr.io/dragonfly/dragonfly/helm/dragonfly \
  --version v0.11.0
```
to install the chart directly.

After the first release, the package will most likely need to be manually linked to the repository :)