### PR TITLE
fix(server): all scan commands needs to return cursor as bulk string #503

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1219,7 +1219,7 @@ void GenericFamily::Scan(CmdArgList args, ConnectionContext* cntx) {
   cursor = ScanGeneric(cursor, scan_op, &keys, cntx);
 
   (*cntx)->StartArray(2);
-  (*cntx)->SendSimpleString(absl::StrCat(cursor));
+  (*cntx)->SendBulkString(absl::StrCat(cursor));
   (*cntx)->StartArray(keys.size());
   for (const auto& k : keys) {
     (*cntx)->SendBulkString(k);

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -854,7 +854,7 @@ void HSetFamily::HScan(CmdArgList args, ConnectionContext* cntx) {
   OpResult<StringVec> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
   if (result.status() != OpStatus::WRONG_TYPE) {
     (*cntx)->StartArray(2);
-    (*cntx)->SendSimpleString(absl::StrCat(cursor));
+    (*cntx)->SendBulkString(absl::StrCat(cursor));
     (*cntx)->StartArray(result->size());
     for (const auto& k : *result) {
       (*cntx)->SendBulkString(k);

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -1445,7 +1445,7 @@ void SScan(CmdArgList args, ConnectionContext* cntx) {
   OpResult<StringVec> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
   if (result.status() != OpStatus::WRONG_TYPE) {
     (*cntx)->StartArray(2);
-    (*cntx)->SendSimpleString(absl::StrCat(cursor));
+    (*cntx)->SendBulkString(absl::StrCat(cursor));
     (*cntx)->StartArray(result->size());
     for (const auto& k : *result) {
       (*cntx)->SendBulkString(k);

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1445,7 +1445,7 @@ void ZSetFamily::ZScan(CmdArgList args, ConnectionContext* cntx) {
   OpResult<StringVec> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
   if (result.status() != OpStatus::WRONG_TYPE) {
     (*cntx)->StartArray(2);
-    (*cntx)->SendSimpleString(absl::StrCat(cursor));
+    (*cntx)->SendBulkString(absl::StrCat(cursor));
     (*cntx)->StartArray(result->size());
     for (const auto& k : *result) {
       (*cntx)->SendBulkString(k);

--- a/tests/dragonfly/server_family_test.py
+++ b/tests/dragonfly/server_family_test.py
@@ -1,5 +1,10 @@
 import pytest
 import redis
+import random
+from string import ascii_lowercase
+import time
+import datetime
+from .utility import *
 
 
 def test_quit(connection):
@@ -60,3 +65,18 @@ def test_connection_name(client):
     client.execute_command("CLIENT SETNAME test_conn_name")
     name = client.execute_command("CLIENT GETNAME")
     assert name == "test_conn_name"
+
+'''
+make sure that the scan command is working with python
+'''
+def test_scan(client):
+    try:
+        for key, val in gen_test_data(n=10, seed="set-test-key"):
+            res = client.set(key, val)
+            assert res is not None
+            cur, keys = client.scan(cursor=0, match=key, count=2)
+            assert cur == 0
+            assert len(keys) == 1
+            assert keys[0] == key
+    except Exception as e:
+        assert False, str(e)


### PR DESCRIPTION
Signed-off-by: Boaz Sade <boaz@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
fixes issue #503 
The scan commands - scan, hscan, zscan, sscan all should return bulk string and not a "regular string" for the cursor value.
This issue was found as a result of running a java client ([redisson source code](https://github.com/redisson/redisson), that expecting to have the correct data type for this case.