### PR TITLE
feat(server): adding matrices for memory defrag

### DIFF
--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -792,9 +792,9 @@ TEST_F(DefragDflyEngineTest, TestDefragOption) {
     EngineShard* shard = EngineShard::tlocal();
     ASSERT_FALSE(shard == nullptr);  // we only have one and its should not be empty!
     this_fiber::sleep_for(100ms);
-    EXPECT_EQ(shard->GetDefragStats().success_count, 0);
+    EXPECT_EQ(shard->stats().defrag_realloc_total, 0);
     // we are expecting to have at least one try by now
-    EXPECT_GT(shard->GetDefragStats().tries, 0);
+    EXPECT_GT(shard->stats().defrag_attempt_total, 0);
   });
 
   ArgSlice delete_cmd(keys);
@@ -808,16 +808,16 @@ TEST_F(DefragDflyEngineTest, TestDefragOption) {
     ASSERT_FALSE(shard == nullptr);  // we only have one and its should not be empty!
     // a "busy wait" to ensure that memory defragmentations was successful:
     // the task ran and did it work
-    auto stats = shard->GetDefragStats();
+    auto stats = shard->stats();
     for (int i = 0; i < kMaxDefragTriesForTests; i++) {
-      stats = shard->GetDefragStats();
-      if (stats.success_count > 0) {
+      stats = shard->stats();
+      if (stats.defrag_realloc_total > 0) {
         break;
       }
       this_fiber::sleep_for(220ms);
     }
     // make sure that we successfully found places to defrag in memory
-    EXPECT_GT(stats.success_count, 0);
+    EXPECT_GT(stats.defrag_realloc_total, 0);
   });
 }
 

--- a/src/server/engine_shard_set.h
+++ b/src/server/engine_shard_set.h
@@ -37,13 +37,10 @@ class EngineShard {
   struct Stats {
     uint64_t ooo_runs = 0;    // how many times transactions run as OOO.
     uint64_t quick_runs = 0;  //  how many times single shard "RunQuickie" transaction run.
+    uint64_t defrag_attempt_total = 0;
+    uint64_t defrag_realloc_total = 0;
 
     Stats& operator+=(const Stats&);
-  };
-
-  struct DefragStats {
-    uint64_t success_count = 0;  // how many objects were moved
-    uint64_t tries = 0;          // how many times we tried
   };
 
   // EngineShard() is private down below.
@@ -146,17 +143,12 @@ class EngineShard {
     journal_ = j;
   }
 
-  const DefragStats& GetDefragStats() const {
-    return defrag_state_.stats;
-  }
-
   void TEST_EnableHeartbeat();
 
  private:
   struct DefragTaskState {
     // we will add more data members later
     uint64_t cursor = 0u;
-    DefragStats stats;
 
     // check the current threshold and return true if
     // we need to do the de-fermentation

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1304,6 +1304,8 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
     append("total_writes_processed", m.conn_stats.io_write_cnt);
     append("async_writes_count", m.conn_stats.async_writes_cnt);
     append("parser_err_count", m.conn_stats.parser_err_cnt);
+    append("defrag_attempt_total", m.shard_stats.defrag_attempt_total);
+    append("defrag_realloc_total", m.shard_stats.defrag_realloc_total);
   }
 
   if (should_enter("TIERED", true)) {


### PR DESCRIPTION
Signed-off-by: Boaz Sade <boaz@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
Add metrics for the memory defragmentation.
This see this run the command "info stats"
Two new entries:
defrag_attempt_total - the total number of times that the stasks (for all shards) checked memory for possible defragmentation
defrag_realloc_total - the total number of pointers (from all shards) that were moved dues defragmentation