### PR TITLE
feat(server): defrag memory counter for total memory access

### DIFF
--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -794,7 +794,7 @@ TEST_F(DefragDflyEngineTest, TestDefragOption) {
     this_fiber::sleep_for(100ms);
     EXPECT_EQ(shard->stats().defrag_realloc_total, 0);
     // we are expecting to have at least one try by now
-    EXPECT_GT(shard->stats().defrag_attempt_total, 0);
+    EXPECT_GT(shard->stats().defrag_task_invocation_total, 0);
   });
 
   ArgSlice delete_cmd(keys);
@@ -818,6 +818,7 @@ TEST_F(DefragDflyEngineTest, TestDefragOption) {
     }
     // make sure that we successfully found places to defrag in memory
     EXPECT_GT(stats.defrag_realloc_total, 0);
+    EXPECT_GE(stats.defrag_attempt_total, stats.defrag_realloc_total);
   });
 }
 

--- a/src/server/engine_shard_set.h
+++ b/src/server/engine_shard_set.h
@@ -39,6 +39,7 @@ class EngineShard {
     uint64_t quick_runs = 0;  //  how many times single shard "RunQuickie" transaction run.
     uint64_t defrag_attempt_total = 0;
     uint64_t defrag_realloc_total = 0;
+    uint64_t defrag_task_invocation_total = 0;
 
     Stats& operator+=(const Stats&);
   };
@@ -152,7 +153,7 @@ class EngineShard {
 
     // check the current threshold and return true if
     // we need to do the de-fermentation
-    bool IsRequired();
+    bool IsRequired() const;
   };
 
   EngineShard(util::ProactorBase* pb, bool update_db_time, mi_heap_t* heap);

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1306,6 +1306,7 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
     append("parser_err_count", m.conn_stats.parser_err_cnt);
     append("defrag_attempt_total", m.shard_stats.defrag_attempt_total);
     append("defrag_realloc_total", m.shard_stats.defrag_realloc_total);
+    append("defrag_task_invocation_total", m.shard_stats.defrag_task_invocation_total);
   }
 
   if (should_enter("TIERED", true)) {


### PR DESCRIPTION
Signed-off-by: Boaz Sade <boaz@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
Another defrag counter - this one count the number of times that we are attempting the defrag operation.
The flag "defrag_attempt_total" will count the number of times that we access the memory to try and check if this memory location is underutilised. 
The new flag "defrag_task_invocation_total" will count the number of time that we call the function that do the memory scan (i,e we detect possible memory underutilised).