### PR TITLE
feat: add healtcheck for container

### DIFF
--- a/contrib/charts/dragonfly/templates/deployment.yaml
+++ b/contrib/charts/dragonfly/templates/deployment.yaml
@@ -52,14 +52,9 @@ spec:
             - name: dragonfly
               containerPort: 6379
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: dragonfly
-          readinessProbe:
-            httpGet:
-              path: /
-              port: dragonfly
+        {{- with .Values.probes }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
           {{- if .Values.command.cmd }}
           command:
             {{ toYaml .Values.command.cmd | nindent 12 }}

--- a/contrib/charts/dragonfly/templates/statefulset.yaml
+++ b/contrib/charts/dragonfly/templates/statefulset.yaml
@@ -55,14 +55,9 @@ spec:
             - name: dragonfly
               containerPort: 6379
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: dragonfly
-          readinessProbe:
-            httpGet:
-              path: /
-              port: dragonfly
+        {{- with .Values.probes }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
           {{- if .Values.command.cmd }}
           command:
             {{ toYaml .Values.command.cmd | nindent 12 }}

--- a/contrib/charts/dragonfly/values.yaml
+++ b/contrib/charts/dragonfly/values.yaml
@@ -108,6 +108,27 @@ tls:
   #   HLunol88AeTOcKfD6hBYGvcRfu5NV29jJxZCOBfbFQXjnNlnrhRCag==
   #   -----END RSA PRIVATE KEY-----
 
+probes:
+  livenessProbe:
+    exec:
+      command:
+        - /bin/sh
+        - /usr/local/bin/healthcheck.sh
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+      successThreshold: 1
+  readinessProbe:
+    exec:
+      command:
+        - /bin/sh
+        - /usr/local/bin/healthcheck.sh
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+      successThreshold: 1
 
 command:
   # -- Allow overriding the container's command

--- a/tools/docker/Dockerfile.alpine-prod
+++ b/tools/docker/Dockerfile.alpine-prod
@@ -18,15 +18,17 @@ LABEL org.opencontainers.image.source https://github.com/${ORG_NAME}/dragonfly
 
 RUN addgroup -S -g 1000 dfly && adduser -S -G dfly -u 999 dfly
 RUN apk --no-cache add libgcc libstdc++ libunwind boost1.77-fiber \
-    'su-exec>=0.2'
+    'su-exec>=0.2' netcat-openbsd
 
 RUN mkdir /data && chown dfly:dfly /data
 VOLUME /data
 WORKDIR /data
 COPY tools/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY tools/docker/healthcheck.sh /usr/local/bin/healthcheck.sh
 COPY --from=builder /build/build-opt/dragonfly /usr/local/bin/
 RUN dragonfly -version
 
+HEALTHCHECK CMD /usr/local/bin/healthcheck.sh
 ENTRYPOINT ["entrypoint.sh"]
 
 EXPOSE 6380

--- a/tools/docker/Dockerfile.ubuntu-prod
+++ b/tools/docker/Dockerfile.ubuntu-prod
@@ -25,6 +25,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 LABEL org.opencontainers.image.title Dragonfly
 LABEL org.opencontainers.image.source https://github.com/${ORG_NAME}/dragonfly
 
+RUN apt clean && apt update && apt -y install netcat-openbsd
+
 
 RUN groupadd -r -g 999 dfly && useradd -r -g dfly -u 999 dfly
 RUN mkdir /data && chown dfly:dfly /data
@@ -32,9 +34,11 @@ RUN mkdir /data && chown dfly:dfly /data
 VOLUME /data
 WORKDIR /data
 COPY tools/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY tools/docker/healthcheck.sh /usr/local/bin/healthcheck.sh
 COPY --from=builder /build/su-exec /usr/local/bin/
 COPY --from=builder /build/dragonfly /usr/local/bin/
 
+HEALTHCHECK CMD /usr/local/bin/healthcheck.sh
 ENTRYPOINT ["entrypoint.sh"]
 
 # For inter-container communication.

--- a/tools/docker/healthcheck.sh
+++ b/tools/docker/healthcheck.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+HOST="localhost"
+PORT=6379
+
+echo "ping" | nc -q1 $HOST $PORT
+
+exit $?


### PR DESCRIPTION
This change will add a proper healthcheck to the container. Similar to `redis-cli ping`, just without `redis-cli`.

At the same time, we'll start utilising the new healthcheck in the helm chart. Sample container available at `ghcr.io/tamcore/dragonfly:v0.12.0` :) 