### PR TITLE
feat(server): json set type support

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_library(dfly_core compact_object.cc dragonfly_core.cc extent_tree.cc
-    external_alloc.cc interpreter.cc mi_memory_resource.cc
+    external_alloc.cc interpreter.cc json_object.cc mi_memory_resource.cc
     segment_allocator.cc small_string.cc tx_queue.cc dense_set.cc string_set.cc)
 cxx_link(dfly_core base absl::flat_hash_map absl::str_format redis_lib TRDP::lua lua_modules
-    Boost::fiber crypto)
+    Boost::fiber TRDP::jsoncons crypto)
 
 add_executable(dash_bench dash_bench.cc)
 cxx_link(dash_bench dfly_core)

--- a/src/core/json_object.cc
+++ b/src/core/json_object.cc
@@ -1,0 +1,37 @@
+// Copyright 2022, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "core/json_object.h"
+extern "C" {
+#include "redis/object.h"
+#include "redis/zmalloc.h"
+}
+#include <jsoncons/json.hpp>
+
+#include "base/logging.h"
+
+namespace dfly {
+
+std::optional<JsonType> JsonFromString(std::string_view input) {
+  using namespace jsoncons;
+
+  std::error_code ec;
+  auto JsonErrorHandler = [](json_errc ec, const ser_context&) {
+    VLOG(1) << "Error while decode JSON: " << make_error_code(ec).message();
+    return false;
+  };
+
+  json_decoder<JsonType> decoder;
+  json_parser parser(basic_json_decode_options<char>{}, JsonErrorHandler);
+
+  parser.update(input);
+  parser.finish_parse(decoder, ec);
+
+  if (decoder.is_valid()) {
+    return decoder.get_result();
+  }
+  return {};
+}
+
+}  // namespace dfly

--- a/src/core/json_object.h
+++ b/src/core/json_object.h
@@ -1,0 +1,36 @@
+// Copyright 2022, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <memory>
+#include <memory_resource>
+#include <optional>
+#include <string_view>
+
+// Note about this file - once we have the issue with jsonpath in jsoncons resolved
+// we would add the implementation for the allocator here as well. Right now this
+// file is a little bit empty, but for external "users" such as json_family they
+// should include this when creating JSON object from string that we're getting
+// from the commands.
+namespace jsoncons {
+struct sorted_policy;
+template <typename CharT, typename Policy, typename Allocator> class basic_json;
+}  // namespace jsoncons
+
+// the last one in object.h is OBJ_STREAM and it is 6,
+// this will add enough place for Redis types to grow
+constexpr unsigned OBJ_JSON = 15;
+
+namespace dfly {
+
+// This is temporary, there is an issue right now with jsoncons about using jsonpath
+// with custom allocator. once it would resolved, we would change this to use custom allocator
+// that allocate memory from mimalloc
+using JsonType = jsoncons::basic_json<char, jsoncons::sorted_policy, std::allocator<char>>;
+
+// Build a json object from string. If the string is not legal json, will return nullopt
+std::optional<JsonType> JsonFromString(std::string_view input);
+
+}  // namespace dfly

--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -15,8 +15,8 @@ extern "C" {
 #include "redis/util.h"
 #include "redis/zmalloc.h"
 }
-
 #include "base/logging.h"
+#include "core/compact_object.h"
 #include "server/error.h"
 #include "server/server_state.h"
 
@@ -87,6 +87,8 @@ const char* ObjTypeName(int type) {
       return "hash";
     case OBJ_STREAM:
       return "stream";
+    case OBJ_JSON:
+      return "ReJSON-RL";
     default:
       LOG(ERROR) << "Unsupported type " << type;
   }


### PR DESCRIPTION
Signed-off-by: Boaz Sade <boaz@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
Adding support for JSON type.
This makes that JSON one of the types that we are saving in its native format and can accessing keys based on this type.
This is the first step for the completion of the JSON.SET command in the sense that we are not yet using this type for any of the JSON family commands.
Once this PR is completed we can go ahead and start using this type for the JSON commands.
Note that:
1. We should switch to mimalloc based allocator, but this is not working right now due to issue with the JSON code we're using (open issue for this and waiting for it to resolved).
2. You should use the function JsonFromString to correctly create a JSON object that can be saved to the store.
3. Later it would be possible to access and change the data inside the JSON without the need to parse again or set a new JSON again (in place changes).