### PR TITLE
feat(server): Improved cancellation

### DIFF
--- a/src/server/common.h
+++ b/src/server/common.h
@@ -15,6 +15,7 @@
 
 #include "facade/facade_types.h"
 #include "facade/op_status.h"
+#include "util/fibers/fiber.h"
 
 namespace dfly {
 
@@ -243,7 +244,8 @@ using AggregateGenericError = AggregateValue<GenericError>;
 // Context is a utility for managing error reporting and cancellation for complex tasks.
 //
 // When submitting an error with `Error`, only the first is stored (as in aggregate values).
-// Then a special error handler is run, if present, and the context is cancelled.
+// Then a special error handler is run, if present, and the context is cancelled. The error handler
+// is run in a separate handler to free up the caller.
 //
 // Manual cancellation with `Cancel` is simulated by reporting an `errc::operation_canceled` error.
 // This allows running the error handler and representing this scenario as an error.
@@ -255,10 +257,10 @@ class Context : protected Cancellation {
   Context(ErrHandler err_handler) : Cancellation{}, err_{}, err_handler_{std::move(err_handler)} {
   }
 
-  // Cancels the context by submitting an `errc::operation_canceled` error.
-  void Cancel();
-  using Cancellation::IsCancelled;
+  ~Context();
 
+  void Cancel();  // Cancels the context by submitting an `errc::operation_canceled` error.
+  using Cancellation::IsCancelled;
   const Cancellation* GetCancellation() const;
 
   GenericError GetError();
@@ -266,27 +268,11 @@ class Context : protected Cancellation {
   // Report an error by submitting arguments for GenericError.
   // If this is the first error that occured, then the error handler is run
   // and the context is cancelled.
-  //
-  // Note: this function blocks when called from inside an error handler.
   template <typename... T> GenericError Error(T... ts) {
-    if (!mu_.try_lock())  // TODO: Maybe use two separate locks.
-      return GenericError{std::forward<T>(ts)...};
-
-    std::lock_guard lk{mu_, std::adopt_lock};
-    if (err_)
-      return err_;
-
-    GenericError new_err{std::forward<T>(ts)...};
-    if (err_handler_)
-      err_handler_(new_err);
-
-    err_ = std::move(new_err);
-    Cancellation::Cancel();
-
-    return err_;
+    return ReportInternal(GenericError{std::forward<T>(ts)...});
   }
 
-  // Reset error and cancellation flag, assign new error handler.
+  // Wait for error handler to stop, reset error and cancellation flag, assign new error handler.
   void Reset(ErrHandler handler);
 
   // Atomically replace the error handler if no error is present, and return the
@@ -297,10 +283,22 @@ class Context : protected Cancellation {
   // will never run if the context was cancelled between the first two steps.
   GenericError Switch(ErrHandler handler);
 
+  // If any error handler is running, wait for it to stop.
+  void Stop();
+
+ private:
+  // Report error.
+  GenericError ReportInternal(GenericError&& err);
+
+  // Wait until the error handler finished running.
+  void CheckHandlerFb();
+
  private:
   GenericError err_;
-  ErrHandler err_handler_;
   ::boost::fibers::mutex mu_;
+
+  ErrHandler err_handler_;
+  ::util::fibers_ext::Fiber err_handler_fb_;
 };
 
 struct ScanOpts {

--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -12,6 +12,7 @@
 #include <memory>
 
 #include "server/conn_context.h"
+#include "util/fibers/fiber.h"
 
 namespace facade {
 class RedisReplyBuilder;
@@ -91,8 +92,8 @@ class DflyCmd {
 
     facade::Connection* conn;
 
-    ::boost::fibers::fiber full_sync_fb;  // Full sync fiber.
-    std::unique_ptr<RdbSaver> saver;      // Saver used by the full sync phase.
+    util::fibers_ext::Fiber full_sync_fb;  // Full sync fiber.
+    std::unique_ptr<RdbSaver> saver;       // Saver used by the full sync phase.
     std::string eof_token;
 
     std::function<void()> cleanup;  // Optional cleanup for cancellation.

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -92,7 +92,8 @@ class Replica {
   void CloseAllSockets();  // Close all sockets.
   void JoinAllFlows();     // Join all flows if possible.
 
-  std::error_code SendNextPhaseRequest();  // Send DFLY SYNC or DFLY STARTSTABLE.
+  // Send DFLY SYNC or DFLY STARTSTABLE if stable is true.
+  std::error_code SendNextPhaseRequest(bool stable);
 
   void DefaultErrorHandler(const GenericError& err);
 
@@ -179,6 +180,9 @@ class Replica {
   // MainReplicationFb in standalone mode, FullSyncDflyFb in flow mode.
   ::boost::fibers::fiber sync_fb_;
   std::vector<std::unique_ptr<Replica>> shard_flows_;
+
+  // Guard operations where flows might be in a mixed state (transition/setup)
+  ::boost::fibers::mutex flows_op_mu_;
 
   std::unique_ptr<base::IoBuf> leftover_buf_;
   std::unique_ptr<facade::RedisParser> parser_;


### PR DESCRIPTION
I've been debugging replication cancellation the whole day. I've witnessed the coolest bugs, but its pure hell in general 🙂 

### The Test

I've been trying to make it pass the pytests (specifically replication cancellation) tests with the normal pytests, the new pytest generator and under intense load & many instances. They seem to pass usually, but if you increase the number of keys/instances/iterations, run it in optimized mode, add printing for delay, etc it tends to fail at places.

In short, the most problematic test was `disconnect_master` . It starts a master and a few replicas, kills the master, starts it again, waits some time and makes sure all the replicas have reconnected to the master. This sounds not very difficult, but it is. It makes sure that a replica:
- Recovers from any error at any time (because the master disconnect can happen at different phases)
- Unblocks the current operation in a timely manner and runs cleanup for it
- Switches back to looping mode (where it tries to re-connect)
- Once the master is back alive, is starts a new full sync operation

I do all of this a few times in a loop, so it can basically fail while re-trying, fail again while doing cleanup, etc...

### The cancellation mechanism

I'll provide my thought process as separate steps

**1.** What the error handler is for

* We have blocking code in many operations on replica and master (block on socket, mutex, barrier, blocking counter, eyc. ) that need to be unblocked manually on cancellation.
* The `Context` stores a specific error handler that knows how to do all of this for the currently running task
* While we can precisely control error propagation inside some function, we rely on the context for collecting errors from different fibers (there can be many many for a single task), so we don't need to invent our own collection mechanism for every task and we can use contexts in general components.

**2.** Division of responsibility

* What do I mean by task? The whole replication flow is split into parts, I like to call the big and difficult ones tasks. For now, there are exactly four - full and stable sync on replica and master accordingly (2x2). Those have clearly a start, an end, own resources and need complex cleanup. The other parts use cancellation as well - but in a simpler way.
* Inside the replica, transferring responsibility when changing parts happens with switching the error handler atomically and retries are prepared with resetting the context
* The master uses an older custom mechanism for storing explicit error callbacks for each `FlowInfo` and one general error handler (that is not changed during the whole process), which invokes the separate handlers. It needs to be re-viewed

**2.5** Uneven split

* The biggest difference here is that the replica is active - it coordinates the replication process - and the master is reactive - it just reacts to events - which makes the replica much more complicated
* Seriously, it has all the pain points. Only the replica:
  * Initiates all phases
  * Does retries
  * Keeps track of the general flow, blocks there
  * Can fail during during task initialization because it is the one sending set-up requests

**3.** Starting the error handler

* The `Context` invokes the error handler upon receiving the first error. This might happen from any fiber of the task
* The `Context` guards its operations with a mutex. Previously, it directly ran the error handler in the fiber that reported the error and held the lock until if finished. 
* The benefits of this were:
  * Is is very simple
  * It prevent others from resetting the context (because the only lock is held)
  * It conveniently allows to wait until the handler finished
* The downside is that its very difficult to make it work reliably:
  * The context is locked
  * Some fiber deep inside the task is occupied by the error handler itself. 
  * The more features we add, the more complex it becomes, which increases the probability of it deadlocking and makes thinking about cleanup more difficult.
* In reality we want:
  * Freely access the context, propagate its errors, block on resetting it, etc.
  * Allow the error handler to precisely manage its own lifetime (so it can run before, in-between, after all tasks unblocked)

**4.** Special case "Master"

* There were no issues with the master cancellation though... Why? Because it uses a custom more sophisticated approach and doesn't have the notion of re-trying operations
* Currently, cancelling the context for a session in master is equal to evicting it. The error handler cannot really manage destroying the whole object is belongs to - its essentially a reversed relationship - so I start a separate detached fiber `CancelReplication` that takes over the whole cancelling process. This avoids many many problems

**5.** The solution?

* The solution in my mind is to externalize cancellation as a default in a way that it has as little as possible friction with the task that we are tearing down itself, so we move the whole complexity into the context itself.
* The pain point here for the task (or its manager, the one who started it) is that:
  * It needs to wait for the cancellation to stop before starting a new task (because it might be re-trying)
  * If the context has more responsibility, the task is more vulnerable during the initialization of resources

**6.** To the point

* `Context` now starts a separate error handler fibers and stores it
* When resetting/switching handlers on the context, it waits for a running error handler to stop - this solves the retry and coordination problem 
* Checking for handler stop is done with `Stop()` on the context
* On the replica, fast fails during the initialization are handled with a `flows_op_mu_` mutex. Because we first transfer responsibility and only then initialize resources, we need for the error handler to wait until all initialized resources are in a state where they can be teared down correctly.

### Goals

* Review my new replica cancellation mechanism
* Review the master cancellation mechanism and maybe see what common parts they share
* Maybe review how we split cancellation complexity between the two actors
 


