### PR TITLE
docs(quickstart): Clarify docker command for macOS

### DIFF
--- a/docs/quick-start/README.md
+++ b/docs/quick-start/README.md
@@ -14,8 +14,18 @@ If you do not have docker on your machine, [Install Docker](https://docs.docker.
 
 ## Step 1
 
+### On linux
+
 ```bash
 docker run --network=host --ulimit memlock=-1 docker.dragonflydb.io/dragonflydb/dragonfly
+```
+
+### On macOS
+
+_`network=host` doesn't work well on macOS, see [this issue](https://github.com/docker/for-mac/issues/1031)_
+
+```bash
+docker run --p 6379:6379 --ulimit memlock=-1 docker.dragonflydb.io/dragonflydb/dragonfly
 ```
 
 Dragonfly DB will answer to both `http` and `redis` requests out of the box!


### PR DESCRIPTION
I had issues when running the command on my m2 macbook air. [It turns out][1] that apparently docker desktop on macOS doesn't really support the host option.

Additionally, it looks like I had to explicitly pass the port mapping options for the ports to be actually mapped.

There might be a better and more efficient solution, but this is what I came up with and it finally worked.

[1]:https://github.com/docker/for-mac/issues/1031

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->