### PR TITLE
feat(ci test): add testing for helm chart

### DIFF
--- a/.ct.yaml
+++ b/.ct.yaml
@@ -1,0 +1,8 @@
+# See https://github.com/helm/chart-testing#configuration
+remote: origin
+target-branch: main
+chart-dirs:
+  - contrib/charts
+helm-extra-args: --debug --timeout 60s
+check-version-increment: false
+validate-maintainers: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,49 @@ jobs:
           GLOG_logtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 ctest -V -L DFLY
           ./dragonfly_test  --mem_defrag_threshold=0.05 # trying to catch issue with defrag
           # GLOG_logtostderr=1 GLOG_vmodule=transaction=1,engine_shard_set=1 CTEST_OUTPUT_ON_FAILURE=1 ninja server/test
+  lint-test-chart:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.3.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config .ct.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: |
+          ct \
+            lint \
+            --config .ct.yaml \
+            ${{github.event_name == 'workflow_dispatch' && '--all'}} ;
+
+      - if: steps.list-changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
+        name: Create kind cluster
+        uses: helm/kind-action@v1.5.0
+
+      - name: Run chart-testing (install)
+        run: |
+          ct \
+            install \
+            --config .ct.yaml \
+            --debug \
+            --helm-extra-set-args "--set=image.repository=ghcr.io/${{ github.repository }}" \
+            ${{github.event_name == 'workflow_dispatch' && '--all'}} ;


### PR DESCRIPTION
- Manually setting `--set=image.repository=ghcr.io/${{ github.repository }}` for this CI job, so the image is pulled from Github instead
- If the workflow is manually triggered (`github.event_name == 'workflow_dispatch'`), it will not check for changes made to the chart and simply force a run


- Fail with invalid YAML
  - https://github.com/tamcore/dragonfly/actions/runs/3801483178/jobs/6465998892
- Fail with broken PodSpec
  - https://github.com/tamcore/dragonfly/actions/runs/3801584857/jobs/6466201901
- Pass, as PR doesn't change chart
  - https://github.com/tamcore/dragonfly/actions/runs/3801652981/jobs/6466348221
- Pass, as PR changes chart but does not break it
  - https://github.com/tamcore/dragonfly/actions/runs/3801698388/jobs/6466447398