### PR TITLE
feat(container): make healthcheck tls compatible

### DIFF
--- a/tools/docker/Dockerfile.alpine-dev
+++ b/tools/docker/Dockerfile.alpine-dev
@@ -25,7 +25,8 @@ RUN build-opt/dragonfly --version
 
 FROM alpine:3.17.0
 
-RUN apk --no-cache add libgcc libstdc++ libunwind boost1.80-fiber zstd-dev su-exec netcat-openbsd
+RUN apk --no-cache add libgcc libstdc++ libunwind boost1.80-fiber \
+    zstd-dev su-exec netcat-openbsd openssl
 
 RUN addgroup -S -g 1000 dfly && adduser -S -G dfly -u 999 dfly
 RUN mkdir /data && chown dfly:dfly /data

--- a/tools/docker/Dockerfile.alpine-prod.wip
+++ b/tools/docker/Dockerfile.alpine-prod.wip
@@ -15,7 +15,7 @@ FROM alpine:latest
 
 RUN addgroup -S -g 1000 dfly && adduser -S -G dfly -u 999 dfly
 RUN apk --no-cache add libgcc libstdc++ libunwind boost1.77-fiber \
-    'su-exec>=0.2' netcat-openbsd
+    'su-exec>=0.2' netcat-openbsd openssl
 
 RUN mkdir /data && chown dfly:dfly /data
 VOLUME /data

--- a/tools/docker/healthcheck.sh
+++ b/tools/docker/healthcheck.sh
@@ -3,6 +3,14 @@
 HOST="localhost"
 PORT=6379
 
-echo "ping" | nc -q1 $HOST $PORT
+# If we're running with TLS enabled, utilise OpenSSL for the check
+if [ -f "/etc/dragonfly/tls/ca.crt" ]
+then
+    _healthcheck="openssl s_client -connect ${HOST}:${PORT} -CAfile /etc/dragonfly/tls/ca.crt -quiet -no_ign_eof"
+else
+    _healthcheck="nc -q1 $HOST $PORT"
+fi
+
+echo PING | ${_healthcheck}
 
 exit $?


### PR DESCRIPTION
While implementing the healthcheck I forgot to cover TLS, causing the healthcheck throw a bunch of handshake errors in the application log. This change takes care of that.

Now it tries to rely on OpenSSL to establish the connection.