### PR TITLE
feat(chart): add feature to generate/request TLS certificate through cert-manager

### DIFF
--- a/contrib/charts/dragonfly/README.md
+++ b/contrib/charts/dragonfly/README.md
@@ -74,8 +74,12 @@ Kubernetes: `>=1.23.0-0`
 | storage.requests | string | `"128Mi"` | Volume size to request for the PVC |
 | storage.storageClassName | string | `""` | Global StorageClass for Persistent Volume(s) |
 | tls.cert | string | `""` | TLS certificate |
+| tls.createCerts | bool | `false` | use cert-manager to automatically create the certificate |
+| tls.duration | string | `"87600h0m0s"` | duration or ttl of the validity of the created certificate |
 | tls.enabled | bool | `false` | enable TLS |
 | tls.existing_secret | string | `""` | use TLS certificates from existing secret |
+| tls.issuer.kind | string | `"ClusterIssuer"` | cert-manager issuer kind. Usually Issuer or ClusterIssuer |
+| tls.issuer.name | string | `"selfsigned"` | name of the referenced issuer |
 | tls.key | string | `""` | TLS private key |
 | tolerations | list | `[]` | Tolerations for pod assignment |
 

--- a/contrib/charts/dragonfly/templates/_pod.tpl
+++ b/contrib/charts/dragonfly/templates/_pod.tpl
@@ -97,6 +97,10 @@ volumes:
   - name: tls
     secret:
       secretName: {{ .Values.tls.existing_secret }}
+  {{- else if .Values.tls.createCerts }}
+  - name: tls
+    secret:
+      secretName: '{{ include "dragonfly.fullname" . }}-server-tls'
   {{- else }}
   - name: tls
     secret:

--- a/contrib/charts/dragonfly/templates/certificate.yaml
+++ b/contrib/charts/dragonfly/templates/certificate.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.tls.enabled .Values.tls.createCerts }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "dragonfly.fullname" . }}
+  labels:
+    {{- include "dragonfly.labels" . | nindent 4 }}
+spec:
+  commonName: '{{ include "dragonfly.fullname" . }}'
+  dnsNames:
+  - '*.{{ include "dragonfly.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local'
+  - '{{ include "dragonfly.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local'
+  - '{{ include "dragonfly.fullname" . }}.{{ .Release.Namespace }}.svc'
+  - '{{ include "dragonfly.fullname" . }}.{{ .Release.Namespace }}'
+  - '{{ include "dragonfly.fullname" . }}'
+  - localhost
+  duration: {{ required "tls.duration is required, if createCerts is enabled" .Values.tls.duration }}
+  ipAddresses:
+  - 127.0.0.1
+  issuerRef:
+    kind: {{ required "tls.issuer.kind is required, if createCerts is enabled" .Values.tls.issuer.kind }}
+    name: {{ required "tls.issuer.name is required, if createCerts is enabled" .Values.tls.issuer.name }}
+  secretName: '{{ include "dragonfly.fullname" . }}-server-tls'
+  usages:
+  - client auth
+  - server auth
+  - signing
+  - key encipherment
+{{- end }}

--- a/contrib/charts/dragonfly/values.yaml
+++ b/contrib/charts/dragonfly/values.yaml
@@ -94,6 +94,15 @@ storage:
 tls:
   # -- enable TLS
   enabled: false
+  # -- use cert-manager to automatically create the certificate
+  createCerts: false
+  # -- duration or ttl of the validity of the created certificate
+  duration: 87600h0m0s
+  issuer:
+    # -- cert-manager issuer kind. Usually Issuer or ClusterIssuer
+    kind: ClusterIssuer
+    # -- name of the referenced issuer
+    name: selfsigned
   # -- use TLS certificates from existing secret
   existing_secret: ""
   # -- TLS certificate
@@ -156,6 +165,12 @@ extraContainers: []
 
 # -- extra K8s manifests to deploy
 extraObjects: []
+  # - apiVersion: cert-manager.io/v1
+  #   kind: ClusterIssuer
+  #   metadata:
+  #     name: selfsigned
+  #   spec:
+  #     selfSigned: {}
 
 resources:
   # -- The requested resources for the containers


### PR DESCRIPTION
With this it'll be possible, to just trigger certificate creation through cert-manager. Granted, deploying the `Certificate` object was already pretty easy through the `extraObjects` object, but this makes it even easier :)

Comes in handy, when the user already operates a his own CA and has a `(Cluster)Issuer` ready for it.