### PR TITLE
fix(lua): fix a bug that truncates the last lua argument.

### DIFF
--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -349,6 +349,12 @@ TEST_F(DflyEngineTest, Eval) {
   resp = Run({"eval", "return redis.call('exists', KEYS[2])", "2", "a", "b"});
   EXPECT_EQ(2, GetDebugInfo().shards_count);
   EXPECT_THAT(resp, IntArg(0));
+
+  resp = Run({"eval", "return redis.call('hmset', KEYS[1], 'f1', '2222')", "1", "hmap"});
+  EXPECT_EQ(resp, "OK");
+
+  resp = Run({"hvals", "hmap"});
+  EXPECT_EQ(resp, "2222");
 }
 
 TEST_F(DflyEngineTest, EvalResp) {


### PR DESCRIPTION
This happens when the last argument is a number because SNPrintF makes sure to write \0 even though we did not account of that when passing capacity. Since we allocate more than we use, the only thing we need to do is to pass larger capacity.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->