### PR TITLE
chore(server): snapshot stats fix

### DIFF
--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -225,12 +225,12 @@ RdbSerializer::RdbSerializer(CompressionMode compression_mode)
 }
 
 RdbSerializer::~RdbSerializer() {
-  VLOG(1) << "compression mode: " << uint32_t(compression_mode_);
+  VLOG(2) << "compression mode: " << uint32_t(compression_mode_);
   if (compression_stats_) {
-    VLOG(1) << "compression not effective: " << compression_stats_->compression_no_effective;
-    VLOG(1) << "small string none compression applied: " << compression_stats_->small_str_count;
-    VLOG(1) << "compression failed: " << compression_stats_->compression_failed;
-    VLOG(1) << "compressed blobs:" << compression_stats_->compressed_blobs;
+    VLOG(2) << "compression not effective: " << compression_stats_->compression_no_effective;
+    VLOG(2) << "small string none compression applied: " << compression_stats_->small_str_count;
+    VLOG(2) << "compression failed: " << compression_stats_->compression_failed;
+    VLOG(2) << "compressed blobs:" << compression_stats_->compressed_blobs;
   }
 }
 

--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -112,9 +112,6 @@ class SliceSnapshot {
   // Return if flushed.
   bool FlushDefaultBuffer(bool force);
 
-  // Convert value into DbRecord.
-  DbRecord GetDbRecord(DbIndex db_index, std::string value);
-
  public:
   uint64_t snapshot_version() const {
     return snapshot_version_;
@@ -156,7 +153,7 @@ class SliceSnapshot {
 
   struct Stats {
     size_t channel_bytes = 0;
-    size_t serialized = 0, skipped = 0, side_saved = 0;
+    size_t loop_serialized = 0, skipped = 0, side_saved = 0;
     size_t savecb_calls = 0;
   } stats_;
 };


### PR DESCRIPTION
Fixed stats accounting. Now loop_serialized + side_saved should correspond to number of saved items in a shard.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->