### PR TITLE
fix(server): Fix bug in flushing in snapshot

### DIFF
--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -680,8 +680,6 @@ io::Bytes RdbSerializer::PrepareFlush() {
   if (compression_mode_ == CompressionMode::MULTY_ENTRY_ZSTD ||
       compression_mode_ == CompressionMode::MULTY_ENTRY_LZ4) {
     CompressBlob();
-    // After blob was compressed membuf was overwirten with compressed data
-    sz = mem_buf_.InputLen();
   }
 
   return mem_buf_.InputBuffer();

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -118,17 +118,11 @@ class RdbSerializer {
 
   ~RdbSerializer();
 
-  // Get access to internal buffer, compressed, if enabled.
-  io::Bytes Flush();
-
   // Internal buffer size. Might shrink after flush due to compression.
   size_t SerializedLen() const;
 
   // Flush internal buffer to sink.
   std::error_code FlushToSink(io::Sink* s);
-
-  // Clear internal buffer contents.
-  void Clear();
 
   std::error_code SelectDb(uint32_t dbid);
 
@@ -161,6 +155,9 @@ class RdbSerializer {
   std::error_code SendFullSyncCut();
 
  private:
+  // Prepare internal buffer for flush. Compress it.
+  io::Bytes PrepareFlush();
+
   std::error_code SaveLzfBlob(const ::io::Bytes& src, size_t uncompressed_len);
   std::error_code SaveObject(const PrimeValue& pv);
   std::error_code SaveListObject(const robj* obj);

--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -95,8 +95,8 @@ class SliceSnapshot {
   void SerializeEntry(DbIndex db_index, const PrimeKey& pk, const PrimeValue& pv,
                       std::optional<uint64_t> expire, RdbSerializer* serializer);
 
-  // Push byte slice to channel.
-  void PushBytesToChannel(DbIndex db_index, io::Bytes bytes);
+  // Push rdb serializer's internal buffer to channel. Return now many bytes were written.
+  size_t PushBytesToChannel(DbIndex db_index, RdbSerializer* serializer);
 
   // DbChange listener
   void OnDbChange(DbIndex db_index, const DbSlice::ChangeReq& req);


### PR DESCRIPTION
The bug was here:

```
  VLOG(2) << "FlushDefaultBuffer " << bytes.size() << " bytes";
  PushBytesToChannel(current_db_, bytes);
  default_serializer_->Clear();
```

We might block on the channel when pushing. If the snapshot continues serializing, it will write to the default serializer. And once the channel unblocked, the clear will remove everything - not only the part it has written, but also the new one. 

The solution would be to make Clear consume only a fixed part - but instead I decided to revert some changes I made previously as well because of the changes in async streamer.

I initially abstracted flushing in snapshot to pushing just bytes taken from the rdb serializer. But since in the async streamer we're gonna make the streamer base to act as a sink as well, we can just use `FlushToSink` for everyhing, so I removed `Flush` and make it just `PrepareFlush`.

