### PR TITLE
fix(server): Fix db initialization in stable state

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -704,7 +704,6 @@ void DbSlice::Release(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
 
 bool DbSlice::CheckLock(IntentLock::Mode mode, const KeyLockArgs& lock_args) const {
   DCHECK(!lock_args.args.empty());
-
   const auto& lt = db_arr_[lock_args.db_index]->trans_locks;
   for (size_t i = 0; i < lock_args.args.size(); i += lock_args.key_step) {
     auto s = lock_args.args[i];

--- a/src/server/journal/executor.cc
+++ b/src/server/journal/executor.cc
@@ -4,10 +4,38 @@
 
 #include "server/journal/executor.h"
 
+#include <absl/strings/str_cat.h>
+#include <absl/strings/str_split.h>
+
+#include <algorithm>
+#include <memory>
+
 #include "base/logging.h"
 #include "server/main_service.h"
 
+using namespace std;
+
 namespace dfly {
+
+namespace {
+// Build a CmdData from parts passed to absl::StrCat.
+template <typename... Ts> journal::ParsedEntry::CmdData BuildFromParts(Ts... parts) {
+  vector<string> raw_parts{absl::StrCat(forward<Ts>(parts))...};
+
+  auto cmd_str = accumulate(raw_parts.begin(), raw_parts.end(), std::string{});
+  auto buf = make_unique<char[]>(cmd_str.size());
+  memcpy(buf.get(), cmd_str.data(), cmd_str.size());
+
+  CmdArgVec slice_parts{};
+  size_t start = 0;
+  for (auto part : raw_parts) {
+    slice_parts.push_back(MutableSlice{buf.get() + start, part.size()});
+    start += part.size();
+  }
+
+  return {std::move(buf), std::move(slice_parts)};
+}
+}  // namespace
 
 JournalExecutor::JournalExecutor(Service* service)
     : service_{service}, conn_context_{&null_sink_, nullptr} {
@@ -16,20 +44,33 @@ JournalExecutor::JournalExecutor(Service* service)
 }
 
 void JournalExecutor::Execute(DbIndex dbid, std::vector<journal::ParsedEntry::CmdData>& cmds) {
-  conn_context_.conn_state.db_index = dbid;
+  SelectDb(dbid);
   for (auto& cmd : cmds) {
     Execute(cmd);
   }
 }
 
 void JournalExecutor::Execute(DbIndex dbid, journal::ParsedEntry::CmdData& cmd) {
-  conn_context_.conn_state.db_index = dbid;
+  SelectDb(dbid);
   Execute(cmd);
 }
 
 void JournalExecutor::Execute(journal::ParsedEntry::CmdData& cmd) {
   auto span = CmdArgList{cmd.cmd_args.data(), cmd.cmd_args.size()};
   service_->DispatchCommand(span, &conn_context_);
+}
+
+void JournalExecutor::SelectDb(DbIndex dbid) {
+  conn_context_.conn_state.db_index = dbid;
+
+  if (ensured_dbs_.size() <= dbid)
+    ensured_dbs_.resize(dbid + 1);
+
+  if (!ensured_dbs_[dbid]) {
+    auto cmd = BuildFromParts("SELECT", dbid);
+    Execute(cmd);
+    ensured_dbs_[dbid] = true;
+  }
 }
 
 }  // namespace dfly

--- a/src/server/journal/executor.h
+++ b/src/server/journal/executor.h
@@ -19,9 +19,15 @@ class JournalExecutor {
 
  private:
   void Execute(journal::ParsedEntry::CmdData& cmd);
+
+  // Select database. Ensure it exists if accessed for first time.
+  void SelectDb(DbIndex dbid);
+
   Service* service_;
   ConnectionContext conn_context_;
   io::NullSink null_sink_;
+
+  std::vector<bool> ensured_dbs_;
 };
 
 }  // namespace dfly


### PR DESCRIPTION
Looks like last bug left for new pytest to pass🥳 

If you try accessing a new database in stable state, it will fail because it doesn't exist on replica. Once the executor sees a new db for the first time, it creates it.

This looks like a very raw solution, probably we should have some execution flag inside the tx framework that will check for this on replica? But I hope this is enough for now