### PR TITLE
fix(server): Flush dbs before full sync

### DIFF
--- a/src/server/journal/executor.cc
+++ b/src/server/journal/executor.cc
@@ -55,6 +55,11 @@ void JournalExecutor::Execute(DbIndex dbid, journal::ParsedEntry::CmdData& cmd) 
   Execute(cmd);
 }
 
+void JournalExecutor::FlushAll() {
+  auto cmd = BuildFromParts("FLUSHALL");
+  Execute(cmd);
+}
+
 void JournalExecutor::Execute(journal::ParsedEntry::CmdData& cmd) {
   auto span = CmdArgList{cmd.cmd_args.data(), cmd.cmd_args.size()};
   service_->DispatchCommand(span, &conn_context_);

--- a/src/server/journal/executor.h
+++ b/src/server/journal/executor.h
@@ -17,6 +17,8 @@ class JournalExecutor {
   void Execute(DbIndex dbid, std::vector<journal::ParsedEntry::CmdData>& cmds);
   void Execute(DbIndex dbid, journal::ParsedEntry::CmdData& cmd);
 
+  void FlushAll();  // Execute FLUSHALL.
+
  private:
   void Execute(journal::ParsedEntry::CmdData& cmd);
 

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -467,8 +467,10 @@ error_code Replica::InitiateDflySync() {
   RETURN_ON_ERR(cntx_.SwitchErrorHandler(std::move(err_handler)));
 
   // Make sure we're in LOADING state.
-  // TODO: Flush db on retry.
   CHECK(service_.SwitchState(GlobalState::ACTIVE, GlobalState::LOADING) == GlobalState::LOADING);
+
+  // Flush dbs.
+  JournalExecutor{&service_}.FlushAll();
 
   // Start full sync flows.
   {


### PR DESCRIPTION
One more issue: Replica is not flushing its DB before retrying full sync.

Is this placement correct? Now the replica flushes after REPLICAOF and before each full sync.