### PR TITLE
fix(build): verify build image for releases

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env sh
+
+APP_PATH=build-opt/dragonfly
 
 set -e
 
@@ -14,6 +16,18 @@ pwd
 
 make HELIO_RELEASE=y release
 
-build-opt/dragonfly --version
+if ! [ -f ${APP_PATH} ]; then
+   echo "ERROR"
+   echo "Failed to generate new dragonfly binary."
+   exit 1
+fi
+
+${APP_PATH} --version
+
+if readelf -a ${APP_PATH} | grep GLIBC_PRIVATE >/dev/null 2>&1 ; then
+   echo "ERROR"
+   echo "The generated binary contain invalid GLIBC version entries."
+   exit 1
+fi
 
 make package


### PR DESCRIPTION
Signed-off-by: Boaz Sade <boaz@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
This commit include:
- update helio version that include a fix in the code to ensure that we will not have link issue (not using getaddrinfo_a)
- the build script that we are using as part of the releases will ensure that the code is able to link outside of the build machine (ubuntu 20.04)