### PR TITLE
fix(server): Fix shutdown order

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -498,13 +498,13 @@ void Service::Shutdown() {
   // rejected
   pp_.AwaitFiberOnAll([](ProactorBase* pb) { ServerState::tlocal()->Shutdown(); });
 
-  engine_varz.reset();
-  request_latency_usec.Shutdown();
-
   // to shutdown all the runtime components that depend on EngineShard.
   server_family_.Shutdown();
   StringFamily::Shutdown();
   GenericFamily::Shutdown();
+
+  engine_varz.reset();
+  request_latency_usec.Shutdown();
 
   shard_set->Shutdown();
 


### PR DESCRIPTION
When cancelling the replica while it was about to execute `FlushAll()`, the instance would crash.

As far as I understand, when stopping the instance, all transactions are stopped when destroying the connection that spawned them. But for the journal executor we don't have one.

It would crash because the varz parts are finalized before the replica is, so I just swapped them. It seems to be working now. Not sure if this order breaks anything?