### PR TITLE
feat(actions): add support for debian packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,18 +98,28 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
+    - name: Configure
+      run: |
+          apt update && apt install -y debhelper
     - name: Build artifacts
       run: |
           # Work around https://github.com/actions/checkout/issues/766
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git describe --always --tags ${{ github.sha }}
           ./tools/release.sh
+          # once the build is over, we want to generate a Debian package
+          ./tools/packaging/generate_debian_package.sh build-opt/dragonfly-x86_64
+    - name: Save artifacts
+      run: |
+          # place all artifacts at the same location
+          mkdir -p results-artifacts
+          mv build-opt/dragonfly-*tar.gz results-artifacts
+          mv dragonfly_*.deb results-artifacts
     - name: Upload
       uses: actions/upload-artifact@v3
       with:
         name: dragonfly-amd64
-        path: build-opt/dragonfly-*tar.gz
-
+        path: results-artifacts/*
   publish_release:
     runs-on: ubuntu-latest
     needs: [build-native, build-qemu]

--- a/tools/packaging/generate_changelog.sh
+++ b/tools/packaging/generate_changelog.sh
@@ -18,9 +18,16 @@ THIS_DIR=$(dirname ${SCRIPT_ABS_PATH})
 GIT_DIR=$1
 PACKGE_DIR=${THIS_DIR}/debian
 CHANGE_LOG=${PACKGE_DIR}/changelog
-
 cd ${GIT_DIR}
 git config --global --add safe.directory ${GIT_DIR}
+has_tags=$(git tag -l v* | wc -l 2>/dev/null)
+if [ "$has_tags" = "" -o "$has_tags" = "0" ]; then
+	git fetch --all --tags || {
+		echo "failed to fetch tags, cannot build changelog file"
+		exit 1
+	}
+fi
+
 >${CHANGE_LOG}
 prevtag=v0.2.0
 pkgname=`cat ${PACKGE_DIR}/control | grep '^Package: ' | sed 's/^Package: //'`
@@ -28,3 +35,13 @@ git tag -l v* | sort -V | while read tag; do
     (echo "$pkgname (${tag#v}) unstable; urgency=low"; git log --pretty=format:'  * %s' $prevtag..$tag; git log --pretty='format:%n%n -- %aN <%aE>  %aD%n%n' $tag^..$tag) | cat - ${CHANGE_LOG} | sponge ${CHANGE_LOG}
         prevtag=$tag
 done
+if [ -f ${CHANGE_LOG} ]; then
+	haslnes=$(wc -l ${CHANGE_LOG} 2>/dev/null | awk '{print $1}')
+	if [ "$haslnes" = "" ]; then
+		echo "empty file ${CHANGE_LOG}, failed to generate changelog"
+		exit 1
+	fi
+else
+	echo "failed to generate ${CHANGE_LOG}"
+	exit 1
+fi


### PR DESCRIPTION
Signed-off-by: Boaz Sade <boaz@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
This complement PR [689](https://github.com/dragonflydb/dragonfly/commit/57e3ec9a81f72d649997f54646d786592aec5166).
And should complete issue #249 
It would generate along with the normal binaries, an installation package for Debian, that can be used for installation on Debian based distributions. 
There is a change in the package generation as well:
In order to ensure that we can generate the change log file, we are trying to fetch them if they do not exists. 
The reason that this is required is to make sure that we are creating unique deb package with different version number for each of these builds.