### PR TITLE
feat(build): debian package building fix dependency bug

### DIFF
--- a/tools/packaging/debian/control
+++ b/tools/packaging/debian/control
@@ -7,6 +7,6 @@ Vcs-Git: https://github.com/dragonflydb/dragonfly
 
 Package: dragonfly
 Architecture: amd64 arm64
-Depends: libc6, openssl, adduser, systemctl
+Depends: libc6, openssl, adduser
 Homepage: https://dragonflydb.io
 Description: A fast in-memory store that is fully compatible with Redis™* and Memcached.


### PR DESCRIPTION
Signed-off-by: Boaz Sade <boaz@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
There was an issue with the dependency on systemctl. This would cause serious issue when systemd is installed. Remove it then verify that the resulting package install successfully on Ubuntu 20/22 and Debian 11