### PR TITLE
fix(server): fix getex command with persist can get time overflow

### DIFF
--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -403,8 +403,8 @@ OpStatus SetCmd::Set(const SetParams& params, string_view key, string_view value
   db_slice.PostUpdate(op_args_.db_cntx.db_index, it, key, false);
 
   if (params.expire_after_ms) {
-    db_slice.UpdateExpire(op_args_.db_cntx.db_index, it,
-                          params.expire_after_ms + op_args_.db_cntx.time_now_ms);
+    db_slice.AddExpire(op_args_.db_cntx.db_index, it,
+                       params.expire_after_ms + op_args_.db_cntx.time_now_ms);
   }
 
   if (params.memcache_flags)
@@ -447,7 +447,7 @@ OpStatus SetCmd::SetExisting(const SetParams& params, PrimeIterator it, ExpireIt
   if (!(params.flags & SET_KEEP_EXPIRE)) {
     if (at_ms) {  // Command has an expiry paramater.
       if (IsValid(e_it)) {
-        // Updated exisitng expiry information.
+        // Updated existing expiry information.
         e_it->second = db_slice.FromAbsoluteTime(at_ms);
       } else {
         // Add new expiry information.


### PR DESCRIPTION
Signed-off-by: Boaz Sade <boaz@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
This fix issue #705 
GETEX command with PERSIST will result in integer overflow since in this case, the expiration time cannot be calculated.
The fix is, in case we have persist enable, don't try to calculate the persist time, just set as persist value.