### PR TITLE
feat(server): admin port and interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ In addition, it has Dragonfly specific arguments options:
  * `hz` - key expiry evaluation frequency. Default is 100. Lower frequency uses less cpu when
    idle at the expense of slower eviction rate.
  * `save_schedule` - glob spec for the UTC time to save a snapshot which matches HH:MM (24h time). default: ""
+ * `primary_port_http_enabled` - If true allows accessing http console on main TCP port, default: true
+ * `admin_port` - If set, would enable admin access to console on the assigned port. This supports both HTTP and RESP protocols. default disabled
+ * `admin_bind` - If set, the admin consol TCP connection would be bind the given address. This supports both HTTP and RESP protocols. default any
 
 ### Example Start Script, with popular options:
 

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -417,14 +417,12 @@ io::Result<bool> Connection::CheckForHttpProto(FiberSocketBase* peer) {
   bool enabled = absl::GetFlag(FLAGS_primary_port_http_enabled);
   if (!enabled) {
     uint16_t admin_port = absl::GetFlag(FLAGS_admin_port);
-    if (admin_port != 0) {
-      // check if this connection is from the admin port, if so, override primary_port_http_enabled
-      LinuxSocketBase* lsb = static_cast<LinuxSocketBase*>(socket_.get());
-      enabled = lsb->LocalEndpoint().port() == admin_port;
-    }
-    if (!enabled) {
-      return false;
-    }
+    // check if this connection is from the admin port, if so, override primary_port_http_enabled
+    LinuxSocketBase* lsb = static_cast<LinuxSocketBase*>(socket_.get());
+    enabled = lsb->LocalEndpoint().port() == admin_port;
+  }
+  if (!enabled) {
+    return false;
   }
   size_t last_len = 0;
   do {


### PR DESCRIPTION
Signed-off-by: Boaz Sade <boaz@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
Fix issue #668 
This will:
* change the flag http_admin_console --> primary_port_http_enabled.
* Add flag admin_port that when set, enable connecting with HTTP/RESP to this port.
* Add flag admin_bind that when set (together with admin_port),  enable connection with HTTP/RESP on this address/port.
* By default these two new flags are disabled.
* Note that if the connection is from admin port while admin port is enabled, it will allow HTTP connection to this port/address only. Trying to connect to the console from the "normal" port will not for HTTP connection