### PR TITLE
feat(action): build debian package for arm64 arch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,8 @@ jobs:
               done
             fi
             ./tools/release.sh
+            ./tools/packaging/generate_debian_package.sh build-opt/dragonfly-aarch64
+            mv dragonfly_*.deb build-opt/
     - name: Show the artifact
       # Items placed in /src/build-opt in the container will be in
       # ${PWD}/build-opt on the host.
@@ -87,7 +89,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: dragonfly-aarch64
-        path: build-opt/dragonfly-*tar.gz
+        path: build-opt/dragonfly-*tar.gz, build-opt/dragonfly_*.deb
 
   build-native:
     runs-on: ubuntu-latest

--- a/tools/packaging/generate_debian_package.sh
+++ b/tools/packaging/generate_debian_package.sh
@@ -12,10 +12,22 @@
 # Please note that is must run from main branch.
 # Best running this from inside a container.
 # The result are writing to the location from which you would execute the script (not where the script is located).
-# Version number is the tag number. Currently this would only generate a package for amd64.
+# Version number is the tag number.
+# Params:
+#	* optional location to the binary to place at the package
 
 
 set -eu
+
+ARCH_VAL=amd64
+if [ "$(uname -m)" = "x86_64" ]; then
+	ARCH_VAL="amd64"
+elif [ "$(uname -m)" = "aarch64" ]; then
+	ARCH_VAL="aarch64"
+else
+	echo "Unknown architecture: $(uname -m). Only x86_64 and aarch64 are supported."
+        exit 1
+fi
 
 SCRIPT_ABS_PATH=$(realpath $0)
 SCRIPT_PATH=$(dirname ${SCRIPT_ABS_PATH})
@@ -26,7 +38,6 @@ ROOT_ABS_PATH=$(cd ${SCRIPT_PATH}; while [ ! -d ${BUILD_DIR} ]; do cd ..; done ;
 REPO_PATH=${ROOT_ABS_PATH}
 TEMP_WORK_DIR=$(mktemp -d)
 BASE_DIR=${TEMP_WORK_DIR}/packges
-ARCH_VAL=amd64
 BASE_PATH=${BASE_DIR}/dragonfly_${ARCH_VAL}
 BINARY_TARGET_DIR=${BASE_PATH}/debian/bin
 
@@ -48,7 +59,7 @@ fi
 
 mkdir -p ${BASE_PATH} || cleanup "failed to create working directory for building the package"
 
-cp -r ${PACKAGES_PATH} ${BASE_PATH} || cleanup "failed to copy required for the package build from ${PACKAGES_PATH}"
+cp -r ${PACKAGES_PATH} ${BASE_PATH} || cleanup "failed to copy required files for the package build from ${PACKAGES_PATH}"
 
 cp ${SCRIPT_PATH}/${CHANGELOG_SCRIPT} ${BASE_PATH} || cleanup "failed to copy changelog script to ${BASE_PATH}"
 


### PR DESCRIPTION
Signed-off-by: Boaz Sade <boaz@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
This would add support for building the debian package for ARM64 based arch.
* The git action file will run the script that generate a package for ARM as well as for x86.
* The build script is now accepting new arg of the arch type.
* The build of the ARM package can only be run inside environment that is itself ARM64.