### PR TITLE
fix: a small warning fix.

### DIFF
--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -490,8 +490,7 @@ OpStatus SetCmd::SetExisting(const SetParams& params, PrimeIterator it, ExpireIt
 }
 
 void SetCmd::RecordJournal(const SetParams& params, string_view key, string_view value) {
-  absl::InlinedVector<string_view, 5> cmds{};  // 4 is theoretical maximum;
-  cmds.insert(cmds.end(), {key, value});
+  absl::InlinedVector<string_view, 5> cmds({key, value});  // 4 is theoretical maximum;
 
   std::string exp_str;
   if (params.flags & SET_EXPIRE_AFTER_MS) {


### PR DESCRIPTION
on my machine it gave me:
```
inlined from ‘void dfly::SetCmd::RecordJournal(const dfly::SetCmd::SetParams&, std::string_view, std::string_view)’ at /home/roman/projects/dragonfly/src/server/string_family.cc:494:14: /home/roman/projects/dragonfly/build-opt/_deps/abseil_cpp-src/absl/container/inlined_vector.h:627:29: warning: ‘cmds’ may be used uninitialized [-Wmaybe-uninitialized]
```

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->