### PR TITLE
fix(lua): Fix a deadlock happenning when calling a lua script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           echo Run ctest -V -L DFLY
           #GLOG_logtostderr=1 GLOG_vmodule=transaction=1,engine_shard_set=1
           GLOG_logtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 ctest -V -L DFLY
-          ./dragonfly_test  --mem_defrag_threshold=0.05 # trying to catch issue with defrag
+          ./dragonfly_test  --gtest_repeat=100
           # GLOG_logtostderr=1 GLOG_vmodule=transaction=1,engine_shard_set=1 CTEST_OUTPUT_ON_FAILURE=1 ninja server/test
   lint-test-chart:
     runs-on: ubuntu-latest

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -904,7 +904,7 @@ pair<bool, bool> Transaction::ScheduleInShard(EngineShard* shard) {
     // All transactions in the queue must acquire the intent lock.
     lock_granted = shard->db_slice().Acquire(mode, lock_args) && shard_unlocked;
     sd.local_mask |= KEYLOCK_ACQUIRED;
-    DVLOG(1) << "Lock granted " << lock_granted << " for trans " << DebugId();
+    DVLOG(2) << "Lock granted " << lock_granted << " for trans " << DebugId();
   }
 
   if (!txq->Empty()) {


### PR DESCRIPTION
The scenario is described in a unit test that reproduces the issue with high chance. Also added dragonfly_test in repeat=100 mode to CI.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->