### PR TITLE
fix(sentinel_test):Remove return type which breaks regression tests

### DIFF
--- a/tests/dragonfly/sentinel_test.py
+++ b/tests/dragonfly/sentinel_test.py
@@ -10,7 +10,7 @@ import asyncio
 # Output is expected be of even number of lines where each pair of consecutive lines results in a single key value pair.
 # If new_dict_key is not empty, encountering it in the output will start a new dictionary, this let us return multiple
 # dictionaries, for example in the 'slaves' command, one dictionary for each slave.
-def stdout_as_list_of_dicts(cp: subprocess.CompletedProcess, new_dict_key ="") -> list[dict]:
+def stdout_as_list_of_dicts(cp: subprocess.CompletedProcess, new_dict_key =""):
     lines = cp.stdout.splitlines()
     res = []
     d = None


### PR DESCRIPTION
Signed-off-by: ashotland <ari@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->