### PR TITLE
fix(regression-tests): sentinel_test.py: Ditch docker whcih is complex on CI in favour of local redis binary

### DIFF
--- a/tests/dragonfly/sentinel_test.py
+++ b/tests/dragonfly/sentinel_test.py
@@ -56,7 +56,7 @@ class Sentinel:
     def start(self):
         config = [
             f"port {self.port}",
-            f"sentinel monitor {self.default_deployment} 127.0.01 {self.initial_master_port} 1",
+            f"sentinel monitor {self.default_deployment} 127.0.0.1 {self.initial_master_port} 1",
             f"sentinel down-after-milliseconds {self.default_deployment} 3000"
             ]
         self.config_file.write_text("\n".join(config))


### PR DESCRIPTION
Successful CI run:
https://github.com/dragonflydb/dragonfly/actions/runs/4095713187/jobs/7062824086


Signed-off-by: ashotland <ari@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->