### PR TITLE
feat(server): Extend malloc-stats command functionality.

### DIFF
--- a/src/core/segment_allocator.cc
+++ b/src/core/segment_allocator.cc
@@ -3,7 +3,14 @@
 //
 #include "core/segment_allocator.h"
 
+#include <mimalloc-types.h>
+
 #include "base/logging.h"
+
+constexpr size_t kSegmentSize = MI_SEGMENT_SIZE;
+
+// mimalloc uses 32MiB segments and we might need change this code if it changes.
+static_assert(kSegmentSize == 1 << 25);
 
 namespace dfly {
 
@@ -11,12 +18,11 @@ SegmentAllocator::SegmentAllocator(mi_heap_t* heap) : heap_(heap) {
 }
 
 void SegmentAllocator::ValidateMapSize() {
-  CHECK_LT(address_table_.size(), 1u << 12)
-      << "TODO: to monitor address_table_ map, it should not grow to such sizes";
-
-  // TODO: we should learn how large this maps can grow for very large databases.
-  // We should learn if mimalloc drops (deallocates) segments and we need to perform GC
-  // to protect ourselves from bloated address table.
+  if (address_table_.size() > 1u << 12) {
+    // This can happen if we restrict dragonfly to small number of threads on high-memory machine,
+    // for example.
+    LOG(WARNING) << "address_table_ map is growing too large: " << address_table_.size();
+  }
 }
 
 }  // namespace dfly

--- a/src/core/segment_allocator.h
+++ b/src/core/segment_allocator.h
@@ -47,7 +47,9 @@ class SegmentAllocator {
     return heap_;
   }
 
-  size_t used() const { return used_; }
+  size_t used() const {
+    return used_;
+  }
 
  private:
   static uint32_t Offset(Ptr p) {
@@ -77,7 +79,8 @@ inline auto SegmentAllocator::Allocate(uint32_t size) -> std::pair<Ptr, uint8_t*
     address_table_.push_back((uint8_t*)seg_ptr);
   }
 
-  Ptr res = (((iptr - seg_ptr) / 8) << kSegmentIdBits) | it->second;
+  uint32_t seg_offset = (iptr - seg_ptr) / 8;
+  Ptr res = (seg_offset << kSegmentIdBits) | it->second;
   used_ += mi_good_size(size);
 
   return std::make_pair(res, (uint8_t*)ptr);

--- a/src/server/memory_cmd.h
+++ b/src/server/memory_cmd.h
@@ -17,8 +17,6 @@ class MemoryCmd {
   void Run(CmdArgList args);
 
  private:
-  std::string MallocStats(unsigned tid);
-
   ServerFamily& sf_;
   ConnectionContext* cntx_;
 };


### PR DESCRIPTION
1. Remove dangerous check-fail in SegmentAllocator.
2. Allow printing heap stats for both backing and data heaps.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->