### PR TITLE
feat(replica): add debug command - replica offset

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -105,7 +105,7 @@ void DebugCmd::Run(CmdArgList args) {
         "REPLICA PAUSE/RESUME",
         "    Stops replica from reconnecting to master, or resumes",
         "REPLICA OFFSET",
-        "    Get number of journal commands executed for each replica flow",
+        "    Return sync id and array of number of journal commands executed for each replica flow",
         "WATCHED",
         "    Shows the watched keys as a result of BLPOP and similar operations.",
         "POPULATE <count> [<prefix>] [<size>] [RAND]",

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -195,8 +195,9 @@ void DebugCmd::Replica(CmdArgList args) {
   } else if (opt == "OFFSET") {
     const auto& offset_info = sf_.GetReplicaOffsetInfo();
     if (offset_info) {
-      (*cntx_)->StartArray(offset_info.value().flow_offsets.size() + 1);
+      (*cntx_)->StartArray(2);
       (*cntx_)->SendBulkString(offset_info.value().sync_id);
+      (*cntx_)->StartArray(offset_info.value().flow_offsets.size());
       for (uint64_t offset : offset_info.value().flow_offsets) {
         (*cntx_)->SendLong(offset);
       }

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -104,6 +104,8 @@ void DebugCmd::Run(CmdArgList args) {
         "      existing RDB file.",
         "REPLICA PAUSE/RESUME",
         "    Stops replica from reconnecting to master, or resumes",
+        "REPLICA OFFSET",
+        "    Get number of journal commands executed for each replica flow",
         "WATCHED",
         "    Shows the watched keys as a result of BLPOP and similar operations.",
         "POPULATE <count> [<prefix>] [<size>] [RAND]",
@@ -190,6 +192,18 @@ void DebugCmd::Replica(CmdArgList args) {
   if (opt == "PAUSE" || opt == "RESUME") {
     sf_.PauseReplication(opt == "PAUSE");
     return (*cntx_)->SendOk();
+  } else if (opt == "OFFSET") {
+    const auto& offset_info = sf_.GetReplicaOffsetInfo();
+    if (offset_info) {
+      (*cntx_)->StartArray(offset_info.value().flow_offsets.size() + 1);
+      (*cntx_)->SendBulkString(offset_info.value().sync_id);
+      for (uint64_t offset : offset_info.value().flow_offsets) {
+        (*cntx_)->SendLong(offset);
+      }
+      return;
+    } else {
+      return (*cntx_)->SendError("I am master");
+    }
   }
   return (*cntx_)->SendError(UnknownSubCmd("replica", "DEBUG"));
 }

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -193,7 +193,7 @@ void DebugCmd::Replica(CmdArgList args) {
     sf_.PauseReplication(opt == "PAUSE");
     return (*cntx_)->SendOk();
   } else if (opt == "OFFSET") {
-    const auto& offset_info = sf_.GetReplicaOffsetInfo();
+    const auto offset_info = sf_.GetReplicaOffsetInfo();
     if (offset_info) {
       (*cntx_)->StartArray(2);
       (*cntx_)->SendBulkString(offset_info.value().sync_id);

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -63,6 +63,7 @@ class Replica {
     DbIndex dbid;
     uint32_t shard_cnt;
     std::vector<journal::ParsedEntry::CmdData> commands;
+    // Counting the number of journal records in specific transaction in specific shard.
     uint32_t journal_rec_count = 0;
   };
 
@@ -220,6 +221,7 @@ class Replica {
   bool use_multi_shard_exe_sync_;
 
   std::unique_ptr<JournalExecutor> executor_;
+  // Count the number of journal records executed in specific flow
   std::atomic_uint64_t journal_rec_executed_ = 0;
 
   // MainReplicationFb in standalone mode, FullSyncDflyFb in flow mode.

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -755,6 +755,18 @@ void ServerFamily::PauseReplication(bool pause) {
   }
 }
 
+std::optional<ReplicaOffsetInfo> ServerFamily::GetReplicaOffsetInfo() {
+  unique_lock lk(replicaof_mu_);
+
+  // Switch to primary mode.
+  if (!ServerState::tlocal()->is_master) {
+    auto repl_ptr = replica_;
+    CHECK(repl_ptr);
+    return ReplicaOffsetInfo{repl_ptr->GetSyncId(), repl_ptr->GetReplicaOffset()};
+  }
+  return nullopt;
+}
+
 void ServerFamily::OnClose(ConnectionContext* cntx) {
   dfly_cmd_->OnClose(cntx);
 }

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1531,7 +1531,6 @@ void ServerFamily::ReplicaOf(CmdArgList args, ConnectionContext* cntx) {
     // use this lock as critical section to prevent concurrent replicaof commands running.
     unique_lock lk(replicaof_mu_);
 
-    // Switch to primary mode.
     if (!ServerState::tlocal()->is_master) {
       auto repl_ptr = replica_;
       CHECK(repl_ptr);

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -61,6 +61,11 @@ struct SnapshotSpec {
   std::string minute_spec;
 };
 
+struct ReplicaOffsetInfo {
+  std::string sync_id;
+  std::vector<uint64_t> flow_offsets;
+};
+
 class ServerFamily {
  public:
   ServerFamily(Service* service);
@@ -103,6 +108,7 @@ class ServerFamily {
   void ConfigureMetrics(util::HttpListenerBase* listener);
 
   void PauseReplication(bool pause);
+  std::optional<ReplicaOffsetInfo> GetReplicaOffsetInfo();
 
   const std::string& master_id() const {
     return master_id_;

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -87,7 +87,6 @@ async def check_replica_finished_exec(c_replica, c_master):
     r_offset = await c_replica.execute_command("DEBUG REPLICA OFFSET")
     command = "DFLY REPLICAOFFSET " + r_offset[0].decode()
     m_offset = await c_master.execute_command(command)
-    print(r_offset[1])
     return r_offset[1] == m_offset
 
 

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -87,7 +87,8 @@ async def check_replica_finished_exec(c_replica, c_master):
     r_offset = await c_replica.execute_command("DEBUG REPLICA OFFSET")
     command = "DFLY REPLICAOFFSET " + r_offset[0].decode()
     m_offset = await c_master.execute_command(command)
-    return r_offset[1:] == m_offset
+    print(r_offset[1])
+    return r_offset[1] == m_offset
 
 
 async def check_all_replicas_finished(c_replicas, c_master):


### PR DESCRIPTION
Signed-off-by: adi_holden <adi@dragonflydb.io>

 1. Add DEBUG REPLICA OFFSET command which will return the sync id and array offsets for each flow
 2. fix bug in Replica::TransactionReader::NextTxData
