### PR TITLE
Basic multi modes for MULTI/EXEC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
           #GLOG_logtostderr=1 GLOG_vmodule=transaction=1,engine_shard_set=1
           GLOG_logtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 ctest -V -L DFLY
           ./dragonfly_test  --gtest_repeat=10
+          ./multi_test --multi_exec_mode=2 --gtest_repeat=10
+          ./multi_test --multi_exec_mode=3 --gtest_repeat=10
           # GLOG_logtostderr=1 GLOG_vmodule=transaction=1,engine_shard_set=1 CTEST_OUTPUT_ON_FAILURE=1 ninja server/test
   lint-test-chart:
     runs-on: ubuntu-latest

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -58,12 +58,21 @@ struct KeyLockArgs {
 
 // Describes key indices.
 struct KeyIndex {
-  // if index is non-zero then adds another key index (usually 1).
-  // relevant for for commands like ZUNIONSTORE/ZINTERSTORE for destination key.
-  unsigned bonus = 0;
   unsigned start;
   unsigned end;   // does not include this index (open limit).
   unsigned step;  // 1 for commands like mget. 2 for commands like mset.
+
+  // if index is non-zero then adds another key index (usually 1).
+  // relevant for for commands like ZUNIONSTORE/ZINTERSTORE for destination key.
+  unsigned bonus = 0;
+
+  static KeyIndex Empty() {
+    return KeyIndex{0, 0, 0, 0};
+  }
+
+  static KeyIndex Range(unsigned start, unsigned end, unsigned step = 1) {
+    return KeyIndex{start, end, step, 0};
+  }
 
   bool HasSingleKey() const {
     return bonus == 0 && (start + step >= end);

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -674,7 +674,6 @@ size_t DbSlice::DbSize(DbIndex db_ind) const {
 }
 
 bool DbSlice::Acquire(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
-  DCHECK(!lock_args.args.empty());
   DCHECK_GT(lock_args.key_step, 0u);
 
   auto& lt = db_arr_[lock_args.db_index]->trans_locks;
@@ -701,8 +700,6 @@ bool DbSlice::Acquire(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
 }
 
 void DbSlice::Release(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
-  DCHECK(!lock_args.args.empty());
-
   DVLOG(2) << "Release " << IntentLock::ModeName(mode) << " for " << lock_args.args[0];
   if (lock_args.args.size() == 1) {
     Release(mode, lock_args.db_index, lock_args.args.front(), 1);


### PR DESCRIPTION
This commit adds the notion of multi transaction modes that allow controlling the execution and
locking behaviour of multi transactions.
In general, there are four modes:
- GLOBAL: all commands run within a global transaction. There is no need for recording locks. Lua scripts can theoretically run with undeclared keys.
- LOCK_AHEAD: the transaction locks all keys ahead likewise to a regular transaction and schedules itself.
- LOCK_INCREMENTAL: the transaction determines what shards it has keys in and schedules itself on those shards, but locks only when accessing a new key. This allows other transactions to run ooo alonside with a big multi-transaction that accesses a contended key only at its very end.
- NON_ATOMIC: all commands run separately, no atomicity is provided, likewise to a pipeline

This commit only adds support for the first 3 modes to EXEC commands.

Signed-off-by: Vladislav Oleshko <vlad@dragonflydb.io>