### PR TITLE
feat(server): save dragonfly snapshot in a new format by default

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -27,6 +27,7 @@ using namespace std;
 
 ABSL_DECLARE_FLAG(string, dir);
 ABSL_DECLARE_FLAG(string, dbfilename);
+ABSL_DECLARE_FLAG(bool, df_snapshot_format);
 
 namespace dfly {
 
@@ -174,7 +175,7 @@ void DebugCmd::Reload(CmdArgList args) {
     trans->InitByArgs(0, {});
     VLOG(1) << "Performing save";
 
-    GenericError ec = sf_.DoSave(false, trans.get());
+    GenericError ec = sf_.DoSave(absl::GetFlag(FLAGS_df_snapshot_format), trans.get());
     if (ec) {
       return (*cntx_)->SendError(ec.Format());
     }


### PR DESCRIPTION
Introduce a new flag `df_snapshot_format` that controls the default behavior. The flag itself is defaulted to save snapshots in a new Dragonfly specific format.

BREAKING CHANGE: before that Dragonfly saved snapshots in rdb format by default. Now the flag controls which format is chosen when issuing SAVE/BGSAVE commands. In addition, "SAVE DF", "SAVE RDB" can be used to save using dragonfly/redis formats accordingly.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->