### PR TITLE
chore(server): reduce number of allocations with multi-exec commands

### DIFF
--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -17,11 +17,19 @@ namespace dfly {
 using namespace std;
 
 StoredCmd::StoredCmd(const CommandId* d, CmdArgList args) : descr(d) {
-  stored_args_.reserve(args.size());
+  size_t total_size = 0;
+  for (auto args : args) {
+    total_size += args.size();
+  }
+
+  backing_storage_.reset(new char[total_size]);
   arg_vec_.resize(args.size());
+  char* next = backing_storage_.get();
   for (size_t i = 0; i < args.size(); ++i) {
-    stored_args_.emplace_back(ArgS(args, i));
-    arg_vec_[i] = MutableSlice{stored_args_[i].data(), stored_args_[i].size()};
+    auto src = args[i];
+    memcpy(next, src.data(), src.size());
+    arg_vec_[i] = MutableSlice{next, src.size()};
+    next += src.size();
   }
   arg_list_ = {arg_vec_.data(), arg_vec_.size()};
 }

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -19,7 +19,7 @@ struct StoredCmd {
   const CommandId* descr;
 
  private:
-  std::vector<std::string> stored_args_;
+  std::unique_ptr<char[]> backing_storage_;
   CmdArgVec arg_vec_;
   CmdArgList arg_list_;
 


### PR DESCRIPTION

This is useful when DF is used to store large blobs and MULTI is used.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->