### PR TITLE
feat(core): Add Ttl semantics to string_map

### DIFF
--- a/src/core/string_map_test.cc
+++ b/src/core/string_map_test.cc
@@ -90,10 +90,31 @@ TEST_F(StringMapTest, Basic) {
   EXPECT_GT(sm_->ObjMallocUsed(), sz);
   it = sm_->begin();
   EXPECT_STREQ("baraaaaaaaaaaaa2", it->second);
+
+  EXPECT_FALSE(sm_->AddOrSkip("foo", "bar2"));
+  EXPECT_STREQ("baraaaaaaaaaaaa2", it->second);
 }
 
 TEST_F(StringMapTest, EmptyFind) {
   sm_->Find("bar");
+}
+
+TEST_F(StringMapTest, Ttl) {
+  EXPECT_TRUE(sm_->AddOrUpdate("bla", "val1", 1));
+  EXPECT_FALSE(sm_->AddOrUpdate("bla", "val2", 1));
+  sm_->set_time(1);
+  EXPECT_TRUE(sm_->AddOrUpdate("bla", "val2", 1));
+  EXPECT_EQ(1u, sm_->Size());
+
+  EXPECT_FALSE(sm_->AddOrSkip("bla", "val3", 2));
+
+  // set ttl to 2, meaning that the key will expire at time 3.
+  EXPECT_TRUE(sm_->AddOrSkip("bla2", "val3", 2));
+  EXPECT_TRUE(sm_->Contains("bla2"));
+
+  sm_->set_time(3);
+  auto it = sm_->begin();
+  EXPECT_TRUE(it == sm_->end());
 }
 
 }  // namespace dfly

--- a/src/core/string_set.cc
+++ b/src/core/string_set.cc
@@ -39,7 +39,7 @@ StringSet::~StringSet() {
 }
 
 bool StringSet::AddSds(sds s1) {
-  return AddOrFind(s1, false) == nullptr;
+  return AddOrFindObj(s1, false) == nullptr;
 }
 
 bool StringSet::Add(string_view src, uint32_t ttl_sec) {
@@ -60,7 +60,7 @@ bool StringSet::Add(string_view src, uint32_t ttl_sec) {
     has_ttl = true;
   }
 
-  if (AddOrFind(newsds, has_ttl) != nullptr) {
+  if (AddOrFindObj(newsds, has_ttl) != nullptr) {
     sdsfree(newsds);
     return false;
   }


### PR DESCRIPTION
Now string_map respects the optional ttl argument that accepts ttl time in seconds. Upon traversing and accessing expirerd elements they will be transparently removed and deleted from the map.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->