### PR TITLE
feat(server): Add HSETEX command

### DIFF
--- a/src/server/common.h
+++ b/src/server/common.h
@@ -325,4 +325,11 @@ struct ScanOpts {
   static OpResult<ScanOpts> TryFrom(CmdArgList args);
 };
 
+// I use relative time from Feb 1, 2023 in seconds.
+constexpr uint64_t kMemberExpiryBase = 1675209600;
+
+inline uint32_t MemberTimeSeconds(uint64_t now_ms) {
+  return (now_ms / 1000) - kMemberExpiryBase;
+}
+
 }  // namespace dfly

--- a/src/server/hset_family.h
+++ b/src/server/hset_family.h
@@ -27,6 +27,8 @@ class HSetFamily {
   static StringMap* ConvertToStrMap(uint8_t* lp);
 
  private:
+  // TODO: to move it to anonymous namespace in cc file.
+
   static void HDel(CmdArgList args, ConnectionContext* cntx);
   static void HLen(CmdArgList args, ConnectionContext* cntx);
   static void HExists(CmdArgList args, ConnectionContext* cntx);
@@ -42,8 +44,6 @@ class HSetFamily {
   static void HSetNx(CmdArgList args, ConnectionContext* cntx);
   static void HStrLen(CmdArgList args, ConnectionContext* cntx);
   static void HRandField(CmdArgList args, ConnectionContext* cntx);
-
-  static void HGetGeneric(CmdArgList args, ConnectionContext* cntx, uint8_t getall_mask);
 };
 
 }  // namespace dfly

--- a/src/server/hset_family_test.cc
+++ b/src/server/hset_family_test.cc
@@ -191,4 +191,16 @@ TEST_F(HSetFamilyTest, HRandFloat) {
   Run({"hrandfield", "k"});
 }
 
+TEST_F(HSetFamilyTest, HSetEx) {
+  TEST_current_time_ms = kMemberExpiryBase * 1000;  // to reset to test time.
+
+  EXPECT_THAT(Run({"HSETEX", "k", "1", "f", "v"}), IntArg(1));
+
+  AdvanceTime(500);
+  EXPECT_THAT(Run({"HGET", "k", "f"}), "v");
+
+  AdvanceTime(500);
+  EXPECT_THAT(Run({"HGET", "k", "f"}), ArgType(RespExpr::NIL));
+}
+
 }  // namespace dfly


### PR DESCRIPTION
The format as follows: `HSETEX key seconds field value [field value ...]` This allows adding hset members with expiration time in seconds.

Both `SADDEX` and HSETEX` do not support currently RDB serialization and replication.
This will be added in subsequent PRs.

Fixes #687

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->