### PR TITLE
EVAL multi modes + non atomic modes

### DIFF
--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -34,10 +34,6 @@ StoredCmd::StoredCmd(const CommandId* d, CmdArgList args) : descr(d) {
   arg_list_ = {arg_vec_.data(), arg_vec_.size()};
 }
 
-void StoredCmd::Invoke(ConnectionContext* ctx) {
-  descr->Invoke(arg_list_, ctx);
-}
-
 void ConnectionContext::ChangeMonitor(bool start) {
   // This will either remove or register a new connection
   // at the "top level" thread --> ServerState context

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -29,8 +29,6 @@ struct StoredCmd {
   CmdArgList ArgList() const {
     return arg_list_;
   }
-
-  void Invoke(ConnectionContext* ctx);
 };
 
 struct ConnectionState {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -723,7 +723,11 @@ void Service::DispatchCommand(CmdArgList args, facade::ConnectionContext* cntx) 
 
   dfly_cntx->cid = cid;
 
-  if (!InvokeCmd(args, cid, dfly_cntx, bool(dist_trans))) {
+  // Collect stats for all regular transactions and all multi transactions from scripts, except EVAL
+  // itself. EXEC does not use DispatchCommand for dispatching.
+  bool collect_stats =
+      dfly_cntx->transaction && (!dfly_cntx->transaction->IsMulti() || under_script);
+  if (!InvokeCmd(args, cid, dfly_cntx, collect_stats)) {
     dfly_cntx->reply_builder()->SendError("Internal Error");
     dfly_cntx->reply_builder()->CloseConnection();
   }

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -39,6 +39,10 @@ class Service : public facade::ServiceInterface {
   void Shutdown();
 
   void DispatchCommand(CmdArgList args, facade::ConnectionContext* cntx) final;
+
+  // Returns true if command was executed successfully.
+  bool InvokeCmd(CmdArgList args, const CommandId* cid, ConnectionContext* cntx, bool record_stats);
+
   void DispatchMC(const MemcacheParser::Command& cmd, std::string_view value,
                   facade::ConnectionContext* cntx) final;
 

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -279,6 +279,7 @@ void Transaction::InitByKeys(KeyIndex key_index) {
       shard_data_.resize(1);
       sd = &shard_data_.front();
     }
+    sd->local_mask |= ACTIVE;
     sd->arg_count = -1;
     sd->arg_start = -1;
   }

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -75,7 +75,7 @@ class Transaction {
     // The shards to schedule on are detemined ahead and remain fixed.
     LOCK_INCREMENTAL = 3,
     // Each command is executed separately. Equivalent to a pipeline.
-    NOT_ATOMIC = 4,
+    NON_ATOMIC = 4,
   };
 
   // State on specific shard.
@@ -150,6 +150,9 @@ class Transaction {
   // Start multi in LOCK_INCREMENTAL mode on given shards.
   void StartMultiLockedIncr(DbIndex dbid, const std::vector<bool>& shards);
 
+  // Start multi in NON_ATOMIC mode.
+  void StartMultiNonAtomic();
+
   // Unlock key locks of a multi transaction.
   void UnlockMulti();
 
@@ -203,6 +206,10 @@ class Transaction {
 
   bool IsMulti() const {
     return bool(multi_);
+  }
+
+  bool IsRunningMulti() const {
+    return multi_ && multi_->mode != NON_ATOMIC;
   }
 
   MultiMode GetMultiMode() const {

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -208,10 +208,6 @@ class Transaction {
     return bool(multi_);
   }
 
-  bool IsRunningMulti() const {
-    return multi_ && multi_->mode != NON_ATOMIC;
-  }
-
   MultiMode GetMultiMode() const {
     return multi_->mode;
   }
@@ -404,6 +400,14 @@ class Transaction {
 
   uint32_t GetUseCount() const {
     return use_count_.load(std::memory_order_relaxed);
+  }
+
+  // Whether the transaction is multi and runs in an atomic mode.
+  // This, instead of just IsMulti(), should be used to check for the possibility of
+  // different optimizations, because they can safely be applied to non-atomic multi
+  // transactions as well.
+  bool IsAtomicMulti() const {
+    return multi_ && multi_->mode != NON_ATOMIC;
   }
 
   unsigned SidToId(ShardId sid) const {

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -205,6 +205,10 @@ class Transaction {
     return bool(multi_);
   }
 
+  MultiMode GetMultiMode() const {
+    return multi_->mode;
+  }
+
   bool IsGlobal() const;
 
   bool IsOOO() const {
@@ -279,8 +283,8 @@ class Transaction {
 
     MultiMode mode;
 
-    absl::flat_hash_map<std::string_view, LockCnt> lock_counts;
-    std::vector<std::string_view> keys;
+    absl::flat_hash_map<std::string, LockCnt> lock_counts;
+    std::vector<std::string> keys;
 
     // The shard_journal_write vector variable is used to determine the number of shards
     // involved in a multi-command transaction. This information is utilized by replicas when


### PR DESCRIPTION
- add multi modes to eval
- add non atomic modes
- allow undeclared kets with global & non atomic modes 

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->