### PR TITLE
feat(server): add debug information about running transactions

### DIFF
--- a/src/server/debugcmd.h
+++ b/src/server/debugcmd.h
@@ -26,6 +26,7 @@ class DebugCmd {
   void Load(std::string_view filename);
   void Inspect(std::string_view key);
   void Watched();
+  void TxAnalysis();
 
   ServerFamily& sf_;
   ConnectionContext* cntx_;


### PR DESCRIPTION
Specifically, provide a total length over all shards of pending txs. Also, provide number of "free" transactions pending in the queue - those that could progress immediately but do not because they are not first in the queue.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->