### PR TITLE
fix(zset): Make count optional for ZPOP{MIN,MAX}

### DIFF
--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1758,16 +1758,18 @@ bool ZSetFamily::ParseRangeByScoreParams(CmdArgList args, RangeParams* params) {
 
 void ZSetFamily::ZPopMinMax(CmdArgList args, bool reverse, ConnectionContext* cntx) {
   string_view key = ArgS(args, 1);
-  string_view count = ArgS(args, 2);
 
   RangeParams range_params;
   range_params.reverse = reverse;
   ZRangeSpec range_spec;
   range_spec.params = range_params;
-  TopNScored sc;
 
-  if (!SimpleAtoi(count, &sc)) {
-    return (*cntx)->SendError(kUintErr);
+  TopNScored sc = 1;
+  if (args.size() > 2) {
+    string_view count = ArgS(args, 2);
+    if (!SimpleAtoi(count, &sc)) {
+      return (*cntx)->SendError(kUintErr);
+    }
   }
 
   range_spec.interval = sc;
@@ -2131,8 +2133,8 @@ void ZSetFamily::Register(CommandRegistry* registry) {
             << CI{"ZINCRBY", CO::FAST | CO::WRITE | CO::DENYOOM, 4, 1, 1, 1}.HFUNC(ZIncrBy)
             << CI{"ZINTERSTORE", kStoreMask, -4, 3, 3, 1}.HFUNC(ZInterStore)
             << CI{"ZLEXCOUNT", CO::READONLY, 4, 1, 1, 1}.HFUNC(ZLexCount)
-            << CI{"ZPOPMAX", CO::READONLY, 3, 1, 1, 1}.HFUNC(ZPopMax)
-            << CI{"ZPOPMIN", CO::READONLY, 3, 1, 1, 1}.HFUNC(ZPopMin)
+            << CI{"ZPOPMAX", CO::FAST | CO::WRITE, -2, 1, 1, 1}.HFUNC(ZPopMax)
+            << CI{"ZPOPMIN", CO::FAST | CO::WRITE, -2, 1, 1, 1}.HFUNC(ZPopMin)
             << CI{"ZREM", CO::FAST | CO::WRITE, -3, 1, 1, 1}.HFUNC(ZRem)
             << CI{"ZRANGE", CO::READONLY, -4, 1, 1, 1}.HFUNC(ZRange)
             << CI{"ZRANK", CO::READONLY | CO::FAST, 3, 1, 1, 1}.HFUNC(ZRank)

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -416,30 +416,36 @@ TEST_F(ZSetFamilyTest, ZAddBug148) {
 }
 
 TEST_F(ZSetFamilyTest, ZPopMin) {
-  auto resp = Run({"zadd", "key", "1", "a", "2", "b", "3", "c", "4", "d", "5", "e"});
-  EXPECT_THAT(resp, IntArg(5));
+  auto resp = Run({"zadd", "key", "1", "a", "2", "b", "3", "c", "4", "d", "5", "e", "6", "f"});
+  EXPECT_THAT(resp, IntArg(6));
+
+  resp = Run({"zpopmin", "key"});
+  ASSERT_THAT(resp, "a");
 
   resp = Run({"zpopmin", "key", "2"});
   ASSERT_THAT(resp, ArrLen(2));
-  EXPECT_THAT(resp.GetVec(), ElementsAre("a", "b"));
+  EXPECT_THAT(resp.GetVec(), ElementsAre("b", "c"));
 
   resp = Run({"zpopmin", "key", "-1"});
   ASSERT_THAT(resp, ErrArg("value is out of range, must be positive"));
 
   resp = Run({"zpopmin", "key", "1"});
-  ASSERT_THAT(resp, "c");
+  ASSERT_THAT(resp, "d");
 
   resp = Run({"zpopmin", "key", "3"});
   ASSERT_THAT(resp, ArrLen(2));
-  EXPECT_THAT(resp.GetVec(), ElementsAre("d", "e"));
+  EXPECT_THAT(resp.GetVec(), ElementsAre("e", "f"));
 
   resp = Run({"zpopmin", "key", "1"});
   ASSERT_THAT(resp, ArrLen(0));
 }
 
 TEST_F(ZSetFamilyTest, ZPopMax) {
-  auto resp = Run({"zadd", "key", "1", "a", "2", "b", "3", "c", "4", "d", "5", "e"});
-  EXPECT_THAT(resp, IntArg(5));
+  auto resp = Run({"zadd", "key", "1", "a", "2", "b", "3", "c", "4", "d", "5", "e", "6", "f"});
+  EXPECT_THAT(resp, IntArg(6));
+
+  resp = Run({"zpopmax", "key"});
+  ASSERT_THAT(resp, "f");
 
   resp = Run({"zpopmax", "key", "2"});
   ASSERT_THAT(resp, ArrLen(2));


### PR DESCRIPTION
The commands should allow count to be optional and default to `1` as per the official redis command documentation ([ZPOPMIN](https://redis.io/commands/zpopmin/), [ZPOPMAX](https://redis.io/commands/zpopmax/)).

Will fix: #801