### PR TITLE
bug(snapshot): Fix unwriten entries in multiple snapshotting Fixes   #823

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -852,13 +852,14 @@ uint64_t DbSlice::RegisterOnChange(ChangeCallback cb) {
   return ver;
 }
 
-void DbSlice::CallChangeOnAllLessThanVersion(DbIndex db_ind, PrimeIterator it, uint64_t version) {
+void DbSlice::FlushChangeToEarlierCallbacks(DbIndex db_ind, PrimeIterator it,
+                                            uint64_t upper_bound) {
   uint64_t bucket_version = it.GetVersion();
-  // change_cb_ is ordered by version.
+  // change_cb_ is ordered by vesion.
   for (const auto& ccb : change_cb_) {
     uint64_t cb_vesrion = ccb.first;
-    DCHECK_LE(cb_vesrion, version);
-    if (cb_vesrion == version) {
+    DCHECK_LE(cb_vesrion, upper_bound);
+    if (cb_vesrion == upper_bound) {
       return;
     }
     if (bucket_version < cb_vesrion) {

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -278,7 +278,8 @@ class DbSlice {
   //! at a time of the call.
   uint64_t RegisterOnChange(ChangeCallback cb);
 
-  void CallChangeOnAllLessThanVersion(DbIndex db_ind, PrimeIterator it, uint64_t version);
+  // Call registered callbacks with vesrion less than upper_bound.
+  void FlushChangeToEarlierCallbacks(DbIndex db_ind, PrimeIterator it, uint64_t upper_bound);
 
   //! Unregisters the callback.
   void UnregisterOnChange(uint64_t id);

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -278,6 +278,8 @@ class DbSlice {
   //! at a time of the call.
   uint64_t RegisterOnChange(ChangeCallback cb);
 
+  void CallChangeOnAllLessThanVersion(DbIndex db_ind, PrimeIterator it, uint64_t version);
+
   //! Unregisters the callback.
   void UnregisterOnChange(uint64_t id);
 

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -178,7 +178,7 @@ bool SliceSnapshot::BucketSaveCb(PrimeIterator it) {
     ++stats_.skipped;
     return false;
   }
-  db_slice_->CallChangeOnAllLessThanVersion(current_db_, it, snapshot_version_);
+  db_slice_->FlushChangeToEarlierCallbacks(current_db_, it, snapshot_version_);
 
   stats_.loop_serialized += SerializeBucket(current_db_, it);
   return false;

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -178,6 +178,7 @@ bool SliceSnapshot::BucketSaveCb(PrimeIterator it) {
     ++stats_.skipped;
     return false;
   }
+  db_slice_->CallChangeOnAllLessThanVersion(current_db_, it, snapshot_version_);
 
   stats_.loop_serialized += SerializeBucket(current_db_, it);
   return false;


### PR DESCRIPTION
When traversing over buckets for snapshoting we deside to serialize bucket if its version is lower than snapshot version,
after we serialize the bucket we update the snapshot version.
When we have 2 snapshots S1 and S2 running at the same time with versions v1 , v2 where v1 < v2 and
S2 reaches bucket B before S1, then S1 will skip serializing the bucket .

My fix:
In BucketSaveCb called from the snapshot main loop, we first trigger calls of OnDbChange for all snapshots with version less than the current flow version. This way we make sure that the snapshot with higher version will not overide the bucket version before the snapshot with lower version will serialize it

Fixes #823 