### PR TITLE
bug(snapshot) : Do not preempt inside OnDbChange issue #829

### DIFF
--- a/src/server/journal/serializer.cc
+++ b/src/server/journal/serializer.cc
@@ -90,10 +90,6 @@ JournalReader::JournalReader(io::Source* source, DbIndex dbid)
     : source_{source}, buf_{4_KB}, dbid_{dbid} {
 }
 
-void JournalReader::SetDb(DbIndex dbid) {
-  dbid_ = dbid;
-}
-
 void JournalReader::SetSource(io::Source* source) {
   CHECK_EQ(buf_.InputLen(), 0ULL);
   source_ = source;

--- a/src/server/journal/serializer.h
+++ b/src/server/journal/serializer.h
@@ -43,9 +43,6 @@ struct JournalReader {
   // Initialize start database index.
   JournalReader(io::Source* source, DbIndex dbid);
 
-  // Overwrite current db index.
-  void SetDb(DbIndex dbid);
-
   // Overwrite current source and ensure there is no leftover from previous.
   void SetSource(io::Source* source);
 

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -1820,7 +1820,7 @@ error_code RdbLoader::Load(io::Source* src) {
       for (unsigned i = 0; i < shard_set->size(); ++i) {
         FlushShardAsync(i);
       }
-      RETURN_ON_ERR(HandleJournalBlob(service_, cur_db_index_));
+      RETURN_ON_ERR(HandleJournalBlob(service_));
       continue;
     }
 
@@ -1961,7 +1961,7 @@ error_code RdbLoaderBase::HandleCompressedBlobFinish() {
   return kOk;
 }
 
-error_code RdbLoaderBase::HandleJournalBlob(Service* service, DbIndex dbid) {
+error_code RdbLoaderBase::HandleJournalBlob(Service* service) {
   // Read the number of entries in the journal blob.
   size_t num_entries;
   bool _encoded;
@@ -1972,7 +1972,6 @@ error_code RdbLoaderBase::HandleJournalBlob(Service* service, DbIndex dbid) {
   SET_OR_RETURN(FetchGenericString(), journal_blob);
 
   io::BytesSource bs{io::Buffer(journal_blob)};
-  journal_reader_.SetDb(dbid);
   journal_reader_.SetSource(&bs);
 
   // Parse and exectue in loop.

--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -129,7 +129,7 @@ class RdbLoaderBase {
   std::error_code HandleCompressedBlobFinish();
   void AllocateDecompressOnce(int op_type);
 
-  std::error_code HandleJournalBlob(Service* service, DbIndex dbid);
+  std::error_code HandleJournalBlob(Service* service);
 
   static size_t StrLen(const RdbVariant& tset);
 

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -258,6 +258,7 @@ error_code RdbSerializer::SelectDb(uint32_t dbid) {
   if (dbid == last_entry_db_index_) {
     return error_code{};
   }
+  last_entry_db_index_ = dbid;
   uint8_t buf[16];
   buf[0] = RDB_OPCODE_SELECTDB;
   unsigned enclen = WritePackedUInt(dbid, io::MutableBytes{buf}.subspan(1));
@@ -268,7 +269,6 @@ error_code RdbSerializer::SelectDb(uint32_t dbid) {
 io::Result<uint8_t> RdbSerializer::SaveEntry(const PrimeKey& pk, const PrimeValue& pv,
                                              uint64_t expire_ms, DbIndex dbid) {
   SelectDb(dbid);
-  last_entry_db_index_ = dbid;
   uint8_t buf[16];
   error_code ec;
   /* Save the expire time */
@@ -686,7 +686,11 @@ error_code RdbSerializer::FlushToSink(io::Sink* s) {
   // interrupt point.
   RETURN_ON_ERR(s->Write(bytes));
   mem_buf_.ConsumeInput(bytes.size());
-  last_entry_db_index_ = kInvalidDbId;  // After every flash we should write the DB index again.
+  // After every flush we should write the DB index again because the blobs in the channel are
+  // interleaved and multiple savers can correspond to a single writer (in case of single file rdb
+  // snapshot)
+  last_entry_db_index_ = kInvalidDbId;
+
   return error_code{};
 }
 
@@ -707,7 +711,7 @@ io::Bytes RdbSerializer::PrepareFlush() {
   return mem_buf_.InputBuffer();
 }
 
-error_code RdbSerializer::WriteJournalEntries(const journal::Entry& entry) {
+error_code RdbSerializer::WriteJournalEntry(const journal::Entry& entry) {
   io::BufSink buf_sink{&journal_mem_buf_};
   JournalWriter writer{&buf_sink};
   writer.Write(entry);
@@ -715,12 +719,6 @@ error_code RdbSerializer::WriteJournalEntries(const journal::Entry& entry) {
   RETURN_ON_ERR(WriteOpcode(RDB_OPCODE_JOURNAL_BLOB));
   RETURN_ON_ERR(SaveLen(1));
   RETURN_ON_ERR(SaveString(io::View(journal_mem_buf_.InputBuffer())));
-  // SELECTDB is serialized inside journal writer. In rdb loader when parsing journal blob
-  // the journal reader parses the entry db index, and we dont use the main flow of
-  // updating the current db index. Unless we change the flow in the loader, we must
-  // update last_entry_db_index_ to invalid so that the next snapshot entry to be serialized
-  // will update the db index.
-  last_entry_db_index_ = kInvalidDbId;
   journal_mem_buf_.Clear();
   return error_code{};
 }

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -129,7 +129,8 @@ class RdbSerializer {
   // Must be called in the thread to which `it` belongs.
   // Returns the serialized rdb_type or the error.
   // expire_ms = 0 means no expiry.
-  io::Result<uint8_t> SaveEntry(const PrimeKey& pk, const PrimeValue& pv, uint64_t expire_ms);
+  io::Result<uint8_t> SaveEntry(const PrimeKey& pk, const PrimeValue& pv, uint64_t expire_ms,
+                                DbIndex dbid);
 
   std::error_code SaveLen(size_t len);
   std::error_code SaveString(std::string_view val);
@@ -149,7 +150,7 @@ class RdbSerializer {
   }
 
   // Write journal entries as an embedded journal blob.
-  std::error_code WriteJournalEntries(absl::Span<const journal::Entry> entries);
+  std::error_code WriteJournalEntries(const journal::Entry& entry);
 
   // Send FULL_SYNC_CUT opcode to notify that all static data was sent.
   std::error_code SendFullSyncCut();
@@ -180,6 +181,7 @@ class RdbSerializer {
   base::IoBuf journal_mem_buf_;
   std::string tmp_str_;
   base::PODArray<uint8_t> tmp_buf_;
+  DbIndex last_entry_db_index_ = kInvalidDbId;
 
   std::unique_ptr<LZF_HSLOT[]> lzf_;
 

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -149,8 +149,8 @@ class RdbSerializer {
     return WriteRaw(::io::Bytes{&opcode, 1});
   }
 
-  // Write journal entries as an embedded journal blob.
-  std::error_code WriteJournalEntries(const journal::Entry& entry);
+  // Write journal entry as an embedded journal blob.
+  std::error_code WriteJournalEntry(const journal::Entry& entry);
 
   // Send FULL_SYNC_CUT opcode to notify that all static data was sent.
   std::error_code SendFullSyncCut();

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -157,7 +157,9 @@ void SliceSnapshot::IterateBucketsFb(const Cancellation* cll) {
   mu_.lock();
   mu_.unlock();
 
-  serializer_->SendFullSyncCut();
+  // TODO: investigate why a single byte gets stuck and does not arrive to replica
+  for (unsigned i = 10; i > 1; i--)
+    CHECK(!serializer_->SendFullSyncCut());
   PushSerializedToChannel(true);
 
   // serialized + side_saved must be equal to the total saved.

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -157,9 +157,7 @@ void SliceSnapshot::IterateBucketsFb(const Cancellation* cll) {
   mu_.lock();
   mu_.unlock();
 
-  // TODO: investigate why a single byte gets stuck and does not arrive to replica
-  for (unsigned i = 10; i > 1; i--)
-    CHECK(!serializer_->SendFullSyncCut());
+  serializer_->SendFullSyncCut();
   PushSerializedToChannel(true);
 
   // serialized + side_saved must be equal to the total saved.
@@ -266,7 +264,7 @@ void SliceSnapshot::OnJournalEntry(const journal::Entry& entry, bool unused_awai
     return;
   }
 
-  serializer_->WriteJournalEntries(entry);
+  serializer_->WriteJournalEntry(entry);
 
   // This is the only place that flushes in streaming mode
   // once the iterate buckets fiber finished.

--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -102,7 +102,7 @@ class SliceSnapshot {
   void CloseRecordChannel();
 
   // Push serializer's internal buffer to channel.
-  // Push regradless of buffer size if force is true.
+  // Push regardless of buffer size if force is true.
   // Return if pushed.
   bool PushSerializedToChannel(bool force);
 


### PR DESCRIPTION
1. Serializer encode db index of entries
2. Do not encode db index inside consume channel
3. Allow push serialized data to channel from main snapshot loop and from journal callback (push may preempt)