### PR TITLE
fix(server): Fix lua reply builder

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -338,7 +338,6 @@ void InterpreterReplier::SendSimpleStrArr(const string_view* arr, uint32_t count
     explr_->OnString(arr[i]);
   }
   explr_->OnArrayEnd();
-  PostItem();
 }
 
 void InterpreterReplier::SendNullArray() {

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -373,6 +373,13 @@ TEST_F(MultiTest, Eval) {
   resp = Run({"hvals", "hmap"});
   EXPECT_EQ(resp, "2222");
 
+  Run({"sadd", "s1", "a", "b"});
+  Run({"sadd", "s2", "a", "c"});
+  resp = Run({"eval", "return redis.call('SUNION', KEYS[1], KEYS[2])", "2", "s1", "s2"});
+  ASSERT_THAT(resp, ArrLen(3));
+  const auto& arr = resp.GetVec();
+  EXPECT_THAT(arr, ElementsAre("a", "b", "c"));
+
   absl::SetFlag(&FLAGS_multi_eval_mode, multi_mode);
 }
 


### PR DESCRIPTION
It crashed on the assert in PostItem, its redundant as all users of SendSimpleStrArr call PostItem themselves afterwards