### PR TITLE
fix(charts): Use `Release.Namespace` everywhere

### DIFF
--- a/contrib/charts/dragonfly/ci/affinity-values.golden.yaml
+++ b/contrib/charts/dragonfly/ci/affinity-values.golden.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -15,6 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -36,6 +38,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test

--- a/contrib/charts/dragonfly/ci/command_extraargs-values.golden.yaml
+++ b/contrib/charts/dragonfly/ci/command_extraargs-values.golden.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -15,6 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -36,6 +38,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test

--- a/contrib/charts/dragonfly/ci/extracontainer-string-values.golden.yaml
+++ b/contrib/charts/dragonfly/ci/extracontainer-string-values.golden.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -15,6 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -36,6 +38,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test

--- a/contrib/charts/dragonfly/ci/extracontainer-tpl-values.golden.yaml
+++ b/contrib/charts/dragonfly/ci/extracontainer-tpl-values.golden.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -15,6 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -36,6 +38,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test

--- a/contrib/charts/dragonfly/ci/extravolumes-values.golden.yaml
+++ b/contrib/charts/dragonfly/ci/extravolumes-values.golden.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -15,6 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -36,6 +38,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test

--- a/contrib/charts/dragonfly/ci/initcontainer-string-values.golden.yaml
+++ b/contrib/charts/dragonfly/ci/initcontainer-string-values.golden.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -15,6 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -36,6 +38,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test

--- a/contrib/charts/dragonfly/ci/initcontainer-tpl-values.golden.yaml
+++ b/contrib/charts/dragonfly/ci/initcontainer-tpl-values.golden.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -15,6 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -36,6 +38,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test

--- a/contrib/charts/dragonfly/ci/passwordsecret-values.golden.yaml
+++ b/contrib/charts/dragonfly/ci/passwordsecret-values.golden.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -23,6 +24,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -44,6 +46,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test

--- a/contrib/charts/dragonfly/ci/persistent-values.golden.yaml
+++ b/contrib/charts/dragonfly/ci/persistent-values.golden.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -15,6 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -36,6 +38,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test

--- a/contrib/charts/dragonfly/ci/resources-values.golden.yaml
+++ b/contrib/charts/dragonfly/ci/resources-values.golden.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -15,6 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -36,6 +38,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test

--- a/contrib/charts/dragonfly/ci/securitycontext-values.golden.yaml
+++ b/contrib/charts/dragonfly/ci/securitycontext-values.golden.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -15,6 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -36,6 +38,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test

--- a/contrib/charts/dragonfly/ci/tls-values.golden.yaml
+++ b/contrib/charts/dragonfly/ci/tls-values.golden.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -15,6 +16,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: test-dragonfly-tls
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -30,6 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -51,6 +54,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -65,7 +69,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/tls-secret: ff929f88966be27e210398f2d89e55aff290936daade804b9e8d2c3a864cf7d7
+        checksum/tls-secret: aa19e66107bd65d211f8a06a017cfb875c4403d3ea018111c7d2a43333f6b6c6
       labels:
         app.kubernetes.io/name: dragonfly
         app.kubernetes.io/instance: test

--- a/contrib/charts/dragonfly/ci/tolerations-values.golden.yaml
+++ b/contrib/charts/dragonfly/ci/tolerations-values.golden.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -15,6 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test
@@ -36,6 +38,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: test-dragonfly
+  namespace: default
   labels:
     app.kubernetes.io/name: dragonfly
     app.kubernetes.io/instance: test

--- a/contrib/charts/dragonfly/templates/certificate.yaml
+++ b/contrib/charts/dragonfly/templates/certificate.yaml
@@ -3,6 +3,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "dragonfly.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dragonfly.labels" . | nindent 4 }}
 spec:

--- a/contrib/charts/dragonfly/templates/deployment.yaml
+++ b/contrib/charts/dragonfly/templates/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "dragonfly.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dragonfly.labels" . | nindent 4 }}
 spec:

--- a/contrib/charts/dragonfly/templates/metrics-service.yaml
+++ b/contrib/charts/dragonfly/templates/metrics-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "dragonfly.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dragonfly.labels" . | nindent 4 }}
     type: metrics

--- a/contrib/charts/dragonfly/templates/service.yaml
+++ b/contrib/charts/dragonfly/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "dragonfly.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/contrib/charts/dragonfly/templates/serviceaccount.yaml
+++ b/contrib/charts/dragonfly/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "dragonfly.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/contrib/charts/dragonfly/templates/statefulset.yaml
+++ b/contrib/charts/dragonfly/templates/statefulset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "dragonfly.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dragonfly.labels" . | nindent 4 }}
 spec:

--- a/contrib/charts/dragonfly/templates/tls-secret.yaml
+++ b/contrib/charts/dragonfly/templates/tls-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "dragonfly.fullname" . }}-tls
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dragonfly.labels" . | nindent 4 }}
 type: kubernetes.io/tls


### PR DESCRIPTION
Fixes https://github.com/dragonflydb/dragonfly/issues/874

This updates all the namespace fields in the Helm chart to use the `Release.Namespace` template variable. This is the recommended way to do it in Helm 3, and allows the chart to be installed in a namespace as set by the user, without having to modify the chart or use `--namespace` in `kubectl`.

This seems to be the [recommended approach in Helm](https://github.com/helm/helm/issues/5465). 

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->