### PR TITLE
test(helm): Add command to update golden files

### DIFF
--- a/contrib/charts/dragonfly/golden_test.go
+++ b/contrib/charts/dragonfly/golden_test.go
@@ -52,7 +52,7 @@ func TestHelmRender(t *testing.T) {
 			}
 
 			if string(expected) != output {
-				t.Fatalf("Expected %s, but got %s", string(expected), output)
+				t.Fatalf("Expected %s, but got %s\n. Update golden files by running `go test -v ./... -update`", string(expected), output)
 			}
 		}
 


### PR DESCRIPTION
While we have docs in `Contributing.md`, It seems better to
have that command emitted in the error message.  It is much 
more straightforward this way.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->