### PR TITLE
feat(zset_family): support zscan match and count optional params issue

### DIFF
--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1799,6 +1799,7 @@ OpResult<StringVec> ZSetFamily::OpScan(const OpArgs& op_args, std::string_view k
 
   if (zobj->encoding == OBJ_ENCODING_LISTPACK) {
     RangeParams params;
+    params.with_scores = true;
     IntervalVisitor iv{Action::RANGE, params, zobj};
 
     iv(IndexInterval{0, kuint32max});

--- a/src/server/zset_family.h
+++ b/src/server/zset_family.h
@@ -91,7 +91,8 @@ class ZSetFamily {
   static void ZRankGeneric(CmdArgList args, bool reverse, ConnectionContext* cntx);
   static bool ParseRangeByScoreParams(CmdArgList args, RangeParams* params);
   static void ZPopMinMax(CmdArgList args, bool reverse, ConnectionContext* cntx);
-  static OpResult<StringVec> OpScan(const OpArgs& op_args, std::string_view key, uint64_t* cursor);
+  static OpResult<StringVec> OpScan(const OpArgs& op_args, std::string_view key, uint64_t* cursor,
+                                    const ScanOpts& scan_op);
 
   static OpResult<unsigned> OpRem(const OpArgs& op_args, std::string_view key, ArgSlice members);
   static OpResult<double> OpScore(const OpArgs& op_args, std::string_view key,

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -270,6 +270,19 @@ TEST_F(ZSetFamilyTest, ZScan) {
   } while (cursor != 0);
 
   EXPECT_EQ(100 * 2, scan_len);
+
+  // Check scan with count and match params
+  scan_len = 0;
+  do {
+    auto resp = Run({"zscan", "key", absl::StrCat(cursor), "count", "5", "match", "*0"});
+    ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+    ASSERT_THAT(resp.GetVec(), ElementsAre(ArgType(RespExpr::STRING), ArgType(RespExpr::ARRAY)));
+    string_view token = ToSV(resp.GetVec()[0].GetBuf());
+    ASSERT_TRUE(absl::SimpleAtoi(token, &cursor));
+    auto sub_arr = resp.GetVec()[1].GetVec();
+    scan_len += sub_arr.size();
+  } while (cursor != 0);
+  EXPECT_EQ(10 * 2, scan_len);  // expected members a0,a10,a20..,a90
 }
 
 TEST_F(ZSetFamilyTest, ZUnionError) {


### PR DESCRIPTION
I worked on it because it was missing for the redis compare library.

Fixes #838