### PR TITLE
bug(replica): call add entry outside DCHECK

### DIFF
--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -1232,7 +1232,8 @@ bool Replica::TransactionData::IsGlobalCmd() const {
 
 Replica::TransactionData Replica::TransactionData::FromSingle(journal::ParsedEntry&& entry) {
   TransactionData data;
-  DCHECK(data.AddEntry(std::move(entry)));
+  bool res = data.AddEntry(std::move(entry));
+  DCHECK(res);
   return data;
 }
 


### PR DESCRIPTION
If we call the function inside DCHECK it is not called when we build dragonfly opt