### PR TITLE
bug(list_family): fix BPopPusher command replication

### DIFF
--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -953,8 +953,8 @@ OpResult<string> BPopPusher::RunSingle(Transaction* t, time_point tp) {
     OpArgs op_args = t->GetOpArgs(shard);
     op_res = OpMoveSingleShard(op_args, pop_key_, push_key_, popdir_, pushdir_);
     if (op_res && op_args.shard->journal()) {
-      RecordJournal(op_args, "LMOVE",
-                    ArgSlice{pop_key_, push_key_, DirToSv(popdir_), DirToSv(pushdir_)}, 1);
+      std::array<string_view, 4> arr = {pop_key_, push_key_, DirToSv(popdir_), DirToSv(pushdir_)};
+      RecordJournal(op_args, "LMOVE", arr, 1);
     }
     return OpStatus::OK;
   };

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -953,8 +953,8 @@ OpResult<string> BPopPusher::RunSingle(Transaction* t, time_point tp) {
     OpArgs op_args = t->GetOpArgs(shard);
     op_res = OpMoveSingleShard(op_args, pop_key_, push_key_, popdir_, pushdir_);
     if (op_res && op_args.shard->journal()) {
-      ArgSlice args{pop_key_, push_key_, DirToSv(popdir_), DirToSv(pushdir_)};
-      RecordJournal(op_args, "LMOVE", args, 1);
+      RecordJournal(op_args, "LMOVE",
+                    ArgSlice{pop_key_, push_key_, DirToSv(popdir_), DirToSv(pushdir_)}, 1);
     }
     return OpStatus::OK;
   };


### PR DESCRIPTION
because ArgSlice (absl::span) is not the owner memory when constructing with initializer list we must make sure that the span is passed directly to function.
i.e
arg = ArgSlice {"1"}
foo(arg) // arg is dangling pointer
we should use 
foo(ArgSlice {"1"})