### PR TITLE
fix(tests): Disable logging in replication tests

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -53,8 +53,8 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/tests
           export DRAGONFLY_PATH="${GITHUB_WORKSPACE}/build/dragonfly" # used by PyTests
-          pytest -xvs dragonfly/replication_test.py --df alsologtostderr --df vmodule=replica=2 --df enable_multi_shard_sync=true
-          pytest -xvs dragonfly/replication_test.py --df alsologtostderr --df vmodule=replica=2 --df enable_multi_shard_sync=false
+          pytest -xvs dragonfly/replication_test.py --df alsologtostderr --df enable_multi_shard_sync=true
+          pytest -xvs dragonfly/replication_test.py --df alsologtostderr --df enable_multi_shard_sync=false
 
       - name: Send notification on failure
         if: failure() || cancelled()


### PR DESCRIPTION
Replication tests currently time out, its most likely because of the enormous amount of debug output