### PR TITLE
fix: send a single RDB_OPCODE_FULLSYNC_END from a snapshot

### DIFF
--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -1717,6 +1717,8 @@ error_code RdbLoader::Load(io::Source* src) {
     /* Read type. */
     SET_OR_RETURN(FetchType(), type);
 
+    DVLOG(2) << "Opcode type: " << type;
+
     /* Handle special types. */
     if (type == RDB_OPCODE_EXPIRETIME) {
       LOG(ERROR) << "opcode RDB_OPCODE_EXPIRETIME not supported";
@@ -1753,6 +1755,9 @@ error_code RdbLoader::Load(io::Source* src) {
     }
 
     if (type == RDB_OPCODE_FULLSYNC_END) {
+      VLOG(1) << "Read RDB_OPCODE_FULLSYNC_END";
+      RETURN_ON_ERR(EnsureRead(8));
+      mem_buf_->ConsumeInput(8);  // ignore 8 bytes
       if (full_sync_cut_cb)
         full_sync_cut_cb();
       continue;
@@ -1832,6 +1837,8 @@ error_code RdbLoader::Load(io::Source* src) {
     RETURN_ON_ERR(LoadKeyValPair(type, &settings));
     settings.Reset();
   }  // main load loop
+
+  DVLOG(1) << "RdbLoad loop finished";
 
   if (stop_early_) {
     return *ec_;

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -157,9 +157,7 @@ void SliceSnapshot::IterateBucketsFb(const Cancellation* cll) {
   mu_.lock();
   mu_.unlock();
 
-  // TODO: investigate why a single byte gets stuck and does not arrive to replica
-  for (unsigned i = 10; i > 1; i--)
-    CHECK(!serializer_->SendFullSyncCut());
+  CHECK(!serializer_->SendFullSyncCut());
   PushSerializedToChannel(true);
 
   // serialized + side_saved must be equal to the total saved.


### PR DESCRIPTION
Fixes #917

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->