### PR TITLE
feat(server): Pragmas from scripts

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -998,7 +998,8 @@ void Service::Eval(CmdArgList args, ConnectionContext* cntx) {
   }
 
   if (add_result == Interpreter::ADD_OK) {
-    server_family_.script_mgr()->Insert(result, body);
+    if (auto err = server_family_.script_mgr()->Insert(result, body); err)
+      return (*cntx)->SendError(err.Format(), facade::kScriptErrType);
   }
 
   EvalArgs eval_args;

--- a/src/server/script_mgr.h
+++ b/src/server/script_mgr.h
@@ -23,11 +23,11 @@ class ScriptMgr {
     bool atomic = true;            // Whether script must run atomically.
     bool undeclared_keys = false;  // Whether script accesses undeclared keys.
 
-    // Return true if pragma was valid, false otherwise.
+    // Return GenericError if some pragma was invalid.
     // Valid pragmas are:
     // - allow-undeclared-keys -> undeclared_keys=true
     // - disable-atomicity     -> atomic=false
-    static bool ApplyPragma(std::string_view pragma, ScriptParams* params);
+    static GenericError ApplyPragmas(std::string_view pragma, ScriptParams* params);
   };
 
   struct ScriptData : public ScriptParams {
@@ -44,8 +44,8 @@ class ScriptMgr {
 
   void Run(CmdArgList args, ConnectionContext* cntx);
 
-  // Insert script. Returns true if inserted new script.
-  bool Insert(std::string_view sha, std::string_view body);
+  // Insert script. Get possible error from parsing script pragmas.
+  GenericError Insert(std::string_view sha, std::string_view body);
 
   // Get script body by sha, returns nullptr if not found.
   std::optional<ScriptData> Find(std::string_view sha) const;


### PR DESCRIPTION
1. What format should pragmas use? Now I just parse the first line that goes
```
-- pragma: *pragmas*
```

2. I currently count settings from our base default, not from the configured ones. This means that script pragmas totally override everything, i.e. doing `-- pragma: ` will reset to default state, even when the default script config flag had some pragmas included