### PR TITLE
fix(ci): Use correct `x86-64` with builds

### DIFF
--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         # Build with these flags
-        flags: ["-DMARCH_OPT=-march=x86_64"]
+        flags: ["-DMARCH_OPT=-march=x86-64"]
     timeout-minutes: 30
 
     container:


### PR DESCRIPTION
This commits fixes the flag to use the right format
for `x86-64`