### PR TITLE
fix(server): fix Interpreter::AddFunction

### DIFF
--- a/src/core/interpreter.cc
+++ b/src/core/interpreter.cc
@@ -409,8 +409,6 @@ auto Interpreter::AddFunction(string_view sha, string_view body, string* result)
   if (type == LUA_TNIL && !AddInternal(funcname, body, result))
     return COMPILE_ERR;
 
-  result->assign(funcname + 2);
-
   return type == LUA_TNIL ? ADD_OK : ALREADY_EXISTS;
 }
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1080,7 +1080,7 @@ optional<ScriptMgr::ScriptParams> LoadScipt(string_view sha, ScriptMgr* script_m
 
     string err;
     CHECK_EQ(Interpreter::ADD_OK, interpreter->AddFunction(sha, script_data->body, &err));
-    CHECK(err.empty());
+    CHECK(err.empty()) << err;
 
     return script_data;
   }


### PR DESCRIPTION
string* err is now only used for errors, otherwise return value should be clear