### PR TITLE
fix(docker): Use the right shebang in `healthcheck.sh`

### DIFF
--- a/tools/docker/healthcheck.sh
+++ b/tools/docker/healthcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 HOST="localhost"
 PORT=6379


### PR DESCRIPTION
Fixes #942 

Alpine images don't have bash installed by default, so we need to use
`/bin/sh` instead. This follows the **same existing convention that
we follow in the `entrypoint.sh` script**.

Both ubuntu and alpine images have been tested (i.e healthchecks to
pass) to work with this change.


## Testing

Build the new image

```bash
docker build -f ./tools/docker/Dockerfile.alpine-dev . -t ghcr.io/pothulapati/df
```
Run and Verify
```bash
docker run --network=host --ulimit memlock=-1 ghcr.io/pothulapati/df  &

docker ps
```