### PR TITLE
bug(server): Fix crash in ZPOPMIN

### DIFF
--- a/src/redis/sds.h
+++ b/src/redis/sds.h
@@ -85,10 +85,6 @@ struct __attribute__ ((__packed__)) sdshdr64 {
 #define SDS_TYPE_5_LEN(f) ((f)>>SDS_TYPE_BITS)
 
 static inline size_t sdslen(const sds s) {
-    if (s == 0) {
-      return 0;
-    }
-
     unsigned char flags = s[-1];
     switch(flags&SDS_TYPE_MASK) {
         case SDS_TYPE_5:

--- a/src/redis/sds.h
+++ b/src/redis/sds.h
@@ -85,6 +85,10 @@ struct __attribute__ ((__packed__)) sdshdr64 {
 #define SDS_TYPE_5_LEN(f) ((f)>>SDS_TYPE_BITS)
 
 static inline size_t sdslen(const sds s) {
+    if (s == 0) {
+      return 0;
+    }
+
     unsigned char flags = s[-1];
     switch(flags&SDS_TYPE_MASK) {
         case SDS_TYPE_5:

--- a/src/redis/t_zset.c
+++ b/src/redis/t_zset.c
@@ -1157,9 +1157,10 @@ void zsetConvert(robj *zobj, int encoding) {
         zs->zsl = zslCreate();
 
         eptr = lpSeek(zl,0);
-        serverAssertWithInfo(NULL,zobj,eptr != NULL);
-        sptr = lpNext(zl,eptr);
-        serverAssertWithInfo(NULL,zobj,sptr != NULL);
+        if (eptr != NULL) {
+            sptr = lpNext(zl,eptr);
+            serverAssertWithInfo(NULL,zobj,sptr != NULL);
+        }
 
         while (eptr != NULL) {
             score = zzlGetScore(sptr);

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -146,6 +146,8 @@ class IntervalVisitor {
     return removed_;
   }
 
+  void FindBadNull();
+
  private:
   void ExtractListPack(const zrangespec& range);
   void ExtractSkipList(const zrangespec& range);
@@ -390,6 +392,22 @@ void IntervalVisitor::ExtractListPack(const zrangespec& range) {
 
     /* Move to next node */
     Next(zl, &eptr, &sptr);
+  }
+}
+
+void IntervalVisitor::FindBadNull() {
+  if (zobj_->encoding == OBJ_ENCODING_LISTPACK) {
+    // TODO!
+  } else {
+    DCHECK_EQ(OBJ_ENCODING_SKIPLIST, zobj_->encoding);
+    zset* zs = (zset*)zobj_->ptr;
+    zskiplist* zsl = zs->zsl;
+    zskiplistNode* ln = zsl->header;
+
+    while (ln) {
+      CHECK_NE(ln->ele, nullptr);
+      ln = Next(ln);
+    }
   }
 }
 
@@ -870,7 +888,21 @@ OpResult<AddResult> OpAdd(const OpArgs& op_args, const ZParams& zparams, string_
     const auto& m = members[j];
     tmp_str = sdscpylen(tmp_str, m.second.data(), m.second.size());
 
+    bool check = false;
+    if (check) {
+      ZSetFamily::RangeParams params;
+      IntervalVisitor iv{Action::RANGE, params, zobj};
+      iv.FindBadNull();
+    }
+
+    LOG(INFO) << "XXXX Adding " << tmp_str;
     int retval = zsetAdd(zobj, m.first, tmp_str, zparams.flags, &retflags, &new_score);
+
+    if (check) {
+      ZSetFamily::RangeParams params;
+      IntervalVisitor iv{Action::RANGE, params, zobj};
+      iv.FindBadNull();
+    }
 
     if (zparams.flags & ZADD_IN_INCR) {
       if (retval == 0) {
@@ -1096,6 +1128,7 @@ bool ParseLimit(string_view offset_str, string_view limit_str, ZSetFamily::Range
 }  // namespace
 
 void ZSetFamily::ZAdd(CmdArgList args, ConnectionContext* cntx) {
+  LOG(INFO) << "XXXXX ZADD " << args;
   string_view key = ArgS(args, 1);
 
   ZParams zparams;
@@ -1164,7 +1197,8 @@ void ZSetFamily::ZAdd(CmdArgList args, ConnectionContext* cntx) {
 
   absl::Span memb_sp{members.data(), members.size()};
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpAdd(t->GetOpArgs(shard), zparams, key, memb_sp);
+    auto r = OpAdd(t->GetOpArgs(shard), zparams, key, memb_sp);
+    return r;
   };
 
   OpResult<AddResult> add_result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
@@ -1345,6 +1379,7 @@ void ZSetFamily::ZPopMax(CmdArgList args, ConnectionContext* cntx) {
 }
 
 void ZSetFamily::ZPopMin(CmdArgList args, ConnectionContext* cntx) {
+  LOG(INFO) << "XXXX ZPOPMIN " << args;
   ZPopMinMax(std::move(args), false, cntx);
 }
 

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -477,4 +477,14 @@ TEST_F(ZSetFamilyTest, ZPopMax) {
   resp = Run({"zpopmax", "key", "1"});
   ASSERT_THAT(resp, ArrLen(0));
 }
+
+TEST_F(ZSetFamilyTest, ZAddPopCrash) {
+  for (int i = 0; i < 129; ++i) {
+    auto resp = Run({"zadd", "key", absl::StrCat(i), absl::StrCat("element:", i)});
+    EXPECT_THAT(resp, IntArg(1));
+  }
+
+  auto resp = Run({"zpopmin", "key"});
+  EXPECT_THAT(resp, IntArg(1));
+}
 }  // namespace dfly

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -485,6 +485,6 @@ TEST_F(ZSetFamilyTest, ZAddPopCrash) {
   }
 
   auto resp = Run({"zpopmin", "key"});
-  EXPECT_THAT(resp, IntArg(1));
+  EXPECT_EQ(resp, "element:0");
 }
 }  // namespace dfly

--- a/tests/dragonfly/utility.py
+++ b/tests/dragonfly/utility.py
@@ -199,7 +199,7 @@ class CommandGenerator:
         ('SPOP {k}', ValueType.SET),
         ('HSETNX {k} v0 {val}', ValueType.HSET),
         ('HINCRBY {k} v1 1', ValueType.HSET),
-        # ('ZPOPMIN {k} 1', ValueType.ZSET), https://github.com/dragonflydb/dragonfly/issues/949
+        ('ZPOPMIN {k} 1', ValueType.ZSET),
         ('ZADD {k} 0 {val}', ValueType.ZSET),
         ('JSON.NUMINCRBY {k} $..i 1', ValueType.JSON),
         ('JSON.ARRPOP {k} $.arr', ValueType.JSON),


### PR DESCRIPTION
Crash was due to an attempt to access nullptr[-1], which is a bad idea :)

Fixes #949

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->