### PR TITLE
feat(server): Pubsub updates with RCU

### DIFF
--- a/src/server/channel_store.cc
+++ b/src/server/channel_store.cc
@@ -191,6 +191,8 @@ void ChannelStoreUpdater::Modify(ChannelMap* target, string_view key) {
   else
     replacement->erase(cntx_);
 
+  // The pointer can still be in use, so delay freeing it
+  // until the dispatch and update the slot atomically.
   freelist_.push_back(it->second.Get());
   it->second.Set(replacement);
 }

--- a/src/server/channel_store.cc
+++ b/src/server/channel_store.cc
@@ -11,6 +11,8 @@ extern "C" {
 }
 
 #include "base/logging.h"
+#include "server/engine_shard_set.h"
+#include "server/server_state.h"
 
 namespace dfly {
 using namespace std;
@@ -23,10 +25,36 @@ ChannelStore::Subscriber::Subscriber(uint32_t tid)
     : conn_cntx(nullptr), borrow_token(0), thread_id(tid) {
 }
 
+bool ChannelStore::Subscriber::ByThread(const Subscriber& lhs, const Subscriber& rhs) {
+  if (lhs.thread_id == rhs.thread_id)
+    return (lhs.conn_cntx != nullptr) < (rhs.conn_cntx != nullptr);
+  return lhs.thread_id < rhs.thread_id;
+}
+
+ChannelStore::UpdatablePointer::UpdatablePointer(const UpdatablePointer& other) {
+  ptr.store(other.ptr.load(memory_order_relaxed), memory_order_relaxed);
+}
+
+ChannelStore::SubscribeMap* ChannelStore::UpdatablePointer::Get() const {
+  return ptr.load(memory_order_relaxed);
+}
+
+void ChannelStore::UpdatablePointer::Set(ChannelStore::SubscribeMap* sm) {
+  ptr.store(sm, memory_order_relaxed);
+}
+
+ChannelStore::SubscribeMap* ChannelStore::UpdatablePointer::operator->() {
+  return Get();
+}
+
+const ChannelStore::SubscribeMap& ChannelStore::UpdatablePointer::operator*() const {
+  return *Get();
+}
+
 void ChannelStore::ChannelMap::Add(string_view key, ConnectionContext* me, uint32_t thread_id) {
   auto it = find(key);
   if (it == end())
-    it = emplace(key, make_unique<SubscribeMap>()).first;
+    it = emplace(key, new SubscribeMap{}).first;
   it->second->emplace(me, thread_id);
 }
 
@@ -38,35 +66,44 @@ void ChannelStore::ChannelMap::Remove(string_view key, ConnectionContext* me) {
   }
 }
 
-void ChannelStore::AddSub(string_view channel, ConnectionContext* me, uint32_t thread_id) {
-  unique_lock lk{lock_};
-  channels_.Add(channel, me, thread_id);
+void ChannelStore::ChannelMap::DeleteAll() {
+  for (auto [k, ptr] : *this)
+    delete ptr.Get();
 }
 
-void ChannelStore::AddPatternSub(string_view pattern, ConnectionContext* me, uint32_t thread_id) {
-  unique_lock lk{lock_};
-  patterns_.Add(pattern, me, thread_id);
+ChannelStore::ChannelStore(ChannelStore::ControlBlock* cb)
+    : channels_{new ChannelMap{}}, patterns_{new ChannelMap{}}, control_block_{cb} {
+  cb->most_recent = this;
 }
 
-void ChannelStore::RemoveSub(string_view channel, ConnectionContext* me) {
-  unique_lock lk{lock_};
-  channels_.Remove(channel, me);
+ChannelStore::ChannelStore(ChannelMap* channels, ChannelMap* patterns, ControlBlock* cb)
+    : channels_{channels}, patterns_{patterns}, control_block_{cb} {
 }
 
-void ChannelStore::RemovePatternSub(string_view pattern, ConnectionContext* me) {
-  unique_lock lk{lock_};
-  patterns_.Remove(pattern, me);
+void ChannelStore::ControlBlock::Destroy() {
+  update_mu.lock();
+  update_mu.unlock();
+  for (auto* chan_map : {most_recent->channels_, most_recent->patterns_}) {
+    chan_map->DeleteAll();
+    delete chan_map;
+  }
+  delete most_recent;
 }
 
-vector<ChannelStore::Subscriber> ChannelStore::FetchSubscribers(string_view channel) {
-  shared_lock lk{lock_};
+unsigned ChannelStore::SlotSize(bool pattern, string_view key) {
+  ChannelMap* map = pattern ? patterns_ : channels_;
+  auto it = map->find(key);
+  return it == map->end() ? 0 : it->second->size();
+}
+
+vector<ChannelStore::Subscriber> ChannelStore::FetchSubscribers(string_view channel) const {
   vector<Subscriber> res;
 
-  if (auto it = channels_.find(channel); it != channels_.end()) {
+  if (auto it = channels_->find(channel); it != channels_->end()) {
     Fill(*it->second, string{}, &res);
   }
 
-  for (const auto& [pat, subs] : patterns_) {
+  for (const auto& [pat, subs] : *patterns_) {
     if (stringmatchlen(pat.data(), pat.size(), channel.data(), channel.size(), 0) == 1) {
       Fill(*subs, pat, &res);
     }
@@ -90,9 +127,8 @@ void ChannelStore::Fill(const SubscribeMap& src, const string& pattern, vector<S
 }
 
 std::vector<string> ChannelStore::ListChannels(const string_view pattern) const {
-  shared_lock lk{lock_};
   vector<string> res;
-  for (const auto& [channel, _] : channels_) {
+  for (const auto& [channel, _] : *channels_) {
     if (pattern.empty() ||
         stringmatchlen(pattern.data(), pattern.size(), channel.data(), channel.size(), 0) == 1) {
       res.push_back(channel);
@@ -102,8 +138,85 @@ std::vector<string> ChannelStore::ListChannels(const string_view pattern) const 
 }
 
 size_t ChannelStore::PatternCount() const {
-  shared_lock lk{lock_};
-  return patterns_.size();
+  return patterns_->size();
+}
+
+ChannelStoreUpdater::ChannelStoreUpdater(ChannelStore* store, bool pattern, ConnectionContext* cntx,
+                                         uint32_t thread_id)
+    : store_{store}, pattern_{pattern}, cntx_{cntx}, thread_id_{thread_id} {
+}
+
+void ChannelStoreUpdater::Add(string_view key) {
+  ops_.emplace_back(key, true);
+  // If we insert the first entry, we need to add a new map slot
+  needs_copy_ = store_->SlotSize(pattern_, key) == 0;
+}
+
+void ChannelStoreUpdater::Remove(string_view key) {
+  ops_.emplace_back(key, false);
+  // If we remove the last entry, we need to clear the map slot
+  needs_copy_ = store_->SlotSize(pattern_, key) == 1;
+}
+
+void ChannelStoreUpdater::Apply() {
+  using ChannelMap = ChannelStore::ChannelMap;
+  using SubscribeMap = ChannelStore::SubscribeMap;
+
+  ChannelStore::ControlBlock* cb = store_->control_block_;
+  cb->update_mu.lock();
+  store_ = cb->most_recent;
+
+  ChannelMap* target = pattern_ ? store_->patterns_ : store_->channels_;
+
+  if (needs_copy_)
+    target = new ChannelMap{*target};
+
+  for (auto [key, add] : ops_) {
+    auto it = target->find(key);
+    DCHECK(it != target->end() || add);
+
+    if (add && it == target->end()) {
+      DCHECK(needs_copy_);
+      target->emplace(key, new SubscribeMap{{cntx_, thread_id_}});
+      continue;
+    }
+
+    if (!add && it->second->size() == 1) {
+      DCHECK(it->second->begin()->first == cntx_);
+      freelist_.push_back(it->second.Get());
+      target->erase(it);
+      continue;
+    }
+
+    DCHECK(it->second->size() > 0);
+    auto* replacement = new SubscribeMap{*it->second};
+    if (add)
+      replacement->emplace(cntx_, thread_id_);
+    else
+      replacement->erase(cntx_);
+
+    freelist_.push_back(it->second.Get());
+    it->second.Set(replacement);
+  }
+
+  auto* replacement = store_;
+  if (needs_copy_) {
+    replacement = pattern_ ? new ChannelStore{store_->channels_, target, cb}
+                           : new ChannelStore{target, store_->patterns_, cb};
+  }
+
+  shard_set->pool()->Await([replacement](unsigned idx, util::ProactorBase*) {
+    ServerState::tlocal()->UpdateChannelStore(replacement);
+  });
+
+  cb->most_recent = replacement;
+  cb->update_mu.unlock();
+
+  if (needs_copy_)
+    delete store_;
+
+  for (auto ptr : freelist_)
+    delete ptr;
 }
 
 }  // namespace dfly

--- a/src/server/channel_store.h
+++ b/src/server/channel_store.h
@@ -138,7 +138,7 @@ struct ChannelStoreUpdater {
   // Get target map and flag whether it was copied.
   std::pair<ChannelMap*, bool> GetTargetMap();
 
-  // Apply modifly operation to target map.
+  // Apply modify operation to target map.
   void Modify(ChannelMap* target, std::string_view key);
 
  private:

--- a/src/server/channel_store.h
+++ b/src/server/channel_store.h
@@ -4,28 +4,40 @@
 #pragma once
 
 #include <absl/container/flat_hash_map.h>
-#include <base/RWSpinLock.h>
 
+#include <boost/fiber/mutex.hpp>
 #include <string_view>
 
 #include "server/conn_context.h"
 
 namespace dfly {
 
-// Centralized store holding pubsub subscribers. All public functions are thread safe.
+struct ChannelStoreUpdater;
+
+// ChannelStore manages PUB/SUB subscriptions.
+//
+// Updates are carried out via RCU (read-copy-update). Each thread stores a pointer to ChannelStore
+// in its local ServerState and uses it for reads. Whenever an update needs to be performed,
+// a new ChannelStore is constructed with the requested modifications and broadcasted to all
+// threads.
+//
+// ServerState ChannelStore* -> ChannelMap* -> atomic<SubscribeMap*> (cntx -> thread)
+//
+// Specifically, whenever a new channel is registered or a channel is removed fully,
+// a new ChannelMap for the specified type (channel/pattern) needs to be constructed. However, if
+// only a single SubscribeMap is modified (no map ChannelMap slots are added or removed),
+// we can update only it with a simpler version of RCU, as SubscribeMap is stored as an atomic
+// pointer inside ChannelMap.
+//
+// To prevent parallel (and thus overlapping) updates, a centralized ControlBlock is used.
+// Update operations are carried out by the ChannelStoreUpdater.
 class ChannelStore {
+  friend struct ChannelStoreUpdater;
+
  public:
   struct Subscriber {
-    ConnectionContext* conn_cntx;
-    util::fibers_ext::BlockingCounter borrow_token;
-    uint32_t thread_id;
-
-    // non-empty if was registered via psubscribe
-    std::string pattern;
-
     Subscriber(ConnectionContext* cntx, uint32_t tid);
     Subscriber(uint32_t tid);
-    // Subscriber() : borrow_token(0) {}
 
     Subscriber(Subscriber&&) noexcept = default;
     Subscriber& operator=(Subscriber&&) noexcept = default;
@@ -34,39 +46,100 @@ class ChannelStore {
     void operator=(const Subscriber&) = delete;
 
     // Sort by thread-id. Subscriber without owner comes first.
-    static bool ByThread(const Subscriber& lhs, const Subscriber& rhs) {
-      if (lhs.thread_id == rhs.thread_id)
-        return (lhs.conn_cntx != nullptr) < (rhs.conn_cntx != nullptr);
-      return lhs.thread_id < rhs.thread_id;
-    }
+    static bool ByThread(const Subscriber& lhs, const Subscriber& rhs);
+
+    ConnectionContext* conn_cntx;
+    util::fibers_ext::BlockingCounter borrow_token;  // to keep connection alive
+    uint32_t thread_id;
+    std::string pattern;  // non-empty if registered via psubscribe
   };
 
-  void AddSub(std::string_view channel, ConnectionContext* me, uint32_t thread_id);
-  void RemoveSub(std::string_view channel, ConnectionContext* me);
+  // Centralized controller to prevent overlaping updates.
+  struct ControlBlock {
+    void Destroy();
 
-  void AddPatternSub(std::string_view pattern, ConnectionContext* me, uint32_t thread_id);
-  void RemovePatternSub(std::string_view pattern, ConnectionContext* me);
+    ChannelStore* most_recent;
+    ::boost::fibers::mutex update_mu;  // locked during updates.
+  };
 
-  std::vector<Subscriber> FetchSubscribers(std::string_view channel);
+  // Initialize ChannelStore bound to specific control block.
+  ChannelStore(ControlBlock* cb);
+
+  // Fetch all subscribers for channel, including matching patterns.
+  std::vector<Subscriber> FetchSubscribers(std::string_view channel) const;
 
   std::vector<std::string> ListChannels(const std::string_view pattern) const;
   size_t PatternCount() const;
 
  private:
   using ThreadId = unsigned;
+
+  // Subscribers for a single channel/pattern.
   using SubscribeMap = absl::flat_hash_map<ConnectionContext*, ThreadId>;
 
-  struct ChannelMap : absl::flat_hash_map<std::string, std::unique_ptr<SubscribeMap>> {
+  // Wrapper around atomic pointer that allows copying and moving.
+  // Made to overcome restrictions of absl::flat_hash_map.
+  // Copy/Move don't need to be atomic with RCU.
+  struct UpdatablePointer {
+    UpdatablePointer(SubscribeMap* sm) : ptr{sm} {
+    }
+
+    UpdatablePointer(const UpdatablePointer& other);
+
+    SubscribeMap* Get() const;
+    void Set(SubscribeMap* sm);
+
+    SubscribeMap* operator->();
+    const SubscribeMap& operator*() const;
+
+   private:
+    std::atomic<SubscribeMap*> ptr;
+  };
+
+  // Subscriber maps for channels/pointers.
+  struct ChannelMap : absl::flat_hash_map<std::string, UpdatablePointer> {
     void Add(std::string_view key, ConnectionContext* me, uint32_t thread_id);
     void Remove(std::string_view key, ConnectionContext* me);
+
+    // Delete stored all SubscribeMap pointers.
+    void DeleteAll();
   };
+
+ private:
+  ChannelStore(ChannelMap* channels, ChannelMap* patterns, ControlBlock*);
+
+  // Size of underlying SubscribeMapf or key, or 0 if not present.
+  unsigned SlotSize(bool pattern, std::string_view key);
 
   static void Fill(const SubscribeMap& src, const std::string& pattern,
                    std::vector<Subscriber>* out);
 
-  mutable folly::RWSpinLock lock_;
-  ChannelMap channels_;
-  ChannelMap patterns_;
+  ChannelMap* channels_;
+  ChannelMap* patterns_;
+  ControlBlock* control_block_;
+};
+
+// Performs RCU (read-copy-update) updates to the channel store.
+// See ChannelStore header top for design details.
+// Queues operations and performs them with Apply().
+struct ChannelStoreUpdater {
+  ChannelStoreUpdater(ChannelStore* store, bool pattern, ConnectionContext* cntx,
+                      uint32_t thread_id);
+
+  void Add(std::string_view key);
+  void Remove(std::string_view key);
+  void Apply();
+
+ private:
+  ChannelStore* store_;
+
+  bool pattern_;
+  ConnectionContext* cntx_;
+  uint32_t thread_id_;
+
+  bool needs_copy_ = false;
+  std::vector<std::pair<std::string_view, bool>> ops_;
+  std::vector<ChannelStore::SubscribeMap*> freelist_;
 };
 
 }  // namespace dfly

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -74,18 +74,15 @@ vector<unsigned> ChangeSubscriptions(bool pattern, CmdArgList args, bool to_add,
   int32_t tid = util::ProactorBase::GetIndex();
   DCHECK_GE(tid, 0);
 
-  ChannelStoreUpdater csu{store, pattern, conn, uint32_t(tid)};
+  ChannelStoreUpdater csu{store, pattern, to_add, conn, uint32_t(tid)};
 
   // Gather all the channels we need to subscribe to / remove.
   for (size_t i = 0; i < args.size(); ++i) {
     string_view channel = ArgS(args, i);
-    if (to_add) {
-      if (local_store.emplace(channel).second)
-        csu.Add(channel);
-    } else {
-      if (local_store.erase(channel) > 0)
-        csu.Remove(channel);
-    }
+    if (to_add && local_store.emplace(channel).second)
+      csu.Record(channel);
+    else if (!to_add && local_store.erase(channel) > 0)
+      csu.Record(channel);
 
     if (to_reply)
       result[i] = sinfo.SubscriptionCount();

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -134,10 +134,10 @@ class ConnectionContext : public facade::ConnectionContext {
     return conn_state.db_index;
   }
 
-  void ChangeSubscription(ChannelStore* store, bool to_add, bool to_reply, CmdArgList args);
-  void ChangePSubscription(ChannelStore* store, bool to_add, bool to_reply, CmdArgList args);
-  void UnsubscribeAll(ChannelStore* store, bool to_reply);
-  void PUnsubscribeAll(ChannelStore* store, bool to_reply);
+  void ChangeSubscription(bool to_add, bool to_reply, CmdArgList args);
+  void ChangePSubscription(bool to_add, bool to_reply, CmdArgList args);
+  void UnsubscribeAll(bool to_reply);
+  void PUnsubscribeAll(bool to_reply);
   void ChangeMonitor(bool start);  // either start or stop monitor on a given connection
 
   bool is_replicating = false;

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -396,6 +396,8 @@ TEST_F(DflyEngineTest, PSubscribe) {
 
   ASSERT_EQ(1, SubscriberMessagesLen("IO1"));
 
+  pp_->AwaitFiberOnAll([](ProactorBase* pb) {});
+
   const facade::Connection::PubMessage& msg = GetPublishedMessage("IO1", 0);
   EXPECT_EQ("foo", *msg.message);
   EXPECT_EQ("ab", *msg.channel);

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -399,9 +399,9 @@ TEST_F(DflyEngineTest, PSubscribe) {
   resp = pp_->at(0)->Await([&] { return Run({"publish", "ab", "foo"}); });
   EXPECT_THAT(resp, IntArg(1));
 
-  ASSERT_EQ(1, SubscriberMessagesLen("IO1"));
-
   pp_->AwaitFiberOnAll([](ProactorBase* pb) {});
+
+  ASSERT_EQ(1, SubscriberMessagesLen("IO1"));
 
   const facade::Connection::PubMessage& msg = GetPublishedMessage("IO1", 0);
   EXPECT_EQ("foo", *msg.message);

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -533,7 +533,7 @@ void Service::Init(util::AcceptServer* acceptor, util::ListenerInterface* main_i
   GenericFamily::Init(&pp_);
   server_family_.Init(acceptor, main_interface);
 
-  ChannelStore* cs = new ChannelStore{&channel_control_};
+  ChannelStore* cs = new ChannelStore{};
   pp_.Await(
       [cs](uint32_t index, ProactorBase* pb) { ServerState::tlocal()->UpdateChannelStore(cs); });
 }
@@ -556,7 +556,7 @@ void Service::Shutdown() {
   engine_varz.reset();
   request_latency_usec.Shutdown();
 
-  channel_control_.Destroy();
+  ChannelStore::Destroy();
 
   shard_set->Shutdown();
   pp_.Await([](ProactorBase* pb) { ServerState::tlocal()->Destroy(); });

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -128,8 +128,6 @@ class Service : public facade::ServiceInterface {
   CommandRegistry registry_;
   absl::flat_hash_map<std::string, unsigned> unknown_cmds_;
 
-  ChannelStore::ControlBlock channel_control_;
-
   mutable ::boost::fibers::mutex mu_;
   GlobalState global_state_ = GlobalState::ACTIVE;  // protected by mu_;
 };

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -128,6 +128,8 @@ class Service : public facade::ServiceInterface {
   CommandRegistry registry_;
   absl::flat_hash_map<std::string, unsigned> unknown_cmds_;
 
+  ChannelStore::ControlBlock channel_control_;
+
   mutable ::boost::fibers::mutex mu_;
   GlobalState global_state_ = GlobalState::ACTIVE;  // protected by mu_;
 };

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -358,7 +358,6 @@ ServerFamily::ServerFamily(Service* service) : service_(*service) {
   last_save_info_ = make_shared<LastSaveInfo>();
   last_save_info_->save_time = start_time_;
   script_mgr_.reset(new ScriptMgr());
-  channel_store_.reset(new ChannelStore());
   journal_.reset(new journal::Journal());
 
   {

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -122,10 +122,6 @@ class ServerFamily {
     return journal_.get();
   }
 
-  ChannelStore* channel_store() {
-    return channel_store_.get();
-  }
-
   void OnClose(ConnectionContext* cntx);
 
   void BreakOnShutdown();
@@ -183,7 +179,6 @@ class ServerFamily {
   std::unique_ptr<ScriptMgr> script_mgr_;
   std::unique_ptr<journal::Journal> journal_;
   std::unique_ptr<DflyCmd> dfly_cmd_;
-  std::unique_ptr<ChannelStore> channel_store_;
 
   std::string master_id_;
 

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -110,11 +110,6 @@ class ServerState {  // public struct - to allow initialization.
     state_->gstate_ = GlobalState::SHUTTING_DOWN;
   }
 
-  bool is_master = true;
-  std::string remote_client_id_;  // for cluster support
-
-  facade::ConnectionStats connection_stats;
-
   void TxCountInc() {
     ++live_transactions_;
   }
@@ -190,7 +185,21 @@ class ServerState {  // public struct - to allow initialization.
     return thread_index_;
   }
 
+  ChannelStore* channel_store() const {
+    return channel_store_;
+  }
+
+  void UpdateChannelStore(ChannelStore* replacement) {
+    channel_store_ = replacement;
+  }
+
+ public:
   Stats stats;
+
+  bool is_master = true;
+  std::string remote_client_id_;  // for cluster support
+
+  facade::ConnectionStats connection_stats;
 
  private:
   int64_t live_transactions_ = 0;
@@ -199,6 +208,8 @@ class ServerState {  // public struct - to allow initialization.
 
   InterpreterManager interpreter_mgr_;
   absl::flat_hash_map<ScriptMgr::ScriptKey, ScriptMgr::ScriptParams> cached_script_params_;
+
+  ChannelStore* channel_store_;
 
   GlobalState gstate_ = GlobalState::ACTIVE;
 


### PR DESCRIPTION
Implements RCU (read-copy-update) for updating the centralized channel store.

Contrary to old mechanism of sharding subscriber info across shards, a centralized store allows avoiding a hop for fetching subscribers. In general, it only slightly improves the latency, but in case of heavy traffic on one channel it allows "spreading" the load, as the single shard no longer is a bottleneck, thus increasing throughput by multiple times.

```
Benchmarks:

1. Dry run without subscribers

OLD
===================================================================================================
Type          Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec  
---------------------------------------------------------------------------------------------------
Publishs    955759.86         0.75294         0.71100         1.32700         4.57500     43709.23  
Totals      955759.86         0.75294         0.71100         1.32700         4.57500     43709.23

NEW
===================================================================================================
Type          Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec  
---------------------------------------------------------------------------------------------------
Publishs   1040942.05         0.69134         0.67900         1.07900         3.75900     47604.77  
Totals     1040942.05         0.69134         0.67900         1.07900         3.75900     47604.77 

2. Run with subscribers

OLD
===================================================================================================
Type          Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec  
---------------------------------------------------------------------------------------------------
Publishs    399898.33         1.79988         1.37500         7.00700        11.64700     18288.39  
Totals      399898.33         1.79988         1.37500         7.00700        11.64700     18288.39 

NEW
===================================================================================================
Type          Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec  
---------------------------------------------------------------------------------------------------
Publishs    418730.46         1.71866         1.21500         6.97500        10.81500     19149.67  
Totals      418730.46         1.71866         1.21500         6.97500        10.81500     19149.6

3. Single channel

OLD
===================================================================================================
Type          Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec  
---------------------------------------------------------------------------------------------------
Publishs     88210.54         9.06565         8.76700        15.10300        22.01500      4048.73  
Totals       88210.54         9.06565         8.76700        15.10300        22.01500      4048.73 

NEW
===================================================================================================
Type          Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec  
---------------------------------------------------------------------------------------------------
Publishs    236476.81         3.38045         1.13500        27.39100        35.32700     10853.92  
Totals      236476.81         3.38045         1.13500        27.39100        35.32700     10853.92
```
