### PR TITLE
bug(helm): Fix parsing error with statefulset

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 default_stages: [commit]
 exclude: 'src\/redis\/.*'
+exclude: 'contrib\/charts\/dragonfly\/ci\/.*'
 repos:
   - repo: local
     hooks:

--- a/contrib/charts/dragonfly/Chart.yaml
+++ b/contrib/charts/dragonfly/Chart.yaml
@@ -21,7 +21,7 @@ version: v1.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.0.1"
+appVersion: "v1.0.0"
 
 home: https://dragonflydb.io/
 

--- a/contrib/charts/dragonfly/Chart.yaml
+++ b/contrib/charts/dragonfly/Chart.yaml
@@ -21,7 +21,7 @@ version: v1.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.0.0"
+appVersion: "v1.0.1"
 
 home: https://dragonflydb.io/
 

--- a/contrib/charts/dragonfly/ci/passwordsecret-values.golden.yaml
+++ b/contrib/charts/dragonfly/ci/passwordsecret-values.golden.yaml
@@ -99,6 +99,7 @@ spec:
           resources:
             limits: {}
             requests: {}
+          
           env:
             - name: DFLY_PASSWORD
               valueFrom:

--- a/contrib/charts/dragonfly/ci/persistence-and-existing-secret.golden.yaml
+++ b/contrib/charts/dragonfly/ci/persistence-and-existing-secret.golden.yaml
@@ -1,0 +1,120 @@
+---
+# Source: dragonfly/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-dragonfly
+  namespace: default
+  labels:
+    app.kubernetes.io/name: dragonfly
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "v1.0.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: dragonfly/templates/extra-manifests.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dfly-password
+stringData:
+  password: foobar
+---
+# Source: dragonfly/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-dragonfly
+  namespace: default
+  labels:
+    app.kubernetes.io/name: dragonfly
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "v1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      targetPort: dragonfly
+      protocol: TCP
+      name: dragonfly
+  selector:
+    app.kubernetes.io/name: dragonfly
+    app.kubernetes.io/instance: test
+---
+# Source: dragonfly/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-dragonfly
+  namespace: default
+  labels:
+    app.kubernetes.io/name: dragonfly
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "v1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  serviceName: test
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dragonfly
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      annotations:
+      labels:
+        app.kubernetes.io/name: dragonfly
+        app.kubernetes.io/instance: test
+    spec:
+      serviceAccountName: test-dragonfly
+      containers:
+        - name: dragonfly
+          image: "docker.dragonflydb.io/dragonflydb/dragonfly:v1.0.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: dragonfly
+              containerPort: 6379
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - /usr/local/bin/healthcheck.sh
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - /usr/local/bin/healthcheck.sh
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          args:
+            - "--alsologtostderr"
+          resources:
+            limits: {}
+            requests: {}
+          volumeMounts:
+            - mountPath: /data
+              name: "test-data"
+          env:
+            - name: DFLY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dfly-password
+                  key: password
+  volumeClaimTemplates:
+    - metadata:
+        name: "test-data"
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: standard
+        resources:
+          requests:
+            storage: 128Mi

--- a/contrib/charts/dragonfly/ci/persistence-and-existing-secret.yaml
+++ b/contrib/charts/dragonfly/ci/persistence-and-existing-secret.yaml
@@ -1,0 +1,18 @@
+storage:
+  enabled: true
+  storageClassName: "standard"
+  requests: 128Mi
+
+extraObjects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: dfly-password
+  stringData:
+    password: foobar
+
+passwordFromSecret:
+  enable: true
+  existingSecret:
+    name: dfly-password
+    key: password

--- a/contrib/charts/dragonfly/templates/_pod.tpl
+++ b/contrib/charts/dragonfly/templates/_pod.tpl
@@ -86,7 +86,7 @@ containers:
       {{- toYaml . | trim | nindent 6 }}
     {{- end }}
     {{- include "dragonfly.volumemounts" . | trim | nindent 4 }}
-    {{- if .Values.passwordFromSecret.enable -}}
+    {{- if .Values.passwordFromSecret.enable }}
     env:
       - name: DFLY_PASSWORD
         valueFrom:


### PR DESCRIPTION
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->

When installing the helm chart with persistence to true and using an existingSecret (or with only tls enabled), the following parsing error is triggered:

Error: YAML parse error on dragonfly/templates/statefulset.yaml: error converting YAML to JSON: yaml: line 61: did not find expected key.

This simple PR fixes this.