### PR TITLE
fix: improve connection affinity heuristic

### DIFF
--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -88,7 +88,7 @@ class Connection : public util::Connection {
     CopyCharBuf(phase, sizeof(phase_), phase_);
   }
 
-  std::string GetClientInfo() const;
+  std::string GetClientInfo(unsigned thread_id) const;
   std::string RemoteEndpointStr() const;
   std::string RemoteEndpointAddress() const;
   std::string LocalBindAddress() const;

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -43,8 +43,7 @@ void ConnectionContext::ChangeMonitor(bool start) {
   if (start) {
     my_monitors.Add(owner());
   } else {
-    VLOG(1) << "connection " << owner()->GetClientInfo()
-            << " no longer needs to be monitored - removing 0x" << std::hex << this;
+    VLOG(1) << "connection " << owner()->GetClientId() << " no longer needs to be monitored";
     my_monitors.Remove(owner());
   }
   // Tell other threads that about the change in the number of connection that we monitor

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1493,7 +1493,7 @@ void Service::PubsubPatterns(ConnectionContext* cntx) {
 }
 
 void Service::Monitor(CmdArgList args, ConnectionContext* cntx) {
-  VLOG(1) << "starting monitor on this connection: " << cntx->owner()->GetClientInfo();
+  VLOG(1) << "starting monitor on this connection: " << cntx->owner()->GetClientId();
   // we are registering the current connection for all threads so they will be aware of
   // this connection, to send to it any command
   (*cntx)->SendOk();


### PR DESCRIPTION
1. fix potential crash bug when traversing connections with client list
2. fetch cpu/napi id information when handling a new connection.
3. add thread id (tid) and irqmatch fields to client list command.
4. Implement a heuristic under flag that puts a connection on the
   CPU id that handles the IRQ queue that handles its socket.
   However, if a too wide gap introduced between number of connections on
   IRQ threads and other threads we fallback to other threads.
   In my tests I saw 15-20% CPU reduction when this heuristic is enabled.