### PR TITLE
refactor(facade): Refactor reply builder

### DIFF
--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -13,12 +13,36 @@ namespace facade {
 
 class SinkReplyBuilder {
  public:
+  struct ResponseValue {
+    std::string_view key;
+    std::string value;
+    uint64_t mc_ver = 0;  // 0 means we do not output it (i.e has not been requested).
+    uint32_t mc_flag = 0;
+  };
+
+  using OptResp = std::optional<ResponseValue>;
+
+ public:
   SinkReplyBuilder(const SinkReplyBuilder&) = delete;
   void operator=(const SinkReplyBuilder&) = delete;
 
   SinkReplyBuilder(::io::Sink* sink);
 
   virtual ~SinkReplyBuilder() {
+  }
+
+  virtual void SendError(std::string_view str, std::string_view type = {}) = 0;  // MC and Redis
+
+  virtual void SendStored() = 0;  // Reply for set commands.
+  virtual void SendSetSkipped() = 0;
+
+  virtual void SendMGetResponse(const OptResp* resp, uint32_t count) = 0;
+
+  virtual void SendLong(long val) = 0;
+  virtual void SendSimpleString(std::string_view str) = 0;
+
+  void SendOk() {
+    SendSimpleString("OK");
   }
 
   // In order to reduce interrupt rate we allow coalescing responses together using
@@ -53,36 +77,10 @@ class SinkReplyBuilder {
     return err_count_;
   }
 
-  //! Sends a string as is without any formatting. raw should be encoded according to the protocol.
-  void SendRaw(std::string_view str);
+ protected:
+  void SendRaw(std::string_view str);  // Sends raw without any formatting.
   void SendRawVec(absl::Span<const std::string_view> msg_vec);
 
-  // Common for both MC and Redis.
-  virtual void SendError(std::string_view str, std::string_view type = std::string_view{}) = 0;
-
-  virtual void SendSimpleString(std::string_view str) = 0;
-
-  void SendOk() {
-    SendSimpleString("OK");
-  }
-
-  struct ResponseValue {
-    std::string_view key;
-    std::string value;
-    uint64_t mc_ver = 0;  // 0 means we do not output it (i.e has not been requested).
-    uint32_t mc_flag = 0;
-  };
-
-  using OptResp = std::optional<ResponseValue>;
-
-  virtual void SendMGetResponse(const OptResp* resp, uint32_t count) = 0;
-  virtual void SendLong(long val) = 0;
-
-  // Reply for set commands.
-  virtual void SendStored() = 0;
-  virtual void SendSetSkipped() = 0;
-
- protected:
   void Send(const iovec* v, uint32_t len);
 
   std::string batch_;
@@ -100,6 +98,8 @@ class MCReplyBuilder : public SinkReplyBuilder {
  public:
   MCReplyBuilder(::io::Sink* stream);
 
+  using SinkReplyBuilder::SendRaw;
+
   void SendError(std::string_view str, std::string_view type = std::string_view{}) final;
 
   // void SendGetReply(std::string_view key, uint32_t flags, std::string_view value) final;
@@ -116,44 +116,40 @@ class MCReplyBuilder : public SinkReplyBuilder {
 
 class RedisReplyBuilder : public SinkReplyBuilder {
  public:
+  enum CollectionType { ARRAY, SET, MAP };
+
+ public:
   RedisReplyBuilder(::io::Sink* stream);
 
   void SetResp3(bool is_resp3);
 
-  void SendError(std::string_view str, std::string_view type = std::string_view{}) override;
+  void SendError(std::string_view str, std::string_view type = {}) override;
   void SendMGetResponse(const OptResp* resp, uint32_t count) override;
-  void SendSimpleString(std::string_view str) override;
+
   void SendStored() override;
-  void SendLong(long val) override;
   void SendSetSkipped() override;
 
-  void SendError(OpStatus status);
+  void SendLong(long val) override;
+  void SendSimpleString(std::string_view str) override;
 
-  virtual void SendSimpleStrArr(const std::string_view* arr, uint32_t count);
-  // Send *-1
-  virtual void SendNullArray();
-  // Send *0
-  virtual void SendEmptyArray();
+  virtual void SendError(OpStatus status);
 
-  virtual void SendStringArr(absl::Span<const std::string_view> arr);
-  virtual void SendStringArr(absl::Span<const std::string> arr);
-  virtual void SendStringArrayAsMap(absl::Span<const std::string_view> arr);
-  virtual void SendStringArrayAsMap(absl::Span<const std::string> arr);
-  virtual void SendStringArrayAsSet(absl::Span<const std::string_view> arr);
-  virtual void SendStringArrayAsSet(absl::Span<const std::string> arr);
+  virtual void SendNullArray();   // Send *-1
+  virtual void SendEmptyArray();  // Send *0
+  virtual void SendSimpleStrArr(absl::Span<const std::string_view> arr);
+
+  virtual void SendStringArr(absl::Span<const std::string_view> arr, CollectionType type = ARRAY);
+  virtual void SendStringArr(absl::Span<const std::string> arr, CollectionType type = ARRAY);
 
   virtual void SendNull();
-
-  virtual void SendScoredArray(const std::vector<std::pair<std::string, double>>& arr,
-                               bool with_scores);
-
   virtual void SendDouble(double val);
 
   virtual void SendBulkString(std::string_view str);
+  virtual void SendScoredArray(const std::vector<std::pair<std::string, double>>& arr,
+                               bool with_scores);
 
-  virtual void StartArray(unsigned len);
-  virtual void StartMap(unsigned num_pairs);
-  virtual void StartSet(unsigned num_elements);
+  void StartArray(unsigned len);  // StartCollection(len, ARRAY)
+  virtual void StartCollection(unsigned len, CollectionType type);
 
   static char* FormatDouble(double val, char* dest, unsigned dest_len);
 
@@ -162,17 +158,12 @@ class RedisReplyBuilder : public SinkReplyBuilder {
   static std::string_view StatusToMsg(OpStatus status);
 
  private:
-  enum CollectionType {
-    ARRAY,
-    SET,
-    MAP,
-  };
+  template <typename S>  // string or string_view
+  void SendStringCollection(absl::Span<const S> arr, CollectionType type);
 
-  using StrPtr = std::variant<const std::string_view*, const std::string*>;
-  void SendStringCollection(StrPtr str_ptr, uint32_t len, CollectionType type);
+  const char* NullString();
 
   bool is_resp3_ = false;
-  const char* NullString();
 };
 
 class ReqSerializer {

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -120,7 +120,6 @@ class RedisReplyBuilder : public SinkReplyBuilder {
 
   using StrSpan = std::variant<absl::Span<const std::string>, absl::Span<const std::string_view>>;
 
- public:
   RedisReplyBuilder(::io::Sink* stream);
 
   void SetResp3(bool is_resp3);

--- a/src/facade/reply_builder_test.cc
+++ b/src/facade/reply_builder_test.cc
@@ -357,7 +357,7 @@ TEST_F(RedisReplyBuilderTest, SendSimpleStrArr) {
       // random values
       "+++", "---", "$$$", "~~~~", "@@@", "^^^", "1234", "foo"};
   const std::size_t kArrayLen = sizeof(kArrayMessage) / sizeof(kArrayMessage[0]);
-  builder_->SendSimpleStrArr(kArrayMessage, kArrayLen);
+  builder_->SendSimpleStrArr(kArrayMessage);
   ASSERT_TRUE(builder_->err_count().empty());
   // Tokenize the message and verify content
   std::vector<std::string_view> message_tokens = TokenizeMessage();
@@ -674,13 +674,13 @@ TEST_F(RedisReplyBuilderTest, TestSendStringArrayAsMap) {
   const std::vector<std::string> map_array{"k1", "v1", "k2", "v2"};
 
   builder_->SetResp3(false);
-  builder_->SendStringArrayAsMap(map_array);
+  builder_->SendStringArr(map_array, builder_->MAP);
   ASSERT_TRUE(builder_->err_count().empty());
   ASSERT_EQ(TakePayload(), "*4\r\n$2\r\nk1\r\n$2\r\nv1\r\n$2\r\nk2\r\n$2\r\nv2\r\n")
       << "SendStringArrayAsMap Resp2 Failed.";
 
   builder_->SetResp3(true);
-  builder_->SendStringArrayAsMap(map_array);
+  builder_->SendStringArr(map_array, builder_->MAP);
   ASSERT_TRUE(builder_->err_count().empty());
   ASSERT_EQ(TakePayload(), "%2\r\n$2\r\nk1\r\n$2\r\nv1\r\n$2\r\nk2\r\n$2\r\nv2\r\n")
       << "SendStringArrayAsMap Resp3 Failed.";
@@ -690,13 +690,13 @@ TEST_F(RedisReplyBuilderTest, TestSendStringArrayAsSet) {
   const std::vector<std::string> set_array{"e1", "e2", "e3"};
 
   builder_->SetResp3(false);
-  builder_->SendStringArrayAsSet(set_array);
+  builder_->SendStringArr(set_array, builder_->SET);
   ASSERT_TRUE(builder_->err_count().empty());
   ASSERT_EQ(TakePayload(), "*3\r\n$2\r\ne1\r\n$2\r\ne2\r\n$2\r\ne3\r\n")
       << "SendStringArrayAsSet Resp2 Failed.";
 
   builder_->SetResp3(true);
-  builder_->SendStringArrayAsSet(set_array);
+  builder_->SendStringArr(set_array, builder_->SET);
   ASSERT_TRUE(builder_->err_count().empty());
   ASSERT_EQ(TakePayload(), "~3\r\n$2\r\ne1\r\n$2\r\ne2\r\n$2\r\ne3\r\n")
       << "SendStringArrayAsSet Resp3 Failed.";

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -117,7 +117,7 @@ void DebugCmd::Run(CmdArgList args) {
         "HELP",
         "    Prints this help.",
     };
-    return (*cntx_)->SendSimpleStrArr(help_arr, ABSL_ARRAYSIZE(help_arr));
+    return (*cntx_)->SendSimpleStrArr(help_arr);
   }
 
   VLOG(1) << "subcmd " << subcmd;

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1012,11 +1012,8 @@ void GenericFamily::Sort(CmdArgList args, ConnectionContext* cntx) {
       end_it = entries.begin() + std::min(bounds->first + bounds->second, entries.size());
     }
 
-    if (result_type == OBJ_SET || result_type == OBJ_ZSET) {
-      (*cntx)->StartSet(std::distance(start_it, end_it));
-    } else {
-      (*cntx)->StartArray(std::distance(start_it, end_it));
-    }
+    auto type = (result_type == OBJ_SET || result_type == OBJ_ZSET) ? (*cntx)->SET : (*cntx)->ARRAY;
+    (*cntx)->StartCollection(std::distance(start_it, end_it), type);
 
     for (auto it = start_it; it != end_it; ++it) {
       (*cntx)->SendBulkString(it->key);

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1012,8 +1012,9 @@ void GenericFamily::Sort(CmdArgList args, ConnectionContext* cntx) {
       end_it = entries.begin() + std::min(bounds->first + bounds->second, entries.size());
     }
 
-    auto type = (result_type == OBJ_SET || result_type == OBJ_ZSET) ? (*cntx)->SET : (*cntx)->ARRAY;
-    (*cntx)->StartCollection(std::distance(start_it, end_it), type);
+    bool is_set = (result_type == OBJ_SET || result_type == OBJ_ZSET);
+    (*cntx)->StartCollection(std::distance(start_it, end_it),
+                             is_set ? RedisReplyBuilder::SET : RedisReplyBuilder::ARRAY);
 
     for (auto it = start_it; it != end_it; ++it) {
       (*cntx)->SendBulkString(it->key);

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -697,11 +697,8 @@ void HGetGeneric(CmdArgList args, ConnectionContext* cntx, uint8_t getall_mask) 
   OpResult<vector<string>> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
 
   if (result) {
-    if (getall_mask == (VALUES | FIELDS)) {
-      (*cntx)->SendStringArrayAsMap(absl::Span<const string>{*result});
-    } else {
-      (*cntx)->SendStringArr(absl::Span<const string>{*result});
-    }
+    auto type = (getall_mask == (VALUES | FIELDS)) ? (*cntx)->MAP : (*cntx)->ARRAY;
+    (*cntx)->SendStringArr(absl::Span<const string>{*result}, type);
   } else {
     (*cntx)->SendError(result.status());
   }

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -697,8 +697,9 @@ void HGetGeneric(CmdArgList args, ConnectionContext* cntx, uint8_t getall_mask) 
   OpResult<vector<string>> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
 
   if (result) {
-    auto type = (getall_mask == (VALUES | FIELDS)) ? (*cntx)->MAP : (*cntx)->ARRAY;
-    (*cntx)->SendStringArr(absl::Span<const string>{*result}, type);
+    bool is_map = (getall_mask == (VALUES | FIELDS));
+    (*cntx)->SendStringArr(absl::Span<const string>{*result},
+                           is_map ? RedisReplyBuilder::MAP : RedisReplyBuilder::ARRAY);
   } else {
     (*cntx)->SendError(result.status());
   }

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -214,8 +214,7 @@ class InterpreterReplier : public RedisReplyBuilder {
   void SendSimpleStrArr(absl::Span<const string_view> arr) override final;
   void SendNullArray() override final;
 
-  void SendStringArr(absl::Span<const string_view> arr, CollectionType type) override final;
-  void SendStringArr(absl::Span<const string> arr, CollectionType type) override final;
+  void SendStringArr(StrSpan arr, CollectionType type) override final;
   void SendNull() override final;
 
   void SendLong(long val) override final;
@@ -343,15 +342,12 @@ void InterpreterReplier::SendNullArray() {
   PostItem();
 }
 
-void InterpreterReplier::SendStringArr(absl::Span<const string_view> arr, CollectionType) {
-  SendSimpleStrArr(arr);
-  PostItem();
-}
-
-void InterpreterReplier::SendStringArr(absl::Span<const string> arr, CollectionType) {
-  explr_->OnArrayStart(arr.size());
-  for (auto sv : arr)
-    explr_->OnString(sv);
+void InterpreterReplier::SendStringArr(StrSpan arr, CollectionType) {
+  WrappedStrSpan warr{arr};
+  size_t size = warr.Size();
+  explr_->OnArrayStart(size);
+  for (size_t i = 0; i < size; i++)
+    explr_->OnString(warr[i]);
   explr_->OnArrayEnd();
   PostItem();
 }

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -206,23 +206,23 @@ class InterpreterReplier : public RedisReplyBuilder {
   InterpreterReplier(ObjectExplorer* explr) : RedisReplyBuilder(nullptr), explr_(explr) {
   }
 
-  void SendError(std::string_view str, std::string_view type = std::string_view{}) override final;
-  void SendStored() override final;
+  void SendError(std::string_view str, std::string_view type = std::string_view{}) final;
+  void SendStored() final;
 
-  void SendSimpleString(std::string_view str) override final;
-  void SendMGetResponse(const OptResp* resp, uint32_t count) override final;
-  void SendSimpleStrArr(absl::Span<const string_view> arr) override final;
-  void SendNullArray() override final;
+  void SendSimpleString(std::string_view str) final;
+  void SendMGetResponse(const OptResp* resp, uint32_t count) final;
+  void SendSimpleStrArr(absl::Span<const string_view> arr) final;
+  void SendNullArray() final;
 
-  void SendStringArr(StrSpan arr, CollectionType type) override final;
-  void SendNull() override final;
+  void SendStringArr(StrSpan arr, CollectionType type) final;
+  void SendNull() final;
 
-  void SendLong(long val) override final;
-  void SendDouble(double val) override final;
+  void SendLong(long val) final;
+  void SendDouble(double val) final;
 
-  void SendBulkString(std::string_view str) override final;
+  void SendBulkString(std::string_view str) final;
 
-  void StartCollection(unsigned len, CollectionType type) override final;
+  void StartCollection(unsigned len, CollectionType type) final;
 
  private:
   void PostItem();

--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -84,7 +84,7 @@ void MemoryCmd::Run(CmdArgList args) {
         "USAGE",
         "    (not implemented).",
     };
-    return (*cntx_)->SendSimpleStrArr(help_arr, ABSL_ARRAYSIZE(help_arr));
+    return (*cntx_)->SendSimpleStrArr(help_arr);
   };
 
   if (sub_cmd == "USAGE") {

--- a/src/server/script_mgr.cc
+++ b/src/server/script_mgr.cc
@@ -71,7 +71,7 @@ void ScriptMgr::Run(CmdArgList args, ConnectionContext* cntx) {
         "   Prints latency histograms in usec for every called function.",
         "HELP"
         "   Prints this help."};
-    return (*cntx)->SendSimpleStrArr(kHelp, ABSL_ARRAYSIZE(kHelp));
+    return (*cntx)->SendSimpleStrArr(kHelp);
   }
 
   if (subcmd == "EXISTS" && args.size() > 1)

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1317,7 +1317,7 @@ void ServerFamily::Config(CmdArgList args, ConnectionContext* cntx) {
     string_view param = ArgS(args, 2);
     string_view res[2] = {param, "tbd"};
 
-    return (*cntx)->SendStringArr(res, (*cntx)->MAP);
+    return (*cntx)->SendStringArr(res, RedisReplyBuilder::MAP);
   } else if (sub_cmd == "RESETSTAT") {
     shard_set->pool()->Await([](auto*) {
       auto* stats = ServerState::tl_connection_stats();
@@ -1710,7 +1710,7 @@ void ServerFamily::Hello(CmdArgList args, ConnectionContext* cntx) {
     (*cntx)->SetResp3(false);
   }
 
-  (*cntx)->StartCollection(7, (*cntx)->MAP);
+  (*cntx)->StartCollection(7, RedisReplyBuilder::MAP);
   (*cntx)->SendBulkString("server");
   (*cntx)->SendBulkString("redis");
   (*cntx)->SendBulkString("version");

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1205,7 +1205,7 @@ void ServerFamily::Cluster(CmdArgList args, ConnectionContext* cntx) {
         "HELP",
         "    Prints this help.",
     };
-    return (*cntx)->SendSimpleStrArr(help_arr, ABSL_ARRAYSIZE(help_arr));
+    return (*cntx)->SendSimpleStrArr(help_arr);
   }
 
   if (sub_cmd == "SLOTS") {
@@ -1317,7 +1317,7 @@ void ServerFamily::Config(CmdArgList args, ConnectionContext* cntx) {
     string_view param = ArgS(args, 2);
     string_view res[2] = {param, "tbd"};
 
-    return (*cntx)->SendStringArrayAsMap(res);
+    return (*cntx)->SendStringArr(res, (*cntx)->MAP);
   } else if (sub_cmd == "RESETSTAT") {
     shard_set->pool()->Await([](auto*) {
       auto* stats = ServerState::tl_connection_stats();
@@ -1710,7 +1710,7 @@ void ServerFamily::Hello(CmdArgList args, ConnectionContext* cntx) {
     (*cntx)->SetResp3(false);
   }
 
-  (*cntx)->StartMap(7);
+  (*cntx)->StartCollection(7, (*cntx)->MAP);
   (*cntx)->SendBulkString("server");
   (*cntx)->SendBulkString("redis");
   (*cntx)->SendBulkString("version");

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -1205,7 +1205,7 @@ void SPop(CmdArgList args, ConnectionContext* cntx) {
         (*cntx)->SendBulkString(result.value().front());
       }
     } else {  // SPOP key cnt
-      (*cntx)->SendStringArrayAsSet(*result);
+      (*cntx)->SendStringArr(*result, (*cntx)->SET);
     }
     return;
   }
@@ -1241,7 +1241,7 @@ void SDiff(CmdArgList args, ConnectionContext* cntx) {
   if (cntx->conn_state.script_info) {  // sort under script
     sort(arr.begin(), arr.end());
   }
-  (*cntx)->SendStringArrayAsSet(arr);
+  (*cntx)->SendStringArr(arr, (*cntx)->SET);
 }
 
 void SDiffStore(CmdArgList args, ConnectionContext* cntx) {
@@ -1309,7 +1309,7 @@ void SMembers(CmdArgList args, ConnectionContext* cntx) {
     if (cntx->conn_state.script_info) {  // sort under script
       sort(svec.begin(), svec.end());
     }
-    (*cntx)->SendStringArrayAsSet(*result);
+    (*cntx)->SendStringArr(*result, (*cntx)->SET);
   } else {
     (*cntx)->SendError(result.status());
   }
@@ -1331,7 +1331,7 @@ void SInter(CmdArgList args, ConnectionContext* cntx) {
     if (cntx->conn_state.script_info) {  // sort under script
       sort(arr.begin(), arr.end());
     }
-    (*cntx)->SendStringArrayAsSet(arr);
+    (*cntx)->SendStringArr(arr, (*cntx)->SET);
   } else {
     (*cntx)->SendError(result.status());
   }
@@ -1394,7 +1394,7 @@ void SUnion(CmdArgList args, ConnectionContext* cntx) {
     if (cntx->conn_state.script_info) {  // sort under script
       sort(arr.begin(), arr.end());
     }
-    (*cntx)->SendStringArrayAsSet(arr);
+    (*cntx)->SendStringArr(arr, (*cntx)->SET);
   } else {
     (*cntx)->SendError(unionset.status());
   }

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -27,6 +27,8 @@ ABSL_DECLARE_FLAG(bool, use_set2);
 
 namespace dfly {
 
+using namespace facade;
+
 using namespace std;
 using absl::GetFlag;
 
@@ -1205,7 +1207,7 @@ void SPop(CmdArgList args, ConnectionContext* cntx) {
         (*cntx)->SendBulkString(result.value().front());
       }
     } else {  // SPOP key cnt
-      (*cntx)->SendStringArr(*result, (*cntx)->SET);
+      (*cntx)->SendStringArr(*result, RedisReplyBuilder::SET);
     }
     return;
   }
@@ -1241,7 +1243,7 @@ void SDiff(CmdArgList args, ConnectionContext* cntx) {
   if (cntx->conn_state.script_info) {  // sort under script
     sort(arr.begin(), arr.end());
   }
-  (*cntx)->SendStringArr(arr, (*cntx)->SET);
+  (*cntx)->SendStringArr(arr, RedisReplyBuilder::SET);
 }
 
 void SDiffStore(CmdArgList args, ConnectionContext* cntx) {
@@ -1309,7 +1311,7 @@ void SMembers(CmdArgList args, ConnectionContext* cntx) {
     if (cntx->conn_state.script_info) {  // sort under script
       sort(svec.begin(), svec.end());
     }
-    (*cntx)->SendStringArr(*result, (*cntx)->SET);
+    (*cntx)->SendStringArr(*result, RedisReplyBuilder::SET);
   } else {
     (*cntx)->SendError(result.status());
   }
@@ -1331,7 +1333,7 @@ void SInter(CmdArgList args, ConnectionContext* cntx) {
     if (cntx->conn_state.script_info) {  // sort under script
       sort(arr.begin(), arr.end());
     }
-    (*cntx)->SendStringArr(arr, (*cntx)->SET);
+    (*cntx)->SendStringArr(arr, RedisReplyBuilder::SET);
   } else {
     (*cntx)->SendError(result.status());
   }
@@ -1394,7 +1396,7 @@ void SUnion(CmdArgList args, ConnectionContext* cntx) {
     if (cntx->conn_state.script_info) {  // sort under script
       sort(arr.begin(), arr.end());
     }
-    (*cntx)->SendStringArr(arr, (*cntx)->SET);
+    (*cntx)->SendStringArr(arr, RedisReplyBuilder::SET);
   } else {
     (*cntx)->SendError(unionset.status());
   }

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -734,7 +734,7 @@ void StreamFamily::XInfo(CmdArgList args, ConnectionContext* cntx) {
           string_view arr[8] = {"name",    ginfo.name,  "consumers",         an1.Piece(),
                                 "pending", an2.Piece(), "last-delivered-id", last_id};
 
-          (*cntx)->SendStringArr(absl::Span<string_view>{arr, 8}, (*cntx)->MAP);
+          (*cntx)->SendStringArr(absl::Span<string_view>{arr, 8}, RedisReplyBuilder::MAP);
         }
         return;
       }

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -666,7 +666,7 @@ void StreamFamily::XGroup(CmdArgList args, ConnectionContext* cntx) {
         "SETID <key> <groupname> <id|$>",
         "    Set the current group ID.",
     };
-    return (*cntx)->SendSimpleStrArr(help_arr, ABSL_ARRAYSIZE(help_arr));
+    return (*cntx)->SendSimpleStrArr(help_arr);
   }
 
   if (args.size() >= 3) {
@@ -709,7 +709,7 @@ void StreamFamily::XInfo(CmdArgList args, ConnectionContext* cntx) {
         "STREAM <key> [FULL [COUNT <count>]",
         "    Show information about the stream.",
     };
-    return (*cntx)->SendSimpleStrArr(help_arr, ABSL_ARRAYSIZE(help_arr));
+    return (*cntx)->SendSimpleStrArr(help_arr);
   }
 
   if (args.size() >= 3) {
@@ -734,7 +734,7 @@ void StreamFamily::XInfo(CmdArgList args, ConnectionContext* cntx) {
           string_view arr[8] = {"name",    ginfo.name,  "consumers",         an1.Piece(),
                                 "pending", an2.Piece(), "last-delivered-id", last_id};
 
-          (*cntx)->SendStringArrayAsMap(absl::Span<string_view>{arr, 8});
+          (*cntx)->SendStringArr(absl::Span<string_view>{arr, 8}, (*cntx)->MAP);
         }
         return;
       }


### PR DESCRIPTION
Refactor ReplyBuilder:

- Functions like SendStringArrayAsMap are only used once or twice, but there are lots of virtual overrides for them and at the end they converge to one generic function, so its better to expose the type enum instead of the overloads
- Explicitly set overrides
- Tidy some code
