### PR TITLE
feat(facade): Capturing reply builder

### DIFF
--- a/src/facade/CMakeLists.txt
+++ b/src/facade/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(dfly_facade dragonfly_listener.cc dragonfly_connection.cc facade.cc
-            memcache_parser.cc redis_parser.cc reply_builder.cc op_status.cc)
+            memcache_parser.cc redis_parser.cc reply_builder.cc op_status.cc
+            reply_capture.cc)
 
 if (DF_USE_SSL)
   set(TLS_LIB tls_lib)

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -124,11 +124,11 @@ void MCReplyBuilder::SendLong(long val) {
   SendSimpleString(string_view(buf, next - buf));
 }
 
-void MCReplyBuilder::SendMGetResponse(const OptResp* resp, uint32_t count) {
+void MCReplyBuilder::SendMGetResponse(absl::Span<const OptResp> arr) {
   string header;
-  for (unsigned i = 0; i < count; ++i) {
-    if (resp[i]) {
-      const auto& src = *resp[i];
+  for (unsigned i = 0; i < arr.size(); ++i) {
+    if (arr[i]) {
+      const auto& src = *arr[i];
       absl::StrAppend(&header, "VALUE ", src.key, " ", src.mc_flag, " ", src.value.size());
       if (src.mc_ver) {
         absl::StrAppend(&header, " ", src.mc_ver);
@@ -323,12 +323,12 @@ void RedisReplyBuilder::SendDouble(double val) {
   }
 }
 
-void RedisReplyBuilder::SendMGetResponse(const OptResp* resp, uint32_t count) {
-  string res = absl::StrCat("*", count, kCRLF);
-  for (size_t i = 0; i < count; ++i) {
-    if (resp[i]) {
-      StrAppend(&res, "$", resp[i]->value.size(), kCRLF);
-      res.append(resp[i]->value).append(kCRLF);
+void RedisReplyBuilder::SendMGetResponse(absl::Span<const OptResp> arr) {
+  string res = absl::StrCat("*", arr.size(), kCRLF);
+  for (size_t i = 0; i < arr.size(); ++i) {
+    if (arr[i]) {
+      StrAppend(&res, "$", arr[i]->value.size(), kCRLF);
+      res.append(arr[i]->value).append(kCRLF);
     } else {
       res.append(NullString());
     }

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -337,11 +337,13 @@ void RedisReplyBuilder::SendMGetResponse(const OptResp* resp, uint32_t count) {
   SendRaw(res);
 }
 
-void RedisReplyBuilder::SendSimpleStrArr(absl::Span<const std::string_view> arr) {
-  string res = absl::StrCat("*", arr.size(), kCRLF);
+void RedisReplyBuilder::SendSimpleStrArr(StrSpan arr) {
+  WrappedStrSpan warr{arr};
 
-  for (auto sv : arr)
-    StrAppend(&res, "+", sv, kCRLF);
+  string res = absl::StrCat("*", warr.Size(), kCRLF);
+
+  for (unsigned i = 0; i < warr.Size(); i++)
+    StrAppend(&res, "+", warr[i], kCRLF);
 
   SendRaw(res);
 }

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -1,6 +1,8 @@
 // Copyright 2022, DragonflyDB authors.  All rights reserved.
 // See LICENSE for licensing terms.
 //
+#pragma once
+
 #include <absl/container/flat_hash_map.h>
 
 #include <optional>
@@ -133,7 +135,7 @@ class RedisReplyBuilder : public SinkReplyBuilder {
 
   virtual void SendNullArray();   // Send *-1
   virtual void SendEmptyArray();  // Send *0
-  virtual void SendSimpleStrArr(absl::Span<const std::string_view> arr);
+  virtual void SendSimpleStrArr(StrSpan arr);
   virtual void SendStringArr(StrSpan arr, CollectionType type = ARRAY);
 
   virtual void SendNull();

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -16,7 +16,7 @@ namespace facade {
 class SinkReplyBuilder {
  public:
   struct ResponseValue {
-    std::string_view key;
+    std::string key;
     std::string value;
     uint64_t mc_ver = 0;  // 0 means we do not output it (i.e has not been requested).
     uint32_t mc_flag = 0;
@@ -38,7 +38,7 @@ class SinkReplyBuilder {
   virtual void SendStored() = 0;  // Reply for set commands.
   virtual void SendSetSkipped() = 0;
 
-  virtual void SendMGetResponse(const OptResp* resp, uint32_t count) = 0;
+  virtual void SendMGetResponse(absl::Span<const OptResp>) = 0;
 
   virtual void SendLong(long val) = 0;
   virtual void SendSimpleString(std::string_view str) = 0;
@@ -105,7 +105,7 @@ class MCReplyBuilder : public SinkReplyBuilder {
   void SendError(std::string_view str, std::string_view type = std::string_view{}) final;
 
   // void SendGetReply(std::string_view key, uint32_t flags, std::string_view value) final;
-  void SendMGetResponse(const OptResp* resp, uint32_t count) final;
+  void SendMGetResponse(absl::Span<const OptResp>) final;
 
   void SendStored() final;
   void SendLong(long val) final;
@@ -127,7 +127,7 @@ class RedisReplyBuilder : public SinkReplyBuilder {
   void SetResp3(bool is_resp3);
 
   void SendError(std::string_view str, std::string_view type = {}) override;
-  void SendMGetResponse(const OptResp* resp, uint32_t count) override;
+  void SendMGetResponse(absl::Span<const OptResp>) override;
 
   void SendStored() override;
   void SendSetSkipped() override;

--- a/src/facade/reply_builder_test.cc
+++ b/src/facade/reply_builder_test.cc
@@ -816,13 +816,15 @@ TEST_F(RedisReplyBuilderTest, TestBasicCapture) {
   crb.SetResp3(true);
   builder_->SetResp3(true);
 
+  // Run generator functions on both a regular redis builder
+  // and the capturing builder with its capture applied.
   for (auto& f : funcs) {
     f(builder_.get());
-    auto c1 = TakePayload();
+    auto expected = TakePayload();
     f(&crb);
     CapturingReplyBuilder::Apply(crb.Take(), builder_.get());
-    auto c2 = TakePayload();
-    EXPECT_EQ(c1, c2);
+    auto actual = TakePayload();
+    EXPECT_EQ(expected, actual);
   }
 
   builder_->SetResp3(false);

--- a/src/facade/reply_builder_test.cc
+++ b/src/facade/reply_builder_test.cc
@@ -6,6 +6,7 @@
 #include "facade/error.h"
 #include "facade/facade_test.h"
 #include "facade/redis_parser.h"
+#include "facade/reply_capture.h"
 
 // This will test the reply_builder RESP (Redis).
 
@@ -750,6 +751,10 @@ TEST_F(RedisReplyBuilderTest, TestSendMGetResponse) {
   builder_->SendMGetResponse(&mget_res[0], 3);
   ASSERT_TRUE(builder_->err_count().empty());
   ASSERT_EQ(TakePayload(), "*3\r\n$2\r\nv3\r\n_\r\n$0\r\n\r\n") << "Resp3 SendMGetResponse failed.";
+}
+
+TEST_F(RedisReplyBuilderTest, TestCapture) {
+  // TODO
 }
 
 }  // namespace facade

--- a/src/facade/reply_capture.cc
+++ b/src/facade/reply_capture.cc
@@ -1,0 +1,156 @@
+#include "facade/reply_capture.h"
+
+#include "base/logging.h"
+#include "reply_capture.h"
+
+namespace facade {
+
+using namespace std;
+
+void CapturingReplyBuilder::SendError(std::string_view str, std::string_view type) {
+  Capture(Error{str, type});
+}
+
+void CapturingReplyBuilder::SendMGetResponse(const OptResp* resp, uint32_t count) {
+  // TODO
+}
+
+void CapturingReplyBuilder::SendStored() {
+  // TODO
+}
+
+void CapturingReplyBuilder::SendSetSkipped() {
+  // TODO
+}
+
+void CapturingReplyBuilder::SendError(OpStatus status) {
+  Capture(status);
+}
+
+void CapturingReplyBuilder::SendNullArray() {
+  Capture(unique_ptr<CollectionPayload>{nullptr});
+}
+
+void CapturingReplyBuilder::SendEmptyArray() {
+  Capture(make_unique<CollectionPayload>(CollectionPayload{0, ARRAY, vector<Payload>{}}));
+}
+
+void CapturingReplyBuilder::SendSimpleStrArr(StrSpan arr) {
+  DCHECK_EQ(current_.index(), 0u);
+
+  WrappedStrSpan warr{arr};
+  vector<string> sarr(warr.Size());
+  for (unsigned i = 0; i < warr.Size(); i++)
+    sarr[i] = warr[i];
+
+  Capture(StrArrPayload{true, ARRAY, move(sarr)});
+}
+
+void CapturingReplyBuilder::SendStringArr(StrSpan arr, CollectionType type) {
+  DCHECK_EQ(current_.index(), 0u);
+
+  // TODO: 1. Allocate all strings at once 2. Allow movable types
+  WrappedStrSpan warr{arr};
+  vector<string> sarr(warr.Size());
+  for (unsigned i = 0; i < warr.Size(); i++)
+    sarr[i] = warr[i];
+
+  Capture(StrArrPayload{false, type, move(sarr)});
+}
+
+void CapturingReplyBuilder::SendNull() {
+  Capture(nullptr_t{});
+}
+
+void CapturingReplyBuilder::SendLong(long val) {
+  Capture(val);
+}
+
+void CapturingReplyBuilder::SendDouble(double val) {
+  Capture(val);
+}
+
+void CapturingReplyBuilder::SendSimpleString(std::string_view str) {
+  Capture(SimpleString{string{str}});
+}
+
+void CapturingReplyBuilder::SendBulkString(std::string_view str) {
+  Capture(BulkString{string{str}});
+}
+
+void CapturingReplyBuilder::SendScoredArray(const std::vector<std::pair<std::string, double>>& arr,
+                                            bool with_scores) {
+  CHECK(false) << "Not implemented";
+}
+
+void CapturingReplyBuilder::StartCollection(unsigned len, CollectionType type) {
+  Capture(make_unique<CollectionPayload>(CollectionPayload{len, type, vector<Payload>{}}));
+}
+
+CapturingReplyBuilder::Payload CapturingReplyBuilder::Get() {
+  CHECK(stack_.empty());
+  return move(current_);
+}
+
+struct CaptureVisitor {
+  void operator()(monostate) {
+  }
+
+  void operator()(long v) {
+    rb->SendLong(v);
+  }
+
+  void operator()(double v) {
+    rb->SendDouble(v);
+  }
+
+  void operator()(const CapturingReplyBuilder::SimpleString& ss) {
+    rb->SendSimpleString(ss);
+  }
+
+  void operator()(const CapturingReplyBuilder::BulkString& bs) {
+    rb->SendBulkString(bs);
+  }
+
+  void operator()(CapturingReplyBuilder::Null) {
+    rb->SendNull();
+  }
+
+  void operator()(CapturingReplyBuilder::Error err) {
+    rb->SendError(err.first, err.second);
+  }
+
+  void operator()(OpStatus status) {
+    rb->SendError(status);
+  }
+
+  void operator()(const CapturingReplyBuilder::StrArrPayload& sa) {
+    if (sa.simple)
+      rb->SendSimpleStrArr(sa.arr);
+    else
+      rb->SendStringArr(sa.arr, sa.type);
+  }
+
+  void operator()(const unique_ptr<CapturingReplyBuilder::CollectionPayload>& cp) {
+    if (!cp) {
+      rb->SendNullArray();
+      return;
+    }
+    if (cp->len == 0 && cp->type == RedisReplyBuilder::ARRAY) {
+      rb->SendEmptyArray();
+      return;
+    }
+    rb->StartCollection(cp->len, cp->type);
+    for (auto& pl : cp->arr)
+      visit(*this, pl);
+  }
+
+  RedisReplyBuilder* rb;
+};
+
+void CapturingReplyBuilder::Apply(Payload&& pl, RedisReplyBuilder* rb) {
+  CaptureVisitor cv{rb};
+  visit(cv, pl);
+}
+
+}  // namespace facade

--- a/src/facade/reply_capture.h
+++ b/src/facade/reply_capture.h
@@ -1,0 +1,108 @@
+// Copyright 2023, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <memory>
+#include <stack>
+#include <variant>
+
+#include "base/logging.h"
+#include "facade/reply_builder.h"
+
+namespace facade {
+
+struct CaptureVisitor;
+
+class CapturingReplyBuilder : public RedisReplyBuilder {
+  friend struct CaptureVisitor;
+
+ public:
+  void SendError(std::string_view str, std::string_view type = {}) override;
+  void SendMGetResponse(const OptResp* resp, uint32_t count) override;
+
+  void SendStored() override;
+  void SendSetSkipped() override;
+  void SendError(OpStatus status) override;
+
+  void SendNullArray() override;
+  void SendEmptyArray() override;
+  void SendSimpleStrArr(StrSpan arr) override;
+  void SendStringArr(StrSpan arr, CollectionType type = ARRAY) override;
+
+  void SendNull() override;
+  void SendLong(long val) override;
+  void SendDouble(double val) override;
+  void SendSimpleString(std::string_view str) override;
+
+  void SendBulkString(std::string_view str) override;
+  void SendScoredArray(const std::vector<std::pair<std::string, double>>& arr,
+                       bool with_scores) override;
+
+  void StartCollection(unsigned len, CollectionType type) override;
+
+ private:
+  using Error = std::pair<std::string, std::string>;  // SendError
+  using Null = std::nullptr_t;                        // SendNull or SendNullArray
+  struct SimpleString : public std::string {};        // SendSimpleString
+  struct BulkString : public std::string {};          // SendBulkString
+
+  struct StrArrPayload {
+    bool simple;
+    CollectionType type;
+    std::vector<std::string> arr;
+  };
+
+  struct CollectionPayload;
+
+ public:
+  using Payload = std::variant<std::monostate, Null, Error, OpStatus, long, double, SimpleString,
+                               BulkString, StrArrPayload, std::unique_ptr<CollectionPayload>>;
+
+  Payload Get();
+
+  static void Apply(Payload&& pl, RedisReplyBuilder* builder);
+
+ private:
+  struct CollectionPayload {
+    unsigned len;
+    CollectionType type;
+    std::vector<Payload> arr;
+  };
+
+ private:
+  template <typename T> void Capture(T&& val, bool skip_collection = false) {
+    // Try adding collection to stack if not skipping it.
+    bool added = false;
+    if constexpr (std::is_same_v<std::remove_reference_t<T>, std::unique_ptr<CollectionPayload>>) {
+      if (!skip_collection) {
+        int size = val ? (val->type == MAP ? val->len * 2 : val->len) : 0;
+        stack_.emplace(std::move(val), size);
+        added = true;
+      }
+    }
+
+    // Add simple element to topmost collection or as standalone.
+    if (!added) {
+      if (!stack_.empty()) {
+        stack_.top().first->arr.push_back(Payload{});
+        stack_.top().second--;
+      } else {
+        DCHECK_EQ(current_.index(), 0u);
+        current_ = std::move(val);
+      }
+    }
+
+    while (!stack_.empty() && stack_.top().second == 0) {
+      auto pl = std::move(stack_.top());
+      stack_.pop();
+      Capture(std::move(pl.first), true);
+    }
+  }
+
+  std::stack<std::pair<std::unique_ptr<CollectionPayload>, int>> stack_;
+  Payload current_;
+};
+
+}  // namespace facade

--- a/src/facade/reply_capture.h
+++ b/src/facade/reply_capture.h
@@ -8,7 +8,6 @@
 #include <stack>
 #include <variant>
 
-#include "base/logging.h"
 #include "facade/reply_builder.h"
 
 namespace facade {

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -1114,7 +1114,7 @@ void StringFamily::MGet(CmdArgList args, ConnectionContext* cntx) {
     }
   }
 
-  return cntx->reply_builder()->SendMGetResponse(res.data(), res.size());
+  return cntx->reply_builder()->SendMGetResponse(res);
 }
 
 void StringFamily::MSet(CmdArgList args, ConnectionContext* cntx) {


### PR DESCRIPTION
Implement CapturingReplyBuilder to allow capturing responses and replaying them.

Captured responses will be used for executing multiple squashed commands in parallel. The stored responses can then be reordeded and replayed from a single thread.