### PR TITLE
fix(ci): Use stripped binaries for docker images

### DIFF
--- a/.github/workflows/reusable-container-workflow.yaml
+++ b/.github/workflows/reusable-container-workflow.yaml
@@ -82,6 +82,8 @@ jobs:
           echo "Input prerelease ${{ github.event.inputs.PRERELEASE }}"
           ls -l
           ls -l releases
+          # remove un-stripped packages so that we use the stripped version
+          rm releases/*.unstripped.tar.gz
           for f in releases/*.tar.gz; do tar xvfz $f -C releases; done
           rm releases/*.tar.gz
 


### PR DESCRIPTION
Fixes #999 

This PR updates the container release workflow to delete the
unstripped packages so that we prevent the stripped packages from
being overwritten.

This should reduce the size of the container images significantly.
