### PR TITLE
fix: add missing barrier to fix reads in the coordinator fiber

### DIFF
--- a/src/facade/facade_test.h
+++ b/src/facade/facade_test.h
@@ -32,8 +32,8 @@ class RespMatcher {
   RespExpr::Type type_;
 
   std::string exp_str_;
-  int64_t exp_int_;
-  double_t exp_double_;
+  int64_t exp_int_ = 0;
+  double_t exp_double_ = 0;
 };
 
 class RespTypeMatcher {


### PR DESCRIPTION
1. Adds memory barriers around `run_count_` so that the coordinator thread won't read stale data.
2. (unrelated to the fix): Replaces transaction callback with `FunctionRef` that does not allocate like `std::function`.


Fixes #997.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->