### PR TITLE
LPUSHX and RPUSHX now return 0 size when key does not exist.

### DIFF
--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -437,7 +437,7 @@ OpResult<uint32_t> OpPush(const OpArgs& op_args, std::string_view key, ListDir d
   if (skip_notexist) {
     auto it_res = es->db_slice().Find(op_args.db_cntx, key, OBJ_LIST);
     if (!it_res)
-      return it_res.status();
+      return 0;  // Redis returns 0 for nonexisting keys for the *PUSHX actions.
     it = *it_res;
   } else {
     try {

--- a/src/server/list_family_test.cc
+++ b/src/server/list_family_test.cc
@@ -813,4 +813,28 @@ TEST_F(ListFamilyTest, BLMove) {
   ASSERT_THAT(resp.GetVec(), ElementsAre("val1", "val2"));
 }
 
+TEST_F(ListFamilyTest, LPushX) {
+  // No push for 'lpushx' on nonexisting key.
+  EXPECT_THAT(Run({"lpushx", kKey1, "val1"}), IntArg(0));
+  EXPECT_THAT(Run({"llen", kKey1}), IntArg(0));
+
+  EXPECT_THAT(Run({"lpush", kKey1, "val1"}), IntArg(1));
+  EXPECT_THAT(Run({"lrange", kKey1, "0", "-1"}), "val1");
+
+  EXPECT_THAT(Run({"lpushx", kKey1, "val2"}), IntArg(2));
+  EXPECT_THAT(Run({"lrange", kKey1, "0", "-1"}).GetVec(), ElementsAre("val2", "val1"));
+}
+
+TEST_F(ListFamilyTest, RPushX) {
+  // No push for 'rpushx' on nonexisting key.
+  EXPECT_THAT(Run({"rpushx", kKey1, "val1"}), IntArg(0));
+  EXPECT_THAT(Run({"llen", kKey1}), IntArg(0));
+
+  EXPECT_THAT(Run({"rpush", kKey1, "val1"}), IntArg(1));
+  EXPECT_THAT(Run({"lrange", kKey1, "0", "-1"}), "val1");
+
+  EXPECT_THAT(Run({"rpushx", kKey1, "val2"}), IntArg(2));
+  EXPECT_THAT(Run({"lrange", kKey1, "0", "-1"}).GetVec(), ElementsAre("val1", "val2"));
+}
+
 }  // namespace dfly


### PR DESCRIPTION
Fixes #834

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->