### PR TITLE
ZPOPMAX and ZPOPMIN now reply with scores.

### DIFF
--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1755,6 +1755,7 @@ void ZSetFamily::ZPopMinMax(CmdArgList args, bool reverse, ConnectionContext* cn
 
   RangeParams range_params;
   range_params.reverse = reverse;
+  range_params.with_scores = true;
   ZRangeSpec range_spec;
   range_spec.params = range_params;
 

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -433,21 +433,23 @@ TEST_F(ZSetFamilyTest, ZPopMin) {
   EXPECT_THAT(resp, IntArg(6));
 
   resp = Run({"zpopmin", "key"});
-  ASSERT_THAT(resp, "a");
+  ASSERT_THAT(resp, ArrLen(2));
+  EXPECT_THAT(resp.GetVec(), ElementsAre("a", "1"));
 
   resp = Run({"zpopmin", "key", "2"});
-  ASSERT_THAT(resp, ArrLen(2));
-  EXPECT_THAT(resp.GetVec(), ElementsAre("b", "c"));
+  ASSERT_THAT(resp, ArrLen(4));
+  EXPECT_THAT(resp.GetVec(), ElementsAre("b", "2", "c", "3"));
 
   resp = Run({"zpopmin", "key", "-1"});
   ASSERT_THAT(resp, ErrArg("value is out of range, must be positive"));
 
   resp = Run({"zpopmin", "key", "1"});
-  ASSERT_THAT(resp, "d");
+  ASSERT_THAT(resp, ArrLen(2));
+  EXPECT_THAT(resp.GetVec(), ElementsAre("d", "4"));
 
   resp = Run({"zpopmin", "key", "3"});
-  ASSERT_THAT(resp, ArrLen(2));
-  EXPECT_THAT(resp.GetVec(), ElementsAre("e", "f"));
+  ASSERT_THAT(resp, ArrLen(4));
+  EXPECT_THAT(resp.GetVec(), ElementsAre("e", "5", "f", "6"));
 
   resp = Run({"zpopmin", "key", "1"});
   ASSERT_THAT(resp, ArrLen(0));
@@ -458,21 +460,23 @@ TEST_F(ZSetFamilyTest, ZPopMax) {
   EXPECT_THAT(resp, IntArg(6));
 
   resp = Run({"zpopmax", "key"});
-  ASSERT_THAT(resp, "f");
+  ASSERT_THAT(resp, ArrLen(2));
+  EXPECT_THAT(resp.GetVec(), ElementsAre("f", "6"));
 
   resp = Run({"zpopmax", "key", "2"});
-  ASSERT_THAT(resp, ArrLen(2));
-  EXPECT_THAT(resp.GetVec(), ElementsAre("e", "d"));
+  ASSERT_THAT(resp, ArrLen(4));
+  EXPECT_THAT(resp.GetVec(), ElementsAre("e", "5", "d", "4"));
 
   resp = Run({"zpopmax", "key", "-1"});
   ASSERT_THAT(resp, ErrArg("value is out of range, must be positive"));
 
   resp = Run({"zpopmax", "key", "1"});
-  ASSERT_THAT(resp, "c");
+  ASSERT_THAT(resp, ArrLen(2));
+  EXPECT_THAT(resp.GetVec(), ElementsAre("c", "3"));
 
   resp = Run({"zpopmax", "key", "3"});
-  ASSERT_THAT(resp, ArrLen(2));
-  EXPECT_THAT(resp.GetVec(), ElementsAre("b", "a"));
+  ASSERT_THAT(resp, ArrLen(4));
+  EXPECT_THAT(resp.GetVec(), ElementsAre("b", "2", "a", "1"));
 
   resp = Run({"zpopmax", "key", "1"});
   ASSERT_THAT(resp, ArrLen(0));
@@ -485,7 +489,7 @@ TEST_F(ZSetFamilyTest, ZAddPopCrash) {
   }
 
   auto resp = Run({"zpopmin", "key"});
-  EXPECT_EQ(resp, "element:0");
+  EXPECT_THAT(resp.GetVec(), ElementsAre("element:0", "0"));
 }
 
 TEST_F(ZSetFamilyTest, Resp3) {


### PR DESCRIPTION
This is aligned with Redis' behavior.

Fixes #833

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->