### PR TITLE
chore: remove fiber related names from the codebase

### DIFF
--- a/src/core/fibers.h
+++ b/src/core/fibers.h
@@ -5,10 +5,12 @@
 
 // An import header that centralizes all the imports from helio project regarding fibers
 
+#include "util/fiber_sched_algo.h"
 #include "util/fibers/event_count.h"
 #include "util/fibers/fiber.h"
 #include "util/fibers/fiberqueue_threadpool.h"
 #include "util/fibers/fibers_ext.h"
+#include "util/fibers/simple_channel.h"
 
 namespace dfly {
 
@@ -18,10 +20,12 @@ using util::fibers_ext::Done;
 using util::fibers_ext::EventCount;
 using util::fibers_ext::Fiber;
 using util::fibers_ext::FiberQueue;
+using util::fibers_ext::FiberQueueThreadPool;
 using util::fibers_ext::Future;
 using util::fibers_ext::Launch;
 using util::fibers_ext::Mutex;
 using util::fibers_ext::Promise;
+using util::fibers_ext::SimpleChannel;
 using CondVar = ::boost::fibers::condition_variable;
 
 }  // namespace dfly

--- a/src/core/uring.h
+++ b/src/core/uring.h
@@ -1,0 +1,17 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include "util/uring/proactor.h"
+#include "util/uring/uring_file.h"
+
+namespace dfly {
+
+using util::uring::FiberCall;
+using util::uring::LinuxFile;
+using util::uring::OpenLinux;
+using util::uring::OpenRead;
+
+}  // namespace dfly

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -14,8 +14,6 @@
 #include "facade/memcache_parser.h"
 #include "facade/redis_parser.h"
 #include "facade/service_interface.h"
-#include "util/fiber_sched_algo.h"
-#include "util/fibers/fiber.h"
 
 #ifdef DFLY_USE_SSL
 #include "util/tls/tls_socket.h"
@@ -393,7 +391,7 @@ void Connection::UnregisterShutdownHook(ShutdownHandle id) {
 }
 
 void Connection::HandleRequests() {
-  FiberProps::SetName("DflyConnection");
+  ThisFiber::SetName("DflyConnection");
 
   LinuxSocketBase* lsb = static_cast<LinuxSocketBase*>(socket_.get());
 
@@ -841,7 +839,7 @@ auto Connection::IoLoop(util::FiberSocketBase* peer) -> variant<error_code, Pars
 // InputLoop. Note: in some cases, InputLoop may decide to dispatch directly and bypass the
 // DispatchFiber.
 void Connection::DispatchFiber(util::FiberSocketBase* peer) {
-  FiberProps::SetName("DispatchFiber");
+  ThisFiber::SetName("DispatchFiber");
 
   SinkReplyBuilder* builder = cc_->reply_builder();
   DispatchOperations dispatch_op{builder, this};

--- a/src/facade/dragonfly_listener.cc
+++ b/src/facade/dragonfly_listener.cc
@@ -46,6 +46,8 @@ CONFIG_enum(tls_auth_clients, "yes", "", tls_auth_clients_enum, tls_auth_clients
 namespace facade {
 
 using namespace util;
+using util::detail::SafeErrorMessage;
+
 using absl::GetFlag;
 
 namespace {
@@ -152,7 +154,7 @@ error_code Listener::ConfigureServerSocket(int fd) {
   constexpr int kInterval = 300;  // 300 seconds is ok to start checking for liveness.
 
   if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val)) < 0) {
-    LOG(WARNING) << "Could not set reuse addr on socket " << detail::SafeErrorMessage(errno);
+    LOG(WARNING) << "Could not set reuse addr on socket " << SafeErrorMessage(errno);
   }
   bool success = ConfigureKeepAlive(fd, kInterval);
 
@@ -165,7 +167,7 @@ error_code Listener::ConfigureServerSocket(int fd) {
     // Ignore the error on UDS.
     if (getsockopt(fd, SOL_SOCKET, SO_DOMAIN, &socket_type, &length) != 0 ||
         socket_type != AF_UNIX) {
-      LOG(WARNING) << "Could not configure keep alive " << detail::SafeErrorMessage(myerr);
+      LOG(WARNING) << "Could not configure keep alive " << SafeErrorMessage(myerr);
     }
   }
 

--- a/src/facade/dragonfly_listener.h
+++ b/src/facade/dragonfly_listener.h
@@ -7,7 +7,6 @@
 #include <absl/base/internal/spinlock.h>
 
 #include "facade/facade_types.h"
-#include "util/fibers/fiber.h"
 #include "util/http/http_handler.h"
 #include "util/listener_interface.h"
 

--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -27,6 +27,7 @@ extern "C" {
 namespace dfly {
 
 using namespace std;
+using namespace util;
 
 atomic_uint64_t used_mem_peak(0);
 atomic_uint64_t used_mem_current(0);
@@ -311,7 +312,7 @@ GenericError Context::ReportErrorInternal(GenericError&& err) {
   CHECK(!err_handler_fb_.IsJoinable());
 
   if (err_handler_)
-    err_handler_fb_ = Fiber{err_handler_, err_};
+    err_handler_fb_ = MakeFiber(err_handler_, err_);
 
   Cancellation::Cancel();
   return err_;

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -10,7 +10,6 @@
 #include "server/server_family.h"
 #include "server/server_state.h"
 #include "src/facade/dragonfly_connection.h"
-#include "util/proactor_base.h"
 
 namespace dfly {
 

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -13,9 +13,6 @@ extern "C" {
 #include "server/journal/journal.h"
 #include "server/server_state.h"
 #include "server/tiered_storage.h"
-#include "util/fiber_sched_algo.h"
-#include "util/fibers/fiber.h"
-#include "util/proactor_base.h"
 
 namespace dfly {
 

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -11,10 +11,6 @@
 #include "server/conn_context.h"
 #include "server/table.h"
 
-namespace util {
-class ProactorBase;
-}
-
 namespace dfly {
 
 using facade::OpResult;

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -19,8 +19,6 @@
 #include "server/server_state.h"
 #include "server/string_family.h"
 #include "server/transaction.h"
-#include "util/fiber_sched_algo.h"
-#include "util/fibers/fiber.h"
 
 using namespace std;
 
@@ -314,7 +312,7 @@ void DebugCmd::Populate(CmdArgList args) {
 
 void DebugCmd::PopulateRangeFiber(uint64_t from, uint64_t len, std::string_view prefix,
                                   unsigned value_len, bool populate_random_values) {
-  FiberProps::SetName("populate_range");
+  ThisFiber::SetName("populate_range");
   VLOG(1) << "PopulateRange: " << from << "-" << (from + len - 1);
 
   string key = absl::StrCat(prefix, ":");

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -383,7 +383,7 @@ OpStatus DflyCmd::StartFullSyncInThread(FlowInfo* flow, Context* cntx, EngineSha
     flow->saver->StartSnapshotInShard(true, cntx->GetCancellation(), shard);
   }
 
-  flow->full_sync_fb = Fiber(&DflyCmd::FullSyncFb, this, flow, cntx);
+  flow->full_sync_fb = MakeFiber(&DflyCmd::FullSyncFb, this, flow, cntx);
   return OpStatus::OK;
 }
 

--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -10,7 +10,6 @@
 #include <memory>
 
 #include "server/conn_context.h"
-#include "util/fibers/fiber.h"
 
 namespace facade {
 class RedisReplyBuilder;

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -15,7 +15,6 @@ extern "C" {
 #include "server/server_state.h"
 #include "server/tiered_storage.h"
 #include "server/transaction.h"
-#include "util/fiber_sched_algo.h"
 #include "util/varz.h"
 
 using namespace std;
@@ -532,7 +531,7 @@ BlockingController* EngineShard::EnsureBlockingController() {
 
 void EngineShard::TEST_EnableHeartbeat() {
   fiber_periodic_ = MakeFiber([this, period_ms = 1] {
-    FiberProps::SetName("shard_periodic_TEST");
+    ThisFiber::SetName("shard_periodic_TEST");
     RunPeriodic(std::chrono::milliseconds(period_ms));
   });
 }

--- a/src/server/io_mgr.h
+++ b/src/server/io_mgr.h
@@ -7,14 +7,15 @@
 #include <functional>
 #include <string>
 
-#include "util/uring/uring_file.h"
+#include "core/uring.h"
 
 namespace dfly {
 
 class IoMgr {
  public:
   // first arg - io result.
-  // using WriteCb = fu2::function_base<true, false, fu2::capacity_default, false, false, void(int)>;
+  // using WriteCb = fu2::function_base<true, false, fu2::capacity_default, false, false,
+  // void(int)>;
   using WriteCb = std::function<void(int)>;
 
   // (io_res, )
@@ -46,7 +47,7 @@ class IoMgr {
   }
 
  private:
-  std::unique_ptr<util::uring::LinuxFile> backing_file_;
+  std::unique_ptr<LinuxFile> backing_file_;
   size_t sz_ = 0;
 
   union {

--- a/src/server/io_utils.h
+++ b/src/server/io_utils.h
@@ -5,7 +5,6 @@
 #include "base/io_buf.h"
 #include "io/io.h"
 #include "server/common.h"
-#include "util/fibers/event_count.h"
 
 namespace dfly {
 
@@ -62,7 +61,7 @@ class BufferedStreamerBase : public io::Sink {
  protected:
   bool producer_done_ = false;  // whether producer is done
   unsigned buffered_ = 0;       // how many entries are buffered
-  EventCount waker_{};          // two sided waker
+  EventCount waker_;            // two sided waker
 
   const Cancellation* cll_;  // global cancellation
 

--- a/src/server/journal/journal_slice.cc
+++ b/src/server/journal/journal_slice.cc
@@ -11,6 +11,7 @@
 #include <filesystem>
 
 #include "base/logging.h"
+#include "util/uring/uring_file.h"
 
 namespace dfly {
 namespace journal {
@@ -84,8 +85,7 @@ std::error_code JournalSlice::Open(std::string_view dir) {
   // https://www.evanjones.ca/durability-filesystem.html
   // NOTE: O_DSYNC is omitted.
   constexpr auto kJournalFlags = O_CLOEXEC | O_CREAT | O_TRUNC | O_RDWR;
-  io::Result<std::unique_ptr<uring::LinuxFile>> res =
-      uring::OpenLinux(shard_path_, kJournalFlags, 0666);
+  io::Result<unique_ptr<LinuxFile>> res = OpenLinux(shard_path_, kJournalFlags, 0666);
   if (!res) {
     return res.error();
   }

--- a/src/server/journal/journal_slice.h
+++ b/src/server/journal/journal_slice.h
@@ -8,9 +8,9 @@
 #include <string_view>
 
 #include "base/ring_buffer.h"
+#include "core/uring.h"
 #include "server/common.h"
 #include "server/journal/types.h"
-#include "util/uring/uring_file.h"
 
 namespace dfly {
 namespace journal {
@@ -49,10 +49,10 @@ class JournalSlice {
   struct RingItem;
 
   std::string shard_path_;
-  std::unique_ptr<util::uring::LinuxFile> shard_file_;
+  std::unique_ptr<LinuxFile> shard_file_;
   std::optional<base::RingBuffer<RingItem>> ring_buffer_;
 
-  util::fibers_ext::SharedMutex cb_mu_;
+  util::SharedMutex cb_mu_;
   std::vector<std::pair<uint32_t, ChangeCallback>> change_cb_arr_;
 
   size_t file_offset_ = 0;

--- a/src/server/journal/streamer.cc
+++ b/src/server/journal/streamer.cc
@@ -5,9 +5,10 @@
 #include "server/journal/streamer.h"
 
 namespace dfly {
+using namespace util;
 
 void JournalStreamer::Start(io::Sink* dest) {
-  write_fb_ = Fiber(&JournalStreamer::WriterFb, this, dest);
+  write_fb_ = MakeFiber(&JournalStreamer::WriterFb, this, dest);
   journal_cb_id_ =
       journal_->RegisterOnChange([this](const journal::Entry& entry, bool allow_await) {
         if (entry.opcode == journal::Op::NOOP) {

--- a/src/server/journal/streamer.h
+++ b/src/server/journal/streamer.h
@@ -7,7 +7,6 @@
 #include "server/io_utils.h"
 #include "server/journal/journal.h"
 #include "server/journal/serializer.h"
-#include "util/fibers/fiber.h"
 
 namespace dfly {
 

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -25,7 +25,6 @@ extern "C" {
 #include "server/main_service.h"
 #include "server/rdb_load.h"
 #include "strings/human_readable.h"
-#include "util/proactor_base.h"
 
 ABSL_FLAG(bool, enable_multi_shard_sync, false,
           "Execute multi shards commands on replica syncrhonized");
@@ -160,7 +159,7 @@ bool Replica::Start(ConnectionContext* cntx) {
   cntx_.Reset(absl::bind_front(&Replica::DefaultErrorHandler, this));
 
   // 5. Spawn main coordination fiber.
-  sync_fb_ = Fiber(&Replica::MainReplicationFb, this);
+  sync_fb_ = MakeFiber(&Replica::MainReplicationFb, this);
 
   (*cntx)->SendOk();
   return true;

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -10,8 +10,6 @@
 #include "facade/redis_parser.h"
 #include "server/channel_store.h"
 #include "server/engine_shard_set.h"
-#include "util/fibers/fiber.h"
-#include "util/proactor_pool.h"
 
 namespace util {
 class AcceptServer;
@@ -189,7 +187,7 @@ class ServerFamily {
   std::atomic_bool is_saving_{false};
 
   Done is_snapshot_done_;
-  std::unique_ptr<util::fibers_ext::FiberQueueThreadPool> fq_threadpool_;
+  std::unique_ptr<FiberQueueThreadPool> fq_threadpool_;
 };
 
 }  // namespace dfly

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -18,8 +18,6 @@ extern "C" {
 #include "server/journal/journal.h"
 #include "server/rdb_extensions.h"
 #include "server/rdb_save.h"
-#include "util/fiber_sched_algo.h"
-#include "util/proactor_base.h"
 
 namespace dfly {
 
@@ -107,7 +105,7 @@ void SliceSnapshot::Join() {
 void SliceSnapshot::IterateBucketsFb(const Cancellation* cll) {
   {
     auto fiber_name = absl::StrCat("SliceSnapshot-", ProactorBase::GetIndex());
-    FiberProps::SetName(std::move(fiber_name));
+    ThisFiber::SetName(std::move(fiber_name));
   }
 
   PrimeTable::Cursor cursor;

--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -12,7 +12,6 @@
 #include "server/db_slice.h"
 #include "server/rdb_save.h"
 #include "server/table.h"
-#include "util/fibers/simple_channel.h"
 
 namespace dfly {
 
@@ -55,8 +54,7 @@ class SliceSnapshot {
     std::string value;
   };
 
-  using RecordChannel =
-      ::util::fibers_ext::SimpleChannel<DbRecord, base::mpmc_bounded_queue<DbRecord>>;
+  using RecordChannel = SimpleChannel<DbRecord, base::mpmc_bounded_queue<DbRecord>>;
 
   SliceSnapshot(DbSlice* slice, RecordChannel* dest, CompressionMode compression_mode);
   ~SliceSnapshot();

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -14,7 +14,6 @@ extern "C" {
 #include "base/logging.h"
 #include "server/db_slice.h"
 #include "server/engine_shard_set.h"
-#include "util/proactor_base.h"
 
 ABSL_FLAG(uint32_t, tiered_storage_max_pending_writes, 32,
           "Maximal number of pending writes per thread");

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -9,7 +9,6 @@
 #include "server/common.h"
 #include "server/io_mgr.h"
 #include "server/table.h"
-#include "util/fibers/event_count.h"
 
 namespace dfly {
 


### PR DESCRIPTION
Remove Boost.Fibers mentions and remove fibers_ext mentions. Done in preparation to switch to helio-native fb2 implementation.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->