### PR TITLE
(build)allow to compile with a custom OpenSSL installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/helio/cmake" ${CMAKE_MODULE_P
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(DF_USE_SSL "Provide support for SSL connections" ON)
 
+find_package(OpenSSL)
+
 include(third_party)
 include(internal)
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(dfly_core compact_object.cc dragonfly_core.cc extent_tree.cc
     string_set.cc string_map.cc detail/bitpacking.cc)
 
 cxx_link(dfly_core base absl::flat_hash_map absl::str_format redis_lib TRDP::lua lua_modules
-    Boost::fiber TRDP::jsoncons crypto)
+    Boost::fiber TRDP::jsoncons OpenSSL::Crypto)
 
 add_executable(dash_bench dash_bench.cc)
 cxx_link(dash_bench dfly_core)


### PR DESCRIPTION
* allow to pass a custom OpenSSL folder from build command as -DOPENSSL_ROOT_DIR=/path/to/openssl/folder
* make sure crypto and ssl library using the same installation source