### PR TITLE
fix(server): Return the replica's port on ROLE command

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1894,8 +1894,9 @@ void ServerFamily::Role(CmdArgList args, ConnectionContext* cntx) {
     auto vec = dfly_cmd_->GetReplicasRoleInfo();
     (*cntx)->StartArray(vec.size());
     for (auto& data : vec) {
-      (*cntx)->StartArray(2);
+      (*cntx)->StartArray(3);
       (*cntx)->SendBulkString(data.address);
+      (*cntx)->SendBulkString(absl::StrCat(data.listening_port));
       (*cntx)->SendBulkString(data.state);
     }
 


### PR DESCRIPTION
Fix #859.

Sample output after the change:

```
127.0.0.1:6379> role
1) "master"
2) 1) 1) "127.0.0.1"
      2) "6380"
      3) "stable sync"
```