### PR TITLE
feat: increase the flexibility of how to assign DF threads

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -42,12 +42,13 @@ using namespace std;
 ABSL_FLAG(uint32_t, port, 6379, "Redis port");
 ABSL_FLAG(uint32_t, memcache_port, 0, "Memcached port");
 
-ABSL_FLAG(int, multi_exec_mode, 1,
+ABSL_FLAG(uint32_t, multi_exec_mode, 1,
           "Set multi exec atomicity mode: 1 for global, 2 for locking ahead, 3 for locking "
           "incrementally, 4 for non atomic");
-ABSL_FLAG(int, multi_eval_mode, 1,
+ABSL_FLAG(uint32_t, multi_eval_mode, 1,
           "Set EVAL atomicity mode: 1 for global, 2 for locking ahead, 3 for locking "
           "incrementally, 4 for non atomic");
+ABSL_FLAG(uint32_t, num_shards, 0, "Number of database shards, 0 - to choose automatically");
 
 namespace dfly {
 
@@ -518,7 +519,13 @@ void Service::Init(util::AcceptServer* acceptor, util::ListenerInterface* main_i
 
   pp_.Await([](uint32_t index, ProactorBase* pb) { ServerState::Init(index); });
 
-  uint32_t shard_num = pp_.size() > 1 ? pp_.size() - 1 : pp_.size();
+  uint32_t shard_num = GetFlag(FLAGS_num_shards);
+  if (shard_num == 0) {
+    shard_num = pp_.size() > 1 ? pp_.size() - 1 : pp_.size();
+  } else if (shard_num > pp_.size()) {
+    shard_num = pp_.size();
+  }
+
   shard_set->Init(shard_num, !opts.disable_time_update);
 
   request_latency_usec.Init(&pp_);

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -15,7 +15,7 @@
 #include "server/test_utils.h"
 #include "server/transaction.h"
 
-ABSL_DECLARE_FLAG(int, multi_exec_mode);
+ABSL_DECLARE_FLAG(uint32_t, multi_exec_mode);
 ABSL_DECLARE_FLAG(std::string, default_lua_config);
 
 namespace dfly {


### PR DESCRIPTION
Specifically, introduce `conn_io_threads` and `conn_io_thread_start` flags that choose which threads can handle I/O. In addition, introduce `num_shards` flag that may override how many database shards exist in a dragonfly process.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->