### PR TITLE
fix(server): Set lower timeouts for Replica::ConnectAndAuth()

### DIFF
--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -296,8 +296,8 @@ error_code Replica::ConnectAndAuth(std::chrono::milliseconds connect_timeout_ms)
   CHECK(mythread);
   sock_.reset(mythread->CreateSocket());
 
-  // We want a timeout for the initial connection because this stage might be blocking.
-  // We don't need it for the rest of the sync.
+  // We set this timeout because this call blocks other REPLICAOF commands. We don't need it for the
+  // rest of the sync.
   {
     uint32_t timeout = sock_->timeout();
     sock_->set_timeout(connect_timeout_ms.count());

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -118,8 +118,9 @@ class Replica {
   void MainReplicationFb();
 
   std::error_code ResolveMasterDns();  // Resolve master dns
-  std::error_code ConnectAndAuth();    // Connect to master and authenticate if needed.
-  std::error_code Greet();             // Send PING and REPLCONF.
+  // Connect to master and authenticate if needed.
+  std::error_code ConnectAndAuth(std::chrono::milliseconds connect_timeout_ms);
+  std::error_code Greet();  // Send PING and REPLCONF.
 
   std::error_code InitiatePSync();     // Redis full sync.
   std::error_code InitiateDflySync();  // Dragonfly full sync.


### PR DESCRIPTION
Fix #1032 

The problem turned out to be that we call `Replica->Stop()` while holding the global replication mutex. The `Stop()` call was blocked because the previous replication fiber was trying to reconnect and it was stuck in the `ConnectAndAuth()` stage of the `MainReplicationFb` mainloop.

This kind of fixes the issue by setting timeouts for our replication sockets: 20 seconds for the initial connection and 1 second for any subsequent re-connection attempt. These timeouts can be configured with flags. So now the previous replica will stop faster and won't block the command for 2 minutes.
