### PR TITLE
feat(tests): rand seed flag and output

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -17,6 +17,8 @@ You can override the location of the binary using `DRAGONFLY_PATH` environment v
 - use `--gdb` to start all instances inside gdb.
 - use `--df arg=val` to pass custom arguments to all dragonfly instances. Can be used multiple times.
 - use `--log-seeder file` to store all single-db commands from the lastest tests seeder inside file.
+- use `--existing-port` to use an existing instance for tests instead of starting one
+- use `--rand-seed` to set the global random seed. Makes the seeder predictable.
 
 for example,
 

--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -9,6 +9,7 @@ import pytest
 import pytest_asyncio
 import redis
 import aioredis
+import random
 
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -44,6 +45,14 @@ def test_env(tmp_dir: Path):
 
 @pytest.fixture(scope="session", params=[{}])
 def df_seeder_factory(request) -> DflySeederFactory:
+    seed = request.config.getoption("--rand-seed")
+    if seed is None:
+        seed = random.randrange(sys.maxsize)
+
+
+    random.seed(int(seed))
+    print(f"--- Random seed: {seed}, check: {random.randrange(100)} ---")
+
     return DflySeederFactory(request.config.getoption("--log-seeder"))
 
 
@@ -162,6 +171,8 @@ def pytest_addoption(parser):
         --gdb - start all instances inside gdb
         --df arg - pass arg to all instances, can be used multiple times
         --log-seeder file - to log commands of last seeder run
+        --existing-port - to provide a port to an existing process instead of starting a new instance
+        --rand-seed - to set the global random seed
     """
     parser.addoption(
         '--gdb', action='store_true', default=False, help='Run instances in gdb'
@@ -171,6 +182,9 @@ def pytest_addoption(parser):
     )
     parser.addoption(
         '--log-seeder', action='store', default=None, help='Store last generator commands in file'
+    )
+    parser.addoption(
+        '--rand-seed', action='store', default=None, help='Set seed for global random. Makes seeder predictable'
     )
     parser.addoption(
         '--existing-port', action='store', default=None, help='Provide a port to the existing process for the test')


### PR DESCRIPTION
- Allows setting the global random seed with a flag
- Adds output for pytests that print the global random seed before creating the seeder
- Makes it possible to repoduce command sequences