### PR TITLE
chore: change Dragonfly to use fb2 helio library.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
         run: |
-          cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -L
           cd ${{github.workspace}}/build && pwd
           du -hcs _deps/
       - name: Build & Test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ find_package(OpenSSL)
 include(third_party)
 include(internal)
 
+set(USE_FB2 ON CACHE BOOL "")
+
 include_directories(src)
 include_directories(helio)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,6 +67,8 @@ endif(ENABLE_GIT_VERSION)
 # the output file resides in the build directory.
 configure_file(server/version.cc.in "${CMAKE_CURRENT_SOURCE_DIR}/server/version.cc" @ONLY)
 
+add_definitions(-DUSE_FB2)
+
 add_subdirectory(redis)
 add_subdirectory(core)
 add_subdirectory(facade)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(dfly_core compact_object.cc dragonfly_core.cc extent_tree.cc
     string_set.cc string_map.cc detail/bitpacking.cc)
 
 cxx_link(dfly_core base absl::flat_hash_map absl::str_format redis_lib TRDP::lua lua_modules
-    Boost::fiber TRDP::jsoncons OpenSSL::Crypto)
+    fibers2 TRDP::jsoncons OpenSSL::Crypto)
 
 add_executable(dash_bench dash_bench.cc)
 cxx_link(dash_bench dfly_core)

--- a/src/facade/CMakeLists.txt
+++ b/src/facade/CMakeLists.txt
@@ -7,7 +7,7 @@ if (DF_USE_SSL)
   target_compile_definitions(dfly_facade PRIVATE DFLY_USE_SSL)
 endif()
 
-cxx_link(dfly_facade base uring_fiber_lib fibers_ext strings_lib http_server_lib
+cxx_link(dfly_facade base strings_lib http_server_lib fibers2
          ${TLS_LIB} TRDP::mimalloc TRDP::dconv)
 
 add_library(facade_test facade_test.cc)

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(dragonfly dfly_main.cc)
-cxx_link(dragonfly base dragonfly_lib epoll_fiber_lib)
+cxx_link(dragonfly base dragonfly_lib)
 
 if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" AND CMAKE_BUILD_TYPE STREQUAL "Release")
   # Add core2 only to this file, thus avoiding instructions in this object file that
@@ -12,7 +12,7 @@ add_library(dfly_transaction db_slice.cc malloc_stats.cc engine_shard_set.cc blo
             common.cc
             io_mgr.cc journal/journal.cc journal/journal_slice.cc server_state.cc table.cc
             tiered_storage.cc top_keys.cc transaction.cc)
-cxx_link(dfly_transaction uring_fiber_lib dfly_core strings_lib)
+cxx_link(dfly_transaction dfly_core strings_lib)
 
 add_library(dragonfly_lib channel_store.cc command_registry.cc
             config_flags.cc conn_context.cc debugcmd.cc dflycmd.cc
@@ -28,7 +28,7 @@ cxx_link(dragonfly_lib dfly_transaction dfly_facade redis_lib strings_lib html_l
          absl::random_random TRDP::jsoncons zstd TRDP::lz4)
 
 add_library(dfly_test_lib test_utils.cc)
-cxx_link(dfly_test_lib dragonfly_lib epoll_fiber_lib facade_test gtest_main_ext)
+cxx_link(dfly_test_lib dragonfly_lib facade_test gtest_main_ext)
 
 cxx_test(dragonfly_test dfly_test_lib LABELS DFLY)
 cxx_test(multi_test dfly_test_lib LABELS DFLY)

--- a/src/server/blocking_controller_test.cc
+++ b/src/server/blocking_controller_test.cc
@@ -11,7 +11,7 @@
 #include "server/engine_shard_set.h"
 #include "server/server_state.h"
 #include "server/transaction.h"
-#include "util/uring/uring_pool.h"
+#include "util/fibers/pool.h"
 
 namespace dfly {
 
@@ -37,7 +37,7 @@ class BlockingControllerTest : public Test {
 constexpr size_t kNumThreads = 3;
 
 void BlockingControllerTest::SetUp() {
-  pp_.reset(new uring::UringPool(16, kNumThreads));
+  pp_.reset(fb2::Pool::IOUring(16, kNumThreads));
   pp_->Run();
   pp_->Await([](unsigned index, ProactorBase* p) { ServerState::Init(index); });
 

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -30,9 +30,8 @@
 #include "server/version.h"
 #include "strings/human_readable.h"
 #include "util/accept_server.h"
-#include "util/epoll/epoll_pool.h"
+#include "util/fibers/pool.h"
 #include "util/http/http_client.h"
-#include "util/uring/uring_pool.h"
 #include "util/varz.h"
 
 #define STRING_PP_NX(A) #A
@@ -527,9 +526,9 @@ Usage: dragonfly [FLAGS]
 
   bool use_epoll = ShouldUseEpollAPI(kver);
   if (use_epoll) {
-    pool.reset(new epoll::EpollPool);
+    pool.reset(fb2::Pool::Epoll());
   } else {
-    pool.reset(new uring::UringPool(1024));  // 1024 - iouring queue size.
+    pool.reset(fb2::Pool::IOUring(1024));  // 1024 - iouring queue size.
   }
 
   pool->Run();

--- a/src/server/io_utils.h
+++ b/src/server/io_utils.h
@@ -3,6 +3,7 @@
 //
 
 #include "base/io_buf.h"
+#include "core/fibers.h"
 #include "io/io.h"
 #include "server/common.h"
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1453,7 +1453,7 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
   Metrics m = GetMetrics();
 
   if (should_enter("SERVER")) {
-    ProactorBase::ProactorKind kind = ProactorBase::me()->GetKind();
+    auto kind = ProactorBase::me()->GetKind();
     const char* multiplex_api = (kind == ProactorBase::IOURING) ? "iouring" : "epoll";
 
     ADD_HEADER("# Server");

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -16,8 +16,7 @@ extern "C" {
 #include "base/logging.h"
 #include "base/stl_util.h"
 #include "facade/dragonfly_connection.h"
-#include "util/epoll/epoll_pool.h"
-#include "util/uring/uring_pool.h"
+#include "util/fibers/pool.h"
 
 using namespace std;
 
@@ -138,9 +137,9 @@ void BaseFamilyTest::SetUpTestSuite() {
 
 void BaseFamilyTest::SetUp() {
   if (absl::GetFlag(FLAGS_force_epoll)) {
-    pp_.reset(new epoll::EpollPool(num_threads_));
+    pp_.reset(fb2::Pool::Epoll(num_threads_));
   } else {
-    pp_.reset(new uring::UringPool(16, num_threads_));
+    pp_.reset(fb2::Pool::IOUring(16, num_threads_));
   }
   pp_->Run();
   service_.reset(new Service{pp_.get()});


### PR DESCRIPTION
It's a bit more efficient than Boost.Fibers due to better integrations of Fibers with Proactor loop.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->