### PR TITLE
fix(server): Allow interrupting REPLICAOF commands during full sync

### DIFF
--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -22,7 +22,7 @@ enum CommandOpt : uint32_t {
   READONLY = 1U << 0,
   FAST = 1U << 1,
   WRITE = 1U << 2,
-  LOADING = 1U << 3,
+  LOADING = 1U << 3,  // Command allowed during LOADING state.
   DENYOOM = 1U << 4,  // use-memory in redis.
   REVERSE_MAPPING = 1U << 5,
 

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1442,7 +1442,7 @@ void GenericFamily::Register(CommandRegistry* registry) {
   constexpr auto kSelectOpts = CO::LOADING | CO::FAST | CO::NOSCRIPT;
 
   *registry << CI{"DEL", CO::WRITE, -2, 1, -1, 1}.HFUNC(Del)
-            /* Redis compaitibility:
+            /* Redis compatibility:
              * We don't allow PING during loading since in Redis PING is used as
              * failure detection, and a loading server is considered to be
              * not available. */

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -1032,7 +1032,7 @@ error_code RdbSaver::Impl::ConsumeChannel(const Cancellation* cll) {
     pushed_bytes += ptr->channel_bytes();
   }
 
-  DCHECK(!channel_.TryPop(*record));
+  DCHECK(!record.has_value() || !channel_.TryPop(*record));
 
   VLOG(1) << "Channel pulled bytes: " << channel_bytes << " pushed bytes: " << pushed_bytes;
 

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -156,7 +156,7 @@ bool Replica::Start(ConnectionContext* cntx) {
   CHECK(mythread);
 
   auto should_continue = [this, &cntx](const error_code& ec, const char* msg) {
-    if (state_mask_ & R_CANCELLED) {
+    if (cntx_.IsCancelled()) {
       (*cntx)->SendError("replication cancelled");
       return false;
     }
@@ -205,8 +205,8 @@ void Replica::Stop() {
   // Mark disabled, prevent from retrying.
   if (sock_) {
     sock_->proactor()->Await([this] {
-      state_mask_ = R_CANCELLED;  // Specifically ~R_ENABLED.
-      cntx_.Cancel();             // Context is fully resposible for cleanup.
+      state_mask_ = 0;  // Specifically ~R_ENABLED.
+      cntx_.Cancel();   // Context is fully resposible for cleanup.
     });
   }
 

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -49,6 +49,7 @@ class Replica {
     R_GREETED = 4,
     R_SYNCING = 8,
     R_SYNC_OK = 0x10,
+    R_CANCELLED = 0x20,
   };
 
   // This class holds the commands of transaction in single shard.

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -221,6 +221,7 @@ class Replica {
   Service& service_;
   MasterContext master_context_;
   std::unique_ptr<util::LinuxSocketBase> sock_;
+  Mutex sock_mu_;
 
   std::shared_ptr<MultiShardExecution> multi_shard_exe_;
 
@@ -253,7 +254,7 @@ class Replica {
   // ack_offs_ last acknowledged offset.
   size_t repl_offs_ = 0, ack_offs_ = 0;
   uint64_t last_io_time_ = 0;  // in ns, monotonic clock.
-  unsigned state_mask_ = 0;
+  std::atomic<unsigned> state_mask_ = 0;
   unsigned num_df_flows_ = 0;
 
   bool is_paused_ = false;

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -103,7 +103,7 @@ class Replica {
   // Spawns a fiber that runs until link with master is broken or the replication is stopped.
   // Returns true if initial link with master has been established or
   // false if it has failed.
-  bool Start(ConnectionContext* cntx);
+  std::error_code Start(ConnectionContext* cntx);
 
   void Stop();  // thread-safe
 

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -49,7 +49,6 @@ class Replica {
     R_GREETED = 4,
     R_SYNCING = 8,
     R_SYNC_OK = 0x10,
-    R_CANCELLED = 0x20,
   };
 
   // This class holds the commands of transaction in single shard.

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -78,9 +78,11 @@ void SliceSnapshot::Cancel() {
   VLOG(1) << "SliceSnapshot::Cancel";
 
   CloseRecordChannel();
-  // Set journal_cb_id_ to 0 and unregister callback, but only once.
-  uint32_t cb_id = journal_cb_id_.load();
-  if (cb_id && journal_cb_id_.compare_exchange_strong(cb_id, 0)) {
+  // Cancel() might be called multiple times from different fibers of the same thread, but we
+  // should unregister the callback only once.
+  uint32_t cb_id = journal_cb_id_;
+  if (cb_id) {
+    journal_cb_id_ = 0;
     db_slice_->shard_owner()->journal()->UnregisterOnChange(cb_id);
   }
 }

--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -136,7 +136,7 @@ class SliceSnapshot {
 
   // version upper bound for entries that should be saved (not included).
   uint64_t snapshot_version_ = 0;
-  uint32_t journal_cb_id_ = 0;
+  atomic_uint32_t journal_cb_id_ = 0;
   uint64_t rec_id_ = 0;
 
   struct Stats {

--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -136,7 +136,7 @@ class SliceSnapshot {
 
   // version upper bound for entries that should be saved (not included).
   uint64_t snapshot_version_ = 0;
-  atomic_uint32_t journal_cb_id_ = 0;
+  uint32_t journal_cb_id_ = 0;
   uint64_t rec_id_ = 0;
 
   struct Stats {

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -386,6 +386,42 @@ async def test_rotating_masters(df_local_factory, df_seeder_factory, t_replica, 
         fill_task.cancel()
 
 
+@pytest.mark.asyncio
+async def test_cancel_replication_immediately(df_local_factory, df_seeder_factory):
+    replica = df_local_factory.create(port=BASE_PORT, v=1)
+    masters = [df_local_factory.create(port=BASE_PORT+i+1) for i in range(4)]
+    seeders = [df_seeder_factory.create(port=m.port) for m in masters]
+
+    df_local_factory.start_all([replica] + masters)
+    c_replica = aioredis.Redis(port=replica.port)
+    await asyncio.gather(*(seeder.run(target_deviation=0.1) for seeder in seeders))
+
+    replication_commands = []
+    # Issue 40 replication commands randomally distributed over 10 seconds. This
+    # checks that the replication state machine can handle cancellation well.
+    # After we finish the 'fuzzing' part, replicate the first master and check that
+    # all the data is correct.
+    async def replicate(index):
+        await asyncio.sleep(10.0 * random.random())
+        try:
+            start = time.time()
+            await c_replica.execute_command(f"REPLICAOF localhost {masters[index].port}")
+            # Giving replication commands shouldn't hang.
+            assert time.time() - start < 2.0
+        except aioredis.exceptions.ResponseError as e:
+            print(e)
+
+    for i in range(40):
+        index = random.choice(range(len(masters)))
+        replication_commands.append(replicate(index))
+    await asyncio.gather(*replication_commands)
+
+    await c_replica.execute_command(f"REPLICAOF localhost {masters[0].port}")
+
+    capture = await seeders[0].capture()
+    assert await seeders[0].compare(capture, replica.port)
+
+
 """
 Test flushall command. Set data to master send flashall and set more data.
 Check replica keys at the end.

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -388,6 +388,12 @@ async def test_rotating_masters(df_local_factory, df_seeder_factory, t_replica, 
 
 @pytest.mark.asyncio
 async def test_cancel_replication_immediately(df_local_factory, df_seeder_factory):
+    """
+    Issue 40 replication commands randomally distributed over 10 seconds. This
+    checks that the replication state machine can handle cancellation well.
+    After we finish the 'fuzzing' part, replicate the first master and check that
+    all the data is correct.
+    """
     replica = df_local_factory.create(port=BASE_PORT, v=1)
     masters = [df_local_factory.create(port=BASE_PORT+i+1) for i in range(4)]
     seeders = [df_seeder_factory.create(port=m.port) for m in masters]
@@ -397,10 +403,6 @@ async def test_cancel_replication_immediately(df_local_factory, df_seeder_factor
     await asyncio.gather(*(seeder.run(target_deviation=0.1) for seeder in seeders))
 
     replication_commands = []
-    # Issue 40 replication commands randomally distributed over 10 seconds. This
-    # checks that the replication state machine can handle cancellation well.
-    # After we finish the 'fuzzing' part, replicate the first master and check that
-    # all the data is correct.
     async def replicate(index):
         await asyncio.sleep(10.0 * random.random())
         try:

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -396,6 +396,8 @@ async def test_cancel_replication_immediately(df_local_factory, df_seeder_factor
     After we finish the 'fuzzing' part, replicate the first master and check that
     all the data is correct.
     """
+    COMMANDS_TO_ISSUE = 40
+
     replica = df_local_factory.create(port=BASE_PORT, v=1)
     masters = [df_local_factory.create(port=BASE_PORT+i+1) for i in range(4)]
     seeders = [df_seeder_factory.create(port=m.port) for m in masters]
@@ -417,12 +419,12 @@ async def test_cancel_replication_immediately(df_local_factory, df_seeder_factor
             assert e.args[0] == "replication cancelled"
             return False
 
-    for i in range(40):
+    for i in range(COMMANDS_TO_ISSUE):
         index = random.choice(range(len(masters)))
         replication_commands.append(replicate(index))
     results = await asyncio.gather(*replication_commands)
     num_successes = sum(results)
-    assert 40 > num_successes, "At least one REPLICAOF must be cancelled"
+    assert COMMANDS_TO_ISSUE > num_successes, "At least one REPLICAOF must be cancelled"
     assert num_successes > 0, "At least one REPLICAOF must be succeed"
 
 


### PR DESCRIPTION
Fix #1017

There's still a stage that's not interruptible: When forming the initial connection to the master.
Also fixed 2 crashes (one of them in a DCHECK) in the replication cancelling flow.

I did some stress testing locally, so I'm relatively sure it works. Still a bit unsure about how to test this...
