### PR TITLE
chore: disable self-hosted runner

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -15,7 +15,8 @@ jobs:
         # Test of these containers
         container: ["ubuntu-dev:20"]
         build-type: [Debug, Release]
-        runner: [ubuntu-latest, [self-hosted, linux, ARM64]]
+        # TODO: To bring back [self-hosted, linux, ARM64] once we stabilize the tests.
+        runner: [ubuntu-latest]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
 


### PR DESCRIPTION
There are weird errors coming from regression tests.
I would like to remove temporary the self-hosted runner to reduce the noise until we find the root cause.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->