### PR TITLE
fix(server): Fix resp3 for pubsub commands

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -290,17 +290,19 @@ void Connection::DispatchOperations::operator()(const PubMsgRecord& msg) {
       arr[0] = "message";
       arr[1] = *pub_msg.channel;
       arr[2] = *pub_msg.message;
-      rbuilder->SendStringArr(absl::Span<string_view>{arr, 3});
+      rbuilder->SendStringArr(absl::Span<string_view>{arr, 3},
+                              RedisReplyBuilder::CollectionType::PUSH);
     } else {
       arr[0] = "pmessage";
       arr[1] = pub_msg.pattern;
       arr[2] = *pub_msg.channel;
       arr[3] = *pub_msg.message;
-      rbuilder->SendStringArr(absl::Span<string_view>{arr, 4});
+      rbuilder->SendStringArr(absl::Span<string_view>{arr, 4},
+                              RedisReplyBuilder::CollectionType::PUSH);
     }
   } else {
     const char* action[2] = {"unsubscribe", "subscribe"};
-    rbuilder->StartArray(3);
+    rbuilder->StartCollection(3, RedisReplyBuilder::CollectionType::PUSH);
     rbuilder->SendBulkString(action[pub_msg.type == PubMessage::kSubscribe]);
     rbuilder->SendBulkString(*pub_msg.channel);
     rbuilder->SendLong(pub_msg.channel_cnt);

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -371,7 +371,7 @@ void RedisReplyBuilder::StartArray(unsigned len) {
   StartCollection(len, ARRAY);
 }
 
-constexpr static string_view START_SYMBOLS[] = {"*", "~", "%"};
+constexpr static string_view START_SYMBOLS[] = {"*", "~", "%", ">"};
 static_assert(START_SYMBOLS[RedisReplyBuilder::MAP] == "%" &&
               START_SYMBOLS[RedisReplyBuilder::SET] == "~");
 

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -118,7 +118,7 @@ class MCReplyBuilder : public SinkReplyBuilder {
 
 class RedisReplyBuilder : public SinkReplyBuilder {
  public:
-  enum CollectionType { ARRAY, SET, MAP };
+  enum CollectionType { ARRAY, SET, MAP, PUSH };
 
   using StrSpan = std::variant<absl::Span<const std::string>, absl::Span<const std::string_view>>;
 

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -162,7 +162,7 @@ void ConnectionContext::PUnsubscribeAll(bool to_reply) {
 void ConnectionContext::SendSubscriptionChangedResponse(string_view action,
                                                         std::optional<string_view> topic,
                                                         unsigned count) {
-  (*this)->StartArray(3);
+  (*this)->StartCollection(3, RedisReplyBuilder::CollectionType::PUSH);
   (*this)->SendBulkString(action);
   if (topic.has_value())
     (*this)->SendBulkString(topic.value());


### PR DESCRIPTION
Add a PUSH ('>') Collection type and use it for pubsub commands.

Tested with netcat comparing to redis raw output for subscribe and publish.

Fixes #1052 

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->