### PR TITLE
feat: enable multi-tx squashing.

### DIFF
--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -101,11 +101,14 @@ void EngineShard::DefragTaskState::UpdateScanState(uint64_t cursor_val) {
 // (control by mem_defrag_waste_threshold flag)
 bool EngineShard::DefragTaskState::CheckRequired() {
   if (cursor > kCursorDoneState || underutilized_found) {
-    VLOG(1) << "Already found memory utilization issue - cursor: " << cursor
-            << " and underutilized_found " << underutilized_found;
+    VLOG(1) << "cursor: " << cursor << " and underutilized_found " << underutilized_found;
     return true;
   }
+
   const std::size_t memory_per_shard = max_memory_limit / shard_set->size();
+  if (memory_per_shard < (1 << 16)) {  // Too small.
+    return false;
+  }
 
   const std::size_t threshold_mem = memory_per_shard * GetFlag(FLAGS_mem_defrag_threshold);
   const double waste_threshold = GetFlag(FLAGS_mem_defrag_waste_threshold);

--- a/src/server/list_family_test.cc
+++ b/src/server/list_family_test.cc
@@ -240,9 +240,6 @@ TEST_F(ListFamilyTest, BLPopMultiPush) {
 }
 
 TEST_F(ListFamilyTest, BLPopSerialize) {
-  // TODO: Fix squashed blocking handling
-  GTEST_SKIP() << "Skipped because squashing breaks seralization guarantees";
-
   RespExpr blpop_resp;
 
   auto pop_fb = pp_->at(0)->LaunchFiber(Launch::dispatch, [&] {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -49,7 +49,7 @@ ABSL_FLAG(uint32_t, multi_exec_mode, 1,
           "Set multi exec atomicity mode: 1 for global, 2 for locking ahead, 3 for locking "
           "incrementally, 4 for non atomic");
 
-ABSL_FLAG(bool, multi_exec_squash, false,
+ABSL_FLAG(bool, multi_exec_squash, true,
           "Whether multi exec will squash single shard commands to optimize performance");
 
 ABSL_FLAG(uint32_t, num_shards, 0, "Number of database shards, 0 - to choose automatically");

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -181,6 +181,9 @@ void MultiCommandSquasher::Run() {
 
   ExecuteSquashed();  // Flush leftover
 
+  // Set last txid.
+  cntx_->last_command_debug.clock = cntx_->transaction->txid();
+
   if (!sharded_.empty())
     cntx_->transaction->ReportWritesSquashedMulti(
         [this](ShardId sid) { return sharded_[sid].had_writes; });


### PR DESCRIPTION
Make blpop test pass with squashing. The problem was that the txid was not properly reported back to the testing code.

Also, fixed redundant codepath for defragmentation.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->