### PR TITLE
fix: bugs in rdb code

### DIFF
--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -85,8 +85,17 @@ class RdbLoaderBase {
   };
 
   struct LoadTrace {
-    std::vector<LoadBlob> arr;
+    // Some traces are very long. We divide them into multiple segments.
+    std::vector<std::vector<LoadBlob>> arr;
     std::unique_ptr<StreamTrace> stream_trace;
+
+    size_t blob_count() const {
+      size_t count = 0;
+      for (const auto& seg : arr) {
+        count += seg.size();
+      }
+      return count;
+    }
   };
 
   class OpaqueObjLoader;
@@ -136,7 +145,6 @@ class RdbLoaderBase {
 
   std::error_code EnsureReadInternal(size_t min_sz);
 
- protected:
   base::IoBuf* mem_buf_ = nullptr;
   base::IoBuf origin_mem_buf_;
   ::io::Source* src_ = nullptr;


### PR DESCRIPTION
1. Pull newest helio that fixes 32-bit overflow in IoBuf.
2. Allow responsiveness when loading huge sets and maps.
3. Break array of blobs into segments of limited size so that  we won't allocate billion-byte arrays when handling large (h)sets.
   It reduces pressure on the allocator when loading millions of items.

Fixes #1076.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->