### PR TITLE
fix(tests): Don't return the same port from PortPicker.get_available_port twice

### DIFF
--- a/tests/dragonfly/__init__.py
+++ b/tests/dragonfly/__init__.py
@@ -150,7 +150,8 @@ class PortPicker():
     def get_available_port(self):
         while not self.is_port_available(self.next_port):
             self.next_port += 1
-        return self.next_port
+        self.next_port += 1
+        return self.next_port - 1
 
     def is_port_available(self, port):
         import socket


### PR DESCRIPTION
The regression tests failed because we tried to start 3 instances with the same port. Fix by making PortPicker never return the same port twice.