### PR TITLE
fix: Remove incremental locking

### DIFF
--- a/docs/transaction.md
+++ b/docs/transaction.md
@@ -120,7 +120,7 @@ Redis transactions (MULTI/EXEC sequences) and commands produced by Lua scripts a
 
 The multi feature of the transactional framework allows running consecutive commands without rescheduling the transaction for each command as if they are part of one single transaction. This feature is transparent to the commands itself, so no changes are required for them to be used in a multi-transaction.
 
-There are four modes called "multi modes" in which a multi transaction can be executed, each with its own benefits and drawbacks.
+There are three modes called "multi modes" in which a multi transaction can be executed, each with its own benefits and drawbacks.
 
 __1. Global mode__
 
@@ -130,11 +130,7 @@ __2. Lock ahead mode__
 
 The transaction is equivalent to a regular transaction with multiple hops. It is scheduled on all keys used by the commands in the transaction block, or Lua script, and the commands are executed as a series of consecutive hops.
 
-__3. Incremental lock mode__
-
-The transaction schedules itself on all the shards that are accessed by the Redis transaction or Lua script, but does not lock any keys ahead. Only when it executes and occupies all the predetermined shards, it starts locking the keys it accesses. This mode _can_ be useful for delaying the acquisition of locks for contended keys and thus allowing other transactions to run in parallel for a longer period of time, however this mode disabled a wide range of optimizations for the multi-transaction itself, such as running out of order.
-
-__4. Non atomic mode__
+__3. Non atomic mode__
 
 All commands are executed as separate transactions making the multi-transaction not atomic. It vastly improves the throughput with contended keys, as locks are acquired only for single commands. This mode is useful for Lua scripts without atomicity requirements.
 

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -27,7 +27,7 @@ template <typename F> void IterateKeys(CmdArgList args, KeyIndex keys, F&& f) {
 MultiCommandSquasher::MultiCommandSquasher(absl::Span<StoredCmd> cmds, ConnectionContext* cntx)
     : cmds_{cmds}, cntx_{cntx}, base_cid_{cntx->transaction->GetCId()} {
   auto mode = cntx->transaction->GetMultiMode();
-  track_keys_ = (mode == Transaction::LOCK_INCREMENTAL) || (mode == Transaction::NON_ATOMIC);
+  track_keys_ = mode == Transaction::NON_ATOMIC;
 }
 
 MultiCommandSquasher::ShardExecInfo& MultiCommandSquasher::PrepareShardInfo(ShardId sid) {

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -130,16 +130,11 @@ void Transaction::InitShardData(absl::Span<const PerShardCache> shard_index, siz
     sd.arg_count = si.args.size();
     sd.arg_start = args_.size();
 
-    if (multi_) {
-      // Multi transactions can re-intitialize on different shards, so clear ACTIVE flag.
+    // Multi transactions can re-intitialize on different shards, so clear ACTIVE flag.
+    if (multi_)
       sd.local_mask &= ~ACTIVE;
 
-      // If we increase locks, clear KEYLOCK_ACQUIRED to track new locks.
-      if (multi_->IsIncrLocks())
-        sd.local_mask &= ~KEYLOCK_ACQUIRED;
-    }
-
-    if (sd.arg_count == 0 && !si.requested_active)
+    if (sd.arg_count == 0)
       continue;
 
     sd.local_mask |= ACTIVE;
@@ -163,9 +158,7 @@ void Transaction::InitMultiData(KeyIndex key_index) {
   if (multi_->mode == NON_ATOMIC)
     return;
 
-  // TODO: determine correct locking mode for transactions, scripts and regular commands.
   IntentLock::Mode mode = Mode();
-  multi_->keys.clear();
 
   auto& tmp_uniques = tmp_space.uniq_keys;
   tmp_uniques.clear();
@@ -174,16 +167,12 @@ void Transaction::InitMultiData(KeyIndex key_index) {
     if (auto [_, inserted] = tmp_uniques.insert(key); !inserted)
       return;
 
-    if (multi_->IsIncrLocks()) {
-      multi_->keys.emplace_back(key);
-    } else {
-      multi_->lock_counts[key][mode]++;
-    }
+    multi_->lock_counts[key][mode]++;
   };
 
   // With EVAL, we call this function for EVAL itself as well as for each command
   // for eval. currently, we lock everything only during the eval call.
-  if (multi_->IsIncrLocks() || !multi_->locks_recorded) {
+  if (!multi_->locks_recorded) {
     for (size_t i = key_index.start; i < key_index.end; i += key_index.step)
       lock_key(ArgS(full_args_, i));
     if (key_index.bonus)
@@ -192,7 +181,7 @@ void Transaction::InitMultiData(KeyIndex key_index) {
 
   multi_->locks_recorded = true;
   DCHECK(IsAtomicMulti());
-  DCHECK(multi_->mode == GLOBAL || !multi_->keys.empty() || !multi_->lock_counts.empty());
+  DCHECK(multi_->mode == GLOBAL || !multi_->lock_counts.empty());
 }
 
 void Transaction::StoreKeysInArgs(KeyIndex key_index, bool rev_mapping) {
@@ -384,24 +373,6 @@ void Transaction::StartMultiLockedAhead(DbIndex dbid, CmdArgList keys) {
   ScheduleInternal();
 }
 
-void Transaction::StartMultiLockedIncr(DbIndex dbid, const vector<bool>& shards) {
-  DCHECK(multi_);
-  DCHECK(shard_data_.empty());  // Make sure default InitByArgs didn't run.
-  DCHECK(std::any_of(shards.begin(), shards.end(), [](bool s) { return s; }));
-
-  multi_->mode = LOCK_INCREMENTAL;
-  InitBase(dbid, {});
-
-  auto& shard_index = tmp_space.GetShardIndex(shard_set->size());
-  for (size_t i = 0; i < shards.size(); i++)
-    shard_index[i].requested_active = shards[i];
-
-  shard_data_.resize(shard_index.size());
-  InitShardData(shard_index, 0, false);
-
-  ScheduleInternal();
-}
-
 void Transaction::StartMultiNonAtomic() {
   DCHECK(multi_);
   multi_->mode = NON_ATOMIC;
@@ -461,7 +432,6 @@ bool Transaction::RunInShard(EngineShard* shard) {
 
   bool was_suspended = sd.local_mask & SUSPENDED_Q;
   bool awaked_prerun = sd.local_mask & AWAKED_Q;
-  bool incremental_lock = multi_ && multi_->IsIncrLocks();
 
   // For multi we unlock transaction (i.e. its keys) in UnlockMulti() call.
   // Therefore we differentiate between concluding, which says that this specific
@@ -471,15 +441,6 @@ bool Transaction::RunInShard(EngineShard* shard) {
   bool is_concluding = (coordinator_state_ & COORD_EXEC_CONCLUDING);
   bool should_release = is_concluding && !IsAtomicMulti();
   IntentLock::Mode mode = Mode();
-
-  // We make sure that we lock exactly once for each (multi-hop) transaction inside
-  // transactions that lock incrementally.
-  if (!IsGlobal() && incremental_lock && ((sd.local_mask & KEYLOCK_ACQUIRED) == 0)) {
-    DCHECK(!awaked_prerun);  // we should not have a blocking transaction inside multi block.
-
-    sd.local_mask |= KEYLOCK_ACQUIRED;
-    shard->db_slice().Acquire(mode, GetLockArgs(idx));
-  }
 
   DCHECK(IsGlobal() || (sd.local_mask & KEYLOCK_ACQUIRED) || (multi_ && multi_->mode == GLOBAL));
 
@@ -620,7 +581,6 @@ void Transaction::ScheduleInternal() {
       coordinator_state_ |= COORD_SCHED;
       // If we granted all locks, we can run out of order.
       if (!ooo_disabled && lock_granted_cnt.load(memory_order_relaxed) == num_shards) {
-        // Currently we don't support OOO for incremental locking. Sp far they are global.
         coordinator_state_ |= COORD_OOO;
       }
       VLOG(2) << "Scheduled " << DebugId()
@@ -665,18 +625,6 @@ void Transaction::ScheduleInternal() {
       sd.local_mask |= OUT_OF_ORDER;
     }
   }
-}
-
-void Transaction::MultiData::AddLocks(IntentLock::Mode mode) {
-  DCHECK(IsIncrLocks());
-  for (auto& key : keys) {
-    lock_counts[std::move(key)][mode]++;
-  }
-  keys.clear();
-}
-
-bool Transaction::MultiData::IsIncrLocks() const {
-  return mode == LOCK_INCREMENTAL;
 }
 
 // Optimized "Schedule and execute" function for the most common use-case of a single hop
@@ -733,9 +681,6 @@ OpStatus Transaction::ScheduleSingleHop(RunnableType cb) {
 
     if (!IsAtomicMulti())  // Multi schedule in advance.
       ScheduleInternal();
-
-    if (multi_ && multi_->IsIncrLocks())
-      multi_->AddLocks(Mode());
 
     ExecuteAsync();
   }
@@ -807,9 +752,6 @@ uint32_t Transaction::CalcMultiNumOfShardJournals() const {
 void Transaction::Schedule() {
   if (multi_ && multi_->role == SQUASHED_STUB)
     return;
-
-  if (multi_ && multi_->IsIncrLocks())
-    multi_->AddLocks(Mode());
 
   if (!IsAtomicMulti())
     ScheduleInternal();
@@ -1101,7 +1043,7 @@ bool Transaction::CancelShardCb(EngineShard* shard) {
   if (sd.local_mask & KEYLOCK_ACQUIRED) {
     auto mode = Mode();
     auto lock_args = GetLockArgs(shard->shard_id());
-    DCHECK(lock_args.args.size() > 0 || (multi_ && multi_->mode == LOCK_INCREMENTAL));
+    DCHECK(lock_args.args.size() > 0);
     shard->db_slice().Release(mode, lock_args);
     sd.local_mask &= ~KEYLOCK_ACQUIRED;
   }
@@ -1115,7 +1057,7 @@ bool Transaction::CancelShardCb(EngineShard* shard) {
 
 // runs in engine-shard thread.
 ArgSlice Transaction::GetShardArgs(ShardId sid) const {
-  DCHECK(!args_.empty() || (multi_ && multi_->IsIncrLocks()));
+  DCHECK(!args_.empty());
 
   // We can read unique_shard_cnt_  only because ShardArgsInShard is called after IsArmedInShard
   // barrier.


### PR DESCRIPTION
Removes incremental locking, all its usages and mentions. Incremental locking is incompatible with out-of-order execution of multi hop transactions, which is a more important optimization.