### PR TITLE
feat: add oom insertion rejections

### DIFF
--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -50,6 +50,9 @@ struct SliceEvents {
   size_t hits = 0;
   size_t misses = 0;
 
+  // how many insertions were rejected due to OOM.
+  size_t insertion_rejections = 0;
+
   SliceEvents& operator+=(const SliceEvents& o);
 };
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1546,6 +1546,7 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
     append("garbage_collected", m.events.garbage_collected);
     append("bump_ups", m.events.bumpups);
     append("stash_unloaded", m.events.stash_unloaded);
+    append("oom_rejections", m.events.insertion_rejections);
     append("traverse_ttl_sec", m.traverse_ttl_per_sec);
     append("delete_ttl_sec", m.delete_ttl_per_sec);
     append("keyspace_hits", m.events.hits);


### PR DESCRIPTION
Add statistics about how many times DF rejection to proceed with insertion of an entry due to possible OOM situation.

 
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->