### PR TITLE
fix: systemd configuration

### DIFF
--- a/tools/packaging/debian/dragonfly.conf
+++ b/tools/packaging/debian/dragonfly.conf
@@ -1,4 +1,4 @@
 --pidfile=/var/run/dragonfly/dragonfly.pid
 --log_dir=/var/log/dragonfly
---dir=/var/run/dragonfly
+--dir=/var/lib/dragonfly
 --version_check=true

--- a/tools/packaging/debian/dragonfly.service
+++ b/tools/packaging/debian/dragonfly.service
@@ -5,9 +5,10 @@ Documentation=
 
 [Service]
 Type=simple
+EnvironmentFile=-/etc/dragonfly/environment
 ExecStart=/usr/bin/dragonfly --flagfile=/etc/dragonfly/dragonfly.conf
 PIDFile=/var/run/dragonfly/dragonfly.pid
-TimeoutStopSec=0
+TimeoutStopSec=infinity
 Restart=always
 User=dfly
 Group=dfly
@@ -16,10 +17,11 @@ RuntimeDirectoryMode=2755
 
 UMask=007
 PrivateTmp=yes
-LimitNOFILE=65535
+LimitNOFILE=262144
 PrivateDevices=yes
 ProtectHome=yes
-ReadOnlyDirectories=/
+ProtectSystem=full
+
 ReadWritePaths=-/var/lib/dragonfly
 ReadWritePaths=-/var/log/dragonfly
 ReadWritePaths=-/var/run/dragonfly
@@ -34,8 +36,7 @@ RestrictRealtime=true
 RestrictNamespaces=true
 RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
 
-ProtectSystem=true
-ReadWriteDirectories=-/etc/dragonfly
+
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
1. Tune some security directives.
2. Fix the flags file that mistakenly configured dragonfly to store its dump files into /run (tmpfs).

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->