### PR TITLE
fix(helm): Allow prometheus rules fields to be empty

### DIFF
--- a/contrib/charts/dragonfly/templates/prometheusrule.yaml
+++ b/contrib/charts/dragonfly/templates/prometheusrule.yaml
@@ -10,5 +10,5 @@ spec:
   groups:
   - name: {{ template "dragonfly.name" . }}
     rules:
-    {{- toYaml .Values.prometheusRule.spec | nindent 4 }}
+      {{- toYaml .Values.prometheusRule.spec | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
Fixes https://github.com/dragonflydb/dragonfly/issues/1015

This commit fixes a rendering error where when the rules are
empty, the helm chart fails to render. By using the correct
indentation, the chart will render correctly.
