### PR TITLE
Dispatch queue memory optimizations

### DIFF
--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -127,7 +127,7 @@ void ConnectionContext::ChangeSubscription(bool to_add, bool to_reply, CmdArgLis
 
   if (to_reply) {
     for (size_t i = 0; i < result.size(); ++i) {
-      owner()->SendPubMessageAsync({to_add, make_shared<string>(ArgS(args, i)), result[i]});
+      owner()->SendPubMessageAsync({to_add, ArgS(args, i), result[i]});
     }
   }
 }

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -403,9 +403,9 @@ TEST_F(DflyEngineTest, PSubscribe) {
 
   ASSERT_EQ(1, SubscriberMessagesLen("IO1"));
 
-  const facade::Connection::PubMessage& msg = GetPublishedMessage("IO1", 0);
-  EXPECT_EQ("foo", *msg.message);
-  EXPECT_EQ("ab", *msg.channel);
+  const auto& msg = GetPublishedMessage("IO1", 0);
+  EXPECT_EQ("foo", msg.Message());
+  EXPECT_EQ("ab", msg.Channel());
   EXPECT_EQ("a*", msg.pattern);
 }
 

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -62,15 +62,15 @@ TestConnection::TestConnection(Protocol protocol, io::StringSink* sink)
 }
 
 void TestConnection::SendPubMessageAsync(PubMessage pmsg) {
-  if (pmsg.type == PubMessage::kPublish) {
-    messages.push_back(move(pmsg));
-  } else {
+  if (auto* ptr = std::get_if<PubMessage::MessageData>(&pmsg.data); ptr != nullptr) {
+    messages.push_back(move(*ptr));
+  } else if (auto* ptr = std::get_if<PubMessage::SubscribeData>(&pmsg.data); ptr != nullptr) {
     RedisReplyBuilder builder(sink_);
     const char* action[2] = {"unsubscribe", "subscribe"};
     builder.StartArray(3);
-    builder.SendBulkString(action[pmsg.type == PubMessage::kSubscribe]);
-    builder.SendBulkString(*pmsg.channel);
-    builder.SendLong(pmsg.channel_cnt);
+    builder.SendBulkString(action[ptr->add]);
+    builder.SendBulkString(ptr->channel);
+    builder.SendLong(ptr->channel_cnt);
   }
 }
 
@@ -84,7 +84,7 @@ class BaseFamilyTest::TestConnWrapper {
   RespVec ParseResponse(bool fully_consumed);
 
   // returns: type(pmessage), pattern, channel, message.
-  const facade::Connection::PubMessage& GetPubMessage(size_t index) const;
+  const facade::Connection::PubMessage::MessageData& GetPubMessage(size_t index) const;
 
   ConnectionContext* cmd_cntx() {
     return &cmd_cntx_;
@@ -360,7 +360,7 @@ RespVec BaseFamilyTest::TestConnWrapper::ParseResponse(bool fully_consumed) {
   return res;
 }
 
-const facade::Connection::PubMessage& BaseFamilyTest::TestConnWrapper::GetPubMessage(
+const facade::Connection::PubMessage::MessageData& BaseFamilyTest::TestConnWrapper::GetPubMessage(
     size_t index) const {
   CHECK_LT(index, dummy_conn_->messages.size());
   return dummy_conn_->messages[index];
@@ -391,8 +391,8 @@ size_t BaseFamilyTest::SubscriberMessagesLen(string_view conn_id) const {
   return it->second->conn()->messages.size();
 }
 
-const facade::Connection::PubMessage& BaseFamilyTest::GetPublishedMessage(string_view conn_id,
-                                                                          size_t index) const {
+const facade::Connection::PubMessage::MessageData& BaseFamilyTest::GetPublishedMessage(
+    string_view conn_id, size_t index) const {
   auto it = connections_.find(conn_id);
   CHECK(it != connections_.end());
 

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -23,7 +23,7 @@ class TestConnection : public facade::Connection {
 
   void SendPubMessageAsync(PubMessage pmsg) final;
 
-  std::vector<PubMessage> messages;
+  std::vector<PubMessage::MessageData> messages;
 
  private:
   io::StringSink* sink_;
@@ -87,8 +87,8 @@ class BaseFamilyTest : public ::testing::Test {
   std::string GetId() const;
   size_t SubscriberMessagesLen(std::string_view conn_id) const;
 
-  const facade::Connection::PubMessage& GetPublishedMessage(std::string_view conn_id,
-                                                            size_t index) const;
+  const facade::Connection::PubMessage::MessageData& GetPublishedMessage(std::string_view conn_id,
+                                                                         size_t index) const;
 
   std::unique_ptr<util::ProactorPool> pp_;
   std::unique_ptr<Service> service_;


### PR DESCRIPTION
Important memory optimizations for pubsub:

* We previously had a `class Connection::Request` which contained a `variant<PipelineMessage, PubMessage, MonitorMessage>`. The issue - `PipelineMessage` stores lots of stuff inline and its size is 200+ bytes - so the size of `Request` is by itself 200+ bytes.
* `PubMessage` contained two `shared_ptr<string>` for channel and name, and one optional `string` for the pattern and also some other fields for another mode - stack size ~64 bytes. 
* `PubMessage` heap overhead: two strings and two shared_ptr control blocks (24+24+24?+24?) = 96 bytes.

**So in the end a simple `publish foo bar` costs us 300+ bytes** and multiple allocations 💀 Redis writes directly to client buffers and it takes up around ~10 bytes there. A x30 difference. This means, that if you run heavy publish traffic in parallel your memory usage just skyrockets...

What I've done: 
* I moved the variant one level up, so we don't allocate 200 base bytes for a simple pubsub message. 
* Inside `PubMessage`, I replaced two `shared_ptr<string>` with one `shared_ptr<char[]>` and size fields

~~_What I'm still not sure about:_~~
~~* I removed pointers for `PubMessage` and `MonitorMessage` completely, they're placed by value into the dispatch queue~~
~~* Now the entry size of dispatch queue is 72 (64 from PubMessage + 8 variant /align )... which is a lot and adds 64 bytes overhead to pipeline messages~~

-> I've left it as a pointer

