### PR TITLE
chore: Allow passing empty strings as flag arguments in DflyInstance

### DIFF
--- a/tests/dragonfly/__init__.py
+++ b/tests/dragonfly/__init__.py
@@ -88,7 +88,9 @@ class DflyInstance:
     def format_args(args):
         out = []
         for (k, v) in args.items():
-            out.extend((str(s) for s in ("--"+k, v) if s != ""))
+            out.append(f"--{k}")
+            if v is not None:
+                out.append(str(v))
         return out
 
 

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -47,7 +47,7 @@ class TestRdbSnapshot(SnapshotTestBase):
         assert await seeder.compare(start_capture)
 
 
-@dfly_args({**BASIC_ARGS, "dbfilename": "test-rdbexact.rdb", "nodf_snapshot_format": ""})
+@dfly_args({**BASIC_ARGS, "dbfilename": "test-rdbexact.rdb", "nodf_snapshot_format": None})
 class TestRdbSnapshotExactFilename(SnapshotTestBase):
     """Test single file rdb snapshot without a timestamp"""
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
For example, this will be needed to disable auto save on shutdown with --dbfilename=""

Before:
```
df_factory.create(param="")  # -> ./dragonfly --param
df_factory.create(param=None)  # -> ./dragonfly --param "None"
```

After:
```
df_factory.create(param="")  # -> ./dragonfly --param ""
df_factory.create(param=None)  # -> ./dragonfly --param
```
