### PR TITLE
fix(server): Don't allow directory escapes in dbfilename

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -277,11 +277,9 @@ void ExtendDfsFilenameWithShard(int shard, fs::path* filename) {
 }
 
 GenericError ValidateFilename(const fs::path& filename, bool new_version) {
-  for (const auto& path_component : filename) {
-    if (path_component == "..") {
-      return {absl::StrCat("filename may not contain directory escaping sequences (Got \"",
-                           filename.c_str(), "\")")};
-    }
+  if (!filename.parent_path().empty()) {
+    return {absl::StrCat("filename may not contain directory separators (Got \"", filename.c_str(),
+                         "\")")};
   }
 
   if (!filename.has_extension()) {

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -144,3 +144,21 @@ class TestPeriodicSnapshot(SnapshotTestBase):
         time.sleep(60)
 
         assert super().get_main_file("test-periodic-summary.dfs")
+
+
+@dfly_args({**BASIC_ARGS})
+class TestPathEscapes(SnapshotTestBase):
+    """Test that we don't allow path escapes. We just check that df_server.start()
+    fails because we don't have a much better way to test that."""
+    @pytest.fixture(autouse=True)
+    def setup(self, tmp_dir: Path):
+        super().setup(tmp_dir)
+
+    @pytest.mark.asyncio
+    async def test_snapshot(self, df_local_factory):
+        df_server = df_local_factory.create(dbfilename="../../../../etc/passwd")
+        try:
+            df_server.start()
+            assert False, "Server should not start correctly"
+        except Exception as e:
+            pass


### PR DESCRIPTION
Allowing `..` inside dbfilename can allow almost arbitrary overwrite of files outside of `--dir`. Under specific assumptions, this might be a security issue. Fix by filtering not allowing such components.
