### PR TITLE
fix: container limits

### DIFF
--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -498,12 +498,13 @@ void ReadContainerMemoryLimits(io::MemInfoData& mdata) {
       CHECK(absl::SimpleAtoi(max.value(), &mdata.mem_total));
   }
 
+  mdata.mem_avail = mdata.mem_total;
   auto high = io::ReadFileToString(cgroup + "/memory.high");
 
   if (high.has_value()) {
     auto high_val = high.value();
     if (high_val.find("max") != high_val.npos)
-      mdata.mem_avail = mdata.mem_total;
+      return;
     else
       CHECK(absl::SimpleAtoi(high.value(), &mdata.mem_avail));
   }
@@ -603,7 +604,6 @@ Usage: dragonfly [FLAGS]
   }
 
   auto memory = ReadMemInfo().value();
-  LOG(INFO) << "inside container: " << InsideContainer();
 
   auto inside_container = InsideContainer();
   if (inside_container)

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -438,6 +438,56 @@ bool ShouldUseEpollAPI(const base::sys::KernelVersion& kver) {
   return true;
 }
 
+bool InsideContainer() {
+  /**
+   * (attemps) to check whether we are running
+   * inside a container or not.
+   *
+   * We employ several tests, all of which
+   * are flawed, however together do cover a
+   * good portion of cases.
+   *
+   * 1. Checking '/.dockerenv': very simple, however
+   * only works for Docker, and this file may be moved
+   * in the future.
+   * 2. Checking '/sys/fs/cgroup/memory.max': This
+   * directory -cannot- be edited (not even using sudoedit),
+   * so users are not able to add files to there. The file
+   * 'memory.max' should contain a memory limit for processes.
+   *
+   * We also use this file to find out how much memory we can use.
+   * However, on LXC this is placed in a different directory:
+   * 3. Checking '/sys/fs/cgroup/memory/memory.limit_in_bytes':
+   * Same idea.
+   */
+
+  using io::Exists;
+
+  return Exists("/.dockerenv") || Exists("/sys/fs/cgroup/memory.max");
+}
+
+void ReadContainerLimits(io::MemInfoData& mdata) {
+  auto max = io::ReadFileToString("/sys/fs/cgroup/memory.max");
+
+  if (max.has_value()) {
+    auto max_val = max.value();
+    if (max_val.find("max") != max_val.npos)
+      return; /*use the host's settings. */
+    else
+      CHECK(absl::SimpleAtoi(max.value(), &mdata.mem_total));
+  }
+
+  auto high = io::ReadFileToString("/sys/fs/cgroup/memory.high");
+
+  if (high.has_value()) {
+    auto high_val = high.value();
+    if (high_val.find("max") != high_val.npos)
+      mdata.mem_avail = mdata.mem_total;
+    else
+      CHECK(absl::SimpleAtoi(high.value(), &mdata.mem_avail));
+  }
+}
+
 }  // namespace
 }  // namespace dfly
 
@@ -494,17 +544,30 @@ Usage: dragonfly [FLAGS]
     }
   }
 
+  auto memory = ReadMemInfo().value();
+  LOG(INFO) << "inside container: " << InsideContainer();
+
+  if (InsideContainer())
+    ReadContainerLimits(memory);
+
+  if (memory.swap_total != 0)
+    LOG(WARNING) << "SWAP is enabled. Consider disabling it when running Dragonfly.";
+
   if (GetFlag(FLAGS_maxmemory).value == 0) {
     LOG(INFO) << "maxmemory has not been specified. Deciding myself....";
 
-    Result<MemInfoData> res = ReadMemInfo();
-    size_t available = res->mem_avail;
+    size_t available = memory.mem_avail;
     size_t maxmemory = size_t(0.8 * available);
     LOG(INFO) << "Found " << HumanReadableNumBytes(available)
               << " available memory. Setting maxmemory to " << HumanReadableNumBytes(maxmemory);
     absl::SetFlag(&FLAGS_maxmemory, MaxMemoryFlag(maxmemory));
   } else {
-    LOG(INFO) << "Max memory limit is: " << HumanReadableNumBytes(GetFlag(FLAGS_maxmemory).value);
+    auto limit = GetFlag(FLAGS_maxmemory).value;
+    auto hr_limit = HumanReadableNumBytes(limit);
+    if (limit > memory.mem_avail)
+      LOG(WARNING) << "Got memory limit " << hr_limit << ", however only "
+                   << HumanReadableNumBytes(memory.mem_avail) << " was found.";
+    LOG(INFO) << "Max memory limit is: " << hr_limit;
   }
 
   dfly::max_memory_limit = GetFlag(FLAGS_maxmemory).value;

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -448,11 +448,16 @@ string get_cgroup_path(void) {
     // Here, we assume that CGroup v1 is being used. This
     // is quite likely, as CGroup v1 was introduced back in 2015.
 
-    // strip 0::<path> into just <path>.
-    return cg.value().substr(3); 
+    // strip 0::<path> into just <path>, and newline.
+    auto cgv = std::move(cg.value());
+    return cgv.substr(3, cgv.length() - 3 - 1);
+    /**
+     * -3: we are skipping the first three characters
+     * -1: we discard the last character (a newline)
+    */
 }
 
-const auto cgroup = get_cgroup_path();
+const auto cgroup = "/sys/fs/cgroup/" + get_cgroup_path();
 
 bool InsideContainer() {
   /**

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -466,7 +466,7 @@ bool InsideContainer() {
   return Exists("/.dockerenv") || Exists("/sys/fs/cgroup/memory.max");
 }
 
-void ReadContainerLimits(io::MemInfoData& mdata) {
+void ReadContainerMemoryLimits(io::MemInfoData& mdata) {
   auto max = io::ReadFileToString("/sys/fs/cgroup/memory.max");
 
   if (max.has_value()) {
@@ -547,8 +547,9 @@ Usage: dragonfly [FLAGS]
   auto memory = ReadMemInfo().value();
   LOG(INFO) << "inside container: " << InsideContainer();
 
-  if (InsideContainer())
-    ReadContainerLimits(memory);
+  auto inside_container = InsideContainer();
+  if (inside_container)
+    ReadContainerMemoryLimits(memory);
 
   if (memory.swap_total != 0)
     LOG(WARNING) << "SWAP is enabled. Consider disabling it when running Dragonfly.";

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -440,21 +440,21 @@ bool ShouldUseEpollAPI(const base::sys::KernelVersion& kver) {
 }
 
 string get_cgroup_path(void) {
-    // Begin by reading /proc/self/cgroup
+  // Begin by reading /proc/self/cgroup
 
-    auto cg = io::ReadFileToString("/proc/self/cgroup");
-    CHECK(cg.has_value());
+  auto cg = io::ReadFileToString("/proc/self/cgroup");
+  CHECK(cg.has_value());
 
-    // Here, we assume that CGroup v1 is being used. This
-    // is quite likely, as CGroup v1 was introduced back in 2015.
+  // Here, we assume that CGroup v1 is being used. This
+  // is quite likely, as CGroup v1 was introduced back in 2015.
 
-    // strip 0::<path> into just <path>, and newline.
-    auto cgv = std::move(cg.value());
-    return cgv.substr(3, cgv.length() - 3 - 1);
-    /**
-     * -3: we are skipping the first three characters
-     * -1: we discard the last character (a newline)
-    */
+  // strip 0::<path> into just <path>, and newline.
+  auto cgv = std::move(cg.value());
+  return cgv.substr(3, cgv.length() - 3 - 1);
+  /**
+   * -3: we are skipping the first three characters
+   * -1: we discard the last character (a newline)
+   */
 }
 
 const auto cgroup = "/sys/fs/cgroup/" + get_cgroup_path();


### PR DESCRIPTION
Dragonfly now respects CGroup limits (memory, CPUs) and uses those instead of the host's limits.

Closes #986.