### PR TITLE
fix(server): Prevent preemption inside SerializeBucket

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -857,7 +857,7 @@ void DbSlice::FlushChangeToEarlierCallbacks(DbIndex db_ind, PrimeIterator it,
                                             uint64_t upper_bound) {
   FiberAtomicGuard fg;
   uint64_t bucket_version = it.GetVersion();
-  // change_cb_ is ordered by vesion.
+  // change_cb_ is ordered by version.
   for (const auto& ccb : change_cb_) {
     uint64_t cb_vesrion = ccb.first;
     DCHECK_LE(cb_vesrion, upper_bound);

--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -70,7 +70,7 @@ class SliceSnapshot {
   void Join();
 
   // Force stop. Needs to be called together with cancelling the context.
-  // Snapshot can't always react to cancellation in streaming mode becuase the
+  // Snapshot can't always react to cancellation in streaming mode because the
   // iteration fiber might have finished running by then.
   void Cancel();
 
@@ -128,7 +128,8 @@ class SliceSnapshot {
 
   std::unique_ptr<RdbSerializer> serializer_;
 
-  Mutex mu_;
+  bool serialize_bucket_running_ = false;
+  EventCount serialize_bucket_evc_;
   Fiber snapshot_fb_;  // IterateEntriesFb
 
   CompressionMode compression_mode_;

--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -128,8 +128,8 @@ class SliceSnapshot {
 
   std::unique_ptr<RdbSerializer> serializer_;
 
+  // Used for sanity checks.
   bool serialize_bucket_running_ = false;
-  EventCount serialize_bucket_evc_;
   Fiber snapshot_fb_;  // IterateEntriesFb
 
   CompressionMode compression_mode_;


### PR DESCRIPTION
Fix the problem described by @romange in #1036.

Some synchronizations were removed after Adi and I went over the code. I left `CHECK`s around to be a bit more safe.