### PR TITLE
bug(server): replicate scripts in stable state

### DIFF
--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -29,7 +29,7 @@ CommandId::CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first
 }
 
 bool CommandId::IsTransactional() const {
-  if (first_key_ > 0 || (opt_mask_ & CO::GLOBAL_TRANS))
+  if (first_key_ > 0 || (opt_mask_ & CO::GLOBAL_TRANS) || (opt_mask_ & CO::NO_KEY_JOURNAL))
     return true;
 
   string_view name{name_};
@@ -124,6 +124,8 @@ const char* OptName(CO::CommandOpt fl) {
       return "variadic-keys";
     case NO_AUTOJOURNAL:
       return "custom-journal";
+    case NO_KEY_JOURNAL:
+      return "no-key-journal";
   }
   return "unknown";
 }

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -34,6 +34,7 @@ enum CommandOpt : uint32_t {
   GLOBAL_TRANS = 1U << 12,
 
   NO_AUTOJOURNAL = 1U << 15,  // Skip automatically logging command to journal inside transaction.
+  NO_KEY_JOURNAL = 1U << 16,  // Command with no keys that need to be journaled
 };
 
 const char* OptName(CommandOpt fl);

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -674,6 +674,9 @@ size_t DbSlice::DbSize(DbIndex db_ind) const {
 }
 
 bool DbSlice::Acquire(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
+  if (lock_args.args.empty()) {
+    return false;
+  }
   DCHECK_GT(lock_args.key_step, 0u);
 
   auto& lt = db_arr_[lock_args.db_index]->trans_locks;
@@ -700,6 +703,9 @@ bool DbSlice::Acquire(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
 }
 
 void DbSlice::Release(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
+  if (lock_args.args.empty()) {
+    return;
+  }
   DVLOG(2) << "Release " << IntentLock::ModeName(mode) << " for " << lock_args.args[0];
   if (lock_args.args.size() == 1) {
     Release(mode, lock_args.db_index, lock_args.args.front(), 1);
@@ -729,7 +735,6 @@ bool DbSlice::CheckLock(IntentLock::Mode mode, DbIndex dbid, string_view key) co
 }
 
 bool DbSlice::CheckLock(IntentLock::Mode mode, const KeyLockArgs& lock_args) const {
-  DCHECK(!lock_args.args.empty());
   const auto& lt = db_arr_[lock_args.db_index]->trans_locks;
   for (size_t i = 0; i < lock_args.args.size(); i += lock_args.key_step) {
     auto s = lock_args.args[i];

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -675,7 +675,7 @@ size_t DbSlice::DbSize(DbIndex db_ind) const {
 
 bool DbSlice::Acquire(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
   if (lock_args.args.empty()) {
-    return false;
+    return true;
   }
   DCHECK_GT(lock_args.key_step, 0u);
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2084,7 +2084,7 @@ void ServerFamily::Register(CommandRegistry* registry) {
             << CI{"REPLCONF", CO::ADMIN | CO::LOADING, -1, 0, 0, 0}.HFUNC(ReplConf)
             << CI{"ROLE", CO::LOADING | CO::FAST | CO::NOSCRIPT, 1, 0, 0, 0}.HFUNC(Role)
             << CI{"SLOWLOG", CO::ADMIN | CO::FAST, -2, 0, 0, 0}.SetHandler(SlowLog)
-            << CI{"SCRIPT", CO::NOSCRIPT, -2, 0, 0, 0}.HFUNC(Script)
+            << CI{"SCRIPT", CO::NOSCRIPT | CO::NO_KEY_JOURNAL, -2, 0, 0, 0}.HFUNC(Script)
             << CI{"DFLY", CO::ADMIN | CO::GLOBAL_TRANS, -2, 0, 0, 0}.HFUNC(Dfly);
 }
 

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -929,6 +929,7 @@ KeyLockArgs Transaction::GetLockArgs(ShardId sid) const {
   res.db_index = db_index_;
   res.key_step = cid_->key_arg_step();
   res.args = GetShardArgs(sid);
+  DCHECK(!res.args.empty() || (cid_->opt_mask() & CO::NO_KEY_JOURNAL));
 
   return res;
 }
@@ -960,6 +961,7 @@ bool Transaction::ScheduleUniqueShard(EngineShard* shard) {
   sd.pq_pos = shard->txq()->Insert(this);
 
   DCHECK_EQ(0, sd.local_mask & KEYLOCK_ACQUIRED);
+
   shard->db_slice().Acquire(mode, lock_args);
   sd.local_mask |= KEYLOCK_ACQUIRED;
 

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -949,7 +949,7 @@ bool Transaction::ScheduleUniqueShard(EngineShard* shard) {
   auto& sd = shard_data_[SidToId(unique_shard_id_)];
   DCHECK_EQ(TxQueue::kEnd, sd.pq_pos);
 
-  if (false && shard->shard_lock()->Check(mode)) {
+  if (shard->shard_lock()->Check(mode)) {
     if (empty_args_ || shard->db_slice().CheckLock(mode, GetLockArgs(shard->shard_id()))) {
       RunQuickie(shard);
       return true;

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -389,6 +389,9 @@ class Transaction {
   // Init as a global transaction.
   void InitGlobal();
 
+  // Init when command has no keys and it need to use transaction framework
+  void InitNoKey();
+
   // Init with a set of keys.
   void InitByKeys(KeyIndex keys);
 
@@ -531,6 +534,7 @@ class Transaction {
 
   TxId txid_{0};
   bool global_{false};
+  bool empty_args_{false};
   DbIndex db_index_{0};
   uint64_t time_now_ms_{0};
 

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -534,7 +534,6 @@ class Transaction {
 
   TxId txid_{0};
   bool global_{false};
-  bool empty_args_{false};
   DbIndex db_index_{0};
   uint64_t time_now_ms_{0};
 


### PR DESCRIPTION
Fixes #1040 

The solution is this PR for replicating scripts:
Script is non key command and is not part of the transaction framework which is how we replicate commands.
Therefor I created a new command mask, if this mask is set I use the transaction framework using shard 0 to replicate the command
