### PR TITLE
fix(tests): Disable 'dbfilename' unless explicitly given in the test

### DIFF
--- a/tests/dragonfly/__init__.py
+++ b/tests/dragonfly/__init__.py
@@ -106,6 +106,7 @@ class DflyInstanceFactory:
 
     def create(self, **kwargs) -> DflyInstance:
         args = {**self.args, **kwargs}
+        args.setdefault("dbfilename", "")
         for k, v in args.items():
             args[k] = v.format(**self.params.env) if isinstance(v, str) else v
 


### PR DESCRIPTION
After #1086, some replication tests were broken sometimes. This disables snapshots everywhere in the tests unless explicitly provided (`snapshot_test.py` for example). Accidental snapshots make testing more complicated so it is better to avoid them at all.