### PR TITLE
Dispatch queue backpressure and batching

### DIFF
--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -116,7 +116,7 @@ class Connection : public util::Connection {
   using PubMessagePtr = std::unique_ptr<PubMessage, MessageDeleter>;
 
   struct MessageHandle {
-    size_t StorageCapacity() const;
+    size_t UsedMemory() const;  // How much bytes this handle takes up in total.
 
     bool IsPipelineMsg() const;
 
@@ -132,6 +132,10 @@ class Connection : public util::Connection {
 
   // Add monitor message to dispatch queue.
   void SendMonitorMessageAsync(std::string);
+
+  // Must be called before Send_Async to ensure the connection dispatch queue is not overfilled.
+  // Blocks until free space is available.
+  void EnsureAsyncMemoryBudget();
 
   // Register hook that is executed on connection shutdown.
   ShutdownHandle RegisterShutdownHook(ShutdownCb cb);
@@ -212,6 +216,9 @@ class Connection : public util::Connection {
   std::deque<MessageHandle> dispatch_q_;  // dispatch queue
   dfly::EventCount evc_;                  // dispatch queue waker
 
+  std::atomic_uint32_t dispatch_q_bytes_ = 0;  // memory usage of all entries
+  dfly::EventCount evc_bp_;                    // backpressure for memory limit
+
   base::IoBuf io_buf_;  // used in io loop and parsers
   std::unique_ptr<RedisParser> redis_parser_;
   std::unique_ptr<MemcacheParser> memcache_parser_;
@@ -233,8 +240,6 @@ class Connection : public util::Connection {
   std::unique_ptr<ConnectionContext> cc_;
 
   unsigned parser_error_ = 0;
-  uint32_t pipeline_msg_cnt_ = 0;
-
   uint32_t break_poll_id_ = UINT32_MAX;
 
   BreakerCb breaker_cb_;

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -216,7 +216,7 @@ class Connection : public util::Connection {
   std::deque<MessageHandle> dispatch_q_;  // dispatch queue
   dfly::EventCount evc_;                  // dispatch queue waker
 
-  std::atomic_uint32_t dispatch_q_bytes_ = 0;  // memory usage of all entries
+  std::atomic_uint64_t dispatch_q_bytes_ = 0;  // memory usage of all entries
   dfly::EventCount evc_bp_;                    // backpressure for memory limit
 
   base::IoBuf io_buf_;  // used in io loop and parsers

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1470,6 +1470,11 @@ void Service::Publish(CmdArgList args, ConnectionContext* cntx) {
 
   if (!subscribers.empty()) {
     // Make sure neither of the subscribers buffers is filled up.
+    // This check actually doesn't reserve any memory ahead and doesn't prevent the buffer
+    // from eventually filling up, especially if multiple clients are unblocked simultaneously
+    // but is generally good enough to limit too fast producers.
+    // Most importantly, this approach allows not blocking and not awaiting in the dispatch below,
+    // thus not adding any overhead to backpressure checks.
     for (auto& sub : subscribers)
       sub.conn_cntx->owner()->EnsureAsyncMemoryBudget();
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1469,6 +1469,10 @@ void Service::Publish(CmdArgList args, ConnectionContext* cntx) {
   int num_published = subscribers.size();
 
   if (!subscribers.empty()) {
+    // Make sure neither of the subscribers buffers is filled up.
+    for (auto& sub : subscribers)
+      sub.conn_cntx->owner()->EnsureAsyncMemoryBudget();
+
     auto subscribers_ptr = make_shared<decltype(subscribers)>(move(subscribers));
     auto buf = shared_ptr<char[]>{new char[channel.size() + msg.size()]};
     memcpy(buf.get(), channel.data(), channel.size());


### PR DESCRIPTION
Fixes #1039 

This PR:
* Adds "almost correct" backpressure to publish messages (without decreasing dispatch performance)
* Enables batching for pubsub