### PR TITLE
fix: replace journal executor reply builder

### DIFF
--- a/src/server/journal/executor.cc
+++ b/src/server/journal/executor.cc
@@ -38,9 +38,14 @@ template <typename... Ts> journal::ParsedEntry::CmdData BuildFromParts(Ts... par
 }  // namespace
 
 JournalExecutor::JournalExecutor(Service* service)
-    : service_{service}, conn_context_{&null_sink_, nullptr} {
+    : service_{service}, reply_builder_{facade::ReplyMode::NONE}, conn_context_{nullptr,
+                                                                                &reply_builder_} {
   conn_context_.is_replicating = true;
   conn_context_.journal_emulated = true;
+}
+
+JournalExecutor::~JournalExecutor() {
+  conn_context_.Inject(nullptr);
 }
 
 void JournalExecutor::Execute(DbIndex dbid, std::vector<journal::ParsedEntry::CmdData>& cmds) {

--- a/src/server/journal/executor.h
+++ b/src/server/journal/executor.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "facade/reply_capture.h"
 #include "server/journal/types.h"
 
 namespace dfly {
@@ -14,6 +15,10 @@ class Service;
 class JournalExecutor {
  public:
   JournalExecutor(Service* service);
+  ~JournalExecutor();
+
+  JournalExecutor(JournalExecutor&&) = delete;
+
   void Execute(DbIndex dbid, std::vector<journal::ParsedEntry::CmdData>& cmds);
   void Execute(DbIndex dbid, journal::ParsedEntry::CmdData& cmd);
 
@@ -26,8 +31,8 @@ class JournalExecutor {
   void SelectDb(DbIndex dbid);
 
   Service* service_;
+  facade::CapturingReplyBuilder reply_builder_;
   ConnectionContext conn_context_;
-  io::NullSink null_sink_;
 
   std::vector<bool> ensured_dbs_;
 };


### PR DESCRIPTION
A regular reply builder with a null sink still serializes all replies. The capturing reply builder with a `NONE` filter is a no-op for all send methods.