### PR TITLE
test(sentinel_test.py): increase timeout in failover test

### DIFF
--- a/tests/dragonfly/sentinel_test.py
+++ b/tests/dragonfly/sentinel_test.py
@@ -159,7 +159,7 @@ async def test_failover(df_local_factory, sentinel, port_picker):
         await await_for(
             lambda: master_client.get("key"),
             lambda val: val == b"value",
-            10, "Timeout waiting for key to exist in replica."
+            15, "Timeout waiting for key to exist in replica."
         )
     except AssertionError:
         syncid, r_offset = await master_client.execute_command("DEBUG REPLICA OFFSET")


### PR DESCRIPTION
As can be seen in the log of a failure 10 secs can be just shy and eventually the value is present both in replica and master:

[2023-04-24 15:22:15.836 INFO] key was set on promoted replica, awaiting get on promoted replica.

[2023-04-24 15:22:25.905 INFO] SYNC1 [0, 0] [0, 0] (first log in timeout exception expect clause)

[2023-04-24 15:22:25.957 INFO] replica val: b'value'
[2023-04-24 15:22:25.957 INFO] master val: b'value'

(full log https://github.com/dragonflydb/dragonfly/actions/runs/4787901920/jobs/8513772429)
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->