### PR TITLE
fix: remove redundant ToLower call from the HSET function

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -723,8 +723,7 @@ void GenericFamily::Expire(CmdArgList args, ConnectionContext* cntx) {
   }
 
   if (int_arg > kMaxExpireDeadlineSec || int_arg < -kMaxExpireDeadlineSec) {
-    ToLower(&args[0]);
-    return (*cntx)->SendError(InvalidExpireTime(ArgS(args, 0)));
+    return (*cntx)->SendError(InvalidExpireTime(cntx->cid->name()));
   }
 
   int_arg = std::max(int_arg, -1L);

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -955,10 +955,11 @@ void HSetFamily::HScan(CmdArgList args, ConnectionContext* cntx) {
 
 void HSetFamily::HSet(CmdArgList args, ConnectionContext* cntx) {
   string_view key = ArgS(args, 0);
-  ToLower(&args[0]);
+
+  string_view cmd{cntx->cid->name()};
 
   if (args.size() % 2 != 1) {
-    return (*cntx)->SendError(facade::WrongNumArgsError("hset"), kSyntaxErrType);
+    return (*cntx)->SendError(facade::WrongNumArgsError(cmd), kSyntaxErrType);
   }
 
   args.remove_prefix(1);
@@ -967,7 +968,6 @@ void HSetFamily::HSet(CmdArgList args, ConnectionContext* cntx) {
   };
 
   OpResult<uint32_t> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
-  string_view cmd{cntx->cid->name()};
 
   if (result && cmd == "HSET") {
     (*cntx)->SendLong(*result);

--- a/src/server/hset_family_test.cc
+++ b/src/server/hset_family_test.cc
@@ -225,4 +225,10 @@ TEST_F(HSetFamilyTest, TriggerConvertToStrMap) {
   EXPECT_THAT(Run({"HLEN", "hk"}), IntArg(kElements));
 }
 
+TEST_F(HSetFamilyTest, Issue1140) {
+  Run({"HSET", "CaseKey", "Foo", "Bar"});
+
+  EXPECT_EQ("Bar", Run({"HGET", "CaseKey", "Foo"}));
+}
+
 }  // namespace dfly

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -1092,8 +1092,7 @@ void StringFamily::SetExGeneric(bool seconds, CmdArgList args, ConnectionContext
   }
 
   if (unit_vals < 1 || unit_vals >= kMaxExpireDeadlineSec) {
-    ToLower(&args[0]);
-    return (*cntx)->SendError(InvalidExpireTime(ArgS(args, 0)));
+    return (*cntx)->SendError(InvalidExpireTime(cntx->cid->name()));
   }
 
   SetCmd::SetParams sparams;


### PR DESCRIPTION
The call was left during big refactoring when we removed command name from the arguments slice passed to commands.

Fixes #1140

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->