### PR TITLE
fix(server): Return strings with underscores instead of spaces for replication states

### DIFF
--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -68,10 +68,10 @@ DflyCmd::ReplicaRoleInfo::ReplicaRoleInfo(std::string address, uint32_t listenin
       state = "preparation";
       break;
     case SyncState::FULL_SYNC:
-      state = "full sync";
+      state = "full_sync";
       break;
     case SyncState::STABLE_SYNC:
-      state = "stable sync";
+      state = "stable_sync";
       break;
     case SyncState::CANCELLED:
       state = "cancelled";

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1993,11 +1993,11 @@ void ServerFamily::Role(CmdArgList args, ConnectionContext* cntx) {
     (*cntx)->SendBulkString(rinfo.host);
     (*cntx)->SendBulkString(absl::StrCat(rinfo.port));
     if (rinfo.sync_in_progress) {
-      (*cntx)->SendBulkString("full sync");
+      (*cntx)->SendBulkString("full_sync");
     } else if (!rinfo.master_link_established) {
       (*cntx)->SendBulkString("connecting");
     } else {
-      (*cntx)->SendBulkString("stable sync");
+      (*cntx)->SendBulkString("stable_sync");
     }
   }
 }


### PR DESCRIPTION
Part of #1146 