### PR TITLE
chore: Fix errors/warnings in GCC13

### DIFF
--- a/src/core/small_string.h
+++ b/src/core/small_string.h
@@ -3,6 +3,7 @@
 //
 #pragma once
 
+#include <cstdint>
 #include <string_view>
 
 #include "core/core_types.h"

--- a/src/core/string_map.h
+++ b/src/core/string_map.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <string_view>
+
 #include "core/dense_set.h"
 
 extern "C" {

--- a/src/core/string_set.h
+++ b/src/core/string_set.h
@@ -7,6 +7,8 @@
 #include <cstdint>
 #include <functional>
 #include <optional>
+#include <string>
+#include <string_view>
 
 #include "core/dense_set.h"
 

--- a/src/facade/memcache_parser.h
+++ b/src/facade/memcache_parser.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string_view>
 #include <vector>
 

--- a/src/facade/memcache_parser.h
+++ b/src/facade/memcache_parser.h
@@ -49,7 +49,7 @@ class MemcacheParser {
 
     union {
       uint64_t cas_unique = 0;  // for CAS COMMAND
-      uint64_t delta;          // for DECR/INCR commands.
+      uint64_t delta;           // for DECR/INCR commands.
     };
 
     uint32_t expire_ts = 0;  // relative time in seconds.
@@ -76,4 +76,4 @@ class MemcacheParser {
  private:
 };
 
-}  // namespace dfly
+}  // namespace facade

--- a/src/facade/op_status.h
+++ b/src/facade/op_status.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <ostream>
 
 namespace facade {

--- a/src/facade/op_status.h
+++ b/src/facade/op_status.h
@@ -76,6 +76,14 @@ template <typename V> class OpResult : public OpResultBase {
     return status() == OpStatus::OK ? v_ : v;
   }
 
+  V* operator->() {
+    return &v_;
+  }
+
+  V& operator*() {
+    return v_;
+  }
+
   const V* operator->() const {
     return &v_;
   }

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1045,7 +1045,7 @@ optional<CapturingReplyBuilder::Payload> Service::FlushEvalAsyncCmds(ConnectionC
   info->async_cmds_heap_mem = 0;
   info->async_cmds.clear();
 
-  auto reply = move(crb.Take());
+  auto reply = crb.Take();
   return CapturingReplyBuilder::GetError(reply) ? make_optional(move(reply)) : nullopt;
 }
 


### PR DESCRIPTION
* Re-add includes that were removed
* Fix 2 std::moves that didn't work as expected (found by better move analysis!)
