### PR TITLE
feat(server): allow AUTH and SETNAME options in the HELLO command

### DIFF
--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -235,11 +235,17 @@ TEST_F(DflyEngineTest, Hello) {
                           ArgType(RespExpr::STRING), "proto", IntArg(3), "id",
                           ArgType(RespExpr::INT64), "mode", "standalone", "role", "master"));
 
-  // These are valid arguments to HELLO, however as they are not yet supported the implementation
-  // is degraded to 'unknown command'.
-  EXPECT_THAT(
-      Run({"hello", "2", "AUTH", "uname", "pwd"}),
-      ErrArg("ERR unknown command 'HELLO' with args beginning with: `2`, `AUTH`, `uname`, `pwd`"));
+  EXPECT_THAT(Run({"hello", "2", "AUTH", "uname", "pwd"}),
+              ErrArg("WRONGPASS invalid username-password pair or user is disabled."));
+
+  EXPECT_THAT(Run({"hello", "2", "AUTH", "default", "pwd"}),
+              ErrArg("WRONGPASS invalid username-password pair or user is disabled."));
+
+  resp = Run({"hello", "3", "AUTH", "default", ""});
+  ASSERT_THAT(resp, ArrLen(14));
+
+  resp = Run({"hello", "3", "AUTH", "default", "", "SETNAME", "myname"});
+  ASSERT_THAT(resp, ArrLen(14));
 }
 
 TEST_F(DflyEngineTest, Memcache) {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -625,7 +625,7 @@ bool Service::VerifyCommand(const CommandId* cid, CmdArgList args,
   string_view cmd_name{cid->name()};
 
   if (cntx->req_auth && !cntx->authenticated) {
-    if (cmd_name != "AUTH" && cmd_name != "QUIT") {
+    if (cmd_name != "AUTH" && cmd_name != "QUIT" && cmd_name != "HELLO") {
       (*cntx)->SendError("-NOAUTH Authentication required.");
       return false;
     }


### PR DESCRIPTION
Hi @romange,

I just tried to implement AUTH and SETNAME in the HELLO command to resolve the issue https://github.com/dragonflydb/dragonfly/issues/1151 by copying logic from here https://github.com/redis/redis/blob/d659c734569be4ed32a270bac2527ccf35418c43/src/networking.c#L3529-L3579

#Fixes #1151

