### PR TITLE
fix: 'xgroup help' should show help message

### DIFF
--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -31,6 +31,7 @@ enum CommandOpt : uint32_t {
   ADMIN = 1U << 7,  // implies NOSCRIPT,
   NOSCRIPT = 1U << 8,
   BLOCKING = 1U << 9,  // implies REVERSE_MAPPING
+  HIDDEN = 1U << 10,   // does not show in COMMAND command output
   GLOBAL_TRANS = 1U << 12,
 
   NO_AUTOJOURNAL = 1U << 15,  // Skip automatically logging command to journal inside transaction.
@@ -41,6 +42,10 @@ const char* OptName(CommandOpt fl);
 
 constexpr inline bool IsEvalKind(std::string_view name) {
   return name.compare(0, 4, "EVAL") == 0;
+}
+
+constexpr inline bool IsTransKind(std::string_view name) {
+  return (name == "EXEC") || (name == "MULTI") || (name == "DISCARD");
 }
 
 static_assert(IsEvalKind("EVAL") && IsEvalKind("EVALSHA"));
@@ -78,7 +83,7 @@ class CommandId {
   CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first_key, int8_t last_key,
             int8_t step);
 
-  const char* name() const {
+  std::string_view name() const {
     return name_;
   }
 
@@ -132,7 +137,7 @@ class CommandId {
   static uint32_t OptCount(uint32_t mask);
 
  private:
-  const char* name_;
+  std::string_view name_;
 
   uint32_t opt_mask_;
   int8_t arity_;

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -116,7 +116,9 @@ class Service : public facade::ServiceInterface {
   };
 
   // Return false if command is invalid and reply with error.
-  bool VerifyCommand(const CommandId* cid, CmdArgList args, facade::ConnectionContext* cntx);
+  bool VerifyCommand(const CommandId* cid, CmdArgList args, ConnectionContext* cntx);
+
+  const CommandId* FindCmd(CmdArgList args) const;
 
   void EvalInternal(const EvalArgs& eval_args, Interpreter* interpreter, ConnectionContext* cntx);
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2158,7 +2158,7 @@ void ServerFamily::Register(CommandRegistry* registry) {
             << CI{"ROLE", CO::LOADING | CO::FAST | CO::NOSCRIPT, 1, 0, 0, 0}.HFUNC(Role)
             << CI{"SLOWLOG", CO::ADMIN | CO::FAST, -2, 0, 0, 0}.SetHandler(SlowLog)
             << CI{"SCRIPT", CO::NOSCRIPT | CO::NO_KEY_JOURNAL, -2, 0, 0, 0}.HFUNC(Script)
-            << CI{"DFLY", CO::ADMIN | CO::GLOBAL_TRANS, -2, 0, 0, 0}.HFUNC(Dfly);
+            << CI{"DFLY", CO::ADMIN | CO::GLOBAL_TRANS | CO::HIDDEN, -2, 0, 0, 0}.HFUNC(Dfly);
 }
 
 }  // namespace dfly

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -563,6 +563,24 @@ void SetId(string_view key, string_view gname, CmdArgList args, ConnectionContex
   }
 }
 
+void XGroupHelp(CmdArgList args, ConnectionContext* cntx) {
+  string_view help_arr[] = {
+      "CREATE <key> <groupname> <id|$> [option]",
+      "    Create a new consumer group. Options are:",
+      "    * MKSTREAM",
+      "      Create the empty stream if it does not exist.",
+      "CREATECONSUMER <key> <groupname> <consumer>",
+      "    Create a new consumer in the specified group.",
+      "DELCONSUMER <key> <groupname> <consumer>",
+      "    Remove the specified consumer.",
+      "DESTROY <key> <groupname>"
+      "    Remove the specified group.",
+      "SETID <key> <groupname> <id|$>",
+      "    Set the current group ID.",
+  };
+  return (*cntx)->SendSimpleStrArr(help_arr);
+}
+
 }  // namespace
 
 void StreamFamily::XAdd(CmdArgList args, ConnectionContext* cntx) {
@@ -651,23 +669,6 @@ void StreamFamily::XDel(CmdArgList args, ConnectionContext* cntx) {
 void StreamFamily::XGroup(CmdArgList args, ConnectionContext* cntx) {
   ToUpper(&args[0]);
   string_view sub_cmd = ArgS(args, 0);
-  if (sub_cmd == "HELP") {
-    string_view help_arr[] = {
-        "CREATE <key> <groupname> <id|$> [option]",
-        "    Create a new consumer group. Options are:",
-        "    * MKSTREAM",
-        "      Create the empty stream if it does not exist.",
-        "CREATECONSUMER <key> <groupname> <consumer>",
-        "    Create a new consumer in the specified group.",
-        "DELCONSUMER <key> <groupname> <consumer>",
-        "    Remove the specified consumer.",
-        "DESTROY <key> <groupname>"
-        "    Remove the specified group.",
-        "SETID <key> <groupname> <id|$>",
-        "    Set the current group ID.",
-    };
-    return (*cntx)->SendSimpleStrArr(help_arr);
-  }
 
   if (args.size() >= 2) {
     string_view key = ArgS(args, 1);
@@ -859,12 +860,13 @@ void StreamFamily::Register(CommandRegistry* registry) {
 
   *registry << CI{"XADD", CO::WRITE | CO::FAST, -5, 1, 1, 1}.HFUNC(XAdd)
             << CI{"XDEL", CO::WRITE | CO::FAST, -3, 1, 1, 1}.HFUNC(XDel)
-            << CI{"XGROUP", CO::WRITE | CO::DENYOOM, -2, 2, 2, 1}.HFUNC(XGroup)
+            << CI{"XGROUP", CO::WRITE | CO::DENYOOM, -3, 2, 2, 1}.HFUNC(XGroup)
             << CI{"XINFO", CO::READONLY | CO::NOSCRIPT, -2, 0, 0, 0}.HFUNC(XInfo)
             << CI{"XLEN", CO::READONLY | CO::FAST, 2, 1, 1, 1}.HFUNC(XLen)
             << CI{"XRANGE", CO::READONLY, -4, 1, 1, 1}.HFUNC(XRange)
             << CI{"XREVRANGE", CO::READONLY, -4, 1, 1, 1}.HFUNC(XRevRange)
-            << CI{"XSETID", CO::WRITE | CO::DENYOOM, 3, 1, 1, 1}.HFUNC(XSetId);
+            << CI{"XSETID", CO::WRITE | CO::DENYOOM, 3, 1, 1, 1}.HFUNC(XSetId)
+            << CI{"_XGROUP_HELP", CO::NOSCRIPT | CO::HIDDEN, 2, 0, 0, 0}.SetHandler(XGroupHelp);
 }
 
 }  // namespace dfly

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -84,4 +84,12 @@ TEST_F(StreamFamilyTest, Range) {
   EXPECT_THAT(sub1, ElementsAre("1-0", ArrLen(2)));
 }
 
+TEST_F(StreamFamilyTest, Issue854) {
+  auto resp = Run({"xgroup", "help"});
+  EXPECT_THAT(resp, ArgType(RespExpr::ARRAY));
+
+  resp = Run({"eval", "redis.call('xgroup', 'help')", "0"});
+  EXPECT_THAT(resp, ErrArg("is not allowed"));
+}
+
 }  // namespace dfly

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -920,7 +920,7 @@ void Transaction::UnwatchBlocking(bool should_expire, WaitKeysProvider wcb) {
   DVLOG(1) << "UnwatchBlocking finished " << DebugId();
 }
 
-const char* Transaction::Name() const {
+string_view Transaction::Name() const {
   return cid_->name();
 }
 

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -251,7 +251,7 @@ class Transaction {
 
   IntentLock::Mode Mode() const;  // Based on command mask
 
-  const char* Name() const;  // Based on command name
+  std::string_view Name() const;  // Based on command name
 
   uint32_t GetUniqueShardCnt() const {
     return unique_shard_cnt_;

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -615,7 +615,7 @@ bool ParseLexBound(string_view src, ZSetFamily::LexBound* bound) {
 }
 
 void SendAtLeastOneKeyError(ConnectionContext* cntx) {
-  string name = cntx->cid->name();
+  string name{cntx->cid->name()};
   absl::AsciiStrToLower(&name);
   (*cntx)->SendError(absl::StrCat("at least 1 input key is needed for ", name));
 }


### PR DESCRIPTION
Along the way, performs small cleanups in command handling code.

Fixes #854.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->