### PR TITLE
fix: fix replica closing socket

### DIFF
--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -739,8 +739,11 @@ void Replica::CloseSocket() {
   unique_lock lk(sock_mu_);
   if (sock_) {
     sock_->proactor()->Await([this] {
-      auto ec = sock_->Shutdown(SHUT_RDWR);
-      LOG_IF(ERROR, ec) << "Could not shutdown socket " << ec;
+      if (sock_->IsOpen()) {
+        auto ec = sock_->Shutdown(SHUT_RDWR);
+        LOG_IF(ERROR, ec) << "Could not shutdown socket " << ec;
+        sock_->Close();
+      }
     });
   }
 }


### PR DESCRIPTION
This bug was found inside `test_cancel_replication_immediately` of the regression tests

https://github.com/dragonflydb/dragonfly/actions/runs/4828930130/jobs/8603358782

The stacktrace suggests that we try to shut down a socket that is already closed or not initalized. What is more, 

>  [Error generic:125 while calling check_connection_error(ec, kConnErr)](replica.cc:181] Error generic:125 while calling check_connection_error(ec, kConnErr))

indicates that it must be that `Replica::Start` is cancelled after the socket is initialized (the pointer is valid), but before it's connected (fd = -1)

I first looked only at the iouring socket's code and saw that fd is not changed even on errors, which made me think of many different causes for this bug. But as pytests are running with epoll, it simply looks like the socket failed to connect, set fd_ to -1 and the contex was cancelled. 
