### PR TITLE
fix: remove preliminary socket close in replica

### DIFF
--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -742,7 +742,6 @@ void Replica::CloseSocket() {
       if (sock_->IsOpen()) {
         auto ec = sock_->Shutdown(SHUT_RDWR);
         LOG_IF(ERROR, ec) << "Could not shutdown socket " << ec;
-        sock_->Close();
       }
     });
   }


### PR DESCRIPTION
Fix regression tests (again).

The socket is closed on destruction, no need to close it ahead. If we close it ahead, asserts in the regular socket flow fail (we don't check there every time if its valid or not)