### PR TITLE
fix: fix parsing nested arrays

### DIFF
--- a/src/facade/redis_parser.cc
+++ b/src/facade/redis_parser.cc
@@ -276,9 +276,6 @@ auto RedisParser::ConsumeArrayLen(Buffer str) -> Result {
     return OK;
   }
 
-  DVLOG(1) << "PushStack: (" << len << ", " << cached_expr_ << ")";
-  parse_stack_.emplace_back(len, cached_expr_);
-
   if (state_ == PARSE_ARG_S) {
     DCHECK(!server_mode_);
 
@@ -291,6 +288,9 @@ auto RedisParser::ConsumeArrayLen(Buffer str) -> Result {
   } else {
     state_ = PARSE_ARG_S;
   }
+
+  DVLOG(1) << "PushStack: (" << len << ", " << cached_expr_ << ")";
+  parse_stack_.emplace_back(len, cached_expr_);
 
   return OK;
 }

--- a/src/facade/redis_parser_test.cc
+++ b/src/facade/redis_parser_test.cc
@@ -197,4 +197,16 @@ TEST_F(RedisParserTest, NILs) {
   ASSERT_EQ(RedisParser::OK, Parse("_\r\n"));
 }
 
+TEST_F(RedisParserTest, NestedArray) {
+  parser_.SetClientMode();
+
+  // [[['foo'],['bar']],['car']]
+  ASSERT_EQ(RedisParser::OK,
+            Parse("*2\r\n*2\r\n*1\r\n$3\r\nfoo\r\n*1\r\n$3\r\nbar\r\n*1\r\n$3\r\ncar\r\n"));
+
+  ASSERT_THAT(args_, ElementsAre(ArrArg(2), ArrArg(1)));
+  ASSERT_THAT(args_[0].GetVec(), ElementsAre(ArrArg(1), ArrArg(1)));
+  ASSERT_THAT(args_[1].GetVec(), ElementsAre("car"));
+}
+
 }  // namespace facade


### PR DESCRIPTION
Fixes a bug parsing nested arrays in client mode.

When `parse_stack_.emplace_back(len, cached_expr_)` is called **before** creating the new array, the root array would be added to `parse_stack_` twice and the leaf array would never be added. That means when a stack was popped, `cached_expr_` would end up pointing to the wrong array.

Such as the array `[[['foo'],['bar']],['car']]` (`"*2\r\n*2\r\n*1\r\n$3\r\nfoo\r\n*1\r\n$3\r\nbar\r\n*1\r\n$3\r\ncar\r\n"`) would have been parsed as `[[['foo']],['bar'],['car']]`, since after `foo` was parsed such that the nested array was at capacity, popping the stack would end up pointing `cached_expr_` to the root array instead of the first nested array.