### PR TITLE
feat(admin): Implement admin_nopass flag

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,7 @@
   * Helm Chart
 * **[Meng Chen](https://github.com/matchyc)**
 * **[Yuxuan Chen](https://github.com/YuxuanChen98)**
+* **[Pawel Kaplinski](https://github.com/pawelKapl)**
 * **[Redha Lhimeur](https://github.com/redhal)**
 * **[Braydn Moore](https://github.com/braydnm)**
 * **[Logan Raarup](https://github.com/logandk)**

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ There are also some Dragonfly-specific arguments:
  * `primary_port_http_enabled`: Allows accessing HTTP console on main TCP port if `true` (`default: true`).
  * `admin_port`: To enable admin access to the console on the assigned port (`default: disabled`). Supports both HTTP and RESP protocols.
  * `admin_bind`: To bind the admin console TCP connection to a given address (`default: any`). Supports both HTTP and RESP protocols.
+ * `admin_nopass`: To enable open admin access to console on the assigned port, without auth token needed (`default: false`). Supports both HTTP and RESP protocols.
  * `cluster_mode`: Cluster mode supported (`default: ""`). Currently supports only `emulated`.
  * `cluster_announce_ip`: The IP that cluster commands announce to the client.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -119,6 +119,8 @@ Dragonfly 支持 Redis 的常见参数。
 
 * `admin_bind`：如果设置，将管理控制台 TCP 连接绑定到给定地址。支持 HTTP 和 RESP 协议。默认为any。
 
+* `admin_nopass`: 将管理控制台 TCP 连接绑定到给定地址。同时支持 HTTP 和 RESP 协议。
+
 * `cluster_mode`：支持集群模式。目前仅支持 `emulated`。默认为空`""`。
 
 * `cluster_announce_ip`：集群模式下向客户端公开的 IP。

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -155,6 +155,7 @@ class Connection : public util::Connection {
   std::string RemoteEndpointAddress() const;
   std::string LocalBindAddress() const;
   uint32_t GetClientId() const;
+  bool IsAdmin() const;
 
   Protocol protocol() const {
     return protocol_;


### PR DESCRIPTION
Signed-off-by: Paweł Kapliński [pawkapl89@gmail.com](mailto:pawkapl89@gmail.com)

Fixing issue #1181

Changes:
- adding admin_nopass flag
- when admin_nopass flag is turned on, clients have open access to the admin network interface and console at admin port pointed by admin_port flag. 
- when admin_nopass flag is turned off, admin network interface requires AUTH just like a regular network interface. 

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->