### PR TITLE
fix: use redis.asyncio instead of aioredis

### DIFF
--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -1,8 +1,9 @@
 import pytest
 import redis
-from . import dfly_args
-import aioredis
+from redis import asyncio as aioredis
 import asyncio
+
+from . import dfly_args
 
 BASE_PORT = 30001
 
@@ -133,7 +134,7 @@ async def test_cluster_info(async_client):
 async def test_cluster_nodes(async_client):
     res = await async_client.execute_command("CLUSTER NODES")
     assert len(res) == 1
-    info = res['127.0.0.2:6379@6379']
+    info = res['127.0.0.2:6379']
     assert res is not None
     assert info['connected'] == False
     assert info['epoch'] == '1'

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -1,11 +1,10 @@
 import random
 import pytest
 import asyncio
-import aioredis
+from redis import asyncio as aioredis
 import async_timeout
 
 from . import DflyInstance
-
 
 async def run_monitor_eval(monitor, expected):
     async with monitor as mon:

--- a/tests/dragonfly/eval_test.py
+++ b/tests/dragonfly/eval_test.py
@@ -1,5 +1,5 @@
-import aioredis
 import asyncio
+from redis import asyncio as aioredis
 import time
 import json
 import pytest

--- a/tests/dragonfly/generic_test.py
+++ b/tests/dragonfly/generic_test.py
@@ -1,6 +1,8 @@
 import os
-import aioredis
 import pytest
+import redis
+from redis import asyncio as aioredis
+
 from . import dfly_multi_test_args
 from .utility import batch_fill_data, gen_test_data
 
@@ -27,7 +29,7 @@ async def test_password(df_local_factory, export_dfly_password):
     dfly.start()
 
     # Expect password form environment variable
-    with pytest.raises(aioredis.exceptions.AuthenticationError):
+    with pytest.raises(redis.exceptions.AuthenticationError):
         client = aioredis.Redis()
         await client.ping()
     client = aioredis.Redis(password=export_dfly_password)
@@ -40,7 +42,7 @@ async def test_password(df_local_factory, export_dfly_password):
     dfly.start()
 
     # Expect password form flag
-    with pytest.raises(aioredis.exceptions.ResponseError):
+    with pytest.raises(redis.exceptions.AuthenticationError):
         client = aioredis.Redis(password=export_dfly_password)
         await client.ping()
     client = aioredis.Redis(password=requirepass)

--- a/tests/dragonfly/json_test.py
+++ b/tests/dragonfly/json_test.py
@@ -1,6 +1,6 @@
 import pytest
 import redis
-from redis.commands.json.path import Path
+from redis import asyncio as aioredis
 from .utility import *
 from json import JSONDecoder, JSONEncoder
 
@@ -45,7 +45,7 @@ async def test_access_json_value_as_string(async_client: aioredis.Redis):
     try:
         result = await async_client.get(key_name)
         assert False, "should not be able to access JSON value as string"
-    except aioredis.exceptions.ResponseError as e:
+    except redis.exceptions.ResponseError as e:
         assert e.args[0] == "WRONGTYPE Operation against a key holding the wrong kind of value"
 
 
@@ -89,6 +89,6 @@ async def test_update_value(async_client: aioredis.Redis):
         await get_set_json(async_client, value="0", key=key_name,
                            path="$.a.*")
         assert False, "should not be able to modify JSON value as string"
-    except aioredis.exceptions.ResponseError as e:
+    except redis.exceptions.ResponseError as e:
         assert e.args[0] == "WRONGTYPE Operation against a key holding the wrong kind of value"
     assert await async_client.type(key_name) == "string"

--- a/tests/dragonfly/list_family_test.py
+++ b/tests/dragonfly/list_family_test.py
@@ -1,5 +1,5 @@
 import asyncio
-import aioredis
+from redis import asyncio as aioredis
 
 import pytest
 

--- a/tests/dragonfly/redis_replicaiton_test.py
+++ b/tests/dragonfly/redis_replicaiton_test.py
@@ -1,7 +1,7 @@
 import time
 import pytest
 import asyncio
-import aioredis
+from redis import asyncio as aioredis
 import subprocess
 from .utility import *
 

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1,14 +1,12 @@
-
-import pytest
-import asyncio
-import aioredis
 import random
 from itertools import chain, repeat
 import re
-
+import pytest
+import asyncio
+import redis
+from redis import asyncio as aioredis
 from .utility import *
 from . import DflyInstanceFactory, dfly_args
-
 
 BASE_PORT = 1111
 
@@ -414,7 +412,7 @@ async def test_cancel_replication_immediately(df_local_factory, df_seeder_factor
             # Giving replication commands shouldn't hang.
             assert time.time() - start < 2.0
             return True
-        except aioredis.exceptions.ResponseError as e:
+        except redis.exceptions.ResponseError as e:
             assert e.args[0] == "replication cancelled"
             return False
 

--- a/tests/dragonfly/requirements.txt
+++ b/tests/dragonfly/requirements.txt
@@ -10,6 +10,6 @@ pytest==7.1.2
 redis==4.5.3
 tomli==2.0.1
 wrapt==1.14.1
-aioredis==2.0.1
+redis==4.5.0
 pytest-asyncio==0.20.1
 pytest-repeat==0.9.1

--- a/tests/dragonfly/sentinel_test.py
+++ b/tests/dragonfly/sentinel_test.py
@@ -1,7 +1,7 @@
 import pathlib
 import subprocess
 from typing import Awaitable
-import aioredis
+from redis import asyncio as aioredis
 import pytest
 import time
 import asyncio

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -2,9 +2,8 @@ import time
 import pytest
 import os
 import glob
-import aioredis
+from redis import asyncio as aioredis
 from pathlib import Path
-import aioredis
 
 from . import dfly_args
 from .utility import DflySeeder, wait_available_async

--- a/tests/dragonfly/utility.py
+++ b/tests/dragonfly/utility.py
@@ -1,7 +1,7 @@
-import aioredis
 import itertools
 import sys
 import asyncio
+from redis import asyncio as aioredis
 import random
 import string
 import itertools


### PR DESCRIPTION
aioredis is deprecated and recommends to transition to redis-py. New modules like redis search are supported only there 

Fixes #1190 

There is also some kind of new issue with cluster client disconnects on redis-py 5.4 😵 For some reason it's still counted as alive even when the connection pool is closed, so I had to disable connection checks with cluster clients