### PR TITLE
fix(replication): Don't open a replication flow in non-shard threads

### DIFF
--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -45,7 +45,7 @@ class JournalStreamer;
 //    access.
 //
 // Upon first connection from the replica, a new ReplicaInfo is created.
-// It tranistions through the following phases:
+// It transitions through the following phases:
 //  1. Preparation
 //    During this start phase the "flows" are set up - one connection for every master thread. Those
 //    connections registered by the FLOW command sent from each newly opened connection.
@@ -130,7 +130,7 @@ class DflyCmd {
   void Shutdown();
 
   // Create new sync session.
-  uint32_t CreateSyncSession(ConnectionContext* cntx);
+  std::pair<uint32_t, std::shared_ptr<ReplicaInfo>> CreateSyncSession(ConnectionContext* cntx);
 
   std::vector<ReplicaRoleInfo> GetReplicasRoleInfo();
 

--- a/src/server/engine_shard_set.h
+++ b/src/server/engine_shard_set.h
@@ -264,11 +264,13 @@ class EngineShardSet {
   }
 
   // Runs a brief function on all shards. Waits for it to complete.
+  // `func` must not preempt.
   template <typename U> void RunBriefInParallel(U&& func) const {
     RunBriefInParallel(std::forward<U>(func), [](auto i) { return true; });
   }
 
   // Runs a brief function on selected shard thread. Waits for it to complete.
+  // `func` must not preempt.
   template <typename U, typename P> void RunBriefInParallel(U&& func, P&& pred) const;
 
   template <typename U> void RunBlockingInParallel(U&& func);

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -942,7 +942,7 @@ RdbSaver::Impl::Impl(bool align_writes, unsigned producers_len, CompressionMode 
     aligned_buf_.emplace(kBufLen, sink);
     sink_ = &aligned_buf_.value();
   }
-  if (sm == SaveMode::SINGLE_SHARD) {
+  if (sm == SaveMode::SINGLE_SHARD || sm == SaveMode::SINGLE_SHARD_WITH_SUMMARY) {
     push_to_sink_with_order_ = true;
   }
 
@@ -1098,6 +1098,7 @@ RdbSaver::RdbSaver(::io::Sink* sink, SaveMode save_mode, bool align_writes) {
       }
       break;
     case SaveMode::SINGLE_SHARD:
+    case SaveMode::SINGLE_SHARD_WITH_SUMMARY:
       producer_count = 1;
       if (compression_mode == 3) {
         compression_mode_ = CompressionMode::MULTY_ENTRY_LZ4;

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -58,9 +58,11 @@ class AlignedBuffer : public ::io::Sink {
 
 // SaveMode for snapshot. Used by RdbSaver to adjust internals.
 enum class SaveMode {
-  SUMMARY,       // Save only header values (summary.dfs). Expected to read no shards.
-  SINGLE_SHARD,  // Save single shard values (XXXX.dfs). Expected to read one shard.
-  RDB,           // Save .rdb file. Expected to read all shards.
+  SUMMARY,                    // Save only header values (summary.dfs). Expected to read no shards.
+  SINGLE_SHARD,               // Save single shard values (XXXX.dfs). Expected to read one shard.
+  SINGLE_SHARD_WITH_SUMMARY,  // Save single shard value with the global summary. Used in the
+                              // replication's fully sync stage.
+  RDB,                        // Save .rdb file. Expected to read all shards.
 };
 
 enum class CompressionMode { NONE, SINGLE_ENTRY, MULTY_ENTRY_ZSTD, MULTY_ENTRY_LZ4 };


### PR DESCRIPTION
We would create a connection per thread, not per shard thread. The PR changes it to replicate only over shard.

I'm pretty sure we don't send anything over that connection, and now that I switch to absolute offsets instead of per-replication offsets it was awkward to handle offsets without having an actual shard.