### PR TITLE
fix(docker): Install libxml2 as part of ubuntu Dockerfile

### DIFF
--- a/tools/docker/Dockerfile.ubuntu-prod
+++ b/tools/docker/Dockerfile.ubuntu-prod
@@ -21,7 +21,7 @@ FROM ubuntu:20.04
 ARG QEMU_CPU
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt clean && apt update && apt -y install netcat-openbsd ca-certificates redis-tools
+RUN apt clean && apt update && apt -y install netcat-openbsd ca-certificates redis-tools libxml2
 
 
 RUN groupadd -r -g 999 dfly && useradd -r -g dfly -u 999 dfly


### PR DESCRIPTION
Fixes https://github.com/dragonflydb/dragonfly/issues/1238
