### PR TITLE
feat(cluster): cluster config delete now owned slots data

### DIFF
--- a/src/server/cluster/cluster_config.h
+++ b/src/server/cluster/cluster_config.h
@@ -63,7 +63,7 @@ class ClusterConfig {
 
   ClusterShards GetConfig() const;
 
-  // Returns Deleted slots set if `new_config` is valid and internal state was changed. Returns
+  // Returns deleted slot set if `new_config` is valid and internal state was changed. Returns
   // nullopt and changes nothing otherwise.
   std::optional<SlotSet> SetConfig(const ClusterShards& new_config);
 

--- a/src/server/cluster/cluster_config.h
+++ b/src/server/cluster/cluster_config.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <absl/base/thread_annotations.h>
+#include <absl/container/flat_hash_set.h>
 
 #include <array>
 #include <optional>
@@ -17,6 +18,7 @@
 namespace dfly {
 
 using SlotId = uint16_t;
+using SlotSet = absl::flat_hash_set<SlotId>;
 
 class ClusterConfig {
  public:
@@ -61,12 +63,12 @@ class ClusterConfig {
 
   ClusterShards GetConfig() const;
 
-  // Returns true if `new_config` is valid and internal state was changed. Returns false and changes
-  // nothing otherwise.
-  bool SetConfig(const ClusterShards& new_config);
+  // Returns Deleted slots set if `new_config` is valid and internal state was changed. Returns
+  // nullopt and changes nothing otherwise.
+  std::optional<SlotSet> SetConfig(const ClusterShards& new_config);
 
   // Parses `json` into `ClusterShards` and calls the above overload.
-  bool SetConfig(const JsonType& json);
+  std::optional<SlotSet> SetConfig(const JsonType& json);
 
  private:
   struct SlotEntry {

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -285,7 +285,7 @@ void ClusterFamily::DflyClusterConfig(CmdArgList args, ConnectionContext* cntx) 
   }
 
   auto deleted_slot_ids = cluster_config_->SetConfig(json.value());
-  if (!deleted_slot_ids) {
+  if (!deleted_slot_ids.has_value()) {
     return rb->SendError("Invalid cluster configuration.");
   }
 

--- a/src/server/cluster_config_test.cc
+++ b/src/server/cluster_config_test.cc
@@ -12,6 +12,7 @@
 #include "base/logging.h"
 
 using namespace std;
+using namespace testing;
 using Node = dfly::ClusterConfig::Node;
 
 namespace dfly {
@@ -138,7 +139,7 @@ TEST_F(ClusterConfigTest, ConfigSetGetDeletedSlots) {
                           .master = {.id = "other-master2", .ip = "192.168.0.104", .port = 7004},
                           .replicas = {}}});
 
-  EXPECT_TRUE(ds);
+  EXPECT_TRUE(ds.has_value());
   EXPECT_TRUE(ds.value().empty());  // On first config set no deleted slots.
 
   ds = config_.SetConfig({{.slot_ranges = {{.start = 0, .end = 6'000}},
@@ -151,7 +152,7 @@ TEST_F(ClusterConfigTest, ConfigSetGetDeletedSlots) {
                            .master = {.id = "other-master2", .ip = "192.168.0.104", .port = 7004},
                            .replicas = {}}});
 
-  EXPECT_TRUE(ds);
+  EXPECT_TRUE(ds.has_value());
   EXPECT_TRUE(ds.value().empty());  // On second config no slots taken from ownership
 
   ds = config_.SetConfig({{.slot_ranges = {{.start = 0, .end = 5'997}},
@@ -164,11 +165,8 @@ TEST_F(ClusterConfigTest, ConfigSetGetDeletedSlots) {
                            .master = {.id = "other-master2", .ip = "192.168.0.104", .port = 7004},
                            .replicas = {}}});
 
-  EXPECT_TRUE(ds);
-  EXPECT_FALSE(ds.value().empty());
-  EXPECT_TRUE(ds.value().contains(5'998));
-  EXPECT_TRUE(ds.value().contains(5'999));
-  EXPECT_TRUE(ds.value().contains(6'000));
+  EXPECT_TRUE(ds.has_value());
+  EXPECT_THAT(ds.value(), UnorderedElementsAre(5'998, 5'999, 6'000));
 }
 
 TEST_F(ClusterConfigTest, ConfigSetInvalidSlotRanges) {

--- a/src/server/cluster_config_test.cc
+++ b/src/server/cluster_config_test.cc
@@ -126,6 +126,51 @@ TEST_F(ClusterConfigTest, ConfigSetMultipleInstances) {
   }
 }
 
+TEST_F(ClusterConfigTest, ConfigSetGetDeletedSlots) {
+  auto ds =
+      config_.SetConfig({{.slot_ranges = {{.start = 0, .end = 5'000}},
+                          .master = {.id = kMyId, .ip = "192.168.0.100", .port = 7000},
+                          .replicas = {}},
+                         {.slot_ranges = {{.start = 5'001, .end = 10'000}},
+                          .master = {.id = "other-master", .ip = "192.168.0.102", .port = 7002},
+                          .replicas = {}},
+                         {.slot_ranges = {{.start = 10'001, .end = 0x3FFF}},
+                          .master = {.id = "other-master2", .ip = "192.168.0.104", .port = 7004},
+                          .replicas = {}}});
+
+  EXPECT_TRUE(ds);
+  EXPECT_TRUE(ds.value().empty());  // On first config set no deleted slots.
+
+  ds = config_.SetConfig({{.slot_ranges = {{.start = 0, .end = 6'000}},
+                           .master = {.id = kMyId, .ip = "192.168.0.100", .port = 7000},
+                           .replicas = {}},
+                          {.slot_ranges = {{.start = 6'001, .end = 10'000}},
+                           .master = {.id = "other-master", .ip = "192.168.0.102", .port = 7002},
+                           .replicas = {}},
+                          {.slot_ranges = {{.start = 10'001, .end = 0x3FFF}},
+                           .master = {.id = "other-master2", .ip = "192.168.0.104", .port = 7004},
+                           .replicas = {}}});
+
+  EXPECT_TRUE(ds);
+  EXPECT_TRUE(ds.value().empty());  // On second config no slots taken from ownership
+
+  ds = config_.SetConfig({{.slot_ranges = {{.start = 0, .end = 5'997}},
+                           .master = {.id = kMyId, .ip = "192.168.0.100", .port = 7000},
+                           .replicas = {}},
+                          {.slot_ranges = {{.start = 5'998, .end = 10'000}},
+                           .master = {.id = "other-master", .ip = "192.168.0.102", .port = 7002},
+                           .replicas = {}},
+                          {.slot_ranges = {{.start = 10'001, .end = 0x3FFF}},
+                           .master = {.id = "other-master2", .ip = "192.168.0.104", .port = 7004},
+                           .replicas = {}}});
+
+  EXPECT_TRUE(ds);
+  EXPECT_FALSE(ds.value().empty());
+  EXPECT_TRUE(ds.value().contains(5'998));
+  EXPECT_TRUE(ds.value().contains(5'999));
+  EXPECT_TRUE(ds.value().contains(6'000));
+}
+
 TEST_F(ClusterConfigTest, ConfigSetInvalidSlotRanges) {
   // Note that slot_ranges is not an object
   EXPECT_FALSE(config_.SetConfig(ParseJson(R"json(

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <absl/container/flat_hash_set.h>
-
 #include "facade/op_status.h"
 #include "server/common.h"
 #include "server/conn_context.h"
@@ -210,7 +208,6 @@ class DbSlice {
    */
   void FlushDb(DbIndex db_ind);
 
-  using SlotSet = absl::flat_hash_set<SlotId>;
   // Flushes the data of given slot ids.
   void FlushSlots(SlotSet slot_ids);
 


### PR DESCRIPTION
On config update we check what are the deleted slots and delete the db data of deleted slots

testing:
I checked the config command deletes slots data manually
I want to add a unit test for it , but now I understand that I need a command for the node id to implement the test, so I will create it in a new PR once you merge your cluster family PR changes.