### PR TITLE
feat: Report replication lag in INFO REPLICATION

### DIFF
--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -64,8 +64,8 @@ struct TransactionGuard {
 }  // namespace
 
 DflyCmd::ReplicaRoleInfo::ReplicaRoleInfo(std::string address, uint32_t listening_port,
-                                          SyncState sync_state)
-    : address(address), listening_port(listening_port) {
+                                          SyncState sync_state, uint64_t lag)
+    : address(address), listening_port(listening_port), lag(lag) {
   switch (sync_state) {
     case SyncState::PREPARATION:
       state = "preparation";
@@ -553,9 +553,12 @@ shared_ptr<DflyCmd::ReplicaInfo> DflyCmd::GetReplicaInfo(uint32_t sync_id) {
 std::vector<DflyCmd::ReplicaRoleInfo> DflyCmd::GetReplicasRoleInfo() {
   std::vector<ReplicaRoleInfo> vec;
   unique_lock lk(mu_);
+
+  auto replication_lags = ReplicationLags();
+
   for (const auto& info : replica_infos_) {
     vec.emplace_back(info.second->address, info.second->listening_port,
-                     info.second->state.load(memory_order_relaxed));
+                     info.second->state.load(memory_order_relaxed), replication_lags[info.first]);
   }
   return vec;
 }
@@ -577,6 +580,39 @@ pair<uint32_t, shared_ptr<DflyCmd::ReplicaInfo>> DflyCmd::GetReplicaInfoOrReply(
   }
 
   return {sync_id, sync_it->second};
+}
+
+std::map<uint32_t, LSN> DflyCmd::ReplicationLags() const {
+  if (replica_infos_.empty())
+    return {};
+
+  // In each shard we calculate a vector of replication lags for all replicas.
+  std::vector<std::vector<uint64_t>> shard_lags(shard_set->size());
+  shard_set->RunBriefInParallel([&shard_lags, this](EngineShard* shard) {
+    auto& lags = shard_lags[shard->shard_id()];
+    lags.reserve(replica_infos_.size());
+    for (const auto& info : replica_infos_) {
+      int64_t lag = shard->journal()->GetLsn() - info.second->flows[shard->shard_id()].last_ack;
+      DCHECK(lag >= 0);
+      lags.push_back(lag);
+    }
+  });
+
+  // Then we accumulate the lags in each shard and calculate the maximal lag for each replica.
+  std::vector<uint64_t> max_lags(shard_set->size());
+  for (const auto& lags : shard_lags) {
+    std::transform(max_lags.begin(), max_lags.end(), lags.begin(), max_lags.begin(),
+                   [](uint64_t a, uint64_t b) { return std::max(a, b); });
+  }
+
+  // And map it back into a replication ID.
+  size_t i = 0;
+  std::map<uint32_t, LSN> rv;
+  for (const auto& info : replica_infos_) {
+    rv[info.first] = max_lags[i];
+    i++;
+  }
+  return rv;
 }
 
 bool DflyCmd::CheckReplicaStateOrReply(const ReplicaInfo& sync_info, SyncState expected,

--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -114,11 +114,11 @@ class DflyCmd {
 
   struct ReplicaRoleInfo {
     ReplicaRoleInfo(std::string address, uint32_t listening_port, SyncState sync_state,
-                    uint64_t lag);
+                    uint64_t lsn_lag);
     std::string address;
     uint32_t listening_port;
     std::string state;
-    uint64_t lag;
+    uint64_t lsn_lag;
   };
 
  public:

--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -113,10 +113,12 @@ class DflyCmd {
   };
 
   struct ReplicaRoleInfo {
-    ReplicaRoleInfo(std::string address, uint32_t listening_port, SyncState sync_state);
+    ReplicaRoleInfo(std::string address, uint32_t listening_port, SyncState sync_state,
+                    uint64_t lag);
     std::string address;
     uint32_t listening_port;
     std::string state;
+    uint64_t lag;
   };
 
  public:
@@ -193,6 +195,10 @@ class DflyCmd {
   // Check replica is in expected state and flows are set-up correctly.
   bool CheckReplicaStateOrReply(const ReplicaInfo& ri, SyncState expected,
                                 facade::RedisReplyBuilder* rb);
+
+  // Return a map between replication ID to lag. lag is defined as the maximum of difference
+  // between the master's LSN and the last acknowledged LSN in over all shards.
+  std::map<uint32_t, LSN> ReplicationLags() const;
 
  private:
   ServerFamily* sf_;  // Not owned

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -26,6 +26,7 @@ extern "C" {
 #include "server/rdb_load.h"
 #include "strings/human_readable.h"
 
+ABSL_FLAG(int, replication_acks_interval, 3000, "Interval between acks in milliseconds.");
 ABSL_FLAG(bool, enable_multi_shard_sync, false,
           "Execute multi shards commands on replica syncrhonized");
 ABSL_FLAG(std::string, masterauth, "", "password for authentication with master");
@@ -977,7 +978,8 @@ void Replica::StableSyncDflyReadFb(Context* cntx) {
 }
 
 void Replica::StableSyncDflyAcksFb(Context* cntx) {
-  constexpr std::chrono::duration kAckTimeMaxInterval = 3s;
+  constexpr std::chrono::duration ack_time_max_interval =
+      1ms * absl::GetFlag(FLAGS_replication_acks_interval);
   constexpr size_t kAckRecordMaxInterval = 1024;
   std::string ack_cmd;
   ReqSerializer serializer{sock_.get()};
@@ -991,7 +993,7 @@ void Replica::StableSyncDflyAcksFb(Context* cntx) {
     VLOG(1) << "Sending an ACK with offset=" << current_offset << " forced=" << force_ping_;
     ack_cmd = absl::StrCat("REPLCONF ACK ", current_offset);
     force_ping_ = false;
-    next_ack_tp = std::chrono::steady_clock::now() + kAckTimeMaxInterval;
+    next_ack_tp = std::chrono::steady_clock::now() + ack_time_max_interval;
     if (auto ec = SendCommand(ack_cmd, &serializer); ec) {
       cntx->ReportError(ec);
       break;

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -978,9 +978,9 @@ void Replica::StableSyncDflyReadFb(Context* cntx) {
 }
 
 void Replica::StableSyncDflyAcksFb(Context* cntx) {
-  constexpr std::chrono::duration ack_time_max_interval =
-      1ms * absl::GetFlag(FLAGS_replication_acks_interval);
   constexpr size_t kAckRecordMaxInterval = 1024;
+  std::chrono::duration ack_time_max_interval =
+      1ms * absl::GetFlag(FLAGS_replication_acks_interval);
   std::string ack_cmd;
   ReqSerializer serializer{sock_.get()};
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1629,7 +1629,7 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
         auto& r = replicas[i];
         // e.g. slave0:ip=172.19.0.3,port=6379,state=full_sync
         append(StrCat("slave", i), StrCat("ip=", r.address, ",port=", r.listening_port,
-                                          ",state=", r.state, ",lag=", r.lag));
+                                          ",state=", r.state, ",lag=", r.lsn_lag));
       }
       append("master_replid", master_id_);
     } else {

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1628,8 +1628,8 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
       for (size_t i = 0; i < replicas.size(); i++) {
         auto& r = replicas[i];
         // e.g. slave0:ip=172.19.0.3,port=6379,state=full_sync
-        append(StrCat("slave", i),
-               StrCat("ip=", r.address, ",port=", r.listening_port, ",state=", r.state));
+        append(StrCat("slave", i), StrCat("ip=", r.address, ",port=", r.listening_port,
+                                          ",state=", r.state, ",lag=", r.lag));
       }
       append("master_replid", master_id_);
     } else {

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -900,3 +900,46 @@ async def test_role_command(df_local_factory, n_keys=20):
 
     await c_master.connection_pool.disconnect()
     await c_replica.connection_pool.disconnect()
+
+
+def parse_lag(replication_info: bytes):
+    lags = re.findall(b"lag=([0-9]+)\r\n", replication_info)
+    assert len(lags) == 1
+    return int(lags[0])
+
+
+async def assert_lag_condition(client, condition):
+    for _ in range(10):
+        lag = parse_lag(await client.execute_command("info replication"))
+        if condition(lag):
+            break
+        print("current lag =", lag)
+        time.sleep(0.05)
+    else:
+        assert False, "Lag has never satisfied condition!"
+
+
+@dfly_args({"proactor_threads": 2})
+@pytest.mark.asyncio
+async def test_replication_info(df_local_factory, df_seeder_factory, n_keys=2000):
+    master = df_local_factory.create(port=BASE_PORT)
+    replica = df_local_factory.create(
+        port=BASE_PORT+1, logtostdout=True, replication_acks_interval=100)
+    df_local_factory.start_all([master, replica])
+    c_master = aioredis.Redis(port=master.port)
+    c_replica = aioredis.Redis(port=replica.port)
+
+    await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
+    await wait_available_async(c_replica)
+    await assert_lag_condition(c_master, lambda lag: lag == 0)
+
+    seeder = df_seeder_factory.create(port=master.port, keys=n_keys, dbcount=2)
+    fill_task = asyncio.create_task(seeder.run(target_ops=300))
+    await assert_lag_condition(c_master, lambda lag: lag > 30)
+
+    await fill_task
+    await wait_available_async(c_replica)
+    await assert_lag_condition(c_master, lambda lag: lag == 0)
+
+    await c_master.connection_pool.disconnect()
+    await c_replica.connection_pool.disconnect()


### PR DESCRIPTION
Add a 'lag=LAG' field to `INFO REPLICATION`.

The lag is defined to be the maximal difference over all the shards between master's LSN and acknowledged LSNs from replica. A flag to control PING interval was added to improve testing stability.