### PR TITLE
fix(stream): avoid using designated initializer

### DIFF
--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -543,11 +543,11 @@ OpResult<streamID> OpAdd(const OpArgs& op_args, string_view key, const AddOpts& 
       streamTrimByID(stream_inst, opts.minid.val, opts.trim_approx);
     }
   } else {
-    streamAddTrimArgs add_args = {
-        .trim_strategy = static_cast<int>(opts.trim_strategy),
-        .approx_trim = opts.trim_approx,
-        .limit = opts.limit,
-    };
+    streamAddTrimArgs add_args = {0};
+    add_args.trim_strategy = static_cast<int>(opts.trim_strategy);
+    add_args.approx_trim = opts.trim_approx;
+    add_args.limit = opts.limit;
+
     if (opts.trim_strategy == TrimStrategy::kAddOptsTrimMaxLen) {
       add_args.maxlen = opts.max_len;
     } else if (opts.trim_strategy == TrimStrategy::kAddOptsTrimMinId) {


### PR DESCRIPTION
Following the [comment](https://github.com/dragonflydb/dragonfly/pull/1201#issuecomment-1552640507), a warning is popping up while building the `stream_family.cc` file.

```
[19/37] Building CXX object src/server/CMakeFiles/dragonfly_lib.dir/stream_family.cc.o
/home/roy/work/dragonfly/src/server/stream_family.cc: In function ‘facade::OpResult<streamID> dfly::{anonymous}::OpAdd(const dfly::OpArgs&, std::string_view, const dfly::{anonymous}::AddOpts&, facade::CmdArgList)’:
/home/roy/work/dragonfly/src/server/stream_family.cc:543:5: warning: missing initializer for member ‘streamAddTrimArgs::id’ [-Wmissing-field-initializers]
  543 |     };
      |     ^
/home/roy/work/dragonfly/src/server/stream_family.cc:543:5: warning: missing initializer for member ‘streamAddTrimArgs::id_given’ [-Wmissing-field-initializers]
/home/roy/work/dragonfly/src/server/stream_family.cc:543:5: warning: missing initializer for member ‘streamAddTrimArgs::seq_given’ [-Wmissing-field-initializers]
[...]
```

It is because a designated initializer is used to initialize a `streamAddTrimArgs` type variable. The `-Wmissing-field-initializers` throws a warning if all the struct fields are not initialized while using a designated initializer.

In our case, we don't need to set other fields as they are mainly used for redis's internal `xadd` implementation specific fields and are not used in `streamTrim` function.