### PR TITLE
fix: S3 writes are now working with new format as well

### DIFF
--- a/src/core/fibers.h
+++ b/src/core/fibers.h
@@ -5,8 +5,6 @@
 
 // An import header that centralizes all the imports from helio project regarding fibers
 
-#ifdef USE_FB2
-
 #include "util/fibers/fiber2.h"
 #include "util/fibers/fiberqueue_threadpool.h"
 #include "util/fibers/future.h"
@@ -33,32 +31,3 @@ using util::fb2::SimpleChannel;
 namespace util {
 using fb2::SharedMutex;
 }
-
-#else
-
-#include "util/fiber_sched_algo.h"
-#include "util/fibers/event_count.h"
-#include "util/fibers/fiber.h"
-#include "util/fibers/fiberqueue_threadpool.h"
-#include "util/fibers/fibers_ext.h"
-#include "util/fibers/simple_channel.h"
-
-namespace dfly {
-
-using util::fibers_ext::Barrier;
-using util::fibers_ext::BlockingCounter;
-using util::fibers_ext::Done;
-using util::fibers_ext::EventCount;
-using util::fibers_ext::Fiber;
-using util::fibers_ext::FiberQueue;
-using util::fibers_ext::FiberQueueThreadPool;
-using util::fibers_ext::Future;
-using util::fibers_ext::Launch;
-using util::fibers_ext::Mutex;
-using util::fibers_ext::Promise;
-using util::fibers_ext::SimpleChannel;
-using CondVar = ::boost::fibers::condition_variable;
-
-}  // namespace dfly
-
-#endif

--- a/src/core/uring.h
+++ b/src/core/uring.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#ifdef USE_FB2
-
 #include "util/fibers/uring_proactor.h"
 #include "util/uring/uring_file.h"
 namespace dfly {
@@ -16,17 +14,3 @@ using util::fb2::OpenLinux;
 using util::fb2::OpenRead;
 
 }  // namespace dfly
-
-#else
-#include "util/uring/proactor.h"
-#include "util/uring/uring_file.h"
-
-namespace dfly {
-
-using util::uring::FiberCall;
-using util::uring::LinuxFile;
-using util::uring::OpenLinux;
-using util::uring::OpenRead;
-
-}  // namespace dfly
-#endif

--- a/src/facade/dragonfly_listener.h
+++ b/src/facade/dragonfly_listener.h
@@ -25,12 +25,12 @@ class Listener : public util::ListenerInterface {
   std::error_code ConfigureServerSocket(int fd) final;
 
  private:
-  util::Connection* NewConnection(util::ProactorBase* proactor) final;
-  util::ProactorBase* PickConnectionProactor(util::LinuxSocketBase* sock) final;
+  util::Connection* NewConnection(ProactorBase* proactor) final;
+  ProactorBase* PickConnectionProactor(util::LinuxSocketBase* sock) final;
 
   void OnConnectionStart(util::Connection* conn) final;
   void OnConnectionClose(util::Connection* conn) final;
-  void PreAcceptLoop(util::ProactorBase* pb) final;
+  void PreAcceptLoop(ProactorBase* pb) final;
 
   void PreShutdown() final;
 

--- a/src/server/io_mgr.cc
+++ b/src/server/io_mgr.cc
@@ -19,15 +19,9 @@ using namespace std;
 using namespace util;
 using namespace facade;
 
-#ifdef USE_FB2
 using Proactor = fb2::UringProactor;
 using fb2::ProactorBase;
 using fb2::SubmitEntry;
-
-#else
-using uring::Proactor;
-using uring::SubmitEntry;
-#endif
 
 namespace {
 


### PR DESCRIPTION
1. Refactor snapshot saving logic, specifically, build the full path once for both versions.
2. Pull the newest version of helio, where many s3 bugs are fixed.
3. Include some cleanups because helio now does not contain Boost.Fibers implementation anymore.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->