### PR TITLE
fix: fix dispatch ordering

### DIFF
--- a/src/facade/conn_context.h
+++ b/src/facade/conn_context.h
@@ -45,13 +45,16 @@ class ConnectionContext {
   }
 
   // connection state / properties.
-  bool async_dispatch : 1;  // whether this connection is currently handled by dispatch fiber.
   bool conn_closing : 1;
   bool req_auth : 1;
   bool replica_conn : 1;
   bool authenticated : 1;
-  bool force_dispatch : 1;    // whether we should route all requests to the dispatch fiber.
-  bool journal_emulated : 1;  // whether it is used to dispatch journal commands.
+  bool async_dispatch : 1;    // whether this connection is amid an async dispatch
+  bool sync_dispatch : 1;     // whether this connection is amid a sync dispatch
+  bool journal_emulated : 1;  // whether it is used to dispatch journal commands
+
+  // How many async subscription sources are active: monitor and/or pubsub - at most 2.
+  uint8_t subscriptions;
 
  private:
   Connection* owner_;

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -198,7 +198,7 @@ void Connection::DispatchOperations::operator()(const PubMessage& pub_msg) {
   RedisReplyBuilder* rbuilder = (RedisReplyBuilder*)builder;
   ++stats->async_writes_cnt;
   unsigned i = 0;
-  string_view arr[4];
+  array<string_view, 4> arr;
   if (pub_msg.pattern.empty()) {
     arr[i++] = "message";
   } else {
@@ -207,7 +207,8 @@ void Connection::DispatchOperations::operator()(const PubMessage& pub_msg) {
   }
   arr[i++] = pub_msg.Channel();
   arr[i++] = pub_msg.Message();
-  rbuilder->SendStringArr(absl::Span<string_view>{arr, i}, RedisReplyBuilder::CollectionType::PUSH);
+  rbuilder->SendStringArr(absl::Span<string_view>{arr.data(), i},
+                          RedisReplyBuilder::CollectionType::PUSH);
   VLOG(0) << "Sent data";
 }
 

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -102,18 +102,14 @@ struct Connection::Shutdown {
 
 Connection::PubMessage::PubMessage(string pattern, shared_ptr<char[]> buf, size_t channel_len,
                                    size_t message_len)
-    : data{MessageData{pattern, move(buf), channel_len, message_len}} {
+    : pattern{move(pattern)}, buf{move(buf)}, channel_len{channel_len}, message_len{message_len} {
 }
 
-Connection::PubMessage::PubMessage(bool add, string_view channel, uint32_t channel_cnt)
-    : data{SubscribeData{add, string{channel}, channel_cnt}} {
-}
-
-string_view Connection::PubMessage::MessageData::Channel() const {
+string_view Connection::PubMessage::Channel() const {
   return {buf.get(), channel_len};
 }
 
-string_view Connection::PubMessage::MessageData::Message() const {
+string_view Connection::PubMessage::Message() const {
   return {buf.get() + channel_len, message_len};
 }
 
@@ -179,8 +175,7 @@ template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
 size_t Connection::MessageHandle::UsedMemory() const {
   // TODO: don't count inline size
   auto pub_size = [](const PubMessage& msg) -> size_t {
-    const auto* md = get_if<PubMessage::MessageData>(&msg.data);
-    return sizeof(PubMessage) + (md ? (md->channel_len + md->message_len) : 0u);
+    return sizeof(PubMessage) + (msg.channel_len + msg.message_len);
   };
   auto msg_size = [](const PipelineMessage& arg) -> size_t {
     return sizeof(PipelineMessage) + arg.args.capacity() * sizeof(MutableSlice) +
@@ -202,28 +197,18 @@ void Connection::DispatchOperations::operator()(const MonitorMessage& msg) {
 void Connection::DispatchOperations::operator()(const PubMessage& pub_msg) {
   RedisReplyBuilder* rbuilder = (RedisReplyBuilder*)builder;
   ++stats->async_writes_cnt;
-  auto send_msg = [rbuilder](const PubMessage::MessageData& data) {
-    unsigned i = 0;
-    string_view arr[4];
-    if (data.pattern.empty()) {
-      arr[i++] = "message";
-    } else {
-      arr[i++] = "pmessage";
-      arr[i++] = data.pattern;
-    }
-    arr[i++] = data.Channel();
-    arr[i++] = data.Message();
-    rbuilder->SendStringArr(absl::Span<string_view>{arr, i},
-                            RedisReplyBuilder::CollectionType::PUSH);
-  };
-  auto send_sub = [rbuilder](const PubMessage::SubscribeData& data) {
-    const char* action[2] = {"unsubscribe", "subscribe"};
-    rbuilder->StartCollection(3, RedisReplyBuilder::CollectionType::PUSH);
-    rbuilder->SendBulkString(action[data.add]);
-    rbuilder->SendBulkString(data.channel);
-    rbuilder->SendLong(data.channel_cnt);
-  };
-  visit(Overloaded{send_msg, send_sub}, pub_msg.data);
+  unsigned i = 0;
+  string_view arr[4];
+  if (pub_msg.pattern.empty()) {
+    arr[i++] = "message";
+  } else {
+    arr[i++] = "pmessage";
+    arr[i++] = pub_msg.pattern;
+  }
+  arr[i++] = pub_msg.Channel();
+  arr[i++] = pub_msg.Message();
+  rbuilder->SendStringArr(absl::Span<string_view>{arr, i}, RedisReplyBuilder::CollectionType::PUSH);
+  VLOG(0) << "Sent data";
 }
 
 void Connection::DispatchOperations::operator()(Connection::PipelineMessage& msg) {
@@ -231,10 +216,8 @@ void Connection::DispatchOperations::operator()(Connection::PipelineMessage& msg
 
   DVLOG(2) << "Dispatching pipeline: " << ToSV(msg.args.front());
 
-  self->cc_->async_dispatch = true;
   self->service_->DispatchCommand(CmdArgList{msg.args.data(), msg.args.size()}, self->cc_.get());
   self->last_interaction_ = time(nullptr);
-  self->cc_->async_dispatch = false;
 }
 
 Connection::Connection(Protocol protocol, util::HttpListenerBase* http_listener, SSL_CTX* ctx,
@@ -542,7 +525,44 @@ void Connection::ConnectionFlow(FiberSocketBase* peer) {
   --stats_->num_conns;
 }
 
-auto Connection::ParseRedis() -> ParserStatus {
+void Connection::DispatchCommand(uint32_t consumed, mi_heap_t* heap) {
+  bool can_dispatch_sync = (consumed >= io_buf_.InputLen());
+
+  // Avoid sync dispatch if an async dispatch is already in progress, or else they'll interleave.
+  if (cc_->async_dispatch)
+    can_dispatch_sync = false;
+
+  // Avoid sync dispatch if we already have pending async messages or
+  // can potentially receive some (subscriptions > 0). Otherwise the dispatch
+  // fiber might be constantly blocked by sync_dispatch.
+  if (dispatch_q_.size() > 0 || cc_->subscriptions > 0)
+    can_dispatch_sync = false;
+
+  if (can_dispatch_sync) {
+    ShrinkPipelinePool();  // Gradually release pipeline request pool.
+
+    RespToArgList(tmp_parse_args_, &tmp_cmd_vec_);
+
+    {
+      cc_->sync_dispatch = true;
+      service_->DispatchCommand(absl::MakeSpan(tmp_cmd_vec_), cc_.get());
+      cc_->sync_dispatch = false;
+    }
+
+    last_interaction_ = time(nullptr);
+
+    // We might have blocked the dispatch queue from processing, wake it up.
+    if (dispatch_q_.size() > 0)
+      evc_.notify();
+
+  } else {
+    SendAsync(MessageHandle{FromArgs(move(tmp_parse_args_), heap)});
+    if (dispatch_q_.size() > 10)
+      ThisFiber::Yield();
+  }
+}
+
+Connection::ParserStatus Connection::ParseRedis() {
   uint32_t consumed = 0;
 
   RedisParser::Result result = RedisParser::OK;
@@ -558,28 +578,7 @@ auto Connection::ParseRedis() -> ParserStatus {
         DVLOG(2) << "Got Args with first token " << ToSV(first.GetBuf());
       }
 
-      // An optimization to skip dispatch_q_ if no pipelining is identified.
-      // We use ASYNC_DISPATCH as a lock to avoid out-of-order replies when the
-      // dispatch fiber pulls the last record but is still processing the command and then this
-      // fiber enters the condition below and executes out of order.
-      bool is_sync_dispatch = !cc_->async_dispatch && !cc_->force_dispatch;
-      if (dispatch_q_.empty() && is_sync_dispatch && consumed >= io_buf_.InputLen()) {
-        // Gradually release the request pool.
-        ShrinkPipelinePool();
-
-        RespToArgList(tmp_parse_args_, &tmp_cmd_vec_);
-
-        DVLOG(2) << "Sync dispatch " << ToSV(tmp_cmd_vec_.front());
-
-        CmdArgList cmd_list{tmp_cmd_vec_.data(), tmp_cmd_vec_.size()};
-        service_->DispatchCommand(cmd_list, cc_.get());
-        last_interaction_ = time(nullptr);
-      } else {
-        // Dispatch via queue to speedup input reading.
-        SendAsync(MessageHandle{FromArgs(move(tmp_parse_args_), tlh)});
-        if (dispatch_q_.size() > 10)
-          ThisFiber::Yield();
-      }
+      DispatchCommand(consumed, tlh);
     }
     io_buf_.ConsumeInput(consumed);
   } while (RedisParser::OK == result && !builder->GetError());
@@ -742,7 +741,8 @@ void Connection::DispatchFiber(util::FiberSocketBase* peer) {
   uint64_t request_cache_limit = absl::GetFlag(FLAGS_request_cache_limit);
 
   while (!builder->GetError()) {
-    evc_.await([this] { return cc_->conn_closing || !dispatch_q_.empty(); });
+    evc_.await(
+        [this] { return cc_->conn_closing || (!dispatch_q_.empty() && !cc_->sync_dispatch); });
     if (cc_->conn_closing)
       break;
 
@@ -751,11 +751,16 @@ void Connection::DispatchFiber(util::FiberSocketBase* peer) {
 
     builder->SetBatchMode(dispatch_q_.size() > 0);
 
-    std::visit(dispatch_op, msg.handle);
+    {
+      cc_->async_dispatch = true;
+      std::visit(dispatch_op, msg.handle);
+      cc_->async_dispatch = false;
+    }
 
     dispatch_q_bytes_.fetch_sub(msg.UsedMemory(), memory_order_relaxed);
     evc_bp_.notify();
 
+    // Retain pipeline message in pool.
     if (auto* pipe = get_if<PipelineMessagePtr>(&msg.handle); pipe) {
       if (stats_->pipeline_cache_capacity < request_cache_limit) {
         stats_->pipeline_cache_capacity += (*pipe)->StorageCapacity();
@@ -859,7 +864,7 @@ void Connection::SendAsync(MessageHandle msg) {
   dispatch_q_bytes_.fetch_add(msg.UsedMemory(), memory_order_relaxed);
 
   dispatch_q_.push_back(move(msg));
-  if (dispatch_q_.size() == 1) {
+  if (dispatch_q_.size() == 1 && !cc_->sync_dispatch) {
     evc_.notify();
   }
 }

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -62,26 +62,13 @@ class Connection : public util::Connection {
 
   // PubSub message, either incoming message for active subscription or reply for new subscription.
   struct PubMessage {
-    // Represents incoming message.
-    struct MessageData {
-      std::string pattern{};            // non-empty for pattern subscriber
-      std::shared_ptr<char[]> buf;      // stores channel name and message
-      size_t channel_len, message_len;  // lengths in buf
+    std::string pattern{};            // non-empty for pattern subscriber
+    std::shared_ptr<char[]> buf;      // stores channel name and message
+    size_t channel_len, message_len;  // lengths in buf
 
-      std::string_view Channel() const;
-      std::string_view Message() const;
-    };
+    std::string_view Channel() const;
+    std::string_view Message() const;
 
-    // Represents reply for subscribe/unsubscribe.
-    struct SubscribeData {
-      bool add;
-      std::string channel;
-      uint32_t channel_cnt;
-    };
-
-    std::variant<MessageData, SubscribeData> data;
-
-    PubMessage(bool add, std::string_view channel, uint32_t channel_cnt);
     PubMessage(std::string pattern, std::shared_ptr<char[]> buf, size_t channel_len,
                size_t message_len);
   };
@@ -193,6 +180,9 @@ class Connection : public util::Connection {
 
   // Returns true if HTTP header is detected.
   io::Result<bool> CheckForHttpProto(util::FiberSocketBase* peer);
+
+  // Dispatch last command parsed by ParseRedis
+  void DispatchCommand(uint32_t consumed, mi_heap_t* heap);
 
   // Handles events from dispatch queue.
   void DispatchFiber(util::FiberSocketBase* peer);

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -115,13 +115,15 @@ ConnectionContext::ConnectionContext(::io::Sink* stream, Connection* owner) : ow
       break;
   }
 
-  async_dispatch = false;
   conn_closing = false;
   req_auth = false;
   replica_conn = false;
   authenticated = false;
-  force_dispatch = false;
+  async_dispatch = false;
+  sync_dispatch = false;
   journal_emulated = false;
+
+  subscriptions = 0;
 }
 
 RedisReplyBuilder* ConnectionContext::operator->() {

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -134,6 +134,7 @@ vector<unsigned> ChangeSubscriptions(bool pattern, CmdArgList args, bool to_add,
   // removed.
   if (!to_add && conn_state.subscribe_info->IsEmpty()) {
     conn_state.subscribe_info.reset();
+    DCHECK_GE(conn->subscriptions, 1u);
     conn->subscriptions--;
   }
 

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -176,7 +176,7 @@ class ConnectionContext : public facade::ConnectionContext {
 
  private:
   void EnableMonitoring(bool enable) {
-    force_dispatch = enable;  // required to support the monitoring
+    subscriptions++;  // required to support the monitoring
     monitor = enable;
   }
   void SendSubscriptionChangedResponse(std::string_view action,

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -450,58 +450,6 @@ TEST_F(DflyEngineTest, PUnsubscribe) {
   EXPECT_THAT(resp.GetVec(), ElementsAre("punsubscribe", "b*", IntArg(0)));
 }
 
-TEST_F(DflyEngineTest, SubscribeInMulti) {
-  Run({"multi"});
-  for (unsigned i = 0; i < 10; i++) {
-    Run({"set", "a", "1"});
-    string chan = "ch" + to_string(i);
-    Run({"subscribe", chan});
-  }
-  auto resp = Run({"exec"});
-
-  // Make sure subscribe responses are ordered correctly
-  for (unsigned i = 0; i < 10; i++) {
-    EXPECT_EQ(resp.GetVec()[2 * i], "OK");
-    string chan = "ch" + to_string(i);
-    EXPECT_THAT(resp.GetVec()[2 * i + 1].GetVec(), ElementsAre("subscribe", chan, IntArg(i + 1)));
-  }
-}
-
-TEST_F(DflyEngineTest, SubscribeInMultiWithStream) {
-  atomic_bool done = false;
-
-  auto f = pp_->at(1)->LaunchFiber([&] {
-    while (!done.load()) {
-      ThisFiber::Yield();
-      Run({"publish", "foo", "bar"});
-    }
-  });
-
-  for (unsigned i = 0; i < 10; i++) {
-    Run({"multi"});
-    Run({"set", "a", "1"});
-    Run({"subscribe", "foo"});
-    for (unsigned j = 0; j < 100; j++)
-      Run({"get", "a"});
-    auto resp = Run({"exec"});
-
-    // Make sure no messages from publish got into the MULTI/EXEC response
-    EXPECT_EQ(resp.GetVec()[0], "OK");
-    EXPECT_THAT(resp.GetVec()[1].GetVec(), ElementsAre("subscribe", "foo", IntArg(1)));
-    for (unsigned j = 0; j < 100; j++)
-      EXPECT_EQ(resp.GetVec()[2 + j], "1");
-
-    ThisFiber::Yield();
-
-    Run({"unsubscribe", "foo"});
-  }
-
-  EXPECT_GT(SubscriberMessagesLen("IO0"), 0) << "Weak test";
-
-  done = true;
-  f.Join();
-}
-
 TEST_F(DflyEngineTest, Bug468) {
   RespExpr resp = Run({"multi"});
   ASSERT_EQ(resp, "OK");

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -735,8 +735,8 @@ bool Service::VerifyCommand(const CommandId* cid, CmdArgList args, ConnectionCon
   }
 
   if (under_multi) {
-    if (cmd_name == "SELECT") {
-      (*dfly_cntx)->SendError("Can not call SELECT within a transaction");
+    if (cmd_name == "SELECT" || absl::EndsWith(cmd_name, "SUBSCRIBE")) {
+      (*dfly_cntx)->SendError(absl::StrCat("Can not call ", cmd_name, " within a transaction"));
       return false;
     }
 

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -23,7 +23,7 @@ class TestConnection : public facade::Connection {
 
   void SendPubMessageAsync(PubMessage pmsg) final;
 
-  std::vector<PubMessage::MessageData> messages;
+  std::vector<PubMessage> messages;
 
  private:
   io::StringSink* sink_;
@@ -87,8 +87,8 @@ class BaseFamilyTest : public ::testing::Test {
   std::string GetId() const;
   size_t SubscriberMessagesLen(std::string_view conn_id) const;
 
-  const facade::Connection::PubMessage::MessageData& GetPublishedMessage(std::string_view conn_id,
-                                                                         size_t index) const;
+  const facade::Connection::PubMessage& GetPublishedMessage(std::string_view conn_id,
+                                                            size_t index) const;
 
   static unsigned NumLocked();
 

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -335,3 +335,14 @@ async def test_subscribe_pipelined(async_client: aioredis.Redis):
     pipe.execute_command('subscribe channel').execute_command(
         'subscribe channel')
     await pipe.echo('bye bye').execute()
+
+async def test_subscribe_in_pipeline(async_client: aioredis.Redis):
+    pipe = async_client.pipeline(transaction=False)
+    pipe.echo("one")
+    pipe.execute_command("SUBSCRIBE ch1")
+    pipe.echo("two")
+    pipe.execute_command("SUBSCRIBE ch2")
+    pipe.echo("three")
+    res = await pipe.execute()
+
+    assert res == ['one', ['subscribe', 'ch1', 1], 'two', ['subscribe', 'ch2', 2], 'three']


### PR DESCRIPTION
Fixes #1245 

Make subscribe reply immediately. Solves two issues:

1. During pipeline (where requests are part of dispatch q) the subscribe response is pushed back to the dispatch queue, so the client can receive its reply potentially very long after it executed. Most clients (probably?) expect a direct reply

2. Currently the responses are pushed back after all the channel store callbacks have been registered. This means that if a subscribe has many channels with possible suspension points (like `SUBSCRIBE ch1 ... ch10`), then until it gets to subscribe to the tenth, other channels could have received lots of messages.  What is more, its theoretically possible that a client receives a message before the confirmation itself.
