### PR TITLE
fix: remove xread required arguments

### DIFF
--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -175,18 +175,6 @@ TEST_F(StreamFamilyTest, XReadInvalidArgs) {
   // Unbalanced list of streams.
   resp = Run({"xread", "count", "invalid", "streams", "s1", "s2", "s3", "0", "0"});
   EXPECT_THAT(resp, ErrArg("syntax error"));
-
-  // Missing COUNT option.
-  // TODO Remove once support optional COUNT option.
-  resp = Run({"xread", "streams", "s1", "s2", "0", "0"});
-  EXPECT_THAT(resp, ErrArg("requires COUNT option"));
-
-  // Less/more than two streams.
-  // TODO Remove once support a variable number of streams.
-  resp = Run({"xread", "count", "5", "streams", "s1", "0"});
-  EXPECT_THAT(resp, ErrArg("requires 2 streams"));
-  resp = Run({"xread", "count", "5", "streams", "s1", "s2", "s3", "0", "0", "0"});
-  EXPECT_THAT(resp, ErrArg("requires 2 streams"));
 }
 
 TEST_F(StreamFamilyTest, Issue854) {


### PR DESCRIPTION
https://github.com/dragonflydb/dragonfly/pull/1235 restricted the XREAD arguments to always include COUNT and 2 streams due to limitations parsing the keys - though thats now been fixed by https://github.com/dragonflydb/dragonfly/pull/1250 so those restrictions can be removed

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->