### PR TITLE
Reply with `MOVED` error for non-owned slots.

### DIFF
--- a/src/server/cluster_family_test.cc
+++ b/src/server/cluster_family_test.cc
@@ -4,6 +4,7 @@
 
 #include <absl/flags/reflection.h>
 #include <gmock/gmock-matchers.h>
+#include <gtest/gtest-matchers.h>
 
 #include <string>
 #include <string_view>
@@ -151,6 +152,10 @@ TEST_F(ClusterFamilyTest, ClusterConfigNoReplicas) {
   EXPECT_THAT(cluster_info, HasSubstr("cluster_slots_ok:16384"));
   EXPECT_THAT(cluster_info, HasSubstr("cluster_known_nodes:1"));
   EXPECT_THAT(cluster_info, HasSubstr("cluster_size:1"));
+
+  EXPECT_THAT(Run({"get", "x"}).GetString(),
+              testing::MatchesRegex(R"(MOVED [0-9]+ 10.0.0.1:7000)"));
+
   // TODO: Use "CLUSTER SLOTS" and "CLUSTER SHARDS" once implemented to verify new configuration
   // takes effect.
 }
@@ -243,6 +248,32 @@ TEST_F(ClusterFamilyTest, ClusterConfigFullMultipleInstances) {
   EXPECT_THAT(cluster_info, HasSubstr("cluster_slots_ok:16384"));
   EXPECT_THAT(cluster_info, HasSubstr("cluster_known_nodes:4"));
   EXPECT_THAT(cluster_info, HasSubstr("cluster_size:2"));
+
+  absl::InsecureBitGen eng;
+  while (true) {
+    string random_key = GetRandomHex(eng, 40);
+    SlotId slot = ClusterConfig::KeySlot(random_key);
+    if (slot > 10'000) {
+      continue;
+    }
+
+    EXPECT_THAT(Run({"get", random_key}).GetString(),
+        testing::MatchesRegex(R"(MOVED [0-9]+ 10.0.0.1:7000)"));
+    break;
+  }
+
+  while (true) {
+    string random_key = GetRandomHex(eng, 40);
+    SlotId slot = ClusterConfig::KeySlot(random_key);
+    if (slot <= 10'000) {
+      continue;
+    }
+
+    EXPECT_THAT(Run({"get", random_key}).GetString(),
+        testing::MatchesRegex(R"(MOVED [0-9]+ 10.0.0.2:7001)"));
+    break;
+  }
+
   // TODO: Use "CLUSTER SLOTS" and "CLUSTER SHARDS" once implemented to verify new configuration
   // takes effect.
 }

--- a/src/server/cluster_family_test.cc
+++ b/src/server/cluster_family_test.cc
@@ -258,7 +258,7 @@ TEST_F(ClusterFamilyTest, ClusterConfigFullMultipleInstances) {
     }
 
     EXPECT_THAT(Run({"get", random_key}).GetString(),
-        testing::MatchesRegex(R"(MOVED [0-9]+ 10.0.0.1:7000)"));
+                testing::MatchesRegex(R"(MOVED [0-9]+ 10.0.0.1:7000)"));
     break;
   }
 
@@ -270,7 +270,7 @@ TEST_F(ClusterFamilyTest, ClusterConfigFullMultipleInstances) {
     }
 
     EXPECT_THAT(Run({"get", random_key}).GetString(),
-        testing::MatchesRegex(R"(MOVED [0-9]+ 10.0.0.2:7001)"));
+                testing::MatchesRegex(R"(MOVED [0-9]+ 10.0.0.2:7001)"));
     break;
   }
 


### PR DESCRIPTION
This only applies to cluster mode.

Fixes #1266

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->