### PR TITLE
bug(memory): read LXC memory.limit_in_bytes too

### DIFF
--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -514,6 +514,13 @@ void UpdateResourceLimitsIfInsideContainer(io::MemInfoData* mdata, size_t* max_t
     return;
 
   /* Update memory limits */
+  auto mlimit = io::ReadFileToString(cgroup + "/memory/memory.limit_in_bytes");
+  DVLOG(1) << "memory/memory.limit_in_bytes: " << mlimit.value_or("N/A");
+
+  if (mlimit && !absl::StartsWith(*mlimit, "max")) {
+    CHECK(absl::SimpleAtoi(*mlimit, &mdata->mem_total));
+  }
+  
   auto mmax = io::ReadFileToString(cgroup + "/memory.max");
   DVLOG(1) << "memory.max: " << mmax.value_or("N/A");
 

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -520,7 +520,7 @@ void UpdateResourceLimitsIfInsideContainer(io::MemInfoData* mdata, size_t* max_t
   if (mlimit && !absl::StartsWith(*mlimit, "max")) {
     CHECK(absl::SimpleAtoi(*mlimit, &mdata->mem_total));
   }
-  
+
   auto mmax = io::ReadFileToString(cgroup + "/memory.max");
   DVLOG(1) << "memory.max: " << mmax.value_or("N/A");
 


### PR DESCRIPTION
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->

Read the maximum memory on LXC containers too, such as GKE with Containerd. Fixes #1292.