### PR TITLE
fix: script flags naming + add stick option

### DIFF
--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -17,7 +17,7 @@
 
 ABSL_DECLARE_FLAG(uint32_t, multi_exec_mode);
 ABSL_DECLARE_FLAG(bool, multi_exec_squash);
-ABSL_DECLARE_FLAG(std::string, default_lua_config);
+ABSL_DECLARE_FLAG(std::string, default_lua_flags);
 
 namespace dfly {
 
@@ -338,8 +338,8 @@ TEST_F(MultiTest, FlushDb) {
 }
 
 TEST_F(MultiTest, Eval) {
-  if (auto config = absl::GetFlag(FLAGS_default_lua_config); config != "") {
-    LOG(WARNING) << "Skipped Eval test because default_lua_config is set";
+  if (auto config = absl::GetFlag(FLAGS_default_lua_flags); config != "") {
+    LOG(WARNING) << "Skipped Eval test because default_lua_flags is set";
     return;
   }
 
@@ -520,8 +520,8 @@ TEST_F(MultiTest, MultiOOO) {
 
 // Lua scripts lock their keys ahead and thus can run out of order.
 TEST_F(MultiTest, EvalOOO) {
-  if (auto config = absl::GetFlag(FLAGS_default_lua_config); config != "") {
-    LOG(WARNING) << "Skipped Eval test because default_lua_config is set";
+  if (auto config = absl::GetFlag(FLAGS_default_lua_flags); config != "") {
+    LOG(WARNING) << "Skipped Eval test because default_lua_flags is set";
     return;
   }
 
@@ -632,8 +632,8 @@ TEST_F(MultiTest, ExecGlobalFallback) {
 }
 
 TEST_F(MultiTest, ScriptConfig) {
-  if (auto config = absl::GetFlag(FLAGS_default_lua_config); config != "") {
-    LOG(WARNING) << "Skipped Eval test because default_lua_config is set";
+  if (auto config = absl::GetFlag(FLAGS_default_lua_flags); config != "") {
+    LOG(WARNING) << "Skipped Eval test because default_lua_flags is set";
     return;
   }
 

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -631,8 +631,8 @@ TEST_F(MultiTest, ExecGlobalFallback) {
   //  EXPECT_EQ(1, GetMetrics().ooo_tx_transaction_cnt);
 }
 
-TEST_F(MultiTest, ScriptConfig) {
-  if (auto config = absl::GetFlag(FLAGS_default_lua_flags); config != "") {
+TEST_F(MultiTest, ScriptFlagsCommand) {
+  if (auto flags = absl::GetFlag(FLAGS_default_lua_flags); flags != "") {
     LOG(WARNING) << "Skipped Eval test because default_lua_flags is set";
     return;
   }
@@ -643,30 +643,31 @@ TEST_F(MultiTest, ScriptConfig) {
   Run({"set", "random-key-1", "works"});
   Run({"set", "random-key-2", "works"});
 
-  // Check SCRIPT CONFIG is applied correctly to loaded scripts.
+  // Check SCRIPT FLAGS is applied correctly to loaded scripts.
   {
     auto sha_resp = Run({"script", "load", kUndeclared1});
     auto sha = facade::ToSV(sha_resp.GetBuf());
 
     EXPECT_THAT(Run({"evalsha", sha, "0"}), ErrArg("undeclared"));
 
-    EXPECT_THAT(Run({"script", "config", sha, "allow-undeclared-keys"}), "OK");
+    EXPECT_EQ(Run({"script", "flags", sha, "allow-undeclared-keys"}), "OK");
+
     EXPECT_THAT(Run({"evalsha", sha, "0"}), "works");
   }
 
-  // Check SCRIPT CONFIG can be applied by sha before loading.
+  // Check SCRIPT FLAGS can be applied by sha before loading.
   {
     char sha_buf[41];
     Interpreter::FuncSha1(kUndeclared2, sha_buf);
     string_view sha{sha_buf, 40};
 
-    EXPECT_THAT(Run({"script", "config", sha, "allow-undeclared-keys"}), "OK");
+    EXPECT_THAT(Run({"script", "flags", sha, "allow-undeclared-keys"}), "OK");
 
     EXPECT_THAT(Run({"eval", kUndeclared2, "0"}), "works");
   }
 }
 
-TEST_F(MultiTest, ScriptFlags) {
+TEST_F(MultiTest, ScriptFlagsEmbedded) {
   const char* s1 = R"(
   #!lua flags=allow-undeclared-keys
   return redis.call('GET', 'random-key');

--- a/src/server/script_mgr.cc
+++ b/src/server/script_mgr.cc
@@ -22,8 +22,8 @@
 #include "server/server_state.h"
 #include "server/transaction.h"
 
-ABSL_FLAG(std::string, default_lua_config, "",
-          "Configure default mode for running Lua scripts: \n - Use 'allow-undeclared-keys' to "
+ABSL_FLAG(std::string, default_lua_flags, "",
+          "Configure default flags for running Lua scripts: \n - Use 'allow-undeclared-keys' to "
           "allow accessing undeclared keys, \n - Use 'disable-atomicity' to allow "
           "running scripts non-atomically. \nSpecify multiple values "
           "separated by space, for example 'allow-undeclared-keys disable-atomicity' runs scripts "
@@ -40,12 +40,12 @@ using namespace facade;
 using namespace util;
 
 ScriptMgr::ScriptMgr() {
-  // Build default script config
-  std::string config = absl::GetFlag(FLAGS_default_lua_config);
+  // Build default script flags
+  string flags = absl::GetFlag(FLAGS_default_lua_flags);
 
   static_assert(ScriptParams{}.atomic && !ScriptParams{}.undeclared_keys);
 
-  auto err = ScriptParams::ApplyFlags(config, &default_params_);
+  auto err = ScriptParams::ApplyFlags(flags, &default_params_);
   CHECK(!err) << err.Format();
 }
 
@@ -65,11 +65,11 @@ void ScriptMgr::Run(CmdArgList args, ConnectionContext* cntx) {
         "   Return information about the existence of the scripts in the script cache.",
         "LOAD <script>",
         "   Load a script into the scripts cache without executing it.",
-        "CONFIGURE <sha> [options ...]",
-        "   The following options are possible: ",
+        "FLAGS <sha> [flags ...]",
+        "   Set specific flags for script. Can be called before the sript is loaded."
+        "   The following flags are possible: ",
         "      - Use 'allow-undeclared-keys' to allow accessing undeclared keys",
-        "      - Use 'disable-atomicity' to allow running scripts non-atomically to improve "
-        "performance",
+        "      - Use 'disable-atomicity' to allow running scripts non-atomically",
         "LIST",
         "   Lists loaded scripts.",
         "LATENCY",

--- a/src/server/script_mgr.cc
+++ b/src/server/script_mgr.cc
@@ -91,7 +91,7 @@ void ScriptMgr::Run(CmdArgList args, ConnectionContext* cntx) {
   if (subcmd == "LOAD" && args.size() == 2)
     return LoadCmd(args, cntx);
 
-  if (subcmd == "CONFIG" && args.size() > 2)
+  if (subcmd == "FLAGS" && args.size() > 2)
     return ConfigCmd(args, cntx);
 
   string err = absl::StrCat("Unknown subcommand or wrong number of arguments for '", subcmd,

--- a/src/server/string_family.h
+++ b/src/server/string_family.h
@@ -26,11 +26,12 @@ class SetCmd {
 
   enum SetFlags {
     SET_ALWAYS = 0,
-    SET_IF_NOTEXIST = 1 << 0,    /* NX: Set if key not exists. */
-    SET_IF_EXISTS = 1 << 1,      /* XX: Set if key exists. */
-    SET_KEEP_EXPIRE = 1 << 2,    /* KEEPTTL: Set and keep the ttl */
-    SET_GET = 1 << 3,            /* GET: Set if want to get key before set */
-    SET_EXPIRE_AFTER_MS = 1 << 4 /* EX,PX,EXAT,PXAT: Expire after ms. */
+    SET_IF_NOTEXIST = 1 << 0,     /* NX: Set if key not exists. */
+    SET_IF_EXISTS = 1 << 1,       /* XX: Set if key exists. */
+    SET_KEEP_EXPIRE = 1 << 2,     /* KEEPTTL: Set and keep the ttl */
+    SET_GET = 1 << 3,             /* GET: Set if want to get key before set */
+    SET_EXPIRE_AFTER_MS = 1 << 4, /* EX,PX,EXAT,PXAT: Expire after ms. */
+    SET_STICK = 1 << 5,           /* Set STICK flag */
   };
 
   struct SetParams {

--- a/src/server/string_family_test.cc
+++ b/src/server/string_family_test.cc
@@ -462,6 +462,11 @@ TEST_F(StringFamilyTest, SetPxAtExAt) {
   EXPECT_EQ(Run({"get", "foo2"}), "abc");
 }
 
+TEST_F(StringFamilyTest, SetStick) {
+  Run({"set", "foo", "bar", "STICK"});
+  EXPECT_THAT(Run({"STICK", "foo"}), IntArg(0));
+}
+
 TEST_F(StringFamilyTest, GetDel) {
   auto resp = Run({"set", "foo", "bar"});
   EXPECT_THAT(resp, "OK");

--- a/tests/dragonfly/eval_test.py
+++ b/tests/dragonfly/eval_test.py
@@ -91,8 +91,8 @@ so Dragonfly must run in global (1) or non-atomic (4) multi eval mode.
 """
 
 
-@dfly_multi_test_args({'default_lua_config': 'allow-undeclared-keys', 'proactor_threads': 4},
-                      {'default_lua_config': 'allow-undeclared-keys disable-atomicity', 'proactor_threads': 4})
+@dfly_multi_test_args({'default_lua_flags': 'allow-undeclared-keys', 'proactor_threads': 4},
+                      {'default_lua_flags': 'allow-undeclared-keys disable-atomicity', 'proactor_threads': 4})
 async def test_django_cacheops_script(async_client, num_keys=500):
     script = async_client.register_script(DJANGO_CACHEOPS_SCRIPT)
 
@@ -158,8 +158,8 @@ the task system should work reliably.
 """
 
 
-@dfly_multi_test_args({'default_lua_config': 'allow-undeclared-keys', 'proactor_threads': 4},
-                      {'default_lua_config': 'allow-undeclared-keys disable-atomicity', 'proactor_threads': 4})
+@dfly_multi_test_args({'default_lua_flags': 'allow-undeclared-keys', 'proactor_threads': 4},
+                      {'default_lua_flags': 'allow-undeclared-keys disable-atomicity', 'proactor_threads': 4})
 async def test_golang_asynq_script(async_pool, num_queues=10, num_tasks=100):
     async def enqueue_worker(queue):
         client = aioredis.Redis(connection_pool=async_pool)


### PR DESCRIPTION
Keep consistent and use 'flags' everywhere. Need to settle for normal names now because those will be mentioned in docs.

* SCRIPT CONFIG should be SCRIPT FLAGS
* defualt_lua_config should be default_lua_flags

Another change: Add STICK option to SET