### PR TITLE
fix: werror in ci and warning that slipped by

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
             -DCMAKE_C_COMPILER="${{matrix.compiler.c}}" \
             -DCMAKE_CXX_COMPILER="${{matrix.compiler.cxx}}" \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_FLAGS="${{matrix.compiler.cxx_flags}}" \
+            -DCMAKE_CXX_FLAGS="${{matrix.cxx_flags}}" \
             -L
           cd ${{github.workspace}}/build && pwd
           du -hcs _deps/

--- a/src/core/search/parser.y
+++ b/src/core/search/parser.y
@@ -26,6 +26,10 @@
 %code {
 #include "core/search/query_driver.h"
 
+// Have to disable because GCC doesn't understand `symbol_type`'s union
+// implementation
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+
 #define yylex driver->scanner()->Lex
 
 using namespace std;

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -35,7 +35,8 @@ DoubleToStringConverter dfly_conv(kConvFlags, "inf", "nan", 'e', -6, 21, 6, 0);
 
 }  // namespace
 
-SinkReplyBuilder::SinkReplyBuilder(::io::Sink* sink) : sink_(sink) {
+SinkReplyBuilder::SinkReplyBuilder(::io::Sink* sink)
+    : sink_(sink), should_batch_(false), should_aggregate_(false) {
 }
 
 void SinkReplyBuilder::CloseConnection() {

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -119,10 +119,10 @@ class SinkReplyBuilder {
   size_t io_write_bytes_ = 0;
   absl::flat_hash_map<std::string, uint64_t> err_count_;
 
-  bool should_batch_ : 1 = false;
+  bool should_batch_ : 1;
 
   // Similarly to batch mode but is controlled by at operation level.
-  bool should_aggregate_ : 2 = false;
+  bool should_aggregate_ : 1;
   uint32_t batch_cnt_ = 0;
 };
 

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -89,7 +89,7 @@ struct ReadOpts {
   uint32_t count = kuint32max;
   // Contains the time to block waiting for entries, or -1 if should not block.
   int64_t timeout = -1;
-  size_t streams_arg;
+  size_t streams_arg = 0;
 };
 
 const char kInvalidStreamId[] = "Invalid stream ID specified as stream command argument";


### PR DESCRIPTION
I accidentally disabled `-Werror` when adding the Clang flow