### PR TITLE
feat(cluster): Implement CLUSTER NODES command.

### DIFF
--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -216,7 +216,7 @@ void ClusterFamily::ClusterSlots(ConnectionContext* cntx) {
 
 namespace {
 void ClusterNodesImpl(const ClusterShards& config, string_view my_id, ConnectionContext* cntx) {
-  // For more details https://redis.io/commands/cluster-slots/
+  // For more details https://redis.io/commands/cluster-nodes/
 
   string result;
 
@@ -248,7 +248,8 @@ void ClusterNodesImpl(const ClusterShards& config, string_view my_id, Connection
   for (const auto& shard : config) {
     WriteNode(shard.master, "master", "-", shard.slot_ranges);
     for (const auto& replica : shard.replicas) {
-      WriteNode(replica, "slave", shard.master.id, shard.slot_ranges);
+      // Only the master prints ranges, so we send an empty set for replicas.
+      WriteNode(replica, "slave", shard.master.id, {});
     }
   }
 

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -34,6 +34,10 @@ namespace {
 using namespace std;
 using namespace facade;
 using CI = CommandId;
+using ClusterShard = ClusterConfig::ClusterShard;
+using ClusterShards = ClusterConfig::ClusterShards;
+using Node = ClusterConfig::Node;
+using SlotRange = ClusterConfig::SlotRange;
 
 constexpr string_view kClusterDisabled =
     "Cluster is disabled. Enabled via passing --cluster_mode=emulated|yes";
@@ -61,8 +65,8 @@ bool ClusterFamily::IsEnabledOrEmulated() const {
 
 // TODO: Extend this method to accommodate the needs of `CLUSTER NODES` and `CLUSTER SLOTS`.
 // TODO: Also make this function safe in that it will read the state atomically.
-ClusterConfig::ClusterShard ClusterFamily::GetEmulatedShardInfo(ConnectionContext* cntx) const {
-  ClusterConfig::ClusterShard info{
+ClusterShard ClusterFamily::GetEmulatedShardInfo(ConnectionContext* cntx) const {
+  ClusterShard info{
       .slot_ranges = {{.start = 0, .end = ClusterConfig::kMaxSlotNum}},
       .master = {},
       .replicas = {},
@@ -95,41 +99,6 @@ ClusterConfig::ClusterShard ClusterFamily::GetEmulatedShardInfo(ConnectionContex
   return info;
 }
 
-string ClusterFamily::BuildClusterNodeReply(ConnectionContext* cntx) const {
-  ServerState& etl = *ServerState::tlocal();
-  auto epoch_master_time = std::time(nullptr) * 1000;
-  if (etl.is_master) {
-    std::string cluster_announce_ip = absl::GetFlag(FLAGS_cluster_announce_ip);
-    std::string preferred_endpoint =
-        cluster_announce_ip.empty() ? cntx->owner()->LocalBindAddress() : cluster_announce_ip;
-    auto vec = server_family_->GetDflyCmd()->GetReplicasRoleInfo();
-    auto my_port = absl::GetFlag(FLAGS_port);
-    const char* connect_state = vec.empty() ? "disconnected" : "connected";
-    std::string msg = absl::StrCat(server_family_->master_id(), " ", preferred_endpoint, ":",
-                                   my_port, "@", my_port, " myself,master - 0 ", epoch_master_time,
-                                   " 1 ", connect_state, " 0-16383\r\n");
-    if (!vec.empty()) {  // info about the replica
-      const auto& info = vec[0];
-      absl::StrAppend(&msg, etl.remote_client_id_, " ", info.address, ":", info.listening_port, "@",
-                      info.listening_port, " slave 0 ", server_family_->master_id(), " 1 ",
-                      connect_state, "\r\n");
-    }
-    return msg;
-  } else {
-    Replica::Info info = server_family_->GetReplicaInfo();
-    auto my_ip = cntx->owner()->LocalBindAddress();
-    auto my_port = absl::GetFlag(FLAGS_port);
-    const char* connect_state = info.master_link_established ? "connected" : "disconnected";
-    std::string msg = absl::StrCat(server_family_->master_id(), " ", my_ip, ":", my_port, "@",
-                                   my_port, " myself,slave ", server_family_->master_id(), " 0 ",
-                                   epoch_master_time, " 1 ", connect_state, "\r\n");
-    absl::StrAppend(&msg, server_family_->GetReplicaMasterId(), " ", info.host, ":", info.port, "@",
-                    info.port, " master - 0 ", epoch_master_time, " 1 ", connect_state,
-                    " 0-16383\r\n");
-    return msg;
-  }
-}
-
 void ClusterFamily::ClusterHelp(ConnectionContext* cntx) {
   string_view help_arr[] = {
       "CLUSTER <subcommand> [<arg> [value] [opt] ...]. Subcommands are:",
@@ -148,11 +117,11 @@ void ClusterFamily::ClusterHelp(ConnectionContext* cntx) {
 }
 
 namespace {
-void ClusterShardsImpl(const ClusterConfig::ClusterShards& config, ConnectionContext* cntx) {
+void ClusterShardsImpl(const ClusterShards& config, ConnectionContext* cntx) {
   // For more details https://redis.io/commands/cluster-shards/
   constexpr unsigned int kEntrySize = 4;
 
-  auto WriteNode = [&](const ClusterConfig::Node& node, string_view role) {
+  auto WriteNode = [&](const Node& node, string_view role) {
     constexpr unsigned int kNodeSize = 14;
     (*cntx)->StartArray(kNodeSize);
     (*cntx)->SendBulkString("id");
@@ -203,9 +172,9 @@ void ClusterFamily::ClusterShards(ConnectionContext* cntx) {
 }
 
 namespace {
-void ClusterSlotsImpl(const ClusterConfig::ClusterShards& config, ConnectionContext* cntx) {
+void ClusterSlotsImpl(const ClusterShards& config, ConnectionContext* cntx) {
   // For more details https://redis.io/commands/cluster-slots/
-  auto WriteNode = [&](const ClusterConfig::Node& node) {
+  auto WriteNode = [&](const Node& node) {
     constexpr unsigned int kNodeSize = 3;
     (*cntx)->StartArray(kNodeSize);
     (*cntx)->SendBulkString(node.ip);
@@ -245,12 +214,56 @@ void ClusterFamily::ClusterSlots(ConnectionContext* cntx) {
   }
 }
 
+namespace {
+void ClusterNodesImpl(const ClusterShards& config, string_view my_id, ConnectionContext* cntx) {
+  // For more details https://redis.io/commands/cluster-slots/
+
+  string result;
+
+  auto WriteNode = [&](const Node& node, string_view role, string_view master_id,
+                       const vector<SlotRange>& ranges) {
+    absl::StrAppend(&result, node.id, " ");
+
+    absl::StrAppend(&result, node.ip, ":", node.port, "@", node.port, " ");
+
+    if (my_id == node.id) {
+      absl::StrAppend(&result, "myself,");
+    }
+    absl::StrAppend(&result, role, " ");
+
+    absl::StrAppend(&result, master_id, " ");
+
+    absl::StrAppend(&result, "0 0 0 connected");
+
+    for (const auto& range : ranges) {
+      absl::StrAppend(&result, " ", range.start);
+      if (range.start != range.end) {
+        absl::StrAppend(&result, "-", range.end);
+      }
+    }
+
+    absl::StrAppend(&result, "\r\n");
+  };
+
+  for (const auto& shard : config) {
+    WriteNode(shard.master, "master", "-", shard.slot_ranges);
+    for (const auto& replica : shard.replicas) {
+      WriteNode(replica, "slave", shard.master.id, shard.slot_ranges);
+    }
+  }
+
+  return (*cntx)->SendBulkString(result);
+}
+}  // namespace
+
 void ClusterFamily::ClusterNodes(ConnectionContext* cntx) {
-  // Support for NODES commands can help in case we are working in cluster mode
-  // In this case, we can save information about the cluster
-  // In case this is the master, it can save the information about the replica from this command
-  std::string msg = BuildClusterNodeReply(cntx);
-  (*cntx)->SendBulkString(msg);
+  if (is_emulated_cluster_) {
+    return ClusterNodesImpl({GetEmulatedShardInfo(cntx)}, server_family_->master_id(), cntx);
+  } else if (cluster_config_->IsConfigured()) {
+    return ClusterNodesImpl(cluster_config_->GetConfig(), server_family_->master_id(), cntx);
+  } else {
+    return (*cntx)->SendError(kClusterNotConfigured);
+  }
 }
 
 void ClusterFamily::ClusterInfo(ConnectionContext* cntx) {

--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -47,8 +47,6 @@ class ClusterFamily {
   void DflyClusterGetSlotInfo(CmdArgList args, ConnectionContext* cntx);
   void DflyClusterMyId(CmdArgList args, ConnectionContext* cntx);
 
-  std::string BuildClusterNodeReply(ConnectionContext* cntx) const;
-
   ClusterConfig::ClusterShard GetEmulatedShardInfo(ConnectionContext* cntx) const;
 
   bool is_emulated_cluster_ = false;

--- a/src/server/cluster_family_test.cc
+++ b/src/server/cluster_family_test.cc
@@ -276,7 +276,7 @@ TEST_F(ClusterFamilyTest, ClusterConfigFull) {
 
   EXPECT_EQ(Run({"cluster", "nodes"}),
             "abcd1234 10.0.0.1:7000@7000 master - 0 0 0 connected 0-16383\r\n"
-            "wxyz 10.0.0.10:8000@8000 slave abcd1234 0 0 0 connected 0-16383\r\n");
+            "wxyz 10.0.0.10:8000@8000 slave abcd1234 0 0 0 connected\r\n");
 }
 
 TEST_F(ClusterFamilyTest, ClusterConfigFullMultipleInstances) {
@@ -400,9 +400,9 @@ TEST_F(ClusterFamilyTest, ClusterConfigFullMultipleInstances) {
 
   EXPECT_THAT(Run({"cluster", "nodes"}),
               "abcd1234 10.0.0.1:7000@7000 master - 0 0 0 connected 0-10000\r\n"
-              "wxyz 10.0.0.10:8000@8000 slave abcd1234 0 0 0 connected 0-10000\r\n"
+              "wxyz 10.0.0.10:8000@8000 slave abcd1234 0 0 0 connected\r\n"
               "efgh7890 10.0.0.2:7001@7001 master - 0 0 0 connected 10001-16383\r\n"
-              "qwerty 10.0.0.11:8001@8001 slave efgh7890 0 0 0 connected 10001-16383\r\n");
+              "qwerty 10.0.0.11:8001@8001 slave efgh7890 0 0 0 connected\r\n");
 
   absl::InsecureBitGen eng;
   while (true) {

--- a/src/server/cluster_family_test.cc
+++ b/src/server/cluster_family_test.cc
@@ -67,6 +67,7 @@ TEST_F(ClusterFamilyTest, ClusterConfigInvalidJSON) {
 
   EXPECT_THAT(Run({"cluster", "shards"}), ErrArg("Cluster is not yet configured"));
   EXPECT_THAT(Run({"cluster", "slots"}), ErrArg("Cluster is not yet configured"));
+  EXPECT_THAT(Run({"cluster", "nodes"}), ErrArg("Cluster is not yet configured"));
 }
 
 TEST_F(ClusterFamilyTest, ClusterConfigInvalidConfig) {
@@ -201,6 +202,9 @@ TEST_F(ClusterFamilyTest, ClusterConfigNoReplicas) {
                                         "10.0.0.1",         //
                                         IntArg(7'000),      //
                                         "abcd1234")))));
+
+  EXPECT_EQ(Run({"cluster", "nodes"}),
+            "abcd1234 10.0.0.1:7000@7000 master - 0 0 0 connected 0-16383\r\n");
 }
 
 TEST_F(ClusterFamilyTest, ClusterConfigFull) {
@@ -269,6 +273,10 @@ TEST_F(ClusterFamilyTest, ClusterConfigFull) {
                                         "10.0.0.10",        //
                                         IntArg(8'000),      //
                                         "wxyz")))));
+
+  EXPECT_EQ(Run({"cluster", "nodes"}),
+            "abcd1234 10.0.0.1:7000@7000 master - 0 0 0 connected 0-16383\r\n"
+            "wxyz 10.0.0.10:8000@8000 slave abcd1234 0 0 0 connected 0-16383\r\n");
 }
 
 TEST_F(ClusterFamilyTest, ClusterConfigFullMultipleInstances) {
@@ -389,6 +397,12 @@ TEST_F(ClusterFamilyTest, ClusterConfigFullMultipleInstances) {
                                             "10.0.0.11",        //
                                             IntArg(8'001),      //
                                             "qwerty")))))));
+
+  EXPECT_THAT(Run({"cluster", "nodes"}),
+              "abcd1234 10.0.0.1:7000@7000 master - 0 0 0 connected 0-10000\r\n"
+              "wxyz 10.0.0.10:8000@8000 slave abcd1234 0 0 0 connected 0-10000\r\n"
+              "efgh7890 10.0.0.2:7001@7001 master - 0 0 0 connected 10001-16383\r\n"
+              "qwerty 10.0.0.11:8001@8001 slave efgh7890 0 0 0 connected 10001-16383\r\n");
 
   absl::InsecureBitGen eng;
   while (true) {
@@ -539,6 +553,12 @@ TEST_F(ClusterFamilyEmulatedTest, ClusterSlots) {
                                         "fake-host",        //
                                         IntArg(6379),       //
                                         RunAdmin({"dflycluster", "myid"}).GetString())))));
+}
+
+TEST_F(ClusterFamilyEmulatedTest, ClusterNodes) {
+  EXPECT_THAT(Run({"cluster", "nodes"}),
+              RunAdmin({"dflycluster", "myid"}).GetString() +
+                  " fake-host:6379@6379 myself,master - 0 0 0 connected 0-16383\r\n");
 }
 
 }  // namespace


### PR DESCRIPTION
Implementation handles the following cases:
1. Real, configured cluster
2. Real, unconfigured cluster (error message)
3. Emulated cluster
4. Cluster mode unset (error message)

The only regression from previous (emulated mode) is that we no longer specify 'disconnected'. This is because, in cluster mode, we can't tell that anyway, so we might as well do that in emulated mode as well.

Fixes #1278 

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->