### PR TITLE
chore: Silence unwanted asyncio clutter

### DIFF
--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -19,6 +19,8 @@ from tempfile import TemporaryDirectory
 from . import DflyInstance, DflyInstanceFactory, DflyParams, PortPicker, dfly_args
 from .utility import DflySeederFactory
 
+logging.getLogger('asyncio').setLevel(logging.WARNING)
+
 DATABASE_INDEX = 1
 
 


### PR DESCRIPTION
Gets rid of the `[2023-05-28 14:34:27.304 DEBUG] Using selector: EpollSelector` spam.