### PR TITLE
feat(server): Add versioning to dragonfly replication

### DIFF
--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -11,6 +11,7 @@
 #include "facade/conn_context.h"
 #include "facade/reply_capture.h"
 #include "server/common.h"
+#include "server/version.h"
 
 namespace dfly {
 
@@ -116,6 +117,7 @@ struct ConnectionState {
     uint32_t repl_session_id = 0;
     uint32_t repl_flow_id = UINT32_MAX;
     uint32_t repl_listening_port = 0;
+    DflyVersion repl_version = DflyVersion::VER0;
   };
 
   enum MCGetMask {

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -418,7 +418,6 @@ error_code Replica::Greet() {
   } else if (resp_args_.size() >= 3) {  // it's dragonfly master.
     if (auto ec = HandleCapaDflyResp(); ec)
       return err_handler();
-    io_buf.ConsumeInput(consumed);
     if (auto ec = ConfigureDflyMaster(); ec)
       return ec;
   } else {
@@ -474,6 +473,9 @@ std::error_code Replica::ConfigureDflyMaster() {
     LOG(WARNING) << "master did not return OK on id message";
   }
 
+  io_buf.ConsumeInput(consumed);
+
+  // Tell the master our version if it supports REPLCONF CLIENT-VERSION
   if (master_context_.version > DflyVersion::VER0) {
     RETURN_ON_ERR(
         SendCommand(StrCat("REPLCONF CLIENT-VERSION ", DflyVersion::CURRENT_VER), &serializer));

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -416,55 +416,74 @@ error_code Replica::Greet() {
     if (cmd != "OK")
       return err_handler();
   } else if (resp_args_.size() >= 3) {  // it's dragonfly master.
-    // Response is: <master_repl_id, syncid, num_shards>
-    if (!CheckRespFirstTypes({RespExpr::STRING, RespExpr::STRING, RespExpr::INT64}) ||
-        resp_args_[0].GetBuf().size() != CONFIG_RUN_ID_SIZE)
+    if (auto ec = HandleCapaDflyResp(); ec)
       return err_handler();
-
-    int64 param_num_flows = get<int64_t>(resp_args_[2].u);
-    if (param_num_flows <= 0 || param_num_flows > 1024) {
-      // sanity check, we support upto 1024 shards.
-      // It's not that we can not support more but it's probably highly unlikely that someone
-      // will run dragonfly with more than 1024 cores.
-      LOG(ERROR) << "Invalid flow count " << param_num_flows;
-      return make_error_code(errc::bad_message);
-    }
-
-    master_context_.master_repl_id = ToSV(resp_args_[0].GetBuf());
-    master_context_.dfly_session_id = ToSV(resp_args_[1].GetBuf());
-    num_df_flows_ = param_num_flows;
     io_buf.ConsumeInput(consumed);
-    if (resp_args_.size() >= 4) {
-      if (resp_args_[3].type != RespExpr::INT64)
-        return err_handler();
-      master_context_.version = DflyVersion(get<int64_t>(resp_args_[3].u));
-    }
-    VLOG(1) << "Master id: " << master_context_.master_repl_id
-            << ", sync id: " << master_context_.dfly_session_id << ", num journals "
-            << num_df_flows_ << " version: " << unsigned(master_context_.version);
-
-    // We need to send this because we may require to use this for cluster commands.
-    // this reason to send this here is that in other context we can get an error reply
-    // since we are budy with the replication
-    RETURN_ON_ERR(SendCommand(StrCat("REPLCONF CLIENT-ID ", id_), &serializer));
-    RETURN_ON_ERR(ReadRespReply(&io_buf, &consumed));
-    if (!CheckRespIsSimpleReply("OK")) {
-      LOG(WARNING) << "master did not return OK on id message";
-    }
-
-    if (master_context_.version > DflyVersion::VER0) {
-      RETURN_ON_ERR(
-          SendCommand(StrCat("REPLCONF CLIENT-VERSION ", DflyVersion::CURRENT_VER), &serializer));
-      RETURN_ON_ERR(ReadRespReply(&io_buf, &consumed));
-      if (!CheckRespIsSimpleReply("OK"))
-        return err_handler();
-    }
+    if (auto ec = ConfigureDflyMaster(); ec)
+      return ec;
   } else {
     return err_handler();
   }
 
-  io_buf.ConsumeInput(consumed);
   state_mask_.fetch_or(R_GREETED);
+  return error_code{};
+}
+
+std::error_code Replica::HandleCapaDflyResp() {
+  // Response is: <master_repl_id, syncid, num_shards [, version]>
+  if (!CheckRespFirstTypes({RespExpr::STRING, RespExpr::STRING, RespExpr::INT64}) ||
+      resp_args_[0].GetBuf().size() != CONFIG_RUN_ID_SIZE)
+    return make_error_code(errc::bad_message);
+
+  int64 param_num_flows = get<int64_t>(resp_args_[2].u);
+  if (param_num_flows <= 0 || param_num_flows > 1024) {
+    // sanity check, we support upto 1024 shards.
+    // It's not that we can not support more but it's probably highly unlikely that someone
+    // will run dragonfly with more than 1024 cores.
+    LOG(ERROR) << "Invalid flow count " << param_num_flows;
+    return make_error_code(errc::bad_message);
+  }
+
+  master_context_.master_repl_id = ToSV(resp_args_[0].GetBuf());
+  master_context_.dfly_session_id = ToSV(resp_args_[1].GetBuf());
+  num_df_flows_ = param_num_flows;
+
+  if (resp_args_.size() >= 4) {
+    if (resp_args_[3].type != RespExpr::INT64)
+      return make_error_code(errc::bad_message);
+    master_context_.version = DflyVersion(get<int64_t>(resp_args_[3].u));
+  }
+  VLOG(1) << "Master id: " << master_context_.master_repl_id
+          << ", sync id: " << master_context_.dfly_session_id << ", num journals: " << num_df_flows_
+          << ", version: " << unsigned(master_context_.version);
+
+  return error_code{};
+}
+
+std::error_code Replica::ConfigureDflyMaster() {
+  base::IoBuf io_buf{128};
+  ReqSerializer serializer{sock_.get()};
+  uint32_t consumed = 0;
+
+  // We need to send this because we may require to use this for cluster commands.
+  // this reason to send this here is that in other context we can get an error reply
+  // since we are budy with the replication
+  RETURN_ON_ERR(SendCommand(StrCat("REPLCONF CLIENT-ID ", id_), &serializer));
+  RETURN_ON_ERR(ReadRespReply(&io_buf, &consumed));
+  if (!CheckRespIsSimpleReply("OK")) {
+    LOG(WARNING) << "master did not return OK on id message";
+  }
+
+  if (master_context_.version > DflyVersion::VER0) {
+    RETURN_ON_ERR(
+        SendCommand(StrCat("REPLCONF CLIENT-VERSION ", DflyVersion::CURRENT_VER), &serializer));
+    RETURN_ON_ERR(ReadRespReply(&io_buf, &consumed));
+    if (!CheckRespIsSimpleReply("OK")) {
+      LOG(ERROR) << "Unexpected response " << ToSV(io_buf.InputBuffer());
+      return make_error_code(errc::bad_message);
+    }
+  }
+
   return error_code{};
 }
 

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -14,6 +14,7 @@
 #include "facade/redis_parser.h"
 #include "server/common.h"
 #include "server/journal/types.h"
+#include "server/version.h"
 #include "util/fiber_socket_base.h"
 
 namespace facade {
@@ -38,6 +39,8 @@ class Replica {
     std::string master_repl_id;
     std::string dfly_session_id;         // Sync session id for dfly sync.
     uint32_t dfly_flow_id = UINT32_MAX;  // Flow id if replica acts as a dfly flow.
+
+    DflyVersion version = DflyVersion::VER0;
 
     std::string Description() const;
   };

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -127,6 +127,9 @@ class Replica {
   std::error_code ConnectAndAuth(std::chrono::milliseconds connect_timeout_ms);
   std::error_code Greet();  // Send PING and REPLCONF.
 
+  std::error_code HandleCapaDflyResp();
+  std::error_code ConfigureDflyMaster();
+
   std::error_code InitiatePSync();     // Redis full sync.
   std::error_code InitiateDflySync();  // Dragonfly full sync.
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1936,6 +1936,8 @@ void ServerFamily::ReplConf(CmdArgList args, ConnectionContext* cntx) {
       if (!absl::SimpleAtoi(arg, &version)) {
         return (*cntx)->SendError(kInvalidIntErr);
       }
+      VLOG(1) << "Client version for session_id="
+              << cntx->conn_state.replicaiton_info.repl_session_id << " is " << version;
       cntx->conn_state.replicaiton_info.repl_version = DflyVersion(version);
     } else {
       VLOG(1) << cmd << " " << arg;

--- a/src/server/version.h
+++ b/src/server/version.h
@@ -13,4 +13,20 @@ extern const char kBuildTime[];
 
 const char* GetVersion();
 
+// An enum for internal versioning of dragonfly specific behavior.
+// Please document for each new entry what the behavior changes are
+// and to which released versions this corresponds.
+enum class DflyVersion {
+  // Versions <=1.3
+  VER0,
+
+  // Versions 1.4<=
+  // - Supports receiving ACKs from replicas
+  // - Sends version back on REPLCONF capa dragonfly
+  VER1,
+
+  // Always points to the latest version
+  CURRENT_VER = VER1,
+};
+
 }  // namespace dfly


### PR DESCRIPTION
Implement support for #1216: We now send the server version to the client in the `replconf capa dragonfly` response, and the client sends back its version with `replconf client-version ver`.


I'd like to rebase #1259 on top of this in order to conditionally disable the ACKs.