### PR TITLE
fix: Clarify logging for snapshots loading.

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -586,6 +586,11 @@ void ServerFamily::Shutdown() {
   });
 }
 
+struct AggregateLoadResult {
+  AggregateError first_error;
+  std::atomic<size_t> keys_read;
+};
+
 // Load starts as many fibers as there are files to load each one separately.
 // It starts one more fiber that waits for all load fibers to finish and returns the first
 // error (if any occured) with a future.
@@ -640,7 +645,7 @@ Future<std::error_code> ServerFamily::Load(const std::string& load_path) {
   vector<Fiber> load_fibers;
   load_fibers.reserve(paths.size());
 
-  auto first_error = std::make_shared<AggregateError>();
+  auto load_result = std::make_shared<AggregateLoadResult>();
 
   for (auto& path : paths) {
     // For single file, choose thread that does not handle shards if possible.
@@ -652,8 +657,10 @@ Future<std::error_code> ServerFamily::Load(const std::string& load_path) {
       proactor = pool.GetNextProactor();
     }
 
-    auto load_fiber = [this, first_error, path = std::move(path)]() {
-      *first_error = LoadRdb(path);
+    auto load_fiber = [this, load_result, path = std::move(path)]() {
+      size_t keys_loaded = 0;
+      load_result->first_error = LoadRdb(path, &keys_loaded);
+      load_result->keys_read.fetch_add(keys_loaded);
     };
     load_fibers.push_back(proactor->LaunchFiber(std::move(load_fiber)));
   }
@@ -662,15 +669,15 @@ Future<std::error_code> ServerFamily::Load(const std::string& load_path) {
   Future<std::error_code> ec_future = ec_promise.get_future();
 
   // Run fiber that empties the channel and sets ec_promise.
-  auto load_join_fiber = [this, first_error, load_fibers = std::move(load_fibers),
+  auto load_join_fiber = [this, load_result, load_fibers = std::move(load_fibers),
                           ec_promise = std::move(ec_promise)]() mutable {
     for (auto& fiber : load_fibers) {
       fiber.Join();
     }
 
-    VLOG(1) << "Load finished";
+    LOG(INFO) << "Load finished, num keys read: " << load_result->keys_read;
     service_.SwitchState(GlobalState::LOADING, GlobalState::ACTIVE);
-    ec_promise.set_value(**first_error);
+    ec_promise.set_value(*(load_result->first_error));
   };
   pool.GetNextProactor()->Dispatch(std::move(load_join_fiber));
 
@@ -709,7 +716,7 @@ void ServerFamily::SnapshotScheduling(const SnapshotSpec& spec) {
   }
 }
 
-error_code ServerFamily::LoadRdb(const std::string& rdb_file) {
+error_code ServerFamily::LoadRdb(const std::string& rdb_file, size_t* keys_loaded) {
   error_code ec;
   io::ReadonlyFileOrError res;
 
@@ -725,9 +732,10 @@ error_code ServerFamily::LoadRdb(const std::string& rdb_file) {
     RdbLoader loader{&service_};
     ec = loader.Load(&fs);
     if (!ec) {
-      LOG(INFO) << "Done loading RDB, keys loaded: " << loader.keys_loaded();
-      LOG(INFO) << "Loading finished after "
-                << strings::HumanReadableElapsedTime(loader.load_time());
+      VLOG(1) << "Done loading RDB from " << rdb_file << ", keys loaded: " << loader.keys_loaded();
+      VLOG(1) << "Loading finished after " << strings::HumanReadableElapsedTime(loader.load_time());
+      if (keys_loaded)
+        *keys_loaded = loader.keys_loaded();
     }
   } else {
     ec = res.error();

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -173,7 +173,8 @@ class ServerFamily {
 
   void SyncGeneric(std::string_view repl_master_id, uint64_t offs, ConnectionContext* cntx);
 
-  std::error_code LoadRdb(const std::string& rdb_file, size_t* keys_loaded = nullptr);
+  // Returns the number of loaded keys if successfull.
+  io::Result<size_t> LoadRdb(const std::string& rdb_file);
 
   void SnapshotScheduling(const SnapshotSpec& time);
 

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -173,7 +173,7 @@ class ServerFamily {
 
   void SyncGeneric(std::string_view repl_master_id, uint64_t offs, ConnectionContext* cntx);
 
-  std::error_code LoadRdb(const std::string& rdb_file);
+  std::error_code LoadRdb(const std::string& rdb_file, size_t* keys_loaded = nullptr);
 
   void SnapshotScheduling(const SnapshotSpec& time);
 


### PR DESCRIPTION
Close #1309.

Example output:
```
I20230529 15:37:32.397684 291516 server_family.cc:635] Loading /home/roy/work/dragonfly/build-dbg/dump-2023-05-29T15:37:31-summary.dfs
I20230529 15:37:32.400419 291520 listener_interface.cc:96] sock[53] AcceptServer - listening on port 6379
I20230529 15:37:32.402602 291519 server_family.cc:678] Load finished, num keys read: 2000
```