### PR TITLE
feat: simple search indices (unused)

### DIFF
--- a/src/core/search/CMakeLists.txt
+++ b/src/core/search/CMakeLists.txt
@@ -3,7 +3,7 @@ gen_bison(parser)
 
 cur_gen_dir(gen_dir)
 
-add_library(query_parser base.cc ast_expr.cc query_driver.cc search.cc
+add_library(query_parser base.cc ast_expr.cc indices.cc query_driver.cc search.cc
     ${gen_dir}/parser.cc ${gen_dir}/lexer.cc)
 target_link_libraries(query_parser base absl::strings TRDP::reflex)
 cxx_test(search_parser_test query_parser LABELS DFLY)

--- a/src/core/search/base.h
+++ b/src/core/search/base.h
@@ -22,4 +22,15 @@ struct DocumentAccessor {
   virtual bool Check(FieldConsumer f, std::string_view active_field) const = 0;
 };
 
+using DocId = uint32_t;
+
+// Base class for type-specific indices.
+//
+// Queries should be done directly on subclasses with their distinc
+// query functions. All results for all index types should be sorted.
+struct BaseIndex {
+  virtual ~BaseIndex() = default;
+  virtual void Add(DocId doc, std::string_view value) = 0;
+};
+
 }  // namespace dfly::search

--- a/src/core/search/indices.cc
+++ b/src/core/search/indices.cc
@@ -56,8 +56,8 @@ vector<DocId> NumericIndex::Range(int64_t l, int64_t r) const {
 
 void TextIndex::Add(DocId doc, string_view value) {
   for (const auto& word : GetWords(value)) {
-    entries_[word].push_back(doc);
-    sort(entries_[word].begin(), entries_[word].end());
+    auto& list = entries_[word];
+    list.insert(upper_bound(list.begin(), list.end(), doc), doc);
   }
 }
 

--- a/src/core/search/indices.cc
+++ b/src/core/search/indices.cc
@@ -1,0 +1,69 @@
+// Copyright 2023, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "core/search/indices.h"
+
+#include <absl/container/flat_hash_set.h>
+#include <absl/strings/ascii.h>
+#include <absl/strings/numbers.h>
+
+#include <algorithm>
+#include <regex>
+
+#include "base/logging.h"
+
+namespace dfly::search {
+
+using namespace std;
+
+namespace {
+
+// Get all words from text as matched by regex word boundaries
+vector<string> GetWords(string_view text) {
+  std::regex rx{"\\b.*?\\b", std::regex_constants::icase};
+  std::cregex_iterator begin{text.data(), text.data() + text.size(), rx}, end{};
+
+  absl::flat_hash_set<string> words;
+  for (auto it = begin; it != end; ++it) {
+    auto word = it->str();
+    absl::AsciiStrToLower(&word);
+    words.insert(move(word));
+  }
+
+  return vector<string>{make_move_iterator(words.begin()), make_move_iterator(words.end())};
+}
+
+};  // namespace
+
+void NumericIndex::Add(DocId doc, string_view value) {
+  int64_t num;
+  if (absl::SimpleAtoi(value, &num))
+    entries_.emplace(num, doc);
+}
+
+vector<DocId> NumericIndex::Range(int64_t l, int64_t r) const {
+  auto it_l = entries_.lower_bound({l, 0});
+  auto it_r = entries_.lower_bound({r, numeric_limits<DocId>::max()});
+
+  vector<DocId> out;
+  for (auto it = it_l; it != it_r; ++it)
+    out.push_back(it->second);
+
+  sort(out.begin(), out.end());
+  return out;
+}
+
+void TextIndex::Add(DocId doc, string_view value) {
+  for (const auto& word : GetWords(value)) {
+    entries_[word].push_back(doc);
+    sort(entries_[word].begin(), entries_[word].end());
+  }
+}
+
+vector<DocId> TextIndex::Matching(string_view word_sv) const {
+  auto it = entries_.find(word_sv);
+  return (it != entries_.end()) ? it->second : vector<DocId>{};
+}
+
+}  // namespace dfly::search

--- a/src/core/search/indices.h
+++ b/src/core/search/indices.h
@@ -1,0 +1,37 @@
+// Copyright 2023, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include <absl/container/flat_hash_map.h>
+
+#include <optional>
+#include <set>
+#include <vector>
+
+#include "core/search/base.h"
+
+namespace dfly::search {
+
+// Index for integer fields.
+// Range bounds are queried in logarithmic time, iteration is constant.
+struct NumericIndex : public BaseIndex {
+  void Add(DocId doc, std::string_view value) override;
+
+  std::vector<DocId> Range(int64_t l, int64_t r) const;
+
+ private:
+  std::set<std::pair<uint64_t, DocId>> entries_;
+};
+
+// Index for text fields.
+// Hashmap based lookup per word.
+struct TextIndex : public BaseIndex {
+  void Add(DocId doc, std::string_view value) override;
+
+  std::vector<DocId> Matching(std::string_view word) const;
+
+ private:
+  absl::flat_hash_map<std::string, std::vector<DocId>> entries_;
+};
+
+}  // namespace dfly::search

--- a/src/core/search/indices.h
+++ b/src/core/search/indices.h
@@ -20,7 +20,7 @@ struct NumericIndex : public BaseIndex {
   std::vector<DocId> Range(int64_t l, int64_t r) const;
 
  private:
-  std::set<std::pair<uint64_t, DocId>> entries_;
+  std::set<std::pair<int64_t, DocId>> entries_;
 };
 
 // Index for text fields.


### PR DESCRIPTION
Implements two basic search indices without any optimizations.
* TextIndex
* NumericIndex

I've just cut them out of my larger PR #1294 .

So far at this step they're dead simple, so I don't see any reason to test them. The tests in the main PR verify correctness good enough