### PR TITLE
chore: split search tests + pr preparation

### DIFF
--- a/src/core/search/CMakeLists.txt
+++ b/src/core/search/CMakeLists.txt
@@ -7,3 +7,4 @@ add_library(query_parser base.cc ast_expr.cc query_driver.cc search.cc
     ${gen_dir}/parser.cc ${gen_dir}/lexer.cc)
 target_link_libraries(query_parser base absl::strings TRDP::reflex)
 cxx_test(search_parser_test query_parser LABELS DFLY)
+cxx_test(search_test query_parser LABELS DFLY)

--- a/src/core/search/search_parser_test.cc
+++ b/src/core/search/search_parser_test.cc
@@ -8,8 +8,7 @@
 #include "core/search/query_driver.h"
 #include "core/search/search.h"
 
-namespace dfly {
-namespace search {
+namespace dfly::search {
 
 using namespace std;
 
@@ -34,51 +33,7 @@ class SearchParserTest : public ::testing::Test {
     return Parser(&query_driver_)();
   }
 
-  void ParseExpr(const std::string& str) {
-    raw_expr_ = str;
-    CHECK(search_algo_.Init(str));
-  }
-
-  bool Check(DocumentAccessor* doc) const {
-    return search_algo_.Check(doc);
-  }
-
-  string DebugExpr() const {
-    return raw_expr_;
-  }
-
-  string raw_expr_;
-  SearchAlgorithm search_algo_;
   QueryDriver query_driver_;
-};
-
-class MockedDocument : public DocumentAccessor {
- public:
-  using Map = std::unordered_map<std::string, std::string>;
-
-  MockedDocument() = default;
-  MockedDocument(std::string test_field) : hset_{{"field", test_field}} {
-  }
-
-  bool Check(DocumentAccessor::FieldConsumer f, string_view active_field) const override {
-    if (!active_field.empty()) {
-      auto it = hset_.find(string{active_field});
-      return f(it != hset_.end() ? it->second : "");
-    } else {
-      for (const auto& [k, v] : hset_) {
-        if (f(v))
-          return true;
-      }
-      return false;
-    }
-  }
-
-  void Set(Map hset) {
-    hset_ = hset;
-  }
-
- private:
-  Map hset_{};
 };
 
 // tokens are not assignable, so we can not reuse them. This macros reduce the boilerplate.
@@ -103,22 +58,6 @@ class MockedDocument : public DocumentAccessor {
       caught = true;                          \
     }                                         \
     ASSERT_TRUE(caught);                      \
-  }
-
-#define CHECK_ALL(...)                                                  \
-  {                                                                     \
-    for (auto str : {__VA_ARGS__}) {                                    \
-      MockedDocument hset{str};                                         \
-      EXPECT_TRUE(Check(&hset)) << str << " failed on " << DebugExpr(); \
-    }                                                                   \
-  }
-
-#define CHECK_NONE(...)                                                  \
-  {                                                                      \
-    for (auto str : {__VA_ARGS__}) {                                     \
-      MockedDocument hset{str};                                          \
-      EXPECT_FALSE(Check(&hset)) << str << " failed on " << DebugExpr(); \
-    }                                                                    \
   }
 
 TEST_F(SearchParserTest, Scanner) {
@@ -163,152 +102,4 @@ TEST_F(SearchParserTest, Parse) {
   EXPECT_EQ(1, Parse(" @foo: "));
 }
 
-TEST_F(SearchParserTest, MatchTerm) {
-  ParseExpr("foo");
-
-  // Check basic cases
-  CHECK_ALL("foo", "foo bar", "more foo bar");
-  CHECK_NONE("wrong", "nomatch");
-
-  // Check part of sentence + case.
-  CHECK_ALL("Foo is cool.", "Where is foo?", "One. FOO!. More", "Foo is foo.");
-
-  // Check part of word is not matched
-  CHECK_NONE("foocool", "veryfoos", "ufoo", "morefoomore", "thefoo");
-}
-
-TEST_F(SearchParserTest, MatchNotTerm) {
-  ParseExpr("-foo");
-  CHECK_ALL("faa", "definitielyright");
-  CHECK_NONE("foo", "foo bar", "more foo bar");
-}
-
-TEST_F(SearchParserTest, MatchLogicalNode) {
-  ParseExpr("foo bar");
-
-  CHECK_ALL("foo bar", "bar foo", "more bar and foo");
-  CHECK_NONE("wrong", "foo", "bar", "foob", "far");
-
-  ParseExpr("foo | bar");
-
-  CHECK_ALL("foo bar", "foo", "bar", "foo and more", "or only bar");
-  CHECK_NONE("wrong", "only far");
-
-  ParseExpr("foo bar baz");
-
-  CHECK_ALL("baz bar foo", "bar and foo and baz");
-  CHECK_NONE("wrong", "foo baz", "bar baz", "and foo");
-}
-
-TEST_F(SearchParserTest, MatchParenthesis) {
-  ParseExpr("( foo | oof ) ( bar | rab )");
-
-  CHECK_ALL("foo bar", "oof rab", "foo rab", "oof bar", "foo oof bar rab");
-  CHECK_NONE("wrong", "bar rab", "foo oof");
-}
-
-TEST_F(SearchParserTest, CheckNotPriority) {
-  for (auto expr : {"-bar foo baz", "foo -bar baz", "foo baz -bar"}) {
-    ParseExpr(expr);
-
-    CHECK_ALL("foo baz", "foo rab baz", "baz rab foo");
-    CHECK_NONE("wrong", "bar", "foo bar baz", "foo baz bar");
-  }
-
-  for (auto expr : {"-bar | foo", "foo | -bar"}) {
-    ParseExpr(expr);
-
-    CHECK_ALL("foo", "right", "foo bar");
-    CHECK_NONE("bar", "bar baz");
-  }
-}
-
-TEST_F(SearchParserTest, CheckParenthesisPriority) {
-  ParseExpr("foo | -(bar baz)");
-
-  CHECK_ALL("foo", "not b/r and b/z", "foo bar baz", "single bar", "only baz");
-  CHECK_NONE("bar baz", "some more bar and baz");
-
-  ParseExpr("( foo (bar | baz) (rab | zab) ) | true");
-
-  CHECK_ALL("true", "foo bar rab", "foo baz zab", "foo bar zab");
-  CHECK_NONE("wrong", "foo bar baz", "foo rab zab", "foo bar what", "foo rab foo");
-}
-
-TEST_F(SearchParserTest, MatchField) {
-  ParseExpr("@f1:foo @f2:bar @f3:baz");
-
-  MockedDocument doc{};
-
-  doc.Set({{"f1", "foo"}, {"f2", "bar"}, {"f3", "baz"}});
-  EXPECT_TRUE(Check(&doc));
-
-  doc.Set({{"f1", "foo"}, {"f2", "bar"}, {"f3", "last is wrong"}});
-  EXPECT_FALSE(Check(&doc));
-
-  doc.Set({{"f1", "its"}, {"f2", "totally"}, {"f3", "wrong"}});
-  EXPECT_FALSE(Check(&doc));
-
-  doc.Set({{"f1", "im foo but its only me and"}, {"f2", "bar"}});
-  EXPECT_FALSE(Check(&doc));
-
-  doc.Set({});
-  EXPECT_FALSE(Check(&doc));
-}
-
-TEST_F(SearchParserTest, MatchRange) {
-  ParseExpr("@f1:[1 10] @f2:[50 100]");
-
-  MockedDocument doc{};
-
-  doc.Set({{"f1", "5"}, {"f2", "50"}});
-  EXPECT_TRUE(Check(&doc));
-
-  doc.Set({{"f1", "1"}, {"f2", "100"}});
-  EXPECT_TRUE(Check(&doc));
-
-  doc.Set({{"f1", "10"}, {"f2", "50"}});
-  EXPECT_TRUE(Check(&doc));
-
-  doc.Set({{"f1", "11"}, {"f2", "49"}});
-  EXPECT_FALSE(Check(&doc));
-
-  doc.Set({{"f1", "0"}, {"f2", "101"}});
-  EXPECT_FALSE(Check(&doc));
-}
-
-TEST_F(SearchParserTest, CheckExprInField) {
-  ParseExpr("@f1:(a|b) @f2:(c d) @f3:-e");
-
-  MockedDocument doc{};
-
-  doc.Set({{"f1", "a"}, {"f2", "c and d"}, {"f3", "right"}});
-  EXPECT_TRUE(Check(&doc));
-
-  doc.Set({{"f1", "b"}, {"f2", "d and c"}, {"f3", "ok"}});
-  EXPECT_TRUE(Check(&doc));
-
-  doc.Set({{"f1", "none"}, {"f2", "only d"}, {"f3", "ok"}});
-  EXPECT_FALSE(Check(&doc));
-
-  doc.Set({{"f1", "b"}, {"f2", "d and c"}, {"f3", "it has an e"}});
-  EXPECT_FALSE(Check(&doc)) << DebugExpr();
-
-  ParseExpr({"@f1:(a (b | c) -(d | e)) @f2:-(a|b)"});
-
-  doc.Set({{"f1", "a b w"}, {"f2", "c"}});
-  EXPECT_TRUE(Check(&doc));
-
-  doc.Set({{"f1", "a b d"}, {"f2", "c"}});
-  EXPECT_FALSE(Check(&doc));
-
-  doc.Set({{"f1", "a b w"}, {"f2", "a"}});
-  EXPECT_FALSE(Check(&doc));
-
-  doc.Set({{"f1", "a w"}, {"f2", "c"}});
-  EXPECT_FALSE(Check(&doc));
-}
-
-}  // namespace search
-
-}  // namespace dfly
+}  // namespace dfly::search

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -1,0 +1,279 @@
+// Copyright 2023, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "core/search/search.h"
+
+#include <absl/container/flat_hash_map.h>
+
+#include <algorithm>
+#include <random>
+
+#include "base/gtest.h"
+#include "base/logging.h"
+#include "core/search/base.h"
+#include "core/search/query_driver.h"
+
+namespace dfly {
+namespace search {
+
+using namespace std;
+
+struct MockedDocument : public DocumentAccessor {
+ public:
+  using Map = absl::flat_hash_map<std::string, std::string>;
+
+  MockedDocument() = default;
+  MockedDocument(Map map) : fields_{map} {
+  }
+  MockedDocument(std::string test_field) : fields_{{"field", test_field}} {
+  }
+
+  bool Check(DocumentAccessor::FieldConsumer f, string_view active_field) const override {
+    if (!active_field.empty()) {
+      auto it = fields_.find(string{active_field});
+      return f(it != fields_.end() ? it->second : "");
+    } else {
+      for (const auto& [k, v] : fields_) {
+        if (f(v))
+          return true;
+      }
+      return false;
+    }
+  }
+
+  string DebugFormat() {
+    string out = "{";
+    for (const auto& [field, value] : fields_)
+      absl::StrAppend(&out, field, "=", value, ",");
+    if (out.size() > 1)
+      out.pop_back();
+    out += "}";
+    return out;
+  }
+
+  void Set(Map hset) {
+    fields_ = hset;
+  }
+
+ private:
+  Map fields_{};
+};
+
+// Just a filler. TODO: Remove
+struct Schema {
+  enum FieldType { TEXT, NUMERIC };
+
+  absl::flat_hash_map<std::string, FieldType> fields;
+};
+
+class SearchParserTest : public ::testing::Test {
+ protected:
+  SearchParserTest() {
+    PrepareSchema();
+  }
+
+  ~SearchParserTest() {
+    EXPECT_EQ(entries_.size(), 0u) << "Missing check";
+  }
+
+  void PrepareSchema(Schema schema = {{{"field", Schema::TEXT}}}) {
+    schema_ = schema;
+  }
+
+  void PrepareQuery(string_view query) {
+    query_ = query;
+  }
+
+  template <typename... Args> void ExpectAll(Args... args) {
+    (entries_.emplace_back(args, true), ...);
+  }
+
+  template <typename... Args> void ExpectNone(Args... args) {
+    (entries_.emplace_back(args, false), ...);
+  }
+
+  bool Check() {
+    SearchAlgorithm search_algo{};
+    search_algo.Init(query_);
+
+    for (auto& [doc, expect_match] : entries_) {
+      bool doc_matched = search_algo.Check(&doc);
+
+      if (doc_matched != expect_match) {
+        error_ = "doc: \"" + doc.DebugFormat() + "\"" + " was expected" +
+                 (expect_match ? "" : " not") + " to match" + " query: \"" + query_ + "\"";
+        entries_.clear();
+        return false;
+      }
+    }
+
+    entries_.clear();
+    return true;
+  }
+
+  string_view GetError() const {
+    return error_;
+  }
+
+ private:
+  using DocEntry = pair<MockedDocument, bool /*should_match*/>;
+
+  Schema schema_;
+  vector<DocEntry> entries_;
+  string query_, error_;
+};
+
+TEST_F(SearchParserTest, MatchTerm) {
+  PrepareQuery("foo");
+
+  // Check basic cases
+  ExpectAll("foo", "foo bar", "more foo bar");
+  ExpectNone("wrong", "nomatch");
+
+  // Check part of sentence + case.
+  ExpectAll("Foo is cool.", "Where is foo?", "One. FOO!. More", "Foo is foo.");
+
+  // Check part of word is not matched
+  ExpectNone("foocool", "veryfoos", "ufoo", "morefoomore", "thefoo");
+
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+TEST_F(SearchParserTest, MatchNotTerm) {
+  PrepareQuery("-foo");
+
+  ExpectAll("faa", "definitielyright");
+  ExpectNone("foo", "foo bar", "more foo bar");
+
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+TEST_F(SearchParserTest, MatchLogicalNode) {
+  {
+    PrepareQuery("foo bar");
+
+    ExpectAll("foo bar", "bar foo", "more bar and foo");
+    ExpectNone("wrong", "foo", "bar", "foob", "far");
+
+    EXPECT_TRUE(Check()) << GetError();
+  }
+
+  {
+    PrepareQuery("foo | bar");
+
+    ExpectAll("foo bar", "foo", "bar", "foo and more", "or only bar");
+    ExpectNone("wrong", "only far");
+
+    EXPECT_TRUE(Check()) << GetError();
+  }
+
+  {
+    PrepareQuery("foo bar baz");
+
+    ExpectAll("baz bar foo", "bar and foo and baz");
+    ExpectNone("wrong", "foo baz", "bar baz", "and foo");
+
+    EXPECT_TRUE(Check()) << GetError();
+  }
+}
+
+TEST_F(SearchParserTest, MatchParenthesis) {
+  PrepareQuery("( foo | oof ) ( bar | rab )");
+
+  ExpectAll("foo bar", "oof rab", "foo rab", "oof bar", "foo oof bar rab");
+  ExpectNone("wrong", "bar rab", "foo oof");
+
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+TEST_F(SearchParserTest, CheckNotPriority) {
+  for (auto expr : {"-bar foo baz", "foo -bar baz", "foo baz -bar"}) {
+    PrepareQuery(expr);
+
+    ExpectAll("foo baz", "foo rab baz", "baz rab foo");
+    ExpectNone("wrong", "bar", "foo bar baz", "foo baz bar");
+
+    EXPECT_TRUE(Check()) << GetError();
+  }
+
+  for (auto expr : {"-bar | foo", "foo | -bar"}) {
+    PrepareQuery(expr);
+
+    ExpectAll("foo", "right", "foo bar");
+    ExpectNone("bar", "bar baz");
+
+    EXPECT_TRUE(Check()) << GetError();
+  }
+}
+
+TEST_F(SearchParserTest, CheckParenthesisPriority) {
+  {
+    PrepareQuery("foo | -(bar baz)");
+
+    ExpectAll("foo", "not b/r and b/z", "foo bar baz", "single bar", "only baz");
+    ExpectNone("bar baz", "some more bar and baz");
+
+    EXPECT_TRUE(Check()) << GetError();
+  }
+  {
+    PrepareQuery("( foo (bar | baz) (rab | zab) ) | true");
+
+    ExpectAll("true", "foo bar rab", "foo baz zab", "foo bar zab");
+    ExpectNone("wrong", "foo bar baz", "foo rab zab", "foo bar what", "foo rab foo");
+
+    EXPECT_TRUE(Check()) << GetError();
+  }
+}
+
+using Map = MockedDocument::Map;
+
+TEST_F(SearchParserTest, MatchField) {
+  PrepareSchema({{{"f1", Schema::TEXT}, {"f2", Schema::TEXT}, {"f3", Schema::TEXT}}});
+  PrepareQuery("@f1:foo @f2:bar @f3:baz");
+
+  ExpectAll(Map{{"f1", "foo"}, {"f2", "bar"}, {"f3", "baz"}});
+  ExpectNone(Map{{"f1", "foo"}, {"f2", "bar"}, {"f3", "last is wrong"}},
+             Map{{"f1", "its"}, {"f2", "totally"}, {"f3", "wrong"}},
+             Map{{"f1", "im foo but its only me and"}, {"f2", "bar"}});
+
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+TEST_F(SearchParserTest, MatchRange) {
+  PrepareSchema({{{"f1", Schema::NUMERIC}, {"f2", Schema::NUMERIC}}});
+  PrepareQuery("@f1:[1 10] @f2:[50 100]");
+
+  ExpectAll(Map{{"f1", "5"}, {"f2", "50"}}, Map{{"f1", "1"}, {"f2", "100"}},
+            Map{{"f1", "10"}, {"f2", "50"}});
+  ExpectNone(Map{{"f1", "11"}, {"f2", "49"}}, Map{{"f1", "0"}, {"f2", "101"}});
+
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+TEST_F(SearchParserTest, CheckExprInField) {
+  PrepareSchema({{{"f1", Schema::TEXT}, {"f2", Schema::TEXT}, {"f3", Schema::TEXT}}});
+  {
+    PrepareQuery("@f1:(a|b) @f2:(c d) @f3:-e");
+
+    ExpectAll(Map{{"f1", "a"}, {"f2", "c and d"}, {"f3", "right"}},
+              Map{{"f1", "b"}, {"f2", "d and c"}, {"f3", "ok"}});
+    ExpectNone(Map{{"f1", "none"}, {"f2", "only d"}, {"f3", "ok"}},
+               Map{{"f1", "b"}, {"f2", "d and c"}, {"f3", "it has an e"}});
+
+    EXPECT_TRUE(Check()) << GetError();
+  }
+  {
+    PrepareQuery({"@f1:(a (b | c) -(d | e)) @f2:-(a|b)"});
+
+    ExpectAll(Map{{"f1", "a b w"}, {"f2", "c"}});
+    ExpectNone(Map{{"f1", "a b d"}, {"f2", "c"}}, Map{{"f1", "a b w"}, {"f2", "a"}},
+               Map{{"f1", "a w"}, {"f2", "c"}});
+
+    EXPECT_TRUE(Check()) << GetError();
+  }
+}
+
+}  // namespace search
+
+}  // namespace dfly


### PR DESCRIPTION
Split search test into explicit search and just parser test. 

Taken out of the big PR #1294 