### PR TITLE
feat: track update and delete for search

### DIFF
--- a/src/core/search/base.h
+++ b/src/core/search/base.h
@@ -22,6 +22,7 @@ using DocId = uint32_t;
 struct BaseIndex {
   virtual ~BaseIndex() = default;
   virtual void Add(DocId doc, std::string_view value) = 0;
+  virtual void Remove(DocId doc, std::string_view value) = 0;
 };
 
 }  // namespace dfly::search

--- a/src/core/search/indices.cc
+++ b/src/core/search/indices.cc
@@ -21,7 +21,7 @@ using namespace std;
 namespace {
 
 // Get all words from text as matched by regex word boundaries
-vector<string> Tokenize(string_view text) {
+absl::flat_hash_set<string> Tokenize(string_view text) {
   std::regex rx{"\\b.*?\\b", std::regex_constants::icase};
   std::cregex_iterator begin{text.data(), text.data() + text.size(), rx}, end{};
 
@@ -31,12 +31,11 @@ vector<string> Tokenize(string_view text) {
     absl::AsciiStrToLower(&word);
     words.insert(move(word));
   }
-
-  return vector<string>{make_move_iterator(words.begin()), make_move_iterator(words.end())};
+  return words;
 }
 
 // Split taglist, remove duplicates and convert all to lowercase
-vector<string> NormalizeTags(string_view taglist) {
+absl::flat_hash_set<string> NormalizeTags(string_view taglist) {
   string tmp;
   absl::flat_hash_set<string> tags;
   for (string_view tag : absl::StrSplit(taglist, ',')) {
@@ -44,7 +43,7 @@ vector<string> NormalizeTags(string_view taglist) {
     absl::AsciiStrToLower(&tmp);
     tags.insert(move(tmp));
   }
-  return vector<string>{make_move_iterator(tags.begin()), make_move_iterator(tags.end())};
+  return tags;
 }
 
 };  // namespace

--- a/src/core/search/indices.cc
+++ b/src/core/search/indices.cc
@@ -21,7 +21,7 @@ using namespace std;
 namespace {
 
 // Get all words from text as matched by regex word boundaries
-vector<string> GetWords(string_view text) {
+vector<string> Tokenize(string_view text) {
   std::regex rx{"\\b.*?\\b", std::regex_constants::icase};
   std::cregex_iterator begin{text.data(), text.data() + text.size(), rx}, end{};
 
@@ -35,6 +35,18 @@ vector<string> GetWords(string_view text) {
   return vector<string>{make_move_iterator(words.begin()), make_move_iterator(words.end())};
 }
 
+// Split taglist, remove duplicates and convert all to lowercase
+vector<string> NormalizeTags(string_view taglist) {
+  string tmp;
+  absl::flat_hash_set<string> tags;
+  for (string_view tag : absl::StrSplit(taglist, ',')) {
+    tmp = absl::StripAsciiWhitespace(tag);
+    absl::AsciiStrToLower(&tmp);
+    tags.insert(move(tmp));
+  }
+  return vector<string>{make_move_iterator(tags.begin()), make_move_iterator(tags.end())};
+}
+
 };  // namespace
 
 void NumericIndex::Add(DocId doc, string_view value) {
@@ -43,9 +55,15 @@ void NumericIndex::Add(DocId doc, string_view value) {
     entries_.emplace(num, doc);
 }
 
+void NumericIndex::Remove(DocId doc, string_view value) {
+  int64_t num;
+  if (absl::SimpleAtoi(value, &num))
+    entries_.erase({num, doc});
+}
+
 vector<DocId> NumericIndex::Range(int64_t l, int64_t r) const {
-  auto it_l = entries_.lower_bound(l);
-  auto it_r = entries_.lower_bound(r + 1);
+  auto it_l = entries_.lower_bound({l, 0});
+  auto it_r = entries_.lower_bound({r + 1, 0});
 
   vector<DocId> out;
   for (auto it = it_l; it != it_r; ++it)
@@ -61,17 +79,34 @@ const vector<DocId>* BaseStringIndex::Matching(string_view str) const {
 }
 
 void TextIndex::Add(DocId doc, string_view value) {
-  for (const auto& word : GetWords(value)) {
+  for (const auto& word : Tokenize(value)) {
     auto& list = entries_[word];
     list.insert(upper_bound(list.begin(), list.end(), doc), doc);
   }
 }
 
+void TextIndex::Remove(DocId doc, string_view value) {
+  for (const auto& word : Tokenize(value)) {
+    auto& list = entries_[word];
+    auto it = lower_bound(list.begin(), list.end(), doc);
+    if (it != list.end() && *it == doc)
+      list.erase(it);
+  }
+}
+
 void TagIndex::Add(DocId doc, string_view value) {
-  auto tags = absl::StrSplit(value, ',');
-  for (string_view tag : tags) {
-    auto& list = entries_[absl::StripAsciiWhitespace(tag)];
+  for (auto& tag : NormalizeTags(value)) {
+    auto& list = entries_[tag];
     list.insert(upper_bound(list.begin(), list.end(), doc), doc);
+  }
+}
+
+void TagIndex::Remove(DocId doc, string_view value) {
+  for (auto& tag : NormalizeTags(value)) {
+    auto& list = entries_[tag];
+    auto it = lower_bound(list.begin(), list.end(), doc);
+    if (it != list.end() && *it == doc)
+      list.erase(it);
   }
 }
 

--- a/src/core/search/indices.h
+++ b/src/core/search/indices.h
@@ -2,7 +2,7 @@
 // See LICENSE for licensing terms.
 //
 
-#include <absl/container/btree_map.h>
+#include <absl/container/btree_set.h>
 #include <absl/container/flat_hash_map.h>
 
 #include <map>
@@ -17,11 +17,12 @@ namespace dfly::search {
 // Range bounds are queried in logarithmic time, iteration is constant.
 struct NumericIndex : public BaseIndex {
   void Add(DocId doc, std::string_view value) override;
+  void Remove(DocId doc, std::string_view value) override;
 
   std::vector<DocId> Range(int64_t l, int64_t r) const;
 
  private:
-  absl::btree_multimap<int64_t, DocId> entries_;
+  absl::btree_set<std::pair<int64_t, DocId>> entries_;
 };
 
 // Base index for string based indices.
@@ -37,12 +38,14 @@ struct BaseStringIndex : public BaseIndex {
 // Hashmap based lookup per word.
 struct TextIndex : public BaseStringIndex {
   void Add(DocId doc, std::string_view value) override;
+  void Remove(DocId doc, std::string_view value) override;
 };
 
 // Index for text fields.
 // Hashmap based lookup per word.
 struct TagIndex : public BaseStringIndex {
   void Add(DocId doc, std::string_view value) override;
+  void Remove(DocId doc, std::string_view value) override;
 };
 
 }  // namespace dfly::search

--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -221,8 +221,16 @@ void FieldIndices::Add(DocId doc, DocumentAccessor* access) {
   for (auto& [field, index] : indices_) {
     index->Add(doc, access->Get(field));
   }
-  all_ids_.push_back(doc);
-  sort(all_ids_.begin(), all_ids_.end());
+  all_ids_.insert(upper_bound(all_ids_.begin(), all_ids_.end(), doc), doc);
+}
+
+void FieldIndices::Remove(DocId doc, DocumentAccessor* access) {
+  for (auto& [field, index] : indices_) {
+    index->Remove(doc, access->Get(field));
+  }
+  auto it = lower_bound(all_ids_.begin(), all_ids_.end(), doc);
+  CHECK(it != all_ids_.end() && *it == doc);
+  all_ids_.erase(it);
 }
 
 BaseIndex* FieldIndices::GetIndex(string_view field) const {

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -38,6 +38,7 @@ class FieldIndices {
   FieldIndices(Schema schema);
 
   void Add(DocId doc, DocumentAccessor* access);
+  void Remove(DocId doc, DocumentAccessor* access);
 
   BaseIndex* GetIndex(std::string_view field) const;
   std::vector<TextIndex*> GetAllTextIndices() const;

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -84,6 +84,10 @@ class DbSlice {
     }
   };
 
+  // Called before deleting an element to notify the search indices.
+  using DocDeletionCallback =
+      std::function<void(std::string_view, const Context&, const PrimeValue& pv)>;
+
   struct ExpireParams {
     int64_t value = INT64_MIN;  // undefined
 
@@ -312,6 +316,8 @@ class DbSlice {
   // Unregisted all watched key entries for connection.
   void UnregisterConnectionWatches(ConnectionState::ExecInfo* exec_info);
 
+  void SetDocDeletionCallback(DocDeletionCallback ddcb);
+
  private:
   std::pair<PrimeIterator, bool> AddOrUpdateInternal(const Context& cntx, std::string_view key,
                                                      PrimeValue obj, uint64_t expire_at_ms,
@@ -354,6 +360,9 @@ class DbSlice {
 
   // ordered from the smallest to largest version.
   std::vector<std::pair<uint64_t, ChangeCallback>> change_cb_;
+
+  // Registered by shard indices on when first document index is created.
+  DocDeletionCallback doc_del_cb_;
 };
 
 }  // namespace dfly

--- a/src/server/search/doc_accessors.cc
+++ b/src/server/search/doc_accessors.cc
@@ -74,7 +74,7 @@ SearchDocData JsonAccessor::Serialize() const {
   return out;
 }
 
-unique_ptr<BaseAccessor> GetAccessor(const OpArgs& op_args, const PrimeValue& pv) {
+unique_ptr<BaseAccessor> GetAccessor(const DbContext& db_cntx, const PrimeValue& pv) {
   DCHECK(pv.ObjType() == OBJ_HASH || pv.ObjType() == OBJ_JSON);
 
   if (pv.ObjType() == OBJ_JSON) {
@@ -86,7 +86,7 @@ unique_ptr<BaseAccessor> GetAccessor(const OpArgs& op_args, const PrimeValue& pv
     auto ptr = reinterpret_cast<ListPackAccessor::LpPtr>(pv.RObjPtr());
     return make_unique<ListPackAccessor>(ptr);
   } else {
-    auto* sm = container_utils::GetStringMap(pv, op_args.db_cntx);
+    auto* sm = container_utils::GetStringMap(pv, db_cntx);
     return make_unique<StringMapAccessor>(sm);
   }
 }

--- a/src/server/search/doc_accessors.h
+++ b/src/server/search/doc_accessors.h
@@ -65,6 +65,6 @@ struct JsonAccessor : public BaseAccessor {
 };
 
 // Get accessor for value
-std::unique_ptr<BaseAccessor> GetAccessor(const OpArgs& op_args, const PrimeValue& pv);
+std::unique_ptr<BaseAccessor> GetAccessor(const DbContext& db_cntx, const PrimeValue& pv);
 
 }  // namespace dfly

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -146,7 +146,7 @@ void SearchFamily::FtCreate(CmdArgList args, ConnectionContext* cntx) {
 
   auto idx_ptr = make_shared<DocIndex>(move(index));
   cntx->transaction->ScheduleSingleHop([idx_name, idx_ptr](auto* tx, auto* es) {
-    es->search_indices()->Init(tx->GetOpArgs(es), idx_name, idx_ptr);
+    es->search_indices()->InitIndex(tx->GetOpArgs(es), idx_name, idx_ptr);
     return OpStatus::OK;
   });
 
@@ -170,7 +170,7 @@ void SearchFamily::FtSearch(CmdArgList args, ConnectionContext* cntx) {
   vector<SearchResult> docs(shard_set->size());
 
   cntx->transaction->ScheduleSingleHop([&](Transaction* t, EngineShard* es) {
-    if (auto* index = es->search_indices()->Get(index_name); index)
+    if (auto* index = es->search_indices()->GetIndex(index_name); index)
       docs[es->shard_id()] = index->Search(t->GetOpArgs(es), *params, &search_algo);
     else
       index_not_found.store(true, memory_order_relaxed);


### PR DESCRIPTION
Can only be tested after #1294 

This PR:
* Before the document is changed, calls RemvoeDoc on each shard document index that tracks the document
* After the document is changed, calls AddDoc on the same shard doc indices
* Some small naming changes for less ambiguity

Basically, to update a document, it is fully removed and then fully added. In the future we should only update the indices which are affected by the changed fields (if its possible, definitely for hset, more difficult with json)
