### PR TITLE
feat(cluster): Allow actions on non-owned keys on replication port.

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -593,6 +593,11 @@ void Service::Shutdown() {
 
 bool Service::CheckKeysOwnership(const CommandId* cid, CmdArgList args,
                                  ConnectionContext* dfly_cntx) {
+  if (dfly_cntx->is_replicating) {
+    // Always allow commands on the replication port, as it might be for future-owned keys.
+    return true;
+  }
+
   if (cid->first_key_pos() == 0) {
     return true;  // No key command.
   }

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -379,6 +379,7 @@ async def test_cluster_replica_sets_non_owned_keys(df_local_factory):
     await push_config(replica_config, [c_replica_admin])
 
     # The replica should have deleted the key.
+    # Note: this is not the long-term intended behavior. It will change after we fix #1320.
     assert await c_replica.execute_command("dbsize") == 0
 
     # Set another key on the master, which it owns but the replica does not own.


### PR DESCRIPTION
This allows masters to send data of non-owned keys to their replicas, which is useful when:
1. Config is temporarily different between master and replica
2. Preparing for taking ownership over currently not-owned slots (in the
   upcoming migration feature)

Fixed #1319

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->