### PR TITLE
feat(streams): Add support for XTRIM

### DIFF
--- a/src/server/stream_family.h
+++ b/src/server/stream_family.h
@@ -25,6 +25,7 @@ class StreamFamily {
   static void XRange(CmdArgList args, ConnectionContext* cntx);
   static void XRead(CmdArgList args, ConnectionContext* cntx);
   static void XSetId(CmdArgList args, ConnectionContext* cntx);
+  static void XTrim(CmdArgList args, ConnectionContext* cntx);
   static void XRangeGeneric(CmdArgList args, bool is_rev, ConnectionContext* cntx);
 };
 


### PR DESCRIPTION
Adds support for XTRIM (https://github.com/dragonflydb/dragonfly/issues/1332)
* Renames `TrimStrategy` enum given the `AddOptsTrim` prefix seems redundant given its always prefixed by `TrimStrategy`?
* Adds `OpTrim` which is the same as trimming in `OpAdd` (theres a TODO about handling replication copied over from `OpAdd` which seems out of scope for this)
* Refactors `XADD` and `XTRIM` argument parsing into `ParseAddOrTrimArgsOrReply` (which matches how Redis parses the commands given their arguments are very similar)