### PR TITLE
fix: remove redundant list assertions

### DIFF
--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -536,7 +536,6 @@ OpResult<int> OpInsert(const OpArgs& op_args, string_view key, string_view pivot
 }
 
 OpResult<uint32_t> OpRem(const OpArgs& op_args, string_view key, string_view elem, long count) {
-  DCHECK(!elem.empty());
   auto& db_slice = op_args.shard->db_slice();
   auto it_res = db_slice.Find(op_args.db_cntx, key, OBJ_LIST);
   if (!it_res)
@@ -579,7 +578,6 @@ OpResult<uint32_t> OpRem(const OpArgs& op_args, string_view key, string_view ele
 }
 
 OpStatus OpSet(const OpArgs& op_args, string_view key, string_view elem, long index) {
-  DCHECK(!elem.empty());
   auto& db_slice = op_args.shard->db_slice();
   auto it_res = db_slice.Find(op_args.db_cntx, key, OBJ_LIST);
   if (!it_res)


### PR DESCRIPTION
Removes `OpRem` and `OpSet` assertions that check the new element is not empty. Running locally both work fine with empty elements.

Empty elements in `LREM` and `LSET` are supported by Redis, eg `EVAL "redis.call('RPUSH', 'mylist', 'one'); redis.call('LSET', 'mylist', 0, '');" 0`, and are used by bullmq (https://github.com/taskforcesh/bullmq/blob/master/src/commands/includes/cleanList.lua#L36) (see https://github.com/dragonflydb/dragonfly/issues/782)

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->