### PR TITLE
feat: Support tags in search

### DIFF
--- a/src/core/search/ast_expr.cc
+++ b/src/core/search/ast_expr.cc
@@ -9,6 +9,8 @@
 #include <algorithm>
 #include <regex>
 
+#include "base/logging.h"
+
 using namespace std;
 
 namespace dfly::search {
@@ -40,6 +42,18 @@ AstLogicalNode::AstLogicalNode(AstNode&& l, AstNode&& r, LogicOp op) : op{op}, n
 
 AstFieldNode::AstFieldNode(string field, AstNode&& node)
     : field{field.substr(1)}, node{make_unique<AstNode>(move(node))} {
+}
+
+AstTagsNode::AstTagsNode(std::string tag) {
+  tags = {move(tag)};
+}
+
+AstTagsNode::AstTagsNode(AstExpr&& l, std::string tag) {
+  DCHECK(holds_alternative<AstTagsNode>(l));
+  auto& tags_node = get<AstTagsNode>(l);
+
+  tags = move(tags_node.tags);
+  tags.push_back(move(tag));
 }
 
 }  // namespace dfly::search

--- a/src/core/search/ast_expr.h
+++ b/src/core/search/ast_expr.h
@@ -59,8 +59,16 @@ struct AstFieldNode {
   std::unique_ptr<AstNode> node;
 };
 
+// Stores a list of tags for a tag query
+struct AstTagsNode {
+  AstTagsNode(std::string tag);
+  AstTagsNode(AstNode&& l, std::string tag);
+
+  std::vector<std::string> tags;
+};
+
 using NodeVariants = std::variant<std::monostate, AstTermNode, AstRangeNode, AstNegateNode,
-                                  AstLogicalNode, AstFieldNode>;
+                                  AstLogicalNode, AstFieldNode, AstTagsNode>;
 struct AstNode : public NodeVariants {
   using variant::variant;
 };

--- a/src/core/search/indices.h
+++ b/src/core/search/indices.h
@@ -23,15 +23,24 @@ struct NumericIndex : public BaseIndex {
   std::set<std::pair<int64_t, DocId>> entries_;
 };
 
+// Base index for string based indices.
+struct BaseStringIndex : public BaseIndex {
+  std::vector<DocId> Matching(std::string_view str) const;
+
+ protected:
+  absl::flat_hash_map<std::string, std::vector<DocId>> entries_;
+};
+
 // Index for text fields.
 // Hashmap based lookup per word.
-struct TextIndex : public BaseIndex {
+struct TextIndex : public BaseStringIndex {
   void Add(DocId doc, std::string_view value) override;
+};
 
-  std::vector<DocId> Matching(std::string_view word) const;
-
- private:
-  absl::flat_hash_map<std::string, std::vector<DocId>> entries_;
+// Index for text fields.
+// Hashmap based lookup per word.
+struct TagIndex : public BaseStringIndex {
+  void Add(DocId doc, std::string_view value) override;
 };
 
 }  // namespace dfly::search

--- a/src/core/search/lexer.lex
+++ b/src/core/search/lexer.lex
@@ -58,6 +58,8 @@ term_char [_]|\w
 "=>"           return Parser::make_ARROW (loc());
 "["            return Parser::make_LBRACKET (loc());
 "]"            return Parser::make_RBRACKET (loc());
+"{"            return Parser::make_LCURLBR (loc());
+"}"            return Parser::make_RCURLBR (loc());
 "|"            return Parser::make_OR_OP (loc());
 
 -?[0-9]+       return make_INT64(matched_view(), loc());

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -26,7 +26,7 @@ struct DocumentAccessor {
 };
 
 struct Schema {
-  enum FieldType { TEXT, NUMERIC };
+  enum FieldType { TAG, TEXT, NUMERIC };
 
   absl::flat_hash_map<std::string, FieldType> fields;
 };

--- a/src/core/search/search_parser_test.cc
+++ b/src/core/search/search_parser_test.cc
@@ -85,6 +85,13 @@ TEST_F(SearchParserTest, Scanner) {
   NEXT_TOK(TOK_COLON);
   NEXT_EQ(TOK_TERM, string, "hello");
 
+  SetInput("@field:{ tag }");
+  NEXT_EQ(TOK_FIELD, string, "@field");
+  NEXT_TOK(TOK_COLON);
+  NEXT_TOK(TOK_LCURLBR);
+  NEXT_EQ(TOK_TERM, string, "tag");
+  NEXT_TOK(TOK_RCURLBR);
+
   SetInput("почтальон Печкин");
   NEXT_EQ(TOK_TERM, string, "почтальон");
   NEXT_EQ(TOK_TERM, string, "Печкин");
@@ -96,6 +103,8 @@ TEST_F(SearchParserTest, Scanner) {
 TEST_F(SearchParserTest, Parse) {
   EXPECT_EQ(0, Parse(" foo bar (baz) "));
   EXPECT_EQ(0, Parse(" -(foo) @foo:bar @ss:[1 2]"));
+  EXPECT_EQ(0, Parse("@foo:{ tag1 | tag2 }"));
+
   EXPECT_EQ(1, Parse(" -(foo "));
   EXPECT_EQ(1, Parse(" foo:bar "));
   EXPECT_EQ(1, Parse(" @foo:@bar "));

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -31,7 +31,9 @@ using namespace facade;
 namespace {
 
 unordered_map<string_view, search::Schema::FieldType> kSchemaTypes = {
-    {"TEXT"sv, search::Schema::TEXT}, {"NUMERIC"sv, search::Schema::NUMERIC}};
+    {"TAG"sv, search::Schema::TAG},
+    {"TEXT"sv, search::Schema::TEXT},
+    {"NUMERIC"sv, search::Schema::NUMERIC}};
 
 optional<search::Schema> ParseSchemaOrReply(CmdArgList args, ConnectionContext* cntx) {
   search::Schema schema;
@@ -48,6 +50,12 @@ optional<search::Schema> ParseSchemaOrReply(CmdArgList args, ConnectionContext* 
     if (it == kSchemaTypes.end()) {
       (*cntx)->SendError("Invalid field type: " + string{type_str});
       return nullopt;
+    }
+
+    // Skip optional WEIGHT or SEPARATOR flags
+    if (i + 2 < args.size() &&
+        (ArgS(args, i + 1) == "WEIGHT" || ArgS(args, i + 1) == "SEPARATOR")) {
+      i += 2;
     }
 
     schema.fields[field] = it->second;

--- a/tests/dragonfly/search_test.py
+++ b/tests/dragonfly/search_test.py
@@ -6,18 +6,25 @@ import pytest
 from redis import asyncio as aioredis
 from .utility import *
 
-from redis.commands.search.query import Query
-from redis.commands.search.field import TextField
+from redis.commands.search.field import TextField, NumericField, TagField
 from redis.commands.search.indexDefinition import IndexDefinition, IndexType
 
 TEST_DATA = [
-    {"title": "First article", "content": "Long description"},
-    {"title": "Second article", "content": "Small text"},
-    {"title": "Third piece", "content": "Brief description"},
-    {"title": "Last piece", "content": "Interesting text"},
+    {"title": "First article", "content": "Long description",
+        "views": 100, "topic": "world, science"},
+
+    {"title": "Second article", "content": "Small text",
+        "views": 200, "topic": "national, policits"},
+
+    {"title": "Third piece", "content": "Brief description",
+        "views": 300, "topic": "health, lifestyle"},
+
+    {"title": "Last piece", "content": "Interesting text",
+        "views": 400, "topic": "world, business"},
 ]
 
-TEST_DATA_SCHEMA = [TextField("title"), TextField("content")]
+TEST_DATA_SCHEMA = [TextField("title"), TextField(
+    "content"), NumericField("views"), TagField("topic")]
 
 
 async def index_test_data(async_client: aioredis.Redis, itype: IndexType, prefix=""):
@@ -27,17 +34,24 @@ async def index_test_data(async_client: aioredis.Redis, itype: IndexType, prefix
         else:
             await async_client.json().set(prefix+str(i), "$", e)
 
+def doc_to_str(doc):
+    if not type(doc) is dict:
+        doc = doc.__dict__
+
+    doc = dict(doc) # copy to remove fields
+    doc.pop('id', None)
+    doc.pop('payload', None)
+
+    return '//'.join(sorted(doc))
 
 def contains_test_data(res, td_indices):
     if res.total != len(td_indices):
         return False
 
-    docset = set()
-    for doc in res.docs:
-        docset.add(f"{doc.title}//{doc.content}")
+    docset = {doc_to_str(doc) for doc in res.docs}
 
     for td_entry in (TEST_DATA[tdi] for tdi in td_indices):
-        if not f"{td_entry['title']}//{td_entry['content']}" in docset:
+        if not doc_to_str(td_entry) in docset:
             return False
 
     return True
@@ -46,8 +60,8 @@ def contains_test_data(res, td_indices):
 @pytest.mark.parametrize("index_type", [IndexType.HASH, IndexType.JSON])
 async def test_basic(async_client, index_type):
     i1 = async_client.ft("i-"+str(index_type))
-    await i1.create_index(TEST_DATA_SCHEMA, definition=IndexDefinition(index_type=index_type))
     await index_test_data(async_client, index_type)
+    await i1.create_index(TEST_DATA_SCHEMA, definition=IndexDefinition(index_type=index_type))
 
     res = await i1.search("article")
     assert contains_test_data(res, [0, 1])
@@ -60,3 +74,21 @@ async def test_basic(async_client, index_type):
 
     res = await i1.search("@title:(article|last) @content:text")
     assert contains_test_data(res, [1, 3])
+
+    res = await i1.search("@views:[200 300]")
+    assert contains_test_data(res, [1, 2])
+
+    res = await i1.search("@views:[0 150] | @views:[350 500]")
+    assert contains_test_data(res, [0, 3])
+
+    res = await i1.search("@topic:{world}")
+    assert contains_test_data(res, [0, 3])
+
+    res = await i1.search("@topic:{business}")
+    assert contains_test_data(res, [3])
+
+    res = await i1.search("@topic:{world | national}")
+    assert contains_test_data(res, [0, 1, 3])
+
+    res = await i1.search("@topic:{science | health}")
+    assert contains_test_data(res, [0, 2])


### PR DESCRIPTION
This PR adds support for [RediSearch Tags](https://redis.io/docs/stack/search/reference/tags/) in the whole pipeline from parser to ft.create schema.
