### PR TITLE
fix(cluster): Fix crash when getting `DFLYCLUSTER GETSLOTINFO` with no other args.

### DIFF
--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -434,7 +434,7 @@ void ClusterFamily::DflyClusterConfig(CmdArgList args, ConnectionContext* cntx) 
 }
 
 void ClusterFamily::DflyClusterGetSlotInfo(CmdArgList args, ConnectionContext* cntx) {
-  if (args.size() == 2) {
+  if (args.size() <= 2) {
     return (*cntx)->SendError(facade::WrongNumArgsError("DFLYCLUSTER GETSLOTINFO"), kSyntaxErrType);
   }
   ToUpper(&args[1]);

--- a/src/server/cluster_family_test.cc
+++ b/src/server/cluster_family_test.cc
@@ -430,6 +430,14 @@ TEST_F(ClusterFamilyTest, ClusterConfigFullMultipleInstances) {
   }
 }
 
+TEST_F(ClusterFamilyTest, ClusterGetSlotInfoInvalid) {
+  constexpr string_view kTooFewArgs =
+      "ERR wrong number of arguments for 'dflycluster getslotinfo' command";
+  EXPECT_THAT(RunAdmin({"dflycluster", "getslotinfo"}), ErrArg(kTooFewArgs));
+  EXPECT_THAT(RunAdmin({"dflycluster", "getslotinfo", "s"}), ErrArg(kTooFewArgs));
+  EXPECT_THAT(RunAdmin({"dflycluster", "getslotinfo", "slots"}), ErrArg(kTooFewArgs));
+}
+
 TEST_F(ClusterFamilyTest, ClusterGetSlotInfo) {
   string config_template = R"json(
       [


### PR DESCRIPTION

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->