### PR TITLE
feat(cluster): Add `total_reads` and `total_writes` to `GETSLOTSINFO`.

### DIFF
--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -437,6 +437,7 @@ void ClusterFamily::DflyClusterGetSlotInfo(CmdArgList args, ConnectionContext* c
   if (args.size() <= 2) {
     return (*cntx)->SendError(facade::WrongNumArgsError("DFLYCLUSTER GETSLOTINFO"), kSyntaxErrType);
   }
+
   ToUpper(&args[1]);
   string_view slots_str = ArgS(args, 1);
   if (slots_str != "SLOTS") {
@@ -474,10 +475,14 @@ void ClusterFamily::DflyClusterGetSlotInfo(CmdArgList args, ConnectionContext* c
   (*cntx)->StartArray(slots_stats.size());
 
   for (const auto& slot_data : slots_stats) {
-    (*cntx)->StartArray(3);
-    (*cntx)->SendBulkString(absl::StrCat(slot_data.first));
+    (*cntx)->StartArray(7);
+    (*cntx)->SendLong(slot_data.first);
     (*cntx)->SendBulkString("key_count");
-    (*cntx)->SendBulkString(absl::StrCat(slot_data.second.key_count));
+    (*cntx)->SendLong(static_cast<long>(slot_data.second.key_count));
+    (*cntx)->SendBulkString("total_reads");
+    (*cntx)->SendLong(static_cast<long>(slot_data.second.total_reads));
+    (*cntx)->SendBulkString("total_writes");
+    (*cntx)->SendLong(static_cast<long>(slot_data.second.total_writes));
   }
 }
 

--- a/src/server/table.cc
+++ b/src/server/table.cc
@@ -34,10 +34,11 @@ DbTableStats& DbTableStats::operator+=(const DbTableStats& o) {
 }
 
 SlotStats& SlotStats::operator+=(const SlotStats& o) {
-  constexpr size_t kDbSz = sizeof(SlotStats);
-  static_assert(kDbSz == 8);
+  static_assert(sizeof(SlotStats) == 24);
 
   ADD(key_count);
+  ADD(total_reads);
+  ADD(total_writes);
   return *this;
 }
 

--- a/src/server/table.h
+++ b/src/server/table.h
@@ -39,6 +39,8 @@ inline bool IsValid(ExpireIterator it) {
 
 struct SlotStats {
   uint64_t key_count = 0;
+  uint64_t total_reads = 0;
+  uint64_t total_writes = 0;
   SlotStats& operator+=(const SlotStats& o);
 };
 


### PR DESCRIPTION
While at it, modify response such that it returns numbers instead of strings for numerical values.

#1318

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->