### PR TITLE
feat(cluster): Use thread-local cluster config

### DIFF
--- a/src/server/cluster/cluster_config.cc
+++ b/src/server/cluster/cluster_config.cc
@@ -114,11 +114,11 @@ unique_ptr<ClusterConfig> ClusterConfig::CreateFromConfig(string_view my_id,
   result->config_ = config;
 
   for (const auto& shard : result->config_) {
-    for (const auto& slot_range : shard.slot_ranges) {
-      bool owned_by_me =
-          shard.master.id == my_id || any_of(shard.replicas.begin(), shard.replicas.end(),
-                                             [&](const Node& node) { return node.id == my_id; });
-      if (owned_by_me) {
+    bool owned_by_me =
+        shard.master.id == my_id || any_of(shard.replicas.begin(), shard.replicas.end(),
+                                           [&](const Node& node) { return node.id == my_id; });
+    if (owned_by_me) {
+      for (const auto& slot_range : shard.slot_ranges) {
         for (SlotId i = slot_range.start; i <= slot_range.end; ++i) {
           result->my_slots_.set(i);
         }

--- a/src/server/cluster/cluster_config.cc
+++ b/src/server/cluster/cluster_config.cc
@@ -1,3 +1,5 @@
+#include <optional>
+
 extern "C" {
 #include "redis/crc16.h"
 }
@@ -32,10 +34,6 @@ SlotId ClusterConfig::KeySlot(string_view key) {
   return crc16(tag.data(), tag.length()) & kMaxSlotNum;
 }
 
-ClusterConfig::ClusterConfig(string_view my_id) : my_id_(my_id) {
-  cluster_enabled = true;
-}
-
 namespace {
 bool HasValidNodeIds(const ClusterConfig::ClusterShards& new_config) {
   absl::flat_hash_set<string_view> nodes;
@@ -60,11 +58,10 @@ bool HasValidNodeIds(const ClusterConfig::ClusterShards& new_config) {
 
   return true;
 }
-}  // namespace
 
-bool ClusterConfig::IsConfigValid(const ClusterShards& new_config) {
+bool IsConfigValid(const ClusterConfig::ClusterShards& new_config) {
   // Make sure that all slots are set exactly once.
-  array<bool, tuple_size<decltype(slots_)>::value> slots_found = {};
+  array<bool, ClusterConfig::kMaxSlotNum + 1> slots_found = {};
 
   if (!HasValidNodeIds(new_config)) {
     return false;
@@ -103,38 +100,31 @@ bool ClusterConfig::IsConfigValid(const ClusterShards& new_config) {
 
   return true;
 }
+}  // namespace
 
-optional<SlotSet> ClusterConfig::SetConfig(const vector<ClusterShard>& new_config) {
-  if (!IsConfigValid(new_config)) {
-    return nullopt;
+/* static */
+unique_ptr<ClusterConfig> ClusterConfig::CreateFromConfig(string_view my_id,
+                                                          const ClusterShards& config) {
+  if (!IsConfigValid(config)) {
+    return nullptr;
   }
 
-  // When set config is called the first time, deleted_slots will contain all slots which are not
-  // allocated to this node. This makes sure that if there is data in server that was loaded from
-  // disk (rdb_load), then after the call to set config the server data will contain only data from
-  // the node owned slots.
-  bool is_first_config = !IsConfigured();
+  unique_ptr<ClusterConfig> result(new ClusterConfig());
 
-  lock_guard gu(mu_);
+  result->config_ = config;
 
-  config_ = new_config;
-
-  SlotSet deleted_slots;
-  for (const auto& shard : config_) {
+  for (const auto& shard : result->config_) {
     for (const auto& slot_range : shard.slot_ranges) {
       bool owned_by_me =
-          shard.master.id == my_id_ || any_of(shard.replicas.begin(), shard.replicas.end(),
-                                              [&](const Node& node) { return node.id == my_id_; });
+          shard.master.id == my_id || any_of(shard.replicas.begin(), shard.replicas.end(),
+                                             [&](const Node& node) { return node.id == my_id; });
       for (SlotId i = slot_range.start; i <= slot_range.end; ++i) {
-        if ((slots_[i].owned_by_me || is_first_config) && !owned_by_me) {
-          deleted_slots.insert(i);
-        }
-        slots_[i] = {.shard = &shard, .owned_by_me = owned_by_me};
+        result->slots_[i] = {.shard = &shard, .owned_by_me = owned_by_me};
       }
     }
   }
 
-  return deleted_slots;
+  return result;
 }
 
 namespace {
@@ -261,13 +251,15 @@ optional<ClusterConfig::ClusterShards> BuildClusterConfigFromJson(const JsonType
 }
 }  // namespace
 
-optional<SlotSet> ClusterConfig::SetConfig(const JsonType& json) {
-  optional<ClusterShards> config = BuildClusterConfigFromJson(json);
+/* static */
+unique_ptr<ClusterConfig> ClusterConfig::CreateFromConfig(string_view my_id,
+                                                          const JsonType& json_config) {
+  optional<ClusterShards> config = BuildClusterConfigFromJson(json_config);
   if (!config.has_value()) {
-    return nullopt;
+    return nullptr;
   }
 
-  return SetConfig(config.value());
+  return CreateFromConfig(my_id, config.value());
 }
 
 bool ClusterConfig::IsMySlot(SlotId id) const {
@@ -276,28 +268,29 @@ bool ClusterConfig::IsMySlot(SlotId id) const {
     return false;
   }
 
-  shared_lock gu(mu_);
   return slots_[id].owned_by_me;
 }
 
 ClusterConfig::Node ClusterConfig::GetMasterNodeForSlot(SlotId id) const {
-  shared_lock gu(mu_);
-
   CHECK_LT(id, slots_.size()) << "Requesting a non-existing slot id " << id;
   CHECK_NE(slots_[id].shard, nullptr)
-      << "Calling GetMasterNodeForSlot(" << id << ") before SetConfig()";
+      << "Calling GetMasterNodeForSlot(" << id << ") before setting configuration";
 
   return slots_[id].shard->master;
 }
 
 ClusterConfig::ClusterShards ClusterConfig::GetConfig() const {
-  shared_lock gu(mu_);
   return config_;
 }
 
-bool ClusterConfig::IsConfigured() const {
-  shared_lock gu(mu_);
-  return !config_.empty();
+SlotSet ClusterConfig::GetOwnedSlots() const {
+  SlotSet set;
+  for (SlotId id = 0; id <= kMaxSlotNum; ++id) {
+    if (IsMySlot(id)) {
+      set.insert(id);
+    }
+  }
+  return set;
 }
 
 }  // namespace dfly

--- a/src/server/cluster/cluster_config.h
+++ b/src/server/cluster/cluster_config.h
@@ -8,6 +8,7 @@
 #include <absl/container/flat_hash_set.h>
 
 #include <array>
+#include <bitset>
 #include <memory>
 #include <string_view>
 #include <vector>
@@ -91,8 +92,8 @@ class ClusterConfig {
 
   ClusterShards config_;
 
-  // This array covers the whole range of possible slots for fast access. It points into `config_`.
-  std::array<SlotEntry, kMaxSlotNum + 1> slots_ = {};
+  // True bits in `my_slots_` indicate that this slot is owned by this node.
+  std::bitset<kMaxSlotNum + 1> my_slots_;
 };
 
 }  // namespace dfly

--- a/src/server/cluster/cluster_config.h
+++ b/src/server/cluster/cluster_config.h
@@ -8,7 +8,7 @@
 #include <absl/container/flat_hash_set.h>
 
 #include <array>
-#include <optional>
+#include <memory>
 #include <string_view>
 #include <vector>
 
@@ -43,9 +43,13 @@ class ClusterConfig {
 
   using ClusterShards = std::vector<ClusterShard>;
 
-  explicit ClusterConfig(std::string_view my_id);
+  ClusterConfig& operator=(const ClusterConfig&) = default;
 
   static SlotId KeySlot(std::string_view key);
+
+  static void EnableCluster() {
+    cluster_enabled = true;
+  }
 
   static bool IsClusterEnabled() {
     return cluster_enabled;
@@ -54,24 +58,24 @@ class ClusterConfig {
   // If the key contains the {...} pattern, return only the part between { and }
   static std::string_view KeyTag(std::string_view key);
 
+  // Returns an instance with `config` if it is valid.
+  // Returns heap-allocated object as it is too big for a stack frame.
+  static std::unique_ptr<ClusterConfig> CreateFromConfig(std::string_view my_id,
+                                                         const ClusterShards& config);
+
+  // Parses `json_config` into `ClusterShards` and calls the above overload.
+  static std::unique_ptr<ClusterConfig> CreateFromConfig(std::string_view my_id,
+                                                         const JsonType& json_config);
+
   // If key is in my slots ownership return true
   bool IsMySlot(SlotId id) const;
 
   // Returns the master configured for `id`.
-  // Must not be called when IsConfigured() == false.
   Node GetMasterNodeForSlot(SlotId id) const;
 
   ClusterShards GetConfig() const;
 
-  // Returns deleted slot set if `new_config` is valid and internal state was changed. Returns
-  // nullopt and changes nothing otherwise.
-  std::optional<SlotSet> SetConfig(const ClusterShards& new_config);
-
-  // Parses `json` into `ClusterShards` and calls the above overload.
-  std::optional<SlotSet> SetConfig(const JsonType& json);
-
-  // Returns whether SetConfig() was ever successfully called.
-  bool IsConfigured() const;
+  SlotSet GetOwnedSlots() const;
 
  private:
   struct SlotEntry {
@@ -79,18 +83,16 @@ class ClusterConfig {
     bool owned_by_me = false;
   };
 
-  bool IsConfigValid(const ClusterShards& new_config);
-
   static bool cluster_enabled;
 
-  const std::string my_id_;
+  ClusterConfig() = default;
 
-  mutable util::SharedMutex mu_;
+  std::string my_id_;
 
-  ClusterShards config_ ABSL_GUARDED_BY(mu_);
+  ClusterShards config_;
 
   // This array covers the whole range of possible slots for fast access. It points into `config_`.
-  std::array<SlotEntry, kMaxSlotNum + 1> slots_ ABSL_GUARDED_BY(mu_) = {};
+  std::array<SlotEntry, kMaxSlotNum + 1> slots_ = {};
 };
 
 }  // namespace dfly

--- a/src/server/cluster/cluster_config_test.cc
+++ b/src/server/cluster/cluster_config_test.cc
@@ -30,7 +30,6 @@ class ClusterConfigTest : public ::testing::Test {
   }
 
   const string kMyId = "my-id";
-  ClusterConfig config_{kMyId};
 };
 
 TEST_F(ClusterConfigTest, KeyTagTest) {
@@ -50,377 +49,365 @@ TEST_F(ClusterConfigTest, KeyTagTest) {
   ASSERT_EQ(key, ClusterConfig::KeyTag(key));
 }
 
-TEST_F(ClusterConfigTest, ConfigEmpty) {
-  // Test that empty-initialization causes none of the slots to be owned locally.
-  for (SlotId i : {0, 1, 10, 100, 1'000, 10'000, 16'000, 0x3FFF}) {
-    EXPECT_FALSE(config_.IsMySlot(i));
-  }
-}
-
 TEST_F(ClusterConfigTest, ConfigSetInvalidEmpty) {
-  EXPECT_FALSE(config_.SetConfig(ClusterConfig::ClusterShards{}));
+  EXPECT_EQ(ClusterConfig::CreateFromConfig(kMyId, ClusterConfig::ClusterShards{}), nullptr);
 }
 
 TEST_F(ClusterConfigTest, ConfigSetInvalidMissingSlots) {
-  EXPECT_FALSE(config_.SetConfig({{.slot_ranges = {{.start = 0, .end = 16000}},
-                                   .master = {.id = "other", .ip = "192.168.0.100", .port = 7000},
-                                   .replicas = {}}}));
+  EXPECT_EQ(ClusterConfig::CreateFromConfig(
+                kMyId, {{.slot_ranges = {{.start = 0, .end = 16000}},
+                         .master = {.id = "other", .ip = "192.168.0.100", .port = 7000},
+                         .replicas = {}}}),
+            nullptr);
 }
 
 TEST_F(ClusterConfigTest, ConfigSetInvalidDoubleBookedSlot) {
-  EXPECT_FALSE(config_.SetConfig({{.slot_ranges = {{.start = 0, .end = 0x3FFF}},
-                                   .master = {.id = "other", .ip = "192.168.0.100", .port = 7000},
-                                   .replicas = {}},
-                                  {.slot_ranges = {{.start = 0, .end = 0}},
-                                   .master = {.id = "other2", .ip = "192.168.0.101", .port = 7001},
-                                   .replicas = {}}}));
+  EXPECT_EQ(ClusterConfig::CreateFromConfig(
+                kMyId, {{.slot_ranges = {{.start = 0, .end = 0x3FFF}},
+                         .master = {.id = "other", .ip = "192.168.0.100", .port = 7000},
+                         .replicas = {}},
+                        {.slot_ranges = {{.start = 0, .end = 0}},
+                         .master = {.id = "other2", .ip = "192.168.0.101", .port = 7001},
+                         .replicas = {}}}),
+            nullptr);
 }
 
 TEST_F(ClusterConfigTest, ConfigSetInvalidSlotId) {
-  EXPECT_FALSE(config_.SetConfig({{.slot_ranges = {{.start = 0, .end = 0x3FFF + 1}},
-                                   .master = {.id = "other", .ip = "192.168.0.100", .port = 7000},
-                                   .replicas = {}}}));
+  EXPECT_EQ(ClusterConfig::CreateFromConfig(
+                kMyId, {{.slot_ranges = {{.start = 0, .end = 0x3FFF + 1}},
+                         .master = {.id = "other", .ip = "192.168.0.100", .port = 7000},
+                         .replicas = {}}}),
+            nullptr);
 }
 
 TEST_F(ClusterConfigTest, ConfigSetOk) {
-  EXPECT_TRUE(config_.SetConfig({{.slot_ranges = {{.start = 0, .end = 0x3FFF}},
-                                  .master = {.id = "other", .ip = "192.168.0.100", .port = 7000},
-                                  .replicas = {}}}));
-  EXPECT_THAT(config_.GetMasterNodeForSlot(0),
+  auto config = ClusterConfig::CreateFromConfig(
+      kMyId, {{.slot_ranges = {{.start = 0, .end = 0x3FFF}},
+               .master = {.id = "other", .ip = "192.168.0.100", .port = 7000},
+               .replicas = {}}});
+  EXPECT_NE(config, nullptr);
+  EXPECT_THAT(config->GetMasterNodeForSlot(0),
               NodeMatches(Node{.id = "other", .ip = "192.168.0.100", .port = 7000}));
+  EXPECT_THAT(config->GetOwnedSlots(), UnorderedElementsAre());
 }
 
 TEST_F(ClusterConfigTest, ConfigSetOkWithReplicas) {
-  EXPECT_TRUE(config_.SetConfig(
-      {{.slot_ranges = {{.start = 0, .end = 0x3FFF}},
-        .master = {.id = "other-master", .ip = "192.168.0.100", .port = 7000},
-        .replicas = {{.id = "other-replica", .ip = "192.168.0.101", .port = 7001}}}}));
-  EXPECT_THAT(config_.GetMasterNodeForSlot(0),
+  auto config = ClusterConfig::CreateFromConfig(
+      kMyId, {{.slot_ranges = {{.start = 0, .end = 0x3FFF}},
+               .master = {.id = "other-master", .ip = "192.168.0.100", .port = 7000},
+               .replicas = {{.id = "other-replica", .ip = "192.168.0.101", .port = 7001}}}});
+  EXPECT_NE(config, nullptr);
+  EXPECT_THAT(config->GetMasterNodeForSlot(0),
               NodeMatches(Node{.id = "other-master", .ip = "192.168.0.100", .port = 7000}));
 }
 
 TEST_F(ClusterConfigTest, ConfigSetMultipleInstances) {
-  EXPECT_TRUE(config_.SetConfig(
-      {{.slot_ranges = {{.start = 0, .end = 5'000}},
-        .master = {.id = "other-master", .ip = "192.168.0.100", .port = 7000},
-        .replicas = {{.id = "other-replica", .ip = "192.168.0.101", .port = 7001}}},
-       {.slot_ranges = {{.start = 5'001, .end = 10'000}},
-        .master = {.id = kMyId, .ip = "192.168.0.102", .port = 7002},
-        .replicas = {{.id = "other-replica2", .ip = "192.168.0.103", .port = 7003}}},
-       {.slot_ranges = {{.start = 10'001, .end = 0x3FFF}},
-        .master = {.id = "other-master3", .ip = "192.168.0.104", .port = 7004},
-        .replicas = {{.id = "other-replica3", .ip = "192.168.0.105", .port = 7005}}}}));
+  auto config = ClusterConfig::CreateFromConfig(
+      kMyId, {{.slot_ranges = {{.start = 0, .end = 5'000}},
+               .master = {.id = "other-master", .ip = "192.168.0.100", .port = 7000},
+               .replicas = {{.id = "other-replica", .ip = "192.168.0.101", .port = 7001}}},
+              {.slot_ranges = {{.start = 5'001, .end = 10'000}},
+               .master = {.id = kMyId, .ip = "192.168.0.102", .port = 7002},
+               .replicas = {{.id = "other-replica2", .ip = "192.168.0.103", .port = 7003}}},
+              {.slot_ranges = {{.start = 10'001, .end = 0x3FFF}},
+               .master = {.id = "other-master3", .ip = "192.168.0.104", .port = 7004},
+               .replicas = {{.id = "other-replica3", .ip = "192.168.0.105", .port = 7005}}}});
+  EXPECT_NE(config, nullptr);
+  SlotSet owned_slots = config->GetOwnedSlots();
+  EXPECT_EQ(owned_slots.size(), 5'000);
+
   {
     for (int i = 0; i <= 5'000; ++i) {
-      EXPECT_THAT(config_.GetMasterNodeForSlot(i),
+      EXPECT_THAT(config->GetMasterNodeForSlot(i),
                   NodeMatches(Node{.id = "other-master", .ip = "192.168.0.100", .port = 7000}));
-      EXPECT_FALSE(config_.IsMySlot(i));
+      EXPECT_FALSE(config->IsMySlot(i));
+      EXPECT_FALSE(owned_slots.contains(i));
     }
   }
   {
     for (int i = 5'001; i <= 10'000; ++i) {
-      EXPECT_THAT(config_.GetMasterNodeForSlot(i),
+      EXPECT_THAT(config->GetMasterNodeForSlot(i),
                   NodeMatches(Node{.id = kMyId, .ip = "192.168.0.102", .port = 7002}));
-      EXPECT_TRUE(config_.IsMySlot(i));
+      EXPECT_TRUE(config->IsMySlot(i));
+      EXPECT_TRUE(owned_slots.contains(i));
     }
   }
   {
     for (int i = 10'001; i <= 0x3FFF; ++i) {
-      EXPECT_THAT(config_.GetMasterNodeForSlot(i),
+      EXPECT_THAT(config->GetMasterNodeForSlot(i),
                   NodeMatches(Node{.id = "other-master3", .ip = "192.168.0.104", .port = 7004}));
-      EXPECT_FALSE(config_.IsMySlot(i));
+      EXPECT_FALSE(config->IsMySlot(i));
+      EXPECT_FALSE(owned_slots.contains(i));
     }
   }
 }
 
-TEST_F(ClusterConfigTest, ConfigSetGetDeletedSlots) {
-  auto ds =
-      config_.SetConfig({{.slot_ranges = {{.start = 0, .end = 16'380}},
-                          .master = {.id = kMyId, .ip = "192.168.0.100", .port = 7000},
-                          .replicas = {}},
-                         {.slot_ranges = {{.start = 16'381, .end = 0x3FFF}},
-                          .master = {.id = "other-master2", .ip = "192.168.0.104", .port = 7004},
-                          .replicas = {}}});
-
-  EXPECT_TRUE(ds.has_value());
-  // On first config non owned slots are returned as deleted
-  EXPECT_THAT(ds.value(), UnorderedElementsAre(16'381, 16'382, 16'383));
-
-  ds = config_.SetConfig({{.slot_ranges = {{.start = 0, .end = 16'381}},
-                           .master = {.id = kMyId, .ip = "192.168.0.100", .port = 7000},
-                           .replicas = {}},
-                          {.slot_ranges = {{.start = 16'382, .end = 0x3FFF}},
-                           .master = {.id = "other-master2", .ip = "192.168.0.104", .port = 7004},
-                           .replicas = {}}});
-
-  EXPECT_TRUE(ds.has_value());
-  EXPECT_TRUE(ds.value().empty());  // On second config no slots taken from ownership
-
-  ds = config_.SetConfig({{.slot_ranges = {{.start = 0, .end = 16'378}},
-                           .master = {.id = kMyId, .ip = "192.168.0.100", .port = 7000},
-                           .replicas = {}},
-                          {.slot_ranges = {{.start = 16'379, .end = 0x3FFF}},
-                           .master = {.id = "other-master2", .ip = "192.168.0.104", .port = 7004},
-                           .replicas = {}}});
-
-  EXPECT_TRUE(ds.has_value());
-  EXPECT_THAT(ds.value(), UnorderedElementsAre(16'379, 16'380, 16'381));
-}
-
 TEST_F(ClusterConfigTest, ConfigSetInvalidSlotRanges) {
   // Note that slot_ranges is not an object
-  EXPECT_FALSE(config_.SetConfig(ParseJson(R"json(
-      [
-        {
-          "slot_ranges": "0,16383",
-          "master": {
-            "id": "abcd1234",
-            "ip": "10.0.0.1",
-            "port": 7000
-          },
-          "replicas": []
-        }
-      ])json")));
+  EXPECT_EQ(ClusterConfig::CreateFromConfig(kMyId, ParseJson(R"json(
+                [
+                  {
+                    "slot_ranges": "0,16383",
+                    "master": {
+                      "id": "abcd1234",
+                      "ip": "10.0.0.1",
+                      "port": 7000
+                    },
+                    "replicas": []
+                  }
+                ])json")),
+            nullptr);
 }
 
 TEST_F(ClusterConfigTest, ConfigSetInvalidSlotRangeStart) {
   // Note that slot_ranges.start is not a number
-  EXPECT_FALSE(config_.SetConfig(ParseJson(R"json(
-      [
-        {
-          "slot_ranges": [
-            {
-              "start": "0",
-              "end": 16383
-            }
-          ],
-          "master": {
-            "id": "abcd1234",
-            "ip": "10.0.0.1",
-            "port": 7000
-          },
-          "replicas": []
-        }
-      ])json")));
+  EXPECT_EQ(ClusterConfig::CreateFromConfig(kMyId, ParseJson(R"json(
+                [
+                  {
+                    "slot_ranges": [
+                      {
+                        "start": "0",
+                        "end": 16383
+                      }
+                    ],
+                    "master": {
+                      "id": "abcd1234",
+                      "ip": "10.0.0.1",
+                      "port": 7000
+                    },
+                    "replicas": []
+                  }
+                ])json")),
+            nullptr);
 }
 
 TEST_F(ClusterConfigTest, ConfigSetInvalidSlotRangeEnd) {
   // Note that slot_ranges.end is not a number
-  EXPECT_FALSE(config_.SetConfig(ParseJson(R"json(
-      [
-        {
-          "slot_ranges": [
-            {
-              "start": 0,
-              "end": "16383"
-            }
-          ],
-          "master": {
-            "id": "abcd1234",
-            "ip": "10.0.0.1",
-            "port": 7000
-          },
-          "replicas": []
-        }
-      ])json")));
+  EXPECT_EQ(ClusterConfig::CreateFromConfig(kMyId, ParseJson(R"json(
+                [
+                  {
+                    "slot_ranges": [
+                      {
+                        "start": 0,
+                        "end": "16383"
+                      }
+                    ],
+                    "master": {
+                      "id": "abcd1234",
+                      "ip": "10.0.0.1",
+                      "port": 7000
+                    },
+                    "replicas": []
+                  }
+                ])json")),
+            nullptr);
 }
 
 TEST_F(ClusterConfigTest, ConfigSetInvalidMissingMaster) {
-  EXPECT_FALSE(config_.SetConfig(ParseJson(R"json(
-      [
-        {
-          "slot_ranges": [
-            {
-              "start": 0,
-              "end": 16383
-            }
-          ]
-        }
-      ])json")));
+  EXPECT_EQ(ClusterConfig::CreateFromConfig(kMyId, ParseJson(R"json(
+                [
+                  {
+                    "slot_ranges": [
+                      {
+                        "start": 0,
+                        "end": 16383
+                      }
+                    ]
+                  }
+                ])json")),
+            nullptr);
 }
 
 TEST_F(ClusterConfigTest, ConfigSetInvalidMasterNotObject) {
   // Note that master is not an object
-  EXPECT_FALSE(config_.SetConfig(ParseJson(R"json(
-      [
-        {
-          "slot_ranges": [
-            {
-              "start": 0,
-              "end": 16383
-            }
-          ],
-          "master": 123,
-          "replicas": []
-        }
-      ])json")));
+  EXPECT_EQ(ClusterConfig::CreateFromConfig(kMyId, ParseJson(R"json(
+                [
+                  {
+                    "slot_ranges": [
+                      {
+                        "start": 0,
+                        "end": 16383
+                      }
+                    ],
+                    "master": 123,
+                    "replicas": []
+                  }
+                ])json")),
+            nullptr);
 }
 
 TEST_F(ClusterConfigTest, ConfigSetInvalidMasterMissingId) {
-  EXPECT_FALSE(config_.SetConfig(ParseJson(R"json(
-      [
-        {
-          "slot_ranges": [
-            {
-              "start": 0,
-              "end": 16383
-            }
-          ],
-          "master": {
-            "ip": "10.0.0.0",
-            "port": 8000
-          },
-          "replicas": []
-        }
-      ])json")));
+  EXPECT_EQ(ClusterConfig::CreateFromConfig(kMyId, ParseJson(R"json(
+                [
+                  {
+                    "slot_ranges": [
+                      {
+                        "start": 0,
+                        "end": 16383
+                      }
+                    ],
+                    "master": {
+                      "ip": "10.0.0.0",
+                      "port": 8000
+                    },
+                    "replicas": []
+                  }
+                ])json")),
+            nullptr);
 }
 
 TEST_F(ClusterConfigTest, ConfigSetInvalidMasterMissingIp) {
-  EXPECT_FALSE(config_.SetConfig(ParseJson(R"json(
-      [
-        {
-          "slot_ranges": [
-            {
-              "start": 0,
-              "end": 16383
-            }
-          ],
-          "master": {
-            "id": "abcdefg",
-            "port": 8000
-          },
-          "replicas": []
-        }
-      ])json")));
+  EXPECT_EQ(ClusterConfig::CreateFromConfig(kMyId, ParseJson(R"json(
+                [
+                  {
+                    "slot_ranges": [
+                      {
+                        "start": 0,
+                        "end": 16383
+                      }
+                    ],
+                    "master": {
+                      "id": "abcdefg",
+                      "port": 8000
+                    },
+                    "replicas": []
+                  }
+                ])json")),
+            nullptr);
 }
 
 TEST_F(ClusterConfigTest, ConfigSetInvalidMasterMissingPort) {
-  EXPECT_FALSE(config_.SetConfig(ParseJson(R"json(
-      [
-        {
-          "slot_ranges": [
-            {
-              "start": 0,
-              "end": 16383
-            }
-          ],
-          "master": {
-            "id": "abcdefg",
-            "ip": "10.0.0.0"
-          },
-          "replicas": []
-        }
-      ])json")));
+  EXPECT_EQ(ClusterConfig::CreateFromConfig(kMyId, ParseJson(R"json(
+                [
+                  {
+                    "slot_ranges": [
+                      {
+                        "start": 0,
+                        "end": 16383
+                      }
+                    ],
+                    "master": {
+                      "id": "abcdefg",
+                      "ip": "10.0.0.0"
+                    },
+                    "replicas": []
+                  }
+                ])json")),
+            nullptr);
 }
 
 TEST_F(ClusterConfigTest, ConfigSetInvalidMissingReplicas) {
-  EXPECT_FALSE(config_.SetConfig(ParseJson(R"json(
-      [
-        {
-          "slot_ranges": [
-            {
-              "start": 0,
-              "end": 16383
-            }
-          ],
-          "master": {
-            "id": "abcdefg",
-            "ip": "10.0.0.0",
-            "port": 8000
-          }
-        }
-      ])json")));
+  EXPECT_EQ(ClusterConfig::CreateFromConfig(kMyId, ParseJson(R"json(
+                [
+                  {
+                    "slot_ranges": [
+                      {
+                        "start": 0,
+                        "end": 16383
+                      }
+                    ],
+                    "master": {
+                      "id": "abcdefg",
+                      "ip": "10.0.0.0",
+                      "port": 8000
+                    }
+                  }
+                ])json")),
+            nullptr);
 }
 
 TEST_F(ClusterConfigTest, ConfigSetInvalidRepeatingMasterId) {
-  EXPECT_FALSE(config_.SetConfig(ParseJson(R"json(
-      [
-        {
-          "slot_ranges": [
-            {
-              "start": 0,
-              "end": 10000
-            }
-          ],
-          "master": {
-            "id": "abcdefg",
-            "ip": "10.0.0.0",
-            "port": 8000
-          },
-          "replicas": []
-        },
-        {
-          "slot_ranges": [
-            {
-              "start": 10001,
-              "end": 16383
-            }
-          ],
-          "master": {
-            "id": "abcdefg",
-            "ip": "10.0.0.0",
-            "port": 8000
-          },
-          "replicas": []
-        }
-      ])json")));
+  EXPECT_EQ(ClusterConfig::CreateFromConfig(kMyId, ParseJson(R"json(
+                [
+                  {
+                    "slot_ranges": [
+                      {
+                        "start": 0,
+                        "end": 10000
+                      }
+                    ],
+                    "master": {
+                      "id": "abcdefg",
+                      "ip": "10.0.0.0",
+                      "port": 8000
+                    },
+                    "replicas": []
+                  },
+                  {
+                    "slot_ranges": [
+                      {
+                        "start": 10001,
+                        "end": 16383
+                      }
+                    ],
+                    "master": {
+                      "id": "abcdefg",
+                      "ip": "10.0.0.0",
+                      "port": 8000
+                    },
+                    "replicas": []
+                  }
+                ])json")),
+            nullptr);
 }
 
 TEST_F(ClusterConfigTest, ConfigSetInvalidRepeatingReplicaId) {
-  EXPECT_FALSE(config_.SetConfig(ParseJson(R"json(
-      [
-        {
-          "slot_ranges": [
-            {
-              "start": 0,
-              "end": 16383
-            }
-          ],
-          "master": {
-            "id": "abcdefg",
-            "ip": "10.0.0.0",
-            "port": 8000
-          },
-          "replicas": [
-            {
-              "id": "xyz",
-              "ip": "10.0.0.1",
-              "port": 8001
-            },
-            {
-              "id": "xyz",
-              "ip": "10.0.0.2",
-              "port": 8002
-            }
-          ]
-        }
-      ])json")));
+  EXPECT_EQ(ClusterConfig::CreateFromConfig(kMyId, ParseJson(R"json(
+                [
+                  {
+                    "slot_ranges": [
+                      {
+                        "start": 0,
+                        "end": 16383
+                      }
+                    ],
+                    "master": {
+                      "id": "abcdefg",
+                      "ip": "10.0.0.0",
+                      "port": 8000
+                    },
+                    "replicas": [
+                      {
+                        "id": "xyz",
+                        "ip": "10.0.0.1",
+                        "port": 8001
+                      },
+                      {
+                        "id": "xyz",
+                        "ip": "10.0.0.2",
+                        "port": 8002
+                      }
+                    ]
+                  }
+                ])json")),
+            nullptr);
 }
 
 TEST_F(ClusterConfigTest, ConfigSetInvalidRepeatingMasterAndReplicaId) {
-  EXPECT_FALSE(config_.SetConfig(ParseJson(R"json(
-      [
-        {
-          "slot_ranges": [
-            {
-              "start": 0,
-              "end": 16383
-            }
-          ],
-          "master": {
-            "id": "abcdefg",
-            "ip": "10.0.0.0",
-            "port": 8000
-          },
-          "replicas": [
-            {
-              "id": "abcdefg",
-              "ip": "10.0.0.1",
-              "port": 8001
-            }
-          ]
-        }
-      ])json")));
+  EXPECT_EQ(ClusterConfig::CreateFromConfig(kMyId, ParseJson(R"json(
+                [
+                  {
+                    "slot_ranges": [
+                      {
+                        "start": 0,
+                        "end": 16383
+                      }
+                    ],
+                    "master": {
+                      "id": "abcdefg",
+                      "ip": "10.0.0.0",
+                      "port": 8000
+                    },
+                    "replicas": [
+                      {
+                        "id": "abcdefg",
+                        "ip": "10.0.0.1",
+                        "port": 8001
+                      }
+                    ]
+                  }
+                ])json")),
+            nullptr);
 }
 
 }  // namespace dfly

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -5,6 +5,7 @@
 #include "server/cluster/cluster_family.h"
 
 #include <jsoncons/json.hpp>
+#include <memory>
 #include <mutex>
 #include <string>
 
@@ -17,6 +18,7 @@
 #include "server/conn_context.h"
 #include "server/dflycmd.h"
 #include "server/error.h"
+#include "server/main_service.h"
 #include "server/replica.h"
 #include "server/server_family.h"
 #include "server/server_state.h"
@@ -43,6 +45,8 @@ constexpr string_view kClusterDisabled =
     "Cluster is disabled. Enabled via passing --cluster_mode=emulated|yes";
 constexpr string_view kDflyClusterCmdPort = "DflyCluster command allowed only under admin port";
 
+thread_local unique_ptr<ClusterConfig> tl_cluster_config;
+
 }  // namespace
 
 ClusterFamily::ClusterFamily(ServerFamily* server_family) : server_family_(server_family) {
@@ -52,11 +56,15 @@ ClusterFamily::ClusterFamily(ServerFamily* server_family) : server_family_(serve
   if (cluster_mode == "emulated") {
     is_emulated_cluster_ = true;
   } else if (cluster_mode == "yes") {
-    cluster_config_ = std::make_unique<ClusterConfig>(server_family_->master_id());
+    ClusterConfig::EnableCluster();
   } else if (!cluster_mode.empty()) {
     LOG(ERROR) << "invalid cluster_mode. Exiting...";
     exit(1);
   }
+}
+
+ClusterConfig* ClusterFamily::cluster_config() {
+  return tl_cluster_config.get();
 }
 
 bool ClusterFamily::IsEnabledOrEmulated() const {
@@ -163,8 +171,8 @@ void ClusterShardsImpl(const ClusterShards& config, ConnectionContext* cntx) {
 void ClusterFamily::ClusterShards(ConnectionContext* cntx) {
   if (is_emulated_cluster_) {
     return ClusterShardsImpl({GetEmulatedShardInfo(cntx)}, cntx);
-  } else if (cluster_config_->IsConfigured()) {
-    return ClusterShardsImpl(cluster_config_->GetConfig(), cntx);
+  } else if (tl_cluster_config != nullptr) {
+    return ClusterShardsImpl(tl_cluster_config->GetConfig(), cntx);
   } else {
     return (*cntx)->SendError(kClusterNotConfigured);
   }
@@ -206,8 +214,8 @@ void ClusterSlotsImpl(const ClusterShards& config, ConnectionContext* cntx) {
 void ClusterFamily::ClusterSlots(ConnectionContext* cntx) {
   if (is_emulated_cluster_) {
     return ClusterSlotsImpl({GetEmulatedShardInfo(cntx)}, cntx);
-  } else if (cluster_config_->IsConfigured()) {
-    return ClusterSlotsImpl(cluster_config_->GetConfig(), cntx);
+  } else if (tl_cluster_config != nullptr) {
+    return ClusterSlotsImpl(tl_cluster_config->GetConfig(), cntx);
   } else {
     return (*cntx)->SendError(kClusterNotConfigured);
   }
@@ -259,8 +267,8 @@ void ClusterNodesImpl(const ClusterShards& config, string_view my_id, Connection
 void ClusterFamily::ClusterNodes(ConnectionContext* cntx) {
   if (is_emulated_cluster_) {
     return ClusterNodesImpl({GetEmulatedShardInfo(cntx)}, server_family_->master_id(), cntx);
-  } else if (cluster_config_->IsConfigured()) {
-    return ClusterNodesImpl(cluster_config_->GetConfig(), server_family_->master_id(), cntx);
+  } else if (tl_cluster_config != nullptr) {
+    return ClusterNodesImpl(tl_cluster_config->GetConfig(), server_family_->master_id(), cntx);
   } else {
     return (*cntx)->SendError(kClusterNotConfigured);
   }
@@ -321,8 +329,8 @@ void ClusterInfoImpl(const ClusterShards& config, ConnectionContext* cntx) {
 void ClusterFamily::ClusterInfo(ConnectionContext* cntx) {
   if (is_emulated_cluster_) {
     return ClusterInfoImpl({GetEmulatedShardInfo(cntx)}, cntx);
-  } else if (cluster_config_->IsConfigured()) {
-    return ClusterInfoImpl(cluster_config_->GetConfig(), cntx);
+  } else if (tl_cluster_config != nullptr) {
+    return ClusterInfoImpl(tl_cluster_config->GetConfig(), cntx);
   } else {
     return ClusterInfoImpl({}, cntx);
   }
@@ -377,8 +385,6 @@ void ClusterFamily::DflyCluster(CmdArgList args, ConnectionContext* cntx) {
     return (*cntx)->SendError(kDflyClusterCmdPort);
   }
 
-  CHECK(is_emulated_cluster_ || cluster_config_.get() != nullptr);
-
   ToUpper(&args[0]);
   string_view sub_cmd = ArgS(args, 0);
   if (sub_cmd == "GETSLOTINFO") {
@@ -399,6 +405,21 @@ void ClusterFamily::DflyClusterMyId(CmdArgList args, ConnectionContext* cntx) {
   (*cntx)->SendBulkString(server_family_->master_id());
 }
 
+namespace {
+SlotSet GetDeletedSlots(bool is_first_config, const SlotSet& before, const SlotSet& after) {
+  SlotSet result;
+  for (SlotId id = 0; id <= ClusterConfig::kMaxSlotNum; ++id) {
+    if ((before.contains(id) || is_first_config) && !after.contains(id)) {
+      result.insert(id);
+    }
+  }
+  return result;
+}
+
+// Guards set configuration, so that we won't handle 2 in parallel.
+Mutex set_config_mu;
+}  // namespace
+
 void ClusterFamily::DflyClusterConfig(CmdArgList args, ConnectionContext* cntx) {
   SinkReplyBuilder* rb = cntx->reply_builder();
 
@@ -413,19 +434,40 @@ void ClusterFamily::DflyClusterConfig(CmdArgList args, ConnectionContext* cntx) 
     return rb->SendError("Invalid JSON cluster config", kSyntaxErrType);
   }
 
-  auto deleted_slot_ids = cluster_config_->SetConfig(json.value());
-  if (!deleted_slot_ids.has_value()) {
+  unique_ptr<ClusterConfig> new_config =
+      ClusterConfig::CreateFromConfig(server_family_->master_id(), json.value());
+  if (new_config == nullptr) {
+    LOG(WARNING) << "Can't set cluster config";
     return rb->SendError("Invalid cluster configuration.");
   }
 
+  lock_guard gu(set_config_mu);
+
+  bool is_first_config = true;
+  SlotSet before;
+  if (tl_cluster_config != nullptr) {
+    is_first_config = false;
+    before = tl_cluster_config->GetOwnedSlots();
+  }
+
+  auto cb = [&](util::ProactorBase* pb) {
+    tl_cluster_config = make_unique<ClusterConfig>(*new_config);
+  };
+  server_family_->service().proactor_pool().AwaitFiberOnAll(std::move(cb));
+
+  DCHECK(tl_cluster_config != nullptr);
+
+  SlotSet after = tl_cluster_config->GetOwnedSlots();
+
   // Delete old slots data.
-  if (!deleted_slot_ids.value().empty()) {
+  SlotSet deleted_slot_ids = GetDeletedSlots(is_first_config, before, after);
+  if (!deleted_slot_ids.empty()) {
     auto cb = [&](auto*) {
       EngineShard* shard = EngineShard::tlocal();
       if (shard == nullptr)
         return;
 
-      shard->db_slice().FlushSlots(deleted_slot_ids.value());
+      shard->db_slice().FlushSlots(deleted_slot_ids);
     };
     shard_set->pool()->AwaitFiberOnAll(std::move(cb));
   }

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -451,7 +451,11 @@ void ClusterFamily::DflyClusterConfig(CmdArgList args, ConnectionContext* cntx) 
   }
 
   auto cb = [&](util::ProactorBase* pb) {
-    tl_cluster_config = make_unique<ClusterConfig>(*new_config);
+    if (tl_cluster_config == nullptr) {
+      tl_cluster_config = make_unique<ClusterConfig>(*new_config);
+    } else {
+      *tl_cluster_config = *new_config;
+    }
   };
   server_family_->service().proactor_pool().AwaitFiberOnAll(std::move(cb));
 

--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <memory>
 #include <string>
 
 #include "facade/conn_context.h"
@@ -25,9 +24,8 @@ class ClusterFamily {
 
   bool IsEnabledOrEmulated() const;
 
-  ClusterConfig* cluster_config() {
-    return cluster_config_.get();
-  }
+  // Returns a thread-local pointer.
+  ClusterConfig* cluster_config();
 
  private:
   // Cluster commands compatible with Redis
@@ -51,8 +49,6 @@ class ClusterFamily {
 
   bool is_emulated_cluster_ = false;
   ServerFamily* server_family_ = nullptr;
-
-  std::unique_ptr<ClusterConfig> cluster_config_;
 };
 
 }  // namespace dfly

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -628,8 +628,8 @@ bool Service::CheckKeysOwnership(const CommandId* cid, CmdArgList args,
   }
 
   // Check keys slot is in my ownership
-  const auto& cluster_config = cluster_family_.cluster_config();
-  if (!cluster_config->IsConfigured()) {
+  const ClusterConfig* cluster_config = cluster_family_.cluster_config();
+  if (cluster_config == nullptr) {
     (*dfly_cntx)->SendError(kClusterNotConfigured);
     return false;
   }


### PR DESCRIPTION
As part of this change, now `SetConfig()` does not return the deleted slots, but instead we calculate it ourselves once (instead of it being done in each thread separately).

While at it, add a small test function to remove `sleep()`s and wait in a less fragile way.

Fixes #1357

feat(cluster): Use thread-local cluster config

To support this, I refactored some of the code:

* We no longer have `IsConfigured()` and `SetConfig()`, now configuration validation is done via instantiation
* As a result, we check if `tl_cluster_config` is `nullptr` or not to determine whether the cluster has been configured
* Pushing new configuration is done via copy-c'tor                                                                                                         

While at it, add a small test function to remove `sleep()`s and wait in a less fragile way.

Fixes #1357                                                                                                                                                                                                     


<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->