### PR TITLE
fix(alpine): Add libxml2 into the build pipeline

### DIFF
--- a/tools/docker/Dockerfile.alpine-dev
+++ b/tools/docker/Dockerfile.alpine-dev
@@ -26,7 +26,7 @@ RUN build-opt/dragonfly --version
 FROM alpine:3.17.0
 
 RUN apk --no-cache add libgcc libstdc++ libunwind boost1.80-fiber \
-    zstd-dev su-exec netcat-openbsd openssl
+    zstd-dev su-exec netcat-openbsd openssl libxml2
 
 RUN addgroup -S -g 1000 dfly && adduser -S -G dfly -u 999 dfly
 RUN mkdir /data && chown dfly:dfly /data

--- a/tools/docker/Dockerfile.alpine-prod.wip
+++ b/tools/docker/Dockerfile.alpine-prod.wip
@@ -14,7 +14,7 @@ RUN ninja dragonfly
 FROM alpine:latest
 
 RUN addgroup -S -g 1000 dfly && adduser -S -G dfly -u 999 dfly
-RUN apk --no-cache add libgcc libstdc++ libunwind boost1.77-fiber \
+RUN apk --no-cache add libgcc libstdc++ libunwind boost1.77-fiber libxml2 \
     'su-exec>=0.2' netcat-openbsd openssl
 
 RUN mkdir /data && chown dfly:dfly /data


### PR DESCRIPTION
Currently, The docker run command on an alpine image fails due to the
lack of this dependency
