### PR TITLE
fix: fix linsert pivot

### DIFF
--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -1050,7 +1050,7 @@ void ListFamily::LInsert(CmdArgList args, ConnectionContext* cntx) {
   string_view elem = ArgS(args, 3);
   int where;
 
-  ToUpper(&args[2]);
+  ToUpper(&args[1]);
   if (param == "AFTER") {
     where = LIST_TAIL;
   } else if (param == "BEFORE") {


### PR DESCRIPTION
Fixes the `LINSERT` pivot - before the pivot was being capitalised rather than the direction

Fixes https://github.com/dragonflydb/dragonfly/issues/1364

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->