### PR TITLE
feat: search limit

### DIFF
--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -25,7 +25,10 @@ struct SearchResult {
 };
 
 struct SearchParams {
-  size_t limit_offset, limit_total;
+  // Parameters for "LIMIT offset total": select total amount documents with a specific offset from
+  // the whole result set
+  size_t limit_offset;
+  size_t limit_total;
 };
 
 // Stores basic info about a document index.

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -19,6 +19,15 @@ namespace dfly {
 using SearchDocData = absl::flat_hash_map<std::string /*field*/, std::string /*value*/>;
 using SerializedSearchDoc = std::pair<std::string /*key*/, SearchDocData>;
 
+struct SearchResult {
+  std::vector<SerializedSearchDoc> docs;
+  size_t total_hits;
+};
+
+struct SearchParams {
+  size_t limit_offset, limit_total;
+};
+
 // Stores basic info about a document index.
 struct DocIndex {
   enum DataType { HASH, JSON };
@@ -52,8 +61,8 @@ class ShardDocIndex {
   ShardDocIndex(std::shared_ptr<DocIndex> index);
 
   // Perform search on all indexed documents and return results.
-  std::vector<SerializedSearchDoc> Search(const OpArgs& op_args,
-                                          search::SearchAlgorithm* search_algo) const;
+  SearchResult Search(const OpArgs& op_args, const SearchParams& params,
+                      search::SearchAlgorithm* search_algo) const;
 
   // Initialize index. Traverses all matching documents and assigns ids.
   void Init(const OpArgs& op_args);

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -69,6 +69,30 @@ optional<search::Schema> ParseSchemaOrReply(CmdArgList args, ConnectionContext* 
   return schema;
 }
 
+optional<SearchParams> ParseSearchParamsOrReply(CmdArgList args, ConnectionContext* cntx) {
+  size_t limit_offset = 0, limit_total = 10;
+
+  for (size_t i = 0; i < args.size(); i++) {
+    ToUpper(&args[i]);
+
+    // [LIMIT offset total]
+    if (ArgS(args, i) == "LIMIT") {
+      if (i + 2 >= args.size()) {
+        (*cntx)->SendError(kSyntaxErr);
+        return nullopt;
+      }
+      if (!absl::SimpleAtoi(ArgS(args, i + 1), &limit_offset) ||
+          !absl::SimpleAtoi(ArgS(args, i + 2), &limit_total)) {
+        (*cntx)->SendError(kInvalidIntErr);
+        return nullopt;
+      }
+      i += 2;
+    }
+  }
+
+  return SearchParams{limit_offset, limit_total};
+}
+
 }  // namespace
 
 void SearchFamily::FtCreate(CmdArgList args, ConnectionContext* cntx) {
@@ -133,17 +157,21 @@ void SearchFamily::FtSearch(CmdArgList args, ConnectionContext* cntx) {
   string_view index_name = ArgS(args, 0);
   string_view query_str = ArgS(args, 1);
 
+  auto params = ParseSearchParamsOrReply(args.subspan(2), cntx);
+  if (!params)
+    return;
+
   search::SearchAlgorithm search_algo;
   if (!search_algo.Init(query_str))
     return (*cntx)->SendError("Query syntax error");
 
   // Because our coordinator thread may not have a shard, we can't check ahead if the index exists.
   atomic<bool> index_not_found{false};
-  vector<vector<SerializedSearchDoc>> docs(shard_set->size());
+  vector<SearchResult> docs(shard_set->size());
 
   cntx->transaction->ScheduleSingleHop([&](Transaction* t, EngineShard* es) {
     if (auto* index = es->search_indices()->Get(index_name); index)
-      docs[es->shard_id()] = index->Search(t->GetOpArgs(es), &search_algo);
+      docs[es->shard_id()] = index->Search(t->GetOpArgs(es), *params, &search_algo);
     else
       index_not_found.store(true, memory_order_relaxed);
     return OpStatus::OK;
@@ -154,12 +182,27 @@ void SearchFamily::FtSearch(CmdArgList args, ConnectionContext* cntx) {
 
   size_t total_count = 0;
   for (const auto& shard_docs : docs)
-    total_count += shard_docs.size();
+    total_count += shard_docs.total_hits;
 
-  (*cntx)->StartArray(total_count * 2 + 1);
+  size_t response_count =
+      min(total_count - min(total_count, params->limit_offset), params->limit_total);
+
+  (*cntx)->StartArray(response_count * 2 + 1);
   (*cntx)->SendLong(total_count);
+
+  size_t sent = 0;
+  size_t to_skip = 0;
   for (const auto& shard_docs : docs) {
-    for (const auto& [key, doc] : shard_docs) {
+    for (const auto& [key, doc] : shard_docs.docs) {
+      // Scoring is not implemented yet, so we take just cut them in the order they were retrieved
+      if (to_skip > 0) {
+        to_skip--;
+        continue;
+      }
+
+      if (sent++ >= response_count)
+        goto END;
+
       (*cntx)->SendBulkString(key);
       (*cntx)->StartCollection(doc.size(), RedisReplyBuilder::MAP);
       for (const auto& [k, v] : doc) {
@@ -168,6 +211,7 @@ void SearchFamily::FtSearch(CmdArgList args, ConnectionContext* cntx) {
       }
     }
   }
+END:;
 }
 
 #define HFUNC(x) SetHandler(&SearchFamily::x)

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -158,7 +158,7 @@ void SearchFamily::FtSearch(CmdArgList args, ConnectionContext* cntx) {
   string_view query_str = ArgS(args, 1);
 
   auto params = ParseSearchParamsOrReply(args.subspan(2), cntx);
-  if (!params)
+  if (!params.has_value())
     return;
 
   search::SearchAlgorithm search_algo;
@@ -194,14 +194,14 @@ void SearchFamily::FtSearch(CmdArgList args, ConnectionContext* cntx) {
   size_t to_skip = 0;
   for (const auto& shard_docs : docs) {
     for (const auto& [key, doc] : shard_docs.docs) {
-      // Scoring is not implemented yet, so we take just cut them in the order they were retrieved
+      // Scoring is not implemented yet, so we just cut them in the order they were retrieved
       if (to_skip > 0) {
         to_skip--;
         continue;
       }
 
       if (sent++ >= response_count)
-        goto END;
+        return;
 
       (*cntx)->SendBulkString(key);
       (*cntx)->StartCollection(doc.size(), RedisReplyBuilder::MAP);
@@ -211,7 +211,6 @@ void SearchFamily::FtSearch(CmdArgList args, ConnectionContext* cntx) {
       }
     }
   }
-END:;
 }
 
 #define HFUNC(x) SetHandler(&SearchFamily::x)

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -190,4 +190,23 @@ TEST_F(SearchFamilyTest, Numbers) {
   */
 }
 
+TEST_F(SearchFamilyTest, TestLimit) {
+  for (unsigned i = 0; i < 20; i++)
+    Run({"hset", to_string(i), "match", "all"});
+  Run({"ft.create", "i1", "SCHEMA", "match", "text"});
+
+  // Default limit is 10
+  auto resp = Run({"ft.search", "i1", "all"});
+  EXPECT_THAT(resp, ArrLen(10 * 2 + 1));
+
+  resp = Run({"ft.search", "i1", "all", "limit", "0", "0"});
+  EXPECT_THAT(resp, IntArg(20));
+
+  resp = Run({"ft.search", "i1", "all", "limit", "0", "5"});
+  EXPECT_THAT(resp, ArrLen(5 * 2 + 1));
+
+  resp = Run({"ft.search", "i1", "all", "limit", "17", "5"});
+  EXPECT_THAT(resp, ArrLen(3 * 2 + 1));
+}
+
 }  // namespace dfly


### PR DESCRIPTION
This PR adds support for the LIMIT option for search. Because scoring is not implemented, it just cuts off the part in the order it was retrieved.

The default limit is 10