### PR TITLE
bug(debug populate): fix debug populate keys

### DIFF
--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -169,6 +169,10 @@ TEST_F(RdbTest, Stream) {
 
 TEST_F(RdbTest, ComressionModeSaveDragonflyAndReload) {
   Run({"debug", "populate", "50000"});
+  ASSERT_EQ(50000, CheckedInt({"dbsize"}));
+  // Check keys inserted are lower than 50,000.
+  auto resp = Run({"keys", "key:[5-9][0-9][0-9][0-9][0-9]*"});
+  EXPECT_EQ(resp.GetVec().size(), 0);
 
   for (int i = 0; i <= 3; ++i) {
     SetFlag(&FLAGS_compression_mode, i);


### PR DESCRIPTION
1. found a bug in the keys, they jumped with no reason in the regular debug populate function. I fixed it and added a check in unit test.
2. Added print for the set to see if it fails in the CI
I still did not found the reason why it fails on ARM. When running on aws arm machine with same number of cores the bug does not reproduce. I will try to see if it fails here in the CI