### PR TITLE
bug(helm) Fix tolerations and affinity mishandling in Helm template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,11 @@ jobs:
         name: Create kind cluster
         uses: helm/kind-action@v1.5.0
 
+      - if: steps.list-changed.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
+        name: Getting cluster ready
+        run: |
+          kubectl label nodes chart-testing-control-plane key/node-kind=high-memory
+
       - name: Run chart-testing (install)
         run: |
           ct \

--- a/contrib/charts/dragonfly/ci/resources-values.golden.yaml
+++ b/contrib/charts/dragonfly/ci/resources-values.golden.yaml
@@ -91,7 +91,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 128Mi
+              memory: 400Mi
             requests:
               cpu: 100m
-              memory: 128Mi
+              memory: 300Mi

--- a/contrib/charts/dragonfly/ci/resources-values.yaml
+++ b/contrib/charts/dragonfly/ci/resources-values.yaml
@@ -1,7 +1,7 @@
 resources:
   requests:
     cpu: 100m
-    memory: 128Mi
+    memory: 300Mi
   limits:
     cpu: 100m
-    memory: 128Mi
+    memory: 400Mi

--- a/contrib/charts/dragonfly/ci/taints-tolerations-values.golden.yaml
+++ b/contrib/charts/dragonfly/ci/taints-tolerations-values.golden.yaml
@@ -1,0 +1,111 @@
+---
+# Source: dragonfly/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-dragonfly
+  namespace: default
+  labels:
+    app.kubernetes.io/name: dragonfly
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "v1.3.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: dragonfly/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-dragonfly
+  namespace: default
+  labels:
+    app.kubernetes.io/name: dragonfly
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "v1.3.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      targetPort: dragonfly
+      protocol: TCP
+      name: dragonfly
+  selector:
+    app.kubernetes.io/name: dragonfly
+    app.kubernetes.io/instance: test
+---
+# Source: dragonfly/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-dragonfly
+  namespace: default
+  labels:
+    app.kubernetes.io/name: dragonfly
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "v1.3.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dragonfly
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      annotations:
+      labels:
+        app.kubernetes.io/name: dragonfly
+        app.kubernetes.io/instance: test
+    spec:
+      tolerations:
+        - effect: NoSchedule
+          key: key/high-memory
+          operator: Equal
+          value: "true"
+        - effect: PreferNoSchedule
+          key: key/high-memory
+          operator: Equal
+          value: "true"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: key/node-kind
+                operator: In
+                values:
+                - high-memory
+      serviceAccountName: test-dragonfly
+      containers:
+        - name: dragonfly
+          image: "docker.dragonflydb.io/dragonflydb/dragonfly:v1.3.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: dragonfly
+              containerPort: 6379
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - /usr/local/bin/healthcheck.sh
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - /usr/local/bin/healthcheck.sh
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          args:
+            - "--alsologtostderr"
+          resources:
+            limits: {}
+            requests: {}

--- a/contrib/charts/dragonfly/ci/taints-tolerations-values.yaml
+++ b/contrib/charts/dragonfly/ci/taints-tolerations-values.yaml
@@ -1,0 +1,18 @@
+tolerations:
+  - key: key/high-memory
+    operator: "Equal"
+    value: "true"
+    effect: "NoSchedule"
+  - key: key/high-memory
+    operator: "Equal"
+    value: "true"
+    effect: "PreferNoSchedule"
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: key/node-kind
+              operator: In
+              values:
+                - high-memory

--- a/contrib/charts/dragonfly/templates/_pod.tpl
+++ b/contrib/charts/dragonfly/templates/_pod.tpl
@@ -16,15 +16,15 @@ volumeMounts:
 {{- end }}
 
 {{- define "dragonfly.pod" -}}
-{{- with .Values.tolerations -}}
+{{- with .Values.tolerations }}
 tolerations:
   {{- toYaml . | trim | nindent 2 -}}
 {{- end }}
-{{- with .Values.nodeSelector -}}
+{{- with .Values.nodeSelector }}
 nodeSelector:
   {{- toYaml . | trim | nindent 2 -}}
 {{- end }}
-{{- with .Values.affinity -}}
+{{- with .Values.affinity }}
 affinity:
   {{- toYaml . | trim | nindent 2 -}}
 {{- end }}


### PR DESCRIPTION
Hello,

This pull request addresses a significant issue found in the Helm template for Dragonfly deployment related to the mishandling of 'tolerations' and 'affinity'.

**Problem**:
The problem was that the Helm template incorrectly concatenated values within 'tolerations' and 'affinity', which led to erroneous YAML outputs. Specifically, the rendered YAML for the tolerations would incorrectly join the last toleration and 'affinity', as evidenced by the resulting YAML.

**Change**:
The change primarily involves updating the Helm chart's handling of 'tolerations', 'nodeSelector', and 'affinity' values. The adjustment lies in the removal of the dash (-) in the 'with' statement for each of the three values. The changes are as follows:

```yaml
# Before
{{- with .Values.tolerations -}}
{{- with .Values.nodeSelector -}}
{{- with .Values.affinity -}}

# After
{{- with .Values.tolerations }}
{{- with .Values.nodeSelector }}
{{- with .Values.affinity }}
```

With the proposed changes, the issue with the incorrect concatenation of values in 'tolerations' and 'affinity' is resolved. The generated YAML now correctly separates each section, ensuring the successful application of the Helm chart.

I have provided the changes in values for testing:

```yaml
tolerations:
  - key: key/high-memory
    operator: "Equal"
    value: "true"
    effect: "NoSchedule"
  - key: key/high-memory
    operator: "Equal"
    value: "true"
    effect: "PreferNoSchedule"
affinity:
  nodeAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
      nodeSelectorTerms:
        - matchExpressions:
            - key: key/node-kind
              operator: In
              values:
                - high-memory
```

Here is an example of how the previous code used to parse the values:
```yaml
tolerations:
  - effect: NoSchedule
    key: key/high-memory
    operator: Equal
    value: "true"
  - effect: PreferNoSchedule
    key: key/high-memory
    operator: Equal
    value: "true"affinity:
  nodeAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
      nodeSelectorTerms:
      - matchExpressions:
        - key: key/node-kind
          operator: In
          values:
          - high-memory
```

Please consider merging this fix as it greatly improves the usability and robustness of the Dragonfly deployment Helm chart.