### PR TITLE
fix(server): Do more aggressive batching.

### DIFF
--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -123,7 +123,6 @@ class SinkReplyBuilder {
 
   // Similarly to batch mode but is controlled by at operation level.
   bool should_aggregate_ : 1;
-  uint32_t batch_cnt_ = 0;
 };
 
 class MCReplyBuilder : public SinkReplyBuilder {


### PR DESCRIPTION
This removes the "25" limit for batched messages.

Turns out the aggregation in #1287 was not aggressive enough, because it's quite possible to reach the specified max capacity of  io vectors. For example, each "QUEUED" is actually "+", "QUEUED", "\r\n" so we can reach the limit with about 8 batched commands and then we prematurely flush.

Closes #1285
