### PR TITLE
fix(xinfo): send integer info in correct type

### DIFF
--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -158,7 +158,7 @@ TEST_F(RdbTest, Stream) {
 
   resp = Run({"xinfo", "groups", "key:1"});  // test dereferences array of size 1
   EXPECT_THAT(resp, ArrLen(8));
-  EXPECT_THAT(resp.GetVec(), ElementsAre("name", "g2", "consumers", "0", "pending", "0",
+  EXPECT_THAT(resp.GetVec(), ElementsAre("name", "g2", "consumers", IntArg(0), "pending", IntArg(0),
                                          "last-delivered-id", "1655444851523-1"));
 
   resp = Run({"xinfo", "groups", "key:2"});

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -1266,13 +1266,17 @@ void StreamFamily::XInfo(CmdArgList args, ConnectionContext* cntx) {
       if (result) {
         (*cntx)->StartArray(result->size());
         for (const auto& ginfo : *result) {
-          absl::AlphaNum an1(ginfo.consumer_size);
-          absl::AlphaNum an2(ginfo.pending_size);
           string last_id = StreamIdRepr(ginfo.last_id);
-          string_view arr[8] = {"name",    ginfo.name,  "consumers",         an1.Piece(),
-                                "pending", an2.Piece(), "last-delivered-id", last_id};
 
-          (*cntx)->SendStringArr(absl::Span<string_view>{arr, 8}, RedisReplyBuilder::MAP);
+          (*cntx)->StartCollection(4, RedisReplyBuilder::MAP);
+          (*cntx)->SendBulkString("name");
+          (*cntx)->SendBulkString(ginfo.name);
+          (*cntx)->SendBulkString("consumers");
+          (*cntx)->SendLong(ginfo.consumer_size);
+          (*cntx)->SendBulkString("pending");
+          (*cntx)->SendLong(ginfo.pending_size);
+          (*cntx)->SendBulkString("last-delivered-id");
+          (*cntx)->SendBulkString(last_id);
         }
         return;
       }


### PR DESCRIPTION
`xinfo groups` command sends all the information as string (irrespective of their true type e.g. integer). This PR fixes that.