### PR TITLE
feat(CI): Update weekly build image name to be `dragonfly-weekly`

### DIFF
--- a/.github/workflows/docker-weekly.yml
+++ b/.github/workflows/docker-weekly.yml
@@ -16,8 +16,9 @@ jobs:
     uses: ./.github/workflows/reusable-container-workflow.yaml
     with:
       build_type: dev
-      tag: alpha
-      image: ghcr.io/${{ github.repository }}
+      tag: ${{ github.sha}}
+      tag_latest: true
+      image: ghcr.io/dragonflydb/dragonfly-weekly
       registry: ghcr.io
       registry_username: ${{ github.repository_owner }}
     secrets:


### PR DESCRIPTION
This commit updates the weekly docker build to use `dragonfly-weekly`
image tag so that we get better separation. We also now push these
images with the github sha commit tags. We also update `latest` as
these get pushed.
