### PR TITLE
fix: aggregate eval replys

### DIFF
--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -46,7 +46,7 @@ void SinkReplyBuilder::CloseConnection() {
 
 void SinkReplyBuilder::Send(const iovec* v, uint32_t len) {
   DCHECK(sink_);
-  constexpr size_t kMaxBatchSize = 8192;
+  constexpr size_t kMaxBatchSize = 1024;
 
   size_t bsize = 0;
   for (unsigned i = 0; i < len; ++i) {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1354,6 +1354,7 @@ void Service::EvalInternal(const EvalArgs& eval_args, Interpreter* interpreter,
 
   CHECK(result == Interpreter::RUN_OK);
 
+  SinkReplyBuilder::ReplyAggregator agg(cntx->reply_builder());
   EvalSerializer ser{static_cast<RedisReplyBuilder*>(cntx->reply_builder())};
   if (!interpreter->IsResultSafe()) {
     (*cntx)->SendError("reached lua stack limit");


### PR DESCRIPTION
Lua scripts not aggregating seemed to be the main cause of the high latency running `should obliterate a queue with high number of jobs in different statuses` in https://github.com/dragonflydb/dragonfly/issues/782 - so adding aggregation to `EVAL`/`EVALSHA`

Though adding that increased the latency of `EXEC/MULTI` transactions containing Lua scripts, as `MULTI` does its own aggregating, but each script also aggregating causes extra sync writes (from each script calling `StopAggregate`)

Maybe theres a nicer way to do this...? It reduces the `should obliterate a queue with high number of jobs in different statuses` latency from ~15s to ~1.5s

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->