### PR TITLE
fix: A more gracefull shutdown

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -837,6 +837,10 @@ void Connection::ShutdownThreadLocal() {
   pipeline_req_pool_.clear();
 }
 
+bool Connection::IsCurrentlyDispatching() const {
+  return cc_->async_dispatch || cc_->sync_dispatch;
+}
+
 void RespToArgList(const RespVec& src, CmdArgVec* dest) {
   dest->resize(src.size());
   for (size_t i = 0; i < src.size(); ++i) {

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -138,6 +138,8 @@ class Connection : public util::Connection {
 
   static void ShutdownThreadLocal();
 
+  bool IsCurrentlyDispatching() const;
+
   std::string GetClientInfo(unsigned thread_id) const;
   std::string RemoteEndpointStr() const;
   std::string RemoteEndpointAddress() const;

--- a/src/facade/dragonfly_listener.cc
+++ b/src/facade/dragonfly_listener.cc
@@ -180,6 +180,37 @@ void Listener::PreAcceptLoop(util::ProactorBase* pb) {
 }
 
 void Listener::PreShutdown() {
+  // Iterate on all connections and allow them to finish their commands for
+  // a short period.
+  // Executed commands can be visible in snapshots or replicas, but if we close the client
+  // connections too fast we might not send the acknowledgment for those commands.
+  // This shouldn't take a long time: All clients should reject incoming commands
+  // at this stage since we're in SHUTDOWN mode.
+  // If a command is running for too long we give up and proceed.
+  const absl::Duration kDispatchShutdownTimeout = absl::Milliseconds(10);
+  absl::Time start = absl::Now();
+
+  bool success = false;
+  while (absl::Now() - start < kDispatchShutdownTimeout) {
+    std::atomic<bool> any_connection_dispatching = false;
+    auto cb = [&any_connection_dispatching](unsigned thread_index, util::Connection* conn) {
+      if (static_cast<Connection*>(conn)->IsCurrentlyDispatching()) {
+        any_connection_dispatching.store(true);
+      }
+    };
+    this->TraverseConnections(cb);
+    if (!any_connection_dispatching.load()) {
+      success = true;
+      break;
+    }
+    VLOG(1) << "A command is still dispatching, let's wait for it";
+    ThisFiber::SleepFor(100us);
+  }
+
+  if (!success) {
+    LOG(WARNING) << "Some commands are still being dispatched but didn't conclude in time. "
+                    "Proceeding in shutdown.";
+  }
 }
 
 void Listener::PostShutdown() {

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2069,6 +2069,9 @@ void ServerFamily::_Shutdown(CmdArgList args, ConnectionContext* cntx) {
     }
   }
 
+  service_.proactor_pool().AwaitFiberOnAll(
+      [](ProactorBase* pb) { ServerState::tlocal()->EnterLameDuck(); });
+
   CHECK_NOTNULL(acceptor_)->Stop();
   (*cntx)->SendOk();
 }

--- a/tests/dragonfly/shutdown_test.py
+++ b/tests/dragonfly/shutdown_test.py
@@ -1,0 +1,48 @@
+import pytest
+import asyncio
+import redis
+from redis import asyncio as aioredis
+from pathlib import Path
+
+from . import dfly_args
+
+BASIC_ARGS = {"dir": "{DRAGONFLY_TMP}/"}
+
+
+@dfly_args({"proactor_threads": "4"})
+class TestDflyAutoLoadSnapshot():
+    """Test automatic loading of dump files on startup with timestamp"""
+
+    @pytest.mark.asyncio
+    async def test_gracefull_shutdown(self, df_local_factory):
+        df_args = {"dbfilename": "dump", **BASIC_ARGS, "port": 1111}
+
+        df_server = df_local_factory.create(**df_args)
+        df_server.start()
+        client = aioredis.Redis(port=df_server.port)
+
+        async def counter(key):
+            value = 0
+            await client.execute_command(f"SET {key} 0")
+            while True:
+                try:
+                    value = await client.execute_command(f"INCR {key}")
+                except (redis.exceptions.ConnectionError, redis.exceptions.ResponseError) as e:
+                    break
+            return key, value
+
+        async def delayed_takeover():
+            await asyncio.sleep(1)
+            await client.execute_command("SHUTDOWN")
+            await client.connection_pool.disconnect()
+
+        _, *results = await asyncio.gather(delayed_takeover(), *[counter(f"key{i}") for i in range(16)])
+
+        df_server.start()
+        client = aioredis.Redis(port=df_server.port)
+
+        for key, acknowleged_value in results:
+            value_from_snapshot = await client.get(key)
+            assert acknowleged_value == int(value_from_snapshot)
+
+        await client.connection_pool.disconnect()


### PR DESCRIPTION
- Adds a new 'IsCurrentlyDispatching' method to `facade::Connection`.
- Adds a time limited (10ms) wait for all connections to stop dispatching on shutdown.
- Move `EnterLameDuck` earlier so we stop accepting new commands earlier in the shutdown flow.
- Adds a new python test for the new safety feature.

Closes #1313.
