### PR TITLE
fix: Allow readonly commands in replica script

### DIFF
--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -87,7 +87,6 @@ struct ConnectionState {
 
   // Lua-script related data.
   struct ScriptInfo {
-    bool is_write = true;
     absl::flat_hash_set<std::string_view> keys;  // declared keys
 
     size_t async_cmds_heap_mem = 0;     // bytes used by async_cmds

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -723,8 +723,7 @@ bool Service::VerifyCommand(const CommandId* cid, CmdArgList args, ConnectionCon
     return false;
   }
 
-  bool is_write_cmd = (cid->opt_mask() & CO::WRITE) ||
-                      (under_script && dfly_cntx->conn_state.script_info->is_write);
+  bool is_write_cmd = cid->opt_mask() & CO::WRITE;
   bool under_multi = dfly_cntx->conn_state.exec_info.IsActive() && !is_trans_cmd;
 
   if (!etl.is_master && is_write_cmd && !dfly_cntx->is_replicating) {


### PR DESCRIPTION
Fixes #1391

It looks that long ago we planned to distinguish scripts read-only status ahead, so all of them were marked as write. Found this comment:

>   // TODO: to determine whether the script is RO by scanning all "redis.p?call" calls
  // and checking whether all invocations consist of RO commands.
  // we can do it once during script insertion into script mgr.

For now I've removed any categorization into read-only or not. Write commands will fail as usual.