### PR TITLE
feat(cluster): Use `shared_ptr` for thread-local cluster config

### DIFF
--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -45,7 +45,7 @@ constexpr string_view kClusterDisabled =
     "Cluster is disabled. Enabled via passing --cluster_mode=emulated|yes";
 constexpr string_view kDflyClusterCmdPort = "DflyCluster command allowed only under admin port";
 
-thread_local unique_ptr<ClusterConfig> tl_cluster_config;
+thread_local shared_ptr<ClusterConfig> tl_cluster_config;
 
 }  // namespace
 
@@ -434,7 +434,7 @@ void ClusterFamily::DflyClusterConfig(CmdArgList args, ConnectionContext* cntx) 
     return rb->SendError("Invalid JSON cluster config", kSyntaxErrType);
   }
 
-  unique_ptr<ClusterConfig> new_config =
+  shared_ptr<ClusterConfig> new_config =
       ClusterConfig::CreateFromConfig(server_family_->master_id(), json.value());
   if (new_config == nullptr) {
     LOG(WARNING) << "Can't set cluster config";
@@ -452,7 +452,7 @@ void ClusterFamily::DflyClusterConfig(CmdArgList args, ConnectionContext* cntx) 
 
   auto cb = [&](util::ProactorBase* pb) {
     if (tl_cluster_config == nullptr) {
-      tl_cluster_config = make_unique<ClusterConfig>(*new_config);
+      tl_cluster_config = new_config;
     } else {
       *tl_cluster_config = *new_config;
     }


### PR DESCRIPTION
As proposed by @adiholden here: https://github.com/dragonflydb/dragonfly/pull/1361#discussion_r1223135234
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->