### PR TITLE
Fix crash on shutdown from #1388

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -838,6 +838,8 @@ void Connection::ShutdownThreadLocal() {
 }
 
 bool Connection::IsCurrentlyDispatching() const {
+  if (!cc_)
+    return false;
   return cc_->async_dispatch || cc_->sync_dispatch;
 }
 

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -233,6 +233,8 @@ class Connection : public util::Connection {
   Phase phase_;
   std::string name_;
 
+  // A pointer to the ConnectionContext object if it exists. Some connections (like http
+  // requests) don't have it.
   std::unique_ptr<ConnectionContext> cc_;
 
   unsigned parser_error_ = 0;


### PR DESCRIPTION
My recent PR accesses Connection->cc_ on shutdown, but sometimes it's a null pointer.
Make it optional.
