### PR TITLE
fix: remove NotifyPending from UnwatchShardCb

### DIFF
--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1171,8 +1171,6 @@ void Transaction::UnwatchShardCb(ArgSlice wkeys, bool should_expire, EngineShard
     sd.local_mask &= ~KEYLOCK_ACQUIRED;
     shard->blocking_controller()->FinalizeWatched(wkeys, this);
     DCHECK(!shard->blocking_controller()->awakened_transactions().contains(this));
-
-    shard->blocking_controller()->NotifyPending();
   }
 
   // Need to see why I decided to call this.


### PR DESCRIPTION
NotifyPending was being called when a blocked transaction expires, which meant other blocked transactions could be woken up even though another transaction could be in progress. NotifyPending has no affect on the blocked transaction.

Fixes https://github.com/dragonflydb/dragonfly/issues/1387.

(Ran `list_family_test --gtest_repeat=100` as requested which passed)

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->