### PR TITLE
fix: drain the connection socket on a protocol error

### DIFF
--- a/src/facade/redis_parser.cc
+++ b/src/facade/redis_parser.cc
@@ -252,7 +252,7 @@ auto RedisParser::ConsumeArrayLen(Buffer str) -> Result {
       return BAD_ARRAYLEN;
     case OK:
       if (len < -1 || len > kMaxArrayLen) {
-        VLOG_IF(1, len > kMaxArrayLen) << "Multi bulk len is too big " << len;
+        LOG_IF(WARNING, len > kMaxArrayLen) << "Multi bulk len is too big " << len;
 
         return BAD_ARRAYLEN;
       }


### PR DESCRIPTION
Fix for https://github.com/dragonflydb/dragonfly/issues/1327.

To avoid the client `write` failing on a protocol error, meaning they never read the protocol error response, this closes only the servers send side of the connection (to send a FIN to the client but not an RST if the client keeps writing) then drains the client socket. So on the client `write` will still succeed, then they will receive the error protocol response.

So in https://github.com/dragonflydb/dragonfly/issues/1327, the client now receives `panic: Protocol error: invalid multibulk length` rather than `panic: write tcp 127.0.0.1:42780->127.0.0.1:6379: write: connection reset by peer`.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->