### PR TITLE
fix(docker-release): Run Docker test only if image is built

### DIFF
--- a/.github/workflows/reusable-container-workflow.yaml
+++ b/.github/workflows/reusable-container-workflow.yaml
@@ -164,7 +164,8 @@ jobs:
             cache-from: type=gha
             cache-to: type=gha,mode=max
 
-      - name: Test Docker run
+      - if: ${{ hashFiles(format('{0}-{1}', matrix.dockerfile, inputs.build_type)) }}
+        name: Test Docker run
         run: |
           # docker run with port-forwarding
           # install redis-tools


### PR DESCRIPTION
Currently, During docker release we don't actually build the alpine release but the new docker run test ends up trying to run it and fails. This adds the same toggle that we use for build to prevent the test step.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->