### PR TITLE
feat(server): Add missing fields to INFO PERSISTENCE command (#1408)

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -215,7 +215,7 @@ DbStats& DbStats::operator+=(const DbStats& o) {
 }
 
 SliceEvents& SliceEvents::operator+=(const SliceEvents& o) {
-  static_assert(sizeof(SliceEvents) == 80, "You should update this function with new fields");
+  static_assert(sizeof(SliceEvents) == 88, "You should update this function with new fields");
 
   ADD(evicted_keys);
   ADD(hard_evictions);
@@ -227,6 +227,7 @@ SliceEvents& SliceEvents::operator+=(const SliceEvents& o) {
   ADD(hits);
   ADD(misses);
   ADD(insertion_rejections);
+  ADD(update);
 
   return *this;
 }
@@ -873,6 +874,8 @@ void DbSlice::PostUpdate(DbIndex db_ind, PrimeIterator it, std::string_view key,
     }
   }
 
+  ++events_.update;
+
   if (ClusterConfig::IsClusterEnabled()) {
     db.slots_stats[ClusterConfig::KeySlot(key)].total_writes += 1;
   }
@@ -1141,6 +1144,10 @@ void DbSlice::InvalidateSlotWatches(const SlotSet& slot_ids) {
 
 void DbSlice::SetDocDeletionCallback(DocDeletionCallback ddcb) {
   doc_del_cb_ = move(ddcb);
+}
+
+void DbSlice::ResetUpdateEvents() {
+  events_.update = 0;
 }
 
 }  // namespace dfly

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -51,6 +51,9 @@ struct SliceEvents {
   // how many insertions were rejected due to OOM.
   size_t insertion_rejections = 0;
 
+  // how many updates and insertions of keys between snapshot intervals
+  size_t update = 0;
+
   SliceEvents& operator+=(const SliceEvents& o);
 };
 
@@ -317,6 +320,9 @@ class DbSlice {
   void UnregisterConnectionWatches(ConnectionState::ExecInfo* exec_info);
 
   void SetDocDeletionCallback(DocDeletionCallback ddcb);
+
+  // Resets the event counter for updates/insertions
+  void ResetUpdateEvents();
 
  private:
   std::pair<PrimeIterator, bool> AddOrUpdateInternal(const Context& cntx, std::string_view key,

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1806,6 +1806,11 @@ GlobalState Service::SwitchState(GlobalState from, GlobalState to) {
   return to;
 }
 
+GlobalState Service::GetGlobalState() const {
+  lock_guard lk(mu_);
+  return global_state_;
+}
+
 void Service::ConfigureHttpHandlers(util::HttpListenerBase* base) {
   server_family_.ConfigureMetrics(base);
   base->RegisterCb("/txz", TxTable);

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -85,6 +85,8 @@ class Service : public facade::ServiceInterface {
   // Upon switch, updates cached global state in threadlocal ServerState struct.
   GlobalState SwitchState(GlobalState from, GlobalState to);
 
+  GlobalState GetGlobalState() const;
+
   void ConfigureHttpHandlers(util::HttpListenerBase* base) final;
   void OnClose(facade::ConnectionContext* cntx) final;
   std::string GetContextInfo(facade::ConnectionContext* cntx) final;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -594,20 +594,6 @@ struct AggregateLoadResult {
   std::atomic<size_t> keys_read;
 };
 
-template <typename T> class OnScopeExit {
- public:
-  explicit OnScopeExit(T&& f) : fun(move(f)) {
-  }
-  OnScopeExit(const OnScopeExit&) = delete;
-  OnScopeExit(const OnScopeExit&&) = delete;
-  ~OnScopeExit() {
-    fun();
-  };
-
- private:
-  T fun;
-};
-
 // Load starts as many fibers as there are files to load each one separately.
 // It starts one more fiber that waits for all load fibers to finish and returns the first
 // error (if any occured) with a future.

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -192,7 +192,7 @@ class TestDflySnapshotOnShutdown(SnapshotTestBase):
 
         assert await seeder.compare(start_capture)
 
-@dfly_args({**BASIC_ARGS, "dbfilename": "test-shutdown"})
+@dfly_args({**BASIC_ARGS, "dbfilename": "test-info-persistence"})
 class TestDflyInfoPersistenceLoadingField(SnapshotTestBase):
     """Test is_loading field on INFO PERSISTENCE during snapshot loading"""
     @pytest.fixture(autouse=True)
@@ -215,7 +215,6 @@ class TestDflyInfoPersistenceLoadingField(SnapshotTestBase):
 
         a_client = aioredis.Redis(port=df_server.port)
         res = await a_client.execute_command("INFO PERSISTENCE")
-        expected = 1
         assert '1' == self.extract_is_loading_field(res)
 
         #Wait for snapshot to finish loading and retry INFO PERSISTENCE

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -191,3 +191,36 @@ class TestDflySnapshotOnShutdown(SnapshotTestBase):
         await a_client.connection_pool.disconnect()
 
         assert await seeder.compare(start_capture)
+
+@dfly_args({**BASIC_ARGS, "dbfilename": "test-shutdown"})
+class TestDflyInfoPersistenceLoadingField(SnapshotTestBase):
+    """Test is_loading field on INFO PERSISTENCE during snapshot loading"""
+    @pytest.fixture(autouse=True)
+    def setup(self, tmp_dir: Path):
+        self.tmp_dir = tmp_dir
+
+    def extract_is_loading_field(self, res):
+        matcher = b'loading:'
+        start = res.find(matcher)
+        pos = start + len(matcher)
+        return chr(res[pos])
+
+    @pytest.mark.asyncio
+    async def test_snapshot(self, df_seeder_factory, df_server):
+        seeder = df_seeder_factory.create(port=df_server.port, **SEEDER_ARGS)
+        await seeder.run(target_deviation=0.1)
+
+        df_server.stop()
+        df_server.start()
+
+        a_client = aioredis.Redis(port=df_server.port)
+        res = await a_client.execute_command("INFO PERSISTENCE")
+        expected = 1
+        assert '1' == self.extract_is_loading_field(res)
+
+        #Wait for snapshot to finish loading and retry INFO PERSISTENCE
+        await wait_available_async(a_client)
+        res = await a_client.execute_command("INFO PERSISTENCE")
+        assert '0' == self.extract_is_loading_field(res)
+
+        await a_client.connection_pool.disconnect()


### PR DESCRIPTION
This PR adds `loading` and `rdb_changes_since_last_save` fields to `INFO PERSISTENCE` command. 
This PR addresses the issue #1408 