### PR TITLE
fix: add numpy to regtests (needed for knn)

### DIFF
--- a/tests/dragonfly/requirements.txt
+++ b/tests/dragonfly/requirements.txt
@@ -13,3 +13,4 @@ wrapt==1.14.1
 pytest-asyncio==0.20.1
 pytest-repeat==0.9.1
 pymemcache==4.0.0
+numpy==1.24.3


### PR DESCRIPTION
Add numpy to regtests dependencies