### PR TITLE
fix: rename memcache to memcacheD

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Dragonfly currently supports the following Redis-specific arguments:
  * `dbfilename`: The filename to save and load the database (`default: dump`).
 
 There are also some Dragonfly-specific arguments:
- * `memcache_port`: The port to enable Memcached-compatible API on (`default: disabled`).
+ * `memcached_port`: The port to enable Memcached-compatible API on (`default: disabled`).
  * `keys_output_limit`: Maximum number of returned keys in `keys` command (`default: 8192`). Note that `keys` is a dangerous command. We truncate its result to avoid a blowup in memory use when fetching too many keys.
  * `dbnum`: Maximum number of supported databases for `select`.
  * `cache_mode`: See the [novel cache design](#novel-cache-design) section below.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,7 +99,7 @@ Dragonfly 支持 Redis 的常见参数。
 
 此外，还有 Dragonfly 特定的参数选项：
 
-* `memcache_port`：在此端口上启用 memcached 兼容的 API。默认禁用。
+* `memcached_port`：在此端口上启用 memcached 兼容的 API。默认禁用。
 
 * `keys_output_limit`：在`keys` 命令中返回的最大键数。默认为 8192。
 

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -71,7 +71,7 @@ std::string AbslUnparseFlag(const MaxMemoryFlag& flag) {
 }
 
 ABSL_DECLARE_FLAG(uint32_t, port);
-ABSL_DECLARE_FLAG(uint32_t, memcache_port);
+ABSL_DECLARE_FLAG(uint32_t, memcached_port);
 ABSL_DECLARE_FLAG(uint16_t, admin_port);
 ABSL_DECLARE_FLAG(std::string, admin_bind);
 
@@ -322,7 +322,7 @@ bool RunEngine(ProactorPool* pool, AcceptServer* acceptor) {
   const auto& bind = GetFlag(FLAGS_bind);
   const char* bind_addr = bind.empty() ? nullptr : bind.c_str();
   auto port = GetFlag(FLAGS_port);
-  auto mc_port = GetFlag(FLAGS_memcache_port);
+  auto mc_port = GetFlag(FLAGS_memcached_port);
   string unix_sock = GetFlag(FLAGS_unixsocket);
   bool unlink_uds = false;
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -48,7 +48,7 @@ using namespace std;
 using dfly::operator""_KB;
 
 ABSL_FLAG(uint32_t, port, 6379, "Redis port");
-ABSL_FLAG(uint32_t, memcache_port, 0, "Memcached port");
+ABSL_FLAG(uint32_t, memcached_port, 0, "Memcached port");
 
 ABSL_FLAG(uint32_t, num_shards, 0, "Number of database shards, 0 - to choose automatically");
 

--- a/tests/dragonfly/pymemcached_test.py
+++ b/tests/dragonfly/pymemcached_test.py
@@ -3,18 +3,18 @@ import pymemcache
 from . import dfly_args
 
 
-@dfly_args({"memcache_port": 11211})
+@dfly_args({"memcached_port": 11211})
 def test_add_get(memcached_connection):
     assert memcached_connection.add(b"key", b"data", noreply=False)
     assert memcached_connection.get(b"key") == b"data"
 
-@dfly_args({"memcache_port": 11211})
+@dfly_args({"memcached_port": 11211})
 def test_add_set(memcached_connection):
     assert memcached_connection.add(b"key", b"data", noreply=False)
     memcached_connection.set(b"key", b"other")
     assert memcached_connection.get(b"key") == b"other"
 
-@dfly_args({"memcache_port": 11211})
+@dfly_args({"memcached_port": 11211})
 def test_set_add(memcached_connection):
     memcached_connection.set(b"key", b"data")
     # stuck here
@@ -23,7 +23,7 @@ def test_set_add(memcached_connection):
     memcached_connection.set(b"key", b"other")
     assert memcached_connection.get(b"key") == b"other"
 
-@dfly_args({"memcache_port": 11211})
+@dfly_args({"memcached_port": 11211})
 def test_mixed_reply(memcached_connection):
     memcached_connection.set(b"key", b"data", noreply=True)
     memcached_connection.add(b"key", b"other", noreply=False)


### PR DESCRIPTION
The product is called Memcache**D**. Noticed this when writing docs