### PR TITLE
fix: support json v1 dot path

### DIFF
--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -1005,4 +1005,15 @@ TEST_F(JsonFamilyTest, Set) {
   EXPECT_EQ(resp, R"([{"a":2,"b":8,"c":[1,2,3]}])");
 }
 
+TEST_F(JsonFamilyTest, LegacyV1) {
+  string json = R"({"key":[1,2,3,4]})";
+
+  auto resp = Run({"JSON.SET", "json1", ".", json});
+  EXPECT_THAT(resp, "OK");
+
+  // JSON.GET key "." is the same as JSON.GET key "$"
+  resp = Run({"JSON.GET", "json1", "."});
+  EXPECT_THAT(resp, absl::StrCat("[", absl::StripAsciiWhitespace(json), "]"));
+}
+
 }  // namespace dfly

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -1013,7 +1013,7 @@ TEST_F(JsonFamilyTest, LegacyV1) {
 
   // JSON.GET key "." is the same as JSON.GET key "$"
   resp = Run({"JSON.GET", "json1", "."});
-  EXPECT_THAT(resp, absl::StrCat("[", absl::StripAsciiWhitespace(json), "]"));
+  EXPECT_THAT(resp, absl::StrCat("[", json, "]"));
 }
 
 }  // namespace dfly


### PR DESCRIPTION
Fixes #1456 

There is a special optimization for root level set that doesn't parse the path. It already checks both "." and "$". This is why it failed only for get commands