### PR TITLE
feat(debian): retain debug symbols in deb package

### DIFF
--- a/tools/packaging/debian/rules
+++ b/tools/packaging/debian/rules
@@ -1,5 +1,7 @@
 #!/usr/bin/make -f
 
+export DEB_BUILD_OPTIONS="noopt nostrip nocheck"
+
 %:
 	dh $@
 


### PR DESCRIPTION
This PR adds relevant Build Options to retain debug symbols.

After this:

![Screenshot from 2023-06-22 16-53-30](https://github.com/dragonflydb/dragonfly/assets/7892868/880030a0-104b-4a57-b7b7-7ba9e55d7bed)

Also, With this the deb package size grew from 3 MB to 9 MB,
