### PR TITLE
fix: avoid using main_listener when migrating connections

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -843,6 +843,10 @@ void Connection::ShutdownSelf() {
   util::Connection::Shutdown();
 }
 
+void Connection::Migrate(util::fb2::ProactorBase* dest) {
+  owner()->Migrate(this, dest);
+}
+
 void Connection::ShutdownThreadLocal() {
   pipeline_req_pool_.clear();
 }

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -136,6 +136,9 @@ class Connection : public util::Connection {
   // Manually shutdown self.
   void ShutdownSelf();
 
+  // Migrate this connecton to a different thread.
+  void Migrate(util::fb2::ProactorBase* dest);
+
   static void ShutdownThreadLocal();
 
   bool IsCurrentlyDispatching() const;

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -80,8 +80,7 @@ struct TransactionGuard {
 };
 }  // namespace
 
-DflyCmd::DflyCmd(util::ListenerInterface* listener, ServerFamily* server_family)
-    : sf_(server_family), listener_(listener) {
+DflyCmd::DflyCmd(ServerFamily* server_family) : sf_(server_family) {
 }
 
 void DflyCmd::Run(CmdArgList args, ConnectionContext* cntx) {
@@ -204,7 +203,7 @@ void DflyCmd::Thread(CmdArgList args, ConnectionContext* cntx) {
 
   if (num_thread < pool->size()) {
     if (int(num_thread) != ProactorBase::GetIndex()) {
-      listener_->Migrate(cntx->owner(), pool->at(num_thread));
+      cntx->owner()->Migrate(pool->at(num_thread));
     }
 
     return rb->SendOk();
@@ -249,7 +248,7 @@ void DflyCmd::Flow(CmdArgList args, ConnectionContext* cntx) {
   cntx->replication_flow = &replica_ptr->flows[flow_id];
   replica_ptr->flows[flow_id].conn = cntx->owner();
   replica_ptr->flows[flow_id].eof_token = eof_token;
-  listener_->Migrate(cntx->owner(), shard_set->pool()->at(flow_id));
+  cntx->owner()->Migrate(shard_set->pool()->at(flow_id));
 
   rb->StartArray(2);
   rb->SendSimpleString("FULL");

--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -114,7 +114,7 @@ class DflyCmd {
   };
 
  public:
-  DflyCmd(util::ListenerInterface* listener, ServerFamily* server_family);
+  DflyCmd(ServerFamily* server_family);
 
   void Run(CmdArgList args, ConnectionContext* cntx);
 
@@ -195,7 +195,6 @@ class DflyCmd {
  private:
   ServerFamily* sf_;  // Not owned
 
-  util::ListenerInterface* listener_;
   TxId journal_txid_ = 0;
 
   uint32_t next_sync_id_ = 1;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -498,7 +498,7 @@ void ServerFamily::Init(util::AcceptServer* acceptor, util::ListenerInterface* m
   CHECK(acceptor_ == nullptr);
   acceptor_ = acceptor;
   main_listener_ = main_listener;
-  dfly_cmd_ = make_unique<DflyCmd>(main_listener, this);
+  dfly_cmd_ = make_unique<DflyCmd>(this);
   cluster_family_ = cluster_family;
 
   pb_task_ = shard_set->pool()->GetNextProactor();


### PR DESCRIPTION
Partly solves #1470

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->