### PR TITLE
feat(stream): add support for xreadgroup command

### DIFF
--- a/src/server/stream_family.h
+++ b/src/server/stream_family.h
@@ -24,6 +24,7 @@ class StreamFamily {
   static void XRevRange(CmdArgList args, ConnectionContext* cntx);
   static void XRange(CmdArgList args, ConnectionContext* cntx);
   static void XRead(CmdArgList args, ConnectionContext* cntx);
+  static void XReadGroup(CmdArgList args, ConnectionContext* cntx);
   static void XSetId(CmdArgList args, ConnectionContext* cntx);
   static void XTrim(CmdArgList args, ConnectionContext* cntx);
   static void XRangeGeneric(CmdArgList args, bool is_rev, ConnectionContext* cntx);

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1414,7 +1414,7 @@ OpResult<KeyIndex> DetermineKeys(const CommandId* cid, CmdArgList args) {
 
     string_view name{cid->name()};
 
-    if (name == "XREAD") {
+    if (name == "XREAD" || name == "XREADGROUP") {
       for (size_t i = 0; i < args.size(); ++i) {
         string_view arg = ArgS(args, i);
         if (absl::EqualsIgnoreCase(arg, "STREAMS")) {


### PR DESCRIPTION
XREADGROUP lets consumers read entries from streams. This PR implements the `XREADGROUP` command.

Fixes #1433 