### PR TITLE
feat(cluster): Send flush slots cmd from masters to replicas.

### DIFF
--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -46,6 +46,7 @@ class ClusterFamily {
   void DflyClusterConfig(CmdArgList args, ConnectionContext* cntx);
   void DflyClusterGetSlotInfo(CmdArgList args, ConnectionContext* cntx);
   void DflyClusterMyId(CmdArgList args, ConnectionContext* cntx);
+  void DflyClusterFlushSlots(CmdArgList args, ConnectionContext* cntx);
 
   ClusterConfig::ClusterShard GetEmulatedShardInfo(ConnectionContext* cntx) const;
 

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -47,6 +47,10 @@ class ClusterFamilyTest : public BaseFamilyTest {
     EXPECT_LE(absl::Now(), deadline)
         << "Timeout of " << timeout << " reached when expecting condition";
   }
+
+  string GetMyId() {
+    return RunAdmin({"dflycluster", "myid"}).GetString();
+  }
 };
 
 TEST_F(ClusterFamilyTest, DflyClusterOnlyOnAdminPort) {
@@ -474,7 +478,7 @@ TEST_F(ClusterFamilyTest, ClusterGetSlotInfo) {
           "replicas": []
         }
       ])json";
-  string config = absl::Substitute(config_template, RunAdmin({"dflycluster", "myid"}).GetString());
+  string config = absl::Substitute(config_template, GetMyId());
 
   EXPECT_EQ(RunAdmin({"dflycluster", "config", config}), "OK");
 
@@ -528,7 +532,7 @@ TEST_F(ClusterFamilyTest, ClusterSlotsPopulate) {
           "replicas": []
         }
       ])json";
-  string config = absl::Substitute(config_template, RunAdmin({"dflycluster", "myid"}).GetString());
+  string config = absl::Substitute(config_template, GetMyId());
 
   EXPECT_EQ(RunAdmin({"dflycluster", "config", config}), "OK");
 
@@ -563,7 +567,7 @@ TEST_F(ClusterFamilyTest, ClusterConfigDeleteSlots) {
           "replicas": []
         }
       ])json";
-  string config = absl::Substitute(config_template, RunAdmin({"dflycluster", "myid"}).GetString());
+  string config = absl::Substitute(config_template, GetMyId());
 
   EXPECT_EQ(RunAdmin({"dflycluster", "config", config}), "OK");
 
@@ -608,7 +612,7 @@ TEST_F(ClusterFamilyTest, ClusterConfigDeleteSlotsNoCrashOnShutdown) {
           "replicas": []
         }
       ])json";
-  string config = absl::Substitute(config_template, RunAdmin({"dflycluster", "myid"}).GetString());
+  string config = absl::Substitute(config_template, GetMyId());
 
   EXPECT_EQ(RunAdmin({"dflycluster", "config", config}), "OK");
 
@@ -659,7 +663,7 @@ TEST_F(ClusterFamilyTest, ClusterConfigDeleteSomeSlots) {
           "replicas": []
         }
       ])json";
-  string config = absl::Substitute(config_template, RunAdmin({"dflycluster", "myid"}).GetString());
+  string config = absl::Substitute(config_template, GetMyId());
 
   EXPECT_EQ(RunAdmin({"dflycluster", "config", config}), "OK");
 
@@ -683,6 +687,72 @@ TEST_F(ClusterFamilyTest, ClusterConfigDeleteSomeSlots) {
               RespArray(ElementsAre(
                   RespArray(ElementsAre(IntArg(7999), "key_count", IntArg(1), _, _, _, _)),
                   RespArray(ElementsAre(IntArg(8000), "key_count", IntArg(0), _, _, _, _)))));
+}
+
+TEST_F(ClusterFamilyTest, ClusterConfigReplicaDoesNotDeleteSlots) {
+  string config_template = R"json(
+      [
+        {
+          "slot_ranges": [
+            {
+              "start": 0,
+              "end": $0
+            }
+          ],
+          "master": {
+            "id": "some-master",
+            "ip": "10.0.0.1",
+            "port": 7000
+          },
+          "replicas": [
+            {
+              "id": "$1",
+              "ip": "10.0.0.1",
+              "port": 7000
+            }
+          ]
+        },
+        {
+          "slot_ranges": [
+            {
+              "start": $2,
+              "end": 16383
+            }
+          ],
+          "master": {
+            "id": "other",
+            "ip": "10.0.0.2",
+            "port": 7000
+          },
+          "replicas": []
+        }
+      ])json";
+  string config = absl::Substitute(config_template, /* last-owned-slot= */ 8'000, GetMyId(),
+                                   /* next-owned-slot= */ 8'001);
+
+  EXPECT_EQ(RunAdmin({"dflycluster", "config", config}), "OK");
+
+  EXPECT_EQ(Run({"debug", "populate", "10", "key", "4", "slots", "7999", "8000"}), "OK");
+
+  EXPECT_THAT(
+      RunAdmin({"dflycluster", "getslotinfo", "slots", "7999", "8000"}),
+      RespArray(ElementsAre(RespArray(ElementsAre(IntArg(7'999), "key_count", Not(IntArg(0)),
+                                                  "total_reads", _, "total_writes", _)),
+                            RespArray(ElementsAre(IntArg(8'000), "key_count", Not(IntArg(0)),
+                                                  "total_reads", _, "total_writes", _)))));
+
+  // Move ownership of slot 8,000 to another node.
+  config = absl::Substitute(config_template, /* last-owned-slot= */ 8'001, GetMyId(),
+                            /* next-owned-slot= */ 8'002);
+  EXPECT_EQ(RunAdmin({"dflycluster", "config", config}), "OK");
+
+  // Expect that no data was removed, despite ownership move, because node is a replica.
+  EXPECT_THAT(
+      RunAdmin({"dflycluster", "getslotinfo", "slots", "7999", "8000"}),
+      RespArray(ElementsAre(RespArray(ElementsAre(IntArg(7'999), "key_count", Not(IntArg(0)),
+                                                  "total_reads", _, "total_writes", _)),
+                            RespArray(ElementsAre(IntArg(8'000), "key_count", Not(IntArg(0)),
+                                                  "total_reads", _, "total_writes", _)))));
 }
 
 TEST_F(ClusterFamilyTest, ClusterModeSelectNotAllowed) {
@@ -733,7 +803,33 @@ TEST_F(ClusterFamilyTest, Keyslot) {
             CheckedInt({"cluster", "keyslot", "123{def}456"}));
 }
 
-class ClusterFamilyEmulatedTest : public BaseFamilyTest {
+TEST_F(ClusterFamilyTest, FlushSlots) {
+  EXPECT_EQ(Run({"debug", "populate", "100", "key", "4", "slots", "0", "1"}), "OK");
+
+  EXPECT_THAT(RunAdmin({"dflycluster", "getslotinfo", "slots", "0", "1"}),
+              RespArray(ElementsAre(RespArray(ElementsAre(IntArg(0), "key_count", Not(IntArg(0)),
+                                                          "total_reads", _, "total_writes", _)),
+                                    RespArray(ElementsAre(IntArg(1), "key_count", Not(IntArg(0)),
+                                                          "total_reads", _, "total_writes", _)))));
+
+  EXPECT_EQ(RunAdmin({"dflycluster", "flushslots", "0"}), "OK");
+
+  EXPECT_THAT(RunAdmin({"dflycluster", "getslotinfo", "slots", "0", "1"}),
+              RespArray(ElementsAre(RespArray(ElementsAre(IntArg(0), "key_count", IntArg(0),
+                                                          "total_reads", _, "total_writes", _)),
+                                    RespArray(ElementsAre(IntArg(1), "key_count", Not(IntArg(0)),
+                                                          "total_reads", _, "total_writes", _)))));
+
+  EXPECT_EQ(RunAdmin({"dflycluster", "flushslots", "0", "1"}), "OK");
+
+  EXPECT_THAT(RunAdmin({"dflycluster", "getslotinfo", "slots", "0", "1"}),
+              RespArray(ElementsAre(RespArray(ElementsAre(IntArg(0), "key_count", IntArg(0),
+                                                          "total_reads", _, "total_writes", _)),
+                                    RespArray(ElementsAre(IntArg(1), "key_count", IntArg(0),
+                                                          "total_reads", _, "total_writes", _)))));
+}
+
+class ClusterFamilyEmulatedTest : public ClusterFamilyTest {
  public:
   ClusterFamilyEmulatedTest() {
     SetTestFlag("cluster_mode", "emulated");
@@ -752,17 +848,17 @@ TEST_F(ClusterFamilyEmulatedTest, ClusterInfo) {
 
 TEST_F(ClusterFamilyEmulatedTest, ClusterShards) {
   EXPECT_THAT(Run({"cluster", "shards"}),
-              RespArray(ElementsAre("slots",                                                      //
-                                    RespArray(ElementsAre(IntArg(0), IntArg(16383))),             //
-                                    "nodes",                                                      //
-                                    RespArray(ElementsAre(                                        //
-                                        RespArray(ElementsAre(                                    //
-                                            "id", RunAdmin({"dflycluster", "myid"}).GetString(),  //
-                                            "endpoint", "fake-host",                              //
-                                            "ip", "fake-host",                                    //
-                                            "port", IntArg(6379),                                 //
-                                            "role", "master",                                     //
-                                            "replication-offset", IntArg(0),                      //
+              RespArray(ElementsAre("slots",                                           //
+                                    RespArray(ElementsAre(IntArg(0), IntArg(16383))),  //
+                                    "nodes",                                           //
+                                    RespArray(ElementsAre(                             //
+                                        RespArray(ElementsAre(                         //
+                                            "id", GetMyId(),                           //
+                                            "endpoint", "fake-host",                   //
+                                            "ip", "fake-host",                         //
+                                            "port", IntArg(6379),                      //
+                                            "role", "master",                          //
+                                            "replication-offset", IntArg(0),           //
                                             "health", "online")))))));
 }
 
@@ -773,13 +869,12 @@ TEST_F(ClusterFamilyEmulatedTest, ClusterSlots) {
                                     RespArray(ElementsAre(  //
                                         "fake-host",        //
                                         IntArg(6379),       //
-                                        RunAdmin({"dflycluster", "myid"}).GetString())))));
+                                        GetMyId())))));
 }
 
 TEST_F(ClusterFamilyEmulatedTest, ClusterNodes) {
   EXPECT_THAT(Run({"cluster", "nodes"}),
-              RunAdmin({"dflycluster", "myid"}).GetString() +
-                  " fake-host:6379@6379 myself,master - 0 0 0 connected 0-16383\r\n");
+              GetMyId() + " fake-host:6379@6379 myself,master - 0 0 0 connected 0-16383\r\n");
 }
 
 }  // namespace


### PR DESCRIPTION
This fixes potential data diffs between master and replica upon slot moving

Fixes #1320

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->