### PR TITLE
fix(regression): remove test case for info persistence

### DIFF
--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -210,18 +210,8 @@ class TestDflyInfoPersistenceLoadingField(SnapshotTestBase):
         seeder = df_seeder_factory.create(port=df_server.port, **SEEDER_ARGS)
         await seeder.run(target_deviation=0.05)
         a_client = aioredis.Redis(port=df_server.port)
-        #10 million keys
-        await a_client.execute_command("DEBUG POPULATE 10000000")
-        await a_client.execute_command("SAVE")
 
-        df_server.stop()
-        df_server.start()
-
-        a_client = aioredis.Redis(port=df_server.port)
-        res = await a_client.execute_command("INFO PERSISTENCE")
-        assert '1' == self.extract_is_loading_field(res)
-
-        #Wait for snapshot to finish loading and retry INFO PERSISTENCE
+        #Wait for snapshot to finish loading and try INFO PERSISTENCE
         await wait_available_async(a_client)
         res = await a_client.execute_command("INFO PERSISTENCE")
         assert '0' == self.extract_is_loading_field(res)


### PR DESCRIPTION
The test case for checking is_loading == 1 is inherently racy because the client can connect at any time before or after the dragonfly instance loads the snapshot.
