### PR TITLE
fix: avoid crashing dragonfly on parsing error of cgroups config

### DIFF
--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -506,7 +506,10 @@ error_code GetCGroupPath(string* memory_path, string* cpu_path) {
       // in v1 the format is
       // N:s1:2 where N is an integer, s1, s2 strings with s1 maybe empty.
       vector<string_view> entry = absl::StrSplit(sv, ':');
-      CHECK_EQ(entry.size(), 3u);
+      if (entry.size() != 3u) {
+        LOG(ERROR) << "Unsupported group " << sv;
+        continue;
+      }
 
       // in v1 there are several 'canonical' cgroups
       // we are interested in the 'memory' and the 'cpu,cpuacct' ones


### PR DESCRIPTION
Fixes #1502

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->