### PR TITLE
fix: disable prohibited eval in multi test

### DIFF
--- a/tests/dragonfly/server_family_test.py
+++ b/tests/dragonfly/server_family_test.py
@@ -40,7 +40,7 @@ change to match the fact that we supporting this operation.
 For now we are expecting to get an error
 '''
 
-
+@pytest.skip("Skip until we decided on correct behaviour of eval inside multi")
 async def test_multi_eval(async_client: aioredis.Redis):
     try:
         pipeline = async_client.pipeline()


### PR DESCRIPTION
Disable this test because we experimentally allow eval in exec (and this test now works), yet there are very few safety checks and its kind of a hotfix. There is another tests already that asserts this behaviour in eval_test.py, so lets skip this one for now