### PR TITLE
fix: zunion and zunionstore zero numkeys bug

### DIFF
--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1445,10 +1445,12 @@ OpResult<KeyIndex> DetermineKeys(const CommandId* cid, CmdArgList args) {
     if (!absl::SimpleAtoi(num, &num_custom_keys) || num_custom_keys < 0)
       return OpStatus::INVALID_INT;
 
-    // TODO Fix this for Z family functions.
-    // Examples that crash: ZUNION 0 myset
     if (name == "ZDIFF" && num_custom_keys == 0) {
       return OpStatus::INVALID_INT;
+    }
+
+    if (name == "ZUNION" && num_custom_keys == 0) {
+      return OpStatus::SYNTAX_ERR;
     }
 
     if (args.size() < size_t(num_custom_keys) + num_keys_index + 1)

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -956,7 +956,7 @@ OpResult<void> FillAggType(string_view agg, SetOpArgs* op_args) {
 
 // Parse functions return the number of arguments read from CmdArgList
 OpResult<unsigned> ParseAggregate(CmdArgList args, bool store, SetOpArgs* op_args) {
-  if (args.size() < 1) {
+  if (args.size() <= 1) {
     return OpStatus::SYNTAX_ERR;
   }
 

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -291,6 +291,9 @@ TEST_F(ZSetFamilyTest, ZUnionError) {
   resp = Run({"zunion", "0"});
   EXPECT_THAT(resp, ErrArg("wrong number of arguments"));
 
+  resp = Run({"zunion", "0", "myset"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
+
   resp = Run({"zunion", "3", "z1", "z2", "z3", "weights", "1", "1", "k"});
   EXPECT_THAT(resp, ErrArg("weight value is not a float"));
 
@@ -359,6 +362,9 @@ TEST_F(ZSetFamilyTest, ZUnionStore) {
 
   resp = Run({"zunionstore", "key", "0"});
   EXPECT_THAT(resp, ErrArg("wrong number of arguments"));
+
+  resp = Run({"zunionstore", "key", "0", "aggregate"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
 
   resp = Run({"zunionstore", "key", "0", "aggregate", "sum"});
   EXPECT_THAT(resp, ErrArg("at least 1 input key is needed"));


### PR DESCRIPTION
Fixes #1442

Behaviour after this fix : 
```shell
127.0.0.1:6379> zunion 0 key
(error) ERR syntax error
127.0.0.1:6379> zunionstore out 0  aggregate
(error) ERR syntax error
``` 