### PR TITLE
bug(server): multi exec eval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           #GLOG_logtostderr=1 GLOG_vmodule=transaction=1,engine_shard_set=1
           GLOG_logtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 ctest -V -L DFLY
           ./dragonfly_test  --gtest_repeat=10
-          ./multi_test --multi_exec_mode=2 --gtest_repeat=10
+          ./multi_test --multi_exec_mode=1 --gtest_repeat=10
           ./multi_test --multi_exec_mode=3 --gtest_repeat=10
           # GLOG_logtostderr=1 GLOG_vmodule=transaction=1,engine_shard_set=1 CTEST_OUTPUT_ON_FAILURE=1 ninja server/test
   lint-test-chart:

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -52,7 +52,7 @@ ABSL_FLAG(uint32_t, memcached_port, 0, "Memcached port");
 
 ABSL_FLAG(uint32_t, num_shards, 0, "Number of database shards, 0 - to choose automatically");
 
-ABSL_FLAG(uint32_t, multi_exec_mode, 1,
+ABSL_FLAG(uint32_t, multi_exec_mode, 2,
           "Set multi exec atomicity mode: 1 for global, 2 for locking ahead, 3 for non atomic");
 
 ABSL_FLAG(bool, multi_exec_squash, true,

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1281,8 +1281,7 @@ bool StartMultiEval(DbIndex dbid, CmdArgList keys, ScriptMgr::ScriptParams param
   Transaction::MultiMode multi_mode = DetermineMultiMode(params);
 
   // Check if eval is already part of a running multi transaction
-  if ((trans->GetMultiMode() != Transaction::NOT_DETERMINED) &&
-      trans->GetMultiMode() != Transaction::NON_ATOMIC) {
+  if (trans->GetMultiMode() != Transaction::NOT_DETERMINED) {
     DCHECK_LE(trans->GetMultiMode(), multi_mode);  // Check the transaction covers our requirements
     return false;
   }

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1543,6 +1543,8 @@ void Service::Exec(CmdArgList args, ConnectionContext* cntx) {
 
   if (state != ExecEvalState::NONE) {
     // Allow multi eval only when scripts run global and multi runs in global or lock ahead
+    // We adjust the atomicity level of multi transaction inside StartMultiExec i.e if multi mode is
+    // lock ahead and we run global script in the transaction then multi mode will be global.
     if (!global_script || (multi_mode == Transaction::NON_ATOMIC)) {
       return rb->SendError(
           "Dragonfly does not allow execution of a server-side Lua in Multi transaction");

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -755,8 +755,7 @@ TEST_F(MultiEvalTest, MultiAllEval) {
   RespExpr exec_resp = Run({"exec"});
   fb0.Join();
 
-  ASSERT_THAT(exec_resp, ArrLen(2));
-  ASSERT_THAT(exec_resp.GetVec(), ElementsAre(IntArg(1), "y"));
+  EXPECT_THAT(exec_resp.GetVec(), ElementsAre(IntArg(1), "y"));
 
   EXPECT_THAT(brpop_resp, ArgType(RespExpr::NIL_ARRAY));
 }
@@ -778,8 +777,7 @@ TEST_F(MultiEvalTest, MultiSomeEval) {
   RespExpr exec_resp = Run({"exec"});
   fb0.Join();
 
-  ASSERT_THAT(exec_resp, ArrLen(2));
-  ASSERT_THAT(exec_resp.GetVec(), ElementsAre(IntArg(1), "y"));
+  EXPECT_THAT(exec_resp.GetVec(), ElementsAre(IntArg(1), "y"));
 
   EXPECT_THAT(brpop_resp, ArgType(RespExpr::NIL_ARRAY));
 }

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -731,11 +731,10 @@ class MultiEvalTest : public BaseFamilyTest {
  protected:
   MultiEvalTest() : BaseFamilyTest() {
     num_threads_ = kPoolThreadCount;
-    fs_.reset(new absl::FlagSaver);
     absl::SetFlag(&FLAGS_default_lua_flags, "allow-undeclared-keys");
   }
 
-  std::unique_ptr<absl::FlagSaver> fs_;
+  absl::FlagSaver fs_;
 };
 
 TEST_F(MultiEvalTest, MultiAllEval) {

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -64,7 +64,7 @@ TEST_F(MultiTest, MultiAndEval) {
 
   // Run the fiber at creation.
   auto fb0 = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] { resp = Run({"brpop", "x", "1"}); });
-  Run({"mutli"});
+  Run({"multi"});
   Run({"eval", "return redis.call('lpush', 'x', 'y')", "0"});
   Run({"eval", "return redis.call('lpop', 'x')", "0"});
   Run({"exec"});


### PR DESCRIPTION
* The bug - if all commands inside multi trasaction are eval commands and global scripts mode is on, we did ignored the trasaction and run each eval separately.
* The fix - run all evals under multi inside the global lock
