### PR TITLE
chore: eliminate futher robj references in zset_family code

### DIFF
--- a/src/server/zset_family.h
+++ b/src/server/zset_family.h
@@ -49,9 +49,6 @@ class ZSetFamily {
     RangeParams params;
   };
 
-  using ScoredMember = std::pair<std::string, double>;
-  using ScoredArray = std::vector<ScoredMember>;
-
  private:
   template <typename T> using OpResult = facade::OpResult<T>;
 
@@ -88,8 +85,6 @@ class ZSetFamily {
   static void ZUnionStore(CmdArgList args, ConnectionContext* cntx);
 
   static void ZRangeByScoreInternal(CmdArgList args, bool reverse, ConnectionContext* cntx);
-  static void OutputScoredArrayResult(const OpResult<ScoredArray>& arr, const RangeParams& params,
-                                      ConnectionContext* cntx);
   static void ZRemRangeGeneric(std::string_view key, const ZRangeSpec& range_spec,
                                ConnectionContext* cntx);
   static void ZRangeGeneric(CmdArgList args, RangeParams range_params, ConnectionContext* cntx);


### PR DESCRIPTION
Next step before pulling out "zset*" functionality into our own class.
No functional changes are done.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->