### PR TITLE
fix: add wait after killing a process to avoid unhandled SIGTERM

### DIFF
--- a/tests/dragonfly/__init__.py
+++ b/tests/dragonfly/__init__.py
@@ -60,6 +60,12 @@ class DflyInstance:
             else:
                 proc.terminate()
             proc.communicate(timeout=15)
+            # We need to wait, because kill sends a SIGTERM which can then be ignored or blocked
+            # By waiting 15 sec it gives enough time for the signal to be handled by the process
+            # Moreover, proc.communicate calls wait() internally, but completely ignores
+            # the value returned which suggests that there is a bug with the python implementation
+            # If this fails, it will throw an exception
+            proc.wait(timeout=15)
         except subprocess.TimeoutExpired:
             print("Unable to terminate DragonflyDB gracefully, it was killed")
             proc.kill()

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1344,9 +1344,6 @@ async def test_tls_replication(
 
     # 4. Kill master, spin it up and see if replica reconnects
     master.stop(kill=True)
-    # We need to await, because kill sends a SIGTERM which can then be ignored or blocked
-    # By waiting 1 sec it gives enough time for the signal to be handled by the process
-    await asyncio.sleep(10)
     master.start()
     c_master = aioredis.Redis(port=master.port, **with_ca_tls_client_args)
     # Master doesn't load the snapshot, therefore dbsize should be 0

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1344,6 +1344,9 @@ async def test_tls_replication(
 
     # 4. Kill master, spin it up and see if replica reconnects
     master.stop(kill=True)
+    # We need to await, because kill sends a SIGTERM which can then be ignored or blocked
+    # By waiting 1 sec it gives enough time for the signal to be handled by the process
+    await asyncio.sleep(10)
     master.start()
     c_master = aioredis.Redis(port=master.port, **with_ca_tls_client_args)
     # Master doesn't load the snapshot, therefore dbsize should be 0


### PR DESCRIPTION
`process.kill` sends a `SIGTERM` to the soon to be killed process. However, signals are non-blocking, meaning that the process receiving them can ignore or block(meaning that the signal is queued on a blocking queue to be handled later by the process) on them. By waiting for a second, we give enough time to the soon to be killed process to handle the signal and the OS to reclaim the its resources (sockets, etc)