### PR TITLE
Fix(regression test): test_tls_replication

### DIFF
--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1353,6 +1353,7 @@ async def test_tls_replication(
 
     # 4. Kill master, spin it up and see if replica reconnects
     master.stop(kill=True)
+    await asyncio.sleep(3)
     master.start()
     c_master = aioredis.Redis(port=master.port, **with_ca_tls_client_args)
     # Master doesn't load the snapshot, therefore dbsize should be 0


### PR DESCRIPTION
The test fails sometimes when starting master after killing it. The reason for this is that OS did not release port untill we started master again.
The fix - adding sleep after kill
After we will have randomly selected ports on pytest we can remove this sleep.
