### PR TITLE
perf: Special handling for sending constant strings

### DIFF
--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -20,6 +20,22 @@ enum class ReplyMode {
   FULL       // All replies are recorded
 };
 
+#define DFLY_COMMON_STRINGS_X_MACRO() \
+  X(OK)                               \
+  X(ERROR)                            \
+  X(QUEUED)                           \
+  X(NOT_FOUND)                        \
+  X(STORED)                           \
+  X(NOT_STORED)                       \
+  X(END)                              \
+  X(FULL)                             \
+  X(DELETED)                          \
+  X(PONG)
+
+#define X(t) t,
+enum class CommonStrings { DFLY_COMMON_STRINGS_X_MACRO() };
+#undef X
+
 class SinkReplyBuilder {
  public:
   struct ResponseValue {
@@ -50,8 +66,10 @@ class SinkReplyBuilder {
   virtual void SendLong(long val) = 0;
   virtual void SendSimpleString(std::string_view str) = 0;
 
+  virtual void SendCommonString(CommonStrings string) = 0;
+
   void SendOk() {
-    SendSimpleString("OK");
+    SendCommonString(CommonStrings::OK);
   }
 
   virtual void SendProtocolError(std::string_view str) = 0;
@@ -155,6 +173,7 @@ class MCReplyBuilder : public SinkReplyBuilder {
 
   void SendClientError(std::string_view str);
   void SendNotFound();
+  void SendCommonString(CommonStrings str) final;
   void SendSimpleString(std::string_view str) final;
   void SendProtocolError(std::string_view str) final;
 
@@ -189,6 +208,7 @@ class RedisReplyBuilder : public SinkReplyBuilder {
   virtual void SendNull();
   void SendLong(long val) override;
   virtual void SendDouble(double val);
+  void SendCommonString(CommonStrings str) override;
   void SendSimpleString(std::string_view str) override;
 
   virtual void SendBulkString(std::string_view str);

--- a/src/facade/reply_capture.cc
+++ b/src/facade/reply_capture.cc
@@ -80,6 +80,19 @@ void CapturingReplyBuilder::SendDouble(double val) {
   Capture(val);
 }
 
+void CapturingReplyBuilder::SendCommonString(CommonStrings string) {
+#define X(t)             \
+  case CommonStrings::t: \
+    return Capture(SimpleString(#t));
+
+  SKIP_LESS(ReplyMode::FULL);
+  switch (string) {
+    DFLY_COMMON_STRINGS_X_MACRO()
+    default:
+      LOG(FATAL) << "bad string " << int(string);
+  }
+}
+
 void CapturingReplyBuilder::SendSimpleString(std::string_view str) {
   SKIP_LESS(ReplyMode::FULL);
   Capture(SimpleString{string{str}});

--- a/src/facade/reply_capture.cc
+++ b/src/facade/reply_capture.cc
@@ -81,9 +81,11 @@ void CapturingReplyBuilder::SendDouble(double val) {
 }
 
 void CapturingReplyBuilder::SendCommonString(CommonStrings string) {
+  using namespace std::string_literals;
+
 #define X(t)             \
   case CommonStrings::t: \
-    return Capture(SimpleString(#t));
+    return Capture(SimpleString(#t##s));
 
   SKIP_LESS(ReplyMode::FULL);
   switch (string) {

--- a/src/facade/reply_capture.cc
+++ b/src/facade/reply_capture.cc
@@ -85,7 +85,7 @@ void CapturingReplyBuilder::SendCommonString(CommonStrings string) {
 
 #define X(t)             \
   case CommonStrings::t: \
-    return Capture(SimpleString(#t##s));
+    return Capture(SimpleString{#t##s});
 
   SKIP_LESS(ReplyMode::FULL);
   switch (string) {

--- a/src/facade/reply_capture.h
+++ b/src/facade/reply_capture.h
@@ -38,6 +38,7 @@ class CapturingReplyBuilder : public RedisReplyBuilder {
   void SendNull() override;
   void SendLong(long val) override;
   void SendDouble(double val) override;
+  void SendCommonString(CommonStrings string) override;
   void SendSimpleString(std::string_view str) override;
 
   void SendBulkString(std::string_view str) override;

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -272,7 +272,7 @@ void DflyCmd::Flow(CmdArgList args, ConnectionContext* cntx) {
   cntx->owner()->Migrate(shard_set->pool()->at(flow_id));
 
   rb->StartArray(2);
-  rb->SendSimpleString("FULL");
+  rb->SendCommonString(CommonStrings::FULL);
   rb->SendSimpleString(eof_token);
 }
 

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -660,7 +660,7 @@ void GenericFamily::Del(CmdArgList args, ConnectionContext* cntx) {
     if (del_cnt == 0) {
       mc_builder->SendNotFound();
     } else {
-      mc_builder->SendSimpleString("DELETED");
+      mc_builder->SendCommonString(CommonStrings::DELETED);
     }
   } else {
     (*cntx)->SendLong(del_cnt);
@@ -675,7 +675,7 @@ void GenericFamily::Ping(CmdArgList args, ConnectionContext* cntx) {
   // We synchronously block here until the engine sends us the payload and notifies that
   // the I/O operation has been processed.
   if (args.size() == 0) {
-    return (*cntx)->SendSimpleString("PONG");
+    return (*cntx)->SendCommonString(CommonStrings::PONG);
   } else {
     string_view arg = ArgS(args, 0);
     DVLOG(2) << "Ping " << arg;

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -1124,7 +1124,7 @@ void JsonFamily::Set(CmdArgList args, ConnectionContext* cntx) {
 
   if (result) {
     if (*result) {
-      (*cntx)->SendSimpleString("OK");
+      (*cntx)->SendOk();
     } else {
       (*cntx)->SendNull();
     }


### PR DESCRIPTION
Adds a new member function to `SinkReplyBuilder`: `SendCommonString`. The new function sends a constant string and removes the (admittedly small) overhead of sending small strings like `+` or `\r\n`.

Some motivation for this is the problems we've had with insufficient buffering and Nagall's algorithm, but I think the change is probably nice to have anyway.