### PR TITLE
bug(server): multi atomicity fix

### DIFF
--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -727,7 +727,6 @@ TEST_F(MultiTest, TestSquashing) {
   f1.Join();
 }
 
-#if 0
 TEST_F(MultiTest, MultiLeavesTxQueue) {
   if (auto mode = absl::GetFlag(FLAGS_multi_exec_mode); mode == Transaction::NON_ATOMIC) {
     GTEST_SKIP() << "Skipped MultiLeavesTxQueue test because multi_exec_mode is non atomic";
@@ -807,7 +806,6 @@ TEST_F(MultiTest, MultiLeavesTxQueue) {
   fb2.Join();
   ASSERT_TRUE(success);
 }
-#endif
 
 class MultiEvalTest : public BaseFamilyTest {
  protected:

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -498,8 +498,12 @@ bool Transaction::RunInShard(EngineShard* shard, bool txq_ooo) {
   // If we're the head of tx queue (txq_ooo is false), we remove ourselves upon first invocation
   // and successive hops are run by continuation_trans_ in engine shard.
   // Otherwise we can remove ourselves only when we're concluding (so no more hops will follow).
-  bool remove_txq = is_concluding || !txq_ooo;
+  // In case of multi transaction is_concluding represents only if the current running op is
+  // concluding, therefore we remove from txq in unlock multi funcion which is when the transaction
+  // is concluding.
+  bool remove_txq = should_release || !txq_ooo;
   if (remove_txq && sd.pq_pos != TxQueue::kEnd) {
+    VLOG(2) << "Remove from txq" << this->DebugId();
     shard->txq()->Remove(sd.pq_pos);
     sd.pq_pos = TxQueue::kEnd;
   }

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -170,7 +170,7 @@ class Transaction {
   // Called by engine shard to execute a transaction hop.
   // txq_ooo is set to true if the transaction is running out of order
   // not as the tx queue head.
-  // Returns true if transaction should be kept in the queue.
+  // Returns true if the transaction continues running in the thread
   bool RunInShard(EngineShard* shard, bool txq_ooo);
 
   // Registers transaction into watched queue and blocks until a) either notification is received.


### PR DESCRIPTION
The bug: when multi transaction run OOO we removed it from trasaction queue, causing non atomic execution.
The fix: When we run multi transaction unless it is the head in txq we remove it inside unlock multi from txq.

