### PR TITLE
Fix(regression test): fix test_flushall_in_full_sync

### DIFF
--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1026,6 +1026,7 @@ async def test_flushall_in_full_sync(df_local_factory, df_seeder_factory):
 
     async def get_sync_mode(c_master):
         result = await c_master.execute_command("role")
+        # result[1]->replicas info [0]->first replica info [2]->replication state
         return result[1][0][2]
 
     async def is_full_sync_mode(c_master):

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1024,15 +1024,15 @@ async def test_flushall_in_full_sync(df_local_factory, df_seeder_factory):
     c_replica = aioredis.Redis(port=replica.port)
     await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
 
-    async def get_sync_mode(c_replica):
-        result = await c_replica.execute_command("role")
-        return result[3]
+    async def get_sync_mode(c_master):
+        result = await c_master.execute_command("role")
+        return result[1][0][2]
 
-    async def is_full_sync_mode(c_replica):
-        return await get_sync_mode(c_replica) == b"full_sync"
+    async def is_full_sync_mode(c_master):
+        return await get_sync_mode(c_master) == b"full_sync"
 
     # Wait for full sync to start
-    while not await is_full_sync_mode(c_replica):
+    while not await is_full_sync_mode(c_master):
         await asyncio.sleep(0.0)
 
     syncid, _ = await c_replica.execute_command("DEBUG REPLICA OFFSET")
@@ -1040,7 +1040,7 @@ async def test_flushall_in_full_sync(df_local_factory, df_seeder_factory):
     # Issue FLUSHALL and push some more entries
     await c_master.execute_command("FLUSHALL")
 
-    if not await is_full_sync_mode(c_replica):
+    if not await is_full_sync_mode(c_master):
         logging.error("!!! Full sync finished too fast. Adjust test parameters !!!")
         return
 


### PR DESCRIPTION
The bug: the test checks the replication using role command on replica The replica updates the status to full sync when starting the full sync flow, but actually the master did not start snapshoting yet. The fix: check the status using role command on master, because master updates the status only after snapshoting started.

