### PR TITLE
feat(server): Use hashtags for sharding in emulated cluster mode.

### DIFF
--- a/src/server/cluster/cluster_config.h
+++ b/src/server/cluster/cluster_config.h
@@ -46,13 +46,10 @@ class ClusterConfig {
 
   static SlotId KeySlot(std::string_view key);
 
-  static void EnableCluster() {
-    cluster_enabled = true;
-  }
-
-  static bool IsClusterEnabled() {
-    return cluster_enabled;
-  }
+  static void Initialize();
+  static bool IsEnabled();
+  static bool IsEmulated();
+  static bool IsEnabledOrEmulated();
 
   // If the key contains the {...} pattern, return only the part between { and }
   static std::string_view KeyTag(std::string_view key);
@@ -81,8 +78,6 @@ class ClusterConfig {
     const ClusterShard* shard = nullptr;
     bool owned_by_me = false;
   };
-
-  static bool cluster_enabled;
 
   ClusterConfig() = default;
 

--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -22,8 +22,6 @@ class ClusterFamily {
 
   void Register(CommandRegistry* registry);
 
-  bool IsEnabledOrEmulated() const;
-
   // Returns a thread-local pointer.
   ClusterConfig* cluster_config();
 
@@ -50,7 +48,6 @@ class ClusterFamily {
 
   ClusterConfig::ClusterShard GetEmulatedShardInfo(ConnectionContext* cntx) const;
 
-  bool is_emulated_cluster_ = false;
   ServerFamily* server_family_ = nullptr;
 };
 

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -55,7 +55,7 @@ void PerformDeletion(PrimeIterator del_it, ExpireIterator exp_it, EngineShard* s
   if (pv.ObjType() == OBJ_STRING)
     stats.strval_memory_usage -= value_heap_size;
 
-  if (ClusterConfig::IsClusterEnabled()) {
+  if (ClusterConfig::IsEnabled()) {
     string tmp;
     string_view key = del_it->first.GetSlice(&tmp);
     SlotId sid = ClusterConfig::KeySlot(key);
@@ -340,7 +340,7 @@ pair<PrimeIterator, ExpireIterator> DbSlice::FindExt(const Context& cntx, string
   events_.hits++;
   db.top_keys.Touch(key);
 
-  if (ClusterConfig::IsClusterEnabled()) {
+  if (ClusterConfig::IsEnabled()) {
     db.slots_stats[ClusterConfig::KeySlot(key)].total_reads += 1;
   }
 
@@ -438,7 +438,7 @@ tuple<PrimeIterator, ExpireIterator, bool> DbSlice::AddOrFind2(const Context& cn
 
     it.SetVersion(NextVersion());
     memory_budget_ = evp.mem_budget() + evicted_obj_bytes;
-    if (ClusterConfig::IsClusterEnabled()) {
+    if (ClusterConfig::IsEnabled()) {
       SlotId sid = ClusterConfig::KeySlot(key);
       db.slots_stats[sid].key_count += 1;
     }
@@ -877,7 +877,7 @@ void DbSlice::PostUpdate(DbIndex db_ind, PrimeIterator it, std::string_view key,
 
   ++events_.update;
 
-  if (ClusterConfig::IsClusterEnabled()) {
+  if (ClusterConfig::IsEnabled()) {
     db.slots_stats[ClusterConfig::KeySlot(key)].total_writes += 1;
   }
 }

--- a/src/server/engine_shard_set.h
+++ b/src/server/engine_shard_set.h
@@ -349,7 +349,7 @@ template <typename U> void EngineShardSet::RunBlockingInParallel(U&& func) {
 }
 
 inline ShardId Shard(std::string_view v, ShardId shard_num) {
-  if (ClusterConfig::IsClusterEnabled()) {
+  if (ClusterConfig::IsEnabledOrEmulated()) {
     v = ClusterConfig::KeyTag(v);
   }
   XXH64_hash_t hash = XXH64(v.data(), v.size(), 120577240643ULL);

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1165,7 +1165,7 @@ void GenericFamily::Select(CmdArgList args, ConnectionContext* cntx) {
   if (!absl::SimpleAtoi(key, &index)) {
     return (*cntx)->SendError(kInvalidDbIndErr);
   }
-  if (ClusterConfig::IsClusterEnabled() && index != 0) {
+  if (ClusterConfig::IsEnabled() && index != 0) {
     return (*cntx)->SendError("SELECT is not allowed in cluster mode");
   }
   if (index < 0 || index >= absl::GetFlag(FLAGS_dbnum)) {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -631,7 +631,7 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
   request_latency_usec.Init(&pp_);
   StringFamily::Init(&pp_);
   GenericFamily::Init(&pp_);
-  server_family_.Init(acceptor, std::move(listeners), &cluster_family_);
+  server_family_.Init(acceptor, std::move(listeners));
 
   ChannelStore* cs = new ChannelStore{};
   pp_.Await(
@@ -849,7 +849,7 @@ bool Service::VerifyCommand(const CommandId* cid, CmdArgList args, ConnectionCon
     }
   }
 
-  if (ClusterConfig::IsClusterEnabled() && !CheckKeysOwnership(cid, args.subspan(1), dfly_cntx)) {
+  if (ClusterConfig::IsEnabled() && !CheckKeysOwnership(cid, args.subspan(1), dfly_cntx)) {
     return false;
   }
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -526,13 +526,11 @@ ServerFamily::ServerFamily(Service* service) : service_(*service) {
 ServerFamily::~ServerFamily() {
 }
 
-void ServerFamily::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> listeners,
-                        ClusterFamily* cluster_family) {
+void ServerFamily::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> listeners) {
   CHECK(acceptor_ == nullptr);
   acceptor_ = acceptor;
   listeners_ = std::move(listeners);
   dfly_cmd_ = make_unique<DflyCmd>(this);
-  cluster_family_ = cluster_family;
 
   pb_task_ = shard_set->pool()->GetNextProactor();
   if (pb_task_->GetKind() == ProactorBase::EPOLL) {
@@ -1863,7 +1861,7 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
 
   if (should_enter("CLUSTER")) {
     ADD_HEADER("# Cluster");
-    append("cluster_enabled", cluster_family_->IsEnabledOrEmulated());
+    append("cluster_enabled", ClusterConfig::IsEnabledOrEmulated());
   }
 
   (*cntx)->SendBulkString(info);

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -92,8 +92,7 @@ class ServerFamily {
   explicit ServerFamily(Service* service);
   ~ServerFamily();
 
-  void Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> listeners,
-            ClusterFamily* cluster_family);
+  void Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> listeners);
   void Register(CommandRegistry* registry);
   void Shutdown();
 
@@ -214,7 +213,6 @@ class ServerFamily {
   std::unique_ptr<ScriptMgr> script_mgr_;
   std::unique_ptr<journal::Journal> journal_;
   std::unique_ptr<DflyCmd> dfly_cmd_;
-  ClusterFamily* cluster_family_ = nullptr;  // Not owned
 
   std::string master_id_;
 

--- a/src/server/table.cc
+++ b/src/server/table.cc
@@ -46,7 +46,7 @@ DbTable::DbTable(PMR_NS::memory_resource* mr)
     : prime(kInitSegmentLog, detail::PrimeTablePolicy{}, mr),
       expire(0, detail::ExpireTablePolicy{}, mr), mcflag(0, detail::ExpireTablePolicy{}, mr),
       top_keys({.enabled = absl::GetFlag(FLAGS_enable_top_keys_tracking)}) {
-  if (ClusterConfig::IsClusterEnabled()) {
+  if (ClusterConfig::IsEnabled()) {
     slots_stats.resize(ClusterConfig::kMaxSlotNum + 1);
   }
 }


### PR DESCRIPTION
This PR would have been 1 line change instead of 11 files, but it required some plumbing and refactoring:
* Now ClusterConfig is aware of emulated cluster mode
* As a result, this API was moved from ClusterFamily
* And so was the flag & its parsing
* ClusterFamily doesn't need is_emulated_cluster_ member
* ServerFamily no longer needs ClusterFamily* member (because the API is static)
* I also changed `ClusterConfig::IsClusterEnabled()` to `ClusterConfig::IsEnabled()` to be shorter

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->