### PR TITLE
Add delete functionality to the b+tree

### DIFF
--- a/src/core/bptree_set_test.cc
+++ b/src/core/bptree_set_test.cc
@@ -19,7 +19,7 @@ class BPTreeSetTest : public ::testing::Test {
   using Node = detail::BPTreeNode<uint64_t>;
 
  protected:
-  BPTreeSetTest() : mi_alloc_(mi_heap_get_backing()), bPtree_(&mi_alloc_) {
+  BPTreeSetTest() : mi_alloc_(mi_heap_get_backing()), bptree_(&mi_alloc_) {
   }
   static void SetUpTestSuite() {
   }
@@ -29,7 +29,7 @@ class BPTreeSetTest : public ::testing::Test {
   static bool Validate(Node* node, uint64_t ubound);
 
   MiMemoryResource mi_alloc_;
-  BPTree<uint64_t> bPtree_;
+  BPTree<uint64_t> bptree_;
 };
 
 bool BPTreeSetTest::Validate(Node* node, uint64_t ubound) {
@@ -45,7 +45,7 @@ bool BPTreeSetTest::Validate(Node* node, uint64_t ubound) {
 }
 
 bool BPTreeSetTest::Validate() {
-  auto* root = bPtree_.DEBUG_root();
+  auto* root = bptree_.DEBUG_root();
   if (!root)
     return true;
 
@@ -75,7 +75,7 @@ TEST_F(BPTreeSetTest, BPtreeInsert) {
   mt19937 generator(1);
 
   for (unsigned i = 1; i < 7000; ++i) {
-    bPtree_.Insert(i);
+    bptree_.Insert(i);
   }
   ASSERT_TRUE(Validate());
 
@@ -83,33 +83,66 @@ TEST_F(BPTreeSetTest, BPtreeInsert) {
   ASSERT_LT(mi_alloc_.used(), 66000u);
 
   for (unsigned i = 1; i < 7000; ++i) {
-    ASSERT_TRUE(bPtree_.Contains(i));
+    ASSERT_TRUE(bptree_.Contains(i));
   }
 
-  bPtree_.Clear();
+  bptree_.Clear();
   ASSERT_EQ(mi_alloc_.used(), 0u);
 
   uniform_int_distribution<uint64_t> dist(0, 100000);
   for (unsigned i = 0; i < 20000; ++i) {
-    bPtree_.Insert(dist(generator));
+    bptree_.Insert(dist(generator));
   }
-  LOG(INFO) << bPtree_.Height() << " " << bPtree_.Size();
+  LOG(INFO) << bptree_.Height() << " " << bptree_.Size();
 
   ASSERT_TRUE(Validate());
   ASSERT_GT(mi_alloc_.used(), 10000u);
-  bPtree_.Clear();
+  bptree_.Clear();
   ASSERT_EQ(mi_alloc_.used(), 0u);
 
   for (unsigned i = 20000; i > 1; --i) {
-    bPtree_.Insert(i);
+    bptree_.Insert(i);
   }
   ASSERT_TRUE(Validate());
 
-  LOG(INFO) << bPtree_.Height() << " " << bPtree_.Size();
+  LOG(INFO) << bptree_.Height() << " " << bptree_.Size();
   ASSERT_GT(mi_alloc_.used(), 20000 * 8);
   ASSERT_LT(mi_alloc_.used(), 20000 * 10);
-  bPtree_.Clear();
+  bptree_.Clear();
   ASSERT_EQ(mi_alloc_.used(), 0u);
+}
+
+TEST_F(BPTreeSetTest, Delete) {
+  for (unsigned i = 31; i > 10; --i) {
+    bptree_.Insert(i);
+  }
+
+  for (unsigned i = 1; i < 10; ++i) {
+    ASSERT_FALSE(bptree_.Delete(i));
+  }
+
+  for (unsigned i = 11; i < 32; ++i) {
+    ASSERT_TRUE(bptree_.Delete(i));
+  }
+  ASSERT_EQ(mi_alloc_.used(), 0u);
+  ASSERT_EQ(bptree_.Size(), 0u);
+
+  constexpr size_t kNumElems = 7000;
+  for (unsigned i = 0; i < kNumElems; ++i) {
+    bptree_.Insert(i);
+  }
+
+  ASSERT_GT(bptree_.NodeCount(), 2u);
+  unsigned sz = bptree_.Size();
+  for (unsigned i = 0; i < kNumElems; ++i) {
+    ASSERT_TRUE(bptree_.Delete(i));
+    ASSERT_EQ(bptree_.Size(), --sz);
+  }
+
+  ASSERT_EQ(mi_alloc_.used(), 0u);
+  ASSERT_EQ(bptree_.Size(), 0u);
+  ASSERT_EQ(bptree_.Height(), 0u);
+  ASSERT_EQ(bptree_.NodeCount(), 0u);
 }
 
 }  // namespace dfly


### PR DESCRIPTION
Implemented  BPTree::Delete method.
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->