### PR TITLE
fix: refactor RunCbOnFirstNonEmptyBlocking

### DIFF
--- a/src/server/container_utils.cc
+++ b/src/server/container_utils.cc
@@ -237,51 +237,57 @@ OpResult<ShardFFResult> FindFirstNonEmptyKey(Transaction* trans, int req_obj_typ
   return OpResult<ShardFFResult>{std::move(shard_result)};
 }
 
-// If OK is returned then cb was called on the first non empty key and `out_key` is set to the key.
 OpResult<string> RunCbOnFirstNonEmptyBlocking(Transaction* trans, int req_obj_type,
                                               BlockingResultCb func, unsigned limit_ms) {
-  auto limit_tp = limit_ms ? std::chrono::steady_clock::now() + std::chrono::milliseconds(limit_ms)
-                           : Transaction::time_point::max();
-  bool is_multi = trans->IsMulti();
   trans->Schedule();
 
-  ShardFFResult ff_result;
+  string result_key;
   OpResult<ShardFFResult> result = FindFirstNonEmptyKey(trans, req_obj_type);
 
+  // If a non-empty key exists, execute the callback immediately
   if (result.ok()) {
-    ff_result = std::move(result.value());
-  } else if (result.status() == OpStatus::KEY_NOTFOUND) {
-    // Close transaction and return.
-    if (is_multi) {
-      trans->Conclude();
-      return OpStatus::TIMED_OUT;
-    }
-
-    auto wcb = [](Transaction* t, EngineShard* shard) {
-      return t->GetShardArgs(shard->shard_id());
+    auto cb = [&](Transaction* t, EngineShard* shard) {
+      if (shard->shard_id() == result->sid) {
+        result->key.GetString(&result_key);
+        func(t, shard, result_key);
+      }
+      return OpStatus::OK;
     };
+    trans->Execute(std::move(cb), true);
 
-    VLOG(1) << "Blocking BLPOP " << trans->DebugId();
+    return result_key;
+  }
 
-    bool wait_succeeded = trans->WaitOnWatch(limit_tp, std::move(wcb));
-    if (!wait_succeeded)
-      return OpStatus::TIMED_OUT;
-  } else {
-    // Could be the wrong-type error.
-    // cleanups, locks removal etc.
+  // Abort on possible errors: wrong type, etc
+  if (result.status() != OpStatus::KEY_NOTFOUND) {
     trans->Conclude();
-
-    DCHECK_NE(result.status(), OpStatus::KEY_NOTFOUND);
     return result.status();
   }
 
-  string result_key;
+  // Multi transactions are not allowed to block
+  if (trans->IsMulti()) {
+    trans->Conclude();
+    return OpStatus::TIMED_OUT;
+  }
+
+  VLOG(1) << "Blocking " << trans->DebugId();
+
+  // If timeout (limit_ms) is zero, block indefinitely
+  auto limit_tp = Transaction::time_point::max();
+  if (limit_ms > 0) {
+    using namespace std::chrono;
+    limit_tp = steady_clock::now() + milliseconds(limit_ms);
+  }
+
+  auto wcb = [](Transaction* t, EngineShard* shard) { return t->GetShardArgs(shard->shard_id()); };
+
+  bool wait_succeeded = trans->WaitOnWatch(limit_tp, std::move(wcb));
+  if (!wait_succeeded)
+    return OpStatus::TIMED_OUT;
+
   auto cb = [&](Transaction* t, EngineShard* shard) {
     if (auto wake_key = t->GetWakeKey(shard->shard_id()); wake_key) {
       result_key = *wake_key;
-      func(t, shard, result_key);
-    } else if (shard->shard_id() == ff_result.sid) {
-      ff_result.key.GetString(&result_key);
       func(t, shard, result_key);
     }
     return OpStatus::OK;

--- a/src/server/container_utils.h
+++ b/src/server/container_utils.h
@@ -89,7 +89,12 @@ struct ShardFFResult {
 
 OpResult<ShardFFResult> FindFirstNonEmptyKey(Transaction* trans, int req_obj_type);
 
-using BlockingResultCb = std::function<void(Transaction*, EngineShard*, std::string_view)>;
+using BlockingResultCb =
+    std::function<void(Transaction*, EngineShard*, std::string_view /* key */)>;
+
+// Block until a any key of the transaction becomes non-empty and executes the callback.
+// If multiple keys are non-empty when this function is called, the callback is executed
+// immediately with the first key listed in the tx arguments.
 OpResult<std::string> RunCbOnFirstNonEmptyBlocking(Transaction* trans, int req_obj_type,
                                                    BlockingResultCb cb, unsigned limit_ms);
 


### PR DESCRIPTION
I refactored RunCbOnFirstNonEmptyBlocking a little to be more readable and easier to understand

1. I've explicitly split the callback invocation into expiry/non expiry path (I remember Roman once asked for this). The code flow is linear now and easier to grasp
2. Added some high level comments for logic
3. Some small changes

Shouldn't include any functional changes