### PR TITLE
feat(server): Add `--lock_on_hashtags` mode.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,13 @@ jobs:
           echo Run ctest -V -L DFLY
           #GLOG_logtostderr=1 GLOG_vmodule=transaction=1,engine_shard_set=1
           GLOG_logtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 ctest -V -L DFLY
+
+          echo "Running tests with --cluster_mode=emulated"
+          FLAGS_cluster_mode=emulated ctest -V -L DFLY
+
+          echo "Running tests with both --cluster_mode=emulated & --lock_on_hashtags"
+          FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true ctest -V -L DFLY
+
           ./dragonfly_test  --gtest_repeat=10
           ./multi_test --multi_exec_mode=1 --gtest_repeat=10
           ./multi_test --multi_exec_mode=3 --gtest_repeat=10

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -175,7 +175,7 @@ class ConnectionContext : public facade::ConnectionContext {
   void UnsubscribeAll(bool to_reply);
   void PUnsubscribeAll(bool to_reply);
   void ChangeMonitor(bool start);  // either start or stop monitor on a given connection
-  void CancelBlocking(); // Cancel an ongoing blocking transaction if there is one.
+  void CancelBlocking();           // Cancel an ongoing blocking transaction if there is one.
 
   // Whether this connection is a connection from a replica to its master.
   // This flag is true only on replica side, where we need to setup a special ConnectionContext

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -226,13 +226,13 @@ class DbSlice {
     return shard_id_;
   }
 
+  static std::string_view GetLockKey(std::string_view key);
+
   bool Acquire(IntentLock::Mode m, const KeyLockArgs& lock_args);
 
   void Release(IntentLock::Mode m, const KeyLockArgs& lock_args);
 
-  void Release(IntentLock::Mode m, DbIndex db_index, std::string_view key, unsigned count) {
-    db_arr_[db_index]->Release(m, key, count);
-  }
+  void Release(IntentLock::Mode m, DbIndex db_index, std::string_view key, unsigned count);
 
   // Returns true if the key can be locked under m. Does not lock.
   bool CheckLock(IntentLock::Mode m, DbIndex dbid, std::string_view key) const;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -736,14 +736,15 @@ OpStatus CheckKeysDeclared(const ConnectionState::ScriptInfo& eval_info, const C
 
   const auto& key_index = *key_index_res;
   for (unsigned i = key_index.start; i < key_index.end; ++i) {
-    string_view key = ArgS(args, i);
+    string_view key = DbSlice::GetLockKey(ArgS(args, i));
     if (!eval_info.keys.contains(key)) {
       VLOG(1) << "Key " << key << " is not declared for command " << cid->name();
       return OpStatus::KEY_NOTFOUND;
     }
   }
 
-  if (key_index.bonus && !eval_info.keys.contains(ArgS(args, *key_index.bonus)))
+  if (key_index.bonus &&
+      !eval_info.keys.contains(DbSlice::GetLockKey(ArgS(args, *key_index.bonus))))
     return OpStatus::KEY_NOTFOUND;
 
   return OpStatus::OK;
@@ -770,7 +771,7 @@ bool Service::VerifyCommand(const CommandId* cid, CmdArgList args, ConnectionCon
   }
 
   bool is_trans_cmd = CO::IsTransKind(cid->name());
-  bool under_script = bool(dfly_cntx->conn_state.script_info);
+  bool under_script = dfly_cntx->conn_state.script_info != nullptr;
   bool allowed_by_state = true;
   switch (etl.gstate()) {
     case GlobalState::LOADING:
@@ -1356,7 +1357,7 @@ Transaction::MultiMode DetermineMultiMode(ScriptMgr::ScriptParams params) {
 }
 
 // Start multi transaction for eval. Returns true if transaction was scheduled.
-// Skips scheduling if multi mode requies declaring keys, but no keys were declared.
+// Skips scheduling if multi mode requires declaring keys, but no keys were declared.
 bool StartMultiEval(DbIndex dbid, CmdArgList keys, ScriptMgr::ScriptParams params,
                     Transaction* trans) {
   Transaction::MultiMode multi_mode = DetermineMultiMode(params);
@@ -1422,9 +1423,9 @@ void Service::EvalInternal(const EvalArgs& eval_args, Interpreter* interpreter,
   // and checking whether all invocations consist of RO commands.
   // we can do it once during script insertion into script mgr.
   auto& sinfo = cntx->conn_state.script_info;
-  sinfo.reset(new ConnectionState::ScriptInfo{});
+  sinfo = make_unique<ConnectionState::ScriptInfo>();
   for (size_t i = 0; i < eval_args.keys.size(); ++i) {
-    sinfo->keys.insert(ArgS(eval_args.keys, i));
+    sinfo->keys.insert(DbSlice::GetLockKey(ArgS(eval_args.keys, i)));
   }
   sinfo->async_cmds_heap_limit = absl::GetFlag(FLAGS_multi_eval_squash_buffer);
   DCHECK(cntx->transaction);

--- a/src/server/table.cc
+++ b/src/server/table.cc
@@ -62,15 +62,4 @@ void DbTable::Clear() {
   stats = DbTableStats{};
 }
 
-void DbTable::Release(IntentLock::Mode mode, std::string_view key, unsigned count) {
-  DVLOG(1) << "Release " << IntentLock::ModeName(mode) << " " << count << " for " << key;
-
-  auto it = trans_locks.find(key);
-  CHECK(it != trans_locks.end()) << key;
-  it->second.Release(mode, count);
-  if (it->second.IsFree()) {
-    trans_locks.erase(it);
-  }
-}
-
 }  // namespace dfly

--- a/src/server/table.h
+++ b/src/server/table.h
@@ -88,7 +88,6 @@ struct DbTable : boost::intrusive_ref_counter<DbTable, boost::thread_unsafe_coun
   ~DbTable();
 
   void Clear();
-  void Release(IntentLock::Mode mode, std::string_view key, unsigned count);
 };
 
 // We use reference counting semantics of DbTable when doing snapshotting.

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -125,6 +125,15 @@ void BaseFamilyTest::SetUpTestSuite() {
 
   absl::SetFlag(&FLAGS_dbfilename, "");
   init_zmalloc_threadlocal(mi_heap_get_backing());
+
+  // TODO: go over all env variables starting with FLAGS_ and make sure they are in the below list.
+  static constexpr const char* kEnvFlags[] = {"cluster_mode", "lock_on_hashtags"};
+  for (string_view flag : kEnvFlags) {
+    const char* value = getenv(absl::StrCat("FLAGS_", flag).data());
+    if (value != nullptr) {
+      SetTestFlag(flag, value);
+    }
+  }
 }
 
 void BaseFamilyTest::SetUp() {

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -104,7 +104,7 @@ class BaseFamilyTest : public ::testing::Test {
 
   static unsigned NumLocked();
 
-  void SetTestFlag(std::string_view flag_name, std::string_view new_value);
+  static void SetTestFlag(std::string_view flag_name, std::string_view new_value);
 
   std::unique_ptr<util::ProactorPool> pp_;
   std::unique_ptr<Service> service_;

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -170,7 +170,7 @@ void Transaction::InitMultiData(KeyIndex key_index) {
   tmp_uniques.clear();
 
   auto lock_key = [this, mode, &tmp_uniques](string_view key) {
-    if (auto [_, inserted] = tmp_uniques.insert(key); !inserted)
+    if (auto [_, inserted] = tmp_uniques.insert(DbSlice::GetLockKey(key)); !inserted)
       return;
 
     multi_->lock_counts[key][mode]++;


### PR DESCRIPTION
This new mode effectively locks hashtags (i.e. strings within {curly braces}) instead of the full keys being used.
This can allow scripts to access undeclared keys if they all use a common hashtag, like for the case of BullMQ.

To make sure this mode is tested, I added a way to specify flags via env variables, and modified `ci.yml` to run all tests using this mode as well. While at it, I also added `--cluster_mode=emulated` mode to CI.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->