### PR TITLE
feat: Remove batch locks from non-atomic squashing

### DIFF
--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -26,9 +26,9 @@ template <typename F> void IterateKeys(CmdArgList args, KeyIndex keys, F&& f) {
 
 MultiCommandSquasher::MultiCommandSquasher(absl::Span<StoredCmd> cmds, ConnectionContext* cntx,
                                            bool error_abort)
-    : cmds_{cmds}, cntx_{cntx}, base_cid_{cntx->transaction->GetCId()}, error_abort_{error_abort} {
+    : cmds_{cmds}, cntx_{cntx}, base_cid_{nullptr}, error_abort_{error_abort} {
   auto mode = cntx->transaction->GetMultiMode();
-  track_keys_ = mode == Transaction::NON_ATOMIC;
+  base_cid_ = mode == Transaction::NON_ATOMIC ? nullptr : cntx->transaction->GetCId();
 }
 
 MultiCommandSquasher::ShardExecInfo& MultiCommandSquasher::PrepareShardInfo(ShardId sid) {
@@ -36,8 +36,14 @@ MultiCommandSquasher::ShardExecInfo& MultiCommandSquasher::PrepareShardInfo(Shar
     sharded_.resize(shard_set->size());
 
   auto& sinfo = sharded_[sid];
-  if (!sinfo.local_tx)
-    sinfo.local_tx = new Transaction{cntx_->transaction};
+  if (!sinfo.local_tx) {
+    if (base_cid_) {
+      sinfo.local_tx = new Transaction{cntx_->transaction};
+    } else {
+      sinfo.local_tx = new Transaction{cntx_->transaction->GetCId(), sid};
+      sinfo.local_tx->StartMultiNonAtomic();
+    }
+  }
 
   return sinfo;
 }
@@ -70,9 +76,6 @@ MultiCommandSquasher::SquashResult MultiCommandSquasher::TrySquash(StoredCmd* cm
 
   if (found_more || last_sid == kInvalidSid)
     return SquashResult::NOT_SQUASHED;
-
-  if (track_keys_)
-    IterateKeys(args, *keys, [this](MutableSlice key) { collected_keys_.insert(key); });
 
   auto& sinfo = PrepareShardInfo(last_sid);
 
@@ -138,21 +141,24 @@ bool MultiCommandSquasher::ExecuteSquashed() {
   if (order_.empty())
     return false;
 
-  Transaction* tx = cntx_->transaction;
-
-  if (track_keys_) {
-    tmp_keylist_.assign(collected_keys_.begin(), collected_keys_.end());
-    tx->PrepareSquashedMultiHop(base_cid_, CmdArgList{tmp_keylist_});
-  } else {
-    auto cb = [this](ShardId sid) { return !sharded_[sid].cmds.empty(); };
-    tx->PrepareSquashedMultiHop(base_cid_, cb);
-  }
-
   for (auto& sd : sharded_)
     sd.replies.reserve(sd.cmds.size());
 
-  cntx_->cid = base_cid_;
-  tx->ScheduleSingleHop([this](auto* tx, auto* es) { return SquashedHopCb(tx, es); });
+  Transaction* tx = cntx_->transaction;
+
+  // Atomic transactions (that have all keys locked) perform hops and run squashed commands via
+  // stubs, non-atomic ones just run the commands in parallel.
+  if (base_cid_) {
+    cntx_->cid = base_cid_;
+    auto cb = [this](ShardId sid) { return !sharded_[sid].cmds.empty(); };
+    tx->PrepareSquashedMultiHop(base_cid_, cb);
+    tx->ScheduleSingleHop([this](auto* tx, auto* es) { return SquashedHopCb(tx, es); });
+  } else {
+    shard_set->RunBlockingInParallel([this, tx](auto* es) {
+      if (!sharded_[es->shard_id()].cmds.empty())
+        SquashedHopCb(tx, es);
+    });
+  }
 
   bool aborted = false;
 
@@ -174,7 +180,6 @@ bool MultiCommandSquasher::ExecuteSquashed() {
     sinfo.cmds.clear();
 
   order_.clear();
-  collected_keys_.clear();
   return aborted;
 }
 
@@ -202,6 +207,15 @@ void MultiCommandSquasher::Run() {
   if (!sharded_.empty())
     cntx_->transaction->ReportWritesSquashedMulti(
         [this](ShardId sid) { return sharded_[sid].had_writes; });
+
+  // UnlockMulti is a no-op for non-atomic multi transactions,
+  // still called for correctness and future changes
+  if (base_cid_ == nullptr) {
+    for (auto& sd : sharded_) {
+      if (sd.local_tx)
+        sd.local_tx->UnlockMulti();
+    }
+  }
 }
 
 }  // namespace dfly

--- a/src/server/multi_command_squasher.h
+++ b/src/server/multi_command_squasher.h
@@ -65,6 +65,8 @@ class MultiCommandSquasher {
   // Run all commands until completion.
   void Run();
 
+  bool IsAtomic() const;
+
  private:
   absl::Span<StoredCmd> cmds_;  // Input range of stored commands
   ConnectionContext* cntx_;     // Underlying context

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -332,14 +332,6 @@ OpStatus Transaction::InitByArgs(DbIndex index, CmdArgList args) {
   return OpStatus::OK;
 }
 
-void Transaction::PrepareSquashedMultiHop(const CommandId* cid, CmdArgList keys) {
-  MultiSwitchCmd(cid);
-
-  multi_->role = SQUASHER;
-  InitBase(db_index_, keys);
-  InitByKeys(KeyIndex::Range(0, keys.size()));
-}
-
 void Transaction::PrepareSquashedMultiHop(const CommandId* cid,
                                           absl::FunctionRef<bool(ShardId)> enabled) {
   CHECK(multi_->mode == GLOBAL || multi_->mode == LOCK_AHEAD);

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -195,9 +195,6 @@ class Transaction {
     renabled_auto_journal_.store(true, std::memory_order_relaxed);
   }
 
-  // Prepare a squashed hop on given keys.
-  void PrepareSquashedMultiHop(const CommandId* cid, CmdArgList keys);
-
   // Prepare a squashed hop on given shards.
   // Only compatible with multi modes that acquire all locks ahead - global and lock_ahead.
   void PrepareSquashedMultiHop(const CommandId* cid, absl::FunctionRef<bool(ShardId)> enabled);


### PR DESCRIPTION
This PR changes the locking mechanism of non atomic squashing

Squashed sequences consists of batches that are executed in parallel on multiple shards.

Previously, all keys of a batch were collected and locked ahead of executing the full batch on multiple shards (akin to running a transaction with those collected keys)

Now, no keys are collected in advance. Instead the commands are just sent to their respective shards where they're executed on separate transactions. We could create a new transaction for every run, but I just create a single non-atomic multi transaction for every shard.

This new locking mechanism will be used for parallelizing pipelines.