### PR TITLE
feat: Pipeline squashing

### DIFF
--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -224,6 +224,7 @@ class Connection : public util::Connection {
 
   std::atomic_uint64_t dispatch_q_bytes_ = 0;  // memory usage of all entries
   dfly::EventCount evc_bp_;                    // backpressure for memory limit
+  size_t dispatch_q_cmds_count_;               // how many queued async commands
 
   base::IoBuf io_buf_;  // used in io loop and parsers
   std::unique_ptr<RedisParser> redis_parser_;

--- a/src/facade/ok_main.cc
+++ b/src/facade/ok_main.cc
@@ -27,6 +27,11 @@ class OkService : public ServiceInterface {
     (*cntx)->SendOk();
   }
 
+  void DispatchManyCommands(absl::Span<CmdArgList> args_lists, ConnectionContext* cntx) final {
+    for (auto args : args_lists)
+      DispatchCommand(args, cntx);
+  }
+
   void DispatchMC(const MemcacheParser::Command& cmd, std::string_view value,
                   ConnectionContext* cntx) final {
     cntx->reply_builder()->SendError("");

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -110,9 +110,12 @@ void SinkReplyBuilder::StopAggregate() {
   if (should_batch_ || batch_.empty())
     return;
 
+  FlushBatch();
+}
+
+void SinkReplyBuilder::FlushBatch() {
   error_code ec = sink_->Write(io::Buffer(batch_));
   batch_.clear();
-
   if (ec)
     ec_ = ec;
 }

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -64,6 +64,8 @@ class SinkReplyBuilder {
     should_batch_ = batch;
   }
 
+  void FlushBatch();
+
   // Used for QUIT - > should move to conn_context?
   void CloseConnection();
 

--- a/src/facade/service_interface.h
+++ b/src/facade/service_interface.h
@@ -26,10 +26,14 @@ class ServiceInterface {
   }
 
   virtual void DispatchCommand(CmdArgList args, ConnectionContext* cntx) = 0;
+
+  virtual void DispatchManyCommands(absl::Span<CmdArgList> args_list, ConnectionContext* cntx) = 0;
+
   virtual void DispatchMC(const MemcacheParser::Command& cmd, std::string_view value,
                           ConnectionContext* cntx) = 0;
 
   virtual ConnectionContext* CreateContext(util::FiberSocketBase* peer, Connection* owner) = 0;
+
   virtual ConnectionStats* GetThreadLocalConnectionStats() = 0;
 
   virtual void ConfigureHttpHandlers(util::HttpListenerBase* base) {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1040,7 +1040,7 @@ void Service::DispatchManyCommands(absl::Span<CmdArgList> args_list,
 
     // MULTI...EXEC commands need to be collected into a single context, so squashing is not
     // possible
-    bool is_multi =
+    const bool is_multi =
         dfly_cntx->conn_state.exec_info.IsCollecting() || CO::IsTransKind(ArgS(args, 0));
 
     if (!is_multi && cid != nullptr) {

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -42,6 +42,10 @@ class Service : public facade::ServiceInterface {
   // Prepare command execution, verify and execute, reply to context
   void DispatchCommand(CmdArgList args, facade::ConnectionContext* cntx) final;
 
+  // Execute multiple consecutive commands, possibly in parallel by squashing
+  void DispatchManyCommands(absl::Span<CmdArgList> args_list,
+                            facade::ConnectionContext* cntx) final;
+
   // Check VerifyCommandExecution and invoke command with args
   bool InvokeCmd(const CommandId* cid, CmdArgList tail_args, ConnectionContext* reply_cntx,
                  bool record_stats = false);

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -165,6 +165,8 @@ class Service : public facade::ServiceInterface {
   CommandRegistry registry_;
   absl::flat_hash_map<std::string, unsigned> unknown_cmds_;
 
+  const CommandId* exec_cid_;  // command id of EXEC command for pipeline squashing
+
   mutable Mutex mu_;
   GlobalState global_state_ = GlobalState::ACTIVE;  // protected by mu_;
 };


### PR DESCRIPTION
1. Adds DispatchManyCommands to Service interface that possibly can squash command execution. It uses a non-atomic transaction underneath to execute commands on top of it
2. Makes the context detect cases when the dispatch queue is filled with just commands that can be executed with DispatchManyCommands in one go

I've also run a few benchmarks to test the new feature. Before, pipelining from a single connection had really bad performance. 


1M LPUSH commands on 1k keys, evenly distributed, threshold 100, 32 sized batches, 
executed with `redis-cli --pipe < cmds`


```
Regular (8t): 12.2s
Regular (4t): 9s
Redis: 1.1s
Squashing (4t): 1.1s
Squashing (8t): 0.9s
```

For 8 threads is more than a tenfold improvement! 