### PR TITLE
fix: remove coordinator_index_ from tx & fix short circuit

### DIFF
--- a/src/server/blocking_controller_test.cc
+++ b/src/server/blocking_controller_test.cc
@@ -45,7 +45,7 @@ void BlockingControllerTest::SetUp() {
   shard_set = new EngineShardSet(pp_.get());
   shard_set->Init(kNumThreads, false);
 
-  trans_.reset(new Transaction{&cid_, 0});
+  trans_.reset(new Transaction{&cid_});
 
   str_vec_.assign({"blpop", "x", "z", "0"});
   for (auto& s : str_vec_) {

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -224,8 +224,7 @@ void DebugCmd::Load(string_view filename) {
   };
 
   const CommandId* cid = sf_.service().FindCmd("FLUSHALL");
-  intrusive_ptr<Transaction> flush_trans(
-      new Transaction{cid, ServerState::tlocal()->thread_index()});
+  intrusive_ptr<Transaction> flush_trans(new Transaction{cid});
   flush_trans->InitByArgs(0, {});
   VLOG(1) << "Performing flush";
   error_code ec = sf_.Drakarys(flush_trans.get(), DbSlice::kDbAll);

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -937,7 +937,7 @@ void Service::DispatchCommand(CmdArgList args, facade::ConnectionContext* cntx) 
     DCHECK(dfly_cntx->transaction == nullptr);
 
     if (cid->IsTransactional()) {
-      dist_trans.reset(new Transaction{cid, etl.thread_index()});
+      dist_trans.reset(new Transaction{cid});
 
       if (!dist_trans->IsMulti()) {  // Multi command initialize themself based on their mode.
         if (auto st = dist_trans->InitByArgs(dfly_cntx->conn_state.db_index, args_no_cmd);

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -41,7 +41,7 @@ MultiCommandSquasher::ShardExecInfo& MultiCommandSquasher::PrepareShardInfo(Shar
     if (IsAtomic()) {
       sinfo.local_tx = new Transaction{cntx_->transaction};
     } else {
-      sinfo.local_tx = new Transaction{cntx_->transaction->GetCId(), sid};
+      sinfo.local_tx = new Transaction{cntx_->transaction->GetCId()};
       sinfo.local_tx->StartMultiNonAtomic();
     }
   }

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1110,8 +1110,7 @@ GenericError DoPartialSave(fs::path full_filename, const dfly::StringVec& script
 GenericError ServerFamily::DoSave() {
   const CommandId* cid = service().FindCmd("SAVE");
   CHECK_NOTNULL(cid);
-  boost::intrusive_ptr<Transaction> trans(
-      new Transaction{cid, ServerState::tlocal()->thread_index()});
+  boost::intrusive_ptr<Transaction> trans(new Transaction{cid});
   trans->InitByArgs(0, {});
   return DoSave(absl::GetFlag(FLAGS_df_snapshot_format), {}, trans.get());
 }

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -138,7 +138,7 @@ class Transaction {
   };
 
  public:
-  explicit Transaction(const CommandId* cid, uint32_t thread_index);
+  explicit Transaction(const CommandId* cid);
 
   explicit Transaction(const Transaction* parent);
 
@@ -559,7 +559,6 @@ class Transaction {
   // they read this variable the coordinator thread is stalled and can not cause data races.
   // If COORDINATOR_XXX has been set, it means we passed or crossed stage XXX.
   uint8_t coordinator_state_ = 0;
-  uint32_t coordinator_index_;  // thread_index of the coordinator thread.
 
   // Used for single-hop transactions with unique_shards_ == 1, hence no data-race.
   OpStatus local_result_ = OpStatus::OK;


### PR DESCRIPTION
1. #1601 doesn't check for inline scheduling conditions
2. We actually don't need the `coordinator_index_` variable because we access the thread local server state variable in any case for checking inline scheduling conditions

I quietly missed the moment when the inline scheduling conditions were introduced. I remember when I benchmarked basic inline scheduling with random traffic it had no performance benefits in the general case. That's why we added coordinator_index_ in the first place and that's why the thread_local became `__thread`. I wonder if its still more performant 🤔 

Anyways in the case with moving a single shard lua script it will definitely help