### PR TITLE
fix: Add selective non-atomic squash dispatch

### DIFF
--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -155,10 +155,8 @@ bool MultiCommandSquasher::ExecuteSquashed() {
     tx->PrepareSquashedMultiHop(base_cid_, cb);
     tx->ScheduleSingleHop([this](auto* tx, auto* es) { return SquashedHopCb(tx, es); });
   } else {
-    shard_set->RunBlockingInParallel([this, tx](auto* es) {
-      if (!sharded_[es->shard_id()].cmds.empty())
-        SquashedHopCb(tx, es);
-    });
+    shard_set->RunBlockingInParallel([this, tx](auto* es) { SquashedHopCb(tx, es); },
+                                     [this](auto sid) { return !sharded_[sid].cmds.empty(); });
   }
 
   bool aborted = false;


### PR DESCRIPTION
This will avoid running on all threads every time

Didn't benchmark yet how much it helps squashed pipelines in the MVP, but I'm sure it won't make them slower 

On a small number of shards an evenly distributed pipeline runs on all shards on every single batch, but exceptions are possible