### PR TITLE
feat: Fix rank for delete operations

### DIFF
--- a/src/core/detail/bptree_internal.h
+++ b/src/core/detail/bptree_internal.h
@@ -265,8 +265,6 @@ template <typename T> class BPTreeNode {
 
   void InsertItem(unsigned index, KeyT item) {
     assert(index <= num_items_);
-    assert(index == 0 || Key(index - 1) < item);
-    assert(index == num_items_ || Key(index) > item);
 
     ShiftRight(index);
     SetKey(index, item);


### PR DESCRIPTION
Also add a benchmark test that shows 2-3 times better performance for Find vs redis zslGetRank when number of items grows.
For Insert/Delete I expect the differrence be even bigger.

```
Benchmark                            Time             CPU   Iterations
----------------------------------------------------------------------
BM_FindRandomBPTree/1024         56000 ns        55996 ns        75079
BM_FindRandomBPTree/65536      9406738 ns      9406552 ns          450
BM_FindRandomBPTree/1048576  390559398 ns    390539398 ns           11
BM_FindRandomZSL/1024            87991 ns        87989 ns        49196
BM_FindRandomZSL/65536        17917190 ns     17916618 ns          196
BM_FindRandomZSL/1048576    1343231616 ns   1343130709 ns            3
```

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->