### PR TITLE
hotfix: snapshot endless loop on exit.

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -763,7 +763,9 @@ void ServerFamily::SnapshotScheduling() {
     const std::chrono::time_point now = std::chrono::system_clock::now();
     const std::chrono::time_point next = cron::cron_next(cron_expr.value(), now);
 
-    schedule_done_.WaitFor(next - now);
+    if (schedule_done_.WaitFor(next - now)) {
+      break;
+    };
 
     GenericError ec = DoSave();
     if (ec) {


### PR DESCRIPTION
Snapshot caused endless save loop on exit due to fiber not finishing. The fix is to add a `break` to the `while` loop after `schedule_done_` has notified.

Solves #1636.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->