### PR TITLE
feat: Use compressed sorted set for search

### DIFF
--- a/src/core/search/compressed_sorted_set.h
+++ b/src/core/search/compressed_sorted_set.h
@@ -47,32 +47,7 @@ class CompressedSortedSet {
     absl::Span<const uint8_t> diffs_{};
   };
 
-  // Output iterator to build compressed list from sorted range
-  struct SortedBackInserter {
-    using iterator_category = std::forward_iterator_tag;
-    using difference_type = std::ptrdiff_t;
-    using value_type = IntType;
-    using pointer = IntType*;
-    using reference = IntType&;
-
-    explicit SortedBackInserter(CompressedSortedSet* list);
-
-    SortedBackInserter& operator*() {
-      return *this;
-    }
-    SortedBackInserter& operator++() {
-      return *this;
-    }
-
-    SortedBackInserter& operator=(IntType value);
-
-   private:
-    IntType last_;
-    CompressedSortedSet* list_;
-  };
-
   friend struct Iterator;
-  friend struct SortedBackInserter;
 
  public:
   ConstIterator begin() const;
@@ -106,7 +81,8 @@ class CompressedSortedSet {
   static std::pair<IntType /*value*/, size_t /*read*/> ReadVarLen(absl::Span<const uint8_t> source);
 
  private:
-  IntType size_{0};
+  uint32_t size_{0};
+  std::optional<IntType> tail_value_{};
   std::vector<uint8_t> diffs_{};
 };
 

--- a/src/core/search/compressed_sorted_set_test.cc
+++ b/src/core/search/compressed_sorted_set_test.cc
@@ -13,6 +13,35 @@ namespace dfly::search {
 
 using namespace std;
 
+namespace {
+
+struct SetInserter {
+  using iterator_category = std::forward_iterator_tag;
+  using difference_type = std::ptrdiff_t;
+  using value_type = CompressedSortedSet::IntType;
+  using pointer = value_type*;
+  using reference = value_type&;
+
+  explicit SetInserter(CompressedSortedSet* set) : set_{set} {};
+
+  SetInserter& operator*() {
+    return *this;
+  }
+  SetInserter& operator++() {
+    return *this;
+  }
+
+  SetInserter& operator=(value_type value) {
+    set_->Insert(value);
+    return *this;
+  }
+
+ private:
+  CompressedSortedSet* set_;
+};
+
+}  // namespace
+
 class CompressedSortedSetTest : public ::testing::Test {
  protected:
 };
@@ -113,7 +142,7 @@ TEST_F(CompressedSortedSetTest, SortedBackInserter) {
   vector<uint32_t> v1 = {1, 3, 5};
   vector<uint32_t> v2 = {2, 4, 6};
 
-  merge(v1.begin(), v1.end(), v2.begin(), v2.end(), CompressedSortedSet::SortedBackInserter{&list});
+  merge(v1.begin(), v1.end(), v2.begin(), v2.end(), SetInserter{&list});
 
   EXPECT_EQ(IdVec(list.begin(), list.end()), IdVec({1, 2, 3, 4, 5, 6}));
 }
@@ -122,7 +151,7 @@ TEST_F(CompressedSortedSetTest, BasicRemove) {
   CompressedSortedSet list;
 
   IdVec values = {1, 3, 4, 7, 8, 11, 15, 17, 20, 22, 27};
-  copy(values.begin(), values.end(), CompressedSortedSet::SortedBackInserter(&list));
+  copy(values.begin(), values.end(), SetInserter{&list});
   EXPECT_EQ(IdVec(list.begin(), list.end()), values);
 
   auto remove = [&list, &values](uint32_t value) {
@@ -153,7 +182,7 @@ TEST_F(CompressedSortedSetTest, BasicRemoveLargeValues) {
   CompressedSortedSet list;
 
   IdVec values = {1, 12, 123, 123'4, 123'45, 123'456, 1'234'567, 12'345'678};
-  copy(values.begin(), values.end(), CompressedSortedSet::SortedBackInserter(&list));
+  copy(values.begin(), values.end(), SetInserter{&list});
   EXPECT_EQ(IdVec(list.begin(), list.end()), values);
 
   auto remove = [&list, &values](uint32_t value) {

--- a/src/core/search/indices.h
+++ b/src/core/search/indices.h
@@ -4,12 +4,14 @@
 
 #include <absl/container/btree_set.h>
 #include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
 
 #include <map>
 #include <optional>
 #include <vector>
 
 #include "core/search/base.h"
+#include "core/search/compressed_sorted_set.h"
 
 namespace dfly::search {
 
@@ -27,25 +29,29 @@ struct NumericIndex : public BaseIndex {
 
 // Base index for string based indices.
 struct BaseStringIndex : public BaseIndex {
+  void Add(DocId id, DocumentAccessor* doc, std::string_view field) override;
+  void Remove(DocId id, DocumentAccessor* doc, std::string_view field) override;
+
+  // Used by Add & Remove to tokenize text value
+  virtual absl::flat_hash_set<std::string> Tokenize(std::string_view value) const = 0;
+
   // Pointer is valid as long as index is not mutated. Nullptr if not found
-  const std::vector<DocId>* Matching(std::string_view str) const;
+  const CompressedSortedSet* Matching(std::string_view str) const;
 
  protected:
-  absl::flat_hash_map<std::string, std::vector<DocId>> entries_;
+  absl::flat_hash_map<std::string, CompressedSortedSet> entries_;
 };
 
 // Index for text fields.
 // Hashmap based lookup per word.
 struct TextIndex : public BaseStringIndex {
-  void Add(DocId id, DocumentAccessor* doc, std::string_view field) override;
-  void Remove(DocId id, DocumentAccessor* doc, std::string_view field) override;
+  absl::flat_hash_set<std::string> Tokenize(std::string_view value) const override;
 };
 
 // Index for text fields.
 // Hashmap based lookup per word.
 struct TagIndex : public BaseStringIndex {
-  void Add(DocId id, DocumentAccessor* doc, std::string_view field) override;
-  void Remove(DocId id, DocumentAccessor* doc, std::string_view field) override;
+  absl::flat_hash_set<std::string> Tokenize(std::string_view value) const override;
 };
 
 // Index for vector fields.

--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -10,6 +10,7 @@
 
 #include "base/logging.h"
 #include "core/search/ast_expr.h"
+#include "core/search/compressed_sorted_set.h"
 #include "core/search/indices.h"
 #include "core/search/query_driver.h"
 #include "core/search/vector.h"
@@ -35,21 +36,18 @@ struct IndexResult {
 
   IndexResult() : value_{DocVec{}} {};
 
-  IndexResult(const DocVec* dv) : value_{dv} {
-    if (dv == nullptr)
+  IndexResult(const CompressedSortedSet* css) : value_{css} {
+    if (css == nullptr)
       value_ = DocVec{};
   }
 
   IndexResult(DocVec&& dv) : value_{move(dv)} {
   }
 
-  // Transparent const access to underlying value
-  const DocVec* operator->() const {
-    return holds_alternative<DocVec>(value_) ? &get<DocVec>(value_) : get<const DocVec*>(value_);
-  }
-
-  const DocVec& operator*() const {
-    return holds_alternative<DocVec>(value_) ? get<DocVec>(value_) : *get<const DocVec*>(value_);
+  size_t Size() const {
+    if (holds_alternative<DocVec>(value_))
+      return get<DocVec>(value_).size();
+    return get<const CompressedSortedSet*>(value_)->Size();
   }
 
   IndexResult& operator=(DocVec&& entries) {
@@ -62,15 +60,23 @@ struct IndexResult {
     return *this;
   }
 
+  variant<const DocVec*, const CompressedSortedSet*> Borrowed() {
+    if (holds_alternative<DocVec>(value_))
+      return &get<DocVec>(value_);
+    return get<const CompressedSortedSet*>(value_);
+  }
+
   // Move out of owned or copy borrowed
   DocVec Take() {
     if (holds_alternative<DocVec>(value_))
       return move(get<DocVec>(value_));
-    return *get<const DocVec*>(value_);
+
+    const CompressedSortedSet* css = get<const CompressedSortedSet*>(value_);
+    return DocVec(css->begin(), css->end());
   }
 
  private:
-  variant<DocVec /*owned*/, const DocVec* /*pointer to borrowed*/> value_;
+  variant<DocVec /*owned*/, const CompressedSortedSet* /* borrowed */> value_;
 };
 
 struct BasicSearch {
@@ -103,13 +109,17 @@ struct BasicSearch {
     tmp_vec_.clear();
 
     if (op == LogicOp::AND) {
-      tmp_vec_.reserve(min(matched->size(), current->size()));
-      set_intersection(matched->begin(), matched->end(), current->begin(), current->end(),
-                       back_inserter(tmp_vec_));
+      tmp_vec_.reserve(min(matched.Size(), current.Size()));
+      auto cb = [this](auto* s1, auto* s2) {
+        set_intersection(s1->begin(), s1->end(), s2->begin(), s2->end(), back_inserter(tmp_vec_));
+      };
+      visit(cb, matched.Borrowed(), current.Borrowed());
     } else {
-      tmp_vec_.reserve(matched->size() + current->size());
-      set_union(matched->begin(), matched->end(), current->begin(), current->end(),
-                back_inserter(tmp_vec_));
+      tmp_vec_.reserve(matched.Size() + current.Size());
+      auto cb = [this](auto* s1, auto* s2) {
+        set_union(s1->begin(), s1->end(), s2->begin(), s2->end(), back_inserter(tmp_vec_));
+      };
+      visit(cb, matched.Borrowed(), current.Borrowed());
     }
 
     current = move(tmp_vec_);
@@ -124,7 +134,7 @@ struct BasicSearch {
     // AND: the result only shrinks, so starting with the smallest is most optimal.
     // OR: unifying smaller sets first reduces the number of element traversals on average.
     sort(sub_results.begin(), sub_results.end(),
-         [](const auto& l, const auto& r) { return l->size() < r->size(); });
+         [](const auto& l, const auto& r) { return l.Size() < r.Size(); });
 
     IndexResult out{move(sub_results[0])};
     for (auto& matched : absl::MakeSpan(sub_results).subspan(1))
@@ -138,7 +148,7 @@ struct BasicSearch {
 
   IndexResult Search(const AstStarNode& node, string_view active_field) {
     DCHECK(active_field.empty());
-    return &indices_->GetAllDocs();
+    return vector<DocId>{indices_->GetAllDocs()};  // TODO FIX;
   }
 
   // "term": access field's text index or unify results from all text indices if no field is set
@@ -201,11 +211,14 @@ struct BasicSearch {
 
     auto* vec_index = GetIndex<VectorIndex>(knn.field);
 
-    distances_.reserve(sub_results->size());
-    for (DocId matched_doc : *sub_results) {
-      float dist = VectorDistance(knn.vector, vec_index->Get(matched_doc));
-      distances_.emplace_back(dist, matched_doc);
-    }
+    distances_.reserve(sub_results.Size());
+    auto cb = [&](auto* set) {
+      for (DocId matched_doc : *set) {
+        float dist = VectorDistance(knn.vector, vec_index->Get(matched_doc));
+        distances_.emplace_back(dist, matched_doc);
+      }
+    };
+    visit(cb, sub_results.Borrowed());
 
     sort(distances_.begin(), distances_.end());
 
@@ -223,7 +236,8 @@ struct BasicSearch {
 
     // Top level results don't need to be sorted, because they will be scored, sorted by fields or
     // used by knn
-    DCHECK(top_level || is_sorted(result->begin(), result->end()));
+    DCHECK(top_level ||
+           visit([](auto* set) { return is_sorted(set->begin(), set->end()); }, result.Borrowed()));
 
     return result;
   }
@@ -232,7 +246,7 @@ struct BasicSearch {
     IndexResult result = SearchGeneric(query, "", true);
 
     if (!distances_.empty()) {
-      vector<float> out_distances(result->size());
+      vector<float> out_distances(result.Size());
       for (size_t i = 0; i < out_distances.size(); i++)
         out_distances[i] = distances_[i].first;
 


### PR DESCRIPTION
1. Use the newly created compressed sorted set type
2. Add back insertion optimization to compressed sorted set instead of separate back inserter