### PR TITLE
feat: Refactor command verification before execution

### DIFF
--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -60,18 +60,18 @@ void CommandId::Invoke(CmdArgList args, ConnectionContext* cntx) const {
   ent.second += (after - before) / 1000;
 }
 
-optional<facade::ErrorReply> CommandId::Validate(CmdArgList args) const {
-  if ((arity() > 0 && args.size() != size_t(arity())) ||
-      (arity() < 0 && args.size() < size_t(-arity()))) {
+optional<facade::ErrorReply> CommandId::Validate(CmdArgList tail_args) const {
+  if ((arity() > 0 && tail_args.size() + 1 != size_t(arity())) ||
+      (arity() < 0 && tail_args.size() + 1 < size_t(-arity()))) {
     return facade::ErrorReply{facade::WrongNumArgsError(name()), kSyntaxErrType};
   }
 
-  if (key_arg_step() == 2 && (args.size() % 2) == 0) {
+  if (key_arg_step() == 2 && (tail_args.size() % 2) != 0) {
     return facade::ErrorReply{facade::WrongNumArgsError(name()), kSyntaxErrType};
   }
 
   if (validator_)
-    return validator_(args.subspan(1));
+    return validator_(tail_args);
   return nullopt;
 }
 

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -72,7 +72,7 @@ class CommandId : public facade::CommandId {
   void Invoke(CmdArgList args, ConnectionContext* cntx) const;
 
   // Returns error if validation failed, otherwise nullopt
-  std::optional<facade::ErrorReply> Validate(CmdArgList args) const;
+  std::optional<facade::ErrorReply> Validate(CmdArgList tail_args) const;
 
   bool IsTransactional() const;
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -757,7 +757,7 @@ optional<ErrorReply> Service::VerifyCommandExecution(const CommandId* cid) {
 
 std::optional<ErrorReply> Service::VerifyCommandState(const CommandId* cid, CmdArgList tail_args,
                                                       const ConnectionContext& dfly_cntx) {
-  DCHECK_NOTNULL(cid);
+  DCHECK(cid);
 
   ServerState& etl = *ServerState::tlocal();
 
@@ -945,7 +945,7 @@ void Service::DispatchCommand(CmdArgList args, facade::ConnectionContext* cntx) 
 
 bool Service::InvokeCmd(const CommandId* cid, CmdArgList tail_args, ConnectionContext* cntx,
                         bool record_stats) {
-  DCHECK_NOTNULL(cid);
+  DCHECK(cid);
   DCHECK(!cid->Validate(tail_args));
 
   if (auto err = VerifyCommandExecution(cid); err) {

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -39,10 +39,22 @@ class Service : public facade::ServiceInterface {
 
   void Shutdown();
 
+  // Prepare command execution, verify and execute, reply to context
   void DispatchCommand(CmdArgList args, facade::ConnectionContext* cntx) final;
 
-  // Returns true if command was executed successfully.
-  bool InvokeCmd(CmdArgList args, const CommandId* cid, ConnectionContext* cntx, bool record_stats);
+  // Check VerifyCommandExecution and invoke command with args
+  bool InvokeCmd(const CommandId* cid, CmdArgList tail_args, ConnectionContext* reply_cntx,
+                 bool record_stats = false);
+
+  // Verify command can be executed now (check out of memory), always called immediately before
+  // execution
+  std::optional<facade::ErrorReply> VerifyCommandExecution(const CommandId* cid);
+
+  // Verify command prepares excution in correct state/
+  // Its usually called before command execution. Only for multi/exec transactions it's checked
+  // when the command is queued for execution, not before the execution itself.
+  std::optional<facade::ErrorReply> VerifyCommandState(const CommandId* cid, CmdArgList tail_args,
+                                                       const ConnectionContext& cntx);
 
   void DispatchMC(const MemcacheParser::Command& cmd, std::string_view value,
                   facade::ConnectionContext* cntx) final;
@@ -51,6 +63,24 @@ class Service : public facade::ServiceInterface {
                                            facade::Connection* owner) final;
 
   facade::ConnectionStats* GetThreadLocalConnectionStats() final;
+
+  const CommandId* FindCmd(std::string_view cmd) const {
+    return registry_.Find(cmd);
+  }
+
+  facade::ErrorReply ReportUnknownCmd(std::string_view cmd_name);
+
+  // Returns: the new state.
+  // if from equals the old state then the switch is performed "to" is returned.
+  // Otherwise, does not switch and returns the current state in the system.
+  // Upon switch, updates cached global state in threadlocal ServerState struct.
+  GlobalState SwitchState(GlobalState from, GlobalState to);
+
+  GlobalState GetGlobalState() const;
+
+  void ConfigureHttpHandlers(util::HttpListenerBase* base) final;
+  void OnClose(facade::ConnectionContext* cntx) final;
+  std::string GetContextInfo(facade::ConnectionContext* cntx) final;
 
   uint32_t shard_count() const {
     return shard_set->size();
@@ -66,10 +96,6 @@ class Service : public facade::ServiceInterface {
 
   absl::flat_hash_map<std::string, unsigned> UknownCmdMap() const;
 
-  const CommandId* FindCmd(std::string_view cmd) const {
-    return registry_.Find(cmd);
-  }
-
   ScriptMgr* script_mgr() {
     return server_family_.script_mgr();
   }
@@ -77,18 +103,6 @@ class Service : public facade::ServiceInterface {
   ServerFamily& server_family() {
     return server_family_;
   }
-
-  // Returns: the new state.
-  // if from equals the old state then the switch is performed "to" is returned.
-  // Otherwise, does not switch and returns the current state in the system.
-  // Upon switch, updates cached global state in threadlocal ServerState struct.
-  GlobalState SwitchState(GlobalState from, GlobalState to);
-
-  GlobalState GetGlobalState() const;
-
-  void ConfigureHttpHandlers(util::HttpListenerBase* base) final;
-  void OnClose(facade::ConnectionContext* cntx) final;
-  std::string GetContextInfo(facade::ConnectionContext* cntx) final;
 
  private:
   static void Quit(CmdArgList args, ConnectionContext* cntx);
@@ -118,13 +132,6 @@ class Service : public facade::ServiceInterface {
     std::string_view sha;  // only one of them is defined.
     CmdArgList keys, args;
   };
-
-  // Verify command exists and has no obvious formatting errors
-  std::optional<facade::ErrorReply> VerifyCommandArguments(const CommandId* cid, CmdArgList args);
-
-  // Verify command can be executed
-  std::optional<facade::ErrorReply> VerifyCommand(const CommandId* cid, CmdArgList args,
-                                                  const ConnectionContext& cntx);
 
   // Return error if not all keys are owned by the server when running in cluster mode
   std::optional<facade::ErrorReply> CheckKeysOwnership(const CommandId* cid, CmdArgList args,

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -50,8 +50,8 @@ class Service : public facade::ServiceInterface {
   // execution
   std::optional<facade::ErrorReply> VerifyCommandExecution(const CommandId* cid);
 
-  // Verify command prepares excution in correct state/
-  // Its usually called before command execution. Only for multi/exec transactions it's checked
+  // Verify command prepares excution in correct state.
+  // It's usually called before command execution. Only for multi/exec transactions it's checked
   // when the command is queued for execution, not before the execution itself.
   std::optional<facade::ErrorReply> VerifyCommandState(const CommandId* cid, CmdArgList tail_args,
                                                        const ConnectionContext& cntx);

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -51,7 +51,7 @@ MultiCommandSquasher::ShardExecInfo& MultiCommandSquasher::PrepareShardInfo(Shar
 }
 
 MultiCommandSquasher::SquashResult MultiCommandSquasher::TrySquash(StoredCmd* cmd) {
-  DCHECK_NOTNULL(cmd->Cid());
+  DCHECK(cmd->Cid());
 
   if (!cmd->Cid()->IsTransactional() || (cmd->Cid()->opt_mask() & CO::BLOCKING) ||
       (cmd->Cid()->opt_mask() & CO::GLOBAL_TRANS))

--- a/src/server/multi_command_squasher.h
+++ b/src/server/multi_command_squasher.h
@@ -55,13 +55,13 @@ class MultiCommandSquasher {
   // Retrun squash flags
   SquashResult TrySquash(StoredCmd* cmd);
 
-  // Execute separate non-squashed cmd. Return true if aborting on error.
+  // Execute separate non-squashed cmd. Return false if aborting on error.
   bool ExecuteStandalone(StoredCmd* cmd);
 
   // Callback that runs on shards during squashed hop.
   facade::OpStatus SquashedHopCb(Transaction* parent_tx, EngineShard* es);
 
-  // Execute all currently squashed commands. Return true if aborting on error.
+  // Execute all currently squashed commands. Return false if aborting on error.
   bool ExecuteSquashed();
 
   // Run all commands until completion.

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -866,7 +866,9 @@ TEST_F(MultiEvalTest, ScriptSquashingUknownCmd) {
   absl::FlagSaver fs;
   absl::SetFlag(&FLAGS_lua_auto_async, true);
 
-  // The script should abort only at the second error, no further commands should be executed
+  // The script below contains two commands for which execution can't even be prepared
+  // (FIRST/SECOND WRONG). The first is issued with pcall, so its error should be completely
+  // ignored, the second one should cause an abort and no further commands should be executed
   string_view s = R"(
     redis.pcall('INCR', 'A')
     redis.pcall('FIRST WRONG')


### PR DESCRIPTION
This PR:

1. Cleans up command verification a little bit and adds more comments about the differences
2. Makes more check functions accept only `tail arguments` - argument lists without the command name upfront, makes it easier to call them with stored commands
3. Enables verification for squashing. This makes it possible to verify commands while squashing instead of doing it ahead. This will allow a parallelized pipeline to be executed without verifying each command separately and breaking squashing chains