### PR TITLE
chore: Iterate over bptree_set.

### DIFF
--- a/src/core/bptree_set_test.cc
+++ b/src/core/bptree_set_test.cc
@@ -36,6 +36,7 @@ class BPTreeSetTest : public ::testing::Test {
 
   MiMemoryResource mi_alloc_;
   BPTree<uint64_t> bptree_;
+  mt19937 generator_{1};
 };
 
 bool BPTreeSetTest::Validate(const Node* node, uint64_t ubound) {
@@ -93,8 +94,6 @@ bool BPTreeSetTest::Validate() {
 }
 
 TEST_F(BPTreeSetTest, BPtreeInsert) {
-  mt19937 generator(1);
-
   for (unsigned i = 1; i < 7000; ++i) {
     ASSERT_TRUE(bptree_.Insert(i));
     ASSERT_EQ(i, bptree_.Size());
@@ -115,7 +114,7 @@ TEST_F(BPTreeSetTest, BPtreeInsert) {
 
   uniform_int_distribution<uint64_t> dist(0, 100000);
   for (unsigned i = 0; i < 20000; ++i) {
-    bptree_.Insert(dist(generator));
+    bptree_.Insert(dist(generator_));
     // ASSERT_TRUE(Validate()) << i;
   }
   ASSERT_TRUE(Validate());
@@ -175,6 +174,50 @@ TEST_F(BPTreeSetTest, Delete) {
   ASSERT_EQ(bptree_.Size(), 0u);
   ASSERT_EQ(bptree_.Height(), 0u);
   ASSERT_EQ(bptree_.NodeCount(), 0u);
+}
+
+TEST_F(BPTreeSetTest, Iterate) {
+  constexpr size_t kNumElems = 7000;
+  for (unsigned i = 0; i < kNumElems; ++i) {
+    bptree_.Insert(i * 2);
+  }
+
+  unsigned cnt = 0;
+  bptree_.Iterate(31, 543, [&](uint64_t val) {
+    ASSERT_EQ((31 + cnt) * 2, val);
+    ++cnt;
+  });
+  ASSERT_EQ(543 - 31 + 1, cnt);
+
+  for (unsigned j = 0; j < 10; ++j) {
+    cnt = 0;
+    unsigned from = generator_() % kNumElems;
+    unsigned to = from + generator_() % (kNumElems - from);
+    bptree_.Iterate(from, to, [&](uint64_t val) {
+      ASSERT_EQ((from + cnt) * 2, val) << from << " " << to << " " << cnt;
+      ++cnt;
+    });
+    ASSERT_EQ(to - from + 1, cnt);
+  }
+
+  // Reverse iteration
+  cnt = 0;
+  bptree_.IterateReverse(5845, 6849, [&](uint64_t val) {
+    ASSERT_EQ((6849 - cnt) * 2, val);
+    ++cnt;
+  });
+  ASSERT_EQ(6849 - 5845 + 1, cnt);
+
+  for (unsigned j = 0; j < 10; ++j) {
+    cnt = 0;
+    unsigned from = generator_() % kNumElems;
+    unsigned to = from + generator_() % (kNumElems - from);
+    bptree_.IterateReverse(from, to, [&](uint64_t val) {
+      ASSERT_EQ((to - cnt) * 2, val) << from << " " << to << " " << cnt;
+      ++cnt;
+    });
+    ASSERT_EQ(to - from + 1, cnt);
+  }
 }
 
 struct ZsetPolicy {

--- a/src/core/detail/bptree_internal.h
+++ b/src/core/detail/bptree_internal.h
@@ -689,17 +689,24 @@ template <typename T> void BPTreePath<T>::Next() {
   assert(depth_ > 0);
   BPTreeNode<T>* node = Last().first;
 
+  // The data in BPTree is stored in both the leaf nodes and the inner nodes.
   if (node->IsLeaf()) {
-    if (++record_[depth_ - 1].pos < node->NumItems()) {
+    ++record_[depth_ - 1].pos;
+    if (record_[depth_ - 1].pos < node->NumItems()) {
       return;
     }
 
+    // Advance to the next item, which is Key(i) in some ascendent of the subtree with
+    // root Child(i). i in that case must be less than NumItems().
+    // Note, that subtree Child(i) in a inner node is located before Key(i).
     do {
       Pop();
     } while (depth_ > 0 && Position(depth_ - 1) == Node(depth_ - 1)->NumItems());
-    return;  // we either point now on separator in the parent node or we finished the tree.
+    return;  // we either point now on separator Key(i) in the parent node or we finished the tree.
   }
 
+  // We are in the inner node after the ascent from the leaf node. We need to advance to the next
+  // Child and dig left.
   assert(!node->IsLeaf());
   assert(record_[depth_ - 1].pos < node->NumItems());
 


### PR DESCRIPTION
Add iterate by rank functions.

For that we introduce BPTreePath::Next() and BPTreePath::Prev() functions that allow iterating over immutable tree.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->