### PR TITLE
feat: Add LowerBound and DeleteRangeByRank

### DIFF
--- a/src/core/bptree_set.h
+++ b/src/core/bptree_set.h
@@ -90,12 +90,20 @@ template <typename T, typename Policy = BPTreePolicy<T>> class BPTree {
   /// @brief  Deletes all items in the range [start, end] by rank.
   /// @param start
   /// @param end - inclusive. must be >= start.
+  /// @param cb - callback to be called for each deleted item.
   /// @return number of deleted items.
-  size_t DeleteRangeByRank(uint32_t start, uint32_t end);
+  size_t DeleteRangeByRank(uint32_t start, uint32_t end, std::function<void(KeyT)> cb);
+
+  /// @brief Returns the path to the first item in the tree that is greater or equal to key.
+  /// @param item
+  /// @return the path if such item exists, empty path otherwise.
+  /// @todo: to wrap the result into iterator to avoid the leakage of internal data structures.
+  detail::BPTreePath<T> LowerBound(KeyT key) const;
 
  private:
   BPTreeNode* CreateNode(bool leaf);
 
+  void Delete(BPTreePath path);
   void DestroyNode(BPTreeNode* node);
 
   void InsertToFullLeaf(KeyT item, const BPTreePath& path);
@@ -108,7 +116,8 @@ template <typename T, typename Policy = BPTreePolicy<T>> class BPTree {
 
   // Charts the path towards key. Returns true if key is found.
   // In that case path->Last().first->Key(path->Last().second) == key.
-  // Fills the tree path not including the key itself.
+  // Fills the tree path not including the key itself. In case key was not found,
+  // returns the path to the item that is greater than key.
   bool Locate(KeyT key, BPTreePath* path) const;
 
   // Sets the tree path to item at specified rank. Rank is 0-based and must be less than Size().
@@ -205,70 +214,7 @@ template <typename T, typename Policy> bool BPTree<T, Policy>::Delete(KeyT item)
   if (!found)
     return false;
 
-  BPTreeNode* node = path.Last().first;
-  unsigned key_pos = path.Last().second;
-
-  // Remove the key from the node.
-  if (node->IsLeaf()) {
-    node->ShiftLeft(key_pos);  // shift left everything after key_pos.
-  } else {
-    // We can not remove the item from the inner node because it also serves as a separator.
-    // Therefore, we swap it the rightmost key in the left subtree and pop from there instead.
-    path.DigRight();
-
-    BPTreeNode* leaf = path.Last().first;
-    // set a new separator.
-    node->SetKey(key_pos, leaf->Key(leaf->NumItems() - 1));
-    leaf->LeafEraseRight();  // pop the rightmost key from the leaf.
-    node = leaf;
-  }
-  count_--;
-
-  assert(node->IsLeaf());
-
-  // go up the tree and rebalance if number of items in the node is less
-  // than low limit. We either merge or rebalance nodes.
-  while (node->NumItems() < node->MinItems()) {
-    if (node == root_) {
-      if (node->NumItems() == 0) {
-        // terminal case, we reached the root - and it has either a single child (0 delimiters)
-        // or no children at all (leaf). The former is more common case: the tree can only shrink
-        // through the root.
-        if (node->IsLeaf()) {
-          assert(count_ == 0u);
-          root_ = nullptr;
-        } else {
-          root_ = root_->Child(0);
-        }
-        --height_;
-        DestroyNode(node);
-      }
-      return true;
-    }
-
-    // The node has a parent. Pop the node from the path and try rebalance it via its parent.
-    assert(path.Depth() > 0u);
-    path.Pop();
-
-    BPTreeNode* parent = path.Last().first;
-    unsigned pos = path.Last().second;
-    assert(parent->Child(pos) == node);
-    node = parent->MergeOrRebalanceChild(pos);
-
-    parent->IncreaseTreeCount(-1);
-
-    if (node == nullptr)  // succeeded to merge/rebalance without the need to propagate.
-      break;
-
-    DestroyNode(node);
-
-    // assert(parent->TreeCount() == parent->DEBUG_TreeCount());
-    node = parent;
-  }
-
-  if (path.Depth() >= 2) {
-    IncreaseSubtreeCounts(path, path.Depth() - 2, -1);
-  }
+  Delete(path);
   return true;
 }
 
@@ -516,12 +462,116 @@ void BPTree<T, Policy>::ToRank(uint32_t rank, BPTreePath* path) const {
 }
 
 template <typename T, typename Policy>
+size_t BPTree<T, Policy>::DeleteRangeByRank(uint32_t start, uint32_t end,
+                                            std::function<void(KeyT)> cb) {
+  assert(start <= end && end < count_);
+
+  BPTreePath path;
+  size_t deleted = 0;
+  for (uint32_t i = start; i <= end; ++i) {
+    /* Ideally, we would want to advance path to the next item and delete the previous one.
+     * However, we can not do that because the path is invalidated after the
+     * deletion. So we have to recreate the path for each item using the same rank.
+     * Note, it is probably could be improved, but it's much more complicated.
+     */
+
+    ToRank(start, &path);
+    cb(path.Terminal());
+    Delete(path);
+    path.Clear();
+    ++deleted;
+  }
+  return deleted;
+}
+
+template <typename T, typename Policy>
+detail::BPTreePath<T> BPTree<T, Policy>::LowerBound(KeyT item) const {
+  BPTreePath path;
+  Locate(item, &path);
+  if (path.Last().second >= path.Last().first->NumItems())
+    path.Clear();
+
+  return path;
+}
+
+template <typename T, typename Policy>
 detail::BPTreeNode<T>* BPTree<T, Policy>::CreateNode(bool leaf) {
   num_nodes_++;
   void* ptr = mr_->allocate(detail::kBPNodeSize, 8);
   BPTreeNode* node = new (ptr) BPTreeNode(leaf);
 
   return node;
+}
+
+template <typename T, typename Policy> void BPTree<T, Policy>::Delete(BPTreePath path) {
+  using Comp [[maybe_unused]] = typename Policy::KeyCompareTo;
+
+  BPTreeNode* node = path.Last().first;
+  unsigned key_pos = path.Last().second;
+
+  // Remove the key from the node.
+  if (node->IsLeaf()) {
+    node->ShiftLeft(key_pos);  // shift left everything after key_pos.
+  } else {
+    // We can not remove the item from the inner node because it also serves as a separator.
+    // Therefore, we swap it the rightmost key in the left subtree and pop from there instead.
+    path.DigRight();
+
+    BPTreeNode* leaf = path.Last().first;
+    assert(Comp()(leaf->Key(leaf->NumItems() - 1), node->Key(key_pos)) == -1);
+
+    // set a new separator.
+    node->SetKey(key_pos, leaf->Key(leaf->NumItems() - 1));
+    leaf->LeafEraseRight();  // pop the rightmost key from the leaf.
+    node = leaf;
+  }
+  count_--;
+
+  assert(node->IsLeaf());
+
+  // go up the tree and rebalance if number of items in the node is less
+  // than low limit. We either merge or rebalance nodes.
+  while (node->NumItems() < node->MinItems()) {
+    if (node == root_) {
+      if (node->NumItems() == 0) {
+        // terminal case, we reached the root - and it has either a single child (0 delimiters)
+        // or no children at all (leaf). The former is more common case: the tree can only shrink
+        // through the root.
+        if (node->IsLeaf()) {
+          assert(count_ == 0u);
+          root_ = nullptr;
+        } else {
+          root_ = root_->Child(0);
+        }
+        --height_;
+        DestroyNode(node);
+      }
+      return;
+    }
+
+    // The node has a parent. Pop the node from the path and try rebalance it via its parent.
+    assert(path.Depth() > 0u);
+    path.Pop();
+
+    BPTreeNode* parent = path.Last().first;
+    unsigned pos = path.Last().second;
+    assert(parent->Child(pos) == node);
+    node = parent->MergeOrRebalanceChild(pos);
+
+    parent->IncreaseTreeCount(-1);
+
+    if (node == nullptr)  // succeeded to merge/rebalance without the need to propagate.
+      break;
+
+    DestroyNode(node);
+
+    // assert(parent->TreeCount() == parent->DEBUG_TreeCount());
+    node = parent;
+  }
+
+  if (path.Depth() >= 2) {
+    IncreaseSubtreeCounts(path, path.Depth() - 2, -1);
+  }
 }
 
 template <typename T, typename Policy> void BPTree<T, Policy>::DestroyNode(BPTreeNode* node) {

--- a/src/core/detail/bptree_internal.h
+++ b/src/core/detail/bptree_internal.h
@@ -301,6 +301,10 @@ template <typename T> class BPTreePath {
     return depth_;
   }
 
+  void Clear() {
+    depth_ = 0;
+  }
+
   std::pair<BPTreeNode<T>*, unsigned> Last() const {
     assert(depth_ > 0u);
     return {record_[depth_ - 1].node, record_[depth_ - 1].pos};
@@ -321,24 +325,15 @@ template <typename T> class BPTreePath {
     depth_--;
   }
 
-  // Extend the path to the leaf by always taking the leftmost child.
-  void DigRight() {
-    assert(depth_ > 0u && !Last().first->IsLeaf());
-    BPTreeNode<T>* last = Last().first;
-    do {
-      unsigned pos = last->NumItems();
-      BPTreeNode<T>* child = last->Child(last->NumItems());
-      Push(child, pos);
-      last = child;
-    } while (!last->IsLeaf());
-  }
-
   T Terminal() const {
     return Last().first->Key(Last().second);
   }
 
   void Next();
   void Prev();
+
+  // Extend the path to the leaf by always taking the rightmost child.
+  void DigRight();
 
  private:
   struct Record {
@@ -745,6 +740,15 @@ template <typename T> void BPTreePath<T>::Prev() {
     --record_[depth_ - 1].pos;
     return;
   }
+
+  DigRight();
+}
+
+template <typename T> void BPTreePath<T>::DigRight() {
+  assert(depth_ > 0);
+  BPTreeNode<T>* node = Last().first;
+
+  assert(!node->IsLeaf());
 
   // we are in the inner node pointing to the separator.
   // we now must explore the left subtree which is located under the same index as the separator.


### PR DESCRIPTION
Follows #1654 .

Also, fix Deletion bug inside DigRight function.
DeleteRangeByRank is implemented naively but it should be still
faster than zsl given that zsl needs to deallocate metadata per each item deleted.


<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->