### PR TITLE
feat: add ScoreMap that maps sds strings to doubles

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_library(dfly_core compact_object.cc dragonfly_core.cc extent_tree.cc
     external_alloc.cc interpreter.cc json_object.cc mi_memory_resource.cc sds_utils.cc
-    segment_allocator.cc simple_lru_counter.cc small_string.cc sorted_map.cc
+    segment_allocator.cc simple_lru_counter.cc score_map.cc small_string.cc sorted_map.cc
     tx_queue.cc dense_set.cc
     string_set.cc string_map.cc detail/bitpacking.cc)
 
@@ -22,5 +22,6 @@ cxx_test(string_set_test dfly_core LABELS DFLY)
 cxx_test(string_map_test dfly_core LABELS DFLY)
 cxx_test(sorted_map_test dfly_core LABELS DFLY)
 cxx_test(bptree_set_test dfly_core LABELS DFLY)
+cxx_test(score_map_test dfly_core LABELS DFLY)
 
 add_subdirectory(search)

--- a/src/core/score_map.cc
+++ b/src/core/score_map.cc
@@ -1,0 +1,142 @@
+// Copyright 2023, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "core/score_map.h"
+
+#include "base/endian.h"
+#include "base/logging.h"
+#include "core/compact_object.h"
+#include "core/sds_utils.h"
+
+extern "C" {
+#include "redis/zmalloc.h"
+}
+
+using namespace std;
+
+namespace dfly {
+
+namespace {
+
+union DoubleUnion {
+  double d;
+  uint64_t u;
+};
+
+inline double GetValue(sds key) {
+  char* valptr = key + sdslen(key) + 1;
+  DoubleUnion u;
+  u.u = absl::little_endian::Load64(valptr);
+  return u.d;
+}
+
+}  // namespace
+
+ScoreMap::~ScoreMap() {
+  Clear();
+}
+
+bool ScoreMap::AddOrUpdate(string_view field, double value) {
+  size_t meta_offset = field.size() + 1;
+  DoubleUnion u;
+  u.d = value;
+
+  // The layout is:
+  // key, '\0', 8-byte double value
+  sds newkey = AllocSdsWithSpace(field.size(), 8);
+
+  if (!field.empty()) {
+    memcpy(newkey, field.data(), field.size());
+  }
+
+  absl::little_endian::Store64(newkey + meta_offset, u.u);
+
+  // Replace the whole entry.
+  sds prev_entry = (sds)AddOrReplaceObj(newkey, false);
+  if (prev_entry) {
+    ObjDelete(prev_entry, false);
+    return false;
+  }
+
+  return true;
+}
+
+bool ScoreMap::AddOrSkip(std::string_view field, double value) {
+  void* obj = FindInternal(&field, 1);  // 1 - string_view
+
+  if (obj)
+    return false;
+
+  return AddOrUpdate(field, value);
+}
+
+bool ScoreMap::Erase(string_view key) {
+  return EraseInternal(&key, 1);
+}
+
+void ScoreMap::Clear() {
+  ClearInternal();
+}
+
+std::optional<double> ScoreMap::Find(std::string_view key) {
+  sds str = (sds)FindInternal(&key, 1);
+  if (!str)
+    return nullopt;
+
+  return GetValue(str);
+}
+
+uint64_t ScoreMap::Hash(const void* obj, uint32_t cookie) const {
+  DCHECK_LT(cookie, 2u);
+
+  if (cookie == 0) {
+    sds s = (sds)obj;
+    return CompactObj::HashCode(string_view{s, sdslen(s)});
+  }
+
+  const string_view* sv = (const string_view*)obj;
+  return CompactObj::HashCode(*sv);
+}
+
+bool ScoreMap::ObjEqual(const void* left, const void* right, uint32_t right_cookie) const {
+  DCHECK_LT(right_cookie, 2u);
+
+  sds s1 = (sds)left;
+  if (right_cookie == 0) {
+    sds s2 = (sds)right;
+
+    if (sdslen(s1) != sdslen(s2)) {
+      return false;
+    }
+
+    return sdslen(s1) == 0 || memcmp(s1, s2, sdslen(s1)) == 0;
+  }
+
+  const string_view* right_sv = (const string_view*)right;
+  string_view left_sv{s1, sdslen(s1)};
+  return left_sv == (*right_sv);
+}
+
+size_t ScoreMap::ObjectAllocSize(const void* obj) const {
+  sds s1 = (sds)obj;
+  size_t res = zmalloc_usable_size(sdsAllocPtr(s1));
+  return res;
+}
+
+uint32_t ScoreMap::ObjExpireTime(const void* obj) const {
+  // Should not reach.
+  return UINT32_MAX;
+}
+
+void ScoreMap::ObjDelete(void* obj, bool has_ttl) const {
+  sds s1 = (sds)obj;
+  sdsfree(s1);
+}
+
+detail::SdsScorePair ScoreMap::iterator::BreakToPair(void* obj) {
+  sds f = (sds)obj;
+  return detail::SdsScorePair(f, GetValue(f));
+}
+
+}  // namespace dfly

--- a/src/core/score_map.h
+++ b/src/core/score_map.h
@@ -1,0 +1,113 @@
+// Copyright 2023, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <optional>
+#include <string_view>
+
+#include "core/dense_set.h"
+
+extern "C" {
+#include "redis/sds.h"
+}
+
+namespace dfly {
+
+namespace detail {
+
+class SdsScorePair {
+ public:
+  SdsScorePair(sds k, double v) : first(k), second(v) {
+  }
+
+  SdsScorePair* operator->() {
+    return this;
+  }
+
+  const SdsScorePair* operator->() const {
+    return this;
+  }
+
+  const sds first;
+  const double second;
+};
+
+};  // namespace detail
+
+class ScoreMap : public DenseSet {
+ public:
+  ScoreMap(MemoryResource* res = PMR_NS::get_default_resource()) : DenseSet(res) {
+  }
+
+  ~ScoreMap();
+
+  class iterator : private DenseSet::IteratorBase {
+    static detail::SdsScorePair BreakToPair(void* obj);
+
+   public:
+    iterator() : IteratorBase() {
+    }
+
+    iterator(DenseSet* owner, bool is_end) : IteratorBase(owner, is_end) {
+    }
+
+    detail::SdsScorePair operator->() const {
+      void* ptr = curr_entry_->GetObject();
+      return BreakToPair(ptr);
+    }
+
+    detail::SdsScorePair operator*() const {
+      void* ptr = curr_entry_->GetObject();
+      return BreakToPair(ptr);
+    }
+
+    iterator& operator++() {
+      Advance();
+      return *this;
+    }
+
+    bool operator==(const iterator& b) const {
+      return curr_list_ == b.curr_list_;
+    }
+
+    bool operator!=(const iterator& b) const {
+      return !(*this == b);
+    }
+  };
+
+  // Returns true if field was added
+  // otherwise updates its value and returns false.
+  bool AddOrUpdate(std::string_view field, double value);
+
+  // Returns true if field was added
+  // false, if already exists. In that case no update is done.
+  bool AddOrSkip(std::string_view field, double value);
+
+  bool Erase(std::string_view s1);
+
+  /// @brief  Returns value of the key or nullptr if key not found.
+  /// @param key
+  /// @return sds
+  std::optional<double> Find(std::string_view key);
+
+  void Clear();
+
+  iterator begin() {
+    return iterator{this, false};
+  }
+
+  iterator end() {
+    return iterator{this, true};
+  }
+
+ private:
+  uint64_t Hash(const void* obj, uint32_t cookie) const final;
+  bool ObjEqual(const void* left, const void* right, uint32_t right_cookie) const final;
+  size_t ObjectAllocSize(const void* obj) const final;
+  uint32_t ObjExpireTime(const void* obj) const final;
+  void ObjDelete(void* obj, bool has_ttl) const final;
+};
+
+}  // namespace dfly

--- a/src/core/score_map_test.cc
+++ b/src/core/score_map_test.cc
@@ -1,0 +1,87 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "core/score_map.h"
+
+#include "base/gtest.h"
+#include "base/logging.h"
+#include "core/mi_memory_resource.h"
+
+extern "C" {
+#include "redis/zmalloc.h"
+}
+
+using namespace std;
+
+namespace dfly {
+
+class ScoreMapTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    auto* tlh = mi_heap_get_backing();
+    init_zmalloc_threadlocal(tlh);
+  }
+
+  static void TearDownTestSuite() {
+    mi_heap_collect(mi_heap_get_backing(), true);
+
+    auto cb_visit = [](const mi_heap_t* heap, const mi_heap_area_t* area, void* block,
+                       size_t block_size, void* arg) {
+      LOG(ERROR) << "Unfreed allocations: block_size " << block_size
+                 << ", allocated: " << area->used * block_size;
+      return true;
+    };
+
+    mi_heap_visit_blocks(mi_heap_get_backing(), false /* do not visit all blocks*/, cb_visit,
+                         nullptr);
+  }
+
+  ScoreMapTest() : mi_alloc_(mi_heap_get_backing()) {
+  }
+
+  void SetUp() override {
+    sm_.reset(new ScoreMap(&mi_alloc_));
+  }
+
+  void TearDown() override {
+    sm_.reset();
+    EXPECT_EQ(zmalloc_used_memory_tl, 0);
+  }
+
+  MiMemoryResource mi_alloc_;
+  std::unique_ptr<ScoreMap> sm_;
+};
+
+TEST_F(ScoreMapTest, Basic) {
+  EXPECT_TRUE(sm_->AddOrUpdate("foo", 5));
+  EXPECT_EQ(5, sm_->Find("foo"));
+
+  auto it = sm_->begin();
+  EXPECT_STREQ("foo", it->first);
+  EXPECT_EQ(5, it->second);
+  ++it;
+
+  EXPECT_TRUE(it == sm_->end());
+
+  for (const auto& k_v : *sm_) {
+    EXPECT_STREQ("foo", k_v.first);
+    EXPECT_EQ(5, k_v.second);
+  }
+
+  size_t sz = sm_->ObjMallocUsed();
+  EXPECT_FALSE(sm_->AddOrUpdate("foo", 17));
+  EXPECT_EQ(sm_->ObjMallocUsed(), sz);
+
+  it = sm_->begin();
+  EXPECT_EQ(17, it->second);
+
+  EXPECT_FALSE(sm_->AddOrSkip("foo", 31));
+  EXPECT_EQ(17, it->second);
+}
+
+TEST_F(ScoreMapTest, EmptyFind) {
+  EXPECT_EQ(nullopt, sm_->Find("bar"));
+}
+
+}  // namespace dfly


### PR DESCRIPTION
This map should serve as a replacement for dict that currently is used internally by the SortedMap. Specifically, it maps sds strings to scores to provide a reverse mapping. It should be more efficient in memory and CPU - requires a single allocation to store both the key and the value, in contrast to dict that needs two allocations.

In addition, it also reduces the object size needed for the zset score set: zsl stores both the sds pointer and its double, i.e. requires 16 bytes not including the metadata. By passing to bptree_set the internal ScoreMap objects that are allocated by ScoreMap::AddOrUpdate we can just store 8-byte pointers, not including the bptree metadata.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->