### PR TITLE
feat(server): support multi eval in lock ahead mode

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -757,13 +757,13 @@ bool DbSlice::Acquire(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
   if (lock_args.args.size() == 1) {
     string_view key = KeyLockArgs::GetLockKey(lock_args.args.front());
     lock_acquired = lt[key].Acquire(mode);
-    uniq_keys_ = {string{key}};
+    uniq_keys_ = {key};
   } else {
     uniq_keys_.clear();
 
     for (size_t i = 0; i < lock_args.args.size(); i += lock_args.key_step) {
       auto s = KeyLockArgs::GetLockKey(lock_args.args[i]);
-      if (uniq_keys_.insert(string{s}).second) {
+      if (uniq_keys_.insert(s).second) {
         bool res = lt[s].Acquire(mode);
         lock_acquired &= res;
       }
@@ -804,13 +804,12 @@ void DbSlice::Release(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
   if (lock_args.args.size() == 1) {
     string_view key = KeyLockArgs::GetLockKey(lock_args.args.front());
     ReleaseNormalized(mode, lock_args.db_index, key, 1);
-    uniq_keys_ = {string{key}};
   } else {
     auto& lt = db_arr_[lock_args.db_index]->trans_locks;
     uniq_keys_.clear();
     for (size_t i = 0; i < lock_args.args.size(); i += lock_args.key_step) {
       auto s = KeyLockArgs::GetLockKey(lock_args.args[i]);
-      if (uniq_keys_.insert(string{s}).second) {
+      if (uniq_keys_.insert(s).second) {
         auto it = lt.find(s);
         CHECK(it != lt.end());
         it->second.Release(mode);
@@ -820,6 +819,7 @@ void DbSlice::Release(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
       }
     }
   }
+  uniq_keys_.clear();
 }
 
 bool DbSlice::CheckLock(IntentLock::Mode mode, DbIndex dbid, string_view key) const {
@@ -831,11 +831,9 @@ bool DbSlice::CheckLock(IntentLock::Mode mode, DbIndex dbid, string_view key) co
 }
 
 bool DbSlice::CheckLock(IntentLock::Mode mode, const KeyLockArgs& lock_args) const {
-  uniq_keys_.clear();
   const auto& lt = db_arr_[lock_args.db_index]->trans_locks;
   for (size_t i = 0; i < lock_args.args.size(); i += lock_args.key_step) {
     auto s = KeyLockArgs::GetLockKey(lock_args.args[i]);
-    uniq_keys_.insert(string{s});
     auto it = lt.find(s);
     if (it != lt.end() && !it->second.Check(mode)) {
       return false;

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -312,7 +312,7 @@ class DbSlice {
   }
 
   // Test hook to inspect last locked keys.
-  absl::flat_hash_set<std::string> TEST_GetLastLockedKeys() const {
+  absl::flat_hash_set<std::string_view> TEST_GetLastLockedKeys() const {
     return uniq_keys_;
   }
 
@@ -374,7 +374,7 @@ class DbSlice {
   DbTableArray db_arr_;
 
   // Used in temporary computations in Acquire/Release.
-  mutable absl::flat_hash_set<std::string> uniq_keys_;
+  mutable absl::flat_hash_set<std::string_view> uniq_keys_;
 
   // ordered from the smallest to largest version.
   std::vector<std::pair<uint64_t, ChangeCallback>> change_cb_;

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -312,7 +312,7 @@ class DbSlice {
   }
 
   // Test hook to inspect last locked keys.
-  absl::flat_hash_set<std::string_view> TEST_GetLastLockedKeys() const {
+  absl::flat_hash_set<std::string> TEST_GetLastLockedKeys() const {
     return uniq_keys_;
   }
 
@@ -374,7 +374,7 @@ class DbSlice {
   DbTableArray db_arr_;
 
   // Used in temporary computations in Acquire/Release.
-  mutable absl::flat_hash_set<std::string_view> uniq_keys_;
+  mutable absl::flat_hash_set<std::string> uniq_keys_;
 
   // ordered from the smallest to largest version.
   std::vector<std::pair<uint64_t, ChangeCallback>> change_cb_;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1441,7 +1441,7 @@ void Service::EvalInternal(const EvalArgs& eval_args, Interpreter* interpreter,
   Transaction* tx = cntx->transaction;
   CHECK(tx != nullptr);
 
-  optional<bool> scheduled = StartMultiEval(cntx->db_index(), eval_args.keys, *params, tx);
+  optional<bool> scheduled = StartMultiEval(cntx->db_index(), eval_args.keys, *params, cntx);
   if (!scheduled) {
     return;
   }

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -655,6 +655,11 @@ TEST_F(MultiTest, ScriptFlagsEmbedded) {
 }
 
 TEST_F(MultiTest, MultiEvalModeConflict) {
+  if (auto mode = absl::GetFlag(FLAGS_multi_exec_mode); mode == Transaction::GLOBAL) {
+    GTEST_SKIP() << "Skipped MultiEvalModeConflict test because multi_exec_mode is global";
+    return;
+  }
+
   const char* s1 = R"(
   #!lua flags=allow-undeclared-keys
   return redis.call('GET', 'random-key');

--- a/src/server/string_family_test.cc
+++ b/src/server/string_family_test.cc
@@ -747,8 +747,9 @@ TEST_F(StringFamilyTest, MultiSetWithHashtagsDontLockHashtags) {
   EXPECT_EQ(Run({"multi"}), "OK");
   EXPECT_EQ(Run({"set", "{key}1", "val1"}), "QUEUED");
   EXPECT_EQ(Run({"set", "{key}2", "val2"}), "QUEUED");
-  EXPECT_THAT(Run({"exec"}), RespArray(ElementsAre("OK", "OK")));
-  EXPECT_THAT(GetLastUsedKeys(), UnorderedElementsAre("{key}1", "{key}2"));
+  EXPECT_EQ(Run({"eval", "return redis.call('set', KEYS[1], 'val3')", "1", "{key}3"}), "QUEUED");
+  EXPECT_THAT(Run({"exec"}), RespArray(ElementsAre("OK", "OK", "OK")));
+  EXPECT_THAT(GetLastUsedKeys(), UnorderedElementsAre("{key}1", "{key}2", "{key}3"));
 }
 
 TEST_F(StringFamilyTest, MultiSetWithHashtagsLockHashtags) {
@@ -759,7 +760,8 @@ TEST_F(StringFamilyTest, MultiSetWithHashtagsLockHashtags) {
   EXPECT_EQ(Run({"multi"}), "OK");
   EXPECT_EQ(Run({"set", "{key}1", "val1"}), "QUEUED");
   EXPECT_EQ(Run({"set", "{key}2", "val2"}), "QUEUED");
-  EXPECT_THAT(Run({"exec"}), RespArray(ElementsAre("OK", "OK")));
+  EXPECT_EQ(Run({"eval", "return redis.call('set', KEYS[1], 'val3')", "1", "{key}3"}), "QUEUED");
+  EXPECT_THAT(Run({"exec"}), RespArray(ElementsAre("OK", "OK", "OK")));
   EXPECT_THAT(GetLastUsedKeys(), UnorderedElementsAre("key"));
 }
 

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -544,7 +544,7 @@ void BaseFamilyTest::ExpectConditionWithinTimeout(const std::function<bool()>& c
 Fiber BaseFamilyTest::ExpectConditionWithSuspension(const std::function<bool()>& condition) {
   TransactionSuspension tx;
   tx.Start();
-  auto fb = pp_->at(1)->LaunchFiber([condition, tx = std::move(tx)]() mutable {
+  auto fb = pp_->at(0)->LaunchFiber([condition, tx = std::move(tx)]() mutable {
     ExpectConditionWithinTimeout(condition);
     tx.Terminate();
   });

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -121,6 +121,7 @@ class BaseFamilyTest : public ::testing::Test {
   static absl::flat_hash_set<std::string> GetLastUsedKeys();
   static void ExpectConditionWithinTimeout(const std::function<bool()>& condition,
                                            absl::Duration timeout = absl::Seconds(10));
+  Fiber ExpectConditionWithSuspension(const std::function<bool()>& condition);
 
   static unsigned NumLocked();
 


### PR DESCRIPTION
1. remove validation to allow multi eval only in global script mode
2. send error if there is a mode conflict when running eval inside multi
3. change uniqe_keys_ to string set
