### PR TITLE
chore: Refactor SortedMap

### DIFF
--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -41,10 +41,6 @@ class RobjWrapper {
   void SetString(std::string_view s, MemoryResource* mr);
   void Init(unsigned type, unsigned encoding, void* inner);
 
-  // Equivalent to zsetAdd
-  int AddZsetMember(std::string_view member, double score, int in_flags, int* out_flags,
-                    double* newscore);
-
   unsigned type() const {
     return type_;
   }

--- a/src/core/sorted_map.cc
+++ b/src/core/sorted_map.cc
@@ -58,28 +58,22 @@ inline bool IsUnder(bool reverse, double score, const zrangespec& spec) {
 
 }  // namespace
 
-SortedMap::SortedMap() {
-  dict_ = dictCreate(&zsetDictType);
-  zsl_ = zslCreate();
+void SortedMap::RdImpl::Init() {
+  dict = dictCreate(&zsetDictType);
+  zsl = zslCreate();
 }
 
-SortedMap::~SortedMap() {
-  dictRelease(dict_);
-  zslFree(zsl_);
+size_t SortedMap::RdImpl::MallocSize() const {
+  return DictMallocSize(dict) + zmalloc_size(zsl);
 }
 
-size_t SortedMap::MallocSize() const {
-  // TODO: introduce a proper malloc usage tracking.
-  return DictMallocSize(dict_) + zmalloc_size(zsl_);
-}
-
-bool SortedMap::Insert(double score, sds member) {
-  zskiplistNode* znode = zslInsert(zsl_, score, member);
-  int ret = dictAdd(dict_, member, &znode->score);
+bool SortedMap::RdImpl::Insert(double score, sds member) {
+  zskiplistNode* znode = zslInsert(zsl, score, member);
+  int ret = dictAdd(dict, member, &znode->score);
   return ret == DICT_OK;
 }
 
-int SortedMap::Add(double score, sds ele, int in_flags, int* out_flags, double* newscore) {
+int SortedMap::RdImpl::Add(double score, sds ele, int in_flags, int* out_flags, double* newscore) {
   zskiplistNode* znode;
 
   /* Turn options into simple to check vars. */
@@ -92,7 +86,7 @@ int SortedMap::Add(double score, sds ele, int in_flags, int* out_flags, double* 
   *out_flags = 0; /* We'll return our response flags. */
   double curscore;
 
-  dictEntry* de = dictFind(dict_, ele);
+  dictEntry* de = dictFind(dict, ele);
   if (de != NULL) {
     /* NX? Return, same element already exists. */
     if (nx) {
@@ -117,12 +111,11 @@ int SortedMap::Add(double score, sds ele, int in_flags, int* out_flags, double* 
       return 1;
     }
 
-    if (newscore)
-      *newscore = score;
+    *newscore = score;
 
     /* Remove and re-insert when score changes. */
     if (score != curscore) {
-      znode = zslUpdateScore(zsl_, curscore, ele, score);
+      znode = zslUpdateScore(zsl, curscore, ele, score);
       /* Note that we did not removed the original element from
        * the hash table representing the sorted set, so we just
        * update the score. */
@@ -132,17 +125,317 @@ int SortedMap::Add(double score, sds ele, int in_flags, int* out_flags, double* 
     return 1;
   } else if (!xx) {
     ele = sdsdup(ele);
-    znode = zslInsert(zsl_, score, ele);
-    CHECK_EQ(DICT_OK, dictAdd(dict_, ele, &znode->score));
+    znode = zslInsert(zsl, score, ele);
+    CHECK_EQ(DICT_OK, dictAdd(dict, ele, &znode->score));
 
     *out_flags |= ZADD_OUT_ADDED;
-    if (newscore)
-      *newscore = score;
+    *newscore = score;
     return 1;
   }
 
   *out_flags |= ZADD_OUT_NOP;
   return 1;
+}
+
+optional<unsigned> SortedMap::RdImpl::GetRank(sds ele, bool reverse) const {
+  dictEntry* de = dictFind(dict, ele);
+  if (de == NULL)
+    return std::nullopt;
+
+  double score = *(double*)dictGetVal(de);
+  unsigned rank = zslGetRank(zsl, score, ele);
+
+  /* Existing elements always have a rank. */
+  DCHECK(rank != 0);
+  return reverse ? zsl->length - rank : rank - 1;
+}
+
+optional<double> SortedMap::RdImpl::GetScore(sds member) const {
+  dictEntry* de = dictFind(dict, member);
+  if (de == NULL)
+    return std::nullopt;
+
+  return *(double*)dictGetVal(de);
+}
+
+int SortedMap::DfImpl::Add(double score, sds ele, int in_flags, int* out_flags, double* newscore) {
+  LOG(FATAL) << "TBD";
+  return 0;
+}
+
+optional<double> SortedMap::DfImpl::GetScore(sds ele) const {
+  LOG(FATAL) << "TBD";
+  return std::nullopt;
+}
+
+void SortedMap::DfImpl::Init() {
+  LOG(FATAL) << "TBD";
+}
+
+void SortedMap::DfImpl::Free() {
+  LOG(FATAL) << "TBD";
+}
+
+bool SortedMap::DfImpl::Insert(double score, sds member) {
+  LOG(FATAL) << "TBD";
+  return false;
+}
+
+optional<unsigned> SortedMap::DfImpl::GetRank(sds ele, bool reverse) const {
+  LOG(FATAL) << "TBD";
+  return std::nullopt;
+}
+
+SortedMap::ScoredArray SortedMap::RdImpl::GetRange(const zrangespec& range, unsigned offset,
+                                                   unsigned limit, bool reverse) const {
+  /* If reversed, get the last node in range as starting point. */
+  zskiplistNode* ln;
+
+  if (reverse) {
+    ln = zslLastInRange(zsl, &range);
+  } else {
+    ln = zslFirstInRange(zsl, &range);
+  }
+
+  /* If there is an offset, just traverse the number of elements without
+   * checking the score because that is done in the next loop. */
+  while (ln && offset--) {
+    ln = Next(reverse, ln);
+  }
+
+  ScoredArray result;
+  while (ln && limit--) {
+    /* Abort when the node is no longer in range. */
+    if (!IsUnder(reverse, ln->score, range))
+      break;
+
+    result.emplace_back(string{ln->ele, sdslen(ln->ele)}, ln->score);
+
+    /* Move to next node */
+    ln = Next(reverse, ln);
+  }
+  return result;
+}
+
+SortedMap::ScoredArray SortedMap::DfImpl::GetRange(const zrangespec& range, unsigned offset,
+                                                   unsigned limit, bool reverse) const {
+  LOG(FATAL) << "TBD";
+  return {};
+}
+
+SortedMap::ScoredArray SortedMap::RdImpl::GetLexRange(const zlexrangespec& range, unsigned offset,
+                                                      unsigned limit, bool reverse) const {
+  zskiplistNode* ln;
+  /* If reversed, get the last node in range as starting point. */
+  if (reverse) {
+    ln = zslLastInLexRange(zsl, &range);
+  } else {
+    ln = zslFirstInLexRange(zsl, &range);
+  }
+
+  /* If there is an offset, just traverse the number of elements without
+   * checking the score because that is done in the next loop. */
+  while (ln && offset--) {
+    ln = Next(reverse, ln);
+  }
+
+  ScoredArray result;
+  while (ln && limit--) {
+    /* Abort when the node is no longer in range. */
+    if (reverse) {
+      if (!zslLexValueGteMin(ln->ele, &range))
+        break;
+    } else {
+      if (!zslLexValueLteMax(ln->ele, &range))
+        break;
+    }
+
+    result.emplace_back(string{ln->ele, sdslen(ln->ele)}, ln->score);
+
+    /* Move to next node */
+    ln = Next(reverse, ln);
+  }
+
+  return result;
+}
+
+SortedMap::ScoredArray SortedMap::DfImpl::GetLexRange(const zlexrangespec& range, unsigned offset,
+                                                      unsigned limit, bool reverse) const {
+  LOG(FATAL) << "TBD";
+  return {};
+}
+
+uint8_t* SortedMap::RdImpl::ToListPack() const {
+  uint8_t* lp = lpNew(0);
+
+  /* Approach similar to zslFree(), since we want to free the skiplist at
+   * the same time as creating the listpack. */
+  zskiplistNode* node = zsl->header->level[0].forward;
+
+  while (node) {
+    lp = zzlInsertAt(lp, NULL, node->ele, node->score);
+    node = node->level[0].forward;
+  }
+
+  return lp;
+}
+
+uint8_t* SortedMap::DfImpl::ToListPack() const {
+  LOG(FATAL) << "TBD";
+  return nullptr;
+}
+
+bool SortedMap::RdImpl::Delete(sds member) {
+  dictEntry* de = dictUnlink(dict, member);
+  if (de == NULL)
+    return false;
+
+  /* Get the score in order to delete from the skiplist later. */
+  double score = *(double*)dictGetVal(de);
+
+  /* Delete from the hash table and later from the skiplist.
+   * Note that the order is important: deleting from the skiplist
+   * actually releases the SDS string representing the element,
+   * which is shared between the skiplist and the hash table, so
+   * we need to delete from the skiplist as the final step. */
+  dictFreeUnlinkedEntry(dict, de);
+  if (htNeedsResize(dict))
+    dictResize(dict);
+
+  /* Delete from skiplist. */
+  int retval = zslDelete(zsl, score, member, NULL);
+  DCHECK(retval);
+
+  return true;
+}
+
+bool SortedMap::DfImpl::Delete(sds ele) {
+  LOG(FATAL) << "TBD";
+  return false;
+}
+
+SortedMap::ScoredArray SortedMap::RdImpl::PopTopScores(unsigned count, bool reverse) {
+  zskiplistNode* ln;
+  if (reverse) {
+    ln = zsl->tail;
+  } else {
+    ln = zsl->header->level[0].forward;
+  }
+
+  ScoredArray result;
+  while (ln && count--) {
+    result.emplace_back(string{ln->ele, sdslen(ln->ele)}, ln->score);
+
+    /* we can delete the element now */
+    CHECK(Delete(ln->ele));
+
+    ln = Next(reverse, ln);
+  }
+  return result;
+}
+
+size_t SortedMap::RdImpl::Count(const zrangespec& range) const {
+  /* Find first element in range */
+  zskiplistNode* zn = zslFirstInRange(zsl, &range);
+
+  /* Use rank of first element, if any, to determine preliminary count */
+  if (zn == NULL)
+    return 0;
+
+  unsigned long rank = zslGetRank(zsl, zn->score, zn->ele);
+  size_t count = (zsl->length - (rank - 1));
+
+  /* Find last element in range */
+  zn = zslLastInRange(zsl, &range);
+
+  /* Use rank of last element, if any, to determine the actual count */
+  if (zn != NULL) {
+    rank = zslGetRank(zsl, zn->score, zn->ele);
+    count -= (zsl->length - rank);
+  }
+
+  return count;
+}
+
+size_t SortedMap::RdImpl::LexCount(const zlexrangespec& range) const {
+  /* Find first element in range */
+  zskiplistNode* zn = zslFirstInLexRange(zsl, &range);
+
+  /* Use rank of first element, if any, to determine preliminary count */
+  if (zn == NULL)
+    return 0;
+
+  unsigned long rank = zslGetRank(zsl, zn->score, zn->ele);
+  size_t count = (zsl->length - (rank - 1));
+
+  /* Find last element in range */
+  zn = zslLastInLexRange(zsl, &range);
+
+  /* Use rank of last element, if any, to determine the actual count */
+  if (zn != NULL) {
+    rank = zslGetRank(zsl, zn->score, zn->ele);
+    count -= (zsl->length - rank);
+  }
+  return count;
+}
+
+bool SortedMap::RdImpl::Iterate(unsigned start_rank, unsigned len, bool reverse,
+                                absl::FunctionRef<bool(sds, double)> cb) const {
+  zskiplistNode* ln;
+
+  /* Check if starting point is trivial, before doing log(N) lookup. */
+  if (reverse) {
+    ln = zsl->tail;
+    unsigned long llen = zsl->length;
+    if (start_rank > 0)
+      ln = zslGetElementByRank(zsl, llen - start_rank);
+  } else {
+    ln = zsl->header->level[0].forward;
+    if (start_rank > 0)
+      ln = zslGetElementByRank(zsl, start_rank + 1);
+  }
+
+  bool success = true;
+  while (success && len--) {
+    DCHECK(ln != NULL);
+    success = cb(ln->ele, ln->score);
+    ln = reverse ? ln->backward : ln->level[0].forward;
+    if (!ln)
+      break;
+  }
+  return success;
+}
+
+SortedMap::ScoredArray SortedMap::DfImpl::PopTopScores(unsigned count, bool reverse) {
+  LOG(FATAL) << "TBD";
+  return {};
+}
+
+size_t SortedMap::DfImpl::Count(const zrangespec& range) const {
+  LOG(FATAL) << "TBD";
+  return 0;
+}
+
+size_t SortedMap::DfImpl::LexCount(const zlexrangespec& range) const {
+  LOG(FATAL) << "TBD";
+  return 0;
+}
+
+bool SortedMap::DfImpl::Iterate(unsigned start_rank, unsigned len, bool reverse,
+                                absl::FunctionRef<bool(sds, double)> cb) const {
+  LOG(FATAL) << "TBD";
+  return false;
+}
+
+/***************************************************************************/
+/* SortedMap */
+/***************************************************************************/
+SortedMap::SortedMap() : impl_(RdImpl()) {
+  std::visit(Overload{[](RdImpl& impl) { impl.Init(); }, [](DfImpl& impl) { impl.Init(); }}, impl_);
+}
+
+SortedMap::~SortedMap() {
+  std::visit(Overload{[](RdImpl& impl) { impl.Free(); }, [](DfImpl& impl) { impl.Free(); }}, impl_);
 }
 
 // taken from zsetConvert
@@ -175,232 +468,6 @@ unique_ptr<SortedMap> SortedMap::FromListPack(const uint8_t* lp) {
   }
 
   return zs;
-}
-
-// taken from zsetConvert
-uint8_t* SortedMap::ToListPack() const {
-  uint8_t* lp = lpNew(0);
-
-  /* Approach similar to zslFree(), since we want to free the skiplist at
-   * the same time as creating the listpack. */
-  zskiplistNode* node = zsl_->header->level[0].forward;
-
-  while (node) {
-    lp = zzlInsertAt(lp, NULL, node->ele, node->score);
-    node = node->level[0].forward;
-  }
-
-  return lp;
-}
-
-// returns true if the element was deleted.
-bool SortedMap::Delete(sds ele) {
-  // Taken from zsetRemoveFromSkiplist.
-
-  dictEntry* de = dictUnlink(dict_, ele);
-  if (de == NULL)
-    return false;
-
-  /* Get the score in order to delete from the skiplist later. */
-  double score = *(double*)dictGetVal(de);
-
-  /* Delete from the hash table and later from the skiplist.
-   * Note that the order is important: deleting from the skiplist
-   * actually releases the SDS string representing the element,
-   * which is shared between the skiplist and the hash table, so
-   * we need to delete from the skiplist as the final step. */
-  dictFreeUnlinkedEntry(dict_, de);
-  if (htNeedsResize(dict_))
-    dictResize(dict_);
-
-  /* Delete from skiplist. */
-  int retval = zslDelete(zsl_, score, ele, NULL);
-  DCHECK(retval);
-
-  return true;
-}
-
-std::optional<double> SortedMap::GetScore(sds ele) const {
-  dictEntry* de = dictFind(dict_, ele);
-  if (de == NULL)
-    return std::nullopt;
-
-  return *(double*)dictGetVal(de);
-}
-
-std::optional<unsigned> SortedMap::GetRank(sds ele, bool reverse) const {
-  dictEntry* de = dictFind(dict_, ele);
-  if (de == NULL)
-    return nullopt;
-
-  double score = *(double*)dictGetVal(de);
-  unsigned rank = zslGetRank(zsl_, score, ele);
-
-  /* Existing elements always have a rank. */
-  DCHECK(rank != 0);
-  if (reverse)
-    return zsl_->length - rank;
-  else
-    return rank - 1;
-}
-
-auto SortedMap::GetRange(const zrangespec& range, unsigned offset, unsigned limit,
-                         bool reverse) const -> ScoredArray {
-  /* If reversed, get the last node in range as starting point. */
-  zskiplistNode* ln;
-
-  if (reverse) {
-    ln = zslLastInRange(zsl_, &range);
-  } else {
-    ln = zslFirstInRange(zsl_, &range);
-  }
-
-  /* If there is an offset, just traverse the number of elements without
-   * checking the score because that is done in the next loop. */
-  while (ln && offset--) {
-    ln = Next(reverse, ln);
-  }
-
-  ScoredArray result;
-  while (ln && limit--) {
-    /* Abort when the node is no longer in range. */
-    if (!IsUnder(reverse, ln->score, range))
-      break;
-
-    result.emplace_back(string{ln->ele, sdslen(ln->ele)}, ln->score);
-
-    /* Move to next node */
-    ln = Next(reverse, ln);
-  }
-  return result;
-}
-
-auto SortedMap::GetLexRange(const zlexrangespec& range, unsigned offset, unsigned limit,
-                            bool reverse) const -> ScoredArray {
-  zskiplistNode* ln;
-  /* If reversed, get the last node in range as starting point. */
-  if (reverse) {
-    ln = zslLastInLexRange(zsl_, &range);
-  } else {
-    ln = zslFirstInLexRange(zsl_, &range);
-  }
-
-  /* If there is an offset, just traverse the number of elements without
-   * checking the score because that is done in the next loop. */
-  while (ln && offset--) {
-    ln = Next(reverse, ln);
-  }
-
-  ScoredArray result;
-  while (ln && limit--) {
-    /* Abort when the node is no longer in range. */
-    if (reverse) {
-      if (!zslLexValueGteMin(ln->ele, &range))
-        break;
-    } else {
-      if (!zslLexValueLteMax(ln->ele, &range))
-        break;
-    }
-
-    result.emplace_back(string{ln->ele, sdslen(ln->ele)}, ln->score);
-
-    /* Move to next node */
-    ln = Next(reverse, ln);
-  }
-
-  return result;
-}
-
-auto SortedMap::PopTopScores(unsigned count, bool reverse) -> ScoredArray {
-  zskiplistNode* ln;
-  if (reverse) {
-    ln = zsl_->tail;
-  } else {
-    ln = zsl_->header->level[0].forward;
-  }
-
-  ScoredArray result;
-  while (ln && count--) {
-    result.emplace_back(string{ln->ele, sdslen(ln->ele)}, ln->score);
-
-    /* we can delete the element now */
-    CHECK(Delete(ln->ele));
-
-    ln = Next(reverse, ln);
-  }
-  return result;
-}
-
-size_t SortedMap::Count(const zrangespec& range) const {
-  /* Find first element in range */
-  zskiplistNode* zn = zslFirstInRange(zsl_, &range);
-
-  /* Use rank of first element, if any, to determine preliminary count */
-  if (zn == NULL)
-    return 0;
-
-  unsigned long rank = zslGetRank(zsl_, zn->score, zn->ele);
-  size_t count = (zsl_->length - (rank - 1));
-
-  /* Find last element in range */
-  zn = zslLastInRange(zsl_, &range);
-
-  /* Use rank of last element, if any, to determine the actual count */
-  if (zn != NULL) {
-    rank = zslGetRank(zsl_, zn->score, zn->ele);
-    count -= (zsl_->length - rank);
-  }
-
-  return count;
-}
-
-size_t SortedMap::LexCount(const zlexrangespec& range) const {
-  /* Find first element in range */
-  zskiplistNode* zn = zslFirstInLexRange(zsl_, &range);
-
-  /* Use rank of first element, if any, to determine preliminary count */
-  if (zn == NULL)
-    return 0;
-
-  unsigned long rank = zslGetRank(zsl_, zn->score, zn->ele);
-  size_t count = (zsl_->length - (rank - 1));
-
-  /* Find last element in range */
-  zn = zslLastInLexRange(zsl_, &range);
-
-  /* Use rank of last element, if any, to determine the actual count */
-  if (zn != NULL) {
-    rank = zslGetRank(zsl_, zn->score, zn->ele);
-    count -= (zsl_->length - rank);
-  }
-  return count;
-}
-
-bool SortedMap::Iterate(unsigned start_rank, unsigned len, bool reverse,
-                        absl::FunctionRef<bool(sds, double)> cb) const {
-  zskiplistNode* ln;
-
-  /* Check if starting point is trivial, before doing log(N) lookup. */
-  if (reverse) {
-    ln = zsl_->tail;
-    unsigned long llen = zsl_->length;
-    if (start_rank > 0)
-      ln = zslGetElementByRank(zsl_, llen - start_rank);
-  } else {
-    ln = zsl_->header->level[0].forward;
-    if (start_rank > 0)
-      ln = zslGetElementByRank(zsl_, start_rank + 1);
-  }
-
-  bool success = true;
-  while (success && len--) {
-    DCHECK(ln != NULL);
-    success = cb(ln->ele, ln->score);
-    ln = reverse ? ln->backward : ln->level[0].forward;
-    if (!ln)
-      break;
-  }
-  return success;
 }
 
 }  // namespace detail

--- a/src/core/sorted_map.h
+++ b/src/core/sorted_map.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <variant>
 #include <vector>
 
 extern "C" {
@@ -16,8 +17,16 @@ extern "C" {
 #include "redis/zset.h"
 }
 
+#include "core/bptree_set.h"
+#include "core/score_map.h"
+
 namespace dfly {
+
 namespace detail {
+
+template <typename... Ts> struct Overload : Ts... { using Ts::operator()...; };
+
+template <typename... Ts> Overload(Ts...) -> Overload<Ts...>;
 
 /**
  * @brief SortedMap is a sorted map implementation based on zset.h. It holds unique strings that
@@ -40,60 +49,250 @@ class SortedMap {
   static std::unique_ptr<SortedMap> FromListPack(const uint8_t* lp);
 
   size_t Size() const {
-    return zsl_->length;
+    return std::visit(Overload{[](const RdImpl& impl) { return impl.Size(); },
+                               [](const DfImpl& impl) { return impl.Size(); }},
+                      impl_);
   }
 
   bool Reserve(size_t sz) {
-    return dictExpand(dict_, sz) == DICT_OK;
+    return std::visit(Overload{[&](RdImpl& impl) { return impl.Reserve(sz); },
+                               [&](DfImpl& impl) { return impl.Reserve(sz); }},
+                      impl_);
   }
 
   // Interface equivalent to zsetAdd.
-  int Add(double score, sds ele, int in_flags, int* out_flags, double* newscore);
+  // Does not take ownership over ele string.
+  // Returns 1 if succeeded, false if the final score became invalid due to the update.
+  // newscore is set to the new score of the element only if in_flags contains ZADD_IN_INCR.
+  int Add(double score, sds ele, int in_flags, int* out_flags, double* newscore) {
+    return std::visit(
+        Overload{[&](RdImpl& impl) { return impl.Add(score, ele, in_flags, out_flags, newscore); },
+                 [&](DfImpl& impl) { return impl.Add(score, ele, in_flags, out_flags, newscore); }},
+        impl_);
+  }
 
-  bool Insert(double score, sds member);
+  bool Insert(double score, sds member) {
+    return std::visit(Overload{[&](RdImpl& impl) { return impl.Insert(score, member); },
+                               [&](DfImpl& impl) { return impl.Insert(score, member); }},
+                      impl_);
+  }
 
-  uint8_t* ToListPack() const;
-  size_t MallocSize() const;
+  uint8_t* ToListPack() const {
+    return std::visit(Overload{[](const RdImpl& impl) { return impl.ToListPack(); },
+                               [](const DfImpl& impl) { return impl.ToListPack(); }},
+                      impl_);
+  }
 
+  size_t MallocSize() const {
+    return std::visit(Overload{[](const RdImpl& impl) { return impl.MallocSize(); },
+                               [](const DfImpl& impl) { return impl.MallocSize(); }},
+                      impl_);
+  }
+
+  // TODO: to get rid of this method.
   dict* GetDict() const {
-    return dict_;
+    return std::get<RdImpl>(impl_).dict;
   }
 
   size_t DeleteRangeByRank(unsigned start, unsigned end) {
-    return zslDeleteRangeByRank(zsl_, start + 1, end + 1, dict_);
+    return std::visit(Overload{[&](RdImpl& impl) { return impl.DeleteRangeByRank(start, end); },
+                               [&](DfImpl& impl) { return impl.DeleteRangeByRank(start, end); }},
+                      impl_);
   }
 
   size_t DeleteRangeByScore(const zrangespec& range) {
-    return zslDeleteRangeByScore(zsl_, &range, dict_);
+    return std::visit(Overload{[&](RdImpl& impl) { return impl.DeleteRangeByScore(range); },
+                               [&](DfImpl& impl) { return impl.DeleteRangeByScore(range); }},
+                      impl_);
   }
 
   size_t DeleteRangeByLex(const zlexrangespec& range) {
-    return zslDeleteRangeByLex(zsl_, &range, dict_);
+    return std::visit(Overload{[&](RdImpl& impl) { return impl.DeleteRangeByLex(range); },
+                               [&](DfImpl& impl) { return impl.DeleteRangeByLex(range); }},
+                      impl_);
   }
 
   // returns true if the element was deleted.
-  bool Delete(sds ele);
+  bool Delete(sds ele) {
+    return std::visit(Overload{[&](RdImpl& impl) { return impl.Delete(ele); },
+                               [&](DfImpl& impl) { return impl.Delete(ele); }},
+                      impl_);
+  }
 
-  std::optional<double> GetScore(sds ele) const;
-  std::optional<unsigned> GetRank(sds ele, bool reverse) const;
+  std::optional<double> GetScore(sds ele) const {
+    return std::visit(Overload{[&](const RdImpl& impl) { return impl.GetScore(ele); },
+                               [&](const DfImpl& impl) { return impl.GetScore(ele); }},
+                      impl_);
+  }
+
+  std::optional<unsigned> GetRank(sds ele, bool reverse) const {
+    return std::visit(Overload{[&](const RdImpl& impl) { return impl.GetRank(ele, reverse); },
+                               [&](const DfImpl& impl) { return impl.GetRank(ele, reverse); }},
+                      impl_);
+  }
 
   ScoredArray GetRange(const zrangespec& range, unsigned offset, unsigned limit,
-                       bool reverse) const;
-  ScoredArray GetLexRange(const zlexrangespec& range, unsigned offset, unsigned limit,
-                          bool reverse) const;
+                       bool reverse) const {
+    return std::visit(
+        Overload{[&](const RdImpl& impl) { return impl.GetRange(range, offset, limit, reverse); },
+                 [&](const DfImpl& impl) { return impl.GetRange(range, offset, limit, reverse); }},
+        impl_);
+  }
 
-  ScoredArray PopTopScores(unsigned count, bool reverse);
-  size_t Count(const zrangespec& range) const;
-  size_t LexCount(const zlexrangespec& range) const;
+  ScoredArray GetLexRange(const zlexrangespec& range, unsigned offset, unsigned limit,
+                          bool reverse) const {
+    return std::visit(
+        Overload{
+            [&](const RdImpl& impl) { return impl.GetLexRange(range, offset, limit, reverse); },
+            [&](const DfImpl& impl) { return impl.GetLexRange(range, offset, limit, reverse); }},
+        impl_);
+  }
+
+  ScoredArray PopTopScores(unsigned count, bool reverse) {
+    return std::visit(Overload{[&](RdImpl& impl) { return impl.PopTopScores(count, reverse); },
+                               [&](DfImpl& impl) { return impl.PopTopScores(count, reverse); }},
+                      impl_);
+  }
+
+  size_t Count(const zrangespec& range) const {
+    return std::visit(Overload{[&](const RdImpl& impl) { return impl.Count(range); },
+                               [&](const DfImpl& impl) { return impl.Count(range); }},
+                      impl_);
+  }
+
+  size_t LexCount(const zlexrangespec& range) const {
+    return std::visit(Overload{[&](const RdImpl& impl) { return impl.LexCount(range); },
+                               [&](const DfImpl& impl) { return impl.LexCount(range); }},
+                      impl_);
+  }
 
   // Runs cb for each element in the range [start_rank, start_rank + len).
   // Stops iteration if cb returns false. Returns false in this case.
   bool Iterate(unsigned start_rank, unsigned len, bool reverse,
-               absl::FunctionRef<bool(sds, double)> cb) const;
+               absl::FunctionRef<bool(sds, double)> cb) const {
+    return std::visit(
+        Overload{[&](const RdImpl& impl) { return impl.Iterate(start_rank, len, reverse, cb); },
+                 [&](const DfImpl& impl) { return impl.Iterate(start_rank, len, reverse, cb); }},
+        impl_);
+  }
 
  private:
-  dict* dict_ = nullptr;
-  zskiplist* zsl_ = nullptr;
+  struct RdImpl {
+    struct dict* dict = nullptr;
+    zskiplist* zsl = nullptr;
+
+    int Add(double score, sds ele, int in_flags, int* out_flags, double* newscore);
+
+    void Init();
+
+    void Free() {
+      dictRelease(dict);
+      zslFree(zsl);
+    }
+
+    bool Insert(double score, sds member);
+
+    bool Delete(sds ele);
+
+    size_t Size() const {
+      return zsl->length;
+    }
+
+    size_t MallocSize() const;
+
+    bool Reserve(size_t sz) {
+      return dictExpand(dict, 1) == DICT_OK;
+    }
+
+    size_t DeleteRangeByRank(unsigned start, unsigned end) {
+      return zslDeleteRangeByRank(zsl, start + 1, end + 1, dict);
+    }
+
+    size_t DeleteRangeByScore(const zrangespec& range) {
+      return zslDeleteRangeByScore(zsl, &range, dict);
+    }
+
+    size_t DeleteRangeByLex(const zlexrangespec& range) {
+      return zslDeleteRangeByLex(zsl, &range, dict);
+    }
+
+    ScoredArray PopTopScores(unsigned count, bool reverse);
+
+    uint8_t* ToListPack() const;
+
+    std::optional<double> GetScore(sds ele) const;
+    std::optional<unsigned> GetRank(sds ele, bool reverse) const;
+
+    ScoredArray GetRange(const zrangespec& r, unsigned offs, unsigned len, bool rev) const;
+    ScoredArray GetLexRange(const zlexrangespec& r, unsigned o, unsigned l, bool rev) const;
+
+    size_t Count(const zrangespec& range) const;
+    size_t LexCount(const zlexrangespec& range) const;
+
+    // Runs cb for each element in the range [start_rank, start_rank + len).
+    // Stops iteration if cb returns false. Returns false in this case.
+    bool Iterate(unsigned start_rank, unsigned len, bool reverse,
+                 absl::FunctionRef<bool(sds, double)> cb) const;
+  };
+
+  struct DfImpl {
+    ScoreMap* score_map = nullptr;
+    BPTree<uint64_t>* bptree = nullptr;  // just a stub for now.
+
+    void Init();
+
+    void Free();
+
+    int Add(double score, sds ele, int in_flags, int* out_flags, double* newscore);
+
+    bool Insert(double score, sds member);
+
+    bool Delete(sds ele);
+
+    size_t Size() const {
+      return score_map->Size();
+    }
+
+    size_t MallocSize() const {
+      return 0;
+    }
+
+    bool Reserve(size_t sz) {
+      return false;
+    }
+
+    size_t DeleteRangeByRank(unsigned start, unsigned end) {
+      return 0;
+    }
+
+    size_t DeleteRangeByScore(const zrangespec& range) {
+      return 0;
+    }
+
+    size_t DeleteRangeByLex(const zlexrangespec& range) {
+      return 0;
+    }
+
+    ScoredArray PopTopScores(unsigned count, bool reverse);
+
+    uint8_t* ToListPack() const;
+
+    std::optional<double> GetScore(sds ele) const;
+    std::optional<unsigned> GetRank(sds ele, bool reverse) const;
+
+    ScoredArray GetRange(const zrangespec& r, unsigned offs, unsigned len, bool rev) const;
+    ScoredArray GetLexRange(const zlexrangespec& r, unsigned o, unsigned l, bool rev) const;
+
+    size_t Count(const zrangespec& range) const;
+    size_t LexCount(const zlexrangespec& range) const;
+
+    // Runs cb for each element in the range [start_rank, start_rank + len).
+    // Stops iteration if cb returns false. Returns false in this case.
+    bool Iterate(unsigned start_rank, unsigned len, bool reverse,
+                 absl::FunctionRef<bool(sds, double)> cb) const;
+  };
+
+  std::variant<RdImpl, DfImpl> impl_;
 };
 
 }  // namespace detail

--- a/src/core/sorted_map.h
+++ b/src/core/sorted_map.h
@@ -49,15 +49,11 @@ class SortedMap {
   static std::unique_ptr<SortedMap> FromListPack(const uint8_t* lp);
 
   size_t Size() const {
-    return std::visit(Overload{[](const RdImpl& impl) { return impl.Size(); },
-                               [](const DfImpl& impl) { return impl.Size(); }},
-                      impl_);
+    return std::visit(Overload{[](const auto& impl) { return impl.Size(); }}, impl_);
   }
 
   bool Reserve(size_t sz) {
-    return std::visit(Overload{[&](RdImpl& impl) { return impl.Reserve(sz); },
-                               [&](DfImpl& impl) { return impl.Reserve(sz); }},
-                      impl_);
+    return std::visit(Overload{[&](auto& impl) { return impl.Reserve(sz); }}, impl_);
   }
 
   // Interface equivalent to zsetAdd.
@@ -66,27 +62,20 @@ class SortedMap {
   // newscore is set to the new score of the element only if in_flags contains ZADD_IN_INCR.
   int Add(double score, sds ele, int in_flags, int* out_flags, double* newscore) {
     return std::visit(
-        Overload{[&](RdImpl& impl) { return impl.Add(score, ele, in_flags, out_flags, newscore); },
-                 [&](DfImpl& impl) { return impl.Add(score, ele, in_flags, out_flags, newscore); }},
+        Overload{[&](auto& impl) { return impl.Add(score, ele, in_flags, out_flags, newscore); }},
         impl_);
   }
 
   bool Insert(double score, sds member) {
-    return std::visit(Overload{[&](RdImpl& impl) { return impl.Insert(score, member); },
-                               [&](DfImpl& impl) { return impl.Insert(score, member); }},
-                      impl_);
+    return std::visit(Overload{[&](auto& impl) { return impl.Insert(score, member); }}, impl_);
   }
 
   uint8_t* ToListPack() const {
-    return std::visit(Overload{[](const RdImpl& impl) { return impl.ToListPack(); },
-                               [](const DfImpl& impl) { return impl.ToListPack(); }},
-                      impl_);
+    return std::visit(Overload{[](const auto& impl) { return impl.ToListPack(); }}, impl_);
   }
 
   size_t MallocSize() const {
-    return std::visit(Overload{[](const RdImpl& impl) { return impl.MallocSize(); },
-                               [](const DfImpl& impl) { return impl.MallocSize(); }},
-                      impl_);
+    return std::visit(Overload{[](const auto& impl) { return impl.MallocSize(); }}, impl_);
   }
 
   // TODO: to get rid of this method.
@@ -95,75 +84,57 @@ class SortedMap {
   }
 
   size_t DeleteRangeByRank(unsigned start, unsigned end) {
-    return std::visit(Overload{[&](RdImpl& impl) { return impl.DeleteRangeByRank(start, end); },
-                               [&](DfImpl& impl) { return impl.DeleteRangeByRank(start, end); }},
+    return std::visit(Overload{[&](auto& impl) { return impl.DeleteRangeByRank(start, end); }},
                       impl_);
   }
 
   size_t DeleteRangeByScore(const zrangespec& range) {
-    return std::visit(Overload{[&](RdImpl& impl) { return impl.DeleteRangeByScore(range); },
-                               [&](DfImpl& impl) { return impl.DeleteRangeByScore(range); }},
-                      impl_);
+    return std::visit(Overload{[&](auto& impl) { return impl.DeleteRangeByScore(range); }}, impl_);
   }
 
   size_t DeleteRangeByLex(const zlexrangespec& range) {
-    return std::visit(Overload{[&](RdImpl& impl) { return impl.DeleteRangeByLex(range); },
-                               [&](DfImpl& impl) { return impl.DeleteRangeByLex(range); }},
-                      impl_);
+    return std::visit(Overload{[&](auto& impl) { return impl.DeleteRangeByLex(range); }}, impl_);
   }
 
   // returns true if the element was deleted.
   bool Delete(sds ele) {
-    return std::visit(Overload{[&](RdImpl& impl) { return impl.Delete(ele); },
-                               [&](DfImpl& impl) { return impl.Delete(ele); }},
-                      impl_);
+    return std::visit(Overload{[&](auto& impl) { return impl.Delete(ele); }}, impl_);
   }
 
   std::optional<double> GetScore(sds ele) const {
-    return std::visit(Overload{[&](const RdImpl& impl) { return impl.GetScore(ele); },
-                               [&](const DfImpl& impl) { return impl.GetScore(ele); }},
-                      impl_);
+    return std::visit(Overload{[&](const auto& impl) { return impl.GetScore(ele); }}, impl_);
   }
 
   std::optional<unsigned> GetRank(sds ele, bool reverse) const {
-    return std::visit(Overload{[&](const RdImpl& impl) { return impl.GetRank(ele, reverse); },
-                               [&](const DfImpl& impl) { return impl.GetRank(ele, reverse); }},
+    return std::visit(Overload{[&](const auto& impl) { return impl.GetRank(ele, reverse); }},
                       impl_);
   }
 
   ScoredArray GetRange(const zrangespec& range, unsigned offset, unsigned limit,
                        bool reverse) const {
     return std::visit(
-        Overload{[&](const RdImpl& impl) { return impl.GetRange(range, offset, limit, reverse); },
-                 [&](const DfImpl& impl) { return impl.GetRange(range, offset, limit, reverse); }},
+        Overload{[&](const auto& impl) { return impl.GetRange(range, offset, limit, reverse); }},
         impl_);
   }
 
   ScoredArray GetLexRange(const zlexrangespec& range, unsigned offset, unsigned limit,
                           bool reverse) const {
     return std::visit(
-        Overload{
-            [&](const RdImpl& impl) { return impl.GetLexRange(range, offset, limit, reverse); },
-            [&](const DfImpl& impl) { return impl.GetLexRange(range, offset, limit, reverse); }},
+        Overload{[&](const auto& impl) { return impl.GetLexRange(range, offset, limit, reverse); }},
         impl_);
   }
 
   ScoredArray PopTopScores(unsigned count, bool reverse) {
-    return std::visit(Overload{[&](RdImpl& impl) { return impl.PopTopScores(count, reverse); },
-                               [&](DfImpl& impl) { return impl.PopTopScores(count, reverse); }},
+    return std::visit(Overload{[&](auto& impl) { return impl.PopTopScores(count, reverse); }},
                       impl_);
   }
 
   size_t Count(const zrangespec& range) const {
-    return std::visit(Overload{[&](const RdImpl& impl) { return impl.Count(range); },
-                               [&](const DfImpl& impl) { return impl.Count(range); }},
-                      impl_);
+    return std::visit(Overload{[&](const auto& impl) { return impl.Count(range); }}, impl_);
   }
 
   size_t LexCount(const zlexrangespec& range) const {
-    return std::visit(Overload{[&](const RdImpl& impl) { return impl.LexCount(range); },
-                               [&](const DfImpl& impl) { return impl.LexCount(range); }},
-                      impl_);
+    return std::visit(Overload{[&](const auto& impl) { return impl.LexCount(range); }}, impl_);
   }
 
   // Runs cb for each element in the range [start_rank, start_rank + len).
@@ -171,8 +142,7 @@ class SortedMap {
   bool Iterate(unsigned start_rank, unsigned len, bool reverse,
                absl::FunctionRef<bool(sds, double)> cb) const {
     return std::visit(
-        Overload{[&](const RdImpl& impl) { return impl.Iterate(start_rank, len, reverse, cb); },
-                 [&](const DfImpl& impl) { return impl.Iterate(start_rank, len, reverse, cb); }},
+        Overload{[&](const auto& impl) { return impl.Iterate(start_rank, len, reverse, cb); }},
         impl_);
   }
 

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -525,7 +525,7 @@ TEST_F(ZSetFamilyTest, ZPopMax) {
 TEST_F(ZSetFamilyTest, ZAddPopCrash) {
   for (int i = 0; i < 129; ++i) {
     auto resp = Run({"zadd", "key", absl::StrCat(i), absl::StrCat("element:", i)});
-    EXPECT_THAT(resp, IntArg(1));
+    EXPECT_THAT(resp, IntArg(1)) << i;
   }
 
   auto resp = Run({"zpopmin", "key"});


### PR DESCRIPTION
1. intoduce variant of Redis and Dragonfly implementation and wrap each operation with a dedicated dispatcher operator. The dragonfly implementation path is a noop and not implemented.

2. Introduce a very basic sorted_map_test around Add and move the unrelated old test from sorted_map_test to bptree_set_test.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->