### PR TITLE
test(server): test transaction locked keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,9 +103,9 @@ jobs:
           echo "Running tests with both --cluster_mode=emulated & --lock_on_hashtags"
           FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true ctest -V -L DFLY
 
-          ./dragonfly_test  --gtest_repeat=10
-          ./multi_test --multi_exec_mode=1 --gtest_repeat=10
-          ./multi_test --multi_exec_mode=3 --gtest_repeat=10
+          ./dragonfly_test
+          ./multi_test --multi_exec_mode=1
+          ./multi_test --multi_exec_mode=3
           # GLOG_logtostderr=1 GLOG_vmodule=transaction=1,engine_shard_set=1 CTEST_OUTPUT_ON_FAILURE=1 ninja server/test
   lint-test-chart:
     runs-on: ubuntu-latest

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -33,21 +33,6 @@ class ClusterFamilyTest : public BaseFamilyTest {
  protected:
   static constexpr string_view kInvalidConfiguration = "Invalid cluster configuration";
 
-  void ExpectConditionWithinTimeout(const std::function<bool()>& condition,
-                                    absl::Duration timeout = absl::Seconds(10)) {
-    absl::Time deadline = absl::Now() + timeout;
-
-    while (deadline > absl::Now()) {
-      if (condition()) {
-        break;
-      }
-      absl::SleepFor(absl::Milliseconds(10));
-    }
-
-    EXPECT_LE(absl::Now(), deadline)
-        << "Timeout of " << timeout << " reached when expecting condition";
-  }
-
   string GetMyId() {
     return RunAdmin({"dflycluster", "myid"}).GetString();
   }

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -817,12 +817,8 @@ TEST_F(MultiTest, TestLockedKeys) {
     EXPECT_THAT(Run({"exec"}), RespArray(ElementsAre("OK", "OK")));
   });
 
-  for (int i = 0; i < 1000; ++i) {
-    if (service_->IsLocked(0, "key1") && service_->IsLocked(0, "key2")) {
-      break;
-    }
-    ThisFiber::SleepFor(1ms);
-  }
+  ExpectConditionWithinTimeout(
+      [&]() { return service_->IsLocked(0, "key1") && service_->IsLocked(0, "key2"); });
 
   tx.Terminate();
   fb0.Join();

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -807,6 +807,11 @@ TEST_F(MultiTest, MultiLeavesTxQueue) {
 }
 
 TEST_F(MultiTest, TestLockedKeys) {
+  if (auto mode = absl::GetFlag(FLAGS_multi_exec_mode); mode != Transaction::LOCK_AHEAD) {
+    GTEST_SKIP() << "Skipped TestLockedKeys test because multi_exec_mode is not lock ahead";
+    return;
+  }
+
   TransactionSuspension tx;
   tx.Start();
 

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -38,6 +38,10 @@ class TestConnection : public facade::Connection {
   bool is_admin_ = false;
 };
 
+// The TransactionSuspension class is designed to facilitate the temporary suspension of commands
+// executions. When the 'start' method is invoked, it enforces the suspension of other
+// transactions by acquiring a global shard lock. Conversely, invoking the 'terminate' method
+// releases the global shard lock, enabling all transactions in the queue to resume execution.
 class TransactionSuspension {
  public:
   void Start();

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -12,6 +12,7 @@
 #include "io/io.h"
 #include "server/conn_context.h"
 #include "server/main_service.h"
+#include "server/transaction.h"
 #include "util/proactor_pool.h"
 
 namespace dfly {
@@ -35,6 +36,15 @@ class TestConnection : public facade::Connection {
  private:
   io::StringSink* sink_;
   bool is_admin_ = false;
+};
+
+class TransactionSuspension {
+ public:
+  void Start();
+  void Terminate();
+
+ private:
+  boost::intrusive_ptr<dfly::Transaction> transaction_;
 };
 
 class BaseFamilyTest : public ::testing::Test {

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -119,6 +119,8 @@ class BaseFamilyTest : public ::testing::Test {
                                                             size_t index) const;
 
   static absl::flat_hash_set<std::string> GetLastUsedKeys();
+  static void ExpectConditionWithinTimeout(const std::function<bool()>& condition,
+                                           absl::Duration timeout = absl::Seconds(10));
 
   static unsigned NumLocked();
 


### PR DESCRIPTION
1. Add test utility class that will add suspension to transaction execution.
2. Add test for locked keys in transaction
