### PR TITLE
fix(VersionMonitor): request to update on older version

### DIFF
--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -203,6 +203,10 @@ bool VersionMonitor::IsVersionOutdated(const std::string_view remote,
     if (remote_x > current_x) {
       return true;
     }
+
+    if (remote_x < current_x) {
+      return false;
+    }
   }
 
   return false;


### PR DESCRIPTION
Fix the improper log to update on an older version.

I  hardcode tested this locally with with the following:

1. remote = 1.8.0 curr = 1.7.0
2. remote = 1.8.0 curr = 1.8.0
3. remote = 1.8.0 curr = 1.8.1 