### PR TITLE
feat(server): SharedThreadLocal class

### DIFF
--- a/src/server/shared_thread_local.h
+++ b/src/server/shared_thread_local.h
@@ -1,0 +1,43 @@
+// Copyright 2023, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <memory>
+
+#include "server/engine_shard_set.h"
+#include "util/proactor_pool.h"
+
+namespace dfly {
+
+// Allows duplicating some class T to all threads via thread-local storage.
+// Calls to Set() will copy the shared_ptr<T> to thread_local variables, which can then be quickly
+// accessed without locks or atomic operations locally.
+// This class is thread-safe, but is not copyable nor movable.
+template <typename T> class SharedThreadLocal {
+ public:
+  static bool HasValue() {
+    return tl_t_ != nullptr;
+  }
+
+  static T* Get() {
+    return tl_t_.get();
+  }
+
+  static void Set(T t) {
+    Set(std::make_shared<T>(std::move(t)));
+  }
+
+  static void Set(std::shared_ptr<T> t) {
+    auto cb = [&](util::ProactorBase* pb) { tl_t_ = t; };
+    shard_set->pool()->AwaitFiberOnAll(std::move(cb));
+  }
+
+ private:
+  static thread_local std::shared_ptr<T> tl_t_;
+};
+
+template <typename T> thread_local std::shared_ptr<T> SharedThreadLocal<T>::tl_t_;
+
+}  // namespace dfly


### PR DESCRIPTION
This class allows setting a single T and view it from all threads in a lockless manner. It's a growingly common pattern, that can be generalized (as I did now).

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->