### PR TITLE
fix: Correctly read container limits when running under k8s

### DIFF
--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -562,9 +562,9 @@ void UpdateResourceLimitsIfInsideContainer(io::MemInfoData* mdata, size_t* max_t
 
     size_t temp = numeric_limits<size_t>::max();
 
-    if (file.has_value() && !absl::StartsWith(*file, "max")) {
-      CHECK(absl::SimpleAtoi(*file, &temp))
-          << "Failed in parsing cgroup limits, path: " << path << " (read: " << *file << ")";
+    if (file.has_value()) {
+      if (!absl::StartsWith(*file, "max"))
+        CHECK(absl::SimpleAtoi(*file, &temp)) << "Failed in parsing cgroup limits, path: " << path << " (read: " << *file << ")";
       read_something = true;
     }
 

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -520,9 +520,10 @@ error_code GetCGroupPath(string* memory_path, string* cpu_path) {
       return make_error_code(errc::not_supported);
     }
 
-    string_view res = absl::StripTrailingAsciiWhitespace(cgv.substr(pos + 1));
+    auto cgroup = string_view(cgv.c_str() + pos + 1);
+    string_view cgroup_stripped = absl::StripTrailingAsciiWhitespace(cgroup);
 
-    *memory_path = absl::StrCat("/sys/fs/cgroup/", res);
+    *memory_path = absl::StrCat("/sys/fs/cgroup/", cgroup_stripped);
     *cpu_path = *memory_path;  // in v2 the path to the cgroup is singular
   } else {
     for (const auto& sv : groups) {

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -565,7 +565,8 @@ void UpdateResourceLimitsIfInsideContainer(io::MemInfoData* mdata, size_t* max_t
 
     if (file.has_value()) {
       if (!absl::StartsWith(*file, "max"))
-        CHECK(absl::SimpleAtoi(*file, &temp)) << "Failed in parsing cgroup limits, path: " << path << " (read: " << *file << ")";
+        CHECK(absl::SimpleAtoi(*file, &temp))
+            << "Failed in parsing cgroup limits, path: " << path << " (read: " << *file << ")";
       read_something = true;
     }
 

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -581,8 +581,8 @@ void UpdateResourceLimitsIfInsideContainer(io::MemInfoData* mdata, size_t* max_t
 
   CHECK(!err) << "Unsupported cgroup v2 format, read:" << mem_path;
 
-  LOG(INFO) << "mem_path = " << mem_path;
-  LOG(INFO) << "cpu_path = " << cpu_path;
+  VLOG(1) << "mem_path = " << mem_path;
+  VLOG(1) << "cpu_path = " << cpu_path;
 
   /* Update memory limits */
 
@@ -658,8 +658,8 @@ void UpdateResourceLimitsIfInsideContainer(io::MemInfoData* mdata, size_t* max_t
     }
   };
 
-  read_cpu(base_cpu, max_threads);
-  read_cpu(cpu_path, max_threads);
+  read_cpu(base_cpu, max_threads);  // global cpu limits
+  read_cpu(cpu_path, max_threads);  // cgroup-specific limits
 
   if (!read_something) {
     LOG(ERROR) << "Failed in deducing any cgroup limits with paths " << mem_path << " and "


### PR DESCRIPTION
Closes #1683.

---

Background: In k8s, the memory/CPU cgroups which are reported by `/proc/self/cgroup` do not exist, i.e., the path `/sys/fs/cgroup/<resource>/<k8s cgroup>` doesn't exist. This causes Dragonfly to not read container limits at all, hence missing potential limits set by the user.

Fix: Begin by first reading `/sys/fs/cgroup/<resource>/<limit>`, which, in words, means "read the resource limits of the system". Later the path `/sys/fs/cgroup/<resource>/<specific group>` is read, updating the limit if needed. 