### PR TITLE
fix: allow integer tokens in search queries

### DIFF
--- a/src/core/search/parser.y
+++ b/src/core/search/parser.y
@@ -92,10 +92,14 @@ search_expr:
  | search_expr OR_OP search_expr        { $$ = AstLogicalNode(move($1), move($3), AstLogicalNode::OR); }
  | NOT_OP search_expr                   { $$ = AstNegateNode(move($2)); }
  | TERM                                 { $$ = AstTermNode(move($1)); }
+ | INT64                                { $$ = AstTermNode(to_string($1)); }
  | FIELD COLON field_cond               { $$ = AstFieldNode(move($1), move($3)); }
 
+// field_cond doesn't implicitly turn into field_cond_expr that can contain multi-term and/or expressions,
+// as those can only be contained inside parentheses
 field_cond:
   TERM                                  { $$ = AstTermNode(move($1)); }
+  | INT64                               { $$ = AstTermNode(to_string($1)); }
   | NOT_OP field_cond                   { $$ = AstNegateNode(move($2)); }
   | LPAREN field_cond_expr RPAREN       { $$ = move($2); }
   | LBRACKET INT64 INT64 RBRACKET       { $$ = AstRangeNode(move($2), move($3)); }
@@ -107,10 +111,13 @@ field_cond_expr:
   | field_cond_expr OR_OP field_cond_expr         { $$ = AstLogicalNode(move($1), move($3), AstLogicalNode::OR); }
   | NOT_OP field_cond_expr                        { $$ = AstNegateNode(move($2)); };
   | TERM                                          { $$ = AstTermNode(move($1)); }
+  | INT64                                         { $$ = AstTermNode(to_string($1)); }
 
 tag_list:
   TERM                       { $$ = AstTagsNode(move($1)); }
+  | INT64                    { $$ = AstTagsNode(to_string($1)); }
   | tag_list OR_OP TERM      { $$ = AstTagsNode(move($1), move($3)); }
+  | tag_list OR_OP INT64     { $$ = AstTagsNode(move($1), to_string($3)); }
 
 %%
 

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -315,6 +315,17 @@ TEST_F(SearchParserTest, CheckTag) {
   EXPECT_TRUE(Check()) << GetError();
 }
 
+TEST_F(SearchParserTest, IntegerTerms) {
+  PrepareSchema({{{"status", Schema::TAG}, {"title", Schema::TEXT}}});
+
+  PrepareQuery("@status:{1} @title:33");
+
+  ExpectAll(Map{{"status", "1"}, {"title", "33 cars on the road"}});
+  ExpectNone(Map{{"status", "0"}, {"title", "22 trains on the tracks"}});
+
+  EXPECT_TRUE(Check()) << GetError();
+}
+
 TEST_F(SearchParserTest, SimpleKnn) {
   Schema schema{{{"even", Schema::TAG}, {"pos", Schema::VECTOR}}};
   FieldIndices indices{schema};


### PR DESCRIPTION
Makes it possible to include integers into search, `@status:1` is a common query I've seen where the status field is text/tag. I first though it can be somehow solved on the lexer level by making the int64 implicitly convertible to term, but it seems like its not easy doable with bison