### PR TITLE
security: Fix the password hashing in UserRegistry.

### DIFF
--- a/src/server/acl/user.cc
+++ b/src/server/acl/user.cc
@@ -4,9 +4,20 @@
 
 #include "server/acl/user.h"
 
-#include <xxhash.h>
+#include <openssl/sha.h>
 
 namespace dfly {
+
+namespace {
+std::string StringSHA256(std::string_view password) {
+  std::string hash;
+  hash.resize(SHA256_DIGEST_LENGTH);
+  SHA256(reinterpret_cast<const unsigned char*>(password.data()), password.size(),
+         reinterpret_cast<unsigned char*>(hash.data()));
+  return hash;
+}
+
+}  // namespace
 
 User::User() {
   // acl_categories_ = AclCat::ACL_CATEGORY_ADMIN;
@@ -14,7 +25,7 @@ User::User() {
 
 void User::Update(UpdateRequest&& req) {
   if (req.password) {
-    SetPassword(*req.password);
+    SetPasswordHash(*req.password);
   }
 
   if (req.plus_acl_categories) {
@@ -30,19 +41,19 @@ void User::Update(UpdateRequest&& req) {
   }
 }
 
-void User::SetPassword(std::string_view password) {
-  password_ = HashPassword(password);
+void User::SetPasswordHash(std::string_view password) {
+  password_hash_ = StringSHA256(password);
 }
 
 bool User::HasPassword(std::string_view password) const {
-  if (!password_) {
+  if (!password_hash_) {
     if (password == "nopass") {
       return true;
     }
     return false;
   }
   // hash password and compare
-  return *password_ == HashPassword(password);
+  return *password_hash_ == StringSHA256(password);
 }
 
 void User::SetAclCategories(uint64_t cat) {
@@ -68,10 +79,6 @@ void User::SetIsActive(bool is_active) {
 
 bool User::IsActive() const {
   return is_active_;
-}
-
-uint32_t User::HashPassword(std::string_view password) const {
-  return XXH3_64bits(password.data(), password.size());
 }
 
 }  // namespace dfly

--- a/src/server/acl/user.h
+++ b/src/server/acl/user.h
@@ -147,15 +147,12 @@ class User final {
   // For is_active flag
   void SetIsActive(bool is_active);
 
-  // Helper function for hashing passwords
-  uint32_t HashPassword(std::string_view password) const;
-
   // For passwords
-  void SetPassword(std::string_view password);
+  void SetPasswordHash(std::string_view password);
 
   // when optional is empty, the special `nopass` password is implied
   // password hashed with xx64
-  std::optional<uint64_t> password_;
+  std::optional<std::string> password_hash_;
   uint32_t acl_categories_{AclCat::ACL_CATEGORY_NONE};
 
   // we have at least 221 commands including a bunch of subcommands


### PR DESCRIPTION
The hash function was trimming the hash state to 32 bits, so it could be trivially brute forced after 4 billion attempts. XXH3 is also not a cryptographic hash which means it's generally not safe to use in this context.

SHA256 is safe and is also what Redis are using, it looks as if they're also allowing to set the password hash directly. So let's use this instead.
