### PR TITLE
feat: introduce partial DfImpl implementation for sorted_map

### DIFF
--- a/src/core/bptree_set_test.cc
+++ b/src/core/bptree_set_test.cc
@@ -225,61 +225,80 @@ TEST_F(BPTreeSetTest, Iterate) {
   FillTree(2);
 
   unsigned cnt = 0;
-  bptree_.Iterate(31, 543, [&](uint64_t val) {
-    ASSERT_EQ((31 + cnt) * 2, val);
+  bool res = bptree_.Iterate(31, 543, [&](uint64_t val) {
+    if ((31 + cnt) * 2 != val)
+      return false;
     ++cnt;
+    return true;
   });
   ASSERT_EQ(543 - 31 + 1, cnt);
+  ASSERT_TRUE(res);
 
   for (unsigned j = 0; j < 10; ++j) {
     cnt = 0;
     unsigned from = generator_() % kNumElems;
     unsigned to = from + generator_() % (kNumElems - from);
-    bptree_.Iterate(from, to, [&](uint64_t val) {
-      ASSERT_EQ((from + cnt) * 2, val) << from << " " << to << " " << cnt;
+    res = bptree_.Iterate(from, to, [&](uint64_t val) {
+      if ((from + cnt) * 2 != val)
+        return false;
       ++cnt;
+      return true;
     });
+
     ASSERT_EQ(to - from + 1, cnt);
+    ASSERT_TRUE(res);
   }
 
   // Reverse iteration
   cnt = 0;
-  bptree_.IterateReverse(5845, 6849, [&](uint64_t val) {
-    ASSERT_EQ((6849 - cnt) * 2, val);
+  res = bptree_.IterateReverse(5845, 6849, [&](uint64_t val) {
+    if ((6849 - cnt) * 2 != val)
+      return false;
     ++cnt;
+    return true;
   });
   ASSERT_EQ(6849 - 5845 + 1, cnt);
+  ASSERT_TRUE(res);
 
   for (unsigned j = 0; j < 10; ++j) {
     cnt = 0;
     unsigned from = generator_() % kNumElems;
     unsigned to = from + generator_() % (kNumElems - from);
-    bptree_.IterateReverse(from, to, [&](uint64_t val) {
-      ASSERT_EQ((to - cnt) * 2, val) << from << " " << to << " " << cnt;
+    res = bptree_.IterateReverse(from, to, [&](uint64_t val) {
+      if ((to - cnt) * 2 != val)
+        return false;
       ++cnt;
+      return true;
     });
     ASSERT_EQ(to - from + 1, cnt);
+    ASSERT_TRUE(res);
   }
 }
 
-TEST_F(BPTreeSetTest, LowerBound) {
+TEST_F(BPTreeSetTest, Ranges) {
   FillTree(2);
 
-  auto path = bptree_.LowerBound(31);
+  auto path = bptree_.GEQ(31);
   EXPECT_EQ(32, path.Terminal());
 
-  path = bptree_.LowerBound(32);
+  path = bptree_.GEQ(32);
   EXPECT_EQ(32, path.Terminal());
 
-  path = bptree_.LowerBound(13998);
+  path = bptree_.GEQ(13998);
   EXPECT_EQ(13998, path.Terminal());
 
-  path = bptree_.LowerBound(14000);
+  path = bptree_.LEQ(14000);
+  EXPECT_EQ(13998, path.Terminal());
+
+  path = bptree_.GEQ(14000);
   EXPECT_EQ(0, path.Depth());
 
   ASSERT_TRUE(bptree_.Delete(0));
-  path = bptree_.LowerBound(0);
+  path = bptree_.GEQ(0);
   EXPECT_EQ(2, path.Terminal());
+
+  path = bptree_.LEQ(1);
+  EXPECT_TRUE(path.Empty());
 }
 
 TEST_F(BPTreeSetTest, DeleteRangeRank) {

--- a/src/core/score_map.h
+++ b/src/core/score_map.h
@@ -87,6 +87,10 @@ class ScoreMap : public DenseSet {
 
   bool Erase(std::string_view s1);
 
+  bool Erase(sds s1) {
+    return EraseInternal(s1, 0);
+  }
+
   /// @brief  Returns value of the key or nullptr if key not found.
   /// @param key
   /// @return sds

--- a/src/core/sorted_map.h
+++ b/src/core/sorted_map.h
@@ -141,9 +141,8 @@ class SortedMap {
   // Stops iteration if cb returns false. Returns false in this case.
   bool Iterate(unsigned start_rank, unsigned len, bool reverse,
                absl::FunctionRef<bool(sds, double)> cb) const {
-    return std::visit(
-        Overload{[&](const auto& impl) { return impl.Iterate(start_rank, len, reverse, cb); }},
-        impl_);
+    return std::visit([&](const auto& impl) { return impl.Iterate(start_rank, len, reverse, cb); },
+                      impl_);
   }
 
  private:
@@ -236,25 +235,15 @@ class SortedMap {
       return score_map->Size();
     }
 
-    size_t MallocSize() const {
-      return 0;
-    }
+    size_t MallocSize() const;
 
-    bool Reserve(size_t sz) {
-      return false;
-    }
+    bool Reserve(size_t sz);
 
-    size_t DeleteRangeByRank(unsigned start, unsigned end) {
-      return 0;
-    }
+    size_t DeleteRangeByRank(unsigned start, unsigned end);
 
-    size_t DeleteRangeByScore(const zrangespec& range) {
-      return 0;
-    }
+    size_t DeleteRangeByScore(const zrangespec& range);
 
-    size_t DeleteRangeByLex(const zlexrangespec& range) {
-      return 0;
-    }
+    size_t DeleteRangeByLex(const zlexrangespec& range);
 
     ScoredArray PopTopScores(unsigned count, bool reverse);
 

--- a/src/core/sorted_map_test.cc
+++ b/src/core/sorted_map_test.cc
@@ -4,6 +4,7 @@
 
 #include "core/sorted_map.h"
 
+#include <gmock/gmock.h>
 #include <mimalloc.h>
 
 #include "base/gtest.h"
@@ -15,6 +16,9 @@ extern "C" {
 }
 
 using namespace std;
+using testing::ElementsAre;
+using testing::Pair;
+using testing::StrEq;
 
 namespace dfly {
 
@@ -76,7 +80,7 @@ TEST_F(SortedMapTest, Scan) {
   EXPECT_EQ(972, cnt);
 }
 
-TEST_F(SortedMapTest, Insert) {
+TEST_F(SortedMapTest, InsertPop) {
   SortedMap sm(&mr_);
   for (unsigned i = 0; i < 256; ++i) {
     sds s = sdsempty();
@@ -84,6 +88,62 @@ TEST_F(SortedMapTest, Insert) {
     s = sdscatfmt(s, "a%u", i);
     ASSERT_TRUE(sm.Insert(1000, s));
   }
+
+  vector<sds> vec;
+  bool res = sm.Iterate(1, 2, false, [&](sds ele, double score) {
+    vec.push_back(ele);
+    return true;
+  });
+  EXPECT_TRUE(res);
+  EXPECT_THAT(vec, ElementsAre(StrEq("a1"), StrEq("a10")));
+
+  sds s = sdsnew("a1");
+  EXPECT_EQ(1, sm.GetRank(s, false));
+  EXPECT_EQ(254, sm.GetRank(s, true));
+  sdsfree(s);
+
+  auto top_scores = sm.PopTopScores(3, false);
+  EXPECT_THAT(top_scores, ElementsAre(Pair(StrEq("a0"), 1000), Pair(StrEq("a1"), 1000),
+                                      Pair(StrEq("a10"), 1000)));
+  top_scores = sm.PopTopScores(3, true);
+  EXPECT_THAT(top_scores, ElementsAre(Pair(StrEq("a99"), 1000), Pair(StrEq("a98"), 1000),
+                                      Pair(StrEq("a97"), 1000)));
+}
+
+TEST_F(SortedMapTest, ScoreRanges) {
+  SortedMap sm(&mr_);
+
+  for (unsigned i = 0; i < 10; ++i) {
+    sds s = sdsempty();
+
+    s = sdscatfmt(s, "a%u", i);
+    ASSERT_TRUE(sm.Insert(1, s));
+  }
+
+  for (unsigned i = 0; i < 10; ++i) {
+    sds s = sdsempty();
+
+    s = sdscatfmt(s, "b%u", i);
+    ASSERT_TRUE(sm.Insert(2, s));
+  }
+
+  zrangespec range;
+  range.max = 5;
+  range.min = 1;
+  range.maxex = 0;
+  range.minex = 0;
+  EXPECT_EQ(20, sm.Count(range));
+
+  range.minex = 1;  // exclude all the "1" scores.
+  EXPECT_EQ(10, sm.Count(range));
+
+  range.max = 1;
+  range.minex = 0;
+  range.min = -HUGE_VAL;
+  EXPECT_EQ(10, sm.Count(range));
+
+  range.maxex = 1;
+  EXPECT_EQ(0, sm.Count(range));
 }
 
 }  // namespace dfly


### PR DESCRIPTION
Specifically add comparison operator that supports lex mode, score mode and infinity abstractions for both modes.

Also, introduce LEQ/GEQ range queries for bptree_set.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->