### PR TITLE
chore: Mark slow pytests as 'slow' so they can be excluded.

### DIFF
--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -37,6 +37,7 @@ replication_cases = [
 
 
 @pytest.mark.asyncio
+@pytest.mark.slow
 @pytest.mark.parametrize("t_master, t_replicas, seeder_config, from_admin_port", replication_cases)
 async def test_replication_all(
     df_local_factory, df_seeder_factory, t_master, t_replicas, seeder_config, from_admin_port
@@ -292,6 +293,7 @@ master_crash_cases = [
 
 
 @pytest.mark.asyncio
+@pytest.mark.slow
 @pytest.mark.parametrize("t_master, t_replicas, n_random_crashes, n_keys", master_crash_cases)
 async def test_disconnect_master(
     df_local_factory, df_seeder_factory, t_master, t_replicas, n_random_crashes, n_keys
@@ -364,6 +366,7 @@ rotating_master_cases = [(4, [4, 4, 4, 4], dict(keys=2_000, dbcount=4))]
 
 
 @pytest.mark.asyncio
+@pytest.mark.slow
 @pytest.mark.parametrize("t_replica, t_masters, seeder_config", rotating_master_cases)
 async def test_rotating_masters(
     df_local_factory, df_seeder_factory, t_replica, t_masters, seeder_config
@@ -404,6 +407,7 @@ async def test_rotating_masters(
 
 
 @pytest.mark.asyncio
+@pytest.mark.slow
 async def test_cancel_replication_immediately(df_local_factory, df_seeder_factory):
     """
     Issue 40 replication commands randomally distributed over 10 seconds. This
@@ -1007,6 +1011,7 @@ More details in https://github.com/dragonflydb/dragonfly/issues/1231
 
 
 @pytest.mark.asyncio
+@pytest.mark.slow
 async def test_flushall_in_full_sync(df_local_factory, df_seeder_factory):
     master = df_local_factory.create(port=BASE_PORT, proactor_threads=4, logtostdout=True)
     replica = df_local_factory.create(port=BASE_PORT + 1, proactor_threads=2, logtostdout=True)

--- a/tests/dragonfly/sentinel_test.py
+++ b/tests/dragonfly/sentinel_test.py
@@ -137,6 +137,7 @@ def sentinel(tmp_dir, port_picker) -> Sentinel:
 
 
 @pytest.mark.asyncio
+@pytest.mark.slow
 async def test_failover(df_local_factory, sentinel, port_picker):
     master = df_local_factory.create(port=sentinel.initial_master_port)
     replica = df_local_factory.create(port=port_picker.get_available_port())
@@ -202,6 +203,7 @@ async def test_failover(df_local_factory, sentinel, port_picker):
 
 
 @pytest.mark.asyncio
+@pytest.mark.slow
 async def test_master_failure(df_local_factory, sentinel, port_picker):
     master = df_local_factory.create(port=sentinel.initial_master_port)
     replica = df_local_factory.create(port=port_picker.get_available_port())

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -44,6 +44,7 @@ class TestRdbSnapshot(SnapshotTestBase):
         super().setup(tmp_dir)
 
     @pytest.mark.asyncio
+    @pytest.mark.slow
     async def test_snapshot(self, df_seeder_factory, async_client, df_server):
         seeder = df_seeder_factory.create(port=df_server.port, **SEEDER_ARGS)
         await seeder.run(target_deviation=0.1)
@@ -67,6 +68,7 @@ class TestRdbSnapshotExactFilename(SnapshotTestBase):
         super().setup(tmp_dir)
 
     @pytest.mark.asyncio
+    @pytest.mark.slow
     async def test_snapshot(self, df_seeder_factory, async_client, df_server):
         seeder = df_seeder_factory.create(port=df_server.port, **SEEDER_ARGS)
         await seeder.run(target_deviation=0.1)
@@ -91,6 +93,7 @@ class TestDflySnapshot(SnapshotTestBase):
         self.tmp_dir = tmp_dir
 
     @pytest.mark.asyncio
+    @pytest.mark.slow
     async def test_snapshot(self, df_seeder_factory, async_client, df_server):
         seeder = df_seeder_factory.create(port=df_server.port, **SEEDER_ARGS)
         await seeder.run(target_deviation=0.1)
@@ -157,6 +160,7 @@ class TestPeriodicSnapshot(SnapshotTestBase):
         super().setup(tmp_dir)
 
     @pytest.mark.asyncio
+    @pytest.mark.slow
     async def test_snapshot(self, df_seeder_factory, df_server):
         seeder = df_seeder_factory.create(
             port=df_server.port, keys=10, multi_transaction_probability=0
@@ -178,6 +182,7 @@ class TestCronPeriodicSnapshot(SnapshotTestBase):
         super().setup(tmp_dir)
 
     @pytest.mark.asyncio
+    @pytest.mark.slow
     async def test_snapshot(self, df_seeder_factory, df_server):
         seeder = df_seeder_factory.create(
             port=df_server.port, keys=10, multi_transaction_probability=0
@@ -217,6 +222,7 @@ class TestDflySnapshotOnShutdown(SnapshotTestBase):
         self.tmp_dir = tmp_dir
 
     @pytest.mark.asyncio
+    @pytest.mark.slow
     async def test_snapshot(self, df_seeder_factory, df_server):
         seeder = df_seeder_factory.create(port=df_server.port, **SEEDER_ARGS)
         await seeder.run(target_deviation=0.1)

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -5,3 +5,5 @@ log_date_format = %Y-%m-%d %H:%M:%S
 log_file_level=DEBUG
 log_cli = true
 asyncio_mode=auto
+markers =
+  slow: marks tests as slow (deselect with '-m "not slow"')


### PR DESCRIPTION
Marked every test running over 10s as 'slow'.

All the tests together - 10:13, only the fast tests - 2:40.