### PR TITLE
fix(AclFamily): commands parsing and error handling

### DIFF
--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -37,6 +37,10 @@ static std::string AclToString(uint32_t acl_category) {
   return tmp;
 }
 
+void AclFamily::Acl(CmdArgList args, ConnectionContext* cntx) {
+  (*cntx)->SendError("Wrong number of arguments for acl command");
+}
+
 void AclFamily::List(CmdArgList args, ConnectionContext* cntx) {
   const auto registry_with_lock = ServerState::tlocal()->user_registry->GetRegistryWithLock();
   const auto& registry = registry_with_lock.registry;
@@ -69,7 +73,8 @@ using CI = dfly::CommandId;
 // easy to handle that case explicitly in `DispatchCommand`.
 
 void AclFamily::Register(dfly::CommandRegistry* registry) {
-  *registry << CI{"ACL LIST", CO::ADMIN | CO::NOSCRIPT | CO::LOADING, 0, 0, 0, 0, acl::kList}.HFUNC(
+  *registry << CI{"ACL", CO::NOSCRIPT | CO::LOADING, 0, 0, 0, 0, acl::kList}.HFUNC(Acl);
+  *registry << CI{"ACL LIST", CO::ADMIN | CO::NOSCRIPT | CO::LOADING, 1, 0, 0, 0, acl::kList}.HFUNC(
       List);
 }
 

--- a/src/server/acl/acl_family.h
+++ b/src/server/acl/acl_family.h
@@ -17,6 +17,7 @@ class AclFamily {
   static void Register(CommandRegistry* registry);
 
  private:
+  static void Acl(CmdArgList args, ConnectionContext* cntx);
   static void List(CmdArgList args, ConnectionContext* cntx);
 };
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1481,6 +1481,9 @@ static std::string FullAclCommandFromArgs(CmdArgList args) {
 std::pair<const CommandId*, CmdArgList> Service::FindCmd(CmdArgList args) const {
   const std::string_view command = facade::ToSV(args[0]);
   if (command == "ACL") {
+    if (args.size() == 1) {
+      return {registry_.Find(ArgS(args, 0)), args};
+    }
     return {registry_.Find(FullAclCommandFromArgs(args)), args.subspan(2)};
   }
 

--- a/tests/dragonfly/acl_family_test.py
+++ b/tests/dragonfly/acl_family_test.py
@@ -1,4 +1,5 @@
 import pytest
+import redis
 from redis import asyncio as aioredis
 from . import DflyInstanceFactory
 from .utility import disconnect_clients
@@ -9,6 +10,14 @@ async def test_acl_list_default_user(async_client):
     """
     make sure that the default created user is printed correctly
     """
+
+    # Bad input
+    with pytest.raises(redis.exceptions.ResponseError):
+        await async_client.execute_command("ACL LIST TEMP")
+
+    with pytest.raises(redis.exceptions.ResponseError):
+        await async_client.execute_command("ACL")
+
     result = await async_client.execute_command("ACL LIST")
     assert 1 == len(result)
     assert "user default on nopass +@all" == result[0]


### PR DESCRIPTION
1. Fixed broken `ACL` command (previously df crashed)
2. Fixed broken `ACL LIST STR` (previously passed, now prints an argument error)
3. Added tests