### PR TITLE
fix(ACL): Fix the iteration over categories loop in AclToString

### DIFF
--- a/src/server/acl/acl_commands_def.h
+++ b/src/server/acl/acl_commands_def.h
@@ -100,9 +100,10 @@ inline const absl::flat_hash_map<std::string_view, uint32_t> CATEGORY_INDEX_TABL
 // bit 1 at index 1
 // bit n at index n
 inline const std::vector<std::string> REVERSE_CATEGORY_INDEX_TABLE{
-    "KEYSPACE",   "READ",        "WRITE",     "SET",       "SORTED_SET", "LIST",
-    "HASH",       "STRING",      "BITMAP",    "HYPERLOG",  "GEO",        "STREAM",
-    "PUBSUB",     "ADMIN",       "FAST",      "SLOW",      "BLOCKING",   "DANGEROUS",
-    "CONNECTION", "TRANSACTION", "SCRIPTING", "FT_SEARCH", "THROTTLE",   "JSON"};
+    "KEYSPACE",  "READ",      "WRITE",     "SET",       "SORTED_SET", "LIST",        "HASH",
+    "STRING",    "BITMAP",    "HYPERLOG",  "GEO",       "STREAM",     "PUBSUB",      "ADMIN",
+    "FAST",      "SLOW",      "BLOCKING",  "DANGEROUS", "CONNECTION", "TRANSACTION", "SCRIPTING",
+    "_RESERVED", "_RESERVED", "_RESERVED", "_RESERVED", "_RESERVED",  "_RESERVED",   "_RESERVED",
+    "_RESERVED", "FT_SEARCH", "THROTTLE",  "JSON"};
 
 }  // namespace dfly::acl

--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -27,9 +27,9 @@ static std::string AclToString(uint32_t acl_category) {
   const std::string prefix = "+@";
   const std::string postfix = " ";
 
-  for (uint32_t step = 0, cat = 0; cat != JSON; cat = 1ULL << ++step) {
+  for (const auto& [cat_name, cat] : CATEGORY_INDEX_TABLE) {
     if (acl_category & cat) {
-      absl::StrAppend(&tmp, prefix, REVERSE_CATEGORY_INDEX_TABLE[step], postfix);
+      absl::StrAppend(&tmp, prefix, cat_name, postfix);
     }
   }
   tmp.erase(tmp.size());

--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -27,9 +27,10 @@ static std::string AclToString(uint32_t acl_category) {
   const std::string prefix = "+@";
   const std::string postfix = " ";
 
-  for (const auto& [cat_name, cat] : CATEGORY_INDEX_TABLE) {
-    if (acl_category & cat) {
-      absl::StrAppend(&tmp, prefix, cat_name, postfix);
+  for (uint32_t i = 0; i < 32; i++) {
+    uint32_t cat_bit = 1ULL << i;
+    if (acl_category & cat_bit) {
+      absl::StrAppend(&tmp, prefix, REVERSE_CATEGORY_INDEX_TABLE[i], postfix);
     }
   }
   tmp.erase(tmp.size());


### PR DESCRIPTION
The loop had several problems - it's using `step` to access the strings, but the bitfields is not contiguous (there's a jump between `SCRIPTING` and `FT_SEARCH`), and it has two off-by-ones (`KEYSPACE` and `JSON` are never checked for).
