### PR TITLE
feat(AclFamily): add AUTH for acl members

### DIFF
--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -117,15 +117,16 @@ std::variant<User::UpdateRequest, ErrorReply> ParseAclSetUser(CmdArgList args) {
   User::UpdateRequest req;
 
   for (auto arg : args) {
-    ToUpper(&arg);
-    const auto command = facade::ToSV(arg);
-    if (auto pass = MaybeParsePassword(command); pass) {
+    if (auto pass = MaybeParsePassword(facade::ToSV(arg)); pass) {
       if (req.password) {
         return ErrorReply("Only one password is allowed");
       }
       req.password = std::move(pass);
       continue;
     }
+
+    ToUpper(&arg);
+    const auto command = facade::ToSV(arg);
 
     if (auto status = MaybeParseStatus(command); status) {
       if (req.is_active) {

--- a/src/server/acl/user_registry.cc
+++ b/src/server/acl/user_registry.cc
@@ -5,6 +5,7 @@
 #include "server/acl/user_registry.h"
 
 #include "core/fibers.h"
+#include "facade/facade_types.h"
 #include "server/acl/acl_commands_def.h"
 
 namespace dfly::acl {
@@ -44,14 +45,15 @@ bool UserRegistry::IsUserActive(std::string_view username) const {
   return it->second.IsActive();
 }
 
-bool UserRegistry::AuthUser(std::string_view username, std::string_view password) const {
+std::pair<bool, const std::string_view> UserRegistry::AuthUser(std::string_view username,
+                                                               std::string_view password) const {
   std::shared_lock<util::SharedMutex> lock(mu_);
   const auto& user = registry_.find(username);
   if (user == registry_.end()) {
-    return false;
+    return {false, {}};
   }
 
-  return user->second.HasPassword(password);
+  return {user->second.HasPassword(password) && user->second.IsActive(), user->first};
 }
 
 UserRegistry::RegistryViewWithLock::RegistryViewWithLock(std::shared_lock<util::SharedMutex> mu,

--- a/src/server/acl/user_registry.h
+++ b/src/server/acl/user_registry.h
@@ -51,7 +51,8 @@ class UserRegistry {
 
   // Acquires a read lock
   // Used by Auth
-  bool AuthUser(std::string_view username, std::string_view password) const;
+  std::pair<bool, const std::string_view> AuthUser(std::string_view username,
+                                                   std::string_view password) const;
 
   // Helper class for accessing the registry with a ReadLock outside the scope of UserRegistry
   class RegistryViewWithLock {

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -196,6 +196,8 @@ class ConnectionContext : public facade::ConnectionContext {
   // Reference to a FlowInfo for this connection if from a master to a replica.
   FlowInfo* replication_flow;
 
+  std::optional<std::string_view> authed_username;
+
  private:
   void EnableMonitoring(bool enable) {
     subscriptions++;  // required to support the monitoring

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1498,8 +1498,16 @@ void ServerFamily::Auth(CmdArgList args, ConnectionContext* cntx) {
     return (*cntx)->SendError(kSyntaxErr);
   }
 
-  if (args.size() == 3) {
-    return (*cntx)->SendError("ACL is not supported yet");
+  if (args.size() == 2) {
+    const auto* registry = ServerState::tlocal()->user_registry;
+    std::string_view username = facade::ToSV(args[0]);
+    std::string_view password = facade::ToSV(args[1]);
+    auto [is_authorized, user] = registry->AuthUser(username, password);
+    if (is_authorized) {
+      cntx->authed_username = user;
+      return (*cntx)->SendOk();
+    }
+    return (*cntx)->SendError(absl::StrCat("Could not authorize user: ", username));
   }
 
   if (!cntx->req_auth) {

--- a/tests/dragonfly/acl_family_test.py
+++ b/tests/dragonfly/acl_family_test.py
@@ -55,3 +55,25 @@ async def test_acl_setuser(async_client):
     await async_client.execute_command("ACL SETUSER kostas +@all")
     result = await async_client.execute_command("ACL LIST")
     assert "user kostas on nopass +@ALL" in result
+
+
+@pytest.mark.asyncio
+async def test_acl_auth(async_client):
+    await async_client.execute_command("ACL SETUSER kostas >mypass")
+
+    with pytest.raises(redis.exceptions.ResponseError):
+        await async_client.execute_command("AUTH kostas wrong_pass")
+
+    # This should fail because user is inactive
+    with pytest.raises(redis.exceptions.ResponseError):
+        await async_client.execute_command("AUTH kostas mypass")
+
+    # Activate user
+    await async_client.execute_command("ACL SETUSER kostas ON")
+
+    result = await async_client.execute_command("AUTH kostas mypass")
+    result == "ok"
+
+    # Let's also try default
+    result = await async_client.execute_command("AUTH default nopass")
+    result == "ok"


### PR DESCRIPTION
1. Extends `AUTH` command to authenticate ACL users
2. Add tests