### PR TITLE
fix: Fix inconsistency when deleting dash entries

### DIFF
--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -1340,7 +1340,10 @@ auto StringFamily::OpMGet(bool fetch_mcflag, bool fetch_mcver, const Transaction
 
     dest.value = GetString(shard, it->second);
     if (fetch_mcflag) {
-      dest.mc_flag = db_slice.GetMCFlag(t->GetDbIndex(), it->first);
+      if (it->second.HasFlag()) {
+        dest.mc_flag = db_slice.GetMCFlag(t->GetDbIndex(), it->first);
+      }
+
       if (fetch_mcver) {
         dest.mc_ver = it.GetVersion();
       }


### PR DESCRIPTION
Partially addresses #1730.

Beforehand we removed entries from mcflag only inside DbSlice::Del function but we delete entries in other cases too (like expiration) and in this case we left dangling entries in mcflag table. The fix adds the deletion of mcflag entries into PerformDeletion function.

It by itself does not explain the crash but
dangling entries cause UB (because the keys are references to non-existent PrimeKeys) so maybe this somehow causes inconsistency where a key is not present in mcflags.

I am not sure I fixed the original issue but I surely fixed a corruption bug. In addition, I removed the redundant check fail and added error logs to follow up on this later.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->