### PR TITLE
fix: fix defrag stats

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -141,7 +141,7 @@ inline void FreeObjZset(unsigned encoding, void* ptr) {
   }
 }
 
-// Iterates over allocations of internal hash data structes and re-allocates
+// Iterates over allocations of internal hash data structures and re-allocates
 // them if their pages are underutilized.
 // Returns pointer to new object ptr and whether any re-allocations happened.
 pair<void*, bool> DefragHash(MemoryResource* mr, unsigned encoding, void* ptr, float ratio) {

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -59,13 +59,16 @@ class RobjWrapper {
     return std::string_view{reinterpret_cast<char*>(inner_obj_), sz_};
   }
 
+  // Try reducing memory fragmentation by re-allocating values from underutilized pages.
+  // Returns true if re-allocated.
   bool DefragIfNeeded(float ratio);
 
   // as defined in zset.h
   int ZsetAdd(double score, char* ele, int in_flags, int* out_flags, double* newscore);
 
  private:
-  bool Reallocate(MemoryResource* mr);
+  void ReallocateString(MemoryResource* mr);
+
   size_t InnerObjMallocUsed() const;
   void MakeInnerRoom(size_t current_cap, size_t desired, MemoryResource* mr);
 

--- a/src/core/compact_object_test.cc
+++ b/src/core/compact_object_test.cc
@@ -634,7 +634,7 @@ TEST_F(CompactObjectTest, DefragHash) {
 
   // Trigger re-allocation
   cobj_.InitRobj(OBJ_HASH, kEncodingListPack, target_lp);
-  cobj_.DefragIfNeeded(0.8);
+  CHECK(cobj_.DefragIfNeeded(0.8));
 
   // Check the pointer changes as the listpack needed defragmentation
   auto lp = (uint8_t*)cobj_.RObjPtr();

--- a/src/core/compact_object_test.cc
+++ b/src/core/compact_object_test.cc
@@ -634,11 +634,11 @@ TEST_F(CompactObjectTest, DefragHash) {
 
   // Trigger re-allocation
   cobj_.InitRobj(OBJ_HASH, kEncodingListPack, target_lp);
-  CHECK(cobj_.DefragIfNeeded(0.8));
+  ASSERT_TRUE(cobj_.DefragIfNeeded(0.8));
 
   // Check the pointer changes as the listpack needed defragmentation
   auto lp = (uint8_t*)cobj_.RObjPtr();
-  CHECK_NE(lp, target_lp);
+  EXPECT_NE(lp, target_lp) << "must have changed due to realloc";
 
   uint8_t* fptr = lpFirst(lp);
   for (size_t i = 0; i < 100; i++) {

--- a/src/core/string_map.h
+++ b/src/core/string_map.h
@@ -62,14 +62,18 @@ class StringMap : public DenseSet {
       return BreakToPair(ptr);
     }
 
-    void ReallocIfNeeded(float ratio) {
+    // Try reducing memory fragmentation of the value by re-allocating. Returns true if
+    // re-allocation happened.
+    bool ReallocIfNeeded(float ratio) {
       // Unwrap all links to correctly call SetObject()
       auto* ptr = curr_entry_;
       while (ptr->IsLink())
         ptr = ptr->AsLink();
 
       auto* obj = ptr->GetObject();
-      ptr->SetObject(static_cast<StringMap*>(owner_)->ReallocIfNeeded(obj, ratio));
+      auto [new_obj, realloced] = static_cast<StringMap*>(owner_)->ReallocIfNeeded(obj, ratio);
+      ptr->SetObject(new_obj);
+      return realloced;
     }
 
     iterator& operator++() {
@@ -115,8 +119,8 @@ class StringMap : public DenseSet {
 
  private:
   // Reallocate key and/or value if their pages are underutilized.
-  // Returns new object pointer (stays the same if utilization is enough).
-  sds ReallocIfNeeded(void* obj, float ratio);
+  // Returns new pointer (stays same if key utilization is enough) and if reallocation happened.
+  std::pair<sds, bool> ReallocIfNeeded(void* obj, float ratio);
 
   uint64_t Hash(const void* obj, uint32_t cookie) const final;
   bool ObjEqual(const void* left, const void* right, uint32_t right_cookie) const final;


### PR DESCRIPTION
Fixes a bug from the hash defrag PR: Successful re-allocations are not reported back. 

Should we count a hash re-allocation as one (currently doing so) or also count every internal re-allocation (each StringMap key, etc.)  ?