### PR TITLE
fix: fix index loading

### DIFF
--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -151,7 +151,7 @@ bool DocIndex::Matches(string_view key, unsigned obj_code) const {
 }
 
 ShardDocIndex::ShardDocIndex(shared_ptr<DocIndex> index)
-    : base_{index}, indices_{{}}, key_index_{} {
+    : base_{std::move(index)}, indices_{{}}, key_index_{} {
 }
 
 void ShardDocIndex::Rebuild(const OpArgs& op_args) {

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -11,6 +11,7 @@
 #include "base/logging.h"
 #include "server/engine_shard_set.h"
 #include "server/search/doc_accessors.h"
+#include "server/server_state.h"
 
 extern "C" {
 #include "redis/object.h"
@@ -150,10 +151,13 @@ bool DocIndex::Matches(string_view key, unsigned obj_code) const {
 }
 
 ShardDocIndex::ShardDocIndex(shared_ptr<DocIndex> index)
-    : base_{index}, indices_{index->schema}, key_index_{} {
+    : base_{index}, indices_{{}}, key_index_{} {
 }
 
-void ShardDocIndex::Init(const OpArgs& op_args) {
+void ShardDocIndex::Rebuild(const OpArgs& op_args) {
+  key_index_ = DocKeyIndex{};
+  indices_ = search::FieldIndices{base_->schema};
+
   auto cb = [this](string_view key, BaseAccessor* doc) { indices_.Add(key_index_.Add(key), doc); };
   TraverseAllMatching(*base_, op_args, cb);
 }
@@ -213,7 +217,11 @@ void ShardDocIndices::InitIndex(const OpArgs& op_args, std::string_view name,
                                 shared_ptr<DocIndex> index_ptr) {
   auto shard_index = make_unique<ShardDocIndex>(index_ptr);
   auto [it, _] = indices_.emplace(name, move(shard_index));
-  it->second->Init(op_args);
+
+  // Don't build while loading, shutting down, etc.
+  // After loading, indices are rebuilt separately
+  if (ServerState::tlocal()->gstate() == GlobalState::ACTIVE)
+    it->second->Rebuild(op_args);
 
   op_args.shard->db_slice().SetDocDeletionCallback(
       [this](string_view key, const DbContext& cntx, const PrimeValue& pv) {
@@ -233,6 +241,11 @@ bool ShardDocIndices::DropIndex(string_view name) {
 
   indices_.erase(it);
   return true;
+}
+
+void ShardDocIndices::RebuildAllIndices(const OpArgs& op_args) {
+  for (auto& [_, ptr] : indices_)
+    ptr->Rebuild(op_args);
 }
 
 vector<string> ShardDocIndices::GetIndexNames() const {

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -75,6 +75,7 @@ class ShardDocIndex {
   struct DocKeyIndex {
     DocId Add(std::string_view key);
     DocId Remove(std::string_view key);
+
     std::string_view Get(DocId id) const;
     size_t Size() const;
 
@@ -86,14 +87,15 @@ class ShardDocIndex {
   };
 
  public:
+  // Index must be rebuilt at least once after intialization
   ShardDocIndex(std::shared_ptr<DocIndex> index);
 
   // Perform search on all indexed documents and return results.
   SearchResult Search(const OpArgs& op_args, const SearchParams& params,
                       search::SearchAlgorithm* search_algo) const;
 
-  // Initialize index. Traverses all matching documents and assigns ids.
-  void Init(const OpArgs& op_args);
+  // Clears internal data. Traverses all matching documents and assigns ids.
+  void Rebuild(const OpArgs& op_args);
 
   // Return whether base index matches
   bool Matches(std::string_view key, unsigned obj_code) const;
@@ -114,10 +116,16 @@ class ShardDocIndices {
  public:
   // Get sharded document index by its name or nullptr if not found
   ShardDocIndex* GetIndex(std::string_view name);
-  // Init index: create shard local state for given index with given name
+
+  // Init index: create shard local state for given index with given name.
+  // Build if instance is in active state.
   void InitIndex(const OpArgs& op_args, std::string_view name, std::shared_ptr<DocIndex> index);
+
   // Drop index, return true if it existed and was dropped
   bool DropIndex(std::string_view name);
+
+  // Rebuild all indices
+  void RebuildAllIndices(const OpArgs& op_args);
 
   std::vector<std::string> GetIndexNames() const;
 


### PR DESCRIPTION
Now indices are built separately after they've been read.

1. Instead of splitting the Init/Rebuild steps, they could've been collected as strings and build fully after loading. But it would've made the dfs loading / search code more complex. Now they're created & validated & stored, but not populated with documents. 

2. Either way we'll need some kind of post-load controller. Alternatively we store the index definitions in all shards and all loading steps are fully independent

3. Index construction will be async at some point either way, so it will be enough just to notify the "async index creator" after loading that it can run

For now I hope this fix suffices 👀 
