### PR TITLE
feat(search): named return values

### DIFF
--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -23,13 +23,17 @@ struct TextIndex;
 struct SchemaField {
   enum FieldType { TAG, TEXT, NUMERIC, VECTOR };
 
-  std::string identifier;  // short alias name is stored only in schema
   FieldType type;
+  std::string short_name;  // equal to ident if none provided
 };
 
 // Describes the fields of an index
 struct Schema {
-  absl::flat_hash_map<std::string /*name*/, SchemaField> fields;
+  // List of fields by identifier.
+  absl::flat_hash_map<std::string /*identifier*/, SchemaField> fields;
+
+  // Mapping for short field names (aliases).
+  absl::flat_hash_map<std::string /* short name*/, std::string /*identifier*/> field_names;
 };
 
 // Collection of indices for all fields in schema

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -71,7 +71,7 @@ struct MockedDocument : public DocumentAccessor {
 Schema MakeSimpleSchema(initializer_list<pair<string_view, SchemaField::FieldType>> ilist) {
   Schema schema;
   for (auto [name, type] : ilist) {
-    schema.fields[name] = {string{name}, type};
+    schema.fields[name] = {type, string{name}};
   }
   return schema;
 }

--- a/src/server/search/doc_accessors.h
+++ b/src/server/search/doc_accessors.h
@@ -5,6 +5,10 @@
 #pragma once
 
 #include <absl/container/flat_hash_map.h>
+#include <absl/types/span.h>
+
+#include <string>
+#include <utility>
 
 #include "core/json_object.h"
 #include "core/search/search.h"
@@ -20,8 +24,12 @@ class StringMap;
 // behind a document interface for quering fields and serializing.
 // Field string_view's are only valid until the next is requested.
 struct BaseAccessor : public search::DocumentAccessor {
-  // Convert underlying type to a map<string, string> to be sent as a reply
-  virtual SearchDocData Serialize(search::Schema schema) const = 0;
+  // Convert the full underlying type to a map<string, string> to be sent as a reply
+  virtual SearchDocData Serialize(const search::Schema& schema) const = 0;
+
+  // Serialize selected fields
+  SearchDocData Serialize(const search::Schema& schema,
+                          const SearchParams::FieldAliasList& fields) const;
 };
 
 // Accessor for hashes stored with listpack
@@ -33,7 +41,7 @@ struct ListPackAccessor : public BaseAccessor {
 
   std::string_view GetString(std::string_view field) const override;
   search::FtVector GetVector(std::string_view field) const override;
-  SearchDocData Serialize(search::Schema schema) const override;
+  SearchDocData Serialize(const search::Schema& schema) const override;
 
  private:
   mutable std::array<uint8_t, 33> intbuf_[2];
@@ -47,7 +55,7 @@ struct StringMapAccessor : public BaseAccessor {
 
   std::string_view GetString(std::string_view field) const override;
   search::FtVector GetVector(std::string_view field) const override;
-  SearchDocData Serialize(search::Schema schema) const override;
+  SearchDocData Serialize(const search::Schema& schema) const override;
 
  private:
   StringMap* hset_;
@@ -62,7 +70,11 @@ struct JsonAccessor : public BaseAccessor {
 
   std::string_view GetString(std::string_view field) const override;
   search::FtVector GetVector(std::string_view field) const override;
-  SearchDocData Serialize(search::Schema schema) const override;
+  SearchDocData Serialize(const search::Schema& schema) const override;
+
+  // The JsonAccessor works with structured types and not plain strings, so an overload is needed
+  SearchDocData Serialize(const search::Schema& schema,
+                          const SearchParams::FieldAliasList& fields) const;
 
   static void RemoveFieldFromCache(std::string_view field);
 

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -93,8 +93,8 @@ string DocIndexInfo::BuildRestoreCommand() const {
     absl::StrAppend(&out, " PREFIX", " 1 ", base_index.prefix);
 
   absl::StrAppend(&out, " SCHEMA");
-  for (const auto& [fname, finfo] : base_index.schema.fields) {
-    absl::StrAppend(&out, " ", finfo.identifier, " AS ", fname, " ",
+  for (const auto& [fident, finfo] : base_index.schema.fields) {
+    absl::StrAppend(&out, " ", fident, " AS ", finfo.short_name, " ",
                     SearchFieldTypeToString(finfo.type));
   }
 
@@ -192,7 +192,10 @@ SearchResult ShardDocIndex::Search(const OpArgs& op_args, const SearchParams& pa
       continue;
     }
 
-    auto doc_data = GetAccessor(op_args.db_cntx, (*it)->second)->Serialize(base_->schema);
+    auto accessor = GetAccessor(op_args.db_cntx, (*it)->second);
+    auto doc_data = params.return_fields ? accessor->Serialize(base_->schema, *params.return_fields)
+                                         : accessor->Serialize(base_->schema);
+
     float score = search_results.knn_distances.empty() ? 0 : search_results.knn_distances[i];
     out.push_back(SerializedSearchDoc{string{key}, std::move(doc_data), score});
   }
@@ -228,8 +231,8 @@ bool ShardDocIndices::DropIndex(string_view name) {
 
   // Clean caches that might have data from this index
   auto info = it->second->GetInfo();
-  for (const auto& [_, field] : info.base_index.schema.fields)
-    JsonAccessor::RemoveFieldFromCache(field.identifier);
+  for (const auto& [fident, field] : info.base_index.schema.fields)
+    JsonAccessor::RemoveFieldFromCache(fident);
 
   indices_.erase(it);
   return true;

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -41,7 +41,15 @@ struct SearchParams {
   size_t limit_offset;
   size_t limit_total;
 
+  using FieldAliasList =
+      std::vector<std::pair<std::string /*identifier*/, std::string /*short name*/>>;
+  std::optional<FieldAliasList> return_fields;
+
   search::FtVector knn_vector;
+
+  bool IdsOnly() const {
+    return return_fields && return_fields->empty();
+  }
 };
 
 // Stores basic info about a document index.

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -134,7 +134,7 @@ optional<SearchParams> ParseSearchParamsOrReply(CmdArgList args, ConnectionConte
 
       alias_list = SearchParams::FieldAliasList{};
       while (alias_list->size() < num_fields) {
-        if (i++ >= args.size()) {
+        if (++i >= args.size()) {
           (*cntx)->SendError(kSyntaxErr);
           return nullopt;
         }


### PR DESCRIPTION
This PR adds the `RETURN` and `NOCONTENT` options to FT.Search queries. Most queries don't all the fields to be returned and only ask for specific ones (or even ids only). Sometimes a more complex path needs to be looked up and returned with a shorter name (alias/named return).