### PR TITLE
fix: extend CI running time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,12 @@ jobs:
             build-type: Debug
             compiler: {cxx: clang++, c: clang}
             cxx_flags: ""
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_CACHE_SIZE: 6G
+      SCCACHE_ERROR_LOG: /tmp/sccache_log.txt
+      SCCACHE_LOG: debug
 
     container:
       image: ghcr.io/romange/${{ matrix.container }}
@@ -92,7 +95,7 @@ jobs:
         run: |
           cd ${{github.workspace}}/build
           ninja src/all
-          ${SCCACHE_PATH} --show-stats
+          ${SCCACHE_PATH} --show-stats | tee $GITHUB_STEP_SUMMARY
 
       - name: Test
         run: |
@@ -114,6 +117,12 @@ jobs:
           ./multi_test --multi_exec_mode=1
           ./multi_test --multi_exec_mode=3
           # GLOG_logtostderr=1 GLOG_vmodule=transaction=1,engine_shard_set=1 CTEST_OUTPUT_ON_FAILURE=1 ninja server/test
+      - name: Upload cache log
+        uses: actions/upload-artifact@v3
+        with:
+          name: sccache_log.txt
+          path: /tmp/sccache_log.txt
+
   lint-test-chart:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Also, add sccache debug log in hope to understand
why we get 0 hits sometimes.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->