### PR TITLE
feat: implement CONFIG GET command

### DIFF
--- a/src/facade/error.h
+++ b/src/facade/error.h
@@ -27,11 +27,13 @@ extern const char kInvalidDbIndErr[];
 extern const char kScriptNotFound[];
 extern const char kAuthRejected[];
 extern const char kExpiryOutOfRange[];
-extern const char kSyntaxErrType[];
-extern const char kScriptErrType[];
 extern const char kIndexOutOfRange[];
 extern const char kOutOfMemory[];
 extern const char kInvalidNumericResult[];
 extern const char kClusterNotConfigured[];
+
+extern const char kSyntaxErrType[];
+extern const char kScriptErrType[];
+extern const char kConfigErrType[];
 
 }  // namespace facade

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -79,12 +79,14 @@ const char kInvalidDbIndErr[] = "invalid DB index";
 const char kScriptNotFound[] = "-NOSCRIPT No matching script. Please use EVAL.";
 const char kAuthRejected[] = "-WRONGPASS invalid username-password pair or user is disabled.";
 const char kExpiryOutOfRange[] = "expiry is out of range";
-const char kSyntaxErrType[] = "syntax_error";
-const char kScriptErrType[] = "script_error";
 const char kIndexOutOfRange[] = "index out of range";
 const char kOutOfMemory[] = "Out of memory";
 const char kInvalidNumericResult[] = "result is not a number";
 const char kClusterNotConfigured[] = "Cluster is not yet configured";
+
+const char kSyntaxErrType[] = "syntax_error";
+const char kScriptErrType[] = "script_error";
+const char kConfigErrType[] = "config_error";
 
 const char* RespExpr::TypeName(Type t) {
   switch (t) {

--- a/src/server/config_registry.cc
+++ b/src/server/config_registry.cc
@@ -7,40 +7,47 @@
 
 #include "base/logging.h"
 
+extern "C" {
+#include "redis/util.h"
+}
+
 namespace dfly {
 
 using namespace std;
 
-ConfigRegistry& ConfigRegistry::Register(std::string_view name, WriteCb cb) {
+ConfigRegistry& ConfigRegistry::Register(std::string_view name, bool is_mutable, WriteCb cb) {
   absl::CommandLineFlag* flag = absl::FindCommandLineFlag(name);
   CHECK(flag) << "Unknown config name: " << name;
 
   unique_lock lk(mu_);
-  auto [it, inserted] = registry_.emplace(name, std::move(cb));
+  auto [it, inserted] = registry_.emplace(name, Entry{std::move(cb), is_mutable});
   CHECK(inserted) << "Duplicate config name: " << name;
   return *this;
 }
 
-ConfigRegistry& ConfigRegistry::Register(std::string_view name) {
-  return Register(name, [](const absl::CommandLineFlag& flag) { return true; });
+ConfigRegistry& ConfigRegistry::Register(std::string_view name, bool is_mutable) {
+  return Register(name, is_mutable, [](const absl::CommandLineFlag& flag) { return true; });
 }
 
 // Returns true if the value was updated.
-bool ConfigRegistry::Set(std::string_view config_name, std::string_view value) {
+auto ConfigRegistry::Set(std::string_view config_name, std::string_view value) -> SetResult {
   unique_lock lk(mu_);
   auto it = registry_.find(config_name);
   if (it == registry_.end())
-    return false;
-  auto cb = it->second;
+    return SetResult::UNKNOWN;
+  if (!it->second.is_mutable)
+    return SetResult::READONLY;
+
+  auto cb = it->second.cb;
   lk.unlock();
 
   absl::CommandLineFlag* flag = absl::FindCommandLineFlag(config_name);
   CHECK(flag);
   string error;
   if (!flag->ParseFrom(value, &error))
-    return false;
+    return SetResult::INVALID;
 
-  return cb(*flag);
+  return cb(*flag) ? SetResult::OK : SetResult::INVALID;
 }
 
 std::optional<std::string> ConfigRegistry::Get(std::string_view config_name) {
@@ -57,6 +64,16 @@ std::optional<std::string> ConfigRegistry::Get(std::string_view config_name) {
 void ConfigRegistry::Reset() {
   unique_lock lk(mu_);
   registry_.clear();
+}
+
+vector<string> ConfigRegistry::List(string_view glob) const {
+  vector<string> res;
+  unique_lock lk(mu_);
+  for (const auto& [name, _] : registry_) {
+    if (stringmatchlen(glob.data(), glob.size(), name.data(), name.size(), 1))
+      res.push_back(name);
+  }
+  return res;
 }
 
 ConfigRegistry config_registry;

--- a/src/server/config_registry.cc
+++ b/src/server/config_registry.cc
@@ -15,20 +15,6 @@ namespace dfly {
 
 using namespace std;
 
-ConfigRegistry& ConfigRegistry::Register(std::string_view name, bool is_mutable, WriteCb cb) {
-  absl::CommandLineFlag* flag = absl::FindCommandLineFlag(name);
-  CHECK(flag) << "Unknown config name: " << name;
-
-  unique_lock lk(mu_);
-  auto [it, inserted] = registry_.emplace(name, Entry{std::move(cb), is_mutable});
-  CHECK(inserted) << "Duplicate config name: " << name;
-  return *this;
-}
-
-ConfigRegistry& ConfigRegistry::Register(std::string_view name, bool is_mutable) {
-  return Register(name, is_mutable, [](const absl::CommandLineFlag& flag) { return true; });
-}
-
 // Returns true if the value was updated.
 auto ConfigRegistry::Set(std::string_view config_name, std::string_view value) -> SetResult {
   unique_lock lk(mu_);
@@ -47,7 +33,8 @@ auto ConfigRegistry::Set(std::string_view config_name, std::string_view value) -
   if (!flag->ParseFrom(value, &error))
     return SetResult::INVALID;
 
-  return cb(*flag) ? SetResult::OK : SetResult::INVALID;
+  bool success = !cb || cb(*flag);
+  return success ? SetResult::OK : SetResult::INVALID;
 }
 
 std::optional<std::string> ConfigRegistry::Get(std::string_view config_name) {
@@ -74,6 +61,15 @@ vector<string> ConfigRegistry::List(string_view glob) const {
       res.push_back(name);
   }
   return res;
+}
+
+void ConfigRegistry::RegisterInternal(std::string_view name, bool is_mutable, WriteCb cb) {
+  absl::CommandLineFlag* flag = absl::FindCommandLineFlag(name);
+  CHECK(flag) << "Unknown config name: " << name;
+
+  unique_lock lk(mu_);
+  auto [it, inserted] = registry_.emplace(name, Entry{std::move(cb), is_mutable});
+  CHECK(inserted) << "Duplicate config name: " << name;
 }
 
 ConfigRegistry config_registry;

--- a/src/server/config_registry.h
+++ b/src/server/config_registry.h
@@ -14,19 +14,34 @@ class ConfigRegistry {
   // Accepts the new value as argument. Return true if config was successfully updated.
   using WriteCb = std::function<bool(const absl::CommandLineFlag&)>;
 
-  ConfigRegistry& Register(std::string_view name, WriteCb cb);
-  ConfigRegistry& Register(std::string_view name);
+  ConfigRegistry& Register(std::string_view name, bool is_mutable, WriteCb cb);
+  ConfigRegistry& Register(std::string_view name, bool is_mutable);
+
+  enum class SetResult : uint8_t {
+    OK,
+    UNKNOWN,
+    READONLY,
+    INVALID,
+  };
 
   // Returns true if the value was updated.
-  bool Set(std::string_view config_name, std::string_view value);
+  SetResult Set(std::string_view config_name, std::string_view value);
 
   std::optional<std::string> Get(std::string_view config_name);
 
   void Reset();
 
+  std::vector<std::string> List(std::string_view glob) const;
+
  private:
-  util::fb2::Mutex mu_;
-  absl::flat_hash_map<std::string, WriteCb> registry_ ABSL_GUARDED_BY(mu_);
+  mutable util::fb2::Mutex mu_;
+
+  struct Entry {
+    WriteCb cb;
+    bool is_mutable;
+  };
+
+  absl::flat_hash_map<std::string, Entry> registry_ ABSL_GUARDED_BY(mu_);
 };
 
 extern ConfigRegistry config_registry;

--- a/src/server/config_registry.h
+++ b/src/server/config_registry.h
@@ -14,8 +14,15 @@ class ConfigRegistry {
   // Accepts the new value as argument. Return true if config was successfully updated.
   using WriteCb = std::function<bool(const absl::CommandLineFlag&)>;
 
-  ConfigRegistry& Register(std::string_view name, bool is_mutable, WriteCb cb);
-  ConfigRegistry& Register(std::string_view name, bool is_mutable);
+  ConfigRegistry& Register(std::string_view name) {
+    RegisterInternal(name, false, {});
+    return *this;
+  }
+
+  ConfigRegistry& RegisterMutable(std::string_view name, WriteCb cb = {}) {
+    RegisterInternal(name, true, std::move(cb));
+    return *this;
+  }
 
   enum class SetResult : uint8_t {
     OK,
@@ -34,6 +41,8 @@ class ConfigRegistry {
   std::vector<std::string> List(std::string_view glob) const;
 
  private:
+  void RegisterInternal(std::string_view name, bool is_mutable, WriteCb cb);
+
   mutable util::fb2::Mutex mu_;
 
   struct Entry {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -637,7 +637,7 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
                    const InitOpts& opts) {
   InitRedisTables();
 
-  config_registry.Register("maxmemory", true, [](const absl::CommandLineFlag& flag) {
+  config_registry.RegisterMutable("maxmemory", [](const absl::CommandLineFlag& flag) {
     auto res = flag.TryGet<MaxMemoryFlag>();
     if (!res)
       return false;
@@ -646,11 +646,11 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
     return true;
   });
 
-  config_registry.Register("dbnum", false);  // equivalent to databases in redis.
-  config_registry.Register("dir", true);     // TODO: to add validation for dir
-  config_registry.Register("requirepass", true);
-  config_registry.Register("masterauth", true);
-  config_registry.Register("tcp_keepalive", true);
+  config_registry.Register("dbnum");       // equivalent to databases in redis.
+  config_registry.RegisterMutable("dir");  // TODO: to add validation for dir
+  config_registry.RegisterMutable("requirepass");
+  config_registry.RegisterMutable("masterauth");
+  config_registry.RegisterMutable("tcp_keepalive");
 
   acl::UserRegistry* reg = &user_registry_;
   pp_.Await([reg](uint32_t index, ProactorBase* pb) { ServerState::Init(index, reg); });

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -637,7 +637,7 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
                    const InitOpts& opts) {
   InitRedisTables();
 
-  config_registry.Register("maxmemory", [](const absl::CommandLineFlag& flag) {
+  config_registry.Register("maxmemory", true, [](const absl::CommandLineFlag& flag) {
     auto res = flag.TryGet<MaxMemoryFlag>();
     if (!res)
       return false;
@@ -646,10 +646,12 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
     return true;
   });
 
-  config_registry.Register("dir");
-  config_registry.Register("requirepass");
-  config_registry.Register("masterauth");
-  config_registry.Register("tcp_keepalive");
+  config_registry.Register("dbnum", false);  // equivalent to databases in redis.
+  config_registry.Register("dir", true);     // TODO: to add validation for dir
+  config_registry.Register("requirepass", true);
+  config_registry.Register("masterauth", true);
+  config_registry.Register("tcp_keepalive", true);
+
   acl::UserRegistry* reg = &user_registry_;
   pp_.Await([reg](uint32_t index, ProactorBase* pb) { ServerState::Init(index, reg); });
 

--- a/src/server/server_family.cc.orig
+++ b/src/server/server_family.cc.orig
@@ -915,7 +915,7 @@ void ServerFamily::Init(util::AcceptServer* acceptor, std::vector<facade::Listen
   dfly_cmd_ = make_unique<DflyCmd>(this);
 
   SetMaxClients(listeners_, absl::GetFlag(FLAGS_maxclients));
-  config_registry.RegisterMutable("maxclients", [this](const absl::CommandLineFlag& flag) {
+  config_registry.Register("maxclients", [this](const absl::CommandLineFlag& flag) {
     auto res = flag.TryGet<uint32_t>();
     if (res.has_value())
       SetMaxClients(listeners_, res.value());
@@ -1652,6 +1652,15 @@ void ServerFamily::Config(CmdArgList args, ConnectionContext* cntx) {
     // Send empty response, like Redis does, unless the param is supported
 
     string_view param = ArgS(args, 1);
+<<<<<<< HEAD
+    if (param == "databases") {
+      res.emplace_back(param);
+      res.push_back(absl::StrCat(absl::GetFlag(FLAGS_dbnum)));
+    } else if (auto value_from_registry = config_registry.Get(param);
+               value_from_registry.has_value()) {
+      res.emplace_back(param);
+      res.push_back(*value_from_registry);
+=======
     vector<string> names = config_registry.List(param);
     vector<string> res;
 
@@ -1659,6 +1668,7 @@ void ServerFamily::Config(CmdArgList args, ConnectionContext* cntx) {
       absl::CommandLineFlag* flag = CHECK_NOTNULL(absl::FindCommandLineFlag(name));
       res.push_back(name);
       res.push_back(flag->CurrentValue());
+>>>>>>> 660af341 (feat: implement CONFIG GET command)
     }
 
     return (*cntx)->SendStringArr(res, RedisReplyBuilder::MAP);

--- a/tests/dragonfly/management_test.py
+++ b/tests/dragonfly/management_test.py
@@ -1,0 +1,14 @@
+import pytest
+import asyncio
+from redis import asyncio as aioredis
+from redis.exceptions import ResponseError
+
+
+@pytest.mark.asyncio
+async def test_config_cmd(async_client: aioredis.Redis):
+    with pytest.raises(ResponseError):
+        await async_client.config_set("foo", "bar")
+    await async_client.config_set("requirepass", "foobar") == "OK"
+    res = await async_client.config_get("*")
+    assert len(res) > 0
+    assert res["requirepass"] == "foobar"


### PR DESCRIPTION
The command returns all the matched arguments and their current values. In addition, this PR adds mutability semantics to each config - whether it can be changed at runtime.

Fixes #1700

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->