### PR TITLE
fix: make Dragonfly compatible with older systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,5 +36,3 @@ include_directories(helio)
 
 add_subdirectory(helio)
 add_subdirectory(src)
-
-include(cmake/Packing.cmake)

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,16 @@ HELIO_OPENSSL_USE_STATIC_LIBS = ON
 HELIO_ENABLE_GIT_VERSION = ON
 HELIO_WITH_UNWIND = OFF
 
+# equivalent to: if $(uname_m) == x86_64 || $(uname_m) == amd64
+ifneq (, $(filter $(BUILD_ARCH),x86_64 amd64))
+HELIO_MARCH_OPT := -march=core2 -msse4.1 -mpopcnt -mtune=skylake
+endif
+
 HELIO_FLAGS = $(if $(HELIO_RELEASE),-release $(HELIO_RELEASE_FLAGS),) \
               -DBoost_USE_STATIC_LIBS=$(HELIO_USE_STATIC_LIBS) \
               -DOPENSSL_USE_STATIC_LIBS=$(HELIO_OPENSSL_USE_STATIC_LIBS) \
               -DENABLE_GIT_VERSION=$(HELIO_ENABLE_GIT_VERSION) \
-              -DWITH_UNWIND=$(HELIO_WITH_UNWIND) \
+              -DWITH_UNWIND=$(HELIO_WITH_UNWIND) -DMARCH_OPT="$(HELIO_MARCH_OPT)"
 
 .PHONY: default
 


### PR DESCRIPTION
Change the Makefile to configure the compile to produce code
compatible with core2 architecture for x86_64 systems.
Plus specify precise CPU extensions that we use in the code.
Partly addresses https://github.com/dragonflydb/dragonfly/issues/1519

Before the change we relied on default helio logic that configured
the build to run on sandybridge for x86_64.
This PR overrides x86_64 settings to much older core2 processor.

Also, we remove an unneeded cmake include.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->