### PR TITLE
fix(replication): Handle errors instead of crashing.

### DIFF
--- a/src/server/journal/serializer.cc
+++ b/src/server/journal/serializer.cc
@@ -106,7 +106,11 @@ std::error_code JournalReader::EnsureRead(size_t num) {
   // Try reading at least how much we need, but possibly more
   uint64_t read;
   SET_OR_RETURN(source_->ReadAtLeast(buf_.AppendBuffer(), remainder), read);
-  CHECK(read >= remainder);
+
+  // Happens on end of stream (for example, a too-small string buffer or a closed socket)
+  if (read < remainder) {
+    return make_error_code(errc::io_error);
+  }
 
   buf_.CommitWrite(read);
   return {};

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -666,7 +666,10 @@ error_code DflyShardReplica::StartStableSyncFlow(Context* cntx) {
   ProactorBase* mythread = ProactorBase::me();
   CHECK(mythread);
 
-  CHECK(Sock()->IsOpen());
+  if (!Sock()->IsOpen()) {
+    return std::make_error_code(errc::io_error);
+  }
+
   sync_fb_ =
       fb2::Fiber("shard_stable_sync_read", &DflyShardReplica::StableSyncDflyReadFb, this, cntx);
   if (use_multi_shard_exe_sync_) {


### PR DESCRIPTION
Gracefully handle two small `CHECK`s that can trigger sometimes on malformed replication data.