### PR TITLE
fix(server): Dont apply memory limit when loading/replicating

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -89,8 +89,12 @@ class PrimeEvictionPolicy {
 
   PrimeEvictionPolicy(const DbContext& cntx, bool can_evict, ssize_t mem_budget, ssize_t soft_limit,
                       DbSlice* db_slice, bool apply_memory_limit)
-      : db_slice_(db_slice), mem_budget_(mem_budget), soft_limit_(soft_limit), cntx_(cntx),
-        can_evict_(can_evict), apply_memory_limit_(apply_memory_limit) {
+      : db_slice_(db_slice),
+        mem_budget_(mem_budget),
+        soft_limit_(soft_limit),
+        cntx_(cntx),
+        can_evict_(can_evict),
+        apply_memory_limit_(apply_memory_limit) {
   }
 
   // A hook function that is called every time a segment is full and requires splitting.

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -416,7 +416,7 @@ tuple<PrimeIterator, ExpireIterator, bool> DbSlice::AddOrFind2(const Context& cn
                           apply_memory_limit};
 
   // If we are over limit in non-cache scenario, just be conservative and throw.
-  if (!caching_mode_ && evp.mem_budget() < 0) {
+  if (apply_memory_limit && !caching_mode_ && evp.mem_budget() < 0) {
     VLOG(1) << "AddOrFind2: over limit, budget: " << evp.mem_budget();
     events_.insertion_rejections++;
     throw bad_alloc();

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -931,7 +931,7 @@ void Service::DispatchCommand(CmdArgList args, facade::ConnectionContext* cntx) 
 
   uint64_t start_ns = absl::GetCurrentTimeNanos();
 
-  if (cid->opt_mask() & CO::DENYOOM) {
+  if (cid->opt_mask() & CO::DENYOOM && etl.is_master) {
     uint64_t used_memory = etl.GetUsedMemory(start_ns);
     double oom_deny_ratio = GetFlag(FLAGS_oom_deny_ratio);
     if (used_memory > (max_memory_limit * oom_deny_ratio)) {

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2289,6 +2289,8 @@ void RdbLoader::LoadItemsBuffer(DbIndex db_ind, const ItemsBuf& ib) {
 void RdbLoader::ResizeDb(size_t key_num, size_t expire_num) {
   DCHECK_LT(key_num, 1U << 31);
   DCHECK_LT(expire_num, 1U << 31);
+  // Note: To reserve space, it's necessary to allocate space at the shard level. We might
+  // load with different number of shards which makes database resizing unfeasible.
 }
 
 error_code RdbLoader::LoadKeyValPair(int type, ObjSettings* settings) {


### PR DESCRIPTION
No memory limit on loading from file or replicating.
When loading a snapshot created by the same server configuration (memory and
number of shards) we will create a different dash table segment directory tree, because the
tree shape is related to the order of entries insertion. Therefore when loading data from
snapshot or from replication the conservative memory checks might fail as the new tree might
have more segments. Because we dont want to fail loading a snapshot from the same server
configuration we disable this checks on loading and replication.

fixes #1708 