### PR TITLE
bug(server): command stats show origin command name

### DIFF
--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -156,7 +156,7 @@ class CommandRegistry {
       auto src = k_v.second.GetStats(thread_index);
       if (src.first == 0)
         continue;
-      cb(k_v.first, src);
+      cb(k_v.second.name(), src);
     }
   }
 };


### PR DESCRIPTION
the bug: when command is renamed we show the rename command in command stats
the fix: print the origin command name in command stats
fixes #1756 