### PR TITLE
chore: split daily build and bullmq tests

### DIFF
--- a/.github/workflows/bullmq-tests.yml
+++ b/.github/workflows/bullmq-tests.yml
@@ -1,0 +1,48 @@
+# These tests are disabled until Dragonfly works well with BullMQ.
+name: bullmq-tests
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+  runs-on: ubuntu-latest
+    name: Build
+
+    timeout-minutes: 60
+    container:
+      image: ghcr.io/romange/alpine-dev:latest
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Install NodeJs
+        run: |
+          apk add --no-cache nodejs npm yarn
+          node --version
+          npm --version
+          yarn --version
+          mkdir -p ${{github.workspace}}/build
+      - name: Configure/Build
+        working-directory: ${{github.workspace}}/build
+        # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+        # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+        run: |
+          cmake .. -DCMAKE_BUILD_TYPE=Debug -GNinja
+          ninja dragonfly
+          ./dragonfly --alsologtostderr &
+
+      - name: Clone and build BullMQ
+        run: |
+          git clone https://github.com/taskforcesh/bullmq.git
+          cd bullmq
+          pwd
+          yarn install --ignore-engines --frozen-lockfile --non-interactive
+          yarn build
+      - name: Test BullMQ
+        working-directory: ${{github.workspace}}/bullmq
+        run: |
+          # yarn test -i -g "should process delayed jobs with several workers respecting delay"

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -13,15 +13,21 @@ jobs:
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-latest
-    name: Build with ${{ matrix.flags }} flags
+    name: Build ${{ matrix.name }}
     strategy:
       matrix:
-        # Build with these flags
-        flags: ["-DMARCH_OPT=-march=x86-64"]
+        include:
+          # Build with these flags
+          - name: generic
+            container: alpine-dev
+            flags: "-DMARCH_OPT=-march=x86-64"
+          - name: fedora
+            container: fedora:30
+
     timeout-minutes: 45
 
     container:
-      image: ghcr.io/romange/alpine-dev:latest
+      image: ghcr.io/romange/${{ matrix.container }}
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -30,49 +36,19 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Install NodeJs
-        run: |
-          apk add --no-cache nodejs npm yarn
-          node --version
-          npm --version
-          yarn --version
       - name: Install dependencies
         run: |
-          uname -a
           cmake --version
           mkdir -p ${{github.workspace}}/build
-      - name: Cache build deps
-        id: cache-deps
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.ccache
-            ${{github.workspace}}/build/_deps
-          key: ${{ runner.os }}-deps-${{ github.base_ref }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-deps-${{ github.base_ref }}-
 
-      - name: Configure CMake
+      - name: Configure & Build
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+        working-directory: ${{github.workspace}}/build
         run: |
-          cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ${{ matrix.flags }}
-          cd ${{github.workspace}}/build && pwd
-          du -hcs _deps/
-      - name: Build & Run
-        run: |
-          cd ${{github.workspace}}/build
+          cmake .. -DCMAKE_BUILD_TYPE=Debug -GNinja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ${{ matrix.flags }}
           ninja src/all
-          ccache --show-stats
-          ./dragonfly --alsologtostderr --default_lua_flags=allow-undeclared-keys &
-      - name: Clone and build BullMQ
+      - name: Test
+        working-directory: ${{github.workspace}}/build
         run: |
-          cd ${{github.workspace}}
-          git clone https://github.com/taskforcesh/bullmq.git
-          cd bullmq
-          yarn install --ignore-engines --frozen-lockfile --non-interactive
-          yarn build
-      - name: Test BullMQ with dragonfly
-        run: |
-          cd ${{github.workspace}}/bullmq
-          # yarn test -i -g "should process delayed jobs with several workers respecting delay"
+            ctest -V -L DFLY


### PR DESCRIPTION
Also add fedora linux to daily build matrix.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->