### PR TITLE
feat(search): Query parameters

### DIFF
--- a/src/core/search/base.h
+++ b/src/core/search/base.h
@@ -17,20 +17,23 @@ using DocId = uint32_t;
 using FtVector = std::vector<float>;
 
 // Query params represent named parameters for queries supplied via PARAMS.
-struct QueryParams : private absl::flat_hash_map<std::string, std::string> {
+struct QueryParams {
   size_t Size() const {
-    return size();
+    return params.size();
   }
 
   std::string_view operator[](std::string_view name) const {
-    if (auto it = find(name); it != end())
+    if (auto it = params.find(name); it != params.end())
       return it->second;
     return "";
   }
 
   decltype(auto) operator[](std::string_view k) {
-    return static_cast<absl::flat_hash_map<std::string, std::string>*>(this)->operator[](k);
+    return params[k];
   }
+
+ private:
+  absl::flat_hash_map<std::string, std::string> params;
 };
 
 // Interface for accessing document values with different data structures underneath.

--- a/src/core/search/base.h
+++ b/src/core/search/base.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <absl/container/flat_hash_map.h>
+
 #include <cstdint>
 #include <string>
 #include <string_view>
@@ -15,9 +17,20 @@ using DocId = uint32_t;
 using FtVector = std::vector<float>;
 
 // Query params represent named parameters for queries supplied via PARAMS.
-// Currently its only a placeholder to pass the vector to KNN.
-struct QueryParams {
-  FtVector knn_vec;
+struct QueryParams : private absl::flat_hash_map<std::string, std::string> {
+  size_t Size() const {
+    return size();
+  }
+
+  std::string_view operator[](std::string_view name) const {
+    if (auto it = find(name); it != end())
+      return it->second;
+    return "";
+  }
+
+  decltype(auto) operator[](std::string_view k) {
+    return static_cast<absl::flat_hash_map<std::string, std::string>*>(this)->operator[](k);
+  }
 };
 
 // Interface for accessing document values with different data structures underneath.

--- a/src/core/search/base.h
+++ b/src/core/search/base.h
@@ -28,7 +28,7 @@ struct QueryParams {
     return "";
   }
 
-  decltype(auto) operator[](std::string_view k) {
+  std::string& operator[](std::string_view k) {
     return params[k];
   }
 

--- a/src/core/search/lexer.lex
+++ b/src/core/search/lexer.lex
@@ -67,7 +67,7 @@ term_char [_]|\w
 
 {dq}{str_char}*{dq}  return make_StringLit(matched_view(1, 1), loc());
 
-"$"{term_char}+ return Parser::make_PARAM(str(), loc());
+"$"{term_char}+ return ParseParam(str(), loc());
 "@"{term_char}+ return Parser::make_FIELD(str(), loc());
 
 {term_char}+   return Parser::make_TERM(str(), loc());
@@ -75,9 +75,7 @@ term_char [_]|\w
 <<EOF>>    return Parser::make_YYEOF(loc());
 %%
 
-Parser::symbol_type
-make_INT64 (string_view str, const Parser::location_type& loc)
-{
+Parser::symbol_type make_INT64 (string_view str, const Parser::location_type& loc) {
   int64_t val = 0;
   if (!absl::SimpleAtoi(str, &val))
     throw Parser::syntax_error (loc, "not an integer or out of range: " + string(str));
@@ -87,8 +85,8 @@ make_INT64 (string_view str, const Parser::location_type& loc)
 
 Parser::symbol_type make_StringLit(string_view src, const Parser::location_type& loc) {
   string res;
-  if (!absl::CUnescape(src, &res)) {
+  if (!absl::CUnescape(src, &res))
     throw Parser::syntax_error (loc, "bad escaped string: " + string(src));
-  }
+
   return Parser::make_TERM(res, loc);
 }

--- a/src/core/search/parser.y
+++ b/src/core/search/parser.y
@@ -25,6 +25,7 @@
 // Added to cc file
 %code {
 #include "core/search/query_driver.h"
+#include "core/search/vector.h"
 
 // Have to disable because GCC doesn't understand `symbol_type`'s union
 // implementation
@@ -80,7 +81,7 @@ final_query:
   filter
       { driver->Set(move($1)); }
   | filter ARROW LBRACKET KNN INT64 FIELD TERM RBRACKET
-      { driver->Set(AstKnnNode(move($1), $5, $6, driver->GetParams().knn_vec)); }
+      { driver->Set(AstKnnNode(move($1), $5, $6, BytesToFtVector($7))); }
 
 filter:
   search_expr { $$ = move($1); }

--- a/src/core/search/query_driver.cc
+++ b/src/core/search/query_driver.cc
@@ -15,7 +15,9 @@ QueryDriver::~QueryDriver() {
 
 void QueryDriver::ResetScanner() {
   scanner_ = std::make_unique<Scanner>();
+  scanner_->SetParams(params_);
 }
+
 }  // namespace search
 
 }  // namespace dfly

--- a/src/core/search/query_driver.h
+++ b/src/core/search/query_driver.h
@@ -25,9 +25,9 @@ class QueryDriver {
     scanner()->in(cur_str_);
   }
 
-  void SetParams(const QueryParams& params) {
-    params_ = &params;
-    scanner_->SetParams(params_);
+  void SetParams(const QueryParams* params) {
+    params_ = params;
+    scanner_->SetParams(params);
   }
 
   Parser::symbol_type Lex() {
@@ -44,7 +44,7 @@ class QueryDriver {
     return std::move(expr_);
   }
 
-  const QueryParams& GetParams() {
+  const QueryParams& GetParams() const {
     return *params_;
   }
 

--- a/src/core/search/query_driver.h
+++ b/src/core/search/query_driver.h
@@ -20,17 +20,14 @@ class QueryDriver {
   QueryDriver();
   ~QueryDriver();
 
-  Scanner* scanner() {
-    return scanner_.get();
-  }
-
   void SetInput(std::string str) {
     cur_str_ = std::move(str);
     scanner()->in(cur_str_);
   }
 
-  void SetParams(QueryParams params) {
-    params_ = std::move(params);
+  void SetParams(const QueryParams& params) {
+    params_ = &params;
+    scanner_->SetParams(params_);
   }
 
   Parser::symbol_type Lex() {
@@ -48,14 +45,18 @@ class QueryDriver {
   }
 
   const QueryParams& GetParams() {
-    return params_;
+    return *params_;
+  }
+
+  Scanner* scanner() {
+    return scanner_.get();
   }
 
  public:
   Parser::location_type location;
 
  private:
-  QueryParams params_;
+  const QueryParams* params_;
   AstExpr expr_;
 
   std::string cur_str_;

--- a/src/core/search/scanner.h
+++ b/src/core/search/scanner.h
@@ -10,15 +10,23 @@
 #include "core/search/lexer.h"
 #endif
 
+#include <absl/strings/str_cat.h>
+
+#include "base/logging.h"
+
 namespace dfly {
 namespace search {
 
 class Scanner : public Lexer {
  public:
-  Scanner() {
+  Scanner() : params_{nullptr} {
   }
 
   Parser::symbol_type Lex();
+
+  void SetParams(const QueryParams* params) {
+    params_ = params;
+  }
 
  private:
   std::string_view matched_view(size_t skip_left = 0, size_t skip_right = 0) const {
@@ -29,6 +37,23 @@ class Scanner : public Lexer {
   dfly::search::location loc() {
     return location();
   }
+
+  Parser::symbol_type ParseParam(std::string_view name, const Parser::location_type& loc) {
+    name = name.substr(1);
+
+    std::string_view str = (*params_)[name];
+    if (str.empty())
+      throw std::runtime_error(absl::StrCat("Query parameter ", name, " not found"));
+
+    int64_t val = 0;
+    if (!absl::SimpleAtoi(str, &val))
+      return Parser::make_TERM(std::string{str}, loc);
+
+    return Parser::make_INT64(val, loc);
+  }
+
+ private:
+  const QueryParams* params_;
 };
 
 }  // namespace search

--- a/src/core/search/scanner.h
+++ b/src/core/search/scanner.h
@@ -39,7 +39,8 @@ class Scanner : public Lexer {
   }
 
   Parser::symbol_type ParseParam(std::string_view name, const Parser::location_type& loc) {
-    name = name.substr(1);
+    if (name.size() > 0)
+      name.remove_prefix(1);
 
     std::string_view str = (*params_)[name];
     if (str.empty())

--- a/src/core/search/scanner.h
+++ b/src/core/search/scanner.h
@@ -39,7 +39,7 @@ class Scanner : public Lexer {
   }
 
   Parser::symbol_type ParseParam(std::string_view name, const Parser::location_type& loc) {
-    if (name.size() > 0)
+    if (!name.empty())
       name.remove_prefix(1);
 
     std::string_view str = (*params_)[name];

--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -26,7 +26,7 @@ namespace dfly::search {
 
 namespace {
 
-AstExpr ParseQuery(std::string_view query, const QueryParams& params) {
+AstExpr ParseQuery(std::string_view query, const QueryParams* params) {
   QueryDriver driver{};
   driver.ResetScanner();
   driver.SetParams(params);
@@ -396,7 +396,7 @@ const vector<DocId>& FieldIndices::GetAllDocs() const {
 SearchAlgorithm::SearchAlgorithm() = default;
 SearchAlgorithm::~SearchAlgorithm() = default;
 
-bool SearchAlgorithm::Init(string_view query, const QueryParams& params) {
+bool SearchAlgorithm::Init(string_view query, const QueryParams* params) {
   try {
     query_ = make_unique<AstExpr>(ParseQuery(query, params));
     return !holds_alternative<monostate>(*query_);

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -85,7 +85,7 @@ class SearchAlgorithm {
   ~SearchAlgorithm();
 
   // Init with query and return true if successful.
-  bool Init(std::string_view query, const QueryParams& params);
+  bool Init(std::string_view query, const QueryParams* params);
 
   SearchResult Search(const FieldIndices* index) const;
 

--- a/src/core/search/search_parser_test.cc
+++ b/src/core/search/search_parser_test.cc
@@ -33,7 +33,7 @@ class SearchParserTest : public ::testing::Test {
     return Parser(&query_driver_)();
   }
 
-  void SetParams(const QueryParams& params) {
+  void SetParams(const QueryParams* params) {
     query_driver_.SetParams(params);
   }
 
@@ -118,7 +118,7 @@ TEST_F(SearchParserTest, ParseParams) {
   QueryParams params;
   params["k"] = "10";
   params["name"] = "alex";
-  SetParams(params);
+  SetParams(&params);
 
   SetInput("$name $k");
   NEXT_EQ(TOK_TERM, string, "alex");

--- a/src/core/search/search_parser_test.cc
+++ b/src/core/search/search_parser_test.cc
@@ -33,6 +33,10 @@ class SearchParserTest : public ::testing::Test {
     return Parser(&query_driver_)();
   }
 
+  void SetParams(const QueryParams& params) {
+    query_driver_.SetParams(params);
+  }
+
   QueryDriver query_driver_;
 };
 
@@ -79,8 +83,7 @@ TEST_F(SearchParserTest, Scanner) {
   SetInput(R"( "hello\"world" )");
   NEXT_EQ(TOK_TERM, string, R"(hello"world)");
 
-  SetInput(" $param @field:hello");
-  NEXT_EQ(TOK_PARAM, string, "$param");
+  SetInput("@field:hello");
   NEXT_EQ(TOK_FIELD, string, "@field");
   NEXT_TOK(TOK_COLON);
   NEXT_EQ(TOK_TERM, string, "hello");
@@ -109,6 +112,17 @@ TEST_F(SearchParserTest, Parse) {
   EXPECT_EQ(1, Parse(" foo:bar "));
   EXPECT_EQ(1, Parse(" @foo:@bar "));
   EXPECT_EQ(1, Parse(" @foo: "));
+}
+
+TEST_F(SearchParserTest, ParseParams) {
+  QueryParams params;
+  params["k"] = "10";
+  params["name"] = "alex";
+  SetParams(params);
+
+  SetInput("$name $k");
+  NEXT_EQ(TOK_TERM, string, "alex");
+  NEXT_EQ(TOK_INT64, int64_t, 10);
 }
 
 }  // namespace dfly::search

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -113,7 +113,7 @@ class SearchParserTest : public ::testing::Test {
       index.Add(i, &entries_[i].first);
 
     SearchAlgorithm search_algo{};
-    if (!search_algo.Init(query_, params_)) {
+    if (!search_algo.Init(query_, &params_)) {
       error_ = "Failed to parse query";
       return false;
     }
@@ -352,35 +352,35 @@ TEST_F(SearchParserTest, SimpleKnn) {
   // Five closest to 50
   {
     params["vec"] = FtVectorToBytes(FtVector{50.0});
-    algo.Init("*=>[KNN 5 @pos $vec]", params);
+    algo.Init("*=>[KNN 5 @pos $vec]", &params);
     EXPECT_THAT(algo.Search(&indices).ids, testing::UnorderedElementsAre(48, 49, 50, 51, 52));
   }
 
   // Five closest to 0
   {
     params["vec"] = FtVectorToBytes(FtVector{0.0});
-    algo.Init("*=>[KNN 5 @pos $vec]", params);
+    algo.Init("*=>[KNN 5 @pos $vec]", &params);
     EXPECT_THAT(algo.Search(&indices).ids, testing::UnorderedElementsAre(0, 1, 2, 3, 4));
   }
 
   // Five closest to 20, all even
   {
     params["vec"] = FtVectorToBytes(FtVector{20.0});
-    algo.Init("@even:{yes} =>[KNN 5 @pos $vec]", params);
+    algo.Init("@even:{yes} =>[KNN 5 @pos $vec]", &params);
     EXPECT_THAT(algo.Search(&indices).ids, testing::UnorderedElementsAre(16, 18, 20, 22, 24));
   }
 
   // Three closest to 31, all odd
   {
     params["vec"] = FtVectorToBytes(FtVector{31.0});
-    algo.Init("@even:{no} =>[KNN 3 @pos $vec]", params);
+    algo.Init("@even:{no} =>[KNN 3 @pos $vec]", &params);
     EXPECT_THAT(algo.Search(&indices).ids, testing::UnorderedElementsAre(29, 31, 33));
   }
 
   // Two closest to 70.5
   {
     params["vec"] = FtVectorToBytes(FtVector{70.5});
-    algo.Init("* =>[KNN 2 @pos $vec]", params);
+    algo.Init("* =>[KNN 2 @pos $vec]", &params);
     EXPECT_THAT(algo.Search(&indices).ids, testing::UnorderedElementsAre(70, 71));
   }
 }
@@ -408,42 +408,42 @@ TEST_F(SearchParserTest, Simple2dKnn) {
   // Single center
   {
     params["vec"] = FtVectorToBytes(FtVector{0.5, 0.5});
-    algo.Init("* =>[KNN 1 @pos $vec]", params);
+    algo.Init("* =>[KNN 1 @pos $vec]", &params);
     EXPECT_THAT(algo.Search(&indices).ids, testing::UnorderedElementsAre(4));
   }
 
   // Lower left
   {
     params["vec"] = FtVectorToBytes(FtVector{0, 0});
-    algo.Init("* =>[KNN 4 @pos $vec]", params);
+    algo.Init("* =>[KNN 4 @pos $vec]", &params);
     EXPECT_THAT(algo.Search(&indices).ids, testing::UnorderedElementsAre(0, 1, 3, 4));
   }
 
   // Upper right
   {
     params["vec"] = FtVectorToBytes(FtVector{1, 1});
-    algo.Init("* =>[KNN 4 @pos $vec]", params);
+    algo.Init("* =>[KNN 4 @pos $vec]", &params);
     EXPECT_THAT(algo.Search(&indices).ids, testing::UnorderedElementsAre(1, 2, 3, 4));
   }
 
   // Request more than there is
   {
     params["vec"] = FtVectorToBytes(FtVector{0, 0});
-    algo.Init("* => [KNN 10 @pos $vec]", params);
+    algo.Init("* => [KNN 10 @pos $vec]", &params);
     EXPECT_THAT(algo.Search(&indices).ids, testing::UnorderedElementsAre(0, 1, 2, 3, 4));
   }
 
   // Test correct order: (0.7, 0.15)
   {
     params["vec"] = FtVectorToBytes(FtVector{0.7, 0.15});
-    algo.Init("* => [KNN 10 @pos $vec]", params);
+    algo.Init("* => [KNN 10 @pos $vec]", &params);
     EXPECT_THAT(algo.Search(&indices).ids, testing::ElementsAre(1, 4, 0, 2, 3));
   }
 
   // Test correct order: (0.8, 0.9)
   {
     params["vec"] = FtVectorToBytes(FtVector{0.8, 0.9});
-    algo.Init("* => [KNN 10 @pos $vec]", params);
+    algo.Init("* => [KNN 10 @pos $vec]", &params);
     EXPECT_THAT(algo.Search(&indices).ids, testing::ElementsAre(2, 4, 3, 1, 0));
   }
 }

--- a/src/core/search/vector.cc
+++ b/src/core/search/vector.cc
@@ -5,12 +5,26 @@
 #include "core/search/vector.h"
 
 #include <cmath>
+#include <memory>
 
 #include "base/logging.h"
 
 namespace dfly::search {
 
 using namespace std;
+
+FtVector BytesToFtVector(string_view value) {
+  DCHECK_EQ(value.size() % sizeof(float), 0u);
+  FtVector out(value.size() / sizeof(float));
+
+  // Create copy for aligned access
+  unique_ptr<float[]> float_ptr = make_unique<float[]>(out.size());
+  memcpy(float_ptr.get(), value.data(), value.size());
+
+  for (size_t i = 0; i < out.size(); i++)
+    out[i] = float_ptr[i];
+  return out;
+}
 
 // Euclidean vector distance: sqrt( sum: (u[i] - v[i])^2  )
 __attribute__((optimize("fast-math"))) float VectorDistance(const FtVector& u, const FtVector& v) {

--- a/src/core/search/vector.h
+++ b/src/core/search/vector.h
@@ -8,6 +8,8 @@
 
 namespace dfly::search {
 
+FtVector BytesToFtVector(std::string_view value);
+
 float VectorDistance(const FtVector& v1, const FtVector& v2);
 
 }  // namespace dfly::search

--- a/src/server/search/doc_accessors.cc
+++ b/src/server/search/doc_accessors.cc
@@ -12,6 +12,7 @@
 
 #include "core/json_object.h"
 #include "core/search/search.h"
+#include "core/search/vector.h"
 #include "core/string_map.h"
 #include "server/container_utils.h"
 
@@ -32,7 +33,7 @@ string_view SdsToSafeSv(sds str) {
 
 string PrintField(search::SchemaField::FieldType type, string_view value) {
   if (type == search::SchemaField::VECTOR)
-    return absl::StrCat("[", absl::StrJoin(BytesToFtVector(value), ","), "]");
+    return absl::StrCat("[", absl::StrJoin(search::BytesToFtVector(value), ","), "]");
   else
     return string{value};
 }
@@ -48,7 +49,7 @@ string ExtractValue(const search::Schema& schema, string_view key, string_view v
 }  // namespace
 
 SearchDocData BaseAccessor::Serialize(const search::Schema& schema,
-                                      const SearchParams::FieldAliasList& fields) const {
+                                      const SearchParams::FieldReturnList& fields) const {
   SearchDocData out{};
   for (const auto& [fident, fname] : fields) {
     auto it = schema.fields.find(fident);
@@ -63,7 +64,7 @@ string_view ListPackAccessor::GetString(string_view active_field) const {
 }
 
 search::FtVector ListPackAccessor::GetVector(string_view active_field) const {
-  return BytesToFtVector(GetString(active_field));
+  return search::BytesToFtVector(GetString(active_field));
 }
 
 SearchDocData ListPackAccessor::Serialize(const search::Schema& schema) const {
@@ -89,7 +90,7 @@ string_view StringMapAccessor::GetString(string_view active_field) const {
 }
 
 search::FtVector StringMapAccessor::GetVector(string_view active_field) const {
-  return BytesToFtVector(GetString(active_field));
+  return search::BytesToFtVector(GetString(active_field));
 }
 
 SearchDocData StringMapAccessor::Serialize(const search::Schema& schema) const {
@@ -146,7 +147,7 @@ SearchDocData JsonAccessor::Serialize(const search::Schema& schema) const {
 }
 
 SearchDocData JsonAccessor::Serialize(const search::Schema& schema,
-                                      const SearchParams::FieldAliasList& fields) const {
+                                      const SearchParams::FieldReturnList& fields) const {
   SearchDocData out{};
   for (const auto& [ident, name] : fields)
     out[name] = GetString(ident);

--- a/src/server/search/doc_accessors.h
+++ b/src/server/search/doc_accessors.h
@@ -29,7 +29,7 @@ struct BaseAccessor : public search::DocumentAccessor {
 
   // Serialize selected fields
   SearchDocData Serialize(const search::Schema& schema,
-                          const SearchParams::FieldAliasList& fields) const;
+                          const SearchParams::FieldReturnList& fields) const;
 };
 
 // Accessor for hashes stored with listpack
@@ -74,7 +74,7 @@ struct JsonAccessor : public BaseAccessor {
 
   // The JsonAccessor works with structured types and not plain strings, so an overload is needed
   SearchDocData Serialize(const search::Schema& schema,
-                          const SearchParams::FieldAliasList& fields) const;
+                          const SearchParams::FieldReturnList& fields) const;
 
   static void RemoveFieldFromCache(std::string_view field);
 

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -57,19 +57,6 @@ const absl::flat_hash_map<string_view, search::SchemaField::FieldType> kSchemaTy
 
 }  // namespace
 
-search::FtVector BytesToFtVector(string_view value) {
-  DCHECK_EQ(value.size() % sizeof(float), 0u);
-  search::FtVector out(value.size() / sizeof(float));
-
-  // Create copy for aligned access
-  unique_ptr<float[]> float_ptr = make_unique<float[]>(out.size());
-  memcpy(float_ptr.get(), value.data(), value.size());
-
-  for (size_t i = 0; i < out.size(); i++)
-    out[i] = float_ptr[i];
-  return out;
-}
-
 optional<search::SchemaField::FieldType> ParseSearchFieldType(string_view name) {
   auto it = kSchemaTypes.find(name);
   return it != kSchemaTypes.end() ? make_optional(it->second) : nullopt;

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -20,7 +20,6 @@ namespace dfly {
 
 using SearchDocData = absl::flat_hash_map<std::string /*field*/, std::string /*value*/>;
 
-search::FtVector BytesToFtVector(std::string_view value);
 std::optional<search::SchemaField::FieldType> ParseSearchFieldType(std::string_view name);
 std::string_view SearchFieldTypeToString(search::SchemaField::FieldType);
 
@@ -38,16 +37,17 @@ struct SearchResult {
 };
 
 struct SearchParams {
+  using FieldReturnList =
+      std::vector<std::pair<std::string /*identifier*/, std::string /*short name*/>>;
+
   // Parameters for "LIMIT offset total": select total amount documents with a specific offset from
   // the whole result set
   size_t limit_offset;
   size_t limit_total;
 
-  using FieldAliasList =
-      std::vector<std::pair<std::string /*identifier*/, std::string /*short name*/>>;
-  std::optional<FieldAliasList> return_fields;
-
-  search::FtVector knn_vector;
+  // Set but empty means no fields should be returned
+  std::optional<FieldReturnList> return_fields;
+  search::QueryParams query_params;
 
   bool IdsOnly() const {
     return return_fields && return_fields->empty();

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -366,7 +366,7 @@ void SearchFamily::FtSearch(CmdArgList args, ConnectionContext* cntx) {
     return;
 
   search::SearchAlgorithm search_algo;
-  if (!search_algo.Init(query_str, params->query_params))
+  if (!search_algo.Init(query_str, &params->query_params))
     return (*cntx)->SendError("Query syntax error");
 
   // Because our coordinator thread may not have a shard, we can't check ahead if the index exists.

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -394,13 +394,13 @@ void SearchFamily::FtProfile(CmdArgList args, ConnectionContext* cntx) {
   string_view index_name = ArgS(args, 0);
   string_view query_str = ArgS(args, 3);
 
-  search::SearchAlgorithm search_algo;
-  if (!search_algo.Init(query_str, {search::FtVector{}}))
-    return (*cntx)->SendError("Query syntax error");
-
   optional<SearchParams> params = ParseSearchParamsOrReply(args.subspan(4), cntx);
   if (!params.has_value())
     return;
+
+  search::SearchAlgorithm search_algo;
+  if (!search_algo.Init(query_str, &params->query_params))
+    return (*cntx)->SendError("Query syntax error");
 
   search_algo.EnableProfiling();
 

--- a/tests/dragonfly/search_test.py
+++ b/tests/dragonfly/search_test.py
@@ -217,18 +217,18 @@ async def test_knn(async_client: aioredis.Redis, index_type):
             pipe.json().set(f"k{i}", "$", {"even": even, "pos": [float(i)]})
     await pipe.execute()
 
-    assert await knn_query(i2, "* => [KNN 3 @pos VEC]", [50.0]) == {"k49", "k50", "k51"}
+    assert await knn_query(i2, "* => [KNN 3 @pos $vec]", [50.0]) == {"k49", "k50", "k51"}
 
-    assert await knn_query(i2, "@even:{yes} => [KNN 3 @pos VEC]", [20.0]) == {"k18", "k20", "k22"}
+    assert await knn_query(i2, "@even:{yes} => [KNN 3 @pos $vec]", [20.0]) == {"k18", "k20", "k22"}
 
-    assert await knn_query(i2, "@even:{no} => [KNN 4 @pos VEC]", [30.0]) == {
+    assert await knn_query(i2, "@even:{no} => [KNN 4 @pos $vec]", [30.0]) == {
         "k27",
         "k29",
         "k31",
         "k33",
     }
 
-    assert await knn_query(i2, "@even:{yes} => [KNN 3 @pos VEC]", [10.0] == {"k8", "k10", "k12"})
+    assert await knn_query(i2, "@even:{yes} => [KNN 3 @pos $vec]", [10.0] == {"k8", "k10", "k12"})
 
     await i2.dropindex()
 
@@ -281,7 +281,7 @@ async def test_multidim_knn(async_client: aioredis.Redis, index_type):
             for i, point in sorted(points, key=lambda p: np.linalg.norm(center - p[1]))[:limit]
         ]
 
-        got_ids = await knn_query(i3, f"* => [KNN {limit} @pos VEC]", center)
+        got_ids = await knn_query(i3, f"* => [KNN {limit} @pos $vec]", center)
 
         assert set(expected_ids) == set(got_ids)
 


### PR DESCRIPTION
This PR makes it possible to use query parameters in search queries

For example `'$name => [KNN $k @pos $vec]' PARAMS name joe k 10 vec \x00\x00`