### PR TITLE
fix: run container as `dfly` user

### DIFF
--- a/tools/docker/Dockerfile.alpine-dev
+++ b/tools/docker/Dockerfile.alpine-dev
@@ -42,4 +42,6 @@ ENTRYPOINT ["entrypoint.sh"]
 
 EXPOSE 6379
 
+USER dfly
+
 CMD ["dragonfly", "--logtostderr"]

--- a/tools/docker/Dockerfile.alpine-prod.wip
+++ b/tools/docker/Dockerfile.alpine-prod.wip
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-from ghcr.io/romange/alpine-dev as builder
+FROM ghcr.io/romange/alpine-dev as builder
 
 WORKDIR /build
 COPY src/  ./src/
@@ -29,4 +29,7 @@ HEALTHCHECK CMD /usr/local/bin/healthcheck.sh
 ENTRYPOINT ["entrypoint.sh"]
 
 EXPOSE 6380
+
+USER dfly
+
 CMD ["dragonfly", "--logtostderr"]

--- a/tools/docker/Dockerfile.ubuntu-dev
+++ b/tools/docker/Dockerfile.ubuntu-dev
@@ -53,4 +53,6 @@ ENTRYPOINT ["entrypoint.sh"]
 # For inter-container communication.
 EXPOSE 6379
 
+USER dfly
+
 CMD ["dragonfly", "--logtostderr"]

--- a/tools/docker/Dockerfile.ubuntu-prod
+++ b/tools/docker/Dockerfile.ubuntu-prod
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-from ghcr.io/romange/ubuntu-dev:20 as builder
+FROM ghcr.io/romange/ubuntu-dev:20 as builder
 
 ARG TARGETPLATFORM
 
@@ -12,7 +12,6 @@ RUN curl -O https://raw.githubusercontent.com/ncopa/su-exec/master/su-exec.c && 
 
 RUN /tmp/fetch_release.sh ${TARGETPLATFORM}
 
-
 # Now prod image
 FROM ubuntu:20.04
 
@@ -23,12 +22,12 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt clean && apt update && apt -y install netcat-openbsd ca-certificates redis-tools libxml2
 
-
 RUN groupadd -r -g 999 dfly && useradd -r -g dfly -u 999 dfly
 RUN mkdir /data && chown dfly:dfly /data
 
 VOLUME /data
 WORKDIR /data
+
 COPY tools/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY tools/docker/healthcheck.sh /usr/local/bin/healthcheck.sh
 COPY --from=builder /build/su-exec /usr/local/bin/
@@ -39,5 +38,7 @@ ENTRYPOINT ["entrypoint.sh"]
 
 # For inter-container communication.
 EXPOSE 6379
+
+USER dfly
 
 CMD ["dragonfly", "--logtostderr"]


### PR DESCRIPTION
- Beautified the Dockerfile a little bit
- Running the container as the `dfly` user resolves write permission issues on volumes provisioned on the Container-as-a-service provider, [fly.io](https://fly.io). If the container runs as root (which is the default if no user is specified), I'm unable to write files to an external `/data` volume. Additionally - it's also considered as best practice to execute a container with a user account that has lower privileges than root

---

I think it can solve this discussion: https://github.com/dragonflydb/dragonfly/discussions/1527