### PR TITLE
feat: introduce configurable flags for I/O limits

### DIFF
--- a/src/facade/memcache_parser.cc
+++ b/src/facade/memcache_parser.cc
@@ -154,8 +154,8 @@ auto MP::Parse(string_view str, uint32_t* consumed, Command* cmd) -> Result {
     return UNKNOWN_CMD;
   }
 
-  if (cmd->type <= CAS) {  // Store command
-    if (num_tokens < 5 || tokens[1].size() > 250) {
+  if (cmd->type <= CAS) {                            // Store command
+    if (num_tokens < 5 || tokens[1].size() > 250) {  // key length limit
       return MP::PARSE_ERROR;
     }
 

--- a/src/facade/redis_parser.cc
+++ b/src/facade/redis_parser.cc
@@ -11,14 +11,6 @@ namespace facade {
 
 using namespace std;
 
-namespace {
-
-// When changing this constant, also update `test_large_cmd` test in connection_test.py.
-constexpr int kMaxArrayLen = 65536;
-constexpr int64_t kMaxBulkLen = 256 * (1ul << 20);  // 256MB.
-
-}  // namespace
-
 auto RedisParser::Parse(Buffer str, uint32_t* consumed, RespExpr::Vec* res) -> Result {
   *consumed = 0;
   res->clear();
@@ -251,8 +243,8 @@ auto RedisParser::ConsumeArrayLen(Buffer str) -> Result {
     case BAD_INT:
       return BAD_ARRAYLEN;
     case OK:
-      if (len < -1 || len > kMaxArrayLen) {
-        LOG_IF(WARNING, len > kMaxArrayLen) << "Multi bulk len is too big " << len;
+      if (len < -1 || len > max_arr_len_) {
+        LOG_IF(WARNING, len > max_arr_len_) << "Multibulk len is too large " << len;
 
         return BAD_ARRAYLEN;
       }

--- a/src/facade/redis_parser.h
+++ b/src/facade/redis_parser.h
@@ -22,10 +22,13 @@ namespace facade {
  */
 class RedisParser {
  public:
+  constexpr static long kMaxBulkLen = 256 * (1ul << 20);  // 256MB.
+
   enum Result { OK, INPUT_PENDING, BAD_ARRAYLEN, BAD_BULKLEN, BAD_STRING, BAD_INT, BAD_DOUBLE };
   using Buffer = RespExpr::Buffer;
 
-  explicit RedisParser(bool server_mode = true) : server_mode_(server_mode) {
+  explicit RedisParser(uint32_t max_arr_len = UINT32_MAX, bool server_mode = true)
+      : max_arr_len_(max_arr_len), server_mode_(server_mode) {
   }
 
   /**
@@ -98,6 +101,8 @@ class RedisParser {
   using BlobPtr = std::unique_ptr<uint8_t[]>;
   std::vector<BlobPtr> buf_stash_;
   RespVec* cached_expr_ = nullptr;
+  uint32_t max_arr_len_;
+
   bool is_broken_token_ = false;
   bool server_mode_ = true;
 };

--- a/src/facade/reply_builder_test.cc
+++ b/src/facade/reply_builder_test.cc
@@ -172,7 +172,7 @@ RedisReplyBuilderTest::ParsingResults RedisReplyBuilderTest::Parse() {
   parser_buffer_.reset(new uint8_t[SinkSize()]);
   auto* ptr = parser_buffer_.get();
   memcpy(ptr, str().data(), SinkSize());
-  RedisParser parser(false);  // client side
+  RedisParser parser(UINT32_MAX, false);  // client side
   result.result =
       parser.Parse(RedisParser::Buffer{ptr, SinkSize()}, &result.consumed, &result.args);
   return result;

--- a/src/server/protocol_client.cc
+++ b/src/server/protocol_client.cc
@@ -425,7 +425,8 @@ error_code ProtocolClient::SendCommandAndReadResponse(string_view command) {
 }
 
 void ProtocolClient::ResetParser(bool server_mode) {
-  parser_.reset(new RedisParser(server_mode));
+  // We accept any length for the parser because it has been approved by the master.
+  parser_.reset(new RedisParser(UINT32_MAX, server_mode));
 }
 
 uint64_t ProtocolClient::LastIoTime() const {

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -423,7 +423,7 @@ RespVec BaseFamilyTest::TestConnWrapper::ParseResponse(bool fully_consumed) {
   auto s_copy = s;
 
   uint32_t consumed = 0;
-  parser_.reset(new RedisParser{false});  // Client mode.
+  parser_.reset(new RedisParser{UINT32_MAX, false});  // Client mode.
   RespVec res;
   RedisParser::Result st = parser_->Parse(buf, &consumed, &res);
 


### PR DESCRIPTION
Introduced `max_multi_bulk_len` as a max limit when parsing RESP arrays
as well as `max_client_iobuf_len` as a max limit on the iobuf used to
read from a socket.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->