### PR TITLE
fix(server): Adjust batching behavior to reduce network latency on MULTI blocks

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -794,12 +794,27 @@ void Connection::DispatchFiber(util::FiberSocketBase* peer) {
 
   size_t squashing_threshold = absl::GetFlag(FLAGS_pipeline_squash);
 
-  bool queue_was_larger_than_1 = false;
+  uint64_t prev_epoch = fb2::FiberSwitchEpoch();
   while (!builder->GetError()) {
     evc_.await(
         [this] { return cc_->conn_closing || (!dispatch_q_.empty() && !cc_->sync_dispatch); });
     if (cc_->conn_closing)
       break;
+
+    // We really want to have batching in the builder if possible. This is especially
+    // critical in situations where Nagle's algorithm can introduce unwanted high
+    // latencies. However we can only batch if we're sure that there are more commands
+    // on the way that will trigger a flush. To know if there are, we sometimes yield before
+    // executing the last command in the queue and let the producer fiber push more commands if it
+    // wants to.
+    // As an optimization, we only yield if the fiber was not suspended since the last dispatch.
+    uint64_t cur_epoch = fb2::FiberSwitchEpoch();
+    if (dispatch_q_.size() == 1 && cur_epoch == prev_epoch) {
+      ThisFiber::Yield();
+      DVLOG(1) << "After yielding to producer, dispatch_q_.size()=" << dispatch_q_.size();
+    }
+    prev_epoch = cur_epoch;
+    builder->SetBatchMode(dispatch_q_.size() > 1);
 
     auto recycle = [this, request_cache_limit](MessageHandle msg) {
       dispatch_q_bytes_.fetch_sub(msg.UsedMemory(), memory_order_relaxed);
@@ -813,19 +828,6 @@ void Connection::DispatchFiber(util::FiberSocketBase* peer) {
         }
       }
     };
-
-    // We really want to have batching in the builder if possible. This is especially
-    // critical in situations where Nagle's algorithm can introduce unwanted high
-    // latencies. However we can only batch if we're sure that there are more commands
-    // on the way. To know if there are, we sometimes yield before executing the last
-    // command in the queue and let the producer fiber push more commands if it wants
-    // to.
-    // As a small optimization, if the queue was never larger than 1, skip the Yield() call.
-    if (dispatch_q_.size() == 1 && queue_was_larger_than_1) {
-      ThisFiber::Yield();
-    }
-    queue_was_larger_than_1 = dispatch_q_.size() > 1;
-    builder->SetBatchMode(queue_was_larger_than_1);
 
     // Special case: if the dispatch queue accumulated a big number of commands,
     // we can try to squash them

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -718,6 +718,7 @@ auto Connection::IoLoop(util::FiberSocketBase* peer, SinkReplyBuilder* orig_buil
     stats_->io_read_bytes += *recv_sz;
     ++stats_->io_read_cnt;
     phase_ = PROCESS;
+    bool is_iobuf_full = io_buf_.AppendLen() == 0;
 
     if (redis_parser_) {
       parse_status = ParseRedis(orig_builder);
@@ -735,11 +736,20 @@ auto Connection::IoLoop(util::FiberSocketBase* peer, SinkReplyBuilder* orig_buil
         if (redis_parser_)
           parser_hint = redis_parser_->parselen_hint();  // Could be done for MC as well.
 
+        // If we got a partial request and we managed to parse its
+        // length, make sure we have space to store it instead of
+        // increasing space incrementally.
+        // (Note: The buffer object is only working in power-of-2 sizes,
+        // so there's no danger of accidental O(n^2) behavior.)
         if (parser_hint > capacity) {
           io_buf_.Reserve(std::min(max_iobfuf_len, parser_hint));
         }
 
-        if (io_buf_.AppendLen() < 64u) {
+        // If we got a partial request and we couldn't parse the length, just
+        // double the capacity.
+        // If we got a partial request because iobuf was full, grow it up to
+        // a reasonable limit to save on Recv() calls.
+        if (io_buf_.AppendLen() < 64u || (is_iobuf_full && capacity < 4096)) {
           // Last io used most of the io_buf to the end.
           io_buf_.Reserve(capacity * 2);  // Valid growth range.
         }
@@ -784,6 +794,7 @@ void Connection::DispatchFiber(util::FiberSocketBase* peer) {
 
   size_t squashing_threshold = absl::GetFlag(FLAGS_pipeline_squash);
 
+  bool queue_was_larger_than_1 = false;
   while (!builder->GetError()) {
     evc_.await(
         [this] { return cc_->conn_closing || (!dispatch_q_.empty() && !cc_->sync_dispatch); });
@@ -803,7 +814,18 @@ void Connection::DispatchFiber(util::FiberSocketBase* peer) {
       }
     };
 
-    builder->SetBatchMode(dispatch_q_.size() > 1);
+    // We really want to have batching in the builder if possible. This is especially
+    // critical in situations where Nagle's algorithm can introduce unwanted high
+    // latencies. However we can only batch if we're sure that there are more commands
+    // on the way. To know if there are, we sometimes yield before executing the last
+    // command in the queue and let the producer fiber push more commands if it wants
+    // to.
+    // As a small optimization, if the queue was never larger than 1, skip the Yield() call.
+    if (dispatch_q_.size() == 1 && queue_was_larger_than_1) {
+      ThisFiber::Yield();
+    }
+    queue_was_larger_than_1 = dispatch_q_.size() > 1;
+    builder->SetBatchMode(queue_was_larger_than_1);
 
     // Special case: if the dispatch queue accumulated a big number of commands,
     // we can try to squash them

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -62,9 +62,7 @@ class SinkReplyBuilder {
   // In order to reduce interrupt rate we allow coalescing responses together using
   // Batch mode. It is controlled by Connection state machine because it makes sense only
   // when pipelined requests are arriving.
-  void SetBatchMode(bool batch) {
-    should_batch_ = batch;
-  }
+  void SetBatchMode(bool batch);
 
   void FlushBatch();
 
@@ -121,10 +119,7 @@ class SinkReplyBuilder {
 
   void Send(const iovec* v, uint32_t len);
 
-  void StartAggregate() {
-    should_aggregate_ = true;
-  }
-
+  void StartAggregate();
   void StopAggregate();
 
   std::string batch_;


### PR DESCRIPTION
1. Add a Yield() call before executing the last command in the async queue when needed.
2. Allow the receive buffer to grow when needed.
3. Improve debugging logs for batching behavior.


The whole 'triggering the bug' process looks like this:
1. We process a larger packet with multiple short commands inside a MULTI segment.
2. We read the commands into a relatively small buffer (size 256)
3. The `ParseRedis` loop reads commands from the first part of the packet and pushes them into the dispatch queue.
4. The dispatch fiber processes all the commands in the dispatch queue quickly and without preemption because it's inside a MULTI block and all commands return immediately. After emptying the queue it calls SetBatchMode(false) which causes a flush of the response buffer after the next command is executed.
5. The rest of the commands are parsed and executed, but the second packet is not sent until an ACK is received from the client because of Nagle's algorithm.

Close #1285