### PR TITLE
fix(AclFamily): stream acl updates via dispatch queue in connection

### DIFF
--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -79,6 +79,11 @@ class Connection : public util::Connection {
 
   struct MonitorMessage : public std::string {};
 
+  struct AclUpdateMessage {
+    std::string_view username;
+    uint64_t categories{0};
+  };
+
   struct PipelineMessage {
     PipelineMessage(size_t nargs, size_t capacity) : args(nargs), storage(capacity) {
     }
@@ -111,7 +116,7 @@ class Connection : public util::Connection {
 
     bool IsPipelineMsg() const;
 
-    std::variant<MonitorMessage, PubMessagePtr, PipelineMessagePtr> handle;
+    std::variant<MonitorMessage, PubMessagePtr, PipelineMessagePtr, AclUpdateMessage> handle;
   };
 
   enum Phase { READ_SOCKET, PROCESS };
@@ -123,6 +128,9 @@ class Connection : public util::Connection {
 
   // Add monitor message to dispatch queue.
   void SendMonitorMessageAsync(std::string);
+
+  // Add acl update to dispatch queue.
+  void SendAclUpdateAsync(AclUpdateMessage msg);
 
   // Must be called before Send_Async to ensure the connection dispatch queue is not overfilled.
   // Blocks until free space is available.

--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -164,10 +164,7 @@ void AclFamily::StreamUpdatesToAllProactorConnections(std::string_view user, uin
   auto update_cb = [user, update_cat]([[maybe_unused]] size_t id, util::Connection* conn) {
     DCHECK(conn);
     auto connection = static_cast<facade::Connection*>(conn);
-    auto ctx = static_cast<ConnectionContext*>(connection->cntx());
-    if (ctx && user == ctx->authed_username) {
-      ctx->acl_categories = update_cat;
-    }
+    connection->SendAclUpdateAsync(facade::Connection::AclUpdateMessage{user, update_cat});
   };
 
   if (main_listener_) {

--- a/src/server/acl/user_registry.cc
+++ b/src/server/acl/user_registry.cc
@@ -65,14 +65,14 @@ UserRegistry::RegistryViewWithLock UserRegistry::GetRegistryWithLock() const {
   return {std::move(lock), registry_};
 }
 
-UserRegistry::UserViewWithLock::UserViewWithLock(std::shared_lock<util::SharedMutex> lk,
-                                                 const User& user, bool exists)
+UserRegistry::UserWithWriteLock::UserWithWriteLock(std::unique_lock<util::SharedMutex> lk,
+                                                   const User& user, bool exists)
     : user(user), exists(exists), registry_lk_(std::move(lk)) {
 }
 
-UserRegistry::UserViewWithLock UserRegistry::MaybeAddAndUpdateWithLock(std::string_view username,
-                                                                       User::UpdateRequest req) {
-  std::shared_lock<util::SharedMutex> lock(mu_);
+UserRegistry::UserWithWriteLock UserRegistry::MaybeAddAndUpdateWithLock(std::string_view username,
+                                                                        User::UpdateRequest req) {
+  std::unique_lock<util::SharedMutex> lock(mu_);
   const bool exists = registry_.contains(username);
   auto& user = registry_[username];
   user.Update(std::move(req));

--- a/src/server/acl/user_registry.h
+++ b/src/server/acl/user_registry.h
@@ -65,17 +65,17 @@ class UserRegistry {
   RegistryViewWithLock GetRegistryWithLock() const;
 
   // Helper class for accessing a user with a ReadLock outside the scope of UserRegistry
-  class UserViewWithLock {
+  class UserWithWriteLock {
    public:
-    UserViewWithLock(std::shared_lock<util::SharedMutex> lk, const User& user, bool exists);
+    UserWithWriteLock(std::unique_lock<util::SharedMutex> lk, const User& user, bool exists);
     const User& user;
     const bool exists;
 
    private:
-    std::shared_lock<util::SharedMutex> registry_lk_;
+    std::unique_lock<util::SharedMutex> registry_lk_;
   };
 
-  UserViewWithLock MaybeAddAndUpdateWithLock(std::string_view username, User::UpdateRequest req);
+  UserWithWriteLock MaybeAddAndUpdateWithLock(std::string_view username, User::UpdateRequest req);
 
  private:
   RegistryType registry_;

--- a/tests/dragonfly/acl_family_test.py
+++ b/tests/dragonfly/acl_family_test.py
@@ -210,13 +210,14 @@ async def test_acl_with_long_running_script(df_server):
     await client.execute_command("AUTH roman yoman")
     admin_client = aioredis.Redis(port=df_server.port)
 
-    res = await asyncio.gather(
+    await asyncio.gather(
         client.eval(script, 4, "key", "key1", "key2", "key3"),
         admin_client.execute_command("ACL SETUSER -@string -@scripting"),
     )
 
-    res = await admin_client.get("key")
-    assert res == b"10000"
+    for i in range(1, 4):
+        res = await admin_client.get(f"key{i}")
+        assert res == b"10000"
 
     await client.close()
     await admin_client.close()


### PR DESCRIPTION
There was a bug on updates of the acl categories when squashing was used. Basically, the parent context could be accessed in parallel by the "stub" contexts causing a dreaded data race on the update. 

This is fixed by adding a new `AclUpdateMessage` at the front of the dispatch queue of the connection.