### PR TITLE
feat(search): FT.PROFILE

### DIFF
--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -136,9 +136,11 @@ struct ProfileBuilder {
 struct BasicSearch {
   using LogicOp = AstLogicalNode::LogicOp;
 
-  BasicSearch(const FieldIndices* indices, bool profile = false) : indices_{indices}, tmp_vec_{} {
-    if (profile)
-      profile_builder_ = ProfileBuilder{};
+  BasicSearch(const FieldIndices* indices) : indices_{indices}, tmp_vec_{} {
+  }
+
+  void EnableProfiling() {
+    profile_builder_ = ProfileBuilder{};
   }
 
   // Get casted sub index by field
@@ -408,7 +410,10 @@ bool SearchAlgorithm::Init(string_view query, const QueryParams& params) {
 }
 
 SearchResult SearchAlgorithm::Search(const FieldIndices* index) const {
-  return BasicSearch{index, profiling_enabled_}.Search(*query_);
+  auto bs = BasicSearch{index};
+  if (profiling_enabled_)
+    bs.EnableProfiling();
+  return bs.Search(*query_);
 }
 
 optional<size_t> SearchAlgorithm::HasKnn() const {

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -55,6 +55,17 @@ class FieldIndices {
   absl::flat_hash_map<std::string, std::unique_ptr<BaseIndex>> indices_;
 };
 
+struct AlgorithmProfile {
+  struct ProfileEvent {
+    std::string descr;
+    size_t micros;  // time event took in microseconds
+    size_t depth;   // tree depth of event
+    size_t flow;    // number of results processed by op
+  };
+
+  std::vector<ProfileEvent> events;
+};
+
 // Represents a search result returned from the search algorithm.
 struct SearchResult {
   std::vector<DocId> ids;
@@ -62,6 +73,9 @@ struct SearchResult {
   // If a KNN-query is present, distances for doc ids are returned as well
   // and sorted from smallest to largest.
   std::vector<float> knn_distances;
+
+  // If profiling was enabled
+  std::optional<AlgorithmProfile> profile;
 };
 
 // SearchAlgorithm allows searching field indices with a query
@@ -78,7 +92,10 @@ class SearchAlgorithm {
   // Return KNN limit if it is enabled
   std::optional<size_t> HasKnn() const;
 
+  void EnableProfiling();
+
  private:
+  bool profiling_enabled_ = false;
   std::unique_ptr<AstNode> query_;
 };
 

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -58,9 +58,9 @@ class FieldIndices {
 struct AlgorithmProfile {
   struct ProfileEvent {
     std::string descr;
-    size_t micros;  // time event took in microseconds
-    size_t depth;   // tree depth of event
-    size_t flow;    // number of results processed by op
+    size_t micros;         // time event took in microseconds
+    size_t depth;          // tree depth of event
+    size_t num_processed;  // number of results processed by the event
   };
 
   std::vector<ProfileEvent> events;

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -204,7 +204,8 @@ SearchResult ShardDocIndex::Search(const OpArgs& op_args, const SearchParams& pa
     out.push_back(SerializedSearchDoc{string{key}, std::move(doc_data), score});
   }
 
-  return SearchResult{std::move(out), search_results.ids.size() - expired_count};
+  return SearchResult{std::move(out), search_results.ids.size() - expired_count,
+                      std::move(search_results.profile)};
 }
 
 DocIndexInfo ShardDocIndex::GetInfo() const {

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -33,6 +33,8 @@ struct SerializedSearchDoc {
 struct SearchResult {
   std::vector<SerializedSearchDoc> docs;
   size_t total_hits;
+
+  std::optional<search::AlgorithmProfile> profile;
 };
 
 struct SearchParams {

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -454,7 +454,7 @@ void SearchFamily::FtProfile(CmdArgList args, ConnectionContext* cntx) {
         (*cntx)->StartArray(2);
 
       (*cntx)->SendSimpleString(
-          absl::StrFormat("t=%-10u f=%-10u %s", event.micros, event.flow, event.descr));
+          absl::StrFormat("t=%-10u n=%-10u %s", event.micros, event.num_processed, event.descr));
 
       if (children > 0)
         (*cntx)->StartArray(children);

--- a/src/server/search/search_family.h
+++ b/src/server/search/search_family.h
@@ -19,6 +19,7 @@ class SearchFamily {
   static void FtInfo(CmdArgList args, ConnectionContext* cntx);
   static void FtList(CmdArgList args, ConnectionContext* cntx);
   static void FtSearch(CmdArgList args, ConnectionContext* cntx);
+  static void FtProfile(CmdArgList args, ConnectionContext* cntx);
 
  public:
   static void Register(CommandRegistry* registry);


### PR DESCRIPTION
Adds FT.PROFILE commands that runs the search query with profiling to see a detailed execution plan with timings. Does not comply with RS's FtProfile.

Example output for a simple query. First, it prints general results, then the detailed execution plan for each shard

![image](https://github.com/dragonflydb/dragonfly/assets/20553775/8f4a96ca-2318-4a2d-be5f-b955ba35ac5f)

