### PR TITLE
fix(AclFamily): setuser signed interleaved categories updates

### DIFF
--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -7,6 +7,7 @@
 
 #include <cctype>
 #include <optional>
+#include <utility>
 #include <variant>
 
 #include "absl/strings/ascii.h"
@@ -151,8 +152,10 @@ std::variant<User::UpdateRequest, ErrorReply> ParseAclSetUser(CmdArgList args) {
       return ErrorReply(absl::StrCat("Unrecognized parameter", command));
     }
 
-    auto* acl_field = add ? &req.plus_acl_categories : &req.minus_acl_categories;
-    *acl_field = acl_field->value_or(0) | *cat;
+    using Sign = User::Sign;
+    using Val = std::pair<Sign, uint32_t>;
+    auto val = add ? Val{Sign::PLUS, *cat} : Val{Sign::MINUS, *cat};
+    req.categories.push_back(val);
   }
 
   return req;

--- a/src/server/acl/user.cc
+++ b/src/server/acl/user.cc
@@ -28,12 +28,12 @@ void User::Update(UpdateRequest&& req) {
     SetPasswordHash(*req.password);
   }
 
-  if (req.plus_acl_categories) {
-    SetAclCategories(*req.plus_acl_categories);
-  }
-
-  if (req.minus_acl_categories) {
-    UnsetAclCategories(*req.minus_acl_categories);
+  for (auto [sign, category] : req.categories) {
+    if (sign == Sign::PLUS) {
+      SetAclCategories(category);
+      continue;
+    }
+    UnsetAclCategories(category);
   }
 
   if (req.is_active) {

--- a/src/server/acl/user.h
+++ b/src/server/acl/user.h
@@ -9,6 +9,8 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/hash/hash.h"
@@ -18,11 +20,12 @@ namespace dfly::acl {
 
 class User final {
  public:
+  enum class Sign : int8_t { PLUS, MINUS };
+
   struct UpdateRequest {
     std::optional<std::string> password{};
 
-    std::optional<uint32_t> plus_acl_categories{};
-    std::optional<uint32_t> minus_acl_categories{};
+    std::vector<std::pair<Sign, uint32_t>> categories;
 
     // DATATYPE_BITSET commands;
 

--- a/src/server/acl/user_registry.cc
+++ b/src/server/acl/user_registry.cc
@@ -11,7 +11,8 @@
 namespace dfly::acl {
 
 UserRegistry::UserRegistry() {
-  User::UpdateRequest req{{}, acl::ALL, {}, true};
+  std::pair<User::Sign, uint32_t> acl{User::Sign::PLUS, acl::ALL};
+  User::UpdateRequest req{{}, {acl}, true};
   MaybeAddAndUpdate("default", std::move(req));
 }
 

--- a/tests/dragonfly/acl_family_test.py
+++ b/tests/dragonfly/acl_family_test.py
@@ -53,6 +53,11 @@ async def test_acl_setuser(async_client):
     result = await async_client.execute_command("ACL LIST")
     assert "user kostas on nopass +@LIST" in result
 
+    # mix and match interleaved
+    await async_client.execute_command("ACL SETUSER kostas +@set -@set +@set")
+    result = await async_client.execute_command("ACL LIST")
+    assert "user kostas on nopass +@SET +@LIST" in result
+
     await async_client.execute_command("ACL SETUSER kostas +@all")
     result = await async_client.execute_command("ACL LIST")
     assert "user kostas on nopass +@ALL" in result


### PR DESCRIPTION
We had back previously for interleaved updates to categories via `ACL SETUSER` command.

An example is:

`ACL SETUSER kostas -@SET +@SET` which would not result to `kostas` having the `SET` category enabled (because internally we would first update the `+` and then the `-` which would mess with the ordering. 

This PR fixes this. 

Later on next week I will add uniqueness to SETUSER, that is, the user won't be able to write redundant code like `-@SET +@SET`.