### PR TITLE
chore: Update double-conversion library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,7 +47,11 @@ endfunction()
 
 add_third_party(
   dconv
-  URL https://github.com/google/double-conversion/archive/refs/tags/v3.2.0.tar.gz
+  URL https://github.com/google/double-conversion/archive/refs/tags/v3.3.0.tar.gz
+  PATCH_COMMAND sed -i "/static const std::ctype/d"
+                <SOURCE_DIR>/double-conversion/string-to-double.cc
+  COMMAND sed -i "/std::use_facet</d" <SOURCE_DIR>/double-conversion/string-to-double.cc
+  COMMAND sed -i "s/cType.tolower/std::tolower/g" <SOURCE_DIR>/double-conversion/string-to-double.cc
   LIB libdouble-conversion.a
 )
 


### PR DESCRIPTION
Add double to string coversion tests.
Patch the library to avoid using locale - because freebsd c++ lib does not have this symbol.

changing this function: https://github.com/google/double-conversion/blob/master/double-conversion/string-to-double.cc#L55


<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->