### PR TITLE
feat (hset): Support arguments (count, withvalues) in HRANDFIELD

### DIFF
--- a/src/core/string_map.h
+++ b/src/core/string_map.h
@@ -81,6 +81,12 @@ class StringMap : public DenseSet {
       return *this;
     }
 
+    iterator& operator+=(unsigned int n) {
+      for (unsigned int i = 0; i < n; ++i)
+        Advance();
+      return *this;
+    }
+
     bool operator==(const iterator& b) const {
       return curr_list_ == b.curr_list_;
     }
@@ -116,6 +122,21 @@ class StringMap : public DenseSet {
   iterator end() {
     return iterator{this, true};
   }
+
+  // Returns a random key value pair.
+  // Returns key only if value is a nullptr.
+  std::pair<sds, sds> RandomPair();
+
+  // Randomly selects count of key value pairs. The selections are unique.
+  // if count is larger than the total number of key value pairs, returns
+  // every pair.
+  void RandomPairsUnique(unsigned int count, std::vector<sds>& keys, std::vector<sds>& vals,
+                         bool with_value);
+
+  // Randomly selects count of key value pairs. The select key value pairs
+  // are allowed to have duplications.
+  void RandomPairs(unsigned int count, std::vector<sds>& keys, std::vector<sds>& vals,
+                   bool with_value);
 
  private:
   // Reallocate key and/or value if their pages are underutilized.

--- a/src/server/hset_family_test.cc
+++ b/src/server/hset_family_test.cc
@@ -203,6 +203,117 @@ TEST_F(HSetFamilyTest, HRandFloat) {
   Run({"hrandfield", "k"});
 }
 
+TEST_F(HSetFamilyTest, HRandField) {
+  // exercise Redis' listpack encoding
+  Run({"HSET", "k", "a", "0", "b", "1", "c", "2"});
+
+  EXPECT_THAT(Run({"hrandfield", "k"}), AnyOf("a", "b", "c"));
+
+  EXPECT_THAT(Run({"hrandfield", "k", "2"}).GetVec(), IsSubsetOf({"a", "b", "c"}));
+
+  EXPECT_THAT(Run({"hrandfield", "k", "3"}).GetVec(), UnorderedElementsAre("a", "b", "c"));
+
+  EXPECT_THAT(Run({"hrandfield", "k", "4"}).GetVec(), UnorderedElementsAre("a", "b", "c"));
+
+  auto resp = Run({"hrandfield", "k", "4", "withvalues"});
+  EXPECT_THAT(resp, ArrLen(6));
+  auto vec = resp.GetVec();
+
+  std::vector<RespExpr> k, v;
+  for (unsigned int i = 0; i < vec.size(); ++i) {
+    if (i % 2 == 1)
+      v.push_back(vec[i]);
+    else
+      k.push_back(vec[i]);
+  }
+
+  EXPECT_THAT(v, UnorderedElementsAre("0", "1", "2"));
+  EXPECT_THAT(k, UnorderedElementsAre("a", "b", "c"));
+
+  resp = Run({"hrandfield", "k", "-4", "withvalues"});
+  EXPECT_THAT(resp, ArrLen(8));
+  vec = resp.GetVec();
+  k.clear();
+  v.clear();
+  for (unsigned int i = 0; i < vec.size(); ++i) {
+    if (i % 2 == 0) {
+      if (vec[i] == "a")
+        EXPECT_EQ(vec[i + 1], "0");
+      else if (vec[i] == "b")
+        EXPECT_EQ(vec[i + 1], "1");
+      else if (vec[i] == "c")
+        EXPECT_EQ(vec[i + 1], "2");
+      else
+        ADD_FAILURE();
+    }
+  }
+
+  // exercise Dragonfly's string map encoding
+  int num_entries = 500;
+  for (int i = 0; i < num_entries; i++) {
+    Run({"HSET", "largehash", std::to_string(i), std::to_string(i * 10)});
+  }
+
+  resp = Run({"hrandfield", "largehash"});
+  EXPECT_LE(stoi(resp.GetString()), num_entries - 1);
+  EXPECT_GE(stoi(resp.GetString()), 0);
+
+  resp = Run({"hrandfield", "largehash", std::to_string(num_entries / 2)});
+  vec = resp.GetVec();
+  std::vector<std::string> string_vec;
+  for (auto v : vec) {
+    string_vec.push_back(v.GetString());
+  }
+
+  sort(string_vec.begin(), string_vec.end());
+  auto it = std::unique(string_vec.begin(), string_vec.end());
+  bool is_unique = (it == string_vec.end());
+  EXPECT_TRUE(is_unique);
+
+  for (const auto& str : string_vec) {
+    EXPECT_LE(stoi(str), num_entries - 1);
+    EXPECT_GE(stoi(str), 0);
+  }
+
+  resp = Run({"hrandfield", "largehash", std::to_string(num_entries * -1 - 1)});
+  EXPECT_THAT(resp, ArrLen(num_entries + 1));
+  vec = resp.GetVec();
+
+  string_vec.clear();
+  for (auto v : vec) {
+    string_vec.push_back(v.GetString());
+    int i = stoi(v.GetString());
+    EXPECT_LE(i, num_entries - 1);
+    EXPECT_GE(i, 0);
+  }
+
+  sort(string_vec.begin(), string_vec.end());
+  it = std::unique(string_vec.begin(), string_vec.end());
+  is_unique = (it == string_vec.end());
+  EXPECT_FALSE(is_unique);
+
+  resp = Run({"hrandfield", "largehash", std::to_string(num_entries * -1 - 1), "withvalues"});
+  EXPECT_THAT(resp, ArrLen((num_entries + 1) * 2));
+  vec = resp.GetVec();
+
+  string_vec.clear();
+  for (unsigned int i = 0; i < vec.size(); ++i) {
+    if (i % 2 == 0) {
+      int k = stoi(vec[i].GetString());
+      EXPECT_LE(k, num_entries - 1);
+      EXPECT_GE(k, 0);
+      int v = stoi(vec[i + 1].GetString());
+      EXPECT_EQ(v, k * 10);
+      string_vec.push_back(vec[i].GetString());
+    }
+  }
+
+  sort(string_vec.begin(), string_vec.end());
+  it = std::unique(string_vec.begin(), string_vec.end());
+  is_unique = (it == string_vec.end());
+  EXPECT_FALSE(is_unique);
+}
+
 TEST_F(HSetFamilyTest, HSetEx) {
   TEST_current_time_ms = kMemberExpiryBase * 1000;  // to reset to test time.
 


### PR DESCRIPTION
Fixes: https://github.com/dragonflydb/dragonfly/issues/858

It might possibly fix: https://github.com/dragonflydb/dragonfly/issues/1707

The algorithms that support both encodings (string map and listpack) have been implemented and tested. To use string map requires a larger hset (my tests used 500+ entries)

The random selection algorithms implemented for string map class are the reimplementation of the same algorithms used by Redis' listpack. (therefore same time complexities)

Without this patch:

```
127.0.0.1:6379> HSET coin heads obverse tails reverse edge null
(integer) 3
127.0.0.1:6379> HRANDFIELD coin 3 WITHVALUES
(error) ERR wrong number of arguments for 'hrandfield' command
127.0.0.1:6379> HRANDFIELD coin -1
(error) ERR wrong number of arguments for 'hrandfield' command
127.0.0.1:6379> 
```
after this patch:

```
127.0.0.1:6379> HSET coin heads obverse tails reverse edge null
(integer) 3
127.0.0.1:6379> HRANDFIELD coin -5 WITHVALUES
 1) "tails"
 2) "reverse"
 3) "tails"
 4) "reverse"
 5) "heads"
 6) "obverse"
 7) "tails"
 8) "reverse"
 9) "edge"
10) "null"
127.0.0.1:6379> HRANDFIELD coin 3
1) "heads"
2) "tails"
3) "edge"
127.0.0.1:6379> HRANDFIELD coin 3 WITHVALUES
1) "heads"
2) "obverse"
3) "tails"
4) "reverse"
5) "edge"
6) "null"
```