### PR TITLE
feat(stream): add support for xpending command

### DIFF
--- a/src/server/stream_family.h
+++ b/src/server/stream_family.h
@@ -21,6 +21,7 @@ class StreamFamily {
   static void XGroup(CmdArgList args, ConnectionContext* cntx);
   static void XInfo(CmdArgList args, ConnectionContext* cntx);
   static void XLen(CmdArgList args, ConnectionContext* cntx);
+  static void XPending(CmdArgList args, ConnectionContext* cntx);
   static void XRevRange(CmdArgList args, ConnectionContext* cntx);
   static void XRange(CmdArgList args, ConnectionContext* cntx);
   static void XRead(CmdArgList args, ConnectionContext* cntx);


### PR DESCRIPTION
This PR adds support for `xpending` command. I also created a `StreamCreateNack` function to use test-hookable `GetCurrentTimeMs()` instead of `mstime()`. It gives better control to test stream commands.

Fixes #1161 