### PR TITLE
bug(server): multi cleanup on error

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1729,13 +1729,13 @@ void StartMultiExec(DbIndex dbid, Transaction* trans, ConnectionState::ExecInfo*
 void Service::Exec(CmdArgList args, ConnectionContext* cntx) {
   RedisReplyBuilder* rb = (*cntx).operator->();
 
+  absl::Cleanup exec_clear = [&cntx] { MultiCleanup(cntx); };
+
   if (!cntx->conn_state.exec_info.IsCollecting()) {
     return rb->SendError("EXEC without MULTI");
   }
 
   auto& exec_info = cntx->conn_state.exec_info;
-  absl::Cleanup exec_clear = [&cntx] { MultiCleanup(cntx); };
-
   if (IsWatchingOtherDbs(cntx->db_index(), exec_info)) {
     return rb->SendError("Dragonfly does not allow WATCH and EXEC on different databases");
   }

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -70,6 +70,20 @@ TEST_F(MultiTest, MultiAndFlush) {
   EXPECT_THAT(Run({"FLUSHALL"}), ErrArg("'FLUSHALL' inside MULTI is not allowed"));
 }
 
+TEST_F(MultiTest, MultiWithError) {
+  EXPECT_THAT(Run({"multi"}), "OK");
+  EXPECT_THAT(Run({"set", "x", "y"}), "QUEUED");
+  EXPECT_THAT(Run({"set", "x"}), ErrArg("wrong number of arguments for 'set' command"));
+  EXPECT_THAT(Run({"exec"}), ErrArg("EXEC without MULTI"));
+
+  EXPECT_THAT(Run({"multi"}), "OK");
+  EXPECT_THAT(Run({"set", "z", "y"}), "QUEUED");
+  EXPECT_THAT(Run({"exec"}), "OK");
+
+  EXPECT_THAT(Run({"get", "x"}), ArgType(RespExpr::NIL));
+  EXPECT_THAT(Run({"get", "z"}), "y");
+}
+
 TEST_F(MultiTest, Multi) {
   RespExpr resp = Run({"multi"});
   ASSERT_EQ(resp, "OK");


### PR DESCRIPTION
the bug: when returning error on a command in multi tx we do not cleanup the multi cntx
the fix: cleanup the cntx when error is returned
