### PR TITLE
feat(CI): Configure sccache to work with GCS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,6 @@ jobs:
             cxx_flags: ""
     timeout-minutes: 60
     env:
-      SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_CACHE_SIZE: 6G
       SCCACHE_ERROR_LOG: /tmp/sccache_log.txt
       SCCACHE_LOG: debug
 
@@ -67,6 +65,13 @@ jobs:
           cmake --version
           mkdir -p ${{github.workspace}}/build
 
+      - name: Write GCS service account key
+        shell: bash
+        env:
+          GCS_SERVICE_ACCOUNT_KEY: ${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}
+        run: |
+          echo "$GCS_SERVICE_ACCOUNT_KEY" > /tmp/key.json
+
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
 
@@ -74,8 +79,10 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '')
+            core.exportVariable('SCCACHE_GCS_KEY_PATH', '/tmp/key.json');
+            core.exportVariable('SCCACHE_GCS_BUCKET', 'gh-sccache-storage')
+            core.exportVariable('SCCACHE_GCS_RW_MODE', 'READ_WRITE')
+            core.exportVariable('SCCACHE_GCS_VERBOSE_STATS', '1')
 
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,6 @@ jobs:
     timeout-minutes: 60
     env:
       SCCACHE_ERROR_LOG: /tmp/sccache_log.txt
-      SCCACHE_LOG: debug
 
     container:
       image: ghcr.io/romange/${{ matrix.container }}


### PR DESCRIPTION
This allows sharing of compiled artifacts across PRs, and so speeds up the CI.