### PR TITLE
fix(aws): initialise aws in a proactor

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -426,7 +426,8 @@ void ServerFamily::Init(util::AcceptServer* acceptor, std::vector<facade::Listen
   string flag_dir = GetFlag(FLAGS_dir);
   if (IsCloudPath(flag_dir)) {
     aws_ = make_unique<cloud::AWS>("s3");
-    if (auto ec = aws_->Init(); ec) {
+    auto ec = shard_set->pool()->GetNextProactor()->Await([&] { return aws_->Init(); });
+    if (ec) {
       LOG(FATAL) << "Failed to initialize AWS " << ec;
     }
   }


### PR DESCRIPTION
Fixes https://github.com/dragonflydb/controlplane/issues/226

When running on EC2, `AWS::Init()` makes a network call in `AWS::GetConnectionDataFromMetadata` which uses `ProactorBase::me`, so it must run in a proactor

Also pulls in latest helio changes (which includes other S3 fixes)

Tested on EC2