### PR TITLE
fix: possible segfault bug

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -388,6 +388,9 @@ std::string Connection::LocalBindAddress() const {
 }
 
 string Connection::GetClientInfo(unsigned thread_id) const {
+  CHECK(service_ && socket_);
+  CHECK_LT(unsigned(phase_), NUM_PHASES);
+
   string res;
   auto le = socket_->LocalEndpoint();
   auto re = socket_->RemoteEndpoint();
@@ -403,7 +406,7 @@ string Connection::GetClientInfo(unsigned thread_id) const {
   int my_cpu_id = sched_getcpu();
 #endif
 
-  static constexpr string_view PHASE_NAMES[] = {"readsock", "process"};
+  static constexpr string_view PHASE_NAMES[] = {"setup", "readsock", "process"};
   static_assert(PHASE_NAMES[PROCESS] == "process");
 
   absl::StrAppend(&res, "id=", id_, " addr=", re.address().to_string(), ":", re.port());

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -119,7 +119,7 @@ class Connection : public util::Connection {
     std::variant<MonitorMessage, PubMessagePtr, PipelineMessagePtr, AclUpdateMessage> handle;
   };
 
-  enum Phase { READ_SOCKET, PROCESS };
+  enum Phase { SETUP, READ_SOCKET, PROCESS, NUM_PHASES };
 
  public:
   // Add PubMessage to dispatch queue.
@@ -249,7 +249,7 @@ class Connection : public util::Connection {
 
   time_t creation_time_, last_interaction_;
 
-  Phase phase_;
+  Phase phase_ = SETUP;
   std::string name_;
 
   // A pointer to the ConnectionContext object if it exists. Some connections (like http


### PR DESCRIPTION
A user reported crash in Connection::GetClientInfo function. When connection just start running, its phase_ variable was not initialized, so a possible "CLIENT LIST" command from another connection could trigger invalid data access when printing phase_. To be on the safe side I also verify that other pointers in the function are set (could also be that we have a similar issue during connection shutdown).

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->