### PR TITLE
feat(snapshot): add snapshot storage

### DIFF
--- a/src/server/detail/save_stages_controller.cc
+++ b/src/server/detail/save_stages_controller.cc
@@ -151,6 +151,68 @@ GenericError ValidateFilename(const fs::path& filename, bool new_version) {
   return {};
 }
 
+FileSnapshotStorage::FileSnapshotStorage(FiberQueueThreadPool* fq_threadpool)
+    : fq_threadpool_{fq_threadpool} {
+}
+
+GenericError FileSnapshotStorage::OpenFile(const std::string& path, io::Sink** file,
+                                           bool* is_direct, bool* is_linux_file) {
+  if (fq_threadpool_) {  // EPOLL
+    auto res = util::OpenFiberWriteFile(path, fq_threadpool_);
+    if (!res)
+      return GenericError(res.error(), "Couldn't open file for writing");
+    *file = *res;
+    *is_direct = false;
+    *is_linux_file = false;
+  } else {
+#ifdef __linux__
+    auto res = OpenLinux(path, kRdbWriteFlags, 0666);
+    if (!res) {
+      return GenericError(
+          res.error(),
+          "Couldn't open file for writing (is direct I/O supported by the file system?)");
+    }
+    *file = new LinuxWriteWrapper(res->release());
+    *is_direct = kRdbWriteFlags & O_DIRECT;
+    *is_linux_file = true;
+#else
+    LOG(FATAL) << "Linux I/O is not supported on this platform";
+#endif
+  }
+
+  return {};
+}
+
+AwsS3SnapshotStorage::AwsS3SnapshotStorage(util::cloud::AWS* aws) : aws_{aws} {
+}
+
+GenericError AwsS3SnapshotStorage::OpenFile(const std::string& path, io::Sink** file,
+                                            bool* is_direct, bool* is_linux_file) {
+  DCHECK(aws_);
+
+  optional<pair<string, string>> bucket_path = GetBucketPath(path);
+  if (!bucket_path) {
+    return GenericError("Invalid S3 path");
+  }
+  auto [bucket_name, obj_path] = *bucket_path;
+
+  cloud::S3Bucket bucket(*aws_, bucket_name);
+  error_code ec = bucket.Connect(kBucketConnectMs);
+  if (ec) {
+    return GenericError(ec, "Couldn't connect to S3 bucket");
+  }
+  auto res = bucket.OpenWriteFile(obj_path);
+  if (!res) {
+    return GenericError(res.error(), "Couldn't open file for writing");
+  }
+
+  *file = *res;
+  *is_direct = false;
+  *is_linux_file = false;
+
+  return {};
+}
+
 string InferLoadFile(string_view dir, cloud::AWS* aws) {
   fs::path data_folder;
   string bucket_name, obj_path;
@@ -230,47 +292,12 @@ GenericError RdbSnapshot::Start(SaveMode save_mode, const std::string& path,
   bool is_direct = false;
   VLOG(1) << "Saving RDB " << path;
 
-  if (IsCloudPath(path)) {
-    DCHECK(aws_);
-
-    optional<pair<string, string>> bucket_path = GetBucketPath(path);
-    if (!bucket_path) {
-      return GenericError("Invalid S3 path");
-    }
-    auto [bucket_name, obj_path] = *bucket_path;
-
-    cloud::S3Bucket bucket(*aws_, bucket_name);
-    error_code ec = bucket.Connect(kBucketConnectMs);
-    if (ec) {
-      return GenericError(ec, "Couldn't connect to S3 bucket");
-    }
-    auto res = bucket.OpenWriteFile(obj_path);
-    if (!res) {
-      return GenericError(res.error(), "Couldn't open file for writing");
-    }
-    io_sink_.reset(*res);
-  } else {
-    if (fq_tp_) {  // EPOLL
-      auto res = util::OpenFiberWriteFile(path, fq_tp_);
-      if (!res)
-        return GenericError(res.error(), "Couldn't open file for writing");
-      io_sink_.reset(*res);
-    } else {
-#ifdef __linux__
-      auto res = OpenLinux(path, kRdbWriteFlags, 0666);
-      if (!res) {
-        return GenericError(
-            res.error(),
-            "Couldn't open file for writing (is direct I/O supported by the file system?)");
-      }
-      is_linux_file_ = true;
-      io_sink_.reset(new LinuxWriteWrapper(res->release()));
-      is_direct = kRdbWriteFlags & O_DIRECT;
-#else
-      LOG(FATAL) << "Linux I/O is not supported on this platform";
-#endif
-    }
+  io::Sink* file;
+  GenericError err = snapshot_storage_->OpenFile(path, &file, &is_direct, &is_linux_file_);
+  if (err) {
+    return err;
   }
+  io_sink_.reset(file);
 
   saver_.reset(new RdbSaver(io_sink_.get(), save_mode, is_direct));
 
@@ -431,7 +458,7 @@ GenericError SaveStagesController::InitResources() {
 
   snapshots_.resize(use_dfs_format_ ? shard_set->size() + 1 : 1);
   for (auto& [snapshot, _] : snapshots_)
-    snapshot = make_unique<RdbSnapshot>(fq_threadpool_, aws_->get());
+    snapshot = make_unique<RdbSnapshot>(fq_threadpool_, snapshot_storage_.get());
   return {};
 }
 

--- a/src/server/detail/save_stages_controller.h
+++ b/src/server/detail/save_stages_controller.h
@@ -18,6 +18,37 @@ class Transaction;
 class Service;
 
 namespace detail {
+
+class SnapshotStorage {
+ public:
+  virtual ~SnapshotStorage() = default;
+
+  virtual GenericError OpenFile(const std::string& path, io::Sink** file, bool* is_direct,
+                                bool* is_linux_file) = 0;
+};
+
+class FileSnapshotStorage : public SnapshotStorage {
+ public:
+  FileSnapshotStorage(FiberQueueThreadPool* fq_threadpool);
+
+  GenericError OpenFile(const std::string& path, io::Sink** file, bool* is_direct,
+                        bool* is_linux_file) override;
+
+ private:
+  util::fb2::FiberQueueThreadPool* fq_threadpool_;
+};
+
+class AwsS3SnapshotStorage : public SnapshotStorage {
+ public:
+  AwsS3SnapshotStorage(util::cloud::AWS* aws);
+
+  GenericError OpenFile(const std::string& path, io::Sink** file, bool* is_direct,
+                        bool* is_linux_file) override;
+
+ private:
+  util::cloud::AWS* aws_;
+};
+
 struct SaveStagesInputs {
   bool use_dfs_format_;
   std::string_view basename_;
@@ -28,11 +59,13 @@ struct SaveStagesInputs {
   std::shared_ptr<LastSaveInfo>* last_save_info_;
   util::fb2::Mutex* save_mu_;
   std::unique_ptr<util::cloud::AWS>* aws_;
+  std::shared_ptr<SnapshotStorage> snapshot_storage_;
 };
 
 class RdbSnapshot {
  public:
-  RdbSnapshot(FiberQueueThreadPool* fq_tp, util::cloud::AWS* aws) : fq_tp_{fq_tp}, aws_{aws} {
+  RdbSnapshot(FiberQueueThreadPool* fq_tp, SnapshotStorage* snapshot_storage)
+      : fq_tp_{fq_tp}, snapshot_storage_{snapshot_storage} {
   }
 
   GenericError Start(SaveMode save_mode, const string& path, const RdbSaver::GlobalData& glob_data);
@@ -53,7 +86,7 @@ class RdbSnapshot {
   bool started_ = false;
   bool is_linux_file_ = false;
   util::fb2::FiberQueueThreadPool* fq_tp_ = nullptr;
-  util::cloud::AWS* aws_ = nullptr;
+  SnapshotStorage* snapshot_storage_ = nullptr;
 
   unique_ptr<io::Sink> io_sink_;
   unique_ptr<RdbSaver> saver_;

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -27,6 +27,12 @@ class AWS;
 
 namespace dfly {
 
+namespace detail {
+
+class SnapshotStorage;
+
+}  // namespace detail
+
 std::string GetPassword();
 
 namespace journal {
@@ -242,6 +248,7 @@ class ServerFamily {
   Done schedule_done_;
   std::unique_ptr<FiberQueueThreadPool> fq_threadpool_;
   std::unique_ptr<util::cloud::AWS> aws_;
+  std::shared_ptr<detail::SnapshotStorage> snapshot_storage_;
 };
 
 }  // namespace dfly


### PR DESCRIPTION
As part of cloud snapshots, looking at starting to remove `aws_` and `IsCloudPath` which are quite hard to maintain and will get harder when adding GCP snapshots as well

This starts to move storage specific logic into `SnapshotStorage` which can then be implemented for either local snapshots with `FileSnapshotStore` or AWS S3 with `AwsS3SnapshotStorage` (can then add `GcpStoreSnapshotStorage` later)

Only added `OpenFile` so far figuring its worth checking this approach is ok before doing too much - if its alright will move `InferLoadFile` and parts of `ServerFamily::Load` too so we can add support for loading snapshots from S3

My C++ is a bit rusty so please correct anything that doesn't look right or isn't idiomatic :)

I'm not sure what the standard practice is for tagging reviewers so just tagging at random - please correct if wrong