### PR TITLE
feat(snapshot): move load path to snapshot storage

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(dragonfly_lib channel_store.cc command_registry.cc
             protocol_client.cc
             snapshot.cc script_mgr.cc server_family.cc malloc_stats.cc
             detail/save_stages_controller.cc
+            detail/snapshot_storage.cc
             set_family.cc stream_family.cc string_family.cc
             zset_family.cc version.cc bitops_family.cc container_utils.cc io_utils.cc
             serializer_commons.cc journal/serializer.cc journal/executor.cc journal/streamer.cc

--- a/src/server/detail/save_stages_controller.cc
+++ b/src/server/detail/save_stages_controller.cc
@@ -104,7 +104,7 @@ GenericError RdbSnapshot::Start(SaveMode save_mode, const std::string& path,
                                 const RdbSaver::GlobalData& glob_data) {
   VLOG(1) << "Saving RDB " << path;
 
-  auto res = snapshot_storage_->OpenFile(path);
+  auto res = snapshot_storage_->OpenWriteFile(path);
   if (!res) {
     return res.error();
   }

--- a/src/server/detail/save_stages_controller.cc
+++ b/src/server/detail/save_stages_controller.cc
@@ -6,20 +6,14 @@
 #include "server/detail/save_stages_controller.h"
 
 #include <absl/strings/match.h>
-#include <absl/strings/str_replace.h>
-#include <absl/strings/strip.h>
 
 #include "base/flags.h"
 #include "base/logging.h"
-#include "io/file_util.h"
 #include "server/main_service.h"
 #include "server/script_mgr.h"
 #include "server/search/doc_index.h"
 #include "server/transaction.h"
 #include "strings/human_readable.h"
-#include "util/cloud/s3.h"
-#include "util/fibers/fiber_file.h"
-#include "util/uring/uring_file.h"
 
 using namespace std;
 

--- a/src/server/detail/save_stages_controller.cc
+++ b/src/server/detail/save_stages_controller.cc
@@ -38,29 +38,8 @@ namespace fs = std::filesystem;
 
 namespace {
 
-const size_t kBucketConnectMs = 2000;
-
-#ifdef __linux__
-const int kRdbWriteFlags = O_CREAT | O_WRONLY | O_TRUNC | O_CLOEXEC | O_DIRECT;
-#endif
-
-constexpr string_view kS3Prefix = "s3://"sv;
-
 bool IsCloudPath(string_view path) {
   return absl::StartsWith(path, kS3Prefix);
-}
-
-// Returns bucket_name, obj_path for an s3 path.
-optional<pair<string, string>> GetBucketPath(string_view path) {
-  string_view clean = absl::StripPrefix(path, kS3Prefix);
-
-  size_t pos = clean.find('/');
-  if (pos == string_view::npos)
-    return nullopt;
-
-  string bucket_name{clean.substr(0, pos)};
-  string obj_path{clean.substr(pos + 1)};
-  return make_pair(move(bucket_name), move(obj_path));
 }
 
 string FormatTs(absl::Time now) {
@@ -94,32 +73,6 @@ void ExtendDfsFilenameWithShard(int shard, string_view extension, fs::path* file
   SetExtension(absl::Dec(shard, absl::kZeroPad4), extension, filename);
 }
 
-// takes ownership over the file.
-class LinuxWriteWrapper : public io::Sink {
- public:
-  LinuxWriteWrapper(fb2::LinuxFile* lf) : lf_(lf) {
-  }
-
-  io::Result<size_t> WriteSome(const iovec* v, uint32_t len) final;
-
-  error_code Close() {
-    return lf_->Close();
-  }
-
- private:
-  unique_ptr<fb2::LinuxFile> lf_;
-  off_t offset_ = 0;
-};
-
-io::Result<size_t> LinuxWriteWrapper::WriteSome(const iovec* v, uint32_t len) {
-  io::Result<size_t> res = lf_->WriteSome(v, len, offset_, 0);
-  if (res) {
-    offset_ += *res;
-  }
-
-  return res;
-}
-
 }  // namespace
 
 GenericError ValidateFilename(const fs::path& filename, bool new_version) {
@@ -149,65 +102,6 @@ GenericError ValidateFilename(const fs::path& filename, bool new_version) {
                          "\" for SAVE with type RDB")};
   }
   return {};
-}
-
-FileSnapshotStorage::FileSnapshotStorage(FiberQueueThreadPool* fq_threadpool)
-    : fq_threadpool_{fq_threadpool} {
-}
-
-io::Result<std::pair<io::Sink*, uint8_t>, GenericError> FileSnapshotStorage::OpenFile(
-    const std::string& path) {
-  if (fq_threadpool_) {  // EPOLL
-    auto res = util::OpenFiberWriteFile(path, fq_threadpool_);
-    if (!res) {
-      return nonstd::make_unexpected(GenericError(res.error(), "Couldn't open file for writing"));
-    }
-
-    return std::pair(*res, FileType::FILE);
-  } else {
-#ifdef __linux__
-    auto res = OpenLinux(path, kRdbWriteFlags, 0666);
-    if (!res) {
-      return nonstd::make_unexpected(GenericError(
-          res.error(),
-          "Couldn't open file for writing (is direct I/O supported by the file system?)"));
-    }
-
-    uint8_t file_type = FileType::FILE | FileType::IO_URING;
-    if (kRdbWriteFlags & O_DIRECT) {
-      file_type |= FileType::DIRECT;
-    }
-    return std::pair(new LinuxWriteWrapper(res->release()), file_type);
-#else
-    LOG(FATAL) << "Linux I/O is not supported on this platform";
-#endif
-  }
-}
-
-AwsS3SnapshotStorage::AwsS3SnapshotStorage(util::cloud::AWS* aws) : aws_{aws} {
-}
-
-io::Result<std::pair<io::Sink*, uint8_t>, GenericError> AwsS3SnapshotStorage::OpenFile(
-    const std::string& path) {
-  DCHECK(aws_);
-
-  optional<pair<string, string>> bucket_path = GetBucketPath(path);
-  if (!bucket_path) {
-    return nonstd::make_unexpected(GenericError("Invalid S3 path"));
-  }
-  auto [bucket_name, obj_path] = *bucket_path;
-
-  cloud::S3Bucket bucket(*aws_, bucket_name);
-  error_code ec = bucket.Connect(kBucketConnectMs);
-  if (ec) {
-    return nonstd::make_unexpected(GenericError(ec, "Couldn't connect to S3 bucket"));
-  }
-  auto res = bucket.OpenWriteFile(obj_path);
-  if (!res) {
-    return nonstd::make_unexpected(GenericError(res.error(), "Couldn't open file for writing"));
-  }
-
-  return std::pair<io::Sink*, uint8_t>(*res, FileType::CLOUD);
 }
 
 string InferLoadFile(string_view dir, cloud::AWS* aws) {

--- a/src/server/detail/save_stages_controller.h
+++ b/src/server/detail/save_stages_controller.h
@@ -7,6 +7,7 @@
 
 #include <filesystem>
 
+#include "server/detail/snapshot_storage.h"
 #include "server/rdb_save.h"
 #include "server/server_family.h"
 #include "util/cloud/aws.h"
@@ -18,45 +19,6 @@ class Transaction;
 class Service;
 
 namespace detail {
-
-enum FileType : uint8_t {
-  FILE = (1u << 0),
-  CLOUD = (1u << 1),
-  IO_URING = (1u << 2),
-  DIRECT = (1u << 3),
-};
-
-class SnapshotStorage {
- public:
-  virtual ~SnapshotStorage() = default;
-
-  // Opens the file at the given path, and returns the open file and file
-  // type, which is a bitmask of FileType.
-  virtual io::Result<std::pair<io::Sink*, uint8_t>, GenericError> OpenFile(
-      const std::string& path) = 0;
-};
-
-class FileSnapshotStorage : public SnapshotStorage {
- public:
-  FileSnapshotStorage(FiberQueueThreadPool* fq_threadpool);
-
-  io::Result<std::pair<io::Sink*, uint8_t>, GenericError> OpenFile(
-      const std::string& path) override;
-
- private:
-  util::fb2::FiberQueueThreadPool* fq_threadpool_;
-};
-
-class AwsS3SnapshotStorage : public SnapshotStorage {
- public:
-  AwsS3SnapshotStorage(util::cloud::AWS* aws);
-
-  io::Result<std::pair<io::Sink*, uint8_t>, GenericError> OpenFile(
-      const std::string& path) override;
-
- private:
-  util::cloud::AWS* aws_;
-};
 
 struct SaveStagesInputs {
   bool use_dfs_format_;

--- a/src/server/detail/snapshot_storage.cc
+++ b/src/server/detail/snapshot_storage.cc
@@ -1,0 +1,100 @@
+// Copyright 2023, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#include "server/detail/snapshot_storage.h"
+
+#include <absl/strings/strip.h>
+
+#include "base/logging.h"
+#include "util/cloud/s3.h"
+#include "util/fibers/fiber_file.h"
+
+namespace dfly {
+namespace detail {
+
+std::optional<std::pair<std::string, std::string>> GetBucketPath(std::string_view path) {
+  std::string_view clean = absl::StripPrefix(path, kS3Prefix);
+
+  size_t pos = clean.find('/');
+  if (pos == std::string_view::npos)
+    return std::nullopt;
+
+  std::string bucket_name{clean.substr(0, pos)};
+  std::string obj_path{clean.substr(pos + 1)};
+  return std::make_pair(std::move(bucket_name), std::move(obj_path));
+}
+
+#ifdef __linux__
+const int kRdbWriteFlags = O_CREAT | O_WRONLY | O_TRUNC | O_CLOEXEC | O_DIRECT;
+#endif
+
+FileSnapshotStorage::FileSnapshotStorage(FiberQueueThreadPool* fq_threadpool)
+    : fq_threadpool_{fq_threadpool} {
+}
+
+io::Result<std::pair<io::Sink*, uint8_t>, GenericError> FileSnapshotStorage::OpenFile(
+    const std::string& path) {
+  if (fq_threadpool_) {  // EPOLL
+    auto res = util::OpenFiberWriteFile(path, fq_threadpool_);
+    if (!res) {
+      return nonstd::make_unexpected(GenericError(res.error(), "Couldn't open file for writing"));
+    }
+
+    return std::pair(*res, FileType::FILE);
+  } else {
+#ifdef __linux__
+    auto res = util::fb2::OpenLinux(path, kRdbWriteFlags, 0666);
+    if (!res) {
+      return nonstd::make_unexpected(GenericError(
+          res.error(),
+          "Couldn't open file for writing (is direct I/O supported by the file system?)"));
+    }
+
+    uint8_t file_type = FileType::FILE | FileType::IO_URING;
+    if (kRdbWriteFlags & O_DIRECT) {
+      file_type |= FileType::DIRECT;
+    }
+    return std::pair(new LinuxWriteWrapper(res->release()), file_type);
+#else
+    LOG(FATAL) << "Linux I/O is not supported on this platform";
+#endif
+  }
+}
+
+AwsS3SnapshotStorage::AwsS3SnapshotStorage(util::cloud::AWS* aws) : aws_{aws} {
+}
+
+io::Result<std::pair<io::Sink*, uint8_t>, GenericError> AwsS3SnapshotStorage::OpenFile(
+    const std::string& path) {
+  DCHECK(aws_);
+
+  std::optional<std::pair<std::string, std::string>> bucket_path = GetBucketPath(path);
+  if (!bucket_path) {
+    return nonstd::make_unexpected(GenericError("Invalid S3 path"));
+  }
+  auto [bucket_name, obj_path] = *bucket_path;
+
+  util::cloud::S3Bucket bucket(*aws_, bucket_name);
+  std::error_code ec = bucket.Connect(kBucketConnectMs);
+  if (ec) {
+    return nonstd::make_unexpected(GenericError(ec, "Couldn't connect to S3 bucket"));
+  }
+  auto res = bucket.OpenWriteFile(obj_path);
+  if (!res) {
+    return nonstd::make_unexpected(GenericError(res.error(), "Couldn't open file for writing"));
+  }
+
+  return std::pair<io::Sink*, uint8_t>(*res, FileType::CLOUD);
+}
+
+io::Result<size_t> LinuxWriteWrapper::WriteSome(const iovec* v, uint32_t len) {
+  io::Result<size_t> res = lf_->WriteSome(v, len, offset_, 0);
+  if (res) {
+    offset_ += *res;
+  }
+
+  return res;
+}
+
+}  // namespace detail
+}  // namespace dfly

--- a/src/server/detail/snapshot_storage.h
+++ b/src/server/detail/snapshot_storage.h
@@ -38,8 +38,10 @@ class SnapshotStorage {
 
   // Opens the file at the given path, and returns the open file and file
   // type, which is a bitmask of FileType.
-  virtual io::Result<std::pair<io::Sink*, uint8_t>, GenericError> OpenFile(
+  virtual io::Result<std::pair<io::Sink*, uint8_t>, GenericError> OpenWriteFile(
       const std::string& path) = 0;
+
+  virtual io::ReadonlyFileOrError OpenReadFile(const std::string& path) = 0;
 
   // Returns the path of the RDB file or DFS summary file to load.
   virtual std::string LoadPath(const std::string_view& dir, const std::string_view& dbfilename) = 0;
@@ -52,8 +54,10 @@ class FileSnapshotStorage : public SnapshotStorage {
  public:
   FileSnapshotStorage(FiberQueueThreadPool* fq_threadpool);
 
-  io::Result<std::pair<io::Sink*, uint8_t>, GenericError> OpenFile(
+  io::Result<std::pair<io::Sink*, uint8_t>, GenericError> OpenWriteFile(
       const std::string& path) override;
+
+  io::ReadonlyFileOrError OpenReadFile(const std::string& path) override;
 
   std::string LoadPath(const std::string_view& dir, const std::string_view& dbfilename) override;
 
@@ -67,8 +71,10 @@ class AwsS3SnapshotStorage : public SnapshotStorage {
  public:
   AwsS3SnapshotStorage(util::cloud::AWS* aws);
 
-  io::Result<std::pair<io::Sink*, uint8_t>, GenericError> OpenFile(
+  io::Result<std::pair<io::Sink*, uint8_t>, GenericError> OpenWriteFile(
       const std::string& path) override;
+
+  io::ReadonlyFileOrError OpenReadFile(const std::string& path) override;
 
   std::string LoadPath(const std::string_view& dir, const std::string_view& dbfilename) override;
 

--- a/src/server/detail/snapshot_storage.h
+++ b/src/server/detail/snapshot_storage.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <filesystem>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -15,6 +16,8 @@
 
 namespace dfly {
 namespace detail {
+
+namespace fs = std::filesystem;
 
 using namespace std::literals;
 
@@ -37,6 +40,8 @@ class SnapshotStorage {
   // type, which is a bitmask of FileType.
   virtual io::Result<std::pair<io::Sink*, uint8_t>, GenericError> OpenFile(
       const std::string& path) = 0;
+
+  virtual std::string LoadPath(const std::string_view& dir, const std::string_view& dbfilename) = 0;
 };
 
 class FileSnapshotStorage : public SnapshotStorage {
@@ -45,6 +50,8 @@ class FileSnapshotStorage : public SnapshotStorage {
 
   io::Result<std::pair<io::Sink*, uint8_t>, GenericError> OpenFile(
       const std::string& path) override;
+
+  std::string LoadPath(const std::string_view& dir, const std::string_view& dbfilename) override;
 
  private:
   util::fb2::FiberQueueThreadPool* fq_threadpool_;
@@ -56,6 +63,8 @@ class AwsS3SnapshotStorage : public SnapshotStorage {
 
   io::Result<std::pair<io::Sink*, uint8_t>, GenericError> OpenFile(
       const std::string& path) override;
+
+  std::string LoadPath(const std::string_view& dir, const std::string_view& dbfilename) override;
 
  private:
   util::cloud::AWS* aws_;
@@ -80,6 +89,8 @@ class LinuxWriteWrapper : public io::Sink {
   std::unique_ptr<util::fb2::LinuxFile> lf_;
   off_t offset_ = 0;
 };
+
+void SubstituteFilenameTsPlaceholder(fs::path* filename, std::string_view replacement);
 
 }  // namespace detail
 }  // namespace dfly

--- a/src/server/detail/snapshot_storage.h
+++ b/src/server/detail/snapshot_storage.h
@@ -1,0 +1,85 @@
+// Copyright 2023, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "io/io.h"
+#include "server/common.h"
+#include "util/cloud/aws.h"
+#include "util/fibers/fiberqueue_threadpool.h"
+#include "util/uring/uring_file.h"
+
+namespace dfly {
+namespace detail {
+
+using namespace std::literals;
+
+constexpr std::string_view kS3Prefix = "s3://"sv;
+
+const size_t kBucketConnectMs = 2000;
+
+enum FileType : uint8_t {
+  FILE = (1u << 0),
+  CLOUD = (1u << 1),
+  IO_URING = (1u << 2),
+  DIRECT = (1u << 3),
+};
+
+class SnapshotStorage {
+ public:
+  virtual ~SnapshotStorage() = default;
+
+  // Opens the file at the given path, and returns the open file and file
+  // type, which is a bitmask of FileType.
+  virtual io::Result<std::pair<io::Sink*, uint8_t>, GenericError> OpenFile(
+      const std::string& path) = 0;
+};
+
+class FileSnapshotStorage : public SnapshotStorage {
+ public:
+  FileSnapshotStorage(FiberQueueThreadPool* fq_threadpool);
+
+  io::Result<std::pair<io::Sink*, uint8_t>, GenericError> OpenFile(
+      const std::string& path) override;
+
+ private:
+  util::fb2::FiberQueueThreadPool* fq_threadpool_;
+};
+
+class AwsS3SnapshotStorage : public SnapshotStorage {
+ public:
+  AwsS3SnapshotStorage(util::cloud::AWS* aws);
+
+  io::Result<std::pair<io::Sink*, uint8_t>, GenericError> OpenFile(
+      const std::string& path) override;
+
+ private:
+  util::cloud::AWS* aws_;
+};
+
+// Returns bucket_name, obj_path for an s3 path.
+std::optional<std::pair<std::string, std::string>> GetBucketPath(std::string_view path);
+
+// takes ownership over the file.
+class LinuxWriteWrapper : public io::Sink {
+ public:
+  LinuxWriteWrapper(util::fb2::LinuxFile* lf) : lf_(lf) {
+  }
+
+  io::Result<size_t> WriteSome(const iovec* v, uint32_t len) final;
+
+  std::error_code Close() {
+    return lf_->Close();
+  }
+
+ private:
+  std::unique_ptr<util::fb2::LinuxFile> lf_;
+  off_t offset_ = 0;
+};
+
+}  // namespace detail
+}  // namespace dfly

--- a/src/server/detail/snapshot_storage.h
+++ b/src/server/detail/snapshot_storage.h
@@ -41,7 +41,11 @@ class SnapshotStorage {
   virtual io::Result<std::pair<io::Sink*, uint8_t>, GenericError> OpenFile(
       const std::string& path) = 0;
 
+  // Returns the path of the RDB file or DFS summary file to load.
   virtual std::string LoadPath(const std::string_view& dir, const std::string_view& dbfilename) = 0;
+
+  // Returns the snapshot paths given the RDB file or DFS summary file path.
+  virtual io::Result<std::vector<std::string>> LoadPaths(const std::string& load_path) = 0;
 };
 
 class FileSnapshotStorage : public SnapshotStorage {
@@ -52,6 +56,8 @@ class FileSnapshotStorage : public SnapshotStorage {
       const std::string& path) override;
 
   std::string LoadPath(const std::string_view& dir, const std::string_view& dbfilename) override;
+
+  io::Result<std::vector<std::string>> LoadPaths(const std::string& load_path) override;
 
  private:
   util::fb2::FiberQueueThreadPool* fq_threadpool_;
@@ -65,6 +71,8 @@ class AwsS3SnapshotStorage : public SnapshotStorage {
       const std::string& path) override;
 
   std::string LoadPath(const std::string_view& dir, const std::string_view& dbfilename) override;
+
+  io::Result<std::vector<std::string>> LoadPaths(const std::string& load_path) override;
 
  private:
   util::cloud::AWS* aws_;

--- a/src/server/detail/snapshot_storage.h
+++ b/src/server/detail/snapshot_storage.h
@@ -19,9 +19,7 @@ namespace detail {
 
 namespace fs = std::filesystem;
 
-using namespace std::literals;
-
-constexpr std::string_view kS3Prefix = "s3://"sv;
+constexpr std::string_view kS3Prefix = "s3://";
 
 const size_t kBucketConnectMs = 2000;
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -594,18 +594,7 @@ void ServerFamily::SnapshotScheduling() {
 
 io::Result<size_t> ServerFamily::LoadRdb(const std::string& rdb_file) {
   error_code ec;
-  io::ReadonlyFileOrError res;
-
-#ifdef __linux__
-  if (fq_threadpool_) {
-    res = util::OpenFiberReadFile(rdb_file, fq_threadpool_.get());
-  } else {
-    res = OpenRead(rdb_file);
-  }
-#else
-  res = util::OpenFiberReadFile(rdb_file, fq_threadpool_.get());
-#endif
-
+  io::ReadonlyFileOrError res = snapshot_storage_->OpenReadFile(rdb_file);
   if (res) {
     io::FileSource fs(*res);
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -441,7 +441,7 @@ void ServerFamily::Init(util::AcceptServer* acceptor, std::vector<facade::Listen
     snapshot_storage_ = std::make_shared<detail::FileSnapshotStorage>(nullptr);
   }
 
-  string load_path = detail::InferLoadFile(flag_dir, aws_.get());
+  string load_path = snapshot_storage_->LoadPath(flag_dir, GetFlag(FLAGS_dbfilename));
   if (!load_path.empty()) {
     load_result_ = Load(load_path);
   }


### PR DESCRIPTION
Moves storage specific logic for loading snapshots into `SnapshotStorage` and moves to a new file
* Replaces `InferLoadFile` with `SnapshotStorage::LoadPath`
* Replaces load path logic in `ServerFamily::Load` with `SnapshotStorage::LoadPaths`
  * At some point can probably combine though just moving for now rather than doing any refactoring
* Opens snapshot file with `FileSnapshotStorage::OpenReadFile`

Now should be able to add support for loading snapshots from S3 by implementing `AwsS3SnapshotStorage` methods (will do that in another PR)