### PR TITLE
feat(snapshot): add support for snapshot recovery from S3

### DIFF
--- a/src/server/detail/snapshot_storage.cc
+++ b/src/server/detail/snapshot_storage.cc
@@ -85,8 +85,8 @@ io::ReadonlyFileOrError FileSnapshotStorage::OpenReadFile(const std::string& pat
 #endif
 }
 
-io::Result<std::string, GenericError> FileSnapshotStorage::LoadPath(
-    const std::string_view& dir, const std::string_view& dbfilename) {
+io::Result<std::string, GenericError> FileSnapshotStorage::LoadPath(std::string_view dir,
+                                                                    std::string_view dbfilename) {
   if (dbfilename.empty())
     return "";
 
@@ -212,8 +212,8 @@ io::ReadonlyFileOrError AwsS3SnapshotStorage::OpenReadFile(const std::string& pa
   return res;
 }
 
-io::Result<std::string, GenericError> AwsS3SnapshotStorage::LoadPath(
-    const std::string_view& dir, const std::string_view& dbfilename) {
+io::Result<std::string, GenericError> AwsS3SnapshotStorage::LoadPath(std::string_view dir,
+                                                                     std::string_view dbfilename) {
   if (dbfilename.empty())
     return "";
 
@@ -312,7 +312,7 @@ io::Result<std::vector<std::string>, GenericError> AwsS3SnapshotStorage::LoadPat
 }
 
 io::Result<std::vector<std::string>, GenericError> AwsS3SnapshotStorage::ListObjects(
-    const std::string& bucket_name, const std::string& prefix) {
+    std::string_view bucket_name, std::string_view prefix) {
   util::cloud::S3Bucket bucket(*aws_, bucket_name);
   std::error_code ec = bucket.Connect(kBucketConnectMs);
   if (ec) {

--- a/src/server/detail/snapshot_storage.h
+++ b/src/server/detail/snapshot_storage.h
@@ -42,8 +42,8 @@ class SnapshotStorage {
   virtual io::ReadonlyFileOrError OpenReadFile(const std::string& path) = 0;
 
   // Returns the path of the RDB file or DFS summary file to load.
-  virtual io::Result<std::string, GenericError> LoadPath(const std::string_view& dir,
-                                                         const std::string_view& dbfilename) = 0;
+  virtual io::Result<std::string, GenericError> LoadPath(std::string_view dir,
+                                                         std::string_view dbfilename) = 0;
 
   // Returns the snapshot paths given the RDB file or DFS summary file path.
   virtual io::Result<std::vector<std::string>, GenericError> LoadPaths(
@@ -59,8 +59,8 @@ class FileSnapshotStorage : public SnapshotStorage {
 
   io::ReadonlyFileOrError OpenReadFile(const std::string& path) override;
 
-  io::Result<std::string, GenericError> LoadPath(const std::string_view& dir,
-                                                 const std::string_view& dbfilename) override;
+  io::Result<std::string, GenericError> LoadPath(std::string_view dir,
+                                                 std::string_view dbfilename) override;
 
   io::Result<std::vector<std::string>, GenericError> LoadPaths(
       const std::string& load_path) override;
@@ -78,8 +78,8 @@ class AwsS3SnapshotStorage : public SnapshotStorage {
 
   io::ReadonlyFileOrError OpenReadFile(const std::string& path) override;
 
-  io::Result<std::string, GenericError> LoadPath(const std::string_view& dir,
-                                                 const std::string_view& dbfilename) override;
+  io::Result<std::string, GenericError> LoadPath(std::string_view dir,
+                                                 std::string_view dbfilename) override;
 
   io::Result<std::vector<std::string>, GenericError> LoadPaths(
       const std::string& load_path) override;
@@ -87,8 +87,8 @@ class AwsS3SnapshotStorage : public SnapshotStorage {
  private:
   // List the objects in the given bucket with the given prefix. This must
   // run from a proactor.
-  io::Result<std::vector<std::string>, GenericError> ListObjects(const std::string& bucket_name,
-                                                                 const std::string& prefix);
+  io::Result<std::vector<std::string>, GenericError> ListObjects(std::string_view bucket_name,
+                                                                 std::string_view prefix);
 
   util::cloud::AWS* aws_;
 };

--- a/src/server/detail/snapshot_storage.h
+++ b/src/server/detail/snapshot_storage.h
@@ -79,6 +79,10 @@ class AwsS3SnapshotStorage : public SnapshotStorage {
   io::Result<std::vector<std::string>> LoadPaths(const std::string& load_path) override;
 
  private:
+  // List the objects in the given bucket with the given prefix. This must
+  // run from a proactor.
+  std::vector<std::string> ListObjects(const std::string& bucket_name, const std::string& prefix);
+
   util::cloud::AWS* aws_;
 };
 

--- a/src/server/detail/snapshot_storage.h
+++ b/src/server/detail/snapshot_storage.h
@@ -42,10 +42,12 @@ class SnapshotStorage {
   virtual io::ReadonlyFileOrError OpenReadFile(const std::string& path) = 0;
 
   // Returns the path of the RDB file or DFS summary file to load.
-  virtual std::string LoadPath(const std::string_view& dir, const std::string_view& dbfilename) = 0;
+  virtual io::Result<std::string, GenericError> LoadPath(const std::string_view& dir,
+                                                         const std::string_view& dbfilename) = 0;
 
   // Returns the snapshot paths given the RDB file or DFS summary file path.
-  virtual io::Result<std::vector<std::string>> LoadPaths(const std::string& load_path) = 0;
+  virtual io::Result<std::vector<std::string>, GenericError> LoadPaths(
+      const std::string& load_path) = 0;
 };
 
 class FileSnapshotStorage : public SnapshotStorage {
@@ -57,9 +59,11 @@ class FileSnapshotStorage : public SnapshotStorage {
 
   io::ReadonlyFileOrError OpenReadFile(const std::string& path) override;
 
-  std::string LoadPath(const std::string_view& dir, const std::string_view& dbfilename) override;
+  io::Result<std::string, GenericError> LoadPath(const std::string_view& dir,
+                                                 const std::string_view& dbfilename) override;
 
-  io::Result<std::vector<std::string>> LoadPaths(const std::string& load_path) override;
+  io::Result<std::vector<std::string>, GenericError> LoadPaths(
+      const std::string& load_path) override;
 
  private:
   util::fb2::FiberQueueThreadPool* fq_threadpool_;
@@ -74,14 +78,17 @@ class AwsS3SnapshotStorage : public SnapshotStorage {
 
   io::ReadonlyFileOrError OpenReadFile(const std::string& path) override;
 
-  std::string LoadPath(const std::string_view& dir, const std::string_view& dbfilename) override;
+  io::Result<std::string, GenericError> LoadPath(const std::string_view& dir,
+                                                 const std::string_view& dbfilename) override;
 
-  io::Result<std::vector<std::string>> LoadPaths(const std::string& load_path) override;
+  io::Result<std::vector<std::string>, GenericError> LoadPaths(
+      const std::string& load_path) override;
 
  private:
   // List the objects in the given bucket with the given prefix. This must
   // run from a proactor.
-  std::vector<std::string> ListObjects(const std::string& bucket_name, const std::string& prefix);
+  io::Result<std::vector<std::string>, GenericError> ListObjects(const std::string& bucket_name,
+                                                                 const std::string& prefix);
 
   util::cloud::AWS* aws_;
 };

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -507,12 +507,12 @@ struct AggregateLoadResult {
 // Load starts as many fibers as there are files to load each one separately.
 // It starts one more fiber that waits for all load fibers to finish and returns the first
 // error (if any occured) with a future.
-Future<std::error_code> ServerFamily::Load(const std::string& load_path) {
+Future<GenericError> ServerFamily::Load(const std::string& load_path) {
   auto paths_result = snapshot_storage_->LoadPaths(load_path);
   if (!paths_result) {
     LOG(ERROR) << "Failed to load snapshot: " << paths_result.error().Format();
 
-    Promise<std::error_code> ec_promise;
+    Promise<GenericError> ec_promise;
     ec_promise.set_value(paths_result.error());
     return ec_promise.get_future();
   }
@@ -554,8 +554,8 @@ Future<std::error_code> ServerFamily::Load(const std::string& load_path) {
     load_fibers.push_back(proactor->LaunchFiber(std::move(load_fiber)));
   }
 
-  Promise<std::error_code> ec_promise;
-  Future<std::error_code> ec_future = ec_promise.get_future();
+  Promise<GenericError> ec_promise;
+  Future<GenericError> ec_future = ec_promise.get_future();
 
   // Run fiber that empties the channel and sets ec_promise.
   auto load_join_fiber = [this, aggregated_result, load_fibers = std::move(load_fibers),

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -135,7 +135,7 @@ class ServerFamily {
 
   // Load snapshot from file (.rdb file or summary.dfs file) and return
   // future with error_code.
-  Future<std::error_code> Load(const std::string& file_name);
+  Future<GenericError> Load(const std::string& file_name);
 
   // used within tests.
   bool IsSaving() const {
@@ -220,7 +220,7 @@ class ServerFamily {
   void SnapshotScheduling();
 
   Fiber snapshot_schedule_fb_;
-  Future<std::error_code> load_result_;
+  Future<GenericError> load_result_;
 
   uint32_t stats_caching_task_ = 0;
   Service& service_;


### PR DESCRIPTION
Fixes https://github.com/dragonflydb/controlplane/issues/227.

Adds support for loading snapshots from S3. The Helio S3 client still needs some work to make it more reliable, though this at least gets loading snapshots working.

`AwsS3SnapshotStorage::OpenReadFile` is the same as `AwsS3SnapshotStorage::OpenWriteFile`, so the main changes here are adding `LoadFile` and `LoadFiles` implementations for S3

To match the correct snapshot, unlike `FileSnapshotStorage::LoadFile` we can't use globs, so this instead uses a regex for the timestamp and shard number.

(Note looked at combining `LoadFile` and `LoadFiles` to avoid repeated calls to S3, but since the `DEBUG` command allows explicitly specifying the load path its easier to keep separate. Could cache but doesn't seem worth it for 1 extra call)

Also refactors logging and error handling so both `LoadPath` and `LoadPaths` return a `GenericError` then log the error in one place, rather than logging spread out among arbitrary functions which is hard to follow and easy to miss or forget to update. (Its a bit more verbose though I think its cleaner - can revert if prefered)

Successful load:
```
I20230911 09:23:18.520285 289591 snapshot_storage.cc:225] Load snapshot: Searching for snapshot in S3 path: s3://dev-andy-dfcloud-backups-us-east-1/backupa/
I20230911 09:23:19.355569 289590 server_family.cc:522] Loading s3://dev-andy-dfcloud-backups-us-east-1/backupa/dump-2023-09-11T09:23:16-summary.dfs
```

```
I20230911 09:34:00.932328 290444 snapshot_storage.cc:104] Load snapshot: Searching for snapshot in directory: "/home/andydunstall/projects/dragonfly/dragonfly/build-dbg"
I20230911 09:34:00.932595 290444 server_family.cc:522] Loading /home/andydunstall/projects/dragonfly/dragonfly/build-dbg/dump-2023-09-11T09:33:59-summary.dfs
```

Not found:
```
I20230911 09:23:57.472137 289655 snapshot_storage.cc:225] Load snapshot: Searching for snapshot in S3 path: s3://dev-andy-dfcloud-backups-us-east-1/backupb/
W20230911 09:23:57.864356 289654 server_family.cc:452] Load snapshot: No snapshot found
```

Error:
```
I20230911 09:24:22.830351 289682 snapshot_storage.cc:225] Load snapshot: Searching for snapshot in S3 path: s3://dev-andy-dfcloud-backups-us-east-1/backupb/
E20230911 09:24:23.364082 289681 server_family.cc:454] Failed to load snapshot: Connection refused: Couldn't list objects in S3 bucket
```


### Tasks
- [x] Rebase latest DF and Helio S3 fixes
- [x] Test with different S3 paths and RDB
- [x] Improve logging and error handling when failing to load snapshots