### PR TITLE
Fix a potential crash in OnBreakCb

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -696,7 +696,12 @@ void Connection::OnBreakCb(int32_t mask) {
     return;  // we cancelled the poller, which means we do not need to break from anything.
 
   VLOG(1) << "Got event " << mask;
-  CHECK(cc_);
+
+  if (!cc_) {
+    LOG(ERROR) << "Unexpected event " << mask << " " << break_poll_id_;
+    return;
+  }
+
   cc_->conn_closing = true;
   break_poll_id_ = UINT32_MAX;  // do not attempt to cancel it.
 


### PR DESCRIPTION
I am not sure about the root cause of this flow but we can definitely avoid a check-fail here.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->