### PR TITLE
fix(ServerFamily): proper initialization of FileSnapshotStorage when replicaof flag is used

### DIFF
--- a/src/server/detail/save_stages_controller.cc
+++ b/src/server/detail/save_stages_controller.cc
@@ -98,6 +98,7 @@ GenericError RdbSnapshot::Start(SaveMode save_mode, const std::string& path,
                                 const RdbSaver::GlobalData& glob_data) {
   VLOG(1) << "Saving RDB " << path;
 
+  CHECK_NOTNULL(snapshot_storage_);
   auto res = snapshot_storage_->OpenWriteFile(path);
   if (!res) {
     return res.error();

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1563,5 +1563,8 @@ async def test_df_crash_on_replicaof_flag(df_local_factory):
     await wait_available_async(c_master)
     await wait_available_async(c_replica)
 
-    res = await c_replica.execute_command(f"BGSAVE")
+    res = await c_replica.execute_command("BGSAVE")
     assert True == res
+
+    res = await c_replica.execute_command("DBSIZE")
+    assert res == 0


### PR DESCRIPTION
The issue was that `snapshot_storage_` initialization was skipped when `replicaof` flag was used to start dragonfly.

1. Fixes #1857
2. Add test such that it doesn't happen again