### PR TITLE
feat: Span-all no-key transactional commands

### DIFF
--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -41,7 +41,7 @@ CommandId::CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first
 }
 
 bool CommandId::IsTransactional() const {
-  if (first_key_ > 0 || (opt_mask_ & CO::GLOBAL_TRANS) || (opt_mask_ & CO::NO_KEY_JOURNAL))
+  if (first_key_ > 0 || (opt_mask_ & CO::GLOBAL_TRANS) || (opt_mask_ & CO::NO_KEY_TRANSACTIONAL))
     return true;
 
   if (name_ == "EVAL" || name_ == "EVALSHA" || name_ == "EXEC")
@@ -140,8 +140,8 @@ const char* OptName(CO::CommandOpt fl) {
       return "variadic-keys";
     case NO_AUTOJOURNAL:
       return "custom-journal";
-    case NO_KEY_JOURNAL:
-      return "no-key-journal";
+    case NO_KEY_TRANSACTIONAL:
+      return "no-key-transactional";
   }
   return "unknown";
 }

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -156,6 +156,8 @@ const char* OptName(CO::CommandOpt fl) {
       return "custom-journal";
     case NO_KEY_TRANSACTIONAL:
       return "no-key-transactional";
+    case NO_KEY_TX_SPAN_ALL:
+      return "no-key-tx-span-all";
   }
   return "unknown";
 }

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -40,6 +40,8 @@ enum CommandOpt : uint32_t {
 
   // Allows commands without keys to respect transaction ordering and enables journaling by default
   NO_KEY_TRANSACTIONAL = 1U << 16,
+  NO_KEY_TX_SPAN_ALL =
+      1U << 17,  // If set, all shards are active for the no-key-transactional command
 };
 
 const char* OptName(CommandOpt fl);

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -33,10 +33,13 @@ enum CommandOpt : uint32_t {
   NOSCRIPT = 1U << 8,
   BLOCKING = 1U << 9,  // implies REVERSE_MAPPING
   HIDDEN = 1U << 10,   // does not show in COMMAND command output
+
   GLOBAL_TRANS = 1U << 12,
 
   NO_AUTOJOURNAL = 1U << 15,  // Skip automatically logging command to journal inside transaction.
-  NO_KEY_JOURNAL = 1U << 16,  // Command with no keys that need to be journaled
+
+  // Allows commands without keys to respect transaction ordering and enables journaling by default
+  NO_KEY_TRANSACTIONAL = 1U << 16,
 };
 
 const char* OptName(CommandOpt fl);

--- a/src/server/script_mgr.cc
+++ b/src/server/script_mgr.cc
@@ -132,8 +132,7 @@ void ScriptMgr::LoadCmd(CmdArgList args, ConnectionContext* cntx) {
     return (*cntx)->SendError(res.error().Format());
 
   // Schedule empty callback inorder to journal command via transaction framework.
-  cntx->transaction->EnableShards(0);
-  cntx->transaction->ScheduleSingleHop([&](auto* t, auto* shard) { return OpStatus::OK; });
+  cntx->transaction->ScheduleSingleHop([](auto* t, auto* shard) { return OpStatus::OK; });
 
   return (*cntx)->SendBulkString(res.value());
 }
@@ -151,8 +150,7 @@ void ScriptMgr::ConfigCmd(CmdArgList args, ConnectionContext* cntx) {
   UpdateScriptCaches(key, data);
 
   // Schedule empty callback inorder to journal command via transaction framework.
-  cntx->transaction->EnableShards(0);
-  cntx->transaction->ScheduleSingleHop([&](auto* t, auto* shard) { return OpStatus::OK; });
+  cntx->transaction->ScheduleSingleHop([](auto* t, auto* shard) { return OpStatus::OK; });
 
   return (*cntx)->SendOk();
 }

--- a/src/server/script_mgr.cc
+++ b/src/server/script_mgr.cc
@@ -132,9 +132,9 @@ void ScriptMgr::LoadCmd(CmdArgList args, ConnectionContext* cntx) {
     return (*cntx)->SendError(res.error().Format());
 
   // Schedule empty callback inorder to journal command via transaction framework.
-  auto cb = [&](Transaction* t, EngineShard* shard) { return OpStatus::OK; };
+  cntx->transaction->EnableShards(1);
+  cntx->transaction->ScheduleSingleHop([&](auto* t, auto* shard) { return OpStatus::OK; });
 
-  cntx->transaction->ScheduleSingleHop(std::move(cb));
   return (*cntx)->SendBulkString(res.value());
 }
 
@@ -149,6 +149,10 @@ void ScriptMgr::ConfigCmd(CmdArgList args, ConnectionContext* cntx) {
   }
 
   UpdateScriptCaches(key, data);
+
+  // Schedule empty callback inorder to journal command via transaction framework.
+  cntx->transaction->EnableShards(1);
+  cntx->transaction->ScheduleSingleHop([&](auto* t, auto* shard) { return OpStatus::OK; });
 
   return (*cntx)->SendOk();
 }

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -345,6 +345,8 @@ void SearchFamily::FtInfo(CmdArgList args, ConnectionContext* cntx) {
 
   atomic_uint num_notfound{0};
   vector<DocIndexInfo> infos(shard_set->size());
+
+  cntx->transaction->EnableShards();
   cntx->transaction->ScheduleSingleHop([&](Transaction* t, EngineShard* es) {
     auto* index = es->search_indices()->GetIndex(idx_name);
     if (index == nullptr)
@@ -390,6 +392,7 @@ void SearchFamily::FtList(CmdArgList args, ConnectionContext* cntx) {
   atomic_int first{0};
   vector<string> names;
 
+  cntx->transaction->EnableShards();
   cntx->transaction->ScheduleSingleHop([&](Transaction* t, EngineShard* es) {
     // Using `first` to assign `names` only once without a race
     if (first.fetch_add(1) == 0)
@@ -416,6 +419,7 @@ void SearchFamily::FtSearch(CmdArgList args, ConnectionContext* cntx) {
   atomic<bool> index_not_found{false};
   vector<SearchResult> docs(shard_set->size());
 
+  cntx->transaction->EnableShards();
   cntx->transaction->ScheduleSingleHop([&](Transaction* t, EngineShard* es) {
     if (auto* index = es->search_indices()->GetIndex(index_name); index)
       docs[es->shard_id()] = index->Search(t->GetOpArgs(es), *params, &search_algo);
@@ -452,6 +456,8 @@ void SearchFamily::FtProfile(CmdArgList args, ConnectionContext* cntx) {
   atomic_uint total_serialized = 0;
 
   vector<pair<search::AlgorithmProfile, absl::Duration>> results(shard_set->size());
+
+  cntx->transaction->EnableShards();
   cntx->transaction->ScheduleSingleHop([&](Transaction* t, EngineShard* es) {
     auto* index = es->search_indices()->GetIndex(index_name);
     if (!index)
@@ -521,13 +527,16 @@ void SearchFamily::FtProfile(CmdArgList args, ConnectionContext* cntx) {
 void SearchFamily::Register(CommandRegistry* registry) {
   using CI = CommandId;
 
+  // Disable journaling, because no-key-transactional enables it by default
+  const uint32_t kReadOnlyMask = CO::NO_KEY_TRANSACTIONAL | CO::NO_AUTOJOURNAL;
+
   *registry << CI{"FT.CREATE", CO::GLOBAL_TRANS, -2, 0, 0, 0, acl::FT_SEARCH}.HFUNC(FtCreate)
             << CI{"FT.DROPINDEX", CO::GLOBAL_TRANS, -2, 0, 0, 0, acl::FT_SEARCH}.HFUNC(FtDropIndex)
-            << CI{"FT.INFO", CO::GLOBAL_TRANS, 2, 0, 0, 0, acl::FT_SEARCH}.HFUNC(FtInfo)
+            << CI{"FT.INFO", kReadOnlyMask, 2, 0, 0, 0, acl::FT_SEARCH}.HFUNC(FtInfo)
             // Underscore same as in RediSearch because it's "temporary" (long time already)
-            << CI{"FT._LIST", CO::GLOBAL_TRANS, 1, 0, 0, 0, acl::FT_SEARCH}.HFUNC(FtList)
-            << CI{"FT.SEARCH", CO::GLOBAL_TRANS, -3, 0, 0, 0, acl::FT_SEARCH}.HFUNC(FtSearch)
-            << CI{"FT.PROFILE", CO::GLOBAL_TRANS, -4, 0, 0, 0, acl::FT_SEARCH}.HFUNC(FtProfile);
+            << CI{"FT._LIST", kReadOnlyMask, 1, 0, 0, 0, acl::FT_SEARCH}.HFUNC(FtList)
+            << CI{"FT.SEARCH", kReadOnlyMask, -3, 0, 0, 0, acl::FT_SEARCH}.HFUNC(FtSearch)
+            << CI{"FT.PROFILE", kReadOnlyMask, -4, 0, 0, 0, acl::FT_SEARCH}.HFUNC(FtProfile);
 }
 
 }  // namespace dfly

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2021,7 +2021,8 @@ void ServerFamily::Register(CommandRegistry* registry) {
       << CI{"REPLCONF", CO::ADMIN | CO::LOADING, -1, 0, 0, 0, acl::kReplConf}.HFUNC(ReplConf)
       << CI{"ROLE", CO::LOADING | CO::FAST | CO::NOSCRIPT, 1, 0, 0, 0, acl::kRole}.HFUNC(Role)
       << CI{"SLOWLOG", CO::ADMIN | CO::FAST, -2, 0, 0, 0, acl::kSlowLog}.SetHandler(SlowLog)
-      << CI{"SCRIPT", CO::NOSCRIPT | CO::NO_KEY_JOURNAL, -2, 0, 0, 0, acl::kScript}.HFUNC(Script)
+      << CI{"SCRIPT", CO::NOSCRIPT | CO::NO_KEY_TRANSACTIONAL, -2, 0, 0, 0, acl::kScript}.HFUNC(
+             Script)
       << CI{"DFLY", CO::ADMIN | CO::GLOBAL_TRANS | CO::HIDDEN, -2, 0, 0, 0, acl::kDfly}.HFUNC(Dfly);
 }
 

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1333,7 +1333,7 @@ void Transaction::LogAutoJournalOnShard(EngineShard* shard) {
   if (multi_ && multi_->role == SQUASHER)
     return;
 
-  // Logged commands are either write commands or no-key-transactional
+  // Only write commands and/or no-key-transactional commands are logged
   if ((cid_->opt_mask() & CO::WRITE) == 0 && (cid_->opt_mask() & CO::NO_KEY_TRANSACTIONAL) == 0)
     return;
 

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -82,14 +82,6 @@ void Transaction::InitGlobal() {
     sd.local_mask = ACTIVE;
 }
 
-void Transaction::InitNoKey() {
-  // No key command will use the first shard.
-  unique_shard_cnt_ = 1;
-  unique_shard_id_ = 0;
-  shard_data_.resize(1);
-  shard_data_.front().local_mask |= ACTIVE;
-}
-
 void Transaction::BuildShardIndex(KeyIndex key_index, bool rev_mapping,
                                   std::vector<PerShardCache>* out) {
   auto args = full_args_;
@@ -315,8 +307,8 @@ OpStatus Transaction::InitByArgs(DbIndex index, CmdArgList args) {
     return OpStatus::OK;
   }
 
-  if ((cid_->opt_mask() & CO::NO_KEY_JOURNAL) > 0) {
-    InitNoKey();
+  if ((cid_->opt_mask() & CO::NO_KEY_TRANSACTIONAL) > 0) {
+    // Shards need to enabled with EnableShards()
     return OpStatus::OK;
   }
 
@@ -894,6 +886,24 @@ void Transaction::Conclude() {
   Execute(std::move(cb), true);
 }
 
+void Transaction::EnableShards(std::optional<ShardId> sid) {
+  DCHECK(cid_->opt_mask() & CO::NO_KEY_TRANSACTIONAL);
+
+  if (sid) {
+    unique_shard_cnt_ = 1;
+    unique_shard_id_ = *sid;
+    shard_data_.resize(1);
+    shard_data_.front().local_mask |= ACTIVE;
+    return;
+  }
+
+  unique_shard_cnt_ = shard_set->size();
+  unique_shard_id_ = kInvalidSid;
+  shard_data_.resize(shard_set->size());
+  for (auto& sd : shard_data_)
+    sd.local_mask |= ACTIVE;
+}
+
 void Transaction::RunQuickie(EngineShard* shard) {
   DCHECK(!IsAtomicMulti());
   DCHECK(shard_data_.size() == 1u || multi_->mode == NON_ATOMIC);
@@ -956,7 +966,7 @@ KeyLockArgs Transaction::GetLockArgs(ShardId sid) const {
   res.db_index = db_index_;
   res.key_step = cid_->key_arg_step();
   res.args = GetShardArgs(sid);
-  DCHECK(!res.args.empty() || (cid_->opt_mask() & CO::NO_KEY_JOURNAL));
+  DCHECK(!res.args.empty() || (cid_->opt_mask() & CO::NO_KEY_TRANSACTIONAL));
 
   return res;
 }
@@ -1326,18 +1336,13 @@ void Transaction::LogAutoJournalOnShard(EngineShard* shard) {
   if (multi_ && multi_->role == SQUASHER)
     return;
 
-  bool journal_by_cmd_mask = true;
-  if ((cid_->opt_mask() & CO::NO_KEY_JOURNAL) > 0) {
-    journal_by_cmd_mask = true;  // Enforce journaling for commands that dont change the db.
-  } else if ((cid_->opt_mask() & CO::WRITE) == 0) {
-    journal_by_cmd_mask = false;  // Non-write command are not journaled.
-  } else if ((cid_->opt_mask() & CO::NO_AUTOJOURNAL) > 0 &&
-             !renabled_auto_journal_.load(memory_order_relaxed)) {
-    journal_by_cmd_mask = false;  // Command disabled auto journal.
-  }
-  if (!journal_by_cmd_mask) {
+  // Logged commands are either write commands or no-key-transactional
+  if ((cid_->opt_mask() & CO::WRITE) == 0 && (cid_->opt_mask() & CO::NO_KEY_TRANSACTIONAL) == 0)
     return;
-  }
+
+  // If autojournaling was disabled and not re-enabled, skip it
+  if ((cid_->opt_mask() & CO::NO_AUTOJOURNAL) && !renabled_auto_journal_.load(memory_order_relaxed))
+    return;
 
   auto journal = shard->journal();
   if (journal == nullptr)

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -170,10 +170,6 @@ class Transaction {
   // Conclude transaction
   void Conclude();
 
-  // Enable shards for no-key-transactional commands
-  // If shard is nullopt, enable all shards
-  void EnableShards(std::optional<ShardId> shard = std::nullopt);
-
   // Called by engine shard to execute a transaction hop.
   // txq_ooo is set to true if the transaction is running out of order
   // not as the tx queue head.
@@ -403,11 +399,11 @@ class Transaction {
   // Init as a global transaction.
   void InitGlobal();
 
-  // Init when command has no keys and it need to use transaction framework
-  void InitNoKey();
-
   // Init with a set of keys.
   void InitByKeys(KeyIndex keys);
+
+  void EnableShard(ShardId sid);
+  void EnableAllShards();
 
   // Build shard index by distributing the arguments by shards based on the key index.
   void BuildShardIndex(KeyIndex keys, bool rev_mapping, std::vector<PerShardCache>* out);

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -170,6 +170,10 @@ class Transaction {
   // Conclude transaction
   void Conclude();
 
+  // Enable shards for no-key-transactional commands
+  // If shard is nullopt, enable all shards
+  void EnableShards(std::optional<ShardId> shard = std::nullopt);
+
   // Called by engine shard to execute a transaction hop.
   // txq_ooo is set to true if the transaction is running out of order
   // not as the tx queue head.


### PR DESCRIPTION
Goal: Currently _all_ search commands are global transactions, readonly commands obviously should not be. Yet I want them to keep transactional to make it impossible for those read commands to interleave with write commands. This will guarantee that all read commands access the same search state on all shards.

We already have `NO_KEY_JOURNAL` to make no-key commands be logged in the journal. I changed to `NO_KEY_TRANSACTIONAL` to have a more generic name. (No key journal was used only by SCRIPT).

Additionally, I introduced `EnableShards()` to make it possible to run a no-key-transactional command on all shards