### PR TITLE
fix(Auth): authenticate with any password for default user

### DIFF
--- a/src/server/acl/acl_family_test.cc
+++ b/src/server/acl/acl_family_test.cc
@@ -80,7 +80,10 @@ TEST_F(AclFamilyTest, AclList) {
 
 TEST_F(AclFamilyTest, AclAuth) {
   TestInitAclFam();
-  auto resp = Run({"ACL", "SETUSER", "shahar", ">mypass"});
+  auto resp = Run({"AUTH", "default", R"("")"});
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run({"ACL", "SETUSER", "shahar", ">mypass"});
   EXPECT_THAT(resp, "OK");
 
   resp = Run({"AUTH", "shahar", "wrongpass"});

--- a/src/server/acl/user.cc
+++ b/src/server/acl/user.cc
@@ -68,10 +68,7 @@ void User::SetPasswordHash(std::string_view password, bool is_hashed) {
 
 bool User::HasPassword(std::string_view password) const {
   if (!password_hash_) {
-    if (password == "nopass") {
-      return true;
-    }
-    return false;
+    return true;
   }
   // hash password and compare
   return *password_hash_ == StringSHA256(password);


### PR DESCRIPTION
Address #1862 

Basically, our implementation would only verify the default user with the password `nopass`. This restriction is lifted and now we conform with the redis impl of `AUTH` that authenticates with any password.

Moreover, I should check in a separate PR:

```
Otherwise if the "default" user is not flagged with "nopass"
# the connections will start in not authenticated state, and will require
# AUTH (or the HELLO command AUTH option) in order to be authenticated and
# start to work.
```