### PR TITLE
fix: improve performance of listpack sorted sets

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -469,8 +469,8 @@ int RobjWrapper::ZsetAdd(double score, sds ele, int in_flags, int* out_flags, do
 
       /* check if the element is too large or the list
        * becomes too long *before* executing zzlInsert. */
-      if (zl_len + 1 > server.zset_max_listpack_entries ||
-          sdslen(ele) > server.zset_max_listpack_value || !lpSafeToAdd(lp, sdslen(ele))) {
+      if (zl_len >= server.zset_max_listpack_entries ||
+          sdslen(ele) > server.zset_max_listpack_value) {
         unique_ptr<SortedMap> ss = SortedMap::FromListPack(tl.local_mr, lp);
         lpFree(lp);
         inner_obj_ = ss.release();

--- a/src/redis/listpack.h
+++ b/src/redis/listpack.h
@@ -63,6 +63,8 @@ unsigned char *lpPrepend(unsigned char *lp, const unsigned char *s, uint32_t sle
 unsigned char *lpPrependInteger(unsigned char *lp, long long lval);
 unsigned char *lpAppend(unsigned char *lp, const unsigned char *s, uint32_t slen);
 unsigned char *lpAppendInteger(unsigned char *lp, long long lval);
+unsigned char *lpInsertInteger(unsigned char *lp, long long lval, unsigned char *p, int where,
+                               unsigned char **newp);
 unsigned char *lpReplace(unsigned char *lp, unsigned char **p, const unsigned char *s, uint32_t slen);
 unsigned char *lpReplaceInteger(unsigned char *lp, unsigned char **p, long long lval);
 unsigned char *lpDelete(unsigned char *lp, unsigned char *p, unsigned char **newp);

--- a/src/redis/object.h
+++ b/src/redis/object.h
@@ -180,7 +180,6 @@ void hashTypeCurrentObject(hashTypeIterator *hi, int what, unsigned char **vstr,
 sds hashTypeCurrentObjectNewSds(hashTypeIterator *hi, int what);
 int hashTypeGetValue(robj *o, sds field, unsigned char **vstr, unsigned int *vlen, long long *vll);
 robj *hashTypeGetValueObject(robj *o, sds field);
-int hashTypeSet(robj *o, sds field, sds value, int flags);
 robj *hashTypeDup(robj *o);
 int hashTypeGetFromListpack(robj *o, sds field,
                             unsigned char **vstr,

--- a/src/redis/redis_aux.c
+++ b/src/redis/redis_aux.c
@@ -14,20 +14,16 @@ void InitRedisTables() {
   crc64_init();
   memset(&server, 0, sizeof(server));
 
-  server.page_size = sysconf(_SC_PAGESIZE);
-
   server.maxmemory_policy = 0;
   server.lfu_decay_time = 0;
 
   // been used by t_zset routines that convert listpack to skiplist for cases
   // above these thresholds.
-  server.zset_max_listpack_entries = 128;
-  server.zset_max_listpack_value = 64;
+  server.zset_max_listpack_entries = 100;
+  server.zset_max_listpack_value = 32;
 
-  // Present so that redis code compiles. However, we ignore this field and instead check against
-  // listpack total size in hset_family.cc
-  server.hash_max_listpack_entries = 512;
-  server.hash_max_listpack_value = 32;  // decreased from redis default 64.
+  server.max_map_field_len = 64;
+  server.max_listpack_map_bytes = 1024;
 
   server.stream_node_max_bytes = 4096;
   server.stream_node_max_entries = 100;

--- a/src/redis/redis_aux.h
+++ b/src/redis/redis_aux.h
@@ -71,8 +71,8 @@ typedef struct ServerStub {
   // unused - left so that object.c will compile.
   int maxmemory_policy; /* Policy for key eviction */
 
-  unsigned long page_size;
-  size_t hash_max_listpack_entries, hash_max_listpack_value;
+  size_t max_map_field_len, max_listpack_map_bytes;
+
   size_t zset_max_listpack_entries;
   size_t zset_max_listpack_value;
 

--- a/src/redis/t_hash.c
+++ b/src/redis/t_hash.c
@@ -41,28 +41,6 @@
  * Hash type API
  *----------------------------------------------------------------------------*/
 
-/* Check the length of a number of objects to see if we need to convert a
- * listpack to a real hash. Note that we only check string encoded objects
- * as their string length can be queried in constant time. */
-void hashTypeTryConversion(robj *o, robj **argv, int start, int end) {
-    int i;
-    size_t sum = 0;
-
-    if (o->encoding != OBJ_ENCODING_LISTPACK) return;
-
-    for (i = start; i <= end; i++) {
-        if (!sdsEncodedObject(argv[i]))
-            continue;
-        size_t len = sdslen(argv[i]->ptr);
-        if (len > server.hash_max_listpack_value) {
-            hashTypeConvert(o, OBJ_ENCODING_HT);
-            return;
-        }
-        sum += len;
-    }
-    if (!lpSafeToAdd(o->ptr, sum))
-        hashTypeConvert(o, OBJ_ENCODING_HT);
-}
 
 /* Get the value from a listpack encoded hash, identified by field.
  * Returns -1 when the field cannot be found. */
@@ -186,96 +164,6 @@ int hashTypeExists(robj *o, sds field) {
         serverPanic("Unknown hash encoding");
     }
     return 0;
-}
-
-/* Add a new field, overwrite the old with the new value if it already exists.
- * Return 0 on insert and 1 on update.
- *
- * By default, the key and value SDS strings are copied if needed, so the
- * caller retains ownership of the strings passed. However this behavior
- * can be effected by passing appropriate flags (possibly bitwise OR-ed):
- *
- * HASH_SET_TAKE_FIELD -- The SDS field ownership passes to the function.
- * HASH_SET_TAKE_VALUE -- The SDS value ownership passes to the function.
- *
- * When the flags are used the caller does not need to release the passed
- * SDS string(s). It's up to the function to use the string to create a new
- * entry or to free the SDS string before returning to the caller.
- *
- * HASH_SET_COPY corresponds to no flags passed, and means the default
- * semantics of copying the values if needed.
- *
- */
-#define HASH_SET_TAKE_FIELD (1<<0)
-#define HASH_SET_TAKE_VALUE (1<<1)
-#define HASH_SET_COPY 0
-int hashTypeSet(robj *o, sds field, sds value, int flags) {
-    int update = 0;
-
-    if (o->encoding == OBJ_ENCODING_LISTPACK) {
-        unsigned char *zl, *fptr, *vptr;
-
-        zl = o->ptr;
-        fptr = lpFirst(zl);
-        if (fptr != NULL) {
-            fptr = lpFind(zl, fptr, (unsigned char*)field, sdslen(field), 1);
-            if (fptr != NULL) {
-                /* Grab pointer to the value (fptr points to the field) */
-                vptr = lpNext(zl, fptr);
-                serverAssert(vptr != NULL);
-                update = 1;
-
-                /* Replace value */
-                zl = lpReplace(zl, &vptr, (unsigned char*)value, sdslen(value));
-            }
-        }
-
-        if (!update) {
-            /* Push new field/value pair onto the tail of the listpack */
-            zl = lpAppend(zl, (unsigned char*)field, sdslen(field));
-            zl = lpAppend(zl, (unsigned char*)value, sdslen(value));
-        }
-        o->ptr = zl;
-
-        /* Check if the listpack needs to be converted to a hash table */
-        if (hashTypeLength(o) > server.hash_max_listpack_entries)
-            hashTypeConvert(o, OBJ_ENCODING_HT);
-    } else if (o->encoding == OBJ_ENCODING_HT) {
-        dictEntry *de = dictFind(o->ptr,field);
-        if (de) {
-            sdsfree(dictGetVal(de));
-            if (flags & HASH_SET_TAKE_VALUE) {
-                dictGetVal(de) = value;
-                value = NULL;
-            } else {
-                dictGetVal(de) = sdsdup(value);
-            }
-            update = 1;
-        } else {
-            sds f,v;
-            if (flags & HASH_SET_TAKE_FIELD) {
-                f = field;
-                field = NULL;
-            } else {
-                f = sdsdup(field);
-            }
-            if (flags & HASH_SET_TAKE_VALUE) {
-                v = value;
-                value = NULL;
-            } else {
-                v = sdsdup(value);
-            }
-            dictAdd(o->ptr,f,v);
-        }
-    } else {
-        serverPanic("Unknown hash encoding");
-    }
-
-    /* Free SDS strings we did not referenced elsewhere if the flags
-     * want this function to be responsible. */
-    if (flags & HASH_SET_TAKE_FIELD && field) sdsfree(field);
-    if (flags & HASH_SET_TAKE_VALUE && value) sdsfree(value);
-    return update;
 }
 
 /* Delete an element from a hash.

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -59,8 +59,13 @@ void PerformDeletion(PrimeIterator del_it, ExpireIterator exp_it, EngineShard* s
   size_t value_heap_size = pv.MallocUsed();
   stats.inline_keys -= del_it->first.IsInline();
   stats.obj_memory_usage -= (del_it->first.MallocUsed() + value_heap_size);
-  if (pv.ObjType() == OBJ_STRING)
+  if (pv.ObjType() == OBJ_STRING) {
     stats.strval_memory_usage -= value_heap_size;
+  } else if (pv.ObjType() == OBJ_HASH && pv.Encoding() == kEncodingListPack) {
+    --stats.listpack_blob_cnt;
+  } else if (pv.ObjType() == OBJ_ZSET && pv.Encoding() == OBJ_ENCODING_LISTPACK) {
+    --stats.listpack_blob_cnt;
+  }
 
   if (ClusterConfig::IsEnabled()) {
     string tmp;

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -858,7 +858,7 @@ Usage: dragonfly [FLAGS]
 
   mi_option_enable(mi_option_show_errors);
   mi_option_set(mi_option_max_warnings, 0);
-  mi_option_set(mi_option_decommit_delay, 0);
+  mi_option_set(mi_option_decommit_delay, 1);
 
   unique_ptr<util::ProactorPool> pool;
 

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -31,7 +31,6 @@ using absl::SimpleAtoi;
 
 namespace {
 
-constexpr size_t kMaxListPackLen = 1024;
 using IncrByParam = std::variant<double, int64_t>;
 using OptStr = std::optional<std::string>;
 enum GetAllMode : uint8_t { FIELDS = 1, VALUES = 2 };
@@ -39,12 +38,12 @@ enum GetAllMode : uint8_t { FIELDS = 1, VALUES = 2 };
 bool IsGoodForListpack(CmdArgList args, const uint8_t* lp) {
   size_t sum = 0;
   for (auto s : args) {
-    if (s.size() > server.hash_max_listpack_value)
+    if (s.size() > server.max_map_field_len)
       return false;
     sum += s.size();
   }
 
-  return lpBytes(const_cast<uint8_t*>(lp)) + sum < kMaxListPackLen;
+  return lpBytes(const_cast<uint8_t*>(lp)) + sum < server.max_listpack_map_bytes;
 }
 
 using container_utils::GetStringMap;
@@ -182,7 +181,7 @@ OpStatus OpIncrBy(const OpArgs& op_args, string_view key, string_view field, Inc
       lpb = lpBytes(lp);
       stats->listpack_bytes -= lpb;
 
-      if (lpb >= kMaxListPackLen) {
+      if (lpb >= server.max_listpack_map_bytes) {
         stats->listpack_blob_cnt--;
         StringMap* sm = HSetFamily::ConvertToStrMap(lp);
         pv.InitRobj(OBJ_HASH, kEncodingStrMap2, sm);
@@ -1162,10 +1161,6 @@ void HSetFamily::Register(CommandRegistry* registry) {
       << CI{"HSETNX", CO::WRITE | CO::DENYOOM | CO::FAST, 4, 1, 1, 1, acl::kHSetNx}.HFUNC(HSetNx)
       << CI{"HSTRLEN", CO::READONLY | CO::FAST, 3, 1, 1, 1, acl::kHStrLen}.HFUNC(HStrLen)
       << CI{"HVALS", CO::READONLY, 2, 1, 1, 1, acl::kHVals}.HFUNC(HVals);
-}
-
-uint32_t HSetFamily::MaxListPackLen() {
-  return kMaxListPackLen;
 }
 
 StringMap* HSetFamily::ConvertToStrMap(uint8_t* lp) {

--- a/src/server/hset_family.h
+++ b/src/server/hset_family.h
@@ -21,7 +21,6 @@ using facade::OpStatus;
 class HSetFamily {
  public:
   static void Register(CommandRegistry* registry);
-  static uint32_t MaxListPackLen();
 
   // Does not free lp.
   static StringMap* ConvertToStrMap(uint8_t* lp);

--- a/src/server/hset_family_test.cc
+++ b/src/server/hset_family_test.cc
@@ -35,16 +35,6 @@ class HestFamilyTestProtocolVersioned : public HSetFamilyTest,
 INSTANTIATE_TEST_CASE_P(HestFamilyTestProtocolVersioned, HestFamilyTestProtocolVersioned,
                         ::testing::Values("2", "3"));
 
-TEST_F(HSetFamilyTest, Hash) {
-  robj* obj = createHashObject();
-  sds field = sdsnew("field");
-  sds val = sdsnew("value");
-  hashTypeSet(obj, field, val, 0);
-  sdsfree(field);
-  sdsfree(val);
-  decrRefCount(obj);
-}
-
 TEST_F(HSetFamilyTest, Basic) {
   auto resp = Run({"hset", "x", "a"});
   EXPECT_THAT(resp, ErrArg("wrong number"));

--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -69,6 +69,10 @@ std::string MallocStats(bool backing, unsigned tid) {
   return str;
 }
 
+size_t MemoryUsage(PrimeIterator it) {
+  return it->first.MallocUsed() + it->second.MallocUsed();
+}
+
 }  // namespace
 
 MemoryCmd::MemoryCmd(ServerFamily* owner, ConnectionContext* cntx) : cntx_(cntx) {
@@ -83,15 +87,14 @@ void MemoryCmd::Run(CmdArgList args) {
         "MALLOC-STATS [BACKING] [thread-id]",
         "    Show malloc stats for a heap residing in specified thread-id. 0 by default.",
         "    If BACKING is specified, show stats for the backing heap.",
-        "USAGE",
-        "    (not implemented).",
+        "USAGE <key>",
     };
     return (*cntx_)->SendSimpleStrArr(help_arr);
   };
 
-  if (sub_cmd == "USAGE") {
-    // dummy output, in practice not implemented yet.
-    return (*cntx_)->SendLong(1);
+  if (sub_cmd == "USAGE" && args.size() > 1) {
+    string_view key = ArgS(args, 1);
+    return Usage(key);
   }
 
   if (sub_cmd == "MALLOC-STATS") {
@@ -119,6 +122,24 @@ void MemoryCmd::Run(CmdArgList args) {
 
   string err = UnknownSubCmd(sub_cmd, "MEMORY");
   return (*cntx_)->SendError(err, kSyntaxErrType);
+}
+
+void MemoryCmd::Usage(std::string_view key) {
+  ShardId sid = Shard(key, shard_set->size());
+  ssize_t memory_usage = shard_set->pool()->at(sid)->AwaitBrief([key, this]() -> ssize_t {
+    auto& db_slice = EngineShard::tlocal()->db_slice();
+    auto [pt, exp_t] = db_slice.GetTables(cntx_->db_index());
+    PrimeIterator it = pt->Find(key);
+    if (IsValid(it)) {
+      return MemoryUsage(it);
+    } else {
+      return -1;
+    }
+  });
+
+  if (memory_usage < 0)
+    return cntx_->SendError(kKeyNotFoundErr);
+  (*cntx_)->SendLong(memory_usage);
 }
 
 }  // namespace dfly

--- a/src/server/memory_cmd.h
+++ b/src/server/memory_cmd.h
@@ -17,6 +17,8 @@ class MemoryCmd {
   void Run(CmdArgList args);
 
  private:
+  void Usage(std::string_view key);
+
   ConnectionContext* cntx_;
 };
 

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -332,11 +332,11 @@ TEST_F(RdbTest, SaveManyDbs) {
 
 TEST_F(RdbTest, HMapBugs) {
   // Force kEncodingStrMap2 encoding.
-  server.hash_max_listpack_value = 0;
+  server.max_map_field_len = 0;
   Run({"hset", "hmap1", "key1", "val", "key2", "val2"});
   Run({"hset", "hmap2", "key1", string(690557, 'a')});
 
-  server.hash_max_listpack_value = 32;
+  server.max_map_field_len = 32;
   Run({"debug", "reload"});
   EXPECT_EQ(2, CheckedInt({"hlen", "hmap1"}));
 }
@@ -353,10 +353,10 @@ TEST_F(RdbTest, Issue1305) {
   */
 
   // Force kEncodingStrMap2 encoding.
-  server.hash_max_listpack_value = 0;
+  server.max_map_field_len = 0;
   Run({"hset", "hmap", "key1", "val", "key2", ""});
 
-  server.hash_max_listpack_value = 32;
+  server.max_map_field_len = 32;
   Run({"debug", "reload"});
   EXPECT_EQ(2, CheckedInt({"hlen", "hmap"}));
 }


### PR DESCRIPTION
1. Cherry-pick changes from Redis 7 that encode integer scores more efficiently
2. Introduces optimization that first checks if the new element should be the last for listpack sorted sets.
3. Consolidates listpack related constants and tightens usage for listpack.

When running `redis-zbench-go -mode load -r 100000 -p 6379 -c 40 -key-elements-min=30 -key-elements-max=100` against v.10 and this PR, we improve the throughput by 4x on my machine.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->