### PR TITLE
chore: optimize BPTreeNode::BSearch

### DIFF
--- a/src/core/detail/bptree_internal.h
+++ b/src/core/detail/bptree_internal.h
@@ -370,6 +370,18 @@ template <typename Comp>
 auto BPTreeNode<T>::BSearch(KeyT key, Comp&& cmp_op) const -> SearchResult {
   uint16_t lo = 0;
   uint16_t hi = num_items_;
+  assert(hi > 0);
+
+  // optimization: check the last item first.
+  int cmp_res = cmp_op(key, Key(hi - 1));
+  if (cmp_res >= 0) {
+    return cmp_res > 0 ? SearchResult{.index = hi, .found = false}
+                       : SearchResult{.index = uint16_t(hi - 1), .found = true};
+  }
+
+  // key < Key(hi - 1)
+
+  --hi;
   while (lo < hi) {
     uint16_t mid = (lo + hi) >> 1;
     assert(mid < hi);
@@ -389,7 +401,7 @@ auto BPTreeNode<T>::BSearch(KeyT key, Comp&& cmp_op) const -> SearchResult {
   }
   assert(lo == hi);
 
-  return {.index = hi, .found = 0};
+  return {.index = hi, .found = false};
 }
 
 template <typename T> void BPTreeNode<T>::ShiftRight(unsigned index) {

--- a/src/core/uring.h
+++ b/src/core/uring.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
+#include "util/fibers/uring_file.h"
 #include "util/fibers/uring_proactor.h"
-#include "util/uring/uring_file.h"
 namespace dfly {
 
 using util::fb2::FiberCall;

--- a/src/server/detail/snapshot_storage.cc
+++ b/src/server/detail/snapshot_storage.cc
@@ -13,7 +13,6 @@
 #include "server/engine_shard_set.h"
 #include "util/cloud/s3.h"
 #include "util/fibers/fiber_file.h"
-#include "util/uring/uring_file.h"
 
 namespace dfly {
 namespace detail {

--- a/src/server/detail/snapshot_storage.h
+++ b/src/server/detail/snapshot_storage.h
@@ -12,7 +12,7 @@
 #include "server/common.h"
 #include "util/cloud/aws.h"
 #include "util/fibers/fiberqueue_threadpool.h"
-#include "util/uring/uring_file.h"
+#include "util/fibers/uring_file.h"
 
 namespace dfly {
 namespace detail {

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -926,7 +926,12 @@ OpResult<AddResult> OpAdd(const OpArgs& op_args, const ZParams& zparams, string_
     return OpStatus::OK;
   }
 
-  OpResult<PrimeIterator> res_it = FindZEntry(zparams, op_args, key, members.front().second.size());
+  // When we have too many members to add, make sure field_len is large enough to use
+  // skiplist encoding.
+  size_t field_len = members.size() > server.zset_max_listpack_entries
+                         ? UINT32_MAX
+                         : members.front().second.size();
+  OpResult<PrimeIterator> res_it = FindZEntry(zparams, op_args, key, field_len);
 
   if (!res_it)
     return res_it.status();


### PR DESCRIPTION
Check whether the key is the biggest one before doing the binary search. Also avoid using listpacks if possible during ZADD calls.

Before: 3K qps with `redis-zbench-go -mode load -r 100000 -p 6379 -c 40 -key-elements-min=130 -key-elements-max=200`
Now: 25K qps.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->