### PR TITLE
fix(regression-tests): increase waiting delay for df startup

### DIFF
--- a/tests/dragonfly/__init__.py
+++ b/tests/dragonfly/__init__.py
@@ -11,7 +11,7 @@ from redis.asyncio import Redis as RedisClient
 
 from dataclasses import dataclass
 
-START_DELAY = 0.4
+START_DELAY = 0.8
 START_GDB_DELAY = 3.0
 
 


### PR DESCRIPTION
Sometimes, regression-tests fail because df did not start and the `wait_for_server` times out. I doubled the timeout time `START_DELAY` such that it can increase the window for a DF instance to start properly. This is an experiment and we should see if this reduces the times we timeout on regressions.