### PR TITLE
feat(AclFamily): add acl dryrun command

### DIFF
--- a/src/server/acl/acl_family.h
+++ b/src/server/acl/acl_family.h
@@ -42,6 +42,7 @@ class AclFamily final {
   void Users(CmdArgList args, ConnectionContext* cntx);
   void Cat(CmdArgList args, ConnectionContext* cntx);
   void GetUser(CmdArgList args, ConnectionContext* cntx);
+  void DryRun(CmdArgList args, ConnectionContext* cntx);
 
   // Helper function that updates all open connections and their
   // respective ACL fields on all the available proactor threads

--- a/src/server/acl/acl_family_test.cc
+++ b/src/server/acl/acl_family_test.cc
@@ -242,4 +242,34 @@ TEST_F(AclFamilyTest, TestGetUser) {
   EXPECT_THAT(kvec[5], "+@STRING +HSET");
 }
 
+TEST_F(AclFamilyTest, TestDryRun) {
+  TestInitAclFam();
+  auto resp = Run({"ACL", "DRYRUN"});
+  EXPECT_THAT(resp, ErrArg("ERR wrong number of arguments for 'acl dryrun' command"));
+
+  resp = Run({"ACL", "DRYRUN", "default"});
+  EXPECT_THAT(resp, ErrArg("ERR wrong number of arguments for 'acl dryrun' command"));
+
+  resp = Run({"ACL", "DRYRUN", "default", "get", "more"});
+  EXPECT_THAT(resp, ErrArg("ERR wrong number of arguments for 'acl dryrun' command"));
+
+  resp = Run({"ACL", "DRYRUN", "kostas", "more"});
+  EXPECT_THAT(resp, ErrArg("ERR User: kostas does not exists!"));
+
+  resp = Run({"ACL", "DRYRUN", "default", "nope"});
+  EXPECT_THAT(resp, ErrArg("ERR Command: NOPE does not exists!"));
+
+  resp = Run({"ACL", "DRYRUN", "default", "SET"});
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run({"ACL", "SETUSER", "kostas", "+GET"});
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run({"ACL", "DRYRUN", "kostas", "GET"});
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run({"ACL", "DRYRUN", "kostas", "SET"});
+  EXPECT_THAT(resp, ErrArg("ERR User: kostas is not allowed to execute command: SET"));
+}
+
 }  // namespace dfly

--- a/src/server/acl/validator.cc
+++ b/src/server/acl/validator.cc
@@ -13,13 +13,8 @@ namespace dfly::acl {
 
 [[nodiscard]] bool IsUserAllowedToInvokeCommand(const ConnectionContext& cntx,
                                                 const facade::CommandId& id) {
-  const auto cat_credentials = id.acl_categories();
-
-  const size_t index = id.GetFamily();
-  const uint64_t command_mask = id.GetBitIndex();
-  DCHECK_LT(index, cntx.acl_commands.size());
-  const bool is_authed = (cntx.acl_categories & cat_credentials) != 0 ||
-                         (cntx.acl_commands[index] & command_mask) != 0;
+  const bool is_authed =
+      IsUserAllowedToInvokeCommandGeneric(cntx.acl_categories, cntx.acl_commands, id);
 
   if (!is_authed) {
     auto& log = ServerState::tlocal()->acl_log;
@@ -28,6 +23,16 @@ namespace dfly::acl {
   }
 
   return is_authed;
+}
+
+[[nodiscard]] bool IsUserAllowedToInvokeCommandGeneric(uint32_t acl_cat,
+                                                       const std::vector<uint64_t>& acl_commands,
+                                                       const facade::CommandId& id) {
+  const auto cat_credentials = id.acl_categories();
+  const size_t index = id.GetFamily();
+  const uint64_t command_mask = id.GetBitIndex();
+  DCHECK_LT(index, acl_commands.size());
+  return (acl_cat & cat_credentials) != 0 || (acl_commands[index] & command_mask) != 0;
 }
 
 }  // namespace dfly::acl

--- a/src/server/acl/validator.h
+++ b/src/server/acl/validator.h
@@ -9,6 +9,10 @@
 
 namespace dfly::acl {
 
+bool IsUserAllowedToInvokeCommandGeneric(uint32_t acl_cat,
+                                         const std::vector<uint64_t>& acl_commands,
+                                         const facade::CommandId& id);
+
 bool IsUserAllowedToInvokeCommand(const ConnectionContext& cntx, const facade::CommandId& id);
 
-}
+}  // namespace dfly::acl


### PR DESCRIPTION
* add acl dryrun command
* add unit tests

I decided to omit the optional `ARGS` because it does not make sense in the context of ACL, simply put, `ACL DRYRUN` asserts that a given command is allowed to be executed by the user. Therefore, if the command itself is illformed, is something beyond the scope of `ACL DRYRUN` (plus it would be really hard for us to check given our implementation).

resolves: #1895