### PR TITLE
bug(server): zadd wrong insert when non unique members

### DIFF
--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -73,7 +73,9 @@ struct TransactionGuard {
   };
 
   explicit TransactionGuard(Transaction* t, bool disable_expirations = false) : t(t) {
+    VLOG(1) << "Transaction guard try schedule";
     t->Schedule();
+    VLOG(1) << "Transaction guard schedule";
     t->Execute(
         [disable_expirations](Transaction* t, EngineShard* shard) {
           if (disable_expirations) {

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1701,9 +1701,9 @@ void ZSetFamily::ZAdd(CmdArgList args, ConnectionContext* cntx) {
     return;
   }
 
-  absl::flat_hash_set<string> members_set;
+  absl::flat_hash_set<string_view> members_set;
   absl::InlinedVector<ScoredMemberView, 4> members;
-  bool uniqe_members = true;
+  bool unique_members = true;
   for (; i < args.size(); i += 2) {
     string_view cur_arg = ArgS(args, i);
     double val = 0;
@@ -1716,13 +1716,13 @@ void ZSetFamily::ZAdd(CmdArgList args, ConnectionContext* cntx) {
       return (*cntx)->SendError(kScoreNaN);
     }
     string_view member = ArgS(args, i + 1);
-    auto [_, inserted] = members_set.insert(string(member));
-    uniqe_members &= inserted;
+    auto [_, inserted] = members_set.insert(member);
+    unique_members &= inserted;
     members.emplace_back(val, member);
   }
   DCHECK(cntx->transaction);
 
-  if (uniqe_members) {
+  if (unique_members) {
     std::sort(members.begin(), members.end());
   }
 

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -51,6 +51,14 @@ TEST_F(ZSetFamilyTest, Add) {
   EXPECT_EQ(0.79028573343077946, 0.7902857334307795);
 }
 
+TEST_F(ZSetFamilyTest, AddNonUniqeMembers) {
+  auto resp = Run({"zadd", "zset", "2", "a", "1", "a"});
+  EXPECT_THAT(resp, IntArg(1));
+
+  resp = Run({"zscore", "zset", "a"});
+  EXPECT_EQ(resp, "1");
+}
+
 TEST_F(ZSetFamilyTest, ZRem) {
   auto resp = Run({"zadd", "x", "1.1", "b", "2.1", "a"});
   EXPECT_THAT(resp, IntArg(2));


### PR DESCRIPTION
the bug: when calling zadd with non uniq members the server would result in updating the zset with the higher score instead of the last score given
f.e
zadd myzset 2 a 1 a
will result in member a score 2 while the expected 1 the fix: if the members in zadd command are not unique than we do not sort the members. As a result in this case when we dont sort we will not have perfomace optimization on listpack.
