### PR TITLE
bug(streams): fixing xreadgroup's behavior to be compatible with Redis

### DIFF
--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -136,15 +136,15 @@ const uint32_t STREAM_ITEM_FLAG_NONE = 0;              /* No special flags. */
 const uint32_t STREAM_ITEM_FLAG_DELETED = (1 << 0);    /* Entry is deleted. Skip it. */
 const uint32_t STREAM_ITEM_FLAG_SAMEFIELDS = (1 << 1); /* Same fields as master entry. */
 
-inline string StreamIdRepr(const streamID& id) {
+string StreamIdRepr(const streamID& id) {
   return absl::StrCat(id.ms, "-", id.seq);
 };
 
-inline string NoGroupError(string_view key, string_view cgroup) {
+string NoGroupError(string_view key, string_view cgroup) {
   return absl::StrCat("-NOGROUP No such consumer group '", cgroup, "' for key name '", key, "'");
 }
 
-inline string NoGroupOrKey(string_view key, string_view cgroup, string_view suffix = "") {
+string NoGroupOrKey(string_view key, string_view cgroup, string_view suffix = "") {
   return absl::StrCat("-NOGROUP No such key '", key, "'", " or consumer group '", cgroup, "'",
                       suffix);
 }
@@ -2277,10 +2277,9 @@ void XReadImpl(CmdArgList args, std::optional<ReadOpts> opts, ConnectionContext*
 
       if (opts->read_group && !requested_sitem.group) {
         // if the group associated with the key is not found,
-        // return NoGroupOrKey error.
-        // We are simply mimicking Redis' error message here...
-        // However, we could actually report more precise error message...
-        // continue;
+        // send NoGroupOrKey error.
+        // We are simply mimicking Redis' error message here.
+        // However, we could actually report more precise error message.
         cntx->transaction->Conclude();
         cntx->SendError(NoGroupOrKey(stream, opts->group_name, " in XREADGROUP with GROUP option"));
         return;
@@ -2311,10 +2310,9 @@ void XReadImpl(CmdArgList args, std::optional<ReadOpts> opts, ConnectionContext*
       }
     } else {
       if (opts->read_group) {
-        // if the key is not found,
-        // return NoGroupOrKey error.
-        // We are simply mimicking Redis' error message here...
-        // However, we could actually report more precise error message...
+        // if the key is not found, send NoGroupOrKey error.
+        // We are simply mimicking Redis' error message here.
+        // However, we could actually report more precise error message.
         string error_msg =
             NoGroupOrKey(stream, opts->group_name, " in XREADGROUP with GROUP option");
         cntx->transaction->Conclude();

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -2321,9 +2321,7 @@ void XReadImpl(CmdArgList args, std::optional<ReadOpts> opts, ConnectionContext*
     }
   }
 
-  block = true;
   if (block) {
-    //(*cntx)->SendError("BLOCK SET!");
     return XReadBlock(*opts, cntx);
   }
 

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -1415,7 +1415,7 @@ OpResult<PendingResult> OpPending(const OpArgs& op_args, string_view key, const 
 
 void CreateGroup(CmdArgList args, string_view key, ConnectionContext* cntx) {
   if (args.size() < 2)
-    return (*cntx)->SendError(UnknownSubCmd("CREATE", "XGROUP"));
+    return cntx->SendError(UnknownSubCmd("CREATE", "XGROUP"));
 
   CreateOpts opts;
   opts.gname = ArgS(args, 0);
@@ -2261,7 +2261,7 @@ void XReadImpl(CmdArgList args, std::optional<ReadOpts> opts, ConnectionContext*
     cntx->transaction->Conclude();
 
     if (last_ids.status() == OpStatus::WRONG_TYPE) {
-      (*cntx)->SendError(kWrongTypeErr);
+      cntx->SendError(kWrongTypeErr);
       return;
     }
 
@@ -2282,8 +2282,7 @@ void XReadImpl(CmdArgList args, std::optional<ReadOpts> opts, ConnectionContext*
         // However, we could actually report more precise error message...
         // continue;
         cntx->transaction->Conclude();
-        (*cntx)->SendError(
-            NoGroupOrKey(stream, opts->group_name, " in XREADGROUP with GROUP option"));
+        cntx->SendError(NoGroupOrKey(stream, opts->group_name, " in XREADGROUP with GROUP option"));
         return;
       }
 
@@ -2319,7 +2318,7 @@ void XReadImpl(CmdArgList args, std::optional<ReadOpts> opts, ConnectionContext*
         string error_msg =
             NoGroupOrKey(stream, opts->group_name, " in XREADGROUP with GROUP option");
         cntx->transaction->Conclude();
-        (*cntx)->SendError(error_msg);
+        cntx->SendError(error_msg);
         return;
       }
     }

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -2303,13 +2303,9 @@ void XReadImpl(CmdArgList args, std::optional<ReadOpts> opts, ConnectionContext*
           opts->serve_history = true;
           continue;
         }
-
         requested_sitem.id.val = requested_sitem.group->last_id;
         streamIncrID(&requested_sitem.id.val);
       }
-
-      // std::cout << last_id.ms << "-" << last_id.seq << std::endl;
-      // std::cout << requested_sitem.id.val.ms << "-" << requested_sitem.id.val.seq << std::endl;
 
       if (streamCompareID(&last_id, &requested_sitem.id.val) >= 0) {
         block = false;

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -226,22 +226,30 @@ TEST_F(StreamFamilyTest, XReadGroup) {
 
   // No Group
   resp = Run({"xreadgroup", "group", "nogroup", "alice", "streams", "foo", "0"});
-  EXPECT_THAT(resp, ArgType(RespExpr::ERROR));
+  EXPECT_THAT(
+      resp,
+      ErrArg("No such key 'foo' or consumer group 'nogroup' in XREADGROUP with GROUP option"));
 
   // '>' gives the null array result if group doesn't exist
   resp = Run({"xreadgroup", "group", "group", "alice", "streams", "mystream", ">"});
-  EXPECT_THAT(resp, ArgType(RespExpr::ERROR));
+  EXPECT_THAT(
+      resp,
+      ErrArg("No such key 'mystream' or consumer group 'group' in XREADGROUP with GROUP option"));
 
   Run({"xadd", "foo", "1-*", "k7", "v7"});
   resp = Run({"xreadgroup", "group", "group", "alice", "streams", "mystream", "foo", ">", ">"});
   // returns no group error as "group" was not created for mystream.
-  EXPECT_THAT(resp, ArgType(RespExpr::ERROR));
+  EXPECT_THAT(
+      resp,
+      ErrArg("No such key 'mystream' or consumer group 'group' in XREADGROUP with GROUP option"));
 
   // returns no group error when key doesn't exists
   // this is how Redis' behave
   resp = Run({"xreadgroup", "group", "group", "consumer", "count", "10", "block", "5000", "streams",
               "nostream", ">"});
-  EXPECT_THAT(resp, ArgType(RespExpr::ERROR));
+  EXPECT_THAT(
+      resp,
+      ErrArg("No such key 'nostream' or consumer group 'group' in XREADGROUP with GROUP option"));
 
   // block on empty stream via xgroup create.
   Run({"xgroup", "create", "emptystream", "group", "0", "mkstream"});


### PR DESCRIPTION
fixes https://github.com/dragonflydb/dragonfly/issues/1860

Therefore, now:

```
127.0.0.1:6379> flushdb
OK
127.0.0.1:6379> "XREADGROUP" "GROUP" group consumer COUNT 10 BLOCK 5000 STREAMS stream >
(error) NOGROUP No such key 'stream' or consumer group 'group' in XREADGROUP with GROUP option
```

(used to block for 5 seconds..)

and

```
127.0.0.1:6379> flushdb
OK
127.0.0.1:6379> "XGROUP" "CREATE" stream group "0" MKSTREAM
OK
127.0.0.1:6379> keys *
1) "stream"
127.0.0.1:6379> "XREADGROUP" "GROUP" group consumer COUNT 10 BLOCK 5000 STREAMS stream >
(nil)
(5.02s)
```
(used to return immediately without blocking)