### PR TITLE
bug(server): global command stalls on server load with pipeline mode

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1225,6 +1225,7 @@ Metrics ServerFamily::GetMetrics() const {
     result.ooo_tx_transaction_cnt += ss->stats.ooo_tx_cnt;
     result.eval_io_coordination_cnt += ss->stats.eval_io_coordination_cnt;
     result.eval_shardlocal_coordination_cnt += ss->stats.eval_shardlocal_coordination_cnt;
+    result.cancled_tx_schedule_cnt += ss->stats.cancled_tx_schedule_cnt;
 
     service_.mutable_registry()->MergeCallStats(
         index, [&dest_map = result.cmd_stats_map](string_view name, const CmdCallStats& src) {
@@ -1400,6 +1401,7 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
     append("defrag_task_invocation_total", m.shard_stats.defrag_task_invocation_total);
     append("eval_io_coordination_total", m.eval_io_coordination_cnt);
     append("eval_shardlocal_coordination_total", m.eval_shardlocal_coordination_cnt);
+    append("cancle_tx_schedule", m.cancled_tx_schedule_cnt);
   }
 
   if (should_enter("TIERED", true)) {

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1225,7 +1225,7 @@ Metrics ServerFamily::GetMetrics() const {
     result.ooo_tx_transaction_cnt += ss->stats.ooo_tx_cnt;
     result.eval_io_coordination_cnt += ss->stats.eval_io_coordination_cnt;
     result.eval_shardlocal_coordination_cnt += ss->stats.eval_shardlocal_coordination_cnt;
-    result.cancled_tx_schedule_cnt += ss->stats.cancled_tx_schedule_cnt;
+    result.tx_schedule_cancel_cnt += ss->stats.tx_schedule_cancel_cnt;
 
     service_.mutable_registry()->MergeCallStats(
         index, [&dest_map = result.cmd_stats_map](string_view name, const CmdCallStats& src) {
@@ -1401,7 +1401,7 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
     append("defrag_task_invocation_total", m.shard_stats.defrag_task_invocation_total);
     append("eval_io_coordination_total", m.eval_io_coordination_cnt);
     append("eval_shardlocal_coordination_total", m.eval_shardlocal_coordination_cnt);
-    append("cancle_tx_schedule", m.cancled_tx_schedule_cnt);
+    append("tx_schedule_cancel_total", m.tx_schedule_cancel_cnt);
   }
 
   if (should_enter("TIERED", true)) {

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -67,6 +67,7 @@ struct Metrics {
   uint64_t ooo_tx_transaction_cnt = 0;
   uint64_t eval_io_coordination_cnt = 0;
   uint64_t eval_shardlocal_coordination_cnt = 0;
+  uint64_t cancled_tx_schedule_cnt = 0;
   uint32_t traverse_ttl_per_sec = 0;
   uint32_t delete_ttl_per_sec = 0;
   bool is_master = true;

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -67,7 +67,7 @@ struct Metrics {
   uint64_t ooo_tx_transaction_cnt = 0;
   uint64_t eval_io_coordination_cnt = 0;
   uint64_t eval_shardlocal_coordination_cnt = 0;
-  uint64_t cancled_tx_schedule_cnt = 0;
+  uint64_t tx_schedule_cancel_cnt = 0;
   uint32_t traverse_ttl_per_sec = 0;
   uint32_t delete_ttl_per_sec = 0;
   bool is_master = true;

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -94,6 +94,7 @@ class ServerState {  // public struct - to allow initialization.
     uint64_t ooo_tx_cnt = 0;
     uint64_t eval_io_coordination_cnt = 0;
     uint64_t eval_shardlocal_coordination_cnt = 0;
+    uint64_t cancled_tx_schedule_cnt = 0;
   };
 
   static ServerState* tlocal() {

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -94,7 +94,7 @@ class ServerState {  // public struct - to allow initialization.
     uint64_t ooo_tx_cnt = 0;
     uint64_t eval_io_coordination_cnt = 0;
     uint64_t eval_shardlocal_coordination_cnt = 0;
-    uint64_t cancled_tx_schedule_cnt = 0;
+    uint64_t tx_schedule_cancel_cnt = 0;
   };
 
   static ServerState* tlocal() {

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -594,7 +594,7 @@ void Transaction::ScheduleInternal() {
     }
 
     VLOG(2) << "Cancelling " << DebugId();
-    ServerState::tlocal()->stats.cancled_tx_schedule_cnt += 1;
+    ServerState::tlocal()->stats.tx_schedule_cancel_cnt += 1;
 
     atomic_bool should_poll_execution{false};
     auto cancel = [&](EngineShard* shard) {


### PR DESCRIPTION
fixes #1797 
the bug: global command is not able to schedule into txq when high load pipelined commands. Only after the load finish the global transaction gets scheduled into the txq. The reason for this is when we start a global transaction we set the shard lock and all the transactions start to enter the txq. They compete with the global tx on the order they are inserted into the queue to preserve transaction atomicity. Because the global tx needs to be inserted to all shard queues its chance to schedule with order with all the other transactions is low. 
the solution: lock the global transaction inside the schedule in shard, locking closer to scheduling decreases the number of transactions in the queue and the competition on ordering correctly has higher chance now.
