### PR TITLE
chore: Avoid allocating unique_members arrays 

### DIFF
--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -195,6 +195,7 @@ bool ParseDouble(string_view src, double* value) {
     *value = HUGE_VAL;
   } else {
     fast_float::from_chars_result result = fast_float::from_chars(src.data(), src.end(), *value);
+    // nan double could be sent as "nan" with any case.
     if (int(result.ec) != 0 || result.ptr != src.end() || isnan(*value))
       return false;
   }

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -52,11 +52,15 @@ TEST_F(ZSetFamilyTest, Add) {
 }
 
 TEST_F(ZSetFamilyTest, AddNonUniqeMembers) {
-  auto resp = Run({"zadd", "zset", "2", "a", "1", "a"});
+  auto resp = Run({"zadd", "x", "2", "a", "1", "a"});
   EXPECT_THAT(resp, IntArg(1));
 
-  resp = Run({"zscore", "zset", "a"});
+  resp = Run({"zscore", "x", "a"});
   EXPECT_EQ(resp, "1");
+
+  resp = Run({"zadd", "y", "3", "a", "1", "a", "2", "b"});
+  EXPECT_THAT(resp, IntArg(2));
+  EXPECT_EQ("1", Run({"zscore", "y", "a"}));
 }
 
 TEST_F(ZSetFamilyTest, ZRem) {


### PR DESCRIPTION
when we have 1 or 2 members.
I assume that using ZADD with a single member is probably the most common usecase

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->