### PR TITLE
chore: remove redundant Find calls when inserting into DenseSet

### DIFF
--- a/src/core/dense_set.h
+++ b/src/core/dense_set.h
@@ -253,7 +253,7 @@ class DenseSet {
     return false;
   }
 
-  void* FindInternal(const void* obj, uint32_t cookie) const;
+  void* FindInternal(const void* obj, uint64_t hashcode, uint32_t cookie) const;
   void* PopInternal();
 
   // Note this does not free any dynamic allocations done by derived classes, that a DensePtr
@@ -279,6 +279,9 @@ class DenseSet {
   // Returns the previous object if it has been replaced.
   // nullptr, if obj was added.
   void* AddOrReplaceObj(void* obj, bool has_ttl);
+
+  // Assumes that the object does not exist in the set.
+  void AddUnique(void* obj, bool has_ttl, uint64_t hashcode);
 
  private:
   DenseSet(const DenseSet&) = delete;
@@ -346,11 +349,12 @@ class DenseSet {
   uint32_t time_now_ = 0;
 };
 
-inline void* DenseSet::FindInternal(const void* obj, uint32_t cookie) const {
+inline void* DenseSet::FindInternal(const void* obj, uint64_t hashcode, uint32_t cookie) const {
   if (entries_.empty())
     return nullptr;
 
-  DensePtr* ptr = const_cast<DenseSet*>(this)->Find(obj, BucketId(obj, cookie), cookie).second;
+  uint32_t bid = BucketId(hashcode);
+  DensePtr* ptr = const_cast<DenseSet*>(this)->Find(obj, bid, cookie).second;
   return ptr ? ptr->GetObject() : nullptr;
 }
 

--- a/src/core/score_map.h
+++ b/src/core/score_map.h
@@ -85,10 +85,14 @@ class ScoreMap : public DenseSet {
   // false, if already exists. In that case no update is done.
   std::pair<void*, bool> AddOrSkip(std::string_view field, double value);
 
-  bool Erase(std::string_view s1);
+  void* AddUnique(std::string_view field, double value);
 
-  bool Erase(sds s1) {
-    return EraseInternal(s1, 0);
+  bool Erase(std::string_view field) {
+    return EraseInternal(&field, 1);
+  }
+
+  bool Erase(sds field) {
+    return EraseInternal(field, 0);
   }
 
   /// @brief  Returns value of the key or nullptr if key not found.
@@ -98,10 +102,12 @@ class ScoreMap : public DenseSet {
 
   // returns the internal object if found, otherwise nullptr.
   void* FindObj(sds ele) {
-    return FindInternal(ele, 0);
+    return FindInternal(ele, Hash(ele, 0), 0);
   }
 
-  void Clear();
+  void Clear() {
+    ClearInternal();
+  }
 
   iterator begin() {
     return iterator{this, false};

--- a/src/core/sorted_map.cc
+++ b/src/core/sorted_map.cc
@@ -435,13 +435,11 @@ int SortedMap::DfImpl::Add(double score, sds ele, int in_flags, int* out_flags, 
       return 1;
     }
 
-    auto [newk, added] = score_map->AddOrUpdate(string_view{ele, sdslen(ele)}, score);
-    DCHECK(added);
+    obj = score_map->AddUnique(string_view{ele, sdslen(ele)}, score);
 
     *out_flags = ZADD_OUT_ADDED;
     *newscore = score;
-    obj = newk;
-    added = score_tree->Insert(obj);
+    bool added = score_tree->Insert(obj);
     DCHECK(added);
 
     return 1;

--- a/src/core/string_set.cc
+++ b/src/core/string_set.cc
@@ -68,18 +68,6 @@ bool StringSet::Add(string_view src, uint32_t ttl_sec) {
   return true;
 }
 
-bool StringSet::Erase(string_view str) {
-  return EraseInternal(&str, 1);
-}
-
-bool StringSet::Contains(string_view s1) const {
-  return FindInternal(&s1, 1) != nullptr;
-}
-
-void StringSet::Clear() {
-  ClearInternal();
-}
-
 std::optional<std::string> StringSet::Pop() {
   sds str = (sds)PopInternal();
 

--- a/src/core/string_set.h
+++ b/src/core/string_set.h
@@ -31,11 +31,17 @@ class StringSet : public DenseSet {
   // Used currently by rdb_load. Returns true if elem was added.
   bool AddSds(sds elem);
 
-  bool Erase(std::string_view s1);
+  bool Erase(std::string_view str) {
+    return EraseInternal(&str, 1);
+  }
 
-  bool Contains(std::string_view s1) const;
+  bool Contains(std::string_view s1) const {
+    return FindInternal(&s1, Hash(&s1, 1), 1) != nullptr;
+  }
 
-  void Clear();
+  void Clear() {
+    ClearInternal();
+  }
 
   std::optional<std::string> Pop();
 


### PR DESCRIPTION
A regular DenseSet insertion first checks for uniqueness and then inserts a new element. Sometimes we know that the new element is new and we can insert it without checking for uniqueness first.

Also, pass hashcode into internal functions so we could save some hash calls.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->