### PR TITLE
fix(dragonfly_test): failing bug207 on build opt

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -152,7 +152,7 @@ bool PrimeEvictionPolicy::CanGrow(const PrimeTable& tbl) const {
   if (!apply_memory_limit_ || mem_budget_ > soft_limit_)
     return true;
 
-  DCHECK_LT(tbl.size(), tbl.capacity());
+  DCHECK_LE(tbl.size(), tbl.capacity());
 
   // We take a conservative stance here -
   // we estimate how much memory we will take with the current capacity

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -380,16 +380,15 @@ TEST_F(DflyEngineTest, OOM) {
 /// Reproduces the case where items with expiry data were evicted,
 /// and then written with the same key.
 TEST_F(DflyEngineTest, Bug207) {
+  max_memory_limit = 300000;
   shard_set->TEST_EnableHeartBeat();
   shard_set->TEST_EnableCacheMode();
   absl::FlagSaver fs;
   absl::SetFlag(&FLAGS_oom_deny_ratio, 4);
 
-  max_memory_limit = 300000;
-
   ssize_t i = 0;
   RespExpr resp;
-  for (; i < 5000; ++i) {
+  for (; i < 10000; ++i) {
     resp = Run({"setex", StrCat("key", i), "30", "bar"});
     // we evict some items because 5000 is too much when max_memory_limit is 300000.
     ASSERT_EQ(resp, "OK");


### PR DESCRIPTION
The issue was that the `Heartbeat` would run every `1ms` and this is problematic because the `for-loop` would take less than `1ms` to finish. Therefore, the memory pool would not adjust and items would not be evicted from the store. By doubling the amount of elements created in the for-loop, we give enough time for the first heartbeat to run and adjust the memory available (which will cause the evictions to happen). 

This passes locally but if we see flakes on the CI we can slightly increase the elements we create in the forloop again. 