### PR TITLE
chore: implement ParseDouble using fast_float

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,6 +109,12 @@ add_third_party(
   LIB "none"
 )
 
+add_third_party(
+  fast_float
+  URL https://github.com/fastfloat/fast_float/archive/refs/tags/v5.2.0.tar.gz
+  LIB "none"
+)
+
 add_library(TRDP::jsoncons INTERFACE IMPORTED)
 add_dependencies(TRDP::jsoncons jsoncons_project)
 set_target_properties(TRDP::jsoncons PROPERTIES
@@ -123,6 +129,11 @@ add_library(TRDP::hnswlib INTERFACE IMPORTED)
 add_dependencies(TRDP::hnswlib hnswlib_project)
 set_target_properties(TRDP::hnswlib PROPERTIES
                       INTERFACE_INCLUDE_DIRECTORIES "${HNSWLIB_INCLUDE_DIR}")
+
+add_library(TRDP::fast_float INTERFACE IMPORTED)
+add_dependencies(TRDP::fast_float fast_float_project)
+set_target_properties(TRDP::fast_float PROPERTIES
+                      INTERFACE_INCLUDE_DIRECTORIES "${FAST_FLOAT_INCLUDE_DIR}")
 
 Message(STATUS "THIRD_PARTY_LIB_DIR ${THIRD_PARTY_LIB_DIR}")
 

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -20,7 +20,7 @@ add_library(dfly_transaction db_slice.cc malloc_stats.cc engine_shard_set.cc blo
             serializer_commons.cc journal/serializer.cc journal/executor.cc journal/streamer.cc
             ${TX_LINUX_SRCS} acl/acl_log.cc
             )
-cxx_link(dfly_transaction dfly_core strings_lib)
+cxx_link(dfly_transaction dfly_core strings_lib TRDP::fast_float)
 
 
 if (NOT APPLE)
@@ -47,7 +47,8 @@ add_library(dragonfly_lib channel_store.cc command_registry.cc
 find_library(ZSTD_LIB NAMES libzstd.a libzstdstatic.a zstd NAMES_PER_DIR REQUIRED)
 
 cxx_link(dragonfly_lib dfly_transaction dfly_facade redis_lib aws_lib strings_lib html_lib
-         http_client_lib absl::random_random TRDP::jsoncons ${ZSTD_LIB} TRDP::lz4 TRDP::croncpp)
+         http_client_lib absl::random_random TRDP::jsoncons ${ZSTD_LIB} TRDP::lz4
+         TRDP::croncpp)
 
 if (DF_USE_SSL)
   set(TLS_LIB tls_lib)

--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -4,9 +4,9 @@
 
 #include "server/common.h"
 
-#include <absl/strings/charconv.h>
 #include <absl/strings/match.h>
 #include <absl/strings/str_cat.h>
+#include <fast_float/fast_float.h>
 
 #include <system_error>
 
@@ -194,7 +194,7 @@ bool ParseDouble(string_view src, double* value) {
   } else if (absl::EqualsIgnoreCase(src, "+inf")) {
     *value = HUGE_VAL;
   } else {
-    absl::from_chars_result result = absl::from_chars(src.data(), src.end(), *value);
+    fast_float::from_chars_result result = fast_float::from_chars(src.data(), src.end(), *value);
     if (int(result.ec) != 0 || result.ptr != src.end() || isnan(*value))
       return false;
   }

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -8,8 +8,10 @@ extern "C" {
 }
 
 #include <absl/strings/ascii.h>
+#include <absl/strings/charconv.h>
 #include <absl/strings/str_join.h>
 #include <absl/strings/strip.h>
+#include <fast_float/fast_float.h>
 #include <gmock/gmock.h>
 
 #include "base/flags.h"
@@ -666,5 +668,38 @@ TEST_F(DflyEngineTest, Latency) {
 // TODO: to test transactions with a single shard since then all transactions become local.
 // To consider having a parameter in dragonfly engine controlling number of shards
 // unconditionally from number of cpus. TO TEST BLPOP under multi for single/multi argument case.
+
+// Parse Double benchmarks
+static void BM_ParseFastFloat(benchmark::State& state) {
+  std::vector<std::string> args(100);
+  std::random_device rd;
+
+  for (auto& arg : args) {
+    arg = std::to_string(std::uniform_real_distribution<double>(0, 1e5)(rd));
+  }
+  double res;
+  while (state.KeepRunning()) {
+    for (const auto& arg : args) {
+      fast_float::from_chars(arg.data(), arg.data() + arg.size(), res);
+    }
+  }
+}
+BENCHMARK(BM_ParseFastFloat);
+
+static void BM_ParseDoubleAbsl(benchmark::State& state) {
+  std::vector<std::string> args(100);
+  std::random_device rd;
+  for (auto& arg : args) {
+    arg = std::to_string(std::uniform_real_distribution<double>(0, 1e5)(rd));
+  }
+
+  double res;
+  while (state.KeepRunning()) {
+    for (const auto& arg : args) {
+      absl::from_chars(arg.data(), arg.data() + arg.size(), res);
+    }
+  }
+}
+BENCHMARK(BM_ParseDoubleAbsl);
 
 }  // namespace dfly

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -9,7 +9,6 @@ extern "C" {
 }
 
 #include <absl/container/inlined_vector.h>
-#include <double-conversion/string-to-double.h>
 
 #include <algorithm>
 #include <array>
@@ -35,7 +34,6 @@ namespace {
 
 using namespace std;
 using namespace facade;
-using namespace double_conversion;
 
 using CI = CommandId;
 DEFINE_VARZ(VarzQps, set_qps);
@@ -253,10 +251,8 @@ OpResult<double> OpIncrFloat(const OpArgs& op_args, string_view key, double val)
   string tmp;
   string_view slice = GetSlice(op_args.shard, it->second, &tmp);
 
-  StringToDoubleConverter stod(StringToDoubleConverter::NO_FLAGS, 0, 0, NULL, NULL);
-  int processed_digits = 0;
-  double base = stod.StringToDouble(slice.data(), slice.size(), &processed_digits);
-  if (unsigned(processed_digits) != slice.size()) {
+  double base = 0;
+  if (!ParseDouble(slice, &base)) {
     return OpStatus::INVALID_FLOAT;
   }
 


### PR DESCRIPTION
Integrate a wonderful library fast_float by Daniel Lemire. It achieves x2 improvement on x86_64:
```
BM_ParseFastFloat         663 ns          663 ns      1049085
BM_ParseDoubleAbsl       1358 ns         1358 ns       523853
```

on c6g:

```
BM_ParseFastFloat        2207 ns         2207 ns       317968
BM_ParseDoubleAbsl       5028 ns         5028 ns       139341
```
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->