### PR TITLE
chore: performance improvements around zset

### DIFF
--- a/src/core/dense_set.h
+++ b/src/core/dense_set.h
@@ -331,8 +331,15 @@ class DenseSet {
     mr()->deallocate(plink, sizeof(DenseLinkKey), alignof(DenseLinkKey));
   }
 
-  // Returns true if *ptr was deleted.
-  bool ExpireIfNeeded(DensePtr* prev, DensePtr* ptr) const;
+  // Returns true if *node was deleted.
+  bool ExpireIfNeeded(DensePtr* prev, DensePtr* node) const {
+    if (node->HasTtl()) {
+      return ExpireIfNeededInternal(prev, node);
+    }
+    return false;
+  }
+
+  bool ExpireIfNeededInternal(DensePtr* prev, DensePtr* node) const;
 
   // Deletes the object pointed by ptr and removes it from the set.
   // If ptr is a link then it will be deleted internally.

--- a/src/core/sorted_map.h
+++ b/src/core/sorted_map.h
@@ -170,7 +170,7 @@ class SortedMap {
     size_t MallocSize() const;
 
     bool Reserve(size_t sz) {
-      return dictExpand(dict, 1) == DICT_OK;
+      return dictExpand(dict, sz) == DICT_OK;
     }
 
     size_t DeleteRangeByRank(unsigned start, unsigned end) {

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -56,6 +56,7 @@ void SinkReplyBuilder::Send(const iovec* v, uint32_t len) {
 
   // Allow batching with up to kMaxBatchSize of data.
   if ((should_batch_ || should_aggregate_) && (batch_.size() + bsize < kMaxBatchSize)) {
+    batch_.reserve(batch_.size() + bsize);
     for (unsigned i = 0; i < len; ++i) {
       std::string_view src((char*)v[i].iov_base, v[i].iov_len);
       DVLOG(3) << "Appending to stream " << absl::CHexEscape(src);


### PR DESCRIPTION
1. ExpireIfNeeded was unjuistifiedly high in the profile topk table. Lets make the initial condition within an inline to reduce its impact.
2. Reserve space for hmap/zset if multiple items are added.
3. Fix DenseSet::Reserve that was broken and never actually worked

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->