### PR TITLE
feat(build): fix lua on mac arm64

### DIFF
--- a/patches/lua-v5.4.4.patch
+++ b/patches/lua-v5.4.4.patch
@@ -32,7 +32,7 @@ index d46e650c..c27e5677 100644
 +# equivalent to: if $(uname_m) == x86_64 || $(uname_m) == amd64
 +ifneq (, $(filter $(uname_m),x86_64 amd64))
 +OPTFLAGS= -march=sandybridge
-+else ifeq ($(uname_m), aarch64)
++else ifneq (, $(filter $(uname_m),aarch64 arm64))
 +OPTFLAGS= -march=armv8.2-a+fp16+rcpc+dotprod+crypto
 +else ifeq ($(uname_m), s390x)
 +OPTFLAGS= -march=native


### PR DESCRIPTION
Fixes `makefile:84: *** ERROR: unknown architecture arm64.  Stop.` on ARM64 MacOS

Copied the changed line from the above `ifneq (, $(filter $(uname_m),x86_64 amd64))`

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->