### PR TITLE
fix: set the key index within the json.debug command

### DIFF
--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -1816,7 +1816,7 @@ void JsonFamily::Register(CommandRegistry* registry) {
   *registry << CI{"JSON.ARRAPPEND", CO::WRITE | CO::DENYOOM | CO::FAST, -4, 1, 1, 1, acl::JSON}
                    .HFUNC(ArrAppend);
   *registry << CI{"JSON.ARRINDEX", CO::READONLY | CO::FAST, -4, 1, 1, 1, acl::JSON}.HFUNC(ArrIndex);
-  *registry << CI{"JSON.DEBUG", CO::READONLY | CO::FAST, -2, 1, 1, 1, acl::JSON}.HFUNC(Debug);
+  *registry << CI{"JSON.DEBUG", CO::READONLY | CO::FAST, -3, 2, 2, 1, acl::JSON}.HFUNC(Debug);
   *registry << CI{"JSON.RESP", CO::READONLY | CO::FAST, -2, 1, 1, 1, acl::JSON}.HFUNC(Resp);
   *registry << CI{"JSON.SET", CO::WRITE | CO::DENYOOM | CO::FAST, -4, 1, 1, 1, acl::JSON}.HFUNC(
       Set);

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -1816,6 +1816,7 @@ void JsonFamily::Register(CommandRegistry* registry) {
   *registry << CI{"JSON.ARRAPPEND", CO::WRITE | CO::DENYOOM | CO::FAST, -4, 1, 1, 1, acl::JSON}
                    .HFUNC(ArrAppend);
   *registry << CI{"JSON.ARRINDEX", CO::READONLY | CO::FAST, -4, 1, 1, 1, acl::JSON}.HFUNC(ArrIndex);
+  // TODO: Support negative first_key index to revive the debug sub-command
   *registry << CI{"JSON.DEBUG", CO::READONLY | CO::FAST, -3, 2, 2, 1, acl::JSON}.HFUNC(Debug);
   *registry << CI{"JSON.RESP", CO::READONLY | CO::FAST, -2, 1, 1, 1, acl::JSON}.HFUNC(Resp);
   *registry << CI{"JSON.SET", CO::WRITE | CO::DENYOOM | CO::FAST, -4, 1, 1, 1, acl::JSON}.HFUNC(

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -932,6 +932,17 @@ TEST_F(JsonFamilyTest, DebugFields) {
 
   resp = Run({"JSON.DEBUG", "fields", "json1", "$"});
   EXPECT_THAT(resp, IntArg(16));
+
+  json = R"({"a":1, "b":2, "c":{"k1":1,"k2":2}})";
+
+  resp = Run({"JSON.SET", "obj_doc", "$", json});
+  ASSERT_THAT(resp, "OK");
+
+  resp = Run({"JSON.DEBUG", "FIELDS", "obj_doc", "$.a"});
+  EXPECT_THAT(resp, IntArg(1));
+
+  resp = Run({"JSON.DEBUG", "fields", "obj_doc", "$.a"});
+  EXPECT_THAT(resp, IntArg(1));
 }
 
 TEST_F(JsonFamilyTest, Resp) {


### PR DESCRIPTION
Fixes: #1916 