### PR TITLE
chore: flip default sorted set implementation to bptree

### DIFF
--- a/src/core/sorted_map.cc
+++ b/src/core/sorted_map.cc
@@ -19,7 +19,7 @@ extern "C" {
 
 using namespace std;
 
-ABSL_FLAG(bool, use_zset_tree, false, "If true use b+tree for zset implementation");
+ABSL_FLAG(bool, use_zset_tree, true, "If true use b+tree for zset implementation");
 
 extern "C" unsigned char* zzlInsertAt(unsigned char* zl, unsigned char* eptr, sds ele,
                                       double score);

--- a/src/redis/redis_aux.c
+++ b/src/redis/redis_aux.c
@@ -19,7 +19,7 @@ void InitRedisTables() {
 
   // been used by t_zset routines that convert listpack to skiplist for cases
   // above these thresholds.
-  server.zset_max_listpack_entries = 100;
+  server.zset_max_listpack_entries = 128;
   server.zset_max_listpack_value = 32;
 
   server.max_map_field_len = 64;


### PR DESCRIPTION
Also, bring back the default max listpack entries count for zset to 128. The reason for this - I've added some optimizations that improved listpack performance and also because I would like to write an article about it and I need to compare Dragonfly to Redis7 that has this setting set to 128 by default.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->