### PR TITLE
feat(search): Early limit cutoff

### DIFF
--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -88,7 +88,7 @@ struct IndexResult {
     return visit(cb, value_);
   }
 
-  // Move out of owned or copy borrowed
+  // Move out of owned or copy borrowed, truncate to limit if set
   DocVec Take(optional<size_t> limit = nullopt) {
     if (IsOwned()) {
       auto out = std::move(get<DocVec>(value_));

--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -89,11 +89,21 @@ struct IndexResult {
   }
 
   // Move out of owned or copy borrowed
-  DocVec Take() {
-    if (IsOwned())
-      return move(get<DocVec>(value_));
+  DocVec Take(optional<size_t> limit = nullopt) {
+    if (IsOwned()) {
+      auto out = std::move(get<DocVec>(value_));
+      out.resize(min(limit.value_or(out.size()), out.size()));
+      return out;
+    }
 
-    return visit([](auto* set) { return DocVec(set->begin(), set->end()); }, Borrowed());
+    auto cb = [limit](auto* set) {
+      DocVec out(min(limit.value_or(set->size()), set->size()));
+      auto it = set->begin();
+      for (size_t i = 0; it != set->end() && i < out.size(); ++i, ++it)
+        out[i] = *it;
+      return out;
+    };
+    return visit(cb, Borrowed());
   }
 
  private:
@@ -326,6 +336,7 @@ struct BasicSearch {
       return IndexResult{};
     }
 
+    preagg_total_ = sub_results.Size();
     distances_.clear();
     if (auto hnsw_index = dynamic_cast<HnswVectorIndex*>(vec_index); hnsw_index)
       SearchKnnHnsw(hnsw_index, knn, std::move(sub_results));
@@ -359,7 +370,7 @@ struct BasicSearch {
     return result;
   }
 
-  SearchResult Search(const AstNode& query) {
+  SearchResult Search(const AstNode& query, size_t limit) {
     IndexResult result = SearchGeneric(query, "", true);
 
     // Copy knn distances to be returned
@@ -374,11 +385,18 @@ struct BasicSearch {
     optional<AlgorithmProfile> profile =
         profile_builder_ ? make_optional(profile_builder_->Take()) : nullopt;
 
-    return SearchResult{result.Take(), std::move(knn_distances), std::move(profile),
+    size_t total = result.Size();
+    return SearchResult{total,
+                        max(total, preagg_total_),
+                        result.Take(limit),
+                        std::move(knn_distances),
+                        std::move(profile),
                         std::move(error_)};
   }
 
   const FieldIndices* indices_;
+
+  size_t preagg_total_ = 0;
 
   string error_;
   optional<ProfileBuilder> profile_builder_ = ProfileBuilder{};
@@ -481,11 +499,11 @@ bool SearchAlgorithm::Init(string_view query, const QueryParams* params) {
   }
 }
 
-SearchResult SearchAlgorithm::Search(const FieldIndices* index) const {
+SearchResult SearchAlgorithm::Search(const FieldIndices* index, size_t limit) const {
   auto bs = BasicSearch{index};
   if (profiling_enabled_)
     bs.EnableProfiling();
-  return bs.Search(*query_);
+  return bs.Search(*query_, limit);
 }
 
 optional<size_t> SearchAlgorithm::HasKnn() const {

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -86,7 +86,7 @@ struct SearchResult {
   size_t total;  // how many documents were matched in total
 
   // number of matches before any aggregation, used by multi-shard optimizations
-  size_t pre_aggreation_total;
+  size_t pre_aggregation_total;
 
   // The ids of the matched documents
   std::vector<DocId> ids;

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -83,6 +83,12 @@ struct AlgorithmProfile {
 
 // Represents a search result returned from the search algorithm.
 struct SearchResult {
+  size_t total;  // how many documents were matched in total
+
+  // number of matches before any aggregation, used by multi-shard optimizations
+  size_t pre_aggreation_total;
+
+  // The ids of the matched documents
   std::vector<DocId> ids;
 
   // If a KNN-query is present, distances for doc ids are returned as well
@@ -105,7 +111,8 @@ class SearchAlgorithm {
   // Init with query and return true if successful.
   bool Init(std::string_view query, const QueryParams* params);
 
-  SearchResult Search(const FieldIndices* index) const;
+  SearchResult Search(const FieldIndices* index,
+                      size_t limit = std::numeric_limits<size_t>::max()) const;
 
   // Return KNN limit if it is enabled
   std::optional<size_t> HasKnn() const;

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -32,16 +32,16 @@ struct SerializedSearchDoc {
 struct SearchResult {
   SearchResult() = default;
 
-  SearchResult(std::vector<SerializedSearchDoc> docs, size_t total_hits,
+  SearchResult(size_t total_hits, std::vector<SerializedSearchDoc> docs,
                std::optional<search::AlgorithmProfile> profile)
-      : docs{std::move(docs)}, total_hits{total_hits}, profile{std::move(profile)} {
+      : total_hits{total_hits}, docs{std::move(docs)}, profile{std::move(profile)} {
   }
 
   SearchResult(facade::ErrorReply error) : error{std::move(error)} {
   }
 
-  std::vector<SerializedSearchDoc> docs;
   size_t total_hits;
+  std::vector<SerializedSearchDoc> docs;
   std::optional<search::AlgorithmProfile> profile;
 
   std::optional<facade::ErrorReply> error;


### PR DESCRIPTION
Don't return more search results than requested from core search algorithm. This is because for some queries (like the select ALL query) the result set is borrowed, which leads to a very expensive copy

Also trace the number of filtered items pre-aggregation (will only be used later)

Helper for both #1941 #1924 