### PR TITLE
feat(healthcheck): Allow the port to be overwritable

### DIFF
--- a/tools/docker/healthcheck.sh
+++ b/tools/docker/healthcheck.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 HOST="localhost"
-PORT=6379
+PORT=${PORT:-6379}
 
 # If we're running with TLS enabled, utilise OpenSSL for the check
 if [ -f "/etc/dragonfly/tls/ca.crt" ]


### PR DESCRIPTION
In the Operator, For cases where TLS is enabled or a password is set
, It seems better to just hit the admin port instead of the default
port. This allows the port to be overwritable.
