### PR TITLE
chore(Http): change authed username to default and skip auth on metrics

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -469,10 +469,17 @@ bool Connection::IsAdmin() const {
   return static_cast<Listener*>(owner())->IsAdminInterface();
 }
 
+bool Connection::IsMain() const {
+  return static_cast<Listener*>(owner())->IsMainInterface();
+}
+
 io::Result<bool> Connection::CheckForHttpProto(FiberSocketBase* peer) {
-  bool primary_port_enabled = absl::GetFlag(FLAGS_primary_port_http_enabled);
-  bool admin = IsAdmin();
-  if (!primary_port_enabled && !admin) {
+  if (!IsAdmin() && !IsMain()) {
+    return false;
+  }
+
+  const bool primary_port_enabled = absl::GetFlag(FLAGS_primary_port_http_enabled);
+  if (!primary_port_enabled && !IsAdmin()) {
     return false;
   }
 

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -335,7 +335,7 @@ void Connection::HandleRequests() {
 #ifdef DFLY_USE_SSL
   if (ctx_) {
     const bool no_tls_on_admin_port = absl::GetFlag(FLAGS_no_tls_on_admin_port);
-    if (!(IsAdmin() && no_tls_on_admin_port)) {
+    if (!(IsPrivileged() && no_tls_on_admin_port)) {
       unique_ptr<tls::TlsSocket> tls_sock = make_unique<tls::TlsSocket>(std::move(socket_));
       tls_sock->InitSSL(ctx_);
       FiberSocketBase::AcceptResult aresult = tls_sock->Accept();
@@ -465,8 +465,8 @@ uint32_t Connection::GetClientId() const {
   return id_;
 }
 
-bool Connection::IsAdmin() const {
-  return static_cast<Listener*>(owner())->IsAdminInterface();
+bool Connection::IsPrivileged() const {
+  return static_cast<Listener*>(owner())->IsPrivilegedInterface();
 }
 
 bool Connection::IsMain() const {
@@ -474,12 +474,12 @@ bool Connection::IsMain() const {
 }
 
 io::Result<bool> Connection::CheckForHttpProto(FiberSocketBase* peer) {
-  if (!IsAdmin() && !IsMain()) {
+  if (!IsPrivileged() && !IsMain()) {
     return false;
   }
 
   const bool primary_port_enabled = absl::GetFlag(FLAGS_primary_port_http_enabled);
-  if (!primary_port_enabled && !IsAdmin()) {
+  if (!primary_port_enabled && !IsPrivileged()) {
     return false;
   }
 

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -165,6 +165,8 @@ class Connection : public util::Connection {
   // Virtual because behavior is overridden in test_utils.
   virtual bool IsAdmin() const;
 
+  bool IsMain() const;
+
   Protocol protocol() const {
     return protocol_;
   }

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -163,7 +163,7 @@ class Connection : public util::Connection {
 
   uint32_t GetClientId() const;
   // Virtual because behavior is overridden in test_utils.
-  virtual bool IsAdmin() const;
+  virtual bool IsPrivileged() const;
 
   bool IsMain() const;
 

--- a/src/facade/dragonfly_listener.h
+++ b/src/facade/dragonfly_listener.h
@@ -25,7 +25,7 @@ class ServiceInterface;
 
 class Listener : public util::ListenerInterface {
  public:
-  enum class Role { ADMIN, MAIN, OTHER };
+  enum class Role { PRIVILEGED, MAIN, OTHER };
   Listener(Protocol protocol, ServiceInterface*, Role role = Role::OTHER);
   ~Listener();
 
@@ -36,7 +36,7 @@ class Listener : public util::ListenerInterface {
   bool AwaitDispatches(absl::Duration timeout,
                        const std::function<bool(util::Connection*)>& filter);
 
-  bool IsAdminInterface() const;
+  bool IsPrivilegedInterface() const;
   bool IsMainInterface() const;
 
  private:

--- a/src/facade/dragonfly_listener.h
+++ b/src/facade/dragonfly_listener.h
@@ -25,6 +25,9 @@ class ServiceInterface;
 
 class Listener : public util::ListenerInterface {
  public:
+  // The Role PRIVILEGED is for admin port/listener
+  // The Role MAIN is for the main listener on main port
+  // The Role OTHER is for all the other listeners
   enum class Role { PRIVILEGED, MAIN, OTHER };
   Listener(Protocol protocol, ServiceInterface*, Role role = Role::OTHER);
   ~Listener();

--- a/src/facade/dragonfly_listener.h
+++ b/src/facade/dragonfly_listener.h
@@ -25,7 +25,8 @@ class ServiceInterface;
 
 class Listener : public util::ListenerInterface {
  public:
-  Listener(Protocol protocol, ServiceInterface*);
+  enum class Role { ADMIN, MAIN, OTHER };
+  Listener(Protocol protocol, ServiceInterface*, Role role = Role::OTHER);
   ~Listener();
 
   std::error_code ConfigureServerSocket(int fd) final;
@@ -36,7 +37,7 @@ class Listener : public util::ListenerInterface {
                        const std::function<bool(util::Connection*)>& filter);
 
   bool IsAdminInterface() const;
-  void SetAdminInterface(bool is_admin = true);
+  bool IsMainInterface() const;
 
  private:
   util::Connection* NewConnection(ProactorBase* proactor) final;
@@ -62,7 +63,7 @@ class Listener : public util::ListenerInterface {
 
   std::atomic_uint32_t next_id_{0};
 
-  bool is_admin_ = false;
+  Role role_;
 
   uint32_t conn_cnt_{0};
   uint32_t min_cnt_thread_id_{0};

--- a/src/facade/service_interface.h
+++ b/src/facade/service_interface.h
@@ -36,7 +36,7 @@ class ServiceInterface {
 
   virtual ConnectionStats* GetThreadLocalConnectionStats() = 0;
 
-  virtual void ConfigureHttpHandlers(util::HttpListenerBase* base) {
+  virtual void ConfigureHttpHandlers(util::HttpListenerBase* base, bool is_admin) {
   }
 
   virtual void OnClose(ConnectionContext* cntx) {

--- a/src/facade/service_interface.h
+++ b/src/facade/service_interface.h
@@ -36,7 +36,7 @@ class ServiceInterface {
 
   virtual ConnectionStats* GetThreadLocalConnectionStats() = 0;
 
-  virtual void ConfigureHttpHandlers(util::HttpListenerBase* base, bool is_admin) {
+  virtual void ConfigureHttpHandlers(util::HttpListenerBase* base, bool is_privileged) {
   }
 
   virtual void OnClose(ConnectionContext* cntx) {

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -378,7 +378,7 @@ void ClusterFamily::DflyCluster(CmdArgList args, ConnectionContext* cntx) {
     return (*cntx)->SendError(kClusterDisabled);
   }
 
-  if (cntx->conn() && !cntx->conn()->IsAdmin()) {
+  if (cntx->conn() && !cntx->conn()->IsPrivileged()) {
     return (*cntx)->SendError(kDflyClusterCmdPort);
   }
 

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -346,7 +346,7 @@ bool RunEngine(ProactorPool* pool, AcceptServer* acceptor) {
   // we depend on tcp listener to be at the front since we later
   // need to pass it to the AclFamily::Init
   if (!tcp_disabled) {
-    main_listener = new Listener{Protocol::REDIS, &service};
+    main_listener = new Listener{Protocol::REDIS, &service, Listener::Role::MAIN};
     listeners.push_back(main_listener);
   }
 
@@ -420,8 +420,7 @@ bool RunEngine(ProactorPool* pool, AcceptServer* acceptor) {
     const char* interface_addr = admin_bind.empty() ? nullptr : admin_bind.c_str();
     const std::string printable_addr =
         absl::StrCat("admin socket ", interface_addr ? interface_addr : "any", ":", admin_port);
-    Listener* admin_listener = new Listener{Protocol::REDIS, &service};
-    admin_listener->SetAdminInterface();
+    Listener* admin_listener = new Listener{Protocol::REDIS, &service, Listener::Role::ADMIN};
     error_code ec = acceptor->AddListener(interface_addr, admin_port, admin_listener);
 
     if (ec) {

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -420,15 +420,16 @@ bool RunEngine(ProactorPool* pool, AcceptServer* acceptor) {
     const char* interface_addr = admin_bind.empty() ? nullptr : admin_bind.c_str();
     const std::string printable_addr =
         absl::StrCat("admin socket ", interface_addr ? interface_addr : "any", ":", admin_port);
-    Listener* admin_listener = new Listener{Protocol::REDIS, &service, Listener::Role::ADMIN};
-    error_code ec = acceptor->AddListener(interface_addr, admin_port, admin_listener);
+    Listener* privileged_listener =
+        new Listener{Protocol::REDIS, &service, Listener::Role::PRIVILEGED};
+    error_code ec = acceptor->AddListener(interface_addr, admin_port, privileged_listener);
 
     if (ec) {
       LOG(ERROR) << "Failed to open " << printable_addr << ", error: " << ec.message();
-      delete admin_listener;
+      delete privileged_listener;
     } else {
       LOG(INFO) << "Listening on " << printable_addr;
-      listeners.push_back(admin_listener);
+      listeners.push_back(privileged_listener);
     }
   }
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2066,10 +2066,9 @@ GlobalState Service::GetGlobalState() const {
 void Service::ConfigureHttpHandlers(util::HttpListenerBase* base, bool is_admin) {
   // We set the password for the HTTP service unless it is only enabled on the
   // admin port and the admin port is password-less.
-  if (is_admin && GetFlag(FLAGS_admin_nopass)) {
-    base->SetAuthFunctor([](std::string_view path, std::string_view username,
-                            std::string_view password) { return username == "default"; });
-  } else if (GetFlag(FLAGS_primary_port_http_enabled) || !GetFlag(FLAGS_admin_nopass)) {
+  const bool admin_nopass = GetFlag(FLAGS_admin_nopass);
+  const bool should_skip_auth = is_admin && admin_nopass;
+  if (!should_skip_auth && GetFlag(FLAGS_primary_port_http_enabled)) {
     base->SetAuthFunctor([pass = GetPassword()](std::string_view path, std::string_view username,
                                                 std::string_view password) {
       if (path == "/metrics")

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -82,8 +82,8 @@ ABSL_FLAG(uint32_t, multi_eval_squash_buffer, 4_KB, "Max buffer for squashed com
 
 ABSL_DECLARE_FLAG(bool, primary_port_http_enabled);
 ABSL_FLAG(bool, admin_nopass, false,
-          "If set, would enable open admin access to console on the assigned port, without auth "
-          "token needed.");
+          "If set, would enable open admin access to console on the assigned port, without "
+          "authorization needed.");
 
 ABSL_FLAG(MaxMemoryFlag, maxmemory, MaxMemoryFlag{},
           "Limit on maximum-memory that is used by the database. "
@@ -823,7 +823,7 @@ std::optional<ErrorReply> Service::VerifyCommandState(const CommandId* cid, CmdA
 
   // If there is no connection owner, it means the command it being called
   // from another command or used internally, therefore is always permitted.
-  if (dfly_cntx.conn() != nullptr && !dfly_cntx.conn()->IsAdmin() && cid->IsRestricted()) {
+  if (dfly_cntx.conn() != nullptr && !dfly_cntx.conn()->IsPrivileged() && cid->IsRestricted()) {
     return ErrorReply{"Cannot execute restricted command (admin only)"};
   }
 
@@ -1204,7 +1204,7 @@ ErrorReply Service::ReportUnknownCmd(string_view cmd_name) {
   return ErrorReply{StrCat("unknown command `", cmd_name, "`"), "unknown_cmd"};
 }
 
-bool RequireAdminAuth() {
+bool RequirePrivilegedAuth() {
   return !GetFlag(FLAGS_admin_nopass);
 }
 
@@ -1212,7 +1212,7 @@ facade::ConnectionContext* Service::CreateContext(util::FiberSocketBase* peer,
                                                   facade::Connection* owner) {
   ConnectionContext* res = new ConnectionContext{peer, owner};
 
-  if (owner->IsAdmin() && !RequireAdminAuth()) {
+  if (owner->IsPrivileged() && !RequirePrivilegedAuth()) {
     res->req_auth = false;
   } else {
     res->req_auth = !GetPassword().empty();
@@ -2070,12 +2070,10 @@ GlobalState Service::GetGlobalState() const {
   return global_state_;
 }
 
-void Service::ConfigureHttpHandlers(util::HttpListenerBase* base, bool is_admin) {
-  // We set the password for the HTTP service unless it is only enabled on the
-  // admin port and the admin port is password-less.
-  const bool admin_nopass = GetFlag(FLAGS_admin_nopass);
-  const bool should_skip_auth = is_admin && admin_nopass;
-  if (!should_skip_auth && GetFlag(FLAGS_primary_port_http_enabled)) {
+void Service::ConfigureHttpHandlers(util::HttpListenerBase* base, bool is_privileged) {
+  // We skip authentication on privileged listener if the flag admin_nopass is set
+  const bool should_skip_auth = is_privileged && !RequirePrivilegedAuth();
+  if (!should_skip_auth) {
     base->SetAuthFunctor([pass = GetPassword()](std::string_view path, std::string_view username,
                                                 std::string_view password) {
       if (path == "/metrics")

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2067,7 +2067,9 @@ void Service::ConfigureHttpHandlers(util::HttpListenerBase* base) {
   // We set the password for the HTTP service unless it is only enabled on the
   // admin port and the admin port is password-less.
   if (GetFlag(FLAGS_primary_port_http_enabled) || !GetFlag(FLAGS_admin_nopass)) {
+    base->SetUsername("default");
     base->SetPassword(GetPassword());
+    base->SetSkipAuthForPath([](std::string_view path) { return path == "/metrics"; });
   }
   server_family_.ConfigureMetrics(base);
   base->RegisterCb("/txz", TxTable);

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2070,9 +2070,8 @@ void Service::ConfigureHttpHandlers(util::HttpListenerBase* base, bool is_admin)
     base->SetAuthFunctor([](std::string_view path, std::string_view username,
                             std::string_view password) { return username == "default"; });
   } else if (GetFlag(FLAGS_primary_port_http_enabled) || !GetFlag(FLAGS_admin_nopass)) {
-    std::string pass = GetPassword();
-    base->SetAuthFunctor([pass = std::move(pass)](std::string_view path, std::string_view username,
-                                                  std::string_view password) {
+    base->SetAuthFunctor([pass = GetPassword()](std::string_view path, std::string_view username,
+                                                std::string_view password) {
       if (path == "/metrics")
         return true;
       const bool pass_verified = pass.empty() ? true : password == pass;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2063,10 +2063,13 @@ GlobalState Service::GetGlobalState() const {
   return global_state_;
 }
 
-void Service::ConfigureHttpHandlers(util::HttpListenerBase* base) {
+void Service::ConfigureHttpHandlers(util::HttpListenerBase* base, bool is_admin) {
   // We set the password for the HTTP service unless it is only enabled on the
   // admin port and the admin port is password-less.
-  if (GetFlag(FLAGS_primary_port_http_enabled) || !GetFlag(FLAGS_admin_nopass)) {
+  if (is_admin && GetFlag(FLAGS_admin_nopass)) {
+    base->SetAuthFunctor([](std::string_view path, std::string_view username,
+                            std::string_view password) { return username == "default"; });
+  } else if (GetFlag(FLAGS_primary_port_http_enabled) || !GetFlag(FLAGS_admin_nopass)) {
     std::string pass = GetPassword();
     base->SetAuthFunctor([pass = std::move(pass)](std::string_view path, std::string_view username,
                                                   std::string_view password) {

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -91,7 +91,7 @@ class Service : public facade::ServiceInterface {
 
   GlobalState GetGlobalState() const;
 
-  void ConfigureHttpHandlers(util::HttpListenerBase* base) final;
+  void ConfigureHttpHandlers(util::HttpListenerBase* base, bool is_admin) final;
   void OnClose(facade::ConnectionContext* cntx) final;
   std::string GetContextInfo(facade::ConnectionContext* cntx) final;
 

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -91,7 +91,7 @@ class Service : public facade::ServiceInterface {
 
   GlobalState GetGlobalState() const;
 
-  void ConfigureHttpHandlers(util::HttpListenerBase* base, bool is_admin) final;
+  void ConfigureHttpHandlers(util::HttpListenerBase* base, bool is_privileged) final;
   void OnClose(facade::ConnectionContext* cntx) final;
   std::string GetContextInfo(facade::ConnectionContext* cntx) final;
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -374,7 +374,7 @@ ServerFamily::~ServerFamily() {
 
 void SetMaxClients(std::vector<facade::Listener*>& listeners, uint32_t maxclients) {
   for (auto* listener : listeners) {
-    if (!listener->IsAdminInterface()) {
+    if (!listener->IsPrivilegedInterface()) {
       listener->SetMaxClients(maxclients);
     }
   }

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -269,19 +269,19 @@ RespExpr BaseFamilyTest::Run(ArgSlice list) {
   return Run(GetId(), list);
 }
 
-RespExpr BaseFamilyTest::RunAdmin(std::initializer_list<const std::string_view> list) {
+RespExpr BaseFamilyTest::RunPrivileged(std::initializer_list<const std::string_view> list) {
   if (!ProactorBase::IsProactorThread()) {
-    return pp_->at(0)->Await([&] { return this->RunAdmin(list); });
+    return pp_->at(0)->Await([&] { return this->RunPrivileged(list); });
   }
   string id = GetId();
   TestConnWrapper* conn_wrapper = AddFindConn(Protocol::REDIS, id);
   // Before running the command set the connection as admin connection
-  conn_wrapper->conn()->SetAdmin(true);
+  conn_wrapper->conn()->SetPrivileged(true);
   auto res = Run(id, ArgSlice{list.begin(), list.size()});
   // After running the command set the connection as non admin connection
   // because the connction is returned to the poll. This way the next call to Run from the same
   // thread will not have the connection set as admin.
-  conn_wrapper->conn()->SetAdmin(false);
+  conn_wrapper->conn()->SetPrivileged(false);
   return res;
 }
 

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -24,18 +24,18 @@ class TestConnection : public facade::Connection {
 
   void SendPubMessageAsync(PubMessage pmsg) final;
 
-  bool IsAdmin() const override {
-    return is_admin_;
+  bool IsPrivileged() const override {
+    return is_privileged_;
   }
-  void SetAdmin(bool is_admin) {
-    is_admin_ = is_admin;
+  void SetPrivileged(bool is_privileged) {
+    is_privileged_ = is_privileged;
   }
 
   std::vector<PubMessage> messages;
 
  private:
   io::StringSink* sink_;
-  bool is_admin_ = false;
+  bool is_privileged_ = false;
 };
 
 // The TransactionSuspension class is designed to facilitate the temporary suspension of commands
@@ -68,9 +68,9 @@ class BaseFamilyTest : public ::testing::Test {
     return Run(ArgSlice{list.begin(), list.size()});
   }
 
-  // Runs the command in a mocked admin connection
+  // Runs the command in a mocked privileged connection
   // Use for running commands which are allowed only when using admin connection.
-  RespExpr RunAdmin(std::initializer_list<const std::string_view> list);
+  RespExpr RunPrivileged(std::initializer_list<const std::string_view> list);
 
   RespExpr Run(ArgSlice list);
   RespExpr Run(absl::Span<std::string> list);

--- a/tests/dragonfly/http_conf_test.py
+++ b/tests/dragonfly/http_conf_test.py
@@ -8,12 +8,19 @@ async def test_password(df_factory):
             resp = await session.get(f"http://localhost:{server.port}/")
             assert resp.status == 401
         async with aiohttp.ClientSession(
-            auth=aiohttp.BasicAuth("user", "wrongpassword")
+            auth=aiohttp.BasicAuth("default", "wrongpassword")
         ) as session:
             resp = await session.get(f"http://localhost:{server.port}/")
             assert resp.status == 401
-        async with aiohttp.ClientSession(auth=aiohttp.BasicAuth("user", "XXX")) as session:
+        async with aiohttp.ClientSession(auth=aiohttp.BasicAuth("default", "XXX")) as session:
             resp = await session.get(f"http://localhost:{server.port}/")
+            assert resp.status == 200
+
+
+async def test_skip_metrics(df_factory):
+    with df_factory.create(port=1112, requirepass="XXX") as server:
+        async with aiohttp.ClientSession(auth=aiohttp.BasicAuth("whoops", "whoops")) as session:
+            resp = await session.get(f"http://localhost:{server.port}/metrics")
             assert resp.status == 200
 
 
@@ -26,7 +33,7 @@ async def test_no_password_on_admin(df_factory):
         noprimary_port_http_enabled=None,
         admin_nopass=None,
     ) as server:
-        async with aiohttp.ClientSession(auth=aiohttp.BasicAuth("user", "XXX")) as session:
+        async with aiohttp.ClientSession(auth=aiohttp.BasicAuth("default", "XXX")) as session:
             resp = await session.get(f"http://localhost:{server.admin_port}/")
             assert resp.status == 200
 
@@ -39,9 +46,9 @@ async def test_password_on_admin(df_factory):
         requirepass="XXX",
         admin_nopass=None,
     ) as server:
-        async with aiohttp.ClientSession(auth=aiohttp.BasicAuth("user", "badpass")) as session:
+        async with aiohttp.ClientSession(auth=aiohttp.BasicAuth("default", "badpass")) as session:
             resp = await session.get(f"http://localhost:{server.port}/")
             assert resp.status == 401
-        async with aiohttp.ClientSession(auth=aiohttp.BasicAuth("user", "XXX")) as session:
+        async with aiohttp.ClientSession(auth=aiohttp.BasicAuth("default", "XXX")) as session:
             resp = await session.get(f"http://localhost:{server.port}/")
             assert resp.status == 200

--- a/tests/dragonfly/http_conf_test.py
+++ b/tests/dragonfly/http_conf_test.py
@@ -2,7 +2,6 @@ import aiohttp
 
 
 async def test_password(df_factory):
-    # Needs a private key and certificate.
     with df_factory.create(port=1112, requirepass="XXX") as server:
         async with aiohttp.ClientSession() as session:
             resp = await session.get(f"http://localhost:{server.port}/")
@@ -18,37 +17,47 @@ async def test_password(df_factory):
 
 
 async def test_skip_metrics(df_factory):
-    with df_factory.create(port=1112, requirepass="XXX") as server:
+    with df_factory.create(port=1112, admin_port=1113, requirepass="XXX") as server:
         async with aiohttp.ClientSession(auth=aiohttp.BasicAuth("whoops", "whoops")) as session:
             resp = await session.get(f"http://localhost:{server.port}/metrics")
+            assert resp.status == 200
+        async with aiohttp.ClientSession(auth=aiohttp.BasicAuth("whoops", "whoops")) as session:
+            resp = await session.get(f"http://localhost:{server.admin_port}/metrics")
             assert resp.status == 200
 
 
 async def test_no_password_on_admin(df_factory):
-    # Needs a private key and certificate.
     with df_factory.create(
         port=1112,
         admin_port=1113,
         requirepass="XXX",
-        noprimary_port_http_enabled=None,
+        primary_port_http_enabled=True,
         admin_nopass=None,
     ) as server:
         async with aiohttp.ClientSession(auth=aiohttp.BasicAuth("default", "XXX")) as session:
             resp = await session.get(f"http://localhost:{server.admin_port}/")
             assert resp.status == 200
+        async with aiohttp.ClientSession(auth=aiohttp.BasicAuth("default")) as session:
+            resp = await session.get(f"http://localhost:{server.admin_port}/")
+            assert resp.status == 200
+        async with aiohttp.ClientSession() as session:
+            resp = await session.get(f"http://localhost:{server.admin_port}/")
+            # we still need to specify the user default in the header
+            assert resp.status == 401
 
 
 async def test_password_on_admin(df_factory):
-    # Needs a private key and certificate.
     with df_factory.create(
         port=1112,
         admin_port=1113,
         requirepass="XXX",
-        admin_nopass=None,
     ) as server:
         async with aiohttp.ClientSession(auth=aiohttp.BasicAuth("default", "badpass")) as session:
-            resp = await session.get(f"http://localhost:{server.port}/")
+            resp = await session.get(f"http://localhost:{server.admin_port}/")
+            assert resp.status == 401
+        async with aiohttp.ClientSession() as session:
+            resp = await session.get(f"http://localhost:{server.admin_port}/")
             assert resp.status == 401
         async with aiohttp.ClientSession(auth=aiohttp.BasicAuth("default", "XXX")) as session:
-            resp = await session.get(f"http://localhost:{server.port}/")
+            resp = await session.get(f"http://localhost:{server.admin_port}/")
             assert resp.status == 200

--- a/tests/dragonfly/http_conf_test.py
+++ b/tests/dragonfly/http_conf_test.py
@@ -37,13 +37,12 @@ async def test_no_password_on_admin(df_factory):
         async with aiohttp.ClientSession(auth=aiohttp.BasicAuth("default", "XXX")) as session:
             resp = await session.get(f"http://localhost:{server.admin_port}/")
             assert resp.status == 200
-        async with aiohttp.ClientSession(auth=aiohttp.BasicAuth("default")) as session:
+        async with aiohttp.ClientSession(auth=aiohttp.BasicAuth("random")) as session:
             resp = await session.get(f"http://localhost:{server.admin_port}/")
             assert resp.status == 200
         async with aiohttp.ClientSession() as session:
             resp = await session.get(f"http://localhost:{server.admin_port}/")
-            # we still need to specify the user default in the header
-            assert resp.status == 401
+            assert resp.status == 200
 
 
 async def test_password_on_admin(df_factory):

--- a/tests/dragonfly/http_conf_test.py
+++ b/tests/dragonfly/http_conf_test.py
@@ -32,7 +32,7 @@ async def test_no_password_on_admin(df_factory):
         admin_port=1113,
         requirepass="XXX",
         primary_port_http_enabled=True,
-        admin_nopass=None,
+        admin_nopass=True,
     ) as server:
         async with aiohttp.ClientSession(auth=aiohttp.BasicAuth("default", "XXX")) as session:
             resp = await session.get(f"http://localhost:{server.admin_port}/")


### PR DESCRIPTION
* Http now `auths` with username `default` instead of `user`
* skip auth for `/metrics` page
* add/improved tests
* fix a bug with admin port requiring auth on http even if nopass was set
* update helio ref
* update listener class to now contain its respective Role
* fix http init to only include admin and main listener