### PR TITLE
chore(regression): test bptree on regression pytests

### DIFF
--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -39,10 +39,10 @@ runs:
         pytest -m "${{inputs.filter}}" --json-report --json-report-file=report.json dragonfly --ignore=dragonfly/replication_test.py --log-cli-level=INFO
 
     - name: Run PyTests replication test
-      if: ${{ inputs.run-only-on-ubuntu-latest == 'false' || matrix.runner  == 'ubuntu-latest' }}
+      if: ${{ inputs.run-only-on-ubuntu-latest == 'true' || ('inputs.run-only-on-ubuntu-latest == 'false' && matrix.runner  == 'ubuntu-latest') }}
       shell: bash
       run: |
-        echo "Running PyTests replication test with flag: ${{ inputs.run-only-on-ubuntu-latest }}"
+        echo "Running PyTests replication test"
         cd ${GITHUB_WORKSPACE}/tests
         # used by PyTests
         export DRAGONFLY_PATH="${GITHUB_WORKSPACE}/${{inputs.build-folder-name}}/${{inputs.dfly-executable}}"

--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -39,7 +39,7 @@ runs:
         pytest -m "${{inputs.filter}}" --json-report --json-report-file=report.json dragonfly --ignore=dragonfly/replication_test.py --log-cli-level=INFO
 
     - name: Run PyTests replication test
-      if: ${{ inputs.run-only-on-ubuntu-latest == 'true' || ('inputs.run-only-on-ubuntu-latest == 'false' && matrix.runner  == 'ubuntu-latest') }}
+      if: ${{ inputs.run-only-on-ubuntu-latest == 'true' || (inputs.run-only-on-ubuntu-latest == 'false' && matrix.runner == 'ubuntu-latest') }}
       shell: bash
       run: |
         echo "Running PyTests replication test"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,8 @@ jobs:
           #GLOG_logtostderr=1 GLOG_vmodule=transaction=1,engine_shard_set=1
           GLOG_logtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 ctest -V -L DFLY
 
-          echo "Running tests with --force_epoll and --use_zset_tree"
-          FLAGS_force_epoll=true FLAGS_use_zset_tree=true ctest -V -L DFLY
+          echo "Running tests with --force_epoll"
+          FLAGS_force_epoll=true ctest -V -L DFLY
 
           echo "Running tests with --cluster_mode=emulated"
           FLAGS_cluster_mode=emulated ctest -V -L DFLY

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -2,7 +2,7 @@ name: Regression Tests
 
 on:
   schedule:
-    - cron: '0 0/3 * * *'
+    - cron: "0 0/3 * * *"
   workflow_dispatch:
 
 jobs:
@@ -24,7 +24,7 @@ jobs:
           submodules: true
 
       - name: Print cpu info
-        run:  cat /proc/cpuinfo
+        run: cat /proc/cpuinfo
 
       - name: Configure & Build
         run: |
@@ -40,5 +40,5 @@ jobs:
         with:
           dfly-executable: dragonfly
           gspace-secret: ${{ secrets.GSPACES_BOT_DF_BUILD }}
-          run-only-on-ubuntu-latest: true
+          run-only-on-ubuntu-latest: false
           build-folder-name: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
       with:
         dfly-executable: dragonfly-x86_64
         gspace-secret: ${{ secrets.GSPACES_BOT_DF_BUILD }}
-        run-only-on-ubuntu-latest: false
+        run-only-on-ubuntu-latest: true
         build-folder-name: build-opt
     - name: Save artifacts
       run: |

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -154,8 +154,7 @@ class DflyInstance:
         if self.dynamic_port:
             self._port = None
 
-        base_args = []
-        all_args = self.format_args(self.args) + base_args
+        all_args = self.format_args(self.args)
         logging.debug(f"Starting instance with arguments {all_args} from {self.params.path}")
 
         run_cmd = [self.params.path, *all_args]

--- a/tests/dragonfly/utility.py
+++ b/tests/dragonfly/utility.py
@@ -166,10 +166,12 @@ class CommandGenerator:
             )
             return ("v0", 0, "v1", 0) + tuple(itertools.chain(*elements))
         elif t == ValueType.ZSET:
-            # Random sequnce of k-letter keys and int score for ZSET
-            elements = (
-                (random.randint(0, self.val_size), rand_str()) for _ in range(self.val_size // 4)
-            )
+            # Random sequnce of k-letter members and int score for ZADD
+            # The length of the sequence will vary between val_size/4 and 130. This ensures that we test both the ZSET implementation with Lispack and the bptree.
+            value_sizes = [self.val_size // 4, 130]
+            probabilities = [4, 1]
+            value_size = random.choices(value_sizes, probabilities)[0]
+            elements = ((random.randint(0, self.val_size), rand_str()) for _ in range(value_size))
             return tuple(itertools.chain(*elements))
 
         elif t == ValueType.JSON:


### PR DESCRIPTION
1. stop passing the flag use_zset_tree as it is true on default
2. fix ci test to run replication tests
3. change replication tests seeder to sometimes add more than 128 values to zset to test the pbtree impl

