### PR TITLE
chore: preallocate lua arrays

### DIFF
--- a/src/core/interpreter.cc
+++ b/src/core/interpreter.cc
@@ -143,7 +143,7 @@ void RedisTranslator::OnNil() {
 
 void RedisTranslator::OnStatus(std::string_view str) {
   CHECK(array_index_.empty()) << "unexpected status";
-  lua_newtable(lua_);
+  lua_createtable(lua_, 0, 1);
   lua_pushstring(lua_, "ok");
   lua_pushlstring(lua_, str.data(), str.size());
   lua_settable(lua_, -3);
@@ -156,7 +156,7 @@ void RedisTranslator::OnError(std::string_view str) {
 
 void RedisTranslator::OnArrayStart(unsigned len) {
   ArrayPre();
-  lua_newtable(lua_);
+  lua_createtable(lua_, len, 0);
   array_index_.push_back(1);
 }
 
@@ -201,7 +201,7 @@ optional<int> FetchKey(lua_State* lua, const char* key) {
 }
 
 void SetGlobalArrayInternal(lua_State* lua, const char* name, MutSliceSpan args) {
-  lua_newtable(lua);
+  lua_createtable(lua, args.size(), 0);
   for (size_t j = 0; j < args.size(); j++) {
     lua_pushlstring(lua, args[j].data(), args[j].size());
     lua_rawseti(lua, -2, j + 1);


### PR DESCRIPTION
saves 1-2% due to SetGlobalArrayInternal calls with lots of arguments/keys.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->