### PR TITLE
fix(regTests): adjust network disconnect small buffer to pass on

### DIFF
--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1664,7 +1664,11 @@ async def test_network_disconnect_small_buffer(df_local_factory, df_seeder_facto
         try:
             await c_replica.execute_command(f"REPLICAOF localhost {proxy.port}")
 
-            fill_task = asyncio.create_task(seeder.run(target_ops=10000))
+            # If this ever fails gain, adjust the target_ops
+            # Df is blazingly fast, so by the time we tick a second time on
+            # line 1674, DF already replicated all the data so the assertion
+            # at the end of the test will always fail
+            fill_task = asyncio.create_task(seeder.run(target_ops=100000))
 
             for _ in range(3):
                 await asyncio.sleep(random.randint(5, 10) / 10)


### PR DESCRIPTION
The issue was very interesting. First, that it always failed on `build-opt`. Second, the long story short is that DF would replicate everything really fast, that would make the assertion at the end of the test fail (because there would be no stale LSN, it would be the last item). Let me explain:

I noticed that df on the first call of `Flow()` LSN would hold the value of `0`, which makes sense since the replication did not even start before the pytest dropped the connection via the `proxy.drop()`. BUT, on the next iteration of the for loop in pytest, DF would have an LSN number equal to the amount of items created by the seeder which simply meant that by the time the proxy drops the connection a second time, the replica has already established a connection with DF AND finished the replication. Therefore, we would never reach an intermediate state, where lsn would be between `0 < LSN < LSN_MAX_NUMBER`, that is, LSN == LSN_MAX_NUMBER and would never trigger the `LOG(INFO) << "Stale"` ...

I also verified this by printing the time on each step of the for loop in pytest:
```
for _ in range(3):
  await asyncio.sleep(random.randint(5, 10) / 10) 
  proxy.drop_connection() 
  logging.info(datetime.datetime.now()) 
```
Which would print:
```
[2023-09-29 13:16:48.346 INFO] 2023-09-29 13:16:48.346447
[2023-09-29 13:16:49.146 INFO] 2023-09-29 13:16:49.146874
[2023-09-29 13:16:50.048 INFO] 2023-09-29 13:16:50.048421 
```

Meanwhile DF log would contain (I put that `LOG(INFO)` for testing):
```
I20230929 13:16:47.450294 1072270 dflycmd.cc:256] LSN has_value 0 
I20230929 13:16:48.849153 1072270 dflycmd.cc:257] LSN value_or 10055 
I20230929 13:16:49.651592 1072270 dflycmd.cc:257] LSN value_or 10055
```

And now let's concat the two logs in coherent time and observe what I described above:

```
I20230929 13:16:47.450294 1072270 dflycmd.cc:256] LSN has_value 0 -> Start of Flow()
[2023-09-29 13:16:48.346 INFO] 2023-09-29 13:16:48.346447 -> We drop 
I20230929 13:16:48.849153 1072270 dflycmd.cc:257] LSN value_or 10055 -> DF finished replicating ALL items
[2023-09-29 13:16:49.146 INFO] 2023-09-29 13:16:49.146874 -> We dropped the connection again, too late, DF finished
I20230929 13:16:49.651592 1072270 dflycmd.cc:257] LSN value_or 10055 -> DF does nothing here, we are done not STALE
-> another drop here, goes to waste
```


