### PR TITLE
fix: logrotate for dragonfly logs

### DIFF
--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -787,8 +787,11 @@ Usage: dragonfly [FLAGS]
   };
 
   absl::SetFlagsUsageConfig(config);
+  google::InitGoogleLogging(argv[0]);
+  google::SetLogFilenameExtension(".log");
 
   MainInitGuard guard(&argc, &argv);
+
   ParseFlagsFromEnv();
 
   PrintBasicUsageInfo();

--- a/tools/packaging/debian/control
+++ b/tools/packaging/debian/control
@@ -7,6 +7,6 @@ Vcs-Git: https://github.com/dragonflydb/dragonfly
 
 Package: dragonfly
 Architecture: amd64 arm64
-Depends: libc6, openssl, adduser
+Depends: libc6, openssl, adduser, zstd
 Homepage: https://dragonflydb.io
 Description: A fast in-memory store that is fully compatible with Redis™* and Memcached.

--- a/tools/packaging/debian/dragonfly.conf
+++ b/tools/packaging/debian/dragonfly.conf
@@ -1,4 +1,5 @@
 --pidfile=/var/run/dragonfly/dragonfly.pid
 --log_dir=/var/log/dragonfly
 --dir=/var/lib/dragonfly
+--max_log_size=20
 --version_check=true

--- a/tools/packaging/debian/dragonfly.logrotate
+++ b/tools/packaging/debian/dragonfly.logrotate
@@ -1,7 +1,26 @@
-/var/log/dragonfly/dragonfly* {
-        weekly
+# installed by debhelper by convention into /etc/logrotate.d/
+
+/var/log/dragonfly/dragonfly*.log {
+        daily
         missingok
-        rotate 12
+
         compress
+        compresscmd zstd
+        uncompresscmd unzstd
+        compressext .zst
         notifempty
+
+# do not create an empty file after the rotation.
+        nocreate
+        prerotate
+                if lsof -t $1 > /dev/null; then
+                # file is open. Skipping rotation."
+                exit 1
+                fi
+        endscript
+
+# Possible hook to upload rotated logs to cloud storage.
+        postrotate
+                echo "TBD: POSTROTATE"
+        endscript
 }


### PR DESCRIPTION
The new logrotate settings assume that dragonfly closes a log file once it grows to large. It never rotates file that is currently open for writing.

Specifically logrotate:

1. rotate only log files
2. skip those that are currently open by a process.
3. compresses using zstd which is more cpu efficient than gzip
4. does not truncate/create old files as 0-sized blobs - just renames them

Fixes #1935

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->