### PR TITLE
fix(server): Add additional metrics

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1054,6 +1054,7 @@ void Connection::SendAsync(MessageHandle msg) {
   };
 
   dispatch_q_bytes_.fetch_add(msg.UsedMemory(), memory_order_relaxed);
+
   if (std::holds_alternative<AclUpdateMessage>(msg.handle)) {
     // We need to reorder the queue, since multiple updates might happen before we
     // pop the message, invalidating the correct order since we always push at the front

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -278,6 +278,8 @@ class Connection : public util::Connection {
   // limit memory taken up by pipelined / pubsub commands and slow down clients
   // producing them to quickly via EnsureAsyncMemoryBudget.
   struct QueueBackpressure {
+    void EnsureBelowLimit();  // block until memory usage is above limit
+
     dfly::EventCount ec;
     std::atomic_size_t bytes = 0;
     size_t limit = 0;

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -133,7 +133,7 @@ class Connection : public util::Connection {
   // Add acl update to dispatch queue.
   void SendAclUpdateAsync(AclUpdateMessage msg);
 
-  // Must be called before Send_Async to ensure the connection dispatch queue is not overfilled.
+  // Must be called before SendAsync to ensure the connection dispatch queue is not overfilled.
   // Blocks until free space is available.
   void EnsureAsyncMemoryBudget();
 
@@ -236,9 +236,7 @@ class Connection : public util::Connection {
   dfly::EventCount evc_;                  // dispatch queue waker
   util::fb2::Fiber dispatch_fb_;          // dispatch fiber (if started)
 
-  std::atomic_uint64_t dispatch_q_bytes_ = 0;  // memory usage of all entries
-  dfly::EventCount evc_bp_;                    // backpressure for memory limit
-  size_t dispatch_q_cmds_count_;               // how many queued async commands
+  size_t dispatch_q_cmds_count_;  // how many queued async commands
 
   base::IoBuf io_buf_;  // used in io loop and parsers
   std::unique_ptr<RedisParser> redis_parser_;
@@ -275,6 +273,16 @@ class Connection : public util::Connection {
   // Aggregated while handling pipelines,
   // graudally released while handling regular commands.
   static thread_local std::vector<PipelineMessagePtr> pipeline_req_pool_;
+
+  // Keeps track of total per-thread sizes of dispatch queues to
+  // limit memory taken up by pipelined / pubsub commands and slow down clients
+  // producing them to quickly via EnsureAsyncMemoryBudget.
+  struct QueueBackpressure {
+    dfly::EventCount ec;
+    std::atomic_size_t bytes = 0;
+    size_t limit = 0;
+  };
+  static thread_local QueueBackpressure queue_backpressure_;
 };
 
 }  // namespace facade

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -27,17 +27,19 @@ constexpr size_t kSizeConnStats = sizeof(ConnectionStats);
 
 ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
   // To break this code deliberately if we add/remove a field to this struct.
-  static_assert(kSizeConnStats == 136u);
+  static_assert(kSizeConnStats == 152u);
 
   ADD(read_buf_capacity);
-  ADD(pipeline_cache_capacity);
+  ADD(dispatch_queue_entries);
+  ADD(dispatch_queue_bytes);
+  ADD(dispatch_queue_peak_bytes);
+  ADD(pipeline_cmd_cache_bytes);
   ADD(io_read_cnt);
   ADD(io_read_bytes);
   ADD(io_write_cnt);
   ADD(io_write_bytes);
   ADD(command_cnt);
   ADD(pipelined_cmd_cnt);
-  ADD(async_writes_cnt);
   ADD(conn_received_cnt);
   ADD(num_conns);
   ADD(num_replicas);
@@ -143,8 +145,13 @@ RedisReplyBuilder* ConnectionContext::operator->() {
 
 CommandId::CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first_key,
                      int8_t last_key, int8_t step, uint32_t acl_categories)
-    : name_(name), opt_mask_(mask), arity_(arity), first_key_(first_key), last_key_(last_key),
-      step_key_(step), acl_categories_(acl_categories) {
+    : name_(name),
+      opt_mask_(mask),
+      arity_(arity),
+      first_key_(first_key),
+      last_key_(last_key),
+      step_key_(step),
+      acl_categories_(acl_categories) {
 }
 
 uint32_t CommandId::OptCount(uint32_t mask) {

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -27,12 +27,11 @@ constexpr size_t kSizeConnStats = sizeof(ConnectionStats);
 
 ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
   // To break this code deliberately if we add/remove a field to this struct.
-  static_assert(kSizeConnStats == 152u);
+  static_assert(kSizeConnStats == 144u);
 
   ADD(read_buf_capacity);
   ADD(dispatch_queue_entries);
   ADD(dispatch_queue_bytes);
-  ADD(dispatch_queue_peak_bytes);
   ADD(pipeline_cmd_cache_bytes);
   ADD(io_read_cnt);
   ADD(io_read_bytes);

--- a/src/facade/facade_types.h
+++ b/src/facade/facade_types.h
@@ -39,18 +39,21 @@ struct CmdArgListFormatter {
 struct ConnectionStats {
   absl::flat_hash_map<std::string, uint64_t> err_count_map;
 
-  size_t read_buf_capacity = 0;
-  size_t pipeline_cache_capacity = 0;
+  size_t read_buf_capacity = 0;       // total capacity of input buffers
+  size_t dispatch_queue_entries = 0;  // total number of dispatch queue entries
+  size_t dispatch_queue_bytes = 0;    // total size of all dispatch queue entries
+  size_t dispatch_queue_peak_bytes = 0;
+
+  size_t pipeline_cmd_cache_bytes = 0;
 
   size_t io_read_cnt = 0;
   size_t io_read_bytes = 0;
   size_t io_write_cnt = 0;
   size_t io_write_bytes = 0;
+
   uint64_t command_cnt = 0;
   uint64_t pipelined_cmd_cnt = 0;
 
-  // Writes count that happened via DispatchOperations call.
-  uint64_t async_writes_cnt = 0;
   uint64_t conn_received_cnt = 0;
 
   uint32_t num_conns = 0;

--- a/src/facade/facade_types.h
+++ b/src/facade/facade_types.h
@@ -42,7 +42,6 @@ struct ConnectionStats {
   size_t read_buf_capacity = 0;       // total capacity of input buffers
   size_t dispatch_queue_entries = 0;  // total number of dispatch queue entries
   size_t dispatch_queue_bytes = 0;    // total size of all dispatch queue entries
-  size_t dispatch_queue_peak_bytes = 0;
 
   size_t pipeline_cmd_cache_bytes = 0;
 

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -694,6 +694,29 @@ std::vector<ReplicaRoleInfo> DflyCmd::GetReplicasRoleInfo() {
   return vec;
 }
 
+void DflyCmd::GetReplicationMemoryStats(ReplicationMemoryStats* stats) {
+  Mutex stats_mu;
+
+  lock_guard lk_main{mu_};  // prevent state changes
+  auto cb = [this, &stats, &stats_mu](EngineShard* shard) {
+    lock_guard lk{stats_mu};
+    for (const auto& [_, info] : replica_infos_) {
+      lock_guard repl_lk{info->mu};
+      if (info->flows.empty())
+        continue;
+
+      const auto& flow = info->flows[shard->shard_id()];
+
+      if (flow.streamer)
+        stats->streamer_buf_capacity_bytes_ += flow.streamer->GetTotalBufferCapacities();
+
+      if (flow.saver)
+        stats->full_sync_buf_bytes_ += flow.saver->GetTotalBuffersSize();
+    }
+  };
+  shard_set->RunBlockingInParallel(cb);
+}
+
 pair<uint32_t, shared_ptr<DflyCmd::ReplicaInfo>> DflyCmd::GetReplicaInfoOrReply(
     std::string_view id_str, RedisReplyBuilder* rb) {
   unique_lock lk(mu_);
@@ -714,6 +737,7 @@ pair<uint32_t, shared_ptr<DflyCmd::ReplicaInfo>> DflyCmd::GetReplicaInfoOrReply(
 }
 
 std::map<uint32_t, LSN> DflyCmd::ReplicationLags() const {
+  DCHECK(!mu_.try_lock());  // expects to be under global lock
   if (replica_infos_.empty())
     return {};
 

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -680,7 +680,7 @@ shared_ptr<DflyCmd::ReplicaInfo> DflyCmd::GetReplicaInfo(uint32_t sync_id) {
   return {};
 }
 
-std::vector<ReplicaRoleInfo> DflyCmd::GetReplicasRoleInfo() {
+std::vector<ReplicaRoleInfo> DflyCmd::GetReplicasRoleInfo() const {
   std::vector<ReplicaRoleInfo> vec;
   unique_lock lk(mu_);
 
@@ -694,7 +694,7 @@ std::vector<ReplicaRoleInfo> DflyCmd::GetReplicasRoleInfo() {
   return vec;
 }
 
-void DflyCmd::GetReplicationMemoryStats(ReplicationMemoryStats* stats) {
+void DflyCmd::GetReplicationMemoryStats(ReplicationMemoryStats* stats) const {
   Mutex stats_mu;
 
   lock_guard lk_main{mu_};  // prevent state changes

--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -137,9 +137,9 @@ class DflyCmd {
   // Create new sync session.
   std::pair<uint32_t, std::shared_ptr<ReplicaInfo>> CreateSyncSession(ConnectionContext* cntx);
 
-  std::vector<ReplicaRoleInfo> GetReplicasRoleInfo();
+  std::vector<ReplicaRoleInfo> GetReplicasRoleInfo() const;
 
-  void GetReplicationMemoryStats(ReplicationMemoryStats* out);
+  void GetReplicationMemoryStats(ReplicationMemoryStats* out) const;
 
   // Sets metadata.
   void SetDflyClientVersion(ConnectionContext* cntx, DflyVersion version);

--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -26,11 +26,13 @@ class ServerFamily;
 class RdbSaver;
 class JournalStreamer;
 struct ReplicaRoleInfo;
+struct ReplicationMemoryStats;
 
 // Stores information related to a single flow.
 struct FlowInfo {
   FlowInfo();
   ~FlowInfo();
+
   // Shutdown associated socket if its still open.
   void TryShutdownSocket();
 
@@ -40,6 +42,7 @@ struct FlowInfo {
   std::unique_ptr<RdbSaver> saver;  // Saver used by the full sync phase.
   std::unique_ptr<JournalStreamer> streamer;
   std::string eof_token;
+
   DflyVersion version;
 
   std::optional<LSN> start_partial_sync_at;
@@ -136,6 +139,8 @@ class DflyCmd {
 
   std::vector<ReplicaRoleInfo> GetReplicasRoleInfo();
 
+  void GetReplicationMemoryStats(ReplicationMemoryStats* out);
+
   // Sets metadata.
   void SetDflyClientVersion(ConnectionContext* cntx, DflyVersion version);
 
@@ -218,7 +223,7 @@ class DflyCmd {
   using ReplicaInfoMap = absl::btree_map<uint32_t, std::shared_ptr<ReplicaInfo>>;
   ReplicaInfoMap replica_infos_;
 
-  Mutex mu_;  // Guard global operations. See header top for locking levels.
+  mutable Mutex mu_;  // Guard global operations. See header top for locking levels.
 };
 
 }  // namespace dfly

--- a/src/server/io_utils.cc
+++ b/src/server/io_utils.cc
@@ -75,4 +75,9 @@ bool BufferedStreamerBase::IsStopped() {
 bool BufferedStreamerBase::IsStalled() {
   return buffered_ > max_buffered_cnt_ || producer_buf_.InputLen() > max_buffered_mem_;
 }
+
+size_t BufferedStreamerBase::GetTotalBufferCapacities() const {
+  return consumer_buf_.Capacity() + producer_buf_.Capacity();
+}
+
 }  // namespace dfly

--- a/src/server/io_utils.h
+++ b/src/server/io_utils.h
@@ -25,6 +25,10 @@ class BufferedStreamerBase : public io::Sink {
       : cll_{cll}, max_buffered_cnt_{max_buffered_cnt}, max_buffered_mem_{max_buffered_mem} {
   }
 
+ public:
+  size_t GetTotalBufferCapacities() const;
+
+ protected:
   // Write some data into the internal buffer.
   //
   // Consumer needs to be woken up manually with NotifyWritten to avoid waking it up for small

--- a/src/server/journal/streamer.h
+++ b/src/server/journal/streamer.h
@@ -29,6 +29,8 @@ class JournalStreamer : protected BufferedStreamerBase {
   // and manual cleanup.
   void Cancel();
 
+  using BufferedStreamerBase::GetTotalBufferCapacities;
+
  private:
   // Writer fiber that steals buffer contents and writes them to dest.
   void WriterFb(io::Sink* dest);

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -925,6 +925,8 @@ void Service::DispatchCommand(CmdArgList args, facade::ConnectionContext* cntx) 
               << " in dbid=" << dfly_cntx->conn_state.db_index;
   }
 
+  etl.RecordCmd();
+
   if (auto err = VerifyCommandState(cid, args_no_cmd, *dfly_cntx); err) {
     if (auto& exec_info = dfly_cntx->conn_state.exec_info; exec_info.IsCollecting())
       exec_info.state = ConnectionState::ExecInfo::EXEC_ERROR;
@@ -1023,8 +1025,6 @@ bool Service::InvokeCmd(const CommandId* cid, CmdArgList tail_args, ConnectionCo
   if (!monitors.Empty() && (cid->opt_mask() & CO::ADMIN) == 0) {
     DispatchMonitor(cntx, cid, tail_args);
   }
-
-  etl.RecordCmd();
 
   try {
     cid->Invoke(tail_args, cntx);

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2043,7 +2043,7 @@ VarzValue::Map Service::GetVarzStats() {
 
   Metrics m = server_family_.GetMetrics();
   DbStats db_stats;
-  for (const auto& s : m.db) {
+  for (const auto& s : m.db_stats) {
     db_stats += s;
   }
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -925,8 +925,6 @@ void Service::DispatchCommand(CmdArgList args, facade::ConnectionContext* cntx) 
               << " in dbid=" << dfly_cntx->conn_state.db_index;
   }
 
-  etl.RecordCmd();
-
   if (auto err = VerifyCommandState(cid, args_no_cmd, *dfly_cntx); err) {
     if (auto& exec_info = dfly_cntx->conn_state.exec_info; exec_info.IsCollecting())
       exec_info.state = ConnectionState::ExecInfo::EXEC_ERROR;
@@ -1025,6 +1023,8 @@ bool Service::InvokeCmd(const CommandId* cid, CmdArgList tail_args, ConnectionCo
   if (!monitors.Empty() && (cid->opt_mask() & CO::ADMIN) == 0) {
     DispatchMonitor(cntx, cid, tail_args);
   }
+
+  etl.RecordCmd();
 
   try {
     cid->Invoke(tail_args, cntx);

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -692,6 +692,10 @@ error_code RdbSerializer::SendFullSyncCut() {
   return WriteRaw(buf);
 }
 
+size_t RdbSerializer::GetTotalBufferCapacity() const {
+  return mem_buf_.Capacity();
+}
+
 error_code RdbSerializer::WriteRaw(const io::Bytes& buf) {
   mem_buf_.Reserve(mem_buf_.InputLen() + buf.size());
   IoBuf::Bytes dest = mem_buf_.AppendBuffer();
@@ -902,16 +906,17 @@ class RdbSaver::Impl {
 
   error_code ConsumeChannel(const Cancellation* cll);
 
-  error_code Flush() {
-    if (aligned_buf_)
-      return aligned_buf_->Flush();
-
-    return error_code{};
-  }
-
   void FillFreqMap(RdbTypeFreqMap* dest) const;
 
   error_code SaveAuxFieldStrStr(string_view key, string_view val);
+
+  void Cancel();
+
+  size_t GetTotalBuffersSize() const;
+
+  error_code Flush() {
+    return aligned_buf_ ? aligned_buf_->Flush() : error_code{};
+  }
 
   size_t Size() const {
     return shard_snapshots_.size();
@@ -920,11 +925,10 @@ class RdbSaver::Impl {
   RdbSerializer* serializer() {
     return &meta_serializer_;
   }
+
   io::Sink* sink() {
     return sink_;
   }
-
-  void Cancel();
 
  private:
   unique_ptr<SliceSnapshot>& GetSnapshot(EngineShard* shard);
@@ -936,10 +940,15 @@ class RdbSaver::Impl {
   SliceSnapshot::RecordChannel channel_;
   bool push_to_sink_with_order_ = false;
   std::optional<AlignedBuffer> aligned_buf_;
-  CompressionMode
-      compression_mode_;  // Single entry compression is compatible with redis rdb snapshot
-                          // Multi entry compression is available only on df snapshot, this will
-                          // make snapshot size smaller and opreation faster.
+
+  // Single entry compression is compatible with redis rdb snapshot
+  // Multi entry compression is available only on df snapshot, this will
+  // make snapshot size smaller and opreation faster.
+  CompressionMode compression_mode_;
+
+  struct Stats {
+    size_t pulled_bytes = 0;
+  } stats_;
 };
 
 // We pass K=sz to say how many producers are pushing data in order to maintain
@@ -1014,15 +1023,12 @@ std::optional<SliceSnapshot::DbRecord> RdbSaver::Impl::RecordsPopper::InternalPo
 
 error_code RdbSaver::Impl::ConsumeChannel(const Cancellation* cll) {
   error_code io_error;
-
-  size_t channel_bytes = 0;
   std::optional<SliceSnapshot::DbRecord> record;
 
   RecordsPopper records_popper(push_to_sink_with_order_, &channel_);
 
   // we can not exit on io-error since we spawn fibers that push data.
   // TODO: we may signal them to stop processing and exit asap in case of the error.
-
   while ((record = records_popper.Pop())) {
     if (io_error || cll->IsCancelled())
       continue;
@@ -1032,7 +1038,7 @@ error_code RdbSaver::Impl::ConsumeChannel(const Cancellation* cll) {
         continue;
 
       DVLOG(2) << "Pulled " << record->id;
-      channel_bytes += record->value.size();
+      stats_.pulled_bytes += record->value.size();
 
       io_error = sink_->Write(io::Buffer(record->value));
       if (io_error) {
@@ -1044,12 +1050,12 @@ error_code RdbSaver::Impl::ConsumeChannel(const Cancellation* cll) {
   size_t pushed_bytes = 0;
   for (auto& ptr : shard_snapshots_) {
     ptr->Join();
-    pushed_bytes += ptr->channel_bytes();
+    pushed_bytes += ptr->pushed_bytes();
   }
 
   DCHECK(!record.has_value() || !channel_.TryPop(*record));
 
-  VLOG(1) << "Channel pulled bytes: " << channel_bytes << " pushed bytes: " << pushed_bytes;
+  VLOG(1) << "Channel pulled bytes: " << stats_.pulled_bytes << " pushed bytes: " << pushed_bytes;
 
   return io_error;
 }
@@ -1088,6 +1094,17 @@ void RdbSaver::Impl::Cancel() {
   }
 
   snapshot->Join();
+}
+
+size_t RdbSaver::Impl::GetTotalBuffersSize() const {
+  DCHECK_EQ(shard_snapshots_.size(), 1u) << "Only supported for dragonfly replication";
+  auto& snapshot = shard_snapshots_.front();
+
+  // Calculate number of enqueued bytes as difference between pushed and pulled
+  size_t enqueued_bytes = snapshot->pushed_bytes() - stats_.pulled_bytes;
+  size_t serializer_bytes = snapshot->GetTotalBufferCapacity();
+
+  return enqueued_bytes + serializer_bytes;
 }
 
 void RdbSaver::Impl::FillFreqMap(RdbTypeFreqMap* dest) const {
@@ -1264,6 +1281,10 @@ error_code RdbSaver::SaveAuxFieldStrInt(string_view key, int64_t val) {
 
 void RdbSaver::Cancel() {
   impl_->Cancel();
+}
+
+size_t RdbSaver::GetTotalBuffersSize() const {
+  return impl_->GetTotalBuffersSize();
 }
 
 void RdbSerializer::AllocateCompressorOnce() {

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -108,6 +108,10 @@ class RdbSaver {
     return save_mode_;
   }
 
+  // Can only be called for dragonfly replication.
+  // Get total size of all rdb serializer buffers and items currently placed in channel
+  size_t GetTotalBuffersSize() const;
+
  private:
   class Impl;
 
@@ -167,6 +171,8 @@ class RdbSerializer {
 
   // Send FULL_SYNC_CUT opcode to notify that all static data was sent.
   std::error_code SendFullSyncCut();
+
+  size_t GetTotalBufferCapacity() const;
 
  private:
   // Prepare internal buffer for flush. Compress it.

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -285,9 +285,9 @@ TEST_F(RdbTest, SaveManyDbs) {
   });
 
   auto metrics = GetMetrics();
-  ASSERT_EQ(2, metrics.db.size());
-  EXPECT_EQ(50000, metrics.db[0].key_count);
-  EXPECT_EQ(10000, metrics.db[1].key_count);
+  ASSERT_EQ(2, metrics.db_stats.size());
+  EXPECT_EQ(50000, metrics.db_stats[0].key_count);
+  EXPECT_EQ(10000, metrics.db_stats[1].key_count);
 
   auto save_fb = pp_->at(0)->LaunchFiber([&] {
     RespExpr resp = Run({"save"});
@@ -317,10 +317,10 @@ TEST_F(RdbTest, SaveManyDbs) {
   EXPECT_EQ(resp, "OK");
 
   metrics = GetMetrics();
-  ASSERT_EQ(2, metrics.db.size());
-  EXPECT_EQ(50000, metrics.db[0].key_count);
-  EXPECT_EQ(10000, metrics.db[1].key_count);
-  if (metrics.db[1].key_count != 10000) {
+  ASSERT_EQ(2, metrics.db_stats.size());
+  EXPECT_EQ(50000, metrics.db_stats[0].key_count);
+  EXPECT_EQ(10000, metrics.db_stats[1].key_count);
+  if (metrics.db_stats[1].key_count != 10000) {
     Run({"select", "1"});
     resp = Run({"scan", "0", "match", "ab*"});
     StringVec vec = StrArray(resp.GetVec()[1]);

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1417,17 +1417,11 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
     append("defrag_attempt_total", m.shard_stats.defrag_attempt_total);
     append("defrag_realloc_total", m.shard_stats.defrag_realloc_total);
     append("defrag_task_invocation_total", m.shard_stats.defrag_task_invocation_total);
-<<<<<<< HEAD
-    append("eval_io_coordination_total", m.eval_io_coordination_cnt);
-    append("eval_shardlocal_coordination_total", m.eval_shardlocal_coordination_cnt);
-    append("eval_squashed_flushes", m.eval_squashed_flushes);
-    append("tx_schedule_cancel_total", m.tx_schedule_cancel_cnt);
-=======
     append("eval_io_coordination_total", m.coordinator_stats.eval_io_coordination_cnt);
     append("eval_shardlocal_coordination_total",
            m.coordinator_stats.eval_shardlocal_coordination_cnt);
+    append("eval_squashed_flushes", m.coordinator_stats.eval_squashed_flushes);
     append("tx_schedule_cancel_total", m.coordinator_stats.tx_schedule_cancel_cnt);
->>>>>>> 382c4f6a (fix(server): Clean up metrics collection)
   }
 
   if (should_enter("TIERED", true)) {
@@ -1517,7 +1511,6 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
   }
 
   if (should_enter("SEARCH", true)) {
-    ADD_HEADER("# Search");
     append("search_memory", m.search_stats.used_memory);
     append("search_num_indices", m.search_stats.num_indices);
     append("search_num_entries", m.search_stats.num_entries);

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1369,6 +1369,13 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
       // Compatible with redis based frameworks.
       append("maxmemory_policy", "noeviction");
     }
+
+    if (m.is_master && !m.replication_metrics.empty()) {
+      ReplicationMemoryStats repl_mem;
+      dfly_cmd_->GetReplicationMemoryStats(&repl_mem);
+      append("replication_streaming_buffer_bytes", repl_mem.streamer_buf_capacity_bytes_);
+      append("replication_full_sync_buffer_bytes", repl_mem.full_sync_buf_bytes_);
+    }
   }
 
   if (should_enter("STATS")) {

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -55,8 +55,14 @@ struct ReplicaRoleInfo {
 };
 
 struct ReplicationMemoryStats {
-  size_t streamer_buf_capacity_bytes_ = 0;  // get total capacities of streamer buffers
-  size_t full_sync_buf_bytes_ = 0;          // get total bytes used for full sync bufferings
+  size_t streamer_buf_capacity_bytes_ = 0;  // total capacities of streamer buffers
+  size_t full_sync_buf_bytes_ = 0;          // total bytes used for full sync buffers
+};
+
+// Global peak stats recorded after aggregating metrics over all shards
+struct PeakStats {
+  size_t conn_dispatch_queue_bytes = 0;  // peak value of conn_stats.dispatch_queue_bytes
+  size_t conn_read_buf_capacity = 0;     // peak of total read buf capcacities
 };
 
 // Aggregated metrics over multiple sources on all shards
@@ -69,6 +75,8 @@ struct Metrics {
   TieredStats tiered_stats;            // stats for tiered storage
   SearchStats search_stats;
   ServerState::Stats coordinator_stats;  // stats on transaction running
+
+  PeakStats peak_stats;
 
   size_t uptime = 0;
   size_t qps = 0;
@@ -256,6 +264,9 @@ class ServerFamily {
   std::unique_ptr<FiberQueueThreadPool> fq_threadpool_;
   std::unique_ptr<util::cloud::AWS> aws_;
   std::shared_ptr<detail::SnapshotStorage> snapshot_storage_;
+
+  mutable Mutex peak_stats_mu_;
+  mutable PeakStats peak_stats_;
 };
 
 }  // namespace dfly

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -59,7 +59,8 @@ struct ReplicationMemoryStats {
   size_t full_sync_buf_bytes_ = 0;          // total bytes used for full sync buffers
 };
 
-// Global peak stats recorded after aggregating metrics over all shards
+// Global peak stats recorded after aggregating metrics over all shards.
+// Note that those values are only updated during GetMetrics calls.
 struct PeakStats {
   size_t conn_dispatch_queue_bytes = 0;  // peak value of conn_stats.dispatch_queue_bytes
   size_t conn_read_buf_capacity = 0;     // peak of total read buf capcacities

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -54,6 +54,11 @@ struct ReplicaRoleInfo {
   uint64_t lsn_lag;
 };
 
+struct ReplicationMemoryStats {
+  size_t streamer_buf_capacity_bytes_ = 0;  // get total capacities of streamer buffers
+  size_t full_sync_buf_bytes_ = 0;          // get total bytes used for full sync bufferings
+};
+
 // Aggregated metrics over multiple sources on all shards
 struct Metrics {
   SliceEvents events;              // general keyspace stats

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -27,9 +27,10 @@ ServerState::Stats& ServerState::Stats::operator+=(const ServerState::Stats& oth
   this->ooo_tx_cnt += other.ooo_tx_cnt;
   this->eval_io_coordination_cnt += other.eval_io_coordination_cnt;
   this->eval_shardlocal_coordination_cnt += other.eval_shardlocal_coordination_cnt;
+  this->eval_squashed_flushes += other.eval_squashed_flushes;
   this->tx_schedule_cancel_cnt += other.tx_schedule_cancel_cnt;
 
-  static_assert(sizeof(Stats) == 4 * 8);
+  static_assert(sizeof(Stats) == 5 * 8);
   return *this;
 }
 

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -23,6 +23,16 @@ namespace dfly {
 
 __thread ServerState* ServerState::state_ = nullptr;
 
+ServerState::Stats& ServerState::Stats::operator+=(const ServerState::Stats& other) {
+  this->ooo_tx_cnt += other.ooo_tx_cnt;
+  this->eval_io_coordination_cnt += other.eval_io_coordination_cnt;
+  this->eval_shardlocal_coordination_cnt += other.eval_shardlocal_coordination_cnt;
+  this->tx_schedule_cancel_cnt += other.tx_schedule_cancel_cnt;
+
+  static_assert(sizeof(Stats) == 4 * 8);
+  return *this;
+}
+
 void MonitorsRepo::Add(facade::Connection* connection) {
   VLOG(1) << "register connection "
           << " at address 0x" << std::hex << (const void*)connection << " for thread "

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -98,6 +98,8 @@ class ServerState {  // public struct - to allow initialization.
     uint64_t eval_squashed_flushes = 0;
 
     uint64_t tx_schedule_cancel_cnt = 0;
+
+    Stats& operator+=(const Stats& other);
   };
 
   static ServerState* tlocal() {

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -273,7 +273,8 @@ bool SliceSnapshot::PushSerializedToChannel(bool force) {
   size_t serialized = sfile.val.size();
   if (serialized == 0)
     return 0;
-  stats_.channel_bytes += serialized;
+
+  stats_.pushed_bytes += serialized;
 
   auto id = rec_id_++;
   DVLOG(2) << "Pushed " << id;
@@ -328,6 +329,10 @@ void SliceSnapshot::CloseRecordChannel() {
   if (closed_chan_.compare_exchange_strong(expected, true)) {
     dest_->StartClosing();
   }
+}
+
+size_t SliceSnapshot::GetTotalBufferCapacity() const {
+  return serializer_->GetTotalBufferCapacity();
 }
 
 }  // namespace dfly

--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -114,13 +114,15 @@ class SliceSnapshot {
     return snapshot_version_;
   }
 
-  size_t channel_bytes() const {
-    return stats_.channel_bytes;
+  size_t pushed_bytes() const {
+    return stats_.pushed_bytes;
   }
 
   const RdbTypeFreqMap& freq_map() const {
     return type_freq_map_;
   }
+
+  size_t GetTotalBufferCapacity() const;
 
  private:
   DbSlice* db_slice_;
@@ -146,7 +148,7 @@ class SliceSnapshot {
   uint64_t rec_id_ = 0;
 
   struct Stats {
-    size_t channel_bytes = 0;
+    size_t pushed_bytes = 0;
     size_t loop_serialized = 0, skipped = 0, side_saved = 0;
     size_t savecb_calls = 0;
   } stats_;

--- a/src/server/string_family_test.cc
+++ b/src/server/string_family_test.cc
@@ -48,7 +48,7 @@ TEST_F(StringFamilyTest, SetGet) {
   EXPECT_EQ(Run({"get", "key"}), "2");
 
   auto metrics = GetMetrics();
-  EXPECT_EQ(6, metrics.ooo_tx_transaction_cnt);
+  EXPECT_EQ(6, metrics.coordinator_stats.ooo_tx_cnt);
 }
 
 TEST_F(StringFamilyTest, Incr) {

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -67,26 +67,26 @@ TEST_F(TieredStorageTest, Basic) {
 
   EXPECT_EQ(5000, CheckedInt({"dbsize"}));
   Metrics m = GetMetrics();
-  EXPECT_GT(m.db[0].tiered_entries, 0u);
+  EXPECT_GT(m.db_stats[0].tiered_entries, 0u);
 
   FillExternalKeys(5000);
   usleep(20000);  // 0.02 milliseconds
 
   m = GetMetrics();
-  DbStats stats = m.db[0];
+  DbStats stats = m.db_stats[0];
 
   LOG(INFO) << stats;
-  unsigned tiered_entries = m.db[0].tiered_entries;
+  unsigned tiered_entries = m.db_stats[0].tiered_entries;
   EXPECT_GT(tiered_entries, 0u);
   string resp = CheckedString({"debug", "object", "k1"});
   EXPECT_THAT(resp, HasSubstr("spill_len"));
   m = GetMetrics();
-  LOG(INFO) << m.db[0];
-  ASSERT_EQ(tiered_entries, m.db[0].tiered_entries);
+  LOG(INFO) << m.db_stats[0];
+  ASSERT_EQ(tiered_entries, m.db_stats[0].tiered_entries);
 
   Run({"del", "k1"});
   m = GetMetrics();
-  EXPECT_EQ(m.db[0].tiered_entries, tiered_entries - 1);
+  EXPECT_EQ(m.db_stats[0].tiered_entries, tiered_entries - 1);
 }
 
 }  // namespace dfly


### PR DESCRIPTION
1.  Clean up metrics collection (no functional changes)
    - Group together tx stats in Metrics struct
    - Remove ADD_HEADER
    - Small polishment
2. Add dispatch queue stats
    - entries
    - bytes
    - peak_bytes
3. Add replication buffer stats
    - total streamer buffer capacities
    - full sync buffers & channel bytes
4. Add a per-thread limit to the dispatch queue size