### PR TITLE
fix(regtests): Reduce load on redis replication test

### DIFF
--- a/tests/dragonfly/redis_replication_test.py
+++ b/tests/dragonfly/redis_replication_test.py
@@ -153,11 +153,11 @@ async def test_replication_stable_sync(
 # Threads for each dragonfly replica, Seeder Config.
 replication_specs = [
     ([1], dict(keys=1000, dbcount=1, unsupported_types=[ValueType.JSON])),
-    ([6, 6, 6], dict(keys=4_000, dbcount=4, unsupported_types=[ValueType.JSON])),
-    ([2, 2, 2, 2], dict(keys=4_000, dbcount=4, unsupported_types=[ValueType.JSON])),
-    ([8, 8], dict(keys=4_000, dbcount=4, unsupported_types=[ValueType.JSON])),
-    ([1] * 8, dict(keys=500, dbcount=2, unsupported_types=[ValueType.JSON])),
-    ([1], dict(keys=100, dbcount=2, unsupported_types=[ValueType.JSON])),
+    ([6, 6, 6], dict(keys=4_000, dbcount=2, unsupported_types=[ValueType.JSON])),
+    ([2, 2, 2, 2], dict(keys=4_000, dbcount=2, unsupported_types=[ValueType.JSON])),
+    ([8, 8], dict(keys=4_000, dbcount=2, unsupported_types=[ValueType.JSON])),
+    ([1] * 8, dict(keys=500, dbcount=1, unsupported_types=[ValueType.JSON])),
+    ([1], dict(keys=100, dbcount=4, unsupported_types=[ValueType.JSON])),
 ]
 
 

--- a/tests/dragonfly/utility.py
+++ b/tests/dragonfly/utility.py
@@ -167,9 +167,10 @@ class CommandGenerator:
             return ("v0", 0, "v1", 0) + tuple(itertools.chain(*elements))
         elif t == ValueType.ZSET:
             # Random sequnce of k-letter members and int score for ZADD
-            # The length of the sequence will vary between val_size/4 and 130. This ensures that we test both the ZSET implementation with Lispack and the bptree.
+            # The length of the sequence will vary between val_size/4 and 130.
+            # This ensures that we test both the ZSET implementation with listpack and the our custom BPtree.
             value_sizes = [self.val_size // 4, 130]
-            probabilities = [4, 1]
+            probabilities = [8, 1]
             value_size = random.choices(value_sizes, probabilities)[0]
             elements = ((random.randint(0, self.val_size), rand_str()) for _ in range(value_size))
             return tuple(itertools.chain(*elements))


### PR DESCRIPTION
#1963 Increased the load a little and it was enough to make the test time out. It takes >2 min alone so I decided to lower the load a little