### PR TITLE
fix(Listener): skip auth when requirepass is empty on http

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2072,8 +2072,9 @@ GlobalState Service::GetGlobalState() const {
 
 void Service::ConfigureHttpHandlers(util::HttpListenerBase* base, bool is_privileged) {
   // We skip authentication on privileged listener if the flag admin_nopass is set
+  // We also skip authentication if requirepass is empty
   const bool should_skip_auth = is_privileged && !RequirePrivilegedAuth();
-  if (!should_skip_auth) {
+  if (!should_skip_auth && !GetPassword().empty()) {
     base->SetAuthFunctor([pass = GetPassword()](std::string_view path, std::string_view username,
                                                 std::string_view password) {
       if (path == "/metrics")

--- a/tests/dragonfly/http_conf_test.py
+++ b/tests/dragonfly/http_conf_test.py
@@ -26,6 +26,21 @@ async def test_skip_metrics(df_factory):
             assert resp.status == 200
 
 
+async def test_no_password_main_port(df_factory):
+    with df_factory.create(
+        port=1112,
+    ) as server:
+        async with aiohttp.ClientSession(auth=aiohttp.BasicAuth("default", "XXX")) as session:
+            resp = await session.get(f"http://localhost:{server.port}/")
+            assert resp.status == 200
+        async with aiohttp.ClientSession(auth=aiohttp.BasicAuth("random")) as session:
+            resp = await session.get(f"http://localhost:{server.port}/")
+            assert resp.status == 200
+        async with aiohttp.ClientSession() as session:
+            resp = await session.get(f"http://localhost:{server.port}/")
+            assert resp.status == 200
+
+
 async def test_no_password_on_admin(df_factory):
     with df_factory.create(
         port=1112,


### PR DESCRIPTION
When `requirepass` was empty, we would still require the username to authenticate. This is fixed now.