### PR TITLE
update(requirepass): behave as redis requirepass

### DIFF
--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -223,7 +223,7 @@ std::optional<facade::ErrorReply> AclFamily::LoadToRegistryFromFile(std::string_
   auto file_contents = std::move(is_file_read.value());
 
   if (file_contents.empty()) {
-    return {};
+    return {facade::ErrorReply("Empty file")};
   }
 
   std::vector<std::string> usernames;

--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -16,6 +16,7 @@
 #include <utility>
 #include <variant>
 
+#include "absl/flags/commandlineflag.h"
 #include "absl/strings/match.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
@@ -34,6 +35,7 @@
 #include "server/acl/validator.h"
 #include "server/command_registry.h"
 #include "server/common.h"
+#include "server/config_registry.h"
 #include "server/conn_context.h"
 #include "server/server_state.h"
 #include "util/proactor_pool.h"
@@ -559,11 +561,14 @@ void AclFamily::Register(dfly::CommandRegistry* registry) {
 void AclFamily::Init(facade::Listener* main_listener, UserRegistry* registry) {
   main_listener_ = main_listener;
   registry_ = registry;
+  config_registry.RegisterMutable("requirepass", [this](const absl::CommandLineFlag& flag) {
+    User::UpdateRequest rqst;
+    rqst.password = flag.CurrentValue();
+    registry_->MaybeAddAndUpdate("default", std::move(rqst));
+    return true;
+  });
   auto acl_file = absl::GetFlag(FLAGS_aclfile);
-  if (!acl_file.empty()) {
-    if (!Load()) {
-      registry_->Init();
-    }
+  if (!acl_file.empty() && Load()) {
     return;
   }
   registry_->Init();

--- a/src/server/acl/user_registry.cc
+++ b/src/server/acl/user_registry.cc
@@ -7,7 +7,7 @@
 #include <limits>
 #include <mutex>
 
-#include "absl/flags/internal/flag.h"
+#include "base/flags.h"
 #include "core/fibers.h"
 #include "facade/facade_types.h"
 #include "server/acl/acl_commands_def.h"

--- a/src/server/acl/user_registry.cc
+++ b/src/server/acl/user_registry.cc
@@ -100,6 +100,10 @@ void UserRegistry::Init() {
   auto maybe_password = absl::GetFlag(FLAGS_requirepass);
   if (!maybe_password.empty()) {
     default_user.password = std::move(maybe_password);
+  } else if (const char* env_var = getenv("DFLY_PASSWORD"); env_var) {
+    default_user.password = env_var;
+  } else if (const char* env_var = getenv("DFLY_requirepass"); env_var) {
+    default_user.password = env_var;
   }
   MaybeAddAndUpdate("default", std::move(default_user));
 }

--- a/src/server/acl/user_registry.cc
+++ b/src/server/acl/user_registry.cc
@@ -7,9 +7,12 @@
 #include <limits>
 #include <mutex>
 
+#include "absl/flags/internal/flag.h"
 #include "core/fibers.h"
 #include "facade/facade_types.h"
 #include "server/acl/acl_commands_def.h"
+
+ABSL_DECLARE_FLAG(std::string, requirepass);
 
 namespace dfly::acl {
 
@@ -89,7 +92,16 @@ User::UpdateRequest UserRegistry::DefaultUserUpdateRequest() const {
 void UserRegistry::Init() {
   // Add default user
   User::UpdateRequest::CommandsUpdateType tmp(NumberOfFamilies());
-  MaybeAddAndUpdate("default", DefaultUserUpdateRequest());
+  // if there exists an acl file to load from, requirepass
+  // will not overwrite the default's user password loaded from
+  // that file. Loading the default's user password from a file
+  // has higher priority than the deprecated flag
+  auto default_user = DefaultUserUpdateRequest();
+  auto maybe_password = absl::GetFlag(FLAGS_requirepass);
+  if (!maybe_password.empty()) {
+    default_user.password = std::move(maybe_password);
+  }
+  MaybeAddAndUpdate("default", std::move(default_user));
 }
 
 }  // namespace dfly::acl

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1213,6 +1213,8 @@ facade::ConnectionContext* Service::CreateContext(util::FiberSocketBase* peer,
 
   if (owner->IsPrivileged() && RequirePrivilegedAuth()) {
     res->req_auth = !GetPassword().empty();
+  } else {
+    res->req_auth = !user_registry_.AuthUser("default", "");
   }
 
   // a bit of a hack. I set up breaker callback here for the owner.

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -652,7 +652,6 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
 
   config_registry.Register("dbnum");       // equivalent to databases in redis.
   config_registry.RegisterMutable("dir");  // TODO: to add validation for dir
-  config_registry.RegisterMutable("requirepass");
   config_registry.RegisterMutable("masterauth");
   config_registry.RegisterMutable("tcp_keepalive");
   config_registry.RegisterMutable("replica_partial_sync");
@@ -1212,9 +1211,7 @@ facade::ConnectionContext* Service::CreateContext(util::FiberSocketBase* peer,
                                                   facade::Connection* owner) {
   ConnectionContext* res = new ConnectionContext{peer, owner};
 
-  if (owner->IsPrivileged() && !RequirePrivilegedAuth()) {
-    res->req_auth = false;
-  } else {
+  if (owner->IsPrivileged() && RequirePrivilegedAuth()) {
     res->req_auth = !GetPassword().empty();
   }
 

--- a/tests/dragonfly/acl_family_test.py
+++ b/tests/dragonfly/acl_family_test.py
@@ -331,10 +331,11 @@ async def test_good_acl_file(df_local_factory, tmp_dir):
     await client.execute_command("ACL SETUSER vlad +@STRING")
 
     result = await client.execute_command("ACL LIST")
-    assert 3 == len(result)
+    assert 4 == len(result)
     assert "user roy on ea71c25a7a60224 +@STRING +HSET" in result
     assert "user shahar off ea71c25a7a60224 +@SET" in result
     assert "user vlad off nopass +@STRING" in result
+    assert "user default on nopass +@ALL +ALL" in result
 
     result = await client.execute_command("ACL DELUSER shahar")
     assert result == b"OK"
@@ -399,8 +400,10 @@ async def test_require_pass(df_local_factory):
 
     client = aioredis.Redis(port=df.port)
 
-    with pytest.raises(redis.exceptions.ResponseError):
+    with pytest.raises(redis.exceptions.AuthenticationError):
         await client.execute_command("AUTH default wrongpass")
+
+    client = aioredis.Redis(password="mypass", port=df.port)
 
     res = await client.execute_command("AUTH default mypass")
     assert res == b"OK"


### PR DESCRIPTION
* requirepass also updates ACL default user password
* update config set requirepass to include the new behaviour
* add tests
* fix non existent default user when loading empty files