### PR TITLE
fix: buffer overrun when passing long command name from lua

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,8 +7,8 @@ endif()
 
 add_third_party(
   lua
-  URL https://github.com/lua/lua/archive/refs/tags/v5.4.4.tar.gz
-  PATCH_COMMAND patch -p1 -i "${CMAKE_SOURCE_DIR}/patches/lua-v5.4.4.patch"
+  GIT_REPOSITORY https://github.com/dragonflydb/lua
+  GIT_TAG Dragonfly-5.4.6
   CONFIGURE_COMMAND echo
   BUILD_IN_SOURCE 1
   BUILD_COMMAND ${DFLY_TOOLS_MAKE} all

--- a/src/core/interpreter.h
+++ b/src/core/interpreter.h
@@ -130,6 +130,7 @@ class Interpreter {
   lua_State* lua_;
   unsigned cmd_depth_ = 0;
   RedisFunc redis_func_;
+  std::string buffer_;
 };
 
 // Manages an internal interpreter pool. This allows multiple connections residing on the same

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -159,8 +159,9 @@ void Connection::PipelineMessage::SetArgs(const RespVec& args) {
     size_t s = buf.size();
     if (s)
       memcpy(next, buf.data(), s);
+    next[s] = '\0';
     this->args[i] = MutableSlice(next, s);
-    next += s;
+    next += (s + 1);
   }
 }
 
@@ -959,7 +960,7 @@ Connection::PipelineMessagePtr Connection::FromArgs(RespVec args, mi_heap_t* hea
   size_t backed_sz = 0;
   for (const auto& arg : args) {
     CHECK_EQ(RespExpr::STRING, arg.type);
-    backed_sz += arg.GetBuf().size();
+    backed_sz += arg.GetBuf().size() + 1;  // for '\0'
   }
   DCHECK(backed_sz);
 

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -21,13 +21,13 @@ using namespace facade;
 StoredCmd::StoredCmd(const CommandId* cid, CmdArgList args, facade::ReplyMode mode)
     : cid_{cid}, buffer_{}, sizes_(args.size()), reply_mode_{mode} {
   size_t total_size = 0;
-  for (auto args : args)
-    total_size += args.size();
-
+  for (auto args : args) {
+    total_size += args.size() + 1;  // +1 for null terminator
+  }
   buffer_.resize(total_size);
   char* next = buffer_.data();
   for (unsigned i = 0; i < args.size(); i++) {
-    memcpy(next, args[i].data(), args[i].size());
+    memcpy(next, args[i].data(), args[i].size() + 1);
     sizes_[i] = args[i].size();
     next += args[i].size();
   }

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -371,6 +371,7 @@ void InterpreterReplier::PostItem() {
 
 void InterpreterReplier::SendError(string_view str, std::string_view type) {
   DCHECK(array_len_.empty());
+  DVLOG(1) << "Lua/df_call error " << str;
   explr_->OnError(str);
 }
 
@@ -1377,7 +1378,7 @@ optional<CapturingReplyBuilder::Payload> Service::FlushEvalAsyncCmds(ConnectionC
 
 void Service::CallFromScript(ConnectionContext* cntx, Interpreter::CallArgs& ca) {
   DCHECK(cntx->transaction);
-  DVLOG(1) << "CallFromScript " << cntx->transaction->DebugId() << " " << ArgS(ca.args, 0);
+  DVLOG(1) << "CallFromScript " << ArgS(ca.args, 0);
 
   InterpreterReplier replier(ca.translator);
   facade::SinkReplyBuilder* orig = cntx->Inject(&replier);


### PR DESCRIPTION
Also, few additional changes that do not affect functionality.
1. make sure passed arguments to DispatchCommand are `\0` delimited during pipelining.
2. extend lua malloc hook to call precise functions - to help with cpu profiling.
3. reuse arguments buffer (save allocations) when calling Dragonfly command from lua scripts.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->