### PR TITLE
chore: Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
         run: |
           changed=$(ct list-changed --config .ct.yaml)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -36,8 +36,8 @@ jobs:
       run: |
         # If env.IS_PRERELEASE is true, set tag to alpha and do not enable tag_latest
         # If env.IS_PRERELEASE is not true (aka false), don't set an extra tag and enable tag_latest
-        echo "::set-output name=tag::${{ env.IS_PRERELEASE == 'true' && 'alpha' }}"
-        echo "::set-output name=tag_latest::${{ env.IS_PRERELEASE == 'true' && 'false' || 'true' }}"
+        echo "tag=${{ env.IS_PRERELEASE == 'true' && 'alpha' }}" >> $GITHUB_OUTPUT
+        echo "tag_latest=${{ env.IS_PRERELEASE == 'true' && 'false' || 'true' }}" >> $GITHUB_OUTPUT
 
   release-container:
     needs: release-container-prereq


### PR DESCRIPTION
## Description

Closes #2009 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo "::set-output name=changed::true"
```

**TO-BE**

```yaml
echo "changed=true" >> $GITHUB_OUTPUT
```