### PR TITLE
chore: Enable squashing by default

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -48,7 +48,7 @@ ABSL_FLAG(uint64_t, pipeline_queue_limit, 1ULL << 27,  // 128MB
 
 ABSL_FLAG(bool, no_tls_on_admin_port, false, "Allow non-tls connections on admin port");
 
-ABSL_FLAG(uint64_t, pipeline_squash, 20,
+ABSL_FLAG(uint64_t, pipeline_squash, 5,
           "Number of queued pipelined commands above which squashing is enabled, 0 means disabled");
 
 // When changing this constant, also update `test_large_cmd` test in connection_test.py.

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -48,7 +48,7 @@ ABSL_FLAG(uint64_t, pipeline_queue_limit, 1ULL << 27,  // 128MB
 
 ABSL_FLAG(bool, no_tls_on_admin_port, false, "Allow non-tls connections on admin port");
 
-ABSL_FLAG(uint64_t, pipeline_squash, 0,
+ABSL_FLAG(uint64_t, pipeline_squash, 20,
           "Number of queued pipelined commands above which squashing is enabled, 0 means disabled");
 
 // When changing this constant, also update `test_large_cmd` test in connection_test.py.

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -75,7 +75,7 @@ ABSL_FLAG(uint32_t, num_shards, 0, "Number of database shards, 0 - to choose aut
 ABSL_FLAG(uint32_t, multi_exec_mode, 2,
           "Set multi exec atomicity mode: 1 for global, 2 for locking ahead, 3 for non atomic");
 
-ABSL_FLAG(bool, multi_exec_squash, false,
+ABSL_FLAG(bool, multi_exec_squash, true,
           "Whether multi exec will squash single shard commands to optimize performance");
 
 ABSL_FLAG(uint32_t, multi_eval_squash_buffer, 4_KB, "Max buffer for squashed commands per script");


### PR DESCRIPTION
AS per request:
* Set pipeline squashing by default to 20
* Enable multi-exec squashing

Some side notes:
1. Pipeline squashing reorders commands which might be unexpected to users
2. We still have performance trouble with squashed reads, see bottom of #1907 