### PR TITLE
opt(server): Allow round-robin keys between shards based on prefix

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -82,6 +82,7 @@ cxx_test(cluster/cluster_config_test dfly_test_lib LABELS DFLY)
 cxx_test(cluster/cluster_family_test dfly_test_lib LABELS DFLY)
 cxx_test(acl/user_registry_test dfly_test_lib LABELS DFLY)
 cxx_test(acl/acl_family_test dfly_test_lib LABELS DFLY)
+cxx_test(engine_shard_set_test dfly_test_lib LABELS DFLY)
 
 
 

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -78,7 +78,13 @@ ShardMemUsage ReadShardMemUsage(float wasted_ratio) {
   return usage;
 }
 
-// TODO: document this class.
+// RoundRobinSharder implements a way to distribute keys that begin with some prefix.
+// Round-robin is disabled by default. It is not a general use-case optimization, but instead only
+// reasonable when there are a few highly contended keys, which we'd like to spread between the
+// shards evenly.
+// When enabled, the distribution is done via hash table: the hash of the key is used to look into
+// a pre-allocated vector. This means that collisions are possible, but are very unlikely if only
+// a few keys are used.
 // Thread safe.
 class RoundRobinSharder {
  public:

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -702,11 +702,14 @@ void EngineShardSet::TEST_EnableCacheMode() {
   RunBriefInParallel([](EngineShard* shard) { shard->db_slice().TEST_EnableCacheMode(); });
 }
 
-ShardId Shard(std::string_view v, ShardId shard_num) {
+ShardId Shard(string_view v, ShardId shard_num) {
   bool has_hashtags = false;
   if (ClusterConfig::IsEnabledOrEmulated()) {
-    v = ClusterConfig::KeyTag(v);
-    has_hashtags = true;
+    string_view v_hash_tag = ClusterConfig::KeyTag(v);
+    if (v_hash_tag.size() != v.size()) {
+      has_hashtags = true;
+      v = v_hash_tag;
+    }
   }
 
   XXH64_hash_t hash = XXH64(v.data(), v.size(), 120577240643ULL);

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -44,10 +44,10 @@ ABSL_FLAG(float, mem_defrag_page_utilization_threshold, 0.8,
           "memory page under utilization threshold. Ratio between used and committed size, below "
           "this, memory in this page will defragmented");
 
-ABSL_FLAG(string, round_robin_prefix, "",
+ABSL_FLAG(string, shard_round_robin_prefix, "",
           "When non-empty, keys with hash-tags, whose hash-tag starts with this prefix are not "
           "distributed across shards based on their value but instead via round-robin. Use "
-          "cautiously! This can efficiently support up to a few hunderds of keys.");
+          "cautiously! This can efficiently support up to a few hunderds of hash-tags.");
 
 namespace dfly {
 
@@ -83,7 +83,7 @@ ShardMemUsage ReadShardMemUsage(float wasted_ratio) {
 class RoundRobinSharder {
  public:
   void Init() {
-    round_robin_prefix_ = absl::GetFlag(FLAGS_round_robin_prefix);
+    round_robin_prefix_ = absl::GetFlag(FLAGS_shard_round_robin_prefix);
 
     if (IsEnabled()) {
       // ~100k entries will consume 200kb per thread, and will allow 100 keys with < 2.5% collision

--- a/src/server/engine_shard_set.h
+++ b/src/server/engine_shard_set.h
@@ -360,13 +360,7 @@ template <typename U, typename P> void EngineShardSet::RunBlockingInParallel(U&&
   bc.Wait();
 }
 
-inline ShardId Shard(std::string_view v, ShardId shard_num) {
-  if (ClusterConfig::IsEnabledOrEmulated()) {
-    v = ClusterConfig::KeyTag(v);
-  }
-  XXH64_hash_t hash = XXH64(v.data(), v.size(), 120577240643ULL);
-  return hash % shard_num;
-}
+ShardId Shard(std::string_view v, ShardId shard_num);
 
 // absl::GetCurrentTimeNanos is twice faster than clock_gettime(CLOCK_REALTIME) on my laptop
 // and 4 times faster than on a VM. it takes 5-10ns to do a call.

--- a/src/server/engine_shard_set_test.cc
+++ b/src/server/engine_shard_set_test.cc
@@ -1,0 +1,91 @@
+// Copyright 2023, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include <absl/flags/reflection.h>
+#include <absl/strings/numbers.h>
+#include <absl/strings/str_split.h>
+#include <absl/strings/strip.h>
+#include <gmock/gmock.h>
+
+#include <map>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "base/flags.h"
+#include "base/gtest.h"
+#include "base/logging.h"
+#include "server/main_service.h"
+#include "server/test_utils.h"
+
+ABSL_DECLARE_FLAG(std::string, shard_round_robin_prefix);
+
+namespace dfly {
+namespace {
+
+using namespace std;
+using testing::Contains;
+using testing::Pair;
+
+class RoundRobinSharderTest : public BaseFamilyTest {
+ protected:
+  RoundRobinSharderTest() : BaseFamilyTest() {
+    absl::SetFlag(&FLAGS_shard_round_robin_prefix, "RR:");
+    SetTestFlag("cluster_mode", "emulated");
+    ResetService();
+  }
+
+  map<int, int> GetShardKeyCount() {
+    map<int, int> m;
+
+    auto res = Run({"debug", "shards"});
+    for (string_view line : absl::StrSplit(res.GetString(), '\n')) {
+      vector<string> parts = absl::StrSplit(line, ": ");
+      if (parts.size() != 2) {
+        continue;
+      }
+
+      string_view k = parts[0];
+      if (!absl::StartsWith(k, "shard") || !absl::EndsWith(k, "_key_count")) {
+        continue;
+      }
+
+      CHECK(absl::ConsumePrefix(&k, "shard")) << k;
+      CHECK(absl::ConsumeSuffix(&k, "_key_count")) << k;
+      int sid;
+      CHECK(absl::SimpleAtoi(k, &sid));
+      int count;
+      CHECK(absl::SimpleAtoi(parts[1], &count));
+      m[sid] = count;
+    }
+    return m;
+  }
+};
+
+TEST_F(RoundRobinSharderTest, RoundRobinShard) {
+  if (shard_set->size() < 2) {
+    GTEST_SKIP() << "Can only test round robin with 2+ shards";
+  }
+
+  Run({"set", "{RR:key0}", "value"});
+  EXPECT_THAT(GetShardKeyCount(), Contains(Pair(0, 1)));  // shard 0 has 1 key
+  EXPECT_THAT(GetShardKeyCount(), Contains(Pair(1, 0)));  // shard 1 has 0 keys
+
+  Run({"set", "{RR:key1}", "value"});
+  EXPECT_THAT(GetShardKeyCount(), Contains(Pair(0, 1)));  // shard 0 has 1 key
+  EXPECT_THAT(GetShardKeyCount(), Contains(Pair(1, 1)));  // shard 1 also has 1 key
+
+  Run({"set", "{RR:key2}", "value"});
+  if (shard_set->size() == 2) {
+    EXPECT_THAT(GetShardKeyCount(), Contains(Pair(0, 2)));
+    EXPECT_THAT(GetShardKeyCount(), Contains(Pair(1, 1)));
+  } else {
+    EXPECT_THAT(GetShardKeyCount(), Contains(Pair(0, 1)));
+    EXPECT_THAT(GetShardKeyCount(), Contains(Pair(1, 1)));
+    EXPECT_THAT(GetShardKeyCount(), Contains(Pair(2, 1)));
+  }
+}
+
+}  // namespace
+}  // namespace dfly


### PR DESCRIPTION
This will allow some use cases with few busy keys to distribute load more evenly between threads.

Idea by @dranikpg.

To calculate how many entries are needed in the table I used the following quick-n-dirty code, to reach <1% collision with 100 keys:

```cpp
bool Distribute(int balls = 100, int bins = 100) {
  vector<int> v(bins);
  for (int i = 0; i < balls; ++i) {
    v[rand() % v.size()]++;
  }

  for (int v : v) {
    if (v >= 2) {
      return true;
    }
  }

  return false;
}

int main(int argc, char** argv) {
  int has_2_balls = 0;
  constexpr int kRounds = 1'000'000;
  for (int i = 0; i < kRounds; ++i) {
    has_2_balls += Distribute(100, 500'000);
  }
  cout << has_2_balls << " rounds had 2+ balls in a single bin out of " << kRounds << endl;
}
```

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->