### PR TITLE
fix(server): Fix shardlocal eval with round-robin prefix

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1602,8 +1602,8 @@ void Service::EvalInternal(CmdArgList args, const EvalArgs& eval_args, Interpret
   auto& sinfo = cntx->conn_state.script_info;
   sinfo = make_unique<ConnectionState::ScriptInfo>();
   for (size_t i = 0; i < eval_args.keys.size(); ++i) {
-    string_view key = KeyLockArgs::GetLockKey(ArgS(eval_args.keys, i));
-    sinfo->keys.insert(key);
+    string_view key = ArgS(eval_args.keys, i);
+    sinfo->keys.insert(KeyLockArgs::GetLockKey(key));
 
     ShardId cur_sid = Shard(key, shard_count());
     if (i == 0) {

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -251,10 +251,7 @@ void Transaction::InitByKeys(KeyIndex key_index) {
     shard_data_.front().local_mask |= ACTIVE;
 
     unique_shard_cnt_ = 1;
-    if (is_stub)  // stub transactions don't migrate
-      DCHECK_EQ(unique_shard_id_, Shard(args_.front(), shard_set->size()));
-    else
-      unique_shard_id_ = Shard(args_.front(), shard_set->size());
+    unique_shard_id_ = Shard(args_.front(), shard_set->size());
 
     return;
   }

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -251,7 +251,10 @@ void Transaction::InitByKeys(KeyIndex key_index) {
     shard_data_.front().local_mask |= ACTIVE;
 
     unique_shard_cnt_ = 1;
-    unique_shard_id_ = Shard(args_.front(), shard_set->size());
+    if (is_stub)  // stub transactions don't migrate
+      DCHECK_EQ(unique_shard_id_, Shard(args_.front(), shard_set->size()));
+    else
+      unique_shard_id_ = Shard(args_.front(), shard_set->size());
 
     return;
   }


### PR DESCRIPTION
Calling `Shard()` on a normalized key does not detect the round-robin prefix, as we decided to only apply that on hash-tags.

~It looks like that `DCHECK()` fails when working with BullMQ.
I imagine it's the fact that we schedule the remote Lua work with ScheduleSingleHop, but I haven't thought too much about it.~

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->