### PR TITLE
fix(ubuntu-prod): Set suexec hash correctly

### DIFF
--- a/tools/packaging/Dockerfile.ubuntu-prod
+++ b/tools/packaging/Dockerfile.ubuntu-prod
@@ -7,7 +7,7 @@ WORKDIR /build
 COPY tools/docker/fetch_release.sh /tmp/
 COPY releases/dragonfly-* /tmp/
 
-ARG SUEXEC_HASH d6c40440609a23483f12eb6295b5191e94baf08298a856bab6e15b10c3b82891
+ARG SUEXEC_HASH=d6c40440609a23483f12eb6295b5191e94baf08298a856bab6e15b10c3b82891
 RUN curl -O https://raw.githubusercontent.com/ncopa/su-exec/212b75144bbc06722fbd7661f651390dc47a43d1/su-exec.c && \
     if [ "$SUEXEC_HASH" != $(sha256sum su-exec.c | awk '{print $1}') ]; then echo "Wrong hash!" && exit 1; fi && \
     gcc -Wall -O2 su-exec.c -o su-exec


### PR DESCRIPTION
After this PR:

```
dragonfly on  tar/healthcheck_port [$!?] via C v11.3.0-gcc via △ v3.22.1 via 🐹 v1.20.2 via 🐍 v3.10.6 on ☁️  (us-east-1) on ☁️  tarun@dragonflydb.io 
❯ docker build --no-cache -f ./tools/packaging/Dockerfile.ubuntu-prod .
Sending build context to Docker daemon  105.8MB
Step 1/24 : FROM ghcr.io/romange/ubuntu-dev:20 as builder
 ---> 91563d76322e
Step 2/24 : ARG TARGETPLATFORM
 ---> Running in 84e6971077c6
Removing intermediate container 84e6971077c6
 ---> a6bf761f6a5f
Step 3/24 : WORKDIR /build
 ---> Running in 9381c3df44cb
Removing intermediate container 9381c3df44cb
 ---> 334fd565b419
Step 4/24 : COPY tools/docker/fetch_release.sh /tmp/
 ---> 09ed3b5fefb1
Step 5/24 : ARG SUEXEC_HASH=d6c40440609a23483f12eb6295b5191e94baf08298a856bab6e15b10c3b82891
 ---> Running in a03cb5ccab00
Removing intermediate container a03cb5ccab00
 ---> 2a9b7a3429f3
Step 6/24 : RUN curl -O https://raw.githubusercontent.com/ncopa/su-exec/212b75144bbc06722fbd7661f651390dc47a43d1/su-exec.c &&     if [ "$SUEXEC_HASH" != $(sha256sum su-exec.c | awk '{print $1}') ]; then echo "Wrong hash!" && exit 1; fi &&     gcc -Wall -O2 su-exec.c -o su-exec
 ---> Running in 0ac4cddd1b7b
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1900  100  1900    0     0  44186      0 --:--:-- --:--:-- --:--:-- 44186
Removing intermediate container 0ac4cddd1b7b
 ---> bfd102d55ec0
Step 7/24 : RUN /tmp/fetch_release.sh ${TARGETPLATFORM}
 ---> Running in cb5fd5b8e2b8
PSHORT 
mv: cannot stat '/tmp/dragonfly-aarch64': No such file or directory
The command '/bin/sh -c /tmp/fetch_release.sh ${TARGETPLATFORM}' returned a non-ze
```