### PR TITLE
feat(config): support setting multiple parameters

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -84,6 +84,7 @@ cxx_test(cluster/cluster_family_test dfly_test_lib LABELS DFLY)
 cxx_test(acl/user_registry_test dfly_test_lib LABELS DFLY)
 cxx_test(acl/acl_family_test dfly_test_lib LABELS DFLY)
 cxx_test(engine_shard_set_test dfly_test_lib LABELS DFLY)
+cxx_test(config_registry_test dfly_test_lib LABELS DFLY)
 
 
 

--- a/src/server/config_registry.cc
+++ b/src/server/config_registry.cc
@@ -16,7 +16,8 @@ namespace dfly {
 using namespace std;
 
 // Returns true if the value was updated.
-auto ConfigRegistry::Set(std::string_view config_name, std::string_view value) -> SetResult {
+auto ConfigRegistry::Set(std::string_view config_name, std::string_view value, bool apply)
+    -> SetResult {
   unique_lock lk(mu_);
   auto it = registry_.find(config_name);
   if (it == registry_.end())
@@ -33,8 +34,12 @@ auto ConfigRegistry::Set(std::string_view config_name, std::string_view value) -
   if (!flag->ParseFrom(value, &error))
     return SetResult::INVALID;
 
-  bool success = !cb || cb(*flag);
-  return success ? SetResult::OK : SetResult::INVALID;
+  if (apply) {
+    bool success = !cb || cb(*flag);
+    return success ? SetResult::OK : SetResult::INVALID;
+  }
+
+  return SetResult::OK;
 }
 
 std::optional<std::string> ConfigRegistry::Get(std::string_view config_name) {

--- a/src/server/config_registry.cc
+++ b/src/server/config_registry.cc
@@ -15,28 +15,86 @@ namespace dfly {
 
 using namespace std;
 
-// Returns true if the value was updated.
-auto ConfigRegistry::Set(std::string_view config_name, std::string_view value, bool apply)
-    -> SetResult {
-  unique_lock lk(mu_);
-  auto it = registry_.find(config_name);
-  if (it == registry_.end())
-    return SetResult::UNKNOWN;
-  if (!it->second.is_mutable)
-    return SetResult::READONLY;
+struct ConfigUpdate {
+  std::string_view name;
+  std::string_view new_value;
+  std::string prev_value;
+  absl::CommandLineFlag* flag;
+  ConfigRegistry::WriteCb cb;
+};
 
-  auto cb = it->second.cb;
-  lk.unlock();
+void RollbackUpdates(const std::vector<ConfigUpdate>& updates, size_t applied);
 
-  absl::CommandLineFlag* flag = absl::FindCommandLineFlag(config_name);
-  CHECK(flag);
-  string error;
-  if (!flag->ParseFrom(value, &error))
-    return SetResult::INVALID;
+// TODO(andydunstall): Add unit test coverage
+// TODO(andydunstall): Return the invalid argument to return to user
+auto ConfigRegistry::Set(CmdArgList args) -> SetResult {
+  lock_guard lk(mu_);
 
-  if (apply) {
-    bool success = !cb || cb(*flag);
-    return success ? SetResult::OK : SetResult::INVALID;
+  if (args.empty() || args.size() % 2 != 0) {
+    return SetResult::WRONG_ARGS_NUMBER;
+  }
+
+  std::vector<ConfigUpdate> updates;
+  std::unordered_set<std::string_view> updated_keys;
+
+  // Verify all keys exist and check for duplicates. Store the previous value
+  // so we can roll back if needed.
+  for (size_t args_indx = 0; args_indx < args.size(); args_indx += 2) {
+    ToLower(&args[args_indx]);
+
+    ConfigUpdate update;
+    update.name = ArgS(args, args_indx);
+    update.new_value = ArgS(args, args_indx + 1);
+
+    auto it = registry_.find(update.name);
+    if (it == registry_.end()) {
+      // No need to roll back as no config has been updated.
+      return SetResult::UNKNOWN;
+    }
+    if (!it->second.is_mutable) {
+      // No need to roll back as no config has been updated.
+      return SetResult::READONLY;
+    }
+    update.cb = it->second.cb;
+
+    if (updated_keys.contains(update.name)) {
+      // No need to roll back as no config has been updated.
+      return SetResult::DUPLICATE;
+    }
+
+    update.flag = absl::FindCommandLineFlag(update.name);
+    CHECK(update.flag);
+    update.prev_value = std::string(update.flag->CurrentValue());
+
+    updates.push_back(update);
+    updated_keys.emplace(update.name);
+
+    DVLOG(1) << "update config; name=" << update.name << "; prev_value=" << update.prev_value
+             << "; new_value=" << update.new_value;
+  }
+
+  // Update the flags without applying any registered callbacks.
+  for (size_t i = 0; i != updates.size(); i++) {
+    const ConfigUpdate update = updates[i];
+    std::string error;
+
+    if (!update.flag->ParseFrom(update.new_value, &error)) {
+      // Revert all updated flags.
+      RollbackUpdates(updates, 0);
+      return SetResult::INVALID;
+    }
+  }
+
+  // Apply the registered callbacks.
+  for (size_t i = 0; i != updates.size(); i++) {
+    const ConfigUpdate update = updates[i];
+    std::string error;
+    if (update.cb && !update.cb(*update.flag)) {
+      // Roll back any applied updates. Note only roll back updates already
+      // applied which excludes the latest failed callback.
+      RollbackUpdates(updates, i);
+      return SetResult::INVALID;
+    }
   }
 
   return SetResult::OK;
@@ -75,6 +133,33 @@ void ConfigRegistry::RegisterInternal(std::string_view name, bool is_mutable, Wr
   unique_lock lk(mu_);
   auto [it, inserted] = registry_.emplace(name, Entry{std::move(cb), is_mutable});
   CHECK(inserted) << "Duplicate config name: " << name;
+}
+
+// Reverts all flags to their previous values and roll backs any applied
+// callbacks with their previous values.
+void RollbackUpdates(const std::vector<ConfigUpdate>& updates, size_t applied) {
+  // Revert all flags.
+  for (const ConfigUpdate& update : updates) {
+    DVLOG(1) << "rollback: revert flag; name=" << update.name
+             << "; prev_value=" << update.prev_value;
+
+    std::string error;
+    if (!update.flag->ParseFrom(update.prev_value, &error)) {
+      // This should never happen as we're rolling back to a previous value.
+      LOG(ERROR) << "rollback failed: could not parse update; key=" << update.name
+                 << "; value=" << update.prev_value;
+    }
+  }
+
+  // Only rollback the already applied values.
+  for (size_t i = 0; i != applied; i++) {
+    DVLOG(1) << "rollback: rollback update; name=" << updates[i].name;
+
+    if (updates[i].cb && !updates[i].cb(*updates[i].flag)) {
+      // This should never happen as we're rolling back to a previous value.
+      LOG(ERROR) << "rollback failed: could not apply update; key=" << updates[i].name;
+    }
+  }
 }
 
 ConfigRegistry config_registry;

--- a/src/server/config_registry.h
+++ b/src/server/config_registry.h
@@ -32,7 +32,7 @@ class ConfigRegistry {
   };
 
   // Returns true if the value was updated.
-  SetResult Set(std::string_view config_name, std::string_view value);
+  SetResult Set(std::string_view config_name, std::string_view value, bool apply);
 
   std::optional<std::string> Get(std::string_view config_name);
 

--- a/src/server/config_registry.h
+++ b/src/server/config_registry.h
@@ -5,6 +5,7 @@
 #include <absl/container/flat_hash_map.h>
 #include <absl/flags/reflection.h>
 
+#include "src/server/common.h"
 #include "util/fibers/synchronization.h"
 
 namespace dfly {
@@ -29,10 +30,11 @@ class ConfigRegistry {
     UNKNOWN,
     READONLY,
     INVALID,
+    WRONG_ARGS_NUMBER,
+    DUPLICATE,
   };
 
-  // Returns true if the value was updated.
-  SetResult Set(std::string_view config_name, std::string_view value, bool apply);
+  SetResult Set(CmdArgList args);
 
   std::optional<std::string> Get(std::string_view config_name);
 

--- a/src/server/config_registry_test.cc
+++ b/src/server/config_registry_test.cc
@@ -1,0 +1,45 @@
+// Copyright 2023, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#include "server/config_registry.h"
+
+#include "base/flags.h"
+#include "base/gtest.h"
+
+ABSL_FLAG(std::string, key1, "", "nop flag");
+
+namespace dfly {
+
+std::vector<MutableSlice> StringsToMutableSlice(const std::vector<std::string>& ss) {
+  std::vector<MutableSlice> slices;
+  for (const auto& s : ss) {
+    slices.push_back(MutableSlice{(char*)s.c_str(), s.size()});
+  }
+  return slices;
+}
+
+class ConfigRegistryTest : public ::testing::Test {};
+
+TEST_F(ConfigRegistryTest, SetParamOK) {
+  std::string val1;
+
+  ConfigRegistry registry;
+  registry.RegisterMutable("key1", [&](const absl::CommandLineFlag& flag) {
+    auto res = flag.TryGet<std::string>();
+    if (res.has_value()) {
+      val1 = res.value();
+    }
+    return res.has_value();
+  });
+
+  std::vector<std::string> args{"key1", "foo"};
+  std::vector<MutableSlice> slices = StringsToMutableSlice(args);
+  EXPECT_EQ(ConfigRegistry::SetResult::OK, registry.Set(CmdArgList{slices}));
+
+  EXPECT_EQ("foo", registry.Get("key1"));
+  EXPECT_EQ("foo", val1);
+}
+
+// ... TODO(andydunstall)
+
+}  // namespace dfly

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1192,104 +1192,16 @@ void ServerFamily::Client(CmdArgList args, ConnectionContext* cntx) {
   return (*cntx)->SendError(UnknownSubCmd(sub_cmd, "CLIENT"), kSyntaxErrType);
 }
 
-void ConfigRollBack(const std::unordered_map<std::string_view, std::string>& prev_config,
-                    bool apply) {
-  for (auto const& [key, value] : prev_config) {
-    ConfigRegistry::SetResult result = config_registry.Set(key, value, false);
-    if (result != ConfigRegistry::SetResult::OK) {
-      // Log the error, but theres nothing else we can do.
-      LOG(ERROR) << "failed to roll back config; key=" << key;
-    }
-  }
-  if (apply) {
-    for (auto const& [key, value] : prev_config) {
-      ConfigRegistry::SetResult result = config_registry.Set(key, value, true);
-      if (result != ConfigRegistry::SetResult::OK) {
-        // Log the error, but theres nothing else we can do.
-        LOG(ERROR) << "failed to roll back config; key=" << key;
-      }
-    }
-  }
-}
-
 void ConfigSet(CmdArgList args, ConnectionContext* cntx) {
-  // Require an even number of arguments for conf-value pairs.
-  if (args.size() < 3 || args.size() % 2 != 1) {
-    return (*cntx)->SendError(WrongNumArgsError("config|set"));
+  ConfigRegistry::SetResult result = config_registry.Set(args.subspan(1));
+  switch (result) {
+    case ConfigRegistry::SetResult::OK:
+      return (*cntx)->SendOk();
+    default:
+      // TODO(andydunstall): Error handling... Return the bad argument from
+      // Set
+      return (*cntx)->SendError("...");
   }
-
-  // Lookup the previous config and verify the parameters all exist and
-  // have no duplicates.
-  std::unordered_map<std::string_view, std::string> prev_config;
-  for (size_t indx = 1; indx < args.size(); indx += 2) {
-    ToLower(&args[indx]);
-    const std::string_view config_name = ArgS(args, indx);
-
-    const std::optional<std::string> prev = config_registry.Get(config_name);
-    if (!prev) {
-      // No need to roll back as no config has been updated.
-      return (*cntx)->SendError(absl::StrCat("config not found: ", config_name));
-    }
-    if (prev_config.find(config_name) != prev_config.end()) {
-      // No need to roll back as no config has been updated.
-      return (*cntx)->SendError(absl::StrCat("duplicate parameter: ", config_name));
-    }
-    prev_config.emplace(config_name, *prev);
-  }
-
-  // Set all config flags without applying the registered callbacks. This
-  // ensures callbacks run with the latest flags.
-  for (size_t indx = 1; indx < args.size(); indx += 2) {
-    const std::string_view config_name = ArgS(args, indx);
-    ConfigRegistry::SetResult result =
-        config_registry.Set(config_name, ArgS(args, indx + 1), false);
-    std::string error_message;
-    switch (result) {
-      case ConfigRegistry::SetResult::OK:
-        continue;
-      case ConfigRegistry::SetResult::UNKNOWN:
-        error_message = absl::StrCat("unknown option: ", config_name);
-        break;
-      case ConfigRegistry::SetResult::READONLY:
-        error_message = absl::StrCat("cannot set immutable config: ", config_name);
-        break;
-      case ConfigRegistry::SetResult::INVALID:
-        error_message = absl::StrCat("invalid config argument: ", config_name);
-        break;
-      default:
-        error_message = absl::StrCat("unknown error: ", config_name);
-        break;
-    }
-    ConfigRollBack(prev_config, false);
-    return (*cntx)->SendError(error_message);
-  }
-
-  // Finally apply the config which runs the registered callbacks.
-  for (size_t indx = 1; indx < args.size(); indx += 2) {
-    const std::string_view config_name = ArgS(args, indx);
-    ConfigRegistry::SetResult result = config_registry.Set(config_name, ArgS(args, indx + 1), true);
-    std::string error_message;
-    switch (result) {
-      case ConfigRegistry::SetResult::OK:
-        continue;
-      case ConfigRegistry::SetResult::UNKNOWN:
-        error_message = absl::StrCat("unknown option: ", config_name);
-        break;
-      case ConfigRegistry::SetResult::READONLY:
-        error_message = absl::StrCat("cannot set immutable config: ", config_name);
-        break;
-      case ConfigRegistry::SetResult::INVALID:
-        error_message = absl::StrCat("invalid config argument: ", config_name);
-        break;
-      default:
-        error_message = absl::StrCat("unknown error: ", config_name);
-        break;
-    }
-    ConfigRollBack(prev_config, true);
-    return (*cntx)->SendError(error_message);
-  }
-
-  return (*cntx)->SendOk();
 }
 
 void ServerFamily::Config(CmdArgList args, ConnectionContext* cntx) {

--- a/src/server/server_family_test.cc
+++ b/src/server/server_family_test.cc
@@ -181,4 +181,12 @@ TEST_F(ServerFamilyTest, SlowLogMinusOneDisabled) {
   EXPECT_THAT(resp.GetInt(), 0);
 }
 
+TEST_F(ServerFamilyTest, ConfigSet) {
+  // Invalid arguments.
+  auto resp = Run({"config", "set", "foo"});
+  EXPECT_THAT(resp, ErrArg("wrong number of arguments for 'config|set' command"));
+  resp = Run({"config", "set", "foo", "1", "car"});
+  EXPECT_THAT(resp, ErrArg("wrong number of arguments for 'config|set' command"));
+}
+
 }  // namespace dfly

--- a/tests/dragonfly/management_test.py
+++ b/tests/dragonfly/management_test.py
@@ -1,14 +1,57 @@
 import pytest
-import asyncio
-from redis import asyncio as aioredis
-from redis.exceptions import ResponseError
+import redis
 
 
 @pytest.mark.asyncio
-async def test_config_cmd(async_client: aioredis.Redis):
-    with pytest.raises(ResponseError):
-        await async_client.config_set("foo", "bar")
-    await async_client.config_set("requirepass", "foobar") == "OK"
-    res = await async_client.config_get("*")
-    assert len(res) > 0
-    assert res["requirepass"] == "foobar"
+async def test_config_cmd_single_config(df_factory):
+    with df_factory.create() as server:
+        async with server.client() as client:
+            await client.config_set("requirepass", "foobar") == "OK"
+
+            # Verify the config was set.
+            res = await client.config_get("*")
+            assert len(res) > 0
+            assert res["requirepass"] == "foobar"
+
+        # Verify the config was applied.
+        with pytest.raises(redis.exceptions.ConnectionError):
+            async with server.client() as client:
+                await client.ping()
+
+
+@pytest.mark.asyncio
+async def test_config_cmd_multi_config(df_factory):
+    with df_factory.create() as server:
+        async with server.client() as client:
+            await client.config_set("requirepass", "foobar", "maxclients", "100") == "OK"
+
+            # Verify the config was set.
+            res = await client.config_get("*")
+            assert len(res) > 0
+            assert res["requirepass"] == "foobar"
+            assert res["maxclients"] == "100"
+
+        # Verify the config was applied.
+        with pytest.raises(redis.exceptions.ConnectionError):
+            async with server.client() as client:
+                await client.ping()
+
+
+@pytest.mark.asyncio
+async def test_config_roll_back_invalid_config(df_factory):
+    with df_factory.create() as server:
+        async with server.client() as client:
+            # Set a valid password by invalid maxclients, neither config
+            # should be set.
+            with pytest.raises(redis.exceptions.ResponseError):
+                await client.config_set("requirepass", "foobar", "maxclients", "invalid")
+
+            # Verify the config was NOT set.
+            res = await client.config_get("*")
+            assert len(res) > 0
+            assert res["requirepass"] == ""
+            assert res["maxclients"] == "64000"
+
+        # Verify requirepass was not applied.
+        async with server.client() as client:
+            await client.ping()


### PR DESCRIPTION
As part of https://github.com/dragonflydb/dragonfly/issues/2038, looking at how to apply multiple config values at once, such as `CONFIG SET tls true tls-cert-file cert.pem tls-key-file key.pem` (currently only the first config-value pair is updated)

Simply iterating over `config_registry.Set` won't work as it will update the first flag, run the first callback, update the second flag, run the second callback... Therefore the first callback will still have the old value for the other updated flags, which doesn't work when you need to set multiple flags at once for the config to be valid (eg in the TLS case).

So instead looking at updating the flags first, then running the callbacks. So in the TLS case it would set all configured TLS flags, then run the callbacks to reconfigure the SSL context.

Also looking at Redis `CONFIG SET`, they roll back the updated config if it is invalid rather than doing a partial update. (Roll backs aren't as useful now, but will be useful if we add TLS, say the key is valid but certificate is invalid, you'd want to revert both...)

This doesn't work great in Dragonfly since other code could directly query a flag mid update given flags don't seem to be locked (maybe this is why we currently only support setting one parameter? though if all flags registered with config registry are only updated via registered callback it should be ok?)... Since the config registry also only locks each `Set`, parallel `CONFIG SET`s could cause issues, though assuming locking the config registry for the whole command isn't great either...

So maybe this isn't worth doing and we just accept TLS config must be updated one parameter at a time in a way that's valid... But was playing about with so figured worth adding a draft PR anyway to get your thoughts (or see if there's a better approach here?)... cc @romange 