### PR TITLE
chore: measure rss memory and track its peak

### DIFF
--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -64,6 +64,9 @@ string_view KeyLockArgs::GetLockKey(string_view key) {
 
 atomic_uint64_t used_mem_peak(0);
 atomic_uint64_t used_mem_current(0);
+atomic_uint64_t rss_mem_current(0);
+atomic_uint64_t rss_mem_peak(0);
+
 unsigned kernel_version = 0;
 size_t max_memory_limit = 0;
 

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -175,6 +175,9 @@ const char* RdbTypeName(unsigned type);
 // Cached values, updated frequently to represent the correct state of the system.
 extern std::atomic_uint64_t used_mem_peak;
 extern std::atomic_uint64_t used_mem_current;
+extern std::atomic_uint64_t rss_mem_current;
+extern std::atomic_uint64_t rss_mem_peak;
+
 extern size_t max_memory_limit;
 
 // malloc memory stats.


### PR DESCRIPTION
Up until know we did not have cached rss metric in the process. This PR consolidates caching of all values together inside the EngineShard periodic fiber code. Also, we know expose rss_mem_current that can be used internally for identifying memory pressuring periods during the process run.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->