### PR TITLE
chore(server-family): do not log SETINFO

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1191,7 +1191,10 @@ void ServerFamily::Client(CmdArgList args, ConnectionContext* cntx) {
     return (*cntx)->SendBulkString(result);
   }
 
-  LOG_FIRST_N(ERROR, 10) << "Subcommand " << sub_cmd << " not supported";
+  if (sub_cmd != "SETINFO") {
+    LOG_FIRST_N(ERROR, 10) << "Subcommand " << sub_cmd << " not supported";
+  }
+
   return (*cntx)->SendError(UnknownSubCmd(sub_cmd, "CLIENT"), kSyntaxErrType);
 }
 


### PR DESCRIPTION
I could make `SETINFO` a noop instead of disabling the `log` but I would find it confusing, to get an `OK` reply for a sub-command we don't support.

The reason for this PR is to remove the noise from our CI. Specifically, the log:

```
server_family.cc:1194] Subcommand SETINFO not supported
```