### PR TITLE
feat(server): add memory stats for snapshot save

### DIFF
--- a/src/server/detail/save_stages_controller.cc
+++ b/src/server/detail/save_stages_controller.cc
@@ -193,10 +193,7 @@ size_t SaveStagesController::GetSaveBuffersSize() {
 
   } else {
     // When rdb format save is running, there is only one rdb saver instance, it is running on the
-    // connection thread that runs the save command. How can we make sure that the value returned
-    // from GetSaveBuffersSize is valid? as it does not runs on the same thread, but pulling the
-    // pulled bytes values updated by the rdb saver, should we make this value atomic? is there
-    // another soliution?
+    // connection thread that runs the save command.
     total_bytes.store(snapshots_.front().first->GetSaveBuffersSize(), memory_order_relaxed);
   }
   return total_bytes.load(memory_order_relaxed);

--- a/src/server/detail/save_stages_controller.cc
+++ b/src/server/detail/save_stages_controller.cc
@@ -118,6 +118,10 @@ error_code RdbSnapshot::SaveBody() {
   return saver_->SaveBody(&cntx_, &freq_map_);
 }
 
+size_t RdbSnapshot::GetSaveBuffersSize() {
+  return saver_->GetTotalBuffersSize();
+}
+
 error_code RdbSnapshot::Close() {
   if (is_linux_file_) {
     return static_cast<LinuxWriteWrapper*>(io_sink_.get())->Close();
@@ -156,7 +160,17 @@ GenericError SaveStagesController::Save() {
     SaveRdb();
 
   is_saving_->store(true, memory_order_relaxed);
+  {
+    lock_guard lk{*save_mu_};
+    *save_bytes_cb_ = [this]() { return GetSaveBuffersSize(); };
+  }
+
   RunStage(&SaveStagesController::SaveCb);
+  {
+    lock_guard lk{*save_mu_};
+    *save_bytes_cb_ = nullptr;
+  }
+
   is_saving_->store(false, memory_order_relaxed);
 
   RunStage(&SaveStagesController::CloseCb);
@@ -167,6 +181,25 @@ GenericError SaveStagesController::Save() {
     UpdateSaveInfo();
 
   return *shared_err_;
+}
+
+size_t SaveStagesController::GetSaveBuffersSize() {
+  std::atomic<size_t> total_bytes{0};
+  if (use_dfs_format_) {
+    auto cb = [this, &total_bytes](ShardId sid) {
+      total_bytes.fetch_add(snapshots_[sid].first->GetSaveBuffersSize(), memory_order_relaxed);
+    };
+    shard_set->RunBriefInParallel([&](EngineShard* es) { cb(es->shard_id()); });
+
+  } else {
+    // When rdb format save is running, there is only one rdb saver instance, it is running on the
+    // connection thread that runs the save command. How can we make sure that the value returned
+    // from GetSaveBuffersSize is valid? as it does not runs on the same thread, but pulling the
+    // pulled bytes values updated by the rdb saver, should we make this value atomic? is there
+    // another soliution?
+    total_bytes.store(snapshots_.front().first->GetSaveBuffersSize(), memory_order_relaxed);
+  }
+  return total_bytes.load(memory_order_relaxed);
 }
 
 // In the new version (.dfs) we store a file for every shard and one more summary file.

--- a/src/server/detail/save_stages_controller.h
+++ b/src/server/detail/save_stages_controller.h
@@ -28,6 +28,7 @@ struct SaveStagesInputs {
   util::fb2::FiberQueueThreadPool* fq_threadpool_;
   std::shared_ptr<LastSaveInfo>* last_save_info_;
   util::fb2::Mutex* save_mu_;
+  std::function<size_t()>* save_bytes_cb_;
   std::shared_ptr<SnapshotStorage> snapshot_storage_;
 };
 
@@ -42,6 +43,7 @@ class RdbSnapshot {
 
   error_code SaveBody();
   error_code Close();
+  size_t GetSaveBuffersSize();
 
   const RdbTypeFreqMap freq_map() const {
     return freq_map_;
@@ -102,6 +104,8 @@ struct SaveStagesController : public SaveStagesInputs {
   void RunStage(void (SaveStagesController::*cb)(unsigned));
 
   RdbSaver::GlobalData GetGlobalData() const;
+
+  size_t GetSaveBuffersSize();
 
  private:
   absl::Time start_time_;

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -108,7 +108,6 @@ class RdbSaver {
     return save_mode_;
   }
 
-  // Can only be called for dragonfly replication.
   // Get total size of all rdb serializer buffers and items currently placed in channel
   size_t GetTotalBuffersSize() const;
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -984,9 +984,9 @@ GenericError ServerFamily::DoSave() {
 }
 
 GenericError ServerFamily::DoSave(bool new_version, string_view basename, Transaction* trans) {
-  SaveStagesController sc{detail::SaveStagesInputs{new_version, basename, trans, &service_,
-                                                   &is_saving_, fq_threadpool_.get(),
-                                                   &last_save_info_, &save_mu_, snapshot_storage_}};
+  SaveStagesController sc{detail::SaveStagesInputs{
+      new_version, basename, trans, &service_, &is_saving_, fq_threadpool_.get(), &last_save_info_,
+      &save_mu_, &save_bytes_cb_, snapshot_storage_}};
   return sc.Save();
 }
 
@@ -1466,6 +1466,13 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
       dfly_cmd_->GetReplicationMemoryStats(&repl_mem);
       append("replication_streaming_buffer_bytes", repl_mem.streamer_buf_capacity_bytes_);
       append("replication_full_sync_buffer_bytes", repl_mem.full_sync_buf_bytes_);
+    }
+
+    if (IsSaving()) {
+      lock_guard lk{save_mu_};
+      if (save_bytes_cb_) {
+        append("save_buffer_bytes", save_bytes_cb_());
+      }
     }
   }
 

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -151,7 +151,6 @@ class ServerFamily {
   // future with error_code.
   Future<GenericError> Load(const std::string& file_name);
 
-  // used within tests.
   bool IsSaving() const {
     return is_saving_.load(std::memory_order_relaxed);
   }
@@ -257,6 +256,9 @@ class ServerFamily {
 
   std::shared_ptr<LastSaveInfo> last_save_info_;  // protected by save_mu_;
   std::atomic_bool is_saving_{false};
+  // If a save operation is currently in progress, calling this function will provide information
+  // about the memory consumption during the save operation.
+  std::function<size_t()> save_bytes_cb_ = nullptr;
 
   // Used to override save on shutdown behavior that is usually set
   // be --dbfilename.


### PR DESCRIPTION
Add memory bytes used by running snapshot save.
When running save command it will create a snapshot save operation, To enable info command to fetch the memory used by this running process, I created a callback which return the bytes used by the current running save operation, there is only one save at a single time.
When staring a save, the save stages controller will update the callback to the running save instance, this way info command can invoke the callback and get this instance memory buffers size.
