### PR TITLE
fix(bptree): Reverse iteration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,9 @@
       "request": "launch",
       "program": "${workspaceFolder}/build-dbg/dragonfly",
       "args": [
-        "--alsologtostderr"
+        "--alsologtostderr",
+        "--dbfilename=",
+        "--proactor_threads=1"
       ],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}/build-dbg",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,9 +7,7 @@
       "request": "launch",
       "program": "${workspaceFolder}/build-dbg/dragonfly",
       "args": [
-        "--alsologtostderr",
-        "--dbfilename=",
-        "--proactor_threads=1"
+        "--alsologtostderr"
       ],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}/build-dbg",

--- a/src/core/bptree_set.h
+++ b/src/core/bptree_set.h
@@ -420,7 +420,7 @@ bool BPTree<T, Policy>::IterateReverse(uint32_t rank_start, uint32_t rank_end,
   assert(rank_start <= rank_end && rank_end < count_);
 
   BPTreePath path;
-  ToRank(rank_end, &path);
+  ToRank(count_ - 1 - rank_start, &path);
   for (uint32_t i = rank_start; i <= rank_end; ++i) {
     if (!cb(path.Terminal()))
       return false;

--- a/src/core/bptree_set_test.cc
+++ b/src/core/bptree_set_test.cc
@@ -4,6 +4,7 @@
 #include "core/bptree_set.h"
 
 #include <absl/container/btree_set.h>
+#include <gmock/gmock.h>
 #include <mimalloc.h>
 
 #include <random>
@@ -248,31 +249,6 @@ TEST_F(BPTreeSetTest, Iterate) {
     ASSERT_EQ(to - from + 1, cnt);
     ASSERT_TRUE(res);
   }
-
-  // Reverse iteration
-  cnt = 0;
-  res = bptree_.IterateReverse(5845, 6849, [&](uint64_t val) {
-    if ((6849 - cnt) * 2 != val)
-      return false;
-    ++cnt;
-    return true;
-  });
-  ASSERT_EQ(6849 - 5845 + 1, cnt);
-  ASSERT_TRUE(res);
-
-  for (unsigned j = 0; j < 10; ++j) {
-    cnt = 0;
-    unsigned from = generator_() % kNumElems;
-    unsigned to = from + generator_() % (kNumElems - from);
-    res = bptree_.IterateReverse(from, to, [&](uint64_t val) {
-      if ((to - cnt) * 2 != val)
-        return false;
-      ++cnt;
-      return true;
-    });
-    ASSERT_EQ(to - from + 1, cnt);
-    ASSERT_TRUE(res);
-  }
 }
 
 TEST_F(BPTreeSetTest, Ranges) {
@@ -352,7 +328,7 @@ TEST_F(BPTreeSetTest, InsertSDS) {
   }
 }
 
-TEST_F(BPTreeSetTest, Repro) {
+TEST_F(BPTreeSetTest, ReverseIterate) {
   vector<ZsetPolicy::KeyT> vals;
   for (int i = 0; i < 2; ++i) {
     sds s = sdsempty();
@@ -381,6 +357,13 @@ TEST_F(BPTreeSetTest, Repro) {
       EXPECT_EQ(score, vals[0].d);
     }
   }
+
+  vector<int> res;
+  tree.IterateReverse(0, 1, [&](auto i) {
+    res.push_back(i.d);
+    return true;
+  });
+  EXPECT_THAT(res, testing::ElementsAre(1, 0));
 
   for (auto v : vals) {
     sdsfree(v.s);

--- a/src/core/bptree_set_test.cc
+++ b/src/core/bptree_set_test.cc
@@ -330,7 +330,7 @@ TEST_F(BPTreeSetTest, InsertSDS) {
 
 TEST_F(BPTreeSetTest, ReverseIterate) {
   vector<ZsetPolicy::KeyT> vals;
-  for (int i = 0; i < 2; ++i) {
+  for (int i = -1000; i < 1000; ++i) {
     sds s = sdsempty();
 
     s = sdscatfmt(s, "a%u", i);
@@ -363,7 +363,7 @@ TEST_F(BPTreeSetTest, ReverseIterate) {
     res.push_back(i.d);
     return true;
   });
-  EXPECT_THAT(res, testing::ElementsAre(1, 0));
+  EXPECT_THAT(res, testing::ElementsAre(999, 998));
 
   for (auto v : vals) {
     sdsfree(v.s);


### PR DESCRIPTION
Reported by a user on Discord, we had a bug reverse iterating items in BPTree.

Thanks @romange for the actual fix :)

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->