### PR TITLE
fix(AclFamily): renaming commands and subcommands

### DIFF
--- a/src/facade/command_id.h
+++ b/src/facade/command_id.h
@@ -93,7 +93,7 @@ class CommandId {
   static uint32_t OptCount(uint32_t mask);
 
  protected:
-  std::string_view name_;
+  std::string name_;
 
   uint32_t opt_mask_;
   int8_t arity_;

--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -574,6 +574,7 @@ void AclFamily::Register(dfly::CommandRegistry* registry) {
 
   registry->StartFamily();
   *registry << CI{"ACL", CO::NOSCRIPT | CO::LOADING, 0, 0, 0, 0, acl::kAcl}.HFUNC(Acl);
+  registry->SubCommandsSameIndex();
   *registry << CI{"ACL LIST", CO::ADMIN | CO::NOSCRIPT | CO::LOADING, 1, 0, 0, 0, acl::kList}.HFUNC(
       List);
   *registry << CI{"ACL SETUSER", CO::ADMIN | CO::NOSCRIPT | CO::LOADING, -2, 0, 0, 0, acl::kSetUser}
@@ -598,7 +599,6 @@ void AclFamily::Register(dfly::CommandRegistry* registry) {
                    .HFUNC(DryRun);
   *registry << CI{"ACL GENPASS", CO::NOSCRIPT | CO::LOADING, -1, 0, 0, 0, acl::kGenPass}.HFUNC(
       GenPass);
-
   cmd_registry_ = registry;
 }
 

--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -574,7 +574,6 @@ void AclFamily::Register(dfly::CommandRegistry* registry) {
 
   registry->StartFamily();
   *registry << CI{"ACL", CO::NOSCRIPT | CO::LOADING, 0, 0, 0, 0, acl::kAcl}.HFUNC(Acl);
-  registry->SubCommandsSameIndex();
   *registry << CI{"ACL LIST", CO::ADMIN | CO::NOSCRIPT | CO::LOADING, 1, 0, 0, 0, acl::kList}.HFUNC(
       List);
   *registry << CI{"ACL SETUSER", CO::ADMIN | CO::NOSCRIPT | CO::LOADING, -2, 0, 0, 0, acl::kSetUser}

--- a/src/server/acl/acl_family_test.cc
+++ b/src/server/acl/acl_family_test.cc
@@ -27,7 +27,6 @@ class AclFamilyTest : public BaseFamilyTest {
 class AclFamilyTestRename : public BaseFamilyTest {
   void SetUp() override {
     absl::SetFlag(&FLAGS_rename_command, {"ACL=ROCKS"});
-    std::cout << "FLAGS SET" << absl::GetFlag(FLAGS_rename_command).at(0) << std::endl;
     ResetService();
   }
 };

--- a/src/server/acl/acl_family_test.cc
+++ b/src/server/acl/acl_family_test.cc
@@ -4,6 +4,8 @@
 
 #include "server/acl/acl_family.h"
 
+#include "absl/container/flat_hash_map.h"
+#include "absl/flags/internal/flag.h"
 #include "absl/strings/str_cat.h"
 #include "base/gtest.h"
 #include "base/logging.h"
@@ -14,10 +16,20 @@
 
 using namespace testing;
 
+ABSL_DECLARE_FLAG(std::vector<std::string>, rename_command);
+
 namespace dfly {
 
 class AclFamilyTest : public BaseFamilyTest {
  protected:
+};
+
+class AclFamilyTestRename : public BaseFamilyTest {
+  void SetUp() override {
+    absl::SetFlag(&FLAGS_rename_command, {"ACL=ROCKS"});
+    std::cout << "FLAGS SET" << absl::GetFlag(FLAGS_rename_command).at(0) << std::endl;
+    ResetService();
+  }
 };
 
 TEST_F(AclFamilyTest, AclSetUser) {
@@ -37,6 +49,14 @@ TEST_F(AclFamilyTest, AclSetUser) {
   auto vec = resp.GetVec();
   EXPECT_THAT(vec, UnorderedElementsAre("user default on nopass +@ALL +ALL",
                                         "user vlad off nopass +@NONE"));
+
+  resp = Run({"ACL", "SETUSER", "vlad", "+ACL"});
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run({"ACL", "LIST"});
+  vec = resp.GetVec();
+  EXPECT_THAT(vec, UnorderedElementsAre("user default on nopass +@ALL +ALL",
+                                        "user vlad off nopass +@NONE +ACL"));
 }
 
 TEST_F(AclFamilyTest, AclDelUser) {
@@ -319,6 +339,17 @@ TEST_F(AclFamilyTest, AclGenPass) {
   // and the pattern continues
   resp = Run({"ACL", "GENPASS", "9"});
   EXPECT_THAT(resp.GetString().length(), 3);
+}
+
+TEST_F(AclFamilyTestRename, AclRename) {
+  auto resp = Run({"ACL", "SETUSER", "billy"});
+  EXPECT_THAT(resp, ErrArg("ERR unknown command `ACL`"));
+
+  resp = Run({"ROCKS", "SETUSER", "billy", "ON", ">mypass"});
+  EXPECT_THAT(resp.GetString(), "OK");
+
+  resp = Run({"ROCKS", "DELUSER", "billy"});
+  EXPECT_THAT(resp.GetString(), "OK");
 }
 
 }  // namespace dfly

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -119,8 +119,7 @@ CommandRegistry& CommandRegistry::operator<<(CommandId cmd) {
 
   absl::InlinedVector<std::string_view, 2> maybe_subcommand = StrSplit(cmd.name(), " ");
   const bool is_sub_command = maybe_subcommand.size() == 2;
-  std::string_view c_name = maybe_subcommand.front();
-  auto it = cmd_rename_map_.find(c_name);
+  auto it = cmd_rename_map_.find(maybe_subcommand.front());
   if (it != cmd_rename_map_.end()) {
     if (it->second.empty()) {
       return *this;  // Incase of empty string we want to remove the command from registry.

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -8,6 +8,7 @@
 #include <absl/time/clock.h>
 
 #include "absl/container/inlined_vector.h"
+#include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 #include "base/bits.h"
 #include "base/flags.h"
@@ -114,20 +115,17 @@ void CommandRegistry::Init(unsigned int thread_count) {
 }
 
 CommandRegistry& CommandRegistry::operator<<(CommandId cmd) {
-  auto k = std::string(cmd.name());
+  auto k = cmd.name();
 
-  absl::InlinedVector<std::string, 2> maybe_subcommand = StrSplit(cmd.name(), " ");
+  absl::InlinedVector<std::string_view, 2> maybe_subcommand = StrSplit(cmd.name(), " ");
+  const bool is_sub_command = maybe_subcommand.size() == 2;
   std::string_view c_name = maybe_subcommand.front();
   auto it = cmd_rename_map_.find(c_name);
   if (it != cmd_rename_map_.end()) {
     if (it->second.empty()) {
       return *this;  // Incase of empty string we want to remove the command from registry.
     }
-    if (maybe_subcommand.size() == 2) {
-      k = absl::StrCat(it->second, " ", maybe_subcommand[1]);
-    } else {
-      k = it->second;
-    }
+    k = is_sub_command ? absl::StrCat(it->second, " ", maybe_subcommand[1]) : it->second;
   }
 
   if (restricted_cmds_.find(k) != restricted_cmds_.end()) {
@@ -135,10 +133,13 @@ CommandRegistry& CommandRegistry::operator<<(CommandId cmd) {
   }
 
   cmd.SetFamily(family_of_commands_.size() - 1);
-  cmd.SetBitIndex(1ULL << bit_index_);
-  if (!same_index_) {
+  if (!is_sub_command) {
+    cmd.SetBitIndex(1ULL << bit_index_);
     family_of_commands_.back().push_back(std::string(k));
     ++bit_index_;
+  } else {
+    DCHECK(absl::StartsWith(k, family_of_commands_.back().back()));
+    cmd.SetBitIndex(1ULL << (bit_index_ - 1));
   }
   CHECK(cmd_map_.emplace(k, std::move(cmd)).second) << k;
 
@@ -146,15 +147,8 @@ CommandRegistry& CommandRegistry::operator<<(CommandId cmd) {
 }
 
 void CommandRegistry::StartFamily() {
-  same_index_ = false;
   family_of_commands_.push_back({});
   bit_index_ = 0;
-}
-
-void CommandRegistry::SubCommandsSameIndex() {
-  same_index_ = true;
-  // Because it was already incremented when the main command got inserted
-  --bit_index_;
 }
 
 std::string_view CommandRegistry::RenamedOrOriginal(std::string_view orig) const {

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -163,17 +163,23 @@ class CommandRegistry {
     }
   }
 
-  using FamiliesVec = std::vector<std::vector<std::string>>;
   void StartFamily();
+
+  void SubCommandsSameIndex();
+
+  std::string_view RenamedOrOriginal(std::string_view orig) const;
+
+  using FamiliesVec = std::vector<std::vector<std::string>>;
   FamiliesVec GetFamilies();
 
  private:
-  absl::flat_hash_map<std::string_view, CommandId> cmd_map_;
+  absl::flat_hash_map<std::string, CommandId> cmd_map_;
   absl::flat_hash_map<std::string, std::string> cmd_rename_map_;
   absl::flat_hash_set<std::string> restricted_cmds_;
 
   FamiliesVec family_of_commands_;
   size_t bit_index_;
+  bool same_index_;
 };
 
 }  // namespace dfly

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -165,8 +165,6 @@ class CommandRegistry {
 
   void StartFamily();
 
-  void SubCommandsSameIndex();
-
   std::string_view RenamedOrOriginal(std::string_view orig) const;
 
   using FamiliesVec = std::vector<std::vector<std::string>>;
@@ -179,7 +177,6 @@ class CommandRegistry {
 
   FamiliesVec family_of_commands_;
   size_t bit_index_;
-  bool same_index_;
 };
 
 }  // namespace dfly

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1578,9 +1578,8 @@ optional<bool> StartMultiEval(DbIndex dbid, CmdArgList keys, ScriptMgr::ScriptPa
 
 static std::string FullAclCommandFromArgs(CmdArgList args, std::string_view name) {
   ToUpper(&args[1]);
-  // Guranteed SSO no dynamic allocations here
-
-  return absl::StrCat(name, " ", std::string(args[1].begin(), args[1].end()));
+  auto res = absl::StrCat(name, " ", ArgS(args, 1));
+  return res;
 }
 
 std::pair<const CommandId*, CmdArgList> Service::FindCmd(CmdArgList args) const {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1549,19 +1549,22 @@ optional<bool> StartMultiEval(DbIndex dbid, CmdArgList keys, ScriptMgr::ScriptPa
   return false;
 }
 
-static std::string FullAclCommandFromArgs(CmdArgList args) {
+static std::string FullAclCommandFromArgs(CmdArgList args, std::string_view name) {
   ToUpper(&args[1]);
   // Guranteed SSO no dynamic allocations here
-  return std::string("ACL ") + std::string(args[1].begin(), args[1].end());
+
+  return absl::StrCat(name, " ", std::string(args[1].begin(), args[1].end()));
 }
 
 std::pair<const CommandId*, CmdArgList> Service::FindCmd(CmdArgList args) const {
   const std::string_view command = facade::ToSV(args[0]);
-  if (command == "ACL") {
+  std::string_view acl = "ACL";
+  acl = registry_.RenamedOrOriginal(acl);
+  if (command == acl) {
     if (args.size() == 1) {
       return {registry_.Find(ArgS(args, 0)), args};
     }
-    return {registry_.Find(FullAclCommandFromArgs(args)), args.subspan(2)};
+    return {registry_.Find(FullAclCommandFromArgs(args, acl)), args.subspan(2)};
   }
 
   const CommandId* res = registry_.Find(ArgS(args, 0));

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1585,12 +1585,11 @@ static std::string FullAclCommandFromArgs(CmdArgList args, std::string_view name
 std::pair<const CommandId*, CmdArgList> Service::FindCmd(CmdArgList args) const {
   const std::string_view command = facade::ToSV(args[0]);
   std::string_view acl = "ACL";
-  acl = registry_.RenamedOrOriginal(acl);
-  if (command == acl) {
+  if (command == registry_.RenamedOrOriginal(acl)) {
     if (args.size() == 1) {
       return {registry_.Find(ArgS(args, 0)), args};
     }
-    return {registry_.Find(FullAclCommandFromArgs(args, acl)), args.subspan(2)};
+    return {registry_.Find(FullAclCommandFromArgs(args, command)), args.subspan(2)};
   }
 
   const CommandId* res = registry_.Find(ArgS(args, 0));


### PR DESCRIPTION
* Fix renaming ACL commands
* Fix ACL subcommands to be treated as such. For example: ACL list would print all ACL subcommands. Now it only prints ACL
* Add tests

Addresses #2036