### PR TITLE
fix(docs): add missing libstdc++-static dependency info

### DIFF
--- a/docs/build-from-source.md
+++ b/docs/build-from-source.md
@@ -23,7 +23,7 @@ On Fedora:
 
 ```bash
 sudo dnf install -y automake boost-devel g++ git cmake libtool ninja-build libzstd-devel  \
-     openssl-devel libunwind-devel autoconf-archive patch bison libxml2-devel
+     openssl-devel libunwind-devel autoconf-archive patch bison libxml2-devel libstdc++-static
 ```
 
 On openSUSE:


### PR DESCRIPTION
Based on this: https://github.com/dragonflydb/dragonfly/discussions/289#discussioncomment-7392440