### PR TITLE
fix(requirements): conflicting dependencies redis and redis-om

### DIFF
--- a/tests/dragonfly/requirements.txt
+++ b/tests/dragonfly/requirements.txt
@@ -7,7 +7,7 @@ pluggy==1.0.0
 py==1.11.0
 pyparsing==3.0.9
 pytest==7.1.2
-redis==5.0.0
+redis==4.6.0
 tomli==2.0.1
 wrapt==1.14.1
 pytest-asyncio==0.20.1


### PR DESCRIPTION
When `pip3 install -r dragonfly/requirements.txt`: 
```
ERROR: Cannot install redis-om==0.2.1 and redis==5.0.0 because these package versions have conflicting dependencies.
```

I downgraded `redis` to `4.6.0` because otherwise we can't really fix the error. 

I am still unsure how this passes on the CI because I created temporary branch that should fail if `pip install` fails but it fails locally :/