### PR TITLE
fix(server): Correctly set expiration from Lua scripts

### DIFF
--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -661,6 +661,8 @@ void Transaction::ScheduleInternal() {
 OpStatus Transaction::ScheduleSingleHop(RunnableType cb) {
   DCHECK(!cb_ptr_);
 
+  time_now_ms_ = GetCurrentTimeMs();
+
   if (multi_ && multi_->role == SQUASHED_STUB) {
     return RunSquashedMultiCb(cb);
   }
@@ -682,8 +684,6 @@ OpStatus Transaction::ScheduleSingleHop(RunnableType cb) {
     // IsArmedInShard() first checks run_count_ before shard_data, so use release ordering.
     shard_data_[SidToId(unique_shard_id_)].is_armed.store(true, memory_order_relaxed);
     run_count_.store(1, memory_order_release);
-
-    time_now_ms_ = GetCurrentTimeMs();
 
     // NOTE: schedule_cb cannot update data on stack when run_fast is false.
     // This is because ScheduleSingleHop can finish before the callback returns.

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -661,8 +661,6 @@ void Transaction::ScheduleInternal() {
 OpStatus Transaction::ScheduleSingleHop(RunnableType cb) {
   DCHECK(!cb_ptr_);
 
-  time_now_ms_ = GetCurrentTimeMs();
-
   if (multi_ && multi_->role == SQUASHED_STUB) {
     return RunSquashedMultiCb(cb);
   }
@@ -684,6 +682,8 @@ OpStatus Transaction::ScheduleSingleHop(RunnableType cb) {
     // IsArmedInShard() first checks run_count_ before shard_data, so use release ordering.
     shard_data_[SidToId(unique_shard_id_)].is_armed.store(true, memory_order_relaxed);
     run_count_.store(1, memory_order_release);
+
+    time_now_ms_ = GetCurrentTimeMs();
 
     // NOTE: schedule_cb cannot update data on stack when run_fast is false.
     // This is because ScheduleSingleHop can finish before the callback returns.


### PR DESCRIPTION
We used to set `time_now_ms_` only in the non-squashed execution path.

Fixes #2034

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->