### PR TITLE
fix(ReplyGuard): set member variable on construction and remove unused

### DIFF
--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -169,7 +169,6 @@ MCReplyBuilder::MCReplyBuilder(::io::Sink* sink) : SinkReplyBuilder(sink), norep
 }
 
 void MCReplyBuilder::SendSimpleString(std::string_view str) {
-  has_replied_ = true;
   if (noreply_)
     return;
 
@@ -213,6 +212,10 @@ void MCReplyBuilder::SendError(string_view str, std::string_view type) {
 
 void MCReplyBuilder::SendProtocolError(std::string_view str) {
   SendSimpleString(absl::StrCat("CLIENT_ERROR ", str));
+}
+
+bool MCReplyBuilder::NoReply() const {
+  return noreply_;
 }
 
 void MCReplyBuilder::SendClientError(string_view str) {

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -169,6 +169,7 @@ MCReplyBuilder::MCReplyBuilder(::io::Sink* sink) : SinkReplyBuilder(sink), norep
 }
 
 void MCReplyBuilder::SendSimpleString(std::string_view str) {
+  has_replied_ = true;
   if (noreply_)
     return;
 

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -165,6 +165,8 @@ class MCReplyBuilder : public SinkReplyBuilder {
   void SetNoreply(bool noreply) {
     noreply_ = noreply;
   }
+
+  bool NoReply() const;
 };
 
 class RedisReplyBuilder : public SinkReplyBuilder {

--- a/src/facade/reply_capture.cc
+++ b/src/facade/reply_capture.cc
@@ -120,6 +120,7 @@ CapturingReplyBuilder::Payload CapturingReplyBuilder::Take() {
 }
 
 void CapturingReplyBuilder::SendDirect(Payload&& val) {
+  has_replied_ = !holds_alternative<monostate>(val);
   bool is_err = holds_alternative<Error>(val) || holds_alternative<OpStatus>(val);
   ReplyMode min_mode = is_err ? ReplyMode::ONLY_ERR : ReplyMode::FULL;
   if (reply_mode_ >= min_mode) {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1053,7 +1053,9 @@ class ReplyGuard {
     const bool is_script = bool(cntx->conn_state.script_info);
     const bool is_one_of =
         absl::flat_hash_set<std::string_view>({"REPLCONF", "DFLY"}).contains(cid_name);
-    const bool should_dcheck = !is_one_of && !is_script;
+    auto* maybe_mcache = dynamic_cast<MCReplyBuilder*>(cntx->reply_builder());
+    const bool is_no_reply_memcache = maybe_mcache && maybe_mcache->NoReply();
+    const bool should_dcheck = !is_one_of && !is_script && !is_no_reply_memcache;
     if (should_dcheck) {
       builder_ = cntx->reply_builder();
       builder_->ExpectReply();

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1050,25 +1050,24 @@ void Service::DispatchCommand(CmdArgList args, facade::ConnectionContext* cntx) 
 class ReplyGuard {
  public:
   ReplyGuard(ConnectionContext* cntx, std::string_view cid_name) {
-    auto* builder = cntx->reply_builder();
     const bool is_script = bool(cntx->conn_state.script_info);
     const bool is_one_of =
-        absl::flat_hash_set<std::string_view>({"REPLCONF", "DFLY", "EXEC", "EVALSHA"})
-            .contains(cid_name);
+        absl::flat_hash_set<std::string_view>({"REPLCONF", "DFLY"}).contains(cid_name);
     const bool should_dcheck = !is_one_of && !is_script;
     if (should_dcheck) {
-      builder->ExpectReply();
+      builder_ = cntx->reply_builder();
+      builder_->ExpectReply();
     }
   }
 
   ~ReplyGuard() {
-    if (builder) {
-      DCHECK(builder->HasReplied());
+    if (builder_) {
+      DCHECK(builder_->HasReplied());
     }
   }
 
  private:
-  RedisReplyBuilder* builder = nullptr;
+  SinkReplyBuilder* builder_ = nullptr;
 };
 
 bool Service::InvokeCmd(const CommandId* cid, CmdArgList tail_args, ConnectionContext* cntx,

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -9,6 +9,7 @@ import psutil
 import itertools
 from prometheus_client.parser import text_string_to_metric_families
 from redis.asyncio import Redis as RedisClient
+import signal
 
 
 START_DELAY = 0.8


### PR DESCRIPTION
* set member variable to point to the reply builder
* remove redundant checks
* import missing signal in instance.py