### PR TITLE
chore: use decode_responses when creating a redis client

### DIFF
--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -37,7 +37,11 @@ runs:
         export DRAGONFLY_PATH="${GITHUB_WORKSPACE}/${{inputs.build-folder-name}}/${{inputs.dfly-executable}}"
         export UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 # to crash on errors
 
-        timeout 20m pytest -m "${{inputs.filter}}" --json-report --json-report-file=report.json dragonfly --ignore=dragonfly/replication_test.py --log-cli-level=INFO || code=$?; if [[ $code -ne 0 ]]; then echo "TIMEDOUT=1">> "$GITHUB_OUTPUT"; exit 1; fi
+        timeout 20m pytest -m "${{inputs.filter}}" --color=yes --json-report --json-report-file=report.json dragonfly --ignore=dragonfly/replication_test.py --log-cli-level=INFO || code=$?
+        if [[ $code -ne 0 ]]; then
+          echo "TIMEDOUT=1">> "$GITHUB_OUTPUT";
+          exit 1
+        fi
 
     - name: Run PyTests replication test
       id: second
@@ -50,7 +54,13 @@ runs:
         export DRAGONFLY_PATH="${GITHUB_WORKSPACE}/${{inputs.build-folder-name}}/${{inputs.dfly-executable}}"
 
         run_pytest_with_args() {
-          timeout 20m pytest -m "${{inputs.filter}}" --json-report --json-report-file=rep1_report.json dragonfly/replication_test.py --log-cli-level=INFO --df alsologtostderr $1 $2 || code=$?; if [[ $code -ne 0 ]]; then echo "TIMEDOUT=1">> "$GITHUB_OUTPUT"; exit 1; fi
+          timeout 20m pytest -m "${{inputs.filter}}" --color=yes --json-report \
+            --json-report-file=rep1_report.json dragonfly/replication_test.py --log-cli-level=INFO \
+            --df alsologtostderr $1 $2 || code=$?
+          if [[ $code -ne 0 ]]; then
+            echo "TIMEDOUT=1">> "$GITHUB_OUTPUT"
+            exit 1
+          fi
         }
 
         (run_pytest_with_args --df enable_multi_shard_sync=true)

--- a/tests/dragonfly/config_test.py
+++ b/tests/dragonfly/config_test.py
@@ -9,7 +9,7 @@ async def test_maxclients(df_factory):
     # Needs some authentication
     with df_factory.create(port=1111, maxclients=1, admin_port=1112) as server:
         async with server.client() as client1:
-            assert [b"maxclients", b"1"] == await client1.execute_command("CONFIG GET maxclients")
+            assert ["maxclients", "1"] == await client1.execute_command("CONFIG GET maxclients")
 
             with pytest.raises(redis.exceptions.ConnectionError):
                 async with server.client() as client2:
@@ -20,6 +20,6 @@ async def test_maxclients(df_factory):
                 await admin_client.get("test")
 
             await client1.execute_command("CONFIG SET maxclients 3")
-            assert [b"maxclients", b"3"] == await client1.execute_command("CONFIG GET maxclients")
+            assert ["maxclients", "3"] == await client1.execute_command("CONFIG GET maxclients")
             async with server.client() as client2:
                 await client2.get("test")

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -91,7 +91,7 @@ class DflyInstance:
         assert self.proc == None
 
     def client(self, *args, **kwargs) -> RedisClient:
-        return RedisClient(port=self.port, *args, **kwargs)
+        return RedisClient(port=self.port, decode_responses=True, *args, **kwargs)
 
     def admin_client(self, *args, **kwargs) -> RedisClient:
         return RedisClient(port=self.admin_port, *args, **kwargs)

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -94,7 +94,13 @@ class DflyInstance:
         return RedisClient(port=self.port, decode_responses=True, *args, **kwargs)
 
     def admin_client(self, *args, **kwargs) -> RedisClient:
-        return RedisClient(port=self.admin_port, *args, **kwargs)
+        return RedisClient(
+            port=self.admin_port,
+            single_connection_client=True,
+            decode_responses=True,
+            *args,
+            **kwargs,
+        )
 
     def __enter__(self):
         self.start()

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -923,6 +923,8 @@ async def test_role_command(df_local_factory, n_keys=20):
     await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
     await wait_available_async(c_replica)
 
+    # It may take a bit more time to actually propagate the role change
+    # See https://github.com/dragonflydb/dragonfly/pull/2111
     await asyncio.sleep(1)
 
     assert await c_master.execute_command("role") == [

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -148,7 +148,7 @@ class TestDflyAutoLoadSnapshot(SnapshotTestBase):
             async with df_server.client() as client:
                 await wait_available_async(client)
                 response = await client.get("TEST")
-                assert response.decode("utf-8") == str(hash(dbfilename))
+                assert response == str(hash(dbfilename))
 
 
 @dfly_args({**BASIC_ARGS, "dbfilename": "test-periodic", "save_schedule": "*:*"})


### PR DESCRIPTION
Also force colors when running pytest in github actions.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->