### PR TITLE
fix(regTests): can't execute command while loading on snapshots

### DIFF
--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -139,13 +139,13 @@ class TestDflyAutoLoadSnapshot(SnapshotTestBase):
         if save_type == "rdb":
             df_args["nodf_snapshot_format"] = None
         with df_local_factory.create(**df_args) as df_server:
-            wait_available_async(df_server)
+            await wait_available_async(df_server)
             async with df_server.client() as client:
                 await client.set("TEST", hash(dbfilename))
                 await client.execute_command("SAVE " + save_type)
 
         with df_local_factory.create(**df_args) as df_server:
-            wait_available_async(df_server)
+            await wait_available_async(df_server)
             async with df_server.client() as client:
                 response = await client.get("TEST")
                 assert response.decode("utf-8") == str(hash(dbfilename))

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -139,14 +139,14 @@ class TestDflyAutoLoadSnapshot(SnapshotTestBase):
         if save_type == "rdb":
             df_args["nodf_snapshot_format"] = None
         with df_local_factory.create(**df_args) as df_server:
-            await wait_available_async(df_server)
             async with df_server.client() as client:
+                await wait_available_async(client)
                 await client.set("TEST", hash(dbfilename))
                 await client.execute_command("SAVE " + save_type)
 
         with df_local_factory.create(**df_args) as df_server:
-            await wait_available_async(df_server)
             async with df_server.client() as client:
+                await wait_available_async(client)
                 response = await client.get("TEST")
                 assert response.decode("utf-8") == str(hash(dbfilename))
 

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -139,11 +139,13 @@ class TestDflyAutoLoadSnapshot(SnapshotTestBase):
         if save_type == "rdb":
             df_args["nodf_snapshot_format"] = None
         with df_local_factory.create(**df_args) as df_server:
+            wait_available_async(df_server)
             async with df_server.client() as client:
                 await client.set("TEST", hash(dbfilename))
                 await client.execute_command("SAVE " + save_type)
 
         with df_local_factory.create(**df_args) as df_server:
+            wait_available_async(df_server)
             async with df_server.client() as client:
                 response = await client.get("TEST")
                 assert response.decode("utf-8") == str(hash(dbfilename))


### PR DESCRIPTION
`TestDflyAutoLoadSnapshot` was failing because client would send a `SET` command before `DF` got into the loading phase