### PR TITLE
fix(server): Do not crash `HRANDFIELD` if some/all elements expired

### DIFF
--- a/src/core/string_map.h
+++ b/src/core/string_map.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string_view>
 
 #include "core/dense_set.h"
@@ -74,9 +75,15 @@ class StringMap : public DenseSet {
       return *this;
     }
 
+    // Advances at most `n` steps, but stops at end.
     iterator& operator+=(unsigned int n) {
-      for (unsigned int i = 0; i < n; ++i)
+      for (unsigned int i = 0; i < n; ++i) {
+        if (curr_entry_ == nullptr) {
+          break;
+        }
+
         Advance();
+      }
       return *this;
     }
 
@@ -126,7 +133,7 @@ class StringMap : public DenseSet {
 
   // Returns a random key value pair.
   // Returns key only if value is a nullptr.
-  std::pair<sds, sds> RandomPair();
+  std::optional<std::pair<sds, sds>> RandomPair();
 
   // Randomly selects count of key value pairs. The selections are unique.
   // if count is larger than the total number of key value pairs, returns
@@ -143,6 +150,8 @@ class StringMap : public DenseSet {
   // Reallocate key and/or value if their pages are underutilized.
   // Returns new pointer (stays same if key utilization is enough) and if reallocation happened.
   std::pair<sds, bool> ReallocIfNeeded(void* obj, float ratio);
+
+  void CollectExpired();
 
   uint64_t Hash(const void* obj, uint32_t cookie) const final;
   bool ObjEqual(const void* left, const void* right, uint32_t right_cookie) const final;

--- a/src/core/string_map.h
+++ b/src/core/string_map.h
@@ -138,11 +138,13 @@ class StringMap : public DenseSet {
   // Randomly selects count of key value pairs. The selections are unique.
   // if count is larger than the total number of key value pairs, returns
   // every pair.
+  // Executes at O(n) (i.e. slow for large sets).
   void RandomPairsUnique(unsigned int count, std::vector<sds>& keys, std::vector<sds>& vals,
                          bool with_value);
 
   // Randomly selects count of key value pairs. The select key value pairs
   // are allowed to have duplications.
+  // Executes at O(n) (i.e. slow for large sets).
   void RandomPairs(unsigned int count, std::vector<sds>& keys, std::vector<sds>& vals,
                    bool with_value);
 

--- a/src/core/string_map_test.cc
+++ b/src/core/string_map_test.cc
@@ -118,6 +118,15 @@ TEST_F(StringMapTest, Ttl) {
   EXPECT_TRUE(it == sm_->end());
 }
 
+TEST_F(StringMapTest, IterateExpired) {
+  EXPECT_TRUE(sm_->AddOrUpdate("k1", "v1", 1));
+  EXPECT_TRUE(sm_->AddOrUpdate("k2", "v2", 1));
+  sm_->set_time(1);
+  auto it = sm_->begin();
+  it += 1;
+  EXPECT_EQ(it, sm_->end());
+}
+
 unsigned total_wasted_memory = 0;
 
 TEST_F(StringMapTest, ReallocIfNeeded) {


### PR DESCRIPTION
The issue is twofold:
1. If all elements are expired, dividing by `Size()` will crash. However, we cannot know this in advance, as `begin()` will actually invalidate all elements, but we're already inside `RandomPair()` which must return a result (it should not be called if *real* size is 0, after expiration)
2. We cannot use `operator +=` before we know how many *real* elements are in the array. Today we do `+= rand() / Size()`, and this in fact is problematic even if `Size()` is non-zero, but is greater than post-expiration size

Unfortunately, this solution will iterate over all elements in map for the multi-random retrieval function, to know how many non-expired elements (if any) are in the list. I don't think it's too bad, as we iterate there anyway (although not necessarily through all)

Fixes #2108 and other bugs.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->