### PR TITLE
docs(contributing): Fix typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ Please squash all commits for a change into a single commit (this can be done us
 
 ## Use Conventional Commits
 
-This repo uses [Conventional Commmits](https://www.conventionalcommits.org/en/v1.0.0/)
+This repo uses [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
 
 The Conventional Commits specification is a lightweight convention on top of commit messages.
 It provides an easy set of rules for creating an explicit commit history;


### PR DESCRIPTION
**Description:**

This PR addresses a minor typo in the "CONTRIBUTING.md" file. The typo was found in the "Conventional Commmits" section, where "commmits" was mistakenly spelled with an extra "m."

**Changes Made:**

- Corrected the typo by removing the extra "m," making it "commits."

**Why is this change necessary?**

The typo in the contributing documentation could potentially confuse new contributors or lead to misunderstandings. By fixing this typo, we ensure that the documentation is clear and accurate for everyone who wants to contribute to the project.

**How Has This Been Tested?**

This change has been locally tested to verify the accuracy and readability of the modified text.

**Related Issues:**

No related Issues
