### PR TITLE
fix(acl): case insensitive parsing from files and serialization format

### DIFF
--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -168,10 +168,10 @@ std::string AclFamily::RegistryToString() const {
   auto& registry = registry_with_read_lock.registry;
   std::string result;
   for (auto& [username, user] : registry) {
-    std::string command = "ACL SETUSER ";
+    std::string command = "USER ";
     const std::string_view pass = user.Password();
     const std::string password =
-        pass == "nopass" ? "nopass " : absl::StrCat(">", PrettyPrintSha(pass, true), " ");
+        pass == "nopass" ? "nopass " : absl::StrCat("#", PrettyPrintSha(pass, true), " ");
     const std::string acl_cat = AclCatToString(user.AclCategory());
     const std::string acl_commands = AclCommandToString(user.AclCommandsRef());
     const std::string maybe_space = acl_commands.empty() ? "" : " ";

--- a/src/server/acl/helpers.h
+++ b/src/server/acl/helpers.h
@@ -23,7 +23,7 @@ std::string AclCommandToString(const std::vector<uint64_t>& acl_category);
 
 std::string PrettyPrintSha(std::string_view pass, bool all = false);
 
-std::optional<std::string> MaybeParsePassword(std::string_view command);
+std::optional<std::string> MaybeParsePassword(std::string_view command, bool hashed = false);
 
 std::optional<bool> MaybeParseStatus(std::string_view command);
 

--- a/tests/dragonfly/acl_family_test.py
+++ b/tests/dragonfly/acl_family_test.py
@@ -426,7 +426,7 @@ async def test_require_pass(df_local_factory):
 
 @pytest.mark.asyncio
 async def test_set_acl_file(async_client: aioredis.Redis, tmp_dir):
-    acl_file_content = "ACL SETUSER roy ON >ea71c25a7a602246b4c39824b855678894a96f43bb9b71319c39700a1e045222 +@STRING +HSET"
+    acl_file_content = "USER roy ON #ea71c25a7a602246b4c39824b855678894a96f43bb9b71319c39700a1e045222 +@STRING +@FAST +HSET\nUSER john on nopass +@string"
 
     acl = create_temp_file(acl_file_content, tmp_dir)
 
@@ -435,9 +435,12 @@ async def test_set_acl_file(async_client: aioredis.Redis, tmp_dir):
     await async_client.execute_command("ACL LOAD")
 
     result = await async_client.execute_command("ACL LIST")
-    assert 2 == len(result)
+    assert 3 == len(result)
 
     result = await async_client.execute_command("AUTH roy mypass")
+    assert result == "OK"
+
+    result = await async_client.execute_command("AUTH john nopass")
     assert result == "OK"
 
 


### PR DESCRIPTION
Addresses #2094

* replace `>` with `#` for acl files
* replace `ACL SETUSER` with `USER` for acl files
* add case insensitive parsing for acl files
* update tests