### PR TITLE
fix(test): Don't access null pointer

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1183,9 +1183,12 @@ finish:
   // send the deletion to the replicas.
   // fiber preemption could happen in this phase.
   vector<string_view> args(keys_to_journal.begin(), keys_to_journal.end());
-  ArgSlice delete_args(&args[0], args.size());
-  if (auto journal = owner_->journal(); journal) {
-    journal->RecordEntry(0, journal::Op::EXPIRED, db_ind, 1, make_pair("DEL", delete_args), false);
+  if (!args.empty()) {
+    ArgSlice delete_args(&args[0], args.size());
+    if (auto journal = owner_->journal(); journal) {
+      journal->RecordEntry(0, journal::Op::EXPIRED, db_ind, 1, make_pair("DEL", delete_args),
+                           false);
+    }
   }
 
   auto time_finish = absl::GetCurrentTimeNanos();


### PR DESCRIPTION
This caused a UBSan warning to be printed in test `DflyEngineTest.Bug207`

```
/usr/include/c++/11/bits/stl_vector.h:1046:34: runtime error: reference binding to null pointer of type 'struct value_type'
```

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->