### PR TITLE
chore(eval): Don't crash on unsupported script commands

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1026,7 +1026,7 @@ std::optional<ErrorReply> Service::VerifyCommandState(const CommandId* cid, CmdA
     Transaction::MultiMode mode = dfly_cntx.transaction->GetMultiMode();
     bool shard_access = (cid->opt_mask()) & (CO::GLOBAL_TRANS | CO::NO_KEY_TRANSACTIONAL);
     if (shard_access && (mode != Transaction::GLOBAL && mode != Transaction::NON_ATOMIC))
-      return ErrorReply("This command requires advanced script flags");
+      return ErrorReply("This Redis command is not allowed from script");
   }
 
   if (under_script && cid->IsTransactional()) {

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -697,13 +697,13 @@ TEST_F(MultiTest, ScriptBadCommand) {
   )";
 
   auto resp = Run({"eval", s1, "0"});  // tx won't be scheduled at all
-  EXPECT_THAT(resp, ErrArg("This command requires advanced script flags"));
+  EXPECT_THAT(resp, ErrArg("This Redis command is not allowed from script"));
 
   resp = Run({"eval", s2, "1", "works", "false"});  // will be scheduled as lock ahead
-  EXPECT_THAT(resp, ErrArg("This command requires advanced script flags"));
+  EXPECT_THAT(resp, ErrArg("This Redis command is not allowed from script"));
 
   resp = Run({"eval", s3, "1", "works", "false"});  // also async call will happen
-  EXPECT_THAT(resp, ErrArg("This command requires advanced script flags"));
+  EXPECT_THAT(resp, ErrArg("This Redis command is not allowed from script"));
 
   resp = Run({"eval", s4, "0"});
   EXPECT_EQ(resp, "OK");


### PR DESCRIPTION
Eval'ing `redis.call('FLUSHALL')` was enough to crash, fixes #2134 