### PR TITLE
fix(regTests): increase cancel replication test timeout

### DIFF
--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -430,7 +430,7 @@ async def test_cancel_replication_immediately(
     df_local_factory.start_all([replica, master])
 
     seeder = df_seeder_factory.create(port=master.port)
-    c_replica = replica.client(socket_timeout=20)
+    c_replica = replica.client(socket_timeout=80)
 
     await seeder.run(target_deviation=0.1)
 
@@ -451,7 +451,7 @@ async def test_cancel_replication_immediately(
     replication_commands = [asyncio.create_task(replicate()) for _ in range(COMMANDS_TO_ISSUE)]
 
     num_successes = 0
-    for result in asyncio.as_completed(replication_commands, timeout=30):
+    for result in asyncio.as_completed(replication_commands, timeout=80):
         num_successes += await result
 
     logging.info(f"succeses: {num_successes}")

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -423,7 +423,7 @@ async def test_cancel_replication_immediately(
     After we finish the 'fuzzing' part, replicate the first master and check that
     all the data is correct.
     """
-    COMMANDS_TO_ISSUE = 200
+    COMMANDS_TO_ISSUE = 100
 
     replica = df_local_factory.create()
     master = df_local_factory.create()


### PR DESCRIPTION
These timeouts were introduced by Roman to localize a deadlock issue. However, once Vlad fixed them, we did not revert the changes and it can happen that the machine that runs the CI is executing more tests at the same time causing this to fail/timeout. I reproduced locally, by running the same test case 3-4 times concurrently (the tests passed when I removed or increased the timeout). 

I did not remove the timeout, but rather chose to increase it -- which is not what we had before (we had no local timeouts) but I think it suffices for now to just increase it and it won't cause any problems. 