### PR TITLE
chore(tls): add tls config test for ca_dir

### DIFF
--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -291,6 +291,10 @@ def with_ca_dir_tls_server_args(with_tls_server_args, with_tls_ca_cert_args):
     args = deepcopy(with_tls_server_args)
     ca_cert = with_tls_ca_cert_args["ca_cert"]
     ca_dir = os.path.dirname(ca_cert)
+    # We need this because any program that uses OpenSSL requires directories to be set up like this
+    # in order to find the certificates. This command, creates the necessary symlinks to the files
+    # such that they can be consumed by OpenSSL when loaded from the directory.
+    # For more info see: https://www.openssl.org/docs/man3.0/man1/c_rehash.html
     command = f"c_rehash {ca_dir}"
     subprocess.run(command, shell=True)
     args["tls_ca_cert_dir"] = ca_dir

--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -287,6 +287,17 @@ def with_ca_tls_server_args(with_tls_server_args, with_tls_ca_cert_args):
 
 
 @pytest.fixture(scope="session")
+def with_ca_dir_tls_server_args(with_tls_server_args, with_tls_ca_cert_args):
+    args = deepcopy(with_tls_server_args)
+    ca_cert = with_tls_ca_cert_args["ca_cert"]
+    ca_dir = os.path.dirname(ca_cert)
+    command = f"c_rehash {ca_dir}"
+    subprocess.run(command, shell=True)
+    args["tls_ca_cert_dir"] = ca_dir
+    return args, ca_cert
+
+
+@pytest.fixture(scope="session")
 def with_tls_client_args(tmp_dir, with_tls_ca_cert_args):
     tls_client_key = os.path.join(tmp_dir, "client-key.pem")
     tls_client_req = os.path.join(tmp_dir, "client-req.pem")

--- a/tests/dragonfly/tls_conf_test.py
+++ b/tests/dragonfly/tls_conf_test.py
@@ -54,6 +54,19 @@ async def test_client_tls_cert(df_factory, with_tls_server_args):
         pass
 
 
+async def test_config_enable_tls_with_ca_dir(
+    df_factory, with_ca_dir_tls_server_args, with_tls_client_args
+):
+    server_args, ca_cert = with_ca_dir_tls_server_args
+    server_args["tls"] = "true"
+
+    with df_factory.create(**server_args) as server:
+        async with server.client(**with_tls_client_args, ssl_ca_certs=ca_cert) as client:
+            await client.execute_command("SET foo 44")
+            res = await client.execute_command("GET foo")
+            assert res == "44"
+
+
 async def test_config_update_tls_certs(
     df_factory, with_tls_server_args, with_tls_ca_cert_args, tmp_dir
 ):


### PR DESCRIPTION
Partially addresses #2081 by adding a test case to cover the use case

* add test for `ca_dir` 

I will update our docs as well.