### PR TITLE
chore(facade): Introduce AwaitCurrentDispatches

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1152,6 +1152,8 @@ void Connection::SendAsync(MessageHandle msg) {
   DCHECK(owner());
   DCHECK_EQ(ProactorBase::me(), socket_->proactor());
 
+  // We still deliver control messages even to closing connections, as messages
+  // like checkpoints always expect to be handled.
   if (cc_->conn_closing && !msg.IsIntrusive())
     return;
 

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1111,7 +1111,7 @@ void Connection::ShutdownThreadLocal() {
 }
 
 bool Connection::IsCurrentlyDispatching() const {
-  if (!cc_ || cc_->conn_closing)
+  if (!cc_)
     return false;
   return cc_->async_dispatch || cc_->sync_dispatch;
 }
@@ -1132,6 +1132,9 @@ void Connection::SendAclUpdateAsync(AclUpdateMessage msg) {
 void Connection::AwaitCurrentDispatches(fb2::BlockingCounter bc) {
   if (!IsCurrentlyDispatching())
     return;
+
+  // TODO: what about a closing connection?
+  // still send and check upon destruction?
 
   bc.Add(1);
   SendAsync({CheckpointMessage{bc}});

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1132,7 +1132,7 @@ void Connection::SendAclUpdateAsync(AclUpdateMessage msg) {
   SendAsync({std::move(msg)});
 }
 
-void Connection::AwaitCurrentDispatches(fb2::BlockingCounter bc) {
+void Connection::SendCheckpoint(fb2::BlockingCounter bc) {
   if (!IsCurrentlyDispatching())
     return;
 

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -954,7 +954,7 @@ void Connection::SquashPipeline(facade::SinkReplyBuilder* builder) {
 
   service_->DispatchManyCommands(absl::MakeSpan(squash_cmds), cc_.get());
 
-  if (dispatch_q_.empty()) {  // Flush if no new messages appeared
+  if (dispatch_q_cmds_count_ == 0) {  // Flush if no new commands appeared
     builder->FlushBatch();
     builder->SetBatchMode(false);  // in case the next dispatch is sync
   }

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -954,7 +954,7 @@ void Connection::SquashPipeline(facade::SinkReplyBuilder* builder) {
 
   service_->DispatchManyCommands(absl::MakeSpan(squash_cmds), cc_.get());
 
-  if (dispatch_q_cmds_count_ == 0) {  // Flush if no new commands appeared
+  if (dispatch_q_cmds_count_ == squash_cmds.size()) {  // Flush if no new commands appeared
     builder->FlushBatch();
     builder->SetBatchMode(false);  // in case the next dispatch is sync
   }

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -151,7 +151,7 @@ class Connection : public util::Connection {
 
   // If any dispatch is currently in progress, increment counter and send checkpoint message to
   // decrement it once finished.
-  void AwaitCurrentDispatches(util::fb2::BlockingCounter bc);
+  void SendCheckpoint(util::fb2::BlockingCounter bc);
 
   // Must be called before SendAsync to ensure the connection dispatch queue is not overfilled.
   // Blocks until free space is available.

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -107,9 +107,9 @@ class Connection : public util::Connection {
   // Migration request message, the dispatch fiber stops to give way for thread migration.
   struct MigrationRequestMessage {};
 
-  // Checkpoint message, decrements counter when processed.
+  // Checkpoint message, used to track when the connection finishes executing the current command.
   struct CheckpointMessage {
-    util::fb2::BlockingCounter bc;
+    util::fb2::BlockingCounter bc;  // Decremented counter when processed
   };
 
   struct MessageDeleter {

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -15,13 +15,11 @@
 #include <variant>
 
 #include "base/io_buf.h"
-#include "util/connection.h"
-#include "util/http/http_handler.h"
-
-//
 #include "core/fibers.h"
 #include "facade/facade_types.h"
 #include "facade/resp_expr.h"
+#include "util/connection.h"
+#include "util/http/http_handler.h"
 
 typedef struct ssl_ctx_st SSL_CTX;
 typedef struct mi_heap_s mi_heap_t;
@@ -77,16 +75,7 @@ class Connection : public util::Connection {
                size_t message_len);
   };
 
-  struct MonitorMessage : public std::string {};
-
-  struct AclUpdateMessage {
-    std::vector<std::string> username;
-    std::vector<uint32_t> categories;
-    std::vector<std::vector<uint64_t>> commands;
-  };
-
-  struct MigrationRequestMessage {};
-
+  // Pipeline message, accumulated command to be executed.
   struct PipelineMessage {
     PipelineMessage(size_t nargs, size_t capacity) : args(nargs), storage(capacity) {
     }
@@ -105,6 +94,24 @@ class Connection : public util::Connection {
     StorageType storage;
   };
 
+  // Monitor message, carries a simple payload with the registered event to be sent.
+  struct MonitorMessage : public std::string {};
+
+  // ACL Update message, contains ACL updates to be applied to the connection.
+  struct AclUpdateMessage {
+    std::vector<std::string> username;
+    std::vector<uint32_t> categories;
+    std::vector<std::vector<uint64_t>> commands;
+  };
+
+  // Migration request message, the dispatch fiber stops to give way for thread migration.
+  struct MigrationRequestMessage {};
+
+  // Checkpoint message, decrements counter when processed.
+  struct CheckpointMessage {
+    util::fb2::BlockingCounter bc;
+  };
+
   struct MessageDeleter {
     void operator()(PipelineMessage* msg) const;
     void operator()(PubMessage* msg) const;
@@ -114,13 +121,18 @@ class Connection : public util::Connection {
   using PipelineMessagePtr = std::unique_ptr<PipelineMessage, MessageDeleter>;
   using PubMessagePtr = std::unique_ptr<PubMessage, MessageDeleter>;
 
+  // Variant wrapper around different message types
   struct MessageHandle {
     size_t UsedMemory() const;  // How much bytes this handle takes up in total.
+
+    // Intrusive messages put themselves at the front of the queue, but only after all other
+    // intrusive ones. Used for quick transfer or control / update messages.
+    bool IsIntrusive() const;
 
     bool IsPipelineMsg() const;
 
     std::variant<MonitorMessage, PubMessagePtr, PipelineMessagePtr, AclUpdateMessage,
-                 MigrationRequestMessage>
+                 MigrationRequestMessage, CheckpointMessage>
         handle;
   };
 
@@ -136,6 +148,10 @@ class Connection : public util::Connection {
 
   // Add acl update to dispatch queue.
   void SendAclUpdateAsync(AclUpdateMessage msg);
+
+  // If any dispatch is currently in progress, increment counter and send checkpoint message to
+  // decrement it once finished.
+  void AwaitCurrentDispatches(util::fb2::BlockingCounter bc);
 
   // Must be called before SendAsync to ensure the connection dispatch queue is not overfilled.
   // Blocks until free space is available.
@@ -260,7 +276,7 @@ class Connection : public util::Connection {
   void HandleMigrateRequest();
   bool ShouldEndDispatchFiber(const MessageHandle& msg);
 
-  void LaunchDispatchFiberIfNeeded();
+  void LaunchDispatchFiberIfNeeded();  // Dispatch fiber is started lazily
 
   // Squashes pipelined commands from the dispatch queue to spread load over all threads
   void SquashPipeline(facade::SinkReplyBuilder*);

--- a/src/facade/dragonfly_listener.cc
+++ b/src/facade/dragonfly_listener.cc
@@ -248,6 +248,7 @@ bool Listener::AwaitCurrentDispatches(absl::Duration timeout, util::Connection* 
   util::MakeFiber([bc, cancelled = weak_ptr{cancelled}, start = absl::Now(), timeout]() mutable {
     while (!cancelled.expired()) {
       if (absl::Now() - start > timeout) {
+        VLOG(1) << "AwaitCurrentDispatches timed out";
         *cancelled.lock() = true;  // same thread, no promotion race
         bc.Cancel();
       }

--- a/src/facade/dragonfly_listener.cc
+++ b/src/facade/dragonfly_listener.cc
@@ -234,26 +234,29 @@ void Listener::PreAcceptLoop(util::ProactorBase* pb) {
   per_thread_.resize(pool()->size());
 }
 
-bool Listener::AwaitDispatches(absl::Duration timeout,
-                               const std::function<bool(util::Connection*)>& filter) {
-  absl::Time start = absl::Now();
+bool Listener::AwaitCurrentDispatches(absl::Duration timeout, util::Connection* issuer) {
+  // Fill blocking counter with ongoing dispatches
+  util::fb2::BlockingCounter bc{0};
+  this->TraverseConnections([bc, issuer](unsigned thread_index, util::Connection* conn) {
+    if (conn != issuer)
+      static_cast<Connection*>(conn)->AwaitCurrentDispatches(bc);
+  });
 
-  while (absl::Now() - start < timeout) {
-    std::atomic<bool> any_connection_dispatching = false;
-    auto cb = [&any_connection_dispatching, &filter](unsigned thread_index,
-                                                     util::Connection* conn) {
-      if (filter(conn) && static_cast<Connection*>(conn)->IsCurrentlyDispatching()) {
-        any_connection_dispatching.store(true);
+  auto cancelled = make_shared<bool>(false);
+
+  // TODO: Add wait with timeout or polling to helio (including cancel flag)
+  util::MakeFiber([bc, cancelled = weak_ptr{cancelled}, start = absl::Now(), timeout]() mutable {
+    while (!cancelled.expired()) {
+      if (absl::Now() - start > timeout) {
+        *cancelled.lock() = true;  // same thread, no promotion race
+        bc.Cancel();
       }
-    };
-    this->TraverseConnections(cb);
-    if (!any_connection_dispatching.load()) {
-      return true;
+      ThisFiber::SleepFor(10ms);
     }
-    VLOG(1) << "A command is still dispatching, let's wait for it";
-    ThisFiber::SleepFor(100us);
-  }
-  return false;
+  }).Detach();
+
+  bc.Wait();
+  return !*cancelled;
 }
 
 bool Listener::IsPrivilegedInterface() const {
@@ -273,8 +276,7 @@ void Listener::PreShutdown() {
   // at this stage since we're in SHUTDOWN mode.
   // If a command is running for too long we give up and proceed.
   const absl::Duration kDispatchShutdownTimeout = absl::Milliseconds(10);
-
-  if (!AwaitDispatches(kDispatchShutdownTimeout, [](util::Connection*) { return true; })) {
+  if (!AwaitCurrentDispatches(kDispatchShutdownTimeout, nullptr)) {
     LOG(WARNING) << "Some commands are still being dispatched but didn't conclude in time. "
                     "Proceeding in shutdown.";
   }

--- a/src/facade/dragonfly_listener.cc
+++ b/src/facade/dragonfly_listener.cc
@@ -239,7 +239,7 @@ bool Listener::AwaitCurrentDispatches(absl::Duration timeout, util::Connection* 
   util::fb2::BlockingCounter bc{0};
   this->TraverseConnections([bc, issuer](unsigned thread_index, util::Connection* conn) {
     if (conn != issuer)
-      static_cast<Connection*>(conn)->AwaitCurrentDispatches(bc);
+      static_cast<Connection*>(conn)->SendCheckpoint(bc);
   });
 
   auto cancelled = make_shared<bool>(false);

--- a/src/facade/dragonfly_listener.h
+++ b/src/facade/dragonfly_listener.h
@@ -34,13 +34,12 @@ class Listener : public util::ListenerInterface {
 
   std::error_code ConfigureServerSocket(int fd) final;
 
+  // Wait until all command dispatches that are currently in progress finish,
+  // ignore commands from issuer connection.
+  bool AwaitCurrentDispatches(absl::Duration timeout, util::Connection* issuer);
+
   // ReconfigureTLS MUST be called from the same proactor as the listener.
   bool ReconfigureTLS();
-
-  // Wait until all connections that pass the filter have stopped dispatching or until a timeout has
-  // run out. Returns true if the all connections have stopped dispatching.
-  bool AwaitDispatches(absl::Duration timeout,
-                       const std::function<bool(util::Connection*)>& filter);
 
   bool IsPrivilegedInterface() const;
   bool IsMainInterface() const;

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -506,10 +506,6 @@ void ClusterFamily::DflyClusterConfig(CmdArgList args, ConnectionContext* cntx) 
   server_family_->service().proactor_pool().AwaitFiberOnAll(std::move(cb));
   DCHECK(tl_cluster_config != nullptr);
 
-  bool success = server_family_->AwaitCurrentDispatches(absl::Seconds(1), cntx->conn());
-  // TODO... and what to do?
-  (void)success;
-
   SlotSet after = tl_cluster_config->GetOwnedSlots();
   if (ServerState::tlocal()->is_master) {
     auto deleted_slots = GetDeletedSlots(is_first_config, before, after);

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -504,11 +504,12 @@ void ClusterFamily::DflyClusterConfig(CmdArgList args, ConnectionContext* cntx) 
 
   auto cb = [&](util::ProactorBase* pb) { tl_cluster_config = new_config; };
   server_family_->service().proactor_pool().AwaitFiberOnAll(std::move(cb));
-
   DCHECK(tl_cluster_config != nullptr);
 
-  SlotSet after = tl_cluster_config->GetOwnedSlots();
+  bool success = server_family_->AwaitCurrentDispatches(absl::Seconds(1), cntx->conn());
+  // TODO... and what to do?
 
+  SlotSet after = tl_cluster_config->GetOwnedSlots();
   if (ServerState::tlocal()->is_master) {
     auto deleted_slots = GetDeletedSlots(is_first_config, before, after);
     DeleteSlots(deleted_slots);

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -508,6 +508,7 @@ void ClusterFamily::DflyClusterConfig(CmdArgList args, ConnectionContext* cntx) 
 
   bool success = server_family_->AwaitCurrentDispatches(absl::Seconds(1), cntx->conn());
   // TODO... and what to do?
+  (void)success;
 
   SlotSet after = tl_cluster_config->GetOwnedSlots();
   if (ServerState::tlocal()->is_master) {

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1123,17 +1123,20 @@ void ServerFamily::CancelBlockingCommands() {
   }
 }
 
-bool ServerFamily::AwaitDispatches(absl::Duration timeout,
-                                   const std::function<bool(util::Connection*)>& filter) {
-  auto start = absl::Now();
+bool ServerFamily::AwaitCurrentDispatches(absl::Duration timeout, util::Connection* issuer) {
+  vector<Fiber> fibers;
+  bool successful = true;
+
   for (auto* listener : listeners_) {
-    absl::Duration remaining_time = timeout - (absl::Now() - start);
-    if (remaining_time < absl::Nanoseconds(0) ||
-        !listener->AwaitDispatches(remaining_time, filter)) {
-      return false;
-    }
+    fibers.push_back(MakeFiber([listener, timeout, issuer, &successful]() {
+      successful &= listener->AwaitCurrentDispatches(timeout, issuer);
+    }));
   }
-  return true;
+
+  for (auto& fb : fibers)
+    fb.JoinIfNeeded();
+
+  return successful;
 }
 
 string GetPassword() {

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -192,8 +192,8 @@ class ServerFamily {
 
   void CancelBlockingCommands();
 
-  bool AwaitDispatches(absl::Duration timeout,
-                       const std::function<bool(util::Connection*)>& filter);
+  // Wait until all current dispatches finish, returns true on success, false if timeout was reached
+  bool AwaitCurrentDispatches(absl::Duration timeout, util::Connection* issuer);
 
   // Sets the server to replicate another instance. Does not flush the database beforehand!
   void Replicate(std::string_view host, std::string_view port);


### PR DESCRIPTION
We have some places in our code base that first push a global change and then need to wait until there are no commands anymore running that have values of the old state cached / are amidst a breaking execution:

* When doing takeover, we first set the global state to taking-over and then wait for ongoing commands to finish. No new commands will be able to run because of the global state rejecting all commands
* When pushing cluster configs, before we delete moved slots, we want to make sure no command is accessing them, see #1480 
* Possibly when doing client pause (currently a PR)

The current implementation of `AwaitDispatches` waits until a point of time when _no dispatches at all_ are happening - which is too strong of a guarantee, we only want to wait for commands that were amidst execution during the update to finish. 

The first case is lucky as is disallows execution at all, so there are no suspension points in the commands, meaning the current AwaitDispatches loop will only execute in-between dispatches. However with cluster config changes, no commands are rejected, so even under moderate load there just may be no such moment that no command is currently running -> means AwaitDispatches will always fail

The new implementation of `AwaitCurrentDispatches` just enqueues checkpoints for all connections which are currently dispatching. Once they're done, they reach the checkpoint and decrement the counter  