### PR TITLE
feat: Memory stats

### DIFF
--- a/src/core/size_tracking_channel.h
+++ b/src/core/size_tracking_channel.h
@@ -1,0 +1,73 @@
+// Copyright 2023, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include "core/fibers.h"
+
+namespace dfly {
+
+// SimpleQueue-like interface, but also keeps track over the size of Ts it owns.
+// It has a slightly less efficient TryPush() API as it forces construction of Ts even if they are
+// not pushed.
+// T must have a .size() method, which should return the heap-allocated size of T, excluding
+// anything included in sizeof(T). We could generalize this in the future.
+template <typename T, typename Queue = folly::ProducerConsumerQueue<T>> class SizeTrackingChannel {
+ public:
+  SizeTrackingChannel(size_t n, unsigned num_producers = 1) : queue_(n, num_producers) {
+  }
+
+  // Here and below, we must accept a T instead of building it from variadic args, as we need to
+  // know its size in case it is added.
+  void Push(T t) noexcept {
+    size_ += t.size();
+    queue_.Push(std::move(t));
+  }
+
+  bool TryPush(T t) noexcept {
+    const size_t tmp_size = t.size();
+    if (queue_.TryPush(std::move(t))) {
+      size_ += tmp_size;
+      return true;
+    }
+
+    return false;
+  }
+
+  bool Pop(T& dest) {
+    if (queue_.Pop(dest)) {
+      size_ -= dest.size();
+      return true;
+    }
+
+    return false;
+  }
+
+  void StartClosing() {
+    queue_.StartClosing();
+  }
+
+  bool TryPop(T& dest) {
+    if (queue_.TryPop(dest)) {
+      size_ -= dest.size();
+      return true;
+    }
+
+    return false;
+  }
+
+  bool IsClosing() const {
+    return queue_.IsClosing();
+  }
+
+  size_t GetSize() const {
+    return queue_.Capacity() * sizeof(T) + size_;
+  }
+
+ private:
+  SimpleChannel<T, Queue> queue_;
+  size_t size_ = 0;
+};
+
+}  // namespace dfly

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -187,6 +187,10 @@ class Connection : public util::Connection {
     return name_;
   }
 
+  base::IoBuf::MemoryUsage GetMemoryUsage() const {
+    return io_buf_.GetMemoryUsage();
+  }
+
   ConnectionContext* cntx();
 
   // Requests that at some point, this connection will be migrated to `dest` thread.

--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -7,8 +7,12 @@
 #include <absl/strings/str_cat.h>
 #include <mimalloc.h>
 
+#include "base/io_buf.h"
+#include "facade/dragonfly_connection.h"
 #include "facade/error.h"
 #include "server/engine_shard_set.h"
+#include "server/rdb_save.h"
+#include "server/server_family.h"
 #include "server/server_state.h"
 
 using namespace std;
@@ -75,7 +79,7 @@ size_t MemoryUsage(PrimeIterator it) {
 
 }  // namespace
 
-MemoryCmd::MemoryCmd(ServerFamily* owner, ConnectionContext* cntx) : cntx_(cntx) {
+MemoryCmd::MemoryCmd(ServerFamily* owner, ConnectionContext* cntx) : cntx_(cntx), owner_(owner) {
 }
 
 void MemoryCmd::Run(CmdArgList args) {
@@ -84,6 +88,8 @@ void MemoryCmd::Run(CmdArgList args) {
   if (sub_cmd == "HELP") {
     string_view help_arr[] = {
         "MEMORY <subcommand> [<arg> ...]. Subcommands are:",
+        "STATS",
+        "    Shows breakdown of memory.",
         "MALLOC-STATS [BACKING] [thread-id]",
         "    Show malloc stats for a heap residing in specified thread-id. 0 by default.",
         "    If BACKING is specified, show stats for the backing heap.",
@@ -94,6 +100,10 @@ void MemoryCmd::Run(CmdArgList args) {
     };
     return (*cntx_)->SendSimpleStrArr(help_arr);
   };
+
+  if (sub_cmd == "STATS") {
+    return Stats();
+  }
 
   if (sub_cmd == "USAGE" && args.size() > 1) {
     string_view key = ArgS(args, 1);
@@ -141,6 +151,110 @@ void MemoryCmd::Run(CmdArgList args) {
 
   string err = UnknownSubCmd(sub_cmd, "MEMORY");
   return (*cntx_)->SendError(err, kSyntaxErrType);
+}
+
+namespace {
+
+struct ConnectionMemoryUsage {
+  size_t connection_count = 0;
+  size_t pipelined_bytes = 0;
+  base::IoBuf::MemoryUsage connections_memory;
+
+  size_t replication_connection_count = 0;
+  base::IoBuf::MemoryUsage replication_memory;
+};
+
+ConnectionMemoryUsage GetConnectionMemoryUsage(ServerFamily* server) {
+  Mutex mu;
+  ConnectionMemoryUsage mem ABSL_GUARDED_BY(mu);
+
+  for (auto* listener : server->GetListeners()) {
+    listener->TraverseConnections([&](unsigned thread_index, util::Connection* conn) {
+      auto* dfly_conn = static_cast<facade::Connection*>(conn);
+      auto* cntx = static_cast<ConnectionContext*>(dfly_conn->cntx());
+      lock_guard lock(mu);
+
+      if (cntx->replication_flow == nullptr) {
+        mem.connection_count++;
+        mem.connections_memory += dfly_conn->GetMemoryUsage();
+      } else {
+        mem.replication_connection_count++;
+        mem.replication_memory += dfly_conn->GetMemoryUsage();
+      }
+
+      if (cntx != nullptr) {
+        mem.pipelined_bytes += cntx->conn_state.exec_info.body.capacity() * sizeof(StoredCmd);
+        for (const auto& pipeline : cntx->conn_state.exec_info.body) {
+          mem.pipelined_bytes += pipeline.UsedHeapMemory();
+        }
+      }
+    });
+  }
+
+  return mem;
+}
+
+void PushMemoryUsageStats(const base::IoBuf::MemoryUsage& mem, string_view prefix, size_t total,
+                          vector<string>* stats) {
+  stats->push_back(absl::StrCat(prefix, ".total_bytes"));
+  stats->push_back(absl::StrCat(total));
+  stats->push_back(absl::StrCat(prefix, ".consumed_bytes"));
+  stats->push_back(absl::StrCat(mem.consumed));
+  stats->push_back(absl::StrCat(prefix, ".pending_input_bytes"));
+  stats->push_back(absl::StrCat(mem.input_length));
+  stats->push_back(absl::StrCat(prefix, ".pending_output_bytes"));
+  stats->push_back(absl::StrCat(mem.append_length));
+}
+
+}  // namespace
+
+void MemoryCmd::Stats() {
+  vector<string> stats;
+  stats.reserve(50);
+  auto server_metrics = owner_->GetMetrics();
+
+  // RSS
+  stats.push_back("rss_bytes");
+  stats.push_back(absl::StrCat(rss_mem_current.load()));
+  stats.push_back("rss_peak_bytes");
+  stats.push_back(absl::StrCat(rss_mem_peak.load()));
+
+  // Used by DbShards and DashTable
+  stats.push_back("data_bytes");
+  stats.push_back(absl::StrCat(used_mem_current.load()));
+  stats.push_back("data_peak_bytes");
+  stats.push_back(absl::StrCat(used_mem_peak.load()));
+
+  ConnectionMemoryUsage connection_memory = GetConnectionMemoryUsage(owner_);
+
+  // Connection stats, excluding replication connections
+  stats.push_back("connections.count");
+  stats.push_back(absl::StrCat(connection_memory.connection_count));
+  PushMemoryUsageStats(
+      connection_memory.connections_memory, "connections",
+      connection_memory.connections_memory.GetTotalSize() + connection_memory.pipelined_bytes,
+      &stats);
+  stats.push_back("connections.pipeline_bytes");
+  stats.push_back(absl::StrCat(connection_memory.pipelined_bytes));
+
+  // Replication connection stats
+  stats.push_back("replication.connections_count");
+  stats.push_back(absl::StrCat(connection_memory.replication_connection_count));
+  PushMemoryUsageStats(connection_memory.replication_memory, "replication",
+                       connection_memory.replication_memory.GetTotalSize(), &stats);
+
+  Mutex mu;
+  base::IoBuf::MemoryUsage serialization_memory ABSL_GUARDED_BY(mu);
+  shard_set->pool()->AwaitFiberOnAll([&](auto*) {
+    lock_guard lock(mu);
+    serialization_memory += RdbSerializer::GetThreadLocalMemoryUsage();
+  });
+
+  // Serialization stats, including both replication-related serialization and saving to RDB files.
+  PushMemoryUsageStats(serialization_memory, "serialization", serialization_memory.GetTotalSize(),
+                       &stats);
+
+  return (*cntx_)->SendSimpleStrArr(stats);
 }
 
 void MemoryCmd::Usage(std::string_view key) {

--- a/src/server/memory_cmd.h
+++ b/src/server/memory_cmd.h
@@ -17,9 +17,11 @@ class MemoryCmd {
   void Run(CmdArgList args);
 
  private:
+  void Stats();
   void Usage(std::string_view key);
 
   ConnectionContext* cntx_;
+  ServerFamily* owner_;
 };
 
 }  // namespace dfly

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -227,11 +227,18 @@ io::Result<io::Bytes> Lz4Compressor::Compress(io::Bytes data) {
   return io::Bytes(compr_buf_.data(), frame_size);
 }
 
+namespace {
+thread_local absl::flat_hash_set<RdbSerializer*> tl_rdb_serializers;
+}  // namespace
+
 RdbSerializer::RdbSerializer(CompressionMode compression_mode)
     : mem_buf_{4_KB}, tmp_buf_(nullptr), compression_mode_(compression_mode) {
+  tl_rdb_serializers.insert(this);
 }
 
 RdbSerializer::~RdbSerializer() {
+  tl_rdb_serializers.erase(this);
+
   VLOG(2) << "compression mode: " << uint32_t(compression_mode_);
   if (compression_stats_) {
     VLOG(2) << "compression not effective: " << compression_stats_->compression_no_effective;
@@ -239,6 +246,14 @@ RdbSerializer::~RdbSerializer() {
     VLOG(2) << "compression failed: " << compression_stats_->compression_failed;
     VLOG(2) << "compressed blobs:" << compression_stats_->compressed_blobs;
   }
+}
+
+IoBuf::MemoryUsage RdbSerializer::GetThreadLocalMemoryUsage() {
+  IoBuf::MemoryUsage mem;
+  for (RdbSerializer* serializer : tl_rdb_serializers) {
+    mem += serializer->mem_buf_.GetMemoryUsage();
+  }
+  return mem;
 }
 
 std::error_code RdbSerializer::SaveValue(const PrimeValue& pv) {

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -132,6 +132,8 @@ class RdbSerializer {
 
   ~RdbSerializer();
 
+  static base::IoBuf::MemoryUsage GetThreadLocalMemoryUsage();
+
   // Internal buffer size. Might shrink after flush due to compression.
   size_t SerializedLen() const;
 

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -132,8 +132,6 @@ class RdbSerializer {
 
   ~RdbSerializer();
 
-  static base::IoBuf::MemoryUsage GetThreadLocalMemoryUsage();
-
   // Internal buffer size. Might shrink after flush due to compression.
   size_t SerializedLen() const;
 

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -178,6 +178,10 @@ class ServerFamily {
     return dfly_cmd_.get();
   }
 
+  const std::vector<facade::Listener*>& GetListeners() const {
+    return listeners_;
+  }
+
   bool HasReplica() const;
   std::optional<Replica::Info> GetReplicaInfo() const;
   std::string GetReplicaMasterId() const;

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -25,12 +25,26 @@ using namespace std;
 using namespace util;
 using namespace chrono_literals;
 
+namespace {
+thread_local absl::flat_hash_set<SliceSnapshot*> tl_slice_snapshots;
+}  // namespace
+
 SliceSnapshot::SliceSnapshot(DbSlice* slice, RecordChannel* dest, CompressionMode compression_mode)
     : db_slice_(slice), dest_(dest), compression_mode_(compression_mode) {
   db_array_ = slice->databases();
+  tl_slice_snapshots.insert(this);
 }
 
 SliceSnapshot::~SliceSnapshot() {
+  tl_slice_snapshots.erase(this);
+}
+
+size_t SliceSnapshot::GetThreadLocalMemoryUsage() {
+  size_t mem = 0;
+  for (SliceSnapshot* snapshot : tl_slice_snapshots) {
+    mem += snapshot->GetTotalBufferCapacity() + snapshot->GetTotalChannelCapacity();
+  }
+  return mem;
 }
 
 void SliceSnapshot::Start(bool stream_journal, const Cancellation* cll) {
@@ -333,6 +347,10 @@ void SliceSnapshot::CloseRecordChannel() {
 
 size_t SliceSnapshot::GetTotalBufferCapacity() const {
   return serializer_->GetTotalBufferCapacity();
+}
+
+size_t SliceSnapshot::GetTotalChannelCapacity() const {
+  return dest_->GetSize();
 }
 
 }  // namespace dfly

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -288,8 +288,6 @@ bool SliceSnapshot::PushSerializedToChannel(bool force) {
   if (serialized == 0)
     return 0;
 
-  stats_.pushed_bytes += serialized;
-
   auto id = rec_id_++;
   DVLOG(2) << "Pushed " << id;
   DbRecord db_rec{.id = id, .value = std::move(sfile.val)};

--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -122,10 +122,6 @@ class SliceSnapshot {
     return snapshot_version_;
   }
 
-  size_t pushed_bytes() const {
-    return stats_.pushed_bytes;
-  }
-
   const RdbTypeFreqMap& freq_map() const {
     return type_freq_map_;
   }
@@ -157,7 +153,6 @@ class SliceSnapshot {
   uint64_t rec_id_ = 0;
 
   struct Stats {
-    size_t pushed_bytes = 0;
     size_t loop_serialized = 0, skipped = 0, side_saved = 0;
     size_t savecb_calls = 0;
   } stats_;


### PR DESCRIPTION
Add `MEMORY STATS` command that prints some useful memory related information, including RSS, db memory size, connection count & buffer size, replication count & buffer size, serialization buffer size.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->