### PR TITLE
feat: DispatchTracker to replace everything

### DIFF
--- a/src/facade/conn_context.h
+++ b/src/facade/conn_context.h
@@ -80,6 +80,7 @@ class ConnectionContext {
   bool async_dispatch : 1;    // whether this connection is amid an async dispatch
   bool sync_dispatch : 1;     // whether this connection is amid a sync dispatch
   bool journal_emulated : 1;  // whether it is used to dispatch journal commands
+  bool paused : 1;            // whether this connection is paused due to CLIENT PAUSE
 
   // How many async subscription sources are active: monitor and/or pubsub - at most 2.
   uint8_t subscriptions;

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1186,8 +1186,11 @@ void Connection::SendAclUpdateAsync(AclUpdateMessage msg) {
   SendAsync({make_unique<AclUpdateMessage>(std::move(msg))});
 }
 
-void Connection::SendCheckpoint(fb2::BlockingCounter bc) {
+void Connection::SendCheckpoint(fb2::BlockingCounter bc, bool ignore_paused) {
   if (!IsCurrentlyDispatching())
+    return;
+
+  if (cc_->paused && !ignore_paused)
     return;
 
   bc.Add(1);

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -870,7 +870,7 @@ auto Connection::IoLoop(util::FiberSocketBase* peer, SinkReplyBuilder* orig_buil
 
     phase_ = PROCESS;
     bool is_iobuf_full = io_buf_.AppendLen() == 0;
-    service_->AwaitOnPauseDispatch();
+
     if (redis_parser_) {
       parse_status = ParseRedis(orig_builder);
     } else {

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -280,6 +280,8 @@ void Connection::DispatchOperations::operator()(const MigrationRequestMessage& m
 }
 
 void Connection::DispatchOperations::operator()(CheckpointMessage msg) {
+  VLOG(1) << "Decremented checkpoint at " << self->DebugInfo();
+
   msg.bc.Dec();
 }
 
@@ -1014,6 +1016,7 @@ void Connection::ClearPipelinedMessages() {
 std::string Connection::DebugInfo() const {
   std::string info = "{";
 
+  absl::StrAppend(&info, "address=", uint64_t(this), ", ");
   absl::StrAppend(&info, "phase=", phase_, ", ");
   absl::StrAppend(&info, "dispatch(s/a)=", cc_->sync_dispatch, " ", cc_->async_dispatch, ", ");
   absl::StrAppend(&info, "closing=", cc_->conn_closing, ", ");
@@ -1197,6 +1200,8 @@ void Connection::SendCheckpoint(fb2::BlockingCounter bc, bool ignore_paused) {
 
   if (cc_->paused && !ignore_paused)
     return;
+
+  VLOG(1) << "Sent checkpoint to " << DebugInfo();
 
   bc.Add(1);
   SendAsync({CheckpointMessage{bc}});

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -155,7 +155,7 @@ class Connection : public util::Connection {
   void SendAclUpdateAsync(AclUpdateMessage msg);
 
   // If any dispatch is currently in progress, increment counter and send checkpoint message to
-  // decrement it once finished.
+  // decrement it once finished. It ignore_paused is true, paused dispatches are ignored.
   void SendCheckpoint(util::fb2::BlockingCounter bc, bool ignore_paused = false);
 
   // Must be called before sending pubsub messages to ensure the threads pipeline queue limit is not

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -347,6 +347,8 @@ class Connection : public util::Connection {
   bool migration_enabled_;
   util::fb2::ProactorBase* migration_request_ = nullptr;
 
+  bool skip_next_squashing_ = false;  // Forcefully skip next squashing
+
   // Pooled pipeline messages per-thread
   // Aggregated while handling pipelines, gradually released while handling regular commands.
   static thread_local std::vector<PipelineMessagePtr> pipeline_req_pool_;

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -156,7 +156,7 @@ class Connection : public util::Connection {
 
   // If any dispatch is currently in progress, increment counter and send checkpoint message to
   // decrement it once finished.
-  void SendCheckpoint(util::fb2::BlockingCounter bc);
+  void SendCheckpoint(util::fb2::BlockingCounter bc, bool ignore_paused = false);
 
   // Must be called before sending pubsub messages to ensure the threads pipeline queue limit is not
   // reached. Blocks until free space is available. Controlled with `pipeline_queue_limit` flag.

--- a/src/facade/dragonfly_listener.cc
+++ b/src/facade/dragonfly_listener.cc
@@ -8,6 +8,7 @@
 
 #include <memory>
 
+#include "absl/functional/bind_front.h"
 #include "facade/tls_error.h"
 
 #ifdef DFLY_USE_SSL
@@ -234,32 +235,6 @@ void Listener::PreAcceptLoop(util::ProactorBase* pb) {
   per_thread_.resize(pool()->size());
 }
 
-bool Listener::AwaitCurrentDispatches(absl::Duration timeout, util::Connection* issuer) {
-  // Fill blocking counter with ongoing dispatches
-  util::fb2::BlockingCounter bc{0};
-  this->TraverseConnections([bc, issuer](unsigned thread_index, util::Connection* conn) {
-    if (conn != issuer)
-      static_cast<Connection*>(conn)->SendCheckpoint(bc);
-  });
-
-  auto cancelled = make_shared<bool>(false);
-
-  // TODO: Add wait with timeout or polling to helio (including cancel flag)
-  util::MakeFiber([bc, cancelled = weak_ptr{cancelled}, start = absl::Now(), timeout]() mutable {
-    while (!cancelled.expired()) {
-      if (absl::Now() - start > timeout) {
-        VLOG(1) << "AwaitCurrentDispatches timed out";
-        *cancelled.lock() = true;  // same thread, no promotion race
-        bc.Cancel();
-      }
-      ThisFiber::SleepFor(10ms);
-    }
-  }).Detach();
-
-  bc.Wait();
-  return !*cancelled;
-}
-
 bool Listener::IsPrivilegedInterface() const {
   return role_ == Role::PRIVILEGED;
 }
@@ -276,8 +251,10 @@ void Listener::PreShutdown() {
   // This shouldn't take a long time: All clients should reject incoming commands
   // at this stage since we're in SHUTDOWN mode.
   // If a command is running for too long we give up and proceed.
-  const absl::Duration kDispatchShutdownTimeout = absl::Milliseconds(10);
-  if (!AwaitCurrentDispatches(kDispatchShutdownTimeout, nullptr)) {
+  DispatchTracker tracker{{this}, nullptr};
+  tracker.TrackAll();
+
+  if (!tracker.Wait(absl::Milliseconds(10))) {
     LOG(WARNING) << "Some commands are still being dispatched but didn't conclude in time. "
                     "Proceeding in shutdown.";
   }
@@ -394,6 +371,30 @@ ProactorBase* Listener::PickConnectionProactor(util::FiberSocketBase* sock) {
   }
 
   return pp->at(res_id);
+}
+
+DispatchTracker::DispatchTracker(absl::Span<facade::Listener* const> listeners,
+                                 facade::Connection* issuer)
+    : listeners_{listeners.begin(), listeners.end()}, issuer_{issuer} {
+}
+
+void DispatchTracker::TrackOnThread() {
+  for (auto* listener : listeners_)
+    listener->TraverseConnectionsOnThread(absl::bind_front(&DispatchTracker::Handle, this));
+}
+
+bool DispatchTracker::Wait(absl::Duration duration) {
+  return bc_.WaitFor(absl::ToChronoMilliseconds(duration));
+}
+
+void DispatchTracker::TrackAll() {
+  for (auto* listener : listeners_)
+    listener->TraverseConnections(absl::bind_front(&DispatchTracker::Handle, this));
+}
+
+void DispatchTracker::Handle(unsigned thread_index, util::Connection* conn) {
+  if (auto* fconn = static_cast<facade::Connection*>(conn); fconn != issuer_)
+    fconn->SendCheckpoint(bc_);
 }
 
 }  // namespace facade

--- a/src/facade/dragonfly_listener.h
+++ b/src/facade/dragonfly_listener.h
@@ -82,7 +82,10 @@ class Listener : public util::ListenerInterface {
 };
 
 // Dispatch tracker allows tracking the dispatch state of connections and blocking until all
-// detected busy connections finished dispatching. Ignores issuer if set.
+// detected busy connections finished dispatching. Ignores issuer connection.
+//
+// Mostly used to detect when global state changes (takeover, pause, cluster config update) are
+// visible to all commands and no commands are still running according to the old state / config.
 class DispatchTracker {
  public:
   DispatchTracker(absl::Span<facade::Listener* const>, facade::Connection* issuer = nullptr,
@@ -93,7 +96,7 @@ class DispatchTracker {
 
   // Wait until all tracked connections finished dispatching.
   // Returns true on success, false if timeout was reached.
-  bool Wait(absl::Duration);
+  bool Wait(absl::Duration timeout);
 
  private:
   void Handle(unsigned thread_index, util::Connection* conn);

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -133,6 +133,7 @@ ConnectionContext::ConnectionContext(::io::Sink* stream, Connection* owner) : ow
   async_dispatch = false;
   sync_dispatch = false;
   journal_emulated = false;
+  paused = false;
 
   subscriptions = 0;
 }

--- a/src/facade/ok_main.cc
+++ b/src/facade/ok_main.cc
@@ -27,9 +27,10 @@ class OkService : public ServiceInterface {
     (*cntx)->SendOk();
   }
 
-  void DispatchManyCommands(absl::Span<CmdArgList> args_lists, ConnectionContext* cntx) final {
+  size_t DispatchManyCommands(absl::Span<CmdArgList> args_lists, ConnectionContext* cntx) final {
     for (auto args : args_lists)
       DispatchCommand(args, cntx);
+    return args_lists.size();
   }
 
   void DispatchMC(const MemcacheParser::Command& cmd, std::string_view value,

--- a/src/facade/ok_main.cc
+++ b/src/facade/ok_main.cc
@@ -44,10 +44,6 @@ class OkService : public ServiceInterface {
   ConnectionStats* GetThreadLocalConnectionStats() final {
     return &tl_stats;
   }
-
-  void AwaitOnPauseDispatch() {
-    return;
-  }
 };
 
 void RunEngine(ProactorPool* pool, AcceptServer* acceptor) {

--- a/src/facade/service_interface.h
+++ b/src/facade/service_interface.h
@@ -35,7 +35,6 @@ class ServiceInterface {
   virtual ConnectionContext* CreateContext(util::FiberSocketBase* peer, Connection* owner) = 0;
 
   virtual ConnectionStats* GetThreadLocalConnectionStats() = 0;
-  virtual void AwaitOnPauseDispatch() = 0;
 
   virtual void ConfigureHttpHandlers(util::HttpListenerBase* base, bool is_privileged) {
   }

--- a/src/facade/service_interface.h
+++ b/src/facade/service_interface.h
@@ -27,7 +27,9 @@ class ServiceInterface {
 
   virtual void DispatchCommand(CmdArgList args, ConnectionContext* cntx) = 0;
 
-  virtual void DispatchManyCommands(absl::Span<CmdArgList> args_list, ConnectionContext* cntx) = 0;
+  // Returns number of processed commands
+  virtual size_t DispatchManyCommands(absl::Span<CmdArgList> args_list,
+                                      ConnectionContext* cntx) = 0;
 
   virtual void DispatchMC(const MemcacheParser::Command& cmd, std::string_view value,
                           ConnectionContext* cntx) = 0;

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -502,9 +502,17 @@ void ClusterFamily::DflyClusterConfig(CmdArgList args, ConnectionContext* cntx) 
     before = tl_cluster_config->GetOwnedSlots();
   }
 
-  auto cb = [&](util::ProactorBase* pb) { tl_cluster_config = new_config; };
+  DispatchTracker tracker{server_family_->GetListeners(), cntx->conn()};
+  auto cb = [&tracker, &new_config](util::ProactorBase* pb) {
+    tl_cluster_config = new_config;
+    tracker.TrackOnThread();
+  };
   server_family_->service().proactor_pool().AwaitFiberOnAll(std::move(cb));
   DCHECK(tl_cluster_config != nullptr);
+
+  if (!tracker.Wait(absl::Seconds(1))) {
+    LOG(WARNING) << "Cluster config change timed out";
+  }
 
   SlotSet after = tl_cluster_config->GetOwnedSlots();
   if (ServerState::tlocal()->is_master) {

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -427,7 +427,10 @@ void DflyCmd::TakeOver(CmdArgList args, ConnectionContext* cntx) {
 
   // We need to await for all dispatches to finish: Otherwise a transaction might be scheduled
   // after this function exits but before the actual shutdown.
-  if (!sf_->AwaitCurrentDispatches(timeout_dur, cntx->conn())) {
+  facade::DispatchTracker tracker{sf_->GetListeners(), cntx->conn()};
+  tracker.TrackAll();
+
+  if (!tracker.Wait(timeout_dur)) {
     LOG(WARNING) << "Couldn't wait for commands to finish dispatching. " << timeout_dur;
     status = OpStatus::TIMED_OUT;
   }

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1059,9 +1059,8 @@ void Service::DispatchCommand(CmdArgList args, facade::ConnectionContext* cntx) 
   bool dispatching_in_multi = under_script || under_multi;
 
   if (VLOG_IS_ON(2) && cntx->conn() /* no owner in replica context */) {
-    const char* lua = under_script ? "LUA " : "";
-    LOG(INFO) << "Got (" << cntx->conn()->GetClientId() << "): " << lua << args
-              << " in dbid=" << dfly_cntx->conn_state.db_index;
+    LOG(INFO) << "Got (" << cntx->conn()->GetClientId() << "): " << (under_script ? "LUA " : "")
+              << args << " in dbid=" << dfly_cntx->conn_state.db_index;
   }
 
   if (!dispatching_in_multi) {  // Don't interrupt running multi commands

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1259,10 +1259,6 @@ size_t Service::DispatchManyCommands(absl::Span<CmdArgList> args_list,
   };
 
   for (auto args : args_list) {
-    // Stop accumulating when a pause is requested, fall back to regular dispatch
-    if (dfly::ServerState::tlocal()->IsPaused())
-      break;
-
     ToUpper(&args[0]);
     const auto [cid, tail_args] = FindCmd(args);
 
@@ -1286,6 +1282,10 @@ size_t Service::DispatchManyCommands(absl::Span<CmdArgList> args_list,
 
     // Squash accumulated commands
     perform_squash();
+
+    // Stop accumulating when a pause is requested, fall back to regular dispatch
+    if (dfly::ServerState::tlocal()->IsPaused())
+      break;
 
     // Dispatch non squashed command only after all squshed commands were executed and replied
     DispatchCommand(args, cntx);

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -48,8 +48,8 @@ class Service : public facade::ServiceInterface {
   void DispatchCommand(CmdArgList args, facade::ConnectionContext* cntx) final;
 
   // Execute multiple consecutive commands, possibly in parallel by squashing
-  void DispatchManyCommands(absl::Span<CmdArgList> args_list,
-                            facade::ConnectionContext* cntx) final;
+  size_t DispatchManyCommands(absl::Span<CmdArgList> args_list,
+                              facade::ConnectionContext* cntx) final;
 
   // Check VerifyCommandExecution and invoke command with args
   bool InvokeCmd(const CommandId* cid, CmdArgList tail_args, ConnectionContext* reply_cntx,

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -73,7 +73,6 @@ class Service : public facade::ServiceInterface {
                                            facade::Connection* owner) final;
 
   facade::ConnectionStats* GetThreadLocalConnectionStats() final;
-  void AwaitOnPauseDispatch() final;
 
   std::pair<const CommandId*, CmdArgList> FindCmd(CmdArgList args) const;
   const CommandId* FindCmd(std::string_view) const;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1294,6 +1294,8 @@ void ServerFamily::ClientPause(CmdArgList args, ConnectionContext* cntx) {
   // Exlude already paused commands from the busy count.
   DispatchTracker tracker{GetListeners(), cntx->conn(), true /* ignore paused commands */};
   service_.proactor_pool().Await([&tracker, pause_state](util::ProactorBase* pb) {
+    // Commands don't suspend before checking the pause state, so
+    // it's impossible to deadlock on waiting for a command that will be paused.
     tracker.TrackOnThread();
     ServerState::tlocal()->SetPauseState(pause_state, true);
   });

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -184,7 +184,7 @@ class ServerFamily {
     return dfly_cmd_.get();
   }
 
-  const std::vector<facade::Listener*>& GetListeners() const {
+  absl::Span<facade::Listener* const> GetListeners() const {
     return listeners_;
   }
 
@@ -197,9 +197,6 @@ class ServerFamily {
   void BreakOnShutdown();
 
   void CancelBlockingCommands();
-
-  // Wait until all current dispatches finish, returns true on success, false if timeout was reached
-  bool AwaitCurrentDispatches(absl::Duration timeout, util::Connection* issuer);
 
   // Sets the server to replicate another instance. Does not flush the database beforehand!
   void Replicate(std::string_view host, std::string_view port);

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -126,6 +126,10 @@ void ServerState::AwaitPauseState(bool is_write) {
   });
 }
 
+bool ServerState::IsPaused() const {
+  return client_pauses_[0] + client_pauses_[1] > 0;
+}
+
 Interpreter* ServerState::BorrowInterpreter() {
   return interpreter_mgr_.Get();
 }

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -121,30 +121,10 @@ void ServerState::SetPauseState(ClientPause state, bool start) {
 
 void ServerState::AwaitPauseState(bool is_write) {
   client_pause_ec_.await([is_write, this]() {
-    if (client_pauses_[int(ClientPause::ALL)]) {
-      return false;
-    }
-    if (is_write && client_pauses_[int(ClientPause::WRITE)]) {
-      return false;
-    }
-    return true;
+    int num_pauses =
+        is_write ? client_pauses_[int(ClientPause::WRITE)] : client_pauses_[int(ClientPause::ALL)];
+    return num_pauses > 0;
   });
-}
-
-void ServerState::AwaitOnPauseDispatch() {
-  pause_dispatch_ec_.await([this]() {
-    if (pause_dispatch_) {
-      return false;
-    }
-    return true;
-  });
-}
-
-void ServerState::SetPauseDispatch(bool pause) {
-  pause_dispatch_ = pause;
-  if (!pause_dispatch_) {
-    pause_dispatch_ec_.notifyAll();
-  }
 }
 
 Interpreter* ServerState::BorrowInterpreter() {

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -127,7 +127,7 @@ void ServerState::AwaitPauseState(bool is_write) {
 }
 
 bool ServerState::IsPaused() const {
-  return client_pauses_[0] + client_pauses_[1] > 0;
+  return (client_pauses_[0] + client_pauses_[1]) > 0;
 }
 
 Interpreter* ServerState::BorrowInterpreter() {

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -121,9 +121,8 @@ void ServerState::SetPauseState(ClientPause state, bool start) {
 
 void ServerState::AwaitPauseState(bool is_write) {
   client_pause_ec_.await([is_write, this]() {
-    int num_pauses =
-        is_write ? client_pauses_[int(ClientPause::WRITE)] : client_pauses_[int(ClientPause::ALL)];
-    return num_pauses > 0;
+    return client_pauses_[int(ClientPause::ALL)] == 0 &&
+           (!is_write || client_pauses_[int(ClientPause::WRITE)] == 0);
   });
 }
 

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -231,12 +231,6 @@ class ServerState {  // public struct - to allow initialization.
   // @is_write controls whether the command is a write command or not.
   void AwaitPauseState(bool is_write);
 
-  // Toggle a boolean indicating whether the server should temporarily pause or allow dispatching
-  // new commands.
-  void SetPauseDispatch(bool pause);
-  // Awaits until dispatching new commands is allowed as determinded by SetPauseDispatch function
-  void AwaitOnPauseDispatch();
-
   SlowLogShard& GetSlowLog() {
     return slow_log_shard_;
   };

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -254,8 +254,6 @@ class ServerState {  // public struct - to allow initialization.
   // notified when the break is over.
   int client_pauses_[2] = {};
   EventCount client_pause_ec_;
-  bool pause_dispatch_ = false;
-  EventCount pause_dispatch_ec_;
 
   using Counter = util::SlidingCounter<7>;
   Counter qps_;

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -231,6 +231,8 @@ class ServerState {  // public struct - to allow initialization.
   // @is_write controls whether the command is a write command or not.
   void AwaitPauseState(bool is_write);
 
+  bool IsPaused() const;
+
   SlowLogShard& GetSlowLog() {
     return slow_log_shard_;
   };

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1763,6 +1763,7 @@ async def test_search(df_local_factory):
     ].id == "k0"
 
 
+# @pytest.mark.slow
 @pytest.mark.asyncio
 async def test_client_pause_with_replica(df_local_factory, df_seeder_factory):
     master = df_local_factory.create(proactor_threads=4)


### PR DESCRIPTION
#### Extends AwaitDispatches to be a re-usable DispatchTracker
  In contrast to an AwaitDispatches() call, the tracker can be used to track connection dispatches _exactly when_ the state is changed, so we actually wait for the right commands to finish, not for anything that is running roughly at the same time

#### Re-adopt CLIENT PAUSE to use it
  * Removes the dispatch pause as we don't need it anymore when we exclude paused commands from tracking
  * Fixes the bug with multiple client pauses not being possible (because the old AwaitDispatches doesn't detect paused ones)

#### Adds tracking to cluster family
 * Let's decide or put it off again 😅 