### PR TITLE
fix(server): client pause fix on pipeline squash

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1265,9 +1265,8 @@ void Service::DispatchManyCommands(absl::Span<CmdArgList> args_list,
     // invocations, we can potentially execute multiple eval in parallel, which is very powerful
     // paired with shardlocal eval
     const bool is_eval = CO::IsEvalKind(ArgS(args, 0));
-    const bool is_pause = dfly::ServerState::tlocal()->IsPaused();
 
-    if (!is_multi && !is_eval && cid != nullptr && !is_pause) {
+    if (!is_multi && !is_eval && cid != nullptr) {
       stored_cmds.reserve(args_list.size());
       stored_cmds.emplace_back(cid, tail_args);
       continue;

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -119,10 +119,6 @@ void ServerState::SetPauseState(ClientPause state, bool start) {
   }
 }
 
-bool ServerState::IsPaused() const {
-  return client_pauses_[0] || client_pauses_[1];
-}
-
 void ServerState::AwaitPauseState(bool is_write) {
   client_pause_ec_.await([is_write, this]() {
     if (client_pauses_[int(ClientPause::ALL)]) {

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -227,9 +227,6 @@ class ServerState {  // public struct - to allow initialization.
   // whether this is starting or ending the pause.
   void SetPauseState(ClientPause state, bool start);
 
-  // Returns whether any type of commands is paused.
-  bool IsPaused() const;
-
   // Awaits until the pause is over and the command can execute.
   // @is_write controls whether the command is a write command or not.
   void AwaitPauseState(bool is_write);

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1763,8 +1763,6 @@ async def test_search(df_local_factory):
     ].id == "k0"
 
 
-# @pytest.mark.slow
-@pytest.mark.skip(reason="Client pause command bug with pipeline squashing")
 @pytest.mark.asyncio
 async def test_client_pause_with_replica(df_local_factory, df_seeder_factory):
     master = df_local_factory.create(proactor_threads=4)


### PR DESCRIPTION
1. allow squashing commands on pause
2. move await on client pause inside InvokeCommand - this way all flows of command invoke will read pause state