### PR TITLE
feat(helm): add priority class name for pod

### DIFF
--- a/contrib/charts/dragonfly/ci/priorityclassname-values.golden.yaml
+++ b/contrib/charts/dragonfly/ci/priorityclassname-values.golden.yaml
@@ -1,0 +1,103 @@
+---
+# Source: dragonfly/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-dragonfly
+  namespace: default
+  labels:
+    app.kubernetes.io/name: dragonfly
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "v1.12.1"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: dragonfly/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-dragonfly
+  namespace: default
+  labels:
+    app.kubernetes.io/name: dragonfly
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "v1.12.1"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      targetPort: dragonfly
+      protocol: TCP
+      name: dragonfly
+  selector:
+    app.kubernetes.io/name: dragonfly
+    app.kubernetes.io/instance: test
+---
+# Source: dragonfly/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-dragonfly
+  namespace: default
+  labels:
+    app.kubernetes.io/name: dragonfly
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "v1.12.1"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dragonfly
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      annotations:
+      labels:
+        app.kubernetes.io/name: dragonfly
+        app.kubernetes.io/instance: test
+    spec:
+      priorityClassName: high-priority
+      serviceAccountName: test-dragonfly
+      containers:
+        - name: dragonfly
+          image: "docker.dragonflydb.io/dragonflydb/dragonfly:v1.12.1"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: dragonfly
+              containerPort: 6379
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - /usr/local/bin/healthcheck.sh
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - /usr/local/bin/healthcheck.sh
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          args:
+            - "--alsologtostderr"
+          resources:
+            limits: {}
+            requests: {}
+---
+# Source: dragonfly/templates/extra-manifests.yaml
+apiVersion: scheduling.k8s.io/v1
+description: This priority class should be used only for tests.
+globalDefault: false
+kind: PriorityClass
+metadata:
+  name: high-priority
+value: 1000000

--- a/contrib/charts/dragonfly/ci/priorityclassname-values.yaml
+++ b/contrib/charts/dragonfly/ci/priorityclassname-values.yaml
@@ -1,0 +1,10 @@
+priorityClassName: "high-priority"
+
+extraObjects:
+  - apiVersion: scheduling.k8s.io/v1
+    kind: PriorityClass
+    metadata:
+      name: high-priority
+    value: 1000000
+    globalDefault: false
+    description: "This priority class should be used only for tests."

--- a/contrib/charts/dragonfly/templates/_pod.tpl
+++ b/contrib/charts/dragonfly/templates/_pod.tpl
@@ -16,6 +16,9 @@ volumeMounts:
 {{- end }}
 
 {{- define "dragonfly.pod" -}}
+{{- if ne .Values.priorityClassName "" }}
+priorityClassName: {{ .Values.priorityClassName }}
+{{- end }}
 {{- with .Values.tolerations }}
 tolerations:
   {{- toYaml . | trim | nindent 2 -}}

--- a/contrib/charts/dragonfly/values.yaml
+++ b/contrib/charts/dragonfly/values.yaml
@@ -193,6 +193,9 @@ resources:
   #   cpu: 100m
   #   memory: 128Mi
 
+# -- Priority class name for pod assignment
+priorityClassName: ""
+
 # -- Node labels for pod assignment
 nodeSelector: {}
 


### PR DESCRIPTION
We use scalers that can place pods according to [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/).
We don’t want dragonfly to be removed as a result of high load on node. 
Not sure if it's right to do it here or using a post renderer.