### PR TITLE
chore: connection fixes

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -220,7 +220,7 @@ size_t Connection::MessageHandle::UsedMemory() const {
 }
 
 bool Connection::MessageHandle::IsIntrusive() const {
-  return holds_alternative<AclUpdateMessage>(handle) ||
+  return holds_alternative<AclUpdateMessagePtr>(handle) ||
          holds_alternative<CheckpointMessage>(handle);
 }
 

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -203,8 +203,10 @@ size_t Connection::MessageHandle::UsedMemory() const {
     size_t operator()(const MonitorMessage& msg) {
       return msg.capacity();
     }
-    size_t operator()(const AclUpdateMessage& msg) {
-      return 0;
+    size_t operator()(const AclUpdateMessagePtr& msg) {
+      return sizeof(AclUpdateMessage) + msg->username.capacity() * sizeof(string) +
+             msg->commands.capacity() * sizeof(vector<int>) +
+             msg->categories.capacity() * sizeof(uint32_t);
     }
     size_t operator()(const MigrationRequestMessage& msg) {
       return 0;
@@ -1150,7 +1152,7 @@ void Connection::SendMonitorMessageAsync(string msg) {
 }
 
 void Connection::SendAclUpdateAsync(AclUpdateMessage msg) {
-  SendAsync({std::move(msg)});
+  SendAsync({make_unique<AclUpdateMessage>(std::move(msg))});
 }
 
 void Connection::SendCheckpoint(fb2::BlockingCounter bc) {

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -824,6 +824,8 @@ void Connection::HandleMigrateRequest() {
     queue_backpressure_ = &tl_queue_backpressure_;
   }
 
+  DCHECK(dispatch_q_.empty());
+
   // In case we Yield()ed in Migrate() above, dispatch_fb_ might have been started.
   LaunchDispatchFiberIfNeeded();
 }
@@ -1045,7 +1047,7 @@ void Connection::DispatchFiber(util::FiberSocketBase* peer) {
 
       if (ShouldEndDispatchFiber(msg)) {
         RecycleMessage(std::move(msg));
-        DCHECK(dispatch_q_.empty());
+        CHECK(dispatch_q_.empty());
         return;  // don't set conn closing flag
       }
 

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1166,7 +1166,6 @@ void Connection::SendAsync(MessageHandle msg) {
   DCHECK(cc_);
   DCHECK(owner());
   DCHECK_EQ(ProactorBase::me(), socket_->proactor());
-  DCHECK_NE(phase_, PRECLOSE);  // No more messages are processed after this point
 
   // "Closing" connections might be still processing commands, as we don't interrupt them.
   // So we still want to deliver control messages to them (like checkpoints).
@@ -1176,6 +1175,8 @@ void Connection::SendAsync(MessageHandle msg) {
   // If we launch while closing, it won't be awaited. Control messages will be processed on cleanup.
   if (!cc_->conn_closing)
     LaunchDispatchFiberIfNeeded();
+
+  DCHECK_NE(phase_, PRECLOSE);  // No more messages are processed after this point
 
   size_t used_mem = msg.UsedMemory();
   queue_backpressure_->bytes.fetch_add(used_mem, memory_order_relaxed);

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -240,8 +240,8 @@ class Connection : public util::Connection {
     dfly::EventCount ec;
     std::atomic_size_t subscriber_bytes = 0;
 
-    size_t subsciber_thread_limit = 0;  // cached flag subsciber_thread_limit
-    size_t pipeline_cache_limit = 0;    // cached flag pipeline_cache_limit
+    size_t subscriber_thread_limit = 0;  // cached flag subscriber_thread_limit
+    size_t pipeline_cache_limit = 0;     // cached flag pipeline_cache_limit
   };
 
  private:

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -231,18 +231,17 @@ class Connection : public util::Connection {
   struct Shutdown;
 
   // Keeps track of total per-thread sizes of dispatch queues to
-  // limit memory taken up by pipelined / pubsub commands and slow down clients
+  // limit memory taken up by messages from PUBLISH commands and slow down clients
   // producing them to quickly via EnsureAsyncMemoryBudget.
-  // Currently we provide backpressure only to pubsub's PUBLISH.
   struct QueueBackpressure {
     // Block until memory usage is below limit, can be called from any thread
     void EnsureBelowLimit();
 
     dfly::EventCount ec;
-    std::atomic_size_t pub_bytes = 0;
+    std::atomic_size_t subscriber_bytes = 0;
 
-    size_t pipeline_queue_limit = 0;  // cached flag pipeline_queue_limit
-    size_t pipeline_cache_limit = 0;  // cached flag pipeline_cache_limit
+    size_t subsciber_thread_limit = 0;  // cached flag subsciber_thread_limit
+    size_t pipeline_cache_limit = 0;    // cached flag pipeline_cache_limit
   };
 
  private:

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -120,6 +120,7 @@ class Connection : public util::Connection {
   // Requests are allocated on the mimalloc heap and thus require a custom deleter.
   using PipelineMessagePtr = std::unique_ptr<PipelineMessage, MessageDeleter>;
   using PubMessagePtr = std::unique_ptr<PubMessage, MessageDeleter>;
+  using AclUpdateMessagePtr = std::unique_ptr<AclUpdateMessage>;
 
   // Variant wrapper around different message types
   struct MessageHandle {
@@ -132,10 +133,13 @@ class Connection : public util::Connection {
     bool IsPipelineMsg() const;
     bool IsPubMsg() const;
 
-    std::variant<MonitorMessage, PubMessagePtr, PipelineMessagePtr, AclUpdateMessage,
+    std::variant<MonitorMessage, PubMessagePtr, PipelineMessagePtr, AclUpdateMessagePtr,
                  MigrationRequestMessage, CheckpointMessage>
         handle;
   };
+
+  static_assert(sizeof(MessageHandle) <= 40,
+                "Big structs should use indirection to avoid wasting deque space!");
 
   enum Phase { SETUP, READ_SOCKET, PROCESS, SHUTTING_DOWN, PRECLOSE, NUM_PHASES };
 

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -285,6 +285,9 @@ class Connection : public util::Connection {
   // Squashes pipelined commands from the dispatch queue to spread load over all threads
   void SquashPipeline(facade::SinkReplyBuilder*);
 
+  // Clear pipelined messages, disaptching only intrusive ones.
+  void ClearPipelinedMessages();
+
  private:
   std::pair<std::string, std::string> GetClientInfoBeforeAfterTid() const;
   std::deque<MessageHandle> dispatch_q_;  // dispatch queue

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -136,7 +136,7 @@ class Connection : public util::Connection {
         handle;
   };
 
-  enum Phase { SETUP, READ_SOCKET, PROCESS, NUM_PHASES };
+  enum Phase { SETUP, READ_SOCKET, PROCESS, SHUTTING_DOWN, PRECLOSE, NUM_PHASES };
 
  public:
   // Add PubMessage to dispatch queue.

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -153,8 +153,8 @@ class Connection : public util::Connection {
   // decrement it once finished.
   void SendCheckpoint(util::fb2::BlockingCounter bc);
 
-  // Must be called before SendAsync to ensure the connection dispatch queue is not overfilled.
-  // Blocks until free space is available.
+  // Must be called before SendAsync to ensure the threads pipeline queue limit is not reached.
+  // Blocks until free space is available. Controlled with `pipeline_queue_limit` flag.
   void EnsureAsyncMemoryBudget();
 
   // Register hook that is executed on connection shutdown.

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -27,11 +27,12 @@ constexpr size_t kSizeConnStats = sizeof(ConnectionStats);
 
 ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
   // To break this code deliberately if we add/remove a field to this struct.
-  static_assert(kSizeConnStats == 136u);
+  static_assert(kSizeConnStats == 144u);
 
   ADD(read_buf_capacity);
   ADD(dispatch_queue_entries);
   ADD(dispatch_queue_bytes);
+  ADD(dispatch_queue_pub_bytes);
   ADD(pipeline_cmd_cache_bytes);
   ADD(io_read_cnt);
   ADD(io_read_bytes);

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -32,7 +32,7 @@ ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
   ADD(read_buf_capacity);
   ADD(dispatch_queue_entries);
   ADD(dispatch_queue_bytes);
-  ADD(dispatch_queue_pub_bytes);
+  ADD(dispatch_queue_subscriber_bytes);
   ADD(pipeline_cmd_cache_bytes);
   ADD(io_read_cnt);
   ADD(io_read_bytes);

--- a/src/facade/facade_types.h
+++ b/src/facade/facade_types.h
@@ -39,10 +39,10 @@ struct CmdArgListFormatter {
 struct ConnectionStats {
   absl::flat_hash_map<std::string, uint64_t> err_count_map;
 
-  size_t read_buf_capacity = 0;         // total capacity of input buffers
-  size_t dispatch_queue_entries = 0;    // total number of dispatch queue entries
-  size_t dispatch_queue_bytes = 0;      // total size of all dispatch queue entries
-  size_t dispatch_queue_pub_bytes = 0;  // total size of all publish messages
+  size_t read_buf_capacity = 0;                // total capacity of input buffers
+  size_t dispatch_queue_entries = 0;           // total number of dispatch queue entries
+  size_t dispatch_queue_bytes = 0;             // total size of all dispatch queue entries
+  size_t dispatch_queue_subscriber_bytes = 0;  // total size of all publish messages
 
   size_t pipeline_cmd_cache_bytes = 0;
 

--- a/src/facade/facade_types.h
+++ b/src/facade/facade_types.h
@@ -39,9 +39,10 @@ struct CmdArgListFormatter {
 struct ConnectionStats {
   absl::flat_hash_map<std::string, uint64_t> err_count_map;
 
-  size_t read_buf_capacity = 0;       // total capacity of input buffers
-  size_t dispatch_queue_entries = 0;  // total number of dispatch queue entries
-  size_t dispatch_queue_bytes = 0;    // total size of all dispatch queue entries
+  size_t read_buf_capacity = 0;         // total capacity of input buffers
+  size_t dispatch_queue_entries = 0;    // total number of dispatch queue entries
+  size_t dispatch_queue_bytes = 0;      // total size of all dispatch queue entries
+  size_t dispatch_queue_pub_bytes = 0;  // total size of all publish messages
 
   size_t pipeline_cmd_cache_bytes = 0;
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2076,14 +2076,21 @@ void Service::Publish(CmdArgList args, ConnectionContext* cntx) {
   int num_published = subscribers.size();
 
   if (!subscribers.empty()) {
-    // Make sure neither of the subscribers buffers is filled up.
+    // Make sure neither of the threads limits is reached.
     // This check actually doesn't reserve any memory ahead and doesn't prevent the buffer
-    // from eventually filling up, especially if multiple clients are unblocked simultaneously
+    // from eventually filling up, especially if multiple clients are unblocked simultaneously,
     // but is generally good enough to limit too fast producers.
     // Most importantly, this approach allows not blocking and not awaiting in the dispatch below,
     // thus not adding any overhead to backpressure checks.
-    for (auto& sub : subscribers)
+    optional<uint32_t> last_thread;
+    for (auto& sub : subscribers) {
+      DCHECK_LE(last_thread.value_or(0), sub.thread_id);
+      if (last_thread && *last_thread == sub.thread_id)  // skip same thread
+        continue;
+
       sub.conn_cntx->conn()->EnsureAsyncMemoryBudget();
+      last_thread = sub.thread_id;
+    }
 
     auto subscribers_ptr = make_shared<decltype(subscribers)>(std::move(subscribers));
     auto buf = shared_ptr<char[]>{new char[channel.size() + msg.size()]};

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2335,25 +2335,22 @@ void Service::OnClose(facade::ConnectionContext* cntx) {
   ConnectionState& conn_state = server_cntx->conn_state;
 
   if (conn_state.subscribe_info) {  // Clean-ups related to PUBSUB
-    optional<BlockingCounter> token;
-
     if (!conn_state.subscribe_info->channels.empty()) {
-      token = conn_state.subscribe_info->borrow_token;
+      auto token = conn_state.subscribe_info->borrow_token;
       server_cntx->UnsubscribeAll(false);
+
+      // Check that all borrowers finished processing.
+      // token is increased in channel_slice (the publisher side).
+      token.Wait();
     }
 
     if (conn_state.subscribe_info) {
       DCHECK(!conn_state.subscribe_info->patterns.empty());
-      // DCHECK(!token || *token == conn_state.subscribe_info->borrow_token);
 
-      token = conn_state.subscribe_info->borrow_token;
+      auto token = conn_state.subscribe_info->borrow_token;
       server_cntx->PUnsubscribeAll(false);
+      token.Wait();  // Same as above
     }
-
-    // Check that all borrowers finished processing.
-    // The tokens are increased in channel_slice (the publisher side).
-    if (token)
-      token->Wait();
 
     DCHECK(!conn_state.subscribe_info);
   }

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1635,6 +1635,7 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
     append("small_string_bytes", m.small_string_bytes);
     append("pipeline_cache_bytes", m.conn_stats.pipeline_cmd_cache_bytes);
     append("dispatch_queue_bytes", m.conn_stats.dispatch_queue_bytes);
+    append("dispatch_queue_pub_bytes", m.conn_stats.dispatch_queue_bytes);
     append("dispatch_queue_peak_bytes", m.peak_stats.conn_dispatch_queue_bytes);
     append("client_read_buffer_peak_bytes", m.peak_stats.conn_read_buf_capacity);
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1635,7 +1635,7 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
     append("small_string_bytes", m.small_string_bytes);
     append("pipeline_cache_bytes", m.conn_stats.pipeline_cmd_cache_bytes);
     append("dispatch_queue_bytes", m.conn_stats.dispatch_queue_bytes);
-    append("dispatch_queue_pub_bytes", m.conn_stats.dispatch_queue_bytes);
+    append("dispatch_queue_subscriber_bytes", m.conn_stats.dispatch_queue_subscriber_bytes);
     append("dispatch_queue_peak_bytes", m.peak_stats.conn_dispatch_queue_bytes);
     append("client_read_buffer_peak_bytes", m.peak_stats.conn_read_buf_capacity);
 

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -287,6 +287,50 @@ async def test_multi_pubsub(async_client):
     assert state, message
 
 
+"""
+Test that pubsub clients who are stuck on backpressure from a slow client (the one in the test doesn't read messages at all)
+will eventually unblock when it disconnects.
+"""
+
+
+@pytest.mark.asyncio
+@pytest.mark.slow
+@dfly_args({"proactor_threads": "1", "pipeline_queue_limit": "100"})
+async def test_publish_stuck(df_server: DflyInstance, async_client: aioredis.Redis):
+    reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port, limit=10)
+    writer.write(b"SUBSCRIBE channel\r\n")
+    await writer.drain()
+
+    async def pub_task():
+        payload = "msg" * 1000
+        p = async_client.pipeline()
+        for _ in range(1000):
+            p.publish("channel", payload)
+        await p.execute()
+
+    publishers = [asyncio.create_task(pub_task()) for _ in range(20)]
+
+    await asyncio.sleep(5)
+
+    # Check we reached the limit
+    pub_bytes = int((await async_client.info())["dispatch_queue_pub_bytes"])
+    assert pub_bytes >= 100
+
+    await asyncio.sleep(0.1)
+
+    # Make sure processing is stalled
+    new_pub_bytes = int((await async_client.info())["dispatch_queue_pub_bytes"])
+    assert new_pub_bytes == pub_bytes
+
+    writer.write(b"QUIT\r\n")
+    await writer.drain()
+    writer.close()
+
+    # Make sure all publishers unblock eventually
+    for pub in asyncio.as_completed(publishers):
+        await pub
+
+
 @pytest.mark.asyncio
 async def test_subscribers_with_active_publisher(df_server: DflyInstance, max_connections=100):
     # TODO: I am not how to customize the max connections for the pool.


### PR DESCRIPTION
* Add more connection state
* Fix dispatch of pipelined messages during connection closing state
* Skip same thread backpressure for publish producers
* Don't partially wait on borrow token
* Reduce size of Message by two 
* Small fixes

Now the pipelining logic does not throttle itself, only pubsub throttles if the subsriber thread is overflown. 