### PR TITLE
fix(replication): fix cancel replication race

### DIFF
--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -133,8 +133,10 @@ void Replica::EnableReplication(ConnectionContext* cntx) {
 void Replica::Stop() {
   VLOG(1) << "Stopping replication";
   // Stops the loop in MainReplicationFb.
-  state_mask_.store(0);  // Specifically ~R_ENABLED.
+  // Note: we must call cntx_.Cancel() before reseting state, to make sure we dont have race between
+  // Start and Stop. In Start we store R_ENABLED and after we check of cancel.
   cntx_.Cancel();        // Context is fully resposible for cleanup.
+  state_mask_.store(0);  // Specifically ~R_ENABLED.
 
   waker_.notifyAll();
 

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -156,6 +156,7 @@ class Replica : ProtocolClient {
   std::string GetSyncId() const;
 
  private:
+  util::fb2::ProactorBase* proactor_ = nullptr;
   Service& service_;
   MasterContext master_context_;
 


### PR DESCRIPTION
The bug: One connection calls replica start and second call replica stop. In this flow stop first reset state mask state_mask_.store(0), Start sets state mask state_mask_.store(R_ENABLED) continues to greet and create main replication fiber and then stop runs cntx_.Cancel(), which will at later be reset inside the main replication fiber. In this flow main replication fiber does not cancel and the connection calling to Stop is deadlocked waiting to join the main replication fiber.

The fix: run cntx_.Cancel() and state_mask_.store(0) in replica thread.

```mermaid
flowchart TD
    A[Start] --> T[Time:T0]
    T --> E["state |=Enabled"]
    E -->  F[FiberDispatch]
   B[Stop] --> R["state=0"] 
   R --> T2[Time:T0] 
   T2 --> T3[Time:T1]
   T3 --> CC["Context.Cancel()"] 
   CC --> D[JoinFiber/Deadlock]
   T <--> T2
   T4[Time:T1] <--> T3
   FS[FiberStart] --> W["While (state & enabled)"]
   W --> T4
   T4 --> ER["if context.error() then continue"]
   ER --> W
```
