### PR TITLE
fix(squashing): Reset base command id

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1242,6 +1242,9 @@ void Service::DispatchManyCommands(absl::Span<CmdArgList> args_list,
     if (!dist_trans) {
       dist_trans.reset(new Transaction{exec_cid_});
       dist_trans->StartMultiNonAtomic();
+    } else {
+      // Reset to original command id as it's changed during squashing
+      dist_trans->MultiSwitchCmd(exec_cid_);
     }
 
     dfly_cntx->transaction = dist_trans.get();


### PR DESCRIPTION
The multi command squasher takes it's base command id (EXEC or EVAL or EVALSHA) from the context. Then the context is modified to run different commands on it. Whenever collection is interrupted inside pipeline squashing due to a nested multi-transaction, we don't reset the base command when we continue using the context.