### PR TITLE
chore: improve performance of mget operation

### DIFF
--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -36,6 +36,14 @@ DoubleToStringConverter dfly_conv(kConvFlags, "inf", "nan", 'e', -6, 21, 6, 0);
 
 }  // namespace
 
+SinkReplyBuilder::MGetResponse::~MGetResponse() {
+  while (storage_list) {
+    auto* next = storage_list->next;
+    delete[] reinterpret_cast<char*>(storage_list);
+    storage_list = next;
+  }
+}
+
 SinkReplyBuilder::SinkReplyBuilder(::io::Sink* sink)
     : sink_(sink), should_batch_(false), should_aggregate_(false), has_replied_(true) {
 }
@@ -187,11 +195,11 @@ void MCReplyBuilder::SendLong(long val) {
   SendSimpleString(string_view(buf, next - buf));
 }
 
-void MCReplyBuilder::SendMGetResponse(absl::Span<const OptResp> arr) {
+void MCReplyBuilder::SendMGetResponse(MGetResponse resp) {
   string header;
-  for (unsigned i = 0; i < arr.size(); ++i) {
-    if (arr[i]) {
-      const auto& src = *arr[i];
+  for (unsigned i = 0; i < resp.resp_arr.size(); ++i) {
+    if (resp.resp_arr[i]) {
+      const auto& src = *resp.resp_arr[i];
       absl::StrAppend(&header, "VALUE ", src.key, " ", src.mc_flag, " ", src.value.size());
       if (src.mc_ver) {
         absl::StrAppend(&header, " ", src.mc_ver);
@@ -365,12 +373,13 @@ void RedisReplyBuilder::SendDouble(double val) {
   }
 }
 
-void RedisReplyBuilder::SendMGetResponse(absl::Span<const OptResp> arr) {
-  string res = absl::StrCat("*", arr.size(), kCRLF);
-  for (size_t i = 0; i < arr.size(); ++i) {
-    if (arr[i]) {
-      StrAppend(&res, "$", arr[i]->value.size(), kCRLF);
-      res.append(arr[i]->value).append(kCRLF);
+void RedisReplyBuilder::SendMGetResponse(MGetResponse resp) {
+  string res = absl::StrCat("*", resp.resp_arr.size(), kCRLF);
+  for (size_t i = 0; i < resp.resp_arr.size(); ++i) {
+    const auto& item = resp.resp_arr[i];
+    if (item) {
+      StrAppend(&res, "$", item->value.size(), kCRLF);
+      res.append(item->value).append(kCRLF);
     } else {
       res.append(NullString());
     }

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -23,22 +23,59 @@ enum class ReplyMode {
 
 class SinkReplyBuilder {
  public:
-  struct ResponseValue {
-    std::string key;
-    std::string value;
-    uint64_t mc_ver = 0;  // 0 means we do not output it (i.e has not been requested).
-    uint32_t mc_flag = 0;
+  struct MGetStorage {
+    MGetStorage* next = nullptr;
+    char data[1];
   };
 
-  using OptResp = std::optional<ResponseValue>;
+  struct GetResp {
+    std::string key;  // TODO: to use backing storage to optimize this as well.
+    std::string_view value;
 
- public:
+    uint64_t mc_ver = 0;  // 0 means we do not output it (i.e has not been requested).
+    uint32_t mc_flag = 0;
+
+    GetResp() = default;
+    GetResp(std::string_view val) : value(val) {
+    }
+  };
+
+  struct MGetResponse {
+    MGetStorage* storage_list = nullptr;  // backing storage of resp_arr values.
+    std::vector<std::optional<GetResp>> resp_arr;
+
+    MGetResponse() = default;
+
+    MGetResponse(size_t size) : resp_arr(size) {
+    }
+
+    ~MGetResponse();
+
+    MGetResponse(MGetResponse&& other) noexcept
+        : storage_list(other.storage_list), resp_arr(std::move(other.resp_arr)) {
+      other.storage_list = nullptr;
+    }
+
+    MGetResponse& operator=(MGetResponse&& other) noexcept {
+      resp_arr = std::move(other.resp_arr);
+      storage_list = other.storage_list;
+      other.storage_list = nullptr;
+      return *this;
+    }
+  };
+
   SinkReplyBuilder(const SinkReplyBuilder&) = delete;
   void operator=(const SinkReplyBuilder&) = delete;
 
   SinkReplyBuilder(::io::Sink* sink);
 
   virtual ~SinkReplyBuilder() {
+  }
+
+  static MGetStorage* AllocMGetStorage(size_t size) {
+    static_assert(alignof(MGetStorage) == 8);  // if this breaks we should fix the code below.
+    char* buf = new char[size + sizeof(MGetStorage)];
+    return new (buf) MGetStorage();
   }
 
   virtual void SendError(std::string_view str, std::string_view type = {}) = 0;  // MC and Redis
@@ -48,7 +85,7 @@ class SinkReplyBuilder {
   virtual void SendStored() = 0;  // Reply for set commands.
   virtual void SendSetSkipped() = 0;
 
-  virtual void SendMGetResponse(absl::Span<const OptResp>) = 0;
+  virtual void SendMGetResponse(MGetResponse resp) = 0;
 
   virtual void SendLong(long val) = 0;
   virtual void SendSimpleString(std::string_view str) = 0;
@@ -151,7 +188,7 @@ class MCReplyBuilder : public SinkReplyBuilder {
   void SendError(std::string_view str, std::string_view type = std::string_view{}) final;
 
   // void SendGetReply(std::string_view key, uint32_t flags, std::string_view value) final;
-  void SendMGetResponse(absl::Span<const OptResp>) final;
+  void SendMGetResponse(MGetResponse resp) final;
 
   void SendStored() final;
   void SendLong(long val) final;
@@ -182,7 +219,7 @@ class RedisReplyBuilder : public SinkReplyBuilder {
   void SendError(std::string_view str, std::string_view type = {}) override;
   using SinkReplyBuilder::SendError;
 
-  void SendMGetResponse(absl::Span<const OptResp>) override;
+  void SendMGetResponse(MGetResponse resp) override;
 
   void SendStored() override;
   void SendSetSkipped() override;

--- a/src/facade/reply_capture.h
+++ b/src/facade/reply_capture.h
@@ -25,7 +25,7 @@ class CapturingReplyBuilder : public RedisReplyBuilder {
  public:
   void SendError(std::string_view str, std::string_view type = {}) override;
   void SendError(ErrorReply error) override;
-  void SendMGetResponse(absl::Span<const OptResp>) override;
+  void SendMGetResponse(MGetResponse resp) override;
 
   // SendStored -> SendSimpleString("OK")
   // SendSetSkipped -> SendNull()
@@ -71,9 +71,9 @@ class CapturingReplyBuilder : public RedisReplyBuilder {
       : RedisReplyBuilder{nullptr}, reply_mode_{mode}, stack_{}, current_{} {
   }
 
-  using Payload = std::variant<std::monostate, Null, Error, OpStatus, long, double, SimpleString,
-                               BulkString, StrArrPayload, std::unique_ptr<CollectionPayload>,
-                               std::vector<OptResp>, ScoredArray>;
+  using Payload =
+      std::variant<std::monostate, Null, Error, OpStatus, long, double, SimpleString, BulkString,
+                   StrArrPayload, std::unique_ptr<CollectionPayload>, MGetResponse, ScoredArray>;
 
   // Non owned Error based on SendError arguments (msg, type)
   using ErrorRef = std::pair<std::string_view, std::string_view>;

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -404,7 +404,7 @@ OpResult<uint32_t> OpDel(const OpArgs& op_args, string_view key, CmdArgList valu
   return deleted;
 }
 
-OpResult<vector<OptStr>> OpMGet(const OpArgs& op_args, std::string_view key, CmdArgList fields) {
+OpResult<vector<OptStr>> OpHMGet(const OpArgs& op_args, std::string_view key, CmdArgList fields) {
   DCHECK(!fields.empty());
 
   auto& db_slice = op_args.shard->db_slice();
@@ -801,7 +801,7 @@ void HSetFamily::HMGet(CmdArgList args, ConnectionContext* cntx) {
 
   args.remove_prefix(1);
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpMGet(t->GetOpArgs(shard), key, args);
+    return OpHMGet(t->GetOpArgs(shard), key, args);
   };
 
   OpResult<vector<OptStr>> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -973,7 +973,7 @@ OpResult<vector<OptLong>> OpArrIndex(const OpArgs& op_args, string_view key,
 }
 
 // Returns string vector that represents the query result of each supplied key.
-vector<OptString> OpMGet(JsonExpression expression, const Transaction* t, EngineShard* shard) {
+vector<OptString> OpJsonMGet(JsonExpression expression, const Transaction* t, EngineShard* shard) {
   auto args = t->GetShardArgs(shard->shard_id());
   DCHECK(!args.empty());
   vector<OptString> response(args.size());
@@ -1271,7 +1271,7 @@ void JsonFamily::MGet(CmdArgList args, ConnectionContext* cntx) {
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     ShardId sid = shard->shard_id();
-    mget_resp[sid] = OpMGet(ParseJsonPath(path, &ec), t, shard);
+    mget_resp[sid] = OpJsonMGet(ParseJsonPath(path, &ec), t, shard);
     return OpStatus::OK;
   };
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -282,7 +282,7 @@ class InterpreterReplier : public RedisReplyBuilder {
   void SendStored() final;
 
   void SendSimpleString(std::string_view str) final;
-  void SendMGetResponse(absl::Span<const OptResp>) final;
+  void SendMGetResponse(MGetResponse resp) final;
   void SendSimpleStrArr(StrSpan arr) final;
   void SendNullArray() final;
 
@@ -389,13 +389,13 @@ void InterpreterReplier::SendSimpleString(string_view str) {
   PostItem();
 }
 
-void InterpreterReplier::SendMGetResponse(absl::Span<const OptResp> arr) {
+void InterpreterReplier::SendMGetResponse(MGetResponse resp) {
   DCHECK(array_len_.empty());
 
-  explr_->OnArrayStart(arr.size());
-  for (uint32_t i = 0; i < arr.size(); ++i) {
-    if (arr[i].has_value()) {
-      explr_->OnString(arr[i]->value);
+  explr_->OnArrayStart(resp.resp_arr.size());
+  for (uint32_t i = 0; i < resp.resp_arr.size(); ++i) {
+    if (resp.resp_arr[i].has_value()) {
+      explr_->OnString(resp.resp_arr[i]->value);
     } else {
       explr_->OnNil();
     }

--- a/src/server/string_family.h
+++ b/src/server/string_family.h
@@ -96,16 +96,6 @@ class StringFamily {
   static void IncrByGeneric(std::string_view key, int64_t val, ConnectionContext* cntx);
   static void ExtendGeneric(CmdArgList args, bool prepend, ConnectionContext* cntx);
   static void SetExGeneric(bool seconds, CmdArgList args, ConnectionContext* cntx);
-
-  struct GetResp {
-    std::string value;
-    uint64_t mc_ver = 0;  // 0 means we do not output it (i.e has not been requested).
-    uint32_t mc_flag = 0;
-  };
-
-  using MGetResponse = std::vector<std::optional<GetResp>>;
-  static MGetResponse OpMGet(bool fetch_mcflag, bool fetch_mcver, const Transaction* t,
-                             EngineShard* shard);
 };
 
 }  // namespace dfly

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -341,7 +341,7 @@ class Transaction {
   // owned std::string because callbacks its used in run fully async and can outlive the entries.
   using KeyList = std::vector<std::pair<std::string, LockCnt>>;
 
-  struct PerShardData {
+  struct alignas(64) PerShardData {
     PerShardData(PerShardData&&) noexcept {
     }
 


### PR DESCRIPTION
Specifically, allocate only a single blob when returning multiple entries from a shard.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->