### PR TITLE
fix: fix cmd latency units in /metrics

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -513,11 +513,11 @@ uint32_t Connection::GetClientId() const {
 }
 
 bool Connection::IsPrivileged() const {
-  return static_cast<Listener*>(owner())->IsPrivilegedInterface();
+  return static_cast<Listener*>(listener())->IsPrivilegedInterface();
 }
 
 bool Connection::IsMain() const {
-  return static_cast<Listener*>(owner())->IsMainInterface();
+  return static_cast<Listener*>(listener())->IsMainInterface();
 }
 
 io::Result<bool> Connection::CheckForHttpProto(FiberSocketBase* peer) {
@@ -1158,7 +1158,7 @@ void Connection::Migrate(util::fb2::ProactorBase* dest) {
   CHECK_EQ(cc_->subscriptions, 0);    // are bound to thread local caches
   CHECK(!dispatch_fb_.IsJoinable());  // can't move once it started
 
-  owner()->Migrate(this, dest);
+  listener()->Migrate(this, dest);
 }
 
 void Connection::ShutdownThreadLocal() {
@@ -1202,7 +1202,7 @@ void Connection::LaunchDispatchFiberIfNeeded() {
 
 void Connection::SendAsync(MessageHandle msg) {
   DCHECK(cc_);
-  DCHECK(owner());
+  DCHECK(listener());
   DCHECK_EQ(ProactorBase::me(), socket_->proactor());
 
   // "Closing" connections might be still processing commands, as we don't interrupt them.

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -62,19 +62,19 @@ void CommandId::Invoke(CmdArgList args, ConnectionContext* cntx) const {
   int64_t after = absl::GetCurrentTimeNanos();
 
   ServerState* ss = ServerState::tlocal();  // Might have migrated thread, read after invocation
-  int64_t execution_time_micro_s = (after - before) / 1000;
+  int64_t execution_time_usec = (after - before) / 1000;
 
   const auto* conn = cntx->conn();
   auto& ent = command_stats_[ss->thread_index()];
   // TODO: we should probably discard more commands here,
   // not just the blocking ones
   if (!(opt_mask_ & CO::BLOCKING) && conn != nullptr && ss->GetSlowLog().Capacity() > 0 &&
-      execution_time_micro_s > ss->log_slower_than_usec) {
+      execution_time_usec > ss->log_slower_than_usec) {
     ss->GetSlowLog().Add(name(), args, conn->GetName(), conn->RemoteEndpointStr(),
-                         execution_time_micro_s, after);
+                         execution_time_usec, after);
   }
   ++ent.first;
-  ent.second += execution_time_micro_s;
+  ent.second += execution_time_usec;
 }
 
 optional<facade::ErrorReply> CommandId::Validate(CmdArgList tail_args) const {

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -60,7 +60,7 @@ static_assert(!IsEvalKind(""));
 
 };  // namespace CO
 
-// Per thread vector of command stats. Each entry is {cmd_calls, cmd_sum}.
+// Per thread vector of command stats. Each entry is {cmd_calls, cmd_latency_agg in usec}.
 using CmdCallStats = std::pair<uint64_t, uint64_t>;
 
 class CommandId : public facade::CommandId {

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -916,7 +916,7 @@ void PrintPrometheusMetrics(const Metrics& m, StringResponse* resp) {
                        &command_metrics);
     for (const auto& [name, stat] : m.cmd_stats_map) {
       const auto calls = stat.first;
-      const double duration_seconds = stat.second * 0.001;
+      const double duration_seconds = stat.second * 1e-6;
       AppendMetricValue("commands_total", calls, {"cmd"}, {name}, &command_metrics);
       AppendMetricValue("commands_duration_seconds_total", duration_seconds, {"cmd"}, {name},
                         &command_metrics);
@@ -939,13 +939,13 @@ void PrintPrometheusMetrics(const Metrics& m, StringResponse* resp) {
 
   AppendMetricWithoutLabels("fiber_switch_total", "", m.fiber_switch_cnt, MetricType::COUNTER,
                             &resp->body());
-  double delay_seconds = m.fiber_switch_delay_ns * 1e-9;
+  double delay_seconds = m.fiber_switch_delay_usec * 1e-6;
   AppendMetricWithoutLabels("fiber_switch_delay_seconds_total", "", delay_seconds,
                             MetricType::COUNTER, &resp->body());
 
   AppendMetricWithoutLabels("fiber_longrun_total", "", m.fiber_longrun_cnt, MetricType::COUNTER,
                             &resp->body());
-  double longrun_seconds = m.fiber_longrun_ns * 1e-9;
+  double longrun_seconds = m.fiber_longrun_usec * 1e-6;
   AppendMetricWithoutLabels("fiber_longrun_seconds_total", "", longrun_seconds, MetricType::COUNTER,
                             &resp->body());
 
@@ -1508,9 +1508,9 @@ Metrics ServerFamily::GetMetrics() const {
     lock_guard lk(mu);
 
     result.fiber_switch_cnt += fb2::FiberSwitchEpoch();
-    result.fiber_switch_delay_ns += fb2::FiberSwitchDelay();
+    result.fiber_switch_delay_usec += fb2::FiberSwitchDelayUsec();
     result.fiber_longrun_cnt += fb2::FiberLongRunCnt();
-    result.fiber_longrun_ns += fb2::FiberLongRunSum();
+    result.fiber_longrun_usec += fb2::FiberLongRunSumUsec();
 
     result.coordinator_stats += ss->stats;
     result.conn_stats += ss->connection_stats;

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -87,13 +87,14 @@ struct Metrics {
   uint32_t traverse_ttl_per_sec = 0;
   uint32_t delete_ttl_per_sec = 0;
   uint64_t fiber_switch_cnt = 0;
-  uint64_t fiber_switch_delay_ns = 0;
+  uint64_t fiber_switch_delay_usec = 0;
 
   // Statistics about fibers running for a long time (more than 1ms).
   uint64_t fiber_longrun_cnt = 0;
-  uint64_t fiber_longrun_ns = 0;
+  uint64_t fiber_longrun_usec = 0;
 
-  std::map<std::string, std::pair<uint64_t, uint64_t>> cmd_stats_map;  // command call frequencies
+  // command call frequencies (count, aggregated latency in usec).
+  std::map<std::string, std::pair<uint64_t, uint64_t>> cmd_stats_map;
 
   bool is_master = true;
   std::vector<ReplicaRoleInfo> replication_metrics;


### PR DESCRIPTION
Also,
1. rebase helio dependency
2. get rid of varz counters that are superseded by commands_total/commands_duration_seconds_total metrics

Resolves #2213 

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->