### PR TITLE
fix: memcached VERSION is now parseable by php-memcached client

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1335,7 +1335,7 @@ void Service::DispatchMC(const MemcacheParser::Command& cmd, std::string_view va
       server_family_.StatsMC(cmd.key, cntx);
       return;
     case MemcacheParser::VERSION:
-      mc_builder->SendSimpleString(StrCat("VERSION ", kGitTag));
+      mc_builder->SendSimpleString("VERSION 1.5.0 DF");
       return;
     default:
       mc_builder->SendClientError("bad command line format");

--- a/tests/dragonfly/pymemcached_test.py
+++ b/tests/dragonfly/pymemcached_test.py
@@ -38,6 +38,19 @@ def test_mixed_reply(memcached_connection):
 
 
 @dfly_args({"memcached_port": 11211})
+def test_version(memcached_connection: pymemcache.Client):
+    """
+    php-memcached client expects version to be in the format of "n.n.n",
+    so we return 1.5.0 emulating an old memcached server. Our real version is being returned in the stats command. Also verified manually that php client parses correctly the version string
+    that ends with "DF".
+    """
+    assert b"1.5.0 DF" == memcached_connection.version()
+    stats = memcached_connection.stats()
+    version = stats[b"version"].decode("utf-8")
+    assert version.startswith("v") or version == "dev"
+
+
+@dfly_args({"memcached_port": 11211})
 def test_length_in_set_command(df_server: DflyInstance):
     client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     client.connect(("127.0.0.1", 11211))


### PR DESCRIPTION
The DF version is being unparseable by Memcached::getVersion() that expects n.n.n string. Change the version to emulate the old memcached server. The DF version can still be fetched via Memcached::getStats() function.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->