### PR TITLE
feat(bitops_family): implement bitfield command

### DIFF
--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -143,6 +143,13 @@ struct CmdArgParser {
     return std::exchange(error_, {});
   }
 
+  bool HasAtLeast(size_t i) const {
+    if (i == 0) {
+      return false;
+    }
+    return cur_i_ + i <= args_.size() && !error_;
+  }
+
  private:
   template <class T, class... Cases>
   std::optional<std::decay_t<T>> SwitchImpl(std::string_view arg, std::string_view tag, T&& value,

--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -144,9 +144,6 @@ struct CmdArgParser {
   }
 
   bool HasAtLeast(size_t i) const {
-    if (i == 0) {
-      return false;
-    }
     return cur_i_ + i <= args_.size() && !error_;
   }
 

--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -853,7 +853,7 @@ class CommandApplyVisitor {
     return get.ApplyTo(overflow_, &bitfield_);
   }
 
-  Result operator()(auto& update) {
+  template <typename T> Result operator()(T& update) {
     should_commit_ = true;
     return update.ApplyTo(overflow_, &bitfield_);
   }

--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -6,7 +6,6 @@
 
 #include <bitset>
 
-#include "absl/base/internal/endian.h"
 #include "base/expected.hpp"
 #include "facade/op_status.h"
 
@@ -569,7 +568,7 @@ void BitCount(CmdArgList args, ConnectionContext* cntx) {
   if (args.size() == 2 || args.size() > 4) {
     return (*cntx)->SendError(kSyntaxErr);
   }
-  // return (*cntx)->SendLong(0);
+
   std::string_view key = ArgS(args, 0);
   bool as_bit = false;
   int64_t start = 0;
@@ -601,249 +600,262 @@ struct CommonAttributes {
   size_t offset;
 };
 
-struct Nill {};
-using ResultType = std::variant<int64_t, Nill>;
+// We either return the result of the subcommand (int64_t) or Nill (empty optional)
+// to represent overflow/underflow failures
+using ResultType = std::optional<int64_t>;
 
 struct Overflow {
   enum Policy { WRAP, SAT, FAIL };
 
-  static std::optional<Policy> PolicyFromStr(std::string_view policy) {
-    if (policy == "WRAP") {
-      return WRAP;
-    }
-    if (policy == "SAT") {
-      return SAT;
-    }
-    if (policy == "FAIL") {
-      return FAIL;
-    }
-    return {};
-  }
+  // Used to check for unsigned overflow/underflow.
+  // If incr is non zero, we check for overflows in the expression incr + *value
+  // If incr is zero, we check for overflows in the expression *value
+  // If the overflow fails because of Policy::FAIL, it returns false. Otherwise, true.
+  // The result of handling the overflow is stored in the pointer value
+  bool UIntOverflow(int64_t incr, size_t total_bits, int64_t* value) const;
 
-  bool UIntOverflow(int64_t* value, int64_t incr, size_t total_bits) const {
-    // total up to 63 bits -- we do not support 64 bit unsigned
-    const uint64_t max = (1UL << total_bits) - 1;
-
-    uint64_t incr_value = incr;
-    if (incr_value + *value > max) {
-      switch (type) {
-        case Overflow::WRAP:
-          // safe to do, won't overflow, both incr and value are <= than 2^63 - 1
-          *value = (incr_value + *value) % max;
-          break;
-        case Overflow::SAT:
-          *value = max;
-          break;
-        case Overflow::FAIL:
-          *value = 0;
-          return false;
-      }
-      return true;
-    }
-
-    *value = incr_value + *value;
-    return true;
-  }
-
-  bool IntOverflow(int64_t* value, size_t total_bits, int64_t incr = 0, bool add = false) const {
-    // first check the parsed value is in range
-    const int64_t max = (1UL << total_bits) - 1;
-    const int64_t min = -1LL << total_bits;
-    const uint64_t total_elements = total_bits == 63 ? std::numeric_limits<uint64_t>::max()
-                                                     : static_cast<uint64_t>(max) * 2 + 2;
-    // overflow of the increment value
-    if (*value >= 0 && *value > max - incr) {
-      switch (type) {
-        case Overflow::WRAP: {
-          int64_t res = add ? incr - 1 : *value % total_elements;
-          *value = min + res;
-          break;
-        }
-        case Overflow::SAT:
-          *value = max;
-          break;
-        case Overflow::FAIL:
-          *value = 0;
-          return false;
-      }
-      return true;
-    }
-
-    // underflow of the increment value
-    if (min - incr > *value) {
-      switch (type) {
-        case Overflow::WRAP: {
-          int64_t res = add ? incr + 1 : *value % total_elements;
-          *value = max + res;
-          break;
-        }
-        case Overflow::SAT:
-          *value = min;
-          break;
-        case Overflow::FAIL:
-          *value = 0;
-          return false;
-      }
-      return true;
-    }
-
-    if (add) {
-      *value = *value + incr;
-    }
-    return true;
-  }
+  // Used to check for signed overflow/underflow.
+  // If incr is non zero, we check for overflows in the expression incr + *value
+  // If incr is zero, we check for overflows in the expression *value
+  // If the overflow fails because of Policy::FAIL, it returns false. Otherwise, true.
+  // The result of handling the overflow is stored in the pointer value
+  bool IntOverflow(size_t total_bits, int64_t incr, bool add, int64_t* value) const;
 
   Policy type = WRAP;
 };
+
+bool Overflow::UIntOverflow(int64_t incr, size_t total_bits, int64_t* value) const {
+  // total up to 63 bits -- we do not support 64 bit unsigned
+  const uint64_t max = (1UL << total_bits) - 1;
+
+  uint64_t incr_value = incr;
+  if (incr_value + *value > max) {
+    switch (type) {
+      case Overflow::WRAP:
+        // safe to do, won't overflow, both incr and value are <= than 2^63 - 1
+        *value = (incr_value + *value) % max;
+        break;
+      case Overflow::SAT:
+        *value = max;
+        break;
+      case Overflow::FAIL:
+        *value = 0;
+        return false;
+    }
+    return true;
+  }
+
+  *value = incr_value + *value;
+  return true;
+}
+
+bool Overflow::IntOverflow(size_t total_bits, int64_t incr, bool add, int64_t* value) const {
+  // first check the parsed value is in range
+  const int64_t max = (1UL << total_bits) - 1;
+  const int64_t min = -max - 1;
+  const uint64_t total_elements =
+      total_bits == 63 ? std::numeric_limits<uint64_t>::max() : static_cast<uint64_t>(max) * 2 + 2;
+
+  auto switch_overflow = [&](int64_t wrap_case, int64_t sat_case, int64_t i) {
+    switch (type) {
+      case Overflow::WRAP: {
+        int64_t res = add ? incr - i : *value % total_elements;
+        *value = wrap_case + res;
+        break;
+      }
+      case Overflow::SAT:
+        *value = sat_case;
+        break;
+      case Overflow::FAIL:
+        *value = 0;
+        return false;
+    }
+    return true;
+  };
+
+  // overflow of the increment value
+  if (*value >= 0 && *value > max - incr) {
+    return switch_overflow(min, max, 1);
+  }
+
+  // underflow of the increment value
+  if (min - incr > *value) {
+    return switch_overflow(max, min, -1);
+  }
+
+  if (add) {
+    *value = *value + incr;
+  }
+  return true;
+}
 
 class Get {
  public:
   explicit Get(CommonAttributes attr) : attr_(attr) {
   }
 
-  ResultType ApplyTo(const std::string& value, Overflow ov) {
-    const int32_t total_bytes = static_cast<int32_t>(value.size());
-    auto last_byte_offset = GetByteIndex(attr_.offset + attr_.encoding_bit_size - 1);
-
-    uint32_t lsb = attr_.offset + attr_.encoding_bit_size - 1;
-    if (last_byte_offset > total_bytes) {
-      return Nill{};
-    }
-
-    const bool is_negative =
-        CheckBitStatus(GetByteValue(value, attr_.offset), GetNormalizedBitIndex(attr_.offset));
-
-    int64_t result = 0;
-    for (size_t i = 0; i < attr_.encoding_bit_size; ++i) {
-      uint8_t byte{GetByteValue(value, lsb)};
-      int32_t index = GetNormalizedBitIndex(lsb);
-      int64_t old_bit = CheckBitStatus(byte, index);
-      result |= old_bit << i;
-      --lsb;
-    }
-
-    if (is_negative && attr_.type == EncodingType::INT) {
-      result = (-1LL << (attr_.encoding_bit_size - 1)) | result;
-    }
-
-    return result;
-  }
+  // Apply the GET subcommand to the bitfield bytes.
+  // Return either the subcommand result (int64_t) or empty optional if failed because of
+  // Policy:FAIL
+  ResultType ApplyTo(Overflow ov, const std::string* bitfield);
 
  private:
   CommonAttributes attr_;
 };
+
+ResultType Get::ApplyTo(Overflow ov, const std::string* bitfield) {
+  const auto& bytes = *bitfield;
+  const int32_t total_bytes = static_cast<int32_t>(bytes.size());
+  const size_t offset = attr_.offset;
+  auto last_byte_offset = GetByteIndex(attr_.offset + attr_.encoding_bit_size - 1);
+
+  uint32_t lsb = attr_.offset + attr_.encoding_bit_size - 1;
+  if (last_byte_offset > total_bytes) {
+    return {};
+  }
+
+  const bool is_negative =
+      CheckBitStatus(GetByteValue(bytes, offset), GetNormalizedBitIndex(offset));
+
+  int64_t result = 0;
+  for (size_t i = 0; i < attr_.encoding_bit_size; ++i) {
+    uint8_t byte{GetByteValue(bytes, lsb)};
+    int32_t index = GetNormalizedBitIndex(lsb);
+    int64_t old_bit = CheckBitStatus(byte, index);
+    result |= old_bit << i;
+    --lsb;
+  }
+
+  if (is_negative && attr_.type == EncodingType::INT && result > 0) {
+    result |= -1L ^ ((1L << attr_.encoding_bit_size) - 1);
+  }
+
+  return result;
+}
 
 class Set {
  public:
   explicit Set(CommonAttributes attr, int64_t value) : attr_(attr), set_value_(value) {
   }
 
-  ResultType ApplyTo(std::string& bytes, Overflow ov) {
-    const int32_t total_bytes = static_cast<int32_t>(bytes.size());
-    auto last_byte_offset = GetByteIndex(attr_.offset + attr_.encoding_bit_size - 1) + 1;
-    if (last_byte_offset > total_bytes) {
-      bytes.resize(last_byte_offset, 0);
-    }
-
-    if (!HandleOverflow(ov)) {
-      return Nill{};
-    }
-
-    uint32_t lsb = attr_.offset + attr_.encoding_bit_size - 1;
-    int64_t old_value = 0;
-
-    for (size_t i = 0; i < attr_.encoding_bit_size; ++i) {
-      bool bit_value = (set_value_ >> i) & 0x01;
-      uint8_t byte{GetByteValue(bytes, lsb)};
-      int32_t index = GetNormalizedBitIndex(lsb);
-      int64_t old_bit = CheckBitStatus(byte, index);
-      byte = bit_value ? TurnBitOn(byte, index) : TurnBitOff(byte, index);
-      bytes[GetByteIndex(lsb)] = byte;
-      old_value |= old_bit << i;
-      --lsb;
-    }
-
-    return old_value;
-  }
-
-  bool HandleOverflow(Overflow ov) {
-    size_t total_bits = attr_.encoding_bit_size;
-    if (attr_.type == EncodingType::UINT) {
-      return ov.UIntOverflow(&set_value_, 0, attr_.encoding_bit_size);
-    }
-
-    return ov.IntOverflow(&set_value_, total_bits - 1);
-  }
+  // Apply the SET subcommand to the bitfield value.
+  // Return either the subcommand result (int64_t) or empty optional if failed because of
+  // Policy:FAIL Updates the bitfield to contain the new value
+  ResultType ApplyTo(Overflow ov, std::string* bitfield);
 
  private:
+  // Helper function that delegates overflow checking to the Overflow object
+  bool HandleOverflow(Overflow ov);
+
   CommonAttributes attr_;
   int64_t set_value_;
 };
+
+ResultType Set::ApplyTo(Overflow ov, std::string* bitfield) {
+  std::string& bytes = *bitfield;
+  const int32_t total_bytes = static_cast<int32_t>(bytes.size());
+  auto last_byte_offset = GetByteIndex(attr_.offset + attr_.encoding_bit_size - 1) + 1;
+  if (last_byte_offset > total_bytes) {
+    bytes.resize(last_byte_offset, 0);
+  }
+
+  if (!HandleOverflow(ov)) {
+    return {};
+  }
+
+  uint32_t lsb = attr_.offset + attr_.encoding_bit_size - 1;
+  int64_t old_value = 0;
+
+  for (size_t i = 0; i < attr_.encoding_bit_size; ++i) {
+    bool bit_value = (set_value_ >> i) & 0x01;
+    uint8_t byte{GetByteValue(bytes, lsb)};
+    int32_t index = GetNormalizedBitIndex(lsb);
+    int64_t old_bit = CheckBitStatus(byte, index);
+    byte = bit_value ? TurnBitOn(byte, index) : TurnBitOff(byte, index);
+    bytes[GetByteIndex(lsb)] = byte;
+    old_value |= old_bit << i;
+    --lsb;
+  }
+
+  return old_value;
+}
+
+bool Set::HandleOverflow(Overflow ov) {
+  size_t total_bits = attr_.encoding_bit_size;
+  if (attr_.type == EncodingType::UINT) {
+    return ov.UIntOverflow(0, attr_.encoding_bit_size, &set_value_);
+  }
+
+  return ov.IntOverflow(total_bits - 1, 0, false, &set_value_);
+}
 
 class IncrBy {
  public:
   explicit IncrBy(CommonAttributes attr, int64_t val) : attr_(attr), incr_value_(val) {
   }
 
-  ResultType ApplyTo(std::string& value, Overflow ov) {
-    Get get(attr_);
-    auto res = get.ApplyTo(value, ov);
-
-    auto nill_case = [&](Nill nill) -> ResultType {
-      Set set(attr_, incr_value_);
-      return set.ApplyTo(value, ov);
-    };
-
-    auto int_cases = [&](auto num) -> ResultType {
-      if (!HandleOverflow(ov, num)) {
-        return ResultType{Nill{}};
-      }
-      Set set(attr_, num);
-      set.ApplyTo(value, ov);
-      return num;
-    };
-
-    return std::visit(Overloaded{int_cases, nill_case}, res);
-  }
-
-  bool HandleOverflow(Overflow ov, int64_t& previous) {
-    if (attr_.type == EncodingType::UINT) {
-      return ov.UIntOverflow(&previous, incr_value_, attr_.encoding_bit_size);
-    }
-
-    const size_t total_bits = attr_.encoding_bit_size - 1;
-    if (!ov.IntOverflow(&incr_value_, total_bits)) {
-      return false;
-    }
-    return ov.IntOverflow(&previous, total_bits, incr_value_, true);
-  }
+  // Apply the INCRBY subcommand to the bitfield value.
+  // Return either the subcommand result (int64_t) or empty optional if failed because of
+  // Policy:FAIL Updates the bitfield to contain the new incremented value
+  ResultType ApplyTo(Overflow ov, std::string* bitfield);
 
  private:
+  // Helper function that delegates overflow checking to the Overflow object
+  bool HandleOverflow(Overflow ov, int64_t& previous);
+
   CommonAttributes attr_;
   int64_t incr_value_;
 };
 
+ResultType IncrBy::ApplyTo(Overflow ov, std::string* bitfield) {
+  std::string& bytes = *bitfield;
+  Get get(attr_);
+  auto res = get.ApplyTo(ov, &bytes);
+
+  if (!res) {
+    Set set(attr_, incr_value_);
+    return set.ApplyTo(ov, &bytes);
+  }
+
+  if (!HandleOverflow(ov, *res)) {
+    return {};
+  }
+
+  Set set(attr_, *res);
+  set.ApplyTo(ov, &bytes);
+  return *res;
+}
+
+bool IncrBy::HandleOverflow(Overflow ov, int64_t& previous) {
+  if (attr_.type == EncodingType::UINT) {
+    return ov.UIntOverflow(incr_value_, attr_.encoding_bit_size, &previous);
+  }
+
+  const size_t total_bits = attr_.encoding_bit_size - 1;
+  if (!ov.IntOverflow(total_bits, 0, false, &incr_value_)) {
+    return false;
+  }
+  return ov.IntOverflow(total_bits, incr_value_, true, &previous);
+}
+
+// Subcommand types for each of the subcommands of the BITFIELD command
 using Command = std::variant<Get, Set, Overflow, IncrBy>;
 
 using Result = std::optional<ResultType>;
 
+// Visitor for all the subcommand variants. Calls ApplyTo, to execute the subcommand
 class CommandApplyVisitor {
  public:
-  CommandApplyVisitor(std::string value) : value_(std::move(value)) {
+  explicit CommandApplyVisitor(std::string bitfield) : bitfield_(std::move(bitfield)) {
   }
 
   Result operator()(Get& get) {
-    return get.ApplyTo(value_, overflow_);
+    return get.ApplyTo(overflow_, &bitfield_);
   }
 
-  Result operator()(Set& set) {
+  Result operator()(auto& update) {
     should_commit_ = true;
-    return set.ApplyTo(value_, overflow_);
-  }
-
-  Result operator()(IncrBy& incr) {
-    should_commit_ = true;
-    return incr.ApplyTo(value_, overflow_);
+    return update.ApplyTo(overflow_, &bitfield_);
   }
 
   Result operator()(Overflow& overflow) {
@@ -851,8 +863,8 @@ class CommandApplyVisitor {
     return {};
   }
 
-  std::string_view Value() const {
-    return value_;
+  std::string_view Bitfield() const {
+    return bitfield_;
   }
 
   bool ShouldCommit() const {
@@ -860,50 +872,62 @@ class CommandApplyVisitor {
   }
 
  private:
+  // Most recent overflow object encountered. We cache it to make the overflow
+  // policy changes stick among different subcommands
   Overflow overflow_;
-  std::string value_;
+  // This will be commited if it was updated
+  std::string bitfield_;
+  // If either of the subcommands SET|INCRBY is used we should persist the changes.
+  // Otherwise, we only used a read only subcommand (GET)
   bool should_commit_ = false;
 };
 
+// A lit of subcommands used in BITFIELD command
 using CommandList = std::vector<Command>;
 
+// Helper class used in the shard cb that abstracts away the iteration and execution of subcommands
 class StateExecutor {
  public:
   StateExecutor(ElementAccess access, EngineShard* shard) : access_{access}, shard_(shard) {
   }
 
-  OpResult<std::vector<ResultType>> Execute(CommandList& commands) {
-    auto res = access_.Exists(shard_);
-    if (!res) {
-      return {OpStatus::WRONG_TYPE};
-    }
-    std::string value;
-    if (*res) {
-      access_.Find(shard_);
-      value = access_.Value();
-    }
-
-    std::vector<ResultType> results;
-    CommandApplyVisitor visitor(std::move(value));
-    for (auto& command : commands) {
-      auto res = std::visit(visitor, command);
-      if (res) {
-        results.push_back(*res);
-      }
-    }
-
-    if (visitor.ShouldCommit()) {
-      access_.Find(shard_);
-      access_.Commit(visitor.Value());
-    }
-
-    return results;
-  }
+  //  Iterates over all of the parsed subcommands and executes them one by one. At the end,
+  //  if an update subcommand SET|INCRBY was used, commit back the changes via the ElementAccess
+  //  object
+  OpResult<std::vector<ResultType>> Execute(CommandList& commands);
 
  private:
   ElementAccess access_;
   EngineShard* shard_;
 };
+
+OpResult<std::vector<ResultType>> StateExecutor::Execute(CommandList& commands) {
+  auto res = access_.Exists(shard_);
+  if (!res) {
+    return {OpStatus::WRONG_TYPE};
+  }
+  std::string value;
+  if (*res) {
+    access_.Find(shard_);
+    value = access_.Value();
+  }
+
+  std::vector<ResultType> results;
+  CommandApplyVisitor visitor(std::move(value));
+  for (auto& command : commands) {
+    auto res = std::visit(visitor, command);
+    if (res) {
+      results.push_back(*res);
+    }
+  }
+
+  if (visitor.ShouldCommit()) {
+    access_.Find(shard_);
+    access_.Commit(visitor.Bitfield());
+  }
+
+  return results;
+}
 
 nonstd::expected<CommonAttributes, std::string> ParseCommonAttr(CmdArgParser& parser) {
   CommonAttributes parsed;
@@ -940,8 +964,7 @@ nonstd::expected<CommonAttributes, std::string> ParseCommonAttr(CmdArgParser& pa
         "is.");
   }
 
-  auto offset_proxy = parser.Next();
-  std::string_view offset_str = offset_proxy;
+  std::string_view offset_str = parser.Next();
   bool is_proxy = false;
   if (absl::StartsWith(offset_str, "#")) {
     offset_str = offset_str.substr(1);
@@ -956,20 +979,9 @@ nonstd::expected<CommonAttributes, std::string> ParseCommonAttr(CmdArgParser& pa
   return parsed;
 }
 
-nonstd::expected<int64_t, std::string> ParseValue(CmdArgParser& parser) {
-  using nonstd::make_unexpected;
-  if (!parser.HasAtLeast(1)) {
-    return make_unexpected(kSyntaxErr);
-  }
-
-  auto value = parser.ToUpper().Next();
-  int64_t res{0};
-  if (!absl::SimpleAtoi(value, &res)) {
-    return make_unexpected(kSyntaxErr);
-  }
-  return res;
-}
-
+// Parses a list of arguments (without key) to a CommandList.
+// Returns the CommandList if the parsing completed succefully or std::string
+// to indicate an error
 nonstd::expected<CommandList, std::string> ParseToCommandList(CmdArgList args) {
   CommandList result;
 
@@ -985,11 +997,13 @@ nonstd::expected<CommandList, std::string> ParseToCommandList(CmdArgList args) {
 
     using namespace std::string_view_literals;
     if (op == "OVERFLOW"sv) {
-      auto policy = parser.ToUpper().Next();
-      if (auto res = Overflow::PolicyFromStr(policy); res) {
-        result.push_back(Overflow{*res});
+      using pol = Overflow::Policy;
+      auto res = parser.ToUpper().Switch("SAT", pol::SAT, "WRAP", pol::WRAP, "FAIL", pol::FAIL);
+      if (!parser.HasError()) {
+        result.push_back(Overflow{res});
         continue;
       }
+      parser.Error();
       return make_unexpected(kSyntaxErr);
     }
 
@@ -1004,12 +1018,12 @@ nonstd::expected<CommandList, std::string> ParseToCommandList(CmdArgList args) {
       continue;
     }
 
-    auto maybe_value = ParseValue(parser);
-    if (!maybe_value.has_value()) {
-      return make_unexpected(std::move(maybe_value.error()));
+    auto value = parser.ToUpper().Next<int64_t>();
+    if (parser.HasError()) {
+      parser.Error();
+      return make_unexpected(kSyntaxErr);
     }
 
-    auto value = maybe_value.value();
     if (op == "SET"sv) {
       result.push_back(Command(Set(attr, value)));
       continue;
@@ -1034,10 +1048,12 @@ void SendResults(const std::vector<ResultType>& results, ConnectionContext* cntx
 
   (*cntx)->StartArray(total);
   for (const auto& elem : results) {
-    auto nill_case = [&](Nill nill) { (*cntx)->SendNull(); };
-    auto int_cases = [&](auto num) { (*cntx)->SendLong(num); };
+    if (elem) {
+      (*cntx)->SendLong(*elem);
+      continue;
+    }
 
-    std::visit(Overloaded{nill_case, int_cases}, elem);
+    (*cntx)->SendNull();
   }
 }
 

--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -656,7 +656,7 @@ bool Overflow::UIntOverflow(int64_t incr, size_t total_bits, int64_t* value) con
 }
 
 bool Overflow::IntOverflow(size_t total_bits, int64_t incr, bool add, int64_t* value) const {
-  // first check the parsed value is in range
+  // This is exactly how redis handles signed overflow and we use the exact same chore
   const int64_t int_max = std::numeric_limits<int64_t>::max();
   const int64_t max = (total_bits == 64) ? int_max : ((1L << (total_bits - 1)) - 1);
   const int64_t min = (-max) - 1;
@@ -688,7 +688,10 @@ bool Overflow::IntOverflow(size_t total_bits, int64_t incr, bool add, int64_t* v
     return true;
   };
 
-  // These can overflow but it won't be an issue because we only use them after we check below
+  // maxincr/minincr can overflow but it won't be an issue because we only use them
+  // after checking 'value' range, so when they are used no overflow
+  // happens. 'uint64_t' cast is there just to prevent undefined behavior on
+  // overflow */
   int64_t maxincr = static_cast<uint64_t>(max) - *value;
   int64_t minincr = min - *value;
 

--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -592,6 +592,10 @@ void BitCount(CmdArgList args, ConnectionContext* cntx) {
   HandleOpValueResult(res, cntx);
 }
 
+// GCC yields a wrong warning about uninitialized optional use
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+
 enum class EncodingType { UINT, INT, NILL };
 
 struct CommonAttributes {
@@ -1092,6 +1096,8 @@ void BitFieldRo(CmdArgList args, ConnectionContext* cntx) {
   cntx->SendError("Not Yet Implemented");
   // return BitField(args, cntx);
 }
+
+#pragma GCC diagnostic pop
 
 void BitOp(CmdArgList args, ConnectionContext* cntx) {
   static const std::array<std::string_view, 4> BITOP_OP_NAMES{OR_OP_NAME, XOR_OP_NAME, AND_OP_NAME,

--- a/src/server/bitops_family_test.cc
+++ b/src/server/bitops_family_test.cc
@@ -7,9 +7,11 @@
 #include <bitset>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <string>
 #include <string_view>
 
+#include "absl/strings/str_cat.h"
 #include "base/gtest.h"
 #include "base/logging.h"
 #include "facade/facade_test.h"
@@ -528,6 +530,238 @@ TEST_F(BitOpsFamilyTest, BitPos) {
 
   // Non-existent key should be treated like an empty string.
   EXPECT_EQ(-1, CheckedInt({"bitpos", "d", "0"}));
+}
+
+TEST_F(BitOpsFamilyTest, BitFieldParsing) {
+  const auto syntax_error = ErrArg("ERR syntax error");
+  // Parsing Errors
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u1"}), syntax_error);
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u1", "0"}), syntax_error);
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u1", "0", "0", "55"}), syntax_error);
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u1", "0", "0", "get", "u1"}), syntax_error);
+  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "u1"}), syntax_error);
+  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "u1", "0"}), syntax_error);
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "0", "15"}), syntax_error);
+  ASSERT_THAT(Run({"bitfield", "foo", "get"}), syntax_error);
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u1", "0", "0", "set"}), syntax_error);
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow"}), syntax_error);
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "nonsense"}), syntax_error);
+
+  // Range errors
+  auto expected_error = ErrArg(
+      "ERR invalid bitfield type. use something like i16 u8. note that u64 is not supported but "
+      "i64 is.");
+
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u0", "0", "0"}), expected_error);
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u0", "0", "0"}), expected_error);
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u64", "0", "0"}), expected_error);
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u65", "0", "0"}), expected_error);
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "i65", "0", "0"}), expected_error);
+}
+
+TEST_F(BitOpsFamilyTest, BitFieldCreate) {
+  // check that SET, INCR create the key when it does not exist
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u1", "0", "1"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "0"}), IntArg(1));
+  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "u1", "1", "1"}), IntArg(1));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "1"}), IntArg(1));
+}
+
+TEST_F(BitOpsFamilyTest, BitFieldOverflowUnderflow) {
+  Run({"bitfield", "foo", "set", "u2", "0", "2"});
+
+  // unsigned 1bit
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u1", "0", "2"}), IntArg(1));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "0"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "u1", "1", "2"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "1"}), IntArg(0));
+
+  // unsigned 63bit
+  int64_t max = std::numeric_limits<int64_t>::max();
+  Run({"bitfield", "foo", "set", "i64", "0", absl::StrCat(max)});
+  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i64", "0", "1"}), IntArg(-max - 1));
+
+  // signed 1 bit
+  Run({"bitfield", "foo", "set", "i1", "0", "-2"});
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i1", "0"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i1", "0", "-1"}), IntArg(-1));
+  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i1", "0", "-1"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i1", "0", "-3"}), IntArg(-1));
+
+  // signed 64 bit
+  int64_t min = std::numeric_limits<int64_t>::min();
+  Run({"bitfield", "foo", "set", "i64", "0", absl::StrCat(min)});
+  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i64", "0", "-1"}), IntArg(max));
+
+  // overflow sat
+  // unsigned 8 bit
+  Run({"bitfield", "foo", "set", "u1", "0", "0"});
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "incrby", "u8", "0", "300"}), IntArg(255));
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "incrby", "u8", "0", "10"}), IntArg(255));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "0"}), IntArg(255));
+
+  // unsigned 63 bit
+  Run({"bitfield", "foo", "set", "u63", "0", "0"});
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "set", "u63", "0", absl::StrCat(max)}),
+              IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "incrby", "u63", "0", "10"}), IntArg(max));
+
+  // signed 8 bit
+  Run({"bitfield", "foo", "set", "u8", "0", "0"});
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "set", "i8", "0", "300"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "incrby", "i8", "0", "-127"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "incrby", "i8", "0", "-255"}),
+              IntArg(-128));
+
+  // signed 64 bit
+  Run({"bitfield", "foo", "set", "i64", "0", "0"});
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "set", "i64", "0", absl::StrCat(max)}),
+              IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "incrby", "i64", "0", "100"}),
+              IntArg(max));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i64", "0"}), IntArg(max));
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "set", "i64", "0", absl::StrCat(min)}),
+              IntArg(max));
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "incrby", "i64", "0", "-100"}),
+              IntArg(min));
+
+  // overflow fail
+  // unsigned
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "fail", "set", "u8", "0", "300"}),
+              ArgType(RespExpr::Type::NIL));
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "fail", "incrby", "u1", "0", "10"}),
+              ArgType(RespExpr::Type::NIL));
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "fail", "incrby", "u1", "0", "-10"}),
+              ArgType(RespExpr::Type::NIL));
+
+  // signed
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "fail", "incrby", "i8", "0", "300"}),
+              ArgType(RespExpr::Type::NIL));
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "fail", "incrby", "i1", "0", "10"}),
+              ArgType(RespExpr::Type::NIL));
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "fail", "incrby", "i1", "0", "-10"}),
+              ArgType(RespExpr::Type::NIL));
+
+  // stickiness of overflow among operations in a chain
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "fail", "set", "u8", "0", "300", "set", "u1", "0",
+                   "400"}),
+              RespArray(ElementsAre(ArgType(RespExpr::NIL), ArgType(RespExpr::NIL))));
+}
+
+TEST_F(BitOpsFamilyTest, BitFieldOperations) {
+  // alligned offset reads/writes unsigned
+  Run({"bitfield", "foo", "set", "u32", "0", "0"});
+  // Set the bit battern 01111000 00000001 00000001 00001010
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u8", "0", "120"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "0"}), IntArg(120));
+
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u8", "8", "1"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "8"}), IntArg(1));
+
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u8", "16", "1"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "16"}), IntArg(1));
+
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u8", "24", "10"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "24"}), IntArg(10));
+
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u32", "0"}), IntArg(2013331722));
+
+  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "u8", "0", "120"}), IntArg(240));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "0"}), IntArg(240));
+
+  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "u16", "0", "120"}), IntArg(61561));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u16", "0"}), IntArg(61561));
+
+  // alligned offset reads/writes signed
+  Run({"bitfield", "foo", "set", "u32", "0", "0"});
+  // Set the bit battern 10001000 11111111 11111111 11110110
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "i8", "0", "-120"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "0"}), IntArg(-120));
+
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "i8", "8", "-1"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "8"}), IntArg(-1));
+
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "i8", "16", "-1"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "16"}), IntArg(-1));
+
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "i8", "24", "-10"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "24"}), IntArg(-10));
+
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i32", "0"}), IntArg(-1996488714));
+
+  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i8", "0", "-8"}), IntArg(-128));
+
+  // nonalligned offset reads/writes unsigned
+  Run({"bitfield", "foo", "set", "i64", "0", "0"});
+  // Set the bit battern 00000000 10000000 10000000 10000000 10000000
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u8", "1", "1"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "1"}), IntArg(1));
+
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u8", "9", "1"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "9"}), IntArg(1));
+
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u8", "17", "1"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "17"}), IntArg(1));
+
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u8", "25", "1"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "25"}), IntArg(1));
+
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "0"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "8"}), IntArg(1));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "16"}), IntArg(1));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "24"}), IntArg(1));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "32"}), IntArg(1));
+
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u33", "0"}), IntArg(16843009));
+
+  // nonalligned offset reads/writes signed
+  Run({"bitfield", "foo", "set", "i64", "0", "0"});
+  // Set the bit battern 1111111 11111111 0000000 000000001
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "i8", "1", "-1"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "1"}), IntArg(-1));
+
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "i8", "9", "-1"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "9"}), IntArg(-1));
+
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "i8", "17", "0"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "17"}), IntArg(0));
+
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "i8", "25", "1"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "25"}), IntArg(1));
+
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i32", "1"}), IntArg(-65535));
+
+  // chaining
+  Run({
+      "bitfield", "foo", "set", "u1", "0", "1", "set", "u1", "1", "1", "set", "u1",
+      "2",        "1",   "set", "u1", "3", "1", "set", "u1", "4", "1", "set", "u1",
+      "5",        "1",   "set", "u1", "6", "1", "set", "u1", "7", "1",
+  });
+
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "0"}), IntArg(255));
+
+  ASSERT_THAT(Run({
+                  "bitfield",
+                  "foo",
+                  "set",
+                  "u1",
+                  "0",
+                  "0",
+                  "incrby",
+                  "u1",
+                  "0",
+                  "1",
+                  "get",
+                  "u1",
+                  "0",
+              }),
+              RespArray(ElementsAre(IntArg(1), IntArg(1), IntArg(1))));
+
+  // check for positional offsets
+  Run({"bitfield", "foo", "set", "u8", "#0", "1", "set", "u8", "#1", "1", "set", "u8", "#2", "1"});
+
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "7"}), IntArg(1));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "15"}), IntArg(1));
 }
 
 }  // end of namespace dfly

--- a/src/server/bitops_family_test.cc
+++ b/src/server/bitops_family_test.cc
@@ -588,8 +588,11 @@ TEST_F(BitOpsFamilyTest, BitFieldOverflowUnderflow) {
   ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i1", "0", "-1"}), IntArg(0));
   ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i1", "0", "-3"}), IntArg(-1));
 
-  // signed 64 bit
   int64_t min = std::numeric_limits<int64_t>::min();
+  Run({"bitfield", "foo", "set", "i8", "0", absl::StrCat(min)});
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "0"}), IntArg(0));
+
+  // signed 64 bit
   Run({"bitfield", "foo", "set", "i64", "0", absl::StrCat(min)});
   ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i64", "0", "-1"}), IntArg(max));
 


### PR DESCRIPTION
Resolves #213 

* implement bitfield command
* add tests

Note that there are certain optimizations that can be done. 

1. We read/write bit by bit (this is done in redis as well) even when we address the whole byte. Therefore, to update a single byte, we need 8 ops. To update 8 bytes, we need 64 ops. We can do that in one op, when these are aligned. Unless this becomes a proven bottleneck I would not spent time optimizing it further.

2. I do not like that we copy the whole string (target key value -- i.e, the bitfield) when we start processing/executing the command. This is wasteful, and for large large bitfields, this can quickly become a bottleneck. However, doing otherwise requires a little bit more involved work. In particular, we need a way to fetch and store individual bytes from the `CompactObject` and the interfaces `GetString()` and `SetString()` are not sufficient. Again, when and if this ever becomes a bottleneck, we can patch this. I am just mentioning this here for completeness.


P.s. apologies for the large PR. I did my best to keep it as short as possible.