### PR TITLE
fix(tiering): fix crash when item was deleted before offloaded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,15 +114,15 @@ jobs:
           EOF
 
           gdb -ix ./init.gdb --batch -ex r --args ./dragonfly_test --force_epoll
-          FLAGS_force_epoll=true ctest -V -L DFLY
+          FLAGS_force_epoll=true GLOG_vmodule=tiered_storage=2 ctest -V -L DFLY
 
           echo "Finished running tests with --force_epoll"
 
           echo "Running tests with --cluster_mode=emulated"
-          FLAGS_cluster_mode=emulated ctest -V -L DFLY
+          FLAGS_cluster_mode=emulated GLOG_vmodule=tiered_storage=2 ctest -V -L DFLY
 
           echo "Running tests with both --cluster_mode=emulated & --lock_on_hashtags"
-          FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true ctest -V -L DFLY
+          FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true GLOG_vmodule=tiered_storage=2 ctest -V -L DFLY
 
           ./dragonfly_test
           ./multi_test --multi_exec_mode=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,15 +114,15 @@ jobs:
           EOF
 
           gdb -ix ./init.gdb --batch -ex r --args ./dragonfly_test --force_epoll
-          FLAGS_force_epoll=true GLOG_vmodule=tiered_storage=2 ctest -V -L DFLY
+          FLAGS_force_epoll=true ctest -V -L DFLY
 
           echo "Finished running tests with --force_epoll"
 
           echo "Running tests with --cluster_mode=emulated"
-          FLAGS_cluster_mode=emulated GLOG_vmodule=tiered_storage=2 ctest -V -L DFLY
+          FLAGS_cluster_mode=emulated GLOG_logtostderr=1 GLOG_vmodule=tiered_storage=2 ctest -V -L DFLY
 
           echo "Running tests with both --cluster_mode=emulated & --lock_on_hashtags"
-          FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true GLOG_vmodule=tiered_storage=2 ctest -V -L DFLY
+          FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true GLOG_logtostderr=1 GLOG_vmodule=tiered_storage=2 ctest -V -L DFLY
 
           ./dragonfly_test
           ./multi_test --multi_exec_mode=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/build
           echo Run ctest -V -L DFLY
-          GLOG_logtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 ctest -V -L DFLY
+          GLOG_logtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1,tiered_storage=2 ctest -V -L DFLY
 
           echo "Running tests with --force_epoll"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/build
           echo Run ctest -V -L DFLY
-          GLOG_logtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1,tiered_storage=2 ctest -V -L DFLY
+          GLOG_logtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 ctest -V -L DFLY
 
           echo "Running tests with --force_epoll"
 
@@ -119,10 +119,10 @@ jobs:
           echo "Finished running tests with --force_epoll"
 
           echo "Running tests with --cluster_mode=emulated"
-          FLAGS_cluster_mode=emulated GLOG_logtostderr=1 GLOG_vmodule=tiered_storage=2 ctest -V -L DFLY
+          FLAGS_cluster_mode=emulated ctest -V -L DFLY
 
           echo "Running tests with both --cluster_mode=emulated & --lock_on_hashtags"
-          FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true GLOG_logtostderr=1 GLOG_vmodule=tiered_storage=2 ctest -V -L DFLY
+          FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true ctest -V -L DFLY
 
           ./dragonfly_test
           ./multi_test --multi_exec_mode=1

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -647,9 +647,13 @@ void DbSlice::FlushDb(DbIndex db_ind) {
     return;
   }
 
-  std::vector<DbIndex> all_indexes(db_arr_.size());
-  std::iota(all_indexes.begin(), all_indexes.end(), 0);
-  FlushDbIndexes(all_indexes);
+  std::vector<DbIndex> indexes;
+  for (DbIndex i = 0; i < db_arr_.size(); ++i) {
+    if (db_arr_[i]) {
+      indexes.push_back(i);
+    }
+  }
+  FlushDbIndexes(indexes);
 }
 
 void DbSlice::AddExpire(DbIndex db_ind, PrimeIterator main_it, uint64_t at) {

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -344,6 +344,7 @@ class DbSlice {
                                                      bool force_update) noexcept(false);
 
   void FlushSlotsFb(const SlotSet& slot_ids);
+  void FlushDbIndexes(const std::vector<DbIndex>& indexes);
 
   // Invalidate all watched keys in database. Used on FLUSH.
   void InvalidateDbWatches(DbIndex db_indx);

--- a/src/server/table.cc
+++ b/src/server/table.cc
@@ -42,10 +42,12 @@ SlotStats& SlotStats::operator+=(const SlotStats& o) {
   return *this;
 }
 
-DbTable::DbTable(PMR_NS::memory_resource* mr)
+DbTable::DbTable(PMR_NS::memory_resource* mr, DbIndex db_index)
     : prime(kInitSegmentLog, detail::PrimeTablePolicy{}, mr),
-      expire(0, detail::ExpireTablePolicy{}, mr), mcflag(0, detail::ExpireTablePolicy{}, mr),
-      top_keys({.enabled = absl::GetFlag(FLAGS_enable_top_keys_tracking)}) {
+      expire(0, detail::ExpireTablePolicy{}, mr),
+      mcflag(0, detail::ExpireTablePolicy{}, mr),
+      top_keys({.enabled = absl::GetFlag(FLAGS_enable_top_keys_tracking)}),
+      index(db_index) {
   if (ClusterConfig::IsEnabled()) {
     slots_stats.resize(ClusterConfig::kMaxSlotNum + 1);
   }

--- a/src/server/table.h
+++ b/src/server/table.h
@@ -82,8 +82,9 @@ struct DbTable : boost::intrusive_ref_counter<DbTable, boost::thread_unsafe_coun
   ExpireTable::Cursor expire_cursor;
 
   TopKeys top_keys;
+  DbIndex index;
 
-  explicit DbTable(PMR_NS::memory_resource* mr);
+  explicit DbTable(PMR_NS::memory_resource* mr, DbIndex index);
   ~DbTable();
 
   void Clear();

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -552,6 +552,7 @@ bool TieredStorage::FlushPending(DbIndex db_index, unsigned bin_index) {
   PerDb* db = db_arr_[db_index];
 
   int64_t res = alloc_.Malloc(kBlockLen);
+  VLOG(2) << "FlushPending Malloc:" << res;
   if (res < 0) {
     InitiateGrow(-res);
     return false;

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -426,13 +426,14 @@ void TieredStorage::CancelIo(DbIndex db_index, PrimeIterator it) {
   DCHECK(prime_value.HasIoPending());
 
   prime_value.SetIoPending(false);  // remove io flag.
-  PerDb* db = db_arr_[db_index];
+
   size_t blob_len = prime_value.Size();
 
   if (blob_len > kMaxSmallBin) {
     return;
   }
 
+  PerDb* db = db_arr_[db_index];
   unsigned bin_index = SmallToBin(blob_len);
   auto& bin_record = db->bin_map[bin_index];
   auto pending_it = bin_record.pending_entries.find(it->first);

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -122,7 +122,10 @@ struct TieredStorage::PerDb {
   };
 
   BinRecord bin_map[kSmallBinLen];
-  absl::flat_hash_map<int64, size_t> pages;  // map from page offset to page size.
+
+  // Map page offset to page size. We track all db allocted offsets
+  // inorder to free all the allocated offsets during flushdb and flushall.
+  absl::flat_hash_map<int64, size_t> pages;
 };
 
 class TieredStorage::InflightWriteRequest {

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -462,7 +462,6 @@ void TieredStorage::WriteSingle(DbIndex db_index, PrimeIterator it, size_t blob_
     InitiateGrow(-res);
     return;
   }
-  DbTableStats* stats = db_slice_.MutableStats(db_index);
   PerDb* db = db_arr_[db_index];
   db->pages.emplace(res, blob_len);
 
@@ -491,7 +490,7 @@ void TieredStorage::WriteSingle(DbIndex db_index, PrimeIterator it, size_t blob_
   it->second.GetString(block_ptr);
   it->second.SetIoPending(true);
 
-  auto cb = [this, req = std::move(req), stats, db_index](int io_res) {
+  auto cb = [this, req = std::move(req), db_index](int io_res) {
     PrimeIterator it = req.pt->Find(req.key);
     CHECK(!it.is_done());
 
@@ -507,7 +506,7 @@ void TieredStorage::WriteSingle(DbIndex db_index, PrimeIterator it, size_t blob_
       return;
     }
 
-    ExternalizeEntry(req.offset, stats, &it->second);
+    ExternalizeEntry(req.offset, db_slice_.MutableStats(db_index), &it->second);
 
     mi_free(req.block_ptr);
   };

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -255,6 +255,7 @@ unsigned TieredStorage::InflightWriteRequest::ExternalizeEntries(PerDb::BinRecor
       CHECK(!pit.is_done()) << "TBD";
 
       ExternalizeEntry(item_offset, stats, &pit->second);
+      VLOG(2) << "ExternalizeEntry: " << it->first;
       bin_record->enqueued_entries.erase(it);
     }
   }
@@ -446,6 +447,7 @@ void TieredStorage::CancelIo(DbIndex db_index, PrimeIterator it) {
   }
 
   string key = it->first.ToString();
+  VLOG(2) << "CancelIo: " << key;
   CHECK(bin_record.enqueued_entries.erase(key));
 }
 

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -455,8 +455,8 @@ void TieredStorage::CancelIo(DbIndex db_index, PrimeIterator it) {
   CHECK(bin_record.enqueued_entries.erase(key));
 }
 
-void TieredStorage::CancelAllIo(DbIndex db_index) {
-  VLOG(2) << "CancelAllIo " << db_index;
+void TieredStorage::CancelAllIos(DbIndex db_index) {
+  VLOG(2) << "CancelAllIos " << db_index;
   if (db_index >= db_arr_.size()) {
     return;
   }

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -451,6 +451,7 @@ void TieredStorage::CancelIo(DbIndex db_index, PrimeIterator it) {
   }
 
   string key = it->first.ToString();
+  VLOG(2) << "CancelIo from enqueue: " << key;
   CHECK(bin_record.enqueued_entries.erase(key));
 }
 
@@ -570,6 +571,7 @@ bool TieredStorage::FlushPending(DbIndex db_index, unsigned bin_index) {
     }
 
     req->Add(it->first, it->second);
+    VLOG(2) << "add to enqueued_entries" << req->entries().back();
     auto res = bin_record.enqueued_entries.emplace(req->entries().back(), req);
     CHECK(res.second);
   }

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -573,11 +573,12 @@ bool TieredStorage::FlushPending(DbIndex db_index, unsigned bin_index) {
     PrimeIterator it = pt->Find(key_view);
     DCHECK(IsValid(it));
 
-    req->Add(it->first, it->second);
     if (it->second.HasExpire()) {
       auto [pit, exp_it] = db_slice_.ExpireIfNeeded(db_context, it);
       CHECK(!pit.is_done()) << "TBD: should abort in case of expired keys";
     }
+
+    req->Add(it->first, it->second);
     auto res = bin_record.enqueued_entries.emplace(req->entries().back(), req);
     CHECK(res.second);
   }

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -37,11 +37,13 @@ class TieredStorage {
     return val.size() >= kMinBlobLen;
   }
 
-  void Free(size_t offset, size_t len);
+  void Free(size_t offset, size_t len, DbIndex db_index);
 
   void Shutdown();
 
   TieredStats GetStats() const;
+  void FlushDB(DbIndex db_index);
+  void FlushAll();
 
  private:
   class InflightWriteRequest;
@@ -59,11 +61,7 @@ class TieredStorage {
   IoMgr io_mgr_;
   ExternalAllocator alloc_;
 
-  size_t submitted_io_writes_ = 0;
-  size_t submitted_io_write_size_ = 0;
   uint32_t num_active_requests_ = 0;
-
-  EventCount active_req_sem_;
 
   struct PerDb;
   std::vector<PerDb*> db_arr_;

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -43,7 +43,7 @@ class TieredStorage {
 
   TieredStats GetStats() const;
 
-  void CancelAllIo(DbIndex db_index);
+  void CancelAllIos(DbIndex db_index);
 
  private:
   class InflightWriteRequest;

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -37,13 +37,11 @@ class TieredStorage {
     return val.size() >= kMinBlobLen;
   }
 
-  void Free(size_t offset, size_t len, DbIndex db_index);
+  void Free(size_t offset, size_t len);
 
   void Shutdown();
 
   TieredStats GetStats() const;
-  void FlushDB(DbIndex db_index);
-  void FlushAll();
 
  private:
   class InflightWriteRequest;

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -43,6 +43,8 @@ class TieredStorage {
 
   TieredStats GetStats() const;
 
+  void CancelAllIo(DbIndex db_index);
+
  private:
   class InflightWriteRequest;
 

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -133,17 +133,14 @@ TEST_F(TieredStorageTest, FlushDBAfterSet) {
   FillExternalKeys(100);
   EXPECT_EQ(100, CheckedInt({"dbsize"}));
 
-  Metrics m = GetMetrics();
-  EXPECT_GT(m.db_stats[5].tiered_entries, 0u);
-  EXPECT_LT(m.db_stats[5].tiered_entries, 100);
-
   Run({"flushdb"});
-  m = GetMetrics();
+  Metrics m = GetMetrics();
   EXPECT_EQ(m.db_stats[5].tiered_entries, 0u);
 
   FillExternalKeys(100);
   EXPECT_EQ(100, CheckedInt({"dbsize"}));
 
+  usleep(20000);  // 0.02 milliseconds
   m = GetMetrics();
   EXPECT_GT(m.db_stats[5].tiered_entries, 0u);
   EXPECT_LT(m.db_stats[5].tiered_entries, 100);
@@ -153,17 +150,14 @@ TEST_F(TieredStorageTest, FlushAllAfterSet) {
   FillExternalKeys(100);
   EXPECT_EQ(100, CheckedInt({"dbsize"}));
 
-  Metrics m = GetMetrics();
-  EXPECT_GT(m.db_stats[0].tiered_entries, 0u);
-  EXPECT_LT(m.db_stats[0].tiered_entries, 100);
-
   Run({"flushall"});
-  m = GetMetrics();
+  Metrics m = GetMetrics();
   EXPECT_EQ(m.db_stats[0].tiered_entries, 0u);
 
   FillExternalKeys(100);
   EXPECT_EQ(100, CheckedInt({"dbsize"}));
 
+  usleep(20000);  // 0.02 milliseconds
   m = GetMetrics();
   EXPECT_GT(m.db_stats[0].tiered_entries, 0u);
   EXPECT_LT(m.db_stats[0].tiered_entries, 100);
@@ -173,17 +167,14 @@ TEST_F(TieredStorageTest, AddBigValuse) {
   FillExternalKeys(100, 5000);
   EXPECT_EQ(100, CheckedInt({"dbsize"}));
 
-  Metrics m = GetMetrics();
-  EXPECT_GT(m.db_stats[0].tiered_entries, 0u);
-  EXPECT_EQ(m.db_stats[0].tiered_entries, 100);
-
   Run({"flushall"});
-  m = GetMetrics();
+  Metrics m = GetMetrics();
   EXPECT_EQ(m.db_stats[0].tiered_entries, 0u);
 
   FillExternalKeys(100, 5000);
   EXPECT_EQ(100, CheckedInt({"dbsize"}));
 
+  usleep(20000);  // 0.02 milliseconds
   m = GetMetrics();
   EXPECT_EQ(m.db_stats[0].tiered_entries, 100);
 }

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -147,20 +147,21 @@ TEST_F(TieredStorageTest, FlushDBAfterSet) {
 }
 
 TEST_F(TieredStorageTest, FlushAllAfterSet) {
+  Run({"select", "5"});
   FillExternalKeys(100);
   EXPECT_EQ(100, CheckedInt({"dbsize"}));
 
   Run({"flushall"});
   Metrics m = GetMetrics();
-  EXPECT_EQ(m.db_stats[0].tiered_entries, 0u);
+  EXPECT_EQ(m.db_stats[5].tiered_entries, 0u);
 
   FillExternalKeys(100);
   EXPECT_EQ(100, CheckedInt({"dbsize"}));
 
   usleep(20000);  // 0.02 milliseconds
   m = GetMetrics();
-  EXPECT_GT(m.db_stats[0].tiered_entries, 0u);
-  EXPECT_LT(m.db_stats[0].tiered_entries, 100);
+  EXPECT_GT(m.db_stats[5].tiered_entries, 0u);
+  EXPECT_LT(m.db_stats[5].tiered_entries, 100);
 }
 
 TEST_F(TieredStorageTest, AddBigValues) {

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -93,6 +93,7 @@ TEST_F(TieredStorageTest, DelBeforeOffload) {
   FillExternalKeys(100);
   EXPECT_EQ(100, CheckedInt({"dbsize"}));
 
+  usleep(20000);  // 0.02 milliseconds
   Metrics m = GetMetrics();
   EXPECT_GT(m.db_stats[0].tiered_entries, 0u);
   EXPECT_LT(m.db_stats[0].tiered_entries, 100);
@@ -104,6 +105,7 @@ TEST_F(TieredStorageTest, DelBeforeOffload) {
   EXPECT_EQ(m.db_stats[0].tiered_entries, 0u);
 
   FillExternalKeys(100);
+  usleep(20000);  // 0.02 milliseconds
   m = GetMetrics();
   EXPECT_GT(m.db_stats[0].tiered_entries, 0u);
   EXPECT_LT(m.db_stats[0].tiered_entries, 100);
@@ -116,6 +118,8 @@ TEST_F(TieredStorageTest, AddMultiDb) {
   Run({"select", "5"});
   FillExternalKeys(100);
   EXPECT_EQ(100, CheckedInt({"dbsize"}));
+
+  usleep(20000);  // 0.02 milliseconds
 
   Metrics m = GetMetrics();
   EXPECT_GT(m.db_stats[1].tiered_entries, 0u);

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -163,11 +163,29 @@ TEST_F(TieredStorageTest, FlushAllAfterSet) {
   EXPECT_LT(m.db_stats[0].tiered_entries, 100);
 }
 
-TEST_F(TieredStorageTest, AddBigValuse) {
+TEST_F(TieredStorageTest, AddBigValues) {
   FillExternalKeys(100, 5000);
   EXPECT_EQ(100, CheckedInt({"dbsize"}));
 
   Run({"flushall"});
+  Metrics m = GetMetrics();
+  EXPECT_EQ(m.db_stats[0].tiered_entries, 0u);
+
+  FillExternalKeys(100, 5000);
+  EXPECT_EQ(100, CheckedInt({"dbsize"}));
+
+  usleep(20000);  // 0.02 milliseconds
+  m = GetMetrics();
+  EXPECT_EQ(m.db_stats[0].tiered_entries, 100);
+}
+
+TEST_F(TieredStorageTest, DelBigValues) {
+  FillExternalKeys(100, 5000);
+  EXPECT_EQ(100, CheckedInt({"dbsize"}));
+
+  for (unsigned i = 0; i < 100; ++i) {
+    Run({"del", StrCat("k", i)});
+  }
   Metrics m = GetMetrics();
   EXPECT_EQ(m.db_stats[0].tiered_entries, 0u);
 

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -169,7 +169,6 @@ TEST_F(TieredStorageTest, AddBigValuse) {
   FillExternalKeys(100, 5000);
   EXPECT_EQ(100, CheckedInt({"dbsize"}));
 
-  usleep(20000);  // 0.02 milliseconds
   Metrics m = GetMetrics();
   EXPECT_GT(m.db_stats[0].tiered_entries, 0u);
   EXPECT_EQ(m.db_stats[0].tiered_entries, 100);
@@ -180,7 +179,6 @@ TEST_F(TieredStorageTest, AddBigValuse) {
 
   FillExternalKeys(100, 5000);
   EXPECT_EQ(100, CheckedInt({"dbsize"}));
-  usleep(50000);  // 0.02 milliseconds
 
   m = GetMetrics();
   EXPECT_EQ(m.db_stats[0].tiered_entries, 100);

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -24,7 +24,7 @@ class TieredStorageTest : public BaseFamilyTest {
     num_threads_ = 1;
   }
 
-  void FillExternalKeys(unsigned count);
+  void FillExternalKeys(unsigned count, int val_size = 256);
 
   static void SetUpTestSuite();
 };
@@ -41,8 +41,8 @@ void TieredStorageTest::SetUpTestSuite() {
   }
 }
 
-void TieredStorageTest::FillExternalKeys(unsigned count) {
-  string val(256, 'a');
+void TieredStorageTest::FillExternalKeys(unsigned count, int val_size) {
+  string val(val_size, 'a');
 
   unsigned batch_cnt = count / 50;
   for (unsigned i = 0; i < batch_cnt; ++i) {
@@ -50,7 +50,7 @@ void TieredStorageTest::FillExternalKeys(unsigned count) {
     cmd.push_back("mset");
 
     for (unsigned j = 0; j < 50; ++j) {
-      string key = StrCat("k", i * 100 + j);
+      string key = StrCat("k", i * 50 + j);
       cmd.push_back(key);
       cmd.push_back(val);
     }
@@ -87,6 +87,103 @@ TEST_F(TieredStorageTest, Basic) {
   Run({"del", "k1"});
   m = GetMetrics();
   EXPECT_EQ(m.db_stats[0].tiered_entries, tiered_entries - 1);
+}
+
+TEST_F(TieredStorageTest, DelBeforeOffload) {
+  FillExternalKeys(100);
+  EXPECT_EQ(100, CheckedInt({"dbsize"}));
+
+  Metrics m = GetMetrics();
+  EXPECT_GT(m.db_stats[0].tiered_entries, 0u);
+  EXPECT_LT(m.db_stats[0].tiered_entries, 100);
+
+  for (unsigned i = 0; i < 100; ++i) {
+    Run({"del", StrCat("k", i)});
+  }
+  m = GetMetrics();
+  EXPECT_EQ(m.db_stats[0].tiered_entries, 0u);
+
+  FillExternalKeys(100);
+  m = GetMetrics();
+  EXPECT_GT(m.db_stats[0].tiered_entries, 0u);
+  EXPECT_LT(m.db_stats[0].tiered_entries, 100);
+}
+
+TEST_F(TieredStorageTest, AddMultiDb) {
+  Run({"select", "1"});
+  FillExternalKeys(100);
+  EXPECT_EQ(100, CheckedInt({"dbsize"}));
+  Run({"select", "5"});
+  FillExternalKeys(100);
+  EXPECT_EQ(100, CheckedInt({"dbsize"}));
+
+  Metrics m = GetMetrics();
+  EXPECT_GT(m.db_stats[1].tiered_entries, 0u);
+  EXPECT_LT(m.db_stats[1].tiered_entries, 100);
+  EXPECT_GT(m.db_stats[5].tiered_entries, 0u);
+  EXPECT_LT(m.db_stats[4].tiered_entries, 100);
+}
+
+TEST_F(TieredStorageTest, FlushDBAfterSet) {
+  Run({"select", "5"});
+  FillExternalKeys(100);
+  EXPECT_EQ(100, CheckedInt({"dbsize"}));
+
+  Metrics m = GetMetrics();
+  EXPECT_GT(m.db_stats[5].tiered_entries, 0u);
+  EXPECT_LT(m.db_stats[5].tiered_entries, 100);
+
+  Run({"flushdb"});
+  m = GetMetrics();
+  EXPECT_EQ(m.db_stats[5].tiered_entries, 0u);
+
+  FillExternalKeys(100);
+  EXPECT_EQ(100, CheckedInt({"dbsize"}));
+
+  m = GetMetrics();
+  EXPECT_GT(m.db_stats[5].tiered_entries, 0u);
+  EXPECT_LT(m.db_stats[5].tiered_entries, 100);
+}
+
+TEST_F(TieredStorageTest, FlushAllAfterSet) {
+  FillExternalKeys(100);
+  EXPECT_EQ(100, CheckedInt({"dbsize"}));
+
+  Metrics m = GetMetrics();
+  EXPECT_GT(m.db_stats[0].tiered_entries, 0u);
+  EXPECT_LT(m.db_stats[0].tiered_entries, 100);
+
+  Run({"flushall"});
+  m = GetMetrics();
+  EXPECT_EQ(m.db_stats[0].tiered_entries, 0u);
+
+  FillExternalKeys(100);
+  EXPECT_EQ(100, CheckedInt({"dbsize"}));
+
+  m = GetMetrics();
+  EXPECT_GT(m.db_stats[0].tiered_entries, 0u);
+  EXPECT_LT(m.db_stats[0].tiered_entries, 100);
+}
+
+TEST_F(TieredStorageTest, AddBigValuse) {
+  FillExternalKeys(100, 5000);
+  EXPECT_EQ(100, CheckedInt({"dbsize"}));
+
+  usleep(20000);  // 0.02 milliseconds
+  Metrics m = GetMetrics();
+  EXPECT_GT(m.db_stats[0].tiered_entries, 0u);
+  EXPECT_EQ(m.db_stats[0].tiered_entries, 100);
+
+  Run({"flushall"});
+  m = GetMetrics();
+  EXPECT_EQ(m.db_stats[0].tiered_entries, 0u);
+
+  FillExternalKeys(100, 5000);
+  EXPECT_EQ(100, CheckedInt({"dbsize"}));
+  usleep(50000);  // 0.02 milliseconds
+
+  m = GetMetrics();
+  EXPECT_EQ(m.db_stats[0].tiered_entries, 100);
 }
 
 }  // namespace dfly

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -176,7 +176,7 @@ TEST_F(TieredStorageTest, AddBigValues) {
 
   usleep(20000);  // 0.02 milliseconds
   m = GetMetrics();
-  EXPECT_EQ(m.db_stats[0].tiered_entries, 100);
+  EXPECT_GT(m.db_stats[0].tiered_entries, 0u);
 }
 
 TEST_F(TieredStorageTest, DelBigValues) {
@@ -194,7 +194,7 @@ TEST_F(TieredStorageTest, DelBigValues) {
 
   usleep(20000);  // 0.02 milliseconds
   m = GetMetrics();
-  EXPECT_EQ(m.db_stats[0].tiered_entries, 100);
+  EXPECT_GT(m.db_stats[0].tiered_entries, 0u);
 }
 
 }  // namespace dfly


### PR DESCRIPTION
Fixes: #2199 
The bug: On insert key is inserted to bin pending entries, if this key was deleted we would check fail on finding this item when trying to flush bin entries.

The fix: Call CancelIo when the entry is deleted
