### PR TITLE
fix(test): Fix connection context access

### DIFF
--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -301,6 +301,9 @@ class Connection : public util::Connection {
 
   std::pair<std::string, std::string> GetClientInfoBeforeAfterTid() const;
 
+ protected:
+  std::unique_ptr<ConnectionContext> cc_;  // Null for http connections
+
  private:
   std::deque<MessageHandle> dispatch_q_;  // dispatch queue
   dfly::EventCount evc_;                  // dispatch queue waker
@@ -325,10 +328,6 @@ class Connection : public util::Connection {
 
   Phase phase_ = SETUP;
   std::string name_;
-
-  // A pointer to the ConnectionContext object if it exists. Some connections (like http
-  // requests) don't have it.
-  std::unique_ptr<ConnectionContext> cc_;
 
   unsigned parser_error_ = 0;
   bool break_cb_engaged_ = false;

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -65,6 +65,7 @@ static vector<string> SplitLines(const std::string& src) {
 
 TestConnection::TestConnection(Protocol protocol, io::StringSink* sink)
     : facade::Connection(protocol, nullptr, nullptr, nullptr), sink_(sink) {
+  cc_.reset(new dfly::ConnectionContext(sink_, this));
 }
 
 void TestConnection::SendPubMessageAsync(PubMessage pmsg) {
@@ -105,7 +106,7 @@ class BaseFamilyTest::TestConnWrapper {
   const facade::Connection::PubMessage& GetPubMessage(size_t index) const;
 
   ConnectionContext* cmd_cntx() {
-    return &cmd_cntx_;
+    return static_cast<ConnectionContext*>(dummy_conn_->cntx());
   }
 
   StringVec SplitLines() const {
@@ -125,14 +126,13 @@ class BaseFamilyTest::TestConnWrapper {
 
   std::unique_ptr<TestConnection> dummy_conn_;
 
-  ConnectionContext cmd_cntx_;
   std::vector<std::unique_ptr<std::string>> tmp_str_vec_;
 
   std::unique_ptr<RedisParser> parser_;
 };
 
 BaseFamilyTest::TestConnWrapper::TestConnWrapper(Protocol proto)
-    : dummy_conn_(new TestConnection(proto, &sink_)), cmd_cntx_(&sink_, dummy_conn_.get()) {
+    : dummy_conn_(new TestConnection(proto, &sink_)) {
 }
 
 BaseFamilyTest::TestConnWrapper::~TestConnWrapper() {


### PR DESCRIPTION
Issue from #2227 

Currently the test context knows about the test connection, but the test connection doesn't know about the test context

so calling `cc_` inside the connection is a nullptr