### PR TITLE
feat(server): support client side tracking (resp3 protocol only)

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -832,6 +832,9 @@ void Connection::HandleMigrateRequest() {
   if (cc_->subscriptions == 0) {
     migration_request_ = nullptr;
     this->Migrate(dest);
+
+    // We're now running in `dest` thread
+    queue_backpressure_ = &tl_queue_backpressure_;
   }
 
   DCHECK(dispatch_q_.empty());

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1384,7 +1384,7 @@ Connection::MemoryUsage Connection::GetMemoryUsage() const {
 
 Connection::WeakRef::WeakRef(std::shared_ptr<Connection> ptr, QueueBackpressure* backpressure,
                              unsigned thread)
-    : ptr_{ptr}, backpressure_{backpressure}, thread_{thread} {
+    : ptr_{ptr}, backpressure_{backpressure}, thread_{thread}, client_id_{ptr->GetClientId()} {
 }
 
 unsigned Connection::WeakRef::Thread() const {
@@ -1394,6 +1394,10 @@ unsigned Connection::WeakRef::Thread() const {
 Connection* Connection::WeakRef::Get() const {
   // DCHECK_EQ(ProactorBase::me()->GetPoolIndex(), int(thread_));
   return ptr_.lock().get();
+}
+
+uint32_t Connection::WeakRef::GetClientId() const {
+  return client_id_;
 }
 
 bool Connection::WeakRef::EnsureMemoryBudget() const {

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1358,7 +1358,10 @@ Connection* Connection::WeakRef::Get() const {
 }
 
 bool Connection::WeakRef::EnsureMemoryBudget() const {
+  // Simple optimization: If a connection was closed, don't check memory budget.
   if (!ptr_.expired()) {
+    // We don't rely on the connection ptr staying valid because we only access
+    // the threads backpressure
     backpressure_->EnsureBelowLimit();
     return true;
   }

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -282,7 +282,6 @@ void Connection::DispatchOperations::operator()(const MigrationRequestMessage& m
   // no-op
 }
 
-
 void Connection::DispatchOperations::operator()(CheckpointMessage msg) {
   msg.bc.Dec();
 }
@@ -1357,6 +1356,15 @@ void Connection::RequestAsyncMigration(util::fb2::ProactorBase* dest) {
   migration_request_ = dest;
 }
 
+void Connection::EnableTracking() {
+  tracking_enabled_ = true;
+  cc_->subscriptions++;
+}
+
+void Connection::DisableTracking() {
+  tracking_enabled_ = false;
+}
+
 Connection::MemoryUsage Connection::GetMemoryUsage() const {
   size_t mem = sizeof(*this) + dfly::HeapSize(dispatch_q_) + dfly::HeapSize(name_) +
                dfly::HeapSize(tmp_parse_args_) + dfly::HeapSize(tmp_cmd_vec_) +
@@ -1384,7 +1392,7 @@ unsigned Connection::WeakRef::Thread() const {
 }
 
 Connection* Connection::WeakRef::Get() const {
-  DCHECK_EQ(ProactorBase::me()->GetPoolIndex(), int(thread_));
+  // DCHECK_EQ(ProactorBase::me()->GetPoolIndex(), int(thread_));
   return ptr_.lock().get();
 }
 

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1159,6 +1159,7 @@ void Connection::Migrate(util::fb2::ProactorBase* dest) {
   // connections
   CHECK(!cc_->async_dispatch);
   CHECK_EQ(cc_->subscriptions, 0);    // are bound to thread local caches
+  CHECK_EQ(self_.use_count(), 1u);    // references cache our thread and backpressure
   CHECK(!dispatch_fb_.IsJoinable());  // can't move once it started
 
   listener()->Migrate(this, dest);

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1169,11 +1169,11 @@ void Connection::Migrate(util::fb2::ProactorBase* dest) {
   listener()->Migrate(this, dest);
 }
 
-Connection::WeakRef Connection::Borrow(unsigned thread) {
+Connection::WeakRef Connection::Borrow() {
   DCHECK(self_);
   DCHECK_GT(cc_->subscriptions, 0);
 
-  return WeakRef{self_, queue_backpressure_, thread};
+  return WeakRef(self_, queue_backpressure_, socket_->proactor()->GetPoolIndex());
 }
 
 void Connection::ShutdownThreadLocal() {
@@ -1353,7 +1353,7 @@ unsigned Connection::WeakRef::Thread() const {
 }
 
 Connection* Connection::WeakRef::Get() const {
-  DCHECK_EQ(ProactorBase::GetIndex(), int(thread_));
+  DCHECK_EQ(ProactorBase::me()->GetPoolIndex(), int(thread_));
   return ptr_.lock().get();
 }
 

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -313,8 +313,9 @@ Connection::Connection(Protocol protocol, util::HttpListenerBase* http_listener,
 
   migration_enabled_ = absl::GetFlag(FLAGS_migrate_connections);
 
-  // Create dummy value for valid control block and then use aliasing construtor to return `this`
-  self_ = {make_shared<std::nullptr_t>(nullptr), this};
+  // Create shared_ptr with empty value and associate it with `this` pointer (aliasing constructor).
+  // We use it for reference counting and accessing `this` (without managing it).
+  self_ = {std::make_shared<std::monostate>(std::monostate{}), this};
 
 #ifdef DFLY_USE_SSL
   // Increment reference counter so Listener won't free the context while we're

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -164,6 +164,12 @@ class Connection : public util::Connection {
     // Ensure owner thread's memory budget. If expired, skips and returns false. Thread-safe.
     bool EnsureMemoryBudget() const;
 
+    bool operator==(const WeakRef rhs) const {
+      auto rhs_ptr = rhs.ptr_.lock();
+      auto lhs_ptr = ptr_.lock();
+      return (rhs_ptr == lhs_ptr);
+    };
+
    private:
     friend class Connection;
 
@@ -257,13 +263,11 @@ class Connection : public util::Connection {
   // Connections will migrate at most once, and only when the flag --migrate_connections is true.
   void RequestAsyncMigration(util::fb2::ProactorBase* dest);
 
-  void EnableTracking() {
-    tracking_enabled_ = true;
-  }
+  // Set the flag to enable client side tracking
+  void EnableTracking();
 
-  void DisableTracking() {
-    tracking_enabled_ = false;
-  }
+  // Set the flag to disable client side tracking
+  void DisableTracking();
 
   bool IsTrackingOn() const {
     return tracking_enabled_;

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -203,7 +203,7 @@ class Connection : public util::Connection {
   void Migrate(util::fb2::ProactorBase* dest);
 
   // Borrow weak reference to connection. Can be called from any thread.
-  WeakRef Borrow(unsigned thread);
+  WeakRef Borrow();
 
   static void ShutdownThreadLocal();
 

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -145,8 +145,9 @@ class Connection : public util::Connection {
 
   enum Phase { SETUP, READ_SOCKET, PROCESS, SHUTTING_DOWN, PRECLOSE, NUM_PHASES };
 
-  // Stores an non-owning weak reference to a connection.
-  struct BorrowedRef {
+  // Weak reference to a connection, invalidated upon connection close.
+  // Used to dispatch async operations for the connection without worrying about pointer lifetime.
+  struct WeakRef {
    public:
     // Get residing thread of connection. Thread-safe.
     unsigned Thread() const;
@@ -161,7 +162,7 @@ class Connection : public util::Connection {
    private:
     friend class Connection;
 
-    BorrowedRef(std::shared_ptr<Connection> ptr, QueueBackpressure* backpressure, unsigned thread);
+    WeakRef(std::shared_ptr<Connection> ptr, QueueBackpressure* backpressure, unsigned thread);
 
     std::weak_ptr<Connection> ptr_;
     QueueBackpressure* backpressure_;
@@ -202,7 +203,7 @@ class Connection : public util::Connection {
   void Migrate(util::fb2::ProactorBase* dest);
 
   // Borrow weak reference to connection. Can be called from any thread.
-  BorrowedRef Borrow(unsigned thread);
+  WeakRef Borrow(unsigned thread);
 
   static void ShutdownThreadLocal();
 

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -161,6 +161,8 @@ class Connection : public util::Connection {
     // Can only be called from connection's thread.
     Connection* Get() const;
 
+    uint32_t GetClientId() const;
+
     // Ensure owner thread's memory budget. If expired, skips and returns false. Thread-safe.
     bool EnsureMemoryBudget() const;
 
@@ -178,6 +180,7 @@ class Connection : public util::Connection {
     std::weak_ptr<Connection> ptr_;
     QueueBackpressure* backpressure_;
     unsigned thread_;
+    uint32_t client_id_;
   };
 
  public:

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -77,21 +77,10 @@ class Connection : public util::Connection {
                size_t message_len);
   };
 
-
   struct InvalidationMessage {
     std::string_view key;
     bool invalidate_due_to_flush = false;
   };
-
-  struct MonitorMessage : public std::string {};
-
-  struct AclUpdateMessage {
-    std::vector<std::string> username;
-    std::vector<uint32_t> categories;
-    std::vector<std::vector<uint64_t>> commands;
-  };
-
-  struct MigrationRequestMessage {};
 
   // Pipeline message, accumulated command to be execute.d
   struct PipelineMessage {

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -263,6 +263,10 @@ char* RedisReplyBuilder::FormatDouble(double val, char* dest, unsigned dest_len)
 RedisReplyBuilder::RedisReplyBuilder(::io::Sink* sink) : SinkReplyBuilder(sink) {
 }
 
+bool RedisReplyBuilder::IsResp3() const {
+  return is_resp3_;
+}
+
 void RedisReplyBuilder::SetResp3(bool is_resp3) {
   is_resp3_ = is_resp3;
 }

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -30,6 +30,8 @@ constexpr char kCRLF[] = "\r\n";
 constexpr char kErrPref[] = "-ERR ";
 constexpr char kSimplePref[] = "+";
 
+constexpr char kRET[] = "$1\r\n\r\r\n";
+
 constexpr unsigned kConvFlags =
     DoubleToStringConverter::UNIQUE_ZERO | DoubleToStringConverter::EMIT_POSITIVE_EXPONENT_SIGN;
 
@@ -289,9 +291,14 @@ void RedisReplyBuilder::SendProtocolError(std::string_view str) {
   SendError(absl::StrCat("-ERR Protocol error: ", str), "protocol_error");
 }
 
+void RedisReplyBuilder::SendRET() {
+  // iovec v[3] = {IoVec(kSimplePref), IoVec(str), IoVec(kCRLF)};
+  iovec v[1] = {IoVec(kRET)};
+  Send(v, ABSL_ARRAYSIZE(v));
+}
+
 void RedisReplyBuilder::SendSimpleString(std::string_view str) {
   iovec v[3] = {IoVec(kSimplePref), IoVec(str), IoVec(kCRLF)};
-
   Send(v, ABSL_ARRAYSIZE(v));
 }
 

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -212,6 +212,8 @@ class RedisReplyBuilder : public SinkReplyBuilder {
  public:
   enum CollectionType { ARRAY, SET, MAP, PUSH };
 
+  enum VerbatimFormat { TXT, MARKDOWN };
+
   using StrSpan = std::variant<absl::Span<const std::string>, absl::Span<const std::string_view>>;
 
   RedisReplyBuilder(::io::Sink* stream);
@@ -247,7 +249,7 @@ class RedisReplyBuilder : public SinkReplyBuilder {
 
   static char* FormatDouble(double val, char* dest, unsigned dest_len);
 
-  void SendRET();
+  void SendVerbatimString(std::string_view str, VerbatimFormat format = TXT);
 
  protected:
   struct WrappedStrSpan : public StrSpan {

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -154,7 +154,6 @@ class SinkReplyBuilder {
   bool HasReplied() const;
 
   virtual size_t UsedMemory() const;
-  std::string batch_;
 
  protected:
   void SendRaw(std::string_view str);  // Sends raw without any formatting.

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -165,6 +165,7 @@ class SinkReplyBuilder {
   void StartAggregate();
   void StopAggregate();
 
+  std::string batch_;
   ::io::Sink* sink_;
   std::error_code ec_;
 

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -218,6 +218,8 @@ class RedisReplyBuilder : public SinkReplyBuilder {
 
   RedisReplyBuilder(::io::Sink* stream);
 
+  bool IsResp3() const;
+
   void SetResp3(bool is_resp3);
 
   void SendError(std::string_view str, std::string_view type = {}) override;

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -154,6 +154,7 @@ class SinkReplyBuilder {
   bool HasReplied() const;
 
   virtual size_t UsedMemory() const;
+  std::string batch_;
 
  protected:
   void SendRaw(std::string_view str);  // Sends raw without any formatting.
@@ -164,7 +165,6 @@ class SinkReplyBuilder {
   void StartAggregate();
   void StopAggregate();
 
-  std::string batch_;
   ::io::Sink* sink_;
   std::error_code ec_;
 
@@ -246,6 +246,8 @@ class RedisReplyBuilder : public SinkReplyBuilder {
   virtual void StartCollection(unsigned len, CollectionType type);
 
   static char* FormatDouble(double val, char* dest, unsigned dest_len);
+
+  void SendRET();
 
  protected:
   struct WrappedStrSpan : public StrSpan {

--- a/src/server/channel_store.cc
+++ b/src/server/channel_store.cc
@@ -114,7 +114,7 @@ void ChannelStore::Fill(const SubscribeMap& src, const string& pattern, vector<S
   out->reserve(out->size() + src.size());
   for (const auto [cntx, thread_id] : src) {
     CHECK(cntx->conn_state.subscribe_info);
-    out->push_back({cntx->conn()->Borrow(thread_id), pattern});
+    out->push_back({cntx->conn()->Borrow(), pattern});
   }
 }
 

--- a/src/server/channel_store.cc
+++ b/src/server/channel_store.cc
@@ -114,7 +114,8 @@ void ChannelStore::Fill(const SubscribeMap& src, const string& pattern, vector<S
   out->reserve(out->size() + src.size());
   for (const auto [cntx, thread_id] : src) {
     CHECK(cntx->conn_state.subscribe_info);
-    out->push_back({cntx->conn()->Borrow(), pattern});
+    Subscriber sub{cntx->conn()->Borrow(), pattern};
+    out->push_back(std::move(sub));
   }
 }
 

--- a/src/server/channel_store.h
+++ b/src/server/channel_store.h
@@ -40,7 +40,7 @@ class ChannelStore {
   friend class ChannelStoreUpdater;
 
  public:
-  struct Subscriber : public facade::Connection::BorrowedRef {
+  struct Subscriber : public facade::Connection::WeakRef {
     // Sort by thread-id. Subscriber without owner comes first.
     static bool ByThread(const Subscriber& lhs, const Subscriber& rhs);
     static bool ByThreadId(const Subscriber& lhs, const unsigned thread);

--- a/src/server/channel_store.h
+++ b/src/server/channel_store.h
@@ -7,6 +7,7 @@
 
 #include <string_view>
 
+#include "facade/dragonfly_connection.h"
 #include "server/conn_context.h"
 
 namespace dfly {
@@ -39,22 +40,11 @@ class ChannelStore {
   friend class ChannelStoreUpdater;
 
  public:
-  struct Subscriber {
-    Subscriber(ConnectionContext* cntx, uint32_t tid);
-    Subscriber(uint32_t tid);
-
-    Subscriber(Subscriber&&) noexcept = default;
-    Subscriber& operator=(Subscriber&&) noexcept = default;
-
-    Subscriber(const Subscriber&) = delete;
-    void operator=(const Subscriber&) = delete;
-
+  struct Subscriber : public facade::Connection::BorrowedRef {
     // Sort by thread-id. Subscriber without owner comes first.
     static bool ByThread(const Subscriber& lhs, const Subscriber& rhs);
+    static bool ByThreadId(const Subscriber& lhs, const unsigned thread);
 
-    ConnectionContext* conn_cntx;
-    BlockingCounter borrow_token;  // to keep connection alive
-    uint32_t thread_id;
     std::string pattern;  // non-empty if registered via psubscribe
   };
 

--- a/src/server/channel_store.h
+++ b/src/server/channel_store.h
@@ -41,6 +41,10 @@ class ChannelStore {
 
  public:
   struct Subscriber : public facade::Connection::WeakRef {
+    Subscriber(WeakRef ref, const std::string& pattern)
+        : facade::Connection::WeakRef(std::move(ref)), pattern(pattern) {
+    }
+
     // Sort by thread-id. Subscriber without owner comes first.
     static bool ByThread(const Subscriber& lhs, const Subscriber& rhs);
     static bool ByThreadId(const Subscriber& lhs, const unsigned thread);

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -117,8 +117,6 @@ struct ConnectionState {
     // TODO: to provide unique_strings across service. This will allow us to use string_view here.
     absl::flat_hash_set<std::string> channels;
     absl::flat_hash_set<std::string> patterns;
-
-    BlockingCounter borrow_token{0};
   };
 
   struct ReplicationInfo {
@@ -208,6 +206,7 @@ class ConnectionContext : public facade::ConnectionContext {
     subscriptions++;  // required to support the monitoring
     monitor = enable;
   }
+
   void SendSubscriptionChangedResponse(std::string_view action,
                                        std::optional<std::string_view> topic, unsigned count);
 };

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1402,8 +1402,7 @@ void DbSlice::SendInvalidationTrackingMessage(std::string_view key) {
             continue;
           facade::Connection* conn = it->first->conn();
           DCHECK(conn);
-          facade::Connection::InvalidationMessage x{key};
-          conn->SendInvalidationMessageAsync(x);
+          conn->SendInvalidationMessageAsync({key});
           return;
         }
       };

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -334,7 +334,8 @@ class DbSlice {
   }
 
   // Start tracking keys for the client with client_id
-  void TrackKeys(ConnectionContext*, int32_t, const std::vector<std::string_view>&);
+  // void TrackKeys(ConnectionContext*, int32_t, const std::vector<std::string_view>&);
+  void TrackKeys(facade::Connection::WeakRef, int32_t, const std::vector<std::string_view>&);
 
   // Send invalidatoin message when a key being tracked is updated/deleted.
   // A connection that has been closed will be garbage collected along the way.
@@ -392,17 +393,13 @@ class DbSlice {
   DocDeletionCallback doc_del_cb_;
 
   struct Hash {
-    size_t operator()(const std::pair<ConnectionContext*, int32_t>& p) const {
-      // return std::hash<int32_t>()(p.second);
-      return std::hash<uint32_t>()(p.first->conn()->GetClientId());
+    size_t operator()(const std::pair<facade::Connection::WeakRef, int32_t>& p) const {
+      return std::hash<uint32_t>()(p.first.Get()->GetClientId());
     }
   };
 
-  // maps keys to the IDs of the clients that are tracking this key.
-  // absl::flat_hash_map<std::string_view, absl::flat_hash_set<std::pair<ConnectionContext*,
-  // int32_t>, Hash> > client_tracking_map_;
   absl::flat_hash_map<std::string,
-                      absl::flat_hash_set<std::pair<ConnectionContext*, int32_t>, Hash>>
+                      absl::flat_hash_set<std::pair<facade::Connection::WeakRef, int32_t>, Hash>>
       client_tracking_map_;
 };
 

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -394,7 +394,7 @@ class DbSlice {
 
   struct Hash {
     size_t operator()(const std::pair<facade::Connection::WeakRef, int32_t>& p) const {
-      return std::hash<uint32_t>()(p.first.Get()->GetClientId());
+      return std::hash<uint32_t>()(p.first.GetClientId());
     }
   };
 

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -1135,7 +1135,10 @@ void HSetFamily::HRandField(CmdArgList args, ConnectionContext* cntx) {
 
   OpResult<StringVec> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
   if (result) {
-    (*cntx)->SendStringArr(*result);
+    if (result->size() == 1)
+      (*cntx)->SendBulkString(result->front());
+    else
+      (*cntx)->SendStringArr(*result);
   } else if (result.status() == OpStatus::KEY_NOTFOUND) {
     (*cntx)->SendNull();
   } else {

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -1135,7 +1135,7 @@ void HSetFamily::HRandField(CmdArgList args, ConnectionContext* cntx) {
 
   OpResult<StringVec> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
   if (result) {
-    if (result->size() == 1)
+    if ((result->size() == 1) && (args.size() == 1))
       (*cntx)->SendBulkString(result->front());
     else
       (*cntx)->SendStringArr(*result);

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -1140,7 +1140,10 @@ void HSetFamily::HRandField(CmdArgList args, ConnectionContext* cntx) {
     else
       (*cntx)->SendStringArr(*result);
   } else if (result.status() == OpStatus::KEY_NOTFOUND) {
-    (*cntx)->SendNull();
+    if (args.size() == 1)
+      (*cntx)->SendNull();
+    else
+      (*cntx)->SendEmptyArray();
   } else {
     (*cntx)->SendError(result.status());
   }

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1152,7 +1152,7 @@ void Service::DispatchCommand(CmdArgList args, facade::ConnectionContext* cntx) 
   // notify the client when there is update, see PostUpdate() in db_slice.cc
   if ((cid->opt_mask() & CO::READONLY) && dfly_cntx->conn()->IsTrackingOn()) {
     // let's pass thread id and connection to db_slice for tracking
-    int32_t tid = util::ProactorBase::GetIndex();
+    int32_t tid = ProactorBase::me()->GetPoolIndex();
     // uint32_t client_id = dfly_cntx->conn()->GetClientId();
     auto cb = [&](Transaction* t, EngineShard* shard) {
       auto keys = t->GetShardArgs(shard->shard_id());
@@ -1162,9 +1162,6 @@ void Service::DispatchCommand(CmdArgList args, facade::ConnectionContext* cntx) 
     dfly_cntx->transaction->Refurbish();
     dfly_cntx->transaction->ScheduleSingleHopT(cb);
   }
-
-  uint64_t end_ns = ProactorBase::GetMonotonicTimeNs();
-  request_latency_usec.IncBy(cid->name(), (end_ns - start_ns) / 1000);
 
   if (!dispatching_in_multi) {
     dfly_cntx->transaction = nullptr;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2081,12 +2081,12 @@ void Service::Publish(CmdArgList args, ConnectionContext* cntx) {
     // thus not adding any overhead to backpressure checks.
     optional<uint32_t> last_thread;
     for (auto& sub : subscribers) {
-      DCHECK_LE(last_thread.value_or(0), sub.thread_id);
-      if (last_thread && *last_thread == sub.thread_id)  // skip same thread
+      DCHECK_LE(last_thread.value_or(0), sub.Thread());
+      if (last_thread && *last_thread == sub.Thread())  // skip same thread
         continue;
 
-      sub.conn_cntx->conn()->EnsureAsyncMemoryBudget();
-      last_thread = sub.thread_id;
+      if (sub.EnsureMemoryBudget())  // Invalid pointers are skipped
+        last_thread = sub.Thread();
     }
 
     auto subscribers_ptr = make_shared<decltype(subscribers)>(std::move(subscribers));
@@ -2096,14 +2096,13 @@ void Service::Publish(CmdArgList args, ConnectionContext* cntx) {
 
     auto cb = [subscribers_ptr, buf, channel, msg](unsigned idx, util::ProactorBase*) {
       auto it = lower_bound(subscribers_ptr->begin(), subscribers_ptr->end(), idx,
-                            ChannelStore::Subscriber::ByThread);
+                            ChannelStore::Subscriber::ByThreadId);
 
-      while (it != subscribers_ptr->end() && it->thread_id == idx) {
-        facade::Connection* conn = it->conn_cntx->conn();
-        DCHECK(conn);
-        conn->SendPubMessageAsync(
-            {std::move(it->pattern), std::move(buf), channel.size(), msg.size()});
-        it->borrow_token.Dec();
+      while (it != subscribers_ptr->end() && it->Thread() == idx) {
+        if (auto* ptr = it->Get(); ptr) {
+          ptr->SendPubMessageAsync(
+              {std::move(it->pattern), std::move(buf), channel.size(), msg.size()});
+        }
         it++;
       }
     };
@@ -2333,20 +2332,12 @@ void Service::OnClose(facade::ConnectionContext* cntx) {
 
   if (conn_state.subscribe_info) {  // Clean-ups related to PUBSUB
     if (!conn_state.subscribe_info->channels.empty()) {
-      auto token = conn_state.subscribe_info->borrow_token;
       server_cntx->UnsubscribeAll(false);
-
-      // Check that all borrowers finished processing.
-      // token is increased in channel_slice (the publisher side).
-      token.Wait();
     }
 
     if (conn_state.subscribe_info) {
       DCHECK(!conn_state.subscribe_info->patterns.empty());
-
-      auto token = conn_state.subscribe_info->borrow_token;
       server_cntx->PUnsubscribeAll(false);
-      token.Wait();  // Same as above
     }
 
     DCHECK(!conn_state.subscribe_info);

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1043,7 +1043,7 @@ std::optional<ErrorReply> Service::VerifyCommandState(const CommandId* cid, CmdA
 OpResult<bool> OpTrackKeys(const OpArgs& op_args, ConnectionContext* cntx, uint32_t tid,
                            vector<string_view>& keys, CmdArgList args) {
   auto& db_slice = op_args.shard->db_slice();
-  db_slice.TrackKeys(cntx, tid, keys);
+  db_slice.TrackKeys(cntx->conn()->Borrow(), tid, keys);
   return true;
 }
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1169,57 +1169,8 @@ void Service::DispatchCommand(CmdArgList args, facade::ConnectionContext* cntx) 
     auto cb = [&](Transaction* t, EngineShard* shard) {
       return OpTrackKeys(t->GetOpArgs(shard), dfly_cntx, tid, keys_to_track, args);
     };
-
-    // OpResult<bool> remember_key_result =
     dfly_cntx->transaction->ScheduleSingleHopT(cb);
-
-    //(*dfly_cntx)->StartCollection(2, RedisReplyBuilder::CollectionType::PUSH);
-    // std::string inval = "invalidate";
-    //(*dfly_cntx)->SendBulkString(inval);
-    //(*dfly_cntx)->SendStringArr(keys_to_track);
-    //(*dfly_cntx)->SendRET();
-
-    //(*dfly_cntx)->StartCollection(2, RedisReplyBuilder::CollectionType::PUSH);
-    //(*dfly_cntx)->SendBulkString(inval);
-    //(*dfly_cntx)->SendStringArr(keys_to_track);
   }
-
-  /*
-    if (is_read_cmd) {
-
-    OpResult<KeyIndex> key_index_res = DetermineKeys(cid, args_no_cmd);
-    if (!key_index_res) {
-    }
-
-    const auto& key_index = *key_index_res;
-    std::vector<string_view> keys;
-    // Iterate keys and check to which slot they belong.
-    for (unsigned i = key_index.start; i < key_index.end; i += key_index.step) {
-      string_view key = ArgS(args_no_cmd, i);
-      keys.push_back(key);
-    }
-
-      uint32_t client_id = dfly_cntx->conn()->GetClientId();
-
-       auto cb = [&](Transaction* t, EngineShard* shard) {
-        return OpRememberKey(t->GetOpArgs(shard), client_id, keys, args);
-      };
-
-
-
-      //OpStatus status =
-      //      dfly_cntx->transaction->InitByArgs(dfly_cntx->conn_state.db_index, args_no_cmd);
-      OpResult<bool> remember_key_result = dfly_cntx->transaction->ScheduleSingleHopT(cb);
-
-
-      // send PUSH message to client to invalidate the key
-      (*dfly_cntx)->StartCollection(2, RedisReplyBuilder::CollectionType::PUSH);
-      std::string inval = "invalidate";
-      (*dfly_cntx)->SendBulkString(inval);
-      (*dfly_cntx)->SendStringArr(keys);
-
-    }
-  */
 
   uint64_t end_ns = ProactorBase::GetMonotonicTimeNs();
   request_latency_usec.IncBy(cid->name(), (end_ns - start_ns) / 1000);

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1165,10 +1165,13 @@ void Service::DispatchCommand(CmdArgList args, facade::ConnectionContext* cntx) 
     // let's pass thread id and connection to db_slice for tracking
     int32_t tid = util::ProactorBase::GetIndex();
 
+    DVLOG(2) << "Ready to schedul transaction";
+
     // uint32_t client_id = dfly_cntx->conn()->GetClientId();
     auto cb = [&](Transaction* t, EngineShard* shard) {
       return OpTrackKeys(t->GetOpArgs(shard), dfly_cntx, tid, keys_to_track, args);
     };
+    dfly_cntx->transaction->Refurbish();
     dfly_cntx->transaction->ScheduleSingleHopT(cb);
   }
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1328,7 +1328,7 @@ void ServerFamily::ClientList(CmdArgList args, ConnectionContext* cntx) {
 
   string result = absl::StrJoin(client_info, "\n");
   result.append("\n");
-  return (*cntx)->SendBulkString(result);
+  return (*cntx)->SendVerbatimString(result);
 }
 
 void ServerFamily::ClientPause(CmdArgList args, ConnectionContext* cntx) {

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1877,7 +1877,7 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
     append("cluster_enabled", ClusterConfig::IsEnabledOrEmulated());
   }
 
-  (*cntx)->SendBulkString(info);
+  (*cntx)->SendVerbatimString(info);
 }
 
 void ServerFamily::Hello(CmdArgList args, ConnectionContext* cntx) {

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1264,15 +1264,19 @@ void ServerFamily::Client(CmdArgList args, ConnectionContext* cntx) {
   }
 
   if (sub_cmd == "TRACKING" && args.size() == 2) {
-    ToUpper(&args[1]);
-    string_view switch_state = ArgS(args, 1);
-    if (switch_state == "ON") {
-      cntx->conn()->EnableTracking();
-      return (*cntx)->SendOk();
-    } else if (switch_state == "OFF") {
-      cntx->conn()->DisableTracking();
-      // todo: the client id in tracking table will be garbage collected.
-      return (*cntx)->SendOk();
+    if ((*cntx)->IsResp3()) {
+      ToUpper(&args[1]);
+      string_view switch_state = ArgS(args, 1);
+      if (switch_state == "ON") {
+        cntx->conn()->EnableTracking();
+        return (*cntx)->SendOk();
+      } else if (switch_state == "OFF") {
+        cntx->conn()->DisableTracking();
+        return (*cntx)->SendOk();
+      }
+    } else {
+      LOG_FIRST_N(ERROR, 10)
+          << "Client tracking is currently not supported in RESP2, please use RESP3.";
     }
   }
 

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -256,6 +256,8 @@ class ServerFamily {
 
   void SnapshotScheduling();
 
+  void SendInvalidationMessages() const;
+
   Fiber snapshot_schedule_fb_;
   Future<GenericError> load_result_;
 

--- a/src/server/server_family_test.cc
+++ b/src/server/server_family_test.cc
@@ -199,5 +199,12 @@ TEST_F(ServerFamilyTest, ClientPause) {
   Run({"set", "key", "value2"});
   EXPECT_GT((absl::Now() - start), absl::Milliseconds(50));
 }
+  
+TEST_F(ServerFamilyTest, ClientTracking) {
+  // client tracking only works for RESP3
+  auto resp = Run({"hello", "3"});
+  resp = RUN({"client", "tracking", "on"});
+  EXPECT_THAT(resp.GetString(), "OK");
+}
 
 }  // namespace dfly

--- a/src/server/server_family_test.cc
+++ b/src/server/server_family_test.cc
@@ -199,11 +199,11 @@ TEST_F(ServerFamilyTest, ClientPause) {
   Run({"set", "key", "value2"});
   EXPECT_GT((absl::Now() - start), absl::Milliseconds(50));
 }
-  
+
 TEST_F(ServerFamilyTest, ClientTracking) {
   // client tracking only works for RESP3
   auto resp = Run({"hello", "3"});
-  resp = RUN({"client", "tracking", "on"});
+  resp = Run({"client", "tracking", "on"});
   EXPECT_THAT(resp.GetString(), "OK");
 }
 

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -66,6 +66,7 @@ static vector<string> SplitLines(const std::string& src) {
 TestConnection::TestConnection(Protocol protocol, io::StringSink* sink)
     : facade::Connection(protocol, nullptr, nullptr, nullptr), sink_(sink) {
   cc_.reset(new dfly::ConnectionContext(sink_, this));
+  SetSocket(ProactorBase::me()->CreateSocket());
 }
 
 void TestConnection::SendPubMessageAsync(PubMessage pmsg) {

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -906,6 +906,12 @@ void Transaction::Conclude() {
   Execute(std::move(cb), true);
 }
 
+void Transaction::Refurbish() {
+  txid_ = 0;
+  coordinator_state_ = 0;
+  cb_ptr_ = nullptr;
+}
+
 void Transaction::EnableShard(ShardId sid) {
   unique_shard_cnt_ = 1;
   unique_shard_id_ = sid;

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -323,6 +323,8 @@ class Transaction {
   // Utility to run a single hop on a no-key command
   static void RunOnceAsCommand(const CommandId* cid, RunnableType cb);
 
+  void Refurbish();
+
  private:
   // Holds number of locks for each IntentLock::Mode: shared and exlusive.
   struct LockCnt {


### PR DESCRIPTION
fixes: https://github.com/dragonflydb/dragonfly/issues/2139

this set of changes meant to provide minimal client tracking implementation for integrating with Relay.

note: this is still a draft... this branch meant to provide a prototype being used for testing with Relay team. We will divide these patches into different smaller production PRs after all the tests are passed with Relay. 
