### PR TITLE
feat(Server):support Verbatim strings resp type, using it for CLIENT LIST and INFO commands

### DIFF
--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -328,6 +328,32 @@ void RedisReplyBuilder::SendBulkString(std::string_view str) {
   return Send(v, ABSL_ARRAYSIZE(v));
 }
 
+void RedisReplyBuilder::SendVerbatimString(std::string_view str, VerbatimFormat format) {
+  if (!is_resp3_)
+    return SendBulkString(str);
+
+  char tmp[absl::numbers_internal::kFastToBufferSize + 3];
+  tmp[0] = '=';
+  // + 4 because format is three byte, and need to be followed by a ":"
+  char* next = absl::numbers_internal::FastIntToBuffer(uint32_t(str.size() + 4), tmp + 1);
+  *next++ = '\r';
+  *next++ = '\n';
+
+  std::string_view lenpref{tmp, size_t(next - tmp)};
+
+  std::string_view format_str;
+  if (format == VerbatimFormat::TXT)
+    format_str = "txt:";
+  else if (format == VerbatimFormat::MARKDOWN)
+    format_str = "mkd:";
+  else {
+    DVLOG(1) << "Unknown verbatim reply format: " << format;
+    return;
+  }
+  iovec v[4] = {IoVec(lenpref), IoVec(format_str), IoVec(str), IoVec(kCRLF)};
+  return Send(v, ABSL_ARRAYSIZE(v));
+}
+
 void RedisReplyBuilder::SendLong(long num) {
   string str = absl::StrCat(":", num, kCRLF);
   SendRaw(str);

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -339,14 +339,11 @@ void RedisReplyBuilder::SendVerbatimString(std::string_view str, VerbatimFormat 
   *next++ = '\r';
   *next++ = '\n';
 
+  DCHECK(format <= VerbatimFormat::MARKDOWN);
   if (format == VerbatimFormat::TXT)
     strcpy(next, "txt:");
   else if (format == VerbatimFormat::MARKDOWN)
     strcpy(next, "mkd:");
-  else {
-    DVLOG(1) << "Unknown verbatim reply format: " << format;
-    return;
-  }
   next += 4;
   std::string_view lenpref{tmp, size_t(next - tmp)};
   iovec v[3] = {IoVec(lenpref), IoVec(str), IoVec(kCRLF)};

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -339,18 +339,17 @@ void RedisReplyBuilder::SendVerbatimString(std::string_view str, VerbatimFormat 
   *next++ = '\r';
   *next++ = '\n';
 
-  std::string_view lenpref{tmp, size_t(next - tmp)};
-
-  std::string_view format_str;
   if (format == VerbatimFormat::TXT)
-    format_str = "txt:";
+    strcpy(next, "txt:");
   else if (format == VerbatimFormat::MARKDOWN)
-    format_str = "mkd:";
+    strcpy(next, "mkd:");
   else {
     DVLOG(1) << "Unknown verbatim reply format: " << format;
     return;
   }
-  iovec v[4] = {IoVec(lenpref), IoVec(format_str), IoVec(str), IoVec(kCRLF)};
+  next += 4;
+  std::string_view lenpref{tmp, size_t(next - tmp)};
+  iovec v[4] = {IoVec(lenpref), IoVec(str), IoVec(kCRLF)};
   return Send(v, ABSL_ARRAYSIZE(v));
 }
 

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -349,7 +349,7 @@ void RedisReplyBuilder::SendVerbatimString(std::string_view str, VerbatimFormat 
   }
   next += 4;
   std::string_view lenpref{tmp, size_t(next - tmp)};
-  iovec v[4] = {IoVec(lenpref), IoVec(str), IoVec(kCRLF)};
+  iovec v[3] = {IoVec(lenpref), IoVec(str), IoVec(kCRLF)};
   return Send(v, ABSL_ARRAYSIZE(v));
 }
 

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -332,7 +332,7 @@ void RedisReplyBuilder::SendVerbatimString(std::string_view str, VerbatimFormat 
   if (!is_resp3_)
     return SendBulkString(str);
 
-  char tmp[absl::numbers_internal::kFastToBufferSize + 3];
+  char tmp[absl::numbers_internal::kFastToBufferSize + 7];
   tmp[0] = '=';
   // + 4 because format is three byte, and need to be followed by a ":"
   char* next = absl::numbers_internal::FastIntToBuffer(uint32_t(str.size() + 4), tmp + 1);

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -212,6 +212,8 @@ class RedisReplyBuilder : public SinkReplyBuilder {
  public:
   enum CollectionType { ARRAY, SET, MAP, PUSH };
 
+  enum VerbatimFormat { TXT, MARKDOWN };
+
   using StrSpan = std::variant<absl::Span<const std::string>, absl::Span<const std::string_view>>;
 
   RedisReplyBuilder(::io::Sink* stream);
@@ -238,6 +240,7 @@ class RedisReplyBuilder : public SinkReplyBuilder {
   void SendSimpleString(std::string_view str) override;
 
   virtual void SendBulkString(std::string_view str);
+  virtual void SendVerbatimString(std::string_view str, VerbatimFormat format = TXT);
   virtual void SendScoredArray(const std::vector<std::pair<std::string, double>>& arr,
                                bool with_scores);
 

--- a/src/facade/reply_builder_test.cc
+++ b/src/facade/reply_builder_test.cc
@@ -913,6 +913,26 @@ TEST_F(RedisReplyBuilderTest, FormatDouble) {
   EXPECT_STREQ("1e-23", format(1e-23));
 }
 
+TEST_F(RedisReplyBuilderTest, VerbatimString) {
+  // test resp3
+  std::string str = "A simple string!";
+
+  builder_->SetResp3(true);
+  builder_->SendVerbatimString(str, RedisReplyBuilder::VerbatimFormat::TXT);
+  ASSERT_TRUE(builder_->err_count().empty());
+  ASSERT_EQ(TakePayload(), "=20\r\ntxt:A simple string!\r\n") << "Resp3 VerbatimString TXT failed.";
+
+  builder_->SetResp3(true);
+  builder_->SendVerbatimString(str, RedisReplyBuilder::VerbatimFormat::MARKDOWN);
+  ASSERT_TRUE(builder_->err_count().empty());
+  ASSERT_EQ(TakePayload(), "=20\r\nmkd:A simple string!\r\n") << "Resp3 VerbatimString TXT failed.";
+
+  builder_->SetResp3(false);
+  builder_->SendVerbatimString(str);
+  ASSERT_TRUE(builder_->err_count().empty());
+  ASSERT_EQ(TakePayload(), "$16\r\nA simple string!\r\n") << "Resp3 VerbatimString TXT failed.";
+}
+
 static void BM_FormatDouble(benchmark::State& state) {
   vector<double> values;
   char buf[64];

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1275,7 +1275,7 @@ void ServerFamily::ClientList(CmdArgList args, ConnectionContext* cntx) {
 
   string result = absl::StrJoin(client_info, "\n");
   result.append("\n");
-  return (*cntx)->SendBulkString(result);
+  return (*cntx)->SendVerbatimString(result);
 }
 
 void ServerFamily::ClientPause(CmdArgList args, ConnectionContext* cntx) {
@@ -1825,7 +1825,8 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
     append("cluster_enabled", ClusterConfig::IsEnabledOrEmulated());
   }
 
-  (*cntx)->SendBulkString(info);
+  //(*cntx)->SendBulkString(info);
+  (*cntx)->SendVerbatimString(info);
 }
 
 void ServerFamily::Hello(CmdArgList args, ConnectionContext* cntx) {


### PR DESCRIPTION
fixes https://github.com/dragonflydb/dragonfly/issues/2242 https://github.com/dragonflydb/dragonfly/issues/2253

Reference:
The definition of Redis verbatim strings: https://redis.io/docs/reference/protocol-spec/#verbatim-strings

"For example, the Redis command [INFO](https://redis.io/commands/info) outputs a report that includes newlines. When using RESP3, redis-cli displays it correctly because it is sent as a Verbatim String reply (with its three bytes being "txt"). When using RESP2, however, the redis-cli is hard-coded to look for the [INFO](https://redis.io/commands/info) command to ensure its correct display to the user."
