### PR TITLE
feat(server): Support CLIENT TRACKING subcommand (1/2)

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1350,6 +1350,16 @@ void Connection::RequestAsyncMigration(util::fb2::ProactorBase* dest) {
   migration_request_ = dest;
 }
 
+void Connection::SetClientTrackingSwitch(bool is_on) {
+  tracking_enabled_ = is_on;
+  if (tracking_enabled_)
+    cc_->subscriptions++;
+}
+
+bool Connection::IsTrackingOn() const {
+  return tracking_enabled_;
+}
+
 Connection::MemoryUsage Connection::GetMemoryUsage() const {
   size_t mem = sizeof(*this) + dfly::HeapSize(dispatch_q_) + dfly::HeapSize(name_) +
                dfly::HeapSize(tmp_parse_args_) + dfly::HeapSize(tmp_cmd_vec_) +

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1428,8 +1428,12 @@ bool Connection::WeakRef::operator<(const WeakRef& other) {
   return client_id_ < other.client_id_;
 }
 
-bool Connection::WeakRef::operator==(const WeakRef& other) {
+bool Connection::WeakRef::operator==(const WeakRef& other) const {
   return client_id_ == other.client_id_;
 }
+
+// bool Connection::WeakRef::operator==(const WeakRef other) const {
+//   return (client_id_ == other.client_id_);
+// }
 
 }  // namespace facade

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1432,8 +1432,4 @@ bool Connection::WeakRef::operator==(const WeakRef& other) const {
   return client_id_ == other.client_id_;
 }
 
-// bool Connection::WeakRef::operator==(const WeakRef other) const {
-//   return (client_id_ == other.client_id_);
-// }
-
 }  // namespace facade

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -261,6 +261,10 @@ class Connection : public util::Connection {
   // Connections will migrate at most once, and only when the flag --migrate_connections is true.
   void RequestAsyncMigration(util::fb2::ProactorBase* dest);
 
+  void SetClientTrackingSwitch(bool is_on);
+
+  bool IsTrackingOn() const;
+
  protected:
   void OnShutdown() override;
   void OnPreMigrateThread() override;
@@ -400,6 +404,9 @@ class Connection : public util::Connection {
 
   // Per-thread queue backpressure structs.
   static thread_local QueueBackpressure tl_queue_backpressure_;
+
+  // a flag indicating whether the client has turned on client tracking.
+  bool tracking_enabled_ = false;
 };
 
 }  // namespace facade

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -168,7 +168,6 @@ class Connection : public util::Connection {
 
     bool operator<(const WeakRef& other);
     bool operator==(const WeakRef& other) const;
-    // bool operator==(const WeakRef other) const;
 
    private:
     friend class Connection;

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -167,7 +167,8 @@ class Connection : public util::Connection {
     bool EnsureMemoryBudget() const;
 
     bool operator<(const WeakRef& other);
-    bool operator==(const WeakRef& other);
+    bool operator==(const WeakRef& other) const;
+    // bool operator==(const WeakRef other) const;
 
    private:
     friend class Connection;

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -269,6 +269,10 @@ void RedisReplyBuilder::SetResp3(bool is_resp3) {
   is_resp3_ = is_resp3;
 }
 
+bool RedisReplyBuilder::IsResp3() const {
+  return is_resp3_;
+}
+
 void RedisReplyBuilder::SendError(string_view str, string_view err_type) {
   VLOG(1) << "Error: " << str;
 

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -219,6 +219,7 @@ class RedisReplyBuilder : public SinkReplyBuilder {
   RedisReplyBuilder(::io::Sink* stream);
 
   void SetResp3(bool is_resp3);
+  bool IsResp3() const;
 
   void SendError(std::string_view str, std::string_view type = {}) override;
   using SinkReplyBuilder::SendError;

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1338,8 +1338,7 @@ void DbSlice::ResetUpdateEvents() {
   events_.update = 0;
 }
 
-void DbSlice::TrackKeys(const facade::Connection::WeakRef& conn,
-                        const std::vector<std::string_view>& keys) {
+void DbSlice::TrackKeys(const facade::Connection::WeakRef& conn, const ArgSlice& keys) {
   if (conn.IsExpired()) {
     DVLOG(2) << "Connection expired, exiting TrackKey function.";
     return;
@@ -1348,16 +1347,9 @@ void DbSlice::TrackKeys(const facade::Connection::WeakRef& conn,
   DVLOG(2) << "Start tracking keys for client ID: " << conn.GetClientId()
            << " with thread ID: " << conn.Thread();
   for (auto key : keys) {
-    if (client_tracking_map_.find(key) == client_tracking_map_.end()) {
-      DVLOG(2) << "The key " << key << " has not been tracked by any client.";
-      DVLOG(2) << "Creating a new entry in the tracking table for this key.";
-      absl::flat_hash_set<facade::Connection::WeakRef, Hash> tracking_client_set{conn};
-      client_tracking_map_[key] = tracking_client_set;
-    } else {
-      DVLOG(2) << "The key " << key << " exists in the client tracking table.";
-      DVLOG(2) << "Inserting client ID " << conn.GetClientId() << " into its tracking client set: ";
-      client_tracking_map_[key].insert(conn);
-    }
+    DVLOG(2) << "Inserting client ID " << conn.GetClientId()
+             << " into the tracking client set of key " << key;
+    client_tracking_map_[key].insert(conn);
   }
 }
 

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -336,7 +336,7 @@ class DbSlice {
   }
 
   // Track keys for the client represented by the the weak reference to its connection.
-  void TrackKeys(const facade::Connection::WeakRef&, const std::vector<std::string_view>&);
+  void TrackKeys(const facade::Connection::WeakRef&, const ArgSlice&);
 
  private:
   // Releases a single key. `key` must have been normalized by GetLockKey().

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "facade/dragonfly_connection.h"
 #include "facade/op_status.h"
 #include "server/common.h"
 #include "server/conn_context.h"
@@ -334,6 +335,9 @@ class DbSlice {
     expire_allowed_ = is_allowed;
   }
 
+  // Track keys for the client represented by the the weak reference to its connection.
+  void TrackKeys(const facade::Connection::WeakRef&, const std::vector<std::string_view>&);
+
  private:
   // Releases a single key. `key` must have been normalized by GetLockKey().
   void ReleaseNormalized(IntentLock::Mode m, DbIndex db_index, std::string_view key,
@@ -384,6 +388,16 @@ class DbSlice {
 
   // Registered by shard indices on when first document index is created.
   DocDeletionCallback doc_del_cb_;
+
+  struct Hash {
+    size_t operator()(const facade::Connection::WeakRef& c) const {
+      return std::hash<uint32_t>()(c.GetClientId());
+    }
+  };
+
+  // the table that maps keys to the clients that are tracking them.
+  absl::flat_hash_map<std::string, absl::flat_hash_set<facade::Connection::WeakRef, Hash>>
+      client_tracking_map_;
 };
 
 }  // namespace dfly

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1465,6 +1465,9 @@ void Service::Quit(CmdArgList args, ConnectionContext* cntx) {
     cntx->SendOk();
   using facade::SinkReplyBuilder;
 
+  // turn off tracking for this client
+  cntx->conn()->SetClientTrackingSwitch(false);
+
   SinkReplyBuilder* builder = cntx->reply_builder();
   builder->CloseConnection();
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1012,7 +1012,6 @@ string ServerFamily::GetReplicaMasterId() const {
 
 void ServerFamily::OnClose(ConnectionContext* cntx) {
   dfly_cmd_->OnClose(cntx);
-  cntx->conn()->SetClientTrackingSwitch(false);
 }
 
 void ServerFamily::StatsMC(std::string_view section, facade::ConnectionContext* cntx) {

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1345,7 +1345,7 @@ void ServerFamily::ClientPause(CmdArgList args, ConnectionContext* cntx) {
 }
 
 void ServerFamily::ClientTracking(CmdArgList args, ConnectionContext* cntx) {
-  if (args.size() != 2)
+  if (args.size() != 1)
     return cntx->SendError(kSyntaxErr);
 
   auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
@@ -1353,8 +1353,8 @@ void ServerFamily::ClientTracking(CmdArgList args, ConnectionContext* cntx) {
     return cntx->SendError(
         "Client tracking is currently not supported for RESP2. Please use RESP3.");
 
-  ToUpper(&args[1]);
-  string_view state = ArgS(args, 1);
+  ToUpper(&args[0]);
+  string_view state = ArgS(args, 0);
   bool is_on;
   if (state == "ON") {
     is_on = true;

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -214,6 +214,7 @@ class ServerFamily {
   void ClientGetName(CmdArgList args, ConnectionContext* cntx);
   void ClientList(CmdArgList args, ConnectionContext* cntx);
   void ClientPause(CmdArgList args, ConnectionContext* cntx);
+  void ClientTracking(CmdArgList args, ConnectionContext* cntx);
   void Config(CmdArgList args, ConnectionContext* cntx);
   void DbSize(CmdArgList args, ConnectionContext* cntx);
   void Debug(CmdArgList args, ConnectionContext* cntx);

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -906,6 +906,12 @@ void Transaction::Conclude() {
   Execute(std::move(cb), true);
 }
 
+void Transaction::Refurbish() {
+  txid_ = 0;
+  coordinator_state_ = 0;
+  cb_ptr_ = nullptr;
+}
+
 void Transaction::EnableShard(ShardId sid) {
   unique_shard_cnt_ = 1;
   unique_shard_id_ = sid;

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -323,6 +323,8 @@ class Transaction {
   // Utility to run a single hop on a no-key command
   static void RunOnceAsCommand(const CommandId* cid, RunnableType cb);
 
+  void Refurbish();
+
  private:
   // Holds number of locks for each IntentLock::Mode: shared and exlusive.
   struct LockCnt {


### PR DESCRIPTION
fixes https://github.com/dragonflydb/dragonfly/issues/2139

Implement CLIENT TRACKING subcommand.
 
Track the keys of a readonly command by maintaining mapping that maps keys to the sets of tracking clients.

Also include a transaction interface `Refurbish()`  that allows the reuse of a transaction, which is used for tracking the keys involved in a readonly command.
