### PR TITLE
fix(server): handle no-key-transactional commands in multi/exec

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -678,6 +678,12 @@ optional<Transaction::MultiMode> DeduceExecMode(ExecEvalState state,
     for (const auto& scmd : exec_info.body) {
       transactional |= scmd.Cid()->IsTransactional();
       contains_global |= scmd.Cid()->opt_mask() & CO::GLOBAL_TRANS;
+
+      // We can't run no-key-transactional commands in lock-ahead mode currently,
+      // because it means we have to schedule on all shards
+      if (scmd.Cid()->opt_mask() & CO::NO_KEY_TRANSACTIONAL)
+        contains_global = true;
+
       if (contains_global)
         break;
     }

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -920,6 +920,12 @@ TEST_F(MultiTest, EvalExpiration) {
   EXPECT_LE(CheckedInt({"pttl", "x"}), 5000);
 }
 
+TEST_F(MultiTest, NoKeyTransactional) {
+  Run({"multi"});
+  Run({"ft._list"});
+  Run({"exec"});
+}
+
 class MultiEvalTest : public BaseFamilyTest {
  protected:
   MultiEvalTest() : BaseFamilyTest() {


### PR DESCRIPTION
Fixes #2278 