### PR TITLE
fix(tiering): fix tiering crash on setting expire

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -935,7 +935,9 @@ void DbSlice::PreUpdate(DbIndex db_ind, PrimeIterator it) {
       TieredStorage* tiered = shard_owner()->tiered_storage();
       auto [offset, size] = it->second.GetExternalSlice();
       tiered->Free(offset, size);
+      bool has_expire = it->second.HasExpire();
       it->second.Reset();
+      it->second.SetExpire(has_expire);  // we keep expire data
 
       stats->tiered_entries -= 1;
       stats->tiered_size -= size;

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -277,12 +277,7 @@ unsigned TieredStorage::InflightWriteRequest::ExternalizeEntries(PerDb::BinRecor
     if (it != bin_record->enqueued_entries.end() && it->second == this) {
       PrimeIterator pit = pt->Find(pkey);
       size_t item_offset = page_index_ * 4096 + offset + i * bin_size;
-
-      // TODO: the key may be deleted or overriden. The last one is especially dangerous.
-      // we should update active pending request with any change we make to the entry.
-      // it should not be a problem since we have HasIoPending tag that mean we must
-      // update the inflight request (or mark the entry as cancelled).
-      CHECK(!pit.is_done()) << "TBD";
+      CHECK(!pit.is_done());
 
       ExternalizeEntry(item_offset, stats, &pit->second);
       VLOG(2) << "ExternalizeEntry: " << it->first;
@@ -300,9 +295,7 @@ void TieredStorage::InflightWriteRequest::Undo(PerDb::BinRecord* bin_record, DbS
     if (it != bin_record->enqueued_entries.end() && it->second == this) {
       PrimeIterator pit = pt->Find(pkey);
 
-      // TODO: what happens when if the entry was deleted meanwhile
-      // or it has been serialized again?
-      CHECK(pit->second.HasIoPending()) << "TBD: fix inconsistencies";
+      CHECK(pit->second.HasIoPending());
       VLOG(2) << "Undo key:" << pkey;
       pit->second.SetIoPending(false);
 


### PR DESCRIPTION
fixes #2224
the bug: when updateing entry pre update will resets the PrimeValue if this is an external entries leading to crash if we insert entries with expire time.

the fix: reserve the expire mask in PrimeValue on pre update

