### PR TITLE
feat: add command flow for slot migration process

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(dragonfly_lib engine_shard_set.cc channel_store.cc command_registry.
             zset_family.cc version.cc bitops_family.cc container_utils.cc io_utils.cc
             top_keys.cc multi_command_squasher.cc hll_family.cc cluster/cluster_config.cc
             cluster/cluster_family.cc cluster/cluster_slot_migration.cc
+            cluster/cluster_shard_migration.cc
             acl/user.cc acl/user_registry.cc acl/acl_family.cc
             acl/validator.cc acl/helpers.cc)
 

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -686,8 +686,7 @@ ClusterSlotMigration* ClusterFamily::AddMigration(std::string host_ip, uint16_t 
     }
   }
   return migrations_jobs_
-      .emplace_back(make_unique<ClusterSlotMigration>(std::string(host_ip), port,
-                                                      &server_family_->service(), std::move(slots)))
+      .emplace_back(make_unique<ClusterSlotMigration>(std::string(host_ip), port, std::move(slots)))
       .get();
 }
 

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -728,8 +728,8 @@ void ClusterFamily::MigrationConf(CmdArgList args, ConnectionContext* cntx) {
   cntx->conn()->SetName("slot_migration_ctrl");
   auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
   rb->StartArray(2);
-  cntx->SendLong(shard_set->size());
-  cntx->SendLong(sync_id);
+  rb->SendLong(sync_id);
+  rb->SendLong(shard_set->size());
   return;
 }
 
@@ -747,8 +747,9 @@ void ClusterFamily::Flow(CmdArgList args, ConnectionContext* cntx) {
   CmdArgParser parser{args};
   auto [sync_id, shard_id] = parser.Next<uint32_t, uint32_t>();
 
-  if (auto err = parser.Error(); err)
+  if (auto err = parser.Error(); err) {
     return cntx->SendError(err->MakeReply());
+  }
 
   VLOG(1) << "Create flow "
           << " sync_id: " << sync_id << " shard_id: " << shard_id << " shard";

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -703,8 +703,7 @@ void ClusterFamily::MigrationConf(CmdArgList args, ConnectionContext* cntx) {
     slots.emplace_back(SlotRange{slot_start, slot_end});
   } while (parser.HasNext());
 
-  if (auto err = parser.Error(); err)
-    return cntx->SendError(err->MakeReply());
+  DCHECK(!parser.Error());
 
   if (!tl_cluster_config) {
     cntx->SendError(kClusterNotConfigured);
@@ -731,13 +730,9 @@ void ClusterFamily::MigrationConf(CmdArgList args, ConnectionContext* cntx) {
 void ClusterFamily::Flow(CmdArgList args, ConnectionContext* cntx) {
   CmdArgParser parser{args};
   auto shard_id = parser.Next<size_t>();
+  DCHECK(!parser.Error());
 
   VLOG(1) << "Create flow for " << shard_id << " shard";
-
-  absl::InsecureBitGen gen;
-  string eof_token = GetRandomHex(gen, 40);
-
-  cntx->SendSimpleString(eof_token);
 }
 
 using EngineFunc = void (ClusterFamily::*)(CmdArgList args, ConnectionContext* cntx);

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -697,7 +697,6 @@ void ClusterFamily::MigrationConf(CmdArgList args, ConnectionContext* cntx) {
   VLOG(1) << "Create slot migration config";
   CmdArgParser parser{args};
   auto port = parser.Next<uint16_t>();
-  ;
 
   std::vector<ClusterConfig::SlotRange> slots;
   do {
@@ -735,7 +734,7 @@ void ClusterFamily::MigrationConf(CmdArgList args, ConnectionContext* cntx) {
 
 uint32_t ClusterFamily::CreateMigrationSession(ConnectionContext* cntx, uint16_t port) {
   std::lock_guard lk(migration_mu_);
-  auto sync_id = next_sync_id++;
+  auto sync_id = next_sync_id_++;
   auto info = make_shared<MigrationInfo>(cntx->conn()->RemoteEndpointAddress(), sync_id, port);
   auto [it, inserted] = migration_infos_.emplace(sync_id, info);
   CHECK(inserted);

--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -61,15 +61,19 @@ class ClusterFamily {
   void Flow(CmdArgList args, ConnectionContext* cntx);
   void Sync(CmdArgList args, ConnectionContext* cntx);
 
+  struct FlowInfo {
+    facade::Connection* conn = nullptr;
+  };
+
   struct MigrationInfo {
     MigrationInfo() = default;
-    MigrationInfo(std::string ip, uint32_t sync_id, uint16_t port)
-        : host_ip(ip), sync_id(sync_id), port(port) {
+    MigrationInfo(std::uint32_t flows_num, std::string ip, uint32_t sync_id, uint16_t port)
+        : host_ip(ip), sync_id(sync_id), port(port), flows(flows_num) {
     }
     std::string host_ip;
-    facade::Connection* conn = nullptr;
     uint32_t sync_id;
     uint16_t port;
+    std::vector<FlowInfo> flows;
   };
 
   std::shared_ptr<MigrationInfo> GetMigrationInfo(uint32_t sync_id);

--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -53,13 +53,16 @@ class ClusterFamily {
   void DflyMigrate(CmdArgList args, ConnectionContext* cntx);
 
   void MigrationConf(CmdArgList args, ConnectionContext* cntx);
+  void Flow(CmdArgList args, ConnectionContext* cntx);
+  void Sync(CmdArgList args, ConnectionContext* cntx);
+
+  // create a ClusterSlotMigration entity which will execute migration
   ClusterSlotMigration* AddMigration(std::string host_ip, uint16_t port,
                                      std::vector<ClusterConfig::SlotRange> slots);
 
-  uint32_t CreateMigrationSession(ConnectionContext* cntx, uint16_t port);
-
-  void Flow(CmdArgList args, ConnectionContext* cntx);
-  void Sync(CmdArgList args, ConnectionContext* cntx);
+  // store info about migration and create unique session id
+  uint32_t CreateMigrationSession(ConnectionContext* cntx, uint16_t port,
+                                  std::vector<ClusterConfig::SlotRange> slots);
 
   struct FlowInfo {
     facade::Connection* conn = nullptr;
@@ -67,13 +70,15 @@ class ClusterFamily {
 
   struct MigrationInfo {
     MigrationInfo() = default;
-    MigrationInfo(std::uint32_t flows_num, std::string ip, uint32_t sync_id, uint16_t port)
-        : host_ip(ip), sync_id(sync_id), port(port), flows(flows_num) {
+    MigrationInfo(std::uint32_t flows_num, std::string ip, uint32_t sync_id, uint16_t port,
+                  std::vector<ClusterConfig::SlotRange> slots)
+        : host_ip(ip), flows(flows_num), slots(slots), sync_id(sync_id), port(port) {
     }
     std::string host_ip;
+    std::vector<FlowInfo> flows;
+    std::vector<ClusterConfig::SlotRange> slots;
     uint32_t sync_id;
     uint16_t port;
-    std::vector<FlowInfo> flows;
   };
 
   std::shared_ptr<MigrationInfo> GetMigrationInfo(uint32_t sync_id);

--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -83,7 +83,7 @@ class ClusterFamily {
   std::vector<std::unique_ptr<ClusterSlotMigration>> migrations_jobs_
       ABSL_GUARDED_BY(migration_mu_);
 
-  uint32_t next_sync_id = 1;
+  uint32_t next_sync_id_ = 1;
   using MigrationInfoMap = absl::btree_map<uint32_t, std::shared_ptr<MigrationInfo>>;
   MigrationInfoMap migration_infos_;
 };

--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -54,6 +54,8 @@ class ClusterFamily {
   ClusterSlotMigration* AddMigration(std::string host_ip, uint16_t port,
                                      std::vector<ClusterConfig::SlotRange> slots);
 
+  void Flow(CmdArgList args, ConnectionContext* cntx);
+
   ClusterConfig::ClusterShard GetEmulatedShardInfo(ConnectionContext* cntx) const;
 
   ServerFamily* server_family_ = nullptr;

--- a/src/server/cluster/cluster_shard_migration.cc
+++ b/src/server/cluster/cluster_shard_migration.cc
@@ -1,0 +1,57 @@
+// Copyright 2023, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+#include "server/cluster/cluster_shard_migration.h"
+
+#include <absl/flags/flag.h>
+#include <absl/strings/str_cat.h>
+
+#include "base/logging.h"
+#include "server/error.h"
+
+ABSL_DECLARE_FLAG(int, source_connect_timeout_ms);
+
+namespace dfly {
+
+using namespace std;
+using namespace facade;
+using absl::GetFlag;
+
+ClusterShardMigration::ClusterShardMigration(ServerContext server_context, uint32_t shard_id)
+    : ProtocolClient(server_context), source_shard_id_(shard_id) {
+}
+
+ClusterShardMigration::~ClusterShardMigration() {
+}
+
+std::error_code ClusterShardMigration::StartSyncFlow(BlockingCounter sb, Context* cntx) {
+  using nonstd::make_unexpected;
+
+  RETURN_ON_ERR(ConnectAndAuth(absl::GetFlag(FLAGS_source_connect_timeout_ms) * 1ms, &cntx_));
+
+  VLOG(1) << "Sending on flow " << source_shard_id_;
+
+  std::string cmd = absl::StrCat("DFLYMIGRATE FLOW ", source_shard_id_);
+
+  ResetParser(/*server_mode=*/false);
+  leftover_buf_.emplace(128);
+  RETURN_ON_ERR(SendCommand(cmd));
+  auto read_resp = ReadRespReply(&*leftover_buf_);
+  if (!read_resp.has_value()) {
+    return read_resp.error();
+  }
+
+  PC_RETURN_ON_BAD_RESPONSE(CheckRespFirstTypes({RespExpr::STRING}));
+
+  string eof_token(ToSV(LastResponseArgs()[0].GetBuf()));
+
+  sb.Dec();  // for future sync
+
+  return {};
+}
+
+void ClusterShardMigration::Cancel() {
+  CloseSocket();
+}
+
+}  // namespace dfly

--- a/src/server/cluster/cluster_shard_migration.cc
+++ b/src/server/cluster/cluster_shard_migration.cc
@@ -24,7 +24,7 @@ ClusterShardMigration::ClusterShardMigration(ServerContext server_context, uint3
 ClusterShardMigration::~ClusterShardMigration() {
 }
 
-std::error_code ClusterShardMigration::StartSyncFlow(BlockingCounter sb, Context* cntx) {
+std::error_code ClusterShardMigration::StartSyncFlow(Context* cntx) {
   using nonstd::make_unexpected;
 
   RETURN_ON_ERR(ConnectAndAuth(absl::GetFlag(FLAGS_source_connect_timeout_ms) * 1ms, &cntx_));
@@ -42,10 +42,6 @@ std::error_code ClusterShardMigration::StartSyncFlow(BlockingCounter sb, Context
   }
 
   PC_RETURN_ON_BAD_RESPONSE(CheckRespFirstTypes({RespExpr::STRING}));
-
-  string eof_token(ToSV(LastResponseArgs()[0].GetBuf()));
-
-  sb.Dec();  // for future sync
 
   return {};
 }

--- a/src/server/cluster/cluster_shard_migration.h
+++ b/src/server/cluster/cluster_shard_migration.h
@@ -10,15 +10,22 @@ namespace dfly {
 
 class ClusterShardMigration : public ProtocolClient {
  public:
-  ClusterShardMigration(ServerContext server_context, uint32_t shard_id);
+  ClusterShardMigration(ServerContext server_context, uint32_t shard_id, uint32_t sync_id);
   ~ClusterShardMigration();
 
   std::error_code StartSyncFlow(Context* cntx);
   void Cancel();
 
  private:
+  void FullSyncShardFb(Context* cntx);
+  void JoinFlow();
+
+ private:
   uint32_t source_shard_id_;
+  uint32_t sync_id_;
   std::optional<base::IoBuf> leftover_buf_;
+
+  Fiber sync_fb_;
 };
 
 }  // namespace dfly

--- a/src/server/cluster/cluster_shard_migration.h
+++ b/src/server/cluster/cluster_shard_migration.h
@@ -8,6 +8,8 @@
 
 namespace dfly {
 
+// ClusterShardMigration manage data receiving in slots migration process.
+// It is created per shard on the target node to initiate FLOW step.
 class ClusterShardMigration : public ProtocolClient {
  public:
   ClusterShardMigration(ServerContext server_context, uint32_t shard_id, uint32_t sync_id);

--- a/src/server/cluster/cluster_shard_migration.h
+++ b/src/server/cluster/cluster_shard_migration.h
@@ -13,7 +13,7 @@ class ClusterShardMigration : public ProtocolClient {
   ClusterShardMigration(ServerContext server_context, uint32_t shard_id);
   ~ClusterShardMigration();
 
-  std::error_code StartSyncFlow(BlockingCounter sb, Context* cntx);
+  std::error_code StartSyncFlow(Context* cntx);
   void Cancel();
 
  private:

--- a/src/server/cluster/cluster_shard_migration.h
+++ b/src/server/cluster/cluster_shard_migration.h
@@ -1,0 +1,24 @@
+// Copyright 2023, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+#pragma once
+
+#include "base/io_buf.h"
+#include "server/protocol_client.h"
+
+namespace dfly {
+
+class ClusterShardMigration : public ProtocolClient {
+ public:
+  ClusterShardMigration(ServerContext server_context, uint32_t shard_id);
+  ~ClusterShardMigration();
+
+  std::error_code StartSyncFlow(BlockingCounter sb, Context* cntx);
+  void Cancel();
+
+ private:
+  uint32_t source_shard_id_;
+  std::optional<base::IoBuf> leftover_buf_;
+};
+
+}  // namespace dfly

--- a/src/server/cluster/cluster_slot_migration.cc
+++ b/src/server/cluster/cluster_slot_migration.cc
@@ -107,13 +107,13 @@ void ClusterSlotMigration::MainMigrationFb() {
   state_ = ClusterSlotMigration::C_FULL_SYNC;
 
   // TODO add reconnection code
-  if (auto ec = InitiateDflyFullSync(); ec) {
+  if (auto ec = InitiateSlotsMigration(); ec) {
     LOG(WARNING) << "Error syncing with " << server().Description() << " " << ec << " "
                  << ec.message();
   }
 }
 
-std::error_code ClusterSlotMigration::InitiateDflyFullSync() {
+std::error_code ClusterSlotMigration::InitiateSlotsMigration() {
   shard_flows_.resize(source_shards_num_);
   for (unsigned i = 0; i < source_shards_num_; ++i) {
     shard_flows_[i].reset(new ClusterShardMigration(server(), i, sync_id_));

--- a/src/server/cluster/cluster_slot_migration.cc
+++ b/src/server/cluster/cluster_slot_migration.cc
@@ -86,12 +86,12 @@ error_code ClusterSlotMigration::Greet() {
   }
   VLOG(1) << "Migration command: " << cmd;
   RETURN_ON_ERR(SendCommandAndReadResponse(cmd));
-  // Response is: num_shards
-  if (!CheckRespFirstTypes({RespExpr::INT64}))
+  // Response is: sync_id, num_shards
+  if (!CheckRespFirstTypes({RespExpr::INT64, RespExpr::INT64}))
     return make_error_code(errc::bad_message);
 
-  source_shards_num_ = get<int64_t>(LastResponseArgs()[0].u);
   sync_id_ = get<int64_t>(LastResponseArgs()[0].u);
+  source_shards_num_ = get<int64_t>(LastResponseArgs()[1].u);
 
   return error_code{};
 }

--- a/src/server/cluster/cluster_slot_migration.cc
+++ b/src/server/cluster/cluster_slot_migration.cc
@@ -3,9 +3,11 @@
 //
 #include "server/cluster/cluster_slot_migration.h"
 
+#include <absl/cleanup/cleanup.h>
 #include <absl/flags/flag.h>
 
 #include "base/logging.h"
+#include "server/cluster/cluster_shard_migration.h"
 #include "server/error.h"
 #include "server/main_service.h"
 
@@ -17,15 +19,29 @@ ABSL_DECLARE_FLAG(int32_t, port);
 namespace dfly {
 
 using namespace std;
+using namespace util;
 using namespace facade;
 using absl::GetFlag;
 
-ClusterSlotMigration::ClusterSlotMigration(string host_ip, uint16_t port,
+namespace {
+// Distribute flow indices over all available threads (shard_set pool size).
+vector<vector<unsigned>> Partition(unsigned num_flows) {
+  vector<vector<unsigned>> partition(shard_set->pool()->size());
+  for (unsigned i = 0; i < num_flows; ++i) {
+    partition[i % partition.size()].push_back(i);
+  }
+  return partition;
+}
+
+}  // namespace
+
+ClusterSlotMigration::ClusterSlotMigration(string host_ip, uint16_t port, Service* se,
                                            std::vector<ClusterConfig::SlotRange> slots)
-    : ProtocolClient(std::move(host_ip), port), slots_(std::move(slots)) {
+    : ProtocolClient(move(host_ip), port), service_(*se), slots_(std::move(slots)) {
 }
 
 ClusterSlotMigration::~ClusterSlotMigration() {
+  sync_fb_.JoinIfNeeded();
 }
 
 error_code ClusterSlotMigration::Start(ConnectionContext* cntx) {
@@ -46,11 +62,13 @@ error_code ClusterSlotMigration::Start(ConnectionContext* cntx) {
   ec = ConnectAndAuth(absl::GetFlag(FLAGS_source_connect_timeout_ms) * 1ms, &cntx_);
   RETURN_ON_ERR(check_connection_error(ec, "couldn't connect to source"));
 
+  state_ = ClusterSlotMigration::C_CONNECTING;
+
   VLOG(1) << "Greeting";
   ec = Greet();
   RETURN_ON_ERR(check_connection_error(ec, "couldn't greet source "));
 
-  state_ = ClusterSlotMigration::C_CONNECTING;
+  sync_fb_ = fb2::Fiber("main_migration", &ClusterSlotMigration::MainMigrationFb, this);
 
   return {};
 }
@@ -72,7 +90,7 @@ error_code ClusterSlotMigration::Greet() {
   if (!CheckRespFirstTypes({RespExpr::INT64}))
     return make_error_code(errc::bad_message);
 
-  souce_shards_num_ = get<int64_t>(LastResponseArgs()[0].u);
+  source_shards_num_ = get<int64_t>(LastResponseArgs()[0].u);
 
   return error_code{};
 }
@@ -80,6 +98,75 @@ error_code ClusterSlotMigration::Greet() {
 ClusterSlotMigration::Info ClusterSlotMigration::GetInfo() const {
   const auto& ctx = server();
   return {ctx.host, ctx.port, state_};
+}
+
+void ClusterSlotMigration::MainMigrationFb() {
+  VLOG(1) << "Main migration fiber started";
+
+  state_ = ClusterSlotMigration::C_FULL_SYNC;
+
+  // TODO add reconnection code
+  if (auto ec = InitiateDflyFullSync(); ec) {
+    LOG(WARNING) << "Error syncing with " << server().Description() << " " << ec << " "
+                 << ec.message();
+  }
+}
+
+std::error_code ClusterSlotMigration::InitiateDflyFullSync() {
+  shard_flows_.resize(source_shards_num_);
+  for (unsigned i = 0; i < source_shards_num_; ++i) {
+    shard_flows_[i].reset(new ClusterShardMigration(server(), i));
+  }
+
+  // Blocked on until all flows got full sync cut.
+  BlockingCounter sync_block{source_shards_num_};
+
+  // Switch to new error handler that closes flow sockets.
+  auto err_handler = [this, sync_block](const auto& ge) mutable {
+    // Unblock this function.
+    sync_block.Cancel();
+
+    // Make sure the flows are not in a state transition
+    lock_guard lk{flows_op_mu_};
+
+    // Unblock all sockets.
+    DefaultErrorHandler(ge);
+    for (auto& flow : shard_flows_)
+      flow->Cancel();
+  };
+  RETURN_ON_ERR(cntx_.SwitchErrorHandler(std::move(err_handler)));
+
+  CHECK(service_.SwitchState(GlobalState::ACTIVE, GlobalState::LOADING).first ==
+        GlobalState::LOADING);
+
+  absl::Cleanup cleanup = [this]() {
+    // We do the following operations regardless of outcome.
+    service_.SwitchState(GlobalState::LOADING, GlobalState::ACTIVE);
+  };
+
+  std::atomic_uint32_t synced_shards = 0;
+  auto partition = Partition(source_shards_num_);
+  auto shard_cb = [&](unsigned index, auto*) {
+    for (auto id : partition[index]) {
+      auto ec = shard_flows_[id]->StartSyncFlow(sync_block, &cntx_);
+      if (!ec) {
+        ++synced_shards;
+      } else {
+        cntx_.ReportError(ec);
+      }
+    }
+  };
+  // Lock to prevent the error handler from running instantly
+  // while the flows are in a mixed state.
+  lock_guard lk{flows_op_mu_};
+  shard_set->pool()->AwaitFiberOnAll(std::move(shard_cb));
+
+  VLOG(1) << synced_shards << " from " << source_shards_num_ << " shards is synchronized";
+  if (synced_shards != source_shards_num_) {
+    cntx_.ReportError(std::make_error_code(errc::state_not_recoverable), "full sync is failed");
+  }
+
+  return cntx_.GetError();
 }
 
 }  // namespace dfly

--- a/src/server/cluster/cluster_slot_migration.cc
+++ b/src/server/cluster/cluster_slot_migration.cc
@@ -35,9 +35,9 @@ vector<vector<unsigned>> Partition(unsigned num_flows) {
 
 }  // namespace
 
-ClusterSlotMigration::ClusterSlotMigration(string host_ip, uint16_t port, Service* se,
+ClusterSlotMigration::ClusterSlotMigration(string host_ip, uint16_t port,
                                            std::vector<ClusterConfig::SlotRange> slots)
-    : ProtocolClient(move(host_ip), port), service_(*se), slots_(std::move(slots)) {
+    : ProtocolClient(move(host_ip), port), slots_(std::move(slots)) {
 }
 
 ClusterSlotMigration::~ClusterSlotMigration() {

--- a/src/server/cluster/cluster_slot_migration.h
+++ b/src/server/cluster/cluster_slot_migration.h
@@ -35,6 +35,7 @@ class ClusterSlotMigration : ProtocolClient {
   std::error_code Greet();
   std::vector<ClusterConfig::SlotRange> slots_;
   uint32_t source_shards_num_ = 0;
+  uint32_t sync_id_ = 0;
   State state_ = C_NO_STATE;
 
   Fiber sync_fb_;

--- a/src/server/cluster/cluster_slot_migration.h
+++ b/src/server/cluster/cluster_slot_migration.h
@@ -27,7 +27,7 @@ class ClusterSlotMigration : ProtocolClient {
 
  private:
   void MainMigrationFb();
-  std::error_code InitiateDflyFullSync();
+  std::error_code InitiateSlotsMigration();
 
  private:
   Mutex flows_op_mu_;

--- a/src/server/cluster/cluster_slot_migration.h
+++ b/src/server/cluster/cluster_slot_migration.h
@@ -18,7 +18,7 @@ class ClusterSlotMigration : ProtocolClient {
     State state;
   };
 
-  ClusterSlotMigration(std::string host_ip, uint16_t port, Service* se,
+  ClusterSlotMigration(std::string host_ip, uint16_t port,
                        std::vector<ClusterConfig::SlotRange> slots);
   ~ClusterSlotMigration();
 
@@ -30,7 +30,6 @@ class ClusterSlotMigration : ProtocolClient {
   std::error_code InitiateDflyFullSync();
 
  private:
-  Service& service_;
   Mutex flows_op_mu_;
   std::vector<std::unique_ptr<ClusterShardMigration>> shard_flows_;
   std::error_code Greet();

--- a/src/server/cluster/cluster_slot_migration.h
+++ b/src/server/cluster/cluster_slot_migration.h
@@ -8,6 +8,9 @@
 
 namespace dfly {
 
+// The main entity on the target side that manage slots migration process
+// Creates initial connection between the target and source node,
+// manage migration process state and data
 class ClusterSlotMigration : ProtocolClient {
  public:
   enum State : uint8_t { C_NO_STATE, C_CONNECTING, C_FULL_SYNC, C_STABLE_SYNC };
@@ -22,17 +25,20 @@ class ClusterSlotMigration : ProtocolClient {
                        std::vector<ClusterConfig::SlotRange> slots);
   ~ClusterSlotMigration();
 
+  // Initiate connection with source node and create migration fiber
   std::error_code Start(ConnectionContext* cntx);
   Info GetInfo() const;
 
  private:
+  // Send DFLYMIGRATE CONF to the source and get info about migration process
+  std::error_code Greet();
   void MainMigrationFb();
+  // Creates flows, one per shard on the source node and manage migration process
   std::error_code InitiateSlotsMigration();
 
  private:
   Mutex flows_op_mu_;
   std::vector<std::unique_ptr<ClusterShardMigration>> shard_flows_;
-  std::error_code Greet();
   std::vector<ClusterConfig::SlotRange> slots_;
   uint32_t source_shards_num_ = 0;
   uint32_t sync_id_ = 0;

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -801,10 +801,12 @@ async def test_cluster_slot_migration(df_local_factory: DflyInstanceFactory):
     )
     assert "OK" == res
 
+    await asyncio.sleep(0.5)
+
     status = await c_nodes_admin[1].execute_command(
         "DFLYCLUSTER", "SLOT-MIGRATION-STATUS", "127.0.0.1", str(nodes[0].admin_port)
     )
-    assert "CONNECTING" == status
+    assert "FULL_SYNC" == status
 
     try:
         await c_nodes_admin[1].execute_command(


### PR DESCRIPTION
fixes #2295

DFLYMIGRATE FLOW command was added to establish connections for every shard replication process.
The slow serialization step is a separate issue so for now only eof_token is sent to reply for the DFLYMIGRATE FLOW command.
The expected state for START-SLOT-MIGRATION is FULL_SYNC now.