### PR TITLE
fix(bug): access invalid prime table iterator

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -691,7 +691,7 @@ void DbSlice::FlushDbIndexes(const std::vector<DbIndex>& indexes) {
       tiered->CancelAllIos(index);
     }
   }
-
+  CHECK(bumped_items_.empty());
   auto cb = [this, flush_db_arr = std::move(flush_db_arr)]() mutable {
     for (auto& db_ptr : flush_db_arr) {
       if (db_ptr && db_ptr->stats.tiered_entries > 0) {

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -478,7 +478,7 @@ DbSlice::ItAndExp DbSlice::FindInternal(const Context& cntx, std::string_view ke
     }
     res.it = db.prime.BumpUp(res.it, PrimeBumpPolicy{bumped_items_});
     ++events_.bumpups;
-    bumped_items_.insert(res.first->first.AsRef());
+    bumped_items_.insert(res.it->first.AsRef());
   }
 
   db.top_keys.Touch(key);

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -448,7 +448,7 @@ class DbSlice {
   std::vector<std::pair<uint64_t, ChangeCallback>> change_cb_;
 
   // Used in temporary computations in Find item and CbFinish
-  mutable absl::flat_hash_set<std::string_view> bump_items_;
+  mutable absl::flat_hash_set<CompactObjectView, PrimeHasher> bumped_items_;
 
   // Registered by shard indices on when first document index is created.
   DocDeletionCallback doc_del_cb_;

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -276,6 +276,8 @@ class DbSlice {
     return shard_id_;
   }
 
+  void OnCbFinish();
+
   bool Acquire(IntentLock::Mode m, const KeyLockArgs& lock_args);
 
   void Release(IntentLock::Mode m, const KeyLockArgs& lock_args);
@@ -444,6 +446,9 @@ class DbSlice {
 
   // ordered from the smallest to largest version.
   std::vector<std::pair<uint64_t, ChangeCallback>> change_cb_;
+
+  // Used in temporary computations in Find item and CbFinish
+  mutable absl::flat_hash_set<std::string_view> bump_items_;
 
   // Registered by shard indices on when first document index is created.
   DocDeletionCallback doc_del_cb_;

--- a/src/server/table.h
+++ b/src/server/table.h
@@ -47,6 +47,12 @@ inline bool IsValid(ExpireConstIterator it) {
   return !it.is_done();
 }
 
+struct PrimeHasher {
+  size_t operator()(const PrimeKey& o) const {
+    return o.HashCode();
+  }
+};
+
 struct SlotStats {
   uint64_t key_count = 0;
   uint64_t total_reads = 0;

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -100,12 +100,6 @@ static size_t ExternalizeEntry(size_t item_offset, DbTableStats* stats, PrimeVal
   return item_size;
 }
 
-struct PrimeHasher {
-  size_t operator()(const PrimeKey& o) const {
-    return o.HashCode();
-  }
-};
-
 struct SingleRequest {
   SingleRequest(size_t blob_len, int64 offset, string key)
       : blob_len(blob_len), offset(offset), key(std::move(key)) {
@@ -422,7 +416,7 @@ error_code TieredStorage::ScheduleOffload(DbIndex db_index, PrimeIterator it) {
   CHECK_LT(bin_record.pending_entries.size(), max_entries);
 
   VLOG(2) << "ScheduleOffload:" << it->first.ToString();
-  bin_record.pending_entries.insert(it->first);
+  bin_record.pending_entries.insert(it->first.AsRef());
   it->second.SetIoPending(true);
 
   if (bin_record.pending_entries.size() < max_entries)

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -497,6 +497,7 @@ bool Transaction::RunInShard(EngineShard* shard, bool txq_ooo) {
   if (is_concluding)  // Check last hop
     LogAutoJournalOnShard(shard);
 
+  shard->db_slice().OnCbFinish();
   // at least the coordinator thread owns the reference.
   DCHECK_GE(GetUseCount(), 1u);
 

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -951,7 +951,7 @@ void Transaction::RunQuickie(EngineShard* shard) {
   } catch (std::exception& e) {
     LOG(FATAL) << "Unexpected exception " << e.what();
   }
-
+  shard->db_slice().OnCbFinish();
   LogAutoJournalOnShard(shard);
 
   sd.is_armed.store(false, memory_order_relaxed);
@@ -1239,6 +1239,7 @@ OpStatus Transaction::RunSquashedMultiCb(RunnableType cb) {
   DCHECK_EQ(unique_shard_cnt_, 1u);
   auto* shard = EngineShard::tlocal();
   auto status = cb(this, shard);
+  shard->db_slice().OnCbFinish();
   LogAutoJournalOnShard(shard);
   return status;
 }


### PR DESCRIPTION
fixes #2276 
The bug:
When running dragonfly in cache mode we bump up items on dash table when we find them. If we access few items on the callback that reside next to each other we will invalidate the first found iterator.

The fix:
After we bump up entry we insert the key to bump keys set. When checking if we can bump down a key we check the key is not in this set. Once we finish running the transaction callback we clear the set.