### PR TITLE
feat(server): Account for RObj concrete objects

### DIFF
--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -324,6 +324,17 @@ class CompactObj {
   static void InitThreadLocal(MemoryResource* mr);
   static MemoryResource* memory_resource();  // thread-local.
 
+  template <typename T> static T* AllocateMR() {
+    void* ptr = memory_resource()->allocate(sizeof(T), alignof(T));
+    return new (ptr) T{memory_resource()};
+  }
+
+  template <typename T> static void DeleteMR(void* ptr) {
+    T* t = (T*)ptr;
+    t->~T();
+    memory_resource()->deallocate(ptr, alignof(T));
+  }
+
  private:
   size_t DecodedLen(size_t sz) const;
 

--- a/src/core/sorted_map.cc
+++ b/src/core/sorted_map.cc
@@ -1067,7 +1067,7 @@ SortedMap::~SortedMap() {
 }
 
 // taken from zsetConvert
-unique_ptr<SortedMap> SortedMap::FromListPack(PMR_NS::memory_resource* res, const uint8_t* lp) {
+SortedMap* SortedMap::FromListPack(PMR_NS::memory_resource* res, const uint8_t* lp) {
   uint8_t* zl = (uint8_t*)lp;
   unsigned char *eptr, *sptr;
   unsigned char* vstr;
@@ -1075,7 +1075,8 @@ unique_ptr<SortedMap> SortedMap::FromListPack(PMR_NS::memory_resource* res, cons
   long long vlong;
   sds ele;
 
-  unique_ptr<SortedMap> zs(new SortedMap(res));
+  void* ptr = res->allocate(sizeof(SortedMap), alignof(SortedMap));
+  SortedMap* zs = new (ptr) SortedMap{res};
 
   eptr = lpSeek(zl, 0);
   if (eptr != NULL) {

--- a/src/core/sorted_map.h
+++ b/src/core/sorted_map.h
@@ -45,8 +45,9 @@ class SortedMap {
 
   ~SortedMap();
 
-  // The ownership for the returned SortedMap stays with the caller
-  static std::unique_ptr<SortedMap> FromListPack(PMR_NS::memory_resource* res, const uint8_t* lp);
+  // The ownership for the returned SortedMap stays with the caller, and must be freed via
+  // placement delete and then res->deallocate().
+  static SortedMap* FromListPack(PMR_NS::memory_resource* res, const uint8_t* lp);
 
   size_t Size() const {
     return std::visit(Overload{[](const auto& impl) { return impl.Size(); }}, impl_);

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -636,8 +636,7 @@ OpResult<uint32_t> OpSet(const OpArgs& op_args, string_view key, CmdArgList valu
       stats->listpack_blob_cnt++;
       stats->listpack_bytes += lpBytes(lp);
     } else {
-      StringMap* sm = new StringMap(CompactObj::memory_resource());
-      pv.InitRobj(OBJ_HASH, kEncodingStrMap2, sm);
+      pv.InitRobj(OBJ_HASH, kEncodingStrMap2, CompactObj::AllocateMR<StringMap>());
     }
   } else {
     if (pv.ObjType() != OBJ_HASH)
@@ -1202,7 +1201,7 @@ void HSetFamily::Register(CommandRegistry* registry) {
 }
 
 StringMap* HSetFamily::ConvertToStrMap(uint8_t* lp) {
-  StringMap* sm = new StringMap(CompactObj::memory_resource());
+  StringMap* sm = CompactObj::AllocateMR<StringMap>();
   size_t lplen = lpLength(lp);
   if (lplen == 0)
     return sm;

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -510,7 +510,7 @@ void RdbLoaderBase::OpaqueObjLoader::CreateSet(const LoadTrace* ltrace) {
     bool use_set2 = GetFlag(FLAGS_use_set2);
 
     if (use_set2) {
-      StringSet* set = new StringSet{CompactObj::memory_resource()};
+      StringSet* set = CompactObj::AllocateMR<StringSet>();
       set->set_time(MemberTimeSeconds(GetCurrentTimeMs()));
       res = createObject(OBJ_SET, set);
       res->encoding = OBJ_ENCODING_HT;
@@ -641,10 +641,10 @@ void RdbLoaderBase::OpaqueObjLoader::CreateHMap(const LoadTrace* ltrace) {
     lp = lpShrinkToFit(lp);
     pv_->InitRobj(OBJ_HASH, kEncodingListPack, lp);
   } else {
-    StringMap* string_map = new StringMap;
+    StringMap* string_map = CompactObj::AllocateMR<StringMap>();
     string_map->set_time(MemberTimeSeconds(GetCurrentTimeMs()));
 
-    auto cleanup = absl::MakeCleanup([&] { delete string_map; });
+    auto cleanup = absl::MakeCleanup([&] { CompactObj::DeleteMR<StringMap>(string_map); });
     std::string key;
     string_map->Reserve(len);
     for (const auto& seg : ltrace->arr) {
@@ -761,9 +761,9 @@ void RdbLoaderBase::OpaqueObjLoader::CreateList(const LoadTrace* ltrace) {
 
 void RdbLoaderBase::OpaqueObjLoader::CreateZSet(const LoadTrace* ltrace) {
   size_t zsetlen = ltrace->blob_count();
-  detail::SortedMap* zs = new detail::SortedMap(CompactObj::memory_resource());
+  detail::SortedMap* zs = CompactObj::AllocateMR<detail::SortedMap>();
   unsigned encoding = OBJ_ENCODING_SKIPLIST;
-  auto cleanup = absl::MakeCleanup([&] { delete zs; });
+  auto cleanup = absl::MakeCleanup([&] { CompactObj::DeleteMR<detail::SortedMap>(zs); });
 
   if (zsetlen > DICT_HT_INITIAL_SIZE && !zs->Reserve(zsetlen)) {
     LOG(ERROR) << "OOM in dictTryExpand " << zsetlen;
@@ -977,7 +977,7 @@ void RdbLoaderBase::OpaqueObjLoader::HandleBlob(string_view blob) {
     const bool use_set2 = GetFlag(FLAGS_use_set2);
     robj* res = nullptr;
     if (use_set2) {
-      StringSet* set = new StringSet{CompactObj::memory_resource()};
+      StringSet* set = CompactObj::AllocateMR<StringSet>();
       res = createObject(OBJ_SET, set);
       res->encoding = OBJ_ENCODING_HT;
       auto f = [this, res](unsigned char* val, unsigned int slen, long long lval) {
@@ -1060,7 +1060,7 @@ void RdbLoaderBase::OpaqueObjLoader::HandleBlob(string_view blob) {
     unsigned encoding = OBJ_ENCODING_LISTPACK;
     void* inner;
     if (lpBytes(lp) >= server.max_listpack_map_bytes) {
-      inner = detail::SortedMap::FromListPack(CompactObj::memory_resource(), lp).release();
+      inner = detail::SortedMap::FromListPack(CompactObj::memory_resource(), lp);
       lpFree(lp);
       encoding = OBJ_ENCODING_SKIPLIST;
     } else {

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -803,7 +803,7 @@ void RdbLoaderBase::OpaqueObjLoader::CreateZSet(const LoadTrace* ltrace) {
       maxelelen <= server.zset_max_listpack_value && lpSafeToAdd(NULL, totelelen)) {
     encoding = OBJ_ENCODING_LISTPACK;
     inner = zs->ToListPack();
-    delete zs;
+    CompactObj::DeleteMR<detail::SortedMap>(zs);
   }
 
   std::move(cleanup).Cancel();

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -154,8 +154,7 @@ unsigned AddStrSet(const DbContext& db_context, ArgSlice vals, uint32_t ttl_sec,
 
 void InitStrSet(CompactObj* set) {
   if (GetFlag(FLAGS_use_set2)) {
-    StringSet* ss = new StringSet{CompactObj::memory_resource()};
-    set->InitRobj(OBJ_SET, kEncodingStrMap2, ss);
+    set->InitRobj(OBJ_SET, kEncodingStrMap2, CompactObj::AllocateMR<StringSet>());
   } else {
     dict* ds = dictCreate(&setDictType);
     set->InitRobj(OBJ_SET, kEncodingStrMap, ds);
@@ -1637,7 +1636,7 @@ bool SetFamily::ConvertToStrSet(const intset* is, size_t expected_len, robj* des
   int ii = 0;
 
   if (GetFlag(FLAGS_use_set2)) {
-    StringSet* ss = new StringSet{CompactObj::memory_resource()};
+    StringSet* ss = CompactObj::AllocateMR<StringSet>();
     if (expected_len) {
       ss->Reserve(expected_len);
     }

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -202,8 +202,7 @@ OpResult<DbSlice::ItAndUpdater> FindZEntry(const ZParams& zparams, const OpArgs&
   DbTableStats* stats = db_slice.MutableStats(op_args.db_cntx.db_index);
   if (add_res.is_new || zparams.override) {
     if (member_len > server.max_map_field_len) {
-      detail::SortedMap* zs = new detail::SortedMap(CompactObj::memory_resource());
-      pv.InitRobj(OBJ_ZSET, OBJ_ENCODING_SKIPLIST, zs);
+      pv.InitRobj(OBJ_ZSET, OBJ_ENCODING_SKIPLIST, CompactObj::AllocateMR<detail::SortedMap>());
     } else {
       unsigned char* lp = lpNew(0);
       pv.InitRobj(OBJ_ZSET, OBJ_ENCODING_LISTPACK, lp);


### PR DESCRIPTION
Now we allocate the inner objects (`StringSet`, `StringMap` and `SortedMap`) directly via mimalloc, which automatically accounts for them in the used memory metric. We also add this information for the type-specific metrics.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->