### PR TITLE
feat: expose tx_queue_len metric

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -739,7 +739,7 @@ void DebugCmd::ObjHist() {
 
   absl::StrAppend(&result, "___end object histogram___\n");
   auto* rb = static_cast<RedisReplyBuilder*>(cntx_->reply_builder());
-  rb->SendBulkString(result);
+  rb->SendVerbatimString(result);
 }
 
 void DebugCmd::Stacktrace() {
@@ -803,7 +803,7 @@ void DebugCmd::Shards() {
 #undef ADD_STAT
 #undef MAXMIN_STAT
   auto* rb = static_cast<RedisReplyBuilder*>(cntx_->reply_builder());
-  rb->SendBulkString(out);
+  rb->SendVerbatimString(out);
 }
 
 }  // namespace dfly

--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -149,7 +149,7 @@ void MemoryCmd::Run(CmdArgList args) {
     string res = shard_set->pool()->at(tid)->AwaitBrief([=] { return MallocStats(backing, tid); });
 
     auto* rb = static_cast<RedisReplyBuilder*>(cntx_->reply_builder());
-    return rb->SendBulkString(res);
+    return rb->SendVerbatimString(res);
   }
 
   string err = UnknownSubCmd(sub_cmd, "MEMORY");

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -753,9 +753,9 @@ void PrintPrometheusMetrics(const Metrics& m, StringResponse* resp) {
   // Server metrics
   AppendMetricHeader("version", "", MetricType::GAUGE, &resp->body());
   AppendMetricValue("version", 1, {"version"}, {GetVersion()}, &resp->body());
-  AppendMetricHeader("role", "", MetricType::GAUGE, &resp->body());
-  AppendMetricValue("role", 1, {"role"}, {m.is_master ? "master" : "replica"}, &resp->body());
-  AppendMetricWithoutLabels("master", "1 if master 0 if replica", m.is_master ? 1 : 0,
+
+  bool is_master = ServerState::tlocal()->is_master;
+  AppendMetricWithoutLabels("master", "1 if master 0 if replica", is_master ? 1 : 0,
                             MetricType::GAUGE, &resp->body());
   AppendMetricWithoutLabels("uptime_in_seconds", "", m.uptime, MetricType::COUNTER, &resp->body());
 
@@ -884,7 +884,7 @@ void PrintPrometheusMetrics(const Metrics& m, StringResponse* resp) {
   double longrun_seconds = m.fiber_longrun_usec * 1e-6;
   AppendMetricWithoutLabels("fiber_longrun_seconds_total", "", longrun_seconds, MetricType::COUNTER,
                             &resp->body());
-
+  AppendMetricWithoutLabels("tx_queue_len", "", m.tx_queue_len, MetricType::GAUGE, &resp->body());
   absl::StrAppend(&resp->body(), db_key_metrics);
   absl::StrAppend(&resp->body(), db_key_expire_metrics);
 }
@@ -1496,6 +1496,8 @@ Metrics ServerFamily::GetMetrics() const {
 
       result.traverse_ttl_per_sec += shard->GetMovingSum6(EngineShard::TTL_TRAVERSE);
       result.delete_ttl_per_sec += shard->GetMovingSum6(EngineShard::TTL_DELETE);
+      if (result.tx_queue_len < shard->txq()->size())
+        result.tx_queue_len = shard->txq()->size();
     }
 
     service_.mutable_registry()->MergeCallStats(index, cmd_stat_cb);
@@ -1508,11 +1510,12 @@ Metrics ServerFamily::GetMetrics() const {
   result.traverse_ttl_per_sec /= 6;
   result.delete_ttl_per_sec /= 6;
 
-  result.is_master = ServerState::tlocal() && ServerState::tlocal()->is_master;
-  if (result.is_master)
+  bool is_master = ServerState::tlocal() && ServerState::tlocal()->is_master;
+  if (is_master)
     result.replication_metrics = dfly_cmd_->GetReplicasRoleInfo();
 
-  // Update peak stats
+  // Update peak stats. We rely on the fact that GetMetrics is called frequently enough to
+  // update peak_stats_ from it.
   lock_guard lk{peak_stats_mu_};
   UpdateMax(&peak_stats_.conn_dispatch_queue_bytes, result.conn_stats.dispatch_queue_bytes);
   UpdateMax(&peak_stats_.conn_read_buf_capacity, result.conn_stats.read_buf_capacity);
@@ -1629,7 +1632,7 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
       append("maxmemory_policy", "noeviction");
     }
 
-    if (m.is_master && !m.replication_metrics.empty()) {
+    if (!m.replication_metrics.empty()) {
       ReplicationMemoryStats repl_mem;
       dfly_cmd_->GetReplicationMemoryStats(&repl_mem);
       append("replication_streaming_buffer_bytes", repl_mem.streamer_buf_capacity_bytes_);
@@ -1725,6 +1728,7 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
            m.coordinator_stats.eval_shardlocal_coordination_cnt);
     append("eval_squashed_flushes", m.coordinator_stats.eval_squashed_flushes);
     append("tx_schedule_cancel_total", m.coordinator_stats.tx_schedule_cancel_cnt);
+    append("tx_queue_len", m.tx_queue_len);
   }
 
   if (should_enter("REPLICATION")) {

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -93,10 +93,11 @@ struct Metrics {
   uint64_t fiber_longrun_cnt = 0;
   uint64_t fiber_longrun_usec = 0;
 
+  // Max length of the all the tx shard-queues.
+  uint32_t tx_queue_len = 0;
+
   // command call frequencies (count, aggregated latency in usec).
   std::map<std::string, std::pair<uint64_t, uint64_t>> cmd_stats_map;
-
-  bool is_master = true;
   std::vector<ReplicaRoleInfo> replication_metrics;
 };
 


### PR DESCRIPTION
This metric shows how much the transaction queue of dragonfly is loaded.
Also remove the redunant `is_master` field from metrics.
Finally, removed unnecessary "role" metric from the prometheus metrics,  see #1754  for the context.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->