### PR TITLE
feat: introduce 'debug tx' command and periodic overload logs

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -906,12 +906,12 @@ bool DbSlice::Acquire(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
   if (lock_args.args.size() == 1) {
     string_view key = KeyLockArgs::GetLockKey(lock_args.args.front());
     lock_acquired = lt[key].Acquire(mode);
-    uniq_keys_ = {key};
+    uniq_keys_ = {key};  // needed only for tests.
   } else {
     uniq_keys_.clear();
 
     for (size_t i = 0; i < lock_args.args.size(); i += lock_args.key_step) {
-      auto s = KeyLockArgs::GetLockKey(lock_args.args[i]);
+      string_view s = KeyLockArgs::GetLockKey(lock_args.args[i]);
       if (uniq_keys_.insert(s).second) {
         bool res = lt[s].Acquire(mode);
         lock_acquired &= res;

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -248,6 +248,8 @@ void DebugCmd::Run(CmdArgList args) {
         "    Prints the stacktraces of all current fibers to the logs.",
         "SHARDS",
         "    Prints memory usage and key stats per shard, as well as min/max indicators.",
+        "TX",
+        "    Performs transaction analysis per shard.",
         "HELP",
         "    Prints this help.",
     };
@@ -282,7 +284,7 @@ void DebugCmd::Run(CmdArgList args) {
     return Inspect(key);
   }
 
-  if (subcmd == "TRANSACTION") {
+  if (subcmd == "TX") {
     return TxAnalysis();
   }
 
@@ -659,60 +661,27 @@ void DebugCmd::Watched() {
 }
 
 void DebugCmd::TxAnalysis() {
-  atomic_uint32_t queue_len{0}, free_cnt{0}, armed_cnt{0};
-
-  using SvLockTable = absl::flat_hash_map<string_view, IntentLock>;
-  vector<SvLockTable> lock_table_arr(shard_set->size());
+  vector<EngineShard::TxQueueInfo> shard_info(shard_set->size());
 
   auto cb = [&](EngineShard* shard) {
-    ShardId sid = shard->shard_id();
-
-    TxQueue* queue = shard->txq();
-
-    if (queue->Empty())
-      return;
-
-    auto cur = queue->Head();
-    do {
-      auto value = queue->At(cur);
-      Transaction* trx = std::get<Transaction*>(value);
-      queue_len.fetch_add(1, std::memory_order_relaxed);
-
-      if (trx->IsArmedInShard(sid)) {
-        armed_cnt.fetch_add(1, std::memory_order_relaxed);
-
-        IntentLock::Mode mode = trx->Mode();
-
-        // We consider keys from the currently assigned command inside the transaction.
-        // Meaning that for multi-tx it does not take into account all the keys.
-        KeyLockArgs lock_args = trx->GetLockArgs(sid);
-        auto& lock_table = lock_table_arr[sid];
-
-        // We count locks ourselves and do not rely on the lock table inside dbslice.
-        // The reason for this - to account for ordering information.
-        // For example, consider T1, T2 both residing in the queue and both lock 'x' exclusively.
-        // DbSlice::CheckLock returns false for both transactions, but T1 in practice owns the lock.
-        bool can_take = true;
-        for (size_t i = 0; i < lock_args.args.size(); i += lock_args.key_step) {
-          string_view s = lock_args.args[i];
-          bool was_ack = lock_table[s].Acquire(mode);
-          if (!was_ack) {
-            can_take = false;
-          }
-        }
-
-        if (can_take) {
-          free_cnt.fetch_add(1, std::memory_order_relaxed);
-        }
-      }
-      cur = queue->Next(cur);
-    } while (cur != queue->Head());
+    auto& info = shard_info[shard->shard_id()];
+    info = shard->AnalyzeTxQueue();
   };
 
   shard_set->RunBriefInParallel(cb);
 
-  cntx_->SendSimpleString(absl::StrCat("queue_len:", queue_len.load(), "armed: ", armed_cnt.load(),
-                                       " free:", free_cnt.load()));
+  string result;
+  for (unsigned i = 0; i < shard_set->size(); ++i) {
+    const auto& info = shard_info[i];
+    StrAppend(&result, "shard", i, ":\n", "  tx armed ", info.tx_armed, ", total: ", info.tx_total,
+              ",global:", info.tx_global, ",runnable:", info.tx_runnable, "\n");
+    StrAppend(&result, "  locks total:", info.total_locks, ",contended:", info.contended_locks,
+              "\n");
+    StrAppend(&result, "  max contention score: ", info.max_contention_score,
+              ",lock_name:", info.max_contention_lock_name, "\n");
+  }
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx_->reply_builder());
+  rb->SendVerbatimString(result);
 }
 
 void DebugCmd::ObjHist() {

--- a/src/server/engine_shard_set.h
+++ b/src/server/engine_shard_set.h
@@ -153,6 +153,29 @@ class EngineShard {
 
   void TEST_EnableHeartbeat();
 
+  struct TxQueueInfo {
+    // Armed - those that the coordinator has armed with callbacks and wants them to run.
+    // Runnable - those that could run (they own the locks) but probably can not run due
+    // to head of line blocking in the transaction queue i.e. there is a transaction that
+    // either is not armed or not runnable that is blocking the runnable transactions.
+    // tx_total is the size of the transaction queue.
+    unsigned tx_armed = 0, tx_total = 0, tx_runnable = 0, tx_global = 0;
+
+    // total_locks - total number of the transaction locks in the shard.
+    unsigned total_locks = 0;
+
+    // contended_locks - number of locks that are contended by more than one transaction.
+    unsigned contended_locks = 0;
+
+    // The score of the lock with maximum contention (see IntentLock::ContetionScore for details).
+    unsigned max_contention_score = 0;
+
+    // the lock name with maximum contention
+    std::string max_contention_lock_name;
+  };
+
+  TxQueueInfo AnalyzeTxQueue();
+
  private:
   struct DefragTaskState {
     size_t dbid = 0u;


### PR DESCRIPTION
This command shows the current state of transaction queues, specifically how many armed (ready to run) transactions there, how loaded these queue are and how many locks there are in each shard.

In addition, if a tx queue becomes too long, we will output warning logs about the state of the queue, in order to be able to identify the bottlenecks post-factum.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->