### PR TITLE
refactor(server): Call `PreUpdate()` from `PerformDeletion()`

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1031,23 +1031,20 @@ DbSlice::ItAndExp DbSlice::ExpireIfNeeded(const Context& cntx, PrimeIterator it)
     return {it, expire_it};
 
   string tmp_key_buf;
-  string_view tmp_key;
-
-  // Replicate expiry
-  if (auto journal = owner_->journal(); journal) {
-    tmp_key = it->first.GetSlice(&tmp_key_buf);
-    RecordExpiry(cntx.db_index, tmp_key);
-  }
+  string_view tmp_key = it->first.GetSlice(&tmp_key_buf);
 
   auto obj_type = it->second.ObjType();
   if (doc_del_cb_ && (obj_type == OBJ_JSON || obj_type == OBJ_HASH)) {
-    if (tmp_key.empty())
-      tmp_key = it->first.GetSlice(&tmp_key_buf);
     doc_del_cb_(tmp_key, cntx, it->second);
   }
 
   PerformDeletion(it, expire_it, shard_owner(), db.get());
   ++events_.expired_keys;
+
+  // Replicate expiry
+  if (auto journal = owner_->journal(); journal) {
+    RecordExpiry(cntx.db_index, tmp_key);
+  }
 
   return {PrimeIterator{}, ExpireIterator{}};
 }

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -388,11 +388,12 @@ class DbSlice {
   // Track keys for the client represented by the the weak reference to its connection.
   void TrackKeys(const facade::Connection::WeakRef&, const ArgSlice&);
 
-  // Delete a key referred by its iterator.
-  void PerformDeletion(PrimeIterator del_it, EngineShard* shard, DbTable* table);
-
  private:
-  void PreUpdate(DbIndex db_ind, PrimeIterator it);
+  enum class PreUpdateMode {
+    kRegular,
+    kNoIncVersion,
+  };
+  void PreUpdate(DbTable* table, PrimeIterator it, PreUpdateMode mode = PreUpdateMode::kRegular);
   void PostUpdate(DbIndex db_ind, PrimeIterator it, std::string_view key, size_t orig_size);
 
   // Releases a single key. `key` must have been normalized by GetLockKey().
@@ -410,6 +411,9 @@ class DbSlice {
 
   // Invalidate all watched keys for given slots. Used on FlushSlots.
   void InvalidateSlotWatches(const SlotSet& slot_ids);
+
+  // Delete a key referred by its iterator.
+  void PerformDeletion(PrimeIterator del_it, EngineShard* shard, DbTable* table);
 
   void PerformDeletion(PrimeIterator del_it, ExpireIterator exp_it, EngineShard* shard,
                        DbTable* table);


### PR DESCRIPTION
While at it:
1. Remove 2 copies of `PerformDeletion()` which were unused
2. Make `PerformDeletion()` private, expose only `Del()`

Fixes #2316

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->