### PR TITLE
bug(server): reject replicaof while loading from snapshot

### DIFF
--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -204,6 +204,7 @@ class ServerFamily {
 
  private:
   void JoinSnapshotSchedule();
+  void LoadFromSnapshot();
 
   uint32_t shard_count() const {
     return shard_set->size();

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1814,7 +1814,7 @@ async def test_replicaof_reject_on_load(df_local_factory, df_seeder_factory):
     replica = df_local_factory.create(dbfilename=f"dump_{tmp_file_name}")
     df_local_factory.start_all([master, replica])
 
-    seeder = df_seeder_factory.create(port=replica.port, keys=10000)
+    seeder = df_seeder_factory.create(port=replica.port, keys=30000)
     await seeder.run(target_deviation=0.1)
     c_replica = replica.client()
     dbsize = await c_replica.dbsize()
@@ -1832,3 +1832,7 @@ async def test_replicaof_reject_on_load(df_local_factory, df_seeder_factory):
     # Check one we finish loading snapshot replicaof success
     await wait_available_async(c_replica)
     await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
+
+    await c_replica.close()
+    master.stop()
+    replica.stop()

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1806,3 +1806,29 @@ async def test_client_pause_with_replica(df_local_factory, df_seeder_factory):
     assert await seeder.compare(capture, port=replica.port)
 
     await disconnect_clients(c_master, c_replica)
+
+
+async def test_replicaof_reject_on_load(df_local_factory, df_seeder_factory):
+    tmp_file_name = "".join(random.choices(string.ascii_letters, k=10))
+    master = df_local_factory.create()
+    replica = df_local_factory.create(dbfilename=f"dump_{tmp_file_name}")
+    df_local_factory.start_all([master, replica])
+
+    seeder = df_seeder_factory.create(port=replica.port, keys=10000)
+    await seeder.run(target_deviation=0.1)
+    c_replica = replica.client()
+    dbsize = await c_replica.dbsize()
+    assert dbsize >= 9000
+
+    replica.stop()
+    replica.start()
+    c_replica = replica.client()
+    # Check replica of not alowed while loading snapshot
+    try:
+        await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
+        assert False
+    except aioredis.ResponseError as e:
+        assert "Can not execute during LOADING" in str(e)
+    # Check one we finish loading snapshot replicaof success
+    await wait_available_async(c_replica)
+    await c_replica.execute_command(f"REPLICAOF localhost {master.port}")


### PR DESCRIPTION
fix #2337 
The bug:
replicaof was not rejected while loading snapshot
The fix:
replicaof is allowed while server is in loading state to allow replicaof while replication in full sync mode
I now reject replicaof if the server is in loading state and it is master

Another bug fix:
allow cron snapshot if --replicaof flag was set

