### PR TITLE
chore: expose the multi length in slowlog

### DIFF
--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -174,6 +174,9 @@ class ConnectionContext : public facade::ConnectionContext {
     uint32_t shards_count = 0;
     TxClock clock = 0;
     bool is_ooo = false;
+
+    // number of commands in the last exec body.
+    unsigned exec_body_len = 0;
   };
 
   DebugInfo last_command_debug;


### PR DESCRIPTION
 1. Fix AnalyzeTxQueue to stop crashing for various transaction types.
 2. Pass exec command length to slowlog


<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->