### PR TITLE
feat(makefile): Build with full debug symbols and strip in `make package`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ RELEASE_NAME := "dragonfly-${BUILD_ARCH}"
 
 HELIO_RELEASE := $(if $(HELIO_RELEASE),y,)
 
-HELIO_RELEASE_FLAGS = -DHELIO_RELEASE_FLAGS="-g1 -gz"
+HELIO_RELEASE_FLAGS = -DHELIO_RELEASE_FLAGS="-g"
 HELIO_USE_STATIC_LIBS = ON
 HELIO_OPENSSL_USE_STATIC_LIBS = ON
 HELIO_ENABLE_GIT_VERSION = ON
@@ -46,7 +46,12 @@ build-debug:
 
 package:
 	cd build-opt; \
-	mv dragonfly $(RELEASE_NAME); \
+	objcopy \
+		--remove-section=".debug_*" \
+		--remove-section="!.debug_line" \
+		--compress-debug-sections \
+		dragonfly \
+		$(RELEASE_NAME); \
 	tar cvfz $(RELEASE_NAME).tar.gz $(RELEASE_NAME) ../LICENSE.md
 
 release: configure build


### PR DESCRIPTION
Before this PR, using `make` for building releases used `-g1 -gz` to provide some level of debug symbols (mostly function names in stack traces).

We want to be able to have binaries with full debug symbols (for coredumps etc), but not in the public releases.

This PR builds with full debug symbols, but changes `make package` to strip most debug symbols, while keeping `.debug_line` (and keeping them compressed as if with `-gz`). This will allow a single build command for public releases as well as releases with full symbols.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->