### PR TITLE
fix: unblock transactions only if requirements are correct

### DIFF
--- a/src/server/blocking_controller.h
+++ b/src/server/blocking_controller.h
@@ -39,7 +39,7 @@ class BlockingController {
   // TODO: consider moving all watched functions to
   // EngineShard with separate per db map.
   //! AddWatched adds a transaction to the blocking queue.
-  void AddWatched(ArgSlice watch_keys, Transaction* me);
+  void AddWatched(ArgSlice watch_keys, KeyReadyChecker krc, Transaction* me);
 
   // Called from operations that create keys like lpush, rename etc.
   void AwakeWatched(DbIndex db_index, std::string_view db_key);
@@ -54,7 +54,7 @@ class BlockingController {
 
   using WatchQueueMap = absl::flat_hash_map<std::string, std::unique_ptr<WatchQueue>>;
 
-  void NotifyWatchQueue(std::string_view key, WatchQueueMap* wqm);
+  void NotifyWatchQueue(std::string_view key, WatchQueueMap* wqm, const DbContext& context);
 
   // void NotifyConvergence(Transaction* tx);
 

--- a/src/server/blocking_controller_test.cc
+++ b/src/server/blocking_controller_test.cc
@@ -75,7 +75,8 @@ TEST_F(BlockingControllerTest, Basic) {
     EngineShard* shard = EngineShard::tlocal();
     BlockingController bc(shard);
     auto keys = trans_->GetShardArgs(shard->shard_id());
-    bc.AddWatched(keys, trans_.get());
+    bc.AddWatched(
+        keys, [](auto...) { return true; }, trans_.get());
     EXPECT_EQ(1, bc.NumWatched(0));
 
     bc.FinalizeWatched(keys, trans_.get());
@@ -89,7 +90,7 @@ TEST_F(BlockingControllerTest, Timeout) {
   trans_->Schedule();
   auto cb = [&](Transaction* t, EngineShard* shard) { return trans_->GetShardArgs(0); };
 
-  facade::OpStatus status = trans_->WaitOnWatch(tp, cb);
+  facade::OpStatus status = trans_->WaitOnWatch(tp, cb, [](auto...) { return true; });
 
   EXPECT_EQ(status, facade::OpStatus::TIMED_OUT);
   unsigned num_watched = shard_set->Await(

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -359,6 +359,10 @@ inline uint32_t MemberTimeSeconds(uint64_t now_ms) {
   return (now_ms / 1000) - kMemberExpiryBase;
 }
 
+// Checks whether the touched key is valid for a blocking transaction watching it
+using KeyReadyChecker =
+    std::function<bool(EngineShard*, const DbContext& context, Transaction* tx, std::string_view)>;
+
 struct MemoryBytesFlag {
   uint64_t value = 0;
 };

--- a/src/server/container_utils.cc
+++ b/src/server/container_utils.cc
@@ -283,7 +283,11 @@ OpResult<string> RunCbOnFirstNonEmptyBlocking(Transaction* trans, int req_obj_ty
   auto wcb = [](Transaction* t, EngineShard* shard) { return t->GetShardArgs(shard->shard_id()); };
 
   *block_flag = true;
-  auto status = trans->WaitOnWatch(limit_tp, std::move(wcb));
+  const auto key_checker = [req_obj_type](EngineShard* owner, const DbContext& context,
+                                          Transaction*, std::string_view key) -> bool {
+    return owner->db_slice().FindReadOnly(context, key, req_obj_type).ok();
+  };
+  auto status = trans->WaitOnWatch(limit_tp, std::move(wcb), key_checker);
   *block_flag = false;
 
   if (status != OpStatus::OK)

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -342,26 +342,18 @@ TEST_F(StreamFamilyTest, XReadGroupBlock) {
   ThisFiber::SleepFor(50us);
   pp_->at(1)->Await([&] { return Run("xadd", {"xadd", "bar", "1-*", "k5", "v5"}); });
   // The second one should be unblocked
+  ThisFiber::SleepFor(50us);
 
   fb0.Join();
   fb1.Join();
-  // temporary incorrect results
-  if (resp0.GetVec()[1].GetVec().size() == 0) {
-    EXPECT_THAT(resp0.GetVec(), ElementsAre("foo", ArrLen(0)));
-    EXPECT_THAT(resp1.GetVec(), ElementsAre("foo", ArrLen(1)));
-  } else {
-    EXPECT_THAT(resp0.GetVec(), ElementsAre("foo", ArrLen(1)));
-    EXPECT_THAT(resp1.GetVec(), ElementsAre("foo", ArrLen(0)));
-  }
 
-  // correct results
-  // if (resp0.GetVec()[0].GetString() == "foo") {
-  //   EXPECT_THAT(resp0.GetVec(), ElementsAre("foo", ArrLen(1)));
-  //   EXPECT_THAT(resp1.GetVec(), ElementsAre("bar", ArrLen(1)));
-  // } else {
-  //   EXPECT_THAT(resp1.GetVec(), ElementsAre("foo", ArrLen(1)));
-  //   EXPECT_THAT(resp0.GetVec(), ElementsAre("bar", ArrLen(1)));
-  // }
+  if (resp0.GetVec()[0].GetString() == "foo") {
+    EXPECT_THAT(resp0.GetVec(), ElementsAre("foo", ArrLen(1)));
+    EXPECT_THAT(resp1.GetVec(), ElementsAre("bar", ArrLen(1)));
+  } else {
+    EXPECT_THAT(resp1.GetVec(), ElementsAre("foo", ArrLen(1)));
+    EXPECT_THAT(resp0.GetVec(), ElementsAre("bar", ArrLen(1)));
+  }
 }
 
 TEST_F(StreamFamilyTest, XReadInvalidArgs) {

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -186,7 +186,7 @@ class Transaction {
   // or b) tp is reached. If tp is time_point::max() then waits indefinitely.
   // Expects that the transaction had been scheduled before, and uses Execute(.., true) to register.
   // Returns false if timeout occurred, true if was notified by one of the keys.
-  facade::OpStatus WaitOnWatch(const time_point& tp, WaitKeysProvider cb);
+  facade::OpStatus WaitOnWatch(const time_point& tp, WaitKeysProvider cb, KeyReadyChecker krc);
 
   // Returns true if transaction is awaked, false if it's timed-out and can be removed from the
   // blocking queue.
@@ -456,7 +456,7 @@ class Transaction {
   void ExecuteAsync();
 
   // Adds itself to watched queue in the shard. Must run in that shard thread.
-  OpStatus WatchInShard(ArgSlice keys, EngineShard* shard);
+  OpStatus WatchInShard(ArgSlice keys, EngineShard* shard, KeyReadyChecker krc);
 
   // Expire blocking transaction, unlock keys and unregister it from the blocking controller
   void ExpireBlocking(WaitKeysProvider wcb);


### PR DESCRIPTION
fixes #2294

bug: we unblocked XREADGROUP cmd even if we don't have new values

fix: added check with custom requirements for blocking commands