### PR TITLE
feat: add SLOT-MIGRATION-STATUS cmd for source node

### DIFF
--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -641,7 +641,7 @@ static std::string_view state_to_str(ClusterSlotMigration::State state) {
     case ClusterSlotMigration::C_STABLE_SYNC:
       return "STABLE_SYNC"sv;
   }
-  assert(false);
+  DCHECK(false) << "Unknown State value " << state;
   return "UNDEFINED_STATE"sv;
 }
 
@@ -656,17 +656,18 @@ void ClusterFamily::DflySlotMigrationStatus(CmdArgList args, ConnectionContext* 
 
     lock_guard lk(migration_mu_);
     // find incoming slot migration
-    for (const auto& m : migrations_jobs_) {
+    for (const auto& m : incoming_migrations_jobs_) {
       const auto& info = m->GetInfo();
       if (info.host == host_ip && info.port == port)
         return rb->SendSimpleString(state_to_str(info.state));
     }
-    // find outcoming slot migration
-    for (const auto& m : migration_infos_) {
-      if (m.second->host_ip == host_ip && m.second->port == port)
-        return rb->SendSimpleString(state_to_str(m.second->state));
+    // find outgoing slot migration
+    for (const auto& [_, info] : outgoing_migration_infos_) {
+      if (info->host_ip == host_ip && info->port == port)
+        return rb->SendSimpleString(state_to_str(info->state));
     }
-  } else if (auto arr_size = migrations_jobs_.size() + migration_infos_.size(); arr_size != 0) {
+  } else if (auto arr_size = incoming_migrations_jobs_.size() + outgoing_migration_infos_.size();
+             arr_size != 0) {
     rb->StartArray(arr_size);
     const auto& send_answer = [rb](std::string_view direction, std::string_view host, uint16_t port,
                                    auto state) {
@@ -674,12 +675,12 @@ void ClusterFamily::DflySlotMigrationStatus(CmdArgList args, ConnectionContext* 
       rb->SendSimpleString(str);
     };
     lock_guard lk(migration_mu_);
-    for (const auto& m : migrations_jobs_) {
+    for (const auto& m : incoming_migrations_jobs_) {
       const auto& info = m->GetInfo();
       send_answer("in", info.host, info.port, info.state);
     }
-    for (const auto& m : migration_infos_) {
-      send_answer("out", m.second->host_ip, m.second->port, m.second->state);
+    for (const auto& [_, info] : outgoing_migration_infos_) {
+      send_answer("out", info->host_ip, info->port, info->state);
     }
     return;
   }
@@ -704,12 +705,12 @@ void ClusterFamily::DflyMigrate(CmdArgList args, ConnectionContext* cntx) {
 ClusterSlotMigration* ClusterFamily::AddMigration(std::string host_ip, uint16_t port,
                                                   std::vector<ClusterConfig::SlotRange> slots) {
   lock_guard lk(migration_mu_);
-  for (const auto& mj : migrations_jobs_) {
+  for (const auto& mj : incoming_migrations_jobs_) {
     if (auto info = mj->GetInfo(); info.host == host_ip && info.port == port) {
       return nullptr;
     }
   }
-  return migrations_jobs_
+  return incoming_migrations_jobs_
       .emplace_back(make_unique<ClusterSlotMigration>(std::string(host_ip), port, std::move(slots)))
       .get();
 }
@@ -760,7 +761,7 @@ uint32_t ClusterFamily::CreateMigrationSession(ConnectionContext* cntx, uint16_t
   auto sync_id = next_sync_id_++;
   auto info = make_shared<MigrationInfo>(shard_set->size(), cntx->conn()->RemoteEndpointAddress(),
                                          sync_id, port, std::move(slots));
-  auto [it, inserted] = migration_infos_.emplace(sync_id, info);
+  auto [it, inserted] = outgoing_migration_infos_.emplace(sync_id, info);
   CHECK(inserted);
   return sync_id;
 }
@@ -816,8 +817,8 @@ void ClusterFamily::Sync(CmdArgList args, ConnectionContext* cntx) {
 
 shared_ptr<ClusterFamily::MigrationInfo> ClusterFamily::GetMigrationInfo(uint32_t sync_id) {
   unique_lock lk(migration_mu_);
-  auto sync_it = migration_infos_.find(sync_id);
-  return sync_it != migration_infos_.end() ? sync_it->second : nullptr;
+  auto sync_it = outgoing_migration_infos_.find(sync_id);
+  return sync_it != outgoing_migration_infos_.end() ? sync_it->second : nullptr;
 }
 
 using EngineFunc = void (ClusterFamily::*)(CmdArgList args, ConnectionContext* cntx);

--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -58,7 +58,7 @@ class ClusterFamily {
 
   // DFLYMIGRATE CONF initiate first step in slots migration procedure
   // MigrationConf process this request and saving slots range and
-  // target node port in migration_infos_.
+  // target node port in outgoing_migration_infos_.
   // return sync_id and shard number to the target node
   void MigrationConf(CmdArgList args, ConnectionContext* cntx);
 
@@ -112,13 +112,13 @@ class ClusterFamily {
 
   mutable Mutex migration_mu_;  // guard migrations operations
   // holds all incoming slots migrations that are currently in progress.
-  std::vector<std::unique_ptr<ClusterSlotMigration>> migrations_jobs_
+  std::vector<std::unique_ptr<ClusterSlotMigration>> incoming_migrations_jobs_
       ABSL_GUARDED_BY(migration_mu_);
 
   uint32_t next_sync_id_ = 1;
-  // holds all outcoming slots migrations that are currently in progress
+  // holds all outgoing slots migrations that are currently in progress
   using MigrationInfoMap = absl::btree_map<uint32_t, std::shared_ptr<MigrationInfo>>;
-  MigrationInfoMap migration_infos_;
+  MigrationInfoMap outgoing_migration_infos_;
 
  private:
   ClusterConfig::ClusterShard GetEmulatedShardInfo(ConnectionContext* cntx) const;

--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -93,13 +93,19 @@ class ClusterFamily {
     MigrationInfo() = default;
     MigrationInfo(std::uint32_t flows_num, std::string ip, uint32_t sync_id, uint16_t port,
                   std::vector<ClusterConfig::SlotRange> slots)
-        : host_ip(ip), flows(flows_num), slots(slots), sync_id(sync_id), port(port) {
+        : host_ip(ip),
+          flows(flows_num),
+          slots(slots),
+          sync_id(sync_id),
+          port(port),
+          state(ClusterSlotMigration::State::C_CONNECTING) {
     }
     std::string host_ip;
     std::vector<FlowInfo> flows;
     std::vector<ClusterConfig::SlotRange> slots;
     uint32_t sync_id;
     uint16_t port;
+    ClusterSlotMigration::State state = ClusterSlotMigration::State::C_NO_STATE;
   };
 
   std::shared_ptr<MigrationInfo> GetMigrationInfo(uint32_t sync_id);

--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -111,11 +111,12 @@ class ClusterFamily {
   std::shared_ptr<MigrationInfo> GetMigrationInfo(uint32_t sync_id);
 
   mutable Mutex migration_mu_;  // guard migrations operations
-  // holds all slots migrations that are currently in progress.
+  // holds all incoming slots migrations that are currently in progress.
   std::vector<std::unique_ptr<ClusterSlotMigration>> migrations_jobs_
       ABSL_GUARDED_BY(migration_mu_);
 
   uint32_t next_sync_id_ = 1;
+  // holds all outcoming slots migrations that are currently in progress
   using MigrationInfoMap = absl::btree_map<uint32_t, std::shared_ptr<MigrationInfo>>;
   MigrationInfoMap migration_infos_;
 

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -808,6 +808,14 @@ async def test_cluster_slot_migration(df_local_factory: DflyInstanceFactory):
     )
     assert "FULL_SYNC" == status
 
+    status = await c_nodes_admin[0].execute_command(
+        "DFLYCLUSTER", "SLOT-MIGRATION-STATUS", "127.0.0.1", str(nodes[1].port)
+    )
+    assert "FULL_SYNC" == status
+
+    status = await c_nodes_admin[0].execute_command("DFLYCLUSTER", "SLOT-MIGRATION-STATUS")
+    assert ["out 127.0.0.1:30002 FULL_SYNC"] == status
+
     try:
         await c_nodes_admin[1].execute_command(
             "DFLYCLUSTER",


### PR DESCRIPTION
implements #2232
also adding the ability to use SLOT-MIGRATION-STATUS without args to print info about all migration processes for the current node

