### PR TITLE
fix: relax the requirement for parsing successfully container limits

### DIFF
--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -405,7 +405,8 @@ void GetCGroupPath(string* memory_path, string* cpu_path) {
   }
 }
 
-void UpdateResourceLimitsIfInsideContainer(io::MemInfoData* mdata, size_t* max_threads) {
+// returns true on success.
+bool UpdateResourceLimitsIfInsideContainer(io::MemInfoData* mdata, size_t* max_threads) {
   using absl::StrCat;
 
   // did we succeed in reading *something*? if not, exit.
@@ -433,8 +434,7 @@ void UpdateResourceLimitsIfInsideContainer(io::MemInfoData* mdata, size_t* max_t
   GetCGroupPath(&mem_path, &cpu_path);
 
   if (mem_path.empty() || cpu_path.empty()) {
-    VLOG(1) << "Failed to get cgroup path, error";
-    return;
+    return true;  // not a container
   }
 
   VLOG(1) << "mem_path = " << mem_path;
@@ -519,9 +519,10 @@ void UpdateResourceLimitsIfInsideContainer(io::MemInfoData* mdata, size_t* max_t
 
   if (!read_something) {
     LOG(ERROR) << "Failed in deducing any cgroup limits with paths " << mem_path << " and "
-               << cpu_path << ". Exiting.";
-    exit(1);
+               << cpu_path;
+    return false;
   }
+  return true;
 }
 
 #endif


### PR DESCRIPTION
We parse the container limits for heuristics that deduces memory/cpu capacities automatically. It's ok if we fail on some less common systems since there are manual overrides that allows specifying these limits explicitly.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->