### PR TITLE
feat(getslotsinfo): Add memory usage per slot

### DIFF
--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -582,7 +582,7 @@ void ClusterFamily::DflyClusterGetSlotInfo(CmdArgList args, ConnectionContext* c
   rb->StartArray(slots_stats.size());
 
   for (const auto& slot_data : slots_stats) {
-    rb->StartArray(7);
+    rb->StartArray(9);
     rb->SendLong(slot_data.first);
     rb->SendBulkString("key_count");
     rb->SendLong(static_cast<long>(slot_data.second.key_count));
@@ -590,6 +590,8 @@ void ClusterFamily::DflyClusterGetSlotInfo(CmdArgList args, ConnectionContext* c
     rb->SendLong(static_cast<long>(slot_data.second.total_reads));
     rb->SendBulkString("total_writes");
     rb->SendLong(static_cast<long>(slot_data.second.total_writes));
+    rb->SendBulkString("memory_bytes");
+    rb->SendLong(static_cast<long>(slot_data.second.memory_bytes));
   }
 }
 

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -46,11 +46,18 @@ static_assert(kPrimeSegmentSize == 32288);
 // 24576
 static_assert(kExpireSegmentSize == 23528);
 
-void AccountObjectMemory(unsigned type, int64_t size, DbTableStats* stats) {
-  DCHECK_GE(static_cast<int64_t>(stats->obj_memory_usage) + size, 0)
-      << "Can't decrease " << size << " from " << stats->obj_memory_usage;
-  stats->obj_memory_usage += size;
-  stats->AddTypeMemoryUsage(type, size);
+void AccountObjectMemory(string_view key, unsigned type, int64_t size, DbTable* db) {
+  DCHECK_NE(db, nullptr);
+  DbTableStats& stats = db->stats;
+  DCHECK_GE(static_cast<int64_t>(stats.obj_memory_usage) + size, 0)
+      << "Can't decrease " << size << " from " << stats.obj_memory_usage;
+
+  stats.obj_memory_usage += size;
+  stats.AddTypeMemoryUsage(type, size);
+
+  if (ClusterConfig::IsEnabled()) {
+    db->slots_stats[ClusterConfig::KeySlot(key)].memory_bytes += size;
+  }
 }
 
 void PerformDeletion(PrimeIterator del_it, ExpireIterator exp_it, EngineShard* shard,
@@ -82,8 +89,14 @@ void PerformDeletion(PrimeIterator del_it, ExpireIterator exp_it, EngineShard* s
   }
 
   stats.inline_keys -= del_it->first.IsInline();
-  AccountObjectMemory(del_it->first.ObjType(), -del_it->first.MallocUsed(), &stats);    // Key
-  AccountObjectMemory(del_it->second.ObjType(), -del_it->second.MallocUsed(), &stats);  // Value
+
+  {
+    string tmp;
+    string_view key = del_it->first.GetSlice(&tmp);
+    AccountObjectMemory(key, del_it->first.ObjType(), -del_it->first.MallocUsed(), table);  // Key
+    AccountObjectMemory(key, del_it->second.ObjType(), -del_it->second.MallocUsed(),
+                        table);  // Value
+  }
 
   if (pv.ObjType() == OBJ_HASH && pv.Encoding() == kEncodingListPack) {
     --stats.listpack_blob_cnt;
@@ -610,7 +623,7 @@ DbSlice::AddOrFindResult DbSlice::AddOrFind(const Context& cntx, string_view key
   }
 
   db.stats.inline_keys += it->first.IsInline();
-  AccountObjectMemory(it->first.ObjType(), it->first.MallocUsed(), &db.stats);  // Account for key
+  AccountObjectMemory(key, it->first.ObjType(), it->first.MallocUsed(), &db);  // Account for key
 
   DCHECK_EQ(it->second.MallocUsed(), 0UL);  // Make sure accounting is no-op
   it.SetVersion(NextVersion());
@@ -1040,10 +1053,8 @@ void DbSlice::PreUpdate(DbIndex db_ind, PrimeIterator it) {
 }
 
 void DbSlice::PostUpdate(DbIndex db_ind, PrimeIterator it, std::string_view key, size_t orig_size) {
-  DbTableStats* stats = MutableStats(db_ind);
-
   int64_t delta = static_cast<int64_t>(it->second.MallocUsed()) - static_cast<int64_t>(orig_size);
-  AccountObjectMemory(it->second.ObjType(), delta, stats);
+  AccountObjectMemory(key, it->second.ObjType(), delta, GetDBTable(db_ind));
 
   auto& db = *db_arr_[db_ind];
   auto& watched_keys = db.watched_keys;
@@ -1500,9 +1511,8 @@ void DbSlice::PerformDeletion(PrimeIterator del_it, ExpireIterator exp_it, Engin
 
   size_t value_heap_size = pv.MallocUsed();
   stats.inline_keys -= del_it->first.IsInline();
-  int64_t delta = del_it->first.MallocUsed() + value_heap_size;
-  stats.obj_memory_usage -= delta;
-  stats.AddTypeMemoryUsage(pv.ObjType(), -delta);
+  AccountObjectMemory(key, del_it->first.ObjType(), -del_it->first.MallocUsed(), table);  // Key
+  AccountObjectMemory(key, pv.ObjType(), -value_heap_size, table);                        // Value
   if (pv.ObjType() == OBJ_HASH && pv.Encoding() == kEncodingListPack) {
     --stats.listpack_blob_cnt;
   } else if (pv.ObjType() == OBJ_ZSET && pv.Encoding() == OBJ_ENCODING_LISTPACK) {

--- a/src/server/table.cc
+++ b/src/server/table.cc
@@ -47,11 +47,12 @@ DbTableStats& DbTableStats::operator+=(const DbTableStats& o) {
 }
 
 SlotStats& SlotStats::operator+=(const SlotStats& o) {
-  static_assert(sizeof(SlotStats) == 24);
+  static_assert(sizeof(SlotStats) == 32);
 
   ADD(key_count);
   ADD(total_reads);
   ADD(total_writes);
+  ADD(memory_bytes);
   return *this;
 }
 

--- a/src/server/table.h
+++ b/src/server/table.h
@@ -57,6 +57,7 @@ struct SlotStats {
   uint64_t key_count = 0;
   uint64_t total_reads = 0;
   uint64_t total_writes = 0;
+  uint64_t memory_bytes = 0;
   SlotStats& operator+=(const SlotStats& o);
 };
 


### PR DESCRIPTION
It's a good thing we waited with this feature until after the recent refactors. Now it's trivial and safer!

Fixes #1478

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->