### PR TITLE
fix(server): call OnCbFinish after debug populate

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -580,6 +580,11 @@ void DebugCmd::PopulateRangeFiber(uint64_t from, uint64_t num_of_keys,
   ess.AwaitRunningOnShardQueue([&](EngineShard* shard) {
     DoPopulateBatch(options.prefix, options.val_size, options.populate_random_values, params,
                     ps[shard->shard_id()]);
+    // Debug populate does not use transaction framework therefore we call OnCbFinish manually
+    // after running the callback
+    // Note that running debug populate while running flushall/db can cause dcheck fail because the
+    // finish cb is executed just when we finish populating the database.
+    shard->db_slice().OnCbFinish();
   });
 }
 


### PR DESCRIPTION
fixes issue #2353 
The bug:
dcheck failed when running flushdb after debug populate 
The reason for this is that debug populate is not transactional and therefore did not call on callback finish to clear the bumped items in db slice

The fix:
call OnCbFinish after debug populate finishes