### PR TITLE
fix(dash table): bucket count returns the number of buckets

### DIFF
--- a/src/core/dash.h
+++ b/src/core/dash.h
@@ -213,12 +213,12 @@ class DashTable : public detail::DashTableBase {
   }
 
   size_t bucket_count() const {
-    return unique_segments_ * SegmentType::capacity();
+    return unique_segments_ * SegmentType::kNumBuckets;
   }
 
   // Overall capacity of the table (including stash buckets).
   size_t capacity() const {
-    return bucket_count();
+    return unique_segments_ * SegmentType::capacity();
   }
 
   double load_factor() const {
@@ -721,7 +721,7 @@ void DashTable<_Key, _Value, Policy>::Erase(iterator it) {
 
 template <typename _Key, typename _Value, typename Policy>
 void DashTable<_Key, _Value, Policy>::Reserve(size_t size) {
-  if (size <= bucket_count())
+  if (size <= capacity())
     return;
 
   size_t sg_floor = (size - 1) / SegmentType::capacity();

--- a/src/core/dash_test.cc
+++ b/src/core/dash_test.cc
@@ -465,7 +465,7 @@ TEST_F(DashTest, Custom) {
 }
 
 TEST_F(DashTest, Reserve) {
-  unsigned bc = dt_.bucket_count();
+  unsigned bc = dt_.capacity();
   for (unsigned i = 0; i <= bc * 2; ++i) {
     dt_.Reserve(i);
     ASSERT_GE((1 << dt_.depth()) * Dash64::kSegCapacity, i);
@@ -562,7 +562,7 @@ struct TestEvictionPolicy {
   }
 
   bool CanGrow(const Dash64& tbl) const {
-    return tbl.bucket_count() < max_capacity;
+    return tbl.capacity() < max_capacity;
   }
 
   void RecordSplit(Dash64::Segment_t*) {
@@ -876,7 +876,7 @@ struct SimpleEvictPolicy {
   static constexpr bool can_evict = true;
 
   bool CanGrow(const U64Dash& tbl) {
-    return tbl.bucket_count() + U64Dash::kSegCapacity < max_capacity;
+    return tbl.capacity() + U64Dash::kSegCapacity < max_capacity;
   }
 
   void RecordSplit(U64Dash::Segment_t* segment) {
@@ -921,7 +921,7 @@ struct ShiftRightPolicy {
   static constexpr bool can_evict = true;
 
   bool CanGrow(const U64Dash& tbl) {
-    return tbl.bucket_count() + U64Dash::kSegCapacity < max_capacity;
+    return tbl.capacity() + U64Dash::kSegCapacity < max_capacity;
   }
 
   void RecordSplit(U64Dash::Segment_t* segment) {


### PR DESCRIPTION
bucket count is returned in Info command
This PR fixes the bucket count to be the number of buckets in dragonfly 
Before this fix the returned number was the slots number