### PR TITLE
feat(server): Add `RestoreSerializer`

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -419,7 +419,9 @@ OpResult<std::string> OpDump(const OpArgs& op_args, string_view key) {
 
   if (IsValid(it)) {
     DVLOG(1) << "Dump: key '" << key << "' successfully found, going to dump it";
-    return RdbSerializer::DumpObject(it->second);
+    io::StringSink sink;
+    SerializerBase::DumpObject(it->second, &sink);
+    return sink.str();  // TODO: Add rvalue overload to str()
   }
   // fallback
   DVLOG(1) << "Dump: '" << key << "' Not found";

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -794,14 +794,14 @@ error_code SerializerBase::FlushToSink(io::Sink* s) {
 }
 
 error_code RdbSerializer::FlushToSink(io::Sink* s) {
-  error_code res = SerializerBase::FlushToSink(s);
-  if (res) {
-    // After every flush we should write the DB index again because the blobs in the channel are
-    // interleaved and multiple savers can correspond to a single writer (in case of single file rdb
-    // snapshot)
-    last_entry_db_index_ = kInvalidDbId;
-  }
-  return res;
+  RETURN_ON_ERR(SerializerBase::FlushToSink(s));
+
+  // After every flush we should write the DB index again because the blobs in the channel are
+  // interleaved and multiple savers can correspond to a single writer (in case of single file rdb
+  // snapshot)
+  last_entry_db_index_ = kInvalidDbId;
+
+  return {};
 }
 
 namespace {

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -823,8 +823,8 @@ CrcBuffer MakeCheckSum(std::string_view dump_res) {
 }
 
 void AppendFooter(io::StringSink* dump_res) {
-  auto to_bytes = [](auto buf) {
-    return io::Bytes(reinterpret_cast<uint8_t*>(&buf[0]), buf.size());
+  auto to_bytes = [](const auto& buf) {
+    return io::Bytes(reinterpret_cast<const uint8_t*>(buf.data()), buf.size());
   };
 
   /* Write the footer, this is how it looks like:

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -131,11 +131,10 @@ class RdbSaver {
 
 class CompressorImpl;
 
-class RdbSerializer {
+class SerializerBase {
  public:
-  explicit RdbSerializer(CompressionMode compression_mode);
-
-  ~RdbSerializer();
+  explicit SerializerBase(CompressionMode compression_mode);
+  virtual ~SerializerBase() = default;
 
   // Dumps `obj` in DUMP command format. Uses default compression mode.
   static std::string DumpObject(const CompactObj& obj);
@@ -144,8 +143,45 @@ class RdbSerializer {
   size_t SerializedLen() const;
 
   // Flush internal buffer to sink.
-  std::error_code FlushToSink(io::Sink* s);
+  virtual std::error_code FlushToSink(io::Sink* s);
 
+  size_t GetTotalBufferCapacity() const;
+
+  std::error_code WriteRaw(const ::io::Bytes& buf);
+
+ protected:
+  // Prepare internal buffer for flush. Compress it.
+  io::Bytes PrepareFlush();
+
+  // If membuf data is compressable use compression impl to compress the data and write it to membuf
+  void CompressBlob();
+  void AllocateCompressorOnce();
+
+  CompressionMode compression_mode_;
+  base::IoBuf mem_buf_;
+  std::unique_ptr<CompressorImpl> compressor_impl_;
+
+  static constexpr size_t kMinStrSizeToCompress = 256;
+  static constexpr double kMinCompressionReductionPrecentage = 0.95;
+  struct CompressionStats {
+    uint32_t compression_no_effective = 0;
+    uint32_t small_str_count = 0;
+    uint32_t compression_failed = 0;
+    uint32_t compressed_blobs = 0;
+  };
+  std::optional<CompressionStats> compression_stats_;
+};
+
+class RdbSerializer : public SerializerBase {
+ public:
+  explicit RdbSerializer(CompressionMode compression_mode);
+
+  ~RdbSerializer();
+
+  // Dumps `obj` in DUMP command format. Uses default compression mode.
+  static std::string DumpObject(const CompactObj& obj);
+
+  std::error_code FlushToSink(io::Sink* s) override;
   std::error_code SelectDb(uint32_t dbid);
 
   // Must be called in the thread to which `it` belongs.
@@ -166,7 +202,6 @@ class RdbSerializer {
   // for the dump command - thus it is public function
   std::error_code SaveValue(const PrimeValue& pv);
 
-  std::error_code WriteRaw(const ::io::Bytes& buf);
   std::error_code WriteOpcode(uint8_t opcode) {
     return WriteRaw(::io::Bytes{&opcode, 1});
   }
@@ -179,12 +214,7 @@ class RdbSerializer {
   // Send FULL_SYNC_CUT opcode to notify that all static data was sent.
   std::error_code SendFullSyncCut();
 
-  size_t GetTotalBufferCapacity() const;
-
  private:
-  // Prepare internal buffer for flush. Compress it.
-  io::Bytes PrepareFlush();
-
   std::error_code SaveLzfBlob(const ::io::Bytes& src, size_t uncompressed_len);
   std::error_code SaveObject(const PrimeValue& pv);
   std::error_code SaveListObject(const robj* obj);
@@ -199,29 +229,21 @@ class RdbSerializer {
   std::error_code SaveListPackAsZiplist(uint8_t* lp);
   std::error_code SaveStreamPEL(rax* pel, bool nacks);
   std::error_code SaveStreamConsumers(streamCG* cg);
-  // If membuf data is compressable use compression impl to compress the data and write it to membuf
-  void CompressBlob();
-  void AllocateCompressorOnce();
 
-  base::IoBuf mem_buf_;
   std::string tmp_str_;
   base::PODArray<uint8_t> tmp_buf_;
   DbIndex last_entry_db_index_ = kInvalidDbId;
 
   std::unique_ptr<LZF_HSLOT[]> lzf_;
+};
 
-  CompressionMode compression_mode_;
-  std::unique_ptr<CompressorImpl> compressor_impl_;
+// Serializes CompactObj as RESTORE commands.
+class RestoreSerializer : public SerializerBase {
+ public:
+  explicit RestoreSerializer(CompressionMode compression_mode);
 
-  static constexpr size_t kMinStrSizeToCompress = 256;
-  static constexpr double kMinCompressionReductionPrecentage = 0.95;
-  struct CompressionStats {
-    uint32_t compression_no_effective = 0;
-    uint32_t small_str_count = 0;
-    uint32_t compression_failed = 0;
-    uint32_t compressed_blobs = 0;
-  };
-  std::optional<CompressionStats> compression_stats_;
+  std::error_code SaveEntry(const PrimeKey& pk, const PrimeValue& pv, uint64_t expire_ms,
+                            DbIndex dbid);
 };
 
 }  // namespace dfly

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -136,8 +136,8 @@ class SerializerBase {
   explicit SerializerBase(CompressionMode compression_mode);
   virtual ~SerializerBase() = default;
 
-  // Dumps `obj` in DUMP command format. Uses default compression mode.
-  static std::string DumpObject(const CompactObj& obj);
+  // Dumps `obj` in DUMP command format into `out`. Uses default compression mode.
+  static void DumpObject(const CompactObj& obj, io::StringSink* out);
 
   // Internal buffer size. Might shrink after flush due to compression.
   size_t SerializedLen() const;
@@ -244,6 +244,12 @@ class RestoreSerializer : public SerializerBase {
 
   std::error_code SaveEntry(const PrimeKey& pk, const PrimeValue& pv, uint64_t expire_ms,
                             DbIndex dbid);
+
+ private:
+  // All members are used for saving allocations.
+  std::string key_buffer_;
+  io::StringSink value_dump_sink_;
+  io::StringSink sink_;
 };
 
 }  // namespace dfly


### PR DESCRIPTION
This utility class serializes `CompactObj`s as `RESTORE` commands, and has a similar interface (and a common base class) as `RdbSerializer`

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->