### PR TITLE
chore: consolidate facade stats under a single struct

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -149,7 +149,7 @@ string_view Connection::PubMessage::Message() const {
 
 struct Connection::DispatchOperations {
   DispatchOperations(SinkReplyBuilder* b, Connection* me)
-      : stats{me->service_->GetThreadLocalConnectionStats()}, builder{b}, self(me) {
+      : stats{&tl_facade_stats->conn_stats}, builder{b}, self(me) {
   }
 
   void operator()(const PubMessage& msg);
@@ -595,7 +595,7 @@ io::Result<bool> Connection::CheckForHttpProto(FiberSocketBase* peer) {
 }
 
 void Connection::ConnectionFlow(FiberSocketBase* peer) {
-  stats_ = service_->GetThreadLocalConnectionStats();
+  stats_ = &tl_facade_stats->conn_stats;
 
   ++stats_->num_conns;
   ++stats_->conn_received_cnt;
@@ -866,7 +866,7 @@ void Connection::HandleMigrateRequest() {
 
       queue_backpressure_ = &tl_queue_backpressure_;
 
-      stats_ = service_->GetThreadLocalConnectionStats();
+      stats_ = &tl_facade_stats->conn_stats;
       ++stats_->num_conns;
       stats_->read_buf_capacity += io_buf_.Capacity();
       if (cc_->replica_conn) {

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -39,6 +39,21 @@ ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
   return *this;
 }
 
+ReplyStats& ReplyStats::operator+=(const ReplyStats& o) {
+  ADD(io_write_cnt);
+  ADD(io_write_bytes);
+
+  for (const auto& k_v : o.err_count) {
+    err_count[k_v.first] += k_v.second;
+  }
+
+  for (unsigned i = 0; i < kNumTypes; ++i) {
+    send_stats[i] += o.send_stats[i];
+  }
+
+  return *this;
+}
+
 #undef ADD
 
 string WrongNumArgsError(string_view cmd) {
@@ -112,6 +127,8 @@ CommandId::CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first
 uint32_t CommandId::OptCount(uint32_t mask) {
   return absl::popcount(mask);
 }
+
+__thread FacadeStats* tl_facade_stats = nullptr;
 
 }  // namespace facade
 

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -40,6 +40,7 @@ ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
 }
 
 ReplyStats& ReplyStats::operator+=(const ReplyStats& o) {
+  static_assert(sizeof(ReplyStats) == 80u);
   ADD(io_write_cnt);
   ADD(io_write_bytes);
 

--- a/src/facade/facade_types.h
+++ b/src/facade/facade_types.h
@@ -71,6 +71,8 @@ struct ReplyStats {
     int64_t total_duration = 0;
 
     SendStats& operator+=(const SendStats& other) {
+      static_assert(sizeof(SendStats) == 16u);
+
       count += other.count;
       total_duration += other.total_duration;
       return *this;

--- a/src/facade/ok_main.cc
+++ b/src/facade/ok_main.cc
@@ -19,8 +19,6 @@ namespace facade {
 
 namespace {
 
-thread_local ConnectionStats tl_stats;
-
 class OkService : public ServiceInterface {
  public:
   void DispatchCommand(CmdArgList args, ConnectionContext* cntx) final {
@@ -41,14 +39,11 @@ class OkService : public ServiceInterface {
   ConnectionContext* CreateContext(util::FiberSocketBase* peer, Connection* owner) final {
     return new ConnectionContext{peer, owner};
   }
-
-  ConnectionStats* GetThreadLocalConnectionStats() final {
-    return &tl_stats;
-  }
 };
 
 void RunEngine(ProactorPool* pool, AcceptServer* acceptor) {
   OkService service;
+  pool->Await([](auto*) { tl_facade_stats = new FacadeStats; });
 
   acceptor->AddListener(GetFlag(FLAGS_port), new Listener{Protocol::REDIS, &service});
 

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -141,34 +141,10 @@ class SinkReplyBuilder {
 
   virtual size_t UsedMemory() const;
 
-  enum SendStatsType {
-    kRegular,   // Send() operations that are written to sockets
-    kBatch,     // Send() operations that are internally batched to a buffer
-    kNumTypes,  // Number of types, do not use directly
-  };
+  static const ReplyStats& GetThreadLocalStats() {
+    return tl_facade_stats->reply_stats;
+  }
 
-  struct SendStats {
-    int64_t count = 0;
-    int64_t total_duration = 0;
-
-    SendStats& operator+=(const SendStats& other) {
-      count += other.count;
-      total_duration += other.total_duration;
-      return *this;
-    }
-  };
-
-  struct ReplyStats {
-    SendStats send_stats[SendStatsType::kNumTypes];
-
-    size_t io_write_cnt = 0;
-    size_t io_write_bytes = 0;
-    absl::flat_hash_map<std::string, uint64_t> err_count;
-
-    ReplyStats& operator+=(const ReplyStats& other);
-  };
-
-  static const ReplyStats& GetThreadLocalStats();
   static void ResetThreadLocalStats();
 
  protected:

--- a/src/facade/reply_builder_test.cc
+++ b/src/facade/reply_builder_test.cc
@@ -106,6 +106,10 @@ class RedisReplyBuilderTest : public testing::Test {
     SinkReplyBuilder::ResetThreadLocalStats();
   }
 
+  static void SetUpTestSuite() {
+    tl_facade_stats = new FacadeStats;
+  }
+
  protected:
   std::vector<std::string_view> RawTokenizedMessage() const {
     CHECK(!str().empty());
@@ -133,11 +137,11 @@ class RedisReplyBuilderTest : public testing::Test {
   }
 
   static bool NoErrors() {
-    return SinkReplyBuilder::GetThreadLocalStats().err_count.empty();
+    return tl_facade_stats->reply_stats.err_count.empty();
   }
 
-  static const SinkReplyBuilder::ReplyStats& GetReplyStats() {
-    return SinkReplyBuilder::GetThreadLocalStats();
+  static const ReplyStats& GetReplyStats() {
+    return tl_facade_stats->reply_stats;
   }
 
   // Breaks the string we have in sink into tokens.

--- a/src/facade/service_interface.h
+++ b/src/facade/service_interface.h
@@ -36,7 +36,7 @@ class ServiceInterface {
 
   virtual ConnectionContext* CreateContext(util::FiberSocketBase* peer, Connection* owner) = 0;
 
-  virtual ConnectionStats* GetThreadLocalConnectionStats() = 0;
+  // virtual ConnectionStats* GetThreadLocalConnectionStats() = 0;
 
   virtual void ConfigureHttpHandlers(util::HttpListenerBase* base, bool is_privileged) {
   }

--- a/src/facade/service_interface.h
+++ b/src/facade/service_interface.h
@@ -36,8 +36,6 @@ class ServiceInterface {
 
   virtual ConnectionContext* CreateContext(util::FiberSocketBase* peer, Connection* owner) = 0;
 
-  // virtual ConnectionStats* GetThreadLocalConnectionStats() = 0;
-
   virtual void ConfigureHttpHandlers(util::HttpListenerBase* base, bool is_privileged) {
   }
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -791,6 +791,7 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
 
   // Must initialize before the shard_set because EngineShard::Init references ServerState.
   pp_.Await([&](uint32_t index, ProactorBase* pb) {
+    tl_facade_stats = new FacadeStats;
     ServerState::Init(index, shard_num, &user_registry_);
   });
 
@@ -1459,10 +1460,6 @@ facade::ConnectionContext* Service::CreateContext(util::FiberSocketBase* peer,
   });
 
   return res;
-}
-
-facade::ConnectionStats* Service::GetThreadLocalConnectionStats() {
-  return ServerState::tl_connection_stats();
 }
 
 const CommandId* Service::FindCmd(std::string_view cmd) const {

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -72,8 +72,6 @@ class Service : public facade::ServiceInterface {
   facade::ConnectionContext* CreateContext(util::FiberSocketBase* peer,
                                            facade::Connection* owner) final;
 
-  facade::ConnectionStats* GetThreadLocalConnectionStats() final;
-
   std::pair<const CommandId*, CmdArgList> FindCmd(CmdArgList args) const;
   const CommandId* FindCmd(std::string_view) const;
 

--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -195,10 +195,8 @@ ConnectionMemoryUsage GetConnectionMemoryUsage(ServerFamily* server) {
   }
 
   shard_set->pool()->Await([&](unsigned index, auto*) {
-    mems[index].pipelined_bytes +=
-        server->service().GetThreadLocalConnectionStats()->pipeline_cmd_cache_bytes;
-    mems[index].pipelined_bytes +=
-        server->service().GetThreadLocalConnectionStats()->dispatch_queue_bytes;
+    mems[index].pipelined_bytes += tl_facade_stats->conn_stats.pipeline_cmd_cache_bytes;
+    mems[index].pipelined_bytes += tl_facade_stats->conn_stats.dispatch_queue_bytes;
   });
 
   ConnectionMemoryUsage mem;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -214,7 +214,7 @@ using namespace util;
 using detail::SaveStagesController;
 using http::StringResponse;
 using strings::HumanReadableNumBytes;
-using SendStatsType = facade::SinkReplyBuilder::SendStatsType;
+using SendStatsType = facade::ReplyStats::SendStatsType;
 
 namespace {
 
@@ -764,7 +764,7 @@ void PrintPrometheusMetrics(const Metrics& m, StringResponse* resp) {
   AppendMetricWithoutLabels("uptime_in_seconds", "", m.uptime, MetricType::COUNTER, &resp->body());
 
   // Clients metrics
-  const auto& conn_stats = m.conn_stats;
+  const auto& conn_stats = m.facade_stats.conn_stats;
   AppendMetricWithoutLabels("connected_clients", "", conn_stats.num_conns, MetricType::GAUGE,
                             &resp->body());
   AppendMetricWithoutLabels("client_read_buffer_bytes", "", conn_stats.read_buf_capacity,
@@ -827,7 +827,7 @@ void PrintPrometheusMetrics(const Metrics& m, StringResponse* resp) {
   // Net metrics
   AppendMetricWithoutLabels("net_input_bytes_total", "", conn_stats.io_read_bytes,
                             MetricType::COUNTER, &resp->body());
-  AppendMetricWithoutLabels("net_output_bytes_total", "", m.reply_stats.io_write_bytes,
+  AppendMetricWithoutLabels("net_output_bytes_total", "", m.facade_stats.reply_stats.io_write_bytes,
                             MetricType::COUNTER, &resp->body());
   {
     string send_latency_metrics;
@@ -841,7 +841,7 @@ void PrintPrometheusMetrics(const Metrics& m, StringResponse* resp) {
                        &send_count_metrics);
 
     for (unsigned i = 0; i < SendStatsType::kNumTypes; ++i) {
-      auto& stats = m.reply_stats.send_stats[i];
+      auto& stats = m.facade_stats.reply_stats.send_stats[i];
       string_view type;
       switch (SendStatsType(i)) {
         case SendStatsType::kRegular:
@@ -1045,11 +1045,11 @@ void ServerFamily::StatsMC(std::string_view section, facade::ConnectionContext* 
   ADD_LINE(rusage_user, utime);
   ADD_LINE(rusage_system, systime);
   ADD_LINE(max_connections, -1);
-  ADD_LINE(curr_connections, m.conn_stats.num_conns);
+  ADD_LINE(curr_connections, m.facade_stats.conn_stats.num_conns);
   ADD_LINE(total_connections, -1);
   ADD_LINE(rejected_connections, -1);
-  ADD_LINE(bytes_read, m.conn_stats.io_read_bytes);
-  ADD_LINE(bytes_written, m.reply_stats.io_write_bytes);
+  ADD_LINE(bytes_read, m.facade_stats.conn_stats.io_read_bytes);
+  ADD_LINE(bytes_written, m.facade_stats.reply_stats.io_write_bytes);
   ADD_LINE(limit_maxbytes, -1);
 
   absl::StrAppend(&info, "END\r\n");
@@ -1448,9 +1448,8 @@ void ServerFamily::Config(CmdArgList args, ConnectionContext* cntx) {
   if (sub_cmd == "RESETSTAT") {
     shard_set->pool()->Await([registry = service_.mutable_registry()](unsigned index, auto*) {
       registry->ResetCallStats(index);
-      auto& sstate = *ServerState::tlocal();
-      auto& stats = sstate.connection_stats;
       SinkReplyBuilder::ResetThreadLocalStats();
+      auto& stats = tl_facade_stats->conn_stats;
       stats.command_cnt = 0;
       stats.pipelined_cmd_cnt = 0;
     });
@@ -1536,7 +1535,6 @@ Metrics ServerFamily::GetMetrics() const {
   auto cb = [&](unsigned index, ProactorBase* pb) {
     EngineShard* shard = EngineShard::tlocal();
     ServerState* ss = ServerState::tlocal();
-    auto reply_stats = SinkReplyBuilder::GetThreadLocalStats();
 
     lock_guard lk(mu);
 
@@ -1549,8 +1547,7 @@ Metrics ServerFamily::GetMetrics() const {
 
     result.uptime = time(NULL) - this->start_time_;
     result.qps += uint64_t(ss->MovingSum6());
-    result.conn_stats += ss->connection_stats;
-    result.reply_stats += reply_stats;
+    result.facade_stats += *tl_facade_stats;
 
     if (shard) {
       result.heap_used_bytes += shard->UsedMemory();
@@ -1585,8 +1582,9 @@ Metrics ServerFamily::GetMetrics() const {
   // Update peak stats. We rely on the fact that GetMetrics is called frequently enough to
   // update peak_stats_ from it.
   lock_guard lk{peak_stats_mu_};
-  UpdateMax(&peak_stats_.conn_dispatch_queue_bytes, result.conn_stats.dispatch_queue_bytes);
-  UpdateMax(&peak_stats_.conn_read_buf_capacity, result.conn_stats.read_buf_capacity);
+  UpdateMax(&peak_stats_.conn_dispatch_queue_bytes,
+            result.facade_stats.conn_stats.dispatch_queue_bytes);
+  UpdateMax(&peak_stats_.conn_read_buf_capacity, result.facade_stats.conn_stats.read_buf_capacity);
 
   result.peak_stats = peak_stats_;
 
@@ -1642,10 +1640,10 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
   }
 
   if (should_enter("CLIENTS")) {
-    append("connected_clients", m.conn_stats.num_conns);
-    append("client_read_buffer_bytes", m.conn_stats.read_buf_capacity);
-    append("blocked_clients", m.conn_stats.num_blocked_clients);
-    append("dispatch_queue_entries", m.conn_stats.dispatch_queue_entries);
+    append("connected_clients", m.facade_stats.conn_stats.num_conns);
+    append("client_read_buffer_bytes", m.facade_stats.conn_stats.read_buf_capacity);
+    append("blocked_clients", m.facade_stats.conn_stats.num_blocked_clients);
+    append("dispatch_queue_entries", m.facade_stats.conn_stats.dispatch_queue_entries);
   }
 
   if (should_enter("MEMORY")) {
@@ -1684,9 +1682,10 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
     append("listpack_blobs", total.listpack_blob_cnt);
     append("listpack_bytes", total.listpack_bytes);
     append("small_string_bytes", m.small_string_bytes);
-    append("pipeline_cache_bytes", m.conn_stats.pipeline_cmd_cache_bytes);
-    append("dispatch_queue_bytes", m.conn_stats.dispatch_queue_bytes);
-    append("dispatch_queue_subscriber_bytes", m.conn_stats.dispatch_queue_subscriber_bytes);
+    append("pipeline_cache_bytes", m.facade_stats.conn_stats.pipeline_cmd_cache_bytes);
+    append("dispatch_queue_bytes", m.facade_stats.conn_stats.dispatch_queue_bytes);
+    append("dispatch_queue_subscriber_bytes",
+           m.facade_stats.conn_stats.dispatch_queue_subscriber_bytes);
     append("dispatch_queue_peak_bytes", m.peak_stats.conn_dispatch_queue_bytes);
     append("client_read_buffer_peak_bytes", m.peak_stats.conn_read_buf_capacity);
 
@@ -1716,12 +1715,15 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
   }
 
   if (should_enter("STATS")) {
-    append("total_connections_received", m.conn_stats.conn_received_cnt);
-    append("total_commands_processed", m.conn_stats.command_cnt);
+    auto& conn_stats = m.facade_stats.conn_stats;
+    auto& reply_stats = m.facade_stats.reply_stats;
+
+    append("total_connections_received", conn_stats.conn_received_cnt);
+    append("total_commands_processed", conn_stats.command_cnt);
     append("instantaneous_ops_per_sec", m.qps);
-    append("total_pipelined_commands", m.conn_stats.pipelined_cmd_cnt);
-    append("total_net_input_bytes", m.conn_stats.io_read_bytes);
-    append("total_net_output_bytes", m.reply_stats.io_write_bytes);
+    append("total_pipelined_commands", conn_stats.pipelined_cmd_cnt);
+    append("total_net_input_bytes", conn_stats.io_read_bytes);
+    append("total_net_output_bytes", reply_stats.io_write_bytes);
     append("instantaneous_input_kbps", -1);
     append("instantaneous_output_kbps", -1);
     append("rejected_connections", -1);
@@ -1738,16 +1740,16 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
     append("keyspace_hits", m.events.hits);
     append("keyspace_misses", m.events.misses);
     append("keyspace_mutations", m.events.mutations);
-    append("total_reads_processed", m.conn_stats.io_read_cnt);
-    append("total_writes_processed", m.reply_stats.io_write_cnt);
+    append("total_reads_processed", conn_stats.io_read_cnt);
+    append("total_writes_processed", reply_stats.io_write_cnt);
     append("defrag_attempt_total", m.shard_stats.defrag_attempt_total);
     append("defrag_realloc_total", m.shard_stats.defrag_realloc_total);
     append("defrag_task_invocation_total", m.shard_stats.defrag_task_invocation_total);
-    append("reply_count", m.reply_stats.send_stats[SendStatsType::kRegular].count);
-    append("reply_latency_usec", m.reply_stats.send_stats[SendStatsType::kRegular].total_duration);
-    append("reply_batch_count", m.reply_stats.send_stats[SendStatsType::kBatch].count);
+    append("reply_count", reply_stats.send_stats[SendStatsType::kRegular].count);
+    append("reply_latency_usec", reply_stats.send_stats[SendStatsType::kRegular].total_duration);
+    append("reply_batch_count", reply_stats.send_stats[SendStatsType::kBatch].count);
     append("reply_batch_latency_usec",
-           m.reply_stats.send_stats[SendStatsType::kBatch].total_duration);
+           reply_stats.send_stats[SendStatsType::kBatch].total_duration);
   }
 
   if (should_enter("TIERED", true)) {
@@ -1813,7 +1815,7 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
 
     if (etl.is_master) {
       append("role", "master");
-      append("connected_slaves", m.conn_stats.num_replicas);
+      append("connected_slaves", m.facade_stats.conn_stats.num_replicas);
       const auto& replicas = m.replication_metrics;
       for (size_t i = 0; i < replicas.size(); i++) {
         auto& r = replicas[i];
@@ -1880,7 +1882,7 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
   }
 
   if (should_enter("ERRORSTATS", true)) {
-    for (const auto& k_v : m.reply_stats.err_count) {
+    for (const auto& k_v : m.facade_stats.reply_stats.err_count) {
       append(k_v.first, k_v.second);
     }
   }

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -73,13 +73,10 @@ struct Metrics {
   std::vector<DbStats> db_stats;   // dbsize stats
   EngineShard::Stats shard_stats;  // per-shard stats
 
-  facade::ConnectionStats conn_stats;  // client stats and buffer sizes
-  TieredStats tiered_stats;            // stats for tiered storage
+  facade::FacadeStats facade_stats;  // client stats and buffer sizes
+  TieredStats tiered_stats;          // stats for tiered storage
   SearchStats search_stats;
   ServerState::Stats coordinator_stats;  // stats on transaction running
-
-  facade::SinkReplyBuilder::ReplyStats reply_stats;  // Stats for Send*() ops
-
   PeakStats peak_stats;
 
   size_t uptime = 0;

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -130,7 +130,7 @@ class ServerState {  // public struct - to allow initialization.
   }
 
   static facade::ConnectionStats* tl_connection_stats() {
-    return &state_->connection_stats;
+    return &facade::tl_facade_stats->conn_stats;
   }
 
   ServerState();
@@ -180,7 +180,7 @@ class ServerState {  // public struct - to allow initialization.
   }
 
   void RecordCmd() {
-    ++connection_stats.command_cnt;
+    ++tl_connection_stats()->command_cnt;
     qps_.Inc();
   }
 
@@ -235,8 +235,6 @@ class ServerState {  // public struct - to allow initialization.
   bool is_master = true;
   std::string remote_client_id_;  // for cluster support
   uint32_t log_slower_than_usec = UINT32_MAX;
-
-  facade::ConnectionStats connection_stats;
 
   acl::UserRegistry* user_registry;
 


### PR DESCRIPTION
Remove connection stats from server state and move them under FacadeStats.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->