### PR TITLE
fix(regTests): assertion failure during load in cancel_replication_immediately 

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -276,7 +276,7 @@ template <typename T> void UpdateMax(T* maxv, T current) {
 
 void SetMasterFlagOnAllThreads(bool is_master) {
   auto cb = [is_master](auto* pb) { ServerState::tlocal()->is_master = is_master; };
-  shard_set->pool()->DispatchBrief(cb);
+  shard_set->pool()->Await(cb);
 }
 
 std::optional<cron::cronexpr> InferSnapshotCronExpr() {

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -445,7 +445,7 @@ async def test_cancel_replication_immediately(
             return True
         except redis.exceptions.ResponseError as e:
             err = e.args[0]
-            assert err == "replication cancelled" or err == "Can not execute during LOADING"
+            assert err == "replication cancelled"
             return False
 
     ping_job = asyncio.create_task(ping_status())

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -444,7 +444,8 @@ async def test_cancel_replication_immediately(
             await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
             return True
         except redis.exceptions.ResponseError as e:
-            assert e.args[0] == "replication cancelled"
+            err = e.args[0]
+            assert err == "replication cancelled" or err == "Can not execute during LOADING"
             return False
 
     ping_job = asyncio.create_task(ping_status())

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -444,8 +444,7 @@ async def test_cancel_replication_immediately(
             await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
             return True
         except redis.exceptions.ResponseError as e:
-            err = e.args[0]
-            assert err == "replication cancelled"
+            assert e.args[0] == "replication cancelled"
             return False
 
     ping_job = asyncio.create_task(ping_status())


### PR DESCRIPTION
The issue came up when we introduced [here](https://github.com/dragonflydb/dragonfly/pull/2338/files#diff-04447876005188a028fe0e46ee54f437b03f9d2dfb8b456be2fa6fa539a56499R1945)  and it sometimes causes the CI to [fail](https://github.com/dragonflydb/dragonfly/actions/runs/7393992898/job/20114698331#step:6:3061). 

The problem is that we used `DispatchBrief` instead of `Await` in `SetMasterFlagOnAllThreads`. This triggered the condition introduced on the PR above because by the time the lock on `replicaof_mu` was released the flag change might not have been propagated to other proactor threads allowing an inconsistent state.