### PR TITLE
fix(test): Fix flaky test

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1228,7 +1228,7 @@ bool Service::InvokeCmd(const CommandId* cid, CmdArgList tail_args, ConnectionCo
   // not just the blocking ones
   const auto* conn = cntx->conn();
   if (!(cid->opt_mask() & CO::BLOCKING) && conn != nullptr && etl.GetSlowLog().IsEnabled() &&
-      invoke_time_usec > etl.log_slower_than_usec) {
+      invoke_time_usec >= etl.log_slower_than_usec) {
     vector<string> aux_params;
     CmdArgVec aux_slices;
 


### PR DESCRIPTION
Issue was that in `ServerFamilyTest.SlowLogLen` we set the threshold to be 0 microseconds and make sure that all commands are logged as slow. However, in opt, some commands sometimes take 0 microseconds, which fails the test.

Confirmed via:

```
./server_family_test --gtest_repeat=100 --gtest_filter=ServerFamilyTest.SlowLogLen
```

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->