### PR TITLE
chore: increase action timeout for replication regression tests

### DIFF
--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -54,7 +54,7 @@ runs:
         export DRAGONFLY_PATH="${GITHUB_WORKSPACE}/${{inputs.build-folder-name}}/${{inputs.dfly-executable}}"
 
         run_pytest_with_args() {
-          timeout 20m pytest -m "${{inputs.filter}}" --color=yes --json-report \
+          timeout 30m pytest -m "${{inputs.filter}}" --color=yes --json-report \
             --json-report-file=rep1_report.json dragonfly/replication_test.py --log-cli-level=INFO \
             --df alsologtostderr $1 $2 || code=$?
           if [[ $code -ne 0 ]]; then


### PR DESCRIPTION
On average, the regression tests for `ubuntu-dev:20, Debug, ubuntu-latest` run in 19 minutes which is very close to the timeout limit of 20m. If for some reason the tests take a little longer, they will timeout causing the CI to fail. I increased the timeout time to 30 minutes for replication tests. 

Generally speaking, we should look on how to improve the reg tests. 

* increase the timeout for replication tests from 20m to 30m