### PR TITLE
chore: improvements in dash code

### DIFF
--- a/src/core/dash.h
+++ b/src/core/dash.h
@@ -213,7 +213,7 @@ class DashTable : public detail::DashTableBase {
   }
 
   size_t bucket_count() const {
-    return unique_segments_ * SegmentType::kNumBuckets;
+    return unique_segments_ * SegmentType::kRegularBucketCnt;
   }
 
   // Overall capacity of the table (including stash buckets).
@@ -920,8 +920,8 @@ template <typename Cb>
 void DashTable<_Key, _Value, Policy>::TraverseBucket(const_iterator it, Cb&& cb) {
   SegmentType& s = *segment_[it.seg_id_];
   const auto& b = s.GetBucket(it.bucket_id_);
-  b.ForEachSlot([&](uint8_t slot, bool probe) {
-    cb(iterator{this, it.seg_id_, it.bucket_id_, slot});
+  b.ForEachSlot([it, cb = std::move(cb), table = this](auto* bucket, uint8_t slot, bool probe) {
+    cb(iterator{table, it.seg_id_, it.bucket_id_, slot});
   });
 }
 

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1313,8 +1313,8 @@ size_t DbSlice::EvictObjects(size_t memory_to_free, PrimeIterator it, DbTable* t
   PrimeTable::Segment_t* segment = table->prime.GetSegment(it.segment_id());
   DCHECK(segment);
 
-  constexpr unsigned kNumStashBuckets =
-      PrimeTable::Segment_t::kTotalBuckets - PrimeTable::Segment_t::kNumBuckets;
+  constexpr unsigned kNumStashBuckets = PrimeTable::Segment_t::kStashBucketCnt;
+  constexpr unsigned kNumRegularBuckets = PrimeTable::Segment_t::kRegularBucketCnt;
 
   PrimeTable::bucket_iterator it2(it);
   unsigned evicted = 0;
@@ -1329,7 +1329,7 @@ size_t DbSlice::EvictObjects(size_t memory_to_free, PrimeIterator it, DbTable* t
   };
 
   for (unsigned i = 0; !evict_succeeded && i < kNumStashBuckets; ++i) {
-    unsigned stash_bid = i + PrimeTable::Segment_t::kNumBuckets;
+    unsigned stash_bid = i + kNumRegularBuckets;
     const auto& bucket = segment->GetBucket(stash_bid);
     if (bucket.IsEmpty())
       continue;
@@ -1360,8 +1360,8 @@ size_t DbSlice::EvictObjects(size_t memory_to_free, PrimeIterator it, DbTable* t
   // Try normal buckets now. We iterate from largest slot to smallest across the whole segment.
   for (int slot_id = PrimeTable::Segment_t::kNumSlots - 1; !evict_succeeded && slot_id >= 0;
        --slot_id) {
-    for (unsigned i = 0; i < PrimeTable::Segment_t::kNumBuckets; ++i) {
-      unsigned bid = (it.bucket_id() + i) % PrimeTable::Segment_t::kNumBuckets;
+    for (unsigned i = 0; i < kNumRegularBuckets; ++i) {
+      unsigned bid = (it.bucket_id() + i) % kNumRegularBuckets;
       const auto& bucket = segment->GetBucket(bid);
       if (!bucket.IsBusy(slot_id))
         continue;


### PR DESCRIPTION
Some naming changes + improving the interface of ForEachSlot command that now passes the bucket object instead of relying on the fact that we pass a reference to the bucket via capture. This makes the code more straightforward, imho.

no functional changes are made.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->