### PR TITLE
feat(cluster): Add `RestoreStreamer`.

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 
 
 add_library(dfly_transaction db_slice.cc malloc_stats.cc blocking_controller.cc
-            command_registry.cc
+            command_registry.cc  cluster/unique_slot_checker.cc
             common.cc journal/journal.cc journal/types.cc journal/journal_slice.cc
             server_state.cc table.cc  top_keys.cc transaction.cc
             serializer_commons.cc journal/serializer.cc journal/executor.cc journal/streamer.cc
@@ -42,7 +42,7 @@ add_library(dragonfly_lib engine_shard_set.cc channel_store.cc
             zset_family.cc version.cc bitops_family.cc container_utils.cc io_utils.cc
             top_keys.cc multi_command_squasher.cc hll_family.cc cluster/cluster_config.cc
             cluster/cluster_family.cc cluster/cluster_slot_migration.cc
-            cluster/cluster_shard_migration.cc cluster/unique_slot_checker.cc
+            cluster/cluster_shard_migration.cc
             acl/user.cc acl/user_registry.cc acl/acl_family.cc
             acl/validator.cc acl/helpers.cc)
 

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -42,7 +42,7 @@ add_library(dragonfly_lib engine_shard_set.cc channel_store.cc
             zset_family.cc version.cc bitops_family.cc container_utils.cc io_utils.cc
             top_keys.cc multi_command_squasher.cc hll_family.cc cluster/cluster_config.cc
             cluster/cluster_family.cc cluster/cluster_slot_migration.cc
-            cluster/cluster_shard_migration.cc
+            cluster/cluster_shard_migration.cc cluster/unique_slot_checker.cc
             acl/user.cc acl/user_registry.cc acl/acl_family.cc
             acl/validator.cc acl/helpers.cc)
 

--- a/src/server/cluster/cluster_config.h
+++ b/src/server/cluster/cluster_config.h
@@ -24,6 +24,7 @@ using SlotSet = absl::flat_hash_set<SlotId>;
 class ClusterConfig {
  public:
   static constexpr SlotId kMaxSlotNum = 0x3FFF;
+  static constexpr SlotId kInvalidSlotId = kMaxSlotNum + 1;
 
   struct Node {
     std::string id;

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -478,9 +478,10 @@ void WriteFlushSlotsToJournal(const SlotSet& slots) {
     }
 
     // Send journal entry
+    // TODO: Break slot migration upon FLUSHSLOTS
     journal->RecordEntry(/* txid= */ 0, journal::Op::COMMAND, /* dbid= */ 0,
-                         /* shard_cnt= */ shard_set->size(), make_pair("DFLYCLUSTER", args_view),
-                         false);
+                         /* shard_cnt= */ shard_set->size(), nullopt,
+                         make_pair("DFLYCLUSTER", args_view), false);
   };
   shard_set->pool()->AwaitFiberOnAll(std::move(cb));
 }

--- a/src/server/cluster/unique_slot_checker.cc
+++ b/src/server/cluster/unique_slot_checker.cc
@@ -1,0 +1,38 @@
+#include "server/cluster/unique_slot_checker.h"
+
+using namespace std;
+
+namespace dfly {
+
+void UniqueSlotChecker::Add(std::string_view key) {
+  if (!ClusterConfig::IsEnabled()) {
+    return;
+  }
+
+  Add(ClusterConfig::KeySlot(key));
+}
+
+void UniqueSlotChecker::Add(SlotId slot_id) {
+  if (!ClusterConfig::IsEnabled()) {
+    return;
+  }
+
+  if (!slot_id_.has_value()) {
+    slot_id_ = slot_id;
+    return;
+  }
+
+  if (*slot_id_ != slot_id) {
+    slot_id_ = ClusterConfig::kInvalidSlotId;
+  }
+}
+
+optional<SlotId> UniqueSlotChecker::GetUniqueSlotId() const {
+  if (slot_id_.has_value() && *slot_id_ == ClusterConfig::kInvalidSlotId) {
+    return nullopt;
+  }
+
+  return slot_id_;
+}
+
+}  // namespace dfly

--- a/src/server/cluster/unique_slot_checker.h
+++ b/src/server/cluster/unique_slot_checker.h
@@ -1,0 +1,27 @@
+// Copyright 2023, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <optional>
+#include <string_view>
+
+#include "server/cluster/cluster_config.h"
+
+namespace dfly {
+
+// A simple utility class that "aggregates" SlotId-s and can tell whether all inputs were the same.
+// Only works when cluster is enabled.
+class UniqueSlotChecker {
+ public:
+  void Add(std::string_view key);
+  void Add(SlotId slot_id);
+
+  std::optional<SlotId> GetUniqueSlotId() const;
+
+ private:
+  std::optional<SlotId> slot_id_;
+};
+
+}  // namespace dfly

--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -220,13 +220,14 @@ void RecordJournalFinish(const OpArgs& op_args, uint32_t shard_cnt) {
 void RecordExpiry(DbIndex dbid, string_view key) {
   auto journal = EngineShard::tlocal()->journal();
   CHECK(journal);
-  journal->RecordEntry(0, journal::Op::EXPIRED, dbid, 1, make_pair("DEL", ArgSlice{key}), false);
+  journal->RecordEntry(0, journal::Op::EXPIRED, dbid, 1, ClusterConfig::KeySlot(key),
+                       make_pair("DEL", ArgSlice{key}), false);
 }
 
 void TriggerJournalWriteToSink() {
   auto journal = EngineShard::tlocal()->journal();
   CHECK(journal);
-  journal->RecordEntry(0, journal::Op::NOOP, 0, 0, {}, true);
+  journal->RecordEntry(0, journal::Op::NOOP, 0, 0, nullopt, {}, true);
 }
 
 #define ADD(x) (x) += o.x

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -452,7 +452,7 @@ void DflyCmd::TakeOver(CmdArgList args, ConnectionContext* cntx) {
                &status](EngineShard* shard) {
       FlowInfo* flow = &replica_ptr->flows[shard->shard_id()];
 
-      shard->journal()->RecordEntry(0, journal::Op::PING, 0, 0, {}, true);
+      shard->journal()->RecordEntry(0, journal::Op::PING, 0, 0, nullopt, {}, true);
       while (flow->last_acked_lsn < shard->journal()->GetLsn()) {
         if (absl::Now() - start > timeout_dur) {
           LOG(WARNING) << "Couldn't synchronize with replica for takeover in time: "

--- a/src/server/journal/journal.cc
+++ b/src/server/journal/journal.cc
@@ -119,8 +119,8 @@ bool Journal::EnterLameDuck() {
 }
 
 void Journal::RecordEntry(TxId txid, Op opcode, DbIndex dbid, unsigned shard_cnt,
-                          Entry::Payload payload, bool await) {
-  journal_slice.AddLogRecord(Entry{txid, opcode, dbid, shard_cnt, std::move(payload)}, await);
+                          std::optional<SlotId> slot, Entry::Payload payload, bool await) {
+  journal_slice.AddLogRecord(Entry{txid, opcode, dbid, shard_cnt, slot, std::move(payload)}, await);
 }
 
 /*

--- a/src/server/journal/journal.h
+++ b/src/server/journal/journal.h
@@ -57,8 +57,8 @@ class Journal {
 */
   LSN GetLsn() const;
 
-  void RecordEntry(TxId txid, Op opcode, DbIndex dbid, unsigned shard_cnt, Entry::Payload payload,
-                   bool await);
+  void RecordEntry(TxId txid, Op opcode, DbIndex dbid, unsigned shard_cnt,
+                   std::optional<SlotId> slot, Entry::Payload payload, bool await);
 
  private:
   mutable Mutex state_mu_;

--- a/src/server/journal/journal_slice.cc
+++ b/src/server/journal/journal_slice.cc
@@ -151,6 +151,7 @@ void JournalSlice::AddLogRecord(const Entry& entry, bool await) {
     item->lsn = -1;
     item->opcode = entry.opcode;
     item->data = "";
+    item->slot = entry.slot;
   } else {
     FiberAtomicGuard fg;
     // GetTail gives a pointer to a new tail entry in the buffer, possibly overriding the last entry
@@ -158,6 +159,7 @@ void JournalSlice::AddLogRecord(const Entry& entry, bool await) {
     item = ring_buffer_->GetTail(true);
     item->opcode = entry.opcode;
     item->lsn = lsn_++;
+    item->slot = entry.slot;
 
     io::BufSink buf_sink{&ring_serialize_buf_};
     JournalWriter writer{&buf_sink};

--- a/src/server/journal/journal_test.cc
+++ b/src/server/journal/journal_test.cc
@@ -98,15 +98,15 @@ TEST(Journal, WriteRead) {
   auto list = [v = &lists](auto... ss) { return StoreList(v, ss...); };
 
   std::vector<journal::Entry> test_entries = {
-      {0, journal::Op::COMMAND, 0, 2, make_pair("MSET", slice("A", "1", "B", "2"))},
-      {0, journal::Op::COMMAND, 0, 2, make_pair("MSET", slice("C", "3"))},
-      {1, journal::Op::COMMAND, 0, 2, make_pair("DEL", list("A", "B"))},
-      {2, journal::Op::COMMAND, 1, 1, make_pair("LPUSH", list("l", "v1", "v2"))},
-      {3, journal::Op::COMMAND, 0, 1, make_pair("MSET", slice("D", "4"))},
-      {4, journal::Op::COMMAND, 1, 1, make_pair("DEL", list("l1"))},
-      {5, journal::Op::COMMAND, 2, 1, make_pair("DEL", list("E", "2"))},
-      {6, journal::Op::MULTI_COMMAND, 2, 1, make_pair("SET", list("E", "2"))},
-      {6, journal::Op::EXEC, 2, 1}};
+      {0, journal::Op::COMMAND, 0, 2, nullopt, make_pair("MSET", slice("A", "1", "B", "2"))},
+      {0, journal::Op::COMMAND, 0, 2, nullopt, make_pair("MSET", slice("C", "3"))},
+      {1, journal::Op::COMMAND, 0, 2, nullopt, make_pair("DEL", list("A", "B"))},
+      {2, journal::Op::COMMAND, 1, 1, nullopt, make_pair("LPUSH", list("l", "v1", "v2"))},
+      {3, journal::Op::COMMAND, 0, 1, nullopt, make_pair("MSET", slice("D", "4"))},
+      {4, journal::Op::COMMAND, 1, 1, nullopt, make_pair("DEL", list("l1"))},
+      {5, journal::Op::COMMAND, 2, 1, nullopt, make_pair("DEL", list("E", "2"))},
+      {6, journal::Op::MULTI_COMMAND, 2, 1, nullopt, make_pair("SET", list("E", "2"))},
+      {6, journal::Op::EXEC, 2, 1, nullopt}};
 
   // Write all entries to a buffer.
   base::IoBuf buf;

--- a/src/server/journal/serializer.cc
+++ b/src/server/journal/serializer.cc
@@ -64,7 +64,7 @@ void JournalWriter::Write(std::monostate) {
 void JournalWriter::Write(const journal::Entry& entry) {
   // Check if entry has a new db index and we need to emit a SELECT entry.
   if (entry.opcode != journal::Op::SELECT && (!cur_dbid_ || entry.dbid != *cur_dbid_)) {
-    Write(journal::Entry{journal::Op::SELECT, entry.dbid});
+    Write(journal::Entry{journal::Op::SELECT, entry.dbid, entry.slot});
     cur_dbid_ = entry.dbid;
   }
 

--- a/src/server/journal/streamer.h
+++ b/src/server/journal/streamer.h
@@ -63,11 +63,14 @@ class RestoreStreamer : public JournalStreamer {
   bool ShouldWrite(const journal::JournalItem& item) const override;
   bool ShouldWrite(SlotId slot_id) const;
 
-  void WriteEntry(DbIndex db_index, string_view key, const PrimeValue& pv, uint64_t expire_ms);
+  void WriteBucket(PrimeTable::bucket_iterator it);
+  void WriteEntry(string_view key, const PrimeValue& pv, uint64_t expire_ms);
 
   DbSlice* db_slice_;
   uint64_t snapshot_version_ = 0;
   SlotSet my_slots_;
+  Fiber snapshot_fb_;
+  Cancellation fiber_cancellation_;
 };
 
 }  // namespace dfly

--- a/src/server/journal/streamer.h
+++ b/src/server/journal/streamer.h
@@ -65,6 +65,7 @@ class RestoreStreamer : public JournalStreamer {
 
   void WriteBucket(PrimeTable::bucket_iterator it);
   void WriteEntry(string_view key, const PrimeValue& pv, uint64_t expire_ms);
+  void WriteCommand(journal::Entry::Payload cmd_payload);
 
   DbSlice* db_slice_;
   uint64_t snapshot_version_ = 0;

--- a/src/server/journal/streamer.h
+++ b/src/server/journal/streamer.h
@@ -4,9 +4,11 @@
 
 #pragma once
 
+#include "server/db_slice.h"
 #include "server/io_utils.h"
 #include "server/journal/journal.h"
 #include "server/journal/serializer.h"
+#include "server/rdb_save.h"
 
 namespace dfly {
 
@@ -23,17 +25,20 @@ class JournalStreamer : protected BufferedStreamerBase {
   JournalStreamer(JournalStreamer&& other) = delete;
 
   // Register journal listener and start writer in fiber.
-  void Start(io::Sink* dest);
+  virtual void Start(io::Sink* dest);
 
   // Must be called on context cancellation for unblocking
   // and manual cleanup.
-  void Cancel();
+  virtual void Cancel();
 
   using BufferedStreamerBase::GetTotalBufferCapacities;
 
  private:
   // Writer fiber that steals buffer contents and writes them to dest.
   void WriterFb(io::Sink* dest);
+  virtual bool ShouldWrite(const journal::JournalItem& item) const {
+    return true;
+  }
 
  private:
   Context* cntx_;
@@ -42,6 +47,27 @@ class JournalStreamer : protected BufferedStreamerBase {
   journal::Journal* journal_;
 
   Fiber write_fb_{};
+};
+
+// Serializes existing DB as RESTORE commands, and sends updates as regular commands.
+// Only handles relevant slots, while ignoring all others.
+class RestoreStreamer : public JournalStreamer {
+ public:
+  RestoreStreamer(DbSlice* slice, SlotSet slots, journal::Journal* journal, Context* cntx);
+
+  void Start(io::Sink* dest) override;
+  void Cancel() override;
+
+ private:
+  void OnDbChange(DbIndex db_index, const DbSlice::ChangeReq& req);
+  bool ShouldWrite(const journal::JournalItem& item) const override;
+  bool ShouldWrite(SlotId slot_id) const;
+
+  void WriteEntry(DbIndex db_index, string_view key, const PrimeValue& pv, uint64_t expire_ms);
+
+  DbSlice* db_slice_;
+  uint64_t snapshot_version_ = 0;
+  SlotSet my_slots_;
 };
 
 }  // namespace dfly

--- a/src/server/multi_command_squasher.h
+++ b/src/server/multi_command_squasher.h
@@ -50,7 +50,7 @@ class MultiCommandSquasher {
                        bool verify_commands, bool error_abort);
 
   // Lazy initialize shard info.
-  ShardExecInfo& PrepareShardInfo(ShardId sid);
+  ShardExecInfo& PrepareShardInfo(ShardId sid, std::optional<SlotId> slot_id);
 
   // Retrun squash flags
   SquashResult TrySquash(StoredCmd* cmd);

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -196,9 +196,6 @@ class RdbSerializer : public SerializerBase {
 
   ~RdbSerializer();
 
-  // Dumps `obj` in DUMP command format. Uses default compression mode.
-  static std::string DumpObject(const CompactObj& obj);
-
   std::error_code FlushToSink(io::Sink* s) override;
   std::error_code SelectDb(uint32_t dbid);
 

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -235,19 +235,4 @@ class RdbSerializer : public SerializerBase {
   DbIndex last_entry_db_index_ = kInvalidDbId;
 };
 
-// Serializes CompactObj as RESTORE commands.
-class RestoreSerializer : public SerializerBase {
- public:
-  explicit RestoreSerializer(CompressionMode compression_mode);
-
-  std::error_code SaveEntry(const PrimeKey& pk, const PrimeValue& pv, uint64_t expire_ms,
-                            DbIndex dbid);
-
- private:
-  // All members are used for saving allocations.
-  std::string key_buffer_;
-  io::StringSink value_dump_sink_;
-  io::StringSink sink_;
-};
-
 }  // namespace dfly

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -16,6 +16,7 @@
 #include "core/intent_lock.h"
 #include "core/tx_queue.h"
 #include "facade/op_status.h"
+#include "server/cluster/unique_slot_checker.h"
 #include "server/common.h"
 #include "server/journal/types.h"
 #include "server/table.h"
@@ -146,7 +147,7 @@ class Transaction {
   explicit Transaction(const CommandId* cid);
 
   // Initialize transaction for squashing placed on a specific shard with a given parent tx
-  explicit Transaction(const Transaction* parent, ShardId shard_id);
+  explicit Transaction(const Transaction* parent, ShardId shard_id, std::optional<SlotId> slot_id);
 
   // Initialize from command (args) on specific db.
   OpStatus InitByArgs(DbIndex index, CmdArgList args);
@@ -572,6 +573,7 @@ class Transaction {
   // unique_shard_cnt_ and unique_shard_id_ are accessed only by coordinator thread.
   uint32_t unique_shard_cnt_{0};          // Number of unique shards active
   ShardId unique_shard_id_{kInvalidSid};  // Set if unique_shard_cnt_ = 1
+  UniqueSlotChecker unique_slot_checker_;
 
   EventCount blocking_ec_;  // Used to wake blocking transactions.
   EventCount run_ec_;       // Used to wait for shard callbacks


### PR DESCRIPTION
`RestoreStreamer`, like `JournalStreamer`, streams journal changes to a sink. However, in addition, it traverses the DB like `RdbSerializer` and sends existing entries as `RESTORE` commands.

Adding it required a bit of plumbing to get all journal changes to be slot-aware.

In a follow-up PR I will remove the now unneeded `SerializerBase`.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->