### PR TITLE
chore: reduce Makefile for release procedures only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: write
 
+env:
+  RELEASE_DIR: build-release
+
 jobs:
   create-release:
     runs-on: ubuntu-latest
@@ -34,8 +37,8 @@ jobs:
       uses: actions/cache@v3
       with:
         path: |
-          ${{github.workspace}}/build-opt/
-          !${{github.workspace}}/build-opt/CMakeCache.txt
+          ${{github.workspace}}/${{ env.RELEASE_DIR }}/
+          !${{github.workspace}}/${{ env.RELEASE_DIR }}/CMakeCache.txt
         key: ${{ runner.os }}-release-deps-${{ github.sha }}
         #restore-keys: |
         #  ${{ runner.os }}-release-deps-
@@ -70,19 +73,19 @@ jobs:
             cd /src
             git describe --always --tags ${{ github.sha }}
 
-            if [ -d build-opt ]; then
-              chown -R root build-opt
-              ls -l ./build-opt
-              for i in `ls -d ./build-opt/_deps/*-src`; do
+            if [ -d ${{ env.RELEASE_DIR }} ]; then
+              chown -R root ${{ env.RELEASE_DIR }}
+              ls -l ./${{ env.RELEASE_DIR }}
+              for i in `ls -d ./${{ env.RELEASE_DIR }}/_deps/*-src`; do
                 git config --global --add safe.directory $(realpath $i)
               done
             fi
             ./tools/release.sh
-            ./tools/packaging/generate_debian_package.sh build-opt/dragonfly-aarch64
-            mv dragonfly_*.deb build-opt/
+            ./tools/packaging/generate_debian_package.sh ${{ env.RELEASE_DIR }}/dragonfly-aarch64
+            mv dragonfly_*.deb ${{ env.RELEASE_DIR }}/
     - name: Show the artifact
-      # Items placed in /src/build-opt in the container will be in
-      # ${PWD}/build-opt on the host.
+      # Items placed in /src/${{ env.RELEASE_DIR }} in the container will be in
+      # ${PWD}/${{ env.RELEASE_DIR }} on the host.
       run: |
         echo finished
         ls -al
@@ -91,8 +94,8 @@ jobs:
       with:
         name: dragonfly-aarch64
         path: |
-          build-opt/dragonfly-*tar.gz
-          build-opt/dragonfly_*.deb
+          ${{ env.RELEASE_DIR }}/dragonfly-*tar.gz
+          ${{ env.RELEASE_DIR }}/dragonfly_*.deb
 
   build-native:
     runs-on: ubuntu-latest
@@ -124,10 +127,10 @@ jobs:
           ./tools/release.sh
           # once the build is over, we want to generate a Debian package
           if [ -f /etc/debian_version ]; then
-            ./tools/packaging/generate_debian_package.sh build-opt/dragonfly-x86_64
+            ./tools/packaging/generate_debian_package.sh ${{ env.RELEASE_DIR }}/dragonfly-x86_64
           else
             echo "Creating package for ${{github.ref_name}}"
-            ./tools/packaging/rpm/build_rpm.sh build-opt/dragonfly-x86_64.tar.gz ${{github.ref_name}}
+            ./tools/packaging/rpm/build_rpm.sh ${{ env.RELEASE_DIR }}/dragonfly-x86_64.tar.gz ${{github.ref_name}}
           fi
 
     - name: Run regression tests
@@ -138,13 +141,13 @@ jobs:
         dfly-executable: dragonfly-x86_64
         gspace-secret: ${{ secrets.GSPACES_BOT_DF_BUILD }}
         run-only-on-ubuntu-latest: true
-        build-folder-name: build-opt
+        build-folder-name: ${{ env.RELEASE_DIR }}
     - name: Save artifacts
       run: |
           # place all artifacts at the same location
           mkdir -p results-artifacts
           if [ -f /etc/debian_version ]; then
-            mv build-opt/dragonfly-*tar.gz results-artifacts
+            mv ${{ env.RELEASE_DIR }}/dragonfly-*tar.gz results-artifacts
             mv dragonfly_*.deb results-artifacts
           else
             ls -l *.rpm


### PR DESCRIPTION
Also, change its build directory to build-release. Simplify a bit its configuration steps as well. No change in functionality is expected.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->