### PR TITLE
chore: remove atomic<> from ReplicaInfo::state

### DIFF
--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -104,20 +104,22 @@ class DflyCmd {
   struct ReplicaInfo {
     ReplicaInfo(unsigned flow_count, std::string address, uint32_t listening_port,
                 Context::ErrHandler err_handler)
-        : state{SyncState::PREPARATION},
+        : replica_state{SyncState::PREPARATION},
           cntx{std::move(err_handler)},
           address{std::move(address)},
           listening_port(listening_port),
           flows{flow_count} {
     }
 
-    std::atomic<SyncState> state;
+    SyncState replica_state;  // always guarded by ReplicaInfo::mu
     Context cntx;
 
     std::string address;
     uint32_t listening_port;
     DflyVersion version = DflyVersion::VER0;
 
+    // Flows describe the state of shard-local flow.
+    // They are always indexed by the shard index on the master.
     std::vector<FlowInfo> flows;
     Mutex mu;  // See top of header for locking levels.
   };

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -14,7 +14,7 @@
 #include "server/journal/journal.h"
 #include "server/server_state.h"
 
-ABSL_FLAG(uint32_t, tx_queue_warning_len, 40,
+ABSL_FLAG(uint32_t, tx_queue_warning_len, 96,
           "Length threshold for warning about long transaction queue");
 
 namespace dfly {


### PR DESCRIPTION
This field is protected by ReplicaInfo::mu so non-protected access to it shows a design problem. Indeed, it was done for being able to access this field without a mutex inside ReplicationLags() function.

I moved the access to this field to GetReplicasRoleInfo where we need to lock ReplicaRoleInfo anyways. Also, done some cleanups in the file.

Finally, raised a threshold for "tx queue too long" warnings.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->