### PR TITLE
fix: missing error reply to client after AddOrFind throw std::bad_alloc

### DIFF
--- a/src/server/hll_family.cc
+++ b/src/server/hll_family.cc
@@ -258,7 +258,12 @@ OpResult<int> PFMergeInternal(CmdArgList args, ConnectionContext* cntx) {
     string_view key = ArgS(args, 0);
     const OpArgs& op_args = t->GetOpArgs(shard);
     auto& db_slice = op_args.shard->db_slice();
-    auto res = db_slice.AddOrFind(t->GetDbContext(), key);
+    DbSlice::AddOrFindResult res;
+    try {
+      res = db_slice.AddOrFind(t->GetDbContext(), key);
+    } catch (const bad_alloc& e) {
+      return OpStatus::OUT_OF_MEMORY;
+    }
     res.it->second.SetString(hll);
     return OpStatus::OK;
   };

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -168,7 +168,12 @@ OpStatus IncrementValue(optional<string_view> prev_val, IncrByParam* param) {
 
 OpStatus OpIncrBy(const OpArgs& op_args, string_view key, string_view field, IncrByParam* param) {
   auto& db_slice = op_args.shard->db_slice();
-  auto add_res = db_slice.AddOrFind(op_args.db_cntx, key);
+  DbSlice::AddOrFindResult add_res;
+  try {
+    add_res = db_slice.AddOrFind(op_args.db_cntx, key);
+  } catch (const bad_alloc& e) {
+    return OpStatus::OUT_OF_MEMORY;
+  }
 
   DbTableStats* stats = db_slice.MutableStats(op_args.db_cntx.db_index);
 

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -1076,7 +1076,12 @@ OpResult<bool> OpSet(const OpArgs& op_args, string_view key, string_view path,
       }
     }
 
-    SetJson(op_args, key, std::move(parsed_json.value()));
+    try {
+      SetJson(op_args, key, std::move(parsed_json.value()));
+
+    } catch (const bad_alloc& e) {
+      return OpStatus::OUT_OF_MEMORY;
+    }
     return true;
   }
 
@@ -1154,7 +1159,9 @@ void JsonFamily::Set(CmdArgList args, ConnectionContext* cntx) {
   };
 
   Transaction* trans = cntx->transaction;
+
   OpResult<bool> result = trans->ScheduleSingleHopT(std::move(cb));
+
   auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
   if (result) {
     if (*result) {


### PR DESCRIPTION
There were executions paths that did not handle `std::bad_alloc` thrown in `AddOrFind`. Consequently, the commands affected did not reply to the client with error, triggering the `ReplyGuard`

Fixes #2380 