### PR TITLE
feat: allow throttling tiered writes

### DIFF
--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -233,7 +233,7 @@ void TriggerJournalWriteToSink() {
 #define ADD(x) (x) += o.x
 
 TieredStats& TieredStats::operator+=(const TieredStats& o) {
-  static_assert(sizeof(TieredStats) == 48);
+  static_assert(sizeof(TieredStats) == 56);
 
   ADD(tiered_reads);
   ADD(tiered_writes);
@@ -241,6 +241,7 @@ TieredStats& TieredStats::operator+=(const TieredStats& o) {
   ADD(storage_reserved);
   ADD(aborted_write_cnt);
   ADD(flush_skip_cnt);
+  ADD(throttled_write_cnt);
 
   return *this;
 }

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -123,15 +123,16 @@ void RecordExpiry(DbIndex dbid, std::string_view key);
 void TriggerJournalWriteToSink();
 
 struct TieredStats {
-  size_t tiered_reads = 0;
-  size_t tiered_writes = 0;
+  uint64_t tiered_reads = 0;
+  uint64_t tiered_writes = 0;
 
   size_t storage_capacity = 0;
 
   // how much was reserved by actively stored items.
   size_t storage_reserved = 0;
-  size_t aborted_write_cnt = 0;
-  size_t flush_skip_cnt = 0;
+  uint64_t aborted_write_cnt = 0;
+  uint64_t flush_skip_cnt = 0;
+  uint64_t throttled_write_cnt = 0;
 
   TieredStats& operator+=(const TieredStats&);
 };

--- a/src/server/engine_shard_set.h
+++ b/src/server/engine_shard_set.h
@@ -250,7 +250,6 @@ class EngineShard {
   using Counter = util::SlidingCounter<7>;
 
   Counter counter_[COUNTER_TOTAL];
-  std::vector<Counter> ttl_survivor_sum_;  // we need it per db.
 
   static __thread EngineShard* shard_;
 };

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1784,8 +1784,9 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
     append("tiered_writes", m.tiered_stats.tiered_writes);
     append("tiered_reserved", m.tiered_stats.storage_reserved);
     append("tiered_capacity", m.tiered_stats.storage_capacity);
-    append("tiered_aborted_write_total", m.tiered_stats.aborted_write_cnt);
-    append("tiered_flush_skip_total", m.tiered_stats.flush_skip_cnt);
+    append("tiered_aborted_writes", m.tiered_stats.aborted_write_cnt);
+    append("tiered_flush_skipped", m.tiered_stats.flush_skip_cnt);
+    append("tiered_throttled_writes", m.tiered_stats.throttled_write_cnt);
   }
 
   if (should_enter("PERSISTENCE", true)) {

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -595,15 +595,15 @@ OpResult<optional<string>> SetCmd::Set(const SetParams& params, string_view key,
   if (params.memcache_flags)
     db_slice.SetMCFlag(op_args_.db_cntx.db_index, it->first.AsRef(), params.memcache_flags);
 
+  if (params.flags & SET_STICK) {
+    it->first.SetSticky(true);
+  }
+
   if (shard->tiered_storage() &&
       TieredStorage::EligibleForOffload(value)) {  // external storage enabled.
     // TODO: we may have a bug if we block the fiber inside UnloadItem - "it" may be invalid
     // afterwards.
     shard->tiered_storage()->ScheduleOffload(op_args_.db_cntx.db_index, it);
-  }
-
-  if (params.flags & SET_STICK) {
-    it->first.SetSticky(true);
   }
 
   if (manual_journal_ && op_args_.shard->journal()) {
@@ -662,7 +662,7 @@ OpStatus SetCmd::SetExisting(const SetParams& params, PrimeIterator it, ExpireIt
   prime_value.SetString(value);
   DCHECK(!prime_value.HasIoPending());
 
-  if (value.size() >= kMinTieredLen) {  // external storage enabled.
+  if (TieredStorage::EligibleForOffload(value)) {
     // TODO: if UnloadItem can block the calling fiber, then we have the bug because then "it"
     // can be invalid after the function returns and the functions that follow may access invalid
     // entry.

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -67,7 +67,7 @@ class TieredStorage {
   std::vector<PerDb*> db_arr_;
 
   absl::flat_hash_map<uint32_t, uint8_t> page_refcnt_;
-
+  util::fb2::EventCount throttle_ec_;
   TieredStats stats_;
   size_t max_file_size_;
   size_t allocated_size_ = 0;

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -14,7 +14,7 @@ using namespace testing;
 using absl::SetFlag;
 using absl::StrCat;
 
-ABSL_DECLARE_FLAG(string, spill_file_prefix);
+ABSL_DECLARE_FLAG(string, tiered_prefix);
 
 namespace dfly {
 
@@ -32,7 +32,7 @@ class TieredStorageTest : public BaseFamilyTest {
 
 void TieredStorageTest::SetUpTestSuite() {
   BaseFamilyTest::SetUpTestSuite();
-  SetFlag(&FLAGS_spill_file_prefix, "/tmp/spill");
+  SetFlag(&FLAGS_tiered_prefix, "/tmp/spill");
 
   auto* force_epoll = absl::FindCommandLineFlag("force_epoll");
   if (force_epoll->CurrentValue() == "true") {


### PR DESCRIPTION
The throttling is controlled by tiered_storage_throttle_us flag and can be disabled by passing `--tiered_storage_throttle_us=0`. This introduces a soft back-pressure during writes.

On my machine `debug POPULATE 10000000 key 1000 RAND` with tiered_storage_throttle_us=0 offloads 12% of all the entries, but with tiered_storage_throttle_us=1 it offloads almost 100% by prolonging the operation from 0.96s to 1.72s.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->