### PR TITLE
feat(transaction): Independent out of order execution

### DIFF
--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -173,7 +173,6 @@ class ConnectionContext : public facade::ConnectionContext {
   struct DebugInfo {
     uint32_t shards_count = 0;
     TxClock clock = 0;
-    bool is_ooo = false;
 
     // number of commands in the last exec body.
     unsigned exec_body_len = 0;

--- a/src/server/engine_shard_set.h
+++ b/src/server/engine_shard_set.h
@@ -41,6 +41,7 @@ class EngineShard {
     uint64_t defrag_realloc_total = 0;
     uint64_t defrag_task_invocation_total = 0;
     uint64_t poll_execution_total = 0;
+    uint64_t tx_ooo_total = 0;
     Stats& operator+=(const Stats&);
   };
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1245,10 +1245,8 @@ bool Service::InvokeCmd(const CommandId* cid, CmdArgList tail_args, ConnectionCo
 
   if (cntx->transaction && !cntx->conn_state.exec_info.IsRunning() &&
       cntx->conn_state.script_info == nullptr) {
-    bool is_ooo = cntx->transaction->IsOOO();
-
     cntx->last_command_debug.clock = cntx->transaction->txid();
-    cntx->last_command_debug.is_ooo = is_ooo;
+    cntx->last_command_debug.is_ooo = cntx->transaction->IsOOO();
   }
 
   return true;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1246,7 +1246,6 @@ bool Service::InvokeCmd(const CommandId* cid, CmdArgList tail_args, ConnectionCo
   if (cntx->transaction && !cntx->conn_state.exec_info.IsRunning() &&
       cntx->conn_state.script_info == nullptr) {
     cntx->last_command_debug.clock = cntx->transaction->txid();
-    cntx->last_command_debug.is_ooo = cntx->transaction->IsOOO();
   }
 
   return true;

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -556,9 +556,9 @@ TEST_F(MultiTest, MultiOOO) {
   // OOO works in LOCK_AHEAD mode.
   int mode = absl::GetFlag(FLAGS_multi_exec_mode);
   if (mode == Transaction::LOCK_AHEAD || mode == Transaction::NON_ATOMIC)
-    EXPECT_EQ(200, metrics.coordinator_stats.tx_shard_ooo_cnt);
+    EXPECT_EQ(200, metrics.shard_stats.tx_ooo_total);
   else
-    EXPECT_EQ(0, metrics.coordinator_stats.tx_shard_ooo_cnt);
+    EXPECT_EQ(0, metrics.shard_stats.tx_ooo_total);
 }
 
 // Lua scripts lock their keys ahead and thus can run out of order.

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -556,9 +556,9 @@ TEST_F(MultiTest, MultiOOO) {
   // OOO works in LOCK_AHEAD mode.
   int mode = absl::GetFlag(FLAGS_multi_exec_mode);
   if (mode == Transaction::LOCK_AHEAD || mode == Transaction::NON_ATOMIC)
-    EXPECT_EQ(200, metrics.coordinator_stats.tx_type_cnt[ServerState::OOO]);
+    EXPECT_EQ(200, metrics.coordinator_stats.tx_shard_ooo_cnt);
   else
-    EXPECT_EQ(0, metrics.coordinator_stats.tx_type_cnt[ServerState::OOO]);
+    EXPECT_EQ(0, metrics.coordinator_stats.tx_shard_ooo_cnt);
 }
 
 // Lua scripts lock their keys ahead and thus can run out of order.

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1920,7 +1920,7 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
       val.pop_back();  // last comma.
       append("tx_width_freq", val);
     }
-    append("tx_shard_ooo_total", m.coordinator_stats.tx_shard_ooo_cnt);
+    append("tx_shard_ooo_total", m.shard_stats.tx_ooo_total);
     append("tx_schedule_cancel_total", m.coordinator_stats.tx_schedule_cancel_cnt);
     append("tx_queue_len", m.tx_queue_len);
     append("eval_io_coordination_total", m.coordinator_stats.eval_io_coordination_cnt);

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1159,8 +1159,7 @@ void PrintPrometheusMetrics(const Metrics& m, StringResponse* resp) {
   AppendMetricHeader("transaction_types_total", "Transaction counts by their types",
                      MetricType::COUNTER, &resp->body());
 
-  const char* kTxTypeNames[ServerState::NUM_TX_TYPES] = {"global", "normal", "ooo", "quick",
-                                                         "inline"};
+  const char* kTxTypeNames[ServerState::NUM_TX_TYPES] = {"global", "normal", "quick", "inline"};
   for (unsigned type = 0; type < ServerState::NUM_TX_TYPES; ++type) {
     if (tc[type] > 0) {
       AppendMetricValue("transaction_types_total", tc[type], {"type"}, {kTxTypeNames[type]},
@@ -1908,8 +1907,7 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
   if (should_enter("TRANSACTION", true)) {
     const auto& tc = m.coordinator_stats.tx_type_cnt;
     string val = StrCat("global=", tc[ServerState::GLOBAL], ",normal=", tc[ServerState::NORMAL],
-                        ",ooo=", tc[ServerState::OOO], ",quick=", tc[ServerState::QUICK],
-                        ",inline=", tc[ServerState::INLINE]);
+                        ",quick=", tc[ServerState::QUICK], ",inline=", tc[ServerState::INLINE]);
     append("tx_type_cnt", val);
     val.clear();
     for (unsigned width = 0; width < shard_set->size(); ++width) {
@@ -1922,12 +1920,13 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
       val.pop_back();  // last comma.
       append("tx_width_freq", val);
     }
+    append("tx_shard_ooo_total", m.coordinator_stats.tx_shard_ooo_cnt);
+    append("tx_schedule_cancel_total", m.coordinator_stats.tx_schedule_cancel_cnt);
+    append("tx_queue_len", m.tx_queue_len);
     append("eval_io_coordination_total", m.coordinator_stats.eval_io_coordination_cnt);
     append("eval_shardlocal_coordination_total",
            m.coordinator_stats.eval_shardlocal_coordination_cnt);
     append("eval_squashed_flushes", m.coordinator_stats.eval_squashed_flushes);
-    append("tx_schedule_cancel_total", m.coordinator_stats.tx_schedule_cancel_cnt);
-    append("tx_queue_len", m.tx_queue_len);
     append("multi_squash_execution_total", m.coordinator_stats.multi_squash_executions);
     append("multi_squash_execution_hop_usec", m.coordinator_stats.multi_squash_exec_hop_usec);
     append("multi_squash_execution_reply_usec", m.coordinator_stats.multi_squash_exec_reply_usec);

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -39,7 +39,6 @@ auto ServerState::Stats::operator=(Stats&& other) -> Stats& {
   this->eval_shardlocal_coordination_cnt = other.eval_shardlocal_coordination_cnt;
   this->eval_squashed_flushes = other.eval_squashed_flushes;
   this->tx_schedule_cancel_cnt = other.tx_schedule_cancel_cnt;
-  this->tx_shard_ooo_cnt = other.tx_shard_ooo_cnt;
 
   delete[] this->tx_width_freq_arr;
   this->tx_width_freq_arr = other.tx_width_freq_arr;
@@ -49,7 +48,7 @@ auto ServerState::Stats::operator=(Stats&& other) -> Stats& {
 }
 
 ServerState::Stats& ServerState::Stats::Add(unsigned num_shards, const ServerState::Stats& other) {
-  static_assert(sizeof(Stats) == 13 * 8, "Stats size mismatch");
+  static_assert(sizeof(Stats) == 12 * 8, "Stats size mismatch");
 
   for (int i = 0; i < NUM_TX_TYPES; ++i) {
     this->tx_type_cnt[i] += other.tx_type_cnt[i];
@@ -59,7 +58,6 @@ ServerState::Stats& ServerState::Stats::Add(unsigned num_shards, const ServerSta
   this->eval_shardlocal_coordination_cnt += other.eval_shardlocal_coordination_cnt;
   this->eval_squashed_flushes += other.eval_squashed_flushes;
   this->tx_schedule_cancel_cnt += other.tx_schedule_cancel_cnt;
-  this->tx_shard_ooo_cnt += other.tx_shard_ooo_cnt;
 
   this->multi_squash_executions += other.multi_squash_executions;
   this->multi_squash_exec_hop_usec += other.multi_squash_exec_hop_usec;

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -39,6 +39,7 @@ auto ServerState::Stats::operator=(Stats&& other) -> Stats& {
   this->eval_shardlocal_coordination_cnt = other.eval_shardlocal_coordination_cnt;
   this->eval_squashed_flushes = other.eval_squashed_flushes;
   this->tx_schedule_cancel_cnt = other.tx_schedule_cancel_cnt;
+  this->tx_shard_ooo_cnt = other.tx_shard_ooo_cnt;
 
   delete[] this->tx_width_freq_arr;
   this->tx_width_freq_arr = other.tx_width_freq_arr;
@@ -58,6 +59,7 @@ ServerState::Stats& ServerState::Stats::Add(unsigned num_shards, const ServerSta
   this->eval_shardlocal_coordination_cnt += other.eval_shardlocal_coordination_cnt;
   this->eval_squashed_flushes += other.eval_squashed_flushes;
   this->tx_schedule_cancel_cnt += other.tx_schedule_cancel_cnt;
+  this->tx_shard_ooo_cnt += other.tx_shard_ooo_cnt;
 
   this->multi_squash_executions += other.multi_squash_executions;
   this->multi_squash_exec_hop_usec += other.multi_squash_exec_hop_usec;

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -96,7 +96,6 @@ class ServerState {  // public struct - to allow initialization.
   enum TxType { GLOBAL, NORMAL, QUICK, INLINE, NUM_TX_TYPES };
   struct Stats {
     std::array<uint64_t, NUM_TX_TYPES> tx_type_cnt;
-    uint64_t tx_shard_ooo_cnt = 0;
     uint64_t tx_schedule_cancel_cnt = 0;
 
     uint64_t eval_io_coordination_cnt = 0;

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -93,15 +93,16 @@ class ServerState {  // public struct - to allow initialization.
   void operator=(const ServerState&) = delete;
 
  public:
-  enum TxType { GLOBAL, NORMAL, OOO, QUICK, INLINE, NUM_TX_TYPES };
+  enum TxType { GLOBAL, NORMAL, QUICK, INLINE, NUM_TX_TYPES };
   struct Stats {
     std::array<uint64_t, NUM_TX_TYPES> tx_type_cnt;
+    uint64_t tx_shard_ooo_cnt = 0;
+    uint64_t tx_schedule_cancel_cnt = 0;
 
     uint64_t eval_io_coordination_cnt = 0;
     uint64_t eval_shardlocal_coordination_cnt = 0;
     uint64_t eval_squashed_flushes = 0;
 
-    uint64_t tx_schedule_cancel_cnt = 0;
     uint64_t multi_squash_executions = 0;
     uint64_t multi_squash_exec_hop_usec = 0;
     uint64_t multi_squash_exec_reply_usec = 0;

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1127,7 +1127,6 @@ bool Transaction::ScheduleInShard(EngineShard* shard) {
     sd.local_mask |= KEYLOCK_ACQUIRED;
     if (lock_granted) {
       sd.local_mask |= OUT_OF_ORDER;
-      ServerState::tlocal()->stats.tx_shard_ooo_cnt++;
     }
 
     DVLOG(3) << "Lock granted " << lock_granted << " for trans " << DebugId();

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -157,7 +157,7 @@ class Transaction {
   // State on specific shard.
   enum LocalMask : uint16_t {
     ACTIVE = 1,                 // Set on all active shards.
-    OUT_OF_ORDER = 1 << 2,      // Whether it can run as out of order
+    OUT_OF_ORDER = 1 << 2,      // Whether it can run out of order, meaningless without keylock
     KEYLOCK_ACQUIRED = 1 << 3,  // Whether its key locks are acquired
     SUSPENDED_Q = 1 << 4,       // Whether is suspended (by WatchInShard())
     AWAKED_Q = 1 << 5,          // Whether it was awakened (by NotifySuspended())

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -157,7 +157,7 @@ class Transaction {
   // State on specific shard.
   enum LocalMask : uint16_t {
     ACTIVE = 1,                 // Set on all active shards.
-    OUT_OF_ORDER = 1 << 2,      // Whether it can run out of order, meaningless without keylock
+    OUT_OF_ORDER = 1 << 2,      // Whether it can run out of order. Undefined if KEYLOCK_ACQUIRED is not set.
     KEYLOCK_ACQUIRED = 1 << 3,  // Whether its key locks are acquired
     SUSPENDED_Q = 1 << 4,       // Whether is suspended (by WatchInShard())
     AWAKED_Q = 1 << 5,          // Whether it was awakened (by NotifySuspended())

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -156,8 +156,9 @@ class Transaction {
 
   // State on specific shard.
   enum LocalMask : uint16_t {
-    ACTIVE = 1,                 // Set on all active shards.
-    OUT_OF_ORDER = 1 << 2,      // Whether it can run out of order. Undefined if KEYLOCK_ACQUIRED is not set.
+    ACTIVE = 1,  // Set on all active shards.
+    OUT_OF_ORDER =
+        1 << 2,  // Whether it can run out of order. Undefined if KEYLOCK_ACQUIRED is not set.
     KEYLOCK_ACQUIRED = 1 << 3,  // Whether its key locks are acquired
     SUSPENDED_Q = 1 << 4,       // Whether is suspended (by WatchInShard())
     AWAKED_Q = 1 << 5,          // Whether it was awakened (by NotifySuspended())
@@ -309,10 +310,6 @@ class Transaction {
 
   bool IsGlobal() const;
 
-  bool IsOOO() const {
-    return coordinator_state_ & COORD_OOO;
-  }
-
   // If blocking tx was woken up on this shard, get wake key.
   std::optional<std::string_view> GetWakeKey(ShardId sid) const;
 
@@ -422,7 +419,6 @@ class Transaction {
     COORD_CONCLUDING = 1 << 1,  // Whether its the last hop of a transaction
     COORD_BLOCKED = 1 << 2,
     COORD_CANCELLED = 1 << 3,
-    COORD_OOO = 1 << 4,
   };
 
   struct PerShardCache {


### PR DESCRIPTION
Previously, transactions would run out of order only when all shards determined that the keys locks were free. With this change, each shard might decide to run out of order independently if the locks are free. `COORD_OOO` is now deprecated and the `OUT_OF_ORDER` per-shard flag should is used to indicate it