### PR TITLE
refactor: return OpResult in DbSlice::AddOrFind instead of throwing std::bad_alloc

### DIFF
--- a/src/facade/op_status.h
+++ b/src/facade/op_status.h
@@ -82,15 +82,19 @@ template <typename V> class OpResult : public OpResultBase {
     return &v_;
   }
 
-  V& operator*() {
+  V& operator*() & {
     return v_;
+  }
+
+  V&& operator*() && {
+    return std::move(v_);
   }
 
   const V* operator->() const {
     return &v_;
   }
 
-  const V& operator*() const {
+  const V& operator*() const& {
     return v_;
   }
 

--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -324,9 +324,7 @@ std::optional<bool> ElementAccess::Exists(EngineShard* shard) {
 
 OpStatus ElementAccess::Find(EngineShard* shard) {
   auto op_res = shard->db_slice().AddOrFindAndFetch(context_, key_);
-  if (!op_res) {
-    return op_res.status();
-  }
+  RETURN_ON_BAD_STATUS(op_res);
   auto& add_res = *op_res;
 
   if (!add_res.is_new && add_res.it->second.ObjType() != OBJ_STRING) {

--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -327,12 +327,10 @@ OpStatus ElementAccess::Find(EngineShard* shard) {
   if (!op_res) {
     return op_res.status();
   }
-  auto add_res = std::move(*op_res);
+  auto& add_res = *op_res;
 
-  if (!add_res.is_new) {
-    if (add_res.it->second.ObjType() != OBJ_STRING) {
-      return OpStatus::WRONG_TYPE;
-    }
+  if (!add_res.is_new && add_res.it->second.ObjType() != OBJ_STRING) {
+    return OpStatus::WRONG_TYPE;
   }
   element_iter_ = add_res.it;
   added_ = add_res.is_new;

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -495,7 +495,8 @@ OpResult<pair<PrimeConstIterator, unsigned>> DbSlice::FindFirstReadOnly(const Co
   return OpStatus::KEY_NOTFOUND;
 }
 
-DbSlice::AddOrFindResult DbSlice::AddOrFind(const Context& cntx, string_view key) noexcept(false) {
+OpResult<DbSlice::AddOrFindResult> DbSlice::AddOrFind(const Context& cntx,
+                                                      string_view key) noexcept(false) {
   DCHECK(IsDbValid(cntx.db_index));
 
   DbTable& db = *db_arr_[cntx.db_index];
@@ -504,14 +505,15 @@ DbSlice::AddOrFindResult DbSlice::AddOrFind(const Context& cntx, string_view key
 
   if (IsValid(res.it)) {
     PreUpdate(cntx.db_index, res.it);
-    return {.it = res.it,
-            .exp_it = res.exp_it,
-            .is_new = false,
-            .post_updater = AutoUpdater({.action = AutoUpdater::DestructorAction::kRun,
-                                         .db_slice = this,
-                                         .db_ind = cntx.db_index,
-                                         .it = res.it,
-                                         .key = key})};
+    return DbSlice::AddOrFindResult{
+        .it = res.it,
+        .exp_it = res.exp_it,
+        .is_new = false,
+        .post_updater = AutoUpdater({.action = AutoUpdater::DestructorAction::kRun,
+                                     .db_slice = this,
+                                     .db_ind = cntx.db_index,
+                                     .it = res.it,
+                                     .key = key})};
   }
 
   // It's a new entry.
@@ -542,7 +544,7 @@ DbSlice::AddOrFindResult DbSlice::AddOrFind(const Context& cntx, string_view key
   if (apply_memory_limit && !caching_mode_ && evp.mem_budget() < 0) {
     VLOG(2) << "AddOrFind: over limit, budget: " << evp.mem_budget();
     events_.insertion_rejections++;
-    throw bad_alloc();
+    return OpStatus::OUT_OF_MEMORY;
   }
 
   // Fast-path if change_cb_ is empty so we Find or Add using
@@ -556,8 +558,7 @@ DbSlice::AddOrFindResult DbSlice::AddOrFind(const Context& cntx, string_view key
   } catch (bad_alloc& e) {
     VLOG(2) << "AddOrFind2: bad alloc exception, budget: " << evp.mem_budget();
     events_.insertion_rejections++;
-
-    throw e;
+    return OpStatus::OUT_OF_MEMORY;
   }
 
   size_t evicted_obj_bytes = 0;
@@ -589,14 +590,15 @@ DbSlice::AddOrFindResult DbSlice::AddOrFind(const Context& cntx, string_view key
     db.slots_stats[sid].key_count += 1;
   }
 
-  return {.it = it,
-          .exp_it = ExpireIterator{},
-          .is_new = true,
-          .post_updater = AutoUpdater({.action = AutoUpdater::DestructorAction::kRun,
-                                       .db_slice = this,
-                                       .db_ind = cntx.db_index,
-                                       .it = it,
-                                       .key = key})};
+  return DbSlice::AddOrFindResult{
+      .it = it,
+      .exp_it = ExpireIterator{},
+      .is_new = true,
+      .post_updater = AutoUpdater({.action = AutoUpdater::DestructorAction::kRun,
+                                   .db_slice = this,
+                                   .db_ind = cntx.db_index,
+                                   .it = it,
+                                   .key = key})};
 }
 
 void DbSlice::ActivateDb(DbIndex db_ind) {
@@ -774,12 +776,18 @@ uint32_t DbSlice::GetMCFlag(DbIndex db_ind, const PrimeKey& key) const {
   return it->second;
 }
 
-DbSlice::ItAndUpdater DbSlice::AddNew(const Context& cntx, string_view key, PrimeValue obj,
-                                      uint64_t expire_at_ms) noexcept(false) {
-  auto res = AddOrUpdateInternal(cntx, key, std::move(obj), expire_at_ms, false);
+OpResult<DbSlice::ItAndUpdater> DbSlice::AddNew(const Context& cntx, string_view key,
+                                                PrimeValue obj,
+                                                uint64_t expire_at_ms) noexcept(false) {
+  auto op_result = AddOrUpdateInternal(cntx, key, std::move(obj), expire_at_ms, false);
+  if (!op_result) {
+    return op_result.status();
+  }
+  auto res = std::move(*op_result);
   CHECK(res.is_new);
 
-  return {.it = res.it, .exp_it = res.exp_it, .post_updater = std::move(res.post_updater)};
+  return DbSlice::ItAndUpdater{
+      .it = res.it, .exp_it = res.exp_it, .post_updater = std::move(res.post_updater)};
 }
 
 pair<int64_t, int64_t> DbSlice::ExpireParams::Calculate(int64_t now_ms) const {
@@ -832,14 +840,21 @@ OpResult<int64_t> DbSlice::UpdateExpire(const Context& cntx, PrimeIterator prime
   }
 }
 
-DbSlice::AddOrFindResult DbSlice::AddOrUpdateInternal(const Context& cntx, std::string_view key,
-                                                      PrimeValue obj, uint64_t expire_at_ms,
-                                                      bool force_update) noexcept(false) {
+OpResult<DbSlice::AddOrFindResult> DbSlice::AddOrUpdateInternal(const Context& cntx,
+                                                                std::string_view key,
+                                                                PrimeValue obj,
+                                                                uint64_t expire_at_ms,
+                                                                bool force_update) noexcept(false) {
   DCHECK(!obj.IsRef());
 
-  auto res = AddOrFind(cntx, key);
+  auto op_result = AddOrFind(cntx, key);
+  if (!op_result) {
+    return op_result;
+  }
+
+  auto& res = *op_result;
   if (!res.is_new && !force_update)  // have not inserted.
-    return res;
+    return op_result;
 
   auto& db = *db_arr_[cntx.db_index];
   auto& it = res.it;
@@ -856,11 +871,12 @@ DbSlice::AddOrFindResult DbSlice::AddOrUpdateInternal(const Context& cntx, std::
     }
   }
 
-  return res;
+  return op_result;
 }
 
-DbSlice::AddOrFindResult DbSlice::AddOrUpdate(const Context& cntx, string_view key, PrimeValue obj,
-                                              uint64_t expire_at_ms) noexcept(false) {
+OpResult<DbSlice::AddOrFindResult> DbSlice::AddOrUpdate(const Context& cntx, string_view key,
+                                                        PrimeValue obj,
+                                                        uint64_t expire_at_ms) noexcept(false) {
   return AddOrUpdateInternal(cntx, key, std::move(obj), expire_at_ms, true);
 }
 

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -495,8 +495,7 @@ OpResult<pair<PrimeConstIterator, unsigned>> DbSlice::FindFirstReadOnly(const Co
   return OpStatus::KEY_NOTFOUND;
 }
 
-OpResult<DbSlice::AddOrFindResult> DbSlice::AddOrFind(const Context& cntx,
-                                                      string_view key) noexcept(false) {
+OpResult<DbSlice::AddOrFindResult> DbSlice::AddOrFind(const Context& cntx, string_view key) {
   DCHECK(IsDbValid(cntx.db_index));
 
   DbTable& db = *db_arr_[cntx.db_index];
@@ -777,13 +776,12 @@ uint32_t DbSlice::GetMCFlag(DbIndex db_ind, const PrimeKey& key) const {
 }
 
 OpResult<DbSlice::ItAndUpdater> DbSlice::AddNew(const Context& cntx, string_view key,
-                                                PrimeValue obj,
-                                                uint64_t expire_at_ms) noexcept(false) {
+                                                PrimeValue obj, uint64_t expire_at_ms) {
   auto op_result = AddOrUpdateInternal(cntx, key, std::move(obj), expire_at_ms, false);
   if (!op_result) {
     return op_result.status();
   }
-  auto res = std::move(*op_result);
+  auto& res = *op_result;
   CHECK(res.is_new);
 
   return DbSlice::ItAndUpdater{
@@ -844,7 +842,7 @@ OpResult<DbSlice::AddOrFindResult> DbSlice::AddOrUpdateInternal(const Context& c
                                                                 std::string_view key,
                                                                 PrimeValue obj,
                                                                 uint64_t expire_at_ms,
-                                                                bool force_update) noexcept(false) {
+                                                                bool force_update) {
   DCHECK(!obj.IsRef());
 
   auto op_result = AddOrFind(cntx, key);
@@ -875,8 +873,7 @@ OpResult<DbSlice::AddOrFindResult> DbSlice::AddOrUpdateInternal(const Context& c
 }
 
 OpResult<DbSlice::AddOrFindResult> DbSlice::AddOrUpdate(const Context& cntx, string_view key,
-                                                        PrimeValue obj,
-                                                        uint64_t expire_at_ms) noexcept(false) {
+                                                        PrimeValue obj, uint64_t expire_at_ms) {
   return AddOrUpdateInternal(cntx, key, std::move(obj), expire_at_ms, true);
 }
 

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -221,17 +221,17 @@ class DbSlice {
     AddOrFindResult& operator=(ItAndUpdater&& o);
   };
 
-  OpResult<AddOrFindResult> AddOrFind(const Context& cntx, std::string_view key) noexcept(false);
+  OpResult<AddOrFindResult> AddOrFind(const Context& cntx, std::string_view key);
 
   // Same as AddOrSkip, but overwrites in case entry exists.
   OpResult<AddOrFindResult> AddOrUpdate(const Context& cntx, std::string_view key, PrimeValue obj,
-                                        uint64_t expire_at_ms) noexcept(false);
+                                        uint64_t expire_at_ms);
 
   // Adds a new entry. Requires: key does not exist in this slice.
   // Returns the iterator to the newly added entry.
   // Returns OpStatus::OUT_OF_MEMORY if bad_alloc is thrown
   OpResult<ItAndUpdater> AddNew(const Context& cntx, std::string_view key, PrimeValue obj,
-                                uint64_t expire_at_ms) noexcept(false);
+                                uint64_t expire_at_ms);
 
   // Update entry expiration. Return epxiration timepoint in abs milliseconds, or -1 if the entry
   // already expired and was deleted;
@@ -399,7 +399,7 @@ class DbSlice {
 
   OpResult<AddOrFindResult> AddOrUpdateInternal(const Context& cntx, std::string_view key,
                                                 PrimeValue obj, uint64_t expire_at_ms,
-                                                bool force_update) noexcept(false);
+                                                bool force_update);
 
   void FlushSlotsFb(const SlotSet& slot_ids);
   void FlushDbIndexes(const std::vector<DbIndex>& indexes);

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -221,17 +221,17 @@ class DbSlice {
     AddOrFindResult& operator=(ItAndUpdater&& o);
   };
 
-  AddOrFindResult AddOrFind(const Context& cntx, std::string_view key) noexcept(false);
+  OpResult<AddOrFindResult> AddOrFind(const Context& cntx, std::string_view key) noexcept(false);
 
   // Same as AddOrSkip, but overwrites in case entry exists.
-  AddOrFindResult AddOrUpdate(const Context& cntx, std::string_view key, PrimeValue obj,
-                              uint64_t expire_at_ms) noexcept(false);
+  OpResult<AddOrFindResult> AddOrUpdate(const Context& cntx, std::string_view key, PrimeValue obj,
+                                        uint64_t expire_at_ms) noexcept(false);
 
   // Adds a new entry. Requires: key does not exist in this slice.
   // Returns the iterator to the newly added entry.
-  // throws: bad_alloc is insertion could not happen due to out of memory.
-  ItAndUpdater AddNew(const Context& cntx, std::string_view key, PrimeValue obj,
-                      uint64_t expire_at_ms) noexcept(false);
+  // Returns OpStatus::OUT_OF_MEMORY if bad_alloc is thrown
+  OpResult<ItAndUpdater> AddNew(const Context& cntx, std::string_view key, PrimeValue obj,
+                                uint64_t expire_at_ms) noexcept(false);
 
   // Update entry expiration. Return epxiration timepoint in abs milliseconds, or -1 if the entry
   // already expired and was deleted;
@@ -397,8 +397,9 @@ class DbSlice {
   void PreUpdate(DbIndex db_ind, PrimeIterator it);
   void PostUpdate(DbIndex db_ind, PrimeIterator it, std::string_view key, size_t orig_size);
 
-  AddOrFindResult AddOrUpdateInternal(const Context& cntx, std::string_view key, PrimeValue obj,
-                                      uint64_t expire_at_ms, bool force_update) noexcept(false);
+  OpResult<AddOrFindResult> AddOrUpdateInternal(const Context& cntx, std::string_view key,
+                                                PrimeValue obj, uint64_t expire_at_ms,
+                                                bool force_update) noexcept(false);
 
   void FlushSlotsFb(const SlotSet& slot_ids);
   void FlushDbIndexes(const std::vector<DbIndex>& indexes);

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -541,19 +541,19 @@ TEST_F(DflyEngineTest, Bug496) {
         db.RegisterOnChange([&cb_hits](DbIndex, const DbSlice::ChangeReq&) { cb_hits++; });
 
     {
-      auto res = std::move(*db.AddOrFind({}, "key-1"));
+      auto res = *db.AddOrFind({}, "key-1");
       EXPECT_TRUE(res.is_new);
       EXPECT_EQ(cb_hits, 1);
     }
 
     {
-      auto res = std::move(*db.AddOrFind({}, "key-1"));
+      auto res = *db.AddOrFind({}, "key-1");
       EXPECT_FALSE(res.is_new);
       EXPECT_EQ(cb_hits, 2);
     }
 
     {
-      auto res = std::move(*db.AddOrFind({}, "key-2"));
+      auto res = *db.AddOrFind({}, "key-2");
       EXPECT_TRUE(res.is_new);
       EXPECT_EQ(cb_hits, 3);
     }

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -539,19 +539,19 @@ TEST_F(DflyEngineTest, Bug496) {
         db.RegisterOnChange([&cb_hits](DbIndex, const DbSlice::ChangeReq&) { cb_hits++; });
 
     {
-      auto res = db.AddOrFind({}, "key-1");
+      auto res = std::move(*db.AddOrFind({}, "key-1"));
       EXPECT_TRUE(res.is_new);
       EXPECT_EQ(cb_hits, 1);
     }
 
     {
-      auto res = db.AddOrFind({}, "key-1");
+      auto res = std::move(*db.AddOrFind({}, "key-1"));
       EXPECT_FALSE(res.is_new);
       EXPECT_EQ(cb_hits, 2);
     }
 
     {
-      auto res = db.AddOrFind({}, "key-2");
+      auto res = std::move(*db.AddOrFind({}, "key-2"));
       EXPECT_TRUE(res.is_new);
       EXPECT_EQ(cb_hits, 3);
     }

--- a/src/server/error.h
+++ b/src/server/error.h
@@ -33,6 +33,17 @@ using facade::kWrongTypeErr;
 
 #endif  // RETURN_ON_ERR
 
+#ifndef RETURN_ON_BAD_STATUS
+
+#define RETURN_ON_BAD_STATUS(x) \
+  do {                          \
+    if (!(x)) {                 \
+      return (x).status();      \
+    }                           \
+  } while (0)
+
+#endif  // RETURN_ON_BAD_STATUS
+
 namespace rdb {
 
 enum errc {

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -371,9 +371,7 @@ OpStatus Renamer::UpdateDest(Transaction* t, EngineShard* es) {
       }
       auto op_res =
           db_slice.AddNew(t->GetDbContext(), dest_key, std::move(pv_), src_res_.expire_ts);
-      if (!op_res) {
-        return op_res.status();
-      }
+      RETURN_ON_BAD_STATUS(op_res);
       res = std::move(*op_res);
     }
 
@@ -1439,9 +1437,7 @@ OpResult<void> GenericFamily::OpRen(const OpArgs& op_args, string_view from_key,
     from_res.post_updater.Run();
     CHECK(db_slice.Del(op_args.db_cntx.db_index, from_res.it));
     auto op_result = db_slice.AddNew(op_args.db_cntx, to_key, std::move(from_obj), exp_ts);
-    if (!op_result) {
-      return op_result.status();
-    }
+    RETURN_ON_BAD_STATUS(op_result);
     to_res = std::move(*op_result);
   }
 
@@ -1501,9 +1497,7 @@ OpStatus GenericFamily::OpMove(const OpArgs& op_args, string_view key, DbIndex t
 
   CHECK(db_slice.Del(op_args.db_cntx.db_index, from_res.it));
   auto op_result = db_slice.AddNew(target_cntx, key, std::move(from_obj), exp_ts);
-  if (!op_result) {
-    return op_result.status();
-  }
+  RETURN_ON_BAD_STATUS(op_result);
   auto& add_res = *op_result;
   add_res.it->first.SetSticky(sticky);
 

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -138,8 +138,8 @@ bool RdbRestoreValue::Add(std::string_view data, std::string_view key, DbSlice& 
   }
 
   DbContext context{.db_index = index, .time_now_ms = GetCurrentTimeMs()};
-  db_slice.AddNew(context, key, std::move(pv), expire_ms);
-  return true;
+  auto res = db_slice.AddNew(context, key, std::move(pv), expire_ms);
+  return res.ok();
 }
 
 class RestoreArgs {
@@ -369,7 +369,10 @@ OpStatus Renamer::UpdateDest(Transaction* t, EngineShard* es) {
       if (src_res_.ref_val.ObjType() == OBJ_STRING) {
         pv_.SetString(str_val_);
       }
-      res = db_slice.AddNew(t->GetDbContext(), dest_key, std::move(pv_), src_res_.expire_ts);
+      auto res = db_slice.AddNew(t->GetDbContext(), dest_key, std::move(pv_), src_res_.expire_ts);
+      if (!res) {
+        return res.status();
+      }
     }
 
     dest_it->first.SetSticky(src_res_.sticky);
@@ -1433,7 +1436,11 @@ OpResult<void> GenericFamily::OpRen(const OpArgs& op_args, string_view from_key,
     // the value in `from_obj`.
     from_res.post_updater.Run();
     CHECK(db_slice.Del(op_args.db_cntx.db_index, from_res.it));
-    to_res = db_slice.AddNew(op_args.db_cntx, to_key, std::move(from_obj), exp_ts);
+    auto op_result = db_slice.AddNew(op_args.db_cntx, to_key, std::move(from_obj), exp_ts);
+    if (!op_result) {
+      return op_result.status();
+    }
+    to_res = std::move(*op_result);
   }
 
   to_res.it->first.SetSticky(sticky);
@@ -1491,7 +1498,11 @@ OpStatus GenericFamily::OpMove(const OpArgs& op_args, string_view key, DbIndex t
   from_res.it->second.SetExpire(IsValid(from_res.exp_it));
 
   CHECK(db_slice.Del(op_args.db_cntx.db_index, from_res.it));
-  auto add_res = db_slice.AddNew(target_cntx, key, std::move(from_obj), exp_ts);
+  auto op_result = db_slice.AddNew(target_cntx, key, std::move(from_obj), exp_ts);
+  if (!op_result) {
+    return op_result.status();
+  }
+  auto add_res = std::move(*op_result);
   add_res.it->first.SetSticky(sticky);
 
   if (add_res.it->second.ObjType() == OBJ_LIST && op_args.shard->blocking_controller()) {

--- a/src/server/hll_family.cc
+++ b/src/server/hll_family.cc
@@ -18,6 +18,7 @@ extern "C" {
 #include "server/conn_context.h"
 #include "server/container_utils.h"
 #include "server/engine_shard_set.h"
+#include "server/error.h"
 #include "server/transaction.h"
 
 namespace dfly {
@@ -71,9 +72,7 @@ OpResult<int> AddToHll(const OpArgs& op_args, string_view key, CmdArgList values
   string hll;
 
   auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
-  if (!op_res) {
-    return op_res.status();
-  }
+  RETURN_ON_BAD_STATUS(op_res);
   auto& res = *op_res;
   if (res.is_new) {
     hll.resize(getDenseHllSize());
@@ -259,9 +258,7 @@ OpResult<int> PFMergeInternal(CmdArgList args, ConnectionContext* cntx) {
     const OpArgs& op_args = t->GetOpArgs(shard);
     auto& db_slice = op_args.shard->db_slice();
     auto op_res = db_slice.AddOrFind(t->GetDbContext(), key);
-    if (!op_res) {
-      return op_res.status();
-    }
+    RETURN_ON_BAD_STATUS(op_res);
     auto& res = *op_res;
     res.it->second.SetString(hll);
 

--- a/src/server/hll_family.cc
+++ b/src/server/hll_family.cc
@@ -74,7 +74,7 @@ OpResult<int> AddToHll(const OpArgs& op_args, string_view key, CmdArgList values
   if (!op_res) {
     return op_res.status();
   }
-  auto res = std::move(*op_res);
+  auto& res = *op_res;
   if (res.is_new) {
     hll.resize(getDenseHllSize());
     createDenseHll(StringToHllPtr(hll));
@@ -262,7 +262,7 @@ OpResult<int> PFMergeInternal(CmdArgList args, ConnectionContext* cntx) {
     if (!op_res) {
       return op_res.status();
     }
-    auto res = std::move(*op_res);
+    auto& res = *op_res;
     res.it->second.SetString(hll);
     return OpStatus::OK;
   };

--- a/src/server/hll_family.cc
+++ b/src/server/hll_family.cc
@@ -70,33 +70,33 @@ OpResult<int> AddToHll(const OpArgs& op_args, string_view key, CmdArgList values
 
   string hll;
 
-  try {
-    auto res = db_slice.AddOrFind(op_args.db_cntx, key);
-    if (res.is_new) {
-      hll.resize(getDenseHllSize());
-      createDenseHll(StringToHllPtr(hll));
-    } else if (res.it->second.ObjType() != OBJ_STRING) {
-      return OpStatus::WRONG_TYPE;
-    } else {
-      res.it->second.GetString(&hll);
-      ConvertToDenseIfNeeded(&hll);
-    }
-
-    int updated = 0;
-    for (const auto& value : values) {
-      int added = pfadd(StringToHllPtr(hll), (unsigned char*)value.data(), value.size());
-      if (added < 0) {
-        return OpStatus::INVALID_VALUE;
-      }
-      updated += added;
-    }
-
-    res.it->second.SetString(hll);
-
-    return std::min(updated, 1);
-  } catch (const std::bad_alloc&) {
-    return OpStatus::OUT_OF_MEMORY;
+  auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
+  if (!op_res) {
+    return op_res.status();
   }
+  auto res = std::move(*op_res);
+  if (res.is_new) {
+    hll.resize(getDenseHllSize());
+    createDenseHll(StringToHllPtr(hll));
+  } else if (res.it->second.ObjType() != OBJ_STRING) {
+    return OpStatus::WRONG_TYPE;
+  } else {
+    res.it->second.GetString(&hll);
+    ConvertToDenseIfNeeded(&hll);
+  }
+
+  int updated = 0;
+  for (const auto& value : values) {
+    int added = pfadd(StringToHllPtr(hll), (unsigned char*)value.data(), value.size());
+    if (added < 0) {
+      return OpStatus::INVALID_VALUE;
+    }
+    updated += added;
+  }
+
+  res.it->second.SetString(hll);
+
+  return std::min(updated, 1);
 }
 
 void PFAdd(CmdArgList args, ConnectionContext* cntx) {
@@ -258,12 +258,11 @@ OpResult<int> PFMergeInternal(CmdArgList args, ConnectionContext* cntx) {
     string_view key = ArgS(args, 0);
     const OpArgs& op_args = t->GetOpArgs(shard);
     auto& db_slice = op_args.shard->db_slice();
-    DbSlice::AddOrFindResult res;
-    try {
-      res = db_slice.AddOrFind(t->GetDbContext(), key);
-    } catch (const bad_alloc& e) {
-      return OpStatus::OUT_OF_MEMORY;
+    auto op_res = db_slice.AddOrFind(t->GetDbContext(), key);
+    if (!op_res) {
+      return op_res.status();
     }
+    auto res = std::move(*op_res);
     res.it->second.SetString(hll);
     return OpStatus::OK;
   };

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -172,7 +172,7 @@ OpStatus OpIncrBy(const OpArgs& op_args, string_view key, string_view field, Inc
   if (!op_res) {
     return op_res.status();
   }
-  auto add_res = std::move(*op_res);
+  auto& add_res = *op_res;
 
   DbTableStats* stats = db_slice.MutableStats(op_args.db_cntx.db_index);
 
@@ -623,7 +623,7 @@ OpResult<uint32_t> OpSet(const OpArgs& op_args, string_view key, CmdArgList valu
   if (!op_res) {
     return op_res.status();
   }
-  auto add_res = std::move(*op_res);
+  auto& add_res = *op_res;
 
   DbTableStats* stats = db_slice.MutableStats(op_args.db_cntx.db_index);
 

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -168,12 +168,11 @@ OpStatus IncrementValue(optional<string_view> prev_val, IncrByParam* param) {
 
 OpStatus OpIncrBy(const OpArgs& op_args, string_view key, string_view field, IncrByParam* param) {
   auto& db_slice = op_args.shard->db_slice();
-  DbSlice::AddOrFindResult add_res;
-  try {
-    add_res = db_slice.AddOrFind(op_args.db_cntx, key);
-  } catch (const bad_alloc& e) {
-    return OpStatus::OUT_OF_MEMORY;
+  auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
+  if (!op_res) {
+    return op_res.status();
   }
+  auto add_res = std::move(*op_res);
 
   DbTableStats* stats = db_slice.MutableStats(op_args.db_cntx.db_index);
 
@@ -620,12 +619,11 @@ OpResult<uint32_t> OpSet(const OpArgs& op_args, string_view key, CmdArgList valu
   VLOG(2) << "OpSet(" << key << ")";
 
   auto& db_slice = op_args.shard->db_slice();
-  DbSlice::AddOrFindResult add_res;
-  try {
-    add_res = db_slice.AddOrFind(op_args.db_cntx, key);
-  } catch (bad_alloc&) {
-    return OpStatus::OUT_OF_MEMORY;
+  auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
+  if (!op_res) {
+    return op_res.status();
   }
+  auto add_res = std::move(*op_res);
 
   DbTableStats* stats = db_slice.MutableStats(op_args.db_cntx.db_index);
 

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -14,12 +14,12 @@ extern "C" {
 
 #include "base/logging.h"
 #include "core/string_map.h"
-#include "facade/error.h"
 #include "server/acl/acl_commands_def.h"
 #include "server/command_registry.h"
 #include "server/conn_context.h"
 #include "server/container_utils.h"
 #include "server/engine_shard_set.h"
+#include "server/error.h"
 #include "server/search/doc_index.h"
 #include "server/transaction.h"
 
@@ -169,6 +169,7 @@ OpStatus IncrementValue(optional<string_view> prev_val, IncrByParam* param) {
 OpStatus OpIncrBy(const OpArgs& op_args, string_view key, string_view field, IncrByParam* param) {
   auto& db_slice = op_args.shard->db_slice();
   auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
+  RETURN_ON_BAD_STATUS(op_res);
   if (!op_res) {
     return op_res.status();
   }
@@ -620,9 +621,7 @@ OpResult<uint32_t> OpSet(const OpArgs& op_args, string_view key, CmdArgList valu
 
   auto& db_slice = op_args.shard->db_slice();
   auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
-  if (!op_res) {
-    return op_res.status();
-  }
+  RETURN_ON_BAD_STATUS(op_res);
   auto& add_res = *op_res;
 
   DbTableStats* stats = db_slice.MutableStats(op_args.db_cntx.db_index);

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -56,9 +56,7 @@ facade::OpStatus SetJson(const OpArgs& op_args, string_view key, JsonType&& valu
   auto& db_slice = op_args.shard->db_slice();
 
   auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
-  if (!op_res) {
-    return op_res.status();
-  }
+  RETURN_ON_BAD_STATUS(op_res);
 
   auto& res = *op_res;
 

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -4,6 +4,8 @@
 
 #include "server/json_family.h"
 
+#include "facade/op_status.h"
+
 extern "C" {
 #include "redis/object.h"
 }
@@ -50,15 +52,22 @@ inline OpStatus JsonReplaceVerifyNoOp(JsonType&) {
   return OpStatus::OK;
 }
 
-void SetJson(const OpArgs& op_args, string_view key, JsonType&& value) {
+facade::OpStatus SetJson(const OpArgs& op_args, string_view key, JsonType&& value) {
   auto& db_slice = op_args.shard->db_slice();
-  auto res = db_slice.AddOrFind(op_args.db_cntx, key);
+
+  auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
+  if (!op_res) {
+    return op_res.status();
+  }
+
+  auto res = std::move(*op_res);
 
   op_args.shard->search_indices()->RemoveDoc(key, op_args.db_cntx, res.it->second);
 
   res.it->second.SetJson(std::move(value));
 
   op_args.shard->search_indices()->AddDoc(key, op_args.db_cntx, res.it->second);
+  return OpStatus::OK;
 }
 
 string JsonTypeToName(const JsonType& val) {
@@ -1076,12 +1085,10 @@ OpResult<bool> OpSet(const OpArgs& op_args, string_view key, string_view path,
       }
     }
 
-    try {
-      SetJson(op_args, key, std::move(parsed_json.value()));
-
-    } catch (const bad_alloc& e) {
+    if (SetJson(op_args, key, std::move(parsed_json.value())) == OpStatus::OUT_OF_MEMORY) {
       return OpStatus::OUT_OF_MEMORY;
     }
+
     return true;
   }
 

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -60,7 +60,7 @@ facade::OpStatus SetJson(const OpArgs& op_args, string_view key, JsonType&& valu
     return op_res.status();
   }
 
-  auto res = std::move(*op_res);
+  auto& res = *op_res;
 
   op_args.shard->search_indices()->RemoveDoc(key, op_args.db_cntx, res.it->second);
 

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -247,12 +247,11 @@ OpResult<string> OpMoveSingleShard(const OpArgs& op_args, string_view src, strin
 
   quicklist* dest_ql = nullptr;
   src_res->post_updater.Run();
-  DbSlice::AddOrFindResult dest_res;
-  try {
-    dest_res = db_slice.AddOrFind(op_args.db_cntx, dest);
-  } catch (bad_alloc&) {
-    return OpStatus::OUT_OF_MEMORY;
+  auto op_res = db_slice.AddOrFind(op_args.db_cntx, dest);
+  if (!op_res) {
+    return op_res.status();
   }
+  auto dest_res = std::move(*op_res);
 
   // Insertion of dest could invalidate src_it. Find it again.
   src_res = db_slice.FindMutable(op_args.db_cntx, src, OBJ_LIST);
@@ -321,11 +320,11 @@ OpResult<uint32_t> OpPush(const OpArgs& op_args, std::string_view key, ListDir d
       return 0;  // Redis returns 0 for nonexisting keys for the *PUSHX actions.
     res = std::move(*tmp_res);
   } else {
-    try {
-      res = es->db_slice().AddOrFind(op_args.db_cntx, key);
-    } catch (bad_alloc&) {
-      return OpStatus::OUT_OF_MEMORY;
+    auto op_res = es->db_slice().AddOrFind(op_args.db_cntx, key);
+    if (!op_res) {
+      return op_res.status();
     }
+    res = std::move(*op_res);
   }
 
   quicklist* ql = nullptr;

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -248,9 +248,7 @@ OpResult<string> OpMoveSingleShard(const OpArgs& op_args, string_view src, strin
   quicklist* dest_ql = nullptr;
   src_res->post_updater.Run();
   auto op_res = db_slice.AddOrFind(op_args.db_cntx, dest);
-  if (!op_res) {
-    return op_res.status();
-  }
+  RETURN_ON_BAD_STATUS(op_res);
   auto& dest_res = *op_res;
 
   // Insertion of dest could invalidate src_it. Find it again.
@@ -321,9 +319,7 @@ OpResult<uint32_t> OpPush(const OpArgs& op_args, std::string_view key, ListDir d
     res = std::move(*tmp_res);
   } else {
     auto op_res = es->db_slice().AddOrFind(op_args.db_cntx, key);
-    if (!op_res) {
-      return op_res.status();
-    }
+    RETURN_ON_BAD_STATUS(op_res);
     res = std::move(*op_res);
   }
 

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -251,7 +251,7 @@ OpResult<string> OpMoveSingleShard(const OpArgs& op_args, string_view src, strin
   if (!op_res) {
     return op_res.status();
   }
-  auto dest_res = std::move(*op_res);
+  auto& dest_res = *op_res;
 
   // Insertion of dest could invalidate src_it. Find it again.
   src_res = db_slice.FindMutable(op_args.db_cntx, src, OBJ_LIST);

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2372,7 +2372,7 @@ void RdbLoader::LoadItemsBuffer(DbIndex db_ind, const ItemsBuf& ib) {
       break;
     }
 
-    auto res = std::move(*op_res);
+    auto& res = *op_res;
     res.it->first.SetSticky(item->is_sticky);
     if (!res.is_new) {
       LOG(WARNING) << "RDB has duplicated key '" << item->key << "' in DB " << db_ind;

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2364,17 +2364,18 @@ void RdbLoader::LoadItemsBuffer(DbIndex db_ind, const ItemsBuf& ib) {
     if (item->expire_ms > 0 && db_cntx.time_now_ms >= item->expire_ms)
       continue;
 
-    try {
-      auto res = db_slice.AddOrUpdate(db_cntx, item->key, std::move(pv), item->expire_ms);
-      res.it->first.SetSticky(item->is_sticky);
-      if (!res.is_new) {
-        LOG(WARNING) << "RDB has duplicated key '" << item->key << "' in DB " << db_ind;
-      }
-    } catch (const std::bad_alloc&) {
+    auto op_res = db_slice.AddOrUpdate(db_cntx, item->key, std::move(pv), item->expire_ms);
+    if (!op_res) {
       LOG(ERROR) << "OOM failed to add key '" << item->key << "' in DB " << db_ind;
       ec_ = RdbError(errc::out_of_memory);
       stop_early_ = true;
       break;
+    }
+
+    auto res = std::move(*op_res);
+    res.it->first.SetSticky(item->is_sticky);
+    if (!res.is_new) {
+      LOG(WARNING) << "RDB has duplicated key '" << item->key << "' in DB " << db_ind;
     }
   }
 

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -570,7 +570,7 @@ OpResult<uint32_t> OpAdd(const OpArgs& op_args, std::string_view key, ArgSlice v
   if (!op_res) {
     return op_res.status();
   }
-  auto add_res = std::move(*op_res);
+  auto& add_res = *op_res;
 
   CompactObj& co = add_res.it->second;
 
@@ -647,7 +647,7 @@ OpResult<uint32_t> OpAddEx(const OpArgs& op_args, string_view key, uint32_t ttl_
   if (!op_res) {
     return op_res.status();
   }
-  auto add_res = std::move(*op_res);
+  auto& add_res = *op_res;
 
   CompactObj& co = add_res.it->second;
 

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -567,9 +567,7 @@ OpResult<uint32_t> OpAdd(const OpArgs& op_args, std::string_view key, ArgSlice v
   }
 
   auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
-  if (!op_res) {
-    return op_res.status();
-  }
+  RETURN_ON_BAD_STATUS(op_res);
   auto& add_res = *op_res;
 
   CompactObj& co = add_res.it->second;
@@ -644,9 +642,7 @@ OpResult<uint32_t> OpAddEx(const OpArgs& op_args, string_view key, uint32_t ttl_
   auto& db_slice = es->db_slice();
 
   auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
-  if (!op_res) {
-    return op_res.status();
-  }
+  RETURN_ON_BAD_STATUS(op_res);
   auto& add_res = *op_res;
 
   CompactObj& co = add_res.it->second;

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -566,13 +566,11 @@ OpResult<uint32_t> OpAdd(const OpArgs& op_args, std::string_view key, ArgSlice v
     return 0;
   }
 
-  DbSlice::AddOrFindResult add_res;
-
-  try {
-    add_res = db_slice.AddOrFind(op_args.db_cntx, key);
-  } catch (bad_alloc& e) {
-    return OpStatus::OUT_OF_MEMORY;
+  auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
+  if (!op_res) {
+    return op_res.status();
   }
+  auto add_res = std::move(*op_res);
 
   CompactObj& co = add_res.it->second;
 
@@ -645,13 +643,11 @@ OpResult<uint32_t> OpAddEx(const OpArgs& op_args, string_view key, uint32_t ttl_
   auto* es = op_args.shard;
   auto& db_slice = es->db_slice();
 
-  DbSlice::AddOrFindResult add_res;
-
-  try {
-    add_res = db_slice.AddOrFind(op_args.db_cntx, key);
-  } catch (bad_alloc& e) {
-    return OpStatus::OUT_OF_MEMORY;
+  auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
+  if (!op_res) {
+    return op_res.status();
   }
+  auto add_res = std::move(*op_res);
 
   CompactObj& co = add_res.it->second;
 

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -13,12 +13,12 @@ extern "C" {
 }
 
 #include "base/logging.h"
-#include "facade/error.h"
 #include "server/acl/acl_commands_def.h"
 #include "server/blocking_controller.h"
 #include "server/command_registry.h"
 #include "server/conn_context.h"
 #include "server/engine_shard_set.h"
+#include "server/error.h"
 #include "server/server_state.h"
 #include "server/transaction.h"
 
@@ -617,9 +617,7 @@ OpResult<streamID> OpAdd(const OpArgs& op_args, const AddTrimOpts& opts, CmdArgL
     add_res = std::move(*res_it);
   } else {
     auto op_res = db_slice.AddOrFind(op_args.db_cntx, opts.key);
-    if (!op_res) {
-      return op_res.status();
-    }
+    RETURN_ON_BAD_STATUS(op_res);
     add_res = std::move(*op_res);
   }
 

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -616,11 +616,11 @@ OpResult<streamID> OpAdd(const OpArgs& op_args, const AddTrimOpts& opts, CmdArgL
     }
     add_res = std::move(*res_it);
   } else {
-    try {
-      add_res = db_slice.AddOrFind(op_args.db_cntx, opts.key);
-    } catch (bad_alloc&) {
-      return OpStatus::OUT_OF_MEMORY;
+    auto op_res = db_slice.AddOrFind(op_args.db_cntx, opts.key);
+    if (!op_res) {
+      return op_res.status();
     }
+    add_res = std::move(*op_res);
   }
 
   robj* stream_obj = nullptr;

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -88,29 +88,27 @@ OpResult<uint32_t> OpSetRange(const OpArgs& op_args, string_view key, size_t sta
     }
   }
 
-  DbSlice::AddOrFindResult res;
-
-  try {
-    res = db_slice.AddOrFind(op_args.db_cntx, key);
-
-    string s;
-
-    if (res.is_new) {
-      s.resize(range_len);
-    } else {
-      if (res.it->second.ObjType() != OBJ_STRING)
-        return OpStatus::WRONG_TYPE;
-
-      s = GetString(op_args.shard, res.it->second);
-      if (s.size() < range_len)
-        s.resize(range_len);
-    }
-
-    memcpy(s.data() + start, value.data(), value.size());
-    res.it->second.SetString(s);
-  } catch (const std::bad_alloc& e) {
-    return OpStatus::OUT_OF_MEMORY;
+  auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
+  if (!op_res) {
+    return op_res.status();
   }
+  auto res = std::move(*op_res);
+
+  string s;
+
+  if (res.is_new) {
+    s.resize(range_len);
+  } else {
+    if (res.it->second.ObjType() != OBJ_STRING)
+      return OpStatus::WRONG_TYPE;
+
+    s = GetString(op_args.shard, res.it->second);
+    if (s.size() < range_len)
+      s.resize(range_len);
+  }
+
+  memcpy(s.data() + start, value.data(), value.size());
+  res.it->second.SetString(s);
   return res.it->second.Size();
 }
 
@@ -166,12 +164,11 @@ OpResult<uint32_t> ExtendOrSet(const OpArgs& op_args, string_view key, string_vi
                                bool prepend) {
   auto* shard = op_args.shard;
   auto& db_slice = shard->db_slice();
-  DbSlice::AddOrFindResult add_res;
-  try {
-    add_res = db_slice.AddOrFind(op_args.db_cntx, key);
-  } catch (const std::bad_alloc& e) {
-    return OpStatus::OUT_OF_MEMORY;
+  auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
+  if (!op_res) {
+    return op_res.status();
   }
+  auto add_res = std::move(*op_res);
   if (add_res.is_new) {
     add_res.it->second.SetString(val);
     return val.size();
@@ -234,12 +231,12 @@ OpResult<string> OpMutableGet(const OpArgs& op_args, string_view key, bool del_h
 
 OpResult<double> OpIncrFloat(const OpArgs& op_args, string_view key, double val) {
   auto& db_slice = op_args.shard->db_slice();
-  DbSlice::AddOrFindResult add_res;
-  try {
-    add_res = db_slice.AddOrFind(op_args.db_cntx, key);
-  } catch (const std::bad_alloc& e) {
-    return OpStatus::OUT_OF_MEMORY;
+
+  auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
+  if (!op_res) {
+    return op_res.status();
   }
+  auto add_res = std::move(*op_res);
 
   char buf[128];
 
@@ -292,10 +289,9 @@ OpResult<int64_t> OpIncrBy(const OpArgs& op_args, string_view key, int64_t incr,
     CompactObj cobj;
     cobj.SetInt(incr);
 
-    try {
-      res = db_slice.AddNew(op_args.db_cntx, key, std::move(cobj), 0);
-    } catch (bad_alloc&) {
-      return OpStatus::OUT_OF_MEMORY;
+    auto op_result = db_slice.AddNew(op_args.db_cntx, key, std::move(cobj), 0);
+    if (!op_result) {
+      return op_result.status();
     }
 
     return incr;
@@ -463,10 +459,9 @@ OpResult<array<int64_t, 5>> OpThrottle(const OpArgs& op_args, const string_view 
       CompactObj cobj;
       cobj.SetInt(new_tat_ms);
 
-      try {
-        db_slice.AddNew(op_args.db_cntx, key, std::move(cobj), new_tat_ms);
-      } catch (bad_alloc&) {
-        return OpStatus::OUT_OF_MEMORY;
+      auto res = db_slice.AddNew(op_args.db_cntx, key, std::move(cobj), new_tat_ms);
+      if (!res) {
+        return res.status();
       }
     }
   }
@@ -584,12 +579,11 @@ OpResult<optional<string>> SetCmd::Set(const SetParams& params, string_view key,
   // At this point we either need to add missing entry, or we
   // will override an existing one
   // Trying to add a new entry.
-  DbSlice::AddOrFindResult add_res;
-  try {
-    add_res = db_slice.AddOrFind(op_args_.db_cntx, key);
-  } catch (bad_alloc& e) {
-    return OpStatus::OUT_OF_MEMORY;
+  auto op_res = db_slice.AddOrFind(op_args_.db_cntx, key);
+  if (!op_res) {
+    return op_res.status();
   }
+  auto add_res = std::move(*op_res);
 
   PrimeIterator it = add_res.it;
   if (!add_res.is_new) {

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -92,7 +92,7 @@ OpResult<uint32_t> OpSetRange(const OpArgs& op_args, string_view key, size_t sta
   if (!op_res) {
     return op_res.status();
   }
-  auto res = std::move(*op_res);
+  auto& res = *op_res;
 
   string s;
 
@@ -168,7 +168,7 @@ OpResult<uint32_t> ExtendOrSet(const OpArgs& op_args, string_view key, string_vi
   if (!op_res) {
     return op_res.status();
   }
-  auto add_res = std::move(*op_res);
+  auto& add_res = *op_res;
   if (add_res.is_new) {
     add_res.it->second.SetString(val);
     return val.size();
@@ -236,7 +236,7 @@ OpResult<double> OpIncrFloat(const OpArgs& op_args, string_view key, double val)
   if (!op_res) {
     return op_res.status();
   }
-  auto add_res = std::move(*op_res);
+  auto& add_res = *op_res;
 
   char buf[128];
 
@@ -583,7 +583,7 @@ OpResult<optional<string>> SetCmd::Set(const SetParams& params, string_view key,
   if (!op_res) {
     return op_res.status();
   }
-  auto add_res = std::move(*op_res);
+  auto& add_res = *op_res;
 
   PrimeIterator it = add_res.it;
   if (!add_res.is_new) {

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -72,9 +72,7 @@ OpResult<uint32_t> OpSetRange(const OpArgs& op_args, string_view key, size_t sta
   }
 
   auto op_res = db_slice.AddOrFindAndFetch(op_args.db_cntx, key);
-  if (!op_res) {
-    return op_res.status();
-  }
+  RETURN_ON_BAD_STATUS(op_res);
   auto& res = *op_res;
 
   string s;
@@ -149,9 +147,7 @@ OpResult<uint32_t> ExtendOrSet(const OpArgs& op_args, string_view key, string_vi
   auto* shard = op_args.shard;
   auto& db_slice = shard->db_slice();
   auto op_res = db_slice.AddOrFindAndFetch(op_args.db_cntx, key);
-  if (!op_res) {
-    return op_res.status();
-  }
+  RETURN_ON_BAD_STATUS(op_res);
   auto& add_res = *op_res;
   if (add_res.is_new) {
     add_res.it->second.SetString(val);
@@ -217,9 +213,7 @@ OpResult<double> OpIncrFloat(const OpArgs& op_args, string_view key, double val)
   auto& db_slice = op_args.shard->db_slice();
 
   auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
-  if (!op_res) {
-    return op_res.status();
-  }
+  RETURN_ON_BAD_STATUS(op_res);
   auto& add_res = *op_res;
 
   char buf[128];
@@ -274,9 +268,7 @@ OpResult<int64_t> OpIncrBy(const OpArgs& op_args, string_view key, int64_t incr,
     cobj.SetInt(incr);
 
     auto op_result = db_slice.AddNew(op_args.db_cntx, key, std::move(cobj), 0);
-    if (!op_result) {
-      return op_result.status();
-    }
+    RETURN_ON_BAD_STATUS(op_result);
 
     return incr;
   }
@@ -587,9 +579,7 @@ OpResult<optional<string>> SetCmd::Set(const SetParams& params, string_view key,
   // will override an existing one
   // Trying to add a new entry.
   auto op_res = db_slice.AddOrFind(op_args_.db_cntx, key);
-  if (!op_res) {
-    return op_res.status();
-  }
+  RETURN_ON_BAD_STATUS(op_res);
   auto& add_res = *op_res;
 
   PrimeIterator it = add_res.it;

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -193,13 +193,11 @@ OpResult<DbSlice::ItAndUpdater> FindZEntry(const ZParams& zparams, const OpArgs&
     return db_slice.FindMutable(op_args.db_cntx, key, OBJ_ZSET);
   }
 
-  DbSlice::AddOrFindResult add_res;
-
-  try {
-    add_res = db_slice.AddOrFind(op_args.db_cntx, key);
-  } catch (bad_alloc&) {
-    return OpStatus::OUT_OF_MEMORY;
+  auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
+  if (!op_res) {
+    return op_res.status();
   }
+  auto add_res = std::move(*op_res);
 
   PrimeIterator& it = add_res.it;
   PrimeValue& pv = it->second;

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -197,7 +197,7 @@ OpResult<DbSlice::ItAndUpdater> FindZEntry(const ZParams& zparams, const OpArgs&
   if (!op_res) {
     return op_res.status();
   }
-  auto add_res = std::move(*op_res);
+  auto& add_res = *op_res;
 
   PrimeIterator& it = add_res.it;
   PrimeValue& pv = it->second;

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -28,6 +28,7 @@ extern "C" {
 #include "server/conn_context.h"
 #include "server/container_utils.h"
 #include "server/engine_shard_set.h"
+#include "server/error.h"
 #include "server/transaction.h"
 
 namespace dfly {
@@ -194,9 +195,7 @@ OpResult<DbSlice::ItAndUpdater> FindZEntry(const ZParams& zparams, const OpArgs&
   }
 
   auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
-  if (!op_res) {
-    return op_res.status();
-  }
+  RETURN_ON_BAD_STATUS(op_res);
   auto& add_res = *op_res;
 
   PrimeIterator& it = add_res.it;


### PR DESCRIPTION
resolve comments in #2379

* return OpResult in AddOrFind instead of throwing bad_alloc