### PR TITLE
fix(replication): Correctly replicate commands even when OOM

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -194,7 +194,7 @@ unsigned PrimeEvictionPolicy::Evict(const PrimeTable::HotspotBuckets& eb, PrimeT
 
     // log the evicted keys to journal.
     if (auto journal = db_slice_->shard_owner()->journal(); journal) {
-      ArgSlice delete_args{key};
+      ArgSlice delete_args{&key, 1};
       journal->RecordEntry(0, journal::Op::EXPIRED, cntx_.db_index, 1, ClusterConfig::KeySlot(key),
                            make_pair("DEL", delete_args), false);
     }

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -343,7 +343,7 @@ void OpMSet(const OpArgs& op_args, ArgSlice args, atomic_bool* success) {
     // We write a custom journal because an OOM in the above loop could lead to partial success, so
     // we replicate only what was changed.
     string_view cmd;
-    ArgSlice args;
+    ArgSlice cmd_args;
     if (i == 0) {
       // All shards must record the tx was executed for the replica to execute it, so we send a PING
       // in case nothing was changed
@@ -351,9 +351,9 @@ void OpMSet(const OpArgs& op_args, ArgSlice args, atomic_bool* success) {
     } else {
       // journal [0, i)
       cmd = "MSET";
-      args = ArgSlice(&args[0], i);
+      cmd_args = ArgSlice(&args[0], i);
     }
-    RecordJournal(op_args, cmd, args, op_args.tx->GetUniqueShardCnt());
+    RecordJournal(op_args, cmd, cmd_args, op_args.tx->GetUniqueShardCnt());
   }
 }
 

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -516,7 +516,7 @@ bool Transaction::RunInShard(EngineShard* shard, bool txq_ooo) {
 
   // Log to jounrnal only once the command finished running
   if (is_concluding || (multi_ && multi_->concluding))
-    LogAutoJournalOnShard(shard);
+    LogAutoJournalOnShard(shard, result);
 
   // If we're the head of tx queue (txq_ooo is false), we remove ourselves upon first invocation
   // and successive hops are run by continuation_trans_ in engine shard.
@@ -1033,6 +1033,10 @@ ShardId Transaction::GetUniqueShard() const {
   return unique_shard_id_;
 }
 
+optional<SlotId> Transaction::GetUniqueSlotId() const {
+  return unique_slot_checker_.GetUniqueSlotId();
+}
+
 KeyLockArgs Transaction::GetLockArgs(ShardId sid) const {
   KeyLockArgs res;
   res.db_index = db_index_;
@@ -1074,7 +1078,7 @@ bool Transaction::ScheduleUniqueShard(EngineShard* shard) {
       DCHECK_EQ(sd.is_armed, false);
       unlocked_keys = false;
     } else {
-      LogAutoJournalOnShard(shard);
+      LogAutoJournalOnShard(shard, result);
     }
   }
 
@@ -1337,7 +1341,7 @@ OpStatus Transaction::RunSquashedMultiCb(RunnableType cb) {
   auto* shard = EngineShard::tlocal();
   auto result = cb(this, shard);
   shard->db_slice().OnCbFinish();
-  LogAutoJournalOnShard(shard);
+  LogAutoJournalOnShard(shard, result);
 
   DCHECK_EQ(result.flags, 0);  // if it's sophisticated, we shouldn't squash it
   return result;
@@ -1464,7 +1468,7 @@ optional<string_view> Transaction::GetWakeKey(ShardId sid) const {
   return GetShardArgs(sid).at(sd.wake_key_pos);
 }
 
-void Transaction::LogAutoJournalOnShard(EngineShard* shard) {
+void Transaction::LogAutoJournalOnShard(EngineShard* shard, RunnableResult result) {
   // TODO: For now, we ignore non shard coordination.
   if (shard == nullptr)
     return;
@@ -1477,12 +1481,20 @@ void Transaction::LogAutoJournalOnShard(EngineShard* shard) {
   if (cid_->IsWriteOnly() == 0 && (cid_->opt_mask() & CO::NO_KEY_TRANSACTIONAL) == 0)
     return;
 
-  // If autojournaling was disabled and not re-enabled, skip it
-  if ((cid_->opt_mask() & CO::NO_AUTOJOURNAL) && !renabled_auto_journal_.load(memory_order_relaxed))
-    return;
-
   auto journal = shard->journal();
   if (journal == nullptr)
+    return;
+
+  if (result.status != OpStatus::OK) {
+    // We log NOOP even for NO_AUTOJOURNAL commands because the non-success status could have been
+    // due to OOM in a single shard, while other shards succeeded
+    journal->RecordEntry(txid_, journal::Op::NOOP, db_index_, unique_shard_cnt_,
+                         unique_slot_checker_.GetUniqueSlotId(), journal::Entry::Payload{}, true);
+    return;
+  }
+
+  // If autojournaling was disabled and not re-enabled, skip it
+  if ((cid_->opt_mask() & CO::NO_AUTOJOURNAL) && !renabled_auto_journal_.load(memory_order_relaxed))
     return;
 
   // TODO: Handle complex commands like LMPOP correctly once they are implemented.

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -296,6 +296,8 @@ class Transaction {
   // This method is meaningless if GetUniqueShardCnt() != 1.
   ShardId GetUniqueShard() const;
 
+  std::optional<SlotId> GetUniqueSlotId() const;
+
   bool IsMulti() const {
     return bool(multi_);
   }
@@ -520,7 +522,7 @@ class Transaction {
 
   // Log command in shard's journal, if this is a write command with auto-journaling enabled.
   // Should be called immediately after the last phase (hop).
-  void LogAutoJournalOnShard(EngineShard* shard);
+  void LogAutoJournalOnShard(EngineShard* shard, RunnableResult shard_result);
 
   // Returns the previous value of run count.
   uint32_t DecreaseRunCnt();

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1880,7 +1880,7 @@ async def test_policy_based_eviction_propagation(df_local_factory, df_seeder_fac
     master = df_local_factory.create(
         proactor_threads=2,
         cache_mode="true",
-        maxmemory="256mb",
+        maxmemory="512mb",
         logtostdout="true",
         enable_heartbeat_eviction="false",
     )
@@ -1890,7 +1890,7 @@ async def test_policy_based_eviction_propagation(df_local_factory, df_seeder_fac
     c_master = master.client()
     c_replica = replica.client()
 
-    await c_master.execute_command("DEBUG POPULATE 6000 size 44000")
+    await c_master.execute_command("DEBUG POPULATE 6000 size 88000")
 
     await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
     await wait_available_async(c_replica)

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1878,13 +1878,13 @@ async def test_heartbeat_eviction_propagation(df_local_factory):
 @pytest.mark.asyncio
 async def test_policy_based_eviction_propagation(df_local_factory, df_seeder_factory):
     master = df_local_factory.create(
-        proactor_threads=1,
+        proactor_threads=2,
         cache_mode="true",
         maxmemory="256mb",
         logtostdout="true",
         enable_heartbeat_eviction="false",
     )
-    replica = df_local_factory.create(proactor_threads=1)
+    replica = df_local_factory.create(proactor_threads=2)
     df_local_factory.start_all([master, replica])
 
     c_master = master.client()

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1919,3 +1919,41 @@ async def test_heartbeat_eviction_propagation(df_local_factory):
     keys_replica = await c_replica.execute_command("keys *")
     assert set(keys_master) == set(keys_replica)
     await disconnect_clients(c_master, *[c_replica])
+
+
+@pytest.mark.asyncio
+async def test_policy_based_eviction_propagation(df_local_factory, df_seeder_factory):
+    master = df_local_factory.create(
+        proactor_threads=1,
+        cache_mode="true",
+        maxmemory="256mb",
+        logtostdout="true",
+        enable_heartbeat_eviction="false",
+    )
+    replica = df_local_factory.create(proactor_threads=1)
+    df_local_factory.start_all([master, replica])
+
+    c_master = master.client()
+    c_replica = replica.client()
+
+    await c_master.execute_command("DEBUG POPULATE 6000 size 44000")
+
+    await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
+    await wait_available_async(c_replica)
+
+    seeder = df_seeder_factory.create(
+        port=master.port, keys=500, val_size=1000, stop_on_failure=False
+    )
+    await seeder.run(target_deviation=0.1)
+
+    info = await c_master.info("stats")
+    assert info["evicted_keys"] > 0, "Weak testcase: policy based eviction was not triggered."
+
+    await check_all_replicas_finished([c_replica], c_master)
+    keys_master = await c_master.execute_command("keys k*")
+    keys_replica = await c_replica.execute_command("keys k*")
+
+    assert len(keys_master) == len(keys_replica)
+    assert set(keys_master) == set(keys_replica)
+
+    await disconnect_clients(c_master, *[c_replica])

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1838,52 +1838,6 @@ async def test_replicaof_reject_on_load(df_local_factory, df_seeder_factory):
     replica.stop()
 
 
-# note: please be careful if you want to change any of the parameters used in this test.
-# changing parameters without extensive testing may easily lead to weak testing case assertion
-# which means eviction may not get triggered.
-@pytest.mark.asyncio
-@pytest.mark.skip(reason="Failing due to bug in replication on command errors")
-async def test_policy_based_eviction_propagation(df_local_factory, df_seeder_factory):
-    master = df_local_factory.create(
-        proactor_threads=1, cache_mode="true", maxmemory="256mb", enable_heartbeat_eviction="false"
-    )
-    replica = df_local_factory.create(proactor_threads=1)
-    df_local_factory.start_all([master, replica])
-
-    c_master = master.client()
-    c_replica = replica.client()
-
-    await c_master.execute_command("DEBUG POPULATE 6000 size 44000")
-
-    await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
-    await wait_available_async(c_replica)
-
-    seeder = df_seeder_factory.create(
-        port=master.port,
-        keys=500,
-        val_size=200,
-        stop_on_failure=False,
-        unsupported_types=[
-            ValueType.JSON,
-            ValueType.LIST,
-            ValueType.SET,
-            ValueType.HSET,
-            ValueType.ZSET,
-        ],
-    )
-    await seeder.run(target_deviation=0.1)
-
-    info = await c_master.info("stats")
-    assert info["evicted_keys"] > 0, "Weak testcase: policy based eviction was not triggered."
-
-    await check_all_replicas_finished([c_replica], c_master)
-    keys_master = await c_master.execute_command("keys *")
-    keys_replica = await c_replica.execute_command("keys *")
-
-    assert set(keys_master) == set(keys_replica)
-    await disconnect_clients(c_master, *[c_replica])
-
-
 @pytest.mark.asyncio
 async def test_heartbeat_eviction_propagation(df_local_factory):
     master = df_local_factory.create(


### PR DESCRIPTION
Before this change, OOM in shard callbacks could have led to data inconsistency between the master and the replica. For example, commands which mutated data on 1 shard but failed on another, like `LMOVE`.

After this change, callbacks that result in an OOM will correctly replicate their work (none, partial or complete) to replicas.

Note that `MSET` and `MSETNX` required special handling, in that they are the only commands that can _create_ multiple keys, and so some of them can fail.

Fixes #2381

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->