### PR TITLE
feat: measure latency of pipelined commands

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -409,11 +409,10 @@ void Connection::DispatchOperations::operator()(const PubMessage& pub_msg) {
 }
 
 void Connection::DispatchOperations::operator()(Connection::PipelineMessage& msg) {
-  ++stats->pipelined_cmd_cnt;
-
   DVLOG(2) << "Dispatching pipeline: " << ToSV(msg.args.front());
 
   self->service_->DispatchCommand(CmdArgList{msg.args.data(), msg.args.size()}, self->cc_.get());
+
   self->last_interaction_ = time(nullptr);
   self->skip_next_squashing_ = false;
 }
@@ -1268,7 +1267,6 @@ void Connection::DispatchFiber(util::FiberSocketBase* peer) {
       cc_->async_dispatch = true;
       std::visit(dispatch_op, msg.handle);
       cc_->async_dispatch = false;
-
       RecycleMessage(std::move(msg));
     }
 
@@ -1428,6 +1426,7 @@ void Connection::SendAsync(MessageHandle msg) {
   stats_->dispatch_queue_entries++;
   stats_->dispatch_queue_bytes += used_mem;
 
+  msg.dispatch_ts = ProactorBase::GetMonotonicTimeNs();
   if (msg.IsPubMsg()) {
     queue_backpressure_->subscriber_bytes.fetch_add(used_mem, memory_order_relaxed);
     stats_->dispatch_queue_subscriber_bytes += used_mem;
@@ -1465,6 +1464,9 @@ void Connection::RecycleMessage(MessageHandle msg) {
 
   // Retain pipeline message in pool.
   if (auto* pipe = get_if<PipelineMessagePtr>(&msg.handle); pipe) {
+    ++stats_->pipelined_cmd_cnt;
+    stats_->pipelined_cmd_latency += (ProactorBase::GetMonotonicTimeNs() - msg.dispatch_ts) / 1000;
+
     pending_pipeline_cmd_cnt_--;
     if (stats_->pipeline_cmd_cache_bytes < queue_backpressure_->pipeline_cache_limit) {
       stats_->pipeline_cmd_cache_bytes += (*pipe)->StorageCapacity();

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -146,6 +146,10 @@ class Connection : public util::Connection {
     std::variant<MonitorMessage, PubMessagePtr, PipelineMessagePtr, AclUpdateMessagePtr,
                  MigrationRequestMessage, CheckpointMessage, InvalidationMessage>
         handle;
+
+    // time when the message was dispatched to the dispatch queue as reported by
+    // ProactorBase::GetMonotonicTimeNs()
+    uint64_t dispatch_ts = 0;
   };
 
   static_assert(sizeof(MessageHandle) <= 80,

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -20,7 +20,7 @@ constexpr size_t kSizeConnStats = sizeof(ConnectionStats);
 
 ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
   // To break this code deliberately if we add/remove a field to this struct.
-  static_assert(kSizeConnStats == 96u);
+  static_assert(kSizeConnStats == 104u);
 
   ADD(read_buf_capacity);
   ADD(dispatch_queue_entries);
@@ -31,6 +31,7 @@ ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
   ADD(io_read_bytes);
   ADD(command_cnt);
   ADD(pipelined_cmd_cnt);
+  ADD(pipelined_cmd_latency);
   ADD(conn_received_cnt);
   ADD(num_conns);
   ADD(num_replicas);

--- a/src/facade/facade_types.h
+++ b/src/facade/facade_types.h
@@ -49,7 +49,7 @@ struct ConnectionStats {
 
   uint64_t command_cnt = 0;
   uint64_t pipelined_cmd_cnt = 0;
-
+  uint64_t pipelined_cmd_latency = 0;  // in microseconds
   uint64_t conn_received_cnt = 0;
 
   uint32_t num_conns = 0;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1836,6 +1836,7 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
     append("total_commands_processed", conn_stats.command_cnt);
     append("instantaneous_ops_per_sec", m.qps);
     append("total_pipelined_commands", conn_stats.pipelined_cmd_cnt);
+    append("pipelined_latency_usec", conn_stats.pipelined_cmd_latency);
     append("total_net_input_bytes", conn_stats.io_read_bytes);
     append("total_net_output_bytes", reply_stats.io_write_bytes);
     append("instantaneous_input_kbps", -1);


### PR DESCRIPTION
Unlike with regular latency measurement that measures the execution and the reply,
here we measure the overall latency from the point in time when a command was parsed.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->