### PR TITLE
fix(server): Use custom journal for multi-key `PFMERGE` cmd

### DIFF
--- a/src/server/hll_family.cc
+++ b/src/server/hll_family.cc
@@ -265,6 +265,11 @@ OpResult<int> PFMergeInternal(CmdArgList args, ConnectionContext* cntx) {
       return OpStatus::OUT_OF_MEMORY;
     }
     res.it->second.SetString(hll);
+
+    if (op_args.shard->journal()) {
+      RecordJournal(op_args, "SET", ArgSlice{key, hll});
+    }
+
     return OpStatus::OK;
   };
   trans->Execute(std::move(set_cb), true);
@@ -297,8 +302,9 @@ void HllFamily::Register(CommandRegistry* registry) {
   using CI = CommandId;
   registry->StartFamily();
   *registry << CI{"PFADD", CO::WRITE, -3, 1, 1, acl::kPFAdd}.SetHandler(PFAdd)
-            << CI{"PFCOUNT", CO::WRITE, -2, 1, -1, acl::kPFCount}.SetHandler(PFCount)
-            << CI{"PFMERGE", CO::WRITE, -2, 1, -1, acl::kPFMerge}.SetHandler(PFMerge);
+            << CI{"PFCOUNT", CO::READONLY, -2, 1, -1, acl::kPFCount}.SetHandler(PFCount)
+            << CI{"PFMERGE", CO::WRITE | CO::NO_AUTOJOURNAL, -2, 1, -1, acl::kPFMerge}.SetHandler(
+                   PFMerge);
 }
 
 const char HllFamily::kInvalidHllErr[] = "Key is not a valid HyperLogLog string value.";


### PR DESCRIPTION
While at it, also fix `PFCOUNT` to say that it's a readonly cmd.

Fixed #2421

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->