### PR TITLE
fix: release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,7 @@ jobs:
             dnf install -y rpm-build libstdc++-static
           fi
     - name: Build artifacts
+      timeout-minutes: 25
       run: |
           # Work around https://github.com/actions/checkout/issues/766
           git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ HELIO_USE_STATIC_LIBS = ON
 HELIO_OPENSSL_USE_STATIC_LIBS = ON
 HELIO_ENABLE_GIT_VERSION = ON
 HELIO_WITH_UNWIND = OFF
+RELEASE_DIR=build-release
 
 # Some distributions (old fedora) have incorrect dependencies for crypto
 # so we add -lz for them.
@@ -29,14 +30,14 @@ HELIO_FLAGS = -DHELIO_RELEASE_FLAGS="-g" \
 .PHONY: default
 
 configure:
-	cmake -L -B build-release -DCMAKE_BUILD_TYPE=Release -GNinja $(HELIO_FLAGS)
+	cmake -L -B $(RELEASE_DIR) -DCMAKE_BUILD_TYPE=Release -GNinja $(HELIO_FLAGS)
 
 build:
-	cd build-release; \
+	cd $(RELEASE_DIR); \
 	ninja dragonfly && ldd dragonfly
 
 package:
-	cd build-release; \
+	cd $(RELEASE_DIR); \
 	objcopy \
 		--remove-section=".debug_*" \
 		--remove-section="!.debug_line" \

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 
-APP_PATH=build-release/dragonfly
+RELEASE_DIR=build-release
+APP_PATH=$RELEASE_DIR/dragonfly
 
 set -e
 
@@ -22,6 +23,7 @@ if ! [ -f ${APP_PATH} ]; then
    exit 1
 fi
 
+echo "Running ${APP_PATH} --version"
 ${APP_PATH} --version
 
 if readelf -a ${APP_PATH} | grep GLIBC_PRIVATE >/dev/null 2>&1 ; then
@@ -31,3 +33,5 @@ if readelf -a ${APP_PATH} | grep GLIBC_PRIVATE >/dev/null 2>&1 ; then
 fi
 
 make package
+echo "Release package created: "
+ls -lh $RELEASE_DIR/


### PR DESCRIPTION
We had a place in tools/packaging/generate_debian_package.sh that relied on the existence of build-opt, moreover, if it did not exist the script deadlocked.

1. Added more loggings
2. Removed the loop
3. Removed unnecessary dependency in the script on the build-dir name.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->