### PR TITLE
fix: allow lock_on_hashtags with any cluster mode

### DIFF
--- a/src/server/cluster/cluster_config.cc
+++ b/src/server/cluster/cluster_config.cc
@@ -51,10 +51,6 @@ bool ClusterConfig::IsEmulated() {
   return cluster_mode == ClusterMode::kEmulatedCluster;
 }
 
-bool ClusterConfig::IsEnabledOrEmulated() {
-  return IsEnabled() || IsEmulated();
-}
-
 string_view ClusterConfig::KeyTag(string_view key) {
   size_t start = key.find('{');
   if (start == key.npos) {

--- a/src/server/cluster/cluster_config.h
+++ b/src/server/cluster/cluster_config.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <absl/base/thread_annotations.h>
 #include <absl/container/flat_hash_set.h>
 
 #include <array>
@@ -15,6 +14,7 @@
 
 #include "core/json_object.h"
 #include "src/core/fibers.h"
+#include "src/server/common.h"
 
 namespace dfly {
 
@@ -50,7 +50,14 @@ class ClusterConfig {
   static void Initialize();
   static bool IsEnabled();
   static bool IsEmulated();
-  static bool IsEnabledOrEmulated();
+
+  static bool IsEnabledOrEmulated() {
+    return IsEnabled() || IsEmulated();
+  }
+
+  static bool IsShardedByTag() {
+    return IsEnabledOrEmulated() || KeyLockArgs::IsLockHashTagEnabled();
+  }
 
   // If the key contains the {...} pattern, return only the part between { and }
   static std::string_view KeyTag(std::string_view key);

--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -27,8 +27,7 @@ extern "C" {
 #include "strings/human_readable.h"
 
 ABSL_FLAG(bool, lock_on_hashtags, false,
-          "When true, locks are done in the {hashtag} level instead of key level. "
-          "Only use this with --cluster_mode=emulated|yes.");
+          "When true, locks are done in the {hashtag} level instead of key level.");
 
 namespace dfly {
 

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -858,11 +858,8 @@ void EngineShardSet::TEST_EnableCacheMode() {
 }
 
 ShardId Shard(string_view v, ShardId shard_num) {
-  if (ClusterConfig::IsEnabledOrEmulated()) {
-    string_view v_hash_tag = ClusterConfig::KeyTag(v);
-    if (v_hash_tag.size() != v.size()) {
-      v = v_hash_tag;
-    }
+  if (ClusterConfig::IsShardedByTag()) {
+    v = ClusterConfig::KeyTag(v);
   }
 
   XXH64_hash_t hash = XXH64(v.data(), v.size(), 120577240643ULL);

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -727,11 +727,6 @@ Service::Service(ProactorPool* pp)
   CHECK(pp);
   CHECK(shard_set == NULL);
 
-  if (KeyLockArgs::IsLockHashTagEnabled() && !ClusterConfig::IsEnabledOrEmulated()) {
-    LOG(ERROR) << "Setting --lock_on_hashtags without --cluster_mode is unsupported";
-    exit(1);
-  }
-
 #ifdef PRINT_STACKTRACES_ON_SIGNAL
   LOG(INFO) << "PRINT STACKTRACES REGISTERED";
   pp_.GetNextProactor()->RegisterSignal({SIGUSR1}, [this](int signal) {


### PR DESCRIPTION
Motivation - after we submitted #2429 some smart-ass clients prevent users from accessing single-node commands like "SELECT". This PR fixes it by allowing consistent sharding based on hashtags even with cluster mode disabled.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->