### PR TITLE
feat: allow reading offloaded strings without loading to the store

### DIFF
--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -231,10 +231,18 @@ void TriggerJournalWriteToSink() {
 
 #define ADD(x) (x) += o.x
 
-TieredStats& TieredStats::operator+=(const TieredStats& o) {
-  static_assert(sizeof(TieredStats) == 56);
+IoMgrStats& IoMgrStats::operator+=(const IoMgrStats& rhs) {
+  static_assert(sizeof(IoMgrStats) == 16);
 
-  ADD(tiered_reads);
+  read_total += rhs.read_total;
+  read_delay_usec += rhs.read_delay_usec;
+
+  return *this;
+}
+
+TieredStats& TieredStats::operator+=(const TieredStats& o) {
+  static_assert(sizeof(TieredStats) == 48);
+
   ADD(tiered_writes);
   ADD(storage_capacity);
   ADD(storage_reserved);

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -122,8 +122,14 @@ void RecordExpiry(DbIndex dbid, std::string_view key);
 // Must be called from shard thread of journal to sink.
 void TriggerJournalWriteToSink();
 
+struct IoMgrStats {
+  uint64_t read_total = 0;
+  uint64_t read_delay_usec = 0;
+
+  IoMgrStats& operator+=(const IoMgrStats& rhs);
+};
+
 struct TieredStats {
-  uint64_t tiered_reads = 0;
   uint64_t tiered_writes = 0;
 
   size_t storage_capacity = 0;

--- a/src/server/io_mgr.h
+++ b/src/server/io_mgr.h
@@ -7,7 +7,8 @@
 #include <functional>
 #include <string>
 
-#include "core/uring.h"
+#include "server/common.h"
+#include "util/fibers/uring_file.h"
 
 namespace dfly {
 
@@ -46,8 +47,12 @@ class IoMgr {
     return flags.grow_progress;
   }
 
+  const IoMgrStats& GetStats() const {
+    return stats_;
+  }
+
  private:
-  std::unique_ptr<LinuxFile> backing_file_;
+  std::unique_ptr<util::fb2::LinuxFile> backing_file_;
   size_t sz_ = 0;
 
   union {
@@ -56,6 +61,8 @@ class IoMgr {
       uint8_t grow_progress : 1;
     } flags;
   };
+
+  IoMgrStats stats_;
 };
 
 }  // namespace dfly

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1675,8 +1675,11 @@ Metrics ServerFamily::GetMetrics() const {
       MergeDbSliceStats(shard->db_slice().GetStats(), &result);
       result.shard_stats += shard->stats();
 
-      if (shard->tiered_storage())
+      if (shard->tiered_storage()) {
         result.tiered_stats += shard->tiered_storage()->GetStats();
+        result.disk_stats += shard->tiered_storage()->GetDiskStats();
+      }
+
       if (shard->search_indices())
         result.search_stats += shard->search_indices()->GetStats();
 
@@ -1878,7 +1881,8 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
   if (should_enter("TIERED", true)) {
     append("tiered_entries", total.tiered_entries);
     append("tiered_bytes", total.tiered_size);
-    append("tiered_reads", m.tiered_stats.tiered_reads);
+    append("tiered_reads", m.disk_stats.read_total);
+    append("tiered_read_latency_usec", m.disk_stats.read_delay_usec);
     append("tiered_writes", m.tiered_stats.tiered_writes);
     append("tiered_reserved", m.tiered_stats.storage_reserved);
     append("tiered_capacity", m.tiered_stats.storage_capacity);

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -75,6 +75,7 @@ struct Metrics {
 
   facade::FacadeStats facade_stats;  // client stats and buffer sizes
   TieredStats tiered_stats;          // stats for tiered storage
+  IoMgrStats disk_stats;             // disk stats for io_mgr
   SearchStats search_stats;
   ServerState::Stats coordinator_stats;  // stats on transaction running
   PeakStats peak_stats;

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -16,8 +16,8 @@ extern "C" {
 #include <cstdint>
 #include <tuple>
 
+#include "base/flags.h"
 #include "base/logging.h"
-#include "redis/util.h"
 #include "server/acl/acl_commands_def.h"
 #include "server/command_registry.h"
 #include "server/conn_context.h"
@@ -26,6 +26,9 @@ extern "C" {
 #include "server/journal/journal.h"
 #include "server/tiered_storage.h"
 #include "server/transaction.h"
+
+ABSL_FLAG(bool, tiered_skip_prefetch, false,
+          "If true does not load offloaded string back to in-memory store");
 
 namespace dfly {
 
@@ -847,11 +850,28 @@ void StringFamily::Get(CmdArgList args, ConnectionContext* cntx) {
   auto cb = [&](Transaction* t, EngineShard* shard) -> OpResult<string> {
     auto op_args = t->GetOpArgs(shard);
     DbSlice& db_slice = op_args.shard->db_slice();
-    auto res = db_slice.FindAndFetchReadOnly(op_args.db_cntx, key, OBJ_STRING);
+
+    OpResult<PrimeConstIterator> res;
+
+    // A temporary code that allows running dragonfly without filling up memory store
+    // when reading data from disk.
+    if (TieredStorage* tiered = shard->tiered_storage();
+        tiered && absl::GetFlag(FLAGS_tiered_skip_prefetch)) {
+      res = db_slice.FindReadOnly(op_args.db_cntx, key, OBJ_STRING);
+      if (res && (*res)->second.IsExternal()) {
+        auto [offset, size] = (*res)->second.GetExternalSlice();
+        string blob(size, '\0');
+        auto ec = tiered->Read(offset, size, blob.data());
+        CHECK(!ec) << "TBD";
+        return blob;
+      }
+    } else {
+      res = db_slice.FindAndFetchReadOnly(op_args.db_cntx, key, OBJ_STRING);
+    }
+
     if (!res) {
       return res.status();
     }
-
     return GetString((*res)->second);
   };
 

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -28,7 +28,8 @@ extern "C" {
 #include "server/transaction.h"
 
 ABSL_FLAG(bool, tiered_skip_prefetch, false,
-          "If true does not load offloaded string back to in-memory store");
+          "If true, does not load offloaded string back to in-memory store during GET command."
+          "For testing/development purposes only.");
 
 namespace dfly {
 

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -327,7 +327,6 @@ error_code TieredStorage::Open(const string& base) {
 }
 
 std::error_code TieredStorage::Read(size_t offset, size_t len, char* dest) {
-  stats_.tiered_reads++;
   DVLOG(1) << "Read " << offset << " " << len;
 
   return io_mgr_.Read(offset, io::MutableBytes{reinterpret_cast<uint8_t*>(dest), len});

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -43,6 +43,10 @@ class TieredStorage {
 
   TieredStats GetStats() const;
 
+  const IoMgrStats& GetDiskStats() const {
+    return io_mgr_.GetStats();
+  }
+
   void CancelAllIos(DbIndex db_index);
 
   std::error_code Read(size_t offset, size_t len, char* dest);

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -45,6 +45,8 @@ class TieredStorage {
 
   void CancelAllIos(DbIndex db_index);
 
+  std::error_code Read(size_t offset, size_t len, char* dest);
+
  private:
   class InflightWriteRequest;
 
@@ -61,7 +63,6 @@ class TieredStorage {
 
   void FinishIoRequest(int io_res, InflightWriteRequest* req);
   void SetExternal(DbIndex db_index, size_t item_offset, PrimeValue* dest);
-  std::error_code Read(size_t offset, size_t len, char* dest);
 
   DbSlice& db_slice_;
   IoMgr io_mgr_;


### PR DESCRIPTION
This adds a development setting that allows reading from disk while bypassing the prefetching layer.
In addition, I added latency stats for disk reads. 


<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->