### PR TITLE
chore(transaction): Simplify PollExecution()

### DIFF
--- a/src/server/container_utils.cc
+++ b/src/server/container_utils.cc
@@ -336,8 +336,6 @@ OpResult<string> RunCbOnFirstNonEmptyBlocking(Transaction* trans, int req_obj_ty
   if (status != OpStatus::OK)
     return status;
 
-  VLOG(0) << "Woken up, re-arming";
-
   auto cb = [&](Transaction* t, EngineShard* shard) {
     if (auto wake_key = t->GetWakeKey(shard->shard_id()); wake_key) {
       result_key = *wake_key;

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -470,6 +470,7 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
         << "cont_mask: " << continuation_trans_->GetLocalMask(sid) << " vs "
         << trans->GetLocalMask(sid);
 
+    // Commands like BRPOPLPUSH don't conclude immediately
     if (trans->RunInShard(this, false)) {
       continuation_trans_ = trans;
       return;

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -959,7 +959,8 @@ Transaction::RunnableResult Transaction::RunQuickie(EngineShard* shard) {
   DVLOG(1) << "RunQuickSingle " << DebugId() << " " << shard->shard_id();
   DCHECK(cb_ptr_) << DebugId() << " " << shard->shard_id();
 
-  sd.is_armed.store(false, memory_order_relaxed);
+  bool prev_armed = sd.is_armed.exchange(false, memory_order_relaxed);
+  DCHECK(prev_armed);
 
   // Calling the callback in somewhat safe way
   RunnableResult result;

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -959,8 +959,7 @@ Transaction::RunnableResult Transaction::RunQuickie(EngineShard* shard) {
   DVLOG(1) << "RunQuickSingle " << DebugId() << " " << shard->shard_id();
   DCHECK(cb_ptr_) << DebugId() << " " << shard->shard_id();
 
-  bool prev_armed = sd.is_armed.exchange(false, memory_order_relaxed);
-  DCHECK(prev_armed);
+  CHECK(sd.is_armed.exchange(false, memory_order_relaxed));
 
   // Calling the callback in somewhat safe way
   RunnableResult result;

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -504,7 +504,6 @@ class Transaction {
     // In this specific case we synchronize with DecreaseRunCnt that releases run_count_.
     // See #997 before changing it.
     std::atomic_thread_fence(std::memory_order_acquire);
-    seqlock_.fetch_add(1, std::memory_order_relaxed);
   }
 
   // Log command in shard's journal, if this is a write command with auto-journaling enabled.
@@ -582,7 +581,7 @@ class Transaction {
   uint64_t time_now_ms_{0};
 
   std::atomic_uint32_t wakeup_requested_{0};  // whether tx was woken up
-  std::atomic_uint32_t use_count_{0}, run_count_{0}, seqlock_{0};
+  std::atomic_uint32_t use_count_{0}, run_count_{0};
 
   // unique_shard_cnt_ and unique_shard_id_ are accessed only by coordinator thread.
   uint32_t unique_shard_cnt_{0};          // Number of unique shards active


### PR DESCRIPTION
Motivation: We invented a separate seqlock mechanism to avoid calling `PollExecution` if we expired. Let's just make calling it safe and the seqlock mechanism becomes redundant.

Also, refactor PollExecution and update its comments to be easier to understand