### PR TITLE
chore: Introduce LockKey for LockTable

### DIFF
--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -405,8 +405,7 @@ class DbSlice {
   void PerformDeletion(PrimeIterator del_it, DbTable* table);
 
   // Releases a single key. `key` must have been normalized by GetLockKey().
-  void ReleaseNormalized(IntentLock::Mode m, DbIndex db_index, std::string_view key,
-                         unsigned count);
+  void ReleaseNormalized(IntentLock::Mode m, DbIndex db_index, std::string_view key);
 
  private:
   void PreUpdate(DbIndex db_ind, PrimeIterator it);

--- a/src/server/table.cc
+++ b/src/server/table.cc
@@ -56,6 +56,44 @@ SlotStats& SlotStats::operator+=(const SlotStats& o) {
   return *this;
 }
 
+void LockTable::Key::MakeOwned() const {
+  if (std::holds_alternative<std::string_view>(val_))
+    val_ = std::string{std::get<std::string_view>(val_)};
+}
+
+size_t LockTable::Size() const {
+  return locks_.size();
+}
+
+std::optional<const IntentLock> LockTable::Find(std::string_view key) const {
+  DCHECK_EQ(KeyLockArgs::GetLockKey(key), key);
+
+  if (auto it = locks_.find(Key{key}); it != locks_.end())
+    return it->second;
+  return std::nullopt;
+}
+
+bool LockTable::Acquire(std::string_view key, IntentLock::Mode mode) {
+  DCHECK_EQ(KeyLockArgs::GetLockKey(key), key);
+
+  auto [it, inserted] = locks_.try_emplace(Key{key});
+  if (!inserted)            // If more than one transaction refers to a key
+    it->first.MakeOwned();  // we must fall back to using a self-contained string
+
+  return it->second.Acquire(mode);
+}
+
+void LockTable::Release(std::string_view key, IntentLock::Mode mode) {
+  DCHECK_EQ(KeyLockArgs::GetLockKey(key), key);
+
+  auto it = locks_.find(Key{key});
+  CHECK(it != locks_.end()) << key;
+
+  it->second.Release(mode);
+  if (it->second.IsFree())
+    locks_.erase(it);
+}
+
 DbTable::DbTable(PMR_NS::memory_resource* mr, DbIndex db_index)
     : prime(kInitSegmentLog, detail::PrimeTablePolicy{}, mr),
       expire(0, detail::ExpireTablePolicy{}, mr),

--- a/src/server/table.h
+++ b/src/server/table.h
@@ -79,7 +79,47 @@ struct DbTableStats {
   DbTableStats& operator+=(const DbTableStats& o);
 };
 
-using LockTable = absl::flat_hash_map<std::string, IntentLock>;
+// Table for recording locks that uses string_views where possible. LockTable falls back to
+// strings for locks that are used by multiple transactions. Keys used with the lock table
+// should be normalized with GetLockKey
+class LockTable {
+ public:
+  size_t Size() const;
+  std::optional<const IntentLock> Find(std::string_view key) const;
+
+  bool Acquire(std::string_view key, IntentLock::Mode mode);
+  void Release(std::string_view key, IntentLock::Mode mode);
+
+  auto begin() const {
+    return locks_.cbegin();
+  }
+
+  auto end() const {
+    return locks_.cbegin();
+  }
+
+ private:
+  struct Key {
+    operator std::string_view() const {
+      return visit([](const auto& s) -> std::string_view { return s; }, val_);
+    }
+
+    bool operator==(const Key& o) const {
+      return *this == std::string_view(o);
+    }
+
+    friend std::ostream& operator<<(std::ostream& o, const Key& key) {
+      return o << std::string_view(key);
+    }
+
+    // If the key is backed by a string_view, replace it with a string with the same value
+    void MakeOwned() const;
+
+    mutable std::variant<std::string_view, std::string> val_;
+  };
+
+  absl::flat_hash_map<Key, IntentLock> locks_;
+};
 
 // A single Db table that represents a table that can be chosen with "SELECT" command.
 struct DbTable : boost::intrusive_ref_counter<DbTable, boost::thread_unsafe_counter> {

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -311,7 +311,7 @@ unsigned BaseFamilyTest::NumLocked() {
       if (db == nullptr) {
         continue;
       }
-      count += db->trans_locks.size();
+      count += db->trans_locks.Size();
     }
   });
   return count;


### PR DESCRIPTION
This should reduce allocations in a common case (not multi). In addition, rename Transaction::args_ to kv_args_.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->