### PR TITLE
feat(lua): add missing no-op redis.replicate_commands()

### DIFF
--- a/src/core/interpreter.cc
+++ b/src/core/interpreter.cc
@@ -351,6 +351,13 @@ int RedisStatusReplyCommand(lua_State* lua) {
   return SingleFieldTable(lua, "ok");
 }
 
+// no-op
+int RedisReplicateCommands(lua_State* lua) {
+  lua_pushinteger(lua, 1);
+  // number of results (the number of elements pushed to the lua stack
+  return 1;
+}
+
 // See https://www.lua.org/manual/5.3/manual.html#lua_Alloc
 void* mimalloc_glue(void* ud, void* ptr, size_t osize, size_t nsize) {
   (void)ud;
@@ -406,6 +413,11 @@ Interpreter::Interpreter() {
   lua_settable(lua_, -3);
   lua_pushstring(lua_, "status_reply");
   lua_pushcfunction(lua_, RedisStatusReplyCommand);
+  lua_settable(lua_, -3);
+
+  /* no-op function redis.replicate_commands*/
+  lua_pushstring(lua_, "replicate_commands");
+  lua_pushcfunction(lua_, RedisReplicateCommands);
   lua_settable(lua_, -3);
 
   /* Finally set the table as 'redis' global var. */

--- a/src/core/interpreter_test.cc
+++ b/src/core/interpreter_test.cc
@@ -458,4 +458,18 @@ TEST_F(InterpreterTest, AsyncReplacement) {
   }
 }
 
+TEST_F(InterpreterTest, ReplicateCommands) {
+  EXPECT_TRUE(Execute("return redis.replicate_commands()"));
+  EXPECT_EQ("i(1)", ser_.res);
+  EXPECT_TRUE(Execute("redis.replicate_commands()"));
+  EXPECT_EQ("nil", ser_.res);
+}
+
+TEST_F(InterpreterTest, Log) {
+  EXPECT_TRUE(Execute(R"(redis.log('nonsense', 'nonsense'))"));
+  EXPECT_EQ("nil", ser_.res);
+  EXPECT_TRUE(Execute(R"(redis.log(redis.LOG_WARNING, 'warn'))"));
+  EXPECT_EQ("nil", ser_.res);
+}
+
 }  // namespace dfly

--- a/tests/dragonfly/eval_test.py
+++ b/tests/dragonfly/eval_test.py
@@ -264,3 +264,12 @@ async def test_lua_auto_async(async_client: aioredis.Redis):
 
     flushes = (await async_client.info("transaction"))["eval_squashed_flushes"]
     assert 1 <= flushes <= 3  # all 100 commands are executed in at most 3 batches
+
+
+@dfly_args({"proactor_threads": 4, "lua_auto_async": None})
+async def test_lua_replicate_commands(async_client: aioredis.Redis):
+    res = await async_client.eval("return redis.replicate_commands()", 0)
+    assert res == 1
+
+    res = await async_client.eval("redis.replicate_commands()", 0)
+    assert res == None

--- a/tests/dragonfly/eval_test.py
+++ b/tests/dragonfly/eval_test.py
@@ -264,21 +264,3 @@ async def test_lua_auto_async(async_client: aioredis.Redis):
 
     flushes = (await async_client.info("transaction"))["eval_squashed_flushes"]
     assert 1 <= flushes <= 3  # all 100 commands are executed in at most 3 batches
-
-
-@dfly_args({"proactor_threads": 4, "lua_auto_async": None})
-async def test_lua_replicate_commands(async_client: aioredis.Redis):
-    res = await async_client.eval("return redis.replicate_commands()", 0)
-    assert res == 1
-
-    res = await async_client.eval("redis.replicate_commands()", 0)
-    assert res == None
-
-
-@dfly_args({"proactor_threads": 4, "lua_auto_async": None})
-async def test_lua_redis_log_noop(async_client: aioredis.Redis):
-    res = await async_client.eval("redis.log('nonsense', 'nonsense')", 0)
-    assert res == None
-
-    res = await async_client.eval("redis.log(redis.LOG_WARNING, 'warn')", 0)
-    assert res == None


### PR DESCRIPTION
fixes #2468

* add no-op lua function redis.replicate_commands()