### PR TITLE
fix: fixes for v1.14.0

### DIFF
--- a/src/server/journal/journal_slice.cc
+++ b/src/server/journal/journal_slice.cc
@@ -31,7 +31,6 @@ namespace {
 string ShardName(std::string_view base, unsigned index) {
   return absl::StrCat(base, "-", absl::Dec(index, absl::kZeroPad4), ".log");
 }
-*/
 
 uint32_t NextPowerOf2(uint32_t x) {
   if (x < 2) {
@@ -40,6 +39,8 @@ uint32_t NextPowerOf2(uint32_t x) {
   int log = 32 - __builtin_clz(x - 1);
   return 1 << log;
 }
+
+*/
 
 }  // namespace
 

--- a/src/server/journal/journal_slice.cc
+++ b/src/server/journal/journal_slice.cc
@@ -61,7 +61,7 @@ void JournalSlice::Init(unsigned index) {
     return;
 
   slice_index_ = index;
-  ring_buffer_.emplace(NextPowerOf2(absl::GetFlag(FLAGS_shard_repl_backlog_len)));
+  ring_buffer_.emplace(2);
 }
 
 #if 0
@@ -156,7 +156,7 @@ void JournalSlice::AddLogRecord(const Entry& entry, bool await) {
     FiberAtomicGuard fg;
     // GetTail gives a pointer to a new tail entry in the buffer, possibly overriding the last entry
     // if the buffer is full.
-    item = ring_buffer_->GetTail(true);
+    item = &dummy;
     item->opcode = entry.opcode;
     item->lsn = lsn_++;
     item->slot = entry.slot;

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1396,7 +1396,7 @@ void Transaction::DecreaseRunCnt() {
   uint32_t res = run_count_.fetch_sub(1, memory_order_release);
 
   CHECK_GE(res, 1u) << unique_shard_cnt_ << " " << unique_shard_id_ << " " << cid_->name() << " "
-                    << use_count_.load(memory_order_relaxed) << " " << coordinator_state_;
+                    << use_count_.load(memory_order_relaxed) << " " << uint32_t(coordinator_state_);
 
   if (res == 1) {
     run_ec_.notify();

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -494,6 +494,7 @@ bool Transaction::RunInShard(EngineShard* shard, bool txq_ooo) {
   auto& sd = shard_data_[idx];
 
   CHECK(sd.is_armed.exchange(false, memory_order_relaxed));
+  CHECK_GT(run_count_.load(memory_order_relaxed), 0u);
 
   VLOG(2) << "RunInShard: " << DebugId() << " sid:" << shard->shard_id() << " " << sd.local_mask;
 

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -523,7 +523,7 @@ class Transaction {
   void LogAutoJournalOnShard(EngineShard* shard, RunnableResult shard_result);
 
   // Returns the previous value of run count.
-  uint32_t DecreaseRunCnt();
+  void DecreaseRunCnt();
 
   uint32_t GetUseCount() const {
     return use_count_.load(std::memory_order_relaxed);


### PR DESCRIPTION
1. Stop writing to the replication ring_buffer
2. Stop allocating in TopKeys
3. Tighter CHECKs around tx execution.