### PR TITLE
chore(transaction): Launder copied keys in multi transactions

### DIFF
--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -234,7 +234,7 @@ size_t ConnectionState::ExecInfo::UsedMemory() const {
 }
 
 size_t ConnectionState::ScriptInfo::UsedMemory() const {
-  return async_cmds_heap_mem;
+  return dfly::HeapSize(keys) + async_cmds_heap_mem;
 }
 
 size_t ConnectionState::SubscribeInfo::UsedMemory() const {

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -234,7 +234,7 @@ size_t ConnectionState::ExecInfo::UsedMemory() const {
 }
 
 size_t ConnectionState::ScriptInfo::UsedMemory() const {
-  return dfly::HeapSize(keys);
+  return async_cmds_heap_mem;
 }
 
 size_t ConnectionState::SubscribeInfo::UsedMemory() const {

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -101,6 +101,8 @@ struct ConnectionState {
   struct ScriptInfo {
     size_t UsedMemory() const;
 
+    absl::flat_hash_set<std::string_view> keys;  // declared keys
+
     size_t async_cmds_heap_mem = 0;     // bytes used by async_cmds
     size_t async_cmds_heap_limit = 0;   // max bytes allowed for async_cmds
     std::vector<StoredCmd> async_cmds;  // aggregated by acall

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -101,8 +101,6 @@ struct ConnectionState {
   struct ScriptInfo {
     size_t UsedMemory() const;
 
-    absl::flat_hash_set<std::string_view> keys;  // declared keys
-
     size_t async_cmds_heap_mem = 0;     // bytes used by async_cmds
     size_t async_cmds_heap_limit = 0;   // max bytes allowed for async_cmds
     std::vector<StoredCmd> async_cmds;  // aggregated by acall

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -167,27 +167,23 @@ class RoundRobinSharder {
 
 bool HasContendedLocks(unsigned shard_id, Transaction* trx, const DbTable* table) {
   bool has_contended_locks = false;
+  auto record = [table, &has_contended_locks](string_view key) {
+    auto it = table->trans_locks.find(key);
+    DCHECK(it != table->trans_locks.end());
+    has_contended_locks |= it->second.IsContended();
+  };
 
   if (trx->IsMulti()) {
-    trx->IterateMultiLocks(shard_id, [&](const string& key) {
-      auto it = table->trans_locks.find(key);
-      DCHECK(it != table->trans_locks.end());
-      if (it->second.IsContended()) {
-        has_contended_locks = true;
-      }
-    });
+    auto keys = trx->GetMultiKeys();
+    for (string_view key : keys) {
+      if (Shard(key, shard_set->size()) == shard_id)
+        record(key);
+    }
   } else {
     KeyLockArgs lock_args = trx->GetLockArgs(shard_id);
     for (size_t i = 0; i < lock_args.args.size(); i += lock_args.key_step) {
       string_view s = KeyLockArgs::GetLockKey(lock_args.args[i]);
-      auto it = table->trans_locks.find(s);
-      DCHECK(it != table->trans_locks.end());
-      if (it != table->trans_locks.end()) {
-        if (it->second.IsContended()) {
-          has_contended_locks = true;
-          break;
-        }
-      }
+      record(s);
     }
   }
   return has_contended_locks;

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -204,7 +204,7 @@ void Transaction::InitShardData(absl::Span<const PerShardCache> shard_index, siz
   CHECK_EQ(args_.size(), num_args);
 }
 
-void Transaction::CopyMultiKeys(CmdArgVec* keys) {
+void Transaction::LaunderKeyStorage(CmdArgVec* keys) {
   DCHECK_EQ(multi_->mode, LOCK_AHEAD);
   DCHECK_GT(keys->size(), 0u);
 
@@ -423,7 +423,7 @@ void Transaction::StartMultiLockedAhead(DbIndex dbid, CmdArgVec keys) {
   multi_->mode = LOCK_AHEAD;
   multi_->lock_mode = LockMode();
 
-  CopyMultiKeys(&keys);  // Filter uniques and normalize
+  LaunderKeyStorage(&keys);  // Filter uniques and normalize
 
   InitBase(dbid, absl::MakeSpan(keys));
   InitByKeys(KeyIndex::Range(0, keys.size()));

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -205,10 +205,10 @@ void Transaction::InitShardData(absl::Span<const PerShardCache> shard_index, siz
 }
 
 CmdArgList Transaction::CopyMultiKeys(CmdArgList keys) {
-  DCHECK(multi_->mode == LOCK_AHEAD);
+  DCHECK_EQ(multi_->mode, LOCK_AHEAD);
   DCHECK_GT(keys.size(), 0u);
 
-  // Store all unqiue keys in multi data
+  // Store all unique keys in multi data
   absl::flat_hash_set<std::string_view> seen_keys;
   for (MutableSlice key : keys) {
     auto lock_key = KeyLockArgs::GetLockKey(facade::ToSV(key));

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -430,7 +430,7 @@ void Transaction::StartMultiLockedAhead(DbIndex dbid, CmdArgVec keys) {
 
   ScheduleInternal();
 
-  full_args_ = {nullptr, 0};  // Was pointer to temporary
+  full_args_ = {nullptr, 0};  // InitBase set it to temporary keys, now we reset it.
 }
 
 void Transaction::StartMultiNonAtomic() {

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -457,7 +457,7 @@ class Transaction {
 
   // Multi transactions unlock asynchronously, so they need to keep a copy of all they keys.
   // "Launder" keys by filtering uniques and replacing pointers with same lifetime as transaction.
-  void CopyMultiKeys(CmdArgVec* keys);
+  void LaunderKeyStorage(CmdArgVec* keys);
 
   // Generic schedule used from Schedule() and ScheduleSingleHop() on slow path.
   void ScheduleInternal();


### PR DESCRIPTION
Introduce `CopyMultiKeys` to use copied key versions when locking, making way for #2463 