### PR TITLE
chore: switch json object to pmr allocator

### DIFF
--- a/src/core/compact_object_test.cc
+++ b/src/core/compact_object_test.cc
@@ -577,14 +577,15 @@ TEST_F(CompactObjectTest, JsonTypeWithPathTest) {
   ASSERT_TRUE(json_array.has_value());
   cobj_.SetJson(std::move(json_array.value()));
   ASSERT_TRUE(cobj_.ObjType() == OBJ_JSON);  // and now this is a JSON type
-  auto f = [](const std::string& /*path*/, JsonType& book) {
+  auto f = [](const auto& /*path*/, JsonType& book) {
     if (book.at("category") == "memoir" && !book.contains("price")) {
       book.try_emplace("price", 140.0);
     }
   };
   JsonType* json = cobj_.GetJson();
   ASSERT_TRUE(json != nullptr);
-  jsonpath::json_replace(*json, "$.books[*]", f);
+  auto allocator_set = jsoncons::combine_allocators(json->get_allocator());
+  jsonpath::json_replace(allocator_set, *json, "$.books[*]"sv, f);
 
   // Check whether we've changed the entry for json in place
   // we should have prices only for memoir books

--- a/src/core/json_test.cc
+++ b/src/core/json_test.cc
@@ -35,10 +35,15 @@ TEST_F(JsonTest, Basic) {
     }
 )";
 
-  json j = json::parse(data);
+  pmr::json j = pmr::json::parse(data);
   EXPECT_TRUE(j.contains("reputons"));
   jsonpath::json_replace(j, "$.reputons[*].rating", 1.1);
   EXPECT_EQ(1.1, j["reputons"][0]["rating"].as_double());
+}
+
+TEST_F(JsonTest, SetEmpty) {
+  pmr::json dest{json_object_arg};  // crashes on UB without the tag.
+  dest["bar"] = "foo";
 }
 
 TEST_F(JsonTest, Query) {

--- a/src/core/sorted_map.cc
+++ b/src/core/sorted_map.cc
@@ -1054,7 +1054,7 @@ uint64_t SortedMap::DfImpl::Scan(uint64_t cursor,
 /***************************************************************************/
 /* SortedMap */
 /***************************************************************************/
-SortedMap::SortedMap(PMR_NS::memory_resource* mr) : impl_(RdImpl()), mr_res_(mr) {
+SortedMap::SortedMap(PMR_NS::memory_resource* mr) : impl_(RdImpl()) {
   if (absl::GetFlag(FLAGS_use_zset_tree)) {
     impl_ = DfImpl();
   }

--- a/src/core/sorted_map.h
+++ b/src/core/sorted_map.h
@@ -268,7 +268,6 @@ class SortedMap {
   };
 
   std::variant<RdImpl, DfImpl> impl_;
-  PMR_NS::memory_resource* mr_res_;
 };
 
 // Used by CompactObject.

--- a/src/server/journal/tx_executor.h
+++ b/src/server/journal/tx_executor.h
@@ -10,7 +10,7 @@
 
 namespace dfly {
 
-class JournalReader;
+struct JournalReader;
 
 // Coordinator for multi shard execution.
 class MultiShardExecution {

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -90,14 +90,17 @@ string JsonTypeToName(const JsonType& val) {
   return std::string{};
 }
 
-JsonExpression ParseJsonPath(string_view path, error_code* ec) {
+io::Result<JsonExpression> ParseJsonPath(string_view path) {
   if (path == ".") {
     // RedisJson V1 uses the dot for root level access.
     // There are more incompatibilities with legacy paths which are not supported.
     path = "$"sv;
   }
-
-  return jsonpath::make_expression<JsonType>(path, *ec);
+  std::error_code ec;
+  JsonExpression res = MakeJsonPathExpr(path, ec);
+  if (ec)
+    return nonstd::make_unexpected(ec);
+  return res;
 }
 
 template <typename T>
@@ -436,7 +439,7 @@ OpResult<string> OpJsonGet(const OpArgs& op_args, string_view key,
     return expr ? expr->evaluate(json_entry) : json_entry;
   };
 
-  json out;
+  JsonType out{json_object_arg};  // see https://github.com/danielaparker/jsoncons/issues/482
   if (expressions.size() == 1) {
     out = eval_wrapped(expressions[0].second);
   } else {
@@ -558,7 +561,7 @@ OpResult<string> OpDoubleArithmetic(const OpArgs& op_args, string_view key, stri
   bool is_result_overflow = false;
   double int_part;
   bool has_fractional_part = (modf(num, &int_part) != 0);
-  json output(json_array_arg);
+  JsonType output(json_array_arg);
 
   auto cb = [&](const auto&, JsonType& val) {
     if (val.is_number()) {
@@ -575,7 +578,7 @@ OpResult<string> OpDoubleArithmetic(const OpArgs& op_args, string_view key, stri
       }
       output.push_back(val);
     } else {
-      output.push_back(json::null());
+      output.push_back(JsonType::null());
     }
   };
 
@@ -624,12 +627,12 @@ OpResult<long> OpDel(const OpArgs& op_args, string_view key, string_view path) {
     return total_deletions;
   }
 
-  json patch(json_array_arg, {});
+  JsonType patch(json_array_arg, {});
   reverse(deletion_items.begin(), deletion_items.end());  // deletion should finish at root keys.
   for (const auto& item : deletion_items) {
     string pointer = ConvertToJsonPointer(item);
     total_deletions++;
-    json patch_item(json_object_arg, {{"op", "remove"}, {"path", pointer}});
+    JsonType patch_item(json_object_arg, {{"op", "remove"}, {"path", pointer}});
     patch.emplace_back(patch_item);
   }
 
@@ -1140,6 +1143,14 @@ OpResult<bool> OpSet(const OpArgs& op_args, string_view key, string_view path,
 
 }  // namespace
 
+#define PARSE_PATH_ARG(path)                                                \
+  io::Result<JsonExpression> expression = ParseJsonPath(path);              \
+  while (!expression) {                                                     \
+    VLOG(1) << "Invalid JSONPath syntax: " << expression.error().message(); \
+    cntx->SendError(kSyntaxErr);                                            \
+    return;                                                                 \
+  }
+
 void JsonFamily::Set(CmdArgList args, ConnectionContext* cntx) {
   string_view key = ArgS(args, 0);
   string_view path = ArgS(args, 1);
@@ -1186,17 +1197,10 @@ void JsonFamily::Resp(CmdArgList args, ConnectionContext* cntx) {
     path = ArgS(args, 1);
   }
 
-  error_code ec;
-  JsonExpression expression = ParseJsonPath(path, &ec);
-
-  if (ec) {
-    VLOG(1) << "Invalid JSONPath syntax: " << ec.message();
-    cntx->SendError(kSyntaxErr);
-    return;
-  }
+  PARSE_PATH_ARG(path);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpResp(t->GetOpArgs(shard), key, std::move(expression));
+    return OpResp(t->GetOpArgs(shard), key, std::move(*expression));
   };
 
   Transaction* trans = cntx->transaction;
@@ -1239,19 +1243,12 @@ void JsonFamily::Debug(CmdArgList args, ConnectionContext* cntx) {
     return;
   }
 
-  error_code ec;
   string_view key = ArgS(args, 1);
   string_view path = ArgS(args, 2);
-  JsonExpression expression = ParseJsonPath(path, &ec);
-
-  if (ec) {
-    VLOG(1) << "Invalid JSONPath syntax: " << ec.message();
-    cntx->SendError(kSyntaxErr);
-    return;
-  }
+  PARSE_PATH_ARG(path);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return func(t->GetOpArgs(shard), key, std::move(expression));
+    return func(t->GetOpArgs(shard), key, std::move(*expression));
   };
 
   Transaction* trans = cntx->transaction;
@@ -1267,15 +1264,8 @@ void JsonFamily::Debug(CmdArgList args, ConnectionContext* cntx) {
 void JsonFamily::MGet(CmdArgList args, ConnectionContext* cntx) {
   DCHECK_GE(args.size(), 1U);
 
-  error_code ec;
   string_view path = ArgS(args, args.size() - 1);
-  JsonExpression expression = ParseJsonPath(path, &ec);
-
-  if (ec) {
-    VLOG(1) << "Invalid JSONPath syntax: " << ec.message();
-    cntx->SendError(kSyntaxErr);
-    return;
-  }
+  PARSE_PATH_ARG(path);
 
   Transaction* transaction = cntx->transaction;
   unsigned shard_count = shard_set->size();
@@ -1283,7 +1273,7 @@ void JsonFamily::MGet(CmdArgList args, ConnectionContext* cntx) {
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     ShardId sid = shard->shard_id();
-    mget_resp[sid] = OpJsonMGet(ParseJsonPath(path, &ec), t, shard);
+    mget_resp[sid] = OpJsonMGet(*ParseJsonPath(path), t, shard);
     return OpStatus::OK;
   };
 
@@ -1325,14 +1315,7 @@ void JsonFamily::ArrIndex(CmdArgList args, ConnectionContext* cntx) {
   string_view key = ArgS(args, 0);
   string_view path = ArgS(args, 1);
 
-  error_code ec;
-  JsonExpression expression = ParseJsonPath(path, &ec);
-
-  if (ec) {
-    VLOG(1) << "Invalid JSONPath syntax: " << ec.message();
-    cntx->SendError(kSyntaxErr);
-    return;
-  }
+  PARSE_PATH_ARG(path);
 
   optional<JsonType> search_value = JsonFromString(ArgS(args, 2));
   if (!search_value) {
@@ -1364,7 +1347,7 @@ void JsonFamily::ArrIndex(CmdArgList args, ConnectionContext* cntx) {
   }
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpArrIndex(t->GetOpArgs(shard), key, std::move(expression), *search_value, start_index,
+    return OpArrIndex(t->GetOpArgs(shard), key, std::move(*expression), *search_value, start_index,
                       end_index);
   };
 
@@ -1487,14 +1470,7 @@ void JsonFamily::ArrPop(CmdArgList args, ConnectionContext* cntx) {
     }
   }
 
-  error_code ec;
-  JsonExpression expression = ParseJsonPath(path, &ec);
-
-  if (ec) {
-    VLOG(1) << "Invalid JSONPath syntax: " << ec.message();
-    cntx->SendError(kSyntaxErr);
-    return;
-  }
+  PARSE_PATH_ARG(path);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpArrPop(t->GetOpArgs(shard), key, path, index);
@@ -1562,17 +1538,10 @@ void JsonFamily::ObjKeys(CmdArgList args, ConnectionContext* cntx) {
   string_view key = ArgS(args, 0);
   string_view path = ArgS(args, 1);
 
-  error_code ec;
-  JsonExpression expression = ParseJsonPath(path, &ec);
-
-  if (ec) {
-    VLOG(1) << "Invalid JSONPath syntax: " << ec.message();
-    cntx->SendError(kSyntaxErr);
-    return;
-  }
+  PARSE_PATH_ARG(path);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpObjKeys(t->GetOpArgs(shard), key, std::move(expression));
+    return OpObjKeys(t->GetOpArgs(shard), key, std::move(*expression));
   };
 
   Transaction* trans = cntx->transaction;
@@ -1680,17 +1649,10 @@ void JsonFamily::Type(CmdArgList args, ConnectionContext* cntx) {
   string_view key = ArgS(args, 0);
   string_view path = ArgS(args, 1);
 
-  error_code ec;
-  JsonExpression expression = ParseJsonPath(path, &ec);
-
-  if (ec) {
-    VLOG(1) << "Invalid JSONPath syntax: " << ec.message();
-    cntx->SendError(kSyntaxErr);
-    return;
-  }
+  PARSE_PATH_ARG(path);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpType(t->GetOpArgs(shard), key, std::move(expression));
+    return OpType(t->GetOpArgs(shard), key, std::move(*expression));
   };
 
   Transaction* trans = cntx->transaction;
@@ -1716,17 +1678,10 @@ void JsonFamily::ArrLen(CmdArgList args, ConnectionContext* cntx) {
   string_view key = ArgS(args, 0);
   string_view path = ArgS(args, 1);
 
-  error_code ec;
-  JsonExpression expression = ParseJsonPath(path, &ec);
-
-  if (ec) {
-    VLOG(1) << "Invalid JSONPath syntax: " << ec.message();
-    cntx->SendError(kSyntaxErr);
-    return;
-  }
+  PARSE_PATH_ARG(path);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpArrLen(t->GetOpArgs(shard), key, std::move(expression));
+    return OpArrLen(t->GetOpArgs(shard), key, std::move(*expression));
   };
 
   Transaction* trans = cntx->transaction;
@@ -1743,17 +1698,10 @@ void JsonFamily::ObjLen(CmdArgList args, ConnectionContext* cntx) {
   string_view key = ArgS(args, 0);
   string_view path = ArgS(args, 1);
 
-  error_code ec;
-  JsonExpression expression = ParseJsonPath(path, &ec);
-
-  if (ec) {
-    VLOG(1) << "Invalid JSONPath syntax: " << ec.message();
-    cntx->SendError(kSyntaxErr);
-    return;
-  }
+  PARSE_PATH_ARG(path);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpObjLen(t->GetOpArgs(shard), key, std::move(expression));
+    return OpObjLen(t->GetOpArgs(shard), key, std::move(*expression));
   };
 
   Transaction* trans = cntx->transaction;
@@ -1770,17 +1718,10 @@ void JsonFamily::StrLen(CmdArgList args, ConnectionContext* cntx) {
   string_view key = ArgS(args, 0);
   string_view path = ArgS(args, 1);
 
-  error_code ec;
-  JsonExpression expression = ParseJsonPath(path, &ec);
-
-  if (ec) {
-    VLOG(1) << "Invalid JSONPath syntax: " << ec.message();
-    cntx->SendError(kSyntaxErr);
-    return;
-  }
+  PARSE_PATH_ARG(path);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpStrLen(t->GetOpArgs(shard), key, std::move(expression));
+    return OpStrLen(t->GetOpArgs(shard), key, std::move(*expression));
   };
 
   Transaction* trans = cntx->transaction;
@@ -1822,12 +1763,13 @@ void JsonFamily::Get(CmdArgList args, ConnectionContext* cntx) {
     string_view expr_str = parser.Next();
 
     if (expr_str != ".") {
-      error_code ec;
-      expr = ParseJsonPath(expr_str, &ec);
-      if (ec) {
-        LOG(WARNING) << "path '" << expr_str << "': Invalid JSONPath syntax: " << ec.message();
+      io::Result<JsonExpression> res = ParseJsonPath(expr_str);
+      if (!res) {
+        LOG(WARNING) << "path '" << expr_str
+                     << "': Invalid JSONPath syntax: " << res.error().message();
         return cntx->SendError(kSyntaxErr);
       }
+      expr.emplace(std::move(*res));
     }
 
     expressions.emplace_back(expr_str, std::move(expr));

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -377,7 +377,6 @@ class RdbLoaderBase::OpaqueObjLoader {
   void operator()(const base::PODArray<char>& str);
   void operator()(const LzfString& lzfstr);
   void operator()(const unique_ptr<LoadTrace>& ptr);
-  void operator()(const JsonType& jt);
 
   std::error_code ec() const {
     return ec_;
@@ -460,10 +459,6 @@ void RdbLoaderBase::OpaqueObjLoader::operator()(const unique_ptr<LoadTrace>& ptr
     default:
       LOG(FATAL) << "Unsupported rdb type " << rdb_type_;
   }
-}
-
-void RdbLoaderBase::OpaqueObjLoader::operator()(const JsonType& json) {
-  pv_->SetJson(JsonType{json});
 }
 
 void RdbLoaderBase::OpaqueObjLoader::CreateSet(const LoadTrace* ltrace) {
@@ -1080,6 +1075,12 @@ void RdbLoaderBase::OpaqueObjLoader::HandleBlob(string_view blob) {
     unsigned char* lp = (uint8_t*)zmalloc(bytes);
     std::memcpy(lp, src_lp, bytes);
     pv_->InitRobj(OBJ_ZSET, OBJ_ENCODING_LISTPACK, lp);
+  } else if (rdb_type_ == RDB_TYPE_JSON) {
+    auto json = JsonFromString(blob);
+    if (!json) {
+      ec_ = RdbError(errc::bad_json_string);
+    }
+    pv_->SetJson(std::move(*json));
   } else {
     LOG(FATAL) << "Unsupported rdb type " << rdb_type_;
   }
@@ -1400,20 +1401,18 @@ error_code RdbLoaderBase::ReadObj(int rdbtype, OpaqueObj* dest) {
       iores = ReadStreams();
       break;
     case RDB_TYPE_JSON:
+      iores = ReadJson();
+      break;
     case RDB_TYPE_SET_LISTPACK:
       // We need to deal with protocol versions 9 and older because in these
       // RDB_TYPE_JSON == 20. On newer versions > 9 we bumped up RDB_TYPE_JSON to 30
       // because it overlapped with the new type RDB_TYPE_SET_LISTPACK
-      if (rdb_version_ < 10 && rdbtype == RDB_TYPE_JSON_OLD) {
+      if (rdb_version_ < 10) {
+        // consider it RDB_TYPE_JSON_OLD
         iores = ReadJson();
-        break;
+      } else {
+        iores = ReadGeneric(rdbtype);
       }
-      if (rdbtype == RDB_TYPE_JSON) {
-        iores = ReadJson();
-        break;
-      }
-
-      iores = ReadGeneric(rdbtype);
       break;
     default:
       LOG(ERROR) << "Unsupported rdb type " << rdbtype;
@@ -1829,14 +1828,12 @@ auto RdbLoaderBase::ReadStreams() -> io::Result<OpaqueObj> {
 }
 
 auto RdbLoaderBase::ReadJson() -> io::Result<OpaqueObj> {
-  string json_str;
-  SET_OR_UNEXPECT(FetchGenericString(), json_str);
+  RdbVariant dest;
+  error_code ec = ReadStringObj(&dest);
+  if (ec)
+    return make_unexpected(ec);
 
-  auto json = JsonFromString(json_str);
-  if (!json)
-    return Unexpected(errc::bad_json_string);
-
-  return OpaqueObj{std::move(*json), RDB_TYPE_JSON};
+  return OpaqueObj{std::move(dest), RDB_TYPE_JSON};
 }
 
 template <typename T> io::Result<T> RdbLoaderBase::FetchInt() {

--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -41,8 +41,8 @@ class RdbLoaderBase {
     uint64_t uncompressed_len;
   };
 
-  using RdbVariant = std::variant<long long, base::PODArray<char>, LzfString,
-                                  std::unique_ptr<LoadTrace>, JsonType>;
+  using RdbVariant =
+      std::variant<long long, base::PODArray<char>, LzfString, std::unique_ptr<LoadTrace>>;
 
   struct OpaqueObj {
     RdbVariant obj;

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -192,7 +192,8 @@ uint8_t RdbObjectType(const PrimeValue& pv) {
     case OBJ_MODULE:
       return RDB_TYPE_MODULE_2;
     case OBJ_JSON:
-      return RDB_TYPE_JSON_OLD;
+      return RDB_TYPE_JSON;  // save with RDB_TYPE_JSON, deprecate RDB_TYPE_JSON_OLD after July
+                             // 2024.
   }
   LOG(FATAL) << "Unknown encoding " << compact_enc << " for type " << type;
   return 0; /* avoid warning */

--- a/src/server/search/doc_accessors.cc
+++ b/src/server/search/doc_accessors.cc
@@ -172,7 +172,8 @@ JsonAccessor::JsonPathContainer* JsonAccessor::GetPath(std::string_view field) c
   }
 
   error_code ec;
-  auto path_expr = jsoncons::jsonpath::make_expression<JsonType>(field, ec);
+  auto path_expr = MakeJsonPathExpr(field, ec);
+
   if (ec) {
     LOG(WARNING) << "Invalid Json path: " << field << ' ' << ec.message();
     return nullptr;

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -10,8 +10,6 @@
 #include <absl/strings/str_format.h>
 
 #include <atomic>
-#include <jsoncons/json.hpp>
-#include <jsoncons_ext/jsonpath/jsonpath.hpp>
 #include <variant>
 #include <vector>
 
@@ -41,7 +39,7 @@ static const set<string_view> kIgnoredOptions = {"WEIGHT", "SEPARATOR"};
 
 bool IsValidJsonPath(string_view path) {
   error_code ec;
-  jsoncons::jsonpath::make_expression<JsonType>(path, ec);
+  MakeJsonPathExpr(path, ec);
   return !ec;
 }
 

--- a/src/server/table.h
+++ b/src/server/table.h
@@ -16,6 +16,9 @@
 #include "server/detail/table.h"
 #include "server/top_keys.h"
 
+extern "C" {
+#include "redis/redis_aux.h"
+}
 namespace dfly {
 
 using PrimeKey = detail::PrimeKey;


### PR DESCRIPTION
1. Move json object creation code to the shard-thread inside rdb_load
2. Now json_family never references "json" type, always dfly::JsonType
3. Switch JsonType to pmr::json.
4. Make sure we pass the correct memory_resource when creating json object from string.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->