### PR TITLE
Update healthcheck.sh

### DIFF
--- a/tools/docker/healthcheck.sh
+++ b/tools/docker/healthcheck.sh
@@ -7,6 +7,9 @@ PORT=6379
 if [ -f "/etc/dragonfly/tls/ca.crt" ]
 then
     _healthcheck="openssl s_client -connect ${HOST}:${PORT} -CAfile /etc/dragonfly/tls/ca.crt -quiet -no_ign_eof"
+elif [ -f "/etc/dragonfly/client-ca-cert/ca.crt" ]
+then
+    _healthcheck="openssl s_client -connect ${HOST}:${PORT} -CAfile /etc/dragonfly/client-ca-cert/ca.crt -quiet -no_ign_eof"
 else
     _healthcheck="nc -q1 $HOST $PORT"
 fi


### PR DESCRIPTION
The operator changes the directory that the ca.crt gets mounted to. Solves the errors in the logs https://github.com/dragonflydb/dragonfly-operator/issues/145

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->