### PR TITLE
chore: remove batch reply statistics

### DIFF
--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -41,7 +41,7 @@ ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
 }
 
 ReplyStats& ReplyStats::operator+=(const ReplyStats& o) {
-  static_assert(sizeof(ReplyStats) == 80u);
+  static_assert(sizeof(ReplyStats) == 64u);
   ADD(io_write_cnt);
   ADD(io_write_bytes);
 
@@ -49,9 +49,7 @@ ReplyStats& ReplyStats::operator+=(const ReplyStats& o) {
     err_count[k_v.first] += k_v.second;
   }
 
-  for (unsigned i = 0; i < kNumTypes; ++i) {
-    send_stats[i] += o.send_stats[i];
-  }
+  send_stats += o.send_stats;
 
   return *this;
 }

--- a/src/facade/facade_types.h
+++ b/src/facade/facade_types.h
@@ -60,12 +60,6 @@ struct ConnectionStats {
 };
 
 struct ReplyStats {
-  enum SendStatsType {
-    kRegular,   // Send() operations that are written to sockets
-    kBatch,     // Send() operations that are internally batched to a buffer
-    kNumTypes,  // Number of types, do not use directly
-  };
-
   struct SendStats {
     int64_t count = 0;
     int64_t total_duration = 0;
@@ -79,7 +73,8 @@ struct ReplyStats {
     }
   };
 
-  SendStats send_stats[SendStatsType::kNumTypes];
+  // Send() operations that are written to sockets
+  SendStats send_stats;
 
   size_t io_write_cnt = 0;
   size_t io_write_bytes = 0;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -215,7 +215,6 @@ using namespace util;
 using detail::SaveStagesController;
 using http::StringResponse;
 using strings::HumanReadableNumBytes;
-using SendStatsType = facade::ReplyStats::SendStatsType;
 
 namespace {
 
@@ -1051,35 +1050,11 @@ void PrintPrometheusMetrics(const Metrics& m, StringResponse* resp) {
   AppendMetricWithoutLabels("net_output_bytes_total", "", m.facade_stats.reply_stats.io_write_bytes,
                             MetricType::COUNTER, &resp->body());
   {
-    string send_latency_metrics;
-    constexpr string_view kReplyLatency = "reply_duration_seconds";
-    AppendMetricHeader(kReplyLatency, "Reply latency per type", MetricType::COUNTER,
-                       &send_latency_metrics);
-
-    string send_count_metrics;
-    constexpr string_view kReplyCount = "reply_total";
-    AppendMetricHeader(kReplyCount, "Reply count per type", MetricType::COUNTER,
-                       &send_count_metrics);
-
-    for (unsigned i = 0; i < SendStatsType::kNumTypes; ++i) {
-      auto& stats = m.facade_stats.reply_stats.send_stats[i];
-      string_view type;
-      switch (SendStatsType(i)) {
-        case SendStatsType::kRegular:
-          type = "regular";
-          break;
-        case SendStatsType::kBatch:
-          type = "batch";
-          break;
-        case SendStatsType::kNumTypes:
-          type = "other";
-          break;
-      }
-
-      AppendMetricValue(kReplyLatency, double(stats.total_duration) * 1e-6, {"type"}, {type},
-                        &send_latency_metrics);
-      AppendMetricValue(kReplyCount, stats.count, {"type"}, {type}, &send_count_metrics);
-    }
+    AppendMetricWithoutLabels("reply_duration_seconds", "",
+                              m.facade_stats.reply_stats.send_stats.total_duration * 1e-6,
+                              MetricType::COUNTER, &resp->body());
+    AppendMetricWithoutLabels("reply_total", "", m.facade_stats.reply_stats.send_stats.count,
+                              MetricType::COUNTER, &resp->body());
 
     // Tiered metrics.
     if (m.disk_stats.read_total > 0) {
@@ -1089,8 +1064,6 @@ void PrintPrometheusMetrics(const Metrics& m, StringResponse* resp) {
                                 double(m.disk_stats.read_delay_usec) * 1e-6, MetricType::COUNTER,
                                 &resp->body());
     }
-    absl::StrAppend(&resp->body(), send_latency_metrics);
-    absl::StrAppend(&resp->body(), send_count_metrics);
   }
 
   // DB stats
@@ -1642,9 +1615,7 @@ void ServerFamily::ResetStat() {
 
     tl_facade_stats->reply_stats.io_write_bytes = 0;
     tl_facade_stats->reply_stats.io_write_cnt = 0;
-    for (auto& send_stat : tl_facade_stats->reply_stats.send_stats) {
-      send_stat = {};
-    }
+    tl_facade_stats->reply_stats.send_stats = {};
 
     service_.mutable_registry()->ResetCallStats(index);
   });
@@ -1878,11 +1849,8 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
     append("defrag_attempt_total", m.shard_stats.defrag_attempt_total);
     append("defrag_realloc_total", m.shard_stats.defrag_realloc_total);
     append("defrag_task_invocation_total", m.shard_stats.defrag_task_invocation_total);
-    append("reply_count", reply_stats.send_stats[SendStatsType::kRegular].count);
-    append("reply_latency_usec", reply_stats.send_stats[SendStatsType::kRegular].total_duration);
-    append("reply_batch_count", reply_stats.send_stats[SendStatsType::kBatch].count);
-    append("reply_batch_latency_usec",
-           reply_stats.send_stats[SendStatsType::kBatch].total_duration);
+    append("reply_count", reply_stats.send_stats.count);
+    append("reply_latency_usec", reply_stats.send_stats.total_duration);
   }
 
   if (should_enter("TIERED", true)) {


### PR DESCRIPTION
1. average batch latency will always be 0, because even in cases we have outliers they will be dominated by small CPU only copies that take dozens of ns.
2. Measuring an operation like kBatch, which is solely CPU-based, necessitated the use of a clock. According to the CPU profiler, this contributed to approximately 5% of the CPU usage.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->