### PR TITLE
chore: introduce TaskQueue for executing shard local tasks

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -4,7 +4,7 @@ set(SEARCH_LIB query_parser)
 add_library(dfly_core compact_object.cc dragonfly_core.cc extent_tree.cc
     external_alloc.cc interpreter.cc json_object.cc mi_memory_resource.cc sds_utils.cc
     segment_allocator.cc score_map.cc small_string.cc sorted_map.cc
-    tx_queue.cc dense_set.cc
+    tx_queue.cc dense_set.cc task_queue.cc
     string_set.cc string_map.cc detail/bitpacking.cc)
 
 cxx_link(dfly_core base absl::flat_hash_map absl::str_format redis_lib TRDP::lua lua_modules

--- a/src/core/fibers.h
+++ b/src/core/fibers.h
@@ -18,8 +18,6 @@ using util::fb2::CondVar;
 using util::fb2::Done;
 using util::fb2::EventCount;
 using util::fb2::Fiber;
-using util::fb2::FiberQueue;
-using util::fb2::FiberQueueThreadPool;
 using util::fb2::Future;
 using util::fb2::Launch;
 using util::fb2::Mutex;

--- a/src/core/task_queue.cc
+++ b/src/core/task_queue.cc
@@ -1,0 +1,74 @@
+// Copyright 2022, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "core/task_queue.h"
+
+#include <absl/strings/str_cat.h>
+
+#include "base/logging.h"
+
+using namespace std;
+using namespace util;
+
+namespace dfly {
+
+TaskQueue::TaskQueue(unsigned consumer_fb_cnt, unsigned queue_size)
+    : queue_(queue_size),
+      num_consumers_(consumer_fb_cnt),
+      consumer_fiber_(new fb2::Fiber[consumer_fb_cnt]) {
+}
+
+void TaskQueue::Start(string_view base_name) {
+  CHECK_GT(num_consumers_, 0u);
+
+  for (unsigned i = 0; i < num_consumers_; ++i) {
+    CHECK(!consumer_fiber_[i].IsJoinable());
+
+    string name = absl::StrCat(base_name, "_", i);
+    consumer_fiber_[i] = fb2::Fiber(name, [this] { TaskLoop(); });
+  }
+}
+
+void TaskQueue::Shutdown() {
+  is_closed_.store(true, memory_order_seq_cst);
+  pull_ec_.notifyAll();
+  for (unsigned i = 0; i < num_consumers_; ++i) {
+    consumer_fiber_[i].Join();
+  }
+  consumer_fiber_.reset();
+}
+
+void TaskQueue::TaskLoop() {
+  bool is_closed = false;
+  CbFunc func;
+
+  auto cb = [&] {
+    if (queue_.try_dequeue(func)) {
+      push_ec_.notify();
+      return true;
+    }
+
+    if (is_closed_.load(std::memory_order_acquire)) {
+      is_closed = true;
+      return true;
+    }
+    return false;
+  };
+
+  while (true) {
+    pull_ec_.await(cb);
+
+    if (is_closed)
+      break;
+    try {
+      concurrency_level_++;
+      func();
+      concurrency_level_--;  // We check-fail on exception, so it's safe to decrement here.
+    } catch (std::exception& e) {
+      LOG(FATAL) << "Exception " << e.what();
+    }
+  }
+}
+
+}  // namespace dfly

--- a/src/core/task_queue.h
+++ b/src/core/task_queue.h
@@ -1,0 +1,106 @@
+// Copyright 2022, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include "base/mpmc_bounded_queue.h"
+#include "util/fibers/detail/result_mover.h"
+#include "util/fibers/fibers.h"
+#include "util/fibers/synchronization.h"
+namespace dfly {
+
+/**
+ *  MPSC task-queue that is handled by a single consumer thread.
+ *  The design is based on helio's FiberQueue with differrence that we can run multiple
+ *  consumer Fibers in the consumer thread to allow better CPU utilization in case the
+ *  tasks are not CPU bound.
+ *
+ *  Another difference - TaskQueue manages its consumer fibers itself.
+ *  TODO: consider moving to util/fibers.
+ */
+class TaskQueue {
+ public:
+  explicit TaskQueue(unsigned consumer_fb_cnt, unsigned queue_size = 128);
+
+  template <typename F> bool TryAdd(F&& f) {
+    if (queue_.try_enqueue(std::forward<F>(f))) {
+      pull_ec_.notify();
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * @brief Submits a callback into the queue. Should not be called after calling Shutdown().
+   *
+   * @tparam F - callback type
+   * @param f  - callback object
+   * @return true if Add() had to preempt, false is fast path without preemptions was followed.
+   */
+  template <typename F> bool Add(F&& f) {
+    if (TryAdd(std::forward<F>(f))) {
+      return false;
+    }
+
+    bool result = false;
+    while (true) {
+      auto key = push_ec_.prepareWait();
+
+      if (TryAdd(std::forward<F>(f))) {
+        break;
+      }
+      result = true;
+      push_ec_.wait(key.epoch());
+    }
+    return result;
+  }
+
+  template <typename F> auto Await(F&& f) -> decltype(f()) {
+    util::fb2::Done done;
+    using ResultType = decltype(f());
+    util::detail::ResultMover<ResultType> mover;
+
+    Add([&mover, f = std::forward<F>(f), done]() mutable {
+      mover.Apply(f);
+      done.Notify();
+    });
+
+    done.Wait();
+    return std::move(mover).get();
+  }
+
+  /**
+   * @brief Start running consumer loop in the caller thread by spawning fibers.
+   *        Returns immediately.
+   */
+  void Start(std::string_view base_name);
+
+  /**
+   * @brief Notifies Run() function to empty the queue and to exit.
+   *        Does not block.
+   */
+  void Shutdown();
+
+  // Returns number of callbacks being currently called by the queue.
+  // Valid only from the consumer thread.
+  unsigned concurrency_level() const {
+    return concurrency_level_;
+  }
+
+ private:
+  void TaskLoop();
+
+  typedef std::function<void()> CbFunc;
+
+  using FuncQ = base::mpmc_bounded_queue<CbFunc>;
+  FuncQ queue_;
+
+  util::fb2::EventCount push_ec_, pull_ec_;
+  std::atomic_bool is_closed_{false};
+  unsigned num_consumers_;
+  std::unique_ptr<util::fb2::Fiber[]> consumer_fiber_;
+  unsigned concurrency_level_ = 0;
+};
+
+}  // namespace dfly

--- a/src/server/detail/save_stages_controller.h
+++ b/src/server/detail/save_stages_controller.h
@@ -34,7 +34,7 @@ struct SaveStagesInputs {
 
 class RdbSnapshot {
  public:
-  RdbSnapshot(FiberQueueThreadPool* fq_tp, SnapshotStorage* snapshot_storage)
+  RdbSnapshot(util::fb2::FiberQueueThreadPool* fq_tp, SnapshotStorage* snapshot_storage)
       : snapshot_storage_{snapshot_storage} {
   }
 

--- a/src/server/detail/snapshot_storage.cc
+++ b/src/server/detail/snapshot_storage.cc
@@ -25,6 +25,8 @@
 namespace dfly {
 namespace detail {
 
+using namespace util;
+
 std::optional<std::pair<std::string, std::string>> GetBucketPath(std::string_view path) {
   std::string_view clean = absl::StripPrefix(path, kS3Prefix);
 
@@ -42,14 +44,14 @@ std::optional<std::pair<std::string, std::string>> GetBucketPath(std::string_vie
 const int kRdbWriteFlags = O_CREAT | O_WRONLY | O_TRUNC | O_CLOEXEC | O_DIRECT;
 #endif
 
-FileSnapshotStorage::FileSnapshotStorage(FiberQueueThreadPool* fq_threadpool)
+FileSnapshotStorage::FileSnapshotStorage(fb2::FiberQueueThreadPool* fq_threadpool)
     : fq_threadpool_{fq_threadpool} {
 }
 
 io::Result<std::pair<io::Sink*, uint8_t>, GenericError> FileSnapshotStorage::OpenWriteFile(
     const std::string& path) {
   if (fq_threadpool_) {  // EPOLL
-    auto res = util::OpenFiberWriteFile(path, fq_threadpool_);
+    auto res = OpenFiberWriteFile(path, fq_threadpool_);
     if (!res) {
       return nonstd::make_unexpected(GenericError(res.error(), "Couldn't open file for writing"));
     }
@@ -57,7 +59,7 @@ io::Result<std::pair<io::Sink*, uint8_t>, GenericError> FileSnapshotStorage::Ope
     return std::pair(*res, FileType::FILE);
   } else {
 #ifdef __linux__
-    auto res = util::fb2::OpenLinux(path, kRdbWriteFlags, 0666);
+    auto res = fb2::OpenLinux(path, kRdbWriteFlags, 0666);
     if (!res) {
       return nonstd::make_unexpected(GenericError(
           res.error(),
@@ -78,12 +80,12 @@ io::Result<std::pair<io::Sink*, uint8_t>, GenericError> FileSnapshotStorage::Ope
 io::ReadonlyFileOrError FileSnapshotStorage::OpenReadFile(const std::string& path) {
 #ifdef __linux__
   if (fq_threadpool_) {
-    return util::OpenFiberReadFile(path, fq_threadpool_);
+    return OpenFiberReadFile(path, fq_threadpool_);
   } else {
-    return util::fb2::OpenRead(path);
+    return fb2::OpenRead(path);
   }
 #else
-  return util::OpenFiberReadFile(path, fq_threadpool_);
+  return OpenFiberReadFile(path, fq_threadpool_);
 #endif
 }
 
@@ -186,29 +188,29 @@ AwsS3SnapshotStorage::AwsS3SnapshotStorage(const std::string& endpoint, bool htt
       s3_conf.payloadSigningPolicy = Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::ForceNever;
     }
     std::shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials_provider =
-        std::make_shared<util::aws::CredentialsProviderChain>();
+        std::make_shared<aws::CredentialsProviderChain>();
     // Pass a custom endpoint. If empty uses the S3 endpoint.
     std::shared_ptr<Aws::S3::S3EndpointProviderBase> endpoint_provider =
-        std::make_shared<util::aws::S3EndpointProvider>(endpoint, https);
+        std::make_shared<aws::S3EndpointProvider>(endpoint, https);
     s3_ = std::make_shared<Aws::S3::S3Client>(credentials_provider, endpoint_provider, s3_conf);
   });
 }
 
 io::Result<std::pair<io::Sink*, uint8_t>, GenericError> AwsS3SnapshotStorage::OpenWriteFile(
     const std::string& path) {
-  util::fb2::ProactorBase* proactor = shard_set->pool()->GetNextProactor();
+  fb2::ProactorBase* proactor = shard_set->pool()->GetNextProactor();
   return proactor->Await([&]() -> io::Result<std::pair<io::Sink*, uint8_t>, GenericError> {
     std::optional<std::pair<std::string, std::string>> bucket_path = GetBucketPath(path);
     if (!bucket_path) {
       return nonstd::make_unexpected(GenericError("Invalid S3 path"));
     }
     auto [bucket, key] = *bucket_path;
-    io::Result<util::aws::S3WriteFile> file = util::aws::S3WriteFile::Open(bucket, key, s3_);
+    io::Result<aws::S3WriteFile> file = aws::S3WriteFile::Open(bucket, key, s3_);
     if (!file) {
       return nonstd::make_unexpected(GenericError(file.error(), "Failed to open write file"));
     }
 
-    util::aws::S3WriteFile* f = new util::aws::S3WriteFile(std::move(*file));
+    aws::S3WriteFile* f = new aws::S3WriteFile(std::move(*file));
     return std::pair<io::Sink*, uint8_t>(f, FileType::CLOUD);
   });
 }
@@ -219,7 +221,7 @@ io::ReadonlyFileOrError AwsS3SnapshotStorage::OpenReadFile(const std::string& pa
     return nonstd::make_unexpected(GenericError("Invalid S3 path"));
   }
   auto [bucket, key] = *bucket_path;
-  return new util::aws::S3ReadFile(bucket, key, s3_);
+  return new aws::S3ReadFile(bucket, key, s3_);
 }
 
 io::Result<std::string, GenericError> AwsS3SnapshotStorage::LoadPath(std::string_view dir,
@@ -234,7 +236,7 @@ io::Result<std::string, GenericError> AwsS3SnapshotStorage::LoadPath(std::string
   }
   auto [bucket_name, prefix] = *bucket_path;
 
-  util::fb2::ProactorBase* proactor = shard_set->pool()->GetNextProactor();
+  fb2::ProactorBase* proactor = shard_set->pool()->GetNextProactor();
   return proactor->Await(
       [&, bucket_name = bucket_name, prefix = prefix]() -> io::Result<std::string, GenericError> {
         LOG(INFO) << "Load snapshot: Searching for snapshot in S3 path: " << kS3Prefix
@@ -287,7 +289,7 @@ io::Result<std::vector<std::string>, GenericError> AwsS3SnapshotStorage::LoadPat
 
   // Find snapshot shard files if we're loading DFS.
   if (absl::EndsWith(load_path, "summary.dfs")) {
-    util::fb2::ProactorBase* proactor = shard_set->pool()->GetNextProactor();
+    fb2::ProactorBase* proactor = shard_set->pool()->GetNextProactor();
     return proactor->Await([&]() -> io::Result<std::vector<std::string>, GenericError> {
       std::vector<std::string> paths{{load_path}};
 

--- a/src/server/detail/snapshot_storage.h
+++ b/src/server/detail/snapshot_storage.h
@@ -53,7 +53,7 @@ class SnapshotStorage {
 
 class FileSnapshotStorage : public SnapshotStorage {
  public:
-  FileSnapshotStorage(FiberQueueThreadPool* fq_threadpool);
+  FileSnapshotStorage(util::fb2::FiberQueueThreadPool* fq_threadpool);
 
   io::Result<std::pair<io::Sink*, uint8_t>, GenericError> OpenWriteFile(
       const std::string& path) override;

--- a/src/server/engine_shard_set.h
+++ b/src/server/engine_shard_set.h
@@ -18,8 +18,8 @@ extern "C" {
 
 //
 #include "core/external_alloc.h"
-#include "core/fibers.h"
 #include "core/mi_memory_resource.h"
+#include "core/task_queue.h"
 #include "core/tx_queue.h"
 #include "server/cluster/cluster_config.h"
 #include "server/db_slice.h"
@@ -74,7 +74,7 @@ class EngineShard {
     return &mi_resource_;
   }
 
-  FiberQueue* GetFiberQueue() {
+  TaskQueue* GetFiberQueue() {
     return &queue_;
   }
 
@@ -225,8 +225,7 @@ class EngineShard {
   // return true if we did not complete the shard scan
   bool DoDefrag();
 
-  FiberQueue queue_;
-  Fiber fiber_q_;
+  TaskQueue queue_;
 
   TxQueue txq_;
   MiMemoryResource mi_resource_;
@@ -342,7 +341,7 @@ class EngineShardSet {
   void InitThreadLocal(util::ProactorBase* pb, bool update_db_time, size_t max_file_size);
 
   util::ProactorPool* pp_;
-  std::vector<FiberQueue*> shard_queue_;
+  std::vector<TaskQueue*> shard_queue_;
   bool is_tiering_enabled_ = false;
 };
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -688,7 +688,7 @@ void ServerFamily::Init(util::AcceptServer* acceptor, std::vector<facade::Listen
 
   pb_task_ = shard_set->pool()->GetNextProactor();
   if (pb_task_->GetKind() == ProactorBase::EPOLL) {
-    fq_threadpool_.reset(new FiberQueueThreadPool(absl::GetFlag(FLAGS_epoll_file_threads)));
+    fq_threadpool_.reset(new fb2::FiberQueueThreadPool(absl::GetFlag(FLAGS_epoll_file_threads)));
   }
 
   string flag_dir = GetFlag(FLAGS_dir);

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -15,6 +15,7 @@
 #include "server/engine_shard_set.h"
 #include "server/replica.h"
 #include "server/server_state.h"
+#include "util/fibers/fiberqueue_threadpool.h"
 
 void SlowLogGet(dfly::CmdArgList args, dfly::ConnectionContext* cntx, dfly::Service& service,
                 std::string_view sub_cmd);
@@ -294,7 +295,7 @@ class ServerFamily {
   bool save_on_shutdown_{true};
 
   Done schedule_done_;
-  std::unique_ptr<FiberQueueThreadPool> fq_threadpool_;
+  std::unique_ptr<util::fb2::FiberQueueThreadPool> fq_threadpool_;
   std::shared_ptr<detail::SnapshotStorage> snapshot_storage_;
 
   mutable Mutex peak_stats_mu_;


### PR DESCRIPTION
TaskQueue replaces fb2::FiberQueue and allows running multiple fibers on the consumer side.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->