### PR TITLE
fix(server): Fix crash in `RENAME`

### DIFF
--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -282,6 +282,15 @@ TEST_F(GenericFamilyTest, RenameSameName) {
   EXPECT_EQ(Run({"rename", kKey, kKey}), "OK");
 }
 
+TEST_F(GenericFamilyTest, RenameSameShard) {
+  num_threads_ = 1;
+  ResetService();
+
+  ASSERT_EQ(Run({"set", "x", "value"}), "OK");
+  ASSERT_EQ(Run({"set", "y", "value"}), "OK");
+  EXPECT_EQ(Run({"rename", "x", "y"}), "OK");
+}
+
 TEST_F(GenericFamilyTest, Stick) {
   // check stick returns zero on non-existent keys
   ASSERT_THAT(Run({"stick", "a", "b"}), IntArg(0));


### PR DESCRIPTION
Crash was a `CHECK()` failure when renaming to an existing key within the same shard.

Specifically, the problem was that we ran post updater after deletion, which is illegal as it could invalidate iterators.

Fixes #2502

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->