### PR TITLE
feat(tiering): add background offload step

### DIFF
--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -118,7 +118,12 @@ class CompactObj {
     ASCII2_ENC_BIT = 0x10,
     IO_PENDING = 0x20,
     STICKY = 0x40,
-    SIEVE = 0x80,
+
+    // TOUCHED used to determin which items are hot/cold.
+    // by checking if the item was touched from the last time we
+    // reached this item while travering the database to set items as cold.
+    // https://junchengyang.com/publication/nsdi24-SIEVE.pdf
+    TOUCHED = 0x80,
   };
 
   static constexpr uint8_t kEncMask = ASCII1_ENC_BIT | ASCII2_ENC_BIT;
@@ -217,15 +222,15 @@ class CompactObj {
     }
   }
 
-  bool HasTouched() const {
-    return mask_ & SIEVE;
+  bool WasTouched() const {
+    return mask_ & TOUCHED;
   }
 
   void SetTouched(bool e) {
     if (e) {
-      mask_ |= SIEVE;
+      mask_ |= TOUCHED;
     } else {
-      mask_ &= ~SIEVE;
+      mask_ &= ~TOUCHED;
     }
   }
 

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -118,6 +118,7 @@ class CompactObj {
     ASCII2_ENC_BIT = 0x10,
     IO_PENDING = 0x20,
     STICKY = 0x40,
+    SIEVE = 0x80,
   };
 
   static constexpr uint8_t kEncMask = ASCII1_ENC_BIT | ASCII2_ENC_BIT;
@@ -213,6 +214,18 @@ class CompactObj {
       mask_ |= FLAG_BIT;
     } else {
       mask_ &= ~FLAG_BIT;
+    }
+  }
+
+  bool HasTouched() const {
+    return mask_ & SIEVE;
+  }
+
+  void SetTouched(bool e) {
+    if (e) {
+      mask_ |= SIEVE;
+    } else {
+      mask_ &= ~SIEVE;
     }
   }
 

--- a/src/core/dash.h
+++ b/src/core/dash.h
@@ -241,7 +241,9 @@ class DashTable : public detail::DashTableBase {
   template <typename Cb> void TraverseBucket(const_iterator it, Cb&& cb);
 
   // Traverses over a single bucket in table and calls cb(iterator). The traverse order will be
-  // segment by segment over phisical backets.
+  // segment by segment over physical backets.
+  // traverse by segment order does not guarantees coverage if the table grows/shrinks, it is useful
+  // when formal full coverage is not critically important.
   template <typename Cb> Cursor TraverseBySegmentOrder(Cursor curs, Cb&& cb);
 
   // Discards slots information.

--- a/src/core/dash.h
+++ b/src/core/dash.h
@@ -213,7 +213,7 @@ class DashTable : public detail::DashTableBase {
   }
 
   size_t bucket_count() const {
-    return unique_segments_ * SegmentType::kRegularBucketCnt;
+    return unique_segments_ * SegmentType::kTotalBuckets;
   }
 
   // Overall capacity of the table (including stash buckets).
@@ -239,6 +239,10 @@ class DashTable : public detail::DashTableBase {
   // Takes an iterator pointing to an entry in a dash bucket and traverses all bucket's entries by
   // calling cb(iterator) for every non-empty slot. The iteration goes over a physical bucket.
   template <typename Cb> void TraverseBucket(const_iterator it, Cb&& cb);
+
+  // Traverses over a single bucket in table and calls cb(iterator). The traverse order will be
+  // segment by segment over phisical backets.
+  template <typename Cb> Cursor TraverseBySegmentOrder(Cursor curs, Cb&& cb);
 
   // Discards slots information.
   static const_bucket_iterator BucketIt(const_iterator it) {
@@ -884,6 +888,30 @@ void DashTable<_Key, _Value, Policy>::Split(uint32_t seg_id) {
   for (size_t i = start_idx + chunk_size / 2; i < start_idx + chunk_size; ++i) {
     segment_[i] = target;
   }
+}
+
+template <typename _Key, typename _Value, typename Policy>
+template <typename Cb>
+auto DashTable<_Key, _Value, Policy>::TraverseBySegmentOrder(Cursor curs, Cb&& cb) -> Cursor {
+  uint32_t sid = curs.segment_id(global_depth_);
+  assert(sid < segment_.size());
+  SegmentType* s = segment_[sid];
+  assert(s);
+  uint8_t bid = curs.bucket_id();
+
+  auto dt_cb = [&](const SegmentIterator& it) { cb(iterator{this, sid, it.index, it.slot}); };
+  s->TraverseBucket(bid, std::move(dt_cb));
+
+  ++bid;
+  if (bid == kPhysicalBucketNum) {
+    sid = NextSeg(sid);
+    bid = 0;
+    if (sid >= segment_.size()) {
+      return 0;  // "End of traversal" cursor.
+    }
+  }
+
+  return Cursor{global_depth_, sid, bid};
 }
 
 template <typename _Key, typename _Value, typename Policy>

--- a/src/core/dash_internal.h
+++ b/src/core/dash_internal.h
@@ -459,6 +459,10 @@ template <typename _Key, typename _Value, typename Policy = DefaultSegmentPolicy
   // Cb  accepts (const Iterator&).
   template <typename Cb> void TraverseAll(Cb&& cb) const;
 
+  // Traverses over Segment's bucket bid and calls cb(Iterator& it)
+  // for each slot in the bucket. The iteration goes over a physical bucket.
+  template <typename Cb> void TraverseBucket(uint8_t bid, Cb&& cb);
+
   // Used in test.
   unsigned NumProbingBuckets() const {
     unsigned res = 0;
@@ -1572,6 +1576,15 @@ std::enable_if_t<UV, unsigned> Segment<Key, Value, Policy>::CVCOnBump(uint64_t v
   }
 
   return result;
+}
+
+template <typename Key, typename Value, typename Policy>
+template <typename Cb>
+void Segment<Key, Value, Policy>::TraverseBucket(uint8_t bid, Cb&& cb) {
+  assert(bid < kTotalBuckets);
+
+  const Bucket& b = bucket_[bid];
+  b.ForEachSlot([&](auto* bucket, uint8_t slot, bool probe) { cb(Iterator{bid, slot}); });
 }
 
 template <typename Key, typename Value, typename Policy>

--- a/src/core/dash_test.cc
+++ b/src/core/dash_test.cc
@@ -565,6 +565,30 @@ TEST_F(DashTest, Bucket) {
   EXPECT_EQ(s.size(), num_items);
 }
 
+TEST_F(DashTest, TraverseSegmentOrder) {
+  constexpr auto kNumItems = 50;
+  for (size_t i = 0; i < kNumItems; ++i) {
+    dt_.Insert(i, i);
+  }
+
+  vector<unsigned> nums;
+  auto tr_cb = [&](Dash64::iterator it) {
+    nums.push_back(it->first);
+    VLOG(1) << it.bucket_id() << " " << it.slot_id() << " " << it->first;
+  };
+
+  Dash64::Cursor cursor;
+  do {
+    cursor = dt_.TraverseBySegmentOrder(cursor, tr_cb);
+  } while (cursor);
+
+  sort(nums.begin(), nums.end());
+  nums.resize(unique(nums.begin(), nums.end()) - nums.begin());
+  ASSERT_EQ(kNumItems, nums.size());
+  EXPECT_EQ(0, nums[0]);
+  EXPECT_EQ(kNumItems - 1, nums.back());
+}
+
 struct TestEvictionPolicy {
   static constexpr bool can_evict = true;
   static constexpr bool can_gc = false;

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -18,6 +18,7 @@ extern "C" {
 #include "server/journal/journal.h"
 #include "server/server_state.h"
 #include "server/tiered_storage.h"
+#include "strings/human_readable.h"
 
 ABSL_FLAG(bool, enable_heartbeat_eviction, true,
           "Enable eviction during heartbeat when memory is under pressure.");
@@ -482,6 +483,7 @@ OpResult<DbSlice::ItAndExp> DbSlice::FindInternal(const Context& cntx, std::stri
         return OpStatus::KEY_NOTFOUND;
       }
     }
+    res.it->first.SetTouched(true);
   }
 
   FiberAtomicGuard fg;
@@ -975,7 +977,7 @@ bool DbSlice::Acquire(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
 
 void DbSlice::ReleaseNormalized(IntentLock::Mode mode, DbIndex db_index, std::string_view key) {
   DCHECK_EQ(key, KeyLockArgs::GetLockKey(key));
-  DVLOG(1) << "Release " << IntentLock::ModeName(mode) << " "
+  DVLOG(2) << "Release " << IntentLock::ModeName(mode) << " "
            << " for " << key;
 
   auto& lt = db_arr_[db_index]->trans_locks;
@@ -1196,6 +1198,41 @@ int32_t DbSlice::GetNextSegmentForEviction(int32_t segment_id, DbIndex db_ind) c
   // wraps around if we reached the end
   return db_arr_[db_ind]->prime.NextSeg((size_t)segment_id) %
          db_arr_[db_ind]->prime.GetSegmentCount();
+}
+
+bool DbSlice::CanBeExternalized(PrimeIterator it) {
+  return it->first.ObjType() == OBJ_STRING && !it->second.HasIoPending() &&
+         !it->second.IsExternal() && TieredStorage::EligibleForOffload(it->second.Size());
+}
+
+void DbSlice::ScheduleForOffloadStep(DbIndex db_indx, size_t increase_goal_bytes) {
+  VLOG(1) << "ScheduleForOffloadStep increase_goal_bytes:"
+          << strings::HumanReadableNumBytes(increase_goal_bytes);
+  DCHECK(shard_owner()->tiered_storage());
+  FiberAtomicGuard guard;
+  PrimeTable& pt = db_arr_[db_indx]->prime;
+
+  static PrimeTable::Cursor cursor;
+
+  size_t offloaded_bytes = 0;
+  auto cb = [&](PrimeIterator it) {
+    // TBD check we did not lock it for future transaction
+
+    if (increase_goal_bytes > offloaded_bytes && !(it->first.HasTouched()) &&
+        CanBeExternalized(it)) {
+      shard_owner()->tiered_storage()->ScheduleOffload(db_indx, it);
+      if (it->second.HasIoPending()) {
+        offloaded_bytes += it->second.Size();
+        VLOG(2) << "ScheduleOffload bytes:" << offloaded_bytes;
+      }
+    }
+    it->first.SetTouched(false);
+  };
+
+  // Traverse a single segment every time this function is called.
+  for (int i = 0; i < 60; ++i) {
+    cursor = pt.TraverseBySegmentOrder(cursor, cb);
+  }
 }
 
 void DbSlice::FreeMemWithEvictionStep(DbIndex db_ind, size_t increase_goal_bytes) {

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1213,7 +1213,8 @@ void DbSlice::ScheduleForOffloadStep(DbIndex db_indx, size_t increase_goal_bytes
   auto cb = [&](PrimeIterator it) {
     // TBD check we did not lock it for future transaction
 
-    if (increase_goal_bytes > offloaded_bytes && !(it->first.HasTouched()) &&
+    // If the item is cold (not touched) and can be externalized, schedule it for offload.
+    if (increase_goal_bytes > offloaded_bytes && !(it->first.WasTouched()) &&
         TieredStorage::CanExternalizeEntry(it)) {
       shard_owner()->tiered_storage()->ScheduleOffload(db_indx, it);
       if (it->second.HasIoPending()) {

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -51,6 +51,10 @@ struct SliceEvents {
   size_t misses = 0;
   size_t mutations = 0;
 
+  // ram hit/miss when tiering is enabled
+  size_t ram_hits = 0;
+  size_t ram_misses = 0;
+
   // how many insertions were rejected due to OOM.
   size_t insertion_rejections = 0;
 

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -364,6 +364,8 @@ class DbSlice {
   // Deletes some amount of possible expired items.
   DeleteExpiredStats DeleteExpiredStep(const Context& cntx, unsigned count);
   void FreeMemWithEvictionStep(DbIndex db_indx, size_t increase_goal_bytes);
+  void ScheduleForOffloadStep(DbIndex db_indx, size_t increase_goal_bytes);
+  bool CanBeExternalized(PrimeIterator it);
 
   int32_t GetNextSegmentForEviction(int32_t segment_id, DbIndex db_ind) const;
 

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -365,7 +365,6 @@ class DbSlice {
   DeleteExpiredStats DeleteExpiredStep(const Context& cntx, unsigned count);
   void FreeMemWithEvictionStep(DbIndex db_indx, size_t increase_goal_bytes);
   void ScheduleForOffloadStep(DbIndex db_indx, size_t increase_goal_bytes);
-  bool CanBeExternalized(PrimeIterator it);
 
   int32_t GetNextSegmentForEviction(int32_t segment_id, DbIndex db_ind) const;
 

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -39,7 +39,7 @@ ABSL_FLAG(dfly::MemoryBytesFlag, tiered_max_file_size, dfly::MemoryBytesFlag{},
           "default: 0");
 
 ABSL_FLAG(float, tiered_offload_threshold, 0.5,
-          "The ration of used/max memory above which we run offloading values to disk");
+          "The ratio of used/max memory above which we start offloading values to disk");
 
 ABSL_FLAG(uint32_t, hz, 100,
           "Base frequency at which the server performs other background tasks. "

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -629,8 +629,12 @@ void EngineShard::Heartbeat() {
       db_slice_.FreeMemWithEvictionStep(i, eviction_redline - db_slice_.memory_budget());
     }
 
-    if (tiered_storage_ && UsedMemory() > tiering_redline) {
-      db_slice_.ScheduleForOffloadStep(i, UsedMemory() - tiering_redline);
+    if (tiered_storage_) {
+      size_t offload_bytes = 0;
+      if (UsedMemory() > tiering_redline) {
+        offload_bytes = UsedMemory() - tiering_redline;
+      }
+      db_slice_.ScheduleForOffloadStep(i, offload_bytes);
     }
   }
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1884,6 +1884,8 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
     append("reply_count", reply_stats.send_stats.count);
     append("reply_latency_usec", reply_stats.send_stats.total_duration);
     append("blocked_on_interpreter", m.coordinator_stats.blocked_on_interpreter);
+    append("ram_hits", m.events.ram_hits);
+    append("ram_misses", m.events.ram_misses);
   }
 
   if (should_enter("TIERED", true)) {

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1891,6 +1891,7 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
   if (should_enter("TIERED", true)) {
     append("tiered_entries", total.tiered_entries);
     append("tiered_bytes", total.tiered_size);
+    append("tiered_bytes_human", HumanReadableNumBytes(total.tiered_size));
     append("tiered_reads", m.disk_stats.read_total);
     append("tiered_read_latency_usec", m.disk_stats.read_delay_usec);
     append("tiered_writes", m.tiered_stats.tiered_writes);

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -610,10 +610,8 @@ OpResult<optional<string>> SetCmd::Set(const SetParams& params, string_view key,
   }
 
   if (shard->tiered_storage() &&
-      TieredStorage::EligibleForOffload(value)) {  // external storage enabled.
-    // TODO: we may have a bug if we block the fiber inside UnloadItem - "it" may be invalid
-    // afterwards. handle this
-    shard->tiered_storage()->ScheduleOffload(op_args_.db_cntx.db_index, it, key);
+      TieredStorage::EligibleForOffload(value.size())) {  // external storage enabled.
+    shard->tiered_storage()->ScheduleOffloadWithThrottle(op_args_.db_cntx.db_index, it, key);
   }
 
   if (manual_journal_ && op_args_.shard->journal()) {

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -762,4 +762,9 @@ void TieredStorage::InitiateGrow(size_t grow_size) {
   CHECK(!ec) << "TBD";  // TODO
 }
 
+bool TieredStorage::CanExternalizeEntry(PrimeIterator it) {
+  return it->first.ObjType() == OBJ_STRING && !it->second.HasIoPending() &&
+         !it->second.IsExternal() && EligibleForOffload(it->second.Size());
+}
+
 }  // namespace dfly

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -34,6 +34,8 @@ class TieredStorage {
     return size >= kMinBlobLen;
   }
 
+  static bool CanExternalizeEntry(PrimeIterator it);
+
   // Schedules offloadin of the item, pointed by the iterator, this function can preempt.
   std::error_code ScheduleOffloadWithThrottle(DbIndex db_index, PrimeIterator it,
                                               std::string_view key);

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -56,15 +56,17 @@ class TieredStorage {
 
   std::error_code Read(size_t offset, size_t len, char* dest);
 
-  bool AllowWrites() const;
+  bool IoDeviceUnderloaded() const;
 
  private:
   class InflightWriteRequest;
 
   void WriteSingle(DbIndex db_index, PrimeIterator it, size_t blob_len);
 
-  // Returns a pair consisting of an bool denoting whether we can write to disk, and updated
-  // iterator as this function can yield. 'it' should not be used after the call to this function.
+  // If the io device is overloaded this funciton will yield untill the device is underloaded or
+  // throttle timeout is reached. Returns a pair consisting of an bool denoting whether device is
+  // underloaded and updated iterator as this function can yield. 'it' should not be used after the
+  // call to this function.
   std::pair<bool, PrimeIterator> ThrottleWrites(DbIndex db_index, PrimeIterator it,
                                                 std::string_view key);
 


### PR DESCRIPTION
implement tiering background offloading based on https://junchengyang.com/publication/nsdi24-SIEVE.pdf
When fetching an item we set it as touched item (hot)
A background task running periodically traversing several buckets (continuing from the last place stopped) setting them as untouched items (cold) 
The background task checks if the item is cold (not touched from the last time the traverse set it as cold). If an item is cold and it can be offloaded schedule it for offload.