### PR TITLE
feat(server): Implement CONFIG HELP command

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1486,11 +1486,11 @@ void ServerFamily::Config(CmdArgList args, ConnectionContext* cntx) {
         "RESETSTAT",
         "    Reset statistics reported by the INFO command.",
         "HELP",
-        "    Prints this help."};
+        "    Prints this help.",
+    };
 
     auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
-    rb->SendSimpleStrArr(help_arr);
-    return;
+    return rb->SendSimpleStrArr(help_arr);
   }
 
   if (sub_cmd == "SET") {

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1476,6 +1476,23 @@ void ServerFamily::Config(CmdArgList args, ConnectionContext* cntx) {
   ToUpper(&args[0]);
   string_view sub_cmd = ArgS(args, 0);
 
+  if (sub_cmd == "HELP") {
+    string_view help_arr[] = {
+        "CONFIG <subcommand> [<arg> [value] [opt] ...]. Subcommands are:",
+        "GET <pattern>",
+        "    Return parameters matching the glob-like <pattern> and their values.",
+        "SET <directive> <value>",
+        "    Set the configuration <directive> to <value>.",
+        "RESETSTAT",
+        "    Reset statistics reported by the INFO command.",
+        "HELP",
+        "    Prints this help."};
+
+    auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+    rb->SendSimpleStrArr(help_arr);
+    return;
+  }
+
   if (sub_cmd == "SET") {
     if (args.size() != 3) {
       return cntx->SendError(WrongNumArgsError("config|set"));


### PR DESCRIPTION
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->

Related Issue: https://github.com/dragonflydb/dragonfly/issues/857

The `CONFIG HELP` command is implemented in this PR.
The implementation of the `CONFIG HELP` command in Redis 7.2 was used as a reference.
The notation of the `CONFIG HELP` command in Redis 7.2 is as follows.
````
 1) CONFIG <subcommand> [<arg> [value] [opt] ...] . Subcommands are: .
 2) GET <pattern> .
 3)     Return parameters matching the glob-like <pattern> and their values.
 4) SET <directive> <value> 5) Set the configuration <directive> <value> .
 5)     Set the configuration <directive> to <value>.
 6) RESETSTAT
 7)     Reset statistics reported by the INFO command.
 8) REWRITE
 9)     Rewrite the configuration file.
10) HELP
11)    Prints this help.
````
The `CONFIG REWRITE` command is not yet implemented in the current DragonflyDB.
The newly implemented `CONFIG HELP` command excludes the `CONFIG REWRITE` command.
