### PR TITLE
fix(transaction): Add special barrier for blocking tx

### DIFF
--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -124,21 +124,21 @@ uint32_t Transaction::PhasedBarrier::DEBUG_Count() const {
   return count_.load(memory_order_relaxed);
 }
 
-bool Transaction::SingleClaimBarrier::IsClaimed() const {
+bool Transaction::BatonBarrierrier::IsClaimed() const {
   return claimed_.load(memory_order_relaxed);
 }
 
-bool Transaction::SingleClaimBarrier::TryClaim() {
+bool Transaction::BatonBarrierrier::TryClaim() {
   return !claimed_.exchange(true, memory_order_relaxed);  // false means first means success
 }
 
-void Transaction::SingleClaimBarrier::Close() {
+void Transaction::BatonBarrierrier::Close() {
   DCHECK(claimed_.load(memory_order_relaxed));
   closed_.store(true, memory_order_relaxed);
   ec_.notify();  // release
 }
 
-cv_status Transaction::SingleClaimBarrier::Wait(time_point tp) {
+cv_status Transaction::BatonBarrierrier::Wait(time_point tp) {
   auto cb = [this] { return closed_.load(memory_order_acquire); };
 
   if (tp != time_point::max()) {

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -444,7 +444,7 @@ class Transaction {
   // "Single claim - single modification" barrier. Multiple threads might try to claim it, only one
   // will succeed and will be allowed to modify the guarded object until it closes the barrier.
   // A closed barrier can't be claimed again or re-used in any way.
-  class SingleClaimBarrier {
+  class BatonBarrierrier {
    public:
     bool IsClaimed() const;  // Return if barrier is claimed, only for peeking
     bool TryClaim();         // Return if the barrier was claimed successfully
@@ -611,7 +611,7 @@ class Transaction {
   UniqueSlotChecker unique_slot_checker_;
 
   // Barrier for waking blocking transactions that ensures exclusivity of waking operation.
-  SingleClaimBarrier blocking_barrier_{};
+  BatonBarrierrier blocking_barrier_{};
 
   // Transaction coordinator state, written and read by coordinator thread.
   uint8_t coordinator_state_ = 0;


### PR DESCRIPTION
Currently we assume waking a transaction is exlusive and we ensured exclusivity with

> if (wakeup_requested_.fetch_add(1, memory_order_relaxed) > 0) return

in `NotifySuspended()`

However we ensured no exclusivity with cancelling or timing out. I.e. it was totally possible for a transaction to time out and start preparing the cleanup hops, while another thread would call `NotifySuspended()`. What is more, we removed `COORD_BLOCKED` only after we called `Expire`, so we could be cancelled _while_ we are expiring. This results in a lot of unsafe data parallel accesses.

Another problem here is also that once we do 

> wakeup_requested_.fetch_add(1, memory_order_relaxed)

we technically allow blocking_ec_ in the coordinator to pass. If it wasn't suspended and just reached the check (fast path), it will proceed _without_ waiting for the foreign thread to actually finish modifying the values. Paired with no proper acquire/release semantics later on, this is a very unsafe inter-thread exchange

Instead I suggest to use `SingleClaimBarrier`

> "Single claim - single modification" barrier. Multiple threads might try to claim it, only one
> will succeed and will be allowed to modify the barrier until it releases it.

with proper expiration

> Wait for barrier until time_point, indefinitely if time_point::max() was passed.
> Expiration plays by the same rules as all other threads, it will try to claim the barrier or
> wait for an ongoing modification to release.

It results in very **simple guarantees:** 
* If any actor (blocking controller, expiration, cancellation) has claimed the barrier with `TryClaim()`, it is totally safe to for it perform modifications until `Release()`
* The barrier can be claimed only once and no modifications can be performed without claiming it, so we have no ambiguity on how to interpret `Expire()` during `NotifySuspended()`
* If `TryClaim()` returned false we have to discard our operation, no exceptions, if it returned true, we can expect the transaction to be in a clean state - no one modified it before us since registering in the blocking controller

With those guarantees we also don't need `EXPIRED_Q` and `COORD_BLOCKED`

Linked: 
* #956 (fixes concurrent data access instead of exclusivity of operations)
* #1168 (Adds exclusivity for `NotifySuspended()`, but does it unsafely)


