### PR TITLE
feat(server): Add `MEMORY TRACK ADDRESS` command

### DIFF
--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -341,7 +341,7 @@ void MemoryCmd::Track(CmdArgList args) {
       return cntx_->SendError(parser.Error()->MakeReply());
     }
 
-    atomic_bool error;
+    atomic_bool error{false};
     shard_set->pool()->Await([&](unsigned index, auto*) {
       if (!AllocationTracker::Get().Add(
               {.lower_bound = lower_bound, .upper_bound = upper_bound, .sample_odds = odds})) {
@@ -362,7 +362,7 @@ void MemoryCmd::Track(CmdArgList args) {
       return cntx_->SendError(parser.Error()->MakeReply());
     }
 
-    atomic_bool error;
+    atomic_bool error{false};
     shard_set->pool()->Await([&](unsigned index, auto*) {
       if (!AllocationTracker::Get().Remove(lower_bound, upper_bound)) {
         error.store(true);
@@ -403,7 +403,7 @@ void MemoryCmd::Track(CmdArgList args) {
       return cntx_->SendError("Address must be hex number");
     }
 
-    atomic_bool found;
+    atomic_bool found{false};
     shard_set->pool()->Await([&](unsigned index, auto*) {
       if (mi_heap_check_owned(mi_heap_get_backing(), (void*)ptr)) {
         found.store(true);


### PR DESCRIPTION
Given a hex address, it replies with whether or not this address is currently allocated by mimalloc's backing heap.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->