### PR TITLE
fix(zset): ignore cancelled op status in BZPopMinMax

### DIFF
--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1335,6 +1335,7 @@ void BZPopMinMax(CmdArgList args, ConnectionContext* cntx, bool is_max) {
   switch (popped_key.status()) {
     case OpStatus::WRONG_TYPE:
       return rb->SendError(kWrongTypeErr);
+    case OpStatus::CANCELLED:
     case OpStatus::TIMED_OUT:
       return rb->SendNullArray();
     default:


### PR DESCRIPTION
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->

Been seeing a few cases of `zset_family.cc:1344] Unexpected error 17`, which looks like its `CANCELLED`

This ignores `OpStatus::CANCELLED` in `BZPopMinMax`, which matches what `ListFamily::BPopGeneric` does (looks like it can be cancelled if the socket has an error)