### PR TITLE
 server(json): implement JSON.MSET command

### DIFF
--- a/src/server/json_family.h
+++ b/src/server/json_family.h
@@ -41,6 +41,7 @@ class JsonFamily {
   static void Debug(CmdArgList args, ConnectionContext* cntx);
   static void Resp(CmdArgList args, ConnectionContext* cntx);
   static void Set(CmdArgList args, ConnectionContext* cntx);
+  static void MSet(CmdArgList args, ConnectionContext* cntx);
 };
 
 }  // namespace dfly

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -1050,4 +1050,30 @@ TEST_F(JsonFamilyTest, Set) {
   EXPECT_EQ(resp, R"([{"a":2,"b":8,"c":[1,2,3]}])");
 }
 
+TEST_F(JsonFamilyTest, MSet) {
+  string json1 = R"(
+    {"abc":1}
+  )";
+
+  string json2 = R"(
+    {"def":{"num1":16,"num2":32}}
+  )";
+
+  string json3 = R"(
+    {"def":{"num3":64},"ghi":{"num3":128}}}
+  )";
+
+  auto resp = Run({"JSON.MSET", "json1", "$", json1, "json2", "$", json2, "json3", "$", json3});
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run({"JSON.GET", "json1", "$"});
+  EXPECT_EQ(resp, R"({"abc":1})");
+
+  resp = Run({"JSON.GET", "json2", "$"});
+  EXPECT_EQ(resp, R"({"def":{"num1":16,"num2":32}})");
+
+  resp = Run({"JSON.GET", "json3", "$"});
+  EXPECT_EQ(resp, R"({"def":{"num3":64},"ghi":{"num3":128}}})");
+}
+
 }  // namespace dfly


### PR DESCRIPTION
FIxes: #2021 
This is an attempt to implement JSON.MSET command. JSON.MSET is atomic, hence, all given additions or updates should be applied or not.
The logic backups the original data before each change, and whether one of the keys couldn't be updated for any reason, the changes that were affected before the error, are being rolled back.