### PR TITLE
bug: DFLY_PASSWORD environment variable deprecation

### DIFF
--- a/contrib/charts/dragonfly/Chart.yaml
+++ b/contrib/charts/dragonfly/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v1.14.1
+version: v1.14.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/contrib/charts/dragonfly/ci/passwordsecret-values.golden.yaml
+++ b/contrib/charts/dragonfly/ci/passwordsecret-values.golden.yaml
@@ -101,7 +101,7 @@ spec:
             requests: {}
           
           env:
-            - name: DFLY_PASSWORD
+            - name: DFLY_requirepass
               valueFrom:
                 secretKeyRef:
                   name: dfly-password

--- a/contrib/charts/dragonfly/ci/persistence-and-existing-secret.golden.yaml
+++ b/contrib/charts/dragonfly/ci/persistence-and-existing-secret.golden.yaml
@@ -104,7 +104,7 @@ spec:
             - mountPath: /data
               name: "test-data"
           env:
-            - name: DFLY_PASSWORD
+            - name: DFLY_requirepass
               valueFrom:
                 secretKeyRef:
                   name: dfly-password

--- a/contrib/charts/dragonfly/ci/priorityclassname-values.golden.yaml
+++ b/contrib/charts/dragonfly/ci/priorityclassname-values.golden.yaml
@@ -1,4 +1,13 @@
 ---
+# Source: dragonfly/templates/extra-manifests.yaml
+apiVersion: scheduling.k8s.io/v1
+description: This priority class should be used only for tests.
+globalDefault: false
+kind: PriorityClass
+metadata:
+  name: high-priority
+value: 1000000
+---
 # Source: dragonfly/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -92,12 +101,3 @@ spec:
           resources:
             limits: {}
             requests: {}
----
-# Source: dragonfly/templates/extra-manifests.yaml
-apiVersion: scheduling.k8s.io/v1
-description: This priority class should be used only for tests.
-globalDefault: false
-kind: PriorityClass
-metadata:
-  name: high-priority
-value: 1000000

--- a/contrib/charts/dragonfly/ci/tls-values.golden.yaml
+++ b/contrib/charts/dragonfly/ci/tls-values.golden.yaml
@@ -123,7 +123,7 @@ spec:
             - mountPath: /etc/dragonfly/tls
               name: tls
           env:
-            - name: DFLY_PASSWORD
+            - name: DFLY_requirepass
               valueFrom:
                 secretKeyRef:
                   name: dfly-password

--- a/contrib/charts/dragonfly/templates/_pod.tpl
+++ b/contrib/charts/dragonfly/templates/_pod.tpl
@@ -91,7 +91,13 @@ containers:
     {{- include "dragonfly.volumemounts" . | trim | nindent 4 }}
     {{- if .Values.passwordFromSecret.enable }}
     env:
+    {{- $appVersion := .Chart.AppVersion }}
+    {{- $imageTag := .Values.image.tag | default $appVersion }}
+    {{- if semverCompare ">=14.0.0" $imageTag }}
       - name: DFLY_PASSWORD
+    {{- else }}
+      - name: DFLY_requirepass
+    {{- end }}
         valueFrom:
           secretKeyRef:
             name: {{ .Values.passwordFromSecret.existingSecret.name }}

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,0 +1,2 @@
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=


### PR DESCRIPTION
If the image.tag version is equal to 14.0.0 or greater then specify the DFLY_requirepass environment variable. Otherwise use the DFLY_PASSWORD environment variable.
