### PR TITLE
fix: wrongly printing timedout emoji on test failures

### DIFF
--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -38,8 +38,15 @@ runs:
         export UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 # to crash on errors
 
         timeout 20m pytest -m "${{inputs.filter}}" --color=yes --json-report --json-report-file=report.json dragonfly --ignore=dragonfly/replication_test.py --log-cli-level=INFO || code=$?
-        if [[ $code -ne 0 ]]; then
+
+        # timeout returns 124 if we exceeded the timeout duration
+        if [[ $code -eq 124 ]]; then
           echo "TIMEDOUT=1">> "$GITHUB_OUTPUT";
+          exit 1
+        fi
+
+        # when a test fails in pytest it returns 1 but there are other return codes as well so we just check if the code is non zero
+        if [[ $code -ne 0 ]]; then
           exit 1
         fi
 
@@ -57,8 +64,15 @@ runs:
           timeout 20m pytest -m "${{inputs.filter}}" --color=yes --json-report \
             --json-report-file=rep1_report.json dragonfly/replication_test.py --log-cli-level=INFO \
             --df alsologtostderr $1 $2 || code=$?
-          if [[ $code -ne 0 ]]; then
+
+          # timeout returns 124 if we exceeded the timeout duration
+          if [[ $code -eq 124 ]]; then
             echo "TIMEDOUT=1">> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          # when a test fails in pytest it returns 1 but there are other return codes as well so we just check if the code is non zero
+          if [[ $code -ne 0 ]]; then
             exit 1
           fi
         }
@@ -73,11 +87,11 @@ runs:
         TIMEDOUT_STEP_1: ${{ steps.first.outputs.TIMEDOUT }}
         TIMEDOUT_STEP_2: ${{ steps.second.outputs.TIMEDOUT }}
       run: |
-        if [[ "${{ env.TIMEDOUT_STEP_1 }}" -eq 1 ]] || [[ "${{ env.TIMEDOUT_STEP_2 }}" -eq 1 ]]; then
           echo "🪵🪵🪵🪵🪵🪵 Latest log before timeout 🪵🪵🪵🪵🪵🪵\n\n"
           ls -t /tmp/dragonfly*log*INFO* | head -n 1 | xargs cat
           echo "🪵🪵🪵🪵🪵🪵 Latest log before timeout end 🪵🪵🪵🪵🪵🪵\n\n"
 
+        if [[ "${{ env.TIMEDOUT_STEP_1 }}" -eq 1 ]] || [[ "${{ env.TIMEDOUT_STEP_2 }}" -eq 1 ]]; then
           echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑"
           echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 TESTS TIMEDOUT 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑"
           echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑"

--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -87,9 +87,9 @@ runs:
         TIMEDOUT_STEP_1: ${{ steps.first.outputs.TIMEDOUT }}
         TIMEDOUT_STEP_2: ${{ steps.second.outputs.TIMEDOUT }}
       run: |
-          echo "🪵🪵🪵🪵🪵🪵 Latest log before timeout 🪵🪵🪵🪵🪵🪵\n\n"
-          ls -t /tmp/dragonfly*log*INFO* | head -n 1 | xargs cat
-          echo "🪵🪵🪵🪵🪵🪵 Latest log before timeout end 🪵🪵🪵🪵🪵🪵\n\n"
+        echo "🪵🪵🪵🪵🪵🪵 Latest log before timeout 🪵🪵🪵🪵🪵🪵\n\n"
+        ls -t /tmp/dragonfly*log*INFO* | head -n 1 | xargs cat
+        echo "🪵🪵🪵🪵🪵🪵 Latest log before timeout end 🪵🪵🪵🪵🪵🪵\n\n"
 
         if [[ "${{ env.TIMEDOUT_STEP_1 }}" -eq 1 ]] || [[ "${{ env.TIMEDOUT_STEP_2 }}" -eq 1 ]]; then
           echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑"

--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -37,7 +37,7 @@ runs:
         export DRAGONFLY_PATH="${GITHUB_WORKSPACE}/${{inputs.build-folder-name}}/${{inputs.dfly-executable}}"
         export UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 # to crash on errors
 
-        timeout 20m pytest -m "${{inputs.filter}}" --color=yes --json-report --json-report-file=report.json dragonfly --ignore=dragonfly/replication_test.py --log-cli-level=INFO || code=$?
+        timeout 1m pytest -m "${{inputs.filter}}" --color=yes --json-report --json-report-file=report.json dragonfly --ignore=dragonfly/replication_test.py --log-cli-level=INFO || code=$?
 
         # timeout returns 124 if we exceeded the timeout duration
         if [[ $code -eq 124 ]]; then

--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -37,7 +37,7 @@ runs:
         export DRAGONFLY_PATH="${GITHUB_WORKSPACE}/${{inputs.build-folder-name}}/${{inputs.dfly-executable}}"
         export UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 # to crash on errors
 
-        timeout 1m pytest -m "${{inputs.filter}}" --color=yes --json-report --json-report-file=report.json dragonfly --ignore=dragonfly/replication_test.py --log-cli-level=INFO || code=$?
+        timeout 20m pytest -m "${{inputs.filter}}" --color=yes --json-report --json-report-file=report.json dragonfly --ignore=dragonfly/replication_test.py --log-cli-level=INFO || code=$?
 
         # timeout returns 124 if we exceeded the timeout duration
         if [[ $code -eq 124 ]]; then

--- a/tests/dragonfly/acl_family_test.py
+++ b/tests/dragonfly/acl_family_test.py
@@ -11,7 +11,6 @@ from . import dfly_args
 
 @pytest.mark.asyncio
 async def test_acl_setuser(async_client):
-    assert False
     await async_client.execute_command("ACL SETUSER kostas")
     result = await async_client.execute_command("ACL LIST")
     assert 2 == len(result)

--- a/tests/dragonfly/acl_family_test.py
+++ b/tests/dragonfly/acl_family_test.py
@@ -11,6 +11,7 @@ from . import dfly_args
 
 @pytest.mark.asyncio
 async def test_acl_setuser(async_client):
+    assert False
     await async_client.execute_command("ACL SETUSER kostas")
     result = await async_client.execute_command("ACL LIST")
     assert 2 == len(result)

--- a/tests/dragonfly/requirements.txt
+++ b/tests/dragonfly/requirements.txt
@@ -22,3 +22,4 @@ boto3==1.28.55
 redis-om==0.2.1
 pytest-emoji==0.2.0
 pytest-icdiff==0.8
+pytest-timeout==2.2.0


### PR DESCRIPTION
* fix wrongly printing timedout emoji on non timedout test failures
* add pytest-timeout as dependency in tests/dragonfly/requirements