### PR TITLE
chore(server): replica not accumulate multi commands untill exec

### DIFF
--- a/src/server/cluster/cluster_shard_migration.cc
+++ b/src/server/cluster/cluster_shard_migration.cc
@@ -62,7 +62,7 @@ void ClusterShardMigration::FullSyncShardFb(Context* cntx) {
   io::PrefixSource ps{leftover_buf_->InputBuffer(), Sock()};
 
   JournalReader reader{&ps, 0};
-  TransactionReader tx_reader{};
+  TransactionReader tx_reader{false};
 
   while (!cntx->IsCancelled()) {
     if (cntx->IsCancelled())

--- a/src/server/journal/tx_executor.cc
+++ b/src/server/journal/tx_executor.cc
@@ -71,7 +71,6 @@ void TransactionData::AddEntry(journal::ParsedEntry&& entry) {
     default:
       DCHECK(false) << "Unsupported opcode";
   }
-  return;
 }
 
 bool TransactionData::IsGlobalCmd() const {

--- a/src/server/journal/tx_executor.cc
+++ b/src/server/journal/tx_executor.cc
@@ -12,6 +12,8 @@
 using namespace std;
 using namespace facade;
 
+ABSL_DECLARE_FLAG(bool, enable_multi_shard_sync);
+
 namespace dfly {
 
 bool MultiShardExecution::InsertTxToSharedMap(TxId txid, uint32_t shard_cnt) {
@@ -47,32 +49,29 @@ void MultiShardExecution::CancelAllBlockingEntities() {
   }
 }
 
-bool TransactionData::AddEntry(journal::ParsedEntry&& entry) {
+void TransactionData::AddEntry(journal::ParsedEntry&& entry) {
   ++journal_rec_count;
   opcode = entry.opcode;
 
   switch (entry.opcode) {
     case journal::Op::PING:
-      return true;
+      return;
     case journal::Op::FIN:
-      return true;
+      return;
     case journal::Op::EXPIRED:
     case journal::Op::COMMAND:
+    case journal::Op::MULTI_COMMAND:
       commands.push_back(std::move(entry.cmd));
       [[fallthrough]];
     case journal::Op::EXEC:
       shard_cnt = entry.shard_cnt;
       dbid = entry.dbid;
       txid = entry.txid;
-      return true;
-    case journal::Op::MULTI_COMMAND:
-      commands.push_back(std::move(entry.cmd));
-      dbid = entry.dbid;
-      return false;
+      return;
     default:
       DCHECK(false) << "Unsupported opcode";
   }
-  return false;
+  return;
 }
 
 bool TransactionData::IsGlobalCmd() const {
@@ -98,8 +97,7 @@ bool TransactionData::IsGlobalCmd() const {
 
 TransactionData TransactionData::FromSingle(journal::ParsedEntry&& entry) {
   TransactionData data;
-  bool res = data.AddEntry(std::move(entry));
-  DCHECK(res);
+  data.AddEntry(std::move(entry));
   return data;
 }
 
@@ -114,7 +112,8 @@ std::optional<TransactionData> TransactionReader::NextTxData(JournalReader* read
     // Check if journal command can be executed right away.
     // Expiration checks lock on master, so it never conflicts with running multi transactions.
     if (res->opcode == journal::Op::EXPIRED || res->opcode == journal::Op::COMMAND ||
-        res->opcode == journal::Op::PING || res->opcode == journal::Op::FIN)
+        res->opcode == journal::Op::PING || res->opcode == journal::Op::FIN ||
+        (res->opcode == journal::Op::MULTI_COMMAND && !accumulate_multi_))
       return TransactionData::FromSingle(std::move(res.value()));
 
     // Otherwise, continue building multi command.
@@ -123,7 +122,9 @@ std::optional<TransactionData> TransactionReader::NextTxData(JournalReader* read
 
     auto txid = res->txid;
     auto& txdata = current_[txid];
-    if (txdata.AddEntry(std::move(res.value()))) {
+    txdata.AddEntry(std::move(res.value()));
+    // accumulate multi until we get exec opcode.
+    if (txdata.opcode == journal::Op::EXEC) {
       auto out = std::move(txdata);
       current_.erase(txid);
       return out;

--- a/src/server/journal/tx_executor.h
+++ b/src/server/journal/tx_executor.h
@@ -38,9 +38,8 @@ class MultiShardExecution {
 // This class holds the commands of transaction in single shard.
 // Once all commands were received, the transaction can be executed.
 struct TransactionData {
-  // Update the data from ParsedEntry and return true if all shard transaction commands were
-  // received.
-  bool AddEntry(journal::ParsedEntry&& entry);
+  // Update the data from ParsedEntry
+  void AddEntry(journal::ParsedEntry&& entry);
 
   bool IsGlobalCmd() const;
 
@@ -58,11 +57,14 @@ struct TransactionData {
 // The journal stream can contain interleaved data for multiple multi transactions,
 // expiries and out of order executed transactions that need to be grouped on the replica side.
 struct TransactionReader {
+  TransactionReader(bool accumulate_multi) : accumulate_multi_(accumulate_multi) {
+  }
   std::optional<TransactionData> NextTxData(JournalReader* reader, Context* cntx);
 
  private:
   // Stores ongoing multi transaction data.
   absl::flat_hash_map<TxId, TransactionData> current_;
+  bool accumulate_multi_ = false;
 };
 
 }  // namespace dfly

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -784,7 +784,7 @@ void DflyShardReplica::StableSyncDflyReadFb(Context* cntx) {
   io::PrefixSource ps{prefix, Sock()};
 
   JournalReader reader{&ps, 0};
-  TransactionReader tx_reader{};
+  TransactionReader tx_reader{use_multi_shard_exe_sync_};
 
   if (master_context_.version > DflyVersion::VER0) {
     acks_fb_ = fb2::Fiber("shard_acks", &DflyShardReplica::StableSyncDflyAcksFb, this, cntx);
@@ -803,17 +803,25 @@ void DflyShardReplica::StableSyncDflyReadFb(Context* cntx) {
 
     last_io_time_ = Proactor()->GetMonotonicTimeNs();
 
-    if (tx_data->opcode != journal::Op::PING) {
+    if (tx_data->opcode == journal::Op::PING) {
+      force_ping_ = true;
+      journal_rec_executed_.fetch_add(1, std::memory_order_relaxed);
+    } else if (tx_data->opcode == journal::Op::EXEC) {
+      if (use_multi_shard_exe_sync_) {
+        InsertTxDataToShardResource(std::move(*tx_data));
+      } else {
+        // On no shard sync mode we execute multi commands once they are recived, therefor when
+        // revieving exec opcode we only increase the journal counting.
+        DCHECK_EQ(tx_data->commands.size(), 0u);
+        journal_rec_executed_.fetch_add(1, std::memory_order_relaxed);
+      }
+    } else {
       if (use_multi_shard_exe_sync_) {
         InsertTxDataToShardResource(std::move(*tx_data));
       } else {
         ExecuteTxWithNoShardSync(std::move(*tx_data), cntx);
       }
-    } else {
-      force_ping_ = true;
-      journal_rec_executed_.fetch_add(1, std::memory_order_relaxed);
     }
-
     waker_.notify();
   }
 }

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -810,8 +810,8 @@ void DflyShardReplica::StableSyncDflyReadFb(Context* cntx) {
       if (use_multi_shard_exe_sync_) {
         InsertTxDataToShardResource(std::move(*tx_data));
       } else {
-        // On no shard sync mode we execute multi commands once they are recived, therefor when
-        // revieving exec opcode we only increase the journal counting.
+        // On no shard sync mode we execute multi commands once they are recieved, therefor when
+        // receiving exec opcode, we only increase the journal counting.
         DCHECK_EQ(tx_data->commands.size(), 0u);
         journal_rec_executed_.fetch_add(1, std::memory_order_relaxed);
       }


### PR DESCRIPTION
fixes #2544 
when enable_multi_shard_sync flag is false we do not sync execution of multi commands between shards in replication.
Now we will not accumulate the multi commands as well but will just execute them once we get the journal change in replica