### PR TITLE
fix(tiering tests): introduce wait until tiering entries num EQ/GT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,8 +118,8 @@ jobs:
       - name: C++ Unit Tests
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          echo Run tiered_storage_test
-          GLOG_alsologtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1,tiered_storage=2 ./tiered_storage_test
+          echo Run ctest -V -L DFLY
+          GLOG_alsologtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1,tiered_storage=2 ctest -V -L DFLY
 
           echo "Running tests with --force_epoll"
 
@@ -137,10 +137,10 @@ jobs:
           echo "Finished running tests with --force_epoll"
 
           echo "Running tests with --cluster_mode=emulated"
-          FLAGS_cluster_mode=emulated ctest -V -L DFLY
+          GLOG_alsologtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1,tiered_storage=2 FLAGS_cluster_mode=emulated ctest -V -L DFLY
 
           echo "Running tests with both --cluster_mode=emulated & --lock_on_hashtags"
-          FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true ctest -V -L DFLY
+          GLOG_alsologtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1,tiered_storage=2 FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true ctest -V -L DFLY
 
           ./dragonfly_test
           ./multi_test --multi_exec_mode=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,8 +118,8 @@ jobs:
       - name: C++ Unit Tests
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          echo Run ctest -V -L DFLY
-          GLOG_alsologtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 ctest -V -L DFLY
+          echo Run tiered_storage_test
+          GLOG_alsologtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1,tiered_storage=2 ./tiered_storage_test
 
           echo "Running tests with --force_epoll"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/build
           echo Run ctest -V -L DFLY
-          GLOG_alsologtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1,tiered_storage=2 ctest -V -L DFLY
+          GLOG_alsologtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 ctest -V -L DFLY
 
           echo "Running tests with --force_epoll"
 
@@ -137,10 +137,10 @@ jobs:
           echo "Finished running tests with --force_epoll"
 
           echo "Running tests with --cluster_mode=emulated"
-          GLOG_alsologtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1,tiered_storage=2 FLAGS_cluster_mode=emulated ctest -V -L DFLY
+          FLAGS_cluster_mode=emulated ctest -V -L DFLY
 
           echo "Running tests with both --cluster_mode=emulated & --lock_on_hashtags"
-          GLOG_alsologtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1,tiered_storage=2 FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true ctest -V -L DFLY
+          FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true ctest -V -L DFLY
 
           ./dragonfly_test
           ./multi_test --multi_exec_mode=1

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -17,6 +17,7 @@
 
 namespace dfly {
 using namespace facade;
+using namespace std;
 
 class TestConnection : public facade::Connection {
  public:
@@ -123,6 +124,10 @@ class BaseFamilyTest : public ::testing::Test {
 
   // Wait for a locked key to unlock. Aborts after timeout seconds passed.
   void WaitUntilLocked(DbIndex db_index, std::string_view key, double timeout = 3);
+
+  // Wait until condition_cb returns true or timeout reached. Returns condition_cb value
+  bool WaitUntilCondition(std::function<bool()> condition_cb,
+                          std::chrono::milliseconds timeout_ms = 100ms);
 
   std::string GetId() const;
   size_t SubscriberMessagesLen(std::string_view conn_id) const;

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -377,7 +377,6 @@ void TieredStorage::FinishIoRequest(int io_res, InflightWriteRequest* req) {
   if (shutdown_) {
     return;
   }
-  CHECK(db_arr_[req->db_index()]);
   PerDb* db = db_arr_[req->db_index()];
   auto& bin_record = db->bin_map[req->bin_index()];
   if (io_res < 0) {

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -579,6 +579,9 @@ void TieredStorage::WriteSingle(DbIndex db_index, PrimeIterator it, size_t blob_
   it->second.SetIoPending(true);
 
   auto cb = [this, req, db_index](int io_res) {
+    if (shutdown_) {
+      return;
+    }
     PrimeTable* pt = db_slice_.GetTables(db_index).first;
 
     absl::Cleanup cleanup = [this, req]() {

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -372,6 +372,7 @@ TieredStats TieredStorage::GetStats() const {
 }
 
 void TieredStorage::FinishIoRequest(int io_res, InflightWriteRequest* req) {
+  CHECK(db_arr_[req->db_index()]);
   PerDb* db = db_arr_[req->db_index()];
   auto& bin_record = db->bin_map[req->bin_index()];
   if (io_res < 0) {

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -360,6 +360,8 @@ void TieredStorage::Free(PrimeIterator it, DbTableStats* stats) {
 }
 
 void TieredStorage::Shutdown() {
+  VLOG(1) << "Shutdown TieredStorage";
+  shutdown_ = true;
   io_mgr_.Shutdown();
 }
 
@@ -372,6 +374,9 @@ TieredStats TieredStorage::GetStats() const {
 }
 
 void TieredStorage::FinishIoRequest(int io_res, InflightWriteRequest* req) {
+  if (shutdown_) {
+    return;
+  }
   CHECK(db_arr_[req->db_index()]);
   PerDb* db = db_arr_[req->db_index()];
   auto& bin_record = db->bin_map[req->bin_index()];

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -82,6 +82,7 @@ class TieredStorage {
   TieredStats stats_;
   size_t max_file_size_;
   size_t allocated_size_ = 0;
+  bool shutdown_ = false;
 };
 
 }  // namespace dfly


### PR DESCRIPTION
fixes #2541 
Tiering unit tests might fail in github as we wait for fixed time 20 mili for writing to disc.
This PR introduces wait until condition function util for unit tests 
Tiering unit tests use this function to wait untill the tiered entries counter is updated or fail on timeout