### PR TITLE
fix: make sure SCRIPT FLUSH concludes

### DIFF
--- a/src/core/interpreter.h
+++ b/src/core/interpreter.h
@@ -9,7 +9,7 @@
 #include <string_view>
 
 #include "core/core_types.h"
-#include "core/fibers.h"
+#include "util/fibers/synchronization.h"
 
 typedef struct lua_State lua_State;
 
@@ -141,7 +141,6 @@ class InterpreterManager {
     // We pre-allocate the backing storage during initialization and
     // start storing pointers to slots in the available vector.
     storage_.reserve(num);
-    available_.reserve(num);
   }
 
   // Borrow interpreter. Always return it after usage.
@@ -152,9 +151,13 @@ class InterpreterManager {
   void Reset();
 
  private:
-  EventCount waker_;
+  util::fb2::EventCount waker_, reset_ec_;
   std::vector<Interpreter*> available_;
   std::vector<Interpreter> storage_;
+
+  util::fb2::Mutex reset_mu_;  // Acts as a singleton.
+
+  unsigned return_untracked_ = 0;  // Number of returned interpreters during reset.
 };
 
 }  // namespace dfly

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1679,8 +1679,8 @@ void Service::CallSHA(CmdArgList args, string_view sha, Interpreter* interpreter
   ServerState::tlocal()->RecordCallLatency(sha, (end - start) / 1000);
 }
 
-optional<ScriptMgr::ScriptParams> LoadScipt(string_view sha, ScriptMgr* script_mgr,
-                                            Interpreter* interpreter) {
+optional<ScriptMgr::ScriptParams> LoadScript(string_view sha, ScriptMgr* script_mgr,
+                                             Interpreter* interpreter) {
   auto ss = ServerState::tlocal();
 
   if (!interpreter->Exists(sha)) {
@@ -1808,7 +1808,7 @@ void Service::EvalInternal(CmdArgList args, const EvalArgs& eval_args, Interpret
     return cntx->SendError(facade::kScriptNotFound);
   }
 
-  auto params = LoadScipt(eval_args.sha, server_family_.script_mgr(), interpreter);
+  auto params = LoadScript(eval_args.sha, server_family_.script_mgr(), interpreter);
   if (!params)
     return cntx->SendError(facade::kScriptNotFound);
 

--- a/src/server/script_mgr.cc
+++ b/src/server/script_mgr.cc
@@ -287,7 +287,7 @@ void ScriptMgr::FlushAllScript() {
   lock_guard lk{mu_};
   db_.clear();
 
-  shard_set->pool()->Await([](auto index, auto* pb) {
+  shard_set->pool()->AwaitFiberOnAll([](auto* pb) {
     ServerState* ss = ServerState::tlocal();
     ss->ResetInterpreter();
   });


### PR DESCRIPTION
InterpreterManager::Reset creates now a new storage for interpreters,
 and waits for the old ones to be returned.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->