### PR TITLE
fix: do not migrate during connection close

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -502,20 +502,15 @@ void Connection::OnShutdown() {
 }
 
 void Connection::OnPreMigrateThread() {
-  // If we migrating to another io_uring we should cancel any pending requests we have.
-  if (break_cb_engaged_) {
-    socket_->CancelOnErrorCb();
-    break_cb_engaged_ = false;
-  }
+  CHECK(!cc_->conn_closing);
+
+  socket_->CancelOnErrorCb();
 }
 
 void Connection::OnPostMigrateThread() {
   // Once we migrated, we should rearm OnBreakCb callback.
   if (breaker_cb_) {
-    DCHECK(!break_cb_engaged_);
-
     socket_->RegisterOnErrorCb([this](int32_t mask) { this->OnBreakCb(mask); });
-    break_cb_engaged_ = true;
   }
 
   // Update tl variables
@@ -594,14 +589,11 @@ void Connection::HandleRequests() {
       cc_.reset(service_->CreateContext(peer, this));
       if (breaker_cb_) {
         socket_->RegisterOnErrorCb([this](int32_t mask) { this->OnBreakCb(mask); });
-        break_cb_engaged_ = true;
       }
 
       ConnectionFlow(peer);
 
-      if (break_cb_engaged_) {
-        socket_->CancelOnErrorCb();
-      }
+      socket_->CancelOnErrorCb();  // noop if nothing is registered.
 
       cc_.reset();
     }
@@ -975,14 +967,13 @@ void Connection::OnBreakCb(int32_t mask) {
           << cc_->reply_builder()->IsSendActive() << " " << cc_->reply_builder()->GetError();
 
   cc_->conn_closing = true;
-  break_cb_engaged_ = false;  // do not attempt to cancel it.
 
   breaker_cb_(mask);
   evc_.notify();  // Notify dispatch fiber.
 }
 
 void Connection::HandleMigrateRequest() {
-  if (!migration_request_) {
+  if (cc_->conn_closing || !migration_request_) {
     return;
   }
 
@@ -996,6 +987,7 @@ void Connection::HandleMigrateRequest() {
   // We don't support migrating with subscriptions as it would require moving thread local
   // handles. We can't check above, as the queue might have contained a subscribe request.
   if (cc_->subscriptions == 0) {
+    stats_->num_migrations++;
     migration_request_ = nullptr;
 
     DecreaseStatsOnClose();

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -401,7 +401,6 @@ class Connection : public util::Connection {
   std::string name_;
 
   unsigned parser_error_ = 0;
-  bool break_cb_engaged_ = false;
 
   BreakerCb breaker_cb_;
   std::unique_ptr<Shutdown> shutdown_cb_;

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -20,7 +20,7 @@ constexpr size_t kSizeConnStats = sizeof(ConnectionStats);
 
 ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
   // To break this code deliberately if we add/remove a field to this struct.
-  static_assert(kSizeConnStats == 104u);
+  static_assert(kSizeConnStats == 112u);
 
   ADD(read_buf_capacity);
   ADD(dispatch_queue_entries);
@@ -36,6 +36,7 @@ ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
   ADD(num_conns);
   ADD(num_replicas);
   ADD(num_blocked_clients);
+  ADD(num_migrations);
 
   return *this;
 }

--- a/src/facade/facade_types.h
+++ b/src/facade/facade_types.h
@@ -61,7 +61,7 @@ struct ConnectionStats {
   uint32_t num_conns = 0;
   uint32_t num_replicas = 0;
   uint32_t num_blocked_clients = 0;
-
+  uint64_t num_migrations = 0;
   ConnectionStats& operator+=(const ConnectionStats& o);
 };
 

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1441,6 +1441,9 @@ void DbSlice::TrackKeys(const facade::Connection::WeakRef& conn, const ArgSlice&
 }
 
 void DbSlice::SendInvalidationTrackingMessage(std::string_view key) {
+  if (client_tracking_map_.empty())
+    return;
+
   auto it = client_tracking_map_.find(key);
   if (it != client_tracking_map_.end()) {
     // notify all the clients.

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1859,6 +1859,7 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
     append("total_pipelined_commands", conn_stats.pipelined_cmd_cnt);
     append("pipelined_latency_usec", conn_stats.pipelined_cmd_latency);
     append("total_net_input_bytes", conn_stats.io_read_bytes);
+    append("connection_migrations", conn_stats.num_migrations);
     append("total_net_output_bytes", reply_stats.io_write_bytes);
     append("instantaneous_input_kbps", -1);
     append("instantaneous_output_kbps", -1);


### PR DESCRIPTION
Fixes #2569
Before the change we had a corner case where Dragonfly would call OnPreMigrateThread but would not call CancelOnErrorCb because OnBreakCb has already been called (it resets break_cb_engaged_)

On the other hand in OnPostMigrateThread we called RegisterOnErrorCb if breaker_cb_ which resulted in double registration. This change simplifies the logic by removing break_cb_engaged_ flag since CancelOnErrorCb is safe to call if nothing is registered. Moreover, we now skip Migrate flow if a socket is being closed.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->