### PR TITLE
feat(pytest): More types for seeder

### DIFF
--- a/src/core/interpreter.cc
+++ b/src/core/interpreter.cc
@@ -70,6 +70,40 @@ void PushError(lua_State* lua, string_view error, bool trace = true) {
   lua_settable(lua, -3);
 }
 
+struct StringCollectorTranslator : public ObjectExplorer {
+  void OnString(std::string_view str) final {
+    values.emplace_back(str);
+  }
+
+  void OnArrayStart(unsigned len) final {
+    CHECK(values.empty());
+    values.reserve(len);
+  }
+  void OnArrayEnd() final {
+  }
+
+  void OnBool(bool b) final {
+    OnString(absl::AlphaNum(b).Piece());
+  }
+  void OnDouble(double d) final {
+    OnString(absl::AlphaNum(d).Piece());
+  }
+  void OnInt(int64_t val) final {
+    OnString(absl::AlphaNum(val).Piece());
+  }
+  void OnNil() final {
+    OnString("");
+  }
+  void OnStatus(std::string_view str) final {
+    OnString(absl::AlphaNum(str).Piece());
+  }
+  void OnError(std::string_view str) final {
+    LOG(ERROR) << str;
+  }
+
+  vector<string> values;
+};
+
 class RedisTranslator : public ObjectExplorer {
  public:
   RedisTranslator(lua_State* lua) : lua_(lua) {
@@ -306,37 +340,59 @@ void ToHex(const uint8_t* src, char* dest) {
 }
 
 int DragonflyHashCommand(lua_State* lua) {
-  int argc = lua_gettop(lua);
-  if (argc != 2) {
-    lua_pushstring(lua, "wrong number of arguments");
-    return lua_error(lua);
-  }
-
   XXH64_hash_t hash = absl::bit_cast<XXH64_hash_t>(lua_tointeger(lua, 1));
-  auto update_hash = [&hash](string_view sv) { hash = XXH64(sv.data(), sv.length(), hash); };
+  bool requires_sort = lua_toboolean(lua, 2);
 
-  auto digest_value = [&hash, &update_hash, lua](int pos) {
-    if (int type = lua_type(lua, pos); type == LUA_TSTRING) {
-      const char* str = lua_tostring(lua, pos);
-      update_hash(string_view{str, strlen(str)});
-    } else {
-      CHECK_EQ(type, LUA_TNUMBER) << "Only strings and integers can be hashed";
-      update_hash(to_string(lua_tointeger(lua, pos)));
-    }
-  };
+  lua_remove(lua, 1);
+  lua_remove(lua, 1);
 
-  if (lua_type(lua, 2) == LUA_TTABLE) {
-    lua_pushnil(lua);
-    while (lua_next(lua, 2) != 0) {
-      digest_value(-2);  // key, included for correct hashing
-      digest_value(-1);  // value
-      lua_pop(lua, 1);
-    }
-  } else {
-    digest_value(2);
+  {
+    size_t len;
+    const char* key = lua_tolstring(lua, 2, &len);
+    hash = XXH64(key, len, hash);
   }
+
+  StringCollectorTranslator translator;
+  void** ptr = static_cast<void**>(lua_getextraspace(lua));
+  reinterpret_cast<Interpreter*>(*ptr)->RedisGenericCommand(false, false, &translator);
+
+  if (requires_sort)
+    sort(translator.values.begin(), translator.values.end());
+
+  for (string_view str : translator.values)
+    hash = XXH64(str.data(), str.size(), hash);
 
   lua_pushinteger(lua, absl::bit_cast<lua_Integer>(hash));
+  return 1;
+}
+
+int DragonflyRandstrCommand(lua_State* state) {
+  int argc = lua_gettop(state);
+  lua_Integer dsize = lua_tonumber(state, 1);
+  lua_remove(state, 1);
+
+  std::string buf(dsize, ' ');
+  auto push_str = [dsize, state, &buf]() {
+    static const char alphanum[] =
+        "0123456789"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "abcdefghijklmnopqrstuvwxyz";
+    for (int i = 0; i < dsize; ++i)
+      buf[i] = alphanum[rand() % (sizeof(alphanum) - 1)];
+    lua_pushlstring(state, buf.c_str(), buf.length());
+  };
+
+  if (argc == 1) {
+    push_str();
+  } else {
+    lua_Integer num = lua_tonumber(state, 1);
+    lua_createtable(state, num, 0);
+    for (size_t i = 1; i <= num; i++) {
+      push_str();
+      lua_rawseti(state, -2, i);
+    }
+  }
+
   return 1;
 }
 
@@ -427,8 +483,14 @@ Interpreter::Interpreter() {
   /* Register the dragonfly commands table and fields */
   lua_newtable(lua_);
 
+  /* dragonfly.ihash call - compute quick integer hash of string/interger or flat table */
   lua_pushstring(lua_, "ihash");
   lua_pushcfunction(lua_, DragonflyHashCommand);
+  lua_settable(lua_, -3);
+
+  /* dragonfly.*/
+  lua_pushstring(lua_, "randstr");
+  lua_pushcfunction(lua_, DragonflyRandstrCommand);
   lua_settable(lua_, -3);
 
   /* Finally set the table as 'dragonfly' global var. */
@@ -785,7 +847,7 @@ void Interpreter::ResetStack() {
 // Returns number of results, which is always 1 in this case.
 // Please note that lua resets the stack once the function returns so no need
 // to unwind the stack manually in the function (though lua allows doing this).
-int Interpreter::RedisGenericCommand(bool raise_error, bool async) {
+int Interpreter::RedisGenericCommand(bool raise_error, bool async, ObjectExplorer* explorer) {
   /* By using Lua debug hooks it is possible to trigger a recursive call
    * to luaRedisGenericCommand(), which normally should never happen.
    * To make this function reentrant is futile and makes it slower, but
@@ -884,9 +946,16 @@ int Interpreter::RedisGenericCommand(bool raise_error, bool async) {
   /* Pop all arguments from the stack, we do not need them anymore
    * and this way we guaranty we will have room on the stack for the result. */
   lua_pop(lua_, argc);
-  RedisTranslator translator(lua_);
-  redis_func_(
-      CallArgs{MutSliceSpan{args}, &buffer_, &translator, async, raise_error, &raise_error});
+
+  DCHECK(explorer == nullptr || (!raise_error && !async));
+
+  optional<RedisTranslator> translator;
+  if (explorer == nullptr) {
+    translator.emplace(lua_);
+    explorer = &*translator;
+  }
+
+  redis_func_(CallArgs{MutSliceSpan{args}, &buffer_, explorer, async, raise_error, &raise_error});
   cmd_depth_--;
 
   // Shrink reusable buffer if it's too big.
@@ -895,8 +964,11 @@ int Interpreter::RedisGenericCommand(bool raise_error, bool async) {
     buffer_.shrink_to_fit();
   }
 
+  if (!translator)
+    return 0;
+
   // Raise error for regular 'call' command if needed.
-  if (raise_error && translator.HasError()) {
+  if (raise_error && translator->HasError()) {
     // error is already on top of stack
     return RaiseError(lua_);
   }

--- a/src/core/interpreter.h
+++ b/src/core/interpreter.h
@@ -17,8 +17,7 @@ namespace dfly {
 
 class ObjectExplorer {
  public:
-  virtual ~ObjectExplorer() {
-  }
+  virtual ~ObjectExplorer() = default;
 
   virtual void OnBool(bool b) = 0;
   virtual void OnString(std::string_view str) = 0;
@@ -113,14 +112,14 @@ class Interpreter {
     redis_func_ = std::forward<U>(u);
   }
 
+  // Invoke command with arguments from lua stack, given options and possibly custom explorer
+  int RedisGenericCommand(bool raise_error, bool async, ObjectExplorer* explorer = nullptr);
+
  private:
   // Returns true if function was successfully added,
   // otherwise returns false and sets the error.
   bool AddInternal(const char* f_id, std::string_view body, std::string* error);
   bool IsTableSafe() const;
-
-  int RedisGenericCommand(bool raise_error, bool async);
-  int RedisACallErrorsCommand();
 
   static int RedisCallCommand(lua_State* lua);
   static int RedisPCallCommand(lua_State* lua);

--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -101,7 +101,7 @@ const char* ObjTypeName(int type) {
     case OBJ_STREAM:
       return "stream";
     case OBJ_JSON:
-      return "ReJSON-RL";
+      return "rejson-rl";
     default:
       LOG(ERROR) << "Unsupported type " << type;
   }

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -319,7 +319,7 @@ class DflyInstanceFactory:
         args = {**self.args, **kwargs}
         args.setdefault("dbfilename", "")
         vmod = "dragonfly_connection=1,accept_server=1,listener_interface=1,main_service=1,rdb_save=1,replica=1,cluster_family=1"
-        args.setdefault("vmodule", vmod)
+        # args.setdefault("vmodule", vmod)
 
         for k, v in args.items():
             args[k] = v.format(**self.params.env) if isinstance(v, str) else v

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -319,7 +319,7 @@ class DflyInstanceFactory:
         args = {**self.args, **kwargs}
         args.setdefault("dbfilename", "")
         vmod = "dragonfly_connection=1,accept_server=1,listener_interface=1,main_service=1,rdb_save=1,replica=1,cluster_family=1"
-        # args.setdefault("vmodule", vmod)
+        args.setdefault("vmodule", vmod)
 
         for k, v in args.items():
             args[k] = v.format(**self.params.env) if isinstance(v, str) else v

--- a/tests/dragonfly/json_test.py
+++ b/tests/dragonfly/json_test.py
@@ -22,7 +22,7 @@ async def test_basic_json_get_set(async_client: aioredis.Redis):
     result = await get_set_json(connection=async_client, key=key_name, value=jane)
     assert result, "failed to set JSON value"
     the_type = await async_client.type(key_name)
-    assert the_type == "ReJSON-RL"
+    assert the_type == "rejson-rl"
     assert len(result) == 1
     assert result[0]["name"] == "Jane"
     assert result[0]["Age"] == 33
@@ -34,7 +34,7 @@ async def test_access_json_value_as_string(async_client: aioredis.Redis):
     assert result is not None, "failed to set JSON value"
     # make sure that we have valid JSON here
     the_type = await async_client.type(key_name)
-    assert the_type == "ReJSON-RL"
+    assert the_type == "rejson-rl"
     # you cannot access this key as string
     try:
         result = await async_client.get(key_name)
@@ -49,7 +49,7 @@ async def test_reset_key_to_string(async_client: aioredis.Redis):
     assert result is not None, "failed to set JSON value"
     # make sure that we have valid JSON here
     the_type = await async_client.type(key_name)
-    assert the_type == "ReJSON-RL"
+    assert the_type == "rejson-rl"
 
     # set the key to be string - this is legal
     await async_client.set(key_name, "some random value")
@@ -60,7 +60,7 @@ async def test_reset_key_to_string(async_client: aioredis.Redis):
     # to change the type to JSON and override it
     result = await get_set_json(async_client, key=key_name, value=jane)
     the_type = await async_client.type(key_name)
-    assert the_type == "ReJSON-RL"
+    assert the_type == "rejson-rl"
 
 
 async def test_update_value(async_client: aioredis.Redis):
@@ -69,7 +69,7 @@ async def test_update_value(async_client: aioredis.Redis):
     assert result is not None, "failed to set JSON value"
     # make sure that we have valid JSON here
     the_type = await async_client.type(key_name)
-    assert the_type == "ReJSON-RL"
+    assert the_type == "rejson-rl"
     result = await get_set_json(async_client, value="0", key=key_name, path="$.a.*")
     assert len(result) == 3
     # make sure that all the values under 'a' where set to 0

--- a/tests/dragonfly/seeder/__init__.py
+++ b/tests/dragonfly/seeder/__init__.py
@@ -18,7 +18,7 @@ except ImportError:
 class SeederBase:
     UID_COUNTER = 1  # multiple generators should not conflict on keys
     CACHED_SCRIPTS = {}
-    TYPES = ["STRING", "LIST", "SET", "HASH", "ZSET"]
+    TYPES = ["STRING", "LIST", "SET", "HASH", "ZSET", "JSON"]
 
     def __init__(self):
         self.uid = SeederBase.UID_COUNTER

--- a/tests/dragonfly/seeder/script-generate.lua
+++ b/tests/dragonfly/seeder/script-generate.lua
@@ -28,13 +28,14 @@ local modfunc = LG_funcs['mod_' .. string.lower(type)]
 local function action_add()
     local key = prefix .. tostring(key_counter)
     key_counter = key_counter + 1
+
+    addfunc(key, keys)
     table.insert(keys, key)
-    addfunc(key, data_size)
 end
 
 local function action_mod()
     local key = keys[math.random(#keys)]
-    modfunc(key, data_size)
+    modfunc(key, keys)
 end
 
 local function action_del()
@@ -60,11 +61,6 @@ while true do
     -- break if we reached target ops
     if total_ops > 0 and counter > total_ops then
         break
-    end
-
-    if key_target < 100 and min_dev > 0 then
-        print(real_target, key_target, math.abs(#keys - real_target) / real_target)
-        print()
     end
 
     -- break if we reached our target deviation

--- a/tests/dragonfly/seeder/script-generate.lua
+++ b/tests/dragonfly/seeder/script-generate.lua
@@ -22,6 +22,7 @@ local data_size = tonumber(ARGV[8])
 -- assumes exclusive ownership
 local keys = LU_collect_keys(prefix, type)
 
+LG_funcs.init(data_size)
 local addfunc = LG_funcs['add_' .. string.lower(type)]
 local modfunc = LG_funcs['mod_' .. string.lower(type)]
 
@@ -87,7 +88,7 @@ while true do
         -- the add intensity is monotonically decreasing with keycount growing,
         -- the delete intensity is monotonically increasing with keycount growing,
         -- the point where the intensities are equal is the equilibrium point,
-        -- based on the formulas it's ~0.82 * key_target
+        -- based on the formulas it's ~0.956 * key_target
         local i_add = math.max(0, 1 - (#keys / key_target) ^ 16)
         local i_del = (#keys / key_target) ^ 16
 

--- a/tests/dragonfly/seeder/script-genlib.lua
+++ b/tests/dragonfly/seeder/script-genlib.lua
@@ -127,3 +127,29 @@ function LG_funcs.mod_zset(key, dbsize)
         redis.apcall('ZPOPMIN', key)
     end
 end
+
+-- json
+-- store single list of integers inside object
+
+function LG_funcs.add_json(key)
+    -- generate single list of counters
+    local seed = math.random(100)
+    local counters = {}
+    for i = 1, LG_funcs.csize do
+        counters[i] = ((i + seed) * 123) % 701
+    end
+    redis.apcall('JSON.SET', key, '$', cjson.encode({counters = counters}))
+end
+
+function LG_funcs.mod_json(key, dbsize)
+    local action = math.random(1, 4)
+    if action == 1 then
+        redis.apcall('JSON.ARRAPPEND', key, '$.counters', math.random(701))
+    elseif action == 2 then
+        redis.apcall('JSON.ARRPOP', key, '$.counters')
+    elseif action == 3 then
+        redis.apcall('JSON.NUMMULTBY', key, '$.counters[' .. math.random(LG_funcs.csize ) .. ']', 2)
+    else
+        redis.apcall('JSON.NUMINCRBY', key, '$.counters[' .. math.random(LG_funcs.csize ) .. ']', 1)
+    end
+end

--- a/tests/dragonfly/seeder/script-genlib.lua
+++ b/tests/dragonfly/seeder/script-genlib.lua
@@ -60,7 +60,7 @@ function LG_funcs.add_set(key, keys)
         while i1 == i2 do
             i2 = math.random(#keys)
         end
-        -- redis.apcall('SDIFFSTORE', key, keys[i1], keys[i2])
+        redis.apcall('SDIFFSTORE', key, keys[i1], keys[i2])
     else
         local elements = dragonfly.randstr(LG_funcs.esize, LG_funcs.csize)
         redis.apcall('SADD', key, unpack(elements))

--- a/tests/dragonfly/seeder/script-genlib.lua
+++ b/tests/dragonfly/seeder/script-genlib.lua
@@ -1,20 +1,129 @@
 local LG_funcs = {}
 
--- strings
-
-function LG_funcs.add_string(key, dsize)
-    local char = string.char(math.random(65, 90))
-    redis.apcall('SET', key, string.rep(char, dsize))
+function LG_funcs.init(dsize)
+    LG_funcs.dsize = dsize
+    LG_funcs.csize = math.floor(dsize ^ (2/3))
+    LG_funcs.esize = math.ceil(dsize ^ (1/3))
 end
 
-function LG_funcs.mod_string(key, dsize)
+-- strings
+-- store blobs of random chars
+
+function LG_funcs.add_string(key)
+    redis.apcall('SET', key, dragonfly.randstr(LG_funcs.dsize))
+end
+
+function LG_funcs.mod_string(key)
     -- APPEND and SETRANGE are the only modifying operations for strings,
     -- issue APPEND rarely to not grow data too much
     if math.random() < 0.05 then
         redis.apcall('APPEND', key, '+')
     else
-        local char = string.char(math.random(65, 90))
-        local replacement = string.rep(char, math.random(0, dsize / 2))
-        redis.apcall('SETRANGE', key, math.random(0, dsize / 2), replacement)
+        local replacement = dragonfly.randstr(LG_funcs.dsize // 2)
+        redis.apcall('SETRANGE', key, math.random(0, LG_funcs.dsize // 2), replacement)
+    end
+end
+
+-- lists
+-- store list of random blobs of default container/element sizes
+
+function LG_funcs.add_list(key)
+    local elements = dragonfly.randstr(LG_funcs.esize, LG_funcs.csize)
+    redis.apcall('LPUSH', key, unpack(elements))
+end
+
+function LG_funcs.mod_list(key)
+    -- equally likely pops and pushes, we rely on the list size being large enough
+    -- to "highly likely" not get emptied out by consequitve pops
+    local action = math.random(1, 4)
+    if action == 1 then
+        redis.apcall('RPOP', key)
+    elseif action == 2 then
+        redis.apcall('LPOP', key)
+    elseif action == 3 then
+        redis.apcall('LPUSH', key, dragonfly.randstr(LG_funcs.esize))
+    else
+        redis.apcall('RPUSH', key, dragonfly.randstr(LG_funcs.esize))
+    end
+end
+
+-- sets
+-- store sets of blobs of default container/element sizes
+
+function LG_funcs.add_set(key, keys)
+    if #keys > 100 and math.random() < 0.05 then
+        -- we assume that elements overlap with a very low proabiblity, so
+        -- SDIFF is expected to be equal to the origin set.
+        -- Repeating this operation too often can lead to two equal sets being chosen
+        local i1 = math.random(#keys)
+        local i2 = math.random(#keys)
+        while i1 == i2 do
+            i2 = math.random(#keys)
+        end
+        -- redis.apcall('SDIFFSTORE', key, keys[i1], keys[i2])
+    else
+        local elements = dragonfly.randstr(LG_funcs.esize, LG_funcs.csize)
+        redis.apcall('SADD', key, unpack(elements))
+    end
+end
+
+function LG_funcs.mod_set(key)
+     -- equally likely pops and additions
+    if math.random() < 0.5 then
+        redis.apcall('SPOP', key)
+    else
+        redis.apcall('SADD', key, dragonfly.randstr(LG_funcs.esize))
+    end
+end
+
+
+-- hashes
+-- store  {to_string(i): value for i in [1, csize]},
+-- where `value` is a random string for even indices and a number for odd indices
+
+function LG_funcs.add_hash(key)
+    local blobs  = dragonfly.randstr(LG_funcs.esize, LG_funcs.csize / 2)
+    local htable = {}
+    for i = 1,  LG_funcs.csize, 2 do
+        htable[i * 2 - 1] = tostring(i)
+        htable[i * 2] = math.random(0, 1000)
+    end
+    for i = 2,  LG_funcs.csize, 2 do
+        htable[i * 2 - 1] = tostring(i)
+        htable[i * 2] = blobs[i // 2]
+    end
+    redis.apcall('HSET', key, unpack(htable))
+end
+
+function LG_funcs.mod_hash(key)
+    local idx = math.random(LG_funcs.csize)
+    if idx % 2 == 1 then
+        redis.apcall('HINCRBY', key, tostring(idx), 1)
+    else
+        redis.apcall('HSET', key, tostring(idx), dragonfly.randstr(LG_funcs.esize))
+    end
+end
+
+-- sorted sets
+
+function LG_funcs.add_zset(key, keys)
+    -- TODO: We don't support ZDIFFSTORE
+    local blobs  = dragonfly.randstr(LG_funcs.esize, LG_funcs.csize)
+    local ztable = {}
+    for i = 1,  LG_funcs.csize do
+        ztable[i * 2 - 1] = tostring(i)
+        ztable[i * 2] = blobs[i]
+    end
+    redis.apcall('ZADD', key, unpack(ztable))
+end
+
+function LG_funcs.mod_zset(key, dbsize)
+    local action = math.random(1, 4)
+    if action <= 2 then
+        redis.apcall('ZADD', key, math.random(0, LG_funcs.csize * 2), dragonfly.randstr(LG_funcs.esize))
+    elseif action == 3 then
+        redis.apcall('ZPOPMAX', key)
+    else
+        redis.apcall('ZPOPMIN', key)
     end
 end

--- a/tests/dragonfly/seeder/script-hash.lua
+++ b/tests/dragonfly/seeder/script-hash.lua
@@ -8,7 +8,7 @@ Keys of every type are sorted lexicographically to ensure consistent order.
 -- import:utillib --
 
 -- inputs
-local requested_types = ARGV
+local type = ARGV[1]
 
 local OUT_HASH = 0
 
@@ -19,16 +19,11 @@ local function process(type)
     -- sort to provide consistent order
     table.sort(keys)
     for _, key in ipairs(keys) do
-        -- add key to hash
-        OUT_HASH = dragonfly.ihash(OUT_HASH, key)
         -- hand hash over to callback
         OUT_HASH = hfunc(key, OUT_HASH)
     end
 end
 
-for _, type in ipairs(requested_types) do
-    process(string.lower(type))
-end
-
+process(string.lower(type))
 
 return OUT_HASH

--- a/tests/dragonfly/seeder/script-hashlib.lua
+++ b/tests/dragonfly/seeder/script-hashlib.lua
@@ -2,38 +2,30 @@ local LH_funcs = {}
 
 function LH_funcs.string(key, hash)
     -- add value to hash
-    return dragonfly.ihash(hash, redis.call('GET', key))
+    return dragonfly.ihash(hash, false, 'GET', key)
 end
 
 function LH_funcs.list(key, hash)
     -- add values to hash
-    return dragonfly.ihash(hash, redis.call('LRANGE', key, 0, -1))
+    return dragonfly.ihash(hash, false, 'LRANGE', key, 0, -1)
 end
 
 function LH_funcs.set(key, hash)
     -- add values to hash, sort before to avoid ambiguity
-    local items = redis.call('SMEMBERS', key)
-    table.sort(items)
-    return dragonfly.ihash(hash, items)
+    return dragonfly.ihash(hash, true, 'SMEMBERS', key)
 end
 
 function LH_funcs.zset(key, hash)
     -- add values to hash, ZRANGE returns always sorted values
-    return dragonfly.ihash(hash, redis.call('ZRANGE', key, 0, -1, 'WITHSCORES'))
+    return dragonfly.ihash(hash, false, 'ZRANGE', key, 0, -1, 'WITHSCORES')
 end
 
 function LH_funcs.hash(key, hash)
     -- add values to hash, first convert to key-value pairs and sort
-    local items = redis.call('HGETALL', key)
-    local paired_items = {}
-    for i = 1, #items, 2 do
-        table.insert(paired_items, items[i] .. '->' .. items[i+1])
-    end
-    table.sort(paired_items)
-    return dragonfly.ihash(hash, paired_items)
+    return dragonfly.ihash(hash, true, 'HGETALL', key)
 end
 
 function LH_funcs.json(key, hash)
     -- add values to hash, note JSON.GET returns just a string
-    return dragonfly.ihash(hash, redis.call('JSON.GET', key))
+    return dragonfly.ihash(hash, false, 'JSON.GET', key)
 end

--- a/tests/dragonfly/seeder/script-utillib.lua
+++ b/tests/dragonfly/seeder/script-utillib.lua
@@ -1,5 +1,10 @@
 -- collect all keys into table specific type on specific prefix. Uses SCAN--
 local function LU_collect_keys(prefix, type)
+    -- SCAN wants this weird type name for json
+    if string.lower(type) == 'json' then
+        type = 'ReJSON-RL'
+    end
+
     local pattern = prefix .. "*"
     local cursor = "0"
     local keys = {}


### PR DESCRIPTION
This PR:
* adds more types to the seeder, finally all types are supported
* makes `dragonfly.ihash` use internal command dispatch to avoid excessive copies
* refactors replication test a little to show how to use markers