### PR TITLE
fix(test): Unflake `GenericFamilyTest.Time*Keys`

### DIFF
--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -479,16 +479,14 @@ TEST_F(GenericFamilyTest, TimeNoKeys) {
   usleep(2000);
   Run({"time"});
   resp = Run({"exec"});
-  EXPECT_THAT(resp, ArrLen(2));
 
-  ASSERT_THAT(resp.GetVec()[0], ArrLen(2));
-  ASSERT_THAT(resp.GetVec()[1], ArrLen(2));
+  EXPECT_THAT(resp, RespArray(ElementsAre(RespArray(ElementsAre(Not(IntArg(0)), _)),
+                                          RespArray(ElementsAre(Not(IntArg(0)), _)))));
 
   for (int i = 0; i < 2; ++i) {
     int64_t val0 = get<int64_t>(resp.GetVec()[0].GetVec()[i].u);
     int64_t val1 = get<int64_t>(resp.GetVec()[1].GetVec()[i].u);
     EXPECT_EQ(val0, val1);
-    EXPECT_NE(val0, 0);
   }
 }
 
@@ -505,16 +503,14 @@ TEST_F(GenericFamilyTest, TimeWithKeys) {
   Run({"time"});
   Run({"get", "x"});
   resp = Run({"exec"});
-  EXPECT_THAT(resp, ArrLen(3));
 
-  ASSERT_THAT(resp.GetVec()[0], ArrLen(2));
-  ASSERT_THAT(resp.GetVec()[1], ArrLen(2));
+  EXPECT_THAT(resp, RespArray(ElementsAre(RespArray(ElementsAre(Not(IntArg(0)), _)),
+                                          RespArray(ElementsAre(Not(IntArg(0)), _)), _)));
 
   for (int i = 0; i < 2; ++i) {
     int64_t val0 = get<int64_t>(resp.GetVec()[0].GetVec()[i].u);
     int64_t val1 = get<int64_t>(resp.GetVec()[1].GetVec()[i].u);
     EXPECT_EQ(val0, val1);
-    EXPECT_NE(val0, 0);
   }
 }
 


### PR DESCRIPTION
The problem was that we checked both "sides" of the time, but the microseconds part will be 0 every one in, well, a million invocations.


<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->