### PR TITLE
chore(transaction): Copy poll flags

### DIFF
--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -930,11 +930,11 @@ void Transaction::ExecuteAsync() {
   DCHECK_GT(unique_shard_cnt_, 0u);
   DCHECK_GT(use_count_.load(memory_order_relaxed), 0u);
   DCHECK(!IsAtomicMulti() || multi_->lock_mode.has_value());
-  DCHECK_LE(shard_data_.size(), 128u);
+  DCHECK_LE(shard_data_.size(), 1024u);
 
   // Set armed flags on all active shards. Copy indices for dispatching poll tasks,
   // because local_mask can be written concurrently after starting a new phase.
-  std::bitset<128> poll_flags(0);
+  std::bitset<1024> poll_flags(0);
   IterateActiveShards([&poll_flags](auto& sd, auto i) {
     sd.local_mask |= ARMED;
     poll_flags.set(i, true);

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -930,7 +930,7 @@ void Transaction::ExecuteAsync() {
   DCHECK_GT(unique_shard_cnt_, 0u);
   DCHECK_GT(use_count_.load(memory_order_relaxed), 0u);
   DCHECK(!IsAtomicMulti() || multi_->lock_mode.has_value());
-  DCHECK_LE(shard_data_.size(), 128);
+  DCHECK_LE(shard_data_.size(), 128u);
 
   // Set armed flags on all active shards. Copy indices for dispatching poll tasks,
   // because local_mask can be written concurrently after starting a new phase.

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -933,7 +933,7 @@ void Transaction::ExecuteAsync() {
   DCHECK_LE(shard_data_.size(), 128);
 
   // Set armed flags on all active shards. Copy indices for dispatching poll tasks,
-  // because local_mask can be modified after starting a new phase.
+  // because local_mask can be written concurrently after starting a new phase.
   std::bitset<128> poll_flags(0);
   IterateActiveShards([&poll_flags](auto& sd, auto i) {
     sd.local_mask |= ARMED;

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -541,17 +541,23 @@ class Transaction {
     return sid < shard_data_.size() ? sid : 0;
   }
 
-  // Iterate over shards and run function accepting (PerShardData&, ShardId) on all active ones.
-  template <typename F> void IterateActiveShards(F&& f) {
-    if (unique_shard_cnt_ == 1) {
+  // Iterate over all available shards, run functor accepting (PerShardData&, ShardId)
+  template <typename F> void IterateShards(F&& f) {
+    if (unique_shard_cnt == 1) {
       f(shard_data_[SidToId(unique_shard_id_)], unique_shard_id_);
     } else {
       for (ShardId i = 0; i < shard_data_.size(); ++i) {
-        if (auto& sd = shard_data_[i]; sd.local_mask & ACTIVE) {
-          f(sd, i);
-        }
+        f(shard_data_[i], i);
       }
     }
+  }
+
+  // Iterate over ACTIVE shards, run functor accepting (PerShardData&, ShardId)
+  template <typename F> void IterateActiveShards(F&& f) {
+    IterateShards([&f](auto& sd, auto i) {
+      if (sd.local_mask & ACTIVE)
+        f(sd, i);
+    });
   }
 
  private:

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -543,7 +543,7 @@ class Transaction {
 
   // Iterate over all available shards, run functor accepting (PerShardData&, ShardId)
   template <typename F> void IterateShards(F&& f) {
-    if (unique_shard_cnt == 1) {
+    if (unique_shard_cnt_ == 1) {
       f(shard_data_[SidToId(unique_shard_id_)], unique_shard_id_);
     } else {
       for (ShardId i = 0; i < shard_data_.size(); ++i) {


### PR DESCRIPTION
Copying poll flags prevents concurrent data access to `PerShardData::local_mask` when dispatching poll tasks