### PR TITLE
fix(server_family): `GetMetrics` should show commands in lowercase

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -19,6 +19,7 @@
 #include <filesystem>
 #include <optional>
 
+#include "absl/strings/ascii.h"
 #include "facade/error.h"
 #include "slowlog.h"
 
@@ -1658,7 +1659,7 @@ Metrics ServerFamily::GetMetrics() const {
   Mutex mu;
 
   auto cmd_stat_cb = [&dest = result.cmd_stats_map](string_view name, const CmdCallStats& stat) {
-    auto& [calls, sum] = dest[string{name}];
+    auto& [calls, sum] = dest[absl::AsciiStrToLower(name)];
     calls += stat.first;
     sum += stat.second;
   };

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1821,7 +1821,7 @@ async def test_client_pause_with_replica(df_local_factory, df_seeder_factory):
     stats_after_sleep = await c_master.info("CommandStats")
     # Check no commands are executed except info and replconf called from replica
     for cmd, cmd_stats in stats_after_sleep.items():
-        if "cmdstat_INFO" != cmd and "cmdstat_REPLCONF" != cmd_stats:
+        if "cmdstat_info" != cmd and "cmdstat_replconf" != cmd_stats:
             assert stats[cmd] == cmd_stats, cmd
 
     await asyncio.sleep(6)
@@ -1830,7 +1830,7 @@ async def test_client_pause_with_replica(df_local_factory, df_seeder_factory):
     stats_after_pause_finish = await c_master.info("CommandStats")
     more_exeuted = False
     for cmd, cmd_stats in stats_after_pause_finish.items():
-        if "cmdstat_INFO" != cmd and "cmdstat_REPLCONF" != cmd_stats and stats[cmd] != cmd_stats:
+        if "cmdstat_info" != cmd and "cmdstat_replconf" != cmd_stats and stats[cmd] != cmd_stats:
             more_exeuted = True
     assert more_exeuted
 


### PR DESCRIPTION
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->

Closes #862

I've ran `INFO ALL` locally and the only section that showed IN CAPS was `cmdstat_COMMAND`.

So I 'lowercased' all commands on `GetMetrics()` and fixed the `replication_test.py` accordingly.
Also checked that Redis behaves the same.