### PR TITLE
chore: allow aggregate functions for jsonpath

### DIFF
--- a/src/core/json/driver.cc
+++ b/src/core/json/driver.cc
@@ -4,12 +4,107 @@
 
 #include "src/core/json/driver.h"
 
+#include <absl/strings/str_cat.h>
+
 #include "base/logging.h"
 #include "src/core/json/lexer_impl.h"
+#include "src/core/overloaded.h"
 
 using namespace std;
 
 namespace dfly::json {
+
+namespace {
+
+class SingleValueImpl : public AggFunction {
+  JsonType GetResultImpl() const final {
+    return visit(Overloaded{
+                     [](monostate) { return JsonType::null(); },
+                     [](double d) { return JsonType(d); },
+                     [](int64_t i) { return JsonType(i); },
+                 },
+                 val_);
+  }
+
+ protected:
+  void Init(const JsonType& src) {
+    if (src.is_double()) {
+      val_.emplace<double>(src.as_double());
+    } else {
+      val_.emplace<int64_t>(src.as<int64_t>());
+    }
+  }
+
+  variant<monostate, double, int64_t> val_;
+};
+
+class MaxImpl : public SingleValueImpl {
+  bool ApplyImpl(const JsonType& src) final {
+    if (!src.is_number()) {
+      return false;
+    }
+
+    visit(Overloaded{
+              [&](monostate) { Init(src); },
+              [&](double d) { val_ = max(d, src.as_double()); },
+              [&](int64_t i) {
+                if (src.is_double())
+                  val_ = max(double(i), src.as_double());
+                else
+                  val_ = max(i, src.as<int64_t>());
+              },
+          },
+          val_);
+
+    return true;
+  }
+};
+
+class MinImpl : public SingleValueImpl {
+ private:
+  bool ApplyImpl(const JsonType& src) final {
+    if (!src.is_number()) {
+      return false;
+    }
+
+    visit(Overloaded{
+              [&](monostate) { Init(src); },
+              [&](double d) { val_ = min(d, src.as_double()); },
+              [&](int64_t i) {
+                if (src.is_double())
+                  val_ = min(double(i), src.as_double());
+                else
+                  val_ = min(i, src.as<int64_t>());
+              },
+          },
+          val_);
+
+    return true;
+  }
+};
+
+class AvgImpl : public AggFunction {
+ private:
+  bool ApplyImpl(const JsonType& src) final {
+    if (!src.is_number()) {
+      return false;
+    }
+    sum_ += src.as_double();
+    count_++;
+
+    return true;
+  }
+
+  JsonType GetResultImpl() const final {
+    DCHECK_GT(count_, 0u);  // AggFunction guarantees that
+    return JsonType(sum_ / count_);
+  }
+
+  double sum_ = 0;
+  uint64_t count_ = 0;
+};
+
+}  // namespace
 
 Driver::Driver() : lexer_(make_unique<Lexer>()) {
 }
@@ -25,6 +120,25 @@ void Driver::SetInput(string str) {
 
 void Driver::ResetScanner() {
   lexer_ = make_unique<Lexer>();
+}
+
+void Driver::AddFunction(string_view fname) {
+  if (!path_.empty()) {
+    throw Parser::syntax_error(lexer_->location(),
+                               "function can be only at the beginning of the path");
+  }
+
+  shared_ptr<AggFunction> func;
+  if (fname == "max") {
+    func = make_shared<MaxImpl>();
+  } else if (fname == "min") {
+    func = make_shared<MinImpl>();
+  } else if (fname == "avg") {
+    func = make_shared<AvgImpl>();
+  } else {
+    throw Parser::syntax_error(lexer_->location(), absl::StrCat("Unknown function: ", fname));
+  }
+  path_.emplace_back(std::move(func));
 }
 
 }  // namespace dfly::json

--- a/src/core/json/driver.h
+++ b/src/core/json/driver.h
@@ -32,6 +32,8 @@ class Driver {
     AddSegment(PathSegment(SegmentType::IDENTIFIER, identifier));
   }
 
+  void AddFunction(std::string_view fname);
+
   void AddWildcard() {
     AddSegment(PathSegment(SegmentType::WILDCARD));
   }

--- a/src/core/json/json_test.cc
+++ b/src/core/json/json_test.cc
@@ -101,6 +101,18 @@ TEST_F(JsonTest, Path) {
     ASSERT_EQ("$['field-dash']", path);
     ASSERT_EQ(2, val.as<int>());
   });
+
+  int called = 0;
+  jsonpath::json_query(j1, "max($.*)", [&](const std::string& path, const json& val) {
+    EXPECT_EQ("$", path);
+    ASSERT_EQ(2, val.as<int>());
+    ++called;
+  });
+  EXPECT_EQ(1, called);
+
+  auto res = jsonpath::json_query(j1, "max($.*)");
+  ASSERT_TRUE(res.is_array() && res.size() == 1);
+  EXPECT_EQ(2, res[0].as<int>());
 }
 
 TEST_F(JsonTest, Delete) {

--- a/src/core/json/jsonpath_grammar.y
+++ b/src/core/json/jsonpath_grammar.y
@@ -47,6 +47,8 @@ using namespace std;
 %token
   LBRACKET "["
   RBRACKET "]"
+  LPARENT  "("
+  RPARENT  ")"
   ROOT "$"
   DOT  "."
   WILDCARD "*"
@@ -66,13 +68,14 @@ using namespace std;
 // https://danielaparker.github.io/JsonCons.Net/articles/JsonPath/Specification.html
 
 jsonpath: ROOT { /* skip adding root */ } opt_relative_location
+         | function_expr opt_relative_location
 
 opt_relative_location:
         | relative_location
 
 relative_location: DOT relative_path
         | DESCENT { driver->AddSegment(PathSegment{SegmentType::DESCENT}); } relative_path
-        | LBRACKET bracket_index RBRACKET { driver->AddSegment($2); }
+        | LBRACKET bracket_index RBRACKET { driver->AddSegment($2); } opt_relative_location
 
 relative_path: identifier { driver->AddIdentifier($1); } opt_relative_location
         | WILDCARD { driver->AddWildcard(); } opt_relative_location
@@ -84,7 +87,7 @@ identifier: UNQ_STR
 bracket_index: WILDCARD { $$ = PathSegment{SegmentType::WILDCARD}; }
               | UINT { $$ = PathSegment(SegmentType::INDEX, $1); }
 
-
+function_expr: UNQ_STR { driver->AddFunction($1); } LPARENT ROOT relative_location RPARENT
 %%
 
 

--- a/src/core/json/jsonpath_lexer.lex
+++ b/src/core/json/jsonpath_lexer.lex
@@ -48,6 +48,8 @@
 "["         return Parser::make_LBRACKET(loc());
 "]"         return Parser::make_RBRACKET(loc());
 "*"         return Parser::make_WILDCARD(loc());
+"("         return Parser::make_LPARENT(loc());
+")"         return Parser::make_RPARENT(loc());
 [0-9]{1,9}  {
               unsigned val;
               CHECK(absl::SimpleAtoi(str(), &val));

--- a/src/core/json/path.cc
+++ b/src/core/json/path.cc
@@ -4,10 +4,12 @@
 
 #include "src/core/json/path.h"
 
+#include <absl/strings/str_cat.h>
 #include <absl/types/span.h>
 
-#include "base/expected.hpp"
 #include "base/logging.h"
+#include "core/json/jsonpath_grammar.hh"
+#include "src/core/json/driver.h"
 #include "src/core/overloaded.h"
 
 using namespace std;
@@ -215,6 +217,8 @@ template <bool IsConst> auto DfsItem<IsConst>::Init(const PathSegment& segment) 
       }
       break;
     }
+    default:
+      LOG(DFATAL) << "Unknown segment " << SegmentName(segment.type());
   }  // end switch
 
   return make_unexpected(MISMATCH);
@@ -335,6 +339,8 @@ auto Dfs::PerformStep(const PathSegment& segment, const JsonType& node, const Cb
         }
       }
     } break;
+    default:
+      LOG(DFATAL) << "Unknown segment " << SegmentName(segment.type());
   }
   return {};
 }
@@ -378,17 +384,93 @@ auto Dfs::MutateStep(const PathSegment& segment, const MutateCallback& cb, JsonT
         }
       }
     } break;
+    case SegmentType::FUNCTION:
+      LOG(DFATAL) << "Function segment is not supported for mutation";
+      break;
   }
-
   return {};
 }
 
+class JsonPathDriver : public json::Driver {
+ public:
+  string msg;
+  void Error(const json::location& l, const std::string& msg) final {
+    this->msg = absl::StrCat("Error: ", msg);
+  }
+};
+
 }  // namespace
+
+const char* SegmentName(SegmentType type) {
+  switch (type) {
+    case SegmentType::IDENTIFIER:
+      return "IDENTIFIER";
+    case SegmentType::INDEX:
+      return "INDEX";
+    case SegmentType::WILDCARD:
+      return "WILDCARD";
+    case SegmentType::DESCENT:
+      return "DESCENT";
+    case SegmentType::FUNCTION:
+      return "FUNCTION";
+  }
+  return nullptr;
+}
+
+void PathSegment::Evaluate(const JsonType& json) const {
+  CHECK(type() == SegmentType::FUNCTION);
+  AggFunction* func = std::get<shared_ptr<AggFunction>>(value_).get();
+  CHECK(func);
+  func->Apply(json);
+}
+
+JsonType PathSegment::GetResult() const {
+  CHECK(type() == SegmentType::FUNCTION);
+  const auto& func = std::get<shared_ptr<AggFunction>>(value_).get();
+  CHECK(func);
+  return func->GetResult();
+}
 
 void EvaluatePath(const Path& path, const JsonType& json, PathCallback callback) {
   if (path.empty())
     return;
-  Dfs().Traverse(path, json, std::move(callback));
+
+  if (path.front().type() != SegmentType::FUNCTION) {
+    Dfs().Traverse(path, json, std::move(callback));
+    return;
+  }
+
+  // Handling the case of `func($.somepath)`
+  // We pass our own callback to gather all the results and then call the function.
+  JsonType result(JsonType::null());
+  absl::Span<const PathSegment> path_tail(path.data() + 1, path.size() - 1);
+
+  const PathSegment& func_segment = path.front();
+
+  if (path_tail.empty()) {
+    LOG(DFATAL) << "Invalid path";  // parser should not allow this.
+  } else {
+    Dfs().Traverse(path_tail, json, [&](auto, const JsonType& val) { func_segment.Evaluate(val); });
+  }
+  callback(nullopt, func_segment.GetResult());
+}
+
+nonstd::expected<json::Path, string> ParsePath(string_view path) {
+  if (path.size() > 8192)
+    return nonstd::make_unexpected("Path too long");
+
+  VLOG(2) << "Parsing path: " << path;
+
+  JsonPathDriver driver;
+  Parser parser(&driver);
+
+  driver.SetInput(string(path));
+  int res = parser();
+  if (res != 0) {
+    return nonstd::make_unexpected(driver.msg);
+  }
+
+  return driver.TakePath();
 }
 
 void MutatePath(const Path& path, MutateCallback callback, JsonType* json) {

--- a/src/core/json/path.h
+++ b/src/core/json/path.h
@@ -10,6 +10,7 @@
 #include <variant>
 #include <vector>
 
+#include "base/expected.hpp"
 #include "src/core/json/json_object.h"
 
 namespace dfly::json {
@@ -19,6 +20,31 @@ enum class SegmentType {
   INDEX = 2,       // $.array[0]
   WILDCARD = 3,    // $.array[*] or $.*
   DESCENT = 4,     // $..identifier
+  FUNCTION = 5,    // max($.prices[*])
+};
+
+const char* SegmentName(SegmentType type);
+
+class AggFunction {
+ public:
+  virtual ~AggFunction() {
+  }
+
+  void Apply(const JsonType& src) {
+    if (valid_ != 0)
+      valid_ = ApplyImpl(src);
+  }
+
+  // returns null if Apply was not called or ApplyImpl failed.
+  JsonType GetResult() const {
+    return valid_ == 1 ? GetResultImpl() : JsonType::null();
+  }
+
+ protected:
+  virtual bool ApplyImpl(const JsonType& src) = 0;
+  virtual JsonType GetResultImpl() const = 0;
+
+  int valid_ = -1;
 };
 
 class PathSegment {
@@ -33,6 +59,10 @@ class PathSegment {
   PathSegment(SegmentType type, unsigned index) : type_(type), value_(index) {
   }
 
+  explicit PathSegment(std::shared_ptr<AggFunction> func)
+      : type_(SegmentType::FUNCTION), value_(std::move(func)) {
+  }
+
   SegmentType type() const {
     return type_;
   }
@@ -45,9 +75,14 @@ class PathSegment {
     return std::get<unsigned>(value_);
   }
 
+  void Evaluate(const JsonType& json) const;
+  JsonType GetResult() const;
+
  private:
   SegmentType type_;
-  std::variant<std::string, unsigned> value_;
+
+  // shared_ptr to preserve copy semantics.
+  std::variant<std::string, unsigned, std::shared_ptr<AggFunction>> value_;
 };
 
 using Path = std::vector<PathSegment>;
@@ -61,5 +96,6 @@ using MutateCallback = absl::FunctionRef<bool(std::optional<std::string_view>, J
 
 void EvaluatePath(const Path& path, const JsonType& json, PathCallback callback);
 void MutatePath(const Path& path, MutateCallback callback, JsonType* json);
+nonstd::expected<Path, std::string> ParsePath(std::string_view path);
 
 }  // namespace dfly::json


### PR DESCRIPTION
Specifically, allows expressions in the form of
`max($.objs[*].score)`, i.e. where a function aggregates 0 or more values produced by the path expression. The final value is passed to a PathCallback. In case no matches are found, json null value is passed. In any case, the callback is called exactly once for such expressions. Currently only `max` function is supported.

In addition, fixed a parser bug that does not allow fields after the bracketing expression.
Finally, introduced an utility function for easier parsing of json::Path.


<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->