### PR TITLE
fix(server): saving is not a server state

### DIFF
--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -76,8 +76,6 @@ const char* GlobalStateName(GlobalState s) {
       return "ACTIVE";
     case GlobalState::LOADING:
       return "LOADING";
-    case GlobalState::SAVING:
-      return "SAVING";
     case GlobalState::SHUTTING_DOWN:
       return "SHUTTING DOWN";
     case GlobalState::TAKEN_OVER:

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -154,7 +154,6 @@ struct SearchStats {
 enum class GlobalState : uint8_t {
   ACTIVE,
   LOADING,
-  SAVING,
   SHUTTING_DOWN,
   TAKEN_OVER,
 };

--- a/src/server/detail/save_stages_controller.cc
+++ b/src/server/detail/save_stages_controller.cc
@@ -148,31 +148,26 @@ SaveStagesController::SaveStagesController(SaveStagesInputs&& inputs)
 SaveStagesController::~SaveStagesController() {
 }
 
-GenericError SaveStagesController::Save() {
-  if (auto err = BuildFullPath(); err)
-    return err;
+SaveInfo SaveStagesController::Save() {
+  if (auto err = BuildFullPath(); err) {
+    shared_err_ = err;
+    return GetSaveInfo();
+  }
 
-  if (auto err = InitResources(); err)
-    return err;
+  InitResources();
 
-  // The stages below report errors to shared_err_
   if (use_dfs_format_)
     SaveDfs();
   else
     SaveRdb();
 
-  is_saving_ = true;
-
   RunStage(&SaveStagesController::SaveCb);
 
   RunStage(&SaveStagesController::CloseCb);
-  is_saving_ = false;
 
   FinalizeFileMovement();
 
-  UpdateSaveInfo();
-
-  return *shared_err_;
+  return GetSaveInfo();
 }
 
 size_t SaveStagesController::GetSaveBuffersSize() {
@@ -216,6 +211,14 @@ void SaveStagesController::SaveDfs() {
   trans_->ScheduleSingleHop(std::move(cb));
 }
 
+bool SaveStagesController::TEST_IsSaving() {
+  if (snapshots_.size() == 0) {
+    return false;
+  }
+  auto& [snapshot, _] = snapshots_.front();
+  return snapshot->HasStarted();
+}
+
 // Start saving a dfs file on shard
 void SaveStagesController::SaveDfsSingle(EngineShard* shard) {
   // for summary file, shard=null and index=shard_set->size(), see SaveDfs() above
@@ -256,18 +259,18 @@ void SaveStagesController::SaveRdb() {
   trans_->ScheduleSingleHop(std::move(cb));
 }
 
-uint32_t SaveStagesController::GetCurrentSaveDuratio() {
+uint32_t SaveStagesController::GetCurrentSaveDuration() {
   return (absl::Now() - start_time_) / absl::Seconds(1);
 }
 
-void SaveStagesController::UpdateSaveInfo() {
-  auto seconds = (absl::Now() - start_time_) / absl::Seconds(1);
+SaveInfo SaveStagesController::GetSaveInfo() {
+  SaveInfo info;
+  info.save_time = absl::ToUnixSeconds(start_time_);
+  info.duration_sec = GetCurrentSaveDuration();
+
   if (shared_err_) {
-    lock_guard lk{*save_mu_};
-    last_save_info_->last_error = *shared_err_;
-    last_save_info_->last_error_time = absl::ToUnixSeconds(start_time_);
-    last_save_info_->failed_duration_sec = seconds;
-    return;
+    info.error = *shared_err_;
+    return info;
   }
 
   fs::path resulting_path = full_path_;
@@ -277,23 +280,22 @@ void SaveStagesController::UpdateSaveInfo() {
     resulting_path.replace_extension();  // remove .tmp
 
   LOG(INFO) << "Saving " << resulting_path << " finished after "
-            << strings::HumanReadableElapsedTime(seconds);
+            << strings::HumanReadableElapsedTime(info.duration_sec);
 
-  lock_guard lk{*save_mu_};
-  last_save_info_->freq_map.clear();
+  info.freq_map.clear();
   for (const auto& k_v : rdb_name_map_) {
-    last_save_info_->freq_map.emplace_back(k_v);
+    info.freq_map.emplace_back(k_v);
   }
-  last_save_info_->save_time = absl::ToUnixSeconds(start_time_);
-  last_save_info_->file_name = resulting_path.generic_string();
-  last_save_info_->success_duration_sec = seconds;
+
+  info.file_name = resulting_path.generic_string();
+
+  return info;
 }
 
-GenericError SaveStagesController::InitResources() {
+void SaveStagesController::InitResources() {
   snapshots_.resize(use_dfs_format_ ? shard_set->size() + 1 : 1);
   for (auto& [snapshot, _] : snapshots_)
     snapshot = make_unique<RdbSnapshot>(fq_threadpool_, snapshot_storage_.get());
-  return {};
 }
 
 // Remove .tmp extension or delete files in case of error

--- a/src/server/detail/save_stages_controller.cc
+++ b/src/server/detail/save_stages_controller.cc
@@ -211,14 +211,6 @@ void SaveStagesController::SaveDfs() {
   trans_->ScheduleSingleHop(std::move(cb));
 }
 
-bool SaveStagesController::TEST_IsSaving() {
-  if (snapshots_.size() == 0) {
-    return false;
-  }
-  auto& [snapshot, _] = snapshots_.front();
-  return snapshot->HasStarted();
-}
-
 // Start saving a dfs file on shard
 void SaveStagesController::SaveDfsSingle(EngineShard* shard) {
   // for summary file, shard=null and index=shard_set->size(), see SaveDfs() above

--- a/src/server/detail/save_stages_controller.h
+++ b/src/server/detail/save_stages_controller.h
@@ -78,8 +78,6 @@ struct SaveStagesController : public SaveStagesInputs {
   size_t GetSaveBuffersSize();
   uint32_t GetCurrentSaveDuration();
 
-  bool TEST_IsSaving();
-
  private:
   // In the new version (.dfs) we store a file for every shard and one more summary file.
   // Summary file is always last in snapshots array.

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -325,7 +325,7 @@ TEST_F(RdbTest, SaveFlush) {
 
   do {
     usleep(10);
-  } while (!service_->server_family().IsSaving());
+  } while (!service_->server_family().TEST_IsSaving());
 
   Run({"flushdb"});
   save_fb.Join();
@@ -355,7 +355,7 @@ TEST_F(RdbTest, SaveManyDbs) {
 
   do {
     usleep(10);
-  } while (!service_->server_family().IsSaving());
+  } while (!service_->server_family().TEST_IsSaving());
 
   pp_->at(1)->Await([&] {
     Run({"select", "1"});

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -40,6 +40,7 @@ extern "C" {
 #include "server/conn_context.h"
 #include "server/debugcmd.h"
 #include "server/detail/save_stages_controller.h"
+#include "server/detail/snapshot_storage.h"
 #include "server/dflycmd.h"
 #include "server/engine_shard_set.h"
 #include "server/error.h"
@@ -1290,27 +1291,30 @@ GenericError ServerFamily::DoSave(bool new_version, string_view basename, Transa
     return GenericError{make_error_code(errc::operation_not_permitted),
                         StrCat("Can not save database in tiering mode")};
   }
-  if (!ignore_state) {
-    auto [new_state, success] = service_.SwitchState(GlobalState::ACTIVE, GlobalState::SAVING);
-    if (!success) {
+  auto state = service_.GetGlobalState();
+  if (!ignore_state && (state != GlobalState::ACTIVE)) {
+    return GenericError{make_error_code(errc::operation_in_progress),
+                        StrCat(GlobalStateName(state), " - can not save database")};
+  }
+
+  {
+    std::lock_guard lk(save_mu_);
+    if (save_controller_) {
       return GenericError{make_error_code(errc::operation_in_progress),
-                          StrCat(GlobalStateName(new_state), " - can not save database")};
+                          "SAVING - can not save database"};
     }
+    save_controller_ = make_unique<SaveStagesController>(
+        detail::SaveStagesInputs{new_version, basename, trans, &service_, fq_threadpool_.get(),
+                                 &last_save_info_, &save_mu_, snapshot_storage_});
   }
+
+  auto res = save_controller_->Save();
+
   {
-    std::lock_guard lck(save_mu_);
-    start_save_time_ = absl::Now();
+    std::lock_guard lk(save_mu_);
+    save_controller_.reset();
   }
-  SaveStagesController sc{detail::SaveStagesInputs{
-      new_version, basename, trans, &service_, &is_saving_, fq_threadpool_.get(), &last_save_info_,
-      &save_mu_, &save_bytes_cb_, snapshot_storage_}};
-  auto res = sc.Save();
-  {
-    std::lock_guard lck(save_mu_);
-    start_save_time_.reset();
-  }
-  if (!ignore_state)
-    service_.SwitchState(GlobalState::SAVING, GlobalState::ACTIVE);
+
   return res;
 }
 
@@ -1329,7 +1333,7 @@ error_code ServerFamily::Drakarys(Transaction* transaction, DbIndex db_ind) {
   return error_code{};
 }
 
-LastSaveInfo ServerFamily::GetLastSaveInfo() const {
+detail::LastSaveInfo ServerFamily::GetLastSaveInfo() const {
   lock_guard lk(save_mu_);
   return last_save_info_;
 }
@@ -1841,10 +1845,10 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
       append("replication_full_sync_buffer_bytes", repl_mem.full_sync_buf_bytes_);
     }
 
-    if (IsSaving()) {
+    {
       lock_guard lk{save_mu_};
-      if (save_bytes_cb_) {
-        append("save_buffer_bytes", save_bytes_cb_());
+      if (save_controller_) {
+        append("save_buffer_bytes", save_controller_->GetSaveBuffersSize());
       }
     }
   }
@@ -1914,9 +1918,17 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
     size_t is_loading = service_.GetGlobalState() == GlobalState::LOADING;
     append("loading", is_loading);
 
-    auto curent_durration_sec =
-        start_save_time_ ? (absl::Now() - *start_save_time_) / absl::Seconds(1) : 0;
-    append("saving", curent_durration_sec != 0);
+    bool is_saving = false;
+    uint32_t curent_durration_sec = 0;
+    {
+      lock_guard lk{save_mu_};
+      if (save_controller_) {
+        is_saving = true;
+        curent_durration_sec = save_controller_->GetCurrentSaveDuratio();
+      }
+    }
+
+    append("saving", is_saving);
     append("current_save_duration_sec", curent_durration_sec);
 
     for (const auto& k_v : save_info.freq_map) {

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -12,6 +12,7 @@
 #include "facade/redis_parser.h"
 #include "facade/reply_builder.h"
 #include "server/channel_store.h"
+#include "server/detail/save_stages_controller.h"
 #include "server/engine_shard_set.h"
 #include "server/replica.h"
 #include "server/server_state.h"
@@ -103,18 +104,6 @@ struct Metrics {
   std::vector<ReplicaRoleInfo> replication_metrics;
 };
 
-struct LastSaveInfo {
-  // last success save info
-  time_t save_time = 0;  // epoch time in seconds.
-  uint32_t success_duration_sec = 0;
-  std::string file_name;                                      //
-  std::vector<std::pair<std::string_view, size_t>> freq_map;  // RDB_TYPE_xxx -> count mapping.
-  // last error save info
-  GenericError last_error;
-  time_t last_error_time = 0;      // epoch time in seconds.
-  time_t failed_duration_sec = 0;  // epoch time in seconds.
-};
-
 struct SnapshotSpec {
   std::string hour_spec;
   std::string minute_spec;
@@ -167,14 +156,15 @@ class ServerFamily {
   // if kDbAll is passed, burns all the databases to the ground.
   std::error_code Drakarys(Transaction* transaction, DbIndex db_ind);
 
-  LastSaveInfo GetLastSaveInfo() const;
+  detail::LastSaveInfo GetLastSaveInfo() const;
 
   // Load snapshot from file (.rdb file or summary.dfs file) and return
   // future with error_code.
   util::fb2::Future<GenericError> Load(const std::string& file_name);
 
   bool IsSaving() const {
-    return is_saving_.load(std::memory_order_relaxed);
+    std::lock_guard lk(save_mu_);
+    return save_controller_ && save_controller_->IsSaving();
   }
 
   void ConfigureMetrics(util::HttpListenerBase* listener);
@@ -281,14 +271,8 @@ class ServerFamily {
 
   time_t start_time_ = 0;  // in seconds, epoch time.
 
-  LastSaveInfo last_save_info_ ABSL_GUARDED_BY(save_mu_);
-  std::atomic_bool is_saving_{false};
-  // this field duplicate SaveStagesController::start_save_time_
-  // TODO make SaveStagesController as member of this class
-  std::optional<absl::Time> start_save_time_;
-  // If a save operation is currently in progress, calling this function will provide information
-  // about the memory consumption during the save operation.
-  std::function<size_t()> save_bytes_cb_ = nullptr;
+  detail::LastSaveInfo last_save_info_ ABSL_GUARDED_BY(save_mu_);
+  std::unique_ptr<detail::SaveStagesController> save_controller_ ABSL_GUARDED_BY(save_mu_);
 
   // Used to override save on shutdown behavior that is usually set
   // be --dbfilename.

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -174,10 +174,7 @@ class ServerFamily {
   // future with error_code.
   util::fb2::Future<GenericError> Load(const std::string& file_name);
 
-  bool TEST_IsSaving() const {
-    std::lock_guard lk(save_mu_);
-    return save_controller_ && save_controller_->TEST_IsSaving();
-  }
+  bool TEST_IsSaving() const;
 
   void ConfigureMetrics(util::HttpListenerBase* listener);
 

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -52,6 +52,10 @@ size_t SliceSnapshot::GetThreadLocalMemoryUsage() {
   return mem;
 }
 
+bool SliceSnapshot::IsSnaphotInProgress() {
+  return tl_slice_snapshots.size() > 0;
+}
+
 void SliceSnapshot::Start(bool stream_journal, const Cancellation* cll) {
   DCHECK(!snapshot_fb_.IsJoinable());
 

--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -61,6 +61,7 @@ class SliceSnapshot {
   ~SliceSnapshot();
 
   static size_t GetThreadLocalMemoryUsage();
+  static bool IsSnaphotInProgress();
 
   // Initialize snapshot, start bucket iteration fiber, register listeners.
   // In journal streaming mode it needs to be stopped by either Stop or Cancel.

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -125,21 +125,21 @@ async def test_dbfilenames(
 
 @pytest.mark.slow
 @dfly_args({**BASIC_ARGS, "dbfilename": "test-cron", "snapshot_cron": "* * * * *"})
-async def test_cron_snapshot(tmp_path: Path, async_client: aioredis.Redis):
+async def test_cron_snapshot(tmp_dir: Path, async_client: aioredis.Redis):
     await StaticSeeder(**LIGHTWEIGHT_SEEDER_ARGS).run(async_client)
 
     file = None
     with async_timeout.timeout(65):
         while file is None:
             await asyncio.sleep(1)
-            file = find_main_file(tmp_path, "test-cron-summary.dfs")
+            file = find_main_file(tmp_dir, "test-cron-summary.dfs")
 
-    assert file is not None, os.listdir(tmp_path)
+    assert file is not None, os.listdir(tmp_dir)
 
 
 @pytest.mark.slow
 @dfly_args({**BASIC_ARGS, "dbfilename": "test-cron-set"})
-async def test_set_cron_snapshot(tmp_path: Path, async_client: aioredis.Redis):
+async def test_set_cron_snapshot(tmp_dir: Path, async_client: aioredis.Redis):
     await StaticSeeder(**LIGHTWEIGHT_SEEDER_ARGS).run(async_client)
 
     await async_client.config_set("snapshot_cron", "* * * * *")
@@ -148,7 +148,7 @@ async def test_set_cron_snapshot(tmp_path: Path, async_client: aioredis.Redis):
     with async_timeout.timeout(65):
         while file is None:
             await asyncio.sleep(1)
-            file = find_main_file(tmp_path, "test-cron-set-summary.dfs")
+            file = find_main_file(tmp_dir, "test-cron-set-summary.dfs")
 
     assert file is not None
 


### PR DESCRIPTION
fixes #2597 
The bug:
server crashed because when replicaof no one was executed the replica was creating a snapshot and there for the server state was not active but saving.
check fail -server_family.cc:2142] Check failed: service_.SwitchState(GlobalState::LOADING, GlobalState::ACTIVE).first == GlobalState::ACTIVE Server is set to replica no one, yet state is not active!
The fix:
1. remove saving from server states
2. move save stage controller to be a member of server family
