### PR TITLE
chore: doc_accessors now parse with json::Path as well

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,6 @@ endif()
 include(third_party)
 include(internal)
 
-set(USE_FB2 ON CACHE BOOL "")
-
 include_directories(src)
 include_directories(helio)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -188,8 +188,6 @@ endfunction()
 # the output file resides in the build directory.
 configure_file(server/version.cc.in "${CMAKE_CURRENT_SOURCE_DIR}/server/version.cc" @ONLY)
 
-add_definitions(-DUSE_FB2)
-
 add_subdirectory(redis)
 add_subdirectory(core)
 add_subdirectory(facade)


### PR DESCRIPTION
search_family_test passes witth `--jsonpathv2`

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->