### PR TITLE
fix: provide more context in case we have duplicate keys

### DIFF
--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -1219,8 +1219,24 @@ StringMap* HSetFamily::ConvertToStrMap(uint8_t* lp) {
     lp_elem = lpNext(lp, lp_elem);  // switch to value
     DCHECK(lp_elem);
     string_view value = LpGetView(lp_elem, intbuf[1]);
-    lp_elem = lpNext(lp, lp_elem);       // switch to next key
-    CHECK(sm->AddOrUpdate(key, value));  // must be unique
+    lp_elem = lpNext(lp, lp_elem);  // switch to next key
+
+    // must be unique
+    if (!sm->AddOrUpdate(key, value)) {
+      uint8_t tmpbuf[LP_INTBUF_SIZE];
+
+      uint8_t* it = lpFirst(lp);
+      LOG(ERROR) << "Internal error while converting listpack to stringmap when inserting key: "
+                 << key << " , listpack keys are:";
+      do {
+        string_view key = LpGetView(it, tmpbuf);
+        LOG(ERROR) << "Listpack key: " << key;
+        it = lpNext(lp, it);
+        CHECK(it);  // value must exist
+        it = lpNext(lp, it);
+      } while (it);
+      LOG(ERROR) << "Internal error, report to Dragonfly team! ------------";
+    }
   } while (lp_elem);
 
   return sm;


### PR DESCRIPTION
Partially addresses #2500 and avoid crashing the process.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->