### PR TITLE
fix: crash when using nonexistent global variable in lua

### DIFF
--- a/src/core/interpreter.cc
+++ b/src/core/interpreter.cc
@@ -226,8 +226,17 @@ string_view TopSv(lua_State* lua) {
 }
 
 optional<int> FetchKey(lua_State* lua, const char* key) {
+  lua_pushcfunction(lua, [](lua_State* lua) -> int {
+    lua_gettable(lua, -3);
+    return 1;
+  });
   lua_pushstring(lua, key);
-  int type = lua_gettable(lua, -2);
+  int status = lua_pcall(lua, 1, 1, 0);
+  if (status != LUA_OK) {
+    lua_pop(lua, 1);
+    return nullopt;
+  }
+  int type = lua_type(lua, -1);
   if (type == LUA_TNIL) {
     lua_pop(lua, 1);
     return nullopt;

--- a/src/core/interpreter_test.cc
+++ b/src/core/interpreter_test.cc
@@ -472,4 +472,11 @@ TEST_F(InterpreterTest, Log) {
   EXPECT_EQ("nil", ser_.res);
 }
 
+TEST_F(InterpreterTest, Robust) {
+  EXPECT_FALSE(Execute(R"(eval "local a = {}
+      setmetatable(a,{__index=function() foo() end})
+      return a")"));
+  EXPECT_EQ("", ser_.res);
+}
+
 }  // namespace dfly


### PR DESCRIPTION
```
eval "local a = {}; setmetatable(a,{__index=function() foo() end}) return a" 1 0
```
This command can make dragonfly crash, I fix it.