### PR TITLE
feat(generic_family): implement RANDOMKEY command

### DIFF
--- a/src/server/generic_family.h
+++ b/src/server/generic_family.h
@@ -68,6 +68,7 @@ class GenericFamily {
   static void Type(CmdArgList args, ConnectionContext* cntx);
   static void Dump(CmdArgList args, ConnectionContext* cntx);
   static void Restore(CmdArgList args, ConnectionContext* cntx);
+  static void RandomKey(CmdArgList args, ConnectionContext* cntx);
   static void FieldTtl(CmdArgList args, ConnectionContext* cntx);
 
   static OpResult<void> RenameGeneric(CmdArgList args, bool skip_exist_dest,

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -734,4 +734,12 @@ TEST_F(GenericFamilyTest, FieldTtl) {
   EXPECT_EQ(-3, CheckedInt({"fieldttl", "k2", "f4"}));
 }
 
+TEST_F(GenericFamilyTest, RandomKey) {
+  auto resp = Run({"randomkey"});
+  EXPECT_EQ(resp.type, RespExpr::NIL);
+
+  resp = Run({"set", "k1", "1"});
+  EXPECT_EQ(Run({"randomkey"}), "k1");
+}
+
 }  // namespace dfly


### PR DESCRIPTION
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->

Resolves #443.

Redis claims to have `O(1)` time complexity because:
1. it sets a threshold of 100 tries to get a key, each try it:
2. collects 15 entries from a random `dict` then:
3. gets a random entry from those 15
4. if the key is not expire, returns the key, else go back to step 2.

~So for this solution I set a threshold of 15 entries, and loop through all shards in parallel collecting 2 entries per child, then I take one random index of these collection.~

Sometimes the `RANDOMKEY` command throws the following error on the `std::vector<>::~vector()`:
```shell
*** SIGSEGV received at time=1708536096 on cpu 0 ***
PC: @     0x55a4ffdb89f9  (unknown)  mi_free
    @     0x55a5007d8b38        192  absl::lts_20230802::WriteFailureInfo()
    @     0x55a5007d910d        272  absl::lts_20230802::AbslFailureSignalHandler()
    @     0x7fcd9382d420  (unknown)  (unknown)
    @     0x55a4fdb9c8d3         48  std::_Destroy<>()
    @     0x55a4fdb9cdda         48  std::_Destroy_aux<>::__destroy<>()
    @     0x55a4fdb9a97c         32  std::_Destroy<>()
    @     0x55a4fdb9ce35         48  std::_Destroy<>()
    @     0x55a4fdb9aad1         48  std::vector<>::~vector()
    @     0x55a4fddda8d7       1056  dfly::GenericFamily::RandomKey()
    @     0x55a4fde57d85         80  fu2::abi_400::detail::invocation::invoke<>()
    @     0x55a4fde54ab2        288  fu2::abi_400::detail::type_erasure::invocation_table::function_trait<>::internal_invoker<>::invoke()
    @     0x55a4ff566494        128  fu2::abi_400::detail::type_erasure::tables::vtable<>::invoke<>()
    @     0x55a4ff5667e0        240  fu2::abi_400::detail::type_erasure::erasure<>::invoke<>()
    @     0x55a4ff5669fd        240  fu2::abi_400::detail::type_erasure::invocation_table::operator_impl<>::operator()()
    @     0x55a4ff55b6d7        240  dfly::CommandId::Invoke()
    @     0x55a4fe2bbfc1       1520  dfly::Service::InvokeCmd()
    @     0x55a4fe2ba2b3       1776  dfly::Service::DispatchCommand()
    @     0x55a4ffbd3fc9        384  facade::Connection::DispatchCommand()
    @     0x55a4ffbd51fe        400  facade::Connection::ParseRedis()
    @     0x55a4ffbdbdc1       1264  facade::Connection::IoLoop()
    @     0x55a4ffbcf4d6       1808  facade::Connection::ConnectionFlow()
    @     0x55a4ffbc645d       1488  facade::Connection::HandleRequests()
    @     0x55a500348c23       1312  util::ListenerInterface::RunSingleConnection()
    @     0x55a500340fbd         48  util::ListenerInterface::RunAcceptLoop()::{lambda()#2}::operator()()
    @     0x55a5003643dc         48  std::__invoke_impl<>()
    @     0x55a500361067         32  std::__invoke<>()
    @     0x55a50035d9bb         32  std::__apply_impl<>()
    @     0x55a50035da32         48  std::apply<>()
    @     0x55a50035dd13        224  util::fb2::detail::WorkerFiberImpl<>::run_()
    @     0x55a50035b786         80  util::fb2::detail::WorkerFiberImpl<>::WorkerFiberImpl<>()::{lambda()#1}::operator()()
    @     0x55a5003703d1         80  std::__invoke_impl<>()
    @     0x55a50036dc03         80  std::__invoke<>()
    @ ... and at least 4 more frames
```