### PR TITLE
fix: fix zmalloc_size on macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           df -h
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.4
 
       - name: Configure Cache Env
         uses: actions/github-script@v6

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -37,10 +37,10 @@ jobs:
         with:
           submodules: true
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.4
 
       - name: Configure Cache Env
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -73,10 +73,20 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.4
+
+      - name: Configure Cache Env
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '')
+
       - name: Install dependencies
         run: |
           brew update && brew install ninja boost openssl automake gcc zstd bison c-ares \
-              autoconf libtool automake
+              autoconf libtool automake flatbuffers
           # brew info icu4c
           mkdir -p $GITHUB_WORKSPACE/build
 
@@ -92,7 +102,8 @@ jobs:
 
 
           echo "*************************** START BUILDING **************************************"
-          CC=gcc-13 CXX=g++-13 cmake .. -DCMAKE_BUILD_TYPE=Debug -GNinja -DWITH_UNWIND=OFF
+          CC=gcc-13 CXX=g++-13 cmake .. -DCMAKE_BUILD_TYPE=Debug -GNinja -DWITH_UNWIND=OFF \
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache
 
           ninja src/all
 

--- a/src/redis/zmalloc.h
+++ b/src/redis/zmalloc.h
@@ -50,7 +50,11 @@
 #elif defined(__APPLE__)
 #include <malloc/malloc.h>
 #define HAVE_MALLOC_SIZE 1
+#ifdef USE_ZMALLOC_MI
+#define zmalloc_size(p) zmalloc_usable_size(p)
+#else
 #define zmalloc_size(p) malloc_size(p)
+#endif
 #define ZMALLOC_LIB "macos"
 #endif
 


### PR DESCRIPTION
Fixes `hset_family_test` tests on MacOS

Looks like `zmalloc_size` isn't defined properly on Mac, so `zmalloc` uses `src/redis/zmalloc_mi.c` definition but `zmalloc_size` uses `malloc_size`
```
void *zp = zmalloc(10);
cout << "zmalloc; zmalloc_size " << zmalloc_size(zp) << endl;  // 0
cout << "zmalloc; malloc_size " << malloc_size(zp) << endl;  // 0
cout << "zmalloc; zmalloc_usable_size " << zmalloc_usable_size(zp) << endl;  // 16
void *mp = malloc(10);
cout << "malloc; malloc_size " << malloc_size(mp) << endl;  // 16
cout << "malloc; zmalloc_size " << zmalloc_size(mp) << endl;  // 16
```

This just copies the `USE_ZMALLOC_MI` branch from `libc` into `macos` branch (I don't really understand this allocator stuff but with this the `hset_family_test` tests pass running locally on Mac - will run rest of the tests on mac)

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->