### PR TITLE
chore: JSON.GET now works with our own jsonpath

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
           ./dragonfly_test
           ./multi_test --multi_exec_mode=1
           ./multi_test --multi_exec_mode=3
-          # GLOG_logtostderr=1 GLOG_vmodule=transaction=1,engine_shard_set=1 CTEST_OUTPUT_ON_FAILURE=1 ninja server/test
+          ./json_family_test --jsonpathv2
 
       - name: Upload unit logs on failure
         if: failure()

--- a/src/core/json/path.cc
+++ b/src/core/json/path.cc
@@ -432,8 +432,10 @@ JsonType PathSegment::GetResult() const {
 }
 
 void EvaluatePath(const Path& path, const JsonType& json, PathCallback callback) {
-  if (path.empty())
+  if (path.empty()) {  // root node
+    callback(nullopt, json);
     return;
+  }
 
   if (path.front().type() != SegmentType::FUNCTION) {
     Dfs().Traverse(path, json, std::move(callback));

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -276,6 +276,9 @@ TEST_F(JsonFamilyTest, Toggle) {
   auto resp = Run({"JSON.SET", "json", ".", json});
   ASSERT_THAT(resp, "OK");
 
+  resp = Run({"JSON.GET", "json", "$.*"});
+  EXPECT_EQ(R"([true,false,1,null,"foo",[],{}])", resp);
+
   resp = Run({"JSON.TOGGLE", "json", "$.*"});
   ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
   EXPECT_THAT(resp.GetVec(),


### PR DESCRIPTION
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->