### PR TITLE
chore: Move CallFromScript log to level 2

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1604,7 +1604,7 @@ optional<CapturingReplyBuilder::Payload> Service::FlushEvalAsyncCmds(ConnectionC
 
 void Service::CallFromScript(ConnectionContext* cntx, Interpreter::CallArgs& ca) {
   DCHECK(cntx->transaction);
-  DVLOG(1) << "CallFromScript " << ArgS(ca.args, 0);
+  DVLOG(2) << "CallFromScript " << ArgS(ca.args, 0);
 
   InterpreterReplier replier(ca.translator);
   facade::SinkReplyBuilder* orig = cntx->Inject(&replier);


### PR DESCRIPTION
With the new seeder, this shows up all the time in the logs - it slows execution down. The new seeder also uses squasing, so it might provide not much insight into what was executed last