### PR TITLE
fix: replace localhost with 127.0.0.1 in cluster tests

### DIFF
--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -1011,7 +1011,7 @@ async def test_cluster_fuzzymigration(
                 "slot_ranges": [{"start": s, "end": e} for (s, e) in node.slots],
                 "master": {
                     "id": await get_node_id(node.admin_client),
-                    "ip": "localhost",
+                    "ip": "127.0.0.1",
                     "port": node.instance.port,
                 },
                 "replicas": [],

--- a/tests/dragonfly/utility.py
+++ b/tests/dragonfly/utility.py
@@ -448,7 +448,7 @@ class DflySeeder:
 
     def _make_client(self, **kwargs):
         if self.cluster_mode:
-            return aioredis.RedisCluster(host="localhost", **kwargs)
+            return aioredis.RedisCluster(host="127.0.0.1", **kwargs)
         else:
             return aioredis.Redis(**kwargs)
 


### PR DESCRIPTION
Redis-py has a bug where they don't find a cached connection once they normalize the host address (i.e. replace localhost with 127.0.0.1), this leads to `Unclosed ClusterNode object` error if a note has more than one slot range

Maybe it's fixed in the latest version 🤷🏻‍♂️ 