### PR TITLE
fix: optionally return float as integer from lua script

### DIFF
--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -160,7 +160,7 @@ ostream& operator<<(ostream& os, const facade::RespExpr& e) {
       os << "i" << get<int64_t>(e.u);
       break;
     case RespExpr::DOUBLE:
-      os << "d" << get<int64_t>(e.u);
+      os << "d" << get<double>(e.u);
       break;
     case RespExpr::STRING:
       os << "'" << ToSV(get<RespExpr::Buffer>(e.u)) << "'";


### PR DESCRIPTION
Redis, due to its old lua enginer and bunch of historic reasons returns floats as integers from lua scripts. This means `eval "return 42.9" 0` would return 42 as long integer.

Dragonfly supports both integers and floats in its lua engine, returning a precise "42.9" in the same scenario. RESP2 does not support float types so "42.9" is returned as a bulk string for RESP2 connections. For RESP3, dragonfly returns 42.9 as a native RESP3 double primitive.

This PR introduces an optional legacy behavior for Dragonfly only for the RESP2 protocol. When the `--lua_resp2_legacy_float` flag is passed, Dragonfly will round down the double value to the nearest integer and return it as RESP2 native long integer.

Fixes #2664

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->