### PR TITLE
fix: missing manual trigger for daily sanitizers

### DIFF
--- a/.github/workflows/daily-sanitizers.yml
+++ b/.github/workflows/daily-sanitizers.yml
@@ -3,6 +3,7 @@ name: daily-sanitizers
 on:
   schedule:
     - cron: '0 4 * * *' # run at 4 AM UTC
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
I forgot to add a manual trigger to daily sanitizers.