### PR TITLE
bug(tiering): fix overflow in page offset calculation and wrong hash offset calculation

### DIFF
--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -221,7 +221,7 @@ void TieredStorage::InflightWriteRequest::Add(const PrimeKey& pk, const PrimeVal
   unsigned bin_size = kSmallBins[bin_index_];
   unsigned max_entries = NumEntriesInSmallBin(bin_size);
 
-  char* next_hash = block_start_ + entries_.size();
+  char* next_hash = block_start_ + entries_.size() * 8;
   char* next_data = block_start_ + max_entries * 8 + entries_.size() * bin_size;
 
   DCHECK_LE(pv.Size(), bin_size);
@@ -270,7 +270,7 @@ unsigned TieredStorage::InflightWriteRequest::ExternalizeEntries(PerDb::BinRecor
 
     if (it != bin_record->enqueued_entries.end() && it->second == this) {
       PrimeIterator pit = pt->Find(pkey);
-      size_t item_offset = page_index_ * 4096 + offset + i * bin_size;
+      size_t item_offset = size_t(page_index_) * 4096 + offset + i * bin_size;
       CHECK(!pit.is_done());
 
       ExternalizeEntry(item_offset, stats, &pit->second);


### PR DESCRIPTION
When `page_index` (uint32_t) gets larger, its multiplication with 4096 would overflow:

```
size_t item_offset = page_index_ * 4096 + offset + i * bin_size;
```
The overflow causes DF crash when there are many keys get inserted. To reproduce, start DF with

```
./dragonfly --logtostderr --dbfilename="" --tiered_prefix=/tmp/df/ssd --backing_file_direct --maxmemory=260m --proactor_threads=1 --tiered_offload_threshold=100
```

Then issue the following memtier command until we see it gets rejected by OOM, kill the command afterwards.

```
memtier_benchmark -p 6379 --pipeline=30 --key-maximum=34375401 -n allkeys --data-size=1024 --ratio=1:0 --key-pattern=P:P --distinct-client-seed -c 2 -t 8
```

Then issue the following Redis command:

```
redis-cli flushdb
```

which yields the crash:

```
F20240303 23:27:26.326807 2397213 tiered_storage.cc:342] Check failed: it != page_refcnt_.end() 30894                                                                                                                                                                                                                                                                                                                                   
*** Check failure stack trace: ***                                                                                                                                                                                                                                                                                                                                                                                                      
    @     0x55cb2a446990  google::LogMessage::Fail()                                                                                                                                                                                                                                                                                                                                                                                    
    @     0x55cb2a44de67  google::LogMessage::SendToLog()                                                                                                                                                                                                                                                                                                                                                                               
    @     0x55cb2a4463a3  google::LogMessage::Flush()                                                                                                                                                                                                                                                                                                                                                                                   
    @     0x55cb2a447d3f  google::LogMessageFatal::~LogMessageFatal()                                                                                                                                                                                                                                                                                                                                                                   
    @     0x55cb29f18a1f  dfly::TieredStorage::Free()                                                                                                                                                                                                                                                                                                                                                                                   
    @     0x55cb29ecf59a  dfly::DbSlice::RemoveFromTiered()                                                                                                                                                                                                                                                                                                                                                                             
    @     0x55cb29ed3726  dfly::DbSlice::PerformDeletion()                                                                                                                                                                                                                                                                                                                                                                              
    @     0x55cb29ed5e7b  _ZN5boost7context6detail11fiber_entryINS1_12fiber_recordINS0_5fiberENS0_21basic_fixedsize_stackINS0_12stack_traitsEEEZN4util3fb26detail15WorkerFiberImplIZN4dfly7DbSlice14FlushDbIndexesERKSt6vectorItSaItEEEUlvE_JEEC4IS7_EESt17basic_string_viewIcSt11char_traitsIcEERKNS0_12preallocatedEOT_OSJ_EUlOS4_E_EEEEvNS1_10transfer_tE                                                                            
    @     0x7f1d58a3b24f  make_fcontext                                                                                                                                                                                                                                                                                                                                                                                                 
*** SIGABRT received at time=1709537246 on cpu 0 ***                                                                                                                                                                                                                                                                                                                                                                                    
PC: @     0x7f1d5808b9fc  (unknown)  pthread_kill                                                                                                                                                                                                                                                                                                                                                                                       
[1]+  Exit 1                  rm /tmp/df/ssd*                                                                                                                                                                                                                                                                                                                                                                                           
Aborted (core dumped)                                      
```

fixed by converting it to `size_t`

Also fix the wrong calculation of hash's offset in a page.

 