### PR TITLE
fix(flushall): Decommit memory after releasing tables.

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -764,6 +764,7 @@ void DbSlice::FlushDbIndexes(const std::vector<DbIndex>& indexes) {
         db_ptr.reset();
       }
     }
+    flush_db_arr.clear();
     mi_heap_collect(ServerState::tlocal()->data_heap(), true);
   };
 


### PR DESCRIPTION
In the fiber we used to call `mi_heap_collect()` when we're done deleting items. But since that fiber captures a `vector` of intrusive pointers to `DbTable`s, it can't free all memory used by the tables themselves.

A local test shows that this fix helps almost entirely: when occupying a 5gb DB, `FLUSHALL` will reduce RSS by 4.7gb, leaving 300mb still used. A follow up `MEMORY DECOMMIT` *will* indeed remove these 300mb, but I'm still not sure why they are not released immediately. Still looking...

Addresses (1) of #2690

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->