### PR TITLE
feat(cluster): Add `--cluster_id` flag

### DIFF
--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -53,12 +53,15 @@ thread_local shared_ptr<ClusterConfig> tl_cluster_config;
 ClusterFamily::ClusterFamily(ServerFamily* server_family) : server_family_(server_family) {
   CHECK_NOTNULL(server_family_);
 
+  ClusterConfig::Initialize();
+
   id_ = absl::GetFlag(FLAGS_cluster_node_id);
   if (id_.empty()) {
     id_ = server_family_->master_replid();
+  } else if (ClusterConfig::IsEmulated()) {
+    LOG(ERROR) << "Setting --cluster_node_id in emulated mode is unsupported";
+    exit(1);
   }
-
-  ClusterConfig::Initialize();
 }
 
 ClusterConfig* ClusterFamily::cluster_config() {

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -25,7 +25,7 @@
 #include "server/server_state.h"
 
 ABSL_FLAG(std::string, cluster_announce_ip, "", "ip that cluster commands announce to the client");
-ABSL_FLAG(std::string, cluster_id, "",
+ABSL_FLAG(std::string, cluster_node_id, "",
           "ID within a cluster, used for slot assignment. MUST be unique. If empty, uses master "
           "replication ID (random string)");
 
@@ -53,7 +53,7 @@ thread_local shared_ptr<ClusterConfig> tl_cluster_config;
 ClusterFamily::ClusterFamily(ServerFamily* server_family) : server_family_(server_family) {
   CHECK_NOTNULL(server_family_);
 
-  id_ = absl::GetFlag(FLAGS_cluster_id);
+  id_ = absl::GetFlag(FLAGS_cluster_node_id);
   if (id_.empty()) {
     id_ = server_family_->master_replid();
   }

--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -100,6 +100,8 @@ class ClusterFamily {
  private:
   ClusterConfig::ClusterShard GetEmulatedShardInfo(ConnectionContext* cntx) const;
 
+  std::string id_;
+
   ServerFamily* server_family_ = nullptr;
 };
 

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -190,7 +190,7 @@ void DflyCmd::Flow(CmdArgList args, ConnectionContext* cntx) {
   VLOG(1) << "Got DFLY FLOW master_id: " << master_id << " sync_id: " << sync_id_str
           << " flow: " << flow_id_str << " seq: " << seqid.value_or(-1);
 
-  if (master_id != sf_->master_id()) {
+  if (master_id != sf_->master_replid()) {
     return rb->SendError(kBadMasterId);
   }
 

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -187,8 +187,8 @@ class ServerFamily {
   void PauseReplication(bool pause);
   std::optional<ReplicaOffsetInfo> GetReplicaOffsetInfo();
 
-  const std::string& master_id() const {
-    return master_id_;
+  const std::string& master_replid() const {
+    return master_replid_;
   }
 
   journal::Journal* journal() {
@@ -282,7 +282,7 @@ class ServerFamily {
   std::unique_ptr<journal::Journal> journal_;
   std::unique_ptr<DflyCmd> dfly_cmd_;
 
-  std::string master_id_;
+  std::string master_replid_;
 
   time_t start_time_ = 0;  // in seconds, epoch time.
 

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -185,6 +185,7 @@ async def test_cluster_node_id(df_local_factory: DflyInstanceFactory):
     await close_clients(conn)
 
 
+@dfly_args({"proactor_threads": 4, "cluster_mode": "yes"})
 async def test_cluster_slot_ownership_changes(df_local_factory: DflyInstanceFactory):
     # Start and configure cluster with 2 nodes
     nodes = [

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -174,6 +174,17 @@ Also add keys to each of them that are *not* moved, and see that they are unaffe
 """
 
 
+@dfly_args({"proactor_threads": 4, "cluster_mode": "yes", "cluster_id": "inigo montoya"})
+async def test_cluster_id(df_local_factory: DflyInstanceFactory):
+    node = df_local_factory.create(port=BASE_PORT)
+    df_local_factory.start_all([node])
+
+    conn = node.client()
+    assert "inigo montoya" == await get_node_id(conn)
+
+    await close_clients(conn)
+
+
 @dfly_args({"proactor_threads": 4, "cluster_mode": "yes"})
 async def test_cluster_slot_ownership_changes(df_local_factory: DflyInstanceFactory):
     # Start and configure cluster with 2 nodes

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -316,11 +316,8 @@ async def test_cluster_slot_ownership_changes(df_local_factory: DflyInstanceFact
 
 
 # Tests that master commands to the replica are applied regardless of slot ownership
-@pytest.mark.parametrize("set_cluster_node_id", [True, False])
 @dfly_args({"proactor_threads": 4, "cluster_mode": "yes"})
-async def test_cluster_replica_sets_non_owned_keys(
-    df_local_factory: DflyInstanceFactory, set_cluster_node_id: bool
-):
+async def test_cluster_replica_sets_non_owned_keys(df_local_factory: DflyInstanceFactory):
     # Start and configure cluster with 1 master and 1 replica, both own all slots
     master = df_local_factory.create(admin_port=BASE_PORT + 1000)
     replica = df_local_factory.create(admin_port=BASE_PORT + 1001)

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -607,11 +607,13 @@ async def test_cluster_native_client(
             port=BASE_PORT + 100 + i,
             admin_port=BASE_PORT + i + 1100,
             cluster_node_id=f"replica{i}" if set_cluster_node_id else "",
+            replicaof=f"localhost:{BASE_PORT + i}",
         )
         for i in range(3)
     ]
     df_local_factory.start_all(replicas)
     c_replicas = [replica.client() for replica in replicas]
+    await asyncio.gather(*(wait_available_async(c) for c in c_replicas))
     c_replicas_admin = [replica.admin_client() for replica in replicas]
     replica_ids = await asyncio.gather(*(get_node_id(c) for c in c_replicas_admin))
 

--- a/tests/dragonfly/utility.py
+++ b/tests/dragonfly/utility.py
@@ -46,12 +46,8 @@ async def wait_available_async(client: aioredis.Redis, timeout=10):
     start = time.time()
     while (time.time() - start) < timeout:
         try:
-            await client.get("key")
+            await client.ping()
             return
-        except aioredis.ResponseError as e:
-            if "MOVED" in str(e):
-                # MOVED means we *can* serve traffic, but 'key' does not belong to an owned slot
-                return
         except aioredis.BusyLoadingError as e:
             assert "Dragonfly is loading the dataset in memory" in str(e)
 


### PR DESCRIPTION
This flag sets the unique ID of a node in a cluster.

It is UB (and bad) to set the same ID to multiple nodes in a cluster.

If unset (default), the `master_replid` (previously known as `master_id`) is used.

Fixes #2643
Related to #2636

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->