### PR TITLE
fix(BgSave): async from sync

### DIFF
--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -695,8 +695,10 @@ TEST_F(GenericFamilyTest, Info) {
   EXPECT_EQ(1, get_rdb_changes_since_last_save(resp.GetString()));
 
   EXPECT_EQ(Run({"bgsave"}), "OK");
-  resp = Run({"info", "persistence"});
-  EXPECT_EQ(0, get_rdb_changes_since_last_save(resp.GetString()));
+  WaitUntilCondition([&]() {
+    resp = Run({"info", "persistence"});
+    return get_rdb_changes_since_last_save(resp.GetString()) == 0;
+  });
 
   EXPECT_EQ(Run({"set", "k3", "3"}), "OK");
   resp = Run({"info", "persistence"});

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1642,8 +1642,7 @@ void ServerFamily::Memory(CmdArgList args, ConnectionContext* cntx) {
   return mem_cmd.Run(args);
 }
 
-void ServerFamily::BgSaveFb(bool new_version, std::string basename,
-                            boost::intrusive_ptr<Transaction> trans) {
+void ServerFamily::BgSaveFb(boost::intrusive_ptr<Transaction> trans) {
   GenericError ec = WaitUntilSaveFinished(trans.get());
   if (ec) {
     LOG(INFO) << "Error in BgSaveFb: " << ec.Format();
@@ -1695,9 +1694,8 @@ void ServerFamily::BgSave(CmdArgList args, ConnectionContext* cntx) {
     return;
   }
   bg_save_fb_.JoinIfNeeded();
-  bg_save_fb_ =
-      fb2::Fiber("bg_save_fiber", &ServerFamily::BgSaveFb, this, version, std::string(basename),
-                 boost::intrusive_ptr<Transaction>(cntx->transaction));
+  bg_save_fb_ = fb2::Fiber("bg_save_fiber", &ServerFamily::BgSaveFb, this,
+                           boost::intrusive_ptr<Transaction>(cntx->transaction));
   cntx->SendOk();
 }
 

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -266,7 +266,18 @@ class ServerFamily {
 
   void SendInvalidationMessages() const;
 
+  // Helper function for arg checks in BgSave and Save paths
+  // In case of an error an empty optional is returned. Otherwise, we return a bool
+  // denoting the version (true for dfs rdb, false for plain rdb)
+  std::optional<bool> ParseSaveArgs(CmdArgList args, ConnectionContext* cntx);
+
   void BgSaveFb(bool new_version, std::string basename, boost::intrusive_ptr<Transaction> trans);
+
+  GenericError DoSaveCheckAndStart(bool new_version, string_view basename, Transaction* trans,
+                                   bool ignore_state = false);
+
+  GenericError PauseUntilSaved(bool new_version, string_view basename, Transaction* trans,
+                               bool ignore_state = false);
 
   Fiber snapshot_schedule_fb_;
   util::fb2::Future<GenericError> load_result_;
@@ -301,8 +312,8 @@ class ServerFamily {
   std::shared_ptr<detail::SnapshotStorage> snapshot_storage_;
 
   Mutex bg_save_mu_;
+  // protected by save_mu_
   util::fb2::Fiber bg_save_fb_;
-  bool bg_save_fb_done_ = false;
 
   mutable util::fb2::Mutex peak_stats_mu_;
   mutable PeakStats peak_stats_;

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -271,7 +271,7 @@ class ServerFamily {
   using VersionBasename = std::pair<bool, std::string_view>;
   std::optional<VersionBasename> GetVersionAndBasename(CmdArgList args, ConnectionContext* cntx);
 
-  void BgSaveFb(bool new_version, std::string basename, boost::intrusive_ptr<Transaction> trans);
+  void BgSaveFb(boost::intrusive_ptr<Transaction> trans);
 
   GenericError DoSaveCheckAndStart(bool new_version, string_view basename, Transaction* trans,
                                    bool ignore_state = false);

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -242,6 +242,7 @@ class ServerFamily {
   void ReplConf(CmdArgList args, ConnectionContext* cntx);
   void Role(CmdArgList args, ConnectionContext* cntx);
   void Save(CmdArgList args, ConnectionContext* cntx);
+  void BgSave(CmdArgList args, ConnectionContext* cntx);
   void Script(CmdArgList args, ConnectionContext* cntx);
   void SlowLog(CmdArgList args, ConnectionContext* cntx);
   void Module(CmdArgList args, ConnectionContext* cntx);
@@ -264,6 +265,8 @@ class ServerFamily {
   void SnapshotScheduling();
 
   void SendInvalidationMessages() const;
+
+  void BgSaveFb(bool new_version, std::string basename, boost::intrusive_ptr<Transaction> trans);
 
   Fiber snapshot_schedule_fb_;
   util::fb2::Future<GenericError> load_result_;
@@ -296,6 +299,10 @@ class ServerFamily {
   util::fb2::Done schedule_done_;
   std::unique_ptr<util::fb2::FiberQueueThreadPool> fq_threadpool_;
   std::shared_ptr<detail::SnapshotStorage> snapshot_storage_;
+
+  Mutex bg_save_mu_;
+  util::fb2::Fiber bg_save_fb_;
+  bool bg_save_fb_done_ = false;
 
   mutable util::fb2::Mutex peak_stats_mu_;
   mutable PeakStats peak_stats_;

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2022,16 +2022,13 @@ async def test_saving_replica(df_local_factory):
     async def save_replica():
         await c_replica.execute_command("save")
 
-    async def is_saving():
-        return "saving:1" in (await c_replica.execute_command("INFO PERSISTENCE"))
-
     save_task = asyncio.create_task(save_replica())
-    while not await is_saving():  # wait for replica start saving
+    while not await is_saving(c_replica):  # wait for replica start saving
         asyncio.sleep(0.1)
     await c_replica.execute_command("replicaof no one")
-    assert await is_saving()
+    assert await is_saving(c_replica)
     await save_task
-    assert not await is_saving()
+    assert not await is_saving(c_replica)
 
     await disconnect_clients(c_master, *[c_replica])
 
@@ -2052,15 +2049,12 @@ async def test_start_replicating_while_save(df_local_factory):
     async def save_replica():
         await c_replica.execute_command("save")
 
-    async def is_saving():
-        return "saving:1" in (await c_replica.execute_command("INFO PERSISTENCE"))
-
     save_task = asyncio.create_task(save_replica())
-    while not await is_saving():  # wait for server start saving
+    while not await is_saving(c_replica):  # wait for server start saving
         asyncio.sleep(0.1)
     await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
-    assert await is_saving()
+    assert await is_saving(c_replica)
     await save_task
-    assert not await is_saving()
+    assert not await is_saving(c_replica)
 
     await disconnect_clients(c_master, *[c_replica])

--- a/tests/dragonfly/utility.py
+++ b/tests/dragonfly/utility.py
@@ -646,3 +646,7 @@ class EnvironCntx:
                 os.environ[k] = self.undo[k]
             else:
                 del os.environ[k]
+
+
+async def is_saving(c_client: aioredis.Redis):
+    return "saving:1" in (await c_client.execute_command("INFO PERSISTENCE"))


### PR DESCRIPTION
resolves #2642

* make BgSave command async


Note that we extend the command by adding `BGSAVE [RDB_TYPE] [NAME] [SCHEDULE]` but in Redis it's `BGSAVE [SCHEDULE]`. Unfortunately, DF supports two rdb_types (df extension and plain redis rdb) and I would like to keep compatibility. 

Furthermore, the option [schedule] is missing. See: #2701