### PR TITLE
fix(channel store): add acquire/release pair in fast update path

### DIFF
--- a/src/server/channel_store.cc
+++ b/src/server/channel_store.cc
@@ -38,14 +38,14 @@ ChannelStore::UpdatablePointer::UpdatablePointer(const UpdatablePointer& other) 
 }
 
 ChannelStore::SubscribeMap* ChannelStore::UpdatablePointer::Get() const {
-  return ptr.load(memory_order_relaxed);
+  return ptr.load(memory_order_acquire);  // sync pointed memory
 }
 
 void ChannelStore::UpdatablePointer::Set(ChannelStore::SubscribeMap* sm) {
-  ptr.store(sm, memory_order_relaxed);
+  ptr.store(sm, memory_order_release);  // sync pointed memory
 }
 
-ChannelStore::SubscribeMap* ChannelStore::UpdatablePointer::operator->() {
+ChannelStore::SubscribeMap* ChannelStore::UpdatablePointer::operator->() const {
   return Get();
 }
 

--- a/src/server/channel_store.h
+++ b/src/server/channel_store.h
@@ -81,7 +81,7 @@ class ChannelStore {
     SubscribeMap* Get() const;
     void Set(SubscribeMap* sm);
 
-    SubscribeMap* operator->();
+    SubscribeMap* operator->() const;
     const SubscribeMap& operator*() const;
 
    private:


### PR DESCRIPTION
I assume this is why our ARM regtest `test_pubsub_numsub` had outdated info. This pointer is shared between threads and update immediately, but the memory behind it is not synced...