### PR TITLE
fix(transaction): Replace with armed sync point

### DIFF
--- a/src/server/blocking_controller.cc
+++ b/src/server/blocking_controller.cc
@@ -123,7 +123,7 @@ void BlockingController::FinalizeWatched(ArgSlice args, Transaction* tx) {
   VLOG(1) << "FinalizeBlocking [" << owner_->shard_id() << "]" << tx->DebugId();
 
   bool removed = awakened_transactions_.erase(tx);
-  DCHECK(!removed || (tx->GetLocalMask(owner_->shard_id()) & Transaction::AWAKED_Q));
+  DCHECK(!removed || (tx->DEBUG_GetLocalMask(owner_->shard_id()) & Transaction::AWAKED_Q));
 
   auto dbit = watched_dbs_.find(tx->GetDbIndex());
 
@@ -138,7 +138,7 @@ void BlockingController::FinalizeWatched(ArgSlice args, Transaction* tx) {
   for (string_view key : args) {
     bool removed_awakened = wt.UnwatchTx(key, tx);
     CHECK(!removed_awakened || removed)
-        << tx->DebugId() << " " << key << " " << tx->GetLocalMask(owner_->shard_id());
+        << tx->DebugId() << " " << key << " " << tx->DEBUG_GetLocalMask(owner_->shard_id());
   }
 
   if (wt.queue_map.empty()) {

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -449,7 +449,8 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
   stats_.poll_execution_total++;
 
   uint16_t local_mask = trans ? trans->DisarmInShardWhen(sid, Transaction::AWAKED_Q) : 0;
-  if (trans && local_mask == 0)
+
+  if (trans && local_mask == 0)  // If not armed, it means that this poll task expired
     return;
 
   // Blocked transactions are executed immediately after waking up
@@ -532,7 +533,7 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
     CHECK(trans->DisarmInShard(sid));
 
     bool is_ooo = local_mask & Transaction::OUT_OF_ORDER;
-    bool keep = run(trans, true);
+    bool keep = run(trans, is_ooo);
     if (is_ooo && !keep) {
       stats_.tx_ooo_total++;
     }

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -514,7 +514,8 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
             << " isarmed: " << head->DEBUG_IsArmedInShard(sid);
 
     // If the transaction isn't armed yet, it will be handled by a successive poll
-    if (!(head == trans && disarmed) && !head->DisarmInShard(sid))
+    bool should_run = (head == trans && disarmed) || head->DisarmInShard(sid);
+    if (!should_run)
       break;
 
     // Avoid processing the caller transaction below if we found it in the queue,

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -457,8 +457,8 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
   if (local_mask & Transaction::AWAKED_Q) {
     CHECK(continuation_trans_ == nullptr || continuation_trans_ == trans)
         << continuation_trans_->DebugId() << " when polling " << trans->DebugId()
-        << "cont_mask: " << continuation_trans_->GetLocalMask(sid) << " vs "
-        << trans->GetLocalMask(sid);
+        << "cont_mask: " << continuation_trans_->DEBUG_GetLocalMask(sid) << " vs "
+        << trans->DEBUG_GetLocalMask(sid);
 
     // Commands like BRPOPLPUSH don't conclude immediately
     if (trans->RunInShard(this, false)) {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -520,7 +520,7 @@ void TxTable(const http::QueryArgs& args, HttpContext* send) {
           Transaction* trx = std::get<Transaction*>(value);
 
           absl::AlphaNum an2(trx->txid());
-          absl::AlphaNum an3(trx->IsArmedInShard(sid));
+          absl::AlphaNum an3(trx->DEBUG_IsArmedInShard(sid));
           SortedTable::Row({sid_an.Piece(), tid.Piece(), an2.Piece(), an3.Piece()}, &mine);
           cur = queue->Next(cur);
         } while (cur != queue->Head());

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -6,8 +6,6 @@
 
 #include <absl/strings/match.h>
 
-#include <atomic>
-
 #include "base/logging.h"
 #include "server/blocking_controller.h"
 #include "server/command_registry.h"

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -996,7 +996,7 @@ void Transaction::FIX_ConcludeJournalExec() {
 string Transaction::DEBUG_PrintFailState(ShardId sid) const {
   auto res = StrCat(
       "usc: ", unique_shard_cnt_, ", name:", GetCId()->name(),
-      ", usecnt:", use_count_.load(memory_order_relaxed), ", runcnt: ", 0,
+      ", usecnt:", use_count_.load(memory_order_relaxed), ", runcnt: ", run_barrier_.DEBUG_Count(),
       ", coordstate: ", coordinator_state_, ", coord native thread: ", stats_.coordinator_index,
       ", schedule attempts: ", stats_.schedule_attempts, ", report from sid: ", sid, "\n");
   std::atomic_thread_fence(memory_order_acquire);

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -97,34 +97,6 @@ uint16_t trans_id(const Transaction* ptr) {
 
 }  // namespace
 
-void Transaction::PhasedBarrier::Start(uint32_t count) {
-  DCHECK_EQ(DEBUG_Count(), 0u);
-  count_.store(count, memory_order_release);
-}
-
-bool Transaction::PhasedBarrier::Active() const {
-  return count_.load(memory_order_acquire) > 0;
-}
-
-void Transaction::PhasedBarrier::Dec(Transaction* keep_alive) {
-  // Prevent transaction from being destroyed after count was decreased and Wait() unlocked,
-  // but before this thread finished notifying.
-  ::boost::intrusive_ptr guard(keep_alive);
-
-  uint32_t before = count_.fetch_sub(1);
-  CHECK_GE(before, 1u) << keep_alive->DEBUG_PrintFailState(EngineShard::tlocal()->shard_id());
-  if (before == 1)
-    ec_.notify();
-}
-
-void Transaction::PhasedBarrier::Wait() {
-  ec_.await([this] { return count_.load(memory_order_acquire) == 0; });
-}
-
-uint32_t Transaction::PhasedBarrier::DEBUG_Count() const {
-  return count_.load(memory_order_relaxed);
-}
-
 bool Transaction::BatonBarrier::IsClaimed() const {
   return claimed_.load(memory_order_relaxed);
 }
@@ -401,7 +373,7 @@ void Transaction::InitByKeys(const KeyIndex& key_index) {
   for (const auto& sd : shard_data_) {
     // sd.local_mask may be non-zero for multi transactions with instant locking.
     // Specifically EVALs may maintain state between calls.
-    DCHECK_EQ(sd.local_mask & ARMED, 0);
+    DCHECK(!sd.is_armed.load(memory_order_relaxed));
     if (!multi_) {
       DCHECK_EQ(TxQueue::kEnd, sd.pq_pos);
     }
@@ -529,7 +501,7 @@ void Transaction::MultiSwitchCmd(const CommandId* cid) {
       DCHECK(IsAtomicMulti());   // Every command determines it's own active shards
       sd.local_mask &= ~ACTIVE;  // so remove ACTIVE flags, but keep KEYLOCK_ACQUIRED
     }
-    DCHECK_EQ(sd.local_mask & ARMED, 0);
+    DCHECK(!sd.is_armed.load(memory_order_relaxed));
   }
 
   if (multi_->mode == NON_ATOMIC) {
@@ -588,19 +560,17 @@ void Transaction::PrepareMultiForScheduleSingleHop(ShardId sid, DbIndex db, CmdA
 
 // Runs in the dbslice thread. Returns true if the transaction continues running in the thread.
 bool Transaction::RunInShard(EngineShard* shard, bool txq_ooo) {
-  DCHECK(run_barrier_.Active());
+  // DCHECK(run_barrier_.Active());
   DCHECK_GT(txid_, 0u);
   CHECK(cb_ptr_) << DebugId();
 
   unsigned idx = SidToId(shard->shard_id());
   auto& sd = shard_data_[idx];
 
-  CHECK(sd.local_mask & ARMED) << DEBUG_PrintFailState(shard->shard_id());
-  sd.local_mask &= ~ARMED;
-
+  CHECK(sd.is_armed.exchange(false)) << DEBUG_PrintFailState(shard->shard_id());
   sd.stats.total_runs++;
 
-  DCHECK_GT(run_barrier_.DEBUG_Count(), 0u);
+  // DCHECK_GT(run_barrier_.DEBUG_Count(), 0u);
   VLOG(2) << "RunInShard: " << DebugId() << " sid:" << shard->shard_id() << " " << sd.local_mask;
 
   bool was_suspended = sd.local_mask & SUSPENDED_Q;
@@ -720,7 +690,7 @@ bool Transaction::RunInShard(EngineShard* shard, bool txq_ooo) {
     }
   }
 
-  run_barrier_.Dec(this);  // From this point on we can not access 'this'.
+  FinishHop();  // From this point on we can not access 'this'.
   return !is_concluding;
 }
 
@@ -824,18 +794,17 @@ OpStatus Transaction::ScheduleSingleHop(RunnableType cb) {
     DCHECK(shard_data_.size() == 1 || multi_);
 
     InitTxTime();
-    shard_data_[SidToId(unique_shard_id_)].local_mask |= ARMED;
 
-    // Start new phase, be careful with writes until phase end!
-    run_barrier_.Start(1);
+    run_barrier_.Add(1);
+    shard_data_[SidToId(unique_shard_id_)].is_armed.store(true, memory_order_release);
 
     auto schedule_cb = [this, &was_ooo] {
       bool run_fast = ScheduleUniqueShard(EngineShard::tlocal());
       if (run_fast) {
         // We didn't decrease the barrier, so the scope is valid UNTIL Dec() below
-        DCHECK_EQ(run_barrier_.DEBUG_Count(), 1u);
+        // DCHECK_EQ(run_barrier_.DEBUG_Count(), 1u);
         was_ooo = true;
-        run_barrier_.Dec(this);
+        FinishHop();
       }
       // Otherwise it's not safe to access the function scope, as
       // ScheduleUniqueShard() -> PollExecution() might have unlocked the barrier below.
@@ -961,17 +930,14 @@ void Transaction::ExecuteAsync() {
   DCHECK(!IsAtomicMulti() || multi_->lock_mode.has_value());
   DCHECK_LE(shard_data_.size(), 1024u);
 
-  // Set armed flags on all active shards. Copy indices for dispatching poll tasks,
-  // because local_mask can be written concurrently after starting a new phase.
+  run_barrier_.Add(unique_shard_cnt_);
+
+  // Set armed flags on all active shards.
   std::bitset<1024> poll_flags(0);
   IterateActiveShards([&poll_flags](auto& sd, auto i) {
-    sd.local_mask |= ARMED;
+    sd.is_armed.store(true, memory_order_release);
     poll_flags.set(i, true);
   });
-
-  // Start new phase: release semantics. From here we can be discovered by IsArmedInShard(),
-  // and thus picked by a foreign thread's PollExecution(). Careful with data access!
-  run_barrier_.Start(unique_shard_cnt_);
 
   auto* ss = ServerState::tlocal();
   if (unique_shard_cnt_ == 1 && ss->thread_index() == unique_shard_id_ &&
@@ -992,6 +958,11 @@ void Transaction::ExecuteAsync() {
     if (poll_flags.test(i))
       shard_set->Add(i, poll_cb);
   });
+}
+
+void Transaction::FinishHop() {
+  boost::intrusive_ptr<Transaction> guard(this);
+  run_barrier_.Dec();
 }
 
 void Transaction::Conclude() {
@@ -1023,7 +994,7 @@ void Transaction::FIX_ConcludeJournalExec() {
 string Transaction::DEBUG_PrintFailState(ShardId sid) const {
   auto res = StrCat(
       "usc: ", unique_shard_cnt_, ", name:", GetCId()->name(),
-      ", usecnt:", use_count_.load(memory_order_relaxed), ", runcnt: ", run_barrier_.DEBUG_Count(),
+      ", usecnt:", use_count_.load(memory_order_relaxed), ", runcnt: ", 0,
       ", coordstate: ", coordinator_state_, ", coord native thread: ", stats_.coordinator_index,
       ", schedule attempts: ", stats_.schedule_attempts, ", report from sid: ", sid, "\n");
   std::atomic_thread_fence(memory_order_acquire);
@@ -1062,8 +1033,8 @@ Transaction::RunnableResult Transaction::RunQuickie(EngineShard* shard) {
   DVLOG(1) << "RunQuickSingle " << DebugId() << " " << shard->shard_id();
   DCHECK(cb_ptr_) << DebugId() << " " << shard->shard_id();
 
-  CHECK(sd.local_mask & ARMED) << DEBUG_PrintFailState(shard->shard_id());
-  sd.local_mask &= ~ARMED;
+  CHECK(sd.is_armed.exchange(false, memory_order_relaxed))
+      << DEBUG_PrintFailState(shard->shard_id());
 
   sd.stats.total_runs++;
 
@@ -1091,7 +1062,7 @@ Transaction::RunnableResult Transaction::RunQuickie(EngineShard* shard) {
 void Transaction::ExpireBlocking(WaitKeysProvider wcb) {
   DCHECK(!IsGlobal());
   DVLOG(1) << "ExpireBlocking " << DebugId();
-  run_barrier_.Start(unique_shard_cnt_);
+  run_barrier_.Add(unique_shard_cnt_);
 
   auto expire_cb = [this, &wcb] {
     EngineShard* es = EngineShard::tlocal();
@@ -1128,7 +1099,7 @@ KeyLockArgs Transaction::GetLockArgs(ShardId sid) const {
 
 bool Transaction::IsArmedInShard(ShardId sid) const {
   // Barrier has acquire semantics
-  return run_barrier_.Active() && (shard_data_[SidToId(sid)].local_mask & ARMED);
+  return shard_data_[SidToId(sid)].is_armed.load(memory_order_relaxed);
 }
 
 bool Transaction::IsActive(ShardId sid) const {
@@ -1145,7 +1116,7 @@ bool Transaction::IsActive(ShardId sid) const {
 
 uint16_t Transaction::GetLocalMask(ShardId sid) const {
   DCHECK(IsActive(sid));
-  DCHECK_GT(run_barrier_.DEBUG_Count(), 0u);
+  // DCHECK_GT(run_barrier_.DEBUG_Count(), 0u);
   return shard_data_[SidToId(sid)].local_mask;
 }
 
@@ -1155,7 +1126,7 @@ IntentLock::Mode Transaction::LockMode() const {
 
 OpArgs Transaction::GetOpArgs(EngineShard* shard) const {
   DCHECK(IsActive(shard->shard_id()));
-  DCHECK((multi_ && multi_->role == SQUASHED_STUB) || (run_barrier_.DEBUG_Count() > 0));
+  // DCHECK((multi_ && multi_->role == SQUASHED_STUB) || (run_barrier_.DEBUG_Count() > 0));
   return OpArgs{shard, this, GetDbContext()};
 }
 
@@ -1190,7 +1161,7 @@ bool Transaction::ScheduleUniqueShard(EngineShard* shard) {
 
     if (result.flags & RunnableResult::AVOID_CONCLUDING) {
       // If we want to run again, we have to actually schedule this transaction
-      DCHECK_EQ(sd.local_mask & ARMED, 0);
+      DCHECK(!sd.is_armed.load(memory_order_relaxed));
       continue_scheduling = true;
     } else {
       LogAutoJournalOnShard(shard, result);
@@ -1400,7 +1371,7 @@ void Transaction::ExpireShardCb(ArgSlice wkeys, EngineShard* shard) {
 
   // Resume processing of transaction queue
   shard->PollExecution("unwatchcb", nullptr);
-  run_barrier_.Dec(this);
+  FinishHop();
 }
 
 OpStatus Transaction::RunSquashedMultiCb(RunnableType cb) {
@@ -1588,7 +1559,7 @@ void Transaction::FinishLogJournalOnShard(EngineShard* shard, uint32_t shard_cnt
 
 void Transaction::ReviveAutoJournal() {
   DCHECK(cid_->opt_mask() & CO::NO_AUTOJOURNAL);
-  DCHECK_EQ(run_barrier_.DEBUG_Count(), 0u);  // Can't be changed while dispatching
+  // DCHECK_EQ(run_barrier_.DEBUG_Count(), 0u);  // Can't be changed while dispatching
   re_enabled_auto_journal_ = true;
 }
 

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -258,7 +258,10 @@ class Transaction {
 
   // Returns true if the transaction is waiting for shard callbacks and the shard is armed.
   // Safe to read transaction state (and update shard local) until following RunInShard() finishes.
+  // DEPRECATED
   bool IsArmedInShard(ShardId sid) const;
+
+  bool DisarmInShard(ShardId sid, uint16_t relevant_flags = 0);
 
   // Returns if the transaction spans this shard. Safe only when the transaction is armed.
   bool IsActive(ShardId sid) const;

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -360,7 +360,7 @@ class Transaction {
   }
 
   bool DEBUG_IsArmedInShard(ShardId sid) const {
-    return shard_data_[SidToId(sid)].is_armed.load(memory_order_relaxed);
+    return shard_data_[SidToId(sid)].is_armed.load(std::memory_order_relaxed);
   }
 
   uint16_t DEBUG_GetLocalMask(ShardId sid) const {

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -261,8 +261,8 @@ class Transaction {
   uint16_t DisarmInShard(ShardId sid);
 
   // Same as DisarmInShard, but the transaction is only disarmed if any of the req_flags is present.
-  // Returns a valid local mask nonetheless if the transaction was armed without the required flags.
-  uint16_t DisarmInShardWhen(ShardId sid, uint16_t req_flags);
+  // If the transaction is armed, returns the local mask and a flag whether it was disarmed.
+  std::pair<uint16_t, bool /* disarmed */> DisarmInShardWhen(ShardId sid, uint16_t req_flags);
 
   // Returns if the transaction spans this shard. Safe only when the transaction is armed.
   bool IsActive(ShardId sid) const;

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -261,7 +261,7 @@ class Transaction {
   uint16_t DisarmInShard(ShardId sid);
 
   // Same as DisarmInShard, but the transaction is only disarmed if any of the req_flags is present.
-  // Returns a valid local_mask nonetheless.
+  // Returns a valid local mask nonetheless if the transaction was armed without the required flags.
   uint16_t DisarmInShardWhen(ShardId sid, uint16_t req_flags);
 
   // Returns if the transaction spans this shard. Safe only when the transaction is armed.


### PR DESCRIPTION
1. Replaces run_barrier as a synchronization point with is_armed + an embedded blocking counter for awaiting running jobs
2. Replaces `IsArmedInShard` + `GetLocalMask` + `is_armed.exchange` chain with a single `DisarmInShard()` / `DisarmInShardWhen`