### PR TITLE
feat(server): Use mimalloc in SSL calls

### DIFF
--- a/src/facade/dragonfly_listener.h
+++ b/src/facade/dragonfly_listener.h
@@ -43,6 +43,9 @@ class Listener : public util::ListenerInterface {
   // ReconfigureTLS MUST be called from the same proactor as the listener.
   bool ReconfigureTLS();
 
+  // Returns thread-local dynamic memory usage by TLS.
+  static size_t TLSUsedMemoryThreadLocal();
+
   bool IsPrivilegedInterface() const;
   bool IsMainInterface() const;
 

--- a/tools/generate-tls-files.sh
+++ b/tools/generate-tls-files.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# This script generates locally-signed TLS files for development usage.
+# It's probably a good idea to run in an empty, temporary directory.
+#
+# Example usage:
+#
+# mkdir /tmp/dfly-tls
+# cd /tmp/dfly-tls
+# ~/dragonfly/tools/generate-tls-files.sh
+# ~/dragonfly/build-dbg/dragonfly \
+#      --dbfilename= \
+#      --logtostdout \
+#      --tls=true \
+#      --tls_key_file=/tmp/dfly-tls/df-key.pem \
+#      --tls_cert_file=/tmp/dfly-tls/df-cert.pem \
+#      --requirepass=XXX
+# redis-cli --tls --cacert /tmp/dfly-tls/ca-cert.pem -a XXX
+
+CA_KEY_PATH=ca-key.pem
+CA_CERTIFICATE_PATH=ca-cert.pem
+CERTIFICATE_REQUEST_PATH=df-req.pem
+PRIVATE_KEY_PATH=df-key.pem
+CERTIFICATE_PATH=df-cert.pem
+
+echo "Generating files in local directory (rm *.pem to cleanup)"
+
+openssl req -x509 -newkey rsa:4096 -days 1 -nodes \
+  -keyout ${CA_KEY_PATH} \
+  -out ${CA_CERTIFICATE_PATH} \
+  -subj "/C=GR/ST=SKG/L=Thessaloniki/O=KK/OU=AcmeStudios/CN=Gr/emailAddress=acme@gmail.com"
+
+openssl req -newkey rsa:4096 -nodes \
+  -keyout ${PRIVATE_KEY_PATH} \
+  -out ${CERTIFICATE_REQUEST_PATH} \
+  -subj "/C=GR/ST=SKG/L=Thessaloniki/O=KK/OU=Comp/CN=Gr/emailAddress=does_not_exist@gmail.com"
+
+openssl x509 -req \
+  -in ${CERTIFICATE_REQUEST_PATH} \
+  -days 1 \
+  -CA ${CA_CERTIFICATE_PATH} \
+  -CAkey ${CA_KEY_PATH} \
+  -CAcreateserial -out ${CERTIFICATE_PATH}
+
+echo "You can now run:"
+echo "dragonfly --tls=true --tls_key_file=${PRIVATE_KEY_PATH} --tls_cert_file=${CERTIFICATE_PATH} --requirepass=XXX"
+echo "redis-cli --tls --cacert ${CA_CERTIFICATE_PATH} -a XXX"


### PR DESCRIPTION
Until now, OpenSSL used `malloc()` directly. This PR overrides it to use mimalloc.

Fixes #2709

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->