### PR TITLE
chore(transaction): Don't call GetLocalMask from blocking controller

### DIFF
--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -550,7 +550,7 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
     // If the transaction concluded, it must remove itself from the tx queue.
     // Otherwise it is required to stay there to keep the relative order.
     if (is_ooo && !trans->IsMulti())
-      DCHECK_EQ(keep, trans->GetLocalTxqPos(sid) != TxQueue::kEnd);
+      DCHECK_EQ(keep, trans->DEBUG_GetTxqPosInShard(sid) != TxQueue::kEnd);
   }
 }
 

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -270,10 +270,6 @@ class Transaction {
   // Get OpArgs for specific shard
   OpArgs GetOpArgs(EngineShard* shard) const;
 
-  uint32_t GetLocalTxqPos(ShardId sid) const {
-    return shard_data_[SidToId(sid)].pq_pos;
-  }
-
   TxId txid() const {
     return txid_;
   }
@@ -355,6 +351,10 @@ class Transaction {
 
   // Print in-dept failure state for debugging.
   std::string DEBUG_PrintFailState(ShardId sid) const;
+
+  uint32_t DEBUG_GetTxqPosInShard(ShardId sid) const {
+    return shard_data_[SidToId(sid)].pq_pos;
+  }
 
  private:
   // Holds number of locks for each IntentLock::Mode: shared and exlusive.


### PR DESCRIPTION
This would be the last external usage of `GetLocalMask` with #2708 so we can remove it. Why? Because a lot of the accessor functions are not safe to call in the general case, so they'd better be not part of the external interface if we can avoid using them without any penalty.

Also, blocking controller code still is written in a way that expects a transaction can be woken up multiple times, so its sometimes unnecessarily complicated