### PR TITLE
refactor: remove start-slot-migration cmd #2727

### DIFF
--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -765,7 +765,7 @@ void ClusterFamily::MigrationConf(CmdArgList args, ConnectionContext* cntx) {
 }
 
 void ClusterFamily::InitMigration(CmdArgList args, ConnectionContext* cntx) {
-  VLOG(1) << "Create slot migration config " << args;
+  VLOG(1) << "Create incoming migration, args: " << args;
   CmdArgParser parser{args};
   auto [sync_id, port, flows_num] = parser.Next<uint32_t, uint32_t, uint32_t>();
 

--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -52,7 +52,6 @@ class ClusterFamily {
   void DflyClusterFlushSlots(CmdArgList args, ConnectionContext* cntx);
 
  private:  // Slots migration section
-  void DflyClusterStartSlotMigration(CmdArgList args, ConnectionContext* cntx);
   void DflyClusterSlotMigrationStatus(CmdArgList args, ConnectionContext* cntx);
 
   // DFLYMIGRATE is internal command defines several steps in slots migrations process

--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -60,12 +60,6 @@ class ClusterFamily {
   // DFLYMIGRATE INIT is internal command to create incoming migration object
   void InitMigration(CmdArgList args, ConnectionContext* cntx);
 
-  // DFLYMIGRATE CONF initiate first step in slots migration procedure
-  // MigrationConf process this request and saving slots range and
-  // target node port in outgoing_migration_jobs_.
-  // return sync_id and shard number to the target node
-  void MigrationConf(CmdArgList args, ConnectionContext* cntx);
-
   // DFLYMIGRATE FLOW initiate second step in slots migration procedure
   // this request should be done for every shard on the target node
   // this method assocciate connection and shard that will be the data
@@ -83,7 +77,8 @@ class ClusterFamily {
   void RemoveFinishedMigrations();
 
   // store info about migration and create unique session id
-  uint32_t CreateOutgoingMigration(std::string host_ip, uint16_t port, SlotRanges slots);
+  std::shared_ptr<OutgoingMigration> CreateOutgoingMigration(std::string host_ip, uint16_t port,
+                                                             SlotRanges slots);
 
   std::shared_ptr<OutgoingMigration> GetOutgoingMigration(uint32_t sync_id);
 

--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -58,6 +58,8 @@ class ClusterFamily {
   // DFLYMIGRATE is internal command defines several steps in slots migrations process
   void DflyMigrate(CmdArgList args, ConnectionContext* cntx);
 
+  void InitMigration(CmdArgList args, ConnectionContext* cntx);
+
   // DFLYMIGRATE CONF initiate first step in slots migration procedure
   // MigrationConf process this request and saving slots range and
   // target node port in outgoing_migration_jobs_.
@@ -73,14 +75,15 @@ class ClusterFamily {
   void DflyMigrateAck(CmdArgList args, ConnectionContext* cntx);
 
   // create a ClusterSlotMigration entity which will execute migration
-  ClusterSlotMigration* AddMigration(std::string host_ip, uint16_t port, SlotRanges slots);
+  ClusterSlotMigration* CreateIncomingMigration(std::string host_ip, uint16_t port,
+                                                SlotRanges slots);
 
   bool StartSlotMigrations(const std::vector<ClusterConfig::MigrationInfo>& migrations,
                            ConnectionContext* cntx);
   void RemoveFinishedMigrations();
 
   // store info about migration and create unique session id
-  uint32_t CreateOutgoingMigration(ConnectionContext* cntx, uint16_t port, SlotRanges slots);
+  uint32_t CreateOutgoingMigration(std::string host_ip, uint16_t port, SlotRanges slots);
 
   std::shared_ptr<OutgoingMigration> GetOutgoingMigration(uint32_t sync_id);
 

--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -57,6 +57,7 @@ class ClusterFamily {
   // DFLYMIGRATE is internal command defines several steps in slots migrations process
   void DflyMigrate(CmdArgList args, ConnectionContext* cntx);
 
+  // DFLYMIGRATE INIT is internal command to create incoming migration object
   void InitMigration(CmdArgList args, ConnectionContext* cntx);
 
   // DFLYMIGRATE CONF initiate first step in slots migration procedure

--- a/src/server/cluster/cluster_slot_migration.h
+++ b/src/server/cluster/cluster_slot_migration.h
@@ -51,8 +51,6 @@ class ClusterSlotMigration : private ProtocolClient {
   }
 
  private:
-  // Send DFLYMIGRATE CONF to the source and get info about migration process
-  std::error_code Greet();
   void MainMigrationFb();
   // Creates flows, one per shard on the source node and manage migration process
   std::error_code InitiateSlotsMigration();

--- a/src/server/cluster/cluster_slot_migration.h
+++ b/src/server/cluster/cluster_slot_migration.h
@@ -25,10 +25,10 @@ class ClusterSlotMigration : private ProtocolClient {
                        SlotRanges slots);
   ~ClusterSlotMigration();
 
+  // Initiate connection with source node and create migration fiber
+  // will be refactored in the future
   std::error_code Init(uint32_t sync_id, uint32_t shards_num);
 
-  // Initiate connection with source node and create migration fiber
-  std::error_code Start(ConnectionContext* cntx);
   Info GetInfo() const;
   uint32_t GetSyncId() const {
     return sync_id_;

--- a/src/server/cluster/cluster_slot_migration.h
+++ b/src/server/cluster/cluster_slot_migration.h
@@ -25,6 +25,8 @@ class ClusterSlotMigration : private ProtocolClient {
                        SlotRanges slots);
   ~ClusterSlotMigration();
 
+  std::error_code Init(uint32_t sync_id, uint32_t shards_num);
+
   // Initiate connection with source node and create migration fiber
   std::error_code Start(ConnectionContext* cntx);
   Info GetInfo() const;

--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -4,14 +4,21 @@
 
 #include "server/cluster/outgoing_slot_migration.h"
 
+#include <absl/flags/flag.h>
+
 #include <atomic>
 
 #include "absl/cleanup/cleanup.h"
 #include "base/logging.h"
 #include "server/db_slice.h"
 #include "server/engine_shard_set.h"
+#include "server/error.h"
 #include "server/journal/streamer.h"
 #include "server/server_family.h"
+
+ABSL_DECLARE_FLAG(int, source_connect_timeout_ms);
+
+ABSL_DECLARE_FLAG(uint16_t, admin_port);
 
 using namespace std;
 using namespace util;
@@ -52,9 +59,12 @@ class OutgoingMigration::SliceSlotMigration {
 };
 
 OutgoingMigration::OutgoingMigration(std::string ip, uint16_t port, SlotRanges slots,
-                                     Context::ErrHandler err_handler, ServerFamily* sf)
-    : host_ip_(ip),
+                                     uint32_t sync_id, Context::ErrHandler err_handler,
+                                     ServerFamily* sf)
+    : ProtocolClient(ip, port),
+      host_ip_(ip),
       port_(port),
+      sync_id_(sync_id),
       slots_(slots),
       cntx_(err_handler),
       slot_migrations_(shard_set->size()),
@@ -65,7 +75,7 @@ OutgoingMigration::~OutgoingMigration() {
   main_sync_fb_.JoinIfNeeded();
 }
 
-void OutgoingMigration::StartFlow(uint32_t sync_id, journal::Journal* journal, io::Sink* dest) {
+void OutgoingMigration::StartFlow(journal::Journal* journal, io::Sink* dest) {
   EngineShard* shard = EngineShard::tlocal();
   DbSlice* slice = &shard->db_slice();
 
@@ -75,7 +85,7 @@ void OutgoingMigration::StartFlow(uint32_t sync_id, journal::Journal* journal, i
   {
     std::lock_guard lck(flows_mu_);
     slot_migrations_[shard_id] =
-        std::make_unique<SliceSlotMigration>(slice, slots_, sync_id, journal, &cntx_, dest);
+        std::make_unique<SliceSlotMigration>(slice, slots_, sync_id_, journal, &cntx_, dest);
     state = GetStateImpl();
   }
 
@@ -141,6 +151,39 @@ void OutgoingMigration::SyncFb() {
   shard_set->pool()->AwaitFiberOnAll(std::move(cb));
 
   // TODO add ACK here and config update
+}
+
+std::error_code OutgoingMigration::Start(ConnectionContext* cntx) {
+  VLOG(1) << "Starting outgoing migration";
+
+  auto check_connection_error = [&cntx](error_code ec, const char* msg) -> error_code {
+    if (ec) {
+      cntx->SendError(absl::StrCat(msg, ec.message()));
+    }
+    return ec;
+  };
+
+  VLOG(1) << "Resolving host DNS";
+  error_code ec = ResolveHostDns();
+  RETURN_ON_ERR(check_connection_error(ec, "could not resolve host dns"));
+
+  VLOG(1) << "Connecting to source";
+  ec = ConnectAndAuth(absl::GetFlag(FLAGS_source_connect_timeout_ms) * 1ms, &cntx_);
+  RETURN_ON_ERR(check_connection_error(ec, "couldn't connect to source"));
+
+  VLOG(1) << "Migration initiating";
+  ResetParser(false);
+  auto port = absl::GetFlag(FLAGS_admin_port);
+  auto cmd = absl::StrCat("DFLYMIGRATE INIT ", sync_id_, " ", port, " ", slot_migrations_.size());
+  for (const auto& s : slots_) {
+    absl::StrAppend(&cmd, " ", s.start, " ", s.end);
+  }
+  RETURN_ON_ERR(SendCommandAndReadResponse(cmd));
+  LOG_IF(ERROR, !CheckRespIsSimpleReply("OK")) << facade::ToSV(LastResponseArgs().front().GetBuf());
+
+  // sync_fb_ = fb2::Fiber("main_migration", &ClusterSlotMigration::MainMigrationFb, this);
+
+  return {};
 }
 
 }  // namespace dfly

--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -181,8 +181,6 @@ std::error_code OutgoingMigration::Start(ConnectionContext* cntx) {
   RETURN_ON_ERR(SendCommandAndReadResponse(cmd));
   LOG_IF(ERROR, !CheckRespIsSimpleReply("OK")) << facade::ToSV(LastResponseArgs().front().GetBuf());
 
-  // sync_fb_ = fb2::Fiber("main_migration", &ClusterSlotMigration::MainMigrationFb, this);
-
   return {};
 }
 

--- a/src/server/cluster/outgoing_slot_migration.h
+++ b/src/server/cluster/outgoing_slot_migration.h
@@ -6,6 +6,7 @@
 #include "io/io.h"
 #include "server/cluster/cluster_config.h"
 #include "server/common.h"
+#include "server/protocol_client.h"
 
 namespace dfly {
 
@@ -17,15 +18,17 @@ class DbSlice;
 class ServerFamily;
 
 // Whole outgoing slots migration manager
-class OutgoingMigration {
+class OutgoingMigration : private ProtocolClient {
  public:
   OutgoingMigration() = default;
   ~OutgoingMigration();
-  OutgoingMigration(std::string ip, uint16_t port, SlotRanges slots, Context::ErrHandler,
-                    ServerFamily* sf);
+  OutgoingMigration(std::string ip, uint16_t port, SlotRanges slots, uint32_t sync_id,
+                    Context::ErrHandler, ServerFamily* sf);
+
+  std::error_code Start(ConnectionContext* cntx);
 
   // should be run for all shards
-  void StartFlow(uint32_t sync_id, journal::Journal* journal, io::Sink* dest);
+  void StartFlow(journal::Journal* journal, io::Sink* dest);
 
   void Finalize(uint32_t shard_id);
   void Cancel(uint32_t shard_id);
@@ -54,6 +57,7 @@ class OutgoingMigration {
  private:
   std::string host_ip_;
   uint16_t port_;
+  uint32_t sync_id_;
   SlotRanges slots_;
   Context cntx_;
   mutable util::fb2::Mutex flows_mu_;

--- a/src/server/cluster/outgoing_slot_migration.h
+++ b/src/server/cluster/outgoing_slot_migration.h
@@ -25,6 +25,7 @@ class OutgoingMigration : private ProtocolClient {
   OutgoingMigration(std::string ip, uint16_t port, SlotRanges slots, uint32_t sync_id,
                     Context::ErrHandler, ServerFamily* sf);
 
+  // start migration process, sends INIT command to the target node
   std::error_code Start(ConnectionContext* cntx);
 
   // should be run for all shards

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -886,7 +886,7 @@ async def test_cluster_slot_migration(df_local_factory: DflyInstanceFactory):
           "master": {{ "id": "{node_ids[0]}", "ip": "localhost", "port": {nodes[0].port} }},
           "replicas": [],
           "migrations": [{{ "slot_ranges": [ {{ "start": 5200, "end": 5259 }} ]
-                         , "ip": "127.0.0.1", "port" : {nodes[0].admin_port}, "target_id": "{node_ids[1]}" }}]
+                         , "ip": "127.0.0.1", "port" : {nodes[1].admin_port}, "target_id": "{node_ids[1]}" }}]
         }},
         {{
           "slot_ranges": [ {{ "start": NEXT_SLOT_CUTOFF, "end": 16383 }} ],
@@ -901,24 +901,26 @@ async def test_cluster_slot_migration(df_local_factory: DflyInstanceFactory):
         c_nodes_admin,
     )
 
-    await asyncio.sleep(0.5)
-    try:
-        await c_nodes_admin[1].execute_command(
-            "DFLYCLUSTER",
-            "START-SLOT-MIGRATION",
-            "127.0.0.1",
-            str(nodes[0].admin_port),
-            "5000",
-            "5200",
-        )
-        assert False, "Should not be able to start slot migration"
-    except redis.exceptions.ResponseError as e:
-        assert e.args[0] == "Can't start the migration, another one is in progress"
+    assert False, "Should not be able to start slot migration"
 
-    await push_config(
-        config.replace("LAST_SLOT_CUTOFF", "5199").replace("NEXT_SLOT_CUTOFF", "5200"),
-        c_nodes_admin,
-    )
+    # await asyncio.sleep(0.5)
+    # try:
+    #     await c_nodes_admin[1].execute_command(
+    #         "DFLYCLUSTER",
+    #         "START-SLOT-MIGRATION",
+    #         "127.0.0.1",
+    #         str(nodes[0].admin_port),
+    #         "5000",
+    #         "5200",
+    #     )
+    #     assert False, "Should not be able to start slot migration"
+    # except redis.exceptions.ResponseError as e:
+    #     assert e.args[0] == "Can't start the migration, another one is in progress"
+
+    # await push_config(
+    #     config.replace("LAST_SLOT_CUTOFF", "5199").replace("NEXT_SLOT_CUTOFF", "5200"),
+    #     c_nodes_admin,
+    # )
 
     await close_clients(*c_nodes, *c_nodes_admin)
 


### PR DESCRIPTION
start-slot-migration command is removed
initiating process starts from the source node instead of the target node