### PR TITLE
chore: Introduce fiber stack allocator

### DIFF
--- a/.github/actions/lint-test-chart/action.yml
+++ b/.github/actions/lint-test-chart/action.yml
@@ -10,7 +10,7 @@ runs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4
 
       - uses: actions/setup-python@v5
         with:
@@ -43,7 +43,7 @@ runs:
             ${{github.event_name == 'workflow_dispatch' && '--all'}} ;
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.8.0
+        uses: helm/kind-action@v1
 
       - name: Getting cluster ready
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,5 +176,5 @@ jobs:
   lint-test-chart:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/lint-test-chart

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -85,8 +85,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew update && brew install ninja boost openssl automake gcc zstd bison c-ares \
-              autoconf libtool automake flatbuffers
+          brew uninstall --formula node kotlin harfbuzz sbt selenium-server imagemagick \
+              gradle maven openjdk postgresql r ant mongodb-community@5.0 mongosh \
+              node@18 php composer
+
+          brew update && brew install --force ninja boost openssl automake gcc zstd bison c-ares \
+              autoconf libtool automake
+
           # brew info icu4c
           mkdir -p $GITHUB_WORKSPACE/build
 

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -68,7 +68,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install helm
-      uses: azure/setup-helm@v3
+      uses: azure/setup-helm@v4
 
     - name: Setup Go
       uses: actions/setup-go@v4

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -18,7 +18,7 @@ jobs:
     container:
       image: ghcr.io/romange/${{ matrix.container }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -57,5 +57,5 @@ jobs:
   lint-test-chart:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/lint-test-chart

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     name: Build aarch64 on ubuntu20.04
     needs: create-release
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Cache build deps
@@ -111,7 +111,7 @@ jobs:
     container:
       image: ghcr.io/romange/${{ matrix.container }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Configure

--- a/.github/workflows/reusable-container-workflow.yaml
+++ b/.github/workflows/reusable-container-workflow.yaml
@@ -60,7 +60,7 @@ jobs:
             tag_main: true
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           submodules: true

--- a/contrib/charts/dragonfly/ci/priorityclassname-values.golden.yaml
+++ b/contrib/charts/dragonfly/ci/priorityclassname-values.golden.yaml
@@ -1,4 +1,13 @@
 ---
+# Source: dragonfly/templates/extra-manifests.yaml
+apiVersion: scheduling.k8s.io/v1
+description: This priority class should be used only for tests.
+globalDefault: false
+kind: PriorityClass
+metadata:
+  name: high-priority
+value: 1000000
+---
 # Source: dragonfly/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -92,12 +101,3 @@ spec:
           resources:
             limits: {}
             requests: {}
----
-# Source: dragonfly/templates/extra-manifests.yaml
-apiVersion: scheduling.k8s.io/v1
-description: This priority class should be used only for tests.
-globalDefault: false
-kind: PriorityClass
-metadata:
-  name: high-priority
-value: 1000000

--- a/src/core/mi_memory_resource.cc
+++ b/src/core/mi_memory_resource.cc
@@ -3,18 +3,21 @@
 //
 #include "core/mi_memory_resource.h"
 
+#include <sys/mman.h>
+
 #include "base/logging.h"
 
 namespace dfly {
 
-void* MiMemoryResource::do_allocate(std::size_t size, std::size_t align) {
+using namespace std;
+
+void* MiMemoryResource::do_allocate(size_t size, size_t align) {
   DCHECK(align);
 
   void* res = mi_heap_malloc_aligned(heap_, size, align);
 
   if (!res)
-    throw std::bad_alloc{};
-
+    throw bad_alloc{};
 
   // It seems that mimalloc has a bug with larger allocations that causes
   // mi_heap_contains_block to lie. See https://github.com/microsoft/mimalloc/issues/587
@@ -28,7 +31,7 @@ void* MiMemoryResource::do_allocate(std::size_t size, std::size_t align) {
   return res;
 }
 
-void MiMemoryResource::do_deallocate(void* ptr, std::size_t size, std::size_t align) {
+void MiMemoryResource::do_deallocate(void* ptr, size_t size, size_t align) {
   DCHECK(size > 33554400 || mi_heap_contains_block(heap_, ptr));
 
   size_t usable = mi_usable_size(ptr);

--- a/src/core/mi_memory_resource.h
+++ b/src/core/mi_memory_resource.h
@@ -10,6 +10,7 @@
 
 namespace dfly {
 
+// Per thread memory resource that uses mimalloc.
 class MiMemoryResource : public PMR_NS::memory_resource {
  public:
   explicit MiMemoryResource(mi_heap_t* heap) : heap_(heap) {

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -7,7 +7,7 @@ cxx_link(dragonfly base dragonfly_lib)
 if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" AND CMAKE_BUILD_TYPE STREQUAL "Release")
   # Add core2 only to this file, thus avoiding instructions in this object file that
   # can cause SIGILL.
-  set_source_files_properties(dfly_main.cc PROPERTIES COMPILE_FLAGS -march=core2)
+  set_source_files_properties(dfly_main.cc PROPERTIES COMPILE_FLAGS "-march=core2")
 endif()
 
 set_property(SOURCE dfly_main.cc APPEND PROPERTY COMPILE_DEFINITIONS

--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -1,11 +1,15 @@
-// Copyright 2022, DragonflyDB authors.  All rights reserved.
+// Copyright 2024, DragonflyDB authors.  All rights reserved.
 // See LICENSE for licensing terms.
 //
 
 #include "server/memory_cmd.h"
 
 #include <absl/strings/str_cat.h>
+
+#ifdef __linux__
 #include <malloc.h>
+#endif
+
 #include <mimalloc.h>
 
 #include "base/io_buf.h"

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -6,7 +6,6 @@
 #include <chrono>
 
 #include "absl/strings/match.h"
-#include "util/fibers/fiber2.h"
 
 extern "C" {
 #include "redis/rdb.h"

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -99,6 +99,8 @@ struct Metrics {
 
   // Max length of the all the tx shard-queues.
   uint32_t tx_queue_len = 0;
+  uint32_t worker_fiber_count = 0;
+  size_t worker_fiber_stack_size = 0;
 
   // command call frequencies (count, aggregated latency in usec).
   std::map<std::string, std::pair<uint64_t, uint64_t>> cmd_stats_map;


### PR DESCRIPTION
1. Use mi_malloc for allocating fiber stacks. Introduce FiberStackResource - a memory resource dedicated for handling stack allocations, and inject it into Fibers library as well as accept listeners.

2. Add "memory_fiberstack_vms_bytes" metric exposing fiber stack vm usage.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->