### PR TITLE
chore: add skeleton files for flat_dfs code

### DIFF
--- a/src/core/flatbuffers_test.cc
+++ b/src/core/flatbuffers_test.cc
@@ -29,7 +29,8 @@ TEST_F(FlatBuffersTest, Basic) {
 
   fbb.Finish();
   auto buffer = fbb.GetBuffer();
-  auto map = flexbuffers::GetRoot(buffer).AsMap();
+  flexbuffers::Reference ref = flexbuffers::GetRoot(buffer);
+  auto map = ref.AsMap();
   EXPECT_EQ("bar", map["foo"].AsString().str());
 }
 

--- a/src/core/json/CMakeLists.txt
+++ b/src/core/json/CMakeLists.txt
@@ -5,8 +5,8 @@ cur_gen_dir(gen_dir)
 
 add_library(jsonpath lexer_impl.cc driver.cc path.cc
             ${gen_dir}/jsonpath_lexer.cc ${gen_dir}/jsonpath_grammar.cc json_object.cc
-            detail/jsoncons_dfs.cc)
-target_link_libraries(jsonpath base absl::strings TRDP::reflex TRDP::jsoncons)
+            detail/jsoncons_dfs.cc detail/flat_dfs.cc)
+target_link_libraries(jsonpath base absl::strings TRDP::reflex TRDP::jsoncons TRDP::flatbuffers)
 
 cxx_test(jsonpath_test jsonpath LABELS DFLY)
 cxx_test(json_test jsonpath TRDP::jsoncons LABELS DFLY)

--- a/src/core/json/detail/flat_dfs.cc
+++ b/src/core/json/detail/flat_dfs.cc
@@ -1,0 +1,40 @@
+// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "core/json/detail/flat_dfs.h"
+
+#include "base/logging.h"
+
+namespace dfly::json::detail {
+
+using namespace std;
+using nonstd::make_unexpected;
+
+inline bool IsRecursive(flexbuffers::Type type) {
+  return false;
+}
+
+// TODO: to finish everything
+auto FlatDfsItem::Init(const PathSegment& segment) -> AdvanceResult {
+  return AdvanceResult{};
+}
+
+auto FlatDfsItem::Advance(const PathSegment& segment) -> AdvanceResult {
+  return AdvanceResult{};
+}
+
+FlatDfs FlatDfs::Traverse(absl::Span<const PathSegment> path, const flexbuffers::Reference root,
+                          const PathFlatCallback& callback) {
+  DCHECK(!path.empty());
+  FlatDfs dfs;
+
+  return dfs;
+}
+
+auto FlatDfs::PerformStep(const PathSegment& segment, const flexbuffers::Reference node,
+                          const PathFlatCallback& callback) -> nonstd::expected<void, MatchStatus> {
+  return {};
+}
+
+}  // namespace dfly::json::detail

--- a/src/core/json/detail/flat_dfs.h
+++ b/src/core/json/detail/flat_dfs.h
@@ -1,0 +1,93 @@
+// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <absl/types/span.h>
+
+#include <variant>
+
+#include "base/expected.hpp"
+#include "core/flatbuffers.h"
+#include "core/json/detail/common.h"
+#include "core/json/path.h"
+
+namespace dfly::json::detail {
+
+class FlatDfsItem {
+ public:
+  using ValueType = flexbuffers::Reference;
+  using DepthState = std::pair<ValueType, unsigned>;  // object, segment_idx pair
+  using AdvanceResult = nonstd::expected<DepthState, MatchStatus>;
+
+  FlatDfsItem(ValueType val, unsigned idx = 0) : depth_state_(val, idx) {
+  }
+
+  // Returns the next object to traverse
+  // or null if traverse was exhausted or the segment does not match.
+  AdvanceResult Advance(const PathSegment& segment);
+
+  unsigned segment_idx() const {
+    return depth_state_.second;
+  }
+
+ private:
+  bool ShouldIterateAll(SegmentType type) const {
+    return type == SegmentType::WILDCARD || type == SegmentType::DESCENT;
+  }
+
+  ValueType obj() const {
+    return depth_state_.first;
+  }
+
+  DepthState Next(ValueType obj) const {
+    return {obj, depth_state_.second + segment_step_};
+  }
+
+  DepthState Exhausted() const {
+    return {ValueType(), 0};
+  }
+
+  AdvanceResult Init(const PathSegment& segment);
+
+  // For most operations we advance the path segment by 1 when we descent into the children.
+  unsigned segment_step_ = 1;
+
+  DepthState depth_state_;
+
+  static constexpr unsigned kInit = -1;
+  unsigned state_ = kInit;
+};
+
+// Traverses a json object according to the given path and calls the callback for each matching
+// field. With DESCENT segments it will match 0 or more fields in depth.
+// MATCH(node, DESCENT|SUFFIX) = MATCH(node, SUFFIX) ||
+// { MATCH(node->child, DESCENT/SUFFIX) for each child of node }
+
+class FlatDfs {
+ public:
+  // TODO: for some operations we need to know the type of mismatches.
+  static FlatDfs Traverse(absl::Span<const PathSegment> path, const flexbuffers::Reference root,
+                          const PathFlatCallback& callback);
+  unsigned matches() const {
+    return matches_;
+  }
+
+ private:
+  bool TraverseImpl(absl::Span<const PathSegment> path, const PathFlatCallback& callback);
+
+  nonstd::expected<void, MatchStatus> PerformStep(const PathSegment& segment,
+                                                  const flexbuffers::Reference node,
+                                                  const PathFlatCallback& callback);
+
+  void DoCall(const PathFlatCallback& callback, std::optional<std::string_view> key,
+              const flexbuffers::Reference node) {
+    ++matches_;
+    callback(key, node);
+  }
+
+  unsigned matches_ = 0;
+};
+
+}  // namespace dfly::json::detail

--- a/src/core/json/path.h
+++ b/src/core/json/path.h
@@ -11,7 +11,8 @@
 #include <vector>
 
 #include "base/expected.hpp"
-#include "src/core/json/json_object.h"
+#include "core/flatbuffers.h"
+#include "core/json/json_object.h"
 
 namespace dfly::json {
 
@@ -90,6 +91,8 @@ using Path = std::vector<PathSegment>;
 // Passes the key name for object fields or nullopt for array elements.
 // The second argument is a json value of either object fields or array elements.
 using PathCallback = absl::FunctionRef<void(std::optional<std::string_view>, const JsonType&)>;
+using PathFlatCallback =
+    absl::FunctionRef<void(std::optional<std::string_view>, flexbuffers::Reference)>;
 
 // Returns true if the entry should be deleted, false otherwise.
 using MutateCallback = absl::FunctionRef<bool(std::optional<std::string_view>, JsonType*)>;


### PR DESCRIPTION
Also adjust jsonpath_test to be a typed test to allow run the same tests for both jsoncons and flatbuffers.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->