### PR TITLE
chore: Support json paths without root selector

### DIFF
--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -5,6 +5,7 @@
 #include "server/json_family.h"
 
 #include <absl/strings/match.h>
+#include <absl/strings/str_cat.h>
 #include <absl/strings/str_join.h>
 #include <absl/strings/str_split.h>
 
@@ -13,7 +14,6 @@
 #include <jsoncons_ext/jsonpath/jsonpath.hpp>
 #include <jsoncons_ext/jsonpointer/jsonpointer.hpp>
 
-#include "absl/strings/str_cat.h"
 #include "base/flags.h"
 #include "base/logging.h"
 #include "core/flatbuffers.h"

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -72,6 +72,9 @@ TEST_F(JsonFamilyTest, SetGetBasic) {
   resp = Run({"JSON.GET", "json", "store.book[0].category"});
   EXPECT_EQ(resp, "[\"Fantasy\"]");
 
+  resp = Run({"JSON.GET", "json", ".store.book[0].category"});
+  EXPECT_EQ(resp, "[\"Fantasy\"]");
+
   resp = Run({"SET", "xml", xml});
   ASSERT_THAT(resp, "OK");
 

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -69,6 +69,9 @@ TEST_F(JsonFamilyTest, SetGetBasic) {
   resp = Run({"JSON.GET", "json", "//book[0]"});
   EXPECT_THAT(resp, ArgType(RespExpr::ERROR));
 
+  resp = Run({"JSON.GET", "json", "store.book[0].category"});
+  EXPECT_EQ(resp, "[\"Fantasy\"]");
+
   resp = Run({"SET", "xml", xml});
   ASSERT_THAT(resp, "OK");
 


### PR DESCRIPTION
To my defense Redis does the same 😆 Closes #2722 

![image](https://github.com/dragonflydb/dragonfly/assets/20553775/7958d3a2-ed54-4f6d-8e02-82d78885ba72)
