### PR TITLE
feat(server): support cluster replication

### DIFF
--- a/src/server/cluster/cluster_config.cc
+++ b/src/server/cluster/cluster_config.cc
@@ -70,24 +70,6 @@ SlotId ClusterConfig::KeySlot(string_view key) {
   return crc16(tag.data(), tag.length()) & kMaxSlotNum;
 }
 
-OpResult<SlotRange> ClusterConfig::SlotRangeFromStr(std::string_view start, std::string_view end) {
-  uint32_t slot_id_start, slot_id_end;
-  if (!absl::SimpleAtoi(start, &slot_id_start)) {
-    return facade::OpStatus::INVALID_INT;
-  }
-  if (slot_id_start > ClusterConfig::kMaxSlotNum) {
-    return facade::OpStatus::INVALID_VALUE;
-  }
-  if (!absl::SimpleAtoi(end, &slot_id_end)) {
-    return facade::OpStatus::INVALID_INT;
-  }
-  if ((slot_id_end > ClusterConfig::kMaxSlotNum) || (slot_id_end < slot_id_start)) {
-    return facade::OpStatus::INVALID_VALUE;
-  }
-  return SlotRange{.start = static_cast<uint16_t>(slot_id_start),
-                   .end = static_cast<uint16_t>(slot_id_end)};
-}
-
 namespace {
 bool HasValidNodeIds(const ClusterConfig::ClusterShards& new_config) {
   absl::flat_hash_set<string_view> nodes;

--- a/src/server/cluster/cluster_config.cc
+++ b/src/server/cluster/cluster_config.cc
@@ -70,6 +70,24 @@ SlotId ClusterConfig::KeySlot(string_view key) {
   return crc16(tag.data(), tag.length()) & kMaxSlotNum;
 }
 
+OpResult<SlotRange> ClusterConfig::SlotRangeFromStr(std::string_view start, std::string_view end) {
+  uint32_t slot_id_start, slot_id_end;
+  if (!absl::SimpleAtoi(start, &slot_id_start)) {
+    return facade::OpStatus::INVALID_INT;
+  }
+  if (slot_id_start > ClusterConfig::kMaxSlotNum) {
+    return facade::OpStatus::INVALID_VALUE;
+  }
+  if (!absl::SimpleAtoi(end, &slot_id_end)) {
+    return facade::OpStatus::INVALID_INT;
+  }
+  if ((slot_id_end > ClusterConfig::kMaxSlotNum) || (slot_id_end < slot_id_start)) {
+    return facade::OpStatus::INVALID_VALUE;
+  }
+  return SlotRange{.start = static_cast<uint16_t>(slot_id_start),
+                   .end = static_cast<uint16_t>(slot_id_end)};
+}
+
 namespace {
 bool HasValidNodeIds(const ClusterConfig::ClusterShards& new_config) {
   absl::flat_hash_set<string_view> nodes;

--- a/src/server/cluster/cluster_config.h
+++ b/src/server/cluster/cluster_config.h
@@ -10,10 +10,13 @@
 #include <vector>
 
 #include "core/json/json_object.h"
+#include "src/facade/op_status.h"
 #include "src/server/cluster/slot_set.h"
 #include "src/server/common.h"
 
 namespace dfly {
+
+using facade::OpResult;
 
 // MigrationState constants are ordered in state changing order
 enum class MigrationState : uint8_t {
@@ -57,6 +60,7 @@ class ClusterConfig {
   using ClusterShards = std::vector<ClusterShard>;
 
   static SlotId KeySlot(std::string_view key);
+  static OpResult<SlotRange> SlotRangeFromStr(std::string_view start, std::string_view end);
 
   static void Initialize();
   static bool IsEnabled();

--- a/src/server/cluster/cluster_config.h
+++ b/src/server/cluster/cluster_config.h
@@ -10,13 +10,10 @@
 #include <vector>
 
 #include "core/json/json_object.h"
-#include "src/facade/op_status.h"
 #include "src/server/cluster/slot_set.h"
 #include "src/server/common.h"
 
 namespace dfly {
-
-using facade::OpResult;
 
 // MigrationState constants are ordered in state changing order
 enum class MigrationState : uint8_t {

--- a/src/server/cluster/cluster_config.h
+++ b/src/server/cluster/cluster_config.h
@@ -60,7 +60,6 @@ class ClusterConfig {
   using ClusterShards = std::vector<ClusterShard>;
 
   static SlotId KeySlot(std::string_view key);
-  static OpResult<SlotRange> SlotRangeFromStr(std::string_view start, std::string_view end);
 
   static void Initialize();
   static bool IsEnabled();

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -719,7 +719,7 @@ TEST_F(ClusterFamilyTest, FlushSlots) {
                                         "total_writes", _, "memory_bytes", _)))));
 
   ExpectConditionWithinTimeout([&]() {
-    return RunPrivileged({"dflycluster", "flushslots", "0"}) == "OK";
+    return RunPrivileged({"dflycluster", "flushslots", "0", "0"}) == "OK";
   });
 
   EXPECT_THAT(RunPrivileged({"dflycluster", "getslotinfo", "slots", "0", "1"}),

--- a/src/server/cluster/slot_set.h
+++ b/src/server/cluster/slot_set.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <absl/strings/str_cat.h>
-
 #include <bitset>
 #include <memory>
 #include <vector>

--- a/src/server/cluster/slot_set.h
+++ b/src/server/cluster/slot_set.h
@@ -15,11 +15,15 @@ namespace dfly {
 using SlotId = uint16_t;
 
 struct SlotRange {
+  static constexpr SlotId kMaxSlotId = 0x3FFF;
   SlotId start = 0;
   SlotId end = 0;
 
   bool operator==(const SlotRange& r) const {
     return start == r.start && end == r.end;
+  }
+  bool IsValid() {
+    return start <= end && start <= kMaxSlotId && end <= kMaxSlotId;
   }
 };
 
@@ -27,8 +31,7 @@ using SlotRanges = std::vector<SlotRange>;
 
 class SlotSet {
  public:
-  static constexpr SlotId kMaxSlot = 0x3FFF;
-  static constexpr SlotId kSlotsNumber = kMaxSlot + 1;
+  static constexpr SlotId kSlotsNumber = SlotRange::kMaxSlotId + 1;
 
   SlotSet(bool full_house = false) : slots_(std::make_unique<BitsetType>()) {
     if (full_house)
@@ -93,16 +96,6 @@ class SlotSet {
     }
 
     return res;
-  }
-
-  std::string ToString() const {
-    std::string slots_str;
-    for (SlotId i = 0; i < kSlotsNumber; ++i) {
-      if (slots_->test(i)) {
-        absl::StrAppend(&slots_str, absl::StrCat(i, " "));
-      }
-    }
-    return slots_str;
   }
 
  private:

--- a/src/server/cluster/slot_set.h
+++ b/src/server/cluster/slot_set.h
@@ -99,7 +99,7 @@ class SlotSet {
     std::string slots_str;
     for (SlotId i = 0; i < kSlotsNumber; ++i) {
       if (slots_->test(i)) {
-        absl::StrAppend(&slots_str, absl::StrCat(i));
+        absl::StrAppend(&slots_str, absl::StrCat(i, " "));
       }
     }
     return slots_str;

--- a/src/server/cluster/slot_set.h
+++ b/src/server/cluster/slot_set.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <absl/strings/str_cat.h>
+
 #include <bitset>
 #include <memory>
 #include <vector>
@@ -91,6 +93,16 @@ class SlotSet {
     }
 
     return res;
+  }
+
+  std::string ToString() const {
+    std::string slots_str;
+    for (SlotId i = 0; i < kSlotsNumber; ++i) {
+      if (slots_->test(i)) {
+        absl::StrAppend(&slots_str, absl::StrCat(i));
+      }
+    }
+    return slots_str;
   }
 
  private:

--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -395,4 +395,17 @@ std::string AbslUnparseFlag(const dfly::MemoryBytesFlag& flag) {
   return strings::HumanReadableNumBytes(flag.value);
 }
 
+std::ostream& operator<<(std::ostream& os, const GlobalState& state) {
+  return os << GlobalStateName(state);
+}
+
+std::ostream& operator<<(std::ostream& os, ArgSlice list) {
+  os << "[";
+  if (!list.empty()) {
+    std::for_each(list.begin(), list.end() - 1, [&os](const auto& val) { os << val << ", "; });
+    os << (*(list.end() - 1));
+  }
+  return os << "]";
+}
+
 }  // namespace dfly

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -160,6 +160,12 @@ enum class GlobalState : uint8_t {
   TAKEN_OVER,
 };
 
+const char* GlobalStateName(GlobalState gs);
+
+std::ostream& operator<<(std::ostream& os, const GlobalState& state);
+
+std::ostream& operator<<(std::ostream& os, ArgSlice list);
+
 enum class TimeUnit : uint8_t { SEC, MSEC };
 
 inline void ToUpper(const MutableSlice* val) {
@@ -194,8 +200,6 @@ int64_t GetMallocCurrentCommitted();
 // version 5.11 maps to 511 etc.
 // set upon server start.
 extern unsigned kernel_version;
-
-const char* GlobalStateName(GlobalState gs);
 
 template <typename RandGen> std::string GetRandomHex(RandGen& gen, size_t len) {
   static_assert(std::is_same<uint64_t, decltype(gen())>::value);

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -160,8 +160,6 @@ enum class GlobalState : uint8_t {
   TAKEN_OVER,
 };
 
-const char* GlobalStateName(GlobalState gs);
-
 std::ostream& operator<<(std::ostream& os, const GlobalState& state);
 
 std::ostream& operator<<(std::ostream& os, ArgSlice list);
@@ -200,6 +198,8 @@ int64_t GetMallocCurrentCommitted();
 // version 5.11 maps to 511 etc.
 // set upon server start.
 extern unsigned kernel_version;
+
+const char* GlobalStateName(GlobalState gs);
 
 template <typename RandGen> std::string GetRandomHex(RandGen& gen, size_t len) {
   static_assert(std::is_same<uint64_t, decltype(gen())>::value);

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -278,8 +278,8 @@ class DbSlice {
    */
   void FlushDb(DbIndex db_ind);
 
-  // Flushes the data of given slot ids.
-  void FlushSlots(SlotSet slot_ids);
+  // Flushes the data of given slot ranges.
+  void FlushSlots(SlotRanges slot_ranges);
 
   EngineShard* shard_owner() const {
     return owner_;

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -538,7 +538,7 @@ void DebugCmd::Load(string_view filename) {
   auto new_state = sf_.service().SwitchState(GlobalState::ACTIVE, GlobalState::LOADING);
 
   if (new_state != GlobalState::LOADING) {
-    LOG(WARNING) << GlobalStateName(new_state) << " in progress, ignored";
+    LOG(WARNING) << new_state << " in progress, ignored";
     return cntx_->SendError("Could not load file");
   }
 

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -536,8 +536,9 @@ void DebugCmd::Load(string_view filename) {
   }
 
   auto new_state = sf_.service().SwitchState(GlobalState::ACTIVE, GlobalState::LOADING);
-  if (new_state.first != GlobalState::LOADING) {
-    LOG(WARNING) << GlobalStateName(new_state.first) << " in progress, ignored";
+
+  if (new_state != GlobalState::LOADING) {
+    LOG(WARNING) << GlobalStateName(new_state) << " in progress, ignored";
     return cntx_->SendError("Could not load file");
   }
 

--- a/src/server/detail/save_stages_controller.h
+++ b/src/server/detail/save_stages_controller.h
@@ -115,9 +115,6 @@ struct SaveStagesController : public SaveStagesInputs {
   // Build full path: get dir, try creating dirs, get filename with placeholder
   GenericError BuildFullPath();
 
-  // Switch to saving state if in active state
-  GenericError SwitchState();
-
   void SaveCb(unsigned index);
 
   void CloseCb(unsigned index);

--- a/src/server/journal/executor.cc
+++ b/src/server/journal/executor.cc
@@ -67,6 +67,13 @@ void JournalExecutor::FlushAll() {
   Execute(cmd);
 }
 
+void JournalExecutor::FlushSlots(const SlotRange& slot_range) {
+  SlotRanges slot_ranges = {slot_range};
+  SlotSet slot_set(slot_ranges);
+  auto cmd = BuildFromParts("FLUSHSLOTS", slot_set.ToString());
+  Execute(cmd);
+}
+
 void JournalExecutor::Execute(journal::ParsedEntry::CmdData& cmd) {
   auto span = CmdArgList{cmd.cmd_args.data(), cmd.cmd_args.size()};
   service_->DispatchCommand(span, &conn_context_);

--- a/src/server/journal/executor.cc
+++ b/src/server/journal/executor.cc
@@ -68,9 +68,7 @@ void JournalExecutor::FlushAll() {
 }
 
 void JournalExecutor::FlushSlots(const SlotRange& slot_range) {
-  SlotRanges slot_ranges = {slot_range};
-  SlotSet slot_set(slot_ranges);
-  auto cmd = BuildFromParts("FLUSHSLOTS", slot_set.ToString());
+  auto cmd = BuildFromParts("DFLYCLUSTER", "FLUSHSLOTS", slot_range.start, slot_range.end);
   Execute(cmd);
 }
 

--- a/src/server/journal/executor.h
+++ b/src/server/journal/executor.h
@@ -7,6 +7,7 @@
 #include <absl/types/span.h>
 
 #include "facade/reply_capture.h"
+#include "server/cluster/slot_set.h"
 #include "server/journal/types.h"
 
 namespace dfly {
@@ -25,6 +26,7 @@ class JournalExecutor {
   void Execute(DbIndex dbid, journal::ParsedEntry::CmdData& cmd);
 
   void FlushAll();  // Execute FLUSHALL.
+  void FlushSlots(const SlotRange& slot_range);
 
   ConnectionContext* connection_context() {
     return &conn_context_;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2403,17 +2403,33 @@ VarzValue::Map Service::GetVarzStats() {
   return res;
 }
 
-std::pair<GlobalState, bool> Service::SwitchState(GlobalState from, GlobalState to) {
+GlobalState Service::SwitchState(GlobalState from, GlobalState to) {
   lock_guard lk(mu_);
-  if (global_state_ != from)
-    return {global_state_, false};
+  // Counting switchs to loading state enables us to do several loading processes (replications)
+  // at the same time. Only when all loading processes finish we exit loading state.
+  // When server is in loading state, calling SwitchState to loading will increase
+  // loading_state_counter_. When server is in loading state, calling SwitchState to active will
+  // decrease loading_state_counter_, if loading_state_counter_ is 0 switch to active.
+  if (global_state_ == to && global_state_ == GlobalState::LOADING) {
+    ++loading_state_counter_;
+    return global_state_;
+  }
+  if (global_state_ == from && global_state_ == GlobalState::LOADING &&
+      loading_state_counter_ > 0) {
+    --loading_state_counter_;
+    return global_state_;
+  }
+
+  if (global_state_ != from) {
+    return global_state_;
+  }
 
   VLOG(1) << "Switching state from " << GlobalStateName(from) << " to " << GlobalStateName(to);
 
   global_state_ = to;
 
   pp_.Await([&](ProactorBase*) { ServerState::tlocal()->set_gstate(to); });
-  return {to, true};
+  return to;
 }
 
 GlobalState Service::GetGlobalState() const {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1024,8 +1024,7 @@ std::optional<ErrorReply> Service::VerifyCommandState(const CommandId* cid, CmdA
   }
 
   if (!allowed_by_state) {
-    VLOG(1) << "Command " << cid->name() << " not executed because global state is "
-            << GlobalStateName(gstate);
+    VLOG(1) << "Command " << cid->name() << " not executed because global state is " << gstate;
 
     if (gstate == GlobalState::LOADING) {
       return ErrorReply(kLoadingErr);
@@ -2409,7 +2408,7 @@ GlobalState Service::SwitchState(GlobalState from, GlobalState to) {
     return global_state_;
   }
 
-  VLOG(1) << "Switching state from " << GlobalStateName(from) << " to " << GlobalStateName(to);
+  VLOG(1) << "Switching state from " << from << " to " << to;
   global_state_ = to;
 
   pp_.Await([&](ProactorBase*) { ServerState::tlocal()->set_gstate(to); });

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2417,7 +2417,9 @@ GlobalState Service::SwitchState(GlobalState from, GlobalState to) {
   if (global_state_ == from && global_state_ == GlobalState::LOADING &&
       loading_state_counter_ > 0) {
     --loading_state_counter_;
-    return global_state_;
+    if (loading_state_counter_ > 0) {
+      return global_state_;
+    }
   }
 
   if (global_state_ != from) {

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -188,8 +188,8 @@ class Service : public facade::ServiceInterface {
   const CommandId* exec_cid_;  // command id of EXEC command for pipeline squashing
 
   mutable util::fb2::Mutex mu_;
-  GlobalState global_state_ = GlobalState::ACTIVE;  // protected by mu_;
-  uint32_t loading_state_counter_ = 0;              // protected by mu_;
+  GlobalState global_state_ ABSL_GUARDED_BY(mu_) = GlobalState::ACTIVE;
+  uint32_t loading_state_counter_ ABSL_GUARDED_BY(mu_) = 0;
 };
 
 uint64_t GetMaxMemoryFlag();

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -84,9 +84,8 @@ class Service : public facade::ServiceInterface {
   // Returns: the new state.
   // if from equals the old state then the switch is performed "to" is returned.
   // Otherwise, does not switch and returns the current state in the system.
-  // true if operation is successed
   // Upon switch, updates cached global state in threadlocal ServerState struct.
-  std::pair<GlobalState, bool> SwitchState(GlobalState from, GlobalState to);
+  GlobalState SwitchState(GlobalState from, GlobalState to);
 
   GlobalState GetGlobalState() const;
 
@@ -187,6 +186,7 @@ class Service : public facade::ServiceInterface {
 
   mutable util::fb2::Mutex mu_;
   GlobalState global_state_ = GlobalState::ACTIVE;  // protected by mu_;
+  uint32_t loading_state_counter_ = 0;              // protected by mu_;
 };
 
 uint64_t GetMaxMemoryFlag();

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -87,6 +87,9 @@ class Service : public facade::ServiceInterface {
   // Upon switch, updates cached global state in threadlocal ServerState struct.
   GlobalState SwitchState(GlobalState from, GlobalState to);
 
+  void RequestLoadingState();
+  void RemoveLoadingState();
+
   GlobalState GetGlobalState() const;
 
   void ConfigureHttpHandlers(util::HttpListenerBase* base, bool is_privileged) final;

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -69,8 +69,9 @@ vector<vector<unsigned>> Partition(unsigned num_flows) {
 
 }  // namespace
 
-Replica::Replica(string host, uint16_t port, Service* se, std::string_view id)
-    : ProtocolClient(std::move(host), port), service_(*se), id_{id} {
+Replica::Replica(string host, uint16_t port, Service* se, std::string_view id,
+                 std::optional<SlotRange> slot_range)
+    : ProtocolClient(std::move(host), port), service_(*se), id_{id}, slot_range_(slot_range) {
   proactor_ = ProactorBase::me();
 }
 
@@ -385,13 +386,17 @@ error_code Replica::InitiatePSync() {
     io::PrefixSource ps{io_buf.InputBuffer(), Sock()};
 
     // Set LOADING state.
-    CHECK(service_.SwitchState(GlobalState::ACTIVE, GlobalState::LOADING).first ==
-          GlobalState::LOADING);
+    CHECK(service_.SwitchState(GlobalState::ACTIVE, GlobalState::LOADING) == GlobalState::LOADING);
     absl::Cleanup cleanup = [this]() {
       service_.SwitchState(GlobalState::LOADING, GlobalState::ACTIVE);
     };
 
-    JournalExecutor{&service_}.FlushAll();
+    if (slot_range_.has_value()) {
+      JournalExecutor{&service_}.FlushSlots(slot_range_.value());
+    } else {
+      JournalExecutor{&service_}.FlushAll();
+    }
+
     RdbLoader loader(NULL);
     loader.set_source_limit(snapshot_size);
     // TODO: to allow registering callbacks within loader to send '\n' pings back to master.
@@ -476,8 +481,7 @@ error_code Replica::InitiateDflySync() {
   RETURN_ON_ERR(cntx_.SwitchErrorHandler(std::move(err_handler)));
 
   // Make sure we're in LOADING state.
-  CHECK(service_.SwitchState(GlobalState::ACTIVE, GlobalState::LOADING).first ==
-        GlobalState::LOADING);
+  CHECK(service_.SwitchState(GlobalState::ACTIVE, GlobalState::LOADING) == GlobalState::LOADING);
 
   // Start full sync flows.
   state_mask_.fetch_or(R_SYNCING);
@@ -508,7 +512,11 @@ error_code Replica::InitiateDflySync() {
         std::accumulate(is_full_sync.get(), is_full_sync.get() + num_df_flows_, 0);
 
     if (num_full_flows == num_df_flows_) {
-      JournalExecutor{&service_}.FlushAll();
+      if (slot_range_.has_value()) {
+        JournalExecutor{&service_}.FlushSlots(slot_range_.value());
+      } else {
+        JournalExecutor{&service_}.FlushAll();
+      }
       RdbLoader::PerformPreLoad(&service_);
     } else if (num_full_flows == 0) {
       sync_type = "partial";
@@ -855,7 +863,7 @@ void Replica::RedisStreamAcksFb() {
   auto next_ack_tp = std::chrono::steady_clock::now();
 
   while (!cntx_.IsCancelled()) {
-    VLOG(1) << "Sending an ACK with offset=" << repl_offs_;
+    VLOG(2) << "Sending an ACK with offset=" << repl_offs_;
     ack_cmd = absl::StrCat("REPLCONF ACK ", repl_offs_);
     next_ack_tp = std::chrono::steady_clock::now() + ack_time_max_interval;
     if (auto ec = SendCommand(ack_cmd); ec) {

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -12,6 +12,7 @@
 #include "base/io_buf.h"
 #include "facade/facade_types.h"
 #include "facade/redis_parser.h"
+#include "server/cluster/slot_set.h"
 #include "server/common.h"
 #include "server/journal/tx_executor.h"
 #include "server/journal/types.h"
@@ -53,7 +54,8 @@ class Replica : ProtocolClient {
   };
 
  public:
-  Replica(std::string master_host, uint16_t port, Service* se, std::string_view id);
+  Replica(std::string master_host, uint16_t port, Service* se, std::string_view id,
+          std::optional<SlotRange> slot_range);
   ~Replica();
 
   // Spawns a fiber that runs until link with master is broken or the replication is stopped.
@@ -170,6 +172,8 @@ class Replica : ProtocolClient {
 
   bool is_paused_ = false;
   std::string id_;
+
+  std::optional<SlotRange> slot_range_;
 };
 
 // This class implements a single shard replication flow from a Dragonfly master instance.

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -269,10 +269,6 @@ bool ValidateServerTlsFlags() {
   return true;
 }
 
-bool IsReplicatingNoOne(string_view host, string_view port) {
-  return absl::EqualsIgnoreCase(host, "no") && absl::EqualsIgnoreCase(port, "one");
-}
-
 template <typename T> void UpdateMax(T* maxv, T current) {
   *maxv = std::max(*maxv, current);
 }
@@ -554,6 +550,57 @@ string_view GetRedisMode() {
   return ClusterConfig::IsEnabledOrEmulated() ? "cluster"sv : "standalone"sv;
 }
 
+struct ReplicaOfArgs {
+  bool no_one = false;
+  string_view host;
+  string_view port_sv;
+  uint32_t port;
+  std::optional<SlotRange> slot_range;
+  static OpResult<ReplicaOfArgs> FromParams(string_view host, string_view port,
+                                            std::optional<string_view> slot_start,
+                                            std::optional<string_view> slot_end);
+};
+
+OpResult<ReplicaOfArgs> ReplicaOfArgs::FromParams(string_view host, string_view port,
+                                                  std::optional<string_view> slot_start,
+                                                  std::optional<string_view> slot_end) {
+  ReplicaOfArgs replicaof_args;
+  replicaof_args.host = host;
+  replicaof_args.port_sv = port;
+  if (absl::EqualsIgnoreCase(replicaof_args.host, "no") &&
+      absl::EqualsIgnoreCase(replicaof_args.port_sv, "one")) {
+    replicaof_args.no_one = true;
+    return replicaof_args;
+  }
+
+  if (!absl::SimpleAtoi(replicaof_args.port_sv, &replicaof_args.port) || replicaof_args.port < 1 ||
+      replicaof_args.port > 65535) {
+    return facade::OpStatus::INVALID_INT;
+  }
+
+  if (slot_start.has_value()) {
+    if (!slot_end.has_value()) {
+      return facade::OpStatus::SYNTAX_ERR;
+    }
+
+    uint32_t slot_id_start, slot_id_end;
+    if (!absl::SimpleAtoi(*slot_start, &slot_id_start)) {
+      return facade::OpStatus::INVALID_INT;
+    }
+    if (slot_id_start > ClusterConfig::kMaxSlotNum) {
+      return facade::OpStatus::INVALID_VALUE;
+    }
+    if (!absl::SimpleAtoi(*slot_end, &slot_id_end)) {
+      return facade::OpStatus::INVALID_INT;
+    }
+    if (slot_id_end > ClusterConfig::kMaxSlotNum) {
+      return facade::OpStatus::INVALID_VALUE;
+    }
+    replicaof_args.slot_range = SlotRange(slot_id_start, slot_id_end);
+  }
+  return replicaof_args;
+}
+
 }  // namespace
 
 std::optional<fb2::Fiber> Pause(absl::Span<facade::Listener* const> listeners,
@@ -798,6 +845,9 @@ void ServerFamily::Shutdown() {
     unique_lock lk(replicaof_mu_);
     if (replica_) {
       replica_->Stop();
+      for (auto& replica : cluster_replicas_) {
+        replica->Stop();
+      }
     }
 
     dfly_cmd_->Shutdown();
@@ -828,8 +878,8 @@ fb2::Future<GenericError> ServerFamily::Load(const std::string& load_path) {
   LOG(INFO) << "Loading " << load_path;
 
   auto new_state = service_.SwitchState(GlobalState::ACTIVE, GlobalState::LOADING);
-  if (new_state.first != GlobalState::LOADING) {
-    LOG(WARNING) << GlobalStateName(new_state.first) << " in progress, ignored";
+  if (new_state != GlobalState::LOADING) {
+    LOG(WARNING) << GlobalStateName(new_state) << " in progress, ignored";
     return {};
   }
 
@@ -1237,11 +1287,6 @@ optional<Replica::Info> ServerFamily::GetReplicaInfo() const {
   } else {
     return replica_->GetInfo();
   }
-}
-
-string ServerFamily::GetReplicaMasterId() const {
-  unique_lock lk(replicaof_mu_);
-  return string(replica_->MasterId());
 }
 
 void ServerFamily::OnClose(ConnectionContext* cntx) {
@@ -2106,15 +2151,21 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
       // The replica pointer can still be mutated even while master=true,
       // we don't want to drop the replica object in this fiber
       unique_lock lk{replicaof_mu_};
-      Replica::Info rinfo = replica_->GetInfo();
-      append("master_host", rinfo.host);
-      append("master_port", rinfo.port);
 
-      const char* link = rinfo.master_link_established ? "up" : "down";
-      append("master_link_status", link);
-      append("master_last_io_seconds_ago", rinfo.master_last_io_sec);
-      append("master_sync_in_progress", rinfo.full_sync_in_progress);
-      append("master_replid", rinfo.master_id);
+      auto replication_info_cb = [&](Replica::Info rinfo) {
+        append("master_host", rinfo.host);
+        append("master_port", rinfo.port);
+
+        const char* link = rinfo.master_link_established ? "up" : "down";
+        append("master_link_status", link);
+        append("master_last_io_seconds_ago", rinfo.master_last_io_sec);
+        append("master_sync_in_progress", rinfo.full_sync_in_progress);
+        append("master_replid", rinfo.master_id);
+      };
+      replication_info_cb(replica_->GetInfo());
+      for (const auto& replica : cluster_replicas_) {
+        replication_info_cb(replica->GetInfo());
+      }
     }
   }
 
@@ -2283,9 +2334,37 @@ void ServerFamily::Hello(CmdArgList args, ConnectionContext* cntx) {
   rb->SendBulkString((*ServerState::tlocal()).is_master ? "master" : "slave");
 }
 
-void ServerFamily::ReplicaOfInternal(string_view host, string_view port_sv, ConnectionContext* cntx,
+void ServerFamily::AddReplicaOf(CmdArgList args, ConnectionContext* cntx) {
+  unique_lock lk(replicaof_mu_);
+  if (ServerState::tlocal()->is_master) {
+    cntx->SendError("Calling ADDREPLICAOFF allowed only after server is already a replica");
+    return;
+  }
+  CHECK(replica_);
+
+  OpResult<ReplicaOfArgs> replicaof_args =
+      ReplicaOfArgs::FromParams(ArgS(args, 0), ArgS(args, 1), ArgS(args, 2), ArgS(args, 3));
+  if (!replicaof_args) {
+    return cntx->SendError(replicaof_args.status());
+  }
+  if (replicaof_args->no_one) {
+    return cntx->SendError("ADDREPLICAOF does not supprot no one");
+  }
+  LOG(INFO) << "Add Replica " << replicaof_args->host << ":" << replicaof_args->port_sv;
+
+  auto add_replica = make_unique<Replica>(string(replicaof_args->host), replicaof_args->port,
+                                          &service_, master_id(), replicaof_args->slot_range);
+  error_code ec = add_replica->Start(cntx);
+  if (!ec) {
+    cluster_replicas_.push_back(std::move(add_replica));
+  }
+}
+
+void ServerFamily::ReplicaOfInternal(std::string_view host, std::string_view port,
+                                     std::optional<string_view> slot_start,
+                                     std::optional<string_view> slot_end, ConnectionContext* cntx,
                                      ActionOnConnectionFail on_err) {
-  LOG(INFO) << "Replicating " << host << ":" << port_sv;
+  LOG(INFO) << "Replicating " << host << ":" << port;
   unique_lock lk(replicaof_mu_);  // Only one REPLICAOF command can run at a time
 
   // We should not execute replica of command while loading from snapshot.
@@ -2294,49 +2373,52 @@ void ServerFamily::ReplicaOfInternal(string_view host, string_view port_sv, Conn
     return;
   }
 
+  OpResult<ReplicaOfArgs> replicaof_args =
+      ReplicaOfArgs::FromParams(host, port, slot_start, slot_end);
+  if (!replicaof_args) {
+    return cntx->SendError(replicaof_args.status());
+  }
+
   // If NO ONE was supplied, just stop the current replica (if it exists)
-  if (IsReplicatingNoOne(host, port_sv)) {
+  if (replicaof_args->no_one) {
     if (!ServerState::tlocal()->is_master) {
       CHECK(replica_);
 
       SetMasterFlagOnAllThreads(true);  // Flip flag before clearing replica
       replica_->Stop();
       replica_.reset();
+
+      for (auto& replica : cluster_replicas_) {
+        replica->Stop();
+      }
+      cluster_replicas_.clear();
     }
 
-    CHECK(service_.SwitchState(GlobalState::LOADING, GlobalState::ACTIVE).first ==
-          GlobalState::ACTIVE)
+    CHECK(service_.SwitchState(GlobalState::LOADING, GlobalState::ACTIVE) == GlobalState::ACTIVE)
         << "Server is set to replica no one, yet state is not active!";
 
     return cntx->SendOk();
   }
 
-  uint32_t port;
-  if (!absl::SimpleAtoi(port_sv, &port) || port < 1 || port > 65535) {
-    cntx->SendError(kInvalidIntErr);
-    return;
-  }
-
-  // First, switch into the loading state
-  if (auto new_state = service_.SwitchState(GlobalState::ACTIVE, GlobalState::LOADING);
-      new_state.first != GlobalState::LOADING) {
-    LOG(WARNING) << GlobalStateName(new_state.first) << " in progress, ignored";
-    cntx->SendError("Invalid state");
-    return;
-  }
-
   // If any replication is in progress, stop it, cancellation should kick in immediately
   if (replica_)
     replica_->Stop();
+  // Stop all cluster replication.
+  for (auto& replica : cluster_replicas_) {
+    replica->Stop();
+  }
+  cluster_replicas_.clear();
 
   // If we are called by "Replicate", cntx->transaction will be null but we do not need
   // to flush anything.
   if (cntx->transaction) {
-    Drakarys(cntx->transaction, DbSlice::kDbAll);
+    // Drakarys(cntx->transaction, DbSlice::kDbAll);
   }
 
   // Create a new replica and assing it
-  auto new_replica = make_shared<Replica>(string(host), port, &service_, master_replid());
+  auto new_replica = make_shared<Replica>(string(replicaof_args->host), replicaof_args->port,
+                                          &service_, master_replid(), replicaof_args->slot_range);
+
   replica_ = new_replica;
 
   // TODO: disconnect pending blocked clients (pubsub, blocking commands)
@@ -2369,8 +2451,14 @@ void ServerFamily::ReplicaOfInternal(string_view host, string_view port_sv, Conn
 void ServerFamily::ReplicaOf(CmdArgList args, ConnectionContext* cntx) {
   string_view host = ArgS(args, 0);
   string_view port = ArgS(args, 1);
+  std::optional<string_view> slot_start;
+  std::optional<string_view> slot_end;
+  if (args.size() == 4) {
+    slot_start = ArgS(args, 2);
+    slot_end = ArgS(args, 3);
+  }
 
-  ReplicaOfInternal(host, port, cntx, ActionOnConnectionFail::kReturnOnError);
+  ReplicaOfInternal(host, port, slot_start, slot_end, cntx, ActionOnConnectionFail::kReturnOnError);
 }
 
 void ServerFamily::Replicate(string_view host, string_view port) {
@@ -2378,7 +2466,8 @@ void ServerFamily::Replicate(string_view host, string_view port) {
   ConnectionContext ctxt{&sink, nullptr};
   ctxt.skip_acl_validation = true;
 
-  ReplicaOfInternal(host, port, &ctxt, ActionOnConnectionFail::kContinueReplication);
+  ReplicaOfInternal(host, port, std::nullopt, std::nullopt, &ctxt,
+                    ActionOnConnectionFail::kContinueReplication);
 }
 
 void ServerFamily::ReplTakeOver(CmdArgList args, ConnectionContext* cntx) {
@@ -2524,19 +2613,27 @@ void ServerFamily::Role(CmdArgList args, ConnectionContext* cntx) {
 
   } else {
     unique_lock lk{replicaof_mu_};
-    Replica::Info rinfo = replica_->GetInfo();
-    rb->StartArray(4);
+
+    size_t additional_replication = cluster_replicas_.size();
+    rb->StartArray(4 + additional_replication * 3);
     rb->SendBulkString("replica");
-    rb->SendBulkString(rinfo.host);
-    rb->SendBulkString(absl::StrCat(rinfo.port));
-    if (rinfo.full_sync_done) {
-      rb->SendBulkString("stable_sync");
-    } else if (rinfo.full_sync_in_progress) {
-      rb->SendBulkString("full_sync");
-    } else if (rinfo.master_link_established) {
-      rb->SendBulkString("preparation");
-    } else {
-      rb->SendBulkString("connecting");
+
+    auto send_replica_info = [rb](Replica::Info rinfo) {
+      rb->SendBulkString(rinfo.host);
+      rb->SendBulkString(absl::StrCat(rinfo.port));
+      if (rinfo.full_sync_done) {
+        rb->SendBulkString("stable_sync");
+      } else if (rinfo.full_sync_in_progress) {
+        rb->SendBulkString("full_sync");
+      } else if (rinfo.master_link_established) {
+        rb->SendBulkString("preparation");
+      } else {
+        rb->SendBulkString("connecting");
+      }
+    };
+    send_replica_info(replica_->GetInfo());
+    for (const auto& replica : cluster_replicas_) {
+      send_replica_info(replica->GetInfo());
     }
   }
 }
@@ -2718,7 +2815,8 @@ void ServerFamily::Register(CommandRegistry* registry) {
       << CI{"SHUTDOWN", CO::ADMIN | CO::NOSCRIPT | CO::LOADING, -1, 0, 0, acl::kShutDown}.HFUNC(
              ShutdownCmd)
       << CI{"SLAVEOF", kReplicaOpts, 3, 0, 0, acl::kSlaveOf}.HFUNC(ReplicaOf)
-      << CI{"REPLICAOF", kReplicaOpts, 3, 0, 0, acl::kReplicaOf}.HFUNC(ReplicaOf)
+      << CI{"REPLICAOF", kReplicaOpts, -3, 0, 0, acl::kReplicaOf}.HFUNC(ReplicaOf)
+      << CI{"ADDREPLICAOF", kReplicaOpts, 5, 0, 0, acl::kReplicaOf}.HFUNC(AddReplicaOf)
       << CI{"REPLTAKEOVER", CO::ADMIN | CO::GLOBAL_TRANS, -2, 0, 0, acl::kReplTakeOver}.HFUNC(
              ReplTakeOver)
       << CI{"REPLCONF", CO::ADMIN | CO::LOADING, -1, 0, 0, acl::kReplConf}.HFUNC(ReplConf)

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2410,6 +2410,14 @@ void ServerFamily::ReplicaOfInternal(std::string_view host, std::string_view por
   }
   cluster_replicas_.clear();
 
+  // First, switch into the loading state
+  if (auto new_state = service_.SwitchState(GlobalState::ACTIVE, GlobalState::LOADING);
+      new_state != GlobalState::LOADING) {
+    LOG(WARNING) << GlobalStateName(new_state) << " in progress, ignored";
+    cntx->SendError("Invalid state");
+    return;
+  }
+
   // If we are called by "Replicate", cntx->transaction will be null but we do not need
   // to flush anything.
   if (cntx->transaction) {

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2353,7 +2353,7 @@ void ServerFamily::AddReplicaOf(CmdArgList args, ConnectionContext* cntx) {
   LOG(INFO) << "Add Replica " << replicaof_args->host << ":" << replicaof_args->port_sv;
 
   auto add_replica = make_unique<Replica>(string(replicaof_args->host), replicaof_args->port,
-                                          &service_, master_id(), replicaof_args->slot_range);
+                                          &service_, master_replid(), replicaof_args->slot_range);
   error_code ec = add_replica->Start(cntx);
   if (!ec) {
     cluster_replicas_.push_back(std::move(add_replica));

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -596,7 +596,8 @@ OpResult<ReplicaOfArgs> ReplicaOfArgs::FromParams(string_view host, string_view 
     if (slot_id_end > ClusterConfig::kMaxSlotNum) {
       return facade::OpStatus::INVALID_VALUE;
     }
-    replicaof_args.slot_range = SlotRange(slot_id_start, slot_id_end);
+    replicaof_args.slot_range = SlotRange{.start = static_cast<uint16_t>(slot_id_start),
+                                          .end = static_cast<uint16_t>(slot_id_end)};
   }
   return replicaof_args;
 }

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -581,14 +581,14 @@ optional<ReplicaOfArgs> ReplicaOfArgs::FromCmdArgs(CmdArgList args, ConnectionCo
   } else {
     replicaof_args.host = parser.Next<string>();
     replicaof_args.port = parser.Next<uint16_t>();
-    if (replicaof_args.port < 1) {
+    if (auto err = parser.Error(); err || replicaof_args.port < 1) {
       cntx->SendError("port is out of range");
       return nullopt;
     }
     if (parser.HasNext()) {
       auto [slot_start, slot_end] = parser.Next<SlotId, SlotId>();
       replicaof_args.slot_range = SlotRange{slot_start, slot_end};
-      if (!replicaof_args.slot_range->IsValid()) {
+      if (auto err = parser.Error(); err || !replicaof_args.slot_range->IsValid()) {
         cntx->SendError("Invalid slot range");
         return nullopt;
       }

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2348,7 +2348,7 @@ void ServerFamily::AddReplicaOf(CmdArgList args, ConnectionContext* cntx) {
     return;
   }
   if (replicaof_args->IsReplicaOfNoOne()) {
-    return cntx->SendError("ADDREPLICAOF does not supprot no one");
+    return cntx->SendError("ADDREPLICAOF does not support no one");
   }
   LOG(INFO) << "Add Replica " << *replicaof_args;
 
@@ -2392,7 +2392,7 @@ void ServerFamily::ReplicaOfInternal(CmdArgList args, ConnectionContext* cntx,
       cluster_replicas_.clear();
     }
 
-    CHECK(service_.SwitchState(GlobalState::LOADING, GlobalState::ACTIVE) == GlobalState::ACTIVE)
+    CHECK_EQ(service_.SwitchState(GlobalState::LOADING, GlobalState::ACTIVE), GlobalState::ACTIVE)
         << "Server is set to replica no one, yet state is not active!";
 
     return cntx->SendOk();

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2412,7 +2412,7 @@ void ServerFamily::ReplicaOfInternal(std::string_view host, std::string_view por
   // If we are called by "Replicate", cntx->transaction will be null but we do not need
   // to flush anything.
   if (cntx->transaction) {
-    // Drakarys(cntx->transaction, DbSlice::kDbAll);
+    Drakarys(cntx->transaction, DbSlice::kDbAll);
   }
 
   // Create a new replica and assing it

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -261,9 +261,7 @@ class ServerFamily {
   };
 
   // REPLICAOF implementation. See arguments above
-  void ReplicaOfInternal(std::string_view host, std::string_view port,
-                         std::optional<string_view> slot_start, std::optional<string_view> slot_end,
-                         ConnectionContext* cntx, ActionOnConnectionFail on_error);
+  void ReplicaOfInternal(CmdArgList args, ConnectionContext* cntx, ActionOnConnectionFail on_error);
 
   // Returns the number of loaded keys if successful.
   io::Result<size_t> LoadRdb(const std::string& rdb_file);

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -281,6 +281,7 @@ class ServerFamily {
                                    bool ignore_state = false);
 
   GenericError WaitUntilSaveFinished(Transaction* trans, bool ignore_state = false);
+  void StopAllClusterReplicas();
 
   util::fb2::Fiber snapshot_schedule_fb_;
   util::fb2::Future<GenericError> load_result_;

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -31,15 +31,6 @@ ABSL_FLAG(bool, force_epoll, false, "If true, uses epoll api instead iouring to 
 
 namespace dfly {
 
-std::ostream& operator<<(std::ostream& os, ArgSlice list) {
-  os << "[";
-  if (!list.empty()) {
-    std::for_each(list.begin(), list.end() - 1, [&os](const auto& val) { os << val << ", "; });
-    os << (*(list.end() - 1));
-  }
-  return os << "]";
-}
-
 std::ostream& operator<<(std::ostream& os, const DbStats& stats) {
   os << "keycount: " << stats.key_count << ", tiered_size: " << stats.tiered_size
      << ", tiered_entries: " << stats.tiered_entries << "\n";

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -823,7 +823,7 @@ double GetKeyWeight(Transaction* t, ShardId shard_id, const vector<double>& weig
 OpResult<ScoredMap> OpUnion(EngineShard* shard, Transaction* t, string_view dest, AggType agg_type,
                             const vector<double>& weights, bool store) {
   ArgSlice keys = t->GetShardArgs(shard->shard_id());
-  DVLOG(1) << "shard:" << shard->shard_id() << ", keys " << vector(keys.begin(), keys.end());
+  DVLOG(1) << "shard:" << shard->shard_id() << ", keys " << keys;
   DCHECK(!keys.empty());
 
   unsigned cmdargs_keys_offset = 1;  // after {numkeys} for ZUNION
@@ -872,7 +872,7 @@ ScoredMap ZSetFromSet(const PrimeValue& pv, double weight) {
 OpResult<ScoredMap> OpInter(EngineShard* shard, Transaction* t, string_view dest, AggType agg_type,
                             const vector<double>& weights, bool store) {
   ArgSlice keys = t->GetShardArgs(shard->shard_id());
-  DVLOG(1) << "shard:" << shard->shard_id() << ", keys " << vector(keys.begin(), keys.end());
+  DVLOG(1) << "shard:" << shard->shard_id() << ", keys " << keys;
   DCHECK(!keys.empty());
 
   unsigned removed_keys = 0;
@@ -1345,7 +1345,7 @@ void BZPopMinMax(CmdArgList args, ConnectionContext* cntx, bool is_max) {
 
 vector<ScoredMap> OpFetch(EngineShard* shard, Transaction* t) {
   ArgSlice keys = t->GetShardArgs(shard->shard_id());
-  DVLOG(1) << "shard:" << shard->shard_id() << ", keys " << vector(keys.begin(), keys.end());
+  DVLOG(1) << "shard:" << shard->shard_id() << ", keys " << keys;
   DCHECK(!keys.empty());
 
   vector<ScoredMap> results;

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -62,7 +62,7 @@ def redis_cluster(port_picker):
 
     create_command = f'echo "yes" |redis-cli --cluster create {" ".join([f"127.0.0.1:{port}" for port in ports])}'
     subprocess.run(create_command, shell=True)
-    time.sleep(3)
+    time.sleep(4)
     yield nodes
     for node in nodes:
         node.stop()

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -62,7 +62,7 @@ def redis_cluster(port_picker):
 
     create_command = f'echo "yes" |redis-cli --cluster create {" ".join([f"127.0.0.1:{port}" for port in ports])}'
     subprocess.run(create_command, shell=True)
-    time.sleep(1)
+    time.sleep(3)
     yield nodes
     for node in nodes:
         node.stop()


### PR DESCRIPTION
In this PR we introduce new command 
ADDREPLICAOF <host> <port> <slot start> <slot end>
and extend REPLICAOF command with optional params <slot start> <slot end>

The slot range data is used only to flush the relevant data if the replication to a node disconnected

To replicate a cluster we first issue command 
REPLICAOF <host> <port> <slot start> <slot end> 
with data for a single node from the cluster
than for each additinal cluster master node we run
ADDREPLICAOF <host> <port> <slot start> <slot end>

To promote the replica to master we will run 
REPLICAOF NO ONE

If we run REPLICAOF this will start replication from scratch removing all added replicas
