### PR TITLE
feat(replication): Do not auto replicate different master

### DIFF
--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -41,7 +41,7 @@ ABSL_FLAG(int, master_reconnect_timeout_ms, 1000,
           "Timeout for re-establishing connection to a replication master");
 ABSL_FLAG(bool, replica_partial_sync, true,
           "Use partial sync to reconnect when a replica connection is interrupted.");
-ABSL_FLAG(bool, replica_break_on_new_master, false,
+ABSL_FLAG(bool, replica_reconnect_on_master_restart, false,
           "When in replica mode, and master restarts, break replication from master.");
 ABSL_DECLARE_FLAG(int32_t, port);
 
@@ -307,7 +307,7 @@ std::error_code Replica::HandleCapaDflyResp() {
   // If we're syncing a different replication ID, drop the saved LSNs.
   string_view master_repl_id = ToSV(LastResponseArgs()[0].GetBuf());
   if (master_context_.master_repl_id != master_repl_id) {
-    if (absl::GetFlag(FLAGS_replica_break_on_new_master) &&
+    if (absl::GetFlag(FLAGS_replica_reconnect_on_master_restart) &&
         !master_context_.master_repl_id.empty()) {
       LOG(ERROR) << "Encountered different master repl id (" << master_repl_id << " vs "
                  << master_context_.master_repl_id << ")";

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -303,10 +303,17 @@ std::error_code Replica::HandleCapaDflyResp() {
   }
 
   // If we're syncing a different replication ID, drop the saved LSNs.
-  if (master_context_.master_repl_id != ToSV(LastResponseArgs()[0].GetBuf())) {
+  string_view master_repl_id = ToSV(LastResponseArgs()[0].GetBuf());
+  if (master_context_.master_repl_id != master_repl_id) {
+    if (!master_context_.master_repl_id.empty()) {
+      LOG(ERROR) << "Encountered different master repl id (" << master_repl_id << " vs "
+                 << master_context_.master_repl_id << ")";
+      state_mask_.store(0);
+      return make_error_code(errc::connection_aborted);
+    }
     last_journal_LSNs_.reset();
   }
-  master_context_.master_repl_id = ToSV(LastResponseArgs()[0].GetBuf());
+  master_context_.master_repl_id = master_repl_id;
   master_context_.dfly_session_id = ToSV(LastResponseArgs()[1].GetBuf());
   num_df_flows_ = param_num_flows;
 

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -41,6 +41,8 @@ ABSL_FLAG(int, master_reconnect_timeout_ms, 1000,
           "Timeout for re-establishing connection to a replication master");
 ABSL_FLAG(bool, replica_partial_sync, true,
           "Use partial sync to reconnect when a replica connection is interrupted.");
+ABSL_FLAG(bool, replica_break_on_new_master, false,
+          "When in replica mode, and master restarts, break replication from master.");
 ABSL_DECLARE_FLAG(int32_t, port);
 
 namespace dfly {
@@ -305,7 +307,8 @@ std::error_code Replica::HandleCapaDflyResp() {
   // If we're syncing a different replication ID, drop the saved LSNs.
   string_view master_repl_id = ToSV(LastResponseArgs()[0].GetBuf());
   if (master_context_.master_repl_id != master_repl_id) {
-    if (!master_context_.master_repl_id.empty()) {
+    if (absl::GetFlag(FLAGS_replica_break_on_new_master) &&
+        !master_context_.master_repl_id.empty()) {
       LOG(ERROR) << "Encountered different master repl id (" << master_repl_id << " vs "
                  << master_context_.master_repl_id << ")";
       state_mask_.store(0);

--- a/tests/dragonfly/proxy.py
+++ b/tests/dragonfly/proxy.py
@@ -68,9 +68,14 @@ class Proxy:
             self.stop_connections.remove(cb)
             cb()
 
-    def close(self):
+    async def close(self, task=None):
         if self.server is not None:
             self.server.close()
             self.server = None
         for cb in self.stop_connections:
             cb()
+        if not task == None:
+            try:
+                await task
+            except asyncio.exceptions.CancelledError:
+                pass

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1403,20 +1403,6 @@ async def test_tls_replication(
     db_size = await c_replica.execute_command("DBSIZE")
     assert 100 == db_size
 
-    # 4. Kill master, spin it up and see if replica reconnects
-    master.stop(kill=True)
-    await asyncio.sleep(3)
-    master.start()
-    c_master = master.client(**with_ca_tls_client_args)
-    # Master doesn't load the snapshot, therefore dbsize should be 0
-    await c_master.execute_command("SET MY_KEY 1")
-    db_size = await c_master.execute_command("DBSIZE")
-    assert 1 == db_size
-
-    await check_all_replicas_finished([c_replica], c_master)
-    db_size = await c_replica.execute_command("DBSIZE")
-    assert 1 == db_size
-
     await c_replica.close()
     await c_master.close()
 

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2107,7 +2107,14 @@ async def test_user_acl_replication(df_local_factory):
 
 @pytest.mark.asyncio
 async def test_replica_reconnect(df_local_factory):
-    # Test that a replica that disconnects from a master will not automatically replicate it after connection reestablishment, if it changed repl-id.
+    """
+    Test replica does not connect to master if master restarted
+    step1: create master and replica
+    step2: stop master and start again with the same port
+    step3: check replica is not replicating the restarted master
+    step4: issue new replicaof command
+    step5: check replica replicates master
+    """
     # Connect replica to master
     master = df_local_factory.create(proactor_threads=1)
     replica = df_local_factory.create(proactor_threads=1)

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2118,7 +2118,9 @@ async def test_replica_reconnect(df_local_factory, break_conn):
     """
     # Connect replica to master
     master = df_local_factory.create(proactor_threads=1)
-    replica = df_local_factory.create(proactor_threads=1, replica_break_on_new_master=break_conn)
+    replica = df_local_factory.create(
+        proactor_threads=1, replica_reconnect_on_master_restart=break_conn
+    )
     df_local_factory.start_all([master, replica])
 
     c_master = master.client()


### PR DESCRIPTION
Until now, replicas would re-connect and re-replicate a master after the master will restart. This is problematic in case the master loses its data, which will cause the replica to flush all and lose its data as well.

This is a breaking change though, in that whoever controls the replica now has to explicitly issue a `REPLICAOF X Y` in order to re-establish a connection to a new master. This is true even if the master loaded an up to date RDB file.

It's not necessary if the replica lost connection to the master and the master was always alive, and the connection is re-established.

Fixes #2636

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->