### PR TITLE
fix(ci): do not overwrite last_log_file among tests

### DIFF
--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -354,3 +354,15 @@ def copy_failed_logs_and_clean_tmp_folder(report):
 def pytest_exception_interact(node, call, report):
     if report.failed:
         copy_failed_logs_and_clean_tmp_folder(report)
+
+
+@pytest.fixture(autouse=True)
+def run_before_and_after_test():
+    # Setup: logic before any of the test starts
+    # Empty the log on each run
+    last_log_file = open("/tmp/last_test_log_files.txt", "w")
+    last_log_file.close()
+
+    yield  # this is where the testing happens
+
+    # Teardown


### PR DESCRIPTION
The problem is that each time we start an instance it overwrites the `last_log_file`. The problem with this is that it erases some of the logs that we should upload during failure. This patch addresses this by providing clean up semantics. Specifically, the file `last_log_file` gets erased each time we start a test case and instances now open the file in `append mode` instead of `overwrite`