### PR TITLE
fix: fiber preempts on read path and OnCbFinish() clears fetched_items_

### DIFF
--- a/src/core/dash_internal.h
+++ b/src/core/dash_internal.h
@@ -1718,10 +1718,6 @@ auto Segment<Key, Value, Policy>::BumpUp(uint8_t bid, SlotId slot, Hash_t key_ha
     return Iterator{bid, slot};
   }
 
-  if (swap_bid == bid) {
-    return Iterator{bid, kLastSlot};
-  }
-
   uint8_t swap_fp = swapb.Fp(kLastSlot);
 
   // is_probing for the existing entry in swapb. It's unrelated to bucket_offs,

--- a/src/core/dash_internal.h
+++ b/src/core/dash_internal.h
@@ -1718,6 +1718,10 @@ auto Segment<Key, Value, Policy>::BumpUp(uint8_t bid, SlotId slot, Hash_t key_ha
     return Iterator{bid, slot};
   }
 
+  if (swap_bid == bid) {
+    return Iterator{bid, kLastSlot};
+  }
+
   uint8_t swap_fp = swapb.Fp(kLastSlot);
 
   // is_probing for the existing entry in swapb. It's unrelated to bucket_offs,


### PR DESCRIPTION
addressed #2486 

* cache fetched_items_ before preemption such that `OnCbFinish` does not affect it