### PR TITLE
chore: fix flat_dfs read tests.

### DIFF
--- a/src/core/json/detail/flat_dfs.cc
+++ b/src/core/json/detail/flat_dfs.cc
@@ -12,12 +12,81 @@ using namespace std;
 using nonstd::make_unexpected;
 
 inline bool IsRecursive(flexbuffers::Type type) {
-  return false;
+  return type == flexbuffers::FBT_MAP || type == flexbuffers::FBT_VECTOR;
 }
 
-// TODO: to finish everything
+// Binary search of a key, returns UINT_MAX if not found.
+unsigned FindByKey(const flexbuffers::TypedVector& keys, const char* elem) {
+  unsigned s = 0, end = keys.size();
+  while (s < end) {
+    unsigned mid = (s + end) / 2;
+    flexbuffers::String mid_elem = keys[mid].AsString();
+    int res = strcmp(elem, mid_elem.c_str());
+    if (res < 0) {
+      end = mid;
+    } else if (res > 0) {
+      s = mid + 1;
+    } else {
+      return mid;
+    }
+  }
+  return UINT_MAX;
+}
+
 auto FlatDfsItem::Init(const PathSegment& segment) -> AdvanceResult {
-  return AdvanceResult{};
+  switch (segment.type()) {
+    case SegmentType::IDENTIFIER: {
+      if (obj().IsMap()) {
+        auto map = obj().AsMap();
+        flexbuffers::TypedVector keys = map.Keys();
+        unsigned index = FindByKey(keys, segment.identifier().c_str());
+        if (index == UINT_MAX) {
+          return Exhausted();
+        }
+        state_ = index;
+        return DepthState{obj().AsVector()[index], depth_state_.second + 1};
+      }
+      break;
+    }
+    case SegmentType::INDEX: {
+      unsigned index = segment.index();
+      if (obj().IsUntypedVector()) {
+        auto vec = obj().AsVector();
+        if (index >= vec.size()) {
+          return nonstd::make_unexpected(OUT_OF_BOUNDS);
+        }
+        state_ = index;
+        return Next(vec[index]);
+      }
+      break;
+    }
+
+    case SegmentType::DESCENT:
+      if (segment_step_ == 1) {
+        // first time, branching to return the same object but with the next segment,
+        // exploring the path of ignoring the DESCENT operator.
+        // Also, shift the state (segment_step) to bypass this branch next time.
+        segment_step_ = 0;
+        return DepthState{depth_state_.first, depth_state_.second + 1};
+      }
+
+      // Now traverse all the children but do not progress with segment path.
+      // This is why segment_step_ is set to 0.
+      [[fallthrough]];
+    case SegmentType::WILDCARD: {
+      auto vec = obj().AsVector();
+      if (vec.size() == 0) {
+        return Exhausted();
+      }
+      state_ = 0;
+      return Next(vec[0]);
+    } break;
+
+    default:
+      LOG(DFATAL) << "Unknown segment " << SegmentName(segment.type());
+  }  // end switch
+
+  return nonstd::make_unexpected(MISMATCH);
 }
 
 auto FlatDfsItem::Advance(const PathSegment& segment) -> AdvanceResult {
@@ -93,7 +162,7 @@ auto FlatDfs::PerformStep(const PathSegment& segment, const flexbuffers::Referen
       }
     } break;
     case SegmentType::INDEX: {
-      if (!node.IsVector())
+      if (!node.IsUntypedVector())
         return make_unexpected(MISMATCH);
       auto vec = node.AsVector();
       if (segment.index() >= vec.size()) {

--- a/src/core/json/jsonpath_test.cc
+++ b/src/core/json/jsonpath_test.cc
@@ -85,7 +85,7 @@ bool is_object(FlatJson ref) {
 }
 
 bool is_array(FlatJson ref) {
-  return ref.IsVector();
+  return ref.IsUntypedVector();
 }
 
 class ScannerTest : public ::testing::Test {
@@ -187,9 +187,6 @@ TYPED_TEST(JsonPathTest, Parser) {
 }
 
 TYPED_TEST(JsonPathTest, Root) {
-  if constexpr (std::is_same_v<TypeParam, FlatJson>) {
-    return;  // TODO
-  }
   TypeParam json = ValidJson<TypeParam>(R"({"foo" : 1, "bar": "str" })");
   ASSERT_EQ(0, this->Parse("$"));
   Path path = this->driver_.TakePath();
@@ -203,10 +200,6 @@ TYPED_TEST(JsonPathTest, Root) {
 }
 
 TYPED_TEST(JsonPathTest, Functions) {
-  if constexpr (std::is_same_v<TypeParam, FlatJson>) {
-    return;  // TODO
-  }
-
   ASSERT_EQ(0, this->Parse("max($.plays[*].score)"));
   Path path = this->driver_.TakePath();
   ASSERT_EQ(4, path.size());
@@ -217,18 +210,14 @@ TYPED_TEST(JsonPathTest, Functions) {
   TypeParam json = ValidJson<TypeParam>(R"({"plays": [{"score": 1}, {"score": 2}]})");
   int called = 0;
   EvaluatePath(path, json, [&](auto, const TypeParam& val) {
+    ++called;
     ASSERT_TRUE(is_int(val));
     ASSERT_EQ(2, to_int(val));
-    ++called;
   });
   ASSERT_EQ(1, called);
 }
 
 TYPED_TEST(JsonPathTest, Descent) {
-  if constexpr (std::is_same_v<TypeParam, FlatJson>) {
-    return;  // TODO
-  }
-
   EXPECT_EQ(0, this->Parse("$..foo"));
   Path path = this->driver_.TakePath();
   ASSERT_EQ(2, path.size());
@@ -247,10 +236,6 @@ TYPED_TEST(JsonPathTest, Descent) {
 }
 
 TYPED_TEST(JsonPathTest, Path) {
-  if constexpr (std::is_same_v<TypeParam, FlatJson>) {
-    return;  // TODO
-  }
-
   Path path;
   TypeParam json = ValidJson<TypeParam>(R"({"v11":{ "f" : 1, "a2": [0]}, "v12": {"f": 2, "a2": [1]},
       "v13": 3
@@ -294,10 +279,6 @@ TYPED_TEST(JsonPathTest, Path) {
 }
 
 TYPED_TEST(JsonPathTest, EvalDescent) {
-  if constexpr (std::is_same_v<TypeParam, FlatJson>) {
-    return;  // TODO
-  }
-
   TypeParam json = ValidJson<TypeParam>(R"(
     {"v11":{ "f" : 1, "a2": [0]}, "v12": {"f": 2, "v21": {"f": 3, "a2": [1]}},
       "v13": { "a2" : { "b" : {"f" : 4}}}
@@ -353,10 +334,6 @@ TYPED_TEST(JsonPathTest, EvalDescent) {
 }
 
 TYPED_TEST(JsonPathTest, Wildcard) {
-  if constexpr (std::is_same_v<TypeParam, FlatJson>) {
-    return;  // TODO
-  }
-
   ASSERT_EQ(0, this->Parse("$[*]"));
   Path path = this->driver_.TakePath();
   ASSERT_EQ(1, path.size());


### PR DESCRIPTION
This commit fixes the logic around read only traversals over flexbuffer json object.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->