### PR TITLE
chore: add a boilerplate for bloom filter family

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -34,7 +34,7 @@ add_library(dfly_transaction db_slice.cc malloc_stats.cc blocking_controller.cc
 SET(SEARCH_FILES search/search_family.cc search/doc_index.cc search/doc_accessors.cc
     search/aggregator.cc)
 
-add_library(dragonfly_lib engine_shard_set.cc channel_store.cc
+add_library(dragonfly_lib bloom_family.cc engine_shard_set.cc channel_store.cc
             config_registry.cc conn_context.cc debugcmd.cc dflycmd.cc
             generic_family.cc hset_family.cc http_api.cc json_family.cc
             ${SEARCH_FILES}
@@ -97,6 +97,7 @@ cxx_test(json_family_test dfly_test_lib LABELS DFLY)
 cxx_test(journal/journal_test dfly_test_lib LABELS DFLY)
 cxx_test(top_keys_test dfly_test_lib LABELS DFLY)
 cxx_test(hll_family_test dfly_test_lib LABELS DFLY)
+cxx_test(bloom_family_test dfly_test_lib LABELS DFLY)
 cxx_test(cluster/cluster_config_test dfly_test_lib LABELS DFLY)
 cxx_test(cluster/cluster_family_test dfly_test_lib LABELS DFLY)
 cxx_test(acl/user_registry_test dfly_test_lib LABELS DFLY)

--- a/src/server/acl/acl_commands_def.h
+++ b/src/server/acl/acl_commands_def.h
@@ -8,34 +8,9 @@
 #include "facade/acl_commands_def.h"
 
 namespace dfly::acl {
+
 /* There are 21 ACL categories as of redis 7
  *
- * bit 0: keyspace
- * bit 1: read
- * bit 2: write
- * bit 3: set
- * bit 4: sortedset
- * bit 5: list
- * bit 6: hash
- * bit 7: string
- * bit 8: bitmap
- * bit 9: hyperloglog
- * bit 10: geo
- * bit 11: stream
- * bit 12: pubsub
- * bit 13: admin
- * bit 14: fast
- * bit 15: slow
- * bit 16: blocking
- * bit 17: dangerous
- * bit 18: connection
- * bit 19: transaction
- * bit 20: scripting
- * bits 21..28: tba
- * Dragonfly extensions:
- * bit 29: ft_search
- * bit 30: throttle
- * bit 31: json
  */
 
 enum AclCat {
@@ -60,6 +35,9 @@ enum AclCat {
   CONNECTION = 1ULL << 18,
   TRANSACTION = 1ULL << 19,
   SCRIPTING = 1ULL << 20,
+
+  // Extensions
+  BLOOM = 1ULL << 28,
   FT_SEARCH = 1ULL << 29,
   THROTTLE = 1ULL << 30,
   JSON = 1ULL << 31
@@ -89,6 +67,7 @@ inline const absl::flat_hash_map<std::string_view, uint32_t> CATEGORY_INDEX_TABL
     {"CONNECTION", CONNECTION},
     {"TRANSACTION", TRANSACTION},
     {"SCRIPTING", SCRIPTING},
+    {"BLOOM", BLOOM},
     {"FT_SEARCH", FT_SEARCH},
     {"THROTTLE", THROTTLE},
     {"JSON", JSON},
@@ -103,7 +82,7 @@ inline const std::vector<std::string> REVERSE_CATEGORY_INDEX_TABLE{
     "STRING",    "BITMAP",    "HYPERLOG",  "GEO",       "STREAM",     "PUBSUB",      "ADMIN",
     "FAST",      "SLOW",      "BLOCKING",  "DANGEROUS", "CONNECTION", "TRANSACTION", "SCRIPTING",
     "_RESERVED", "_RESERVED", "_RESERVED", "_RESERVED", "_RESERVED",  "_RESERVED",   "_RESERVED",
-    "_RESERVED", "FT_SEARCH", "THROTTLE",  "JSON"};
+    "BLOOM",     "FT_SEARCH", "THROTTLE",  "JSON"};
 
 using RevCommandField = std::vector<std::string>;
 using RevCommandsIndexStore = std::vector<RevCommandField>;

--- a/src/server/acl/acl_family_test.cc
+++ b/src/server/acl/acl_family_test.cc
@@ -228,7 +228,7 @@ TEST_F(AclFamilyTest, TestCat) {
   EXPECT_THAT(resp, ErrArg("ERR Unkown category: NONSENSE"));
 
   resp = Run({"ACL", "CAT"});
-  EXPECT_THAT(resp.GetVec().size(), 24);
+  EXPECT_GE(resp.GetVec().size(), 24u);
 
   resp = Run({"ACL", "CAT", "STRING"});
 

--- a/src/server/bloom_family.cc
+++ b/src/server/bloom_family.cc
@@ -1,0 +1,49 @@
+// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "server/bloom_family.h"
+
+#include "facade/cmd_arg_parser.h"
+#include "facade/error.h"
+#include "server/command_registry.h"
+#include "server/conn_context.h"
+
+namespace dfly {
+
+// Bloom interface based on SBFs:
+// https://www.sciencedirect.com/science/article/abs/pii/S0020019006003127 See
+// https://www.alibabacloud.com/help/en/tair/developer-reference/bloom for the API documentation.
+// See c-project for the implementation of bloom filters
+// https://github.com/armon/bloomd as well as https://github.com/jvirkki/libbloom
+
+using namespace facade;
+
+namespace {}  // namespace
+
+void BloomFamily::Reserve(CmdArgList args, ConnectionContext* cntx) {
+  cntx->SendError(kSyntaxErr);
+}
+
+void BloomFamily::Add(CmdArgList args, ConnectionContext* cntx) {
+  cntx->SendError(kSyntaxErr);
+}
+
+void BloomFamily::Exists(CmdArgList args, ConnectionContext* cntx) {
+  cntx->SendError(kSyntaxErr);
+}
+
+using CI = CommandId;
+
+#define HFUNC(x) SetHandler(&BloomFamily::x)
+
+void BloomFamily::Register(CommandRegistry* registry) {
+  registry->StartFamily();
+
+  *registry << CI{"BF.RESERVE", CO::WRITE | CO::DENYOOM | CO::FAST, -4, 1, 1, acl::BLOOM}.HFUNC(
+                   Reserve)
+            << CI{"BF.ADD", CO::WRITE | CO::DENYOOM | CO::FAST, 3, 1, 1, acl::BLOOM}.HFUNC(Add)
+            << CI{"BF.EXISTS", CO::READONLY | CO::FAST, 3, 1, 1, acl::BLOOM}.HFUNC(Exists);
+};
+
+}  // namespace dfly

--- a/src/server/bloom_family.h
+++ b/src/server/bloom_family.h
@@ -1,0 +1,24 @@
+// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include "server/common.h"
+
+namespace dfly {
+
+class CommandRegistry;
+class ConnectionContext;
+
+class BloomFamily {
+ public:
+  static void Register(CommandRegistry* registry);
+
+ private:
+  static void Reserve(CmdArgList args, ConnectionContext* cntx);
+  static void Add(CmdArgList args, ConnectionContext* cntx);
+  static void Exists(CmdArgList args, ConnectionContext* cntx);
+};
+
+}  // namespace dfly

--- a/src/server/bloom_family_test.cc
+++ b/src/server/bloom_family_test.cc
@@ -1,0 +1,18 @@
+// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "server/bloom_family.h"
+
+#include "server/test_utils.h"
+
+namespace dfly {
+
+class BloomFamilyTest : public BaseFamilyTest {
+ protected:
+};
+
+TEST_F(BloomFamilyTest, Basic) {
+}
+
+}  // namespace dfly

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -33,6 +33,7 @@ extern "C" {
 #include "server/acl/user_registry.h"
 #include "server/acl/validator.h"
 #include "server/bitops_family.h"
+#include "server/bloom_family.h"
 #include "server/cluster/cluster_family.h"
 #include "server/cluster/unique_slot_checker.h"
 #include "server/conn_context.h"
@@ -2593,7 +2594,7 @@ void Service::RegisterCommands() {
   BitOpsFamily::Register(&registry_);
   HllFamily::Register(&registry_);
   SearchFamily::Register(&registry_);
-
+  BloomFamily::Register(&registry_);
   server_family_.Register(&registry_);
   cluster_family_.Register(&registry_);
 


### PR DESCRIPTION
Consists of 3 basic functions:
BF.RESERVE, BF.ADD, BF.EXISTS

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->