### PR TITLE
fix(ci): malloc trim on sanitizers workflow

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -61,6 +61,10 @@ if (PRINT_STACKTRACES_ON_SIGNAL)
   target_compile_definitions(dragonfly_lib PRIVATE PRINT_STACKTRACES_ON_SIGNAL)
 endif()
 
+if (WITH_ASAN OR WITH_USAN)
+  target_compile_definitions(dfly_transaction PRIVATE SANITIZERS)
+endif()
+
 find_library(ZSTD_LIB NAMES libzstd.a libzstdstatic.a zstd NAMES_PER_DIR REQUIRED)
 
 cxx_link(dfly_transaction dfly_core strings_lib TRDP::fast_float)

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -166,7 +166,11 @@ void ServerState::DecommitMemory(uint8_t flags) {
     // trims the memory (reduces RSS usage) from the malloc allocator. Does not present in
     // MUSL lib.
 #ifdef __GLIBC__
+// There is an issue with malloc_trim and sanitizers because the asan replace malloc but is not
+// aware of malloc_trim which causes malloc_trim to segfault because it's not initialized properly
+#ifndef SANITIZERS
     malloc_trim(0);
+#endif
 #endif
   }
 }


### PR DESCRIPTION
Make great sanitizers great again.

`malloc_trim` segfaults on sanitizers workflow because sanitizers use their own malloc implementation and they are unaware of `malloc_trim`. Consequently, when called, some of it's contents are not properly initialized causing the tests to segfault.

* remove malloc_trim from sanitizers build

resolves #2751