### PR TITLE
chore: add SBF data structure

### DIFF
--- a/src/core/bloom.cc
+++ b/src/core/bloom.cc
@@ -6,7 +6,6 @@
 
 #include <absl/base/internal/endian.h>
 #include <absl/numeric/bits.h>
-#include <mimalloc.h>
 #include <xxhash.h>
 
 #include <cmath>
@@ -27,20 +26,35 @@ uint64_t GetMask(unsigned log) {
   return (1ULL << log) - 1;
 }
 
-inline uint64_t BitIndex(const XXH128_hash_t& hash, unsigned i, uint64_t mask) {
-  return (hash.low64 + hash.high64 * i) % mask;
+inline uint64_t BitIndex(uint64_t low, uint64_t hi, unsigned i, uint64_t mask) {
+  return (low + hi * i) & mask;
+}
+
+constexpr double kDenom = M_LN2 * M_LN2;
+constexpr double kSBFErrorFactor = 0.5;
+
+inline double BPE(double fp_prob) {
+  return -log(fp_prob) / kDenom;
 }
 
 }  // namespace
 
-Bloom::Bloom(uint32_t entries, double error, mi_heap_t* heap) {
-  CHECK(error > 0 && error < 1);
+Bloom::~Bloom() {
+  CHECK(bf_ == nullptr);
+}
+
+Bloom::Bloom(Bloom&& o) : hash_cnt_(o.hash_cnt_), bit_log_(o.bit_log_), bf_(o.bf_) {
+  o.bf_ = nullptr;
+}
+
+void Bloom::Init(uint64_t entries, double fp_prob, PMR_NS::memory_resource* heap) {
+  CHECK(bf_ == nullptr);
+  CHECK(fp_prob > 0 && fp_prob < 1);
 
   if (entries < 1024)
     entries = 1024;
 
-  constexpr double kDenom = M_LN2 * M_LN2;
-  double bpe = -log(error) / kDenom;
+  double bpe = BPE(fp_prob);
 
   hash_cnt_ = ceil(M_LN2 * bpe);
 
@@ -51,24 +65,27 @@ Bloom::Bloom(uint32_t entries, double error, mi_heap_t* heap) {
   }
 
   uint64_t length = bits / 8;
-
-  bf_ = (uint8_t*)mi_heap_calloc(heap, length, 1);
-
-  static_assert(absl::countr_zero(8u) == 3);
+  bf_ = (uint8_t*)heap->allocate(length);
+  memset(bf_, 0, length);
   bit_log_ = absl::countr_zero(bits);
-  DCHECK_EQ(1UL << bit_log_, bits);
 }
 
-Bloom::~Bloom() {
-  mi_free(bf_);
+void Bloom::Destroy(PMR_NS::memory_resource* resource) {
+  resource->deallocate(CHECK_NOTNULL(bf_), bitlen() / 8);
+  bf_ = nullptr;
 }
 
 bool Bloom::Exists(std::string_view str) const {
   XXH128_hash_t hash = Hash(str);
+  uint64_t fp[2] = {hash.low64, hash.high64};
 
+  return Exists(fp);
+}
+
+bool Bloom::Exists(uint64_t fp[2]) const {
   uint64_t mask = GetMask(bit_log_);
   for (unsigned i = 0; i < hash_cnt_; ++i) {
-    uint64_t index = BitIndex(hash, i, mask);
+    uint64_t index = BitIndex(fp[0], fp[1], i, mask);
     if (!IsSet(index))
       return false;
   }
@@ -77,15 +94,25 @@ bool Bloom::Exists(std::string_view str) const {
 
 bool Bloom::Add(std::string_view str) {
   XXH128_hash_t hash = Hash(str);
+  uint64_t fp[2] = {hash.low64, hash.high64};
+  return Add(fp);
+}
+
+bool Bloom::Add(uint64_t fp[2]) {
   uint64_t mask = GetMask(bit_log_);
 
   unsigned changes = 0;
   for (uint64_t i = 0; i < hash_cnt_; i++) {
-    uint64_t index = BitIndex(hash, i, mask);
+    uint64_t index = BitIndex(fp[0], fp[1], i, mask);
     changes += Set(index);
   }
 
   return changes != 0;
+}
+
+size_t Bloom::Capacity(double fp_prob) const {
+  double bpe = BPE(fp_prob);
+  return floor(bitlen() / bpe);
 }
 
 inline bool Bloom::IsSet(size_t bit_idx) const {
@@ -102,6 +129,64 @@ inline bool Bloom::Set(size_t bit_idx) {
   uint8_t b = bf_[byte_idx];
   bf_[byte_idx] |= (1 << bit_idx);
   return bf_[byte_idx] != b;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// SBF implementation
+///////////////////////////////////////////////////////////////////////////////
+SBF::SBF(uint64_t initial_capacity, double fp_prob, double grow_factor, PMR_NS::memory_resource* mr)
+    : filters_(1, mr), grow_factor_(grow_factor), fp_prob_(fp_prob * kSBFErrorFactor) {
+  filters_.front().Init(initial_capacity, fp_prob_, mr);
+  max_capacity_ = filters_.front().Capacity(fp_prob_);
+}
+
+SBF::~SBF() {
+  PMR_NS::memory_resource* mr = filters_.get_allocator().resource();
+  for (auto& f : filters_)
+    f.Destroy(mr);
+}
+
+bool SBF::Add(std::string_view str) {
+  DCHECK_LT(current_size_, max_capacity_);
+  auto it = filters_.rbegin();  // largest filter
+  auto cur = it++;
+
+  XXH128_hash_t hash = Hash(str);
+  uint64_t fp[2] = {hash.low64, hash.high64};
+
+  // Check for all other filters whether the item exists.
+  for (; it != filters_.rend(); ++it) {
+    if (it->Exists(fp))
+      return false;
+  }
+
+  if (!cur->Add(fp))
+    return false;
+
+  ++current_size_;
+
+  // Based on the paper, the optimal fill ratio for SBF is 50%.
+  // Lets add a new slice if we reach it.
+  if (current_size_ >= max_capacity_) {
+    fp_prob_ *= kSBFErrorFactor;
+    filters_.emplace_back().Init(max_capacity_ * grow_factor_, fp_prob_,
+                                 filters_.get_allocator().resource());
+    current_size_ = 0;
+    max_capacity_ = filters_.back().Capacity(fp_prob_);
+  }
+  return true;
+}
+
+bool SBF::Exists(std::string_view str) const {
+  XXH128_hash_t hash = Hash(str);
+  uint64_t fp[2] = {hash.low64, hash.high64};
+
+  for (auto it = filters_.crbegin(); it != filters_.crend(); ++it) {
+    if (it->Exists(fp)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 }  // namespace dfly

--- a/src/core/bloom.h
+++ b/src/core/bloom.h
@@ -12,7 +12,7 @@
 
 namespace dfly {
 
-// Bloom filter based on the design of https://github.com/jvirkki/libbloom
+/// Bloom filter based on the design of https://github.com/jvirkki/libbloom
 class Bloom {
   Bloom(const Bloom&) = delete;
   Bloom& operator=(const Bloom&) = delete;
@@ -20,23 +20,17 @@ class Bloom {
  public:
   Bloom() = default;
 
-  /// @brief Destroy must be called before calling the d'tor
+  // Note, that Destroy() must be called before calling the d'tor
   ~Bloom();
 
-  /**
-   * @brief Initializes a new Bloom object
-   *
-   * @param entries - entries are silently rounded up to the minimum capacity.
-   * @param fp_prob - False-positive probability of collision. Must be in (0, 1) range.
-   * @param heap
-   */
+  // Initializes a new Bloom object
+  // entries - entries are silently rounded up to the minimum capacity.
+  // fp_prob - False-positive probability of collision. Must be in (0, 1) range.
+  // heap
   void Init(uint64_t entries, double fp_prob, PMR_NS::memory_resource* resource);
 
-  /**
-   * @brief Destroys the object, must be called before destructing the object.
-   *
-   * @param resource - resource with which the object was initialized.
-   */
+  // Destroys the object, must be called before destructing the object.
+  // resource - resource with which the object was initialized.
   void Destroy(PMR_NS::memory_resource* resource);
 
   Bloom(Bloom&& o);
@@ -44,16 +38,13 @@ class Bloom {
   bool Exists(std::string_view str) const;
 
   // Equivalent to the Exist above but accepts two fingerprints of the item.
-  bool Exists(uint64_t fp[2]) const;
+  bool Exists(const uint64_t fp[2]) const;
 
-  /**
-   * @brief Adds an item to the bloom filter.
-   * @param str  -
-   * @return true if element was not present and was added,
-   * @return false - if element (or a collision) had already been added previously.
-   */
+  // Adds an item to the bloom filter.
+  // Returns true if element was not present and was added,
+  // false - if element (or a collision) had already been added previously.
   bool Add(std::string_view str);
-  bool Add(uint64_t fp[2]);
+  bool Add(const uint64_t fp[2]);
 
   size_t bitlen() const {
     return 1ULL << bit_log_;

--- a/src/core/bloom.h
+++ b/src/core/bloom.h
@@ -6,8 +6,9 @@
 
 #include <cstdint>
 #include <string_view>
+#include <vector>
 
-typedef struct mi_heap_s mi_heap_t;
+#include "base/pmr/memory_resource.h"
 
 namespace dfly {
 
@@ -17,20 +18,33 @@ class Bloom {
   Bloom& operator=(const Bloom&) = delete;
 
  public:
-  /**
-   * @brief Construct a new Bloom object
-   *
-   * @param entries - entries are silently rounded up to the minimum capacity.
-   * @param error must be in (0, 1) range.
-   * @param heap
-   */
-  Bloom(uint32_t entries, double error, mi_heap_t* heap);
+  Bloom() = default;
+
+  /// @brief Destroy must be called before calling the d'tor
   ~Bloom();
 
-  Bloom(Bloom&&) = default;
-  Bloom& operator=(Bloom&&) = default;
+  /**
+   * @brief Initializes a new Bloom object
+   *
+   * @param entries - entries are silently rounded up to the minimum capacity.
+   * @param fp_prob - False-positive probability of collision. Must be in (0, 1) range.
+   * @param heap
+   */
+  void Init(uint64_t entries, double fp_prob, PMR_NS::memory_resource* resource);
+
+  /**
+   * @brief Destroys the object, must be called before destructing the object.
+   *
+   * @param resource - resource with which the object was initialized.
+   */
+  void Destroy(PMR_NS::memory_resource* resource);
+
+  Bloom(Bloom&& o);
 
   bool Exists(std::string_view str) const;
+
+  // Equivalent to the Exist above but accepts two fingerprints of the item.
+  bool Exists(uint64_t fp[2]) const;
 
   /**
    * @brief Adds an item to the bloom filter.
@@ -39,14 +53,48 @@ class Bloom {
    * @return false - if element (or a collision) had already been added previously.
    */
   bool Add(std::string_view str);
+  bool Add(uint64_t fp[2]);
+
+  size_t bitlen() const {
+    return 1ULL << bit_log_;
+  }
+
+  // Note that max element capacity is floor(bit_len / bpe), where bpe (bits per element) is
+  // derived from fp_prob.
+  size_t Capacity(double fp_prob) const;
 
  private:
   bool IsSet(size_t index) const;
   bool Set(size_t index);  // return true if bit was set (i.e was 0 before)
 
-  uint8_t hash_cnt_;
-  uint8_t bit_log_;  // log of bit length of the filter. bit length is always power of 2.
-  uint8_t* bf_;      // pointer to the blob.
+  uint8_t hash_cnt_ = 0;
+  uint8_t bit_log_ = 0;    // log of bit length of the filter. bit length is always power of 2.
+  uint8_t* bf_ = nullptr;  // pointer to the blob.
+};
+
+/**
+ * @brief Scalable bloom filter.
+ * Based on https://gsd.di.uminho.pt/members/cbm/ps/dbloom.pdf
+ * Please note that for SBF, the original paper assumes partitioning of bit space into K
+ * disjoint segments where K is number of hash functions. This is done to reduce index collisions.
+ * We do not do this, because we use power of 2 bit lengths.
+ * TODO: to test the actual rate of this filter.
+ */
+class SBF {
+ public:
+  SBF(uint64_t initial_capacity, double fp_prob, double grow_factor, PMR_NS::memory_resource* mr);
+  ~SBF();
+
+  bool Add(std::string_view str);
+  bool Exists(std::string_view str) const;
+
+ private:
+  // multiple filters from the smallest to the largest.
+  std::vector<Bloom, PMR_NS::polymorphic_allocator<Bloom>> filters_;
+  double grow_factor_;
+  double fp_prob_;
+  size_t current_size_ = 0;
+  size_t max_capacity_;
 };
 
 }  // namespace dfly


### PR DESCRIPTION
Based on https://gsd.di.uminho.pt/members/cbm/ps/dbloom.pdf

The data-structure itself is a growing list of bloom filters, where the next filter has exponentially larger capacity with exponentially tighter error bound.

The Exist() goes over all the filters and it's enough that at least one of them returns a positive result. For Add(), we make ensure that all the existing filters do not have the element, as well as making sure that the last filter that is being filled does not cross its maximum designated capacity.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->