### PR TITLE
chore: implement path mutation for JsonFlat

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -697,20 +697,31 @@ std::optional<int64_t> CompactObj::TryGetInt() const {
 
 auto CompactObj::GetJson() const -> JsonType* {
   if (ObjType() == OBJ_JSON) {
+    DCHECK_EQ(u_.json_obj.encoding, kEncodingJsonCons);
     return u_.json_obj.json_ptr;
   }
   return nullptr;
 }
 
 void CompactObj::SetJson(JsonType&& j) {
-  if (taglen_ == JSON_TAG) {                  // already json
+  if (taglen_ == JSON_TAG && u_.json_obj.encoding == kEncodingJsonCons) {
+    // already json
     DCHECK(u_.json_obj.json_ptr != nullptr);  // must be allocated
-    *u_.json_obj.json_ptr = std::move(j);
+    u_.json_obj.json_ptr->swap(j);
   } else {
     SetMeta(JSON_TAG);
-    void* ptr = tl.local_mr->allocate(sizeof(JsonType), kAlignSize);
+    void* ptr = tl.local_mr->allocate(sizeof(JsonType), alignof(JsonType));
     u_.json_obj.json_ptr = new (ptr) JsonType(std::move(j));
+    u_.json_obj.encoding = kEncodingJsonCons;
   }
+}
+
+void CompactObj::SetJson(const uint8_t* buf, size_t len) {
+  SetMeta(JSON_TAG);
+  u_.json_obj.flat_ptr = (uint8_t*)tl.local_mr->allocate(len, kAlignSize);
+  memcpy(u_.json_obj.flat_ptr, buf, len);
+  u_.json_obj.encoding = kEncodingJsonFlat;
+  u_.json_obj.json_len = len;
 }
 
 void CompactObj::SetSBF(uint64_t initial_capacity, double fp_prob, double grow_factor) {
@@ -1009,9 +1020,12 @@ void CompactObj::Free() {
     tl.small_str_bytes -= u_.small_str.MallocUsed();
     u_.small_str.Free();
   } else if (taglen_ == JSON_TAG) {
-    VLOG(1) << "Freeing JSON object";
-    u_.json_obj.json_ptr->~JsonType();
-    tl.local_mr->deallocate(u_.json_obj.json_ptr, sizeof(JsonType), kAlignSize);
+    DVLOG(1) << "Freeing JSON object";
+    if (u_.json_obj.encoding == kEncodingJsonCons) {
+      DeleteMR<JsonType>(u_.json_obj.json_ptr);
+    } else {
+      tl.local_mr->deallocate(u_.json_obj.flat_ptr, u_.json_obj.json_len, kAlignSize);
+    }
   } else if (taglen_ == SBF_TAG) {
     DeleteMR<SBF>(u_.sbf);
   } else {

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -389,7 +389,7 @@ class CompactObj {
     };
     uint32_t json_len = 0;
     uint8_t encoding = 0;
-  } __attribute__((packed));
+  };
 
   // My main data structure. Union of representations.
   // RobjWrapper is kInlineLen=16 bytes, so we employ SSO of that size via inline_str.
@@ -400,7 +400,9 @@ class CompactObj {
 
     SmallString small_str;
     detail::RobjWrapper r_obj;
-    JsonWrapper json_obj;
+
+    // using 'packed' to reduce alignement of U to 1.
+    JsonWrapper json_obj __attribute__((packed));
     SBF* sbf __attribute__((packed));
     int64_t ival __attribute__((packed));
     ExternalPtr ext_ptr;

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -18,6 +18,8 @@ constexpr unsigned kEncodingIntSet = 0;
 constexpr unsigned kEncodingStrMap = 1;   // for set/map encodings of strings
 constexpr unsigned kEncodingStrMap2 = 2;  // for set/map encodings of strings using DenseSet
 constexpr unsigned kEncodingListPack = 3;
+constexpr unsigned kEncodingJsonCons = 0;
+constexpr unsigned kEncodingJsonFlat = 1;
 
 class SBF;
 
@@ -296,6 +298,7 @@ class CompactObj {
   // you need to move an object that created with the function JsonFromString
   // into here, no copying is allowed!
   void SetJson(JsonType&& j);
+  void SetJson(const uint8_t* buf, size_t len);
 
   // pre condition - the type here is OBJ_JSON and was set with SetJson
   JsonType* GetJson() const;
@@ -380,8 +383,12 @@ class CompactObj {
   } __attribute__((packed));
 
   struct JsonWrapper {
-    JsonType* json_ptr = nullptr;
-    size_t unneeded = 0;
+    union {
+      JsonType* json_ptr;
+      uint8_t* flat_ptr;
+    };
+    uint32_t json_len = 0;
+    uint8_t encoding = 0;
   } __attribute__((packed));
 
   // My main data structure. Union of representations.

--- a/src/core/json/path.cc
+++ b/src/core/json/path.cc
@@ -261,4 +261,16 @@ void FromJsonType(const JsonType& src, flexbuffers::Builder* fbb) {
   fbb->EndVector(start, false, false);
 }
 
+unsigned MutatePath(const Path& path, MutateCallback callback, FlatJson json,
+                    flexbuffers::Builder* fbb) {
+  JsonType mut_json = FromFlat(json);
+  unsigned res = MutatePath(path, std::move(callback), &mut_json);
+  if (res) {
+    FromJsonType(mut_json, fbb);
+    fbb->Finish();
+  }
+
+  return res;
+}
+
 }  // namespace dfly::json

--- a/src/core/json/path.h
+++ b/src/core/json/path.h
@@ -111,6 +111,8 @@ void EvaluatePath(const Path& path, FlatJson json, PathFlatCallback callback);
 
 // returns number of matches found with the given path.
 unsigned MutatePath(const Path& path, MutateCallback callback, JsonType* json);
+unsigned MutatePath(const Path& path, MutateCallback callback, FlatJson json,
+                    flexbuffers::Builder* fbb);
 
 // utility function to parse a jsonpath. Returns an error message if a parse error was
 // encountered.


### PR DESCRIPTION
This is done by converting the flat blob into mutable c++ json and then building a new flat blob.

Also, add JsonFlat encoding to CompactObject class.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->