### PR TITLE
fix: propagate memcached flags to replica

### DIFF
--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -347,6 +347,15 @@ TEST_F(DflyEngineTest, Memcache) {
   EXPECT_THAT(resp, ElementsAre("END"));
 }
 
+TEST_F(DflyEngineTest, MemcacheFlags) {
+  using MP = MemcacheParser;
+
+  auto resp = Run("resp", {"SET", "key", "bar", "_MCFLAGS", "42"});
+  ASSERT_EQ(resp, "OK");
+  MCResponse resp2 = RunMC(MP::GET, "key");
+  EXPECT_THAT(resp2, ElementsAre("VALUE key 42 3", "bar", "END"));
+}
+
 TEST_F(DflyEngineTest, LimitMemory) {
   mi_option_enable(mi_option_limit_os_alloc);
   string blob(128, 'a');

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -688,6 +688,10 @@ void SetCmd::RecordJournal(const SetParams& params, string_view key, string_view
   if (params.flags & SET_STICK) {
     cmds.push_back("STICK");
   }
+  if (params.memcache_flags) {
+    cmds.push_back("_MCFLAGS");
+    cmds.push_back(absl::StrCat(params.memcache_flags));
+  }
 
   // Skip NX/XX because SET operation was exectued.
   // Skip GET, because its not important on replica.
@@ -749,6 +753,8 @@ void StringFamily::Set(CmdArgList args, ConnectionContext* cntx) {
         int_arg *= 1000;
       }
       sparams.expire_after_ms = int_arg;
+    } else if (parser.Check("_MCFLAGS").ExpectTail(1)) {
+      sparams.memcache_flags = parser.Next<uint16_t>();
     } else {
       uint16_t flag = parser.Switch(  //
           "GET", SetCmd::SET_GET, "STICK", SetCmd::SET_STICK, "KEEPTTL", SetCmd::SET_KEEP_EXPIRE,


### PR DESCRIPTION
Fixes #1758

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->