### PR TITLE
bug(server): do not write lsn opcode to journal

### DIFF
--- a/src/server/journal/journal.cc
+++ b/src/server/journal/journal.cc
@@ -86,11 +86,6 @@ LSN Journal::GetLsn() const {
 void Journal::RecordEntry(TxId txid, Op opcode, DbIndex dbid, unsigned shard_cnt,
                           std::optional<SlotId> slot, Entry::Payload payload, bool await) {
   journal_slice.AddLogRecord(Entry{txid, opcode, dbid, shard_cnt, slot, std::move(payload)}, await);
-  time_t now = time(nullptr);
-  if (now - last_lsn_joural_time_ > 2) {
-    journal_slice.AddLogRecord(Entry{txid, journal::Op::LSN, 0, 0, nullopt, {}}, await);
-    last_lsn_joural_time_ = now;
-  }
 }
 
 }  // namespace journal

--- a/src/server/journal/journal_slice.cc
+++ b/src/server/journal/journal_slice.cc
@@ -142,7 +142,7 @@ std::string_view JournalSlice::GetEntry(LSN lsn) const {
   return (*ring_buffer_)[lsn - start].data;
 }
 
-void JournalSlice::AddLogRecord(Entry&& entry, bool await) {
+void JournalSlice::AddLogRecord(const Entry& entry, bool await) {
   optional<FiberAtomicGuard> guard;
   if (!await) {
     guard.emplace();  // Guard is non-movable/copyable, so we must use emplace()
@@ -166,7 +166,6 @@ void JournalSlice::AddLogRecord(Entry&& entry, bool await) {
     item->opcode = entry.opcode;
     item->lsn = lsn_++;
     item->slot = entry.slot;
-    entry.lsn = lsn_;
 
     io::BufSink buf_sink{&ring_serialize_buf_};
     JournalWriter writer{&buf_sink};

--- a/src/server/journal/journal_slice.h
+++ b/src/server/journal/journal_slice.h
@@ -37,7 +37,7 @@ class JournalSlice {
     return slice_index_ != UINT32_MAX;
   }
 
-  void AddLogRecord(Entry&& entry, bool await);
+  void AddLogRecord(const Entry& entry, bool await);
 
   // Register a callback that will be called every time a new entry is
   // added to the journal.

--- a/src/server/journal/serializer.cc
+++ b/src/server/journal/serializer.cc
@@ -63,7 +63,8 @@ void JournalWriter::Write(std::monostate) {
 
 void JournalWriter::Write(const journal::Entry& entry) {
   // Check if entry has a new db index and we need to emit a SELECT entry.
-  if (entry.opcode != journal::Op::SELECT && (!cur_dbid_ || entry.dbid != *cur_dbid_)) {
+  if (entry.opcode != journal::Op::SELECT && entry.opcode != journal::Op::LSN &&
+      entry.opcode != journal::Op::PING && (!cur_dbid_ || entry.dbid != *cur_dbid_)) {
     Write(journal::Entry{journal::Op::SELECT, entry.dbid, entry.slot});
     cur_dbid_ = entry.dbid;
   }

--- a/src/server/journal/streamer.h
+++ b/src/server/journal/streamer.h
@@ -44,6 +44,7 @@ class JournalStreamer : protected BufferedStreamerBase {
 
   uint32_t journal_cb_id_{0};
   journal::Journal* journal_;
+  time_t last_lsn_time_ = 0;
 
   util::fb2::Fiber write_fb_{};
 };

--- a/src/server/journal/types.h
+++ b/src/server/journal/types.h
@@ -54,6 +54,9 @@ struct Entry : public EntryBase {
       : EntryBase{0, opcode, dbid, 0, slot_id, 0} {
   }
 
+  Entry(journal::Op opcode, LSN lsn) : EntryBase{0, opcode, 0, 0, std::nullopt, lsn} {
+  }
+
   Entry(TxId txid, journal::Op opcode, DbIndex dbid, uint32_t shard_cnt,
         std::optional<SlotId> slot_id)
       : EntryBase{txid, opcode, dbid, shard_cnt, slot_id, 0} {

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -812,7 +812,9 @@ void DflyShardReplica::StableSyncDflyReadFb(Context* cntx) {
   io::PrefixSource ps{prefix, Sock()};
 
   JournalReader reader{&ps, 0};
-  TransactionReader tx_reader{use_multi_shard_exe_sync_, journal_rec_executed_};
+  DCHECK_GE(journal_rec_executed_, 1u);
+  TransactionReader tx_reader{use_multi_shard_exe_sync_,
+                              journal_rec_executed_.load(std::memory_order_relaxed) - 1};
 
   if (master_context_.version > DflyVersion::VER0) {
     acks_fb_ = fb2::Fiber("shard_acks", &DflyShardReplica::StableSyncDflyAcksFb, this, cntx);
@@ -831,7 +833,7 @@ void DflyShardReplica::StableSyncDflyReadFb(Context* cntx) {
 
     last_io_time_ = Proactor()->GetMonotonicTimeNs();
     if (tx_data->opcode == journal::Op::LSN) {
-      journal_rec_executed_.fetch_add(1, std::memory_order_relaxed);
+      //  Do nothing
     } else if (tx_data->opcode == journal::Op::PING) {
       force_ping_ = true;
       journal_rec_executed_.fetch_add(1, std::memory_order_relaxed);

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -331,8 +331,7 @@ void SliceSnapshot::OnDbChange(DbIndex db_index, const DbSlice::ChangeReq& req) 
 void SliceSnapshot::OnJournalEntry(const journal::JournalItem& item, bool await) {
   // We ignore EXEC and NOOP entries because we they have no meaning during
   // the LOAD phase on replica.
-  if (item.opcode == journal::Op::NOOP || item.opcode == journal::Op::EXEC ||
-      item.opcode == journal::Op::LSN)
+  if (item.opcode == journal::Op::NOOP || item.opcode == journal::Op::EXEC)
     return;
 
   serializer_->WriteJournalEntry(item.data);


### PR DESCRIPTION
The bug:
When downgrading from main to 15.1 using replica takeover the takeover will fail as lags are different between master and replica. The reason for this is that we wrote the LSN opcode to journal but did not send this opcode to replica if the replica version is lower than DflyVersion::VER4 because the replica does not know this opcode.
The problem is that lsn would increase in master but not in replica leading to replica takover fail as lag increase.
The fix:
Sending the LSN opcode now from steamer and do not write it to journal this way we will not increase journal lsn counter