### PR TITLE
fix: test_replicaof_reject_on_load crash on stop

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -566,7 +566,7 @@ void Connection::OnPreMigrateThread() {
 
 void Connection::OnPostMigrateThread() {
   // Once we migrated, we should rearm OnBreakCb callback.
-  if (breaker_cb_) {
+  if (breaker_cb_ && socket()->IsOpen()) {
     socket_->RegisterOnErrorCb([this](int32_t mask) { this->OnBreakCb(mask); });
   }
 
@@ -1418,15 +1418,23 @@ void Connection::ShutdownSelf() {
   util::Connection::Shutdown();
 }
 
-void Connection::Migrate(util::fb2::ProactorBase* dest) {
+bool Connection::Migrate(util::fb2::ProactorBase* dest) {
   // Migrate is used only by replication, so it doesn't have properties of full-fledged
   // connections
   CHECK(!cc_->async_dispatch);
-  CHECK_EQ(cc_->subscriptions, 0);    // are bound to thread local caches
-  CHECK_EQ(self_.use_count(), 1u);    // references cache our thread and backpressure
-  CHECK(!dispatch_fb_.IsJoinable());  // can't move once it started
+  CHECK_EQ(cc_->subscriptions, 0);  // are bound to thread local caches
+  CHECK_EQ(self_.use_count(), 1u);  // references cache our thread and backpressure
+  if (dispatch_fb_.IsJoinable()) {  // can't move once it started
+    return false;
+  }
 
   listener()->Migrate(this, dest);
+  // After we migrate, it could be the case the connection was shut down. We should
+  // act accordingly.
+  if (!socket()->IsOpen()) {
+    return false;
+  }
+  return true;
 }
 
 Connection::WeakRef Connection::Borrow() {
@@ -1500,8 +1508,9 @@ void Connection::SendAsync(MessageHandle msg) {
     return;
 
   // If we launch while closing, it won't be awaited. Control messages will be processed on cleanup.
-  if (!cc_->conn_closing)
+  if (!cc_->conn_closing) {
     LaunchDispatchFiberIfNeeded();
+  }
 
   DCHECK_NE(phase_, PRECLOSE);  // No more messages are processed after this point
 

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -241,7 +241,9 @@ class Connection : public util::Connection {
   void ShutdownSelf();
 
   // Migrate this connecton to a different thread.
-  void Migrate(util::fb2::ProactorBase* dest);
+  // Return true if Migrate succeeded
+  // Return false if dispatch_fb_ is active
+  bool Migrate(util::fb2::ProactorBase* dest);
 
   // Borrow weak reference to connection. Can be called from any thread.
   WeakRef Borrow();
@@ -374,7 +376,6 @@ class Connection : public util::Connection {
   bool ShouldEndDispatchFiber(const MessageHandle& msg);
 
   void LaunchDispatchFiberIfNeeded();  // Dispatch fiber is started lazily
-
   // Squashes pipelined commands from the dispatch queue to spread load over all threads
   void SquashPipeline(facade::SinkReplyBuilder*);
 


### PR DESCRIPTION
resolves #2769

The problem is that we are shutting down master. During this flow, we iterate and shutdown all of the listeners and then we give a chance for the currently executing commands to finish with `DispatchTracker`. However, this is problematic, because internally it traverses all of the connections in all shards and sends `SendCheckPoint` messages. When this happens, it forces the connection that handles the replica to activate its `dispatch_fiber_`.  If this happens before we `Migrate` the connection in the replication flow (dflycmd) then we will trigger the CHECK that asserts that the dispatch_fiber is not actve (it was never launched). 

Unfortunately this is based on timing and therefore it requires two things:

1. Migrate might fail if `dispatch_fiber` is active. In that case do no crash but return false to indicate that the migration was not successful. 
2. After we migrate, we might find ourselves with the socket closed (because of the shutdown signal process/flow). We need to check that the socket is open. If it's not, it means that it was shutdown by the signal flow (because after we finish with DispatchTracker, we start iterating over all of the connections in all of the shards and shut them down.