### PR TITLE
fix(replication): replication with multi shard sync enabled lagging

### DIFF
--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -77,8 +77,7 @@ runs:
           fi
         }
 
-        # disabled due to failures with this mode.
-        # (run_pytest_with_args --df enable_multi_shard_sync=true)
+        (run_pytest_with_args --df enable_multi_shard_sync=true)
         (run_pytest_with_args --df enable_multi_shard_sync=false)
 
     - name: Print last log on timeout

--- a/src/server/journal/tx_executor.cc
+++ b/src/server/journal/tx_executor.cc
@@ -113,6 +113,7 @@ std::optional<TransactionData> TransactionReader::NextTxData(JournalReader* read
     // When LSN opcode is sent master does not increase journal lsn.
     if (lsn_.has_value() && res->opcode != journal::Op::LSN) {
       ++*lsn_;
+      VLOG(2) << "read lsn: " << *lsn_;
     }
 
     // Check if journal command can be executed right away.

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -853,7 +853,7 @@ void DflyShardReplica::StableSyncDflyReadFb(Context* cntx) {
         ExecuteTxWithNoShardSync(std::move(*tx_data), cntx);
       }
     }
-    shard_replica_waker_.notify();
+    shard_replica_waker_.notifyAll();
   }
 }
 
@@ -1007,7 +1007,7 @@ void DflyShardReplica::StableSyncDflyExecFb(Context* cntx) {
     auto& data = trans_data_queue_.front();
     ExecuteTx(std::move(data.first), data.second, cntx);
     trans_data_queue_.pop();
-    shard_replica_waker_.notify();
+    shard_replica_waker_.notifyAll();
   }
 }
 


### PR DESCRIPTION
The bug:
The execution fiber in replica with multi shard sync was not awaked therefore it did not execute some data recieved in replica side. 
The fix:
call notifyAll on waker to wake the ACK fiber and the executor fiber