### PR TITLE
chore: expose direct API on Bloom objects

### DIFF
--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -303,6 +303,11 @@ class CompactObj {
   // pre condition - the type here is OBJ_JSON and was set with SetJson
   JsonType* GetJson() const;
 
+  void SetSBF(SBF* sbf) {
+    SetMeta(SBF_TAG);
+    u_.sbf = sbf;
+  }
+
   void SetSBF(uint64_t initial_capacity, double fp_prob, double grow_factor);
   SBF* GetSBF() const;
 


### PR DESCRIPTION
Needed to be able to (de)serialize SBF objects.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->