### PR TITLE
fix(tests): Fix numsub test

### DIFF
--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -288,47 +288,40 @@ Test PUBSUB NUMSUB command.
 """
 
 
-async def test_pubsub_subcommand_for_numsub(async_client):
-    subs1 = [async_client.pubsub() for i in range(5)]
-    for s in subs1:
-        await s.subscribe("channel_name1")
-    result = await async_client.pubsub_numsub("channel_name1")
-    assert result[0][0] == "channel_name1" and result[0][1] == 5
-
-    for s in subs1:
-        await s.unsubscribe("channel_name1")
-    result = await async_client.pubsub_numsub("channel_name1")
-
-    retry = 5
-    for i in range(0, retry):
-        result = await async_client.pubsub_numsub("channel_name1")
-        if result[0][0] == "channel_name1" and result[0][1] == 0:
-            break
+async def test_pubsub_subcommand_for_numsub(async_client: aioredis.Redis):
+    async def resub(s: "aioredis.PubSub", sub: bool, chan: str):
+        if sub:
+            await s.subscribe(chan)
         else:
-            time.sleep(1)
+            await s.unsubscribe(chan)
+        # Wait for PUSH message to be parsed to make sure upadte was performed
+        await s.get_message(timeout=0.1)
 
-    assert result[0][0] == "channel_name1" and result[0][1] == 0
+    # Subscribe 5 times to chan1
+    subs1 = [async_client.pubsub() for i in range(5)]
+    await asyncio.gather(*(resub(s, True, "chan1") for s in subs1))
+    assert await async_client.pubsub_numsub("chan1") == [("chan1", 5)]
 
-    result = await async_client.pubsub_numsub()
-    assert len(result) == 0
+    # Unsubscribe all from chan1
+    await asyncio.gather(*(resub(s, False, "chan1") for s in subs1))
+
+    # Make sure numsub drops to 0
+    with async_timeout.timeout(1):
+        while (await async_client.pubsub_numsub("chan1"))[0][1] > 0:
+            await asyncio.sleep(0.05)
+
+    # Check empty numsub
+    assert await async_client.pubsub_numsub() == []
 
     subs2 = [async_client.pubsub() for i in range(5)]
-    for s in subs2:
-        await s.subscribe("channel_name2")
+    await asyncio.gather(*(resub(s, True, "chan2") for s in subs2))
 
     subs3 = [async_client.pubsub() for i in range(10)]
-    for s in subs3:
-        await s.subscribe("channel_name3")
+    await asyncio.gather(*(resub(s, True, "chan3") for s in subs3))
 
-    result = await async_client.pubsub_numsub("channel_name2", "channel_name3")
-    assert result[0][0] == "channel_name2" and result[0][1] == 5
-    assert result[1][0] == "channel_name3" and result[1][1] == 10
+    assert await async_client.pubsub_numsub("chan2", "chan3") == [("chan2", 5), ("chan3", 10)]
 
-    for s in subs2:
-        await s.unsubscribe("channel_name2")
-
-    for s in subs3:
-        await s.unsubscribe("channel_name3")
+    await asyncio.gather(*(s.unsubscribe() for s in subs2 + subs3))
 
 
 """


### PR DESCRIPTION
Fixes #2828 

The issue is actually quite simple, both SUBSCRIBE and UNSUBSCRIBE don't send any replies and instead issue RESP3 push notificaitons. The client, however, doesn't wait even for the push notifications

https://github.com/redis/redis-py/blob/master/redis/client.py#L807-L809

I added a manual `get_message` call 
