### PR TITLE
feat(cluster): Send number of keys for incoming and outgoing migrations.

### DIFF
--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -626,31 +626,24 @@ static string_view StateToStr(MigrationState state) {
   return "UNDEFINED_STATE"sv;
 }
 
-void ClusterFamily::SendSingleMigrationStatus(ConnectionContext* cntx, string_view node_id) {
+void ClusterFamily::DflySlotMigrationStatus(CmdArgList args, ConnectionContext* cntx) {
   auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  CmdArgParser parser(args);
 
-  // find incoming slot migration
-  for (const auto& m : incoming_migrations_jobs_) {
-    if (m->GetSourceID() == node_id)
-      return rb->SendSimpleString(StateToStr(m->GetState()));
-  }
-  // find outgoing slot migration
-  for (const auto& migration : outgoing_migration_jobs_) {
-    if (migration->GetMigrationInfo().node_id == node_id)
-      return rb->SendSimpleString(StateToStr(migration->GetState()));
-  }
-  return rb->SendSimpleString(StateToStr(MigrationState::C_NO_STATE));
-}
+  lock_guard lk(migration_mu_);
 
-void ClusterFamily::SendAllMigrationStatus(ConnectionContext* cntx) {
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
-
-  const size_t arr_size = incoming_migrations_jobs_.size() + outgoing_migration_jobs_.size();
-  if (arr_size == 0) {
-    return rb->SendSimpleString(StateToStr(MigrationState::C_NO_STATE));
+  string_view node_id;
+  if (parser.HasNext()) {
+    node_id = parser.Next<std::string_view>();
+    if (auto err = parser.Error(); err) {
+      return rb->SendError(err->MakeReply());
+    }
   }
 
-  auto get_key_count = [](const SlotRanges& slots) {
+  vector<string> reply;
+  reply.reserve(incoming_migrations_jobs_.size() + outgoing_migration_jobs_.size());
+
+  auto get_key_count = [](const SlotRanges& slots) {  // TODO move to anon function
     atomic_uint64_t keys = 0;
 
     shard_set->pool()->Await([&](auto*) {
@@ -670,40 +663,26 @@ void ClusterFamily::SendAllMigrationStatus(ConnectionContext* cntx) {
     return keys.load();
   };
 
-  auto send_answer = [rb](std::string_view direction, std::string_view node_id,
-                          MigrationState state, uint64_t keys) {
-    auto str = absl::StrCat(direction, " ", node_id, " ", StateToStr(state), " ", "key:", keys);
-    rb->SendSimpleString(str);
+  auto append_answer = [rb, &reply](string_view direction, string_view node_id, string_view filter,
+                                    MigrationState state, uint64_t keys) {
+    if (filter.empty() || filter == node_id) {
+      reply.push_back(
+          absl::StrCat(direction, " ", node_id, " ", StateToStr(state), " ", "keys:", keys));
+    }
   };
 
-  rb->StartArray(arr_size);
-
   for (const auto& m : incoming_migrations_jobs_) {
-    send_answer("in", m->GetSourceID(), m->GetState(), get_key_count(m->GetSlots()));
+    append_answer("in", m->GetSourceID(), node_id, m->GetState(), get_key_count(m->GetSlots()));
   }
   for (const auto& migration : outgoing_migration_jobs_) {
-    send_answer("out", migration->GetMigrationInfo().node_id, migration->GetState(),
-                get_key_count(migration->GetSlots()));
+    append_answer("out", migration->GetMigrationInfo().node_id, node_id, migration->GetState(),
+                  get_key_count(migration->GetSlots()));
   }
 
-  return rb->SendSimpleString(StateToStr(MigrationState::C_NO_STATE));
-}
-
-void ClusterFamily::DflySlotMigrationStatus(CmdArgList args, ConnectionContext* cntx) {
-  CmdArgParser parser(args);
-
-  lock_guard lk(migration_mu_);
-
-  if (parser.HasNext()) {
-    auto node_id = parser.Next<std::string_view>();
-    if (auto err = parser.Error(); err) {
-      auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
-      return rb->SendError(err->MakeReply());
-    }
-
-    return SendSingleMigrationStatus(cntx, node_id);
+  if (reply.empty()) {
+    rb->SendSimpleString(StateToStr(MigrationState::C_NO_STATE));
   } else {
-    return SendAllMigrationStatus(cntx);
+    rb->SendStringArr(reply);
   }
 }
 

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -645,6 +645,11 @@ void ClusterFamily::SendSingleMigrationStatus(ConnectionContext* cntx, string_vi
 void ClusterFamily::SendAllMigrationStatus(ConnectionContext* cntx) {
   auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
 
+  const size_t arr_size = incoming_migrations_jobs_.size() + outgoing_migration_jobs_.size();
+  if (arr_size == 0) {
+    return rb->SendSimpleString(StateToStr(MigrationState::C_NO_STATE));
+  }
+
   auto get_key_count = [](const SlotRanges& slots) {
     atomic_uint64_t keys = 0;
 
@@ -671,7 +676,6 @@ void ClusterFamily::SendAllMigrationStatus(ConnectionContext* cntx) {
     rb->SendSimpleString(str);
   };
 
-  const size_t arr_size = incoming_migrations_jobs_.size() + outgoing_migration_jobs_.size();
   rb->StartArray(arr_size);
 
   for (const auto& m : incoming_migrations_jobs_) {

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -645,9 +645,6 @@ void ClusterFamily::SendSingleMigrationStatus(ConnectionContext* cntx, string_vi
 void ClusterFamily::SendAllMigrationStatus(ConnectionContext* cntx) {
   auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
 
-  auto arr_size = incoming_migrations_jobs_.size() + outgoing_migration_jobs_.size();
-  DCHECK(arr_size != 0);
-
   auto get_key_count = [](const SlotRanges& slots) {
     atomic_uint64_t keys = 0;
 
@@ -674,6 +671,7 @@ void ClusterFamily::SendAllMigrationStatus(ConnectionContext* cntx) {
     rb->SendSimpleString(str);
   };
 
+  const size_t arr_size = incoming_migrations_jobs_.size() + outgoing_migration_jobs_.size();
   rb->StartArray(arr_size);
 
   for (const auto& m : incoming_migrations_jobs_) {

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -681,6 +681,9 @@ void ClusterFamily::DflySlotMigrationStatus(CmdArgList args, ConnectionContext* 
 
   if (reply.empty()) {
     rb->SendSimpleString(StateToStr(MigrationState::C_NO_STATE));
+  } else if (!node_id.empty()) {
+    DCHECK_EQ(reply.size(), 1UL);
+    rb->SendSimpleString(reply[0]);
   } else {
     rb->SendStringArr(reply);
   }

--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -56,11 +56,7 @@ class ClusterFamily {
   void DflyClusterFlushSlots(CmdArgList args, ConnectionContext* cntx);
 
  private:  // Slots migration section
-  void DflySlotMigrationStatus(CmdArgList args, ConnectionContext* cntx)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(migration_mu_);
-  void SendSingleMigrationStatus(ConnectionContext* cntx, std::string_view node_id)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(migration_mu_);
-  void SendAllMigrationStatus(ConnectionContext* cntx) ABSL_LOCKS_EXCLUDED(migration_mu_);
+  void DflySlotMigrationStatus(CmdArgList args, ConnectionContext* cntx);
 
   // DFLYMIGRATE is internal command defines several steps in slots migrations process
   void DflyMigrate(CmdArgList args, ConnectionContext* cntx);

--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -56,7 +56,11 @@ class ClusterFamily {
   void DflyClusterFlushSlots(CmdArgList args, ConnectionContext* cntx);
 
  private:  // Slots migration section
-  void DflyIncomingSlotMigrationStatus(CmdArgList args, ConnectionContext* cntx);
+  void DflySlotMigrationStatus(CmdArgList args, ConnectionContext* cntx)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(migration_mu_);
+  void SendSingleMigrationStatus(ConnectionContext* cntx, std::string_view node_id)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(migration_mu_);
+  void SendAllMigrationStatus(ConnectionContext* cntx) ABSL_LOCKS_EXCLUDED(migration_mu_);
 
   // DFLYMIGRATE is internal command defines several steps in slots migrations process
   void DflyMigrate(CmdArgList args, ConnectionContext* cntx);

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -1245,7 +1245,7 @@ async def test_cluster_fuzzymigration(
         for node in nodes:
             states = await node.admin_client.execute_command("DFLYCLUSTER", "SLOT-MIGRATION-STATUS")
             print(states)
-            if not all(s.endswith("FINISHED") for s in states) and not states == "NO_STATE":
+            if not all("FINISHED" in s for s in states) and not states == "NO_STATE":
                 break
         else:
             break

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -1042,9 +1042,8 @@ async def test_cluster_data_migration(df_local_factory: DflyInstanceFactory):
 
     await asyncio.sleep(0.5)
 
-    while (
-        await c_nodes_admin[1].execute_command("DFLYCLUSTER", "SLOT-MIGRATION-STATUS", node_ids[0])
-        != "FINISHED"
+    while "FINISHED" not in await c_nodes_admin[1].execute_command(
+        "DFLYCLUSTER", "SLOT-MIGRATION-STATUS", node_ids[0]
     ):
         await asyncio.sleep(0.05)
 

--- a/tools/cluster_mgr.py
+++ b/tools/cluster_mgr.py
@@ -343,7 +343,7 @@ def migrate(args):
     while True:
         sync_status = send_command(target_node, ["DFLYCLUSTER", "SLOT-MIGRATION-STATUS"])
         assert len(sync_status) == 1
-        if sync_status[0].endswith("STABLE_SYNC"):
+        if "STABLE_SYNC" in sync_status[0]:
             break
 
     print("Reached stable sync: ", sync_status)


### PR DESCRIPTION
The number of keys in an _incoming_ migration indicates how many keys were received, while for _outgoing_ it shows the total number. Combining the two can provide the control plane with percentage.

This slightly modified the format of the response.

Fixes #2756

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->