### PR TITLE
chore: relax repltakeover constraints to only exlude write commands

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1022,7 +1022,7 @@ std::optional<ErrorReply> Service::VerifyCommandState(const CommandId* cid, CmdA
       allowed_by_state = false;
       break;
     case GlobalState::TAKEN_OVER:
-      allowed_by_state = cid->name() == "REPLCONF" || cid->name() == "SAVE";
+      allowed_by_state = !cid->IsWriteOnly();
       break;
     default:
       break;


### PR DESCRIPTION
resolves #2859

* relax `repltakeover` constraints