### PR TITLE
fix: return wrong type errors for SET...GET command

### DIFF
--- a/src/server/string_family_test.cc
+++ b/src/server/string_family_test.cc
@@ -197,6 +197,9 @@ TEST_F(StringFamilyTest, Set) {
 
   resp = Run({"set", "foo", "bar", "ex", "1"});
   ASSERT_THAT(resp, "OK");
+
+  ASSERT_THAT(Run({"sadd", "s1", "1"}), IntArg(1));
+  ASSERT_THAT(Run({"set", "s1", "2"}), "OK");
 }
 
 TEST_F(StringFamilyTest, SetHugeKey) {
@@ -777,6 +780,10 @@ TEST_F(StringFamilyTest, SetWithGetParam) {
   EXPECT_THAT(Run({"set", "key3", "not used", "xx", "get"}), ArgType(RespExpr::NIL));
   EXPECT_THAT(Run({"set", "key2", "val3", "xx", "get"}), "val2");
   EXPECT_EQ(Run({"get", "key2"}), "val3");
+
+  EXPECT_THAT(Run({"sadd", "key4", "1"}), IntArg(1));
+  EXPECT_THAT(Run({"set", "key4", "2", "get"}), ErrArg("wrong kind of value"));
+  EXPECT_THAT(Run({"set", "key4", "2", "xx", "get"}), ErrArg("wrong kind of value"));
 }
 
 TEST_F(StringFamilyTest, SetWithHashtagsNoCluster) {


### PR DESCRIPTION
Fixes #2423

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->