### PR TITLE
feat server: bring visibility to script errors

### DIFF
--- a/src/facade/error.h
+++ b/src/facade/error.h
@@ -32,6 +32,7 @@ extern const char kOutOfMemory[];
 extern const char kInvalidNumericResult[];
 extern const char kClusterNotConfigured[];
 extern const char kLoadingErr[];
+extern const char kUndeclaredKeyErr[];
 
 extern const char kSyntaxErrType[];
 extern const char kScriptErrType[];

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -91,6 +91,7 @@ const char kOutOfMemory[] = "Out of memory";
 const char kInvalidNumericResult[] = "result is not a number";
 const char kClusterNotConfigured[] = "Cluster is not yet configured";
 const char kLoadingErr[] = "-LOADING Dragonfly is loading the dataset in memory";
+const char kUndeclaredKeyErr[] = "script tried accessing undeclared key";
 
 const char kSyntaxErrType[] = "syntax_error";
 const char kScriptErrType[] = "script_error";

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -42,7 +42,7 @@ ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
 }
 
 ReplyStats& ReplyStats::operator+=(const ReplyStats& o) {
-  static_assert(sizeof(ReplyStats) == 96u + kSanitizerOverhead);
+  static_assert(sizeof(ReplyStats) == 72u + kSanitizerOverhead);
   ADD(io_write_cnt);
   ADD(io_write_bytes);
 
@@ -50,9 +50,7 @@ ReplyStats& ReplyStats::operator+=(const ReplyStats& o) {
     err_count[k_v.first] += k_v.second;
   }
 
-  for (const auto& k_v : o.script_error_map) {
-    script_error_map[k_v.first] = k_v.second;
-  }
+  ADD(script_error_count);
 
   send_stats += o.send_stats;
 

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -42,12 +42,16 @@ ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
 }
 
 ReplyStats& ReplyStats::operator+=(const ReplyStats& o) {
-  static_assert(sizeof(ReplyStats) == 64u + kSanitizerOverhead);
+  static_assert(sizeof(ReplyStats) == 96u + kSanitizerOverhead);
   ADD(io_write_cnt);
   ADD(io_write_bytes);
 
   for (const auto& k_v : o.err_count) {
     err_count[k_v.first] += k_v.second;
+  }
+
+  for (const auto& k_v : o.script_error_map) {
+    script_error_map[k_v.first] = k_v.second;
   }
 
   send_stats += o.send_stats;

--- a/src/facade/facade_types.h
+++ b/src/facade/facade_types.h
@@ -95,7 +95,8 @@ struct ReplyStats {
   size_t io_write_cnt = 0;
   size_t io_write_bytes = 0;
   absl::flat_hash_map<std::string, uint64_t> err_count;
-  absl::flat_hash_map<std::string, std::string> script_error_map;
+  absl::flat_hash_map<std::string, std::string>
+      script_error_map;  // map of script sha to last script error
 
   ReplyStats& operator+=(const ReplyStats& other);
 };

--- a/src/facade/facade_types.h
+++ b/src/facade/facade_types.h
@@ -95,8 +95,7 @@ struct ReplyStats {
   size_t io_write_cnt = 0;
   size_t io_write_bytes = 0;
   absl::flat_hash_map<std::string, uint64_t> err_count;
-  absl::flat_hash_map<std::string, std::string>
-      script_error_map;  // map of script sha to last script error
+  size_t script_error_count = 0;
 
   ReplyStats& operator+=(const ReplyStats& other);
 };

--- a/src/facade/facade_types.h
+++ b/src/facade/facade_types.h
@@ -95,6 +95,7 @@ struct ReplyStats {
   size_t io_write_cnt = 0;
   size_t io_write_bytes = 0;
   absl::flat_hash_map<std::string, uint64_t> err_count;
+  absl::flat_hash_map<std::string, std::string> script_error_map;
 
   ReplyStats& operator+=(const ReplyStats& other);
 };

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1084,7 +1084,7 @@ std::optional<ErrorReply> Service::VerifyCommandState(const CommandId* cid, CmdA
         CheckKeysDeclared(*dfly_cntx.conn_state.script_info, cid, tail_args, dfly_cntx.transaction);
 
     if (status == OpStatus::KEY_NOTFOUND)
-      return ErrorReply{"script tried accessing undeclared key"};
+      return ErrorReply(kUndeclaredKeyErr);
 
     if (status != OpStatus::OK)
       return ErrorReply{status};
@@ -1943,6 +1943,7 @@ void Service::EvalInternal(CmdArgList args, const EvalArgs& eval_args, Interpret
 
   if (result == Interpreter::RUN_ERR) {
     string resp = StrCat("Error running script (call to ", eval_args.sha, "): ", error);
+    server_family_.script_mgr()->OnScriptError(eval_args.sha, error);
     return cntx->SendError(resp, facade::kScriptErrType);
   }
 

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -19,6 +19,7 @@
 ABSL_DECLARE_FLAG(uint32_t, multi_exec_mode);
 ABSL_DECLARE_FLAG(bool, multi_exec_squash);
 ABSL_DECLARE_FLAG(bool, lua_auto_async);
+ABSL_DECLARE_FLAG(bool, lua_allow_undeclared_auto_correct);
 ABSL_DECLARE_FLAG(std::string, default_lua_flags);
 
 namespace dfly {
@@ -375,6 +376,7 @@ TEST_F(MultiTest, Eval) {
     GTEST_SKIP() << "Skipped Eval test because default_lua_flags is set";
     return;
   }
+  absl::SetFlag(&FLAGS_lua_allow_undeclared_auto_correct, true);
 
   RespExpr resp;
 

--- a/src/server/script_mgr.cc
+++ b/src/server/script_mgr.cc
@@ -33,7 +33,7 @@ ABSL_FLAG(
     bool, lua_auto_async, false,
     "If enabled, call/pcall with discarded values are automatically replaced with acall/apcall.");
 
-ABSL_FLAG(bool, lua_allow_undeclared_auto_correct, true,
+ABSL_FLAG(bool, lua_allow_undeclared_auto_correct, false,
           "If enabled, when a script that is not allowed to run with undeclared keys is trying to "
           "access undeclared keys, automaticaly set the script flag to be able to run with "
           "undeclared key.");

--- a/src/server/script_mgr.cc
+++ b/src/server/script_mgr.cc
@@ -289,7 +289,7 @@ optional<ScriptMgr::ScriptData> ScriptMgr::Find(std::string_view sha) const {
 
 void ScriptMgr::OnScriptError(std::string_view sha, std::string_view error) {
   lock_guard lk{mu_};
-  script_errors_.fetch_add(1, std::memory_order::relaxed);
+  script_errors_.fetch_add(1, std::memory_order_relaxed);
   auto it = db_.find(sha);
   if (it == db_.end()) {
     return;

--- a/src/server/script_mgr.cc
+++ b/src/server/script_mgr.cc
@@ -288,7 +288,7 @@ optional<ScriptMgr::ScriptData> ScriptMgr::Find(std::string_view sha) const {
 }
 
 void ScriptMgr::OnScriptError(std::string_view sha, std::string_view error) {
-  tl_facade_stats->reply_stats.script_error_map[sha] = error;
+  ++tl_facade_stats->reply_stats.script_error_count;
   lock_guard lk{mu_};
   auto it = db_.find(sha);
   if (it == db_.end()) {

--- a/src/server/script_mgr.cc
+++ b/src/server/script_mgr.cc
@@ -33,8 +33,12 @@ ABSL_FLAG(
     bool, lua_auto_async, false,
     "If enabled, call/pcall with discarded values are automatically replaced with acall/apcall.");
 
-namespace dfly {
+ABSL_FLAG(bool, lua_allow_undeclared_auto_correct, true,
+          "If enabled, when a script that is not allowed to run with undeclared keys is trying to "
+          "access undeclared keys, automaticaly set the script flag to be able to run with "
+          "undeclared key.");
 
+namespace dfly {
 using namespace std;
 using namespace facade;
 using namespace util;
@@ -294,13 +298,15 @@ void ScriptMgr::OnScriptError(std::string_view sha, std::string_view error) {
   if (++it->second.error_resp < 5) {
     LOG(ERROR) << "Error running script (call to " << sha << "): " << error;
   }
-  // If script has undeclared_keys and was not flaged to run in this mode we will change the script
-  // flag - this will make script next run to not fail but run as global.
-  size_t pos = error.rfind(kUndeclaredKeyErr);
-  if (pos != string::npos) {
-    it->second.undeclared_keys = true;
-    LOG(WARNING) << "Setting undeclared_keys flag for script with sha : (" << sha << ")";
-    UpdateScriptCaches(sha, it->second);
+  // If script has undeclared_keys and was not flaged to run in this mode we will change the
+  // script flag - this will make script next run to not fail but run as global.
+  if (absl::GetFlag(FLAGS_lua_allow_undeclared_auto_correct)) {
+    size_t pos = error.rfind(kUndeclaredKeyErr);
+    if (pos != string::npos) {
+      it->second.undeclared_keys = true;
+      LOG(WARNING) << "Setting undeclared_keys flag for script with sha : (" << sha << ")";
+      UpdateScriptCaches(sha, it->second);
+    }
   }
 }
 

--- a/src/server/script_mgr.cc
+++ b/src/server/script_mgr.cc
@@ -288,8 +288,8 @@ optional<ScriptMgr::ScriptData> ScriptMgr::Find(std::string_view sha) const {
 }
 
 void ScriptMgr::OnScriptError(std::string_view sha, std::string_view error) {
+  tl_facade_stats->reply_stats.script_error_map[sha] = error;
   lock_guard lk{mu_};
-  script_errors_.fetch_add(1, std::memory_order_relaxed);
   auto it = db_.find(sha);
   if (it == db_.end()) {
     return;

--- a/src/server/script_mgr.h
+++ b/src/server/script_mgr.h
@@ -62,7 +62,7 @@ class ScriptMgr {
 
   void OnScriptError(std::string_view sha, std::string_view error);
   uint32_t script_errors() {
-    return script_errors_.load(std::memory_order::relaxed);
+    return script_errors_.load(std::memory_order_relaxed);
   }
 
  private:

--- a/src/server/script_mgr.h
+++ b/src/server/script_mgr.h
@@ -7,7 +7,6 @@
 #include <absl/container/flat_hash_map.h>
 
 #include <array>
-#include <atomic>
 #include <optional>
 
 #include "server/conn_context.h"

--- a/src/server/script_mgr.h
+++ b/src/server/script_mgr.h
@@ -61,9 +61,6 @@ class ScriptMgr {
   bool AreGlobalByDefault() const;
 
   void OnScriptError(std::string_view sha, std::string_view error);
-  uint32_t script_errors() {
-    return script_errors_.load(std::memory_order_relaxed);
-  }
 
  private:
   void ExistsCmd(CmdArgList args, ConnectionContext* cntx) const;
@@ -85,7 +82,6 @@ class ScriptMgr {
   ScriptParams default_params_;
 
   absl::flat_hash_map<ScriptKey, InternalScriptData> db_;
-  std::atomic_uint32_t script_errors_{0};
   mutable util::fb2::Mutex mu_;
 };
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2040,6 +2040,7 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
     append("blocked_on_interpreter", m.coordinator_stats.blocked_on_interpreter);
     append("ram_hits", m.events.ram_hits);
     append("ram_misses", m.events.ram_misses);
+    append("script_erros", script_mgr_->script_errors());
   }
 
   if (should_enter("TIERED", true)) {

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1146,16 +1146,8 @@ void PrintPrometheusMetrics(const Metrics& m, StringResponse* resp) {
     }
   }
 
-  {
-    const auto& reply_stats = m.facade_stats.reply_stats;
-    string sript_error_type_metric;
-    AppendMetricHeader("script_error_type", "Error type returned by script", MetricType::GAUGE,
-                       &sript_error_type_metric);
-    for (const auto& [sha, error] : reply_stats.script_error_map) {
-      AppendMetricValue("script_error", error, {"sha"}, {sha}, &sript_error_type_metric);
-    }
-    absl::StrAppend(&resp->body(), sript_error_type_metric);
-  }
+  AppendMetricWithoutLabels("script_error_total", "", m.facade_stats.reply_stats.script_error_count,
+                            MetricType::COUNTER, &resp->body());
 
   // DB stats
   AppendMetricWithoutLabels("expired_keys_total", "", m.events.expired_keys, MetricType::COUNTER,
@@ -1803,7 +1795,7 @@ void ServerFamily::ResetStat() {
     tl_facade_stats->reply_stats.io_write_bytes = 0;
     tl_facade_stats->reply_stats.io_write_cnt = 0;
     tl_facade_stats->reply_stats.send_stats = {};
-    tl_facade_stats->reply_stats.script_error_map.clear();
+    tl_facade_stats->reply_stats.script_error_count = 0;
     tl_facade_stats->reply_stats.err_count.clear();
 
     service_.mutable_registry()->ResetCallStats(index);


### PR DESCRIPTION
fixes #2870 
1. expose a metric with script errors
2. Add an error log of a script SHA and the reason for failure. The error log must be bounded with at most K log entries per script so we won't have logs overflow for high throughput traffic.
3. Additional feature (under a flag) upon receiving the undeclared variable error - transform the script to globally-atomic and retry the call.