### PR TITLE
fix(acl): skip http and add check on connection traversals

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -654,6 +654,7 @@ void Connection::HandleRequests() {
   if (http_res) {
     cc_.reset(service_->CreateContext(peer, this));
     if (*http_res) {
+      stats_ = &tl_facade_stats->conn_stats;
       VLOG(1) << "HTTP1.1 identified";
       is_http_ = true;
       HttpConnection http_conn{http_listener_};
@@ -1635,6 +1636,10 @@ void Connection::StartTrafficLogging(string_view path) {
 void Connection::StopTrafficLogging() {
   lock_guard lk(tl_traffic_logger.mutex);
   tl_traffic_logger.ResetLocked();
+}
+
+bool Connection::IsHttp() const {
+  return is_http_;
 }
 
 Connection::MemoryUsage Connection::GetMemoryUsage() const {

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -605,6 +605,7 @@ void Connection::HandleRequests() {
     DCHECK_EQ(res, 0);
   }
 
+  stats_ = &tl_facade_stats->conn_stats;
   auto remote_ep = RemoteEndpointStr();
 
   FiberSocketBase* peer = socket_.get();
@@ -654,7 +655,6 @@ void Connection::HandleRequests() {
   if (http_res) {
     cc_.reset(service_->CreateContext(peer, this));
     if (*http_res) {
-      stats_ = &tl_facade_stats->conn_stats;
       VLOG(1) << "HTTP1.1 identified";
       is_http_ = true;
       HttpConnection http_conn{http_listener_};
@@ -820,8 +820,6 @@ io::Result<bool> Connection::CheckForHttpProto(FiberSocketBase* peer) {
 }
 
 void Connection::ConnectionFlow(FiberSocketBase* peer) {
-  stats_ = &tl_facade_stats->conn_stats;
-
   ++stats_->num_conns;
   ++stats_->conn_received_cnt;
   stats_->read_buf_capacity += io_buf_.Capacity();

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -307,6 +307,8 @@ class Connection : public util::Connection {
   // Get quick debug info for logs
   std::string DebugInfo() const;
 
+  bool IsHttp() const;
+
  protected:
   void OnShutdown() override;
   void OnPreMigrateThread() override;

--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -85,8 +85,10 @@ void AclFamily::StreamUpdatesToAllProactorConnections(const std::string& user, u
   auto update_cb = [&]([[maybe_unused]] size_t id, util::Connection* conn) {
     DCHECK(conn);
     auto connection = static_cast<facade::Connection*>(conn);
-    connection->SendAclUpdateAsync(
-        facade::Connection::AclUpdateMessage{user, update_cat, update_commands, update_keys});
+    if (!connection->IsHttp() && connection->cntx()) {
+      connection->SendAclUpdateAsync(
+          facade::Connection::AclUpdateMessage{user, update_cat, update_commands, update_keys});
+    }
   };
 
   if (main_listener_) {


### PR DESCRIPTION
Fixes a bug that was reported in Discord. 

When there is an update to an ACL user, the changes are propagated by traversing all the connections on each thread and calling SendAsync with an ACL update message pushed at the front of the queue. This internally activates the `dispatch_fb_`.

Unfortunately, traversals on HTTP connections are causing numerous issues:

1. SendAsync is problematic because for example it accesses `stats_` which uninitialized for that flow 
2. We don't Join the dispatch_fb_ fiber on HTTP flow

All in all, I skip Http connections all together since they are not really part of ACL's atm. Furthermore, I noticed that in some HTTP connections the `cc_` was nullptr (which I think it happens during shudown) and for that I added a sanity check that it's not nullpt (and therefore we won't crash by triggering DCHECK or UB on release)