### PR TITLE
feat(server): Allow configuration of hashtag extraction

### DIFF
--- a/src/server/cluster/cluster_config.cc
+++ b/src/server/cluster/cluster_config.cc
@@ -56,7 +56,7 @@ bool ClusterConfig::IsEmulated() {
 }
 
 string_view ClusterConfig::KeyTag(string_view key) {
-  auto options = KeyLockArgs::GetLocktagOptions();
+  auto options = KeyLockArgs::GetLockTagOptions();
 
   if (!absl::StartsWith(key, options.prefix)) {
     return key;

--- a/src/server/cluster/cluster_config.cc
+++ b/src/server/cluster/cluster_config.cc
@@ -56,21 +56,21 @@ bool ClusterConfig::IsEmulated() {
 }
 
 string_view ClusterConfig::KeyTag(string_view key) {
-  auto options = KeyLockArgs::GetHashtagLockOptions();
+  auto options = KeyLockArgs::GetLocktagOptions();
 
   if (!absl::StartsWith(key, options.prefix)) {
     return key;
   }
 
-  const size_t start = key.find(options.open_hashtag);
+  const size_t start = key.find(options.open_locktag);
   if (start == key.npos) {
     return key;
   }
 
   size_t end = start;
-  for (int i = 0; i <= options.close_skip_n_occurrence; ++i) {
+  for (unsigned i = 0; i <= options.skip_n_end_delimiters; ++i) {
     size_t next = end + 1;
-    end = key.find(options.close_hashtag, next);
+    end = key.find(options.close_locktag, next);
     if (end == key.npos || end == next) {
       return key;
     }

--- a/src/server/cluster/cluster_config.cc
+++ b/src/server/cluster/cluster_config.cc
@@ -55,14 +55,21 @@ bool ClusterConfig::IsEmulated() {
 }
 
 string_view ClusterConfig::KeyTag(string_view key) {
-  size_t start = key.find('{');
+  auto options = KeyLockArgs::GetHashtagLockOptions();
+  const size_t start = key.find(options.open_hashtag);
   if (start == key.npos) {
     return key;
   }
-  size_t end = key.find('}', start + 1);
-  if (end == key.npos || end == start + 1) {
-    return key;
+
+  size_t end = start;
+  for (int i = 0; i <= options.close_n_occurrence; ++i) {
+    size_t next = end + 1;
+    end = key.find(options.close_hashtag, next);
+    if (end == key.npos || end == next) {
+      return key;
+    }
   }
+
   return key.substr(start + 1, end - start - 1);
 }
 

--- a/src/server/cluster/cluster_config.cc
+++ b/src/server/cluster/cluster_config.cc
@@ -10,6 +10,7 @@ extern "C" {
 #include <shared_mutex>
 #include <string_view>
 
+#include "absl/strings/match.h"
 #include "base/flags.h"
 #include "base/logging.h"
 #include "cluster_config.h"
@@ -56,13 +57,18 @@ bool ClusterConfig::IsEmulated() {
 
 string_view ClusterConfig::KeyTag(string_view key) {
   auto options = KeyLockArgs::GetHashtagLockOptions();
+
+  if (!absl::StartsWith(key, options.prefix)) {
+    return key;
+  }
+
   const size_t start = key.find(options.open_hashtag);
   if (start == key.npos) {
     return key;
   }
 
   size_t end = start;
-  for (int i = 0; i <= options.close_n_occurrence; ++i) {
+  for (int i = 0; i <= options.close_skip_n_occurrence; ++i) {
     size_t next = end + 1;
     end = key.find(options.close_hashtag, next);
     if (end == key.npos || end == next) {

--- a/src/server/cluster/cluster_config.h
+++ b/src/server/cluster/cluster_config.h
@@ -64,7 +64,7 @@ class ClusterConfig {
   }
 
   static bool IsShardedByTag() {
-    return IsEnabledOrEmulated() || KeyLockArgs::GetHashtagLockOptions().enabled;
+    return IsEnabledOrEmulated() || KeyLockArgs::GetLocktagOptions().enabled;
   }
 
   // If the key contains the {...} pattern, return only the part between { and }

--- a/src/server/cluster/cluster_config.h
+++ b/src/server/cluster/cluster_config.h
@@ -64,7 +64,7 @@ class ClusterConfig {
   }
 
   static bool IsShardedByTag() {
-    return IsEnabledOrEmulated() || KeyLockArgs::GetLocktagOptions().enabled;
+    return IsEnabledOrEmulated() || KeyLockArgs::GetLockTagOptions().enabled;
   }
 
   // If the key contains the {...} pattern, return only the part between { and }

--- a/src/server/cluster/cluster_config.h
+++ b/src/server/cluster/cluster_config.h
@@ -64,7 +64,7 @@ class ClusterConfig {
   }
 
   static bool IsShardedByTag() {
-    return IsEnabledOrEmulated() || KeyLockArgs::IsLockHashTagEnabled();
+    return IsEnabledOrEmulated() || KeyLockArgs::GetHashtagLockOptions().enabled;
   }
 
   // If the key contains the {...} pattern, return only the part between { and }

--- a/src/server/cluster/cluster_config_test.cc
+++ b/src/server/cluster/cluster_config_test.cc
@@ -10,6 +10,7 @@
 
 #include "base/gtest.h"
 #include "base/logging.h"
+#include "server/test_utils.h"
 
 using namespace std;
 using namespace testing;
@@ -21,26 +22,59 @@ MATCHER_P(NodeMatches, expected, "") {
   return arg.id == expected.id && arg.ip == expected.ip && arg.port == expected.port;
 }
 
-class ClusterConfigTest : public ::testing::Test {
+class ClusterConfigTest : public BaseFamilyTest {
  protected:
   const string kMyId = "my-id";
 };
 
 TEST_F(ClusterConfigTest, KeyTagTest) {
-  string key = "{user1000}.following";
-  ASSERT_EQ("user1000", ClusterConfig::KeyTag(key));
+  SetTestFlag("lock_on_hashtags", "true");
 
-  key = " foo{}{bar}";
-  ASSERT_EQ(key, ClusterConfig::KeyTag(key));
+  EXPECT_EQ(ClusterConfig::KeyTag("{user1000}.following"), "user1000");
 
-  key = "foo{{bar}}zap";
-  ASSERT_EQ("{bar", ClusterConfig::KeyTag(key));
+  EXPECT_EQ(ClusterConfig::KeyTag("foo{{bar}}zap"), "{bar");
 
-  key = "foo{bar}{zap}";
-  ASSERT_EQ("bar", ClusterConfig::KeyTag(key));
+  EXPECT_EQ(ClusterConfig::KeyTag("foo{bar}{zap}"), "bar");
+
+  string_view key = " foo{}{bar}";
+  EXPECT_EQ(key, ClusterConfig::KeyTag(key));
 
   key = "{}foo{bar}{zap}";
-  ASSERT_EQ(key, ClusterConfig::KeyTag(key));
+  EXPECT_EQ(key, ClusterConfig::KeyTag(key));
+
+  SetTestFlag("hashtag_open", ":");
+  SetTestFlag("hashtag_close", ":");
+  TEST_InvalidateLockHashTag();
+
+  key = "{user1000}.following";
+  EXPECT_EQ(ClusterConfig::KeyTag(key), key);
+
+  EXPECT_EQ(ClusterConfig::KeyTag("bull:queue1:123"), "queue1");
+  EXPECT_EQ(ClusterConfig::KeyTag("bull:queue:1:123"), "queue");
+  EXPECT_EQ(ClusterConfig::KeyTag("bull:queue:1:123:456:789:1000"), "queue");
+
+  key = "bull::queue:1:123";
+  EXPECT_EQ(ClusterConfig::KeyTag(key), key);
+
+  SetTestFlag("hashtag_open", ":");
+  SetTestFlag("hashtag_close", ":");
+  SetTestFlag("hashtag_close_n_occurrence", "1");
+  TEST_InvalidateLockHashTag();
+
+  key = "bull:queue1:123";
+  EXPECT_EQ(ClusterConfig::KeyTag(key), key);
+  EXPECT_EQ(ClusterConfig::KeyTag("bull:queue:1:123"), "queue:1");
+  EXPECT_EQ(ClusterConfig::KeyTag("bull:queue:1:123:456:789:1000"), "queue:1");
+
+  key = "bull::queue:1:123";
+  EXPECT_EQ(ClusterConfig::KeyTag(key), key);
+
+  SetTestFlag("hashtag_open", "(");
+  SetTestFlag("hashtag_close", ")");
+  SetTestFlag("hashtag_close_n_occurrence", "2");
+  TEST_InvalidateLockHashTag();
+
+  EXPECT_EQ(ClusterConfig::KeyTag("(a)b)c)d)e"), "a)b)c");
 }
 
 TEST_F(ClusterConfigTest, ConfigSetInvalidEmpty) {

--- a/src/server/cluster/cluster_config_test.cc
+++ b/src/server/cluster/cluster_config_test.cc
@@ -43,7 +43,7 @@ TEST_F(ClusterConfigTest, KeyTagTest) {
   EXPECT_EQ(key, ClusterConfig::KeyTag(key));
 
   SetTestFlag("locktag_delimiter", ":");
-  TEST_InvalidateLocktagOptions();
+  TEST_InvalidateLockTagOptions();
 
   key = "{user1000}.following";
   EXPECT_EQ(ClusterConfig::KeyTag(key), key);
@@ -58,7 +58,7 @@ TEST_F(ClusterConfigTest, KeyTagTest) {
   SetTestFlag("locktag_delimiter", ":");
   SetTestFlag("locktag_skip_n_end_delimiters", "0");
   SetTestFlag("locktag_prefix", "bull");
-  TEST_InvalidateLocktagOptions();
+  TEST_InvalidateLockTagOptions();
   EXPECT_EQ(ClusterConfig::KeyTag("bull:queue:123"), "queue");
   EXPECT_EQ(ClusterConfig::KeyTag("bull:queue:123:456:789:1000"), "queue");
 
@@ -68,7 +68,7 @@ TEST_F(ClusterConfigTest, KeyTagTest) {
   SetTestFlag("locktag_delimiter", ":");
   SetTestFlag("locktag_skip_n_end_delimiters", "1");
   SetTestFlag("locktag_prefix", "bull");
-  TEST_InvalidateLocktagOptions();
+  TEST_InvalidateLockTagOptions();
 
   key = "bull:queue1:123";
   EXPECT_EQ(ClusterConfig::KeyTag(key), key);
@@ -81,7 +81,7 @@ TEST_F(ClusterConfigTest, KeyTagTest) {
   SetTestFlag("locktag_delimiter", "|");
   SetTestFlag("locktag_skip_n_end_delimiters", "2");
   SetTestFlag("locktag_prefix", "");
-  TEST_InvalidateLocktagOptions();
+  TEST_InvalidateLockTagOptions();
 
   EXPECT_EQ(ClusterConfig::KeyTag("|a|b|c|d|e"), "a|b|c");
 }

--- a/src/server/cluster/cluster_config_test.cc
+++ b/src/server/cluster/cluster_config_test.cc
@@ -58,7 +58,19 @@ TEST_F(ClusterConfigTest, KeyTagTest) {
 
   SetTestFlag("hashtag_open", ":");
   SetTestFlag("hashtag_close", ":");
-  SetTestFlag("hashtag_close_n_occurrence", "1");
+  SetTestFlag("hashtag_close_skip_n_occurrence", "0");
+  SetTestFlag("hashtag_prefix", "bull");
+  TEST_InvalidateLockHashTag();
+  EXPECT_EQ(ClusterConfig::KeyTag("bull:queue:123"), "queue");
+  EXPECT_EQ(ClusterConfig::KeyTag("bull:queue:123:456:789:1000"), "queue");
+
+  key = "not-bull:queue1:123";
+  EXPECT_EQ(ClusterConfig::KeyTag(key), key);
+
+  SetTestFlag("hashtag_open", ":");
+  SetTestFlag("hashtag_close", ":");
+  SetTestFlag("hashtag_close_skip_n_occurrence", "1");
+  SetTestFlag("hashtag_prefix", "bull");
   TEST_InvalidateLockHashTag();
 
   key = "bull:queue1:123";
@@ -71,7 +83,8 @@ TEST_F(ClusterConfigTest, KeyTagTest) {
 
   SetTestFlag("hashtag_open", "(");
   SetTestFlag("hashtag_close", ")");
-  SetTestFlag("hashtag_close_n_occurrence", "2");
+  SetTestFlag("hashtag_close_skip_n_occurrence", "2");
+  SetTestFlag("hashtag_prefix", "");
   TEST_InvalidateLockHashTag();
 
   EXPECT_EQ(ClusterConfig::KeyTag("(a)b)c)d)e"), "a)b)c");

--- a/src/server/cluster/cluster_config_test.cc
+++ b/src/server/cluster/cluster_config_test.cc
@@ -42,9 +42,8 @@ TEST_F(ClusterConfigTest, KeyTagTest) {
   key = "{}foo{bar}{zap}";
   EXPECT_EQ(key, ClusterConfig::KeyTag(key));
 
-  SetTestFlag("hashtag_open", ":");
-  SetTestFlag("hashtag_close", ":");
-  TEST_InvalidateLockHashTag();
+  SetTestFlag("locktag_delimiter", ":");
+  TEST_InvalidateLocktagOptions();
 
   key = "{user1000}.following";
   EXPECT_EQ(ClusterConfig::KeyTag(key), key);
@@ -56,22 +55,20 @@ TEST_F(ClusterConfigTest, KeyTagTest) {
   key = "bull::queue:1:123";
   EXPECT_EQ(ClusterConfig::KeyTag(key), key);
 
-  SetTestFlag("hashtag_open", ":");
-  SetTestFlag("hashtag_close", ":");
-  SetTestFlag("hashtag_close_skip_n_occurrence", "0");
-  SetTestFlag("hashtag_prefix", "bull");
-  TEST_InvalidateLockHashTag();
+  SetTestFlag("locktag_delimiter", ":");
+  SetTestFlag("locktag_skip_n_end_delimiters", "0");
+  SetTestFlag("locktag_prefix", "bull");
+  TEST_InvalidateLocktagOptions();
   EXPECT_EQ(ClusterConfig::KeyTag("bull:queue:123"), "queue");
   EXPECT_EQ(ClusterConfig::KeyTag("bull:queue:123:456:789:1000"), "queue");
 
   key = "not-bull:queue1:123";
   EXPECT_EQ(ClusterConfig::KeyTag(key), key);
 
-  SetTestFlag("hashtag_open", ":");
-  SetTestFlag("hashtag_close", ":");
-  SetTestFlag("hashtag_close_skip_n_occurrence", "1");
-  SetTestFlag("hashtag_prefix", "bull");
-  TEST_InvalidateLockHashTag();
+  SetTestFlag("locktag_delimiter", ":");
+  SetTestFlag("locktag_skip_n_end_delimiters", "1");
+  SetTestFlag("locktag_prefix", "bull");
+  TEST_InvalidateLocktagOptions();
 
   key = "bull:queue1:123";
   EXPECT_EQ(ClusterConfig::KeyTag(key), key);
@@ -81,13 +78,12 @@ TEST_F(ClusterConfigTest, KeyTagTest) {
   key = "bull::queue:1:123";
   EXPECT_EQ(ClusterConfig::KeyTag(key), key);
 
-  SetTestFlag("hashtag_open", "(");
-  SetTestFlag("hashtag_close", ")");
-  SetTestFlag("hashtag_close_skip_n_occurrence", "2");
-  SetTestFlag("hashtag_prefix", "");
-  TEST_InvalidateLockHashTag();
+  SetTestFlag("locktag_delimiter", "|");
+  SetTestFlag("locktag_skip_n_end_delimiters", "2");
+  SetTestFlag("locktag_prefix", "");
+  TEST_InvalidateLocktagOptions();
 
-  EXPECT_EQ(ClusterConfig::KeyTag("(a)b)c)d)e"), "a)b)c");
+  EXPECT_EQ(ClusterConfig::KeyTag("|a|b|c|d|e"), "a|b|c");
 }
 
 TEST_F(ClusterConfigTest, ConfigSetInvalidEmpty) {

--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -40,7 +40,7 @@ ABSL_FLAG(
 
 ABSL_FLAG(unsigned, locktag_skip_n_end_delimiters, 0,
           "How many closing tag delimiters should we skip when extracting lock tags. 0 for no "
-          "skipping. For example, when delimiter is ':' and this flag is 2, the hashtag for "
+          "skipping. For example, when delimiter is ':' and this flag is 2, the locktag for "
           "':a:b:c:d:e' will be 'a:b:c'.");
 
 ABSL_FLAG(std::string, locktag_prefix, "",

--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -30,11 +30,13 @@ ABSL_FLAG(bool, lock_on_hashtags, false,
           "When true, locks are done in the {hashtag} level instead of key level.");
 
 // We would have used `char` instead of `string` for the following 2 flags, but that's impossible.
-ABSL_FLAG(std::string, hashtag_open, "{", "Opening hashtag character. Must be a single character.");
-ABSL_FLAG(std::string, hashtag_close, "}",
-          "Closing hashtag character. Must be a single character.");
+ABSL_FLAG(std::string, hashtag_open, "{", "Opening hashtag character. Must be a single char.");
+ABSL_FLAG(std::string, hashtag_close, "}", "Closing hashtag character. Must be a single char.");
 
-ABSL_FLAG(int, hashtag_close_n_occurrence, 0,
+ABSL_FLAG(std::string, hashtag_prefix, "",
+          "Only keys with this prefix participate in hashtag extraction.");
+
+ABSL_FLAG(int, hashtag_close_skip_n_occurrence, 0,
           "How many closing hashtags should we skip. 0 for no skipping. For example, when set to "
           "2, the hashtag for '{a}b}c}d}e' will be 'a}b}c'.");
 
@@ -68,7 +70,8 @@ void TEST_InvalidateLockHashTag() {
         .enabled = absl::GetFlag(FLAGS_lock_on_hashtags),
         .open_hashtag = open[0],
         .close_hashtag = close[0],
-        .close_n_occurrence = absl::GetFlag(FLAGS_hashtag_close_n_occurrence),
+        .close_skip_n_occurrence = absl::GetFlag(FLAGS_hashtag_close_skip_n_occurrence),
+        .prefix = absl::GetFlag(FLAGS_hashtag_prefix),
     };
   }
 

--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -29,17 +29,19 @@ extern "C" {
 // We've generalized "hashtags" so that users can specify custom delimiter and closures, see below.
 // If I had a time machine, I'd rename this to lock_on_tags.
 ABSL_FLAG(bool, lock_on_hashtags, false,
-          "When true, locks are done in the {hashtag} level instead of key level.");
+          "When true, locks are done in the {hashtag} level instead of key level. Hashtag "
+          "extraction can be further configured with locktag_* flags.");
 
 // We would have used `char` instead of `string`, but that's impossible.
 ABSL_FLAG(
     std::string, locktag_delimiter, "",
-    "If set, this char is used to extract a lock key by looking at delimiters, like hash tags. If "
-    "unset, regular hashtag extraction is done. Must be used with --lock_on_hashtags");
+    "If set, this char is used to extract a lock tag by looking at delimiters, like hash tags. If "
+    "unset, regular hashtag extraction is done (with {}). Must be used with --lock_on_hashtags");
 
 ABSL_FLAG(unsigned, locktag_skip_n_end_delimiters, 0,
-          "How many closing hashtags should we skip. 0 for no skipping. For example, when set to "
-          "2, the hashtag for '{a}b}c}d}e' will be 'a}b}c'.");
+          "How many closing tag delimiters should we skip when extracting lock tags. 0 for no "
+          "skipping. For example, when delimiter is ':' and this flag is 2, the hashtag for "
+          "':a:b:c:d:e' will be 'a:b:c'.");
 
 ABSL_FLAG(std::string, locktag_prefix, "",
           "Only keys with this prefix participate in tag extraction.");

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -57,7 +57,8 @@ struct HashtagsLockOptions {
   bool enabled = false;
   char open_hashtag = '{';
   char close_hashtag = '}';
-  int close_n_occurrence = 0;
+  int close_skip_n_occurrence = 0;
+  std::string prefix;
 };
 
 struct KeyLockArgs {

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -53,16 +53,16 @@ class CommandId;
 class Transaction;
 class EngineShard;
 
-struct HashtagsLockOptions {
+struct LocktagsLockOptions {
   bool enabled = false;
-  char open_hashtag = '{';
-  char close_hashtag = '}';
-  int close_skip_n_occurrence = 0;
+  char open_locktag = '{';
+  char close_locktag = '}';
+  unsigned skip_n_end_delimiters = 0;
   std::string prefix;
 };
 
 struct KeyLockArgs {
-  static HashtagsLockOptions GetHashtagLockOptions();
+  static LocktagsLockOptions GetLocktagOptions();
 
   // Before acquiring and releasing keys, one must "normalize" them via GetLockKey().
   static std::string_view GetLockKey(std::string_view key);

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -53,7 +53,7 @@ class CommandId;
 class Transaction;
 class EngineShard;
 
-struct LocktagsLockOptions {
+struct LockTagOptions {
   bool enabled = false;
   char open_locktag = '{';
   char close_locktag = '}';
@@ -62,7 +62,7 @@ struct LocktagsLockOptions {
 };
 
 struct KeyLockArgs {
-  static LocktagsLockOptions GetLocktagOptions();
+  static LockTagOptions GetLockTagOptions();
 
   // Before acquiring and releasing keys, one must "normalize" them via GetLockKey().
   static std::string_view GetLockKey(std::string_view key);

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -53,8 +53,15 @@ class CommandId;
 class Transaction;
 class EngineShard;
 
+struct HashtagsLockOptions {
+  bool enabled = false;
+  char open_hashtag = '{';
+  char close_hashtag = '}';
+  int close_n_occurrence = 0;
+};
+
 struct KeyLockArgs {
-  static bool IsLockHashTagEnabled();
+  static HashtagsLockOptions GetHashtagLockOptions();
 
   // Before acquiring and releasing keys, one must "normalize" them via GetLockKey().
   static std::string_view GetLockKey(std::string_view key);

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -594,7 +594,7 @@ void ClusterHtmlPage(const http::QueryArgs& args, HttpContext* send, ClusterFami
                                                 : "Disabled");
 
   if (ClusterConfig::IsEnabledOrEmulated()) {
-    print_kb("Lock on hashtags", KeyLockArgs::GetHashtagLockOptions().enabled);
+    print_kb("Lock on hashtags", KeyLockArgs::GetLocktagOptions().enabled);
   }
 
   if (ClusterConfig::IsEnabled()) {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -586,7 +586,7 @@ void ClusterHtmlPage(const http::QueryArgs& args, HttpContext* send, ClusterFami
                                                 : "Disabled");
 
   if (ClusterConfig::IsEnabledOrEmulated()) {
-    print_kb("Lock on hashtags", KeyLockArgs::IsLockHashTagEnabled());
+    print_kb("Lock on hashtags", KeyLockArgs::GetHashtagLockOptions().enabled);
   }
 
   if (ClusterConfig::IsEnabled()) {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -594,7 +594,7 @@ void ClusterHtmlPage(const http::QueryArgs& args, HttpContext* send, ClusterFami
                                                 : "Disabled");
 
   if (ClusterConfig::IsEnabledOrEmulated()) {
-    print_kb("Lock on hashtags", KeyLockArgs::GetLocktagOptions().enabled);
+    print_kb("Lock on hashtags", KeyLockArgs::GetLockTagOptions().enabled);
   }
 
   if (ClusterConfig::IsEnabled()) {

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -180,7 +180,7 @@ void BaseFamilyTest::TearDown() {
 
 void BaseFamilyTest::ResetService() {
   if (service_ != nullptr) {
-    TEST_InvalidateLockHashTag();
+    TEST_InvalidateLocktagOptions();
 
     ShutdownService();
   }

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -178,9 +178,6 @@ void BaseFamilyTest::TearDown() {
   LOG(INFO) << "Finishing " << test_info->name();
 }
 
-// Test hook defined in common.cc.
-void TEST_InvalidateLockHashTag();
-
 void BaseFamilyTest::ResetService() {
   if (service_ != nullptr) {
     TEST_InvalidateLockHashTag();

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -180,7 +180,7 @@ void BaseFamilyTest::TearDown() {
 
 void BaseFamilyTest::ResetService() {
   if (service_ != nullptr) {
-    TEST_InvalidateLocktagOptions();
+    TEST_InvalidateLockTagOptions();
 
     ShutdownService();
   }

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -20,6 +20,9 @@ using namespace facade;
 using util::fb2::Fiber;
 using util::fb2::Launch;
 
+// Test hook defined in common.cc.
+void TEST_InvalidateLockHashTag();
+
 class TestConnection : public facade::Connection {
  public:
   TestConnection(Protocol protocol, io::StringSink* sink);

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -21,7 +21,7 @@ using util::fb2::Fiber;
 using util::fb2::Launch;
 
 // Test hook defined in common.cc.
-void TEST_InvalidateLockHashTag();
+void TEST_InvalidateLocktagOptions();
 
 class TestConnection : public facade::Connection {
  public:

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -21,7 +21,7 @@ using util::fb2::Fiber;
 using util::fb2::Launch;
 
 // Test hook defined in common.cc.
-void TEST_InvalidateLocktagOptions();
+void TEST_InvalidateLockTagOptions();
 
 class TestConnection : public facade::Connection {
  public:


### PR DESCRIPTION
Before this PR: Hashtags, if enabled, meant the text between `{` and `}` in the key (if exists and non-empty).

After this PR:

* Hashtags can _still_ be enabled / disabled
* Hashtag open / close char can be specified (and can be the same), like `:` popular with BullMQ
* Hashtag can include `N` closing tags to skip, like `{a}b}c}d` with `2` will return `a}b}c`.
* Hashtags can be limited to only be applied on keys with a specified prefix

This will allow some existing systems to migrate without code changes in client code.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->