### PR TITLE
chore: get rid of lock keys

### DIFF
--- a/src/server/common.h
+++ b/src/server/common.h
@@ -70,7 +70,6 @@ struct LockTagOptions {
 struct KeyLockArgs {
   DbIndex db_index = 0;
   absl::Span<const LockFp> fps;
-  unsigned key_step = 1;
 };
 
 // Describes key indices.
@@ -159,8 +158,6 @@ void RecordExpiry(DbIndex dbid, std::string_view key);
 // Trigger journal write to sink, no journal record will be added to journal.
 // Must be called from shard thread of journal to sink.
 void TriggerJournalWriteToSink();
-
-bool IsLockHashTagEnabled();
 
 struct IoMgrStats {
   uint64_t read_total = 0;

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -118,7 +118,7 @@ struct OpArgs {
   }
 };
 
-// A strong type for a lock tag. Helps to disambiguide between keys and the parts of the
+// A strong type for a lock tag. Helps to disambiguate between keys and the parts of the
 // keys that are used for locking.
 class LockTag {
   std::string_view str_;

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -69,7 +69,7 @@ struct LockTagOptions {
 
 struct KeyLockArgs {
   DbIndex db_index = 0;
-  ArgSlice args;
+  absl::Span<const LockFp> fps;
   unsigned key_step = 1;
 };
 
@@ -159,6 +159,8 @@ void RecordExpiry(DbIndex dbid, std::string_view key);
 // Trigger journal write to sink, no journal record will be added to journal.
 // Must be called from shard thread of journal to sink.
 void TriggerJournalWriteToSink();
+
+bool IsLockHashTagEnabled();
 
 struct IoMgrStats {
   uint64_t read_total = 0;

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -992,7 +992,6 @@ bool DbSlice::Acquire(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
   if (lock_args.fps.empty()) {  // Can be empty for NO_KEY_TRANSACTIONAL commands.
     return true;
   }
-  DCHECK_GT(lock_args.key_step, 0u);
 
   auto& lt = db_arr_[lock_args.db_index]->trans_locks;
   bool lock_acquired = true;
@@ -1003,7 +1002,7 @@ bool DbSlice::Acquire(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
   } else {
     uniq_fps_.clear();
 
-    for (size_t i = 0; i < lock_args.fps.size(); i += lock_args.key_step) {
+    for (size_t i = 0; i < lock_args.fps.size(); ++i) {
       uint64_t fp = lock_args.fps[i];
       if (uniq_fps_.insert(fp).second) {
         lock_acquired &= lt.Acquire(fp, mode);
@@ -1029,7 +1028,7 @@ void DbSlice::Release(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
     lt.Release(fp, mode);
   } else {
     uniq_fps_.clear();
-    for (size_t i = 0; i < lock_args.fps.size(); i += lock_args.key_step) {
+    for (size_t i = 0; i < lock_args.fps.size(); ++i) {
       uint64_t fp = lock_args.fps[i];
       if (uniq_fps_.insert(fp).second) {
         lt.Release(fp, mode);

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1002,8 +1002,7 @@ bool DbSlice::Acquire(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
   } else {
     uniq_fps_.clear();
 
-    for (size_t i = 0; i < lock_args.fps.size(); ++i) {
-      uint64_t fp = lock_args.fps[i];
+    for (LockFp fp : lock_args.fps) {
       if (uniq_fps_.insert(fp).second) {
         lock_acquired &= lt.Acquire(fp, mode);
       }
@@ -1028,8 +1027,7 @@ void DbSlice::Release(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
     lt.Release(fp, mode);
   } else {
     uniq_fps_.clear();
-    for (size_t i = 0; i < lock_args.fps.size(); ++i) {
-      uint64_t fp = lock_args.fps[i];
+    for (LockFp fp : lock_args.fps) {
       if (uniq_fps_.insert(fp).second) {
         lt.Release(fp, mode);
       }

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -989,7 +989,7 @@ size_t DbSlice::DbSize(DbIndex db_ind) const {
 }
 
 bool DbSlice::Acquire(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
-  if (lock_args.args.empty()) {  // Can be empty for NO_KEY_TRANSACTIONAL commands.
+  if (lock_args.fps.empty()) {  // Can be empty for NO_KEY_TRANSACTIONAL commands.
     return true;
   }
   DCHECK_GT(lock_args.key_step, 0u);
@@ -997,62 +997,51 @@ bool DbSlice::Acquire(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
   auto& lt = db_arr_[lock_args.db_index]->trans_locks;
   bool lock_acquired = true;
 
-  if (lock_args.args.size() == 1) {
-    LockTag tag(lock_args.args.front());
-    lock_acquired = lt.Acquire(tag, mode);
-    uniq_keys_ = {string_view(tag)};  // needed only for tests.
+  if (lock_args.fps.size() == 1) {
+    lock_acquired = lt.Acquire(lock_args.fps.front(), mode);
+    uniq_fps_ = {lock_args.fps.front()};  // needed only for tests.
   } else {
-    uniq_keys_.clear();
+    uniq_fps_.clear();
 
-    for (size_t i = 0; i < lock_args.args.size(); i += lock_args.key_step) {
-      LockTag tag(lock_args.args[i]);
-      if (uniq_keys_.insert(string_view(tag)).second) {
-        lock_acquired &= lt.Acquire(tag, mode);
+    for (size_t i = 0; i < lock_args.fps.size(); i += lock_args.key_step) {
+      uint64_t fp = lock_args.fps[i];
+      if (uniq_fps_.insert(fp).second) {
+        lock_acquired &= lt.Acquire(fp, mode);
       }
     }
   }
 
-  DVLOG(2) << "Acquire " << IntentLock::ModeName(mode) << " for " << lock_args.args[0]
+  DVLOG(2) << "Acquire " << IntentLock::ModeName(mode) << " for " << lock_args.fps[0]
            << " has_acquired: " << lock_acquired;
 
   return lock_acquired;
 }
 
-void DbSlice::ReleaseNormalized(IntentLock::Mode mode, DbIndex db_index, LockTag tag) {
-  DVLOG(2) << "Release " << IntentLock::ModeName(mode) << " "
-           << " for " << string_view(tag);
-
-  auto& lt = db_arr_[db_index]->trans_locks;
-  lt.Release(tag, mode);
-}
-
 void DbSlice::Release(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
-  if (lock_args.args.empty()) {  // Can be empty for NO_KEY_TRANSACTIONAL commands.
+  if (lock_args.fps.empty()) {  // Can be empty for NO_KEY_TRANSACTIONAL commands.
     return;
   }
 
-  DVLOG(2) << "Release " << IntentLock::ModeName(mode) << " for " << lock_args.args[0];
-  if (lock_args.args.size() == 1) {
-    string_view key = lock_args.args.front();
-    ReleaseNormalized(mode, lock_args.db_index, LockTag{key});
+  DVLOG(2) << "Release " << IntentLock::ModeName(mode) << " for " << lock_args.fps[0];
+  auto& lt = db_arr_[lock_args.db_index]->trans_locks;
+  if (lock_args.fps.size() == 1) {
+    uint64_t fp = lock_args.fps.front();
+    lt.Release(fp, mode);
   } else {
-    auto& lt = db_arr_[lock_args.db_index]->trans_locks;
-    uniq_keys_.clear();
-    for (size_t i = 0; i < lock_args.args.size(); i += lock_args.key_step) {
-      LockTag tag(lock_args.args[i]);
-      if (uniq_keys_.insert(string_view(tag)).second) {
-        lt.Release(tag, mode);
+    uniq_fps_.clear();
+    for (size_t i = 0; i < lock_args.fps.size(); i += lock_args.key_step) {
+      uint64_t fp = lock_args.fps[i];
+      if (uniq_fps_.insert(fp).second) {
+        lt.Release(fp, mode);
       }
     }
   }
-  uniq_keys_.clear();
+  uniq_fps_.clear();
 }
 
-bool DbSlice::CheckLock(IntentLock::Mode mode, DbIndex dbid, string_view key) const {
+bool DbSlice::CheckLock(IntentLock::Mode mode, DbIndex dbid, uint64_t fp) const {
   const auto& lt = db_arr_[dbid]->trans_locks;
-  LockTag tag(key);
-
-  auto lock = lt.Find(tag);
+  auto lock = lt.Find(fp);
   if (lock) {
     return lock->Check(mode);
   }

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -174,18 +174,18 @@ class RoundRobinSharder {
 };
 
 bool HasContendedLocks(ShardId shard_id, Transaction* trx, const DbTable* table) {
-  auto is_contended = [table](LockTag tag) { return table->trans_locks.Find(tag)->IsContended(); };
+  auto is_contended = [table](LockFp fp) { return table->trans_locks.Find(fp)->IsContended(); };
 
   if (trx->IsMulti()) {
-    auto keys = trx->GetMultiKeys();
-    for (string_view key : keys) {
-      if (Shard(key, shard_set->size()) == shard_id && is_contended(LockTag{key}))
+    auto fps = trx->GetMultiFps();
+    for (const auto& [sid, fp] : fps) {
+      if (sid == shard_id && is_contended(fp))
         return true;
     }
   } else {
     KeyLockArgs lock_args = trx->GetLockArgs(shard_id);
-    for (size_t i = 0; i < lock_args.args.size(); i += lock_args.key_step) {
-      if (is_contended(LockTag{lock_args.args[i]}))
+    for (size_t i = 0; i < lock_args.fps.size(); i += lock_args.key_step) {
+      if (is_contended(lock_args.fps[i]))
         return true;
     }
   }

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -184,7 +184,7 @@ bool HasContendedLocks(ShardId shard_id, Transaction* trx, const DbTable* table)
     }
   } else {
     KeyLockArgs lock_args = trx->GetLockArgs(shard_id);
-    for (size_t i = 0; i < lock_args.fps.size(); i += lock_args.key_step) {
+    for (size_t i = 0; i < lock_args.fps.size(); ++i) {
       if (is_contended(lock_args.fps[i]))
         return true;
     }

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1810,7 +1810,7 @@ optional<bool> StartMultiEval(DbIndex dbid, CmdArgList keys, ScriptMgr::ScriptPa
       trans->StartMultiGlobal(dbid);
       return true;
     case Transaction::LOCK_AHEAD:
-      trans->StartMultiLockedAhead(dbid, CmdArgVec{keys.begin(), keys.end()});
+      trans->StartMultiLockedAhead(dbid, keys);
       return true;
     case Transaction::NON_ATOMIC:
       trans->StartMultiNonAtomic();
@@ -2087,9 +2087,10 @@ void StartMultiExec(DbIndex dbid, Transaction* trans, ConnectionState::ExecInfo*
     case Transaction::GLOBAL:
       trans->StartMultiGlobal(dbid);
       break;
-    case Transaction::LOCK_AHEAD:
-      trans->StartMultiLockedAhead(dbid, CollectAllKeys(exec_info));
-      break;
+    case Transaction::LOCK_AHEAD: {
+      auto vec = CollectAllKeys(exec_info);
+      trans->StartMultiLockedAhead(dbid, absl::MakeSpan(vec));
+    } break;
     case Transaction::NON_ATOMIC:
       trans->StartMultiNonAtomic();
       break;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1088,6 +1088,8 @@ void PrintPrometheusMetrics(const Metrics& m, StringResponse* resp) {
   if (sdata_res.has_value()) {
     size_t rss = sdata_res->vm_rss + sdata_res->hugetlb_pages;
     AppendMetricWithoutLabels("used_memory_rss_bytes", "", rss, MetricType::GAUGE, &resp->body());
+    AppendMetricWithoutLabels("swap_memory_bytes", "", sdata_res->vm_swap, MetricType::GAUGE,
+                              &resp->body());
   } else {
     LOG_FIRST_N(ERROR, 10) << "Error fetching /proc/self/status stats. error "
                            << sdata_res.error().message();

--- a/src/server/table.cc
+++ b/src/server/table.cc
@@ -65,16 +65,15 @@ std::optional<const IntentLock> LockTable::Find(LockTag tag) const {
   return std::nullopt;
 }
 
-bool LockTable::Acquire(LockTag tag, IntentLock::Mode mode) {
-  LockFp fp = tag.Fingerprint();
-  auto [it, inserted] = locks_.try_emplace(fp);
-  return it->second.Acquire(mode);
+std::optional<const IntentLock> LockTable::Find(uint64_t fp) const {
+  if (auto it = locks_.find(fp); it != locks_.end())
+    return it->second;
+  return std::nullopt;
 }
 
-void LockTable::Release(LockTag tag, IntentLock::Mode mode) {
-  LockFp fp = tag.Fingerprint();
+void LockTable::Release(uint64_t fp, IntentLock::Mode mode) {
   auto it = locks_.find(fp);
-  DCHECK(it != locks_.end()) << string_view(tag);
+  DCHECK(it != locks_.end()) << fp;
 
   it->second.Release(mode);
   if (it->second.IsFree())

--- a/src/server/table.h
+++ b/src/server/table.h
@@ -87,8 +87,11 @@ class LockTable {
   std::optional<const IntentLock> Find(LockTag tag) const;
   std::optional<const IntentLock> Find(LockFp fp) const;
 
-  bool Acquire(LockTag tag, IntentLock::Mode mode);
-  void Release(LockTag tag, IntentLock::Mode mode);
+  bool Acquire(LockFp fp, IntentLock::Mode mode) {
+    return locks_[fp].Acquire(mode);
+  }
+
+  void Release(LockFp fp, IntentLock::Mode mode);
 
   auto begin() const {
     return locks_.cbegin();

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -144,7 +144,7 @@ class BaseFamilyTest : public ::testing::Test {
   const facade::Connection::InvalidationMessage& GetInvalidationMessage(std::string_view conn_id,
                                                                         size_t index) const;
 
-  static absl::flat_hash_set<std::string> GetLastUsedKeys();
+  static std::vector<LockFp> GetLastFps();
   static void ExpectConditionWithinTimeout(const std::function<bool()>& condition,
                                            absl::Duration timeout = absl::Seconds(10));
   util::fb2::Fiber ExpectConditionWithSuspension(const std::function<bool()>& condition);

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -83,9 +83,9 @@ uint16_t trans_id(const Transaction* ptr) {
 }
 
 bool CheckLocks(const DbSlice& db_slice, IntentLock::Mode mode, const KeyLockArgs& lock_args) {
-  for (size_t i = 0; i < lock_args.args.size(); i += lock_args.key_step) {
-    string_view s = lock_args.args[i];
-    if (!db_slice.CheckLock(mode, lock_args.db_index, s))
+  for (size_t i = 0; i < lock_args.fps.size(); i += lock_args.key_step) {
+    auto fp = lock_args.fps[i];
+    if (!db_slice.CheckLock(mode, lock_args.db_index, fp))
       return false;
   }
   return true;
@@ -206,8 +206,9 @@ void Transaction::BuildShardIndex(const KeyIndex& key_index, std::vector<PerShar
     string_view key = ArgS(args, i);
     unique_slot_checker_.Add(key);
     uint32_t sid = Shard(key, shard_data_.size());
-    add(sid, i);
+    shard_index[sid].key_step = key_index.step;
 
+    add(sid, i);
     DCHECK_LE(key_index.step, 2u);
     if (key_index.step == 2) {  // Handle value associated with preceding key.
       add(sid, ++i);
@@ -218,6 +219,8 @@ void Transaction::BuildShardIndex(const KeyIndex& key_index, std::vector<PerShar
 void Transaction::InitShardData(absl::Span<const PerShardCache> shard_index, size_t num_args,
                                 bool rev_mapping) {
   kv_args_.reserve(num_args);
+  kv_fp_.reserve(num_args);
+
   if (rev_mapping)
     reverse_index_.reserve(num_args);
 
@@ -242,7 +245,13 @@ void Transaction::InitShardData(absl::Span<const PerShardCache> shard_index, siz
     unique_shard_id_ = i;
 
     for (size_t j = 0; j < si.args.size(); ++j) {
-      kv_args_.push_back(si.args[j]);
+      string_view arg = si.args[j];
+      kv_args_.push_back(arg);
+      if (si.key_step == 1 || j % si.key_step == 0) {
+        kv_fp_.push_back(LockTag(arg).Fingerprint());
+      } else {
+        kv_fp_.push_back(0);
+      }
       if (rev_mapping)
         reverse_index_.push_back(si.original_index[j]);
     }
@@ -251,27 +260,18 @@ void Transaction::InitShardData(absl::Span<const PerShardCache> shard_index, siz
   DCHECK_EQ(kv_args_.size(), num_args);
 }
 
-void Transaction::LaunderKeyStorage(CmdArgVec* keys) {
+void Transaction::PrepareMultiFps(const CmdArgVec& keys) {
   DCHECK_EQ(multi_->mode, LOCK_AHEAD);
-  DCHECK_GT(keys->size(), 0u);
+  DCHECK_GT(keys.size(), 0u);
 
-  auto& m_keys = multi_->frozen_keys;
-  auto& m_keys_set = multi_->frozen_keys_set;
+  auto& tag_fps = multi_->tag_fps;
 
-  // Reserve enough space, so pointers from frozen_keys_set are not invalidated
-  m_keys.reserve(keys->size());
-
-  for (MutableSlice key : *keys) {
-    string_view key_s = string_view(LockTag{facade::ToSV(key)});
-    // Insert copied string view, not original. This is why "try insert" is not allowed
-    if (!m_keys_set.contains(key_s))
-      m_keys_set.insert(m_keys.emplace_back(key_s));
+  tag_fps.reserve(keys.size());
+  for (MutableSlice key : keys) {
+    string_view sv = facade::ToSV(key);
+    ShardId sid = Shard(sv, shard_set->size());
+    tag_fps.emplace(sid, LockTag(sv).Fingerprint());
   }
-
-  // Copy mutable pointers into keys
-  keys->clear();
-  for (string& key : m_keys)
-    keys->emplace_back(key.data(), key.size());
 }
 
 void Transaction::StoreKeysInArgs(const KeyIndex& key_index) {
@@ -280,9 +280,14 @@ void Transaction::StoreKeysInArgs(const KeyIndex& key_index) {
 
   // even for a single key we may have multiple arguments per key (MSET).
   for (unsigned j = key_index.start; j < key_index.end; j++) {
-    kv_args_.push_back(ArgS(full_args_, j));
-    if (key_index.step == 2)
+    string_view arg = ArgS(full_args_, j);
+    kv_args_.push_back(arg);
+    kv_fp_.push_back(LockTag(arg).Fingerprint());
+
+    if (key_index.step == 2) {
       kv_args_.push_back(ArgS(full_args_, ++j));
+      kv_fp_.push_back(0);
+    }
   }
 
   if (key_index.has_reverse_mapping) {
@@ -339,7 +344,7 @@ void Transaction::InitByKeys(const KeyIndex& key_index) {
   // Initialize shard data based on distributed arguments.
   InitShardData(shard_index, key_index.num_args(), key_index.has_reverse_mapping);
 
-  DCHECK(!multi_ || multi_->mode != LOCK_AHEAD || !multi_->frozen_keys.empty());
+  DCHECK(!multi_ || multi_->mode != LOCK_AHEAD || !multi_->tag_fps.empty());
 
   DVLOG(1) << "InitByArgs " << DebugId() << " " << kv_args_.front();
 
@@ -442,6 +447,7 @@ void Transaction::StartMultiGlobal(DbIndex dbid) {
   ScheduleInternal();
 }
 
+// TODO: remove by value.
 void Transaction::StartMultiLockedAhead(DbIndex dbid, CmdArgVec keys, bool skip_scheduling) {
   DVLOG(1) << "StartMultiLockedAhead on " << keys.size() << " keys";
 
@@ -451,7 +457,7 @@ void Transaction::StartMultiLockedAhead(DbIndex dbid, CmdArgVec keys, bool skip_
   multi_->mode = LOCK_AHEAD;
   multi_->lock_mode = LockMode();
 
-  LaunderKeyStorage(&keys);  // Filter uniques and normalize
+  PrepareMultiFps(keys);
 
   InitBase(dbid, absl::MakeSpan(keys));
   InitByKeys(KeyIndex::Range(0, keys.size()));
@@ -796,12 +802,9 @@ void Transaction::UnlockMulti() {
   if ((coordinator_state_ & COORD_SCHED) == 0 || (coordinator_state_ & COORD_CONCLUDING) > 0)
     return;
 
-  multi_->frozen_keys_set.clear();
-
-  auto sharded_keys = make_shared<vector<vector<string_view>>>(shard_set->size());
-  for (string& key : multi_->frozen_keys) {
-    ShardId sid = Shard(key, sharded_keys->size());
-    (*sharded_keys)[sid].emplace_back(key);
+  vector<vector<LockFp>> sharded_keys(shard_set->size());
+  for (const auto& [sid, fp] : multi_->tag_fps) {
+    sharded_keys[sid].emplace_back(fp);
   }
 
   multi_->shard_journal_cnt = ServerState::tlocal()->journal() ? CalcMultiNumOfShardJournals() : 0;
@@ -810,8 +813,9 @@ void Transaction::UnlockMulti() {
 
   DCHECK_EQ(shard_data_.size(), shard_set->size());
   for (ShardId i = 0; i < shard_data_.size(); ++i) {
-    shard_set->Add(i, [this, sharded_keys, i]() {
-      this->UnlockMultiShardCb((*sharded_keys)[i], EngineShard::tlocal());
+    vector<LockFp> fps = std::move(sharded_keys[i]);
+    shard_set->Add(i, [this, fps = std::move(fps)]() {
+      this->UnlockMultiShardCb(fps, EngineShard::tlocal());
       intrusive_ptr_release(this);
     });
   }
@@ -939,9 +943,9 @@ void Transaction::Refurbish() {
   cb_ptr_ = nullptr;
 }
 
-const absl::flat_hash_set<std::string_view>& Transaction::GetMultiKeys() const {
+const absl::flat_hash_set<std::pair<ShardId, LockFp>>& Transaction::GetMultiFps() const {
   DCHECK(multi_);
-  return multi_->frozen_keys_set;
+  return multi_->tag_fps;
 }
 
 void Transaction::FIX_ConcludeJournalExec() {
@@ -1016,9 +1020,13 @@ KeyLockArgs Transaction::GetLockArgs(ShardId sid) const {
   KeyLockArgs res;
   res.db_index = db_index_;
   res.key_step = cid_->opt_mask() & CO::INTERLEAVED_KEYS ? 2 : 1;
-  res.args = GetShardArgs(sid);
-  DCHECK(!res.args.empty() || (cid_->opt_mask() & CO::NO_KEY_TRANSACTIONAL));
 
+  if (unique_shard_cnt_ == 1) {
+    res.fps = {kv_fp_.data(), kv_fp_.size()};
+  } else {
+    const auto& sd = shard_data_[sid];
+    res.fps = {kv_fp_.data() + sd.arg_start, sd.arg_count};
+  }
   return res;
 }
 
@@ -1163,7 +1171,7 @@ bool Transaction::CancelShardCb(EngineShard* shard) {
   } else {
     auto lock_args = GetLockArgs(shard->shard_id());
     DCHECK(sd.local_mask & KEYLOCK_ACQUIRED);
-    DCHECK(!lock_args.args.empty());
+    DCHECK(!lock_args.fps.empty());
     shard->db_slice().Release(LockMode(), lock_args);
     sd.local_mask &= ~KEYLOCK_ACQUIRED;
   }
@@ -1300,8 +1308,7 @@ void Transaction::MultiReportJournalOnShard(EngineShard* shard) const {
   }
 }
 
-void Transaction::UnlockMultiShardCb(absl::Span<const std::string_view> sharded_keys,
-                                     EngineShard* shard) {
+void Transaction::UnlockMultiShardCb(absl::Span<const LockFp> fps, EngineShard* shard) {
   DCHECK(multi_ && multi_->lock_mode);
 
   MultiReportJournalOnShard(shard);
@@ -1309,9 +1316,10 @@ void Transaction::UnlockMultiShardCb(absl::Span<const std::string_view> sharded_
   if (multi_->mode == GLOBAL) {
     shard->shard_lock()->Release(IntentLock::EXCLUSIVE);
   } else {
-    for (const auto& key : sharded_keys) {
-      shard->db_slice().ReleaseNormalized(*multi_->lock_mode, db_index_, LockTag{key});
-    }
+    KeyLockArgs lock_args;
+    lock_args.db_index = db_index_;
+    lock_args.fps = fps;
+    shard->db_slice().Release(*multi_->lock_mode, lock_args);
   }
 
   ShardId sid = shard->shard_id();

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -232,7 +232,7 @@ class Transaction {
   void StartMultiGlobal(DbIndex dbid);
 
   // Start multi in LOCK_AHEAD mode with given keys.
-  void StartMultiLockedAhead(DbIndex dbid, CmdArgVec keys, bool skip_scheduling = false);
+  void StartMultiLockedAhead(DbIndex dbid, CmdArgList keys, bool skip_scheduling = false);
 
   // Start multi in NON_ATOMIC mode.
   void StartMultiNonAtomic();
@@ -397,6 +397,8 @@ class Transaction {
 
     uint32_t arg_start = 0;  // Subspan in kv_args_ with local arguments.
     uint32_t arg_count = 0;
+
+    // span into kv_fp_
     uint32_t fp_start = 0;
     uint32_t fp_count = 0;
 
@@ -499,7 +501,7 @@ class Transaction {
   void StoreKeysInArgs(const KeyIndex& key_index);
 
   // Multi transactions unlock asynchronously, so they need to keep fingerprints of keys.
-  void PrepareMultiFps(const CmdArgVec& keys);
+  void PrepareMultiFps(CmdArgList keys);
 
   // Generic schedule used from Schedule() and ScheduleSingleHop() on slow path.
   void ScheduleInternal();

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -397,6 +397,8 @@ class Transaction {
 
     uint32_t arg_start = 0;  // Subspan in kv_args_ with local arguments.
     uint32_t arg_count = 0;
+    uint32_t fp_start = 0;
+    uint32_t fp_count = 0;
 
     // Position in the tx queue. OOO or cancelled schedules remove themselves by this index.
     TxQueue::Iterator pq_pos = TxQueue::kEnd;
@@ -410,7 +412,7 @@ class Transaction {
     } stats;
 
     // Prevent "false sharing" between cache lines: occupy a full cache line (64 bytes)
-    char pad[64 - 5 * sizeof(uint32_t) - sizeof(Stats)];
+    char pad[64 - 7 * sizeof(uint32_t) - sizeof(Stats)];
   };
 
   static_assert(sizeof(PerShardData) == 64);  // cacheline
@@ -596,7 +598,9 @@ class Transaction {
   // We need values as well since we reorder keys, and we need to know what value corresponds
   // to what key.
   absl::InlinedVector<std::string_view, 4> kv_args_;
-  absl::InlinedVector<uint64_t, 4> kv_fp_;
+
+  // Fingerprints of keys, precomputed once during the transaction initialization.
+  absl::InlinedVector<LockFp, 4> kv_fp_;
 
   // Stores the full undivided command.
   CmdArgList full_args_;


### PR DESCRIPTION
1. Introduce LockTag a type representing the part of the key that is used for locking.
2. Hash keys once in each transaction.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->