### PR TITLE
chore: preparation step for lock fingerprints

### DIFF
--- a/src/core/heap_size.h
+++ b/src/core/heap_size.h
@@ -29,8 +29,14 @@ namespace dfly {
 
 namespace heap_size_detail {
 
+template <class, class = void> struct has_marked_stackonly : std::false_type {};
+
+template <class T>
+struct has_marked_stackonly<T, std::void_t<typename T::is_stackonly>> : std::true_type {};
+
 template <typename T> constexpr bool StackOnlyType() {
-  return std::is_trivial_v<T> || std::is_same_v<T, std::string_view>;
+  return std::is_trivial_v<T> || std::is_same_v<T, std::string_view> ||
+         has_marked_stackonly<T>::value;
 }
 
 template <typename T, typename = void> struct has_used_mem : std::false_type {};

--- a/src/server/cluster/cluster_config.cc
+++ b/src/server/cluster/cluster_config.cc
@@ -55,32 +55,8 @@ bool ClusterConfig::IsEmulated() {
   return cluster_mode == ClusterMode::kEmulatedCluster;
 }
 
-string_view ClusterConfig::KeyTag(string_view key) {
-  auto options = KeyLockArgs::GetLockTagOptions();
-
-  if (!absl::StartsWith(key, options.prefix)) {
-    return key;
-  }
-
-  const size_t start = key.find(options.open_locktag);
-  if (start == key.npos) {
-    return key;
-  }
-
-  size_t end = start;
-  for (unsigned i = 0; i <= options.skip_n_end_delimiters; ++i) {
-    size_t next = end + 1;
-    end = key.find(options.close_locktag, next);
-    if (end == key.npos || end == next) {
-      return key;
-    }
-  }
-
-  return key.substr(start + 1, end - start - 1);
-}
-
 SlotId ClusterConfig::KeySlot(string_view key) {
-  string_view tag = KeyTag(key);
+  string_view tag = LockTagOptions::instance().Tag(key);
   return crc16(tag.data(), tag.length()) & kMaxSlotNum;
 }
 

--- a/src/server/cluster/cluster_config.h
+++ b/src/server/cluster/cluster_config.h
@@ -64,11 +64,8 @@ class ClusterConfig {
   }
 
   static bool IsShardedByTag() {
-    return IsEnabledOrEmulated() || KeyLockArgs::GetLockTagOptions().enabled;
+    return IsEnabledOrEmulated() || LockTagOptions::instance().enabled;
   }
-
-  // If the key contains the {...} pattern, return only the part between { and }
-  static std::string_view KeyTag(std::string_view key);
 
   // Returns an instance with `config` if it is valid.
   // Returns heap-allocated object as it is too big for a stack frame.

--- a/src/server/cluster/cluster_config_test.cc
+++ b/src/server/cluster/cluster_config_test.cc
@@ -27,43 +27,47 @@ class ClusterConfigTest : public BaseFamilyTest {
   const string kMyId = "my-id";
 };
 
+inline string_view GetTag(string_view key) {
+  return LockTagOptions::instance().Tag(key);
+}
+
 TEST_F(ClusterConfigTest, KeyTagTest) {
   SetTestFlag("lock_on_hashtags", "true");
 
-  EXPECT_EQ(ClusterConfig::KeyTag("{user1000}.following"), "user1000");
+  EXPECT_EQ(GetTag("{user1000}.following"), "user1000");
 
-  EXPECT_EQ(ClusterConfig::KeyTag("foo{{bar}}zap"), "{bar");
+  EXPECT_EQ(GetTag("foo{{bar}}zap"), "{bar");
 
-  EXPECT_EQ(ClusterConfig::KeyTag("foo{bar}{zap}"), "bar");
+  EXPECT_EQ(GetTag("foo{bar}{zap}"), "bar");
 
   string_view key = " foo{}{bar}";
-  EXPECT_EQ(key, ClusterConfig::KeyTag(key));
+  EXPECT_EQ(key, GetTag(key));
 
   key = "{}foo{bar}{zap}";
-  EXPECT_EQ(key, ClusterConfig::KeyTag(key));
+  EXPECT_EQ(key, GetTag(key));
 
   SetTestFlag("locktag_delimiter", ":");
   TEST_InvalidateLockTagOptions();
 
   key = "{user1000}.following";
-  EXPECT_EQ(ClusterConfig::KeyTag(key), key);
+  EXPECT_EQ(GetTag(key), key);
 
-  EXPECT_EQ(ClusterConfig::KeyTag("bull:queue1:123"), "queue1");
-  EXPECT_EQ(ClusterConfig::KeyTag("bull:queue:1:123"), "queue");
-  EXPECT_EQ(ClusterConfig::KeyTag("bull:queue:1:123:456:789:1000"), "queue");
+  EXPECT_EQ(GetTag("bull:queue1:123"), "queue1");
+  EXPECT_EQ(GetTag("bull:queue:1:123"), "queue");
+  EXPECT_EQ(GetTag("bull:queue:1:123:456:789:1000"), "queue");
 
   key = "bull::queue:1:123";
-  EXPECT_EQ(ClusterConfig::KeyTag(key), key);
+  EXPECT_EQ(GetTag(key), key);
 
   SetTestFlag("locktag_delimiter", ":");
   SetTestFlag("locktag_skip_n_end_delimiters", "0");
   SetTestFlag("locktag_prefix", "bull");
   TEST_InvalidateLockTagOptions();
-  EXPECT_EQ(ClusterConfig::KeyTag("bull:queue:123"), "queue");
-  EXPECT_EQ(ClusterConfig::KeyTag("bull:queue:123:456:789:1000"), "queue");
+  EXPECT_EQ(GetTag("bull:queue:123"), "queue");
+  EXPECT_EQ(GetTag("bull:queue:123:456:789:1000"), "queue");
 
   key = "not-bull:queue1:123";
-  EXPECT_EQ(ClusterConfig::KeyTag(key), key);
+  EXPECT_EQ(GetTag(key), key);
 
   SetTestFlag("locktag_delimiter", ":");
   SetTestFlag("locktag_skip_n_end_delimiters", "1");
@@ -71,19 +75,19 @@ TEST_F(ClusterConfigTest, KeyTagTest) {
   TEST_InvalidateLockTagOptions();
 
   key = "bull:queue1:123";
-  EXPECT_EQ(ClusterConfig::KeyTag(key), key);
-  EXPECT_EQ(ClusterConfig::KeyTag("bull:queue:1:123"), "queue:1");
-  EXPECT_EQ(ClusterConfig::KeyTag("bull:queue:1:123:456:789:1000"), "queue:1");
+  EXPECT_EQ(GetTag(key), key);
+  EXPECT_EQ(GetTag("bull:queue:1:123"), "queue:1");
+  EXPECT_EQ(GetTag("bull:queue:1:123:456:789:1000"), "queue:1");
 
   key = "bull::queue:1:123";
-  EXPECT_EQ(ClusterConfig::KeyTag(key), key);
+  EXPECT_EQ(GetTag(key), key);
 
   SetTestFlag("locktag_delimiter", "|");
   SetTestFlag("locktag_skip_n_end_delimiters", "2");
   SetTestFlag("locktag_prefix", "");
   TEST_InvalidateLockTagOptions();
 
-  EXPECT_EQ(ClusterConfig::KeyTag("|a|b|c|d|e"), "a|b|c");
+  EXPECT_EQ(GetTag("|a|b|c|d|e"), "a|b|c");
 }
 
 TEST_F(ClusterConfigTest, ConfigSetInvalidEmpty) {

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -236,7 +236,7 @@ size_t ConnectionState::ExecInfo::UsedMemory() const {
 }
 
 size_t ConnectionState::ScriptInfo::UsedMemory() const {
-  return dfly::HeapSize(keys) + async_cmds_heap_mem;
+  return dfly::HeapSize(lock_tags) + async_cmds_heap_mem;
 }
 
 size_t ConnectionState::SubscribeInfo::UsedMemory() const {

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -100,7 +100,7 @@ struct ConnectionState {
   struct ScriptInfo {
     size_t UsedMemory() const;
 
-    absl::flat_hash_set<std::string_view> keys;  // declared keys
+    absl::flat_hash_set<LockTag> lock_tags;  // declared tags
 
     size_t async_cmds_heap_mem = 0;     // bytes used by async_cmds
     size_t async_cmds_heap_limit = 0;   // max bytes allowed for async_cmds

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -198,7 +198,7 @@ unsigned PrimeEvictionPolicy::Evict(const PrimeTable::HotspotBuckets& eb, PrimeT
     string scratch;
     string_view key = last_slot_it->first.GetSlice(&scratch);
     // do not evict locked keys
-    if (lt.Find(KeyLockArgs::GetLockKey(key)).has_value())
+    if (lt.Find(LockTag(key)).has_value())
       return 0;
 
     // log the evicted keys to journal.
@@ -998,16 +998,16 @@ bool DbSlice::Acquire(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
   bool lock_acquired = true;
 
   if (lock_args.args.size() == 1) {
-    string_view key = KeyLockArgs::GetLockKey(lock_args.args.front());
-    lock_acquired = lt.Acquire(key, mode);
-    uniq_keys_ = {key};  // needed only for tests.
+    LockTag tag(lock_args.args.front());
+    lock_acquired = lt.Acquire(tag, mode);
+    uniq_keys_ = {string_view(tag)};  // needed only for tests.
   } else {
     uniq_keys_.clear();
 
     for (size_t i = 0; i < lock_args.args.size(); i += lock_args.key_step) {
-      string_view s = KeyLockArgs::GetLockKey(lock_args.args[i]);
-      if (uniq_keys_.insert(s).second) {
-        lock_acquired &= lt.Acquire(s, mode);
+      LockTag tag(lock_args.args[i]);
+      if (uniq_keys_.insert(string_view(tag)).second) {
+        lock_acquired &= lt.Acquire(tag, mode);
       }
     }
   }
@@ -1018,13 +1018,12 @@ bool DbSlice::Acquire(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
   return lock_acquired;
 }
 
-void DbSlice::ReleaseNormalized(IntentLock::Mode mode, DbIndex db_index, std::string_view key) {
-  DCHECK_EQ(key, KeyLockArgs::GetLockKey(key));
+void DbSlice::ReleaseNormalized(IntentLock::Mode mode, DbIndex db_index, LockTag tag) {
   DVLOG(2) << "Release " << IntentLock::ModeName(mode) << " "
-           << " for " << key;
+           << " for " << string_view(tag);
 
   auto& lt = db_arr_[db_index]->trans_locks;
-  lt.Release(KeyLockArgs::GetLockKey(key), mode);
+  lt.Release(tag, mode);
 }
 
 void DbSlice::Release(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
@@ -1034,15 +1033,15 @@ void DbSlice::Release(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
 
   DVLOG(2) << "Release " << IntentLock::ModeName(mode) << " for " << lock_args.args[0];
   if (lock_args.args.size() == 1) {
-    string_view key = KeyLockArgs::GetLockKey(lock_args.args.front());
-    ReleaseNormalized(mode, lock_args.db_index, key);
+    string_view key = lock_args.args.front();
+    ReleaseNormalized(mode, lock_args.db_index, LockTag{key});
   } else {
     auto& lt = db_arr_[lock_args.db_index]->trans_locks;
     uniq_keys_.clear();
     for (size_t i = 0; i < lock_args.args.size(); i += lock_args.key_step) {
-      string_view s = KeyLockArgs::GetLockKey(lock_args.args[i]);
-      if (uniq_keys_.insert(s).second) {
-        lt.Release(s, mode);
+      LockTag tag(lock_args.args[i]);
+      if (uniq_keys_.insert(string_view(tag)).second) {
+        lt.Release(tag, mode);
       }
     }
   }
@@ -1051,9 +1050,9 @@ void DbSlice::Release(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
 
 bool DbSlice::CheckLock(IntentLock::Mode mode, DbIndex dbid, string_view key) const {
   const auto& lt = db_arr_[dbid]->trans_locks;
-  string_view s = KeyLockArgs::GetLockKey(key);
+  LockTag tag(key);
 
-  auto lock = lt.Find(s);
+  auto lock = lt.Find(tag);
   if (lock) {
     return lock->Check(mode);
   }
@@ -1322,7 +1321,7 @@ void DbSlice::FreeMemWithEvictionStep(DbIndex db_ind, size_t increase_goal_bytes
           // check if the key is locked by looking up transaction table.
           const auto& lt = db_table->trans_locks;
           string_view key = evict_it->first.GetSlice(&tmp);
-          if (lt.Find(KeyLockArgs::GetLockKey(key)).has_value())
+          if (lt.Find(LockTag(key)).has_value())
             continue;
 
           if (auto journal = owner_->journal(); journal) {

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -477,8 +477,8 @@ class DbSlice {
   void PerformDeletion(Iterator del_it, DbTable* table);
   void PerformDeletion(PrimeIterator del_it, DbTable* table);
 
-  // Releases a single key. `key` must have been normalized by GetLockKey().
-  void ReleaseNormalized(IntentLock::Mode m, DbIndex db_index, std::string_view key);
+  // Releases a single tag.
+  void ReleaseNormalized(IntentLock::Mode m, DbIndex db_index, LockTag tag);
 
  private:
   void PreUpdate(DbIndex db_ind, Iterator it);

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -171,21 +171,19 @@ class RoundRobinSharder {
   static fb2::Mutex mutex_;
 };
 
-bool HasContendedLocks(unsigned shard_id, Transaction* trx, const DbTable* table) {
-  auto is_contended = [table](string_view key) {
-    return table->trans_locks.Find(key)->IsContended();
-  };
+bool HasContendedLocks(ShardId shard_id, Transaction* trx, const DbTable* table) {
+  auto is_contended = [table](LockTag tag) { return table->trans_locks.Find(tag)->IsContended(); };
 
   if (trx->IsMulti()) {
     auto keys = trx->GetMultiKeys();
     for (string_view key : keys) {
-      if (Shard(key, shard_set->size()) == shard_id && is_contended(key))
+      if (Shard(key, shard_set->size()) == shard_id && is_contended(LockTag{key}))
         return true;
     }
   } else {
     KeyLockArgs lock_args = trx->GetLockArgs(shard_id);
     for (size_t i = 0; i < lock_args.args.size(); i += lock_args.key_step) {
-      if (is_contended(KeyLockArgs::GetLockKey(lock_args.args[i])))
+      if (is_contended(LockTag{lock_args.args[i]}))
         return true;
     }
   }
@@ -857,7 +855,7 @@ void EngineShardSet::TEST_EnableCacheMode() {
 
 ShardId Shard(string_view v, ShardId shard_num) {
   if (ClusterConfig::IsShardedByTag()) {
-    v = ClusterConfig::KeyTag(v);
+    v = LockTagOptions::instance().Tag(v);
   }
 
   XXH64_hash_t hash = XXH64(v.data(), v.size(), 120577240643ULL);

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -677,6 +677,19 @@ fb2::Fiber BaseFamilyTest::ExpectConditionWithSuspension(const std::function<boo
   return fb;
 }
 
+util::fb2::Fiber BaseFamilyTest::ExpectUsedKeys(const std::vector<std::string_view>& keys) {
+  absl::flat_hash_set<string> own_keys;
+  for (const auto& k : keys) {
+    own_keys.insert(string(k));
+  }
+  auto cb = [=] {
+    auto last_keys = GetLastUsedKeys();
+    return last_keys == own_keys;
+  };
+
+  return ExpectConditionWithSuspension(std::move(cb));
+}
+
 void BaseFamilyTest::SetTestFlag(string_view flag_name, string_view new_value) {
   auto* flag = absl::FindCommandLineFlag(flag_name);
   CHECK_NE(flag, nullptr);

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -148,6 +148,7 @@ class BaseFamilyTest : public ::testing::Test {
   static void ExpectConditionWithinTimeout(const std::function<bool()>& condition,
                                            absl::Duration timeout = absl::Seconds(10));
   util::fb2::Fiber ExpectConditionWithSuspension(const std::function<bool()>& condition);
+  util::fb2::Fiber ExpectUsedKeys(const std::vector<std::string_view>& keys);
 
   static unsigned NumLocked();
 


### PR DESCRIPTION
The main change here is introduction of the strong type LockTag that differentiates from a string_view key.

Also, some testing improvements to improve the footprint of the next PR.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->