### PR TITLE
fix: remove acl-check and cancel instead when REPLCONF ACK fails to validate

### DIFF
--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -149,6 +149,9 @@ class DflyCmd {
   // Sets metadata.
   void SetDflyClientVersion(ConnectionContext* cntx, DflyVersion version);
 
+  // Transition into cancelled state, run cleanup.
+  void CancelReplication(uint32_t sync_id, std::shared_ptr<ReplicaInfo> replica_info_ptr);
+
  private:
   // JOURNAL [START/STOP]
   // Start or stop journaling.
@@ -199,9 +202,6 @@ class DflyCmd {
 
   // Main entrypoint for stopping replication.
   void StopReplication(uint32_t sync_id);
-
-  // Transition into cancelled state, run cleanup.
-  void CancelReplication(uint32_t sync_id, std::shared_ptr<ReplicaInfo> replica_info_ptr);
 
   // Get ReplicaInfo by sync_id.
   std::shared_ptr<ReplicaInfo> GetReplicaInfo(uint32_t sync_id);

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1149,7 +1149,9 @@ void Service::DispatchCommand(CmdArgList args, facade::ConnectionContext* cntx) 
     if (cid->name() == "REPLCONF" && absl::EqualsIgnoreCase(ArgS(args_no_cmd, 0), "ACK")) {
       auto info_ptr = server_family_.GetReplicaInfo(dfly_cntx);
       if (info_ptr) {
-        info_ptr->cntx.Cancel();
+        unsigned session_id = dfly_cntx->conn_state.replication_info.repl_session_id;
+        DCHECK(session_id);
+        server_family_.GetDflyCmd()->CancelReplication(session_id, std::move(info_ptr));
       }
       return;
     }

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1147,9 +1147,6 @@ void Service::DispatchCommand(CmdArgList args, facade::ConnectionContext* cntx) 
     // Bonus points because this allows to continue replication with ACL users who got
     // their access revoked and reinstated
     if (cid->name() == "REPLCONF" && absl::EqualsIgnoreCase(ArgS(args_no_cmd, 0), "ACK")) {
-      // TODO remove this comment when we remove the acl-checker
-      // This code will allow us to transition on later versions without
-      // breaking replica/master setup with different versions of dragonfly
       auto info_ptr = server_family_.GetReplicaInfo(dfly_cntx);
       if (info_ptr) {
         info_ptr->cntx.Cancel();

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1147,6 +1147,9 @@ void Service::DispatchCommand(CmdArgList args, facade::ConnectionContext* cntx) 
     // Bonus points because this allows to continue replication with ACL users who got
     // their access revoked and reinstated
     if (cid->name() == "REPLCONF" && absl::EqualsIgnoreCase(ArgS(args_no_cmd, 0), "ACK")) {
+      // TODO remove this comment when we remove the acl-checker
+      // This code will allow us to transition on later versions without
+      // breaking replica/master setup with different versions of dragonfly
       auto info_ptr = server_family_.GetReplicaInfo(dfly_cntx);
       if (info_ptr) {
         info_ptr->cntx.Cancel();

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1147,7 +1147,10 @@ void Service::DispatchCommand(CmdArgList args, facade::ConnectionContext* cntx) 
     // Bonus points because this allows to continue replication with ACL users who got
     // their access revoked and reinstated
     if (cid->name() == "REPLCONF" && absl::EqualsIgnoreCase(ArgS(args_no_cmd, 0), "ACK")) {
-      LOG(ERROR) << "Tried to reply to REPLCONF";
+      auto info_ptr = server_family_.GetReplicaInfo(dfly_cntx);
+      if (info_ptr) {
+        info_ptr->cntx.Cancel();
+      }
       return;
     }
     dfly_cntx->SendError(std::move(*err));

--- a/src/server/protocol_client.h
+++ b/src/server/protocol_client.h
@@ -116,10 +116,6 @@ class ProtocolClient {
     return sock_.get();
   }
 
-  void SetSocketTimeout(uint32_t msec) {
-    sock_->set_timeout(msec);
-  }
-
  private:
   ServerContext server_context_;
 

--- a/src/server/protocol_client.h
+++ b/src/server/protocol_client.h
@@ -116,6 +116,10 @@ class ProtocolClient {
     return sock_.get();
   }
 
+  void SetSocketTimeout(uint32_t msec) {
+    sock_->set_timeout(msec);
+  }
+
  private:
   ServerContext server_context_;
 

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -918,6 +918,7 @@ class AclCheckerClient : public ProtocolClient {
       LOG(INFO) << "Failed to connect with acl client " << ec.message();
       cntx_->Cancel();
     }
+    SetSocketTimeout(4000);
   }
 
   Context* cntx_;

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -78,6 +78,7 @@ Replica::Replica(string host, uint16_t port, Service* se, std::string_view id,
 Replica::~Replica() {
   sync_fb_.JoinIfNeeded();
   acks_fb_.JoinIfNeeded();
+  acl_check_fb_.JoinIfNeeded();
 }
 
 static const char kConnErr[] = "could not connect to master: ";
@@ -657,9 +658,9 @@ error_code Replica::ConsumeDflyStream() {
   if (master_context_.version >= DflyVersion::VER3) {
     acl_check_fb_ = fb2::Fiber("acl-check", &Replica::AclCheckFb, this);
   }
-  acl_check_fb_.JoinIfNeeded();
 
   JoinDflyFlows();
+  acl_check_fb_.JoinIfNeeded();
 
   last_journal_LSNs_.emplace();
   for (auto& flow : shard_flows_) {

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -149,6 +149,7 @@ void Replica::Stop() {
   // so we can freely release resources (connections).
   sync_fb_.JoinIfNeeded();
   acks_fb_.JoinIfNeeded();
+  acl_check_fb_.JoinIfNeeded();
 }
 
 void Replica::Pause(bool pause) {
@@ -623,6 +624,8 @@ error_code Replica::ConsumeRedisStream() {
 error_code Replica::ConsumeDflyStream() {
   // Set new error handler that closes flow sockets.
   auto err_handler = [this](const auto& ge) {
+    // Trigger acl-checker
+    replica_waker_.notifyAll();
     // Make sure the flows are not in a state transition
     lock_guard lk{flows_op_mu_};
     DefaultErrorHandler(ge);
@@ -650,6 +653,11 @@ error_code Replica::ConsumeDflyStream() {
     lock_guard lk{flows_op_mu_};
     shard_set->pool()->AwaitFiberOnAll(std::move(shard_cb));
   }
+
+  if (master_context_.version >= DflyVersion::VER3) {
+    acl_check_fb_ = fb2::Fiber("acl-check", &Replica::AclCheckFb, this);
+  }
+  acl_check_fb_.JoinIfNeeded();
 
   JoinDflyFlows();
 
@@ -881,6 +889,55 @@ void Replica::RedisStreamAcksFb() {
     replica_waker_.await_until(
         [&]() { return repl_offs_ > ack_offs_ + kAckRecordMaxInterval || cntx_.IsCancelled(); },
         next_ack_tp);
+  }
+}
+
+// TODO(kostasrim): Remove this on 20/6/2024
+class AclCheckerClient : public ProtocolClient {
+ public:
+  AclCheckerClient(ServerContext server, Context* cntx)
+      : ProtocolClient(std::move(server)), cntx_(cntx) {
+    Connect();
+  }
+
+  void CheckAclRoundTrip() {
+    if (auto ec = SendCommandAndReadResponse(StrCat("REPLCONF acl-check ", "0")); ec) {
+      cntx_->Cancel();
+      LOG(INFO) << "Error in REPLCONF acl-check: " << ec.message();
+    } else if (!CheckRespIsSimpleReply("OK")) {
+      cntx_->Cancel();
+      LOG(INFO) << "Error: " << ToSV(LastResponseArgs().front().GetBuf());
+    }
+  }
+
+ private:
+  void Connect() {
+    VLOG(1) << "Connecting with acl client";
+    auto ec = ConnectAndAuth(absl::GetFlag(FLAGS_master_connect_timeout_ms) * 1ms, cntx_);
+    if (ec) {
+      LOG(INFO) << "Failed to connect with acl client " << ec.message();
+      cntx_->Cancel();
+    }
+    SetSocketTimeout(4000);
+  }
+
+  Context* cntx_;
+};
+
+void Replica::AclCheckFb() {
+  // We need a new client with a different socket for acl-checks
+  // instead of using the ACK's fiber. This is because acks should
+  // not be replied (which makes them unusable for periodic ACL checks).
+  // Also there are N ACK fibers per replica instance while we only need
+  // one fiber to periodically check for ACL changes. Therefore,
+  // we decouple the logic via AclCheckFb.
+  AclCheckerClient acl_client(server(), &cntx_);
+
+  while (!cntx_.IsCancelled()) {
+    acl_client.CheckAclRoundTrip();
+    // We poll for ACL changes every second
+    replica_waker_.await_until([&]() { return cntx_.IsCancelled(); },
+                               std::chrono::steady_clock::now() + std::chrono::seconds(1));
   }
 }
 

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -78,7 +78,6 @@ Replica::Replica(string host, uint16_t port, Service* se, std::string_view id,
 Replica::~Replica() {
   sync_fb_.JoinIfNeeded();
   acks_fb_.JoinIfNeeded();
-  acl_check_fb_.JoinIfNeeded();
 }
 
 static const char kConnErr[] = "could not connect to master: ";
@@ -150,7 +149,6 @@ void Replica::Stop() {
   // so we can freely release resources (connections).
   sync_fb_.JoinIfNeeded();
   acks_fb_.JoinIfNeeded();
-  acl_check_fb_.JoinIfNeeded();
 }
 
 void Replica::Pause(bool pause) {
@@ -625,8 +623,6 @@ error_code Replica::ConsumeRedisStream() {
 error_code Replica::ConsumeDflyStream() {
   // Set new error handler that closes flow sockets.
   auto err_handler = [this](const auto& ge) {
-    // Trigger acl-checker
-    replica_waker_.notifyAll();
     // Make sure the flows are not in a state transition
     lock_guard lk{flows_op_mu_};
     DefaultErrorHandler(ge);
@@ -655,12 +651,7 @@ error_code Replica::ConsumeDflyStream() {
     shard_set->pool()->AwaitFiberOnAll(std::move(shard_cb));
   }
 
-  if (master_context_.version >= DflyVersion::VER3) {
-    acl_check_fb_ = fb2::Fiber("acl-check", &Replica::AclCheckFb, this);
-  }
-
   JoinDflyFlows();
-  acl_check_fb_.JoinIfNeeded();
 
   last_journal_LSNs_.emplace();
   for (auto& flow : shard_flows_) {
@@ -890,54 +881,6 @@ void Replica::RedisStreamAcksFb() {
     replica_waker_.await_until(
         [&]() { return repl_offs_ > ack_offs_ + kAckRecordMaxInterval || cntx_.IsCancelled(); },
         next_ack_tp);
-  }
-}
-
-class AclCheckerClient : public ProtocolClient {
- public:
-  AclCheckerClient(ServerContext server, Context* cntx)
-      : ProtocolClient(std::move(server)), cntx_(cntx) {
-    Connect();
-  }
-
-  void CheckAclRoundTrip() {
-    if (auto ec = SendCommandAndReadResponse(StrCat("REPLCONF acl-check ", "0")); ec) {
-      cntx_->Cancel();
-      LOG(INFO) << "Error in REPLCONF acl-check: " << ec.message();
-    } else if (!CheckRespIsSimpleReply("OK")) {
-      cntx_->Cancel();
-      LOG(INFO) << "Error: " << ToSV(LastResponseArgs().front().GetBuf());
-    }
-  }
-
- private:
-  void Connect() {
-    VLOG(1) << "Connecting with acl client";
-    auto ec = ConnectAndAuth(absl::GetFlag(FLAGS_master_connect_timeout_ms) * 1ms, cntx_);
-    if (ec) {
-      LOG(INFO) << "Failed to connect with acl client " << ec.message();
-      cntx_->Cancel();
-    }
-    SetSocketTimeout(4000);
-  }
-
-  Context* cntx_;
-};
-
-void Replica::AclCheckFb() {
-  // We need a new client with a different socket for acl-checks
-  // instead of using the ACK's fiber. This is because acks should
-  // not be replied (which makes them unusable for periodic ACL checks).
-  // Also there are N ACK fibers per replica instance while we only need
-  // one fiber to periodically check for ACL changes. Therefore,
-  // we decouple the logic via AclCheckFb.
-  AclCheckerClient acl_client(server(), &cntx_);
-
-  while (!cntx_.IsCancelled()) {
-    acl_client.CheckAclRoundTrip();
-    // We poll for ACL changes every second
-    replica_waker_.await_until([&]() { return cntx_.IsCancelled(); },
-                               std::chrono::steady_clock::now() + std::chrono::seconds(1));
   }
 }
 

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -152,7 +152,6 @@ class Replica : ProtocolClient {
   // In redis replication mode.
   util::fb2::Fiber sync_fb_;
   util::fb2::Fiber acks_fb_;
-  util::fb2::Fiber acl_check_fb_;
   util::fb2::EventCount replica_waker_;
 
   std::vector<std::unique_ptr<DflyShardReplica>> shard_flows_;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2599,6 +2599,7 @@ void ServerFamily::ReplConf(CmdArgList args, ConnectionContext* cntx) {
       cntx->replication_flow->last_acked_lsn = ack;
       return;
     } else if (cmd == "ACL-CHECK") {
+      // TODO(kostasrim): Remove this branch 20/6/2024
       cntx->SendOk();
       return;
     } else {

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2598,9 +2598,6 @@ void ServerFamily::ReplConf(CmdArgList args, ConnectionContext* cntx) {
       VLOG(2) << "Received client ACK=" << ack;
       cntx->replication_flow->last_acked_lsn = ack;
       return;
-    } else if (cmd == "ACL-CHECK") {
-      cntx->SendOk();
-      return;
     } else {
       VLOG(1) << "Error " << cmd << " " << arg << " " << args.size();
       goto err;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2598,6 +2598,9 @@ void ServerFamily::ReplConf(CmdArgList args, ConnectionContext* cntx) {
       VLOG(2) << "Received client ACK=" << ack;
       cntx->replication_flow->last_acked_lsn = ack;
       return;
+    } else if (cmd == "ACL-CHECK") {
+      cntx->SendOk();
+      return;
     } else {
       VLOG(1) << "Error " << cmd << " " << arg << " " << args.size();
       goto err;

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -13,6 +13,7 @@
 #include "facade/reply_builder.h"
 #include "server/channel_store.h"
 #include "server/detail/save_stages_controller.h"
+#include "server/dflycmd.h"
 #include "server/engine_shard_set.h"
 #include "server/replica.h"
 #include "server/server_state.h"
@@ -47,7 +48,6 @@ class Journal;
 class ClusterFamily;
 class ConnectionContext;
 class CommandRegistry;
-class DflyCmd;
 class Service;
 class ScriptMgr;
 
@@ -214,6 +214,10 @@ class ServerFamily {
 
   bool HasReplica() const;
   std::optional<Replica::Info> GetReplicaInfo() const;
+
+  std::shared_ptr<DflyCmd::ReplicaInfo> GetReplicaInfo(ConnectionContext* cntx) const {
+    return dfly_cmd_->GetReplicaInfo(cntx);
+  }
 
   void OnClose(ConnectionContext* cntx);
 


### PR DESCRIPTION
resolves #2907 

* remove acl-checker which is also the source of this bug
* add a fallback that cancels replication when REPLCONF ACK fail