### PR TITLE
fix: Improve reply latency of HELLO

### DIFF
--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -247,7 +247,8 @@ class RedisReplyBuilder : public SinkReplyBuilder {
   };
 
  private:
-  void SendStringArrInternal(WrappedStrSpan arr, CollectionType type);
+  void SendStringArrInternal(size_t size, absl::FunctionRef<std::string_view(unsigned)> producer,
+                             CollectionType type);
 
   bool is_resp3_ = false;
 };

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2327,6 +2327,7 @@ void ServerFamily::Hello(CmdArgList args, ConnectionContext* cntx) {
     rb->SetResp3(false);
   }
 
+  SinkReplyBuilder::ReplyAggregator agg(rb);
   rb->StartCollection(7, RedisReplyBuilder::MAP);
   rb->SendBulkString("server");
   rb->SendBulkString("redis");


### PR DESCRIPTION
For high connection rate cases it can be significant. In addition, refactor reply_builder so we could use SendStringArrInternal for more cases like SendScoredArray that also has high latency overhead for replies.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->