### PR TITLE
fix: socket closed when RegisterOnErrorCb is called in HandleRequests

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -12,7 +12,6 @@
 #include <numeric>
 #include <variant>
 
-#include "absl/cleanup/cleanup.h"
 #include "base/flags.h"
 #include "base/io_buf.h"
 #include "base/logging.h"


### PR DESCRIPTION
Fixes the following crash: https://github.com/dragonflydb/dragonfly/actions/runs/8746231840/job/24002706099#step:6:1987

The problem is that when an instance is shutdown, it iterates over each of the connections on each shard and it shuts down the socket while the main listener dispatches a connection to the next proactor. When this happens, the socket is closed by the time `HandleRequests` is invoked, which triggers the `DCHECK(socket->IsOpen())` while it tries to register the error cb via `RegisterOnErrorCb`. 