### PR TITLE
feat(metrics): adding max_clients to metrics and info output (#2912)

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1057,6 +1057,8 @@ void PrintPrometheusMetrics(const Metrics& m, StringResponse* resp) {
 
   // Clients metrics
   const auto& conn_stats = m.facade_stats.conn_stats;
+  AppendMetricWithoutLabels("max_clients", "Maximal number of clients", GetFlag(FLAGS_maxclients),
+                            MetricType::GAUGE, &resp->body());
   AppendMetricWithoutLabels("connected_clients", "", conn_stats.num_conns, MetricType::GAUGE,
                             &resp->body());
   AppendMetricWithoutLabels("client_read_buffer_bytes", "", conn_stats.read_buf_capacity,
@@ -1939,6 +1941,7 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
 
   if (should_enter("CLIENTS")) {
     append("connected_clients", m.facade_stats.conn_stats.num_conns);
+    append("max_clients", GetFlag(FLAGS_maxclients));
     append("client_read_buffer_bytes", m.facade_stats.conn_stats.read_buf_capacity);
     append("blocked_clients", m.facade_stats.conn_stats.num_blocked_clients);
     append("dispatch_queue_entries", m.facade_stats.conn_stats.dispatch_queue_entries);


### PR DESCRIPTION
As requested in #2912 

Add the metrics in the two places, run manual tests to confirm that custom and default values are reflected. No automatic tests were found for similar functionality so none were added.

Pre-commit hooks passed.

## Testing details

Test command:
> ./dragonfly --admin_nopass --logtostderr --bind localhost --maxclients 54321 --port 5000

Relevant output of `/metrics`:
```
# HELP dragonfly_max_clients Maximal number of clients
# TYPE dragonfly_max_clients gauge
dragonfly_max_clients 54321
```

Relevant output of redis-cli:
```
127.0.0.1:5000> info clients
# Clients
connected_clients:1
max_clients:54321
client_read_buffer_bytes:256
blocked_clients:0
dispatch_queue_entries:0
```

Results of unit test (`python3 -m pytest -xv dragonfly`):
`30 passed, 3 skipped, 1 warning, 1 error`
Error was due to redis version mismatch (redis-server-6.2.11 required, 7.2.4 present)

