### PR TITLE
feat: extended bracket index in jsonpath

### DIFF
--- a/src/core/json/detail/flat_dfs.h
+++ b/src/core/json/detail/flat_dfs.h
@@ -33,10 +33,6 @@ class FlatDfsItem {
   }
 
  private:
-  bool ShouldIterateAll(SegmentType type) const {
-    return type == SegmentType::WILDCARD || type == SegmentType::DESCENT;
-  }
-
   ValueType obj() const {
     return depth_state_.first;
   }
@@ -55,9 +51,7 @@ class FlatDfsItem {
   unsigned segment_step_ = 1;
 
   DepthState depth_state_;
-
-  static constexpr unsigned kInit = -1;
-  unsigned state_ = kInit;
+  std::optional<IndexExpr> state_;
 };
 
 // Traverses a json object according to the given path and calls the callback for each matching

--- a/src/core/json/jsonpath_grammar.y
+++ b/src/core/json/jsonpath_grammar.y
@@ -57,7 +57,7 @@ using namespace std;
 // Needed 0 at the end to satisfy bison 3.5.1
 %token YYEOF 0
 %token <std::string> UNQ_STR "unquoted string"
-%token <unsigned>    UINT "integer"
+%token <int>  INT "integer"
 
 %nterm <std::string> identifier
 %nterm <PathSegment> bracket_index
@@ -84,8 +84,8 @@ relative_path: identifier { driver->AddIdentifier($1); } opt_relative_location
 identifier: UNQ_STR
          // | single_quoted_string | double_quoted_string
 
-bracket_index: WILDCARD { $$ = PathSegment{SegmentType::WILDCARD}; }
-              | UINT { $$ = PathSegment(SegmentType::INDEX, $1); }
+bracket_index: WILDCARD { $$ = PathSegment{SegmentType::INDEX, IndexExpr::All()}; }
+              | INT { $$ = PathSegment(SegmentType::INDEX, IndexExpr($1, $1)); }
 
 function_expr: UNQ_STR { driver->AddFunction($1); } LPARENT ROOT relative_location RPARENT
 %%

--- a/src/core/json/jsonpath_lexer.lex
+++ b/src/core/json/jsonpath_lexer.lex
@@ -50,11 +50,12 @@
 "*"         return Parser::make_WILDCARD(loc());
 "("         return Parser::make_LPARENT(loc());
 ")"         return Parser::make_RPARENT(loc());
-[0-9]{1,9}  {
-              unsigned val;
+-?[0-9]{1,9}  {
+              int val;
               CHECK(absl::SimpleAtoi(str(), &val));
-              return Parser::make_UINT(val, loc());
+              return Parser::make_INT(val, loc());
             }
+
 \w[\w_\-]*  return Parser::make_UNQ_STR(str(), loc());
 <<EOF>>     return Parser::make_YYEOF(loc());
 .           throw Parser::syntax_error(loc(), UnknownTokenMsg());

--- a/src/core/json/path.cc
+++ b/src/core/json/path.cc
@@ -50,6 +50,24 @@ const char* SegmentName(SegmentType type) {
   return nullptr;
 }
 
+IndexExpr IndexExpr::Normalize(size_t array_len) const {
+  if (array_len == 0)
+    return IndexExpr(1, 0);  // empty range.
+
+  IndexExpr res = *this;
+  if (res.second >= int(array_len)) {
+    res.second = array_len - 1;
+  } else if (res.second < 0) {
+    res.second = res.second % array_len;
+    DCHECK_GE(res.second, 0);
+  }
+  if (res.first < 0) {
+    res.first = res.first % array_len;
+    DCHECK_GE(res.first, 0);
+  }
+  return res;
+}
+
 void PathSegment::Evaluate(const JsonType& json) const {
   CHECK(type() == SegmentType::FUNCTION);
   AggFunction* func = std::get<shared_ptr<AggFunction>>(value_).get();


### PR DESCRIPTION
Before this change, we only allowed a single non-negative index or a wildcard inside brackets []. For example, "$.foo[1]".
This PR extends the indexing expression to negative indices. It also builds up the foundation to support [begin:end] slices, though this has not been implemented in this PR.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->