### PR TITLE
fix(pytests): replace proc.wait() with proc.communicate() to avoid deadlocks

### DIFF
--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -169,8 +169,7 @@ class DflyInstance:
                 proc.kill()
             else:
                 proc.terminate()
-            if proc.wait(timeout=15) < 0 and not kill:
-                raise Exception("Dragfonfly did not terminate gracefully")
+                proc.communicate(timeout=15)
 
         except subprocess.TimeoutExpired:
             # We need to send SIGUSR1 to DF such that it prints the stacktrace


### PR DESCRIPTION
The problem is `proc.wait()` can deadlock according to https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait

I quote:

>>Note This will deadlock when using stdout=PIPE or stderr=PIPE and the child process generates enough output to a pipe such that it blocks waiting for the OS pipe buffer to accept more data. Use [Popen.communicate()](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.communicate) when using pipes to avoid that.

Which we do: 
```
205         self.proc = subprocess.Popen(
206             run_cmd, cwd=self.params.cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
207         )
```
