### PR TITLE
fix: crash during migration when connection is closing

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1456,6 +1456,10 @@ bool Connection::Migrate(util::fb2::ProactorBase* dest) {
     return false;
   }
 
+  if (cc_->conn_closing) {
+    return false;
+  }
+
   listener()->Migrate(this, dest);
   // After we migrate, it could be the case the connection was shut down. We should
   // act accordingly.

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1452,11 +1452,7 @@ bool Connection::Migrate(util::fb2::ProactorBase* dest) {
   CHECK(!cc_->async_dispatch);
   CHECK_EQ(cc_->subscriptions, 0);  // are bound to thread local caches
   CHECK_EQ(self_.use_count(), 1u);  // references cache our thread and backpressure
-  if (dispatch_fb_.IsJoinable()) {  // can't move once it started
-    return false;
-  }
-
-  if (cc_->conn_closing) {
+  if (dispatch_fb_.IsJoinable() || cc_->conn_closing) {  // can't move once it started
     return false;
   }
 


### PR DESCRIPTION
resolves #2905 

The problem is that DF might be shutting down (which sets the connection_closing to true) and a call to `Migrate` will trigger the check that the connection is not closing. The fix is simple: just return false when Migrate is called and the connection is closing.

* Return false when Migrate is called on a closing connection