### PR TITLE
fix: check return code of process after communicate

### DIFF
--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -170,6 +170,11 @@ class DflyInstance:
             else:
                 proc.terminate()
                 proc.communicate(timeout=15)
+                # if the return code is 0 it means normal termination
+                # if the return code is negative it means termination by signal
+                # if the return code is positive it means abnormal exit
+                if proc.returncode > 0:
+                    raise subprocess.TimeoutExpired
 
         except subprocess.TimeoutExpired:
             # We need to send SIGUSR1 to DF such that it prints the stacktrace

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -173,8 +173,8 @@ class DflyInstance:
                 # if the return code is 0 it means normal termination
                 # if the return code is negative it means termination by signal
                 # if the return code is positive it means abnormal exit
-                if proc.returncode > 0:
-                    raise subprocess.TimeoutExpired
+                if proc.returncode != 0:
+                    raise Exception("Dragfonfly did not terminate gracefully")
 
         except subprocess.TimeoutExpired:
             # We need to send SIGUSR1 to DF such that it prints the stacktrace


### PR DESCRIPTION
Fixes: https://github.com/dragonflydb/dragonfly/pull/2964#discussion_r1584260766

* check return code of process after terminate 