### PR TITLE
fix: allow non hashed passwords when loading users from acl file

### DIFF
--- a/src/server/acl/helpers.cc
+++ b/src/server/acl/helpers.cc
@@ -116,12 +116,11 @@ std::optional<std::string> MaybeParsePassword(std::string_view command, bool has
     return std::string(command);
   }
 
-  char symbol = hashed ? '#' : '>';
-  if (command[0] != symbol) {
-    return {};
+  if (command[0] == '>' || (hashed && command[0] == '#')) {
+    return std::string(command.substr(1));
   }
 
-  return std::string(command.substr(1));
+  return {};
 }
 
 std::optional<bool> MaybeParseStatus(std::string_view command) {
@@ -231,7 +230,9 @@ std::variant<User::UpdateRequest, ErrorReply> ParseAclSetUser(T args,
         return ErrorReply("Only one password is allowed");
       }
       req.password = std::move(pass);
-      req.is_hashed = hashed;
+      if (hashed && absl::StartsWith(facade::ToSV(arg), "#")) {
+        req.is_hashed = hashed;
+      }
       continue;
     }
 

--- a/src/server/acl/helpers.h
+++ b/src/server/acl/helpers.h
@@ -23,6 +23,7 @@ std::string AclCommandToString(const std::vector<uint64_t>& acl_category);
 
 std::string PrettyPrintSha(std::string_view pass, bool all = false);
 
+// When hashed is true, we allow passwords that start with both # and >
 std::optional<std::string> MaybeParsePassword(std::string_view command, bool hashed = false);
 
 std::optional<bool> MaybeParseStatus(std::string_view command);


### PR DESCRIPTION
resolves #2980

* allow non hashed passwords when loading from acl file