### PR TITLE
chore: update our container distributions versions

### DIFF
--- a/tools/packaging/Dockerfile.ubuntu-dev
+++ b/tools/packaging/Dockerfile.ubuntu-dev
@@ -3,7 +3,10 @@ FROM ghcr.io/romange/ubuntu-dev:20 as builder
 
 WORKDIR /build
 
-COPY . ./
+COPY ./Makefile ./CMakeLists.txt ./
+COPY src ./src
+COPY cmake ./cmake
+COPY helio ./helio
 
 RUN make release
 
@@ -12,7 +15,7 @@ RUN build-release/dragonfly --version
 RUN curl -O https://raw.githubusercontent.com/ncopa/su-exec/212b75144bbc06722fbd7661f651390dc47a43d1/su-exec.c && \
     gcc -Wall -O2 su-exec.c -o su-exec
 
-FROM ubuntu:20.04
+FROM debian:12-slim
 
 RUN --mount=type=tmpfs,target=/var/cache/apt \
     --mount=type=tmpfs,target=/var/lib/apt/lists \

--- a/tools/packaging/Dockerfile.ubuntu-prod
+++ b/tools/packaging/Dockerfile.ubuntu-prod
@@ -15,7 +15,7 @@ RUN curl -O https://raw.githubusercontent.com/ncopa/su-exec/212b75144bbc06722fbd
 RUN /tmp/fetch_release.sh ${TARGETPLATFORM}
 
 # Now prod image
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # ARG in fact change the env vars during the build process
 # ENV persist the env vars for the built image as well.


### PR DESCRIPTION
1. Restrict build context in our dev/weekly builder to ease development iterations.
2. Switch weekly build to debian 12-slim because it's smaller than 24.04
3. Update our prod releases to use ubuntu 22.04

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->