### PR TITLE
fix(memcached): Register memcached listener to handle `--maxclients`

### DIFF
--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -87,7 +87,8 @@ void AclFamily::StreamUpdatesToAllProactorConnections(const std::string& user, u
   auto update_cb = [&]([[maybe_unused]] size_t id, util::Connection* conn) {
     DCHECK(conn);
     auto connection = static_cast<facade::Connection*>(conn);
-    if (!connection->IsHttp() && connection->cntx()) {
+    if (connection->protocol() == facade::Protocol::REDIS && !connection->IsHttp() &&
+        connection->cntx()) {
       connection->SendAclUpdateAsync(
           facade::Connection::AclUpdateMessage{user, update_cat, update_commands, update_keys});
     }

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -288,7 +288,8 @@ bool RunEngine(ProactorPool* pool, AcceptServer* acceptor) {
 
   if (mc_port > 0 && !tcp_disabled) {
     auto listener = MakeListener(Protocol::MEMCACHE, &service);
-    acceptor->AddListener(mc_port, listener.release());
+    acceptor->AddListener(mc_port, listener.get());
+    listeners.push_back(listener.release());
   }
 
   service.Init(acceptor, listeners, opts);


### PR DESCRIPTION
We add other listeners to `listeners`, but we seem to have forgotten to do that to the memcached listener.

Fixes #2986

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->