### PR TITLE
fix(server): small string allocations only under 256 bytes str

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -790,8 +790,8 @@ void CompactObj::SetString(std::string_view str) {
     }
   }
 
-  if (kUseSmallStrings && SmallString::CanAllocate()) {
-    if ((taglen_ == 0 && encoded.size() < SmallString::kMaxSize)) {
+  if (kUseSmallStrings && SmallString::CanAllocate(encoded.size())) {
+    if (taglen_ == 0) {
       SetMeta(SMALL_TAG, mask);
       tl.small_str_bytes += u_.small_str.Assign(encoded);
       return;

--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -790,8 +790,8 @@ void CompactObj::SetString(std::string_view str) {
     }
   }
 
-  if (kUseSmallStrings) {
-    if ((taglen_ == 0 && encoded.size() < (1 << 13))) {
+  if (kUseSmallStrings && SmallString::CanAllocate()) {
+    if ((taglen_ == 0 && encoded.size() < SmallString::kMaxSize)) {
       SetMeta(SMALL_TAG, mask);
       tl.small_str_bytes += u_.small_str.Assign(encoded);
       return;

--- a/src/core/segment_allocator.cc
+++ b/src/core/segment_allocator.cc
@@ -25,4 +25,8 @@ void SegmentAllocator::ValidateMapSize() {
   }
 }
 
+bool SegmentAllocator::CanAllocate() {
+  return address_table_.size() < (1u << kSegmentIdBits);
+}
+
 }  // namespace dfly

--- a/src/core/segment_allocator.h
+++ b/src/core/segment_allocator.h
@@ -30,6 +30,7 @@ class SegmentAllocator {
   using Ptr = uint32_t;
 
   SegmentAllocator(mi_heap_t* heap);
+  bool CanAllocate();
 
   uint8_t* Translate(Ptr p) const {
     return address_table_[p & kSegmentIdMask] + Offset(p);

--- a/src/core/small_string.cc
+++ b/src/core/small_string.cc
@@ -45,8 +45,8 @@ void SmallString::InitThreadLocal(void* heap) {
   XXH3_64bits_reset_withSeed(tl.xxh_state.get(), kHashSeed);
 }
 
-bool SmallString::CanAllocate() {
-  return tl.seg_alloc->CanAllocate();
+bool SmallString::CanAllocate(size_t size) {
+  return size <= kMaxSize && tl.seg_alloc->CanAllocate();
 }
 
 size_t SmallString::UsedThreadLocal() {

--- a/src/core/small_string.cc
+++ b/src/core/small_string.cc
@@ -45,6 +45,10 @@ void SmallString::InitThreadLocal(void* heap) {
   XXH3_64bits_reset_withSeed(tl.xxh_state.get(), kHashSeed);
 }
 
+bool SmallString::CanAllocate() {
+  return tl.seg_alloc->CanAllocate();
+}
+
 size_t SmallString::UsedThreadLocal() {
   return tl.seg_alloc ? tl.seg_alloc->used() : 0;
 }

--- a/src/core/small_string.h
+++ b/src/core/small_string.h
@@ -10,16 +10,18 @@
 
 namespace dfly {
 
-// blob strings of upto ~64KB. Small sizes are probably predominant
+// blob strings of upto ~256B. Small sizes are probably predominant
 // for in-memory workloads, especially for keys.
 // Please note that this class does not have automatic constructors and destructors, therefore
 // it requires explicit management.
 class SmallString {
-  static constexpr unsigned kPrefLen = 10;
+  static constexpr unsigned kPrefLen = 11;
 
  public:
+  static constexpr unsigned kMaxSize = (1 << 8) - 1;
   static void InitThreadLocal(void* heap);
   static size_t UsedThreadLocal();
+  static bool CanAllocate();
 
   void Reset() {
     size_ = 0;
@@ -55,7 +57,7 @@ class SmallString {
   char prefix_[kPrefLen];
 
   uint32_t small_ptr_;  // 32GB capacity because we ignore 3 lsb bits (i.e. x8).
-  uint16_t size_;       // uint16_t - total size (including prefix)
+  uint8_t size_;        // uint8_t - total size (including prefix)
 
 } __attribute__((packed));
 

--- a/src/core/small_string.h
+++ b/src/core/small_string.h
@@ -15,13 +15,13 @@ namespace dfly {
 // Please note that this class does not have automatic constructors and destructors, therefore
 // it requires explicit management.
 class SmallString {
-  static constexpr unsigned kPrefLen = 11;
+  static constexpr unsigned kPrefLen = 10;
+  static constexpr unsigned kMaxSize = (1 << 8) - 1;
 
  public:
-  static constexpr unsigned kMaxSize = (1 << 8) - 1;
   static void InitThreadLocal(void* heap);
   static size_t UsedThreadLocal();
-  static bool CanAllocate();
+  static bool CanAllocate(size_t size);
 
   void Reset() {
     size_ = 0;
@@ -57,7 +57,7 @@ class SmallString {
   char prefix_[kPrefLen];
 
   uint32_t small_ptr_;  // 32GB capacity because we ignore 3 lsb bits (i.e. x8).
-  uint8_t size_;        // uint8_t - total size (including prefix)
+  uint16_t size_;       // uint16_t - total size (including prefix)
 
 } __attribute__((packed));
 


### PR DESCRIPTION
When allocating small string if SegmentAllocator::address_table_ is bigger than 2^12 we will get wrong pointer when translating the address SegmentAllocator::Translate
This led to crash in dragonfly in DbSlice::AddExpire
CHECK(db_arr_[db_ind]->expire.Insert(main_it->first.AsRef(), ExpirePeriod(delta)).second);
As the key was not in the dash table but because the key string that was fetched from main_it->first.AsRef() was not the correct key that was in the insert flow as the address table was too big