### PR TITLE
chore: another preparation commit to get rid of kv_args in transaction

### DIFF
--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -48,7 +48,7 @@ namespace {
 using namespace std;
 using namespace facade;
 using namespace util;
-
+using Payload = journal::Entry::Payload;
 using CI = CommandId;
 
 constexpr char kIdNotFound[] = "syncid not found";
@@ -485,7 +485,7 @@ void WriteFlushSlotsToJournal(const SlotRanges& slot_ranges) {
     // TODO: Break slot migration upon FLUSHSLOTS
     journal->RecordEntry(/* txid= */ 0, journal::Op::COMMAND, /* dbid= */ 0,
                          /* shard_cnt= */ shard_set->size(), nullopt,
-                         make_pair("DFLYCLUSTER", args_view), false);
+                         Payload("DFLYCLUSTER", args_view), false);
   };
   shard_set->pool()->AwaitFiberOnAll(std::move(cb));
 }

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -39,6 +39,7 @@ using namespace std;
 using namespace util;
 using absl::GetFlag;
 using facade::OpStatus;
+using Payload = journal::Entry::Payload;
 
 namespace {
 
@@ -205,7 +206,7 @@ unsigned PrimeEvictionPolicy::Evict(const PrimeTable::HotspotBuckets& eb, PrimeT
     if (auto journal = db_slice_->shard_owner()->journal(); journal) {
       ArgSlice delete_args(&key, 1);
       journal->RecordEntry(0, journal::Op::EXPIRED, cntx_.db_index, 1, cluster::KeySlot(key),
-                           make_pair("DEL", delete_args), false);
+                           Payload("DEL", delete_args), false);
     }
 
     db_slice_->PerformDeletion(DbSlice::Iterator(last_slot_it, StringOrView::FromView(key)), table);
@@ -1230,7 +1231,7 @@ finish:
     for (string_view key : keys_to_journal) {
       ArgSlice delete_args(&key, 1);
       journal->RecordEntry(0, journal::Op::EXPIRED, db_ind, 1, cluster::KeySlot(key),
-                           make_pair("DEL", delete_args), false);
+                           Payload("DEL", delete_args), false);
     }
   }
 

--- a/src/server/journal/serializer.h
+++ b/src/server/journal/serializer.h
@@ -26,11 +26,11 @@ class JournalWriter {
 
  private:
   void Write(std::string_view sv);  // Write string.
+  void Write(facade::MutableSlice slice) {
+    Write(facade::ToSV(slice));
+  }
 
-  template <typename C>  // CmdArgList or ArgSlice.
-  void Write(std::pair<std::string_view, C> args);
-
-  void Write(std::monostate);  // Overload for empty std::variant
+  void Write(const journal::Entry::Payload& payload);
 
  private:
   io::Sink* sink_;

--- a/src/server/journal/streamer.cc
+++ b/src/server/journal/streamer.cc
@@ -201,7 +201,7 @@ void RestoreStreamer::WriteEntry(string_view key, const PrimeValue& pv, uint64_t
 
   args.push_back("ABSTTL");  // Means expire string is since epoch
 
-  WriteCommand(make_pair("RESTORE", ArgSlice{args}));
+  WriteCommand(journal::Entry::Payload("RESTORE", ArgSlice(args)));
 }
 
 void RestoreStreamer::WriteCommand(journal::Entry::Payload cmd_payload) {

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -19,7 +19,6 @@
 #include "core/flatbuffers.h"
 #include "core/json/json_object.h"
 #include "core/json/path.h"
-#include "core/overloaded.h"
 #include "facade/cmd_arg_parser.h"
 #include "facade/op_status.h"
 #include "server/acl/acl_commands_def.h"

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1422,9 +1422,9 @@ void Transaction::LogAutoJournalOnShard(EngineShard* shard, RunnableResult resul
 
   string_view cmd{cid_->name()};
   if (unique_shard_cnt_ == 1 || kv_args_.empty()) {
-    entry_payload = make_pair(cmd, full_args_);
+    entry_payload = journal::Entry::Payload(cmd, full_args_);
   } else {
-    entry_payload = make_pair(cmd, GetShardArgs(shard->shard_id()).AsSlice());
+    entry_payload = journal::Entry::Payload(cmd, GetShardArgs(shard->shard_id()).AsSlice());
   }
   LogJournalOnShard(shard, std::move(entry_payload), unique_shard_cnt_, false, true);
 }

--- a/src/server/tx_base.cc
+++ b/src/server/tx_base.cc
@@ -13,11 +13,12 @@
 namespace dfly {
 
 using namespace std;
+using Payload = journal::Entry::Payload;
 
 void RecordJournal(const OpArgs& op_args, string_view cmd, ArgSlice args, uint32_t shard_cnt,
                    bool multi_commands) {
   VLOG(2) << "Logging command " << cmd << " from txn " << op_args.tx->txid();
-  op_args.tx->LogJournalOnShard(op_args.shard, make_pair(cmd, args), shard_cnt, multi_commands,
+  op_args.tx->LogJournalOnShard(op_args.shard, Payload(cmd, args), shard_cnt, multi_commands,
                                 false);
 }
 
@@ -29,7 +30,7 @@ void RecordExpiry(DbIndex dbid, string_view key) {
   auto journal = EngineShard::tlocal()->journal();
   CHECK(journal);
   journal->RecordEntry(0, journal::Op::EXPIRED, dbid, 1, cluster::KeySlot(key),
-                       make_pair("DEL", ArgSlice{key}), false);
+                       Payload("DEL", ArgSlice{key}), false);
 }
 
 void TriggerJournalWriteToSink() {

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1033,7 +1033,9 @@ async def assert_lag_condition(inst, client, condition):
 
 @dfly_args({"proactor_threads": 2})
 @pytest.mark.asyncio
-async def test_replication_info(df_local_factory, df_seeder_factory, n_keys=2000):
+async def test_replication_info(
+    df_local_factory: DflyInstanceFactory, df_seeder_factory, n_keys=2000
+):
     master = df_local_factory.create()
     replica = df_local_factory.create(logtostdout=True, replication_acks_interval=100)
     df_local_factory.start_all([master, replica])


### PR DESCRIPTION
This PR changes `Entry::Payload` to struct instead of variant.
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->