### PR TITLE
fix(server): non auto journal write after callback finish

### DIFF
--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1414,8 +1414,10 @@ void Transaction::LogAutoJournalOnShard(EngineShard* shard, RunnableResult resul
   }
 
   // If autojournaling was disabled and not re-enabled, skip it
-  if ((cid_->opt_mask() & CO::NO_AUTOJOURNAL) && !re_enabled_auto_journal_)
+  if ((cid_->opt_mask() & CO::NO_AUTOJOURNAL) && !re_enabled_auto_journal_) {
+    TriggerJournalWriteToSink();
     return;
+  }
 
   // TODO: Handle complex commands like LMPOP correctly once they are implemented.
   journal::Entry::Payload entry_payload;


### PR DESCRIPTION
fixes #3015 
This PR does not allow preempting in the callback but it fixes the problem with back-pressure and memory usage for non auto journal commands that described in the issue.