### PR TITLE
chore(dash): Replace comparator with predicate

### DIFF
--- a/src/core/dash.h
+++ b/src/core/dash.h
@@ -149,6 +149,8 @@ class DashTable : public detail::DashTableBase {
   template <typename U> const_iterator Find(U&& key) const;
   template <typename U> iterator Find(U&& key);
 
+  template <typename Pred> iterator FindFirst(uint64_t key_hash, Pred&& pred);
+
   // it must be valid.
   void Erase(iterator it);
 
@@ -308,8 +310,8 @@ class DashTable : public detail::DashTableBase {
   // the same object. IterateDistinct goes over all distinct segments in the table.
   template <typename Cb> void IterateDistinct(Cb&& cb);
 
-  auto EqPred() const {
-    return [p = &policy_](const auto& a, const auto& b) -> bool { return p->Equal(a, b); };
+  template <typename K> auto EqPred(const K& key) const {
+    return [p = &policy_, &key](const auto& probe) -> bool { return p->Equal(probe, key); };
   }
 
   Policy policy_;
@@ -668,33 +670,32 @@ template <typename _Key, typename _Value, typename Policy>
 template <typename U>
 auto DashTable<_Key, _Value, Policy>::Find(U&& key) const -> const_iterator {
   uint64_t key_hash = DoHash(key);
-  uint32_t seg_id = SegmentId(key_hash);  // seg_id takes up global_depth_ high bits.
-  const auto* target = segment_[seg_id];
+  uint32_t seg_id = SegmentId(key_hash);
 
   // Hash structure is like this: [SSUUUUBF], where S is segment id, U - unused,
   // B - bucket id and F is a fingerprint. Segment id is needed to identify the correct segment.
   // Once identified, the segment instance uses the lower part of hash to locate the key.
   // It uses 8 least significant bits for a fingerprint and few more bits for bucket id.
-  auto seg_it = target->FindIt(key, key_hash, EqPred());
-
-  if (seg_it.found()) {
-    return const_iterator{this, seg_id, seg_it.index, seg_it.slot};
+  if (auto seg_it = segment_[seg_id]->FindIt(key_hash, EqPred(key)); seg_it.found()) {
+    return {this, seg_id, seg_it.index, seg_it.slot};
   }
-  return const_iterator{};
+  return {};
 }
 
 template <typename _Key, typename _Value, typename Policy>
 template <typename U>
 auto DashTable<_Key, _Value, Policy>::Find(U&& key) -> iterator {
-  uint64_t key_hash = DoHash(key);
-  uint32_t segid = SegmentId(key_hash);
-  const auto* target = segment_[segid];
+  return FindFirst(DoHash(key), EqPred(key));
+}
 
-  auto seg_it = target->FindIt(key, key_hash, EqPred());
-  if (seg_it.found()) {
-    return iterator{this, segid, seg_it.index, seg_it.slot};
+template <typename _Key, typename _Value, typename Policy>
+template <typename Pred>
+auto DashTable<_Key, _Value, Policy>::FindFirst(uint64_t key_hash, Pred&& pred) -> iterator {
+  uint32_t seg_id = SegmentId(key_hash);
+  if (auto seg_it = segment_[seg_id]->FindIt(key_hash, pred); seg_it.found()) {
+    return iterator{this, seg_id, seg_it.index, seg_it.slot};
   }
-  return iterator{};
+  return {};
 }
 
 template <typename _Key, typename _Value, typename Policy>
@@ -702,7 +703,7 @@ size_t DashTable<_Key, _Value, Policy>::Erase(const Key_t& key) {
   uint64_t key_hash = DoHash(key);
   size_t x = SegmentId(key_hash);
   auto* target = segment_[x];
-  auto it = target->FindIt(key, key_hash, EqPred());
+  auto it = target->FindIt(key_hash, EqPred(key));
   if (!it.found())
     return 0;
 
@@ -764,7 +765,7 @@ auto DashTable<_Key, _Value, Policy>::InsertInternal(U&& key, V&& value, Evictio
       res = it.found();
     } else {
       std::tie(it, res) =
-          target->Insert(std::forward<U>(key), std::forward<V>(value), key_hash, EqPred());
+          target->Insert(std::forward<U>(key), std::forward<V>(value), key_hash, EqPred(key));
     }
 
     if (res) {  // success

--- a/src/core/dash_internal.h
+++ b/src/core/dash_internal.h
@@ -11,7 +11,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
-#include <functional>
+#include <type_traits>
 
 #include "core/sse_port.h"
 
@@ -328,8 +328,7 @@ template <typename _Key, typename _Value, typename Policy = DefaultSegmentPolicy
       this->SetHash(slot, meta_hash, probe);
     }
 
-    template <typename U, typename Pred>
-    SlotId FindByFp(uint8_t fp_hash, bool probe, U&& k, Pred&& pred) const;
+    template <typename Pred> SlotId FindByFp(uint8_t fp_hash, bool probe, Pred&& pred) const;
 
     bool ShiftRight();
 
@@ -403,7 +402,7 @@ template <typename _Key, typename _Value, typename Policy = DefaultSegmentPolicy
   // Returns (iterator, true) if insert succeeds,
   // (iterator, false) for duplicate and (invalid-iterator, false) if it's full
   template <typename K, typename V, typename Pred>
-  std::pair<Iterator, bool> Insert(K&& key, V&& value, Hash_t key_hash, Pred&& cmp_fun);
+  std::pair<Iterator, bool> Insert(K&& key, V&& value, Hash_t key_hash, Pred&& pred);
 
   template <typename HashFn> void Split(HashFn&& hfunc, Segment* dest);
 
@@ -501,7 +500,8 @@ template <typename _Key, typename _Value, typename Policy = DefaultSegmentPolicy
     dest[3] = NextBid(dest[2]);
   }
 
-  template <typename U, typename Pred> Iterator FindIt(U&& key, Hash_t key_hash, Pred&& cf) const;
+  // Find item with given key hash and truthy predicate
+  template <typename Pred> Iterator FindIt(Hash_t key_hash, Pred&& pred) const;
 
   // Returns valid iterator if succeeded or invalid if not (it's full).
   // Requires: key should be not present in the segment.
@@ -1021,9 +1021,9 @@ ___] |___ |__] |  | |___ | \|  |
 */
 
 template <typename Key, typename Value, typename Policy>
-template <typename U, typename Pred>
-auto Segment<Key, Value, Policy>::Bucket::FindByFp(uint8_t fp_hash, bool probe, U&& k,
-                                                   Pred&& pred) const -> SlotId {
+template <typename Pred>
+auto Segment<Key, Value, Policy>::Bucket::FindByFp(uint8_t fp_hash, bool probe, Pred&& pred) const
+    -> SlotId {
   unsigned mask = this->Find(fp_hash, probe);
   if (!mask)
     return kNanSlot;
@@ -1031,9 +1031,18 @@ auto Segment<Key, Value, Policy>::Bucket::FindByFp(uint8_t fp_hash, bool probe, 
   unsigned delta = __builtin_ctz(mask);
   mask >>= delta;
   for (unsigned i = delta; i < kSlotNum; ++i) {
-    if ((mask & 1) && pred(key[i], k)) {
-      return i;
+    // Filterable just by key
+    if constexpr (std::is_invocable_v<Pred, const Key_t&>) {
+      if ((mask & 1) && pred(key[i]))
+        return i;
     }
+
+    // Filterable by key and value
+    if constexpr (std::is_invocable_v<Pred, const Key_t&, const Value_t&>) {
+      if ((mask & 1) && pred(key[i], value[i]))
+        return i;
+    }
+
     mask >>= 1;
   };
 
@@ -1094,9 +1103,9 @@ auto Segment<Key, Value, Policy>::TryMoveFromStash(unsigned stash_id, unsigned s
 
 template <typename Key, typename Value, typename Policy>
 template <typename U, typename V, typename Pred>
-auto Segment<Key, Value, Policy>::Insert(U&& key, V&& value, Hash_t key_hash, Pred&& cmp_fun)
+auto Segment<Key, Value, Policy>::Insert(U&& key, V&& value, Hash_t key_hash, Pred&& pred)
     -> std::pair<Iterator, bool> {
-  Iterator it = FindIt(key, key_hash, std::forward<Pred>(cmp_fun));
+  Iterator it = FindIt(key_hash, pred);
   if (it.found()) {
     return std::make_pair(it, false); /* duplicate insert*/
   }
@@ -1107,8 +1116,8 @@ auto Segment<Key, Value, Policy>::Insert(U&& key, V&& value, Hash_t key_hash, Pr
 }
 
 template <typename Key, typename Value, typename Policy>
-template <typename U, typename Pred>
-auto Segment<Key, Value, Policy>::FindIt(U&& key, Hash_t key_hash, Pred&& cf) const -> Iterator {
+template <typename Pred>
+auto Segment<Key, Value, Policy>::FindIt(Hash_t key_hash, Pred&& pred) const -> Iterator {
   uint8_t bidx = BucketIndex(key_hash);
   const Bucket& target = bucket_[bidx];
 
@@ -1117,7 +1126,7 @@ auto Segment<Key, Value, Policy>::FindIt(U&& key, Hash_t key_hash, Pred&& cf) co
   __builtin_prefetch(&target);
 
   uint8_t fp_hash = key_hash & kFpMask;
-  SlotId sid = target.FindByFp(fp_hash, false, key, cf);
+  SlotId sid = target.FindByFp(fp_hash, false, pred);
   if (sid != BucketType::kNanSlot) {
     return Iterator{bidx, sid};
   }
@@ -1125,7 +1134,7 @@ auto Segment<Key, Value, Policy>::FindIt(U&& key, Hash_t key_hash, Pred&& cf) co
   uint8_t nid = NextBid(bidx);
   const Bucket& probe = bucket_[nid];
 
-  sid = probe.FindByFp(fp_hash, true, key, cf);
+  sid = probe.FindByFp(fp_hash, true, pred);
 
 #ifdef ENABLE_DASH_STATS
   stats.neighbour_probes++;
@@ -1144,7 +1153,7 @@ auto Segment<Key, Value, Policy>::FindIt(U&& key, Hash_t key_hash, Pred&& cf) co
 
     pos += kBucketNum;
     const Bucket& bucket = bucket_[pos];
-    return bucket.FindByFp(fp_hash, false, key, cf);
+    return bucket.FindByFp(fp_hash, false, pred);
   };
 
   if (target.HasStashOverflow()) {


### PR DESCRIPTION
Goal: Introduce FindFirst(hash, predicate) so we can find an entry without a key - just by hash and predicate

Currently we always invoke the comparator with the same key we passed down, so it can be replaced by a predicate... Which also solves our first problem

Will be used in #3021 