### PR TITLE
fix: reduce delay when stop replica #3020

### DIFF
--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -201,6 +201,10 @@ class RdbLoader : protected RdbLoaderBase {
     return load_time_;
   }
 
+  void stop() {
+    stop_early_.store(true);
+  }
+
   // Return the offset that was received with a RDB_OPCODE_JOURNAL_OFFSET command,
   // or 0 if no offset was received.
   std::optional<uint64_t> journal_offset() const {

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -141,8 +141,8 @@ void Replica::Stop() {
   // Stops the loop in MainReplicationFb.
 
   proactor_->Await([this] {
-    cntx_.Cancel();        // Context is fully resposible for cleanup.
     state_mask_.store(0);  // Specifically ~R_ENABLED.
+    cntx_.Cancel();        // Context is fully resposible for cleanup.
   });
 
   CloseSocket();
@@ -178,7 +178,7 @@ void Replica::MainReplicationFb() {
   SetShardStates(true);
 
   error_code ec;
-  while (!cntx_.IsCancelled() && state_mask_.load() & R_ENABLED) {
+  while (state_mask_.load() & R_ENABLED) {
     // Discard all previous errors and set default error handler.
     cntx_.Reset([this](const GenericError& ge) { this->DefaultErrorHandler(ge); });
     // 1. Connect socket.

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -175,6 +175,7 @@ class Replica : ProtocolClient {
   std::optional<cluster::SlotRange> slot_range_;
 };
 
+class RdbLoader;
 // This class implements a single shard replication flow from a Dragonfly master instance.
 // Multiple DflyShardReplica objects are managed by a Replica object.
 class DflyShardReplica : public ProtocolClient {
@@ -224,6 +225,7 @@ class DflyShardReplica : public ProtocolClient {
   bool use_multi_shard_exe_sync_;
 
   std::unique_ptr<JournalExecutor> executor_;
+  std::unique_ptr<RdbLoader> rdb_loader_;
 
   // The master instance has a LSN for each journal record. This counts
   // the number of journal records executed in this flow plus the initial


### PR DESCRIPTION
this should fix the problem: Running replicaof no one on replica in full sync state returns after more than 20 seconds
the problem was that after we shutdown the socket the buffer still contained data and we processed it.