### PR TITLE
[do not review] feat: add small wasmtime prototype

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "helio"]
 	path = helio
 	url = https://github.com/romange/helio.git
+[submodule "wasmtime"]
+	path = wasmtime
+	url = https://github.com/bytecodealliance/wasmtime.git

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -26,7 +26,6 @@ if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     cxx_test(tiering/external_alloc_test dfly_test_lib LABELS DFLY)
 endif()
 
-
 add_library(dfly_transaction db_slice.cc malloc_stats.cc blocking_controller.cc
             command_registry.cc  cluster/unique_slot_checker.cc
             journal/tx_executor.cc
@@ -54,7 +53,8 @@ add_library(dragonfly_lib bloom_family.cc engine_shard_set.cc channel_store.cc
             cluster/cluster_family.cc cluster/incoming_slot_migration.cc
             cluster/outgoing_slot_migration.cc cluster/cluster_defs.cc
             acl/user.cc acl/user_registry.cc acl/acl_family.cc
-            acl/validator.cc acl/helpers.cc)
+            acl/validator.cc acl/helpers.cc
+            wasm/engine_example.cc wasm/wasm_family.cc)
 
 if (DF_ENABLE_MEMORY_TRACKING)
   target_compile_definitions(dragonfly_lib PRIVATE DFLY_ENABLE_MEMORY_TRACKING)
@@ -76,6 +76,11 @@ cxx_link(dragonfly_lib dfly_transaction dfly_facade redis_lib awsv2_lib jsonpath
          strings_lib html_lib
          http_client_lib absl::random_random TRDP::jsoncons ${ZSTD_LIB} TRDP::lz4
          TRDP::croncpp TRDP::flatbuffers)
+
+add_library(wasmtime STATIC IMPORTED)
+
+target_include_directories(dragonfly_lib PRIVATE ${CMAKE_SOURCE_DIR}/wasmtime/crates/c-api/include)
+target_link_libraries(dragonfly_lib ${CMAKE_SOURCE_DIR}/wasmtime/target/release/libwasmtime.a)
 
 if (DF_USE_SSL)
   set(TLS_LIB tls_lib)

--- a/src/server/acl/acl_commands_def.h
+++ b/src/server/acl/acl_commands_def.h
@@ -37,6 +37,7 @@ enum AclCat {
   SCRIPTING = 1ULL << 20,
 
   // Extensions
+  WASM = 1ULL << 27,
   BLOOM = 1ULL << 28,
   FT_SEARCH = 1ULL << 29,
   THROTTLE = 1ULL << 30,
@@ -67,6 +68,7 @@ inline const absl::flat_hash_map<std::string_view, uint32_t> CATEGORY_INDEX_TABL
     {"CONNECTION", CONNECTION},
     {"TRANSACTION", TRANSACTION},
     {"SCRIPTING", SCRIPTING},
+    {"WASM", WASM},
     {"BLOOM", BLOOM},
     {"FT_SEARCH", FT_SEARCH},
     {"THROTTLE", THROTTLE},
@@ -81,7 +83,7 @@ inline const std::vector<std::string> REVERSE_CATEGORY_INDEX_TABLE{
     "KEYSPACE",  "READ",      "WRITE",     "SET",       "SORTEDSET",  "LIST",        "HASH",
     "STRING",    "BITMAP",    "HYPERLOG",  "GEO",       "STREAM",     "PUBSUB",      "ADMIN",
     "FAST",      "SLOW",      "BLOCKING",  "DANGEROUS", "CONNECTION", "TRANSACTION", "SCRIPTING",
-    "_RESERVED", "_RESERVED", "_RESERVED", "_RESERVED", "_RESERVED",  "_RESERVED",   "_RESERVED",
+    "_RESERVED", "_RESERVED", "_RESERVED", "_RESERVED", "_RESERVED",  "_RESERVED",   "WASM",
     "BLOOM",     "FT_SEARCH", "THROTTLE",  "JSON"};
 
 using RevCommandField = std::vector<std::string>;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2641,6 +2641,7 @@ void Service::RegisterCommands() {
   BloomFamily::Register(&registry_);
   server_family_.Register(&registry_);
   cluster_family_.Register(&registry_);
+  wasm_family_.Register(&registry_);
 
   acl_family_.Register(&registry_);
   acl::BuildIndexers(registry_.GetFamilies());

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -17,6 +17,7 @@
 #include "server/config_registry.h"
 #include "server/engine_shard_set.h"
 #include "server/server_family.h"
+#include "server/wasm/wasm_family.h"
 
 namespace util {
 class AcceptServer;
@@ -181,6 +182,7 @@ class Service : public facade::ServiceInterface {
 
   acl::UserRegistry user_registry_;
   acl::AclFamily acl_family_;
+  wasm::WasmFamily wasm_family_;
   ServerFamily server_family_;
   cluster::ClusterFamily cluster_family_;
   CommandRegistry registry_;

--- a/src/server/wasm/engine_example.cc
+++ b/src/server/wasm/engine_example.cc
@@ -1,0 +1,137 @@
+// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "server/wasm/engine_example.h"
+
+#include <assert.h>
+
+#include <string>
+
+#include "absl/cleanup/cleanup.h"
+#include "base/logging.h"
+#include "wasm.h"
+
+namespace dfly::wasm {
+// Name of the module: dragonfly:
+// exported function hello()
+thread_local ConnectionContext* local_cntx;
+
+void hello() {
+  local_cntx->SendSimpleString("Hello from WASM engine!");
+}
+
+void EngineCall(std::string path, ConnectionContext* cntx) {
+  // Set up our context
+  wasm_engine_t* engine = wasm_engine_new();
+  CHECK(engine != nullptr);
+  wasmtime_store_t* store = wasmtime_store_new(engine, nullptr, nullptr);
+  CHECK(store != nullptr);
+  wasmtime_context_t* context = wasmtime_store_context(store);
+
+  // Create a linker with WASI functions defined
+  wasmtime_linker_t* linker = wasmtime_linker_new(engine);
+  wasmtime_error_t* error = wasmtime_linker_define_wasi(linker);
+  if (error != nullptr)
+    LOG(INFO) << "failed to link wasi";
+
+  // HACK, for some reason if we capture the lambda changes type and it gets rejected by
+  // wasm linker function
+  local_cntx = cntx;
+  auto hello_wrapper = [](auto...) -> wasm_trap_t* {
+    hello();
+    return nullptr;
+  };
+
+  std::string mod = "dragonfly";
+  std::string export_f = "hello";
+  wasm_valtype_vec_t arg_types;
+  wasm_valtype_vec_t result_types;
+  wasm_valtype_vec_new_empty(&result_types);
+  wasm_valtype_vec_new_empty(&arg_types);
+  auto* handle = wasm_functype_new(&arg_types, &result_types);
+  error = wasmtime_linker_define_func(linker, mod.data(), mod.size(), export_f.data(),
+                                      export_f.size(), handle, hello_wrapper, nullptr, nullptr);
+
+  // Compile our modules
+  wasmtime_module_t* module = nullptr;
+
+  absl::Cleanup clean([&]() {
+    // Clean up after ourselves at this point
+    if (handle)
+      wasm_functype_delete(handle);
+    if (module)
+      wasmtime_module_delete(module);
+    if (store)
+      wasmtime_store_delete(store);
+    if (engine)
+      wasm_engine_delete(engine);
+  });
+
+  if (error != nullptr) {
+    LOG(INFO) << "failed to link wasi";
+    return;
+  }
+
+  wasm_byte_vec_t wasm;
+
+  // Load our input file to parse it next
+  FILE* file = fopen(path.data(), "rb");
+  if (!file) {
+    LOG(INFO) << "error opening file";
+    return;
+  }
+  fseek(file, 0L, SEEK_END);
+  size_t file_size = ftell(file);
+  wasm_byte_vec_new_uninitialized(&wasm, file_size);
+  fseek(file, 0L, SEEK_SET);
+  if (fread(wasm.data, file_size, 1, file) != 1) {
+    printf("> Error loading module!\n");
+    exit(1);
+  }
+  fclose(file);
+
+  error = wasmtime_module_new(engine, (uint8_t*)wasm.data, wasm.size, &module);
+  if (!module) {
+    LOG(INFO) << "failed to compile module";
+    return;
+  }
+  wasm_byte_vec_delete(&wasm);
+
+  // Instantiate wasi
+  wasi_config_t* wasi_config = wasi_config_new();
+  assert(wasi_config);
+  wasi_config_inherit_argv(wasi_config);
+  wasi_config_inherit_env(wasi_config);
+  wasi_config_inherit_stdin(wasi_config);
+  wasi_config_inherit_stdout(wasi_config);
+  wasi_config_inherit_stderr(wasi_config);
+  wasm_trap_t* trap = nullptr;
+  error = wasmtime_context_set_wasi(context, wasi_config);
+  if (error != nullptr) {
+    LOG(INFO) << "failed to instantiate WASI";
+    return;
+  }
+
+  // Instantiate the module
+  error = wasmtime_linker_module(linker, context, "", 0, module);
+  if (error != nullptr) {
+    LOG(INFO) << "failed to link";
+    return;
+  }
+
+  // Run it.
+  wasmtime_func_t func;
+  error = wasmtime_linker_get_default(linker, context, "", 0, &func);
+  if (error != nullptr) {
+    LOG(INFO) << "failed to locate default export for module";
+    return;
+  }
+
+  error = wasmtime_func_call(context, &func, nullptr, 0, nullptr, 0, &trap);
+  if (error != nullptr || trap != nullptr) {
+    LOG(INFO) << "error calling default export";
+    return;
+  }
+}
+}  // namespace dfly::wasm

--- a/src/server/wasm/engine_example.h
+++ b/src/server/wasm/engine_example.h
@@ -1,0 +1,19 @@
+// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+// This is just a toy example to demonstrate the high level concepts -- there is no encapsulation
+// and the code is `raw`
+
+#pragma once
+
+#include <string>
+
+#include "server/conn_context.h"
+#include "wasi.h"
+#include "wasm.h"
+#include "wasmtime.h"
+
+namespace dfly::wasm {
+void EngineCall(std::string path, ConnectionContext* cntx);
+}

--- a/src/server/wasm/wasm_family.cc
+++ b/src/server/wasm/wasm_family.cc
@@ -1,0 +1,34 @@
+// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+#include "server/wasm/wasm_family.h"
+
+#include "absl/strings/str_cat.h"
+#include "facade/facade_types.h"
+#include "server/acl/acl_commands_def.h"
+#include "server/command_registry.h"
+#include "server/conn_context.h"
+#include "server/wasm/engine_example.h"
+
+namespace dfly::wasm {
+
+using MemberFunc = void (WasmFamily::*)(CmdArgList args, ConnectionContext* cntx);
+
+CommandId::Handler HandlerFunc(WasmFamily* wasm, MemberFunc f) {
+  return [=](CmdArgList args, ConnectionContext* cntx) { return (wasm->*f)(args, cntx); };
+}
+
+#define HFUNC(x) SetHandler(HandlerFunc(this, &WasmFamily::x))
+
+void WasmFamily::Register(dfly::CommandRegistry* registry) {
+  using CI = dfly::CommandId;
+  registry->StartFamily();
+  *registry << CI{"CALLWASM", dfly::CO::LOADING, 2, 0, 0, acl::WASM}.HFUNC(CallWasm);
+}
+
+void WasmFamily::CallWasm(CmdArgList args, ConnectionContext* cntx) {
+  std::string path = absl::StrCat(facade::ToSV(args[0]), "\0");
+  EngineCall(path, cntx);
+}
+
+}  // namespace dfly::wasm

--- a/src/server/wasm/wasm_family.h
+++ b/src/server/wasm/wasm_family.h
@@ -1,0 +1,24 @@
+// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include "facade/facade_types.h"
+#include "server/command_registry.h"
+
+namespace dfly {
+
+class ConnectionContext;
+namespace wasm {
+
+class WasmFamily final {
+ public:
+  void Register(CommandRegistry* registry);
+
+ private:
+  void CallWasm(CmdArgList args, ConnectionContext* cntx);
+};
+
+}  // namespace wasm
+}  // namespace dfly

--- a/src/wasm_sdk/README.md
+++ b/src/wasm_sdk/README.md
@@ -1,0 +1,26 @@
+# Public facing API for experimental Dragonfly wasm functions
+
+This is the top folder for our public API. Each subfolder should serve as the
+sdk for each language we support. For example:
+`/python` subfolder would contain the declarations (but not the definitions! these will be
+provided/exported by dragonfly and users wasm binaries will be linked against them
+to resolve the symbols) for our API. A client function would be:
+
+```
+#include <dragonfly/wasm.h>
+
+int main() {
+  dragonfly::RegisterUDF("my-udf", [](auto df) {
+    auto val = df.get("foo")
+    df.set(val * 15);
+    return 1;
+  });
+}
+```
+
+and we could call it via:
+
+```
+> CALL my-udf
+> 1
+```

--- a/src/wasm_sdk/cpp/dragonfly.h
+++ b/src/wasm_sdk/cpp/dragonfly.h
@@ -1,0 +1,16 @@
+// Copyright 2022, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+namespace dragonfly {
+
+/* PUBLIC FACING API */
+
+extern "C" {
+#define WASM_IMPORT(mod, name) __attribute__((import_module(#mod), import_name(#name)))
+
+WASM_IMPORT(dragonfly, hello)
+void hello();
+}
+
+}  // namespace dragonfly

--- a/src/wasm_sdk/cpp/examples/example.cc
+++ b/src/wasm_sdk/cpp/examples/example.cc
@@ -1,0 +1,10 @@
+#include "dragonfly.h"
+
+// Compile with wasi-sdk found here: https://github.com/WebAssembly/wasi-sdk.git
+// wasi-sdk-22.0/bin/clang++ -std=c++11 example.cc -o udf.wasm
+// then use redis-cli and call
+// callwasm /path/to/udf.wasm
+
+int main() {
+  dragonfly::hello();
+}


### PR DESCRIPTION
* embed wasmtime in dragonfly
* add hello example as an API export function
* add UDF example
* add cpp sdk example

How to use:

Before you call `cmake` or `blaze` make sure you compile wasmtime:

```
cd dragonfly/wasmtime && cargo build --release -p wasmtime-c-api
```

Then call `blaze` or `cmake` && `ninja dragonfly` to compile. 

See `sdk/cpp/example` on how to compile a UDF to wasm and executed in dragonfly via `CALLWASM` command