### PR TITLE
chore: add half-range indices

### DIFF
--- a/src/core/json/jsonpath_grammar.y
+++ b/src/core/json/jsonpath_grammar.y
@@ -88,6 +88,8 @@ identifier: UNQ_STR
 bracket_index: WILDCARD { $$ = PathSegment{SegmentType::INDEX, IndexExpr::All()}; }
               | INT { $$ = PathSegment(SegmentType::INDEX, IndexExpr($1, $1)); }
               | INT COLON INT { $$ = PathSegment(SegmentType::INDEX, IndexExpr::HalfOpen($1, $3)); }
+              | INT COLON { $$ = PathSegment(SegmentType::INDEX, IndexExpr($1, INT_MAX)); }
+              | COLON INT { $$ = PathSegment(SegmentType::INDEX, IndexExpr::HalfOpen(0, $2)); }
 
 function_expr: UNQ_STR { driver->AddFunction($1); } LPARENT ROOT relative_location RPARENT
 %%

--- a/src/core/json/jsonpath_test.cc
+++ b/src/core/json/jsonpath_test.cc
@@ -519,6 +519,18 @@ TYPED_TEST(JsonPathTest, SubRange) {
   EvaluatePath(path, json, cb);
   ASSERT_THAT(arr, ElementsAre());
   arr.clear();
+
+  ASSERT_EQ(0, this->Parse("$.arr[:2]"));
+  path = this->driver_.TakePath();
+  EvaluatePath(path, json, cb);
+  ASSERT_THAT(arr, ElementsAre(1, 2));
+  arr.clear();
+
+  ASSERT_EQ(0, this->Parse("$.arr[2:]"));
+  path = this->driver_.TakePath();
+  EvaluatePath(path, json, cb);
+  ASSERT_THAT(arr, ElementsAre(3, 4, 5));
+  arr.clear();
 }
 
 }  // namespace dfly::json

--- a/src/core/json/path.cc
+++ b/src/core/json/path.cc
@@ -55,7 +55,7 @@ IndexExpr IndexExpr::Normalize(size_t array_len) const {
     return IndexExpr(1, 0);  // empty range.
 
   IndexExpr res = *this;
-  auto wrap = [=](int negative) {
+  auto wrap = [array_len](int negative) {
     unsigned positive = -negative;
     return positive > array_len ? 0 : array_len - positive;
   };

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -30,7 +30,7 @@
 #include "server/tiered_storage.h"
 #include "server/transaction.h"
 
-ABSL_FLAG(bool, jsonpathv2, false,
+ABSL_FLAG(bool, jsonpathv2, true,
           "If true uses Dragonfly jsonpath implementation, "
           "otherwise uses legacy jsoncons implementation.");
 ABSL_FLAG(bool, experimental_flat_json, false, "If true uses flat json implementation.");


### PR DESCRIPTION
Add indices in form of [:end] or [start:]

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->