### PR TITLE
feat(namespaces): Initial support for multi-tenant

### DIFF
--- a/src/facade/acl_commands_def.h
+++ b/src/facade/acl_commands_def.h
@@ -28,6 +28,7 @@ struct UserCredentials {
   uint32_t acl_categories{0};
   std::vector<uint64_t> acl_commands;
   AclKeys keys;
+  std::string ns;
 };
 
 }  // namespace dfly::acl

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -47,7 +47,7 @@ add_library(dragonfly_lib bloom_family.cc engine_shard_set.cc
             config_registry.cc conn_context.cc debugcmd.cc dflycmd.cc
             generic_family.cc hset_family.cc http_api.cc json_family.cc
             list_family.cc main_service.cc memory_cmd.cc rdb_load.cc rdb_save.cc replica.cc
-            protocol_client.cc
+            protocol_client.cc namespaces.cc
             snapshot.cc script_mgr.cc server_family.cc malloc_stats.cc
             detail/save_stages_controller.cc
             detail/snapshot_storage.cc

--- a/src/server/acl/helpers.cc
+++ b/src/server/acl/helpers.cc
@@ -181,6 +181,13 @@ std::optional<User::UpdatePass> MaybeParsePassword(std::string_view command, boo
   return {};
 }
 
+std::optional<std::string> MaybeParseNamespace(std::string_view command) {
+  if (absl::StartsWith(command, "TENANT:")) {
+    return std::string(command.substr(7));
+  }
+  return {};
+}
+
 std::optional<bool> MaybeParseStatus(std::string_view command) {
   if (command == "ON") {
     return true;
@@ -304,6 +311,11 @@ std::variant<User::UpdateRequest, ErrorReply> ParseAclSetUser(facade::ArgRange a
         return ErrorReply("Multiple ON/OFF are not allowed");
       }
       req.is_active = *status;
+      continue;
+    }
+
+    if (auto ns = MaybeParseNamespace(command); ns) {
+      req.ns = ns;
       continue;
     }
 

--- a/src/server/acl/user.cc
+++ b/src/server/acl/user.cc
@@ -78,6 +78,10 @@ void User::Update(UpdateRequest&& req) {
   if (req.is_active) {
     SetIsActive(*req.is_active);
   }
+
+  if (req.ns) {
+    SetNamespace(*req.ns);
+  }
 }
 
 void User::SetPasswordHash(std::string_view password, bool is_hashed) {
@@ -91,6 +95,14 @@ void User::SetPasswordHash(std::string_view password, bool is_hashed) {
 
 void User::UnsetPassword(std::string_view password) {
   password_hashes_.erase(StringSHA256(password));
+}
+
+void User::SetNamespace(const std::string& ns) {
+  namespace_ = ns;
+}
+
+std::string User::Namespace() const {
+  return namespace_;
 }
 
 bool User::HasPassword(std::string_view password) const {

--- a/src/server/acl/user.h
+++ b/src/server/acl/user.h
@@ -57,8 +57,11 @@ class User final {
     std::vector<UpdateKey> keys;
     bool reset_all_keys{false};
     bool allow_all_keys{false};
+
     // TODO allow reset all
     // bool reset_all{false};
+
+    std::optional<std::string> ns{};
   };
 
   using CategoryChange = uint32_t;
@@ -101,6 +104,8 @@ class User final {
 
   const AclKeys& Keys() const;
 
+  std::string Namespace() const;
+
   using CategoryChanges = absl::flat_hash_map<CategoryChange, ChangeMetadata>;
   using CommandChanges = absl::flat_hash_map<CommandChange, ChangeMetadata>;
 
@@ -128,6 +133,7 @@ class User final {
 
   // For ACL key globs
   void SetKeyGlobs(std::vector<UpdateKey> keys);
+  void SetNamespace(const std::string& ns);
 
   // Set NOPASS and remove all passwords
   void SetNopass();
@@ -159,6 +165,8 @@ class User final {
 
   // if the user is on/off
   bool is_active_{false};
+
+  std::string namespace_;
 };
 
 }  // namespace dfly::acl

--- a/src/server/acl/user_registry.cc
+++ b/src/server/acl/user_registry.cc
@@ -35,7 +35,8 @@ UserCredentials UserRegistry::GetCredentials(std::string_view username) const {
   if (it == registry_.end()) {
     return {};
   }
-  return {it->second.AclCategory(), it->second.AclCommands(), it->second.Keys()};
+  return {it->second.AclCategory(), it->second.AclCommands(), it->second.Keys(),
+          it->second.Namespace()};
 }
 
 bool UserRegistry::IsUserActive(std::string_view username) const {

--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -310,7 +310,7 @@ class ElementAccess {
 };
 
 std::optional<bool> ElementAccess::Exists(EngineShard* shard) {
-  auto res = shard->db_slice().FindReadOnly(context_, key_, OBJ_STRING);
+  auto res = context_.ns->GetCurrentDbSlice().FindReadOnly(context_, key_, OBJ_STRING);
   if (res.status() == OpStatus::WRONG_TYPE) {
     return {};
   }
@@ -318,7 +318,7 @@ std::optional<bool> ElementAccess::Exists(EngineShard* shard) {
 }
 
 OpStatus ElementAccess::Find(EngineShard* shard) {
-  auto op_res = shard->db_slice().AddOrFind(context_, key_);
+  auto op_res = context_.ns->GetCurrentDbSlice().AddOrFind(context_, key_);
   RETURN_ON_BAD_STATUS(op_res);
   auto& add_res = *op_res;
 
@@ -355,7 +355,7 @@ OpResult<bool> BitNewValue(const OpArgs& args, std::string_view key, uint32_t of
                            bool bit_value) {
   EngineShard* shard = args.shard;
   ElementAccess element_access{key, args};
-  auto& db_slice = shard->db_slice();
+  auto& db_slice = args.db_cntx.ns->GetCurrentDbSlice();
   DCHECK(db_slice.IsDbValid(element_access.Index()));
   bool old_value = false;
 
@@ -445,9 +445,9 @@ OpResult<std::string> CombineResultOp(ShardStringResults result, std::string_vie
 
 // For bitop not - we cannot accumulate
 OpResult<std::string> RunBitOpNot(const OpArgs& op_args, string_view key) {
-  EngineShard* es = op_args.shard;
   // if we found the value, just return, if not found then skip, otherwise report an error
-  auto find_res = es->db_slice().FindReadOnly(op_args.db_cntx, key, OBJ_STRING);
+  DbSlice& db_slice = op_args.db_cntx.ns->GetCurrentDbSlice();
+  auto find_res = db_slice.FindReadOnly(op_args.db_cntx, key, OBJ_STRING);
   if (find_res) {
     return GetString(find_res.value()->second);
   } else {
@@ -463,12 +463,13 @@ OpResult<std::string> RunBitOpOnShard(std::string_view op, const OpArgs& op_args
   if (op == NOT_OP_NAME) {
     return RunBitOpNot(op_args, *start);
   }
-  EngineShard* es = op_args.shard;
+
+  DbSlice& db_slice = op_args.db_cntx.ns->GetCurrentDbSlice();
   BitsStrVec values;
 
   // collect all the value for this shard
   for (; start != end; ++start) {
-    auto find_res = es->db_slice().FindReadOnly(op_args.db_cntx, *start, OBJ_STRING);
+    auto find_res = db_slice.FindReadOnly(op_args.db_cntx, *start, OBJ_STRING);
     if (find_res) {
       values.emplace_back(GetString(find_res.value()->second));
     } else {
@@ -1244,7 +1245,8 @@ OpResult<bool> ReadValueBitsetAt(const OpArgs& op_args, std::string_view key, ui
 
 OpResult<std::string> ReadValue(const DbContext& context, std::string_view key,
                                 EngineShard* shard) {
-  auto it_res = shard->db_slice().FindReadOnly(context, key, OBJ_STRING);
+  DbSlice& db_slice = context.ns->GetCurrentDbSlice();
+  auto it_res = db_slice.FindReadOnly(context, key, OBJ_STRING);
   if (!it_res.ok()) {
     return it_res.status();
   }

--- a/src/server/blocking_controller.cc
+++ b/src/server/blocking_controller.cc
@@ -10,6 +10,7 @@
 
 #include "base/logging.h"
 #include "server/engine_shard_set.h"
+#include "server/namespaces.h"
 #include "server/transaction.h"
 
 namespace dfly {
@@ -102,7 +103,7 @@ bool BlockingController::DbWatchTable::UnwatchTx(string_view key, Transaction* t
   return res;
 }
 
-BlockingController::BlockingController(EngineShard* owner) : owner_(owner) {
+BlockingController::BlockingController(EngineShard* owner, Namespace* ns) : owner_(owner), ns_(ns) {
 }
 
 BlockingController::~BlockingController() {
@@ -153,6 +154,7 @@ void BlockingController::NotifyPending() {
   CHECK(tx == nullptr) << tx->DebugId();
 
   DbContext context;
+  context.ns = ns_;
   context.time_now_ms = GetCurrentTimeMs();
 
   for (DbIndex index : awakened_indices_) {

--- a/src/server/blocking_controller.h
+++ b/src/server/blocking_controller.h
@@ -15,10 +15,11 @@
 namespace dfly {
 
 class Transaction;
+class Namespace;
 
 class BlockingController {
  public:
-  explicit BlockingController(EngineShard* owner);
+  explicit BlockingController(EngineShard* owner, Namespace* ns);
   ~BlockingController();
 
   using Keys = std::variant<ShardArgs, ArgSlice>;
@@ -60,6 +61,7 @@ class BlockingController {
   // void NotifyConvergence(Transaction* tx);
 
   EngineShard* owner_;
+  Namespace* ns_;
 
   absl::flat_hash_map<DbIndex, std::unique_ptr<DbWatchTable>> watched_dbs_;
 

--- a/src/server/bloom_family.cc
+++ b/src/server/bloom_family.cc
@@ -35,7 +35,7 @@ using AddResult = absl::InlinedVector<OpResult<bool>, 4>;
 using ExistsResult = absl::InlinedVector<bool, 4>;
 
 OpStatus OpReserve(const SbfParams& params, const OpArgs& op_args, string_view key) {
-  auto& db_slice = op_args.shard->db_slice();
+  auto& db_slice = op_args.db_cntx.ns->GetCurrentDbSlice();
   OpResult op_res = db_slice.AddOrFind(op_args.db_cntx, key);
   if (!op_res)
     return op_res.status();
@@ -50,7 +50,7 @@ OpStatus OpReserve(const SbfParams& params, const OpArgs& op_args, string_view k
 
 // Returns true, if item was added, false if it was already "present".
 OpResult<AddResult> OpAdd(const OpArgs& op_args, string_view key, CmdArgList items) {
-  auto& db_slice = op_args.shard->db_slice();
+  auto& db_slice = op_args.db_cntx.ns->GetCurrentDbSlice();
 
   OpResult op_res = db_slice.AddOrFind(op_args.db_cntx, key);
   if (!op_res)
@@ -73,7 +73,7 @@ OpResult<AddResult> OpAdd(const OpArgs& op_args, string_view key, CmdArgList ite
 }
 
 OpResult<ExistsResult> OpExists(const OpArgs& op_args, string_view key, CmdArgList items) {
-  auto& db_slice = op_args.shard->db_slice();
+  auto& db_slice = op_args.db_cntx.ns->GetCurrentDbSlice();
   OpResult op_res = db_slice.FindReadOnly(op_args.db_cntx, key, OBJ_SBF);
   if (!op_res)
     return op_res.status();

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -21,6 +21,7 @@
 #include "server/error.h"
 #include "server/journal/journal.h"
 #include "server/main_service.h"
+#include "server/namespaces.h"
 #include "server/server_family.h"
 #include "server/server_state.h"
 
@@ -445,7 +446,7 @@ void DeleteSlots(const SlotRanges& slots_ranges) {
     if (shard == nullptr)
       return;
 
-    shard->db_slice().FlushSlots(slots_ranges);
+    namespaces->GetDefaultNamespace().GetCurrentDbSlice().FlushSlots(slots_ranges);
   };
   shard_set->pool()->AwaitFiberOnAll(std::move(cb));
 }
@@ -596,7 +597,7 @@ void ClusterFamily::DflyClusterGetSlotInfo(CmdArgList args, ConnectionContext* c
 
     lock_guard lk(mu);
     for (auto& [slot, data] : slots_stats) {
-      data += shard->db_slice().GetSlotStats(slot);
+      data += namespaces->GetDefaultNamespace().GetCurrentDbSlice().GetSlotStats(slot);
     }
   };
 

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -446,7 +446,7 @@ void DeleteSlots(const SlotRanges& slots_ranges) {
     if (shard == nullptr)
       return;
 
-    namespaces->GetDefaultNamespace().GetCurrentDbSlice().FlushSlots(slots_ranges);
+    Namespaces::Get().GetDefaultNamespace().GetCurrentDbSlice().FlushSlots(slots_ranges);
   };
   shard_set->pool()->AwaitFiberOnAll(std::move(cb));
 }
@@ -594,7 +594,7 @@ void ClusterFamily::DflyClusterGetSlotInfo(CmdArgList args, ConnectionContext* c
 
     lock_guard lk(mu);
     for (auto& [slot, data] : slots_stats) {
-      data += namespaces->GetDefaultNamespace().GetCurrentDbSlice().GetSlotStats(slot);
+      data += Namespaces::Get().GetDefaultNamespace().GetCurrentDbSlice().GetSlotStats(slot);
     }
   };
 

--- a/src/server/cluster/cluster_utility.cc
+++ b/src/server/cluster/cluster_utility.cc
@@ -2,6 +2,7 @@
 
 #include "server/cluster/cluster_defs.h"
 #include "server/engine_shard_set.h"
+#include "server/namespaces.h"
 
 using namespace std;
 
@@ -49,7 +50,8 @@ uint64_t GetKeyCount(const SlotRanges& slots) {
     uint64_t shard_keys = 0;
     for (const SlotRange& range : slots) {
       for (SlotId slot = range.start; slot <= range.end; slot++) {
-        shard_keys += shard->db_slice().GetSlotStats(slot).key_count;
+        shard_keys +=
+            namespaces->GetDefaultNamespace().GetCurrentDbSlice().GetSlotStats(slot).key_count;
       }
     }
     keys.fetch_add(shard_keys);

--- a/src/server/cluster/cluster_utility.cc
+++ b/src/server/cluster/cluster_utility.cc
@@ -50,8 +50,11 @@ uint64_t GetKeyCount(const SlotRanges& slots) {
     uint64_t shard_keys = 0;
     for (const SlotRange& range : slots) {
       for (SlotId slot = range.start; slot <= range.end; slot++) {
-        shard_keys +=
-            namespaces->GetDefaultNamespace().GetCurrentDbSlice().GetSlotStats(slot).key_count;
+        shard_keys += Namespaces::Get()
+                          .GetDefaultNamespace()
+                          .GetCurrentDbSlice()
+                          .GetSlotStats(slot)
+                          .key_count;
       }
     }
     keys.fetch_add(shard_keys);

--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -197,7 +197,7 @@ void OutgoingMigration::SyncFb() {
 
     shard_set->pool()->AwaitFiberOnAll([this](util::ProactorBase* pb) {
       if (auto* shard = EngineShard::tlocal(); shard) {
-        DbSlice& db_slice = namespaces->GetDefaultNamespace().GetCurrentDbSlice();
+        DbSlice& db_slice = Namespaces::Get().GetDefaultNamespace().GetCurrentDbSlice();
         server_family_->journal()->StartInThread();
         slot_migrations_[shard->shard_id()] = std::make_unique<SliceSlotMigration>(
             &db_slice, server(), migration_info_.slot_ranges, server_family_->journal());
@@ -260,7 +260,7 @@ bool OutgoingMigration::FinalizeMigration(long attempt) {
   bool is_block_active = true;
   auto is_pause_in_progress = [&is_block_active] { return is_block_active; };
   auto pause_fb_opt =
-      Pause(server_family_->GetNonPriviligedListeners(), &namespaces->GetDefaultNamespace(),
+      Pause(server_family_->GetNonPriviligedListeners(), &Namespaces::Get().GetDefaultNamespace(),
             nullptr, ClientPause::WRITE, is_pause_in_progress);
 
   if (!pause_fb_opt) {

--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -195,9 +195,10 @@ void OutgoingMigration::SyncFb() {
 
     shard_set->pool()->AwaitFiberOnAll([this](util::ProactorBase* pb) {
       if (auto* shard = EngineShard::tlocal(); shard) {
+        DbSlice& db_slice = namespaces->GetDefaultNamespace().GetCurrentDbSlice();
         server_family_->journal()->StartInThread();
         slot_migrations_[shard->shard_id()] = std::make_unique<SliceSlotMigration>(
-            &shard->db_slice(), server(), migration_info_.slot_ranges, server_family_->journal());
+            &db_slice, server(), migration_info_.slot_ranges, server_family_->journal());
       }
     });
 
@@ -257,8 +258,9 @@ bool OutgoingMigration::FinalizeMigration(long attempt) {
   // TODO implement blocking on migrated slots only
   bool is_block_active = true;
   auto is_pause_in_progress = [&is_block_active] { return is_block_active; };
-  auto pause_fb_opt = Pause(server_family_->GetNonPriviligedListeners(), nullptr,
-                            ClientPause::WRITE, is_pause_in_progress);
+  auto pause_fb_opt =
+      Pause(server_family_->GetNonPriviligedListeners(), &namespaces->GetDefaultNamespace(),
+            nullptr, ClientPause::WRITE, is_pause_in_progress);
 
   if (!pause_fb_opt) {
     LOG(WARNING) << "Cluster migration finalization time out";

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -282,6 +282,7 @@ class ConnectionContext : public facade::ConnectionContext {
   DebugInfo last_command_debug;
 
   // TODO: to introduce proper accessors.
+  Namespace* ns = nullptr;
   Transaction* transaction = nullptr;
   const CommandId* cid = nullptr;
 

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -329,7 +329,7 @@ class DbSlice {
   // Creates a database with index `db_ind`. If such database exists does nothing.
   void ActivateDb(DbIndex db_ind);
 
-  bool Del(DbIndex db_ind, Iterator it);
+  bool Del(Context cntx, Iterator it);
 
   constexpr static DbIndex kDbAll = 0xFFFF;
 

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -159,7 +159,7 @@ void DoPopulateBatch(string_view type, string_view prefix, size_t val_size, bool
     stub_tx->MultiSwitchCmd(cid);
     local_cntx.cid = cid;
     crb.SetReplyMode(ReplyMode::NONE);
-    stub_tx->InitByArgs(local_cntx.conn_state.db_index, args_span);
+    stub_tx->InitByArgs(cntx->ns, local_cntx.conn_state.db_index, args_span);
 
     sf->service().InvokeCmd(cid, args_span, &local_cntx);
   }
@@ -261,8 +261,8 @@ void MergeObjHistMap(ObjHistMap&& src, ObjHistMap* dest) {
   }
 }
 
-void DoBuildObjHist(EngineShard* shard, ObjHistMap* obj_hist_map) {
-  auto& db_slice = shard->db_slice();
+void DoBuildObjHist(EngineShard* shard, ConnectionContext* cntx, ObjHistMap* obj_hist_map) {
+  auto& db_slice = cntx->ns->GetCurrentDbSlice();
   unsigned steps = 0;
 
   for (unsigned i = 0; i < db_slice.db_array_size(); ++i) {
@@ -288,8 +288,9 @@ void DoBuildObjHist(EngineShard* shard, ObjHistMap* obj_hist_map) {
   }
 }
 
-ObjInfo InspectOp(string_view key, DbIndex db_index) {
-  auto& db_slice = EngineShard::tlocal()->db_slice();
+ObjInfo InspectOp(ConnectionContext* cntx, string_view key) {
+  auto& db_slice = cntx->ns->GetCurrentDbSlice();
+  auto db_index = cntx->db_index();
   auto [pt, exp_t] = db_slice.GetTables(db_index);
 
   PrimeIterator it = pt->Find(key);
@@ -323,8 +324,9 @@ ObjInfo InspectOp(string_view key, DbIndex db_index) {
   return oinfo;
 }
 
-OpResult<ValueCompressInfo> EstimateCompression(string_view key, DbIndex db_index) {
-  auto& db_slice = EngineShard::tlocal()->db_slice();
+OpResult<ValueCompressInfo> EstimateCompression(ConnectionContext* cntx, string_view key) {
+  auto& db_slice = cntx->ns->GetCurrentDbSlice();
+  auto db_index = cntx->db_index();
   auto [pt, exp_t] = db_slice.GetTables(db_index);
 
   PrimeIterator it = pt->Find(key);
@@ -544,7 +546,7 @@ void DebugCmd::Load(string_view filename) {
 
   const CommandId* cid = sf_.service().FindCmd("FLUSHALL");
   intrusive_ptr<Transaction> flush_trans(new Transaction{cid});
-  flush_trans->InitByArgs(0, {});
+  flush_trans->InitByArgs(cntx_->ns, 0, {});
   VLOG(1) << "Performing flush";
   error_code ec = sf_.Drakarys(flush_trans.get(), DbSlice::kDbAll);
   if (ec) {
@@ -750,7 +752,7 @@ void DebugCmd::PopulateRangeFiber(uint64_t from, uint64_t num_of_keys,
     // after running the callback
     // Note that running debug populate while running flushall/db can cause dcheck fail because the
     // finish cb is executed just when we finish populating the database.
-    shard->db_slice().OnCbFinish();
+    cntx_->ns->GetCurrentDbSlice().OnCbFinish();
   });
 }
 
@@ -801,7 +803,7 @@ void DebugCmd::Inspect(string_view key, CmdArgList args) {
   string resp;
 
   if (check_compression) {
-    auto cb = [&] { return EstimateCompression(key, cntx_->db_index()); };
+    auto cb = [&] { return EstimateCompression(cntx_, key); };
     auto res = ess.Await(sid, std::move(cb));
     if (!res) {
       cntx_->SendError(res.status());
@@ -812,7 +814,7 @@ void DebugCmd::Inspect(string_view key, CmdArgList args) {
       StrAppend(&resp, " ratio: ", static_cast<double>(res->compressed_size) / (res->raw_size));
     }
   } else {
-    auto cb = [&] { return InspectOp(key, cntx_->db_index()); };
+    auto cb = [&] { return InspectOp(cntx_, key); };
 
     ObjInfo res = ess.Await(sid, std::move(cb));
 
@@ -846,7 +848,7 @@ void DebugCmd::Watched() {
   vector<string> awaked_trans;
 
   auto cb = [&](EngineShard* shard) {
-    auto* bc = shard->blocking_controller();
+    auto* bc = cntx_->ns->GetBlockingController(shard->shard_id());
     if (bc) {
       auto keys = bc->GetWatchedKeys(cntx_->db_index());
 
@@ -894,8 +896,9 @@ void DebugCmd::TxAnalysis() {
 void DebugCmd::ObjHist() {
   vector<ObjHistMap> obj_hist_map_arr(shard_set->size());
 
-  shard_set->RunBlockingInParallel(
-      [&](EngineShard* shard) { DoBuildObjHist(shard, &obj_hist_map_arr[shard->shard_id()]); });
+  shard_set->RunBlockingInParallel([&](EngineShard* shard) {
+    DoBuildObjHist(shard, cntx_, &obj_hist_map_arr[shard->shard_id()]);
+  });
 
   for (size_t i = shard_set->size() - 1; i > 0; --i) {
     MergeObjHistMap(std::move(obj_hist_map_arr[i]), &obj_hist_map_arr[0]);
@@ -937,7 +940,7 @@ void DebugCmd::Shards() {
 
   vector<ShardInfo> infos(shard_set->size());
   shard_set->RunBriefInParallel([&](EngineShard* shard) {
-    auto slice_stats = shard->db_slice().GetStats();
+    auto slice_stats = cntx_->ns->GetCurrentDbSlice().GetStats();
     auto& stats = infos[shard->shard_id()];
 
     stats.used_memory = shard->UsedMemory();

--- a/src/server/detail/save_stages_controller.cc
+++ b/src/server/detail/save_stages_controller.cc
@@ -13,6 +13,7 @@
 #include "base/logging.h"
 #include "server/detail/snapshot_storage.h"
 #include "server/main_service.h"
+#include "server/namespaces.h"
 #include "server/script_mgr.h"
 #include "server/transaction.h"
 #include "strings/human_readable.h"
@@ -254,10 +255,11 @@ void SaveStagesController::SaveDfs() {
 
   // Save shard files.
   auto cb = [this](Transaction* t, EngineShard* shard) {
+    auto& db_slice = namespaces->GetDefaultNamespace().GetCurrentDbSlice();
     // a hack to avoid deadlock in Transaction::RunCallback(...)
-    shard->db_slice().UnlockChangeCb();
+    db_slice.UnlockChangeCb();
     SaveDfsSingle(shard);
-    shard->db_slice().LockChangeCb();
+    db_slice.LockChangeCb();
     return OpStatus::OK;
   };
   trans_->ScheduleSingleHop(std::move(cb));
@@ -298,9 +300,10 @@ void SaveStagesController::SaveRdb() {
 
   auto cb = [snapshot = snapshot.get()](Transaction* t, EngineShard* shard) {
     // a hack to avoid deadlock in Transaction::RunCallback(...)
-    shard->db_slice().UnlockChangeCb();
+    auto& db_slice = namespaces->GetDefaultNamespace().GetCurrentDbSlice();
+    db_slice.UnlockChangeCb();
     snapshot->StartInShard(shard);
-    shard->db_slice().LockChangeCb();
+    db_slice.LockChangeCb();
     return OpStatus::OK;
   };
   trans_->ScheduleSingleHop(std::move(cb));
@@ -406,7 +409,7 @@ void SaveStagesController::CloseCb(unsigned index) {
   }
 
   if (auto* es = EngineShard::tlocal(); use_dfs_format_ && es)
-    es->db_slice().ResetUpdateEvents();
+    namespaces->GetDefaultNamespace().GetCurrentDbSlice().ResetUpdateEvents();
 }
 
 void SaveStagesController::RunStage(void (SaveStagesController::*cb)(unsigned)) {

--- a/src/server/detail/save_stages_controller.cc
+++ b/src/server/detail/save_stages_controller.cc
@@ -255,7 +255,7 @@ void SaveStagesController::SaveDfs() {
 
   // Save shard files.
   auto cb = [this](Transaction* t, EngineShard* shard) {
-    auto& db_slice = namespaces->GetDefaultNamespace().GetCurrentDbSlice();
+    auto& db_slice = Namespaces::Get().GetDefaultNamespace().GetCurrentDbSlice();
     // a hack to avoid deadlock in Transaction::RunCallback(...)
     db_slice.UnlockChangeCb();
     SaveDfsSingle(shard);
@@ -300,7 +300,7 @@ void SaveStagesController::SaveRdb() {
 
   auto cb = [snapshot = snapshot.get()](Transaction* t, EngineShard* shard) {
     // a hack to avoid deadlock in Transaction::RunCallback(...)
-    auto& db_slice = namespaces->GetDefaultNamespace().GetCurrentDbSlice();
+    auto& db_slice = Namespaces::Get().GetDefaultNamespace().GetCurrentDbSlice();
     db_slice.UnlockChangeCb();
     snapshot->StartInShard(shard);
     db_slice.LockChangeCb();
@@ -409,7 +409,7 @@ void SaveStagesController::CloseCb(unsigned index) {
   }
 
   if (auto* es = EngineShard::tlocal(); use_dfs_format_ && es)
-    namespaces->GetDefaultNamespace().GetCurrentDbSlice().ResetUpdateEvents();
+    Namespaces::Get().GetDefaultNamespace().GetCurrentDbSlice().ResetUpdateEvents();
 }
 
 void SaveStagesController::RunStage(void (SaveStagesController::*cb)(unsigned)) {

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -101,7 +101,7 @@ OpStatus WaitReplicaFlowToCatchup(absl::Time end_time, shared_ptr<DflyCmd::Repli
                                   EngineShard* shard) {
   // We don't want any writes to the journal after we send the `PING`,
   // and expirations could ruin that.
-  namespaces->GetDefaultNamespace().GetCurrentDbSlice().SetExpireAllowed(false);
+  Namespaces::Get().GetDefaultNamespace().GetCurrentDbSlice().SetExpireAllowed(false);
   shard->journal()->RecordEntry(0, journal::Op::PING, 0, 0, nullopt, {}, true);
 
   FlowInfo* flow = &replica->flows[shard->shard_id()];
@@ -423,7 +423,7 @@ void DflyCmd::TakeOver(CmdArgList args, ConnectionContext* cntx) {
 
   absl::Cleanup([] {
     shard_set->RunBriefInParallel([](EngineShard* shard) {
-      namespaces->GetDefaultNamespace().GetCurrentDbSlice().SetExpireAllowed(true);
+      Namespaces::Get().GetDefaultNamespace().GetCurrentDbSlice().SetExpireAllowed(true);
     });
     VLOG(2) << "Enable expiration";
   });

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -577,7 +577,7 @@ TEST_F(DflyEngineTest, Bug496) {
     if (shard == nullptr)
       return;
 
-    auto& db = namespaces->GetDefaultNamespace().GetCurrentDbSlice();
+    auto& db = Namespaces::Get().GetDefaultNamespace().GetCurrentDbSlice();
 
     int cb_hits = 0;
     uint32_t cb_id =

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -563,12 +563,12 @@ TEST_F(DflyEngineTest, Bug468) {
   resp = Run({"exec"});
   ASSERT_THAT(resp, ErrArg("not an integer"));
 
-  ASSERT_FALSE(service_->IsLocked(0, "foo"));
+  ASSERT_FALSE(IsLocked(0, "foo"));
 
   resp = Run({"eval", "return redis.call('set', 'foo', 'bar', 'EX', 'moo')", "1", "foo"});
   ASSERT_THAT(resp, ErrArg("not an integer"));
 
-  ASSERT_FALSE(service_->IsLocked(0, "foo"));
+  ASSERT_FALSE(IsLocked(0, "foo"));
 }
 
 TEST_F(DflyEngineTest, Bug496) {
@@ -577,7 +577,7 @@ TEST_F(DflyEngineTest, Bug496) {
     if (shard == nullptr)
       return;
 
-    auto& db = shard->db_slice();
+    auto& db = namespaces->GetDefaultNamespace().GetCurrentDbSlice();
 
     int cb_hits = 0;
     uint32_t cb_id =

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -20,6 +20,7 @@ extern "C" {
 #include "io/proc_reader.h"
 #include "server/blocking_controller.h"
 #include "server/cluster/cluster_defs.h"
+#include "server/namespaces.h"
 #include "server/search/doc_index.h"
 #include "server/server_state.h"
 #include "server/tiered_storage.h"
@@ -285,7 +286,7 @@ void EngineShard::ForceDefrag() {
 bool EngineShard::DoDefrag() {
   // --------------------------------------------------------------------------
   // NOTE: This task is running with exclusive access to the shard.
-  // i.e. - Since we are using shared noting access here, and all access
+  // i.e. - Since we are using shared nothing access here, and all access
   // are done using fibers, This fiber is run only when no other fiber in the
   // context of the controlling thread will access this shard!
   // --------------------------------------------------------------------------
@@ -293,7 +294,8 @@ bool EngineShard::DoDefrag() {
   constexpr size_t kMaxTraverses = 40;
   const float threshold = GetFlag(FLAGS_mem_defrag_page_utilization_threshold);
 
-  auto& slice = db_slice();
+  // TODO: enable tiered storage on non-default db slice
+  DbSlice& slice = namespaces->GetDefaultNamespace().GetDbSlice(shard_->shard_id());
 
   // If we moved to an invalid db, skip as long as it's not the last one
   while (!slice.IsDbValid(defrag_state_.dbid) && defrag_state_.dbid + 1 < slice.db_array_size())
@@ -323,7 +325,7 @@ bool EngineShard::DoDefrag() {
       }
     });
     traverses_count++;
-  } while (traverses_count < kMaxTraverses && cur);
+  } while (traverses_count < kMaxTraverses && cur && namespaces != nullptr);
 
   defrag_state_.UpdateScanState(cur.value());
 
@@ -354,11 +356,14 @@ bool EngineShard::DoDefrag() {
 //     priority.
 //     otherwise lower the task priority so that it would not use the CPU when not required
 uint32_t EngineShard::DefragTask() {
+  if (namespace == nullptr || !namespaces->IsInitialized()) {
+    return util::ProactorBase::kOnIdleMaxLevel;
+  }
+
   constexpr uint32_t kRunAtLowPriority = 0u;
-  const auto shard_id = db_slice().shard_id();
 
   if (defrag_state_.CheckRequired()) {
-    VLOG(2) << shard_id << ": need to run defrag memory cursor state: " << defrag_state_.cursor;
+    VLOG(2) << shard_id_ << ": need to run defrag memory cursor state: " << defrag_state_.cursor;
     if (DoDefrag()) {
       // we didn't finish the scan
       return util::ProactorBase::kOnIdleMaxLevel;
@@ -371,13 +376,11 @@ EngineShard::EngineShard(util::ProactorBase* pb, mi_heap_t* heap)
     : queue_(1, kQueueLen),
       txq_([](const Transaction* t) { return t->txid(); }),
       mi_resource_(heap),
-      db_slice_(pb->GetPoolIndex(), GetFlag(FLAGS_cache_mode), this) {
+      shard_id_(pb->GetPoolIndex()) {
   tmp_str1 = sdsempty();
 
-  db_slice_.UpdateExpireBase(absl::GetCurrentTimeNanos() / 1000000, 0);
-  // start the defragmented task here
-  defrag_task_ = pb->AddOnIdleTask([this]() { return this->DefragTask(); });
-  queue_.Start(absl::StrCat("shard_queue_", db_slice_.shard_id()));
+  defrag_task_ = pb->AddOnIdleTask([this]() { return DefragTask(); });
+  queue_.Start(absl::StrCat("shard_queue_", shard_id()));
 }
 
 EngineShard::~EngineShard() {
@@ -421,15 +424,6 @@ void EngineShard::InitThreadLocal(ProactorBase* pb, bool update_db_time, size_t 
   CompactObj::InitThreadLocal(shard_->memory_resource());
   SmallString::InitThreadLocal(data_heap);
 
-  if (string backing_prefix = GetFlag(FLAGS_tiered_prefix); !backing_prefix.empty()) {
-    LOG_IF(FATAL, pb->GetKind() != ProactorBase::IOURING)
-        << "Only ioring based backing storage is supported. Exiting...";
-
-    shard_->tiered_storage_ = make_unique<TieredStorage>(&shard_->db_slice_, max_file_size);
-    error_code ec = shard_->tiered_storage_->Open(backing_prefix);
-    CHECK(!ec) << ec.message();
-  }
-
   RoundRobinSharder::Init();
 
   shard_->shard_search_indices_.reset(new ShardDocIndices());
@@ -440,11 +434,25 @@ void EngineShard::InitThreadLocal(ProactorBase* pb, bool update_db_time, size_t 
   }
 }
 
+void EngineShard::InitTieredStorage(ProactorBase* pb, size_t max_file_size) {
+  if (string backing_prefix = GetFlag(FLAGS_tiered_prefix); !backing_prefix.empty()) {
+    LOG_IF(FATAL, pb->GetKind() != ProactorBase::IOURING)
+        << "Only ioring based backing storage is supported. Exiting...";
+
+    // TODO: enable tiered storage on non-default namespace
+    DbSlice& db_slice = namespaces->GetDefaultNamespace().GetDbSlice(shard_id());
+    auto* shard = EngineShard::tlocal();
+    shard->tiered_storage_ = make_unique<TieredStorage>(&db_slice, max_file_size);
+    error_code ec = shard->tiered_storage_->Open(backing_prefix);
+    CHECK(!ec) << ec.message();
+  }
+}
+
 void EngineShard::DestroyThreadLocal() {
   if (!shard_)
     return;
 
-  uint32_t index = shard_->db_slice_.shard_id();
+  uint32_t index = shard_->shard_id();
   mi_heap_t* tlh = shard_->mi_resource_.heap();
 
   shard_->Shutdown();
@@ -511,10 +519,16 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
       trans = nullptr;
 
     if ((is_self && disarmed) || continuation_trans_->DisarmInShard(sid)) {
+      auto bc = continuation_trans_->GetNamespace().GetBlockingController(shard_id_);
       if (bool keep = run(continuation_trans_, false); !keep) {
         // if this holds, we can remove this check altogether.
         DCHECK(continuation_trans_ == nullptr);
         continuation_trans_ = nullptr;
+      }
+      if (bc && bc->HasAwakedTransaction()) {
+        // Break if there are any awakened transactions, as we must give way to them
+        // before continuing to handle regular transactions from the queue.
+        return;
       }
     }
   }
@@ -522,12 +536,13 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
   // Progress on the transaction queue if no transaction is running currently.
   Transaction* head = nullptr;
   while (continuation_trans_ == nullptr && !txq_.Empty()) {
+    head = get<Transaction*>(txq_.Front());
+
     // Break if there are any awakened transactions, as we must give way to them
     // before continuing to handle regular transactions from the queue.
-    if (blocking_controller_ && blocking_controller_->HasAwakedTransaction())
+    if (head->GetNamespace().GetBlockingController(shard_id_) &&
+        head->GetNamespace().GetBlockingController(shard_id_)->HasAwakedTransaction())
       break;
-
-    head = get<Transaction*>(txq_.Front());
 
     VLOG(2) << "Considering head " << head->DebugId()
             << " isarmed: " << head->DEBUG_IsArmedInShard(sid);
@@ -578,6 +593,10 @@ void EngineShard::RemoveContTx(Transaction* tx) {
 }
 
 void EngineShard::Heartbeat() {
+  if (namespaces == nullptr || !namespaces->IsInitialized()) {
+    return;
+  }
+
   CacheStats();
 
   if (IsReplica())  // Never run expiration on replica.
@@ -604,22 +623,24 @@ void EngineShard::Heartbeat() {
   DbContext db_cntx;
   db_cntx.time_now_ms = GetCurrentTimeMs();
 
-  for (unsigned i = 0; i < db_slice_.db_array_size(); ++i) {
-    if (!db_slice_.IsDbValid(i))
+  // TODO: iterate over namespaces
+  DbSlice& db_slice = namespaces->GetDefaultNamespace().GetDbSlice(shard_id());
+  for (unsigned i = 0; i < db_slice.db_array_size(); ++i) {
+    if (!db_slice.IsDbValid(i))
       continue;
 
     db_cntx.db_index = i;
-    auto [pt, expt] = db_slice_.GetTables(i);
+    auto [pt, expt] = db_slice.GetTables(i);
     if (expt->size() > pt->size() / 4) {
-      DbSlice::DeleteExpiredStats stats = db_slice_.DeleteExpiredStep(db_cntx, ttl_delete_target);
+      DbSlice::DeleteExpiredStats stats = db_slice.DeleteExpiredStep(db_cntx, ttl_delete_target);
 
       counter_[TTL_TRAVERSE].IncBy(stats.traversed);
       counter_[TTL_DELETE].IncBy(stats.deleted);
     }
 
     // if our budget is below the limit
-    if (db_slice_.memory_budget() < eviction_redline) {
-      db_slice_.FreeMemWithEvictionStep(i, eviction_redline - db_slice_.memory_budget());
+    if (db_slice.memory_budget() < eviction_redline) {
+      db_slice.FreeMemWithEvictionStep(i, eviction_redline - db_slice.memory_budget());
     }
 
     if (tiered_storage_ && UsedMemory() > tiering_redline) {
@@ -640,11 +661,12 @@ void EngineShard::RunPeriodic(std::chrono::milliseconds period_ms) {
   int64_t last_stats_time = time(nullptr);
 
   while (true) {
-    Heartbeat();
     if (fiber_periodic_done_.WaitFor(period_ms)) {
       VLOG(2) << "finished running engine shard periodic task";
       return;
     }
+
+    Heartbeat();
 
     if (runs_global_periodic) {
       ++global_count;
@@ -684,13 +706,14 @@ void EngineShard::CacheStats() {
 
   // Used memory for this shard.
   size_t used_mem = UsedMemory();
-  cached_stats[db_slice_.shard_id()].used_memory.store(used_mem, memory_order_relaxed);
+  DbSlice& db_slice = namespaces->GetDefaultNamespace().GetDbSlice(shard_id());
+  cached_stats[db_slice.shard_id()].used_memory.store(used_mem, memory_order_relaxed);
   ssize_t free_mem = max_memory_limit - used_mem_current.load(memory_order_relaxed);
 
   size_t entries = 0;
   size_t table_memory = 0;
-  for (size_t i = 0; i < db_slice_.db_array_size(); ++i) {
-    DbTable* table = db_slice_.GetDBTable(i);
+  for (size_t i = 0; i < db_slice.db_array_size(); ++i) {
+    DbTable* table = db_slice.GetDBTable(i);
     if (table) {
       entries += table->prime.size();
       table_memory += (table->prime.mem_usage() + table->expire.mem_usage());
@@ -699,20 +722,12 @@ void EngineShard::CacheStats() {
   size_t obj_memory = table_memory <= used_mem ? used_mem - table_memory : 0;
 
   size_t bytes_per_obj = entries > 0 ? obj_memory / entries : 0;
-  db_slice_.SetCachedParams(free_mem / shard_set->size(), bytes_per_obj);
+  db_slice.SetCachedParams(free_mem / shard_set->size(), bytes_per_obj);
 }
 
 size_t EngineShard::UsedMemory() const {
   return mi_resource_.used() + zmalloc_used_memory_tl + SmallString::UsedThreadLocal() +
          search_indices()->GetUsedMemory();
-}
-
-BlockingController* EngineShard::EnsureBlockingController() {
-  if (!blocking_controller_) {
-    blocking_controller_.reset(new BlockingController(this));
-  }
-
-  return blocking_controller_.get();
 }
 
 void EngineShard::TEST_EnableHeartbeat() {
@@ -734,6 +749,8 @@ auto EngineShard::AnalyzeTxQueue() const -> TxQueueInfo {
   info.tx_total = queue->size();
   unsigned max_db_id = 0;
 
+  auto& db_slice = namespaces->GetDefaultNamespace().GetCurrentDbSlice();
+
   do {
     auto value = queue->At(cur);
     Transaction* trx = std::get<Transaction*>(value);
@@ -750,7 +767,7 @@ auto EngineShard::AnalyzeTxQueue() const -> TxQueueInfo {
       if (trx->IsGlobal() || (trx->IsMulti() && trx->GetMultiMode() == Transaction::GLOBAL)) {
         info.tx_global++;
       } else {
-        const DbTable* table = db_slice().GetDBTable(trx->GetDbIndex());
+        const DbTable* table = db_slice.GetDBTable(trx->GetDbIndex());
         bool can_run = !HasContendedLocks(sid, trx, table);
         if (can_run) {
           info.tx_runnable++;
@@ -762,7 +779,7 @@ auto EngineShard::AnalyzeTxQueue() const -> TxQueueInfo {
 
   // Analyze locks
   for (unsigned i = 0; i <= max_db_id; ++i) {
-    const DbTable* table = db_slice().GetDBTable(i);
+    const DbTable* table = db_slice.GetDBTable(i);
     if (table == nullptr)
       continue;
 
@@ -852,6 +869,14 @@ void EngineShardSet::Init(uint32_t sz, bool update_db_time) {
       InitThreadLocal(pb, update_db_time, max_shard_file_size);
     }
   });
+
+  namespaces->Init();
+
+  pp_->AwaitFiberOnAll([&](uint32_t index, ProactorBase* pb) {
+    if (index < shard_queue_.size()) {
+      EngineShard::tlocal()->InitTieredStorage(pb, max_shard_file_size);
+    }
+  });
 }
 
 void EngineShardSet::Shutdown() {
@@ -873,7 +898,9 @@ void EngineShardSet::TEST_EnableHeartBeat() {
 }
 
 void EngineShardSet::TEST_EnableCacheMode() {
-  RunBriefInParallel([](EngineShard* shard) { shard->db_slice().TEST_EnableCacheMode(); });
+  RunBlockingInParallel([](EngineShard* shard) {
+    namespaces->GetDefaultNamespace().GetCurrentDbSlice().TEST_EnableCacheMode();
+  });
 }
 
 ShardId Shard(string_view v, ShardId shard_num) {

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -296,7 +296,7 @@ bool EngineShard::DoDefrag() {
   const float threshold = GetFlag(FLAGS_mem_defrag_page_utilization_threshold);
 
   // TODO: enable tiered storage on non-default db slice
-  DbSlice& slice = namespaces->GetDefaultNamespace().GetDbSlice(shard_->shard_id());
+  DbSlice& slice = Namespaces::Get().GetDefaultNamespace().GetDbSlice(shard_->shard_id());
 
   // If we moved to an invalid db, skip as long as it's not the last one
   while (!slice.IsDbValid(defrag_state_.dbid) && defrag_state_.dbid + 1 < slice.db_array_size())
@@ -326,7 +326,7 @@ bool EngineShard::DoDefrag() {
       }
     });
     traverses_count++;
-  } while (traverses_count < kMaxTraverses && cur && namespaces != nullptr);
+  } while (traverses_count < kMaxTraverses && cur && Namespaces::Get().IsInitialized());
 
   defrag_state_.UpdateScanState(cur.value());
 
@@ -357,7 +357,7 @@ bool EngineShard::DoDefrag() {
 //     priority.
 //     otherwise lower the task priority so that it would not use the CPU when not required
 uint32_t EngineShard::DefragTask() {
-  if (namespaces == nullptr || !namespaces->IsInitialized()) {
+  if (!Namespaces::Get().IsInitialized()) {
     return util::ProactorBase::kOnIdleMaxLevel;
   }
 
@@ -441,7 +441,7 @@ void EngineShard::InitTieredStorage(ProactorBase* pb, size_t max_file_size) {
         << "Only ioring based backing storage is supported. Exiting...";
 
     // TODO: enable tiered storage on non-default namespace
-    DbSlice& db_slice = namespaces->GetDefaultNamespace().GetDbSlice(shard_id());
+    DbSlice& db_slice = Namespaces::Get().GetDefaultNamespace().GetDbSlice(shard_id());
     auto* shard = EngineShard::tlocal();
     shard->tiered_storage_ = make_unique<TieredStorage>(&db_slice, max_file_size);
     error_code ec = shard->tiered_storage_->Open(backing_prefix);
@@ -621,11 +621,11 @@ void EngineShard::Heartbeat() {
   db_cntx.time_now_ms = GetCurrentTimeMs();
 
   // TODO: iterate over all namespaces
-  if (namespaces == nullptr || !namespaces->IsInitialized()) {
+  if (!Namespaces::Get().IsInitialized()) {
     return;
   }
 
-  DbSlice& db_slice = namespaces->GetDefaultNamespace().GetDbSlice(shard_id());
+  DbSlice& db_slice = Namespaces::Get().GetDefaultNamespace().GetDbSlice(shard_id());
   for (unsigned i = 0; i < db_slice.db_array_size(); ++i) {
     if (!db_slice.IsDbValid(i))
       continue;
@@ -667,7 +667,7 @@ void EngineShard::RunPeriodic(std::chrono::milliseconds period_ms) {
       return;
     }
 
-    if (namespaces == nullptr || !namespaces->IsInitialized())
+    if (!Namespaces::Get().IsInitialized())
       continue;
 
     Heartbeat();
@@ -705,7 +705,7 @@ void EngineShard::RunPeriodic(std::chrono::milliseconds period_ms) {
 }
 
 void EngineShard::CacheStats() {
-  if (namespaces == nullptr || !namespaces->IsInitialized()) {
+  if (!Namespaces::Get().IsInitialized()) {
     return;
   }
 
@@ -714,7 +714,7 @@ void EngineShard::CacheStats() {
 
   // Used memory for this shard.
   size_t used_mem = UsedMemory();
-  DbSlice& db_slice = namespaces->GetDefaultNamespace().GetDbSlice(shard_id());
+  DbSlice& db_slice = Namespaces::Get().GetDefaultNamespace().GetDbSlice(shard_id());
   cached_stats[db_slice.shard_id()].used_memory.store(used_mem, memory_order_relaxed);
   ssize_t free_mem = max_memory_limit - used_mem_current.load(memory_order_relaxed);
 
@@ -757,7 +757,7 @@ auto EngineShard::AnalyzeTxQueue() const -> TxQueueInfo {
   info.tx_total = queue->size();
   unsigned max_db_id = 0;
 
-  auto& db_slice = namespaces->GetDefaultNamespace().GetCurrentDbSlice();
+  auto& db_slice = Namespaces::Get().GetDefaultNamespace().GetCurrentDbSlice();
 
   do {
     auto value = queue->At(cur);
@@ -878,7 +878,7 @@ void EngineShardSet::Init(uint32_t sz, bool update_db_time) {
     }
   });
 
-  namespaces->Init();
+  Namespaces::Get().Init();
 
   pp_->AwaitFiberOnAll([&](uint32_t index, ProactorBase* pb) {
     if (index < shard_queue_.size()) {
@@ -907,7 +907,7 @@ void EngineShardSet::TEST_EnableHeartBeat() {
 
 void EngineShardSet::TEST_EnableCacheMode() {
   RunBlockingInParallel([](EngineShard* shard) {
-    namespaces->GetDefaultNamespace().GetCurrentDbSlice().TEST_EnableCacheMode();
+    Namespaces::Get().GetDefaultNamespace().GetCurrentDbSlice().TEST_EnableCacheMode();
   });
 }
 

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -593,10 +593,6 @@ void EngineShard::RemoveContTx(Transaction* tx) {
 }
 
 void EngineShard::Heartbeat() {
-  if (namespaces == nullptr || !namespaces->IsInitialized()) {
-    return;
-  }
-
   CacheStats();
 
   if (IsReplica())  // Never run expiration on replica.
@@ -623,7 +619,11 @@ void EngineShard::Heartbeat() {
   DbContext db_cntx;
   db_cntx.time_now_ms = GetCurrentTimeMs();
 
-  // TODO: iterate over namespaces
+  // TODO: iterate over all namespaces
+  if (namespaces == nullptr || !namespaces->IsInitialized()) {
+    return;
+  }
+
   DbSlice& db_slice = namespaces->GetDefaultNamespace().GetDbSlice(shard_id());
   for (unsigned i = 0; i < db_slice.db_array_size(); ++i) {
     if (!db_slice.IsDbValid(i))
@@ -704,6 +704,10 @@ void EngineShard::RunPeriodic(std::chrono::milliseconds period_ms) {
 }
 
 void EngineShard::CacheStats() {
+  if (namespaces == nullptr || !namespaces->IsInitialized()) {
+    return;
+  }
+
   // mi_heap_visit_blocks(tlh, false /* visit all blocks*/, visit_cb, &sum);
   mi_stats_merge();
 

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -356,7 +356,7 @@ bool EngineShard::DoDefrag() {
 //     priority.
 //     otherwise lower the task priority so that it would not use the CPU when not required
 uint32_t EngineShard::DefragTask() {
-  if (namespace == nullptr || !namespaces->IsInitialized()) {
+  if (namespaces == nullptr || !namespaces->IsInitialized()) {
     return util::ProactorBase::kOnIdleMaxLevel;
   }
 

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -666,6 +666,9 @@ void EngineShard::RunPeriodic(std::chrono::milliseconds period_ms) {
       return;
     }
 
+    if (namespaces == nullptr || !namespaces->IsInitialized())
+      continue;
+
     Heartbeat();
 
     if (runs_global_periodic) {

--- a/src/server/engine_shard_set.h
+++ b/src/server/engine_shard_set.h
@@ -50,6 +50,9 @@ class EngineShard {
   // If update_db_time is true, initializes periodic time update for its db_slice.
   static void InitThreadLocal(util::ProactorBase* pb, bool update_db_time, size_t max_file_size);
 
+  // Must be called after all InitThreadLocal() have finished
+  void InitTieredStorage(util::ProactorBase* pb, size_t max_file_size);
+
   static void DestroyThreadLocal();
 
   static EngineShard* tlocal() {
@@ -57,15 +60,7 @@ class EngineShard {
   }
 
   ShardId shard_id() const {
-    return db_slice_.shard_id();
-  }
-
-  DbSlice& db_slice() {
-    return db_slice_;
-  }
-
-  const DbSlice& db_slice() const {
-    return db_slice_;
+    return shard_id_;
   }
 
   PMR_NS::memory_resource* memory_resource() {
@@ -119,12 +114,6 @@ class EngineShard {
 
   ShardDocIndices* search_indices() const {
     return shard_search_indices_.get();
-  }
-
-  BlockingController* EnsureBlockingController();
-
-  BlockingController* blocking_controller() {
-    return blocking_controller_.get();
   }
 
   // for everyone to use for string transformations during atomic cpu sequences.
@@ -234,7 +223,7 @@ class EngineShard {
 
   TxQueue txq_;
   MiMemoryResource mi_resource_;
-  DbSlice db_slice_;
+  ShardId shard_id_;
 
   Stats stats_;
 
@@ -253,8 +242,8 @@ class EngineShard {
 
   DefragTaskState defrag_state_;
   std::unique_ptr<TieredStorage> tiered_storage_;
+  // TODO: Move indices to Namespace
   std::unique_ptr<ShardDocIndices> shard_search_indices_;
-  std::unique_ptr<BlockingController> blocking_controller_;
 
   using Counter = util::SlidingCounter<7>;
 

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1357,6 +1357,7 @@ void GenericFamily::Select(CmdArgList args, ConnectionContext* cntx) {
   }
   cntx->conn_state.db_index = index;
   auto cb = [cntx, index](EngineShard* shard) {
+    CHECK(cntx->ns != nullptr);
     auto& db_slice = cntx->ns->GetCurrentDbSlice();
     db_slice.ActivateDb(index);
     return OpStatus::OK;

--- a/src/server/journal/executor.cc
+++ b/src/server/journal/executor.cc
@@ -44,6 +44,7 @@ JournalExecutor::JournalExecutor(Service* service)
   conn_context_.is_replicating = true;
   conn_context_.journal_emulated = true;
   conn_context_.skip_acl_validation = true;
+  conn_context_.ns = &namespaces->GetDefaultNamespace();
 }
 
 JournalExecutor::~JournalExecutor() {

--- a/src/server/journal/executor.cc
+++ b/src/server/journal/executor.cc
@@ -44,7 +44,7 @@ JournalExecutor::JournalExecutor(Service* service)
   conn_context_.is_replicating = true;
   conn_context_.journal_emulated = true;
   conn_context_.skip_acl_validation = true;
-  conn_context_.ns = &namespaces->GetDefaultNamespace();
+  conn_context_.ns = &Namespaces::Get().GetDefaultNamespace();
 }
 
 JournalExecutor::~JournalExecutor() {

--- a/src/server/list_family_test.cc
+++ b/src/server/list_family_test.cc
@@ -32,8 +32,10 @@ class ListFamilyTest : public BaseFamilyTest {
 
   static unsigned NumWatched() {
     atomic_uint32_t sum{0};
+
+    auto ns = &namespaces->GetDefaultNamespace();
     shard_set->RunBriefInParallel([&](EngineShard* es) {
-      auto* bc = es->blocking_controller();
+      auto* bc = ns->GetBlockingController(es->shard_id());
       if (bc)
         sum.fetch_add(bc->NumWatched(0), memory_order_relaxed);
     });
@@ -43,8 +45,9 @@ class ListFamilyTest : public BaseFamilyTest {
 
   static bool HasAwakened() {
     atomic_uint32_t sum{0};
+    auto ns = &namespaces->GetDefaultNamespace();
     shard_set->RunBriefInParallel([&](EngineShard* es) {
-      auto* bc = es->blocking_controller();
+      auto* bc = ns->GetBlockingController(es->shard_id());
       if (bc)
         sum.fetch_add(bc->HasAwakedTransaction(), memory_order_relaxed);
     });
@@ -168,7 +171,7 @@ TEST_F(ListFamilyTest, BLPopTimeout) {
   RespExpr resp = Run({"blpop", kKey1, kKey2, kKey3, "0.01"});
   EXPECT_THAT(resp, ArgType(RespExpr::NIL_ARRAY));
   EXPECT_EQ(3, GetDebugInfo().shards_count);
-  ASSERT_FALSE(service_->IsLocked(0, kKey1));
+  ASSERT_FALSE(IsLocked(0, kKey1));
 
   // Under Multi
   resp = Run({"multi"});
@@ -178,7 +181,7 @@ TEST_F(ListFamilyTest, BLPopTimeout) {
   resp = Run({"exec"});
 
   EXPECT_THAT(resp, ArgType(RespExpr::NIL_ARRAY));
-  ASSERT_FALSE(service_->IsLocked(0, kKey1));
+  ASSERT_FALSE(IsLocked(0, kKey1));
   ASSERT_EQ(0, NumWatched());
 }
 

--- a/src/server/list_family_test.cc
+++ b/src/server/list_family_test.cc
@@ -33,7 +33,7 @@ class ListFamilyTest : public BaseFamilyTest {
   static unsigned NumWatched() {
     atomic_uint32_t sum{0};
 
-    auto ns = &namespaces->GetDefaultNamespace();
+    auto ns = &Namespaces::Get().GetDefaultNamespace();
     shard_set->RunBriefInParallel([&](EngineShard* es) {
       auto* bc = ns->GetBlockingController(es->shard_id());
       if (bc)
@@ -45,7 +45,7 @@ class ListFamilyTest : public BaseFamilyTest {
 
   static bool HasAwakened() {
     atomic_uint32_t sum{0};
-    auto ns = &namespaces->GetDefaultNamespace();
+    auto ns = &Namespaces::Get().GetDefaultNamespace();
     shard_set->RunBriefInParallel([&](EngineShard* es) {
       auto* bc = ns->GetBlockingController(es->shard_id());
       if (bc)

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1235,6 +1235,7 @@ void Service::DispatchCommand(CmdArgList args, facade::ConnectionContext* cntx) 
       dist_trans.reset(new Transaction{cid});
 
       if (!dist_trans->IsMulti()) {  // Multi command initialize themself based on their mode.
+        CHECK(dfly_cntx->ns != nullptr);
         if (auto st =
                 dist_trans->InitByArgs(dfly_cntx->ns, dfly_cntx->conn_state.db_index, args_no_cmd);
             st != OpStatus::OK)

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -818,8 +818,10 @@ Service::Service(ProactorPool* pp)
 
   CHECK(shard_set == nullptr);
   shard_set = new EngineShardSet(pp);
+
   CHECK(namespaces == nullptr);
   namespaces = new Namespaces();
+  atomic_thread_fence(memory_order_release);
 
   // We support less than 1024 threads and we support less than 1024 shards.
   // For example, Scan uses 10 bits in cursor to encode shard id it currently traverses.

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -102,7 +102,7 @@ class Service : public facade::ServiceInterface {
   }
 
   // Used by tests.
-  bool IsLocked(DbIndex db_index, std::string_view key) const;
+  bool IsLocked(Namespace* ns, DbIndex db_index, std::string_view key) const;
   bool IsShardSetLocked() const;
 
   util::ProactorPool& proactor_pool() {

--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -24,6 +24,7 @@
 #include "server/server_family.h"
 #include "server/server_state.h"
 #include "server/snapshot.h"
+#include "server/transaction.h"
 
 using namespace std;
 using namespace facade;
@@ -241,7 +242,7 @@ void PushMemoryUsageStats(const base::IoBuf::MemoryUsage& mem, string_view prefi
 void MemoryCmd::Stats() {
   vector<pair<string, size_t>> stats;
   stats.reserve(25);
-  auto server_metrics = owner_->GetMetrics();
+  auto server_metrics = owner_->GetMetrics(cntx_->ns);
 
   // RSS
   stats.push_back({"rss_bytes", rss_mem_current.load(memory_order_relaxed)});
@@ -354,7 +355,7 @@ void MemoryCmd::ArenaStats(CmdArgList args) {
 void MemoryCmd::Usage(std::string_view key) {
   ShardId sid = Shard(key, shard_set->size());
   ssize_t memory_usage = shard_set->pool()->at(sid)->AwaitBrief([key, this]() -> ssize_t {
-    auto& db_slice = EngineShard::tlocal()->db_slice();
+    auto& db_slice = cntx_->ns->GetCurrentDbSlice();
     auto [pt, exp_t] = db_slice.GetTables(cntx_->db_index());
     PrimeIterator it = pt->Find(key);
     if (IsValid(it)) {

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -146,7 +146,7 @@ bool MultiCommandSquasher::ExecuteStandalone(StoredCmd* cmd) {
   cntx_->cid = cmd->Cid();
 
   if (cmd->Cid()->IsTransactional())
-    tx->InitByArgs(cntx_->conn_state.db_index, args);
+    tx->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, args);
   service_->InvokeCmd(cmd->Cid(), args, cntx_);
 
   return true;
@@ -182,7 +182,7 @@ OpStatus MultiCommandSquasher::SquashedHopCb(Transaction* parent_tx, EngineShard
     local_cntx.cid = cmd->Cid();
     crb.SetReplyMode(cmd->ReplyMode());
 
-    local_tx->InitByArgs(local_cntx.conn_state.db_index, args);
+    local_tx->InitByArgs(cntx_->ns, local_cntx.conn_state.db_index, args);
     service_->InvokeCmd(cmd->Cid(), args, &local_cntx);
 
     sinfo.replies.emplace_back(crb.Take());

--- a/src/server/namespaces.cc
+++ b/src/server/namespaces.cc
@@ -65,7 +65,6 @@ bool Namespaces::IsInitialized() const {
 }
 
 Namespace& Namespaces::GetDefaultNamespace() const {
-  CHECK(const_cast<Namespaces*>(this) != nullptr);  // Remove compiler warning
   CHECK(default_namespace_ != nullptr);
   return *default_namespace_;
 }

--- a/src/server/namespaces.cc
+++ b/src/server/namespaces.cc
@@ -65,6 +65,7 @@ bool Namespaces::IsInitialized() const {
 }
 
 Namespace& Namespaces::GetDefaultNamespace() const {
+  CHECK(this != nullptr);
   CHECK(default_namespace_ != nullptr);
   return *default_namespace_;
 }

--- a/src/server/namespaces.cc
+++ b/src/server/namespaces.cc
@@ -65,7 +65,7 @@ bool Namespaces::IsInitialized() const {
 }
 
 Namespace& Namespaces::GetDefaultNamespace() const {
-  CHECK(this != nullptr);
+  CHECK(const_cast<Namespaces*>(this) != nullptr);  // Remove compiler warning
   CHECK(default_namespace_ != nullptr);
   return *default_namespace_;
 }

--- a/src/server/namespaces.cc
+++ b/src/server/namespaces.cc
@@ -1,0 +1,77 @@
+#include "server/namespaces.h"
+
+#include "base/flags.h"
+#include "base/logging.h"
+#include "server/engine_shard_set.h"
+
+ABSL_DECLARE_FLAG(bool, cache_mode);
+
+namespace dfly {
+
+using namespace std;
+
+Namespaces* namespaces = nullptr;
+
+Namespace::Namespace() {
+  shard_db_slices_.resize(shard_set->size());
+  shard_blocking_controller_.resize(shard_set->size());
+  shard_set->RunBriefInParallel([&](EngineShard* es) {
+    CHECK(es != nullptr);
+    ShardId sid = es->shard_id();
+    shard_db_slices_[sid] = make_unique<DbSlice>(sid, absl::GetFlag(FLAGS_cache_mode), es);
+    shard_db_slices_[sid]->UpdateExpireBase(absl::GetCurrentTimeNanos() / 1000000, 0);
+  });
+}
+
+DbSlice& Namespace::GetCurrentDbSlice() {
+  EngineShard* es = EngineShard::tlocal();
+  CHECK(es != nullptr);
+  return GetDbSlice(es->shard_id());
+}
+
+DbSlice& Namespace::GetDbSlice(ShardId sid) {
+  CHECK_LT(sid, shard_db_slices_.size());
+  return *shard_db_slices_[sid];
+}
+
+BlockingController* Namespace::GetOrAddBlockingController(EngineShard* shard) {
+  if (!shard_blocking_controller_[shard->shard_id()]) {
+    shard_blocking_controller_[shard->shard_id()] = make_unique<BlockingController>(shard, this);
+  }
+
+  return shard_blocking_controller_[shard->shard_id()].get();
+}
+
+BlockingController* Namespace::GetBlockingController(ShardId sid) {
+  return shard_blocking_controller_[sid].get();
+}
+
+Namespaces::~Namespaces() {
+  shard_set->RunBriefInParallel([&](EngineShard* es) {
+    CHECK(es != nullptr);
+    for (auto& ns : namespaces_) {
+      ns.second.shard_db_slices_[es->shard_id()].reset();
+    }
+  });
+}
+
+void Namespaces::Init() {
+  DCHECK(default_namespace_ == nullptr);
+  default_namespace_ = &GetOrInsert("");
+}
+
+bool Namespaces::IsInitialized() const {
+  return default_namespace_ != nullptr;
+}
+
+Namespace& Namespaces::GetDefaultNamespace() const {
+  CHECK(default_namespace_ != nullptr);
+  return *default_namespace_;
+}
+
+Namespace& Namespaces::GetOrInsert(std::string_view ns) {
+  std::lock_guard guard(mu_);
+  return namespaces_[ns];
+}
+
+}  // namespace dfly

--- a/src/server/namespaces.h
+++ b/src/server/namespaces.h
@@ -36,8 +36,8 @@ class Namespace {
 
 class Namespaces {
  public:
-  Namespaces() = default;
-  ~Namespaces();
+  static void Destroy();
+  static Namespaces& Get();
 
   void Init();
   bool IsInitialized() const;
@@ -46,11 +46,12 @@ class Namespaces {
   Namespace& GetOrInsert(std::string_view ns);
 
  private:
+  Namespaces() = default;
+  ~Namespaces();
+
   util::fb2::Mutex mu_{};
   absl::node_hash_map<std::string, Namespace> namespaces_ ABSL_GUARDED_BY(mu_);
   Namespace* default_namespace_ = nullptr;
 };
-
-extern Namespaces* namespaces;
 
 }  // namespace dfly

--- a/src/server/namespaces.h
+++ b/src/server/namespaces.h
@@ -1,0 +1,56 @@
+// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <absl/container/node_hash_map.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "server/blocking_controller.h"
+#include "server/db_slice.h"
+#include "server/tx_base.h"
+#include "util/fibers/synchronization.h"
+
+namespace dfly {
+
+class Namespace {
+ public:
+  explicit Namespace();
+
+  DbSlice& GetCurrentDbSlice();
+
+  DbSlice& GetDbSlice(ShardId sid);
+  BlockingController* GetOrAddBlockingController(EngineShard* shard);
+  BlockingController* GetBlockingController(ShardId sid);
+
+ private:
+  std::vector<std::unique_ptr<DbSlice>> shard_db_slices_;
+  std::vector<std::unique_ptr<BlockingController>> shard_blocking_controller_;
+
+  friend class Namespaces;
+};
+
+class Namespaces {
+ public:
+  Namespaces() = default;
+  ~Namespaces();
+
+  void Init();
+  bool IsInitialized() const;
+
+  Namespace& GetDefaultNamespace() const;  // No locks
+  Namespace& GetOrInsert(std::string_view ns);
+
+ private:
+  util::fb2::Mutex mu_{};
+  absl::node_hash_map<std::string, Namespace> namespaces_ ABSL_GUARDED_BY(mu_);
+  Namespace* default_namespace_ = nullptr;
+};
+
+extern Namespaces* namespaces;
+
+}  // namespace dfly

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2550,6 +2550,7 @@ void RdbLoader::LoadSearchIndexDefFromAux(string&& def) {
   cntx.is_replicating = true;
   cntx.journal_emulated = true;
   cntx.skip_acl_validation = true;
+  cntx.ns = &namespaces->GetDefaultNamespace();
 
   // Avoid deleting local crb
   absl::Cleanup cntx_clean = [&cntx] { cntx.Inject(nullptr); };

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2064,8 +2064,9 @@ error_code RdbLoader::Load(io::Source* src) {
         FlushShardAsync(i);
 
         // Active database if not existed before.
-        shard_set->Add(
-            i, [dbid] { namespaces->GetDefaultNamespace().GetCurrentDbSlice().ActivateDb(dbid); });
+        shard_set->Add(i, [dbid] {
+          Namespaces::Get().GetDefaultNamespace().GetCurrentDbSlice().ActivateDb(dbid);
+        });
       }
 
       cur_db_index_ = dbid;
@@ -2440,7 +2441,7 @@ std::error_code RdbLoaderBase::FromOpaque(const OpaqueObj& opaque, CompactObj* p
 }
 
 void RdbLoader::LoadItemsBuffer(DbIndex db_ind, const ItemsBuf& ib) {
-  DbContext db_cntx{&namespaces->GetDefaultNamespace(), db_ind, GetCurrentTimeMs()};
+  DbContext db_cntx{&Namespaces::Get().GetDefaultNamespace(), db_ind, GetCurrentTimeMs()};
   DbSlice& db_slice = db_cntx.ns->GetCurrentDbSlice();
 
   for (const auto* item : ib) {
@@ -2550,7 +2551,7 @@ void RdbLoader::LoadSearchIndexDefFromAux(string&& def) {
   cntx.is_replicating = true;
   cntx.journal_emulated = true;
   cntx.skip_acl_validation = true;
-  cntx.ns = &namespaces->GetDefaultNamespace();
+  cntx.ns = &Namespaces::Get().GetDefaultNamespace();
 
   // Avoid deleting local crb
   absl::Cleanup cntx_clean = [&cntx] { cntx.Inject(nullptr); };
@@ -2600,8 +2601,8 @@ void RdbLoader::PerformPostLoad(Service* service) {
 
   // Rebuild all search indices as only their definitions are extracted from the snapshot
   shard_set->AwaitRunningOnShardQueue([](EngineShard* es) {
-    es->search_indices()->RebuildAllIndices(
-        OpArgs{es, nullptr, DbContext{&namespaces->GetDefaultNamespace(), 0, GetCurrentTimeMs()}});
+    es->search_indices()->RebuildAllIndices(OpArgs{
+        es, nullptr, DbContext{&Namespaces::Get().GetDefaultNamespace(), 0, GetCurrentTimeMs()}});
   });
 }
 

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -35,6 +35,7 @@ extern "C" {
 #include "server/engine_shard_set.h"
 #include "server/error.h"
 #include "server/main_service.h"
+#include "server/namespaces.h"
 #include "server/rdb_extensions.h"
 #include "server/search/doc_index.h"
 #include "server/serializer_commons.h"
@@ -1251,15 +1252,17 @@ error_code RdbSaver::Impl::ConsumeChannel(const Cancellation* cll) {
 void RdbSaver::Impl::StartSnapshotting(bool stream_journal, const Cancellation* cll,
                                        EngineShard* shard) {
   auto& s = GetSnapshot(shard);
-  s = std::make_unique<SliceSnapshot>(&shard->db_slice(), &channel_, compression_mode_);
+  auto& db_slice = namespaces->GetDefaultNamespace().GetCurrentDbSlice();
+  s = std::make_unique<SliceSnapshot>(&db_slice, &channel_, compression_mode_);
 
   s->Start(stream_journal, cll);
 }
 
 void RdbSaver::Impl::StartIncrementalSnapshotting(Context* cntx, EngineShard* shard,
                                                   LSN start_lsn) {
+  auto& db_slice = namespaces->GetDefaultNamespace().GetCurrentDbSlice();
   auto& s = GetSnapshot(shard);
-  s = std::make_unique<SliceSnapshot>(&shard->db_slice(), &channel_, compression_mode_);
+  s = std::make_unique<SliceSnapshot>(&db_slice, &channel_, compression_mode_);
 
   s->StartIncremental(cntx, start_lsn);
 }

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -1252,7 +1252,7 @@ error_code RdbSaver::Impl::ConsumeChannel(const Cancellation* cll) {
 void RdbSaver::Impl::StartSnapshotting(bool stream_journal, const Cancellation* cll,
                                        EngineShard* shard) {
   auto& s = GetSnapshot(shard);
-  auto& db_slice = namespaces->GetDefaultNamespace().GetCurrentDbSlice();
+  auto& db_slice = Namespaces::Get().GetDefaultNamespace().GetCurrentDbSlice();
   s = std::make_unique<SliceSnapshot>(&db_slice, &channel_, compression_mode_);
 
   s->Start(stream_journal, cll);
@@ -1260,7 +1260,7 @@ void RdbSaver::Impl::StartSnapshotting(bool stream_journal, const Cancellation* 
 
 void RdbSaver::Impl::StartIncrementalSnapshotting(Context* cntx, EngineShard* shard,
                                                   LSN start_lsn) {
-  auto& db_slice = namespaces->GetDefaultNamespace().GetCurrentDbSlice();
+  auto& db_slice = Namespaces::Get().GetDefaultNamespace().GetCurrentDbSlice();
   auto& s = GetSnapshot(shard);
   s = std::make_unique<SliceSnapshot>(&db_slice, &channel_, compression_mode_);
 

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -570,6 +570,7 @@ error_code Replica::ConsumeRedisStream() {
   conn_context.is_replicating = true;
   conn_context.journal_emulated = true;
   conn_context.skip_acl_validation = true;
+  conn_context.ns = &namespaces->GetDefaultNamespace();
   ResetParser(true);
 
   // Master waits for this command in order to start sending replication stream.

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -570,7 +570,7 @@ error_code Replica::ConsumeRedisStream() {
   conn_context.is_replicating = true;
   conn_context.journal_emulated = true;
   conn_context.skip_acl_validation = true;
-  conn_context.ns = &namespaces->GetDefaultNamespace();
+  conn_context.ns = &Namespaces::Get().GetDefaultNamespace();
   ResetParser(true);
 
   // Master waits for this command in order to start sending replication stream.

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -8,6 +8,7 @@
 #include "base/logging.h"
 #include "facade/facade_test.h"
 #include "server/command_registry.h"
+#include "server/namespaces.h"
 #include "server/test_utils.h"
 
 using namespace testing;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1345,7 +1345,7 @@ void ServerFamily::ConfigureMetrics(util::HttpListenerBase* http_base) {
 
   auto cb = [this](const util::http::QueryArgs& args, util::HttpContext* send) {
     StringResponse resp = util::http::MakeStringResponse(boost::beast::http::status::ok);
-    PrintPrometheusMetrics(this->GetMetrics(&namespaces->GetDefaultNamespace()),
+    PrintPrometheusMetrics(this->GetMetrics(&Namespaces::Get().GetDefaultNamespace()),
                            this->dfly_cmd_.get(), &resp);
 
     return send->Invoke(std::move(resp));
@@ -1425,7 +1425,7 @@ void ServerFamily::StatsMC(std::string_view section, facade::ConnectionContext* 
   double utime = dbl_time(ru.ru_utime);
   double systime = dbl_time(ru.ru_stime);
 
-  Metrics m = GetMetrics(&namespaces->GetDefaultNamespace());
+  Metrics m = GetMetrics(&Namespaces::Get().GetDefaultNamespace());
 
   ADD_LINE(pid, getpid());
   ADD_LINE(uptime, m.uptime);
@@ -1455,7 +1455,7 @@ GenericError ServerFamily::DoSave(bool ignore_state) {
   const CommandId* cid = service().FindCmd("SAVE");
   CHECK_NOTNULL(cid);
   boost::intrusive_ptr<Transaction> trans(new Transaction{cid});
-  trans->InitByArgs(&namespaces->GetDefaultNamespace(), 0, {});
+  trans->InitByArgs(&Namespaces::Get().GetDefaultNamespace(), 0, {});
   return DoSave(absl::GetFlag(FLAGS_df_snapshot_format), {}, trans.get(), ignore_state);
 }
 
@@ -1648,7 +1648,7 @@ void ServerFamily::Auth(CmdArgList args, ConnectionContext* cntx) {
       auto cred = registry->GetCredentials(username);
       cntx->acl_commands = cred.acl_commands;
       cntx->keys = std::move(cred.keys);
-      cntx->ns = &namespaces->GetOrInsert(cred.ns);
+      cntx->ns = &Namespaces::Get().GetOrInsert(cred.ns);
       cntx->authenticated = true;
       return cntx->SendOk();
     }
@@ -2592,7 +2592,7 @@ void ServerFamily::ReplicaOf(CmdArgList args, ConnectionContext* cntx) {
 void ServerFamily::Replicate(string_view host, string_view port) {
   io::NullSink sink;
   ConnectionContext cntx{&sink, nullptr, {}};
-  cntx.ns = &namespaces->GetDefaultNamespace();
+  cntx.ns = &Namespaces::Get().GetDefaultNamespace();
   cntx.skip_acl_validation = true;
 
   StringVec replicaof_params{string(host), string(port)};

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -15,6 +15,7 @@
 #include "server/detail/save_stages_controller.h"
 #include "server/dflycmd.h"
 #include "server/engine_shard_set.h"
+#include "server/namespaces.h"
 #include "server/replica.h"
 #include "server/server_state.h"
 #include "util/fibers/fiberqueue_threadpool.h"
@@ -158,9 +159,9 @@ class ServerFamily {
     return service_;
   }
 
-  void ResetStat();
+  void ResetStat(Namespace* ns);
 
-  Metrics GetMetrics() const;
+  Metrics GetMetrics(Namespace* ns) const;
 
   ScriptMgr* script_mgr() {
     return script_mgr_.get();
@@ -337,7 +338,7 @@ class ServerFamily {
 };
 
 // Reusable CLIENT PAUSE implementation that blocks while polling is_pause_in_progress
-std::optional<util::fb2::Fiber> Pause(std::vector<facade::Listener*> listeners,
+std::optional<util::fb2::Fiber> Pause(std::vector<facade::Listener*> listeners, Namespace* ns,
                                       facade::Connection* conn, ClientPause pause_state,
                                       std::function<bool()> is_pause_in_progress);
 

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -469,8 +469,7 @@ SvArray ToSvArray(const absl::flat_hash_set<std::string_view>& set) {
 // if overwrite is true then OpAdd writes vals into the key and discards its previous value.
 OpResult<uint32_t> OpAdd(const OpArgs& op_args, std::string_view key, const NewEntries& vals,
                          bool overwrite, bool journal_update) {
-  auto* es = op_args.shard;
-  auto& db_slice = es->db_slice();
+  auto& db_slice = op_args.db_cntx.ns->GetCurrentDbSlice();
   auto vals_it = EntriesRange(vals);
 
   VLOG(2) << "OpAdd(" << key << ")";
@@ -480,7 +479,7 @@ OpResult<uint32_t> OpAdd(const OpArgs& op_args, std::string_view key, const NewE
   // key if it exists.
   if (overwrite && (vals_it.begin() == vals_it.end())) {
     auto it = db_slice.FindMutable(op_args.db_cntx, key).it;  // post_updater will run immediately
-    db_slice.Del(op_args.db_cntx.db_index, it);
+    db_slice.Del(op_args.db_cntx, it);
     if (journal_update && op_args.shard->journal()) {
       RecordJournal(op_args, "DEL"sv, ArgSlice{key});
     }
@@ -555,8 +554,7 @@ OpResult<uint32_t> OpAdd(const OpArgs& op_args, std::string_view key, const NewE
 
 OpResult<uint32_t> OpAddEx(const OpArgs& op_args, string_view key, uint32_t ttl_sec,
                            const NewEntries& vals) {
-  auto* es = op_args.shard;
-  auto& db_slice = es->db_slice();
+  auto& db_slice = op_args.db_cntx.ns->GetCurrentDbSlice();
 
   auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
   RETURN_ON_BAD_STATUS(op_res);
@@ -591,8 +589,7 @@ OpResult<uint32_t> OpAddEx(const OpArgs& op_args, string_view key, uint32_t ttl_
 
 OpResult<uint32_t> OpRem(const OpArgs& op_args, string_view key, facade::ArgRange vals,
                          bool journal_rewrite) {
-  auto* es = op_args.shard;
-  auto& db_slice = es->db_slice();
+  auto& db_slice = op_args.db_cntx.ns->GetCurrentDbSlice();
   auto find_res = db_slice.FindMutable(op_args.db_cntx, key, OBJ_SET);
   if (!find_res) {
     return find_res.status();
@@ -604,7 +601,7 @@ OpResult<uint32_t> OpRem(const OpArgs& op_args, string_view key, facade::ArgRang
   find_res->post_updater.Run();
 
   if (isempty) {
-    CHECK(db_slice.Del(op_args.db_cntx.db_index, find_res->it));
+    CHECK(db_slice.Del(op_args.db_cntx, find_res->it));
   }
   if (journal_rewrite && op_args.shard->journal()) {
     vector<string_view> mapped(vals.Size() + 1);
@@ -638,6 +635,7 @@ class Mover {
 };
 
 OpStatus Mover::OpFind(Transaction* t, EngineShard* es) {
+  auto& db_slice = t->GetCurrentDbSlice();
   ShardArgs largs = t->GetShardArgs(es->shard_id());
 
   // In case both src and dest are in the same shard, largs size will be 2.
@@ -645,7 +643,7 @@ OpStatus Mover::OpFind(Transaction* t, EngineShard* es) {
 
   for (auto k : largs) {
     unsigned index = (k == src_) ? 0 : 1;
-    auto res = es->db_slice().FindReadOnly(t->GetDbContext(), k, OBJ_SET);
+    auto res = db_slice.FindReadOnly(t->GetDbContext(), k, OBJ_SET);
     if (res && index == 0) {  // successful src find.
       DCHECK(!res->is_done());
       const CompactObj& val = res.value()->second;
@@ -713,7 +711,8 @@ OpResult<StringVec> OpUnion(const OpArgs& op_args, ShardArgs::Iterator start,
   absl::flat_hash_set<string> uniques;
 
   for (; start != end; ++start) {
-    auto find_res = op_args.shard->db_slice().FindReadOnly(op_args.db_cntx, *start, OBJ_SET);
+    auto find_res =
+        op_args.db_cntx.ns->GetCurrentDbSlice().FindReadOnly(op_args.db_cntx, *start, OBJ_SET);
     if (find_res) {
       const PrimeValue& pv = find_res.value()->second;
       if (IsDenseEncoding(pv)) {
@@ -738,10 +737,10 @@ OpResult<StringVec> OpUnion(const OpArgs& op_args, ShardArgs::Iterator start,
 // Read-only OpDiff op on sets.
 OpResult<StringVec> OpDiff(const OpArgs& op_args, ShardArgs::Iterator start,
                            ShardArgs::Iterator end) {
+  auto& db_slice = op_args.db_cntx.ns->GetCurrentDbSlice();
   DCHECK(start != end);
   DVLOG(1) << "OpDiff from " << *start;
-  EngineShard* es = op_args.shard;
-  auto find_res = es->db_slice().FindReadOnly(op_args.db_cntx, *start, OBJ_SET);
+  auto find_res = db_slice.FindReadOnly(op_args.db_cntx, *start, OBJ_SET);
 
   if (!find_res) {
     return find_res.status();
@@ -762,7 +761,7 @@ OpResult<StringVec> OpDiff(const OpArgs& op_args, ShardArgs::Iterator start,
   DCHECK(!uniques.empty());  // otherwise the key would not exist.
 
   for (++start; start != end; ++start) {
-    auto diff_res = es->db_slice().FindReadOnly(op_args.db_cntx, *start, OBJ_SET);
+    auto diff_res = db_slice.FindReadOnly(op_args.db_cntx, *start, OBJ_SET);
     if (!diff_res) {
       if (diff_res.status() == OpStatus::WRONG_TYPE) {
         return OpStatus::WRONG_TYPE;
@@ -791,6 +790,7 @@ OpResult<StringVec> OpDiff(const OpArgs& op_args, ShardArgs::Iterator start,
 
 // Read-only OpInter op on sets.
 OpResult<StringVec> OpInter(const Transaction* t, EngineShard* es, bool remove_first) {
+  auto& db_slice = t->GetCurrentDbSlice();
   ShardArgs args = t->GetShardArgs(es->shard_id());
   auto it = args.begin();
   if (remove_first) {
@@ -800,7 +800,7 @@ OpResult<StringVec> OpInter(const Transaction* t, EngineShard* es, bool remove_f
 
   StringVec result;
   if (args.Size() == 1 + unsigned(remove_first)) {
-    auto find_res = es->db_slice().FindReadOnly(t->GetDbContext(), *it, OBJ_SET);
+    auto find_res = db_slice.FindReadOnly(t->GetDbContext(), *it, OBJ_SET);
     if (!find_res)
       return find_res.status();
 
@@ -824,7 +824,7 @@ OpResult<StringVec> OpInter(const Transaction* t, EngineShard* es, bool remove_f
   unsigned index = 0;
   for (; it != args.end(); ++it) {
     auto& dest = sets[index++];
-    auto find_res = es->db_slice().FindReadOnly(t->GetDbContext(), *it, OBJ_SET);
+    auto find_res = db_slice.FindReadOnly(t->GetDbContext(), *it, OBJ_SET);
     if (!find_res) {
       if (status == OpStatus::OK || status == OpStatus::KEY_NOTFOUND ||
           find_res.status() != OpStatus::KEY_NOTFOUND) {
@@ -872,7 +872,8 @@ OpResult<StringVec> OpInter(const Transaction* t, EngineShard* es, bool remove_f
 }
 
 OpResult<StringVec> OpRandMember(const OpArgs& op_args, std::string_view key, int count) {
-  auto find_res = op_args.shard->db_slice().FindReadOnly(op_args.db_cntx, key, OBJ_SET);
+  auto find_res =
+      op_args.db_cntx.ns->GetCurrentDbSlice().FindReadOnly(op_args.db_cntx, key, OBJ_SET);
   if (!find_res)
     return find_res.status();
 
@@ -897,7 +898,7 @@ OpResult<StringVec> OpRandMember(const OpArgs& op_args, std::string_view key, in
 // count - how many elements to pop.
 OpResult<StringVec> OpPop(const OpArgs& op_args, string_view key, unsigned count) {
   auto& db_cntx = op_args.db_cntx;
-  auto& db_slice = op_args.shard->db_slice();
+  auto& db_slice = db_cntx.ns->GetCurrentDbSlice();
   auto find_res = db_slice.FindMutable(db_cntx, key, OBJ_SET);
   if (!find_res) {
     return find_res.status();
@@ -927,7 +928,7 @@ OpResult<StringVec> OpPop(const OpArgs& op_args, string_view key, unsigned count
 
     // Delete the set as it is now empty
     find_res->post_updater.Run();
-    CHECK(db_slice.Del(op_args.db_cntx.db_index, find_res->it));
+    CHECK(db_slice.Del(op_args.db_cntx, find_res->it));
 
     // Replicate as DEL.
     if (op_args.shard->journal()) {
@@ -963,7 +964,8 @@ OpResult<StringVec> OpPop(const OpArgs& op_args, string_view key, unsigned count
 
 OpResult<StringVec> OpScan(const OpArgs& op_args, string_view key, uint64_t* cursor,
                            const ScanOpts& scan_op) {
-  auto find_res = op_args.shard->db_slice().FindReadOnly(op_args.db_cntx, key, OBJ_SET);
+  auto find_res =
+      op_args.db_cntx.ns->GetCurrentDbSlice().FindReadOnly(op_args.db_cntx, key, OBJ_SET);
 
   if (!find_res)
     return find_res.status();
@@ -1010,7 +1012,7 @@ void SIsMember(CmdArgList args, ConnectionContext* cntx) {
   string_view val = ArgS(args, 1);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    auto find_res = shard->db_slice().FindReadOnly(t->GetDbContext(), key, OBJ_SET);
+    auto find_res = t->GetCurrentDbSlice().FindReadOnly(t->GetDbContext(), key, OBJ_SET);
 
     if (find_res) {
       SetType st{find_res.value()->second.RObjPtr(), find_res.value()->second.Encoding()};
@@ -1037,7 +1039,7 @@ void SMIsMember(CmdArgList args, ConnectionContext* cntx) {
   memberships.reserve(vals.size());
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    auto find_res = shard->db_slice().FindReadOnly(t->GetDbContext(), key, OBJ_SET);
+    auto find_res = t->GetCurrentDbSlice().FindReadOnly(t->GetDbContext(), key, OBJ_SET);
     if (find_res) {
       SetType st{find_res.value()->second.RObjPtr(), find_res.value()->second.Encoding()};
       FindInSet(memberships, t->GetDbContext(), st, vals);
@@ -1097,7 +1099,7 @@ void SCard(CmdArgList args, ConnectionContext* cntx) {
   string_view key = ArgS(args, 0);
 
   auto cb = [&](Transaction* t, EngineShard* shard) -> OpResult<uint32_t> {
-    auto find_res = shard->db_slice().FindReadOnly(t->GetDbContext(), key, OBJ_SET);
+    auto find_res = t->GetCurrentDbSlice().FindReadOnly(t->GetDbContext(), key, OBJ_SET);
     if (!find_res) {
       return find_res.status();
     }

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -72,7 +72,7 @@ template <typename T> T GetResult(std::variant<T, util::fb2::Future<T>> v) {
 OpResult<uint32_t> OpSetRange(const OpArgs& op_args, string_view key, size_t start,
                               string_view value) {
   VLOG(2) << "SetRange(" << key << ", " << start << ", " << value << ")";
-  auto& db_slice = op_args.shard->db_slice();
+  auto& db_slice = op_args.db_cntx.ns->GetCurrentDbSlice();
   size_t range_len = start + value.size();
 
   if (range_len == 0) {
@@ -107,7 +107,7 @@ OpResult<uint32_t> OpSetRange(const OpArgs& op_args, string_view key, size_t sta
 }
 
 OpResult<string> OpGetRange(const OpArgs& op_args, string_view key, int32_t start, int32_t end) {
-  auto& db_slice = op_args.shard->db_slice();
+  auto& db_slice = op_args.db_cntx.ns->GetCurrentDbSlice();
   auto it_res = db_slice.FindReadOnly(op_args.db_cntx, key, OBJ_STRING);
   if (!it_res.ok())
     return it_res.status();
@@ -153,7 +153,7 @@ size_t ExtendExisting(DbSlice::Iterator it, string_view key, string_view val, bo
 }
 
 OpResult<bool> ExtendOrSkip(const OpArgs& op_args, string_view key, string_view val, bool prepend) {
-  auto& db_slice = op_args.shard->db_slice();
+  auto& db_slice = op_args.db_cntx.ns->GetCurrentDbSlice();
   auto it_res = db_slice.FindMutable(op_args.db_cntx, key, OBJ_STRING);
   if (!it_res) {
     return false;
@@ -163,7 +163,7 @@ OpResult<bool> ExtendOrSkip(const OpArgs& op_args, string_view key, string_view 
 }
 
 OpResult<double> OpIncrFloat(const OpArgs& op_args, string_view key, double val) {
-  auto& db_slice = op_args.shard->db_slice();
+  auto& db_slice = op_args.db_cntx.ns->GetCurrentDbSlice();
 
   auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
   RETURN_ON_BAD_STATUS(op_res);
@@ -208,7 +208,7 @@ OpResult<double> OpIncrFloat(const OpArgs& op_args, string_view key, double val)
 // if skip_on_missing - returns KEY_NOTFOUND.
 OpResult<int64_t> OpIncrBy(const OpArgs& op_args, string_view key, int64_t incr,
                            bool skip_on_missing) {
-  auto& db_slice = op_args.shard->db_slice();
+  auto& db_slice = op_args.db_cntx.ns->GetCurrentDbSlice();
 
   // we avoid using AddOrFind because of skip_on_missing option for memcache.
   auto res = db_slice.FindMutable(op_args.db_cntx, key);
@@ -307,7 +307,7 @@ OpStatus OpMSet(const OpArgs& op_args, const ShardArgs& args) {
 OpResult<array<int64_t, 5>> OpThrottle(const OpArgs& op_args, const string_view key,
                                        const int64_t limit, const int64_t emission_interval_ms,
                                        const uint64_t quantity) {
-  auto& db_slice = op_args.shard->db_slice();
+  auto& db_slice = op_args.db_cntx.ns->GetCurrentDbSlice();
 
   if (emission_interval_ms > INT64_MAX / limit) {
     return OpStatus::INVALID_INT;
@@ -413,7 +413,7 @@ SinkReplyBuilder::MGetResponse OpMGet(util::fb2::BlockingCounter wait_bc, bool f
   ShardArgs keys = t->GetShardArgs(shard->shard_id());
   DCHECK(!keys.Empty());
 
-  auto& db_slice = shard->db_slice();
+  auto& db_slice = t->GetCurrentDbSlice();
 
   SinkReplyBuilder::MGetResponse response(keys.Size());
   absl::InlinedVector<DbSlice::ConstIterator, 32> iters(keys.Size());
@@ -478,7 +478,7 @@ OpResult<variant<size_t, util::fb2::Future<size_t>>> OpExtend(const OpArgs& op_a
                                                               std::string_view value,
                                                               bool prepend) {
   auto* shard = op_args.shard;
-  auto it_res = shard->db_slice().AddOrFind(op_args.db_cntx, key);
+  auto it_res = op_args.db_cntx.ns->GetCurrentDbSlice().AddOrFind(op_args.db_cntx, key);
   RETURN_ON_BAD_STATUS(it_res);
 
   if (it_res->is_new) {
@@ -551,7 +551,7 @@ bool StringValue::IsEmpty() const {
 }
 
 OpStatus SetCmd::Set(const SetParams& params, string_view key, string_view value) {
-  auto& db_slice = op_args_.shard->db_slice();
+  auto& db_slice = op_args_.db_cntx.ns->GetCurrentDbSlice();
 
   DCHECK(db_slice.IsDbValid(op_args_.db_cntx.db_index));
   VLOG(2) << "Set " << key << "(" << db_slice.shard_id() << ") ";
@@ -596,7 +596,7 @@ OpStatus SetCmd::SetExisting(const SetParams& params, DbSlice::Iterator it,
   PrimeValue& prime_value = it->second;
   EngineShard* shard = op_args_.shard;
 
-  DbSlice& db_slice = shard->db_slice();
+  auto& db_slice = op_args_.db_cntx.ns->GetCurrentDbSlice();
   uint64_t at_ms =
       params.expire_after_ms ? params.expire_after_ms + op_args_.db_cntx.time_now_ms : 0;
 
@@ -636,8 +636,7 @@ OpStatus SetCmd::SetExisting(const SetParams& params, DbSlice::Iterator it,
 
 void SetCmd::AddNew(const SetParams& params, DbSlice::Iterator it, DbSlice::ExpIterator e_it,
                     std::string_view key, std::string_view value) {
-  EngineShard* shard = op_args_.shard;
-  auto& db_slice = shard->db_slice();
+  auto& db_slice = op_args_.db_cntx.ns->GetCurrentDbSlice();
 
   // Adding new value.
   PrimeValue tvalue{value};
@@ -859,7 +858,7 @@ void StringFamily::SetNx(CmdArgList args, ConnectionContext* cntx) {
 
 void StringFamily::Get(CmdArgList args, ConnectionContext* cntx) {
   auto cb = [key = ArgS(args, 0)](Transaction* tx, EngineShard* es) -> OpResult<StringValue> {
-    auto it_res = es->db_slice().FindReadOnly(tx->GetDbContext(), key, OBJ_STRING);
+    auto it_res = tx->GetCurrentDbSlice().FindReadOnly(tx->GetDbContext(), key, OBJ_STRING);
     if (!it_res.ok())
       return it_res.status();
 
@@ -871,13 +870,14 @@ void StringFamily::Get(CmdArgList args, ConnectionContext* cntx) {
 
 void StringFamily::GetDel(CmdArgList args, ConnectionContext* cntx) {
   auto cb = [key = ArgS(args, 0)](Transaction* tx, EngineShard* es) -> OpResult<StringValue> {
-    auto it_res = es->db_slice().FindMutable(tx->GetDbContext(), key, OBJ_STRING);
+    auto& db_slice = tx->GetCurrentDbSlice();
+    auto it_res = db_slice.FindMutable(tx->GetDbContext(), key, OBJ_STRING);
     if (!it_res.ok())
       return it_res.status();
 
     auto value = StringValue::Read(tx->GetDbIndex(), key, it_res->it->second, es);
     it_res->post_updater.Run();  // Run manually before delete
-    es->db_slice().Del(tx->GetDbIndex(), it_res->it);
+    db_slice.Del(tx->GetDbContext(), it_res->it);
     return value;
   };
 
@@ -986,7 +986,8 @@ void StringFamily::GetEx(CmdArgList args, ConnectionContext* cntx) {
   auto cb = [&](Transaction* t, EngineShard* shard) -> OpResult<StringValue> {
     auto op_args = t->GetOpArgs(shard);
 
-    auto it_res = op_args.shard->db_slice().FindMutable(op_args.db_cntx, key, OBJ_STRING);
+    auto it_res =
+        op_args.db_cntx.ns->GetCurrentDbSlice().FindMutable(op_args.db_cntx, key, OBJ_STRING);
     if (!it_res)
       return it_res.status();
 
@@ -994,8 +995,8 @@ void StringFamily::GetEx(CmdArgList args, ConnectionContext* cntx) {
 
     if (exp_params.IsDefined()) {
       it_res->post_updater.Run();  // Run manually before possible delete due to negative expire
-      RETURN_ON_BAD_STATUS(op_args.shard->db_slice().UpdateExpire(op_args.db_cntx, it_res->it,
-                                                                  it_res->exp_it, exp_params));
+      RETURN_ON_BAD_STATUS(op_args.db_cntx.ns->GetCurrentDbSlice().UpdateExpire(
+          op_args.db_cntx, it_res->it, it_res->exp_it, exp_params));
     }
 
     // Replicate GETEX as PEXPIREAT or PERSIST
@@ -1229,7 +1230,7 @@ void StringFamily::MSetNx(CmdArgList args, ConnectionContext* cntx) {
   auto cb = [&](Transaction* t, EngineShard* es) {
     auto args = t->GetShardArgs(es->shard_id());
     for (auto arg_it = args.begin(); arg_it != args.end(); ++arg_it) {
-      auto it = es->db_slice().FindReadOnly(t->GetDbContext(), *arg_it).it;
+      auto it = cntx->ns->GetCurrentDbSlice().FindReadOnly(t->GetDbContext(), *arg_it).it;
       ++arg_it;
       if (IsValid(it)) {
         exists.store(true, memory_order_relaxed);
@@ -1262,7 +1263,7 @@ void StringFamily::StrLen(CmdArgList args, ConnectionContext* cntx) {
   string_view key = ArgS(args, 0);
 
   auto cb = [&](Transaction* t, EngineShard* shard) -> OpResult<size_t> {
-    auto it_res = shard->db_slice().FindReadOnly(t->GetDbContext(), key, OBJ_STRING);
+    auto it_res = t->GetCurrentDbSlice().FindReadOnly(t->GetDbContext(), key, OBJ_STRING);
     if (!it_res.ok())
       return it_res.status();
 

--- a/src/server/string_family_test.cc
+++ b/src/server/string_family_test.cc
@@ -804,7 +804,7 @@ TEST_F(StringFamilyTest, SetWithHashtagsNoCluster) {
   auto fb = ExpectUsedKeys({"{key}1"});
   EXPECT_EQ(Run({"set", "{key}1", "val1"}), "OK");
   fb.Join();
-  EXPECT_FALSE(service_->IsLocked(0, "{key}1"));
+  EXPECT_FALSE(IsLocked(0, "{key}1"));
 
   fb = ExpectUsedKeys({"{key}2"});
   EXPECT_EQ(Run({"set", "{key}2", "val2"}), "OK");

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -80,7 +80,7 @@ void TransactionSuspension::Start() {
 
   transaction_ = new dfly::Transaction{&cid};
 
-  auto st = transaction_->InitByArgs(0, {});
+  auto st = transaction_->InitByArgs(&namespaces->GetDefaultNamespace(), 0, {});
   CHECK_EQ(st, OpStatus::OK);
 
   transaction_->Execute([](Transaction* t, EngineShard* shard) { return OpStatus::OK; }, false);
@@ -106,7 +106,9 @@ class BaseFamilyTest::TestConnWrapper {
   const facade::Connection::InvalidationMessage& GetInvalidationMessage(size_t index) const;
 
   ConnectionContext* cmd_cntx() {
-    return static_cast<ConnectionContext*>(dummy_conn_->cntx());
+    auto cntx = static_cast<ConnectionContext*>(dummy_conn_->cntx());
+    cntx->ns = &namespaces->GetDefaultNamespace();
+    return cntx;
   }
 
   StringVec SplitLines() const {
@@ -209,7 +211,10 @@ void BaseFamilyTest::ResetService() {
   used_mem_current = 0;
 
   TEST_current_time_ms = absl::GetCurrentTimeNanos() / 1000000;
-  auto cb = [&](EngineShard* s) { s->db_slice().UpdateExpireBase(TEST_current_time_ms - 1000, 0); };
+  auto default_ns = &namespaces->GetDefaultNamespace();
+  auto cb = [&](EngineShard* s) {
+    default_ns->GetCurrentDbSlice().UpdateExpireBase(TEST_current_time_ms - 1000, 0);
+  };
   shard_set->RunBriefInParallel(cb);
 
   const TestInfo* const test_info = UnitTest::GetInstance()->current_test_info();
@@ -243,7 +248,8 @@ void BaseFamilyTest::ResetService() {
           }
 
           LOG(ERROR) << "TxLocks for shard " << es->shard_id();
-          for (const auto& k_v : es->db_slice().GetDBTable(0)->trans_locks) {
+          for (const auto& k_v :
+               namespaces->GetDefaultNamespace().GetCurrentDbSlice().GetDBTable(0)->trans_locks) {
             LOG(ERROR) << "Key " << k_v.first << " " << k_v.second;
           }
         }
@@ -263,6 +269,7 @@ void BaseFamilyTest::ShutdownService() {
 
   service_->Shutdown();
   service_.reset();
+
   delete shard_set;
   shard_set = nullptr;
 
@@ -294,8 +301,9 @@ void BaseFamilyTest::CleanupSnapshots() {
 
 unsigned BaseFamilyTest::NumLocked() {
   atomic_uint count = 0;
+  auto default_ns = &namespaces->GetDefaultNamespace();
   shard_set->RunBriefInParallel([&](EngineShard* shard) {
-    for (const auto& db : shard->db_slice().databases()) {
+    for (const auto& db : default_ns->GetCurrentDbSlice().databases()) {
       if (db == nullptr) {
         continue;
       }
@@ -374,6 +382,7 @@ RespExpr BaseFamilyTest::Run(std::string_view id, ArgSlice slice) {
   CmdArgVec args = conn_wrapper->Args(slice);
 
   auto* context = conn_wrapper->cmd_cntx();
+  context->ns = &namespaces->GetDefaultNamespace();
 
   DCHECK(context->transaction == nullptr) << id;
 
@@ -550,12 +559,7 @@ BaseFamilyTest::TestConnWrapper::GetInvalidationMessage(size_t index) const {
 }
 
 bool BaseFamilyTest::IsLocked(DbIndex db_index, std::string_view key) const {
-  ShardId sid = Shard(key, shard_set->size());
-
-  bool is_open = pp_->at(sid)->AwaitBrief([db_index, key] {
-    return EngineShard::tlocal()->db_slice().CheckLock(IntentLock::EXCLUSIVE, db_index, key);
-  });
-  return !is_open;
+  return service_->IsLocked(&namespaces->GetDefaultNamespace(), db_index, key);
 }
 
 string BaseFamilyTest::GetId() const {
@@ -642,7 +646,7 @@ vector<LockFp> BaseFamilyTest::GetLastFps() {
     }
 
     lock_guard lk(mu);
-    for (auto fp : shard->db_slice().TEST_GetLastLockedFps()) {
+    for (auto fp : namespaces->GetDefaultNamespace().GetCurrentDbSlice().TEST_GetLastLockedFps()) {
       result.push_back(fp);
     }
   };

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -117,7 +117,7 @@ class BaseFamilyTest : public ::testing::Test {
   static std::vector<std::string> StrArray(const RespExpr& expr);
 
   Metrics GetMetrics() const {
-    return service_->server_family().GetMetrics();
+    return service_->server_family().GetMetrics(&namespaces->GetDefaultNamespace());
   }
 
   void ClearMetrics();

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -117,7 +117,7 @@ class BaseFamilyTest : public ::testing::Test {
   static std::vector<std::string> StrArray(const RespExpr& expr);
 
   Metrics GetMetrics() const {
-    return service_->server_family().GetMetrics(&namespaces->GetDefaultNamespace());
+    return service_->server_family().GetMetrics(&Namespaces::Get().GetDefaultNamespace());
   }
 
   void ClearMetrics();

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -892,6 +892,7 @@ void Transaction::DispatchHop() {
   use_count_.fetch_add(run_cnt, memory_order_relaxed);  // for each pointer from poll_cb
 
   auto poll_cb = [this] {
+    CHECK(namespace_ != nullptr);
     EngineShard::tlocal()->PollExecution("exec_cb", this);
     DVLOG(3) << "ptr_release " << DebugId();
     intrusive_ptr_release(this);  // against use_count_.fetch_add above.

--- a/src/server/tx_base.h
+++ b/src/server/tx_base.h
@@ -14,6 +14,7 @@ namespace dfly {
 
 class EngineShard;
 class Transaction;
+class Namespace;
 
 using DbIndex = uint16_t;
 using ShardId = uint16_t;
@@ -57,17 +58,17 @@ struct KeyIndex {
 };
 
 struct DbContext {
+  Namespace* ns = nullptr;
   DbIndex db_index = 0;
   uint64_t time_now_ms = 0;
 };
 
 struct OpArgs {
-  EngineShard* shard;
-  const Transaction* tx;
+  EngineShard* shard = nullptr;
+  const Transaction* tx = nullptr;
   DbContext db_cntx;
 
-  OpArgs() : shard(nullptr), tx(nullptr) {
-  }
+  OpArgs() = default;
 
   OpArgs(EngineShard* s, const Transaction* tx, const DbContext& cntx)
       : shard(s), tx(tx), db_cntx(cntx) {

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -188,7 +188,7 @@ void OutputScoredArrayResult(const OpResult<ScoredArray>& result,
 
 OpResult<DbSlice::ItAndUpdater> FindZEntry(const ZParams& zparams, const OpArgs& op_args,
                                            string_view key, size_t member_len) {
-  auto& db_slice = op_args.shard->db_slice();
+  auto& db_slice = op_args.db_cntx.ns->GetCurrentDbSlice();
   if (zparams.flags & ZADD_IN_XX) {
     return db_slice.FindMutable(op_args.db_cntx, key, OBJ_ZSET);
   }
@@ -213,10 +213,11 @@ OpResult<DbSlice::ItAndUpdater> FindZEntry(const ZParams& zparams, const OpArgs&
       return OpStatus::WRONG_TYPE;
   }
 
-  if (add_res.is_new && op_args.shard->blocking_controller()) {
+  auto blocking_controller = op_args.db_cntx.ns->GetBlockingController(op_args.shard->shard_id());
+  if (add_res.is_new && blocking_controller) {
     string tmp;
     string_view key = it->first.GetSlice(&tmp);
-    op_args.shard->blocking_controller()->AwakeWatched(op_args.db_cntx.db_index, key);
+    blocking_controller->AwakeWatched(op_args.db_cntx.db_index, key);
   }
 
   return DbSlice::ItAndUpdater{add_res.it, add_res.exp_it, std::move(add_res.post_updater)};
@@ -845,7 +846,7 @@ OpResult<ScoredMap> OpUnion(EngineShard* shard, Transaction* t, string_view dest
     }
   }
 
-  auto& db_slice = shard->db_slice();
+  auto& db_slice = t->GetCurrentDbSlice();
   KeyIterWeightVec key_weight_vec(keys.Size() - removed_keys);
   unsigned index = 0;
   for (; start != end; ++start) {
@@ -898,7 +899,7 @@ OpResult<ScoredMap> OpInter(EngineShard* shard, Transaction* t, string_view dest
     }
   }
 
-  auto& db_slice = shard->db_slice();
+  auto& db_slice = t->GetCurrentDbSlice();
   vector<pair<DbSlice::ItAndUpdater, double>> it_arr(keys.Size() - removed_keys);
 
   unsigned index = 0;
@@ -964,11 +965,11 @@ size_t EstimateListpackMinBytes(ScoredMemberSpan members) {
 OpResult<AddResult> OpAdd(const OpArgs& op_args, const ZParams& zparams, string_view key,
                           ScoredMemberSpan members) {
   DCHECK(!members.empty() || zparams.override);
-  auto& db_slice = op_args.shard->db_slice();
+  auto& db_slice = op_args.db_cntx.ns->GetCurrentDbSlice();
 
   if (zparams.override && members.empty()) {
     auto it = db_slice.FindMutable(op_args.db_cntx, key).it;  // post_updater will run immediately
-    db_slice.Del(op_args.db_cntx.db_index, it);
+    db_slice.Del(op_args.db_cntx, it);
     return OpStatus::OK;
   }
 
@@ -1266,7 +1267,7 @@ bool ParseLimit(string_view offset_str, string_view limit_str, ZSetFamily::Range
 }
 
 ScoredArray OpBZPop(Transaction* t, EngineShard* shard, std::string_view key, bool is_max) {
-  auto& db_slice = shard->db_slice();
+  auto& db_slice = t->GetCurrentDbSlice();
   auto it_res = db_slice.FindMutable(t->GetDbContext(), key, OBJ_ZSET);
   CHECK(it_res) << t->DebugId() << " " << key;  // must exist and must be ok.
   auto it = it_res->it;
@@ -1297,7 +1298,7 @@ ScoredArray OpBZPop(Transaction* t, EngineShard* shard, std::string_view key, bo
   auto zlen = pv.Size();
   if (zlen == 0) {
     DVLOG(1) << "deleting key " << key << " " << t->DebugId();
-    CHECK(db_slice.Del(t->GetDbIndex(), it_res->it));
+    CHECK(db_slice.Del(t->GetDbContext(), it_res->it));
   }
 
   OpArgs op_args = t->GetOpArgs(shard);
@@ -1374,7 +1375,7 @@ vector<ScoredMap> OpFetch(EngineShard* shard, Transaction* t) {
   vector<ScoredMap> results;
   results.reserve(keys.Size());
 
-  auto& db_slice = shard->db_slice();
+  auto& db_slice = t->GetCurrentDbSlice();
   for (string_view key : keys) {
     auto it = db_slice.FindReadOnly(t->GetDbContext(), key, OBJ_ZSET);
     if (!it) {
@@ -1391,7 +1392,7 @@ vector<ScoredMap> OpFetch(EngineShard* shard, Transaction* t) {
 
 auto OpPopCount(const ZSetFamily::ZRangeSpec& range_spec, const OpArgs& op_args, string_view key)
     -> OpResult<ScoredArray> {
-  auto& db_slice = op_args.shard->db_slice();
+  auto& db_slice = op_args.db_cntx.ns->GetCurrentDbSlice();
   auto res_it = db_slice.FindMutable(op_args.db_cntx, key, OBJ_ZSET);
   if (!res_it)
     return res_it.status();
@@ -1405,7 +1406,7 @@ auto OpPopCount(const ZSetFamily::ZRangeSpec& range_spec, const OpArgs& op_args,
 
   auto zlen = pv.Size();
   if (zlen == 0) {
-    CHECK(op_args.shard->db_slice().Del(op_args.db_cntx.db_index, res_it->it));
+    CHECK(op_args.db_cntx.ns->GetCurrentDbSlice().Del(op_args.db_cntx, res_it->it));
   }
 
   return iv.PopResult();
@@ -1413,7 +1414,8 @@ auto OpPopCount(const ZSetFamily::ZRangeSpec& range_spec, const OpArgs& op_args,
 
 auto OpRange(const ZSetFamily::ZRangeSpec& range_spec, const OpArgs& op_args, string_view key)
     -> OpResult<ScoredArray> {
-  auto res_it = op_args.shard->db_slice().FindReadOnly(op_args.db_cntx, key, OBJ_ZSET);
+  auto res_it =
+      op_args.db_cntx.ns->GetCurrentDbSlice().FindReadOnly(op_args.db_cntx, key, OBJ_ZSET);
   if (!res_it)
     return res_it.status();
 
@@ -1428,7 +1430,8 @@ auto OpRange(const ZSetFamily::ZRangeSpec& range_spec, const OpArgs& op_args, st
 
 auto OpRanges(const std::vector<ZSetFamily::ZRangeSpec>& range_specs, const OpArgs& op_args,
               string_view key) -> OpResult<vector<ScoredArray>> {
-  auto res_it = op_args.shard->db_slice().FindReadOnly(op_args.db_cntx, key, OBJ_ZSET);
+  auto res_it =
+      op_args.db_cntx.ns->GetCurrentDbSlice().FindReadOnly(op_args.db_cntx, key, OBJ_ZSET);
   if (!res_it)
     return res_it.status();
 
@@ -1446,7 +1449,7 @@ auto OpRanges(const std::vector<ZSetFamily::ZRangeSpec>& range_specs, const OpAr
 
 OpResult<unsigned> OpRemRange(const OpArgs& op_args, string_view key,
                               const ZSetFamily::ZRangeSpec& range_spec) {
-  auto& db_slice = op_args.shard->db_slice();
+  auto& db_slice = op_args.db_cntx.ns->GetCurrentDbSlice();
   auto res_it = db_slice.FindMutable(op_args.db_cntx, key, OBJ_ZSET);
   if (!res_it)
     return res_it.status();
@@ -1459,7 +1462,7 @@ OpResult<unsigned> OpRemRange(const OpArgs& op_args, string_view key,
 
   auto zlen = pv.Size();
   if (zlen == 0) {
-    CHECK(op_args.shard->db_slice().Del(op_args.db_cntx.db_index, res_it->it));
+    CHECK(op_args.db_cntx.ns->GetCurrentDbSlice().Del(op_args.db_cntx, res_it->it));
   }
 
   return iv.removed();
@@ -1467,7 +1470,8 @@ OpResult<unsigned> OpRemRange(const OpArgs& op_args, string_view key,
 
 OpResult<unsigned> OpRank(const OpArgs& op_args, string_view key, string_view member,
                           bool reverse) {
-  auto res_it = op_args.shard->db_slice().FindReadOnly(op_args.db_cntx, key, OBJ_ZSET);
+  auto res_it =
+      op_args.db_cntx.ns->GetCurrentDbSlice().FindReadOnly(op_args.db_cntx, key, OBJ_ZSET);
   if (!res_it)
     return res_it.status();
 
@@ -1513,7 +1517,8 @@ OpResult<unsigned> OpRank(const OpArgs& op_args, string_view key, string_view me
 
 OpResult<unsigned> OpCount(const OpArgs& op_args, std::string_view key,
                            const ZSetFamily::ScoreInterval& interval) {
-  auto res_it = op_args.shard->db_slice().FindReadOnly(op_args.db_cntx, key, OBJ_ZSET);
+  auto res_it =
+      op_args.db_cntx.ns->GetCurrentDbSlice().FindReadOnly(op_args.db_cntx, key, OBJ_ZSET);
   if (!res_it)
     return res_it.status();
 
@@ -1563,7 +1568,8 @@ OpResult<unsigned> OpCount(const OpArgs& op_args, std::string_view key,
 
 OpResult<unsigned> OpLexCount(const OpArgs& op_args, string_view key,
                               const ZSetFamily::LexInterval& interval) {
-  auto res_it = op_args.shard->db_slice().FindReadOnly(op_args.db_cntx, key, OBJ_ZSET);
+  auto res_it =
+      op_args.db_cntx.ns->GetCurrentDbSlice().FindReadOnly(op_args.db_cntx, key, OBJ_ZSET);
   if (!res_it)
     return res_it.status();
 
@@ -1605,7 +1611,7 @@ OpResult<unsigned> OpLexCount(const OpArgs& op_args, string_view key,
 }
 
 OpResult<unsigned> OpRem(const OpArgs& op_args, string_view key, facade::ArgRange members) {
-  auto& db_slice = op_args.shard->db_slice();
+  auto& db_slice = op_args.db_cntx.ns->GetCurrentDbSlice();
   auto res_it = db_slice.FindMutable(op_args.db_cntx, key, OBJ_ZSET);
   if (!res_it)
     return res_it.status();
@@ -1621,19 +1627,21 @@ OpResult<unsigned> OpRem(const OpArgs& op_args, string_view key, facade::ArgRang
   res_it->post_updater.Run();
 
   if (zlen == 0) {
-    CHECK(op_args.shard->db_slice().Del(op_args.db_cntx.db_index, res_it->it));
+    CHECK(op_args.db_cntx.ns->GetCurrentDbSlice().Del(op_args.db_cntx, res_it->it));
   }
 
   return deleted;
 }
 
 OpResult<void> OpKeyExisted(const OpArgs& op_args, string_view key) {
-  auto res_it = op_args.shard->db_slice().FindReadOnly(op_args.db_cntx, key, OBJ_ZSET);
+  auto res_it =
+      op_args.db_cntx.ns->GetCurrentDbSlice().FindReadOnly(op_args.db_cntx, key, OBJ_ZSET);
   return res_it.status();
 }
 
 OpResult<double> OpScore(const OpArgs& op_args, string_view key, string_view member) {
-  auto res_it = op_args.shard->db_slice().FindReadOnly(op_args.db_cntx, key, OBJ_ZSET);
+  auto res_it =
+      op_args.db_cntx.ns->GetCurrentDbSlice().FindReadOnly(op_args.db_cntx, key, OBJ_ZSET);
   if (!res_it)
     return res_it.status();
 
@@ -1651,7 +1659,8 @@ OpResult<double> OpScore(const OpArgs& op_args, string_view key, string_view mem
 
 OpResult<MScoreResponse> OpMScore(const OpArgs& op_args, string_view key,
                                   facade::ArgRange members) {
-  auto res_it = op_args.shard->db_slice().FindReadOnly(op_args.db_cntx, key, OBJ_ZSET);
+  auto res_it =
+      op_args.db_cntx.ns->GetCurrentDbSlice().FindReadOnly(op_args.db_cntx, key, OBJ_ZSET);
   if (!res_it)
     return res_it.status();
 
@@ -1671,7 +1680,8 @@ OpResult<MScoreResponse> OpMScore(const OpArgs& op_args, string_view key,
 
 OpResult<StringVec> OpScan(const OpArgs& op_args, std::string_view key, uint64_t* cursor,
                            const ScanOpts& scan_op) {
-  auto find_res = op_args.shard->db_slice().FindReadOnly(op_args.db_cntx, key, OBJ_ZSET);
+  auto find_res =
+      op_args.db_cntx.ns->GetCurrentDbSlice().FindReadOnly(op_args.db_cntx, key, OBJ_ZSET);
 
   if (!find_res)
     return find_res.status();
@@ -1723,7 +1733,7 @@ OpResult<StringVec> OpScan(const OpArgs& op_args, std::string_view key, uint64_t
 
 OpResult<ScoredArray> OpRandMember(int count, const ZSetFamily::RangeParams& params,
                                    const OpArgs& op_args, string_view key) {
-  auto it = op_args.shard->db_slice().FindReadOnly(op_args.db_cntx, key, OBJ_ZSET);
+  auto it = op_args.db_cntx.ns->GetCurrentDbSlice().FindReadOnly(op_args.db_cntx, key, OBJ_ZSET);
   if (!it)
     return it.status();
 
@@ -1921,7 +1931,7 @@ void ZSetFamily::ZCard(CmdArgList args, ConnectionContext* cntx) {
   string_view key = ArgS(args, 0);
 
   auto cb = [&](Transaction* t, EngineShard* shard) -> OpResult<uint32_t> {
-    auto find_res = shard->db_slice().FindReadOnly(t->GetDbContext(), key, OBJ_ZSET);
+    auto find_res = t->GetCurrentDbSlice().FindReadOnly(t->GetDbContext(), key, OBJ_ZSET);
     if (!find_res) {
       return find_res.status();
     }

--- a/tests/dragonfly/acl_family_test.py
+++ b/tests/dragonfly/acl_family_test.py
@@ -2,7 +2,7 @@ import pytest
 import redis
 from redis import asyncio as aioredis
 from .instance import DflyInstanceFactory
-from .utility import disconnect_clients
+from .utility import *
 import tempfile
 import asyncio
 import os
@@ -536,6 +536,43 @@ async def test_acl_keys(async_client):
     # reject because bonus key does not match
     with pytest.raises(redis.exceptions.ResponseError):
         await async_client.execute_command("ZUNIONSTORE destkey 2 barz1 barz2")
+
+
+@pytest.mark.asyncio
+async def test_namespaces(df_local_factory):
+    df = df_local_factory.create()
+    df.start()
+
+    admin = aioredis.Redis(port=df.port)
+    assert await admin.execute_command("SET foo admin") == b"OK"
+    assert await admin.execute_command("GET foo") == b"admin"
+
+    # Create ns space named 'ns1'
+    await admin.execute_command("ACL SETUSER adi TENANT:ns1 ON >adi_pass +@all ~*")
+
+    adi = aioredis.Redis(port=df.port)
+    assert await adi.execute_command("AUTH adi adi_pass") == b"OK"
+    assert await adi.execute_command("SET foo bar") == b"OK"
+    assert await adi.execute_command("GET foo") == b"bar"
+    assert await admin.execute_command("GET foo") == b"admin"
+
+    # Adi and Shahar are on the same team
+    await admin.execute_command("ACL SETUSER shahar TENANT:ns1 ON >shahar_pass +@all ~*")
+
+    shahar = aioredis.Redis(port=df.port)
+    assert await shahar.execute_command("AUTH shahar shahar_pass") == b"OK"
+    assert await shahar.execute_command("GET foo") == b"bar"
+    assert await shahar.execute_command("SET foo bar2") == b"OK"
+    assert await adi.execute_command("GET foo") == b"bar2"
+
+    # Roman is a CTO, he has his own private space
+    await admin.execute_command("ACL SETUSER roman TENANT:ns2 ON >roman_pass +@all ~*")
+
+    roman = aioredis.Redis(port=df.port)
+    assert await roman.execute_command("AUTH roman roman_pass") == b"OK"
+    assert await roman.execute_command("GET foo") == None
+
+    await close_clients(admin, adi, shahar, roman)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR introduces a way to create multiple, separate and isolated namespaces in Dragonfly. Each user can be associated with a single namespace, and will not be able to interact with other namespaces.

This is still experimental, and lacks some important features, such as:
* Replication and RDB saving completely ignores non-default namespaces
* Defrag and statistics either use the default namespace or all namespaces without separation

To associate a user with a namespace, use the `ACL` command with the `TENANT:<namespace>` flag:

```
ACL SETUSER user TENANT:namespace1 ON >user_pass +@all ~*
```

For more examples and up to date info check `tests/dragonfly/acl_family_test.py` - specifically the `test_namespaces` function.