### PR TITLE
chore: reset enable_direct_fd to avoid socket leakage in kernel

### DIFF
--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -79,6 +79,10 @@ ABSL_FLAG(bool, version_check, true,
 
 ABSL_FLAG(uint16_t, tcp_backlog, 128, "TCP listen(2) backlog parameter.");
 
+#ifdef __linux__
+ABSL_DECLARE_FLAG(bool, enable_direct_fd);
+#endif
+
 using namespace util;
 using namespace facade;
 using namespace io;
@@ -716,6 +720,10 @@ Usage: dragonfly [FLAGS]
   unique_ptr<util::ProactorPool> pool;
 
 #ifdef __linux__
+  // NOTE: Seems that enable_direct_fd causes sockets leakage.
+  // Until it is fixed in helio, we disable it.
+  absl::SetFlag(&FLAGS_enable_direct_fd, false);
+
   base::sys::KernelVersion kver;
   base::sys::GetKernelVersion(&kver);
 


### PR DESCRIPTION
The leakage can be identified by checking /proc/net/sockstat
Fixes https://github.com/dragonflydb/dragonfly/issues/3045

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->