### PR TITLE
fix(tiering): Async delete for small bins

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1439,7 +1439,7 @@ void DbSlice::PerformDeletion(Iterator del_it, ExpIterator exp_it, DbTable* tabl
   const PrimeValue& pv = del_it->second;
 
   if (pv.IsExternal() && shard_owner()->tiered_storage()) {
-    shard_owner()->tiered_storage()->Delete(&del_it->second);
+    shard_owner()->tiered_storage()->Delete(table->index, &del_it->second);
   }
 
   size_t value_heap_size = pv.MallocUsed();

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -620,7 +620,7 @@ OpStatus SetCmd::SetExisting(const SetParams& params, DbSlice::Iterator it,
 
   // If value is external, mark it as deleted
   if (prime_value.IsExternal()) {
-    shard->tiered_storage()->Delete(&prime_value);
+    shard->tiered_storage()->Delete(op_args_.db_cntx.db_index, &prime_value);
   }
 
   // overwrite existing entry.

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -59,7 +59,7 @@ class TieredStorage {
   void Stash(DbIndex dbid, std::string_view key, PrimeValue* value);
 
   // Delete value, must be offloaded (external type)
-  void Delete(PrimeValue* value);
+  void Delete(DbIndex dbid, PrimeValue* value);
 
   // Cancel pending stash for value, must have IO_PENDING flag set
   void CancelStash(DbIndex dbid, std::string_view key, PrimeValue* value);

--- a/src/server/tiering/op_manager.cc
+++ b/src/server/tiering/op_manager.cc
@@ -43,7 +43,7 @@ void OpManager::Close() {
 
 void OpManager::Enqueue(EntryId id, DiskSegment segment, ReadCallback cb) {
   // Fill pages for prepared read as it has no penalty and potentially covers more small segments
-  PrepareRead(segment.FillPages()).ForPart(segment, id).callbacks.emplace_back(std::move(cb));
+  PrepareRead(segment.FillPages()).ForSegment(segment, id).callbacks.emplace_back(std::move(cb));
 }
 
 void OpManager::Delete(EntryId id) {
@@ -128,7 +128,7 @@ void OpManager::ProcessRead(size_t offset, std::string_view value) {
   pending_reads_.erase(offset);
 }
 
-OpManager::EntryOps& OpManager::ReadOp::ForPart(DiskSegment key_segment, EntryId id) {
+OpManager::EntryOps& OpManager::ReadOp::ForSegment(DiskSegment key_segment, EntryId id) {
   DCHECK_GE(key_segment.offset, segment.offset);
   DCHECK_LE(key_segment.length, segment.length);
 

--- a/src/server/tiering/op_manager.cc
+++ b/src/server/tiering/op_manager.cc
@@ -11,7 +11,6 @@
 #include "io/io.h"
 #include "server/tiering/common.h"
 #include "server/tiering/disk_storage.h"
-#include "util/fibers/future.h"
 
 namespace dfly::tiering {
 
@@ -44,7 +43,7 @@ void OpManager::Close() {
 
 void OpManager::Enqueue(EntryId id, DiskSegment segment, ReadCallback cb) {
   // Fill pages for prepared read as it has no penalty and potentially covers more small segments
-  PrepareRead(segment.FillPages()).ForId(id, segment).callbacks.emplace_back(std::move(cb));
+  PrepareRead(segment.FillPages()).ForPart(segment, id).callbacks.emplace_back(std::move(cb));
 }
 
 void OpManager::Delete(EntryId id) {
@@ -54,19 +53,20 @@ void OpManager::Delete(EntryId id) {
 }
 
 void OpManager::Delete(DiskSegment segment) {
-  DCHECK_EQ(segment.offset % kPageSize, 0u);
-  if (auto it = pending_reads_.find(segment.offset); it != pending_reads_.end()) {
-    // If a read is pending, it will be deleted once the read finished
-    it->second.delete_requested = true;
-  } else {
-    // Otherwise, delete it immediately
-    storage_.MarkAsFree(segment);
+  EntryOps* pending_op = nullptr;
+  if (auto it = pending_reads_.find(segment.offset); it != pending_reads_.end())
+    pending_op = it->second.ForPart(segment);
+
+  if (pending_op) {
+    pending_op->deleting = true;
+  } else if (ReportDelete(segment)) {
+    storage_.MarkAsFree(segment.FillPages());
   }
 }
 
 std::error_code OpManager::Stash(EntryId id_ref, std::string_view value) {
   auto id = ToOwned(id_ref);
-  unsigned version = ++pending_stash_ver_[id];
+  unsigned version = pending_stash_ver_[id] = ++pending_stash_counter_;
 
   io::Bytes buf_view{reinterpret_cast<const uint8_t*>(value.data()), value.length()};
   auto io_cb = [this, version, id = std::move(id)](DiskSegment segment, std::error_code ec) {
@@ -104,6 +104,7 @@ void OpManager::ProcessStashed(EntryId id, unsigned version, DiskSegment segment
 void OpManager::ProcessRead(size_t offset, std::string_view value) {
   ReadOp* info = &pending_reads_.at(offset);
 
+  bool deleting_full = false;
   std::string key_value;
   for (auto& ko : info->key_ops) {
     key_value = value.substr(ko.segment.offset - info->segment.offset, ko.segment.length);
@@ -112,24 +113,35 @@ void OpManager::ProcessRead(size_t offset, std::string_view value) {
     for (auto& cb : ko.callbacks)
       modified |= cb(&key_value);
 
-    // Report item as fetched only after all action were executed, pass whether it was modified
-    ReportFetched(Borrowed(ko.id), key_value, ko.segment, modified);
+    if (!ko.deleting)
+      ko.deleting |= ReportFetched(Borrowed(ko.id), key_value, ko.segment, modified || ko.deleting);
+
+    if (ko.deleting)
+      deleting_full |= ReportDelete(ko.segment);
   }
 
-  if (info->delete_requested)
+  if (deleting_full)
     storage_.MarkAsFree(info->segment);
   pending_reads_.erase(offset);
 }
 
-OpManager::EntryOps& OpManager::ReadOp::ForId(EntryId id, DiskSegment key_segment) {
+OpManager::EntryOps& OpManager::ReadOp::ForPart(DiskSegment key_segment, EntryId id) {
   DCHECK_GE(key_segment.offset, segment.offset);
   DCHECK_LE(key_segment.length, segment.length);
 
   for (auto& ops : key_ops) {
-    if (Borrowed(ops.id) == id)
+    if (ops.segment.offset == key_segment.offset)
       return ops;
   }
   return key_ops.emplace_back(ToOwned(id), key_segment);
+}
+
+OpManager::EntryOps* OpManager::ReadOp::ForPart(DiskSegment key_segment) {
+  for (auto& ops : key_ops) {
+    if (ops.segment.offset == key_segment.offset)
+      return &ops;
+  }
+  return nullptr;
 }
 
 OpManager::Stats OpManager::GetStats() const {

--- a/src/server/tiering/op_manager.h
+++ b/src/server/tiering/op_manager.h
@@ -93,7 +93,8 @@ class OpManager {
     // Get ops for id or create new
     EntryOps& ForPart(DiskSegment segment, EntryId id);
 
-    EntryOps* ForPart(DiskSegment segment);
+    // Find if there are operations for the given segment, return nullptr otherwise
+    EntryOps* Find(DiskSegment segment);
 
     DiskSegment segment;                       // spanning segment of whole read
     absl::InlinedVector<EntryOps, 1> key_ops;  // enqueued operations for different keys

--- a/src/server/tiering/op_manager.h
+++ b/src/server/tiering/op_manager.h
@@ -91,7 +91,7 @@ class OpManager {
     }
 
     // Get ops for id or create new
-    EntryOps& ForPart(DiskSegment segment, EntryId id);
+    EntryOps& ForSegment(DiskSegment segment, EntryId id);
 
     // Find if there are operations for the given segment, return nullptr otherwise
     EntryOps* Find(DiskSegment segment);

--- a/src/server/tiering/op_manager.h
+++ b/src/server/tiering/op_manager.h
@@ -65,20 +65,24 @@ class OpManager {
   // given error
   virtual void ReportStashed(EntryId id, DiskSegment segment, std::error_code ec) = 0;
 
-  // Report that an entry was successfully fetched.
-  // If modify is set, a modification was executed during the read and the stored value is outdated.
-  virtual void ReportFetched(EntryId id, std::string_view value, DiskSegment segment,
+  // Report that an entry was successfully fetched. Includes whether entry was modified.
+  // Returns true if value needs to be deleted.
+  virtual bool ReportFetched(EntryId id, std::string_view value, DiskSegment segment,
                              bool modified) = 0;
+
+  // Report delete. Return true if the filled segment needs to be marked as free.
+  virtual bool ReportDelete(DiskSegment segment) = 0;
 
  protected:
   // Describes pending futures for a single entry
   struct EntryOps {
-    EntryOps(OwnedEntryId id, DiskSegment segment) : id{std::move(id)}, segment{segment} {
+    EntryOps(OwnedEntryId id, DiskSegment segment) : id(std::move(id)), segment(segment) {
     }
 
     OwnedEntryId id;
     DiskSegment segment;
     absl::InlinedVector<ReadCallback, 1> callbacks;
+    bool deleting = false;
   };
 
   // Describes an ongoing read operation for a fixed segment
@@ -87,11 +91,12 @@ class OpManager {
     }
 
     // Get ops for id or create new
-    EntryOps& ForId(EntryId id, DiskSegment segment);
+    EntryOps& ForPart(DiskSegment segment, EntryId id);
+
+    EntryOps* ForPart(DiskSegment segment);
 
     DiskSegment segment;                       // spanning segment of whole read
     absl::InlinedVector<EntryOps, 1> key_ops;  // enqueued operations for different keys
-    bool delete_requested = false;             // whether to delete after reading the segment
   };
 
   // Prepare read operation for aligned segment or return pending if it exists.
@@ -109,6 +114,7 @@ class OpManager {
 
   absl::flat_hash_map<size_t /* offset */, ReadOp> pending_reads_;
 
+  size_t pending_stash_counter_ = 0;
   // todo: allow heterogeneous lookups with non owned id
   absl::flat_hash_map<OwnedEntryId, unsigned /* version */> pending_stash_ver_;
 };

--- a/src/server/tiering/op_manager_test.cc
+++ b/src/server/tiering/op_manager_test.cc
@@ -47,9 +47,14 @@ struct OpManagerTest : PoolTestBase, OpManager {
     stashed_[id] = segment;
   }
 
-  void ReportFetched(EntryId id, std::string_view value, DiskSegment segment,
+  bool ReportFetched(EntryId id, std::string_view value, DiskSegment segment,
                      bool modified) override {
     fetched_[id] = value;
+    return false;
+  }
+
+  bool ReportDelete(DiskSegment segment) override {
+    return true;
   }
 
   absl::flat_hash_map<EntryId, std::string> fetched_;

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -333,6 +333,7 @@ class Transaction {
   // entry.
   void LogJournalOnShard(EngineShard* shard, journal::Entry::Payload&& payload, uint32_t shard_cnt,
                          bool multi_commands, bool allow_await) const;
+
   void FinishLogJournalOnShard(EngineShard* shard, uint32_t shard_cnt) const;
 
   // Re-enable auto journal for commands marked as NO_AUTOJOURNAL. Call during setup.


### PR DESCRIPTION
Adds a `ReportDelete` to OpManager, so deletes from small bins happen asynchronously too. This was a problem before, one more step for #3021  