### PR TITLE
fix(tiering): wait for IO before test teardown

### DIFF
--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -47,15 +47,6 @@ class TieredStorageTest : public BaseFamilyTest {
 
     BaseFamilyTest::SetUp();
   }
-
-  void TearDown() override {
-    TieredStats stats;
-    do {
-      util::ThisFiber::SleepFor(20ms);
-      stats = GetMetrics().tiered_stats;
-    } while (stats.pending_read_cnt + stats.pending_stash_cnt > 0);
-    BaseFamilyTest::TearDown();
-  }
 };
 
 // Perform simple series of SET, GETSET and GET

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -47,6 +47,15 @@ class TieredStorageTest : public BaseFamilyTest {
 
     BaseFamilyTest::SetUp();
   }
+
+  void TearDown() override {
+    TieredStats stats;
+    do {
+      util::ThisFiber::SleepFor(20ms);
+      stats = GetMetrics().tiered_stats;
+    } while (stats.pending_read_cnt + stats.pending_stash_cnt > 0);
+    BaseFamilyTest::TearDown();
+  }
 };
 
 // Perform simple series of SET, GETSET and GET

--- a/src/server/tiering/disk_storage.h
+++ b/src/server/tiering/disk_storage.h
@@ -45,6 +45,7 @@ class DiskStorage {
   Stats GetStats() const;
 
  private:
+  size_t pending_ops_ = 0;
   size_t max_size_;
   IoMgr io_mgr_;
   ExternalAllocator alloc_;


### PR DESCRIPTION
Fixes #3078 

The better way would be to wait for all SQE to be handled... but this works too