### PR TITLE
fix: bit shift of kTagMask

### DIFF
--- a/src/core/dense_set.h
+++ b/src/core/dense_set.h
@@ -42,12 +42,12 @@ class DenseSet {
   // we can assume that high 12 bits of user address space
   // can be used for tagging. At most 52 bits of address are reserved for
   // some configurations, and usually it's 48 bits.
-  // https://www.kernel.org/doc/html/latest/arm64/memory.html
+  // https://docs.kernel.org/arch/arm64/memory.html
   static constexpr size_t kLinkBit = 1ULL << 52;
   static constexpr size_t kDisplaceBit = 1ULL << 53;
   static constexpr size_t kDisplaceDirectionBit = 1ULL << 54;
   static constexpr size_t kTtlBit = 1ULL << 55;
-  static constexpr size_t kTagMask = 4095ULL << 51;  // we reserve 12 high bits.
+  static constexpr size_t kTagMask = 4095ULL << 52;  // we reserve 12 high bits.
 
   class DensePtr {
    public:


### PR DESCRIPTION
Fix bit shift of kTagMask and update link of kernel doc.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->