### PR TITLE
fix(server): fix compatibility with rdb snapshot

### DIFF
--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -88,7 +88,7 @@ class SliceSnapshot {
  private:
   // Main fiber that iterates over all buckets in the db slice
   // and submits them to SerializeBucket.
-  void IterateBucketsFb(const Cancellation* cll);
+  void IterateBucketsFb(const Cancellation* cll, bool send_full_sync_cut);
 
   // Called on traversing cursor by IterateBucketsFb.
   bool BucketSaveCb(PrimeIterator it);

--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -21,7 +21,7 @@ from copy import deepcopy
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from .instance import DflyInstance, DflyParams, DflyInstanceFactory
+from .instance import DflyInstance, DflyParams, DflyInstanceFactory, RedisServer
 from . import PortPicker, dfly_args
 from .utility import DflySeederFactory, gen_ca_cert, gen_certificate
 
@@ -366,3 +366,24 @@ def run_before_and_after_test():
     yield  # this is where the testing happens
 
     # Teardown
+
+
+@pytest.fixture(scope="function")
+def redis_server(port_picker) -> RedisServer:
+    s = RedisServer(port_picker.get_available_port())
+    try:
+        s.start()
+    except FileNotFoundError as e:
+        pytest.skip("Redis server not found")
+        return None
+    time.sleep(1)
+    yield s
+    s.stop()
+
+
+@pytest.fixture(scope="function")
+def redis_local_server(port_picker) -> RedisServer:
+    s = RedisServer(port_picker.get_available_port())
+    time.sleep(1)
+    yield s
+    s.stop()

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -364,3 +364,36 @@ class DflyInstanceFactory:
 
     def __repr__(self) -> str:
         return f"Factory({self.args})"
+
+
+class RedisServer:
+    def __init__(self, port):
+        self.port = port
+        self.proc = None
+
+    def start(self, **kwargs):
+        command = [
+            "redis-server-6.2.11",
+            f"--port {self.port}",
+            "--save ''",
+            "--appendonly no",
+            "--protected-mode no",
+            "--repl-diskless-sync yes",
+            "--repl-diskless-sync-delay 0",
+        ]
+        # Convert kwargs to command-line arguments
+        for key, value in kwargs.items():
+            if value is None:
+                command.append(f"--{key}")
+            else:
+                command.append(f"--{key} {value}")
+
+        self.proc = subprocess.Popen(command)
+        logging.debug(self.proc.args)
+
+    def stop(self):
+        self.proc.terminate()
+        try:
+            self.proc.wait(timeout=10)
+        except Exception as e:
+            pass

--- a/tests/dragonfly/seeder_test.py
+++ b/tests/dragonfly/seeder_test.py
@@ -17,7 +17,7 @@ async def test_static_seeder(async_client: aioredis.Redis):
 @dfly_args({"proactor_threads": 4})
 async def test_seeder_key_target(async_client: aioredis.Redis):
     """Ensure seeder reaches its key targets"""
-    s = Seeder(units=len(Seeder.TYPES) * 2, key_target=5000)
+    s = Seeder(units=len(Seeder.DEFAULT_TYPES) * 2, key_target=5000)
 
     # Ensure tests are not reasonably slow
     async with async_timeout.timeout(1 + 4):


### PR DESCRIPTION
The bug: writing full sync cut opcode to rdb snapshot format breaks compatibility with rdb format

PR changes:
Do not write dfly full sync cut opcode for disk snapshot (not for df and not for rdb)
Add pytest for loading rdb snapshot generated by dragonfly with Redis server
