### PR TITLE
fix: lua and client tracking

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1338,6 +1338,13 @@ bool Service::InvokeCmd(const CommandId* cid, CmdArgList tail_args, ConnectionCo
     return false;
   }
 
+  // We need to run manually the tracking callback for stub transactions
+  // in lua scripts because the flow internally is different and they are skipped
+  // leading to missed notifications
+  if (trans && trans->IsUnderScriptStub()) {
+    trans->MaybeInvokeTrackingCb();
+  }
+
   auto cid_name = cid->name();
   if ((!trans && cid_name != "MULTI") || (trans && !trans->IsMulti())) {
     // Each time we execute a command we need to increase the sequence number in
@@ -1980,8 +1987,9 @@ void Service::EvalInternal(CmdArgList args, const EvalArgs& eval_args, Interpret
     ++ServerState::tlocal()->stats.eval_shardlocal_coordination_cnt;
     tx->PrepareMultiForScheduleSingleHop(*sid, tx->GetDbIndex(), args);
     tx->ScheduleSingleHop([&](Transaction*, EngineShard*) {
+      const bool is_script_stub = true;
       boost::intrusive_ptr<Transaction> stub_tx =
-          new Transaction{tx, *sid, slot_checker.GetUniqueSlotId()};
+          new Transaction{tx, *sid, slot_checker.GetUniqueSlotId(), is_script_stub};
       cntx->transaction = stub_tx.get();
 
       result = interpreter->RunFunction(eval_args.sha, &error);

--- a/src/server/server_family_test.cc
+++ b/src/server/server_family_test.cc
@@ -447,4 +447,17 @@ TEST_F(ServerFamilyTest, ClientTrackingNonTransactionalBug) {
 
   Run({"CLUSTER", "SLOTS"});
 }
+
+TEST_F(ServerFamilyTest, ClientTrackingLuaBug) {
+  Run({"HELLO", "3"});
+  // Check stickiness
+  Run({"CLIENT", "TRACKING", "ON"});
+  using namespace std::string_literals;
+  Run({"EVAL", R"(redis.call('get', 'foo'); redis.call('set', 'foo', 'bar'); return 1)", "1",
+       "foo"});
+  Run({"PING"});
+
+  EXPECT_EQ(InvalidationMessagesLen("IO0"), 1);
+}
+
 }  // namespace dfly

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -140,12 +140,11 @@ Transaction::Transaction(const CommandId* cid) : cid_{cid} {
 }
 
 Transaction::Transaction(const Transaction* parent, ShardId shard_id,
-                         std::optional<cluster::SlotId> slot_id, bool is_script_stub)
+                         std::optional<cluster::SlotId> slot_id)
     : multi_{make_unique<MultiData>()},
       txid_{parent->txid()},
       unique_shard_cnt_{1},
-      unique_shard_id_{shard_id},
-      is_script_stub_{is_script_stub} {
+      unique_shard_id_{shard_id} {
   if (parent->multi_) {
     multi_->mode = parent->multi_->mode;
   } else {
@@ -1251,6 +1250,7 @@ OpStatus Transaction::RunSquashedMultiCb(RunnableType cb) {
   auto result = cb(this, shard);
   shard->db_slice().OnCbFinish();
   LogAutoJournalOnShard(shard, result);
+  MaybeInvokeTrackingCb();
 
   DCHECK_EQ(result.flags, 0);  // if it's sophisticated, we shouldn't squash it
   return result;

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -172,7 +172,7 @@ class Transaction {
 
   // Initialize transaction for squashing placed on a specific shard with a given parent tx
   explicit Transaction(const Transaction* parent, ShardId shard_id,
-                       std::optional<cluster::SlotId> slot_id);
+                       std::optional<cluster::SlotId> slot_id, bool is_script_stub = false);
 
   // Initialize from command (args) on specific db.
   OpStatus InitByArgs(DbIndex index, CmdArgList args);
@@ -362,6 +362,16 @@ class Transaction {
 
   void SetTrackingCallback(std::function<void(Transaction* trans)> f) {
     tracking_cb_ = std::move(f);
+  }
+
+  bool IsUnderScriptStub() const {
+    return is_script_stub_;
+  }
+
+  void MaybeInvokeTrackingCb() {
+    if (tracking_cb_) {
+      tracking_cb_(this);
+    }
   }
 
   // Remove once BZPOP is stabilized
@@ -641,6 +651,7 @@ class Transaction {
   } stats_;
 
   std::function<void(Transaction* trans)> tracking_cb_;
+  bool is_script_stub_ = false;
 
  private:
   struct TLTmpSpace {

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -364,10 +364,6 @@ class Transaction {
     tracking_cb_ = std::move(f);
   }
 
-  bool IsUnderScriptStub() const {
-    return is_script_stub_;
-  }
-
   void MaybeInvokeTrackingCb() {
     if (tracking_cb_) {
       tracking_cb_(this);
@@ -651,7 +647,6 @@ class Transaction {
   } stats_;
 
   std::function<void(Transaction* trans)> tracking_cb_;
-  bool is_script_stub_ = false;
 
  private:
   struct TLTmpSpace {

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -172,7 +172,7 @@ class Transaction {
 
   // Initialize transaction for squashing placed on a specific shard with a given parent tx
   explicit Transaction(const Transaction* parent, ShardId shard_id,
-                       std::optional<cluster::SlotId> slot_id, bool is_script_stub = false);
+                       std::optional<cluster::SlotId> slot_id);
 
   // Initialize from command (args) on specific db.
   OpStatus InitByArgs(DbIndex index, CmdArgList args);


### PR DESCRIPTION
The issue is that lua scripts don't follow normal flow and the `tracking_cb_` are not called when the transaction concludes. 

* add missing tracking_cb_ invkoe in RunSquashedMultiCb
* add test