### PR TITLE
fix: fix RegisterOnChange methods for journal and db_slice

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1095,7 +1095,7 @@ void DbSlice::FlushChangeToEarlierCallbacks(DbIndex db_ind, Iterator it, uint64_
   DVLOG(2) << "Running callbacks in dbid " << db_ind << " with bucket_version=" << bucket_version
            << ", upper_bound=" << upper_bound;
 
-  lock_guard lk(cb_mu_);
+  std::shared_lock lk(cb_mu_);
   for (const auto& ccb : change_cb_) {
     uint64_t cb_version = ccb.first;
     DCHECK_LE(cb_version, upper_bound);
@@ -1505,7 +1505,7 @@ void DbSlice::OnCbFinish() {
 }
 
 void DbSlice::CallChangeCallbacks(DbIndex id, const ChangeReq& cr) const {
-  lock_guard lk(cb_mu_);
+  std::shared_lock lk(cb_mu_);
   for (const auto& ccb : change_cb_) {
     ccb.second(id, cr);
   }

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -523,6 +523,8 @@ class DbSlice {
     return version_++;
   }
 
+  void CallChangeCallbacks(DbIndex id, const ChangeReq& cr) const;
+
  private:
   ShardId shard_id_;
   uint8_t caching_mode_ : 1;
@@ -544,8 +546,9 @@ class DbSlice {
   // Used in temporary computations in Acquire/Release.
   mutable absl::flat_hash_set<uint64_t> uniq_fps_;
 
+  mutable util::fb2::Mutex cb_mu_;  // to prevent removing callback during call
   // ordered from the smallest to largest version.
-  std::vector<std::shared_ptr<std::pair<uint64_t, ChangeCallback>>> change_cb_;
+  std::list<std::pair<uint64_t, ChangeCallback>> change_cb_;
 
   // Used in temporary computations in Find item and CbFinish
   mutable absl::flat_hash_set<CompactObjectView> fetched_items_;

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -546,7 +546,7 @@ class DbSlice {
   // Used in temporary computations in Acquire/Release.
   mutable absl::flat_hash_set<uint64_t> uniq_fps_;
 
-  mutable util::fb2::Mutex cb_mu_;  // to prevent removing callback during call
+  mutable util::fb2::SharedMutex cb_mu_;  // to prevent removing callback during call
   // ordered from the smallest to largest version.
   std::list<std::pair<uint64_t, ChangeCallback>> change_cb_;
 

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -545,7 +545,7 @@ class DbSlice {
   mutable absl::flat_hash_set<uint64_t> uniq_fps_;
 
   // ordered from the smallest to largest version.
-  std::vector<std::pair<uint64_t, ChangeCallback>> change_cb_;
+  std::vector<std::shared_ptr<std::pair<uint64_t, ChangeCallback>>> change_cb_;
 
   // Used in temporary computations in Find item and CbFinish
   mutable absl::flat_hash_set<CompactObjectView> fetched_items_;

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -470,8 +470,13 @@ class DbSlice {
   void PerformDeletion(PrimeIterator del_it, DbTable* table);
 
   // this is workaround to execute callbacks for db_slice and journal atomically
-  [[nodiscard]] auto GetChangeCbLock() const {
-    return std::shared_lock(cb_mu_);
+  void LockChangeCb() const {
+    return cb_mu_.lock_shared();
+  }
+
+  // this is workaround to execute callbacks for db_slice and journal atomically
+  void UnlockChangeCb() const {
+    return cb_mu_.unlock_shared();
   }
 
  private:

--- a/src/server/journal/journal_slice.cc
+++ b/src/server/journal/journal_slice.cc
@@ -187,26 +187,28 @@ void JournalSlice::AddLogRecord(const Entry& entry, bool await) {
 
   // TODO: Remove the callbacks, replace with notifiers
   {
+    lock_guard lk(cb_mu_);
     DVLOG(2) << "AddLogRecord: run callbacks for " << entry.ToString()
              << " num callbacks: " << change_cb_arr_.size();
 
     for (const auto& k_v : change_cb_arr_) {
-      auto cb = k_v;  // we need a copy of shared_ptr to prevent it removing during callback
-      cb->second(*item, await);
+      k_v.second(*item, await);
     }
   }
 }
 
 uint32_t JournalSlice::RegisterOnChange(ChangeCallback cb) {
+  // mutex lock isn't needed due to iterators are not invalidated
   uint32_t id = next_cb_id_++;
-  change_cb_arr_.emplace_back(
-      std::make_shared<std::pair<uint32_t, ChangeCallback>>(id, std::move(cb)));
+  change_cb_arr_.emplace_back(id, std::move(cb));
   return id;
 }
 
 void JournalSlice::UnregisterOnChange(uint32_t id) {
+  // we need to wait until callback is finished before remove it
+  lock_guard lk(cb_mu_);
   auto it = find_if(change_cb_arr_.begin(), change_cb_arr_.end(),
-                    [id](const auto& e) { return e->first == id; });
+                    [id](const auto& e) { return e.first == id; });
   CHECK(it != change_cb_arr_.end());
   change_cb_arr_.erase(it);
 }

--- a/src/server/journal/journal_slice.cc
+++ b/src/server/journal/journal_slice.cc
@@ -191,13 +191,8 @@ void JournalSlice::AddLogRecord(const Entry& entry, bool await) {
     DVLOG(2) << "AddLogRecord: run callbacks for " << entry.ToString()
              << " num callbacks: " << change_cb_arr_.size();
 
-    auto callbacks_num = change_cb_arr_.size();
     for (const auto& k_v : change_cb_arr_) {
       k_v.second(*item, await);
-      --callbacks_num;
-      // durin calbacks call we can add one more callback so we need to prevent call it
-      if (callbacks_num == 0)
-        break;
     }
   }
 }

--- a/src/server/journal/journal_slice.cc
+++ b/src/server/journal/journal_slice.cc
@@ -187,7 +187,7 @@ void JournalSlice::AddLogRecord(const Entry& entry, bool await) {
 
   // TODO: Remove the callbacks, replace with notifiers
   {
-    lock_guard lk(cb_mu_);
+    std::shared_lock lk(cb_mu_);
     DVLOG(2) << "AddLogRecord: run callbacks for " << entry.ToString()
              << " num callbacks: " << change_cb_arr_.size();
 

--- a/src/server/journal/journal_slice.cc
+++ b/src/server/journal/journal_slice.cc
@@ -191,8 +191,13 @@ void JournalSlice::AddLogRecord(const Entry& entry, bool await) {
     DVLOG(2) << "AddLogRecord: run callbacks for " << entry.ToString()
              << " num callbacks: " << change_cb_arr_.size();
 
+    auto callbacks_num = change_cb_arr_.size();
     for (const auto& k_v : change_cb_arr_) {
       k_v.second(*item, await);
+      --callbacks_num;
+      // durin calbacks call we can add one more callback so we need to prevent call it
+      if (callbacks_num == 0)
+        break;
     }
   }
 }

--- a/src/server/journal/journal_slice.h
+++ b/src/server/journal/journal_slice.h
@@ -61,7 +61,8 @@ class JournalSlice {
   std::optional<base::RingBuffer<JournalItem>> ring_buffer_;
   base::IoBuf ring_serialize_buf_;
 
-  std::vector<std::shared_ptr<std::pair<uint32_t, ChangeCallback>>> change_cb_arr_;
+  mutable util::fb2::Mutex cb_mu_;  // to prevent removing callback during call
+  std::list<std::pair<uint32_t, ChangeCallback>> change_cb_arr_;
 
   LSN lsn_ = 1;
 

--- a/src/server/journal/journal_slice.h
+++ b/src/server/journal/journal_slice.h
@@ -61,7 +61,7 @@ class JournalSlice {
   std::optional<base::RingBuffer<JournalItem>> ring_buffer_;
   base::IoBuf ring_serialize_buf_;
 
-  mutable util::fb2::Mutex cb_mu_;  // to prevent removing callback during call
+  mutable util::fb2::SharedMutex cb_mu_;  // to prevent removing callback during call
   std::list<std::pair<uint32_t, ChangeCallback>> change_cb_arr_;
 
   LSN lsn_ = 1;

--- a/src/server/journal/journal_slice.h
+++ b/src/server/journal/journal_slice.h
@@ -47,7 +47,6 @@ class JournalSlice {
   void UnregisterOnChange(uint32_t);
 
   bool HasRegisteredCallbacks() const {
-    std::shared_lock lk(cb_mu_);
     return !change_cb_arr_.empty();
   }
 
@@ -62,8 +61,7 @@ class JournalSlice {
   std::optional<base::RingBuffer<JournalItem>> ring_buffer_;
   base::IoBuf ring_serialize_buf_;
 
-  mutable util::fb2::SharedMutex cb_mu_;
-  std::vector<std::pair<uint32_t, ChangeCallback>> change_cb_arr_ ABSL_GUARDED_BY(cb_mu_);
+  std::vector<std::shared_ptr<std::pair<uint32_t, ChangeCallback>>> change_cb_arr_;
 
   LSN lsn_ = 1;
 

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -627,7 +627,7 @@ void Transaction::RunCallback(EngineShard* shard) {
   DCHECK_EQ(shard, EngineShard::tlocal());
 
   RunnableResult result;
-  auto change_callback_lock = shard->db_slice().GetChangeCbLock();
+  shard->db_slice().LockChangeCb();
   try {
     result = (*cb_ptr_)(this, shard);
 
@@ -665,8 +665,10 @@ void Transaction::RunCallback(EngineShard* shard) {
   // Log to journal only once the command finished running
   if ((coordinator_state_ & COORD_CONCLUDING) || (multi_ && multi_->concluding)) {
     LogAutoJournalOnShard(shard, result);
-    change_callback_lock.unlock();
+    shard->db_slice().UnlockChangeCb();
     MaybeInvokeTrackingCb();
+  } else {
+    shard->db_slice().UnlockChangeCb();
   }
 }
 
@@ -1249,11 +1251,11 @@ OpStatus Transaction::RunSquashedMultiCb(RunnableType cb) {
   DCHECK_EQ(unique_shard_cnt_, 1u);
 
   auto* shard = EngineShard::tlocal();
-  auto change_callback_lock = shard->db_slice().GetChangeCbLock();
+  shard->db_slice().LockChangeCb();
   auto result = cb(this, shard);
   shard->db_slice().OnCbFinish();
   LogAutoJournalOnShard(shard, result);
-  change_callback_lock.unlock();
+  shard->db_slice().UnlockChangeCb();
   MaybeInvokeTrackingCb();
 
   DCHECK_EQ(result.flags, 0);  // if it's sophisticated, we shouldn't squash it


### PR DESCRIPTION
We have a bug with the journal->RegisterOnChange functions:

1) Start 2 tasks with traversing through the whole DB
2) The first task is already work
3) Second task do db_slice_->RegisterOnChange(db_callback)
4) After that second task do journal->RegisterOnChange(..) and yield to another fiber on the mutex JournalSlice::cb_mu_
5) during the 4th step we do LPUSH for example and db_callback save the bucket
6) we still don't have a callback for the journal so we lost data for LPUSH
7) we finish journal->RegisterOnChange(..)

This issue was reproducible in test_cluster_fuzzymigration

Also, I have fixed the issue with db_slice_->UnregisterOnChange() if it was called during callbacks processing (if the fiber yields during callback)