### PR TITLE
fix(generic_family): fix RenameGeneric command for non-string data types

### DIFF
--- a/src/facade/error.h
+++ b/src/facade/error.h
@@ -33,6 +33,7 @@ extern const char kInvalidNumericResult[];
 extern const char kClusterNotConfigured[];
 extern const char kLoadingErr[];
 extern const char kUndeclaredKeyErr[];
+extern const char kInvalidDumpValueErr[];
 
 extern const char kSyntaxErrType[];
 extern const char kScriptErrType[];

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -95,6 +95,7 @@ const char kInvalidNumericResult[] = "result is not a number";
 const char kClusterNotConfigured[] = "Cluster is not yet configured";
 const char kLoadingErr[] = "-LOADING Dragonfly is loading the dataset in memory";
 const char kUndeclaredKeyErr[] = "script tried accessing undeclared key";
+const char kInvalidDumpValueErr[] = "DUMP payload version or checksum are wrong";
 
 const char kSyntaxErrType[] = "syntax_error";
 const char kScriptErrType[] = "script_error";

--- a/src/facade/facade_types.h
+++ b/src/facade/facade_types.h
@@ -163,7 +163,7 @@ struct ErrorReply {
                       std::string_view kind = {})  // to resolve ambiguity of constructors above
       : message{std::string_view{msg}}, kind{kind} {
   }
-  explicit ErrorReply(OpStatus status) : message{}, kind{}, status{status} {
+  ErrorReply(OpStatus status) : message{}, kind{}, status{status} {
   }
 
   std::string_view ToSv() const {

--- a/src/server/generic_family.h
+++ b/src/server/generic_family.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "base/flags.h"
-#include "facade/op_status.h"
+#include "facade/facade_types.h"
 #include "server/common.h"
 #include "server/table.h"
 
@@ -17,6 +17,7 @@ class ProactorPool;
 
 namespace dfly {
 
+using facade::ErrorReply;
 using facade::OpResult;
 using facade::OpStatus;
 
@@ -71,13 +72,13 @@ class GenericFamily {
   static void RandomKey(CmdArgList args, ConnectionContext* cntx);
   static void FieldTtl(CmdArgList args, ConnectionContext* cntx);
 
-  static OpResult<void> RenameGeneric(CmdArgList args, bool destination_should_not_exist,
-                                      ConnectionContext* cntx);
+  static ErrorReply RenameGeneric(CmdArgList args, bool destination_should_not_exist,
+                                  ConnectionContext* cntx);
   static void TtlGeneric(CmdArgList args, ConnectionContext* cntx, TimeUnit unit);
 
   static OpResult<uint64_t> OpTtl(Transaction* t, EngineShard* shard, std::string_view key);
   static OpResult<void> OpRen(const OpArgs& op_args, std::string_view from, std::string_view to,
-                              bool skip_exists);
+                              bool destination_should_not_exist);
   static OpStatus OpMove(const OpArgs& op_args, std::string_view key, DbIndex target_db);
 };
 

--- a/src/server/generic_family.h
+++ b/src/server/generic_family.h
@@ -71,7 +71,7 @@ class GenericFamily {
   static void RandomKey(CmdArgList args, ConnectionContext* cntx);
   static void FieldTtl(CmdArgList args, ConnectionContext* cntx);
 
-  static OpResult<void> RenameGeneric(CmdArgList args, bool skip_exist_dest,
+  static OpResult<void> RenameGeneric(CmdArgList args, bool destination_should_not_exist,
                                       ConnectionContext* cntx);
   static void TtlGeneric(CmdArgList args, ConnectionContext* cntx, TimeUnit unit);
 

--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -25,6 +25,8 @@ class Service;
 
 class DecompressImpl;
 
+using RdbVersion = std::uint16_t;
+
 class RdbLoaderBase {
  protected:
   RdbLoaderBase();
@@ -170,7 +172,7 @@ class RdbLoaderBase {
   std::unique_ptr<DecompressImpl> decompress_impl_;
   JournalReader journal_reader_{nullptr, 0};
   std::optional<uint64_t> journal_offset_ = std::nullopt;
-  int rdb_version_ = RDB_VERSION;
+  RdbVersion rdb_version_ = RDB_VERSION;
 };
 
 class RdbLoader : protected RdbLoaderBase {

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -689,16 +689,16 @@ async def test_rewrites(df_local_factory):
 
         await c_master.set("renamekey", "1000", px=50000)
         await skip_cmd()
-        # Check RENAME turns into DEL SET and PEXPIREAT
+        # Check RENAME turns into DEL and RESTORE
         await check_list_ooo(
             "RENAME renamekey renamed",
-            [r"DEL renamekey", r"SET renamed 1000", r"PEXPIREAT renamed (.*?)"],
+            [r"DEL renamekey", r"RESTORE renamed (.*?) (.*?) REPLACE ABSTTL"],
         )
         await check_expire("renamed")
-        # Check RENAMENX turns into DEL SET and PEXPIREAT
+        # Check RENAMENX turns into DEL and RESTORE
         await check_list_ooo(
             "RENAMENX renamed renamekey",
-            [r"DEL renamed", r"SET renamekey 1000", r"PEXPIREAT renamekey (.*?)"],
+            [r"DEL renamed", r"RESTORE renamekey (.*?) (.*?) REPLACE ABSTTL"],
         )
         await check_expire("renamekey")
 


### PR DESCRIPTION
fixes dragonflydb#3107, fixes dragonflydb#3113, fixes dragonflydb#307

Implemented using the `DUMP` and `RESTORE` commands, as mentioned [here](https://github.com/dragonflydb/dragonfly/issues/604#issuecomment-1373055960)

Some functionality still is not working due to #837. So I can try to fix the issue with `RESTORE` command or implement `RENAME` command in another way