### PR TITLE
chore: allow calling Context::ReportError from I/O dispatch fiber

### DIFF
--- a/src/server/common.h
+++ b/src/server/common.h
@@ -279,12 +279,12 @@ class Context : protected Cancellation {
   // Report error.
   GenericError ReportErrorInternal(GenericError&& err);
 
- private:
   GenericError err_;
-  mutable util::fb2::Mutex mu_;
-
   ErrHandler err_handler_;
   util::fb2::Fiber err_handler_fb_;
+
+  // We use regular mutexes to be able to call ReportError directly from I/O callbacks.
+  mutable std::mutex err_mu_;  // protects err_ and err_handler_
 };
 
 struct ScanOpts {

--- a/src/server/protocol_client.cc
+++ b/src/server/protocol_client.cc
@@ -155,6 +155,8 @@ ProtocolClient::ProtocolClient(ServerContext context) : server_context_(std::mov
 }
 
 ProtocolClient::~ProtocolClient() {
+  cntx_.JoinErrorHandler();
+
   // FIXME: We should close the socket explictly outside of the destructor. This currently
   // breaks test_cancel_replication_immediately.
   if (sock_) {


### PR DESCRIPTION
Fixes the issue when we are trying to Report the error from JournalStreamer::OnCompletion that is called from a proactor callback directly from the I/O fiber.

We can not use fiber mutexes in the I/O fiber so we switch to regular mutex and reduce its critical sections as much as possible.

Should fix the following failure:
https://github.com/dragonflydb/dragonfly/actions/runs/9536876957/job/26284317328#step:6:622

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->