### PR TITLE
fix(server): Rename confusing flag `replica_reconnect_on_master_restart`

### DIFF
--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -44,7 +44,7 @@ ABSL_FLAG(bool, break_replication_on_master_restart, false,
 ABSL_DECLARE_FLAG(int32_t, port);
 
 // TODO: Remove this flag on release >= 1.22
-ABSL_FLAG(bool, replica_reconnect_on_master_restart, true,
+ABSL_FLAG(bool, replica_reconnect_on_master_restart, false,
           "Deprecated - please use --break_replication_on_master_restart.");
 
 namespace dfly {

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -38,9 +38,14 @@ ABSL_FLAG(int, master_reconnect_timeout_ms, 1000,
           "Timeout for re-establishing connection to a replication master");
 ABSL_FLAG(bool, replica_partial_sync, true,
           "Use partial sync to reconnect when a replica connection is interrupted.");
-ABSL_FLAG(bool, replica_reconnect_on_master_restart, false,
-          "When in replica mode, and master restarts, break replication from master.");
+ABSL_FLAG(bool, break_replication_on_master_restart, false,
+          "When in replica mode, and master restarts, break replication from master to avoid "
+          "flushing the replica's data.");
 ABSL_DECLARE_FLAG(int32_t, port);
+
+// TODO: Remove this flag on release >= 1.22
+ABSL_RETIRED_FLAG(bool, replica_reconnect_on_master_restart, false,
+                  "When in replica mode, and master restarts, break replication from master.");
 
 namespace dfly {
 
@@ -303,7 +308,7 @@ std::error_code Replica::HandleCapaDflyResp() {
   // If we're syncing a different replication ID, drop the saved LSNs.
   string_view master_repl_id = ToSV(LastResponseArgs()[0].GetBuf());
   if (master_context_.master_repl_id != master_repl_id) {
-    if (absl::GetFlag(FLAGS_replica_reconnect_on_master_restart) &&
+    if (absl::GetFlag(FLAGS_break_replication_on_master_restart) &&
         !master_context_.master_repl_id.empty()) {
       LOG(ERROR) << "Encountered different master repl id (" << master_repl_id << " vs "
                  << master_context_.master_repl_id << ")";

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -44,8 +44,8 @@ ABSL_FLAG(bool, break_replication_on_master_restart, false,
 ABSL_DECLARE_FLAG(int32_t, port);
 
 // TODO: Remove this flag on release >= 1.22
-ABSL_RETIRED_FLAG(bool, replica_reconnect_on_master_restart, false,
-                  "When in replica mode, and master restarts, break replication from master.");
+ABSL_FLAG(bool, replica_reconnect_on_master_restart, true,
+          "Deprecated - please use --break_replication_on_master_restart.");
 
 namespace dfly {
 
@@ -308,7 +308,8 @@ std::error_code Replica::HandleCapaDflyResp() {
   // If we're syncing a different replication ID, drop the saved LSNs.
   string_view master_repl_id = ToSV(LastResponseArgs()[0].GetBuf());
   if (master_context_.master_repl_id != master_repl_id) {
-    if (absl::GetFlag(FLAGS_break_replication_on_master_restart) &&
+    if ((absl::GetFlag(FLAGS_replica_reconnect_on_master_restart) ||
+         absl::GetFlag(FLAGS_break_replication_on_master_restart)) &&
         !master_context_.master_repl_id.empty()) {
       LOG(ERROR) << "Encountered different master repl id (" << master_repl_id << " vs "
                  << master_context_.master_repl_id << ")";

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2164,7 +2164,7 @@ async def test_replica_reconnect(df_local_factory, break_conn):
     # Connect replica to master
     master = df_local_factory.create(proactor_threads=1)
     replica = df_local_factory.create(
-        proactor_threads=1, replica_reconnect_on_master_restart=break_conn
+        proactor_threads=1, break_replication_on_master_restart=break_conn
     )
     df_local_factory.start_all([master, replica])
 


### PR DESCRIPTION
That was a misleading name, as the logic was the exact opposite (oops :facepalm:)

This PR introduces a new name for the same flag: `break_replication_on_master_restart`

We're keeping the previous flag for now, to make transition easier. We'll remove it in a later Dragonfly version (>= 1.22)

Fixes #3192

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->