### PR TITLE
fix: replicaof_reject_on_load flake

### DIFF
--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -37,10 +37,7 @@ runs:
         export DRAGONFLY_PATH="${GITHUB_WORKSPACE}/${{inputs.build-folder-name}}/${{inputs.dfly-executable}}"
         export UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 # to crash on errors
 
-        #timeout 40m pytest -m "${{inputs.filter}}" --durations=10 --color=yes --json-report --json-report-file=report.json dragonfly --log-cli-level=INFO || code=$?
-        timeout 20m pytest -m "${{inputs.filter}}" --durations=10 --color=yes --json-report \
-          --json-report-file=rep1_report.json dragonfly/replication_test.py --log-cli-level=INFO \
-          --df alsologtostderr $1 $2 || code=$?
+        timeout 40m pytest -m "${{inputs.filter}}" --durations=10 --color=yes --json-report --json-report-file=report.json dragonfly --log-cli-level=INFO || code=$?
 
         # timeout returns 124 if we exceeded the timeout duration
         if [[ $code -eq 124 ]]; then

--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -37,7 +37,10 @@ runs:
         export DRAGONFLY_PATH="${GITHUB_WORKSPACE}/${{inputs.build-folder-name}}/${{inputs.dfly-executable}}"
         export UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 # to crash on errors
 
-        timeout 40m pytest -m "${{inputs.filter}}" --durations=10 --color=yes --json-report --json-report-file=report.json dragonfly --log-cli-level=INFO || code=$?
+        #timeout 40m pytest -m "${{inputs.filter}}" --durations=10 --color=yes --json-report --json-report-file=report.json dragonfly --log-cli-level=INFO || code=$?
+        timeout 20m pytest -m "${{inputs.filter}}" --durations=10 --color=yes --json-report \
+          --json-report-file=rep1_report.json dragonfly/replication_test.py --log-cli-level=INFO \
+          --df alsologtostderr $1 $2 || code=$?
 
         # timeout returns 124 if we exceeded the timeout duration
         if [[ $code -eq 124 ]]; then

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1909,7 +1909,6 @@ async def test_replicaof_reject_on_load(df_local_factory, df_seeder_factory):
     # Check replica of not alowed while loading snapshot
     try:
         await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
-        assert "loading:1" in (await c_replica.execute_command("INFO PERSISTENCE"))
         assert False
     except aioredis.BusyLoadingError as e:
         assert "Dragonfly is loading the dataset in memory" in str(e)

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1908,8 +1908,8 @@ async def test_replicaof_reject_on_load(df_local_factory, df_seeder_factory):
     c_replica = replica.client()
     # Check replica of not alowed while loading snapshot
     try:
-        assert "loading:1" in (await c_replica.execute_command("INFO PERSISTENCE"))
         await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
+        assert "loading:1" in (await c_replica.execute_command("INFO PERSISTENCE"))
         assert False
     except aioredis.BusyLoadingError as e:
         assert "Dragonfly is loading the dataset in memory" in str(e)

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1897,11 +1897,11 @@ async def test_replicaof_reject_on_load(df_local_factory, df_seeder_factory):
     replica = df_local_factory.create(dbfilename=f"dump_{tmp_file_name}")
     df_local_factory.start_all([master, replica])
 
-    seeder = df_seeder_factory.create(port=replica.port, keys=30000)
+    seeder = df_seeder_factory.create(port=replica.port, keys=40000)
     await seeder.run(target_deviation=0.1)
     c_replica = replica.client()
     dbsize = await c_replica.dbsize()
-    assert dbsize >= 9000
+    assert dbsize >= 30000
 
     replica.stop()
     replica.start()

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1897,7 +1897,7 @@ async def test_replicaof_reject_on_load(df_local_factory, df_seeder_factory):
     replica = df_local_factory.create(dbfilename=f"dump_{tmp_file_name}")
     df_local_factory.start_all([master, replica])
 
-    seeder = SeederV2(keys=40000)
+    seeder = SeederV2(key_target=40000)
     c_replica = replica.client()
     await seeder.run(c_replica, target_deviation=0.1)
     dbsize = await c_replica.dbsize()

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1908,6 +1908,7 @@ async def test_replicaof_reject_on_load(df_local_factory, df_seeder_factory):
     c_replica = replica.client()
     # Check replica of not alowed while loading snapshot
     try:
+        assert "loading:1" in (await c_replica.execute_command("INFO PERSISTENCE"))
         await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
         assert False
     except aioredis.BusyLoadingError as e:


### PR DESCRIPTION
The bug is that by the time we issue a `REPLICA OF` command `dragonfly` might finish loading the snapshot triggering a false positive assertion later on. I increased the snapshot size to provide a smaller window for this issue as I would not like to relax the contstrains.

Furthermore, the reason that some of the logs did not exist in the failed log files is that assertions in pytest kill the process bypassing the `SIGTERM` handlers we defined (and consequently loose some portion of the logs)  