### PR TITLE
fix(tiering): Fix pending leak during immediate stash error

### DIFF
--- a/src/server/tiering/disk_storage.cc
+++ b/src/server/tiering/disk_storage.cc
@@ -181,7 +181,7 @@ DiskStorage::Stats DiskStorage::GetStats() const {
 std::error_code DiskStorage::Grow(off_t grow_size) {
   off_t start = size_;
 
-  if (off_t(alloc_.capacity()) + grow_size >= max_size_)
+  if (off_t(alloc_.capacity()) + grow_size > max_size_)
     return std::make_error_code(std::errc::no_space_on_device);
 
   if (std::exchange(grow_pending_, true))


### PR DESCRIPTION
* Sneaky bug, found it during benchmarks - we don't clear pending_stash_ver_ with immediate errors
* Fix resize bug during multiples of min grow size, need to use >