### PR TITLE
chore(tiering): Fixes

### DIFF
--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -361,7 +361,15 @@ TieredStats TieredStorage::GetStats() const {
 }
 
 void TieredStorage::RunOffloading(DbIndex dbid) {
+  const size_t kMaxIterations = 500;
+
   if (SliceSnapshot::IsSnaphotInProgress())
+    return;
+
+  // Don't run offloading if there's only very little space left
+  auto disk_stats = op_manager_->GetStats().disk_stats;
+  if (disk_stats.allocated_bytes + kMaxIterations / 2 * tiering::kPageSize >
+      disk_stats.max_file_size)
     return;
 
   auto cb = [this, dbid, tmp = std::string{}](PrimeIterator it) mutable {
@@ -378,12 +386,14 @@ void TieredStorage::RunOffloading(DbIndex dbid) {
     if (op_manager_->GetStats().pending_stash_cnt >= write_depth_limit_)
       break;
     offloading_cursor_ = table.TraverseBySegmentOrder(offloading_cursor_, cb);
-  } while (offloading_cursor_ != start_cursor && iterations++ < 500);
+  } while (offloading_cursor_ != start_cursor && iterations++ < kMaxIterations);
 }
 
 bool TieredStorage::ShouldStash(const PrimeValue& pv) const {
+  auto disk_stats = op_manager_->GetStats().disk_stats;
   return !pv.IsExternal() && !pv.HasIoPending() && pv.ObjType() == OBJ_STRING &&
-         pv.Size() >= kMinValueSize;
+         pv.Size() >= kMinValueSize &&
+         disk_stats.allocated_bytes + tiering::kPageSize + pv.Size() < disk_stats.max_file_size;
 }
 
 }  // namespace dfly

--- a/src/server/tiering/disk_storage.h
+++ b/src/server/tiering/disk_storage.h
@@ -22,6 +22,7 @@ class DiskStorage {
     size_t capacity_bytes = 0;
     uint64_t heap_buf_alloc_count = 0;
     uint64_t registered_buf_alloc_count = 0;
+    size_t max_file_size = 0;
   };
 
   using ReadCb = std::function<void(std::string_view, std::error_code)>;


### PR DESCRIPTION
Don't run offloading and stashing if we know ahead that there won't be enough space left