### PR TITLE
fix: fix deadlock in DFLYCLUSTER CONFIG command and outgoing migration finaliztion

### DIFF
--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -31,7 +31,8 @@ class ClusterFamily {
   // Returns a thread-local pointer.
   ClusterConfig* cluster_config();
 
-  void UpdateConfig(const std::vector<SlotRange>& slots, bool enable);
+  void ApplyMigrationSlotRangeToConfig(std::string_view node_id, const SlotRanges& slots,
+                                       bool is_outgoing);
 
   const std::string& MyID() const {
     return id_;
@@ -97,7 +98,8 @@ class ClusterFamily {
  private:
   ClusterShardInfo GetEmulatedShardInfo(ConnectionContext* cntx) const;
 
-  mutable util::fb2::Mutex config_update_mu_;
+  // Guards set configuration, so that we won't handle 2 in parallel.
+  mutable util::fb2::Mutex set_config_mu;
 
   std::string id_;
 

--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -309,7 +309,8 @@ bool OutgoingMigration::FinalizeMigration(long attempt) {
   Finish(is_error);
   if (!is_error) {
     keys_number_ = cluster::GetKeyCount(migration_info_.slot_ranges);
-    cf_->UpdateConfig(migration_info_.slot_ranges, false);
+    cf_->ApplyMigrationSlotRangeToConfig(migration_info_.node_id, migration_info_.slot_ranges,
+                                         false);
     VLOG(1) << "Config is updated for " << cf_->MyID();
   }
   return true;


### PR DESCRIPTION
DispatchTracker hasn't ignored the paused connections which was the reason for deadlock.