### PR TITLE
fix(pytest): timed ticker for simpler conditions

### DIFF
--- a/tests/dragonfly/utility.py
+++ b/tests/dragonfly/utility.py
@@ -40,6 +40,51 @@ def batch_fill_data(client, gen, batch_size=100):
         client.mset({k: v for k, v, in group})
 
 
+async def tick_timer(func, timeout=5, step=0.1):
+    """
+    Async generator with automatic break when all asserts pass
+
+    for object, breaker in tick_timer():
+        with breaker:
+            assert conditions on object
+
+    If the generator times out, the last failed assert is raised
+    """
+
+    class ticker_breaker:
+        def __init__(self):
+            self.exc = None
+            self.entered = False
+
+        def __enter__(self):
+            self.entered = True
+
+        def __exit__(self, exc_type, exc_value, trace):
+            if exc_value:
+                self.exc = exc_value
+                return True
+
+    last_error = None
+    start = time.time()
+    while time.time() - start < timeout:
+        breaker = ticker_breaker()
+        yield (await func(), breaker)
+        if breaker.entered and not breaker.exc:
+            return
+
+        last_error = breaker.exc
+        await asyncio.sleep(step)
+
+    if last_error:
+        raise RuntimeError("Timed out!") from last_error
+    raise RuntimeError("Timed out!")
+
+
+async def info_tick_timer(client: aioredis.Redis, section=None, **kwargs):
+    async for x in tick_timer(lambda: client.info(section), **kwargs):
+        yield x
+
+
 async def wait_available_async(client: aioredis.Redis, timeout=10):
     """Block until instance exits loading phase"""
     its = 0


### PR DESCRIPTION
A gift 🎁 to Roman 😆 

Async generator with automatic break when all asserts pass

```py
for object, breaker in tick_timer(lambda: obj()):
  with breaker:
    assert conditions on object
    ...
```

if the asserts don't pass, it throws a timeout error together with an assert error to see the cause
