### PR TITLE
fix: fix move error during migration finalization

### DIFF
--- a/src/server/cluster/cluster_config.h
+++ b/src/server/cluster/cluster_config.h
@@ -58,6 +58,7 @@ class ClusterConfig {
 
   ClusterConfig() = default;
 
+  std::string my_id_;
   ClusterShardInfos config_;
 
   SlotSet my_slots_;

--- a/src/server/cluster/cluster_config.h
+++ b/src/server/cluster/cluster_config.h
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "src/server/cluster/slot_set.h"
-#include "src/server/common.h"
 
 namespace dfly::cluster {
 

--- a/src/server/cluster/cluster_config_test.cc
+++ b/src/server/cluster/cluster_config_test.cc
@@ -96,7 +96,7 @@ TEST_F(ClusterConfigTest, ConfigSetInvalidEmpty) {
 
 TEST_F(ClusterConfigTest, ConfigSetInvalidMissingSlots) {
   EXPECT_EQ(ClusterConfig::CreateFromConfig(
-                kMyId, {{.slot_ranges = std::vector<SlotRange>{{.start = 0, .end = 16000}},
+                kMyId, {{.slot_ranges = SlotRanges({{.start = 0, .end = 16000}}),
                          .master = {.id = "other", .ip = "192.168.0.100", .port = 7000},
                          .replicas = {},
                          .migrations = {}}}),
@@ -105,11 +105,11 @@ TEST_F(ClusterConfigTest, ConfigSetInvalidMissingSlots) {
 
 TEST_F(ClusterConfigTest, ConfigSetInvalidDoubleBookedSlot) {
   EXPECT_EQ(ClusterConfig::CreateFromConfig(
-                kMyId, {{.slot_ranges = std::vector<SlotRange>{{.start = 0, .end = 0x3FFF}},
+                kMyId, {{.slot_ranges = SlotRanges({{.start = 0, .end = 0x3FFF}}),
                          .master = {.id = "other", .ip = "192.168.0.100", .port = 7000},
                          .replicas = {},
                          .migrations = {}},
-                        {.slot_ranges = std::vector<SlotRange>{{.start = 0, .end = 0}},
+                        {.slot_ranges = SlotRanges({{.start = 0, .end = 0}}),
                          .master = {.id = "other2", .ip = "192.168.0.101", .port = 7001},
                          .replicas = {},
                          .migrations = {}}}),
@@ -118,7 +118,7 @@ TEST_F(ClusterConfigTest, ConfigSetInvalidDoubleBookedSlot) {
 
 TEST_F(ClusterConfigTest, ConfigSetInvalidSlotId) {
   EXPECT_EQ(ClusterConfig::CreateFromConfig(
-                kMyId, {{.slot_ranges = std::vector<SlotRange>{{.start = 0, .end = 0x3FFF + 1}},
+                kMyId, {{.slot_ranges = SlotRanges({{.start = 0, .end = 0x3FFF + 1}}),
                          .master = {.id = "other", .ip = "192.168.0.100", .port = 7000},
                          .replicas = {},
                          .migrations = {}}}),
@@ -127,7 +127,7 @@ TEST_F(ClusterConfigTest, ConfigSetInvalidSlotId) {
 
 TEST_F(ClusterConfigTest, ConfigSetOk) {
   auto config = ClusterConfig::CreateFromConfig(
-      kMyId, {{.slot_ranges = std::vector<SlotRange>{{.start = 0, .end = 0x3FFF}},
+      kMyId, {{.slot_ranges = SlotRanges({{.start = 0, .end = 0x3FFF}}),
                .master = {.id = "other", .ip = "192.168.0.100", .port = 7000},
                .replicas = {},
                .migrations = {}}});
@@ -139,7 +139,7 @@ TEST_F(ClusterConfigTest, ConfigSetOk) {
 
 TEST_F(ClusterConfigTest, ConfigSetOkWithReplica) {
   auto config = ClusterConfig::CreateFromConfig(
-      kMyId, {{.slot_ranges = std::vector<SlotRange>{{.start = 0, .end = 0x3FFF}},
+      kMyId, {{.slot_ranges = SlotRanges({{.start = 0, .end = 0x3FFF}}),
                .master = {.id = "other-master", .ip = "192.168.0.100", .port = 7000},
                .replicas = {{.id = "other-replica", .ip = "192.168.0.101", .port = 7001}},
                .migrations = {}}});
@@ -150,15 +150,15 @@ TEST_F(ClusterConfigTest, ConfigSetOkWithReplica) {
 
 TEST_F(ClusterConfigTest, ConfigSetMultipleInstances) {
   auto config = ClusterConfig::CreateFromConfig(
-      kMyId, {{.slot_ranges = std::vector<SlotRange>{{.start = 0, .end = 5'000}},
+      kMyId, {{.slot_ranges = SlotRanges({{.start = 0, .end = 5'000}}),
                .master = {.id = "other-master", .ip = "192.168.0.100", .port = 7000},
                .replicas = {{.id = "other-replica", .ip = "192.168.0.101", .port = 7001}},
                .migrations = {}},
-              {.slot_ranges = std::vector<SlotRange>{{.start = 5'001, .end = 10'000}},
+              {.slot_ranges = SlotRanges({{.start = 5'001, .end = 10'000}}),
                .master = {.id = kMyId, .ip = "192.168.0.102", .port = 7002},
                .replicas = {{.id = "other-replica2", .ip = "192.168.0.103", .port = 7003}},
                .migrations = {}},
-              {.slot_ranges = std::vector<SlotRange>{{.start = 10'001, .end = 0x3FFF}},
+              {.slot_ranges = SlotRanges({{.start = 10'001, .end = 0x3FFF}}),
                .master = {.id = "other-master3", .ip = "192.168.0.104", .port = 7004},
                .replicas = {{.id = "other-replica3", .ip = "192.168.0.105", .port = 7005}},
                .migrations = {}}});
@@ -481,7 +481,7 @@ TEST_F(ClusterConfigTest, ConfigSetMigrations) {
   auto config1 = ClusterConfig::CreateFromConfig("id0", config_str);
   EXPECT_EQ(
       config1->GetNewOutgoingMigrations(nullptr),
-      (std::vector<MigrationInfo>{{.slot_ranges = std::vector<SlotRange>{{7000, 8000}},
+      (std::vector<MigrationInfo>{{.slot_ranges = SlotRanges({{7000, 8000}}),
                                    .node_info = {.id = "id1", .ip = "127.0.0.1", .port = 9001}}}));
 
   EXPECT_TRUE(config1->GetFinishedOutgoingMigrations(nullptr).empty());
@@ -491,7 +491,7 @@ TEST_F(ClusterConfigTest, ConfigSetMigrations) {
   auto config2 = ClusterConfig::CreateFromConfig("id1", config_str);
   EXPECT_EQ(
       config2->GetNewIncomingMigrations(nullptr),
-      (std::vector<MigrationInfo>{{.slot_ranges = std::vector<SlotRange>{{7000, 8000}},
+      (std::vector<MigrationInfo>{{.slot_ranges = SlotRanges({{7000, 8000}}),
                                    .node_info = {.id = "id0", .ip = "127.0.0.1", .port = 9001}}}));
 
   EXPECT_TRUE(config2->GetFinishedOutgoingMigrations(nullptr).empty());
@@ -523,7 +523,7 @@ TEST_F(ClusterConfigTest, ConfigSetMigrations) {
 
   EXPECT_EQ(
       config4->GetFinishedOutgoingMigrations(config1),
-      (std::vector<MigrationInfo>{{.slot_ranges = std::vector<SlotRange>{{7000, 8000}},
+      (std::vector<MigrationInfo>{{.slot_ranges = SlotRanges({{7000, 8000}}),
                                    .node_info = {.id = "id1", .ip = "127.0.0.1", .port = 9001}}}));
   EXPECT_TRUE(config4->GetNewIncomingMigrations(config1).empty());
   EXPECT_TRUE(config4->GetFinishedIncomingMigrations(config1).empty());
@@ -531,7 +531,7 @@ TEST_F(ClusterConfigTest, ConfigSetMigrations) {
 
   EXPECT_EQ(
       config5->GetFinishedIncomingMigrations(config2),
-      (std::vector<MigrationInfo>{{.slot_ranges = std::vector<SlotRange>{{7000, 8000}},
+      (std::vector<MigrationInfo>{{.slot_ranges = SlotRanges({{7000, 8000}}),
                                    .node_info = {.id = "id0", .ip = "127.0.0.1", .port = 9001}}}));
   EXPECT_TRUE(config5->GetNewIncomingMigrations(config2).empty());
   EXPECT_TRUE(config5->GetFinishedOutgoingMigrations(config2).empty());
@@ -589,7 +589,7 @@ TEST_F(ClusterConfigTest, SlotSetAPI) {
     ss.Set(5010, true);
     EXPECT_EQ(ss.ToSlotRanges(), SlotRanges({{0, 2000}, {5010, 5010}}));
 
-    ss.Set(std::vector<SlotRange>{{5000, 5100}}, true);
+    ss.Set(SlotRanges({{5000, 5100}}), true);
     EXPECT_EQ(ss.ToSlotRanges(), SlotRanges({{0, 2000}, {5000, 5100}}));
 
     ss.Set(5050, false);
@@ -598,7 +598,7 @@ TEST_F(ClusterConfigTest, SlotSetAPI) {
     ss.Set(5500, false);
     EXPECT_EQ(ss.ToSlotRanges(), SlotRanges({{0, 2000}, {5000, 5049}, {5051, 5100}}));
 
-    ss.Set(std::vector<SlotRange>{{5090, 5100}}, false);
+    ss.Set(SlotRanges({{5090, 5100}}), false);
     EXPECT_EQ(ss.ToSlotRanges(), SlotRanges({{0, 2000}, {5000, 5049}, {5051, 5089}}));
 
     SlotSet ss1(SlotRanges({{1001, 2000}}));

--- a/src/server/cluster/cluster_defs.cc
+++ b/src/server/cluster/cluster_defs.cc
@@ -9,6 +9,7 @@ extern "C" {
 #include "base/flags.h"
 #include "base/logging.h"
 #include "cluster_defs.h"
+#include "slot_set.h"
 #include "src/server/common.h"
 
 using namespace std;
@@ -24,9 +25,11 @@ SlotRanges::SlotRanges(std::vector<SlotRange> ranges) : ranges_(std::move(ranges
   std::sort(ranges_.begin(), ranges_.end());
 }
 
-void SlotRanges::Extend(const SlotRanges& sr) {
-  ranges_.insert(ranges_.end(), sr.ranges_.begin(), sr.ranges_.end());
-  std::sort(ranges_.begin(), ranges_.end());
+void SlotRanges::Merge(const SlotRanges& sr) {
+  // TODO rewrite it
+  SlotSet slots(*this);
+  slots.Set(sr, true);
+  ranges_ = std::move(slots.ToSlotRanges().ranges_);
 }
 
 std::string SlotRanges::ToString() const {

--- a/src/server/cluster/cluster_defs.h
+++ b/src/server/cluster/cluster_defs.h
@@ -4,10 +4,7 @@
 
 #pragma once
 
-#include <absl/strings/str_cat.h>
-#include <absl/strings/str_join.h>
-
-#include <memory>
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -24,45 +21,85 @@ struct SlotRange {
   SlotId start = 0;
   SlotId end = 0;
 
-  bool operator==(const SlotRange& r) const {
+  bool operator==(const SlotRange& r) const noexcept {
     return start == r.start && end == r.end;
   }
-  bool IsValid() {
+
+  bool operator<(const SlotRange& r) {
+    return start < r.start || (start == r.start && end < r.end);
+  }
+
+  bool IsValid() const noexcept {
     return start <= end && start <= kMaxSlotId && end <= kMaxSlotId;
   }
 
-  std::string ToString() const {
-    return absl::StrCat("[", start, ", ", end, "]");
+  bool Contains(SlotId id) const noexcept {
+    return id >= start && id <= end;
   }
 
-  static std::string ToString(const std::vector<SlotRange>& ranges) {
-    return absl::StrJoin(ranges, ", ", [](std::string* out, SlotRange range) {
-      absl::StrAppend(out, range.ToString());
-    });
-  }
+  std::string ToString() const;
 };
 
-using SlotRanges = std::vector<SlotRange>;
+class SlotRanges {
+ public:
+  SlotRanges() = default;
+  SlotRanges(std::vector<SlotRange> ranges);
+
+  bool Contains(SlotId id) const noexcept {
+    for (const auto& sr : ranges_) {
+      if (sr.Contains(id))
+        return true;
+    }
+    return false;
+  }
+
+  size_t Size() const noexcept {
+    return ranges_.size();
+  }
+
+  bool Empty() const noexcept {
+    return ranges_.empty();
+  }
+
+  void Extend(const SlotRanges& sr);
+
+  bool operator==(const SlotRanges& r) const noexcept {
+    return ranges_ == r.ranges_;
+  }
+
+  std::string ToString() const;
+
+  friend auto begin(const SlotRanges& sr) noexcept {
+    return sr.ranges_.cbegin();
+  }
+
+  friend auto end(const SlotRanges& sr) noexcept {
+    return sr.ranges_.cend();
+  }
+
+ private:
+  std::vector<SlotRange> ranges_;
+};
 
 struct ClusterNodeInfo {
   std::string id;
   std::string ip;
-  uint16_t port = 0;
+  std::uint16_t port = 0;
+
+  bool operator==(const ClusterNodeInfo& r) const noexcept {
+    return port == r.port && ip == r.ip && id == r.id;
+  }
 };
 
 struct MigrationInfo {
-  std::vector<SlotRange> slot_ranges;
-  std::string node_id;
-  std::string ip;
-  uint16_t port = 0;
+  SlotRanges slot_ranges;
+  ClusterNodeInfo node_info;
 
-  bool operator==(const MigrationInfo& r) const {
-    return ip == r.ip && port == r.port && slot_ranges == r.slot_ranges && node_id == r.node_id;
+  bool operator==(const MigrationInfo& r) const noexcept {
+    return node_info == r.node_info && slot_ranges == r.slot_ranges;
   }
 
-  std::string ToString() const {
-    return absl::StrCat(node_id, ",", ip, ":", port, " (", SlotRange::ToString(slot_ranges), ")");
-  }
+  std::string ToString() const;
 };
 
 struct ClusterShardInfo {

--- a/src/server/cluster/cluster_defs.h
+++ b/src/server/cluster/cluster_defs.h
@@ -25,7 +25,7 @@ struct SlotRange {
     return start == r.start && end == r.end;
   }
 
-  bool operator<(const SlotRange& r) {
+  bool operator<(const SlotRange& r) const noexcept {
     return start < r.start || (start == r.start && end < r.end);
   }
 
@@ -43,7 +43,7 @@ struct SlotRange {
 class SlotRanges {
  public:
   SlotRanges() = default;
-  SlotRanges(std::vector<SlotRange> ranges);
+  explicit SlotRanges(std::vector<SlotRange> ranges);
 
   bool Contains(SlotId id) const noexcept {
     for (const auto& sr : ranges_) {
@@ -61,7 +61,7 @@ class SlotRanges {
     return ranges_.empty();
   }
 
-  void Extend(const SlotRanges& sr);
+  void Merge(const SlotRanges& sr);
 
   bool operator==(const SlotRanges& r) const noexcept {
     return ranges_ == r.ranges_;
@@ -69,12 +69,12 @@ class SlotRanges {
 
   std::string ToString() const;
 
-  friend auto begin(const SlotRanges& sr) noexcept {
-    return sr.ranges_.cbegin();
+  auto begin() const noexcept {
+    return ranges_.cbegin();
   }
 
-  friend auto end(const SlotRanges& sr) noexcept {
-    return sr.ranges_.cend();
+  auto end() const noexcept {
+    return ranges_.cend();
   }
 
  private:
@@ -84,7 +84,7 @@ class SlotRanges {
 struct ClusterNodeInfo {
   std::string id;
   std::string ip;
-  std::uint16_t port = 0;
+  uint16_t port = 0;
 
   bool operator==(const ClusterNodeInfo& r) const noexcept {
     return port == r.port && ip == r.ip && id == r.id;

--- a/src/server/cluster/incoming_slot_migration.cc
+++ b/src/server/cluster/incoming_slot_migration.cc
@@ -144,7 +144,7 @@ bool IncomingSlotMigration::Join() {
 
 void IncomingSlotMigration::Stop() {
   string_view log_state = state_.load() == MigrationState::C_FINISHED ? "Finishing" : "Cancelling";
-  LOG(INFO) << log_state << " incoming migration of slots " << SlotRange::ToString(slots_);
+  LOG(INFO) << log_state << " incoming migration of slots " << slots_.ToString();
   cntx_.Cancel();
 
   for (auto& flow : shard_flows_) {
@@ -156,11 +156,10 @@ void IncomingSlotMigration::Stop() {
 }
 
 void IncomingSlotMigration::StartFlow(uint32_t shard, util::FiberSocketBase* source) {
-  VLOG(1) << "Start flow for shard: " << shard;
   state_.store(MigrationState::C_SYNC);
 
   shard_flows_[shard]->Start(&cntx_, source, bc_);
-  VLOG(1) << "Incoming slot migration flow for shard: " << shard << " finished";
+  VLOG(1) << "Incoming flow: " << shard << " finished for " << source_id_;
 }
 
 size_t IncomingSlotMigration::GetKeyCount() const {

--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -78,7 +78,7 @@ class OutgoingMigration::SliceSlotMigration : private ProtocolClient {
 };
 
 OutgoingMigration::OutgoingMigration(MigrationInfo info, ClusterFamily* cf, ServerFamily* sf)
-    : ProtocolClient(info.ip, info.port),
+    : ProtocolClient(info.node_info.ip, info.node_info.port),
       migration_info_(std::move(info)),
       slot_migrations_(shard_set->size()),
       server_family_(sf),
@@ -107,6 +107,8 @@ bool OutgoingMigration::ChangeState(MigrationState new_state) {
 }
 
 void OutgoingMigration::Finish(bool is_error) {
+  VLOG(1) << "Finish outgoing migration for " << cf_->MyID() << " : "
+          << migration_info_.node_info.id;
   bool should_cancel_flows = false;
 
   {
@@ -217,20 +219,18 @@ void OutgoingMigration::SyncFb() {
     });
 
     if (CheckFlowsForErrors()) {
-      VLOG(1) << "Errors detected, retrying outgoing migration";
+      LOG(WARNING) << "Errors detected, retrying outgoing migration";
       continue;
     }
-
-    VLOG(2) << "Migrations snapshot is finished";
 
     long attempt = 0;
     while (GetState() != MigrationState::C_FINISHED && !FinalizeMigration(++attempt)) {
       // process commands that were on pause and try again
-      VLOG(2) << "Waiting for migration to finalize...";
+      VLOG(1) << "Waiting for migration to finalize...";
       ThisFiber::SleepFor(500ms);
     }
     if (CheckFlowsForErrors()) {
-      VLOG(1) << "Errors detected, retrying outgoing migration";
+      LOG(WARNING) << "Errors detected, retrying outgoing migration";
       continue;
     }
     break;
@@ -242,6 +242,7 @@ void OutgoingMigration::SyncFb() {
 bool OutgoingMigration::FinalizeMigration(long attempt) {
   // if it's not the 1st attempt and flows are work correctly we try to reconnect and ACK one more
   // time
+  VLOG(1) << "FinalizeMigration for " << cf_->MyID() << " : " << migration_info_.node_info.id;
   if (attempt > 1) {
     if (CheckFlowsForErrors()) {
       Finish(true);
@@ -271,11 +272,11 @@ bool OutgoingMigration::FinalizeMigration(long attempt) {
 
   auto cb = [this](util::ProactorBase* pb) {
     if (const auto* shard = EngineShard::tlocal(); shard) {
-      VLOG(1) << "FINALIZE outgoing migration" << shard->shard_id();
       slot_migrations_[shard->shard_id()]->Finalize();
     }
   };
 
+  VLOG(1) << "FINALIZE flows for " << cf_->MyID() << " : " << migration_info_.node_info.id;
   shard_set->pool()->AwaitFiberOnAll(std::move(cb));
 
   auto cmd = absl::StrCat("DFLYMIGRATE ACK ", cf_->MyID(), " ", attempt);
@@ -309,9 +310,8 @@ bool OutgoingMigration::FinalizeMigration(long attempt) {
   Finish(is_error);
   if (!is_error) {
     keys_number_ = cluster::GetKeyCount(migration_info_.slot_ranges);
-    cf_->ApplyMigrationSlotRangeToConfig(migration_info_.node_id, migration_info_.slot_ranges,
+    cf_->ApplyMigrationSlotRangeToConfig(migration_info_.node_info.id, migration_info_.slot_ranges,
                                          false);
-    VLOG(1) << "Config is updated for " << cf_->MyID();
   }
   return true;
 }

--- a/src/server/cluster/slot_set.h
+++ b/src/server/cluster/slot_set.h
@@ -81,7 +81,7 @@ class SlotSet {
       }
     }
 
-    return res;
+    return SlotRanges(res);
   }
 
  private:

--- a/src/server/cluster/slot_set.h
+++ b/src/server/cluster/slot_set.h
@@ -68,7 +68,7 @@ class SlotSet {
   }
 
   SlotRanges ToSlotRanges() const {
-    SlotRanges res;
+    std::vector<SlotRange> res;
 
     for (SlotId i = 0; i < kSlotsNumber; ++i) {
       if (!slots_->test(i)) {

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -1043,7 +1043,7 @@ async def test_cluster_flushall_during_migration(
         df_local_factory.create(
             port=BASE_PORT + i,
             admin_port=BASE_PORT + i + 1000,
-            vmodule="cluster_family=9,cluster_slot_migration=9,outgoing_slot_migration=9",
+            vmodule="cluster_family=9,cluster_slot_migration=9,outgoing_slot_migration=9,incoming_slot_migration=9",
             logtostdout=True,
         )
         for i in range(2)
@@ -1270,7 +1270,7 @@ async def test_cluster_fuzzymigration(
         df_local_factory.create(
             port=BASE_PORT + i,
             admin_port=BASE_PORT + i + 1000,
-            vmodule="cluster_family=9,cluster_slot_migration=9",
+            vmodule="outgoing_slot_migration=9,cluster_family=9,incoming_slot_migration=9",
         )
         for i in range(node_count)
     ]
@@ -1296,9 +1296,6 @@ async def test_cluster_fuzzymigration(
             for i in itertools.count(start=1):
                 await client.lpush(key, i)
         except asyncio.exceptions.CancelledError:
-            return
-        # TODO find the reason of TTL exhausted error and is it possible to fix it
-        except redis.exceptions.ClusterError:
             return
 
     # Start ten counters
@@ -1352,7 +1349,8 @@ async def test_cluster_fuzzymigration(
         res = True
         for node in nodes:
             states = await node.admin_client.execute_command("DFLYCLUSTER", "SLOT-MIGRATION-STATUS")
-            logging.debug(states)
+            if states != "NO_STATE":
+                logging.debug(states)
             for state in states:
                 parsed_state = re.search("([a-z]+) ([a-z0-9]+) ([A-Z]+)", state)
                 if parsed_state == None:


### PR DESCRIPTION
fix for #3227
We had an incorrect MOVE error. We updated only the current node slots config and used the whole cluster config to create the MOVE error. So as a result we redirected to the same node instead of the target node. After several failed attempts we get a TTL exhausted error on the client.

The fix is simple: if the slot that is checked in GetMasterNodeForSlot belongs to the current node, it means the slot was moved to another node, so we need to check migrations.