### PR TITLE
fix: properly clean tiered state upon flash

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1423,14 +1423,13 @@ void DbSlice::ClearOffloadedEntries(absl::Span<const DbIndex> indices, const DbT
       });
     } while (cursor);
 
-    CHECK_EQ(db_ptr->stats.tiered_entries, 0u);
-#if 0
-    // Wait for delete operations to finish in sync
-    while (!async && db_ptr->stats.tiered_entries > 0) {
+    // Wait for delete operations to finish in sync.
+    // TODO: the logic inside tiered_storage that updates tiered_entries is somewhat fragile.
+    // To revisit it, otherwise we may have deadlocks around this code.
+    while (db_ptr->stats.tiered_entries > 0) {
       LOG_EVERY_T(ERROR, 0.5) << "Long wait for tiered entry delete on flush";
       ThisFiber::SleepFor(1ms);
     }
-#endif
   }
 }
 

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -494,10 +494,8 @@ class DbSlice {
   // Invalidate all watched keys for given slots. Used on FlushSlots.
   void InvalidateSlotWatches(const cluster::SlotSet& slot_ids);
 
-  // Properly clear db_arr before deleting it. If async is set, it's called from a detached fiber
-  // after swapping the db.
-  void ClearEntriesOnFlush(absl::Span<const DbIndex> indices, const DbTableArray& db_arr,
-                           bool async);
+  // Clear tiered storage entries for the specified indices.
+  void ClearOffloadedEntries(absl::Span<const DbIndex> indices, const DbTableArray& db_arr);
 
   void PerformDeletion(Iterator del_it, ExpIterator exp_it, DbTable* table);
 

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -362,6 +362,13 @@ TEST_F(DflyEngineTest, MemcacheFlags) {
   ASSERT_EQ(resp, "OK");
   MCResponse resp2 = RunMC(MP::GET, "key");
   EXPECT_THAT(resp2, ElementsAre("VALUE key 42 3", "bar", "END"));
+
+  ASSERT_EQ(Run("resp", {"flushdb"}), "OK");
+  pp_->AwaitFiberOnAll([](auto*) {
+    if (auto* shard = EngineShard::tlocal(); shard) {
+      EXPECT_EQ(shard->db_slice().GetDBTable(0)->mcflag.size(), 0u);
+    }
+  });
 }
 
 TEST_F(DflyEngineTest, LimitMemory) {

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -60,20 +60,6 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
     cache_fetched_ = absl::GetFlag(FLAGS_tiered_storage_cache_fetched);
   }
 
-  // Called before overriding value with segment
-  void RecordAdded(DbTableStats* stats, const PrimeValue& pv, size_t tiered_len) {
-    stats->AddTypeMemoryUsage(pv.ObjType(), -pv.MallocUsed());
-    stats->tiered_entries++;
-    stats->tiered_used_bytes += tiered_len;
-  }
-
-  // Called after setting new value in place of previous segment
-  void RecordDeleted(DbTableStats* stats, const PrimeValue& pv, size_t tiered_len) {
-    stats->AddTypeMemoryUsage(pv.ObjType(), pv.MallocUsed());
-    stats->tiered_entries--;
-    stats->tiered_used_bytes -= tiered_len;
-  }
-
   // Find entry by key in db_slice and store external segment in place of original value.
   // Update memory stats
   void SetExternal(OpManager::KeyRef key, tiering::DiskSegment segment) {
@@ -127,25 +113,7 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
   }
 
   // Load all values from bin by their hashes
-  void Defragment(tiering::DiskSegment segment, string_view value) {
-    // Note: Bin could've already been deleted, in that case DeleteBin returns an empty list
-    for (auto [dbid, hash, sub_segment] : ts_->bins_->DeleteBin(segment, value)) {
-      // Search for key with the same hash and value pointing to the same segment.
-      // If it still exists, it must correspond to the value stored in this bin
-      auto predicate = [sub_segment = sub_segment](const PrimeKey& key, const PrimeValue& probe) {
-        return probe.IsExternal() && tiering::DiskSegment{probe.GetExternalSlice()} == sub_segment;
-      };
-      auto it = db_slice_->GetDBTable(dbid)->prime.FindFirst(hash, predicate);
-      if (!IsValid(it))
-        continue;
-
-      stats_.total_defrags++;
-
-      // Cut out relevant part of value and restore it to memory
-      string_view sub_value = value.substr(sub_segment.offset - segment.offset, sub_segment.length);
-      SetInMemory(&it->second, dbid, sub_value, sub_segment);
-    }
-  }
+  void Defragment(tiering::DiskSegment segment, string_view value);
 
   void ReportStashed(EntryId id, tiering::DiskSegment segment, error_code ec) override {
     if (ec) {
@@ -157,23 +125,7 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
   }
 
   bool ReportFetched(EntryId id, string_view value, tiering::DiskSegment segment,
-                     bool modified) override {
-    ++stats_.total_fetches;
-
-    if (id == EntryId{kFragmentedBin}) {  // Generally we read whole bins only for defrag
-      Defragment(segment, value);
-      return true;  // delete
-    }
-
-    if (!modified && !cache_fetched_)
-      return false;
-
-    if (SliceSnapshot::IsSnaphotInProgress())
-      return false;
-
-    SetInMemory(get<OpManager::KeyRef>(id), value, segment);
-    return true;
-  }
+                     bool modified) override;
 
   bool ReportDelete(tiering::DiskSegment segment) override {
     if (OccupiesWholePages(segment.length))
@@ -203,6 +155,20 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
     return IsValid(it) ? &it->second : nullptr;
   }
 
+  // Called before overriding value with segment
+  void RecordAdded(DbTableStats* stats, const PrimeValue& pv, size_t tiered_len) {
+    stats->AddTypeMemoryUsage(pv.ObjType(), -pv.MallocUsed());
+    stats->tiered_entries++;
+    stats->tiered_used_bytes += tiered_len;
+  }
+
+  // Called after setting new value in place of previous segment
+  void RecordDeleted(DbTableStats* stats, const PrimeValue& pv, size_t tiered_len) {
+    stats->AddTypeMemoryUsage(pv.ObjType(), pv.MallocUsed());
+    stats->tiered_entries--;
+    stats->tiered_used_bytes -= tiered_len;
+  }
+
   bool cache_fetched_ = false;
 
   struct {
@@ -213,6 +179,45 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
   TieredStorage* ts_;
   DbSlice* db_slice_;
 };
+
+void TieredStorage::ShardOpManager::Defragment(tiering::DiskSegment segment, string_view value) {
+  // Note: Bin could've already been deleted, in that case DeleteBin returns an empty list
+  for (auto [dbid, hash, sub_segment] : ts_->bins_->DeleteBin(segment, value)) {
+    // Search for key with the same hash and value pointing to the same segment.
+    // If it still exists, it must correspond to the value stored in this bin
+    auto predicate = [sub_segment = sub_segment](const PrimeKey& key, const PrimeValue& probe) {
+      return probe.IsExternal() && tiering::DiskSegment{probe.GetExternalSlice()} == sub_segment;
+    };
+    auto it = db_slice_->GetDBTable(dbid)->prime.FindFirst(hash, predicate);
+    if (!IsValid(it))
+      continue;
+
+    stats_.total_defrags++;
+
+    // Cut out relevant part of value and restore it to memory
+    string_view sub_value = value.substr(sub_segment.offset - segment.offset, sub_segment.length);
+    SetInMemory(&it->second, dbid, sub_value, sub_segment);
+  }
+}
+
+bool TieredStorage::ShardOpManager::ReportFetched(EntryId id, string_view value,
+                                                  tiering::DiskSegment segment, bool modified) {
+  ++stats_.total_fetches;
+
+  if (id == EntryId{kFragmentedBin}) {  // Generally we read whole bins only for defrag
+    Defragment(segment, value);
+    return true;  // delete
+  }
+
+  if (!modified && !cache_fetched_)
+    return false;
+
+  if (SliceSnapshot::IsSnaphotInProgress())
+    return false;
+
+  SetInMemory(get<OpManager::KeyRef>(id), value, segment);
+  return true;
+}
 
 TieredStorage::TieredStorage(DbSlice* db_slice, size_t max_size)
     : op_manager_{make_unique<ShardOpManager>(this, db_slice, max_size)},

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -61,24 +61,24 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
   }
 
   // Called before overriding value with segment
-  void RecordAdded(DbTableStats* stats, const PrimeValue& pv, tiering::DiskSegment segment) {
+  void RecordAdded(DbTableStats* stats, const PrimeValue& pv, size_t tiered_len) {
     stats->AddTypeMemoryUsage(pv.ObjType(), -pv.MallocUsed());
     stats->tiered_entries++;
-    stats->tiered_used_bytes += segment.length;
+    stats->tiered_used_bytes += tiered_len;
   }
 
   // Called after setting new value in place of previous segment
-  void RecordDeleted(DbTableStats* stats, const PrimeValue& pv, tiering::DiskSegment segment) {
+  void RecordDeleted(DbTableStats* stats, const PrimeValue& pv, size_t tiered_len) {
     stats->AddTypeMemoryUsage(pv.ObjType(), pv.MallocUsed());
     stats->tiered_entries--;
-    stats->tiered_used_bytes -= segment.length;
+    stats->tiered_used_bytes -= tiered_len;
   }
 
   // Find entry by key in db_slice and store external segment in place of original value.
   // Update memory stats
   void SetExternal(OpManager::KeyRef key, tiering::DiskSegment segment) {
     if (auto pv = Find(key); pv) {
-      RecordAdded(db_slice_->MutableStats(key.first), *pv, segment);
+      RecordAdded(db_slice_->MutableStats(key.first), *pv, segment.length);
 
       pv->SetIoPending(false);
       pv->SetExternal(segment.offset, segment.length);
@@ -113,9 +113,7 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
     if (!value.empty())
       pv->SetString(value);
 
-    RecordDeleted(db_slice_->MutableStats(dbid), *pv, segment);
-
-    (value.empty() ? stats_.total_deletes : stats_.total_fetches)++;
+    RecordDeleted(db_slice_->MutableStats(dbid), *pv, segment.length);
   }
 
   // Find entry by key and store it's up-to-date value in place of external segment.
@@ -160,6 +158,8 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
 
   bool ReportFetched(EntryId id, string_view value, tiering::DiskSegment segment,
                      bool modified) override {
+    ++stats_.total_fetches;
+
     if (id == EntryId{kFragmentedBin}) {  // Generally we read whole bins only for defrag
       Defragment(segment, value);
       return true;  // delete
@@ -206,8 +206,8 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
   bool cache_fetched_ = false;
 
   struct {
-    size_t total_stashes = 0, total_fetches = 0, total_cancels = 0, total_deletes = 0;
-    size_t total_defrags = 0;  // included in total_fetches
+    size_t total_stashes = 0, total_cancels = 0, total_fetches = 0;
+    size_t total_defrags = 0;
   } stats_;
 
   TieredStorage* ts_;
@@ -276,7 +276,7 @@ bool TieredStorage::TryStash(DbIndex dbid, string_view key, PrimeValue* value) {
     return false;
 
   // This invariant should always hold because ShouldStash tests for IoPending flag.
-  CHECK(!bins_->IsPending(dbid, key));
+  DCHECK(!bins_->IsPending(dbid, key));
 
   // TODO: When we are low on memory we should introduce a back-pressure, to avoid OOMs
   // with a lot of underutilized disk space.
@@ -310,9 +310,11 @@ bool TieredStorage::TryStash(DbIndex dbid, string_view key, PrimeValue* value) {
 
 void TieredStorage::Delete(DbIndex dbid, PrimeValue* value) {
   DCHECK(value->IsExternal());
+  ++stats_.total_deletes;
+
   tiering::DiskSegment segment = value->GetExternalSlice();
-  op_manager_->Delete(segment);
-  op_manager_->SetInMemory(value, dbid, "", segment);
+  op_manager_->DeleteOffloaded(segment);
+  op_manager_->SetInMemory(value, dbid, string_view{}, segment);
 }
 
 void TieredStorage::CancelStash(DbIndex dbid, std::string_view key, PrimeValue* value) {

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -85,6 +85,7 @@ class TieredStorage {
   unsigned write_depth_limit_ = 10;
   struct {
     uint64_t stash_overflow_cnt = 0;
+    uint64_t total_deletes = 0;
   } stats_;
 };
 

--- a/src/server/tiering/op_manager.cc
+++ b/src/server/tiering/op_manager.cc
@@ -59,7 +59,7 @@ void OpManager::Delete(EntryId id) {
   pending_stash_ver_.erase(ToOwned(id));
 }
 
-void OpManager::Delete(DiskSegment segment) {
+void OpManager::DeleteOffloaded(DiskSegment segment) {
   EntryOps* pending_op = nullptr;
 
   auto base_it = pending_reads_.find(segment.ContainingPages().offset);

--- a/src/server/tiering/op_manager.cc
+++ b/src/server/tiering/op_manager.cc
@@ -60,14 +60,15 @@ void OpManager::Delete(EntryId id) {
 }
 
 void OpManager::DeleteOffloaded(DiskSegment segment) {
-  EntryOps* pending_op = nullptr;
+  EntryOps* pending_read = nullptr;
 
   auto base_it = pending_reads_.find(segment.ContainingPages().offset);
   if (base_it != pending_reads_.end())
-    pending_op = base_it->second.Find(segment);
+    pending_read = base_it->second.Find(segment);
 
-  if (pending_op) {
-    pending_op->deleting = true;
+  if (pending_read) {
+    // Mark that the read operation must finilize with deletion.
+    pending_read->deleting = true;
   } else if (ReportDelete(segment) && base_it == pending_reads_.end()) {
     storage_.MarkAsFree(segment.ContainingPages());
   }

--- a/src/server/tiering/op_manager.h
+++ b/src/server/tiering/op_manager.h
@@ -54,8 +54,8 @@ class OpManager {
   // Delete entry with pending io
   void Delete(EntryId id);
 
-  // Delete offloaded entry
-  void Delete(DiskSegment segment);
+  // Delete offloaded entry located at the segment.
+  void DeleteOffloaded(DiskSegment segment);
 
   // Stash value to be offloaded
   std::error_code Stash(EntryId id, std::string_view value);

--- a/src/server/tiering/op_manager_test.cc
+++ b/src/server/tiering/op_manager_test.cc
@@ -100,7 +100,7 @@ TEST_F(OpManagerTest, DeleteAfterReads) {
     std::vector<util::fb2::Future<std::string>> reads;
     for (unsigned i = 0; i < 100; i++)
       reads.emplace_back(Read(0u, stashed_[0u]));
-    Delete(stashed_[0u]);
+    DeleteOffloaded(stashed_[0u]);
 
     for (auto& fut : reads)
       EXPECT_EQ(fut.Get(), "DATA");

--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -19,7 +19,7 @@ import time
 from copy import deepcopy
 
 from pathlib import Path
-from tempfile import TemporaryDirectory, gettempdir
+from tempfile import gettempdir, mkdtemp
 
 from .instance import DflyInstance, DflyParams, DflyInstanceFactory, RedisServer
 from . import PortPicker, dfly_args
@@ -37,9 +37,12 @@ def tmp_dir():
     where the Dragonfly executable will be run and where all test data
     should be stored. The directory will be cleaned up at the end of a session
     """
-    tmp = TemporaryDirectory()
-    yield Path(tmp.name)
-    tmp.cleanup()
+    tmp_name = mkdtemp()
+    yield Path(tmp_name)
+    if os.environ.get("DRAGONFLY_KEEP_TMP"):
+        logging.info(f"Keeping tmp dir {tmp_name}")
+        return
+    os.rmdir(tmp_name)
 
 
 @pytest.fixture(scope="session")

--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -42,7 +42,7 @@ def tmp_dir():
     if os.environ.get("DRAGONFLY_KEEP_TMP"):
         logging.info(f"Keeping tmp dir {tmp_name}")
         return
-    os.rmdir(tmp_name)
+    shutil.rmtree(tmp_name, ignore_errors=True)
 
 
 @pytest.fixture(scope="session")

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -215,6 +215,8 @@ class DflyInstance:
         if not self.params.existing_port:
             return_code = self.proc.poll()
             if return_code is not None:
+                # log stdout of the failed process
+                logging.error("Dragonfly process error:\n%s", self.proc.stdout.read().decode())
                 self.proc = None
                 raise DflyStartException(f"Failed to start instance, return code {return_code}")
 


### PR DESCRIPTION
The bug was around io pending entries that have not been properly cleaned during flush. This PR simplified the logic around tiered storage handling during flush, it always performs the cleaning in the synchronous part of the command.

In addition, this PR improves error logging in tests if dragonfly process exits with an error. Finally, a test is added that makes sure pending tiered items are flushed during the flash call.

Fixes #3252

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->