### PR TITLE
fix(bug): crash on takeover and info replication

### DIFF
--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -334,7 +334,7 @@ class DflyInstanceFactory:
         args.setdefault("noversion_check", None)
         # MacOs does not set it automatically, so we need to set it manually
         args.setdefault("maxmemory", "8G")
-        vmod = "dragonfly_connection=1,accept_server=1,listener_interface=1,main_service=1,rdb_save=1,replica=1,cluster_family=1"
+        vmod = "dragonfly_connection=1,accept_server=1,listener_interface=1,main_service=1,rdb_save=1,replica=1,cluster_family=1,dflycmd=1"
         args.setdefault("vmodule", vmod)
         args.setdefault("jsonpathv2")
 

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1232,6 +1232,7 @@ async def test_take_over_seeder(
     fill_task = asyncio.create_task(seeder.run())
 
     stop_info = False
+
     async def info_task():
         my_client = replica.client()
         while not stop_info:

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1151,10 +1151,7 @@ take_over_cases = [
 @pytest.mark.parametrize("master_threads, replica_threads", take_over_cases)
 @pytest.mark.asyncio
 async def test_take_over_counters(df_factory, master_threads, replica_threads):
-    master = df_factory.create(
-        proactor_threads=master_threads,
-        logtostderr=True,
-    )
+    master = df_factory.create(proactor_threads=master_threads)
     replica1 = df_factory.create(proactor_threads=replica_threads)
     replica2 = df_factory.create(proactor_threads=replica_threads)
     replica3 = df_factory.create(proactor_threads=replica_threads)
@@ -1214,11 +1211,7 @@ async def test_take_over_seeder(
     request, df_factory, df_seeder_factory, master_threads, replica_threads
 ):
     tmp_file_name = "".join(random.choices(string.ascii_letters, k=10))
-    master = df_factory.create(
-        proactor_threads=master_threads,
-        dbfilename=f"dump_{tmp_file_name}",
-        logtostderr=True,
-    )
+    master = df_factory.create(proactor_threads=master_threads, dbfilename=f"dump_{tmp_file_name}")
     replica = df_factory.create(proactor_threads=replica_threads)
     df_factory.start_all([master, replica])
 
@@ -1268,10 +1261,7 @@ async def test_take_over_seeder(
 @pytest.mark.parametrize("master_threads, replica_threads", [[4, 4]])
 @pytest.mark.asyncio
 async def test_take_over_read_commands(df_factory, master_threads, replica_threads):
-    master = df_factory.create(
-        proactor_threads=master_threads,
-        logtostderr=True,
-    )
+    master = df_factory.create(proactor_threads=master_threads)
     replica = df_factory.create(proactor_threads=replica_threads)
     df_factory.start_all([master, replica])
 

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1250,7 +1250,6 @@ async def test_take_over_seeder(
     assert await c_replica.execute_command("role") == ["master", []]
     stop_info = True
 
-
     # Need to wait a bit to give time to write the shutdown snapshot
     await asyncio.sleep(1)
     assert master.proc.poll() == 0, "Master process did not exit correctly."


### PR DESCRIPTION
fixes #3280 
The bug:
info replication first checks if the server is master, if not takes replica mutex and calls
`dfly::Replica::GetInfo()`
When running replica takeover we take the mutex, finish the takeover, reset the replica object and set `is_master` to true.
With this flow when if we get the mutex after takeover is done but check is master before we will get a crash for accessing the replica object which was reset.
The fix:
take the mutex before checking is_master