### PR TITLE
chore: optimize zpopminmax operations

### DIFF
--- a/src/core/sorted_map.cc
+++ b/src/core/sorted_map.cc
@@ -573,34 +573,50 @@ size_t SortedMap::DeleteRangeByLex(const zlexrangespec& range) {
 }
 
 SortedMap::ScoredArray SortedMap::PopTopScores(unsigned count, bool reverse) {
+  DCHECK_GT(count, 0u);
   DCHECK_EQ(score_map->UpperBoundSize(), score_tree->Size());
   size_t sz = score_map->UpperBoundSize();
 
   ScoredArray res;
 
-  if (sz == 0)
+  DCHECK_GT(sz, 0u);  // Empty sets are not allowed.
+
+  if (sz == 0 || count == 0)
     return res;
 
-  if (count >= sz)
-    count = score_map->UpperBoundSize();
+  if (count > sz)
+    count = sz;
 
   res.reserve(count);
-  unsigned rank = 0;
-  unsigned step = 0;
 
-  if (reverse) {
-    rank = sz - 1;
-    step = 1;
-  }
-
-  for (unsigned i = 0; i < count; ++i) {
-    auto path = score_tree->FromRank(rank);
-    ScoreSds obj = path.Terminal();
+  auto cb = [&](ScoreSds obj) {
     res.emplace_back(string{(sds)obj, sdslen((sds)obj)}, GetObjScore(obj));
 
-    score_tree->Delete(path);
-    score_map->Erase((sds)obj);
-    rank -= step;
+    // We can not delete from score_tree because we are in the middle of the iteration.
+    CHECK(score_map->Erase((sds)obj));
+    return true;
+  };
+
+  unsigned rank = 0;
+  unsigned step = 0;
+  if (reverse) {
+    score_tree->IterateReverse(0, count - 1, std::move(cb));
+    rank = score_tree->Size() - 1;
+    step = 1;
+  } else {
+    score_tree->Iterate(0, count - 1, std::move(cb));
+  }
+
+  // We already deleted elements from score_map, so what's left is to delete from the tree.
+  if (score_map->Empty()) {
+    // Corner case optimization.
+    score_tree->Clear();
+  } else {
+    for (unsigned i = 0; i < res.size(); ++i) {
+      auto path = score_tree->FromRank(rank);
+      score_tree->Delete(path);
+      rank -= step;
+    }
   }
 
   return res;

--- a/src/core/sorted_map.cc
+++ b/src/core/sorted_map.cc
@@ -594,7 +594,7 @@ SortedMap::ScoredArray SortedMap::PopTopScores(unsigned count, bool reverse) {
 
     // We can not delete from score_tree because we are in the middle of the iteration.
     CHECK(score_map->Erase((sds)obj));
-    return true;
+    return true;  // continue with the iteration.
   };
 
   unsigned rank = 0;

--- a/src/core/sorted_map.h
+++ b/src/core/sorted_map.h
@@ -54,6 +54,9 @@ class SortedMap {
   bool Insert(double score, sds member);
   bool Delete(sds ele);
 
+  // Upper bound size of the set.
+  // Note: Currently we do not allow member expiry in sorted sets, therefore it's exact
+  // But if we decide to add expire, this method will provide an approximation from above.
   size_t Size() const {
     return score_map->UpperBoundSize();
   }
@@ -87,8 +90,11 @@ class SortedMap {
  private:
   using ScoreTree = BPTree<ScoreSds, ScoreSdsPolicy>;
 
+  // hash map from fields to scores.
   ScoreMap* score_map = nullptr;
-  ScoreTree* score_tree = nullptr;  // just a stub for now.
+
+  // sorted tree of (score,field) items.
+  ScoreTree* score_tree = nullptr;
 };
 
 // Used by CompactObject.

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -487,11 +487,13 @@ void IntervalVisitor::ActionRem(const zlexrangespec& range) {
 }
 
 void IntervalVisitor::ActionPop(ZSetFamily::TopNScored sc) {
-  if (robj_wrapper_->encoding() == OBJ_ENCODING_LISTPACK) {
-    PopListPack(sc);
-  } else {
-    CHECK_EQ(robj_wrapper_->encoding(), OBJ_ENCODING_SKIPLIST);
-    PopSkipList(sc);
+  if (sc > 0) {
+    if (robj_wrapper_->encoding() == OBJ_ENCODING_LISTPACK) {
+      PopListPack(sc);
+    } else {
+      CHECK_EQ(robj_wrapper_->encoding(), OBJ_ENCODING_SKIPLIST);
+      PopSkipList(sc);
+    }
   }
 }
 

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -698,6 +698,9 @@ TEST_F(ZSetFamilyTest, ZPopMin) {
   ASSERT_THAT(resp, ArrLen(2));
   EXPECT_THAT(resp.GetVec(), ElementsAre("a", "1"));
 
+  resp = Run({"zpopmin", "key", "0"});
+  ASSERT_THAT(resp, ArrLen(0));
+
   resp = Run({"zpopmin", "key", "2"});
   ASSERT_THAT(resp, ArrLen(4));
   EXPECT_THAT(resp.GetVec(), ElementsAre("b", "2", "c", "3"));


### PR DESCRIPTION
Before, we run FromRank operation count times. This operation computes subtree counts on the fly. Now, we iterate over a tree first, delete the keys from the map - no rank calls. And only after we filled the result, we delete the entries from the tree. For cases where we delete all the entries we avoid calling FromRank.

Moreover, we optimized FromRank operations to handle corner cases of most right and most left nodes by avoiding computing the subtree counts.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->