### PR TITLE
feat(test_utils): Add flag to disable single element vector mapping for the run response

### DIFF
--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -390,7 +390,7 @@ RespExpr BaseFamilyTest::Run(std::string_view id, ArgSlice slice) {
   last_cmd_dbg_info_ = context->last_command_debug;
 
   RespVec vec = conn_wrapper->ParseResponse(single_response_);
-  if (vec.size() == 1)
+  if (map_single_element_vector_ && vec.size() == 1)
     return vec.front();
   RespVec* new_vec = new RespVec(vec);
   resp_vec_.push_back(new_vec);

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -168,6 +168,7 @@ class BaseFamilyTest : public ::testing::Test {
   bool single_response_ = true;
   util::fb2::Fiber watchdog_fiber_;
   util::fb2::Done watchdog_done_;
+  bool map_single_element_vector_ = true;
 };
 
 std::ostream& operator<<(std::ostream& os, const DbStats& stats);


### PR DESCRIPTION
refers to [the comment](https://github.com/dragonflydb/dragonfly/pull/3264#discussion_r1671880525)