### PR TITLE
chore: Add CompactObj Raw methods

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -1200,7 +1200,7 @@ pair<StringOrView, uint8_t> CompactObj::GetRawString() const {
     u_.small_str.Get(&tmp);
     return {StringOrView::FromString(std::move(tmp)), mask_ & kEncMask};
   }
-  LOG(FATAL) << "Should not reach here";
+  LOG(FATAL) << "Unsupported tag for GetRawString(): " << taglen_;
   return {};
 }
 

--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -1186,6 +1186,40 @@ void CompactObj::EncodeString(string_view str) {
   u_.r_obj.SetString(encoded, tl.local_mr);
 }
 
+pair<StringOrView, uint8_t> CompactObj::GetRawString() const {
+  DCHECK(!IsExternal());
+
+  if (taglen_ == ROBJ_TAG) {
+    CHECK_EQ(OBJ_STRING, u_.r_obj.type());
+    DCHECK_EQ(OBJ_ENCODING_RAW, u_.r_obj.encoding());
+    return {StringOrView::FromView(u_.r_obj.AsView()), mask_ & kEncMask};
+  }
+
+  if (taglen_ == SMALL_TAG) {
+    string tmp;
+    u_.small_str.Get(&tmp);
+    return {StringOrView::FromString(std::move(tmp)), mask_ & kEncMask};
+  }
+  LOG(FATAL) << "Should not reach here";
+  return {};
+}
+
+void CompactObj::SetRawString(std::string_view blob, uint8_t enc_mask) {
+  DCHECK_GT(blob.size(), kInlineLen);
+  // Current implementation assumes that the object is External, and switches to string.
+  CHECK_EQ(taglen_, EXTERNAL_TAG);
+
+  uint8_t mask = (mask_ & ~kEncMask) | enc_mask;
+
+  if (kUseSmallStrings && SmallString::CanAllocate(blob.size())) {
+    SetMeta(SMALL_TAG, mask);
+    tl.small_str_bytes += u_.small_str.Assign(blob);
+  } else {
+    SetMeta(ROBJ_TAG, mask);
+    u_.r_obj.SetString(blob, tl.local_mr);
+  }
+}
+
 size_t CompactObj::DecodedLen(size_t sz) const {
   return ascii_len(sz) - ((mask_ & ASCII1_ENC_BIT) ? 1 : 0);
 }

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -12,6 +12,7 @@
 #include "base/pmr/memory_resource.h"
 #include "core/json/json_object.h"
 #include "core/small_string.h"
+#include "core/string_or_view.h"
 
 namespace dfly {
 
@@ -375,6 +376,16 @@ class CompactObj {
     t->~T();
     memory_resource()->deallocate(ptr, sizeof(T), alignof(T));
   }
+
+  // returns raw (non-decoded) string together with the encoding mask.
+  // Used to bypass decoding layer.
+  // Precondition: the object is a non-inline string.
+  std::pair<StringOrView, uint8_t> GetRawString() const;
+
+  // (blob, enc_mask) must be the same as returned by GetRawString
+  // NOTE: current implementation assumes that the object is of external type
+  // though the functionality may be extended to other states if needed.
+  void SetRawString(std::string_view blob, uint8_t enc_mask);
 
  private:
   void EncodeString(std::string_view str);


### PR DESCRIPTION
Currently, compact object does decoding/encoding of its internal string blobs. For tiering usecase, it makes sense to introduce the direct access to the blobs and avoid this unnecessary translation.

This PR introduces such access.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->