### PR TITLE
chore: moving functions + renaming in tiered storage

### DIFF
--- a/src/server/tiering/op_manager.h
+++ b/src/server/tiering/op_manager.h
@@ -63,17 +63,17 @@ class OpManager {
   Stats GetStats() const;
 
  protected:
-  // Report that a stash succeeded and the entry was stored at the provided segment or failed with
+  // Notify that a stash succeeded and the entry was stored at the provided segment or failed with
   // given error
-  virtual void ReportStashed(EntryId id, DiskSegment segment, std::error_code ec) = 0;
+  virtual void NotifyStashed(EntryId id, DiskSegment segment, std::error_code ec) = 0;
 
-  // Report that an entry was successfully fetched. Includes whether entry was modified.
+  // Notify that an entry was successfully fetched. Includes whether entry was modified.
   // Returns true if value needs to be deleted.
-  virtual bool ReportFetched(EntryId id, std::string_view value, DiskSegment segment,
+  virtual bool NotifyFetched(EntryId id, std::string_view value, DiskSegment segment,
                              bool modified) = 0;
 
-  // Report delete. Return true if the filled segment needs to be marked as free.
-  virtual bool ReportDelete(DiskSegment segment) = 0;
+  // Notify delete. Return true if the filled segment needs to be marked as free.
+  virtual bool NotifyDelete(DiskSegment segment) = 0;
 
  protected:
   // Describes pending futures for a single entry

--- a/src/server/tiering/op_manager_test.cc
+++ b/src/server/tiering/op_manager_test.cc
@@ -42,18 +42,18 @@ struct OpManagerTest : PoolTestBase, OpManager {
     return future;
   }
 
-  void ReportStashed(EntryId id, DiskSegment segment, std::error_code ec) override {
+  void NotifyStashed(EntryId id, DiskSegment segment, std::error_code ec) override {
     EXPECT_FALSE(ec);
     stashed_[id] = segment;
   }
 
-  bool ReportFetched(EntryId id, std::string_view value, DiskSegment segment,
+  bool NotifyFetched(EntryId id, std::string_view value, DiskSegment segment,
                      bool modified) override {
     fetched_[id] = value;
     return false;
   }
 
-  bool ReportDelete(DiskSegment segment) override {
+  bool NotifyDelete(DiskSegment segment) override {
     return true;
   }
 


### PR DESCRIPTION
There are no functional changes in this PR.
ReportXXX functions are renamed to NotifyXXX
Some functions were moved to private, and some pulled out from the class as being stateless.

This is preparational change before doing changes in the tiered storage code.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->