### PR TITLE
chore: On invalid TTL, print the TTL first

### DIFF
--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -647,8 +647,8 @@ void RdbLoaderBase::OpaqueObjLoader::CreateHMap(const LoadTrace* ltrace) {
           int64_t ttl_time = -1;
           string_view ttl_str = ToSV(seg[i + 2].rdb_var);
           if (!absl::SimpleAtoi(ttl_str, &ttl_time)) {
-            LOG(ERROR) << "Can't parse hashmap TTL for " << key << ", val=" << val
-                       << ", ttl=" << ttl_str;
+            LOG(ERROR) << "Can't parse hashmap TTL for " << key << ", ttl='" << ttl_str
+                       << "', val=" << val;
             ec_ = RdbError(errc::rdb_file_corrupted);
             return;
           }


### PR DESCRIPTION
Before this change we first printed the value, which could be long resulting in the TTL not appearing in the log due to max line length

If the TTL is invalid, we should print it first to see what value it has

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->