### PR TITLE
chore: Separate tiered serialization format from object values

### DIFF
--- a/src/server/tiering/disk_storage.cc
+++ b/src/server/tiering/disk_storage.cc
@@ -22,6 +22,7 @@ ABSL_FLAG(uint64_t, registered_buffer_size, 512_KB,
 
 namespace dfly::tiering {
 
+using namespace std;
 using namespace ::util::fb2;
 
 namespace {
@@ -30,13 +31,13 @@ UringBuf AllocateTmpBuf(size_t size) {
   size = (size + kPageSize - 1) / kPageSize * kPageSize;
   VLOG(1) << "Fallback to temporary allocation: " << size;
 
-  uint8_t* buf = new (std::align_val_t(kPageSize)) uint8_t[size];
-  return UringBuf{{buf, size}, std::nullopt};
+  uint8_t* buf = new (align_val_t(kPageSize)) uint8_t[size];
+  return UringBuf{{buf, size}, nullopt};
 }
 
 void DestroyTmpBuf(UringBuf buf) {
   DCHECK(!buf.buf_idx);
-  ::operator delete[](buf.bytes.data(), std::align_val_t(kPageSize));
+  ::operator delete[](buf.bytes.data(), align_val_t(kPageSize));
 }
 
 void ReturnBuf(UringBuf buf) {
@@ -51,12 +52,12 @@ void ReturnBuf(UringBuf buf) {
 
 constexpr off_t kInitialSize = 1UL << 28;  // 256MB
 
-template <typename... Ts> std::error_code DoFiberCall(void (SubmitEntry::*c)(Ts...), Ts... args) {
+template <typename... Ts> error_code DoFiberCall(void (SubmitEntry::*c)(Ts...), Ts... args) {
   auto* proactor = static_cast<UringProactor*>(ProactorBase::me());
   FiberCall fc(proactor);
   (fc.operator->()->*c)(std::forward<Ts>(args)...);
   FiberCall::IoResult io_res = fc.Get();
-  return io_res < 0 ? std::error_code{-io_res, std::system_category()} : std::error_code{};
+  return io_res < 0 ? error_code{-io_res, system_category()} : error_code{};
 }
 
 }  // anonymous namespace
@@ -64,7 +65,7 @@ template <typename... Ts> std::error_code DoFiberCall(void (SubmitEntry::*c)(Ts.
 DiskStorage::DiskStorage(size_t max_size) : max_size_(max_size) {
 }
 
-std::error_code DiskStorage::Open(std::string_view path) {
+error_code DiskStorage::Open(string_view path) {
   DCHECK_EQ(ProactorBase::me()->GetKind(), ProactorBase::IOURING);
   CHECK(!backing_file_);
 
@@ -86,13 +87,13 @@ std::error_code DiskStorage::Open(std::string_view path) {
 
   auto* up = static_cast<UringProactor*>(ProactorBase::me());
   if (int io_res = up->RegisterBuffers(absl::GetFlag(FLAGS_registered_buffer_size)); io_res < 0)
-    return std::error_code{-io_res, std::system_category()};
+    return error_code{-io_res, system_category()};
 
   return {};
 }
 
 void DiskStorage::Close() {
-  using namespace std::chrono_literals;
+  using namespace chrono_literals;
 
   // TODO: to fix this polling.
   while (pending_ops_ > 0 || grow_pending_)
@@ -106,12 +107,15 @@ void DiskStorage::Read(DiskSegment segment, ReadCb cb) {
   DCHECK_GT(segment.length, 0u);
   DCHECK_EQ(segment.offset % kPageSize, 0u);
 
-  UringBuf buf = PrepareBuf(segment.length);
-  auto io_cb = [this, cb = std::move(cb), buf, segment](int io_res) {
-    if (io_res < 0)
-      cb("", std::error_code{-io_res, std::system_category()});
-    else
-      cb(std::string_view{reinterpret_cast<char*>(buf.bytes.data()), segment.length}, {});
+  size_t len = segment.length;
+  UringBuf buf = PrepareBuf(len);
+  auto io_cb = [this, cb = std::move(cb), buf, len](int io_res) {
+    if (io_res < 0) {
+      cb(nonstd::make_unexpected(error_code{-io_res, system_category()}));
+      return;
+    }
+
+    cb(string_view{reinterpret_cast<char*>(buf.bytes.data()), len});
     ReturnBuf(buf);
     pending_ops_--;
   };
@@ -130,10 +134,11 @@ void DiskStorage::MarkAsFree(DiskSegment segment) {
   alloc_.Free(segment.offset, segment.length);
 }
 
-std::error_code DiskStorage::Stash(io::Bytes bytes, StashCb cb) {
+std::error_code DiskStorage::Stash(io::Bytes bytes, io::Bytes footer, StashCb cb) {
   DCHECK_GT(bytes.length(), 0u);
 
-  int64_t offset = alloc_.Malloc(bytes.size());
+  size_t len = bytes.size() + footer.size();
+  int64_t offset = alloc_.Malloc(len);
 
   // If we've run out of space, block and grow as much as needed
   if (offset < 0) {
@@ -141,20 +146,22 @@ std::error_code DiskStorage::Stash(io::Bytes bytes, StashCb cb) {
     // Right now we do it synchronously as well (see Grow(256MB) call.)
     RETURN_ON_ERR(Grow(-offset));
 
-    offset = alloc_.Malloc(bytes.size());
+    offset = alloc_.Malloc(len);
     if (offset < 0)  // we can't fit it even after resizing
       return std::make_error_code(std::errc::file_too_large);
   }
 
-  UringBuf buf = PrepareBuf(bytes.size());
+  UringBuf buf = PrepareBuf(len);
   memcpy(buf.bytes.data(), bytes.data(), bytes.length());
+  if (!footer.empty())
+    memcpy(buf.bytes.data() + bytes.length(), footer.data(), footer.length());
 
-  auto io_cb = [this, cb, offset, buf, len = bytes.size()](int io_res) {
+  auto io_cb = [this, cb, offset, buf, len](int io_res) {
     if (io_res < 0) {
       MarkAsFree({size_t(offset), len});
-      cb({}, std::error_code{-io_res, std::system_category()});
+      cb(nonstd::make_unexpected(error_code{-io_res, std::system_category()}));
     } else {
-      cb({size_t(offset), len}, {});
+      cb(DiskSegment{size_t(offset), len});
     }
     ReturnBuf(buf);
     pending_ops_--;

--- a/src/server/tiering/disk_storage.h
+++ b/src/server/tiering/disk_storage.h
@@ -24,8 +24,8 @@ class DiskStorage {
     uint64_t registered_buf_alloc_count = 0;
   };
 
-  using ReadCb = std::function<void(std::string_view, std::error_code)>;
-  using StashCb = std::function<void(DiskSegment, std::error_code)>;
+  using ReadCb = std::function<void(io::Result<std::string_view>)>;
+  using StashCb = std::function<void(io::Result<DiskSegment>)>;
 
   explicit DiskStorage(size_t max_size);
 
@@ -42,12 +42,14 @@ class DiskStorage {
   // grow backing file. Returns error code if operation failed  immediately (most likely it failed
   // to grow the backing file) or passes an empty segment if the final write operation failed.
   // Bytes are copied and can be dropped before cb is resolved
-  std::error_code Stash(io::Bytes bytes, StashCb cb);
+  std::error_code Stash(io::Bytes bytes, io::Bytes footer, StashCb cb);
 
   Stats GetStats() const;
 
  private:
   std::error_code Grow(off_t grow_size);
+
+  // Returns a buffer with size greater or equal to len.
   util::fb2::UringBuf PrepareBuf(size_t len);
 
   off_t size_, max_size_;

--- a/src/server/tiering/disk_storage_test.cc
+++ b/src/server/tiering/disk_storage_test.cc
@@ -37,19 +37,19 @@ struct DiskStorageTest : public PoolTestBase {
   void Stash(size_t index, string value) {
     pending_ops_++;
     auto buf = make_shared<string>(value);
-    storage_->Stash(io::Buffer(*buf), [this, index, buf](DiskSegment segment, std::error_code ec) {
-      EXPECT_FALSE(ec);
-      EXPECT_GT(segment.length, 0u);
-      segments_[index] = segment;
+    storage_->Stash(io::Buffer(*buf), {}, [this, index, buf](io::Result<DiskSegment> segment) {
+      EXPECT_TRUE(segment);
+      EXPECT_GT(segment->length, 0u);
+      segments_[index] = *segment;
       pending_ops_--;
     });
   }
 
   void Read(size_t index) {
     pending_ops_++;
-    storage_->Read(segments_[index], [this, index](string_view value, std::error_code ec) {
-      EXPECT_FALSE(ec);
-      last_reads_[index] = value;
+    storage_->Read(segments_[index], [this, index](io::Result<string_view> value) {
+      EXPECT_TRUE(value);
+      last_reads_[index] = *value;
       pending_ops_--;
     });
   }

--- a/src/server/tiering/op_manager.h
+++ b/src/server/tiering/op_manager.h
@@ -57,15 +57,15 @@ class OpManager {
   // Delete offloaded entry located at the segment.
   void DeleteOffloaded(DiskSegment segment);
 
-  // Stash value to be offloaded
-  std::error_code Stash(EntryId id, std::string_view value);
+  // Stash (value, footer) to be offloaded. Both arguments are opaque to OpManager.
+  std::error_code Stash(EntryId id, std::string_view value, io::Bytes footer);
 
   Stats GetStats() const;
 
  protected:
   // Notify that a stash succeeded and the entry was stored at the provided segment or failed with
   // given error
-  virtual void NotifyStashed(EntryId id, DiskSegment segment, std::error_code ec) = 0;
+  virtual void NotifyStashed(EntryId id, const io::Result<DiskSegment>& segment) = 0;
 
   // Notify that an entry was successfully fetched. Includes whether entry was modified.
   // Returns true if value needs to be deleted.
@@ -110,7 +110,7 @@ class OpManager {
   void ProcessRead(size_t offset, std::string_view value);
 
   // Called once Stash finished
-  void ProcessStashed(EntryId id, unsigned version, DiskSegment segment, std::error_code ec);
+  void ProcessStashed(EntryId id, unsigned version, const io::Result<DiskSegment>& segment);
 
  protected:
   DiskStorage storage_;

--- a/src/server/tiering/small_bins.h
+++ b/src/server/tiering/small_bins.h
@@ -49,7 +49,8 @@ class SmallBins {
   }
 
   // Enqueue key/value pair for stash. Returns page to be stashed if it filled up.
-  std::optional<FilledBin> Stash(DbIndex dbid, std::string_view key, std::string_view value);
+  std::optional<FilledBin> Stash(DbIndex dbid, std::string_view key, std::string_view value,
+                                 io::Bytes footer);
 
   // Report that a stash succeeeded. Returns list of stored keys with calculated value locations.
   KeySegmentList ReportStashed(BinId id, DiskSegment segment);

--- a/src/server/tiering/small_bins_test.cc
+++ b/src/server/tiering/small_bins_test.cc
@@ -30,7 +30,7 @@ TEST_F(SmallBinsTest, SimpleStashRead) {
   // Fill single bin
   std::optional<SmallBins::FilledBin> bin;
   for (unsigned i = 0; !bin; i++)
-    bin = bins_.Stash(0, absl::StrCat("k", i), absl::StrCat("v", i));
+    bin = bins_.Stash(0, absl::StrCat("k", i), absl::StrCat("v", i), {});
 
   // Verify cut locations point to correct values
   auto segments = bins_.ReportStashed(bin->first, DiskSegment{0, 4_KB});
@@ -47,7 +47,7 @@ TEST_F(SmallBinsTest, SimpleDeleteAbort) {
   std::optional<SmallBins::FilledBin> bin;
   unsigned i = 0;
   for (; !bin; i++)
-    bin = bins_.Stash(0, absl::StrCat("k", i), absl::StrCat("v", i));
+    bin = bins_.Stash(0, absl::StrCat("k", i), absl::StrCat("v", i), {});
 
   // Delete all even values
   for (unsigned j = 0; j <= i; j += 2)
@@ -69,7 +69,7 @@ TEST_F(SmallBinsTest, PartialStashDelete) {
   std::optional<SmallBins::FilledBin> bin;
   unsigned i = 0;
   for (; !bin; i++)
-    bin = bins_.Stash(0, absl::StrCat("k", i), absl::StrCat("v", i));
+    bin = bins_.Stash(0, absl::StrCat("k", i), absl::StrCat("v", i), {});
 
   // Delete all even values
   for (unsigned j = 0; j <= i; j += 2)
@@ -103,7 +103,7 @@ TEST_F(SmallBinsTest, PartialStashDelete) {
 TEST_F(SmallBinsTest, UpdateStatsAfterDelete) {
   // caused https://github.com/dragonflydb/dragonfly/issues/3240
   for (unsigned i = 0; i < 10; i++) {
-    auto spilled_bin = bins_.Stash(0, absl::StrCat("k", i), SmallString(128));
+    auto spilled_bin = bins_.Stash(0, absl::StrCat("k", i), SmallString(128), {});
     ASSERT_FALSE(spilled_bin);
   }
 


### PR DESCRIPTION
Before that OpManager::Stash, DiskStorage::Stash and SmallBins::Stash received a single value argument as a serialized blob of an object value.

Now they accept an additional footer argument that allows appending arbitrary byte sequence when preparing a disk page. We could, of course serialize, into value before calling these interface but then we would need another copy.
With two arguments we allow an optional meta-format that has a footer after the value.

This PR does not use this feature yet, but we will need it in the next PR in order to store the encoding mask of the string object. In the future we will need storing other meta information in case we decide supporting multiple DF types.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->