### PR TITLE
chore(acl): add test with requirepass and aclfile

### DIFF
--- a/tests/dragonfly/acl_family_test.py
+++ b/tests/dragonfly/acl_family_test.py
@@ -458,6 +458,23 @@ async def test_require_pass(df_factory):
 
 
 @pytest.mark.asyncio
+@dfly_args({"port": 1111, "requirepass": "temp"})
+async def test_require_pass_with_acl_file_order(df_factory, tmp_dir):
+    acl = create_temp_file(
+        "USER default ON >jordan ~* +@all",
+        tmp_dir,
+    )
+
+    df = df_factory.create(aclfile=acl)
+    df.start()
+
+    client = aioredis.Redis(username="default", password="jordan", port=df.port)
+
+    b"OK" == await client.execute_command("SET foo bar")
+    client.close()
+
+
+@pytest.mark.asyncio
 async def test_set_acl_file(async_client: aioredis.Redis, tmp_dir):
     acl_file_content = "USER roy ON #ea71c25a7a602246b4c39824b855678894a96f43bb9b71319c39700a1e045222 +@string +@fast +hset\nUSER john on nopass +@string"
 

--- a/tests/dragonfly/acl_family_test.py
+++ b/tests/dragonfly/acl_family_test.py
@@ -470,8 +470,8 @@ async def test_require_pass_with_acl_file_order(df_factory, tmp_dir):
 
     client = aioredis.Redis(username="default", password="jordan", port=df.port)
 
-    b"OK" == await client.execute_command("SET foo bar")
-    client.close()
+    assert await client.set("foo", "bar")
+    await client.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Ari asked about this functionality and even though we support it in data plane the control planes depends on it and therefore it's good to have a compatibility test. The test just checks that the `requirepass` is overwritten by the `aclfile`

* add a test that uses both requirepass and aclfile