### PR TITLE
chore: skip test_cluster_flushall_during_migration

### DIFF
--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -1032,6 +1032,7 @@ async def test_config_consistency(df_factory: DflyInstanceFactory):
     await close_clients(*[node.client for node in nodes], *[node.admin_client for node in nodes])
 
 
+@pytest.mark.skip("Deadlocks on CI, see #3302")
 @dfly_args({"proactor_threads": 4, "cluster_mode": "yes"})
 async def test_cluster_flushall_during_migration(
     df_factory: DflyInstanceFactory, df_seeder_factory


### PR DESCRIPTION
* skip failing test on ci