### PR TITLE
chore: remove replace_deleted flag from hnswlib

### DIFF
--- a/src/core/search/indices.cc
+++ b/src/core/search/indices.cc
@@ -199,12 +199,9 @@ struct HnswlibAdapter {
   constexpr static size_t kDefaultEfRuntime = 10;
 
   HnswlibAdapter(const SchemaField::VectorParams& params)
-      : space_{MakeSpace(params.dim, params.sim)}, world_{GetSpacePtr(),
-                                                          params.capacity,
-                                                          params.hnsw_m,
-                                                          params.hnsw_ef_construction,
-                                                          100 /* seed*/,
-                                                          true} {
+      : space_{MakeSpace(params.dim, params.sim)},
+        world_{GetSpacePtr(), params.capacity, params.hnsw_m, params.hnsw_ef_construction,
+               100 /* seed*/} {
   }
 
   void Add(float* data, DocId id) {


### PR DESCRIPTION
Fixes #3256 

We internally re-use ids, so we can keep replace_deleted disabled