### PR TITLE
feat(test): Improve benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -94,10 +94,12 @@ jobs:
         run: |
           kubectl apply -n ${{ steps.setup.outputs.namespace }} -f tools/benchmark/k8s-benchmark-job.yaml
 
-      #- name: Version upgrade
-      #  shell: bash
-      #  run: |
-      #    kubectl patch dragonfly dragonfly-sample --type merge -p '{"spec":{"image":"ghcr.io/dragonflydb/dragonfly-weekly:latest"}}'
+      - name: Version upgrade
+        shell: bash
+        run: |
+          # benchmark is running, wait for 30 seconds before version upgrade
+          sleep 30
+          kubectl patch dragonfly dragonfly-sample --type merge -p '{"spec":{"image":"ghcr.io/dragonflydb/dragonfly-weekly:latest"}}'
 
       - name: Wait for Memtier Benchmark
         shell: bash

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -99,7 +99,7 @@ jobs:
         run: |
           # benchmark is running, wait for 30 seconds before version upgrade
           sleep 30
-          kubectl patch dragonfly -n ${{ steps.setup.outputs.namespace }} --type merge -p '{"spec":{"image":"ghcr.io/dragonflydb/dragonfly-weekly:latest"}}'
+          kubectl patch dragonfly dragonfly-sample -n ${{ steps.setup.outputs.namespace }}  --type merge -p '{"spec":{"image":"ghcr.io/dragonflydb/dragonfly-weekly:latest"}}'
 
       - name: Wait for Memtier Benchmark
         shell: bash
@@ -164,7 +164,7 @@ jobs:
           kubectl delete namespace dragonfly-operator-system
 
       - name: Send notification on failure
-        if: failure()
+        if: failure() && github.ref == 'refs/heads/main'
         shell: bash
         run: |
           job_link="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -107,6 +107,7 @@ jobs:
           # Memtier benchmark run will fail at some point because old master shutdown on version upgrade
           kubectl wait --for=condition=failed --timeout=120s -n ${{ steps.setup.outputs.namespace }} jobs/memtier-benchmark 2>/dev/null
           kubectl logs -n ${{ steps.setup.outputs.namespace }} -f jobs/memtier-benchmark
+          kubectl delete -n ${{ steps.setup.outputs.namespace }} jobs/memtier-benchmark
 
       - name: Run Memtier Benchmark again
         shell: bash
@@ -163,7 +164,7 @@ jobs:
           timeout_minutes: 1
           max_attempts: 3
           command: |
-            kubectl describe dragonflies.dragonflydb.io -n ${{ steps.setup.outputs.namespace }} service/dragonfly-sample
+            kubectl describe dragonflies.dragonflydb.io -n ${{ steps.setup.outputs.namespace }} dragonfly-sample
 
       - name: Scale down to zero
         if: always()

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -107,10 +107,6 @@ jobs:
           # Memtier benchmark run will fail at some point because old master shutdown on version upgrade
           kubectl wait --for=condition=failed --timeout=120s -n ${{ steps.setup.outputs.namespace }} jobs/memtier-benchmark 2>/dev/null
           kubectl logs -n ${{ steps.setup.outputs.namespace }} -f jobs/memtier-benchmark
-
-      - name: Delete Memtier Benchmark jon
-        shell: bash
-        run: |
           kubectl delete -n ${{ steps.setup.outputs.namespace }} jobs/memtier-benchmark
 
       - name: Run Memtier Benchmark again

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,7 +23,7 @@ jobs:
                 name: "dragonfly-sample"
               spec:
                 image: "docker.dragonflydb.io/dragonflydb/dragonfly"
-                args: ["--cache_mode"]
+                args: ["--cache_mode", "--vmodule=replica=2"]
                 replicas: 2
                 resources:
                   requests:
@@ -89,12 +89,17 @@ jobs:
           kubectl wait -n ${{ steps.setup.outputs.namespace }} pods --selector app=dragonfly-sample --for condition=Ready --timeout=120s
           kubectl describe -n ${{ steps.setup.outputs.namespace }} pod dragonfly-sample-0
 
-      - name: Run Memtier
+      - name: Run Memtier Benchmark
         shell: bash
         run: |
           kubectl apply -n ${{ steps.setup.outputs.namespace }} -f tools/benchmark/k8s-benchmark-job.yaml
 
-      - name: Wait for memtier benchmark
+      #- name: Version upgrade
+      #  shell: bash
+      #  run: |
+      #    kubectl patch dragonfly dragonfly-sample --type merge -p '{"spec":{"image":"ghcr.io/dragonflydb/dragonfly-weekly:latest"}}'
+
+      - name: Wait for Memtier Benchmark
         shell: bash
         run: |
           while true; do

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -99,7 +99,7 @@ jobs:
         run: |
           # benchmark is running, wait for 30 seconds before version upgrade
           sleep 30
-          kubectl patch dragonfly dragonfly-sample --type merge -p '{"spec":{"image":"ghcr.io/dragonflydb/dragonfly-weekly:latest"}}'
+          kubectl patch dragonfly -n ${{ steps.setup.outputs.namespace }} --type merge -p '{"spec":{"image":"ghcr.io/dragonflydb/dragonfly-weekly:latest"}}'
 
       - name: Wait for Memtier Benchmark
         shell: bash

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -105,7 +105,7 @@ jobs:
         shell: bash
         run: |
           # Memtier benchmark run will fail at some point because old master shutdown on version upgrade
-          kubectl wait --for=condition=failed --timeout=120s -n ${{ steps.setup.outputs.namespace }} jobs/memtier-benchmark 2>/dev/null; then
+          kubectl wait --for=condition=failed --timeout=120s -n ${{ steps.setup.outputs.namespace }} jobs/memtier-benchmark 2>/dev/null
           kubectl logs -n ${{ steps.setup.outputs.namespace }} -f jobs/memtier-benchmark
 
       - name: Run Memtier Benchmark again

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -156,6 +156,15 @@ jobs:
           command: |
             kubectl logs -n ${{ steps.setup.outputs.namespace }} dragonfly-sample-1
 
+      - name: Get kubectl logs
+        uses: nick-fields/retry@v3
+        if: always()
+        with:
+          timeout_minutes: 1
+          max_attempts: 3
+          command: |
+            kubectl describe dragonflies.dragonflydb.io -n ${{ steps.setup.outputs.namespace }} service/dragonfly-sample
+
       - name: Scale down to zero
         if: always()
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,7 +23,7 @@ jobs:
                 name: "dragonfly-sample"
               spec:
                 image: "docker.dragonflydb.io/dragonflydb/dragonfly"
-                args: ["--cache_mode", "--vmodule=replica=2"]
+                args: ["--cache_mode"]
                 replicas: 2
                 resources:
                   requests:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -136,7 +136,6 @@ jobs:
       - name: Server checks
         run: |
           nohup kubectl port-forward -n ${{ steps.setup.outputs.namespace }} service/dragonfly-sample 6379:6379 &
-          #TODO how can we check version upgrade finished
           pip install -r tools/requirements.txt
           python3 tools/benchmark/post_run_checks.py
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -157,7 +157,7 @@ jobs:
           command: |
             kubectl logs -n ${{ steps.setup.outputs.namespace }} dragonfly-sample-1
 
-      - name: Get kubectl logs
+      - name: Describe dragonflydb object
         uses: nick-fields/retry@v3
         if: always()
         with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -105,8 +105,20 @@ jobs:
         shell: bash
         run: |
           # Memtier benchmark run will fail at some point because old master shutdown on version upgrade
-          kubectl wait --for=condition=failed --timeout=120s -n ${{ steps.setup.outputs.namespace }} jobs/memtier-benchmark 2>/dev/null
+          while true; do
+            if kubectl wait --for=condition=failed --timeout=0 -n ${{ steps.setup.outputs.namespace }} jobs/memtier-benchmark 2>/dev/null; then
+              job_result=1
+              break
+            fi
+            sleep 3
+          done
+
+          #kubectl wait --for=condition=failed --timeout=120s -n ${{ steps.setup.outputs.namespace }} jobs/memtier-benchmark 2>/dev/null
           kubectl logs -n ${{ steps.setup.outputs.namespace }} -f jobs/memtier-benchmark
+          if [[ $job_result -nq 1 ]]; then
+            exit 1
+          fi
+
           kubectl delete -n ${{ steps.setup.outputs.namespace }} jobs/memtier-benchmark
 
       - name: Run Memtier Benchmark again

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,7 +22,7 @@ jobs:
                   app.kubernetes.io/created-by: "dragonfly-operator"
                 name: "dragonfly-sample"
               spec:
-                image: "docker.dragonflydb.io/dragonflydb/dragonfly"
+                image: "ghcr.io/dragonflydb/dragonfly:latest"
                 args: ["--cache_mode"]
                 replicas: 2
                 resources:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -115,7 +115,7 @@ jobs:
 
           #kubectl wait --for=condition=failed --timeout=120s -n ${{ steps.setup.outputs.namespace }} jobs/memtier-benchmark 2>/dev/null
           kubectl logs -n ${{ steps.setup.outputs.namespace }} -f jobs/memtier-benchmark
-          if [[ $job_result -nq 1 ]]; then
+          if [[ $job_result -ne 1 ]]; then
             exit 1
           fi
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -105,19 +105,8 @@ jobs:
         shell: bash
         run: |
           # Memtier benchmark run will fail at some point because old master shutdown on version upgrade
-          while true; do
-            if kubectl wait --for=condition=failed --timeout=0 -n ${{ steps.setup.outputs.namespace }} jobs/memtier-benchmark 2>/dev/null; then
-              job_result=1
-              break
-            fi
-            sleep 3
-          done
-
-          #kubectl wait --for=condition=failed --timeout=120s -n ${{ steps.setup.outputs.namespace }} jobs/memtier-benchmark 2>/dev/null
+          kubectl wait --for=condition=failed --timeout=120s -n ${{ steps.setup.outputs.namespace }} jobs/memtier-benchmark 2>/dev/null
           kubectl logs -n ${{ steps.setup.outputs.namespace }} -f jobs/memtier-benchmark
-          if [[ $job_result -ne 1 ]]; then
-            exit 1
-          fi
 
       - name: Delete Memtier Benchmark jon
         shell: bash
@@ -128,6 +117,7 @@ jobs:
         shell: bash
         run: |
           kubectl apply -n ${{ steps.setup.outputs.namespace }} -f tools/benchmark/k8s-benchmark-job.yaml
+
           while true; do
             if kubectl wait --for=condition=complete --timeout=0 -n ${{ steps.setup.outputs.namespace }} jobs/memtier-benchmark 2>/dev/null; then
               job_result=0

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -119,6 +119,9 @@ jobs:
             exit 1
           fi
 
+      - name: Delete Memtier Benchmark jon
+        shell: bash
+        run: |
           kubectl delete -n ${{ steps.setup.outputs.namespace }} jobs/memtier-benchmark
 
       - name: Run Memtier Benchmark again

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -101,9 +101,17 @@ jobs:
           sleep 30
           kubectl patch dragonfly dragonfly-sample -n ${{ steps.setup.outputs.namespace }}  --type merge -p '{"spec":{"image":"ghcr.io/dragonflydb/dragonfly-weekly:latest"}}'
 
-      - name: Wait for Memtier Benchmark
+      - name: Wait for Memtier Benchmark fail
         shell: bash
         run: |
+          # Memtier benchmark run will fail at some point because old master shutdown on version upgrade
+          kubectl wait --for=condition=failed --timeout=120s -n ${{ steps.setup.outputs.namespace }} jobs/memtier-benchmark 2>/dev/null; then
+          kubectl logs -n ${{ steps.setup.outputs.namespace }} -f jobs/memtier-benchmark
+
+      - name: Run Memtier Benchmark again
+        shell: bash
+        run: |
+          kubectl apply -n ${{ steps.setup.outputs.namespace }} -f tools/benchmark/k8s-benchmark-job.yaml
           while true; do
             if kubectl wait --for=condition=complete --timeout=0 -n ${{ steps.setup.outputs.namespace }} jobs/memtier-benchmark 2>/dev/null; then
               job_result=0
@@ -126,7 +134,7 @@ jobs:
       - name: Server checks
         run: |
           nohup kubectl port-forward -n ${{ steps.setup.outputs.namespace }} service/dragonfly-sample 6379:6379 &
-
+          #TODO how can we check version upgrade finished
           pip install -r tools/requirements.txt
           python3 tools/benchmark/post_run_checks.py
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,7 +22,7 @@ jobs:
                   app.kubernetes.io/created-by: "dragonfly-operator"
                 name: "dragonfly-sample"
               spec:
-                image: "ghcr.io/dragonflydb/dragonfly-weekly:latest"
+                image: "docker.dragonflydb.io/dragonflydb/dragonfly"
                 args: ["--cache_mode"]
                 replicas: 2
                 resources:
@@ -89,11 +89,14 @@ jobs:
           kubectl wait -n ${{ steps.setup.outputs.namespace }} pods --selector app=dragonfly-sample --for condition=Ready --timeout=120s
           kubectl describe -n ${{ steps.setup.outputs.namespace }} pod dragonfly-sample-0
 
-      - name: Run Benchmark
+      - name: Run Memtier
         shell: bash
         run: |
           kubectl apply -n ${{ steps.setup.outputs.namespace }} -f tools/benchmark/k8s-benchmark-job.yaml
 
+      - name: Wait for memtier benchmark
+        shell: bash
+        run: |
           while true; do
             if kubectl wait --for=condition=complete --timeout=0 -n ${{ steps.setup.outputs.namespace }} jobs/memtier-benchmark 2>/dev/null; then
               job_result=0
@@ -152,3 +155,16 @@ jobs:
           set -x
           kubectl delete namespace ${{ steps.setup.outputs.namespace }}
           kubectl delete namespace dragonfly-operator-system
+
+      - name: Send notification on failure
+        if: failure()
+        shell: bash
+        run: |
+          job_link="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          message="Benchmark tests failed.\\n Job Link: ${job_link}\\n"
+
+          curl -s \
+            -X POST \
+            -H 'Content-Type: application/json' \
+            '${{ secrets.GSPACES_BOT_DF_BUILD }}' \
+            -d '{"text": "'"${message}"'"}'

--- a/tools/benchmark/k8s-benchmark-job.yaml
+++ b/tools/benchmark/k8s-benchmark-job.yaml
@@ -11,7 +11,7 @@ spec:
         - name: memtier
           image: redislabs/memtier_benchmark:latest
           args:
-            - memtier_benchmark --pipeline=30 --key-maximum=100000 -c 10 -t 2 --test-time=300 --expiry-range=10-100 --reconnect-interval=10000 --distinct-client-seed --hide-histogram -s dragonfly-sample
+            - memtier_benchmark --pipeline=30 --key-maximum=100000 -c 10 -t 2 --test-time=300 --reconnect-interval=10000 --distinct-client-seed --hide-histogram -s dragonfly-sample
           command:
             - sh # This is important! without it memtier cannot DIG the dragonfly SVC domain
             - -c

--- a/tools/benchmark/k8s-benchmark-job.yaml
+++ b/tools/benchmark/k8s-benchmark-job.yaml
@@ -11,7 +11,7 @@ spec:
         - name: memtier
           image: redislabs/memtier_benchmark:latest
           args:
-            - memtier_benchmark --pipeline=30 --key-maximum=10000 -c 10 -t 2 --requests=500000 --expiry-range=10-100 --reconnect-interval=10000 --distinct-client-seed --hide-histogram -s dragonfly-sample
+            - memtier_benchmark --pipeline=30 --key-maximum=100000 -c 10 -t 2 --test-time=300 --expiry-range=10-100 --reconnect-interval=10000 --distinct-client-seed --hide-histogram -s dragonfly-sample
           command:
             - sh # This is important! without it memtier cannot DIG the dragonfly SVC domain
             - -c

--- a/tools/benchmark/k8s-benchmark-job.yaml
+++ b/tools/benchmark/k8s-benchmark-job.yaml
@@ -11,7 +11,7 @@ spec:
         - name: memtier
           image: redislabs/memtier_benchmark:latest
           args:
-            - memtier_benchmark --pipeline=30 --key-maximum=100000 -c 10 -t 2 --test-time=300 --reconnect-interval=10000 --distinct-client-seed --hide-histogram -s dragonfly-sample
+            - memtier_benchmark --pipeline=30 --key-maximum=100000 -c 10 -t 2 --test-time=600 --reconnect-interval=10000 --distinct-client-seed --hide-histogram -s dragonfly-sample
           command:
             - sh # This is important! without it memtier cannot DIG the dragonfly SVC domain
             - -c

--- a/tools/benchmark/post_run_checks.py
+++ b/tools/benchmark/post_run_checks.py
@@ -7,6 +7,10 @@ def main():
     max_unaccounted = 200 * 1024 * 1024  # 200mb
 
     client = redis.Redis(decode_responses=True)
+    info = client.info("server")
+    # Check version upgrade finsihed from last released version to last weekly docker build
+    assert info["dragonfly_version"] == "df-HEAD-HASH-NOTFOUND"
+
     info = client.info("memory")
     print(f'Used memory {info["used_memory"]}, rss {info["used_memory_rss"]}')
     assert info["used_memory_rss"] - info["used_memory"] < max_unaccounted

--- a/tools/benchmark/post_run_checks.py
+++ b/tools/benchmark/post_run_checks.py
@@ -19,8 +19,8 @@ def main():
     def is_zero_lag(replication_state):
         return replication_state["lag"] == 0
 
-    # Wait for 10 seconds for lag to be zero
-    for _ in range(10):
+    # Wait for 30 seconds for lag to be zero
+    for _ in range(30):
         if is_zero_lag(replication_state):
             break
         time.sleep(1)

--- a/tools/benchmark/post_run_checks.py
+++ b/tools/benchmark/post_run_checks.py
@@ -26,7 +26,11 @@ def main():
         time.sleep(1)
         replication_state = client.info("replication")["slave0"]
 
-    assert replication_state["lag"] == 0, f"Lag is bad, expected 0, got {replication_state['lag']}"
+    if replication_state["lag"] != 0:
+        print(f"Lag is bad, expected 0, got {replication_state['lag']}")
+        info = client.info("all")
+        print(f"Info all output: {info}")
+        assert False
 
 
 if __name__ == "__main__":

--- a/tools/benchmark/post_run_checks.py
+++ b/tools/benchmark/post_run_checks.py
@@ -19,8 +19,8 @@ def main():
     def is_zero_lag(replication_state):
         return replication_state["lag"] == 0
 
-    # Wait for 60 seconds for lag to be zero
-    for _ in range(60):
+    # Wait for 10 seconds for lag to be zero
+    for _ in range(10):
         if is_zero_lag(replication_state):
             break
         time.sleep(1)

--- a/tools/benchmark/post_run_checks.py
+++ b/tools/benchmark/post_run_checks.py
@@ -19,8 +19,8 @@ def main():
     def is_zero_lag(replication_state):
         return replication_state["lag"] == 0
 
-    # Wait for 30 seconds for lag to be zero
-    for _ in range(30):
+    # Wait for 60 seconds for lag to be zero
+    for _ in range(60):
         if is_zero_lag(replication_state):
             break
         time.sleep(1)


### PR DESCRIPTION
improvements added to the workflow:
1. add version upgrade from last version to last weekly docker build
2. run memtier benchmark while version is upgraded (if will fail due to takeover to a new pod)
3. run memtier benchmark again after version upgrade finished
4. send logs to channel if benchmark failed