### PR TITLE
fix(test): copy logs for failed test during TEARDOWN phase

### DIFF
--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -394,6 +394,8 @@ def pytest_runtest_makereport(item, call):
     if report.when == "teardown":
         log_dir = getattr(item, "log_dir", None)
         call_outcome = getattr(item, "call_outcome", None)
+        if report.failed:
+            copy_failed_logs(log_dir, report)
         if call_outcome and call_outcome.failed:
             copy_failed_logs(log_dir, call_outcome)
 

--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -175,7 +175,6 @@ def df_server(df_factory: DflyInstanceFactory) -> DflyInstance:
     # else:
     #    print("Cluster clients left: ", len(clients_left))
 
-    raise Exception("Dragonfly did not terminate gracefully")
     if instance["cluster_mode"]:
         print("Cluster clients left: ", len(clients_left))
 

--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -175,6 +175,7 @@ def df_server(df_factory: DflyInstanceFactory) -> DflyInstance:
     # else:
     #    print("Cluster clients left: ", len(clients_left))
 
+    raise Exception("Dragonfly did not terminate gracefully")
     if instance["cluster_mode"]:
         print("Cluster clients left: ", len(clients_left))
 


### PR DESCRIPTION
Pytest has several phases: "setup", "call", and "teardown". Previously I have copied logs only for the "call" state (when the tests are running). During the "teardown" phase all resources are freed and if we have an error during this process we need to copy logs too