### PR TITLE
fix: Proper shutdown sequence with Namespaces

### DIFF
--- a/src/server/blocking_controller_test.cc
+++ b/src/server/blocking_controller_test.cc
@@ -70,8 +70,8 @@ void BlockingControllerTest::SetUp() {
 }
 
 void BlockingControllerTest::TearDown() {
+  shard_set->PreShutdown();
   namespaces.Clear();
-
   shard_set->Shutdown();
   delete shard_set;
 

--- a/src/server/engine_shard_set.h
+++ b/src/server/engine_shard_set.h
@@ -149,6 +149,8 @@ class EngineShard {
 
   void TEST_EnableHeartbeat();
 
+  void StopPeriodicFiber();
+
   struct TxQueueInfo {
     // Armed - those that the coordinator has armed with callbacks and wants them to run.
     // Runnable - those that could run (they own the locks) but probably can not run due
@@ -281,6 +283,12 @@ class EngineShardSet {
   }
 
   void Init(uint32_t size, bool update_db_time);
+
+  // Shutdown sequence:
+  // - EngineShardSet.PreShutDown()
+  // - Namespaces.Clear()
+  // - EngineShardSet.Shutdown()
+  void PreShutdown();
   void Shutdown();
 
   static const std::vector<CachedStats>& GetCachedStats();

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -833,7 +833,6 @@ Service::Service(ProactorPool* pp)
 Service::~Service() {
   delete shard_set;
   shard_set = nullptr;
-  namespaces.Clear();
 }
 
 void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> listeners,
@@ -913,8 +912,8 @@ void Service::Shutdown() {
 
   ChannelStore::Destroy();
 
+  shard_set->PreShutdown();
   namespaces.Clear();
-
   shard_set->Shutdown();
 
   pp_.Await([](ProactorBase* pb) { ServerState::tlocal()->Destroy(); });


### PR DESCRIPTION
This removes a race between periodic fiber and namespaces during shutdown.

Fixes #3328

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->