### PR TITLE
fix: corruption in replication stream

### DIFF
--- a/src/server/journal/streamer.h
+++ b/src/server/journal/streamer.h
@@ -63,7 +63,8 @@ class JournalStreamer {
 
   journal::Journal* journal_;
   std::vector<uint8_t> pending_buf_;
-  size_t in_flight_bytes_ = 0;
+  size_t in_flight_bytes_ = 0, total_sent_ = 0;
+
   time_t last_lsn_time_ = 0;
   util::fb2::EventCount waker_;
   uint32_t journal_cb_id_{0};


### PR DESCRIPTION
Before it was possible to issue several concurrent AsyncWrite requests. But these are not atomic, which leads to replication stream corruption. Now we wait for the previous request to finish before sending the next one.

ThrottleIfNeeded is now takes into account pending buffer size for throttling.

Fixes #3329

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->