### PR TITLE
chore: remove redundant metrics from memory stats

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -917,6 +917,9 @@ void Connection::ConnectionFlow(FiberSocketBase* peer) {
     //
     // Otherwise the clients write could fail (or block), so they would never
     // read the above protocol error (see issue #1327).
+    // TODO: we have a bug that can potentially deadlock the code below.
+    // If a peer does not close the socket on the other side, the while loop will never finish.
+    // to reproduce: nc localhost 6379  and then run invalid sequence: *1 <enter> *1 <enter>
     error_code ec2 = peer->Shutdown(SHUT_WR);
     LOG_IF(WARNING, ec2) << "Could not shutdown socket " << ec2;
     if (!ec2) {


### PR DESCRIPTION
Leave only connection memory usage in memory stats. We should think how we can move it also to /metrics. In addition, added a test verifying that redis parser memory usage is tracked.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->