### PR TITLE
fix(transaction): Fix namespace access

### DIFF
--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -176,11 +176,17 @@ Transaction::~Transaction() {
 
 void Transaction::InitBase(Namespace* ns, DbIndex dbid, CmdArgList args) {
   global_ = false;
-  namespace_ = ns;
   db_index_ = dbid;
   full_args_ = args;
   local_result_ = OpStatus::OK;
   stats_.coordinator_index = ProactorBase::me() ? ProactorBase::me()->GetPoolIndex() : kInvalidSid;
+
+  // Namespace is read by poll execution, so it can't be changed on the fly
+  if (IsScheduled()) {
+    DCHECK_EQ(namespace_, ns);
+  } else {
+    namespace_ = ns;
+  }
 }
 
 void Transaction::InitGlobal() {

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -185,6 +185,7 @@ void Transaction::InitBase(Namespace* ns, DbIndex dbid, CmdArgList args) {
   if (IsScheduled()) {
     DCHECK_EQ(namespace_, ns);
   } else {
+    DCHECK(namespace_ == nullptr || namespace_ == ns);
     namespace_ = ns;
   }
 }


### PR DESCRIPTION
Our area of attack during concurrent transaction access is the call to `DisarmInShard` and `DisarmInShardWhen`, which only access is_armed - an atomic varible. It is not safe to arbitrarily call GetNamespace() if we write to it in InitBase

Solution: Don't write to it post first initialization