### PR TITLE
chore: Introduce CoolQueue

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -3,7 +3,7 @@ add_subdirectory(json)
 
 set(SEARCH_LIB query_parser)
 
-add_library(dfly_core bloom.cc compact_object.cc dragonfly_core.cc extent_tree.cc
+add_library(dfly_core bloom.cc compact_object.cc cool_queue.cc dragonfly_core.cc extent_tree.cc
     interpreter.cc mi_memory_resource.cc sds_utils.cc
     segment_allocator.cc score_map.cc small_string.cc sorted_map.cc
     tx_queue.cc dense_set.cc allocation_tracker.cc

--- a/src/core/cool_queue.cc
+++ b/src/core/cool_queue.cc
@@ -1,0 +1,75 @@
+// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "src/core/cool_queue.h"
+
+#include "base/logging.h"
+
+namespace dfly {
+
+CoolQueue::~CoolQueue() {
+  while (!Empty()) {
+    auto* record = PopBack();
+    CompactObj::DeleteMR<detail::TieredColdRecord>(record);
+  }
+}
+
+detail::TieredColdRecord* CoolQueue::PushFront(uint16_t db_index, uint64_t key_hash,
+                                               uint32_t page_index, CompactObj obj) {
+  detail::TieredColdRecord* record = CompactObj::AllocateMR<detail::TieredColdRecord>();
+  record->key_hash = key_hash;
+  record->db_index = db_index;
+  record->page_index = page_index;
+  record->value = std::move(obj);
+
+  record->next = head_;
+  if (head_) {
+    head_->prev = record;
+  } else {
+    DCHECK(tail_ == nullptr);
+    tail_ = record;
+  }
+  head_ = record;
+  used_memory_ += (sizeof(detail::TieredColdRecord) + record->value.MallocUsed());
+  return record;
+}
+
+detail::TieredColdRecord* CoolQueue::PopBack() {
+  auto* res = tail_;
+  if (tail_) {
+    auto* prev = tail_->prev;
+    tail_->prev = nullptr;
+    if (prev) {
+      prev->next = nullptr;
+    } else {
+      DCHECK(tail_ == head_);
+      head_ = nullptr;
+    }
+    tail_ = prev;
+    used_memory_ -= (sizeof(detail::TieredColdRecord) + res->value.MallocUsed());
+  }
+  return res;
+}
+
+CompactObj CoolQueue::Erase(detail::TieredColdRecord* record) {
+  DCHECK(record);
+
+  if (record == tail_) {
+    PopBack();
+  } else {
+    used_memory_ -= (sizeof(detail::TieredColdRecord) + record->value.MallocUsed());
+    record->next->prev = record->prev;
+    if (record->prev) {
+      record->prev->next = record->next;
+    } else {
+      DCHECK(record == head_);
+      head_ = record->next;
+    }
+  }
+
+  CompactObj res = std::move(record->value);
+  CompactObj::DeleteMR<detail::TieredColdRecord>(record);
+  return res;
+}
+}  // namespace dfly

--- a/src/core/cool_queue.h
+++ b/src/core/cool_queue.h
@@ -1,0 +1,38 @@
+// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include "core/compact_object.h"
+
+namespace dfly {
+
+// Used to store "cold" items before erasing them from RAM.
+//
+class CoolQueue {
+ public:
+  ~CoolQueue();
+
+  bool Empty() const {
+    return head_ == nullptr;
+  }
+
+  detail::TieredColdRecord* PushFront(uint16_t db_index, uint64_t key_hash, uint32_t page_index,
+                                      CompactObj obj);
+
+  // The ownership is passed to the caller. The record must be deleted with
+  // CompactObj::DeleteMR<detail::TieredColdRecord>.
+  detail::TieredColdRecord* PopBack();
+
+  CompactObj Erase(detail::TieredColdRecord* record);
+
+  size_t UsedMemory() const;
+
+ private:
+  detail::TieredColdRecord* head_ = nullptr;
+  detail::TieredColdRecord* tail_ = nullptr;
+  size_t used_memory_ = 0;
+};
+
+}  // namespace dfly

--- a/src/core/dfly_core_test.cc
+++ b/src/core/dfly_core_test.cc
@@ -3,6 +3,7 @@
 //
 
 #include "base/gtest.h"
+#include "core/cool_queue.h"
 #include "core/intent_lock.h"
 #include "core/tx_queue.h"
 
@@ -63,6 +64,17 @@ TEST_F(IntentLockTest, Basic) {
   ASSERT_FALSE(lk_.Check(IntentLock::EXCLUSIVE));
   lk_.Release(IntentLock::SHARED);
   ASSERT_TRUE(lk_.Check(IntentLock::EXCLUSIVE));
+}
+
+TEST_F(TxQueueTest, CoolQueue) {
+  CoolQueue queue;
+
+  ASSERT_TRUE(queue.Empty());
+  auto* record = queue.PushFront(0, 1, 2, CompactObj{});
+  EXPECT_EQ(record->key_hash, 1);
+  ASSERT_FALSE(queue.Empty());
+  queue.PopBack();
+  ASSERT_TRUE(queue.Empty());
 }
 
 }  // namespace dfly


### PR DESCRIPTION
Also, add the according API to compact object.
Now external objects can be in two states: Cool and Offloaded.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->