### PR TITLE
fix(transaction): Properly store block cancel status

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1568,7 +1568,7 @@ void ServerFamily::CancelBlockingOnThread(std::function<OpStatus(ArgSlice)> stat
   auto cb = [status_cb](unsigned thread_index, util::Connection* conn) {
     if (auto fcntx = static_cast<facade::Connection*>(conn)->cntx(); fcntx) {
       auto* cntx = static_cast<ConnectionContext*>(fcntx);
-      if (cntx->transaction && cntx->blocked) {
+      if (cntx->transaction) {
         cntx->transaction->CancelBlocking(status_cb);
       }
     }

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1178,7 +1178,8 @@ OpStatus Transaction::WaitOnWatch(const time_point& tp, WaitKeysProvider wkeys_p
   if (status == cv_status::timeout) {
     result = OpStatus::TIMED_OUT;
   } else if (coordinator_state_ & COORD_CANCELLED) {
-    result = local_result_;
+    DCHECK_GT(block_cancel_result_, OpStatus::OK);
+    result = block_cancel_result_;
   }
 
   // If we don't follow up with an "action" hop, we must clean up manually on all shards.
@@ -1412,7 +1413,8 @@ void Transaction::CancelBlocking(std::function<OpStatus(ArgSlice)> status_cb) {
     return;
 
   coordinator_state_ |= COORD_CANCELLED;
-  local_result_ = status;
+  // don't use local_result_ because it can be overwirtten if we cancel ahead
+  block_cancel_result_ = status;
   blocking_barrier_.Close();
 }
 

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -630,7 +630,9 @@ class Transaction {
 
   // Barrier for waking blocking transactions that ensures exclusivity of waking operation.
   BatonBarrier blocking_barrier_{};
-  OpStatus block_cancel_result_ = OpStatus::OK;  // Stores status is COORD_CANCELLED was set
+  // Stores status if COORD_CANCELLED was set. Apart from cancelled, it can be moved for cluster
+  // changes
+  OpStatus block_cancel_result_ = OpStatus::OK;
 
   // Transaction coordinator state, written and read by coordinator thread.
   uint8_t coordinator_state_ = 0;

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -630,6 +630,7 @@ class Transaction {
 
   // Barrier for waking blocking transactions that ensures exclusivity of waking operation.
   BatonBarrier blocking_barrier_{};
+  OpStatus block_cancel_result_ = OpStatus::OK;  // Stores status is COORD_CANCELLED was set
 
   // Transaction coordinator state, written and read by coordinator thread.
   uint8_t coordinator_state_ = 0;


### PR DESCRIPTION
This code from `RegisterBreakHook` makes sure we can even cancel ahead, so that the transaction is guaranteed to not get stuck:

```c++
 if (res->transaction)
      res->transaction->CancelBlocking(nullptr);
```

however when we do this, we can do it as early as before running the more recent callback with Execute(), which in turn overwrites local_result_

at the end we get local_result_ being set to OK, but COORD_CANCELLED being set as well 