### PR TITLE
chore(replica): remove unused methods in the Replica class

### DIFF
--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -74,10 +74,6 @@ class Replica : ProtocolClient {
 
   std::error_code TakeOver(std::string_view timeout, bool save_flag);
 
-  std::string_view MasterId() const {
-    return master_context_.master_repl_id;
-  }
-
  private: /* Main standalone mode functions */
   // Coordinate state transitions. Spawned by start.
   void MainReplicationFb();
@@ -104,8 +100,6 @@ class Replica : ProtocolClient {
   // Send DFLY ${kind} to the master instance.
   std::error_code SendNextPhaseRequest(std::string_view kind);
 
-  void AclCheckFb();
-
  private: /* Utility */
   struct PSyncResponse {
     // string - end of sync token (diskless)
@@ -131,14 +125,6 @@ class Replica : ProtocolClient {
 
   bool HasDflyMaster() const {
     return !master_context_.dfly_session_id.empty();
-  }
-
-  const std::string& MasterHost() const {
-    return server().host;
-  }
-
-  uint16_t Port() const {
-    return server().port;
   }
 
   std::vector<uint64_t> GetReplicaOffset() const;


### PR DESCRIPTION
While getting deeper into the implementation of replication, I just found some methods that we no longer use