### PR TITLE
chore: Track db_slice table memory instantly

### DIFF
--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -412,6 +412,10 @@ class DbSlice {
     return version_;
   }
 
+  size_t table_memory() const {
+    return table_memory_;
+  }
+
   using ChangeCallback = std::function<void(DbIndex, const ChangeReq&)>;
 
   //! Registers the callback to be called for each change.
@@ -575,6 +579,7 @@ class DbSlice {
   ssize_t memory_budget_ = SSIZE_MAX;
   size_t bytes_per_object_ = 0;
   size_t soft_budget_limit_ = 0;
+  size_t table_memory_ = 0;
 
   mutable SliceEvents events_;  // we may change this even for const operations.
 

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -715,9 +715,10 @@ void EngineShard::CacheStats() {
     DbTable* table = db_slice.GetDBTable(i);
     if (table) {
       entries += table->prime.size();
-      table_memory += (table->prime.mem_usage() + table->expire.mem_usage());
+      table_memory += table->table_memory();
     }
   }
+  DCHECK_EQ(table_memory, db_slice.table_memory());
   size_t obj_memory = table_memory <= used_mem ? used_mem - table_memory : 0;
 
   size_t bytes_per_obj = entries > 0 ? obj_memory / entries : 0;

--- a/src/server/table.h
+++ b/src/server/table.h
@@ -139,6 +139,10 @@ struct DbTable : boost::intrusive_ref_counter<DbTable, boost::thread_unsafe_coun
 
   void Clear();
   PrimeIterator Launder(PrimeIterator it, std::string_view key);
+
+  size_t table_memory() const {
+    return expire.mem_usage() + prime.mem_usage();
+  }
 };
 
 // We use reference counting semantics of DbTable when doing snapshotting.


### PR DESCRIPTION
We update table_memory upon each deletion and insertion of an element.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->