### PR TITLE
chore: introduce a cool queue that gradually retires cool items

### DIFF
--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -44,6 +44,8 @@ class TieredStorage {
   std::error_code Open(std::string_view path);
   void Close();
 
+  void SetMemoryLowLimit(size_t mem_limit);
+
   // Read offloaded value. It must be of external type
   util::fb2::Future<std::string> Read(DbIndex dbid, std::string_view key, const PrimeValue& value);
 
@@ -79,6 +81,9 @@ class TieredStorage {
  private:
   // Returns if a value should be stashed
   bool ShouldStash(const PrimeValue& pv) const;
+
+  // Returns the primary value, and deletes the cool item as well as its offloaded storage.
+  PrimeValue Warmup(DbIndex dbid, PrimeValue::CoolItem item);
 
   PrimeTable::Cursor offloading_cursor_{};  // where RunOffloading left off
 

--- a/src/server/tiering/op_manager.cc
+++ b/src/server/tiering/op_manager.cc
@@ -34,6 +34,8 @@ OpManager::OpManager(size_t max_size) : storage_{max_size} {
 }
 
 OpManager::~OpManager() {
+  DCHECK(pending_stash_ver_.empty());
+  DCHECK(pending_reads_.empty());
 }
 
 std::error_code OpManager::Open(std::string_view file) {


### PR DESCRIPTION
This PR introduces a new state in which the offloaded value is not freed from memory but instead stays in the cool queue.

Upon Read we convert the cool value back to hot table and delete it from storage. When we low on memory we retire oldest cool values until we are above the threshold.

The PR does not fully finish the feature but it is workable enough to start (load)testing. Missing:
a) Handle Modify operations
b) Retire cool items in more cases where we are low on memory. Specifically, refrain from evictions as long as cool items exist.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->