### PR TITLE
chore: set serialization_max_chunk_size to 1 byte

### DIFF
--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -87,6 +87,9 @@ class DflyInstance:
             if threads > 1:
                 self.args["num_shards"] = threads - 1
 
+        # Add 1 byte limit for big values
+        self.args["serialization_max_chunk_size"] = 1
+
     def __del__(self):
         assert self.proc == None
 


### PR DESCRIPTION
Update the flag for extreme testing. We should remove this before the release.

* set serialization_max_chunk_size to 1 byte