### PR TITLE
fix: remove fiber guard from non atomic section

### DIFF
--- a/src/server/common.h
+++ b/src/server/common.h
@@ -384,4 +384,28 @@ class ConditionGuard {
   ConditionFlag* enclosing_;
 };
 
+class LocalBlockingCounter {
+ public:
+  void lock() {
+    ++mutating_;
+  }
+
+  void unlock() {
+    DCHECK(mutating_ > 0);
+    --mutating_;
+    if (mutating_ == 0) {
+      cond_var_.notify_one();
+    }
+  }
+
+  void Wait() {
+    util::fb2::NoOpLock noop_lk_;
+    cond_var_.wait(noop_lk_, [this]() { return mutating_ == 0; });
+  }
+
+ private:
+  util::fb2::CondVarAny cond_var_;
+  size_t mutating_ = 0;
+};
+
 }  // namespace dfly

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -15,6 +15,7 @@
 #include <string_view>
 #include <vector>
 
+#include "base/logging.h"
 #include "facade/facade_types.h"
 #include "facade/op_status.h"
 #include "util/fibers/fibers.h"

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -536,30 +536,6 @@ class DbSlice {
 
   void CallChangeCallbacks(DbIndex id, const ChangeReq& cr) const;
 
-  class LocalBlockingCounter {
-   public:
-    void lock() {
-      ++mutating_;
-    }
-
-    void unlock() {
-      DCHECK(mutating_ > 0);
-      --mutating_;
-      if (mutating_ == 0) {
-        cond_var_.notify_one();
-      }
-    }
-
-    void Wait() {
-      util::fb2::NoOpLock noop_lk_;
-      cond_var_.wait(noop_lk_, [this]() { return mutating_ == 0; });
-    }
-
-   private:
-    util::fb2::CondVarAny cond_var_;
-    size_t mutating_ = 0;
-  };
-
   // We need this because registered callbacks might yield. If RegisterOnChange
   // gets called after we preempt while iterating over the registered callbacks
   // (let's say in FlushChangeToEarlierCallbacks) we will get UB, because we pushed

--- a/src/server/journal/journal.cc
+++ b/src/server/journal/journal.cc
@@ -60,10 +60,12 @@ error_code Journal::Close() {
 }
 
 uint32_t Journal::RegisterOnChange(ChangeCallback cb) {
+  lock_guard lk(state_mu_);
   return journal_slice.RegisterOnChange(cb);
 }
 
 void Journal::UnregisterOnChange(uint32_t id) {
+  lock_guard lk(state_mu_);
   journal_slice.UnregisterOnChange(id);
 }
 
@@ -85,6 +87,7 @@ LSN Journal::GetLsn() const {
 
 void Journal::RecordEntry(TxId txid, Op opcode, DbIndex dbid, unsigned shard_cnt,
                           std::optional<cluster::SlotId> slot, Entry::Payload payload, bool await) {
+  lock_guard lk(state_mu_);
   journal_slice.AddLogRecord(Entry{txid, opcode, dbid, shard_cnt, slot, std::move(payload)}, await);
 }
 

--- a/src/server/journal/journal.cc
+++ b/src/server/journal/journal.cc
@@ -85,7 +85,6 @@ LSN Journal::GetLsn() const {
 
 void Journal::RecordEntry(TxId txid, Op opcode, DbIndex dbid, unsigned shard_cnt,
                           std::optional<cluster::SlotId> slot, Entry::Payload payload, bool await) {
-  lock_guard lk(state_mu_);
   journal_slice.AddLogRecord(Entry{txid, opcode, dbid, shard_cnt, slot, std::move(payload)}, await);
 }
 

--- a/src/server/journal/journal.cc
+++ b/src/server/journal/journal.cc
@@ -60,12 +60,10 @@ error_code Journal::Close() {
 }
 
 uint32_t Journal::RegisterOnChange(ChangeCallback cb) {
-  lock_guard lk(state_mu_);
   return journal_slice.RegisterOnChange(cb);
 }
 
 void Journal::UnregisterOnChange(uint32_t id) {
-  lock_guard lk(state_mu_);
   journal_slice.UnregisterOnChange(id);
 }
 

--- a/src/server/journal/journal_slice.cc
+++ b/src/server/journal/journal_slice.cc
@@ -187,8 +187,11 @@ void JournalSlice::AddLogRecord(const Entry& entry, bool await) {
     DVLOG(2) << "AddLogRecord: run callbacks for " << entry.ToString()
              << " num callbacks: " << change_cb_arr_.size();
 
-    for (const auto& k_v : change_cb_arr_) {
-      k_v.second(*item, await);
+    const size_t size = change_cb_arr_.size();
+    auto k_v = change_cb_arr_.begin();
+    for (size_t i = 0; i < size; ++i) {
+      k_v->second(*item, await);
+      ++k_v;
     }
   }
 }

--- a/src/server/journal/journal_slice.cc
+++ b/src/server/journal/journal_slice.cc
@@ -143,11 +143,6 @@ std::string_view JournalSlice::GetEntry(LSN lsn) const {
 }
 
 void JournalSlice::AddLogRecord(const Entry& entry, bool await) {
-  optional<FiberAtomicGuard> guard;
-  if (!await) {
-    guard.emplace();  // Guard is non-movable/copyable, so we must use emplace()
-  }
-
   DCHECK(ring_buffer_);
 
   JournalItem dummy;


### PR DESCRIPTION
We now might `preempt` when we serialize big values and the code in journal was marked as Atomic triggering an atomic section `CHECK`

* remove fiber guard from non atomic section
* move LocalBlockingCounter to common