### PR TITLE
fix: Fix `test_take_over_seeder`

### DIFF
--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -406,6 +406,8 @@ void DflyCmd::TakeOver(CmdArgList args, ConnectionContext* cntx) {
   if (*status == OpStatus::OK) {
     auto cb = [replica_ptr = std::move(replica_ptr), end_time,
                &catchup_success](EngineShard* shard) {
+      // We can't std::move(replica_ptr) into WaitReplicaFlowToCatchup() because `cb` runs on
+      // multiple threads, meaning it will be moved()d multiple times
       if (!WaitReplicaFlowToCatchup(end_time, replica_ptr, shard)) {
         catchup_success.store(false);
       }

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -71,8 +71,8 @@ std::string_view SyncStateName(DflyCmd::SyncState sync_state) {
   return "unsupported";
 }
 
-OpStatus WaitReplicaFlowToCatchup(absl::Time end_time, shared_ptr<DflyCmd::ReplicaInfo> replica,
-                                  EngineShard* shard) {
+bool WaitReplicaFlowToCatchup(absl::Time end_time, shared_ptr<DflyCmd::ReplicaInfo> replica,
+                              EngineShard* shard) {
   // We don't want any writes to the journal after we send the `PING`,
   // and expirations could ruin that.
   namespaces.GetDefaultNamespace().GetDbSlice(shard->shard_id()).SetExpireAllowed(false);
@@ -84,17 +84,17 @@ OpStatus WaitReplicaFlowToCatchup(absl::Time end_time, shared_ptr<DflyCmd::Repli
       LOG(WARNING) << "Couldn't synchronize with replica for takeover in time: " << replica->address
                    << ":" << replica->listening_port << ", last acked: " << flow->last_acked_lsn
                    << ", expecting " << shard->journal()->GetLsn();
-      return OpStatus::TIMED_OUT;
+      return false;
     }
     if (replica->cntx.IsCancelled()) {
-      return OpStatus::CANCELLED;
+      return false;
     }
     VLOG(1) << "Replica lsn:" << flow->last_acked_lsn
             << " master lsn:" << shard->journal()->GetLsn();
     ThisFiber::SleepFor(1ms);
   }
 
-  return OpStatus::OK;
+  return true;
 }
 
 }  // namespace
@@ -395,24 +395,31 @@ void DflyCmd::TakeOver(CmdArgList args, ConnectionContext* cntx) {
 
   VLOG(1) << "AwaitCurrentDispatches done";
 
-  absl::Cleanup([] {
+  absl::Cleanup cleanup([] {
+    VLOG(2) << "Enabling expiration";
     shard_set->RunBriefInParallel([](EngineShard* shard) {
       namespaces.GetDefaultNamespace().GetDbSlice(shard->shard_id()).SetExpireAllowed(true);
     });
-    VLOG(2) << "Enable expiration";
   });
 
+  atomic_bool catchup_success = true;
   if (*status == OpStatus::OK) {
-    auto cb = [replica_ptr = std::move(replica_ptr), end_time, &status](EngineShard* shard) {
-      status = WaitReplicaFlowToCatchup(end_time, std::move(replica_ptr), shard);
+    auto cb = [replica_ptr = std::move(replica_ptr), end_time,
+               &catchup_success](EngineShard* shard) {
+      if (!WaitReplicaFlowToCatchup(end_time, replica_ptr, shard)) {
+        catchup_success.store(false);
+      }
     };
     shard_set->RunBlockingInParallel(std::move(cb));
   }
 
-  if (*status != OpStatus::OK) {
+  VLOG(1) << "WaitReplicaFlowToCatchup done";
+
+  if (*status != OpStatus::OK || !catchup_success.load()) {
     sf_->service().SwitchState(GlobalState::TAKEN_OVER, GlobalState::ACTIVE);
     return cntx->SendError("Takeover failed!");
   }
+
   cntx->SendOk();
 
   if (save_flag) {


### PR DESCRIPTION
There are a few issues with the test:

1. Not using the admin port, which could cause pause to deadlock
2. Not waiting for some of the `task`s (although that won't cause a failure)

But also in the product code:

1. We used to `std::move()` the same pointer multiple times
2. We assigned to the same status object from multiple threads

Hopefully this fixes the test. It used to fail every ~100 attempts on my machine, now it's been >1,000 and they all passed.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->