### PR TITLE
chore: reenable evictions upon insertion to avoid OOM rejections

### DIFF
--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -403,6 +403,8 @@ class CompactObj {
   // Precondition: the object is a non-inline string.
   StringOrView GetRawString() const;
 
+  bool HasAllocated() const;
+
  private:
   void EncodeString(std::string_view str);
   size_t DecodedLen(size_t sz) const;
@@ -411,8 +413,6 @@ class CompactObj {
 
   // Requires: HasAllocated() - true.
   void Free();
-
-  bool HasAllocated() const;
 
   bool CmpEncoded(std::string_view sv) const;
 

--- a/src/server/acl/validator.h
+++ b/src/server/acl/validator.h
@@ -12,7 +12,7 @@
 
 namespace dfly::acl {
 
-class AclKeys;
+struct AclKeys;
 
 std::pair<bool, AclLog::Reason> IsUserAllowedToInvokeCommandGeneric(
     const std::vector<uint64_t>& acl_commands, const AclKeys& keys, facade::CmdArgList tail_args,

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -705,7 +705,7 @@ void DbSlice::FlushSlotsFb(const cluster::SlotSet& slot_ids) {
       string_view key = get<string_view>(req.change);
       table->CVCUponInsert(
           next_version, key,
-          [this, db_index, next_version, iterate_bucket](PrimeTable::bucket_iterator it) {
+          [db_index, next_version, iterate_bucket](PrimeTable::bucket_iterator it) {
             DCHECK_LT(it.GetVersion(), next_version);
             iterate_bucket(db_index, it);
           });
@@ -758,7 +758,7 @@ void DbSlice::FlushDbIndexes(const std::vector<DbIndex>& indexes) {
   }
 
   CHECK(fetched_items_.empty());
-  auto cb = [this, indexes, flush_db_arr = std::move(flush_db_arr)]() mutable {
+  auto cb = [indexes, flush_db_arr = std::move(flush_db_arr)]() mutable {
     flush_db_arr.clear();
     ServerState::tlocal()->DecommitMemory(ServerState::kDataHeap | ServerState::kBackingHeap |
                                           ServerState::kGlibcmalloc);

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -74,6 +74,9 @@ ABSL_FLAG(string, shard_round_robin_prefix, "",
 ABSL_FLAG(uint32_t, mem_defrag_check_sec_interval, 10,
           "Number of seconds between every defragmentation necessity check");
 
+ABSL_FLAG(bool, enable_heartbeat_eviction, true,
+          "Enable eviction during heartbeat when memory is under pressure.");
+
 namespace dfly {
 
 using namespace tiering::literals;
@@ -634,8 +637,10 @@ void EngineShard::Heartbeat() {
     }
 
     // if our budget is below the limit
-    if (db_slice.memory_budget() < eviction_redline) {
-      db_slice.FreeMemWithEvictionStep(i, eviction_redline - db_slice.memory_budget());
+    if (db_slice.memory_budget() < eviction_redline && GetFlag(FLAGS_enable_heartbeat_eviction)) {
+      uint32_t starting_segment_id = rand() % pt->GetSegmentCount();
+      db_slice.FreeMemWithEvictionStep(i, starting_segment_id,
+                                       eviction_redline - db_slice.memory_budget());
     }
 
     if (UsedMemory() > tiering_offload_threshold) {
@@ -651,9 +656,12 @@ void EngineShard::Heartbeat() {
 }
 
 void EngineShard::RunPeriodic(std::chrono::milliseconds period_ms) {
+  VLOG(1) << "RunPeriodic with period " << period_ms.count() << "ms";
+
   bool runs_global_periodic = (shard_id() == 0);  // Only shard 0 runs global periodic.
   unsigned global_count = 0;
   int64_t last_stats_time = time(nullptr);
+  int64_t last_heartbeat_ms = INT64_MAX;
 
   while (true) {
     if (fiber_periodic_done_.WaitFor(period_ms)) {
@@ -661,7 +669,12 @@ void EngineShard::RunPeriodic(std::chrono::milliseconds period_ms) {
       return;
     }
 
+    int64_t now_ms = fb2::ProactorBase::GetMonotonicTimeNs() / 1000000;
+    if (now_ms - 5 * period_ms.count() > last_heartbeat_ms) {
+      VLOG(1) << "This heartbeat took " << now_ms - last_heartbeat_ms << "ms";
+    }
     Heartbeat();
+    last_heartbeat_ms = fb2::ProactorBase::GetMonotonicTimeNs() / 1000000;
 
     if (runs_global_periodic) {
       ++global_count;

--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -165,7 +165,7 @@ void MemoryCmd::Run(CmdArgList args) {
   }
 
   if (sub_cmd == "DEFRAGMENT") {
-    shard_set->pool()->DispatchOnAll([this](util::ProactorBase*) {
+    shard_set->pool()->DispatchOnAll([](util::ProactorBase*) {
       if (auto* shard = EngineShard::tlocal(); shard)
         shard->ForceDefrag();
     });

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -701,7 +701,7 @@ std::optional<fb2::Fiber> Pause(std::vector<facade::Listener*> listeners, Namesp
     return std::nullopt;
   }
 
-  // We should not expire/evict keys while clients are puased.
+  // We should not expire/evict keys while clients are paused.
   shard_set->RunBriefInParallel(
       [ns](EngineShard* shard) { ns->GetDbSlice(shard->shard_id()).SetExpireAllowed(false); });
 


### PR DESCRIPTION
Before: when running dragonfly with --cache_mode we could get OOM rejections even though the eviction policy allowed to evict items to free memory. Ideally, dragonfly in cache mode should not respond with the OOM error.

This PR reuses the same Eviction step we have in the Heartbeat and conditionally applies it during the insertion. In my test the OOM errors went from 500K to 0 and the server still respected memory limit.

Also, remove the old heuristics that has never been used.

Test:

./dfly_bench --key_prefix=bar: -d 1024 --ratio=1:0 --qps=200 -n 3000 ./dragonfly --dbfilename=  --proactor_threads=2 --maxmemory=600M --cache_mode

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->