### PR TITLE
fix: test_big_value_serialization_memory_limit shutdown timeout

### DIFF
--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -552,4 +552,5 @@ async def test_big_value_serialization_memory_limit(df_factory, query):
     await client.execute_command("SAVE")
 
     checker.cancel()
+    await client.execute_command("FLUSHALL")
     await client.close()


### PR DESCRIPTION
The problem is that the test `test_big_value_serialization_memory_limit` will try to shutdown dragonfly at the end with a timeout of 15 seconds. Dragonfly during shutdown takes a snapshot which might take more than 15 seconds and the test fails.

* call flushall before we exit the test