### PR TITLE
fix: disable inline transactions when db_slice has registered callbacks

### DIFF
--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -423,6 +423,10 @@ class DbSlice {
   //! at a time of the call.
   uint64_t RegisterOnChange(ChangeCallback cb);
 
+  bool HasRegisteredCallbacks() const {
+    return !change_cb_.empty();
+  }
+
   // Call registered callbacks with version less than upper_bound.
   void FlushChangeToEarlierCallbacks(DbIndex db_ind, Iterator it, uint64_t upper_bound);
 

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1420,8 +1420,9 @@ void Transaction::CancelBlocking(std::function<OpStatus(ArgSlice)> status_cb) {
 
 bool Transaction::CanRunInlined() const {
   auto* ss = ServerState::tlocal();
+  auto* es = EngineShard::tlocal();
   if (unique_shard_cnt_ == 1 && unique_shard_id_ == ss->thread_index() &&
-      ss->AllowInlineScheduling()) {
+      ss->AllowInlineScheduling() && !GetDbSlice(es->shard_id()).HasRegisteredCallbacks()) {
     ss->stats.tx_inline_runs++;
     return true;
   }


### PR DESCRIPTION
Inline transactions do not acquire any locks and therefore they should not preempt. This is no longer true when db_slice has registered callbacks.

* disable inline transactions when db_slice has registered callbacks