### PR TITLE
fix(acl): remove none from acl categories

### DIFF
--- a/src/server/acl/acl_family.h
+++ b/src/server/acl/acl_family.h
@@ -122,8 +122,7 @@ class AclFamily final {
                                       {"FT_SEARCH", FT_SEARCH},
                                       {"THROTTLE", THROTTLE},
                                       {"JSON", JSON},
-                                      {"ALL", ALL},
-                                      {"NONE", NONE}};
+                                      {"ALL", ALL}};
 
   // bit 0 at index 0
   // bit 1 at index 1

--- a/src/server/acl/acl_family_test.cc
+++ b/src/server/acl/acl_family_test.cc
@@ -109,6 +109,10 @@ TEST_F(AclFamilyTest, AclSetUser) {
   vec = resp.GetVec();
   EXPECT_THAT(vec,
               UnorderedElementsAre("user default on nopass ~* +@all", "user vlad on -@all +acl"));
+
+  // +@NONE should not exist anymore. It's not in the spec.
+  resp = Run({"ACL", "SETUSER", "rand", "+@NONE"});
+  EXPECT_THAT(resp, ErrArg("ERR Unrecognized parameter +@NONE"));
 }
 
 TEST_F(AclFamilyTest, AclDelUser) {


### PR DESCRIPTION
None does not exist in Valkey and its entry was missing from the indexes we use to map categories to commands leading to an out of bounds access and causing a segfault.

* remove none from acl categories