### PR TITLE
chore: increase timeouts for regtests to not fail with serialization_max_chunk_size=1

### DIFF
--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -35,7 +35,7 @@ runs:
         export DRAGONFLY_PATH="${GITHUB_WORKSPACE}/${{inputs.build-folder-name}}/${{inputs.dfly-executable}}"
         export UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 # to crash on errors
 
-        timeout 60m pytest -m "${{inputs.filter}}" --durations=10 --color=yes --json-report --json-report-file=report.json dragonfly --log-cli-level=INFO || code=$?
+        timeout 120m pytest -m "${{inputs.filter}}" --durations=10 --color=yes --json-report --json-report-file=report.json dragonfly --log-cli-level=INFO || code=$?
 
         # timeout returns 124 if we exceeded the timeout duration
         if [[ $code -eq 124 ]]; then

--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -22,8 +22,6 @@ inputs:
 
 runs:
   using: "composite"
-  # bring back timeouts once composite actions start supporting them
-  # timeout-minutes: 20
   steps:
     - name: Run PyTests
       id: main
@@ -37,7 +35,7 @@ runs:
         export DRAGONFLY_PATH="${GITHUB_WORKSPACE}/${{inputs.build-folder-name}}/${{inputs.dfly-executable}}"
         export UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 # to crash on errors
 
-        timeout 40m pytest -m "${{inputs.filter}}" --durations=10 --color=yes --json-report --json-report-file=report.json dragonfly --log-cli-level=INFO || code=$?
+        timeout 60m pytest -m "${{inputs.filter}}" --durations=10 --color=yes --json-report --json-report-file=report.json dragonfly --log-cli-level=INFO || code=$?
 
         # timeout returns 124 if we exceeded the timeout duration
         if [[ $code -eq 124 ]]; then

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -166,7 +166,7 @@ class DflyInstance:
                 proc.kill()
             else:
                 proc.terminate()
-                proc.communicate(timeout=15)
+                proc.communicate(timeout=60)
                 # if the return code is 0 it means normal termination
                 # if the return code is negative it means termination by signal
                 # if the return code is positive it means abnormal exit

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -166,7 +166,7 @@ class DflyInstance:
                 proc.kill()
             else:
                 proc.terminate()
-                proc.communicate(timeout=300)
+                proc.communicate(timeout=900)
                 # if the return code is 0 it means normal termination
                 # if the return code is negative it means termination by signal
                 # if the return code is positive it means abnormal exit

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -166,7 +166,7 @@ class DflyInstance:
                 proc.kill()
             else:
                 proc.terminate()
-                proc.communicate(timeout=60)
+                proc.communicate(timeout=300)
                 # if the return code is 0 it means normal termination
                 # if the return code is negative it means termination by signal
                 # if the return code is positive it means abnormal exit

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -107,7 +107,7 @@ async def test_replication_all(
     )
 
     # Wait for all replicas to transition into stable sync
-    async with async_timeout.timeout(300):
+    async with async_timeout.timeout(900):
         await wait_for_replicas_state(*c_replicas)
 
     # Stop streaming data once every replica is in stable sync

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -107,7 +107,7 @@ async def test_replication_all(
     )
 
     # Wait for all replicas to transition into stable sync
-    async with async_timeout.timeout(20):
+    async with async_timeout.timeout(60):
         await wait_for_replicas_state(*c_replicas)
 
     # Stop streaming data once every replica is in stable sync

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -130,7 +130,7 @@ async def test_replication_all(
     # speed up shutdown
     for c in c_replicas:
         await c.execute_command("REPLICAOF NO ONE")
-    await c_mater.execute_command("FLUSHALL")
+    await c_master.execute_command("FLUSHALL")
 
     await disconnect_clients(c_master, *c_replicas)
 

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -107,7 +107,7 @@ async def test_replication_all(
     )
 
     # Wait for all replicas to transition into stable sync
-    async with async_timeout.timeout(60):
+    async with async_timeout.timeout(300):
         await wait_for_replicas_state(*c_replicas)
 
     # Stop streaming data once every replica is in stable sync
@@ -126,6 +126,11 @@ async def test_replication_all(
 
     # Check data after stable state stream
     await check()
+
+    # speed up shutdown
+    for c in c_replicas:
+        await c.execute_command("REPLICAOF NO ONE")
+    await c_mater.execute_command("FLUSHALL")
 
     await disconnect_clients(c_master, *c_replicas)
 


### PR DESCRIPTION
We added `serialization_max_chunk_size=1` to test big values but this made shutdown for stress tests really slow since the instances need to snapshot when shutdown which causes timeouts. Furthermore, increase the timeout for replicas to sync.

* increase timeout of an instance when stopped from 15 to 60 seconds
* increase timeout for replicas to sync from 20 to 60 seconds