### PR TITLE
chore: tiering - make Modify work with cool storage

### DIFF
--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -391,7 +391,6 @@ class DbSlice {
   // Returns existing keys count in the db.
   size_t DbSize(DbIndex db_ind) const;
 
-  // Callback functions called upon writing to the existing key.
   DbTableStats* MutableStats(DbIndex db_ind) {
     return &db_arr_[db_ind]->stats;
   }
@@ -415,6 +414,10 @@ class DbSlice {
 
   size_t table_memory() const {
     return table_memory_;
+  }
+
+  size_t entries_count() const {
+    return entries_count_;
   }
 
   using ChangeCallback = std::function<void(DbIndex, const ChangeReq&)>;
@@ -567,6 +570,7 @@ class DbSlice {
   size_t bytes_per_object_ = 0;
   size_t soft_budget_limit_ = 0;
   size_t table_memory_ = 0;
+  uint64_t entries_count_ = 0;
 
   mutable SliceEvents events_;  // we may change this even for const operations.
 


### PR DESCRIPTION
1. Fully support tiered_experimental_cooling for all operations
2. Offset cool storage usage when computing memory pressure situations in Hearbeat.
3. Introduce realtime entry counting per db_slice and provide DCHECK to verify it vs the old approach. Later we will switch to realtime entry and free memory computations when computing bytes per object, and remove the old approach in CacheStats().
4. Show hit rate during the run of dfly_bench loadtest.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->