### PR TITLE
Revert "chore: set serialization_max_chunk_size to 1 byte (#3379)"

### DIFF
--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -87,9 +87,6 @@ class DflyInstance:
             if threads > 1:
                 self.args["num_shards"] = threads - 1
 
-        # Add 1 byte limit for big values
-        self.args["serialization_max_chunk_size"] = 1
-
     def __del__(self):
         assert self.proc == None
 


### PR DESCRIPTION
This reverts commit 2867d54a055c49a5925c594d1f483de11d8cc566.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->