### PR TITLE
 chore: Support setting the value of `replica-priority`

### DIFF
--- a/src/server/config_registry.h
+++ b/src/server/config_registry.h
@@ -9,6 +9,9 @@
 
 namespace dfly {
 
+// Allows reading and modifying pre-registered configuration values by string names.
+// All names are normalized to have underscores (_) replaced with dashes (-) for Valkey
+// compatibility.
 class ConfigRegistry {
  public:
   // Accepts the new value as argument. Return true if config was successfully updated.

--- a/src/server/config_registry.h
+++ b/src/server/config_registry.h
@@ -10,8 +10,7 @@
 namespace dfly {
 
 // Allows reading and modifying pre-registered configuration values by string names.
-// All names are normalized to have underscores (_) replaced with dashes (-) for Valkey
-// compatibility.
+// This class treats dashes (-) are as underscores (_).
 class ConfigRegistry {
  public:
   // Accepts the new value as argument. Return true if config was successfully updated.

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1767,6 +1767,7 @@ void ServerFamily::Config(CmdArgList args, ConnectionContext* cntx) {
 
       for (const auto& name : names) {
         auto value = config_registry.Get(name);
+        DCHECK(value.has_value());
         if (value.has_value()) {
           res.push_back(name);
           res.push_back(*value);

--- a/src/server/server_family_test.cc
+++ b/src/server/server_family_test.cc
@@ -517,6 +517,8 @@ TEST_F(ServerFamilyTest, ClientTrackingLuaBug) {
 }
 
 TEST_F(ServerFamilyTest, ConfigNormalization) {
+  absl::FlagSaver fs;  // Restores the flag to default value after test finishes
+
   // Default value
   EXPECT_THAT(Run({"config", "get", "replica-priority"}),
               RespArray(ElementsAre("replica-priority", "100")));

--- a/src/server/server_family_test.cc
+++ b/src/server/server_family_test.cc
@@ -516,4 +516,28 @@ TEST_F(ServerFamilyTest, ClientTrackingLuaBug) {
   EXPECT_EQ(InvalidationMessagesLen("IO0"), 3);
 }
 
+TEST_F(ServerFamilyTest, ConfigNormalization) {
+  // Default value
+  EXPECT_THAT(Run({"config", "get", "replica-priority"}),
+              RespArray(ElementsAre("replica-priority", "100")));
+  EXPECT_THAT(Run({"config", "get", "replica_priority"}),
+              RespArray(ElementsAre("replica-priority", "100")));
+
+  // Set with dash
+  EXPECT_THAT(Run({"config", "set", "replica-priority", "7"}), "OK");
+
+  EXPECT_THAT(Run({"config", "get", "replica-priority"}),
+              RespArray(ElementsAre("replica-priority", "7")));
+  EXPECT_THAT(Run({"config", "get", "replica_priority"}),
+              RespArray(ElementsAre("replica-priority", "7")));
+
+  // Set with underscore
+  EXPECT_THAT(Run({"config", "set", "replica_priority", "13"}), "OK");
+
+  EXPECT_THAT(Run({"config", "get", "replica-priority"}),
+              RespArray(ElementsAre("replica-priority", "13")));
+  EXPECT_THAT(Run({"config", "get", "replica_priority"}),
+              RespArray(ElementsAre("replica-priority", "13")));
+}
+
 }  // namespace dfly

--- a/src/server/server_family_test.cc
+++ b/src/server/server_family_test.cc
@@ -517,29 +517,32 @@ TEST_F(ServerFamilyTest, ClientTrackingLuaBug) {
 }
 
 TEST_F(ServerFamilyTest, ConfigNormalization) {
+  // TODO: Ideally we'd also test that INFO REPLICATION returns the value set in the config, but
+  // there is no way currently to setup a mock replica in unit tests.
+
   absl::FlagSaver fs;  // Restores the flag to default value after test finishes
 
   // Default value
   EXPECT_THAT(Run({"config", "get", "replica-priority"}),
-              RespArray(ElementsAre("replica-priority", "100")));
+              RespArray(ElementsAre("replica_priority", "100")));
   EXPECT_THAT(Run({"config", "get", "replica_priority"}),
-              RespArray(ElementsAre("replica-priority", "100")));
+              RespArray(ElementsAre("replica_priority", "100")));
 
   // Set with dash
   EXPECT_THAT(Run({"config", "set", "replica-priority", "7"}), "OK");
 
   EXPECT_THAT(Run({"config", "get", "replica-priority"}),
-              RespArray(ElementsAre("replica-priority", "7")));
+              RespArray(ElementsAre("replica_priority", "7")));
   EXPECT_THAT(Run({"config", "get", "replica_priority"}),
-              RespArray(ElementsAre("replica-priority", "7")));
+              RespArray(ElementsAre("replica_priority", "7")));
 
   // Set with underscore
   EXPECT_THAT(Run({"config", "set", "replica_priority", "13"}), "OK");
 
   EXPECT_THAT(Run({"config", "get", "replica-priority"}),
-              RespArray(ElementsAre("replica-priority", "13")));
+              RespArray(ElementsAre("replica_priority", "13")));
   EXPECT_THAT(Run({"config", "get", "replica_priority"}),
-              RespArray(ElementsAre("replica-priority", "13")));
+              RespArray(ElementsAre("replica_priority", "13")));
 }
 
 }  // namespace dfly


### PR DESCRIPTION
This PR adds a small refactor to the way we set and get config names which have dashes (`-`) and underscores (`_`).

Until now, words were separated by underscores because this is how our flags library (absl) works. However, this is incompatible with Valkey, which uses dashes as a word separator.

Once merged, we will support both underscores and dashes in config names, but will only return the name with dashes. **This is a behavior change**.

We're doing this in order to be compatible with `replica-priority` and possibly other config names that Valkey uses.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->