### PR TITLE
chore: cancel slot migrations on shutdown

### DIFF
--- a/src/server/cluster/cluster_config.cc
+++ b/src/server/cluster/cluster_config.cc
@@ -300,6 +300,13 @@ std::shared_ptr<ClusterConfig> ClusterConfig::CloneWithChanges(
   return new_config;
 }
 
+std::shared_ptr<ClusterConfig> ClusterConfig::CloneWithoutMigrations() const {
+  auto new_config = std::make_shared<ClusterConfig>(*this);
+  new_config->my_incoming_migrations_.clear();
+  new_config->my_outgoing_migrations_.clear();
+  return new_config;
+}
+
 bool ClusterConfig::IsMySlot(SlotId id) const {
   if (id > cluster::kMaxSlotNum) {
     DCHECK(false) << "Requesting a non-existing slot id " << id;

--- a/src/server/cluster/cluster_config.h
+++ b/src/server/cluster/cluster_config.h
@@ -26,6 +26,8 @@ class ClusterConfig {
   std::shared_ptr<ClusterConfig> CloneWithChanges(const SlotRanges& enable_slots,
                                                   const SlotRanges& disable_slots) const;
 
+  std::shared_ptr<ClusterConfig> CloneWithoutMigrations() const;
+
   // If key is in my slots ownership return true
   bool IsMySlot(SlotId id) const;
   bool IsMySlot(std::string_view key) const;

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -81,6 +81,10 @@ ClusterConfig* ClusterFamily::cluster_config() {
 
 void ClusterFamily::Shutdown() {
   shard_set->pool()->at(0)->Await([this] {
+    lock_guard lk(set_config_mu);
+    if (!tl_cluster_config)
+      return;
+
     auto empty_config = tl_cluster_config->CloneWithoutMigrations();
     RemoveOutgoingMigrations(empty_config, tl_cluster_config);
     RemoveIncomingMigrations(empty_config->GetFinishedIncomingMigrations(tl_cluster_config));

--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -28,6 +28,8 @@ class ClusterFamily {
 
   void Register(CommandRegistry* registry);
 
+  void Shutdown();
+
   // Returns a thread-local pointer.
   static ClusterConfig* cluster_config();
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -910,7 +910,9 @@ void Service::Shutdown() {
 
   config_registry.Reset();
 
-  // to shutdown all the runtime components that depend on EngineShard.
+  // to shutdown all the runtime components that depend on EngineShard
+  cluster_family_.Shutdown();
+
   server_family_.Shutdown();
   StringFamily::Shutdown();
   GenericFamily::Shutdown();


### PR DESCRIPTION
Add ClusterFamily::Shutdown to take out all migrations