### PR TITLE
chore: add db_slice lock to protect segments from preemptions

### DIFF
--- a/src/server/common.h
+++ b/src/server/common.h
@@ -367,44 +367,16 @@ struct ConditionFlag {
 // Helper class used to guarantee atomicity between serialization of buckets
 class ThreadLocalMutex {
  public:
-  void lock() {
-    util::fb2::NoOpLock noop_lk_;
-    cond_var_.wait(noop_lk_, [this]() { return !flag_; });
-    flag_ = true;
-  }
+  ThreadLocalMutex();
+  ~ThreadLocalMutex();
 
-  void unlock() {
-    flag_ = false;
-    cond_var_.notify_one();
-  }
+  void lock();
+  void unlock();
 
  private:
+  EngineShard* shard_;
   util::fb2::CondVarAny cond_var_;
   bool flag_ = false;
-};
-
-class LocalBlockingCounter {
- public:
-  void lock() {
-    ++mutating_;
-  }
-
-  void unlock() {
-    DCHECK(mutating_ > 0);
-    --mutating_;
-    if (mutating_ == 0) {
-      cond_var_.notify_one();
-    }
-  }
-
-  void Wait() {
-    util::fb2::NoOpLock noop_lk_;
-    cond_var_.wait(noop_lk_, [this]() { return mutating_ == 0; });
-  }
-
- private:
-  util::fb2::CondVarAny cond_var_;
-  size_t mutating_ = 0;
 };
 
 }  // namespace dfly

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -497,7 +497,10 @@ class DbSlice {
   void PerformDeletion(Iterator del_it, DbTable* table);
   void PerformDeletion(PrimeIterator del_it, DbTable* table);
 
-  ThreadLocalMutex* GetThreadLocalMutex() {
+  // Provides access to the internal lock of db_slice for flows that serialize
+  // entries with preemption and need to synchronize with Traverse below which
+  // acquires the same lock.
+  ThreadLocalMutex* GetSerializationMutex() {
     return &local_mu_;
   }
 
@@ -561,15 +564,7 @@ class DbSlice {
 
   void CallChangeCallbacks(DbIndex id, std::string_view key, const ChangeReq& cr) const;
 
-  // We need this because registered callbacks might yield. If UnregisterOnChange
-  // gets called after we preempt while iterating over the registered callbacks
-  // (let's say in FlushChangeToEarlierCallbacks) we will get UB, because we removed
-  // an arbitrary element within the list invalidating the iterators that are being
-  // used by the preempted FlushChangeToEarlierCallbacks. LocalBlockingCounter
-  // protects us against this case.
-  mutable LocalBlockingCounter block_counter_;
-
-  // Used to provide exlusive access while Traversing segments
+  // Used to provide exclusive access while Traversing segments
   mutable ThreadLocalMutex local_mu_;
   ShardId shard_id_;
   uint8_t caching_mode_ : 1;

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -272,14 +272,17 @@ void DoBuildObjHist(EngineShard* shard, ConnectionContext* cntx, ObjHistMap* obj
       continue;
     PrimeTable::Cursor cursor;
     do {
-      cursor = dbt->prime.Traverse(cursor, [&](PrimeIterator it) {
-        unsigned obj_type = it->second.ObjType();
-        auto& hist_ptr = (*obj_hist_map)[obj_type];
-        if (!hist_ptr) {
-          hist_ptr.reset(new ObjHist);
-        }
-        steps += AddObjHist(it, hist_ptr.get());
-      });
+      cursor = db_slice.Traverse(
+          cursor,
+          [&](PrimeIterator it) {
+            unsigned obj_type = it->second.ObjType();
+            auto& hist_ptr = (*obj_hist_map)[obj_type];
+            if (!hist_ptr) {
+              hist_ptr.reset(new ObjHist);
+            }
+            steps += AddObjHist(it, hist_ptr.get());
+          },
+          &dbt->prime);
 
       if (steps >= 20000) {
         steps = 0;

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -272,17 +272,14 @@ void DoBuildObjHist(EngineShard* shard, ConnectionContext* cntx, ObjHistMap* obj
       continue;
     PrimeTable::Cursor cursor;
     do {
-      cursor = db_slice.Traverse(
-          cursor,
-          [&](PrimeIterator it) {
-            unsigned obj_type = it->second.ObjType();
-            auto& hist_ptr = (*obj_hist_map)[obj_type];
-            if (!hist_ptr) {
-              hist_ptr.reset(new ObjHist);
-            }
-            steps += AddObjHist(it, hist_ptr.get());
-          },
-          &dbt->prime);
+      cursor = db_slice.Traverse(&dbt->prime, cursor, [&](PrimeIterator it) {
+        unsigned obj_type = it->second.ObjType();
+        auto& hist_ptr = (*obj_hist_map)[obj_type];
+        if (!hist_ptr) {
+          hist_ptr.reset(new ObjHist);
+        }
+        steps += AddObjHist(it, hist_ptr.get());
+      });
 
       if (steps >= 20000) {
         steps = 0;

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -317,18 +317,15 @@ bool EngineShard::DoDefrag() {
   uint64_t attempts = 0;
 
   do {
-    cur = slice.Traverse(
-        cur,
-        [&](PrimeIterator it) {
-          // for each value check whether we should move it because it
-          // seats on underutilized page of memory, and if so, do it.
-          bool did = it->second.DefragIfNeeded(threshold);
-          attempts++;
-          if (did) {
-            reallocations++;
-          }
-        },
-        prime_table);
+    cur = slice.Traverse(prime_table, cur, [&](PrimeIterator it) {
+      // for each value check whether we should move it because it
+      // seats on underutilized page of memory, and if so, do it.
+      bool did = it->second.DefragIfNeeded(threshold);
+      attempts++;
+      if (did) {
+        reallocations++;
+      }
+    });
     traverses_count++;
   } while (traverses_count < kMaxTraverses && cur && namespaces.IsInitialized());
 

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -317,15 +317,18 @@ bool EngineShard::DoDefrag() {
   uint64_t attempts = 0;
 
   do {
-    cur = prime_table->Traverse(cur, [&](PrimeIterator it) {
-      // for each value check whether we should move it because it
-      // seats on underutilized page of memory, and if so, do it.
-      bool did = it->second.DefragIfNeeded(threshold);
-      attempts++;
-      if (did) {
-        reallocations++;
-      }
-    });
+    cur = slice.Traverse(
+        cur,
+        [&](PrimeIterator it) {
+          // for each value check whether we should move it because it
+          // seats on underutilized page of memory, and if so, do it.
+          bool did = it->second.DefragIfNeeded(threshold);
+          attempts++;
+          if (did) {
+            reallocations++;
+          }
+        },
+        prime_table);
     traverses_count++;
   } while (traverses_count < kMaxTraverses && cur && namespaces.IsInitialized());
 

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -582,8 +582,9 @@ void OpScan(const OpArgs& op_args, const ScanOpts& scan_opts, uint64_t* cursor, 
   auto [prime_table, expire_table] = db_slice.GetTables(op_args.db_cntx.db_index);
   string scratch;
   do {
-    cur = prime_table->Traverse(
-        cur, [&](PrimeIterator it) { cnt += ScanCb(op_args, it, scan_opts, &scratch, vec); });
+    cur = db_slice.Traverse(
+        cur, [&](PrimeIterator it) { cnt += ScanCb(op_args, it, scan_opts, &scratch, vec); },
+        prime_table);
   } while (cur && cnt < scan_opts.limit);
 
   VLOG(1) << "OpScan " << db_slice.shard_id() << " cursor: " << cur.value();

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -582,9 +582,9 @@ void OpScan(const OpArgs& op_args, const ScanOpts& scan_opts, uint64_t* cursor, 
   auto [prime_table, expire_table] = db_slice.GetTables(op_args.db_cntx.db_index);
   string scratch;
   do {
-    cur = db_slice.Traverse(
-        cur, [&](PrimeIterator it) { cnt += ScanCb(op_args, it, scan_opts, &scratch, vec); },
-        prime_table);
+    cur = db_slice.Traverse(prime_table, cur, [&](PrimeIterator it) {
+      cnt += ScanCb(op_args, it, scan_opts, &scratch, vec);
+    });
   } while (cur && cnt < scan_opts.limit);
 
   VLOG(1) << "OpScan " << db_slice.shard_id() << " cursor: " << cur.value();

--- a/src/server/journal/streamer.cc
+++ b/src/server/journal/streamer.cc
@@ -213,15 +213,19 @@ void RestoreStreamer::Run() {
       return;
 
     bool written = false;
-    cursor = pt->Traverse(cursor, [&](PrimeTable::bucket_iterator it) {
-      ConditionGuard guard(&bucket_ser_);
+    cursor = db_slice_->Traverse(
+        cursor,
+        [&](PrimeTable::bucket_iterator it) {
+          ConditionGuard guard(&bucket_ser_);
 
-      db_slice_->FlushChangeToEarlierCallbacks(0 /*db_id always 0 for cluster*/,
-                                               DbSlice::Iterator::FromPrime(it), snapshot_version_);
-      if (WriteBucket(it)) {
-        written = true;
-      }
-    });
+          db_slice_->FlushChangeToEarlierCallbacks(0 /*db_id always 0 for cluster*/,
+                                                   DbSlice::Iterator::FromPrime(it),
+                                                   snapshot_version_);
+          if (WriteBucket(it)) {
+            written = true;
+          }
+        },
+        pt);
     if (written) {
       ThrottleIfNeeded();
     }

--- a/src/server/journal/streamer.cc
+++ b/src/server/journal/streamer.cc
@@ -216,8 +216,6 @@ void RestoreStreamer::Run() {
     cursor = db_slice_->Traverse(
         cursor,
         [&](PrimeTable::bucket_iterator it) {
-          ConditionGuard guard(&bucket_ser_);
-
           db_slice_->FlushChangeToEarlierCallbacks(0 /*db_id always 0 for cluster*/,
                                                    DbSlice::Iterator::FromPrime(it),
                                                    snapshot_version_);
@@ -316,8 +314,6 @@ bool RestoreStreamer::WriteBucket(PrimeTable::bucket_iterator it) {
 
 void RestoreStreamer::OnDbChange(DbIndex db_index, const DbSlice::ChangeReq& req) {
   DCHECK_EQ(db_index, 0) << "Restore migration only allowed in cluster mode in db0";
-
-  ConditionGuard guard(&bucket_ser_);
 
   PrimeTable* table = db_slice_->GetTables(0).first;
 

--- a/src/server/journal/streamer.cc
+++ b/src/server/journal/streamer.cc
@@ -213,17 +213,13 @@ void RestoreStreamer::Run() {
       return;
 
     bool written = false;
-    cursor = db_slice_->Traverse(
-        cursor,
-        [&](PrimeTable::bucket_iterator it) {
-          db_slice_->FlushChangeToEarlierCallbacks(0 /*db_id always 0 for cluster*/,
-                                                   DbSlice::Iterator::FromPrime(it),
-                                                   snapshot_version_);
-          if (WriteBucket(it)) {
-            written = true;
-          }
-        },
-        pt);
+    cursor = db_slice_->Traverse(pt, cursor, [&](PrimeTable::bucket_iterator it) {
+      db_slice_->FlushChangeToEarlierCallbacks(0 /*db_id always 0 for cluster*/,
+                                               DbSlice::Iterator::FromPrime(it), snapshot_version_);
+      if (WriteBucket(it)) {
+        written = true;
+      }
+    });
     if (written) {
       ThrottleIfNeeded();
     }

--- a/src/server/journal/streamer.h
+++ b/src/server/journal/streamer.h
@@ -107,8 +107,6 @@ class RestoreStreamer : public JournalStreamer {
   cluster::SlotSet my_slots_;
   bool fiber_cancelled_ = false;
   bool snapshot_finished_ = false;
-
-  ConditionFlag bucket_ser_;
 };
 
 }  // namespace dfly

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -386,7 +386,7 @@ void SliceSnapshot::OnJournalEntry(const journal::JournalItem& item, bool await)
   // To enable journal flushing to sync after non auto journal command is executed we call
   // TriggerJournalWriteToSink. This call uses the NOOP opcode with await=true. Since there is no
   // additional journal change to serialize, it simply invokes PushSerializedToChannel.
-  std::unique_lock lk(*db_slice_->GetThreadLocalMutex());
+  std::unique_lock lk(*db_slice_->GetSerializationMutex());
   if (item.opcode != journal::Op::NOOP) {
     serializer_->WriteJournalEntry(item.data);
   }
@@ -399,7 +399,7 @@ void SliceSnapshot::OnJournalEntry(const journal::JournalItem& item, bool await)
 }
 
 void SliceSnapshot::CloseRecordChannel() {
-  std::unique_lock lk(*db_slice_->GetThreadLocalMutex());
+  std::unique_lock lk(*db_slice_->GetSerializationMutex());
 
   CHECK(!serialize_bucket_running_);
   // Make sure we close the channel only once with a CAS check.

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -221,7 +221,7 @@ void SliceSnapshot::IterateBucketsFb(const Cancellation* cll, bool send_full_syn
         return;
 
       PrimeTable::Cursor next =
-          pt->Traverse(cursor, absl::bind_front(&SliceSnapshot::BucketSaveCb, this));
+          db_slice_->Traverse(cursor, absl::bind_front(&SliceSnapshot::BucketSaveCb, this), pt);
       cursor = next;
       PushSerializedToChannel(false);
 
@@ -253,8 +253,6 @@ void SliceSnapshot::IterateBucketsFb(const Cancellation* cll, bool send_full_syn
 }
 
 bool SliceSnapshot::BucketSaveCb(PrimeIterator it) {
-  ConditionGuard guard(&bucket_ser_);
-
   ++stats_.savecb_calls;
 
   auto check = [&](auto v) {
@@ -364,8 +362,6 @@ bool SliceSnapshot::PushSerializedToChannel(bool force) {
 }
 
 void SliceSnapshot::OnDbChange(DbIndex db_index, const DbSlice::ChangeReq& req) {
-  ConditionGuard guard(&bucket_ser_);
-
   PrimeTable* table = db_slice_->GetTables(db_index).first;
   const PrimeTable::bucket_iterator* bit = req.update();
 
@@ -390,7 +386,7 @@ void SliceSnapshot::OnJournalEntry(const journal::JournalItem& item, bool await)
   // To enable journal flushing to sync after non auto journal command is executed we call
   // TriggerJournalWriteToSink. This call uses the NOOP opcode with await=true. Since there is no
   // additional journal change to serialize, it simply invokes PushSerializedToChannel.
-  ConditionGuard guard(&bucket_ser_);
+  ConditionGuard guard(db_slice_->GetCondFlag());
   if (item.opcode != journal::Op::NOOP) {
     serializer_->WriteJournalEntry(item.data);
   }
@@ -403,7 +399,7 @@ void SliceSnapshot::OnJournalEntry(const journal::JournalItem& item, bool await)
 }
 
 void SliceSnapshot::CloseRecordChannel() {
-  ConditionGuard guard(&bucket_ser_);
+  ConditionGuard guard(db_slice_->GetCondFlag());
 
   CHECK(!serialize_bucket_running_);
   // Make sure we close the channel only once with a CAS check.

--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -179,8 +179,6 @@ class SliceSnapshot {
     size_t savecb_calls = 0;
     size_t keys_total = 0;
   } stats_;
-
-  ConditionFlag bucket_ser_;
 };
 
 }  // namespace dfly

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -87,6 +87,9 @@ class DflyInstance:
             if threads > 1:
                 self.args["num_shards"] = threads - 1
 
+        # Add 1 byte limit for big values
+        self.args["serialization_max_chunk_size"] = 1
+
     def __del__(self):
         assert self.proc == None
 

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -166,7 +166,7 @@ class DflyInstance:
                 proc.kill()
             else:
                 proc.terminate()
-                proc.communicate(timeout=15)
+                proc.communicate(timeout=120)
                 # if the return code is 0 it means normal termination
                 # if the return code is negative it means termination by signal
                 # if the return code is positive it means abnormal exit

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -107,7 +107,7 @@ async def test_replication_all(
     )
 
     # Wait for all replicas to transition into stable sync
-    async with async_timeout.timeout(20):
+    async with async_timeout.timeout(240):
         await wait_for_replicas_state(*c_replicas)
 
     # Stop streaming data once every replica is in stable sync


### PR DESCRIPTION
`DastTable::Traverse` is error prone when the callback passed preempts because the segment might change. This is problematic and we need atomicity while traversing segments with preemption. The fix is to add Traverse in DbSlice and protect the traversal via `ConditionFlag`.

* add ConditionFlag to DbSlice
* add Traverse in DbSlice and protect it with the ConditionFlag
* remove condition flag from snapshot
* remove condition flag from streamer