### PR TITLE
feat: stabilize non-coordinated omission mode

### DIFF
--- a/src/facade/CMakeLists.txt
+++ b/src/facade/CMakeLists.txt
@@ -1,13 +1,16 @@
+add_library(dfly_parser_lib redis_parser.cc resp_expr.cc )
+cxx_link(dfly_parser_lib base strings_lib)
+
 add_library(dfly_facade conn_context.cc dragonfly_listener.cc dragonfly_connection.cc facade.cc
-            memcache_parser.cc redis_parser.cc reply_builder.cc op_status.cc service_interface.cc
-            reply_capture.cc resp_expr.cc cmd_arg_parser.cc tls_error.cc)
+            memcache_parser.cc reply_builder.cc op_status.cc service_interface.cc
+            reply_capture.cc cmd_arg_parser.cc tls_error.cc)
 
 if (DF_USE_SSL)
   set(TLS_LIB tls_lib)
   target_compile_definitions(dfly_facade PRIVATE DFLY_USE_SSL)
 endif()
 
-cxx_link(dfly_facade base strings_lib http_server_lib fibers2
+cxx_link(dfly_facade dfly_parser_lib http_server_lib fibers2
          ${TLS_LIB} TRDP::mimalloc TRDP::dconv)
 
 add_library(facade_test facade_test.cc)

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -18,7 +18,7 @@ if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
       tiering/external_alloc.cc)
 
     add_executable(dfly_bench dfly_bench.cc)
-    cxx_link(dfly_bench dfly_facade fibers2 absl::random_random)
+    cxx_link(dfly_bench dfly_parser_lib fibers2 absl::random_random)
     cxx_test(tiering/disk_storage_test dfly_test_lib LABELS DFLY)
     cxx_test(tiering/op_manager_test dfly_test_lib LABELS DFLY)
     cxx_test(tiering/small_bins_test dfly_test_lib LABELS DFLY)

--- a/src/server/dfly_bench.cc
+++ b/src/server/dfly_bench.cc
@@ -350,7 +350,7 @@ void Driver::Run(uint64_t* cycle_ns, CommandGenerator* cmd_gen) {
       int64_t target_ts = start + i * (*cycle_ns);
       int64_t sleep_ns = target_ts - now;
       if (reqs_.size() > 10 && sleep_ns <= 0) {
-        sleep_ns = 10000;
+        sleep_ns = 10'000;
       }
 
       if (sleep_ns > 0) {

--- a/src/server/dfly_bench.cc
+++ b/src/server/dfly_bench.cc
@@ -243,10 +243,8 @@ class TLocalClient {
 
     for (unsigned i = 0; i < drivers_.size(); ++i) {
       float done = drivers_[i]->done();
-      if (done > max)
-        max = done;
-      if (done < min)
-        min = done;
+      max = std::max(done, max);
+      min = std::min(done, min);
     }
 
     return {min, max};

--- a/src/server/dfly_bench.cc
+++ b/src/server/dfly_bench.cc
@@ -602,8 +602,8 @@ void WatchFiber(atomic_bool* finish_signal, ProactorPool* pp) {
       max_pending = max(max_pending, max_pend);
     });
 
-    uint64_t total_ms = (now - start_time) / 1000000;
-    uint64_t period_ms = (now - last_print) / 1000000;
+    uint64_t total_ms = (now - start_time) / 1'000'000;
+    uint64_t period_ms = (now - last_print) / 1'000'000;
     uint64_t period_resp_cnt = stats.num_responses - num_last_resp_cnt;
     double done_perc = double(stats.num_responses) * 100 / resp_goal;
     double hitrate = stats.hit_opportunities > 0


### PR DESCRIPTION
1. Our latency/RPS computations were off because we started measuring before drivers started running. Now, Run/Start phases are separated, so the start time is measured more precisely (after the start phase)
2. Introduced progress per driver connection - one of my discoveries is that driver connections progress with differrent pace when running in coordinated omission. This can reach x5 speed differrences. Now we measure and output the fastest/slowest progress.
3. Coordinated omission is great when the Server Under Test is able to sustain the required RPS. But if the actual RPS is lower than the one is sent than the final latencies will be infinitely high. We fix it by introducing self-adjusting sleep interval, so if the actual RPS is lower we will increase the interval to be closer to the actual RPS.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->