### PR TITLE
fix: json.merge exception crash

### DIFF
--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -1466,7 +1466,7 @@ void RecursiveMerge(const JsonType& patch, JsonType* dest) {
   for (const auto& k_v : patch.object_range()) {
     if (k_v.value().is_null()) {
       dest->erase(k_v.key());
-    } else {
+    } else if (dest->find(k_v.key()) != dest->object_range().end()) {
       RecursiveMerge(k_v.value(), &dest->at(k_v.key()));
     }
   }
@@ -1485,7 +1485,12 @@ OpStatus OpMerge(const OpArgs& op_args, string_view key, std::string_view json_s
     op_args.shard->search_indices()->RemoveDoc(key, op_args.db_cntx, it_res->it->second);
 
     JsonType* obj = it_res->it->second.GetJson();
-    RecursiveMerge(*parsed_json, obj);
+    try {
+      RecursiveMerge(*parsed_json, obj);
+    } catch (const std::exception& e) {
+      LOG(WARNING) << "Exception in OpMerge: " << e.what();
+      return OpStatus::KEY_NOTFOUND;
+    }
     it_res->post_updater.Run();
     op_args.shard->search_indices()->AddDoc(key, op_args.db_cntx, it_res->it->second);
     return OpStatus::OK;

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -1393,6 +1393,11 @@ TEST_F(JsonFamilyTest, Merge) {
   EXPECT_EQ(resp, "OK");
   resp = Run({"JSON.GET", "j1", "$"});
   EXPECT_EQ(resp, R"([{"a":"z","c":{"d":"e"}}])");
+
+  resp = Run({"JSON.SET", "foo", "$", "{}"});
+  EXPECT_EQ(resp, "OK");
+  resp = Run({"JSON.MERGE", "foo", "$", R"({"a":2} {"b":2})"});
+  EXPECT_EQ(resp, "OK");
 }
 
 }  // namespace dfly

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -1394,12 +1394,12 @@ TEST_F(JsonFamilyTest, Merge) {
   resp = Run({"JSON.GET", "j1", "$"});
   EXPECT_EQ(resp, R"([{"a":"z","c":{"d":"e"}}])");
 
-  resp = Run({"JSON.SET", "foo", "$", "{}"});
+  resp = Run({"JSON.SET", "foo", "$", R"("{"f1":1, "common":2}")"});
   EXPECT_EQ(resp, "OK");
-  resp = Run({"JSON.MERGE", "foo", "$", R"({"a":2} {"b":2})"});
+  resp = Run({"JSON.MERGE", "foo", "$", R"({"f2":2, "common":4})"});
   EXPECT_EQ(resp, "OK");
   resp = Run({"JSON.GET", "foo", "$"});
-  EXPECT_EQ(resp, R"([{"a":2}])");
+  EXPECT_EQ(resp, R"([{"common":4,"f2":2}])");
 }
 
 }  // namespace dfly

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -1398,6 +1398,8 @@ TEST_F(JsonFamilyTest, Merge) {
   EXPECT_EQ(resp, "OK");
   resp = Run({"JSON.MERGE", "foo", "$", R"({"a":2} {"b":2})"});
   EXPECT_EQ(resp, "OK");
+  resp = Run({"JSON.GET", "foo", "$"});
+  EXPECT_EQ(resp, R"([{"a":2}])");
 }
 
 }  // namespace dfly


### PR DESCRIPTION
`json.merge` would throw an exception when the json object did not contain the element to replace because `RecursiveMerge` functions used `&dest->at(k_v.key())` which threw the exception. Remove `RecursiveMerge` completely and use the one implemented in jsoncons lib.

* add test
* replace RecursiveMerge with mergepatch::apply_merge_patch
* add exception handling for that flow