### PR TITLE
chore: increase timeout of regression tests

### DIFF
--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -37,7 +37,7 @@ runs:
         export DRAGONFLY_PATH="${GITHUB_WORKSPACE}/${{inputs.build-folder-name}}/${{inputs.dfly-executable}}"
         export UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 # to crash on errors
 
-        timeout 40m pytest -m "${{inputs.filter}}" --durations=10 --color=yes --json-report --json-report-file=report.json dragonfly --log-cli-level=INFO || code=$?
+        timeout 50m pytest -m "${{inputs.filter}}" --durations=10 --color=yes --json-report --json-report-file=report.json dragonfly --log-cli-level=INFO || code=$?
 
         # timeout returns 124 if we exceeded the timeout duration
         if [[ $code -eq 124 ]]; then


### PR DESCRIPTION
The recent changes of the `serialization_max_chunk_size` set to 1 for extreme testing increased the running time of the tests causing them sometimes to timeout. 

Two examples are: 

https://github.com/dragonflydb/dragonfly/actions/runs/10169667062 and
https://github.com/dragonflydb/dragonfly/actions/runs/10171501123

which both timedout. The average runs takes roughly 39.5 seconds, which is almost 40.

* increase timeout on reg tests from 40 to 50