### PR TITLE
feat: Support non-root paths for json.merge

### DIFF
--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -1400,6 +1400,42 @@ TEST_F(JsonFamilyTest, Merge) {
   EXPECT_EQ(resp, "OK");
   resp = Run({"JSON.GET", "foo", "$"});
   EXPECT_EQ(resp, R"([{"common":4,"f2":2}])");
+
+  json = R"({
+  "ans": {
+    "x": {
+      "y" : {
+        "doubled": false,
+        "answers": [
+          "foo",
+          "bar"
+        ]
+      }
+    }
+  }
+  })";
+  resp = Run({"JSON.SET", "j2", "$", json});
+  ASSERT_EQ(resp, "OK");
+
+  patch = R"(
+    {"z": {
+      "doubled": false,
+      "answers": ["xxx",  "yyy"]
+     }
+     })";
+
+  resp = Run({"JSON.MERGE", "j2", "$.ans.x", patch});
+
+  EXPECT_EQ(resp, "OK");
+  resp = Run({"JSON.GET", "j2", "$"});
+  EXPECT_EQ(resp, R"([{"ans":{"x":{"y":{"answers":["foo","bar"],"doubled":false},)"
+                  R"("z":{"answers":["xxx","yyy"],"doubled":false}}}}])");
+
+  // Test not existing entry
+  resp = Run({"JSON.MERGE", "j3", "$", patch});
+  EXPECT_EQ(resp, "OK");
+  resp = Run({"JSON.GET", "j3", "$"});
+  EXPECT_EQ(resp, R"([{"z":{"answers":["xxx","yyy"],"doubled":false}}])");
 }
 
 }  // namespace dfly

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -1421,21 +1421,22 @@ TEST_F(JsonFamilyTest, Merge) {
     {"z": {
       "doubled": false,
       "answers": ["xxx",  "yyy"]
-     }
+     },
+     "y": { "doubled": true}
      })";
 
   resp = Run({"JSON.MERGE", "j2", "$.ans.x", patch});
 
   EXPECT_EQ(resp, "OK");
   resp = Run({"JSON.GET", "j2", "$"});
-  EXPECT_EQ(resp, R"([{"ans":{"x":{"y":{"answers":["foo","bar"],"doubled":false},)"
+  EXPECT_EQ(resp, R"([{"ans":{"x":{"y":{"answers":["foo","bar"],"doubled":true},)"
                   R"("z":{"answers":["xxx","yyy"],"doubled":false}}}}])");
 
   // Test not existing entry
   resp = Run({"JSON.MERGE", "j3", "$", patch});
   EXPECT_EQ(resp, "OK");
   resp = Run({"JSON.GET", "j3", "$"});
-  EXPECT_EQ(resp, R"([{"z":{"answers":["xxx","yyy"],"doubled":false}}])");
+  EXPECT_EQ(resp, R"([{"y":{"doubled":true},"z":{"answers":["xxx","yyy"],"doubled":false}}])");
 }
 
 }  // namespace dfly


### PR DESCRIPTION
Pass path argument and rewrite the JSON.MERGE code similar to OpToggle or other mutating functions. Currently works only with --experimental_flat_json=false.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->