### PR TITLE
chore: remove verbose printing of tests

### DIFF
--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1316,7 +1316,7 @@ async def test_take_over_read_commands(df_factory, master_threads, replica_threa
 
 @pytest.mark.asyncio
 async def test_take_over_timeout(df_factory, df_seeder_factory):
-    master = df_factory.create(proactor_threads=2, logtostderr=True)
+    master = df_factory.create(proactor_threads=2)
     replica = df_factory.create(proactor_threads=2)
     df_factory.start_all([master, replica])
 
@@ -1325,7 +1325,7 @@ async def test_take_over_timeout(df_factory, df_seeder_factory):
     c_master = master.client()
     c_replica = replica.client()
 
-    print("PORTS ARE:  ", master.port, replica.port)
+    logging.debug(f"PORTS ARE:  {master.port} {replica.port}")
 
     await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
     await wait_available_async(c_replica)


### PR DESCRIPTION
Motivation: to avoid 80MB logs into stdout like this one: https://github.com/dragonflydb/dragonfly/actions/runs/10174852001/job/28141278813?pr=3401

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->