### PR TITLE
chore: expose metric that shows how many task submitters are blocked

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -5,7 +5,7 @@ set(SEARCH_LIB query_parser)
 
 add_library(dfly_core bloom.cc compact_object.cc dragonfly_core.cc extent_tree.cc
     interpreter.cc mi_memory_resource.cc sds_utils.cc
-    segment_allocator.cc score_map.cc small_string.cc sorted_map.cc
+    segment_allocator.cc score_map.cc small_string.cc sorted_map.cc task_queue.cc
     tx_queue.cc dense_set.cc allocation_tracker.cc
     string_set.cc string_map.cc detail/bitpacking.cc)
 

--- a/src/core/task_queue.cc
+++ b/src/core/task_queue.cc
@@ -1,0 +1,11 @@
+// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "core/task_queue.h"
+
+namespace dfly {
+
+__thread unsigned TaskQueue::blocked_submitters_ = 0;
+
+}  // namespace dfly

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1158,6 +1158,7 @@ void PrintPrometheusMetrics(const Metrics& m, DflyCmd* dfly_cmd, StringResponse*
                             MetricType::GAUGE, &resp->body());
   AppendMetricWithoutLabels("fibers_count", "", m.worker_fiber_count, MetricType::GAUGE,
                             &resp->body());
+  AppendMetricWithoutLabels("blocked_tasks", "", m.blocked_tasks, MetricType::GAUGE, &resp->body());
 
   AppendMetricWithoutLabels("memory_max_bytes", "", max_memory_limit, MetricType::GAUGE,
                             &resp->body());
@@ -1937,6 +1938,7 @@ Metrics ServerFamily::GetMetrics(Namespace* ns) const {
     result.fiber_longrun_usec += fb2::FiberLongRunSumUsec();
     result.worker_fiber_stack_size += fb2::WorkerFibersStackSize();
     result.worker_fiber_count += fb2::WorkerFibersCount();
+    result.blocked_tasks += TaskQueue::blocked_submitters();
 
     result.coordinator_stats.Add(ss->stats);
 

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -107,6 +107,7 @@ struct Metrics {
   // Max length of the all the tx shard-queues.
   uint32_t tx_queue_len = 0;
   uint32_t worker_fiber_count = 0;
+  uint32_t blocked_tasks = 0;
   size_t worker_fiber_stack_size = 0;
 
   InterpreterManager::Stats lua_stats;

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -315,7 +315,7 @@ TEST_F(TieredStorageTest, MemoryPressure) {
       ASSERT_FALSE(true) << i << "\nInfo ALL:\n" << resp.GetString();
     }
     // TODO: to remove it once used_mem_current is updated frequently.
-    ThisFiber::SleepFor(10us);
+    ThisFiber::SleepFor(100us);
   }
 
   EXPECT_LT(used_mem_peak.load(), 20_MB);


### PR DESCRIPTION
This should help us in identifying deadlocks quickly.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->