### PR TITLE
chore: retire TEST_EnableHeartBeat

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -897,7 +897,7 @@ void Connection::ConnectionFlow(FiberSocketBase* peer) {
   ClearPipelinedMessages();
   DCHECK(dispatch_q_.empty());
 
-  service_->OnClose(cc_.get());
+  service_->OnConnectionClose(cc_.get());
   DecreaseStatsOnClose();
 
   // We wait for dispatch_fb to finish writing the previous replies before replying to the last

--- a/src/facade/service_interface.h
+++ b/src/facade/service_interface.h
@@ -39,7 +39,7 @@ class ServiceInterface {
   virtual void ConfigureHttpHandlers(util::HttpListenerBase* base, bool is_privileged) {
   }
 
-  virtual void OnClose(ConnectionContext* cntx) {
+  virtual void OnConnectionClose(ConnectionContext* cntx) {
   }
 
   struct ContextInfo {

--- a/src/server/blocking_controller_test.cc
+++ b/src/server/blocking_controller_test.cc
@@ -52,7 +52,7 @@ void BlockingControllerTest::SetUp() {
   });
 
   shard_set = new EngineShardSet(pp_.get());
-  shard_set->Init(kNumThreads, false);
+  shard_set->Init(kNumThreads, nullptr);
 
   trans_.reset(new Transaction{&cid_});
 

--- a/src/server/container_utils.cc
+++ b/src/server/container_utils.cc
@@ -116,7 +116,7 @@ OpResult<ShardFFResult> FindFirstNonEmpty(Transaction* trans, int req_obj_type) 
     return OpStatus::WRONG_TYPE;
 
   // Order result by their keys position in the command arguments, push errors to back
-  auto comp = [trans](const OpResult<FFResult>& lhs, const OpResult<FFResult>& rhs) {
+  auto comp = [](const OpResult<FFResult>& lhs, const OpResult<FFResult>& rhs) {
     if (!lhs || !rhs)
       return lhs.ok();
     size_t i1 = std::get<1>(*lhs);

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -928,6 +928,7 @@ void DebugCmd::Stacktrace() {
     std::unique_lock lk(m);
     fb2::detail::FiberInterface::PrintAllFiberStackTraces();
   });
+  base::FlushLogs();
   cntx_->SendOk();
 }
 

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -186,8 +186,6 @@ bool RunEngine(ProactorPool* pool, AcceptServer* acceptor) {
     listeners.push_back(listener.release());
   }
 
-  Service::InitOpts opts;
-  opts.disable_time_update = false;
   const auto& bind = GetFlag(FLAGS_bind);
   const char* bind_addr = bind.empty() ? nullptr : bind.c_str();
 
@@ -292,7 +290,7 @@ bool RunEngine(ProactorPool* pool, AcceptServer* acceptor) {
     listeners.push_back(listener.release());
   }
 
-  service.Init(acceptor, listeners, opts);
+  service.Init(acceptor, listeners);
 
   VersionMonitor version_monitor;
 

--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -132,8 +132,6 @@ class DflyCmd {
 
   void OnClose(ConnectionContext* cntx);
 
-  void BreakOnShutdown();
-
   // Stop all background processes so we can exit in orderly manner.
   void Shutdown();
 
@@ -214,17 +212,17 @@ class DflyCmd {
   bool CheckReplicaStateOrReply(const ReplicaInfo& ri, SyncState expected,
                                 facade::RedisReplyBuilder* rb);
 
+ private:
   // Return a map between replication ID to lag. lag is defined as the maximum of difference
   // between the master's LSN and the last acknowledged LSN in over all shards.
-  std::map<uint32_t, LSN> ReplicationLags() const;
+  std::map<uint32_t, LSN> ReplicationLagsLocked() const;
 
- private:
   ServerFamily* sf_;  // Not owned
 
   uint32_t next_sync_id_ = 1;
 
   using ReplicaInfoMap = absl::btree_map<uint32_t, std::shared_ptr<ReplicaInfo>>;
-  ReplicaInfoMap replica_infos_;
+  ReplicaInfoMap replica_infos_ ABSL_GUARDED_BY(mu_);
 
   mutable util::fb2::Mutex mu_;  // Guard global operations. See header top for locking levels.
 };

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -402,7 +402,6 @@ TEST_F(DflyEngineTest, FlushAll) {
 }
 
 TEST_F(DflyEngineTest, OOM) {
-  shard_set->TEST_EnableHeartBeat();
   max_memory_limit = 300000;
   size_t i = 0;
   RespExpr resp;
@@ -444,7 +443,6 @@ TEST_F(DflyEngineTest, OOM) {
 /// and then written with the same key.
 TEST_F(DflyEngineTest, Bug207) {
   max_memory_limit = 300000;
-  shard_set->TEST_EnableHeartBeat();
   shard_set->TEST_EnableCacheMode();
   absl::FlagSaver fs;
   absl::SetFlag(&FLAGS_oom_deny_ratio, 4);
@@ -474,7 +472,6 @@ TEST_F(DflyEngineTest, Bug207) {
 }
 
 TEST_F(DflyEngineTest, StickyEviction) {
-  shard_set->TEST_EnableHeartBeat();
   shard_set->TEST_EnableCacheMode();
   absl::FlagSaver fs;
   absl::SetFlag(&FLAGS_oom_deny_ratio, 4);
@@ -583,11 +580,7 @@ TEST_F(DflyEngineTest, Bug468) {
 }
 
 TEST_F(DflyEngineTest, Bug496) {
-  shard_set->pool()->AwaitFiberOnAll([&](unsigned index, ProactorBase* base) {
-    EngineShard* shard = EngineShard::tlocal();
-    if (shard == nullptr)
-      return;
-
+  shard_set->RunBlockingInParallel([](EngineShard* shard) {
     auto& db = namespaces.GetDefaultNamespace().GetDbSlice(shard->shard_id());
 
     int cb_hits = 0;

--- a/src/server/engine_shard_set.h
+++ b/src/server/engine_shard_set.h
@@ -150,8 +150,6 @@ class EngineShard {
     return continuation_trans_;
   }
 
-  void TEST_EnableHeartbeat();
-
   void StopPeriodicFiber();
 
   struct TxQueueInfo {
@@ -205,10 +203,10 @@ class EngineShard {
   // blocks the calling fiber.
   void Shutdown();  // called before destructing EngineShard.
 
-  void StartPeriodicFiber(util::ProactorBase* pb);
+  void StartPeriodicFiber(util::ProactorBase* pb, std::function<void()> global_handler);
 
   void Heartbeat();
-  void RunPeriodic(std::chrono::milliseconds period_ms);
+  void RunPeriodic(std::chrono::milliseconds period_ms, std::function<void()> global_handler);
 
   void CacheStats();
 
@@ -288,7 +286,7 @@ class EngineShardSet {
     return pp_;
   }
 
-  void Init(uint32_t size, bool update_db_time);
+  void Init(uint32_t size, std::function<void()> global_handler);
 
   // Shutdown sequence:
   // - EngineShardSet.PreShutDown()
@@ -342,7 +340,6 @@ class EngineShardSet {
   }
 
   // Used in tests
-  void TEST_EnableHeartBeat();
   void TEST_EnableCacheMode();
 
  private:

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -29,18 +29,10 @@ using facade::MemcacheParser;
 
 class Service : public facade::ServiceInterface {
  public:
-  struct InitOpts {
-    bool disable_time_update;
-
-    InitOpts() : disable_time_update{false} {
-    }
-  };
-
   explicit Service(util::ProactorPool* pp);
   ~Service();
 
-  void Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> listeners,
-            const InitOpts& opts = InitOpts{});
+  void Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> listeners);
 
   void Shutdown();
 
@@ -93,7 +85,7 @@ class Service : public facade::ServiceInterface {
   GlobalState GetGlobalState() const;
 
   void ConfigureHttpHandlers(util::HttpListenerBase* base, bool is_privileged) final;
-  void OnClose(facade::ConnectionContext* cntx) final;
+  void OnConnectionClose(facade::ConnectionContext* cntx) final;
 
   Service::ContextInfo GetContextInfo(facade::ConnectionContext* cntx) const final;
 

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -86,7 +86,7 @@ class RdbSaver {
   ~RdbSaver();
 
   // Initiates the serialization in the shard's thread.
-  // TODO: to implement break functionality to allow stopping early.
+  // cll allows breaking in the middle.
   void StartSnapshotInShard(bool stream_journal, const Cancellation* cll, EngineShard* shard);
 
   // Send only the incremental snapshot since start_lsn.

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -45,6 +45,7 @@ class RdbTest : public BaseFamilyTest {
 
 void RdbTest::SetUp() {
   InitWithDbFilename();
+  max_memory_limit = 40000000;
 }
 
 inline const uint8_t* to_byte(const void* s) {

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -628,8 +628,6 @@ TEST_F(SearchFamilyTest, SimpleExpiry) {
 
   EXPECT_THAT(Run({"ft.search", "i1", "*"}), AreDocIds("d:1", "d:2", "d:3"));
 
-  shard_set->TEST_EnableHeartBeat();
-
   AdvanceTime(60);
   ThisFiber::SleepFor(5ms);  // Give heartbeat time to delete expired doc
   EXPECT_THAT(Run({"ft.search", "i1", "*"}), AreDocIds("d:1", "d:3"));

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -683,7 +683,7 @@ std::optional<fb2::Fiber> Pause(std::vector<facade::Listener*> listeners, Namesp
   //    command that did not pause on the new state yet we will pause after waking up.
   DispatchTracker tracker{std::move(listeners), conn, true /* ignore paused commands */,
                           true /*ignore blocking*/};
-  shard_set->pool()->AwaitBrief([&tracker, pause_state, ns](unsigned, util::ProactorBase*) {
+  shard_set->pool()->AwaitBrief([&tracker, pause_state](unsigned, util::ProactorBase*) {
     // Commands don't suspend before checking the pause state, so
     // it's impossible to deadlock on waiting for a command that will be paused.
     tracker.TrackOnThread();
@@ -1560,10 +1560,6 @@ void ServerFamily::DbSize(CmdArgList args, ConnectionContext* cntx) {
       [](ShardId) { return true; });
 
   return cntx->SendLong(num_keys.load(memory_order_relaxed));
-}
-
-void ServerFamily::BreakOnShutdown() {
-  dfly_cmd_->BreakOnShutdown();
 }
 
 void ServerFamily::CancelBlockingOnThread(std::function<OpStatus(ArgSlice)> status_cb) {

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -227,8 +227,6 @@ class ServerFamily {
 
   void OnClose(ConnectionContext* cntx);
 
-  void BreakOnShutdown();
-
   void CancelBlockingOnThread(std::function<facade::OpStatus(ArgSlice)> = {});
 
   // Sets the server to replicate another instance. Does not flush the database beforehand!

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -167,10 +167,10 @@ void BaseFamilyTest::SetUpTestSuite() {
       SetTestFlag(flag, value);
     }
   }
-  max_memory_limit = INT_MAX;
 }
 
 void BaseFamilyTest::SetUp() {
+  max_memory_limit = INT_MAX;
   ResetService();
 }
 
@@ -207,9 +207,7 @@ void BaseFamilyTest::ResetService() {
   pp_->Run();
   service_ = std::make_unique<Service>(pp_.get());
 
-  Service::InitOpts opts;
-  opts.disable_time_update = true;
-  service_->Init(nullptr, {}, opts);
+  service_->Init(nullptr, {});
   used_mem_current = 0;
 
   TEST_current_time_ms = absl::GetCurrentTimeNanos() / 1000000;

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -192,7 +192,7 @@ void TieredStorage::ShardOpManager::Defragment(tiering::DiskSegment segment, str
   for (auto [dbid, hash, item_segment] : ts_->bins_->DeleteBin(segment, page)) {
     // Search for key with the same hash and value pointing to the same segment.
     // If it still exists, it must correspond to the value stored in this bin
-    auto predicate = [item_segment](const PrimeKey& key, const PrimeValue& probe) {
+    auto predicate = [item_segment = item_segment](const PrimeKey& key, const PrimeValue& probe) {
       return probe.IsExternal() && tiering::DiskSegment{probe.GetExternalSlice()} == item_segment;
     };
     auto it = db_slice_.GetDBTable(dbid)->prime.FindFirst(hash, predicate);

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -209,7 +209,6 @@ TEST_F(TieredStorageTest, BackgroundOffloading) {
   const int kNum = 500;
 
   max_memory_limit = kNum * 4096;
-  pp_->at(0)->AwaitBrief([] { EngineShard::tlocal()->TEST_EnableHeartbeat(); });
 
   // Stash all values
   string value = BuildString(3000);
@@ -302,10 +301,7 @@ TEST_F(TieredStorageTest, FlushPending) {
 
 TEST_F(TieredStorageTest, MemoryPressure) {
   max_memory_limit = 20_MB;
-  pp_->at(0)->AwaitBrief([] {
-    EngineShard::tlocal()->TEST_EnableHeartbeat();
-    EngineShard::tlocal()->tiered_storage()->SetMemoryLowLimit(2_MB);
-  });
+  pp_->at(0)->AwaitBrief([] { EngineShard::tlocal()->tiered_storage()->SetMemoryLowLimit(2_MB); });
 
   constexpr size_t kNum = 10000;
   for (size_t i = 0; i < kNum; i++) {


### PR DESCRIPTION
Now unit tests will run the same Hearbeat fiber like in prod. The whole feature was redundant, with just few explicit settings of maxmemory_limit I succeeeded to make all unit tests pass.

In addition, this change allows passing a global handler that is called by heartbeat from a single thread. This is not used yet - preparation for the next PR to break hung up replication connections on a master.

Finally, this change has some non-functional clean-ups and warning fixes to improve code quality.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->