### PR TITLE
chore: simplify master replication cancelation interface

### DIFF
--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -107,7 +107,7 @@ void DflyCmd::ReplicaInfo::Cancel() {
 
   LOG(INFO) << "Disconnecting from replica " << address << ":" << listening_port;
 
-  // Update tate and cancel context.
+  // Update state and cancel context.
   replica_state = SyncState::CANCELLED;
   cntx.Cancel();
 

--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -119,6 +119,9 @@ class DflyCmd {
       return std::shared_lock{shared_mu};
     }
 
+    // Transition into cancelled state, run cleanup.
+    void Cancel();
+
     SyncState replica_state;  // always guarded by shared_mu
     Context cntx;
 
@@ -156,9 +159,6 @@ class DflyCmd {
 
   // Sets metadata.
   void SetDflyClientVersion(ConnectionContext* cntx, DflyVersion version);
-
-  // Transition into cancelled state, run cleanup.
-  void CancelReplication(uint32_t sync_id, std::shared_ptr<ReplicaInfo> replica_info_ptr);
 
  private:
   // JOURNAL [START/STOP]
@@ -208,9 +208,6 @@ class DflyCmd {
   // Fiber that runs full sync for each flow.
   void FullSyncFb(FlowInfo* flow, Context* cntx);
 
-  // Main entrypoint for stopping replication.
-  void StopReplication(uint32_t sync_id);
-
   // Get ReplicaInfo by sync_id.
   std::shared_ptr<ReplicaInfo> GetReplicaInfo(uint32_t sync_id);
 
@@ -223,6 +220,9 @@ class DflyCmd {
                                 facade::RedisReplyBuilder* rb);
 
  private:
+  // Main entrypoint for stopping replication.
+  void StopReplication(uint32_t sync_id);
+
   // Return a map between replication ID to lag. lag is defined as the maximum of difference
   // between the master's LSN and the last acknowledged LSN in over all shards.
   std::map<uint32_t, LSN> ReplicationLagsLocked() const;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1186,12 +1186,7 @@ void Service::DispatchCommand(CmdArgList args, facade::ConnectionContext* cntx) 
     // Bonus points because this allows to continue replication with ACL users who got
     // their access revoked and reinstated
     if (cid->name() == "REPLCONF" && absl::EqualsIgnoreCase(ArgS(args_no_cmd, 0), "ACK")) {
-      auto info_ptr = server_family_.GetReplicaInfoFromConnection(dfly_cntx);
-      if (info_ptr) {
-        unsigned session_id = dfly_cntx->conn_state.replication_info.repl_session_id;
-        DCHECK(session_id);
-        server_family_.GetDflyCmd()->CancelReplication(session_id, std::move(info_ptr));
-      }
+      server_family_.GetDflyCmd()->OnClose(dfly_cntx);
       return;
     }
     dfly_cntx->SendError(std::move(*err));


### PR DESCRIPTION
Before that CancelReplication did too many things, moreover, we had StopReplication that did the same.

This PR moves CancelReplication under ReplicaInfo struct, and reduces code duplication around this change.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->