### PR TITLE
chore: integrate quicklist changes from valkey

### DIFF
--- a/src/redis/config.h
+++ b/src/redis/config.h
@@ -98,9 +98,9 @@
 #endif
 
 #if __GNUC__ >= 4
-#define redis_unreachable __builtin_unreachable
+#define valkey_unreachable __builtin_unreachable
 #else
-#define redis_unreachable abort
+#define valkey_unreachable abort
 #endif
 #if __GNUC__ >= 3
 #define likely(x) __builtin_expect(!!(x), 1)

--- a/src/redis/redis_aux.c
+++ b/src/redis/redis_aux.c
@@ -13,9 +13,6 @@ void InitRedisTables() {
   crc64_init();
   memset(&server, 0, sizeof(server));
 
-  server.maxmemory_policy = 0;
-  server.lfu_decay_time = 0;
-
   // been used by t_zset routines that convert listpack to skiplist for cases
   // above these thresholds.
   server.zset_max_listpack_entries = 128;

--- a/src/redis/redis_aux.h
+++ b/src/redis/redis_aux.h
@@ -34,14 +34,6 @@ void dictSdsDestructor(dict* privdata, void* val);
 size_t sdsZmallocSize(sds s);
 
 typedef struct ServerStub {
-  int lfu_decay_time; /* LFU counter decay factor. */
-  /* should not be used. Use FLAGS_list_max_ziplist_size and FLAGS_list_compress_depth instead. */
-  // int list_compress_depth;
-  // int list_max_ziplist_size;
-
-  // unused - left so that object.c will compile.
-  int maxmemory_policy; /* Policy for key eviction */
-
   size_t max_map_field_len, max_listpack_map_bytes;
 
   size_t zset_max_listpack_entries;

--- a/src/redis/ziplist.c
+++ b/src/redis/ziplist.c
@@ -350,7 +350,7 @@ static inline unsigned int zipIntSize(unsigned char encoding) {
     if (encoding >= ZIP_INT_IMM_MIN && encoding <= ZIP_INT_IMM_MAX)
         return 0; /* 4 bit immediate */
     /* bad encoding, covered by a previous call to ZIP_ASSERT_ENCODING */
-    redis_unreachable();
+    valkey_unreachable();
     return 0;
 }
 

--- a/src/redis/zmalloc.h
+++ b/src/redis/zmalloc.h
@@ -129,7 +129,7 @@ int zmalloc_get_allocator_wasted_blocks(float ratio, size_t* allocated, size_t* 
  * return 0 if not, 1 if underutilized
  */
 int zmalloc_page_is_underutilized(void *ptr, float ratio);
-// roman: void zlibc_free(void *ptr);
+char *zstrdup(const char *s);
 
 void init_zmalloc_threadlocal(void* heap);
 extern __thread ssize_t zmalloc_used_memory_tl;

--- a/src/redis/zmalloc_mi.c
+++ b/src/redis/zmalloc_mi.c
@@ -178,3 +178,11 @@ void init_zmalloc_threadlocal(void* heap) {
 int zmalloc_page_is_underutilized(void* ptr, float ratio) {
   return mi_heap_page_is_underutilized(zmalloc_heap, ptr, ratio);
 }
+
+char *zstrdup(const char *s) {
+  size_t l = strlen(s) + 1;
+  char *p = zmalloc(l);
+
+  memcpy(p, s, l);
+  return p;
+}


### PR DESCRIPTION
It's impossible to review differential changes for `quicklist.*`, but it's easier to compare them with valkey versions - 
the only differences are the const modifiers that were added to our files.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->