### PR TITLE
feat: DEBUG REPLICA PAUSE now pauses fullsync

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -727,12 +727,6 @@ OpResult<uint32_t> OpStick(const OpArgs& op_args, const ShardArgs& keys) {
 
 }  // namespace
 
-void GenericFamily::Init(util::ProactorPool* pp) {
-}
-
-void GenericFamily::Shutdown() {
-}
-
 void GenericFamily::Del(CmdArgList args, ConnectionContext* cntx) {
   Transaction* transaction = cntx->transaction;
   VLOG(1) << "Del " << ArgS(args, 0);

--- a/src/server/generic_family.h
+++ b/src/server/generic_family.h
@@ -35,9 +35,6 @@ enum ExpireFlags {
 
 class GenericFamily {
  public:
-  static void Init(util::ProactorPool* pp);
-  static void Shutdown();
-
   static void Register(CommandRegistry* registry);
 
   // Accessed by Service::Exec and Service::Watch as an utility.

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -1980,6 +1980,11 @@ error_code RdbLoader::Load(io::Source* src) {
   auto cleanup = absl::Cleanup([&] { FinishLoad(start, &keys_loaded); });
 
   while (!stop_early_.load(memory_order_relaxed)) {
+    if (pause_) {
+      ThisFiber::SleepFor(100ms);
+      continue;
+    }
+
     /* Read type. */
     SET_OR_RETURN(FetchType(), type);
 

--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -207,6 +207,10 @@ class RdbLoader : protected RdbLoaderBase {
     stop_early_.store(true);
   }
 
+  void Pause(bool pause) {
+    pause_ = pause;
+  }
+
   // Return the offset that was received with a RDB_OPCODE_JOURNAL_OFFSET command,
   // or 0 if no offset was received.
   std::optional<uint64_t> journal_offset() const {
@@ -276,8 +280,11 @@ class RdbLoader : protected RdbLoaderBase {
   double load_time_ = 0;
 
   DbIndex cur_db_index_ = 0;
-
+  bool pause_ = false;
   AggregateError ec_;
+
+  // We use atomics here because shard threads can notify RdbLoader fiber from another thread
+  // that it should stop early.
   std::atomic_bool stop_early_{false};
   std::atomic_uint blocked_shards_{0};
 

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -195,6 +195,8 @@ class DflyShardReplica : public ProtocolClient {
 
   uint64_t JournalExecutedCount() const;
 
+  void Pause(bool pause);
+
  private:
   Service& service_;
   MasterContext master_context_;

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -1404,12 +1404,6 @@ void StringFamily::ClThrottle(CmdArgList args, ConnectionContext* cntx) {
   }
 }
 
-void StringFamily::Init(util::ProactorPool* pp) {
-}
-
-void StringFamily::Shutdown() {
-}
-
 #define HFUNC(x) SetHandler(&StringFamily::x)
 
 namespace acl {

--- a/src/server/string_family.h
+++ b/src/server/string_family.h
@@ -95,9 +95,6 @@ class SetCmd {
 
 class StringFamily {
  public:
-  static void Init(util::ProactorPool* pp);
-  static void Shutdown();
-
   static void Register(CommandRegistry* registry);
 
  private:


### PR DESCRIPTION
Before that PAUSE paused the reconnection reconciler flow, now it also pauses the ongoing full sync replication if such exists.

In addition, this PR applies some clean-ups and removes redundant code

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->