### PR TITLE
test: fix test_disconnect_replica

### DIFF
--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -934,7 +934,7 @@ void DflyShardReplica::ExecuteTx(TransactionData&& tx_data, Context* cntx) {
   }
 
   if (!tx_data.IsGlobalCmd()) {
-    VLOG(2) << "Execute cmd without sync between shards. txid: " << tx_data.txid;
+    VLOG(3) << "Execute cmd without sync between shards. txid: " << tx_data.txid;
     executor_->Execute(tx_data.dbid, tx_data.command);
     return;
   }


### PR DESCRIPTION
test had 2 bugs:
1) deadlock in master (can't reproduce anymore after recent changes for replication)
2) incorrect checking (replica can't guarantee that got all data from the master if the connection is dropped)