### PR TITLE
fix: cluster_mgr.py to use `CLUSTER MYID`

### DIFF
--- a/tools/cluster_mgr.py
+++ b/tools/cluster_mgr.py
@@ -24,7 +24,7 @@ class Node:
         self.port = port
 
     def update_id(node):
-        node.id = send_command(node, ["dflycluster", "myid"])
+        node.id = send_command(node, ["cluster", "myid"])
         print(f"- ID {node.id}")
 
 


### PR DESCRIPTION
We recently changed `DFLYCLUSTER MYID` to `CLUSTER MYID`, but since our `cluster_mgr_test.py` is marked as XFAIL we missed updating it.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->