### PR TITLE
chore: disable serialization_max_chunk_size in regtests

### DIFF
--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -88,7 +88,7 @@ class DflyInstance:
                 self.args["num_shards"] = threads - 1
 
         # Add 1 byte limit for big values
-        self.args["serialization_max_chunk_size"] = 1
+        # self.args["serialization_max_chunk_size"] = 1
 
     def __del__(self):
         assert self.proc == None


### PR DESCRIPTION
Intended to stabilize regression tests before releasing our next version.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->