### PR TITLE
fix: Cleanup files before running tests

### DIFF
--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -29,6 +29,11 @@ def find_main_file(path: Path, pattern):
     return next(iter(glob.glob(str(path) + "/" + pattern)), None)
 
 
+def rm_glob(glob: string):
+    for p in Path(BASIC_ARGS["dir"]).glob(glob):
+        p.unlink()
+
+
 @pytest.mark.opt_only
 @pytest.mark.parametrize("format", FILE_FORMATS)
 @pytest.mark.parametrize(
@@ -46,6 +51,7 @@ async def test_consistency(df_factory, format: str, seeder_opts: dict):
     Test consistency over a large variety of data with different sizes
     """
     dbfilename = f"dump_{tmp_file_name()}"
+    rm_glob(f"{dbfilename}*")
     instance = df_factory.create(dbfilename=dbfilename)
     instance.start()
     async_client = instance.client()
@@ -72,6 +78,7 @@ async def test_multidb(df_factory, format: str):
     Test serialization of multiple logical databases
     """
     dbfilename = f"test-multidb{rand(0, 5000)}"
+    rm_glob(f"{dbfilename}*")
     instance = df_factory.create(dbfilename=dbfilename)
     instance.start()
     async_client = instance.client()
@@ -110,6 +117,7 @@ async def test_multidb(df_factory, format: str):
 async def test_dbfilenames(
     df_factory, tmp_dir: Path, save_type: str, dbfilename: str, pattern: str
 ):
+    rm_glob(f"{dbfilename}*")
     df_args = {**BASIC_ARGS, "dbfilename": dbfilename, "port": 1111}
 
     if save_type == "rdb":
@@ -378,7 +386,9 @@ class TestDflySnapshotOnShutdown:
 @pytest.mark.parametrize("format", FILE_FORMATS)
 @dfly_args({**BASIC_ARGS, "dbfilename": "info-while-snapshot"})
 async def test_infomemory_while_snapshoting(df_factory, format: str):
-    instance = df_factory.create(dbfilename=f"dump_{tmp_file_name()}")
+    dbfilename = f"dump_{tmp_file_name()}"
+    rm_glob(f"{dbfilename}*")
+    instance = df_factory.create(dbfilename=dbfilename)
     instance.start()
     async_client = instance.client()
     await async_client.execute_command("DEBUG POPULATE 10000 key 4048 RAND")


### PR DESCRIPTION
In some rare cases we have leftover RDB files _and_ we do not load them in time, so we get an `Dragonfly is loading the dataset in memory` error.

Fixes #3343 (hopefully)

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->