### PR TITLE
fix: missing logs on ci timeout

### DIFF
--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -37,7 +37,7 @@ runs:
         export DRAGONFLY_PATH="${GITHUB_WORKSPACE}/${{inputs.build-folder-name}}/${{inputs.dfly-executable}}"
         export UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 # to crash on errors
 
-        timeout 3m pytest -m "${{inputs.filter}}" --durations=10 --color=yes --json-report --json-report-file=report.json dragonfly --log-cli-level=INFO || code=$?
+        timeout 2m pytest -m "${{inputs.filter}}" --durations=10 --color=yes --json-report --json-report-file=report.json dragonfly --log-cli-level=INFO || code=$?
 
         # timeout returns 124 if we exceeded the timeout duration
         if [[ $code -eq 124 ]]; then
@@ -55,9 +55,9 @@ runs:
 
     - name: Print last log on timeout
       if: failure()
+      shell: bash
       run: |
-        mkdir /tmp/failed
-        cat /tmp/last_test_log_dir.txt | xargs -I {} cp -r {}/ /tmp/failed/
+        cat /tmp/last_test_log_dir.txt | xargs -I {} mv {}/ /tmp/failed/
 
     - name: Send notification on failure
       if: failure() && github.ref == 'refs/heads/main'

--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -37,10 +37,13 @@ runs:
         export DRAGONFLY_PATH="${GITHUB_WORKSPACE}/${{inputs.build-folder-name}}/${{inputs.dfly-executable}}"
         export UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 # to crash on errors
 
-        timeout 50m pytest -m "${{inputs.filter}}" --durations=10 --color=yes --json-report --json-report-file=report.json dragonfly --log-cli-level=INFO || code=$?
+        timeout 3m pytest -m "${{inputs.filter}}" --durations=10 --color=yes --json-report --json-report-file=report.json dragonfly --log-cli-level=INFO || code=$?
 
         # timeout returns 124 if we exceeded the timeout duration
         if [[ $code -eq 124 ]]; then
+          echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑"
+          echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 TESTS TIMEDOUT 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑"
+          echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑"
           echo "TIMEDOUT=1">> "$GITHUB_OUTPUT";
           exit 1
         fi
@@ -52,23 +55,9 @@ runs:
 
     - name: Print last log on timeout
       if: failure()
-      shell: bash
-      env:
-        TIMEDOUT_STEP_1: ${{ steps.first.outputs.TIMEDOUT }}
-        TIMEDOUT_STEP_2: ${{ steps.second.outputs.TIMEDOUT }}
       run: |
-        if [[ "${{ env.TIMEDOUT_STEP_1 }}" -eq 1 ]] || [[ "${{ env.TIMEDOUT_STEP_2 }}" -eq 1 ]]; then
-          echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑"
-          echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 TESTS TIMEDOUT 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑"
-          echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑"
-
-          # It could be the case that the first test failed and the folder was not created. We need mkdir
-          # therefore so plz do not remove
-          mkdir /tmp/failed
-          # Copy over the logs of the test that timedout. We need this because the exception/failure
-          # handlers do not run when the shell command TIMEOUT sends a SIGTERM to terminate the pytest process.
-          cat /tmp/last_test_log_dir.txt | xargs -I {} cp -r {}/ /tmp/failed/
-        fi
+        mkdir /tmp/failed
+        cat /tmp/last_test_log_dir.txt | xargs -I {} cp -r {}/ /tmp/failed/
 
     - name: Send notification on failure
       if: failure() && github.ref == 'refs/heads/main'

--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -44,7 +44,9 @@ runs:
           echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑"
           echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 TESTS TIMEDOUT 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑"
           echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑"
-          echo "TIMEDOUT=1">> "$GITHUB_OUTPUT";
+          # Copy the last log file because we timedout and pytest did not copy it over
+          # the /tmp/failed/ folder
+          cat /tmp/last_test_log_dir.txt | xargs -I {} mv {}/ /tmp/failed/
           exit 1
         fi
 
@@ -52,12 +54,6 @@ runs:
         if [[ $code -ne 0 ]]; then
           exit 1
         fi
-
-    - name: Print last log on timeout
-      if: failure()
-      shell: bash
-      run: |
-        cat /tmp/last_test_log_dir.txt | xargs -I {} mv {}/ /tmp/failed/
 
     - name: Send notification on failure
       if: failure() && github.ref == 'refs/heads/main'

--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -37,7 +37,7 @@ runs:
         export DRAGONFLY_PATH="${GITHUB_WORKSPACE}/${{inputs.build-folder-name}}/${{inputs.dfly-executable}}"
         export UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 # to crash on errors
 
-        timeout 2m pytest -m "${{inputs.filter}}" --durations=10 --color=yes --json-report --json-report-file=report.json dragonfly --log-cli-level=INFO || code=$?
+        timeout 50m pytest -m "${{inputs.filter}}" --durations=10 --color=yes --json-report --json-report-file=report.json dragonfly --log-cli-level=INFO || code=$?
 
         # timeout returns 124 if we exceeded the timeout duration
         if [[ $code -eq 124 ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,54 +118,51 @@ jobs:
           ninja search_family_test
           df -h
           echo "-----------------------------"
-          #ninja src/all
-          ninja dragonfly
-
-
+          ninja src/all
       - name: PostFail
         if: failure()
         run: |
           echo "disk space is:"
           df -h
 
-          #      - name: C++ Unit Tests
-          #        run: |
-          #          cd ${GITHUB_WORKSPACE}/build
-          #          echo Run ctest -V -L DFLY
-          #          GLOG_alsologtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 ctest -V -L DFLY
-          #
-          #          echo "Running tests with --force_epoll"
-          #
-          #          # Create a rule that automatically prints stacktrace upon segfault
-          #          cat > ./init.gdb <<EOF
-          #          catch signal SIGSEGV
-          #          command
-          #          bt
-          #          end
-          #          EOF
-          #
-          #          gdb -ix ./init.gdb --batch -ex r --args ./dragonfly_test --force_epoll
-          #          FLAGS_force_epoll=true GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 ctest -V -L DFLY
-          #
-          #          echo "Finished running tests with --force_epoll"
-          #
-          #          echo "Running tests with --cluster_mode=emulated"
-          #          FLAGS_cluster_mode=emulated ctest -V -L DFLY
-          #
-          #          echo "Running tests with both --cluster_mode=emulated & --lock_on_hashtags"
-          #          FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true ctest -V -L DFLY
-          #
-          #          ./dragonfly_test
-          #          ./multi_test --multi_exec_mode=1
-          #          ./multi_test --multi_exec_mode=3
-          #          ./json_family_test --jsonpathv2=false
-          #
-          #- name: Upload unit logs on failure
-          #  if: failure()
-          #  uses: actions/upload-artifact@v4
-          #  with:
-          #    name: unit_logs
-          #    path: /tmp/*INFO*
+      - name: C++ Unit Tests
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
+          echo Run ctest -V -L DFLY
+          GLOG_alsologtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 ctest -V -L DFLY
+
+          echo "Running tests with --force_epoll"
+
+          # Create a rule that automatically prints stacktrace upon segfault
+          cat > ./init.gdb <<EOF
+          catch signal SIGSEGV
+          command
+          bt
+          end
+          EOF
+
+          gdb -ix ./init.gdb --batch -ex r --args ./dragonfly_test --force_epoll
+          FLAGS_force_epoll=true GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 ctest -V -L DFLY
+
+          echo "Finished running tests with --force_epoll"
+
+          echo "Running tests with --cluster_mode=emulated"
+          FLAGS_cluster_mode=emulated ctest -V -L DFLY
+
+          echo "Running tests with both --cluster_mode=emulated & --lock_on_hashtags"
+          FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true ctest -V -L DFLY
+
+          ./dragonfly_test
+          ./multi_test --multi_exec_mode=1
+          ./multi_test --multi_exec_mode=3
+          ./json_family_test --jsonpathv2=false
+
+      - name: Upload unit logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit_logs
+          path: /tmp/*INFO*
 
       - name: Run regression tests
         if: matrix.container == 'ubuntu-dev:20'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
             cxx_flags: ""
 
     runs-on: ubuntu-latest
-    timeout-minutes: 60
     env:
       SCCACHE_GHA_ENABLED: "true"
       SCCACHE_CACHE_SIZE: 6G
@@ -129,7 +128,7 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/build
           echo Run ctest -V -L DFLY
-          GLOG_alsologtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 ctest -V -L DFLY
+          GLOG_alsologtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 timeout 20 ctest -V -L DFLY
 
           echo "Running tests with --force_epoll"
 
@@ -142,20 +141,20 @@ jobs:
           EOF
 
           gdb -ix ./init.gdb --batch -ex r --args ./dragonfly_test --force_epoll
-          FLAGS_force_epoll=true GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 ctest -V -L DFLY
+          FLAGS_force_epoll=true GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 timeout 20 ctest -V -L DFLY
 
           echo "Finished running tests with --force_epoll"
 
           echo "Running tests with --cluster_mode=emulated"
-          FLAGS_cluster_mode=emulated ctest -V -L DFLY
+          FLAGS_cluster_mode=emulated timeout 20 ctest -V -L DFLY
 
           echo "Running tests with both --cluster_mode=emulated & --lock_on_hashtags"
-          FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true ctest -V -L DFLY
+          FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true timeout 20 ctest -V -L DFLY
 
-          ./dragonfly_test
-          ./multi_test --multi_exec_mode=1
-          ./multi_test --multi_exec_mode=3
-          ./json_family_test --jsonpathv2=false
+          timeout 5 ./dragonfly_test
+          timeout 5 ./multi_test --multi_exec_mode=1
+          timeout 5 ./multi_test --multi_exec_mode=3
+          timeout 5 ./json_family_test --jsonpathv2=false
 
       - name: Upload unit logs on failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/build
           echo Run ctest -V -L DFLY
-          GLOG_alsologtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 timeout 20 ctest -V -L DFLY
+          GLOG_alsologtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 timeout 20m ctest -V -L DFLY
 
           echo "Running tests with --force_epoll"
 
@@ -141,20 +141,20 @@ jobs:
           EOF
 
           gdb -ix ./init.gdb --batch -ex r --args ./dragonfly_test --force_epoll
-          FLAGS_force_epoll=true GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 timeout 20 ctest -V -L DFLY
+          FLAGS_force_epoll=true GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 timeout 20m ctest -V -L DFLY
 
           echo "Finished running tests with --force_epoll"
 
           echo "Running tests with --cluster_mode=emulated"
-          FLAGS_cluster_mode=emulated timeout 20 ctest -V -L DFLY
+          FLAGS_cluster_mode=emulated timeout 20m ctest -V -L DFLY
 
           echo "Running tests with both --cluster_mode=emulated & --lock_on_hashtags"
-          FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true timeout 20 ctest -V -L DFLY
+          FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true timeout 20m ctest -V -L DFLY
 
-          timeout 5 ./dragonfly_test
-          timeout 5 ./multi_test --multi_exec_mode=1
-          timeout 5 ./multi_test --multi_exec_mode=3
-          timeout 5 ./json_family_test --jsonpathv2=false
+          timeout 5m ./dragonfly_test
+          timeout 5m ./multi_test --multi_exec_mode=1
+          timeout 5m ./multi_test --multi_exec_mode=3
+          timeout 5m ./json_family_test --jsonpathv2=false
 
       - name: Upload unit logs on failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,9 @@ jobs:
           ninja search_family_test
           df -h
           echo "-----------------------------"
-          ninja src/all
+          #ninja src/all
+          ninja dragonfly
+
 
       - name: PostFail
         if: failure()
@@ -126,44 +128,44 @@ jobs:
           echo "disk space is:"
           df -h
 
-      - name: C++ Unit Tests
-        run: |
-          cd ${GITHUB_WORKSPACE}/build
-          echo Run ctest -V -L DFLY
-          GLOG_alsologtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 ctest -V -L DFLY
-
-          echo "Running tests with --force_epoll"
-
-          # Create a rule that automatically prints stacktrace upon segfault
-          cat > ./init.gdb <<EOF
-          catch signal SIGSEGV
-          command
-          bt
-          end
-          EOF
-
-          gdb -ix ./init.gdb --batch -ex r --args ./dragonfly_test --force_epoll
-          FLAGS_force_epoll=true GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 ctest -V -L DFLY
-
-          echo "Finished running tests with --force_epoll"
-
-          echo "Running tests with --cluster_mode=emulated"
-          FLAGS_cluster_mode=emulated ctest -V -L DFLY
-
-          echo "Running tests with both --cluster_mode=emulated & --lock_on_hashtags"
-          FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true ctest -V -L DFLY
-
-          ./dragonfly_test
-          ./multi_test --multi_exec_mode=1
-          ./multi_test --multi_exec_mode=3
-          ./json_family_test --jsonpathv2=false
-
-      - name: Upload unit logs on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: unit_logs
-          path: /tmp/*INFO*
+          #      - name: C++ Unit Tests
+          #        run: |
+          #          cd ${GITHUB_WORKSPACE}/build
+          #          echo Run ctest -V -L DFLY
+          #          GLOG_alsologtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 ctest -V -L DFLY
+          #
+          #          echo "Running tests with --force_epoll"
+          #
+          #          # Create a rule that automatically prints stacktrace upon segfault
+          #          cat > ./init.gdb <<EOF
+          #          catch signal SIGSEGV
+          #          command
+          #          bt
+          #          end
+          #          EOF
+          #
+          #          gdb -ix ./init.gdb --batch -ex r --args ./dragonfly_test --force_epoll
+          #          FLAGS_force_epoll=true GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 ctest -V -L DFLY
+          #
+          #          echo "Finished running tests with --force_epoll"
+          #
+          #          echo "Running tests with --cluster_mode=emulated"
+          #          FLAGS_cluster_mode=emulated ctest -V -L DFLY
+          #
+          #          echo "Running tests with both --cluster_mode=emulated & --lock_on_hashtags"
+          #          FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true ctest -V -L DFLY
+          #
+          #          ./dragonfly_test
+          #          ./multi_test --multi_exec_mode=1
+          #          ./multi_test --multi_exec_mode=3
+          #          ./json_family_test --jsonpathv2=false
+          #
+          #- name: Upload unit logs on failure
+          #  if: failure()
+          #  uses: actions/upload-artifact@v4
+          #  with:
+          #    name: unit_logs
+          #    path: /tmp/*INFO*
 
       - name: Run regression tests
         if: matrix.container == 'ubuntu-dev:20'

--- a/tests/dragonfly/acl_family_test.py
+++ b/tests/dragonfly/acl_family_test.py
@@ -11,6 +11,7 @@ from . import dfly_args
 
 @pytest.mark.asyncio
 async def test_acl_setuser(async_client):
+    assert False
     await async_client.execute_command("ACL SETUSER kostas")
     result = await async_client.execute_command("ACL list")
     assert 2 == len(result)

--- a/tests/dragonfly/acl_family_test.py
+++ b/tests/dragonfly/acl_family_test.py
@@ -11,7 +11,6 @@ from . import dfly_args
 
 @pytest.mark.asyncio
 async def test_acl_setuser(async_client):
-    assert False
     await async_client.execute_command("ACL SETUSER kostas")
     result = await async_client.execute_command("ACL list")
     assert 2 == len(result)

--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -30,6 +30,7 @@ logging.getLogger("asyncio").setLevel(logging.WARNING)
 DATABASE_INDEX = 0
 BASE_LOG_DIR = "/tmp/dragonfly_logs/"
 FAILED_PATH = "/tmp/failed/"
+LAST_LOGS = "/tmp/last_test_log_dir.txt"
 
 
 # runs on pytest start
@@ -56,7 +57,7 @@ def pytest_runtest_setup(item):
     item.log_dir = test_dir
 
     # needs for action.yml to get logs if timedout is happen for test
-    last_logs = open("/tmp/last_test_log_dir.txt", "w")
+    last_logs = open(LAST_LOGS, "w")
     last_logs.write(test_dir)
     last_logs.close()
 
@@ -377,6 +378,11 @@ def copy_failed_logs(log_dir, report):
             file = file.rstrip("\n")
             logging.error(f"🪵🪵🪵🪵🪵🪵 {file} 🪵🪵🪵🪵🪵🪵")
             shutil.copy(file, test_failed_path)
+
+    # Clean up so we don't get LOGS twice for failed tests
+    last_logs = open(LAST_LOGS, "w")
+    last_logs.write(test_dir)
+    last_logs.close()
 
 
 # tests results we get on the "call" state

--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -380,8 +380,7 @@ def copy_failed_logs(log_dir, report):
             shutil.copy(file, test_failed_path)
 
     # Clean up
-    last_logs = open(LAST_LOGS, "w")
-    last_logs.close()
+    os.remove(LAST_LOGS)
 
 
 # tests results we get on the "call" state

--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -379,9 +379,8 @@ def copy_failed_logs(log_dir, report):
             logging.error(f"🪵🪵🪵🪵🪵🪵 {file} 🪵🪵🪵🪵🪵🪵")
             shutil.copy(file, test_failed_path)
 
-    # Clean up so we don't get LOGS twice for failed tests
+    # Clean up
     last_logs = open(LAST_LOGS, "w")
-    last_logs.write(test_dir)
     last_logs.close()
 
 


### PR DESCRIPTION
Resolve #3424

The `env` variables exported when regression tests timeout are not working properly and the `if statement` on the action step `Print last log on timeout` would fail to read and upload the files set in `/tmp/last_log_file.txt`. Furthermore, another problem is the `job.timeout` argument that kills the whole job/matrix before the upload log step has a chance to run. For that, we need manual `timeouts` on the workflow similar to what we do in `regression tests action`. 

The fixes are simple:

* remove print last log on timeout action step
* copy the logs on timeout directly within the timeout step
* replace global timeout on CI workflow with timeout command per step

see also:
https://graphite.dev/guides/github-actions-timeouts#3-waiting-for-user-input-or-external-events