### PR TITLE
fix: pytest teardown exception in os.remove(LAST_LOGS)

### DIFF
--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -380,7 +380,10 @@ def copy_failed_logs(log_dir, report):
             shutil.copy(file, test_failed_path)
 
     # Clean up
-    os.remove(LAST_LOGS)
+    try:
+        os.remove(LAST_LOGS)
+    except OSError:
+        pass
 
 
 # tests results we get on the "call" state


### PR DESCRIPTION
os.remove(LAST_LOGS) might throw an exception if the file does not exist which we do not handle. Wrap it in try/catch block

see issue in: https://github.com/dragonflydb/dragonfly/actions/runs/10273843815/job/28429259846#step:6:373

```
INTERNALERROR>     os.remove(LAST_LOGS)
INTERNALERROR> FileNotFoundError: [Errno 2] No such file or directory: '/tmp/last_test_log_dir.txt'
```

* wrap in try/catch os.remove