### PR TITLE
feat: Allow pre-declaring Lua SHAs to run with undeclared keys

### DIFF
--- a/src/server/script_mgr.cc
+++ b/src/server/script_mgr.cc
@@ -38,6 +38,9 @@ ABSL_FLAG(bool, lua_allow_undeclared_auto_correct, false,
           "access undeclared keys, automaticaly set the script flag to be able to run with "
           "undeclared key.");
 
+ABSL_FLAG(std::vector<std::string>, lua_undeclared_keys_shas, {},
+          "Comma-separated list of Lua script SHAs which are allowed to access undeclared keys.");
+
 namespace dfly {
 using namespace std;
 using namespace facade;
@@ -261,6 +264,11 @@ io::Result<string, GenericError> ScriptMgr::Insert(string_view body, Interpreter
   if (!params_opt)
     return params_opt.get_unexpected();
   auto params = params_opt->value_or(default_params_);
+
+  auto undeclared_shas = absl::GetFlag(FLAGS_lua_undeclared_keys_shas);
+  if (find(undeclared_shas.begin(), undeclared_shas.end(), sha) != undeclared_shas.end()) {
+    params.undeclared_keys = true;
+  }
 
   // If the script is atomic, check for possible squashing optimizations.
   // For non atomic modes, squashing increases the time locks are held, which

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -824,6 +824,7 @@ void ServerFamily::Init(util::AcceptServer* acceptor, std::vector<facade::Listen
   config_registry.RegisterMutable("tls_ca_cert_file");
   config_registry.RegisterMutable("tls_ca_cert_dir");
   config_registry.RegisterMutable("replica_priority");
+  config_registry.RegisterMutable("lua_undeclared_keys_shas");
 
   pb_task_ = shard_set->pool()->GetNextProactor();
   if (pb_task_->GetKind() == ProactorBase::EPOLL) {


### PR DESCRIPTION
By using `--lua_undeclared_keys_shas=SHA,SHA,SHA` users can now specify which scripts should run globally (undeclared keys) without explicit support from the scripts themselves.

Fixes #2442

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->