### PR TITLE
chore: relax the version check in test_replicate_old_master

### DIFF
--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2318,7 +2318,7 @@ async def test_replicate_old_master(
         f"df-{dfly_version}"
         == (await c_master.execute_command("info", "server"))["dragonfly_version"]
     )
-    assert "df-dev" == (await c_replica.execute_command("info", "server"))["dragonfly_version"]
+    assert dfly_version != (await c_replica.execute_command("info", "server"))["dragonfly_version"]
 
     await c_master.execute_command("set", "k1", "v1")
 


### PR DESCRIPTION
For commits marked with a git tag, the previous check did not hold.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->