### PR TITLE
fix: flake in teardown of test_unknown_dfly_env

### DIFF
--- a/tests/dragonfly/generic_test.py
+++ b/tests/dragonfly/generic_test.py
@@ -100,12 +100,10 @@ async def test_arg_from_environ(df_factory):
 
 async def test_unknown_dfly_env(df_factory, export_dfly_password):
     with EnvironCntx(DFLY_abcdef="xyz"):
-        try:
-            dfly = df_factory.create()
+        dfly = df_factory.create()
+        with pytest.raises(DflyStartException):
             dfly.start()
-            assert False
-        except DflyStartException:
-            df_factory.set_skip_stop()
+        dfly.set_proc_to_none()
 
 
 async def test_restricted_commands(df_factory):

--- a/tests/dragonfly/generic_test.py
+++ b/tests/dragonfly/generic_test.py
@@ -101,7 +101,7 @@ async def test_arg_from_environ(df_factory):
 async def test_unknown_dfly_env(df_factory, export_dfly_password):
     with EnvironCntx(DFLY_abcdef="xyz"):
         with pytest.raises(DflyStartException):
-            dfly = df_factory.create()
+            dfly = df_factory.create(skip_stop=True)
             dfly.start()
 
 

--- a/tests/dragonfly/generic_test.py
+++ b/tests/dragonfly/generic_test.py
@@ -100,9 +100,12 @@ async def test_arg_from_environ(df_factory):
 
 async def test_unknown_dfly_env(df_factory, export_dfly_password):
     with EnvironCntx(DFLY_abcdef="xyz"):
-        with pytest.raises(DflyStartException):
-            dfly = df_factory.create(skip_stop=True)
+        try:
+            dfly = df_factory.create()
             dfly.start()
+            assert False
+        except DflyStartException:
+            df_factory.set_skip_stop()
 
 
 async def test_restricted_commands(df_factory):

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -334,7 +334,7 @@ class DflyInstanceFactory:
         self.params = params
         self.instances = []
 
-    def create(self, existing_port=None, path=None, **kwargs) -> DflyInstance:
+    def create(self, existing_port=None, path=None, skip_stop=False, **kwargs) -> DflyInstance:
         args = {**self.args, **kwargs}
         args.setdefault("dbfilename", "")
         args.setdefault("noversion_check", None)
@@ -358,6 +358,7 @@ class DflyInstanceFactory:
 
         instance = DflyInstance(params, args)
         self.instances.append(instance)
+        self.skip_stop = skip_stop
         return instance
 
     def start_all(self, instances: List[DflyInstance]):
@@ -370,6 +371,9 @@ class DflyInstanceFactory:
 
     def stop_all(self):
         """Stop all launched instances."""
+        if self.skip_stop == True:
+            return
+
         for instance in self.instances:
             instance.stop()
 

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -155,6 +155,9 @@ class DflyInstance:
             sed_cmd.remove("-u")
         subprocess.Popen(sed_cmd, stdin=self.proc.stdout)
 
+    def set_proc_to_none(self):
+        self.proc = None
+
     def stop(self, kill=False):
         proc, self.proc = self.proc, None
         if proc is None:
@@ -358,7 +361,6 @@ class DflyInstanceFactory:
 
         instance = DflyInstance(params, args)
         self.instances.append(instance)
-        self.skip_stop = False
         return instance
 
     def start_all(self, instances: List[DflyInstance]):
@@ -371,14 +373,8 @@ class DflyInstanceFactory:
 
     def stop_all(self):
         """Stop all launched instances."""
-        if self.skip_stop:
-            return
-
         for instance in self.instances:
             instance.stop()
-
-    def set_skip_stop(self):
-        self.skip_stop = True
 
     def __repr__(self) -> str:
         return f"Factory({self.args})"

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -334,7 +334,7 @@ class DflyInstanceFactory:
         self.params = params
         self.instances = []
 
-    def create(self, existing_port=None, path=None, skip_stop=False, **kwargs) -> DflyInstance:
+    def create(self, existing_port=None, path=None, **kwargs) -> DflyInstance:
         args = {**self.args, **kwargs}
         args.setdefault("dbfilename", "")
         args.setdefault("noversion_check", None)
@@ -358,7 +358,7 @@ class DflyInstanceFactory:
 
         instance = DflyInstance(params, args)
         self.instances.append(instance)
-        self.skip_stop = skip_stop
+        self.skip_stop = False
         return instance
 
     def start_all(self, instances: List[DflyInstance]):
@@ -371,11 +371,14 @@ class DflyInstanceFactory:
 
     def stop_all(self):
         """Stop all launched instances."""
-        if self.skip_stop == True:
+        if self.skip_stop:
             return
 
         for instance in self.instances:
             instance.stop()
+
+    def set_skip_stop(self):
+        self.skip_stop = True
 
     def __repr__(self) -> str:
         return f"Factory({self.args})"


### PR DESCRIPTION
For reasons I do not exactly comprehend, `test_unknown_dfly_env` might fail when we try to `stop the instance`. The thing is, that dragonfly is already killed since we try to launch an instance with an invalid environment flag and `stop_all` should not actually have any effect. Since the error happens at teardown and when we call `stop_all` it makes sense to `skip it` since the instance is not alive in the first place. The fix is simple, allow skipping `stop_all` at instance teardown.

fixes #3314

* allow to skip stop_all on DflyInstanceFactory