### PR TITLE
fix: sanitizers post failure on google chat

### DIFF
--- a/.github/workflows/daily-sanitizers.yml
+++ b/.github/workflows/daily-sanitizers.yml
@@ -86,11 +86,11 @@ jobs:
             ctest -V -L DFLY
 
       - name: Send notifications on failure
-        #todo add only for main here
-        if: failure()
+        if: failure() && github.ref == 'refs/heads/main'
+        shell: bash
         run: |
           job_link="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          message="Benchmark tests failed.\\n Job Link: ${job_link}\\n"
+          message="Daily sanitizers failed.\\n Job Link: ${job_link}\\n"
 
           curl -s \
             -X POST \

--- a/.github/workflows/daily-sanitizers.yml
+++ b/.github/workflows/daily-sanitizers.yml
@@ -86,13 +86,14 @@ jobs:
             ctest -V -L DFLY
 
       - name: Send notifications on failure
+        #todo add only for main here
         if: failure()
         run: |
           job_link="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          message="Daily sanitizers failed.\\n The commit is: ${{github.sha}}.\\n Job Link: ${job_link}\\n"
+          message="Benchmark tests failed.\\n Job Link: ${job_link}\\n"
 
           curl -s \
             -X POST \
             -H 'Content-Type: application/json' \
-            '${{ inputs.gspace-secret }}' \
+            '${{ secrets.GSPACES_BOT_DF_BUILD }}' \
             -d '{"text": "'"${message}"'"}'


### PR DESCRIPTION
The problem is that we do not properly post sanitizer failures on github and I always got notified via email instead.

* fix sanitizers failure post on google chat
* only report failures on main branch