### PR TITLE
fix: test_replicate_old_master missing serialization_max_chunk_size

### DIFF
--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -326,6 +326,9 @@ class DflyInstance:
         mem_info = process.memory_info()
         return mem_info.rss
 
+    def clear_max_chunk_flag(self):
+        del self.args["serialization_max_chunk_size"]
+
 
 class DflyInstanceFactory:
     """

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2316,6 +2316,7 @@ async def test_replicate_old_master(
     dfly_version = "v1.19.2"
     released_dfly_path = download_dragonfly_release(dfly_version)
     master = df_factory.create(path=released_dfly_path, cluster_mode=cluster_mode)
+    master.clear_max_chunk_flag()
     replica = df_factory.create(
         cluster_mode=cluster_mode, announce_ip=announce_ip, announce_port=announce_port
     )


### PR DESCRIPTION
The problem is that the test is using an older version of the master and the flag is not available.

* add a method in DflyInstance to remove this flag for this test