### PR TITLE
fix: missing virtual destructors in ReplyBuilder2

### DIFF
--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -182,6 +182,8 @@ class SinkReplyBuilder2 {
   explicit SinkReplyBuilder2(io::Sink* sink) : sink_(sink) {
   }
 
+  virtual ~SinkReplyBuilder2() = default;
+
   // USE WITH CARE! ReplyScope assumes that all string views in Send calls keep valid for the scopes
   // lifetime. This allows the builder to avoid copies by enqueueing long strings directly for
   // vectorized io.
@@ -318,6 +320,8 @@ class MCReplyBuilder2 : public SinkReplyBuilder2 {
  public:
   explicit MCReplyBuilder2(::io::Sink* sink);
 
+  ~MCReplyBuilder2() override = default;
+
   void SendError(std::string_view str, std::string_view type = std::string_view{}) final;
 
   void SendStored() final;
@@ -407,6 +411,8 @@ class RedisReplyBuilder2Base : public SinkReplyBuilder2 {
   explicit RedisReplyBuilder2Base(io::Sink* sink) : SinkReplyBuilder2(sink) {
   }
 
+  ~RedisReplyBuilder2Base() override = default;
+
   virtual void SendNull();
   void SendSimpleString(std::string_view str) override;
   virtual void SendBulkString(std::string_view str);  // RESP: Blob String
@@ -443,6 +449,8 @@ class RedisReplyBuilder2 : public RedisReplyBuilder2Base {
  public:
   RedisReplyBuilder2(io::Sink* sink) : RedisReplyBuilder2Base(sink) {
   }
+
+  ~RedisReplyBuilder2() override = default;
 
   void SendSimpleStrArr(const facade::ArgRange& strs);
   void SendBulkStrArr(const facade::ArgRange& strs, CollectionType ct = ARRAY);


### PR DESCRIPTION
`ReplyBuilder2` family contain `public virtual functions` and therefore it was missing the `virtual destructors`. 

* add virtual destructors to ReplyBuilder2 family 