### PR TITLE
chore: introduce a secondary TaskQueue for shards

### DIFF
--- a/src/core/task_queue.cc
+++ b/src/core/task_queue.cc
@@ -4,8 +4,35 @@
 
 #include "core/task_queue.h"
 
+#include <absl/strings/str_cat.h>
+
+#include "base/logging.h"
+
+using namespace std;
 namespace dfly {
 
 __thread unsigned TaskQueue::blocked_submitters_ = 0;
+
+TaskQueue::TaskQueue(unsigned queue_size, unsigned start_size, unsigned pool_max_size)
+    : queue_(queue_size), consumer_fibers_(start_size), pool_max_size_(pool_max_size) {
+  CHECK_GT(start_size, 0u);
+  CHECK_LE(start_size, pool_max_size);
+}
+
+void TaskQueue::Start(std::string_view base_name) {
+  for (size_t i = 0; i < consumer_fibers_.size(); ++i) {
+    auto& fb = consumer_fibers_[i];
+    CHECK(!fb.IsJoinable());
+
+    string name = absl::StrCat(base_name, "/", i);
+    fb = util::fb2::Fiber(name, [this] { queue_.Run(); });
+  }
+}
+
+void TaskQueue::Shutdown() {
+  queue_.Shutdown();
+  for (auto& fb : consumer_fibers_)
+    fb.JoinIfNeeded();
+}
 
 }  // namespace dfly

--- a/src/server/engine_shard.h
+++ b/src/server/engine_shard.h
@@ -68,6 +68,10 @@ class EngineShard {
     return &queue_;
   }
 
+  TaskQueue* GetSecondaryQueue() {
+    return &queue2_;
+  }
+
   // Processes TxQueue, blocked transactions or any other execution state related to that
   // shard. Tries executing the passed transaction if possible (does not guarantee though).
   void PollExecution(const char* context, Transaction* trans);
@@ -223,7 +227,7 @@ class EngineShard {
   // return true if we did not complete the shard scan
   bool DoDefrag();
 
-  TaskQueue queue_;
+  TaskQueue queue_, queue2_;
 
   TxQueue txq_;
   MiMemoryResource mi_resource_;


### PR DESCRIPTION
Also allow the TaskQueue to support multiple consumer fibers.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->