### PR TITLE
fix: skip empty objects on load and replication

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -574,6 +574,12 @@ size_t CompactObj::Size() const {
       case ROBJ_TAG:
         raw_size = u_.r_obj.Size();
         break;
+      case JSON_TAG:
+        raw_size = u_.json_obj.json_len;
+        break;
+      case SBF_TAG:
+        raw_size = u_.sbf->current_size();
+        break;
       default:
         LOG(DFATAL) << "Should not reach " << int(taglen_);
     }
@@ -684,9 +690,11 @@ void CompactObj::SetJson(JsonType&& j) {
   if (taglen_ == JSON_TAG && u_.json_obj.encoding == kEncodingJsonCons) {
     // already json
     DCHECK(u_.json_obj.json_ptr != nullptr);  // must be allocated
+    u_.json_obj.json_len = j.size();
     u_.json_obj.json_ptr->swap(j);
   } else {
     SetMeta(JSON_TAG);
+    u_.json_obj.json_len = j.size();
     u_.json_obj.json_ptr = AllocateMR<JsonType>(std::move(j));
     u_.json_obj.encoding = kEncodingJsonCons;
   }

--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -850,6 +850,11 @@ bool CompactObj::HasAllocated() const {
   return true;
 }
 
+bool CompactObj::TagAllowsEmptyValue() const {
+  const auto type = ObjType();
+  return type == OBJ_JSON || type == OBJ_STREAM;
+}
+
 void __attribute__((noinline)) CompactObj::GetString(string* res) const {
   res->resize(Size());
   GetString(res->data());

--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -852,7 +852,7 @@ bool CompactObj::HasAllocated() const {
 
 bool CompactObj::TagAllowsEmptyValue() const {
   const auto type = ObjType();
-  return type == OBJ_JSON || type == OBJ_STREAM;
+  return type == OBJ_JSON || type == OBJ_STREAM || type == OBJ_STRING || type == OBJ_SBF;
 }
 
 void __attribute__((noinline)) CompactObj::GetString(string* res) const {

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -398,9 +398,7 @@ class CompactObj {
 
   bool HasAllocated() const;
 
-  bool HasJsonOrInlineTag() const {
-    return taglen_ <= 6 || taglen_ == JSON_TAG;
-  }
+  bool TagAllowsEmptyValue() const;
 
   uint8_t Tag() const {
     return taglen_;

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -398,6 +398,14 @@ class CompactObj {
 
   bool HasAllocated() const;
 
+  bool HasJsonOrInlineTag() const {
+    return taglen_ <= 6 || taglen_ == JSON_TAG;
+  }
+
+  uint8_t Tag() const {
+    return taglen_;
+  }
+
  private:
   void EncodeString(std::string_view str);
   size_t DecodedLen(size_t sz) const;

--- a/src/server/container_utils.cc
+++ b/src/server/container_utils.cc
@@ -34,7 +34,7 @@ struct ShardFFResult {
 
 // Returns (iterator, args-index) if found, KEY_NOTFOUND otherwise.
 // If multiple keys are found, returns the first index in the ArgSlice.
-OpResult<std::pair<DbSlice::ConstIterator, unsigned>> FindFirstReadOnly(const DbSlice& db_slice,
+OpResult<std::pair<DbSlice::ConstIterator, unsigned>> FindFirstReadOnly(DbSlice& db_slice,
                                                                         const DbContext& cntx,
                                                                         const ShardArgs& args,
                                                                         int req_obj_type) {

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -433,10 +433,16 @@ DbSlice::ItAndExpConst DbSlice::FindReadOnly(const Context& cntx, std::string_vi
 }
 
 OpResult<DbSlice::ConstIterator> DbSlice::FindReadOnly(const Context& cntx, string_view key,
-                                                       unsigned req_obj_type) const {
+                                                       unsigned req_obj_type) {
   auto res = FindInternal(cntx, key, req_obj_type, UpdateStatsMode::kReadStats);
   if (res.ok()) {
-    return ConstIterator(res->it, StringOrView::FromView(key));
+    auto it = ConstIterator(res->it, StringOrView::FromView(key));
+    //    if(!it->second.HasJsonTag() && it->second.Size() == 0) {
+    //      LOG(ERROR) << "Found empty key: " << key << " with obj type " << req_obj_type;
+    //      Del(cntx, FindMutable(cntx, key).it);
+    //      return OpStatus::KEY_NOTFOUND;
+    //    }
+    return it;
   }
   return res.status();
 }

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -447,8 +447,7 @@ OpResult<DbSlice::ConstIterator> DbSlice::FindReadOnly(const Context& cntx, stri
                                                        unsigned req_obj_type) {
   auto res = FindInternal(cntx, key, req_obj_type, UpdateStatsMode::kReadStats);
   if (res.ok()) {
-    auto it = ConstIterator(res->it, StringOrView::FromView(key));
-    return it;
+    return ConstIterator(res->it, StringOrView::FromView(key));
   }
   return res.status();
 }
@@ -549,9 +548,9 @@ OpResult<DbSlice::PrimeItAndExp> DbSlice::FindInternal(const Context& cntx, std:
   // We do not use TopKey feature, so disable it until we redesign it.
   // db.top_keys.Touch(key);
 
-  if (DelEmptyPrimeValue(cntx, Iterator(res.it, StringOrView::FromView(key)))) {
-    return OpStatus::KEY_NOTFOUND;
-  }
+  // if (DelEmptyPrimeValue(cntx, Iterator(res.it, StringOrView::FromView(key)))) {
+  //   return OpStatus::KEY_NOTFOUND;
+  // }
   return res;
 }
 

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -548,9 +548,9 @@ OpResult<DbSlice::PrimeItAndExp> DbSlice::FindInternal(const Context& cntx, std:
   // We do not use TopKey feature, so disable it until we redesign it.
   // db.top_keys.Touch(key);
 
-  // if (DelEmptyPrimeValue(cntx, Iterator(res.it, StringOrView::FromView(key)))) {
-  //   return OpStatus::KEY_NOTFOUND;
-  // }
+  if (DelEmptyPrimeValue(cntx, Iterator(res.it, StringOrView::FromView(key)))) {
+    return OpStatus::KEY_NOTFOUND;
+  }
   return res;
 }
 

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -292,7 +292,7 @@ class DbSlice {
     ExpConstIterator exp_it;
   };
 
-  ItAndExpConst FindReadOnly(const Context& cntx, std::string_view key) const;
+  ItAndExpConst FindReadOnly(const Context& cntx, std::string_view key);
   OpResult<ConstIterator> FindReadOnly(const Context& cntx, std::string_view key,
                                        unsigned req_obj_type);
 
@@ -515,6 +515,8 @@ class DbSlice {
   void PreUpdate(DbIndex db_ind, Iterator it, std::string_view key);
   void PostUpdate(DbIndex db_ind, Iterator it, std::string_view key, size_t orig_size);
 
+  bool DelEmptyPrimeValue(const Context& cntx, Iterator it);
+
   OpResult<AddOrFindResult> AddOrUpdateInternal(const Context& cntx, std::string_view key,
                                                 PrimeValue obj, uint64_t expire_at_ms,
                                                 bool force_update);
@@ -555,7 +557,7 @@ class DbSlice {
 
   OpResult<PrimeItAndExp> FindInternal(const Context& cntx, std::string_view key,
                                        std::optional<unsigned> req_obj_type,
-                                       UpdateStatsMode stats_mode) const;
+                                       UpdateStatsMode stats_mode);
   OpResult<ItAndUpdater> FindMutableInternal(const Context& cntx, std::string_view key,
                                              std::optional<unsigned> req_obj_type);
 

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -294,7 +294,7 @@ class DbSlice {
 
   ItAndExpConst FindReadOnly(const Context& cntx, std::string_view key) const;
   OpResult<ConstIterator> FindReadOnly(const Context& cntx, std::string_view key,
-                                       unsigned req_obj_type) const;
+                                       unsigned req_obj_type);
 
   struct AddOrFindResult {
     Iterator it;

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2467,8 +2467,9 @@ void RdbLoader::LoadItemsBuffer(DbIndex db_ind, const ItemsBuf& ib) {
       stop_early_ = true;
       break;
     }
-    if (pv.Size() == 0) {
-      LOG(ERROR) << "Found empty key: " << item->key << " in DB " << db_ind;
+    if (!pv.TagAllowsEmptyValue() && pv.Size() == 0) {
+      LOG(ERROR) << "Found empty key: " << item->key << " in DB " << db_ind << " rdb_type "
+                 << item->val.rdb_type;
       continue;
     }
 

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2463,6 +2463,10 @@ void RdbLoader::LoadItemsBuffer(DbIndex db_ind, const ItemsBuf& ib) {
   for (const auto* item : ib) {
     PrimeValue pv;
     if (ec_ = FromOpaque(item->val, &pv); ec_) {
+      if (ec_ == rdb::errc::empty_key) {
+        LOG(WARNING) << "Found empty key: " << item->key << " in DB " << db_ind;
+        continue;
+      }
       LOG(ERROR) << "Could not load value for key '" << item->key << "' in DB " << db_ind;
       stop_early_ = true;
       break;

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2472,6 +2472,12 @@ void RdbLoader::LoadItemsBuffer(DbIndex db_ind, const ItemsBuf& ib) {
       stop_early_ = true;
       break;
     }
+    // We need this extra check because we don't return empty_key
+    if (!pv.TagAllowsEmptyValue() && pv.Size() == 0) {
+      LOG(ERROR) << "Found empty key: " << item->key << " in DB " << db_ind << " rdb_type "
+                 << item->val.rdb_type;
+      continue;
+    }
 
     if (item->expire_ms > 0 && db_cntx.time_now_ms >= item->expire_ms)
       continue;

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2463,14 +2463,14 @@ void RdbLoader::LoadItemsBuffer(DbIndex db_ind, const ItemsBuf& ib) {
   for (const auto* item : ib) {
     PrimeValue pv;
     if (ec_ = FromOpaque(item->val, &pv); ec_) {
+      if ((*ec_).value() == errc::empty_key) {
+        LOG(ERROR) << "Found empty key: " << item->key << " in DB " << db_ind << " rdb_type "
+                   << item->val.rdb_type;
+        continue;
+      }
       LOG(ERROR) << "Could not load value for key '" << item->key << "' in DB " << db_ind;
       stop_early_ = true;
       break;
-    }
-    if (!pv.TagAllowsEmptyValue() && pv.Size() == 0) {
-      LOG(ERROR) << "Found empty key: " << item->key << " in DB " << db_ind << " rdb_type "
-                 << item->val.rdb_type;
-      continue;
     }
 
     if (item->expire_ms > 0 && db_cntx.time_now_ms >= item->expire_ms)

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2463,13 +2463,13 @@ void RdbLoader::LoadItemsBuffer(DbIndex db_ind, const ItemsBuf& ib) {
   for (const auto* item : ib) {
     PrimeValue pv;
     if (ec_ = FromOpaque(item->val, &pv); ec_) {
-      if (ec_ == rdb::errc::empty_key) {
-        LOG(WARNING) << "Found empty key: " << item->key << " in DB " << db_ind;
-        continue;
-      }
       LOG(ERROR) << "Could not load value for key '" << item->key << "' in DB " << db_ind;
       stop_early_ = true;
       break;
+    }
+    if (pv.Size() == 0) {
+      LOG(ERROR) << "Found empty key: " << item->key << " in DB " << db_ind;
+      continue;
     }
 
     if (item->expire_ms > 0 && db_cntx.time_now_ms >= item->expire_ms)

--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -59,7 +59,7 @@ class RdbLoaderBase {
 
   struct OpaqueObj {
     RdbVariant obj;
-    int rdb_type;
+    int rdb_type{0};
   };
 
   struct LoadBlob {

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -337,6 +337,13 @@ error_code RdbSerializer::SelectDb(uint32_t dbid) {
 // Called by snapshot
 io::Result<uint8_t> RdbSerializer::SaveEntry(const PrimeKey& pk, const PrimeValue& pv,
                                              uint64_t expire_ms, DbIndex dbid) {
+  string_view key = pk.GetSlice(&tmp_str_);
+  // We skip empty entries of any PrimeValue
+  if (pv.Size() == 0) {
+    LOG(WARNING) << "SaveEntry skipped empty PrimeValue with key: " << key;
+    return 0;
+  }
+
   DVLOG(3) << "Selecting " << dbid << " previous: " << last_entry_db_index_;
   SelectDb(dbid);
 
@@ -357,7 +364,6 @@ io::Result<uint8_t> RdbSerializer::SaveEntry(const PrimeKey& pk, const PrimeValu
       return make_unexpected(ec);
   }
 
-  string_view key = pk.GetSlice(&tmp_str_);
   uint8_t rdb_type = RdbObjectType(pv);
 
   DVLOG(3) << ((void*)this) << ": Saving key/val start " << key << " in dbid=" << dbid;

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -337,12 +337,13 @@ error_code RdbSerializer::SelectDb(uint32_t dbid) {
 // Called by snapshot
 io::Result<uint8_t> RdbSerializer::SaveEntry(const PrimeKey& pk, const PrimeValue& pv,
                                              uint64_t expire_ms, DbIndex dbid) {
-  string_view key = pk.GetSlice(&tmp_str_);
   // We skip empty entries of any PrimeValue
-  if (pv.Size() == 0) {
-    LOG(WARNING) << "SaveEntry skipped empty PrimeValue with key: " << key;
-    return 0;
-  }
+  //  if (!pv.HasJsonTag() && pv.Size() == 0) {
+  //    string_view key = pk.GetSlice(&tmp_str_);
+  //    LOG(ERROR) << "SaveEntry skipped empty PrimeValue with key: " << key << " with tag "
+  //            << pv.Tag();
+  //    return 0;
+  //  }
 
   DVLOG(3) << "Selecting " << dbid << " previous: " << last_entry_db_index_;
   SelectDb(dbid);
@@ -366,6 +367,7 @@ io::Result<uint8_t> RdbSerializer::SaveEntry(const PrimeKey& pk, const PrimeValu
 
   uint8_t rdb_type = RdbObjectType(pv);
 
+  string_view key = pk.GetSlice(&tmp_str_);
   DVLOG(3) << ((void*)this) << ": Saving key/val start " << key << " in dbid=" << dbid;
 
   if (auto ec = WriteOpcode(rdb_type); ec)

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -337,13 +337,12 @@ error_code RdbSerializer::SelectDb(uint32_t dbid) {
 // Called by snapshot
 io::Result<uint8_t> RdbSerializer::SaveEntry(const PrimeKey& pk, const PrimeValue& pv,
                                              uint64_t expire_ms, DbIndex dbid) {
-  // We skip empty entries of any PrimeValue
-  //  if (!pv.HasJsonTag() && pv.Size() == 0) {
-  //    string_view key = pk.GetSlice(&tmp_str_);
-  //    LOG(ERROR) << "SaveEntry skipped empty PrimeValue with key: " << key << " with tag "
-  //            << pv.Tag();
-  //    return 0;
-  //  }
+  if (!pv.TagAllowsEmptyValue() && pv.Size() == 0) {
+    string_view key = pk.GetSlice(&tmp_str_);
+    LOG(ERROR) << "SaveEntry skipped empty PrimeValue with key: " << key << " with tag "
+               << pv.Tag();
+    return 0;
+  }
 
   DVLOG(3) << "Selecting " << dbid << " previous: " << last_entry_db_index_;
   SelectDb(dbid);

--- a/tests/dragonfly/hash_family_test.py
+++ b/tests/dragonfly/hash_family_test.py
@@ -1,0 +1,21 @@
+import pytest
+import asyncio
+from .utility import *
+
+
+@pytest.mark.asyncio
+async def test_empty_hash_as_zipmap_bug(async_client):
+    await async_client.execute_command("HSET foo a_field a_value")
+    await async_client.execute_command("HSETEX foo 1 b_field b_value")
+    await async_client.execute_command("HDEL foo a_field")
+
+    await asyncio.sleep(2)
+
+    @assert_eventually
+    async def check_if_empty():
+        assert await async_client.execute_command("HGETALL foo") == []
+
+    await check_if_empty()
+
+    # Key does not exist and it's empty
+    assert await async_client.execute_command(f"EXISTS foo") == 0

--- a/tests/dragonfly/hash_family_test.py
+++ b/tests/dragonfly/hash_family_test.py
@@ -9,8 +9,6 @@ async def test_empty_hash_as_zipmap_bug(async_client):
     await async_client.execute_command("HSETEX foo 1 b_field b_value")
     await async_client.execute_command("HDEL foo a_field")
 
-    await asyncio.sleep(2)
-
     @assert_eventually
     async def check_if_empty():
         assert await async_client.execute_command("HGETALL foo") == []

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -349,7 +349,7 @@ class DflyInstanceFactory:
             # Add 1 byte limit for big values
             args.setdefault("serialization_max_chunk_size", 1)
 
-        if version >= 1.21:
+        if version > 1.21:
             args.setdefault("use_new_io")
 
         for k, v in args.items():

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2411,3 +2411,33 @@ async def test_replicate_old_master(
     assert await c_replica.execute_command("get", "k1") == "v1"
 
     await disconnect_clients(c_master, c_replica)
+
+
+@pytest.mark.asyncio
+async def test_empty_hash_as_zipmap_bug(df_factory: DflyInstanceFactory):
+    master = df_factory.create()
+    master.start()
+    replica = df_factory.create()
+    replica.start()
+
+    c_master = master.client()
+    await c_master.execute_command("HSET foo a_field a_value")
+    await c_master.execute_command("HSETEX foo 5 b_field b_value")
+    await c_master.execute_command("HDEL foo a_field")
+    async with async_timeout.timeout(15):
+        while True:
+            await asyncio.sleep(5)
+            res = await c_master.execute_command("HGETALL foo")
+            if res == []:
+                break
+
+    # Key exists and it's empty
+    assert await c_master.execute_command(f"EXISTS foo") == 1
+
+    c_replica = replica.client()
+    await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
+    await wait_for_replicas_state(c_replica)
+    # Key does not exist in replica because we skipped it
+    assert await c_replica.execute_command(f"EXISTS foo") == 0
+
+    await close_clients(c_master, c_replica)

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2422,14 +2422,14 @@ async def test_empty_hash_as_zipmap_bug(df_factory: DflyInstanceFactory):
 
     c_master = master.client()
     await c_master.execute_command("HSET foo a_field a_value")
-    await c_master.execute_command("HSETEX foo 5 b_field b_value")
+    await c_master.execute_command("HSETEX foo 1 b_field b_value")
     await c_master.execute_command("HDEL foo a_field")
-    async with async_timeout.timeout(15):
-        while True:
-            await asyncio.sleep(5)
-            res = await c_master.execute_command("HGETALL foo")
-            if res == []:
-                break
+
+    @assert_eventually
+    async def check_if_empty():
+        assert await c_master.execute_command("HGETALL foo") == []
+
+    await check_if_empty()
 
     # Key exists and it's empty
     assert await c_master.execute_command(f"EXISTS foo") == 1


### PR DESCRIPTION
fixes #3504

* skip empty objects in rdb save
* skip empty objects in rdb load
* delete empty keys in FindReadOnly