### PR TITLE
fix: bugs around the growth of a tiered file

### DIFF
--- a/src/core/extent_tree.cc
+++ b/src/core/extent_tree.cc
@@ -36,12 +36,13 @@ void ExtentTree::Add(size_t start, size_t len) {
       merged = true;
       len_extents_.erase(pair{prev->second - prev->first, prev->first});
 
-      if (end == it->first) {  // [first, end = it->first, it->second)
+      // check if we join: prev, [start, end), [it->first, it->second]
+      if (it != extents_.end() && end == it->first) {  // [first, end = it->first, it->second)
         prev->second = it->second;
         len_extents_.erase(pair{it->second - it->first, it->first});
         extents_.erase(it);
       } else {
-        prev->second = end;
+        prev->second = end;  // just extend prev
       }
       len_extents_.emplace(prev->second - prev->first, prev->first);
     }

--- a/src/core/extent_tree.h
+++ b/src/core/extent_tree.h
@@ -23,7 +23,7 @@ class ExtentTree {
   std::optional<std::pair<size_t, size_t>> GetRange(size_t len, size_t align);
 
  private:
-  absl::btree_map<size_t, size_t> extents_;                 // start -> end.
+  absl::btree_map<size_t, size_t> extents_;                 // start -> end).
   absl::btree_set<std::pair<size_t, size_t>> len_extents_;  // (length, start)
 };
 

--- a/src/core/extent_tree_test.cc
+++ b/src/core/extent_tree_test.cc
@@ -55,4 +55,12 @@ TEST_F(ExtentTreeTest, Basic) {
   EXPECT_THAT(*op, testing::Pair(60, 92));
 }
 
+TEST_F(ExtentTreeTest, Union) {
+  tree_.Add(0, 16);
+  tree_.Add(16, 16);
+  auto range = tree_.GetRange(32, 1);
+  ASSERT_TRUE(range);
+  EXPECT_THAT(*range, testing::Pair(0, 32));
+}
+
 }  // namespace dfly

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -413,7 +413,7 @@ bool TieredStorage::TryStash(DbIndex dbid, string_view key, PrimeValue* value) {
   }
 
   if (ec) {
-    LOG(ERROR) << "Stash failed immediately" << ec.message();
+    LOG_IF(ERROR, ec != errc::file_too_large) << "Stash failed immediately" << ec.message();
     visit([this](auto id) { op_manager_->ClearIoPending(id); }, id);
     return false;
   }

--- a/src/server/tiering/disk_storage.h
+++ b/src/server/tiering/disk_storage.h
@@ -48,12 +48,14 @@ class DiskStorage {
   Stats GetStats() const;
 
  private:
+  bool CanGrow() const;
+
   std::error_code Grow(off_t grow_size);
 
   // Returns a buffer with size greater or equal to len.
   util::fb2::UringBuf PrepareBuf(size_t len);
 
-  off_t size_, max_size_;
+  off_t max_size_;
   size_t pending_ops_ = 0;  // number of ongoing ops for safe shutdown
 
   // how many times we allocate registered/heap buffers.

--- a/src/server/tiering/external_alloc.cc
+++ b/src/server/tiering/external_alloc.cc
@@ -404,6 +404,8 @@ void ExternalAllocator::Free(size_t offset, size_t sz) {
 }
 
 void ExternalAllocator::AddStorage(size_t start, size_t size) {
+  VLOG(1) << "AddStorage " << start << "/" << size;
+
   extent_tree_.Add(start, size);
   capacity_ += size;
 }


### PR DESCRIPTION
1. Before - when 15% margin of total size becomes larger than 256MB, we increased the file by 256MB even though we still had unused 256MB. Now it's fixed.
2. We attempted to grow a file even if it reached the limit and then returned the error. It is wrong handle "reach the limit" state as an error - it's just a logical constraint, so now we do not attempt to grow and handle this quietly.
3. There was a segfault bug in extent tree in case the existing segment and the new one needs to be united.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->