### PR TITLE
fix: named volume permissions in docker

### DIFF
--- a/tools/docker/entrypoint.sh
+++ b/tools/docker/entrypoint.sh
@@ -11,12 +11,21 @@ set -e
 # first arg is `-some-option`
 if [ "${1#-}" != "$1" ]; then
     # override arguments by prepending "dragonfly --logtostderr" to them.
-	set -- dragonfly --logtostderr "$@"
+    set -- dragonfly --logtostderr "$@"
 fi
 
 # allow the docker container to be started with `--user`
 if [ "$1" = 'dragonfly' -a "$(id -u)" = '0' ]; then
-	exec su-exec dfly "$0" "$@"   # runs this script under user dfly
+    # find all the files in the WORKDIR including the dir itself that do not
+    # have dfly user on them and chmod them to dfly.
+    find . \! -user dfly -exec chown dfly '{}' +
+    # runs this script under user dfly
+    exec setpriv --reuid=dfly --regid=dfly --clear-groups -- "$0" "$@"
+fi
+
+um="$(umask)"
+if [ "$um" = '0022' ]; then
+    umask 0077  # restrict access permissions only to the owner
 fi
 
 exec "$@"

--- a/tools/packaging/Dockerfile.alpine-dev
+++ b/tools/packaging/Dockerfile.alpine-dev
@@ -30,7 +30,7 @@ COPY tools/docker/healthcheck.sh /usr/local/bin/healthcheck.sh
 COPY --from=builder /build/build-release/dragonfly /usr/local/bin/
 
 RUN apk --no-cache add libgcc libstdc++  \
-     su-exec netcat-openbsd boost-context && ldd /usr/local/bin/dragonfly
+     setpriv netcat-openbsd boost-context && ldd /usr/local/bin/dragonfly
 
 RUN addgroup -S -g 1000 dfly && adduser -S -G dfly -u 999 dfly
 RUN mkdir /data && chown dfly:dfly /data
@@ -42,7 +42,5 @@ HEALTHCHECK CMD /usr/local/bin/healthcheck.sh
 ENTRYPOINT ["entrypoint.sh"]
 
 EXPOSE 6379
-
-USER dfly
 
 CMD ["dragonfly", "--logtostderr"]

--- a/tools/packaging/Dockerfile.ubuntu-dev
+++ b/tools/packaging/Dockerfile.ubuntu-dev
@@ -12,10 +12,7 @@ RUN make release
 
 RUN build-release/dragonfly --version
 
-RUN curl -O https://raw.githubusercontent.com/ncopa/su-exec/212b75144bbc06722fbd7661f651390dc47a43d1/su-exec.c && \
-    gcc -Wall -O2 su-exec.c -o su-exec
-
-FROM debian:12-slim
+FROM ubuntu:22.04
 
 RUN --mount=type=tmpfs,target=/var/cache/apt \
     --mount=type=tmpfs,target=/var/lib/apt/lists \
@@ -30,7 +27,6 @@ WORKDIR /data
 
 COPY tools/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY tools/docker/healthcheck.sh /usr/local/bin/healthcheck.sh
-COPY --from=builder /build/su-exec /usr/local/bin/
 COPY --from=builder /build/build-release/dragonfly /usr/local/bin/
 
 HEALTHCHECK CMD /usr/local/bin/healthcheck.sh
@@ -38,7 +34,5 @@ ENTRYPOINT ["entrypoint.sh"]
 
 # For inter-container communication.
 EXPOSE 6379
-
-USER dfly
 
 CMD ["dragonfly", "--logtostderr"]

--- a/tools/packaging/Dockerfile.ubuntu-prod
+++ b/tools/packaging/Dockerfile.ubuntu-prod
@@ -7,11 +7,6 @@ WORKDIR /build
 COPY tools/docker/fetch_release.sh /tmp/
 COPY releases/dragonfly-* /tmp/
 
-ARG SUEXEC_HASH=d6c40440609a23483f12eb6295b5191e94baf08298a856bab6e15b10c3b82891
-RUN curl -O https://raw.githubusercontent.com/ncopa/su-exec/212b75144bbc06722fbd7661f651390dc47a43d1/su-exec.c && \
-    if [ "$SUEXEC_HASH" != $(sha256sum su-exec.c | awk '{print $1}') ]; then echo "Wrong hash!" && exit 1; fi && \
-    gcc -Wall -O2 su-exec.c -o su-exec
-
 RUN /tmp/fetch_release.sh ${TARGETPLATFORM}
 
 # Now prod image
@@ -35,7 +30,6 @@ WORKDIR /data
 
 COPY tools/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY tools/docker/healthcheck.sh /usr/local/bin/healthcheck.sh
-COPY --from=builder /build/su-exec /usr/local/bin/
 COPY --from=builder /build/dragonfly /usr/local/bin/
 
 HEALTHCHECK CMD /usr/local/bin/healthcheck.sh
@@ -43,7 +37,5 @@ ENTRYPOINT ["entrypoint.sh"]
 
 # For inter-container communication.
 EXPOSE 6379
-
-USER dfly
 
 CMD ["dragonfly", "--logtostderr"]


### PR DESCRIPTION
Fixes #2917

The problem is described in this "working as intended" issue https://github.com/moby/moby/issues/3124 So the advised approach of using "USER dfly" directive does not really work because it requires that the host will also define 'dfly' user with the same id. It's unrealistic expectation.

Therefore, we revert the fix done in #1775 and follow valkey approach: https://github.com/valkey-io/valkey-container/blob/mainline/docker-entrypoint.sh#L12

1. we run the entrypoint in the container as root which later spawns the dragonfly process
2. if we run as root:
   a. we chmod files under /data to dfly.
   b. use setpriv to run ourselves as dfly.
3. if we do not run as root we execute the docker command.

So even though the process starts as root, the server runs as dfly and only the bootstrap part has elevated permissions is used to fix the volume access.

While we are at it, we also switched to setpriv following the change of https://github.com/valkey-io/valkey-container/pull/24/files

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->