### PR TITLE
fix: disable ThreadLocalMutex when big value ser is off

### DIFF
--- a/src/server/common.h
+++ b/src/server/common.h
@@ -371,9 +371,11 @@ class ThreadLocalMutex {
   void unlock();
 
  private:
+  const bool big_value_enabled_;
   EngineShard* shard_;
   util::fb2::CondVarAny cond_var_;
   bool flag_ = false;
+  util::fb2::detail::FiberInterface* locked_fiber_{nullptr};
 };
 
 }  // namespace dfly

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -371,11 +371,12 @@ class ThreadLocalMutex {
   void unlock();
 
  private:
-  const bool big_value_enabled_;
   EngineShard* shard_;
   util::fb2::CondVarAny cond_var_;
   bool flag_ = false;
   util::fb2::detail::FiberInterface* locked_fiber_{nullptr};
 };
+
+extern size_t serialization_max_chunk_size;
 
 }  // namespace dfly

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -99,9 +99,15 @@ ABSL_FLAG(dfly::MemoryBytesFlag, maxmemory, dfly::MemoryBytesFlag{},
           "Limit on maximum-memory that is used by the database. "
           "0 - means the program will automatically determine its maximum memory usage. "
           "default: 0");
+
 ABSL_FLAG(double, oom_deny_ratio, 1.1,
           "commands with flag denyoom will return OOM when the ratio between maxmemory and used "
           "memory is above this value");
+
+ABSL_FLAG(size_t, serialization_max_chunk_size, 0,
+          "Maximum size of a value that may be serialized at once during snapshotting or full "
+          "sync. Values bigger than this threshold will be serialized using streaming "
+          "serialization. 0 - to disable streaming mode");
 
 namespace dfly {
 
@@ -871,6 +877,7 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
   config_registry.RegisterMutable("dbfilename");
   config_registry.RegisterMutable("table_growth_margin");
 
+  serialization_max_chunk_size = GetFlag(FLAGS_serialization_max_chunk_size);
   uint32_t shard_num = GetFlag(FLAGS_num_shards);
   if (shard_num == 0 || shard_num > pp_.size()) {
     LOG_IF(WARNING, shard_num > pp_.size())

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -22,10 +22,6 @@
 #include "util/fibers/synchronization.h"
 
 using facade::operator""_MB;
-ABSL_FLAG(size_t, serialization_max_chunk_size, 0,
-          "Maximum size of a value that may be serialized at once during snapshotting or full "
-          "sync. Values bigger than this threshold will be serialized using streaming "
-          "serialization. 0 - to disable streaming mode");
 
 namespace dfly {
 
@@ -76,7 +72,7 @@ void SliceSnapshot::Start(bool stream_journal, const Cancellation* cll, Snapshot
     journal_cb_id_ = journal->RegisterOnChange(std::move(journal_cb));
   }
 
-  const auto flush_threshold = absl::GetFlag(FLAGS_serialization_max_chunk_size);
+  const auto flush_threshold = serialization_max_chunk_size;
   std::function<void(size_t, RdbSerializer::FlushState)> flush_fun;
   if (flush_threshold != 0 && allow_flush == SnapshotFlush::kAllow) {
     flush_fun = [this, flush_threshold](size_t bytes_serialized,


### PR DESCRIPTION
Disables ThreadLocalMutex altogether and add debug checks for big value set

* disable ThreadLocalMutex when big value ser is off
* add dcheck for debugging