### PR TITLE
fix: deadlock in Heartbeat()

### DIFF
--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -633,8 +633,10 @@ void EngineShard::Heartbeat() {
 void EngineShard::RetireExpiredAndEvict() {
   // TODO: iterate over all namespaces
   DbSlice& db_slice = namespaces.GetDefaultNamespace().GetDbSlice(shard_id());
-  // Some of the functions below might acquire the lock again so we need to unlock it
-  std::unique_lock lk(db_slice.GetSerializationMutex());
+  // Some of the functions below might acquire the same lock again so we need to unlock it
+  // asap. We won't yield before we relock the mutex again, so the code below is atomic
+  // in respect to preemptions.
+  { std::unique_lock lk(db_slice.GetSerializationMutex()); }
   constexpr double kTtlDeleteLimit = 200;
   constexpr double kRedLimitFactor = 0.1;
 
@@ -676,8 +678,6 @@ void EngineShard::RetireExpiredAndEvict() {
     }
   }
 
-  // Because TriggerOnJournalWriteToSink will lock the same lock leading to a deadlock.
-  lk.unlock();
   // Journal entries for expired entries are not writen to socket in the loop above.
   // Trigger write to socket when loop finishes.
   if (auto journal = EngineShard::tlocal()->journal(); journal) {


### PR DESCRIPTION
The problem is that we lock the same mutex `db_slice.GetSerializationMutex()` twice on the same fiber.

We first lock it in `RetireExpiredAndEvict()` and then eventually we write the expired items on the journal via (in the call path of `ExpireIfNeeded`) a call to `RecordExpired` which will apply the callbacks registered by the snapshot. These callbacks, acquire the same mutex:

```
  384 void SliceSnapshot::OnJournalEntry(const journal::JournalItem& item, bool await) {                 
  385   // To enable journal flushing to sync after non auto journal command is executed we call         
  386   // TriggerJournalWriteToSink. This call uses the NOOP opcode with await=true. Since there is no  
  387   // additional journal change to serialize, it simply invokes PushSerializedToChannel.            
  388   std::unique_lock lk(db_slice_->GetSerializationMutex());                                         
  389   if (item.opcode != journal::Op::NOOP) {                                                          
  390     serializer_->WriteJournalEntry(item.data);
  391   }  
  392 
```

Fixes #3472 and #3464

* acquire and immediately release db_slice.GetSerializationMutex() in Heartbeat()