### PR TITLE
fix: macos build

### DIFF
--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -15,6 +15,13 @@
 #include "facade/error.h"
 #include "util/fibers/proactor_base.h"
 
+#ifdef __APPLE__
+#ifndef IOV_MAX
+// Some versions of MacOSX dont have IOV_MAX
+#define IOV_MAX 1024
+#endif
+#endif
+
 using namespace std;
 using absl::StrAppend;
 using namespace double_conversion;

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -19,6 +19,7 @@
 #ifndef IOV_MAX
 // Some versions of MacOSX dont have IOV_MAX
 #define IOV_MAX 1024
+#define UIO_MAXIOV IOV_MAX
 #endif
 #endif
 

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -16,10 +16,9 @@
 #include "util/fibers/proactor_base.h"
 
 #ifdef __APPLE__
-#ifndef IOV_MAX
+#ifndef UIO_MAXIOV
 // Some versions of MacOSX dont have IOV_MAX
-#define IOV_MAX 1024
-#define UIO_MAXIOV IOV_MAX
+#define UIO_MAXIOV 1024
 #endif
 #endif
 


### PR DESCRIPTION
The problem that `IOV_MAX` is not defined on all versions of macos. I found this one in librdkafka which I trust: https://github.com/confluentinc/librdkafka/blob/master/src/rd.h#L210C1-L212C21

* define IOV_MAX on macos if it's not defined