### PR TITLE
fix(transaction): Don't set continuation for blocking

### DIFF
--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -494,9 +494,10 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
 
     // Commands like BRPOPLPUSH don't conclude immediately
     if (trans->RunInShard(this, false)) {
-      // execution is blocked while HasAwakedTransaction() returns true, so no need to set continuation_trans_. 
-     // Moreover, setting it for wakened multi-hop transactions may lead to inconcistency, see BLMove22 test.
-      // continuation continuation_trans_ = trans;
+      // execution is blocked while HasAwakedTransaction() returns true, so no need to set
+      // continuation_trans_. Moreover, setting it for wakened multi-hop transactions may lead to
+      // inconcistency, see BLMoveSimultaneously test.
+      // continuation_trans_ = trans;
       return;
     }
 

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -494,7 +494,8 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
 
     // Commands like BRPOPLPUSH don't conclude immediately
     if (trans->RunInShard(this, false)) {
-      // execution is blocked while the awakened set set is non-empty, so no need to set
+      // execution is blocked while HasAwakedTransaction() returns true, so no need to set continuation_trans_. 
+     // Moreover, setting it for wakened multi-hop transactions may lead to inconcistency, see BLMove22 test.
       // continuation continuation_trans_ = trans;
       return;
     }

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -486,6 +486,7 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
     return;
 
   if (trans_mask & Transaction::AWAKED_Q) {
+    DCHECK(trans->GetNamespace().GetBlockingController(shard_id_)->HasAwakedTransaction());
     CHECK(continuation_trans_ == nullptr || continuation_trans_ == trans)
         << continuation_trans_->DebugId() << " when polling " << trans->DebugId()
         << "cont_mask: " << continuation_trans_->DEBUG_GetLocalMask(sid) << " vs "
@@ -493,7 +494,8 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
 
     // Commands like BRPOPLPUSH don't conclude immediately
     if (trans->RunInShard(this, false)) {
-      continuation_trans_ = trans;
+      // execution is blocked while the awakened set set is non-empty, so no need to set
+      // continuation continuation_trans_ = trans;
       return;
     }
 

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -486,8 +486,8 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
     return;
 
   if (trans_mask & Transaction::AWAKED_Q) {
-    DCHECK(trans->GetNamespace().GetBlockingController(shard_id_)->HasAwakedTransaction());
-    CHECK(continuation_trans_ == nullptr || continuation_trans_ == trans)
+    CHECK(trans->GetNamespace().GetBlockingController(shard_id_)->HasAwakedTransaction());
+    CHECK(continuation_trans_ == nullptr)
         << continuation_trans_->DebugId() << " when polling " << trans->DebugId()
         << "cont_mask: " << continuation_trans_->DEBUG_GetLocalMask(sid) << " vs "
         << trans->DEBUG_GetLocalMask(sid);

--- a/src/server/list_family_test.cc
+++ b/src/server/list_family_test.cc
@@ -772,10 +772,10 @@ TEST_F(ListFamilyTest, BLMoveSimultaneously) {
             Shard("src1", shard_set->size()));  // Trigger MoveTwoShards
 
   auto f1 = pp_->at(1)->LaunchFiber([this]() {
-    Run({"blmove", "src1", "dest110", "LEFT", "RIGHT", "0"});
+    Run("c1", {"blmove", "src1", "dest110", "LEFT", "RIGHT", "0"});
   });
   auto f2 = pp_->at(1)->LaunchFiber([this]() {
-    Run({"blmove", "src10", "dest110", "LEFT", "RIGHT", "0"});
+    Run("c2", {"blmove", "src10", "dest110", "LEFT", "RIGHT", "0"});
   });
 
   ThisFiber::SleepFor(5ms);
@@ -797,7 +797,7 @@ TEST_F(ListFamilyTest, BLMoveRings) {
     auto key1 = to_string(i);
     auto key2 = to_string(i + 1);
     fibers.emplace_back(pp_->at(i % 3)->LaunchFiber([=]() {
-      Run({"blmove", key1, key2, "LEFT", "RIGHT", "0"});
+      Run(key1, {"blmove", key1, key2, "LEFT", "RIGHT", "0"});
     }));
   }
 


### PR DESCRIPTION
Cause: `Check failed: continuation_trans_ == nullptr || continuation_trans_ == trans BLMOVE@4135983/2 {id=33648} when polling BLMOVE@4135965/1 {id=50088}cont_mask: 41 vs 41`

Preconditions: 
* Two BLMOVE commands waiting for different keys on _the same shard_, for both of them the source and destination key are located on different shards, so they need _two hops_ to get the job done
* _A single_ MULTI/EXEC unblocking both of them

Flow:
* Both suspended BLMOVEs wake up and continue running PollExecution
* Because they are 2-hop commands, they try to set continuation_trans_ 
* The first one does so successfully, the second doesn't expect it to be set, so it fails on the check above

Fix:
* Don't set continuation_trans_ for awoken blocking commands that want to proceed with another hop
* Is it safe in regard to other commands? Yes, because we don't continue execution on the transaction queue while there are awakened transactions
* We remove ourselfs from the awakened transaction set only when we conclude
* We unlock the keys only when we conclude, so OOO is not possible (ooo doesn't check for awakened)

Follow up:
* Rethink and improve blocking flow in future code
