### PR TITLE
chore: allow limiting pipelining queue by length

### DIFF
--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -303,10 +303,15 @@ class Connection : public util::Connection {
 
   bool IsHttp() const;
 
+  // Sets max queue length locally in the calling thread.
+  static void SetMaxQueueLenThreadLocal(uint32_t val);
+
  protected:
   void OnShutdown() override;
   void OnPreMigrateThread() override;
   void OnPostMigrateThread() override;
+
+  std::unique_ptr<ConnectionContext> cc_;  // Null for http connections
 
  private:
   enum ParserStatus { OK, NEED_MORE, ERROR };
@@ -327,7 +332,7 @@ class Connection : public util::Connection {
 
     // Used by publisher/subscriber actors to make sure we do not publish too many messages
     // into the queue. Thread-safe to allow safe access in EnsureBelowLimit.
-    util::fb2::EventCount ec;
+    util::fb2::EventCount pubsub_ec;
     std::atomic_size_t subscriber_bytes = 0;
 
     // Used by pipelining/execution fiber to throttle the incoming pipeline messages.
@@ -339,7 +344,6 @@ class Connection : public util::Connection {
     size_t pipeline_buffer_limit = 0;  // cached flag for buffer size in bytes
   };
 
- private:
   // Check protocol and handle connection.
   void HandleRequests() final;
 
@@ -394,10 +398,6 @@ class Connection : public util::Connection {
 
   std::pair<std::string, std::string> GetClientInfoBeforeAfterTid() const;
 
- protected:
-  std::unique_ptr<ConnectionContext> cc_;  // Null for http connections
-
- private:
   void DecreaseStatsOnClose();
   void BreakOnce(uint32_t ev_mask);
 

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -320,30 +320,6 @@ class Connection : public util::Connection {
   struct DispatchCleanup;
   struct Shutdown;
 
-  // Keeps track of total per-thread sizes of dispatch queues to limit memory taken up by messages
-  // in these queues.
-  struct QueueBackpressure {
-    // Block until subscriber memory usage is below limit, can be called from any thread.
-    void EnsureBelowLimit();
-
-    bool IsPipelineBufferOverLimit(size_t size) const {
-      return size >= pipeline_buffer_limit;
-    }
-
-    // Used by publisher/subscriber actors to make sure we do not publish too many messages
-    // into the queue. Thread-safe to allow safe access in EnsureBelowLimit.
-    util::fb2::EventCount pubsub_ec;
-    std::atomic_size_t subscriber_bytes = 0;
-
-    // Used by pipelining/execution fiber to throttle the incoming pipeline messages.
-    // Used together with pipeline_buffer_limit to limit the pipeline usage per thread.
-    util::fb2::CondVarAny pipeline_cnd;
-
-    size_t publish_buffer_limit = 0;   // cached flag publish_buffer_limit
-    size_t pipeline_cache_limit = 0;   // cached flag pipeline_cache_limit
-    size_t pipeline_buffer_limit = 0;  // cached flag for buffer size in bytes
-  };
-
   // Check protocol and handle connection.
   void HandleRequests() final;
 


### PR DESCRIPTION
We already allow limiting the queue by memory usage but it also makes sense to limit by depth, so that in extreme cases we would provide backpressure back to client connections. Otherwise if we parse and read everything, clients do not have a sense of how loaded the connection is on the server side.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->