### PR TITLE
chore(search): fix numeric index query in rev order

### DIFF
--- a/src/core/search/indices.cc
+++ b/src/core/search/indices.cc
@@ -85,8 +85,12 @@ void NumericIndex::Remove(DocId id, DocumentAccessor* doc, string_view field) {
 }
 
 vector<DocId> NumericIndex::Range(double l, double r) const {
+  if (r < l)
+    return {};
+
   auto it_l = entries_.lower_bound({l, 0});
   auto it_r = entries_.lower_bound({r, numeric_limits<DocId>::max()});
+  DCHECK_GE(it_r - it_l, 0);
 
   vector<DocId> out;
   for (auto it = it_l; it != it_r; ++it)

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -433,15 +433,12 @@ TEST_F(SearchFamilyTest, Numbers) {
 
   // Test negation of ranges:
   EXPECT_THAT(Run({"ft.search", "i1", "@i:[9 9] -@j:[1 10]"}), AreDocIds("i9j0"));
+  EXPECT_THAT(Run({"ft.search", "i1", "-@i:[0 9] -@j:[1 10]"}), AreDocIds("i10j0"));
 
-  // TODO: Check on new algo
-  // EXPECT_THAT(Run({"ft.search", "i1", "-@i:[0 9] -@j:[1 10]"}), AreDocIds("i10j0"));
-
-  /*
-  TODO: Breaks the parser
-  EXPECT_THAT(Run({"ft.search", "i1", "(@i:[1 3] ! @i:[2 2]) @j:[7 7]"}),
-              DocIds(vector<string>{"i1j7", "i3j7"}));
-  */
+  // Test empty range
+  EXPECT_THAT(Run({"ft.search", "i1", "@i:[9 1]"}), AreDocIds());
+  EXPECT_THAT(Run({"ft.search", "i1", "@j:[5 0]"}), AreDocIds());
+  EXPECT_THAT(Run({"ft.search", "i1", "@i:[7 1] @j:[6 2]"}), AreDocIds());
 }
 
 TEST_F(SearchFamilyTest, TestLimit) {


### PR DESCRIPTION
Fixes #3500 

Invalid range query caused right tree iterator to be less than left, thus making the `for (left_it ++ != right_it)` loop endless