### PR TITLE
chore(server): Fix watch

### DIFF
--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -484,6 +484,14 @@ TEST_F(MultiTest, Watch) {
   Run({"multi"});
   ASSERT_THAT(Run({"exec"}), kExecFail);
 
+  // Check watch with nonempty exec body
+  EXPECT_EQ(Run({"watch", "a"}), "OK");
+  Run({"multi"});
+  Run({"get", "a"});
+  Run({"get", "b"});
+  Run({"get", "c"});
+  ASSERT_THAT(Run({"exec"}), kExecSuccess);
+
   // Check watch data cleared after EXEC.
   Run({"set", "a", "1"});
   Run({"multi"});
@@ -499,10 +507,9 @@ TEST_F(MultiTest, Watch) {
   // Check EXEC doesn't miss watched key expiration.
   Run({"watch", "a"});
   Run({"expire", "a", "1"});
-
   AdvanceTime(1000);
-
   Run({"multi"});
+  Run({"get", "a"});
   ASSERT_THAT(Run({"exec"}), kExecFail);
 
   // Check unwatch.

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -506,8 +506,8 @@ void Transaction::MultiUpdateWithParent(const Transaction* parent) {
 
 void Transaction::MultiBecomeSquasher() {
   DCHECK(multi_->mode == GLOBAL || multi_->mode == LOCK_AHEAD);
-  DCHECK_GT(GetUniqueShardCnt(), 0u);    // initialized and determined active shards
-  DCHECK(cid_->IsMultiTransactional());  // proper base command set
+  DCHECK_GT(GetUniqueShardCnt(), 0u);                    // initialized and determined active shards
+  DCHECK(cid_->IsMultiTransactional()) << cid_->name();  // proper base command set
   multi_->role = SQUASHER;
 }
 


### PR DESCRIPTION
Just a DCHECK failing because we didn't clean up properly, has no implications on optimized builds