### PR TITLE
fix: string compatibility issues

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -926,12 +926,17 @@ int64_t DbSlice::ExpireParams::Cap(int64_t value, TimeUnit unit) {
 pair<int64_t, int64_t> DbSlice::ExpireParams::Calculate(uint64_t now_ms, bool cap) const {
   if (persist)
     return {0, 0};
+
+  // return a negative absolute time if we overflow.
+  if (unit == TimeUnit::SEC && value > INT64_MAX / 1000) {
+    return {0, -1};
+  }
+
   int64_t msec = (unit == TimeUnit::SEC) ? value * 1000 : value;
-  int64_t now_msec = now_ms;
-  int64_t rel_msec = absolute ? msec - now_msec : msec;
+  int64_t rel_msec = absolute ? msec - now_ms : msec;
   if (cap)
     rel_msec = Cap(rel_msec, TimeUnit::MSEC);
-  return make_pair(rel_msec, now_msec + rel_msec);
+  return make_pair(rel_msec, now_ms + rel_msec);
 }
 
 OpResult<int64_t> DbSlice::UpdateExpire(const Context& cntx, Iterator prime_it,
@@ -945,8 +950,8 @@ OpResult<int64_t> DbSlice::UpdateExpire(const Context& cntx, Iterator prime_it,
     return kPersistValue;
   }
 
-  auto [rel_msec, abs_msec] = params.Calculate(cntx.time_now_ms);
-  if (rel_msec > kMaxExpireDeadlineMs) {
+  auto [rel_msec, abs_msec] = params.Calculate(cntx.time_now_ms, false);
+  if (abs_msec < 0 || rel_msec > kMaxExpireDeadlineMs) {
     return OpStatus::OUT_OF_RANGE;
   }
 

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -213,7 +213,7 @@ class DbSlice {
     static int64_t Cap(int64_t value, TimeUnit unit);
 
     // Calculate relative and absolue timepoints.
-    std::pair<int64_t, int64_t> Calculate(uint64_t now_msec, bool cap = false) const;
+    std::pair<int64_t, int64_t> Calculate(uint64_t now_msec, bool cap) const;
 
     // Return true if relative expiration is in the past
     bool IsExpired(uint64_t now_msec) const {


### PR DESCRIPTION
1. strlen should return 0 for non existing types.
2. reject both EX and PX options in SET
3. prevent overflow of expiry time that is too large

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->