### PR TITLE
fix: compatibility around list,string and sort commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,5 @@ _deps
 releases
 .DS_Store
 .idea/*
-
+.hypothesis
 .secrets

--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -291,9 +291,9 @@ OpResult<ScanOpts> ScanOpts::TryFrom(CmdArgList args) {
       else if (scan_opts.limit > 4096)
         scan_opts.limit = 4096;
     } else if (opt == "MATCH") {
-      scan_opts.pattern = ArgS(args, i + 1);
-      if (scan_opts.pattern == "*")
-        scan_opts.pattern = string_view{};
+      string_view pattern = ArgS(args, i + 1);
+      if (pattern != "*")
+        scan_opts.pattern = pattern;
     } else if (opt == "TYPE") {
       auto obj_type = ObjTypeFromString(ArgS(args, i + 1));
       if (!obj_type) {
@@ -312,9 +312,9 @@ OpResult<ScanOpts> ScanOpts::TryFrom(CmdArgList args) {
 }
 
 bool ScanOpts::Matches(std::string_view val_name) const {
-  if (pattern.empty())
+  if (!pattern)
     return true;
-  return stringmatchlen(pattern.data(), pattern.size(), val_name.data(), val_name.size(), 0) == 1;
+  return stringmatchlen(pattern->data(), pattern->size(), val_name.data(), val_name.size(), 0) == 1;
 }
 
 GenericError::operator std::error_code() const {

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -295,7 +295,7 @@ class Context : protected Cancellation {
 };
 
 struct ScanOpts {
-  std::string_view pattern;
+  std::optional<std::string_view> pattern;
   size_t limit = 10;
   std::optional<CompactObjType> type_filter;
   unsigned bucket_id = UINT_MAX;

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -400,6 +400,15 @@ TEST_F(GenericFamilyTest, Scan) {
   vec = StrArray(resp.GetVec()[1]);
   EXPECT_EQ(10, vec.size());
   EXPECT_THAT(vec, Each(StartsWith("zset")));
+
+  Run({"flushdb"});
+
+  Run({"set", "", "foo"});
+  Run({"set", "bar", "1"});
+  resp = Run({"keys", "*"});
+  EXPECT_THAT(resp, RespArray(ElementsAre("bar", "")));
+  resp = Run({"keys", ""});
+  EXPECT_EQ(resp, "");
 }
 
 TEST_F(GenericFamilyTest, Sort) {
@@ -465,6 +474,10 @@ TEST_F(GenericFamilyTest, Sort) {
   // Test not convertible to double
   Run({"lpush", "list-2", "NOTADOUBLE"});
   ASSERT_THAT(Run({"sort", "list-2"}), ErrArg("One or more scores can't be converted into double"));
+
+  Run({"set", "foo", "bar"});
+  ASSERT_THAT(Run({"sort", "foo"}), ErrArg("WRONGTYPE "));
+  ;
 }
 
 TEST_F(GenericFamilyTest, TimeNoKeys) {

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -156,6 +156,9 @@ OpResult<StringValue> OpGetRange(const OpArgs& op_args, string_view key, int32_t
 
   auto& db_slice = op_args.GetDbSlice();
   auto it_res = db_slice.FindReadOnly(op_args.db_cntx, key, OBJ_STRING);
+  if (it_res == OpStatus::KEY_NOTFOUND) {
+    return StringValue(string{});
+  }
   RETURN_ON_BAD_STATUS(it_res);
 
   if (const CompactObj& co = it_res.value()->second; co.IsExternal()) {

--- a/src/server/string_family_test.cc
+++ b/src/server/string_family_test.cc
@@ -892,8 +892,9 @@ TEST_F(StringFamilyTest, MultiSetWithHashtagsLockHashtags) {
   fb.Join();
 }
 
-TEST_F(StringFamilyTest, StrLen) {
+TEST_F(StringFamilyTest, EmptyKeys) {
   EXPECT_EQ(0, CheckedInt({"strlen", "foo"}));
+  EXPECT_EQ(Run({"SUBSTR", "foo", "0", "-1"}), "");
 }
 
 }  // namespace dfly

--- a/tests/fakeredis/test/test_mixins/test_generic_commands.py
+++ b/tests/fakeredis/test/test_mixins/test_generic_commands.py
@@ -127,6 +127,7 @@ def test_sort_wrong_type(r: redis.Redis):
         r.sort("string")
 
 
+@pytest.mark.unsupported_server_types("dragonfly")
 def test_sort_with_store_option(r: redis.Redis):
     r.rpush("foo", "2")
     r.rpush("foo", "1")
@@ -137,6 +138,7 @@ def test_sort_with_store_option(r: redis.Redis):
     assert r.lrange("bar", 0, -1) == [b"1", b"2", b"3", b"4"]
 
 
+@pytest.mark.unsupported_server_types("dragonfly")
 def test_sort_with_by_and_get_option(r: redis.Redis):
     r.rpush("foo", "2")
     r.rpush("foo", "1")
@@ -186,6 +188,7 @@ def test_sort_with_by_and_get_option(r: redis.Redis):
     ]
 
 
+@pytest.mark.unsupported_server_types("dragonfly")
 def test_sort_with_hash(r: redis.Redis):
     r.rpush("foo", "middle")
     r.rpush("foo", "eldest")
@@ -665,7 +668,9 @@ def test_key_patterns(r: redis.Redis):
     assert sorted(r.keys()) == [b"four", b"one", b"three", b"two"]
 
 
+# seems like a rather peculiar behavior of Redis, maybe a bug? Disabling for Dragonfly for now.
 @pytest.mark.min_server("7")
+@pytest.mark.unsupported_server_types("dragonfly")
 def test_watch_when_setbit_does_not_change_value(r: redis.Redis):
     r.set("foo", b"0")
 

--- a/tests/fakeredis/test/test_mixins/test_string_commands.py
+++ b/tests/fakeredis/test/test_mixins/test_string_commands.py
@@ -533,6 +533,7 @@ def test_getex(r: redis.Redis):
 
 
 @pytest.mark.min_server("7")
+@pytest.mark.unsupported_server_types("dragonfly")
 def test_lcs(r: redis.Redis):
     r.mset({"key1": "ohmytext", "key2": "mynewtext"})
     assert r.lcs("key1", "key2") == b"mytext"


### PR DESCRIPTION
1. Fix corner cases around non existing keys
2. Fix matching logic for * glob, as well as '' glob.
3. Improve SORT option parsing.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->