### PR TITLE
chore: improve compatibility of set and ping commands

### DIFF
--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -755,6 +755,8 @@ TEST_F(DflyEngineTest, EvalBug2664) {
 
   auto resp = Run({"eval", "return 42.9", "0"});
   EXPECT_THAT(resp, IntArg(42));
+  resp = Run({"eval", "return -3.8", "0"});
+  EXPECT_THAT(resp, IntArg(-3));
 
   resp = Run({"hello", "3"});
   ASSERT_THAT(resp, ArrLen(14));

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -767,16 +767,26 @@ void GenericFamily::Ping(CmdArgList args, ConnectionContext* cntx) {
     return cntx->SendError(facade::WrongNumArgsError("ping"), kSyntaxErrType);
   }
 
-  // We synchronously block here until the engine sends us the payload and notifies that
-  // the I/O operation has been processed.
+  string_view msg;
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+
+  if (cntx->conn_state.subscribe_info && !rb->IsResp3()) {
+    if (args.size() == 1) {
+      msg = ArgS(args, 0);
+    }
+
+    string_view resp[2] = {"pong", msg};
+    return rb->SendStringArr(resp);
+  }
+
   if (args.size() == 0) {
     return cntx->SendSimpleString("PONG");
   } else {
-    string_view arg = ArgS(args, 0);
-    DVLOG(2) << "Ping " << arg;
+    msg = ArgS(args, 0);
+    DVLOG(2) << "Ping " << msg;
 
     auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
-    return rb->SendBulkString(arg);
+    return rb->SendBulkString(msg);
   }
 }
 

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -770,6 +770,7 @@ void GenericFamily::Ping(CmdArgList args, ConnectionContext* cntx) {
   string_view msg;
   auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
 
+  // If a client in the subscribe state and in resp2 mode, it returns an array for some reason.
   if (cntx->conn_state.subscribe_info && !rb->IsResp3()) {
     if (args.size() == 1) {
       msg = ArgS(args, 0);

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -330,7 +330,7 @@ class EvalSerializer : public ObjectExplorer {
     if (rb_->IsResp3() || !absl::GetFlag(FLAGS_lua_resp2_legacy_float)) {
       rb_->SendDouble(d);
     } else {
-      long val = static_cast<long>(floor(d));
+      long val = d >= 0 ? static_cast<long>(floor(d)) : static_cast<long>(ceil(d));
       rb_->SendLong(val);
     }
   }

--- a/src/server/set_family_test.cc
+++ b/src/server/set_family_test.cc
@@ -286,26 +286,22 @@ TEST_F(SetFamilyTest, SMIsMember) {
   EXPECT_THAT(resp, ErrArg("wrong number of arguments"));
 
   resp = Run({"smismember", "foo1", "a", "b"});
-  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
-  EXPECT_THAT(resp.GetVec(), ElementsAre("0", "0"));
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(0), IntArg(0))));
 
   resp = Run({"smismember", "foo", "a", "c"});
-  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
-  EXPECT_THAT(resp.GetVec(), ElementsAre("1", "0"));
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(1), IntArg(0))));
 
   resp = Run({"smismember", "foo", "a", "b"});
-  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
-  EXPECT_THAT(resp.GetVec(), ElementsAre("1", "1"));
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(1), IntArg(1))));
 
   resp = Run({"smismember", "foo", "d", "e"});
-  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
-  EXPECT_THAT(resp.GetVec(), ElementsAre("0", "0"));
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(0), IntArg(0))));
 
   resp = Run({"smismember", "foo", "b"});
-  EXPECT_THAT(resp, "1");
+  EXPECT_THAT(resp, IntArg(1));
 
   resp = Run({"smismember", "foo", "x"});
-  EXPECT_THAT(resp, "0");
+  EXPECT_THAT(resp, IntArg(0));
 }
 
 TEST_F(SetFamilyTest, Empty) {

--- a/tests/fakeredis/test/test_mixins/test_pubsub_commands.py
+++ b/tests/fakeredis/test/test_mixins/test_pubsub_commands.py
@@ -480,6 +480,7 @@ def test_pubsub_numsub(r: redis.Redis):
 
 @pytest.mark.min_server("7")
 @testtools.run_test_if_redispy_ver("gte", "5.0.0rc2")
+@pytest.mark.unsupported_server_types("dragonfly")
 def test_published_message_to_shard_channel(r: redis.Redis):
     p = r.pubsub()
     p.ssubscribe("foo")
@@ -493,6 +494,7 @@ def test_published_message_to_shard_channel(r: redis.Redis):
 
 @pytest.mark.min_server("7")
 @testtools.run_test_if_redispy_ver("gte", "5.0.0rc2")
+@pytest.mark.unsupported_server_types("dragonfly")
 def test_subscribe_property_with_shard_channels_cluster(r: redis.Redis):
     p = r.pubsub()
     keys = ["foo", "bar", "uni" + chr(4456) + "code"]
@@ -539,6 +541,7 @@ def test_subscribe_property_with_shard_channels_cluster(r: redis.Redis):
 
 @pytest.mark.min_server("7")
 @testtools.run_test_if_redispy_ver("gte", "5.0.0")
+@pytest.mark.unsupported_server_types("dragonfly")
 def test_pubsub_shardnumsub(r: redis.Redis):
     channels = {b"foo", b"bar", b"baz"}
     p1 = r.pubsub()
@@ -559,6 +562,7 @@ def test_pubsub_shardnumsub(r: redis.Redis):
 
 @pytest.mark.min_server("7")
 @testtools.run_test_if_redispy_ver("gte", "5.0.0rc2")
+@pytest.mark.unsupported_server_types("dragonfly")
 def test_pubsub_shardchannels(r: redis.Redis):
     p = r.pubsub()
     p.ssubscribe("foo", "bar", "baz", "quux")

--- a/tests/fakeredis/test/test_mixins/test_scripting.py
+++ b/tests/fakeredis/test/test_mixins/test_scripting.py
@@ -320,6 +320,8 @@ def test_eval_global_and_return_ok(r: redis.Redis):
         )
 
 
+# Dragonfly uses lua5.4, so it natively supports doubles.
+# To use legacy rounding of doubles to integers run dragonfly with --lua_resp2_legacy_float
 def test_eval_convert_number(r: redis.Redis):
     # Redis forces all Lua numbers to integer
     val = r.eval("return 3.2", 0)
@@ -349,6 +351,7 @@ def test_eval_call_bool6(r: redis.Redis):
 
 
 @pytest.mark.min_server("7")
+@pytest.mark.unsupported_server_types("dragonfly")  # dragonfly allows this
 def test_eval_call_bool7(r: redis.Redis):
     # Redis doesn't allow Lua bools to be passed to [p]call
     with pytest.raises(
@@ -429,6 +432,7 @@ def test_eval_exists(r: redis.Redis):
     assert val == 1
 
 
+@pytest.mark.unsupported_server_types("dragonfly")
 def test_eval_flushdb(r: redis.Redis):
     r.set("foo", "bar")
     val = r.eval(
@@ -441,6 +445,7 @@ def test_eval_flushdb(r: redis.Redis):
     assert val == 1
 
 
+@pytest.mark.unsupported_server_types("dragonfly")
 def test_eval_flushall(r, create_redis):
     r1 = create_redis(db=2)
     r2 = create_redis(db=3)
@@ -461,6 +466,8 @@ def test_eval_flushall(r, create_redis):
     assert "r2" not in r2
 
 
+# Dragonfly lua supports doubles
+@pytest.mark.unsupported_server_types("dragonfly")
 def test_eval_incrbyfloat(r: redis.Redis):
     r.set("foo", 0.5)
     val = r.eval(


### PR DESCRIPTION
smismember should return an array of longs and not array of strings. ping in subscribe mode returns an array for resp2.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->