### PR TITLE
fix: disable test_cluster_flushall_during_migration

### DIFF
--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -1078,6 +1078,7 @@ async def test_config_consistency(df_factory: DflyInstanceFactory):
     await close_clients(*[node.client for node in nodes], *[node.admin_client for node in nodes])
 
 
+@pytest.mark.skip("Deadlocks")
 @dfly_args({"proactor_threads": 4, "cluster_mode": "yes"})
 async def test_cluster_flushall_during_migration(
     df_factory: DflyInstanceFactory, df_seeder_factory


### PR DESCRIPTION
The test deadlocks on the CI.

https://github.com/dragonflydb/dragonfly/actions/runs/10556680020/job/29242720182?pr=3502

* disable test_cluster_flushall_during_migration