### PR TITLE
chore: replace my_fn with MyFn to respect style-guide

### DIFF
--- a/src/facade/command_id.h
+++ b/src/facade/command_id.h
@@ -34,27 +34,27 @@ class CommandId {
   CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first_key, int8_t last_key,
             uint32_t acl_categories);
 
-  std::string_view name() const {
+  std::string_view Name() const {
     return name_;
   }
 
-  int arity() const {
+  int Arity() const {
     return arity_;
   }
 
-  uint32_t opt_mask() const {
+  uint32_t OptMask() const {
     return opt_mask_;
   }
 
-  int8_t first_key_pos() const {
+  int8_t FirstKeyPos() const {
     return first_key_;
   }
 
-  int8_t last_key_pos() const {
+  int8_t LastKeyPos() const {
     return last_key_;
   }
 
-  uint32_t acl_categories() const {
+  uint32_t AclCategories() const {
     return acl_categories_;
   }
 

--- a/src/facade/conn_context.cc
+++ b/src/facade/conn_context.cc
@@ -15,7 +15,7 @@ namespace facade {
 
 ConnectionContext::ConnectionContext(::io::Sink* stream, Connection* owner) : owner_(owner) {
   if (owner) {
-    protocol_ = owner->protocol();
+    protocol_ = owner->Protocol();
   }
 
   if (stream) {

--- a/src/facade/conn_context.h
+++ b/src/facade/conn_context.h
@@ -24,19 +24,19 @@ class ConnectionContext {
   virtual ~ConnectionContext() {
   }
 
-  Connection* conn() {
+  Connection* Conn() {
     return owner_;
   }
 
-  const Connection* conn() const {
+  const Connection* Conn() const {
     return owner_;
   }
 
-  Protocol protocol() const {
+  enum Protocol Protocol() const {
     return protocol_;
   }
 
-  SinkReplyBuilder* reply_builder() {
+  SinkReplyBuilder* ReplyBuilder() {
     return rbuilder_.get();
   }
 
@@ -110,7 +110,7 @@ class ConnectionContext {
 
  private:
   Connection* owner_;
-  Protocol protocol_ = Protocol::REDIS;
+  enum Protocol protocol_ = Protocol::REDIS;
   std::unique_ptr<SinkReplyBuilder> rbuilder_;
 };
 

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -57,7 +57,7 @@ class Connection : public util::Connection {
   struct QueueBackpressure;
 
  public:
-  Connection(Protocol protocol, util::HttpListenerBase* http_listener, SSL_CTX* ctx,
+  Connection(enum Protocol protocol, util::HttpListenerBase* http_listener, SSL_CTX* ctx,
              ServiceInterface* service);
   ~Connection();
 
@@ -268,7 +268,7 @@ class Connection : public util::Connection {
 
   bool IsMain() const;
 
-  Protocol protocol() const {
+  enum facade::Protocol Protocol() const {
     return protocol_;
   }
 
@@ -284,7 +284,7 @@ class Connection : public util::Connection {
   };
   MemoryUsage GetMemoryUsage() const;
 
-  ConnectionContext* cntx();
+  ConnectionContext* Cntx();
 
   // Requests that at some point, this connection will be migrated to `dest` thread.
   // Connections will migrate at most once, and only when the flag --migrate_connections is true.
@@ -388,7 +388,7 @@ class Connection : public util::Connection {
   std::unique_ptr<MemcacheParser> memcache_parser_;
 
   uint32_t id_;
-  Protocol protocol_;
+  enum Protocol protocol_;
   ConnectionStats* stats_ = nullptr;
 
   util::HttpListenerBase* http_listener_;

--- a/src/server/acl/acl_log.cc
+++ b/src/server/acl/acl_log.cc
@@ -39,7 +39,7 @@ void AclLog::Add(const ConnectionContext& cntx, std::string object, Reason reaso
     username = std::move(tried_to_auth);
   }
 
-  std::string client_info = cntx.conn()->GetClientInfo();
+  std::string client_info = cntx.Conn()->GetClientInfo();
   using clock = std::chrono::system_clock;
   LogEntry entry = {std::move(username), std::move(client_info), std::move(object), reason,
                     clock::now()};

--- a/src/server/acl/validator.cc
+++ b/src/server/acl/validator.cc
@@ -28,7 +28,7 @@ namespace dfly::acl {
 
   if (!is_authed) {
     auto& log = ServerState::tlocal()->acl_log;
-    log.Add(cntx, std::string(id.name()), reason);
+    log.Add(cntx, std::string(id.Name()), reason);
   }
 
   return is_authed;
@@ -75,7 +75,7 @@ namespace dfly::acl {
   };
 
   bool keys_allowed = true;
-  if (!keys.all_keys && id.first_key_pos() != 0 && (is_read_command || is_write_command)) {
+  if (!keys.all_keys && id.FirstKeyPos() != 0 && (is_read_command || is_write_command)) {
     auto keys_index = DetermineKeys(&id, tail_args);
     DCHECK(keys_index);
 

--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -1061,7 +1061,7 @@ nonstd::expected<CommandList, std::string> ParseToCommandList(CmdArgList args, b
 }
 
 void SendResults(const std::vector<ResultType>& results, ConnectionContext* cntx) {
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   const size_t total = results.size();
   if (total == 0) {
     rb->SendNullArray();
@@ -1081,7 +1081,7 @@ void SendResults(const std::vector<ResultType>& results, ConnectionContext* cntx
 
 void BitFieldGeneric(CmdArgList args, bool read_only, ConnectionContext* cntx) {
   if (args.size() == 1) {
-    auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+    auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
     rb->SendNullArray();
     return;
   }

--- a/src/server/bloom_family.cc
+++ b/src/server/bloom_family.cc
@@ -159,7 +159,7 @@ void BloomFamily::MAdd(CmdArgList args, ConnectionContext* cntx) {
     return cntx->SendError(res.status());
   }
   const AddResult& add_res = *res;
-  RedisReplyBuilder* rb = (RedisReplyBuilder*)cntx->reply_builder();
+  RedisReplyBuilder* rb = (RedisReplyBuilder*)cntx->ReplyBuilder();
   rb->StartArray(add_res.size());
   for (const OpResult<bool>& val : add_res) {
     if (val) {
@@ -180,7 +180,7 @@ void BloomFamily::MExists(CmdArgList args, ConnectionContext* cntx) {
 
   OpResult res = cntx->transaction->ScheduleSingleHopT(std::move(cb));
 
-  RedisReplyBuilder* rb = (RedisReplyBuilder*)cntx->reply_builder();
+  RedisReplyBuilder* rb = (RedisReplyBuilder*)cntx->ReplyBuilder();
   rb->StartArray(args.size());
   for (size_t i = 0; i < args.size(); ++i) {
     cntx->SendLong(res ? res->at(i) : 0);

--- a/src/server/channel_store.cc
+++ b/src/server/channel_store.cc
@@ -177,7 +177,7 @@ void ChannelStore::Fill(const SubscribeMap& src, const string& pattern, vector<S
     // `cntx` is expected to be valid as it unregisters itself from the channel_store before
     // closing.
     CHECK(cntx->conn_state.subscribe_info);
-    Subscriber sub{cntx->conn()->Borrow(), pattern};
+    Subscriber sub{cntx->Conn()->Borrow(), pattern};
     out->push_back(std::move(sub));
   }
 }

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -53,7 +53,7 @@ bool CommandId::IsTransactional() const {
 }
 
 bool CommandId::IsMultiTransactional() const {
-  return CO::IsTransKind(name()) || CO::IsEvalKind(name());
+  return CO::IsTransKind(Name()) || CO::IsEvalKind(Name());
 }
 
 uint64_t CommandId::Invoke(CmdArgList args, ConnectionContext* cntx) const {
@@ -73,15 +73,15 @@ uint64_t CommandId::Invoke(CmdArgList args, ConnectionContext* cntx) const {
 }
 
 optional<facade::ErrorReply> CommandId::Validate(CmdArgList tail_args) const {
-  if ((arity() > 0 && tail_args.size() + 1 != size_t(arity())) ||
-      (arity() < 0 && tail_args.size() + 1 < size_t(-arity()))) {
-    return facade::ErrorReply{facade::WrongNumArgsError(name()), kSyntaxErrType};
+  if ((Arity() > 0 && tail_args.size() + 1 != size_t(Arity())) ||
+      (Arity() < 0 && tail_args.size() + 1 < size_t(-Arity()))) {
+    return facade::ErrorReply{facade::WrongNumArgsError(Name()), kSyntaxErrType};
   }
 
-  if ((opt_mask() & CO::INTERLEAVED_KEYS)) {
-    if ((name() == "JSON.MSET" && tail_args.size() % 3 != 0) ||
-        (name() == "MSET" && tail_args.size() % 2 != 0))
-      return facade::ErrorReply{facade::WrongNumArgsError(name()), kSyntaxErrType};
+  if ((OptMask() & CO::INTERLEAVED_KEYS)) {
+    if ((Name() == "JSON.MSET" && tail_args.size() % 3 != 0) ||
+        (Name() == "MSET" && tail_args.size() % 2 != 0))
+      return facade::ErrorReply{facade::WrongNumArgsError(Name()), kSyntaxErrType};
   }
 
   if (validator_)
@@ -114,9 +114,9 @@ void CommandRegistry::Init(unsigned int thread_count) {
 }
 
 CommandRegistry& CommandRegistry::operator<<(CommandId cmd) {
-  string k = string(cmd.name());
+  string k = string(cmd.Name());
 
-  absl::InlinedVector<std::string_view, 2> maybe_subcommand = StrSplit(cmd.name(), " ");
+  absl::InlinedVector<std::string_view, 2> maybe_subcommand = StrSplit(cmd.Name(), " ");
   const bool is_sub_command = maybe_subcommand.size() == 2;
   auto it = cmd_rename_map_.find(maybe_subcommand.front());
   if (it != cmd_rename_map_.end()) {
@@ -131,7 +131,7 @@ CommandRegistry& CommandRegistry::operator<<(CommandId cmd) {
   }
 
   cmd.SetFamily(family_of_commands_.size() - 1);
-  if (!is_sub_command || absl::StartsWith(cmd.name(), "ACL")) {
+  if (!is_sub_command || absl::StartsWith(cmd.Name(), "ACL")) {
     cmd.SetBitIndex(1ULL << bit_index_);
     family_of_commands_.back().push_back(std::string(k));
     ++bit_index_;

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -123,7 +123,7 @@ class CommandId : public facade::CommandId {
     return std::move(*this);
   }
 
-  bool is_multi_key() const {
+  bool IsMultiKey() const {
     return (last_key_ != first_key_) || (opt_mask_ & CO::VARIADIC_KEYS);
   }
 
@@ -179,7 +179,7 @@ class CommandRegistry {
       auto src = k_v.second.GetStats(thread_index);
       if (src.first == 0)
         continue;
-      cb(k_v.second.name(), src);
+      cb(k_v.second.Name(), src);
     }
   }
 

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1465,7 +1465,7 @@ void DbSlice::SendInvalidationTrackingMessage(std::string_view key) {
         continue;
       }
       auto* conn = client.Get();
-      auto* cntx = static_cast<ConnectionContext*>(conn->cntx());
+      auto* cntx = static_cast<ConnectionContext*>(conn->Cntx());
       if (cntx && cntx->conn_state.tracking_info_.IsTrackingOn()) {
         conn->SendInvalidationMessageAsync({key});
       }

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -408,7 +408,7 @@ void DebugCmd::Run(CmdArgList args) {
         "HELP",
         "    Prints this help.",
     };
-    auto* rb = static_cast<RedisReplyBuilder*>(cntx_->reply_builder());
+    auto* rb = static_cast<RedisReplyBuilder*>(cntx_->ReplyBuilder());
     return rb->SendSimpleStrArr(help_arr);
   }
 
@@ -515,7 +515,7 @@ void DebugCmd::Replica(CmdArgList args) {
   ToUpper(&args[0]);
   string_view opt = ArgS(args, 0);
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx_->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx_->ReplyBuilder());
   if (opt == "PAUSE" || opt == "RESUME") {
     sf_.PauseReplication(opt == "PAUSE");
     return rb->SendOk();
@@ -734,7 +734,7 @@ void DebugCmd::Exec() {
   for (const auto& k_v : freq_cnt) {
     StrAppend(&res, k_v.second, ":", k_v.first, "\n");
   }
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx_->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx_->ReplyBuilder());
   rb->SendVerbatimString(res);
 }
 
@@ -822,7 +822,7 @@ void DebugCmd::Watched() {
     }
   };
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx_->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx_->ReplyBuilder());
   shard_set->RunBlockingInParallel(cb);
   rb->StartArray(4);
   rb->SendBulkString("awaked");
@@ -851,7 +851,7 @@ void DebugCmd::TxAnalysis() {
     StrAppend(&result, "  max contention score: ", info.max_contention_score,
               ",lock_name:", info.max_contention_lock, "\n");
   }
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx_->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx_->ReplyBuilder());
   rb->SendVerbatimString(result);
 }
 
@@ -879,7 +879,7 @@ void DebugCmd::ObjHist() {
   }
 
   absl::StrAppend(&result, "___end object histogram___\n");
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx_->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx_->ReplyBuilder());
   rb->SendVerbatimString(result);
 }
 
@@ -945,7 +945,7 @@ void DebugCmd::Shards() {
 
 #undef ADD_STAT
 #undef MAXMIN_STAT
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx_->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx_->ReplyBuilder());
   rb->SendVerbatimString(out);
 }
 

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -715,7 +715,7 @@ void HGetGeneric(CmdArgList args, ConnectionContext* cntx, uint8_t getall_mask) 
 
   OpResult<vector<string>> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   if (result) {
     bool is_map = (getall_mask == (VALUES | FIELDS));
     rb->SendStringArr(absl::Span<const string>{*result},
@@ -744,7 +744,7 @@ void HSetEx(CmdArgList args, ConnectionContext* cntx) {
   CmdArgList fields = parser.Tail();
 
   if (fields.size() % 2 != 0) {
-    return cntx->SendError(facade::WrongNumArgsError(cntx->cid->name()), kSyntaxErrType);
+    return cntx->SendError(facade::WrongNumArgsError(cntx->cid->Name()), kSyntaxErrType);
   }
 
   OpSetParams op_sp{skip_if_exists, ttl_sec};
@@ -818,10 +818,10 @@ void HSetFamily::HMGet(CmdArgList args, ConnectionContext* cntx) {
 
   OpResult<vector<OptStr>> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   if (result) {
-    SinkReplyBuilder::ReplyAggregator agg(cntx->reply_builder());
-    auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+    SinkReplyBuilder::ReplyAggregator agg(cntx->ReplyBuilder());
+    auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
     rb->StartArray(result->size());
     for (const auto& val : *result) {
       if (val) {
@@ -831,7 +831,7 @@ void HSetFamily::HMGet(CmdArgList args, ConnectionContext* cntx) {
       }
     }
   } else if (result.status() == OpStatus::KEY_NOTFOUND) {
-    SinkReplyBuilder::ReplyAggregator agg(cntx->reply_builder());
+    SinkReplyBuilder::ReplyAggregator agg(cntx->ReplyBuilder());
 
     rb->StartArray(args.size());
     for (unsigned i = 0; i < args.size(); ++i) {
@@ -850,7 +850,7 @@ void HSetFamily::HGet(CmdArgList args, ConnectionContext* cntx) {
     return OpGet(t->GetOpArgs(shard), key, field);
   };
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   OpResult<string> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
   if (result) {
     rb->SendBulkString(*result);
@@ -917,7 +917,7 @@ void HSetFamily::HIncrByFloat(CmdArgList args, ConnectionContext* cntx) {
   OpStatus status = cntx->transaction->ScheduleSingleHop(std::move(cb));
 
   if (status == OpStatus::OK) {
-    auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+    auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
     rb->SendDouble(get<double>(param));
   } else {
     switch (status) {
@@ -971,7 +971,7 @@ void HSetFamily::HScan(CmdArgList args, ConnectionContext* cntx) {
     return OpScan(t->GetOpArgs(shard), key, &cursor, scan_op);
   };
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   OpResult<StringVec> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
   if (result.status() != OpStatus::WRONG_TYPE) {
     rb->StartArray(2);
@@ -988,7 +988,7 @@ void HSetFamily::HScan(CmdArgList args, ConnectionContext* cntx) {
 void HSetFamily::HSet(CmdArgList args, ConnectionContext* cntx) {
   string_view key = ArgS(args, 0);
 
-  string_view cmd{cntx->cid->name()};
+  string_view cmd{cntx->cid->Name()};
 
   if (args.size() % 2 != 1) {
     return cntx->SendError(facade::WrongNumArgsError(cmd), kSyntaxErrType);
@@ -1151,7 +1151,7 @@ void HSetFamily::HRandField(CmdArgList args, ConnectionContext* cntx) {
     return str_vec;
   };
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   OpResult<StringVec> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
   if (result) {
     if ((result->size() == 1) && (args.size() == 1))

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -649,7 +649,7 @@ auto ExecuteToggle(string_view key, const WrappedJsonPath& json_path, Connection
   };
 
   auto result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   reply_generic::Send(result, rb);
 }
 
@@ -1317,7 +1317,7 @@ void JsonFamily::Set(CmdArgList args, ConnectionContext* cntx) {
 
   OpResult<bool> result = trans->ScheduleSingleHopT(std::move(cb));
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   if (result) {
     if (*result) {
       rb->SendOk();
@@ -1385,7 +1385,7 @@ void JsonFamily::Resp(CmdArgList args, ConnectionContext* cntx) {
 
   Transaction* trans = cntx->transaction;
   auto result = trans->ScheduleSingleHopT(std::move(cb));
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   reply_generic::Send(result, rb);
 }
 
@@ -1396,7 +1396,7 @@ void JsonFamily::Debug(CmdArgList args, ConnectionContext* cntx) {
   // The 'MEMORY' sub-command is not supported yet, calling to operation function should be added
   // here.
   if (absl::EqualsIgnoreCase(command, "help")) {
-    auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+    auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
     rb->StartArray(2);
     rb->SendBulkString(
         "JSON.DEBUG FIELDS <key> <path> - report number of fields in the JSON element.");
@@ -1420,7 +1420,7 @@ void JsonFamily::Debug(CmdArgList args, ConnectionContext* cntx) {
 
   Transaction* trans = cntx->transaction;
   auto result = trans->ScheduleSingleHopT(std::move(cb));
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   reply_generic::Send(result, rb);
 }
 
@@ -1460,7 +1460,7 @@ void JsonFamily::MGet(CmdArgList args, ConnectionContext* cntx) {
     }
   }
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   reply_generic::Send(results, rb);
 }
 
@@ -1505,7 +1505,7 @@ void JsonFamily::ArrIndex(CmdArgList args, ConnectionContext* cntx) {
 
   Transaction* trans = cntx->transaction;
   auto result = trans->ScheduleSingleHopT(std::move(cb));
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   reply_generic::Send(result, rb);
 }
 
@@ -1539,7 +1539,7 @@ void JsonFamily::ArrInsert(CmdArgList args, ConnectionContext* cntx) {
 
   Transaction* trans = cntx->transaction;
   auto result = trans->ScheduleSingleHopT(std::move(cb));
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   reply_generic::Send(result, rb);
 }
 
@@ -1568,7 +1568,7 @@ void JsonFamily::ArrAppend(CmdArgList args, ConnectionContext* cntx) {
 
   Transaction* trans = cntx->transaction;
   auto result = trans->ScheduleSingleHopT(std::move(cb));
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   reply_generic::Send(result, rb);
 }
 
@@ -1603,7 +1603,7 @@ void JsonFamily::ArrTrim(CmdArgList args, ConnectionContext* cntx) {
 
   Transaction* trans = cntx->transaction;
   auto result = trans->ScheduleSingleHopT(std::move(cb));
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   reply_generic::Send(result, rb);
 }
 
@@ -1621,7 +1621,7 @@ void JsonFamily::ArrPop(CmdArgList args, ConnectionContext* cntx) {
 
   Transaction* trans = cntx->transaction;
   auto result = trans->ScheduleSingleHopT(std::move(cb));
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   reply_generic::Send(result, rb);
 }
 
@@ -1638,7 +1638,7 @@ void JsonFamily::Clear(CmdArgList args, ConnectionContext* cntx) {
 
   Transaction* trans = cntx->transaction;
   OpResult<long> result = trans->ScheduleSingleHopT(std::move(cb));
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   reply_generic::Send(result, rb);
 }
 
@@ -1655,7 +1655,7 @@ void JsonFamily::StrAppend(CmdArgList args, ConnectionContext* cntx) {
 
   Transaction* trans = cntx->transaction;
   auto result = trans->ScheduleSingleHopT(std::move(cb));
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   reply_generic::Send(result, rb);
 }
 
@@ -1672,7 +1672,7 @@ void JsonFamily::ObjKeys(CmdArgList args, ConnectionContext* cntx) {
 
   Transaction* trans = cntx->transaction;
   auto result = trans->ScheduleSingleHopT(std::move(cb));
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   reply_generic::Send(result, rb);
 }
 
@@ -1689,7 +1689,7 @@ void JsonFamily::Del(CmdArgList args, ConnectionContext* cntx) {
 
   Transaction* trans = cntx->transaction;
   OpResult<long> result = trans->ScheduleSingleHopT(std::move(cb));
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   reply_generic::Send(result, rb);
 }
 
@@ -1711,7 +1711,7 @@ void JsonFamily::NumIncrBy(CmdArgList args, ConnectionContext* cntx) {
   };
 
   OpResult<string> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   reply_generic::Send(result, rb);
 }
 
@@ -1733,7 +1733,7 @@ void JsonFamily::NumMultBy(CmdArgList args, ConnectionContext* cntx) {
   };
 
   OpResult<string> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   reply_generic::Send(result, rb);
 }
 
@@ -1764,7 +1764,7 @@ void JsonFamily::Type(CmdArgList args, ConnectionContext* cntx) {
 
   Transaction* trans = cntx->transaction;
   auto result = trans->ScheduleSingleHopT(std::move(cb));
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   reply_generic::Send(result, rb);
 }
 
@@ -1781,7 +1781,7 @@ void JsonFamily::ArrLen(CmdArgList args, ConnectionContext* cntx) {
 
   Transaction* trans = cntx->transaction;
   auto result = trans->ScheduleSingleHopT(std::move(cb));
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   reply_generic::Send(result, rb);
 }
 
@@ -1798,7 +1798,7 @@ void JsonFamily::ObjLen(CmdArgList args, ConnectionContext* cntx) {
 
   Transaction* trans = cntx->transaction;
   auto result = trans->ScheduleSingleHopT(std::move(cb));
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   reply_generic::Send(result, rb);
 }
 
@@ -1815,7 +1815,7 @@ void JsonFamily::StrLen(CmdArgList args, ConnectionContext* cntx) {
 
   Transaction* trans = cntx->transaction;
   auto result = trans->ScheduleSingleHopT(std::move(cb));
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   reply_generic::Send(result, rb);
 }
 
@@ -1860,7 +1860,7 @@ void JsonFamily::Get(CmdArgList args, ConnectionContext* cntx) {
 
   Transaction* trans = cntx->transaction;
   OpResult<string> result = trans->ScheduleSingleHopT(std::move(cb));
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   if (result) {
     rb->SendBulkString(*result);
   } else {

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -675,7 +675,7 @@ void MoveGeneric(ConnectionContext* cntx, string_view src, string_view dest, Lis
     result = MoveTwoShards(cntx->transaction, src, dest, src_dir, dest_dir, true);
   }
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   if (result) {
     return rb->SendBulkString(*result);
   }
@@ -712,7 +712,7 @@ void BRPopLPush(CmdArgList args, ConnectionContext* cntx) {
   BPopPusher bpop_pusher(src, dest, ListDir::RIGHT, ListDir::LEFT);
   OpResult<string> op_res = bpop_pusher.Run(cntx, unsigned(timeout * 1000));
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   if (op_res) {
     return rb->SendBulkString(*op_res);
   }
@@ -745,7 +745,7 @@ void BLMove(CmdArgList args, ConnectionContext* cntx) {
   BPopPusher bpop_pusher(src, dest, src_dir, dest_dir);
   OpResult<string> op_res = bpop_pusher.Run(cntx, unsigned(timeout * 1000));
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   if (op_res) {
     return rb->SendBulkString(*op_res);
   }
@@ -941,7 +941,7 @@ void ListFamily::LPos(CmdArgList args, ConnectionContext* cntx) {
     return cntx->SendError(result.status());
   }
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   if (skip_count) {
     if (result->empty()) {
       rb->SendNull();
@@ -949,7 +949,7 @@ void ListFamily::LPos(CmdArgList args, ConnectionContext* cntx) {
       rb->SendLong((*result)[0]);
     }
   } else {
-    SinkReplyBuilder::ReplyAggregator agg(cntx->reply_builder());
+    SinkReplyBuilder::ReplyAggregator agg(cntx->ReplyBuilder());
     rb->StartArray(result->size());
     const auto& array = result.value();
     for (const auto& v : array) {
@@ -971,7 +971,7 @@ void ListFamily::LIndex(CmdArgList args, ConnectionContext* cntx) {
     return OpIndex(t->GetOpArgs(shard), key, index);
   };
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   OpResult<string> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
   if (result) {
     rb->SendBulkString(result.value());
@@ -1044,7 +1044,7 @@ void ListFamily::LRange(CmdArgList args, ConnectionContext* cntx) {
     return cntx->SendError(res.status());
   }
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   rb->SendStringArr(*res);
 }
 
@@ -1136,7 +1136,7 @@ void ListFamily::BPopGeneric(ListDir dir, CmdArgList args, ConnectionContext* cn
       transaction, OBJ_LIST, std::move(cb), unsigned(timeout * 1000), &cntx->blocked,
       &cntx->paused);
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   if (popped_key) {
     DVLOG(1) << "BPop " << transaction->DebugId() << " popped from key " << popped_key;  // key.
     std::string_view str_arr[2] = {*popped_key, popped_value};
@@ -1197,7 +1197,7 @@ void ListFamily::PopGeneric(ListDir dir, CmdArgList args, ConnectionContext* cnt
   };
 
   OpResult<StringVec> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   switch (result.status()) {
     case OpStatus::KEY_NOTFOUND:
       return rb->SendNull();

--- a/src/server/list_family_test.cc
+++ b/src/server/list_family_test.cc
@@ -824,7 +824,6 @@ TEST_F(ListFamilyTest, BLMoveRings) {
       }));
     }
   }
-#pragma GCC diagnostic pop
 
   ThisFiber::SleepFor(5ms);
 
@@ -851,6 +850,7 @@ TEST_F(ListFamilyTest, BLMoveWaves) {
       fibers.emplace_back(pp_->at(i % 3)->LaunchFiber([=]() {
         Run("c" + to_string(i * kFlow + j), {"blmove", src, dest, "LEFT", "RIGHT", "0"});
       }));
+#pragma GCC diagnostic pop
     }
   }
 

--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -130,7 +130,7 @@ void MemoryCmd::Run(CmdArgList args) {
         "        Returns whether <address> is known to be allocated internally by any of the "
         "backing heaps",
     };
-    auto* rb = static_cast<RedisReplyBuilder*>(cntx_->reply_builder());
+    auto* rb = static_cast<RedisReplyBuilder*>(cntx_->ReplyBuilder());
     return rb->SendSimpleStrArr(help_arr);
   };
 
@@ -199,7 +199,7 @@ ConnectionMemoryUsage GetConnectionMemoryUsage(ServerFamily* server) {
       }
 
       auto* dfly_conn = static_cast<facade::Connection*>(conn);
-      auto* cntx = static_cast<ConnectionContext*>(dfly_conn->cntx());
+      auto* cntx = static_cast<ConnectionContext*>(dfly_conn->Cntx());
 
       auto usage = dfly_conn->GetMemoryUsage();
       if (cntx == nullptr || cntx->replication_flow == nullptr) {
@@ -264,7 +264,7 @@ void MemoryCmd::Stats() {
                            connection_memory.replication_connection_size,
                        &stats);
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx_->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx_->ReplyBuilder());
   rb->StartCollection(stats.size(), RedisReplyBuilder::MAP);
   for (const auto& [k, v] : stats) {
     rb->SendBulkString(k);
@@ -296,7 +296,7 @@ void MemoryCmd::MallocStats() {
   mi_stats_print_out(MiStatsCallback, &report);
   absl::StrAppend(&report, "___ End mimalloc stats ___\n\n");
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx_->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx_->ReplyBuilder());
   return rb->SendVerbatimString(report);
 }
 
@@ -326,7 +326,7 @@ void MemoryCmd::ArenaStats(CmdArgList args) {
 
   if (show_arenas) {
     mi_debug_show_arenas(true, true, true);
-    return cntx_->reply_builder()->SendOk();
+    return cntx_->ReplyBuilder()->SendOk();
   }
 
   if (backing && tid >= shard_set->pool()->size()) {
@@ -341,7 +341,7 @@ void MemoryCmd::ArenaStats(CmdArgList args) {
   string mi_malloc_info =
       shard_set->pool()->at(tid)->AwaitBrief([=] { return MallocStatsCb(backing, tid); });
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx_->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx_->ReplyBuilder());
   return rb->SendVerbatimString(mi_malloc_info);
 }
 
@@ -358,7 +358,7 @@ void MemoryCmd::Usage(std::string_view key) {
     }
   });
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx_->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx_->ReplyBuilder());
   if (memory_usage < 0)
     return rb->SendNull();
   rb->SendLong(memory_usage);
@@ -425,7 +425,7 @@ void MemoryCmd::Track(CmdArgList args) {
 
   if (sub_cmd == "GET") {
     auto ranges = AllocationTracker::Get().GetRanges();
-    auto* rb = static_cast<facade::RedisReplyBuilder*>(cntx_->reply_builder());
+    auto* rb = static_cast<facade::RedisReplyBuilder*>(cntx_->ReplyBuilder());
     rb->StartArray(ranges.size());
     for (const auto& range : ranges) {
       rb->SendSimpleString(

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -69,11 +69,11 @@ MultiCommandSquasher::ShardExecInfo& MultiCommandSquasher::PrepareShardInfo(
 MultiCommandSquasher::SquashResult MultiCommandSquasher::TrySquash(StoredCmd* cmd) {
   DCHECK(cmd->Cid());
 
-  if (!cmd->Cid()->IsTransactional() || (cmd->Cid()->opt_mask() & CO::BLOCKING) ||
-      (cmd->Cid()->opt_mask() & CO::GLOBAL_TRANS))
+  if (!cmd->Cid()->IsTransactional() || (cmd->Cid()->OptMask() & CO::BLOCKING) ||
+      (cmd->Cid()->OptMask() & CO::GLOBAL_TRANS))
     return SquashResult::NOT_SQUASHED;
 
-  if (cmd->Cid()->name() == "CLIENT" || cntx_->conn_state.tracking_info_.IsTrackingOn()) {
+  if (cmd->Cid()->Name() == "CLIENT" || cntx_->conn_state.tracking_info_.IsTrackingOn()) {
     return SquashResult::NOT_SQUASHED;
   }
 
@@ -143,8 +143,8 @@ OpStatus MultiCommandSquasher::SquashedHopCb(Transaction* parent_tx, EngineShard
   auto* local_tx = sinfo.local_tx.get();
   facade::CapturingReplyBuilder crb;
   ConnectionContext local_cntx{cntx_, local_tx, &crb};
-  if (cntx_->conn()) {
-    local_cntx.skip_acl_validation = cntx_->conn()->IsPrivileged();
+  if (cntx_->Conn()) {
+    local_cntx.skip_acl_validation = cntx_->Conn()->IsPrivileged();
   }
   absl::InlinedVector<MutableSlice, 4> arg_vec;
 
@@ -234,7 +234,7 @@ bool MultiCommandSquasher::ExecuteSquashed() {
   uint64_t after_hop = proactor->GetMonotonicTimeNs();
   bool aborted = false;
 
-  RedisReplyBuilder* rb = static_cast<RedisReplyBuilder*>(cntx_->reply_builder());
+  RedisReplyBuilder* rb = static_cast<RedisReplyBuilder*>(cntx_->ReplyBuilder());
   for (auto idx : order_) {
     auto& replies = sharded_[idx].replies;
     CHECK(!replies.empty());

--- a/src/server/script_mgr.cc
+++ b/src/server/script_mgr.cc
@@ -93,7 +93,7 @@ void ScriptMgr::Run(CmdArgList args, ConnectionContext* cntx) {
         "   Invokes garbage collection on all unused interpreter instances.",
         "HELP",
         "   Prints this help."};
-    auto rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+    auto rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
     return rb->SendSimpleStrArr(kHelp);
   }
 
@@ -131,7 +131,7 @@ void ScriptMgr::ExistsCmd(CmdArgList args, ConnectionContext* cntx) const {
     }
   }
 
-  auto rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   rb->StartArray(res.size());
   for (uint8_t v : res) {
     rb->SendLong(v);
@@ -146,7 +146,7 @@ void ScriptMgr::FlushCmd(CmdArgList args, ConnectionContext* cntx) {
 
 void ScriptMgr::LoadCmd(CmdArgList args, ConnectionContext* cntx) {
   string_view body = ArgS(args, 1);
-  auto rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   if (body.empty()) {
     char sha[41];
     Interpreter::FuncSha1(body, sha);
@@ -187,7 +187,7 @@ void ScriptMgr::ConfigCmd(CmdArgList args, ConnectionContext* cntx) {
 
 void ScriptMgr::ListCmd(ConnectionContext* cntx) const {
   vector<pair<string, ScriptData>> scripts = GetAll();
-  auto rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   rb->StartArray(scripts.size());
   for (const auto& [sha, data] : scripts) {
     rb->StartArray(2);
@@ -209,7 +209,7 @@ void ScriptMgr::LatencyCmd(ConnectionContext* cntx) const {
     mu.unlock();
   });
 
-  auto rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   rb->StartArray(result.size());
   for (const auto& k_v : result) {
     rb->StartArray(2);

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -364,7 +364,7 @@ optional<AggregateParams> ParseAggregatorParamsOrReply(CmdArgParser parser,
 }
 
 void SendSerializedDoc(const SerializedSearchDoc& doc, ConnectionContext* cntx) {
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   rb->SendBulkString(doc.key);
   rb->StartCollection(doc.values.size(), RedisReplyBuilder::MAP);
   for (const auto& [k, v] : doc.values) {
@@ -382,12 +382,12 @@ void ReplyWithResults(const SearchParams& params, absl::Span<SearchResult> resul
   size_t result_count =
       min(total_count - min(total_count, params.limit_offset), params.limit_total);
 
-  facade::SinkReplyBuilder::ReplyAggregator agg{cntx->reply_builder()};
+  facade::SinkReplyBuilder::ReplyAggregator agg{cntx->ReplyBuilder()};
 
   bool ids_only = params.IdsOnly();
   size_t reply_size = ids_only ? (result_count + 1) : (result_count * 2 + 1);
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   rb->StartArray(reply_size);
   rb->SendLong(total_count);
 
@@ -442,8 +442,8 @@ void ReplySorted(search::AggregationInfo agg, const SearchParams& params,
   if (!params.ShouldReturnField(agg.alias))
     agg.alias = "";
 
-  facade::SinkReplyBuilder::ReplyAggregator agg_reply{cntx->reply_builder()};
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  facade::SinkReplyBuilder::ReplyAggregator agg_reply{cntx->ReplyBuilder()};
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   rb->StartArray(reply_size);
   rb->SendLong(min(total, agg_limit));
   for (auto* doc : absl::MakeSpan(docs).subspan(start_idx, result_count)) {
@@ -630,7 +630,7 @@ void SearchFamily::FtInfo(CmdArgList args, ConnectionContext* cntx) {
   const auto& info = infos.front();
   const auto& schema = info.base_index.schema;
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   rb->StartCollection(4, RedisReplyBuilder::MAP);
 
   rb->SendSimpleString("index_name");
@@ -678,7 +678,7 @@ void SearchFamily::FtList(CmdArgList args, ConnectionContext* cntx) {
       names = es->search_indices()->GetIndexNames();
     return OpStatus::OK;
   });
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   rb->SendStringArr(names);
 }
 
@@ -760,7 +760,7 @@ void SearchFamily::FtProfile(CmdArgList args, ConnectionContext* cntx) {
   });
 
   auto took = absl::Now() - start;
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   rb->StartArray(results.size() + 1);
 
   // General stats
@@ -833,7 +833,7 @@ void SearchFamily::FtTagVals(CmdArgList args, ConnectionContext* cntx) {
   shard_results.clear();
   vector<string> vec(result_set.begin(), result_set.end());
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   rb->SendStringArr(vec, RedisReplyBuilder::SET);
 }
 
@@ -868,7 +868,7 @@ void SearchFamily::FtAggregate(CmdArgList args, ConnectionContext* cntx) {
   if (!agg_results.has_value())
     return cntx->SendError(agg_results.error());
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   Overloaded replier{
       [rb](monostate) { rb->SendNull(); },
       [rb](double d) { rb->SendDouble(d); },

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -995,7 +995,7 @@ void SMIsMember(CmdArgList args, ConnectionContext* cntx) {
     return find_res.status();
   };
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   OpResult<void> result = cntx->transaction->ScheduleSingleHop(std::move(cb));
   if (result || result == OpStatus::KEY_NOTFOUND) {
     rb->StartArray(memberships.size());
@@ -1081,7 +1081,7 @@ void SPop(CmdArgList args, ConnectionContext* cntx) {
     return OpPop(t->GetOpArgs(shard), key, count);
   };
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   OpResult<StringVec> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
   if (result || result.status() == OpStatus::KEY_NOTFOUND) {
     if (args.size() == 1) {  // SPOP key
@@ -1128,7 +1128,7 @@ void SDiff(CmdArgList args, ConnectionContext* cntx) {
   if (cntx->conn_state.script_info) {  // sort under script
     sort(arr.begin(), arr.end());
   }
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   rb->SendStringArr(arr, RedisReplyBuilder::SET);
 }
 
@@ -1197,7 +1197,7 @@ void SMembers(CmdArgList args, ConnectionContext* cntx) {
     if (cntx->conn_state.script_info) {  // sort under script
       sort(svec.begin(), svec.end());
     }
-    auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+    auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
     rb->SendStringArr(*result, RedisReplyBuilder::SET);
   } else {
     cntx->SendError(result.status());
@@ -1222,7 +1222,7 @@ void SRandMember(CmdArgList args, ConnectionContext* cntx) {
   };
 
   OpResult<StringVec> result = cntx->transaction->ScheduleSingleHopT(cb);
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   if (result || result == OpStatus::KEY_NOTFOUND) {
     if (is_count) {
       rb->SendStringArr(*result, RedisReplyBuilder::SET);
@@ -1252,7 +1252,7 @@ void SInter(CmdArgList args, ConnectionContext* cntx) {
     if (cntx->conn_state.script_info) {  // sort under script
       sort(arr.begin(), arr.end());
     }
-    auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+    auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
     rb->SendStringArr(arr, RedisReplyBuilder::SET);
   } else {
     cntx->SendError(result.status());
@@ -1343,7 +1343,7 @@ void SUnion(CmdArgList args, ConnectionContext* cntx) {
     if (cntx->conn_state.script_info) {  // sort under script
       sort(arr.begin(), arr.end());
     }
-    auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+    auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
     rb->SendStringArr(arr, RedisReplyBuilder::SET);
   } else {
     cntx->SendError(unionset.status());
@@ -1418,7 +1418,7 @@ void SScan(CmdArgList args, ConnectionContext* cntx) {
     return OpScan(t->GetOpArgs(shard), key, &cursor, scan_op);
   };
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+  auto* rb = static_cast<RedisReplyBuilder*>(cntx->ReplyBuilder());
   OpResult<StringVec> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
   if (result.status() != OpStatus::WRONG_TYPE) {
     rb->StartArray(2);

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -25,7 +25,7 @@ void TEST_InvalidateLockTagOptions();
 
 class TestConnection : public facade::Connection {
  public:
-  TestConnection(Protocol protocol, io::StringSink* sink);
+  TestConnection(enum Protocol protocol, io::StringSink* sink);
   std::string RemoteEndpointStr() const override;
 
   void SendPubMessageAsync(PubMessage pmsg) final;


### PR DESCRIPTION
My ocd kicked in and I couldn't stand the naming discrepancies and I wanted as to be as close to our style guide as possible. It was something I wanted to refactor long time ago. If I missed something I will make sure I take care of it next time.

There are `no` functional changes.

* replace my_fn with MyFn