### PR TITLE
fix: xreadgroup replies as a map for RESP3

### DIFF
--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -1886,7 +1886,7 @@ void SetId(string_view key, string_view gname, CmdArgList args, ConnectionContex
   facade::CmdArgParser parser{args};
 
   string_view id = parser.Next();
-  while (parser.ToUpper().HasNext()) {
+  while (parser.HasNext()) {
     if (parser.Check("ENTRIESREAD").ExpectTail(1)) {
       // TODO: to support ENTRIESREAD.
       return cntx->SendError(kSyntaxErr);

--- a/tests/fakeredis/test/test_mixins/test_streams_commands.py
+++ b/tests/fakeredis/test/test_mixins/test_streams_commands.py
@@ -377,6 +377,7 @@ def test_xgroup_create_redis7(r: redis.Redis):
 
 
 @pytest.mark.min_server("7")
+@pytest.mark.unsupported_server_types("dragonfly")
 def test_xgroup_setid_redis7(r: redis.Redis):
     stream, group = "stream", "group"
     message_id = r.xadd(stream, {"foo": "bar"})


### PR DESCRIPTION
1. xreadgroup should return data for all the streams, irrespective whether they have results or not (unlike with XREAD)
2. xpending with 0 results should still return a 4-element array
3. reject ENTRIESREAD option as it's not implemented.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->