### PR TITLE
fix(json_family): Fix JSON.GET crash for the multiple legacy mode paths

### DIFF
--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -572,7 +572,9 @@ OpResult<std::string> OpJsonGet(const OpArgs& op_args, string_view key,
   } else {
     for (const auto& [path_str, path] : paths) {
       auto eval_result = eval_wrapped(path);
-      DCHECK(eval_result);
+      if (legacy_mode_is_enabled && !eval_result) {
+        return OpStatus::INVALID_JSON_PATH;
+      }
       out[path_str] = std::move(eval_result).value();  // TODO(Print not existing path to the user)
     }
   }

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -152,6 +152,12 @@ TEST_F(JsonFamilyTest, GetLegacy) {
   resp = Run({"JSON.GET", "json", "bar"});  // V1 Response
   ASSERT_THAT(resp, ErrArg("ERR invalid JSON path"));
 
+  resp = Run({"JSON.GET", "json", ".", "bar"});  // V1 Response
+  ASSERT_THAT(resp, ErrArg("ERR invalid JSON path"));
+
+  resp = Run({"JSON.GET", "json", ".a", "bar", "foo", "third", "."});  // V1 Response
+  ASSERT_THAT(resp, ErrArg("ERR invalid JSON path"));
+
   resp = Run({"JSON.GET", "json", "$.bar"});  // V2 Response
   ASSERT_THAT(resp, "[]");
 


### PR DESCRIPTION
fixes dragonflydb#3558

relates to the #3580 . Another problem when we have multiple legacy mode paths in the `JSON.GET` command.