### PR TITLE
fix: warning as error on sanitizers build

### DIFF
--- a/src/server/list_family_test.cc
+++ b/src/server/list_family_test.cc
@@ -824,7 +824,6 @@ TEST_F(ListFamilyTest, BLMoveRings) {
       }));
     }
   }
-#pragma GCC diagnostic pop
 
   ThisFiber::SleepFor(5ms);
 
@@ -1057,4 +1056,5 @@ TEST_F(ListFamilyTest, ContendExpire) {
   }
 }
 
+#pragma GCC diagnostic pop
 }  // namespace dfly


### PR DESCRIPTION
Same reason as #3542 