### PR TITLE
chore: remove DflyVersion::VER0

### DIFF
--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -133,7 +133,7 @@ struct ConnectionState {
     uint32_t repl_flow_id = UINT32_MAX;
     std::string repl_ip_address;
     uint32_t repl_listening_port = 0;
-    DflyVersion repl_version = DflyVersion::VER0;
+    DflyVersion repl_version = DflyVersion::VER1;
   };
 
   struct SquashingInfo {

--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -43,7 +43,7 @@ struct FlowInfo {
   std::unique_ptr<JournalStreamer> streamer;  // Streamer for stable sync phase
   std::string eof_token;
 
-  DflyVersion version = DflyVersion::VER0;
+  DflyVersion version = DflyVersion::VER1;
 
   std::optional<LSN> start_partial_sync_at;
   uint64_t last_acked_lsn = 0;
@@ -128,7 +128,7 @@ class DflyCmd {
     std::string id;
     std::string address;
     uint32_t listening_port;
-    DflyVersion version = DflyVersion::VER0;
+    DflyVersion version = DflyVersion::VER1;
 
     // Flows describe the state of shard-local flow.
     // They are always indexed by the shard index on the master.
@@ -153,6 +153,7 @@ class DflyCmd {
   // Master side acces method to replication info of that connection.
   std::shared_ptr<ReplicaInfo> GetReplicaInfoFromConnection(ConnectionContext* cntx);
 
+  // Master-side command. Provides Replica info.
   std::vector<ReplicaRoleInfo> GetReplicasRoleInfo() const ABSL_LOCKS_EXCLUDED(mu_);
 
   void GetReplicationMemoryStats(ReplicationMemoryStats* out) const ABSL_LOCKS_EXCLUDED(mu_);

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -67,12 +67,6 @@ struct ReplicationMemoryStats {
   size_t full_sync_buf_bytes = 0;          // total bytes used for full sync buffers
 };
 
-struct ReplicaReconnectionsInfo {
-  std::string host;
-  uint16_t port;
-  uint32_t reconnect_count;
-};
-
 struct LoadingStats {
   size_t restore_count = 0;
   size_t failed_restore_count = 0;
@@ -128,8 +122,16 @@ struct Metrics {
 
   // command call frequencies (count, aggregated latency in usec).
   std::map<std::string, std::pair<uint64_t, uint64_t>> cmd_stats_map;
-  std::vector<ReplicaRoleInfo> replication_metrics;
-  std::optional<ReplicaReconnectionsInfo> replica_reconnections;
+
+  // Replica info on the master side.
+  std::vector<ReplicaRoleInfo> master_side_replicas_info;
+
+  struct ReplicaInfo {
+    uint32_t reconnect_count;
+  };
+
+  // Replica reconnect stats on the replica side. Undefined for master
+  std::optional<ReplicaInfo> replica_side_info;
 
   LoadingStats loading_stats;
 };

--- a/src/server/version.h
+++ b/src/server/version.h
@@ -17,9 +17,6 @@ const char* GetVersion();
 // Please document for each new entry what the behavior changes are
 // and to which released versions this corresponds.
 enum class DflyVersion {
-  //         ver <= 1.3
-  VER0,
-
   // 1.4  <= ver <= 1.10
   // - Supports receiving ACKs from replicas
   // - Sends version back on REPLCONF capa dragonfly


### PR DESCRIPTION
Stop supporting DflyVersion::VER0 from more than a year ago. In addition, rename Metrics fields to make them more clear General improvements and fix the reconnect metric.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->