### PR TITLE
feat: add slave_repl_offset to the replication section.

### DIFF
--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -1096,6 +1096,10 @@ auto Replica::GetSummary() const -> Summary {
     res.master_last_io_sec = (ProactorBase::GetMonotonicTimeNs() - last_io_time) / 1000000000UL;
     res.master_id = master_context_.master_repl_id;
     res.reconnect_count = reconnect_count_;
+    res.repl_offset_sum = 0;
+    for (uint64_t offs : GetReplicaOffset()) {
+      res.repl_offset_sum += offs;
+    }
     return res;
   };
 

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -121,6 +121,9 @@ class Replica : ProtocolClient {
     time_t master_last_io_sec;  // monotonic clock.
     std::string master_id;
     uint32_t reconnect_count;
+
+    // sum of the offsets on all the flows.
+    uint64_t repl_offset_sum;
   };
 
   Summary GetSummary() const;  // thread-safe, blocks fiber, makes a hop.

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2379,6 +2379,8 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
         append("master_last_io_seconds_ago", rinfo.master_last_io_sec);
         append("master_sync_in_progress", rinfo.full_sync_in_progress);
         append("master_replid", rinfo.master_id);
+        if (rinfo.full_sync_done)
+          append("slave_repl_offset", rinfo.repl_offset_sum);
         append("slave_priority", GetFlag(FLAGS_replica_priority));
         append("slave_read_only", 1);
       };

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1556,7 +1556,6 @@ async def test_replicaof_flag(df_factory):
 
     await wait_available_async(c_replica)  # give it time to startup
     # wait until we have a connection
-    await wait_for_replica_status(c_replica, status="up")
     await check_all_replicas_finished([c_replica], c_master)
 
     dbsize = await c_replica.dbsize()
@@ -1636,7 +1635,6 @@ async def test_replicaof_flag_disconnect(df_factory):
 
     c_replica = replica.client()
     await wait_available_async(c_replica)
-    await wait_for_replica_status(c_replica, status="up")
     await check_all_replicas_finished([c_replica], c_master)
 
     dbsize = await c_replica.dbsize()
@@ -1672,7 +1670,6 @@ async def test_df_crash_on_memcached_error(df_factory):
     c_replica = replica.client()
     await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
     await wait_available_async(c_replica)
-    await wait_for_replica_status(c_replica, status="up")
     await c_replica.close()
 
     memcached_client = pymemcache.Client(f"127.0.0.1:{replica.mc_port}")
@@ -1731,7 +1728,6 @@ async def test_network_disconnect(df_factory, df_seeder_factory):
 
             # Give time to detect dropped connection and reconnect
             await asyncio.sleep(1.0)
-            await wait_for_replica_status(c_replica, status="up")
             await wait_available_async(c_replica)
 
             capture = await seeder.capture()
@@ -1770,7 +1766,6 @@ async def test_network_disconnect_active_stream(df_factory, df_seeder_factory):
 
             # Give time to detect dropped connection and reconnect
             await asyncio.sleep(1.0)
-            await wait_for_replica_status(c_replica, status="up")
             await wait_available_async(c_replica)
 
             logging.debug(await c_replica.execute_command("INFO REPLICATION"))
@@ -1817,7 +1812,6 @@ async def test_network_disconnect_small_buffer(df_factory, df_seeder_factory):
 
             # Give time to detect dropped connection and reconnect
             await asyncio.sleep(1.0)
-            await wait_for_replica_status(c_replica, status="up")
             await wait_available_async(c_replica)
 
             # logging.debug(await c_replica.execute_command("INFO REPLICATION"))
@@ -1852,7 +1846,6 @@ async def test_replica_reconnections_after_network_disconnect(df_factory, df_see
             await c_replica.execute_command(f"REPLICAOF localhost {proxy.port}")
 
             # Wait replica to be up and synchronized with master
-            await wait_for_replica_status(c_replica, status="up")
             await wait_available_async(c_replica)
 
             initial_reconnects_count = await get_replica_reconnects_count(replica)
@@ -1869,7 +1862,6 @@ async def test_replica_reconnections_after_network_disconnect(df_factory, df_see
             task = asyncio.create_task(proxy.serve())
 
             # Wait replica to be reconnected and synchronized with master
-            await wait_for_replica_status(c_replica, status="up")
             await wait_available_async(c_replica)
 
             capture = await seeder.capture()

--- a/tests/dragonfly/utility.py
+++ b/tests/dragonfly/utility.py
@@ -14,6 +14,7 @@ import json
 import subprocess
 import pytest
 import os
+from typing import Iterable, Union
 from enum import Enum
 
 
@@ -91,22 +92,30 @@ async def info_tick_timer(client: aioredis.Redis, section=None, **kwargs):
         yield x
 
 
-async def wait_available_async(client: aioredis.Redis, timeout=120):
-    """Block until instance exits loading phase"""
-    its = 0
-    start = time.time()
-    while (time.time() - start) < timeout:
-        try:
-            await client.ping()
-            return
-        except aioredis.BusyLoadingError as e:
-            assert "Dragonfly is loading the dataset in memory" in str(e)
+# wait for replica to reach stable sync state
+async def wait_available_async(
+    clients: Union[aioredis.Redis, Iterable[aioredis.Redis]], timeout=120
+):
+    if isinstance(clients, aioredis.Redis):
+        """Block until instance exits loading phase"""
+        # First we make sure that ping passes
+        start = time.time()
+        while (time.time() - start) < timeout:
+            try:
+                await clients.ping()
+                break
+            except aioredis.BusyLoadingError as e:
+                assert "Dragonfly is loading the dataset in memory" in str(e)
+        timeout -= time.time() - start
+        if timeout <= 0:
+            raise RuntimeError("Timed out!")
 
-        # Print W to indicate test is waiting for replica
-        print("W", end="", flush=True)
-        await asyncio.sleep(0.01)
-        its += 1
-    raise RuntimeError("Client did not become available in time!")
+        # Secondly for replicas, we make sure they reached stable state replicaton
+        async for info, breaker in info_tick_timer(clients, "REPLICATION", timeout=timeout):
+            with breaker:
+                assert info["role"] == "master" or "slave_repl_offset" in info, info
+        return
+    await asyncio.gather(*(wait_available_async(c) for c in clients))
 
 
 class SizeChange(Enum):

--- a/tests/dragonfly/utility.py
+++ b/tests/dragonfly/utility.py
@@ -92,7 +92,9 @@ async def info_tick_timer(client: aioredis.Redis, section=None, **kwargs):
         yield x
 
 
-# wait for replica to reach stable sync state
+# wait for a process becomes "responsive":
+# for a master - waits that it finishes loading a snapshot if it's budy doing so,
+# and for replica it waits until it finishes its full sync stage and reaches the stable sync state.
 async def wait_available_async(
     clients: Union[aioredis.Redis, Iterable[aioredis.Redis]], timeout=120
 ):


### PR DESCRIPTION
In Valkey slave_repl_offset denotes the replication offset on replica site during stable sync phase. During fullsync phase it appears with 0 value.

In Dragonfly this field appears only after full sync has completed, thus it allows to check whether Dragonfly reached stable sync phase. The value of this field describes the cumulative progress of all the replication flows and it does not directly correspond to master side metrics.

In addition, this PR fixes the bug in wait_available_async() function in our replication tests. This function is intended to wait until a replica reaches stable state and it did by sending pings until they do not respond with LOADING error, hence the assumption is that the replica is in full sync state already.

However it can happen that master_link_status is "up" but replica has not reached full sync state, and the PING will succeed just because wait_available_async() was called before full sync started. The whole approach of polling the state is fragile.

Now we use `slave_repl_offset` explicitly to see if the replica reaches stable state.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->