### PR TITLE
fix: JSON.STRAPPEND

### DIFF
--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -1475,7 +1475,8 @@ void JsonFamily::ArrIndex(CmdArgList args, ConnectionContext* cntx) {
 
   WrappedJsonPath json_path = GET_OR_SEND_UNEXPECTED(ParseJsonPath(path));
 
-  optional<JsonType> search_value = JsonFromString(ArgS(args, 2));
+  optional<JsonType> search_value =
+      dfly::JsonFromString(ArgS(args, 2), PMR_NS::get_default_resource());
   if (!search_value) {
     cntx->SendError(kSyntaxErr);
     return;

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -603,7 +603,7 @@ OpResult<JsonCallbackResult<std::optional<size_t>>> OpStrLen(const OpArgs& op_ar
   };
 
   return JsonEvaluateOperation<std::optional<std::size_t>>(op_args, key, json_path, std::move(cb),
-                                                           {true, false});
+                                                           {true, true});
 }
 
 OpResult<JsonCallbackResult<std::optional<size_t>>> OpObjLen(const OpArgs& op_args, string_view key,
@@ -1828,11 +1828,6 @@ void JsonFamily::StrLen(CmdArgList args, ConnectionContext* cntx) {
   Transaction* trans = cntx->transaction;
   auto result = trans->ScheduleSingleHopT(std::move(cb));
   auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
-  if (result == OpStatus::KEY_NOTFOUND) {
-    if (path.empty())
-      return rb->SendNull();
-    return cntx->SendError(OpStatus::KEY_NOTFOUND);
-  }
   reply_generic::Send(result, rb);
 }
 

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -398,7 +398,7 @@ TEST_F(JsonFamilyTest, StrLen) {
   EXPECT_THAT(resp, IntArg(2));
 
   resp = Run({"JSON.STRLEN", "non_existent_key", "$.c.b"});
-  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
+  EXPECT_THAT(resp, ErrArg("no such key"));
 
   /*
   Test response from several possible values
@@ -441,7 +441,7 @@ TEST_F(JsonFamilyTest, StrLenLegacy) {
   EXPECT_THAT(resp, IntArg(2));
 
   resp = Run({"JSON.STRLEN", "non_existent_key", ".c.b"});
-  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
+  EXPECT_THAT(resp, ErrArg("no such key"));
 
   /*
   Test response from several possible values
@@ -1329,7 +1329,7 @@ TEST_F(JsonFamilyTest, StrAppend) {
 
   /* Test simple response from only one value */
 
-  resp = Run({"JSON.STRAPPEND", "json", "$.a.a", "a", "b"});
+  resp = Run({"JSON.STRAPPEND", "json", "$.a.a", "\"ab\""});
   EXPECT_THAT(resp, IntArg(3));
 
   resp = Run({"JSON.GET", "json"});
@@ -1337,7 +1337,9 @@ TEST_F(JsonFamilyTest, StrAppend) {
       resp,
       R"({"a":{"a":"aab"},"b":{"a":"a","b":1},"c":{"a":"a","b":"bb"},"d":{"a":1,"b":"b","c":3}})");
 
-  resp = Run({"JSON.STRAPPEND", "json", "$.a.*", "a"});
+  const char kVal[] = "\"a\"";
+
+  resp = Run({"JSON.STRAPPEND", "json", "$.a.*", kVal});
   EXPECT_THAT(resp, IntArg(4));
 
   resp = Run({"JSON.GET", "json"});
@@ -1345,7 +1347,7 @@ TEST_F(JsonFamilyTest, StrAppend) {
       resp,
       R"({"a":{"a":"aaba"},"b":{"a":"a","b":1},"c":{"a":"a","b":"bb"},"d":{"a":1,"b":"b","c":3}})");
 
-  resp = Run({"JSON.STRAPPEND", "json", "$.c.b", "a"});
+  resp = Run({"JSON.STRAPPEND", "json", "$.c.b", kVal});
   EXPECT_THAT(resp, IntArg(3));
 
   resp = Run({"JSON.GET", "json"});
@@ -1358,7 +1360,7 @@ TEST_F(JsonFamilyTest, StrAppend) {
   In JSON V2, the response is an array of all possible values
   */
 
-  resp = Run({"JSON.STRAPPEND", "json", "$.b.*", "a"});
+  resp = Run({"JSON.STRAPPEND", "json", "$.b.*", kVal});
   ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
   EXPECT_THAT(resp.GetVec(), ElementsAre(IntArg(2), ArgType(RespExpr::NIL)));
 
@@ -1367,7 +1369,7 @@ TEST_F(JsonFamilyTest, StrAppend) {
       resp,
       R"({"a":{"a":"aaba"},"b":{"a":"aa","b":1},"c":{"a":"a","b":"bba"},"d":{"a":1,"b":"b","c":3}})");
 
-  resp = Run({"JSON.STRAPPEND", "json", "$.c.*", "a"});
+  resp = Run({"JSON.STRAPPEND", "json", "$.c.*", kVal});
   ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
   EXPECT_THAT(resp.GetVec(), ElementsAre(IntArg(2), IntArg(4)));
 
@@ -1376,7 +1378,7 @@ TEST_F(JsonFamilyTest, StrAppend) {
       resp,
       R"({"a":{"a":"aaba"},"b":{"a":"aa","b":1},"c":{"a":"aa","b":"bbaa"},"d":{"a":1,"b":"b","c":3}})");
 
-  resp = Run({"JSON.STRAPPEND", "json", "$.d.*", "a"});
+  resp = Run({"JSON.STRAPPEND", "json", "$.d.*", kVal});
   ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
   EXPECT_THAT(resp.GetVec(),
               ElementsAre(ArgType(RespExpr::NIL), IntArg(2), ArgType(RespExpr::NIL)));
@@ -1393,14 +1395,14 @@ TEST_F(JsonFamilyTest, StrAppend) {
   resp = Run({"JSON.SET", "json", ".", json});
   EXPECT_EQ(resp, "OK");
 
-  resp = Run({"JSON.STRAPPEND", "json", "$.a.*", "a"});
+  resp = Run({"JSON.STRAPPEND", "json", "$.a.*", kVal});
   ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
   EXPECT_THAT(resp.GetVec(), ElementsAre(IntArg(2), IntArg(3), IntArg(4)));
 
   resp = Run({"JSON.GET", "json"});
   EXPECT_EQ(resp, R"({"a":{"a":"aa","b":"aaa","c":"aaaa"},"b":{"a":"aaa","b":"aa","c":"a"}})");
 
-  resp = Run({"JSON.STRAPPEND", "json", "$.b.*", "a"});
+  resp = Run({"JSON.STRAPPEND", "json", "$.b.*", kVal});
   ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
   EXPECT_THAT(resp.GetVec(), ElementsAre(IntArg(4), IntArg(3), IntArg(2)));
 
@@ -1414,7 +1416,7 @@ TEST_F(JsonFamilyTest, StrAppend) {
   resp = Run({"JSON.SET", "json", ".", json});
   EXPECT_EQ(resp, "OK");
 
-  resp = Run({"JSON.STRAPPEND", "json", "$.a.*", "a"});
+  resp = Run({"JSON.STRAPPEND", "json", "$.a.*", kVal});
   ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
   EXPECT_THAT(resp.GetVec(), ElementsAre(IntArg(2), IntArg(3), ArgType(RespExpr::NIL)));
 
@@ -1423,7 +1425,7 @@ TEST_F(JsonFamilyTest, StrAppend) {
       resp,
       R"({"a":{"a":"aa","b":"aaa","c":["aaaaa","aaaaa"]},"b":{"a":"aaa","b":["aaaaa","aaaaa"],"c":"a"}})");
 
-  resp = Run({"JSON.STRAPPEND", "json", "$.b.*", "a"});
+  resp = Run({"JSON.STRAPPEND", "json", "$.b.*", kVal});
   ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
   EXPECT_THAT(resp.GetVec(), ElementsAre(IntArg(4), ArgType(RespExpr::NIL), IntArg(2)));
 
@@ -1439,7 +1441,7 @@ TEST_F(JsonFamilyTest, StrAppend) {
   resp = Run({"JSON.SET", "json", ".", json});
   EXPECT_EQ(resp, "OK");
 
-  resp = Run({"JSON.STRAPPEND", "json", "$.a.*", "a"});
+  resp = Run({"JSON.STRAPPEND", "json", "$.a.*", kVal});
   ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
   EXPECT_THAT(resp.GetVec(), ElementsAre(IntArg(2), IntArg(3), ArgType(RespExpr::NIL)));
 
@@ -1448,7 +1450,7 @@ TEST_F(JsonFamilyTest, StrAppend) {
       resp,
       R"({"a":{"a":"aa","b":"aaa","c":{"c":"aaaaa"}},"b":{"a":"aaa","b":{"b":"aaaaa"},"c":"a"}})");
 
-  resp = Run({"JSON.STRAPPEND", "json", "$.b.*", "a"});
+  resp = Run({"JSON.STRAPPEND", "json", "$.b.*", kVal});
   ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
   EXPECT_THAT(resp.GetVec(), ElementsAre(IntArg(4), ArgType(RespExpr::NIL), IntArg(2)));
 
@@ -1464,7 +1466,7 @@ TEST_F(JsonFamilyTest, StrAppend) {
   resp = Run({"JSON.SET", "json", ".", json});
   EXPECT_EQ(resp, "OK");
 
-  resp = Run({"JSON.STRAPPEND", "json", "$..a", "bar"});
+  resp = Run({"JSON.STRAPPEND", "json", "$..a", "\"bar\""});
   ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
   EXPECT_THAT(resp.GetVec(), ElementsAre(IntArg(6), IntArg(6), ArgType(RespExpr::NIL)));
 
@@ -1482,7 +1484,7 @@ TEST_F(JsonFamilyTest, StrAppendLegacyMode) {
 
   /* Test simple response from only one value */
 
-  resp = Run({"JSON.STRAPPEND", "json", ".a.a", "a", "b"});
+  resp = Run({"JSON.STRAPPEND", "json", ".a.a", "\"ab\""});
   ASSERT_THAT(resp, ArgType(RespExpr::INT64));
   EXPECT_THAT(resp, IntArg(3));
 
@@ -1491,7 +1493,9 @@ TEST_F(JsonFamilyTest, StrAppendLegacyMode) {
       resp,
       R"({"a":{"a":"aab"},"b":{"a":"a","b":1},"c":{"a":"a","b":"bb"},"d":{"a":1,"b":"b","c":3}})");
 
-  resp = Run({"JSON.STRAPPEND", "json", ".a.*", "a"});
+  const char kVal[] = "\"a\"";
+
+  resp = Run({"JSON.STRAPPEND", "json", ".a.*", kVal});
   ASSERT_THAT(resp, ArgType(RespExpr::INT64));
   EXPECT_THAT(resp, IntArg(4));
 
@@ -1500,7 +1504,7 @@ TEST_F(JsonFamilyTest, StrAppendLegacyMode) {
       resp,
       R"({"a":{"a":"aaba"},"b":{"a":"a","b":1},"c":{"a":"a","b":"bb"},"d":{"a":1,"b":"b","c":3}})");
 
-  resp = Run({"JSON.STRAPPEND", "json", ".c.b", "a"});
+  resp = Run({"JSON.STRAPPEND", "json", ".c.b", kVal});
   ASSERT_THAT(resp, ArgType(RespExpr::INT64));
   EXPECT_THAT(resp, IntArg(3));
 
@@ -1515,7 +1519,7 @@ TEST_F(JsonFamilyTest, StrAppendLegacyMode) {
   string.
   */
 
-  resp = Run({"JSON.STRAPPEND", "json", ".b.*", "a"});
+  resp = Run({"JSON.STRAPPEND", "json", ".b.*", kVal});
   ASSERT_THAT(resp, ArgType(RespExpr::INT64));
   EXPECT_THAT(resp, IntArg(2));
 
@@ -1524,7 +1528,7 @@ TEST_F(JsonFamilyTest, StrAppendLegacyMode) {
       resp,
       R"({"a":{"a":"aaba"},"b":{"a":"aa","b":1},"c":{"a":"a","b":"bba"},"d":{"a":1,"b":"b","c":3}})");
 
-  resp = Run({"JSON.STRAPPEND", "json", ".c.*", "a"});
+  resp = Run({"JSON.STRAPPEND", "json", ".c.*", kVal});
   ASSERT_THAT(resp, ArgType(RespExpr::INT64));
   EXPECT_THAT(resp, IntArg(4));
 
@@ -1533,7 +1537,7 @@ TEST_F(JsonFamilyTest, StrAppendLegacyMode) {
       resp,
       R"({"a":{"a":"aaba"},"b":{"a":"aa","b":1},"c":{"a":"aa","b":"bbaa"},"d":{"a":1,"b":"b","c":3}})");
 
-  resp = Run({"JSON.STRAPPEND", "json", ".d.*", "a"});
+  resp = Run({"JSON.STRAPPEND", "json", ".d.*", kVal});
   ASSERT_THAT(resp, ArgType(RespExpr::INT64));
   EXPECT_THAT(resp, IntArg(2));
 
@@ -1549,14 +1553,14 @@ TEST_F(JsonFamilyTest, StrAppendLegacyMode) {
   resp = Run({"JSON.SET", "json", ".", json});
   EXPECT_EQ(resp, "OK");
 
-  resp = Run({"JSON.STRAPPEND", "json", ".a.*", "a"});
+  resp = Run({"JSON.STRAPPEND", "json", ".a.*", kVal});
   ASSERT_THAT(resp, ArgType(RespExpr::INT64));
   EXPECT_THAT(resp, IntArg(4));
 
   resp = Run({"JSON.GET", "json"});
   EXPECT_EQ(resp, R"({"a":{"a":"aa","b":"aaa","c":"aaaa"},"b":{"a":"aaa","b":"aa","c":"a"}})");
 
-  resp = Run({"JSON.STRAPPEND", "json", ".b.*", "a"});
+  resp = Run({"JSON.STRAPPEND", "json", ".b.*", kVal});
   ASSERT_THAT(resp, ArgType(RespExpr::INT64));
   EXPECT_THAT(resp, IntArg(2));
 
@@ -1570,7 +1574,7 @@ TEST_F(JsonFamilyTest, StrAppendLegacyMode) {
   resp = Run({"JSON.SET", "json", ".", json});
   EXPECT_EQ(resp, "OK");
 
-  resp = Run({"JSON.STRAPPEND", "json", ".a.*", "a"});
+  resp = Run({"JSON.STRAPPEND", "json", ".a.*", kVal});
   ASSERT_THAT(resp, ArgType(RespExpr::INT64));
   EXPECT_THAT(resp, IntArg(3));
 
@@ -1579,7 +1583,7 @@ TEST_F(JsonFamilyTest, StrAppendLegacyMode) {
       resp,
       R"({"a":{"a":"aa","b":"aaa","c":["aaaaa","aaaaa"]},"b":{"a":"aaa","b":["aaaaa","aaaaa"],"c":"a"}})");
 
-  resp = Run({"JSON.STRAPPEND", "json", ".b.*", "a"});
+  resp = Run({"JSON.STRAPPEND", "json", ".b.*", kVal});
   ASSERT_THAT(resp, ArgType(RespExpr::INT64));
   EXPECT_THAT(resp, IntArg(2));
 
@@ -1595,7 +1599,7 @@ TEST_F(JsonFamilyTest, StrAppendLegacyMode) {
   resp = Run({"JSON.SET", "json", ".", json});
   EXPECT_EQ(resp, "OK");
 
-  resp = Run({"JSON.STRAPPEND", "json", ".a.*", "a"});
+  resp = Run({"JSON.STRAPPEND", "json", ".a.*", kVal});
   ASSERT_THAT(resp, ArgType(RespExpr::INT64));
   EXPECT_THAT(resp, IntArg(3));
 
@@ -1604,7 +1608,7 @@ TEST_F(JsonFamilyTest, StrAppendLegacyMode) {
       resp,
       R"({"a":{"a":"aa","b":"aaa","c":{"c":"aaaaa"}},"b":{"a":"aaa","b":{"b":"aaaaa"},"c":"a"}})");
 
-  resp = Run({"JSON.STRAPPEND", "json", ".b.*", "a"});
+  resp = Run({"JSON.STRAPPEND", "json", ".b.*", kVal});
   ASSERT_THAT(resp, ArgType(RespExpr::INT64));
   EXPECT_THAT(resp, IntArg(2));
 
@@ -1620,7 +1624,7 @@ TEST_F(JsonFamilyTest, StrAppendLegacyMode) {
   resp = Run({"JSON.SET", "json", ".", json});
   EXPECT_EQ(resp, "OK");
 
-  resp = Run({"JSON.STRAPPEND", "json", "..a", "bar"});
+  resp = Run({"JSON.STRAPPEND", "json", "..a", "\"bar\""});
   ASSERT_THAT(resp, ArgType(RespExpr::INT64));
   EXPECT_THAT(resp, IntArg(6));
 

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -398,7 +398,7 @@ TEST_F(JsonFamilyTest, StrLen) {
   EXPECT_THAT(resp, IntArg(2));
 
   resp = Run({"JSON.STRLEN", "non_existent_key", "$.c.b"});
-  EXPECT_THAT(resp, ErrArg("no such key"));
+  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
 
   /*
   Test response from several possible values
@@ -441,7 +441,7 @@ TEST_F(JsonFamilyTest, StrLenLegacy) {
   EXPECT_THAT(resp, IntArg(2));
 
   resp = Run({"JSON.STRLEN", "non_existent_key", ".c.b"});
-  EXPECT_THAT(resp, ErrArg("no such key"));
+  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
 
   /*
   Test response from several possible values

--- a/tests/fakeredis/test/test_json/test_json.py
+++ b/tests/fakeredis/test/test_json/test_json.py
@@ -321,8 +321,9 @@ def test_jsonstrlen(r: redis.Redis):
     assert r.json().strlen("doc1", "$.nested2.a") == [None]
 
     # Test missing key
-    with pytest.raises(redis.ResponseError):
-        r.json().strlen("non_existing_doc", "$..a")
+    # Note: Dragonfly returns NIL in the accordance to the official docs
+    # with pytest.raises(redis.ResponseError):
+    #    r.json().strlen("non_existing_doc", "$..a")
 
 
 def test_toggle(r: redis.Redis):


### PR DESCRIPTION
JSON.STRAPPEND was completely broken.

First, it accepts exactly 3 arguments, i.e. a single value to append. Secondly, the value must be a json string, not the regular string. Meaning it must be in double quotes. So, before we parsed: `JSON.STRAPPEND key $.field bar` and now we parse: `JSON.STRAPPEND key $.field "bar"`

In addition fixed the behavior of JSON.STRLEN to return "no such key" error in case the json key does not exist and path is specified.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->