### PR TITLE
refactor: remove toUpper() from cmd_arg_parser

### DIFF
--- a/src/facade/cmd_arg_parser.cc
+++ b/src/facade/cmd_arg_parser.cc
@@ -5,7 +5,6 @@
 #include "facade/cmd_arg_parser.h"
 
 #include <absl/strings/ascii.h>
-#include <absl/strings/match.h>
 
 #include "base/logging.h"
 #include "facade/error.h"
@@ -17,7 +16,7 @@ CmdArgParser::CheckProxy::operator bool() const {
     return false;
 
   std::string_view arg = parser_->SafeSV(idx_);
-  if ((!ignore_case_ && arg != tag_) || (ignore_case_ && !absl::EqualsIgnoreCase(arg, tag_)))
+  if (!absl::EqualsIgnoreCase(arg, tag_))
     return false;
 
   if (idx_ + expect_tail_ >= parser_->args_.size()) {

--- a/src/facade/cmd_arg_parser.cc
+++ b/src/facade/cmd_arg_parser.cc
@@ -26,9 +26,6 @@ CmdArgParser::CheckProxy::operator bool() const {
 
   parser_->cur_i_++;
 
-  if (size_t uidx = idx_ + expect_tail_ + 1; next_upper_ && uidx < parser_->args_.size())
-    parser_->ToUpper(uidx);
-
   return true;
 }
 

--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -29,12 +29,6 @@ struct CmdArgParser {
       return *this;
     }
 
-    // Call ToUpper on the next value after the flag and its expected tail.
-    CheckProxy& NextUpper() {
-      next_upper_ = true;
-      return *this;
-    }
-
    private:
     friend struct CmdArgParser;
 
@@ -46,7 +40,6 @@ struct CmdArgParser {
     std::string_view tag_;
     size_t idx_;
     size_t expect_tail_ = 0;
-    bool next_upper_ = false;
   };
 
   struct ErrorInfo {

--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <absl/strings/match.h>
 #include <absl/strings/numbers.h>
 
 #include <optional>
@@ -34,11 +35,6 @@ struct CmdArgParser {
       return *this;
     }
 
-    CheckProxy& IgnoreCase() {
-      ignore_case_ = true;
-      return *this;
-    }
-
    private:
     friend struct CmdArgParser;
 
@@ -51,7 +47,6 @@ struct CmdArgParser {
     size_t idx_;
     size_t expect_tail_ = 0;
     bool next_upper_ = false;
-    bool ignore_case_ = false;
   };
 
   struct ErrorInfo {
@@ -157,7 +152,7 @@ struct CmdArgParser {
   template <class T, class... Cases>
   std::optional<std::decay_t<T>> SwitchImpl(std::string_view arg, std::string_view tag, T&& value,
                                             Cases&&... cases) {
-    if (arg == tag)
+    if (absl::EqualsIgnoreCase(arg, tag))
       return std::forward<T>(value);
 
     if constexpr (sizeof...(cases) > 0)

--- a/src/facade/cmd_arg_parser_test.cc
+++ b/src/facade/cmd_arg_parser_test.cc
@@ -120,17 +120,15 @@ TEST_F(CmdArgParserTest, Cases) {
   EXPECT_EQ(err->index, 1);
 }
 
-TEST_F(CmdArgParserTest, NextUpper) {
+TEST_F(CmdArgParserTest, IgnoreCase) {
   auto parser = Make({"hello", "marker", "taail", "world"});
 
-  parser.ToUpper();
-  EXPECT_EQ(absl::implicit_cast<string_view>(parser.Next()), "HELLO"sv);
+  EXPECT_EQ(absl::implicit_cast<string_view>(parser.Next()), "hello"sv);
 
-  parser.ToUpper();
-  EXPECT_TRUE(parser.Check("MARKER"sv).ExpectTail(1).NextUpper());
+  EXPECT_TRUE(parser.Check("MARKER"sv).ExpectTail(1));
   parser.Skip(1);
 
-  EXPECT_EQ(absl::implicit_cast<string_view>(parser.Next()), "WORLD"sv);
+  EXPECT_EQ(absl::implicit_cast<string_view>(parser.Next()), "world"sv);
 }
 
 }  // namespace facade

--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -1015,7 +1015,7 @@ nonstd::expected<CommandList, std::string> ParseToCommandList(CmdArgList args, b
         make_unexpected("BITFIELD_RO only supports the GET subcommand");
       }
       using pol = Overflow::Policy;
-      auto res = parser.ToUpper().Switch("SAT", pol::SAT, "WRAP", pol::WRAP, "FAIL", pol::FAIL);
+      auto res = parser.Switch("SAT", pol::SAT, "WRAP", pol::WRAP, "FAIL", pol::FAIL);
       if (!parser.HasError()) {
         result.push_back(Overflow{res});
         continue;
@@ -1039,7 +1039,7 @@ nonstd::expected<CommandList, std::string> ParseToCommandList(CmdArgList args, b
       return make_unexpected("BITFIELD_RO only supports the GET subcommand");
     }
 
-    auto value = parser.ToUpper().Next<int64_t>();
+    auto value = parser.Next<int64_t>();
     if (parser.HasError()) {
       parser.Error();
       return make_unexpected(kSyntaxErr);

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -404,7 +404,7 @@ void DflyCmd::TakeOver(CmdArgList args, ConnectionContext* cntx) {
     return cntx->SendError("timeout is negative");
   }
 
-  bool save_flag = static_cast<bool>(parser.Check("SAVE").IgnoreCase());
+  bool save_flag = static_cast<bool>(parser.Check("SAVE"));
 
   string_view sync_id_str = parser.Next<std::string_view>();
 

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -731,7 +731,7 @@ void HSetEx(CmdArgList args, ConnectionContext* cntx) {
 
   string_view key = parser.Next();
 
-  bool skip_if_exists = static_cast<bool>(parser.Check("NX"sv).IgnoreCase());
+  bool skip_if_exists = static_cast<bool>(parser.Check("NX"sv));
   string_view ttl_str = parser.Next();
 
   uint32_t ttl_sec;

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -1838,15 +1838,15 @@ void JsonFamily::Get(CmdArgList args, ConnectionContext* cntx) {
   vector<pair<string_view, WrappedJsonPath>> paths;
 
   while (parser.HasNext()) {
-    if (parser.Check("SPACE").IgnoreCase().ExpectTail(1)) {
+    if (parser.Check("SPACE").ExpectTail(1)) {
       space = parser.Next();
       continue;
     }
-    if (parser.Check("NEWLINE").IgnoreCase().ExpectTail(1)) {
+    if (parser.Check("NEWLINE").ExpectTail(1)) {
       new_line = parser.Next();
       continue;
     }
-    if (parser.Check("INDENT").IgnoreCase().ExpectTail(1)) {
+    if (parser.Check("INDENT").ExpectTail(1)) {
       indent = parser.Next();
       continue;
     }

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -100,7 +100,6 @@ string ListPop(ListDir dir, quicklist* ql) {
 }
 
 ListDir ParseDir(facade::CmdArgParser* parser) {
-  parser->ToUpper();
   return parser->Switch("LEFT", ListDir::LEFT, "RIGHT", ListDir::RIGHT);
 }
 
@@ -902,7 +901,7 @@ void ListFamily::LPos(CmdArgList args, ConnectionContext* cntx) {
   uint32_t max_len = 0;
   bool skip_count = true;
 
-  while (parser.ToUpper().HasNext()) {
+  while (parser.HasNext()) {
     if (parser.Check("RANK").ExpectTail(1)) {
       rank = parser.Next<int>();
       continue;
@@ -986,7 +985,7 @@ void ListFamily::LIndex(CmdArgList args, ConnectionContext* cntx) {
 void ListFamily::LInsert(CmdArgList args, ConnectionContext* cntx) {
   facade::CmdArgParser parser{args};
   string_view key = parser.Next();
-  InsertParam where = parser.ToUpper().Switch("AFTER", INSERT_AFTER, "BEFORE", INSERT_BEFORE);
+  InsertParam where = parser.Switch("AFTER", INSERT_AFTER, "BEFORE", INSERT_BEFORE);
   auto [pivot, elem] = parser.Next<string_view, string_view>();
 
   if (auto err = parser.Error(); err)

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -49,12 +49,6 @@ void TraverseAllMatching(const DocIndex& index, const OpArgs& op_args, F&& f) {
   } while (cursor);
 }
 
-const absl::flat_hash_map<string_view, search::SchemaField::FieldType> kSchemaTypes = {
-    {"TAG"sv, search::SchemaField::TAG},
-    {"TEXT"sv, search::SchemaField::TEXT},
-    {"NUMERIC"sv, search::SchemaField::NUMERIC},
-    {"VECTOR"sv, search::SchemaField::VECTOR}};
-
 }  // namespace
 
 bool SerializedSearchDoc::operator<(const SerializedSearchDoc& other) const {
@@ -70,15 +64,17 @@ bool SearchParams::ShouldReturnField(std::string_view field) const {
   return !return_fields || any_of(return_fields->begin(), return_fields->end(), cb);
 }
 
-optional<search::SchemaField::FieldType> ParseSearchFieldType(string_view name) {
-  auto it = kSchemaTypes.find(name);
-  return it != kSchemaTypes.end() ? make_optional(it->second) : nullopt;
-}
-
 string_view SearchFieldTypeToString(search::SchemaField::FieldType type) {
-  for (auto [it_name, it_type] : kSchemaTypes)
-    if (it_type == type)
-      return it_name;
+  switch (type) {
+    case search::SchemaField::TAG:
+      return "TAG";
+    case search::SchemaField::TEXT:
+      return "TEXT";
+    case search::SchemaField::NUMERIC:
+      return "NUMERIC";
+    case search::SchemaField::VECTOR:
+      return "VECTOR";
+  }
   ABSL_UNREACHABLE();
   return "";
 }

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -22,7 +22,6 @@ namespace dfly {
 
 using SearchDocData = absl::flat_hash_map<std::string /*field*/, std::string /*value*/>;
 
-std::optional<search::SchemaField::FieldType> ParseSearchFieldType(std::string_view name);
 std::string_view SearchFieldTypeToString(search::SchemaField::FieldType);
 
 struct SerializedSearchDoc {

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -47,20 +47,18 @@ bool IsValidJsonPath(string_view path) {
 search::SchemaField::VectorParams ParseVectorParams(CmdArgParser* parser) {
   search::SchemaField::VectorParams params{};
 
-  params.use_hnsw = parser->ToUpper().Switch("HNSW", true, "FLAT", false);
+  params.use_hnsw = parser->Switch("HNSW", true, "FLAT", false);
   size_t num_args = parser->Next<size_t>();
 
   for (size_t i = 0; i * 2 < num_args; i++) {
-    parser->ToUpper();
-
     if (parser->Check("DIM").ExpectTail(1)) {
       params.dim = parser->Next<size_t>();
       continue;
     }
 
     if (parser->Check("DISTANCE_METRIC").ExpectTail(1)) {
-      params.sim = parser->ToUpper().Switch("L2", search::VectorSimilarity::L2, "COSINE",
-                                            search::VectorSimilarity::COSINE);
+      params.sim = parser->Switch("L2", search::VectorSimilarity::L2, "COSINE",
+                                  search::VectorSimilarity::COSINE);
       continue;
     }
 
@@ -100,13 +98,13 @@ search::SchemaField::VectorParams ParseVectorParams(CmdArgParser* parser) {
 search::SchemaField::TagParams ParseTagParams(CmdArgParser* parser) {
   search::SchemaField::TagParams params{};
   while (parser->HasNext()) {
-    if (parser->Check("SEPARATOR").IgnoreCase().ExpectTail(1)) {
+    if (parser->Check("SEPARATOR").ExpectTail(1)) {
       string_view separator = parser->Next();
       params.separator = separator.front();
       continue;
     }
 
-    if (parser->Check("CASESENSITIVE").IgnoreCase()) {
+    if (parser->Check("CASESENSITIVE")) {
       params.case_sensitive = true;
       continue;
     }
@@ -175,12 +173,12 @@ optional<search::Schema> ParseSchemaOrReply(DocIndex::DataType type, CmdArgParse
     // Flags: check for SORTABLE and NOINDEX
     uint8_t flags = 0;
     while (parser.HasNext()) {
-      if (parser.Check("NOINDEX").IgnoreCase()) {
+      if (parser.Check("NOINDEX")) {
         flags |= search::SchemaField::NOINDEX;
         continue;
       }
 
-      if (parser.Check("SORTABLE").IgnoreCase()) {
+      if (parser.Check("SORTABLE")) {
         flags |= search::SchemaField::SORTABLE;
         continue;
       }
@@ -224,7 +222,7 @@ search::QueryParams ParseQueryParams(CmdArgParser* parser) {
 optional<SearchParams> ParseSearchParamsOrReply(CmdArgParser parser, ConnectionContext* cntx) {
   SearchParams params;
 
-  while (parser.ToUpper().HasNext()) {
+  while (parser.HasNext()) {
     // [LIMIT offset total]
     if (parser.Check("LIMIT").ExpectTail(2)) {
       params.limit_offset = parser.Next<size_t>();
@@ -238,7 +236,7 @@ optional<SearchParams> ParseSearchParamsOrReply(CmdArgParser parser, ConnectionC
       params.return_fields = SearchParams::FieldReturnList{};
       while (params.return_fields->size() < num_fields) {
         string_view ident = parser.Next();
-        string_view alias = parser.Check("AS").IgnoreCase().ExpectTail(1) ? parser.Next() : ident;
+        string_view alias = parser.Check("AS").ExpectTail(1) ? parser.Next() : ident;
         params.return_fields->emplace_back(ident, alias);
       }
       continue;
@@ -257,8 +255,7 @@ optional<SearchParams> ParseSearchParamsOrReply(CmdArgParser parser, ConnectionC
     }
 
     if (parser.Check("SORTBY").ExpectTail(1)) {
-      params.sort_option =
-          search::SortOption{string{parser.Next()}, bool(parser.Check("DESC").IgnoreCase())};
+      params.sort_option = search::SortOption{string{parser.Next()}, bool(parser.Check("DESC"))};
       continue;
     }
 
@@ -287,7 +284,7 @@ optional<AggregateParams> ParseAggregatorParamsOrReply(CmdArgParser parser,
   AggregateParams params;
   tie(params.index, params.query) = parser.Next<string_view, string_view>();
 
-  while (parser.ToUpper().HasNext()) {
+  while (parser.HasNext()) {
     // LOAD count field [field ...]
     if (parser.Check("LOAD").ExpectTail(1)) {
       params.load_fields.resize(parser.Next<size_t>());
@@ -303,7 +300,7 @@ optional<AggregateParams> ParseAggregatorParamsOrReply(CmdArgParser parser,
         field = parser.Next();
 
       vector<aggregate::Reducer> reducers;
-      while (parser.ToUpper().Check("REDUCE").ExpectTail(2)) {
+      while (parser.Check("REDUCE").ExpectTail(2)) {
         parser.ToUpper();  // uppercase for func_name
         auto [func_name, nargs] = parser.Next<string_view, size_t>();
         auto func = aggregate::FindReducerFunc(func_name);
@@ -332,7 +329,7 @@ optional<AggregateParams> ParseAggregatorParamsOrReply(CmdArgParser parser,
     if (parser.Check("SORTBY").ExpectTail(1)) {
       parser.ExpectTag("1");
       string_view field = parser.Next();
-      bool desc = bool(parser.Check("DESC").IgnoreCase());
+      bool desc = bool(parser.Check("DESC"));
 
       params.steps.push_back(aggregate::MakeSortStep(field, desc));
       continue;
@@ -471,10 +468,10 @@ void SearchFamily::FtCreate(CmdArgList args, ConnectionContext* cntx) {
   CmdArgParser parser{args};
   string_view idx_name = parser.Next();
 
-  while (parser.ToUpper().HasNext()) {
+  while (parser.HasNext()) {
     // ON HASH | JSON
     if (parser.Check("ON").ExpectTail(1)) {
-      index.type = parser.ToUpper().Switch("HASH"sv, DocIndex::HASH, "JSON"sv, DocIndex::JSON);
+      index.type = parser.Switch("HASH"sv, DocIndex::HASH, "JSON"sv, DocIndex::JSON);
       continue;
     }
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -435,7 +435,7 @@ void ClientPauseCmd(CmdArgList args, vector<facade::Listener*> listeners, Connec
   auto timeout = parser.Next<uint64_t>();
   ClientPause pause_state = ClientPause::ALL;
   if (parser.HasNext()) {
-    pause_state = parser.ToUpper().Switch("WRITE", ClientPause::WRITE, "ALL", ClientPause::ALL);
+    pause_state = parser.Switch("WRITE", ClientPause::WRITE, "ALL", ClientPause::ALL);
   }
   if (auto err = parser.Error(); err) {
     return cntx->SendError(err->MakeReply());
@@ -470,20 +470,20 @@ void ClientTracking(CmdArgList args, ConnectionContext* cntx) {
   bool is_on = false;
   using Tracking = ConnectionState::ClientTracking;
   Tracking::Options option = Tracking::NONE;
-  if (parser.Check("ON").IgnoreCase()) {
+  if (parser.Check("ON")) {
     is_on = true;
-  } else if (!parser.Check("OFF").IgnoreCase()) {
+  } else if (!parser.Check("OFF")) {
     return cntx->SendError(kSyntaxErr);
   }
 
   bool noloop = false;
 
   if (parser.HasNext()) {
-    if (parser.Check("OPTIN").IgnoreCase()) {
+    if (parser.Check("OPTIN")) {
       option = Tracking::OPTIN;
-    } else if (parser.Check("OPTOUT").IgnoreCase()) {
+    } else if (parser.Check("OPTOUT")) {
       option = Tracking::OPTOUT;
-    } else if (parser.Check("NOLOOP").IgnoreCase()) {
+    } else if (parser.Check("NOLOOP")) {
       noloop = true;
     } else {
       return cntx->SendError(kSyntaxErr);
@@ -491,7 +491,7 @@ void ClientTracking(CmdArgList args, ConnectionContext* cntx) {
   }
 
   if (parser.HasNext()) {
-    if (!noloop && parser.Check("NOLOOP").IgnoreCase()) {
+    if (!noloop && parser.Check("NOLOOP")) {
       noloop = true;
     } else {
       return cntx->SendError(kSyntaxErr);
@@ -520,12 +520,12 @@ void ClientCaching(CmdArgList args, ConnectionContext* cntx) {
 
   using Tracking = ConnectionState::ClientTracking;
   CmdArgParser parser{args};
-  if (parser.Check("YES").IgnoreCase()) {
+  if (parser.Check("YES")) {
     if (!cntx->conn_state.tracking_info_.HasOption(Tracking::OPTIN)) {
       return cntx->SendError(
           "ERR CLIENT CACHING YES is only valid when tracking is enabled in OPTIN mode");
     }
-  } else if (parser.Check("NO").IgnoreCase()) {
+  } else if (parser.Check("NO")) {
     if (!cntx->conn_state.tracking_info_.HasOption(Tracking::OPTOUT)) {
       return cntx->SendError(
           "ERR CLIENT CACHING NO is only valid when tracking is enabled in OPTOUT mode");
@@ -645,7 +645,7 @@ optional<ReplicaOfArgs> ReplicaOfArgs::FromCmdArgs(CmdArgList args, ConnectionCo
   ReplicaOfArgs replicaof_args;
   CmdArgParser parser(args);
 
-  if (parser.Check("NO").IgnoreCase().ExpectTail(1)) {
+  if (parser.Check("NO").ExpectTail(1)) {
     parser.ExpectTag("ONE");
     replicaof_args.port = 0;
   } else {
@@ -2705,7 +2705,7 @@ void ServerFamily::ReplTakeOver(CmdArgList args, ConnectionContext* cntx) {
   CmdArgParser parser{args};
 
   int timeout_sec = parser.Next<int>();
-  bool save_flag = static_cast<bool>(parser.Check("SAVE").IgnoreCase());
+  bool save_flag = static_cast<bool>(parser.Check("SAVE"));
 
   if (parser.HasNext())
     return cntx->SendError(absl::StrCat("Unsupported option:", string_view(parser.Next())));

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -2133,7 +2133,7 @@ void ZSetFamily::ZRange(CmdArgList args, ConnectionContext* cntx) {
 
 void ZSetFamily::ZRangeGeneric(CmdArgList args, ConnectionContext* cntx, RangeParams range_params) {
   facade::CmdArgParser parser{args.subspan(3)};
-  while (parser.ToUpper().HasNext()) {
+  while (parser.HasNext()) {
     if (parser.Check("BYSCORE")) {
       if (exchange(range_params.interval_type, RangeParams::SCORE) == RangeParams::LEX)
         return cntx->SendError("BYSCORE and BYLEX options are not compatible");
@@ -2271,7 +2271,7 @@ void ZSetFamily::ZRandMember(CmdArgList args, ConnectionContext* cntx) {
   int count = is_count ? parser.Next<int>() : 1;
 
   ZSetFamily::RangeParams params;
-  params.with_scores = static_cast<bool>(parser.Check("WITHSCORES").IgnoreCase());
+  params.with_scores = static_cast<bool>(parser.Check("WITHSCORES"));
 
   if (parser.HasNext())
     return cntx->SendError(absl::StrCat("Unsupported option:", string_view(parser.Next())));


### PR DESCRIPTION
fix #3471 
fix also a couple of places where we forgot to compare case insensitive or call ToUpper.
Unfortunately, it's only part of the refactoring because there are some places where I want to spend more time and PR can become huge. 