### PR TITLE
chore: Split `--cluster_announce_ip` and `--replica_announce_ip`

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -113,7 +113,7 @@ Dragonfly 特有の議論もある:
  * `admin_bind`: 管理コンソールの TCP 接続を指定されたアドレスにバインドする(`default: any`)。HTTP と RESP の両方のプロトコルをサポートする。
  * `admin_nopass`: 割り当てられたポートで、認証トークンなしでコンソールへのオープン管理アクセスを有効にする (`default: false`)。HTTP と RESP の両方のプロトコルをサポートする。
  * `cluster_mode`: サポートするクラスターモード (`default: ""`)。現在は `emulated` のみをサポートしている。
- * `announce_ip`: クラスタコマンドがクライアントにアナウンスする IP。
+ * `cluster_announce_ip`: クラスタコマンドがクライアントにアナウンスする IP。
 
 ### 一般的なオプションを使用した開始スクリプトの例:
 

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -111,7 +111,7 @@ Dragonfly는 현재 아래와 같은 Redis 인수들을 지원합니다 :
   * `admin_bind`: 주어진 주소에 관리자 콘솔 TCP 연결을 바인딩합니다. (`기본값: any`). HTTP와 RESP 프로토콜 모두를 지원합니다.
   * `admin_nopass`: 할당된 포트에 대해서 인증 토큰 없이 관리자 콘솔 접근을 활성화합니다. (`default: false`). HTTP와 RESP 프로토콜 모두를 지원합니다.
   * `cluster_mode`: 클러스터 모드가 지원됩니다. (`기본값: ""`). 현재는`emulated` 만 지원합니다.
-  * `announce_ip`: 클러스터 명령을 클라이언트에게 알리는 IP 주소.
+  * `cluster_announce_ip`: 클러스터 명령을 클라이언트에게 알리는 IP 주소.
 
 
 ### 주요 옵션을 활용한 실행 스크립트 예시:

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ There are also some Dragonfly-specific arguments:
  * `admin_bind`: To bind the admin console TCP connection to a given address (`default: any`). Supports both HTTP and RESP protocols.
  * `admin_nopass`: To enable open admin access to console on the assigned port, without auth token needed (`default: false`). Supports both HTTP and RESP protocols.
  * `cluster_mode`: Cluster mode supported (`default: ""`). Currently supports only `emulated`.
- * `announce_ip`: The IP that cluster commands announce to the client, and to replication master.
+ * `cluster_announce_ip`: The IP that cluster commands announce to the client.
  * `announce_port`: The port that cluster commands announce to the client, and to replication master.
 
 ### Example start script with popular options:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -135,7 +135,7 @@ Dragonfly 支持 Redis 的常见参数。
 
 * `cluster_mode`：支持集群模式。目前仅支持 `emulated`。默认为空 `""`。
 
-* `announce_ip`：集群模式下向客户端公开的 IP。
+* `cluster_announce_ip`：集群模式下向客户端公开的 IP。
 
 ### 启动脚本示例，包含常用选项：
 

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -696,7 +696,7 @@ class ClusterFamilyEmulatedTest : public ClusterFamilyTest {
  public:
   ClusterFamilyEmulatedTest() {
     SetTestFlag("cluster_mode", "emulated");
-    SetTestFlag("announce_ip", "fake-host");
+    SetTestFlag("cluster_announce_ip", "fake-host");
   }
 };
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -68,8 +68,6 @@ using facade::ErrorReply;
 ABSL_FLAG(int32_t, port, 6379,
           "Redis port. 0 disables the port, -1 will bind on a random available port.");
 
-ABSL_FLAG(std::string, announce_ip, "",
-          "IP address that Dragonfly announces to cluster clients and replication master");
 ABSL_FLAG(uint16_t, announce_port, 0,
           "Port that Dragonfly announces to cluster clients and replication master");
 

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -41,9 +41,10 @@ ABSL_FLAG(bool, replica_partial_sync, true,
 ABSL_FLAG(bool, break_replication_on_master_restart, false,
           "When in replica mode, and master restarts, break replication from master to avoid "
           "flushing the replica's data.");
+ABSL_FLAG(std::string, replica_announce_ip, "",
+          "IP address that Dragonfly announces to replication master");
 ABSL_DECLARE_FLAG(int32_t, port);
 ABSL_DECLARE_FLAG(uint16_t, announce_port);
-ABSL_DECLARE_FLAG(std::string, announce_ip);
 ABSL_FLAG(
     int, replica_priority, 100,
     "Published by info command for sentinel to pick replica based on score during a failover");
@@ -287,7 +288,7 @@ error_code Replica::Greet() {
   RETURN_ON_ERR(SendCommandAndReadResponse(StrCat("REPLCONF listening-port ", port)));
   PC_RETURN_ON_BAD_RESPONSE(CheckRespIsSimpleReply("OK"));
 
-  auto announce_ip = absl::GetFlag(FLAGS_announce_ip);
+  auto announce_ip = absl::GetFlag(FLAGS_replica_announce_ip);
   if (!announce_ip.empty()) {
     RETURN_ON_ERR(SendCommandAndReadResponse(StrCat("REPLCONF ip-address ", announce_ip)));
     LOG_IF(WARNING, !CheckRespIsSimpleReply("OK"))

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -213,7 +213,7 @@ class TestEmulated:
 
 # Unfortunately we can't test --announce_port here because that causes the Python Cluster client to
 # throw if it can't access the port in `CLUSTER SLOTS` :|
-@dfly_args({"cluster_mode": "emulated", "announce_ip": "127.0.0.2"})
+@dfly_args({"cluster_mode": "emulated", "cluster_announce_ip": "127.0.0.2"})
 class TestEmulatedWithAnnounceIp:
     def test_cluster_slots_command(self, df_server, cluster_client: redis.RedisCluster):
         expected = {(0, 16383): {"primary": ("127.0.0.2", df_server.port), "replicas": []}}
@@ -361,7 +361,7 @@ async def test_cluster_info(async_client):
     }
 
 
-@dfly_args({"cluster_mode": "emulated", "announce_ip": "127.0.0.2"})
+@dfly_args({"cluster_mode": "emulated", "cluster_announce_ip": "127.0.0.2"})
 @pytest.mark.asyncio
 async def test_cluster_nodes(df_server, async_client):
     res = await async_client.execute_command("CLUSTER NODES")

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2321,7 +2321,7 @@ async def test_replica_reconnect(df_factory, break_conn):
 @pytest.mark.asyncio
 async def test_announce_ip_port(df_factory):
     master = df_factory.create()
-    replica = df_factory.create(announce_ip="overrode-host", announce_port="1337")
+    replica = df_factory.create(replica_announce_ip="overrode-host", announce_port="1337")
 
     master.start()
     replica.start()
@@ -2418,7 +2418,7 @@ async def test_replicate_old_master(
     released_dfly_path = download_dragonfly_release(dfly_version)
     master = df_factory.create(version=1.19, path=released_dfly_path, cluster_mode=cluster_mode)
     replica = df_factory.create(
-        cluster_mode=cluster_mode, announce_ip=announce_ip, announce_port=announce_port
+        cluster_mode=cluster_mode, cluster_announce_ip=announce_ip, announce_port=announce_port
     )
 
     df_factory.start_all([master, replica])


### PR DESCRIPTION
This PR partially reverts #3421

Fixes #3541

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->