### PR TITLE
fix pytest: use generic random dbfilename in tests

### DIFF
--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -83,7 +83,7 @@ async def test_multidb(df_factory, format: str):
     """
     Test serialization of multiple logical databases
     """
-    dbfilename = f"test-multidb{rand(0, 5000)}"
+    dbfilename = f"dump_{tmp_file_name()}"
     instance = df_factory.create(dbfilename=dbfilename)
     instance.start()
     async_client = instance.client()


### PR DESCRIPTION
see failed pytest https://github.com/dragonflydb/dragonfly/actions/runs/10653781303