### PR TITLE
refactor: remove extra code from CmdArgParser

### DIFF
--- a/src/facade/cmd_arg_parser.cc
+++ b/src/facade/cmd_arg_parser.cc
@@ -11,24 +11,6 @@
 
 namespace facade {
 
-CmdArgParser::CheckProxy::operator bool() const {
-  if (idx_ >= parser_->args_.size())
-    return false;
-
-  std::string_view arg = parser_->SafeSV(idx_);
-  if (!absl::EqualsIgnoreCase(arg, tag_))
-    return false;
-
-  if (idx_ + expect_tail_ >= parser_->args_.size()) {
-    parser_->Report(SHORT_OPT_TAIL, idx_);
-    return false;
-  }
-
-  parser_->cur_i_++;
-
-  return true;
-}
-
 void CmdArgParser::ExpectTag(std::string_view tag) {
   if (cur_i_ >= args_.size()) {
     Report(OUT_OF_BOUNDS, cur_i_);

--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -82,18 +82,13 @@ struct CmdArgParser {
   }
 
   // Check if the next value if equal to a specific tag. If equal, its consumed.
-  bool Check(std::string_view tag, size_t expect_tail = 0) {
+  bool Check(std::string_view tag) {
     if (cur_i_ >= args_.size())
       return false;
 
     std::string_view arg = SafeSV(cur_i_);
     if (!absl::EqualsIgnoreCase(arg, tag))
       return false;
-
-    if (cur_i_ + expect_tail >= args_.size()) {
-      Report(SHORT_OPT_TAIL, cur_i_);
-      return false;
-    }
 
     cur_i_++;
 

--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -17,30 +17,7 @@ namespace facade {
 
 // Utility class for easily parsing command options from argument lists.
 struct CmdArgParser {
-  enum ErrorType { OUT_OF_BOUNDS, SHORT_OPT_TAIL, INVALID_INT, INVALID_CASES, INVALID_NEXT };
-
-  struct CheckProxy {
-    explicit operator bool() const;
-
-    // Expect the tag to be followed by a number of arguments.
-    // Reports an error if the tag is matched but the condition is not met.
-    CheckProxy& ExpectTail(size_t tail) {
-      expect_tail_ = tail;
-      return *this;
-    }
-
-   private:
-    friend struct CmdArgParser;
-
-    CheckProxy(CmdArgParser* parser, std::string_view tag, size_t idx)
-        : parser_{parser}, tag_{tag}, idx_{idx} {
-    }
-
-    CmdArgParser* parser_;
-    std::string_view tag_;
-    size_t idx_;
-    size_t expect_tail_ = 0;
-  };
+  enum ErrorType { OUT_OF_BOUNDS, INVALID_INT, INVALID_CASES, INVALID_NEXT };
 
   struct ErrorInfo {
     ErrorType type;
@@ -65,6 +42,7 @@ struct CmdArgParser {
   template <class T = std::string_view, class... Ts> auto Next() {
     if (cur_i_ + sizeof...(Ts) >= args_.size()) {
       Report(OUT_OF_BOUNDS, cur_i_);
+      return std::conditional_t<sizeof...(Ts) == 0, T, std::tuple<T, Ts...>>();
     }
 
     if constexpr (sizeof...(Ts) == 0) {
@@ -88,8 +66,11 @@ struct CmdArgParser {
 
   // Consume next value
   template <class... Cases> auto Switch(Cases&&... cases) {
-    if (cur_i_ >= args_.size())
+    if (cur_i_ >= args_.size()) {
       Report(OUT_OF_BOUNDS, cur_i_);
+      return typename decltype(SwitchImpl(std::string_view(),
+                                          std::forward<Cases>(cases)...))::value_type{};
+    }
 
     auto idx = cur_i_++;
     auto res = SwitchImpl(SafeSV(idx), std::forward<Cases>(cases)...);
@@ -101,13 +82,26 @@ struct CmdArgParser {
   }
 
   // Check if the next value if equal to a specific tag. If equal, its consumed.
-  CheckProxy Check(std::string_view tag) {
-    return CheckProxy(this, tag, cur_i_);
+  bool Check(std::string_view tag) {
+    if (cur_i_ >= args_.size())
+      return false;
+
+    std::string_view arg = SafeSV(cur_i_);
+    if (!absl::EqualsIgnoreCase(arg, tag))
+      return false;
+
+    cur_i_++;
+
+    return true;
   }
 
   // Skip specified number of arguments
   CmdArgParser& Skip(size_t n) {
-    cur_i_ += n;
+    if (cur_i_ + n >= args_.size()) {
+      Report(OUT_OF_BOUNDS, cur_i_);
+    } else {
+      cur_i_ += n;
+    }
     return *this;
   }
 

--- a/src/facade/cmd_arg_parser_test.cc
+++ b/src/facade/cmd_arg_parser_test.cc
@@ -78,7 +78,7 @@ TEST_F(CmdArgParserTest, Check) {
   EXPECT_TRUE(parser.Check("TAG"));
 
   EXPECT_FALSE(parser.Check("NOT_TAG_2"));
-  EXPECT_TRUE(parser.Check("TAG_2").ExpectTail(1));
+  EXPECT_TRUE(parser.Check("TAG_2"));
 }
 
 TEST_F(CmdArgParserTest, NextStatement) {
@@ -97,15 +97,15 @@ TEST_F(CmdArgParserTest, NextStatement) {
 TEST_F(CmdArgParserTest, CheckTailFail) {
   auto parser = Make({"TAG", "11", "22", "TAG", "33"});
 
-  EXPECT_TRUE(parser.Check("TAG").ExpectTail(2));
+  EXPECT_TRUE(parser.Check("TAG"));
   parser.Skip(2);
 
-  EXPECT_FALSE(parser.Check("TAG").ExpectTail(2));
+  EXPECT_TRUE(parser.Check("TAG"));
+  parser.Next<int, int>();
 
   auto err = parser.Error();
   EXPECT_TRUE(err);
-  EXPECT_EQ(err->type, CmdArgParser::SHORT_OPT_TAIL);
-  EXPECT_EQ(err->index, 3);
+  EXPECT_EQ(err->index, 4);
 }
 
 TEST_F(CmdArgParserTest, Cases) {
@@ -125,7 +125,7 @@ TEST_F(CmdArgParserTest, IgnoreCase) {
 
   EXPECT_EQ(absl::implicit_cast<string_view>(parser.Next()), "hello"sv);
 
-  EXPECT_TRUE(parser.Check("MARKER"sv).ExpectTail(1));
+  EXPECT_TRUE(parser.Check("MARKER"sv));
   parser.Skip(1);
 
   EXPECT_EQ(absl::implicit_cast<string_view>(parser.Next()), "world"sv);

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -1843,15 +1843,15 @@ void JsonFamily::Get(CmdArgList args, ConnectionContext* cntx) {
   vector<pair<string_view, WrappedJsonPath>> paths;
 
   while (parser.HasNext()) {
-    if (parser.Check("SPACE").ExpectTail(1)) {
+    if (parser.Check("SPACE")) {
       space = parser.Next();
       continue;
     }
-    if (parser.Check("NEWLINE").ExpectTail(1)) {
+    if (parser.Check("NEWLINE")) {
       new_line = parser.Next();
       continue;
     }
-    if (parser.Check("INDENT").ExpectTail(1)) {
+    if (parser.Check("INDENT")) {
       indent = parser.Next();
       continue;
     }

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -902,18 +902,18 @@ void ListFamily::LPos(CmdArgList args, ConnectionContext* cntx) {
   bool skip_count = true;
 
   while (parser.HasNext()) {
-    if (parser.Check("RANK").ExpectTail(1)) {
+    if (parser.Check("RANK")) {
       rank = parser.Next<int>();
       continue;
     }
 
-    if (parser.Check("COUNT").ExpectTail(1)) {
+    if (parser.Check("COUNT")) {
       count = parser.Next<uint32_t>();
       skip_count = false;
       continue;
     }
 
-    if (parser.Check("MAXLEN").ExpectTail(1)) {
+    if (parser.Check("MAXLEN")) {
       max_len = parser.Next<uint32_t>();
       continue;
     }

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -57,8 +57,7 @@ search::SchemaField::VectorParams ParseVectorParams(CmdArgParser* parser) {
       params.sim = parser->Switch("L2", search::VectorSimilarity::L2, "COSINE",
                                   search::VectorSimilarity::COSINE);
     } else if (parser->Check("INITIAL_CAP")) {
-      parser->Next<size_t>();
-      // params.capacity = parser->Next<size_t>();
+      params.capacity = parser->Next<size_t>();
     } else if (parser->Check("M")) {
       params.hnsw_m = parser->Next<size_t>();
     } else if (parser->Check("EF_CONSTRUCTION")) {
@@ -216,25 +215,16 @@ optional<SearchParams> ParseSearchParamsOrReply(CmdArgParser parser, ConnectionC
         string_view alias = parser.Check("AS") ? parser.Next() : ident;
         params.return_fields->emplace_back(ident, alias);
       }
-    } else
-
-      // NOCONTENT
-      if (parser.Check("NOCONTENT")) {
-        params.return_fields = SearchParams::FieldReturnList{};
-      } else
-
-        // [PARAMS num(ignored) name(ignored) knn_vector]
-        if (parser.Check("PARAMS")) {
-          params.query_params = ParseQueryParams(&parser);
-        } else
-
-            if (parser.Check("SORTBY")) {
-          params.sort_option =
-              search::SortOption{string{parser.Next()}, bool(parser.Check("DESC"))};
-        } else {
-          // Unsupported parameters are ignored for now
-          parser.Skip(1);
-        }
+    } else if (parser.Check("NOCONTENT")) {  // NOCONTENT
+      params.return_fields = SearchParams::FieldReturnList{};
+    } else if (parser.Check("PARAMS")) {  // [PARAMS num(ignored) name(ignored) knn_vector]
+      params.query_params = ParseQueryParams(&parser);
+    } else if (parser.Check("SORTBY")) {
+      params.sort_option = search::SortOption{string{parser.Next()}, bool(parser.Check("DESC"))};
+    } else {
+      // Unsupported parameters are ignored for now
+      parser.Skip(1);
+    }
   }
 
   if (auto err = parser.Error(); err) {

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -51,22 +51,22 @@ search::SchemaField::VectorParams ParseVectorParams(CmdArgParser* parser) {
   const size_t num_args = parser->Next<size_t>();
 
   for (size_t i = 0; i * 2 < num_args; i++) {
-    if (parser->Check("DIM", 1)) {
+    if (parser->Check("DIM")) {
       params.dim = parser->Next<size_t>();
-    } else if (parser->Check("DISTANCE_METRIC", 1)) {
+    } else if (parser->Check("DISTANCE_METRIC")) {
       params.sim = parser->Switch("L2", search::VectorSimilarity::L2, "COSINE",
                                   search::VectorSimilarity::COSINE);
-    } else if (parser->Check("INITIAL_CAP", 1)) {
+    } else if (parser->Check("INITIAL_CAP")) {
       parser->Next<size_t>();
       // params.capacity = parser->Next<size_t>();
-    } else if (parser->Check("M", 1)) {
+    } else if (parser->Check("M")) {
       params.hnsw_m = parser->Next<size_t>();
-    } else if (parser->Check("EF_CONSTRUCTION", 1)) {
+    } else if (parser->Check("EF_CONSTRUCTION")) {
       params.hnsw_ef_construction = parser->Next<size_t>();
-    } else if (parser->Check("EF_RUNTIME", 1)) {
+    } else if (parser->Check("EF_RUNTIME")) {
       parser->Next<size_t>();
       LOG(WARNING) << "EF_RUNTIME not supported";
-    } else if (parser->Check("EPSILON", 1)) {
+    } else if (parser->Check("EPSILON")) {
       parser->Next<double>();
       LOG(WARNING) << "EPSILON not supported";
     } else {
@@ -444,13 +444,13 @@ void SearchFamily::FtCreate(CmdArgList args, ConnectionContext* cntx) {
 
   while (parser.HasNext()) {
     // ON HASH | JSON
-    if (parser.Check("ON", 1)) {
+    if (parser.Check("ON")) {
       index.type = parser.Switch("HASH"sv, DocIndex::HASH, "JSON"sv, DocIndex::JSON);
       continue;
     }
 
     // PREFIX count prefix [prefix ...]
-    if (parser.Check("PREFIX", 2)) {
+    if (parser.Check("PREFIX")) {
       if (size_t num = parser.Next<size_t>(); num != 1)
         return cntx->SendError("Multiple prefixes are not supported");
       index.prefix = string(parser.Next());

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -645,7 +645,7 @@ optional<ReplicaOfArgs> ReplicaOfArgs::FromCmdArgs(CmdArgList args, ConnectionCo
   ReplicaOfArgs replicaof_args;
   CmdArgParser parser(args);
 
-  if (parser.Check("NO").ExpectTail(1)) {
+  if (parser.Check("NO")) {
     parser.ExpectTag("ONE");
     replicaof_args.port = 0;
   } else {

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -1887,7 +1887,7 @@ void SetId(string_view key, string_view gname, CmdArgList args, ConnectionContex
 
   string_view id = parser.Next();
   while (parser.HasNext()) {
-    if (parser.Check("ENTRIESREAD").ExpectTail(1)) {
+    if (parser.Check("ENTRIESREAD")) {
       // TODO: to support ENTRIESREAD.
       return cntx->SendError(kSyntaxErr);
     } else {

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -799,7 +799,7 @@ void StringFamily::Set(CmdArgList args, ConnectionContext* cntx) {
       }
 
       tie(sparams.expire_after_ms, ignore) = expiry.Calculate(now_ms, true);
-    } else if (parser.Check("_MCFLAGS").ExpectTail(1)) {
+    } else if (parser.Check("_MCFLAGS")) {
       sparams.memcache_flags = parser.Next<uint32_t>();
     } else {
       uint16_t flag = parser.Switch(  //

--- a/tests/dragonfly/search_test.py
+++ b/tests/dragonfly/search_test.py
@@ -227,8 +227,8 @@ async def knn_query(idx, query, vector):
 
 
 @dfly_args({"proactor_threads": 4})
-@pytest.mark.parametrize("index_type", [IndexType.HASH, IndexType.JSON])
-@pytest.mark.parametrize("algo_type", ["FLAT", "HNSW"])
+@pytest.mark.parametrize("index_type", [IndexType.HASH])
+@pytest.mark.parametrize("algo_type", ["FLAT"])
 async def test_knn(async_client: aioredis.Redis, index_type, algo_type):
     i2 = async_client.ft("i2-" + str(index_type))
 

--- a/tests/dragonfly/search_test.py
+++ b/tests/dragonfly/search_test.py
@@ -227,8 +227,8 @@ async def knn_query(idx, query, vector):
 
 
 @dfly_args({"proactor_threads": 4})
-@pytest.mark.parametrize("index_type", [IndexType.HASH])
-@pytest.mark.parametrize("algo_type", ["FLAT"])
+@pytest.mark.parametrize("index_type", [IndexType.HASH, IndexType.JSON])
+@pytest.mark.parametrize("algo_type", ["FLAT", "HNSW"])
 async def test_knn(async_client: aioredis.Redis, index_type, algo_type):
     i2 = async_client.ft("i2-" + str(index_type))
 


### PR DESCRIPTION
There is no sense to do ExpectTail() because we do the same check in Next() or other operations
