### PR TITLE
fix(test_auth_resp3_bug): release build failing

### DIFF
--- a/tests/dragonfly/acl_family_test.py
+++ b/tests/dragonfly/acl_family_test.py
@@ -634,15 +634,12 @@ async def test_auth_resp3_bug(df_factory):
 
     await client.execute_command("ACL SETUSER kostas +@all ON >tmp")
     res = await client.execute_command("HELLO 3 AUTH kostas tmp")
-    assert res == {
-        "server": "redis",
-        "version": "6.2.11",
-        "dragonfly_version": "df-dev",
-        "proto": 3,
-        "id": 1,
-        "mode": "standalone",
-        "role": "master",
-    }
+    assert res["server"] == "redis"
+    assert res["version"] == "6.2.11"
+    assert res["proto"] == 3
+    assert res["mode"] == "standalone"
+    assert res["role"] == "master"
+    assert res["id"] == 1
 
     await client.close()
 


### PR DESCRIPTION
Release build fails because the test included the following assertion:

```
dragonfly_version == df-dev
```

Which is not true for released versions.

I removed the check from the set of assertions. 

* remove problematic assertion