### PR TITLE
fix: limit parsing in zrange commands

### DIFF
--- a/.github/workflows/test-fakeredis.yml
+++ b/.github/workflows/test-fakeredis.yml
@@ -67,14 +67,14 @@ jobs:
           echo "-----------------------------"
 
           # The order of redirect is important
-          ./dragonfly --proactor_threads=4 --dbfilename=   --noversion_check --port=6380  \
+          ./dragonfly --proactor_threads=4  --noversion_check --port=6380  \
            --lua_resp2_legacy_float 1> /tmp/dragonfly.log 2>&1 &
 
       - name: Run tests
         working-directory: tests/fakeredis
         run: |
           poetry run pytest test/ --ignore test/test_hypothesis.py  --ignore test/test_json/ \
-            --ignore test_bitmap_commands.py --ignore test/test_mixins/  \
+            --ignore test_bitmap_commands.py \
             --junit-xml=results-tests.xml  --html=report-tests.html -v
         continue-on-error: true  # For now to mark the flow as successful
 

--- a/src/facade/facade_test.cc
+++ b/src/facade/facade_test.cc
@@ -81,6 +81,9 @@ void RespMatcher::DescribeTo(std::ostream* os) const {
     case RespExpr::ARRAY:
       *os << "array of length " << exp_int_;
       break;
+    case RespExpr::DOUBLE:
+      *os << exp_double_;
+      break;
     default:
       *os << "TBD";
       break;

--- a/tests/fakeredis/test/test_mixins/test_scripting.py
+++ b/tests/fakeredis/test/test_mixins/test_scripting.py
@@ -591,6 +591,7 @@ def test_lua_log_different_types(r, caplog):
     ]
 
 
+@pytest.mark.unsupported_server_types("dragonfly")
 def test_lua_log_wrong_level(r: redis.Redis):
     script = "redis.log(10, 'string')"
     script = r.register_script(script)


### PR DESCRIPTION
1. The offset value can be negative, in that case we should return an empty array.
2. Fix edge cases of inf*0 and -inf + inf, so they will result in 0 and non NaN (similarily to Valkey).

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->