### PR TITLE
fix: crash during SORT DESC call

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1184,9 +1184,10 @@ void GenericFamily::Sort(CmdArgList args, ConnectionContext* cntx) {
                         });
     } else {
       std::sort(entries.begin(), entries.end(),
-                [reversed, &entries](const auto& lhs, const auto& rhs) {
-                  DCHECK(&rhs < &(*entries.end()) && &rhs >= &(*entries.begin()));
-                  return bool(lhs.Cmp() < rhs.Cmp()) ^ reversed;
+                [reversed, &entries](const auto& lhs, const auto& rhs) -> bool {
+                  DCHECK((&rhs - entries.data()) >= 0);
+                  DCHECK((&rhs - entries.data()) < int64_t(entries.size()));
+                  return reversed ? rhs.Cmp() < lhs.Cmp() : lhs.Cmp() < rhs.Cmp();
                 });
     }
 

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -481,6 +481,15 @@ TEST_F(GenericFamilyTest, Sort) {
   ;
 }
 
+TEST_F(GenericFamilyTest, SortBug3636) {
+  Run({"RPUSH", "foo", "1.100000023841858", "1.100000023841858", "1.100000023841858", "-15710",
+       "1.100000023841858", "1.100000023841858", "1.100000023841858", "-15710", "-15710",
+       "1.100000023841858", "-15710", "-15710", "-15710", "-15710", "1.100000023841858", "-15710",
+       "-15710"});
+  auto resp = Run({"SORT", "foo", "desc", "alpha"});
+  ASSERT_THAT(resp, ArrLen(17));
+}
+
 TEST_F(GenericFamilyTest, TimeNoKeys) {
   auto resp = Run({"time"});
   EXPECT_THAT(resp, ArrLen(2));


### PR DESCRIPTION
fixes #3636

The problem was that instead of implementing GT operator, we implemented !LT, which is GE operator. As a result the iterators inside the sort algorithm reached out of bounds.

---------

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->