### PR TITLE
chore: simplify expired flow in StringFamily::Set

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -708,9 +708,7 @@ OpResult<uint32_t> OpStick(const OpArgs& op_args, const ShardArgs& keys) {
   return res;
 }
 
-}  // namespace
-
-OpResult<uint32_t> GenericFamily::OpDel(const OpArgs& op_args, const ShardArgs& keys) {
+OpResult<uint32_t> OpDel(const OpArgs& op_args, const ShardArgs& keys) {
   DVLOG(1) << "Del: " << keys.Front();
   auto& db_slice = op_args.GetDbSlice();
 
@@ -726,6 +724,8 @@ OpResult<uint32_t> GenericFamily::OpDel(const OpArgs& op_args, const ShardArgs& 
 
   return res;
 }
+
+}  // namespace
 
 void GenericFamily::Del(CmdArgList args, ConnectionContext* cntx) {
   Transaction* transaction = cntx->transaction;

--- a/src/server/generic_family.h
+++ b/src/server/generic_family.h
@@ -39,7 +39,6 @@ class GenericFamily {
 
   // Accessed by Service::Exec and Service::Watch as an utility.
   static OpResult<uint32_t> OpExists(const OpArgs& op_args, const ShardArgs& keys);
-  static OpResult<uint32_t> OpDel(const OpArgs& op_args, const ShardArgs& keys);
 
  private:
   static void Del(CmdArgList args, ConnectionContext* cntx);

--- a/src/server/string_family.h
+++ b/src/server/string_family.h
@@ -65,6 +65,7 @@ class SetCmd {
     uint16_t flags = SET_ALWAYS;
     uint32_t memcache_flags = 0;
     uint64_t expire_after_ms = 0;     // Relative value based on now. 0 means no expiration.
+    bool expire_now = false;          // Item will be added but as expired
     StringValue* prev_val = nullptr;  // If set, previous value is stored at pointer
 
     constexpr bool IsConditionalSet() const {


### PR DESCRIPTION
If the time argument of `SET` command is already expired we scheduled a transaction that deleted the (if existed) element that the set command would replace. This was not really needed as the logic around expired values already handles this case. Bonus points is that we also now don't schedule a different transaction (OpDel) when we parse the arguments (and let the normal flow continue)

* handle already expired values in db_slice instead of explicit OpDel
* small refactor