### PR TITLE
fix(docker/healthcheck): run netstat port retreival command as dfly

### DIFF
--- a/tools/docker/healthcheck.sh
+++ b/tools/docker/healthcheck.sh
@@ -6,7 +6,7 @@ PORT=$HEALTHCHECK_PORT
 if [ -z "$HEALTHCHECK_PORT" ]; then
     # check all the TCP listening sockets, filter the dragonfly process, and fetch the port.
     # For cases when dragonfly opens multiple ports, we filter with tail to choose one of them.
-    PORT=$(netstat -tlnp | grep "1/dragonfly" | grep -oE ':[0-9]+' | cut -c2- | tail -n 1)
+    PORT=$(su - dfly -c "netstat -tlnp" | grep "1/dragonfly" | grep -oE ':[0-9]+' | cut -c2- | tail -n 1)
 fi
 
 # If we're running with TLS enabled, utilise OpenSSL for the check

--- a/tools/docker/healthcheck.sh
+++ b/tools/docker/healthcheck.sh
@@ -6,7 +6,7 @@ PORT=$HEALTHCHECK_PORT
 if [ -z "$HEALTHCHECK_PORT" ]; then
     # check all the TCP listening sockets, filter the dragonfly process, and fetch the port.
     # For cases when dragonfly opens multiple ports, we filter with tail to choose one of them.
-    PORT=$(su - dfly -c "netstat -tlnp" | grep "1/dragonfly" | grep -oE ':[0-9]+' | cut -c2- | tail -n 1)
+    PORT=$(su dfly -c "netstat -tlnp" | grep "1/dragonfly" | grep -oE ':[0-9]+' | cut -c2- | tail -n 1)
 fi
 
 # If we're running with TLS enabled, utilise OpenSSL for the check


### PR DESCRIPTION
https://github.com/dragonflydb/dragonfly/pull/3518 updated the process to run as `dfly` causing the `netstat` command to not have the process name being returned when ran normally:
```
# netstat -tlnp | grep "1/dragonfly" | grep -oE ':[0-9]+' | cut -c2- | tail -n 1
# su - dfly -c "netstat -tlnp" | grep "1/dragonfly" | grep -oE ':[0-9]+' | cut -c2- | tail -n 1
su: warning: cannot change directory to /home/dfly: No such file or directory
(Not all processes could be identified, non-owned process info
 will not be shown, you would have to be root to see it all.)
6379
# 
```