### PR TITLE
fix: deadlock in the cluster migration process

### DIFF
--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -85,8 +85,16 @@ class ClusterFamily {
       ABSL_LOCKS_EXCLUDED(migration_mu_);
 
   void StartSlotMigrations(std::vector<MigrationInfo> migrations);
-  SlotRanges RemoveOutgoingMigrations(std::shared_ptr<ClusterConfig> new_config,
-                                      std::shared_ptr<ClusterConfig> old_config)
+
+  // must be destroyed excluded set_config_mu and migration_mu_ locks
+  struct PreparedToRemoveOutgoingMigrations {
+    std::vector<std::shared_ptr<OutgoingMigration>> migrations;
+    SlotRanges slot_ranges;
+    ~PreparedToRemoveOutgoingMigrations() ABSL_LOCKS_EXCLUDED(migration_mu_, set_config_mu);
+  };
+
+  [[nodiscard]] PreparedToRemoveOutgoingMigrations TakeOutOutgoingMigrations(
+      std::shared_ptr<ClusterConfig> new_config, std::shared_ptr<ClusterConfig> old_config)
       ABSL_LOCKS_EXCLUDED(migration_mu_);
   void RemoveIncomingMigrations(const std::vector<MigrationInfo>& migrations)
       ABSL_LOCKS_EXCLUDED(migration_mu_);

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -1088,7 +1088,7 @@ async def test_cluster_flushall_during_migration(
         df_factory.create(
             port=BASE_PORT + i,
             admin_port=BASE_PORT + i + 1000,
-            vmodule="cluster_family=9,cluster_slot_migration=9,outgoing_slot_migration=9,incoming_slot_migration=9",
+            vmodule="cluster_family=9,outgoing_slot_migration=9,incoming_slot_migration=9",
             logtostdout=True,
         )
         for i in range(2)
@@ -1142,7 +1142,12 @@ async def test_cluster_flushall_during_migration(
 async def test_cluster_data_migration(df_factory: DflyInstanceFactory, interrupt: bool):
     # Check data migration from one node to another
     instances = [
-        df_factory.create(port=BASE_PORT + i, admin_port=BASE_PORT + i + 1000) for i in range(2)
+        df_factory.create(
+            port=BASE_PORT + i,
+            admin_port=BASE_PORT + i + 1000,
+            vmodule="outgoing_slot_migration=9,cluster_family=9,incoming_slot_migration=9",
+        )
+        for i in range(2)
     ]
 
     df_factory.start_all(instances)


### PR DESCRIPTION
fixes: #3638 
The problem is a deadlock:
the first lock can be during shutdown or config for set_config_mu after that we try to remove outgoing migration and join it
the second lock happens if the migration process finishes and updates config, it tries to lock set_config_mu that is already locked

The solution: we can remove outgoing migration after unlocking the mutex, to do this under mutex lock we move the migrations from the common storage to a local variable and remove it after mutex unlocking.
