### PR TITLE
fix: recursive calls in the allocation tracker

### DIFF
--- a/src/core/allocation_tracker.h
+++ b/src/core/allocation_tracker.h
@@ -47,6 +47,7 @@ class AllocationTracker {
 
  private:
   absl::InlinedVector<TrackingInfo, 4> tracking_;
+  bool inside_tracker_ = false;
 };
 
 }  // namespace dfly

--- a/src/server/detail/save_stages_controller.h
+++ b/src/server/detail/save_stages_controller.h
@@ -122,7 +122,7 @@ struct SaveStagesController : public SaveStagesInputs {
   void RunStage(void (SaveStagesController::*cb)(unsigned));
 
  private:
-  absl::Time start_time_;
+  time_t start_time_;
   std::filesystem::path full_path_;
   bool is_cloud_;
 


### PR DESCRIPTION
Also, remove dependence of absl::TimeZone bloated monstrosity, which was required by absl::FormatTime api, even though we do not actually format a timezone.

When absl::LocalTimeZone is accessed it allocated hundreds of thousands of bytes for each shard thread (maybe due to lack thread safety during lazy initialization).

At the end, strftime does a great job without any shenanigans.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->