### PR TITLE
deprecate RecordsPopper and serialize channel records during push

### DIFF
--- a/.github/workflows/test-fakeredis.yml
+++ b/.github/workflows/test-fakeredis.yml
@@ -78,6 +78,7 @@ jobs:
             --ignore test/test_geo_commands.py  \
             --ignore test/test_bitmap_commands.py  \
             --ignore test/test_json/ \
+            --ignore test/test_mixins/test_bitmap_commands.py \
             --junit-xml=results-tests.xml  --html=report-tests.html -v
         continue-on-error: true  # For now to mark the flow as successful
 

--- a/src/core/size_tracking_channel.h
+++ b/src/core/size_tracking_channel.h
@@ -22,9 +22,11 @@ template <typename T, typename Queue = folly::ProducerConsumerQueue<T>> class Si
 
   // Here and below, we must accept a T instead of building it from variadic args, as we need to
   // know its size in case it is added.
-  void Push(T t) noexcept {
-    size_.fetch_add(t.size(), std::memory_order_relaxed);
+  size_t Push(T t) noexcept {
+    size_t tsize = t.size();
+    size_t res = size_.fetch_add(tsize, std::memory_order_relaxed);
     queue_.Push(std::move(t));
+    return res + tsize;
   }
 
   bool TryPush(T t) noexcept {

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -21,14 +21,14 @@
 #include "server/tiered_storage.h"
 #include "util/fibers/synchronization.h"
 
-using facade::operator""_MB;
-
 namespace dfly {
 
 using namespace std;
 using namespace util;
 using namespace chrono_literals;
 
+using facade::operator""_MB;
+using facade::operator""_KB;
 namespace {
 thread_local absl::flat_hash_set<SliceSnapshot*> tl_slice_snapshots;
 }  // namespace
@@ -78,7 +78,7 @@ void SliceSnapshot::Start(bool stream_journal, const Cancellation* cll, Snapshot
     flush_fun = [this, flush_threshold](size_t bytes_serialized,
                                         RdbSerializer::FlushState flush_state) {
       if (bytes_serialized > flush_threshold) {
-        auto serialized = Serialize(flush_state);
+        size_t serialized = FlushChannelRecord(flush_state);
         VLOG(2) << "FlushedToChannel " << serialized << " bytes";
       }
     };
@@ -325,7 +325,7 @@ void SliceSnapshot::SerializeEntry(DbIndex db_indx, const PrimeKey& pk, const Pr
   }
 }
 
-size_t SliceSnapshot::Serialize(SerializerBase::FlushState flush_state) {
+size_t SliceSnapshot::FlushChannelRecord(SerializerBase::FlushState flush_state) {
   io::StringFile sfile;
   serializer_->FlushToSink(&sfile, flush_state);
 
@@ -333,34 +333,51 @@ size_t SliceSnapshot::Serialize(SerializerBase::FlushState flush_state) {
   if (serialized == 0)
     return 0;
 
-  auto id = rec_id_++;
-  DVLOG(2) << "Pushed " << id;
+  uint64_t id = rec_id_++;
+  DVLOG(2) << "Pushing " << id;
   DbRecord db_rec{.id = id, .value = std::move(sfile.val)};
+  fb2::NoOpLock lk;
 
-  dest_->Push(std::move(db_rec));
-  if (serialized != 0) {
-    VLOG(2) << "Pushed with Serialize() " << serialized << " bytes";
-  }
+  // We create a critical section here that ensures that records are pushed in sequential order.
+  // As a result, it is not possible for two fiber producers to push into channel concurrently.
+  // If A.id = 5, and then B.id = 6, and both are blocked here, it means that last_pushed_id_ < 4.
+  // Once last_pushed_id_ = 4, A will be unblocked, while B will wait until A finishes pushing and
+  // update last_pushed_id_ to 5.
+  seq_cond_.wait(lk, [&] { return id == this->last_pushed_id_ + 1; });
+
+  // Blocking point.
+  size_t channel_usage = dest_->Push(std::move(db_rec));
+  DCHECK_EQ(last_pushed_id_ + 1, id);
+  last_pushed_id_ = id;
+  seq_cond_.notify_all();
+
+  VLOG(2) << "Pushed with Serialize() " << serialized
+          << " bytes, channel total usage: " << channel_usage;
+
   return serialized;
 }
 
 bool SliceSnapshot::PushSerializedToChannel(bool force) {
-  if (!force && serializer_->SerializedLen() < 4096)
+  if (!force && serializer_->SerializedLen() < 4_KB)
     return false;
 
   // Flush any of the leftovers to avoid interleavings
-  size_t serialized = Serialize();
+  size_t serialized = FlushChannelRecord(FlushState::kFlushMidEntry);
 
-  // Bucket serialization might have accumulated some delayed values.
-  // Because we can finally block in this function, we'll await and serialize them
-  while (!delayed_entries_.empty()) {
-    auto& entry = delayed_entries_.back();
-    serializer_->SaveEntry(entry.key, entry.value.Get(), entry.expire, entry.dbid, entry.mc_flags);
-    delayed_entries_.pop_back();
+  if (!delayed_entries_.empty()) {
+    // Async bucket serialization might have accumulated some delayed values.
+    // Because we can finally block in this function, we'll await and serialize them
+    do {
+      auto& entry = delayed_entries_.back();
+      serializer_->SaveEntry(entry.key, entry.value.Get(), entry.expire, entry.dbid,
+                             entry.mc_flags);
+      delayed_entries_.pop_back();
+    } while (!delayed_entries_.empty());
+
+    // blocking point.
+    serialized += FlushChannelRecord(FlushState::kFlushMidEntry);
   }
-
-  size_t total_serialized = Serialize() + serialized;
-  return total_serialized > 0;
+  return serialized > 0;
 }
 
 void SliceSnapshot::OnDbChange(DbIndex db_index, const DbSlice::ChangeReq& req) {

--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -131,7 +131,7 @@ class SliceSnapshot {
   // Helper function that flushes the serialized items into the RecordStream.
   // Can block on the channel.
   using FlushState = SerializerBase::FlushState;
-  size_t Serialize(FlushState flush_state = FlushState::kFlushMidEntry);
+  size_t FlushChannelRecord(FlushState flush_state);
 
  public:
   uint64_t snapshot_version() const {
@@ -173,14 +173,15 @@ class SliceSnapshot {
   // Used for sanity checks.
   bool serialize_bucket_running_ = false;
   util::fb2::Fiber snapshot_fb_;  // IterateEntriesFb
-
+  util::fb2::CondVarAny seq_cond_;
   CompressionMode compression_mode_;
   RdbTypeFreqMap type_freq_map_;
 
   // version upper bound for entries that should be saved (not included).
   uint64_t snapshot_version_ = 0;
   uint32_t journal_cb_id_ = 0;
-  uint64_t rec_id_ = 0;
+
+  uint64_t rec_id_ = 1, last_pushed_id_ = 0;
 
   struct Stats {
     size_t loop_serialized = 0;

--- a/tests/fakeredis/test/test_mixins/test_geo_commands.py
+++ b/tests/fakeredis/test/test_mixins/test_geo_commands.py
@@ -364,6 +364,7 @@ def test_georadius_errors(r: redis.Redis):
         testtools.raw_command(r, "geoadd", "newgroup", *bad_values)
 
 
+@pytest.mark.unsupported_server_types("dragonfly")
 def test_geosearch(r: redis.Redis):
     values = (
         2.1909389952632,


### PR DESCRIPTION
Records channel is redundant for DFS/replication because we have single producer/consumer
scenario and both running on the same thread. Unfortunately we need it for RDB snapshotting.
  
For non-rdb cases we could just pass a io sink to the snapshot producer,
 so that it would use it directly instead of StringFile inside FlushChannelRecord.
  
This would reduce memory usage, eliminate yet another memory copy and generally would make everything simpler.
For that to work, we must serialize the order inside FlushChannelRecord and this PR allows this.


<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->