### PR TITLE
feat(server): Support `CLIENT SETINFO`

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -798,6 +798,7 @@ string Connection::GetClientInfo(unsigned thread_id) const {
   auto [before, after] = GetClientInfoBeforeAfterTid();
   absl::StrAppend(&before, " tid=", thread_id);
   absl::StrAppend(&before, after);
+  absl::StrAppend(&before, " lib-name=", lib_name_, " lib-ver=", lib_ver_);
   return before;
 }
 
@@ -836,6 +837,14 @@ bool Connection::IsMain() const {
 void Connection::SetName(std::string name) {
   util::ThisFiber::SetName(absl::StrCat("DflyConnection_", name));
   name_ = std::move(name);
+}
+
+void Connection::SetLibName(std::string name) {
+  lib_name_ = std::move(name);
+}
+
+void Connection::SetLibVersion(std::string version) {
+  lib_ver_ = std::move(version);
 }
 
 io::Result<bool> Connection::CheckForHttpProto(FiberSocketBase* peer) {

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -275,6 +275,9 @@ class Connection : public util::Connection {
 
   void SetName(std::string name);
 
+  void SetLibName(std::string name);
+  void SetLibVersion(std::string version);
+
   std::string_view GetName() const {
     return name_;
   }
@@ -400,6 +403,9 @@ class Connection : public util::Connection {
   time_t creation_time_, last_interaction_;
   Phase phase_ = SETUP;
   std::string name_;
+
+  std::string lib_name_;
+  std::string lib_ver_;
 
   unsigned parser_error_ = 0;
 

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -278,6 +278,9 @@ class Connection : public util::Connection {
   void SetLibName(std::string name);
   void SetLibVersion(std::string version);
 
+  // Returns a map of 'libname:libver'->count, thread local data
+  static const absl::flat_hash_map<std::string, uint64_t>& GetLibStatsTL();
+
   std::string_view GetName() const {
     return name_;
   }

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -123,6 +123,8 @@ struct Metrics {
   // command call frequencies (count, aggregated latency in usec).
   std::map<std::string, std::pair<uint64_t, uint64_t>> cmd_stats_map;
 
+  absl::flat_hash_map<std::string, uint64_t> connections_lib_name_ver_map;
+
   // Replica info on the master side.
   std::vector<ReplicaRoleInfo> master_side_replicas_info;
 

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -854,3 +854,13 @@ async def test_tls_when_read_write_is_interleaved(
     client = aioredis.Redis(port=server.port, **with_ca_tls_client_args)
     await client.execute_command("GET foo")
     await client.close()
+
+
+async def test_lib_name_ver(async_client: aioredis.Redis):
+    await async_client.execute_command("client setinfo lib-name dragonfly")
+    await async_client.execute_command("client setinfo lib-ver 1.2.3.4")
+
+    list = await async_client.execute_command("client list")
+    assert len(list) == 1
+    assert list[0]["lib-name"] == "dragonfly"
+    assert list[0]["lib-ver"] == "1.2.3.4"


### PR DESCRIPTION
Add support for `CLIENT SETINFO <LIB-NAME | LIB-VER>` and also return
that as part of `CLIENT LIST`, like Valkey.

Fixes #3137