### PR TITLE
fix(json_family): Fix JSON.ARRPOP command in legacy mode should not return WRONGTYPE error 

### DIFF
--- a/src/server/detail/wrapped_json_path.h
+++ b/src/server/detail/wrapped_json_path.h
@@ -172,8 +172,9 @@ class WrappedJsonPath {
 
   template <typename T>
   OpResult<JsonCallbackResult<std::optional<T>>> Mutate(JsonType* json_entry,
-                                                        JsonPathMutateCallback<T> cb) const {
-    JsonCallbackResult<std::optional<T>> mutate_result{IsLegacyModePath(), false, false};
+                                                        JsonPathMutateCallback<T> cb,
+                                                        bool empty_is_nil) const {
+    JsonCallbackResult<std::optional<T>> mutate_result{IsLegacyModePath(), false, empty_is_nil};
 
     auto mutate_callback = [&cb, &mutate_result](std::optional<std::string_view> path,
                                                  JsonType* val) -> bool {

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -1813,7 +1813,13 @@ TEST_F(JsonFamilyTest, ArrPopLegacy) {
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.ARRPOP", "json", "."});
-  EXPECT_THAT(resp, ErrArg("wrong JSON type of path value"));
+  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
+
+  resp = Run({"JSON.SET", "json", ".", "[]"});
+  ASSERT_THAT(resp, "OK");
+
+  resp = Run({"JSON.ARRPOP", "json", "."});
+  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
 }
 
 TEST_F(JsonFamilyTest, ArrTrim) {


### PR DESCRIPTION
fixes 1. bug in the #3671 

1. Rename `UpdateEntry` to `JsonMutateOperation` by analogy with the `JsonEvaluateOperation` command
2. Add `empty_is_nil` option to the `JsonMutateOperation`
