### PR TITLE
fix(server): fix replication master deadlock on cancelation flow

### DIFF
--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -571,9 +571,14 @@ OpStatus DflyCmd::StartFullSyncInThread(FlowInfo* flow, Context* cntx, EngineSha
   flow->saver = std::make_unique<RdbSaver>(flow->conn->socket(), save_mode, false);
 
   flow->cleanup = [flow]() {
-    flow->saver->Cancel();
+    // socket shutdown is needed before calling saver->Cancel(). Because
+    // we might cancel while the write to socket is blocking and
+    // therefore if we wont cancel the socket the full sync fiber might
+    // not get to pop entries from channel, which can cause dead lock if channel is full and some
+    // callbacks are blocked on trying to insert to channel.
     flow->TryShutdownSocket();
-    flow->full_sync_fb.JoinIfNeeded();
+    flow->saver->Cancel();              // stops writing to channel
+    flow->full_sync_fb.JoinIfNeeded();  // finishes poping data from channel
     flow->saver.reset();
   };
 

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -570,14 +570,14 @@ OpStatus DflyCmd::StartFullSyncInThread(FlowInfo* flow, Context* cntx, EngineSha
       shard->shard_id() == 0 ? SaveMode::SINGLE_SHARD_WITH_SUMMARY : SaveMode::SINGLE_SHARD;
   flow->saver = std::make_unique<RdbSaver>(flow->conn->socket(), save_mode, false);
 
-  flow->cleanup = [flow]() {
+  flow->cleanup = [flow, shard]() {
     // socket shutdown is needed before calling saver->Cancel(). Because
     // we might cancel while the write to socket is blocking and
     // therefore if we wont cancel the socket the full sync fiber might
     // not get to pop entries from channel, which can cause dead lock if channel is full and some
     // callbacks are blocked on trying to insert to channel.
     flow->TryShutdownSocket();
-    flow->saver->Cancel();              // stops writing to channel
+    flow->saver->CancelInShard(shard);  // stops writing to journal stream to channel
     flow->full_sync_fb.JoinIfNeeded();  // finishes poping data from channel
     flow->saver.reset();
   };

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -1092,7 +1092,7 @@ class RdbSaver::Impl {
 
   error_code SaveAuxFieldStrStr(string_view key, string_view val);
 
-  void Cancel();
+  void CancelInShard(EngineShard* shard);
 
   size_t GetTotalBuffersSize() const;
 
@@ -1243,15 +1243,11 @@ void RdbSaver::Impl::StartIncrementalSnapshotting(Context* cntx, EngineShard* sh
 }
 
 void RdbSaver::Impl::StopSnapshotting(EngineShard* shard) {
-  GetSnapshot(shard)->Finalize();
+  GetSnapshot(shard)->FinalizeJournalStream(false);
 }
 
-void RdbSaver::Impl::Cancel() {
-  auto* shard = EngineShard::tlocal();
-  if (!shard)
-    return;
-
-  GetSnapshot(shard)->Cancel();
+void RdbSaver::Impl::CancelInShard(EngineShard* shard) {
+  GetSnapshot(shard)->FinalizeJournalStream(true);
 }
 
 // This function is called from connection thread when info command is invoked.
@@ -1493,8 +1489,8 @@ error_code RdbSaver::SaveAuxFieldStrInt(string_view key, int64_t val) {
   return impl_->SaveAuxFieldStrStr(key, string_view(buf, vlen));
 }
 
-void RdbSaver::Cancel() {
-  impl_->Cancel();
+void RdbSaver::CancelInShard(EngineShard* shard) {
+  impl_->CancelInShard(shard);
 }
 
 size_t RdbSaver::GetTotalBuffersSize() const {

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -1216,7 +1216,7 @@ error_code RdbSaver::Impl::ConsumeChannel(const Cancellation* cll) {
   for (auto& ptr : shard_snapshots_) {
     ptr->Join();
   }
-
+  DVLOG(1) << "Finish ConsumeChannel";
   DCHECK(!channel_.TryPop(record));
 
   return io_error;
@@ -1251,15 +1251,7 @@ void RdbSaver::Impl::Cancel() {
   if (!shard)
     return;
 
-  auto& snapshot = GetSnapshot(shard);
-  if (snapshot)
-    snapshot->StopChannel();
-
-  dfly::SliceSnapshot::DbRecord rec;
-  while (channel_.Pop(rec)) {
-  }
-
-  snapshot->Join();
+  GetSnapshot(shard)->Cancel();
 }
 
 // This function is called from connection thread when info command is invoked.

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -103,7 +103,7 @@ class RdbSaver {
   // freq_map can optionally be null.
   std::error_code SaveBody(Context* cntx, RdbTypeFreqMap* freq_map);
 
-  void Cancel();
+  void CancelInShard(EngineShard* shard);
 
   SaveMode Mode() const {
     return save_mode_;

--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -83,11 +83,9 @@ class SliceSnapshot {
   // Blocking. Must be called from the Snapshot thread.
   void Finalize();
 
-  // Stops channel. Needs to be called together with cancelling the context.
-  // Snapshot can't always react to cancellation in streaming mode because the
-  // iteration fiber might have finished running by then.
-  // Blocking. Must be called from the Snapshot thread.
-  void StopChannel();
+  // Called together with cntx cancel only for replication.
+  // Stops journal streaming.
+  void Cancel();
 
   // Waits for a regular, non journal snapshot to finish.
   // Called only for non-replication, backups usecases.
@@ -180,6 +178,7 @@ class SliceSnapshot {
   // version upper bound for entries that should be saved (not included).
   uint64_t snapshot_version_ = 0;
   uint32_t journal_cb_id_ = 0;
+  bool unregister_journal_ = false;  // true if unregister journal was already called
 
   uint64_t rec_id_ = 1, last_pushed_id_ = 0;
 

--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -79,13 +79,9 @@ class SliceSnapshot {
   // called.
   void StartIncremental(Context* cntx, LSN start_lsn);
 
-  // Finalizes the snapshot. Only called for replication.
+  // Finalizes journal streaming writes. Only called for replication.
   // Blocking. Must be called from the Snapshot thread.
-  void Finalize();
-
-  // Called together with cntx cancel only for replication.
-  // Stops journal streaming.
-  void Cancel();
+  void FinalizeJournalStream(bool cancel);
 
   // Waits for a regular, non journal snapshot to finish.
   // Called only for non-replication, backups usecases.
@@ -178,7 +174,6 @@ class SliceSnapshot {
   // version upper bound for entries that should be saved (not included).
   uint64_t snapshot_version_ = 0;
   uint32_t journal_cb_id_ = 0;
-  bool unregister_journal_ = false;  // true if unregister journal was already called
 
   uint64_t rec_id_ = 1, last_pushed_id_ = 0;
 


### PR DESCRIPTION
fix #3649 
The bug: while running debug populate and cancel replication ,rdb saver cancel is called with context cancel. Both flow calling StopChannel function which sets journal callback to 0 and unregister on journal change and closes channel.
When this flow was called from different fibers than the first call was locked on mutex to unregister the journal the second fiber whould skip the unregister as it was already set the call back id to 0 and it called the close channel leading to deadlock as callback could not push to channel as it was full.
The fiber which consumes from channel already exited because channel was marked as close
The fix:
Now we call close channel only after and if we call the unregister on change, we do this only once and in the cancel function