### PR TITLE
chore: limit number of descriptors in the exec map

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -734,6 +734,8 @@ void DebugCmd::Exec() {
   for (const auto& k_v : freq_cnt) {
     StrAppend(&res, k_v.second, ":", k_v.first, "\n");
   }
+  StrAppend(&res, "--------------------------\n");
+
   auto* rb = static_cast<RedisReplyBuilder*>(cntx_->reply_builder());
   rb->SendVerbatimString(res);
 }

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -753,11 +753,9 @@ Transaction::MultiMode DeduceExecMode(ExecEvalState state,
 
 string CreateExecDescriptor(const std::vector<StoredCmd>& stored_cmds, unsigned num_uniq_shards) {
   string result;
-  result.reserve(stored_cmds.size() * 10);
-  absl::StrAppend(&result, "EXEC/", num_uniq_shards, "\n");
-  for (const auto& scmd : stored_cmds) {
-    absl::StrAppend(&result, "  ", scmd.Cid()->name(), " ", scmd.NumArgs(), "\n");
-  }
+  size_t max_len = std::min<size_t>(20u, stored_cmds.size());
+  absl::StrAppend(&result, "EXEC/", num_uniq_shards, "/", max_len);
+
   return result;
 }
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2019,8 +2019,7 @@ void ServerFamily::ResetStat(Namespace* ns) {
         tl_facade_stats->reply_stats.send_stats = {};
         tl_facade_stats->reply_stats.script_error_count = 0;
         tl_facade_stats->reply_stats.err_count.clear();
-
-        service_.mutable_registry()->ResetCallStats(index);
+        ServerState::tlocal()->exec_freq_count.clear();
       });
 }
 


### PR DESCRIPTION
For some cases, this map can grow indefinitely.
This change makes it less detailed by making sure that number of possible keys is bounded. Still it can provide a good summary of nature of exec transactions.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->