### PR TITLE
fix: join for cancel incoming migration

### DIFF
--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -818,7 +818,7 @@ bool RemoveIncomingMigrationImpl(std::vector<std::shared_ptr<IncomingSlotMigrati
   SlotSet removed = migration_slots.GetRemovedSlots(tl_cluster_config->GetOwnedSlots());
 
   migration->Stop();
-  // all fibers has migration shared_ptr so we don't need to join it and can erase
+  // all migration fibers has migration shared_ptr so the object can be removed later
   jobs.erase(it);
 
   // TODO make it outside in one run with other slots that should be flushed

--- a/src/server/cluster/incoming_slot_migration.h
+++ b/src/server/cluster/incoming_slot_migration.h
@@ -32,7 +32,7 @@ class IncomingSlotMigration {
   // After Join we still can get data due to error situation
   [[nodiscard]] bool Join(long attempt);
 
-  // Stop migrations, can be called even after migration is finished
+  // Stop and join the migration, can be called even after migration is finished
   void Stop();
 
   MigrationState GetState() const {


### PR DESCRIPTION
fixes: #3484
test_cluster_migration_cancel was broken because we haven't joined the migration process during canceling and can start flush slots before the last key update for every flow is executed. 
the fix: we join the migration process for cancel operation
