### PR TITLE
fix: test_replicaof_reject_on_load assert failure

### DIFF
--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2011,11 +2011,8 @@ async def test_replicaof_reject_on_load(df_factory, df_seeder_factory):
     replica = df_factory.create(dbfilename=f"dump_{tmp_file_name()}")
     df_factory.start_all([master, replica])
 
-    seeder = SeederV2(key_target=200000)
     c_replica = replica.client()
-    await seeder.run(c_replica, target_deviation=0.1)
-    dbsize = await c_replica.dbsize()
-    assert dbsize >= 180000
+    await c_replica.execute_command(f"DEBUG POPULATE 10000000")
 
     replica.stop()
     replica.start()

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2011,11 +2011,11 @@ async def test_replicaof_reject_on_load(df_factory, df_seeder_factory):
     replica = df_factory.create(dbfilename=f"dump_{tmp_file_name()}")
     df_factory.start_all([master, replica])
 
-    seeder = SeederV2(key_target=40000)
+    seeder = SeederV2(key_target=200000)
     c_replica = replica.client()
     await seeder.run(c_replica, target_deviation=0.1)
     dbsize = await c_replica.dbsize()
-    assert dbsize >= 30000
+    assert dbsize >= 180000
 
     replica.stop()
     replica.start()


### PR DESCRIPTION
I was able to reproduce it locally on debug build. As is it fails rather frequently. The test is flaky because by the time the client calls `REPLICAOF` command df might have finished loading the snapshot. The fix is increase load such that the client will get `busy loading` while calling `REPLICA OF COMMAND`. I rerun the test a couple of times without any failure locally. I will run it here a few times as well.

* increase snapshot size for the test

resolves #3689