### PR TITLE
fix: allow parsing extra spaces on acl files

### DIFF
--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -788,7 +788,7 @@ MaterializedContents MaterializeFileContents(std::vector<std::string>* usernames
   for (auto& command : commands) {
     if (command.empty())
       continue;
-    std::vector<std::string_view> cmds = absl::StrSplit(command, ' ');
+    std::vector<std::string_view> cmds = absl::StrSplit(command, ' ', absl::SkipEmpty());
     if (!absl::EqualsIgnoreCase(cmds[0], "USER") || cmds.size() < 4) {
       return {};
     }

--- a/tests/dragonfly/acl_family_test.py
+++ b/tests/dragonfly/acl_family_test.py
@@ -485,7 +485,8 @@ async def test_require_pass_with_acl_file_order(df_factory, tmp_dir):
 
 @pytest.mark.asyncio
 async def test_set_acl_file(async_client: aioredis.Redis, tmp_dir):
-    acl_file_content = "USER roy ON #ea71c25a7a602246b4c39824b855678894a96f43bb9b71319c39700a1e045222 +@string +@fast +hset\nUSER john on nopass +@string"
+    # Note the extra space below, it's intented to also check that we properly parse extra spaces
+    acl_file_content = "USER    roy ON #ea71c25a7a602246b4c39824b855678894a96f43bb9b71319c39700a1e045222 +@string +@fast +hset\nUSER john on nopass +@string"
 
     acl = create_temp_file(acl_file_content, tmp_dir)
 


### PR DESCRIPTION
DF would fail to parse ACL file with multiple whitespaces. This PR fixes this.

* allow parsing extra whitespace characters in acl files

Resolves #3698