### PR TITLE
fix: add default value has_mc_flag field

### DIFF
--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -1905,7 +1905,7 @@ struct RdbLoader::ObjSettings {
   bool has_expired = false;
 
   bool is_sticky = false;
-  bool has_mc_flags;
+  bool has_mc_flags = false;
 
   void Reset() {
     expiretime = 0;


### PR DESCRIPTION
we have an issue during the replication. 
```
W20240915 07:49:01.264786 159412 replica.cc:241] Error syncing with ... dragonfly.rdbload:8 Internal error when loading RDB file 8
E20240915 07:49:01.260331 159412 protocol_client.cc:291] Socket error system:103
E20240915 07:49:01.258461  2898 db_slice.cc:894] Internal error, inconsistent state, mcflag should be present but not found
```

The bug manifests on replica side and causes the data on replica be in inconsistent state, potentially triggering errors logs when it's being accessed. The server process will survive this state