### PR TITLE
fix: crash in journal_slice during shutdown 

### DIFF
--- a/src/server/journal/journal_slice.cc
+++ b/src/server/journal/journal_slice.cc
@@ -54,6 +54,8 @@ JournalSlice::JournalSlice() {
 }
 
 JournalSlice::~JournalSlice() {
+  // this mutex is needed to prevent destroying object during change_cb_arr_ executions
+  lock_guard lk(cb_mu_);
   // CHECK(!shard_file_);
 }
 


### PR DESCRIPTION
fixes: #3321

during DF instance shutdown we can get a crash if the journalSlice object was destroyed during one of the journal callbacks execution preemption.
fix: we can guarantee that no callbacks are in progress if lock the mutex in the journalSlice destructor