### PR TITLE
fix(cluster): Do not `Pause()` replication / migrations

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1181,7 +1181,7 @@ void Service::DispatchCommand(CmdArgList args, facade::ConnectionContext* cntx) 
   }
 
   // Don't interrupt running multi commands or admin connections.
-  if (!dispatching_in_multi && (!cntx->conn() || !cntx->conn()->IsPrivileged())) {
+  if (!dispatching_in_multi && cntx->conn() && !cntx->conn()->IsPrivileged()) {
     bool is_write = cid->IsWriteOnly();
     is_write |= cid->name() == "PUBLISH" || cid->name() == "EVAL" || cid->name() == "EVALSHA";
     is_write |= cid->name() == "EXEC" && dfly_cntx->conn_state.exec_info.is_write;


### PR DESCRIPTION
Pre-this change, whenever Dragonfly was paused (either by a user or by internal processes like takeover or slot migration finalization), migrations and replications were also paused.

This could cause timing issues, which sometime result in migration failures. Specifically, when 2 nodes have migrations from one to the other **in parallel** (A->B and B->A), the `Pause()` that happens on A (which happens because it's a source node) will stop it from processing incoming traffic from B (incoming because it is also a target node).

If timed correctly, it will be locked until it times out, and so the migration will fail.

The fix is to prevent replications and migrations from adhering to `Pause()`s, which I think should not have happened in the first place because they should use the admin port anyway.

Fixes #3319

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->