### PR TITLE
fix: fix s3 load snapshot

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -999,13 +999,13 @@ void ServerFamily::FlushAll(ConnectionContext* cntx) {
 // error (if any occured) with a future.
 std::optional<fb2::Future<GenericError>> ServerFamily::Load(string_view load_path,
                                                             LoadExistingKeys existing_keys) {
-  fs::path path(load_path);
+  std::string path(load_path);
 
   if (load_path.empty()) {
     fs::path dir_path(GetFlag(FLAGS_dir));
     string filename = GetFlag(FLAGS_dbfilename);
     dir_path.append(filename);
-    path = dir_path;
+    path = dir_path.generic_string();
   }
 
   DCHECK_GT(shard_count(), 0u);
@@ -1016,7 +1016,7 @@ std::optional<fb2::Future<GenericError>> ServerFamily::Load(string_view load_pat
     return future;
   }
 
-  auto paths_result = snapshot_storage_->LoadPaths(path.generic_string());
+  auto paths_result = snapshot_storage_->LoadPaths(path);
   if (!paths_result) {
     LOG(ERROR) << "Failed to load snapshot: " << paths_result.error().Format();
 
@@ -1027,7 +1027,7 @@ std::optional<fb2::Future<GenericError>> ServerFamily::Load(string_view load_pat
 
   std::vector<std::string> paths = *paths_result;
 
-  LOG(INFO) << "Loading " << path.generic_string();
+  LOG(INFO) << "Loading " << path;
 
   auto new_state = service_.SwitchState(GlobalState::ACTIVE, GlobalState::LOADING);
   if (new_state != GlobalState::LOADING) {


### PR DESCRIPTION
Fixes loading S3 snapshots (see https://github.com/dragonflydb/dragonfly-operator/issues/243).

Before `fs::path path(load_path)` was loading an S3 URL like `s3://my-bucket/my-backup` as a local filepath which messed up the scheme (replaced `s3://` with `s3:/` I think).

So just replacing `fs::path` with `string` and setting `path = dir_path.generic_string()` which I think is equivalent?

As mentioned in 'Eng' chat there is an S3 test (https://github.com/dragonflydb/dragonfly/blob/main/tests/dragonfly/snapshot_test.py#L315) though that needs AWS credentials in CI to run the test. Happy to integrate (just needs setting an environment variable in the workflow) but I'll probably need some help setting up credentials

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->