### PR TITLE
feat(server): introduce oom_deny_commands flag

### DIFF
--- a/src/facade/command_id.h
+++ b/src/facade/command_id.h
@@ -84,6 +84,10 @@ class CommandId {
     restricted_ = restricted;
   }
 
+  void SetFlag(uint32_t flag) {
+    opt_mask_ |= flag;
+  }
+
   static uint32_t OptCount(uint32_t mask);
 
   // PUBLISH/SUBSCRIBE/UNSUBSCRIBE variant

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -26,7 +26,7 @@ ABSL_FLAG(vector<string>, restricted_commands, {},
           "Commands restricted to connections on the admin port");
 
 ABSL_FLAG(vector<string>, oom_deny_commands, {},
-          "aditinal commands that will be marked as denyoom");
+          "Additinal commands that will be marked as denyoom");
 namespace dfly {
 
 using namespace facade;

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -25,6 +25,8 @@ ABSL_FLAG(vector<string>, rename_command, {},
 ABSL_FLAG(vector<string>, restricted_commands, {},
           "Commands restricted to connections on the admin port");
 
+ABSL_FLAG(vector<string>, oom_deny_commands, {},
+          "aditinal commands that will be marked as denyoom");
 namespace dfly {
 
 using namespace facade;
@@ -108,6 +110,10 @@ CommandRegistry::CommandRegistry() {
   for (string name : GetFlag(FLAGS_restricted_commands)) {
     restricted_cmds_.emplace(AsciiStrToUpper(name));
   }
+
+  for (string name : GetFlag(FLAGS_oom_deny_commands)) {
+    oomdeny_cmds_.emplace(AsciiStrToUpper(name));
+  }
 }
 
 void CommandRegistry::Init(unsigned int thread_count) {
@@ -131,6 +137,10 @@ CommandRegistry& CommandRegistry::operator<<(CommandId cmd) {
 
   if (restricted_cmds_.find(k) != restricted_cmds_.end()) {
     cmd.SetRestricted(true);
+  }
+
+  if (oomdeny_cmds_.find(k) != oomdeny_cmds_.end()) {
+    cmd.SetFlag(CO::DENYOOM);
   }
 
   cmd.SetFamily(family_of_commands_.size() - 1);

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -194,6 +194,7 @@ class CommandRegistry {
   absl::flat_hash_map<std::string, CommandId> cmd_map_;
   absl::flat_hash_map<std::string, std::string> cmd_rename_map_;
   absl::flat_hash_set<std::string> restricted_cmds_;
+  absl::flat_hash_set<std::string> oomdeny_cmds_;
 
   FamiliesVec family_of_commands_;
   size_t bit_index_;


### PR DESCRIPTION
I suspect we have memory leak in eval when returning oom 
Using this flag set to evalsha,eval we can verify and if this is the case it stop the leak until we introduce a fix