### PR TITLE
fix server: fix last error reply

### DIFF
--- a/src/facade/reply_capture.cc
+++ b/src/facade/reply_capture.cc
@@ -218,6 +218,8 @@ void CapturingReplyBuilder::Apply(Payload&& pl, RedisReplyBuilder* rb) {
 
   CaptureVisitor cv{rb};
   visit(cv, std::move(pl));
+  // Consumed and printed by InvokeCmd. We just send the actual error here
+  std::ignore = rb->ConsumeLastError();
 }
 
 void CapturingReplyBuilder::SetReplyMode(ReplyMode mode) {

--- a/src/facade/reply_capture.cc
+++ b/src/facade/reply_capture.cc
@@ -29,6 +29,9 @@ void CapturingReplyBuilder::SendMGetResponse(MGetResponse resp) {
 }
 
 void CapturingReplyBuilder::SendError(OpStatus status) {
+  if (status != OpStatus::OK) {
+    last_error_ = StatusToMsg(status);
+  }
   SKIP_LESS(ReplyMode::ONLY_ERR);
   Capture(status);
 }

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1331,7 +1331,7 @@ OpResult<void> OpTrackKeys(const OpArgs slice_args, const facade::Connection::We
 bool Service::InvokeCmd(const CommandId* cid, CmdArgList tail_args, ConnectionContext* cntx) {
   DCHECK(cid);
   DCHECK(!cid->Validate(tail_args));
-
+  DCHECK(cntx->reply_builder()->ConsumeLastError().empty());
   if (auto err = VerifyCommandExecution(cid, cntx, tail_args); err) {
     // We need to skip this because ACK's should not be replied to
     // Bonus points because this allows to continue replication with ACL users who got

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1331,7 +1331,7 @@ OpResult<void> OpTrackKeys(const OpArgs slice_args, const facade::Connection::We
 bool Service::InvokeCmd(const CommandId* cid, CmdArgList tail_args, ConnectionContext* cntx) {
   DCHECK(cid);
   DCHECK(!cid->Validate(tail_args));
-  DCHECK(cntx->reply_builder()->ConsumeLastError().empty());
+
   if (auto err = VerifyCommandExecution(cid, cntx, tail_args); err) {
     // We need to skip this because ACK's should not be replied to
     // Bonus points because this allows to continue replication with ACL users who got
@@ -1375,6 +1375,7 @@ bool Service::InvokeCmd(const CommandId* cid, CmdArgList tail_args, ConnectionCo
   ReplyGuard reply_guard(cntx, cid->name());
 #endif
   uint64_t invoke_time_usec = 0;
+  DCHECK(cntx->reply_builder()->ConsumeLastError().empty());
   try {
     invoke_time_usec = cid->Invoke(tail_args, cntx);
   } catch (std::exception& e) {

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -121,6 +121,7 @@ bool MultiCommandSquasher::ExecuteStandalone(StoredCmd* cmd) {
   if (verify_commands_) {
     if (auto err = service_->VerifyCommandState(cmd->Cid(), args, *cntx_); err) {
       cntx_->SendError(std::move(*err));
+      std::ignore = cntx_->reply_builder()->ConsumeLastError();
       return !error_abort_;
     }
   }


### PR DESCRIPTION
bug 1: in multi command squasher error message was not set therefore it was not printed to log on the relevant command only on exec, fixed by setting the last error in CapturingReplyBuilder::SendError
bug 2: I sometimes see error logs which does not make sence f.e mset will print key does not exist, I added a dcheck for before command execution that there is no error set and it fails. reproduced with test_reply_guard_oom. @kostasrim will you be able to ivestigate this?