### PR TITLE
fix: Fix test `test_client_pause_with_replica`

### DIFF
--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1987,8 +1987,9 @@ async def test_client_pause_with_replica(df_factory, df_seeder_factory):
     stats_after_sleep = await c_master.info("CommandStats")
     # Check no commands are executed except info and replconf called from replica
     for cmd, cmd_stats in stats_after_sleep.items():
-        if "cmdstat_info" != cmd and "cmdstat_replconf" != cmd_stats:
-            assert stats[cmd] == cmd_stats, cmd
+        if cmd in ["cmdstat_info", "cmdstat_replconf", "cmdstat_multi"]:
+            continue
+        assert stats[cmd] == cmd_stats, cmd
 
     await asyncio.sleep(6)
     seeder.stop()


### PR DESCRIPTION
There are 2 minor issues with this test:
1. It specified `cmdstat_replconf` as `cmd_stats` instead of `cmd`, that's clearly a typo as `cmd_stats` is a map with stats, while `replconf` is a Dragonfly command
2. Command `MULTI` is allowed to run even when the server is in paused state, see [here](https://github.com/dragonflydb/dragonfly/blob/main/src/server/main_service.cc#L1197):

   ``` // Don't interrupt running multi commands or admin connections. ```

Fixes #3675

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->