### PR TITLE
fix: allow the healthcheck run in non-privileged containers as well

### DIFF
--- a/tools/docker/healthcheck.sh
+++ b/tools/docker/healthcheck.sh
@@ -3,10 +3,21 @@
 HOST="localhost"
 PORT=$HEALTHCHECK_PORT
 
+
 if [ -z "$HEALTHCHECK_PORT" ]; then
-    # check all the TCP listening sockets, filter the dragonfly process, and fetch the port.
-    # For cases when dragonfly opens multiple ports, we filter with tail to choose one of them.
-    PORT=$(su dfly -c "netstat -tlnp" | grep "1/dragonfly" | grep -oE ':[0-9]+' | cut -c2- | tail -n 1)
+  # try unpriveleged version first. This should cover cases when the container is running
+  # without root, for example:
+  # docker run  --group-add 999  --cap-drop=ALL --user 999 docker.dragonflydb.io/dragonflydb/dragonfly
+  DF_NET=$(netstat -tlnp | grep "1/dragonfly")
+  if [ -z "$DF_NET" ]; then
+    # if we failed, then lets try the priveleged version. is triggerred by the regular command:
+    # docker run docker.dragonflydb.io/dragonflydb/dragonfly
+    DF_NET=$(su dfly -c "netstat -tlnp" | grep "1/dragonfly")
+  fi
+
+  # check all the TCP ports, and fetch the port.
+  # For cases when dragonfly opens multiple ports, we filter with tail to choose one of them.
+  PORT=$(echo $DF_NET | grep -oE ':[0-9]+' | cut -c2- | tail -n 1)
 fi
 
 # If we're running with TLS enabled, utilise OpenSSL for the check


### PR DESCRIPTION
Fixes #3644 (again).

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->