### PR TITLE
fix: Fix `test_take_over_seeder`

### DIFF
--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1286,9 +1286,11 @@ async def test_take_over_seeder(
     stop_info = True
     await info_task
 
-    # Need to wait a bit to give time to write the shutdown snapshot
-    await asyncio.sleep(1)
-    assert master.proc.poll() == 0, "Master process did not exit correctly."
+    @assert_eventually
+    def assert_master_exists():
+        assert master.proc.poll() == 0, "Master process did not exit correctly."
+
+    assert_master_exists()
 
     master.start()
     c_master = master.client()


### PR DESCRIPTION
The test assumed any shutdown will take not more than 1s. This doesn't always hold, and also waiting for 1s isn't ideal because usually it takes less than that.

Changed to use `assert_eventually` instead.

Fixes #3684

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->