### PR TITLE
test: unskip test for debugging purpose

### DIFF
--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1828,7 +1828,6 @@ async def test_network_disconnect_small_buffer(df_factory, df_seeder_factory):
     # assert master.is_in_logs("Partial sync requested from stale LSN")
 
 
-@pytest.mark.skip("Fails sporadically")
 async def test_replica_reconnections_after_network_disconnect(df_factory, df_seeder_factory):
     master = df_factory.create(proactor_threads=6)
     replica = df_factory.create(proactor_threads=4)


### PR DESCRIPTION
I've tried to reproduce the problem with test_replica_reconnections_after_network_disconnect locally but failed, so I decided to unskip it