### PR TITLE
chore: introduce a Clone function for the dense set

### DIFF
--- a/src/core/dense_set.h
+++ b/src/core/dense_set.h
@@ -244,6 +244,8 @@ class DenseSet {
   uint32_t Scan(uint32_t cursor, const ItemCb& cb) const;
   void Reserve(size_t sz);
 
+  void Fill(DenseSet* other) const;
+
   // set an abstract time that allows expiry.
   void set_time(uint32_t val) {
     time_now_ = val;
@@ -264,6 +266,7 @@ class DenseSet {
   virtual size_t ObjectAllocSize(const void* obj) const = 0;
   virtual uint32_t ObjExpireTime(const void* obj) const = 0;
   virtual void ObjDelete(void* obj, bool has_ttl) const = 0;
+  virtual void* ObjectClone(const void* obj, bool has_ttl) const = 0;
 
   void CollectExpired();
 
@@ -323,6 +326,15 @@ class DenseSet {
   DenseSet& operator=(DenseSet&) = delete;
 
   bool Equal(DensePtr dptr, const void* ptr, uint32_t cookie) const;
+
+  struct CloneItem {
+    const DenseLinkKey* link = nullptr;
+    void* obj = nullptr;
+    bool has_ttl = false;
+    bool fetch_tail = false;
+  };
+
+  void CloneBatch(unsigned len, CloneItem* items, DenseSet* other) const;
 
   MemoryResource* mr() {
     return entries_.get_allocator().resource();

--- a/src/core/score_map.cc
+++ b/src/core/score_map.cc
@@ -133,6 +133,10 @@ void ScoreMap::ObjDelete(void* obj, bool has_ttl) const {
   sdsfree(s1);
 }
 
+void* ScoreMap::ObjectClone(const void* obj, bool has_ttl) const {
+  return nullptr;
+}
+
 detail::SdsScorePair ScoreMap::iterator::BreakToPair(void* obj) {
   sds f = (sds)obj;
   return detail::SdsScorePair(f, GetValue(f));

--- a/src/core/score_map.h
+++ b/src/core/score_map.h
@@ -123,6 +123,7 @@ class ScoreMap : public DenseSet {
   size_t ObjectAllocSize(const void* obj) const final;
   uint32_t ObjExpireTime(const void* obj) const final;
   void ObjDelete(void* obj, bool has_ttl) const final;
+  void* ObjectClone(const void* obj, bool has_ttl) const final;
 };
 
 }  // namespace dfly

--- a/src/core/string_map.cc
+++ b/src/core/string_map.cc
@@ -283,6 +283,10 @@ void StringMap::ObjDelete(void* obj, bool has_ttl) const {
   sdsfree(s1);
 }
 
+void* StringMap::ObjectClone(const void* obj, bool has_ttl) const {
+  return nullptr;
+}
+
 detail::SdsPair StringMap::iterator::BreakToPair(void* obj) {
   sds f = (sds)obj;
   return detail::SdsPair(f, GetValue(f));

--- a/src/core/string_map.h
+++ b/src/core/string_map.h
@@ -158,6 +158,7 @@ class StringMap : public DenseSet {
   size_t ObjectAllocSize(const void* obj) const final;
   uint32_t ObjExpireTime(const void* obj) const final;
   void ObjDelete(void* obj, bool has_ttl) const final;
+  void* ObjectClone(const void* obj, bool has_ttl) const final;
 };
 
 }  // namespace dfly

--- a/src/core/string_set.cc
+++ b/src/core/string_set.cc
@@ -133,4 +133,18 @@ void StringSet::ObjDelete(void* obj, bool has_ttl) const {
   sdsfree((sds)obj);
 }
 
+void* StringSet::ObjectClone(const void* obj, bool has_ttl) const {
+  sds src = (sds)obj;
+  if (has_ttl) {
+    size_t slen = sdslen(src);
+    char* ttlptr = src + slen + 1;
+    uint32_t at = absl::little_endian::Load32(ttlptr);
+    sds newsds = AllocImmutableWithTtl(slen, at);
+    if (slen)
+      memcpy(newsds, src, slen);
+    return newsds;
+  }
+  return sdsnewlen(src, sdslen(src));
+}
+
 }  // namespace dfly

--- a/src/core/string_set.h
+++ b/src/core/string_set.h
@@ -112,6 +112,7 @@ class StringSet : public DenseSet {
   size_t ObjectAllocSize(const void* s1) const override;
   uint32_t ObjExpireTime(const void* obj) const override;
   void ObjDelete(void* obj, bool has_ttl) const override;
+  void* ObjectClone(const void* obj, bool has_ttl) const override;
 };
 
 }  // end namespace dfly

--- a/src/redis/sds.c
+++ b/src/redis/sds.c
@@ -169,10 +169,6 @@ sds sdsnewlen(const void *init, size_t initlen) {
     return _sdsnewlen(init, initlen, 0);
 }
 
-sds sdstrynewlen(const void *init, size_t initlen) {
-    return _sdsnewlen(init, initlen, 1);
-}
-
 /* Create an empty (zero length) sds string. Even in this case the string
  * always has an implicit null term. */
 sds sdsempty(void) {

--- a/src/redis/sds.h
+++ b/src/redis/sds.h
@@ -216,7 +216,6 @@ static inline void sdssetalloc(sds s, size_t newlen) {
 }
 
 sds sdsnewlen(const void *init, size_t initlen);
-sds sdstrynewlen(const void *init, size_t initlen);
 sds sdsnew(const char *init);
 sds sdsempty(void);
 sds sdsdup(const sds s);


### PR DESCRIPTION
We use a state machine to prefetch data in batches. After this change, the hot spots are predominantly inside ObjectClone and Hash methods.

All in all benchmarks show ~45% CPU reduction:

BM_Clone/elements:32000    1517322 ns      1517338 ns         2772
BM_Fill/elements:32000      841087 ns       841097 ns         4900

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->