### PR TITLE
chore: Switch ports for `cluster_mgr_test.py`

### DIFF
--- a/tests/dragonfly/cluster_mgr_test.py
+++ b/tests/dragonfly/cluster_mgr_test.py
@@ -5,7 +5,7 @@ from redis import asyncio as aioredis
 from .utility import *
 from . import dfly_args
 
-BASE_PORT = 40001
+BASE_PORT = 30001
 
 
 async def insert_cluster_data(cluster_client: redis.RedisCluster):


### PR DESCRIPTION
We saw failures due to port already in use

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->