### PR TITLE
chore: logs on assert fail for test_acl_cat_commands_multi_exec_squash

### DIFF
--- a/tests/dragonfly/acl_family_test.py
+++ b/tests/dragonfly/acl_family_test.py
@@ -195,7 +195,7 @@ async def test_acl_cat_commands_multi_exec_squash(df_factory):
     # return multiple errors for each command failed. Since the nature of the error
     # is the same, that a rule has changed we should squash those error messages into
     # one.
-    assert res[0].args[0] == "kk ACL rules changed between the MULTI and EXEC"
+    assert res[0].args[0] == "kk ACL rules changed between the MULTI and EXEC", res
 
     await admin_client.close()
     await client.close()


### PR DESCRIPTION
I could not reproduce and this test failed once and it exists for over a year. I am quite skeptical if this is related with `ACL` because `MULTI/EXEC` command always returns an array as a reply. Even if it fails, we still get an array and if the commands return nothing then the array is simply empty. However, from the test failure, it's explicit that the returned object is a `string` so for example `EXEC` could have failed with `internal error` (some random thought). Furthermore, I don't see how else it would fail in `VerifyCommandExecution` so I would say it's unlikely we get a string error from there. Either way, if it ever fails again I would like to know what the error message is and hopefully this will shed some light on the actual issue.

* print result if assertion fails

helps with  #3719 (which I will close and reopen once the test fails again)