### PR TITLE
fix: add value range check for SETBIT command

### DIFF
--- a/src/facade/cmd_arg_parser_test.cc
+++ b/src/facade/cmd_arg_parser_test.cc
@@ -143,4 +143,29 @@ TEST_F(CmdArgParserTest, IgnoreCase) {
   EXPECT_EQ(absl::implicit_cast<string_view>(parser.Next()), "world"sv);
 }
 
+TEST_F(CmdArgParserTest, FixedRangeInt) {
+  {
+    auto parser = Make({"10", "-10", "12"});
+
+    EXPECT_EQ((parser.Next<FInt<-11, 11>>().value), 10);
+    EXPECT_EQ((parser.Next<FInt<-11, 11>>().value), -10);
+    EXPECT_EQ((parser.Next<FInt<-11, 11>>().value), 0);
+
+    auto err = parser.Error();
+    EXPECT_TRUE(err);
+    EXPECT_EQ(err->type, CmdArgParser::INVALID_INT);
+    EXPECT_EQ(err->index, 2);
+  }
+
+  {
+    auto parser = Make({"-12"});
+    EXPECT_EQ((parser.Next<FInt<-11, 11>>().value), 0);
+
+    auto err = parser.Error();
+    EXPECT_TRUE(err);
+    EXPECT_EQ(err->type, CmdArgParser::INVALID_INT);
+    EXPECT_EQ(err->index, 0);
+  }
+}
+
 }  // namespace facade

--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -1209,12 +1209,11 @@ void SetBit(CmdArgList args, ConnectionContext* cntx) {
   // Support for the command "SETBIT key offset new_value"
   // see https://redis.io/commands/setbit/
 
-  uint32_t offset{0};
-  int32_t value{0};
-  std::string_view key = ArgS(args, 0);
+  CmdArgParser parser(args);
+  auto [key, offset, value] = parser.Next<string_view, uint32_t, FInt<0, 1>>();
 
-  if (!absl::SimpleAtoi(ArgS(args, 1), &offset) || !absl::SimpleAtoi(ArgS(args, 2), &value)) {
-    return cntx->SendError(kInvalidIntErr);
+  if (auto err = parser.Error(); err) {
+    return cntx->SendError(err->MakeReply());
   }
 
   auto cb = [&](Transaction* t, EngineShard* shard) {

--- a/src/server/bitops_family_test.cc
+++ b/src/server/bitops_family_test.cc
@@ -235,6 +235,23 @@ TEST_F(BitOpsFamilyTest, SetBitMissingKey) {
   }
 }
 
+TEST_F(BitOpsFamilyTest, SetBitIncorrectValues) {
+  EXPECT_EQ(0, CheckedInt({"setbit", "foo", "0", "1"}));
+  EXPECT_THAT(Run({"setbit", "foo", "1", "-1"}),
+              ErrArg("ERR value is not an integer or out of range"));
+  EXPECT_THAT(Run({"setbit", "foo", "2", "11"}),
+              ErrArg("ERR value is not an integer or out of range"));
+  EXPECT_THAT(Run({"setbit", "foo", "3", "a"}),
+              ErrArg("ERR value is not an integer or out of range"));
+  EXPECT_THAT(Run({"setbit", "foo", "4", "O"}),
+              ErrArg("ERR value is not an integer or out of range"));
+  EXPECT_EQ(1, CheckedInt({"getbit", "foo", "0"}));
+  EXPECT_EQ(0, CheckedInt({"getbit", "foo", "1"}));
+  EXPECT_EQ(0, CheckedInt({"getbit", "foo", "2"}));
+  EXPECT_EQ(0, CheckedInt({"getbit", "foo", "3"}));
+  EXPECT_EQ(0, CheckedInt({"getbit", "foo", "4"}));
+}
+
 const int32_t EXPECTED_VALUES_BYTES_BIT_COUNT[] = {  // got this from redis 0 as start index
     4, 7, 11, 14, 17, 21, 21, 21, 21};
 


### PR DESCRIPTION
fixes: #3747

the problem was that we processed all incorrect values for the SETBIT command as 1
fix: return error if value for SETBIT is not 0 or 1
also added a helper type FInt for CmdArgParser that can validate a numerical range