### PR TITLE
fix: bitop do not add dst key if result is empty

### DIFF
--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -1201,7 +1201,7 @@ void BitOp(CmdArgList args, ConnectionContext* cntx) {
         auto find_res = operation.FindAllowWrongType(shard);
 
         // BITOP command acts as a blind update. If the key existed and its type
-        // was not a string
+        // was not a string we still want to Commit with the new value.
         if (find_res == OpStatus::OK || find_res == OpStatus::WRONG_TYPE) {
           operation.Commit(op_result);
 

--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -343,7 +343,7 @@ std::string ElementAccess::Value() const {
 
 void ElementAccess::Commit(std::string_view new_value) const {
   if (shard_) {
-    if (new_value.empty() && IsNewEntry()) {
+    if (new_value.empty()) {
       // No need to run, it was a new entry and it got removed
       post_updater_.Cancel();
       context_.GetDbSlice(shard_->shard_id()).Del(context_, element_iter_);
@@ -1182,7 +1182,15 @@ void BitOp(CmdArgList args, ConnectionContext* cntx) {
         }
 
         if (shard->journal()) {
-          RecordJournal(t->GetOpArgs(shard), "SET", {dest_key, op_result});
+          if (op_result.empty()) {
+            // We need to delete it if the key exists. If it doesn't, we just
+            // skip it and do not send it to the replica at all.
+            if (!operation.IsNewEntry()) {
+              RecordJournal(t->GetOpArgs(shard), "DEL", {dest_key});
+            }
+          } else {
+            RecordJournal(t->GetOpArgs(shard), "SET", {dest_key, op_result});
+          }
         }
       }
       return OpStatus::OK;

--- a/src/server/bitops_family_test.cc
+++ b/src/server/bitops_family_test.cc
@@ -416,6 +416,11 @@ TEST_F(BitOpsFamilyTest, BitOpsNot) {
   EXPECT_EQ(0, CheckedInt({"bitop", "NOT", "foo", "this-key-do-not-exists"}));
   ASSERT_THAT(Run({"get", "foo"}), ArgType(RespExpr::Type::NIL));
 
+  // Change the type of foo. Bitops is similar to set command. It's a blind update.
+  ASSERT_THAT(Run({"hset", "foo", "bar", "val"}), IntArg(1));
+  EXPECT_EQ(0, CheckedInt({"bitop", "NOT", "foo", "this-key-do-not-exists"}));
+  ASSERT_THAT(Run({"get", "foo"}), ArgType(RespExpr::Type::NIL));
+
   // test bitop not
   resp = Run({"set", KEY_VALUES_BIT_OP[0].first, KEY_VALUES_BIT_OP[0].second});
   EXPECT_EQ(KEY_VALUES_BIT_OP[0].second.Size(),

--- a/src/server/bitops_family_test.cc
+++ b/src/server/bitops_family_test.cc
@@ -412,6 +412,10 @@ TEST_F(BitOpsFamilyTest, BitOpsNot) {
                            "this-key-do-not-exists"}));
   ASSERT_THAT(Run({"get", "bit-op-not-none-existing-key-results"}), ArgType(RespExpr::Type::NIL));
 
+  EXPECT_EQ(Run({"set", "foo", "bar"}), "OK");
+  EXPECT_EQ(0, CheckedInt({"bitop", "NOT", "foo", "this-key-do-not-exists"}));
+  ASSERT_THAT(Run({"get", "foo"}), ArgType(RespExpr::Type::NIL));
+
   // test bitop not
   resp = Run({"set", KEY_VALUES_BIT_OP[0].first, KEY_VALUES_BIT_OP[0].second});
   EXPECT_EQ(KEY_VALUES_BIT_OP[0].second.Size(),

--- a/src/server/bitops_family_test.cc
+++ b/src/server/bitops_family_test.cc
@@ -410,7 +410,7 @@ TEST_F(BitOpsFamilyTest, BitOpsNot) {
   // Make sure that this works with none existing key as well
   EXPECT_EQ(0, CheckedInt({"bitop", "NOT", "bit-op-not-none-existing-key-results",
                            "this-key-do-not-exists"}));
-  EXPECT_EQ(Run({"get", "bit-op-not-none-existing-key-results"}), "");
+  ASSERT_THAT(Run({"get", "bit-op-not-none-existing-key-results"}), ArgType(RespExpr::Type::NIL));
 
   // test bitop not
   resp = Run({"set", KEY_VALUES_BIT_OP[0].first, KEY_VALUES_BIT_OP[0].second});

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -574,17 +574,15 @@ async def test_rewrites(df_factory):
         print("Got:", mcmd)
         return mcmd
 
-    async def is_match_rsp(rx, tmp=False):
+    async def is_match_rsp(rx):
         mcmd = await get_next_command()
-        if tmp:
-            assert mcmd == rx
         print(mcmd, rx)
         return re.match(rx, mcmd)
 
     async def skip_cmd():
         await is_match_rsp(r".*")
 
-    async def check(cmd, rx, tmp=False):
+    async def check(cmd, rx):
         await c_master.execute_command(cmd)
         match = await is_match_rsp(rx)
         assert match
@@ -686,7 +684,7 @@ async def test_rewrites(df_factory):
         await skip_cmd()
         await c_master.set("k3", "-")
         await skip_cmd()
-        await check("BITOP NOT foo k3", r"SET foo \\xd2", True)
+        await check("BITOP NOT foo k3", r"SET foo \\xd2")
 
         # Check there is no rewrite for LMOVE on single shard
         await c_master.lpush("list", "v1", "v2", "v3", "v4")

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2664,7 +2664,7 @@ async def test_double_take_over(df_factory, df_seeder_factory):
 
 
 @pytest.mark.asyncio
-async def test_bug_3528(df_factory, df_seeder_factory):
+async def test_bug_3528(df_factory):
     master = df_factory.create()
     replica = df_factory.create()
     df_factory.start_all([master, replica])

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -674,7 +674,7 @@ async def test_rewrites(df_factory):
         # Check BITOP turns into SET
         await check("BITOP OR kdest k1 k2", r"SET kdest 1100")
         c_master = master.client()
-        # See gh issue
+        # See gh issue #3528
         await c_master.execute_command(f"HSET foo bar val")
         await skip_cmd()
         await check("BITOP NOT foo tmp", r"DEL foo")

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -673,13 +673,10 @@ async def test_rewrites(df_factory):
         await skip_cmd()
         # Check BITOP turns into SET
         await check("BITOP OR kdest k1 k2", r"SET kdest 1100")
-        c_master = master.client()
         # See gh issue #3528
         await c_master.execute_command(f"HSET foo bar val")
         await skip_cmd()
         await check("BITOP NOT foo tmp", r"DEL foo")
-        await c_master.execute_command(f"DEL foo")
-        await skip_cmd()
         await c_master.execute_command(f"HSET foo bar val")
         await skip_cmd()
         await c_master.set("k3", "-")


### PR DESCRIPTION
There are two bugs:

Bug 1:

```
bitop not does_not_exist tmp2
get does_not_exist
```
Should return `nill` and not `""` 

Bug 2:
```
setup master and replica and then:

on master do: hset foo bar val -> bitop not foo bar -> get foo returns WRONGTYPE
on replica do GET foo returns ""

Now state_of(master) != state_of(replica)
```

Bug 3:
```
hset foo bar val -> bitop not foo bar -> get foo returns WRONGTYPE
```

when `get foo` should return `nill`, that is `bitop` acts as a `blind update` similar to `set` command

resolves #3528