### PR TITLE
fix: zset store conclude transaction on error

### DIFF
--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1762,8 +1762,12 @@ void ZBooleanOperation(CmdArgList args, ConnectionContext* cntx, bool is_union, 
   for (auto& op_res : maps) {
     if (op_res.status() == OpStatus::SKIPPED)
       continue;
-    if (!op_res)
+    if (!op_res) {
+      if (store) {
+        cntx->transaction->Conclude();
+      }
       return cntx->SendError(op_res.status());
+    }
 
     if (result.empty())
       result = std::move(op_res.value());


### PR DESCRIPTION
While working on https://github.com/dragonflydb/dragonfly/issues/3742, found other zset `STORE` commands don't conclude the transaction when they return an error.

Such as to reproduce:
```
127.0.0.1:6379> SET foo bar
OK
127.0.0.1:6379> ZINTERSTORE dest 1 foo
(error) WRONGTYPE Operation against a key holding the wrong kind of value
127.0.0.1:6379> ZINTERSTORE dest 1 foo
Could not connect to Redis at 127.0.0.1:6379: Connection refused
```

```
W20240921 13:27:23.480844 1039547 main_service.cc:1387]  ZINTERSTORE dest 1 foo failed with reason: -WRONGTYPE Operation against a key holding the wrong kind of value
*** SIGSEGV received at time=1726921644 on cpu 1 ***
[failure_signal_handler.cc : 345] RAW: Signal 11 raised at PC=0x620500431c6d while already in AbslFailureSignalHandler()
PC: @     0x620500431c6d  (unknown)  std::atomic<>::exchange()
    @     0x6205011b9121         64  absl::lts_20240116::WriteFailureInfo()
    @     0x6205011b937b         96  absl::lts_20240116::AbslFailureSignalHandler()
...
```

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->