### PR TITLE
feat(zset_family): add ZRANGESTORE

### DIFF
--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -2194,6 +2194,11 @@ void ZSetFamily::ZRangeByScore(CmdArgList args, ConnectionContext* cntx) {
   ZRangeGeneric(args, cntx, RangeParams{.interval_type = RangeParams::SCORE});
 }
 
+void ZSetFamily::ZRangeStore(CmdArgList args, ConnectionContext* cntx) {
+  ZRangeGeneric(args.subspan(1), cntx,
+                RangeParams{.with_scores = true, .store_key = ArgS(args, 0)});
+}
+
 void ZSetFamily::ZRevRangeByScore(CmdArgList args, ConnectionContext* cntx) {
   ZRangeGeneric(args, cntx, RangeParams{.reverse = true, .interval_type = RangeParams::SCORE});
 }
@@ -2443,12 +2448,61 @@ void ZSetFamily::ZRangeInternal(CmdArgList args, RangeParams range_params,
     }
   }
 
-  auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpRange(range_spec, t->GetOpArgs(shard), key);
+  OpResult<ScoredArray> range_result;
+  ShardId src_shard = Shard(key, shard_set->size());
+  auto range_cb = [&](Transaction* t, EngineShard* shard) {
+    if (shard->shard_id() != src_shard) {
+      // Only run ZRANGE on the source shard.
+      return OpStatus::OK;
+    }
+    range_result = OpRange(range_spec, t->GetOpArgs(shard), key);
+    return OpStatus::OK;
   };
+  // Don't conclude the transaction if we're storing the result.
+  cntx->transaction->Execute(std::move(range_cb), !range_params.store_key);
 
-  OpResult<ScoredArray> result = cntx->transaction->ScheduleSingleHopT(std::move(cb));
-  OutputScoredArrayResult(result, range_params, cntx);
+  if (range_result.status() == OpStatus::WRONG_TYPE) {
+    if (range_params.store_key) {
+      cntx->transaction->Conclude();
+    }
+    return cntx->SendError(kWrongTypeErr);
+  }
+  LOG_IF(WARNING, !range_result && range_result.status() != OpStatus::KEY_NOTFOUND)
+      << "Unexpected status " << range_result.status();
+
+  if (!range_params.store_key) {
+    auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
+    rb->SendScoredArray(range_result.value(), range_params.with_scores);
+    return;
+  }
+
+  OpResult<AddResult> add_result;
+  ShardId dest_shard = Shard(*range_params.store_key, shard_set->size());
+  auto add_cb = [&](Transaction* t, EngineShard* shard) {
+    if (shard->shard_id() != dest_shard) {
+      // Only write the result on the target shard.
+      return OpStatus::OK;
+    }
+
+    std::vector<ScoredMemberView> mvec(range_result->size());
+    size_t i = 0;
+    for (const auto& [str, score] : *range_result) {
+      mvec[i++] = {score, str};
+    }
+
+    add_result =
+        OpAdd(t->GetOpArgs(shard), ZParams{.override = true}, *range_params.store_key, mvec);
+
+    return OpStatus::OK;
+  };
+  cntx->transaction->Execute(std::move(add_cb), true);
+
+  if (add_result.status() == OpStatus::OUT_OF_MEMORY) {
+    return cntx->SendError(add_result.status());
+  }
+  LOG_IF(WARNING, !add_result) << "Unexpected status " << add_result.status();
+
+  return cntx->SendLong(range_result->size());
 }
 
 void ZSetFamily::ZRankGeneric(CmdArgList args, bool reverse, ConnectionContext* cntx) {
@@ -3121,6 +3175,7 @@ constexpr uint32_t kZRandMember = READ | SORTEDSET | SLOW;
 constexpr uint32_t kZRank = READ | SORTEDSET | FAST;
 constexpr uint32_t kZRangeByLex = READ | SORTEDSET | SLOW;
 constexpr uint32_t kZRangeByScore = READ | SORTEDSET | SLOW;
+constexpr uint32_t kZRangeStore = WRITE | SORTEDSET | SLOW;
 constexpr uint32_t kZScore = READ | SORTEDSET | FAST;
 constexpr uint32_t kZMScore = READ | SORTEDSET | FAST;
 constexpr uint32_t kZRemRangeByRank = WRITE | SORTEDSET | SLOW;
@@ -3170,6 +3225,7 @@ void ZSetFamily::Register(CommandRegistry* registry) {
       << CI{"ZRANK", CO::READONLY | CO::FAST, 3, 1, 1, acl::kZRank}.HFUNC(ZRank)
       << CI{"ZRANGEBYLEX", CO::READONLY, -4, 1, 1, acl::kZRangeByLex}.HFUNC(ZRangeByLex)
       << CI{"ZRANGEBYSCORE", CO::READONLY, -4, 1, 1, acl::kZRangeByScore}.HFUNC(ZRangeByScore)
+      << CI{"ZRANGESTORE", CO::WRITE | CO::DENYOOM, -5, 1, 2, acl::kZRangeStore}.HFUNC(ZRangeStore)
       << CI{"ZSCORE", CO::READONLY | CO::FAST, 3, 1, 1, acl::kZScore}.HFUNC(ZScore)
       << CI{"ZMSCORE", CO::READONLY | CO::FAST, -3, 1, 1, acl::kZMScore}.HFUNC(ZMScore)
       << CI{"ZREMRANGEBYRANK", CO::WRITE, 4, 1, 1, acl::kZRemRangeByRank}.HFUNC(ZRemRangeByRank)

--- a/src/server/zset_family.h
+++ b/src/server/zset_family.h
@@ -43,6 +43,7 @@ class ZSetFamily {
     bool with_scores = false;
     bool reverse = false;
     enum IntervalType { LEX, RANK, SCORE } interval_type = RANK;
+    std::optional<std::string_view> store_key = std::nullopt;
   };
 
   struct ZRangeSpec {
@@ -78,6 +79,7 @@ class ZSetFamily {
   static void ZRangeByLex(CmdArgList args, ConnectionContext* cntx);
   static void ZRevRangeByLex(CmdArgList args, ConnectionContext* cntx);
   static void ZRangeByScore(CmdArgList args, ConnectionContext* cntx);
+  static void ZRangeStore(CmdArgList args, ConnectionContext* cntx);
   static void ZRemRangeByRank(CmdArgList args, ConnectionContext* cntx);
   static void ZRemRangeByScore(CmdArgList args, ConnectionContext* cntx);
   static void ZRemRangeByLex(CmdArgList args, ConnectionContext* cntx);

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -1161,4 +1161,19 @@ TEST_F(ZSetFamilyTest, RangeLimit) {
   EXPECT_THAT(resp, ArrLen(0));
 }
 
+TEST_F(ZSetFamilyTest, RangeStore) {
+  EXPECT_EQ(3, CheckedInt({"ZADD", "src", "1", "a", "2", "b", "3", "c"}));
+  EXPECT_EQ(3, CheckedInt({"ZRANGESTORE", "dest", "src", "0", "-1"}));
+
+  RespExpr resp = Run({"ZRANGE", "dest", "0", "-1", "withscores"});
+  EXPECT_THAT(resp.GetVec(), ElementsAre("a", "1", "b", "2", "c", "3"));
+
+  // Override dest.
+
+  EXPECT_EQ(0, CheckedInt({"ZRANGESTORE", "dest", "not-found", "0", "-1"}));
+
+  resp = Run({"ZRANGE", "dest", "0", "-1"});
+  EXPECT_THAT(resp, ArrLen(0));
+}
+
 }  // namespace dfly


### PR DESCRIPTION
Adds support for `ZRANGESTORE`. Fixes https://github.com/dragonflydb/dragonfly/issues/3742.

Still checking the error handling is right (and trying to get my head around what errors can occur), though figured worth adding a draft PR to check the rough approach looks right. Unlike the other `Z...STORE` commands, `ZRANGESTORE` isn't varadic so I think just setting the command ID first/last key position is enough to get the transaction right?

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->