### PR TITLE
fix: make snapshotting process more responsive

### DIFF
--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -737,8 +737,9 @@ void DflyCmd::BreakStalledFlowsInShard() {
     int64_t timeout_ns = int64_t(absl::GetFlag(FLAGS_replication_timeout)) * 1'000'000LL;
     int64_t now = absl::GetCurrentTimeNanos();
     if (last_write_ns > 0 && last_write_ns + timeout_ns < now) {
-      VLOG(1) << "Breaking full sync for sync_id " << sync_id << " last_write_ts: " << last_write_ns
-              << ", now: " << now;
+      LOG(INFO) << "Breaking full sync for sync_id " << sync_id
+                << " last_write_ts: " << last_write_ns << ", now: " << now;
+
       deleted.push_back(sync_id);
       replica_lock.unlock();
       replica_ptr->Cancel();

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -737,8 +737,9 @@ void DflyCmd::BreakStalledFlowsInShard() {
     int64_t timeout_ns = int64_t(absl::GetFlag(FLAGS_replication_timeout)) * 1'000'000LL;
     int64_t now = absl::GetCurrentTimeNanos();
     if (last_write_ns > 0 && last_write_ns + timeout_ns < now) {
-      LOG(INFO) << "Breaking full sync for sync_id " << sync_id
-                << " last_write_ts: " << last_write_ns << ", now: " << now;
+      LOG(INFO) << "Master detected replication timeout, breaking full sync with replica, sync_id: "
+                << sync_id << " last_write_ms: " << last_write_ns / 1000'000
+                << ", now: " << now / 1000'000;
 
       deleted.push_back(sync_id);
       replica_lock.unlock();

--- a/src/server/journal/streamer.cc
+++ b/src/server/journal/streamer.cc
@@ -13,7 +13,7 @@
 
 using namespace facade;
 
-ABSL_FLAG(uint32_t, replication_timeout, 10000,
+ABSL_FLAG(uint32_t, replication_timeout, 30000,
           "Time in milliseconds to wait for the replication writes being stuck.");
 
 ABSL_FLAG(uint32_t, replication_stream_output_limit, 64_KB,

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -897,6 +897,7 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
                                     return res.has_value();
                                   });
   config_registry.RegisterMutable("replica_partial_sync");
+  config_registry.RegisterMutable("replication_timeout");
   config_registry.RegisterMutable("table_growth_margin");
   config_registry.RegisterMutable("tcp_keepalive");
 

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -1212,8 +1212,6 @@ error_code RdbSaver::Impl::ConsumeChannel(const Cancellation* cll) {
       auto delta_usec = (absl::GetCurrentTimeNanos() - start) / 1'000;
       stats.rdb_save_usec += delta_usec;
       stats.rdb_save_count++;
-      last_write_time_ns_ = -1;
-
     } while ((channel_.TryPop(record)));
   }  // while (channel_.Pop())
 
@@ -1251,7 +1249,7 @@ error_code RdbSaver::Impl::WriteRecord(io::Bytes src) {
       break;
     }
   } while (!src.empty());
-
+  last_write_time_ns_ = -1;
   return ec;
 }
 

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -1118,6 +1118,8 @@ class RdbSaver::Impl {
   }
 
  private:
+  error_code WriteRecord(io::Bytes src);
+
   unique_ptr<SliceSnapshot>& GetSnapshot(EngineShard* shard);
 
   io::Sink* sink_;
@@ -1201,26 +1203,56 @@ error_code RdbSaver::Impl::ConsumeChannel(const Cancellation* cll) {
         continue;
 
       DVLOG(2) << "Pulled " << record.id;
-      last_write_time_ns_ = absl::GetCurrentTimeNanos();
-      io_error = sink_->Write(io::Buffer(record.value));
+      auto start = absl::GetCurrentTimeNanos();
+      io_error = WriteRecord(io::Buffer(record.value));
+      if (io_error) {
+        break;  // from the inner TryPop loop.
+      }
 
-      stats.rdb_save_usec += (absl::GetCurrentTimeNanos() - last_write_time_ns_) / 1'000;
+      auto delta_usec = (absl::GetCurrentTimeNanos() - start) / 1'000;
+      stats.rdb_save_usec += delta_usec;
       stats.rdb_save_count++;
       last_write_time_ns_ = -1;
-      if (io_error) {
-        VLOG(1) << "Error writing to sink " << io_error.message();
-        break;
-      }
+
     } while ((channel_.TryPop(record)));
   }  // while (channel_.Pop())
 
   for (auto& ptr : shard_snapshots_) {
     ptr->Join();
   }
-  DVLOG(1) << "Finish ConsumeChannel";
+  VLOG(1) << "ConsumeChannel finished " << io_error;
+
   DCHECK(!channel_.TryPop(record));
 
   return io_error;
+}
+
+error_code RdbSaver::Impl::WriteRecord(io::Bytes src) {
+  // For huge values, we break them up into chunks of upto several MBs to send in a single call,
+  // so we could be more responsive.
+  error_code ec;
+  size_t start_size = src.size();
+  last_write_time_ns_ = absl::GetCurrentTimeNanos();
+  do {
+    io::Bytes part = src.subspan(0, 8_MB);
+    src.remove_prefix(part.size());
+
+    ec = sink_->Write(part);
+
+    int64_t now = absl::GetCurrentTimeNanos();
+    unsigned delta_ms = (now - last_write_time_ns_) / 1000'000;
+    last_write_time_ns_ = now;
+
+    // Log extreme timings into the log for visibility.
+    LOG_IF(INFO, delta_ms > 1000) << "Channel write took " << delta_ms << " ms while writing "
+                                  << part.size() << "/" << start_size;
+    if (ec) {
+      LOG(INFO) << "Error writing to rdb sink " << ec.message();
+      break;
+    }
+  } while (!src.empty());
+
+  return ec;
 }
 
 void RdbSaver::Impl::StartSnapshotting(bool stream_journal, const Cancellation* cll,

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2149,7 +2149,11 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
     absl::StrAppend(&info, a1, ":", a2, "\r\n");
   };
 
+  uint64_t start = absl::GetCurrentTimeNanos();
   Metrics m = GetMetrics(cntx->ns);
+  uint64_t delta_ms = (absl::GetCurrentTimeNanos() - start) / 1000'000;
+  LOG_IF(INFO, delta_ms > 100) << "GetMetrics took " << delta_ms << " ms";
+
   DbStats total;
   for (const auto& db_stats : m.db_stats)
     total += db_stats;


### PR DESCRIPTION
Before this change - we wrote in a single call whatever record chunks we pulled from the channel.
This can be problematic for 1GB chunks for example, which might take 10sec to write.

Lately we added a replication breaker on the master side that breaks the fully sync after
a predefined threshold has passed. By default it was 10sec. To improve the robustness of this
breaker, we now write chunks of upto 1MB and update last_write_time_ns_ more frequently.

Also, we added more logs to make replication delays on both sides more visible.
We also added logs of breaking the replication on the master sides.

Unfortunately, this did not help making BreakStalledFlowsInShard more robust because now the
problem moved to replica side which may take 20s+ seconds to parse huge values.
Therefore, I increased the threshold for breaking the replication to 30s.

Finally, instrument GetMetrics call as it takes sometimes more than 1 sec.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->