### PR TITLE
fix: tune test_replicaof_reject_on_load parameters

### DIFF
--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2014,7 +2014,7 @@ async def test_replicaof_reject_on_load(df_factory, df_seeder_factory):
     df_factory.start_all([master, replica])
 
     c_replica = replica.client()
-    await c_replica.execute_command(f"DEBUG POPULATE 10000000")
+    await c_replica.execute_command(f"DEBUG POPULATE 8000000")
 
     replica.stop()
     replica.start()
@@ -2031,8 +2031,9 @@ async def test_replicaof_reject_on_load(df_factory, df_seeder_factory):
         assert False
     except aioredis.BusyLoadingError as e:
         assert "Dragonfly is loading the dataset in memory" in str(e)
+
     # Check one we finish loading snapshot replicaof success
-    await wait_available_async(c_replica)
+    await wait_available_async(c_replica, timeout=180)
     await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
 
     await c_replica.close()


### PR DESCRIPTION
Reduce the snapshot size by 20% and increase the timeout to avoid failures due to slow loads.
Fixes https://github.com/dragonflydb/dragonfly/actions/runs/10982136864/job/30490032552

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->