### PR TITLE
chore: some renames + fix a typo in RETURN_ON_BAD_STATUS

### DIFF
--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -217,7 +217,7 @@ EngineShard::Stats& EngineShard::Stats::operator+=(const EngineShard::Stats& o) 
   defrag_task_invocation_total += o.defrag_task_invocation_total;
   poll_execution_total += o.poll_execution_total;
   tx_ooo_total += o.tx_ooo_total;
-  tx_immediate_total += o.tx_immediate_total;
+  tx_optimistic_total += o.tx_optimistic_total;
 
   return *this;
 }

--- a/src/server/engine_shard.h
+++ b/src/server/engine_shard.h
@@ -34,7 +34,8 @@ class EngineShard {
     uint64_t defrag_task_invocation_total = 0;
     uint64_t poll_execution_total = 0;
 
-    uint64_t tx_immediate_total = 0;
+    // number of optimistic executions - that were run as part of the scheduling.
+    uint64_t tx_optimistic_total = 0;
     uint64_t tx_ooo_total = 0;
 
     Stats& operator+=(const Stats&);

--- a/src/server/error.h
+++ b/src/server/error.h
@@ -39,7 +39,7 @@ using facade::kWrongTypeErr;
   do {                           \
     OpStatus __s = (x).status(); \
     if (__s != OpStatus::OK) {   \
-      return (x).status();       \
+      return __s;                \
     }                            \
   } while (0)
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2426,7 +2426,7 @@ void ServerFamily::Info(CmdArgList args, ConnectionContext* cntx) {
 
   if (should_enter("TRANSACTION", true)) {
     append("tx_shard_polls", m.shard_stats.poll_execution_total);
-    append("tx_shard_immediate_total", m.shard_stats.tx_immediate_total);
+    append("tx_shard_optimistic_total", m.shard_stats.tx_optimistic_total);
     append("tx_shard_ooo_total", m.shard_stats.tx_ooo_total);
     append("tx_global_total", m.coordinator_stats.tx_global_cnt);
     append("tx_normal_total", m.coordinator_stats.tx_normal_cnt);

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -128,12 +128,12 @@ TEST_F(StreamFamilyTest, XRead) {
   Run({"xadd", "foo", "1-*", "k2", "v2"});
   Run({"xadd", "foo", "1-*", "k3", "v3"});
   Run({"xadd", "bar", "1-*", "k4", "v4"});
-  EXPECT_EQ(GetMetrics().shard_stats.tx_immediate_total, 4u);
+  EXPECT_EQ(GetMetrics().shard_stats.tx_optimistic_total, 4u);
 
   // Receive all records from a single stream, in a single hop
   auto resp = Run({"xread", "streams", "foo", "0"});
   EXPECT_THAT(resp.GetVec(), ElementsAre("foo", ArrLen(3)));
-  EXPECT_EQ(GetMetrics().shard_stats.tx_immediate_total, 5u);
+  EXPECT_EQ(GetMetrics().shard_stats.tx_optimistic_total, 5u);
 
   // Receive all records from both streams.
   resp = Run({"xread", "streams", "foo", "bar", "0", "0"});


### PR DESCRIPTION
Renames in transaction.h - no functional changes.
Fix a typo in error.h following  #3758

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->