### PR TITLE
chore: give up on InlinedVector due to spurious warnings with optional

### DIFF
--- a/src/server/detail/wrapped_json_path.h
+++ b/src/server/detail/wrapped_json_path.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <absl/container/inlined_vector.h>
-
 #include <string_view>
 #include <utility>
 #include <variant>
@@ -98,7 +96,7 @@ template <typename T> class JsonCallbackResult {
   JsonCallbackResult() {
   }
 
-  explicit JsonCallbackResult(CallbackResultOptions options) : options_(options) {
+  explicit JsonCallbackResult(CallbackResultOptions options) : options_(std::move(options)) {
   }
 
   void AddValue(T value) {
@@ -119,8 +117,8 @@ template <typename T> class JsonCallbackResult {
     return result_.front();
   }
 
-  const absl::InlinedVector<T, 2>& AsV2() const {
-    return std::move(result_);
+  const auto& AsV2() const {
+    return result_;
   }
 
   bool Empty() const {
@@ -144,7 +142,7 @@ template <typename T> class JsonCallbackResult {
   }
 
  private:
-  absl::InlinedVector<T, 2> result_;
+  std::vector<T> result_;
   CallbackResultOptions options_{kDefaultJsonPathType};
 };
 

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -593,13 +593,9 @@ OpResult<JsonCallbackResult<T>> JsonEvaluateOperation(const OpArgs& op_args, std
                                                       EvaluateOperationOptions options = {}) {
   OpResult<JsonType*> result = GetJson(op_args, key);
   if (options.return_nil_if_key_not_found && result == OpStatus::KEY_NOTFOUND) {
-// GCC 13.1 throws spurious warnings around this code.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
     return JsonCallbackResult<T>{
         {JsonPathType::kLegacy, options.cb_result_options.saving_order,
          CallbackResultOptions::OnEmpty::kSendNil}};  // set legacy mode to return nil
-#pragma GCC diagnostic pop
   }
 
   RETURN_ON_BAD_STATUS(result);


### PR DESCRIPTION
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->