### PR TITLE
fix: substr/getrange result for invalid range

### DIFF
--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -147,13 +147,14 @@ OpResult<StringValue> OpGetRange(const OpArgs& op_args, string_view key, int32_t
     if (end < 0)
       end = strlen + end;
 
+    end = min(end, strlen - 1);
+
+    if (strlen == 0 || start > end)
+      return "";
+
     start = max(start, 0);
     end = max(end, 0);
 
-    if (strlen == 0 || start > end || start >= strlen)
-      return "";
-
-    end = min(end, strlen - 1);
     return slice.substr(start, end - start + 1);
   };
 
@@ -1290,13 +1291,11 @@ void StringFamily::StrLen(CmdArgList args, ConnectionContext* cntx) {
 }
 
 void StringFamily::GetRange(CmdArgList args, ConnectionContext* cntx) {
-  string_view key = ArgS(args, 0);
-  string_view from = ArgS(args, 1);
-  string_view to = ArgS(args, 2);
-  int32_t start, end;
+  CmdArgParser parser(args);
+  auto [key, start, end] = parser.Next<string_view, int32_t, int32_t>();
 
-  if (!absl::SimpleAtoi(from, &start) || !absl::SimpleAtoi(to, &end)) {
-    return cntx->SendError(kInvalidIntErr);
+  if (auto err = parser.Error(); err) {
+    return cntx->SendError(err->MakeReply());
   }
 
   auto cb = [&](Transaction* t, EngineShard* shard) {

--- a/src/server/string_family_test.cc
+++ b/src/server/string_family_test.cc
@@ -496,6 +496,9 @@ TEST_F(StringFamilyTest, Range) {
   Run({"SET", "num", "1234"});
   EXPECT_EQ(Run({"getrange", "num", "3", "5000"}), "4");
   EXPECT_EQ(Run({"getrange", "num", "-5000", "10000"}), "1234");
+
+  Run({"SET", "key4", "1"});
+  EXPECT_EQ(Run({"getrange", "key4", "-1", "-2"}), "");
 }
 
 TEST_F(StringFamilyTest, IncrByFloat) {


### PR DESCRIPTION
fixes: #3752
The problem is that the invalid range was transformed into [0, 0] range, so the first symbol was returned.
fix: transformation is done after range is validated