### PR TITLE
fix: setrange with empty value doesn't modify the DB

### DIFF
--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -109,7 +109,7 @@ OpResult<TResult<size_t>> OpSetRange(const OpArgs& op_args, string_view key, siz
   VLOG(2) << "SetRange(" << key << ", " << start << ", " << range << ")";
   auto& db_slice = op_args.GetDbSlice();
 
-  if (start + range.size() == 0) {
+  if (range.empty()) {
     return OpStrLen(op_args, key);
   }
 
@@ -1306,13 +1306,11 @@ void StringFamily::GetRange(CmdArgList args, ConnectionContext* cntx) {
 }
 
 void StringFamily::SetRange(CmdArgList args, ConnectionContext* cntx) {
-  string_view key = ArgS(args, 0);
-  string_view offset = ArgS(args, 1);
-  string_view value = ArgS(args, 2);
-  int32_t start;
+  CmdArgParser parser(args);
+  auto [key, start, value] = parser.Next<string_view, int32_t, string_view>();
 
-  if (!absl::SimpleAtoi(offset, &start)) {
-    return cntx->SendError(kInvalidIntErr);
+  if (auto err = parser.Error(); err) {
+    return cntx->SendError(err->MakeReply());
   }
 
   if (start < 0) {

--- a/src/server/string_family_test.cc
+++ b/src/server/string_family_test.cc
@@ -499,6 +499,12 @@ TEST_F(StringFamilyTest, Range) {
 
   Run({"SET", "key4", "1"});
   EXPECT_EQ(Run({"getrange", "key4", "-1", "-2"}), "");
+
+  EXPECT_EQ(CheckedInt({"SETRANGE", "key5", "1", ""}), 0);
+  EXPECT_EQ(Run({"GET", "key5"}).type, facade::RespExpr::NIL);
+
+  EXPECT_EQ(CheckedInt({"SETRANGE", "num", "6", ""}), 4);
+  EXPECT_EQ(Run({"GET", "num"}), "1234");
 }
 
 TEST_F(StringFamilyTest, IncrByFloat) {

--- a/tests/fakeredis/test/test_hypothesis.py
+++ b/tests/fakeredis/test/test_hypothesis.py
@@ -420,7 +420,7 @@ class TestConnection(BaseTest):
     connection_commands = (
         commands(st.just("echo"), values)
         | commands(st.just("ping"), st.lists(values, max_size=2))
-        | commands(st.just("swapdb"), dbnums, dbnums)
+        # | commands(st.just("swapdb"), dbnums, dbnums)
     )
     command_strategy = connection_commands | common_commands
 


### PR DESCRIPTION
fixes: #3769
the problem: set range modify stored value if the new value was empty
fix: if the new value is empty, the result is the size of the stored value without modification

also comment out the swapdb test, because we don't support this command