### PR TITLE
FIELDEXPIRE / HEXPIRE

### DIFF
--- a/src/core/dense_set.h
+++ b/src/core/dense_set.h
@@ -187,12 +187,9 @@ class DenseSet {
       return curr_entry_->HasTtl() ? owner_->ObjExpireTime(curr_entry_->GetObject()) : UINT32_MAX;
     }
 
-    //TODO
-    uint32_t SetExpiryTime(uint32_t at) const {
-      //TODO feels like there are two paths here:
-      // 1. The item has TTL from before, and we can easily set the TTL.
-      // 2. It doesnt have TTL, and we need to do something extra?
-      return curr_entry_->HasTtl() ? owner_->ObjExpireTime(curr_entry_->GetObject()) : UINT32_MAX;
+    uint32_t SetExpiryTime(uint32_t ttl_sec) {
+      //TODO is uint32 the right return type?
+      return owner_->ObjSetExpireTime(curr_entry_->GetObject(), ttl_sec);
     }
 
     bool HasExpiry() const {
@@ -271,6 +268,7 @@ class DenseSet {
   virtual bool ObjEqual(const void* left, const void* right, uint32_t right_cookie) const = 0;
   virtual size_t ObjectAllocSize(const void* obj) const = 0;
   virtual uint32_t ObjExpireTime(const void* obj) const = 0;
+  virtual uint32_t ObjSetExpireTime(const void* obj, uint32_t ttl_sec) = 0;
   virtual void ObjDelete(void* obj, bool has_ttl) const = 0;
 
   void CollectExpired();

--- a/src/core/dense_set.h
+++ b/src/core/dense_set.h
@@ -187,6 +187,14 @@ class DenseSet {
       return curr_entry_->HasTtl() ? owner_->ObjExpireTime(curr_entry_->GetObject()) : UINT32_MAX;
     }
 
+    //TODO
+    uint32_t SetExpiryTime(uint32_t at) const {
+      //TODO feels like there are two paths here:
+      // 1. The item has TTL from before, and we can easily set the TTL.
+      // 2. It doesnt have TTL, and we need to do something extra?
+      return curr_entry_->HasTtl() ? owner_->ObjExpireTime(curr_entry_->GetObject()) : UINT32_MAX;
+    }
+
     bool HasExpiry() const {
       return curr_entry_->HasTtl();
     }
@@ -314,6 +322,7 @@ class DenseSet {
   // Returns the previous object if it has been replaced.
   // nullptr, if obj was added.
   void* AddOrReplaceObj(void* obj, bool has_ttl);
+  void* ReplaceObj(void* obj, bool has_ttl);
 
   // Assumes that the object does not exist in the set.
   void AddUnique(void* obj, bool has_ttl, uint64_t hashcode);
@@ -355,6 +364,10 @@ class DenseSet {
   // Returns DensePtr if the object with such key already exists,
   // Returns null if obj was added.
   DensePtr* AddOrFindDense(void* obj, bool has_ttl);
+
+  // Returns DensePtr if the object with such key exists,
+  // Returns null if key does not exist.
+  DensePtr* FindDense(void* obj);
 
   // ============ Pseudo Linked List in DenseSet end ==================
 

--- a/src/core/score_map.cc
+++ b/src/core/score_map.cc
@@ -128,6 +128,11 @@ uint32_t ScoreMap::ObjExpireTime(const void* obj) const {
   return UINT32_MAX;
 }
 
+uint32_t ScoreMap::ObjSetExpireTime(const void* obj, uint32_t ttl_sec) {
+  // Should not reach.
+  return UINT32_MAX;
+}
+
 void ScoreMap::ObjDelete(void* obj, bool has_ttl) const {
   sds s1 = (sds)obj;
   sdsfree(s1);

--- a/src/core/score_map.h
+++ b/src/core/score_map.h
@@ -122,6 +122,7 @@ class ScoreMap : public DenseSet {
   bool ObjEqual(const void* left, const void* right, uint32_t right_cookie) const final;
   size_t ObjectAllocSize(const void* obj) const final;
   uint32_t ObjExpireTime(const void* obj) const final;
+  uint32_t ObjSetExpireTime(const void* obj, uint32_t ttl_sec) override;
   void ObjDelete(void* obj, bool has_ttl) const final;
 };
 

--- a/src/core/string_map.cc
+++ b/src/core/string_map.cc
@@ -261,6 +261,30 @@ size_t StringMap::ObjectAllocSize(const void* obj) const {
   return res;
 }
 
+bool StringMap::UpdateTTL(const void* obj, uint32_t ttl_sec) {
+  sds str = (sds)obj;
+  char* valptr = str + sdslen(str) + 1;
+
+  uint32_t at = time_now() + ttl_sec;
+  uint64_t val = absl::little_endian::Load64(valptr);
+
+  DCHECK(val & kValTtlBit);
+  if (val & kValTtlBit) {
+    // if we already have a ttl, update it.
+    absl::little_endian::Store32(valptr + 8, at);
+  } else {
+    // At this point we actually need to reallocate the value if it doesnt have a TTL
+    auto pair = detail::SdsPair(str, GetValue(str));
+    auto [newkey, sdsval_tag] = CreateEntry(pair->first, pair->second, time_now(), ttl_sec);
+
+    sds prev_entry = (sds)ReplaceObj(newkey, sdsval_tag & kValTtlBit);
+    if (prev_entry) {
+      ObjDelete(prev_entry, false);
+    }
+  }
+  return false; //TODO
+}
+
 uint32_t StringMap::ObjExpireTime(const void* obj) const {
   sds str = (sds)obj;
   const char* valptr = str + sdslen(str) + 1;

--- a/src/core/string_map.h
+++ b/src/core/string_map.h
@@ -105,6 +105,7 @@ class StringMap : public DenseSet {
   // Returns true if field was added
   // otherwise updates its value and returns false.
   bool AddOrUpdate(std::string_view field, std::string_view value, uint32_t ttl_sec = UINT32_MAX);
+  bool UpdateTTL(const void* obj, uint32_t ttl_sec);
 
   // Returns true if field was added
   // false, if already exists. In that case no update is done.
@@ -114,7 +115,7 @@ class StringMap : public DenseSet {
 
   bool Contains(std::string_view s1) const;
 
-  /// @brief  Returns value of the key or nullptr if key not found.
+  /// @brief  Returns value of the key or an empty iterator if key not found.
   /// @param key
   /// @return sds
   iterator Find(std::string_view member) {

--- a/src/core/string_map.h
+++ b/src/core/string_map.h
@@ -99,13 +99,13 @@ class StringMap : public DenseSet {
     }
 
     using IteratorBase::ExpiryTime;
+    using IteratorBase::SetExpiryTime;
     using IteratorBase::HasExpiry;
   };
 
   // Returns true if field was added
   // otherwise updates its value and returns false.
   bool AddOrUpdate(std::string_view field, std::string_view value, uint32_t ttl_sec = UINT32_MAX);
-  bool UpdateTTL(const void* obj, uint32_t ttl_sec);
 
   // Returns true if field was added
   // false, if already exists. In that case no update is done.
@@ -158,6 +158,7 @@ class StringMap : public DenseSet {
   bool ObjEqual(const void* left, const void* right, uint32_t right_cookie) const final;
   size_t ObjectAllocSize(const void* obj) const final;
   uint32_t ObjExpireTime(const void* obj) const final;
+  uint32_t ObjSetExpireTime(const void* obj, uint32_t ttl_sec) override;
   void ObjDelete(void* obj, bool has_ttl) const final;
 };
 

--- a/src/core/string_set.h
+++ b/src/core/string_set.h
@@ -87,6 +87,7 @@ class StringSet : public DenseSet {
     }
 
     using IteratorBase::ExpiryTime;
+    using IteratorBase::SetExpiryTime;
     using IteratorBase::HasExpiry;
   };
 
@@ -111,6 +112,7 @@ class StringSet : public DenseSet {
 
   size_t ObjectAllocSize(const void* s1) const override;
   uint32_t ObjExpireTime(const void* obj) const override;
+  uint32_t ObjSetExpireTime(const void* obj, uint32_t ttl_sec) override;
   void ObjDelete(void* obj, bool has_ttl) const override;
 };
 

--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -150,6 +150,10 @@ struct CmdArgParser {
     return cur_i_ + i <= args_.size() && !error_;
   }
 
+  bool HasExactly(size_t i) const {
+    return cur_i_ + i == args_.size() && !error_;
+  }
+
  private:
   template <class T, class... Cases>
   std::optional<std::decay_t<T>> MapImpl(std::string_view arg, std::string_view tag, T&& value,

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -318,7 +318,7 @@ class DbSlice {
   OpResult<ItAndUpdater> AddNew(const Context& cntx, std::string_view key, PrimeValue obj,
                                 uint64_t expire_at_ms) ABSL_LOCKS_EXCLUDED(local_mu_);
 
-  // Update entry expiration. Return epxiration timepoint in abs milliseconds, or -1 if the entry
+  // Update entry expiration. Return expiration timepoint in abs milliseconds, or -1 if the entry
   // already expired and was deleted;
   facade::OpResult<int64_t> UpdateExpire(const Context& cntx, Iterator prime_it, ExpIterator exp_it,
                                          const ExpireParams& params) ABSL_LOCKS_EXCLUDED(local_mu_);

--- a/src/server/hset_family.h
+++ b/src/server/hset_family.h
@@ -29,6 +29,9 @@ class HSetFamily {
   static int32_t FieldExpireTime(const DbContext& db_context, const PrimeValue& pv,
                                  std::string_view field);
 
+  static int32_t FieldSetExpireTime(const DbContext& db_context, PrimeValue& pv,
+                                 std::string_view field, uint32_t ttl_sec);
+
  private:
   // TODO: to move it to anonymous namespace in cc file.
 

--- a/src/server/hset_family.h
+++ b/src/server/hset_family.h
@@ -32,6 +32,7 @@ class HSetFamily {
  private:
   // TODO: to move it to anonymous namespace in cc file.
 
+  static void HExpire(CmdArgList args, ConnectionContext* cntx);
   static void HDel(CmdArgList args, ConnectionContext* cntx);
   static void HLen(CmdArgList args, ConnectionContext* cntx);
   static void HExists(CmdArgList args, ConnectionContext* cntx);

--- a/src/server/set_family.h
+++ b/src/server/set_family.h
@@ -33,6 +33,10 @@ class SetFamily {
   static int32_t FieldExpireTime(const DbContext& db_context, const PrimeValue& pv,
                                  std::string_view field);
 
+
+  static int32_t FieldSetExpireTime(const DbContext& db_context, PrimeValue& pv,
+                                   std::string_view field, uint32_t ttl_sec);
+
  private:
 };
 


### PR DESCRIPTION
Hi :)  Tagging @romange since I've only been speaking to you so far. 

There are a few things missing in this PR, namely:
1. The generic command `FieldExpire` is not yet implemented.
2. There's still some mess to clean up.

I'd like some feedback on a few questions, and in general on the code:
1. Is `HEXPIRE` supposed to call into the more general `FieldExpire` after modifying the `CmdArgParser`, or just use the same underlying common function for manipulating field ttl?
2. Is there a way of returning an int-array in the Redis syntax to the client yet, or would I need to make that?
3. Should I remove `ReplaceObj` and instead use `AddOrFind` since we always `Find` the fields before modifying their ttl?

I think I also need to re-arrange the code such that I ensure the correct encoding (which supports TTL) is only enforced once for each call, and then each field is operated on afterwards. But I can't see a whole lot of code sharing between sets and hsets here, other than that they're both operating on dense_sets. I'm a c++ noob though, so feel free to correct me on this. 

This PR is related to: https://github.com/dragonflydb/dragonfly/issues/3027

Thanks in advance.