### PR TITLE
chore: Forbid replicating a replica

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2839,6 +2839,10 @@ void ServerFamily::ReplTakeOver(CmdArgList args, ConnectionContext* cntx) {
 }
 
 void ServerFamily::ReplConf(CmdArgList args, ConnectionContext* cntx) {
+  if (!ServerState::tlocal()->is_master) {
+    return cntx->SendError("Replicating a replica is unsupported");
+  }
+
   if (args.size() % 2 == 1)
     goto err;
   for (unsigned i = 0; i < args.size(); i += 2) {


### PR DESCRIPTION
We do not support connecting a replica to a replica, but before this PR we allowed doing so. This PR disables that behavior.

Fixes #3679

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->