### PR TITLE
fix: GETRANGE params validation

### DIFF
--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -141,19 +141,27 @@ OpResult<StringValue> OpGetRange(const OpArgs& op_args, string_view key, int32_t
                                  int32_t end) {
   auto read = [start, end](std::string_view slice) mutable -> string_view {
     int32_t strlen = slice.size();
-
-    if (start < 0)
-      start = strlen + start;
-    if (end < 0)
-      end = strlen + end;
-
-    end = min(end, strlen - 1);
-
-    if (strlen == 0 || start > end)
+    if (strlen == 0)
       return "";
 
-    start = max(start, 0);
-    end = max(end, 0);
+    if (start < 0) {
+      if (end < start) {
+        return "";
+      }
+      start = strlen + start;
+      start = max(start, 0);
+    }
+
+    if (end < 0) {
+      end = strlen + end;
+      end = max(end, 0);
+    } else {
+      end = min(end, strlen - 1);
+    }
+
+    if (start > end) {
+      return "";
+    }
 
     return slice.substr(start, end - start + 1);
   };

--- a/src/server/string_family_test.cc
+++ b/src/server/string_family_test.cc
@@ -499,12 +499,16 @@ TEST_F(StringFamilyTest, Range) {
 
   Run({"SET", "key4", "1"});
   EXPECT_EQ(Run({"getrange", "key4", "-1", "-2"}), "");
+  EXPECT_EQ(Run({"getrange", "key4", "0", "-2"}), "1");
 
   EXPECT_EQ(CheckedInt({"SETRANGE", "key5", "1", ""}), 0);
   EXPECT_EQ(Run({"GET", "key5"}).type, facade::RespExpr::NIL);
 
   EXPECT_EQ(CheckedInt({"SETRANGE", "num", "6", ""}), 4);
   EXPECT_EQ(Run({"GET", "num"}), "1234");
+
+  // we support only 256MB string so this test is failed now
+  // EXPECT_THAT(CheckedInt({"SETRANGE", "", "268435456", "0"}), 268435457);
 }
 
 TEST_F(StringFamilyTest, IncrByFloat) {


### PR DESCRIPTION
fix: GETRANGE params validation according to fakeredis tests
set key 0
getrange key 0 -2 returns empty string
expected result  [0, -2]  is correct range and should be transformed into [0, 0] so the result should be 0
