### PR TITLE
chore(acl_family): add allcomands and nocommands

### DIFF
--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -651,7 +651,7 @@ constexpr uint32_t kGenPass = acl::SLOW;
 
 // We can't implement the ACL commands and its respective subcommands LIST, CAT, etc
 // the usual way, (that is, one command called ACL which then dispatches to the subcommand
-// based on the secocond argument) because each of the subcommands has different ACL
+// based on the second argument) because each of the subcommands has different ACL
 // categories. Therefore, to keep it compatible with the CommandId, I need to treat them
 // as separate commands in the registry. This is the least intrusive change because it's very
 // easy to handle that case explicitly in `DispatchCommand`.
@@ -990,6 +990,14 @@ using OptCat = std::optional<uint32_t>;
 // bool == true if +
 // bool == false if -
 std::pair<OptCat, bool> AclFamily::MaybeParseAclCategory(std::string_view command) const {
+  if (absl::EqualsIgnoreCase(command, "ALLCOMMANDS")) {
+    return {cat_table_.at("ALL"), true};
+  }
+
+  if (absl::EqualsIgnoreCase(command, "NOCOMMANDS")) {
+    return {cat_table_.at("ALL"), false};
+  }
+
   if (absl::StartsWith(command, "+@")) {
     auto res = cat_table_.find(command.substr(2));
     if (res == cat_table_.end()) {

--- a/src/server/acl/acl_family_test.cc
+++ b/src/server/acl/acl_family_test.cc
@@ -116,6 +116,24 @@ TEST_F(AclFamilyTest, AclSetUser) {
   // +@NONE should not exist anymore. It's not in the spec.
   resp = Run({"ACL", "SETUSER", "rand", "+@NONE"});
   EXPECT_THAT(resp, ErrArg("ERR Unrecognized parameter +@NONE"));
+
+  resp = Run({"ACL", "SETUSER", "rand", "ALLCOMMANDS"});
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run({"ACL", "LIST"});
+  vec = resp.GetVec();
+  EXPECT_THAT(vec, UnorderedElementsAre("user default on nopass ~* &* +@all",
+                                        "user vlad on resetchannels -@all +acl",
+                                        "user rand off resetchannels +@all"));
+
+  resp = Run({"ACL", "SETUSER", "rand", "NOCOMMANDS"});
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run({"ACL", "LIST"});
+  vec = resp.GetVec();
+  EXPECT_THAT(vec, UnorderedElementsAre("user default on nopass ~* &* +@all",
+                                        "user vlad on resetchannels -@all +acl",
+                                        "user rand off resetchannels -@all"));
 }
 
 TEST_F(AclFamilyTest, AclDelUser) {


### PR DESCRIPTION

Fixes #3458 
TESTED =  <img width="482" alt="1" src="https://github.com/user-attachments/assets/4529f3dd-5616-4d4a-a73e-f00643e8fdf7">
I did not add tests as there was no test earlier for the same but it can be added.