### PR TITLE
chore: allow config set notify_keyspace_events

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1451,6 +1451,15 @@ void DbSlice::ResetEvents() {
   events_ = {};
 }
 
+void DbSlice::SetNotifyKeyspaceEvents(std::string_view notify_keyspace_events) {
+  if (notify_keyspace_events.empty()) {
+    for (auto& db : db_arr_) {
+      db->expired_keys_events_.clear();
+    }
+  }
+  expired_keys_events_recording_ = !notify_keyspace_events.empty();
+}
+
 void DbSlice::SendInvalidationTrackingMessage(std::string_view key) {
   if (client_tracking_map_.empty())
     return;

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1452,11 +1452,6 @@ void DbSlice::ResetEvents() {
 }
 
 void DbSlice::SetNotifyKeyspaceEvents(std::string_view notify_keyspace_events) {
-  if (notify_keyspace_events.empty()) {
-    for (auto& db : db_arr_) {
-      db->expired_keys_events_.clear();
-    }
-  }
   expired_keys_events_recording_ = !notify_keyspace_events.empty();
 }
 

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -511,6 +511,10 @@ class DbSlice {
     return pt->Traverse(cursor, std::forward<Cb>(cb));
   }
 
+  // Does not check for non supported events. Callers must parse the string and reject it
+  // if it's not empty and not EX.
+  void SetNotifyKeyspaceEvents(std::string_view notify_keyspace_events);
+
  private:
   void PreUpdate(DbIndex db_ind, Iterator it, std::string_view key);
   void PostUpdate(DbIndex db_ind, Iterator it, std::string_view key, size_t orig_size);


### PR DESCRIPTION
We do not allow  `notify_keyspace_events` to be set at runtime via `config set` command. This PR addresses this.

* allow notify_keyspace_events in config set command
* add tests

Resolves #3708