### PR TITLE
fix: bitcount invalid range

### DIFF
--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -33,7 +33,14 @@ template <auto min, auto max> constexpr bool is_fint<FInt<min, max>> = true;
 
 // Utility class for easily parsing command options from argument lists.
 struct CmdArgParser {
-  enum ErrorType { OUT_OF_BOUNDS, SHORT_OPT_TAIL, INVALID_INT, INVALID_CASES, INVALID_NEXT };
+  enum ErrorType {
+    OUT_OF_BOUNDS,
+    SHORT_OPT_TAIL,
+    INVALID_INT,
+    INVALID_CASES,
+    INVALID_NEXT,
+    UNPROCESSED
+  };
 
   struct ErrorInfo {
     ErrorType type;
@@ -134,6 +141,14 @@ struct CmdArgParser {
       cur_i_ += n;
     }
     return *this;
+  }
+
+  bool Finalize() {
+    if (HasNext()) {
+      Report(UNPROCESSED, cur_i_);
+      return false;
+    }
+    return !HasError();
   }
 
   // In-place convert the next argument to uppercase

--- a/src/server/bitops_family_test.cc
+++ b/src/server/bitops_family_test.cc
@@ -282,6 +282,7 @@ TEST_F(BitOpsFamilyTest, BitCountByteSubRange) {
   EXPECT_EQ(10, CheckedInt({"bitcount", "foo", "-3", "-1"}));
   EXPECT_EQ(13, CheckedInt({"bitcount", "foo", "-5", "-2"}));
   EXPECT_EQ(0, CheckedInt({"bitcount", "foo", "-1", "-2"}));  // illegal range
+  EXPECT_EQ(0, CheckedInt({"bitcount", "foo", "1", "0"}));    // illegal range
 }
 
 TEST_F(BitOpsFamilyTest, BitCountByteBitSubRange) {


### PR DESCRIPTION
the problem: (bitcount foo 1 0) counts bit for invalid range because we exchange start and end and get range [0, 1]
fix: return 0 if the range is invalid