### PR TITLE
[do not review -- template to reproduce] chore: reproduce template for shutdown deadlock

### DIFF
--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2706,3 +2706,15 @@ async def test_big_containers(df_factory):
     replica_data = await StaticSeeder.capture(c_replica)
     master_data = await StaticSeeder.capture(c_master)
     assert master_data == replica_data
+
+
+@pytest.mark.asyncio
+async def test_reproduce_shutdown(df_factory):
+    master = df_factory.create(proactor_threads=1)
+    replica = df_factory.create(proactor_threads=1)
+    df_factory.start_all([master, replica])
+
+    c_master = master.client()
+    c_replica = replica.client()
+
+    await disconnect_clients(c_master, c_replica)

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,8 @@
+for run in {1..1000}; do
+  python3 -m pytest dragonfly/replication_test.py --log-cli-level=INFO -k "test_reproduce_shutdown"
+  ret=$?
+  if [ $ret -ne 0 ]; then
+    echo "Error"
+    exit 1
+  fi
+done


### PR DESCRIPTION
This only happens on `arm` and `release -- build-opt` build

1. Create a similar instance to the one we use for our `gh runner`
2. Compile for `-release`
3. `cd tests` && `./run.sh &> errors.txt` and wait until exits. Logs exist in `tmp/failed`