### PR TITLE
fix: empty strings in the sort command

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1037,8 +1037,12 @@ struct SortEntry
 
   bool Parse(std::string&& item) {
     if constexpr (!ALPHA) {
-      if (!absl::SimpleAtod(item, &this->score))
-        return false;
+      if (!absl::SimpleAtod(item, &this->score)) {
+        if (!item.empty()) {
+          return false;
+        }
+        this->score = 0;
+      }
     }
     key = std::move(item);
     return true;
@@ -1052,12 +1056,20 @@ struct SortEntry
     return true;
   }
 
-  std::conditional_t<ALPHA, const std::string&, double> Cmp() const {
-    if constexpr (ALPHA) {
-      return key;
-    } else {
-      return this->score;
+  static bool less(const SortEntry& l, const SortEntry& r) {
+    if constexpr (!ALPHA) {
+      if (l.score < r.score) {
+        return true;
+      } else if (r.score < l.score) {
+        return false;
+      }
+      // to prevent unstrict order we compare values lexicographically
     }
+    return l.key < r.key;
+  }
+
+  static bool greater(const SortEntry& l, const SortEntry& r) {
+    return less(r, l);
   }
 };
 
@@ -1176,19 +1188,13 @@ void GenericFamily::Sort(CmdArgList args, ConnectionContext* cntx) {
 
   auto result_type = fetch_result.type();
   auto sort_call = [cntx, bounds, reversed, result_type](auto& entries) {
+    using value_t = typename std::decay_t<decltype(entries)>::value_type;
+    auto cmp = reversed ? &value_t::greater : &value_t::less;
     if (bounds) {
       auto sort_it = entries.begin() + std::min(bounds->first + bounds->second, entries.size());
-      std::partial_sort(entries.begin(), sort_it, entries.end(),
-                        [reversed](const auto& lhs, const auto& rhs) {
-                          return bool(lhs.Cmp() < rhs.Cmp()) ^ reversed;
-                        });
+      std::partial_sort(entries.begin(), sort_it, entries.end(), cmp);
     } else {
-      std::sort(entries.begin(), entries.end(),
-                [reversed, &entries](const auto& lhs, const auto& rhs) -> bool {
-                  DCHECK((&rhs - entries.data()) >= 0);
-                  DCHECK((&rhs - entries.data()) < int64_t(entries.size()));
-                  return reversed ? rhs.Cmp() < lhs.Cmp() : lhs.Cmp() < rhs.Cmp();
-                });
+      std::sort(entries.begin(), entries.end(), cmp);
     }
 
     auto start_it = entries.begin();

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -478,7 +478,13 @@ TEST_F(GenericFamilyTest, Sort) {
 
   Run({"set", "foo", "bar"});
   ASSERT_THAT(Run({"sort", "foo"}), ErrArg("WRONGTYPE "));
-  ;
+
+  Run({"rpush", "list-3", ""});
+  ASSERT_THAT(Run({"sort", "list-3"}), "");
+
+  Run({"rpush", "list-3", "2", "0", "", "-0.14", "0.12", "-0", "-123123", "7654"});
+  ASSERT_THAT(Run({"sort", "list-3"}).GetVec(),
+              ElementsAre("-123123", "-0.14", "", "", "-0", "0", "0.12", "2", "7654"));
 }
 
 TEST_F(GenericFamilyTest, SortBug3636) {


### PR DESCRIPTION
problem: 
RPUSH key 0 -1 2 '' 32
SORT key 
The result is an error because of ''
Expected result: -1 '' 0 2 32

We didn't process empty strings for number sorting