### PR TITLE
chore: reformat listpack according to valkey 8

### DIFF
--- a/src/redis/util.h
+++ b/src/redis/util.h
@@ -81,6 +81,9 @@ int ld2string(char *buf, size_t len, long double value, ld2string_mode mode);
 #define LRU_CLOCK_MAX ((1<<LRU_BITS)-1) /* Max value of obj->lru */
 #define LRU_CLOCK_RESOLUTION 1000 /* LRU clock resolution in ms */
 
+/* Bytes needed for long -> str + '\0' */
+#define LONG_STR_SIZE 21
+
 void serverLog(int level, const char *fmt, ...);
 void _serverPanic(const char *file, int line, const char *msg, ...);
 void _serverAssert(const char *estr, const char *file, int line);


### PR DESCRIPTION
Also add benchmarks for lpCompare code when list contains integers.
No functional changes.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->