### PR TITLE
chore: introduce an optimized integer compare algorithm for lists

### DIFF
--- a/src/redis/listpack.c
+++ b/src/redis/listpack.c
@@ -649,6 +649,75 @@ lpGetWithSize(unsigned char *p, int64_t *count, unsigned char *intbuf, uint64_t 
     }
 }
 
+unsigned char *lpGet2(unsigned char *p, int64_t *count) {
+    int64_t val;
+    uint64_t uval = 0, negstart = UINT64_MAX, negmax = 0;
+    uint8_t encoding = p[0];
+    
+    // Prioritize checking for integers first.
+    if (encoding < LP_ENCODING_7BIT_UINT_MASK) {        
+        uval = encoding & 0x7f;    
+    } else if (encoding > LP_ENCODING_32BIT_STR) {
+        switch (encoding) {
+            case LP_ENCODING_16BIT_INT:
+                uval = (uint64_t)p[1] | (uint64_t)p[2] << 8;
+                negstart = (uint64_t)1<<15;
+                negmax = UINT16_MAX;
+                break;
+            case LP_ENCODING_24BIT_INT:
+                uval = (uint64_t)p[1] | (uint64_t)p[2] << 8 | (uint64_t)p[3] << 16;
+                negstart = (uint64_t)1<<23;
+                negmax = UINT32_MAX>>8;
+                break;
+            case LP_ENCODING_32BIT_INT:
+                uval = (uint64_t)p[1] | (uint64_t)p[2] << 8 | (uint64_t)p[3] << 16 | (uint64_t)p[4] << 24;
+                negstart = (uint64_t)1<<31;
+                negmax = UINT32_MAX;
+                break;
+            case LP_ENCODING_64BIT_INT:                
+                uval = (uint64_t)p[1] | (uint64_t)p[2] << 8 | (uint64_t)p[3] << 16 | (uint64_t)p[4] << 24 |
+               (uint64_t)p[5] << 32 | (uint64_t)p[6] << 40 | (uint64_t)p[7] << 48 | (uint64_t)p[8] << 56;
+                negstart = (uint64_t)1<<63;
+                negmax = UINT64_MAX;
+            break;
+            default:
+                // Invalid encoding, return a large integer value.
+                uval = 12345678900000000ULL + p[0];
+        }
+    } else if (encoding < LP_ENCODING_6BIT_STR_MASK) {        
+        *count = LP_ENCODING_6BIT_STR_LEN(p);        
+        return p + 1;
+    } else if (encoding < LP_ENCODING_13BIT_INT_MASK) {        
+        uval = ((encoding & 0x1f) << 8) | p[1];
+        negstart = (uint64_t)1 << 12;
+        negmax = 8191;        
+    } else if (encoding < LP_ENCODING_12BIT_STR_MASK) {
+        // LP_ENCODING_12BIT_STR
+        *count = LP_ENCODING_12BIT_STR_LEN(p);        
+        return p + 2;
+    } else {
+        // LP_ENCODING_32BIT_STR
+        *count = LP_ENCODING_32BIT_STR_LEN(p);        
+        return p + 5;
+    }
+
+     /* We reach this code path only for integer encodings.
+     * Convert the unsigned value to the signed one using two's complement
+     * rule. */
+    if (uval >= negstart) {
+        /* This three steps conversion should avoid undefined behaviors
+         * in the unsigned -> signed conversion. */
+        uval = negmax-uval;
+        val = uval;
+        val = -val-1;
+    } else {
+        val = uval;
+    }
+    
+    *count = val;
+    return NULL;    
+}
+
 unsigned char *lpGet(unsigned char *p, int64_t *count, unsigned char *intbuf) {
     return lpGetWithSize(p, count, intbuf, NULL);
 }

--- a/src/redis/listpack.h
+++ b/src/redis/listpack.h
@@ -73,7 +73,10 @@ unsigned char *lpDeleteRange(unsigned char *lp, long index, unsigned long num);
 unsigned char *lpMerge(unsigned char **first, unsigned char **second);
 unsigned long lpLength(unsigned char *lp);
 unsigned char *lpGet(unsigned char *p, int64_t *count, unsigned char *intbuf);
-unsigned char *lpGet2(unsigned char *p, int64_t *count);
+
+// Fills count and returns 1 if the item is an integer, 0 otherwise.
+int lpGetInteger(unsigned char *p, int64_t *ival);
+
 unsigned char *lpGetValue(unsigned char *p, unsigned int *slen, long long *lval);
 unsigned char *lpFind(unsigned char *lp, unsigned char *p, unsigned char *s, uint32_t slen, unsigned int skip);
 unsigned char *lpFirst(unsigned char *lp);

--- a/src/redis/listpack.h
+++ b/src/redis/listpack.h
@@ -73,6 +73,7 @@ unsigned char *lpDeleteRange(unsigned char *lp, long index, unsigned long num);
 unsigned char *lpMerge(unsigned char **first, unsigned char **second);
 unsigned long lpLength(unsigned char *lp);
 unsigned char *lpGet(unsigned char *p, int64_t *count, unsigned char *intbuf);
+unsigned char *lpGet2(unsigned char *p, int64_t *count);
 unsigned char *lpGetValue(unsigned char *p, unsigned int *slen, long long *lval);
 unsigned char *lpFind(unsigned char *lp, unsigned char *p, unsigned char *s, uint32_t slen, unsigned int skip);
 unsigned char *lpFirst(unsigned char *lp);


### PR DESCRIPTION
Problem: when lists are long OpRem will spend lots of time comparing an element with records in the list. For integer-based lists, most of the time is spent in lpCompare. In addition, lpGet has lots of branches that penalize integers use-cases.

This PR:
1. Introduces lpGet2 - the improved version with less branches.
2. Benchmarks lpCompare vs an algorithm that compares records to an integer.
3. Benchmarks lpGet vs lpGet2

On c7g:
```
----------------------------------------------------------
Benchmark                Time             CPU   Iterations
----------------------------------------------------------
BM_LpCompare          3068 ns         3068 ns      1844176                                                                                                                                                                                  
BM_LpCompareInt        705 ns          705 ns      8040593                                                                                                                                                                                  
BM_LpGet/1             385 ns          385 ns     14604564                                                                                                                                                                                  
BM_LpGet/2             309 ns          309 ns     18110999 
```

There are no functional changes to the Dragonfly code.
While by itself `LpGet/2` is not worth the hassle, `BM_LpCompareInt ` shows that comparing integers is significantly faster 
than comparing strings

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->