### PR TITLE
chore: add a benchmark comparing lpStringToInt64 to SimpleAtoi

### DIFF
--- a/src/core/compact_object_test.cc
+++ b/src/core/compact_object_test.cc
@@ -733,7 +733,7 @@ static void BM_UnpackSimd(benchmark::State& state) {
 BENCHMARK(BM_UnpackSimd);
 
 static void BM_LpCompare(benchmark::State& state) {
-  std::random_device rd;
+  std::mt19937_64 rd;
   uint8_t* lp = lpNew(0);
   for (unsigned i = 0; i < 100; ++i) {
     lp = lpAppendInteger(lp, rd() % (1ULL << 48));
@@ -752,7 +752,7 @@ static void BM_LpCompare(benchmark::State& state) {
 BENCHMARK(BM_LpCompare);
 
 static void BM_LpCompareInt(benchmark::State& state) {
-  std::random_device rd;
+  std::mt19937_64 rd;
   uint8_t* lp = lpNew(0);
   for (unsigned i = 0; i < 100; ++i) {
     lp = lpAppendInteger(lp, rd() % (1ULL << 48));
@@ -796,5 +796,27 @@ static void BM_LpGet(benchmark::State& state) {
   lpFree(lp);
 }
 BENCHMARK(BM_LpGet);
+
+extern "C" int lpStringToInt64(const char* s, unsigned long slen, int64_t* value);
+
+static void BM_LpString2Int(benchmark::State& state) {
+  int version = state.range(0);
+  std::mt19937_64 rd;
+  vector<string> values;
+  for (unsigned i = 0; i < 1000; ++i) {
+    int64_t val = rd();
+    values.push_back(absl::StrCat(val));
+  }
+
+  int64_t ival = 0;
+  while (state.KeepRunning()) {
+    for (const auto& val : values) {
+      int res = version == 1 ? lpStringToInt64(val.data(), val.size(), &ival)
+                             : absl::SimpleAtoi(val, &ival);
+      benchmark::DoNotOptimize(res);
+    }
+  }
+}
+BENCHMARK(BM_LpString2Int)->Arg(1)->Arg(2);
 
 }  // namespace dfly


### PR DESCRIPTION
Seems that lpStringToInt64 is fairly optimized.
On c7g:

```
BM_LpString2Int/1      27383 ns        27381 ns       204149
BM_LpString2Int/2      24535 ns        24534 ns       227981
```

so SimpleAtoi has only ~10% improvement.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->