### PR TITLE
fix(rdb_load): fix loading huge hmaps with ttl

### DIFF
--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -70,8 +70,13 @@ using namespace tiering::literals;
 namespace {
 
 constexpr size_t kYieldPeriod = 50000;
-constexpr size_t kMaxBlobLen = 1ULL << 12;
 constexpr char kErrCat[] = "dragonfly.rdbload";
+
+// Maximum length of each LoadTrace segment.
+//
+// Note kMaxBlobLen must be a multiple of 6 to avoid truncating elements
+// containing 2 or 3 items.
+constexpr size_t kMaxBlobLen = 4092;
 
 inline void YieldIfNeeded(size_t i) {
   if (i % kYieldPeriod == 0) {


### PR DESCRIPTION
Fixes loading huge hmaps with TTL fields, where the TTL isn't parsed correctly:
```
Can't parse hashmap TTL for d6e8d4c162dd4b7252c55a5e348d017de976ac0b1ca5b3a262, ttl='cab59b6814524488e8ead622fc430e28f11b1fbd86e8f9f13b', val=52505369
```

This is caused by `kMaxBlobLen` not being a multiple of 3. As each `LoadTrace` segment contains elements key, value and TTL, when the segment is truncated, the next segment will be invalid. Such as it may start with 'value', 'ttl' instead of 'key', 'value', 'ttl', which leads to the above parsing error.

Therefore when the map includes a TTL, each segment must be a multiple of 3.

(I guess a simpler alternative is just to set `kMaxBlobLen` to be a multiple of both 2 and 3? I'm not sure how important being a power of 2 is?)