### PR TITLE
chore: add logs to test_acl_cat_commands_multi_exec_squash

### DIFF
--- a/tests/dragonfly/acl_family_test.py
+++ b/tests/dragonfly/acl_family_test.py
@@ -195,6 +195,7 @@ async def test_acl_cat_commands_multi_exec_squash(df_factory):
     # return multiple errors for each command failed. Since the nature of the error
     # is the same, that a rule has changed we should squash those error messages into
     # one.
+    logging.debug(f"Result is: {res}")
     assert res[0].args[0] == "kk ACL rules changed between the MULTI and EXEC", res
 
     await admin_client.close()


### PR DESCRIPTION
Add logs to test such that we know why it failed.

* add logs

Helps with #3719