### PR TITLE
chore: run memory decommit after snapshot load/save

### DIFF
--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -144,10 +144,8 @@ void MemoryCmd::Run(CmdArgList args) {
   }
 
   if (sub_cmd == "DECOMMIT") {
-    shard_set->pool()->AwaitBrief([](unsigned, auto* pb) {
-      ServerState::tlocal()->DecommitMemory(ServerState::kDataHeap | ServerState::kBackingHeap |
-                                            ServerState::kGlibcmalloc);
-    });
+    shard_set->pool()->AwaitBrief(
+        [](unsigned, auto* pb) { ServerState::tlocal()->DecommitMemory(ServerState::kAll); });
     return cntx_->SendSimpleString("OK");
   }
 

--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -145,7 +145,7 @@ void MemoryCmd::Run(CmdArgList args) {
 
   if (sub_cmd == "DECOMMIT") {
     shard_set->pool()->AwaitBrief(
-        [](unsigned, auto* pb) { ServerState::tlocal()->DecommitMemory(ServerState::kAll); });
+        [](unsigned, auto* pb) { ServerState::tlocal()->DecommitMemory(ServerState::kAllMemory); });
     return cntx_->SendSimpleString("OK");
   }
 

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -1995,8 +1995,11 @@ RdbLoader::~RdbLoader() {
   // Decommit local memory.
   // We create an RdbLoader for each thread, so each one will Decommit for itself after
   // full sync ends (since we explicitly reset the RdbLoader).
-  ServerState::tlocal()->DecommitMemory(ServerState::kDataHeap | ServerState::kBackingHeap |
-                                        ServerState::kGlibcmalloc);
+  auto* tlocal = ServerState::tlocal();
+  if (tlocal) {
+    tlocal->DecommitMemory(ServerState::kDataHeap | ServerState::kBackingHeap |
+                           ServerState::kGlibcmalloc);
+  }
 }
 
 error_code RdbLoader::Load(io::Source* src) {

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -1996,9 +1996,7 @@ RdbLoader::~RdbLoader() {
   // We create an RdbLoader for each thread, so each one will Decommit for itself after
   // full sync ends (since we explicitly reset the RdbLoader).
   auto* tlocal = ServerState::tlocal();
-  if (tlocal) {
-    tlocal->DecommitMemory(ServerState::kAllMemory);
-  }
+  tlocal->DecommitMemory(ServerState::kAllMemory);
 }
 
 error_code RdbLoader::Load(io::Source* src) {

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -1997,8 +1997,7 @@ RdbLoader::~RdbLoader() {
   // full sync ends (since we explicitly reset the RdbLoader).
   auto* tlocal = ServerState::tlocal();
   if (tlocal) {
-    tlocal->DecommitMemory(ServerState::kDataHeap | ServerState::kBackingHeap |
-                           ServerState::kGlibcmalloc);
+    tlocal->DecommitMemory(ServerState::kAll);
   }
 }
 

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -1997,7 +1997,7 @@ RdbLoader::~RdbLoader() {
   // full sync ends (since we explicitly reset the RdbLoader).
   auto* tlocal = ServerState::tlocal();
   if (tlocal) {
-    tlocal->DecommitMemory(ServerState::kAll);
+    tlocal->DecommitMemory(ServerState::kAllMemory);
   }
 }
 

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -1991,6 +1991,12 @@ RdbLoader::~RdbLoader() {
       break;
     delete item;
   }
+
+  // Decommit local memory.
+  // We create an RdbLoader for each thread, so each one will Decommit for itself after
+  // full sync ends (since we explicitly reset the RdbLoader).
+  ServerState::tlocal()->DecommitMemory(ServerState::kDataHeap | ServerState::kBackingHeap |
+                                        ServerState::kGlibcmalloc);
 }
 
 error_code RdbLoader::Load(io::Source* src) {

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -1410,8 +1410,7 @@ RdbSaver::~RdbSaver() {
   // We create an RdbSaver for each thread, so each one will Decommit for itself.
   auto* tlocal = ServerState::tlocal();
   if (tlocal) {
-    ServerState::tlocal()->DecommitMemory(ServerState::kDataHeap | ServerState::kBackingHeap |
-                                          ServerState::kGlibcmalloc);
+    ServerState::tlocal()->DecommitMemory(ServerState::kAll);
   }
 }
 

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -1409,9 +1409,7 @@ RdbSaver::~RdbSaver() {
   // Decommit local memory.
   // We create an RdbSaver for each thread, so each one will Decommit for itself.
   auto* tlocal = ServerState::tlocal();
-  if (tlocal) {
-    ServerState::tlocal()->DecommitMemory(ServerState::kAllMemory);
-  }
+  tlocal->DecommitMemory(ServerState::kAllMemory);
 }
 
 void RdbSaver::StartSnapshotInShard(bool stream_journal, const Cancellation* cll,

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -1410,7 +1410,7 @@ RdbSaver::~RdbSaver() {
   // We create an RdbSaver for each thread, so each one will Decommit for itself.
   auto* tlocal = ServerState::tlocal();
   if (tlocal) {
-    ServerState::tlocal()->DecommitMemory(ServerState::kAll);
+    ServerState::tlocal()->DecommitMemory(ServerState::kAllMemory);
   }
 }
 

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -1406,6 +1406,10 @@ RdbSaver::RdbSaver(::io::Sink* sink, SaveMode save_mode, bool align_writes) {
 }
 
 RdbSaver::~RdbSaver() {
+  // Decommit local memory.
+  // We create an RdbSaver for each thread, so each one will Decommit for itself.
+  ServerState::tlocal()->DecommitMemory(ServerState::kDataHeap | ServerState::kBackingHeap |
+                                        ServerState::kGlibcmalloc);
 }
 
 void RdbSaver::StartSnapshotInShard(bool stream_journal, const Cancellation* cll,

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -1408,8 +1408,11 @@ RdbSaver::RdbSaver(::io::Sink* sink, SaveMode save_mode, bool align_writes) {
 RdbSaver::~RdbSaver() {
   // Decommit local memory.
   // We create an RdbSaver for each thread, so each one will Decommit for itself.
-  ServerState::tlocal()->DecommitMemory(ServerState::kDataHeap | ServerState::kBackingHeap |
-                                        ServerState::kGlibcmalloc);
+  auto* tlocal = ServerState::tlocal();
+  if (tlocal) {
+    ServerState::tlocal()->DecommitMemory(ServerState::kDataHeap | ServerState::kBackingHeap |
+                                          ServerState::kGlibcmalloc);
+  }
 }
 
 void RdbSaver::StartSnapshotInShard(bool stream_journal, const Cancellation* cll,

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -157,6 +157,9 @@ void Replica::Stop() {
   // so we can freely release resources (connections).
   sync_fb_.JoinIfNeeded();
   acks_fb_.JoinIfNeeded();
+  for (auto& flow : shard_flows_) {
+    flow.reset();
+  }
 }
 
 void Replica::Pause(bool pause) {

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -282,7 +282,12 @@ class ServerState {  // public struct - to allow initialization.
   // Decommits 3 possible heaps according to the flags.
   // For decommit_glibcmalloc the heap is global for the process, for others it's specific only
   // for this thread.
-  enum { kDataHeap = 1, kBackingHeap = 2, kGlibcmalloc = 4 };
+  enum {
+    kDataHeap = 1,
+    kBackingHeap = 2,
+    kGlibcmalloc = 4,
+    kAll = kDataHeap | kBackingHeap | kGlibcmalloc
+  };
   void DecommitMemory(uint8_t flags);
 
   // Exec descriptor frequency count for this thread.

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -286,7 +286,7 @@ class ServerState {  // public struct - to allow initialization.
     kDataHeap = 1,
     kBackingHeap = 2,
     kGlibcmalloc = 4,
-    kAll = kDataHeap | kBackingHeap | kGlibcmalloc
+    kAllMemory = kDataHeap | kBackingHeap | kGlibcmalloc
   };
   void DecommitMemory(uint8_t flags);
 


### PR DESCRIPTION
Sometimes for large values during snapshot loading/saving we allocate a lot of extra memory. For that, we might need to manually run `memory decommit` for `mimalloc` to release memory pages back to the OS. This PR addresses that by manually running `memory decommit` after each shard finishes loading or saving a snapshot.