### PR TITLE
fix(rdb_load): fix appending to an expired key

### DIFF
--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2537,7 +2537,12 @@ void RdbLoader::LoadItemsBuffer(DbIndex db_ind, const ItemsBuf& ib) {
     if (item->load_config.append) {
       auto res = db_slice.FindMutable(db_cntx, item->key);
       if (!IsValid(res.it)) {
-        LOG(ERROR) << "Count not to find append key '" << item->key << "' in DB " << db_ind;
+        // If the item has expired we may not find the key. Note if the key
+        // is found, but expired since we started loading, we still append to
+        // avoid an inconsistent state where only part of the key is loaded.
+        if (item->expire_ms == 0 || db_cntx.time_now_ms < item->expire_ms) {
+          LOG(ERROR) << "Count not to find append key '" << item->key << "' in DB " << db_ind;
+        }
         continue;
       }
       pv_ptr = &res.it->second;
@@ -2566,8 +2571,10 @@ void RdbLoader::LoadItemsBuffer(DbIndex db_ind, const ItemsBuf& ib) {
       continue;
     }
 
-    if (item->expire_ms > 0 && db_cntx.time_now_ms >= item->expire_ms)
+    if (item->expire_ms > 0 && db_cntx.time_now_ms >= item->expire_ms) {
+      VLOG(1) << "Expire key on load: " << item->key;
       continue;
+    }
 
     auto op_res = db_slice.AddOrUpdate(db_cntx, item->key, std::move(pv), item->expire_ms);
     if (!op_res) {
@@ -2689,7 +2696,7 @@ bool RdbLoader::ShouldDiscardKey(std::string_view key, ObjSettings* settings) co
    * load all the keys as they are, since the log of operations later
    * assume to work in an exact keyspace state. */
   if (ServerState::tlocal()->is_master && settings->has_expired) {
-    VLOG(2) << "Expire key: " << key;
+    VLOG(2) << "Expire key on read: " << key;
     return true;
   }
 


### PR DESCRIPTION
Fixes the logging an error when a key expires between being read and being loaded, meaning the start of the object is not loaded but we still attempt to append to the object

This will still append to an object if the start of the object was loaded, even if the item has now expired to avoid an inconsistent state

Also added `Expire key on load` vlog incase it happens again (should be rare so set to level `1`)

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->