### PR TITLE
refactor: remove CmdArgParser::ToUpper()

### DIFF
--- a/src/facade/cmd_arg_parser.cc
+++ b/src/facade/cmd_arg_parser.cc
@@ -39,9 +39,4 @@ CmdArgParser::~CmdArgParser() {
   // TODO DCHECK(!HasNext()) << "Not all args were processed";
 }
 
-void CmdArgParser::ToUpper(size_t i) {
-  for (auto& c : args_[i])
-    c = absl::ascii_toupper(c);
-}
-
 }  // namespace facade

--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -151,13 +151,6 @@ struct CmdArgParser {
     return !HasError();
   }
 
-  // In-place convert the next argument to uppercase
-  CmdArgParser& ToUpper() {
-    if (cur_i_ < args_.size())
-      ToUpper(cur_i_);
-    return *this;
-  }
-
   // Return remaining arguments
   CmdArgList Tail() const {
     return args_.subspan(cur_i_);
@@ -260,8 +253,6 @@ struct CmdArgParser {
     Report(INVALID_INT, idx);
     return {};
   }
-
-  void ToUpper(size_t i);
 
  private:
   size_t cur_i_ = 0;

--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -371,12 +371,7 @@ void MemoryCmd::Track(CmdArgList args) {
 
   CmdArgParser parser(args);
 
-  string_view sub_cmd = parser.ToUpper().Next();
-  if (parser.HasError()) {
-    return cntx_->SendError(parser.Error()->MakeReply());
-  }
-
-  if (sub_cmd == "ADD") {
+  if (parser.Check("ADD")) {
     AllocationTracker::TrackingInfo tracking_info;
     std::tie(tracking_info.lower_bound, tracking_info.upper_bound, tracking_info.sample_odds) =
         parser.Next<size_t, size_t, double>();
@@ -398,7 +393,7 @@ void MemoryCmd::Track(CmdArgList args) {
     }
   }
 
-  if (sub_cmd == "REMOVE") {
+  if (parser.Check("REMOVE")) {
     auto [lower_bound, upper_bound] = parser.Next<size_t, size_t>();
     if (parser.HasError()) {
       return cntx_->SendError(parser.Error()->MakeReply());
@@ -418,12 +413,12 @@ void MemoryCmd::Track(CmdArgList args) {
     }
   }
 
-  if (sub_cmd == "CLEAR") {
+  if (parser.Check("CLEAR")) {
     shard_set->pool()->AwaitBrief([&](unsigned index, auto*) { AllocationTracker::Get().Clear(); });
     return cntx_->SendOk();
   }
 
-  if (sub_cmd == "GET") {
+  if (parser.Check("GET")) {
     auto ranges = AllocationTracker::Get().GetRanges();
     auto* rb = static_cast<facade::RedisReplyBuilder*>(cntx_->reply_builder());
     rb->StartArray(ranges.size());
@@ -434,7 +429,7 @@ void MemoryCmd::Track(CmdArgList args) {
     return;
   }
 
-  if (sub_cmd == "ADDRESS") {
+  if (parser.Check("ADDRESS")) {
     string_view ptr_str = parser.Next();
     if (parser.HasError()) {
       return cntx_->SendError(parser.Error()->MakeReply());


### PR DESCRIPTION
fixes: #3471
the code was refactored to avoid using CmdArgParser::ToUpper()