### PR TITLE
fix(rdb_load): fix partial reads dropping elements

### DIFF
--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -128,6 +128,10 @@ class RdbLoaderBase {
   };
 
   struct LoadConfig {
+    // Whether the loaded item is being streamed incrementally in partial
+    // reads.
+    bool streamed = false;
+
     // Number of elements in the object to reserve.
     //
     // Used to reserve the elements in a huge object up front, then append


### PR DESCRIPTION
Found a bug in loading huge objects where we append to the wrong encoding.

Say you have a hmap with 4100 integers, we'll load 4092 then 8 elements. The first `CreateHMap` will see `4092 > 64` so create a `StringMap`, but the second `CreateHMap` will see `8 < 64` so creates an `lpNew` instead of appending to the existing `StringMap` (meaning the existing elements are lost). Same applies to set (when loading an 'intset') and zset.

Therefore adding an `item.streamed` to be really explicit about whether the item is being streamed so the larger encoding must always be used. We could probably infer from `append` and `reserve` but seemed better to be explicit.