### PR TITLE
feat(rdb_load): add support for loading huge streams

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -124,7 +124,15 @@ tuple<const CommandId*, absl::InlinedVector<string, 5>> GeneratePopulateCommand(
     }
     json[json.size() - 1] = '}';  // Replace last ',' with '}'
     args.push_back(json);
+  } else if (type == "STREAM") {
+    cid = registry.Find("XADD");
+    args.push_back("*");
+    for (size_t i = 0; i < elements; ++i) {
+      args.push_back(GenerateValue(val_size / 2, random_value, gen));
+      args.push_back(GenerateValue(val_size / 2, random_value, gen));
+    }
   }
+
   return {cid, args};
 }
 

--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -99,17 +99,8 @@ class RdbLoaderBase {
   };
 
   struct LoadTrace {
-    // Some traces are very long. We divide them into multiple segments.
-    std::vector<std::vector<LoadBlob>> arr;
+    std::vector<LoadBlob> arr;
     std::unique_ptr<StreamTrace> stream_trace;
-
-    size_t blob_count() const {
-      size_t count = 0;
-      for (const auto& seg : arr) {
-        count += seg.size();
-      }
-      return count;
-    }
   };
 
   // Contains the state of a pending partial read.


### PR DESCRIPTION
Follows https://github.com/dragonflydb/dragonfly/pull/3850 to add support for loading huge streams (https://github.com/dragonflydb/dragonfly/issues/3760).

This loads the stream entries in partial reads, though loads the stream metadata and consumer groups in a single read (assuming consumer groups will be relatively small so don't need partial reads).

As with lists, loads streams in 512 segments as each stream node can contain 4kb of elements.

Also removes the outer `Ltrace::arr` as we now only use a single array. This means `YieldIfNeeded` is also redundant so removed.

Comparing a 5GB stream:
- `main`: 4.8s / ~13GB RSS
- `load-huge-streams`: 2.6s / ~7GB RSS