### PR TITLE
chore: allow rdb version 12

### DIFF
--- a/src/redis/rdb.h
+++ b/src/redis/rdb.h
@@ -38,7 +38,7 @@
 
 /* The current RDB version. When the format changes in a way that is no longer
  * backward compatible this number gets incremented. */
-#define RDB_VERSION 11
+#define RDB_VERSION 12
 
 /* We would like to serialize to version 9 such that our rdb files
  * can be loaded by redis version 6 (RDB_VERSION 9) */
@@ -110,6 +110,7 @@
 /* Range 200-240 is used by Dragonfly specific opcodes */
 
 /* Special RDB opcodes (saved/loaded with rdbSaveType/rdbLoadType). */
+#define RDB_OPCODE_SLOT_INFO  244   /* Individual slot info, such as slot id and size (cluster mode only). */
 #define RDB_OPCODE_FUNCTION   246   /* engine data */
 #define RDB_OPCODE_FUNCTION2  245   /* function library data */
 #define RDB_OPCODE_FUNCTION_PRE_GA   246   /* old function library data for 7.0 rc1 and rc2 */

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2281,11 +2281,11 @@ error_code RdbLoader::Load(io::Source* src) {
     }
 
     if (type == RDB_OPCODE_SLOT_INFO) {
-      uint64_t slot_id;
+      [[maybe_unused]] uint64_t slot_id;
       SET_OR_RETURN(LoadLen(nullptr), slot_id);
-      uint64_t slot_size;
+      [[maybe_unused]] uint64_t slot_size;
       SET_OR_RETURN(LoadLen(nullptr), slot_size);
-      uint64_t expires_slot_size;
+      [[maybe_unused]] uint64_t expires_slot_size;
       SET_OR_RETURN(LoadLen(nullptr), expires_slot_size);
       LOG(WARNING) << "Loaded and ignored RDB_OPCODE_SLOT_INFO";
       continue;

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2280,6 +2280,17 @@ error_code RdbLoader::Load(io::Source* src) {
       continue;
     }
 
+    if (type == RDB_OPCODE_SLOT_INFO) {
+      uint64_t slot_id;
+      SET_OR_RETURN(LoadLen(nullptr), slot_id);
+      uint64_t slot_size;
+      SET_OR_RETURN(LoadLen(nullptr), slot_size);
+      uint64_t expires_slot_size;
+      SET_OR_RETURN(LoadLen(nullptr), expires_slot_size);
+      LOG(WARNING) << "Loaded and ignored RDB_OPCODE_SLOT_INFO";
+      continue;
+    }
+
     if (!rdbIsObjectTypeDF(type)) {
       return RdbError(errc::invalid_rdb_type);
     }

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2287,7 +2287,6 @@ error_code RdbLoader::Load(io::Source* src) {
       SET_OR_RETURN(LoadLen(nullptr), slot_size);
       [[maybe_unused]] uint64_t expires_slot_size;
       SET_OR_RETURN(LoadLen(nullptr), expires_slot_size);
-      LOG(WARNING) << "Loaded and ignored RDB_OPCODE_SLOT_INFO";
       continue;
     }
 


### PR DESCRIPTION
We currently support rdb files up to version `11`. This is a blocker for people who want to migrate to dragonfly with newer versions of the format. As of now, there is only `v12` and it only includes the addition of `RDB_OPCODE_SLOT_INFO`. For now this PR:

* adds support to load rdb files up to version 12
* reads and discards with a warning the contents of `RDB_OPCODE_SLOT_INFO` if found in the rdb file


addresses:  #3859