### PR TITLE
chore: simplify CloneBatch code

### DIFF
--- a/src/core/dense_set.h
+++ b/src/core/dense_set.h
@@ -331,10 +331,9 @@ class DenseSet {
   bool Equal(DensePtr dptr, const void* ptr, uint32_t cookie) const;
 
   struct CloneItem {
-    const DenseLinkKey* link = nullptr;
+    DensePtr ptr;
     void* obj = nullptr;
     bool has_ttl = false;
-    bool fetch_tail = false;
   };
 
   void CloneBatch(unsigned len, CloneItem* items, DenseSet* other) const;

--- a/src/core/string_set_test.cc
+++ b/src/core/string_set_test.cc
@@ -515,4 +515,20 @@ void BM_Fill(benchmark::State& state) {
 }
 BENCHMARK(BM_Fill)->ArgName("elements")->Arg(32000);
 
+void BM_Clear(benchmark::State& state) {
+  unsigned elems = state.range(0);
+  mt19937 generator(0);
+  StringSet ss;
+  while (state.KeepRunning()) {
+    state.PauseTiming();
+    for (size_t i = 0; i < elems; ++i) {
+      string str = random_string(generator, 16);
+      ss.Add(str);
+    }
+    state.ResumeTiming();
+    ss.Clear();
+  }
+}
+BENCHMARK(BM_Clear)->ArgName("elements")->Arg(32000);
+
 }  // namespace dfly


### PR DESCRIPTION
Remove awkward fetch_tail case and streamline the code. Fix invalid prefetch adresses. Performance improved a little.

Before:
`BM_Fill/elements:32000     874677 ns       874647 ns         4774`

After:
`BM_Fill/elements:32000     831786 ns       831761 ns         5111`

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->