### PR TITLE
chore: improve performance of ClearInternal

### DIFF
--- a/src/core/dense_set.h
+++ b/src/core/dense_set.h
@@ -338,6 +338,9 @@ class DenseSet {
 
   void CloneBatch(unsigned len, CloneItem* items, DenseSet* other) const;
 
+  using ClearItem = CloneItem;
+  void ClearBatch(unsigned len, ClearItem* items);
+
   MemoryResource* mr() {
     return entries_.get_allocator().resource();
   }


### PR DESCRIPTION
Before:
`BM_Clear/elements:32000     418763 ns       418749 ns         9965`

After:
`BM_Clear/elements:32000     323252 ns       323239 ns        12790`

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->