### PR TITLE
chore: Remove DenseSet::AddOrFindDense and AddSds

### DIFF
--- a/src/core/dense_set.h
+++ b/src/core/dense_set.h
@@ -310,13 +310,6 @@ class DenseSet {
     obj_malloc_used_ -= delta;
   }
 
-  // Returns previous if the equivalent object already exists,
-  // Returns nullptr if obj was added.
-  void* AddOrFindObj(void* obj, bool has_ttl) {
-    DensePtr* ptr = AddOrFindDense(obj, has_ttl);
-    return ptr ? ptr->GetObject() : nullptr;
-  }
-
   // Returns the previous object if it has been replaced.
   // nullptr, if obj was added.
   void* AddOrReplaceObj(void* obj, bool has_ttl);
@@ -368,10 +361,6 @@ class DenseSet {
 
   void* PopDataFront(ChainVectorIterator);
   DensePtr PopPtrFront(ChainVectorIterator);
-
-  // Returns DensePtr if the object with such key already exists,
-  // Returns null if obj was added.
-  DensePtr* AddOrFindDense(void* obj, bool has_ttl);
 
   // ============ Pseudo Linked List in DenseSet end ==================
 

--- a/src/core/string_set.cc
+++ b/src/core/string_set.cc
@@ -38,19 +38,16 @@ StringSet::~StringSet() {
   Clear();
 }
 
-bool StringSet::AddSds(sds s1) {
-  return AddOrFindObj(s1, false) == nullptr;
-}
-
 bool StringSet::Add(string_view src, uint32_t ttl_sec) {
-  sds newsds = MakeSetSds(src, ttl_sec);
-  bool has_ttl = ttl_sec != UINT32_MAX;
-
-  if (AddOrFindObj(newsds, has_ttl) != nullptr) {
-    sdsfree(newsds);
+  uint64_t hash = Hash(&src, 1);
+  void* prev = FindInternal(&src, hash, 1);
+  if (prev != nullptr) {
     return false;
   }
 
+  sds newsds = MakeSetSds(src, ttl_sec);
+  bool has_ttl = ttl_sec != UINT32_MAX;
+  AddUnique(newsds, has_ttl, hash);
   return true;
 }
 

--- a/src/core/string_set.h
+++ b/src/core/string_set.h
@@ -28,9 +28,6 @@ class StringSet : public DenseSet {
   // Returns true if elem was added.
   bool Add(std::string_view s1, uint32_t ttl_sec = UINT32_MAX);
 
-  // Used currently by rdb_load. Returns true if elem was added.
-  bool AddSds(sds elem);
-
   bool Erase(std::string_view str) {
     return EraseInternal(&str, 1);
   }

--- a/src/core/string_set_test.cc
+++ b/src/core/string_set_test.cc
@@ -531,4 +531,25 @@ void BM_Clear(benchmark::State& state) {
 }
 BENCHMARK(BM_Clear)->ArgName("elements")->Arg(32000);
 
+void BM_Add(benchmark::State& state) {
+  vector<string> strs;
+  mt19937 generator(0);
+  StringSet ss;
+  unsigned elems = 100000;
+  for (size_t i = 0; i < elems; ++i) {
+    string str = random_string(generator, 16);
+    strs.push_back(str);
+  }
+  ss.Reserve(elems);
+  while (state.KeepRunning()) {
+    for (auto& str : strs)
+      ss.Add(str);
+    state.PauseTiming();
+    ss.Clear();
+    ss.Reserve(elems);
+    state.ResumeTiming();
+  }
+}
+BENCHMARK(BM_Add);
+
 }  // namespace dfly


### PR DESCRIPTION
Clean up interface a bit. AddOrFindDense does not make much sense as a single function because it does not provide any performance benefits - we still must perform a lookup before inserting. AddSds should have been removed a long time ago.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->