### PR TITLE
chore: lock keys for optimistic transactions

### DIFF
--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1074,12 +1074,12 @@ bool Transaction::ScheduleInShard(EngineShard* shard, bool execute_optimistic) {
     lock_args = GetLockArgs(shard->shard_id());
     bool shard_unlocked = shard->shard_lock()->Check(mode);
 
+    acquire_fp_locks(shard_unlocked);
+
     // Check if we can run immediately
-    if (shard_unlocked && execute_optimistic &&
-        CheckLocks(GetDbSlice(shard->shard_id()), mode, lock_args)) {
+    if (shard_unlocked && execute_optimistic && lock_granted) {
       // We need to acquire the fp locks because the executing callback
       // within RunCallback might preempt.
-      acquire_fp_locks(shard_unlocked);
       sd.local_mask |= OPTIMISTIC_EXECUTION;
       shard->stats().tx_optimistic_total++;
 
@@ -1091,10 +1091,6 @@ bool Transaction::ScheduleInShard(EngineShard* shard, bool execute_optimistic) {
         release_fp_locks();
         return true;
       }
-    }
-
-    if (!lock_granted) {
-      acquire_fp_locks(shard_unlocked);
     }
   }
 

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -83,14 +83,6 @@ uint16_t trans_id(const Transaction* ptr) {
   return (intptr_t(ptr) >> 8) & 0xFFFF;
 }
 
-bool CheckLocks(const DbSlice& db_slice, IntentLock::Mode mode, const KeyLockArgs& lock_args) {
-  for (LockFp fp : lock_args.fps) {
-    if (!db_slice.CheckLock(mode, lock_args.db_index, fp))
-      return false;
-  }
-  return true;
-}
-
 struct ScheduleContext {
   Transaction* trans;
   bool optimistic_execution = false;

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1074,12 +1074,12 @@ bool Transaction::ScheduleInShard(EngineShard* shard, bool execute_optimistic) {
     lock_args = GetLockArgs(shard->shard_id());
     bool shard_unlocked = shard->shard_lock()->Check(mode);
 
+    // We need to acquire the fp locks because the executing callback
+    // within RunCallback below might preempt.
     acquire_fp_locks(shard_unlocked);
 
     // Check if we can run immediately
     if (shard_unlocked && execute_optimistic && lock_granted) {
-      // We need to acquire the fp locks because the executing callback
-      // within RunCallback might preempt.
       sd.local_mask |= OPTIMISTIC_EXECUTION;
       shard->stats().tx_optimistic_total++;
 


### PR DESCRIPTION
We did not acquire any locks for transactions that are executing optimistically. However, this is problematic for callbacks that need to preempt (e.g. because a journal is active).

resolves #3841