### PR TITLE
chore: Implement AddMany method

### DIFF
--- a/src/core/dense_set.h
+++ b/src/core/dense_set.h
@@ -208,6 +208,7 @@ class DenseSet {
 
  public:
   using MemoryResource = PMR_NS::memory_resource;
+  static constexpr uint32_t kMaxBatchLen = 32;
 
   explicit DenseSet(MemoryResource* mr = PMR_NS::get_default_resource());
   virtual ~DenseSet();
@@ -316,6 +317,8 @@ class DenseSet {
 
   // Assumes that the object does not exist in the set.
   void AddUnique(void* obj, bool has_ttl, uint64_t hashcode);
+
+  void Prefetch(uint64_t hash);
 
  private:
   DenseSet(const DenseSet&) = delete;

--- a/src/core/string_set.h
+++ b/src/core/string_set.h
@@ -28,6 +28,8 @@ class StringSet : public DenseSet {
   // Returns true if elem was added.
   bool Add(std::string_view s1, uint32_t ttl_sec = UINT32_MAX);
 
+  void AddMany(std::string_view elems[], size_t count, uint32_t ttl_sec, bool* res);
+
   bool Erase(std::string_view str) {
     return EraseInternal(&str, 1);
   }

--- a/src/core/string_set.h
+++ b/src/core/string_set.h
@@ -4,10 +4,11 @@
 
 #pragma once
 
+#include <absl/types/span.h>
+
 #include <cstdint>
 #include <functional>
 #include <optional>
-#include <string>
 #include <string_view>
 
 #include "core/dense_set.h"
@@ -28,7 +29,7 @@ class StringSet : public DenseSet {
   // Returns true if elem was added.
   bool Add(std::string_view s1, uint32_t ttl_sec = UINT32_MAX);
 
-  void AddMany(std::string_view elems[], size_t count, uint32_t ttl_sec, bool* res);
+  unsigned AddMany(absl::Span<std::string_view> span, uint32_t ttl_sec);
 
   bool Erase(std::string_view str) {
     return EraseInternal(&str, 1);

--- a/src/core/string_set_test.cc
+++ b/src/core/string_set_test.cc
@@ -567,13 +567,12 @@ void BM_AddMany(benchmark::State& state) {
   while (state.KeepRunning()) {
     unsigned offset = 0;
     while (offset < elems) {
-      bool res[str_views.size()];
       unsigned len = min(elems - offset, 32u);
       for (size_t i = 0; i < len; ++i) {
         str_views[i] = strs[offset + i];
       }
       offset += len;
-      ss.AddMany(str_views.data(), len, UINT32_MAX, res);
+      ss.AddMany({str_views.data(), len}, UINT32_MAX);
     }
     state.PauseTiming();
     ss.Clear();

--- a/src/core/string_set_test.cc
+++ b/src/core/string_set_test.cc
@@ -552,4 +552,35 @@ void BM_Add(benchmark::State& state) {
 }
 BENCHMARK(BM_Add);
 
+void BM_AddMany(benchmark::State& state) {
+  vector<string> strs;
+  mt19937 generator(0);
+  StringSet ss;
+  unsigned elems = 100000;
+  for (size_t i = 0; i < elems; ++i) {
+    string str = random_string(generator, 16);
+    strs.push_back(str);
+  }
+  ss.Reserve(elems);
+  array<string_view, 32> str_views;
+
+  while (state.KeepRunning()) {
+    unsigned offset = 0;
+    while (offset < elems) {
+      bool res[str_views.size()];
+      unsigned len = min(elems - offset, 32u);
+      for (size_t i = 0; i < len; ++i) {
+        str_views[i] = strs[offset + i];
+      }
+      offset += len;
+      ss.AddMany(str_views.data(), len, UINT32_MAX, res);
+    }
+    state.PauseTiming();
+    ss.Clear();
+    ss.Reserve(elems);
+    state.ResumeTiming();
+  }
+}
+BENCHMARK(BM_AddMany);
+
 }  // namespace dfly


### PR DESCRIPTION
1. Fix a performance bug in Find2 that made redundant comparisons
2. Provide a method to StringSet that adds several items in a batch
3. Use AddMany inside set_family

Before:
```
BM_Add        4253939 ns      4253713 ns          991
```

After:
```
BM_Add        3482177 ns      3482050 ns         1206
BM_AddMany    3101622 ns      3101507 ns         1360
```

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->