### PR TITLE
chore: ClearInternal now can clear partially

### DIFF
--- a/src/core/dense_set.cc
+++ b/src/core/dense_set.cc
@@ -179,12 +179,12 @@ void* DenseSet::PopDataFront(DenseSet::ChainVectorIterator it) {
   return ret;
 }
 
-uint32_t DenseSet::ClearInternal(uint32_t start, uint32_t limit) {
+uint32_t DenseSet::ClearInternal(uint32_t start, uint32_t count) {
   constexpr unsigned kArrLen = 32;
   ClearItem arr[kArrLen];
   unsigned len = 0;
 
-  size_t end = min<size_t>(entries_.size(), start + limit);
+  size_t end = min<size_t>(entries_.size(), start + count);
   for (size_t i = start; i < end; ++i) {
     DensePtr ptr = entries_[i];
     if (ptr.IsEmpty())

--- a/src/core/dense_set.cc
+++ b/src/core/dense_set.cc
@@ -179,16 +179,17 @@ void* DenseSet::PopDataFront(DenseSet::ChainVectorIterator it) {
   return ret;
 }
 
-void DenseSet::ClearInternal() {
+uint32_t DenseSet::ClearInternal(uint32_t start, uint32_t limit) {
   constexpr unsigned kArrLen = 32;
   ClearItem arr[kArrLen];
   unsigned len = 0;
 
-  for (auto it = entries_.begin(); it != entries_.end(); ++it) {
-    if (it->IsEmpty())
+  size_t end = min<size_t>(entries_.size(), start + limit);
+  for (size_t i = start; i < end; ++i) {
+    DensePtr ptr = entries_[i];
+    if (ptr.IsEmpty())
       continue;
 
-    DensePtr ptr = *it;
     auto& dest = arr[len++];
     dest.has_ttl = ptr.HasTtl();
 
@@ -208,11 +209,13 @@ void DenseSet::ClearInternal() {
 
   ClearBatch(len, arr);
 
-  entries_.clear();
-  num_used_buckets_ = 0;
-  num_links_ = 0;
-  size_ = 0;
-  expiration_used_ = false;
+  if (size_ == 0) {
+    entries_.clear();
+    num_used_buckets_ = 0;
+    num_links_ = 0;
+    expiration_used_ = false;
+  }
+  return end;
 }
 
 bool DenseSet::Equal(DensePtr dptr, const void* ptr, uint32_t cookie) const {
@@ -277,6 +280,7 @@ void DenseSet::ClearBatch(unsigned len, ClearItem* items) {
       auto& src = items[i];
       if (src.obj) {
         ObjDelete(src.obj, src.has_ttl);
+        --size_;
         src.obj = nullptr;
       }
 
@@ -285,6 +289,7 @@ void DenseSet::ClearBatch(unsigned len, ClearItem* items) {
 
       if (src.ptr.IsObject()) {
         ObjDelete(src.ptr.Raw(), src.has_ttl);
+        --size_;
       } else {
         auto& dest = items[dest_id++];
         DenseLinkKey* link = src.ptr.AsLink();

--- a/src/core/dense_set.h
+++ b/src/core/dense_set.h
@@ -212,6 +212,10 @@ class DenseSet {
   explicit DenseSet(MemoryResource* mr = PMR_NS::get_default_resource());
   virtual ~DenseSet();
 
+  void Clear() {
+    ClearInternal(0, entries_.size());
+  }
+
   // Returns the number of elements in the map. Note that it might be that some of these elements
   // have expired and can't be accessed.
   size_t UpperBoundSize() const {
@@ -300,7 +304,7 @@ class DenseSet {
   // Note this does not free any dynamic allocations done by derived classes, that a DensePtr
   // in the set may point to. This function only frees the allocated DenseLinkKeys created by
   // DenseSet. All data allocated by a derived class should be freed before calling this
-  void ClearInternal();
+  uint32_t ClearInternal(uint32_t start, uint32_t limit);
 
   void IncreaseMallocUsed(size_t delta) {
     obj_malloc_used_ += delta;

--- a/src/core/dense_set.h
+++ b/src/core/dense_set.h
@@ -304,7 +304,7 @@ class DenseSet {
   // Note this does not free any dynamic allocations done by derived classes, that a DensePtr
   // in the set may point to. This function only frees the allocated DenseLinkKeys created by
   // DenseSet. All data allocated by a derived class should be freed before calling this
-  uint32_t ClearInternal(uint32_t start, uint32_t limit);
+  uint32_t ClearInternal(uint32_t start, uint32_t count);
 
   void IncreaseMallocUsed(size_t delta) {
     obj_malloc_used_ += delta;

--- a/src/core/score_map.h
+++ b/src/core/score_map.h
@@ -105,10 +105,6 @@ class ScoreMap : public DenseSet {
     return FindInternal(ele, Hash(ele, 0), 0);
   }
 
-  void Clear() {
-    ClearInternal();
-  }
-
   iterator begin() {
     return iterator{this, false};
   }

--- a/src/core/string_map.cc
+++ b/src/core/string_map.cc
@@ -62,7 +62,7 @@ pair<sds, uint64_t> CreateEntry(string_view field, string_view value, uint32_t t
 }  // namespace
 
 StringMap::~StringMap() {
-  ClearInternal();
+  Clear();
 }
 
 bool StringMap::AddOrUpdate(string_view field, string_view value, uint32_t ttl_sec) {
@@ -99,10 +99,6 @@ bool StringMap::Contains(string_view field) const {
   // 1 - means it's string_view. See ObjEqual for details.
   uint64_t hashcode = Hash(&field, 1);
   return FindInternal(&field, hashcode, 1) != nullptr;
-}
-
-void StringMap::Clear() {
-  ClearInternal();
 }
 
 optional<pair<sds, sds>> StringMap::RandomPair() {

--- a/src/core/string_map.h
+++ b/src/core/string_map.h
@@ -121,8 +121,6 @@ class StringMap : public DenseSet {
     return iterator{FindIt(&member, 1)};
   }
 
-  void Clear();
-
   iterator begin() {
     return iterator{this};
   }

--- a/src/core/string_set.h
+++ b/src/core/string_set.h
@@ -36,10 +36,6 @@ class StringSet : public DenseSet {
     return FindInternal(&s1, Hash(&s1, 1), 1) != nullptr;
   }
 
-  void Clear() {
-    ClearInternal();
-  }
-
   std::optional<std::string> Pop();
 
   class iterator : private IteratorBase {


### PR DESCRIPTION
Intended for future use - to deallocate large objects gradually. Currently nothing is changed in the functionality besides some cleanups.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->