### PR TITLE
fix: Do not publish to connections without context

### DIFF
--- a/src/server/channel_store.cc
+++ b/src/server/channel_store.cc
@@ -146,7 +146,7 @@ unsigned ChannelStore::SendMessages(std::string_view channel, facade::ArgRange m
     auto it = lower_bound(subscribers_ptr->begin(), subscribers_ptr->end(), idx,
                           ChannelStore::Subscriber::ByThreadId);
     while (it != subscribers_ptr->end() && it->Thread() == idx) {
-      // A connection might have closed or be in the process of closing
+      // if ptr->cntx() is null, a connection might have closed or be in the process of closing
       if (auto* ptr = it->Get(); ptr && ptr->cntx() != nullptr)
         send(ptr, it->pattern);
       it++;

--- a/src/server/channel_store.cc
+++ b/src/server/channel_store.cc
@@ -146,7 +146,8 @@ unsigned ChannelStore::SendMessages(std::string_view channel, facade::ArgRange m
     auto it = lower_bound(subscribers_ptr->begin(), subscribers_ptr->end(), idx,
                           ChannelStore::Subscriber::ByThreadId);
     while (it != subscribers_ptr->end() && it->Thread() == idx) {
-      if (auto* ptr = it->Get(); ptr)
+      // A connection might have closed or be in the process of closing
+      if (auto* ptr = it->Get(); ptr && ptr->cntx() != nullptr)
         send(ptr, it->pattern);
       it++;
     }


### PR DESCRIPTION
This is a rare case where a closed connection is kept alive while the handling fiber yields, therefore leaving `cc_` (the connection context) pointing to null for other fibers to see.

As far as I can see, this can only happen during server shutdown, but there could be other cases that I have missed.

The test on its own does _not_ reproduce the crash, however with added `ThisFiber::SleepFor()`s I could reproduce the crash:

* Right before `DispatchBrief()` [here](https://github.com/dragonflydb/dragonfly/blob/e3214cb603fce42c8bb52a2c220c3115b7f8cecf/src/server/channel_store.cc#L154)
* Right after connection context `reset()` [here](https://github.com/dragonflydb/dragonfly/blob/2ab480e160dece516b908584f1933b25b760abfb/src/facade/dragonfly_connection.cc#L750)

In any case, calling `SendPubMessageAsync()` to a connection where `cc_` is null is a bug, and we fix that here.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->