### PR TITLE
chore: reduce usage of ToUpper

### DIFF
--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -387,9 +387,7 @@ void ClusterFamily::KeySlot(CmdArgList args, ConnectionContext* cntx) {
 void ClusterFamily::Cluster(CmdArgList args, ConnectionContext* cntx) {
   // In emulated cluster mode, all slots are mapped to the same host, and number of cluster
   // instances is thus 1.
-
-  ToUpper(&args[0]);
-  string_view sub_cmd = ArgS(args, 0);
+  string sub_cmd = absl::AsciiStrToUpper(ArgS(args, 0));
 
   if (!IsClusterEnabledOrEmulated()) {
     return cntx->SendError(kClusterDisabled);
@@ -445,8 +443,7 @@ void ClusterFamily::DflyCluster(CmdArgList args, ConnectionContext* cntx) {
     VLOG(2) << "Got DFLYCLUSTER command (NO_CLIENT_ID): " << args;
   }
 
-  ToUpper(&args[0]);
-  string_view sub_cmd = ArgS(args, 0);
+  string sub_cmd = absl::AsciiStrToUpper(ArgS(args, 0));
   args.remove_prefix(1);  // remove subcommand name
   if (sub_cmd == "GETSLOTINFO") {
     return DflyClusterGetSlotInfo(args, cntx);
@@ -747,8 +744,8 @@ void ClusterFamily::DflySlotMigrationStatus(CmdArgList args, ConnectionContext* 
 }
 
 void ClusterFamily::DflyMigrate(CmdArgList args, ConnectionContext* cntx) {
-  ToUpper(&args[0]);
-  string_view sub_cmd = ArgS(args, 0);
+  string sub_cmd = absl::AsciiStrToUpper(ArgS(args, 0));
+
   args.remove_prefix(1);
   if (sub_cmd == "INIT") {
     InitMigration(args, cntx);

--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -305,16 +305,16 @@ void MemoryCmd::ArenaStats(CmdArgList args) {
   bool backing = false;
   bool show_arenas = false;
   if (args.size() >= 2) {
-    ToUpper(&args[1]);
+    string sub_cmd = absl::AsciiStrToUpper(ArgS(args, 1));
 
-    if (ArgS(args, 1) == "SHOW") {
+    if (sub_cmd == "SHOW") {
       if (args.size() != 2)
         return cntx_->SendError(kSyntaxErr, kSyntaxErrType);
       show_arenas = true;
     } else {
       unsigned tid_indx = 1;
 
-      if (ArgS(args, tid_indx) == "BACKING") {
+      if (sub_cmd == "BACKING") {
         ++tid_indx;
         backing = true;
       }

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -1888,9 +1888,7 @@ optional<pair<AddTrimOpts, unsigned>> ParseAddOrTrimArgsOrReply(CmdArgList args,
 
   unsigned id_indx = 1;
   for (; id_indx < args.size(); ++id_indx) {
-    ToUpper(&args[id_indx]);
-    string_view arg = ArgS(args, id_indx);
-
+    string arg = absl::AsciiStrToUpper(ArgS(args, id_indx));
     size_t remaining_args = args.size() - id_indx - 1;
 
     if (is_xadd && arg == "NOMKSTREAM") {
@@ -2059,8 +2057,7 @@ absl::InlinedVector<streamID, 8> GetXclaimIds(CmdArgList& args) {
 
 void ParseXclaimOptions(CmdArgList& args, ClaimOpts& opts, ConnectionContext* cntx) {
   for (size_t i = 0; i < args.size(); ++i) {
-    ToUpper(&args[i]);
-    string_view arg = ArgS(args, i);
+    string arg = absl::AsciiStrToUpper(ArgS(args, i));
     bool remaining_args = args.size() - i - 1 > 0;
 
     if (remaining_args) {
@@ -2186,8 +2183,8 @@ void StreamFamily::XGroup(CmdArgList args, ConnectionContext* cntx) {
 
 void StreamFamily::XInfo(CmdArgList args, ConnectionContext* cntx) {
   auto* rb = static_cast<RedisReplyBuilder*>(cntx->reply_builder());
-  ToUpper(&args[0]);
-  string_view sub_cmd = ArgS(args, 0);
+  string sub_cmd = absl::AsciiStrToUpper(ArgS(args, 0));
+
   if (sub_cmd == "HELP") {
     string_view help_arr[] = {"CONSUMERS <key> <groupname>",
                               "    Show consumers of <groupname>.",
@@ -2254,15 +2251,13 @@ void StreamFamily::XInfo(CmdArgList args, ConnectionContext* cntx) {
 
       if (args.size() >= 3) {
         full = 1;
-        ToUpper(&args[2]);
-        string_view full_arg = ArgS(args, 2);
+        string full_arg = absl::AsciiStrToUpper(ArgS(args, 2));
         if (full_arg != "FULL") {
           return cntx->SendError(
               "unknown subcommand or wrong number of arguments for 'STREAM'. Try XINFO HELP.");
         }
         if (args.size() > 3) {
-          ToUpper(&args[3]);
-          string_view count_arg = ArgS(args, 3);
+          string count_arg = absl::AsciiStrToUpper(ArgS(args, 3));
           string_view count_value_arg = ArgS(args, 4);
           if (count_arg != "COUNT") {
             return cntx->SendError(
@@ -2447,8 +2442,7 @@ void StreamFamily::XLen(CmdArgList args, ConnectionContext* cntx) {
 
 bool ParseXpendingOptions(CmdArgList& args, PendingOpts& opts, ConnectionContext* cntx) {
   size_t id_indx = 0;
-  ToUpper(&args[id_indx]);
-  string_view arg = ArgS(args, id_indx);
+  string arg = absl::AsciiStrToUpper(ArgS(args, id_indx));
 
   if (arg == "IDLE" && args.size() > 4) {
     id_indx++;
@@ -2579,8 +2573,7 @@ std::optional<ReadOpts> ParseReadArgsOrReply(CmdArgList args, bool read_group,
   size_t id_indx = 0;
 
   if (opts.read_group) {
-    ToUpper(&args[id_indx]);
-    string_view arg = ArgS(args, id_indx);
+    string arg = absl::AsciiStrToUpper(ArgS(args, id_indx));
 
     if (arg.size() - 1 < 2) {
       cntx->SendError(kSyntaxErr);
@@ -2599,8 +2592,7 @@ std::optional<ReadOpts> ParseReadArgsOrReply(CmdArgList args, bool read_group,
   }
 
   for (; id_indx < args.size(); ++id_indx) {
-    ToUpper(&args[id_indx]);
-    string_view arg = ArgS(args, id_indx);
+    string arg = absl::AsciiStrToUpper(ArgS(args, id_indx));
 
     bool remaining_args = args.size() - id_indx - 1 > 0;
     if (arg == "BLOCK" && remaining_args) {
@@ -3078,8 +3070,8 @@ void StreamFamily::XRangeGeneric(CmdArgList args, bool is_rev, ConnectionContext
     if (args.size() != 5) {
       return cntx->SendError(WrongNumArgsError("XRANGE"), kSyntaxErrType);
     }
-    ToUpper(&args[3]);
-    string_view opt = ArgS(args, 3);
+
+    string opt = absl::AsciiStrToUpper(ArgS(args, 3));
     string_view val = ArgS(args, 4);
 
     if (opt != "COUNT" || !absl::SimpleAtoi(val, &range_opts.count)) {
@@ -3159,8 +3151,8 @@ void StreamFamily::XAutoClaim(CmdArgList args, ConnectionContext* cntx) {
   opts.start = rs.parsed_id.val;
 
   for (size_t i = 5; i < args.size(); ++i) {
-    ToUpper(&args[i]);
-    string_view arg = ArgS(args, i);
+    string arg = absl::AsciiStrToUpper(ArgS(args, i));
+
     bool remaining_args = args.size() - i - 1 > 0;
 
     if (remaining_args) {

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1106,8 +1106,8 @@ OpResult<unsigned> ParseAggregate(CmdArgList args, bool store, SetOpArgs* op_arg
     return OpStatus::SYNTAX_ERR;
   }
 
-  ToUpper(&args[1]);
-  auto filled = FillAggType(ArgS(args, 1), op_args);
+  string agg_type = absl::AsciiStrToUpper(ArgS(args, 1));
+  auto filled = FillAggType(agg_type, op_args);
   if (!filled) {
     return filled.status();
   }
@@ -1156,8 +1156,7 @@ OpResult<SetOpArgs> ParseSetOpArgs(CmdArgList args, bool store) {
   DCHECK_LE(opt_args_start, args.size());  // Checked inside DetermineKeys
 
   for (size_t i = opt_args_start; i < args.size(); ++i) {
-    ToUpper(&args[i]);
-    string_view arg = ArgS(args, i);
+    string arg = absl::AsciiStrToUpper(ArgS(args, i));
     if (arg == "WEIGHTS") {
       auto parsed_cnt = ParseWeights(args.subspan(i), &op_args);
       if (!parsed_cnt) {
@@ -1815,9 +1814,7 @@ void ZSetFamily::ZAdd(CmdArgList args, ConnectionContext* cntx) {
   ZParams zparams;
   size_t i = 1;
   for (; i < args.size() - 1; ++i) {
-    ToUpper(&args[i]);
-
-    string_view cur_arg = ArgS(args, i);
+    string cur_arg = absl::AsciiStrToUpper(ArgS(args, i));
 
     if (cur_arg == "XX") {
       zparams.flags |= ZADD_IN_XX;  // update only
@@ -2560,9 +2557,7 @@ void ZSetFamily::GeoAdd(CmdArgList args, ConnectionContext* cntx) {
   ZParams zparams;
   size_t i = 1;
   for (; i < args.size(); ++i) {
-    ToUpper(&args[i]);
-
-    string_view cur_arg = ArgS(args, i);
+    string cur_arg = absl::AsciiStrToUpper(ArgS(args, i));
 
     if (cur_arg == "XX") {
       zparams.flags |= ZADD_IN_XX;  // update only
@@ -2661,8 +2656,8 @@ void ZSetFamily::GeoPos(CmdArgList args, ConnectionContext* cntx) {
 void ZSetFamily::GeoDist(CmdArgList args, ConnectionContext* cntx) {
   double distance_multiplier = 1;
   if (args.size() == 4) {
-    ToUpper(&args[3]);
-    string_view unit = ArgS(args, 3);
+    string unit = absl::AsciiStrToUpper(ArgS(args, 3));
+
     distance_multiplier = ExtractUnit(unit);
     args.remove_suffix(1);
     if (distance_multiplier < 0) {
@@ -2933,9 +2928,8 @@ void ZSetFamily::GeoSearch(CmdArgList args, ConnectionContext* cntx) {
   bool by_set = false;
 
   for (size_t i = 1; i < args.size(); ++i) {
-    ToUpper(&args[i]);
+    string cur_arg = absl::AsciiStrToUpper(ArgS(args, i));
 
-    string_view cur_arg = ArgS(args, i);
     if (cur_arg == "FROMMEMBER") {
       if (from_set) {
         return cntx->SendError(kFromMemberLonglatErr);
@@ -3071,9 +3065,8 @@ void ZSetFamily::GeoRadiusByMember(CmdArgList args, ConnectionContext* cntx) {
   shape.type = CIRCULAR_TYPE;
 
   for (size_t i = 4; i < args.size(); ++i) {
-    ToUpper(&args[i]);
+    string cur_arg = absl::AsciiStrToUpper(ArgS(args, i));
 
-    string_view cur_arg = ArgS(args, i);
     if (cur_arg == "ASC") {
       if (geo_ops.sorting != Sorting::kUnsorted) {
         return cntx->SendError(kAscDescErr);


### PR DESCRIPTION
We would like to stop passing MutableSlice as arguments and removing ToUpper is the first step to it.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->