### PR TITLE
[do not review] chore: remove optional flush to sink from journal

### DIFF
--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -514,7 +514,7 @@ void WriteFlushSlotsToJournal(const SlotRanges& slot_ranges) {
     // TODO: Break slot migration upon FLUSHSLOTS
     journal->RecordEntry(/* txid= */ 0, journal::Op::COMMAND, /* dbid= */ 0,
                          /* shard_cnt= */ shard_set->size(), nullopt,
-                         Payload("DFLYCLUSTER", args_view), false);
+                         Payload("DFLYCLUSTER", args_view));
   };
   shard_set->pool()->AwaitFiberOnAll(std::move(cb));
 }

--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -432,26 +432,22 @@ ThreadLocalMutex::~ThreadLocalMutex() {
 }
 
 void ThreadLocalMutex::lock() {
-  if (serialization_max_chunk_size != 0) {
-    DCHECK_EQ(EngineShard::tlocal(), shard_);
-    util::fb2::NoOpLock noop_lk_;
-    if (locked_fiber_ != nullptr) {
-      DCHECK(util::fb2::detail::FiberActive() != locked_fiber_);
-    }
-    cond_var_.wait(noop_lk_, [this]() { return !flag_; });
-    flag_ = true;
-    DCHECK_EQ(locked_fiber_, nullptr);
-    locked_fiber_ = util::fb2::detail::FiberActive();
+  DCHECK_EQ(EngineShard::tlocal(), shard_);
+  util::fb2::NoOpLock noop_lk_;
+  if (locked_fiber_ != nullptr) {
+    DCHECK(util::fb2::detail::FiberActive() != locked_fiber_);
   }
+  cond_var_.wait(noop_lk_, [this]() { return !flag_; });
+  flag_ = true;
+  DCHECK_EQ(locked_fiber_, nullptr);
+  locked_fiber_ = util::fb2::detail::FiberActive();
 }
 
 void ThreadLocalMutex::unlock() {
-  if (serialization_max_chunk_size != 0) {
-    DCHECK_EQ(EngineShard::tlocal(), shard_);
-    flag_ = false;
-    cond_var_.notify_one();
-    locked_fiber_ = nullptr;
-  }
+  DCHECK_EQ(EngineShard::tlocal(), shard_);
+  flag_ = false;
+  cond_var_.notify_one();
+  locked_fiber_ = nullptr;
 }
 
 }  // namespace dfly

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -78,7 +78,7 @@ bool WaitReplicaFlowToCatchup(absl::Time end_time, const DflyCmd::ReplicaInfo* r
   // We don't want any writes to the journal after we send the `PING`,
   // and expirations could ruin that.
   namespaces.GetDefaultNamespace().GetDbSlice(shard->shard_id()).SetExpireAllowed(false);
-  shard->journal()->RecordEntry(0, journal::Op::PING, 0, 0, nullopt, {}, true);
+  shard->journal()->RecordEntry(0, journal::Op::PING, 0, 0, nullopt, {});
 
   const FlowInfo* flow = &replica->flows[shard->shard_id()];
   while (flow->last_acked_lsn < shard->journal()->GetLsn()) {

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -681,12 +681,6 @@ void EngineShard::RetireExpiredAndEvict() {
                                        eviction_redline - db_slice.memory_budget());
     }
   }
-
-  // Journal entries for expired entries are not writen to socket in the loop above.
-  // Trigger write to socket when loop finishes.
-  if (auto journal = EngineShard::tlocal()->journal(); journal) {
-    TriggerJournalWriteToSink();
-  }
 }
 
 void EngineShard::RunPeriodic(std::chrono::milliseconds period_ms,

--- a/src/server/journal/journal.cc
+++ b/src/server/journal/journal.cc
@@ -84,8 +84,8 @@ LSN Journal::GetLsn() const {
 }
 
 void Journal::RecordEntry(TxId txid, Op opcode, DbIndex dbid, unsigned shard_cnt,
-                          std::optional<cluster::SlotId> slot, Entry::Payload payload, bool await) {
-  journal_slice.AddLogRecord(Entry{txid, opcode, dbid, shard_cnt, slot, std::move(payload)}, await);
+                          std::optional<cluster::SlotId> slot, Entry::Payload payload) {
+  journal_slice.AddLogRecord(Entry{txid, opcode, dbid, shard_cnt, slot, std::move(payload)});
 }
 
 }  // namespace journal

--- a/src/server/journal/journal.h
+++ b/src/server/journal/journal.h
@@ -35,7 +35,7 @@ class Journal {
   LSN GetLsn() const;
 
   void RecordEntry(TxId txid, Op opcode, DbIndex dbid, unsigned shard_cnt,
-                   std::optional<cluster::SlotId> slot, Entry::Payload payload, bool await);
+                   std::optional<cluster::SlotId> slot, Entry::Payload payload);
 
  private:
   mutable util::fb2::Mutex state_mu_;

--- a/src/server/journal/journal_slice.h
+++ b/src/server/journal/journal_slice.h
@@ -37,7 +37,7 @@ class JournalSlice {
     return slice_index_ != UINT32_MAX;
   }
 
-  void AddLogRecord(const Entry& entry, bool await);
+  void AddLogRecord(const Entry& entry);
 
   // Register a callback that will be called every time a new entry is
   // added to the journal.

--- a/src/server/journal/types.h
+++ b/src/server/journal/types.h
@@ -97,7 +97,7 @@ struct JournalItem {
   std::optional<cluster::SlotId> slot;
 };
 
-using ChangeCallback = std::function<void(const JournalItem&, bool await)>;
+using ChangeCallback = std::function<void(const JournalItem&)>;
 
 }  // namespace journal
 }  // namespace dfly

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -407,8 +407,6 @@ void SliceSnapshot::OnJournalEntry(const journal::JournalItem& item) {
     serializer_->WriteJournalEntry(item.data);
   }
 
-  // This is the only place that flushes in streaming mode
-  // once the iterate buckets fiber finished.
   PushSerializedToChannel(false);
 }
 

--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -112,7 +112,7 @@ class SliceSnapshot {
   void OnDbChange(DbIndex db_index, const DbSlice::ChangeReq& req);
 
   // Journal listener
-  void OnJournalEntry(const journal::JournalItem& item, bool unused_await_arg);
+  void OnJournalEntry(const journal::JournalItem& item);
 
   // Close dest channel if not closed yet.
   void CloseRecordChannel();

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1370,19 +1370,10 @@ void Transaction::LogAutoJournalOnShard(EngineShard* shard, RunnableResult resul
     return;
 
   if (result.status != OpStatus::OK) {
-    // We log NOOP even for NO_AUTOJOURNAL commands because the non-success status could have been
-    // due to OOM in a single shard, while other shards succeeded
-    journal->RecordEntry(txid_, journal::Op::NOOP, db_index_, unique_shard_cnt_,
-                         unique_slot_checker_.GetUniqueSlotId(), journal::Entry::Payload{}, true);
     return;
   }
 
-  // If autojournaling was disabled and not re-enabled the callback is writing to journal.
-  // We do not allow preemption in callbacks and therefor the call to RecordJournal from
-  // from callbacks does not allow await.
-  // To make sure we flush the changes to sync we call TriggerJournalWriteToSink here.
   if ((cid_->opt_mask() & CO::NO_AUTOJOURNAL) && !re_enabled_auto_journal_) {
-    TriggerJournalWriteToSink();
     return;
   }
 
@@ -1396,15 +1387,15 @@ void Transaction::LogAutoJournalOnShard(EngineShard* shard, RunnableResult resul
   }
   // Record to journal autojournal commands, here we allow await which anables writing to sync
   // the journal change.
-  LogJournalOnShard(shard, std::move(entry_payload), unique_shard_cnt_, true);
+  LogJournalOnShard(shard, std::move(entry_payload), unique_shard_cnt_);
 }
 
 void Transaction::LogJournalOnShard(EngineShard* shard, journal::Entry::Payload&& payload,
-                                    uint32_t shard_cnt, bool allow_await) const {
+                                    uint32_t shard_cnt) const {
   auto journal = shard->journal();
   CHECK(journal);
   journal->RecordEntry(txid_, journal::Op::COMMAND, db_index_, shard_cnt,
-                       unique_slot_checker_.GetUniqueSlotId(), std::move(payload), allow_await);
+                       unique_slot_checker_.GetUniqueSlotId(), std::move(payload));
 }
 
 void Transaction::ReviveAutoJournal() {

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -338,8 +338,8 @@ class Transaction {
   void PrepareMultiForScheduleSingleHop(Namespace* ns, ShardId sid, DbIndex db, CmdArgList args);
 
   // Write a journal entry to a shard journal with the given payload.
-  void LogJournalOnShard(EngineShard* shard, journal::Entry::Payload&& payload, uint32_t shard_cnt,
-                         bool allow_await) const;
+  void LogJournalOnShard(EngineShard* shard, journal::Entry::Payload&& payload,
+                         uint32_t shard_cnt) const;
 
   // Re-enable auto journal for commands marked as NO_AUTOJOURNAL. Call during setup.
   void ReviveAutoJournal();

--- a/src/server/tx_base.cc
+++ b/src/server/tx_base.cc
@@ -53,26 +53,20 @@ size_t ShardArgs::Size() const {
 void RecordJournal(const OpArgs& op_args, string_view cmd, const ShardArgs& args,
                    uint32_t shard_cnt) {
   VLOG(2) << "Logging command " << cmd << " from txn " << op_args.tx->txid();
-  op_args.tx->LogJournalOnShard(op_args.shard, Payload(cmd, args), shard_cnt, false);
+  op_args.tx->LogJournalOnShard(op_args.shard, Payload(cmd, args), shard_cnt);
 }
 
 void RecordJournal(const OpArgs& op_args, std::string_view cmd, facade::ArgSlice args,
                    uint32_t shard_cnt) {
   VLOG(2) << "Logging command " << cmd << " from txn " << op_args.tx->txid();
-  op_args.tx->LogJournalOnShard(op_args.shard, Payload(cmd, args), shard_cnt, false);
+  op_args.tx->LogJournalOnShard(op_args.shard, Payload(cmd, args), shard_cnt);
 }
 
 void RecordExpiry(DbIndex dbid, string_view key) {
   auto journal = EngineShard::tlocal()->journal();
   CHECK(journal);
   journal->RecordEntry(0, journal::Op::EXPIRED, dbid, 1, cluster::KeySlot(key),
-                       Payload("DEL", ArgSlice{key}), false);
-}
-
-void TriggerJournalWriteToSink() {
-  auto journal = EngineShard::tlocal()->journal();
-  CHECK(journal);
-  journal->RecordEntry(0, journal::Op::NOOP, 0, 0, nullopt, {}, true);
+                       Payload("DEL", ArgSlice{key}));
 }
 
 std::ostream& operator<<(std::ostream& os, ArgSlice list) {

--- a/src/server/tx_base.h
+++ b/src/server/tx_base.h
@@ -226,10 +226,6 @@ void RecordJournal(const OpArgs& op_args, std::string_view cmd, ArgSlice args,
 // key.
 void RecordExpiry(DbIndex dbid, std::string_view key);
 
-// Trigger journal write to sink, no journal record will be added to journal.
-// Must be called from shard thread of journal to sink.
-void TriggerJournalWriteToSink();
-
 std::ostream& operator<<(std::ostream& os, ArgSlice list);
 
 }  // namespace dfly


### PR DESCRIPTION
Big value serialization introduced preemption on journal flows. This PR generalizes this by removing the optional flush to channel on journal writes.

Resolves #3845