### PR TITLE
fix: Do not kill Dragonfly on failed `DFLY LOAD`

### DIFF
--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -331,7 +331,7 @@ class ServerFamily {
   bool DoAuth(ConnectionContext* cntx, std::string_view username, std::string_view password) const;
 
   util::fb2::Fiber snapshot_schedule_fb_;
-  std::optional<util::fb2::Future<GenericError>> load_result_;
+  util::fb2::Fiber load_fiber_;
 
   Service& service_;
 


### PR DESCRIPTION
Today, some of the failures to load an RDB file passed via `--dbfilename` cause Dragonfly to terminate with an error code. This is ok and works as expected.

The problem is that the same code path is used for `DFLY LOAD`, which means that if there's an error loading the file (such as corrupted file), Dragonfly will exit instead of returning an error code to the client.

This change fixes that, by only exiting in the code path which loads on init.

Note: failure to load an RDB will have meant that the entire data store was flushed (like with `FLUSHALL`), so this is not an atomic operation.

Note to reviewer: apparently we can't call `Future::Get()` more than once, as the first call resets the state of the future and drops the previously saved value, so we use a Fiber here instead.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->