### PR TITLE
fix(cluster): fix unknown migration error

### DIFF
--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -871,7 +871,7 @@ void ClusterFamily::InitMigration(CmdArgList args, ConnectionContext* cntx) {
                       });
   if (!found) {
     VLOG(1) << "Unrecognized incoming migration from " << source_id;
-    return cntx->SendError(OutgoingMigration::kUnknownMigration);
+    return cntx->SendSimpleString(OutgoingMigration::kUnknownMigration);
   }
 
   VLOG(1) << "Init migration " << source_id;


### PR DESCRIPTION
We're getting redundant errors logs of `outgoing_slot_migration.cc:184] ERR UNKNOWN_MIGRATION` (causing alerts)

Looks like this is expected to be ignored. `ClusterFamily::InitMigration` returns `SendError(OutgoingMigration::kUnknownMigration)`, and `OutgoingMigration::SyncFb` ignores `CheckRespIsSimpleReply(kUnknownMigration)`, which doesn't match

Therefore updating `ClusterFamily::InitMigration` to respond with a simple string `SendSimpleString(OutgoingMigration::kUnknownMigration)` instead so they match. Alternatively `ClusterFamily::InitMigration` could check for an error response (I'm not sure which side is right)?