### PR TITLE
chore: relax assertion in test_noreply_pipeline

### DIFF
--- a/tests/dragonfly/pymemcached_test.py
+++ b/tests/dragonfly/pymemcached_test.py
@@ -48,7 +48,6 @@ def test_basic(memcached_client: MCClient):
 # Noreply (and pipeline) tests
 
 
-@pytest.mark.skip("Flaky")
 @dfly_args(DEFAULT_ARGS)
 def test_noreply_pipeline(df_server: DflyInstance, memcached_client: MCClient):
     """
@@ -68,7 +67,7 @@ def test_noreply_pipeline(df_server: DflyInstance, memcached_client: MCClient):
     assert memcached_client.get_many(keys) == {k: v.encode() for k, v in zip(keys, values)}
 
     info = Redis(port=df_server.port).info()
-    assert info["total_pipelined_commands"] > len(keys) / 6  # sometimes CI is slow
+    assert info["total_pipelined_commands"] > 0  # sometimes CI is slow
 
 
 @dfly_args(DEFAULT_ARGS)


### PR DESCRIPTION
This test is flaky because it depends on how fast the client will push the commands to dragonfly. Unfortunately, the problem here is that the CI can become slow (because we might run multiple regression tests on different branches) which will cause the assertion to fail. Since we don't really test here for regression (that would be the minimum amount of pipeline commands for X) but rather that we do actually pipeline I relaxed the constraints of the assertion to "at least have one pipelined command". This should make the test pass on cases where the CI becomes slow enough for the regression to show up.

Should resolve: #3896