### PR TITLE
fix!: fix BITPOS command responses (#3893)

### DIFF
--- a/src/server/bitops_family_test.cc
+++ b/src/server/bitops_family_test.cc
@@ -555,8 +555,15 @@ TEST_F(BitOpsFamilyTest, BitPos) {
   EXPECT_EQ(-1, CheckedInt({"bitpos", "empty", "0"}));
   EXPECT_EQ(-1, CheckedInt({"bitpos", "empty", "0", "1"}));
 
-  // Non-existent key should be treated like an empty string.
-  EXPECT_EQ(-1, CheckedInt({"bitpos", "d", "0"}));
+  // Non-existent key should be treated like padded with zeros string.
+  EXPECT_EQ(-1, CheckedInt({"bitpos", "d", "1"}));
+  EXPECT_EQ(0, CheckedInt({"bitpos", "d", "0"}));
+
+  // Make sure we accept only 0 and 1 for the bit mode arguement.
+  const auto argument_must_be_0_or_1_error = ErrArg("ERR The bit argument must be 1 or 0");
+  ASSERT_THAT(Run({"bitpos", "d", "2"}), argument_must_be_0_or_1_error);
+  ASSERT_THAT(Run({"bitpos", "d", "42"}), argument_must_be_0_or_1_error);
+  ASSERT_THAT(Run({"bitpos", "d", "-1"}), argument_must_be_0_or_1_error);
 }
 
 TEST_F(BitOpsFamilyTest, BitFieldParsing) {


### PR DESCRIPTION
- BITPOS returns 0 for non-existent keys according to Redis's implementation.
- BITPOS allows only 0 and 1 as the bit mode argument.

NOTE: I've marked this commit as breaking change because it changes BITPOS's responses which might be used by users.

Addresses #3893

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->