### PR TITLE
fix: prevents Dragonfly from blocking in epoll during snapshotting

### DIFF
--- a/src/server/detail/save_stages_controller.cc
+++ b/src/server/detail/save_stages_controller.cc
@@ -344,6 +344,7 @@ void SaveStagesController::InitResources() {
 GenericError SaveStagesController::FinalizeFileMovement() {
   if (is_cloud_)
     return {};
+  DVLOG(1) << "FinalizeFileMovement start";
 
   // If the shared_err is set, the snapshot saving failed
   bool has_error = bool(shared_err_);
@@ -358,6 +359,7 @@ GenericError SaveStagesController::FinalizeFileMovement() {
     if (ec)
       break;
   }
+  DVLOG(1) << "FinalizeFileMovement end";
   return GenericError(ec);
 }
 

--- a/src/server/detail/snapshot_storage.cc
+++ b/src/server/detail/snapshot_storage.cc
@@ -55,12 +55,15 @@ FileSnapshotStorage::FileSnapshotStorage(fb2::FiberQueueThreadPool* fq_threadpoo
 io::Result<std::pair<io::Sink*, uint8_t>, GenericError> FileSnapshotStorage::OpenWriteFile(
     const std::string& path) {
   if (fq_threadpool_) {  // EPOLL
-    auto res = OpenFiberWriteFile(path, fq_threadpool_);
+    FiberWriteOptions opts;
+    opts.direct = true;
+
+    auto res = OpenFiberWriteFile(path, fq_threadpool_, opts);
     if (!res) {
       return nonstd::make_unexpected(GenericError(res.error(), "Couldn't open file for writing"));
     }
 
-    return std::pair(*res, FileType::FILE);
+    return std::pair(*res, FileType::FILE | FileType::DIRECT);
   } else {
 #ifdef __linux__
     auto res = fb2::OpenLinux(path, kRdbWriteFlags, 0666);

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -62,7 +62,6 @@ extern "C" {
 #include "strings/human_readable.h"
 #include "util/accept_server.h"
 #include "util/aws/aws.h"
-#include "util/fibers/fiber_file.h"
 
 using namespace std;
 
@@ -1654,6 +1653,7 @@ GenericError ServerFamily::WaitUntilSaveFinished(Transaction* trans, bool ignore
   save_controller_->WaitAllSnapshots();
   detail::SaveInfo save_info;
 
+  VLOG(1) << "Before WaitUntilSaveFinished::Finalize";
   {
     util::fb2::LockGuard lk(save_mu_);
     save_info = save_controller_->Finalize();

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -4,7 +4,7 @@ pytoml==0.1.21
 PyYAML==6.0
 railroad==0.5.0
 redis==4.4.4
-requests==2.28.1
+requests>=2.32.0
 aiocsv==1.2.3
 aiofiles==22.1.0
 numpy==1.24.1


### PR DESCRIPTION
The problem - we used file write in non-direct mode when writing snapshots in epoll mode. As a result - lots of data was cached into OS memory. But then during the rename operation, when we rename "xxx.dfs.tmp" into "xxx.dfs", the OS flushes the file caches and the thread is stuck in OS system call rename for a long time.

The fix - to use DIRECT mode and to avoid caching the data into OS caches at all.

Fixes #3895

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->