### PR TITLE
fix: Support replicating Valkey and Redis 7.2

### DIFF
--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -3,6 +3,7 @@ import os
 import threading
 import time
 import subprocess
+import random
 import aiohttp
 import logging
 from dataclasses import dataclass
@@ -455,8 +456,9 @@ class RedisServer:
         self.proc = None
 
     def start(self, **kwargs):
+        servers = ["redis-server-6.2.11", "redis-server-7.2.2", "valkey-server-8.0.1"]
         command = [
-            "redis-server-6.2.11",
+            random.choice(servers),
             f"--port {self.port}",
             "--save ''",
             "--appendonly no",


### PR DESCRIPTION
Until now, we only tested Dragonfly against Redis 6.2.  It appears that something has changed in the way Redis sends stable sync commands, and now they also forward `MULTI` and `EXEC` as part of their replication.

Since we do not allow all commands to run under `MULTI`/`EXEC`, specifically `SELECT`, a Dragonfly replica of such servers failed these commands and became inconsistent with the data on the master.

The proposed fix is to simply ignore (i.e. not execute) `MULTI`/`EXEC` coming from a Redis/Valkey master, and run the commands within those transactions individually, like we do for other transactions.

To test this we randomly choose a redis/valkey server based on 3 available installed binaries and test against them.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->