### PR TITLE
fix: Fix `test_flushall_in_full_sync`

### DIFF
--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1107,7 +1107,7 @@ async def test_flushall_in_full_sync(df_factory):
     c_replica = replica.client()
 
     # Fill master with test data
-    seeder = SeederV2(key_target=30_000)
+    seeder = SeederV2(key_target=100_000)
     await seeder.run(c_master, target_deviation=0.1)
 
     # Start replication and wait for full sync


### PR DESCRIPTION
This test failed in CI many times. The issue was that we reach stable sync too quickly, and miss the full sync stage.

I changed the seeder to add 100k (instead of 30k) keys for the stage to take longer.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->