### PR TITLE
chore: ignore applying the same cluster config twice

### DIFF
--- a/src/server/cluster/cluster_config.cc
+++ b/src/server/cluster/cluster_config.cc
@@ -221,7 +221,7 @@ optional<std::vector<MigrationInfo>> ParseMigrations(const JsonType& json) {
 }
 
 optional<ClusterShardInfos> BuildClusterConfigFromJson(const JsonType& json) {
-  ClusterShardInfos config;
+  std::vector<ClusterShardInfo> config;
 
   if (!json.is_array()) {
     LOG(WARNING) << kInvalidConfigPrefix << "not an array " << json;
@@ -271,7 +271,7 @@ optional<ClusterShardInfos> BuildClusterConfigFromJson(const JsonType& json) {
     config.push_back(std::move(shard));
   }
 
-  return config;
+  return ClusterShardInfos(config);
 }
 }  // namespace
 

--- a/src/server/cluster/cluster_defs.cc
+++ b/src/server/cluster/cluster_defs.cc
@@ -49,6 +49,26 @@ std::string MigrationInfo::ToString() const {
                       slot_ranges.ToString(), ")");
 }
 
+bool ClusterShardInfo::operator==(const ClusterShardInfo& r) const {
+  if (slot_ranges == r.slot_ranges && master == r.master) {
+    auto lreplicas = replicas;
+    auto lmigrations = migrations;
+    auto rreplicas = r.replicas;
+    auto rmigrations = r.migrations;
+    std::sort(lreplicas.begin(), lreplicas.end());
+    std::sort(lmigrations.begin(), lmigrations.end());
+    std::sort(rreplicas.begin(), rreplicas.end());
+    std::sort(rmigrations.begin(), rmigrations.end());
+    return lreplicas == rreplicas && lmigrations == rmigrations;
+  }
+  return false;
+}
+
+ClusterShardInfos::ClusterShardInfos(std::vector<ClusterShardInfo> infos)
+    : infos_(std::move(infos)) {
+  std::sort(infos_.begin(), infos_.end());
+}
+
 namespace {
 enum class ClusterMode {
   kUninitialized,

--- a/src/server/cluster/cluster_defs.h
+++ b/src/server/cluster/cluster_defs.h
@@ -90,6 +90,10 @@ struct ClusterNodeInfo {
   bool operator==(const ClusterNodeInfo& r) const noexcept {
     return port == r.port && ip == r.ip && id == r.id;
   }
+
+  bool operator<(const ClusterNodeInfo& r) const noexcept {
+    return id < r.id;
+  }
 };
 
 struct MigrationInfo {
@@ -100,6 +104,10 @@ struct MigrationInfo {
     return node_info == r.node_info && slot_ranges == r.slot_ranges;
   }
 
+  bool operator<(const MigrationInfo& r) const noexcept {
+    return node_info < r.node_info;
+  }
+
   std::string ToString() const;
 };
 
@@ -108,9 +116,48 @@ struct ClusterShardInfo {
   ClusterNodeInfo master;
   std::vector<ClusterNodeInfo> replicas;
   std::vector<MigrationInfo> migrations;
+
+  bool operator==(const ClusterShardInfo& r) const;
+
+  bool operator<(const ClusterShardInfo& r) const noexcept {
+    return master < r.master;
+  }
 };
 
-using ClusterShardInfos = std::vector<ClusterShardInfo>;
+class ClusterShardInfos {
+ public:
+  ClusterShardInfos() = default;
+  ClusterShardInfos(std::vector<ClusterShardInfo> infos);
+  ClusterShardInfos(ClusterShardInfo info) : infos_({info}) {
+  }
+
+  auto begin() const noexcept {
+    return infos_.cbegin();
+  }
+
+  auto end() const noexcept {
+    return infos_.cend();
+  }
+
+  auto size() const noexcept {
+    return infos_.size();
+  }
+
+  bool empty() const noexcept {
+    return infos_.empty();
+  }
+
+  bool operator==(const ClusterShardInfos& r) const noexcept {
+    return infos_ == r.infos_;
+  }
+
+  bool operator!=(const ClusterShardInfos& r) const noexcept {
+    return infos_ != r.infos_;
+  }
+
+ private:
+  std::vector<ClusterShardInfo> infos_;
+};
 
 // MigrationState constants are ordered in state changing order
 enum class MigrationState : uint8_t {

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -530,6 +530,8 @@ void ClusterFamily::DflyClusterConfig(CmdArgList args, ConnectionContext* cntx) 
   if (new_config == nullptr) {
     LOG(WARNING) << "Can't set cluster config";
     return cntx->SendError("Invalid cluster configuration.");
+  } else if (tl_cluster_config && tl_cluster_config->GetConfig() == new_config->GetConfig()) {
+    return cntx->SendOk();
   }
 
   PreparedToRemoveOutgoingMigrations outgoing_migrations;  // should be removed without mutex lock


### PR DESCRIPTION
fixes: #3920

added comparison for cluster config and if the new config is equal to the previous one, we do nothing