### PR TITLE
chore: pass SinkReplyBuilder and Transaction explicitly. Part1

### DIFF
--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -85,12 +85,13 @@ SinkReplyBuilder::MGetResponse::~MGetResponse() {
   }
 }
 
-SinkReplyBuilder::SinkReplyBuilder(::io::Sink* sink)
+SinkReplyBuilder::SinkReplyBuilder(::io::Sink* sink, Type t)
     : sink_(sink),
       should_batch_(false),
       should_aggregate_(false),
       has_replied_(true),
-      send_active_(false) {
+      send_active_(false),
+      type_(t) {
 }
 
 void SinkReplyBuilder::CloseConnection() {
@@ -340,7 +341,7 @@ void SinkReplyBuilder2::NextVec(std::string_view str) {
   vecs_.push_back(iovec{const_cast<char*>(str.data()), str.size()});
 }
 
-MCReplyBuilder::MCReplyBuilder(::io::Sink* sink) : SinkReplyBuilder(sink), noreply_(false) {
+MCReplyBuilder::MCReplyBuilder(::io::Sink* sink) : SinkReplyBuilder(sink, MC), noreply_(false) {
 }
 
 void MCReplyBuilder::SendSimpleString(std::string_view str) {
@@ -466,7 +467,7 @@ char* RedisReplyBuilder::FormatDouble(double val, char* dest, unsigned dest_len)
   return sb.Finalize();
 }
 
-RedisReplyBuilder::RedisReplyBuilder(::io::Sink* sink) : SinkReplyBuilder(sink) {
+RedisReplyBuilder::RedisReplyBuilder(::io::Sink* sink) : SinkReplyBuilder(sink, REDIS) {
 }
 
 void RedisReplyBuilder::SetResp3(bool is_resp3) {

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -67,7 +67,9 @@ class SinkReplyBuilder {
   SinkReplyBuilder(const SinkReplyBuilder&) = delete;
   void operator=(const SinkReplyBuilder&) = delete;
 
-  explicit SinkReplyBuilder(::io::Sink* sink);
+  enum Type { REDIS, MC };
+
+  explicit SinkReplyBuilder(::io::Sink* sink, Type t);
 
   virtual ~SinkReplyBuilder() {
   }
@@ -156,6 +158,10 @@ class SinkReplyBuilder {
     return std::exchange(last_error_, std::string{});
   }
 
+  Type type() const {
+    return type_;
+  }
+
  protected:
   void SendRaw(std::string_view str);  // Sends raw without any formatting.
 
@@ -174,6 +180,7 @@ class SinkReplyBuilder {
   bool should_aggregate_ : 1;
   bool has_replied_ : 1;
   bool send_active_ : 1;
+  Type type_;
 };
 
 // Base class for all reply builders. Offer a simple high level interface for controlling output

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -94,6 +94,22 @@ optional<facade::ErrorReply> CommandId::Validate(CmdArgList tail_args) const {
   return nullopt;
 }
 
+CommandId&& CommandId::SetHandler(Handler2 f) && {
+  handler_ = [f = std::move(f)](CmdArgList args, ConnectionContext* cntx) {
+    f(args, cntx->transaction, cntx->reply_builder());
+  };
+
+  return std::move(*this);
+}
+
+CommandId&& CommandId::SetHandler(Handler3 f) && {
+  handler_ = [f = std::move(f)](CmdArgList args, ConnectionContext* cntx) {
+    f(args, cntx->transaction, cntx->reply_builder(), cntx);
+  };
+
+  return std::move(*this);
+}
+
 CommandRegistry::CommandRegistry() {
   vector<string> rename_command = GetFlag(FLAGS_rename_command);
 

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -14,10 +14,14 @@
 #include "base/function2.hpp"
 #include "facade/command_id.h"
 
+namespace facade {
+class SinkReplyBuilder;
+}  // namespace facade
+
 namespace dfly {
 
 class ConnectionContext;
-
+class Transaction;
 namespace CO {
 
 enum CommandOpt : uint32_t {
@@ -117,6 +121,15 @@ class CommandId : public facade::CommandId {
     handler_ = std::move(f);
     return std::move(*this);
   }
+
+  using Handler2 =
+      fu2::function_base<true, true, fu2::capacity_default, false, false,
+                         void(CmdArgList, Transaction*, facade::SinkReplyBuilder*) const>;
+  using Handler3 = fu2::function_base<true, true, fu2::capacity_default, false, false,
+                                      void(CmdArgList, Transaction*, facade::SinkReplyBuilder*,
+                                           ConnectionContext*) const>;
+  CommandId&& SetHandler(Handler2 f) &&;
+  CommandId&& SetHandler(Handler3 f) &&;
 
   CommandId&& SetValidator(ArgValidator f) && {
     validator_ = std::move(f);

--- a/src/server/string_family.h
+++ b/src/server/string_family.h
@@ -6,10 +6,15 @@
 
 #include "facade/facade_types.h"
 
+namespace facade {
+class SinkReplyBuilder;
+}  // namespace facade
+
 namespace dfly {
 
 class ConnectionContext;
 class CommandRegistry;
+class Transaction;
 
 using facade::CmdArgList;
 
@@ -18,30 +23,39 @@ class StringFamily {
   static void Register(CommandRegistry* registry);
 
  private:
-  static void Append(CmdArgList args, ConnectionContext* cntx);
-  static void Decr(CmdArgList args, ConnectionContext* cntx);
-  static void DecrBy(CmdArgList args, ConnectionContext* cntx);
-  static void Get(CmdArgList args, ConnectionContext* cntx);
-  static void GetDel(CmdArgList args, ConnectionContext* cntx);
-  static void GetRange(CmdArgList args, ConnectionContext* cntx);
-  static void GetSet(CmdArgList args, ConnectionContext* cntx);
-  static void GetEx(CmdArgList args, ConnectionContext* cntx);
-  static void Incr(CmdArgList args, ConnectionContext* cntx);
-  static void IncrBy(CmdArgList args, ConnectionContext* cntx);
-  static void IncrByFloat(CmdArgList args, ConnectionContext* cntx);
-  static void MGet(CmdArgList args, ConnectionContext* cntx);
-  static void MSet(CmdArgList args, ConnectionContext* cntx);
-  static void MSetNx(CmdArgList args, ConnectionContext* cntx);
+  using SinkReplyBuilder = facade::SinkReplyBuilder;
 
-  static void Set(CmdArgList args, ConnectionContext* cntx);
-  static void SetEx(CmdArgList args, ConnectionContext* cntx);
-  static void SetNx(CmdArgList args, ConnectionContext* cntx);
-  static void SetRange(CmdArgList args, ConnectionContext* cntx);
-  static void StrLen(CmdArgList args, ConnectionContext* cntx);
-  static void Prepend(CmdArgList args, ConnectionContext* cntx);
-  static void PSetEx(CmdArgList args, ConnectionContext* cntx);
+  static void Append(CmdArgList args, Transaction* tx, SinkReplyBuilder* rb);
+  static void Decr(CmdArgList args, Transaction* tx, SinkReplyBuilder* rb);
+  static void DecrBy(CmdArgList args, Transaction* tx, SinkReplyBuilder* rb);
+  static void Get(CmdArgList args, Transaction* tx, SinkReplyBuilder* rb);
+  static void GetDel(CmdArgList args, Transaction* tx, SinkReplyBuilder* rb,
+                     ConnectionContext* cntx);
+  static void GetRange(CmdArgList args, Transaction* tx, SinkReplyBuilder* rb);
+  static void GetSet(CmdArgList args, Transaction* tx, SinkReplyBuilder* rb,
+                     ConnectionContext* cntx);
+  static void GetEx(CmdArgList args, Transaction* tx, SinkReplyBuilder* rb,
+                    ConnectionContext* cntx);
+  static void Incr(CmdArgList args, Transaction* tx, SinkReplyBuilder* rb);
+  static void IncrBy(CmdArgList args, Transaction* tx, SinkReplyBuilder* rb);
+  static void IncrByFloat(CmdArgList args, Transaction* tx, SinkReplyBuilder* rb);
+  static void MGet(CmdArgList args, Transaction* tx, SinkReplyBuilder* rb, ConnectionContext* cntx);
+  static void MSet(CmdArgList args, Transaction* tx, SinkReplyBuilder* rb, ConnectionContext* cntx);
+  static void MSetNx(CmdArgList args, Transaction* tx, SinkReplyBuilder* rb,
+                     ConnectionContext* cntx);
 
-  static void ClThrottle(CmdArgList args, ConnectionContext* cntx);
+  static void Set(CmdArgList args, Transaction* tx, SinkReplyBuilder* rb, ConnectionContext* cntx);
+  static void SetEx(CmdArgList args, Transaction* tx, SinkReplyBuilder* rb,
+                    ConnectionContext* cntx);
+  static void SetNx(CmdArgList args, Transaction* tx, SinkReplyBuilder* rb,
+                    ConnectionContext* cntx);
+  static void SetRange(CmdArgList args, Transaction* tx, SinkReplyBuilder* rb);
+  static void StrLen(CmdArgList args, Transaction* tx, SinkReplyBuilder* rb);
+  static void Prepend(CmdArgList args, Transaction* tx, SinkReplyBuilder* rb);
+  static void PSetEx(CmdArgList args, Transaction* tx, SinkReplyBuilder* rb,
+                     ConnectionContext* cntx);
+
+  static void ClThrottle(CmdArgList args, Transaction* tx, SinkReplyBuilder* rb);
 };
 
 }  // namespace dfly


### PR DESCRIPTION
For some of our commands we need to inject another transaction and another SinkReplyBuilder. This results into error-prone injections of temporary objects into ConnectionContext. Most commands just need Transaction and SinkReplyBuilder, so lets pass them explicitly. The final goal will be to remove Transaction and reply_builder fields from ConnectionContext.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->