### PR TITLE
feat: track request sizes histograms

### DIFF
--- a/src/facade/facade_types.h
+++ b/src/facade/facade_types.h
@@ -193,6 +193,8 @@ constexpr inline unsigned long long operator""_KB(unsigned long long x) {
 
 extern __thread FacadeStats* tl_facade_stats;
 
+void ResetStats();
+
 }  // namespace facade
 
 namespace std {

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -98,10 +98,6 @@ void SinkReplyBuilder::CloseConnection() {
     ec_ = std::make_error_code(std::errc::connection_aborted);
 }
 
-void SinkReplyBuilder::ResetThreadLocalStats() {
-  tl_facade_stats->reply_stats = {};
-}
-
 void SinkReplyBuilder::Send(const iovec* v, uint32_t len) {
   has_replied_ = true;
   DCHECK(sink_);

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -147,8 +147,6 @@ class SinkReplyBuilder {
     return tl_facade_stats->reply_stats;
   }
 
-  static void ResetThreadLocalStats();
-
   virtual void StartAggregate();
   virtual void StopAggregate();
 
@@ -235,10 +233,6 @@ class SinkReplyBuilder2 {
 
   static const ReplyStats& GetThreadLocalStats() {
     return tl_facade_stats->reply_stats;
-  }
-
-  static void ResetThreadLocalStats() {
-    tl_facade_stats->reply_stats = {};
   }
 
  public:  // High level interface

--- a/src/facade/reply_builder_test.cc
+++ b/src/facade/reply_builder_test.cc
@@ -84,7 +84,7 @@ class RedisReplyBuilderTest : public testing::Test {
   void SetUp() {
     sink_.Clear();
     builder_.reset(new RedisReplyBuilder2(&sink_));
-    SinkReplyBuilder2::ResetThreadLocalStats();
+    ResetStats();
   }
 
   static void SetUpTestSuite() {

--- a/src/server/debugcmd.h
+++ b/src/server/debugcmd.h
@@ -48,6 +48,7 @@ class DebugCmd {
   void Stacktrace();
   void Shards();
   void LogTraffic(CmdArgList);
+  void RecvSize(std::string_view param);
 
   ServerFamily& sf_;
   ConnectionContext* cntx_;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2050,23 +2050,8 @@ void ServerFamily::ResetStat(Namespace* ns) {
   shard_set->pool()->AwaitBrief(
       [registry = service_.mutable_registry(), this, ns](unsigned index, auto*) {
         registry->ResetCallStats(index);
-        SinkReplyBuilder::ResetThreadLocalStats();
-        auto& stats = tl_facade_stats->conn_stats;
-        stats.command_cnt = 0;
-        stats.pipelined_cmd_cnt = 0;
-
         ns->GetCurrentDbSlice().ResetEvents();
-        tl_facade_stats->conn_stats.conn_received_cnt = 0;
-        tl_facade_stats->conn_stats.pipelined_cmd_cnt = 0;
-        tl_facade_stats->conn_stats.command_cnt = 0;
-        tl_facade_stats->conn_stats.io_read_cnt = 0;
-        tl_facade_stats->conn_stats.io_read_bytes = 0;
-
-        tl_facade_stats->reply_stats.io_write_bytes = 0;
-        tl_facade_stats->reply_stats.io_write_cnt = 0;
-        tl_facade_stats->reply_stats.send_stats = {};
-        tl_facade_stats->reply_stats.script_error_count = 0;
-        tl_facade_stats->reply_stats.err_count.clear();
+        facade::ResetStats();
         ServerState::tlocal()->exec_freq_count.clear();
       });
 }


### PR DESCRIPTION
This PR introduces "DEBUG RECVSIZE ENABLE|DISABLE|tid" command that allows tracking of request sizes.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->