### PR TITLE
chore: tune test_rss_used_mem_gap

### DIFF
--- a/tests/dragonfly/memory_test.py
+++ b/tests/dragonfly/memory_test.py
@@ -9,21 +9,24 @@ from . import dfly_args
 @pytest.mark.parametrize(
     "type, keys, val_size, elements",
     [
-        ("JSON", 300_000, 100, 100),
-        ("SET", 500_000, 100, 100),
-        ("HASH", 400_000, 100, 100),
-        ("ZSET", 400_000, 100, 100),
-        ("LIST", 500_000, 100, 100),
-        ("STRING", 6_000_000, 1000, 1),
+        ("JSON", 200_000, 100, 100),
+        ("SET", 280_000, 100, 100),
+        ("HASH", 250_000, 100, 100),
+        ("ZSET", 250_000, 100, 100),
+        ("LIST", 300_000, 100, 100),
+        ("STRING", 3_500_000, 1000, 1),
     ],
 )
 async def test_rss_used_mem_gap(df_factory, type, keys, val_size, elements):
     # Create a Dragonfly and fill it up with `type` until it reaches `min_rss`, then make sure that
     # the gap between used_memory and rss is no more than `max_unaccounted_ratio`.
-    min_rss = 5 * 1024 * 1024 * 1024  # 5gb
+    min_rss = 3 * 1024 * 1024 * 1024  # 3gb
     max_unaccounted = 200 * 1024 * 1024  # 200mb
 
-    df_server = df_factory.create()
+    # We limit to 5gb just in case to sanity check the gh runner. Otherwise, if we ask for too much
+    # memory it might force the gh runner to run out of memory (since OOM killer might not even
+    # get a chance to run).
+    df_server = df_factory.create(maxmemory="5gb")
     df_factory.start_all([df_server])
     client = df_server.client()
     await asyncio.sleep(1)  # Wait for another RSS heartbeat update in Dragonfly


### PR DESCRIPTION
It appears that newer versions of the gh runner require more memory. Some cases of the test `test_rss_used_mem_gap` allocate more than `6.5-7` gb of memory leaving barely `0.5gb` to the gh runner (7.5 in total available) which sometimes cause the instance to run out of memory. This produces the following two cases:

1. OOM-killer gets triggered and manages to iterate over all of the processes and kill df  (because it consumes the most memory and the process shall have the highest rank for the algorithm) `before` it runs out of memory.
2. OOM-killer gets triggered but does not manage to kill df because the system run out of memory.

Case 1. will cause the test to fail and case 2 will cause the instance to freeze. Rather unfortunate for both cases.

This PR addresses this by tuning the test, lowering its memory requirements and also shielding dragonfly by setting `maxmemory` to `5gb` such that the test fails if we reach close this number instead of making the machine (and the CI) unresponsive. 

Bonus point is that we trim the total running time of the test by a few minutes.