### PR TITLE
chore: increase load in test_noreply_pipeline

### DIFF
--- a/tests/dragonfly/pymemcached_test.py
+++ b/tests/dragonfly/pymemcached_test.py
@@ -55,7 +55,7 @@ def test_noreply_pipeline(df_server: DflyInstance, memcached_client: MCClient):
     so all the commands are pipelined. Assert pipelines work correctly and the
     succeeding regular command receives a reply (it should join the pipeline as last).
     """
-    keys = [f"k{i}" for i in range(200)]
+    keys = [f"k{i}" for i in range(2000)]
     values = [f"d{i}" for i in range(len(keys))]
 
     for k, v in zip(keys, values):


### PR DESCRIPTION
Test is flaky because it relies that the producer (the pytest) to send fast enough a bunch of commands before they get dispatched synchronously. I could not reproduce the failure by running the test in a loop on the same instance type as the gh runner but I increased the threshold and run it a couple of times manually without any failures.

Should resolve #3896