### PR TITLE
fix(cluster): fix backoff on unknown migration

### DIFF
--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -207,9 +207,11 @@ void OutgoingMigration::SyncFb() {
     }
 
     if (!CheckRespIsSimpleReply("OK")) {
-      VLOG(2) << "Received non-OK response, retrying";
-      if (!CheckRespIsSimpleReply(kUnknownMigration)) {
-        VLOG(2) << "Target node does not recognize migration";
+      if (CheckRespIsSimpleReply(kUnknownMigration)) {
+        VLOG(2) << "Target node does not recognize migration; retrying";
+        ThisFiber::SleepFor(1000ms);
+      } else {
+        VLOG(1) << "Unable to initialize migration";
         cntx_.ReportError(GenericError(std::string(ToSV(LastResponseArgs().front().GetBuf()))));
       }
       continue;


### PR DESCRIPTION
Fixes adding a delay before retrying after receiving an 'unknown migration' response. Since 'unknown migration' isn't considered an error, `last_error_` won't be set (broke in https://github.com/dragonflydb/dragonfly/pull/3899)

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->