### PR TITLE
fix: crash if we OOM during migration process

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -195,9 +195,8 @@ std::optional<DbSlice::ItAndUpdater> RdbRestoreValue::Add(std::string_view data,
     return std::nullopt;
   }
 
-  auto res = db_slice.AddNew(cntx, key, std::move(pv), args.ExpirationTime());
-  res->it->first.SetSticky(args.Sticky());
-  if (res) {
+  if (auto res = db_slice.AddNew(cntx, key, std::move(pv), args.ExpirationTime()); res) {
+    res->it->first.SetSticky(args.Sticky());
     shard->search_indices()->AddDoc(key, cntx, res->it->second);
     return std::move(res.value());
   }


### PR DESCRIPTION
problem: crash if add keys during OOM

I've faced this situation when investigating memory consumption increasing for cluster slot migration
maxmemory default value was 8GB and the test used 9GB. The crash happened for the target node during the migration process.

fix: check the iterator before accessing the data

Also, I've updated the test to reproduce this situation easily