### PR TITLE
fix(memory-leak): add missing destructor to RaxTreeMap

### DIFF
--- a/src/core/search/rax_tree.h
+++ b/src/core/search/rax_tree.h
@@ -91,6 +91,10 @@ template <typename V> struct RaxTreeMap {
   explicit RaxTreeMap(PMR_NS::memory_resource* mr) : tree_(raxNew()), alloc_(mr) {
   }
 
+  ~RaxTreeMap() {
+    raxFree(tree_);
+  }
+
   size_t size() const {
     return raxSize(tree_);
   }


### PR DESCRIPTION
The destructor of RaxTreeMap was missing causing memory leak.

Sanitizers caught it :)