### PR TITLE
chore: reduce dependency of debug/memory commands on ConnectionContext

### DIFF
--- a/src/server/debugcmd.h
+++ b/src/server/debugcmd.h
@@ -52,6 +52,7 @@ class DebugCmd {
 
   ServerFamily& sf_;
   ConnectionContext* cntx_;
+  facade::SinkReplyBuilder* builder_;
 };
 
 }  // namespace dfly

--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -141,9 +141,9 @@ class DflyCmd {
  public:
   DflyCmd(ServerFamily* server_family);
 
-  void Run(CmdArgList args, ConnectionContext* cntx);
+  void Run(CmdArgList args, facade::RedisReplyBuilder* rb, ConnectionContext* cntx);
 
-  void OnClose(ConnectionContext* cntx);
+  void OnClose(unsigned sync_id);
 
   // Stop all background processes so we can exit in orderly manner.
   void Shutdown();
@@ -166,42 +166,44 @@ class DflyCmd {
   void BreakStalledFlowsInShard() ABSL_NO_THREAD_SAFETY_ANALYSIS;
 
  private:
+  using RedisReplyBuilder = facade::RedisReplyBuilder;
+
   // JOURNAL [START/STOP]
   // Start or stop journaling.
   // void Journal(CmdArgList args, ConnectionContext* cntx);
 
   // THREAD [to_thread]
   // Return connection thread index or migrate to another thread.
-  void Thread(CmdArgList args, ConnectionContext* cntx);
+  void Thread(CmdArgList args, RedisReplyBuilder* rb, ConnectionContext* cntx);
 
   // FLOW <masterid> <syncid> <flowid> [<seqid>]
   // Register connection as flow for sync session.
   // If seqid is given, it means the client wants to try partial sync.
   // If it is possible, return Ok and prepare for a partial sync, else
   // return error and ask the replica to execute FLOW again.
-  void Flow(CmdArgList args, ConnectionContext* cntx);
+  void Flow(CmdArgList args, RedisReplyBuilder* rb, ConnectionContext* cntx);
 
   // SYNC <syncid>
   // Initiate full sync.
-  void Sync(CmdArgList args, ConnectionContext* cntx);
+  void Sync(CmdArgList args, RedisReplyBuilder* rb, ConnectionContext* cntx);
 
   // STARTSTABLE <syncid>
   // Switch to stable state replication.
-  void StartStable(CmdArgList args, ConnectionContext* cntx);
+  void StartStable(CmdArgList args, RedisReplyBuilder* rb, ConnectionContext* cntx);
 
   // TAKEOVER <syncid>
   // Shut this master down atomically with replica promotion.
-  void TakeOver(CmdArgList args, ConnectionContext* cntx);
+  void TakeOver(CmdArgList args, RedisReplyBuilder* rb, ConnectionContext* cntx);
 
   // EXPIRE
   // Check all keys for expiry.
-  void Expire(CmdArgList args, ConnectionContext* cntx);
+  void Expire(CmdArgList args, RedisReplyBuilder* rb, ConnectionContext* cntx);
 
   // REPLICAOFFSET
   // Return journal records num sent for each flow of replication.
-  void ReplicaOffset(CmdArgList args, ConnectionContext* cntx);
+  void ReplicaOffset(CmdArgList args, RedisReplyBuilder* rb, ConnectionContext* cntx);
 
-  void Load(CmdArgList args, ConnectionContext* cntx);
+  void Load(CmdArgList args, RedisReplyBuilder* rb, ConnectionContext* cntx);
 
   // Start full sync in thread. Start FullSyncFb. Called for each flow.
   facade::OpStatus StartFullSyncInThread(FlowInfo* flow, Context* cntx, EngineShard* shard);

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1282,7 +1282,7 @@ void Service::DispatchCommand(ArgSlice args, facade::ConnectionContext* cntx) {
     // Bonus points because this allows to continue replication with ACL users who got
     // their access revoked and reinstated
     if (cid->name() == "REPLCONF" && absl::EqualsIgnoreCase(ArgS(args_no_cmd, 0), "ACK")) {
-      server_family_.GetDflyCmd()->OnClose(dfly_cntx);
+      server_family_.GetDflyCmd()->OnClose(dfly_cntx->conn_state.replication_info.repl_session_id);
       return;
     }
     dfly_cntx->SendError(std::move(*err));

--- a/src/server/memory_cmd.h
+++ b/src/server/memory_cmd.h
@@ -25,6 +25,7 @@ class MemoryCmd {
 
   ConnectionContext* cntx_;
   ServerFamily* owner_;
+  facade::SinkReplyBuilder* builder_;
 };
 
 }  // namespace dfly

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1563,7 +1563,7 @@ optional<Replica::Summary> ServerFamily::GetReplicaSummary() const {
 }
 
 void ServerFamily::OnClose(ConnectionContext* cntx) {
-  dfly_cmd_->OnClose(cntx);
+  dfly_cmd_->OnClose(cntx->conn_state.replication_info.repl_session_id);
 }
 
 void ServerFamily::StatsMC(std::string_view section, facade::ConnectionContext* cntx) {
@@ -3016,7 +3016,7 @@ void ServerFamily::ShutdownCmd(CmdArgList args, ConnectionContext* cntx) {
 }
 
 void ServerFamily::Dfly(CmdArgList args, ConnectionContext* cntx) {
-  dfly_cmd_->Run(args, cntx);
+  dfly_cmd_->Run(args, static_cast<RedisReplyBuilder*>(cntx->reply_builder()), cntx);
 }
 
 void ServerFamily::SlowLog(CmdArgList args, ConnectionContext* cntx) {


### PR DESCRIPTION
Specifically, remove `cntx->reply_builder` references where possible.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->