### PR TITLE
fix: properly set object with DenseLinkKey

### DIFF
--- a/src/core/dense_set.cc
+++ b/src/core/dense_set.cc
@@ -47,14 +47,16 @@ DenseSet::IteratorBase::IteratorBase(const DenseSet* owner, bool is_end)
 }
 
 void DenseSet::IteratorBase::SetExpiryTime(uint32_t ttl_sec) {
+  DensePtr* ptr = curr_entry_->IsLink() ? curr_entry_->AsLink() : curr_entry_;
+  void* src = ptr->GetObject();
   if (!HasExpiry()) {
-    auto src = curr_entry_->GetObject();
     void* new_obj = owner_->ObjectClone(src, false, true);
-    curr_entry_->SetObject(new_obj);
+    ptr->SetObject(new_obj);
     curr_entry_->SetTtl(true);
     owner_->ObjDelete(src, false);
+    src = new_obj;
   }
-  owner_->ObjUpdateExpireTime(curr_entry_->GetObject(), ttl_sec);
+  owner_->ObjUpdateExpireTime(src, ttl_sec);
 }
 
 void DenseSet::IteratorBase::Advance() {

--- a/src/core/dense_set.h
+++ b/src/core/dense_set.h
@@ -130,6 +130,7 @@ class DenseSet {
 
     // Sets pointer but preserves tagging info
     void SetObject(void* obj) {
+      assert(IsObject());
       ptr_ = (void*)((uptr() & kTagMask) | (uintptr_t(obj) & ~kTagMask));
     }
 

--- a/src/core/string_map_test.cc
+++ b/src/core/string_map_test.cc
@@ -146,6 +146,28 @@ TEST_F(StringMapTest, SetFieldExpireNoHasExpiry) {
   EXPECT_EQ(k.ExpiryTime(), 1);
 }
 
+TEST_F(StringMapTest, Bug3973) {
+  for (unsigned i = 0; i < 8; i++) {
+    EXPECT_TRUE(sm_->AddOrUpdate(to_string(i), "val"));
+  }
+  for (unsigned i = 0; i < 8; i++) {
+    auto k = sm_->Find(to_string(i));
+    ASSERT_FALSE(k.HasExpiry());
+    k.SetExpiryTime(1);
+    EXPECT_EQ(k.ExpiryTime(), 1);
+  }
+  for (unsigned i = 100; i < 1000; i++) {
+    EXPECT_TRUE(sm_->AddOrUpdate(to_string(i), "val"));
+  }
+
+  // make sure the first 8 keys have expiry set
+  for (unsigned i = 0; i < 8; i++) {
+    auto k = sm_->Find(to_string(i));
+    ASSERT_TRUE(k.HasExpiry());
+    EXPECT_EQ(k.ExpiryTime(), 1);
+  }
+}
+
 unsigned total_wasted_memory = 0;
 
 TEST_F(StringMapTest, ReallocIfNeeded) {


### PR DESCRIPTION
The interface around DenseLinkKey is confusing but SetObject works only for unwrapped objects.
Added assert to catch these issues in the future.

Fixes #3973

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->