### PR TITLE
fix: dangling string in DebugCmd::Reload

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -489,7 +489,7 @@ void DebugCmd::Reload(CmdArgList args) {
   bool save = true;
 
   for (size_t i = 1; i < args.size(); ++i) {
-    string_view opt = absl::AsciiStrToUpper(ArgS(args, i));
+    string opt = absl::AsciiStrToUpper(ArgS(args, i));
     VLOG(1) << "opt " << opt;
 
     if (opt == "NOSAVE") {


### PR DESCRIPTION
`string_view opt = absl::AsciiStrToUpper(ArgS(args, i));` temporary bind to `string_view`