### PR TITLE
fix(search_family): Process wrong field types in indexes for the FT.SEARCH and FT.AGGREGATE commands. TEMPORARY SOLUTION

### DIFF
--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -1044,4 +1044,34 @@ TEST_F(SearchFamilyTest, FlushSearchIndices) {
   EXPECT_THAT(resp, ErrArg("ERR Index already exists"));
 }
 
+TEST_F(SearchFamilyTest, WrongFieldType) {
+  Run({"HSET", "h1", "even", "true", "value", "one"});
+  Run({"HSET", "h2", "even", "false", "value", "1"});
+
+  EXPECT_EQ(Run({"FT.CREATE", "i1", "ON", "HASH", "SCHEMA", "value", "NUMERIC", "SORTABLE"}), "OK");
+
+  auto resp = Run({"FT.AGGREGATE", "i1", "*", "LOAD", "1", "@value"});
+  EXPECT_THAT(resp, IsUnordArrayWithSize(IsMap("value", "1")));
+
+  resp = Run({"FT.SEARCH", "i1", "*"});
+  EXPECT_THAT(resp, IsArray(IntArg(1), "h2", IsMap("even", "false", "value", "1")));
+
+  Run({"JSON.SET", "j1", ".", R"({"even":"true", "value":"one"})"});
+  Run({"JSON.SET", "j2", ".", R"({"even":"false", "value":1})"});
+
+  EXPECT_EQ(Run({"FT.CREATE", "i2", "ON", "JSON", "SCHEMA", "$.value", "AS", "value", "NUMERIC",
+                 "SORTABLE"}),
+            "OK");
+
+  /*
+  Temporary disable. We are not supporting aliases for the JSON documents
+
+  resp = Run({"FT.AGGREGATE", "i2", "*", "LOAD", "1", "@value"});
+  EXPECT_THAT(resp, IsUnordArrayWithSize(IsMap("value", "1")));
+  */
+
+  resp = Run({"FT.SEARCH", "i2", "*"});
+  EXPECT_THAT(resp, AreDocIds("j2"));
+}
+
 }  // namespace dfly


### PR DESCRIPTION
fixes dragonflydb#3986

Temporary solution. Being discussed with @dranikpg to find the correct solution. It might be more appropriate to filter the indexes during the `search_algo->Search` function.