### PR TITLE
chore: add ForceUpdate to BPTree

### DIFF
--- a/src/core/bptree_set.h
+++ b/src/core/bptree_set.h
@@ -591,7 +591,7 @@ template <typename T, typename Policy> void BPTree<T, Policy>::DestroyNode(BPTre
 
 template <typename T, typename Policy> void BPTree<T, Policy>::ForceUpdate(KeyT old, KeyT new_obj) {
   BPTreePath path;
-  bool found = Locate(old, &path);
+  [[maybe_unused]] bool found = Locate(old, &path);
 
   assert(path.Depth() > 0u);
   assert(found);

--- a/src/core/bptree_set.h
+++ b/src/core/bptree_set.h
@@ -104,6 +104,10 @@ template <typename T, typename Policy = BPTreePolicy<T>> class BPTree {
   /// @param path
   void Delete(BPTreePath path);
 
+  /// @brief Forces an update to the key. Assumes key has the same value.
+  /// Replaces old with new_obj.
+  void ForceUpdate(KeyT old, KeyT new_obj);
+
  private:
   BPTreeNode* CreateNode(bool leaf);
 
@@ -583,6 +587,17 @@ template <typename T, typename Policy> void BPTree<T, Policy>::DestroyNode(BPTre
   void* ptr = node;
   mr_->deallocate(ptr, detail::kBPNodeSize, 8);
   num_nodes_--;
+}
+
+template <typename T, typename Policy> void BPTree<T, Policy>::ForceUpdate(KeyT old, KeyT new_obj) {
+  BPTreePath path;
+  bool found = Locate(old, &path);
+
+  assert(path.Depth() > 0u);
+  assert(found);
+
+  BPTreeNode* node = path.Last().first;
+  node->SetKey(path.Last().second, new_obj);
 }
 
 }  // namespace dfly

--- a/src/core/score_map.cc
+++ b/src/core/score_map.cc
@@ -148,7 +148,7 @@ detail::SdsScorePair ScoreMap::iterator::BreakToPair(void* obj) {
 
 namespace {
 // Does not Release obj. Callers must do so explicitly if a `Reallocation` happened
-pair<sds, bool> ReallocIfNeededGeneric(void* obj, float ratio) {
+pair<sds, bool> DuplicateEntryIfFragmented(void* obj, float ratio) {
   sds key = (sds)obj;
   size_t key_len = sdslen(key);
 
@@ -173,7 +173,7 @@ bool ScoreMap::iterator::ReallocIfNeeded(float ratio, std::function<void(sds, sd
 
   // Note: we do not iterate over the links. Although we could that...
   auto* obj = ptr->GetObject();
-  auto [new_obj, reallocated] = ReallocIfNeededGeneric(obj, ratio);
+  auto [new_obj, reallocated] = DuplicateEntryIfFragmented(obj, ratio);
   if (reallocated) {
     if (cb) {
       cb((sds)obj, (sds)new_obj);

--- a/src/core/score_map.cc
+++ b/src/core/score_map.cc
@@ -167,15 +167,15 @@ bool ScoreMap::iterator::ReallocIfNeeded(float ratio, std::function<void(sds, sd
   bool reallocated = false;
   auto body = [ratio, &cb, &reallocated](auto* ptr) {
     auto* obj = ptr->GetObject();
-    auto [new_obj, realloc] = DuplicateEntryIfFragmented(obj, ratio);
-    if (realloc) {
+    auto [new_obj, duplicate] = DuplicateEntryIfFragmented(obj, ratio);
+    if (duplicate) {
       if (cb) {
         cb((sds)obj, (sds)new_obj);
       }
       sdsfree((sds)obj);
       ptr->SetObject(new_obj);
     }
-    reallocated |= realloc;
+    reallocated |= duplicate;
   };
 
   TraverseApply(curr_entry_, body);

--- a/src/core/sorted_map.cc
+++ b/src/core/sorted_map.cc
@@ -770,10 +770,7 @@ SortedMap* SortedMap::FromListPack(PMR_NS::memory_resource* res, const uint8_t* 
 }
 
 bool SortedMap::DefragIfNeeded(float ratio) {
-  auto cb = [this](sds old_obj, sds new_obj) {
-    score_tree->Delete(old_obj);
-    score_tree->Insert(new_obj);
-  };
+  auto cb = [this](sds old_obj, sds new_obj) { score_tree->ForceUpdate(old_obj, new_obj); };
   bool reallocated = false;
 
   for (auto it = score_map->begin(); it != score_map->end(); ++it) {


### PR DESCRIPTION
`ReallocIfNeeded` deleted and reinserted the same key in the `BPTree` stored in `SortedMap`. This is not really needed since the key is actually the same and we can just update the pointer within `BPTree` instead of doing the deletion + insertion chore.

Resolves #3963