### PR TITLE
fix: keep the ttl bit when dense_set grows with expiring items

### DIFF
--- a/src/core/dense_set.h
+++ b/src/core/dense_set.h
@@ -367,7 +367,6 @@ class DenseSet {
   size_t PushFront(ChainVectorIterator, void* obj, bool has_ttl);
   void PushFront(ChainVectorIterator, DensePtr);
 
-  void* PopDataFront(ChainVectorIterator);
   DensePtr PopPtrFront(ChainVectorIterator);
 
   // ============ Pseudo Linked List in DenseSet end ==================


### PR DESCRIPTION
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->