### PR TITLE
feat(zset_family): support WITHSCORE in zrevrank/zrank commands (#3921)

### DIFF
--- a/src/core/bptree_set.h
+++ b/src/core/bptree_set.h
@@ -48,7 +48,7 @@ template <typename T, typename Policy = BPTreePolicy<T>> class BPTree {
 
   bool Delete(KeyT item);
 
-  std::optional<uint32_t> GetRank(KeyT item) const;
+  std::optional<uint32_t> GetRank(KeyT item, bool reverse = false) const;
 
   size_t Height() const {
     return height_;
@@ -222,7 +222,7 @@ template <typename T, typename Policy> bool BPTree<T, Policy>::Delete(KeyT item)
 }
 
 template <typename T, typename Policy>
-std::optional<uint32_t> BPTree<T, Policy>::GetRank(KeyT item) const {
+std::optional<uint32_t> BPTree<T, Policy>::GetRank(KeyT item, bool reverse) const {
   if (!root_)
     return std::nullopt;
 
@@ -230,6 +230,10 @@ std::optional<uint32_t> BPTree<T, Policy>::GetRank(KeyT item) const {
   bool found = Locate(item, &path);
   if (!found)
     return std::nullopt;
+
+  if (reverse) {
+    return count_ - path.Rank() - 1;
+  }
 
   return path.Rank();
 }

--- a/src/core/sorted_map.cc
+++ b/src/core/sorted_map.cc
@@ -309,9 +309,9 @@ optional<unsigned> SortedMap::GetRank(sds ele, bool reverse) const {
   if (obj == nullptr)
     return std::nullopt;
 
-  optional rank = score_tree->GetRank(obj);
+  optional rank = score_tree->GetRank(obj, reverse);
   DCHECK(rank);
-  return reverse ? score_map->UpperBoundSize() - *rank - 1 : *rank;
+  return *rank;
 }
 
 SortedMap::ScoredArray SortedMap::GetRange(const zrangespec& range, unsigned offset, unsigned limit,
@@ -783,5 +783,15 @@ bool SortedMap::DefragIfNeeded(float ratio) {
   return reallocated;
 }
 
+std::optional<SortedMap::RankAndScore> SortedMap::GetRankAndScore(sds ele, bool reverse) const {
+  ScoreSds obj = score_map->FindObj(ele);
+  if (obj == nullptr)
+    return std::nullopt;
+
+  optional rank = score_tree->GetRank(obj, reverse);
+  DCHECK(rank);
+
+  return SortedMap::RankAndScore{*rank, GetObjScore(obj)};
+}
 }  // namespace detail
 }  // namespace dfly

--- a/src/core/sorted_map.h
+++ b/src/core/sorted_map.h
@@ -35,6 +35,7 @@ class SortedMap {
   using ScoredMember = std::pair<std::string, double>;
   using ScoredArray = std::vector<ScoredMember>;
   using ScoreSds = void*;
+  using RankAndScore = std::pair<unsigned, double>;
 
   SortedMap(PMR_NS::memory_resource* res);
   ~SortedMap();
@@ -72,6 +73,7 @@ class SortedMap {
 
   std::optional<double> GetScore(sds ele) const;
   std::optional<unsigned> GetRank(sds ele, bool reverse) const;
+  std::optional<RankAndScore> GetRankAndScore(sds ele, bool reverse) const;
   ScoredArray GetRange(const zrangespec& r, unsigned offs, unsigned len, bool rev) const;
   ScoredArray GetLexRange(const zlexrangespec& r, unsigned o, unsigned l, bool rev) const;
 


### PR DESCRIPTION
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->

Hey, it adds WITHSCORE support to zrank/zrevrank.

 I actually wrote another one version with templated RankResult and constexpr'ed ifs, but i couldn't see performance differences with a simple 'boolean and if' solution. Since the other commands implemented with the last approach I've decided to go this way.

Another change it a new method in SortedMap. It could be implemented without this invention but it helps to avoid double lookup in the 'score_map'. The method returns std::pair which doesn't have self-explanatory fields with its 'first' and 'second'  but I've hesitated to add a new struct for this purpose.

