### PR TITLE
chore: support load/save from GCS

### DIFF
--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -297,13 +297,14 @@ void SinkReplyBuilder2::Send() {
   uint64_t before_ns = util::fb2::ProactorBase::GetMonotonicTimeNs();
   reply_stats.io_write_cnt++;
   reply_stats.io_write_bytes += total_size_;
-
+  DVLOG(2) << "Writing " << total_size_ << " bytes";
   if (auto ec = sink_->Write(vecs_.data(), vecs_.size()); ec)
     ec_ = ec;
 
   uint64_t after_ns = util::fb2::ProactorBase::GetMonotonicTimeNs();
   reply_stats.send_stats.count++;
   reply_stats.send_stats.total_duration += (after_ns - before_ns) / 1'000;
+  DVLOG(2) << "Finished writing " << total_size_ << " bytes";
   send_active_ = false;
 }
 

--- a/src/server/detail/save_stages_controller.h
+++ b/src/server/detail/save_stages_controller.h
@@ -124,7 +124,6 @@ struct SaveStagesController : public SaveStagesInputs {
  private:
   time_t start_time_;
   std::filesystem::path full_path_;
-  bool is_cloud_;
 
   AggregateGenericError shared_err_;
   std::vector<std::pair<std::unique_ptr<RdbSnapshot>, std::filesystem::path>> snapshots_;

--- a/src/server/detail/snapshot_storage.cc
+++ b/src/server/detail/snapshot_storage.cc
@@ -41,11 +41,8 @@ constexpr string_view kSummarySuffix = "summary.dfs"sv;
 
 pair<string, string> GetBucketPath(string_view path) {
   string_view clean = path;
-  if (absl::StartsWith(clean, kS3Prefix)) {
-    clean = absl::StripPrefix(clean, kS3Prefix);
-  } else {
-    clean = absl::StripPrefix(clean, kGCSPrefix);
-  }
+  auto prefix = absl::StartsWith(clean, kS3Prefix) ? kS3Prefix : kGCSPrefix;
+  clean = absl::StripPrefix(clean, prefix);
 
   size_t pos = clean.find('/');
   if (pos == string_view::npos) {

--- a/src/server/detail/snapshot_storage.h
+++ b/src/server/detail/snapshot_storage.h
@@ -54,6 +54,10 @@ class SnapshotStorage {
   // Searches for all the relevant snapshot files given the RDB file or DFS summary file path.
   io::Result<std::vector<std::string>, GenericError> ExpandSnapshot(const std::string& load_path);
 
+  virtual bool IsCloud() const {
+    return false;
+  }
+
  protected:
   virtual io::Result<std::vector<std::string>, GenericError> ExpandFromPath(
       const std::string& path) = 0;
@@ -94,6 +98,10 @@ class GcsSnapshotStorage : public SnapshotStorage {
   io::Result<std::string, GenericError> LoadPath(std::string_view dir,
                                                  std::string_view dbfilename) override;
 
+  bool IsCloud() const final {
+    return true;
+  }
+
  private:
   io::Result<std::vector<std::string>, GenericError> ExpandFromPath(const std::string& path) final;
 
@@ -116,6 +124,10 @@ class AwsS3SnapshotStorage : public SnapshotStorage {
 
   io::Result<std::string, GenericError> LoadPath(std::string_view dir,
                                                  std::string_view dbfilename) override;
+
+  bool IsCloud() const final {
+    return true;
+  }
 
  private:
   io::Result<std::vector<std::string>, GenericError> ExpandFromPath(const std::string& path) final;


### PR DESCRIPTION
Not everything is supported but manual load save is supported.

1. Run dragonfly with `--dir gs://bucket/path`
2. In redis-cli: a. SET foo bar b. SAVE DF gsdump c. DFLY LOAD gs://bucket/path/gsdump-summary.dfs

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->