### PR TITLE
chore: improve verbosity logging during shutdown

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -844,6 +844,8 @@ Service::Service(ProactorPool* pp)
   LOG(INFO) << "PRINT STACKTRACES REGISTERED";
   pp_.GetNextProactor()->RegisterSignal({SIGUSR1}, [this](int signal) {
     LOG(INFO) << "Received " << strsignal(signal);
+    base::SetVLogLevel("uring_proactor", 2);
+
     util::fb2::Mutex m;
     pp_.AwaitFiberOnAll([&m](unsigned index, util::ProactorBase* base) {
       util::fb2::LockGuard lk(m);


### PR DESCRIPTION
Increase verbosity levels of uring_proactor if deadlock was detected in debug mode. Also allow optionally to disable periodic fiber, which sometimes helps during the debugging.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->