### PR TITLE
chore: change Namespaces to be a global pointer

### DIFF
--- a/src/server/blocking_controller_test.cc
+++ b/src/server/blocking_controller_test.cc
@@ -61,7 +61,7 @@ void BlockingControllerTest::SetUp() {
     arg_vec_.emplace_back(s);
   }
 
-  trans_->InitByArgs(&namespaces.GetDefaultNamespace(), 0, {arg_vec_.data(), arg_vec_.size()});
+  trans_->InitByArgs(&namespaces->GetDefaultNamespace(), 0, {arg_vec_.data(), arg_vec_.size()});
   CHECK_EQ(0u, Shard("x", shard_set->size()));
   CHECK_EQ(2u, Shard("z", shard_set->size()));
 
@@ -71,7 +71,6 @@ void BlockingControllerTest::SetUp() {
 
 void BlockingControllerTest::TearDown() {
   shard_set->PreShutdown();
-  namespaces.Clear();
   shard_set->Shutdown();
   delete shard_set;
 
@@ -81,7 +80,7 @@ void BlockingControllerTest::TearDown() {
 
 TEST_F(BlockingControllerTest, Basic) {
   trans_->ScheduleSingleHop([&](Transaction* t, EngineShard* shard) {
-    BlockingController bc(shard, &namespaces.GetDefaultNamespace());
+    BlockingController bc(shard, &namespaces->GetDefaultNamespace());
     auto keys = t->GetShardArgs(shard->shard_id());
     bc.AddWatched(
         keys, [](auto...) { return true; }, t);
@@ -107,7 +106,7 @@ TEST_F(BlockingControllerTest, Timeout) {
   unsigned num_watched = shard_set->Await(
 
       0, [&] {
-        return namespaces.GetDefaultNamespace()
+        return namespaces->GetDefaultNamespace()
             .GetBlockingController(EngineShard::tlocal()->shard_id())
             ->NumWatched(0);
       });

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -477,7 +477,7 @@ void DeleteSlots(const SlotRanges& slots_ranges) {
     if (shard == nullptr)
       return;
 
-    namespaces.GetDefaultNamespace().GetDbSlice(shard->shard_id()).FlushSlots(slots_ranges);
+    namespaces->GetDefaultNamespace().GetDbSlice(shard->shard_id()).FlushSlots(slots_ranges);
   };
   shard_set->pool()->AwaitFiberOnAll(std::move(cb));
 }
@@ -633,7 +633,7 @@ void ClusterFamily::DflyClusterGetSlotInfo(CmdArgList args, SinkReplyBuilder* bu
 
     util::fb2::LockGuard lk(mu);
     for (auto& [slot, data] : slots_stats) {
-      data += namespaces.GetDefaultNamespace().GetDbSlice(shard->shard_id()).GetSlotStats(slot);
+      data += namespaces->GetDefaultNamespace().GetDbSlice(shard->shard_id()).GetSlotStats(slot);
     }
   };
 

--- a/src/server/cluster/cluster_utility.cc
+++ b/src/server/cluster/cluster_utility.cc
@@ -50,7 +50,7 @@ uint64_t GetKeyCount(const SlotRanges& slots) {
     uint64_t shard_keys = 0;
     for (const SlotRange& range : slots) {
       for (SlotId slot = range.start; slot <= range.end; slot++) {
-        shard_keys += namespaces.GetDefaultNamespace()
+        shard_keys += namespaces->GetDefaultNamespace()
                           .GetDbSlice(shard->shard_id())
                           .GetSlotStats(slot)
                           .key_count;

--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -101,7 +101,7 @@ OutgoingMigration::OutgoingMigration(MigrationInfo info, ClusterFamily* cf, Serv
       server_family_(sf),
       cf_(cf),
       tx_(new Transaction{sf->service().FindCmd("DFLYCLUSTER")}) {
-  tx_->InitByArgs(&namespaces.GetDefaultNamespace(), 0, {});
+  tx_->InitByArgs(&namespaces->GetDefaultNamespace(), 0, {});
 }
 
 OutgoingMigration::~OutgoingMigration() {
@@ -218,7 +218,7 @@ void OutgoingMigration::SyncFb() {
     }
 
     OnAllShards([this](auto& migration) {
-      DbSlice& db_slice = namespaces.GetDefaultNamespace().GetCurrentDbSlice();
+      DbSlice& db_slice = namespaces->GetDefaultNamespace().GetCurrentDbSlice();
       server_family_->journal()->StartInThread();
       migration = std::make_unique<SliceSlotMigration>(
           &db_slice, server(), migration_info_.slot_ranges, server_family_->journal());
@@ -291,8 +291,8 @@ bool OutgoingMigration::FinalizeMigration(long attempt) {
   bool is_block_active = true;
   auto is_pause_in_progress = [&is_block_active] { return is_block_active; };
   auto pause_fb_opt =
-      Pause(server_family_->GetNonPriviligedListeners(), &namespaces.GetDefaultNamespace(), nullptr,
-            ClientPause::WRITE, is_pause_in_progress);
+      Pause(server_family_->GetNonPriviligedListeners(), &namespaces->GetDefaultNamespace(),
+            nullptr, ClientPause::WRITE, is_pause_in_progress);
 
   if (!pause_fb_opt) {
     LOG(WARNING) << "Cluster migration finalization time out";

--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -120,6 +120,7 @@ atomic_uint64_t rss_mem_peak(0);
 unsigned kernel_version = 0;
 size_t max_memory_limit = 0;
 size_t serialization_max_chunk_size = 0;
+Namespaces* namespaces = nullptr;
 
 const char* GlobalStateName(GlobalState s) {
   switch (s) {

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -49,6 +49,7 @@ class Transaction;
 class EngineShard;
 class ConnectionState;
 class Interpreter;
+class Namespaces;
 
 struct LockTagOptions {
   bool enabled = false;
@@ -131,6 +132,8 @@ extern std::atomic_uint64_t rss_mem_current;
 extern std::atomic_uint64_t rss_mem_peak;
 
 extern size_t max_memory_limit;
+
+extern Namespaces* namespaces;
 
 // version 5.11 maps to 511 etc.
 // set upon server start.

--- a/src/server/detail/save_stages_controller.cc
+++ b/src/server/detail/save_stages_controller.cc
@@ -434,7 +434,7 @@ void SaveStagesController::CloseCb(unsigned index) {
   }
 
   if (auto* es = EngineShard::tlocal(); use_dfs_format_ && es)
-    namespaces.GetDefaultNamespace().GetDbSlice(es->shard_id()).ResetUpdateEvents();
+    namespaces->GetDefaultNamespace().GetDbSlice(es->shard_id()).ResetUpdateEvents();
 }
 
 void SaveStagesController::RunStage(void (SaveStagesController::*cb)(unsigned)) {

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -77,7 +77,7 @@ bool WaitReplicaFlowToCatchup(absl::Time end_time, const DflyCmd::ReplicaInfo* r
                               EngineShard* shard) {
   // We don't want any writes to the journal after we send the `PING`,
   // and expirations could ruin that.
-  namespaces.GetDefaultNamespace().GetDbSlice(shard->shard_id()).SetExpireAllowed(false);
+  namespaces->GetDefaultNamespace().GetDbSlice(shard->shard_id()).SetExpireAllowed(false);
   shard->journal()->RecordEntry(0, journal::Op::PING, 0, 0, nullopt, {}, true);
 
   const FlowInfo* flow = &replica->flows[shard->shard_id()];
@@ -455,7 +455,7 @@ void DflyCmd::TakeOver(CmdArgList args, RedisReplyBuilder* rb, ConnectionContext
   absl::Cleanup cleanup([] {
     VLOG(2) << "Enabling expiration";
     shard_set->RunBriefInParallel([](EngineShard* shard) {
-      namespaces.GetDefaultNamespace().GetDbSlice(shard->shard_id()).SetExpireAllowed(true);
+      namespaces->GetDefaultNamespace().GetDbSlice(shard->shard_id()).SetExpireAllowed(true);
     });
   });
 

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -379,7 +379,7 @@ TEST_F(DflyEngineTest, MemcacheFlags) {
   ASSERT_EQ(Run("resp", {"flushdb"}), "OK");
   pp_->AwaitFiberOnAll([](auto*) {
     if (auto* shard = EngineShard::tlocal(); shard) {
-      EXPECT_EQ(namespaces.GetDefaultNamespace()
+      EXPECT_EQ(namespaces->GetDefaultNamespace()
                     .GetDbSlice(shard->shard_id())
                     .GetDBTable(0)
                     ->mcflag.size(),
@@ -600,7 +600,7 @@ TEST_F(DflyEngineTest, Bug468) {
 
 TEST_F(DflyEngineTest, Bug496) {
   shard_set->RunBlockingInParallel([](EngineShard* shard) {
-    auto& db = namespaces.GetDefaultNamespace().GetDbSlice(shard->shard_id());
+    auto& db = namespaces->GetDefaultNamespace().GetDbSlice(shard->shard_id());
 
     int cb_hits = 0;
     uint32_t cb_id =

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -103,7 +103,10 @@ EngineShardSet* shard_set = nullptr;
 
 void EngineShardSet::Init(uint32_t sz, std::function<void()> shard_handler) {
   CHECK_EQ(0u, size());
+  CHECK(namespaces == nullptr);
+
   shards_.reset(new EngineShard*[sz]);
+
   size_ = sz;
   size_t max_shard_file_size = GetTieredFileLimit(sz);
   pp_->AwaitFiberOnAll([this](uint32_t index, ProactorBase* pb) {
@@ -112,7 +115,8 @@ void EngineShardSet::Init(uint32_t sz, std::function<void()> shard_handler) {
     }
   });
 
-  namespaces.Init();
+  // The order is important here. We must initialize namespaces after shards_.
+  namespaces = new Namespaces();
 
   pp_->AwaitFiberOnAll([&](uint32_t index, ProactorBase* pb) {
     if (index < size_) {
@@ -139,7 +143,11 @@ void EngineShardSet::PreShutdown() {
 }
 
 void EngineShardSet::Shutdown() {
+  namespaces->Clear();
   RunBlockingInParallel([](EngineShard*) { EngineShard::DestroyThreadLocal(); });
+
+  delete namespaces;
+  namespaces = nullptr;
 }
 
 void EngineShardSet::InitThreadLocal(ProactorBase* pb) {
@@ -150,7 +158,7 @@ void EngineShardSet::InitThreadLocal(ProactorBase* pb) {
 
 void EngineShardSet::TEST_EnableCacheMode() {
   RunBlockingInParallel([](EngineShard* shard) {
-    namespaces.GetDefaultNamespace().GetCurrentDbSlice().TEST_EnableCacheMode();
+    namespaces->GetDefaultNamespace().GetCurrentDbSlice().TEST_EnableCacheMode();
   });
 }
 

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -143,6 +143,8 @@ void EngineShardSet::PreShutdown() {
 }
 
 void EngineShardSet::Shutdown() {
+  // Calling Namespaces::Clear before destroying engine shards, because it accesses them
+  // internally.
   namespaces->Clear();
   RunBlockingInParallel([](EngineShard*) { EngineShard::DestroyThreadLocal(); });
 

--- a/src/server/journal/executor.cc
+++ b/src/server/journal/executor.cc
@@ -42,7 +42,7 @@ JournalExecutor::JournalExecutor(Service* service)
   conn_context_.is_replicating = true;
   conn_context_.journal_emulated = true;
   conn_context_.skip_acl_validation = true;
-  conn_context_.ns = &namespaces.GetDefaultNamespace();
+  conn_context_.ns = &namespaces->GetDefaultNamespace();
 }
 
 JournalExecutor::~JournalExecutor() {

--- a/src/server/list_family_test.cc
+++ b/src/server/list_family_test.cc
@@ -33,7 +33,7 @@ class ListFamilyTest : public BaseFamilyTest {
   static unsigned NumWatched() {
     atomic_uint32_t sum{0};
 
-    auto ns = &namespaces.GetDefaultNamespace();
+    auto ns = &namespaces->GetDefaultNamespace();
     shard_set->RunBriefInParallel([&](EngineShard* es) {
       auto* bc = ns->GetBlockingController(es->shard_id());
       if (bc)
@@ -45,7 +45,7 @@ class ListFamilyTest : public BaseFamilyTest {
 
   static bool HasAwakened() {
     atomic_uint32_t sum{0};
-    auto ns = &namespaces.GetDefaultNamespace();
+    auto ns = &namespaces->GetDefaultNamespace();
     shard_set->RunBriefInParallel([&](EngineShard* es) {
       auto* bc = ns->GetBlockingController(es->shard_id());
       if (bc)

--- a/src/server/namespaces.cc
+++ b/src/server/namespaces.cc
@@ -1,3 +1,7 @@
+// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
 #include "server/namespaces.h"
 
 #include "base/flags.h"
@@ -45,19 +49,12 @@ BlockingController* Namespace::GetBlockingController(ShardId sid) {
   return shard_blocking_controller_[sid].get();
 }
 
-Namespaces namespaces;
-
-Namespaces::~Namespaces() {
-  Clear();
-}
-
-void Namespaces::Init() {
-  DCHECK(default_namespace_ == nullptr);
+Namespaces::Namespaces() {
   default_namespace_ = &GetOrInsert("");
 }
 
-bool Namespaces::IsInitialized() const {
-  return default_namespace_ != nullptr;
+Namespaces::~Namespaces() {
+  Clear();
 }
 
 void Namespaces::Clear() {

--- a/src/server/namespaces.h
+++ b/src/server/namespaces.h
@@ -49,11 +49,9 @@ class Namespace {
 // mutual dependencies.
 class Namespaces {
  public:
-  Namespaces() = default;
+  Namespaces();
   ~Namespaces();
 
-  void Init();
-  bool IsInitialized() const;
   void Clear() ABSL_LOCKS_EXCLUDED(mu_);  // Thread unsafe, use in tear-down or tests
 
   Namespace& GetDefaultNamespace() const;  // No locks
@@ -64,7 +62,5 @@ class Namespaces {
   absl::node_hash_map<std::string, Namespace> namespaces_ ABSL_GUARDED_BY(mu_);
   Namespace* default_namespace_ = nullptr;
 };
-
-extern Namespaces namespaces;
 
 }  // namespace dfly

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2258,7 +2258,7 @@ error_code RdbLoader::Load(io::Source* src) {
 
         // Active database if not existed before.
         shard_set->Add(
-            i, [dbid] { namespaces.GetDefaultNamespace().GetCurrentDbSlice().ActivateDb(dbid); });
+            i, [dbid] { namespaces->GetDefaultNamespace().GetCurrentDbSlice().ActivateDb(dbid); });
       }
 
       cur_db_index_ = dbid;
@@ -2656,7 +2656,7 @@ std::error_code RdbLoaderBase::FromOpaque(const OpaqueObj& opaque, LoadConfig co
 
 void RdbLoader::LoadItemsBuffer(DbIndex db_ind, const ItemsBuf& ib) {
   EngineShard* es = EngineShard::tlocal();
-  DbContext db_cntx{&namespaces.GetDefaultNamespace(), db_ind, GetCurrentTimeMs()};
+  DbContext db_cntx{&namespaces->GetDefaultNamespace(), db_ind, GetCurrentTimeMs()};
   DbSlice& db_slice = db_cntx.GetDbSlice(es->shard_id());
 
   auto error_msg = [](const auto* item, auto db_ind) {
@@ -2860,7 +2860,7 @@ void RdbLoader::LoadSearchIndexDefFromAux(string&& def) {
   cntx.is_replicating = true;
   cntx.journal_emulated = true;
   cntx.skip_acl_validation = true;
-  cntx.ns = &namespaces.GetDefaultNamespace();
+  cntx.ns = &namespaces->GetDefaultNamespace();
 
   uint32_t consumed = 0;
   facade::RespVec resp_vec;
@@ -2897,7 +2897,7 @@ void RdbLoader::PerformPostLoad(Service* service) {
   // Rebuild all search indices as only their definitions are extracted from the snapshot
   shard_set->AwaitRunningOnShardQueue([](EngineShard* es) {
     es->search_indices()->RebuildAllIndices(
-        OpArgs{es, nullptr, DbContext{&namespaces.GetDefaultNamespace(), 0, GetCurrentTimeMs()}});
+        OpArgs{es, nullptr, DbContext{&namespaces->GetDefaultNamespace(), 0, GetCurrentTimeMs()}});
   });
 }
 

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -1319,7 +1319,7 @@ void RdbSaver::Impl::FinalizeSnapshotWriting() {
 
 void RdbSaver::Impl::StartSnapshotting(bool stream_journal, Context* cntx, EngineShard* shard) {
   auto& s = GetSnapshot(shard);
-  auto& db_slice = namespaces.GetDefaultNamespace().GetDbSlice(shard->shard_id());
+  auto& db_slice = namespaces->GetDefaultNamespace().GetDbSlice(shard->shard_id());
   auto on_snapshot_finish = std::bind(&RdbSaver::Impl::FinalizeSnapshotWriting, this);
   auto push_cb = std::bind(&RdbSaver::Impl::PushSnapshotData, this, cntx, std::placeholders::_1);
 
@@ -1333,7 +1333,7 @@ void RdbSaver::Impl::StartSnapshotting(bool stream_journal, Context* cntx, Engin
 
 void RdbSaver::Impl::StartIncrementalSnapshotting(Context* cntx, EngineShard* shard,
                                                   LSN start_lsn) {
-  auto& db_slice = namespaces.GetDefaultNamespace().GetDbSlice(shard->shard_id());
+  auto& db_slice = namespaces->GetDefaultNamespace().GetDbSlice(shard->shard_id());
   auto& s = GetSnapshot(shard);
   auto on_finalize_cb = std::bind(&RdbSaver::Impl::FinalizeSnapshotWriting, this);
   auto push_cb = std::bind(&RdbSaver::Impl::PushSnapshotData, this, cntx, std::placeholders::_1);
@@ -1546,9 +1546,9 @@ error_code RdbSaver::SaveBody(Context* cntx) {
 }
 
 void RdbSaver::FillFreqMap(RdbTypeFreqMap* freq_map) {
-  freq_map->clear();
-  impl_->FillFreqMap(freq_map);
-}
+    freq_map->clear();
+    impl_->FillFreqMap(freq_map);
+  }
 
 error_code RdbSaver::SaveAux(const GlobalData& glob_state) {
   static_assert(sizeof(void*) == 8, "");

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -1546,9 +1546,9 @@ error_code RdbSaver::SaveBody(Context* cntx) {
 }
 
 void RdbSaver::FillFreqMap(RdbTypeFreqMap* freq_map) {
-    freq_map->clear();
-    impl_->FillFreqMap(freq_map);
-  }
+  freq_map->clear();
+  impl_->FillFreqMap(freq_map);
+}
 
 error_code RdbSaver::SaveAux(const GlobalData& glob_state) {
   static_assert(sizeof(void*) == 8, "");

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -597,7 +597,7 @@ error_code Replica::ConsumeRedisStream() {
   conn_context.is_replicating = true;
   conn_context.journal_emulated = true;
   conn_context.skip_acl_validation = true;
-  conn_context.ns = &namespaces.GetDefaultNamespace();
+  conn_context.ns = &namespaces->GetDefaultNamespace();
 
   // we never reply back on the commands.
   facade::CapturingReplyBuilder null_builder{facade::ReplyMode::NONE};

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1533,7 +1533,7 @@ void ServerFamily::ConfigureMetrics(util::HttpListenerBase* http_base) {
 
   auto cb = [this](const util::http::QueryArgs& args, util::HttpContext* send) {
     StringResponse resp = util::http::MakeStringResponse(boost::beast::http::status::ok);
-    PrintPrometheusMetrics(this->GetMetrics(&namespaces.GetDefaultNamespace()),
+    PrintPrometheusMetrics(this->GetMetrics(&namespaces->GetDefaultNamespace()),
                            this->dfly_cmd_.get(), &resp);
 
     return send->Invoke(std::move(resp));
@@ -1608,7 +1608,7 @@ void ServerFamily::StatsMC(std::string_view section, SinkReplyBuilder* builder) 
   double utime = dbl_time(ru.ru_utime);
   double systime = dbl_time(ru.ru_stime);
 
-  Metrics m = GetMetrics(&namespaces.GetDefaultNamespace());
+  Metrics m = GetMetrics(&namespaces->GetDefaultNamespace());
 
   ADD_LINE(pid, getpid());
   ADD_LINE(uptime, m.uptime);
@@ -1638,7 +1638,7 @@ GenericError ServerFamily::DoSave(bool ignore_state) {
   const CommandId* cid = service().FindCmd("SAVE");
   CHECK_NOTNULL(cid);
   boost::intrusive_ptr<Transaction> trans(new Transaction{cid});
-  trans->InitByArgs(&namespaces.GetDefaultNamespace(), 0, {});
+  trans->InitByArgs(&namespaces->GetDefaultNamespace(), 0, {});
   return DoSave(absl::GetFlag(FLAGS_df_snapshot_format), {}, trans.get(), ignore_state);
 }
 
@@ -1826,7 +1826,7 @@ bool ServerFamily::DoAuth(ConnectionContext* cntx, std::string_view username,
     cntx->acl_commands = cred.acl_commands;
     cntx->keys = std::move(cred.keys);
     cntx->pub_sub = std::move(cred.pub_sub);
-    cntx->ns = &namespaces.GetOrInsert(cred.ns);
+    cntx->ns = &namespaces->GetOrInsert(cred.ns);
     cntx->authenticated = true;
   }
   return is_authorized;

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -117,7 +117,7 @@ class BaseFamilyTest : public ::testing::Test {
   static std::vector<std::string> StrArray(const RespExpr& expr);
 
   Metrics GetMetrics() const {
-    return service_->server_family().GetMetrics(&namespaces.GetDefaultNamespace());
+    return service_->server_family().GetMetrics(&namespaces->GetDefaultNamespace());
   }
 
   void ClearMetrics();


### PR DESCRIPTION
Before the namespaces object was defined globally. However it has non-trivial d'tor that is being called after main exits. It's quite dangerous to have global non-POD objects being defined globally. For example, if we used LOG(INFO) inside the Clear function , that would crash dragonfly on exit.

Ths PR changes it to be a global pointer.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->