### PR TITLE
fix(server): handle running script load inside multi

### DIFF
--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -18,6 +18,8 @@ extern "C" {
 #include "base/flags.h"
 #include "base/logging.h"
 #include "core/compact_object.h"
+#include "core/interpreter.h"
+#include "server/conn_context.h"
 #include "server/engine_shard_set.h"
 #include "server/error.h"
 #include "server/journal/journal.h"
@@ -451,6 +453,31 @@ void ThreadLocalMutex::unlock() {
     cond_var_.notify_one();
     locked_fiber_ = nullptr;
   }
+}
+
+BorrowedInterpreter::BorrowedInterpreter(Transaction* tx, ConnectionContext* cntx) {
+  // Ensure squashing ignores EVAL. We can't run on a stub context, because it doesn't have our
+  // preborrowed interpreter (which can't be shared on multiple threads).
+  CHECK(!cntx->conn_state.squashing_info);
+
+  if (auto borrowed = cntx->conn_state.exec_info.preborrowed_interpreter; borrowed) {
+    // Ensure a preborrowed interpreter is only set for an already running MULTI transaction.
+    CHECK_EQ(cntx->conn_state.exec_info.state, ConnectionState::ExecInfo::EXEC_RUNNING);
+
+    interpreter_ = borrowed;
+  } else {
+    // A scheduled transaction occupies a place in the transaction queue and holds locks,
+    // preventing other transactions from progressing. Blocking below can deadlock!
+    CHECK(!tx->IsScheduled());
+
+    interpreter_ = ServerState::tlocal()->BorrowInterpreter();
+    owned_ = true;
+  }
+}
+
+BorrowedInterpreter::~BorrowedInterpreter() {
+  if (owned_)
+    ServerState::tlocal()->ReturnInterpreter(interpreter_);
 }
 
 }  // namespace dfly

--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -455,14 +455,14 @@ void ThreadLocalMutex::unlock() {
   }
 }
 
-BorrowedInterpreter::BorrowedInterpreter(Transaction* tx, ConnectionContext* cntx) {
+BorrowedInterpreter::BorrowedInterpreter(Transaction* tx, ConnectionState* state) {
   // Ensure squashing ignores EVAL. We can't run on a stub context, because it doesn't have our
   // preborrowed interpreter (which can't be shared on multiple threads).
-  CHECK(!cntx->conn_state.squashing_info);
+  CHECK(!state->squashing_info);
 
-  if (auto borrowed = cntx->conn_state.exec_info.preborrowed_interpreter; borrowed) {
+  if (auto borrowed = state->exec_info.preborrowed_interpreter; borrowed) {
     // Ensure a preborrowed interpreter is only set for an already running MULTI transaction.
-    CHECK_EQ(cntx->conn_state.exec_info.state, ConnectionState::ExecInfo::EXEC_RUNNING);
+    CHECK_EQ(state->exec_info.state, ConnectionState::ExecInfo::EXEC_RUNNING);
 
     interpreter_ = borrowed;
   } else {

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -47,6 +47,8 @@ using RdbTypeFreqMap = absl::flat_hash_map<unsigned, size_t>;
 class CommandId;
 class Transaction;
 class EngineShard;
+class ConnectionContext;
+class Interpreter;
 
 struct LockTagOptions {
   bool enabled = false;
@@ -351,6 +353,29 @@ template <typename Mutex> class ABSL_SCOPED_LOCKABLE SharedLock {
  private:
   Mutex& m_;
   bool is_locked_;
+};
+
+// Ensures availability of an interpreter for EVAL-like commands and it's automatic release.
+// If it's part of MULTI, the preborrowed interpreter is returned, otherwise a new is acquired.
+struct BorrowedInterpreter {
+  BorrowedInterpreter(Transaction* tx, ConnectionContext* cntx);
+
+  ~BorrowedInterpreter();
+
+  // Give up ownership of the interpreter, it must be returned manually.
+  Interpreter* Release() && {
+    DCHECK(owned_);
+    owned_ = false;
+    return interpreter_;
+  }
+
+  operator Interpreter*() {
+    return interpreter_;
+  }
+
+ private:
+  Interpreter* interpreter_ = nullptr;
+  bool owned_ = false;
 };
 
 extern size_t serialization_max_chunk_size;

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -47,7 +47,7 @@ using RdbTypeFreqMap = absl::flat_hash_map<unsigned, size_t>;
 class CommandId;
 class Transaction;
 class EngineShard;
-class ConnectionContext;
+class ConnectionState;
 class Interpreter;
 
 struct LockTagOptions {
@@ -358,7 +358,7 @@ template <typename Mutex> class ABSL_SCOPED_LOCKABLE SharedLock {
 // Ensures availability of an interpreter for EVAL-like commands and it's automatic release.
 // If it's part of MULTI, the preborrowed interpreter is returned, otherwise a new is acquired.
 struct BorrowedInterpreter {
-  BorrowedInterpreter(Transaction* tx, ConnectionContext* cntx);
+  BorrowedInterpreter(Transaction* tx, ConnectionState* state);
 
   ~BorrowedInterpreter();
 

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -74,7 +74,7 @@ size_t StoredCmd::NumArgs() const {
 
 std::string StoredCmd::FirstArg() const {
   if (sizes_.size() == 0) {
-    return "";
+    return {};
   }
   return buffer_.substr(0, sizes_[0]);
 }

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -4,7 +4,6 @@
 
 #include "server/conn_context.h"
 
-#include "absl/strings/match.h"
 #include "base/logging.h"
 #include "core/heap_size.h"
 #include "facade/acl_commands_def.h"

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -4,6 +4,7 @@
 
 #include "server/conn_context.h"
 
+#include "absl/strings/match.h"
 #include "base/logging.h"
 #include "core/heap_size.h"
 #include "facade/acl_commands_def.h"
@@ -70,6 +71,13 @@ void StoredCmd::Fill(absl::Span<std::string_view> args) {
 
 size_t StoredCmd::NumArgs() const {
   return sizes_.size();
+}
+
+std::string StoredCmd::FirstArg() const {
+  if (sizes_.size() == 0) {
+    return "";
+  }
+  return buffer_.substr(0, sizes_[0]);
 }
 
 facade::ReplyMode StoredCmd::ReplyMode() const {

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -46,6 +46,8 @@ class StoredCmd {
     Fill(absl::MakeSpan(*dest));
   }
 
+  std::string FirstArg() const;
+
   const CommandId* Cid() const;
 
   facade::ReplyMode ReplyMode() const;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -684,32 +684,33 @@ void ClusterHtmlPage(const http::QueryArgs& args, HttpContext* send,
   send->Invoke(std::move(resp));
 }
 
-enum class ExecEvalState {
+enum class ExecScriptUse {
   NONE = 0,
-  ALL = 1,
-  SOME = 2,
+  SCRIPT_LOAD = 1,
+  SCRIPT_RUN = 2,
 };
 
-ExecEvalState DetermineEvalPresense(const std::vector<StoredCmd>& body) {
-  unsigned eval_cnt = 0;
+ExecScriptUse DetermineScriptPresense(const std::vector<StoredCmd>& body) {
+  bool script_load = false;
   for (const auto& scmd : body) {
     if (CO::IsEvalKind(scmd.Cid()->name())) {
-      eval_cnt++;
+      return ExecScriptUse::SCRIPT_RUN;
+    }
+
+    if ((scmd.Cid()->name() == "SCRIPT") && (absl::AsciiStrToUpper(scmd.FirstArg()) == "LOAD")) {
+      script_load = true;
     }
   }
 
-  if (eval_cnt == 0)
-    return ExecEvalState::NONE;
+  if (script_load)
+    return ExecScriptUse::SCRIPT_LOAD;
 
-  if (eval_cnt == body.size())
-    return ExecEvalState::ALL;
-
-  return ExecEvalState::SOME;
+  return ExecScriptUse::NONE;
 }
 
 // Returns the multi mode for that transaction. Returns NOT_DETERMINED if no scheduling
 // is required.
-Transaction::MultiMode DeduceExecMode(ExecEvalState state,
+Transaction::MultiMode DeduceExecMode(ExecScriptUse state,
                                       const ConnectionState::ExecInfo& exec_info,
                                       const ScriptMgr& script_mgr) {
   // Check if script most LIKELY has global eval transactions
@@ -717,7 +718,7 @@ Transaction::MultiMode DeduceExecMode(ExecEvalState state,
   Transaction::MultiMode multi_mode =
       static_cast<Transaction::MultiMode>(absl::GetFlag(FLAGS_multi_exec_mode));
 
-  if (state != ExecEvalState::NONE) {
+  if (state == ExecScriptUse::SCRIPT_RUN) {
     contains_global = script_mgr.AreGlobalByDefault();
   }
 
@@ -764,50 +765,6 @@ string CreateExecDescriptor(const std::vector<StoredCmd>& stored_cmds, unsigned 
 
   return result;
 }
-
-// Ensures availability of an interpreter for EVAL-like commands and it's automatic release.
-// If it's part of MULTI, the preborrowed interpreter is returned, otherwise a new is acquired.
-struct BorrowedInterpreter {
-  BorrowedInterpreter(Transaction* tx, ConnectionContext* cntx) {
-    // Ensure squashing ignores EVAL. We can't run on a stub context, because it doesn't have our
-    // preborrowed interpreter (which can't be shared on multiple threads).
-    CHECK(!cntx->conn_state.squashing_info);
-
-    if (auto borrowed = cntx->conn_state.exec_info.preborrowed_interpreter; borrowed) {
-      // Ensure a preborrowed interpreter is only set for an already running MULTI transaction.
-      CHECK_EQ(cntx->conn_state.exec_info.state, ConnectionState::ExecInfo::EXEC_RUNNING);
-
-      interpreter_ = borrowed;
-    } else {
-      // A scheduled transaction occupies a place in the transaction queue and holds locks,
-      // preventing other transactions from progressing. Blocking below can deadlock!
-      CHECK(!tx->IsScheduled());
-
-      interpreter_ = ServerState::tlocal()->BorrowInterpreter();
-      owned_ = true;
-    }
-  }
-
-  ~BorrowedInterpreter() {
-    if (owned_)
-      ServerState::tlocal()->ReturnInterpreter(interpreter_);
-  }
-
-  // Give up ownership of the interpreter, it must be returned manually.
-  Interpreter* Release() && {
-    DCHECK(owned_);
-    owned_ = false;
-    return interpreter_;
-  }
-
-  operator Interpreter*() {
-    return interpreter_;
-  }
-
- private:
-  Interpreter* interpreter_ = nullptr;
-  bool owned_ = false;
-};
 
 string ConnectionLogContext(const facade::Connection* conn) {
   if (conn == nullptr) {
@@ -2255,10 +2212,10 @@ void Service::Exec(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder,
   cntx->last_command_debug.exec_body_len = exec_info.body.size();
 
   // The transaction can contain scripts, determine their presence ahead to customize logic below.
-  ExecEvalState state = DetermineEvalPresense(exec_info.body);
+  ExecScriptUse state = DetermineScriptPresense(exec_info.body);
 
   // We borrow a single interpreter for all the EVALs inside. Returned by MultiCleanup
-  if (state != ExecEvalState::NONE) {
+  if (state != ExecScriptUse::NONE) {
     exec_info.preborrowed_interpreter = BorrowedInterpreter(tx, cntx).Release();
   }
 
@@ -2293,7 +2250,7 @@ void Service::Exec(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder,
       ServerState::tlocal()->exec_freq_count[descr]++;
     }
 
-    if (absl::GetFlag(FLAGS_multi_exec_squash) && state == ExecEvalState::NONE &&
+    if (absl::GetFlag(FLAGS_multi_exec_squash) && state != ExecScriptUse::SCRIPT_RUN &&
         !cntx->conn_state.tracking_info_.IsTrackingOn()) {
       MultiCommandSquasher::Execute(absl::MakeSpan(exec_info.body), rb, cntx, this);
     } else {

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -1147,6 +1147,24 @@ TEST_F(MultiEvalTest, MultiAndEval) {
   Run({"eval", "return 'OK';", "0"});
   auto resp = Run({"exec"});
   EXPECT_EQ(resp, "OK");
+
+  // We had a bug running script load inside multi
+  Run({"multi"});
+  Run({"script", "load", "return '5'"});
+  Run({"exec"});
+
+  Run({"multi"});
+  Run({"script", "load", "return '5'"});
+  Run({"get", "x"});
+  Run({"exec"});
+
+  Run({"multi"});
+  Run({"script", "load", "return '5'"});
+  Run({"eval", "return redis.call('set', 'x', 'y')", "1", "x"});
+  Run({"get", "x"});
+  Run({"exec"});
+
+  Run({"get", "x"});
 }
 
 TEST_F(MultiTest, MultiTypes) {

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -1160,6 +1160,11 @@ TEST_F(MultiEvalTest, MultiAndEval) {
 
   Run({"multi"});
   Run({"script", "load", "return '5'"});
+  Run({"mset", "x1", "y1", "x2", "y2"});
+  Run({"exec"});
+
+  Run({"multi"});
+  Run({"script", "load", "return '5'"});
   Run({"eval", "return redis.call('set', 'x', 'y')", "1", "x"});
   Run({"get", "x"});
   Run({"exec"});

--- a/src/server/script_mgr.cc
+++ b/src/server/script_mgr.cc
@@ -155,7 +155,7 @@ void ScriptMgr::LoadCmd(CmdArgList args, Transaction* tx, SinkReplyBuilder* buil
     return rb->SendBulkString(sha);
   }
 
-  BorrowedInterpreter interpreter{tx, cntx};
+  BorrowedInterpreter interpreter{tx, &cntx->conn_state};
 
   auto res = Insert(body, interpreter);
   if (!res)

--- a/src/server/script_mgr.cc
+++ b/src/server/script_mgr.cc
@@ -67,7 +67,8 @@ ScriptMgr::ScriptKey::ScriptKey(string_view sha) : array{} {
   memcpy(data(), sha.data(), size());
 }
 
-void ScriptMgr::Run(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder) {
+void ScriptMgr::Run(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder,
+                    ConnectionContext* cntx) {
   string subcmd = absl::AsciiStrToUpper(ArgS(args, 0));
 
   if (subcmd == "HELP") {
@@ -110,7 +111,7 @@ void ScriptMgr::Run(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder)
     return LatencyCmd(tx, builder);
 
   if (subcmd == "LOAD" && args.size() == 2)
-    return LoadCmd(args, tx, builder);
+    return LoadCmd(args, tx, builder, cntx);
 
   if (subcmd == "FLAGS" && args.size() > 2)
     return ConfigCmd(args, tx, builder);
@@ -144,7 +145,8 @@ void ScriptMgr::FlushCmd(CmdArgList args, Transaction* tx, SinkReplyBuilder* bui
   return builder->SendOk();
 }
 
-void ScriptMgr::LoadCmd(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder) {
+void ScriptMgr::LoadCmd(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder,
+                        ConnectionContext* cntx) {
   string_view body = ArgS(args, 1);
   auto rb = static_cast<RedisReplyBuilder*>(builder);
   if (body.empty()) {
@@ -153,9 +155,7 @@ void ScriptMgr::LoadCmd(CmdArgList args, Transaction* tx, SinkReplyBuilder* buil
     return rb->SendBulkString(sha);
   }
 
-  ServerState* ss = ServerState::tlocal();
-  auto interpreter = ss->BorrowInterpreter();
-  absl::Cleanup clean = [ss, interpreter]() { ss->ReturnInterpreter(interpreter); };
+  BorrowedInterpreter interpreter{tx, cntx};
 
   auto res = Insert(body, interpreter);
   if (!res)

--- a/src/server/script_mgr.h
+++ b/src/server/script_mgr.h
@@ -48,7 +48,7 @@ class ScriptMgr {
 
   ScriptMgr();
 
-  void Run(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder);
+  void Run(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder, ConnectionContext* cntx);
 
   // Insert script and return sha. Get possible error from compilation or parsing script flags.
   io::Result<std::string, GenericError> Insert(std::string_view body, Interpreter* interpreter);
@@ -69,7 +69,8 @@ class ScriptMgr {
  private:
   void ExistsCmd(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder) const;
   void FlushCmd(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder);
-  void LoadCmd(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder);
+  void LoadCmd(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder,
+               ConnectionContext* cntx);
   void ConfigCmd(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder);
   void ListCmd(Transaction* tx, SinkReplyBuilder* builder) const;
   void LatencyCmd(Transaction* tx, SinkReplyBuilder* builder) const;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -3008,7 +3008,7 @@ void ServerFamily::Role(CmdArgList args, Transaction* tx, SinkReplyBuilder* buil
 
 void ServerFamily::Script(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder,
                           ConnectionContext* cntx) {
-  script_mgr_->Run(std::move(args), tx, builder);
+  script_mgr_->Run(std::move(args), tx, builder, cntx);
 }
 
 void ServerFamily::LastSave(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder,

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -399,10 +399,7 @@ OpStatus Transaction::InitByArgs(Namespace* ns, DbIndex index, CmdArgList args) 
   }
 
   if ((cid_->opt_mask() & CO::NO_KEY_TRANSACTIONAL) > 0) {
-    // If the transaction should snap on all shards we preparte the transaction to run on all
-    // shards. If its multi transaction we also prepare it to run on all shard to make shure we dont
-    // shring the per shard data array as it still might be read by leftover callbacks.
-    if (((cid_->opt_mask() & CO::NO_KEY_TX_SPAN_ALL) > 0) || IsActiveMulti()) {
+    if (((cid_->opt_mask() & CO::NO_KEY_TX_SPAN_ALL) > 0)) {
       EnableAllShards();
     } else {
       EnableShard(0);
@@ -981,7 +978,7 @@ string Transaction::DEBUG_PrintFailState(ShardId sid) const {
 void Transaction::EnableShard(ShardId sid) {
   unique_shard_cnt_ = 1;
   unique_shard_id_ = sid;
-  shard_data_.resize(1);
+  shard_data_.resize(IsActiveMulti() ? shard_set->size() : 1);
   shard_data_.front().local_mask |= ACTIVE;
 }
 

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -399,6 +399,9 @@ OpStatus Transaction::InitByArgs(Namespace* ns, DbIndex index, CmdArgList args) 
   }
 
   if ((cid_->opt_mask() & CO::NO_KEY_TRANSACTIONAL) > 0) {
+    // If the transaction should snap on all shards we preparte the transaction to run on all
+    // shards. If its multi transaction we also prepare it to run on all shard to make shure we dont
+    // shring the per shard data array as it still might be read by leftover callbacks.
     if (((cid_->opt_mask() & CO::NO_KEY_TX_SPAN_ALL) > 0) || IsActiveMulti()) {
       EnableAllShards();
     } else {

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -399,10 +399,12 @@ OpStatus Transaction::InitByArgs(Namespace* ns, DbIndex index, CmdArgList args) 
   }
 
   if ((cid_->opt_mask() & CO::NO_KEY_TRANSACTIONAL) > 0) {
-    if ((cid_->opt_mask() & CO::NO_KEY_TX_SPAN_ALL) > 0)
+    if (((cid_->opt_mask() & CO::NO_KEY_TX_SPAN_ALL) > 0) || IsActiveMulti()) {
       EnableAllShards();
-    else
+    } else {
       EnableShard(0);
+    }
+
     return OpStatus::OK;
   }
 


### PR DESCRIPTION
fix #4071 
2 bugs found in the flow:
1. we did not use the interperter borrowed in the script load command before running the multi transaction
2. we call InitByArgs for each command in multi transaction. in this flow Transaction::shard_data_ must not be resized to 1. (see comment here - https://github.com/dragonflydb/dragonfly/blob/f8b3fa0d7bf1d95674f80eef826ffd66f5a57659/src/server/transaction.cc#L343) When calling script load we resized it to 1 leading to the crash.  