### PR TITLE
Add index based iterator to QList interface

### DIFF
--- a/src/core/qlist.h
+++ b/src/core/qlist.h
@@ -55,11 +55,6 @@ class QList {
 
   size_t MallocUsed() const;
 
-  // Peeks at the head or tail of the list. Precondition: list is not empty.
-  std::string Peek(Where where) const;
-
-  std::optional<std::string> Get(long index) const;
-
   void Iterate(IterateFunc cb, long start, long end) const;
 
   class Iterator {
@@ -70,18 +65,25 @@ class QList {
     bool Next();
 
    private:
-    QList* owner_;
-    quicklistNode* current_;
-    unsigned char* zi_; /* points to the current element */
-    long offset_;       /* offset in current listpack */
-    uint8_t direction_;
+    QList* owner_ = nullptr;
+    quicklistNode* current_ = nullptr;
+    unsigned char* zi_ = nullptr; /* points to the current element */
+    long offset_ = 0;             /* offset in current listpack */
+    uint8_t direction_ = 1;
 
     friend class QList;
   };
 
   // Returns an iterator to tail or the head of the list.
-  // To follow the quicklist interface, the iterator is not valid until Next() is called.
+  // To mirror the quicklist interface, the iterator is not valid until Next() is called.
+  // TODO: to fix this.
   Iterator GetIterator(Where where);
+
+  // Returns an iterator at a specific index 'idx',
+  // or Invalid iterator if index is out of range.
+  // negative index - means counting from the tail.
+  // Requires calling subsequent Next() to initialize the iterator.
+  Iterator GetIterator(long idx);
 
  private:
   bool AllowCompression() const {

--- a/src/core/qlist_test.cc
+++ b/src/core/qlist_test.cc
@@ -37,8 +37,7 @@ TEST_F(QListTest, Basic) {
   auto it = ql_.GetIterator(QList::HEAD);
   ASSERT_TRUE(it.Next());  // Needed to initialize the iterator.
 
-  QList::Entry entry = it.Get();
-  EXPECT_EQ("abc", entry.view());
+  EXPECT_EQ("abc", it.Get().view());
 
   ASSERT_FALSE(it.Next());
 
@@ -47,13 +46,18 @@ TEST_F(QListTest, Basic) {
 
   it = ql_.GetIterator(QList::TAIL);
   ASSERT_TRUE(it.Next());
-  entry = it.Get();
-  EXPECT_EQ("def", entry.view());
-  ASSERT_TRUE(it.Next());
+  EXPECT_EQ("def", it.Get().view());
 
-  entry = it.Get();
-  EXPECT_EQ("abc", entry.view());
+  ASSERT_TRUE(it.Next());
+  EXPECT_EQ("abc", it.Get().view());
   ASSERT_FALSE(it.Next());
+
+  it = ql_.GetIterator(0);
+  ASSERT_TRUE(it.Next());
+  EXPECT_EQ("abc", it.Get().view());
+  it = ql_.GetIterator(-1);
+  ASSERT_TRUE(it.Next());
+  EXPECT_EQ("def", it.Get().view());
 }
 
 };  // namespace dfly


### PR DESCRIPTION
Follows #4082

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->