### PR TITLE
feat(server) : snapshot traverse physical buckets

### DIFF
--- a/src/core/dash.h
+++ b/src/core/dash.h
@@ -232,7 +232,7 @@ class DashTable : public detail::DashTableBase {
   // shrinks or grows. Returns: cursor that is guaranteed to be less than 2^40.
   template <typename Cb> Cursor Traverse(Cursor curs, Cb&& cb);
 
-  // Traverses over a single physical bucket in table call cb once on bucket iterator.
+  // Traverses over physical buckets. It calls cb once for each bucket by passing a bucket iterator.
   // if cursor=0 starts traversing from the beginning, otherwise continues from where
   // it stopped. returns 0 if the supplied cursor reached end of traversal.
   // Unlike Traverse, TraverseBuckets calls cb once on bucket iterator and not on each entry in
@@ -943,7 +943,6 @@ auto DashTable<_Key, _Value, Policy>::Traverse(Cursor curs, Cb&& cb) -> Cursor {
 
   bool fetched = false;
 
-  // We fix bid and go over all segments. Once we reach the end we increase bid and repeat.
   while (!fetched) {
     uint32_t sid = curs.segment_id(global_depth_);
     uint8_t bid = curs.bucket_id();
@@ -964,6 +963,7 @@ auto DashTable<_Key, _Value, Policy>::Traverse(Cursor curs, Cb&& cb) -> Cursor {
 
 template <typename _Key, typename _Value, typename Policy>
 auto DashTable<_Key, _Value, Policy>::AdvanceCursorBucketOrder(Cursor cursor) -> Cursor {
+  // We fix bid and go over all segments. Once we reach the end we increase bid and repeat.
   uint32_t sid = cursor.segment_id(global_depth_);
   uint8_t bid = cursor.bucket_id();
   sid = NextSeg(sid);

--- a/src/core/dash_test.cc
+++ b/src/core/dash_test.cc
@@ -566,26 +566,6 @@ TEST_F(DashTest, Traverse) {
   EXPECT_EQ(kNumItems - 1, nums.back());
 }
 
-TEST_F(DashTest, Bucket) {
-  constexpr auto kNumItems = 250;
-  for (size_t i = 0; i < kNumItems; ++i) {
-    dt_.Insert(i, 0);
-  }
-  std::vector<uint64_t> s;
-  auto it = dt_.begin();
-  auto bucket_it = Dash64::BucketIt(it);
-
-  dt_.TraverseBucket(it, [&](auto i) { s.push_back(i->first); });
-
-  unsigned num_items = 0;
-  while (!bucket_it.is_done()) {
-    ASSERT_TRUE(find(s.begin(), s.end(), bucket_it->first) != s.end());
-    ++bucket_it;
-    ++num_items;
-  }
-  EXPECT_EQ(s.size(), num_items);
-}
-
 TEST_F(DashTest, TraverseSegmentOrder) {
   constexpr auto kNumItems = 50;
   for (size_t i = 0; i < kNumItems; ++i) {

--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -89,7 +89,7 @@ class SliceSnapshot {
   void SwitchIncrementalFb(Context* cntx, LSN lsn);
 
   // Called on traversing cursor by IterateBucketsFb.
-  bool BucketSaveCb(PrimeIterator it);
+  bool BucketSaveCb(PrimeTable::bucket_iterator it);
 
   // Serialize single bucket.
   // Returns number of serialized entries, updates bucket version to snapshot version.


### PR DESCRIPTION
This PR introduces new api to dash table TraversingBuckets which traveses table by physical buckets
when creating a snapshot we now call this api. The snapshot correctness stays and there are less calls to Serialize bucket callback as it is called only once per bucket and not on every slot 