### PR TITLE
chore: Add initial bindings for QList in list_family

### DIFF
--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -19,8 +19,8 @@
 namespace dfly {
 
 constexpr unsigned kEncodingIntSet = 0;
-constexpr unsigned kEncodingStrMap = 1;   // for set/map encodings of strings
 constexpr unsigned kEncodingStrMap2 = 2;  // for set/map encodings of strings using DenseSet
+constexpr unsigned kEncodingQL2 = 1;
 constexpr unsigned kEncodingListPack = 3;
 constexpr unsigned kEncodingJsonCons = 0;
 constexpr unsigned kEncodingJsonFlat = 1;

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -178,7 +178,7 @@ uint8_t RdbObjectType(const PrimeValue& pv) {
     case OBJ_SET:
       if (compact_enc == kEncodingIntSet)
         return RDB_TYPE_SET_INTSET;
-      else if (compact_enc == kEncodingStrMap || compact_enc == kEncodingStrMap2) {
+      else if (compact_enc == kEncodingStrMap2) {
         if (((StringSet*)pv.RObjPtr())->ExpirationUsed())
           return RDB_TYPE_SET_WITH_EXPIRY;
         else

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -26,8 +26,6 @@ extern "C" {
 #include "server/journal/journal.h"
 #include "server/transaction.h"
 
-ABSL_DECLARE_FLAG(bool, use_set2);
-
 namespace dfly {
 
 using namespace facade;


### PR DESCRIPTION
The feature is guarded by list_experimental_v2 flag, which is disabled.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->