### PR TITLE
fix: slow CI tests

### DIFF
--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -61,7 +61,6 @@ Test full replication pipeline. Test full sync with streaming changes and stable
         pytest.param(
             8, [8, 8], dict(key_target=1_000_000, units=16), 50_000, False, marks=M_STRESS
         ),
-        pytest.param(8, [8, 8], dict(key_target=1_000_000, units=16), 50_000, True, marks=M_STRESS),
     ],
 )
 @pytest.mark.parametrize("mode", [({}), ({"cache_mode": "true"})])

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -599,7 +599,7 @@ async def test_big_value_serialization_memory_limit(df_factory, query):
     await client.execute_command("SAVE")
     info = await client.info("ALL")
 
-    upper_limit = 2_200_000_000  # 2.2 GB
+    upper_limit = 2_250_000_000  # 2.25 GB
     assert info["used_memory_peak_rss"] < upper_limit
 
     await client.execute_command("FLUSHALL")

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -566,12 +566,12 @@ async def test_tiered_entries_throttle(async_client: aioredis.Redis):
     assert await StaticSeeder.capture(async_client) == start_capture
 
 
-@dfly_args({"proactor_threads": 1})
+@dfly_args({"serialization_max_chunk_size": 4096, "proactor_threads": 1})
 @pytest.mark.parametrize(
     "query",
     [
-        ("HSET"),
-        ("SADD"),
+        ("HASH"),
+        ("SET"),
         ("ZSET"),
         ("LIST"),
     ],
@@ -583,38 +583,25 @@ async def test_big_value_serialization_memory_limit(df_factory, query):
     instance.start()
     client = instance.client()
 
-    ten_mb = 10_000_000
+    one_gb = 1_000_000_000
+    elements = 1000
+    one_mb = 1_000_000
 
-    def ten_mb_random_string():
-        return "".join(random.choices(string.ascii_letters, k=ten_mb))
+    await client.execute_command(
+        f"debug populate 1 prefix {one_mb} TYPE {query} RAND ELEMENTS {elements}"
+    )
 
-    one_gb = 1_000_000_000  # 1GB
-
-    upper_limit = one_gb * 1.1  # 1GB + 100MB
-
-    i = 0
-
-    while instance.rss < one_gb:
-        if query == "HSET":
-            i = i + 1
-            await client.execute_command(f"HSET foo_key foo_{i} {ten_mb_random_string()}")
-        elif query == "SADD":
-            await client.execute_command(f"SADD foo_key {ten_mb_random_string()}")
-        elif query == "ZSET":
-            await client.execute_command(f"ZADD foo_key {i} {ten_mb_random_string()}")
-        elif query == "LIST":
-            await client.execute_command(f"LPUSH foo_key {ten_mb_random_string()}")
-
-    async def check_memory_usage(instance):
-        while True:
-            assert instance.rss < upper_limit
-            await asyncio.sleep(0.01)
-
-    checker = asyncio.create_task(check_memory_usage(instance))
-
+    info = await client.info("ALL")
+    # rss double's because of DEBUG POPULATE
+    assert info["used_memory_peak_rss"] > (one_gb * 2)
+    # if we execute SAVE below without big value serialization we trigger the assertion below.
+    # note the peak would reach (one_gb * 3) without it.
     await client.execute_command("SAVE")
+    info = await client.info("ALL")
 
-    checker.cancel()
+    upper_limit = 2_200_000_000  # 2.2 GB
+    assert info["used_memory_peak_rss"] < upper_limit
+
     await client.execute_command("FLUSHALL")
     await client.close()
 

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -568,7 +568,7 @@ async def test_tiered_entries_throttle(async_client: aioredis.Redis):
 
 @dfly_args({"serialization_max_chunk_size": 4096, "proactor_threads": 1})
 @pytest.mark.parametrize(
-    "query",
+    "cont_type",
     [
         ("HASH"),
         ("SET"),
@@ -577,7 +577,7 @@ async def test_tiered_entries_throttle(async_client: aioredis.Redis):
     ],
 )
 @pytest.mark.slow
-async def test_big_value_serialization_memory_limit(df_factory, query):
+async def test_big_value_serialization_memory_limit(df_factory, cont_type):
     dbfilename = f"dump_{tmp_file_name()}"
     instance = df_factory.create(dbfilename=dbfilename)
     instance.start()
@@ -585,10 +585,10 @@ async def test_big_value_serialization_memory_limit(df_factory, query):
 
     one_gb = 1_000_000_000
     elements = 1000
-    one_mb = 1_000_000
+    element_size = 1_000_000  # 1mb
 
     await client.execute_command(
-        f"debug populate 1 prefix {one_mb} TYPE {query} RAND ELEMENTS {elements}"
+        f"debug populate 1 prefix {element_size} TYPE {cont_type} RAND ELEMENTS {elements}"
     )
 
     info = await client.info("ALL")


### PR DESCRIPTION
We have a few *very* slow tests on the CI. Specifically: 

```
241.30s call     dragonfly/replication_test.py::test_replication_all[df_factory0-mode0-8-t_replicas8-seeder_config8-50000-True]
240.80s call     dragonfly/replication_test.py::test_replication_all[df_factory0-mode0-8-t_replicas7-seeder_config7-50000-False]
239.92s call     dragonfly/replication_test.py::test_replication_all[df_factory0-mode1-8-t_replicas7-seeder_config7-50000-False]
236.87s call     dragonfly/replication_test.py::test_replication_all[df_factory0-mode1-8-t_replicas8-seeder_config8-50000-True]
178.18s call     dragonfly/snapshot_test.py::test_big_value_serialization_memory_limit[HSET-df_factory0]
175.97s call     dragonfly/snapshot_test.py::test_big_value_serialization_memory_limit[SADD-df_factory0]
175.79s call     dragonfly/snapshot_test.py::test_big_value_serialization_memory_limit[ZSET-df_factory0]
172.35s call     dragonfly/snapshot_test.py::test_big_value_serialization_memory_limit[LIST-df_factory0]
60.21s call     dragonfly/connection_test.py::test_pubsub_busy_connections[df_factory0]
```

This PR changes:

It refactors the `test_big_value_serialization`. First, the test was incorrect, in fact for some reason it did not even run with big value serialization flag set. Second, the test used `execute_command` in a loop which took a `substantial` amount of time. The changes on my machine reduce the total running time of the test from `4 * 170 seconds` on `average` to a staggering `1 minute and 10 seconds` for *all 4*. 

Also notice, that we don't really need to test big value serialization on a stress test. It's redundant because when we set the value to a small number (4096 etc) it will have the same effect regardless of the stress load. I removed that one test case, saving as roughly (235 * 2) seconds 

* refactor test_big_value_serialization
* remove no needed replication tests for big value