### PR TITLE
chore: Reduce memory consumption when migrating huge values

### DIFF
--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -156,7 +156,7 @@ class SerializerBase {
   virtual ~SerializerBase() = default;
 
   // Dumps `obj` in DUMP command format into `out`. Uses default compression mode.
-  static void DumpObject(const CompactObj& obj, io::StringSink* out);
+  static void DumpObject(const CompactObj& obj, io::Sink* out);
 
   // Internal buffer size. Might shrink after flush due to compression.
   size_t SerializedLen() const;


### PR DESCRIPTION
Before this PR:

We serialized a `RESTORE` command for each entry into a string, and then push that string to the wire.
This means that, when serializing an entry of size X, we consume 2X memory during the migration.

This PR:

Instead of serializing into a string, we serialize into the wire directly. Luckily, only a small modification is needed in the way we interact with `crc64`, which works well even in chunks.

Fixes #4100

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->