### PR TITLE
fix: Use `MOVED` error type for moved replies

### DIFF
--- a/src/server/cluster/cluster_defs.cc
+++ b/src/server/cluster/cluster_defs.cc
@@ -116,15 +116,16 @@ bool IsClusterShardedByTag() {
   return IsClusterEnabledOrEmulated() || LockTagOptions::instance().enabled;
 }
 
-std::optional<std::string> SlotOwnershipErrorStr(SlotId slot_id) {
+std::optional<facade::ErrorReply> SlotOwnershipError(SlotId slot_id) {
   const cluster::ClusterConfig* cluster_config = ClusterFamily::cluster_config();
   if (!cluster_config)
-    return facade::kClusterNotConfigured;
+    return facade::ErrorReply{facade::kClusterNotConfigured};
 
   if (!cluster_config->IsMySlot(slot_id)) {
     // See more details here: https://redis.io/docs/reference/cluster-spec/#moved-redirection
     cluster::ClusterNodeInfo master = cluster_config->GetMasterNodeForSlot(slot_id);
-    return absl::StrCat("-MOVED ", slot_id, " ", master.ip, ":", master.port);
+    return facade::ErrorReply{absl::StrCat("-MOVED ", slot_id, " ", master.ip, ":", master.port),
+                              "MOVED"};
   }
   return std::nullopt;
 }

--- a/src/server/cluster/cluster_defs.cc
+++ b/src/server/cluster/cluster_defs.cc
@@ -116,7 +116,7 @@ bool IsClusterShardedByTag() {
   return IsClusterEnabledOrEmulated() || LockTagOptions::instance().enabled;
 }
 
-std::optional<facade::ErrorReply> SlotOwnershipError(SlotId slot_id) {
+facade::ErrorReply SlotOwnershipError(SlotId slot_id) {
   const cluster::ClusterConfig* cluster_config = ClusterFamily::cluster_config();
   if (!cluster_config)
     return facade::ErrorReply{facade::kClusterNotConfigured};
@@ -127,6 +127,6 @@ std::optional<facade::ErrorReply> SlotOwnershipError(SlotId slot_id) {
     return facade::ErrorReply{absl::StrCat("-MOVED ", slot_id, " ", master.ip, ":", master.port),
                               "MOVED"};
   }
-  return std::nullopt;
+  return facade::ErrorReply{facade::OpStatus::OK};
 }
 }  // namespace dfly::cluster

--- a/src/server/cluster/cluster_defs.h
+++ b/src/server/cluster/cluster_defs.h
@@ -172,7 +172,7 @@ enum class MigrationState : uint8_t {
 SlotId KeySlot(std::string_view key);
 
 // return error message if slot doesn't belong to this node
-std::optional<facade::ErrorReply> SlotOwnershipError(SlotId slot_id);
+facade::ErrorReply SlotOwnershipError(SlotId slot_id);
 
 void InitializeCluster();
 bool IsClusterEnabled();

--- a/src/server/cluster/cluster_defs.h
+++ b/src/server/cluster/cluster_defs.h
@@ -10,6 +10,8 @@
 #include <string_view>
 #include <vector>
 
+#include "facade/facade_types.h"
+
 namespace dfly::cluster {
 
 using SlotId = uint16_t;
@@ -170,8 +172,7 @@ enum class MigrationState : uint8_t {
 SlotId KeySlot(std::string_view key);
 
 // return error message if slot doesn't belong to this node
-std::optional<std::string> SlotOwnershipErrorStr(SlotId slot_id);
-constexpr auto kMovedErrorType = std::string_view("MOVED");
+std::optional<facade::ErrorReply> SlotOwnershipError(SlotId slot_id);
 
 void InitializeCluster();
 bool IsClusterEnabled();

--- a/src/server/cluster/cluster_defs.h
+++ b/src/server/cluster/cluster_defs.h
@@ -171,6 +171,7 @@ SlotId KeySlot(std::string_view key);
 
 // return error message if slot doesn't belong to this node
 std::optional<std::string> SlotOwnershipErrorStr(SlotId slot_id);
+constexpr auto kMovedErrorType = std::string_view("MOVED");
 
 void InitializeCluster();
 bool IsClusterEnabled();

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -1120,7 +1120,7 @@ void BPopGeneric(ListDir dir, CmdArgList args, Transaction* tx, SinkReplyBuilder
     case OpStatus::KEY_MOVED: {
       auto error = cluster::SlotOwnershipErrorStr(*tx->GetUniqueSlotId());
       CHECK(error.has_value());
-      return builder->SendError(std::move(*error));
+      return builder->SendError(std::move(*error), dfly::cluster::kMovedErrorType);
     }
     default:
       LOG(ERROR) << "Unexpected error " << popped_key.status();

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -1119,7 +1119,7 @@ void BPopGeneric(ListDir dir, CmdArgList args, Transaction* tx, SinkReplyBuilder
       return rb->SendNullArray();
     case OpStatus::KEY_MOVED: {
       auto error = cluster::SlotOwnershipError(*tx->GetUniqueSlotId());
-      CHECK(error.status.has_value() && error.status.value() != facade::OpStatus::OK);
+      CHECK(!error.status.has_value() || error.status.value() != facade::OpStatus::OK);
       return builder->SendError(std::move(error));
     }
     default:

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -1119,8 +1119,8 @@ void BPopGeneric(ListDir dir, CmdArgList args, Transaction* tx, SinkReplyBuilder
       return rb->SendNullArray();
     case OpStatus::KEY_MOVED: {
       auto error = cluster::SlotOwnershipError(*tx->GetUniqueSlotId());
-      CHECK(error.has_value());
-      return builder->SendError(std::move(*error));
+      CHECK(error.status.has_value() && error.status.value() != facade::OpStatus::OK);
+      return builder->SendError(std::move(error));
     }
     default:
       LOG(ERROR) << "Unexpected error " << popped_key.status();

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -1118,9 +1118,9 @@ void BPopGeneric(ListDir dir, CmdArgList args, Transaction* tx, SinkReplyBuilder
     case OpStatus::TIMED_OUT:
       return rb->SendNullArray();
     case OpStatus::KEY_MOVED: {
-      auto error = cluster::SlotOwnershipErrorStr(*tx->GetUniqueSlotId());
+      auto error = cluster::SlotOwnershipError(*tx->GetUniqueSlotId());
       CHECK(error.has_value());
-      return builder->SendError(std::move(*error), dfly::cluster::kMovedErrorType);
+      return builder->SendError(std::move(*error));
     }
     default:
       LOG(ERROR) << "Unexpected error " << popped_key.status();

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -941,7 +941,7 @@ optional<ErrorReply> Service::CheckKeysOwnership(const CommandId* cid, CmdArgLis
 
   if (keys_slot.has_value()) {
     if (auto error_str = cluster::SlotOwnershipErrorStr(*keys_slot); error_str) {
-      return ErrorReply{std::move(*error_str)};
+      return ErrorReply{std::move(*error_str), dfly::cluster::kMovedErrorType};
     }
   }
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -941,7 +941,7 @@ optional<ErrorReply> Service::CheckKeysOwnership(const CommandId* cid, CmdArgLis
 
   if (keys_slot.has_value()) {
     if (auto error = cluster::SlotOwnershipError(*keys_slot);
-        error.status.has_value() && error.status.value() == facade::OpStatus::OK) {
+        !error.status.has_value() || error.status.value() != facade::OpStatus::OK) {
       return ErrorReply{std::move(error)};
     }
   }

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -940,8 +940,9 @@ optional<ErrorReply> Service::CheckKeysOwnership(const CommandId* cid, CmdArgLis
   }
 
   if (keys_slot.has_value()) {
-    if (auto error = cluster::SlotOwnershipError(*keys_slot); error) {
-      return ErrorReply{std::move(*error)};
+    if (auto error = cluster::SlotOwnershipError(*keys_slot);
+        error.status.has_value() && error.status.value() == facade::OpStatus::OK) {
+      return ErrorReply{std::move(error)};
     }
   }
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -940,8 +940,8 @@ optional<ErrorReply> Service::CheckKeysOwnership(const CommandId* cid, CmdArgLis
   }
 
   if (keys_slot.has_value()) {
-    if (auto error_str = cluster::SlotOwnershipErrorStr(*keys_slot); error_str) {
-      return ErrorReply{std::move(*error_str), dfly::cluster::kMovedErrorType};
+    if (auto error = cluster::SlotOwnershipError(*keys_slot); error) {
+      return ErrorReply{std::move(*error)};
     }
   }
 

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1281,7 +1281,7 @@ void BZPopMinMax(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder,
     case OpStatus::KEY_MOVED: {
       auto error = cluster::SlotOwnershipErrorStr(*tx->GetUniqueSlotId());
       CHECK(error.has_value());
-      return builder->SendError(std::move(*error));
+      return builder->SendError(std::move(*error), dfly::cluster::kMovedErrorType);
     }
     default:
       LOG(ERROR) << "Unexpected error " << popped_key.status();

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1279,9 +1279,9 @@ void BZPopMinMax(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder,
     case OpStatus::TIMED_OUT:
       return rb->SendNullArray();
     case OpStatus::KEY_MOVED: {
-      auto error = cluster::SlotOwnershipErrorStr(*tx->GetUniqueSlotId());
+      auto error = cluster::SlotOwnershipError(*tx->GetUniqueSlotId());
       CHECK(error.has_value());
-      return builder->SendError(std::move(*error), dfly::cluster::kMovedErrorType);
+      return builder->SendError(std::move(*error));
     }
     default:
       LOG(ERROR) << "Unexpected error " << popped_key.status();

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1280,7 +1280,7 @@ void BZPopMinMax(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder,
       return rb->SendNullArray();
     case OpStatus::KEY_MOVED: {
       auto error = cluster::SlotOwnershipError(*tx->GetUniqueSlotId());
-      CHECK(error.status.has_value() && error.status.value() != facade::OpStatus::OK);
+      CHECK(!error.status.has_value() || error.status.value() != facade::OpStatus::OK);
       return builder->SendError(std::move(error));
     }
     default:

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1280,8 +1280,8 @@ void BZPopMinMax(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder,
       return rb->SendNullArray();
     case OpStatus::KEY_MOVED: {
       auto error = cluster::SlotOwnershipError(*tx->GetUniqueSlotId());
-      CHECK(error.has_value());
-      return builder->SendError(std::move(*error));
+      CHECK(error.status.has_value() && error.status.value() != facade::OpStatus::OK);
+      return builder->SendError(std::move(error));
     }
     default:
       LOG(ERROR) << "Unexpected error " << popped_key.status();


### PR DESCRIPTION
**The problem:**

When in cluster mode, `MOVED` replies (which are arguably not even errors) are aggregated per slot-id + remote host, and displayed in `# Errorstats` as such. For example, in a server that does _not_ own 8k slots, we will aggregate 8k different errors, and their counts (in memory).

This slows down all `INFO` replies, takes a lot of memory, and also makes `INFO` replies very long.

**The fix:**

Use `type` `MOVED` for moved replies, making them all the same under `# Errorstats`

Fixes #4118