### PR TITLE
fix: Do not use `cc_` in connection if it's null

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1429,6 +1429,7 @@ std::string Connection::DebugInfo() const {
   absl::StrAppend(&info, "address=", uint64_t(this), ", ");
   absl::StrAppend(&info, "phase=", phase_, ", ");
   if (cc_) {
+    // In some rare cases cc_ can be null, see https://github.com/dragonflydb/dragonfly/pull/3873
     absl::StrAppend(&info, "dispatch(s/a)=", cc_->sync_dispatch, " ", cc_->async_dispatch, ", ");
     absl::StrAppend(&info, "closing=", cc_->conn_closing, ", ");
   }

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1428,8 +1428,10 @@ std::string Connection::DebugInfo() const {
 
   absl::StrAppend(&info, "address=", uint64_t(this), ", ");
   absl::StrAppend(&info, "phase=", phase_, ", ");
-  absl::StrAppend(&info, "dispatch(s/a)=", cc_->sync_dispatch, " ", cc_->async_dispatch, ", ");
-  absl::StrAppend(&info, "closing=", cc_->conn_closing, ", ");
+  if (cc_) {
+    absl::StrAppend(&info, "dispatch(s/a)=", cc_->sync_dispatch, " ", cc_->async_dispatch, ", ");
+    absl::StrAppend(&info, "closing=", cc_->conn_closing, ", ");
+  }
   absl::StrAppend(&info, "dispatch_fiber:joinable=", dispatch_fb_.IsJoinable(), ", ");
 
   bool intrusive_front = dispatch_q_.size() > 0 && dispatch_q_.front().IsControl();
@@ -1437,11 +1439,13 @@ std::string Connection::DebugInfo() const {
   absl::StrAppend(&info, "dispatch_queue:pipelined=", pending_pipeline_cmd_cnt_, ", ");
   absl::StrAppend(&info, "dispatch_queue:intrusive=", intrusive_front, ", ");
 
-  absl::StrAppend(&info, "state=");
-  if (cc_->paused)
-    absl::StrAppend(&info, "p");
-  if (cc_->blocked)
-    absl::StrAppend(&info, "b");
+  if (cc_) {
+    absl::StrAppend(&info, "state=");
+    if (cc_->paused)
+      absl::StrAppend(&info, "p");
+    if (cc_->blocked)
+      absl::StrAppend(&info, "b");
+  }
 
   absl::StrAppend(&info, "}");
   return info;


### PR DESCRIPTION
This is a rare condition, which we know can happen during shutdown (see [here](https://github.com/dragonflydb/dragonfly/pull/3873#issue-2568503374))

Hopefully fixes #3776 but we couldn't reproduce it to make sure.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->