### PR TITLE
fix server: fix stats of pipeline squashed commands

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1406,13 +1406,13 @@ size_t Service::DispatchManyCommands(absl::Span<CmdArgList> args_list, SinkReply
     }
 
     dfly_cntx->transaction = dist_trans.get();
-    MultiCommandSquasher::Execute(absl::MakeSpan(stored_cmds),
-                                  static_cast<RedisReplyBuilder*>(builder), dfly_cntx, this, true,
-                                  false);
+    size_t squashed_num = MultiCommandSquasher::Execute(absl::MakeSpan(stored_cmds),
+                                                        static_cast<RedisReplyBuilder*>(builder),
+                                                        dfly_cntx, this, true, false);
     dfly_cntx->transaction = nullptr;
 
     dispatched += stored_cmds.size();
-    ss->stats.squashed_commands += stored_cmds.size();
+    ss->stats.squashed_commands += squashed_num;
     stored_cmds.clear();
   };
 

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -254,7 +254,7 @@ bool MultiCommandSquasher::ExecuteSquashed(facade::RedisReplyBuilder* rb) {
   return !aborted;
 }
 
-void MultiCommandSquasher::Run(RedisReplyBuilder* rb) {
+size_t MultiCommandSquasher::Run(RedisReplyBuilder* rb) {
   DVLOG(1) << "Trying to squash " << cmds_.size() << " commands for transaction "
            << cntx_->transaction->DebugId();
 
@@ -291,6 +291,7 @@ void MultiCommandSquasher::Run(RedisReplyBuilder* rb) {
 
   VLOG(1) << "Squashed " << num_squashed_ << " of " << cmds_.size()
           << " commands, max fanout: " << num_shards_ << ", atomic: " << atomic_;
+  return num_squashed_;
 }
 
 bool MultiCommandSquasher::IsAtomic() const {

--- a/src/server/multi_command_squasher.h
+++ b/src/server/multi_command_squasher.h
@@ -22,10 +22,10 @@ namespace dfly {
 // contains a non-atomic multi transaction to execute squashed commands.
 class MultiCommandSquasher {
  public:
-  static void Execute(absl::Span<StoredCmd> cmds, facade::RedisReplyBuilder* rb,
-                      ConnectionContext* cntx, Service* service, bool verify_commands = false,
-                      bool error_abort = false) {
-    MultiCommandSquasher{cmds, cntx, service, verify_commands, error_abort}.Run(rb);
+  static size_t Execute(absl::Span<StoredCmd> cmds, facade::RedisReplyBuilder* rb,
+                        ConnectionContext* cntx, Service* service, bool verify_commands = false,
+                        bool error_abort = false) {
+    return MultiCommandSquasher{cmds, cntx, service, verify_commands, error_abort}.Run(rb);
   }
 
  private:
@@ -62,8 +62,8 @@ class MultiCommandSquasher {
   // Execute all currently squashed commands. Return false if aborting on error.
   bool ExecuteSquashed(facade::RedisReplyBuilder* rb);
 
-  // Run all commands until completion.
-  void Run(facade::RedisReplyBuilder* rb);
+  // Run all commands until completion. Returns number of squashed commands.
+  size_t Run(facade::RedisReplyBuilder* rb);
 
   bool IsAtomic() const;
 


### PR DESCRIPTION
When running multi command squasher not all commands are actually getting squashed due to some constrains in the squasher. Therefor to correctly count the number of squashed commnads now we return the actuall number of squashed 