### PR TITLE
chore: fix plain node insertion

### DIFF
--- a/src/core/qlist.cc
+++ b/src/core/qlist.cc
@@ -156,9 +156,9 @@ quicklistNode* CreateNode(int container, string_view value) {
 
   if (container == QUICKLIST_NODE_CONTAINER_PLAIN) {
     DCHECK(!value.empty());
+    new_node->sz = value.size();
     new_node->entry = (uint8_t*)zmalloc(new_node->sz);
     memcpy(new_node->entry, value.data(), new_node->sz);
-    new_node->sz = value.size();
   } else {
     new_node->entry = LP_Prepend(lpNew(0), value);
     new_node->sz = lpBytes(new_node->entry);

--- a/src/core/qlist_test.cc
+++ b/src/core/qlist_test.cc
@@ -236,6 +236,14 @@ TEST_F(QListTest, InsertDelete) {
   EXPECT_EQ(0, ql_.Size());
 }
 
+TEST_F(QListTest, PushPlain) {
+  // push a value large enough to trigger plain node insertion.
+  string val(9000, 'a');
+  ql_.Push(val, QList::HEAD);
+  auto items = ToItems();
+  EXPECT_THAT(items, ElementsAre(val));
+}
+
 using FillCompress = tuple<int, unsigned>;
 
 class PrintToFillCompress {


### PR DESCRIPTION
The blob allocation had invalid size and the value has never been copied.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->