### PR TITLE
chore: optimize info command

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -630,9 +630,6 @@ void Connection::OnPostMigrateThread() {
   stats_ = &tl_facade_stats->conn_stats;
   ++stats_->num_conns;
   stats_->read_buf_capacity += io_buf_.Capacity();
-  if (cc_->replica_conn) {
-    ++stats_->num_replicas;
-  }
 }
 
 void Connection::OnConnectionStart() {
@@ -1840,10 +1837,6 @@ Connection::MemoryUsage Connection::GetMemoryUsage() const {
 void Connection::DecreaseStatsOnClose() {
   stats_->read_buf_capacity -= io_buf_.Capacity();
 
-  // Update num_replicas if this was a replica connection.
-  if (cc_->replica_conn) {
-    --stats_->num_replicas;
-  }
   --stats_->num_conns;
 }
 

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -20,7 +20,7 @@ constexpr size_t kSizeConnStats = sizeof(ConnectionStats);
 
 ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
   // To break this code deliberately if we add/remove a field to this struct.
-  static_assert(kSizeConnStats == 120u);
+  static_assert(kSizeConnStats == 112u);
 
   ADD(read_buf_capacity);
   ADD(dispatch_queue_entries);
@@ -34,7 +34,6 @@ ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
   ADD(pipelined_cmd_latency);
   ADD(conn_received_cnt);
   ADD(num_conns);
-  ADD(num_replicas);
   ADD(num_blocked_clients);
   ADD(num_migrations);
   ADD(pipeline_throttle_count);

--- a/src/facade/facade_types.h
+++ b/src/facade/facade_types.h
@@ -105,7 +105,6 @@ struct ConnectionStats {
   uint64_t conn_received_cnt = 0;
 
   uint32_t num_conns = 0;
-  uint32_t num_replicas = 0;
   uint32_t num_blocked_clients = 0;
   uint64_t num_migrations = 0;
 

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -47,7 +47,7 @@ using RdbTypeFreqMap = absl::flat_hash_map<unsigned, size_t>;
 class CommandId;
 class Transaction;
 class EngineShard;
-class ConnectionState;
+struct ConnectionState;
 class Interpreter;
 class Namespaces;
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2196,7 +2196,7 @@ Metrics ServerFamily::GetMetrics(Namespace* ns) const {
 
   result.peak_stats = peak_stats_;
 
-  uint64_t delta_ms = (absl::GetCurrentTimeNanos() - start) / 1000'000;
+  uint64_t delta_ms = (absl::GetCurrentTimeNanos() - start) / 1'000'000;
   if (delta_ms > 30) {
     uint64_t cb_dur = (after_cb - start) / 1000'000;
     LOG(INFO) << "GetMetrics took " << delta_ms << " ms, out of which callback took " << cb_dur

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -118,9 +118,6 @@ struct Metrics {
 
   absl::flat_hash_map<std::string, uint64_t> connections_lib_name_ver_map;
 
-  // Replica info on the master side.
-  std::vector<ReplicaRoleInfo> master_side_replicas_info;
-
   struct ReplicaInfo {
     uint32_t reconnect_count;
   };

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -89,7 +89,6 @@ struct Metrics {
   ServerState::Stats coordinator_stats;  // stats on transaction running
   PeakStats peak_stats;
 
-  size_t uptime = 0;
   size_t qps = 0;
 
   size_t heap_used_bytes = 0;


### PR DESCRIPTION
    Info command may have a large latency when returning all the sections.
    But often a single section is required. Specifically,
    SERVER and REPLICATION sections are often fetched by clients
    or management components.

    This PR:
    1. Removes any hops for "INFO SERVER" command.
    2. Removes some redundant stats.
    3. Prints latency stats around GetMetrics command if it took to much.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->