### PR TITLE
chore: tune logs and improve restrict denied error

### DIFF
--- a/src/facade/error.h
+++ b/src/facade/error.h
@@ -42,5 +42,6 @@ extern const char kScriptErrType[];
 extern const char kConfigErrType[];
 extern const char kSearchErrType[];
 extern const char kWrongTypeErrType[];
+extern const char kRestrictDenied[];
 
 }  // namespace facade

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -104,6 +104,7 @@ const char kScriptErrType[] = "script_error";
 const char kConfigErrType[] = "config_error";
 const char kSearchErrType[] = "search_error";
 const char kWrongTypeErrType[] = "wrong_type";
+const char kRestrictDenied[] = "restrict_denied";
 
 const char* RespExpr::TypeName(Type t) {
   switch (t) {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1028,9 +1028,9 @@ std::optional<ErrorReply> Service::VerifyCommandState(const CommandId* cid, CmdA
   // If there is no connection owner, it means the command it being called
   // from another command or used internally, therefore is always permitted.
   if (dfly_cntx.conn() != nullptr && !dfly_cntx.conn()->IsPrivileged() && cid->IsRestricted()) {
-    VLOG(1) << "Non-admin attempt to execute " << cid->name() << " "
+    VLOG(1) << "Non-admin attempt to execute " << cid->name() << " " << tail_args << " "
             << ConnectionLogContext(dfly_cntx.conn());
-    return ErrorReply{"Cannot execute restricted command (admin only)"};
+    return ErrorReply{"Cannot execute restricted command (admin only)", kRestrictDenied};
   }
 
   if (auto err = cid->Validate(tail_args); err)

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2733,7 +2733,7 @@ void RdbLoader::LoadItemsBuffer(DbIndex db_ind, const ItemsBuf& ib) {
     }
 
     if (item->expire_ms > 0 && db_cntx.time_now_ms >= item->expire_ms) {
-      VLOG(1) << "Expire key on load: " << item->key;
+      VLOG(2) << "Expire key on load: " << item->key;
       continue;
     }
 


### PR DESCRIPTION
1. Now error stats show "restrict_denied" instead of "Cannot execute restricted command ..." error.
2. Increased verbosity level when loading a key with expired timestamp.
3. pulled helio with better logs coverage of tls_socket.cc code.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->