### PR TITLE
fix: allow SELECT in multi/exec if it's a noop

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1000,6 +1000,7 @@ bool DbSlice::Acquire(IntentLock::Mode mode, const KeyLockArgs& lock_args) {
   if (lock_args.fps.empty()) {  // Can be empty for NO_KEY_TRANSACTIONAL commands.
     return true;
   }
+  DCHECK_LT(lock_args.db_index, db_array_size());
 
   auto& lt = db_arr_[lock_args.db_index]->trans_locks;
   bool lock_acquired = true;

--- a/src/server/journal/executor.cc
+++ b/src/server/journal/executor.cc
@@ -76,8 +76,6 @@ void JournalExecutor::Execute(journal::ParsedEntry::CmdData& cmd) {
 }
 
 void JournalExecutor::SelectDb(DbIndex dbid) {
-  conn_context_.conn_state.db_index = dbid;
-
   if (ensured_dbs_.size() <= dbid)
     ensured_dbs_.resize(dbid + 1);
 
@@ -85,6 +83,8 @@ void JournalExecutor::SelectDb(DbIndex dbid) {
     auto cmd = BuildFromParts("SELECT", dbid);
     Execute(cmd);
     ensured_dbs_[dbid] = true;
+  } else {
+    conn_context_.conn_state.db_index = dbid;
   }
 }
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1084,7 +1084,7 @@ std::optional<ErrorReply> Service::VerifyCommandState(const CommandId* cid, CmdA
     return ErrorReply{"-READONLY You can't write against a read only replica."};
 
   if (multi_active) {
-    if (cmd_name == "SELECT" || absl::EndsWith(cmd_name, "SUBSCRIBE"))
+    if (absl::EndsWith(cmd_name, "SUBSCRIBE"))
       return ErrorReply{absl::StrCat("Can not call ", cmd_name, " within a transaction")};
 
     if (cmd_name == "WATCH" || cmd_name == "FLUSHALL" || cmd_name == "FLUSHDB")

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1067,7 +1067,7 @@ async def assert_replica_reconnections(replica_inst, initial_reconnects_count):
 @pytest.mark.asyncio
 async def test_replication_info(df_factory: DflyInstanceFactory, df_seeder_factory, n_keys=2000):
     master = df_factory.create()
-    replica = df_factory.create(logtostdout=True, replication_acks_interval=100)
+    replica = df_factory.create(replication_acks_interval=100)
     df_factory.start_all([master, replica])
     c_master = master.client()
     c_replica = replica.client()
@@ -1157,8 +1157,8 @@ redis.call('SET', 'A', 'ErrroR')
 
 @pytest.mark.asyncio
 async def test_readonly_script(df_factory):
-    master = df_factory.create(proactor_threads=2, logtostdout=True)
-    replica = df_factory.create(proactor_threads=2, logtostdout=True)
+    master = df_factory.create(proactor_threads=2)
+    replica = df_factory.create(proactor_threads=2)
 
     df_factory.start_all([master, replica])
 


### PR DESCRIPTION
Fixes #4120

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->