### PR TITLE
fix: UB during cmd squashing reply size calculation

### DIFF
--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -273,8 +273,8 @@ bool MultiCommandSquasher::ExecuteSquashed(facade::RedisReplyBuilder* rb) {
 
     aborted |= error_abort_ && CapturingReplyBuilder::TryExtractError(replies.back());
 
-    CapturingReplyBuilder::Apply(std::move(replies.back()), rb);
     current_reply_size_.fetch_sub(Size(replies.back()), std::memory_order_relaxed);
+    CapturingReplyBuilder::Apply(std::move(replies.back()), rb);
     replies.pop_back();
 
     if (aborted)

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1300,8 +1300,6 @@ void PrintPrometheusMetrics(uint64_t uptime, const Metrics& m, DflyCmd* dfly_cmd
                             MetricType::GAUGE, &resp->body());
   AppendMetricWithoutLabels("dispatch_queue_bytes", "", conn_stats.dispatch_queue_bytes,
                             MetricType::GAUGE, &resp->body());
-  AppendMetricWithoutLabels("pipeline_cache_bytes", "", conn_stats.pipeline_cmd_cache_bytes,
-                            MetricType::GAUGE, &resp->body());
   AppendMetricWithoutLabels("pipeline_queue_length", "", conn_stats.dispatch_queue_entries,
                             MetricType::GAUGE, &resp->body());
   AppendMetricWithoutLabels("pipeline_throttle_total", "", conn_stats.pipeline_throttle_count,
@@ -1312,6 +1310,9 @@ void PrintPrometheusMetrics(uint64_t uptime, const Metrics& m, DflyCmd* dfly_cmd
                             MetricType::COUNTER, &resp->body());
   AppendMetricWithoutLabels("pipeline_commands_duration_seconds", "",
                             conn_stats.pipelined_cmd_latency * 1e-6, MetricType::COUNTER,
+                            &resp->body());
+  AppendMetricWithoutLabels("commands_squashing_replies_bytes", "",
+                            MultiCommandSquasher::GetRepliesMemSize(), MetricType::GAUGE,
                             &resp->body());
   string connections_libs;
   AppendMetricHeader("connections_libs", "Total number of connections by libname:ver",


### PR DESCRIPTION
address comments from https://github.com/dragonflydb/dragonfly/pull/4147