### PR TITLE
fix: Huge entries fail to load outside RDB / replication

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -401,7 +401,7 @@ void DebugCmd::Run(CmdArgList args, facade::SinkReplyBuilder* builder) {
         "    to meet value size.",
         "    If RAND is specified then value will be set to random hex string in specified size.",
         "    If SLOTS is specified then create keys only in given slots range.",
-        "    TYPE specifies data type (must be STRING/LIST/SET/HSET/ZSET/JSON), default STRING.",
+        "    TYPE specifies data type (must be STRING/LIST/SET/HASH/ZSET/JSON), default STRING.",
         "    ELEMENTS specifies how many sub elements if relevant (like entries in a list / set).",
         "OBJHIST",
         "    Prints histogram of object sizes.",

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2667,10 +2667,6 @@ void RdbLoader::FlushAllShards() {
     FlushShardAsync(i);
 }
 
-std::error_code RdbLoaderBase::FromOpaque(const OpaqueObj& opaque, CompactObj* pv) {
-  return RdbLoaderBase::FromOpaque(opaque, LoadConfig{}, pv);
-}
-
 std::error_code RdbLoaderBase::FromOpaque(const OpaqueObj& opaque, LoadConfig config,
                                           CompactObj* pv) {
   OpaqueObjLoader visitor(opaque.rdb_type, pv, config);

--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -139,7 +139,6 @@ class RdbLoaderBase {
 
   template <typename T> io::Result<T> FetchInt();
 
-  static std::error_code FromOpaque(const OpaqueObj& opaque, CompactObj* pv);
   static std::error_code FromOpaque(const OpaqueObj& opaque, LoadConfig config, CompactObj* pv);
 
   io::Result<uint64_t> LoadLen(bool* is_encoded);

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -1773,10 +1773,9 @@ async def test_cluster_migration_cancel(df_factory: DflyInstanceFactory):
         assert str(i) == await nodes[1].client.get(f"{{key50}}:{i}")
 
 
-@pytest.mark.parametrize("type", ["LIST", "HASH", "SET", "ZSET", "STRING"])
 @dfly_args({"proactor_threads": 2, "cluster_mode": "yes"})
 @pytest.mark.asyncio
-async def test_cluster_migration_huge_container(df_factory: DflyInstanceFactory, type):
+async def test_cluster_migration_huge_container(df_factory: DflyInstanceFactory):
     instances = [
         df_factory.create(port=BASE_PORT + i, admin_port=BASE_PORT + i + 1000) for i in range(2)
     ]
@@ -1788,14 +1787,14 @@ async def test_cluster_migration_huge_container(df_factory: DflyInstanceFactory,
 
     await push_config(json.dumps(generate_config(nodes)), [node.admin_client for node in nodes])
 
-    logging.debug(f"Generating huge {type}")
+    logging.debug("Generating huge containers")
     seeder = StaticSeeder(
-        key_target=1,
+        key_target=10,
         data_size=10_000_000,
         collection_size=10_000,
         variance=1,
         samples=1,
-        types=[type],
+        types=["LIST", "HASH", "SET", "ZSET", "STRING"],
     )
     await seeder.run(nodes[0].client)
     source_data = await StaticSeeder.capture(nodes[0].client)

--- a/tests/dragonfly/generic_test.py
+++ b/tests/dragonfly/generic_test.py
@@ -8,6 +8,7 @@ from redis import asyncio as aioredis
 from . import dfly_multi_test_args, dfly_args
 from .instance import DflyStartException
 from .utility import batch_fill_data, gen_test_data, EnvironCntx
+from .seeder import StaticSeeder
 
 
 @dfly_multi_test_args({"keys_output_limit": 512}, {"keys_output_limit": 1024})
@@ -171,7 +172,7 @@ async def test_denyoom_commands(df_factory):
     await client.execute_command("mget x")
 
 
-@pytest.mark.parametrize("type", ["list", "hash", "string", "set", "zset"])
+@pytest.mark.parametrize("type", ["LIST", "HASH", "SET", "ZSET", "STRING"])
 @dfly_args({"proactor_threads": 4})
 @pytest.mark.asyncio
 async def test_rename_huge_values(df_factory, type):
@@ -180,30 +181,27 @@ async def test_rename_huge_values(df_factory, type):
     client = df_server.client()
 
     logging.debug(f"Generating huge {type}")
-    await client.execute_command(f"debug populate 1 k 10000 RAND TYPE {type} ELEMENTS 1000")
-
-    async def get_length(key):
-        if type == "list":
-            return await client.llen(key)
-        elif type == "hash":
-            return await client.hlen(key)
-        elif type == "string":
-            return await client.strlen(key)
-        elif type == "set":
-            return await client.scard(key)
-        else:
-            assert type == "zset"
-            return await client.zcard(key)
-
-    size = await get_length("k:0")
-    logging.debug(f"size {size}")
-    keys = await client.execute_command("keys *")
-    logging.debug(f"keys {keys}")
+    seeder = StaticSeeder(
+        key_target=1,
+        data_size=10_000_000,
+        collection_size=10_000,
+        variance=1,
+        samples=1,
+        types=[type],
+    )
+    await seeder.run(client)
+    source_data = await StaticSeeder.capture(client)
+    logging.debug(f"src {source_data}")
 
     # Rename multiple times to make sure the key moves between shards
-    old_name = "k:0"
+    orig_name = (await client.execute_command("keys *"))[0]
+    old_name = orig_name
+    new_name = ""
     for i in range(10):
         new_name = f"new:{i}"
         await client.execute_command(f"rename {old_name} {new_name}")
-        assert size == await get_length(new_name)
         old_name = new_name
+    await client.execute_command(f"rename {new_name} {orig_name}")
+    target_data = await StaticSeeder.capture(client)
+
+    assert source_data == target_data


### PR DESCRIPTION
We have an internal utility tool that we use to deserialize values in some use cases:

* `RESTORE`
* Cluster slot migration
* `RENAME`, if the source and target shards are different

We [recently](https://github.com/dragonflydb/dragonfly/issues/3760) changed this area of the code, which caused this regression as it only handled RDB / replication streams.

Fixes #4143

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->