### PR TITLE
fix: test_replication_all failure

### DIFF
--- a/src/server/journal/executor.cc
+++ b/src/server/journal/executor.cc
@@ -83,6 +83,11 @@ void JournalExecutor::SelectDb(DbIndex dbid) {
     auto cmd = BuildFromParts("SELECT", dbid);
     Execute(cmd);
     ensured_dbs_[dbid] = true;
+
+    // TODO: This is a temporary fix for #4146.
+    // For some reason without this the replication breaks in regtests.
+    auto cb = [](EngineShard* shard) { return OpStatus::OK; };
+    shard_set->RunBriefInParallel(std::move(cb));
   } else {
     conn_context_.conn_state.db_index = dbid;
   }


### PR DESCRIPTION
Fixes #4150. The failure can be reproduced with high probability on ARM via `pytest dragonfly/replication_test.py -k test_replication_all[df_factory0-mode0-8-t_replicas3-seeder_config3-2000-False]`

Not sure why this barrier is needed but #4146 removes the barrier which breaks a gentle balance in the code in unexpected way.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->