### PR TITLE
chore: allow slow and precise memory measurement of an object

### DIFF
--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -37,7 +37,7 @@ class RobjWrapper {
   RobjWrapper() : sz_(0), type_(0), encoding_(0) {
   }
 
-  size_t MallocUsed() const;
+  size_t MallocUsed(bool slow) const;
 
   uint64_t HashCode() const;
   bool Equal(const RobjWrapper& ow) const;
@@ -359,9 +359,9 @@ class CompactObj {
   // Postcondition: The object is an in-memory string.
   void Materialize(std::string_view str, bool is_raw);
 
-  // In case this object a single blob, returns number of bytes allocated on heap
-  // for that blob. Otherwise returns 0.
-  size_t MallocUsed() const;
+  // Returns the approximation of memory used by the object.
+  // If slow is true, may use more expensive methods to calculate the precise size.
+  size_t MallocUsed(bool slow = false) const;
 
   // Resets the object to empty state (string).
   void Reset();

--- a/src/core/qlist.h
+++ b/src/core/qlist.h
@@ -103,7 +103,7 @@ class QList {
   // Returns true if item was replaced, false if index is out of range.
   bool Replace(long index, std::string_view elem);
 
-  size_t MallocUsed() const;
+  size_t MallocUsed(bool slow) const;
 
   void Iterate(IterateFunc cb, long start, long end) const;
 

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -799,5 +799,9 @@ Usage: dragonfly [FLAGS]
     unlink(pidfile_path.c_str());
   }
 
+  // Returns memory to OS.
+  // This is a workaround for a bug in mi_malloc that may cause a crash on exit.
+  mi_collect(true);
+
   return res;
 }

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -768,6 +768,21 @@ TEST_F(DflyEngineTest, EvalBug2664) {
   EXPECT_THAT(resp, DoubleArg(42.9));
 }
 
+TEST_F(DflyEngineTest, MemoryUsage) {
+  for (unsigned i = 0; i < 1000; ++i) {
+    Run({"rpush", "l1", StrCat("val", i)});
+  }
+
+  for (unsigned i = 0; i < 1000; ++i) {
+    Run({"rpush", "l2", StrCat(string('a', 200), i)});
+  }
+  auto resp = Run({"memory", "usage", "l1"});
+  EXPECT_GT(*resp.GetInt(), 8000);
+
+  resp = Run({"memory", "usage", "l2"});
+  EXPECT_GT(*resp.GetInt(), 100000);
+}
+
 // TODO: to test transactions with a single shard since then all transactions become local.
 // To consider having a parameter in dragonfly engine controlling number of shards
 // unconditionally from number of cpus. TO TEST BLPOP under multi for single/multi argument case.

--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -83,7 +83,8 @@ std::string MallocStatsCb(bool backing, unsigned tid) {
 }
 
 size_t MemoryUsage(PrimeIterator it) {
-  return it->first.MallocUsed() + it->second.MallocUsed();
+  size_t key_size = it->first.MallocUsed();
+  return key_size + it->second.MallocUsed(true);
 }
 
 }  // namespace


### PR DESCRIPTION
Specifically fixes "MEMORY USAGE" for lists.

The  `mi_collect` call may actually fix #3776  At least in my tests it stopped crashing.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->