### PR TITLE
fix: remove DenseSet::IteratorBase::TraverseApply

### DIFF
--- a/src/core/dense_set.cc
+++ b/src/core/dense_set.cc
@@ -840,22 +840,4 @@ size_t DenseSet::SizeSlow() {
   return size_;
 }
 
-size_t DenseSet::IteratorBase::TraverseApply(DensePtr* ptr, std::function<void(DensePtr*)> fun) {
-  size_t links_traversed = 0;
-  while (ptr->IsLink()) {
-    DenseLinkKey* link = ptr->AsLink();
-    fun(link);
-    ptr = &link->next;
-    ++links_traversed;
-  }
-
-  // The last ptr in the link always returns ptr->IsLink() = false
-  DCHECK(!ptr->IsEmpty());
-  DCHECK(ptr->IsObject());
-  fun(ptr);
-  ++links_traversed;
-
-  return links_traversed;
-}
-
 }  // namespace dfly

--- a/src/core/dense_set.h
+++ b/src/core/dense_set.h
@@ -202,11 +202,6 @@ class DenseSet {
 
     void Advance();
 
-    // If ptr is a link, it calls fun on all links in the chain.
-    // Otherwise it calls it only once on the object.
-    // ptr must be non empty.
-    size_t TraverseApply(DensePtr* ptr, std::function<void(DensePtr*)> fun);
-
     DenseSet* owner_;
     ChainVectorIterator curr_list_;
     DensePtr* curr_entry_;

--- a/src/core/string_map.cc
+++ b/src/core/string_map.cc
@@ -298,17 +298,19 @@ detail::SdsPair StringMap::iterator::BreakToPair(void* obj) {
 }
 
 bool StringMap::iterator::ReallocIfNeeded(float ratio) {
-  bool reallocated = false;
-  auto body = [this, ratio, &reallocated](auto* ptr) {
-    auto* obj = ptr->GetObject();
-    auto [new_obj, realloc] = static_cast<StringMap*>(owner_)->ReallocIfNeeded(obj, ratio);
-    ptr->SetObject(new_obj);
-    reallocated |= realloc;
-  };
+  auto* ptr = curr_entry_;
+  if (ptr->IsLink()) {
+    ptr = ptr->AsLink();
+  }
 
-  TraverseApply(curr_entry_, body);
+  DCHECK(!ptr->IsEmpty());
+  DCHECK(ptr->IsObject());
 
-  return reallocated;
+  auto* obj = ptr->GetObject();
+  auto [new_obj, realloced] = static_cast<StringMap*>(owner_)->ReallocIfNeeded(obj, ratio);
+  ptr->SetObject(new_obj);
+
+  return realloced;
 }
 
 }  // namespace dfly


### PR DESCRIPTION
reverts #4019 because:

1. `DefragStrMap2` calls `ReallocIfNeeded()` on each `StringMap::iterator` and the traversal also includes all of the elements of a all `links`.  This TraverseApply just adds extra iterations, if the `iterator` passed is `link`.
2. Suspect to cause the crash/regrssion in #4167

I am still not sure if `TraverseApply` actually causes the crash described in (2)