### PR TITLE
chore: Hide replicas from `CLUSTER` subcmds in managed mode

### DIFF
--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -234,7 +234,7 @@ def verify_slots_result(port: int, answer: list, replicas) -> bool:
 
     info = answer[2]
     assert len(info) == 3
-    ip_addr = str(info[0], "utf-8")
+    ip_addr = info[0]
     assert is_local_host(ip_addr)
     assert info[1] == port
 
@@ -244,7 +244,7 @@ def verify_slots_result(port: int, answer: list, replicas) -> bool:
         replica = replicas[i - 3]
         rep_info = answer[i]
         assert len(rep_info) == 3
-        ip_addr = str(rep_info[0], "utf-8")
+        ip_addr = rep_info[0]
         assert is_local_host(ip_addr)
         assert rep_info[1] == replica.port
         assert rep_info[2] == replica.id
@@ -261,15 +261,12 @@ async def test_emulated_cluster_with_replicas(df_factory):
 
     df_factory.start_all([master, *replicas])
 
-    c_master = aioredis.Redis(port=master.port)
-    c_master_admin = aioredis.Redis(port=master.admin_port)
-    master_id = (await c_master.execute_command("CLUSTER MYID")).decode("utf-8")
+    c_master = master.client()
+    c_master_admin = master.admin_client()
+    master_id = await c_master.execute_command("CLUSTER MYID")
 
-    c_replicas = [aioredis.Redis(port=replica.port) for replica in replicas]
-    replica_ids = [
-        (await c_replica.execute_command("CLUSTER MYID")).decode("utf-8")
-        for c_replica in c_replicas
-    ]
+    c_replicas = [replica.client() for replica in replicas]
+    replica_ids = [(await c_replica.execute_command("CLUSTER MYID")) for c_replica in c_replicas]
 
     for replica, c_replica in zip(replicas, c_replicas):
         res = await c_replica.execute_command("CLUSTER SLOTS")
@@ -282,7 +279,7 @@ async def test_emulated_cluster_with_replicas(df_factory):
     # Connect replicas to master
     for replica, c_replica in zip(replicas, c_replicas):
         rc = await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
-        assert str(rc, "utf-8") == "OK"
+        assert rc == "OK"
 
     await asyncio.sleep(0.5)
 


### PR DESCRIPTION
Part of #4173 (see for context)

This fixes:

* `CLUSTER NODES`
* `CLUSTER SHARDS`
* `CLUSTER SLOTS`

But only for emulated cluster mode. @romange - should we also handle real cluster (in a future PR)?

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->