### PR TITLE
fix: stop using openssl for container healthchecks

### DIFF
--- a/tests/fakeredis/test/test_stack/test_bloomfilter.py
+++ b/tests/fakeredis/test/test_stack/test_bloomfilter.py
@@ -16,6 +16,7 @@ def test_create_bf(r: redis.Redis):
     assert r.bf().create("bloom_ns", 0.01, 1000, noScale=True)
 
 
+@pytest.mark.unsupported_server_types("dragonfly")
 def test_bf_reserve(r: redis.Redis):
     assert r.bf().reserve("bloom", 0.01, 1000)
     assert r.bf().reserve("bloom_ns", 0.01, 1000, noScale=True)

--- a/tools/docker/healthcheck.sh
+++ b/tools/docker/healthcheck.sh
@@ -20,13 +20,7 @@ if [ -z "$HEALTHCHECK_PORT" ]; then
   PORT=$(echo $DF_NET | grep -oE ':[0-9]+' | cut -c2- | tail -n 1)
 fi
 
-# If we're running with TLS enabled, utilise OpenSSL for the check
-if [ -f "/etc/dragonfly/tls/ca.crt" ]
-then
-    _healthcheck="openssl s_client -connect ${HOST}:${PORT} -CAfile /etc/dragonfly/tls/ca.crt -quiet -no_ign_eof"
-else
-    _healthcheck="nc -q1 $HOST $PORT"
-fi
+_healthcheck="nc -q1 $HOST $PORT"
 
 echo PING | ${_healthcheck}
 


### PR DESCRIPTION
Dragonfly responds to ascii based requests to tls port with: `-ERR Bad TLS header, double check if you enabled TLS for your client.`

Therefore, it is possible to test now both tls and non-tls ports with a plain-text PING. Fixes #4171

Also, blacklist the bloom-filter test that Dragonfly does not support yet.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->