### PR TITLE
bug(replication): snapshot cleanup fix in transition to stable sync

### DIFF
--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -209,10 +209,10 @@ class DflyCmd {
   facade::OpStatus StartFullSyncInThread(FlowInfo* flow, Context* cntx, EngineShard* shard);
 
   // Stop full sync in thread. Run state switch cleanup.
-  void StopFullSyncInThread(FlowInfo* flow, Context* cntx, EngineShard* shard);
+  facade::OpStatus StopFullSyncInThread(FlowInfo* flow, Context* cntx, EngineShard* shard);
 
   // Start stable sync in thread. Called for each flow.
-  facade::OpStatus StartStableSyncInThread(FlowInfo* flow, Context* cntx, EngineShard* shard);
+  void StartStableSyncInThread(FlowInfo* flow, Context* cntx, EngineShard* shard);
 
   // Get ReplicaInfo by sync_id.
   std::shared_ptr<ReplicaInfo> GetReplicaInfo(uint32_t sync_id) ABSL_LOCKS_EXCLUDED(mu_);

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -48,6 +48,7 @@ SliceSnapshot::SliceSnapshot(DbSlice* slice, CompressionMode compression_mode,
 }
 
 SliceSnapshot::~SliceSnapshot() {
+  DCHECK(db_slice_->shard_owner()->IsMyThread());
   tl_slice_snapshots.erase(this);
 }
 


### PR DESCRIPTION
The bug:
In case of socket error inside StopFullSyncInThread we would overide the cleanup function in StartStableSyncInThread as we will call it even if the StopFullSyncInThread failed, causing the reset of saver not in his shard thread
The fix:
return error status from StopFullSyncInThread and incase of error dont call StartStableSyncInThread