### PR TITLE
fix: Fix `test_network_disconnect_during_migration` test

### DIFF
--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -37,7 +37,7 @@ class OutgoingMigration::SliceSlotMigration : private ProtocolClient {
   }
 
   ~SliceSlotMigration() {
-    streamer_.Cancel();
+    Cancel();
     cntx_.JoinErrorHandler();
   }
 
@@ -81,6 +81,7 @@ class OutgoingMigration::SliceSlotMigration : private ProtocolClient {
   }
 
   void Cancel() {
+    cntx_.Cancel();
     streamer_.Cancel();
   }
 

--- a/src/server/container_utils.cc
+++ b/src/server/container_utils.cc
@@ -274,13 +274,13 @@ bool IterateMap(const PrimeValue& pv, const IterateKVFunc& func) {
   bool finished = true;
 
   if (pv.Encoding() == kEncodingListPack) {
-    uint8_t intbuf[LP_INTBUF_SIZE];
+    uint8_t k_intbuf[LP_INTBUF_SIZE], v_intbuf[LP_INTBUF_SIZE];
     uint8_t* lp = (uint8_t*)pv.RObjPtr();
     uint8_t* fptr = lpFirst(lp);
     while (fptr) {
-      string_view key = LpGetView(fptr, intbuf);
+      string_view key = LpGetView(fptr, k_intbuf);
       fptr = lpNext(lp, fptr);
-      string_view val = LpGetView(fptr, intbuf);
+      string_view val = LpGetView(fptr, v_intbuf);
       fptr = lpNext(lp, fptr);
       if (!func(ContainerEntry{key.data(), key.size()}, ContainerEntry{val.data(), val.size()})) {
         finished = false;

--- a/src/server/journal/streamer.cc
+++ b/src/server/journal/streamer.cc
@@ -224,6 +224,10 @@ void RestoreStreamer::Run() {
 
       db_slice_->FlushChangeToEarlierCallbacks(0 /*db_id always 0 for cluster*/,
                                                DbSlice::Iterator::FromPrime(it), snapshot_version_);
+
+      if (fiber_cancelled_)  // Could have been cancelled in above call too
+        return;
+
       WriteBucket(it);
     });
 

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -112,6 +112,8 @@ MultiCommandSquasher::SquashResult MultiCommandSquasher::TrySquash(StoredCmd* cm
 
   cmd->Fill(&tmp_keylist_);
   auto args = absl::MakeSpan(tmp_keylist_);
+  if (args.size() == 0)
+    return SquashResult::NOT_SQUASHED;
 
   auto keys = DetermineKeys(cmd->Cid(), args);
   if (!keys.ok())

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -112,7 +112,7 @@ MultiCommandSquasher::SquashResult MultiCommandSquasher::TrySquash(StoredCmd* cm
 
   cmd->Fill(&tmp_keylist_);
   auto args = absl::MakeSpan(tmp_keylist_);
-  if (args.size() == 0)
+  if (args.empty())
     return SquashResult::NOT_SQUASHED;
 
   auto keys = DetermineKeys(cmd->Cid(), args);

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -1290,7 +1290,7 @@ async def test_migration_with_key_ttl(df_factory):
 
 
 @dfly_args({"proactor_threads": 4, "cluster_mode": "yes"})
-async def test_network_disconnect_during_migration(df_factory, df_seeder_factory):
+async def test_network_disconnect_during_migration(df_factory):
     instances = [
         df_factory.create(port=BASE_PORT + i, admin_port=BASE_PORT + i + 1000) for i in range(2)
     ]
@@ -1328,7 +1328,7 @@ async def test_network_disconnect_during_migration(df_factory, df_seeder_factory
 
     await proxy.start()
 
-    await wait_for_status(nodes[0].admin_client, nodes[1].id, "FINISHED", 20)
+    await wait_for_status(nodes[0].admin_client, nodes[1].id, "FINISHED", 60)
     nodes[0].migrations = []
     nodes[0].slots = []
     nodes[1].slots = [(0, 16383)]

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -1336,6 +1336,7 @@ async def test_network_disconnect_during_migration(df_factory):
     await push_config(json.dumps(generate_config(nodes)), [node.admin_client for node in nodes])
 
     assert (await StaticSeeder.capture(nodes[1].client)) == start_capture
+    await proxy.close()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
There are actually a few failures fixed in this PR, only one of which is a test bug:

* `db_slice_->Traverse()` can yield, causing `fiber_cancelled_`'s value to change
* When a migration is cancelled, it may never finish `WaitForInflightToComplete()` because it has `in_flight_bytes_` that will never reach destination due to the cancellation
* `IterateMap()` with numeric key/values overrode the key's buffer with the value's buffer

Fixes #4207

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->