### PR TITLE
chore: Track QList memory

### DIFF
--- a/src/core/qlist.cc
+++ b/src/core/qlist.cc
@@ -394,14 +394,12 @@ void QList::AppendListpack(unsigned char* zl) {
 
   InsertNode(_Tail(), node, AFTER);
   count_ += node->count;
-  malloc_size_ += node->sz;
 }
 
 void QList::AppendPlain(unsigned char* data, size_t sz) {
   quicklistNode* node = CreateRAW(QUICKLIST_NODE_CONTAINER_PLAIN, data, sz);
   InsertNode(_Tail(), node, AFTER);
   ++count_;
-  malloc_size_ += node->sz;
 }
 
 bool QList::Insert(std::string_view pivot, std::string_view elem, InsertOpt opt) {

--- a/src/core/qlist.h
+++ b/src/core/qlist.h
@@ -162,6 +162,9 @@ class QList {
     return head_ ? head_->prev : nullptr;
   }
 
+  void OnPreUpdate(quicklistNode* node);
+  void OnPostUpdate(quicklistNode* node);
+
   // Returns false if used existing sentinel, true if a new sentinel was created.
   bool PushSentinel(std::string_view value, Where where);
 
@@ -184,7 +187,7 @@ class QList {
   bool DelPackedIndex(quicklistNode* node, uint8_t* p);
 
   quicklistNode* head_ = nullptr;
-
+  size_t malloc_size_ = 0;               // size of the quicklist struct
   uint32_t count_ = 0;                   /* total count of all entries in all listpacks */
   uint32_t len_ = 0;                     /* number of quicklistNodes */
   signed int fill_ : QL_FILL_BITS;       /* fill factor for individual nodes */

--- a/src/core/qlist_test.cc
+++ b/src/core/qlist_test.cc
@@ -166,6 +166,7 @@ TEST_F(QListTest, Basic) {
   ql_.Push("abc", QList::HEAD);
   EXPECT_EQ(1, ql_.Size());
   EXPECT_TRUE(ql_.Tail() == ql_.Head());
+  EXPECT_LE(ql_.MallocUsed(false), ql_.MallocUsed(true));
 
   auto it = ql_.GetIterator(QList::HEAD);
   ASSERT_TRUE(it.Next());  // Needed to initialize the iterator.
@@ -176,6 +177,7 @@ TEST_F(QListTest, Basic) {
 
   ql_.Push("def", QList::TAIL);
   EXPECT_EQ(2, ql_.Size());
+  EXPECT_LE(ql_.MallocUsed(false), ql_.MallocUsed(true));
 
   it = ql_.GetIterator(QList::TAIL);
   ASSERT_TRUE(it.Next());
@@ -195,6 +197,7 @@ TEST_F(QListTest, Basic) {
   vector<string> items = ToItems();
 
   EXPECT_THAT(items, ElementsAre("abc", "def"));
+  EXPECT_GT(ql_.MallocUsed(false), ql_.MallocUsed(true) * 0.8);
 }
 
 TEST_F(QListTest, ListPack) {

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -60,8 +60,8 @@ ABSL_FLAG(int32_t, list_max_listpack_size, -2, "Maximum listpack size, default i
  */
 
 ABSL_FLAG(int32_t, list_compress_depth, 0, "Compress depth of the list. Default is no compression");
-ABSL_FLAG(bool, list_experimental_v2, false,
-          "Compress depth of the list. Default is no compression");
+ABSL_FLAG(bool, list_experimental_v2, true,
+          "Enables dragonfly specific implementation of quicklist");
 
 namespace dfly {
 


### PR DESCRIPTION
After running `debug POPULATE 100 list 100 rand type list elements 10000` with `--list_experimental_v2=false`:

```
type_used_memory_list:16512800
used_memory:105573120
```

When running with `--list_experimental_v2=true`:

```
used_memory:105573120
type_used_memory_list:103601700
```

TODO: does not yet handle compressed entries correctly but we do not enable compression by default.

Fixes #3800

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->