### PR TITLE
fix(search_family): Remove the output of extra fields in the FT.AGGREGATE command

### DIFF
--- a/src/server/search/aggregator_test.cc
+++ b/src/server/search/aggregator_test.cc
@@ -18,12 +18,11 @@ TEST(AggregatorTest, Sort) {
   };
   PipelineStep steps[] = {MakeSortStep("a", false)};
 
-  auto result = Process(values, steps);
+  auto result = Process(values, {"a"}, steps);
 
-  EXPECT_TRUE(result);
-  EXPECT_EQ(result->at(0)["a"], Value(0.5));
-  EXPECT_EQ(result->at(1)["a"], Value(1.0));
-  EXPECT_EQ(result->at(2)["a"], Value(1.5));
+  EXPECT_EQ(result.values[0]["a"], Value(0.5));
+  EXPECT_EQ(result.values[1]["a"], Value(1.0));
+  EXPECT_EQ(result.values[2]["a"], Value(1.5));
 }
 
 TEST(AggregatorTest, Limit) {
@@ -35,12 +34,11 @@ TEST(AggregatorTest, Limit) {
   };
   PipelineStep steps[] = {MakeLimitStep(1, 2)};
 
-  auto result = Process(values, steps);
+  auto result = Process(values, {"i"}, steps);
 
-  EXPECT_TRUE(result);
-  EXPECT_EQ(result->size(), 2);
-  EXPECT_EQ(result->at(0)["i"], Value(2.0));
-  EXPECT_EQ(result->at(1)["i"], Value(3.0));
+  EXPECT_EQ(result.values.size(), 2);
+  EXPECT_EQ(result.values[0]["i"], Value(2.0));
+  EXPECT_EQ(result.values[1]["i"], Value(3.0));
 }
 
 TEST(AggregatorTest, SimpleGroup) {
@@ -54,12 +52,11 @@ TEST(AggregatorTest, SimpleGroup) {
   std::string_view fields[] = {"tag"};
   PipelineStep steps[] = {MakeGroupStep(fields, {})};
 
-  auto result = Process(values, steps);
-  EXPECT_TRUE(result);
-  EXPECT_EQ(result->size(), 2);
+  auto result = Process(values, {"i", "tag"}, steps);
+  EXPECT_EQ(result.values.size(), 2);
 
-  EXPECT_EQ(result->at(0).size(), 1);
-  std::set<Value> groups{result->at(0)["tag"], result->at(1)["tag"]};
+  EXPECT_EQ(result.values[0].size(), 1);
+  std::set<Value> groups{result.values[0]["tag"], result.values[1]["tag"]};
   std::set<Value> expected{"even", "odd"};
   EXPECT_EQ(groups, expected);
 }
@@ -83,25 +80,24 @@ TEST(AggregatorTest, GroupWithReduce) {
       Reducer{"null-field", "distinct-null", FindReducerFunc(ReducerFunc::COUNT_DISTINCT)}};
   PipelineStep steps[] = {MakeGroupStep(fields, std::move(reducers))};
 
-  auto result = Process(values, steps);
-  EXPECT_TRUE(result);
-  EXPECT_EQ(result->size(), 2);
+  auto result = Process(values, {"i", "half-i", "tag"}, steps);
+  EXPECT_EQ(result.values.size(), 2);
 
   // Reorder even first
-  if (result->at(0).at("tag") == Value("odd"))
-    std::swap(result->at(0), result->at(1));
+  if (result.values[0].at("tag") == Value("odd"))
+    std::swap(result.values[0], result.values[1]);
 
   // Even
-  EXPECT_EQ(result->at(0).at("count"), Value{(double)5});
-  EXPECT_EQ(result->at(0).at("sum-i"), Value{(double)2 + 4 + 6 + 8});
-  EXPECT_EQ(result->at(0).at("distinct-hi"), Value{(double)3});
-  EXPECT_EQ(result->at(0).at("distinct-null"), Value{(double)1});
+  EXPECT_EQ(result.values[0].at("count"), Value{(double)5});
+  EXPECT_EQ(result.values[0].at("sum-i"), Value{(double)2 + 4 + 6 + 8});
+  EXPECT_EQ(result.values[0].at("distinct-hi"), Value{(double)3});
+  EXPECT_EQ(result.values[0].at("distinct-null"), Value{(double)1});
 
   // Odd
-  EXPECT_EQ(result->at(1).at("count"), Value{(double)5});
-  EXPECT_EQ(result->at(1).at("sum-i"), Value{(double)1 + 3 + 5 + 7 + 9});
-  EXPECT_EQ(result->at(1).at("distinct-hi"), Value{(double)3});
-  EXPECT_EQ(result->at(1).at("distinct-null"), Value{(double)1});
+  EXPECT_EQ(result.values[1].at("count"), Value{(double)5});
+  EXPECT_EQ(result.values[1].at("sum-i"), Value{(double)1 + 3 + 5 + 7 + 9});
+  EXPECT_EQ(result.values[1].at("distinct-hi"), Value{(double)3});
+  EXPECT_EQ(result.values[1].at("distinct-null"), Value{(double)1});
 }
 
 }  // namespace dfly::aggregate

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -1004,8 +1004,7 @@ void SearchFamily::FtAggregate(CmdArgList args, const CommandContext& cmd_cntx) 
     for (const auto& field : agg_results.fields_to_print) {
       rb->SendBulkString(field);
 
-      auto it = value.find(field);
-      if (it != value.end()) {
+      if (auto it = value.find(field); it != value.end()) {
         std::visit(sortable_value_sender, it->second);
       } else {
         rb->SendNull();

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -981,22 +981,35 @@ void SearchFamily::FtAggregate(CmdArgList args, const CommandContext& cmd_cntx) 
                   make_move_iterator(sub_results.end()));
   }
 
-  auto agg_results = aggregate::Process(std::move(values), params->steps);
-  if (!agg_results.has_value())
-    return builder->SendError(agg_results.error());
+  std::vector<std::string_view> load_fields;
+  if (params->load_fields) {
+    load_fields.reserve(params->load_fields->size());
+    for (const auto& field : params->load_fields.value()) {
+      load_fields.push_back(field.GetShortName());
+    }
+  }
 
-  size_t result_size = agg_results->size();
+  auto agg_results = aggregate::Process(std::move(values), load_fields, params->steps);
+
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx.rb);
   auto sortable_value_sender = SortableValueSender(rb);
 
+  const size_t result_size = agg_results.values.size();
   rb->StartArray(result_size + 1);
   rb->SendLong(result_size);
 
-  for (const auto& result : agg_results.value()) {
-    rb->StartArray(result.size() * 2);
-    for (const auto& [k, v] : result) {
-      rb->SendBulkString(k);
-      std::visit(sortable_value_sender, v);
+  const size_t field_count = agg_results.fields_to_print.size();
+  for (const auto& value : agg_results.values) {
+    rb->StartArray(field_count * 2);
+    for (const auto& field : agg_results.fields_to_print) {
+      rb->SendBulkString(field);
+
+      auto it = value.find(field);
+      if (it != value.end()) {
+        std::visit(sortable_value_sender, it->second);
+      } else {
+        rb->SendNull();
+      }
     }
   }
 }

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -962,15 +962,12 @@ TEST_F(SearchFamilyTest, AggregateGroupBy) {
   EXPECT_THAT(resp, IsUnordArrayWithSize(IsMap("foo_total", "20", "word", "item2"),
                                          IsMap("foo_total", "50", "word", "item1")));
 
-  /*
-  Temporary not supported
-
   resp = Run({"ft.aggregate", "i1", "*", "LOAD", "2", "foo", "text", "GROUPBY", "2", "@word",
-  "@text", "REDUCE", "SUM", "1", "@foo", "AS", "foo_total"}); EXPECT_THAT(resp,
-  IsUnordArrayWithSize(IsMap("foo_total", "20", "word", ArgType(RespExpr::NIL), "text", "\"second
-  key\""), IsMap("foo_total", "40", "word", ArgType(RespExpr::NIL), "text", "\"third key\""),
-  IsMap({"foo_total", "10", "word", ArgType(RespExpr::NIL), "text", "\"first key"})));
-  */
+              "@text", "REDUCE", "SUM", "1", "@foo", "AS", "foo_total"});
+  EXPECT_THAT(resp, IsUnordArrayWithSize(
+                        IsMap("foo_total", "40", "word", "item1", "text", "\"third key\""),
+                        IsMap("foo_total", "20", "word", "item2", "text", "\"second key\""),
+                        IsMap("foo_total", "10", "word", "item1", "text", "\"first key\"")));
 }
 
 TEST_F(SearchFamilyTest, JsonAggregateGroupBy) {
@@ -1630,6 +1627,34 @@ TEST_F(SearchFamilyTest, SearchLoadReturnHash) {
   // Search with LOAD @a
   resp = Run({"FT.SEARCH", "i2", "*", "LOAD", "1", "@a"});
   EXPECT_THAT(resp, IsMapWithSize("h2", IsMap("a", "two"), "h1", IsMap("a", "one")));
+}
+
+// Test that FT.AGGREGATE prints only needed fields
+TEST_F(SearchFamilyTest, AggregateResultFields) {
+  Run({"JSON.SET", "j1", ".", R"({"a":"1","b":"2","c":"3"})"});
+  Run({"JSON.SET", "j2", ".", R"({"a":"4","b":"5","c":"6"})"});
+  Run({"JSON.SET", "j3", ".", R"({"a":"7","b":"8","c":"9"})"});
+
+  auto resp = Run({"FT.CREATE", "index", "ON", "JSON", "SCHEMA", "$.a", "AS", "a", "TEXT",
+                   "SORTABLE", "$.b", "AS", "b", "TEXT", "$.c", "AS", "c", "TEXT"});
+  EXPECT_EQ(resp, "OK");
+
+  resp = Run({"FT.AGGREGATE", "index", "*"});
+  EXPECT_THAT(resp, IsUnordArrayWithSize(IsMap(), IsMap(), IsMap()));
+
+  resp = Run({"FT.AGGREGATE", "index", "*", "SORTBY", "1", "a"});
+  EXPECT_THAT(resp, IsUnordArrayWithSize(IsMap("a", "1"), IsMap("a", "4"), IsMap("a", "7")));
+
+  resp = Run({"FT.AGGREGATE", "index", "*", "LOAD", "1", "@b", "SORTBY", "1", "a"});
+  EXPECT_THAT(resp,
+              IsUnordArrayWithSize(IsMap("b", "\"2\"", "a", "1"), IsMap("b", "\"5\"", "a", "4"),
+                                   IsMap("b", "\"8\"", "a", "7")));
+
+  resp = Run({"FT.AGGREGATE", "index", "*", "SORTBY", "1", "a", "GROUPBY", "2", "@b", "@a",
+              "REDUCE", "COUNT", "0", "AS", "count"});
+  EXPECT_THAT(resp, IsUnordArrayWithSize(IsMap("b", "\"8\"", "a", "7", "count", "1"),
+                                         IsMap("b", "\"2\"", "a", "1", "count", "1"),
+                                         IsMap("b", "\"5\"", "a", "4", "count", "1")));
 }
 
 }  // namespace dfly


### PR DESCRIPTION
fixes dragonflydb#4230

First PR for complete support of the SORTBY option (#3631)

To see examples please check the issue.
Add code that checks, during aggregate steps, what fields should be printed. 