### PR TITLE
fix(server): fix memory leak on lua error

### DIFF
--- a/src/core/interpreter.cc
+++ b/src/core/interpreter.cc
@@ -926,18 +926,17 @@ std::optional<absl::FixedArray<std::string_view, 4>> Interpreter::PrepareArgs() 
     }
   }
 
-  char name_buffer[32];  // backing storage for cmd name
   absl::FixedArray<string_view, 4> args(argc);
 
   // Copy command name to name_buffer and set it as first arg.
   unsigned name_len = lua_rawlen(lua_, 1);
-  if (name_len >= sizeof(name_buffer)) {
+  if (name_len >= sizeof(name_buffer_)) {
     PushError(lua_, "Lua redis() command name too long");
     return std::nullopt;
   }
 
-  memcpy(name_buffer, lua_tostring(lua_, 1), name_len);
-  args[0] = {name_buffer, name_len};
+  memcpy(name_buffer_, lua_tostring(lua_, 1), name_len);
+  args[0] = {name_buffer_, name_len};
   buffer_.resize(blob_len + 4, '\0');  // backing storage for args
 
   char* cur = buffer_.data();

--- a/src/core/interpreter.cc
+++ b/src/core/interpreter.cc
@@ -256,11 +256,13 @@ void SetGlobalArrayInternal(lua_State* lua, const char* name, Interpreter::Slice
 /* In case the error set into the Lua stack by PushError() was generated
  * by the non-error-trapping version of redis.pcall(), which is redis.call(),
  * this function will raise the Lua error so that the execution of the
- * script will be halted. */
-int RaiseError(lua_State* lua) {
+ * script will be halted.
+ * This function never returns, it unwinds the Lua call stack until an error handler is found or the
+ * script exits */
+void RaiseError(lua_State* lua) {
   lua_pushstring(lua, "err");
   lua_gettable(lua, -2);
-  return lua_error(lua);
+  lua_error(lua);
 }
 
 void LoadLibrary(lua_State* lua, const char* libname, lua_CFunction luafunc) {
@@ -467,7 +469,7 @@ int RedisLogCommand(lua_State* lua) {
   int argc = lua_gettop(lua);
   if (argc < 2) {
     PushError(lua, "redis.log() requires two arguments or more.");
-    return RaiseError(lua);
+    RaiseError(lua);
   }
 
   return 0;
@@ -899,133 +901,145 @@ int Interpreter::RedisGenericCommand(bool raise_error, bool async, ObjectExplore
    * to luaRedisGenericCommand(), which normally should never happen.
    * To make this function reentrant is futile and makes it slower, but
    * we should at least detect such a misuse, and abort. */
-  if (cmd_depth_) {
-    const char* recursion_warning =
-        "luaRedisGenericCommand() recursive call detected. "
-        "Are you doing funny stuff with Lua debug hooks?";
-    PushError(lua_, recursion_warning);
+  {
+    if (cmd_depth_) {
+      const char* recursion_warning =
+          "luaRedisGenericCommand() recursive call detected. "
+          "Are you doing funny stuff with Lua debug hooks?";
+      PushError(lua_, recursion_warning);
+      return 1;
+    }
+
+    if (!redis_func_) {
+      PushError(lua_, "internal error - redis function not defined");
+      if (raise_error) {
+        goto lua_raise_error;
+        ;
+      }
+      return 1;
+    }
+
+    cmd_depth_++;
+    int argc = lua_gettop(lua_);
+
+#define RETURN_OR_THROW_ERROR(err) \
+  {                                \
+    PushError(lua_, err);          \
+    cmd_depth_--;                  \
+    if (raise_error) {             \
+      goto lua_raise_error;        \
+    }                              \
+    return 1;                      \
+  }
+
+    /* Require at least one argument */
+    if (argc == 0) {
+      RETURN_OR_THROW_ERROR("Please specify at least one argument for redis.call()");
+    }
+
+    size_t blob_len = 0;
+    char tmpbuf[64];
+
+    // Determine size required for backing storage for all args.
+    // Skip command name (idx=1), as its stored in a separate buffer.
+    for (int idx = 2; idx <= argc; idx++) {
+      switch (lua_type(lua_, idx)) {
+        case LUA_TNUMBER:
+          if (lua_isinteger(lua_, idx)) {
+            blob_len += absl::AlphaNum{lua_tointeger(lua_, idx)}.size();
+          } else {
+            int fmt_len = absl::SNPrintF(tmpbuf, sizeof(tmpbuf), "%.17g", lua_tonumber(lua_, idx));
+            CHECK_GT(fmt_len, 0);
+            blob_len += fmt_len;
+          }
+          continue;
+        case LUA_TSTRING:
+          blob_len += lua_rawlen(lua_, idx) + 1;
+          continue;
+        default:
+          RETURN_OR_THROW_ERROR("Lua redis() command arguments must be strings or integers");
+      }
+    }
+
+    char name_buffer[32];  // backing storage for cmd name
+    absl::FixedArray<string_view, 4> args(argc);
+
+    // Copy command name to name_buffer and set it as first arg.
+    unsigned name_len = lua_rawlen(lua_, 1);
+    if (name_len >= sizeof(name_buffer)) {
+      RETURN_OR_THROW_ERROR("Lua redis() command name too long");
+    }
+
+    memcpy(name_buffer, lua_tostring(lua_, 1), name_len);
+    args[0] = {name_buffer, name_len};
+    buffer_.resize(blob_len + 4, '\0');  // backing storage for args
+
+    char* cur = buffer_.data();
+    char* end = cur + blob_len;
+    for (int idx = 2; idx <= argc; idx++) {
+      size_t len = 0;
+      switch (lua_type(lua_, idx)) {
+        case LUA_TNUMBER:
+          if (lua_isinteger(lua_, idx)) {
+            char* next = absl::numbers_internal::FastIntToBuffer(lua_tointeger(lua_, idx), cur);
+            len = next - cur;
+          } else if (lua_isnumber(lua_, idx)) {
+            // we pass `end - cur + 1` because we do not want to skip the last character
+            // if it's the last argument.
+            int fmt_len = absl::SNPrintF(cur, end - cur + 1, "%.17g", lua_tonumber(lua_, idx));
+            CHECK_GT(fmt_len, 0);
+            len = fmt_len;
+          }
+          break;
+        case LUA_TSTRING:
+          len = lua_rawlen(lua_, idx);
+          memcpy(cur, lua_tostring(lua_, idx), len + 1);  // + 1 for null terminator
+      };
+
+      args[idx - 1] = {cur, len};
+      cur += len;
+    }
+
+    /* Pop all arguments from the stack, we do not need them anymore
+     * and this way we guaranty we will have room on the stack for the result. */
+    lua_pop(lua_, argc);
+
+    // Calling with custom explorer is not supported with errors or async
+    DCHECK(explorer == nullptr || (!raise_error && !async));
+
+    // If no custom explorer is set, use default translator
+    optional<RedisTranslator> translator;
+    if (explorer == nullptr) {
+      translator.emplace(lua_);
+      explorer = &*translator;
+    }
+
+    redis_func_(CallArgs{SliceSpan{args}, &buffer_, explorer, async, raise_error, &raise_error});
+    cmd_depth_--;
+
+    // Shrink reusable buffer if it's too big.
+    if (buffer_.capacity() > 128) {
+      buffer_.clear();
+      buffer_.shrink_to_fit();
+    }
+
+    if (!translator)
+      return 0;
+
+    // Raise error for regular 'call' command if needed.
+    if (raise_error && translator->HasError()) {
+      // error is already on top of stack
+      goto lua_raise_error;
+    }
+
+    if (!async)
+      DCHECK_EQ(1, lua_gettop(lua_));
+
     return 1;
   }
-
-  if (!redis_func_) {
-    PushError(lua_, "internal error - redis function not defined");
-    return raise_error ? RaiseError(lua_) : 1;
-  }
-
-  cmd_depth_++;
-  int argc = lua_gettop(lua_);
-
-#define RETURN_ERROR(err)                      \
-  {                                            \
-    PushError(lua_, err);                      \
-    cmd_depth_--;                              \
-    return raise_error ? RaiseError(lua_) : 1; \
-  }
-
-  /* Require at least one argument */
-  if (argc == 0) {
-    RETURN_ERROR("Please specify at least one argument for redis.call()");
-  }
-
-  size_t blob_len = 0;
-  char tmpbuf[64];
-
-  // Determine size required for backing storage for all args.
-  // Skip command name (idx=1), as its stored in a separate buffer.
-  for (int idx = 2; idx <= argc; idx++) {
-    switch (lua_type(lua_, idx)) {
-      case LUA_TNUMBER:
-        if (lua_isinteger(lua_, idx)) {
-          blob_len += absl::AlphaNum{lua_tointeger(lua_, idx)}.size();
-        } else {
-          int fmt_len = absl::SNPrintF(tmpbuf, sizeof(tmpbuf), "%.17g", lua_tonumber(lua_, idx));
-          CHECK_GT(fmt_len, 0);
-          blob_len += fmt_len;
-        }
-        continue;
-      case LUA_TSTRING:
-        blob_len += lua_rawlen(lua_, idx) + 1;
-        continue;
-      default:
-        RETURN_ERROR("Lua redis() command arguments must be strings or integers");
-    }
-  }
-
-  char name_buffer[32];  // backing storage for cmd name
-  absl::FixedArray<string_view, 4> args(argc);
-
-  // Copy command name to name_buffer and set it as first arg.
-  unsigned name_len = lua_rawlen(lua_, 1);
-  if (name_len >= sizeof(name_buffer)) {
-    RETURN_ERROR("Lua redis() command name too long");
-  }
-
-  memcpy(name_buffer, lua_tostring(lua_, 1), name_len);
-  args[0] = {name_buffer, name_len};
-  buffer_.resize(blob_len + 4, '\0');  // backing storage for args
-
-  char* cur = buffer_.data();
-  char* end = cur + blob_len;
-  for (int idx = 2; idx <= argc; idx++) {
-    size_t len = 0;
-    switch (lua_type(lua_, idx)) {
-      case LUA_TNUMBER:
-        if (lua_isinteger(lua_, idx)) {
-          char* next = absl::numbers_internal::FastIntToBuffer(lua_tointeger(lua_, idx), cur);
-          len = next - cur;
-        } else if (lua_isnumber(lua_, idx)) {
-          // we pass `end - cur + 1` because we do not want to skip the last character
-          // if it's the last argument.
-          int fmt_len = absl::SNPrintF(cur, end - cur + 1, "%.17g", lua_tonumber(lua_, idx));
-          CHECK_GT(fmt_len, 0);
-          len = fmt_len;
-        }
-        break;
-      case LUA_TSTRING:
-        len = lua_rawlen(lua_, idx);
-        memcpy(cur, lua_tostring(lua_, idx), len + 1);  // + 1 for null terminator
-    };
-
-    args[idx - 1] = {cur, len};
-    cur += len;
-  }
-
-  /* Pop all arguments from the stack, we do not need them anymore
-   * and this way we guaranty we will have room on the stack for the result. */
-  lua_pop(lua_, argc);
-
-  // Calling with custom explorer is not supported with errors or async
-  DCHECK(explorer == nullptr || (!raise_error && !async));
-
-  // If no custom explorer is set, use default translator
-  optional<RedisTranslator> translator;
-  if (explorer == nullptr) {
-    translator.emplace(lua_);
-    explorer = &*translator;
-  }
-
-  redis_func_(CallArgs{SliceSpan{args}, &buffer_, explorer, async, raise_error, &raise_error});
-  cmd_depth_--;
-
-  // Shrink reusable buffer if it's too big.
-  if (buffer_.capacity() > 128) {
-    buffer_.clear();
-    buffer_.shrink_to_fit();
-  }
-
-  if (!translator)
-    return 0;
-
-  // Raise error for regular 'call' command if needed.
-  if (raise_error && translator->HasError()) {
-    // error is already on top of stack
-    return RaiseError(lua_);
-  }
-
-  if (!async)
-    DCHECK_EQ(1, lua_gettop(lua_));
-
-  return 1;
+lua_raise_error:
+  RaiseError(lua_);  // this function never returns, it unwinds the Lua call stack
+  return 0;
 }
 
 int Interpreter::RedisCallCommand(lua_State* lua) {

--- a/src/core/interpreter.cc
+++ b/src/core/interpreter.cc
@@ -974,7 +974,7 @@ std::optional<absl::FixedArray<std::string_view, 4>> Interpreter::PrepareArgs() 
 std::optional<int> Interpreter::CallRedisFunction(bool* raise_error, bool async,
                                                   ObjectExplorer* explorer, SliceSpan args) {
   // Calling with custom explorer is not supported with errors or async
-  DCHECK(explorer == nullptr || (!raise_error && !async));
+  DCHECK(explorer == nullptr || (!*raise_error && !async));
 
   // If no custom explorer is set, use default translator
   optional<RedisTranslator> translator;

--- a/src/core/interpreter.h
+++ b/src/core/interpreter.h
@@ -148,6 +148,7 @@ class Interpreter {
   unsigned cmd_depth_ = 0;
   RedisFunc redis_func_;
   std::string buffer_;
+  char name_buffer_[32];  // backing storage for cmd name
 };
 
 // Manages an internal interpreter pool. This allows multiple connections residing on the same

--- a/src/core/interpreter.h
+++ b/src/core/interpreter.h
@@ -141,8 +141,7 @@ class Interpreter {
   static int RedisAPCallCommand(lua_State* lua);
 
   std::optional<absl::FixedArray<std::string_view, 4>> PrepareArgs();
-  std::optional<int> CallRedisFunction(bool* raise_error, bool async, ObjectExplorer* explorer,
-                                       SliceSpan args);
+  bool CallRedisFunction(bool raise_error, bool async, ObjectExplorer* explorer, SliceSpan args);
 
   lua_State* lua_;
   unsigned cmd_depth_ = 0;

--- a/src/core/interpreter.h
+++ b/src/core/interpreter.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <absl/container/fixed_array.h>
 #include <absl/types/span.h>
 
 #include <functional>
@@ -138,6 +139,10 @@ class Interpreter {
   static int RedisPCallCommand(lua_State* lua);
   static int RedisACallCommand(lua_State* lua);
   static int RedisAPCallCommand(lua_State* lua);
+
+  std::optional<absl::FixedArray<std::string_view, 4>> PrepareArgs();
+  std::optional<int> CallRedisFunction(bool* raise_error, bool async, ObjectExplorer* explorer,
+                                       SliceSpan args);
 
   lua_State* lua_;
   unsigned cmd_depth_ = 0;


### PR DESCRIPTION
The bug:
calling lua_error does not return, instead it unwinds the Lua call stack until an error handler is found or the
script exits. This lead to memory leak on object that should release memory in destructor.
Specific example is the absl::FixedArray<string_view, 4> args(argc); which allocates on heap if argc > 4. The free was not called leading to memory leak.
The fix:
Add scoping to RedisGenericCommand and call RaiseError which calls lua_error after goto after destructors are called