### PR TITLE
chore: split RecordExpiry preemptive and non-preemptive flows

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1157,7 +1157,6 @@ void DbSlice::ExpireAllIfNeeded() {
       ExpireIfNeeded(Context{nullptr, db_index, GetCurrentTimeMs()}, prime_it, false);
     };
 
-    block_counter_.Wait();
     ExpireTable::Cursor cursor;
     do {
       cursor = Traverse(&db.expire, cursor, cb);

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -555,9 +555,7 @@ class DbSlice {
     ExpireIterator exp_it;
   };
 
-  PrimeItAndExp ExpireIfNeeded(const Context& cntx, PrimeIterator it,
-                               bool preemptive = false) const;
-  PrimeItAndExp ExpireIfNeededImpl(const Context& cntx, PrimeIterator it) const;
+  PrimeItAndExp ExpireIfNeeded(const Context& cntx, PrimeIterator it, bool preempts = false) const;
 
   OpResult<AddOrFindResult> AddOrFindInternal(const Context& cntx, std::string_view key);
 

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -555,7 +555,9 @@ class DbSlice {
     ExpireIterator exp_it;
   };
 
-  PrimeItAndExp ExpireIfNeeded(const Context& cntx, PrimeIterator it) const;
+  PrimeItAndExp ExpireIfNeeded(const Context& cntx, PrimeIterator it,
+                               bool preemptive = false) const;
+  PrimeItAndExp ExpireIfNeededImpl(const Context& cntx, PrimeIterator it) const;
 
   OpResult<AddOrFindResult> AddOrFindInternal(const Context& cntx, std::string_view key);
 

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -597,6 +597,7 @@ void OpScan(const OpArgs& op_args, const ScanOpts& scan_opts, uint64_t* cursor, 
   auto& db_slice = op_args.GetDbSlice();
   DCHECK(db_slice.IsDbValid(op_args.db_cntx.db_index));
 
+  db_slice.BlockingCounter()->Wait();
   unsigned cnt = 0;
 
   VLOG(1) << "PrimeTable " << db_slice.shard_id() << "/" << op_args.db_cntx.db_index << " has "

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -597,7 +597,10 @@ void OpScan(const OpArgs& op_args, const ScanOpts& scan_opts, uint64_t* cursor, 
   auto& db_slice = op_args.GetDbSlice();
   DCHECK(db_slice.IsDbValid(op_args.db_cntx.db_index));
 
+  // We need to make sure we don't preempt below, because we don't hold any locks to the keys
+  // and ExpireIfNeeded requires that.
   db_slice.BlockingCounter()->Wait();
+  util::FiberAtomicGuard guard;
   unsigned cnt = 0;
 
   VLOG(1) << "PrimeTable " << db_slice.shard_id() << "/" << op_args.db_cntx.db_index << " has "

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -597,9 +597,6 @@ void OpScan(const OpArgs& op_args, const ScanOpts& scan_opts, uint64_t* cursor, 
   auto& db_slice = op_args.GetDbSlice();
   DCHECK(db_slice.IsDbValid(op_args.db_cntx.db_index));
 
-  // We need to make sure we don't preempt below, because we don't hold any locks to the keys
-  // and ExpireIfNeeded requires that.
-  db_slice.BlockingCounter()->Wait();
   util::FiberAtomicGuard guard;
   unsigned cnt = 0;
 

--- a/src/server/tx_base.cc
+++ b/src/server/tx_base.cc
@@ -65,7 +65,7 @@ void RecordJournal(const OpArgs& op_args, std::string_view cmd, facade::ArgSlice
 void RecordExpiry(DbIndex dbid, string_view key, bool preempts) {
   auto journal = EngineShard::tlocal()->journal();
   CHECK(journal);
-  if (preempts) {
+  if (!preempts) {
     util::FiberAtomicGuard guard;
     journal->RecordEntry(0, journal::Op::EXPIRED, dbid, 1, cluster::KeySlot(key),
                          Payload("DEL", ArgSlice{key}), preempts);

--- a/src/server/tx_base.cc
+++ b/src/server/tx_base.cc
@@ -62,11 +62,17 @@ void RecordJournal(const OpArgs& op_args, std::string_view cmd, facade::ArgSlice
   op_args.tx->LogJournalOnShard(op_args.shard, Payload(cmd, args), shard_cnt, true);
 }
 
-void RecordExpiry(DbIndex dbid, string_view key) {
+void RecordExpiry(DbIndex dbid, string_view key, bool preempts) {
   auto journal = EngineShard::tlocal()->journal();
   CHECK(journal);
+  if (preempts) {
+    util::FiberAtomicGuard guard;
+    journal->RecordEntry(0, journal::Op::EXPIRED, dbid, 1, cluster::KeySlot(key),
+                         Payload("DEL", ArgSlice{key}), preempts);
+    return;
+  }
   journal->RecordEntry(0, journal::Op::EXPIRED, dbid, 1, cluster::KeySlot(key),
-                       Payload("DEL", ArgSlice{key}), false);
+                       Payload("DEL", ArgSlice{key}), preempts);
 }
 
 void TriggerJournalWriteToSink() {

--- a/src/server/tx_base.h
+++ b/src/server/tx_base.h
@@ -224,7 +224,7 @@ void RecordJournal(const OpArgs& op_args, std::string_view cmd, ArgSlice args,
 
 // Record expiry in journal with independent transaction. Must be called from shard thread holding
 // key.
-void RecordExpiry(DbIndex dbid, std::string_view key);
+void RecordExpiry(DbIndex dbid, std::string_view key, bool preempts = false);
 
 // Trigger journal write to sink, no journal record will be added to journal.
 // Must be called from shard thread of journal to sink.

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -1424,7 +1424,7 @@ async def test_migration_with_key_ttl(df_factory):
     assert await nodes[1].client.execute_command("stick k_sticky") == 0
 
 
-@dfly_args({"proactor_threads": 4, "cluster_mode": "yes", "serialization_max_chunk_size": 0})
+@dfly_args({"proactor_threads": 4, "cluster_mode": "yes"})
 async def test_network_disconnect_during_migration(df_factory):
     instances = [
         df_factory.create(port=BASE_PORT + i, admin_port=BASE_PORT + i + 1000) for i in range(2)

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -1424,7 +1424,7 @@ async def test_migration_with_key_ttl(df_factory):
     assert await nodes[1].client.execute_command("stick k_sticky") == 0
 
 
-@dfly_args({"proactor_threads": 4, "cluster_mode": "yes"})
+@dfly_args({"proactor_threads": 4, "cluster_mode": "yes", "serialization_max_chunk_size": 0})
 async def test_network_disconnect_during_migration(df_factory):
     instances = [
         df_factory.create(port=BASE_PORT + i, admin_port=BASE_PORT + i + 1000) for i in range(2)


### PR DESCRIPTION
* add FiberGuard to RecordExpiry for non-preemptive flows