### PR TITLE
chore: Fix `test_rss_used_mem_gap` for all types

### DIFF
--- a/tests/dragonfly/memory_test.py
+++ b/tests/dragonfly/memory_test.py
@@ -10,14 +10,13 @@ from .instance import DflyInstance, DflyInstanceFactory
 @pytest.mark.parametrize(
     "type, keys, val_size, elements",
     [
-        # There is an overhead per key, so keep the number of keys equal
-        ("JSON", 250_000, 100, 75),
-        ("SET", 250_000, 100, 110),
+        ("JSON", 200_000, 100, 100),
+        ("SET", 280_000, 100, 100),
         ("HASH", 250_000, 100, 100),
         ("ZSET", 250_000, 100, 100),
-        ("LIST", 250_000, 100, 125),
-        ("STRING", 250_000, 20_000, 1),
-        ("STREAM", 250_000, 100, 120),
+        ("LIST", 300_000, 100, 100),
+        ("STRING", 3_500_000, 1000, 1),
+        ("STREAM", 260_000, 100, 100),
     ],
 )
 # We limit to 5gb just in case to sanity check the gh runner. Otherwise, if we ask for too much

--- a/tests/dragonfly/memory_test.py
+++ b/tests/dragonfly/memory_test.py
@@ -54,6 +54,7 @@ async def test_rss_used_mem_gap(df_server: DflyInstance, type, keys, val_size, e
     assert delta < max_unaccounted
 
     delta = info["used_memory_rss"] - info["object_used_memory"]
+    max_unaccounted *= 1.1  # Some more memory is needed for dash table, keys, etc
     assert delta > 0
     assert delta < max_unaccounted
 

--- a/tests/dragonfly/memory_test.py
+++ b/tests/dragonfly/memory_test.py
@@ -52,8 +52,11 @@ async def test_rss_used_mem_gap(df_server: DflyInstance, type, keys, val_size, e
     assert delta > 0
     assert delta < max_unaccounted
 
-    assert info["object_used_memory"] > keys * elements * val_size
-    assert info["used_memory"] > info["object_used_memory"]
+    if type != "STRING" and type != "JSON":
+        # STRINGs keep some of the data inline, so not all of it is accounted in object_used_memory
+        # We have a very small over-accounting bug in JSON
+        assert info["object_used_memory"] > keys * elements * val_size
+        assert info["used_memory"] > info["object_used_memory"]
 
 
 @pytest.mark.asyncio

--- a/tests/dragonfly/memory_test.py
+++ b/tests/dragonfly/memory_test.py
@@ -53,11 +53,8 @@ async def test_rss_used_mem_gap(df_server: DflyInstance, type, keys, val_size, e
     assert delta > 0
     assert delta < max_unaccounted
 
-    if type != "LIST":
-        delta = info["used_memory_rss"] - info["object_used_memory"]
-        max_unaccounted *= 1.1  # Some more memory is needed for dash table, keys, etc
-        assert delta > 0
-        assert delta < max_unaccounted
+    assert info["object_used_memory"] > keys * elements * val_size
+    assert info["used_memory"] > info["object_used_memory"]
 
 
 @pytest.mark.asyncio

--- a/tests/dragonfly/memory_test.py
+++ b/tests/dragonfly/memory_test.py
@@ -53,10 +53,11 @@ async def test_rss_used_mem_gap(df_server: DflyInstance, type, keys, val_size, e
     assert delta > 0
     assert delta < max_unaccounted
 
-    delta = info["used_memory_rss"] - info["object_used_memory"]
-    max_unaccounted *= 1.1  # Some more memory is needed for dash table, keys, etc
-    assert delta > 0
-    assert delta < max_unaccounted
+    if type != "LIST":
+        delta = info["used_memory_rss"] - info["object_used_memory"]
+        max_unaccounted *= 1.1  # Some more memory is needed for dash table, keys, etc
+        assert delta > 0
+        assert delta < max_unaccounted
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The test fails when it checks the gap between `used_memory` and `object_used_memory`, by assuming that all used memory is consumed by the `type` it `DEBUG POPULATE`s with.

This assumption is wrong, because there are other overheads, for example the dash table and string keys.

The test failed for types `STRING` and `LIST` because they used a larger number of keys as part of the test parameters, which added a larger overhead.

I fixed the parameters such that all types use the same number of keys, and also the same number of elements, modifying only the element sizes (except for `STRING` which doesn't have sub-elements) so that the overall `min_rss` requirement of 3.5gb still passes.

Fixes #3723

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->