### PR TITLE
chore(rax_tree): Introduce raxFreeWithCallback call in RaxTreeMap destructor

### DIFF
--- a/src/redis/rax.h
+++ b/src/redis/rax.h
@@ -195,6 +195,7 @@ int raxRemove(rax *rax, unsigned char *s, size_t len, void **old);
 void *raxFind(rax *rax, unsigned char *s, size_t len);
 void raxFree(rax *rax);
 void raxFreeWithCallback(rax *rax, void (*free_callback)(void*));
+void raxFreeWithCallbackAndArgument(rax *rax, void (*free_callback)(void*, void*), void* argument);
 void raxStart(raxIterator *it, rax *rt);
 int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len);
 int raxNext(raxIterator *it);


### PR DESCRIPTION
related to [this comment](https://github.com/dragonflydb/dragonfly/pull/4228#issuecomment-2514645979)