### PR TITLE
fix(save): don't create dirs for cloud dir

### DIFF
--- a/src/server/detail/save_stages_controller.cc
+++ b/src/server/detail/save_stages_controller.cc
@@ -379,7 +379,7 @@ GenericError SaveStagesController::FinalizeFileMovement() {
 // Build full path: get dir, try creating dirs, get filename with placeholder
 GenericError SaveStagesController::BuildFullPath() {
   fs::path dir_path = GetFlag(FLAGS_dir);
-  if (!dir_path.empty()) {
+  if (!dir_path.empty() && !IsCloudPath(GetFlag(FLAGS_dir))) {
     if (auto ec = CreateDirs(dir_path); ec)
       return {ec, "Failed to create directories"};
   }


### PR DESCRIPTION
Fixes creating local directories when `--dir` is a cloud path (eg S3)

Before, if the path was `s3://my-bucket/my-snapshots/`, we'd create directories `s3:/my-bucket/my-snapshots` locally (which were unused). Which was both messy and led to permissions issues if Dragonfly didn't have permission to create those directories

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->