### PR TITLE
chore: fixes the parse error for xread/xreadgroup with unbalanced ids

### DIFF
--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -404,8 +404,8 @@ TEST_F(StreamFamilyTest, XReadInvalidArgs) {
   EXPECT_THAT(resp, ErrArg("syntax error"));
 
   // Unbalanced list of streams.
-  resp = Run({"xread", "count", "invalid", "streams", "s1", "s2", "s3", "0", "0"});
-  EXPECT_THAT(resp, ErrArg("syntax error"));
+  resp = Run({"xread", "count", "invalid", "streams", "s1", "s2", "0", "0"});
+  EXPECT_THAT(resp, ErrArg("value is not an integer"));
 
   // Wrong type.
   Run({"set", "foo", "v"});
@@ -442,7 +442,12 @@ TEST_F(StreamFamilyTest, XReadGroupInvalidArgs) {
 
   // Unbalanced list of streams.
   resp = Run({"xreadgroup", "group", "group", "alice", "streams", "s1", "s2", "s3", "0", "0"});
-  EXPECT_THAT(resp, ErrArg("syntax error"));
+  EXPECT_THAT(resp, ErrArg("Unbalanced 'xreadgroup' list of streams: for each stream key an ID or "
+                           "'>' must be specified"));
+
+  resp = Run({"XREAD", "COUNT", "1", "STREAMS", "mystream"});
+  ASSERT_THAT(resp, ErrArg("Unbalanced 'xread' list of streams: for each stream key an ID or '$' "
+                           "must be specified"));
 }
 
 TEST_F(StreamFamilyTest, XReadGroupEmpty) {

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1563,9 +1563,6 @@ OpResult<KeyIndex> DetermineKeys(const CommandId* cid, CmdArgList args) {
         string_view arg = ArgS(args, i);
         if (absl::EqualsIgnoreCase(arg, "STREAMS")) {
           size_t left = args.size() - i - 1;
-          if (left < 2 || left % 2 != 0)
-            return OpStatus::SYNTAX_ERR;
-
           return KeyIndex(i + 1, i + 1 + (left / 2));
         }
       }


### PR DESCRIPTION
Partiall addresses https://github.com/dragonflydb/dragonfly/issues/4193

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->