### PR TITLE
fix: close socket to prevent onCompletion call after the journal stre…

### DIFF
--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -81,7 +81,8 @@ class OutgoingMigration::SliceSlotMigration : private ProtocolClient {
   }
 
   void Cancel() {
-    cntx_.Cancel();
+    // Close socket for clean disconnect.
+    CloseSocket();
     streamer_.Cancel();
   }
 


### PR DESCRIPTION
fixes: #4269

problem: OnCompletion is called after the JournalStreamer has been removed