### PR TITLE
fix cluster: migration traverse bug

### DIFF
--- a/src/server/journal/streamer.cc
+++ b/src/server/journal/streamer.cc
@@ -208,7 +208,7 @@ void RestoreStreamer::Run() {
   do {
     if (fiber_cancelled_)
       return;
-    cursor = pt->Traverse(cursor, [&](PrimeTable::bucket_iterator it) {
+    cursor = pt->TraverseBuckets(cursor, [&](PrimeTable::bucket_iterator it) {
       if (fiber_cancelled_)  // Could be cancelled any time as Traverse may preempt
         return;
 


### PR DESCRIPTION
The bug:
Dash table traverse function assumes that the cb does not preempts
the traverse applies the cb on each slot of the logical bucket.
In our flow the registered cb WriteBucket can preempt and therefore after preempting the assertion for iterating each slot of the bucket is triggered
F20241208 21:35:59.052592 21717 init.cc:25] [../src/core/dash_internal.h:1587]: assert(BucketIndex(hfun(bucket->key[slot])) == bid) failed!

the bug was discovered in the following regression run
https://github.com/dragonflydb/dragonfly/actions/runs/12225241118/job/34098992760

The fix:
We lately introduced an new dash table function TraveseBucket that iterate on physical bucket and it applies the cb on the bucket only once. It is used in snapshoting now to support big value serialization wich can preempt and it also improves the flow as it applies the cb only once on a bucket and not multiple times for each bucket slot.

