### PR TITLE
fix: support loading of 7.x streams correctly

### DIFF
--- a/src/facade/facade_test.h
+++ b/src/facade/facade_test.h
@@ -91,6 +91,10 @@ inline bool operator==(const RespExpr& left, std::string_view s) {
   return left.type == RespExpr::STRING && ToSV(left.GetBuf()) == s;
 }
 
+inline bool operator==(const RespExpr& left, int64_t val) {
+  return left.type == RespExpr::INT64 && left.GetInt() == val;
+}
+
 inline bool operator!=(const RespExpr& left, std::string_view s) {
   return !(left == s);
 }

--- a/src/server/rdb_extensions.h
+++ b/src/server/rdb_extensions.h
@@ -9,7 +9,6 @@ extern "C" {
 }
 
 //  Custom types: Range 30-35 is used by DF RDB types.
-constexpr uint8_t RDB_TYPE_JSON_OLD = 20;
 constexpr uint8_t RDB_TYPE_JSON = 30;
 constexpr uint8_t RDB_TYPE_HASH_WITH_EXPIRY = 31;
 constexpr uint8_t RDB_TYPE_SET_WITH_EXPIRY = 32;

--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -16,6 +16,8 @@ extern "C" {
 #include "server/common.h"
 #include "server/journal/serializer.h"
 
+struct streamID;
+
 namespace dfly {
 
 class EngineShardSet;
@@ -84,15 +86,15 @@ class RdbLoaderBase {
   };
 
   struct StreamID {
-    uint64_t ms;
-    uint64_t seq;
+    uint64_t ms = 0;
+    uint64_t seq = 0;
   };
 
   struct StreamCGTrace {
     RdbVariant name;
     uint64_t ms;
     uint64_t seq;
-
+    uint64_t entries_read;
     std::vector<StreamPelTrace> pel_arr;
     std::vector<StreamConsumerTrace> cons_arr;
   };
@@ -100,10 +102,10 @@ class RdbLoaderBase {
   struct StreamTrace {
     size_t lp_len;
     size_t stream_len;
-    uint64_t ms, seq;
+    StreamID last_id;
     StreamID first_id;             /* The first non-tombstone entry, zero if empty. */
     StreamID max_deleted_entry_id; /* The maximal ID that was deleted. */
-    uint64_t entries_added;        /* All time count of elements added. */
+    uint64_t entries_added = 0;    /* All time count of elements added. */
     std::vector<StreamCGTrace> cgroup;
   };
 
@@ -191,6 +193,8 @@ class RdbLoaderBase {
   std::error_code EnsureRead(size_t min_sz);
 
   std::error_code EnsureReadInternal(size_t min_to_read);
+
+  static void CopyStreamId(const StreamID& src, struct streamID* dest);
 
   base::IoBuf* mem_buf_ = nullptr;
   base::IoBuf origin_mem_buf_;


### PR DESCRIPTION
Now rdb_load supports RDB_TYPE_STREAM_LISTPACKS, RDB_TYPE_STREAM_LISTPACKS_2 and RDB_TYPE_STREAM_LISTPACKS_3 formats.
rdb_save still saves with RDB_TYPE_STREAM_LISTPACKS format - we want to release the DF version that can load everything first, and
then update the replicaion format in the next versions.

Also, update rdb_test.cc

`active-time` is not supported yet, will be added in the next PR.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->