### PR TITLE
refactor(search_family): Add Aggregator class

### DIFF
--- a/src/server/search/aggregator.cc
+++ b/src/server/search/aggregator.cc
@@ -77,10 +77,7 @@ void Aggregator::DoSort(std::string_view field, bool descending) {
     if (l_it->second < r_it->second) {
       return !descending;
     }
-    if (l_it->second > r_it->second) {
-      return descending;
-    }
-    return true;  // Elements are equal
+    return descending;  // l_it->second >= r_it->second
   };
 
   std::sort(result.values.begin(), result.values.end(), std::move(comparator));

--- a/src/server/search/aggregator.cc
+++ b/src/server/search/aggregator.cc
@@ -10,62 +10,81 @@ namespace dfly::aggregate {
 
 namespace {
 
-struct GroupStep {
-  PipelineResult operator()(PipelineResult result) {
-    // Separate items into groups
-    absl::flat_hash_map<absl::FixedArray<Value>, std::vector<DocValues>> groups;
-    for (auto& value : result.values) {
-      groups[Extract(value)].push_back(std::move(value));
-    }
+using ValuesList = absl::FixedArray<Value>;
 
-    // Restore DocValues and apply reducers
-    std::vector<DocValues> out;
-    while (!groups.empty()) {
-      auto node = groups.extract(groups.begin());
-      DocValues doc = Unpack(std::move(node.key()));
-      for (auto& reducer : reducers_) {
-        doc[reducer.result_field] = reducer.func({reducer.source_field, node.mapped()});
-      }
-      out.push_back(std::move(doc));
-    }
-
-    absl::flat_hash_set<std::string> fields_to_print;
-    fields_to_print.reserve(fields_.size() + reducers_.size());
-
-    for (auto& field : fields_) {
-      fields_to_print.insert(std::move(field));
-    }
-    for (auto& reducer : reducers_) {
-      fields_to_print.insert(std::move(reducer.result_field));
-    }
-
-    return {std::move(out), std::move(fields_to_print)};
+ValuesList ExtractFieldsValues(const DocValues& dv, absl::Span<const std::string> fields) {
+  ValuesList out(fields.size());
+  for (size_t i = 0; i < fields.size(); i++) {
+    auto it = dv.find(fields[i]);
+    out[i] = (it != dv.end()) ? it->second : Value{};
   }
+  return out;
+}
 
-  absl::FixedArray<Value> Extract(const DocValues& dv) {
-    absl::FixedArray<Value> out(fields_.size());
-    for (size_t i = 0; i < fields_.size(); i++) {
-      auto it = dv.find(fields_[i]);
-      out[i] = (it != dv.end()) ? it->second : Value{};
-    }
-    return out;
-  }
-
-  DocValues Unpack(absl::FixedArray<Value>&& values) {
-    DCHECK_EQ(values.size(), fields_.size());
-    DocValues out;
-    for (size_t i = 0; i < fields_.size(); i++)
-      out[fields_[i]] = std::move(values[i]);
-    return out;
-  }
-
-  std::vector<std::string> fields_;
-  std::vector<Reducer> reducers_;
-};
+DocValues PackFields(ValuesList values, absl::Span<const std::string> fields) {
+  DCHECK_EQ(values.size(), fields.size());
+  DocValues out;
+  for (size_t i = 0; i < fields.size(); i++)
+    out[fields[i]] = std::move(values[i]);
+  return out;
+}
 
 const Value kEmptyValue = Value{};
 
 }  // namespace
+
+void Aggregator::DoGroup(absl::Span<const std::string> fields, absl::Span<const Reducer> reducers) {
+  // Separate items into groups
+  absl::flat_hash_map<ValuesList, std::vector<DocValues>> groups;
+  for (auto& value : result.values) {
+    groups[ExtractFieldsValues(value, fields)].push_back(std::move(value));
+  }
+
+  // Restore DocValues and apply reducers
+  auto& values = result.values;
+  values.clear();
+  values.reserve(groups.size());
+  while (!groups.empty()) {
+    auto node = groups.extract(groups.begin());
+    DocValues doc = PackFields(std::move(node.key()), fields);
+    for (auto& reducer : reducers) {
+      doc[reducer.result_field] = reducer.func({reducer.source_field, node.mapped()});
+    }
+    values.push_back(std::move(doc));
+  }
+
+  auto& fields_to_print = result.fields_to_print;
+  fields_to_print.clear();
+  fields_to_print.reserve(fields.size() + reducers.size());
+
+  for (auto& field : fields) {
+    fields_to_print.insert(field);
+  }
+  for (auto& reducer : reducers) {
+    fields_to_print.insert(reducer.result_field);
+  }
+}
+
+void Aggregator::DoSort(std::string_view field, bool descending) {
+  std::sort(result.values.begin(), result.values.end(),
+            [field](const DocValues& l, const DocValues& r) {
+              auto it1 = l.find(field);
+              auto it2 = r.find(field);
+              return it1 == l.end() || (it2 != r.end() && it1->second < it2->second);
+            });
+
+  if (descending) {
+    std::reverse(result.values.begin(), result.values.end());
+  }
+
+  result.fields_to_print.insert(field);
+}
+
+void Aggregator::DoLimit(size_t offset, size_t num) {
+  auto& values = result.values;
+  values.erase(values.begin(), values.begin() + std::min(offset, values.size()));
+  values.resize(std::min(num, values.size()));
+}
 
 const Value& ValueIterator::operator*() const {
   auto it = values_.front().find(field_);
@@ -109,48 +128,30 @@ Reducer::Func FindReducerFunc(ReducerFunc name) {
   return nullptr;
 }
 
-PipelineStep MakeGroupStep(absl::Span<const std::string_view> fields,
-                           std::vector<Reducer> reducers) {
-  return GroupStep{std::vector<std::string>(fields.begin(), fields.end()), std::move(reducers)};
-}
-
-PipelineStep MakeSortStep(std::string_view field, bool descending) {
-  return [field = std::string(field), descending](PipelineResult result) -> PipelineResult {
-    auto& values = result.values;
-
-    std::sort(values.begin(), values.end(), [field](const DocValues& l, const DocValues& r) {
-      auto it1 = l.find(field);
-      auto it2 = r.find(field);
-      return it1 == l.end() || (it2 != r.end() && it1->second < it2->second);
-    });
-
-    if (descending) {
-      std::reverse(values.begin(), values.end());
-    }
-
-    result.fields_to_print.insert(field);
-    return result;
+AggregationStep MakeGroupStep(std::vector<std::string> fields, std::vector<Reducer> reducers) {
+  return [fields = std::move(fields), reducers = std::move(reducers)](Aggregator* aggregator) {
+    aggregator->DoGroup(fields, reducers);
   };
 }
 
-PipelineStep MakeLimitStep(size_t offset, size_t num) {
-  return [offset, num](PipelineResult result) {
-    auto& values = result.values;
-    values.erase(values.begin(), values.begin() + std::min(offset, values.size()));
-    values.resize(std::min(num, values.size()));
-    return result;
+AggregationStep MakeSortStep(std::string field, bool descending) {
+  return [field = std::move(field), descending](Aggregator* aggregator) {
+    aggregator->DoSort(field, descending);
   };
 }
 
-PipelineResult Process(std::vector<DocValues> values,
-                       absl::Span<const std::string_view> fields_to_print,
-                       absl::Span<const PipelineStep> steps) {
-  PipelineResult result{std::move(values), {fields_to_print.begin(), fields_to_print.end()}};
+AggregationStep MakeLimitStep(size_t offset, size_t num) {
+  return [=](Aggregator* aggregator) { aggregator->DoLimit(offset, num); };
+}
+
+AggregationResult Process(std::vector<DocValues> values,
+                          absl::Span<const std::string_view> fields_to_print,
+                          absl::Span<const AggregationStep> steps) {
+  Aggregator aggregator{std::move(values), {fields_to_print.begin(), fields_to_print.end()}};
   for (auto& step : steps) {
-    PipelineResult step_result = step(std::move(result));
-    result = std::move(step_result);
+    step(&aggregator);
   }
-  return result;
+  return aggregator.result;
 }
 
 }  // namespace dfly::aggregate

--- a/src/server/search/aggregator.cc
+++ b/src/server/search/aggregator.cc
@@ -85,7 +85,7 @@ void Aggregator::DoSort(std::string_view field, bool descending) {
 
     // If some of the values is not present
     if (l_it == l.end() || r_it == r.end()) {
-      return l_it != l.end() && r_it == r.end();
+      return l_it != l.end();
     }
 
     auto& lv = l_it->second;

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -168,7 +168,7 @@ struct AggregateParams {
   search::QueryParams params;
 
   std::optional<SearchFieldsList> load_fields;
-  std::vector<aggregate::PipelineStep> steps;
+  std::vector<aggregate::AggregationStep> steps;
 };
 
 // Stores basic info about a document index.

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -320,20 +320,13 @@ optional<AggregateParams> ParseAggregatorParamsOrReply(CmdArgParser parser,
   while (parser.HasNext()) {
     // GROUPBY nargs property [property ...]
     if (parser.Check("GROUPBY")) {
-      vector<string_view> fields(parser.Next<size_t>());
-      for (string_view& field : fields) {
-        auto parsed_field = ParseFieldWithAtSign(&parser);
+      size_t num_fields = parser.Next<size_t>();
 
-        /*
-        TODO: Throw an error if the field has no '@' sign at the beginning
-
-        if (!parsed_field) {
-          builder->SendError(absl::StrCat("bad arguments for GROUPBY: Unknown property '", field,
-                                       "'. Did you mean '@", field, "`?"));
-          return nullopt;
-        } */
-
-        field = parsed_field;
+      std::vector<std::string> fields;
+      fields.reserve(num_fields);
+      while (num_fields > 0 && parser.HasNext()) {
+        fields.emplace_back(ParseFieldWithAtSign(&parser));
+        num_fields--;
       }
 
       vector<aggregate::Reducer> reducers;
@@ -363,7 +356,7 @@ optional<AggregateParams> ParseAggregatorParamsOrReply(CmdArgParser parser,
             aggregate::Reducer{std::move(source_field), std::move(result_field), std::move(func)});
       }
 
-      params.steps.push_back(aggregate::MakeGroupStep(fields, std::move(reducers)));
+      params.steps.push_back(aggregate::MakeGroupStep(std::move(fields), std::move(reducers)));
       continue;
     }
 
@@ -373,7 +366,7 @@ optional<AggregateParams> ParseAggregatorParamsOrReply(CmdArgParser parser,
       string_view field = parser.Next();
       bool desc = bool(parser.Check("DESC"));
 
-      params.steps.push_back(aggregate::MakeSortStep(field, desc));
+      params.steps.push_back(aggregate::MakeSortStep(std::string{field}, desc));
       continue;
     }
 
@@ -975,10 +968,18 @@ void SearchFamily::FtAggregate(CmdArgList args, const CommandContext& cmd_cntx) 
     return OpStatus::OK;
   });
 
-  vector<aggregate::DocValues> values;
+  // ResultContainer is absl::flat_hash_map<std::string, search::SortableValue>
+  // DocValues is absl::flat_hash_map<std::string_view, SortableValue>
+  // Keys of values should point to the keys of the query_results
+  std::vector<aggregate::DocValues> values;
   for (auto& sub_results : query_results) {
-    values.insert(values.end(), make_move_iterator(sub_results.begin()),
-                  make_move_iterator(sub_results.end()));
+    for (auto& docs : sub_results) {
+      aggregate::DocValues doc_value;
+      for (auto& doc : docs) {
+        doc_value[doc.first] = std::move(doc.second);
+      }
+      values.push_back(std::move(doc_value));
+    }
   }
 
   std::vector<std::string_view> load_fields;

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -325,7 +325,17 @@ optional<AggregateParams> ParseAggregatorParamsOrReply(CmdArgParser parser,
       std::vector<std::string> fields;
       fields.reserve(num_fields);
       while (num_fields > 0 && parser.HasNext()) {
-        fields.emplace_back(ParseFieldWithAtSign(&parser));
+        auto parsed_field = ParseFieldWithAtSign(&parser);
+
+        /*
+        TODO: Throw an error if the field has no '@' sign at the beginning
+        if (!parsed_field) {
+          builder->SendError(absl::StrCat("bad arguments for GROUPBY: Unknown property '", field,
+                                       "'. Did you mean '@", field, "`?"));
+          return nullopt;
+        } */
+
+        fields.emplace_back(parsed_field);
         num_fields--;
       }
 


### PR DESCRIPTION
related to this [comment](https://github.com/dragonflydb/dragonfly/pull/4231#discussion_r1864173422)

1. Add `Aggregator` class.
2. Remove redundant `std::string` copies entirely during the aggregation steps.

TODO:
1. Add logs
2. Remove the usage of `std::function`