### PR TITLE
fix: increase cluster migration default timeout

### DIFF
--- a/src/server/cluster/incoming_slot_migration.cc
+++ b/src/server/cluster/incoming_slot_migration.cc
@@ -180,7 +180,7 @@ bool IncomingSlotMigration::Join(long attempt) {
     const absl::Duration passed = now - start;
     VLOG(1) << "Checking whether to continue with join " << passed << " vs " << timeout;
     if (passed >= timeout) {
-      LOG(WARNING) << "Can't join migration in time";
+      LOG(WARNING) << "Can't join migration in time for " << source_id_;
       ReportError(GenericError("Can't join migration in time"));
       return false;
     }

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -1614,7 +1614,7 @@ async def test_cluster_fuzzymigration(
                         res = False
         return res
 
-    @assert_eventually(times=500)
+    @assert_eventually(times=600)
     async def test_all_finished():
         assert await all_finished()
 


### PR DESCRIPTION
fixes: #4289

It looks like 2 seconds isn't enough to finalize the migration process. I've also improved the logs.