### PR TITLE
feat: add migration_finalization_timeout_ms flag

### DIFF
--- a/src/server/cluster/incoming_slot_migration.cc
+++ b/src/server/cluster/incoming_slot_migration.cc
@@ -16,7 +16,7 @@
 #include "server/main_service.h"
 #include "util/fibers/synchronization.h"
 
-ABSL_DECLARE_FLAG(int, slot_migration_connection_timeout_ms);
+ABSL_DECLARE_FLAG(int, migration_finalization_timeout_ms);
 
 namespace dfly::cluster {
 
@@ -173,7 +173,7 @@ void IncomingSlotMigration::Pause(bool pause) {
 bool IncomingSlotMigration::Join(long attempt) {
   const absl::Time start = absl::Now();
   const absl::Duration timeout =
-      absl::Milliseconds(absl::GetFlag(FLAGS_slot_migration_connection_timeout_ms));
+      absl::Milliseconds(absl::GetFlag(FLAGS_migration_finalization_timeout_ms));
 
   while (true) {
     const absl::Time now = absl::Now();
@@ -209,7 +209,7 @@ void IncomingSlotMigration::Stop() {
   // we need to Join the migration process to prevent data corruption
   const absl::Time start = absl::Now();
   const absl::Duration timeout =
-      absl::Milliseconds(absl::GetFlag(FLAGS_slot_migration_connection_timeout_ms));
+      absl::Milliseconds(absl::GetFlag(FLAGS_migration_finalization_timeout_ms));
 
   while (true) {
     const absl::Time now = absl::Now();

--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -20,7 +20,10 @@
 #include "server/server_family.h"
 #include "util/fibers/synchronization.h"
 
-ABSL_FLAG(int, slot_migration_connection_timeout_ms, 5000, "Timeout for network operations");
+ABSL_FLAG(int, slot_migration_connection_timeout_ms, 2000,
+          "Connection creating timeout for migration operations");
+ABSL_FLAG(int, migration_finalization_timeout_ms, 30000,
+          "Timeout for migration finalization operation");
 
 using namespace std;
 using namespace facade;
@@ -333,7 +336,7 @@ bool OutgoingMigration::FinalizeMigration(long attempt) {
 
   const absl::Time start = absl::Now();
   const absl::Duration timeout =
-      absl::Milliseconds(absl::GetFlag(FLAGS_slot_migration_connection_timeout_ms));
+      absl::Milliseconds(absl::GetFlag(FLAGS_migration_finalization_timeout_ms));
   while (true) {
     const absl::Time now = absl::Now();
     const absl::Duration passed = now - start;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -813,6 +813,7 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
 
   config_registry.RegisterMutable("replica_partial_sync");
   config_registry.RegisterMutable("replication_timeout");
+  config_registry.RegisterMutable("migration_finalization_timeout_ms");
   config_registry.RegisterMutable("table_growth_margin");
   config_registry.RegisterMutable("tcp_keepalive");
   config_registry.RegisterMutable("managed_service_info");


### PR DESCRIPTION
fixes: #4299

we decided to distinguish connection and finalization timeouts and introduced the new flag