### PR TITLE
fix(search_family): Fix FT.AGGREGATE output

### DIFF
--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -998,16 +998,20 @@ void SearchFamily::FtAggregate(CmdArgList args, const CommandContext& cmd_cntx) 
   rb->StartArray(result_size + 1);
   rb->SendLong(result_size);
 
-  const size_t field_count = agg_results.fields_to_print.size();
   for (const auto& value : agg_results.values) {
-    rb->StartArray(field_count * 2);
+    size_t fields_count = 0;
     for (const auto& field : agg_results.fields_to_print) {
-      rb->SendBulkString(field);
+      if (value.find(field) != value.end()) {
+        fields_count++;
+      }
+    }
 
-      if (auto it = value.find(field); it != value.end()) {
+    rb->StartArray(fields_count * 2);
+    for (const auto& field : agg_results.fields_to_print) {
+      auto it = value.find(field);
+      if (it != value.end()) {
+        rb->SendBulkString(field);
         std::visit(sortable_value_sender, it->second);
-      } else {
-        rb->SendNull();
       }
     }
   }

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -1635,26 +1635,37 @@ TEST_F(SearchFamilyTest, AggregateResultFields) {
   Run({"JSON.SET", "j2", ".", R"({"a":"4","b":"5","c":"6"})"});
   Run({"JSON.SET", "j3", ".", R"({"a":"7","b":"8","c":"9"})"});
 
-  auto resp = Run({"FT.CREATE", "index", "ON", "JSON", "SCHEMA", "$.a", "AS", "a", "TEXT",
-                   "SORTABLE", "$.b", "AS", "b", "TEXT", "$.c", "AS", "c", "TEXT"});
+  auto resp = Run({"FT.CREATE", "i1", "ON", "JSON", "SCHEMA", "$.a", "AS", "a", "TEXT", "SORTABLE",
+                   "$.b", "AS", "b", "TEXT", "$.c", "AS", "c", "TEXT"});
   EXPECT_EQ(resp, "OK");
 
-  resp = Run({"FT.AGGREGATE", "index", "*"});
+  resp = Run({"FT.AGGREGATE", "i1", "*"});
   EXPECT_THAT(resp, IsUnordArrayWithSize(IsMap(), IsMap(), IsMap()));
 
-  resp = Run({"FT.AGGREGATE", "index", "*", "SORTBY", "1", "a"});
+  resp = Run({"FT.AGGREGATE", "i1", "*", "SORTBY", "1", "a"});
   EXPECT_THAT(resp, IsUnordArrayWithSize(IsMap("a", "1"), IsMap("a", "4"), IsMap("a", "7")));
 
-  resp = Run({"FT.AGGREGATE", "index", "*", "LOAD", "1", "@b", "SORTBY", "1", "a"});
+  resp = Run({"FT.AGGREGATE", "i1", "*", "LOAD", "1", "@b", "SORTBY", "1", "a"});
   EXPECT_THAT(resp,
               IsUnordArrayWithSize(IsMap("b", "\"2\"", "a", "1"), IsMap("b", "\"5\"", "a", "4"),
                                    IsMap("b", "\"8\"", "a", "7")));
 
-  resp = Run({"FT.AGGREGATE", "index", "*", "SORTBY", "1", "a", "GROUPBY", "2", "@b", "@a",
-              "REDUCE", "COUNT", "0", "AS", "count"});
+  resp = Run({"FT.AGGREGATE", "i1", "*", "SORTBY", "1", "a", "GROUPBY", "2", "@b", "@a", "REDUCE",
+              "COUNT", "0", "AS", "count"});
   EXPECT_THAT(resp, IsUnordArrayWithSize(IsMap("b", "\"8\"", "a", "7", "count", "1"),
                                          IsMap("b", "\"2\"", "a", "1", "count", "1"),
                                          IsMap("b", "\"5\"", "a", "4", "count", "1")));
+
+  Run({"JSON.SET", "j4", ".", R"({"id":1, "number":4})"});
+  Run({"JSON.SET", "j5", ".", R"({"id":2})"});
+
+  resp = Run({"FT.CREATE", "i2", "ON", "JSON", "SCHEMA", "$.id", "AS", "id", "NUMERIC", "$.number",
+              "AS", "number", "NUMERIC"});
+  EXPECT_EQ(resp, "OK");
+
+  resp = Run({"FT.AGGREGATE", "i2", "*", "LOAD", "2", "@id", "@number"});
+  EXPECT_THAT(resp, IsUnordArrayWithSize(IsMap("id", "1", "number", "4"), IsMap("id", "2"), IsMap(),
+                                         IsMap(), IsMap()));
 }
 
 }  // namespace dfly


### PR DESCRIPTION
Fixes FT.AGGREGATE output for fields that are not present in the document