### PR TITLE
fix: Remove hardcoded `@assert_eventually` 100 times retry

### DIFF
--- a/tests/dragonfly/utility.py
+++ b/tests/dragonfly/utility.py
@@ -706,7 +706,7 @@ async def is_saving(c_client: aioredis.Redis):
 
 def assert_eventually(wrapped=None, *, times=100):
     if wrapped is None:
-        return functools.partial(assert_eventually, times=100)
+        return functools.partial(assert_eventually, times=times)
 
     @wrapt.decorator
     async def wrapper(wrapped, instance, args, kwargs):


### PR DESCRIPTION
This was a subtle and minor bug. Nice catch Borys!

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->