### PR TITLE
fix: potential OOM when first request sent in small bits

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -928,7 +928,7 @@ io::Result<bool> Connection::CheckForHttpProto() {
       return MatchHttp11Line(ib);
     }
     last_len = io_buf_.InputLen();
-    UpdateIoBufCapacity(io_buf_, stats_, [&]() { io_buf_.EnsureCapacity(io_buf_.Capacity()); });
+    UpdateIoBufCapacity(io_buf_, stats_, [&]() { io_buf_.EnsureCapacity(128); });
   } while (last_len < 1024);
 
   return false;
@@ -959,10 +959,7 @@ void Connection::ConnectionFlow() {
 
   // Main loop.
   if (parse_status != ERROR && !ec) {
-    if (io_buf_.AppendLen() < 64) {
-      UpdateIoBufCapacity(io_buf_, stats_,
-                          [&]() { io_buf_.EnsureCapacity(io_buf_.Capacity() * 2); });
-    }
+    UpdateIoBufCapacity(io_buf_, stats_, [&]() { io_buf_.EnsureCapacity(64); });
     auto res = IoLoop();
 
     if (holds_alternative<error_code>(res)) {

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -606,6 +606,14 @@ async def test_subscribe_in_pipeline(async_client: aioredis.Redis):
     assert res == ["one", ["subscribe", "ch1", 1], "two", ["subscribe", "ch2", 2], "three"]
 
 
+async def test_match_http(df_server: DflyInstance):
+    client = df_server.client()
+    reader, writer = await asyncio.open_connection("localhost", df_server.port)
+    for i in range(2000):
+        writer.write(f"foo bar ".encode())
+        await writer.drain()
+
+
 """
 This test makes sure that Dragonfly can receive blocks of pipelined commands even
 while a script is still executing. This is a dangerous scenario because both the dispatch fiber


### PR DESCRIPTION
Before: if socket data arrived in small bits, then CheckForHttpProto would grow io_buf_ capacity exponentially with each iteration. For example, test_match_http test easily causes OOM.

This PR ensures that there is always a buffer available - but it grows linearly with the input size. Currently, the total input in CheckForHttpProto is limited to 1024.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->