### PR TITLE
chore: add ability to track connections stuck at send

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -638,6 +638,15 @@ optional<ReplicaOfArgs> ReplicaOfArgs::FromCmdArgs(CmdArgList args, SinkReplyBui
   return replicaof_args;
 }
 
+uint64_t GetDelayMs(uint64_t ts) {
+  uint64_t now_ns = fb2::ProactorBase::GetMonotonicTimeNs();
+  uint64_t delay_ns = 0;
+  if (ts < now_ns - 1000000) {  // handle states where ts is larger than now
+    delay_ns = (now_ns - ts) / 1000000;
+  }
+  return delay_ns;
+}
+
 }  // namespace
 
 void SlowLogGet(dfly::CmdArgList args, std::string_view sub_cmd, util::ProactorPool* pp,
@@ -1294,6 +1303,10 @@ void PrintPrometheusMetrics(uint64_t uptime, const Metrics& m, DflyCmd* dfly_cmd
                             MetricType::GAUGE, &resp->body());
   AppendMetricWithoutLabels("pipeline_queue_length", "", conn_stats.dispatch_queue_entries,
                             MetricType::GAUGE, &resp->body());
+  AppendMetricWithoutLabels("send_delay_seconds", "",
+                            double(GetDelayMs(m.oldest_pending_send_ts)) / 1000.0,
+                            MetricType::GAUGE, &resp->body());
+
   AppendMetricWithoutLabels("pipeline_throttle_total", "", conn_stats.pipeline_throttle_count,
                             MetricType::COUNTER, &resp->body());
   AppendMetricWithoutLabels("pipeline_cmd_cache_bytes", "", conn_stats.pipeline_cmd_cache_bytes,
@@ -2145,6 +2158,13 @@ Metrics ServerFamily::GetMetrics(Namespace* ns) const {
       result.connections_lib_name_ver_map[k] += v;
     }
 
+    auto& send_list = facade::SinkReplyBuilder::pending_list;
+    if (!send_list.empty()) {
+      auto& oldest_member = send_list.front();
+      if (oldest_member.timestamp_ns < result.oldest_pending_send_ts) {
+        result.oldest_pending_send_ts = oldest_member.timestamp_ns;
+      }
+    }
     service_.mutable_registry()->MergeCallStats(index, cmd_stat_cb);
   };  // cb
 
@@ -2253,6 +2273,8 @@ void ServerFamily::Info(CmdArgList args, const CommandContext& cmd_cntx) {
     append("client_read_buffer_bytes", m.facade_stats.conn_stats.read_buf_capacity);
     append("blocked_clients", m.facade_stats.conn_stats.num_blocked_clients);
     append("pipeline_queue_length", m.facade_stats.conn_stats.dispatch_queue_entries);
+
+    append("send_delay_ms", GetDelayMs(m.oldest_pending_send_ts));
   }
 
   if (should_enter("MEMORY")) {

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -641,7 +641,7 @@ optional<ReplicaOfArgs> ReplicaOfArgs::FromCmdArgs(CmdArgList args, SinkReplyBui
 uint64_t GetDelayMs(uint64_t ts) {
   uint64_t now_ns = fb2::ProactorBase::GetMonotonicTimeNs();
   uint64_t delay_ns = 0;
-  if (ts < now_ns - 1000000) {  // handle states where ts is larger than now
+  if (ts < now_ns - 1000000) {  // if more than 1ms has passed between ts and now_ns
     delay_ns = (now_ns - ts) / 1000000;
   }
   return delay_ns;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2160,10 +2160,14 @@ Metrics ServerFamily::GetMetrics(Namespace* ns) const {
 
     auto& send_list = facade::SinkReplyBuilder::pending_list;
     if (!send_list.empty()) {
+      DCHECK(std::is_sorted(send_list.begin(), send_list.end(),
+                            [](const auto& left, const auto& right) {
+                              return left.timestamp_ns < right.timestamp_ns;
+                            }));
+
       auto& oldest_member = send_list.front();
-      if (oldest_member.timestamp_ns < result.oldest_pending_send_ts) {
-        result.oldest_pending_send_ts = oldest_member.timestamp_ns;
-      }
+      result.oldest_pending_send_ts =
+          min<uint64_t>(result.oldest_pending_send_ts, oldest_member.timestamp_ns);
     }
     service_.mutable_registry()->MergeCallStats(index, cmd_stat_cb);
   };  // cb

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -107,6 +107,10 @@ struct Metrics {
   uint32_t blocked_tasks = 0;
   size_t worker_fiber_stack_size = 0;
 
+  // monotonic timestamp (ProactorBase::GetMonotonicTimeNs) of the connection stuck on send
+  // for longest time.
+  uint64_t oldest_pending_send_ts = uint64_t(-1);
+
   InterpreterManager::Stats lua_stats;
 
   // command call frequencies (count, aggregated latency in usec).

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -606,7 +606,6 @@ async def test_subscribe_in_pipeline(async_client: aioredis.Redis):
     assert res == ["one", ["subscribe", "ch1", 1], "two", ["subscribe", "ch2", 2], "three"]
 
 
-@dfly_args({"proactor_threads": "2"})
 async def test_send_delay_metric(df_server: DflyInstance):
     client = df_server.client()
     await client.client_setname("client1")

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -606,6 +606,27 @@ async def test_subscribe_in_pipeline(async_client: aioredis.Redis):
     assert res == ["one", ["subscribe", "ch1", 1], "two", ["subscribe", "ch2", 2], "three"]
 
 
+@dfly_args({"proactor_threads": "2"})
+async def test_send_delay_metric(df_server: DflyInstance):
+    client = df_server.client()
+    await client.client_setname("client1")
+    blob = "A" * 1000
+    for j in range(10):
+        await client.set(f"key-{j}", blob)
+
+    await client.config_set("pipeline_queue_limit", 100)
+    reader, writer = await asyncio.open_connection("localhost", df_server.port)
+    for j in range(1000000):
+        writer.write(f"GET key-{j % 10}\n".encode())
+
+    @assert_eventually
+    async def wait_for_large_delay():
+        info = await client.info("clients")
+        assert int(info["send_delay_ms"]) > 100
+
+    await wait_for_large_delay()
+
+
 async def test_match_http(df_server: DflyInstance):
     client = df_server.client()
     reader, writer = await asyncio.open_connection("localhost", df_server.port)


### PR DESCRIPTION
Add send_delay_seconds/send_delay_ms metrics.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->