### PR TITLE
fix(server): use compression for non big values

### DIFF
--- a/src/core/interpreter.cc
+++ b/src/core/interpreter.cc
@@ -386,13 +386,26 @@ int DragonflyRandstrCommand(lua_State* state) {
   lua_remove(state, 1);
 
   std::string buf(dsize, ' ');
+
   auto push_str = [dsize, state, &buf]() {
     static const char alphanum[] =
         "0123456789"
         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         "abcdefghijklmnopqrstuvwxyz";
-    for (int i = 0; i < dsize; ++i)
-      buf[i] = alphanum[rand() % (sizeof(alphanum) - 1)];
+
+    static const char pattern[] = "DRAGONFLY";
+    constexpr int pattern_len = sizeof(pattern) - 1;
+    constexpr int pattern_interval = 53;
+    for (int i = 0; i < dsize; ++i) {
+      if (i % pattern_interval == 0 && i + pattern_len <= dsize) {
+        // Insert the repeating pattern for better compression of random string.
+        buf.replace(i, pattern_len, pattern, pattern_len);
+        i += pattern_len - 1;  // Adjust index to skip the pattern
+      } else {
+        // Fill the rest with semi-random characters for variation
+        buf[i] = alphanum[rand() % (sizeof(alphanum) - 1)];
+      }
+    }
     lua_pushlstring(state, buf.c_str(), buf.length());
   };
 

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -162,16 +162,7 @@ std::string AbslUnparseFlag(dfly::CompressionMode flag) {
 }
 
 dfly::CompressionMode GetDefaultCompressionMode() {
-  const auto flag = absl::GetFlag(FLAGS_compression_mode);
-  return flag;
-  if (ServerState::tlocal()->serialization_max_chunk_size == 0) {
-    return flag;
-  }
-
-  static bool once = flag != dfly::CompressionMode::NONE;
-  LOG_IF(WARNING, once) << "Setting CompressionMode to NONE because big value serialization is on";
-  once = false;
-  return dfly::CompressionMode::NONE;
+  return absl::GetFlag(FLAGS_compression_mode);
 }
 
 uint8_t RdbObjectType(const PrimeValue& pv) {

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -163,6 +163,7 @@ std::string AbslUnparseFlag(dfly::CompressionMode flag) {
 
 dfly::CompressionMode GetDefaultCompressionMode() {
   const auto flag = absl::GetFlag(FLAGS_compression_mode);
+  return flag;
   if (ServerState::tlocal()->serialization_max_chunk_size == 0) {
     return flag;
   }
@@ -944,6 +945,7 @@ io::Bytes SerializerBase::PrepareFlush(SerializerBase::FlushState flush_state) {
     return mem_buf_.InputBuffer();
 
   bool is_last_chunk = flush_state == FlushState::kFlushEndEntry;
+  VLOG(2) << "PrepareFlush:" << is_last_chunk << " " << number_of_chunks_;
   if (is_last_chunk && number_of_chunks_ == 0) {
     if (compression_mode_ == CompressionMode::MULTI_ENTRY_ZSTD ||
         compression_mode_ == CompressionMode::MULTI_ENTRY_LZ4) {
@@ -1603,6 +1605,7 @@ void SerializerBase::CompressBlob() {
     compression_stats_.emplace(CompressionStats{});
   }
   Bytes blob_to_compress = mem_buf_.InputBuffer();
+  VLOG(2) << "CompressBlob size " << blob_to_compress.size();
   size_t blob_size = blob_to_compress.size();
   if (blob_size < kMinStrSizeToCompress) {
     ++compression_stats_->small_str_count;
@@ -1644,6 +1647,8 @@ void SerializerBase::CompressBlob() {
   memcpy(dest.data(), compressed_blob.data(), compressed_blob.length());
   mem_buf_.CommitWrite(compressed_blob.length());
   ++compression_stats_->compressed_blobs;
+  auto& stats = ServerState::tlocal()->stats;
+  ++stats.compressed_blobs;
 }
 
 size_t RdbSerializer::GetTempBufferSize() const {

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -172,6 +172,10 @@ TEST_F(RdbTest, ComressionModeSaveDragonflyAndReload) {
     RespExpr resp = Run({"save", "df"});
     ASSERT_EQ(resp, "OK");
 
+    if (mode == CompressionMode::MULTI_ENTRY_ZSTD || mode == CompressionMode::MULTI_ENTRY_LZ4) {
+      EXPECT_GE(GetMetrics().coordinator_stats.compressed_blobs, 1);
+    }
+
     auto save_info = service_->server_family().GetLastSaveInfo();
     resp = Run({"dfly", "load", save_info.file_name});
     ASSERT_EQ(resp, "OK");

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2373,6 +2373,7 @@ void ServerFamily::Info(CmdArgList args, const CommandContext& cmd_cntx) {
     append("rdb_save_usec", m.coordinator_stats.rdb_save_usec);
     append("rdb_save_count", m.coordinator_stats.rdb_save_count);
     append("big_value_preemptions", m.coordinator_stats.big_value_preemptions);
+    append("compressed_blobs", m.coordinator_stats.compressed_blobs);
     append("instantaneous_input_kbps", -1);
     append("instantaneous_output_kbps", -1);
     append("rejected_connections", -1);

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -27,7 +27,7 @@ ServerState::Stats::Stats(unsigned num_shards) : tx_width_freq_arr(num_shards) {
 }
 
 ServerState::Stats& ServerState::Stats::Add(const ServerState::Stats& other) {
-  static_assert(sizeof(Stats) == 18 * 8, "Stats size mismatch");
+  static_assert(sizeof(Stats) == 19 * 8, "Stats size mismatch");
 
 #define ADD(x) this->x += (other.x)
 
@@ -51,6 +51,7 @@ ServerState::Stats& ServerState::Stats::Add(const ServerState::Stats& other) {
   ADD(rdb_save_count);
 
   ADD(big_value_preemptions);
+  ADD(compressed_blobs);
 
   ADD(oom_error_cmd_cnt);
 

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -123,6 +123,7 @@ class ServerState {  // public struct - to allow initialization.
     uint64_t rdb_save_count = 0;
 
     uint64_t big_value_preemptions = 0;
+    uint64_t compressed_blobs = 0;
 
     // Number of times we rejected command dispatch due to OOM condition.
     uint64_t oom_error_cmd_cnt = 0;

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -364,7 +364,7 @@ bool SliceSnapshot::PushSerialized(bool force) {
     return false;
 
   // Flush any of the leftovers to avoid interleavings
-  size_t serialized = FlushSerialized(FlushState::kFlushMidEntry);
+  size_t serialized = FlushSerialized(FlushState::kFlushEndEntry);
 
   if (!delayed_entries_.empty()) {
     // Async bucket serialization might have accumulated some delayed values.
@@ -377,7 +377,7 @@ bool SliceSnapshot::PushSerialized(bool force) {
     } while (!delayed_entries_.empty());
 
     // blocking point.
-    serialized += FlushSerialized(FlushState::kFlushMidEntry);
+    serialized += FlushSerialized(FlushState::kFlushEndEntry);
   }
   return serialized > 0;
 }

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -416,7 +416,7 @@ class DflyInstanceFactory:
         args.setdefault("noversion_check", None)
         # MacOs does not set it automatically, so we need to set it manually
         args.setdefault("maxmemory", "8G")
-        vmod = "dragonfly_connection=1,accept_server=1,listener_interface=1,main_service=1,rdb_save=2,replica=1,cluster_family=1,proactor_pool=1,dflycmd=1,snapshot=2"
+        vmod = "dragonfly_connection=1,accept_server=1,listener_interface=1,main_service=1,rdb_save=1,replica=1,cluster_family=1,proactor_pool=1,dflycmd=1,snapshot=1"
         args.setdefault("vmodule", vmod)
         args.setdefault("jsonpathv2")
 

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -416,7 +416,7 @@ class DflyInstanceFactory:
         args.setdefault("noversion_check", None)
         # MacOs does not set it automatically, so we need to set it manually
         args.setdefault("maxmemory", "8G")
-        vmod = "dragonfly_connection=1,accept_server=1,listener_interface=1,main_service=1,rdb_save=1,replica=1,cluster_family=1,proactor_pool=1,dflycmd=1"
+        vmod = "dragonfly_connection=1,accept_server=1,listener_interface=1,main_service=1,rdb_save=2,replica=1,cluster_family=1,proactor_pool=1,dflycmd=1,snapshot=2"
         args.setdefault("vmodule", vmod)
         args.setdefault("jsonpathv2")
 
@@ -426,7 +426,7 @@ class DflyInstanceFactory:
         args.setdefault("log_dir", self.params.log_dir)
 
         if version >= 1.21 and "serialization_max_chunk_size" not in args:
-            args.setdefault("serialization_max_chunk_size", 16384)
+            args.setdefault("serialization_max_chunk_size", 300000)
 
         for k, v in args.items():
             args[k] = v.format(**self.params.env) if isinstance(v, str) else v

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2313,6 +2313,7 @@ async def test_replication_timeout_on_full_sync(df_factory: DflyInstanceFactory,
     await assert_replica_reconnections(replica, 0)
 
 
+@dfly_args({"proactor_threads": 1})
 async def test_master_stalled_disconnect(df_factory: DflyInstanceFactory):
     # disconnect after 1 second of being blocked
     master = df_factory.create(replication_timeout=1000)
@@ -2323,7 +2324,7 @@ async def test_master_stalled_disconnect(df_factory: DflyInstanceFactory):
     c_master = master.client()
     c_replica = replica.client()
 
-    await c_master.execute_command("debug", "populate", "200000", "foo", "500")
+    await c_master.execute_command("debug", "populate", "200000", "foo", "500", "RAND")
     await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
 
     @assert_eventually

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -130,13 +130,13 @@ async def test_replication_all(
 
     info = await c_master.info()
     preemptions = info["big_value_preemptions"]
-    # assert preemptions >= seeder.huge_value_target * 0.5
-
+    total_buckets = info["num_buckets"]
     compressed_blobs = info["compressed_blobs"]
-    # TODO(adi): why some runs has compression is no affective
-    # assert compressed_blobs > 1
-    logging.debug(f"Compressed blobs {compressed_blobs}")
+    logging.debug(
+        f"Compressed blobs {compressed_blobs} .Buckets {total_buckets}. Preemptions {preemptions}"
+    )
 
+    assert preemptions >= seeder.huge_value_target * 0.5
     # Because data size could be 10k and for that case there will be almost a preemption
     # per bucket.
     if seeder.data_size < 1000:
@@ -145,8 +145,6 @@ async def test_replication_all(
         # of buckets seems like a big number but that depends on a few parameters like
         # the size of the hug value and the serialization max chunk size. For the test cases here,
         # it's usually close to 10% but there are some that are close to 30.
-        total_buckets = info["num_buckets"]
-        logging.debug(f"Buckets {total_buckets}. Preemptions {preemptions}")
         assert preemptions <= (total_buckets * 0.3)
 
 

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -137,6 +137,7 @@ async def test_replication_all(
     )
 
     assert preemptions >= seeder.huge_value_target * 0.5
+    assert compressed_blobs > 0
     # Because data size could be 10k and for that case there will be almost a preemption
     # per bucket.
     if seeder.data_size < 1000:
@@ -2626,7 +2627,7 @@ async def test_replication_timeout_on_full_sync_heartbeat_expiry(
     c_master = master.client()
     c_replica = replica.client()
 
-    await c_master.execute_command("debug", "populate", "100000", "foo", "5000")
+    await c_master.execute_command("debug", "populate", "100000", "foo", "5000", "RAND")
 
     c_master = master.client()
     c_replica = replica.client()

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2283,7 +2283,7 @@ async def test_replication_timeout_on_full_sync(df_factory: DflyInstanceFactory,
     c_master = master.client()
     c_replica = replica.client()
 
-    await c_master.execute_command("debug", "populate", "200000", "foo", "5000")
+    await c_master.execute_command("debug", "populate", "200000", "foo", "5000", "RAND")
     seeder = df_seeder_factory.create(port=master.port)
     seeder_task = asyncio.create_task(seeder.run())
 

--- a/tests/dragonfly/seeder/script-generate.lua
+++ b/tests/dragonfly/seeder/script-generate.lua
@@ -19,46 +19,24 @@ local min_dev = tonumber(ARGV[7])
 local data_size = tonumber(ARGV[8])
 local collection_size = tonumber(ARGV[9])
 -- Probability of each key in key_target to be a big value
-local huge_value_percentage = tonumber(ARGV[10])
+local huge_value_target = tonumber(ARGV[10])
 local huge_value_size = tonumber(ARGV[11])
-local huge_value_csize = tonumber(ARGV[12])
 
 -- collect all keys belonging to this script
 -- assumes exclusive ownership
 local keys = LU_collect_keys(prefix, type)
 
-LG_funcs.init(data_size, collection_size, huge_value_percentage, huge_value_size, huge_value_csize)
+LG_funcs.init(data_size, collection_size, huge_value_target, huge_value_size)
 local addfunc = LG_funcs['add_' .. string.lower(type)]
 local modfunc = LG_funcs['mod_' .. string.lower(type)]
 local huge_entries = LG_funcs["get_huge_entries"]
 
-local huge_keys = 0
-
-local function huge_entry()
-    local ratio = LG_funcs.huge_value_percentage / 100
-    -- [0, 1]
-    local rand = math.random()
-    local huge_entry = (ratio > rand)
-    return huge_entry
-end
-
 local function action_add()
     local key = prefix .. tostring(key_counter)
     local op_type = string.lower(type)
-    local is_huge = false
-    -- `string` and `json` huge entries are not supported so
-    -- we don't roll a dice to decide if they are huge or not
-    if op_type ~= "string" and op_type ~= "json" then
-      is_huge = huge_entry()
-    end
-
     key_counter = key_counter + 1
-    if is_huge then
-      huge_keys = huge_keys + 1
-    end
 
     table.insert(keys, key)
-    keys[key] = is_huge
     addfunc(key, keys)
 end
 
@@ -149,4 +127,4 @@ if stop_key ~= '' then
     redis.call('DEL', stop_key)
 end
 
-return tostring(key_counter) .. " " .. tostring(huge_keys) .. " " .. tostring(huge_entries())
+return tostring(key_counter) .. " " .. tostring(huge_entries())

--- a/tests/dragonfly/seeder_test.py
+++ b/tests/dragonfly/seeder_test.py
@@ -36,7 +36,7 @@ async def test_static_collection_size(async_client: aioredis.Redis):
         data_size=10_000,
         collection_size=1,
         types=["LIST"],
-        huge_value_percentage=0,
+        huge_value_target=0,
         huge_value_size=0,
     )
     await s.run(async_client)


### PR DESCRIPTION
Changes in this PR:
1. Fix bug in snapshot serialization that caused us not to do compression at all
2. Enable compression if big value serialization is enabled (flag max_serialization_chunk_size !=0)
3. Change dragonfly rand string lua call to generate more compressible string.
4. Add statistics to compression and check stats in tests
5. Simplify the seeder for generating big values. Instead of defining keys as keys of big value, define the total number of entries of big values when running seeder. 
