### PR TITLE
fix: do not check-fail in OpRestore

### DIFF
--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -281,6 +281,10 @@ class DbSlice {
     Iterator it;
     ExpIterator exp_it;
     AutoUpdater post_updater;
+
+    bool IsValid() const {
+      return !it.is_done();
+    }
   };
 
   ItAndUpdater FindMutable(const Context& cntx, std::string_view key);


### PR DESCRIPTION
In some rare cases we reach inconsistent state inside OpRestore where a key already exists, though it should not. In that case log the error instead of crashing the server. In addition, we update the existing entry to the latest restored value.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->