### PR TITLE
fix(pytest): call stop for all instances even if stop raise exception

### DIFF
--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -461,8 +461,11 @@ class DflyInstanceFactory:
             except Exception as e:
                 exceptions.append(e)  # Collect the exception
         if exceptions:
-            # Raise the first exception while preserving the others as context
-            raise Exception("One or more errors occurred while stopping instances")
+            first_exception = exceptions[0]
+            raise Exception(
+                f"One or more errors occurred while stopping instances. "
+                f"First exception: {first_exception}"
+            ) from first_exception
 
     def __repr__(self) -> str:
         return f"Factory({self.args})"

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -453,9 +453,16 @@ class DflyInstanceFactory:
 
     async def stop_all(self):
         """Stop all launched instances."""
+        exceptions = []  # To collect exceptions
         for instance in self.instances:
             await instance.close_clients()
-            instance.stop()
+            try:
+                instance.stop()
+            except Exception as e:
+                exceptions.append(e)  # Collect the exception
+        if exceptions:
+            # Raise the first exception while preserving the others as context
+            raise Exception("One or more errors occurred while stopping instances")
 
     def __repr__(self) -> str:
         return f"Factory({self.args})"


### PR DESCRIPTION
The problem:
if calling stop for one of the instances raise and exception we did not call stop for the rest
