### PR TITLE
fix: add content-type for metrics response

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -715,7 +715,7 @@ string FailedCommandToString(std::string_view command, facade::CmdArgList args,
   absl::StrAppend(&result, " ", command);
 
   for (auto arg : args) {
-    absl::StrAppend(&result, " ", facade::ToSV(arg));
+    absl::StrAppend(&result, " ", absl::CHexEscape(arg));
   }
 
   absl::StrAppend(&result, " failed with reason: ", reason);

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1541,6 +1541,7 @@ void ServerFamily::ConfigureMetrics(util::HttpListenerBase* http_base) {
 
   auto cb = [this](const util::http::QueryArgs& args, util::HttpContext* send) {
     StringResponse resp = util::http::MakeStringResponse(boost::beast::http::status::ok);
+    util::http::SetMime(util::http::kTextMime, &resp);
     uint64_t uptime = time(NULL) - start_time_;
     PrintPrometheusMetrics(uptime, this->GetMetrics(&namespaces->GetDefaultNamespace()),
                            this->dfly_cmd_.get(), &resp);

--- a/tools/local/monitoring/docker-compose.yml
+++ b/tools/local/monitoring/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     command: chown -R 11211:11211 /memcached
 
   prometheus:
-    image: prom/prometheus:v2.45.5
+    image: prom/prometheus:v3.0.0
     restart: always
     volumes:
       - ./prometheus:/etc/prometheus/


### PR DESCRIPTION
Also, update the local stack to use prometheus 3.0
Finally, hex-escape arguments when logging an error for a command.
    
Fixes #4277

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->