### PR TITLE
fix: Stack overflow in `DFLYCLUSTER CONFIG`

### DIFF
--- a/src/server/cluster/cluster_config.cc
+++ b/src/server/cluster/cluster_config.cc
@@ -40,7 +40,7 @@ bool HasValidNodeIds(const ClusterShardInfos& new_config) {
 
 bool IsConfigValid(const ClusterShardInfos& new_config) {
   // Make sure that all slots are set exactly once.
-  array<bool, cluster::kMaxSlotNum + 1> slots_found = {};
+  vector<bool> slots_found(cluster::kMaxSlotNum + 1);
 
   if (!HasValidNodeIds(new_config)) {
     return false;


### PR DESCRIPTION
It's fine to use the heap in such cases, latency doesn't matter.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->