### PR TITLE
fix: ExternalAllocator::Free with large sizes

### DIFF
--- a/src/core/extent_tree_test.cc
+++ b/src/core/extent_tree_test.cc
@@ -28,28 +28,28 @@ TEST_F(ExtentTreeTest, Basic) {
   tree_.Add(0, 256);
   auto op = tree_.GetRange(64, 16);
   EXPECT_TRUE(op);
-  EXPECT_THAT(*op, testing::Pair(0, 64));
+  EXPECT_THAT(*op, testing::Pair(0, 64));  // [64, 256)
 
   tree_.Add(56, 8);
   op = tree_.GetRange(64, 16);
   EXPECT_TRUE(op);
-  EXPECT_THAT(*op, testing::Pair(64, 128));
+  EXPECT_THAT(*op, testing::Pair(64, 128));  // {[56, 64), [128, 256)}
 
   op = tree_.GetRange(18, 2);
   EXPECT_TRUE(op);
-  EXPECT_THAT(*op, testing::Pair(128, 146));
+  EXPECT_THAT(*op, testing::Pair(128, 146));  // {[56, 64), [146, 256)}
 
   op = tree_.GetRange(80, 16);
   EXPECT_TRUE(op);
-  EXPECT_THAT(*op, testing::Pair(160, 240));
+  EXPECT_THAT(*op, testing::Pair(160, 240));  // {[56, 64), [146, 160), [240, 256)}
 
   op = tree_.GetRange(4, 1);
   EXPECT_TRUE(op);
-  EXPECT_THAT(*op, testing::Pair(56, 60));
+  EXPECT_THAT(*op, testing::Pair(56, 60));  // {[60, 64), [146, 160), [240, 256)}
 
   op = tree_.GetRange(32, 1);
   EXPECT_FALSE(op);
-  tree_.Add(64, 240 - 64);
+  tree_.Add(64, 146 - 64);
   op = tree_.GetRange(32, 4);
   EXPECT_TRUE(op);
   EXPECT_THAT(*op, testing::Pair(60, 92));

--- a/src/server/tiering/external_alloc.cc
+++ b/src/server/tiering/external_alloc.cc
@@ -367,6 +367,12 @@ int64_t ExternalAllocator::Malloc(size_t sz) {
 }
 
 void ExternalAllocator::Free(size_t offset, size_t sz) {
+  if (sz > kMediumObjMaxSize) {
+    size_t align_sz = alignup(sz, 4_KB);
+    extent_tree_.Add(offset, align_sz);
+    return;
+  }
+
   size_t idx = offset / 256_MB;
   size_t delta = offset % 256_MB;
   CHECK_LT(idx, segments_.size());

--- a/src/server/tiering/external_alloc_test.cc
+++ b/src/server/tiering/external_alloc_test.cc
@@ -146,4 +146,12 @@ TEST_F(ExternalAllocatorTest, EmptyFull) {
     EXPECT_GT(ext_alloc_.Malloc(kAllocSize), 0u);
 }
 
+TEST_F(ExternalAllocatorTest, AllocLarge) {
+  ext_alloc_.AddStorage(0, kSegSize);
+
+  off_t offs = ext_alloc_.Malloc(2_MB - 1);
+  EXPECT_EQ(offs, 0);
+  ext_alloc_.Free(offs, 2_MB - 1);
+}
+
 }  // namespace dfly::tiering


### PR DESCRIPTION
ExternalAllocator allocates large sizes directly from the extent tree bypassing segment data structure. Unfortunately, we forgot to align Free() the same way. This PR:

1. Make sure that we add back the allocated range to the extent tree in Free.
2. Rewrite and simplify ExtentTree::Add implementation.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->