### PR TITLE
chore: minor refactorings around dense_set deletions

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -791,8 +791,8 @@ uint64_t CompactObj::HashCode() const {
   }
 
   if (encoded) {
-    GetString(&tl.tmp_str);
-    return XXH3_64bits_withSeed(tl.tmp_str.data(), tl.tmp_str.size(), kHashSeed);
+    string_view sv = GetSlice(&tl.tmp_str);
+    return XXH3_64bits_withSeed(sv.data(), sv.size(), kHashSeed);
   }
 
   switch (taglen_) {

--- a/src/core/dense_set.cc
+++ b/src/core/dense_set.cc
@@ -168,14 +168,14 @@ auto DenseSet::PopPtrFront(DenseSet::ChainVectorIterator it) -> DensePtr {
   return front;
 }
 
-uint32_t DenseSet::ClearInternal(uint32_t start, uint32_t count) {
+uint32_t DenseSet::ClearStep(uint32_t start, uint32_t count) {
   constexpr unsigned kArrLen = 32;
   ClearItem arr[kArrLen];
   unsigned len = 0;
 
   size_t end = min<size_t>(entries_.size(), start + count);
   for (size_t i = start; i < end; ++i) {
-    DensePtr ptr = entries_[i];
+    DensePtr& ptr = entries_[i];
     if (ptr.IsEmpty())
       continue;
 
@@ -190,6 +190,7 @@ uint32_t DenseSet::ClearInternal(uint32_t start, uint32_t count) {
       dest.ptr = ptr;
       dest.obj = nullptr;
     }
+    ptr.Reset();
     if (len == kArrLen) {
       ClearBatch(kArrLen, arr);
       len = 0;

--- a/src/core/dense_set.h
+++ b/src/core/dense_set.h
@@ -215,8 +215,12 @@ class DenseSet {
   virtual ~DenseSet();
 
   void Clear() {
-    ClearInternal(0, entries_.size());
+    ClearStep(0, entries_.size());
   }
+
+  // Returns the next bucket index that should be cleared.
+  // Returns BucketCount when all objects are erased.
+  uint32_t ClearStep(uint32_t start, uint32_t count);
 
   // Returns the number of elements in the map. Note that it might be that some of these elements
   // have expired and can't be accessed.
@@ -302,11 +306,6 @@ class DenseSet {
   }
 
   void* PopInternal();
-
-  // Note this does not free any dynamic allocations done by derived classes, that a DensePtr
-  // in the set may point to. This function only frees the allocated DenseLinkKeys created by
-  // DenseSet. All data allocated by a derived class should be freed before calling this
-  uint32_t ClearInternal(uint32_t start, uint32_t count);
 
   void IncreaseMallocUsed(size_t delta) {
     obj_malloc_used_ += delta;

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -669,10 +669,8 @@ void DbSlice::ActivateDb(DbIndex db_ind) {
   CreateDb(db_ind);
 }
 
-bool DbSlice::Del(Context cntx, Iterator it) {
-  if (!IsValid(it)) {
-    return false;
-  }
+void DbSlice::Del(Context cntx, Iterator it) {
+  CHECK(IsValid(it));
 
   auto& db = db_arr_[cntx.db_index];
   auto obj_type = it->second.ObjType();
@@ -683,8 +681,6 @@ bool DbSlice::Del(Context cntx, Iterator it) {
     doc_del_cb_(key, cntx, it->second);
   }
   PerformDeletion(it, db.get());
-
-  return true;
 }
 
 void DbSlice::FlushSlotsFb(const cluster::SlotSet& slot_ids) {
@@ -917,7 +913,7 @@ OpResult<int64_t> DbSlice::UpdateExpire(const Context& cntx, Iterator prime_it,
   }
 
   if (rel_msec <= 0) {  // implicit - don't persist
-    CHECK(Del(cntx, prime_it));
+    Del(cntx, prime_it);
     return -1;
   } else if (IsValid(expire_it) && !params.persist) {
     auto current = ExpireTime(expire_it);

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -346,7 +346,8 @@ class DbSlice {
   // Delete a key referred by its iterator.
   void PerformDeletion(Iterator del_it, DbTable* table);
 
-  bool Del(Context cntx, Iterator it);
+  // Deletes the iterator. The iterator must be valid.
+  void Del(Context cntx, Iterator it);
 
   constexpr static DbIndex kDbAll = 0xFFFF;
 

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -426,11 +426,10 @@ bool EngineShard::DoDefrag() {
 //     priority.
 //     otherwise lower the task priority so that it would not use the CPU when not required
 uint32_t EngineShard::DefragTask() {
-  if (!namespaces) {
-    return util::ProactorBase::kOnIdleMaxLevel;
-  }
-
   constexpr uint32_t kRunAtLowPriority = 0u;
+  if (!namespaces) {
+    return kRunAtLowPriority;
+  }
 
   if (defrag_state_.CheckRequired()) {
     VLOG(2) << shard_id_ << ": need to run defrag memory cursor state: " << defrag_state_.cursor;

--- a/src/server/generic_family.h
+++ b/src/server/generic_family.h
@@ -35,6 +35,7 @@ class GenericFamily {
   using SinkReplyBuilder = facade::SinkReplyBuilder;
 
   static void Del(CmdArgList args, const CommandContext& cmd_cntx);
+  static void Unlink(CmdArgList args, const CommandContext& cmd_cntx);
   static void Ping(CmdArgList args, const CommandContext& cmd_cntx);
   static void Exists(CmdArgList args, const CommandContext& cmd_cntx);
   static void Expire(CmdArgList args, const CommandContext& cmd_cntx);

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -908,8 +908,13 @@ OpResult<long> OpDel(const OpArgs& op_args, string_view key, string_view path,
   if (json_path.RefersToRootElement()) {
     auto& db_slice = op_args.GetDbSlice();
     auto it = db_slice.FindMutable(op_args.db_cntx, key).it;  // post_updater will run immediately
-    return static_cast<long>(db_slice.Del(op_args.db_cntx, it));
+    if (IsValid(it)) {
+      db_slice.Del(op_args.db_cntx, it);
+      return 1;
+    }
+    return 0;
   }
+
   JsonMemTracker tracker;
   // FindMutable because we need to run the AutoUpdater at the end which will account
   // the deltas calculated from the MemoryTracker

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -180,7 +180,7 @@ std::string OpBPop(Transaction* t, EngineShard* shard, std::string_view key, Lis
   OpArgs op_args = t->GetOpArgs(shard);
   if (len == 0) {
     DVLOG(1) << "deleting key " << key << " " << t->DebugId();
-    CHECK(op_args.GetDbSlice().Del(op_args.db_cntx, it));
+    op_args.GetDbSlice().Del(op_args.db_cntx, it);
   }
 
   if (op_args.shard->journal()) {
@@ -276,7 +276,7 @@ OpResult<string> OpMoveSingleShard(const OpArgs& op_args, string_view src, strin
   dest_res.post_updater.Run();
 
   if (prev_len == 1) {
-    CHECK(db_slice.Del(op_args.db_cntx, src_it));
+    db_slice.Del(op_args.db_cntx, src_it);
   }
 
   return val;
@@ -452,7 +452,7 @@ OpResult<StringVec> OpPop(const OpArgs& op_args, string_view key, ListDir dir, u
   it_res->post_updater.Run();
 
   if (count == prev_len) {
-    CHECK(db_slice.Del(op_args.db_cntx, it));
+    db_slice.Del(op_args.db_cntx, it);
   }
 
   if (op_args.shard->journal() && journal_rewrite) {
@@ -765,7 +765,7 @@ OpResult<uint32_t> OpRem(const OpArgs& op_args, string_view key, string_view ele
   it_res->post_updater.Run();
 
   if (len == 0) {
-    CHECK(db_slice.Del(op_args.db_cntx, it));
+    db_slice.Del(op_args.db_cntx, it);
   }
 
   return removed;
@@ -840,7 +840,7 @@ OpStatus OpTrim(const OpArgs& op_args, string_view key, long start, long end) {
   it_res->post_updater.Run();
 
   if (it->second.Size() == 0) {
-    CHECK(db_slice.Del(op_args.db_cntx, it));
+    db_slice.Del(op_args.db_cntx, it);
   }
   return OpStatus::OK;
 }

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -965,7 +965,9 @@ OpResult<AddResult> OpAdd(const OpArgs& op_args, const ZParams& zparams, string_
 
   if (zparams.override && members.empty()) {
     auto it = db_slice.FindMutable(op_args.db_cntx, key).it;  // post_updater will run immediately
-    db_slice.Del(op_args.db_cntx, it);
+    if (IsValid(it)) {
+      db_slice.Del(op_args.db_cntx, it);
+    }
     return OpStatus::OK;
   }
 
@@ -1220,7 +1222,7 @@ ScoredArray OpBZPop(Transaction* t, EngineShard* shard, std::string_view key, bo
   auto zlen = pv.Size();
   if (zlen == 0) {
     DVLOG(1) << "deleting key " << key << " " << t->DebugId();
-    CHECK(db_slice.Del(t->GetDbContext(), it_res->it));
+    db_slice.Del(t->GetDbContext(), it_res->it);
   }
 
   OpArgs op_args = t->GetOpArgs(shard);
@@ -1331,7 +1333,7 @@ auto OpPopCount(const ZSetFamily::ZRangeSpec& range_spec, const OpArgs& op_args,
 
   auto zlen = pv.Size();
   if (zlen == 0) {
-    CHECK(op_args.GetDbSlice().Del(op_args.db_cntx, res_it->it));
+    op_args.GetDbSlice().Del(op_args.db_cntx, res_it->it);
   }
 
   return iv.PopResult();
@@ -1385,7 +1387,7 @@ OpResult<unsigned> OpRemRange(const OpArgs& op_args, string_view key,
 
   auto zlen = pv.Size();
   if (zlen == 0) {
-    CHECK(op_args.GetDbSlice().Del(op_args.db_cntx, res_it->it));
+    op_args.GetDbSlice().Del(op_args.db_cntx, res_it->it);
   }
 
   return iv.removed();
@@ -1564,7 +1566,7 @@ OpResult<unsigned> OpRem(const OpArgs& op_args, string_view key, facade::ArgRang
   res_it->post_updater.Run();
 
   if (zlen == 0) {
-    CHECK(op_args.GetDbSlice().Del(op_args.db_cntx, res_it->it));
+    op_args.GetDbSlice().Del(op_args.db_cntx, res_it->it);
   }
 
   return deleted;


### PR DESCRIPTION
Done as a preparation to introduce asynchronous deletions for sets/zsets/hmaps.

    1. Restrict the interface around DbSlice::Del. Now it requires for the iterator to be valid and the checks should
       be explicit before the call. Most callers already provides a valid iterator.
    
    2. Some minor refactoring in compact_object_test.
    3. Expose DenseSet::ClearStep to allow iterative deletions of elements.


<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->