### PR TITLE
fix(replication): do not log to journal on callback fail

### DIFF
--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -559,7 +559,7 @@ class Transaction {
 
   // Log command in shard's journal, if this is a write command with auto-journaling enabled.
   // Should be called immediately after the last hop.
-  void LogAutoJournalOnShard(EngineShard* shard);
+  void LogAutoJournalOnShard(EngineShard* shard, RunnableResult shard_result);
 
   // Whether the callback can be run directly on this thread without dispatching on the shard queue
   bool CanRunInlined() const;


### PR DESCRIPTION
When replicating we should not log journal change if the command execution failed.
This bug was introduced in a cleanup for replication code https://github.com/dragonflydb/dragonfly/commit/22994cf3b7b9134adcd384a44c6dd712d67f1b73
also fixes #4179 
