### PR TITLE
fix: invalid iterator case in Qlist::Erase

### DIFF
--- a/src/core/qlist.h
+++ b/src/core/qlist.h
@@ -165,12 +165,6 @@ class QList {
   void OnPreUpdate(quicklistNode* node);
   void OnPostUpdate(quicklistNode* node);
 
-  // Returns false if used existing sentinel, true if a new sentinel was created.
-  bool PushSentinel(std::string_view value, Where where);
-
-  // Returns false if used existing head, true if new head created.
-  bool PushTail(std::string_view value);
-
   // Returns newly created plain node.
   quicklistNode* InsertPlainNode(quicklistNode* old_node, std::string_view, InsertOpt insert_opt);
   void InsertNode(quicklistNode* old_node, quicklistNode* new_node, InsertOpt insert_opt);

--- a/src/core/qlist_test.cc
+++ b/src/core/qlist_test.cc
@@ -291,6 +291,18 @@ TEST_F(QListTest, LargeValues) {
   EXPECT_THAT(items, ElementsAre(val));
 }
 
+TEST_F(QListTest, RemoveListpack) {
+  ql_.Push("ABC", QList::TAIL);
+  ql_.Push("DEF", QList::TAIL);
+  auto it = ql_.GetIterator(QList::TAIL);
+  ASSERT_TRUE(it.Next());  // must call Next to initialize the iterator.
+  ql_.Erase(it);
+  it = ql_.GetIterator(QList::TAIL);
+  ASSERT_TRUE(it.Next());
+  it = ql_.Erase(it);
+  ASSERT_FALSE(it.Next());
+}
+
 using FillCompress = tuple<int, unsigned>;
 
 class PrintToFillCompress {


### PR DESCRIPTION
The problem was with reverse iterator that was not set properly when the last node is deleted.

Also, move PushSentinel code into Push.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->