### PR TITLE
fix: geosearch and georadius response format

### DIFF
--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -1258,6 +1258,9 @@ TEST_F(ZSetFamilyTest, GeoSearch) {
                                 RespArray(ElementsAre(DoubleArg(3.7038), DoubleArg(40.4168))))),
           RespArray(ElementsAre("Lisbon", DoubleArg(502.20769462704084),
                                 RespArray(ElementsAre(DoubleArg(9.1427), DoubleArg(38.7369))))))));
+
+  resp = Run({"GEOSEARCH", "Europe", "FROMMEMBER", "Madrid", "BYRADIUS", "700", "KM"});
+  EXPECT_THAT(resp, RespArray(ElementsAre("Madrid", "Lisbon")));
 }
 
 TEST_F(ZSetFamilyTest, GeoRadiusByMember) {


### PR DESCRIPTION
`geosearch` and `georadius` return an array of arrays even when WITHCOORD, WITHDIST, WITHHASH statements are omitted. 

* return array of arrays only when WITHCOORD, WITHDIST, WITHHASH statements are used

resolves #4382