### PR TITLE
chore: tool to aggregate allocator tracking logs

### DIFF
--- a/tools/aggregate_allocator_tracking_logs.py
+++ b/tools/aggregate_allocator_tracking_logs.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+"""
+Usage:
+1. First run Dragonfly with tracking allocator enabled.
+2. Finish tracking.
+3. cat /tmp/dragonfly.INFO |  ./aggregate_allocator_tracking_logs.py
+"""
+
+import sys
+
+
+def aggregate(log_lines):
+    alloc_sum = 0
+    dealloc_sum = 0
+
+    for line in log_lines:
+        allocating = False
+        deallocating = False
+
+        for word in line.rstrip().split():
+            if allocating:
+                alloc_sum = alloc_sum + int(word)
+                break
+            elif deallocating:
+                dealloc_sum = dealloc_sum + int(word)
+                break
+
+            if word == "Allocating":
+                allocating = True
+            if word == "Deallocating":
+                deallocating = True
+
+    print(f"Total allocations: {alloc_sum}\nTotal deallocations {dealloc_sum}")
+
+
+if __name__ == "__main__":
+    log_lines = sys.stdin.readlines()
+    aggregate(log_lines)

--- a/tools/parse_allocator_tracking_logs.py
+++ b/tools/parse_allocator_tracking_logs.py
@@ -2,7 +2,7 @@
 
 """
 Usage:
-1. First run Dragonfly with tracking allocator enabled. Must be a single allocator range with 100% samping rate to catch both allocations and deallocations.
+1. First run Dragonfly with tracking allocator enabled. Must be a single allocator range with 100% sampling rate to catch both allocations and deallocations.
 2. Finish tracking.
 3. cat /tmp/dragonfly.INFO |  ./parse_allocator_tracking_logs.py
 """


### PR DESCRIPTION
Similar to `parse_total_allocator_tracking_logs.py` but outputs the total bytes allocated and deallcoated 


* add tool to aggregate allocator tracking logs