### PR TITLE
fix(stream_family): Fix journaling in the XADD and XTRIM commands

### DIFF
--- a/src/redis/stream.h
+++ b/src/redis/stream.h
@@ -163,9 +163,11 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
 int streamDeleteItem(stream *s, streamID *id);
 void streamGetEdgeID(stream *s, int first, int skip_tombstones, streamID *edge_id);
 long long streamEstimateDistanceFromFirstEverEntry(stream *s, streamID *id);
-int64_t streamTrim(stream *s, streamAddTrimArgs *args);
-int64_t streamTrimByLength(stream *s, long long maxlen, int approx);
-int64_t streamTrimByID(stream *s, streamID minid, int approx);
+int64_t streamTrim(stream *s, streamAddTrimArgs *args, streamID *last_id);
+int64_t streamTrimByLength(stream *s, long long maxlen, int approx, streamID *last_id);
+int64_t streamTrimByLengthLimited(stream *s, long long maxlen, int approx, long long limit, streamID *last_id);
+int64_t streamTrimByID(stream *s, streamID minid, int approx, streamID *last_id);
+int64_t streamTrimByIDLimited(stream *s, streamID minid, int approx, long long limit, streamID *last_id);
 void streamFreeCG(streamCG *cg);
 void streamDelConsumer(streamCG *cg, streamConsumer *consumer);
 void streamLastValidID(stream *s, streamID *maxid);

--- a/src/redis/t_stream.c
+++ b/src/redis/t_stream.c
@@ -300,7 +300,7 @@ void streamGetEdgeID(stream *s, int first, int skip_tombstones, streamID *edge_i
  * that should be trimmed, there is a chance we will still have entries with
  * IDs < 'id' (or number of elements >= maxlen in case of MAXLEN).
  */
-int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
+int64_t streamTrim(stream *s, streamAddTrimArgs *args, streamID *last_id) {
     size_t maxlen = args->maxlen;
     streamID *id = &args->minid;
     int approx = args->approx_trim;
@@ -315,6 +315,8 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
     raxSeek(&ri,"^",NULL,0);
 
     int64_t deleted = 0;
+    streamID last_deleted_id = {0, 0}; // Initialize last deleted ID
+    
     while (raxNext(&ri)) {
         if (trim_strategy == TRIM_STRATEGY_MAXLEN && s->length <= maxlen)
             break;
@@ -331,16 +333,24 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
         streamID master_id = {0}; /* For MINID */
         if (trim_strategy == TRIM_STRATEGY_MAXLEN) {
             remove_node = s->length - entries >= maxlen;
+            if (remove_node) {
+                streamDecodeID(ri.key, &master_id);
+                // Write last ID to last_deleted_id
+                lpGetEdgeStreamID(lp, 0, &master_id, &last_deleted_id);
+            }
         } else {
             /* Read the master ID from the radix tree key. */
             streamDecodeID(ri.key, &master_id);
-
+            
             /* Read last ID. */
             streamID last_id = {0, 0};
             lpGetEdgeStreamID(lp, 0, &master_id, &last_id);
 
             /* We can remove the entire node id its last ID < 'id' */
             remove_node = streamCompareID(&last_id, id) < 0;
+            if (remove_node) {
+                last_deleted_id = last_id;
+            }
         }
 
         if (remove_node) {
@@ -355,6 +365,10 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
         /* If we cannot remove a whole element, and approx is true,
          * stop here. */
         if (approx) break;
+
+        if (trim_strategy == TRIM_STRATEGY_MAXLEN) {
+            streamDecodeID(ri.key, &master_id);
+        }
 
         /* Now we have to trim entries from within 'lp' */
         int64_t deleted_from_lp = 0;
@@ -386,11 +400,7 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
             int64_t seq_delta = lpGetInteger(p);
             p = lpNext(lp, p); /* Skip ID seq delta */
 
-            streamID currid = {0}; /* For MINID */
-            if (trim_strategy == TRIM_STRATEGY_MINID) {
-                currid.ms = master_id.ms + ms_delta;
-                currid.seq = master_id.seq + seq_delta;
-            }
+            streamID currid = {master_id.ms + ms_delta, master_id.seq + seq_delta};
 
             int stop;
             if (trim_strategy == TRIM_STRATEGY_MAXLEN) {
@@ -422,6 +432,7 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
                 deleted_from_lp++;
                 s->length--;
                 p = lp + delta;
+                last_deleted_id = currid;
             }
         }
         deleted += deleted_from_lp;
@@ -458,29 +469,44 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
         streamGetEdgeID(s,1,1,&s->first_id);
     }
 
+    /* Set the last deleted ID, if applicable. */
+    if (last_id) {
+        *last_id = last_deleted_id;
+    }
+
     return deleted;
 }
 
 /* Trims a stream by length. Returns the number of deleted items. */
-int64_t streamTrimByLength(stream *s, long long maxlen, int approx) {
+int64_t streamTrimByLength(stream *s, long long maxlen, int approx, streamID *last_id) {
+    return streamTrimByLengthLimited(s, maxlen, approx, approx ? 100 * server.stream_node_max_entries : 0, last_id);
+}
+
+/* Trims a stream by length. Returns the number of deleted items. */
+int64_t streamTrimByLengthLimited(stream *s, long long maxlen, int approx, long long limit, streamID *last_id) {
     streamAddTrimArgs args = {
         .trim_strategy = TRIM_STRATEGY_MAXLEN,
         .approx_trim = approx,
-        .limit = approx ? 100 * server.stream_node_max_entries : 0,
+        .limit = limit,
         .maxlen = maxlen
     };
-    return streamTrim(s, &args);
+    return streamTrim(s, &args, last_id);
 }
 
 /* Trims a stream by minimum ID. Returns the number of deleted items. */
-int64_t streamTrimByID(stream *s, streamID minid, int approx) {
+int64_t streamTrimByID(stream *s, streamID minid, int approx, streamID *last_id) {
+    return streamTrimByIDLimited(s, minid, approx, approx ? 100 * server.stream_node_max_entries : 0, last_id);
+}
+
+/* Trims a stream by minimum ID. Returns the number of deleted items. */
+int64_t streamTrimByIDLimited(stream *s, streamID minid, int approx, long long limit, streamID *last_id) {
     streamAddTrimArgs args = {
         .trim_strategy = TRIM_STRATEGY_MINID,
         .approx_trim = approx,
-        .limit = approx ? 100 * server.stream_node_max_entries : 0,
+        .limit = limit,
         .minid = minid
     };
-    return streamTrim(s, &args);
+    return streamTrim(s, &args, last_id);
 }
 
 /* Initialize the stream iterator, so that we can call iterating functions

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -66,21 +66,32 @@ struct RangeId {
   bool exclude = false;
 };
 
-enum class TrimStrategy {
-  kNone = TRIM_STRATEGY_NONE,
-  kMaxLen = TRIM_STRATEGY_MAXLEN,
-  kMinId = TRIM_STRATEGY_MINID,
+struct TrimOpts {
+  static constexpr int32_t kNoLimit = -1;
+
+  bool HasLimit() const {
+    return limit != kNoLimit;
+  }
+
+  bool IsMaxLen() const {
+    return std::holds_alternative<uint32_t>(length_or_id);
+  }
+
+  uint32_t AsMaxLen() const {
+    return std::get<uint32_t>(length_or_id);
+  }
+
+  const ParsedStreamId& AsMinId() const {
+    return std::get<ParsedStreamId>(length_or_id);
+  }
+
+  // First is MaxLen, second is MinId.
+  std::variant<uint32_t, ParsedStreamId> length_or_id;
+  int32_t limit = kNoLimit;
+  bool approx = false;
 };
-
-struct AddTrimOpts {
-  string_view key;
-  ParsedStreamId minid;
-  uint32_t max_len = kuint32max;
-  uint32_t limit = 0;
-  TrimStrategy trim_strategy = TrimStrategy::kNone;
-  bool trim_approx = false;
-
-  // XADD only.
+struct AddOpts {
+  std::optional<TrimOpts> trim_opts;
   ParsedStreamId parsed_id;
   bool no_mkstream = false;
 };
@@ -598,45 +609,53 @@ streamNACK* StreamCreateNACK(streamConsumer* consumer, uint64_t now_ms) {
   return nack;
 }
 
-int StreamTrim(const AddTrimOpts& opts, stream* s) {
-  if (!opts.limit) {
-    if (opts.trim_strategy == TrimStrategy::kMaxLen) {
-      /* Notify xtrim event if needed. */
-      return streamTrimByLength(s, opts.max_len, opts.trim_approx);
-      // TODO: when replicating, we should propagate it as exact limit in case of trimming.
-    } else if (opts.trim_strategy == TrimStrategy::kMinId) {
-      return streamTrimByID(s, opts.minid.val, opts.trim_approx);
-    }
-  } else {
-    streamAddTrimArgs trim_args = {};
-    trim_args.trim_strategy = static_cast<int>(opts.trim_strategy);
-    trim_args.approx_trim = opts.trim_approx;
-    trim_args.limit = opts.limit;
-
-    if (opts.trim_strategy == TrimStrategy::kMaxLen) {
-      trim_args.maxlen = opts.max_len;
-    } else if (opts.trim_strategy == TrimStrategy::kMinId) {
-      trim_args.minid = opts.minid.val;
-    }
-    return streamTrim(s, &trim_args);
-  }
-
-  return 0;
+std::string StreamsIdToString(streamID id) {
+  return absl::StrCat(id.ms, "-", id.seq);
 }
 
-OpResult<streamID> OpAdd(const OpArgs& op_args, const AddTrimOpts& opts, CmdArgList args) {
-  DCHECK(!args.empty() && args.size() % 2 == 0);
-  auto& db_slice = op_args.GetDbSlice();
-  DbSlice::AddOrFindResult add_res;
+/* The first value represents the number of deleted items, and the second is the last trimmed ID. */
+std::pair<int64_t, streamID> TrimStream(const TrimOpts& opts, stream* s) {
+  streamID last_id = {0, 0};
 
-  if (opts.no_mkstream) {
-    auto res_it = db_slice.FindMutable(op_args.db_cntx, opts.key, OBJ_STREAM);
-    if (!res_it) {
-      return res_it.status();
+  auto trim = [&]() {
+    bool limit = opts.HasLimit();
+    if (opts.IsMaxLen()) {
+      if (!limit) {
+        return streamTrimByLength(s, opts.AsMaxLen(), opts.approx, &last_id);
+      } else {
+        return streamTrimByLengthLimited(s, opts.AsMaxLen(), opts.approx, opts.limit, &last_id);
+      }
+    } else {
+      const auto& min_id = opts.AsMinId().val;
+      if (!limit) {
+        return streamTrimByID(s, min_id, opts.approx, &last_id);
+      } else {
+        return streamTrimByIDLimited(s, min_id, opts.approx, opts.limit, &last_id);
+      }
     }
+  };
+
+  const int64_t deleted_items_number = trim();
+  return {deleted_items_number, last_id};
+}
+
+bool JournalAsMinId(const TrimOpts& opts) {
+  return opts.approx || opts.IsMaxLen();
+}
+
+OpResult<streamID> OpAdd(const OpArgs& op_args, string_view key, const ShardArgs& shard_args,
+                         const AddOpts& opts, CmdArgList args) {
+  DCHECK(!args.empty() && args.size() % 2 == 0);
+
+  auto& db_slice = op_args.GetDbSlice();
+
+  DbSlice::AddOrFindResult add_res;
+  if (opts.no_mkstream) {
+    auto res_it = db_slice.FindMutable(op_args.db_cntx, key, OBJ_STREAM);
+    RETURN_ON_BAD_STATUS(res_it);
     add_res = std::move(*res_it);
   } else {
-    auto op_res = db_slice.AddOrFind(op_args.db_cntx, opts.key);
+    auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
     RETURN_ON_BAD_STATUS(op_res);
     add_res = std::move(*op_res);
   }
@@ -669,13 +688,30 @@ OpResult<streamID> OpAdd(const OpArgs& op_args, const AddTrimOpts& opts, CmdArgL
     return OpStatus::OUT_OF_MEMORY;
   }
 
-  StreamTrim(opts, stream_inst);
+  std::pair<int64_t, streamID> trim_result{};
+  if (opts.trim_opts) {
+    trim_result = TrimStream(opts.trim_opts.value(), stream_inst);
+  }
 
   mem_tracker.UpdateStreamSize(it->second);
 
+  if (op_args.shard->journal()) {
+    if (opts.trim_opts && JournalAsMinId(opts.trim_opts.value())) {
+      // We need to set exact MinId in the journal.
+      std::string last_id = StreamsIdToString(trim_result.second);
+      std::vector<std::string_view> journal_args = {key, "MINID"sv, "="sv, last_id};
+      if (opts.no_mkstream) {
+        journal_args.push_back("NOMKSTREAM"sv);
+      }
+      RecordJournal(op_args, "XADD"sv, journal_args);
+    } else {
+      RecordJournal(op_args, "XADD"sv, shard_args);
+    }
+  }
+
   auto blocking_controller = op_args.db_cntx.ns->GetBlockingController(op_args.shard->shard_id());
   if (blocking_controller) {
-    blocking_controller->AwakeWatched(op_args.db_cntx.db_index, opts.key);
+    blocking_controller->AwakeWatched(op_args.db_cntx.db_index, key);
   }
 
   return result_id;
@@ -1931,9 +1967,10 @@ void XGroupHelp(CmdArgList args, const CommandContext& cmd_cntx) {
   return rb->SendSimpleStrArr(help_arr);
 }
 
-OpResult<int64_t> OpTrim(const OpArgs& op_args, const AddTrimOpts& opts) {
+OpResult<int64_t> OpTrim(const OpArgs& op_args, std::string_view key, const ShardArgs& shard_args,
+                         const TrimOpts& opts) {
   auto& db_slice = op_args.GetDbSlice();
-  auto res_it = db_slice.FindMutable(op_args.db_cntx, opts.key, OBJ_STREAM);
+  auto res_it = db_slice.FindMutable(op_args.db_cntx, key, OBJ_STREAM);
   if (!res_it) {
     if (res_it.status() == OpStatus::KEY_NOTFOUND) {
       return 0;
@@ -1946,77 +1983,85 @@ OpResult<int64_t> OpTrim(const OpArgs& op_args, const AddTrimOpts& opts) {
   CompactObj& cobj = res_it->it->second;
   stream* s = (stream*)cobj.RObjPtr();
 
-  auto res = StreamTrim(opts, s);
+  auto res = TrimStream(opts, s);
 
   mem_tracker.UpdateStreamSize(cobj);
-  return res;
-}
 
-optional<pair<AddTrimOpts, unsigned>> ParseAddOrTrimArgsOrReply(CmdArgList args, bool is_xadd,
-                                                                SinkReplyBuilder* builder) {
-  AddTrimOpts opts;
-  opts.key = ArgS(args, 0);
-
-  unsigned id_indx = 1;
-  for (; id_indx < args.size(); ++id_indx) {
-    string arg = absl::AsciiStrToUpper(ArgS(args, id_indx));
-    size_t remaining_args = args.size() - id_indx - 1;
-
-    if (is_xadd && arg == "NOMKSTREAM") {
-      opts.no_mkstream = true;
-    } else if ((arg == "MAXLEN" || arg == "MINID") && remaining_args >= 1) {
-      if (opts.trim_strategy != TrimStrategy::kNone) {
-        builder->SendError("MAXLEN and MINID options at the same time are not compatible",
-                           kSyntaxErr);
-        return std::nullopt;
-      }
-
-      if (arg == "MAXLEN") {
-        opts.trim_strategy = TrimStrategy::kMaxLen;
-      } else {
-        opts.trim_strategy = TrimStrategy::kMinId;
-      }
-
-      id_indx++;
-      arg = ArgS(args, id_indx);
-      if (remaining_args >= 2 && arg == "~") {
-        opts.trim_approx = true;
-        id_indx++;
-        arg = ArgS(args, id_indx);
-      } else if (remaining_args >= 2 && arg == "=") {
-        opts.trim_approx = false;
-        id_indx++;
-        arg = ArgS(args, id_indx);
-      }
-
-      if (opts.trim_strategy == TrimStrategy::kMaxLen && !absl::SimpleAtoi(arg, &opts.max_len)) {
-        builder->SendError(kInvalidIntErr);
-        return std::nullopt;
-      }
-      if (opts.trim_strategy == TrimStrategy::kMinId && !ParseID(arg, false, 0, &opts.minid)) {
-        builder->SendError(kSyntaxErr);
-        return std::nullopt;
-      }
-    } else if (arg == "LIMIT" && remaining_args >= 1 && opts.trim_strategy != TrimStrategy::kNone) {
-      if (!opts.trim_approx) {
-        builder->SendError(kSyntaxErr);
-        return std::nullopt;
-      }
-      ++id_indx;
-      if (!absl::SimpleAtoi(ArgS(args, id_indx), &opts.limit)) {
-        builder->SendError(kSyntaxErr);
-        return std::nullopt;
-      }
-    } else if (is_xadd) {
-      // There are still remaining field args.
-      break;
+  if (op_args.shard->journal()) {
+    if (JournalAsMinId(opts)) {
+      // We need to set exact MinId in the journal.
+      std::string last_id = StreamsIdToString(res.second);
+      RecordJournal(op_args, "XTRIM"sv, ArgSlice{key, "MINID"sv, "="sv, last_id});
     } else {
-      builder->SendError(kSyntaxErr);
-      return std::nullopt;
+      RecordJournal(op_args, "XTRIM"sv, shard_args);
     }
   }
 
-  return make_pair(opts, id_indx);
+  return res.first;
+}
+
+optional<TrimOpts> ParseTrimOptsOrReply(bool max_len, CmdArgParser* parser,
+                                        SinkReplyBuilder* builder) {
+  TrimOpts opts;
+  opts.approx = parser->Check("~");
+  if (!opts.approx) {
+    parser->Check("=");
+  }
+
+  if (max_len) {
+    opts.length_or_id = parser->Next<uint32_t>();
+  } else {
+    ParsedStreamId parsed_id;
+    if (!ParseID(parser->Next(), false, 0, &parsed_id)) {
+      builder->SendError(kSyntaxErr);
+      return std::nullopt;
+    }
+
+    opts.length_or_id = parsed_id;  // trivial copy
+  }
+
+  if (parser->Check("LIMIT")) {
+    if (!opts.approx) {
+      builder->SendError(kSyntaxErr);
+      return std::nullopt;
+    }
+
+    opts.limit = parser->Next<uint32_t>();
+  }
+
+  return opts;
+}
+
+optional<TrimOpts> ParseTrimOptsOrReply(CmdArgParser* parser, SinkReplyBuilder* builder) {
+  bool max_len = parser->Check("MAXLEN");
+  if (!max_len) {
+    parser->ExpectTag("MINID");
+  }
+  return ParseTrimOptsOrReply(max_len, parser, builder);
+}
+
+optional<AddOpts> ParseAddOptsOrReply(CmdArgParser* parser, SinkReplyBuilder* builder) {
+  AddOpts opts;
+  while (parser->HasNext()) {
+    if (parser->Check("NOMKSTREAM")) {
+      opts.no_mkstream = true;
+      continue;
+    }
+
+    bool max_len = parser->Check("MAXLEN");
+    if (max_len || parser->Check("MINID")) {
+      auto trim_opts = ParseTrimOptsOrReply(max_len, parser, builder);
+      if (!trim_opts) {
+        return std::nullopt;
+      }
+
+      opts.trim_opts = trim_opts.value();  // trivial copy
+    } else {
+      break;
+    }
+  }
+
+  return opts;
 }
 
 struct StreamReplies {
@@ -2538,46 +2583,52 @@ bool ParseXpendingOptions(CmdArgList& args, PendingOpts& opts, SinkReplyBuilder*
 }  // namespace
 
 void StreamFamily::XAdd(CmdArgList args, const CommandContext& cmd_cntx) {
-  auto parse_resp = ParseAddOrTrimArgsOrReply(args, true, cmd_cntx.rb);
-  if (!parse_resp) {
+  CmdArgParser parser{args};
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx.rb);
+
+  string_view key = parser.Next();
+
+  auto parsed_add_opts = ParseAddOptsOrReply(&parser, rb);
+  if (!parsed_add_opts) {
     return;
   }
 
-  auto add_opts = parse_resp->first;
-  auto id_indx = parse_resp->second;
-
-  args.remove_prefix(id_indx);
-  if (args.size() < 2 || args.size() % 2 == 0) {
-    return cmd_cntx.rb->SendError(WrongNumArgsError("XADD"), kSyntaxErrType);
+  if (auto err = parser.Error(); err) {
+    rb->SendError(err->MakeReply());
+    return;
   }
 
-  string_view id = ArgS(args, 0);
+  auto& add_opts = parsed_add_opts.value();
 
+  std::string_view id = parser.Next();
   if (!ParseID(id, true, 0, &add_opts.parsed_id)) {
-    return cmd_cntx.rb->SendError(kInvalidStreamId, kSyntaxErrType);
+    return rb->SendError(kInvalidStreamId, kSyntaxErrType);
   }
 
-  args.remove_prefix(1);
+  CmdArgList fields = parser.Tail();
+  if (fields.empty() || fields.size() % 2 != 0) {
+    return rb->SendError(WrongNumArgsError("XADD"), kSyntaxErrType);
+  }
+
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpAdd(t->GetOpArgs(shard), add_opts, args);
+    auto op_args = t->GetOpArgs(shard);
+    ShardArgs shard_args = t->GetShardArgs(shard->shard_id());
+    return OpAdd(op_args, key, shard_args, add_opts, fields);
   };
 
   OpResult<streamID> add_result = cmd_cntx.tx->ScheduleSingleHopT(cb);
-  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx.rb);
 
   if (add_result) {
-    return rb->SendBulkString(StreamIdRepr(*add_result));
+    rb->SendBulkString(StreamIdRepr(*add_result));
+  } else {
+    if (add_result == OpStatus::KEY_NOTFOUND) {
+      rb->SendNull();
+    } else if (add_result == OpStatus::STREAM_ID_SMALL) {
+      rb->SendError(LeqTopIdError("XADD"));
+    } else {
+      rb->SendError(add_result.status());
+    }
   }
-
-  if (add_result == OpStatus::KEY_NOTFOUND) {
-    return rb->SendNull();
-  }
-
-  if (add_result.status() == OpStatus::STREAM_ID_SMALL) {
-    return cmd_cntx.rb->SendError(LeqTopIdError("XADD"));
-  }
-
-  return cmd_cntx.rb->SendError(add_result.status());
 }
 
 absl::InlinedVector<streamID, 8> GetXclaimIds(CmdArgList& args) {
@@ -3164,22 +3215,36 @@ void StreamFamily::XSetId(CmdArgList args, const CommandContext& cmd_cntx) {
 }
 
 void StreamFamily::XTrim(CmdArgList args, const CommandContext& cmd_cntx) {
-  auto parse_resp = ParseAddOrTrimArgsOrReply(args, true, cmd_cntx.rb);
-  if (!parse_resp) {
+  CmdArgParser parser{args};
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx.rb);
+
+  std::string_view key = parser.Next();
+
+  auto parse_trim_opts = ParseTrimOptsOrReply(&parser, rb);
+  if (!parse_trim_opts) {
     return;
   }
 
-  auto trim_opts = parse_resp->first;
+  if (!parser.Finalize()) {
+    auto err = parser.Error();
+    rb->SendError(err->MakeReply());
+    return;
+  }
+
+  auto& trim_opts = parse_trim_opts.value();
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpTrim(t->GetOpArgs(shard), trim_opts);
+    auto op_args = t->GetOpArgs(shard);
+    ShardArgs shard_args = t->GetShardArgs(shard->shard_id());
+    return OpTrim(op_args, key, shard_args, trim_opts);
   };
 
   OpResult<int64_t> trim_result = cmd_cntx.tx->ScheduleSingleHopT(cb);
   if (trim_result) {
-    return cmd_cntx.rb->SendLong(*trim_result);
+    rb->SendLong(*trim_result);
+  } else {
+    rb->SendError(trim_result.status());
   }
-  return cmd_cntx.rb->SendError(trim_result.status());
 }
 
 void StreamFamily::XAck(CmdArgList args, const CommandContext& cmd_cntx) {
@@ -3306,7 +3371,9 @@ void StreamFamily::Register(CommandRegistry* registry) {
   using CI = CommandId;
   registry->StartFamily();
   constexpr auto kReadFlags = CO::READONLY | CO::BLOCKING | CO::VARIADIC_KEYS;
-  *registry << CI{"XADD", CO::WRITE | CO::DENYOOM | CO::FAST, -5, 1, 1, acl::kXAdd}.HFUNC(XAdd)
+  *registry << CI{"XADD",    CO::WRITE | CO::DENYOOM | CO::FAST | CO::NO_AUTOJOURNAL, -5, 1, 1,
+                  acl::kXAdd}
+                   .HFUNC(XAdd)
             << CI{"XCLAIM", CO::WRITE | CO::FAST, -6, 1, 1, acl::kXClaim}.HFUNC(XClaim)
             << CI{"XDEL", CO::WRITE | CO::FAST, -3, 1, 1, acl::kXDel}.HFUNC(XDel)
             << CI{"XGROUP", CO::WRITE | CO::DENYOOM, -3, 2, 2, acl::kXGroup}.HFUNC(XGroup)

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -653,13 +653,13 @@ TEST_F(StreamFamilyTest, XTrimInvalidArgs) {
 
   // Include both maxlen and minid.
   resp = Run({"xtrim", "foo", "maxlen", "2", "minid", "1-1"});
-  EXPECT_THAT(resp, ErrArg("MAXLEN and MINID options at the same time are not compatible"));
+  EXPECT_THAT(resp, ErrArg("syntax error"));
   resp = Run({"xtrim", "foo", "minid", "1-1", "maxlen", "2"});
-  EXPECT_THAT(resp, ErrArg("MAXLEN and MINID options at the same time are not compatible"));
+  EXPECT_THAT(resp, ErrArg("syntax error"));
 
   // Invalid limit.
   resp = Run({"xtrim", "foo", "maxlen", "~", "2", "limit", "nan"});
-  EXPECT_THAT(resp, ErrArg("syntax error"));
+  EXPECT_THAT(resp, ErrArg("value is not an integer or out of range"));
 }
 TEST_F(StreamFamilyTest, XPending) {
   Run({"xadd", "foo", "1-0", "k1", "v1"});


### PR DESCRIPTION
fixes #4202

1. Fix journaling
2. Clean up and refactor the parsing logic for the XADD and XTRIM commands
3. I'M CURRENTLY WORKING ON ADDING REPLICATION TEST