### PR TITLE
fix: resp inline parsing correctly resets itself

### DIFF
--- a/src/facade/redis_parser.cc
+++ b/src/facade/redis_parser.cc
@@ -232,8 +232,12 @@ auto RedisParser::ParseInline(Buffer str) -> ResultConsumed {
   }
 
   uint32_t last_consumed = ptr - str.data();
-  if (ptr == end) {                   // we have not finished parsing.
-    is_broken_token_ = ptr[-1] > 32;  // we stopped in the middle of the token.
+  if (ptr == end) {  // we have not finished parsing.
+    if (cached_expr_->empty()) {
+      state_ = CMD_COMPLETE_S;  // have not found anything besides whitespace.
+    } else {
+      is_broken_token_ = ptr[-1] > 32;  // we stopped in the middle of the token.
+    }
     return {INPUT_PENDING, last_consumed};
   }
 

--- a/src/facade/redis_parser_test.cc
+++ b/src/facade/redis_parser_test.cc
@@ -281,4 +281,11 @@ TEST_F(RedisParserTest, InlineSplit) {
   ASSERT_EQ(RedisParser::OK, Parse("ING\n"));
 }
 
+TEST_F(RedisParserTest, InlineReset) {
+  ASSERT_EQ(RedisParser::INPUT_PENDING, Parse("\t \r\n"));
+  EXPECT_EQ(4, consumed_);
+  ASSERT_EQ(RedisParser::OK, Parse("*1\r\n$3\r\nfoo\r\n"));
+  EXPECT_EQ(13, consumed_);
+}
+
 }  // namespace facade


### PR DESCRIPTION
With empty inline string, the parser failed to continue parsing correctly the non-inline input.
Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->