### PR TITLE
fix: slot calculation during transaction squashing

### DIFF
--- a/src/server/cluster_support.cc
+++ b/src/server/cluster_support.cc
@@ -9,6 +9,7 @@ extern "C" {
 #include "base/flags.h"
 #include "base/logging.h"
 #include "cluster_support.h"
+#include "common.h"
 
 using namespace std;
 
@@ -31,22 +32,15 @@ void UniqueSlotChecker::Add(SlotId slot_id) {
     return;
   }
 
-  if (!slot_id_.has_value()) {
+  if (slot_id_ == kNoSlotId) {
     slot_id_ = slot_id;
-    return;
-  }
-
-  if (*slot_id_ != slot_id) {
+  } else if (slot_id_ != slot_id) {
     slot_id_ = kInvalidSlotId;
   }
 }
 
 optional<SlotId> UniqueSlotChecker::GetUniqueSlotId() const {
-  if (slot_id_.has_value() && *slot_id_ == kInvalidSlotId) {
-    return nullopt;
-  }
-
-  return slot_id_;
+  return slot_id_ > kMaxSlotNum ? optional<SlotId>() : slot_id_;
 }
 
 namespace {

--- a/src/server/cluster_support.h
+++ b/src/server/cluster_support.h
@@ -8,14 +8,10 @@
 #include <optional>
 #include <string_view>
 
-#include "common.h"
-
 namespace dfly {
 
 using SlotId = std::uint16_t;
-
 constexpr SlotId kMaxSlotNum = 0x3FFF;
-constexpr SlotId kInvalidSlotId = kMaxSlotNum + 1;
 
 // A simple utility class that "aggregates" SlotId-s and can tell whether all inputs were the same.
 // Only works when cluster is enabled.
@@ -26,8 +22,17 @@ class UniqueSlotChecker {
 
   std::optional<SlotId> GetUniqueSlotId() const;
 
+  void Reset() {
+    slot_id_ = kNoSlotId;
+  }
+
  private:
-  std::optional<SlotId> slot_id_;
+  // kNoSlotId - if slot wasn't set at all
+  static constexpr SlotId kNoSlotId = kMaxSlotNum + 1;
+  // kInvalidSlotId - if several different slots were set
+  static constexpr SlotId kInvalidSlotId = kNoSlotId + 1;
+
+  SlotId slot_id_ = kNoSlotId;
 };
 
 SlotId KeySlot(std::string_view key);

--- a/src/server/multi_command_squasher.h
+++ b/src/server/multi_command_squasher.h
@@ -52,7 +52,7 @@ class MultiCommandSquasher {
                        bool verify_commands, bool error_abort);
 
   // Lazy initialize shard info.
-  ShardExecInfo& PrepareShardInfo(ShardId sid, std::optional<SlotId> slot_id);
+  ShardExecInfo& PrepareShardInfo(ShardId sid);
 
   // Retrun squash flags
   SquashResult TrySquash(StoredCmd* cmd);

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -325,6 +325,7 @@ void Transaction::InitByKeys(const KeyIndex& key_index) {
   // Stub transactions always operate only on single shard.
   bool is_stub = multi_ && multi_->role == SQUASHED_STUB;
 
+  unique_slot_checker_.Reset();
   if ((key_index.NumArgs() == 1 && !IsAtomicMulti()) || is_stub) {
     DCHECK(!IsActiveMulti() || multi_->mode == NON_ATOMIC);
 


### PR DESCRIPTION
problem: we reuse transactions during squashing without slot resetting 
fix: reset UniqueSlotChecker every time when we reuse a transaction