### PR TITLE
fix(search_family): Add options test for the FT.SEARCH command

### DIFF
--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -148,6 +148,7 @@ struct SearchParams {
     Only one of load_fields and return_fields should be set.
   */
   std::optional<SearchFieldsList> load_fields;
+  bool no_content = false;
 
   std::optional<search::SortOption> sort_option;
   search::QueryParams query_params;
@@ -157,7 +158,7 @@ struct SearchParams {
   }
 
   bool IdsOnly() const {
-    return return_fields && return_fields->empty();
+    return no_content || (return_fields && return_fields->empty());
   }
 
   bool ShouldReturnField(std::string_view alias) const;


### PR DESCRIPTION
related to the #4204

After adding the tests, several bugs were identified:
1. Bug with the `NOCONTENT` option.
2. An infinite loop occurring during the parsing of `RETURN` and `LOAD` options if the specified number of fields is big