### PR TITLE
fix(search_family): Add options test for the FT.AGGREGATE command

### DIFF
--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -119,7 +119,7 @@ struct CmdArgParser {
 
   // Check if the next value is equal to a specific tag. If equal, its consumed.
   template <class... Args> bool Check(std::string_view tag, Args*... args) {
-    if (cur_i_ + sizeof...(Args) >= args_.size())
+    if (cur_i_ + sizeof...(Args) >= args_.size() || error_)
       return false;
 
     std::string_view arg = SafeSV(cur_i_);

--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -119,7 +119,7 @@ struct CmdArgParser {
 
   // Check if the next value is equal to a specific tag. If equal, its consumed.
   template <class... Args> bool Check(std::string_view tag, Args*... args) {
-    if (cur_i_ + sizeof...(Args) >= args_.size() || error_)
+    if (cur_i_ + sizeof...(Args) >= args_.size())
       return false;
 
     std::string_view arg = SafeSV(cur_i_);

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -306,7 +306,7 @@ optional<SearchParams> ParseSearchParamsOrReply(CmdArgParser* parser, SinkReplyB
 }
 
 std::optional<aggregate::SortParams> ParseAggregatorSortParams(CmdArgParser* parser) {
-  using SordOrder = aggregate::SortParams::SortOrder;
+  using SortOrder = aggregate::SortParams::SortOrder;
 
   size_t strings_num = parser->Next<size_t>();
 
@@ -318,9 +318,9 @@ std::optional<aggregate::SortParams> ParseAggregatorSortParams(CmdArgParser* par
     std::string_view parsed_field = ParseFieldWithAtSign(parser);
     strings_num--;
 
-    SordOrder sord_order = SordOrder::ASC;
+    SortOrder sord_order = SortOrder::ASC;
     if (strings_num > 0) {
-      auto order = parser->TryMapNext("ASC", SordOrder::ASC, "DESC", SordOrder::DESC);
+      auto order = parser->TryMapNext("ASC", SortOrder::ASC, "DESC", SortOrder::DESC);
       if (order) {
         sord_order = order.value();
         strings_num--;

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -1901,9 +1901,8 @@ TEST_F(SearchFamilyTest, InvalidAggregateOptions) {
   EXPECT_THAT(resp, ErrArg(kInvalidIntErr));
 
   // Test REDUCE with no REDUCE function
-  /* resp = Run({"FT.AGGREGATE", "idx", "*", "GROUPBY", "1", "@field1", "REDUCE"});
-  EXPECT_THAT(resp, ErrArg("Bad arguments for REDUCE: SUCCESS"));
- */
+  resp = Run({"FT.AGGREGATE", "idx", "*", "GROUPBY", "1", "@field1", "REDUCE"});
+  EXPECT_THAT(resp, ErrArg("reducer function  not found"));
 
   /* // Test REDUCE with COUNT function
   resp = Run({"FT.AGGREGATE", "idx", "*", "GROUPBY", "1", "@field1", "REDUCE", "COUNT", "0"});

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -1884,4 +1884,67 @@ TEST_F(SearchFamilyTest, InvalidSearchOptions) {
   EXPECT_THAT(resp, IsArray(IntArg(1), "j1"));
 }
 
+TEST_F(SearchFamilyTest, InvalidAggregateOptions) {
+  Run({"JSON.SET", "j1", ".", R"({"field1":"first","field2":"second"})"});
+  Run({"FT.CREATE", "idx", "ON", "JSON", "SCHEMA", "$.field1", "AS", "field1", "TEXT", "$.field2",
+       "AS", "field2", "TEXT"});
+
+  // Test GROUPBY with no arguments
+  auto resp = Run({"FT.AGGREGATE", "idx", "*", "GROUPBY"});
+  EXPECT_THAT(resp, ErrArg(kSyntaxErr));
+
+  // Test GROUPBY with invalid count
+  resp = Run({"FT.AGGREGATE", "idx", "*", "GROUPBY", "-1", "@field1"});
+  EXPECT_THAT(resp, ErrArg(kInvalidIntErr));
+
+  resp =
+      Run({"FT.AGGREGATE", "idx", "*", "GROUPBY", "100000000000000000000", "@field1", "@field2"});
+  EXPECT_THAT(resp, ErrArg(kInvalidIntErr));
+
+  // Test REDUCE with no REDUCE function
+  /* resp = Run({"FT.AGGREGATE", "idx", "*", "GROUPBY", "1", "@field1", "REDUCE"});
+  EXPECT_THAT(resp, ErrArg("Bad arguments for REDUCE: SUCCESS"));
+ */
+
+  /* // Test REDUCE with COUNT function
+  resp = Run({"FT.AGGREGATE", "idx", "*", "GROUPBY", "1", "@field1", "REDUCE", "COUNT", "0"});
+  EXPECT_THAT(resp, IsMapWithSize("__generated_aliascount", "1", "field1", "first")); */
+
+  // Test REDUCE with invalid function
+  resp = Run({"FT.AGGREGATE", "idx", "*", "GROUPBY", "1", "@field1", "REDUCE", "INVALIDFUNC", "0",
+              "AS", "result"});
+  EXPECT_THAT(resp, ErrArg("reducer function INVALIDFUNC not found"));
+
+  // Test SORTBY with no arguments
+  resp = Run({"FT.AGGREGATE", "idx", "*", "SORTBY"});
+  EXPECT_THAT(resp, ErrArg(kSyntaxErr));
+
+  // Test SORTBY with invalid count
+  resp = Run({"FT.AGGREGATE", "idx", "*", "SORTBY", "-1", "@field1"});
+  EXPECT_THAT(resp, ErrArg(kInvalidIntErr));
+
+  resp = Run({"FT.AGGREGATE", "idx", "*", "SORTBY", "100000000000000000000", "@field1"});
+  EXPECT_THAT(resp, ErrArg(kInvalidIntErr));
+
+  // Test LIMIT with invalid arguments
+  resp = Run({"FT.AGGREGATE", "idx", "*", "LIMIT", "0"});
+  EXPECT_THAT(resp, ErrArg(kSyntaxErr));
+
+  resp = Run({"FT.AGGREGATE", "idx", "*", "LIMIT", "-1", "10"});
+  EXPECT_THAT(resp, ErrArg(kInvalidIntErr));
+
+  resp = Run({"FT.AGGREGATE", "idx", "*", "LIMIT", "0", "100000000000000000000"});
+  EXPECT_THAT(resp, ErrArg(kInvalidIntErr));
+
+  // Test LOAD with invalid arguments
+  resp = Run({"FT.AGGREGATE", "idx", "*", "LOAD", "@field1", "@field2"});
+  EXPECT_THAT(resp, ErrArg(kInvalidIntErr));
+
+  resp = Run({"FT.AGGREGATE", "idx", "*", "LOAD", "-1", "@field1"});
+  EXPECT_THAT(resp, ErrArg(kInvalidIntErr));
+
+  resp = Run({"FT.AGGREGATE", "idx", "*", "LOAD", "100000000000000000000", "@field1", "@field2"});
+  EXPECT_THAT(resp, ErrArg(kInvalidIntErr));
+}
+
 }  // namespace dfly

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -852,7 +852,6 @@ TEST_F(SearchFamilyTest, FtProfileInvalidQuery) {
 
 TEST_F(SearchFamilyTest, FtProfileErrorReply) {
   Run({"ft.create", "i1", "schema", "name", "text"});
-  ;
 
   auto resp = Run({"ft.profile", "i1", "not_search", "query", "(a | b) c d"});
   EXPECT_THAT(resp, ErrArg("no `SEARCH` or `AGGREGATE` provided"));


### PR DESCRIPTION
related to the #4204

1. Fix some small issues during parsing of the several SEARCH methods
2. Remove using builder in Parse* methods.
    It was a bad decision to use it because, in some cases, we were returning an error with `builder->SendError(...)`. However, in those cases, we were not handling parser errors with `parser->Error()`. As a result, debug builds were crashing because of this check:
```cpp
CmdArgParser::~CmdArgParser() {
  DCHECK(!error_.has_value()) << "Parsing error occured but not checked";
}
```
Now, we ensure that parsing errors are processed in all cases.
3. Add options test for the `FT.AGGREGATE` command