### PR TITLE
fix(cluster): crash in cluster migration

### DIFF
--- a/src/core/dash.h
+++ b/src/core/dash.h
@@ -409,6 +409,13 @@ class DashTable<_Key, _Value, Policy>::Iterator {
     return *this;
   }
 
+  Iterator& AdvanceIfNotOccupied() {
+    if (!IsOccupied()) {
+      this->operator++();
+    }
+    return *this;
+  }
+
   IteratorPairType operator->() const {
     auto* seg = owner_->segment_[seg_id_];
     return {seg->Key(bucket_id_, slot_id_), seg->Value(bucket_id_, slot_id_)};

--- a/src/server/journal/streamer.cc
+++ b/src/server/journal/streamer.cc
@@ -231,7 +231,7 @@ void RestoreStreamer::Run() {
       ThisFiber::Yield();
       last_yield = 0;
     }
-  } while (cursor);
+  } while (cursor && !fiber_cancelled_);
 
   VLOG(1) << "RestoreStreamer finished loop of " << my_slots_.ToSlotRanges().ToString()
           << ", shard " << db_slice_->shard_id() << ". Buckets looped " << stats_.buckets_loop;
@@ -302,7 +302,7 @@ bool RestoreStreamer::WriteBucket(PrimeTable::bucket_iterator it) {
 
     it.SetVersion(snapshot_version_);
     string key_buffer;  // we can reuse it
-    for (; !it.is_done(); ++it) {
+    for (it.AdvanceIfNotOccupied(); !it.is_done(); ++it) {
       const auto& pv = it->second;
       string_view key = it->first.GetSlice(&key_buffer);
       if (ShouldWrite(key)) {

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -291,11 +291,10 @@ unsigned SliceSnapshot::SerializeBucket(DbIndex db_index, PrimeTable::bucket_ite
   it.SetVersion(snapshot_version_);
   unsigned result = 0;
 
-  while (!it.is_done()) {
+  for (it.AdvanceIfNotOccupied(); !it.is_done(); ++it) {
     ++result;
     // might preempt due to big value serialization.
     SerializeEntry(db_index, it->first, it->second);
-    ++it;
   }
   serialize_bucket_running_ = false;
   return result;


### PR DESCRIPTION
Fixes #4455 
The bug:
When running the RestoreStreamer::WriteBucket the iterator was not valid, pointing to a location in dash table that is not occupied.
The reason for this was that the call to FlushChangeToEarlierCallbacks when traversing the buckets can delete entires in the dash table. This can happen when we remove finalized migration which results in flush slots operation. This operation also registers a callback which was invoked in FlushChangeToEarlierCallbacks.
The fix:
When traversing the bucket in WriteBucket/SerializeBucket we first update the iterator if needed.