### PR TITLE
chore: introduce background deletions of DenseSet objects

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -36,6 +36,7 @@ extern "C" {
 
 ABSL_FLAG(uint32_t, dbnum, 16, "Number of databases");
 ABSL_FLAG(uint32_t, keys_output_limit, 8192, "Maximum number of keys output by keys command");
+ABSL_FLAG(bool, unlink_experimental_async, true, "If true, runs unlink command asynchronously.");
 
 namespace dfly {
 using namespace std;
@@ -1054,7 +1055,8 @@ void GenericFamily::Del(CmdArgList args, const CommandContext& cmd_cntx) {
 }
 
 void GenericFamily::Unlink(CmdArgList args, const CommandContext& cmd_cntx) {
-  DeleteGeneric(args, cmd_cntx, true);
+  bool async = absl::GetFlag(FLAGS_unlink_experimental_async);
+  DeleteGeneric(args, cmd_cntx, async);
 }
 
 void GenericFamily::Ping(CmdArgList args, const CommandContext& cmd_cntx) {

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -993,14 +993,14 @@ std::optional<int32_t> ParseExpireOptionsOrReply(const CmdArgList args, SinkRepl
   return flags;
 }
 
-void DeleteGeneric(CmdArgList args, const CommandContext& cmd_cntx) {
+void DeleteGeneric(CmdArgList args, const CommandContext& cmd_cntx, bool async) {
   atomic_uint32_t result{0};
   auto* builder = cmd_cntx.rb;
   bool is_mc = (builder->GetProtocol() == Protocol::MEMCACHE);
 
-  auto cb = [&result](const Transaction* t, EngineShard* shard) {
+  auto cb = [&](const Transaction* t, EngineShard* shard) {
     ShardArgs args = t->GetShardArgs(shard->shard_id());
-    auto res = GenericFamily::OpDel(t->GetOpArgs(shard), args);
+    auto res = GenericFamily::OpDel(t->GetOpArgs(shard), args, async);
     result.fetch_add(res.value_or(0), memory_order_relaxed);
 
     return OpStatus::OK;
@@ -1028,8 +1028,8 @@ void DeleteGeneric(CmdArgList args, const CommandContext& cmd_cntx) {
 
 }  // namespace
 
-OpResult<uint32_t> GenericFamily::OpDel(const OpArgs& op_args, const ShardArgs& keys) {
-  DVLOG(1) << "Del: " << keys.Front();
+OpResult<uint32_t> GenericFamily::OpDel(const OpArgs& op_args, const ShardArgs& keys, bool async) {
+  DVLOG(1) << "Del: " << keys.Front() << " async: " << async;
   auto& db_slice = op_args.GetDbSlice();
 
   uint32_t res = 0;
@@ -1039,6 +1039,9 @@ OpResult<uint32_t> GenericFamily::OpDel(const OpArgs& op_args, const ShardArgs& 
     if (!IsValid(it))
       continue;
 
+    if (async)
+      it->first.SetAsyncDelete();
+
     db_slice.Del(op_args.db_cntx, it);
     ++res;
   }
@@ -1047,13 +1050,11 @@ OpResult<uint32_t> GenericFamily::OpDel(const OpArgs& op_args, const ShardArgs& 
 }
 
 void GenericFamily::Del(CmdArgList args, const CommandContext& cmd_cntx) {
-  VLOG(1) << "Del " << ArgS(args, 0);
-
-  DeleteGeneric(args, cmd_cntx);
+  DeleteGeneric(args, cmd_cntx, false);
 }
 
 void GenericFamily::Unlink(CmdArgList args, const CommandContext& cmd_cntx) {
-  DeleteGeneric(args, cmd_cntx);
+  DeleteGeneric(args, cmd_cntx, true);
 }
 
 void GenericFamily::Ping(CmdArgList args, const CommandContext& cmd_cntx) {

--- a/src/server/generic_family.h
+++ b/src/server/generic_family.h
@@ -10,9 +10,6 @@
 
 ABSL_DECLARE_FLAG(uint32_t, dbnum);
 
-namespace facade {
-class SinkReplyBuilder;
-};
 
 namespace dfly {
 
@@ -20,7 +17,6 @@ using facade::CmdArgList;
 using facade::OpResult;
 
 class CommandRegistry;
-class Transaction;
 struct CommandContext;
 
 class GenericFamily {
@@ -29,10 +25,8 @@ class GenericFamily {
 
   // Accessed by Service::Exec and Service::Watch as an utility.
   static OpResult<uint32_t> OpExists(const OpArgs& op_args, const ShardArgs& keys);
-  static OpResult<uint32_t> OpDel(const OpArgs& op_args, const ShardArgs& keys);
-
+  static OpResult<uint32_t> OpDel(const OpArgs& op_args, const ShardArgs& keys, bool async);
  private:
-  using SinkReplyBuilder = facade::SinkReplyBuilder;
 
   static void Del(CmdArgList args, const CommandContext& cmd_cntx);
   static void Unlink(CmdArgList args, const CommandContext& cmd_cntx);

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -883,9 +883,12 @@ TEST_F(GenericFamilyTest, Unlink) {
     }
     auto resp = Run(absl::MakeSpan(cmd));
     ASSERT_THAT(resp, IntArg(10));
+    cmd[1] = "s2";
+    resp = Run(absl::MakeSpan(cmd));
+    ASSERT_THAT(resp, IntArg(10));
   }
-  auto resp = Run({"unlink", "s1"});
-  EXPECT_THAT(resp, IntArg(1));
+  auto resp = Run({"unlink", "s1", "s2"});
+  EXPECT_THAT(resp, IntArg(2));
 }
 
 }  // namespace dfly

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -874,4 +874,18 @@ TEST_F(GenericFamilyTest, Bug4466) {
   EXPECT_THAT(resp, RespElementsAre("0", RespElementsAre()));
 }
 
+TEST_F(GenericFamilyTest, Unlink) {
+  for (unsigned i = 0; i < 1000; ++i) {
+    unsigned start = i * 10;
+    vector<string> cmd = {"SADD", "s1"};
+    for (unsigned j = 0; j < 10; ++j) {
+      cmd.push_back(absl::StrCat("f", start + j));
+    }
+    auto resp = Run(absl::MakeSpan(cmd));
+    ASSERT_THAT(resp, IntArg(10));
+  }
+  auto resp = Run({"unlink", "s1"});
+  EXPECT_THAT(resp, IntArg(1));
+}
+
 }  // namespace dfly

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -1014,7 +1014,7 @@ void StringFamily::Set(CmdArgList args, const CommandContext& cmnd_cntx) {
       if (rel_ms < 0) {
         cmnd_cntx.tx->ScheduleSingleHop([](const Transaction* tx, EngineShard* es) {
           ShardArgs args = tx->GetShardArgs(es->shard_id());
-          GenericFamily::OpDel(tx->GetOpArgs(es), args);
+          GenericFamily::OpDel(tx->GetOpArgs(es), args, false);
           return OpStatus::OK;
         });
         return builder->SendStored();


### PR DESCRIPTION
We currently implement them only for sets but the same approach can work for zset, hashes, lists as well.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->