### PR TITLE
fix cluster: migration crash fix

### DIFF
--- a/src/facade/reply_capture.cc
+++ b/src/facade/reply_capture.cc
@@ -65,6 +65,7 @@ CapturingReplyBuilder::Payload CapturingReplyBuilder::Take() {
   CHECK(stack_.empty());
   Payload pl = std::move(current_);
   current_ = monostate{};
+  ConsumeLastError();
   return pl;
 }
 

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -716,6 +716,7 @@ void DbSlice::FlushSlotsFb(const cluster::SlotSet& slot_ids) {
     PrimeTable* table = GetTables(db_index).first;
 
     auto iterate_bucket = [&](DbIndex db_index, PrimeTable::bucket_iterator it) {
+      it.AdvanceIfNotOccupied();
       while (!it.is_done()) {
         del_entry_cb(it);
         ++it;
@@ -723,7 +724,7 @@ void DbSlice::FlushSlotsFb(const cluster::SlotSet& slot_ids) {
     };
 
     if (const PrimeTable::bucket_iterator* bit = req.update()) {
-      if (bit->GetVersion() < next_version) {
+      if (!bit->is_done() && bit->GetVersion() < next_version) {
         iterate_bucket(db_index, *bit);
       }
     } else {

--- a/src/server/journal/streamer.cc
+++ b/src/server/journal/streamer.cc
@@ -297,7 +297,7 @@ bool RestoreStreamer::ShouldWrite(SlotId slot_id) const {
 bool RestoreStreamer::WriteBucket(PrimeTable::bucket_iterator it) {
   bool written = false;
 
-  if (it.GetVersion() < snapshot_version_) {
+  if (!it.is_done() && it.GetVersion() < snapshot_version_) {
     stats_.buckets_written++;
 
     it.SetVersion(snapshot_version_);

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -390,7 +390,7 @@ void SliceSnapshot::OnDbChange(DbIndex db_index, const DbSlice::ChangeReq& req) 
   const PrimeTable::bucket_iterator* bit = req.update();
 
   if (bit) {
-    if (bit->GetVersion() < snapshot_version_) {
+    if (!bit->is_done() && bit->GetVersion() < snapshot_version_) {
       stats_.side_saved += SerializeBucket(db_index, *bit);
     }
   } else {


### PR DESCRIPTION
fix #4455 
This PR:
1. fix crash in in registered callbacks:
The bug - calling bucket iterator get version will fail if bucket iterator is not valid. This case can happen when we have few callbacks executed on flush changes on earlier buckets. If the first one will remove all data from the bucket, the next call to the next registered callback will call Seek2Occupied and if the bucket is empty the iterator will be invalid.
2. add more test for cluster migration, running traffic while operating several migrations