### PR TITLE
fix(test): fix rdb random fail on OOM

### DIFF
--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -55,9 +55,9 @@ class RdbTest : public BaseFamilyTest {
 };
 
 void RdbTest::SetUp() {
+  max_memory_limit = 40000000;
   InitWithDbFilename();
   CHECK_EQ(zmalloc_used_memory_tl, 0);
-  max_memory_limit = 40000000;
 }
 
 inline const uint8_t* to_byte(const void* s) {

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -55,6 +55,7 @@ class RdbTest : public BaseFamilyTest {
 };
 
 void RdbTest::SetUp() {
+  // Setting max_memory_limit must be before calling  InitWithDbFilename
   max_memory_limit = 40000000;
   InitWithDbFilename();
   CHECK_EQ(zmalloc_used_memory_tl, 0);
@@ -458,8 +459,8 @@ TEST_F(RdbTest, JsonTest) {
 class HllRdbTest : public RdbTest, public testing::WithParamInterface<string> {};
 
 TEST_P(HllRdbTest, Hll) {
-  LOG(ERROR) << " max memory: " << max_memory_limit
-             << " used_mem_current: " << used_mem_current.load();
+  LOG(INFO) << " max memory: " << max_memory_limit
+            << " used_mem_current: " << used_mem_current.load();
   auto ec = LoadRdb("hll.rdb");
 
   ASSERT_FALSE(ec) << ec.message();


### PR DESCRIPTION
The priodic call to CacheStats updates the shard data memory budget
Setting max_memory_limit before InitWithDbFilename ensures that this callback will be called with the correct max_memory_limit value at its first execution