### PR TITLE
chore: add benchmarking of ScanOpts::Matches

### DIFF
--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -498,9 +498,11 @@ TEST_F(DflyEngineTest, StickyEviction) {
   string tmp_val(100, '.');
 
   ssize_t failed = -1;
-  for (ssize_t i = 0; i < 5000; ++i) {
+
+  for (ssize_t i = 0; i < 4500; ++i) {
     string key = StrCat("volatile", i);
     ASSERT_EQ("OK", Run({"set", key, tmp_val}));
+    usleep(1);
   }
 
   bool done = false;
@@ -829,6 +831,8 @@ TEST_F(DflyEngineTest, ReplicaofRejectOnLoad) {
   ASSERT_THAT(res, ErrArg("LOADING Dragonfly is loading the dataset in memory"));
 }
 
+using benchmark::DoNotOptimize;
+
 // TODO: to test transactions with a single shard since then all transactions become local.
 // To consider having a parameter in dragonfly engine controlling number of shards
 // unconditionally from number of cpus. TO TEST BLPOP under multi for single/multi argument case.
@@ -865,5 +869,27 @@ static void BM_ParseDoubleAbsl(benchmark::State& state) {
   }
 }
 BENCHMARK(BM_ParseDoubleAbsl);
+
+static void BM_MatchPattern(benchmark::State& state) {
+  absl::InsecureBitGen eng;
+  string random_val = GetRandomHex(eng, state.range(0));
+  ScanOpts scan_opts;
+  scan_opts.pattern = "*foobar*";
+  while (state.KeepRunning()) {
+    DoNotOptimize(scan_opts.Matches(random_val));
+  }
+}
+BENCHMARK(BM_MatchPattern)->Arg(1000)->Arg(10000);
+
+static void BM_MatchFindSubstr(benchmark::State& state) {
+  absl::InsecureBitGen eng;
+  string random_val = GetRandomHex(eng, state.range(0));
+
+  while (state.KeepRunning()) {
+    DoNotOptimize(random_val.find("foobar"));
+  }
+}
+BENCHMARK(BM_MatchFindSubstr)->Arg(1000)->Arg(10000);
+
 
 }  // namespace dfly


### PR DESCRIPTION
Also, improve robustness of StickyEviction that was failing for me.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->