### PR TITLE
chore: Add Lua force atomicity flag

### DIFF
--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -900,7 +900,7 @@ void ClusterFamily::InitMigration(CmdArgList args, SinkReplyBuilder* builder) {
 
   const auto& incoming_migrations = cluster_config()->GetIncomingMigrations();
   bool found = any_of(incoming_migrations.begin(), incoming_migrations.end(),
-                      [&source_id, &slot_ranges](const MigrationInfo& info) {
+                      [source_id = source_id, &slot_ranges](const MigrationInfo& info) {
                         return info.node_info.id == source_id && info.slot_ranges == slot_ranges;
                       });
   if (!found) {

--- a/src/server/script_mgr.cc
+++ b/src/server/script_mgr.cc
@@ -48,6 +48,13 @@ ABSL_FLAG(
     "Comma-separated list of Lua script SHAs which are allowed to access undeclared keys. SHAs are "
     "only looked at when loading the script, and new values do not affect already-loaded script.");
 
+ABSL_FLAG(std::vector<std::string>, lua_force_atomicity_shas,
+          std::vector<std::string>({
+              "f8133be7f04abd9dfefa83c3b29a9d837cfbda86",  // Sidekiq, see #4522
+          }),
+          "Comma-separated list of Lua script SHAs which are forced to run in atomic mode, even if "
+          "the script specifies disable-atomicity.");
+
 namespace dfly {
 using namespace std;
 using namespace facade;
@@ -264,6 +271,13 @@ io::Result<string, GenericError> ScriptMgr::Insert(string_view body, Interpreter
   if (!params_opt)
     return params_opt.get_unexpected();
   auto params = params_opt->value_or(default_params_);
+
+  if (!params.atomic) {
+    auto force_atomic_shas = absl::GetFlag(FLAGS_lua_force_atomicity_shas);
+    if (find(force_atomic_shas.begin(), force_atomic_shas.end(), sha) != force_atomic_shas.end()) {
+      params.atomic = true;
+    }
+  }
 
   auto undeclared_shas = absl::GetFlag(FLAGS_lua_undeclared_keys_shas);
   if (find(undeclared_shas.begin(), undeclared_shas.end(), sha) != undeclared_shas.end()) {


### PR DESCRIPTION
We accidentally instructed Sidekiq to add `disable-atomicity` to their script, despite them needing to run atomically.

This hack-ish PR adds a `--lua_force_atomicity_shas` flag to allow specifying which SHAs are forced to run in an atomic fashion, even if they are marked as non-atomic.

Fixes #4522

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->