### PR TITLE
chore: clean up of deprecated flags

### DIFF
--- a/src/core/sorted_map.cc
+++ b/src/core/sorted_map.cc
@@ -21,8 +21,6 @@ extern "C" {
 
 using namespace std;
 
-ABSL_RETIRED_FLAG(bool, use_zset_tree, true, "If true use b+tree for zset implementation");
-
 namespace dfly {
 namespace detail {
 

--- a/src/server/container_utils.cc
+++ b/src/server/container_utils.cc
@@ -22,8 +22,6 @@ extern "C" {
 #include "redis/zset.h"
 }
 
-ABSL_FLAG(bool, singlehop_blocking, true, "Use single hop optimization for blocking commands");
-
 namespace dfly::container_utils {
 using namespace std;
 namespace {
@@ -336,7 +334,7 @@ OpResult<string> RunCbOnFirstNonEmptyBlocking(Transaction* trans, int req_obj_ty
   // If we don't find anything, we abort concluding and keep scheduled.
   // Slow path: schedule, find results from shards, execute action if found.
   OpResult<ShardFFResult> result;
-  if (trans->GetUniqueShardCnt() == 1 && absl::GetFlag(FLAGS_singlehop_blocking)) {
+  if (trans->GetUniqueShardCnt() == 1) {
     auto res = FindFirstNonEmptySingleShard(trans, req_obj_type, func);
     if (res.ok()) {
       if (info)

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -49,10 +49,6 @@ ABSL_FLAG(
     int, replica_priority, 100,
     "Published by info command for sentinel to pick replica based on score during a failover");
 
-// TODO: Remove this flag on release >= 1.22
-ABSL_FLAG(bool, replica_reconnect_on_master_restart, false,
-          "Deprecated - please use --break_replication_on_master_restart.");
-
 namespace dfly {
 
 using namespace std;
@@ -339,8 +335,7 @@ std::error_code Replica::HandleCapaDflyResp() {
   // If we're syncing a different replication ID, drop the saved LSNs.
   string_view master_repl_id = ToSV(LastResponseArgs()[0].GetBuf());
   if (master_context_.master_repl_id != master_repl_id) {
-    if ((absl::GetFlag(FLAGS_replica_reconnect_on_master_restart) ||
-         absl::GetFlag(FLAGS_break_replication_on_master_restart)) &&
+    if (absl::GetFlag(FLAGS_break_replication_on_master_restart) &&
         !master_context_.master_repl_id.empty()) {
       LOG(ERROR) << "Encountered different master repl id (" << master_repl_id << " vs "
                  << master_context_.master_repl_id << ")";

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -870,7 +870,6 @@ void ServerFamily::Init(util::AcceptServer* acceptor, std::vector<facade::Listen
   config_registry.RegisterMutable("tls_ca_cert_dir");
   config_registry.RegisterMutable("replica_priority");
   config_registry.RegisterMutable("lua_undeclared_keys_shas");
-  config_registry.RegisterMutable("list_rdb_encode_v2");
 
   pb_task_ = shard_set->pool()->GetNextProactor();
   if (pb_task_->GetKind() == ProactorBase::EPOLL) {

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -480,8 +480,10 @@ class RedisServer:
         self.port = port
         self.proc = None
 
-    def start(self, **kwargs):
-        servers = ["redis-server-6.2.11", "redis-server-7.2.2", "valkey-server-8.0.1"]
+    def start(self, redis7=None, **kwargs):
+        servers = ["redis-server-7.2.2"]
+        if not redis7:
+            servers += ["redis-server-6.2.11", "valkey-server-8.0.1"]
         command = [
             random.choice(servers),
             f"--port {self.port}",

--- a/tests/dragonfly/sentinel_test.py
+++ b/tests/dragonfly/sentinel_test.py
@@ -81,7 +81,7 @@ class Sentinel:
         logging.info(self.config_file.read_text())
 
         self.proc = subprocess.Popen(
-            ["redis-server", f"{self.config_file.absolute()}", "--sentinel"]
+            ["redis-server-6.2.11", f"{self.config_file.absolute()}", "--sentinel"]
         )
 
     def stop(self):

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -154,8 +154,7 @@ async def test_dbfilenames(
     {
         **BASIC_ARGS,
         "proactor_threads": 4,
-        "dbfilename": "test-redis-load-rdb",
-        "list_rdb_encode_v2": "false",  # Needed for compatibility with Redis 6
+        "dbfilename": "test-redis-load-rdb",        
     }
 )
 async def test_redis_load_snapshot(
@@ -176,7 +175,7 @@ async def test_redis_load_snapshot(
     await async_client.connection_pool.disconnect()
     df_server.stop()
 
-    redis_local_server.start(dir=tmp_dir, dbfilename="test-redis-load-rdb.rdb")
+    redis_local_server.start(dir=tmp_dir, redis7=True, dbfilename="test-redis-load-rdb.rdb")
     await asyncio.sleep(1)
     c_master = aioredis.Redis(port=redis_local_server.port)
     await c_master.ping()

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -10,3 +10,5 @@ markers =
   slow: marks tests as slow (deselect with '-m "not slow"')
   opt_only: marks tests that are only reasonable to run against an opt-built Dragonfly
   exclude_epoll: marks tests that should not run on epoll socket
+filterwarnings =
+    ignore::DeprecationWarning


### PR DESCRIPTION
Also fix sentinel test by using a precise redis-server version.
Finally, add pytest warnings filter to reduce noise

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->