### PR TITLE
feat(zset_family): add zdiffstore command

### DIFF
--- a/src/server/zset_family.h
+++ b/src/server/zset_family.h
@@ -57,7 +57,7 @@ class ZSetFamily {
     std::variant<IndexInterval, ScoreInterval, LexInterval, TopNScored> interval;
     RangeParams params;
     ZRangeSpec() = default;
-    ZRangeSpec(const ScoreInterval& si, const RangeParams& rp) : interval(si), params(rp){};
+    ZRangeSpec(const ScoreInterval& si, const RangeParams& rp) : interval(si), params(rp) {};
   };
 
   struct ZParams {
@@ -106,6 +106,7 @@ class ZSetFamily {
   static void ZCard(CmdArgList args, const CommandContext& cmd_cntx);
   static void ZCount(CmdArgList args, const CommandContext& cmd_cntx);
   static void ZDiff(CmdArgList args, const CommandContext& cmd_cntx);
+  static void ZDiffStore(CmdArgList args, const CommandContext& cmd_cntx);
   static void ZIncrBy(CmdArgList args, const CommandContext& cmd_cntx);
   static void ZInterStore(CmdArgList args, const CommandContext& cmd_cntx);
   static void ZInter(CmdArgList args, const CommandContext& cmd_cntx);

--- a/tests/fakeredis/test/test_mixins/test_sortedset_commands.py
+++ b/tests/fakeredis/test/test_mixins/test_sortedset_commands.py
@@ -1155,7 +1155,6 @@ def test_zrandemember(r: redis.Redis):
     assert len(r.zrandmember("a", -10)) == 10
 
 
-@pytest.mark.unsupported_server_types("dragonfly")
 def test_zdiffstore(r: redis.Redis):
     r.zadd("a", {"a1": 1, "a2": 2, "a3": 3})
     r.zadd("b", {"a1": 1, "a2": 2})


### PR DESCRIPTION
Computes the difference between the first and all successive input sorted sets and stores the result in destination.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->