### PR TITLE
fix: consume parser error on dfly load

### DIFF
--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -528,13 +528,7 @@ void DflyCmd::Load(CmdArgList args, RedisReplyBuilder* rb, ConnectionContext* cn
     existing_keys = ServerFamily::LoadExistingKeys::kOverride;
   }
 
-  if (parser.HasNext()) {
-    parser.Error();
-  }
-
-  if (parser.HasError()) {
-    // consume error
-    parser.Error();
+  if (parser.Error() || parser.HasNext()) {
     return rb->SendError(kSyntaxErr);
   }
 

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -533,6 +533,8 @@ void DflyCmd::Load(CmdArgList args, RedisReplyBuilder* rb, ConnectionContext* cn
   }
 
   if (parser.HasError()) {
+    // consume error
+    parser.Error();
     return rb->SendError(kSyntaxErr);
   }
 


### PR DESCRIPTION
`DFLY LOAD` triggers the parser's destructor `DCHECK` which checks if the parsed error was consumed. 

Furthermore, fixes `dfly load path append nonsense` succeeding with `ok` .

* fix dcheck crash on dfly load
* fix dfly load with more than required arguments


IMO do we really need that `DCHECK` in the destructor ? Sometimes, there is no really reason to even consume it (see this PR as an example).

