### PR TITLE
fix server: fix deadlock  blmove does not conclude on error

### DIFF
--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -872,7 +872,7 @@ EngineShard::TxQueueInfo EngineShard::AnalyzeTxQueue() const {
   {
     auto value = queue->At(cur);
     Transaction* trx = std::get<Transaction*>(value);
-    info.head.debug_id_info = trx->DebugId();
+    info.head.debug_id_info = trx->DebugId(sid);
   }
 
   do {

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -1050,6 +1050,7 @@ OpResult<string> BPopPusher::RunPair(time_point tp, Transaction* tx, ConnectionC
     if (op_res.status() == OpStatus::KEY_NOTFOUND) {
       op_res = OpStatus::TIMED_OUT;
     }
+    tx->Conclude();
     return op_res;
   }
 

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -58,7 +58,7 @@ void AnalyzeTxQueue(const EngineShard* shard, const TxQueue* txq) {
                       ", poll_executions:", shard->stats().poll_execution_total);
       const Transaction* cont_tx = shard->GetContTx();
       if (cont_tx) {
-        absl::StrAppend(&msg, " continuation_tx: ", cont_tx->DebugId(), " ",
+        absl::StrAppend(&msg, " continuation_tx: ", cont_tx->DebugId(shard->shard_id()), " ",
                         cont_tx->DEBUG_IsArmedInShard(shard->shard_id()) ? " armed" : "");
       }
       absl::StrAppend(&msg, "\nTxQueue head debug info ", info.head.debug_id_info);
@@ -558,6 +558,7 @@ string Transaction::DebugId(std::optional<ShardId> sid) const {
   absl::StrAppend(&res, " {id=", trans_id(this));
   if (sid) {
     absl::StrAppend(&res, ",mask[", *sid, "]=", int(shard_data_[SidToId(*sid)].local_mask),
+                    ",is_armed=", DEBUG_IsArmedInShard(*sid),
                     ",txqpos[]=", shard_data_[SidToId(*sid)].pq_pos);
   }
   absl::StrAppend(&res, "}");

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -559,7 +559,8 @@ string Transaction::DebugId(std::optional<ShardId> sid) const {
   if (sid) {
     absl::StrAppend(&res, ",mask[", *sid, "]=", int(shard_data_[SidToId(*sid)].local_mask),
                     ",is_armed=", DEBUG_IsArmedInShard(*sid),
-                    ",txqpos[]=", shard_data_[SidToId(*sid)].pq_pos);
+                    ",txqpos[]=", shard_data_[SidToId(*sid)].pq_pos,
+                    ",fail_state_print=", DEBUG_PrintFailState(*sid));
   }
   absl::StrAppend(&res, "}");
   return res;


### PR DESCRIPTION
The bug:
incases where blmove runs on 2 shards and the first hop to run the lmove command will return error f.e wrong type the transaction does not conclude before return. 
Fixes:
1. add conclude on blmove runnning on 2 shards on error flow
2. add more prints to analyze tx 