### PR TITLE
fix: race when bumping items while loading a snapshot

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -283,7 +283,6 @@ DbSlice::DbSlice(uint32_t index, bool cache_mode, EngineShard* owner)
       cache_mode_(cache_mode),
       owner_(owner),
       client_tracking_map_(owner->memory_resource()) {
-  load_in_progress_ = false;
   db_arr_.emplace_back();
   CreateDb(0);
   expire_base_[0] = expire_base_[1] = 0;

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -794,7 +794,8 @@ void DbSlice::FlushDbIndexes(const std::vector<DbIndex>& indexes) {
     std::swap(db_arr_[index]->trans_locks, flush_db_arr[index]->trans_locks);
   }
 
-  CHECK(fetched_items_.empty());
+  LOG_IF(DFATAL, fetched_items_.empty())
+      << "Some operation might bumped up items outside of a transaction";
 
   auto cb = [indexes, flush_db_arr = std::move(flush_db_arr)]() mutable {
     flush_db_arr.clear();

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -794,7 +794,7 @@ void DbSlice::FlushDbIndexes(const std::vector<DbIndex>& indexes) {
     std::swap(db_arr_[index]->trans_locks, flush_db_arr[index]->trans_locks);
   }
 
-  LOG_IF(DFATAL, fetched_items_.empty())
+  LOG_IF(DFATAL, !fetched_items_.empty())
       << "Some operation might bumped up items outside of a transaction";
 
   auto cb = [indexes, flush_db_arr = std::move(flush_db_arr)]() mutable {

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -473,15 +473,15 @@ class DbSlice {
 
   bool IsCacheMode() const {
     // During loading time we never bump elements.
-    return cache_mode_ && (load_in_progress_ == 0);
+    return cache_mode_ && (load_ref_count_ == 0);
   }
 
   void IncrLoadInProgress() {
-    ++load_in_progress_;
+    ++load_ref_count_;
   }
 
   void DecrLoadInProgress() {
-    --load_in_progress_;
+    --load_ref_count_;
   }
 
   // Test hook to inspect last locked keys.
@@ -601,7 +601,7 @@ class DbSlice {
   size_t soft_budget_limit_ = 0;
   size_t table_memory_ = 0;
   uint64_t entries_count_ = 0;
-  size_t load_in_progress_ = 0;
+  unsigned load_ref_count_ = 0;
 
   mutable SliceEvents events_;  // we may change this even for const operations.
 

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -484,11 +484,8 @@ class DbSlice {
     --load_ref_count_;
   }
 
-  bool IsLoadInProgressZeroInCacheMode() const {
-    if (!cache_mode_) {
-      return true;
-    }
-    return IsCacheMode();
+  bool IsLoadRefCountZero() const {
+    return load_ref_count_ == 0;
   }
 
   // Test hook to inspect last locked keys.

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -526,6 +526,10 @@ class DbSlice {
     return &block_counter_;
   }
 
+  bool IsFetchedItemsEmpty() const {
+    return fetched_items_.empty();
+  }
+
  private:
   void PreUpdate(DbIndex db_ind, Iterator it, std::string_view key);
   void PostUpdate(DbIndex db_ind, Iterator it, std::string_view key, size_t orig_size);

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -473,11 +473,15 @@ class DbSlice {
 
   bool IsCacheMode() const {
     // During loading time we never bump elements.
-    return cache_mode_ && !load_in_progress_;
+    return cache_mode_ && (load_in_progress_ == 0);
   }
 
-  void SetLoadInProgress(bool in_progress) {
-    load_in_progress_ = in_progress;
+  void IncrLoadInProgress() {
+    ++load_in_progress_;
+  }
+
+  void DecrLoadInProgress() {
+    --load_in_progress_;
   }
 
   // Test hook to inspect last locked keys.
@@ -585,7 +589,6 @@ class DbSlice {
 
   ShardId shard_id_;
   uint8_t cache_mode_ : 1;
-  uint8_t load_in_progress_ : 1;
 
   EngineShard* owner_;
 
@@ -598,6 +601,7 @@ class DbSlice {
   size_t soft_budget_limit_ = 0;
   size_t table_memory_ = 0;
   uint64_t entries_count_ = 0;
+  size_t load_in_progress_ = 0;
 
   mutable SliceEvents events_;  // we may change this even for const operations.
 

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -484,6 +484,13 @@ class DbSlice {
     --load_ref_count_;
   }
 
+  bool IsLoadInProgressZeroInCacheMode() const {
+    if (!cache_mode_) {
+      return true;
+    }
+    return IsCacheMode();
+  }
+
   // Test hook to inspect last locked keys.
   const auto& TEST_GetLastLockedFps() const {
     return uniq_fps_;
@@ -524,10 +531,6 @@ class DbSlice {
 
   LocalBlockingCounter* BlockingCounter() {
     return &block_counter_;
-  }
-
-  bool IsFetchedItemsEmpty() const {
-    return fetched_items_.empty();
   }
 
  private:

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2513,7 +2513,7 @@ GlobalState Service::SwitchState(GlobalState from, GlobalState to) {
     auto* es = EngineShard::tlocal();
     if (es && to == GlobalState::ACTIVE) {
       DbSlice& db = namespaces->GetDefaultNamespace().GetDbSlice(es->shard_id());
-      DCHECK(db.IsFetchedItemsEmpty());
+      DCHECK(db.IsLoadInProgressZeroInCacheMode());
     }
   });
   return to;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2513,7 +2513,7 @@ GlobalState Service::SwitchState(GlobalState from, GlobalState to) {
     auto* es = EngineShard::tlocal();
     if (es && to == GlobalState::ACTIVE) {
       DbSlice& db = namespaces->GetDefaultNamespace().GetDbSlice(es->shard_id());
-      DCHECK(db.IsLoadInProgressZeroInCacheMode());
+      DCHECK(db.IsLoadRefCountZero());
     }
   });
   return to;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2508,7 +2508,14 @@ GlobalState Service::SwitchState(GlobalState from, GlobalState to) {
   VLOG(1) << "Switching state from " << from << " to " << to;
   global_state_ = to;
 
-  pp_.Await([&](ProactorBase*) { ServerState::tlocal()->set_gstate(to); });
+  pp_.Await([&](ProactorBase*) {
+    ServerState::tlocal()->set_gstate(to);
+    auto* es = EngineShard::tlocal();
+    if (es && to == GlobalState::ACTIVE) {
+      DbSlice& db = namespaces->GetDefaultNamespace().GetDbSlice(es->shard_id());
+      DCHECK(db.IsFetchedItemsEmpty());
+    }
+  });
   return to;
 }
 

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2034,6 +2034,11 @@ error_code RdbLoader::Load(io::Source* src) {
 
   auto cleanup = absl::Cleanup([&] { FinishLoad(start, &keys_loaded); });
 
+  // Increment local one if it exists
+  if (EngineShard* es = EngineShard::tlocal(); es) {
+    namespaces->GetDefaultNamespace().GetCurrentDbSlice().IncrLoadInProgress();
+  }
+
   while (!stop_early_.load(memory_order_relaxed)) {
     if (pause_) {
       ThisFiber::SleepFor(100ms);
@@ -2226,6 +2231,10 @@ void RdbLoader::FinishLoad(absl::Time start_time, size_t* keys_loaded) {
     shard_set->Add(i, [bc]() mutable { bc->Dec(); });
   }
   bc->Wait();  // wait for sentinels to report.
+  // Decrement local one if it exists
+  if (EngineShard* es = EngineShard::tlocal(); es) {
+    namespaces->GetDefaultNamespace().GetCurrentDbSlice().IncrLoadInProgress();
+  }
 
   absl::Duration dur = absl::Now() - start_time;
   load_time_ = double(absl::ToInt64Milliseconds(dur)) / 1000;
@@ -2509,7 +2518,12 @@ void RdbLoader::FlushShardAsync(ShardId sid) {
     return;
 
   auto cb = [indx = this->cur_db_index_, this, ib = std::move(out_buf)] {
+    // Before we start loading, increment LoadInProgress.
+    // This is required because FlushShardAsync dispatches to multiple shards, and those shards
+    // might have not yet have their state (load in progress) incremented.
+    namespaces->GetDefaultNamespace().GetCurrentDbSlice().IncrLoadInProgress();
     this->LoadItemsBuffer(indx, ib);
+    namespaces->GetDefaultNamespace().GetCurrentDbSlice().DecrLoadInProgress();
 
     // Block, if tiered storage is active, but can't keep up
     while (EngineShard::tlocal()->ShouldThrottleForTiering()) {
@@ -2547,6 +2561,8 @@ void RdbLoader::LoadItemsBuffer(DbIndex db_ind, const ItemsBuf& ib) {
   EngineShard* es = EngineShard::tlocal();
   DbContext db_cntx{&namespaces->GetDefaultNamespace(), db_ind, GetCurrentTimeMs()};
   DbSlice& db_slice = db_cntx.GetDbSlice(es->shard_id());
+
+  DCHECK(!db_slice.IsCacheMode());
 
   auto error_msg = [](const auto* item, auto db_ind) {
     return absl::StrCat("Found empty key: ", item->key, " in DB ", db_ind, " rdb_type ",

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2233,7 +2233,7 @@ void RdbLoader::FinishLoad(absl::Time start_time, size_t* keys_loaded) {
   bc->Wait();  // wait for sentinels to report.
   // Decrement local one if it exists
   if (EngineShard* es = EngineShard::tlocal(); es) {
-    namespaces->GetDefaultNamespace().GetCurrentDbSlice().IncrLoadInProgress();
+    namespaces->GetDefaultNamespace().GetCurrentDbSlice().DecrLoadInProgress();
   }
 
   absl::Duration dur = absl::Now() - start_time;

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2034,9 +2034,6 @@ error_code RdbLoader::Load(io::Source* src) {
 
   auto cleanup = absl::Cleanup([&] { FinishLoad(start, &keys_loaded); });
 
-  shard_set->AwaitRunningOnShardQueue([](EngineShard* es) {
-    namespaces->GetDefaultNamespace().GetCurrentDbSlice().SetLoadInProgress(true);
-  });
   while (!stop_early_.load(memory_order_relaxed)) {
     if (pause_) {
       ThisFiber::SleepFor(100ms);
@@ -2226,10 +2223,7 @@ void RdbLoader::FinishLoad(absl::Time start_time, size_t* keys_loaded) {
     FlushShardAsync(i);
 
     // Send sentinel callbacks to ensure that all previous messages have been processed.
-    shard_set->Add(i, [bc]() mutable {
-      namespaces->GetDefaultNamespace().GetCurrentDbSlice().SetLoadInProgress(false);
-      bc->Dec();
-    });
+    shard_set->Add(i, [bc]() mutable { bc->Dec(); });
   }
   bc->Wait();  // wait for sentinels to report.
 

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -735,4 +735,19 @@ TEST_F(RdbTest, HugeKeyIssue4497) {
   EXPECT_EQ(Run({"flushall"}), "OK");
 }
 
+TEST_F(RdbTest, HugeKeyIssue4554) {
+  SetTestFlag("cache_mode", "true");
+  // We need to stress one flow/shard such that the others finish early. Lock on hashtags allows
+  // that.
+  SetTestFlag("lock_on_hashtags", "true");
+  ResetService();
+
+  EXPECT_EQ(
+      Run({"debug", "populate", "20", "{tmp}", "20", "rand", "type", "set", "elements", "10000"}),
+      "OK");
+  EXPECT_EQ(Run({"save", "df", "hugekey"}), "OK");
+  EXPECT_EQ(Run({"dfly", "load", "hugekey-summary.dfs"}), "OK");
+  EXPECT_EQ(Run({"flushall"}), "OK");
+}
+
 }  // namespace dfly

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -542,21 +542,7 @@ error_code Replica::InitiateDflySync() {
     // Lock to prevent the error handler from running instantly
     // while the flows are in a mixed state.
     lock_guard lk{flows_op_mu_};
-    absl::Cleanup clean = [this]() {
-      shard_set->AwaitRunningOnShardQueue([](EngineShard* es) {
-        namespaces->GetDefaultNamespace().GetCurrentDbSlice().SetLoadInProgress(false);
-      });
-    };
 
-    // See issue #4554
-    // We really need two dispatches here because StartSyncFlow executes on different shards.
-    // If the sync fiber on one of the threads, starts, loads the snapshots and starts flushing
-    // the loaded data to the shards asynchronously via LoadItemsBuffer() while the other thread
-    // did not even spawned the Sync flow fiber, it will start Bumping items because
-    // SetLoadInProgress will still be false.
-    shard_set->AwaitRunningOnShardQueue([](EngineShard* es) {
-      namespaces->GetDefaultNamespace().GetCurrentDbSlice().SetLoadInProgress(true);
-    });
     shard_set->pool()->AwaitFiberOnAll(std::move(shard_cb));
 
     size_t num_full_flows =

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1100,6 +1100,11 @@ std::optional<fb2::Future<GenericError>> ServerFamily::Load(string_view load_pat
     return immediate(expand_result.error());
   }
 
+  // See issue #4554
+  shard_set->AwaitRunningOnShardQueue([](EngineShard* es) {
+    namespaces->GetDefaultNamespace().GetCurrentDbSlice().SetLoadInProgress(true);
+  });
+
   auto new_state = service_.SwitchState(GlobalState::ACTIVE, GlobalState::LOADING);
   if (new_state != GlobalState::LOADING) {
     LOG(WARNING) << new_state << " in progress, ignored";
@@ -1155,6 +1160,11 @@ std::optional<fb2::Future<GenericError>> ServerFamily::Load(string_view load_pat
 
     service_.SwitchState(GlobalState::LOADING, GlobalState::ACTIVE);
     future.Resolve(*(aggregated_result->first_error));
+    // See issue #4554
+    // Once we are done we need to clean the state
+    shard_set->AwaitRunningOnShardQueue([](EngineShard* es) {
+      namespaces->GetDefaultNamespace().GetCurrentDbSlice().SetLoadInProgress(false);
+    });
   };
   pool.GetNextProactor()->Dispatch(std::move(load_join_func));
 


### PR DESCRIPTION
The original issue was submitted in #4497 and we supplied a fix in #4507. However, the fix ignored that the `RdbLoader::Load()` function is run per flow/shard thread and the "poison pill" of updating the loading state at the end of `RdbLoader::Load()` introduced a race condition:

```
shard_set->Add(i, [bc]() mutable {
      namespaces->GetDefaultNamespace().GetCurrentDbSlice().SetLoadInProgress(false);
      bc->Dec();
    }); 
```

Any flow `F` that finished loading its own snapshot first (relatively to the rest of the flows) will call `SetLoadInProgress(false)` on *ALL* shard threads. The consequence of that is that other flows are not yet done (their respective RdbLoader::Load()` is still processing) and next time the use the db slice API will start Bumping up items because now load in progress is false.

The fix is to update the state after all shard flows are done and similarly to update all shard flow `before` we start the `Load()` which shall provide a consistent state/view among all shard threads.

Should resolve #4554


P.s. we might be able to simplify the new db slice state via the global loading state. That's something I will need to follow but I won't do this as part of this PR.
