### PR TITLE
fix(seeder): Support stream types in the Seeder

### DIFF
--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -524,9 +524,7 @@ error_code RdbSerializer::SaveStreamObject(const PrimeValue& pv) {
     RETURN_ON_ERR(SaveString((uint8_t*)ri.key, ri.key_len));
     RETURN_ON_ERR(SaveString(lp, lp_bytes));
 
-    const FlushState flush_state =
-        (i + 1 < rax_size) ? FlushState::kFlushMidEntry : FlushState::kFlushEndEntry;
-    FlushIfNeeded(flush_state);
+    FlushIfNeeded(FlushState::kFlushMidEntry);
   }
 
   std::move(stop_listpacks_rax).Invoke();
@@ -594,6 +592,8 @@ error_code RdbSerializer::SaveStreamObject(const PrimeValue& pv) {
       RETURN_ON_ERR(SaveStreamConsumers(rdb_type >= RDB_TYPE_STREAM_LISTPACKS_3, cg));
     }
   }
+
+  FlushIfNeeded(FlushState::kFlushEndEntry);
 
   return error_code{};
 }

--- a/tests/dragonfly/seeder/__init__.py
+++ b/tests/dragonfly/seeder/__init__.py
@@ -18,8 +18,7 @@ except ImportError:
 class SeederBase:
     UID_COUNTER = 1  # multiple generators should not conflict on keys
     CACHED_SCRIPTS = {}
-    DEFAULT_TYPES = ["STRING", "LIST", "SET", "HASH", "ZSET", "JSON"]
-    BIG_VALUE_TYPES = ["LIST", "SET", "HASH", "ZSET"]
+    DEFAULT_TYPES = ["STRING", "LIST", "SET", "HASH", "ZSET", "JSON", "STREAM"]
 
     def __init__(self, types: typing.Optional[typing.List[str]] = None):
         self.uid = SeederBase.UID_COUNTER

--- a/tests/dragonfly/seeder/script-genlib.lua
+++ b/tests/dragonfly/seeder/script-genlib.lua
@@ -192,6 +192,34 @@ function LG_funcs.mod_json(key, dbsize)
     end
 end
 
+-- streams
+-- store sequences of timestamped events
+
+function LG_funcs.add_stream(key)
+    local entries = {}
+
+    local limit = LG_funcs.csize
+    local blobs = randstr_sequence()
+
+    for i = 1, limit do
+        table.insert(entries, tostring(i))
+        table.insert(entries, blobs[i])
+    end
+
+    redis.apcall('XADD', key, '*', unpack(entries))
+end
+
+function LG_funcs.mod_stream(key)
+    local action = math.random(1, 3)
+    if action <= 2 then
+        local size = LG_funcs.csize * 2
+        redis.apcall('XADD', key, '*', math.random(0, size), randstr())
+    else
+        local maxlen = math.random(0, 100)
+        redis.apcall('XTRIM', key, 'MAXLEN', '~', maxlen)
+    end
+end
+
 function LG_funcs.get_huge_entries()
   return huge_entries
 end

--- a/tests/dragonfly/seeder_test.py
+++ b/tests/dragonfly/seeder_test.py
@@ -13,7 +13,7 @@ async def test_static_seeder(async_client: aioredis.Redis):
     s = StaticSeeder(key_target=10_000, data_size=100)
     await s.run(async_client)
 
-    assert abs(await async_client.dbsize() - 10_000) <= 50
+    assert abs(await async_client.dbsize() - 10_000) <= 70
 
 
 @dfly_args({"proactor_threads": 4})


### PR DESCRIPTION
fixes dragonflydb#4573

I can confirm that the seeder detects a difference if there is a bug in the replication of STREAMs