### PR TITLE
fix: incorrect passing of db_index in EVAL transactions

### DIFF
--- a/src/server/list_family_test.cc
+++ b/src/server/list_family_test.cc
@@ -1337,5 +1337,18 @@ TEST_F(ListFamilyTest, AwakeMulti) {
   f3.Join();
 }
 
+TEST_F(ListFamilyTest, AwakeDb1) {
+  const char* kDbId = "1";
+
+  auto f1 = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] {
+    Run("C", {"SELECT", kDbId});
+    Run("C", {"brpoplpush", "x", "y", "0"});
+    ASSERT_EQ(GetDebugInfo("C").shards_count, 1);
+  });
+  Run({"SELECT", kDbId});
+  Run({"EVAL", "redis.call('LPUSH', KEYS[1], 'val'); return 1;", "1", "x"});
+  f1.Join();
+}
+
 #pragma GCC diagnostic pop
 }  // namespace dfly

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1978,7 +1978,7 @@ void Service::EvalInternal(CmdArgList args, const EvalArgs& eval_args, Interpret
     });
 
     ++ServerState::tlocal()->stats.eval_shardlocal_coordination_cnt;
-    tx->PrepareMultiForScheduleSingleHop(cntx->ns, *sid, tx->GetDbIndex(), args);
+    tx->PrepareMultiForScheduleSingleHop(cntx->ns, *sid, cntx->db_index(), args);
     tx->ScheduleSingleHop([&](Transaction*, EngineShard*) {
       boost::intrusive_ptr<Transaction> stub_tx =
           new Transaction{tx, *sid, slot_checker.GetUniqueSlotId()};


### PR DESCRIPTION
Before this PR, EVAL transactions would always use db_index=0 leading to inconsistent interactions with other commands on non-zero databases. Specifically the test in the PR would deadlock.

This PR fixes the issue. Also fixes #4583

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->