### PR TITLE
test: add ClusterEvalCrossslot

### DIFF
--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -480,6 +480,21 @@ TEST_F(ClusterFamilyTest, ClusterSlotsPopulate) {
   }
 }
 
+TEST_F(ClusterFamilyTest, ClusterEvalCrossslot) {
+  ConfigSingleNodeCluster(GetMyId());
+
+  auto res = Run({"EVAL", "return redis.call('MSET', 'x1', 'x1', 'x2', 'x2', 'x3', 'x3');", "3",
+                  "x1", "x2", "x3"});
+
+  EXPECT_THAT(res, ErrArg("CROSSSLOT"));
+
+  auto sha =
+      Run({"SCRPIT", "LOAD", "return redis.call('MSET', 'x1', 'x1', 'x2', 'x2', 'x3', 'x3');", "3",
+           "x1", "x2", "x3"});
+
+  EXPECT_THAT(Run({"EVALSHA", sha.GetString(), "3", "x1", "x2", "x3"}), ErrArg("CROSSSLOT"));
+}
+
 TEST_F(ClusterFamilyTest, ClusterConfigDeleteSlots) {
   ConfigSingleNodeCluster(GetMyId());
 


### PR DESCRIPTION
I wasn't sure that EVAL works correctly with cluster so decided to add tests for CROSSSLOT error