### PR TITLE
fix(server): list move on single shard wake blocking transaction

### DIFF
--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -250,6 +250,10 @@ OpResult<string> OpMoveSingleShard(const OpArgs& op_args, string_view src, strin
                           GetFlag(FLAGS_list_compress_depth));
       dest_res.it->second.InitRobj(OBJ_LIST, OBJ_ENCODING_QUICKLIST, dest_ql);
     }
+    auto blocking_controller = op_args.db_cntx.ns->GetBlockingController(op_args.shard->shard_id());
+    if (blocking_controller) {
+      blocking_controller->AwakeWatched(op_args.db_cntx.db_index, dest);
+    }
   } else {
     if (dest_res.it->second.ObjType() != OBJ_LIST)
       return OpStatus::WRONG_TYPE;
@@ -380,9 +384,6 @@ OpResult<uint32_t> OpPush(const OpArgs& op_args, std::string_view key, ListDir d
   if (res.is_new) {
     auto blocking_controller = op_args.db_cntx.ns->GetBlockingController(es->shard_id());
     if (blocking_controller) {
-      string tmp;
-      string_view key = res.it->first.GetSlice(&tmp);
-
       blocking_controller->AwakeWatched(op_args.db_cntx.db_index, key);
     }
   }
@@ -1012,8 +1013,6 @@ OpResult<string> BPopPusher::RunSingle(time_point tp, Transaction* tx, Connectio
       }
       auto blocking_controller = t->GetNamespace().GetBlockingController(shard->shard_id());
       if (blocking_controller) {
-        string tmp;
-
         blocking_controller->AwakeWatched(op_args.db_cntx.db_index, push_key_);
       }
     }

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -1011,12 +1011,7 @@ OpResult<string> BPopPusher::RunSingle(time_point tp, Transaction* tx, Connectio
         std::array<string_view, 4> arr = {pop_key_, push_key_, DirToSv(popdir_), DirToSv(pushdir_)};
         RecordJournal(op_args, "LMOVE", arr, 1);
       }
-      auto blocking_controller = t->GetNamespace().GetBlockingController(shard->shard_id());
-      if (blocking_controller) {
-        blocking_controller->AwakeWatched(op_args.db_cntx.db_index, push_key_);
-      }
     }
-
     return OpStatus::OK;
   };
   tx->Execute(cb_move, false);

--- a/src/server/list_family_test.cc
+++ b/src/server/list_family_test.cc
@@ -700,6 +700,22 @@ TEST_F(ListFamilyTest, BRPopLPushSingleShardBug2857) {
   EXPECT_THAT(resp, ArgType(RespExpr::NIL_ARRAY));
 }
 
+TEST_F(ListFamilyTest, BRPopLPushSingleShardBug4569) {
+  RespExpr resp;
+  auto fb0 = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] { resp = Run({"brpop", "x", "0"}); });
+  WaitUntilLocked(0, "x");
+
+  ASSERT_TRUE(IsLocked(0, "x"));
+  Run({"lpush", "y", "val"});
+  Run({"rpoplpush", "y", "x"});
+  ASSERT_EQ(1, GetDebugInfo().shards_count);
+  fb0.Join();
+  EXPECT_THAT(resp, ArgType(RespExpr::ARRAY));
+  EXPECT_THAT(resp.GetVec(), ElementsAre("x", "val"));
+  ASSERT_EQ(0, NumWatched());
+  ASSERT_FALSE(IsLocked(0, "x"));
+}
+
 TEST_F(ListFamilyTest, BRPopLPushSingleShardBlocking) {
   RespExpr resp;
 
@@ -1306,7 +1322,6 @@ TEST_F(ListFamilyTest, LMPopWrongType) {
   resp = Run({"lmpop", "2", "l1", "foo", "left"});
   EXPECT_THAT(resp, RespArray(ElementsAre("l1", RespArray(ElementsAre("e1")))));
 }
-
 
 // Reproduce a flow that trigerred a wrong DCHECK in the transaction flow.
 TEST_F(ListFamilyTest, AwakeMulti) {

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -177,8 +177,6 @@ OpResult<DbSlice::ItAndUpdater> FindZEntry(const ZSetFamily::ZParams& zparams,
 
   auto* blocking_controller = op_args.db_cntx.ns->GetBlockingController(op_args.shard->shard_id());
   if (add_res.is_new && blocking_controller) {
-    string tmp;
-    string_view key = it->first.GetSlice(&tmp);
     blocking_controller->AwakeWatched(op_args.db_cntx.db_index, key);
   }
 


### PR DESCRIPTION
fixes #4569 
The bug:
When calling list move (rpoplpush/ lmove/ lpoprpush) in a single shard flow we did not awake blocking transaction.
The fix:
call AwakeWatched from this flow
