### PR TITLE
fix(stream_family): Fix replication for the XADD and XTRIM commands

### DIFF
--- a/src/core/interpreter.cc
+++ b/src/core/interpreter.cc
@@ -76,8 +76,7 @@ struct StringCollectorTranslator : public ObjectExplorer {
     values.emplace_back(str);
   }
   void OnArrayStart(unsigned len) final {
-    CHECK(values.empty());
-    values.reserve(len);
+    values.reserve(values.size() + len);
   }
   void OnArrayEnd() final {
   }

--- a/src/redis/stream.h
+++ b/src/redis/stream.h
@@ -125,9 +125,6 @@ typedef struct {
 /* Prototypes of exported APIs. */
 // struct client;
 
-// Use this to in streamTrimByLength and streamTrimByID
-#define NO_TRIM_LIMIT (-1)
-
 /* Flags for streamCreateConsumer */
 #define SCC_DEFAULT       0
 #define SCC_NO_NOTIFY     (1<<0) /* Do not notify key space if consumer created */
@@ -166,12 +163,9 @@ int streamAppendItem(stream *s, robj **argv, int64_t numfields, streamID *added_
 int streamDeleteItem(stream *s, streamID *id);
 void streamGetEdgeID(stream *s, int first, int skip_tombstones, streamID *edge_id);
 long long streamEstimateDistanceFromFirstEverEntry(stream *s, streamID *id);
-int64_t streamTrim(stream *s, streamAddTrimArgs *args, streamID *last_id);
-
-// If you don't want to specify a limit, use NO_TRIM_LIMIT
-int64_t streamTrimByLength(stream *s, long long maxlen, int approx, streamID *last_id, long long limit);
-int64_t streamTrimByID(stream *s, streamID minid, int approx, streamID *last_id, long long limit);
-
+int64_t streamTrim(stream *s, streamAddTrimArgs *args);
+int64_t streamTrimByLength(stream *s, long long maxlen, int approx);
+int64_t streamTrimByID(stream *s, streamID minid, int approx);
 void streamFreeCG(streamCG *cg);
 void streamDelConsumer(streamCG *cg, streamConsumer *consumer);
 void streamLastValidID(stream *s, streamID *maxid);

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2770,3 +2770,13 @@ async def test_stream_approximate_trimming(df_factory):
     master_data = await StaticSeeder.capture(c_master)
     replica_data = await StaticSeeder.capture(c_replica)
     assert master_data == replica_data
+
+    # Step 3: Trim all streams to 0
+    for i in range(num_streams):
+        stream_name = f"stream{i}"
+        await c_master.execute_command("XTRIM", stream_name, "MAXLEN", "0")
+
+    # Check replica data consistent
+    master_data = await StaticSeeder.capture(c_master)
+    replica_data = await StaticSeeder.capture(c_replica)
+    assert master_data == replica_data

--- a/tests/dragonfly/seeder/script-hashlib.lua
+++ b/tests/dragonfly/seeder/script-hashlib.lua
@@ -29,3 +29,7 @@ function LH_funcs.json(key, hash)
     -- add values to hash, note JSON.GET returns just a string
     return dragonfly.ihash(hash, false, 'JSON.GET', key)
 end
+
+function LH_funcs.stream(key, hash)
+    return dragonfly.ihash(hash, false, 'XRANGE', key, '-', '+')
+end


### PR DESCRIPTION
Following [this comment](https://github.com/dragonflydb/dragonfly/pull/4574#discussion_r1949631279), this PR reverts the changes to the Redis code made in the PR #4448.

Some of the logic is copied from the Seeder's PR:
> ...
> 3. Fix bug when the whole stream was removed after trimming
> 4. Add full removal to the Python test
> 5. Add logs to the XADD command

Also, I added hash calculation for the streams in the seeder here, so `StaticSeeder.capture` works correctly. The `test_stream_approximate_trimming` test passes, confirming that the replication logic works properly.


