### PR TITLE
fix: debian path in dragonfly.service

### DIFF
--- a/tools/packaging/debian/dragonfly.service
+++ b/tools/packaging/debian/dragonfly.service
@@ -6,7 +6,7 @@ Documentation=
 [Service]
 Type=simple
 EnvironmentFile=-/etc/dragonfly/environment
-ExecStart=/usr/local/bin/dragonfly --flagfile=/etc/dragonfly/dragonfly.conf
+ExecStart=/usr/bin/dragonfly --flagfile=/etc/dragonfly/dragonfly.conf
 PIDFile=/var/run/dragonfly/dragonfly.pid
 TimeoutStopSec=infinity
 Restart=always

--- a/tools/packaging/rpm/dragonfly.service
+++ b/tools/packaging/rpm/dragonfly.service
@@ -1,1 +1,43 @@
-../debian/dragonfly.service
+[Unit]
+Description=Modern and fast key-value store
+After=network.target
+Documentation=
+
+[Service]
+Type=simple
+EnvironmentFile=-/etc/dragonfly/environment
+ExecStart=/usr/local/bin/dragonfly --flagfile=/etc/dragonfly/dragonfly.conf
+PIDFile=/var/run/dragonfly/dragonfly.pid
+TimeoutStopSec=infinity
+Restart=always
+User=dfly
+Group=dfly
+RuntimeDirectory=dragonfly
+RuntimeDirectoryMode=2755
+
+UMask=007
+PrivateTmp=yes
+LimitNOFILE=262144
+PrivateDevices=yes
+ProtectHome=yes
+ProtectSystem=full
+
+ReadWritePaths=-/var/lib/dragonfly
+ReadWritePaths=-/var/log/dragonfly
+ReadWritePaths=-/var/run/dragonfly
+
+NoNewPrivileges=true
+CapabilityBoundingSet=CAP_SETGID CAP_SETUID CAP_SYS_RESOURCE
+MemoryDenyWriteExecute=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictRealtime=true
+RestrictNamespaces=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
+
+
+[Install]
+WantedBy=multi-user.target
+Alias=dragonfly.service


### PR DESCRIPTION
Split the rpm service file from debian.
Fixes #4593

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->