### PR TITLE
[do not review] fix: remove explicit CXX from reflex third party

### DIFF
--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -106,17 +106,18 @@ jobs:
           # Furthermore, keep in mind that on macos-15, /Applications/Xcode.app/... have been moved to /Library/Developer
           # so if we upgrade this flow to use a newer version this might fail.
           export CPPFLAGS="-isysroot $(xcrun --sdk macosx --show-sdk-path)"
-          ls -lah /Library/Developer/CommandLineTools/usr/bin
+          export CCFLAGS="-isysroot $(xcrun --sdk macosx --show-sdk-path)"
+          #ls -lah /Library/Developer/CommandLineTools/usr/bin/clang
 
-          echo "next ls"
+          #echo "next ls"
 
-          ls -lah /Library/Developer/
+          #ls -lah /Library/Developer/
 
 
           bison --version
 
           echo "*************************** START BUILDING **************************************"
-          CC=/usr/bin/cc CXX=/usr/bin/c++ cmake .. -DCMAKE_BUILD_TYPE=Debug -GNinja -DWITH_UNWIND=OFF \
+          CC=/Library/Developer/CommandLineTools/usr/bin/clang CXX=/Library/Developer/CommandLineTools/usr/bin/clang++ cmake .. -DCMAKE_BUILD_TYPE=Debug -GNinja -DWITH_UNWIND=OFF \
             -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_FLAGS="-Wl,-ld_classic,-Wno-error=unused-command-line-argument"
 
           ninja src/all

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -102,15 +102,15 @@ jobs:
           cd $GITHUB_WORKSPACE/build
 
           export PATH=/usr/local/opt/bison/bin:$PATH
-          which clang
-          clang --version
-          which clang++
-          clang++ --version
+          which /usr/bin/clang
+          /usr/bin/clang --version
+          which /usr/bin/clang++
+          /usr/bin/clang++ --version
 
           bison --version
 
           echo "*************************** START BUILDING **************************************"
-          CC=clang CXX=clang++ cmake .. -DCMAKE_BUILD_TYPE=Debug -GNinja -DWITH_UNWIND=OFF \
+          CC=/usr/bin/clang CXX=/usr/bin/clang++ cmake .. -DCMAKE_BUILD_TYPE=Debug -GNinja -DWITH_UNWIND=OFF \
             -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_FLAGS="-Wl,-ld_classic,-Wno-error=unused-command-line-argument"
 
           ninja src/all

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -118,7 +118,7 @@ jobs:
 
           echo "*************************** START BUILDING **************************************"
           CC=/Library/Developer/CommandLineTools/usr/bin/clang CXX=/Library/Developer/CommandLineTools/usr/bin/clang++ cmake .. -DCMAKE_BUILD_TYPE=Debug -GNinja -DWITH_UNWIND=OFF \
-            -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_FLAGS="-Wl,-ld_classic,-Wno-error=unused-command-line-argument"
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_FLAGS="-Wl,-Wno-error=unused-command-line-argument"
 
           ninja src/all
 

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -102,15 +102,15 @@ jobs:
           cd $GITHUB_WORKSPACE/build
 
           export PATH=/usr/local/opt/bison/bin:$PATH
-          which /usr/bin/clang
-          /usr/bin/clang --version
-          which /usr/bin/clang++
-          /usr/bin/clang++ --version
+          which /usr/bin/c++
+          /usr/bin/c++ --version
+          which /usr/bin/c
+          /usr/bin/c --version
 
           bison --version
 
           echo "*************************** START BUILDING **************************************"
-          CC=/usr/bin/clang CXX=/usr/bin/clang++ cmake .. -DCMAKE_BUILD_TYPE=Debug -GNinja -DWITH_UNWIND=OFF \
+          CC=/usr/bin/c CXX=/usr/bin/c++ cmake .. -DCMAKE_BUILD_TYPE=Debug -GNinja -DWITH_UNWIND=OFF \
             -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_FLAGS="-Wl,-ld_classic,-Wno-error=unused-command-line-argument"
 
           ninja src/all

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -101,11 +101,18 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/build
 
-          export PATH=/usr/local/opt/bison/bin:$PATH
-          which /usr/bin/c++
-          /usr/bin/c++ --version
-          which /usr/bin/cc
-          /usr/bin/cc --version
+          echo "Paths for /usr/bin/clang++"
+          /usr/bin/clang++ -###
+          #          export PATH=/usr/local/opt/bison/bin:$PATH
+          #          which /usr/bin/c++
+          #          /usr/bin/c++ --version
+          #          which /usr/bin/cc
+          #          /usr/bin/cc --version
+          echo "Paths for /usr/bin/c++"
+          /usr/bin/c++ -###
+
+          echo "Paths for /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++"
+          /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -###
 
           xcode-select -p
           # Use proper toolchain

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -100,6 +100,7 @@ jobs:
       - name: Configure & Build
         run: |
           cd $GITHUB_WORKSPACE/build
+          export PATH=/usr/local/opt/bison/bin:$PATH
 
           # We need -isysroot such that we fetch both include and lib dirs for standard library
           # On macos-15 /usr/bin/cc or /usr/bin/clang does this automatically. However for macos-13 it seems that this is not the case.
@@ -117,7 +118,7 @@ jobs:
           bison --version
 
           echo "*************************** START BUILDING **************************************"
-          CC=/Library/Developer/CommandLineTools/usr/bin/clang CXX=/Library/Developer/CommandLineTools/usr/bin/clang++ cmake .. -DCMAKE_BUILD_TYPE=Debug -GNinja -DWITH_UNWIND=OFF \
+          CC=/usr/bin/cc CXX=/usr/bin/c++ cmake .. -DCMAKE_BUILD_TYPE=Debug -GNinja -DWITH_UNWIND=OFF \
             -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_FLAGS="-Wl"
 
           ninja src/all

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -118,7 +118,7 @@ jobs:
           bison --version
 
           echo "*************************** START BUILDING **************************************"
-          CC=/usr/bin/cc CXX=/usr/bin/c++ cmake .. -DCMAKE_BUILD_TYPE=Debug -GNinja -DWITH_UNWIND=OFF \
+          CC=/usr/bin/clang CXX=/usr/bin/clang++ cmake .. -DCMAKE_BUILD_TYPE=Debug -GNinja -DWITH_UNWIND=OFF \
             -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_FLAGS="-Wl"
 
           ninja src/all

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -107,6 +107,10 @@ jobs:
           which /usr/bin/cc
           /usr/bin/cc --version
 
+          xcode-select -p
+          # Use proper toolchain
+          sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+
           bison --version
 
           echo "*************************** START BUILDING **************************************"

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -118,7 +118,7 @@ jobs:
 
           echo "*************************** START BUILDING **************************************"
           CC=/Library/Developer/CommandLineTools/usr/bin/clang CXX=/Library/Developer/CommandLineTools/usr/bin/clang++ cmake .. -DCMAKE_BUILD_TYPE=Debug -GNinja -DWITH_UNWIND=OFF \
-            -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_FLAGS="-Wl,-Wno-error=unused-command-line-argument"
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_FLAGS="-Wl"
 
           ninja src/all
 

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -101,22 +101,17 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/build
 
-          echo "Paths for /usr/bin/clang++"
-          /usr/bin/clang++ -###
-          #          export PATH=/usr/local/opt/bison/bin:$PATH
-          #          which /usr/bin/c++
-          #          /usr/bin/c++ --version
-          #          which /usr/bin/cc
-          #          /usr/bin/cc --version
-          echo "Paths for /usr/bin/c++"
-          /usr/bin/c++ -###
+          # We need -isysroot such that we fetch both include and lib dirs for standard library
+          # On macos-15 /usr/bin/cc or /usr/bin/clang does this automatically. However for macos-13 it seems that this is not the case.
+          # Furthermore, keep in mind that on macos-15, /Applications/Xcode.app/... have been moved to /Library/Developer
+          # so if we upgrade this flow to use a newer version this might fail.
+          export CPPFLAGS="-isysroot $(xcrun --sdk macosx --show-sdk-path)"
+          ls -lah /Library/Developer/CommandLineTools/usr/bin
 
-          echo "Paths for /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++"
-          /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -###
+          echo "next ls"
 
-          xcode-select -p
-          # Use proper toolchain
-          sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+          ls -lah /Library/Developer/
+
 
           bison --version
 

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -104,13 +104,13 @@ jobs:
           export PATH=/usr/local/opt/bison/bin:$PATH
           which /usr/bin/c++
           /usr/bin/c++ --version
-          which /usr/bin/c
-          /usr/bin/c --version
+          which /usr/bin/cc
+          /usr/bin/cc --version
 
           bison --version
 
           echo "*************************** START BUILDING **************************************"
-          CC=/usr/bin/c CXX=/usr/bin/c++ cmake .. -DCMAKE_BUILD_TYPE=Debug -GNinja -DWITH_UNWIND=OFF \
+          CC=/usr/bin/cc CXX=/usr/bin/c++ cmake .. -DCMAKE_BUILD_TYPE=Debug -GNinja -DWITH_UNWIND=OFF \
             -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_FLAGS="-Wl,-ld_classic,-Wno-error=unused-command-line-argument"
 
           ninja src/all

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -102,13 +102,16 @@ jobs:
           cd $GITHUB_WORKSPACE/build
 
           export PATH=/usr/local/opt/bison/bin:$PATH
-          gcc-12 --version
+          which clang
+          clang --version
+          which clang++
+          clang++ --version
 
           bison --version
 
           echo "*************************** START BUILDING **************************************"
-          CC=gcc-12 CXX=g++-12 cmake .. -DCMAKE_BUILD_TYPE=Debug -GNinja -DWITH_UNWIND=OFF \
-            -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_FLAGS="-Wl,-ld_classic"
+          CC=clang CXX=clang++ cmake .. -DCMAKE_BUILD_TYPE=Debug -GNinja -DWITH_UNWIND=OFF \
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_FLAGS="-Wl,-ld_classic,-Wno-error=unused-command-line-argument"
 
           ninja src/all
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,7 +66,6 @@ add_third_party(
   URL https://github.com/Genivia/RE-flex/archive/refs/tags/v5.2.2.tar.gz
   PATCH_COMMAND autoreconf -fi
   CONFIGURE_COMMAND <SOURCE_DIR>/configure --disable-avx2 --prefix=${THIRD_PARTY_LIB_DIR}/reflex
-          CXX=${CMAKE_CXX_COMPILER} CC=${CMAKE_C_COMPILER}
 )
 
 set(REFLEX "${THIRD_PARTY_LIB_DIR}/reflex/bin/reflex")


### PR DESCRIPTION
It was impossible to compile dragonfly on my mac when `CXX` flag was set. The issue is that building the reflex lib explicitly set the `CXX` to `CMAKE_CXX_COMPILER`. However when the first is set in bash and the second is empty, cmake will try to resolve the value of `CMAKE_CXX_COMPILER` which would be different than the one set via the variable `CXX`.