### PR TITLE
fix: epoll reg tests running on iouring

### DIFF
--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -49,6 +49,8 @@ runs:
         export DRAGONFLY_PATH="${GITHUB_WORKSPACE}/${{inputs.build-folder-name}}/${{inputs.dfly-executable}}"
         export UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 # to crash on errors
 
+        echo "Proactor used: ${{inputs.epoll}}\n"
+
         if [[ "${{inputs.epoll}}" == 'epoll' ]]; then
           export FILTER="${{inputs.filter}} and not exclude_epoll"
           # Run only replication tests with epoll

--- a/.github/workflows/epoll-regression-tests.yml
+++ b/.github/workflows/epoll-regression-tests.yml
@@ -57,7 +57,7 @@ jobs:
           s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}
           # Chain ternary oprator of the form (which can be nested)
           # (expression == condition && <true expression> || <false expression>)
-          epoll: ${{ matrix.proactor == 'Epoll' && 'true' || '' }}
+          epoll: ${{ matrix.proactor == 'Epoll' && 'epoll' || 'iouring' }}
 
       - name: Upload logs on failure
         if: failure()


### PR DESCRIPTION
I accidentally introduced this bug which switched to iouring instead of epoll on the epoll regression tests.

* properly run epoll instead of iouring
* fix print message on failure