### PR TITLE
server: rdb loader big string loading in chunks

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -557,10 +557,10 @@ void RobjWrapper::SetString(string_view s, MemoryResource* mr) {
 }
 
 void RobjWrapper::ReserveString(size_t size, MemoryResource* mr) {
+  CHECK_EQ(inner_obj_, nullptr);
   type_ = OBJ_STRING;
   encoding_ = OBJ_ENCODING_RAW;
   MakeInnerRoom(0, size, mr);
-  sz_ = 0;
 }
 
 void RobjWrapper::AppendString(string_view s, MemoryResource* mr) {

--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -556,6 +556,20 @@ void RobjWrapper::SetString(string_view s, MemoryResource* mr) {
   }
 }
 
+void RobjWrapper::ReserveString(size_t size, MemoryResource* mr) {
+  type_ = OBJ_STRING;
+  encoding_ = OBJ_ENCODING_RAW;
+  MakeInnerRoom(0, size, mr);
+  sz_ = 0;
+}
+
+void RobjWrapper::AppendString(string_view s, MemoryResource* mr) {
+  size_t cur_cap = InnerObjMallocUsed();
+  CHECK(cur_cap >= sz_ + s.size()) << cur_cap << " " << sz_ << " " << s.size();
+  memcpy(reinterpret_cast<uint8_t*>(inner_obj_) + sz_, s.data(), s.size());
+  sz_ += s.size();
+}
+
 void RobjWrapper::SetSize(uint64_t size) {
   sz_ = size;
 }
@@ -974,6 +988,16 @@ void CompactObj::SetString(std::string_view str) {
   }
 
   EncodeString(str);
+}
+
+void CompactObj::ReserveString(size_t size) {
+  uint8_t mask = mask_ & ~kEncMask;
+  SetMeta(ROBJ_TAG, mask);
+  u_.r_obj.ReserveString(size, tl.local_mr);
+}
+
+void CompactObj::AppendString(std::string_view str) {
+  u_.r_obj.AppendString(str, tl.local_mr);
 }
 
 string_view CompactObj::GetSlice(string* scratch) const {

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -46,6 +46,8 @@ class RobjWrapper {
   void Free(MemoryResource* mr);
 
   void SetString(std::string_view s, MemoryResource* mr);
+  void ReserveString(size_t size, MemoryResource* mr);
+  void AppendString(std::string_view s, MemoryResource* mr);
   // Used when sz_ is used to denote memory usage
   void SetSize(uint64_t size);
   void Init(unsigned type, unsigned encoding, void* inner);
@@ -308,6 +310,9 @@ class CompactObj {
   // For STR object.
   void SetString(std::string_view str);
   void GetString(std::string* res) const;
+
+  void ReserveString(size_t size);
+  void AppendString(std::string_view str);
 
   // Will set this to hold OBJ_JSON, after that it is safe to call GetJson
   // NOTE: in order to avid copy which can be expensive in this case,

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2683,6 +2683,7 @@ error_code RdbLoader::LoadKeyValPair(int type, ObjSettings* settings) {
     // If the key can be discarded, we must still continue to read the
     // object from the RDB so we can read the next key.
     if (ShouldDiscardKey(key, settings)) {
+      pending_read_.reserve = 0;
       continue;
     }
 

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -854,7 +854,14 @@ void RdbLoaderBase::OpaqueObjLoader::CreateStream(const LoadTrace* ltrace) {
 
 void RdbLoaderBase::OpaqueObjLoader::HandleBlob(string_view blob) {
   if (rdb_type_ == RDB_TYPE_STRING) {
-    pv_->SetString(blob);
+    if (config_.append) {
+      pv_->AppendString(blob);
+    } else if (config_.reserve) {
+      pv_->ReserveString(config_.reserve);
+      pv_->AppendString(blob);
+    } else {
+      pv_->SetString(blob);
+    }
     return;
   }
 
@@ -1292,12 +1299,6 @@ error_code RdbLoaderBase::ReadObj(int rdbtype, OpaqueObj* dest) {
   io::Result<OpaqueObj> iores;
 
   switch (rdbtype) {
-    case RDB_TYPE_STRING: {
-      dest->rdb_type = RDB_TYPE_STRING;
-
-      /* Read string value */
-      return ReadStringObj(&dest->obj);
-    }
     case RDB_TYPE_SET:
     case RDB_TYPE_SET_WITH_EXPIRY:
       iores = ReadSet(rdbtype);
@@ -1308,6 +1309,8 @@ error_code RdbLoaderBase::ReadObj(int rdbtype, OpaqueObj* dest) {
     case RDB_TYPE_HASH_ZIPLIST:
     case RDB_TYPE_HASH_LISTPACK:
     case RDB_TYPE_ZSET_LISTPACK:
+    case RDB_TYPE_ZSET_ZIPLIST:
+    case RDB_TYPE_STRING:
       iores = ReadGeneric(rdbtype);
       break;
     case RDB_TYPE_HASH:
@@ -1317,9 +1320,6 @@ error_code RdbLoaderBase::ReadObj(int rdbtype, OpaqueObj* dest) {
     case RDB_TYPE_ZSET:
     case RDB_TYPE_ZSET_2:
       iores = ReadZSet(rdbtype);
-      break;
-    case RDB_TYPE_ZSET_ZIPLIST:
-      iores = ReadZSetZL();
       break;
     case RDB_TYPE_LIST_QUICKLIST:
     case RDB_TYPE_LIST_QUICKLIST_2:
@@ -1331,7 +1331,7 @@ error_code RdbLoaderBase::ReadObj(int rdbtype, OpaqueObj* dest) {
       iores = ReadStreams(rdbtype);
       break;
     case RDB_TYPE_JSON:
-      iores = ReadJson();
+      iores = ReadGeneric(rdbtype);
       break;
     case RDB_TYPE_SET_LISTPACK:
       // We need to deal with protocol versions 9 and older because in these
@@ -1339,7 +1339,7 @@ error_code RdbLoaderBase::ReadObj(int rdbtype, OpaqueObj* dest) {
       // because it overlapped with the new type RDB_TYPE_SET_LISTPACK
       if (rdb_version_ < 10) {
         // consider it RDB_TYPE_JSON_OLD (20)
-        iores = ReadJson();
+        iores = ReadGeneric(RDB_TYPE_JSON);
       } else {
         iores = ReadGeneric(rdbtype);
       }
@@ -1362,10 +1362,11 @@ error_code RdbLoaderBase::ReadObj(int rdbtype, OpaqueObj* dest) {
   return error_code{};
 }
 
-error_code RdbLoaderBase::ReadStringObj(RdbVariant* dest) {
-  bool isencoded;
-  size_t len;
+static const size_t kMaxStringSize = 200_KB;
 
+error_code RdbLoaderBase::ReadStringObj(RdbVariant* dest, bool big_string_split) {
+  bool isencoded = false;
+  size_t len;
   SET_OR_RETURN(LoadLen(&isencoded), len);
 
   if (isencoded) {
@@ -1393,10 +1394,24 @@ error_code RdbLoaderBase::ReadStringObj(RdbVariant* dest) {
     }
   }
 
+  if (big_string_split && len > kMaxStringSize) {
+    pending_read_.remaining = len - kMaxStringSize;
+    pending_read_.reserve = len;
+    len = kMaxStringSize;
+  }
+
   auto& blob = dest->emplace<base::PODArray<char>>();
   blob.resize(len);
-  error_code ec = FetchBuf(len, blob.data());
-  return ec;
+  return FetchBuf(len, blob.data());
+}
+
+error_code RdbLoaderBase::ReadRemainingString(RdbVariant* dest) {
+  size_t read_len = std::min(pending_read_.remaining, kMaxStringSize);
+  pending_read_.remaining = pending_read_.remaining - read_len;
+
+  auto& blob = dest->emplace<base::PODArray<char>>();
+  blob.resize(read_len);
+  return FetchBuf(read_len, blob.data());
 }
 
 io::Result<long long> RdbLoaderBase::ReadIntObj(int enctype) {
@@ -1494,12 +1509,18 @@ auto RdbLoaderBase::ReadIntSet() -> io::Result<OpaqueObj> {
 }
 
 auto RdbLoaderBase::ReadGeneric(int rdbtype) -> io::Result<OpaqueObj> {
+  bool is_string_type = RDB_TYPE_STRING == rdbtype;
   RdbVariant str_obj;
-  error_code ec = ReadStringObj(&str_obj);
+  error_code ec;
+  if (pending_read_.remaining) {
+    ec = ReadRemainingString(&str_obj);
+  } else {
+    ec = ReadStringObj(&str_obj, is_string_type);
+  }
   if (ec)
     return make_unexpected(ec);
 
-  if (StrLen(str_obj) == 0) {
+  if (!is_string_type && StrLen(str_obj) == 0) {
     return Unexpected(errc::rdb_file_corrupted);
   }
 
@@ -1587,19 +1608,6 @@ auto RdbLoaderBase::ReadZSet(int rdbtype) -> io::Result<OpaqueObj> {
   }
 
   return OpaqueObj{std::move(load_trace), rdbtype};
-}
-
-auto RdbLoaderBase::ReadZSetZL() -> io::Result<OpaqueObj> {
-  RdbVariant str_obj;
-  error_code ec = ReadStringObj(&str_obj);
-  if (ec)
-    return make_unexpected(ec);
-
-  if (StrLen(str_obj) == 0) {
-    return Unexpected(errc::rdb_file_corrupted);
-  }
-
-  return OpaqueObj{std::move(str_obj), RDB_TYPE_ZSET_ZIPLIST};
 }
 
 auto RdbLoaderBase::ReadListQuicklist(int rdbtype) -> io::Result<OpaqueObj> {
@@ -1873,15 +1881,6 @@ auto RdbLoaderBase::ReadRedisJson() -> io::Result<OpaqueObj> {
   if (!opcode || *opcode != RDB_MODULE_OPCODE_EOF) {
     return Unexpected(errc::rdb_file_corrupted);
   }
-
-  return OpaqueObj{std::move(dest), RDB_TYPE_JSON};
-}
-
-auto RdbLoaderBase::ReadJson() -> io::Result<OpaqueObj> {
-  RdbVariant dest;
-  error_code ec = ReadStringObj(&dest);
-  if (ec)
-    return make_unexpected(ec);
 
   return OpaqueObj{std::move(dest), RDB_TYPE_JSON};
 }

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -1311,6 +1311,7 @@ error_code RdbLoaderBase::ReadObj(int rdbtype, OpaqueObj* dest) {
     case RDB_TYPE_ZSET_LISTPACK:
     case RDB_TYPE_ZSET_ZIPLIST:
     case RDB_TYPE_STRING:
+    case RDB_TYPE_JSON:
       iores = ReadGeneric(rdbtype);
       break;
     case RDB_TYPE_HASH:
@@ -1329,9 +1330,6 @@ error_code RdbLoaderBase::ReadObj(int rdbtype, OpaqueObj* dest) {
     case RDB_TYPE_STREAM_LISTPACKS_2:
     case RDB_TYPE_STREAM_LISTPACKS_3:
       iores = ReadStreams(rdbtype);
-      break;
-    case RDB_TYPE_JSON:
-      iores = ReadGeneric(rdbtype);
       break;
     case RDB_TYPE_SET_LISTPACK:
       // We need to deal with protocol versions 9 and older because in these

--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -164,7 +164,8 @@ class RdbLoaderBase {
   ::io::Result<std::string> ReadKey();
 
   std::error_code ReadObj(int rdbtype, OpaqueObj* dest);
-  std::error_code ReadStringObj(RdbVariant* rdb_variant);
+  std::error_code ReadStringObj(RdbVariant* rdb_variant, bool big_string_split = false);
+  std::error_code ReadRemainingString(RdbVariant* dest);
   ::io::Result<long long> ReadIntObj(int encoding);
   ::io::Result<LzfString> ReadLzf();
 
@@ -173,11 +174,9 @@ class RdbLoaderBase {
   ::io::Result<OpaqueObj> ReadGeneric(int rdbtype);
   ::io::Result<OpaqueObj> ReadHMap(int rdbtype);
   ::io::Result<OpaqueObj> ReadZSet(int rdbtype);
-  ::io::Result<OpaqueObj> ReadZSetZL();
   ::io::Result<OpaqueObj> ReadListQuicklist(int rdbtype);
   ::io::Result<OpaqueObj> ReadStreams(int rdbtype);
   ::io::Result<OpaqueObj> ReadRedisJson();
-  ::io::Result<OpaqueObj> ReadJson();
   ::io::Result<OpaqueObj> ReadSBF();
 
   std::error_code SkipModuleData();

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -230,7 +230,7 @@ RdbSerializer::~RdbSerializer() {
   VLOG(2) << "compression mode: " << uint32_t(compression_mode_);
   if (compression_stats_) {
     VLOG(2) << "compression not effective: " << compression_stats_->compression_no_effective;
-    VLOG(2) << "string none compression applied: " << compression_stats_->size_skip_count;
+    VLOG(2) << "string compression skipped: " << compression_stats_->size_skip_count;
     VLOG(2) << "compression failed: " << compression_stats_->compression_failed;
     VLOG(2) << "compressed blobs:" << compression_stats_->compressed_blobs;
   }

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -230,7 +230,7 @@ RdbSerializer::~RdbSerializer() {
   VLOG(2) << "compression mode: " << uint32_t(compression_mode_);
   if (compression_stats_) {
     VLOG(2) << "compression not effective: " << compression_stats_->compression_no_effective;
-    VLOG(2) << "small string none compression applied: " << compression_stats_->small_str_count;
+    VLOG(2) << "string none compression applied: " << compression_stats_->size_skip_count;
     VLOG(2) << "compression failed: " << compression_stats_->compression_failed;
     VLOG(2) << "compressed blobs:" << compression_stats_->compressed_blobs;
   }
@@ -1572,8 +1572,9 @@ void SerializerBase::CompressBlob() {
   Bytes blob_to_compress = mem_buf_.InputBuffer();
   VLOG(2) << "CompressBlob size " << blob_to_compress.size();
   size_t blob_size = blob_to_compress.size();
-  if (blob_size < kMinStrSizeToCompress) {
-    ++compression_stats_->small_str_count;
+
+  if (blob_size < kMinStrSizeToCompress || blob_size > kMaxStrSizeToCompress) {
+    ++compression_stats_->size_skip_count;
     return;
   }
 

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -199,10 +199,11 @@ class SerializerBase {
   std::unique_ptr<detail::CompressorImpl> compressor_impl_;
 
   static constexpr size_t kMinStrSizeToCompress = 256;
+  static constexpr size_t kMaxStrSizeToCompress = 1 * 1024 * 1024;
   static constexpr double kMinCompressionReductionPrecentage = 0.95;
   struct CompressionStats {
     uint32_t compression_no_effective = 0;
-    uint32_t small_str_count = 0;
+    uint32_t size_skip_count = 0;
     uint32_t compression_failed = 0;
     uint32_t compressed_blobs = 0;
   };


### PR DESCRIPTION
In this PR we introduce rdb loading of string alliteratively in chunks to prevent memory spikes on big string loading.
In this PR 
1. Add 2 apis to compact object to reserve memory and append to string
2. Reading of string data from rdb is done in chunks in case of big string
3. The rdb save compression logic is disabled in case of big buffer to prevent additional spike in snapshot while saving due to compression buffer and in the loader to decompress the buffer.