### PR TITLE
chore: allow yielding in Scan command

### DIFF
--- a/src/core/dash.h
+++ b/src/core/dash.h
@@ -981,7 +981,6 @@ auto DashTable<_Key, _Value, Policy>::Traverse(Cursor curs, Cb&& cb) -> Cursor {
       if (bid >= Policy::kBucketNum)
         return 0;  // "End of traversal" cursor.
     }
-
   } while (!fetched);
 
   return Cursor{global_depth_, sid, bid};

--- a/src/core/dash.h
+++ b/src/core/dash.h
@@ -233,7 +233,12 @@ class DashTable : public detail::DashTableBase {
   // mutations. It guarantees that if key exists (1)at the beginning of traversal, (2) stays in the
   // table during the traversal, then Traverse() will eventually reach it even when the table
   // shrinks or grows. Returns: cursor that is guaranteed to be less than 2^40.
-  template <typename Cb> Cursor Traverse(Cursor curs, Cb&& cb);
+  // YieldCb is used for early preemption. It should accept a size_t that denotes
+  // the number of buckets so far iterated in Traverse and if a threshold (e.g. the number of
+  // buckets iterated) is reached then it suspends. Upon return it should act as an identity
+  // function if the threshold is not reached or return 0 to denote that there was preemption
+  using YieldCb = std::function<size_t(size_t)>;
+  template <typename Cb> Cursor Traverse(Cursor curs, Cb&& cb, YieldCb yield_cb = {});
 
   // Traverses over physical buckets. It calls cb once for each bucket by passing a bucket iterator.
   // if cursor=0 starts traversing from the beginning, otherwise continues from where
@@ -953,7 +958,7 @@ auto DashTable<_Key, _Value, Policy>::GetRandomCursor(absl::BitGen* bitgen) -> C
 
 template <typename _Key, typename _Value, typename Policy>
 template <typename Cb>
-auto DashTable<_Key, _Value, Policy>::Traverse(Cursor curs, Cb&& cb) -> Cursor {
+auto DashTable<_Key, _Value, Policy>::Traverse(Cursor curs, Cb&& cb, YieldCb yield_cb) -> Cursor {
   uint32_t sid = curs.segment_id(global_depth_);
   uint8_t bid = curs.bucket_id();
 
@@ -964,6 +969,7 @@ auto DashTable<_Key, _Value, Policy>::Traverse(Cursor curs, Cb&& cb) -> Cursor {
   auto hash_fun = [this](const auto& k) { return policy_.HashFn(k); };
 
   bool fetched = false;
+  size_t iterated_buckets = 0;
 
   // We fix bid and go over all segments. Once we reach the end we increase bid and repeat.
   do {
@@ -981,6 +987,10 @@ auto DashTable<_Key, _Value, Policy>::Traverse(Cursor curs, Cb&& cb) -> Cursor {
       if (bid >= Policy::kBucketNum)
         return 0;  // "End of traversal" cursor.
     }
+
+    ++iterated_buckets;
+    // might preempt
+    iterated_buckets = yield_cb(iterated_buckets);
   } while (!fetched);
 
   return Cursor{global_depth_, sid, bid};

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -626,13 +626,13 @@ void OpScan(const OpArgs& op_args, const ScanOpts& scan_opts, uint64_t* cursor, 
   size_t buckets_iterated = 0;
   const size_t limit = 10000 / (PrimeTable::kBucketNum * PrimeTable::kSlotNum);
   do {
-    cur = prime_table->Traverse(
-        cur, [&](PrimeIterator it) { cnt += ScanCb(op_args, it, scan_opts, &scratch, vec); });
-    ++buckets_iterated;
-    if (buckets_iterated == limit) {
+    if (buckets_iterated >= limit) {
       buckets_iterated = 0;
       util::ThisFiber::Yield();
     }
+    cur = prime_table->Traverse(
+        cur, [&](PrimeIterator it) { cnt += ScanCb(op_args, it, scan_opts, &scratch, vec); });
+    ++buckets_iterated;
   } while (cur && cnt < scan_opts.limit);
 
   VLOG(1) << "OpScan " << db_slice.shard_id() << " cursor: " << cur.value();

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -621,7 +621,8 @@ void OpScan(const OpArgs& op_args, const ScanOpts& scan_opts, uint64_t* cursor, 
   auto [prime_table, expire_table] = db_slice.GetTables(op_args.db_cntx.db_index);
   string scratch;
   size_t buckets_iterated = 0;
-  const size_t limit = 10000 / (PrimeTable::kBucketNum * PrimeTable::kSlotNum);
+  // 10k Traverses
+  const size_t limit = 10000;
   do {
     if (buckets_iterated >= limit) {
       buckets_iterated = 0;

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -623,18 +623,16 @@ void OpScan(const OpArgs& op_args, const ScanOpts& scan_opts, uint64_t* cursor, 
   PrimeTable::Cursor cur = *cursor;
   auto [prime_table, expire_table] = db_slice.GetTables(op_args.db_cntx.db_index);
   string scratch;
+  size_t buckets_iterated = 0;
+  const size_t limit = 10000 / (PrimeTable::kBucketNum * PrimeTable::kSlotNum);
   do {
     cur = prime_table->Traverse(
-        cur, [&](PrimeIterator it) { cnt += ScanCb(op_args, it, scan_opts, &scratch, vec); },
-        [](size_t count) -> size_t {
-          // Our limit is 100k keys. Estimate how many buckets that is.
-          const size_t limit = 100000 / (PrimeTable::kBucketNum * PrimeTable::kSlotNum);
-          if (count == limit) {
-            util::ThisFiber::Yield();
-            return 0;
-          }
-          return count;
-        });
+        cur, [&](PrimeIterator it) { cnt += ScanCb(op_args, it, scan_opts, &scratch, vec); });
+    ++buckets_iterated;
+    if (buckets_iterated == limit) {
+      buckets_iterated = 0;
+      util::ThisFiber::Yield();
+    }
   } while (cur && cnt < scan_opts.limit);
 
   VLOG(1) << "OpScan " << db_slice.shard_id() << " cursor: " << cur.value();

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -4,8 +4,6 @@
 
 #include "server/generic_family.h"
 
-#include <absl/cleanup/cleanup.h>
-
 #include <boost/operators.hpp>
 #include <optional>
 


### PR DESCRIPTION
Scan command would not yield while traversing which means that it could potentially scan the whole dash table without any preemption until it finds at least one key that it matches. This is not good for some cases.

* allow yield in Scan

