### PR TITLE
chore: Improve loading of sorted sets

### DIFF
--- a/src/core/sorted_map.h
+++ b/src/core/sorted_map.h
@@ -53,7 +53,11 @@ class SortedMap {
 
   bool Reserve(size_t sz);
   int Add(double score, sds ele, int in_flags, int* out_flags, double* newscore);
-  bool Insert(double score, sds member);
+
+  // Inserts a new element. Returns false if the element already exists.
+  // No score update is performed in this case.
+  bool InsertNew(double score, std::string_view member);
+
   bool Delete(sds ele);
 
   // Upper bound size of the set.

--- a/src/core/sorted_map_test.cc
+++ b/src/core/sorted_map_test.cc
@@ -4,6 +4,7 @@
 
 #include "core/sorted_map.h"
 
+#include <absl/strings/str_cat.h>
 #include <gmock/gmock.h>
 #include <mimalloc.h>
 
@@ -19,6 +20,7 @@ using namespace std;
 using testing::ElementsAre;
 using testing::Pair;
 using testing::StrEq;
+using absl::StrCat;
 
 namespace dfly {
 using detail::SortedMap;
@@ -65,7 +67,7 @@ TEST_F(SortedMapTest, Add) {
 
 TEST_F(SortedMapTest, Scan) {
   for (unsigned i = 0; i < 972; ++i) {
-    sm_.Insert(i, sdsfromlonglong(i));
+    sm_.InsertNew(i, StrCat(i));
   }
   uint64_t cursor = 0;
 
@@ -78,10 +80,7 @@ TEST_F(SortedMapTest, Scan) {
 
 TEST_F(SortedMapTest, InsertPop) {
   for (unsigned i = 0; i < 256; ++i) {
-    sds s = sdsempty();
-
-    s = sdscatfmt(s, "a%u", i);
-    ASSERT_TRUE(sm_.Insert(1000, s));
+    ASSERT_TRUE(sm_.InsertNew(1000, StrCat("a", i)));
   }
 
   vector<sds> vec;
@@ -107,10 +106,7 @@ TEST_F(SortedMapTest, InsertPop) {
 
 TEST_F(SortedMapTest, LexRanges) {
   for (unsigned i = 0; i < 100; ++i) {
-    sds s = sdsempty();
-
-    s = sdscatfmt(s, "a%u", i);
-    ASSERT_TRUE(sm_.Insert(1, s));
+    ASSERT_TRUE(sm_.InsertNew(1, StrCat("a", i)));
   }
 
   zlexrangespec range;
@@ -157,17 +153,11 @@ TEST_F(SortedMapTest, LexRanges) {
 
 TEST_F(SortedMapTest, ScoreRanges) {
   for (unsigned i = 0; i < 10; ++i) {
-    sds s = sdsempty();
-
-    s = sdscatfmt(s, "a%u", i);
-    ASSERT_TRUE(sm_.Insert(1, s));
+    ASSERT_TRUE(sm_.InsertNew(1, StrCat("a", i)));
   }
 
   for (unsigned i = 0; i < 10; ++i) {
-    sds s = sdsempty();
-
-    s = sdscatfmt(s, "b%u", i);
-    ASSERT_TRUE(sm_.Insert(2, s));
+    ASSERT_TRUE(sm_.InsertNew(2, StrCat("b", i)));
   }
 
   zrangespec range;
@@ -207,10 +197,7 @@ TEST_F(SortedMapTest, ScoreRanges) {
 
 TEST_F(SortedMapTest, DeleteRange) {
   for (unsigned i = 0; i <= 100; ++i) {
-    sds s = sdsempty();
-
-    s = sdscatfmt(s, "a%u", i);
-    ASSERT_TRUE(sm_.Insert(i * 2, s));
+    ASSERT_TRUE(sm_.InsertNew(i * 2, StrCat("a", i)));
   }
 
   zrangespec range;
@@ -249,10 +236,7 @@ TEST_F(SortedMapTest, DeleteRange) {
 TEST_F(SortedMapTest, RangeBug) {
   constexpr size_t kArrLen = 80;
   for (unsigned i = 0; i < kArrLen; i++) {
-    sds s = sdsempty();
-
-    s = sdscatfmt(s, "score%u", i);
-    sm_.Insert(i, s);
+    ASSERT_TRUE(sm_.InsertNew(i, StrCat("score", i)));
   }
 
   for (unsigned i = 0; i < kArrLen; i++) {

--- a/src/core/task_queue.h
+++ b/src/core/task_queue.h
@@ -24,7 +24,7 @@ class TaskQueue {
 
   template <typename F> bool Add(F&& f) {
     if (queue_.TryAdd(std::forward<F>(f)))
-      return true;
+      return false;
 
     ++blocked_submitters_;
     auto res = queue_.Add(std::forward<F>(f));

--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -310,6 +310,8 @@ class RdbLoader : protected RdbLoaderBase {
 
   void LoadItemsBuffer(DbIndex db_ind, const ItemsBuf& ib);
 
+  void CreateObjectOnShard(const DbContext& db_cntx, const Item* item, DbSlice* db_slice);
+
   void LoadScriptFromAux(std::string&& value);
 
   // Load index definition from RESP string describing it in FT.CREATE format,


### PR DESCRIPTION
1. Reduce number of allocations when creating new members
2. Reverse the saving order because with bptree it's better to add elements from the smallest to largest.
3. Add a runtime flag rdb_load_dry_run that allows us to load the dataset without actually adding entries.

For zset rich dataset, the difference was 415s before vs 220s afterwards.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->