### PR TITLE
fix: performance degradation with Reflex matching

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,3 +1,20 @@
+find_library(LIB_PCRE2 NAMES pcre2-8)
+if(LIB_PCRE2)
+  set(PCRE2_LIB ${LIB_PCRE2})
+else()
+  message(STATUS "pcre2-8 not found. Building without PCRE2 support.")
+  set(PCRE2_LIB "")
+endif()
+
+
+find_library(LIB_RE2 NAMES re2)
+if(LIB_RE2)
+  set(RE2_LIB ${LIB_RE2})
+else()
+  message(STATUS "re2 not found. Building without RE2 support.")
+  set(RE2_LIB "")
+endif()
+
 add_subdirectory(search)
 add_subdirectory(json)
 
@@ -15,22 +32,7 @@ cxx_link(dfly_core base absl::flat_hash_map absl::str_format redis_lib TRDP::lua
 add_executable(dash_bench dash_bench.cc)
 cxx_link(dash_bench dfly_core redis_test_lib)
 
-find_library(LIB_PCRE2 NAMES pcre2-8)
-if(LIB_PCRE2)
-  set(PCRE2_LIB ${LIB_PCRE2})
-else()
-  message(STATUS "pcre2-8 not found. Building without PCRE2 support.")
-  set(PCRE2_LIB "")
-endif()
 
-
-find_library(LIB_RE2 NAMES re2)
-if(LIB_RE2)
-  set(RE2_LIB ${LIB_RE2})
-else()
-  message(STATUS "re2 not found. Building without RE2 support.")
-  set(RE2_LIB "")
-endif()
 
 find_library(ZSTD_LIB NAMES libzstd.a libzstdstatic.a zstd NAMES_PER_DIR REQUIRED)
 
@@ -52,7 +54,8 @@ cxx_test(qlist_test dfly_core DATA testdata/list.txt.zst LABELS DFLY)
 cxx_test(zstd_test dfly_core ${ZSTD_LIB} LABELS DFLY)
 
 if(LIB_PCRE2)
-  target_compile_definitions(dfly_core_test PRIVATE USE_PCRE2)
+  target_compile_definitions(dfly_core_test PRIVATE USE_PCRE2=1)
+  # target_compile_definitions(dfly_core PUBLIC USE_PCRE2=1)
 endif()
 
 if(LIB_RE2)


### PR DESCRIPTION
1. cherry-pick valkey security fixes with stringmatchlen with exponential complexity of stars See https://nvd.nist.gov/vuln/detail/cve-2022-36021
2. Fallback to stringmatchlen for short lengths.
3. Add another backend to GlobMatcher - PCRE2, though do not enable at the moment. While this backend is the fastest one - it requires an additional shared lib dependency.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->