### PR TITLE
fix: do not flush replicaof if failed to connect

### DIFF
--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -124,11 +124,12 @@ error_code Replica::Start(facade::SinkReplyBuilder* builder) {
   ec = Greet();
   RETURN_ON_ERR(check_connection_error(ec, "could not greet master "));
 
-  // 4. Spawn main coordination fiber.
-  sync_fb_ = fb2::Fiber("main_replication", &Replica::MainReplicationFb, this);
-
-  builder->SendOk();
   return {};
+}
+
+void Replica::StartMainReplicationFiber(facade::SinkReplyBuilder* builder) {
+  sync_fb_ = fb2::Fiber("main_replication", &Replica::MainReplicationFb, this);
+  builder->SendOk();
 }
 
 void Replica::EnableReplication(facade::SinkReplyBuilder* builder) {

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -59,6 +59,7 @@ class Replica : ProtocolClient {
   // Returns true if initial link with master has been established or
   // false if it has failed.
   std::error_code Start(facade::SinkReplyBuilder* builder);
+  void StartMainReplicationFiber(facade::SinkReplyBuilder* builder);
 
   // Sets the server state to have replication enabled.
   // It is like Start(), but does not attempt to establish

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2751,8 +2751,8 @@ void ServerFamily::AddReplicaOf(CmdArgList args, const CommandContext& cmd_cntx)
                                           master_replid(), replicaof_args->slot_range);
   error_code ec = add_replica->Start(cmd_cntx.rb);
   if (!ec) {
-    cluster_replicas_.push_back(std::move(add_replica));
     add_replica->StartMainReplicationFiber(cmd_cntx.rb);
+    cluster_replicas_.push_back(std::move(add_replica));
   }
 }
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2752,6 +2752,7 @@ void ServerFamily::AddReplicaOf(CmdArgList args, const CommandContext& cmd_cntx)
   error_code ec = add_replica->Start(cmd_cntx.rb);
   if (!ec) {
     cluster_replicas_.push_back(std::move(add_replica));
+    add_replica->StartMainReplicationFiber(cmd_cntx.rb);
   }
 }
 
@@ -2806,12 +2807,6 @@ void ServerFamily::ReplicaOfInternal(CmdArgList args, Transaction* tx, SinkReply
       return;
     }
 
-    // If we are called by "Replicate", tx will be null but we do not need
-    // to flush anything.
-    if (tx) {
-      Drakarys(tx, DbSlice::kDbAll);
-    }
-
     // Create a new replica and assing it
     new_replica = make_shared<Replica>(replicaof_args->host, replicaof_args->port, &service_,
                                        master_replid(), replicaof_args->slot_range);
@@ -2830,7 +2825,7 @@ void ServerFamily::ReplicaOfInternal(CmdArgList args, Transaction* tx, SinkReply
     case ActionOnConnectionFail::kReturnOnError:
       ec = new_replica->Start(builder);
       break;
-    case ActionOnConnectionFail::kContinueReplication:  // set DF to replicate, and forget about it
+    case ActionOnConnectionFail::kContinueReplication:
       new_replica->EnableReplication(builder);
       break;
   };
@@ -2842,6 +2837,17 @@ void ServerFamily::ReplicaOfInternal(CmdArgList args, Transaction* tx, SinkReply
     service_.SwitchState(GlobalState::LOADING, GlobalState::ACTIVE);
     SetMasterFlagOnAllThreads(true);
     replica_.reset();
+    return;
+  }
+  // Successfully connected now we flush
+  // If we are called by "Replicate", tx will be null but we do not need
+  // to flush anything.
+  if (tx) {
+    Drakarys(tx, DbSlice::kDbAll);
+  }
+
+  if (on_err == ActionOnConnectionFail::kReturnOnError) {
+    replica_->StartMainReplicationFiber(builder);
   }
 }
 

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2820,12 +2820,13 @@ async def test_replicaof_does_not_flush_if_it_fails_to_connect(df_factory):
     c_master = master.client()
     c_replica = replica.client()
 
-    await c_master.execute_comamnd("SET foo bar")
-    await c_replica.execute_command(f"REPLICAOF localhost {master.port()}")
-    await check_all_replicas_finished(c_replica, c_master)
+    await c_master.execute_command("SET foo bar")
+    await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
+    await check_all_replicas_finished([c_replica], c_master)
 
-    res = await c_replica.execute_comamnd("dbsize")
+    res = await c_replica.execute_command("dbsize")
     assert res == 1
-    await c_replica.execute_command(f"REPLICAOF localhost {replica.port()}")
-    res = await c_replica.execute_comamnd("dbsize")
+    with pytest.raises(redis.exceptions.ResponseError):
+        await c_replica.execute_command(f"REPLICAOF localhost {replica.port}")
+    res = await c_replica.execute_command("dbsize")
     assert res == 1


### PR DESCRIPTION
We `unconditionally` flushed the replica even if `replicaof` failed to connect. We now flush *only* if replicaof succeeded to connect and therefore replication can properly start.

resolves #4501
