### PR TITLE
chore: get rid of lispack stats

### DIFF
--- a/src/core/string_set_test.cc
+++ b/src/core/string_set_test.cc
@@ -617,9 +617,12 @@ void BM_AddMany(benchmark::State& state) {
     strs.push_back(str);
   }
   ss.Reserve(elems);
-
+  vector<string_view> svs;
+  for (const auto& str : strs) {
+    svs.push_back(str);
+  }
   while (state.KeepRunning()) {
-    ss.AddMany(absl::MakeSpan(strs), UINT32_MAX);
+    ss.AddMany(absl::MakeSpan(svs), UINT32_MAX);
     state.PauseTiming();
     CHECK_EQ(ss.UpperBoundSize(), elems);
     ss.Clear();

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1590,12 +1590,6 @@ void DbSlice::PerformDeletion(Iterator del_it, ExpIterator exp_it, DbTable* tabl
     }
   }  // del_it->first.IsAsyncDelete()
 
-  if (pv.ObjType() == OBJ_HASH && pv.Encoding() == kEncodingListPack) {
-    --stats.listpack_blob_cnt;
-  } else if (pv.ObjType() == OBJ_ZSET && pv.Encoding() == OBJ_ENCODING_LISTPACK) {
-    --stats.listpack_blob_cnt;
-  }
-
   if (IsClusterEnabled()) {
     SlotId sid = KeySlot(del_it.key());
     table->slots_stats[sid].key_count -= 1;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2329,8 +2329,6 @@ void ServerFamily::Info(CmdArgList args, const CommandContext& cmd_cntx) {
     append("num_buckets", total.bucket_count);
     append("num_entries", total.key_count);
     append("inline_keys", total.inline_keys);
-    append("listpack_blobs", total.listpack_blob_cnt);
-    append("listpack_bytes", total.listpack_bytes);
     append("small_string_bytes", m.small_string_bytes);
     append("pipeline_cache_bytes", m.facade_stats.conn_stats.pipeline_cmd_cache_bytes);
     append("dispatch_queue_bytes", m.facade_stats.conn_stats.dispatch_queue_bytes);

--- a/src/server/table.cc
+++ b/src/server/table.cc
@@ -32,12 +32,10 @@ void DbTableStats::AddTypeMemoryUsage(unsigned type, int64_t delta) {
 
 DbTableStats& DbTableStats::operator+=(const DbTableStats& o) {
   constexpr size_t kDbSz = sizeof(DbTableStats) - sizeof(memory_usage_by_type);
-  static_assert(kDbSz == 48);
+  static_assert(kDbSz == 32);
 
   ADD(inline_keys);
   ADD(obj_memory_usage);
-  ADD(listpack_blob_cnt);
-  ADD(listpack_bytes);
   ADD(tiered_entries);
   ADD(tiered_used_bytes);
 

--- a/src/server/table.h
+++ b/src/server/table.h
@@ -65,8 +65,6 @@ struct DbTableStats {
   // Applies for any non-inline objects.
   size_t obj_memory_usage = 0;
 
-  size_t listpack_blob_cnt = 0;
-  size_t listpack_bytes = 0;
   size_t tiered_entries = 0;
   size_t tiered_used_bytes = 0;
 


### PR DESCRIPTION
They were wrong, we usually do not need them,
and they complicated code. The right way to do it - to add them to OBJHIST statistics.

In addition, did some other code improvements without functional changes.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->