### PR TITLE
server: disable single shard tx optimization on scheduling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Run pre-commit checks
-        run:
+        run: |
           source venv/bin/activate
           pre-commit run --show-diff-on-failure --color=always --from-ref HEAD^ --to-ref HEAD
         shell: bash
@@ -162,6 +162,8 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/build
           echo Run ctest -V -L DFLY
+
+          ./list_family_test --gtest_filter=*AwakeMulti --gtest_repeat=100
 
           GLOG_alsologtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1,op_manager=1,op_manager_test=1 \
           FLAGS_fiber_safety_margin=4096 FLAGS_list_experimental_v2=true timeout 20m ctest -V -L DFLY -E allocation_tracker_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,8 +163,6 @@ jobs:
           cd ${GITHUB_WORKSPACE}/build
           echo Run ctest -V -L DFLY
 
-          ./list_family_test --gtest_filter=*AwakeMulti --gtest_repeat=100
-
           GLOG_alsologtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1,op_manager=1,op_manager_test=1 \
           FLAGS_fiber_safety_margin=4096 FLAGS_list_experimental_v2=true timeout 20m ctest -V -L DFLY -E allocation_tracker_test
 

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -556,6 +556,7 @@ string Transaction::DebugId(std::optional<ShardId> sid) const {
     absl::StrAppend(&res, ":", multi_->cmd_seq_num);
   }
   absl::StrAppend(&res, " {id=", trans_id(this));
+  absl::StrAppend(&res, " {cb_ptr=", absl::StrFormat("%p", static_cast<const void*>(cb_ptr_)));
   if (sid) {
     absl::StrAppend(&res, ",mask[", *sid, "]=", int(shard_data_[SidToId(*sid)].local_mask),
                     ",is_armed=", DEBUG_IsArmedInShard(*sid),

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -763,6 +763,10 @@ void Transaction::ScheduleInternal() {
 
     ScheduleContext schedule_ctx{this, optimistic_exec};
 
+    // TODO: this optimization is disabled due to a issue #4648 revealing this code can
+    // lead to transaction not being scheduled.
+    // To reproduce the bug remove the false in the condition and run
+    // ./list_family_test --gtest_filter=*AwakeMulti on alpine machine
     if (false && unique_shard_cnt_ == 1) {
       // Single shard optimization. Note: we could apply the same optimization
       // to multi-shard transactions as well by creating a vector of ScheduleContext.

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -763,7 +763,7 @@ void Transaction::ScheduleInternal() {
 
     ScheduleContext schedule_ctx{this, optimistic_exec};
 
-    if (unique_shard_cnt_ == 1) {
+    if (false && unique_shard_cnt_ == 1) {
       // Single shard optimization. Note: we could apply the same optimization
       // to multi-shard transactions as well by creating a vector of ScheduleContext.
       schedule_queues[unique_shard_id_].queue.Push(&schedule_ctx);


### PR DESCRIPTION
Helps with #4648
1. This PR removes single shard optimization in transaction scheduling.
2. add tx debug info on test deadlock