### PR TITLE
feat: implement unique keys counting using hll

### DIFF
--- a/src/redis/hyperloglog.c
+++ b/src/redis/hyperloglog.c
@@ -183,7 +183,7 @@
  * when this implementation switches to the dense representation is
  * configured via the define HLL_SPARSE_MAX_BYTES.
  */
-size_t HLL_SPARSE_MAX_BYTES = 3000;
+#define HLL_SPARSE_MAX_BYTES 3000
 
 struct hllhdr {
   char magic[4];       /* "HYLL" */
@@ -1301,9 +1301,10 @@ int convertSparseToDenseHll(struct HllBufferPtr in_hll, struct HllBufferPtr out_
   return C_OK;
 }
 
-int pfadd_sparse(sds* hll_ptr, unsigned char* value, size_t size, int* promoted) {
+int pfadd_sparse(sds* hll_ptr, const unsigned char* value,
+                 size_t size, int* promoted) {
   struct hllhdr* hdr = (struct hllhdr*)(*hll_ptr);
-  int retval = hllSparseAdd(hll_ptr, value, size, promoted);
+  int retval = hllSparseAdd(hll_ptr, (unsigned char*)value, size, promoted);
   switch (retval) {
     case 1:
       HLL_INVALIDATE_CACHE(hdr);
@@ -1313,14 +1314,15 @@ int pfadd_sparse(sds* hll_ptr, unsigned char* value, size_t size, int* promoted)
   }
 }
 
-int pfadd_dense(struct HllBufferPtr hll_ptr, unsigned char* value, size_t size) {
+int pfadd_dense(struct HllBufferPtr hll_ptr, const unsigned char* value,
+                size_t size) {
   if (isValidHLL(hll_ptr) != HLL_VALID_DENSE)
     return C_ERR;
 
   struct hllhdr* hdr = (struct hllhdr*)hll_ptr.hll;
 
   /* Perform the low level ADD operation for every element. */
-  int retval = hllDenseAdd(hdr->registers, value, size);
+  int retval = hllDenseAdd(hdr->registers, (unsigned char*)value, size);
   switch (retval) {
     case 1:
       HLL_INVALIDATE_CACHE(hdr);

--- a/src/redis/hyperloglog.h
+++ b/src/redis/hyperloglog.h
@@ -23,8 +23,6 @@ struct HllBufferPtr {
   size_t size;
 };
 
-extern size_t HLL_SPARSE_MAX_BYTES;
-
 enum HllValidness isValidHLL(struct HllBufferPtr hll_ptr);
 
 size_t getDenseHllSize();
@@ -46,8 +44,8 @@ int convertSparseToDenseHll(struct HllBufferPtr in_hll, struct HllBufferPtr out_
 
 /* Adds `value` of size `size`, to `hll_ptr`.
  * If `obj` does not have an underlying type of HLL a negative number is returned. */
-int pfadd_sparse(sds* hll_ptr, unsigned char* value, size_t size, int* promoted);
-int pfadd_dense(struct HllBufferPtr hll_ptr, unsigned char* value, size_t size);
+int pfadd_sparse(sds* hll_ptr, const unsigned char* value, size_t size, int* promoted);
+int pfadd_dense(struct HllBufferPtr hll_ptr, const unsigned char* value, size_t size);
 
 /* Returns the estimated count of elements for `hll_ptr`.
  * If `hll_ptr` is not a valid dense-encoded HLL, a negative number is returned. */

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -537,6 +537,11 @@ class DbSlice {
   };
   SamplingResult StopSampleTopK(DbIndex db_ind);
 
+  void StartSampleKeys(DbIndex db_ind);
+
+  // Returns number of unique keys sampled.
+  size_t StopSampleKeys(DbIndex db_ind);
+
  private:
   void PreUpdate(DbIndex db_ind, Iterator it, std::string_view key);
   void PostUpdate(DbIndex db_ind, Iterator it, std::string_view key, size_t orig_size);

--- a/src/server/debugcmd.h
+++ b/src/server/debugcmd.h
@@ -56,6 +56,7 @@ class DebugCmd {
   void LogTraffic(CmdArgList, facade::SinkReplyBuilder* builder);
   void RecvSize(std::string_view param, facade::SinkReplyBuilder* builder);
   void Topk(CmdArgList args, facade::SinkReplyBuilder* builder);
+  void Keys(CmdArgList args, facade::SinkReplyBuilder* builder);
 
   ServerFamily& sf_;
   cluster::ClusterFamily& cf_;

--- a/src/server/table.cc
+++ b/src/server/table.cc
@@ -93,6 +93,7 @@ DbTable::DbTable(PMR_NS::memory_resource* mr, DbIndex db_index)
 DbTable::~DbTable() {
   DCHECK_EQ(thread_index, ServerState::tlocal()->thread_index());
   delete top_keys;
+  delete[] dense_hll;
 }
 
 void DbTable::Clear() {

--- a/src/server/table.h
+++ b/src/server/table.h
@@ -130,6 +130,8 @@ struct DbTable : boost::intrusive_ref_counter<DbTable, boost::thread_unsafe_coun
   ExpireTable::Cursor expire_cursor;
 
   TopKeys* top_keys = nullptr;
+  uint8_t* dense_hll = nullptr;
+
   DbIndex index;
   uint32_t thread_index;
 


### PR DESCRIPTION
HyperLogLog is an efficient data structure for approximate counting of unique elements. We use it to sample the traffic via "DEBUG KEYS ON/OFF" command.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->