### PR TITLE
fix: replication error message and scan command yield

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -627,11 +627,7 @@ void OpScan(const OpArgs& op_args, const ScanOpts& scan_opts, uint64_t* cursor, 
   do {
     cur = prime_table->Traverse(
         cur, [&](PrimeIterator it) { cnt += ScanCb(op_args, it, scan_opts, vec); });
-    ++buckets_iterated;
-    if (buckets_iterated >= limit) {
-      break;
-    }
-  } while (cur && cnt < scan_opts.limit);
+  } while (cur && cnt < scan_opts.limit && buckets_iterated++ < limit);
 
   VLOG(1) << "OpScan " << db_slice.shard_id() << " cursor: " << cur.value();
   *cursor = cur.value();

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -611,6 +611,8 @@ void OpScan(const OpArgs& op_args, const ScanOpts& scan_opts, uint64_t* cursor, 
   // we enter the callback in a timing when journaling will not cause preemptions. Otherwise,
   // the bucket might change as we Traverse and yield.
   db_slice.BlockingCounter()->Wait();
+  // Disable flush journal changes to prevent preemtion in traverse.
+  journal::JournalFlushGuard journal_flush_guard(op_args.shard->journal());
   unsigned cnt = 0;
 
   VLOG(1) << "PrimeTable " << db_slice.shard_id() << "/" << op_args.db_cntx.db_index << " has "
@@ -623,16 +625,12 @@ void OpScan(const OpArgs& op_args, const ScanOpts& scan_opts, uint64_t* cursor, 
   // 10k Traverses
   const size_t limit = 10000;
   do {
+    cur = prime_table->Traverse(
+        cur, [&](PrimeIterator it) { cnt += ScanCb(op_args, it, scan_opts, vec); });
+    ++buckets_iterated;
     if (buckets_iterated >= limit) {
       break;
     }
-    {
-      // Disable flush journal changes to prevent preemtion in traverse.
-      journal::JournalFlushGuard journal_flush_guard(op_args.shard->journal());
-      cur = prime_table->Traverse(
-          cur, [&](PrimeIterator it) { cnt += ScanCb(op_args, it, scan_opts, vec); });
-    }
-    ++buckets_iterated;
   } while (cur && cnt < scan_opts.limit);
 
   VLOG(1) << "OpScan " << db_slice.shard_id() << " cursor: " << cur.value();

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -624,8 +624,7 @@ void OpScan(const OpArgs& op_args, const ScanOpts& scan_opts, uint64_t* cursor, 
   const size_t limit = 10000;
   do {
     if (buckets_iterated >= limit) {
-      buckets_iterated = 0;
-      util::ThisFiber::Yield();
+      break;
     }
     {
       // Disable flush journal changes to prevent preemtion in traverse.

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -93,7 +93,7 @@ GenericError Replica::Start() {
 
   auto check_connection_error = [this](error_code ec, const char* msg) -> GenericError {
     if (!cntx_.IsRunning()) {
-      return {std::make_error_code(errc::operation_canceled), "replication cancelled"};
+      return {"replication cancelled"};
     }
     if (ec) {
       cntx_.ReportCancelError();


### PR DESCRIPTION
I accidentally changed the error message in https://github.com/dragonflydb/dragonfly/commit/8512f726f4b98e936672281d963048c8fea9ab89#diff-8174e8eae32841a10b583a676b1b8ec068e7b3f2aa3cf61d2e952553ab343875R96
Furthermore, I never pushed the commit with the early return from the suggestion in https://github.com/dragonflydb/dragonfly/pull/4624/files#diff-f8f9387edb04c03ce7333ad3b69778d7b379fcf8c8765543f62b34d883e187c5R629