### PR TITLE
chore: Add debug logs to help tracking transactional deadlocks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-default_stages: [commit]
+default_stages: [pre-commit]
 exclude: |
     (?x)(
       src/redis/.* |

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -898,6 +898,8 @@ void DbSlice::FlushDbIndexes(const std::vector<DbIndex>& indexes) {
 }
 
 void DbSlice::FlushDb(DbIndex db_ind) {
+  DVLOG(1) << "Flushing db " << db_ind;
+
   // clear client tracking map.
   client_tracking_map_.clear();
 

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -1066,12 +1066,7 @@ void DebugCmd::TxAnalysis(facade::SinkReplyBuilder* builder) {
   string result;
   for (unsigned i = 0; i < shard_set->size(); ++i) {
     const auto& info = shard_info[i];
-    StrAppend(&result, "shard", i, ":\n", "  tx armed ", info.tx_armed, ", total: ", info.tx_total,
-              ",global:", info.tx_global, ",runnable:", info.tx_runnable, "\n");
-    StrAppend(&result, "  locks total:", info.total_locks, ",contended:", info.contended_locks,
-              "\n");
-    StrAppend(&result, "  max contention score: ", info.max_contention_score,
-              ",lock_name:", info.max_contention_lock, "\n");
+    StrAppend(&result, "shard", i, ":\n", info.Format(), "\n");
   }
   auto* rb = static_cast<RedisReplyBuilder*>(builder);
   rb->SendVerbatimString(result);
@@ -1118,13 +1113,7 @@ void DebugCmd::Stacktrace(facade::SinkReplyBuilder* builder) {
     string txq;
     if (es) {
       EngineShard::TxQueueInfo txq_info = es->AnalyzeTxQueue();
-      if (txq_info.tx_total > 0) {
-        txq = StrCat("tx armed ", txq_info.tx_armed, ", total: ", txq_info.tx_total,
-                     ",global:", txq_info.tx_global, ",runnable:", txq_info.tx_runnable, "\n");
-        StrAppend(&txq, "locks total:", txq_info.total_locks,
-                  ",contended:", txq_info.contended_locks, ", head: ", txq_info.head.debug_id_info,
-                  "\n");
-      }
+      txq = txq_info.Format();
     }
     std::unique_lock lk(m);
     LOG_IF(INFO, !txq.empty()) << "Shard" << index << ": " << txq;

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -706,7 +706,7 @@ void EngineShard::RemoveContTx(Transaction* tx) {
 }
 
 void EngineShard::Heartbeat() {
-  DVLOG(2) << " Hearbeat";
+  DVLOG(3) << " Hearbeat";
   DCHECK(namespaces);
 
   CacheStats();

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -5,6 +5,7 @@
 #include "server/engine_shard.h"
 
 #include <absl/strings/match.h>
+#include <absl/strings/str_cat.h>
 
 #include "base/flags.h"
 #include "io/proc_reader.h"
@@ -274,6 +275,25 @@ ShardId Shard(string_view v, ShardId shard_num) {
   }
 
   return hash % shard_num;
+}
+
+string EngineShard::TxQueueInfo::Format() const {
+  string res;
+
+  if (tx_total > 0) {
+    absl::StrAppend(&res, "tx armed ", tx_armed, ", total: ", tx_total, ",global:", tx_global,
+                    ",runnable:", tx_runnable, "\n");
+    absl::StrAppend(&res, ", head: ", head.debug_id_info, "\n");
+  }
+  if (total_locks > 0) {
+    absl::StrAppend(&res, "locks total:", total_locks, ",contended:", contended_locks, "\n");
+  }
+  if (max_contention_score > 0) {
+    absl::StrAppend(&res, "max contention score: ", max_contention_score,
+                    ", lock: ", max_contention_lock, "\n");
+  }
+
+  return res;
 }
 
 EngineShard::Stats& EngineShard::Stats::operator+=(const EngineShard::Stats& o) {

--- a/src/server/engine_shard.h
+++ b/src/server/engine_shard.h
@@ -181,6 +181,8 @@ class EngineShard {
 
     // We can use a vector to hold debug info for all items in the txqueue
     TxQueueItem head;
+
+    std::string Format() const;
   };
 
   TxQueueInfo AnalyzeTxQueue() const;

--- a/src/server/protocol_client.cc
+++ b/src/server/protocol_client.cc
@@ -347,6 +347,7 @@ bool ProtocolClient::CheckRespFirstTypes(initializer_list<RespExpr::Type> types)
 
 error_code ProtocolClient::SendCommand(string_view command) {
   string formatted_command = RedisReplyBuilderBase::SerializeCommand(command);
+  DCHECK(sock_->proactor() == ProactorBase::me());
   auto ec = sock_->Write(io::Buffer(formatted_command));
   if (!ec)
     TouchIoTime();

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2903,6 +2903,7 @@ void ServerFamily::ReplicaOfInternal(CmdArgList args, Transaction* tx, SinkReply
   // If the replication attempt failed, clean up global state. The replica should have stopped
   // internally.
   util::fb2::LockGuard lk(replicaof_mu_);  // Only one REPLICAOF command can run at a time
+
   // If there was an error above during Start we must not start the main replication fiber.
   // However, it could be the case that Start() above connected succefully and by the time
   // we acquire the lock, the context got cancelled because another ReplicaOf command
@@ -2917,11 +2918,8 @@ void ServerFamily::ReplicaOfInternal(CmdArgList args, Transaction* tx, SinkReply
     builder->SendError(ec ? ec.Format() : "replication cancelled");
     return;
   }
-  // Successfully connected now we flush
-  // If we are called by "Replicate", tx will be null but we do not need
-  // to flush anything.
+
   if (on_err == ActionOnConnectionFail::kReturnOnError) {
-    Drakarys(tx, DbSlice::kDbAll);
     new_replica->StartMainReplicationFiber();
   }
   builder->SendOk();

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2918,8 +2918,11 @@ void ServerFamily::ReplicaOfInternal(CmdArgList args, Transaction* tx, SinkReply
     builder->SendError(ec ? ec.Format() : "replication cancelled");
     return;
   }
-
+  // Successfully connected now we flush
+  // If we are called by "Replicate", tx will be null but we do not need
+  // to flush anything.
   if (on_err == ActionOnConnectionFail::kReturnOnError) {
+    Drakarys(tx, DbSlice::kDbAll);
     new_replica->StartMainReplicationFiber();
   }
   builder->SendOk();

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -49,19 +49,14 @@ void AnalyzeTxQueue(const EngineShard* shard, const TxQueue* txq) {
     if (now >= last_log_time + 10) {
       last_log_time = now;
       EngineShard::TxQueueInfo info = shard->AnalyzeTxQueue();
-      string msg =
-          StrCat("TxQueue is too long. Tx count:", info.tx_total, ", armed:", info.tx_armed,
-                 ", runnable:", info.tx_runnable, ", total locks: ", info.total_locks,
-                 ", contended locks: ", info.contended_locks, "\n");
-      absl::StrAppend(&msg, "max contention score: ", info.max_contention_score,
-                      ", lock: ", info.max_contention_lock,
-                      ", poll_executions:", shard->stats().poll_execution_total);
+      string msg = StrCat("TxQueue is too long. ", info.Format());
+      absl::StrAppend(&msg, "poll_executions:", shard->stats().poll_execution_total);
+
       const Transaction* cont_tx = shard->GetContTx();
       if (cont_tx) {
         absl::StrAppend(&msg, " continuation_tx: ", cont_tx->DebugId(shard->shard_id()), " ",
                         cont_tx->DEBUG_IsArmedInShard(shard->shard_id()) ? " armed" : "");
       }
-      absl::StrAppend(&msg, "\nTxQueue head debug info ", info.head.debug_id_info);
 
       LOG(WARNING) << msg;
     }


### PR DESCRIPTION
Add various debug logs to help tracking the deadlock.

Add more assertions in helio and provide state time for fibers during stacktrace printings.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->