### PR TITLE
fix: ZMSCORE return value if key does not exist

### DIFF
--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1363,11 +1363,7 @@ OpResult<MScoreResponse> OpMScore(const OpArgs& op_args, string_view key,
 
   // If the key doesn't exist and there's only one member, return KEY_NOTFOUND
   if (res_it.status() == OpStatus::KEY_NOTFOUND) {
-    if (members.Size() == 1) {
-      return OpStatus::KEY_NOTFOUND;
-    }
-
-    // If the key doesn't exist and there are multiple members, return an array of NIL values
+    // If the key doesn't exist return an array of NIL values
     MScoreResponse result(members.Size(), std::nullopt);
     return result;
   }
@@ -2663,10 +2659,6 @@ void ZSetFamily::ZMScore(CmdArgList args, const CommandContext& cmd_cntx) {
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx.rb);
 
   OpResult<MScoreResponse> result = ZGetMembers(args, cmd_cntx.tx, rb);
-
-  if (result.status() == OpStatus::KEY_NOTFOUND) {
-    return rb->SendNull();
-  }
 
   if (result.status() == OpStatus::WRONG_TYPE) {
     return rb->SendError(kWrongTypeErr);

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1360,6 +1360,18 @@ OpResult<unsigned> OpRem(const OpArgs& op_args, string_view key, facade::ArgRang
 OpResult<MScoreResponse> OpMScore(const OpArgs& op_args, string_view key,
                                   facade::ArgRange members) {
   auto res_it = op_args.GetDbSlice().FindReadOnly(op_args.db_cntx, key, OBJ_ZSET);
+
+  // If the key doesn't exist and there's only one member, return KEY_NOTFOUND
+  if (res_it.status() == OpStatus::KEY_NOTFOUND) {
+    if (members.Size() == 1) {
+      return OpStatus::KEY_NOTFOUND;
+    }
+
+    // If the key doesn't exist and there are multiple members, return an array of NIL values
+    MScoreResponse result(members.Size(), std::nullopt);
+    return result;
+  }
+
   if (!res_it)
     return res_it.status();
 
@@ -2651,6 +2663,10 @@ void ZSetFamily::ZMScore(CmdArgList args, const CommandContext& cmd_cntx) {
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx.rb);
 
   OpResult<MScoreResponse> result = ZGetMembers(args, cmd_cntx.tx, rb);
+
+  if (result.status() == OpStatus::KEY_NOTFOUND) {
+    return rb->SendNull();
+  }
 
   if (result.status() == OpStatus::WRONG_TYPE) {
     return rb->SendError(kWrongTypeErr);

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1361,7 +1361,6 @@ OpResult<MScoreResponse> OpMScore(const OpArgs& op_args, string_view key,
                                   facade::ArgRange members) {
   auto res_it = op_args.GetDbSlice().FindReadOnly(op_args.db_cntx, key, OBJ_ZSET);
 
-  // If the key doesn't exist and there's only one member, return KEY_NOTFOUND
   if (res_it.status() == OpStatus::KEY_NOTFOUND) {
     // If the key doesn't exist return an array of NIL values
     MScoreResponse result(members.Size(), std::nullopt);

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -291,20 +291,22 @@ TEST_F(ZSetFamilyTest, ZMScore) {
 TEST_F(ZSetFamilyTest, ZMScoreSingleMemberNonExistentKey) {
   // Case 1: Single member with non-existent key (ZMSCORE abc x)
   auto resp = Run({"zmscore", "abc", "x"});
-  EXPECT_THAT(resp, ArgType(RespExpr::NIL)) << "Expected NIL response for non-existent key with single member";
+
+  EXPECT_THAT(resp, ArgType(RespExpr::NIL))
+      << "Expected NIL response for non-existent key with single member";
 }
 
 // Test for ZMSCORE with multiple members on a non-existent key
 TEST_F(ZSetFamilyTest, ZMScoreMultipleMembersNonExistentKey) {
   // Case 2: Multiple members with non-existent key (ZMSCORE abc x y z)
   auto resp = Run({"zmscore", "abc", "x", "y", "z"});
-  ASSERT_EQ(RespExpr::ARRAY, resp.type) << "Expected array response for non-existent key with multiple members";
+
+  ASSERT_EQ(RespExpr::ARRAY, resp.type)
+      << "Expected array response for non-existent key with multiple members";
   ASSERT_EQ(3, resp.GetVec().size()) << "Expected array with 3 elements";
-  EXPECT_THAT(resp.GetVec(), ElementsAre(
-    ArgType(RespExpr::NIL),
-    ArgType(RespExpr::NIL),
-    ArgType(RespExpr::NIL)
-  ));
+
+  EXPECT_THAT(resp.GetVec(),
+              ElementsAre(ArgType(RespExpr::NIL), ArgType(RespExpr::NIL), ArgType(RespExpr::NIL)));
 }
 
 TEST_F(ZSetFamilyTest, ZRangeRank) {

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -287,24 +287,14 @@ TEST_F(ZSetFamilyTest, ZMScore) {
   EXPECT_THAT(resp.GetVec(), ElementsAre("42", "3.14", ArgType(RespExpr::NIL)));
 }
 
-// Test for ZMSCORE with a single member on a non-existent key
-TEST_F(ZSetFamilyTest, ZMScoreSingleMemberNonExistentKey) {
+// Test for ZMSCORE with member on a non-existent keys
+TEST_F(ZSetFamilyTest, ZMScoreNonExistentKeys) {
   // Case 1: Single member with non-existent key (ZMSCORE abc x)
   auto resp = Run({"zmscore", "abc", "x"});
+  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
 
-  EXPECT_THAT(resp, ArgType(RespExpr::NIL))
-      << "Expected NIL response for non-existent key with single member";
-}
-
-// Test for ZMSCORE with multiple members on a non-existent key
-TEST_F(ZSetFamilyTest, ZMScoreMultipleMembersNonExistentKey) {
   // Case 2: Multiple members with non-existent key (ZMSCORE abc x y z)
-  auto resp = Run({"zmscore", "abc", "x", "y", "z"});
-
-  ASSERT_EQ(RespExpr::ARRAY, resp.type)
-      << "Expected array response for non-existent key with multiple members";
-  ASSERT_EQ(3, resp.GetVec().size()) << "Expected array with 3 elements";
-
+  resp = Run({"zmscore", "abc", "x", "y", "z"});
   EXPECT_THAT(resp.GetVec(),
               ElementsAre(ArgType(RespExpr::NIL), ArgType(RespExpr::NIL), ArgType(RespExpr::NIL)));
 }

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -287,6 +287,26 @@ TEST_F(ZSetFamilyTest, ZMScore) {
   EXPECT_THAT(resp.GetVec(), ElementsAre("42", "3.14", ArgType(RespExpr::NIL)));
 }
 
+// Test for ZMSCORE with a single member on a non-existent key
+TEST_F(ZSetFamilyTest, ZMScoreSingleMemberNonExistentKey) {
+  // Case 1: Single member with non-existent key (ZMSCORE abc x)
+  auto resp = Run({"zmscore", "abc", "x"});
+  EXPECT_THAT(resp, ArgType(RespExpr::NIL)) << "Expected NIL response for non-existent key with single member";
+}
+
+// Test for ZMSCORE with multiple members on a non-existent key
+TEST_F(ZSetFamilyTest, ZMScoreMultipleMembersNonExistentKey) {
+  // Case 2: Multiple members with non-existent key (ZMSCORE abc x y z)
+  auto resp = Run({"zmscore", "abc", "x", "y", "z"});
+  ASSERT_EQ(RespExpr::ARRAY, resp.type) << "Expected array response for non-existent key with multiple members";
+  ASSERT_EQ(3, resp.GetVec().size()) << "Expected array with 3 elements";
+  EXPECT_THAT(resp.GetVec(), ElementsAre(
+    ArgType(RespExpr::NIL),
+    ArgType(RespExpr::NIL),
+    ArgType(RespExpr::NIL)
+  ));
+}
+
 TEST_F(ZSetFamilyTest, ZRangeRank) {
   Run({"zadd", "x", "1.1", "a", "2.1", "b"});
   EXPECT_THAT(Run({"zrangebyscore", "x", "0", "(1.1"}), ArrLen(0));


### PR DESCRIPTION
fix: ZMSCORE return value if key does not exist #4670