### PR TITLE
fix: prevent tx_executor reading from sock if operation is canceled

### DIFF
--- a/src/server/cluster/incoming_slot_migration.cc
+++ b/src/server/cluster/incoming_slot_migration.cc
@@ -67,8 +67,6 @@ class ClusterShardMigration {
 
       auto tx_data = tx_reader.NextTxData(&reader, cntx);
       if (!tx_data) {
-        in_migration_->ReportError(GenericError("No tx data"));
-        VLOG(1) << "No tx data";
         break;
       }
 

--- a/src/server/journal/tx_executor.cc
+++ b/src/server/journal/tx_executor.cc
@@ -92,6 +92,9 @@ TransactionData TransactionData::FromEntry(journal::ParsedEntry&& entry) {
 
 std::optional<TransactionData> TransactionReader::NextTxData(JournalReader* reader,
                                                              ExecutionState* cntx) {
+  if (!cntx->IsRunning()) {
+    return std::nullopt;
+  }
   io::Result<journal::ParsedEntry> res;
   if (res = reader->ReadEntry(); !res) {
     cntx->ReportError(res.error());

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -866,11 +866,8 @@ void DflyShardReplica::StableSyncDflyReadFb(ExecutionState* cntx) {
 
   acks_fb_ = fb2::Fiber("shard_acks", &DflyShardReplica::StableSyncDflyAcksFb, this, cntx);
 
-  while (cntx->IsRunning()) {
-    auto tx_data = tx_reader.NextTxData(&reader, cntx);
-    if (!tx_data)
-      break;
-
+  std::optional<TransactionData> tx_data;
+  while ((tx_data = tx_reader.NextTxData(&reader, cntx))) {
     DVLOG(3) << "Lsn: " << tx_data->lsn;
 
     last_io_time_ = Proactor()->GetMonotonicTimeNs();


### PR DESCRIPTION
fixes: https://github.com/dragonflydb/dragonfly/issues/4689

problem: we read from the socket after it was shutdown
