### PR TITLE
fix(json_family): Fix JSON.SET handling for nested fields

### DIFF
--- a/src/core/json/jsonpath_lexer.lex
+++ b/src/core/json/jsonpath_lexer.lex
@@ -59,7 +59,7 @@
               return Parser::make_INT(val, loc());
             }
 
-\w[\w_\-]*  return Parser::make_UNQ_STR(str(), loc());
+[\w_\-]+    return Parser::make_UNQ_STR(str(), loc());
 <<EOF>>     return Parser::make_YYEOF(loc());
 .           throw Parser::syntax_error(loc(), UnknownTokenMsg());
 %%

--- a/src/server/detail/wrapped_json_path.h
+++ b/src/server/detail/wrapped_json_path.h
@@ -269,6 +269,10 @@ class WrappedJsonPath {
     return std::get<JsonExpression>(parsed_path_);
   }
 
+  std::string_view Path() const {
+    return path_.view();
+  }
+
  private:
   CallbackResultOptions InitializePathType(CallbackResultOptions options) const {
     if (!options.path_type) {

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -3046,4 +3046,21 @@ TEST_F(JsonFamilyTest, MaxNestingJsonDepth) {
   EXPECT_THAT(resp, ErrArg("failed to parse JSON"));
 }
 
+TEST_F(JsonFamilyTest, SetNestedFields) {
+  auto resp = Run({"JSON.SET", "json", "$", "{}"});
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run({"JSON.SET", "json", "$['field1']", "1"});
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run({"JSON.GET", "json"});
+  EXPECT_EQ(resp, R"({"field1":1})");
+
+  resp = Run({"JSON.SET", "json", "$['-field2']", "2"});
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run({"JSON.GET", "json"});
+  EXPECT_EQ(resp, R"({"-field2":2,"field1":1})");
+}
+
 }  // namespace dfly


### PR DESCRIPTION
fixes dragonflydb#4381

The main bug was in the `ConvertExpressionToJsonPointer` method. I don’t like the idea of parsing a JSON path directly. Instead, I decided to use our JSON path lexer to parse it first and then convert it into JsonPointer. For now, this approach should work fine.

I also spent a significant amount of time ensuring support for both our parsing method, `json::ParsePath`, and the jsoncons parsing method, depending on the `jsonpathv2` flag. However, I found some bugs in the jsoncons parsing method, and it also needs modifications to allow us to extract path tokens and traverse them to convert them into a JsonPointer. And jsoncons does not provide any built-in methods to convert `json_expression` into `json_pointer`. So, I think this is the best solution for now.

Also, in this PR, I made some code cleanups.