### PR TITLE
feat(set_family): Add support for KEEPTTL to SAddEx

### DIFF
--- a/src/core/string_set.h
+++ b/src/core/string_set.h
@@ -29,7 +29,7 @@ class StringSet : public DenseSet {
   // Returns true if elem was added.
   bool Add(std::string_view s1, uint32_t ttl_sec = UINT32_MAX);
 
-  unsigned AddMany(absl::Span<std::string_view> span, uint32_t ttl_sec);
+  unsigned AddMany(absl::Span<std::string_view> span, uint32_t ttl_sec, bool keepttl);
 
   bool Erase(std::string_view str) {
     return EraseInternal(&str, 1);
@@ -108,7 +108,7 @@ class StringSet : public DenseSet {
  protected:
   uint64_t Hash(const void* ptr, uint32_t cookie) const override;
 
-  unsigned AddBatch(absl::Span<std::string_view> span, uint32_t ttl_sec);
+  unsigned AddBatch(absl::Span<std::string_view> span, uint32_t ttl_sec, bool keepttl);
 
   bool ObjEqual(const void* left, const void* right, uint32_t right_cookie) const override;
 

--- a/src/core/string_set_test.cc
+++ b/src/core/string_set_test.cc
@@ -124,7 +124,7 @@ TEST_F(StringSetTest, StandardAddErase) {
 TEST_F(StringSetTest, DisplacedBug) {
   string_view vals[] = {"imY", "OVl", "NhH", "BCe", "YDL", "lpb",
                         "nhF", "xod", "zYR", "PSa", "hce", "cTR"};
-  ss_->AddMany(absl::MakeSpan(vals), UINT32_MAX);
+  ss_->AddMany(absl::MakeSpan(vals), UINT32_MAX, false);
 
   ss_->Add("fIc");
   ss_->Erase("YDL");
@@ -622,7 +622,7 @@ void BM_AddMany(benchmark::State& state) {
     svs.push_back(str);
   }
   while (state.KeepRunning()) {
-    ss.AddMany(absl::MakeSpan(svs), UINT32_MAX);
+    ss.AddMany(absl::MakeSpan(svs), UINT32_MAX, false);
     state.PauseTiming();
     CHECK_EQ(ss.UpperBoundSize(), elems);
     ss.Clear();

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -1433,7 +1433,7 @@ void SScan(CmdArgList args, const CommandContext& cmd_cntx) {
   }
 }
 
-// Syntax: saddex key ttl_sec member [member...]
+// Syntax: saddex key [KEEPTTL] ttl_sec member [member...]
 void SAddEx(CmdArgList args, const CommandContext& cmd_cntx) {
   CmdArgParser parser(args);
 

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -1437,10 +1437,9 @@ void SScan(CmdArgList args, const CommandContext& cmd_cntx) {
 void SAddEx(CmdArgList args, const CommandContext& cmd_cntx) {
   CmdArgParser parser(args);
 
-  auto key = parser.Next<std::string_view>();
+  const std::string_view key = parser.Next<std::string_view>();
   const bool keepttl = parser.Check("KEEPTTL");
-
-  auto ttl_sec = parser.Next<uint32_t>();
+  const uint32_t ttl_sec = parser.Next<uint32_t>();
 
   if (auto err = parser.Error(); err) {
     return cmd_cntx.rb->SendError(err->MakeReply());

--- a/src/server/set_family_test.cc
+++ b/src/server/set_family_test.cc
@@ -395,8 +395,13 @@ TEST_F(SetFamilyTest, SAddEx) {
 
   // KEEPTTL support. add field orig with TTL=10
   EXPECT_THAT(Run({"saddex", "key", "10", "orig"}), IntArg(1));
-  // add fields new and orig with TTL=5 and KEEPTTL=true. orig ttl should be preserved
+
+  // add fields new and orig with TTL=1 and KEEPTTL=true. orig ttl should be preserved
   EXPECT_THAT(Run({"saddex", "key", "KEEPTTL", "1", "orig", "new"}), IntArg(1));
+  EXPECT_LE(CheckedInt({"fieldttl", "key", "new"}), 1);
+
+  // The expiry for orig should be unchanged, at least greater than 5 at this point given some time
+  // has passed since we set it to 10
   EXPECT_GT(CheckedInt({"fieldttl", "key", "orig"}), 5);
 
   // without KEEPTTL the TTL should be overwritten

--- a/src/server/set_family_test.cc
+++ b/src/server/set_family_test.cc
@@ -389,6 +389,9 @@ TEST_F(SetFamilyTest, SAddEx) {
   EXPECT_THAT(Run({"saddex", "key", "2", "val"}), IntArg(0));
   AdvanceTime(1000);
   EXPECT_EQ(1, CheckedInt({"sismember", "key", "val"}));
+
+  auto resp = Run({"saddex", "k", "one", "v"});
+  EXPECT_THAT(resp, ErrArg("value is not an integer or out of range"));
 }
 
 }  // namespace dfly


### PR DESCRIPTION
Support is added for KEEPTTL to the SAddEx command as described in https://github.com/dragonflydb/dragonfly/issues/4701