### PR TITLE
feat(hset_family): Add KEEPTTL support to HSetEx

### DIFF
--- a/src/core/dense_set.cc
+++ b/src/core/dense_set.cc
@@ -569,19 +569,6 @@ void DenseSet::Prefetch(uint64_t hash) {
   PREFETCH_READ(&entries_[bid]);
 }
 
-std::pair<void*, void*> DenseSet::FindObjPtr(const void* ptr, uint64_t hash, uint32_t cookie) {
-  if (entries_.empty()) {
-    return {nullptr, nullptr};
-  }
-
-  DensePtr* old_obj = std::get<2>(Find2(ptr, BucketId(hash), cookie));
-  if (old_obj != nullptr) {
-    return {old_obj, old_obj->GetObject()};
-  }
-
-  return {nullptr, nullptr};
-}
-
 auto DenseSet::Find2(const void* ptr, uint32_t bid, uint32_t cookie)
     -> tuple<size_t, DensePtr*, DensePtr*> {
   DCHECK_LT(bid, entries_.size());
@@ -701,14 +688,10 @@ void* DenseSet::PopInternal() {
   return ret;
 }
 
-void* DenseSet::AddOrReplaceObj(void* obj, bool has_ttl, void* old_obj) {
+void* DenseSet::AddOrReplaceObj(void* obj, bool has_ttl) {
   uint64_t hc = Hash(obj, 0);
 
-  DensePtr* dptr = old_obj ? static_cast<DensePtr*>(old_obj) : nullptr;
-  if (!dptr) {
-    dptr = entries_.empty() ? nullptr : Find(obj, BucketId(hc), 0).second;
-  }
-
+  DensePtr* dptr = entries_.empty() ? nullptr : Find(obj, BucketId(hc), 0).second;
   if (dptr) {  // replace existing object.
     // A bit confusing design: ttl bit is located on the wrapping pointer,
     // therefore we must set ttl bit before unrapping below.

--- a/src/core/dense_set.h
+++ b/src/core/dense_set.h
@@ -317,15 +317,12 @@ class DenseSet {
 
   // Returns the previous object if it has been replaced.
   // nullptr, if obj was added.
-  void* AddOrReplaceObj(void* obj, bool has_ttl, void* old_obj = nullptr);
+  void* AddOrReplaceObj(void* obj, bool has_ttl);
 
   // Assumes that the object does not exist in the set.
   void AddUnique(void* obj, bool has_ttl, uint64_t hashcode);
 
   void Prefetch(uint64_t hash);
-
-  // Attempts to find object. If found the dense ptr and raw ptr are returned.
-  std::pair<void*, void*> FindObjPtr(const void* ptr, uint64_t hash, uint32_t cookie);
 
  private:
   DenseSet(const DenseSet&) = delete;

--- a/src/core/dense_set.h
+++ b/src/core/dense_set.h
@@ -317,12 +317,15 @@ class DenseSet {
 
   // Returns the previous object if it has been replaced.
   // nullptr, if obj was added.
-  void* AddOrReplaceObj(void* obj, bool has_ttl);
+  void* AddOrReplaceObj(void* obj, bool has_ttl, void* old_obj = nullptr);
 
   // Assumes that the object does not exist in the set.
   void AddUnique(void* obj, bool has_ttl, uint64_t hashcode);
 
   void Prefetch(uint64_t hash);
+
+  // Attempts to find object. If found the dense ptr and raw ptr are returned.
+  std::pair<void*, void*> FindObjPtr(const void* ptr, uint64_t hash, uint32_t cookie);
 
  private:
   DenseSet(const DenseSet&) = delete;

--- a/src/core/string_map.cc
+++ b/src/core/string_map.cc
@@ -59,16 +59,6 @@ pair<sds, uint64_t> CreateEntry(string_view field, string_view value, uint32_t t
   return {newkey, sdsval_tag};
 }
 
-std::pair<uint64_t, const char*> LoadValPtr(const void* obj) {
-  sds str = (sds)obj;
-  const char* val_ptr = str + sdslen(str) + 1;
-  return {absl::little_endian::Load64(val_ptr), val_ptr};
-}
-
-uint32_t GetExpiry(const char* val_ptr) {
-  return absl::little_endian::Load32(val_ptr + 8);
-}
-
 }  // namespace
 
 StringMap::~StringMap() {
@@ -77,28 +67,16 @@ StringMap::~StringMap() {
 
 bool StringMap::AddOrUpdate(std::string_view field, std::string_view value, uint32_t ttl_sec,
                             bool keepttl) {
-  void* dptr = nullptr;
-  void* raw = nullptr;
-  // If keepttl was specified, do a search. If the object is found pass it to AddOrReplaceObj
-  // to avoid another search. We might end up doing two searches if keepttl is specified and
-  // field is not present already.
-  if (keepttl) {
-    uint64_t hashcode = Hash(&field, 1);
-    // dense ptr for AddOrReplaceObj and sds for getting expire time.
-    std::tie(dptr, raw) = FindObjPtr(&field, hashcode, 1);
-
-    if (raw) {
-      if (const auto [val, val_ptr] = LoadValPtr(raw); val & kValTtlBit) {
-        ttl_sec = GetExpiry(val_ptr);
-      }
-    }
-  }
-
   // 8 additional bytes for a pointer to value.
   auto [newkey, sdsval_tag] = CreateEntry(field, value, time_now(), ttl_sec);
 
   // Replace the whole entry.
-  if (sds prev_entry = (sds)AddOrReplaceObj(newkey, sdsval_tag & kValTtlBit, dptr); prev_entry) {
+  if (sds prev_entry = (sds)AddOrReplaceObj(newkey, sdsval_tag & kValTtlBit); prev_entry) {
+    if (keepttl) {
+      if (const uint32_t prev_ttl = ObjExpireTime(prev_entry); prev_ttl != UINT32_MAX) {
+        ObjUpdateExpireTime(newkey, prev_ttl);
+      }
+    }
     ObjDelete(prev_entry, false);
     return false;
   }
@@ -285,10 +263,14 @@ size_t StringMap::ObjectAllocSize(const void* obj) const {
 }
 
 uint32_t StringMap::ObjExpireTime(const void* obj) const {
-  auto [val, valptr] = LoadValPtr(obj);
+  sds str = (sds)obj;
+  const char* valptr = str + sdslen(str) + 1;
+
+  uint64_t val = absl::little_endian::Load64(valptr);
+
   DCHECK(val & kValTtlBit);
   if (val & kValTtlBit) {
-    return GetExpiry(valptr);
+    return absl::little_endian::Load32(valptr + 8);
   }
 
   // Should not reach.

--- a/src/core/string_map.cc
+++ b/src/core/string_map.cc
@@ -72,10 +72,10 @@ bool StringMap::AddOrUpdate(std::string_view field, std::string_view value, uint
 
   // Replace the whole entry.
   if (sds prev_entry = (sds)AddOrReplaceObj(newkey, sdsval_tag & kValTtlBit); prev_entry) {
-    if (keepttl) {
-      if (const uint32_t prev_ttl = ObjExpireTime(prev_entry); prev_ttl != UINT32_MAX) {
-        ObjUpdateExpireTime(newkey, prev_ttl);
-      }
+    const bool prev_has_ttl =
+        absl::little_endian::Load64(prev_entry + sdslen(prev_entry) + 1) & kValTtlBit;
+    if (keepttl && prev_has_ttl) {
+      SdsUpdateExpireTime(newkey, ObjExpireTime(prev_entry), 8);
     }
     ObjDelete(prev_entry, false);
     return false;

--- a/src/core/string_map.h
+++ b/src/core/string_map.h
@@ -104,7 +104,8 @@ class StringMap : public DenseSet {
   };
 
   // otherwise updates its value and returns false.
-  bool AddOrUpdate(std::string_view field, std::string_view value, uint32_t ttl_sec = UINT32_MAX);
+  bool AddOrUpdate(std::string_view field, std::string_view value, uint32_t ttl_sec = UINT32_MAX,
+                   bool keepttl = false);
 
   // Returns true if field was added
   // false, if already exists. In that case no update is done.

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -607,6 +607,7 @@ OpResult<size_t> OpStrLen(const OpArgs& op_args, string_view key, string_view fi
 struct OpSetParams {
   bool skip_if_exists = false;
   uint32_t ttl = UINT32_MAX;
+  bool keepttl = false;
 };
 
 OpResult<uint32_t> OpSet(const OpArgs& op_args, string_view key, CmdArgList values,
@@ -673,7 +674,7 @@ OpResult<uint32_t> OpSet(const OpArgs& op_args, string_view key, CmdArgList valu
       if (op_sp.skip_if_exists)
         added = sm->AddOrSkip(field, value, op_sp.ttl);
       else
-        added = sm->AddOrUpdate(field, value, op_sp.ttl);
+        added = sm->AddOrUpdate(field, value, op_sp.ttl, op_sp.keepttl);
 
       created += unsigned(added);
     }
@@ -720,19 +721,44 @@ OpResult<vector<long>> OpHExpire(const OpArgs& op_args, string_view key, uint32_
   return HSetFamily::SetFieldsExpireTime(op_args, ttl_sec, key, values, pv);
 }
 
-// HSETEX key [NX] tll_sec field value field value ...
+enum class HSetExOpts {
+  NX,
+  KEEPTTL,
+};
+
+OpSetParams LoadHSetExParams(CmdArgParser& parser) {
+  OpSetParams op_sp{};
+
+  auto res = parser.TryMapNext("NX"sv, HSetExOpts::NX, "KEEPTTL"sv, HSetExOpts::KEEPTTL);
+  while (res.has_value()) {
+    switch (res.value()) {
+      case HSetExOpts::NX:
+        op_sp.skip_if_exists = true;
+        break;
+      case HSetExOpts::KEEPTTL:
+        op_sp.keepttl = true;
+        break;
+    }
+    res = parser.TryMapNext("NX"sv, HSetExOpts::NX, "KEEPTTL"sv, HSetExOpts::KEEPTTL);
+  }
+
+  // Conversion errors are handled by caller
+  op_sp.ttl = parser.Next<uint32_t>();
+  return op_sp;
+}
+
+// HSETEX key [NX] [KEEPTTL] tll_sec field value field value ...
 void HSetEx(CmdArgList args, const CommandContext& cmd_cntx) {
   CmdArgParser parser{args};
 
   string_view key = parser.Next();
+  OpSetParams op_sp = LoadHSetExParams(parser);
+  if (parser.HasError()) {
+    return cmd_cntx.rb->SendError(parser.Error()->MakeReply());
+  }
 
-  bool skip_if_exists = static_cast<bool>(parser.Check("NX"sv));
-  string_view ttl_str = parser.Next();
-
-  uint32_t ttl_sec;
   constexpr uint32_t kMaxTtl = (1UL << 26);
-
-  if (!absl::SimpleAtoi(ttl_str, &ttl_sec) || ttl_sec == 0 || ttl_sec > kMaxTtl) {
+  if (op_sp.ttl == 0 || op_sp.ttl > kMaxTtl) {
     return cmd_cntx.rb->SendError(kInvalidIntErr);
   }
 
@@ -742,8 +768,6 @@ void HSetEx(CmdArgList args, const CommandContext& cmd_cntx) {
     return cmd_cntx.rb->SendError(facade::WrongNumArgsError(cmd_cntx.conn_cntx->cid->name()),
                                   kSyntaxErrType);
   }
-
-  OpSetParams op_sp{skip_if_exists, ttl_sec};
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpSet(t->GetOpArgs(shard), key, fields, op_sp);

--- a/src/server/hset_family_test.cc
+++ b/src/server/hset_family_test.cc
@@ -399,6 +399,12 @@ TEST_F(HSetFamilyTest, HSetEx) {
   // Invalid TTL handling
   EXPECT_THAT(Run({"HSETEX", "k", "NX", "zero", "kttlfield", "value"}),
               ErrArg("ERR value is not an integer or out of range"));
+
+  // Exercise the code path where a field is added without TTL, but then we set a new expiration AND
+  // provide KEEPTTL. Since there was no old expiry, the new TTL should be applied.
+  EXPECT_EQ(Run({"HSET", "k", "nottl", "val"}), 1);
+  EXPECT_EQ(Run({"HSETEX", "k", "KEEPTTL", long_time, "nottl", "newval"}), 0);
+  EXPECT_EQ(Run({"FIELDTTL", "k", "nottl"}).GetInt(), 100);
 }
 
 TEST_F(HSetFamilyTest, TriggerConvertToStrMap) {

--- a/src/server/hset_family_test.cc
+++ b/src/server/hset_family_test.cc
@@ -372,6 +372,8 @@ TEST_F(HSetFamilyTest, HSetEx) {
   // KEEPTTL resets value of kttlfield, but preserves its TTL. afield is added with TTL=1
   EXPECT_THAT(Run({"HSETEX", "k", "KEEPTTL", "1", "kttlfield", "resetvalue", "afield", "aval"}),
               IntArg(1));
+  EXPECT_EQ(Run({"FIELDTTL", "k", "kttlfield"}).GetInt(), long_time);
+  EXPECT_EQ(Run({"FIELDTTL", "k", "afield"}).GetInt(), 1);
   EXPECT_EQ(Run({"HGET", "k", "afield"}), "aval");
   // make afield expire
   AdvanceTime(1000);


### PR DESCRIPTION
The `KEEPTTL` option is added to `HSetEx` command. 

This option if specified makes sure that TTL is preserved for existing members. It coexists along with the `NX` option and should be specified at the start of the command:

```
HSETEX key [NX] [KEEPTTL] seconds field value [field value ...]
```

fixes https://github.com/dragonflydb/dragonfly/issues/4701