### PR TITLE
chore: Add clion build path to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ releases
 .idea/*
 .hypothesis
 .secrets
+cmake-build-debug


### PR DESCRIPTION
`cmake-build-debug` is managed by clion. added to gitignore