### PR TITLE
server: control cluster migration speed with flag

### DIFF
--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -2136,7 +2136,9 @@ async def test_cluster_migration_huge_container(df_factory: DflyInstanceFactory)
     assert extract_int_after_prefix("buckets on_db_update ", line) == 0
 
 
-@dfly_args({"proactor_threads": 2, "cluster_mode": "yes"})
+@dfly_args(
+    {"proactor_threads": 2, "cluster_mode": "yes", "migration_buckets_serialization_threshold": 3}
+)
 @pytest.mark.parametrize("chunk_size", [1_000_000, 30])
 @pytest.mark.asyncio
 @pytest.mark.exclude_epoll


### PR DESCRIPTION
fix #4578
The problem:
When creating test with not a lot of data migration is fast and we are not able to test the flows of On db change and journal changes.
The fix:
Instead of increasing the data in tests which makes the test slower, I intorduce a flag which controls the speed of migration. By setting low value the migration process gives more time for commands to run at the time of cluster migration.
