### PR TITLE
feat: add an option to start using iouring provided buffers

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -32,6 +32,8 @@
 
 #ifdef __linux__
 #include "util/fibers/uring_file.h"
+#include "util/fibers/uring_proactor.h"
+#include "util/fibers/uring_socket.h"
 #endif
 
 using namespace std;
@@ -987,6 +989,8 @@ io::Result<bool> Connection::CheckForHttpProto() {
 void Connection::ConnectionFlow() {
   DCHECK(reply_builder_);
 
+  ConfigureProvidedBuffer();
+
   ++stats_->num_conns;
   ++stats_->conn_received_cnt;
   stats_->read_buf_capacity += io_buf_.Capacity();
@@ -1150,8 +1154,13 @@ Connection::ParserStatus Connection::ParseRedis() {
     return {FromArgs(std::move(parse_args), tlh)};
   };
 
+  ReadBuffer read_buffer = GetReadBuffer();
+
   do {
-    result = redis_parser_->Parse(io_buf_.InputBuffer(), &consumed, &parse_args);
+    if (read_buffer.ShouldAdvance()) {  // can happen only with io_uring/bundles
+      read_buffer.slice = NextBundleBuffer(read_buffer.available_bytes);
+    }
+    result = redis_parser_->Parse(read_buffer.slice, &consumed, &parse_args);
     request_consumed_bytes_ += consumed;
     if (result == RedisParser::OK && !parse_args.empty()) {
       if (RespExpr& first = parse_args.front(); first.type == RespExpr::STRING)
@@ -1160,7 +1169,7 @@ Connection::ParserStatus Connection::ParseRedis() {
       if (io_req_size_hist)
         io_req_size_hist->Add(request_consumed_bytes_);
       request_consumed_bytes_ = 0;
-      bool has_more = consumed < io_buf_.InputLen();
+      bool has_more = consumed < read_buffer.available_bytes;
 
       if (tl_traffic_logger.log_file && IsMain() /* log only on the main interface */) {
         LogTraffic(id_, has_more, absl::MakeSpan(parse_args), service_->GetContextInfo(cc_.get()));
@@ -1168,15 +1177,23 @@ Connection::ParserStatus Connection::ParseRedis() {
 
       DispatchSingle(has_more, dispatch_sync, dispatch_async);
     }
-    io_buf_.ConsumeInput(consumed);
-  } while (RedisParser::OK == result && io_buf_.InputLen() > 0 && !reply_builder_->GetError());
+    read_buffer.Consume(consumed);
+  } while (RedisParser::OK == result && read_buffer.available_bytes > 0 &&
+           !reply_builder_->GetError());
+
+  MarkReadBufferConsumed();
 
   parser_error_ = result;
   if (result == RedisParser::OK)
     return OK;
 
-  if (result == RedisParser::INPUT_PENDING)
+  if (result == RedisParser::INPUT_PENDING) {
+    DCHECK_EQ(read_buffer.available_bytes, 0u);
+
     return NEED_MORE;
+  }
+
+  VLOG(1) << "Parser error " << result;
 
   return ERROR;
 }
@@ -1305,26 +1322,41 @@ void Connection::HandleMigrateRequest() {
 }
 
 error_code Connection::HandleRecvSocket() {
-  io::MutableBytes append_buf = io_buf_.AppendBuffer();
-  DCHECK(!append_buf.empty());
-
   phase_ = READ_SOCKET;
-  error_code ec;
 
-  ::io::Result<size_t> recv_sz = socket_->Recv(append_buf);
-  last_interaction_ = time(nullptr);
+  // We can use provided buffers only after we emptied io_buf_.
+  if (recv_provided_ && io_buf_.InputBuffer().empty()) {
+    stats_->num_recv_provided_calls++;
 
-  if (!recv_sz) {
-    return recv_sz.error();
+    unsigned res = socket_->RecvProvided(1, &recv_buf_);
+    CHECK_EQ(res, 1u);
+    if (recv_buf_.res_len < 0) {
+      return error_code{-recv_buf_.res_len, system_category()};
+    }
+
+    CHECK_EQ(recv_buf_.type, FiberSocketBase::kBufRingType);  // We only support this type.
+    CHECK_GT(recv_buf_.res_len, 0);
+
+    stats_->io_read_bytes += recv_buf_.res_len;
+  } else {
+    io::MutableBytes append_buf = io_buf_.AppendBuffer();
+    DCHECK(!append_buf.empty());
+
+    ::io::Result<size_t> recv_sz = socket_->Recv(append_buf);
+    last_interaction_ = time(nullptr);
+
+    if (!recv_sz) {
+      return recv_sz.error();
+    }
+
+    size_t commit_sz = *recv_sz;
+    io_buf_.CommitWrite(commit_sz);
+    stats_->io_read_bytes += commit_sz;
   }
 
-  size_t commit_sz = *recv_sz;
-
-  io_buf_.CommitWrite(commit_sz);
-  stats_->io_read_bytes += commit_sz;
   ++stats_->io_read_cnt;
 
-  return ec;
+  return {};
 }
 
 auto Connection::IoLoop() -> variant<error_code, ParserStatus> {
@@ -1333,6 +1365,7 @@ auto Connection::IoLoop() -> variant<error_code, ParserStatus> {
 
   size_t max_iobfuf_len = GetFlag(FLAGS_max_client_iobuf_len);
   auto* peer = socket_.get();
+  recv_buf_.res_len = 0;
 
   do {
     HandleMigrateRequest();
@@ -1898,6 +1931,66 @@ void Connection::BreakOnce(uint32_t ev_mask) {
     auto fun = std::move(breaker_cb_);
     DCHECK(!breaker_cb_);
     fun(ev_mask);
+  }
+}
+
+void Connection::ConfigureProvidedBuffer() {
+  // Provided buffers are supported by IOURING.
+  // We currently support them for TCP sockets only.
+  if (socket_->proactor()->GetKind() == ProactorBase::IOURING && !is_tls_) {
+#ifdef __linux__
+    auto* up = static_cast<fb2::UringProactor*>(socket_->proactor());
+
+    // If bufring is enabled, configure the socket to use it.
+    recv_provided_ = up->BufRingEntrySize(kRecvSockGid) > 0;
+    if (recv_provided_) {
+      auto* us = static_cast<fb2::UringSocket*>(socket_.get());
+      us->set_bufring_id(kRecvSockGid);
+      us->EnableRecvMultishot();
+    }
+#endif
+  }
+}
+
+auto Connection::GetReadBuffer() -> ReadBuffer {
+  bool use_recv_buf = recv_provided_ && recv_buf_.res_len > 0;
+  ReadBuffer res;
+
+  if (use_recv_buf) {
+    uint8_t* src = nullptr;
+#ifdef __linux__
+    fb2::UringProactor* up = static_cast<fb2::UringProactor*>(socket_->proactor());
+    src = up->GetBufRingPtr(kRecvSockGid, recv_buf_.buf_id);
+#endif
+    res.available_bytes = recv_buf_.res_len;
+    res.slice = {src, std::min<size_t>(kRecvBufSize, res.available_bytes)};
+  } else {
+    res.slice = io_buf_.InputBuffer();
+    res.available_bytes = io_buf_.InputLen();
+  }
+  return res;
+}
+
+io::Bytes Connection::NextBundleBuffer(size_t total_len) {
+  ++recv_buf_.buf_pos;
+  io::Bytes res;
+#ifdef __linux__
+  fb2::UringProactor* up = static_cast<fb2::UringProactor*>(socket_->proactor());
+  recv_buf_.buf_id = up->GetBufIdByPos(kRecvSockGid, recv_buf_.buf_pos);
+  uint8_t* src = up->GetBufRingPtr(kRecvSockGid, recv_buf_.buf_id);
+  res = {src, std::min<size_t>(kRecvBufSize, total_len)};
+#endif
+
+  return res;
+}
+
+void Connection::MarkReadBufferConsumed() {
+  bool use_recv_buf = recv_provided_ && recv_buf_.res_len > 0;
+  if (use_recv_buf) {
+    socket_->ReturnProvided(recv_buf_);
+    recv_buf_.res_len = 0;
+  } else {
+    io_buf_.ConsumeInput(io_buf_.InputLen());
   }
 }
 

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -385,6 +385,29 @@ class Connection : public util::Connection {
   void DecreaseStatsOnClose();
   void BreakOnce(uint32_t ev_mask);
 
+  void ConfigureProvidedBuffer();
+
+  // The read buffer with read data that needs to be parsed and processed.
+  // For io_uring bundles we may have available_bytes larger than slice.size()
+  // which means that there are more buffers available to read.
+  struct ReadBuffer {
+    size_t available_bytes;
+    io::Bytes slice;
+
+    bool ShouldAdvance() const {
+      return slice.empty();
+    }
+
+    void Consume(size_t len) {
+      available_bytes -= len;
+      slice.remove_prefix(len);
+    }
+  };
+
+  ReadBuffer GetReadBuffer();
+  io::Bytes NextBundleBuffer(size_t total_len);
+  void MarkReadBufferConsumed();
+
   std::deque<MessageHandle> dispatch_q_;  // dispatch queue
   util::fb2::CondVarAny cnd_;             // dispatch queue waker
   util::fb2::Fiber async_fb_;             // async fiber (if started)
@@ -394,6 +417,7 @@ class Connection : public util::Connection {
   // how many bytes of the current request have been consumed
   size_t request_consumed_bytes_ = 0;
 
+  util::FiberSocketBase::ProvidedBuffer recv_buf_;
   io::IoBuf io_buf_;  // used in io loop and parsers
   std::unique_ptr<RedisParser> redis_parser_;
   std::unique_ptr<MemcacheParser> memcache_parser_;
@@ -448,6 +472,7 @@ class Connection : public util::Connection {
       bool migration_in_process_ : 1;
       bool is_http_ : 1;
       bool is_tls_ : 1;
+      bool recv_provided_ : 1;
     };
   };
 };

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -20,7 +20,7 @@ constexpr size_t kSizeConnStats = sizeof(ConnectionStats);
 
 ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
   // To break this code deliberately if we add/remove a field to this struct.
-  static_assert(kSizeConnStats == 112u);
+  static_assert(kSizeConnStats == 120u);
 
   ADD(read_buf_capacity);
   ADD(dispatch_queue_entries);
@@ -36,6 +36,7 @@ ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
   ADD(num_conns);
   ADD(num_blocked_clients);
   ADD(num_migrations);
+  ADD(num_recv_provided_calls);
   ADD(pipeline_throttle_count);
 
   return *this;

--- a/src/facade/facade_test.cc
+++ b/src/facade/facade_test.cc
@@ -34,7 +34,7 @@ bool RespMatcher::MatchAndExplain(RespExpr e, MatchResultListener* listener) con
 
   if (type_ == RespExpr::STRING || type_ == RespExpr::ERROR) {
     RespExpr::Buffer ebuf = e.GetBuf();
-    std::string_view actual{reinterpret_cast<char*>(ebuf.data()), ebuf.size()};
+    std::string_view actual{reinterpret_cast<const char*>(ebuf.data()), ebuf.size()};
 
     if (type_ == RespExpr::ERROR && !absl::StrContains(actual, exp_str_)) {
       *listener << "Actual does not contain '" << exp_str_ << "'";

--- a/src/facade/facade_types.h
+++ b/src/facade/facade_types.h
@@ -107,6 +107,7 @@ struct ConnectionStats {
   uint32_t num_conns = 0;
   uint32_t num_blocked_clients = 0;
   uint64_t num_migrations = 0;
+  uint64_t num_recv_provided_calls = 0;
 
   // Number of events when the pipeline queue was over the limit and was throttled.
   uint64_t pipeline_throttle_count = 0;
@@ -186,6 +187,8 @@ void ResetStats();
 
 // Constants for socket bufring.
 constexpr uint16_t kRecvSockGid = 0;
+
+// Size of the buffer in bufring (kRecvSockGid).
 constexpr size_t kRecvBufSize = 128;
 
 }  // namespace facade

--- a/src/facade/redis_parser.cc
+++ b/src/facade/redis_parser.cc
@@ -185,11 +185,11 @@ void RedisParser::StashState(RespExpr::Vec* res) {
 auto RedisParser::ParseInline(Buffer str) -> ResultConsumed {
   DCHECK(!str.empty());
 
-  uint8_t* ptr = str.begin();
-  uint8_t* end = str.end();
-  uint8_t* token_start = ptr;
+  const uint8_t* ptr = str.begin();
+  const uint8_t* end = str.end();
+  const uint8_t* token_start = ptr;
 
-  auto find_token_end = [](uint8_t* ptr, uint8_t* end) {
+  auto find_token_end = [](const uint8_t* ptr, const uint8_t* end) {
     while (ptr != end && *ptr > 32)
       ++ptr;
     return ptr;
@@ -411,8 +411,8 @@ auto RedisParser::ParseArg(Buffer str) -> ResultConsumed {
     return ConsumeArrayLen(str);
   }
 
-  char* s = reinterpret_cast<char*>(str.data());
-  char* eol = reinterpret_cast<char*>(memchr(s, '\n', str.size()));
+  const char* s = reinterpret_cast<const char*>(str.data());
+  const char* eol = reinterpret_cast<const char*>(memchr(s, '\n', str.size()));
 
   // TODO: in client mode we still may not consume everything (see INPUT_PENDING below).
   // It's not a problem, because we need consume all the input only in server mode.
@@ -428,7 +428,7 @@ auto RedisParser::ParseArg(Buffer str) -> ResultConsumed {
       return {BAD_STRING, 0};
 
     cached_expr_->emplace_back(arg_c_ == '+' ? RespExpr::STRING : RespExpr::ERROR);
-    cached_expr_->back().u = Buffer{reinterpret_cast<uint8_t*>(s), size_t((eol - 1) - s)};
+    cached_expr_->back().u = Buffer{reinterpret_cast<const uint8_t*>(s), size_t((eol - 1) - s)};
   } else if (arg_c_ == ':') {
     DCHECK(!server_mode_);
     if (!eol) {
@@ -477,7 +477,7 @@ auto RedisParser::ConsumeBulk(Buffer str) -> ResultConsumed {
       // is_broken_token_ can be false, if we just parsed the bulk length but have
       // not parsed the token itself.
       if (is_broken_token_) {
-        memcpy(bulk_str.end(), str.data(), bulk_len_);
+        memcpy(const_cast<uint8_t*>(bulk_str.end()), str.data(), bulk_len_);
         bulk_str = Buffer{bulk_str.data(), bulk_str.size() + bulk_len_};
       } else {
         bulk_str = str.subspan(0, bulk_len_);
@@ -506,7 +506,7 @@ auto RedisParser::ConsumeBulk(Buffer str) -> ResultConsumed {
   size_t len = std::min<size_t>(str.size(), bulk_len_);
 
   if (is_broken_token_) {
-    memcpy(bulk_str.end(), str.data(), len);
+    memcpy(const_cast<uint8_t*>(bulk_str.end()), str.data(), len);
     bulk_str = Buffer{bulk_str.data(), bulk_str.size() + len};
     DVLOG(1) << "Extending bulk stash to size " << bulk_str.size();
   } else {

--- a/src/facade/resp_expr.h
+++ b/src/facade/resp_expr.h
@@ -18,7 +18,7 @@ namespace facade {
 
 class RespExpr {
  public:
-  using Buffer = absl::Span<uint8_t>;
+  using Buffer = absl::Span<const uint8_t>;
 
   enum Type : uint8_t { STRING, ARRAY, INT64, DOUBLE, NIL, NIL_ARRAY, ERROR };
 
@@ -70,7 +70,7 @@ using RespVec = RespExpr::Vec;
 using RespSpan = absl::Span<const RespExpr>;
 
 inline std::string_view ToSV(RespExpr::Buffer buf) {
-  return std::string_view{reinterpret_cast<char*>(buf.data()), buf.size()};
+  return std::string_view{reinterpret_cast<const char*>(buf.data()), buf.size()};
 }
 
 }  // namespace facade

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2422,6 +2422,7 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
     append("pipelined_latency_usec", conn_stats.pipelined_cmd_latency);
     append("total_net_input_bytes", conn_stats.io_read_bytes);
     append("connection_migrations", conn_stats.num_migrations);
+    append("connection_recv_provided_calls", conn_stats.num_recv_provided_calls);
     append("total_net_output_bytes", reply_stats.io_write_bytes);
     append("rdb_save_usec", m.coordinator_stats.rdb_save_usec);
     append("rdb_save_count", m.coordinator_stats.rdb_save_count);


### PR DESCRIPTION
iouring allows to register a pool of predefined buffers used by kernel. then during the recv operation the kernel will choose a buffer from the pool, copy data into it and return it to the application. This is in contrast to prealocate buffers that need to be passed to a regular Recv. So, for example, if we have 10000 connections, today we preallocate 10000 buffers, even though we may have only 100 in-flight requests.

This PR does not retire the old approach, but extends with the new once with the flag `--uring_recv_buffer_cnt=N` that specifies how many receive buffers per thread to preallocate.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->