### PR TITLE
fix(transaction): Fix auto journaling in transaction

### DIFF
--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -697,9 +697,11 @@ OpResult<streamID> OpAdd(const OpArgs& op_args, string_view key, const AddOpts& 
 
   stream* stream_inst = (stream*)it->second.RObjPtr();
 
-  streamID result_id;
   const auto& parsed_id = opts.parsed_id;
   streamID passed_id = parsed_id.val;
+  DCHECK(!op_args.shard->IsReplica() || (op_args.shard->IsReplica() && parsed_id.id_given));
+
+  streamID result_id;
   int res = StreamAppendItem(stream_inst, args, op_args.db_cntx.time_now_ms, &result_id,
                              parsed_id.id_given ? &passed_id : nullptr, parsed_id.has_seq);
 

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -697,11 +697,9 @@ OpResult<streamID> OpAdd(const OpArgs& op_args, string_view key, const AddOpts& 
 
   stream* stream_inst = (stream*)it->second.RObjPtr();
 
+  streamID result_id;
   const auto& parsed_id = opts.parsed_id;
   streamID passed_id = parsed_id.val;
-  DCHECK(!op_args.shard->IsReplica() || (op_args.shard->IsReplica() && parsed_id.id_given));
-
-  streamID result_id;
   int res = StreamAppendItem(stream_inst, args, op_args.db_cntx.time_now_ms, &result_id,
                              parsed_id.id_given ? &passed_id : nullptr, parsed_id.has_seq);
 

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -499,6 +499,7 @@ void Transaction::MultiSwitchCmd(const CommandId* cid) {
   kv_fp_.clear();
 
   cid_ = cid;
+  re_enabled_auto_journal_ = false;
   cb_ptr_ = nullptr;
 
   for (auto& sd : shard_data_) {


### PR DESCRIPTION
1. The first bug is that we were not resetting `re_enabled_auto_journal_` in the transaction. For example, if we are in multi-mode and one of the commands calls `ReviveAutoJournal`, the next commands with `CO::NO_AUTOJOURNAL` will still be auto-journaled because we didn't set `re_enabled_auto_journal_` to false
2. The second bug is specific to the STREAM logic. The `streamId` is generated using Unix time, which can differ between the master and the replica, potentially causing replication issues. To fix this, we need to pass `time_now_ms` from the master to the replica. To achieve this, the `TIMENOW` option was added to the `XADD` command.