### PR TITLE
chore(zset_family/score_map): Replace sds arguments with string_view

### DIFF
--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -75,7 +75,7 @@ class RobjWrapper {
   bool DefragIfNeeded(float ratio);
 
   // as defined in zset.h
-  int ZsetAdd(double score, char* ele, int in_flags, int* out_flags, double* newscore);
+  int ZsetAdd(double score, std::string_view ele, int in_flags, int* out_flags, double* newscore);
 
  private:
   void ReallocateString(MemoryResource* mr);

--- a/src/core/sorted_map.h
+++ b/src/core/sorted_map.h
@@ -50,7 +50,7 @@ class SortedMap {
   // No score update is performed in this case.
   bool InsertNew(double score, std::string_view member);
 
-  bool Delete(sds ele);
+  bool Delete(std::string_view ele) const;
 
   // Upper bound size of the set.
   // Note: Currently we do not allow member expiry in sorted sets, therefore it's exact
@@ -67,7 +67,7 @@ class SortedMap {
 
   ScoredArray PopTopScores(unsigned count, bool reverse);
 
-  std::optional<double> GetScore(sds ele) const;
+  std::optional<double> GetScore(std::string_view ele) const;
   std::optional<unsigned> GetRank(std::string_view ele, bool reverse) const;
   std::optional<RankAndScore> GetRankAndScore(std::string_view ele, bool reverse) const;
   ScoredArray GetRange(const zrangespec& r, unsigned offs, unsigned len, bool rev) const;
@@ -117,7 +117,8 @@ class SortedMap {
 };
 
 // Used by CompactObject.
-unsigned char* ZzlInsert(unsigned char* zl, sds ele, double score);
+unsigned char* ZzlInsert(unsigned char* zl, std::string_view ele, double score);
+unsigned char* ZzlFind(unsigned char* lp, std::string_view ele, double* score);
 
 }  // namespace detail
 }  // namespace dfly

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -159,6 +159,12 @@ TEST_F(ZSetFamilyTest, Add) {
   Run({"zadd", "zs", kHighPrecision, "a"});
   EXPECT_EQ(Run({"zscore", "zs", "a"}), "0.7902857334307795");
   EXPECT_EQ(0.79028573343077946, 0.7902857334307795);
+
+  resp = Run({"zadd", "x", "1.1", ""});
+  EXPECT_THAT(resp, IntArg(1));
+
+  resp = Run({"zscore", "x", ""});
+  EXPECT_EQ(resp, "1.1");
 }
 
 TEST_F(ZSetFamilyTest, AddNonUniqeMembers) {


### PR DESCRIPTION
The usages of WrapSds are removed from zset_family calls.

In most cases it is a straightforward change to use string_view or string_view.data(), string_view.size(). 

In one case a wrapper had to be introduced.

fixes https://github.com/dragonflydb/dragonfly/issues/4639
