### PR TITLE
fix: enforce strong consistency in channel_store

### DIFF
--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -2943,7 +2943,6 @@ async def test_migration_rebalance_node(df_factory: DflyInstanceFactory, df_seed
     assert await seeder.compare(capture, nodes[1].instance.port)
 
 
-@pytest.mark.skip("Flaky test")
 @dfly_args({"proactor_threads": 2, "cluster_mode": "yes"})
 async def test_cluster_sharded_pub_sub(df_factory: DflyInstanceFactory):
     nodes = [df_factory.create(port=next(next_port)) for i in range(2)]

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -2969,6 +2969,9 @@ async def test_cluster_sharded_pub_sub(df_factory: DflyInstanceFactory):
     consumer.ssubscribe("kostas")
 
     await c_nodes[0].execute_command("SPUBLISH kostas hello")
+    # We need to sleep cause we use DispatchBrief internally. Otherwise we can't really gurantee
+    # that the client received the message
+    await asyncio.sleep(1)
 
     # Consume subscription message result from above
     message = consumer.get_sharded_message(target_node=node_a)
@@ -2978,6 +2981,7 @@ async def test_cluster_sharded_pub_sub(df_factory: DflyInstanceFactory):
     assert message == {"type": "message", "pattern": None, "channel": b"kostas", "data": b"hello"}
 
     consumer.sunsubscribe("kostas")
+    await asyncio.sleep(1)
     await c_nodes[0].execute_command("SPUBLISH kostas new_message")
     message = consumer.get_sharded_message(target_node=node_a)
     assert message == {"type": "unsubscribe", "pattern": None, "channel": b"kostas", "data": 0}


### PR DESCRIPTION
Channel store uses a `read-copy-update` to distribute the changes of the channel store to all proactors. The problem is that we use `memory_order_relaxed` to load the new pointer to the channel store for each proactor which `*does not guarantee*` that we fetch the latest value of the channel store. Hence, the fix is to use sequencial consistency such to force fetch the latest value of the channel store. Should fix #4724

Fixes #4659 and #4724