### PR TITLE
refactor: add ability to reinit incoming migration object

### DIFF
--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -87,10 +87,10 @@ class ClusterFamily {
 
   void DflyMigrateAck(CmdArgList args, SinkReplyBuilder* builder);
 
-  std::shared_ptr<IncomingSlotMigration> GetIncomingMigration(std::string_view source_id)
+  std::shared_ptr<IncomingMigration> GetIncomingMigration(std::string_view source_id)
       ABSL_LOCKS_EXCLUDED(migration_mu_);
 
-  void StartSlotMigrations(std::vector<MigrationInfo> migrations);
+  void StartNewSlotMigrations(std::shared_ptr<ClusterConfig> new_config);
 
   // must be destroyed excluded set_config_mu and migration_mu_ locks
   struct PreparedToRemoveOutgoingMigrations {
@@ -105,13 +105,9 @@ class ClusterFamily {
   void RemoveIncomingMigrations(const std::vector<MigrationInfo>& migrations)
       ABSL_LOCKS_EXCLUDED(migration_mu_);
 
-  // store info about migration and create unique session id
-  std::shared_ptr<OutgoingMigration> CreateOutgoingMigration(MigrationInfo info)
-      ABSL_LOCKS_EXCLUDED(migration_mu_);
-
   mutable util::fb2::Mutex migration_mu_;  // guard migrations operations
   // holds all incoming slots migrations that are currently in progress.
-  std::vector<std::shared_ptr<IncomingSlotMigration>> incoming_migrations_jobs_
+  std::vector<std::shared_ptr<IncomingMigration>> incoming_migration_jobs_
       ABSL_GUARDED_BY(migration_mu_);
 
   // holds all outgoing slots migrations that are currently in progress

--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -90,7 +90,7 @@ class ClusterFamily {
   std::shared_ptr<IncomingMigration> GetIncomingMigration(std::string_view source_id)
       ABSL_LOCKS_EXCLUDED(migration_mu_);
 
-  void StartNewSlotMigrations(std::shared_ptr<ClusterConfig> new_config);
+  void StartNewSlotMigrations(const ClusterConfig& new_config);
 
   // must be destroyed excluded set_config_mu and migration_mu_ locks
   struct PreparedToRemoveOutgoingMigrations {

--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -87,7 +87,7 @@ class ClusterFamily {
 
   void DflyMigrateAck(CmdArgList args, SinkReplyBuilder* builder);
 
-  std::shared_ptr<IncomingMigration> GetIncomingMigration(std::string_view source_id)
+  std::shared_ptr<IncomingSlotMigration> GetIncomingMigration(std::string_view source_id)
       ABSL_LOCKS_EXCLUDED(migration_mu_);
 
   void StartNewSlotMigrations(const ClusterConfig& new_config);
@@ -107,7 +107,7 @@ class ClusterFamily {
 
   mutable util::fb2::Mutex migration_mu_;  // guard migrations operations
   // holds all incoming slots migrations that are currently in progress.
-  std::vector<std::shared_ptr<IncomingMigration>> incoming_migrations_jobs_
+  std::vector<std::shared_ptr<IncomingSlotMigration>> incoming_migrations_jobs_
       ABSL_GUARDED_BY(migration_mu_);
 
   // holds all outgoing slots migrations that are currently in progress

--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -107,7 +107,7 @@ class ClusterFamily {
 
   mutable util::fb2::Mutex migration_mu_;  // guard migrations operations
   // holds all incoming slots migrations that are currently in progress.
-  std::vector<std::shared_ptr<IncomingMigration>> incoming_migration_jobs_
+  std::vector<std::shared_ptr<IncomingMigration>> incoming_migrations_jobs_
       ABSL_GUARDED_BY(migration_mu_);
 
   // holds all outgoing slots migrations that are currently in progress

--- a/src/server/cluster/incoming_slot_migration.h
+++ b/src/server/cluster/incoming_slot_migration.h
@@ -17,10 +17,10 @@ class ClusterShardMigration;
 // The main entity on the target side that manage slots migration process
 // Manage connections between the target and source node,
 // manage migration process state and data
-class IncomingMigration {
+class IncomingSlotMigration {
  public:
-  IncomingMigration(std::string source_id, Service* se, SlotRanges slots);
-  ~IncomingMigration();
+  IncomingSlotMigration(std::string source_id, Service* se, SlotRanges slots);
+  ~IncomingSlotMigration();
 
   // process data from FDLYMIGRATE FLOW cmd
   // executes until Stop called or connection closed

--- a/src/server/cluster/outgoing_slot_migration.h
+++ b/src/server/cluster/outgoing_slot_migration.h
@@ -8,7 +8,7 @@
 #include "server/transaction.h"
 
 namespace dfly {
-class DbSlice;
+
 class ServerFamily;
 
 namespace journal {


### PR DESCRIPTION
Made outgoing and incoming migration objects' lifetimes more similar