### PR TITLE
fix: optional brackets were removed for ipv6 host

### DIFF
--- a/src/server/protocol_client.cc
+++ b/src/server/protocol_client.cc
@@ -135,7 +135,13 @@ ProtocolClient::~ProtocolClient() {
 
 error_code ProtocolClient::ResolveHostDns() {
   char ip_addr[INET6_ADDRSTRLEN];
-  auto ec = util::fb2::DnsResolve(server_context_.host, 0, ip_addr, ProactorBase::me());
+
+  std::string host = server_context_.host;
+  if (!host.empty() && host.front() == '[' && host.back() == ']') {
+    host = host.substr(1, host.size() - 2);
+  }
+
+  auto ec = util::fb2::DnsResolve(host, 0, ip_addr, ProactorBase::me());
   if (ec) {
     LOG(ERROR) << "Dns error " << ec << ", host: " << server_context_.host;
     return make_error_code(errc::host_unreachable);

--- a/src/server/protocol_client.cc
+++ b/src/server/protocol_client.cc
@@ -136,6 +136,10 @@ ProtocolClient::~ProtocolClient() {
 error_code ProtocolClient::ResolveHostDns() {
   char ip_addr[INET6_ADDRSTRLEN];
 
+  // IPv6 address can be enclosed in square brackets.
+  // https://www.rfc-editor.org/rfc/rfc2732#section-2
+  // We need to remove the brackets before resolving the DNS.
+  // Enclosed IPv6 addresses can't be resolved by the DNS resolver.
   std::string host = server_context_.host;
   if (!host.empty() && host.front() == '[' && host.back() == ']') {
     host = host.substr(1, host.size() - 2);


### PR DESCRIPTION
fix: optional brackets were removed for IPv6 host
fix: ipv6 support fix in the helio framework: https://github.com/romange/helio/pull/391