### PR TITLE
fix: proper memory accounting for objects loaded via streaming

### DIFF
--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -582,6 +582,8 @@ TEST_F(RdbTest, LoadHugeSet) {
 
   ASSERT_EQ(100000, CheckedInt({"scard", "test:0"}));
   ASSERT_EQ(100000, CheckedInt({"scard", "test:1"}));
+  auto metrics = GetMetrics();
+  EXPECT_GT(metrics.db_stats[0].obj_memory_usage, 24'000'000u);
 }
 
 // Tests loading a huge hmap, where the map is loaded in multiple partial
@@ -602,6 +604,8 @@ TEST_F(RdbTest, LoadHugeHMap) {
 
   ASSERT_EQ(100000, CheckedInt({"hlen", "test:0"}));
   ASSERT_EQ(100000, CheckedInt({"hlen", "test:1"}));
+  auto metrics = GetMetrics();
+  EXPECT_GT(metrics.db_stats[0].obj_memory_usage, 29'000'000u);
 }
 
 // Tests loading a huge zset, where the zset is loaded in multiple partial
@@ -622,6 +626,8 @@ TEST_F(RdbTest, LoadHugeZSet) {
 
   ASSERT_EQ(100000, CheckedInt({"zcard", "test:0"}));
   ASSERT_EQ(100000, CheckedInt({"zcard", "test:1"}));
+  auto metrics = GetMetrics();
+  EXPECT_GT(metrics.db_stats[0].obj_memory_usage, 26'000'000u);
 }
 
 // Tests loading a huge list, where the list is loaded in multiple partial
@@ -642,6 +648,8 @@ TEST_F(RdbTest, LoadHugeList) {
 
   ASSERT_EQ(100000, CheckedInt({"llen", "test:0"}));
   ASSERT_EQ(100000, CheckedInt({"llen", "test:1"}));
+  auto metrics = GetMetrics();
+  EXPECT_GT(metrics.db_stats[0].obj_memory_usage, 20'000'000u);
 }
 
 // Tests loading a huge stream, where the stream is loaded in multiple partial


### PR DESCRIPTION
The bug: during the loading when appending to the existing object, ItAndUpdater scope did not account for the appended data, and as a result `object_used_memory` and its variation did not account for streamed objects.

The fix: to extend the scope of the ItAndUpdater object to cover appends. Added a sanity DCHECK that ensures that object_used_memory is at least as the memory used by a single object. This dcheck fails pre-fix.

Fixes #4773

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->