### PR TITLE
fix(json_family): Fix memory tracking for JSON

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -43,6 +43,13 @@ namespace {
 constexpr XXH64_hash_t kHashSeed = 24061983;
 constexpr size_t kAlignSize = 8u;
 
+// This is needed for LOG_EVERY_N to work.
+#ifdef NDEBUG
+#define FATAL_IF_DEBUG ERROR
+#else
+#define FATAL_IF_DEBUG FATAL
+#endif
+
 // Approximation since does not account for listpacks.
 size_t QlMAllocSize(quicklist* ql, bool slow) {
   size_t node_size = ql->len * sizeof(quicklistNode) + znallocx(sizeof(quicklist));
@@ -61,7 +68,8 @@ size_t UpdateSize(size_t size, int64_t update) {
   }
 
   int64_t result = static_cast<int64_t>(size) + update;
-  DCHECK_GE(result, 0) << "Can't decrease " << size << " from " << -update;
+  LOG_IF_EVERY_N(FATAL_IF_DEBUG, result < 0, 30)
+      << "Can't decrease " << size << " from " << -update;
   return result;
 }
 

--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -43,13 +43,6 @@ namespace {
 constexpr XXH64_hash_t kHashSeed = 24061983;
 constexpr size_t kAlignSize = 8u;
 
-// This is needed for LOG_EVERY_N to work.
-#ifdef NDEBUG
-#define FATAL_IF_DEBUG ERROR
-#else
-#define FATAL_IF_DEBUG FATAL
-#endif
-
 // Approximation since does not account for listpacks.
 size_t QlMAllocSize(quicklist* ql, bool slow) {
   size_t node_size = ql->len * sizeof(quicklistNode) + znallocx(sizeof(quicklist));
@@ -68,8 +61,10 @@ size_t UpdateSize(size_t size, int64_t update) {
   }
 
   int64_t result = static_cast<int64_t>(size) + update;
-  LOG_IF_EVERY_N(FATAL_IF_DEBUG, result < 0, 30)
-      << "Can't decrease " << size << " from " << -update;
+  if (result < 0) {
+    DCHECK(false) << "Can't decrease " << size << " from " << -update;
+    LOG_EVERY_N(ERROR, 30) << "Can't decrease " << size << " from " << -update;
+  }
   return result;
 }
 

--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -55,6 +55,16 @@ size_t QlMAllocSize(quicklist* ql, bool slow) {
   return node_size + ql->count * 16;  // we account for each member 16 bytes.
 }
 
+size_t UpdateSize(size_t size, int64_t update) {
+  if (update >= 0) {
+    return size + update;
+  }
+
+  int64_t result = static_cast<int64_t>(size) + update;
+  DCHECK_GE(result, 0) << "Can't decrease " << size << " from " << -update;
+  return result;
+}
+
 inline void FreeObjSet(unsigned encoding, void* ptr, MemoryResource* mr) {
   switch (encoding) {
     case kEncodingStrMap2: {
@@ -927,10 +937,7 @@ void CompactObj::SetJson(JsonType&& j) {
 void CompactObj::SetJsonSize(int64_t size) {
   if (taglen_ == JSON_TAG && JsonEnconding() == kEncodingJsonCons) {
     // JSON.SET or if mem hasn't changed from a JSON op then we just update.
-    if (size < 0) {
-      DCHECK(static_cast<int64_t>(u_.json_obj.cons.bytes_used) >= size);
-    }
-    u_.json_obj.cons.bytes_used += size;
+    u_.json_obj.cons.bytes_used = UpdateSize(u_.json_obj.cons.bytes_used, size);
   }
 }
 


### PR DESCRIPTION
fixes dragonflydb#4725

Bugs that were found:
1. The first bug was related to conversions between `size_t` and `int64_t`. We performed `size_t` += `int64_t` for negative values of `int64_t`. In this case, `int64_t` is first converted to a large `size_t` value before being added to `bytes_used`.
Additionally, this check doesn't make sense:
```cpp
if (size < 0) {
    DCHECK(static_cast<int64_t>(u_.json_obj.cons.bytes_used) >= size);
}
```

- Because `size_t` is always ≥ 0, while `size` here is < 0.
- I suggest avoiding operations that can potentially cause an overflow and adding utility functions to handle such cases safely.

2. The second bug was that `db_slice.AddOrFind` could deallocate some memory, at least due to `owner_->tiered_storage()->ReclaimMemory`. And `JsonMemTracker` was created before calling the `db_slice.AddOrFind` method. As a result, we initialized `start_size_` in `JsonMemTracker` with the currently used memory. However, `AddOrFind` might deallocate some memory, and later, when we call `SetJsonSize` after inserting a new JSON and calculating the current memory usage, the reported usage may decrease because `AddOrFind` has freed some memory. Here is the relevant snippet:
```
E20250318 16:19:37.185142 107026 json_family.cc:61] JsonMemTracker start size: 41418008
E20250318 16:19:37.185150 107026 json_family.cc:85] JsonMemTracker size: 41418008
E20250318 16:19:37.185191 107026 json_family.cc:85] JsonMemTracker size: 41417000
E20250318 16:19:37.185196 107026 json_family.cc:85] JsonMemTracker size: 41417000
E20250318 16:19:37.185209 107026 json_family.cc:85] JsonMemTracker size: 41417544
E20250318 16:19:37.185214 107026 json_family.cc:66] JsonMemTracker current size in SetJsonSize: 41417544
F20250318 16:19:37.185221 107026 compact_object.cc:64] Check failed: result >= 0 (-448 vs. 0) Can't decrease 0 from 448
```
The initial size is 41,418,008. We print the current size before calling the `AddOrFind` method (which is also 41,418,008), and then we print it again after the method call. As we can see, the size decreases to 41417000 .

I also think that I found another bugs in json memory tracking. So, I'm suggesting to add an `json_mem_tracking` tests.

