### PR TITLE
feat(server): Add support for aliasing commands

### DIFF
--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -22,6 +22,9 @@ using namespace std;
 ABSL_FLAG(vector<string>, rename_command, {},
           "Change the name of commands, format is: <cmd1_name>=<cmd1_new_name>, "
           "<cmd2_name>=<cmd2_new_name>");
+ABSL_FLAG(vector<string>, command_alias, {},
+          "Add an alias for given commands, format is: <alias>=<original>, "
+          "<alias>=<original>");
 ABSL_FLAG(vector<string>, restricted_commands, {},
           "Commands restricted to connections on the admin port");
 
@@ -171,6 +174,7 @@ optional<facade::ErrorReply> CommandId::Validate(CmdArgList tail_args) const {
 
 CommandRegistry::CommandRegistry() {
   cmd_rename_map_ = ParseCmdlineArgMap(FLAGS_rename_command);
+  cmd_aliases_ = ParseCmdlineArgMap(FLAGS_command_alias, true);
 
   for (string name : GetFlag(FLAGS_restricted_commands)) {
     restricted_cmds_.emplace(AsciiStrToUpper(name));

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -90,7 +90,7 @@ absl::flat_hash_map<std::string, std::string> ParseCmdlineArgMap(
     }
 
     std::string key = absl::AsciiStrToUpper(kv[0]);
-    std::string value = kv.size() == 1 ? "" : absl::AsciiStrToUpper(kv[1]);
+    std::string value = absl::AsciiStrToUpper(kv[1]);
 
     if (key == value) {
       LOG(ERROR) << "Invalid attempt to map " << key << " to itself in " << flag.Name();

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -82,21 +82,15 @@ absl::flat_hash_map<std::string, std::string> ParseCmdlineArgMap(
   parsed_mappings.reserve(mappings.size());
 
   for (const std::string& mapping : mappings) {
-    if (mapping.find('=') == std::string::npos) {
+    std::vector<std::string_view> kv = absl::StrSplit(mapping, '=');
+    if (kv.size() != 2) {
       LOG(ERROR) << "Malformed command " << mapping << " for " << flag.Name()
                  << ", expected key=value";
       exit(1);
     }
 
-    const std::vector<std::string> kv = absl::StrSplit(mapping, '=');
-    if (kv.size() > 2) {
-      LOG(ERROR) << "Malformed command " << mapping << " for " << flag.Name()
-                 << ", expected key=value";
-      exit(1);
-    }
-
-    const std::string key = absl::AsciiStrToUpper(std::move(kv[0]));
-    const std::string value = kv.size() == 1 ? "" : absl::AsciiStrToUpper(std::move(kv[1]));
+    std::string key = absl::AsciiStrToUpper(kv[0]);
+    std::string value = kv.size() == 1 ? "" : absl::AsciiStrToUpper(kv[1]);
 
     if (key == value) {
       LOG(ERROR) << "Invalid attempt to map " << key << " to itself in " << flag.Name();

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -169,16 +169,17 @@ class CommandRegistry {
   CommandRegistry& operator<<(CommandId cmd);
 
   const CommandId* Find(std::string_view cmd) const {
-    const auto it = cmd_map_.find(cmd);
-    if (it == cmd_map_.end()) {
-      if (const auto alias_it = cmd_aliases_.find(cmd); alias_it != cmd_aliases_.end()) {
-        if (alias_it->first == alias_it->second) {
-          return nullptr;
-        }
-        return Find(alias_it->second);
-      }
+    if (const auto it = cmd_map_.find(cmd); it != cmd_map_.end()) {
+      return &it->second;
     }
-    return it == cmd_map_.end() ? nullptr : &it->second;
+
+    if (const auto it = cmd_aliases_.find(cmd); it != cmd_aliases_.end()) {
+      if (it->first == it->second) {
+        return nullptr;
+      }
+      return Find(it->second);
+    }
+    return nullptr;
   }
 
   CommandId* Find(std::string_view cmd) {

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -174,10 +174,9 @@ class CommandRegistry {
     }
 
     if (const auto it = cmd_aliases_.find(cmd); it != cmd_aliases_.end()) {
-      if (it->first == it->second) {
-        return nullptr;
+      if (const auto alias_lookup = cmd_map_.find(it->second); alias_lookup != cmd_map_.end()) {
+        return &alias_lookup->second;
       }
-      return Find(it->second);
     }
     return nullptr;
   }

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -2,7 +2,6 @@
 // See LICENSE for licensing terms.
 //
 
-#include "absl/strings/str_split.h"
 extern "C" {
 #include "redis/sds.h"
 #include "redis/zmalloc.h"
@@ -10,6 +9,7 @@ extern "C" {
 
 #include <absl/strings/ascii.h>
 #include <absl/strings/str_join.h>
+#include <absl/strings/str_split.h>
 #include <gmock/gmock.h>
 #include <reflex/matcher.h>
 

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -25,6 +25,7 @@ ABSL_DECLARE_FLAG(float, mem_defrag_threshold);
 ABSL_DECLARE_FLAG(float, mem_defrag_waste_threshold);
 ABSL_DECLARE_FLAG(uint32_t, mem_defrag_check_sec_interval);
 ABSL_DECLARE_FLAG(std::vector<std::string>, rename_command);
+ABSL_DECLARE_FLAG(std::vector<std::string>, command_alias);
 ABSL_DECLARE_FLAG(bool, lua_resp2_legacy_float);
 ABSL_DECLARE_FLAG(double, eviction_memory_budget_threshold);
 
@@ -109,17 +110,13 @@ TEST_F(DflyEngineTest, Sds) {
 
 class DflyRenameCommandTest : public DflyEngineTest {
  protected:
-  DflyRenameCommandTest() : DflyEngineTest() {
+  DflyRenameCommandTest() {
     // rename flushall to myflushall, flushdb command will not be able to execute
     absl::SetFlag(
         &FLAGS_rename_command,
         std::vector<std::string>({"flushall=myflushall", "flushdb=", "ping=abcdefghijklmnop"}));
   }
-
-  void TearDown() {
-    absl::SetFlag(&FLAGS_rename_command, std::vector<std::string>({""}));
-    DflyEngineTest::TearDown();
-  }
+  absl::FlagSaver saver_;
 };
 
 TEST_F(DflyRenameCommandTest, RenameCommand) {
@@ -844,6 +841,30 @@ TEST_F(DflyEngineTest, CommandMetricLabels) {
   EXPECT_EQ(metrics.facade_stats.conn_stats.command_cnt_main, 0);
   EXPECT_EQ(metrics.facade_stats.conn_stats.num_conns_main, 0);
   EXPECT_EQ(metrics.facade_stats.conn_stats.num_conns_other, 0);
+}
+
+class DflyCommandAliasTest : public DflyEngineTest {
+ protected:
+  DflyCommandAliasTest() {
+    // Test an interaction of rename and alias, where we rename and then add an alias on the rename
+    absl::SetFlag(&FLAGS_rename_command, {"ping=gnip"});
+    absl::SetFlag(&FLAGS_command_alias, {"___set=set", "___ping=gnip"});
+  }
+
+  absl::FlagSaver saver_;
+};
+
+TEST_F(DflyCommandAliasTest, Aliasing) {
+  EXPECT_EQ(Run({"SET", "foo", "bar"}), "OK");
+  EXPECT_EQ(Run({"___SET", "a", "b"}), "OK");
+  EXPECT_EQ(Run({"GET", "foo"}), "bar");
+  EXPECT_EQ(Run({"GET", "a"}), "b");
+  // test the alias
+  EXPECT_EQ(Run({"___ping"}), "PONG");
+  // test the rename
+  EXPECT_EQ(Run({"gnip"}), "PONG");
+  // the original command is not accessible
+  EXPECT_THAT(Run({"PING"}), ErrArg("unknown command `PING`"));
 }
 
 }  // namespace dfly

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -2,6 +2,7 @@
 // See LICENSE for licensing terms.
 //
 
+#include "absl/strings/str_split.h"
 extern "C" {
 #include "redis/sds.h"
 #include "redis/zmalloc.h"
@@ -9,7 +10,6 @@ extern "C" {
 
 #include <absl/strings/ascii.h>
 #include <absl/strings/str_join.h>
-#include <absl/strings/strip.h>
 #include <gmock/gmock.h>
 #include <reflex/matcher.h>
 
@@ -17,7 +17,6 @@ extern "C" {
 #include "base/gtest.h"
 #include "base/logging.h"
 #include "facade/facade_test.h"
-#include "server/conn_context.h"
 #include "server/main_service.h"
 #include "server/test_utils.h"
 


### PR DESCRIPTION
Support for aliasing a command is added with the command line flag `command_alias`. Multiple aliases of the same command are allowed.

Example run:

server
```
./dragonfly --command_alias __set=set,doset=set
```

client
```
127.0.0.1:6379> __set foo bar
OK
127.0.0.1:6379> get foo
"bar"
127.0.0.1:6379> doset a b
OK
127.0.0.1:6379> get a
"b"
127.0.0.1:6379>
```

commands which have been renamed using `rename_command` should be aliased with the renamed command name instead of original.

TODO: update docs