### PR TITLE
fix: removal of Expiry bit when overriding external strings

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -875,6 +875,8 @@ void CompactObj::InitRobj(CompactObjType type, unsigned encoding, void* obj) {
 }
 
 void CompactObj::SetInt(int64_t val) {
+  DCHECK(!IsExternal());
+
   if (INT_TAG != taglen_) {
     SetMeta(INT_TAG, mask_ & ~kEncMask);
   }

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -140,7 +140,7 @@ class CompactObj {
     // IO_PENDING is set when the tiered storage has issued an i/o request to save the value. It is
     // cleared when the io request finishes or is cancelled.
     IO_PENDING = 0x20,
-    
+
     // Applied only on keys that should be deleted asynchronously.
     // (it can be the same value as IO_PENDING) that is applied only on values.
     KEY_ASYNC_DELETE = 0x20,
@@ -363,6 +363,12 @@ class CompactObj {
   }
 
   void SetExternal(size_t offset, uint32_t sz);
+
+  // Switches to empty, non-external string.
+  // Preserves all the attributes.
+  void RemoveExternal() {
+    SetMeta(0, mask_);
+  }
 
   // Assigns a cooling record to the object together with its external slice.
   void SetCool(size_t offset, uint32_t serialized_size, detail::TieredColdRecord* record);

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -424,6 +424,8 @@ bool TieredStorage::TryStash(DbIndex dbid, string_view key, PrimeValue* value) {
 
 void TieredStorage::Delete(DbIndex dbid, PrimeValue* value) {
   DCHECK(value->IsExternal());
+  DCHECK(!value->HasStashPending());
+
   ++stats_.total_deletes;
 
   tiering::DiskSegment segment = value->GetExternalSlice();
@@ -433,7 +435,7 @@ void TieredStorage::Delete(DbIndex dbid, PrimeValue* value) {
   }
 
   // In any case we delete the offloaded segment and reset the value.
-  value->Reset();
+  value->RemoveExternal();
   op_manager_->DeleteOffloaded(dbid, segment);
 }
 


### PR DESCRIPTION
The bug: during the override of the existing external string, we called `TieredStorage::Delete` to delete the external reference. This function called CompactObj::Reset that cleared all the attributes on the value, including expiry.

The fix: preserve the mask but clear the external state from the object. Fixes #4672

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->