### PR TITLE
fix: invalid reference inside GetQueueBackpressure

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -313,7 +313,8 @@ QueueBackpressure* thread_queue_backpressure = nullptr;
 
 QueueBackpressure& GetQueueBackpressure() {
   DCHECK(thread_queue_backpressure != nullptr);
-  return *thread_queue_backpressure;
+
+  return thread_queue_backpressure[ProactorBase::me()->GetPoolIndex()];
 }
 
 }  // namespace


### PR DESCRIPTION
thread_queue_backpressure is a global array of per thread QueueBackpressure objects. We referenced these objects incorrectly in 1.27.0-2.

Fixes #4770

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->