### PR TITLE
fix: support dump for external objects

### DIFF
--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -243,7 +243,14 @@ std::error_code RdbSerializer::SaveValue(const PrimeValue& pv) {
     if (opt_int) {
       ec = SaveLongLongAsString(*opt_int);
     } else {
-      ec = SaveString(pv.GetSlice(&tmp_str_));
+      if (pv.IsExternal()) {
+        if (pv.IsCool()) {
+          return SaveValue(pv.GetCool().record->value);
+        }
+        LOG(FATAL) << "External string not supported yet";
+      } else {
+        ec = SaveString(pv.GetSlice(&tmp_str_));
+      }
     }
   } else {
     ec = SaveObject(pv);

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -389,9 +389,8 @@ void SliceSnapshot::SerializeExternal(DbIndex db_index, PrimeKey key, const Prim
                                       time_t expire_time, uint32_t mc_flags) {
   // We prefer avoid blocking, so we just schedule a tiered read and append
   // it to the delayed entries.
-  util::fb2::Future<string> future;
-  auto cb = [future](const std::string& v) mutable { future.Resolve(v); };
-  EngineShard::tlocal()->tiered_storage()->Read(db_index, key.ToString(), pv, std::move(cb));
+  util::fb2::Future<string> future =
+      EngineShard::tlocal()->tiered_storage()->Read(db_index, key.ToString(), pv);
 
   delayed_entries_.push_back({db_index, std::move(key), std::move(future), expire_time, mc_flags});
   ++type_freq_map_[RDB_TYPE_STRING];


### PR DESCRIPTION
Before: the code crashed on check-fail if a dump of the external string was requested.
This PR fixes it.

We call SerializerBase::DumpObject also in CmdSerializer::SerializeRestore,
and there we also do not handle the external strings, which will be fixed
in the future.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->