### PR TITLE
fix(hll_family): Fixed PFMERGE wrong merge operation

### DIFF
--- a/src/redis/hyperloglog.c
+++ b/src/redis/hyperloglog.c
@@ -1370,8 +1370,7 @@ int64_t pfcountSingle(struct HllBufferPtr hll_ptr) {
 }
 
 /* Merge dense-encoded HLL */
-static void hllMergeDense(uint8_t* max, struct HllBufferPtr to) {
-  uint8_t* registers = max + HLL_HDR_SIZE;
+static void hllMergeDense(uint8_t* registers, struct HllBufferPtr to) {
   uint8_t val;
   struct hllhdr* hll_hdr = (struct hllhdr*)to.hll;
 

--- a/src/server/hll_family_test.cc
+++ b/src/server/hll_family_test.cc
@@ -166,8 +166,15 @@ TEST_F(HllFamilyTest, MergeToNew) {
 TEST_F(HllFamilyTest, MergeToExisting) {
   EXPECT_EQ(CheckedInt({"pfadd", "key1", "1", "2", "3"}), 1);
   EXPECT_EQ(CheckedInt({"pfadd", "key2", "4", "5"}), 1);
-  EXPECT_EQ(Run({"pfmerge", "key2", "key1"}), "OK");
-  EXPECT_EQ(CheckedInt({"pfcount", "key2"}), 5);
+  EXPECT_EQ(Run({"pfmerge", "key3", "key2", "key1"}), "OK");
+  EXPECT_EQ(CheckedInt({"pfcount", "key3"}), 5);
+  EXPECT_EQ(Run({"pfmerge", "key3", "key3"}), "OK");
+  EXPECT_EQ(CheckedInt({"pfcount", "key3"}), 5);
+  EXPECT_EQ(Run({"pfmerge", "key3"}), "OK");
+  EXPECT_EQ(CheckedInt({"pfcount", "key3"}), 5);
+  EXPECT_EQ(CheckedInt({"pfadd", "key4", "4", "5", "6"}), 1);
+  EXPECT_EQ(Run({"pfmerge", "key3", "key4"}), "OK");
+  EXPECT_EQ(CheckedInt({"pfcount", "key3"}), 6);
 }
 
 TEST_F(HllFamilyTest, MergeNonExisting) {


### PR DESCRIPTION
Fixed bug in hllMergeDense that writes to wrong register.

Fixes #4750

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->