### PR TITLE
fix(hset_family): Fix crash on scan after expiry set

### DIFF
--- a/src/core/string_map.cc
+++ b/src/core/string_map.cc
@@ -183,8 +183,8 @@ void StringMap::RandomPairs(unsigned int count, std::vector<sds>& keys, std::vec
   }
 }
 
-sds StringMap::GetValue(sds key, std::optional<size_t> len) {
-  char* valptr = key + len.value_or(sdslen(key)) + 1;
+sds StringMap::GetValue(sds key) {
+  char* valptr = key + sdslen(key) + 1;
   const uint64_t val = absl::little_endian::Load64(valptr);
   return (sds)(kValMask & val);
 }

--- a/src/core/string_map.cc
+++ b/src/core/string_map.cc
@@ -19,15 +19,6 @@ namespace dfly {
 
 namespace {
 
-constexpr uint64_t kValTtlBit = 1ULL << 63;
-constexpr uint64_t kValMask = ~kValTtlBit;
-
-inline sds GetValue(sds key) {
-  char* valptr = key + sdslen(key) + 1;
-  uint64_t val = absl::little_endian::Load64(valptr);
-  return (sds)(kValMask & val);
-}
-
 // Returns key, tagged value pair
 pair<sds, uint64_t> CreateEntry(string_view field, string_view value, uint32_t time_now,
                                 uint32_t ttl_sec) {
@@ -48,7 +39,7 @@ pair<sds, uint64_t> CreateEntry(string_view field, string_view value, uint32_t t
     newkey = AllocSdsWithSpace(field.size(), 8 + 4);
     uint32_t at = time_now + ttl_sec;
     absl::little_endian::Store32(newkey + meta_offset + 8, at);  // skip the value pointer.
-    sdsval_tag |= kValTtlBit;
+    sdsval_tag |= StringMap::kValTtlBit;
   }
 
   if (!field.empty()) {
@@ -187,6 +178,12 @@ void StringMap::RandomPairs(unsigned int count, std::vector<sds>& keys, std::vec
     ++index;
     ++itr;
   }
+}
+
+sds StringMap::GetValue(sds key, std::optional<size_t> len) {
+  char* valptr = key + len.value_or(sdslen(key)) + 1;
+  const uint64_t val = absl::little_endian::Load64(valptr);
+  return (sds)(kValMask & val);
 }
 
 pair<sds, bool> StringMap::ReallocIfNeeded(void* obj, float ratio) {

--- a/src/core/string_map.cc
+++ b/src/core/string_map.cc
@@ -19,6 +19,9 @@ namespace dfly {
 
 namespace {
 
+constexpr uint64_t kValTtlBit = 1ULL << 63;
+constexpr uint64_t kValMask = ~kValTtlBit;
+
 // Returns key, tagged value pair
 pair<sds, uint64_t> CreateEntry(string_view field, string_view value, uint32_t time_now,
                                 uint32_t ttl_sec) {
@@ -39,7 +42,7 @@ pair<sds, uint64_t> CreateEntry(string_view field, string_view value, uint32_t t
     newkey = AllocSdsWithSpace(field.size(), 8 + 4);
     uint32_t at = time_now + ttl_sec;
     absl::little_endian::Store32(newkey + meta_offset + 8, at);  // skip the value pointer.
-    sdsval_tag |= StringMap::kValTtlBit;
+    sdsval_tag |= kValTtlBit;
   }
 
   if (!field.empty()) {

--- a/src/core/string_map.h
+++ b/src/core/string_map.h
@@ -147,9 +147,6 @@ class StringMap : public DenseSet {
   void RandomPairs(unsigned int count, std::vector<sds>& keys, std::vector<sds>& vals,
                    bool with_value);
 
-  static constexpr uint64_t kValTtlBit = 1ULL << 63;
-  static constexpr uint64_t kValMask = ~kValTtlBit;
-
   static sds GetValue(sds key, std::optional<size_t> len = std::nullopt);
 
  private:

--- a/src/core/string_map.h
+++ b/src/core/string_map.h
@@ -147,6 +147,11 @@ class StringMap : public DenseSet {
   void RandomPairs(unsigned int count, std::vector<sds>& keys, std::vector<sds>& vals,
                    bool with_value);
 
+  static constexpr uint64_t kValTtlBit = 1ULL << 63;
+  static constexpr uint64_t kValMask = ~kValTtlBit;
+
+  static sds GetValue(sds key, std::optional<size_t> len = std::nullopt);
+
  private:
   // Reallocate key and/or value if their pages are underutilized.
   // Returns new pointer (stays same if key utilization is enough) and if reallocation happened.

--- a/src/core/string_map.h
+++ b/src/core/string_map.h
@@ -147,7 +147,7 @@ class StringMap : public DenseSet {
   void RandomPairs(unsigned int count, std::vector<sds>& keys, std::vector<sds>& vals,
                    bool with_value);
 
-  static sds GetValue(sds key, std::optional<size_t> len = std::nullopt);
+  static sds GetValue(sds key);
 
  private:
   // Reallocate key and/or value if their pages are underutilized.

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -320,8 +320,7 @@ OpResult<StringVec> OpScan(const OpArgs& op_args, std::string_view key, uint64_t
       size_t len = sdslen(val);
       if (scan_op.Matches(string_view(val, len))) {
         res.emplace_back(val, len);
-        val += (len + 1);
-        val = (sds)absl::little_endian::Load64(val);
+        val = StringMap::GetValue(val, len);
         res.emplace_back(val, sdslen(val));
       }
     };

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -320,7 +320,7 @@ OpResult<StringVec> OpScan(const OpArgs& op_args, std::string_view key, uint64_t
       size_t len = sdslen(val);
       if (scan_op.Matches(string_view(val, len))) {
         res.emplace_back(val, len);
-        val = StringMap::GetValue(val, len);
+        val = StringMap::GetValue(val);
         res.emplace_back(val, sdslen(val));
       }
     };

--- a/src/server/hset_family_test.cc
+++ b/src/server/hset_family_test.cc
@@ -507,4 +507,18 @@ TEST_F(HSetFamilyTest, EmptyHashBug) {
   EXPECT_THAT(Run({"EXISTS", "foo"}), IntArg(0));
 }
 
+TEST_F(HSetFamilyTest, ScanAfterExpireSet) {
+  EXPECT_THAT(Run({"HSET", "aset", "afield", "avalue"}), IntArg(1));
+  EXPECT_THAT(Run({"HEXPIRE", "aset", "1", "FIELDS", "1", "afield"}), IntArg(1));
+
+  const auto resp = Run({"HSCAN", "aset", "0", "count", "100"});
+  EXPECT_THAT(resp, ArrLen(2));
+
+  const auto vec = StrArray(resp.GetVec()[1]);
+  EXPECT_EQ(vec.size(), 2);
+
+  EXPECT_THAT(vec, Contains("afield").Times(1));
+  EXPECT_THAT(vec, Contains("avalue").Times(1));
+}
+
 }  // namespace dfly


### PR DESCRIPTION
When expiry is set on an hset its members are migrated to a string map.

When creating a new entry in string map with TTL, we also set a bit on the stored pointer as metadata, this is set as 1 << 63. As a consequence when reading back the pointer, if expiry is set, we need to unset the same bit to get the correct address, this is done already in string map internals.

This change adds a similar AND operation in the scan code to unset the TTL bit before dereferencing the pointer.

fixes https://github.com/dragonflydb/dragonfly/issues/4799