### PR TITLE
feat: ignore managed_service_info flag for cluster

### DIFF
--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -63,23 +63,6 @@ constexpr char kIdNotFound[] = "syncid not found";
 constexpr string_view kClusterDisabled =
     "Cluster is disabled. Enabled via passing --cluster_mode=emulated|yes";
 
-ClusterShardInfos GetConfigForStats(ConnectionContext* cntx) {
-  CHECK(!IsClusterEmulated());
-  CHECK(ClusterConfig::Current() != nullptr);
-
-  auto config = ClusterConfig::Current()->GetConfig();
-  if (cntx->conn()->IsPrivileged()) {
-    return config;
-  }
-
-  auto shards_info = config.Unwrap();
-  for (auto& node : shards_info) {
-    node.replicas.clear();
-  }
-
-  return shards_info;
-}
-
 }  // namespace
 
 ClusterFamily::ClusterFamily(ServerFamily* server_family) : server_family_(server_family) {
@@ -122,7 +105,7 @@ std::optional<ClusterShardInfos> ClusterFamily::GetShardInfos(ConnectionContext*
   }
 
   if (ClusterConfig::Current() != nullptr) {
-    return GetConfigForStats(cntx);
+    return ClusterConfig::Current()->GetConfig();
   }
   return nullopt;
 }

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -68,7 +68,7 @@ ClusterShardInfos GetConfigForStats(ConnectionContext* cntx) {
   CHECK(ClusterConfig::Current() != nullptr);
 
   auto config = ClusterConfig::Current()->GetConfig();
-  if (cntx->conn()->IsPrivileged() || !absl::GetFlag(FLAGS_managed_service_info)) {
+  if (cntx->conn()->IsPrivileged()) {
     return config;
   }
 

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -224,14 +224,14 @@ TEST_F(ClusterFamilyTest, ClusterConfigFull) {
       ])json"}),
             "OK");
 
-  string cluster_info = Run({"cluster", "info"}).GetString();
+  string cluster_info = RunPrivileged({"cluster", "info"}).GetString();
   EXPECT_THAT(cluster_info, HasSubstr("cluster_state:ok"));
   EXPECT_THAT(cluster_info, HasSubstr("cluster_slots_assigned:16384"));
   EXPECT_THAT(cluster_info, HasSubstr("cluster_slots_ok:16384"));
   EXPECT_THAT(cluster_info, HasSubstr("cluster_known_nodes:2"));
   EXPECT_THAT(cluster_info, HasSubstr("cluster_size:1"));
 
-  EXPECT_THAT(Run({"cluster", "shards"}),
+  EXPECT_THAT(RunPrivileged({"cluster", "shards"}),
               RespArray(ElementsAre("slots",                                            //
                                     RespArray(ElementsAre(IntArg(0), IntArg(16'383))),  //
                                     "nodes",                                            //
@@ -253,7 +253,7 @@ TEST_F(ClusterFamilyTest, ClusterConfigFull) {
                                             "replication-offset", IntArg(0),            //
                                             "health", "online")))))));
 
-  EXPECT_THAT(Run({"cluster", "slots"}),
+  EXPECT_THAT(RunPrivileged({"cluster", "slots"}),
               RespArray(ElementsAre(IntArg(0),              //
                                     IntArg(16'383),         //
                                     RespArray(ElementsAre(  //
@@ -265,7 +265,7 @@ TEST_F(ClusterFamilyTest, ClusterConfigFull) {
                                         IntArg(8'000),      //
                                         "wxyz")))));
 
-  EXPECT_EQ(Run({"cluster", "nodes"}),
+  EXPECT_EQ(RunPrivileged({"cluster", "nodes"}),
             "abcd1234 10.0.0.1:7000@7000 master - 0 0 0 connected 0-16383\n"
             "wxyz 10.0.0.10:8000@8000 slave abcd1234 0 0 0 connected\n");
 }
@@ -338,14 +338,14 @@ TEST_F(ClusterFamilyTest, ClusterConfigFullMultipleInstances) {
       ])json"}),
             "OK");
 
-  string cluster_info = Run({"cluster", "info"}).GetString();
+  string cluster_info = RunPrivileged({"cluster", "info"}).GetString();
   EXPECT_THAT(cluster_info, HasSubstr("cluster_state:ok"));
   EXPECT_THAT(cluster_info, HasSubstr("cluster_slots_assigned:16384"));
   EXPECT_THAT(cluster_info, HasSubstr("cluster_slots_ok:16384"));
   EXPECT_THAT(cluster_info, HasSubstr("cluster_known_nodes:7"));
   EXPECT_THAT(cluster_info, HasSubstr("cluster_size:2"));
 
-  EXPECT_THAT(Run({"cluster", "shards"}),
+  EXPECT_THAT(RunPrivileged({"cluster", "shards"}),
               RespArray(ElementsAre(
                   RespArray(ElementsAre("slots",                                                 //
                                         RespArray(ElementsAre(IntArg(0), IntArg(10'000))),       //
@@ -404,7 +404,7 @@ TEST_F(ClusterFamilyTest, ClusterConfigFullMultipleInstances) {
                                                 "replication-offset", IntArg(0),                 //
                                                 "health", "fail")))))))));
 
-  EXPECT_THAT(Run({"cluster", "slots"}),
+  EXPECT_THAT(RunPrivileged({"cluster", "slots"}),
               RespArray(ElementsAre(                            //
                   RespArray(ElementsAre(IntArg(0),              //
                                         IntArg(10'000),         //
@@ -427,7 +427,7 @@ TEST_F(ClusterFamilyTest, ClusterConfigFullMultipleInstances) {
                                             IntArg(8'001),      //
                                             "qwerty")))))));
 
-  EXPECT_THAT(Run({"cluster", "nodes"}),
+  EXPECT_THAT(RunPrivileged({"cluster", "nodes"}),
               "abcd1234 10.0.0.1:7000@7000 master - 0 0 0 disconnected 0-10000\n"
               "wxyz 10.0.0.10:8000@8000 slave abcd1234 0 0 0 connected\n"
               "efgh7890 10.0.0.2:7001@7001 master - 0 0 0 connected 10001-16383\n"

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -224,14 +224,14 @@ TEST_F(ClusterFamilyTest, ClusterConfigFull) {
       ])json"}),
             "OK");
 
-  string cluster_info = RunPrivileged({"cluster", "info"}).GetString();
+  string cluster_info = Run({"cluster", "info"}).GetString();
   EXPECT_THAT(cluster_info, HasSubstr("cluster_state:ok"));
   EXPECT_THAT(cluster_info, HasSubstr("cluster_slots_assigned:16384"));
   EXPECT_THAT(cluster_info, HasSubstr("cluster_slots_ok:16384"));
   EXPECT_THAT(cluster_info, HasSubstr("cluster_known_nodes:2"));
   EXPECT_THAT(cluster_info, HasSubstr("cluster_size:1"));
 
-  EXPECT_THAT(RunPrivileged({"cluster", "shards"}),
+  EXPECT_THAT(Run({"cluster", "shards"}),
               RespArray(ElementsAre("slots",                                            //
                                     RespArray(ElementsAre(IntArg(0), IntArg(16'383))),  //
                                     "nodes",                                            //
@@ -253,7 +253,7 @@ TEST_F(ClusterFamilyTest, ClusterConfigFull) {
                                             "replication-offset", IntArg(0),            //
                                             "health", "online")))))));
 
-  EXPECT_THAT(RunPrivileged({"cluster", "slots"}),
+  EXPECT_THAT(Run({"cluster", "slots"}),
               RespArray(ElementsAre(IntArg(0),              //
                                     IntArg(16'383),         //
                                     RespArray(ElementsAre(  //
@@ -265,7 +265,7 @@ TEST_F(ClusterFamilyTest, ClusterConfigFull) {
                                         IntArg(8'000),      //
                                         "wxyz")))));
 
-  EXPECT_EQ(RunPrivileged({"cluster", "nodes"}),
+  EXPECT_EQ(Run({"cluster", "nodes"}),
             "abcd1234 10.0.0.1:7000@7000 master - 0 0 0 connected 0-16383\n"
             "wxyz 10.0.0.10:8000@8000 slave abcd1234 0 0 0 connected\n");
 }
@@ -338,14 +338,14 @@ TEST_F(ClusterFamilyTest, ClusterConfigFullMultipleInstances) {
       ])json"}),
             "OK");
 
-  string cluster_info = RunPrivileged({"cluster", "info"}).GetString();
+  string cluster_info = Run({"cluster", "info"}).GetString();
   EXPECT_THAT(cluster_info, HasSubstr("cluster_state:ok"));
   EXPECT_THAT(cluster_info, HasSubstr("cluster_slots_assigned:16384"));
   EXPECT_THAT(cluster_info, HasSubstr("cluster_slots_ok:16384"));
   EXPECT_THAT(cluster_info, HasSubstr("cluster_known_nodes:7"));
   EXPECT_THAT(cluster_info, HasSubstr("cluster_size:2"));
 
-  EXPECT_THAT(RunPrivileged({"cluster", "shards"}),
+  EXPECT_THAT(Run({"cluster", "shards"}),
               RespArray(ElementsAre(
                   RespArray(ElementsAre("slots",                                                 //
                                         RespArray(ElementsAre(IntArg(0), IntArg(10'000))),       //
@@ -404,7 +404,7 @@ TEST_F(ClusterFamilyTest, ClusterConfigFullMultipleInstances) {
                                                 "replication-offset", IntArg(0),                 //
                                                 "health", "fail")))))))));
 
-  EXPECT_THAT(RunPrivileged({"cluster", "slots"}),
+  EXPECT_THAT(Run({"cluster", "slots"}),
               RespArray(ElementsAre(                            //
                   RespArray(ElementsAre(IntArg(0),              //
                                         IntArg(10'000),         //
@@ -427,7 +427,7 @@ TEST_F(ClusterFamilyTest, ClusterConfigFullMultipleInstances) {
                                             IntArg(8'001),      //
                                             "qwerty")))))));
 
-  EXPECT_THAT(RunPrivileged({"cluster", "nodes"}),
+  EXPECT_THAT(Run({"cluster", "nodes"}),
               "abcd1234 10.0.0.1:7000@7000 master - 0 0 0 disconnected 0-10000\n"
               "wxyz 10.0.0.10:8000@8000 slave abcd1234 0 0 0 connected\n"
               "efgh7890 10.0.0.2:7001@7001 master - 0 0 0 connected 10001-16383\n"

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -459,7 +459,8 @@ async def test_cluster_managed_service_info(df_factory):
             replica_id,
         ]
     )
-    assert await c_master.execute_command("CLUSTER SLOTS") == expected_full_cluster_slots
+    # managed_service_info is ignored for cluster because we have "hidden" health for replica
+    assert await c_master.execute_command("CLUSTER SLOTS") == expected_hidden_cluster_slots
     assert await c_master_admin.execute_command("CLUSTER SLOTS") == expected_full_cluster_slots
 
     expected_hidden_cluster_nodes = {
@@ -489,7 +490,8 @@ async def test_cluster_managed_service_info(df_factory):
         "node_id": replica_id,
         "slots": [],
     }
-    assert await c_master.execute_command("CLUSTER NODES") == expected_full_cluster_nodes
+    # managed_service_info is ignored for cluster because we have "hidden" health for replica
+    assert await c_master.execute_command("CLUSTER NODES") == expected_hidden_cluster_nodes
     assert await c_master_admin.execute_command("CLUSTER NODES") == expected_full_cluster_nodes
 
     expected_hidden_cluster_shards = [
@@ -536,7 +538,8 @@ async def test_cluster_managed_service_info(df_factory):
             "online",
         ]
     )
-    assert await c_master.execute_command("CLUSTER SHARDS") == expected_full_cluster_shards
+    # managed_service_info is ignored for cluster because we have "hidden" health for replica
+    assert await c_master.execute_command("CLUSTER SHARDS") == expected_hidden_cluster_shards
     assert await c_master_admin.execute_command("CLUSTER SHARDS") == expected_full_cluster_shards
 
     await c_master.execute_command("config set managed_service_info true")

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -459,8 +459,7 @@ async def test_cluster_managed_service_info(df_factory):
             replica_id,
         ]
     )
-    # managed_service_info is ignored for cluster because we have "hidden" health for replica
-    assert await c_master.execute_command("CLUSTER SLOTS") == expected_hidden_cluster_slots
+    assert await c_master.execute_command("CLUSTER SLOTS") == expected_full_cluster_slots
     assert await c_master_admin.execute_command("CLUSTER SLOTS") == expected_full_cluster_slots
 
     expected_hidden_cluster_nodes = {
@@ -490,8 +489,7 @@ async def test_cluster_managed_service_info(df_factory):
         "node_id": replica_id,
         "slots": [],
     }
-    # managed_service_info is ignored for cluster because we have "hidden" health for replica
-    assert await c_master.execute_command("CLUSTER NODES") == expected_hidden_cluster_nodes
+    assert await c_master.execute_command("CLUSTER NODES") == expected_full_cluster_nodes
     assert await c_master_admin.execute_command("CLUSTER NODES") == expected_full_cluster_nodes
 
     expected_hidden_cluster_shards = [
@@ -538,19 +536,19 @@ async def test_cluster_managed_service_info(df_factory):
             "online",
         ]
     )
-    # managed_service_info is ignored for cluster because we have "hidden" health for replica
-    assert await c_master.execute_command("CLUSTER SHARDS") == expected_hidden_cluster_shards
+    assert await c_master.execute_command("CLUSTER SHARDS") == expected_full_cluster_shards
     assert await c_master_admin.execute_command("CLUSTER SHARDS") == expected_full_cluster_shards
 
+    # this flag doesn't affect cluster anymore so the results will be the same
     await c_master.execute_command("config set managed_service_info true")
 
-    assert await c_master.execute_command("CLUSTER SLOTS") == expected_hidden_cluster_slots
+    assert await c_master.execute_command("CLUSTER SLOTS") == expected_full_cluster_slots
     assert await c_master_admin.execute_command("CLUSTER SLOTS") == expected_full_cluster_slots
 
-    assert await c_master.execute_command("CLUSTER NODES") == expected_hidden_cluster_nodes
+    assert await c_master.execute_command("CLUSTER NODES") == expected_full_cluster_nodes
     assert await c_master_admin.execute_command("CLUSTER NODES") == expected_full_cluster_nodes
 
-    assert await c_master.execute_command("CLUSTER SHARDS") == expected_hidden_cluster_shards
+    assert await c_master.execute_command("CLUSTER SHARDS") == expected_full_cluster_shards
     assert await c_master_admin.execute_command("CLUSTER SHARDS") == expected_full_cluster_shards
 
 


### PR DESCRIPTION
managed_service_info is ignored for the cluster because we have "hidden" health status for the replica