### PR TITLE
chore: remove pointer tagging for ScoreSdsPolicy

### DIFF
--- a/src/core/sorted_map.h
+++ b/src/core/sorted_map.h
@@ -89,11 +89,21 @@ class SortedMap {
   bool DefragIfNeeded(float ratio);
 
  private:
+  struct Query {
+    ScoreSds item;
+    bool ignore_score;
+    bool str_is_infinite;
+
+    Query(ScoreSds key, bool ign_score = false, int is_inf = 0)
+        : item(key), ignore_score(ign_score), str_is_infinite(is_inf != 0) {
+    }
+  };
+
   struct ScoreSdsPolicy {
     using KeyT = ScoreSds;
 
     struct KeyCompareTo {
-      int operator()(KeyT a, KeyT b) const;
+      int operator()(Query q, ScoreSds key) const;
     };
   };
 


### PR DESCRIPTION
Now we can support custom Query class when working with bptree, so we get rid of pointer taggings.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->