### PR TITLE
feat(metrics): Update metrics for aliased commands

### DIFF
--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -131,7 +131,7 @@ bool CommandId::IsMultiTransactional() const {
 }
 
 uint64_t CommandId::Invoke(CmdArgList args, const CommandContext& cmd_cntx,
-                           std::optional<std::string_view> orig_cmd_name) const {
+                           std::string_view orig_cmd_name) const {
   int64_t before = absl::GetCurrentTimeNanos();
   handler_(args, cmd_cntx);
   int64_t after = absl::GetCurrentTimeNanos();
@@ -139,8 +139,7 @@ uint64_t CommandId::Invoke(CmdArgList args, const CommandContext& cmd_cntx,
   ServerState* ss = ServerState::tlocal();  // Might have migrated thread, read after invocation
   int64_t execution_time_usec = (after - before) / 1000;
 
-  const std::string_view invoked_name = orig_cmd_name.value_or(name());
-  auto& ent = command_stats_[ss->thread_index()][invoked_name];
+  auto& ent = command_stats_[ss->thread_index()][orig_cmd_name];
 
   ++ent.first;
   ent.second += execution_time_usec;

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -71,8 +71,9 @@ static_assert(!IsEvalKind(""));
 
 };  // namespace CO
 
-// Per thread vector of command stats. Each entry is {cmd_calls, cmd_latency_agg in usec}.
-using CmdCallStats = std::pair<uint64_t, uint64_t>;
+// Per thread vector of command stats. Each entry is:
+// command invocation string -> {cmd_calls, cmd_latency_agg in usec}.
+using CmdCallStats = absl::flat_hash_map<std::string, std::pair<uint64_t, uint64_t>>;
 
 struct CommandContext {
   CommandContext(Transaction* _tx, facade::SinkReplyBuilder* _rb, ConnectionContext* cntx)
@@ -102,8 +103,10 @@ class CommandId : public facade::CommandId {
   using ArgValidator = fu2::function_base<true, true, fu2::capacity_default, false, false,
                                           std::optional<facade::ErrorReply>(CmdArgList) const>;
 
-  // Returns the invoke time in usec.
-  uint64_t Invoke(CmdArgList args, const CommandContext& cmd_cntx) const;
+  // Invokes the command handler. Returns the invoke time in usec. The invoked_by parameter is set
+  // to the string passed in by user, if available. If not set, defaults to command name.
+  uint64_t Invoke(CmdArgList args, const CommandContext& cmd_cntx,
+                  std::optional<std::string_view> orig_cmd_name = std::nullopt) const;
 
   // Returns error if validation failed, otherwise nullopt
   std::optional<facade::ErrorReply> Validate(CmdArgList tail_args) const;
@@ -141,7 +144,7 @@ class CommandId : public facade::CommandId {
   }
 
   void ResetStats(unsigned thread_index) {
-    command_stats_[thread_index] = {0, 0};
+    command_stats_[thread_index].clear();
   }
 
   CmdCallStats GetStats(unsigned thread_index) const {
@@ -200,13 +203,17 @@ class CommandRegistry {
     }
   }
 
-  void MergeCallStats(unsigned thread_index,
-                      std::function<void(std::string_view, const CmdCallStats&)> cb) const {
-    for (const auto& k_v : cmd_map_) {
-      auto src = k_v.second.GetStats(thread_index);
-      if (src.first == 0)
-        continue;
-      cb(k_v.second.name(), src);
+  void MergeCallStats(
+      unsigned thread_index,
+      std::function<void(std::string_view, const CmdCallStats::mapped_type&)> cb) const {
+    for (const auto& [_, cmd_id] : cmd_map_) {
+      for (const auto& [cmd_name, call_stats] : cmd_id.GetStats(thread_index)) {
+        if (call_stats.first == 0) {
+          continue;
+        }
+
+        cb(cmd_name, call_stats);
+      }
     }
   }
 
@@ -219,6 +226,8 @@ class CommandRegistry {
 
   std::pair<const CommandId*, facade::ArgSlice> FindExtended(std::string_view cmd,
                                                              facade::ArgSlice tail_args) const;
+
+  bool IsAlias(std::string_view cmd) const;
 
  private:
   absl::flat_hash_map<std::string, CommandId> cmd_map_;

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -106,7 +106,7 @@ class CommandId : public facade::CommandId {
   // Invokes the command handler. Returns the invoke time in usec. The invoked_by parameter is set
   // to the string passed in by user, if available. If not set, defaults to command name.
   uint64_t Invoke(CmdArgList args, const CommandContext& cmd_cntx,
-                  std::optional<std::string_view> orig_cmd_name = std::nullopt) const;
+                  std::string_view orig_cmd_name) const;
 
   // Returns error if validation failed, otherwise nullopt
   std::optional<facade::ErrorReply> Validate(CmdArgList tail_args) const;

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -37,8 +37,11 @@ using absl::StrCat;
 using fb2::Fiber;
 using ::io::Result;
 using testing::AnyOf;
+using testing::Contains;
 using testing::ElementsAre;
 using testing::HasSubstr;
+using testing::Key;
+using testing::Pair;
 
 namespace {
 
@@ -864,6 +867,13 @@ TEST_F(DflyCommandAliasTest, Aliasing) {
   EXPECT_EQ(Run({"gnip"}), "PONG");
   // the original command is not accessible
   EXPECT_THAT(Run({"PING"}), ErrArg("unknown command `PING`"));
+
+  const Metrics metrics = GetMetrics();
+  const auto& stats = metrics.cmd_stats_map;
+  EXPECT_THAT(stats, Contains(Pair("___set", Key(1))));
+  EXPECT_THAT(stats, Contains(Pair("set", Key(1))));
+  EXPECT_THAT(stats, Contains(Pair("___ping", Key(1))));
+  EXPECT_THAT(stats, Contains(Pair("get", Key(2))));
 }
 
 }  // namespace dfly

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1350,7 +1350,8 @@ bool Service::InvokeCmd(const CommandId* cid, CmdArgList tail_args, SinkReplyBui
   auto last_error = builder->ConsumeLastError();
   DCHECK(last_error.empty());
   try {
-    invoke_time_usec = cid->Invoke(tail_args, CommandContext{tx, builder, cntx}, orig_cmd_name);
+    invoke_time_usec = cid->Invoke(tail_args, CommandContext{tx, builder, cntx},
+                                   orig_cmd_name.value_or(cid->name()));
   } catch (std::exception& e) {
     LOG(ERROR) << "Internal error, system probably unstable " << e.what();
     return false;

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -45,7 +45,8 @@ class Service : public facade::ServiceInterface {
 
   // Check VerifyCommandExecution and invoke command with args
   bool InvokeCmd(const CommandId* cid, CmdArgList tail_args, facade::SinkReplyBuilder* builder,
-                 ConnectionContext* reply_cntx);
+                 ConnectionContext* reply_cntx,
+                 std::optional<std::string_view> orig_cmd_name = std::nullopt);
 
   // Verify command can be executed now (check out of memory), always called immediately before
   // execution

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2211,7 +2211,8 @@ Metrics ServerFamily::GetMetrics(Namespace* ns) const {
 
   uint64_t start = absl::GetCurrentTimeNanos();
 
-  auto cmd_stat_cb = [&dest = result.cmd_stats_map](string_view name, const CmdCallStats& stat) {
+  auto cmd_stat_cb = [&dest = result.cmd_stats_map](string_view name,
+                                                    const CmdCallStats::mapped_type& stat) {
     auto& [calls, sum] = dest[absl::AsciiStrToLower(name)];
     calls += stat.first;
     sum += stat.second;


### PR DESCRIPTION
When a call is made to server, its call count and call time is counted against the string it was called with, if the command was found to be an alias.

Fixes https://github.com/dragonflydb/dragonfly/issues/4068

Follow up PR to https://github.com/dragonflydb/dragonfly/pull/4782