### PR TITLE
fix: python test was excluded for epoll case.

### DIFF
--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -2503,6 +2503,7 @@ async def await_eq_offset(client: aioredis.Redis, timeout=20):
     raise RuntimeError("offset not equal!")
 
 
+@pytest.mark.exclude_epoll
 @dfly_args({"proactor_threads": 4})
 async def test_replicate_redis_cluster(redis_cluster, df_factory, df_seeder_factory):
     """


### PR DESCRIPTION
fix: python test was excluded for epoll case. fixed: https://github.com/dragonflydb/dragonfly/issues/4822