### PR TITLE
fix(dfly_bench): Get MOVED error from parsed response

### DIFF
--- a/src/server/dfly_bench.cc
+++ b/src/server/dfly_bench.cc
@@ -741,18 +741,16 @@ void Driver::ParseRESP() {
   uint32_t consumed = 0;
   RedisParser::Result result = RedisParser::OK;
   RespVec parse_args;
-  constexpr string_view kMovedErrorKey = "-MOVED"sv;
+  constexpr string_view kMovedErrorKey = "MOVED"sv;
 
   do {
     result = parser_.Parse(io_buf_.InputBuffer(), &consumed, &parse_args);
     if (result == RedisParser::OK && !parse_args.empty()) {
       if (parse_args[0].type == RespExpr::ERROR) {
-        string_view error = io::View(io_buf_.InputBuffer());
+        string_view error = parse_args[0].GetView();
         VLOG(2) << "Error " << error;
         if (absl::StartsWith(error, kMovedErrorKey)) {
-          // Extract only single MOVED error response from io buffer (without MOVED prefix)
-          error = error.substr(kMovedErrorKey.length(), consumed - kMovedErrorKey.length());
-
+          error = error.substr(kMovedErrorKey.length());
           vector<string_view> parts =
               absl::StrSplit(absl::StripTrailingAsciiWhitespace(error), ' ', absl::SkipEmpty());
 


### PR DESCRIPTION
There could be multiple errors in io buffer which fails to parse correctly. Fixed with 
getting error string form after parsing.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->