### PR TITLE
feat(command docs): Enable fallback tab completion in cli

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2487,7 +2487,9 @@ void Service::Command(CmdArgList args, const CommandContext& cmd_cntx) {
 
   sufficient_args = (args.size() == 1);
   if (subcmd == "DOCS" && sufficient_args) {
-    return rb->SendOk();
+    // Returning an error here forces the interactive CLI client to fall back to static hints and
+    // tab completion
+    return rb->SendError("COMMAND DOCS Not Implemented");
   }
 
   return rb->SendError(kSyntaxErr, kSyntaxErrType);

--- a/src/server/server_family_test.cc
+++ b/src/server/server_family_test.cc
@@ -547,7 +547,7 @@ TEST_F(ServerFamilyTest, ConfigNormalization) {
 }
 
 TEST_F(ServerFamilyTest, CommandDocsOk) {
-  EXPECT_THAT(Run({"command", "docs"}), "OK");
+  EXPECT_THAT(Run({"command", "docs"}), ErrArg("COMMAND DOCS Not Implemented"));
 }
 
 TEST_F(ServerFamilyTest, PubSubCommandErr) {


### PR DESCRIPTION
redis-cli uses COMMAND DOCS response to set up tab and hints completion. If we return OK no completion is set up. If we return an error the cli sets up fallback completion.

Here we change the response from OK to error so that the completion can be enabled as fallback.

fixes https://github.com/dragonflydb/dragonfly/issues/4841