### PR TITLE
fix: FT.SEARCH commas support for ranges

### DIFF
--- a/src/core/search/lexer.lex
+++ b/src/core/search/lexer.lex
@@ -62,6 +62,7 @@ tag_val_char {term_char}|\\[,.<>{}\[\]\\\"\':;!@#$%^&*()\-+=~\/ ]
 "{"            return Parser::make_LCURLBR (loc());
 "}"            return Parser::make_RCURLBR (loc());
 "|"            return Parser::make_OR_OP (loc());
+","            return Parser::make_COMMA (loc());
 "KNN"          return Parser::make_KNN (loc());
 "AS"           return Parser::make_AS (loc());
 "EF_RUNTIME"   return Parser::make_EF_RUNTIME (loc());

--- a/src/core/search/parser.y
+++ b/src/core/search/parser.y
@@ -141,13 +141,9 @@ field_cond:
   | LBRACKET numeric_filter_expr RBRACKET               { $$ = std::move($2); }
   | LCURLBR tag_list RCURLBR                            { $$ = std::move($2); }
 
-commas:
-  COMMA
-  | commas COMMA
-
 numeric_filter_expr:
   opt_lparen generic_number opt_lparen generic_number { $$ = AstRangeNode($2, $1, $4, $3); }
-  | opt_lparen generic_number commas opt_lparen generic_number { $$ = AstRangeNode($2, $1, $5, $4); }
+  | opt_lparen generic_number COMMA opt_lparen generic_number { $$ = AstRangeNode($2, $1, $5, $4); }
 
 generic_number:
   DOUBLE { $$ = toDouble($1); }

--- a/src/core/search/parser.y
+++ b/src/core/search/parser.y
@@ -56,6 +56,7 @@ double toDouble(string_view src);
   LCURLBR     "{"
   RCURLBR     "}"
   OR_OP       "|"
+  COMMA       ","
   KNN         "KNN"
   AS          "AS"
   EF_RUNTIME  "EF_RUNTIME"
@@ -140,8 +141,13 @@ field_cond:
   | LBRACKET numeric_filter_expr RBRACKET               { $$ = std::move($2); }
   | LCURLBR tag_list RCURLBR                            { $$ = std::move($2); }
 
+commas:
+  COMMA
+  | commas COMMA
+
 numeric_filter_expr:
-opt_lparen generic_number opt_lparen generic_number { $$ = AstRangeNode($2, $1, $4, $3); }
+  opt_lparen generic_number opt_lparen generic_number { $$ = AstRangeNode($2, $1, $4, $3); }
+  | opt_lparen generic_number commas opt_lparen generic_number { $$ = AstRangeNode($2, $1, $5, $4); }
 
 generic_number:
   DOUBLE { $$ = toDouble($1); }

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -500,6 +500,80 @@ TEST_F(SearchTest, Errors) {
   EXPECT_THAT(algo.Search(&indices).error, HasSubstr("Wrong vector index dimensions"));
 }
 
+TEST_F(SearchTest, MatchNumericRangeWithCommas) {
+  PrepareSchema({{"f1", SchemaField::NUMERIC}, {"draw_end", SchemaField::NUMERIC}});
+
+  // Main tests for point range with identical values and different delimiters
+  {
+    // 1. Standard with space
+    PrepareQuery("@draw_end:[1742916180 1742916180]");
+    ExpectAll(Map{{"draw_end", "1742916180"}});
+    ExpectNone(Map{{"draw_end", "1742916181"}}, Map{{"draw_end", "1742916179"}});
+    EXPECT_TRUE(Check()) << GetError();
+  }
+
+  {
+    // 2. With comma
+    PrepareQuery("@draw_end:[1742916180, 1742916180]");
+    ExpectAll(Map{{"draw_end", "1742916180"}});
+    ExpectNone(Map{{"draw_end", "1742916181"}}, Map{{"draw_end", "1742916179"}});
+    EXPECT_TRUE(Check()) << GetError();
+  }
+
+  {
+    // 3. With multiple commas
+    PrepareQuery("@draw_end:[1742916180,,1742916180]");
+    ExpectAll(Map{{"draw_end", "1742916180"}});
+    ExpectNone(Map{{"draw_end", "1742916181"}}, Map{{"draw_end", "1742916179"}});
+    EXPECT_TRUE(Check()) << GetError();
+  }
+
+  {
+    // 4. With many commas - this is the key variant that didn't work
+    PrepareQuery("@draw_end:[1742916180,,,1742916180]");
+    ExpectAll(Map{{"draw_end", "1742916180"}});
+    ExpectNone(Map{{"draw_end", "1742916181"}}, Map{{"draw_end", "1742916179"}});
+    EXPECT_TRUE(Check()) << GetError();
+  }
+
+  {
+    // 5. With multiple spaces
+    PrepareQuery("@draw_end:[1742916180   1742916180]");
+    ExpectAll(Map{{"draw_end", "1742916180"}});
+    ExpectNone(Map{{"draw_end", "1742916181"}}, Map{{"draw_end", "1742916179"}});
+    EXPECT_TRUE(Check()) << GetError();
+  }
+
+  // Tests for checking ranges with different values and delimiters
+  {
+    PrepareQuery("@f1:[100 200]");
+    ExpectAll(Map{{"f1", "100"}}, Map{{"f1", "150"}}, Map{{"f1", "200"}});
+    ExpectNone(Map{{"f1", "99"}}, Map{{"f1", "201"}});
+    EXPECT_TRUE(Check()) << GetError();
+  }
+
+  {
+    PrepareQuery("@f1:[100, 200]");
+    ExpectAll(Map{{"f1", "100"}}, Map{{"f1", "150"}}, Map{{"f1", "200"}});
+    ExpectNone(Map{{"f1", "99"}}, Map{{"f1", "201"}});
+    EXPECT_TRUE(Check()) << GetError();
+  }
+
+  {
+    PrepareQuery("@f1:[100,,200]");
+    ExpectAll(Map{{"f1", "100"}}, Map{{"f1", "150"}}, Map{{"f1", "200"}});
+    ExpectNone(Map{{"f1", "99"}}, Map{{"f1", "201"}});
+    EXPECT_TRUE(Check()) << GetError();
+  }
+
+  {
+    PrepareQuery("@f1:[100,,,200]");
+    ExpectAll(Map{{"f1", "100"}}, Map{{"f1", "150"}}, Map{{"f1", "200"}});
+    ExpectNone(Map{{"f1", "99"}}, Map{{"f1", "201"}});
+    EXPECT_TRUE(Check()) << GetError();
+  }
+}
+
 class KnnTest : public SearchTest, public testing::WithParamInterface<bool /* hnsw */> {};
 
 TEST_P(KnnTest, Simple1D) {

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -505,7 +505,6 @@ TEST_F(SearchTest, MatchNumericRangeWithCommas) {
 
   // Main tests for point range with identical values and different delimiters
   {
-    // 1. Standard with space
     PrepareQuery("@draw_end:[1742916180 1742916180]");
     ExpectAll(Map{{"draw_end", "1742916180"}});
     ExpectNone(Map{{"draw_end", "1742916181"}}, Map{{"draw_end", "1742916179"}});
@@ -513,7 +512,6 @@ TEST_F(SearchTest, MatchNumericRangeWithCommas) {
   }
 
   {
-    // 2. With comma
     PrepareQuery("@draw_end:[1742916180, 1742916180]");
     ExpectAll(Map{{"draw_end", "1742916180"}});
     ExpectNone(Map{{"draw_end", "1742916181"}}, Map{{"draw_end", "1742916179"}});
@@ -521,53 +519,21 @@ TEST_F(SearchTest, MatchNumericRangeWithCommas) {
   }
 
   {
-    // 3. With multiple commas
-    PrepareQuery("@draw_end:[1742916180,,1742916180]");
+    PrepareQuery("@draw_end:[1742916180 ,1742916180]");
     ExpectAll(Map{{"draw_end", "1742916180"}});
     ExpectNone(Map{{"draw_end", "1742916181"}}, Map{{"draw_end", "1742916179"}});
     EXPECT_TRUE(Check()) << GetError();
   }
 
   {
-    // 4. With many commas - this is the key variant that didn't work
-    PrepareQuery("@draw_end:[1742916180,,,1742916180]");
-    ExpectAll(Map{{"draw_end", "1742916180"}});
-    ExpectNone(Map{{"draw_end", "1742916181"}}, Map{{"draw_end", "1742916179"}});
-    EXPECT_TRUE(Check()) << GetError();
-  }
-
-  {
-    // 5. With multiple spaces
     PrepareQuery("@draw_end:[1742916180   1742916180]");
     ExpectAll(Map{{"draw_end", "1742916180"}});
     ExpectNone(Map{{"draw_end", "1742916181"}}, Map{{"draw_end", "1742916179"}});
     EXPECT_TRUE(Check()) << GetError();
   }
 
-  // Tests for checking ranges with different values and delimiters
   {
-    PrepareQuery("@f1:[100 200]");
-    ExpectAll(Map{{"f1", "100"}}, Map{{"f1", "150"}}, Map{{"f1", "200"}});
-    ExpectNone(Map{{"f1", "99"}}, Map{{"f1", "201"}});
-    EXPECT_TRUE(Check()) << GetError();
-  }
-
-  {
-    PrepareQuery("@f1:[100, 200]");
-    ExpectAll(Map{{"f1", "100"}}, Map{{"f1", "150"}}, Map{{"f1", "200"}});
-    ExpectNone(Map{{"f1", "99"}}, Map{{"f1", "201"}});
-    EXPECT_TRUE(Check()) << GetError();
-  }
-
-  {
-    PrepareQuery("@f1:[100,,200]");
-    ExpectAll(Map{{"f1", "100"}}, Map{{"f1", "150"}}, Map{{"f1", "200"}});
-    ExpectNone(Map{{"f1", "99"}}, Map{{"f1", "201"}});
-    EXPECT_TRUE(Check()) << GetError();
-  }
-
-  {
-    PrepareQuery("@f1:[100,,,200]");
+    PrepareQuery("@f1:[100   ,     200]");
     ExpectAll(Map{{"f1", "100"}}, Map{{"f1", "150"}}, Map{{"f1", "200"}});
     ExpectNone(Map{{"f1", "99"}}, Map{{"f1", "201"}});
     EXPECT_TRUE(Check()) << GetError();


### PR DESCRIPTION
Syntax like this should be supported:
FT.SEARCH idx:positions @draw_end:[**1742916180,1742916180**] LIMIT 0 10000

Now, Dragonfly supports the following:
FT.SEARCH idx:positions "@draw_end:[1742916180 1742916180]" LIMIT 0 10000
FT.SEARCH idx:positions "@draw_end:[1742916180,1742916180]" LIMIT 0 10000

Original issue: https://github.com/dragonflydb/dragonfly/issues/4832