### PR TITLE
fix(snapshot): Append trailing slash for GCP

### DIFF
--- a/src/server/detail/snapshot_storage.cc
+++ b/src/server/detail/snapshot_storage.cc
@@ -288,6 +288,11 @@ io::Result<std::string, GenericError> GcsSnapshotStorage::LoadPath(string_view d
 
   auto [bucket_name, prefix] = GetBucketPath(dir);
 
+  // GCS needs trailing slash to match prefix sub path
+  if (!prefix.empty() && prefix.back() != '/') {
+    prefix += '/';
+  }
+
   fb2::ProactorBase* proactor = shard_set->pool()->GetNextProactor();
 
   io::Result<vector<SnapStat>, GenericError> keys =


### PR DESCRIPTION
When GCP storage is used we need to have trailing slash for matching sub directories so append if needed.

Fixes #4833

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->