### PR TITLE
chore: turn on more logs for test_replication_timeout_on_full_sync

### DIFF
--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2676,7 +2676,7 @@ error_code RdbLoader::LoadKeyValPair(int type, ObjSettings* settings) {
 
     error_code ec = ReadObj(type, &item->val);
     if (ec) {
-      VLOG(1) << "ReadObj error " << ec << " for key " << key;
+      VLOG(2) << "ReadObj error " << ec << " for key " << key;
       return ec;
     }
 

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -788,7 +788,7 @@ error_code RdbSerializer::SendJournalOffset(uint64_t journal_offset) {
 }
 
 error_code SerializerBase::SendFullSyncCut() {
-  VLOG(2) << "SendFullSyncCut";
+  VLOG(1) << "SendFullSyncCut";
   RETURN_ON_ERR(WriteOpcode(RDB_OPCODE_FULLSYNC_END));
 
   // RDB_OPCODE_FULLSYNC_END followed by 8 bytes of 0.

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -114,7 +114,7 @@ void SliceSnapshot::StartIncremental(LSN start_lsn) {
 
 // Called only for replication use-case.
 void SliceSnapshot::FinalizeJournalStream(bool cancel) {
-  DVLOG(1) << "Finalize Snapshot";
+  VLOG(1) << "Finalize Snapshot";
   DCHECK(db_slice_->shard_owner()->IsMyThread());
   if (!journal_cb_id_) {  // Finalize only once.
     return;

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2331,7 +2331,9 @@ async def test_announce_ip_port(df_factory):
 
 async def test_replication_timeout_on_full_sync(df_factory: DflyInstanceFactory, df_seeder_factory):
     # setting replication_timeout to a very small value to force the replica to timeout
-    master = df_factory.create(replication_timeout=100, vmodule="replica=2,dflycmd=2")
+    master = df_factory.create(
+        replication_timeout=100, vmodule="replica=2,dflycmd=2,snapshot=2,rdb_save=1,rdb_load=1"
+    )
     replica = df_factory.create()
 
     df_factory.start_all([master, replica])


### PR DESCRIPTION
these changes helps to debug https://github.com/dragonflydb/dragonfly/issues/4795