### PR TITLE
fix(lua) : Prevent Lua stack buffer overflow crash (#4853)

### DIFF
--- a/src/core/interpreter_test.cc
+++ b/src/core/interpreter_test.cc
@@ -517,4 +517,9 @@ end
   EXPECT_EQ("i(1)", ser_.res);
 }
 
+TEST_F(InterpreterTest, AvoidIntOverflow) {
+  EXPECT_TRUE(Execute("return bit.tohex(65535, -2147483648)"));
+  EXPECT_EQ("str(0000FFFF)", ser_.res);
+}
+
 }  // namespace dfly

--- a/src/redis/lua/bit/bit.c
+++ b/src/redis/lua/bit/bit.c
@@ -136,6 +136,7 @@ static int bit_tohex(lua_State *L)
   const char *hexdigits = "0123456789abcdef";
   char buf[8];
   int i;
+  if (n == INT32_MIN) n = INT32_MIN+1;
   if (n < 0) { n = -n; hexdigits = "0123456789ABCDEF"; }
   if (n > 8) n = 8;
   for (i = (int)n; --i >= 0; ) { buf[i] = hexdigits[b & 15]; b >>= 4; }


### PR DESCRIPTION
- Add code to prevent stack buffer overflow.
- Closes #4853


- interpreter_test result.
```
~/Desktop/dragonfly/build$ ./interpreter_test 
[==========] Running 16 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 16 tests from InterpreterTest
[ RUN      ] InterpreterTest.Basic
[       OK ] InterpreterTest.Basic (0 ms)
[ RUN      ] InterpreterTest.UnknownFunc
[       OK ] InterpreterTest.UnknownFunc (0 ms)
[ RUN      ] InterpreterTest.Stack
[       OK ] InterpreterTest.Stack (0 ms)
[ RUN      ] InterpreterTest.Add
[       OK ] InterpreterTest.Add (0 ms)
[ RUN      ] InterpreterTest.Execute
[       OK ] InterpreterTest.Execute (0 ms)
[ RUN      ] InterpreterTest.Call
[       OK ] InterpreterTest.Call (0 ms)
[ RUN      ] InterpreterTest.CallArray
[       OK ] InterpreterTest.CallArray (0 ms)
[ RUN      ] InterpreterTest.ArgKeys
[       OK ] InterpreterTest.ArgKeys (0 ms)
[ RUN      ] InterpreterTest.Modules
[       OK ] InterpreterTest.Modules (0 ms)
[ RUN      ] InterpreterTest.Compatibility
[       OK ] InterpreterTest.Compatibility (0 ms)
[ RUN      ] InterpreterTest.AsyncReplacement
[       OK ] InterpreterTest.AsyncReplacement (0 ms)
[ RUN      ] InterpreterTest.ReplicateCommands
[       OK ] InterpreterTest.ReplicateCommands (0 ms)
[ RUN      ] InterpreterTest.Log
[       OK ] InterpreterTest.Log (0 ms)
[ RUN      ] InterpreterTest.Robust
[       OK ] InterpreterTest.Robust (0 ms)
[ RUN      ] InterpreterTest.Unpack
[       OK ] InterpreterTest.Unpack (1 ms)
[ RUN      ] InterpreterTest.AvoidIntOverflow
[       OK ] InterpreterTest.AvoidIntOverflow (0 ms)
[----------] 16 tests from InterpreterTest (4 ms total)

[----------] Global test environment tear-down
[==========] 16 tests from 1 test suite ran. (4 ms total)
[  PASSED  ] 16 tests.

```