### PR TITLE
fix(lua): Fix integer overflow

### DIFF
--- a/src/core/interpreter_test.cc
+++ b/src/core/interpreter_test.cc
@@ -517,4 +517,9 @@ end
   EXPECT_EQ("i(1)", ser_.res);
 }
 
+TEST_F(InterpreterTest, AvoidIntOverflow) {
+  EXPECT_TRUE(Execute("return bit.tohex(65535, -2147483648)"));
+  EXPECT_EQ("str(0000FFFF)", ser_.res);
+}
+
 }  // namespace dfly

--- a/src/redis/lua/bit/bit.c
+++ b/src/redis/lua/bit/bit.c
@@ -135,10 +135,15 @@ static int bit_tohex(lua_State *L)
   SBits n = lua_isnone(L, 2) ? 8 : (SBits)barg(L, 2);
   const char *hexdigits = "0123456789abcdef";
   char buf[8];
-  int i;
-  if (n < 0) { n = -n; hexdigits = "0123456789ABCDEF"; }
+  if (n < 0) {
+    if (n == INT32_MIN) {
+      n += 1;
+    }
+    n = -n;
+    hexdigits = "0123456789ABCDEF";
+  }
   if (n > 8) n = 8;
-  for (i = (int)n; --i >= 0; ) { buf[i] = hexdigits[b & 15]; b >>= 4; }
+  for (int i = (int)n; --i >= 0; ) { buf[i] = hexdigits[b & 15]; b >>= 4; }
   lua_pushlstring(L, buf, (size_t)n);
   return 1;
 }


### PR DESCRIPTION
When evaluating `bit_tohex` in lua a user can pass the smallest value in signed int range, the code tries to flip the sign which causes an integer overflow.

Special case handling is added to protect against INT32_MIN.

fixes #4853