### PR TITLE
chore: Remove version attribute from compose file

### DIFF
--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   dragonfly:
     image: 'docker.dragonflydb.io/dragonflydb/dragonfly'


### PR DESCRIPTION
- Removes the warning the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion

This just follows the advice from docker of remove the version attribute from the compose file. No more warnings when following the guide 👍🏼 