### PR TITLE
fix: add version id for dev container builds

### DIFF
--- a/tools/packaging/Dockerfile.alpine-dev
+++ b/tools/packaging/Dockerfile.alpine-dev
@@ -17,7 +17,12 @@ COPY --from=libpfm_donor /usr/local/lib/libpfm.so* /usr/local/lib/
 
 WORKDIR /build
 
-COPY . ./
+COPY ./Makefile ./CMakeLists.txt ./
+COPY src ./src
+
+COPY .git ./.git
+COPY cmake ./cmake
+COPY helio ./helio
 
 RUN make release
 

--- a/tools/packaging/Dockerfile.ubuntu-dev
+++ b/tools/packaging/Dockerfile.ubuntu-dev
@@ -5,6 +5,8 @@ WORKDIR /build
 
 COPY ./Makefile ./CMakeLists.txt ./
 COPY src ./src
+
+COPY .git ./.git
 COPY cmake ./cmake
 COPY helio ./helio
 


### PR DESCRIPTION
now it looks like this:
```
> docker run --rm ghcr.io/dragonflydb/dragonfly-dev:ubuntu-f767d82 --version
dragonfly f767d82-f767d82ce78ccbc90ddfb525f4ad4bd9aafcfbed
```

fixes #4830

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->