### PR TITLE
feat: debug compression <type>

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -296,9 +296,9 @@ void DoComputeHist(optional<CompactObjType> type, EngineShard* shard, Connection
       scratch.clear();
       if (!type) {
         it->first.GetString(&scratch);
-      } else if (type == OBJ_STRING && it->second.ObjType() == OBJ_STRING) {
+      } else if (*type == OBJ_STRING && it->second.ObjType() == OBJ_STRING) {
         it->second.GetString(&scratch);
-      } else if (type == OBJ_ZSET && it->second.ObjType() == OBJ_ZSET) {
+      } else if (*type == OBJ_ZSET && it->second.ObjType() == OBJ_ZSET) {
         container_utils::IterateSortedSet(
             it->second.GetRobjWrapper(), [&](container_utils::ContainerEntry entry, double) {
               if (entry.value) {
@@ -306,14 +306,14 @@ void DoComputeHist(optional<CompactObjType> type, EngineShard* shard, Connection
               }
               return true;
             });
-      } else if (type == OBJ_LIST && it->second.ObjType() == OBJ_LIST) {
+      } else if (*type == OBJ_LIST && it->second.ObjType() == OBJ_LIST) {
         container_utils::IterateList(it->second, [&](container_utils::ContainerEntry entry) {
           if (entry.value) {
             HIST_add(dest->hist.data(), entry.value, entry.length);
           }
           return true;
         });
-      } else if (type == OBJ_HASH && it->second.ObjType() == OBJ_HASH) {
+      } else if (*type == OBJ_HASH && it->second.ObjType() == OBJ_HASH) {
         container_utils::IterateMap(it->second, [&](container_utils::ContainerEntry key,
                                                     container_utils::ContainerEntry value) {
           if (key.value) {
@@ -325,8 +325,9 @@ void DoComputeHist(optional<CompactObjType> type, EngineShard* shard, Connection
           return true;
         });
       }
+
       size_t len = std::min(scratch.size(), kMaxLen);
-      if (len > 16)
+      if (len > 16)  // filtering out values that are too small and hosted inline.
         HIST_add(dest->hist.data(), scratch.data(), len);
     });
 
@@ -545,8 +546,8 @@ void DebugCmd::Run(CmdArgList args, facade::SinkReplyBuilder* builder) {
         "RECVSIZE [<tid> | ENABLE | DISABLE]",
         "    Prints the histogram of the received request sizes on the given thread",
         "COMPRESSION [type]"
-        "    Estimate the compressability of values of the given type. if no type is given, ",
-        "    checks compressability of keys",
+        "    Estimate the compressibility of values of the given type. if no type is given, ",
+        "    checks compressibility of keys",
         "HELP",
         "    Prints this help.",
     };

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -279,7 +279,8 @@ struct HufHist {
   }
 };
 
-void DoComputeHist(EngineShard* shard, ConnectionContext* cntx, HufHist* dest) {
+void DoComputeHist(optional<CompactObjType> type, EngineShard* shard, ConnectionContext* cntx,
+                   HufHist* dest) {
   auto& db_slice = cntx->ns->GetDbSlice(shard->shard_id());
   DbTable* dbt = db_slice.GetDBTable(cntx->db_index());
   CHECK(dbt);
@@ -292,9 +293,41 @@ void DoComputeHist(EngineShard* shard, ConnectionContext* cntx, HufHist* dest) {
 
   do {
     cursor = table.Traverse(cursor, [&](PrimeIterator it) {
-      it->first.GetString(&scratch);
+      scratch.clear();
+      if (!type) {
+        it->first.GetString(&scratch);
+      } else if (type == OBJ_STRING && it->second.ObjType() == OBJ_STRING) {
+        it->second.GetString(&scratch);
+      } else if (type == OBJ_ZSET && it->second.ObjType() == OBJ_ZSET) {
+        container_utils::IterateSortedSet(
+            it->second.GetRobjWrapper(), [&](container_utils::ContainerEntry entry, double) {
+              if (entry.value) {
+                HIST_add(dest->hist.data(), entry.value, entry.length);
+              }
+              return true;
+            });
+      } else if (type == OBJ_LIST && it->second.ObjType() == OBJ_LIST) {
+        container_utils::IterateList(it->second, [&](container_utils::ContainerEntry entry) {
+          if (entry.value) {
+            HIST_add(dest->hist.data(), entry.value, entry.length);
+          }
+          return true;
+        });
+      } else if (type == OBJ_HASH && it->second.ObjType() == OBJ_HASH) {
+        container_utils::IterateMap(it->second, [&](container_utils::ContainerEntry key,
+                                                    container_utils::ContainerEntry value) {
+          if (key.value) {
+            HIST_add(dest->hist.data(), key.value, key.length);
+          }
+          if (value.value) {
+            HIST_add(dest->hist.data(), value.value, value.length);
+          }
+          return true;
+        });
+      }
       size_t len = std::min(scratch.size(), kMaxLen);
-      HIST_add(dest->hist.data(), scratch.data(), len);
+      if (len > 16)
+        HIST_add(dest->hist.data(), scratch.data(), len);
     });
 
     if (steps >= 20000) {
@@ -511,8 +544,9 @@ void DebugCmd::Run(CmdArgList args, facade::SinkReplyBuilder* builder) {
         "    traffic logging is stopped.",
         "RECVSIZE [<tid> | ENABLE | DISABLE]",
         "    Prints the histogram of the received request sizes on the given thread",
-        "COMPRESSION"
-        "    Estimate the compressability of values of the given type",
+        "COMPRESSION [type]"
+        "    Estimate the compressability of values of the given type. if no type is given, ",
+        "    checks compressability of keys",
         "HELP",
         "    Prints this help.",
     };
@@ -585,7 +619,7 @@ void DebugCmd::Run(CmdArgList args, facade::SinkReplyBuilder* builder) {
   }
 
   if (subcmd == "COMPRESSION") {
-    return Compression(builder);
+    return Compression(args.subspan(1), builder);
   }
 
   string reply = UnknownSubCmd(subcmd, "DEBUG");
@@ -1233,14 +1267,22 @@ void DebugCmd::Keys(CmdArgList args, facade::SinkReplyBuilder* builder) {
   return builder->SendError(kSyntaxErr);
 }
 
-void DebugCmd::Compression(facade::SinkReplyBuilder* builder) {
+void DebugCmd::Compression(CmdArgList args, facade::SinkReplyBuilder* builder) {
+  optional<CompactObjType> type;
+  if (args.size() > 0) {
+    string_view type_str = ArgS(args, 0);
+    type = ObjTypeFromString(type_str);
+    if (!type) {
+      return builder->SendError(kSyntaxErr);
+    }
+  }
   auto* rb = static_cast<RedisReplyBuilder*>(builder);
 
   fb2::Mutex mu;
   HufHist hist;
   shard_set->RunBlockingInParallel([&](EngineShard* shard) {
     HufHist local;
-    DoComputeHist(shard, cntx_, &local);
+    DoComputeHist(type, shard, cntx_, &local);
     std::unique_lock lk(mu);
     hist.Merge(local);
   });

--- a/src/server/debugcmd.h
+++ b/src/server/debugcmd.h
@@ -58,7 +58,7 @@ class DebugCmd {
   void RecvSize(std::string_view param, facade::SinkReplyBuilder* builder);
   void Topk(CmdArgList args, facade::SinkReplyBuilder* builder);
   void Keys(CmdArgList args, facade::SinkReplyBuilder* builder);
-  void Compression(facade::SinkReplyBuilder* builder);
+  void Compression(CmdArgList args, facade::SinkReplyBuilder* builder);
 
   struct PopulateBatch {
     DbIndex dbid;


### PR DESCRIPTION
Extend `debug compression` to support value types. if no type is given, falls back to testing keys compressability.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->