### PR TITLE
fix: lsn check failure

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -1290,6 +1290,7 @@ void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBat
   for (unsigned i = 0; i < batch.sz; ++i) {
     string key = StrCat(options.prefix, ":", batch.index[i]);
     uint32_t elements_left = options.elements;
+    DCHECK(sf_.AreAllReplicasInStableSync());
 
     while (elements_left) {
       // limit rss grow by 32K by limiting the element count in each command.

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -783,6 +783,8 @@ void DebugCmd::Populate(CmdArgList args, facade::SinkReplyBuilder* builder) {
   if (!options.has_value()) {
     return;
   }
+  DCHECK(sf_.AreAllReplicasInStableSync());
+
   ProactorPool& pp = sf_.service().proactor_pool();
   size_t runners_count = pp.size();
   vector<pair<uint64_t, uint64_t>> ranges(runners_count - 1);
@@ -808,6 +810,8 @@ void DebugCmd::Populate(CmdArgList args, facade::SinkReplyBuilder* builder) {
     fb.Join();
 
   builder->SendOk();
+
+  DCHECK(sf_.AreAllReplicasInStableSync());
 }
 
 void DebugCmd::PopulateRangeFiber(uint64_t from, uint64_t num_of_keys,
@@ -1290,7 +1294,6 @@ void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBat
   for (unsigned i = 0; i < batch.sz; ++i) {
     string key = StrCat(options.prefix, ":", batch.index[i]);
     uint32_t elements_left = options.elements;
-    DCHECK(sf_.AreAllReplicasInStableSync());
 
     while (elements_left) {
       // limit rss grow by 32K by limiting the element count in each command.

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -44,20 +44,6 @@ using namespace util;
 using std::string;
 using util::ProactorBase;
 
-namespace {
-const char kBadMasterId[] = "bad master id";
-const char kIdNotFound[] = "syncid not found";
-const char kInvalidSyncId[] = "bad sync id";
-const char kInvalidState[] = "invalid state";
-
-bool ToSyncId(string_view str, uint32_t* num) {
-  if (!absl::StartsWith(str, "SYNC"))
-    return false;
-  str.remove_prefix(4);
-
-  return absl::SimpleAtoi(str, num);
-}
-
 std::string_view SyncStateName(DflyCmd::SyncState sync_state) {
   switch (sync_state) {
     case DflyCmd::SyncState::PREPARATION:
@@ -71,6 +57,20 @@ std::string_view SyncStateName(DflyCmd::SyncState sync_state) {
   }
   DCHECK(false) << "Unspported state " << int(sync_state);
   return "unsupported";
+}
+
+namespace {
+const char kBadMasterId[] = "bad master id";
+const char kIdNotFound[] = "syncid not found";
+const char kInvalidSyncId[] = "bad sync id";
+const char kInvalidState[] = "invalid state";
+
+bool ToSyncId(string_view str, uint32_t* num) {
+  if (!absl::StartsWith(str, "SYNC"))
+    return false;
+  str.remove_prefix(4);
+
+  return absl::SimpleAtoi(str, num);
 }
 
 bool WaitReplicaFlowToCatchup(absl::Time end_time, const DflyCmd::ReplicaInfo* replica,

--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -143,7 +143,7 @@ class DflyCmd {
   // Create new sync session. Returns (session_id, number of flows)
   std::pair<uint32_t, unsigned> CreateSyncSession(ConnectionState* state) ABSL_LOCKS_EXCLUDED(mu_);
 
-  // Master side acces method to replication info of that connection.
+  // Master side access method to replication info of that connection.
   std::shared_ptr<ReplicaInfo> GetReplicaInfoFromConnection(ConnectionState* state);
 
   // Master-side command. Provides Replica info.
@@ -234,5 +234,7 @@ class DflyCmd {
 
   mutable util::fb2::Mutex mu_;  // Guard global operations. See header top for locking levels.
 };
+
+std::string_view SyncStateName(DflyCmd::SyncState sync_state);
 
 }  // namespace dfly

--- a/src/server/multi_command_squasher.h
+++ b/src/server/multi_command_squasher.h
@@ -61,8 +61,7 @@ class MultiCommandSquasher {
   bool ExecuteStandalone(facade::RedisReplyBuilder* rb, StoredCmd* cmd);
 
   // Callback that runs on shards during squashed hop.
-  facade::OpStatus SquashedHopCb(Transaction* parent_tx, EngineShard* es,
-                                 facade::RespVersion resp_v);
+  facade::OpStatus SquashedHopCb(EngineShard* es, facade::RespVersion resp_v);
 
   // Execute all currently squashed commands. Return false if aborting on error.
   bool ExecuteSquashed(facade::RedisReplyBuilder* rb);

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -266,6 +266,18 @@ class ServerFamily {
 
   void UpdateMemoryGlobalStats();
 
+  // Return true if no replicas are registered or if all replicas reached stable sync
+  // Used in debug populate to DCHECK insocsistent flows that violate transaction gurantees
+  bool AreAllReplicasInStableSync() const {
+    auto roles = dfly_cmd_->GetReplicasRoleInfo();
+    if (roles.empty()) {
+      return true;
+    }
+    auto match = SyncStateName(DflyCmd::SyncState::STABLE_SYNC);
+    return std::all_of(roles.begin(), roles.end(),
+                       [&match](auto& elem) { return elem.state == match; });
+  }
+
  private:
   bool HasPrivilegedInterface();
   void JoinSnapshotSchedule();

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1114,11 +1114,11 @@ bool Transaction::ScheduleInShard(EngineShard* shard, bool execute_optimistic) {
   // Acquire intent locks. Intent locks are always acquired, even if already locked by others.
   if (!IsGlobal()) {
     lock_args = GetLockArgs(shard->shard_id());
-    bool shard_unlocked = shard->shard_lock()->Check(mode);
+    const bool shard_unlocked = shard->shard_lock()->Check(mode);
 
     // We need to acquire the fp locks because the executing callback
     // within RunCallback below might preempt.
-    bool keys_unlocked = GetDbSlice(shard->shard_id()).Acquire(mode, lock_args);
+    const bool keys_unlocked = GetDbSlice(shard->shard_id()).Acquire(mode, lock_args);
     lock_granted = shard_unlocked && keys_unlocked;
 
     sd.local_mask |= KEYLOCK_ACQUIRED;
@@ -1129,7 +1129,7 @@ bool Transaction::ScheduleInShard(EngineShard* shard, bool execute_optimistic) {
     DVLOG(3) << "Lock granted " << lock_granted << " for trans " << DebugId();
 
     // Check if we can run immediately
-    if (shard_unlocked && execute_optimistic && lock_granted) {
+    if (lock_granted && execute_optimistic) {
       sd.local_mask |= OPTIMISTIC_EXECUTION;
       shard->stats().tx_optimistic_total++;
 

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -17,7 +17,7 @@ from .instance import DflyInstanceFactory, DflyInstance
 from .seeder import Seeder as SeederV2
 from . import dfly_args
 from .proxy import Proxy
-from .seeder import StaticSeeder
+from .seeder import DebugPopulateSeeder
 
 ADMIN_PORT = 1211
 
@@ -1132,7 +1132,7 @@ async def test_flushall_in_full_sync(df_factory):
     c_replica = replica.client()
 
     # Fill master with test data
-    seeder = StaticSeeder(key_target=100_000)
+    seeder = DebugPopulateSeeder(key_target=100_000)
     await seeder.run(c_master)
 
     # Start replication and wait for full sync
@@ -2754,8 +2754,8 @@ async def test_memory_on_big_string_loading(df_factory):
     assert replica_peak_memory < 1.1 * replica_used_memory
 
     # Check replica data consistent
-    replica_data = await StaticSeeder.capture(c_replica)
-    master_data = await StaticSeeder.capture(c_master)
+    replica_data = await DebugPopulateSeeder.capture(c_replica)
+    master_data = await DebugPopulateSeeder.capture(c_master)
     assert master_data == replica_data
 
 
@@ -2774,7 +2774,7 @@ async def test_big_containers(df_factory, element_size, elements_number):
     c_replica = replica.client()
 
     logging.debug("Fill master with test data")
-    seeder = StaticSeeder(
+    seeder = DebugPopulateSeeder(
         key_target=50,
         data_size=element_size * elements_number,
         collection_size=elements_number,
@@ -2809,8 +2809,8 @@ async def test_big_containers(df_factory, element_size, elements_number):
     assert replica_peak_memory < 1.1 * replica_used_memory
 
     # Check replica data consistent
-    replica_data = await StaticSeeder.capture(c_replica)
-    master_data = await StaticSeeder.capture(c_master)
+    replica_data = await DebugPopulateSeeder.capture(c_replica)
+    master_data = await DebugPopulateSeeder.capture(c_master)
     assert master_data == replica_data
 
 
@@ -2860,8 +2860,8 @@ async def test_stream_approximate_trimming(df_factory):
     await asyncio.sleep(1)
 
     # Check replica data consistent
-    master_data = await StaticSeeder.capture(c_master)
-    replica_data = await StaticSeeder.capture(c_replica)
+    master_data = await DebugPopulateSeeder.capture(c_master)
+    replica_data = await DebugPopulateSeeder.capture(c_replica)
     assert master_data == replica_data
 
     # Step 3: Trim all streams to 0
@@ -2870,8 +2870,8 @@ async def test_stream_approximate_trimming(df_factory):
         await c_master.execute_command("XTRIM", stream_name, "MAXLEN", "0")
 
     # Check replica data consistent
-    master_data = await StaticSeeder.capture(c_master)
-    replica_data = await StaticSeeder.capture(c_replica)
+    master_data = await DebugPopulateSeeder.capture(c_master)
+    replica_data = await DebugPopulateSeeder.capture(c_replica)
     assert master_data == replica_data
 
 
@@ -2945,7 +2945,7 @@ async def test_preempt_in_atomic_section_of_heartbeat(df_factory: DflyInstanceFa
         rand = random.randint(1, 10)
         await c_master.execute_command(f"EXPIRE tmp:{i} {rand} NX")
 
-    seeder = StaticSeeder(key_target=10000)
+    seeder = DebugPopulateSeeder(key_target=10000)
     fill_task = asyncio.create_task(seeder.run(master.client()))
 
     for replica in c_replicas:
@@ -2957,7 +2957,6 @@ async def test_preempt_in_atomic_section_of_heartbeat(df_factory: DflyInstanceFa
     await fill_task
 
 
-@pytest.mark.skip(reason="Temporary skip it. We have a bug around memory tracking")
 async def test_bug_in_json_memory_tracking(df_factory: DflyInstanceFactory):
     """
     This test reproduces a bug in the JSON memory tracking.
@@ -2978,7 +2977,7 @@ async def test_bug_in_json_memory_tracking(df_factory: DflyInstanceFactory):
         rand = random.randint(1, 4)
         await c_master.execute_command(f"EXPIRE tmp:{i} {rand} NX")
 
-    seeder = StaticSeeder(key_target=100_000)
+    seeder = SeederV2(key_target=100_000)
     fill_task = asyncio.create_task(seeder.run(master.client()))
 
     for replica in c_replicas:

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2945,7 +2945,7 @@ async def test_preempt_in_atomic_section_of_heartbeat(df_factory: DflyInstanceFa
         rand = random.randint(1, 10)
         await c_master.execute_command(f"EXPIRE tmp:{i} {rand} NX")
 
-    seeder = DebugPopulateSeeder(key_target=10000)
+    seeder = SeederV2(key_target=10_000)
     fill_task = asyncio.create_task(seeder.run(master.client()))
 
     for replica in c_replicas:

--- a/tests/dragonfly/seeder/README.md
+++ b/tests/dragonfly/seeder/README.md
@@ -4,20 +4,20 @@ Please use the testing frameworks factories to obtain proper seeder instances!
 
 ### 1. Static seeder
 
-The StaticSeeder is a thin wrapper around `DEBUG POPULATE` with a little bit of fuzziness for collection sizes. It should be preffered for generating "static" data for snapshotting, memory consumption tests, etc.
+The DebugPopulateSeeder is a thin wrapper around `DEBUG POPULATE` with a little bit of fuzziness for collection sizes. It should be preffered for generating "static" data for snapshotting, memory consumption tests, etc.
 
 ```python
-s = StaticSeeder(key_target=10_000)
+s = DebugPopulateSeeder(key_target=10_000)
 await s.run(client) # Creates around 10k keys
 ```
 
 ### 2. Checking consistency
 
-Use `SeederBase.capture()` (accessed via `StaticSeeder` or `Seeder`) to calculate a "state hashes" based on all the data inside an instance. Equal data produces equal hashes (equal hashes don't guarantee equal data but what are the odds...).
+Use `SeederBase.capture()` (accessed via `DebugPopulateSeeder` or `Seeder`) to calculate a "state hashes" based on all the data inside an instance. Equal data produces equal hashes (equal hashes don't guarantee equal data but what are the odds...).
 
 ```python
 # Fill master with ~10k keys
-s = StaticSeeder(key_target=10_000)
+s = DebugPopulateSeeder(key_target=10_000)
 await seeder.run(master)
 
 # "Replicate" or other operations
@@ -25,8 +25,8 @@ replicate(master, replica)
 
 # Ensure master and replica have same state hashes
 master_hashes, replica_hashes = await asyncio.gather(
-    StaticSeeder.capture(master), # note it's a static method
-    StaticSeeder.capture(replica)
+    DebugPopulateSeeder.capture(master), # note it's a static method
+    DebugPopulateSeeder.capture(replica)
 )
 assert master_hashes == replica_hashes
 ```

--- a/tests/dragonfly/seeder/__init__.py
+++ b/tests/dragonfly/seeder/__init__.py
@@ -70,7 +70,7 @@ class SeederBase:
         return script
 
 
-class StaticSeeder(SeederBase):
+class DebugPopulateSeeder(SeederBase):
     """Wrapper around DEBUG POPULATE with fuzzy key sizes and a balanced type mix"""
 
     def __init__(

--- a/tests/dragonfly/seeder_test.py
+++ b/tests/dragonfly/seeder_test.py
@@ -3,14 +3,14 @@ import async_timeout
 import string
 from redis import asyncio as aioredis
 from . import dfly_args
-from .seeder import Seeder, StaticSeeder
+from .seeder import Seeder, DebugPopulateSeeder
 from .instance import DflyInstanceFactory, DflyInstance
 from .utility import *
 
 
 @dfly_args({"proactor_threads": 4})
 async def test_static_seeder(async_client: aioredis.Redis):
-    s = StaticSeeder(key_target=10_000, data_size=100)
+    s = DebugPopulateSeeder(key_target=10_000, data_size=100)
     await s.run(async_client)
 
     assert abs(await async_client.dbsize() - 10_000) <= 70
@@ -24,7 +24,7 @@ async def test_static_collection_size(async_client: aioredis.Redis):
             assert await async_client.llen(key) == 1
             assert len(await async_client.lpop(key)) == 10_000
 
-    s = StaticSeeder(
+    s = DebugPopulateSeeder(
         key_target=10, data_size=10_000, variance=1, samples=1, collection_size=1, types=["LIST"]
     )
     await s.run(async_client)

--- a/tests/dragonfly/tiering_test.py
+++ b/tests/dragonfly/tiering_test.py
@@ -6,7 +6,7 @@ import random
 import redis.asyncio as aioredis
 
 from . import dfly_args
-from .seeder import StaticSeeder
+from .seeder import DebugPopulateSeeder
 from .utility import info_tick_timer
 
 
@@ -21,7 +21,7 @@ async def test_basic_memory_usage(async_client: aioredis.Redis):
     Loading 1GB of mixed size strings (256b-16kb) will keep most of them on disk and thus RAM remains almost unused
     """
 
-    seeder = StaticSeeder(
+    seeder = DebugPopulateSeeder(
         key_target=200_000, data_size=2048, variance=8, samples=100, types=["STRING"]
     )
     await seeder.run(async_client)


### PR DESCRIPTION
Test `test_bug_in_json_memory_tracking` failed because it used `StaticSeeder` which uses `debug populate` which is non transactional. 

* rename StaticSeeder to DebugPopulateSeeder to show intent
* add a DCHECK in debug populate that triggers if there is a registered replica that hasn't reached stable sync
* small cleanup

fixes #4048

Also `test_disconnect_replica` was failing months ago but I run this for more than 5 hours without any success.