### PR TITLE
fix: skip heartbeat if shard is under global lock

### DIFF
--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -735,8 +735,8 @@ void EngineShard::Heartbeat() {
   DbSlice& db_slice = namespaces->GetDefaultNamespace().GetDbSlice(shard_id());
   // Skip heartbeat if we are serializing a big value
   static auto start = std::chrono::system_clock::now();
-  // We acquire exlusive locks during global transactions
-  // If we can't acquire this it means the shard is under global lock.
+  // Skip heartbeat if global transaction is in process.
+  // This is determined by attempting to check if shard lock can be acquired.
   const bool can_acquire_global_lock = shard_lock()->Check(IntentLock::Mode::EXCLUSIVE);
 
   if (db_slice.WillBlockOnJournalWrite() || !can_acquire_global_lock) {

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -735,11 +735,14 @@ void EngineShard::Heartbeat() {
   DbSlice& db_slice = namespaces->GetDefaultNamespace().GetDbSlice(shard_id());
   // Skip heartbeat if we are serializing a big value
   static auto start = std::chrono::system_clock::now();
-  if (db_slice.WillBlockOnJournalWrite()) {
+  // We acquire exlusive locks during global transactions
+  // If we can't acquire this it means the shard is under global lock.
+  const bool can_acquire_global_lock = shard_lock()->Check(IntentLock::Mode::EXCLUSIVE);
+
+  if (db_slice.WillBlockOnJournalWrite() || !can_acquire_global_lock) {
     const auto elapsed = std::chrono::system_clock::now() - start;
     if (elapsed > std::chrono::seconds(1)) {
-      LOG_EVERY_T(WARNING, 5) << "Stalled heartbeat() fiber for " << elapsed.count()
-                              << " seconds because of big value serialization";
+      LOG_EVERY_T(WARNING, 5) << "Stalled heartbeat() fiber for " << elapsed.count() << " seconds";
     }
     return;
   }


### PR DESCRIPTION
We allowed running `heartbeat` during `global transactions`. That's not good. For example, during replication and while transitioning from full to stable sync we unregister and register journal callbacks with a preemption inbetween. If under preemption  heartbeat runs, then we loose those journal entries triggering an lsn check failure.

* early return from HeartBeat if shard is under global lock

Fixes another corner case in  #4048
