### PR TITLE
fix(connection): Close MONITOR connection if pipeline overflows

### DIFF
--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -164,6 +164,10 @@ class Connection : public util::Connection {
       return std::holds_alternative<PubMessagePtr>(handle);
     }
 
+    bool IsMonitor() const {
+      return std::holds_alternative<MonitorMessage>(handle);
+    }
+
     bool IsReplying() const;  // control messges don't reply, messages carrying data do
 
     std::variant<MonitorMessage, PubMessagePtr, PipelineMessagePtr, MCPipelineMessagePtr,


### PR DESCRIPTION
Close MONITOR connection if we overflow pipeline limits. It can happen
that MONITOR connection dispatches messages slower than they are received
causing memory to go out of bounds (and can result in process crash).

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->