### PR TITLE
fix: take_over_counters

### DIFF
--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1246,7 +1246,10 @@ async def test_take_over_counters(df_factory, master_threads, replica_threads):
         "Add a blocking command during takeover to make sure it doesn't block it."
         start = time.time()
         # The command should just be canceled
-        assert await c_blocking.execute_command("BLPOP BLOCKING_KEY1 BLOCKING_KEY2 100") is None
+        try:
+            assert await c_blocking.execute_command("BLPOP BLOCKING_KEY1 BLOCKING_KEY2 100") is None
+        except redis.exceptions.ConnectionError as e:
+            pass
         # And it should happen in reasonable amount of time.
         assert time.time() - start < 10
 

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1246,15 +1246,12 @@ async def test_take_over_counters(df_factory, master_threads, replica_threads):
         "Add a blocking command during takeover to make sure it doesn't block it."
         start = time.time()
         # The command should just be canceled
-        try:
-            assert await c_blocking.execute_command("BLPOP BLOCKING_KEY1 BLOCKING_KEY2 100") is None
-        except redis.exceptions.ConnectionError as e:
-            pass
+        assert await c_blocking.execute_command("BLPOP BLOCKING_KEY1 BLOCKING_KEY2 100") is None
         # And it should happen in reasonable amount of time.
         assert time.time() - start < 10
 
     async def delayed_takeover():
-        await asyncio.sleep(0.3)
+        await asyncio.sleep(1)
         await c1.execute_command(f"REPLTAKEOVER 5")
 
     _, _, *results = await asyncio.gather(


### PR DESCRIPTION
The issue: client fails to connect and redis lib converts `OsError` to `ConnectionError` and rethrows. This happens rarely and the symptom can be treated by catching the exception.

```
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
dragonfly/replication_test.py:1249: in block_during_takeover
    assert await c_blocking.execute_command("BLPOP BLOCKING_KEY1 BLOCKING_KEY2 100") is None
/usr/local/lib/python3.8/dist-packages/redis/asyncio/client.py:611: in execute_command
    conn = self.connection or await pool.get_connection(command_name, **options)
/usr/local/lib/python3.8/dist-packages/redis/asyncio/connection.py:1064: in get_connection
    await self.ensure_connection(connection)
/usr/local/lib/python3.8/dist-packages/redis/asyncio/connection.py:1097: in ensure_connection
    await connection.connect()
/usr/local/lib/python3.8/dist-packages/redis/asyncio/connection.py:296: in connect
    await self.on_connect()
/usr/local/lib/python3.8/dist-packages/redis/asyncio/connection.py:401: in on_connect
    await self.send_command("CLIENT", "SETINFO", "LIB-VER", self.lib_version)
/usr/local/lib/python3.8/dist-packages/redis/asyncio/connection.py:505: in send_command
    await self.send_packed_command(
```

and 
`  redis.exceptions.ConnectionError: Error UNKNOWN while writing to socket. Connection lost.`

Fixes # #4533
 