### PR TITLE
fix: test_migration_rebalance_node

### DIFF
--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -2955,6 +2955,7 @@ async def test_migration_rebalance_node(df_factory: DflyInstanceFactory, df_seed
     logging.debug("stop seeding")
     seeder.stop()
     await seed
+    await asyncio.sleep(0.5)  # wait untill all keys with ttl are expired
     capture = await seeder.capture_fake_redis()
     assert await seeder.compare(capture, nodes[1].instance.port)
 


### PR DESCRIPTION
Problem: during seeding, we can add ttl up to 50ms, so to get the same data on fake_redis and DF we need to sleep a little before capture the resulted data

fixes: #4861