### PR TITLE
fix: invalid master_last_io_seconds_ago metric during stable sync

### DIFF
--- a/src/server/protocol_client.cc
+++ b/src/server/protocol_client.cc
@@ -316,6 +316,7 @@ error_code ProtocolClient::ReadLine(base::IoBuf* io_buf, string_view* line) {
     if (!input_str.empty())
       break;
     RETURN_ON_ERR(Recv(sock_.get(), io_buf));
+    TouchIoTime();
     input_str = ToSV(io_buf->InputBuffer());
   };
 
@@ -333,6 +334,7 @@ error_code ProtocolClient::ReadLine(base::IoBuf* io_buf, string_view* line) {
     }
 
     RETURN_ON_ERR(Recv(sock_.get(), io_buf));
+    TouchIoTime();
     input_str = ToSV(io_buf->InputBuffer());
   }
 


### PR DESCRIPTION
fixes: https://github.com/dragonflydb/dragonfly/issues/4884

Fixed overflow on calculating time difference.