### PR TITLE
fix: test_replica_snapshot_with_big_values_while_seeding

### DIFF
--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -54,11 +54,11 @@ runs:
         if [[ "${{inputs.epoll}}" == 'epoll' ]]; then
           export FILTER="${{inputs.filter}} and not exclude_epoll"
           # Run only replication tests with epoll
-          timeout 50m pytest -m "$FILTER" --durations=10 --timeout=300 --color=yes --json-report --json-report-file=report.json dragonfly --df force_epoll=true --log-cli-level=INFO || code=$?
+          timeout 60m pytest -m "$FILTER" --durations=10 --timeout=300 --color=yes --json-report --json-report-file=report.json dragonfly --df force_epoll=true --log-cli-level=INFO || code=$?
         else
           export FILTER="${{inputs.filter}}"
           # Run only replication tests with epoll
-          timeout 50m pytest -m "$FILTER" --durations=10 --timeout=300 --color=yes --json-report --json-report-file=report.json dragonfly --log-cli-level=INFO || code=$?
+          timeout 60m pytest -m "$FILTER" --durations=10 --timeout=300 --color=yes --json-report --json-report-file=report.json dragonfly --log-cli-level=INFO || code=$?
         fi
 
         # timeout returns 124 if we exceeded the timeout duration

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2977,7 +2977,7 @@ async def test_bug_in_json_memory_tracking(df_factory: DflyInstanceFactory):
         rand = random.randint(1, 4)
         await c_master.execute_command(f"EXPIRE tmp:{i} {rand} NX")
 
-    seeder = SeederV2(key_target=100_000)
+    seeder = SeederV2(key_target=50_000)
     fill_task = asyncio.create_task(seeder.run(master.client()))
 
     for replica in c_replicas:
@@ -2989,7 +2989,6 @@ async def test_bug_in_json_memory_tracking(df_factory: DflyInstanceFactory):
     await fill_task
 
 
-@pytest.mark.skip("Skipped temporarily while being investigated")
 async def test_replica_snapshot_with_big_values_while_seeding(df_factory: DflyInstanceFactory):
     proactors = 4
     master = df_factory.create(proactor_threads=proactors, dbfilename="")
@@ -2999,7 +2998,7 @@ async def test_replica_snapshot_with_big_values_while_seeding(df_factory: DflyIn
     c_replica = replica.client()
 
     # 50% big values
-    seeder_config = dict(key_target=20_000, huge_value_target=10000)
+    seeder_config = dict(key_target=8_000, huge_value_target=4_000)
     # Fill instance with test data
     seeder = SeederV2(**seeder_config)
     await seeder.run(c_master, target_deviation=0.01)


### PR DESCRIPTION
Locally, the test consumes roughly 8gb of memory. Our gh runner has 7.5GB. 
Solution: lower number of seeded keys

Also increase timeout for reg tests. It seems that we timeout now :)

Resolves #4899