### PR TITLE
fix(set_family): Update object time during SET FIELDEXPIRE

### DIFF
--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -848,8 +848,10 @@ TEST_F(GenericFamilyTest, JsonType) {
 
 TEST_F(GenericFamilyTest, FieldExpireSet) {
   Run({"SADD", "key", "a", "b", "c"});
+  AdvanceTime(2'000);
   EXPECT_THAT(Run({"FIELDEXPIRE", "key", "10", "a", "b", "c"}),
               RespArray(ElementsAre(IntArg(1), IntArg(1), IntArg(1))));
+  EXPECT_EQ(10, CheckedInt({"fieldttl", "key", "a"}));
   AdvanceTime(10'000);
   EXPECT_THAT(Run({"SMEMBERS", "key"}), RespArray(ElementsAre()));
 }
@@ -858,8 +860,10 @@ TEST_F(GenericFamilyTest, FieldExpireHset) {
   for (int i = 0; i < 3; ++i) {
     EXPECT_EQ(CheckedInt({"HSET", "key", absl::StrCat("k", i), "v"}), 1);
   }
+  AdvanceTime(2'000);
   EXPECT_THAT(Run({"FIELDEXPIRE", "key", "10", "k0", "k1", "k2"}),
               RespArray(ElementsAre(IntArg(1), IntArg(1), IntArg(1))));
+  EXPECT_EQ(10, CheckedInt({"fieldttl", "key", "k0"}));
   AdvanceTime(10'000);
   EXPECT_THAT(Run({"HGETALL", "key"}), RespArray(ElementsAre()));
 }

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -1567,7 +1567,9 @@ vector<long> SetFamily::SetFieldsExpireTime(const OpArgs& op_args, uint32_t ttl_
     pv->InitRobj(OBJ_SET, kEncodingStrMap2, ss);
   }
 
-  return ExpireElements((StringSet*)pv->RObjPtr(), values, ttl_sec);
+  auto ss = static_cast<StringSet*>(pv->RObjPtr());
+  ss->set_time(MemberTimeSeconds(op_args.db_cntx.time_now_ms));
+  return ExpireElements(ss, values, ttl_sec);
 }
 
 }  // namespace dfly


### PR DESCRIPTION
StringSet object doesn't update time when FIELDEXPIRE is called. It will use base time when object is created. Update object time when we want to expire field in SET object.

Fixes #4894

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->