### PR TITLE
feat(server): Exit process if error is report during load snapshot

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -927,9 +927,11 @@ void ServerFamily::LoadFromSnapshot() {
     if (std::error_code(load_path_result.error()) == std::errc::no_such_file_or_directory) {
       LOG(WARNING) << "Load snapshot: No snapshot found";
     } else {
-      util::fb2::LockGuard lk{loading_stats_mu_};
+      loading_stats_mu_.lock();
       loading_stats_.failed_restore_count++;
-      LOG(ERROR) << "Failed to load snapshot: " << load_path_result.error().Format();
+      loading_stats_mu_.unlock();
+      LOG(ERROR) << "Failed to load snapshot with error: " << load_path_result.error().Format();
+      exit(1);
     }
   }
 }

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -332,6 +332,24 @@ def delete_s3_objects(bucket, prefix):
     "DRAGONFLY_S3_BUCKET" not in os.environ or os.environ["DRAGONFLY_S3_BUCKET"] == "",
     reason="AWS S3 snapshots bucket is not configured",
 )
+async def test_exit_on_s3_snapshot_load_err(df_factory):
+    invalid_s3_dir = "s3://{DRAGONFLY_S3_BUCKET}" + "_invalid_bucket_"
+    df_server = df_factory.create(
+        dir=invalid_s3_dir, dbfilename="db", exit_on_cloud_dir_snapshot_load_err=True
+    )
+    df_server.start()
+    # Let's wait so that process exit
+    await asyncio.sleep(2)
+    with pytest.raises(Exception):
+        df_server._check_status()
+
+
+# If DRAGONFLY_S3_BUCKET is configured, AWS credentials must also be
+# configured.
+@pytest.mark.skipif(
+    "DRAGONFLY_S3_BUCKET" not in os.environ or os.environ["DRAGONFLY_S3_BUCKET"] == "",
+    reason="AWS S3 snapshots bucket is not configured",
+)
 @dfly_args({**BASIC_ARGS, "dir": "s3://{DRAGONFLY_S3_BUCKET}{DRAGONFLY_TMP}", "dbfilename": ""})
 async def test_s3_snapshot(async_client, tmp_dir):
     seeder = DebugPopulateSeeder(key_target=10_000)


### PR DESCRIPTION
Exit process if error is reported when we try to load snapshot for both cloud storage and local directory.

Fixes #4840

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->