### PR TITLE
fix(rdb): Print tag as int in error

### DIFF
--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -275,7 +275,7 @@ io::Result<uint8_t> RdbSerializer::SaveEntry(const PrimeKey& pk, const PrimeValu
   if (!pv.TagAllowsEmptyValue() && pv.Size() == 0) {
     string_view key = pk.GetSlice(&tmp_str_);
     LOG(DFATAL) << "SaveEntry skipped empty PrimeValue with key: " << key << " with tag "
-                << pv.Tag();
+                << static_cast<int>(pv.Tag());
     return 0;
   }
 


### PR DESCRIPTION
When we fail to save empty pv, its tag should be printed as int rather than the default behavior of trying to print `uint8_t` as a char.

fixes #4856 