### PR TITLE
fix(pytest): Remove invalid argument from pytest

### DIFF
--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -334,9 +334,7 @@ def delete_s3_objects(bucket, prefix):
 )
 async def test_exit_on_s3_snapshot_load_err(df_factory):
     invalid_s3_dir = "s3://{DRAGONFLY_S3_BUCKET}" + "_invalid_bucket_"
-    df_server = df_factory.create(
-        dir=invalid_s3_dir, dbfilename="db", exit_on_cloud_dir_snapshot_load_err=True
-    )
+    df_server = df_factory.create(dir=invalid_s3_dir, dbfilename="db")
     df_server.start()
     # Let's wait so that process exit
     await asyncio.sleep(2)


### PR DESCRIPTION
Remove invalid argument from test_exit_on_s3_snapshot_load_err test

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->