### PR TITLE
fix(hset): Fix size account discrepancy when setting TTL

### DIFF
--- a/src/core/dense_set.cc
+++ b/src/core/dense_set.cc
@@ -717,8 +717,7 @@ void* DenseSet::AddOrReplaceObj(void* obj, bool has_ttl) {
 
     void* res = dptr->Raw();
     const size_t res_sz = ObjectAllocSize(res);
-    DCHECK(obj_malloc_used_ >= res_sz) << "Invalid deduction of object size " << res_sz
-                                       << " from total set size " << obj_malloc_used_;
+    DCHECK_GE(obj_malloc_used_, res_sz);
     obj_malloc_used_ -= res_sz;
     obj_malloc_used_ += ObjectAllocSize(obj);
 

--- a/src/core/string_map_test.cc
+++ b/src/core/string_map_test.cc
@@ -230,4 +230,18 @@ TEST_F(StringMapTest, ReallocIfNeeded) {
     EXPECT_EQ(sm_->Find(build_str(i * 10))->second, build_str(i * 10 + 1));
 }
 
+TEST_F(StringMapTest, ExpiryChangesSize) {
+  sm_->AddOrUpdate("field", "value");
+  const size_t old_size = sm_->ObjMallocUsed();
+
+  auto it = sm_->Find("field");
+  it.SetExpiryTime(1);
+
+  const size_t new_size = sm_->ObjMallocUsed();
+  EXPECT_LT(old_size, new_size);
+
+  sm_->AddOrUpdate("field", "value", 1);
+  EXPECT_EQ(new_size, sm_->ObjMallocUsed());
+}
+
 }  // namespace dfly


### PR DESCRIPTION
When setting TTL, the object is cloned. An extra 4 bytes is requested during allocation. This can result in the object being allocated from a larger page, eg moving from 16 byte page to 32 byte page. The page block size is used to report object allocation size. Currently this change in size is not reflected in the total memory usage of the dense set, so it remains 16 bytes while the object allocated size is now 32 bytes.

If such an object is later replaced, we deduct the size of the object from total memory usage of the set. Here we can run into an overflow, because the size of the object is deducted from the tracked size of the set, and the former is greater than the latter.

To avoid this, if during setting expiry time the new size is different from old size, we update the set size.

fixes #4911 
