### PR TITLE
fix(metrics): Make command name mandatory parameter to `Invoke`

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -1362,7 +1362,7 @@ void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBat
       crb.SetReplyMode(ReplyMode::NONE);
       stub_tx->InitByArgs(cntx_->ns, local_cntx.conn_state.db_index, args_span);
 
-      sf_.service().InvokeCmd(cid, args_span, &crb, &local_cntx);
+      sf_.service().InvokeCmd(cid, args_span, &crb, &local_cntx, cid->name());
     }
 
     if (options.expire_ttl_range.has_value()) {
@@ -1383,7 +1383,7 @@ void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBat
       local_cntx.cid = cid;
       crb.SetReplyMode(ReplyMode::NONE);
       stub_tx->InitByArgs(cntx_->ns, local_cntx.conn_state.db_index, args_span);
-      sf_.service().InvokeCmd(cid, args_span, &crb, &local_cntx);
+      sf_.service().InvokeCmd(cid, args_span, &crb, &local_cntx, cid->name());
     }
   }
 

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -45,8 +45,7 @@ class Service : public facade::ServiceInterface {
 
   // Check VerifyCommandExecution and invoke command with args
   bool InvokeCmd(const CommandId* cid, CmdArgList tail_args, facade::SinkReplyBuilder* builder,
-                 ConnectionContext* reply_cntx,
-                 std::optional<std::string_view> orig_cmd_name = std::nullopt);
+                 ConnectionContext* cntx, const std::string_view orig_cmd_name);
 
   // Verify command can be executed now (check out of memory), always called immediately before
   // execution

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -163,7 +163,7 @@ bool MultiCommandSquasher::ExecuteStandalone(facade::RedisReplyBuilder* rb, Stor
 
   if (cmd->Cid()->IsTransactional())
     tx->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, args);
-  service_->InvokeCmd(cmd->Cid(), args, rb, cntx_);
+  service_->InvokeCmd(cmd->Cid(), args, rb, cntx_, cmd->Cid()->name());
 
   return true;
 }
@@ -201,7 +201,7 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
     crb.SetReplyMode(cmd->ReplyMode());
 
     local_tx->InitByArgs(cntx_->ns, local_cntx.conn_state.db_index, args);
-    service_->InvokeCmd(cmd->Cid(), args, &crb, &local_cntx);
+    service_->InvokeCmd(cmd->Cid(), args, &crb, &local_cntx, cmd->Cid()->name());
 
     sinfo.replies.emplace_back(crb.Take());
     current_reply_size_.fetch_add(Size(sinfo.replies.back()), std::memory_order_relaxed);


### PR DESCRIPTION
Removed optional parameter for command invocation, so caller has to handle passing in command name explicitly and pass in alias where applicable.

This simplifies some logic in command invocation where command name is used if an optional is unset.

fixes #4857 