### PR TITLE
fix(pytest): Wait exception on instance start and stop

### DIFF
--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -335,11 +335,9 @@ def delete_s3_objects(bucket, prefix):
 async def test_exit_on_s3_snapshot_load_err(df_factory):
     invalid_s3_dir = "s3://{DRAGONFLY_S3_BUCKET}" + "_invalid_bucket_"
     df_server = df_factory.create(dir=invalid_s3_dir, dbfilename="db")
-    df_server.start()
-    # Let's wait so that process exit
-    await asyncio.sleep(2)
     with pytest.raises(Exception):
-        df_server._check_status()
+        df_server.start()
+        df_server.stop()
 
 
 # If DRAGONFLY_S3_BUCKET is configured, AWS credentials must also be


### PR DESCRIPTION
Pytest test_exit_on_s3_snapshot_load_err can raise exception on start in some test environments. Now wait for exception in instance start and stop.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->