### PR TITLE
chore: Cleanup DbSlice::CallChangeCallbacks

### DIFF
--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -535,7 +535,7 @@ class DbSlice {
   size_t StopSampleKeys(DbIndex db_ind);
 
  private:
-  void PreUpdateBlocking(DbIndex db_ind, Iterator it, std::string_view key);
+  void PreUpdateBlocking(DbIndex db_ind, Iterator it);
   void PostUpdate(DbIndex db_ind, Iterator it, std::string_view key, size_t orig_size);
 
   bool DelEmptyPrimeValue(const Context& cntx, Iterator it);
@@ -588,7 +588,7 @@ class DbSlice {
     return version_++;
   }
 
-  void CallChangeCallbacks(DbIndex id, std::string_view key, const ChangeReq& cr) const;
+  void CallChangeCallbacks(DbIndex id, const ChangeReq& cr) const;
 
   // We need this because registered callbacks might yield and when they do so we want
   // to avoid Heartbeat or Flushing the db.


### PR DESCRIPTION
Remove key argument in DbSlice::CallChangeCallbacks which is used only for DVLOG(2) logging. DbSlice::OnCbFinishBlocking needs to call this funciton but it doesn't have key name so it has to retrieve one from it.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->