### PR TITLE
fix: Skip test_take_over_counters for epoll

### DIFF
--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1210,6 +1210,7 @@ take_over_cases = [
 ]
 
 
+@pytest.mark.exclude_epoll
 @pytest.mark.parametrize("master_threads, replica_threads", take_over_cases)
 async def test_take_over_counters(df_factory, master_threads, replica_threads):
     master = df_factory.create(proactor_threads=master_threads)


### PR DESCRIPTION
Temporarily disable test while failures are investigated