### PR TITLE
feat(server): Add support for command aliasing

### DIFF
--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -591,7 +591,7 @@ void AclFamily::DryRun(CmdArgList args, const CommandContext& cmd_cntx) {
 
   string command = absl::AsciiStrToUpper(ArgS(args, 1));
   auto* cid = cmd_registry_->Find(command);
-  if (!cid) {
+  if (!cid || cid->IsAlias()) {
     auto error = absl::StrCat("Command '", command, "' not found");
     rb->SendError(error);
     return;
@@ -1062,7 +1062,7 @@ std::pair<AclFamily::OptCommand, bool> AclFamily::MaybeParseAclCommand(
     std::string_view command) const {
   if (absl::StartsWith(command, "+")) {
     auto res = cmd_registry_->Find(command.substr(1));
-    if (!res) {
+    if (!res || res->IsAlias()) {
       return {};
     }
     std::pair<size_t, uint64_t> cmd{res->GetFamily(), res->GetBitIndex()};
@@ -1071,7 +1071,7 @@ std::pair<AclFamily::OptCommand, bool> AclFamily::MaybeParseAclCommand(
 
   if (absl::StartsWith(command, "-")) {
     auto res = cmd_registry_->Find(command.substr(1));
-    if (!res) {
+    if (!res || res->IsAlias()) {
       return {};
     }
     std::pair<size_t, uint64_t> cmd{res->GetFamily(), res->GetBitIndex()};

--- a/src/server/acl/validator.cc
+++ b/src/server/acl/validator.cc
@@ -66,6 +66,10 @@ bool ValidateCommand(const std::vector<uint64_t>& acl_commands, const CommandId&
     return true;
   }
 
+  if (id.IsAlias()) {
+    return false;
+  }
+
   std::pair<bool, AclLog::Reason> auth_res;
 
   if (id.IsPubSub() || id.IsShardedPSub()) {

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -223,8 +223,7 @@ CommandRegistry& CommandRegistry::operator<<(CommandId cmd) {
 
   absl::InlinedVector<std::string_view, 2> maybe_subcommand = StrSplit(cmd.name(), " ");
   const bool is_sub_command = maybe_subcommand.size() == 2;
-  auto it = cmd_rename_map_.find(maybe_subcommand.front());
-  if (it != cmd_rename_map_.end()) {
+  if (const auto it = cmd_rename_map_.find(maybe_subcommand.front()); it != cmd_rename_map_.end()) {
     if (it->second.empty()) {
       return *this;  // Incase of empty string we want to remove the command from registry.
     }
@@ -240,9 +239,8 @@ CommandRegistry& CommandRegistry::operator<<(CommandId cmd) {
   }
 
   cmd.SetFamily(family_of_commands_.size() - 1);
-  if (acl_category_) {
+  if (acl_category_)
     cmd.SetAclCategory(*acl_category_);
-  }
 
   if (!is_sub_command || absl::StartsWith(cmd.name(), "ACL")) {
     cmd.SetBitIndex(1ULL << bit_index_);
@@ -253,6 +251,7 @@ CommandRegistry& CommandRegistry::operator<<(CommandId cmd) {
     cmd.SetBitIndex(1ULL << (bit_index_ - 1));
   }
   CHECK(cmd_map_.emplace(k, std::move(cmd)).second) << k;
+
   return *this;
 }
 

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -135,16 +135,13 @@ CommandId::CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first
   implicit_acl_ = !acl_categories.has_value();
 }
 
-CommandId::CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first_key,
-                     int8_t last_key, uint32_t acl_categories, bool implicit_acl)
-    : facade::CommandId(name, mask, arity, first_key, last_key, acl_categories),
-      implicit_acl_(implicit_acl) {
-}
-
 CommandId CommandId::Clone(const std::string_view name) const {
-  CommandId cloned = CommandId{name.data(), opt_mask_ | CO::HIDDEN, arity_,       first_key_,
-                               last_key_,   acl_categories_,        implicit_acl_};
+  CommandId cloned =
+      CommandId{name.data(), opt_mask_, arity_, first_key_, last_key_, acl_categories_};
   cloned.handler_ = handler_;
+  cloned.opt_mask_ = opt_mask_ | CO::HIDDEN;
+  cloned.acl_categories_ = acl_categories_;
+  cloned.implicit_acl_ = implicit_acl_;
   return cloned;
 }
 

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -230,6 +230,4 @@ class CommandRegistry {
   std::optional<uint32_t> acl_category_;  // category of family currently being built
 };
 
-void TestResetAliasMap();
-
 }  // namespace dfly

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -93,7 +93,7 @@ class CommandId : public facade::CommandId {
 
   CommandId(CommandId&&) = default;
 
-  CommandId Clone(std::string_view name) const;
+  [[nodiscard]] CommandId Clone(std::string_view name) const;
 
   void Init(unsigned thread_count) {
     command_stats_ = std::make_unique<CmdCallStats[]>(thread_count);
@@ -155,11 +155,16 @@ class CommandId : public facade::CommandId {
       acl_categories_ |= mask;
   }
 
+  bool IsAlias() const {
+    return is_alias_;
+  }
+
  private:
   bool implicit_acl_;
   std::unique_ptr<CmdCallStats[]> command_stats_;
   Handler3 handler_;
   ArgValidator validator_;
+  bool is_alias_{false};
 };
 
 class CommandRegistry {

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -71,9 +71,8 @@ static_assert(!IsEvalKind(""));
 
 };  // namespace CO
 
-// Per thread vector of command stats. Each entry is:
-// command invocation string -> {cmd_calls, cmd_latency_agg in usec}.
-using CmdCallStats = absl::flat_hash_map<std::string, std::pair<uint64_t, uint64_t>>;
+// Per thread vector of command stats. Each entry is {cmd_calls, cmd_latency_agg in usec}.
+using CmdCallStats = std::pair<uint64_t, uint64_t>;
 
 struct CommandContext {
   CommandContext(Transaction* _tx, facade::SinkReplyBuilder* _rb, ConnectionContext* cntx)
@@ -92,7 +91,12 @@ class CommandId : public facade::CommandId {
   CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first_key, int8_t last_key,
             std::optional<uint32_t> acl_categories = std::nullopt);
 
+  CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first_key, int8_t last_key,
+            uint32_t acl_categories, bool implicit_acl);
+
   CommandId(CommandId&&) = default;
+
+  CommandId Clone(std::string_view name) const;
 
   void Init(unsigned thread_count) {
     command_stats_ = std::make_unique<CmdCallStats[]>(thread_count);
@@ -103,10 +107,8 @@ class CommandId : public facade::CommandId {
   using ArgValidator = fu2::function_base<true, true, fu2::capacity_default, false, false,
                                           std::optional<facade::ErrorReply>(CmdArgList) const>;
 
-  // Invokes the command handler. Returns the invoke time in usec. The invoked_by parameter is set
-  // to the string passed in by user, if available. If not set, defaults to command name.
-  uint64_t Invoke(CmdArgList args, const CommandContext& cmd_cntx,
-                  std::string_view orig_cmd_name) const;
+  // Returns the invoke time in usec.
+  uint64_t Invoke(CmdArgList args, const CommandContext& cmd_cntx) const;
 
   // Returns error if validation failed, otherwise nullopt
   std::optional<facade::ErrorReply> Validate(CmdArgList tail_args) const;
@@ -144,7 +146,7 @@ class CommandId : public facade::CommandId {
   }
 
   void ResetStats(unsigned thread_index) {
-    command_stats_[thread_index].clear();
+    command_stats_[thread_index] = {0, 0};
   }
 
   CmdCallStats GetStats(unsigned thread_index) const {
@@ -172,16 +174,8 @@ class CommandRegistry {
   CommandRegistry& operator<<(CommandId cmd);
 
   const CommandId* Find(std::string_view cmd) const {
-    if (const auto it = cmd_map_.find(cmd); it != cmd_map_.end()) {
-      return &it->second;
-    }
-
-    if (const auto it = cmd_aliases_.find(cmd); it != cmd_aliases_.end()) {
-      if (const auto alias_lookup = cmd_map_.find(it->second); alias_lookup != cmd_map_.end()) {
-        return &alias_lookup->second;
-      }
-    }
-    return nullptr;
+    auto it = cmd_map_.find(cmd);
+    return it == cmd_map_.end() ? nullptr : &it->second;
   }
 
   CommandId* Find(std::string_view cmd) {
@@ -203,17 +197,13 @@ class CommandRegistry {
     }
   }
 
-  void MergeCallStats(
-      unsigned thread_index,
-      std::function<void(std::string_view, const CmdCallStats::mapped_type&)> cb) const {
-    for (const auto& [_, cmd_id] : cmd_map_) {
-      for (const auto& [cmd_name, call_stats] : cmd_id.GetStats(thread_index)) {
-        if (call_stats.first == 0) {
-          continue;
-        }
-
-        cb(cmd_name, call_stats);
-      }
+  void MergeCallStats(unsigned thread_index,
+                      std::function<void(std::string_view, const CmdCallStats&)> cb) const {
+    for (const auto& k_v : cmd_map_) {
+      auto src = k_v.second.GetStats(thread_index);
+      if (src.first == 0)
+        continue;
+      cb(k_v.second.name(), src);
     }
   }
 
@@ -227,16 +217,10 @@ class CommandRegistry {
   std::pair<const CommandId*, facade::ArgSlice> FindExtended(std::string_view cmd,
                                                              facade::ArgSlice tail_args) const;
 
-  bool IsAlias(std::string_view cmd) const;
-
  private:
   absl::flat_hash_map<std::string, CommandId> cmd_map_;
   absl::flat_hash_map<std::string, std::string> cmd_rename_map_;
-  // Stores a mapping from alias to original command. During the find operation, the first lookup is
-  // done in the cmd_map_, then in the alias map. This results in two lookups but only for commands
-  // which are not in original map, ie either typos or aliases. While it would be faster, we cannot
-  // store iterators into cmd_map_ here as they may be invalidated on rehashing.
-  absl::flat_hash_map<std::string, std::string> cmd_aliases_;
+  absl::flat_hash_map<std::string, std::string> alias_map_;
   absl::flat_hash_set<std::string> restricted_cmds_;
   absl::flat_hash_set<std::string> oomdeny_cmds_;
 

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -91,9 +91,6 @@ class CommandId : public facade::CommandId {
   CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first_key, int8_t last_key,
             std::optional<uint32_t> acl_categories = std::nullopt);
 
-  CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first_key, int8_t last_key,
-            uint32_t acl_categories, bool implicit_acl);
-
   CommandId(CommandId&&) = default;
 
   CommandId Clone(std::string_view name) const;

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -220,7 +220,6 @@ class CommandRegistry {
  private:
   absl::flat_hash_map<std::string, CommandId> cmd_map_;
   absl::flat_hash_map<std::string, std::string> cmd_rename_map_;
-  absl::flat_hash_map<std::string, std::string> alias_map_;
   absl::flat_hash_set<std::string> restricted_cmds_;
   absl::flat_hash_set<std::string> oomdeny_cmds_;
 
@@ -228,5 +227,7 @@ class CommandRegistry {
   size_t bit_index_;
   std::optional<uint32_t> acl_category_;  // category of family currently being built
 };
+
+void TestResetAliasMap();
 
 }  // namespace dfly

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -850,8 +850,7 @@ TEST_F(DflyEngineTest, CommandMetricLabels) {
 class DflyCommandAliasTest : public DflyEngineTest {
  protected:
   DflyCommandAliasTest() {
-    absl::SetFlag(&FLAGS_rename_command, {"ping=gnip"});
-    absl::SetFlag(&FLAGS_command_alias, {"___set=set", "___ping=gnip"});
+    absl::SetFlag(&FLAGS_command_alias, {"___set=set", "___ping=ping"});
   }
 
   absl::FlagSaver saver_;
@@ -862,12 +861,7 @@ TEST_F(DflyCommandAliasTest, Aliasing) {
   EXPECT_EQ(Run({"___SET", "a", "b"}), "OK");
   EXPECT_EQ(Run({"GET", "foo"}), "bar");
   EXPECT_EQ(Run({"GET", "a"}), "b");
-  // test the alias
   EXPECT_EQ(Run({"___ping"}), "PONG");
-  // test the rename
-  EXPECT_EQ(Run({"gnip"}), "PONG");
-  // the original command is not accessible
-  EXPECT_THAT(Run({"PING"}), ErrArg("unknown command `PING`"));
 
   Metrics metrics = GetMetrics();
   const auto& stats = metrics.cmd_stats_map;

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -9,7 +9,7 @@ extern "C" {
 
 #include <absl/strings/ascii.h>
 #include <absl/strings/str_join.h>
-#include <absl/strings/str_split.h>
+#include <absl/strings/strip.h>
 #include <gmock/gmock.h>
 #include <reflex/matcher.h>
 
@@ -17,6 +17,7 @@ extern "C" {
 #include "base/gtest.h"
 #include "base/logging.h"
 #include "facade/facade_test.h"
+#include "server/conn_context.h"
 #include "server/main_service.h"
 #include "server/test_utils.h"
 
@@ -24,9 +25,9 @@ ABSL_DECLARE_FLAG(float, mem_defrag_threshold);
 ABSL_DECLARE_FLAG(float, mem_defrag_waste_threshold);
 ABSL_DECLARE_FLAG(uint32_t, mem_defrag_check_sec_interval);
 ABSL_DECLARE_FLAG(std::vector<std::string>, rename_command);
-ABSL_DECLARE_FLAG(std::vector<std::string>, command_alias);
 ABSL_DECLARE_FLAG(bool, lua_resp2_legacy_float);
 ABSL_DECLARE_FLAG(double, eviction_memory_budget_threshold);
+ABSL_DECLARE_FLAG(std::vector<std::string>, command_alias);
 
 namespace dfly {
 
@@ -118,7 +119,8 @@ class DflyRenameCommandTest : public DflyEngineTest {
         &FLAGS_rename_command,
         std::vector<std::string>({"flushall=myflushall", "flushdb=", "ping=abcdefghijklmnop"}));
   }
-  absl::FlagSaver saver_;
+
+  absl::FlagSaver _saver;
 };
 
 TEST_F(DflyRenameCommandTest, RenameCommand) {
@@ -848,7 +850,6 @@ TEST_F(DflyEngineTest, CommandMetricLabels) {
 class DflyCommandAliasTest : public DflyEngineTest {
  protected:
   DflyCommandAliasTest() {
-    // Test an interaction of rename and alias, where we rename and then add an alias on the rename
     absl::SetFlag(&FLAGS_rename_command, {"ping=gnip"});
     absl::SetFlag(&FLAGS_command_alias, {"___set=set", "___ping=gnip"});
   }
@@ -868,12 +869,24 @@ TEST_F(DflyCommandAliasTest, Aliasing) {
   // the original command is not accessible
   EXPECT_THAT(Run({"PING"}), ErrArg("unknown command `PING`"));
 
-  const Metrics metrics = GetMetrics();
+  Metrics metrics = GetMetrics();
   const auto& stats = metrics.cmd_stats_map;
+
   EXPECT_THAT(stats, Contains(Pair("___set", Key(1))));
   EXPECT_THAT(stats, Contains(Pair("set", Key(1))));
   EXPECT_THAT(stats, Contains(Pair("___ping", Key(1))));
   EXPECT_THAT(stats, Contains(Pair("get", Key(2))));
+
+  // test stats within multi-exec
+  EXPECT_EQ(Run({"multi"}), "OK");
+  EXPECT_EQ(Run({"___set", "a", "x"}), "QUEUED");
+  EXPECT_EQ(Run({"exec"}), "OK");
+
+  metrics = GetMetrics();
+  EXPECT_THAT(metrics.cmd_stats_map, Contains(Pair("___set", Key(2))));
+  EXPECT_THAT(metrics.cmd_stats_map, Contains(Pair("set", Key(1))));
+  EXPECT_THAT(metrics.cmd_stats_map, Contains(Pair("multi", Key(1))));
+  EXPECT_THAT(metrics.cmd_stats_map, Contains(Pair("exec", Key(1))));
 }
 
 }  // namespace dfly

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -850,7 +850,6 @@ TEST_F(DflyEngineTest, CommandMetricLabels) {
 class DflyCommandAliasTest : public DflyEngineTest {
  protected:
   DflyCommandAliasTest() {
-    dfly::TestResetAliasMap();
     absl::SetFlag(&FLAGS_rename_command, {"ping=gnip"});
     absl::SetFlag(&FLAGS_command_alias, {"___set=set", "___ping=gnip"});
   }

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -850,6 +850,7 @@ TEST_F(DflyEngineTest, CommandMetricLabels) {
 class DflyCommandAliasTest : public DflyEngineTest {
  protected:
   DflyCommandAliasTest() {
+    dfly::TestResetAliasMap();
     absl::SetFlag(&FLAGS_rename_command, {"ping=gnip"});
     absl::SetFlag(&FLAGS_command_alias, {"___set=set", "___ping=gnip"});
   }

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -4,6 +4,7 @@
 
 #include "server/main_service.h"
 
+#include "absl/strings/str_split.h"
 #include "facade/resp_expr.h"
 #include "util/fibers/synchronization.h"
 
@@ -1235,13 +1236,7 @@ void Service::DispatchCommand(ArgSlice args, SinkReplyBuilder* builder,
 
   dfly_cntx->cid = cid;
 
-  // If cmd is an alias, pass it to Invoke so the stats are updated against the alias. By defaults
-  // stats will be updated for cid.name
-  std::optional<std::string_view> orig_cmd_name = std::nullopt;
-  if (registry_.IsAlias(cmd)) {
-    orig_cmd_name = cmd;
-  }
-  if (!InvokeCmd(cid, args_no_cmd, builder, dfly_cntx, orig_cmd_name)) {
+  if (!InvokeCmd(cid, args_no_cmd, builder, dfly_cntx)) {
     builder->SendError("Internal Error");
     builder->CloseConnection();
   }
@@ -1302,7 +1297,7 @@ OpResult<void> OpTrackKeys(const OpArgs slice_args, const facade::Connection::We
 }
 
 bool Service::InvokeCmd(const CommandId* cid, CmdArgList tail_args, SinkReplyBuilder* builder,
-                        ConnectionContext* cntx, std::optional<std::string_view> orig_cmd_name) {
+                        ConnectionContext* cntx) {
   DCHECK(cid);
   DCHECK(!cid->Validate(tail_args));
 
@@ -1351,8 +1346,7 @@ bool Service::InvokeCmd(const CommandId* cid, CmdArgList tail_args, SinkReplyBui
   auto last_error = builder->ConsumeLastError();
   DCHECK(last_error.empty());
   try {
-    invoke_time_usec = cid->Invoke(tail_args, CommandContext{tx, builder, cntx},
-                                   orig_cmd_name.value_or(cid->name()));
+    invoke_time_usec = cid->Invoke(tail_args, CommandContext{tx, builder, cntx});
   } catch (std::exception& e) {
     LOG(ERROR) << "Internal error, system probably unstable " << e.what();
     return false;

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -45,8 +45,7 @@ class Service : public facade::ServiceInterface {
 
   // Check VerifyCommandExecution and invoke command with args
   bool InvokeCmd(const CommandId* cid, CmdArgList tail_args, facade::SinkReplyBuilder* builder,
-                 ConnectionContext* reply_cntx,
-                 std::optional<std::string_view> orig_cmd_name = std::nullopt);
+                 ConnectionContext* reply_cntx);
 
   // Verify command can be executed now (check out of memory), always called immediately before
   // execution

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2212,8 +2212,7 @@ Metrics ServerFamily::GetMetrics(Namespace* ns) const {
 
   uint64_t start = absl::GetCurrentTimeNanos();
 
-  auto cmd_stat_cb = [&dest = result.cmd_stats_map](string_view name,
-                                                    const CmdCallStats::mapped_type& stat) {
+  auto cmd_stat_cb = [&dest = result.cmd_stats_map](string_view name, const CmdCallStats& stat) {
     auto& [calls, sum] = dest[absl::AsciiStrToLower(name)];
     calls += stat.first;
     sum += stat.second;

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2959,6 +2959,7 @@ async def test_preempt_in_atomic_section_of_heartbeat(df_factory: DflyInstanceFa
     await fill_task
 
 
+@pytest.mark.skip("temporarily skipped")
 async def test_bug_in_json_memory_tracking(df_factory: DflyInstanceFactory):
     """
     This test reproduces a bug in the JSON memory tracking.


### PR DESCRIPTION
This is an effort to simplify previous PRs which introduced commits

https://github.com/dragonflydb/dragonfly/commit/91c27f1f18cb4378ca5daacbbe616855cce437fd
https://github.com/dragonflydb/dragonfly/commit/4539e3d024dd2348ebd60eeb73ef4fb04e110e8b

In this change the previous commits are reverted, and commands are cloned for each alias. An additional hidden opt is added for the cloned command. A new c-tor is added to clone commands cleanly.

FIXES https://github.com/dragonflydb/dragonfly/issues/4857