### PR TITLE
fix: test_migration_timeout_on_sync

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -510,6 +510,8 @@ void DebugCmd::Run(CmdArgList args, facade::SinkReplyBuilder* builder) {
         "      existing RDB file.",
         "REPLICA PAUSE/RESUME",
         "    Stops replica from reconnecting to master, or resumes",
+        "MIGRATION PAUSE/RESUME",
+        "    Stops/resumes incoming migration process only in the SYNC state",
         "REPLICA OFFSET",
         "    Return sync id and array of number of journal commands executed for each replica flow",
         "WATCHED",

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -2745,7 +2745,8 @@ async def test_migration_timeout_on_sync(df_factory: DflyInstanceFactory, df_see
     await push_config(json.dumps(generate_config(nodes)), [node.admin_client for node in nodes])
 
     await asyncio.sleep(random.randint(0, 50) / 100)
-    await wait_for_migration_start(nodes[1].admin_client, nodes[0].id)
+    # to pause migration we need to be in sync state
+    await wait_for_status(nodes[1].admin_client, nodes[0].id, "SYNC", 1000)
 
     logging.debug("debug migration pause")
     await nodes[1].client.execute_command("debug migration pause")


### PR DESCRIPTION
problem: after refactoring in https://github.com/dragonflydb/dragonfly/pull/4756, the incoming migration exist all the time, so we can pause the migration only after sync state when migrationg actually happens