### PR TITLE
fix(search_family): Fix SORTBY option in FT.SEARCH for non-sortable fields and KNN search

### DIFF
--- a/src/core/search/ast_expr.h
+++ b/src/core/search/ast_expr.h
@@ -108,15 +108,9 @@ struct AstKnnNode {
   std::optional<float> ef_runtime;
 };
 
-struct AstSortNode {
-  std::unique_ptr<AstNode> filter;
-  std::string field;
-  bool descending = false;
-};
-
 using NodeVariants =
     std::variant<std::monostate, AstStarNode, AstTermNode, AstPrefixNode, AstRangeNode,
-                 AstNegateNode, AstLogicalNode, AstFieldNode, AstTagsNode, AstKnnNode, AstSortNode>;
+                 AstNegateNode, AstLogicalNode, AstFieldNode, AstTagsNode, AstKnnNode>;
 
 struct AstNode : public NodeVariants {
   using variant::variant;

--- a/src/core/search/base.h
+++ b/src/core/search/base.h
@@ -37,11 +37,6 @@ struct QueryParams {
   absl::flat_hash_map<std::string, std::string> params;
 };
 
-struct SortOption {
-  std::string field;
-  bool descending = false;
-};
-
 // Comparable string stored as char[]. Used to reduce size of std::variant with strings.
 struct WrappedStrPtr {
   // Intentionally implicit and const std::string& for use in templates

--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -143,7 +143,6 @@ struct ProfileBuilder {
         [](const AstKnnNode& n) { return absl::StrCat("KNN{l=", n.limit, "}"); },
         [](const AstNegateNode& n) { return absl::StrCat("Negate{}"); },
         [](const AstStarNode& n) { return absl::StrCat("Star{}"); },
-        [](const AstSortNode& n) { return absl::StrCat("Sort{f", n.field, "}"); },
     };
     return visit(node_info, node.Variant());
   }
@@ -177,8 +176,7 @@ struct ProfileBuilder {
 struct BasicSearch {
   using LogicOp = AstLogicalNode::LogicOp;
 
-  BasicSearch(const FieldIndices* indices, size_t limit)
-      : indices_{indices}, limit_{limit}, tmp_vec_{} {
+  BasicSearch(const FieldIndices* indices) : indices_{indices}, tmp_vec_{} {
   }
 
   void EnableProfiling() {
@@ -372,27 +370,6 @@ struct BasicSearch {
     return UnifyResults(GetSubResults(node.tags, mapping), LogicOp::OR);
   }
 
-  // SORTBY field [DESC]: Sort by field. Part of params and not "core query".
-  IndexResult Search(const AstSortNode& node, string_view active_field) {
-    auto sub_results = SearchGeneric(*node.filter, active_field);
-
-    // Skip sorting again for KNN queries, reverse if needed will be applied on aggregation
-    if (auto knn = get_if<AstKnnNode>(&node.filter->Variant());
-        knn && (knn->score_alias == node.field || "__vector_score" == node.field)) {
-      return sub_results;
-    }
-
-    preagg_total_ = sub_results.Size();
-
-    if (auto* sort_index = GetSortIndex(node.field); sort_index) {
-      auto ids_vec = sub_results.Take();
-      scores_ = sort_index->Sort(&ids_vec, limit_, node.descending);
-      return ids_vec;
-    }
-
-    return IndexResult{};
-  }
-
   void SearchKnnFlat(FlatVectorIndex* vec_index, const AstKnnNode& knn, IndexResult&& sub_results) {
     knn_distances_.reserve(sub_results.Size());
     auto cb = [&](auto* set) {
@@ -482,14 +459,13 @@ struct BasicSearch {
     size_t total = result.Size();
     return SearchResult{total,
                         max(total, preagg_total_),
-                        result.Take(limit_),
+                        result.Take(),
                         std::move(scores_),
                         std::move(profile),
                         std::move(error_)};
   }
 
   const FieldIndices* indices_;
-  size_t limit_;
 
   size_t preagg_total_ = 0;
   string error_;
@@ -677,7 +653,7 @@ const Synonyms* FieldIndices::GetSynonyms() const {
 SearchAlgorithm::SearchAlgorithm() = default;
 SearchAlgorithm::~SearchAlgorithm() = default;
 
-bool SearchAlgorithm::Init(string_view query, const QueryParams* params, const SortOption* sort) {
+bool SearchAlgorithm::Init(string_view query, const QueryParams* params) {
   try {
     query_ = make_unique<AstExpr>(ParseQuery(query, params));
   } catch (const Parser::syntax_error& se) {
@@ -693,35 +669,22 @@ bool SearchAlgorithm::Init(string_view query, const QueryParams* params, const S
     return false;
   }
 
-  if (sort != nullptr)
-    query_ = make_unique<AstNode>(AstSortNode{std::move(query_), sort->field, sort->descending});
-
   return true;
 }
 
-SearchResult SearchAlgorithm::Search(const FieldIndices* index, size_t limit) const {
-  auto bs = BasicSearch{index, limit};
+SearchResult SearchAlgorithm::Search(const FieldIndices* index) const {
+  auto bs = BasicSearch{index};
   if (profiling_enabled_)
     bs.EnableProfiling();
   return bs.Search(*query_);
 }
 
-optional<AggregationInfo> SearchAlgorithm::GetAggregationInfo() const {
+optional<KnnScoreSortOption> SearchAlgorithm::GetKnnScoreSortOption() const {
   DCHECK(query_);
 
   // KNN query
   if (auto* knn = get_if<AstKnnNode>(query_.get()); knn)
-    return AggregationInfo{string_view{knn->score_alias}, false, knn->limit};
-
-  // SEARCH query with SORTBY option
-  if (auto* sort = get_if<AstSortNode>(query_.get()); sort) {
-    string_view alias = "";
-    if (auto* knn = get_if<AstKnnNode>(&sort->filter->Variant());
-        knn && knn->score_alias == sort->field)
-      alias = knn->score_alias;
-
-    return AggregationInfo{alias, sort->descending};
-  }
+    return KnnScoreSortOption{string_view{knn->score_alias}, knn->limit};
 
   return nullopt;
 }

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -140,9 +140,8 @@ struct SearchResult {
   std::string error;
 };
 
-struct AggregationInfo {
-  std::string_view alias;
-  bool descending;
+struct KnnScoreSortOption {
+  std::string_view score_field_alias;
   size_t limit = std::numeric_limits<size_t>::max();
 };
 
@@ -153,13 +152,12 @@ class SearchAlgorithm {
   ~SearchAlgorithm();
 
   // Init with query and return true if successful.
-  bool Init(std::string_view query, const QueryParams* params, const SortOption* sort = nullptr);
+  bool Init(std::string_view query, const QueryParams* params);
 
-  SearchResult Search(const FieldIndices* index,
-                      size_t limit = std::numeric_limits<size_t>::max()) const;
+  SearchResult Search(const FieldIndices* index) const;
 
   // if enabled, return limit & alias for knn query
-  std::optional<AggregationInfo> GetAggregationInfo() const;
+  std::optional<KnnScoreSortOption> GetKnnScoreSortOption() const;
 
   void EnableProfiling();
 

--- a/src/server/search/aggregator.cc
+++ b/src/server/search/aggregator.cc
@@ -5,6 +5,7 @@
 #include "server/search/aggregator.h"
 
 #include "base/logging.h"
+#include "server/search/doc_index.h"
 
 namespace dfly::aggregate {
 
@@ -97,7 +98,7 @@ void Aggregator::DoSort(const SortParams& sort_params) {
       if (lv == rv) {
         continue;
       }
-      return order == SortParams::SortOrder::ASC ? lv < rv : lv > rv;
+      return order == SortOrder::ASC ? lv < rv : lv > rv;
     }
     return false;
   };

--- a/src/server/search/aggregator.h
+++ b/src/server/search/aggregator.h
@@ -15,6 +15,10 @@
 #include "facade/reply_builder.h"
 #include "io/io.h"
 
+namespace dfly {
+enum class SortOrder;
+}
+
 namespace dfly::aggregate {
 
 struct Reducer;
@@ -34,8 +38,6 @@ struct AggregationResult {
 };
 
 struct SortParams {
-  enum class SortOrder { ASC, DESC };
-
   constexpr static int64_t kSortAll = -1;
 
   bool SortAll() const {

--- a/src/server/search/aggregator_test.cc
+++ b/src/server/search/aggregator_test.cc
@@ -5,6 +5,7 @@
 #include "server/search/aggregator.h"
 
 #include "base/gtest.h"
+#include "server/search/doc_index.h"
 
 namespace dfly::aggregate {
 
@@ -20,7 +21,7 @@ TEST(AggregatorTest, Sort) {
   };
 
   SortParams params;
-  params.fields.emplace_back("a", SortParams::SortOrder::ASC);
+  params.fields.emplace_back("a", SortOrder::ASC);
   StepsList steps = {MakeSortStep(std::move(params))};
 
   auto result = Process(values, {"a"}, steps);

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -2278,4 +2278,69 @@ TEST_F(SearchFamilyTest, PrefixSearchWithSynonyms) {
   EXPECT_THAT(resp, AreDocIds("doc:6"));  // Should only find macintosh
 }
 
+TEST_F(SearchFamilyTest, SearchSortByOptionNonSortableFieldJson) {
+  Run({"JSON.SET", "json1", "$", R"({"text":"2"})"});
+  Run({"JSON.SET", "json2", "$", R"({"text":"1"})"});
+
+  auto resp = Run({"FT.CREATE", "index", "ON", "JSON", "SCHEMA", "$.text", "AS", "text", "TEXT"});
+  EXPECT_EQ(resp, "OK");
+
+  auto expect_expr = [](std::string_view text_field) {
+    return IsArray(2, "json2", IsMap(text_field, "\"1\"", "$", R"({"text":"1"})"), "json1",
+                   IsMap(text_field, "\"2\"", "$", R"({"text":"2"})"));
+  };
+
+  resp = Run({"FT.SEARCH", "index", "*", "SORTBY", "text"});
+  EXPECT_THAT(resp, expect_expr("text"sv));
+
+  resp = Run({"FT.SEARCH", "index", "*", "SORTBY", "@text"});
+  EXPECT_THAT(resp, expect_expr("text"sv));
+
+  resp = Run({"FT.SEARCH", "index", "*", "SORTBY", "$.text"});
+  EXPECT_THAT(resp, expect_expr("$.text"sv));
+}
+
+TEST_F(SearchFamilyTest, SearchSortByOptionNonSortableFieldHash) {
+  Run({"HSET", "h1", "text", "2"});
+  Run({"HSET", "h2", "text", "1"});
+
+  auto resp = Run({"FT.CREATE", "index", "ON", "HASH", "SCHEMA", "text", "TEXT"});
+  EXPECT_EQ(resp, "OK");
+
+  auto expected_expr = IsArray(2, "h2", IsMap("text", "1"), "h1", IsMap("text", "2"));
+
+  resp = Run({"FT.SEARCH", "index", "*", "SORTBY", "text"});
+  EXPECT_THAT(resp, expected_expr);
+
+  resp = Run({"FT.SEARCH", "index", "*", "SORTBY", "@text"});
+  EXPECT_THAT(resp, expected_expr);
+}
+
+TEST_F(SearchFamilyTest, KnnSearchWithSortby) {
+  auto to_vector = [](const char* value) { return std::string(value, 16); };
+
+  Run({"HSET", "doc:1", "timestamp", "1713100000", "embedding",
+       to_vector("\x3d\xcc\xcc\x3d\x00\x00\x80\x3f\xcd\xcc\x4c\x3e\x9a\x99\x19\x3f")});
+  Run({"HSET", "doc:2", "timestamp", "1713200000", "embedding",
+       to_vector("\x9a\x99\x19\x3f\xcd\xcc\x4c\x3e\x00\x00\x80\x3f\x3d\xcc\xcc\x3d")});
+  Run({"HSET", "doc:3", "timestamp", "1713300000", "embedding",
+       to_vector("\x00\x00\x80\x3f\x3d\xcc\xcc\x3d\xcd\xcc\x4c\x3e\x9a\x99\x19\x3f")});
+
+  Run({"FT.CREATE", "my_index", "ON", "HASH", "SCHEMA", "timestamp", "NUMERIC", "SORTABLE",
+       "embedding", "VECTOR", "FLAT", "6", "TYPE", "FLOAT32", "DIM", "4", "DISTANCE_METRIC",
+       "COSINE"});
+
+  auto search_vector =
+      to_vector("\x3d\xcc\xcc\x3d\x00\x00\x80\x3f\xcd\xcc\x4c\x3e\x9a\x99\x19\x3f");
+
+  auto resp = Run({"FT.SEARCH", "my_index", "*=>[KNN 2 @embedding $vec]", "PARAMS", "2", "vec",
+                   search_vector, "NOCONTENT"});
+  EXPECT_THAT(resp, IsArray(2, "doc:1", "doc:3"));
+
+  // FT.SEARCH with KNN + SORTBY
+  resp = Run({"FT.SEARCH", "my_index", "*=>[KNN 2 @embedding $vec]", "PARAMS", "2", "vec",
+              search_vector, "SORTBY", "timestamp", "DESC", "NOCONTENT"});
+  EXPECT_THAT(resp, IsArray(2, "doc:3", "doc:1"));
+}
+
 }  // namespace dfly


### PR DESCRIPTION
fixes dragonflydb#4939, dragonflydb#4934

Fixes two issues. They are good described in the tickets above.