### PR TITLE
fix(set_family): Transfer TTL flag from DenseLink object in delete

### DIFF
--- a/src/core/dense_set.cc
+++ b/src/core/dense_set.cc
@@ -648,6 +648,8 @@ void DenseSet::Delete(DensePtr* prev, DensePtr* ptr) {
 
       DenseLinkKey* plink = prev->AsLink();
       DensePtr tmp = DensePtr::From(plink);
+      // Transfer TTL flag
+      tmp.SetTtl(prev->HasTtl());
       DCHECK(ObjectAllocSize(tmp.GetObject()));
 
       FreeLink(plink);

--- a/src/core/string_set_test.cc
+++ b/src/core/string_set_test.cc
@@ -767,4 +767,16 @@ TEST_F(StringSetTest, ReallocIfNeeded) {
     EXPECT_EQ(*ss_->Find(build_str(i * 10)), build_str(i * 10));
 }
 
+TEST_F(StringSetTest, TransferTTLFlagLinkToObjectOnDelete) {
+  for (size_t i = 0; i < 10; i++) {
+    EXPECT_TRUE(ss_->Add(absl::StrCat(i), 1));
+  }
+  for (size_t i = 0; i < 9; i++) {
+    EXPECT_TRUE(ss_->Erase(absl::StrCat(i)));
+  }
+  auto it = ss_->Find("9"sv);
+  EXPECT_TRUE(it.HasExpiry());
+  EXPECT_EQ(1u, it.ExpiryTime());
+}
+
 }  // namespace dfly

--- a/src/server/set_family_test.cc
+++ b/src/server/set_family_test.cc
@@ -412,4 +412,17 @@ TEST_F(SetFamilyTest, SAddEx) {
   EXPECT_THAT(Run({"saddex", "key", "KEEPTTL", "2"}), ErrArg("wrong number of arguments"));
 }
 
+TEST_F(SetFamilyTest, CheckSetLinkExpiryTransfer) {
+  for (int i = 0; i < 10; i++) {
+    EXPECT_THAT(Run({"SADDEX", "key", "5", absl::StrCat(i)}), IntArg(1));
+  }
+  for (int i = 0; i < 9; i++) {
+    Run({"SREM", "key", absl::StrCat(i)});
+  }
+  EXPECT_THAT(Run({"SCARD", "key"}), IntArg(1));
+  AdvanceTime(6000);
+  Run({"SMEMBERS", "key"});
+  EXPECT_THAT(Run({"SCARD", "key"}), IntArg(0));
+}
+
 }  // namespace dfly


### PR DESCRIPTION
When extracting DensePtr from LinkObject we need to transfer TTL flag before this DensePtr is assigned.

Fixes #3915

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->