### PR TITLE
docs(readme): fix typo in README.ko-KR.md

### DIFF
--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -85,7 +85,7 @@ Dragonfly는 유휴 상태에서 Redis보다 메모리 효율이 30% 더 좋았�
 
 Dragonfly는 스냅샷 단계를 몇 초안에 더 빨리 마쳤습니다.
 
-Dragonfly의 메모리 효율에 대한 정보가 더 필요하시다면, 저희의 [Dastable 문서](/docs/dashtable.md)를 참고하시기 바랍니다.
+Dragonfly의 메모리 효율에 대한 정보가 더 필요하시다면, 저희의 [Dashtable 문서](/docs/dashtable.md)를 참고하시기 바랍니다.
 
 
 ## <a name="configuration"><a/>설정


### PR DESCRIPTION
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->

First, thank you for creating such an interesting and amazing data store.

While reading the Korean version of the README file, I found a small typo where 'dashtable' was written as 'dastable,' so I have fixed it.

Although it's just a small typo, I hope this change contributes to the project.

I would appreciate it if you could review it.
Thank you!