### PR TITLE
feat(server): Expose total host memory as part of info metrics

### DIFF
--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -118,6 +118,7 @@ atomic_uint64_t rss_mem_peak(0);
 
 unsigned kernel_version = 0;
 size_t max_memory_limit = 0;
+size_t total_host_memory = 0;
 Namespaces* namespaces = nullptr;
 
 size_t FetchRssMemory(io::StatusData sdata) {

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -135,6 +135,7 @@ extern std::atomic_uint64_t rss_mem_current;
 extern std::atomic_uint64_t rss_mem_peak;
 
 extern size_t max_memory_limit;
+extern size_t total_host_memory;
 
 size_t FetchRssMemory(io::StatusData sdata);
 

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -786,6 +786,7 @@ Usage: dragonfly [FLAGS]
     LOG(WARNING) << "SWAP is enabled. Consider disabling it when running Dragonfly.";
 
   dfly::max_memory_limit = dfly::GetMaxMemoryFlag();
+  dfly::total_host_memory = mem_info.mem_total;
 
   if (dfly::max_memory_limit == 0) {
     LOG(INFO) << "maxmemory has not been specified. Deciding myself....";

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2423,6 +2423,8 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
       }
     }
     append("table_used_memory", total.table_mem_usage);
+    append("total_system_memory", total_host_memory);
+    append("total_system_memory_human", HumanReadableNumBytes(total_host_memory));
     append("num_buckets", total.bucket_count);
     append("num_entries", total.key_count);
     append("inline_keys", total.inline_keys);


### PR DESCRIPTION
The total host memory is expected by some applications such as mastodon to determine if sidekiq is operational. This field is exposed as part of metrics.

Some context is in https://github.com/dragonflydb/dragonfly/issues/4596#issuecomment-2809469606
