### PR TITLE
chore: time sensitive throttle for scan command

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -646,7 +646,7 @@ void OpScan(const OpArgs& op_args, const ScanOpts& scan_opts, uint64_t* cursor, 
 
   const auto start = absl::Now();
   // Don't allow it to monopolize cpu time.
-  const absl::Duration timeout = absl::Milliseconds(200);
+  const absl::Duration timeout = absl::Milliseconds(10);
 
   do {
     cur = prime_table->Traverse(


### PR DESCRIPTION
The issue is that `Scan` has high latency (in seconds) when keys are large and there are no matches. Iterating 10k buckets and string matching each of the keys is potentially an expensive operation that depends on the keyspace and the number of actual matches. 

* replace heuristic in scan command to throttle based on time