### PR TITLE
feat: expose table capacities instead of number of buckets

### DIFF
--- a/src/core/dash.h
+++ b/src/core/dash.h
@@ -208,17 +208,19 @@ class DashTable : public detail::DashTableBase {
     return segment_.capacity() * sizeof(void*) + sizeof(SegmentType) * unique_segments_;
   }
 
+  // Returns the total number of buckets in the table, in contrast to capacity() which
+  // returns the total number of slots.
   size_t bucket_count() const {
     return unique_segments_ * SegmentType::kTotalBuckets;
   }
 
-  // Overall capacity of the table (including stash buckets).
+  // Overall capacity of the table (including stash buckets) in number of keys.
   size_t capacity() const {
     return unique_segments_ * SegmentType::capacity();
   }
 
   double load_factor() const {
-    return double(size()) / (SegmentType::capacity() * unique_segments());
+    return double(size()) / capacity();
   }
 
   // Gets a random cursor based on the available segments and buckets.

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -317,13 +317,14 @@ inline void TouchHllIfNeeded(string_view key, uint8_t* hll) {
 
 DbStats& DbStats::operator+=(const DbStats& o) {
   constexpr size_t kDbSz = sizeof(DbStats) - sizeof(DbTableStats);
-  static_assert(kDbSz == 32);
+  static_assert(kDbSz == 40);
 
   DbTableStats::operator+=(o);
 
   ADD(key_count);
   ADD(expire_count);
-  ADD(bucket_count);
+  ADD(prime_capacity);
+  ADD(expire_capacity);
   ADD(table_mem_usage);
 
   return *this;
@@ -403,7 +404,8 @@ auto DbSlice::GetStats() const -> Stats {
     DbStats& stats = s.db_stats[i];
     stats = db_wrap.stats;
     stats.key_count = db_wrap.prime.size();
-    stats.bucket_count = db_wrap.prime.bucket_count();
+    stats.prime_capacity = db_wrap.prime.capacity();
+    stats.expire_capacity = db_wrap.expire.capacity();
     stats.expire_count = db_wrap.expire.size();
     stats.table_mem_usage = db_wrap.table_memory();
   }

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -30,8 +30,11 @@ struct DbStats : public DbTableStats {
   // number of keys that have expiry deadline.
   size_t expire_count = 0;
 
-  // number of buckets in dictionary (key capacity)
-  size_t bucket_count = 0;
+  // total number of slots in prime dictionary (key capacity).
+  size_t prime_capacity = 0;
+
+  // total number of slots in prime dictionary (key capacity).
+  size_t expire_capacity = 0;
 
   // Memory used by dictionaries.
   size_t table_mem_usage = 0;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2514,7 +2514,7 @@ VarzValue::Map Service::GetVarzStats() {
 
   res.emplace_back("keys", VarzValue::FromInt(db_stats.key_count));
   res.emplace_back("obj_mem_usage", VarzValue::FromInt(db_stats.obj_memory_usage));
-  double load = double(db_stats.key_count) / (1 + db_stats.bucket_count);
+  double load = double(db_stats.key_count) / (1 + db_stats.prime_capacity);
   res.emplace_back("table_load_factor", VarzValue::FromDouble(load));
 
   return res;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1545,12 +1545,19 @@ void PrintPrometheusMetrics(uint64_t uptime, const Metrics& m, DflyCmd* dfly_cmd
   string db_key_expire_metrics;
 
   AppendMetricHeader("db_keys", "Total number of keys by DB", MetricType::GAUGE, &db_key_metrics);
+  AppendMetricHeader("db_capacity", "Table capacity by DB", MetricType::GAUGE, &db_key_metrics);
+
   AppendMetricHeader("db_keys_expiring", "Total number of expiring keys by DB", MetricType::GAUGE,
                      &db_key_expire_metrics);
 
   for (size_t i = 0; i < m.db_stats.size(); ++i) {
     AppendMetricValue("db_keys", m.db_stats[i].key_count, {"db"}, {StrCat("db", i)},
                       &db_key_metrics);
+    AppendMetricValue("db_capacity", m.db_stats[i].prime_capacity, {"db", "type"},
+                      {StrCat("db", i), "prime"}, &db_key_metrics);
+    AppendMetricValue("db_capacity", m.db_stats[i].expire_capacity, {"db", "type"},
+                      {StrCat("db", i), "expire"}, &db_key_metrics);
+
     AppendMetricValue("db_keys_expiring", m.db_stats[i].expire_count, {"db"}, {StrCat("db", i)},
                       &db_key_expire_metrics);
   }
@@ -2423,7 +2430,8 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
       }
     }
     append("table_used_memory", total.table_mem_usage);
-    append("num_buckets", total.bucket_count);
+    append("prime_capacity", total.prime_capacity);
+    append("expire_capacity", total.expire_capacity);
     append("num_entries", total.key_count);
     append("inline_keys", total.inline_keys);
     append("small_string_bytes", m.small_string_bytes);

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -131,10 +131,10 @@ async def test_replication_all(
 
     info = await c_master.info()
     preemptions = info["big_value_preemptions"]
-    total_buckets = info["num_buckets"]
+    key_capacity = info["prime_capacity"]
     compressed_blobs = info["compressed_blobs"]
     logging.debug(
-        f"Compressed blobs {compressed_blobs} .Buckets {total_buckets}. Preemptions {preemptions}"
+        f"Compressed blobs {compressed_blobs} .Capacity {key_capacity}. Preemptions {preemptions}"
     )
 
     assert preemptions >= seeder.huge_value_target * 0.5
@@ -143,11 +143,11 @@ async def test_replication_all(
     # per bucket.
     if seeder.data_size < 1000:
         # We care that we preempt less times than the total buckets such that we can be
-        # sure that we test both flows (with and without preemptions). Preemptions on 30%
+        # sure that we test both flows (with and without preemptions). Preemptions on 3%
         # of buckets seems like a big number but that depends on a few parameters like
         # the size of the hug value and the serialization max chunk size. For the test cases here,
-        # it's usually close to 10% but there are some that are close to 30.
-        assert preemptions <= (total_buckets * 0.3)
+        # it's usually close to 1% but there are some that are close to 3.
+        assert preemptions <= (key_capacity * 0.03)
 
 
 async def check_replica_finished_exec(c_replica: aioredis.Redis, m_offset):

--- a/tools/local/monitoring/grafana/provisioning/dashboards/dragonfly.json
+++ b/tools/local/monitoring/grafana/provisioning/dashboards/dragonfly.json
@@ -865,9 +865,8 @@
         "x": 12,
         "y": 15
       },
-      "id": 10,
+      "id": 25,
       "options": {
-        "alertThreshold": true,
         "legend": {
           "calcs": [],
           "displayMode": "list",
@@ -889,34 +888,18 @@
           "editorMode": "code",
           "exemplar": true,
           "expr":
-              "irate(dragonfly_net_input_bytes_total{namespace=\"$namespace\",pod=~\"$pod_name\"}[5m])",
+              "dragonfly_db_keys{namespace=\"$namespace\",pod=~\"$pod_name\"}/ on(namespace, pod, db) dragonfly_db_capacity{namespace=\"$namespace\",pod=~\"$pod_name\", type=\"prime\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "{{ pod }} input",
+          "legendFormat": "{{ db }} ",
           "range": true,
           "refId": "A",
-          "step": 240
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr":
-              "irate(dragonfly_net_output_bytes_total{namespace=\"$namespace\",pod=~\"$pod_name\"}[5m])",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "{{ pod }} output",
-          "range": true,
-          "refId": "B",
-          "step": 240
+          "step": 240,
+          "target": ""
         }
       ],
-      "title": "Network I/O",
+      "title": "Table Load per DB",
       "type": "timeseries"
     },
     {
@@ -1106,6 +1089,125 @@
         "x": 12,
         "y": 22
       },
+      "id": 10,
+      "options": {
+        "alertThreshold": true,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.1.10",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr":
+              "irate(dragonfly_net_input_bytes_total{namespace=\"$namespace\",pod=~\"$pod_name\"}[5m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{ pod }} input",
+          "range": true,
+          "refId": "A",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr":
+              "irate(dragonfly_net_output_bytes_total{namespace=\"$namespace\",pod=~\"$pod_name\"}[5m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{ pod }} output",
+          "range": true,
+          "refId": "B",
+          "step": 240
+        }
+      ],
+      "title": "Network I/O",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 29
+      },
       "id": 13,
       "options": {
         "alertThreshold": true,
@@ -1224,7 +1326,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 29
+        "y": 36
       },
       "id": 16,
       "options": {
@@ -1267,7 +1369,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 36
+        "y": 43
       },
       "id": 19,
       "panels": [],
@@ -1320,8 +1422,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1337,7 +1438,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 37
+        "y": 44
       },
       "id": 18,
       "options": {
@@ -1435,8 +1536,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1451,7 +1551,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 37
+        "y": 44
       },
       "id": 22,
       "options": {
@@ -1531,8 +1631,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1547,7 +1646,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 45
+        "y": 52
       },
       "id": 21,
       "options": {
@@ -1641,8 +1740,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1658,7 +1756,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 45
+        "y": 52
       },
       "id": 23,
       "options": {


### PR DESCRIPTION
Also, add a local dashboard demonstrating prime table load per db.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->