### PR TITLE
feat(pytest): Generate huge val string in seeder

### DIFF
--- a/tests/dragonfly/seeder_test.py
+++ b/tests/dragonfly/seeder_test.py
@@ -135,3 +135,45 @@ async def test_seeder_fake_redis(
     capture = await seeder.capture_fake_redis()
 
     assert await seeder.compare(capture, instance.port)
+
+
+@pytest.mark.asyncio
+@dfly_args({"proactor_threads": 2})
+async def test_seeder_huge_value(
+    df_factory: DflyInstanceFactory, df_seeder_factory: DflySeederFactory
+):
+    instance = df_factory.create()
+    df_factory.start_all([instance])
+
+    expected_huge_value_count = 10
+    seeder = df_seeder_factory.create(
+        keys=100,
+        port=instance.port,
+        huge_value_count=expected_huge_value_count,
+        huge_value_size=240_000,
+    )
+
+    def custom_command_generation_probability():
+        return [
+            0.0,
+            0.0,
+            100.0,
+        ]  # We will only execute GROW commands
+
+    # Provide custom function for command generation probability
+    seeder.gen.size_change_probs = custom_command_generation_probability
+
+    await seeder.run(target_ops=100)
+
+    client = instance.client()
+
+    keys = await client.execute_command("KEYS *")
+    huge_val_keys_count = 0
+
+    for key in keys:
+        key_size = await client.execute_command(f"MEMORY USAGE {key}")
+        # Count all keys that have memory - i.e. contain huge strings
+        if key_size != None and key_size > 100_000:
+            huge_val_keys_count += 1
+
+    assert huge_val_keys_count == expected_huge_value_count

--- a/tests/dragonfly/utility.py
+++ b/tests/dragonfly/utility.py
@@ -158,7 +158,7 @@ class CommandGenerator:
         self.unsupported_types = unsupported_types
 
         # Generate sorted list of random samples in target_keys range
-        self.huge_val_sample = sorted(random.sample(range(0, target_keys), huge_val_count))
+        self.huge_val_sample = sorted(random.sample(range(target_keys), huge_val_count))
         self.huge_val_size = huge_val_size
 
         # Key management
@@ -239,21 +239,21 @@ class CommandGenerator:
             # Random sequence k-letter elements for LPUSH
             list_size = self.val_size // 4
             element_size = (
-                self.huge_val_size / list_size if generate_huge_val else self.val_size / list_size
+                self.huge_val_size // list_size if generate_huge_val else self.val_size // list_size
             )
             return tuple(rand_str(element_size) for i in range(list_size))
         elif t == ValueType.SET:
             # Random sequence of k-letter elements for SADD
             set_size = self.val_size // 4
             element_size = (
-                self.huge_val_size / set_size if generate_huge_val else self.val_size / set_size
+                self.huge_val_size // set_size if generate_huge_val else self.val_size // set_size
             )
             return tuple(rand_str(element_size) for i in range(set_size))
         elif t == ValueType.HSET:
             # Random sequence of k-letter keys + int and two start values for HSET
             hset_size = self.val_size // 5
             element_size = (
-                self.huge_val_size / hset_size if generate_huge_val else self.val_size / hset_size
+                self.huge_val_size // hset_size if generate_huge_val else self.val_size // hset_size
             )
             elements = (
                 (
@@ -271,7 +271,7 @@ class CommandGenerator:
             probabilities = [8, 1]
             zset_size = random.choices(value_sizes, probabilities)[0]
             element_size = (
-                self.huge_val_size / zset_size if generate_huge_val else self.val_size / zset_size
+                self.huge_val_size // zset_size if generate_huge_val else self.val_size // zset_size
             )
             elements = (
                 (
@@ -288,7 +288,7 @@ class CommandGenerator:
             # - i (random integer)
             json_size = self.val_size // 6
             element_size = (
-                self.huge_val_size / json_size if generate_huge_val else self.val_size / json_size
+                self.huge_val_size // json_size if generate_huge_val else self.val_size // json_size
             )
             ints = [{"i": random.randint(0, 100)} for i in range(json_size)]
             strs = [rand_str(element_size) for i in range(json_size)]

--- a/tests/dragonfly/utility.py
+++ b/tests/dragonfly/utility.py
@@ -141,12 +141,25 @@ class ValueType(Enum):
 class CommandGenerator:
     """Class for generating complex command sequences"""
 
-    def __init__(self, target_keys, val_size, batch_size, max_multikey, unsupported_types=[]):
+    def __init__(
+        self,
+        target_keys,
+        val_size,
+        huge_val_count,
+        huge_val_size,
+        batch_size,
+        max_multikey,
+        unsupported_types=[],
+    ):
         self.key_cnt_target = target_keys
         self.val_size = val_size
         self.batch_size = min(batch_size, target_keys)
         self.max_multikey = max_multikey
         self.unsupported_types = unsupported_types
+
+        # Generate sorted list of random samples in target_keys range
+        self.huge_val_sample = sorted(random.sample(range(0, target_keys), huge_val_count))
+        self.huge_val_size = huge_val_size
 
         # Key management
         self.key_sets = [set() for _ in ValueType]
@@ -205,7 +218,7 @@ class CommandGenerator:
 
         return k, t
 
-    def generate_val(self, t: ValueType):
+    def generate_val(self, t: ValueType, generate_huge_val):
         """Generate filler value of configured size for type t"""
 
         def rand_str(k=3, s=""):
@@ -214,17 +227,33 @@ class CommandGenerator:
 
         if t == ValueType.STRING:
             # Random string for MSET
-            return (rand_str(self.val_size),)
+            return (rand_str(self.huge_val_size if generate_huge_val else self.val_size),)
         elif t == ValueType.LIST:
             # Random sequence k-letter elements for LPUSH
-            return tuple(rand_str() for _ in range(self.val_size // 4))
+            list_size = self.val_size // 4
+            huge_val_element = random.randint(0, list_size - 1) if generate_huge_val else -1
+            return tuple(
+                rand_str(self.huge_val_size if i == huge_val_element else 3)
+                for i in range(list_size)
+            )
         elif t == ValueType.SET:
             # Random sequence of k-letter elements for SADD
-            return tuple(rand_str() for _ in range(self.val_size // 4))
+            set_size = self.val_size // 4
+            huge_val_element = random.randint(0, set_size - 1) if generate_huge_val else -1
+            return tuple(
+                rand_str(self.huge_val_size if i == huge_val_element else 3)
+                for i in range(set_size)
+            )
         elif t == ValueType.HSET:
             # Random sequence of k-letter keys + int and two start values for HSET
+            hset_size = self.val_size // 5
+            huge_val_element = random.randint(0, hset_size - 1) if generate_huge_val else -1
             elements = (
-                (rand_str(), random.randint(0, self.val_size)) for _ in range(self.val_size // 5)
+                (
+                    rand_str(self.huge_val_size if i == huge_val_element else 3),
+                    random.randint(0, self.val_size),
+                )
+                for i in range(hset_size)
             )
             return ("v0", 0, "v1", 0) + tuple(itertools.chain(*elements))
         elif t == ValueType.ZSET:
@@ -234,16 +263,27 @@ class CommandGenerator:
             value_sizes = [self.val_size // 4, 130]
             probabilities = [8, 1]
             value_size = random.choices(value_sizes, probabilities)[0]
-            elements = ((random.randint(0, self.val_size), rand_str()) for _ in range(value_size))
+            huge_val_element = random.randint(0, value_size - 1) if generate_huge_val else -1
+            elements = (
+                (
+                    random.randint(0, self.val_size),
+                    rand_str(self.huge_val_size if i == huge_val_element else 3),
+                )
+                for i in range(value_size)
+            )
             return tuple(itertools.chain(*elements))
-
         elif t == ValueType.JSON:
             # Json object with keys:
             # - arr (array of random strings)
             # - ints (array of objects {i:random integer})
             # - i (random integer)
-            ints = [{"i": random.randint(0, 100)} for i in range(self.val_size // 6)]
-            strs = [rand_str() for _ in range(self.val_size // 6)]
+            json_size = self.val_size // 6
+            huge_val_element = random.randint(json_size - 1) if generate_huge_val else -1
+            ints = [{"i": random.randint(0, 100)} for i in range(json_size)]
+            strs = [
+                rand_str(self.huge_val_size if i == huge_val_element else 3)
+                for i in range(json_size)
+            ]
             return "$", json.dumps({"arr": strs, "ints": ints, "i": random.randint(0, 100)})
         else:
             assert False, "Invalid ValueType"
@@ -312,8 +352,17 @@ class CommandGenerator:
         else:
             count = 1
 
+        # If current key count matches huge val sample than we will create one element with huge val size.
+        generate_huge_val = False
+        if len(self.huge_val_sample) and self.huge_val_sample[0] == self.key_cnt:
+            generate_huge_val = True
+            # Remove this sample from list
+            self.huge_val_sample.pop(0)
+
         keys = (self.add_key(t) for _ in range(count))
-        payload = itertools.chain(*((f"k{k}",) + self.generate_val(t) for k in keys))
+        payload = itertools.chain(
+            *((f"k{k}",) + self.generate_val(t, generate_huge_val) for k in keys)
+        )
         filtered_payload = filter(lambda p: p is not None, payload)
 
         return (self.GROW_ACTINONS[t],) + tuple(filtered_payload), count
@@ -417,6 +466,8 @@ class DflySeeder:
         port=6379,
         keys=1000,
         val_size=50,
+        huge_value_count=5,
+        huge_value_size=100000,
         batch_size=100,
         max_multikey=5,
         dbcount=1,
@@ -434,7 +485,15 @@ class DflySeeder:
             unsupported_types.append(ValueType.JSON)  # Cluster aio client doesn't support JSON
 
         self.cluster_mode = cluster_mode
-        self.gen = CommandGenerator(keys, val_size, batch_size, max_multikey, unsupported_types)
+        self.gen = CommandGenerator(
+            keys,
+            val_size,
+            huge_value_count,
+            huge_value_size,
+            batch_size,
+            max_multikey,
+            unsupported_types,
+        )
         self.port = port
         self.dbcount = dbcount
         self.multi_transaction_probability = multi_transaction_probability

--- a/tests/dragonfly/utility.py
+++ b/tests/dragonfly/utility.py
@@ -218,8 +218,15 @@ class CommandGenerator:
 
         return k, t
 
-    def generate_val(self, t: ValueType, generate_huge_val):
+    def generate_val(self, t: ValueType, idx):
         """Generate filler value of configured size for type t"""
+
+        # If current key count matches huge val sample than we will create one element with huge val size.
+        generate_huge_val = False
+        if len(self.huge_val_sample) and self.huge_val_sample[0] == (self.key_cnt + idx):
+            generate_huge_val = True
+            # Remove this sample from list
+            self.huge_val_sample.pop(0)
 
         def rand_str(k=3, s=""):
             # Use small k value to reduce mem usage and increase number of ops
@@ -352,16 +359,9 @@ class CommandGenerator:
         else:
             count = 1
 
-        # If current key count matches huge val sample than we will create one element with huge val size.
-        generate_huge_val = False
-        if len(self.huge_val_sample) and self.huge_val_sample[0] == self.key_cnt:
-            generate_huge_val = True
-            # Remove this sample from list
-            self.huge_val_sample.pop(0)
-
         keys = (self.add_key(t) for _ in range(count))
         payload = itertools.chain(
-            *((f"k{k}",) + self.generate_val(t, generate_huge_val) for k in keys)
+            *((f"k{k}",) + self.generate_val(t, idx) for idx, k in enumerate(keys))
         )
         filtered_payload = filter(lambda p: p is not None, payload)
 

--- a/tests/dragonfly/utility.py
+++ b/tests/dragonfly/utility.py
@@ -238,26 +238,26 @@ class CommandGenerator:
         elif t == ValueType.LIST:
             # Random sequence k-letter elements for LPUSH
             list_size = self.val_size // 4
-            huge_val_element = random.randint(0, list_size - 1) if generate_huge_val else -1
-            return tuple(
-                rand_str(self.huge_val_size if i == huge_val_element else 3)
-                for i in range(list_size)
+            element_size = (
+                self.huge_val_size / list_size if generate_huge_val else self.val_size / list_size
             )
+            return tuple(rand_str(element_size) for i in range(list_size))
         elif t == ValueType.SET:
             # Random sequence of k-letter elements for SADD
             set_size = self.val_size // 4
-            huge_val_element = random.randint(0, set_size - 1) if generate_huge_val else -1
-            return tuple(
-                rand_str(self.huge_val_size if i == huge_val_element else 3)
-                for i in range(set_size)
+            element_size = (
+                self.huge_val_size / set_size if generate_huge_val else self.val_size / set_size
             )
+            return tuple(rand_str(element_size) for i in range(set_size))
         elif t == ValueType.HSET:
             # Random sequence of k-letter keys + int and two start values for HSET
             hset_size = self.val_size // 5
-            huge_val_element = random.randint(0, hset_size - 1) if generate_huge_val else -1
+            element_size = (
+                self.huge_val_size / hset_size if generate_huge_val else self.val_size / hset_size
+            )
             elements = (
                 (
-                    rand_str(self.huge_val_size if i == huge_val_element else 3),
+                    rand_str(element_size),
                     random.randint(0, self.val_size),
                 )
                 for i in range(hset_size)
@@ -269,14 +269,16 @@ class CommandGenerator:
             # This ensures that we test both the ZSET implementation with listpack and the our custom BPtree.
             value_sizes = [self.val_size // 4, 130]
             probabilities = [8, 1]
-            value_size = random.choices(value_sizes, probabilities)[0]
-            huge_val_element = random.randint(0, value_size - 1) if generate_huge_val else -1
+            zset_size = random.choices(value_sizes, probabilities)[0]
+            element_size = (
+                self.huge_val_size / zset_size if generate_huge_val else self.val_size / zset_size
+            )
             elements = (
                 (
                     random.randint(0, self.val_size),
-                    rand_str(self.huge_val_size if i == huge_val_element else 3),
+                    rand_str(element_size),
                 )
-                for i in range(value_size)
+                for i in range(zset_size)
             )
             return tuple(itertools.chain(*elements))
         elif t == ValueType.JSON:
@@ -285,12 +287,11 @@ class CommandGenerator:
             # - ints (array of objects {i:random integer})
             # - i (random integer)
             json_size = self.val_size // 6
-            huge_val_element = random.randint(json_size - 1) if generate_huge_val else -1
+            element_size = (
+                self.huge_val_size / json_size if generate_huge_val else self.val_size / json_size
+            )
             ints = [{"i": random.randint(0, 100)} for i in range(json_size)]
-            strs = [
-                rand_str(self.huge_val_size if i == huge_val_element else 3)
-                for i in range(json_size)
-            ]
+            strs = [rand_str(element_size) for i in range(json_size)]
             return "$", json.dumps({"arr": strs, "ints": ints, "i": random.randint(0, 100)})
         else:
             assert False, "Invalid ValueType"


### PR DESCRIPTION
Generate long string while generating commands. We will create number of
random samples when to use huge value. When key count matches sampled
number we will generate command with huge string value.

Closes #4430

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->