### PR TITLE
fix: FT.SEARCH KNN crash fixed

### DIFF
--- a/src/core/search/parser.y
+++ b/src/core/search/parser.y
@@ -99,7 +99,14 @@ final_query:
 
 knn_query:
   LBRACKET KNN UINT32 FIELD TERM opt_knn_alias opt_ef_runtime RBRACKET
-    { $$ = AstKnnNode(toUint32($3), $4, BytesToFtVector($5), $6, $7); }
+    {
+      auto vec_result = BytesToFtVectorSafe($5);
+      if (!vec_result) {
+        error(@5, "Invalid vector format");
+        YYERROR;
+      }
+      $$ = AstKnnNode(toUint32($3), $4, std::move(*vec_result), $6, $7);
+    }
 
 opt_knn_alias:
   AS TERM { $$ = std::move($2); }

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -844,6 +844,34 @@ TEST_F(SearchTest, MatchNonNullField) {
   }
 }
 
+TEST_F(SearchTest, InvalidVectorParameter) {
+  search::Schema schema;
+  schema.fields["v"] = search::SchemaField{
+      search::SchemaField::VECTOR,
+      0,   // flags
+      "v"  // short_name
+  };
+
+  search::SchemaField::VectorParams params;
+  params.use_hnsw = true;
+  params.dim = 2;
+  params.sim = search::VectorSimilarity::L2;
+  params.capacity = 10;
+  params.hnsw_m = 16;
+  params.hnsw_ef_construction = 200;
+  schema.fields["v"].special_params = params;
+
+  search::IndicesOptions options;
+  search::FieldIndices indices{schema, options, PMR_NS::get_default_resource(), nullptr};
+
+  search::SearchAlgorithm algo;
+  search::QueryParams query_params;
+
+  query_params["b"] = "abcdefg";
+
+  ASSERT_FALSE(algo.Init("*=>[KNN 2 @v $b]", &query_params));
+}
+
 }  // namespace search
 
 }  // namespace dfly


### PR DESCRIPTION
The example to reproduce the crash:
```
FT.CREATE idx SCHEMA s TEXT t TAG SORTABLE v VECTOR HNSW 12 TYPE FLOAT32 DIM 2 DISTANCE_METRIC L2 INITIAL_CAP 10 M 16 EF_CONSTRUCTION 200
```
```
FT.SEARCH idx "*=>[KNN 2 @v $b]" PARAMS 2 b abcdefg
```