### PR TITLE
fix(glob): Correctly match longer strings with '*' or '**' pattern

### DIFF
--- a/src/core/dfly_core_test.cc
+++ b/src/core/dfly_core_test.cc
@@ -155,6 +155,7 @@ TEST_F(StringMatchTest, Basic) {
 
   // Wildcards
   EXPECT_EQ(MatchLen("*", "hello", 0), 1);
+  EXPECT_EQ(MatchLen("*", "1234567890123456", 0), 1);
   EXPECT_EQ(MatchLen("h*", "hello", 0), 1);
   EXPECT_EQ(MatchLen("h*", "abc", 0), 0);
   EXPECT_EQ(MatchLen("h*o", "hello", 0), 1);

--- a/src/core/glob_matcher.cc
+++ b/src/core/glob_matcher.cc
@@ -236,7 +236,11 @@ GlobMatcher::GlobMatcher(string_view pattern, bool case_sensitive)
     regex.push_back('i');
   }
   regex.push_back(')');
-  regex.append(Glob2Regex(pattern));
+  if (pattern.empty()) {
+    regex.append(Glob2Regex("*"));
+  } else {
+    regex.append(Glob2Regex(pattern));
+  }
   matcher_.pattern(regex);
 #elif USE_PCRE2
   string regex("(?s");  // dotall mode


### PR DESCRIPTION
If string is longer than 16 chars we are using reflex library for matching. When used pattern is '*' or '**' we are 
removing trailing and leading star and have empty pattern as result. We should, in this edge case, set manually star regex.

Fixes #4948

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->