### PR TITLE
chore: split unit test steps in ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
           echo "disk space is:"
           df -h
 
-      - name: C++ Unit Tests
+      - name: C++ Unit Tests - IoUring
         run: |
           cd ${GITHUB_WORKSPACE}/build
           echo Run ctest -V -L DFLY
@@ -151,7 +151,14 @@ jobs:
           # Run allocation tracker test separately without alsologtostderr because it generates a TON of logs.
           FLAGS_fiber_safety_margin=4096 timeout 5m ./allocation_tracker_test
 
-          echo "Running tests with --force_epoll"
+          timeout 5m ./dragonfly_test
+          timeout 5m ./json_family_test --jsonpathv2=false
+          timeout 5m ./tiered_storage_test --vmodule=db_slice=2 --logtostderr
+
+
+      - name: C++ Unit Tests - Epoll
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
 
           # Create a rule that automatically prints stacktrace upon segfault
           cat > ./init.gdb <<EOF
@@ -166,17 +173,13 @@ jobs:
 
           FLAGS_fiber_safety_margin=4096 FLAGS_force_epoll=true timeout 5m ./allocation_tracker_test
 
-          echo "Finished running tests with --force_epoll"
-
-          echo "Running tests with --cluster_mode=emulated"
+      - name: C++ Unit Tests - IoUring with cluster mode
+        run: |
           FLAGS_fiber_safety_margin=4096 FLAGS_cluster_mode=emulated timeout 20m ctest -V -L DFLY
 
-          echo "Running tests with both --cluster_mode=emulated & --lock_on_hashtags"
+      - name: C++ Unit Tests - IoUring with cluster mode and FLAGS_lock_on_hashtags
+        run: |
           FLAGS_fiber_safety_margin=4096 FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true timeout 20m ctest -V -L DFLY
-
-          timeout 5m ./dragonfly_test
-          timeout 5m ./json_family_test --jsonpathv2=false
-          timeout 5m ./tiered_storage_test --vmodule=db_slice=2 --logtostderr
 
       - name: Upload unit logs on failure
         if: failure()


### PR DESCRIPTION
It will be easier to figure out which step failed. 

* split unit tests in different steps 