### PR TITLE
chore: get rid of possible recursion when unwinding structured reply

### DIFF
--- a/src/facade/reply_capture.cc
+++ b/src/facade/reply_capture.cc
@@ -81,24 +81,24 @@ void CapturingReplyBuilder::SendDirect(Payload&& val) {
   }
 }
 
-void CapturingReplyBuilder::Capture(Payload val) {
+void CapturingReplyBuilder::Capture(Payload val, bool collapse_if_needed) {
   if (!stack_.empty()) {
-    stack_.top().first->arr.push_back(std::move(val));
-    stack_.top().second--;
+    auto& last = stack_.top();
+    last.first->arr.push_back(std::move(val));
+    if (collapse_if_needed && last.second-- == 1) {
+      CollapseFilledCollections();
+    }
   } else {
     DCHECK_EQ(current_.index(), 0u);
     current_ = std::move(val);
   }
-
-  // Check if we filled up a collection.
-  CollapseFilledCollections();
 }
 
 void CapturingReplyBuilder::CollapseFilledCollections() {
   while (!stack_.empty() && stack_.top().second == 0) {
     auto pl = std::move(stack_.top());
     stack_.pop();
-    Capture(std::move(pl.first));
+    Capture(std::move(pl.first), false);
   }
 }
 

--- a/src/facade/reply_capture.h
+++ b/src/facade/reply_capture.h
@@ -79,7 +79,7 @@ class CapturingReplyBuilder : public RedisReplyBuilder {
   void SendDirect(Payload&& val);
 
   // Capture value and store eiter in current topmost collection or as a standalone value.
-  void Capture(Payload val);
+  void Capture(Payload val, bool collapse_if_needed = true);
 
   // While topmost collection in stack is full, finalize it and add it as a regular value.
   void CollapseFilledCollections();


### PR DESCRIPTION
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->