### PR TITLE
chore: polishing. put basic usage info to stdout using one call to a void messing lines

### DIFF
--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -669,14 +669,15 @@ void PrintBasicUsageInfo() {
 
   for (const auto& dir : google::GetLoggingDirectories()) {
     const string_view maybe_slash = absl::EndsWith(dir, "/") ? "" : "/";
-    output += std::string(dir) + std::string(maybe_slash) + "dragonfly.*\n";
+    absl::StrAppend(&output, dir, maybe_slash, "dragonfly.*\n");
   }
 
-  output +=
-      "* For the available flags type dragonfly [--help | --helpfull]\n"
-      "* Documentation can be found at: https://www.dragonflydb.io/docs\n";
+  absl::StrAppend(&output,
+                  "* For the available flags type dragonfly [--help | --helpfull]\n"
+                  "* Documentation can be found at: https://www.dragonflydb.io/docs\n");
 
   std::cout << output;
+  std::cout.flush();
 }
 
 void ParseFlagsFromEnv() {


### PR DESCRIPTION
Sometimes we can see the lines being messed with at the start. This change fixes that.

The example from Grafana log:
<img width="574" alt="Screenshot 2025-04-28 at 16 17 35" src="https://github.com/user-attachments/assets/18e5779e-c33e-4600-b24c-e317cb8dcc2e" />
