### PR TITLE
fix(stream_family): Fix stream memory tracking issues

### DIFF
--- a/src/server/family_utils.cc
+++ b/src/server/family_utils.cc
@@ -16,6 +16,21 @@ sds WrapSds(std::string_view s) {
   return tmp_sds = sdscpylen(tmp_sds, s.data(), s.length());
 }
 
+SdsWrapper::SdsWrapper(std::string_view str) {
+  sds_ = sdsempty();
+  sds_ = sdscpylen(sds_, str.data(), str.length());
+}
+
+SdsWrapper::~SdsWrapper() {
+  if (sds_) {
+    sdsfree(sds_);
+  }
+}
+
+SdsWrapper::operator sds() {
+  return sds_;
+}
+
 NonUniquePicksGenerator::NonUniquePicksGenerator(RandomPick max_range) : max_range_(max_range) {
   CHECK_GT(max_range, RandomPick(0));
 }

--- a/src/server/family_utils.h
+++ b/src/server/family_utils.h
@@ -43,6 +43,26 @@ static std::vector<long> ExpireElements(DenseSet* owner, const facade::CmdArgLis
 // Copy str to thread local sds instance. Valid until next WrapSds call on thread
 sds WrapSds(std::string_view str);
 
+// Clears sds on destruction
+// This is a wrapper around sds to avoid using sdsfree() directly
+class SdsWrapper {
+ public:
+  explicit SdsWrapper(std::string_view str);
+
+  SdsWrapper(const SdsWrapper&) = delete;
+  SdsWrapper(SdsWrapper&&) = delete;
+
+  SdsWrapper& operator=(SdsWrapper&&) = delete;
+  SdsWrapper& operator=(const SdsWrapper&) = delete;
+
+  ~SdsWrapper();
+
+  operator sds();
+
+ private:
+  sds sds_{nullptr};
+};
+
 using RandomPick = uint32_t;
 
 class PicksGenerator {


### PR DESCRIPTION
fixes #4961

Three bugs were found:
1. `WrapSds` can allocate memory and not free it after usage (due to the static variable). Because of this, we can account this allocation in the stream memory statistics. To fix it, I introduced `SdsWrapper`, an RAII wrapper for sds.
2. `OpRange` can allocate memory on the stream, which means it is a mutable command. And also we need to update memory statistics there
3. In `OpRange`, we didn't properly stop the `raxIterator` in all cases.

I suggest to completely remove `WrapSds` and use `SdsWrapper` instead.

The next steps would be to create wrappers for the redis stream code. And safely assert that:
1. Clean up the code
2. If the operation only reads -> const for the Wrapper (we can call only const methods) + assert that no allocation occurs
3. If the operation is mutable -> no const + assert that memory tracker is used / in other words, use memory tracker in wrapper and update memory usage in destructor
4. Add memory tests for the streams