### PR TITLE
fix: improved socket error logging for connection diagnostics

### DIFF
--- a/src/facade/CMakeLists.txt
+++ b/src/facade/CMakeLists.txt
@@ -3,7 +3,7 @@ cxx_link(dfly_parser_lib base strings_lib)
 
 add_library(dfly_facade conn_context.cc dragonfly_listener.cc dragonfly_connection.cc facade.cc
             memcache_parser.cc reply_builder.cc op_status.cc service_interface.cc
-            reply_capture.cc cmd_arg_parser.cc tls_helpers.cc)
+            reply_capture.cc cmd_arg_parser.cc tls_helpers.cc socket_utils.cc)
 
 if (DF_USE_SSL)
   set(TLS_LIB tls_lib)

--- a/src/facade/socket_utils.cc
+++ b/src/facade/socket_utils.cc
@@ -1,0 +1,65 @@
+// Copyright 2022, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "socket_utils.h"
+
+#ifdef __linux__
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "absl/strings/str_cat.h"
+#include "io/proc_reader.h"
+
+#endif
+
+namespace dfly {
+
+// Returns information about the TCP socket state by its descriptor
+std::string GetSocketInfo(int socket_fd) {
+  if (socket_fd < 0)
+    return "invalid socket";
+
+#ifdef __linux__
+  struct stat sock_stat;
+  if (fstat(socket_fd, &sock_stat) != 0) {
+    return "could not stat socket";
+  }
+
+  auto tcp_info = io::ReadTcpInfo(sock_stat.st_ino);
+  if (!tcp_info) {
+    auto tcp6_info = io::ReadTcp6Info(sock_stat.st_ino);
+    if (!tcp6_info) {
+      return "socket not found in /proc/net/tcp or /proc/net/tcp6";
+    }
+    tcp_info = std::move(tcp6_info);
+  }
+
+  std::string state_str = io::TcpStateToString(tcp_info->state);
+
+  if (tcp_info->is_ipv6) {
+    char local_ip[INET6_ADDRSTRLEN], remote_ip[INET6_ADDRSTRLEN];
+    inet_ntop(AF_INET6, &tcp_info->local_addr6, local_ip, sizeof(local_ip));
+    inet_ntop(AF_INET6, &tcp_info->remote_addr6, remote_ip, sizeof(remote_ip));
+    return absl::StrCat("State: ", state_str, ", Local: [", local_ip, "]:", tcp_info->local_port,
+                        ", Remote: [", remote_ip, "]:", tcp_info->remote_port,
+                        ", Inode: ", tcp_info->inode);
+  } else {
+    char local_ip[INET_ADDRSTRLEN], remote_ip[INET_ADDRSTRLEN];
+    struct in_addr addr;
+    addr.s_addr = htonl(tcp_info->local_addr);
+    inet_ntop(AF_INET, &addr, local_ip, sizeof(local_ip));
+    addr.s_addr = htonl(tcp_info->remote_addr);
+    inet_ntop(AF_INET, &addr, remote_ip, sizeof(remote_ip));
+    return absl::StrCat("State: ", state_str, ", Local: ", local_ip, ":", tcp_info->local_port,
+                        ", Remote: ", remote_ip, ":", tcp_info->remote_port,
+                        ", Inode: ", tcp_info->inode);
+  }
+#else
+  return "socket info not available on this platform";
+#endif
+}
+
+}  // namespace dfly

--- a/src/facade/socket_utils.h
+++ b/src/facade/socket_utils.h
@@ -1,0 +1,14 @@
+// Copyright 2022, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <string>
+
+namespace dfly {
+
+// Returns information about the TCP socket state by its descriptor
+std::string GetSocketInfo(int socket_fd);
+
+}  // namespace dfly

--- a/src/server/cluster/incoming_slot_migration.cc
+++ b/src/server/cluster/incoming_slot_migration.cc
@@ -10,6 +10,7 @@
 #include "base/flags.h"
 #include "base/logging.h"
 #include "cluster_utility.h"
+#include "facade/socket_utils.h"
 #include "server/error.h"
 #include "server/journal/executor.h"
 #include "server/journal/tx_executor.h"
@@ -67,6 +68,11 @@ class ClusterShardMigration {
 
       auto tx_data = tx_reader.NextTxData(&reader, cntx);
       if (!tx_data) {
+        if (cntx->GetError()) {
+          LOG(WARNING) << "Error reading from migration socket for shard " << source_shard_id_
+                       << ": " << cntx->GetError().Format()
+                       << ", socket state: " << GetSocketInfo(source->native_handle());
+        }
         break;
       }
 
@@ -105,7 +111,12 @@ class ClusterShardMigration {
     if (socket_ != nullptr) {
       return socket_->proactor()->Await([s = socket_]() {
         if (s->IsOpen()) {
-          return s->Shutdown(SHUT_RDWR);  // Does not Close(), only forbids further I/O.
+          auto ec = s->Shutdown(SHUT_RDWR);  // Does not Close(), only forbids further I/O.
+          if (ec) {
+            LOG(WARNING) << "Error shutting down socket for shard migration: " << ec.message()
+                         << ", socket state: " << GetSocketInfo(s->native_handle());
+          }
+          return ec;
         }
         return std::error_code();
       });

--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -12,6 +12,7 @@
 #include "base/logging.h"
 #include "cluster_family.h"
 #include "cluster_utility.h"
+#include "facade/socket_utils.h"
 #include "server/db_slice.h"
 #include "server/engine_shard_set.h"
 #include "server/error.h"
@@ -51,6 +52,9 @@ class OutgoingMigration::SliceSlotMigration : private ProtocolClient {
     VLOG(1) << "Connecting to source node_id " << node_id << " shard_id " << shard_id;
     auto timeout = absl::GetFlag(FLAGS_slot_migration_connection_timeout_ms) * 1ms;
     if (auto ec = ConnectAndAuth(timeout, &exec_st_); ec) {
+      LOG(WARNING) << "Couldn't connect to source node_id " << node_id << " shard_id " << shard_id
+                   << ": " << ec.message()
+                   << ", socket state: " + GetSocketInfo(Sock()->native_handle());
       exec_st_.ReportError(GenericError(ec, "Couldn't connect to source."));
       return;
     }
@@ -203,7 +207,10 @@ void OutgoingMigration::SyncFb() {
     VLOG(1) << "Connecting to target node";
     auto timeout = absl::GetFlag(FLAGS_slot_migration_connection_timeout_ms) * 1ms;
     if (auto ec = ConnectAndAuth(timeout, &exec_st_); ec) {
-      LOG(WARNING) << "Can't connect to target node";
+      std::string socket_info;
+      LOG(WARNING) << "Can't connect to target node " << server().Description()
+                   << " for migration: " << ec.message()
+                   << ", socket state: " + GetSocketInfo(Sock()->native_handle());
       exec_st_.ReportError(GenericError(ec, "Couldn't connect to source."));
       continue;
     }
@@ -216,7 +223,10 @@ void OutgoingMigration::SyncFb() {
     }
 
     if (auto ec = SendCommandAndReadResponse(cmd); ec) {
-      LOG(WARNING) << "Can't connect to target node";
+      std::string socket_info;
+      LOG(WARNING) << "Could not send INIT command to " << server().Description()
+                   << " for migration: " << ec.message()
+                   << ", socket state: " + GetSocketInfo(Sock()->native_handle());
       exec_st_.ReportError(GenericError(ec, "Could not send INIT command."));
       continue;
     }
@@ -296,8 +306,9 @@ bool OutgoingMigration::FinalizeMigration(long attempt) {
     }
     auto timeout = absl::GetFlag(FLAGS_slot_migration_connection_timeout_ms) * 1ms;
     if (auto ec = ConnectAndAuth(timeout, &exec_st_); ec) {
-      LOG(WARNING) << "Couldn't connect " << cf_->MyID() << " : " << migration_info_.node_info.id
-                   << " attempt " << attempt;
+      LOG(WARNING) << "Couldn't connect to " << cf_->MyID() << " : " << migration_info_.node_info.id
+                   << " attempt " << attempt << ": " << ec.message()
+                   << ", socket state: " + GetSocketInfo(Sock()->native_handle());
       return false;
     }
   }
@@ -334,7 +345,8 @@ bool OutgoingMigration::FinalizeMigration(long attempt) {
   VLOG(1) << "send " << cmd;
 
   if (auto err = SendCommand(cmd); err) {
-    LOG(WARNING) << "Error during sending DFLYMIGRATE ACK: " << err.message();
+    LOG(WARNING) << "Error during sending DFLYMIGRATE ACK to " << server().Description() << ": "
+                 << err.message() << ", socket state: " + GetSocketInfo(Sock()->native_handle());
     return false;
   }
 
@@ -351,7 +363,9 @@ bool OutgoingMigration::FinalizeMigration(long attempt) {
     }
 
     if (auto resp = ReadRespReply(absl::ToInt64Milliseconds(passed - timeout)); !resp) {
-      LOG(WARNING) << resp.error();
+      LOG(WARNING) << "Error reading response to ACK command from " << server().Description()
+                   << ": " << resp.error()
+                   << ", socket state: " + GetSocketInfo(Sock()->native_handle());
       return false;
     }
 
@@ -382,6 +396,8 @@ bool OutgoingMigration::FinalizeMigration(long attempt) {
 void OutgoingMigration::Start() {
   VLOG(1) << "Resolving host DNS for outgoing migration";
   if (error_code ec = ResolveHostDns(); ec) {
+    LOG(WARNING) << "Could not resolve host DNS for outgoing migration to "
+                 << server().Description() << ": " << ec.message();
     exec_st_.ReportError(GenericError(ec, "Could not resolve host dns."));
     return;
   }

--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -207,7 +207,6 @@ void OutgoingMigration::SyncFb() {
     VLOG(1) << "Connecting to target node";
     auto timeout = absl::GetFlag(FLAGS_slot_migration_connection_timeout_ms) * 1ms;
     if (auto ec = ConnectAndAuth(timeout, &exec_st_); ec) {
-      std::string socket_info;
       LOG(WARNING) << "Can't connect to target node " << server().Description()
                    << " for migration: " << ec.message()
                    << ", socket state: " + GetSocketInfo(Sock()->native_handle());
@@ -223,7 +222,6 @@ void OutgoingMigration::SyncFb() {
     }
 
     if (auto ec = SendCommandAndReadResponse(cmd); ec) {
-      std::string socket_info;
       LOG(WARNING) << "Could not send INIT command to " << server().Description()
                    << " for migration: " << ec.message()
                    << ", socket state: " + GetSocketInfo(Sock()->native_handle());

--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -363,7 +363,16 @@ GenericError ExecutionState::GetError() const {
 }
 
 void ExecutionState::ReportCancelError() {
-  ReportError(std::make_error_code(errc::operation_canceled), "ExecutionState cancelled");
+  std::string cancel_reason = "ExecutionState cancelled";
+
+  // Add additional information about the reason for cancellation, if possible
+  // Possible to extract from system errors or context
+  std::error_code sys_err = std::error_code(errno, std::system_category());
+  if (sys_err && sys_err != std::errc::operation_canceled) {
+    absl::StrAppend(&cancel_reason, " due to system error: ", sys_err.message());
+  }
+
+  ReportError(std::make_error_code(errc::operation_canceled), cancel_reason);
 }
 
 void ExecutionState::Reset(ErrHandler handler) {

--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -363,16 +363,7 @@ GenericError ExecutionState::GetError() const {
 }
 
 void ExecutionState::ReportCancelError() {
-  std::string cancel_reason = "ExecutionState cancelled";
-
-  // Add additional information about the reason for cancellation, if possible
-  // Possible to extract from system errors or context
-  std::error_code sys_err = std::error_code(errno, std::system_category());
-  if (sys_err && sys_err != std::errc::operation_canceled) {
-    absl::StrAppend(&cancel_reason, " due to system error: ", sys_err.message());
-  }
-
-  ReportError(std::make_error_code(errc::operation_canceled), cancel_reason);
+  ReportError(std::make_error_code(errc::operation_canceled), "ExecutionState cancelled");
 }
 
 void ExecutionState::Reset(ErrHandler handler) {

--- a/src/server/protocol_client.cc
+++ b/src/server/protocol_client.cc
@@ -22,6 +22,7 @@ extern "C" {
 #include "base/logging.h"
 #include "facade/dragonfly_connection.h"
 #include "facade/redis_parser.h"
+#include "facade/socket_utils.h"
 #include "server/error.h"
 #include "server/journal/executor.h"
 #include "server/journal/serializer.h"
@@ -234,6 +235,8 @@ void ProtocolClient::CloseSocket() {
 }
 
 void ProtocolClient::DefaultErrorHandler(const GenericError& err) {
+  LOG(WARNING) << "Socket error: " << err.Format() << " in " << server_context_.Description()
+               << ", socket info: " << GetSocketInfo(sock_->native_handle());
   CloseSocket();
 }
 

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -648,7 +648,6 @@ error_code Replica::ConsumeRedisStream() {
   while (true) {
     auto response = ReadRespReply(&io_buf, /*copy_msg=*/false);
     if (!response.has_value()) {
-      VLOG(1) << "ConsumeRedisStream finished";
       LOG(ERROR) << "Error in Redis Stream at phase " << GetCurrentPhase() << " with "
                  << server().Description() << ", error: " << response.error()
                  << ", socket state: " + GetSocketInfo(Sock()->native_handle());

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -690,7 +690,7 @@ error_code Replica::ConsumeDflyStream() {
     // Make sure the flows are not in a state transition
     lock_guard lk{flows_op_mu_};
 
-    LOG(ERROR) << "DflyStream error in phase " << GetCurrentPhase() << " with "
+    LOG(ERROR) << "Replication error in phase " << GetCurrentPhase() << " with "
                << server().Description() << ", error: " << ge.Format()
                << ", socket state: " + GetSocketInfo(Sock()->native_handle());
 

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -1190,17 +1190,15 @@ std::string Replica::GetSyncId() const {
 }
 
 std::string Replica::GetCurrentPhase() const {
-  uint32_t state = state_mask_.load();
-
-  if (!(state & R_ENABLED))
+  if (!(state_mask_ & R_ENABLED))
     return "DISABLED";
-  if (!(state & R_TCP_CONNECTED))
+  if (!(state_mask_ & R_TCP_CONNECTED))
     return "TCP_CONNECTING";
-  if (!(state & R_GREETED))
+  if (!(state_mask_ & R_GREETED))
     return "GREETING";
-  if (!(state & R_SYNC_OK))
+  if (!(state_mask_ & R_SYNC_OK))
     return "INITIAL_SYNC";
-  if (state & R_SYNCING)
+  if (state_mask_ & R_SYNCING)
     return "FULL_SYNC_IN_PROGRESS";
 
   return "STABLE_SYNC";

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -140,6 +140,9 @@ class Replica : ProtocolClient {
   std::vector<uint64_t> GetReplicaOffset() const;
   std::string GetSyncId() const;
 
+  // Get the current replication phase based on state_mask_
+  std::string GetCurrentPhase() const;
+
  private:
   util::fb2::ProactorBase* proactor_ = nullptr;
   Service& service_;


### PR DESCRIPTION
Fixes: https://github.com/dragonflydb/dragonfly/issues/5041

This implementation enhances error diagnostics when replica connections fail by implementing a utility function that extracts and formats detailed TCP socket information from /proc/net/tcp and /proc/net/tcp6 on Linux systems.
The function converts raw socket data into a human-readable format with proper TCP state names and formatted IP addresses. It's integrated with Replica, Connection, and Migration components to provide better context during connection failures.