### PR TITLE
chore: dash table clean ups

### DIFF
--- a/src/core/dash.h
+++ b/src/core/dash.h
@@ -16,7 +16,7 @@ namespace dfly {
 // After all, we added additional improvements we added as part of the dragonfly project,
 // that probably justify a right to choose our own name for this data structure.
 struct BasicDashPolicy {
-  enum { kSlotNum = 12, kBucketNum = 64, kStashBucketNum = 2 };
+  enum { kSlotNum = 12, kBucketNum = 64 };
   static constexpr bool kUseVersion = false;
 
   template <typename U> static void DestroyValue(const U&) {
@@ -62,11 +62,11 @@ class DashTable : public detail::DashTableBase {
 
   struct HotspotBuckets {
     static constexpr size_t kRegularBuckets = 4;
-    static constexpr size_t kNumBuckets = kRegularBuckets + Policy::kStashBucketNum;
+    static constexpr size_t kNumBuckets = kRegularBuckets + SegmentType::kStashBucketNum;
 
     struct ByType {
       bucket_iterator regular_buckets[kRegularBuckets];
-      bucket_iterator stash_buckets[Policy::kStashBucketNum];
+      bucket_iterator stash_buckets[SegmentType::kStashBucketNum];
     };
 
     union Probes {
@@ -822,7 +822,7 @@ auto DashTable<_Key, _Value, Policy>::InsertInternal(U&& key, V&& value, Evictio
         hotspot.probes.by_type.regular_buckets[j] = bucket_iterator{this, target_seg_id, bid[j]};
       }
 
-      for (unsigned i = 0; i < Policy::kStashBucketNum; ++i) {
+      for (unsigned i = 0; i < SegmentType::kStashBucketNum; ++i) {
         hotspot.probes.by_type.stash_buckets[i] =
             bucket_iterator{this, target_seg_id, uint8_t(Policy::kBucketNum + i), 0};
       }

--- a/src/core/dash_test.cc
+++ b/src/core/dash_test.cc
@@ -240,8 +240,8 @@ TEST_F(DashTest, Segment) {
   for (size_t i = 2; i < Segment::kBucketNum; ++i) {
     EXPECT_EQ(0, segment_.GetBucket(i).Size());
   }
-  EXPECT_EQ(4 * Segment::kSlotNum, keys.size());
-  EXPECT_EQ(4 * Segment::kSlotNum, segment_.SlowSize());
+  EXPECT_EQ(6 * Segment::kSlotNum, keys.size());
+  EXPECT_EQ(6 * Segment::kSlotNum, segment_.SlowSize());
 
   auto hfun = &UInt64Policy::HashFn;
   unsigned has_called = 0;
@@ -268,7 +268,7 @@ TEST_F(DashTest, Segment) {
     ASSERT_TRUE(it.found());
     segment_.Delete(it, hash);
   }
-  EXPECT_EQ(2 * Segment::kSlotNum, segment_.SlowSize());
+  EXPECT_EQ(4 * Segment::kSlotNum, segment_.SlowSize());
   ASSERT_FALSE(Contains(arr.front()));
 }
 
@@ -331,7 +331,7 @@ TEST_F(DashTest, Split) {
   ASSERT_EQ(segment_.SlowSize(), sum[0]);
   EXPECT_EQ(s2.SlowSize(), sum[1]);
   EXPECT_EQ(keys.size(), sum[0] + sum[1]);
-  EXPECT_EQ(4 * Segment::kSlotNum, keys.size());
+  EXPECT_EQ(6 * Segment::kSlotNum, keys.size());
 }
 
 TEST_F(DashTest, Merge) {
@@ -456,12 +456,12 @@ struct Item {
 
 constexpr size_t ItemAlign = alignof(Item);
 
-struct MyBucket : public detail::BucketBase<16, 4> {
+struct MyBucket : public detail::BucketBase<16> {
   Item key[14];
 };
 
 constexpr size_t kMySz = sizeof(MyBucket);
-constexpr size_t kBBSz = sizeof(detail::BucketBase<16, 4>);
+constexpr size_t kBBSz = sizeof(detail::BucketBase<16>);
 
 TEST_F(DashTest, Custom) {
   using ItemSegment = detail::Segment<Item, uint64_t>;
@@ -659,7 +659,7 @@ struct TestEvictionPolicy {
 };
 
 TEST_F(DashTest, Eviction) {
-  TestEvictionPolicy ev(1500);
+  TestEvictionPolicy ev(1540);
 
   size_t num = 0;
   auto loop = [&] {

--- a/src/server/detail/table.h
+++ b/src/server/detail/table.h
@@ -16,7 +16,7 @@ using PrimeKey = CompactObj;
 using PrimeValue = CompactObj;
 
 struct PrimeTablePolicy {
-  enum { kSlotNum = 14, kBucketNum = 56, kStashBucketNum = 4 };
+  enum { kSlotNum = 14, kBucketNum = 56 };
 
   static constexpr bool kUseVersion = true;
 
@@ -46,7 +46,7 @@ struct PrimeTablePolicy {
 };
 
 struct ExpireTablePolicy {
-  enum { kSlotNum = 14, kBucketNum = 56, kStashBucketNum = 4 };
+  enum { kSlotNum = 14, kBucketNum = 56 };
   static constexpr bool kUseVersion = false;
 
   static uint64_t HashFn(const PrimeKey& s) {


### PR DESCRIPTION
Remove stash template parameter because we only use dashtable with a single configuration of STASH_CNT=4.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->