### PR TITLE
chore: further extend the compression analysis

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -1524,13 +1524,13 @@ std::string_view ObjTypeToString(CompactObjType type) {
   return "Invalid type"sv;
 }
 
-std::optional<CompactObjType> ObjTypeFromString(std::string_view sv) {
+CompactObjType ObjTypeFromString(std::string_view sv) {
   for (auto& p : kObjTypeToString) {
     if (absl::EqualsIgnoreCase(sv, p.second)) {
       return p.first;
     }
   }
-  return std::nullopt;
+  return kInvalidCompactObjType;
 }
 
 }  // namespace dfly

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -543,7 +543,8 @@ inline bool CompactObj::operator==(std::string_view sv) const {
 
 std::string_view ObjTypeToString(CompactObjType type);
 
-std::optional<CompactObjType> ObjTypeFromString(std::string_view sv);
+// Returns kInvalidCompactObjType if sv is not a valid type.
+CompactObjType ObjTypeFromString(std::string_view sv);
 
 namespace detail {
 

--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -299,8 +299,8 @@ OpResult<ScanOpts> ScanOpts::TryFrom(CmdArgList args) {
       if (pattern != "*")
         scan_opts.matcher.reset(new GlobMatcher{pattern, true});
     } else if (opt == "TYPE") {
-      auto obj_type = ObjTypeFromString(ArgS(args, i + 1));
-      if (!obj_type) {
+      CompactObjType obj_type = ObjTypeFromString(ArgS(args, i + 1));
+      if (obj_type == kInvalidCompactObjType) {
         return facade::OpStatus::SYNTAX_ERR;
       }
       scan_opts.type_filter = obj_type;


### PR DESCRIPTION
Allow export/import of huffman tables via
`DEBUG COMPRESSION EXPORT` or `DEBUG COMPRESSION IMPORT <bintable>`

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->