### PR TITLE
chore: skip test_bug_in_json_memory_tracking

### DIFF
--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2959,6 +2959,7 @@ async def test_preempt_in_atomic_section_of_heartbeat(df_factory: DflyInstanceFa
     await fill_task
 
 
+@pytest.mark.skip("Flaky test")
 async def test_bug_in_json_memory_tracking(df_factory: DflyInstanceFactory):
     """
     This test reproduces a bug in the JSON memory tracking.


### PR DESCRIPTION
Test fails regularly and is a blocker when we try to merge a PR. Skip it for now. 

https://github.com/dragonflydb/dragonfly/issues/5059 