### PR TITLE
fix(json_family): Fix memory tracking for the JSON.SET command. THIRD PR

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -118,6 +118,7 @@ cxx_test(zset_family_test dfly_test_lib LABELS DFLY)
 cxx_test(geo_family_test dfly_test_lib LABELS DFLY)
 cxx_test(blocking_controller_test dfly_test_lib LABELS DFLY)
 cxx_test(json_family_test dfly_test_lib LABELS DFLY)
+cxx_test(json_family_memory_test dfly_test_lib LABELS DFLY)
 cxx_test(journal/journal_test dfly_test_lib LABELS DFLY)
 cxx_test(hll_family_test dfly_test_lib LABELS DFLY)
 cxx_test(bloom_family_test dfly_test_lib LABELS DFLY)
@@ -131,6 +132,7 @@ if (WITH_ASAN OR WITH_USAN)
   target_compile_definitions(multi_test PRIVATE SANITIZERS)
   target_compile_definitions(search_family_test PRIVATE SANITIZERS)
   target_compile_definitions(json_family_test PRIVATE SANITIZERS)
+  target_compile_definitions(json_family_memory_test PRIVATE SANITIZERS)
   target_compile_definitions(dragonfly_test PRIVATE SANITIZERS)
 endif()
 cxx_test(search/aggregator_test dfly_test_lib LABELS DFLY)
@@ -142,4 +144,5 @@ add_dependencies(check_dfly dragonfly_test json_family_test list_family_test
                  generic_family_test memcache_parser_test rdb_test journal_test
                  redis_parser_test stream_family_test string_family_test
                  bitops_family_test set_family_test zset_family_test geo_family_test
-                 hll_family_test cluster_config_test cluster_family_test acl_family_test)
+                 hll_family_test cluster_config_test cluster_family_test acl_family_test
+                 json_family_memory_test)

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -409,7 +409,7 @@ std::optional<std::string> ConvertJsonPathToJsonPointer(string_view json_path) {
   for (const auto& node : path) {
     const auto& type = node.type();
     if (type == json::SegmentType::IDENTIFIER) {
-      pointer += '/' + node.identifier();
+      absl::StrAppend(&pointer, "/"sv, node.identifier());
     } else if (type == json::SegmentType::INDEX) {
       const auto& index = node.index();
 
@@ -419,7 +419,7 @@ std::optional<std::string> ConvertJsonPathToJsonPointer(string_view json_path) {
         return std::nullopt;
       }
 
-      pointer += '/' + std::to_string(node.index().first);
+      absl::StrAppend(&pointer, "/"sv, node.index().first);
     } else {
       VLOG(2) << "Error during conversion of JSONPath to JSONPointer: " << json_path
               << ". Unsupported segment type.";

--- a/src/server/json_family_memory_test.cc
+++ b/src/server/json_family_memory_test.cc
@@ -1,0 +1,108 @@
+// Copyright 2025, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "base/gtest.h"
+#include "base/logging.h"
+#include "facade/facade_test.h"
+#include "server/command_registry.h"
+#include "server/json_family.h"
+#include "server/test_utils.h"
+
+using namespace testing;
+using namespace std;
+using namespace util;
+
+ABSL_DECLARE_FLAG(bool, jsonpathv2);
+
+namespace dfly {
+
+class JsonFamilyMemoryTest : public BaseFamilyTest {
+ public:
+  static dfly::MiMemoryResource* GetMemoryResource() {
+    static thread_local mi_heap_t* heap = mi_heap_new();
+    static thread_local dfly::MiMemoryResource memory_resource{heap};
+    return &memory_resource;
+  }
+
+ protected:
+  auto GetJsonMemoryUsageFromDb(std::string_view key) {
+    return Run({"MEMORY", "USAGE", key, "WITHOUTKEY"});
+  }
+};
+
+size_t GetMemoryUsage() {
+  return static_cast<MiMemoryResource*>(JsonFamilyMemoryTest::GetMemoryResource())->used();
+}
+
+size_t GetJsonMemoryUsageFromString(std::string_view json_str) {
+  size_t start = GetMemoryUsage();
+  auto json = dfly::JsonFromString(json_str, JsonFamilyMemoryTest::GetMemoryResource());
+  if (!json) {
+    return 0;
+  }
+
+  // The same behaviour as in CompactObj
+  void* ptr =
+      JsonFamilyMemoryTest::GetMemoryResource()->allocate(sizeof(JsonType), alignof(JsonType));
+  JsonType* json_on_heap = new (ptr) JsonType(std::move(json).value());
+  DCHECK(json_on_heap);
+
+  size_t result = GetMemoryUsage() - start;
+
+  // Free the memory
+  json_on_heap->~JsonType();
+  JsonFamilyMemoryTest::GetMemoryResource()->deallocate(json_on_heap, sizeof(JsonType),
+                                                        alignof(JsonType));
+  return result;
+}
+
+TEST_F(JsonFamilyMemoryTest, SimpleSet) {
+  std::string_view big_json = R"({"a":"some big string asdkasdkasdfkkasjdkfjka"})";
+  size_t start_size = GetJsonMemoryUsageFromString(big_json);
+
+  auto resp = Run({"JSON.SET", "j1", "$", big_json});
+  EXPECT_EQ(resp, "OK");
+  resp = GetJsonMemoryUsageFromDb("j1");
+  EXPECT_THAT(resp, IntArg(start_size));
+
+  std::string_view small_json = R"({"a":" "})";
+  size_t next_size = GetJsonMemoryUsageFromString(small_json);
+
+  resp = Run({"JSON.SET", "j1", "$", small_json});
+  EXPECT_EQ(resp, "OK");
+  resp = GetJsonMemoryUsageFromDb("j1");
+  EXPECT_THAT(resp, IntArg(next_size));
+
+  // Again set big json
+  resp = Run({"JSON.SET", "j1", "$", big_json});
+  EXPECT_EQ(resp, "OK");
+  resp = GetJsonMemoryUsageFromDb("j1");
+  EXPECT_THAT(resp, IntArg(start_size));
+}
+
+TEST_F(JsonFamilyMemoryTest, PartialSet) {
+  std::string_view start_json = R"({"a":"some text", "b":" "})";
+  size_t start_size = GetJsonMemoryUsageFromString(start_json);
+
+  auto resp = Run({"JSON.SET", "j1", "$", start_json});
+  EXPECT_EQ(resp, "OK");
+  resp = GetJsonMemoryUsageFromDb("j1");
+  EXPECT_THAT(resp, IntArg(start_size));
+
+  std::string_view json_after_set = R"({"a":"some text", "b":"some another text"})";
+  size_t size_after_set = GetJsonMemoryUsageFromString(json_after_set);
+
+  resp = Run({"JSON.SET", "j1", "$.b", "\"some another text\""});
+  EXPECT_EQ(resp, "OK");
+  resp = GetJsonMemoryUsageFromDb("j1");
+  EXPECT_THAT(resp, IntArg(size_after_set));
+
+  // Again set start json
+  resp = Run({"JSON.SET", "j1", "$.b", "\" \""});
+  EXPECT_EQ(resp, "OK");
+  resp = GetJsonMemoryUsageFromDb("j1");
+  EXPECT_THAT(resp, IntArg(start_size));
+}
+
+}  // namespace dfly

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -2753,4 +2753,18 @@ TEST_F(SearchFamilyTest, RenameDocumentBetweenIndices) {
   EXPECT_EQ(Run({"rename", "idx2:{doc}1", "idx1:{doc}1"}), "OK");
 }
 
+TEST_F(SearchFamilyTest, JsonSetIndexesBug) {
+  auto resp = Run({"JSON.SET", "j1", "$", R"({"text":"some text"})"});
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run(
+      {"FT.CREATE", "index", "ON", "json", "SCHEMA", "$.text", "AS", "text", "TEXT", "SORTABLE"});
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run({"JSON.SET", "j1", "$", R"({"asd}"})"});
+  EXPECT_THAT(resp, ErrArg("ERR failed to parse JSON"));
+
+  resp = Run({"FT.AGGREGATE", "index", "*", "GROUPBY", "1", "@text"});
+  EXPECT_THAT(resp, IsUnordArrayWithSize(IsMap("text", "some text")));
+}
 }  // namespace dfly


### PR DESCRIPTION
fixes memory tracking issues for the JSON.SET command and #5054.
Also, partially fixes #4926

Bugs that were found and fixed:
1. We didn't reset the result of `ShardJsonFromString`, which parses the json_str into the jsoncons's json and returns optional of this. The bug was that `std::optional` still holds the value even after `std::move`. So we overestimate the memory usage.
2. Bug in memory tracker when we overestimate the memory usage because of this:
```cpp
if (is_op_set) {
      diff += static_cast<int64_t>(mi_usable_size(pv.GetJson()));
}
```
3. Bug in partial `JSON.SET` when we called `ShardJsonFromString` before starting the memory tracking
4. Bug in indexes for the `JSON.SET` command: #5054

To fix this, I introduced `json_family_memory_test` and `JsonAutoUpdater`.
It ensures that `RemoveDoc` is called before memory tracking starts, and that `AddDoc` is called after `SetJsonSize` and also it will be called even if an error occurs.
Therefore, whenever we perform an update operation on a JSON value, this class must be used.