### PR TITLE
fix(json_family): Fix memory tracking for JSON mutate operations. FOURTH PR

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -118,6 +118,7 @@ cxx_test(zset_family_test dfly_test_lib LABELS DFLY)
 cxx_test(geo_family_test dfly_test_lib LABELS DFLY)
 cxx_test(blocking_controller_test dfly_test_lib LABELS DFLY)
 cxx_test(json_family_test dfly_test_lib LABELS DFLY)
+cxx_test(json_family_memory_test dfly_test_lib LABELS DFLY)
 cxx_test(journal/journal_test dfly_test_lib LABELS DFLY)
 cxx_test(hll_family_test dfly_test_lib LABELS DFLY)
 cxx_test(bloom_family_test dfly_test_lib LABELS DFLY)
@@ -131,6 +132,7 @@ if (WITH_ASAN OR WITH_USAN)
   target_compile_definitions(multi_test PRIVATE SANITIZERS)
   target_compile_definitions(search_family_test PRIVATE SANITIZERS)
   target_compile_definitions(json_family_test PRIVATE SANITIZERS)
+  target_compile_definitions(json_family_memory_test PRIVATE SANITIZERS)
   target_compile_definitions(dragonfly_test PRIVATE SANITIZERS)
 endif()
 cxx_test(search/aggregator_test dfly_test_lib LABELS DFLY)
@@ -142,4 +144,5 @@ add_dependencies(check_dfly dragonfly_test json_family_test list_family_test
                  generic_family_test memcache_parser_test rdb_test journal_test
                  redis_parser_test stream_family_test string_family_test
                  bitops_family_test set_family_test zset_family_test geo_family_test
-                 hll_family_test cluster_config_test cluster_family_test acl_family_test)
+                 hll_family_test cluster_config_test cluster_family_test acl_family_test
+                 json_family_memory_test)

--- a/src/server/json_family_memory_test.cc
+++ b/src/server/json_family_memory_test.cc
@@ -1,0 +1,108 @@
+// Copyright 2025, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "base/gtest.h"
+#include "base/logging.h"
+#include "facade/facade_test.h"
+#include "server/command_registry.h"
+#include "server/json_family.h"
+#include "server/test_utils.h"
+
+using namespace testing;
+using namespace std;
+using namespace util;
+
+ABSL_DECLARE_FLAG(bool, jsonpathv2);
+
+namespace dfly {
+
+class JsonFamilyMemoryTest : public BaseFamilyTest {
+ public:
+  static dfly::MiMemoryResource* GetMemoryResource() {
+    static thread_local mi_heap_t* heap = mi_heap_new();
+    static thread_local dfly::MiMemoryResource memory_resource{heap};
+    return &memory_resource;
+  }
+
+ protected:
+  auto GetJsonMemoryUsageFromDb(std::string_view key) {
+    return Run({"MEMORY", "USAGE", key, "WITHOUTKEY"});
+  }
+};
+
+size_t GetMemoryUsage() {
+  return static_cast<MiMemoryResource*>(JsonFamilyMemoryTest::GetMemoryResource())->used();
+}
+
+size_t GetJsonMemoryUsageFromString(std::string_view json_str) {
+  size_t start = GetMemoryUsage();
+  auto json = dfly::JsonFromString(json_str, JsonFamilyMemoryTest::GetMemoryResource());
+  if (!json) {
+    return 0;
+  }
+
+  // The same behaviour as in CompactObj
+  void* ptr =
+      JsonFamilyMemoryTest::GetMemoryResource()->allocate(sizeof(JsonType), alignof(JsonType));
+  JsonType* json_on_heap = new (ptr) JsonType(std::move(json).value());
+  DCHECK(json_on_heap);
+
+  size_t result = GetMemoryUsage() - start;
+
+  // Free the memory
+  json_on_heap->~JsonType();
+  JsonFamilyMemoryTest::GetMemoryResource()->deallocate(json_on_heap, sizeof(JsonType),
+                                                        alignof(JsonType));
+  return result;
+}
+
+TEST_F(JsonFamilyMemoryTest, SimpleSet) {
+  std::string_view big_json = R"({"a":"some big string asdkasdkasdfkkasjdkfjka"})";
+  size_t start_size = GetJsonMemoryUsageFromString(big_json);
+
+  auto resp = Run({"JSON.SET", "j1", "$", big_json});
+  EXPECT_EQ(resp, "OK");
+  resp = GetJsonMemoryUsageFromDb("j1");
+  EXPECT_THAT(resp, IntArg(start_size));
+
+  std::string_view small_json = R"({"a":" "})";
+  size_t next_size = GetJsonMemoryUsageFromString(small_json);
+
+  resp = Run({"JSON.SET", "j1", "$", small_json});
+  EXPECT_EQ(resp, "OK");
+  resp = GetJsonMemoryUsageFromDb("j1");
+  EXPECT_THAT(resp, IntArg(next_size));
+
+  // Again set big json
+  resp = Run({"JSON.SET", "j1", "$", big_json});
+  EXPECT_EQ(resp, "OK");
+  resp = GetJsonMemoryUsageFromDb("j1");
+  EXPECT_THAT(resp, IntArg(start_size));
+}
+
+TEST_F(JsonFamilyMemoryTest, PartialSet) {
+  std::string_view start_json = R"({"a":"some text", "b":" "})";
+  size_t start_size = GetJsonMemoryUsageFromString(start_json);
+
+  auto resp = Run({"JSON.SET", "j1", "$", start_json});
+  EXPECT_EQ(resp, "OK");
+  resp = GetJsonMemoryUsageFromDb("j1");
+  EXPECT_THAT(resp, IntArg(start_size));
+
+  std::string_view json_after_set = R"({"a":"some text", "b":"some another text"})";
+  size_t size_after_set = GetJsonMemoryUsageFromString(json_after_set);
+
+  resp = Run({"JSON.SET", "j1", "$.b", "\"some another text\""});
+  EXPECT_EQ(resp, "OK");
+  resp = GetJsonMemoryUsageFromDb("j1");
+  EXPECT_THAT(resp, IntArg(size_after_set));
+
+  // Again set start json
+  resp = Run({"JSON.SET", "j1", "$.b", "\" \""});
+  EXPECT_EQ(resp, "OK");
+  resp = GetJsonMemoryUsageFromDb("j1");
+  EXPECT_THAT(resp, IntArg(start_size));
+}
+
+}  // namespace dfly

--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -82,8 +82,8 @@ std::string MallocStatsCb(bool backing, unsigned tid) {
   return str;
 }
 
-size_t MemoryUsage(PrimeIterator it) {
-  size_t key_size = it->first.MallocUsed();
+size_t MemoryUsage(PrimeIterator it, bool account_key_memory_usage) {
+  size_t key_size = account_key_memory_usage ? it->first.MallocUsed() : 0;
   return key_size + it->second.MallocUsed(true);
 }
 
@@ -95,9 +95,9 @@ MemoryCmd::MemoryCmd(ServerFamily* owner, facade::SinkReplyBuilder* builder,
 }
 
 void MemoryCmd::Run(CmdArgList args) {
-  string sub_cmd = absl::AsciiStrToUpper(ArgS(args, 0));
+  CmdArgParser parser(args);
 
-  if (sub_cmd == "HELP") {
+  if (parser.Check("HELP")) {
     string_view help_arr[] = {
         "MEMORY <subcommand> [<arg> ...]. Subcommands are:",
         "STATS",
@@ -110,8 +110,9 @@ void MemoryCmd::Run(CmdArgList args) {
         "ARENA SHOW",
         "    Prints the arena summary report for the entire process.",
         "    Requires MIMALLOC_VERBOSE=1 environment to be set. The output goes to stdout",
-        "USAGE <key>",
+        "USAGE <key> [WITHOUTKEY]",
         "    Show memory usage of a key.",
+        "    If WITHOUTKEY is specified, the key itself is not accounted.",
         "DECOMMIT",
         "    Force decommit the memory freed by the server back to OS.",
         "TRACK",
@@ -137,35 +138,36 @@ void MemoryCmd::Run(CmdArgList args) {
     return rb->SendSimpleStrArr(help_arr);
   };
 
-  if (sub_cmd == "STATS") {
+  if (parser.Check("STATS")) {
     return Stats();
   }
 
-  if (sub_cmd == "USAGE" && args.size() > 1) {
-    string_view key = ArgS(args, 1);
-    return Usage(key);
+  if (parser.Check("USAGE") && args.size() > 1) {
+    string_view key = parser.Next();
+    bool account_key_memory_usage = !parser.Check("WITHOUTKEY");
+    return Usage(key, account_key_memory_usage);
   }
 
-  if (sub_cmd == "DECOMMIT") {
+  if (parser.Check("DECOMMIT")) {
     shard_set->pool()->AwaitBrief(
         [](unsigned, auto* pb) { ServerState::tlocal()->DecommitMemory(ServerState::kAllMemory); });
     return builder_->SendSimpleString("OK");
   }
 
-  if (sub_cmd == "MALLOC-STATS") {
+  if (parser.Check("MALLOC-STATS")) {
     return MallocStats();
   }
 
-  if (sub_cmd == "ARENA") {
+  if (parser.Check("ARENA")) {
     return ArenaStats(args);
   }
 
-  if (sub_cmd == "TRACK") {
+  if (parser.Check("TRACK")) {
     args.remove_prefix(1);
     return Track(args);
   }
 
-  if (sub_cmd == "DEFRAGMENT") {
+  if (parser.Check("DEFRAGMENT")) {
     shard_set->pool()->DispatchOnAll([](util::ProactorBase*) {
       if (auto* shard = EngineShard::tlocal(); shard)
         shard->ForceDefrag();
@@ -173,7 +175,7 @@ void MemoryCmd::Run(CmdArgList args) {
     return builder_->SendSimpleString("OK");
   }
 
-  string err = UnknownSubCmd(sub_cmd, "MEMORY");
+  string err = UnknownSubCmd(parser.Next(), "MEMORY");
   return builder_->SendError(err, kSyntaxErrType);
 }
 
@@ -346,18 +348,19 @@ void MemoryCmd::ArenaStats(CmdArgList args) {
   return rb->SendVerbatimString(mi_malloc_info);
 }
 
-void MemoryCmd::Usage(std::string_view key) {
+void MemoryCmd::Usage(std::string_view key, bool account_key_memory_usage) {
   ShardId sid = Shard(key, shard_set->size());
-  ssize_t memory_usage = shard_set->pool()->at(sid)->AwaitBrief([key, this, sid]() -> ssize_t {
-    auto& db_slice = cntx_->ns->GetDbSlice(sid);
-    auto [pt, exp_t] = db_slice.GetTables(cntx_->db_index());
-    PrimeIterator it = pt->Find(key);
-    if (IsValid(it)) {
-      return MemoryUsage(it);
-    } else {
-      return -1;
-    }
-  });
+  ssize_t memory_usage = shard_set->pool()->at(sid)->AwaitBrief(
+      [key, account_key_memory_usage, this, sid]() -> ssize_t {
+        auto& db_slice = cntx_->ns->GetDbSlice(sid);
+        auto [pt, exp_t] = db_slice.GetTables(cntx_->db_index());
+        PrimeIterator it = pt->Find(key);
+        if (IsValid(it)) {
+          return MemoryUsage(it, account_key_memory_usage);
+        } else {
+          return -1;
+        }
+      });
 
   auto* rb = static_cast<RedisReplyBuilder*>(builder_);
   if (memory_usage < 0)

--- a/src/server/memory_cmd.h
+++ b/src/server/memory_cmd.h
@@ -20,7 +20,7 @@ class MemoryCmd {
   void Stats();
   void MallocStats();
   void ArenaStats(CmdArgList args);
-  void Usage(std::string_view key);
+  void Usage(std::string_view key, bool account_key_memory_usage);
   void Track(CmdArgList args);
 
   ConnectionContext* cntx_;

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -2753,4 +2753,18 @@ TEST_F(SearchFamilyTest, RenameDocumentBetweenIndices) {
   EXPECT_EQ(Run({"rename", "idx2:{doc}1", "idx1:{doc}1"}), "OK");
 }
 
+TEST_F(SearchFamilyTest, JsonSetIndexesBug) {
+  auto resp = Run({"JSON.SET", "j1", "$", R"({"text":"some text"})"});
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run(
+      {"FT.CREATE", "index", "ON", "json", "SCHEMA", "$.text", "AS", "text", "TEXT", "SORTABLE"});
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run({"JSON.SET", "j1", "$", R"({"asd}"})"});
+  EXPECT_THAT(resp, ErrArg("ERR failed to parse JSON"));
+
+  resp = Run({"FT.AGGREGATE", "index", "*", "GROUPBY", "1", "@text"});
+  EXPECT_THAT(resp, IsUnordArrayWithSize(IsMap("text", "some text")));
+}
 }  // namespace dfly


### PR DESCRIPTION
This is fourth PR that fixes memory tracking issues in JSON.

Bugs that were found and fixed:
1. Bug in JsonMutateOperation, where we called `op_args.shard->search_indices()->RemoveDoc` after starting the memory tracking. `RemoveDoc` has a static cache that may allocate some memory, but this memory does not belong to the JSON object itself. As a result, memory usage will be overestimated in this case.