### PR TITLE
fix(json_family): Fix memory tracking for the JSON.DEL command. FIFTH PR

### DIFF
--- a/src/server/json_family_memory_test.cc
+++ b/src/server/json_family_memory_test.cc
@@ -105,4 +105,108 @@ TEST_F(JsonFamilyMemoryTest, PartialSet) {
   EXPECT_THAT(resp, IntArg(start_size));
 }
 
+/* Tests how works memory usage after deleting json object in jsoncons */
+TEST_F(JsonFamilyMemoryTest, JsonConsDelTest) {
+  std::string_view start_json = R"({"a":"some text", "b":" "})";
+
+  size_t start = GetMemoryUsage();
+
+  auto json = dfly::JsonFromString(start_json, JsonFamilyMemoryTest::GetMemoryResource());
+  void* ptr =
+      JsonFamilyMemoryTest::GetMemoryResource()->allocate(sizeof(JsonType), alignof(JsonType));
+  JsonType* json_on_heap = new (ptr) JsonType(std::move(json).value());
+
+  size_t memory_usage_before_erase = GetMemoryUsage() - start;
+
+  json_on_heap->erase("a");
+  /* To deallocate memory we should use shrink_to_fit */
+  json_on_heap->shrink_to_fit();
+
+  size_t memory_usage_after_erase = GetMemoryUsage() - start;
+
+  EXPECT_GT(memory_usage_before_erase, memory_usage_after_erase);
+  EXPECT_EQ(memory_usage_after_erase, GetJsonMemoryUsageFromString(R"({"b":" "})"));
+}
+
+TEST_F(JsonFamilyMemoryTest, SimpleDel) {
+  std::string_view start_json = R"({"a":"some text", "b":" "})";
+  size_t start_size = GetJsonMemoryUsageFromString(start_json);
+
+  auto resp = Run({"JSON.SET", "j1", "$", start_json});
+  EXPECT_EQ(resp, "OK");
+  resp = GetJsonMemoryUsageFromDb("j1");
+  EXPECT_THAT(resp, IntArg(start_size));
+
+  std::string_view json_after_del = R"({"b":" "})";
+  size_t size_after_del = GetJsonMemoryUsageFromString(json_after_del);
+
+  // Test that raw memory usage is correct
+  resp = Run({"JSON.SET", "j2", "$", json_after_del});
+  EXPECT_EQ(resp, "OK");
+  resp = GetJsonMemoryUsageFromDb("j2");
+  EXPECT_THAT(resp, IntArg(size_after_del));
+
+  // Test that after deletion memory usage is correct
+  resp = Run({"JSON.DEL", "j1", "$.a"});
+  EXPECT_THAT(resp, IntArg(1));
+  resp = Run({"JSON.GET", "j1"});
+  EXPECT_EQ(resp, json_after_del);
+  resp = GetJsonMemoryUsageFromDb("j1");
+
+  /* We still expect the initial size here, because after deletion we do not call shrink_to_fit on
+     the JSON object. As a result, the memory will not be deallocated. Check
+     JsonFamilyMemoryTest::JsonConsDelTest for example. */
+  EXPECT_THAT(resp, IntArg(start_size));
+
+  // Again set start json
+  resp = Run({"JSON.SET", "j1", "$.a", "\"some text\""});
+  EXPECT_EQ(resp, "OK");
+  resp = GetJsonMemoryUsageFromDb("j1");
+  EXPECT_THAT(resp, IntArg(start_size));
+}
+
+TEST_F(JsonFamilyMemoryTest, JsonShrinking) {
+  std::string_view start_json = R"({"a":"some text","b":"some another text","c":" "})";
+  size_t start_size = GetJsonMemoryUsageFromString(start_json);
+
+  auto resp = Run({"JSON.SET", "j1", "$", start_json});
+  EXPECT_EQ(resp, "OK");
+  resp = GetJsonMemoryUsageFromDb("j1");
+  EXPECT_THAT(resp, IntArg(start_size));
+
+  std::string_view json_after_del = R"({"c":" "})";
+  size_t size_after_del = GetJsonMemoryUsageFromString(json_after_del);
+
+  // Test that raw memory usage is correct
+  resp = Run({"JSON.SET", "j2", "$", json_after_del});
+  EXPECT_EQ(resp, "OK");
+  resp = GetJsonMemoryUsageFromDb("j2");
+  EXPECT_THAT(resp, IntArg(size_after_del));
+
+  // Test that after deletion memory usage decreases
+  resp = Run({"JSON.DEL", "j1", "$.a"});
+  EXPECT_THAT(resp, IntArg(1));
+  resp = Run({"JSON.DEL", "j1", "$.b"});
+  EXPECT_THAT(resp, IntArg(1));
+  resp = Run({"JSON.GET", "j1"});
+  EXPECT_EQ(resp, json_after_del);
+  resp = GetJsonMemoryUsageFromDb("j1");
+  // Now we expect the size to be smaller, because shrink_to_fit was called
+  EXPECT_THAT(resp, IntArg(size_after_del));
+
+  // Again set start json
+  resp = Run({"JSON.SET", "j1", "$.a", "\"some text\""});
+  EXPECT_EQ(resp, "OK");
+  resp = Run({"JSON.SET", "j1", "$.b", "\"some another text\""});
+  EXPECT_EQ(resp, "OK");
+  resp = Run({"JSON.GET", "j1"});
+  EXPECT_EQ(resp, start_json);
+  resp = GetJsonMemoryUsageFromDb("j1");
+
+  // Jsoncons will allocate more memory for the new json that needed.
+  // This is totally fine, because we will not call shrink_to_fit.
+  EXPECT_THAT(resp, IntArg(368));
+  EXPECT_GT(368, start_size);
+}
+
 }  // namespace dfly

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -2801,4 +2801,19 @@ TEST_F(SearchFamilyTest, IgnoredOptionsInFtCreate) {
   resp = Run({"FT.SEARCH", "idx", "*"});
   EXPECT_THAT(resp, AreDocIds("doc:1"));
 }
+
+TEST_F(SearchFamilyTest, JsonDelIndexesBug) {
+  auto resp = Run({"JSON.SET", "j1", "$", R"({"text":"some text"})"});
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run(
+      {"FT.CREATE", "index", "ON", "json", "SCHEMA", "$.text", "AS", "text", "TEXT", "SORTABLE"});
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run({"JSON.DEL", "j1", "$.text"});
+  EXPECT_THAT(resp, IntArg(1));
+
+  resp = Run({"FT.AGGREGATE", "index", "*", "GROUPBY", "1", "@text"});
+  EXPECT_THAT(resp, IsUnordArrayWithSize(IsMap("text", ArgType(RespExpr::NIL))));
+}
 }  // namespace dfly


### PR DESCRIPTION
fixes #5055
This PR fixes several issues in JSON.DEL command - we didn't update the indexes and track the memory usage at all. One of the bugs is good described in #5055.

