### PR TITLE
chore: allow setting huffman tables via DEBUG COMPRESSION SET

### DIFF
--- a/.devcontainer/ubuntu24/devcontainer.json
+++ b/.devcontainer/ubuntu24/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "ubuntu24",
+  "image": "ghcr.io/romange/ubuntu-dev:24",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cpptools",
+        "ms-vscode.cmake-tools",
+        "ms-vscode.cpptools-themes",
+        "twxs.cmake"
+      ],
+      "settings": {
+        "cmake.buildDirectory": "/build",
+        "extensions.ignoreRecommendations": true
+      }
+    }
+  },
+  "mounts": [
+    "source=ubuntu24-vol,target=/build,type=volume"
+  ],
+  "postCreateCommand": ".devcontainer/ubuntu24/post-create.sh ${containerWorkspaceFolder}"
+}

--- a/.devcontainer/ubuntu24/post-create.sh
+++ b/.devcontainer/ubuntu24/post-create.sh
@@ -1,0 +1,1 @@
+../ubuntu22/post-create.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ if (SUPPORT_USAN AND WITH_USAN)
 endif()
 
 if(SANITIZERS)
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -rtlib=compiler-rt")
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
 endif()
 
 include(third_party)

--- a/src/core/compact_object_test.cc
+++ b/src/core/compact_object_test.cc
@@ -622,6 +622,12 @@ TEST_F(CompactObjectTest, RawInterface) {
   }
 }
 
+TEST_F(CompactObjectTest, AsanTriggerReadOverflow) {
+  cobj_.SetString(string(32, 'a'));
+  auto dest = make_unique<char[]>(32);
+  cobj_.GetString(dest.get());
+}
+
 TEST_F(CompactObjectTest, lpGetInteger) {
   int64_t val = -1;
   uint8_t* lp = lpNew(0);

--- a/src/core/detail/bitpacking.cc
+++ b/src/core/detail/bitpacking.cc
@@ -269,6 +269,11 @@ void ascii_unpack(const uint8_t* bin, size_t ascii_len, char* ascii) {
   }
 }
 
+// In some cases we may read 2 bytes more than "allowed" (16 bytes during mm_loadu_si128
+// instead of 14 bytes that we actually need). Since we ignore these two bytes, there is no harm.
+// See CompactObjectTest.AsanTriggerReadOverflow for more details.
+// __attribute__((no_sanitize_address)) does not work here for some reason, so I had
+// to put it in sse_port.h.
 void ascii_unpack_simd(const uint8_t* bin, size_t ascii_len, char* ascii) {
 #ifdef __SSSE3__
 

--- a/src/core/sse_port.h
+++ b/src/core/sse_port.h
@@ -16,8 +16,13 @@
 
 namespace dfly {
 
+#if defined(__clang__)
+__attribute__((no_sanitize_address))
+#endif
+
 #ifndef __s390x__
-inline __m128i mm_loadu_si128(const __m128i* ptr) {
+inline __m128i
+mm_loadu_si128(const __m128i* ptr) {
 #if defined(__aarch64__)
   __m128i res;
   memcpy(&res, ptr, sizeof(res));


### PR DESCRIPTION
Also, revert the performance bomb from #2564

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->