### PR TITLE
chore: support fetching a huffman encoded string from CompactObj

### DIFF
--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -410,7 +410,7 @@ class CompactObj {
 
  private:
   void EncodeString(std::string_view str);
-  size_t DecodedLen(size_t sz) const;
+  size_t DecodedLen(size_t sz, uint8_t firstb) const;
 
   bool EqualNonInline(std::string_view sv) const;
 

--- a/src/core/compact_object_test.cc
+++ b/src/core/compact_object_test.cc
@@ -4,6 +4,7 @@
 #include "core/compact_object.h"
 
 #include <absl/strings/str_cat.h>
+#include <gtest/gtest.h>
 #include <mimalloc.h>
 #include <xxhash.h>
 
@@ -13,6 +14,7 @@
 #include "base/logging.h"
 #include "core/detail/bitpacking.h"
 #include "core/flat_set.h"
+#include "core/huff_coder.h"
 #include "core/mi_memory_resource.h"
 #include "core/string_set.h"
 
@@ -654,6 +656,30 @@ TEST_F(CompactObjectTest, lpGetInteger) {
     ptr = lpNext(lp, ptr);
   }
   lpFree(lp);
+}
+
+TEST_F(CompactObjectTest, HuffMan) {
+  array<unsigned, 256> hist;
+  hist.fill(1);
+  hist['a'] = 100;
+  hist['b'] = 50;
+  HuffmanEncoder encoder;
+  ASSERT_TRUE(encoder.Build(hist.data(), hist.size() - 1, nullptr));
+  string bindata = encoder.Export();
+  ASSERT_TRUE(CompactObj::InitHuffmanThreadLocal(bindata));
+  for (unsigned i = 30; i < 2048; i += 10) {
+    string data(i, 'a');
+    cobj_.SetString(data);
+    bool malloc_used = i >= 60;
+    ASSERT_EQ(malloc_used, cobj_.MallocUsed() > 0) << i;
+    ASSERT_EQ(data.size(), cobj_.Size());
+    ASSERT_EQ(CompactObj::HashCode(data), cobj_.HashCode());
+
+    string actual;
+    cobj_.GetString(&actual);
+    EXPECT_EQ(data, actual);
+    EXPECT_EQ(cobj_, data);
+  }
 }
 
 static void ascii_pack_naive(const char* ascii, size_t len, uint8_t* bin) {

--- a/src/core/huff_coder.cc
+++ b/src/core/huff_coder.cc
@@ -144,7 +144,7 @@ bool HuffmanDecoder::Decode(std::string_view src, size_t dest_size, char* dest) 
       HUF_decompress1X_usingDTable(dest, dest_size, src.data(), src.size(), huf_dtable_.get(), 1);
 
   if (HUF_isError(res)) {
-    LOG(FATAL) << "Failed to decompress: " << HUF_getErrorName(res);
+    LOG(DFATAL) << "Failed to decompress: " << HUF_getErrorName(res);
     return false;
   }
   return true;

--- a/src/core/small_string.h
+++ b/src/core/small_string.h
@@ -50,6 +50,10 @@ class SmallString {
 
   bool DefragIfNeeded(float ratio);
 
+  uint8_t first_byte() const {
+    return prefix_[0];
+  }
+
  private:
   // prefix of the string that is broken down into 2 parts.
   char prefix_[kPrefLen];


### PR DESCRIPTION
This requires implementing HashCode, operator== methods as well.
Fixes https://github.com/dragonflydb/dragonfly/issues/4880

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->