### PR TITLE
fix(hset_family): Fix val being overwritten by TTL

### DIFF
--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -482,11 +482,12 @@ void RdbLoaderBase::OpaqueObjLoader::CreateHMap(const LoadTrace* ltrace) {
       }
     });
     std::string key;
+    std::string val;
     for (size_t i = 0; i < ltrace->arr.size(); i += increment) {
       // ToSV may reference an internal buffer, therefore we can use only before the
       // next call to ToSV. To workaround, copy the key locally.
       key = ToSV(ltrace->arr[i].rdb_var);
-      string_view val = ToSV(ltrace->arr[i + 1].rdb_var);
+      val = ToSV(ltrace->arr[i + 1].rdb_var);
 
       if (ec_)
         return;


### PR DESCRIPTION
When hset is loaded from rdb, if a ttl is specified by the user, we recreate a `string_view` on top of the same memory location, `tset_blob_`, that was used for `val` earlier. This causes the `val` string view to point to the same memory location now as TTL has. For example if the `val` string view was 'x' earlier (points to `tset_blob_`, size 1), and `ttl` is `7777777`, `val` now becomes '7'.

To fix this val is now given it's own string. TTL is kept as string view as the pointer is not reused anywhere in the following loop.

FIXES #4992