### PR TITLE
fix: memcached authentication handling

### DIFF
--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -281,6 +281,11 @@ class Connection : public util::Connection {
     return name_;
   }
 
+  // Returns protocol type of this connection
+  Protocol GetProtocol() const {
+    return protocol_;
+  }
+
   struct MemoryUsage {
     size_t mem = 0;
     io::IoBuf::MemoryUsage buf_mem;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1629,7 +1629,13 @@ facade::ConnectionContext* Service::CreateContext(facade::Connection* owner) {
   } else if (owner->IsPrivileged() && RequirePrivilegedAuth()) {
     res->req_auth = !GetPassword().empty();
   } else if (!owner->IsPrivileged()) {
-    res->req_auth = !user_registry_.AuthUser("default", "");
+    // Memcached protocol doesn't support authentication, so we don't require it
+    if (owner->GetProtocol() == Protocol::MEMCACHE) {
+      res->req_auth = false;
+      res->authenticated = true;  // Automatically authenticated for Memcached protocol
+    } else {
+      res->req_auth = !user_registry_.AuthUser("default", "");
+    }
   }
 
   // a bit of a hack. I set up breaker callback here for the owner.

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -141,7 +141,6 @@ ABSL_DECLARE_FLAG(string, tls_ca_cert_file);
 ABSL_DECLARE_FLAG(string, tls_ca_cert_dir);
 ABSL_DECLARE_FLAG(int, replica_priority);
 ABSL_DECLARE_FLAG(double, rss_oom_deny_ratio);
-ABSL_DECLARE_FLAG(uint32_t, memcached_port);
 
 bool AbslParseFlag(std::string_view in, ReplicaOfFlag* flag, std::string* err) {
 #define RETURN_ON_ERROR(cond, m)                                           \
@@ -297,12 +296,6 @@ bool ValidateServerTlsFlags() {
 
   if (!(absl::GetFlag(FLAGS_tls_ca_cert_file).empty() &&
         absl::GetFlag(FLAGS_tls_ca_cert_dir).empty())) {
-    has_auth = true;
-  }
-
-  // Allow TLS without authentication for memcached protocol
-  // We check if memcached_port is enabled, as this is a static check during startup
-  if (GetFlag(FLAGS_memcached_port) > 0) {
     has_auth = true;
   }
 

--- a/tests/dragonfly/pymemcached_test.py
+++ b/tests/dragonfly/pymemcached_test.py
@@ -186,7 +186,7 @@ def test_memcached_tls_no_requirepass(df_factory, with_tls_server_args, with_tls
     the server with TLS enabled but without specifying requirepass and with the Memcached port.
     """
     # Create arguments for TLS without specifying requirepass
-    server_args = {**DEFAULT_ARGS, **with_tls_server_args}
+    server_args = {**DEFAULT_ARGS, **with_tls_server_args, "requirepass": "test_password"}
 
     # Create and start the server - it should not crash
     server = df_factory.create(**server_args)
@@ -204,7 +204,7 @@ def test_memcached_tls_no_requirepass(df_factory, with_tls_server_args, with_tls
     ssl_context.verify_mode = ssl.CERT_NONE
 
     # Output port information for diagnostics
-    print(f"Connecting to memcached port: {server.mc_port} on host: 127.0.0.1")
+    logging.info(f"Connecting to memcached port: {server.mc_port} on host: 127.0.0.1")
 
     # Connect to Memcached over TLS
     client = MCClient(("127.0.0.1", server.mc_port), tls_context=ssl_context)


### PR DESCRIPTION
This PR fixes authentication handling for the Memcached protocol. The previous fix in PR [#5085](https://github.com/dragonflydb/dragonfly/pull/5085) was wrong, because it turned password off for TLS connection regardless of whether it was Redis or Memcached.

Changes:
- Updated test_memcached_tls_no_requirepass to run with password configured but use the Memcached client without authentication.
- Reverted changes for ValidateServerTlsFlags().
- Skip password for Memcached protocol regardless of whether TLS is enabled or not.

Now Dragonfly correctly handles authentication settings for both protocols simultaneously.