### PR TITLE
refactor: provide CommandContext into InvokeCmd

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -1453,7 +1453,8 @@ void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBat
       crb.SetReplyMode(ReplyMode::NONE);
       stub_tx->InitByArgs(cntx_->ns, local_cntx.conn_state.db_index, args_span);
 
-      sf_.service().InvokeCmd(cid, args_span, &crb, &local_cntx);
+      sf_.service().InvokeCmd(cid, args_span,
+                              CommandContext{local_cntx.transaction, &crb, &local_cntx});
     }
 
     if (options.expire_ttl_range.has_value()) {
@@ -1473,7 +1474,8 @@ void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBat
       local_cntx.SwitchTxCmd(cid);
       crb.SetReplyMode(ReplyMode::NONE);
       stub_tx->InitByArgs(cntx_->ns, local_cntx.conn_state.db_index, args_span);
-      sf_.service().InvokeCmd(cid, args_span, &crb, &local_cntx);
+      sf_.service().InvokeCmd(cid, args_span,
+                              CommandContext{local_cntx.transaction, &crb, &local_cntx});
     }
   }
 

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -44,8 +44,7 @@ class Service : public facade::ServiceInterface {
                               facade::ConnectionContext* cntx) final;
 
   // Check VerifyCommandExecution and invoke command with args
-  bool InvokeCmd(const CommandId* cid, CmdArgList tail_args, facade::SinkReplyBuilder* builder,
-                 ConnectionContext* reply_cntx);
+  bool InvokeCmd(const CommandId* cid, CmdArgList tail_args, const CommandContext& cmd_cntx);
 
   // Verify command can be executed now (check out of memory), always called immediately before
   // execution


### PR DESCRIPTION
refactor code a little. Command context can store some additional intermediate information, so using it we can avoid double calculations. 
For example, instead of a  transaction, we can store the Slot Id in the command context.