### PR TITLE
chore: tls improvements

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -74,8 +74,6 @@ ABSL_FLAG(uint32_t, pipeline_queue_limit, 10000,
 ABSL_FLAG(uint64_t, publish_buffer_limit, 128_MB,
           "Amount of memory to use for storing pub commands in bytes - per IO thread");
 
-ABSL_FLAG(bool, no_tls_on_admin_port, false, "Allow non-tls connections on admin port");
-
 ABSL_FLAG(uint32_t, pipeline_squash, 10,
           "Number of queued pipelined commands above which squashing is enabled, 0 means disabled");
 
@@ -733,40 +731,37 @@ void Connection::HandleRequests() {
 
 #ifdef DFLY_USE_SSL
   if (ssl_ctx_) {
-    const bool no_tls_on_admin_port = GetFlag(FLAGS_no_tls_on_admin_port);
-    if (!(IsPrivileged() && no_tls_on_admin_port)) {
-      // Must be done atomically before the premption point in Accept so that at any
-      // point in time, the socket_ is defined.
-      uint8_t buf[2];
-      auto read_sz = socket_->Read(io::MutableBytes(buf));
-      if (!read_sz || *read_sz < sizeof(buf)) {
-        VLOG(1) << "Error reading from peer " << remote_ep << " " << read_sz.error().message();
-        return;
-      }
-      if (buf[0] != 0x16 || buf[1] != 0x03) {
-        VLOG(1) << "Bad TLS header "
-                << absl::StrCat(absl::Hex(buf[0], absl::kZeroPad2),
-                                absl::Hex(buf[1], absl::kZeroPad2));
-        socket_->Write(
-            io::Buffer("-ERR Bad TLS header, double check "
-                       "if you enabled TLS for your client.\r\n"));
-      }
-
-      {
-        FiberAtomicGuard fg;
-        unique_ptr<tls::TlsSocket> tls_sock = make_unique<tls::TlsSocket>(std::move(socket_));
-        tls_sock->InitSSL(ssl_ctx_, buf);
-        SetSocket(tls_sock.release());
-      }
-      FiberSocketBase::AcceptResult aresult = socket_->Accept();
-
-      if (!aresult) {
-        LOG(INFO) << "Error handshaking " << aresult.error().message();
-        return;
-      }
-      is_tls_ = 1;
-      VLOG(1) << "TLS handshake succeeded";
+    // Must be done atomically before the premption point in Accept so that at any
+    // point in time, the socket_ is defined.
+    uint8_t buf[2];
+    auto read_sz = socket_->Read(io::MutableBytes(buf));
+    if (!read_sz || *read_sz < sizeof(buf)) {
+      VLOG(1) << "Error reading from peer " << remote_ep << " " << read_sz.error().message();
+      return;
     }
+    if (buf[0] != 0x16 || buf[1] != 0x03) {
+      VLOG(1) << "Bad TLS header "
+              << absl::StrCat(absl::Hex(buf[0], absl::kZeroPad2),
+                              absl::Hex(buf[1], absl::kZeroPad2));
+      std::ignore =
+          socket_->Write(io::Buffer("-ERR Bad TLS header, double check "
+                                    "if you enabled TLS for your client.\r\n"));
+    }
+
+    {
+      FiberAtomicGuard fg;
+      unique_ptr<tls::TlsSocket> tls_sock = make_unique<tls::TlsSocket>(std::move(socket_));
+      tls_sock->InitSSL(ssl_ctx_, buf);
+      SetSocket(tls_sock.release());
+    }
+    FiberSocketBase::AcceptResult aresult = socket_->Accept();
+
+    if (!aresult) {
+      LOG(INFO) << "Error handshaking " << aresult.error().message();
+      return;
+    }
+    is_tls_ = 1;
+    VLOG(1) << "TLS handshake succeeded";
   }
 #endif
 
@@ -878,7 +873,12 @@ pair<string, string> Connection::GetClientInfoBeforeAfterTid() const {
   } else {
     absl::StrAppend(&before, " name=", name_);
   }
-
+  if (is_tls_) {
+    tls::TlsSocket* tls_sock = static_cast<tls::TlsSocket*>(socket_.get());
+    string_view proto_version = SSL_get_version(tls_sock->ssl_handle());
+    const SSL_CIPHER* cipher = SSL_get_current_cipher(tls_sock->ssl_handle());
+    absl::StrAppend(&before, " tls=", proto_version, "|", SSL_CIPHER_get_name(cipher));
+  }
   string after;
   absl::StrAppend(&after, " irqmatch=", int(cpu == my_cpu_id));
   if (dispatch_q_.size()) {

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -487,6 +487,9 @@ class Connection : public util::Connection {
       bool migration_enabled_ : 1;
       bool migration_in_process_ : 1;
       bool is_http_ : 1;
+
+      // whether the connection is TLS. We can be sure our socket is TlsSocket
+      // if the flag is set.
       bool is_tls_ : 1;
       bool recv_provided_ : 1;
       bool is_main_ : 1;


### PR DESCRIPTION
1. Move no_tls_on_admin_port to listener, stop creating SSL_CTX objects on listeners that do not need it.
2. Make suites selection for tls1.2 and tls1.3 configurable at runtime.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->