### PR TITLE
fix: XTRIM command crash

### DIFF
--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -3328,10 +3328,10 @@ void StreamFamily::XTrim(CmdArgList args, const CommandContext& cmd_cntx) {
 
   std::string_view key = parser.Next();
 
-  if (!parser.HasNext() || (!absl::EqualsIgnoreCase(parser.Peek(), "MAXLEN") &&
-                            !absl::EqualsIgnoreCase(parser.Peek(), "MINID") &&
-                            !absl::EqualsIgnoreCase(parser.Peek(), "~") &&
-                            !absl::EqualsIgnoreCase(parser.Peek(), "="))) {
+  auto next_arg = parser.Peek();
+  if (!parser.HasNext() ||
+      (!absl::EqualsIgnoreCase(next_arg, "MAXLEN") && !absl::EqualsIgnoreCase(next_arg, "MINID") &&
+       next_arg != "~" && next_arg != "=")) {
     rb->SendError(kSyntaxErr);
     return;
   }

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -3330,11 +3330,8 @@ void StreamFamily::XTrim(CmdArgList args, const CommandContext& cmd_cntx) {
 
   auto parsed_trim_opts = ParseTrimOpts(&parser);
   if (!parser.Finalize() || !parsed_trim_opts) {
-    if (parser.HasError()) {
-      rb->SendError(parser.Error()->MakeReply());
-    } else {
-      rb->SendError(parsed_trim_opts.error());
-    }
+    auto err = parser.Error();
+    rb->SendError(!parsed_trim_opts ? parsed_trim_opts.error() : err->MakeReply());
     return;
   }
 

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -3328,6 +3328,14 @@ void StreamFamily::XTrim(CmdArgList args, const CommandContext& cmd_cntx) {
 
   std::string_view key = parser.Next();
 
+  if (!parser.HasNext() || (!absl::EqualsIgnoreCase(parser.Peek(), "MAXLEN") &&
+                            !absl::EqualsIgnoreCase(parser.Peek(), "MINID") &&
+                            !absl::EqualsIgnoreCase(parser.Peek(), "~") &&
+                            !absl::EqualsIgnoreCase(parser.Peek(), "="))) {
+    rb->SendError(kSyntaxErr);
+    return;
+  }
+
   auto parsed_trim_opts = ParseTrimOpts(&parser);
   if (!parsed_trim_opts || !parser.Finalize()) {
     rb->SendError(!parsed_trim_opts ? parsed_trim_opts.error() : parser.Error()->MakeReply());

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -687,9 +687,9 @@ TEST_F(StreamFamilyTest, XTrimInvalidArgs) {
 
   // Include both maxlen and minid.
   resp = Run({"xtrim", "foo", "maxlen", "2", "minid", "1-1"});
-  EXPECT_THAT(resp, ErrArg("syntax error"));
+  EXPECT_THAT(resp, ErrArg("MAXLEN and MINID options at the same time are not compatible"));
   resp = Run({"xtrim", "foo", "minid", "1-1", "maxlen", "2"});
-  EXPECT_THAT(resp, ErrArg("syntax error"));
+  EXPECT_THAT(resp, ErrArg("MAXLEN and MINID options at the same time are not compatible"));
 
   // Invalid limit.
   resp = Run({"xtrim", "foo", "maxlen", "~", "2", "limit", "nan"});

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -687,9 +687,9 @@ TEST_F(StreamFamilyTest, XTrimInvalidArgs) {
 
   // Include both maxlen and minid.
   resp = Run({"xtrim", "foo", "maxlen", "2", "minid", "1-1"});
-  EXPECT_THAT(resp, ErrArg("MAXLEN and MINID options at the same time are not compatible"));
+  EXPECT_THAT(resp, ErrArg("syntax error"));
   resp = Run({"xtrim", "foo", "minid", "1-1", "maxlen", "2"});
-  EXPECT_THAT(resp, ErrArg("MAXLEN and MINID options at the same time are not compatible"));
+  EXPECT_THAT(resp, ErrArg("syntax error"));
 
   // Invalid limit.
   resp = Run({"xtrim", "foo", "maxlen", "~", "2", "limit", "nan"});

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -695,6 +695,13 @@ TEST_F(StreamFamilyTest, XTrimInvalidArgs) {
   resp = Run({"xtrim", "foo", "maxlen", "~", "2", "limit", "nan"});
   EXPECT_THAT(resp, ErrArg("value is not an integer or out of range"));
 }
+
+TEST_F(StreamFamilyTest, XTrimWrongSyntax) {
+  auto resp = Run({"xtrim", "-992", "k1 \"v1\" k2 \"v2 with spaces\" \"k3 with spaces\" \"v3\"",
+                   "list1 element1"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
+}
+
 TEST_F(StreamFamilyTest, XPending) {
   Run({"xadd", "foo", "1-0", "k1", "v1"});
   Run({"xadd", "foo", "1-1", "k2", "v2"});


### PR DESCRIPTION
Fixes: https://github.com/dragonflydb/dragonfly/issues/5120

Additional checks for the following argument were added after the key for the XTRIM command.