### PR TITLE
fix: make search keywords case insensitive

### DIFF
--- a/src/core/search/lexer.lex
+++ b/src/core/search/lexer.lex
@@ -18,7 +18,7 @@
 %o bison-cc-namespace="dfly.search" bison-cc-parser="Parser"
 %o namespace="dfly.search"
 %o class="Scanner" lex="Lex"
-%o nodefault batch
+%o nodefault batch case-insensitive
 /* %o debug */
 
 /* Declarations before lexer implementation.  */

--- a/src/core/search/parser.y
+++ b/src/core/search/parser.y
@@ -98,14 +98,14 @@ final_query:
       { driver->Set(AstKnnNode(std::move($1), std::move($3))); }
 
 knn_query:
-  LBRACKET KNN UINT32 FIELD TERM opt_knn_alias opt_ef_runtime RBRACKET
+  LBRACKET KNN UINT32 FIELD TERM opt_ef_runtime opt_knn_alias RBRACKET
     {
       auto vec_result = BytesToFtVectorSafe($5);
       if (!vec_result) {
         error(@5, "Invalid vector format");
         YYERROR;
       }
-      $$ = AstKnnNode(toUint32($3), $4, std::move(*vec_result), $6, $7);
+      $$ = AstKnnNode(toUint32($3), $4, std::move(*vec_result), $7, $6);
     }
 
 opt_knn_alias:

--- a/src/core/search/search_parser_test.cc
+++ b/src/core/search/search_parser_test.cc
@@ -277,7 +277,7 @@ TEST_F(SearchParserTest, KNN) {
 }
 
 TEST_F(SearchParserTest, KNNfull) {
-  SetInput("*=>[KNN 1 @vector field_vec AS vec_sort EF_RUNTIME 15]");
+  SetInput("*=>[Knn 1 @vector field_vec EF_Runtime 15 as vec_sort]");
   NEXT_TOK(TOK_STAR);
   NEXT_TOK(TOK_ARROW);
   NEXT_TOK(TOK_LBRACKET);
@@ -287,11 +287,11 @@ TEST_F(SearchParserTest, KNNfull) {
   NEXT_TOK(TOK_FIELD);
   NEXT_TOK(TOK_TERM);
 
-  NEXT_TOK(TOK_AS);
-  NEXT_EQ(TOK_TERM, string, "vec_sort");
-
   NEXT_TOK(TOK_EF_RUNTIME);
   NEXT_EQ(TOK_UINT32, string, "15");
+
+  NEXT_TOK(TOK_AS);
+  NEXT_EQ(TOK_TERM, string, "vec_sort");
 
   NEXT_TOK(TOK_RBRACKET);
 }

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -591,6 +591,15 @@ TEST_P(KnnTest, Simple1D) {
     algo.Init("* =>[KNN 2 @pos $vec]", &params);
     EXPECT_THAT(algo.Search(&indices).ids, testing::UnorderedElementsAre(70, 71));
   }
+
+  // Two closest to 70.5
+  {
+    params["vec"] = ToBytes({70.5});
+    algo.Init("* =>[KNN 2 @pos $vec as vector_distance]", &params);
+    EXPECT_EQ("vector_distance", algo.GetKnnScoreSortOption()->score_field_alias);
+    SearchResult result = algo.Search(&indices);
+    EXPECT_THAT(result.ids, testing::UnorderedElementsAre(70, 71));
+  }
 }
 
 TEST_P(KnnTest, Simple2D) {


### PR DESCRIPTION
Also fix the order of alias and the runtime arguments in KNN query.
Making sure that this query:
`"FT.SEARCH" "user-idx" "*=>[knn 3 @embedding $vector EF_RUNTIME 5 as vector_distance]" "RETURN" "1" "vector_distance"  DIALECT 2   "params" "2" "vector" "\n\xd7#>{\x14\xae\xbeH\xe1z?\x1f\x85k>"`  is parsed correctly.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->