### PR TITLE
chore: add basic TOPK commands

### DIFF
--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -15,6 +15,7 @@
 #include "core/mi_memory_resource.h"
 #include "core/small_string.h"
 #include "core/string_or_view.h"
+#include "core/top_keys.h"
 
 namespace dfly {
 
@@ -123,6 +124,7 @@ class CompactObj {
     EXTERNAL_TAG = 20,
     JSON_TAG = 21,
     SBF_TAG = 22,
+    TOPK_TAG = 23,
   };
 
   // String encoding types.
@@ -311,6 +313,9 @@ class CompactObj {
   void SetSBF(uint64_t initial_capacity, double fp_prob, double grow_factor);
   SBF* GetSBF() const;
 
+  void SetTopK(size_t topk, size_t width, size_t depth, double decay);
+  TopKeys* GetTopK() const;
+
   // dest must have at least Size() bytes available
   void GetString(char* dest) const;
 
@@ -479,6 +484,7 @@ class CompactObj {
     // using 'packed' to reduce alignement of U to 1.
     JsonWrapper json_obj __attribute__((packed));
     SBF* sbf __attribute__((packed));
+    TopKeys* topk __attribute__((packed));
     int64_t ival __attribute__((packed));
     ExternalPtr ext_ptr;
 

--- a/src/redis/redis_aux.h
+++ b/src/redis/redis_aux.h
@@ -6,6 +6,7 @@
 /* redis.h auxiliary definitions */
 /* the last one in object.h is OBJ_STREAM and it is 6,
  * this will add enough place for Redis types to grow */
+#define OBJ_TOPK  13U
 #define OBJ_TDIGEST  14U
 #define OBJ_JSON 15U
 #define OBJ_SBF  16U

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -62,7 +62,7 @@ add_library(dragonfly_lib bloom_family.cc
             cluster/cluster_config.cc cluster/cluster_family.cc cluster/incoming_slot_migration.cc
             cluster/outgoing_slot_migration.cc cluster/cluster_defs.cc cluster/cluster_utility.cc
             acl/user.cc acl/user_registry.cc acl/acl_family.cc
-            acl/validator.cc tdigest_family.cc)
+            acl/validator.cc tdigest_family.cc topk_family.cc)
 
 if (DF_ENABLE_MEMORY_TRACKING)
   target_compile_definitions(dragonfly_lib PRIVATE DFLY_ENABLE_MEMORY_TRACKING)

--- a/src/server/acl/acl_commands_def.h
+++ b/src/server/acl/acl_commands_def.h
@@ -41,6 +41,7 @@ enum AclCat {
   SCRIPTING = 1ULL << 20,
 
   // Extensions
+  TOPK = 1ULL << 27,
   TDIGEST = 1ULL << 27,
   BLOOM = 1ULL << 28,
   FT_SEARCH = 1ULL << 29,

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -58,6 +58,7 @@ extern "C" {
 #include "server/stream_family.h"
 #include "server/string_family.h"
 #include "server/tdigest_family.h"
+#include "server/topk_family.h"
 #include "server/transaction.h"
 #include "server/version.h"
 #include "server/zset_family.h"
@@ -2721,6 +2722,7 @@ void Service::RegisterCommands() {
   server_family_.Register(&registry_);
   cluster_family_.Register(&registry_);
   TDigestFamily::Register(&registry_);
+  TopKeysFamily::Register(&registry_);
 
   // AclFamily should always be registered last
   // If we add a new familly, register that first above and *not* below

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -275,6 +275,9 @@ io::Result<uint8_t> RdbSerializer::SaveEntry(const PrimeKey& pk, const PrimeValu
   if (pv.ObjType() == OBJ_TDIGEST) {
     return 0;
   }
+  if (pv.ObjType() == OBJ_TOPK) {
+    return 0;
+  }
   if (!pv.TagAllowsEmptyValue() && pv.Size() == 0) {
     string_view key = pk.GetSlice(&tmp_str_);
     LOG(DFATAL) << "SaveEntry skipped empty PrimeValue with key: " << key << " with tag "

--- a/src/server/topk_family.cc
+++ b/src/server/topk_family.cc
@@ -1,0 +1,143 @@
+// Copyright 2025, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "server/topk_family.h"
+
+#include <type_traits>
+
+#include "facade/cmd_arg_parser.h"
+#include "facade/error.h"
+#include "server/acl/acl_commands_def.h"
+#include "server/command_registry.h"
+#include "server/db_slice.h"
+#include "server/engine_shard.h"
+#include "server/engine_shard_set.h"
+#include "server/transaction.h"
+
+namespace dfly {
+
+void TopKeysFamily::Reserve(CmdArgList args, const CommandContext& cmd_cntx) {
+  facade::CmdArgParser parser{args};
+
+  auto key = parser.Next<std::string_view>();
+  auto total_elements = parser.Next<size_t>();
+  if (parser.HasError()) {
+    return cmd_cntx.rb->SendError(parser.Error()->MakeReply());
+  }
+
+  auto cb = [key, total_elements](Transaction* tx, EngineShard* es) -> OpResult<bool> {
+    auto& db_slice = tx->GetDbSlice(es->shard_id());
+    auto db_cntx = tx->GetDbContext();
+    auto res = db_slice.AddOrFind(db_cntx, key);
+    if (!res) {
+      return res.status();
+    }
+
+    if (!res->is_new) {
+      return OpStatus::KEY_EXISTS;
+    }
+
+    res->it->second.SetTopK(total_elements, (1 << 16), 4, 1.08);
+    return OpStatus::OK;
+  };
+
+  auto res = cmd_cntx.tx->ScheduleSingleHopT(cb);
+  // SendError covers ok
+  if (res.status() == OpStatus::KEY_EXISTS) {
+    return cmd_cntx.rb->SendError("key already exists");
+  }
+  return cmd_cntx.rb->SendOk();
+}
+
+void TopKeysFamily::Add(CmdArgList args, const CommandContext& cmd_cntx) {
+  facade::CmdArgParser parser{args};
+
+  auto key = parser.Next<std::string_view>();
+  std::vector<std::string_view> values;
+  while (parser.HasNext()) {
+    auto val = parser.Next<std::string_view>();
+    values.push_back(val);
+  }
+
+  if (parser.HasError()) {
+    return cmd_cntx.rb->SendError(parser.Error()->MakeReply());
+  }
+
+  using Result = std::vector<std::string>;
+  auto cb = [key, &values](Transaction* tx, EngineShard* es) -> OpResult<Result> {
+    auto& db_slice = tx->GetDbSlice(es->shard_id());
+    auto db_cntx = tx->GetDbContext();
+    auto it = db_slice.FindMutable(db_cntx, key, OBJ_TOPK);
+    if (!it) {
+      return it.status();
+    }
+    auto* topk = it->it->second.GetTopK();
+    Result results;
+    results.reserve(values.size());
+    for (auto val : values) {
+      // TODO return key if removed because of an exponential delay
+      topk->Touch(val);
+      results.push_back("nil");
+    }
+    return results;
+  };
+
+  auto res = cmd_cntx.tx->ScheduleSingleHopT(cb);
+  if (!res) {
+    return cmd_cntx.rb->SendError(res.status());
+  }
+  auto* rb = static_cast<facade::RedisReplyBuilder*>(cmd_cntx.rb);
+  // TODO fix return reply once Touch signature changes. See comment in cb above
+  rb->StartArray(res->size());
+  for ([[maybe_unused]] const auto& reply : *res) {
+    rb->SendNull();
+  }
+}
+
+void TopKeysFamily::List(CmdArgList args, const CommandContext& cmd_cntx) {
+  facade::CmdArgParser parser{args};
+
+  auto key = parser.Next<std::string_view>();
+  // if (parser.HasError()) {
+  //   return cmd_cntx.rb->SendError(parser.Error()->MakeReply());
+  // }
+
+  // even declval() is too verbose here :scream:
+  // using Result = std::invoke_result_t<decltype(&TopKeys::GetTopKeys), TopKeys>;
+  using Result = absl::flat_hash_map<std::string, uint64_t>;
+  auto cb = [key](Transaction* tx, EngineShard* es) -> OpResult<Result> {
+    auto& db_slice = tx->GetDbSlice(es->shard_id());
+    auto db_cntx = tx->GetDbContext();
+    auto it = db_slice.FindMutable(db_cntx, key, OBJ_TOPK);
+    if (!it) {
+      return it.status();
+    }
+    auto* topk = it->it->second.GetTopK();
+    return topk->GetTopKeys();
+  };
+
+  auto res = cmd_cntx.tx->ScheduleSingleHopT(cb);
+  if (!res) {
+    return cmd_cntx.rb->SendError(res.status());
+  }
+  auto* rb = static_cast<facade::RedisReplyBuilder*>(cmd_cntx.rb);
+  rb->StartArray(res->size());
+  for (const auto& reply : *res) {
+    rb->SendSimpleString(reply.first);
+  }
+}
+
+using CI = CommandId;
+
+#define HFUNC(x) SetHandler(&TopKeysFamily::x)
+
+void TopKeysFamily::Register(CommandRegistry* registry) {
+  registry->StartFamily();
+
+  *registry << CI{"TOPK.RESERVE", CO::WRITE | CO::DENYOOM, -2, 1, 1, acl::TOPK}.HFUNC(Reserve)
+            << CI{"TOPK.LIST", CO::WRITE | CO::DENYOOM, -1, 1, 1, acl::TOPK}.HFUNC(List)
+            << CI{"TOPK.ADD", CO::WRITE | CO::DENYOOM, -2, 1, 1, acl::TOPK}.HFUNC(Add);
+};
+
+}  // namespace dfly

--- a/src/server/topk_family.h
+++ b/src/server/topk_family.h
@@ -1,0 +1,24 @@
+// Copyright 2025, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include "server/common.h"
+
+namespace dfly {
+
+class CommandRegistry;
+struct CommandContext;
+
+class TopKeysFamily {
+ public:
+  static void Register(CommandRegistry* registry);
+
+ private:
+  static void Reserve(CmdArgList args, const CommandContext& cmd_cntx);
+  static void Add(CmdArgList args, const CommandContext& cmd_cntx);
+  static void List(CmdArgList args, const CommandContext& cmd_cntx);
+};
+
+}  // namespace dfly


### PR DESCRIPTION
Add basic support for topk data structure in compact object and also implement prototypes for topk.reserve, topk.add and topk.list.

* add support for topk ds in compact object
* add topk.reserve prototype
* add topk.add prototype
* add topk.list prototype