### PR TITLE
fix: collapsing logic in CapturingReplyBuilder

### DIFF
--- a/src/facade/reply_builder_test.cc
+++ b/src/facade/reply_builder_test.cc
@@ -807,8 +807,6 @@ TEST_F(RedisReplyBuilderTest, SendLabeledScoredArray) {
 }
 
 TEST_F(RedisReplyBuilderTest, BasicCapture) {
-  GTEST_SKIP() << "Unmark when CaptuingReplyBuilder is updated";
-
   using namespace std;
   string_view kTestSws[] = {"a1"sv, "a2"sv, "a3"sv, "a4"sv};
 
@@ -868,8 +866,8 @@ TEST_F(RedisReplyBuilderTest, BasicCapture) {
   for (auto& f : funcs) {
     f(builder_.get());
     auto expected = TakePayload();
-    // f(&crb);
-    // CapturingReplyBuilder::Apply(crb.Take(), builder_.get());
+    f(&crb);
+    CapturingReplyBuilder::Apply(crb.Take(), builder_.get());
     auto actual = TakePayload();
     EXPECT_EQ(expected, actual);
   }

--- a/src/facade/reply_capture.cc
+++ b/src/facade/reply_capture.cc
@@ -85,7 +85,7 @@ void CapturingReplyBuilder::Capture(Payload val, bool collapse_if_needed) {
   if (!stack_.empty()) {
     auto& last = stack_.top();
     last.first->arr.push_back(std::move(val));
-    if (collapse_if_needed && last.second-- == 1) {
+    if (last.second-- == 1 && collapse_if_needed) {
       CollapseFilledCollections();
     }
   } else {

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -954,6 +954,10 @@ void DebugCmd::Exec(facade::SinkReplyBuilder* builder) {
 
 void DebugCmd::LogTraffic(CmdArgList args, facade::SinkReplyBuilder* builder) {
   optional<string> path;
+  if (ProactorBase::me()->GetKind() != ProactorBase::IOURING) {
+    return builder->SendError("Traffic recording supported only on iouring");
+  }
+
   if (args.size() == 1 && absl::AsciiStrToUpper(facade::ToSV(args.front())) != "STOP"sv) {
     path = ArgS(args, 0);
     LOG(INFO) << "Logging to traffic to " << *path << "*.bin";


### PR DESCRIPTION
The bug - we have not unwinded collections correctly. Apparently, we did not have testing coverage for CapturingReplyBuilder because the test was disabled due to historic reasons.

The fix: enable the test, make sure it reproduced the problem and fix the bug by correctly updating the pending collection length.

Fixes #5132

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->