### PR TITLE
fix: out of bounds SIMD access

### DIFF
--- a/src/core/sse_port.h
+++ b/src/core/sse_port.h
@@ -4,6 +4,7 @@
 
 #pragma once
 #if defined(__aarch64__)
+#define SSE2NEON_SUPPRESS_WARNINGS
 #include "base/sse2neon.h"
 #elif defined(__riscv) || defined(__riscv__)
 #include "base/sse2rvv.h"
@@ -16,13 +17,8 @@
 
 namespace dfly {
 
-#if defined(__clang__)
-__attribute__((no_sanitize_address))
-#endif
-
 #ifndef __s390x__
-inline __m128i
-mm_loadu_si128(const __m128i* ptr) {
+inline __m128i mm_loadu_si128(const __m128i* ptr) {
 #if defined(__aarch64__)
   __m128i res;
   memcpy(&res, ptr, sizeof(res));


### PR DESCRIPTION
Fixes the regression introduced by #5083
The bug: accessing 2 bytes out of bounds when reading the source string. While the algorithm discards those bytes when doing decoding, it still can cause segfaults because these two bytes could belong to a new memory page that is not part of the process space.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->