### PR TITLE
chore: optimize modulo operations for powers of two

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -1215,7 +1215,7 @@ void CompactObj::SetExternal(size_t offset, uint32_t sz) {
   SetMeta(EXTERNAL_TAG, mask_);
 
   u_.ext_ptr.is_cool = 0;
-  u_.ext_ptr.page_offset = offset % 4096;
+  u_.ext_ptr.page_offset = offset & 4095;
   u_.ext_ptr.serialized_size = sz;
   u_.ext_ptr.offload.page_index = offset / 4096;
 }
@@ -1225,7 +1225,7 @@ void CompactObj::SetCool(size_t offset, uint32_t sz, detail::TieredColdRecord* r
   SetMeta(EXTERNAL_TAG, record->value.mask_);
 
   u_.ext_ptr.is_cool = 1;
-  u_.ext_ptr.page_offset = offset % 4096;
+  u_.ext_ptr.page_offset = offset & 4095;
   u_.ext_ptr.serialized_size = sz;
   u_.ext_ptr.cool_record = record;
 }

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -183,7 +183,7 @@ optional<facade::ErrorReply> CommandId::Validate(CmdArgList tail_args) const {
 
   if ((opt_mask() & CO::INTERLEAVED_KEYS)) {
     if ((name() == "JSON.MSET" && tail_args.size() % 3 != 0) ||
-        (name() == "MSET" && tail_args.size() % 2 != 0))
+        (name() == "MSET" && (tail_args.size() & 1) != 0))
       return facade::ErrorReply{facade::WrongNumArgsError(name()), kSyntaxErrType};
   }
 

--- a/src/server/dfly_bench.cc
+++ b/src/server/dfly_bench.cc
@@ -695,7 +695,7 @@ void Driver::Run(uint64_t* cycle_ns, CommandGenerator* cmd_gen) {
         do {
           ThisFiber::SleepFor(chrono::nanoseconds(sleep_ns));
         } while (should_throttle && reqs_.size() > pipeline * 2);
-      } else if (i % 256 == 255) {
+      } else if ((i & 255) == 255) {
         ThisFiber::Yield();
         VLOG(5) << "Behind QPS schedule";
       }

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -666,7 +666,7 @@ void OpScan(const OpArgs& op_args, const ScanOpts& scan_opts, uint64_t* cursor, 
 
 uint64_t ScanGeneric(uint64_t cursor, const ScanOpts& scan_opts, StringVec* keys,
                      ConnectionContext* cntx) {
-  ShardId sid = cursor % 1024;
+  ShardId sid = cursor & 1023;
 
   EngineShardSet* ess = shard_set;
   unsigned shard_count = ess->size();

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -95,7 +95,7 @@ pair<uint8_t*, bool> LpInsert(uint8_t* lp, string_view field, string_view val, b
 
       /* Replace value */
       lp = lpReplace(lp, &vptr, vsrc, val.size());
-      DCHECK_EQ(0u, lpLength(lp) % 2);
+      DCHECK_EQ(0u, lpLength(lp) & 1);
     }
   }
 
@@ -477,7 +477,7 @@ OpResult<vector<OptStr>> OpHMGet(const OpArgs& op_args, std::string_view key, Cm
     }
 
     size_t lplen = lpLength(lp);
-    DCHECK(lplen > 0 && lplen % 2 == 0);
+    DCHECK(lplen > 0 && (lplen & 1) == 0);
 
     uint8_t ibuf[32];
     string_view key;
@@ -671,7 +671,7 @@ struct OpSetParams {
 
 OpResult<uint32_t> OpSet(const OpArgs& op_args, string_view key, CmdArgList values,
                          const OpSetParams& op_sp = OpSetParams{}) {
-  DCHECK(!values.empty() && 0 == values.size() % 2);
+  DCHECK(!values.empty() && 0 == (values.size() & 1));
   VLOG(2) << "OpSet(" << key << ")";
 
   auto& db_slice = op_args.GetDbSlice();
@@ -820,7 +820,7 @@ void HSetEx(CmdArgList args, const CommandContext& cmd_cntx) {
 
   CmdArgList fields = parser.Tail();
 
-  if (fields.size() % 2 != 0) {
+  if ((fields.size() & 1) != 0) {
     return cmd_cntx.rb->SendError(facade::WrongNumArgsError(cmd_cntx.conn_cntx->cid->name()),
                                   kSyntaxErrType);
   }
@@ -1108,7 +1108,7 @@ void HSetFamily::HSet(CmdArgList args, const CommandContext& cmd_cntx) {
 
   string_view cmd{cmd_cntx.conn_cntx->cid->name()};
 
-  if (args.size() % 2 != 1) {
+  if ((args.size() & 1) != 1) {
     return cmd_cntx.rb->SendError(facade::WrongNumArgsError(cmd), kSyntaxErrType);
   }
 
@@ -1234,7 +1234,7 @@ void HSetFamily::HRandField(CmdArgList args, const CommandContext& cmd_cntx) {
     } else if (pv.Encoding() == kEncodingListPack) {
       uint8_t* lp = (uint8_t*)pv.RObjPtr();
       size_t lplen = lpLength(lp);
-      CHECK(lplen > 0 && lplen % 2 == 0);
+      CHECK(lplen > 0 && (lplen & 1) == 0);
       size_t hlen = lplen / 2;
       if (args.size() == 1) {
         listpackEntry key;
@@ -1275,7 +1275,7 @@ void HSetFamily::HRandField(CmdArgList args, const CommandContext& cmd_cntx) {
       rb->SendBulkString(result->front());
     else if (with_values) {
       const auto result_size = result->size();
-      DCHECK(result_size % 2 == 0)
+      DCHECK((result_size & 1) == 0)
           << "unexpected size of strings " << result_size << ", expected pairs";
       SinkReplyBuilder::ReplyScope scope{rb};
       const bool is_resp3 = rb->IsResp3();

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -442,7 +442,7 @@ void RdbLoaderBase::OpaqueObjLoader::CreateHMap(const LoadTrace* ltrace) {
   if (keep_lp) {
     uint8_t* lp = lpNew(lp_size);
 
-    CHECK(ltrace->arr.size() % 2 == 0);
+    CHECK((ltrace->arr.size() & 1) == 0);
     for (size_t i = 0; i < ltrace->arr.size(); i += 2) {
       /* Add pair to listpack */
       string_view sv = ToSV(ltrace->arr[i].rdb_var);

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -3172,7 +3172,7 @@ void ServerFamily::ReplConf(CmdArgList args, const CommandContext& cmd_cntx) {
     builder->SendError(kSyntaxErr);
   };
 
-  if (args.size() % 2 == 1)
+  if ((args.size() & 1) == 1)
     return err_cb();
 
   auto* cntx = cmd_cntx.conn_cntx;

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -674,7 +674,7 @@ bool JournalAsMinId(const TrimOpts& opts) {
 
 OpResult<streamID> OpAdd(const OpArgs& op_args, string_view key, const AddOpts& opts,
                          CmdArgList args, AddArgsJournaler journaler) {
-  DCHECK(!args.empty() && args.size() % 2 == 0);
+  DCHECK(!args.empty() && (args.size() & 1) == 0);
 
   auto& db_slice = op_args.GetDbSlice();
 
@@ -2247,7 +2247,7 @@ std::optional<ReadOpts> ParseReadArgsOrReply(CmdArgList args, bool read_group,
       opts.streams_arg = id_indx + 1;
 
       size_t pair_count = args.size() - opts.streams_arg;
-      if ((pair_count % 2) != 0) {
+      if ((pair_count & 1) != 0) {
         const char* cmd_name = read_group ? "xreadgroup" : "xread";
         const char* symbol = read_group ? ">" : "$";
         const auto msg = absl::StrCat("Unbalanced '", cmd_name,
@@ -2709,7 +2709,7 @@ void StreamFamily::XAdd(CmdArgList args, const CommandContext& cmd_cntx) {
   AddArgsJournaler journaler{{args.begin(), args.end()}, stream_id_index_in_args};
 
   CmdArgList fields = parser.Tail();
-  if (fields.empty() || fields.size() % 2 != 0) {
+  if (fields.empty() || (fields.size() & 1) != 0) {
     return rb->SendError(WrongNumArgsError("XADD"), kSyntaxErrType);
   }
 

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -379,7 +379,7 @@ OpResult<int64_t> OpIncrBy(const OpArgs& op_args, string_view key, int64_t incr,
 
 // Returns true if keys were set, false otherwise.
 OpStatus OpMSet(const OpArgs& op_args, const ShardArgs& args) {
-  DCHECK(!args.Empty() && args.Size() % 2 == 0);
+  DCHECK(!args.Empty() && (args.Size() & 1) == 0);
 
   SetCmd::SetParams params;
   SetCmd sg(op_args, false);

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -2062,7 +2062,7 @@ void ZSetFamily::ZAdd(CmdArgList args, const CommandContext& cmd_cntx) {
   }
 
   auto* builder = cmd_cntx.rb;
-  if ((args.size() - i) % 2 != 0) {
+  if (((args.size() - i) & 1) != 0) {
     builder->SendError(kSyntaxErr);
     return;
   }


### PR DESCRIPTION
Replaced expressions like `value % 2` with bitwise equivalents like `(value & 1)`.
This is mathematically identical for powers of two but slightly faster, since bitwise operations are cheaper than modulo.