### PR TITLE
chore: enable simd optimizations for aarch64

### DIFF
--- a/src/core/compact_object_test.cc
+++ b/src/core/compact_object_test.cc
@@ -700,29 +700,6 @@ static void ascii_pack_naive(const char* ascii, size_t len, uint8_t* bin) {
   }
 }
 
-static void ascii_unpack_naive(const uint8_t* bin, size_t ascii_len, char* ascii) {
-  constexpr uint8_t kM = 0x7F;
-  uint8_t p = 0;
-  unsigned i = 0;
-
-  while (ascii_len >= 8) {
-    for (i = 0; i < 7; ++i) {
-      uint8_t src = *bin;  // keep on stack in case we unpack inplace.
-      *ascii++ = (p >> (8 - i)) | ((src << i) & kM);
-      p = src;
-      ++bin;
-    }
-
-    ascii_len -= 8;
-    *ascii++ = p >> 1;
-  }
-
-  DCHECK_LT(ascii_len, 8u);
-  for (i = 0; i < ascii_len; ++i) {
-    *ascii++ = *bin++;
-  }
-}
-
 static void BM_PackNaive(benchmark::State& state) {
   string val(1024, 'a');
   uint8_t buf[1024];
@@ -743,16 +720,6 @@ static void BM_Pack(benchmark::State& state) {
 }
 BENCHMARK(BM_Pack);
 
-static void BM_Pack2(benchmark::State& state) {
-  string val(1024, 'a');
-  uint8_t buf[1024];
-
-  while (state.KeepRunning()) {
-    detail::ascii_pack(val.data(), val.size(), buf);
-  }
-}
-BENCHMARK(BM_Pack2);
-
 static void BM_PackSimd(benchmark::State& state) {
   string val(1024, 'a');
   uint8_t buf[1024];
@@ -772,18 +739,6 @@ static void BM_PackSimd2(benchmark::State& state) {
   }
 }
 BENCHMARK(BM_PackSimd2);
-
-static void BM_UnpackNaive(benchmark::State& state) {
-  string val(1024, 'a');
-  uint8_t buf[1024];
-
-  detail::ascii_pack(val.data(), val.size(), buf);
-
-  while (state.KeepRunning()) {
-    ascii_unpack_naive(buf, val.size(), val.data());
-  }
-}
-BENCHMARK(BM_UnpackNaive);
 
 static void BM_Unpack(benchmark::State& state) {
   string val(1024, 'a');


### PR DESCRIPTION
for ascii pack and unpack,

Also optimize scalar unpack for both x86 and aarch64.
We had to fix the bug in https://github.com/dragonflydb/dragonfly/pull/5140 and now we load chunks of 7 bytes
during unpacking. This greatly degraded the performance of
scalar unpack, so we now use the "naive" byte by byte implementation
which actually faster then using 7-byte loads on both x86 and aarch64.

On c4a (aarch64):

Benchmarks before:
```
------------------------------------------------------------
Benchmark                  Time             CPU   Iterations
------------------------------------------------------------
BM_PackNaive             222 ns          222 ns     18936335
BM_Pack                  222 ns          222 ns     18956309
BM_Pack2                 222 ns          222 ns     18951694
BM_PackSimd              220 ns          220 ns     19103906
BM_PackSimd2             223 ns          223 ns     18861252
BM_UnpackNaive           229 ns          229 ns     18228081
BM_Unpack                743 ns          743 ns      5643824
BM_UnpackSimd            744 ns          744 ns      5648469
```

Benchmarks after:
```
------------------------------------------------------------
Benchmark                  Time             CPU   Iterations
------------------------------------------------------------
BM_PackNaive             221 ns          221 ns     18971332
BM_Pack                  222 ns          221 ns     18963948
BM_PackSimd             97.2 ns         97.2 ns     43226095
BM_PackSimd2            96.6 ns         96.6 ns     43491371
BM_Unpack                228 ns          228 ns     18397585
BM_UnpackSimd            101 ns          101 ns     41733901

```

We improved scalar unpack by x3 from 743ns to 228ns, and improved vectorized unpack by x7.
We improved vectorized pack by x2.


On graviton2 (c6g):

before:
```
BM_PackNaive             465 ns          465 ns      1507214
BM_Pack                  434 ns          434 ns      1613102
BM_Pack2                 434 ns          434 ns      1613125
BM_PackSimd              434 ns          434 ns      1612817
BM_PackSimd2             434 ns          434 ns      1612666
BM_UnpackNaive           519 ns          519 ns      1347286
BM_Unpack                927 ns          927 ns       755409
BM_UnpackSimd            929 ns          929 ns       753418
```

after:

```
------------------------------------------------------------
Benchmark                  Time             CPU   Iterations
------------------------------------------------------------
BM_PackNaive             463 ns          463 ns      1511640
BM_Pack                  434 ns          434 ns      1612481
BM_PackSimd              241 ns          241 ns      2912345
BM_PackSimd2             239 ns          238 ns      2940373
BM_Unpack                515 ns          514 ns      1362422
BM_UnpackSimd            271 ns          271 ns      2581556
```

BM_PackSimd twice faster, BM_UnpackSimd x3.5 faster.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->