### PR TITLE
pytest: Add sleep to let master stop propagate to replica

### DIFF
--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2279,6 +2279,9 @@ async def test_replica_reconnect(df_factory, break_conn):
     # kill existing master, create master with different repl_id but same port
     master_port = master.port
     master.stop()
+
+    await asyncio.sleep(1)
+
     repl_info = await c_replica.info("REPLICATION")
     assert repl_info["master_link_status"] == "down", str(repl_info)
 


### PR DESCRIPTION
The test changed in this PR `test_replica_reconnect` is failing often where the replica does not see updated master link status, after master is terminated. The replica code path may take some time to set the flags in its state mask. Adding a sleep may help with avoiding this test failure.
