### PR TITLE
fix: Prevent crash in PFCOUNT when using keys of different types

### DIFF
--- a/src/server/hll_family.cc
+++ b/src/server/hll_family.cc
@@ -208,17 +208,25 @@ OpResult<int64_t> PFCountMulti(CmdArgList args, const CommandContext& cmd_cntx) 
   vector<vector<string>> hlls;
   hlls.resize(shard_set->size());
 
+  OpStatus status = OpStatus::OK;
   auto cb = [&](Transaction* t, EngineShard* shard) {
     ShardId sid = shard->shard_id();
     ShardArgs shard_args = t->GetShardArgs(shard->shard_id());
     auto result = ReadValues(t->GetOpArgs(shard), shard_args);
     if (result.ok()) {
       hlls[sid] = std::move(result.value());
+    } else {
+      status = result.status();
     }
-    return result.status();
+    return OpStatus::OK;
   };
 
-  cmd_cntx.tx->ScheduleSingleHop(std::move(cb));
+  OpStatus cb_status = cmd_cntx.tx->ScheduleSingleHop(std::move(cb));
+
+  // If there was an error in the execution of ReadValues, return it
+  if (cb_status != OpStatus::OK || status != OpStatus::OK) {
+    return status != OpStatus::OK ? status : cb_status;
+  }
 
   vector<HllBufferPtr> ptrs = ConvertShardVector(hlls);
   int64_t pf_count = pfcountMulti(ptrs.data(), ptrs.size());

--- a/src/server/hll_family_test.cc
+++ b/src/server/hll_family_test.cc
@@ -156,6 +156,15 @@ TEST_F(HllFamilyTest, CountMultiple) {
   EXPECT_EQ(CheckedInt({"pfcount", "key1", "key4"}), 5);
 }
 
+TEST_F(HllFamilyTest, CountMultipleWithWrongType) {
+  EXPECT_EQ(Run({"set", "key1", "value1"}), "OK");
+  EXPECT_EQ(CheckedInt({"pfadd", "key", "value"}), 1);
+  EXPECT_EQ(CheckedInt({"pfadd", "list1 element1", "data"}), 1);
+
+  EXPECT_THAT(Run({"pfcount", "key1", "key", "list1 element1"}),
+              ErrArg("Key is not a valid HyperLogLog string value."));
+}
+
 TEST_F(HllFamilyTest, MergeToNew) {
   EXPECT_EQ(CheckedInt({"pfadd", "key1", "1", "2", "3"}), 1);
   EXPECT_EQ(CheckedInt({"pfadd", "key2", "4", "5"}), 1);


### PR DESCRIPTION
Fixes: https://github.com/dragonflydb/dragonfly/issues/5159
PFCOUNT command crashes when arguments include keys of different types (regular strings and HyperLogLog) due to improper WRONG_TYPE error handling in the transaction flow.

Fixed PFCountMulti to properly propagate WRONG_TYPE errors. Modified callback to always return OpStatus::OK while tracking errors separately.
