### PR TITLE
chore: lower log level for harmless "Invalid Json path" warnings

### DIFF
--- a/src/server/search/doc_accessors.cc
+++ b/src/server/search/doc_accessors.cc
@@ -364,7 +364,7 @@ JsonAccessor::JsonPathContainer* JsonAccessor::GetPath(std::string_view field) c
   }
 
   if (!ptr) {
-    LOG(WARNING) << "Invalid Json path: " << field << ' ' << ec_msg;
+    VLOG(1) << "Invalid Json path: " << field << ' ' << ec_msg;
     return nullptr;
   }
 

--- a/src/server/search/doc_accessors.cc
+++ b/src/server/search/doc_accessors.cc
@@ -364,6 +364,9 @@ JsonAccessor::JsonPathContainer* JsonAccessor::GetPath(std::string_view field) c
   }
 
   if (!ptr) {
+    // This can occur for fields that are not actual JSON paths but are computed aliases
+    // (e.g., 'vector_distance' from a KNN search clause in FT.SEARCH RETURN).
+    // Such fields are valid for return but won't be found as paths in the document.
     VLOG(1) << "Invalid Json path: " << field << ' ' << ec_msg;
     return nullptr;
   }


### PR DESCRIPTION
Fixes: https://github.com/dragonflydb/dragonfly/issues/5125

This PR addresses the issue of excessive "Invalid Json path" warnings in the logs when using computed fields (e.g., vector_distance from KNN search) in FT.SEARCH RETURN clauses.

Although the search functionality itself worked correctly and returned the computed values, these warnings cluttered the logs unnecessarily.

This change modifies `JsonAccessor::GetPath` to use `VLOG(1)` instead of `LOG(WARNING)` when a JSON path cannot be parsed or an expression cannot be created. This silences these specific warnings under normal log levels, as they are not indicative of an actual error when dealing with fields that are computed and not expected to be found within the JSON document structure.

This approach simplifies the solution by avoiding complex logic to explicitly mark fields as "computed" throughout the search parameter parsing and processing stages.