### PR TITLE
fix: prevent crash in GEORADIUS argument parsing

### DIFF
--- a/src/server/geo_family.cc
+++ b/src/server/geo_family.cc
@@ -825,7 +825,11 @@ void GeoFamily::GeoRadius(CmdArgList args, const CommandContext& cmd_cntx) {
         geo_ops.withhash = true;
         break;
       default:
-        return builder->SendError(kSyntaxErr);
+        // If MapNext failed, it means an unknown option was provided or
+        // an option requiring an argument was missing its argument.
+        // The parser has already recorded the error. We retrieve it and send it.
+        DCHECK(parser.Error().has_value());
+        return builder->SendError(parser.Error()->MakeReply());
     }
   }
 

--- a/src/server/geo_family_test.cc
+++ b/src/server/geo_family_test.cc
@@ -285,6 +285,12 @@ TEST_F(GeoFamilyTest, GeoRadius) {
   resp = Run({"ZRANGE", "store_dist_key", "0", "-1", "WITHSCORES"});
   EXPECT_THAT(resp,
               RespArray(ElementsAre("Madrid", DoubleArg(0), "Lisbon", DoubleArg(502.207694))));
+
+  // Test with STORE and other options
+  resp = Run({"GEORADIUS", "key:poq6moq\\r", "111.38360132204588", "-71.17374967857494",
+              "69.77510489600115", "ft", "key", "WITHDIST", "COUNT", "key", "WITHCOORD", "count",
+              "WITHHASH", "STORE"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
 }
 
 }  // namespace dfly


### PR DESCRIPTION
Fixes: https://github.com/dragonflydb/dragonfly/issues/5165

`GEORADIUS` could crash due to improper handling of parser errors when encountering unknown or malformed optional arguments. The parser's error state is now correctly processed, and an error is returned to the client.