### PR TITLE
chore: Add option to ignore parsing errors in replay tool

### DIFF
--- a/tools/replay/main.go
+++ b/tools/replay/main.go
@@ -17,6 +17,7 @@ var fHost = flag.String("host", "127.0.0.1:6379", "Redis host")
 var fClientBuffer = flag.Int("buffer", 100, "How many records to buffer per client")
 var fPace = flag.Bool("pace", true, "whether to pace the traffic according to the original timings.false - to pace as fast as possible")
 var fSkip = flag.Uint("skip", 0, "skip N records")
+var fIgnoreParseErrors = flag.Bool("ignore-parse-errors", false, "ignore parsing errors")
 
 func RenderTable(area *pterm.AreaPrinter, files []string, workers []FileWorker) {
 	tableData := pterm.TableData{{"file", "parsed", "processed", "delayed", "clients", "avg(us)", "p50(us)", "p75(us)", "p90(us)", "p99(us)"}}
@@ -127,7 +128,7 @@ func Print(files []string) {
 			parseRecords(file, func(r Record) bool {
 				ch <- r
 				return true
-			})
+			}, *fIgnoreParseErrors)
 			close(ch)
 			wg.Done()
 		}(tops[i].ch, file)
@@ -181,7 +182,7 @@ func Analyze(files []string) {
 			cmdCounts[r.values[0].(string)] += 1
 
 			return true
-		})
+		}, *fIgnoreParseErrors)
 
 		clients += len(fileClients)
 	}

--- a/tools/replay/parsing.go
+++ b/tools/replay/parsing.go
@@ -40,7 +40,7 @@ func parseStrings(file io.Reader) (out []interface{}, err error) {
 	return
 }
 
-func parseRecords(filename string, cb func(Record) bool) error {
+func parseRecords(filename string, cb func(Record) bool, ignoreErrors bool) error {
 	file, err := os.Open(filename)
 	if err != nil {
 		return err
@@ -69,7 +69,12 @@ func parseRecords(filename string, cb func(Record) bool) error {
 		rec.values, err = parseStrings(reader)
 		if err != nil {
 			log.Printf("Could not parse %vth record", recordNum)
-			return err
+			if !ignoreErrors {
+				return err
+			}
+			log.Printf("Ignoring parse error and continuing")
+			recordNum++
+			continue
 		}
 
 		if !cb(rec) {

--- a/tools/replay/workers.go
+++ b/tools/replay/workers.go
@@ -35,7 +35,7 @@ func DetermineBaseTime(files []string) time.Time {
 				minTime = r.Time
 			}
 			return false
-		})
+		}, *fIgnoreParseErrors)
 	}
 	return time.Unix(0, int64(minTime))
 }
@@ -173,7 +173,7 @@ func (w *FileWorker) Run(file string, wg *sync.WaitGroup) {
 		atomic.AddUint64(&w.parsed, 1)
 		client.incoming <- r
 		return true
-	})
+	}, *fIgnoreParseErrors)
 
 	if err != nil {
 		log.Fatalf("Could not parse records for file %s: %v", file, err)


### PR DESCRIPTION
This PR adds a new flag to the replay tool that allows ignoring parsing errors during replay operations.

Changes:
- Added a new command-line flag -ignore-parse-errors (default: false)
- Modified the parseRecords function to accept an additional ignoreErrors parameter
- When errors occur during parsing and the flag is enabled, the tool will log the error but continue processing subsequent records instead of aborting

Usage:
```
./traffic-replay -ignore-parse-errors run traffic-*.bin
```

This enhancement improves resilience when dealing with partially corrupted replay files, allowing the tool to extract and process as much valid data as possible instead of failing completely on the first error.