### PR TITLE
replication: Ensure snapshot fiber joined in all code paths

### DIFF
--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -115,6 +115,9 @@ void SliceSnapshot::FinalizeJournalStream(bool cancel) {
   VLOG(1) << "FinalizeJournalStream";
   DCHECK(db_slice_->shard_owner()->IsMyThread());
   if (!journal_cb_id_) {  // Finalize only once.
+    // In case of incremental snapshotting in StartIncremental, if an error is encountered,
+    // journal_cb_id_ may not be set, but the snapshot fiber is still running.
+    snapshot_fb_.JoinIfNeeded();
     return;
   }
   uint32_t cb_id = journal_cb_id_;


### PR DESCRIPTION
While replicating data through the incremental snapshot code path, if an error occurs, the journal callback id is not set. When finalizing the stream, this id is used to decide on early return.

In the error code path mentioned above, the snapshot fiber may end up not being joined by the time the containing object is destroyed, triggering an assertion (and generally leaving things in an inconsistent state).

To avoid this even if journal callback id is 0, we still wait for the snapshot fiber.

FIXES #5135 