### PR TITLE
chore(dash_table): pass memory resource to segment

### DIFF
--- a/src/core/dash.h
+++ b/src/core/dash.h
@@ -49,7 +49,7 @@ class DashTable : public detail::DashTableBase {
   using bucket_iterator = Iterator<false, true>;
   using Cursor = detail::DashCursor;
 
-  struct HotspotBuckets {
+  struct HotBuckets {
     static constexpr size_t kRegularBuckets = 4;
     static constexpr size_t kNumBuckets = kRegularBuckets + SegmentType::kStashBucketNum;
 
@@ -807,12 +807,12 @@ auto DashTable<_Key, _Value, Policy>::InsertInternal(U&& key, V&& value, Evictio
     // try garbage collect or evict.
     if constexpr (EvictionPolicy::can_evict || EvictionPolicy::can_gc) {
       // Try gc.
-      uint8_t bid[HotspotBuckets::kRegularBuckets];
+      uint8_t bid[HotBuckets::kRegularBuckets];
       SegmentType::FillProbeArray(key_hash, bid);
-      HotspotBuckets hotspot;
+      HotBuckets hotspot;
       hotspot.key_hash = key_hash;
 
-      for (unsigned j = 0; j < HotspotBuckets::kRegularBuckets; ++j) {
+      for (unsigned j = 0; j < HotBuckets::kRegularBuckets; ++j) {
         hotspot.probes.by_type.regular_buckets[j] = bucket_iterator{this, target_seg_id, bid[j]};
       }
 
@@ -820,7 +820,7 @@ auto DashTable<_Key, _Value, Policy>::InsertInternal(U&& key, V&& value, Evictio
         hotspot.probes.by_type.stash_buckets[i] =
             bucket_iterator{this, target_seg_id, uint8_t(Policy::kBucketNum + i), 0};
       }
-      hotspot.num_buckets = HotspotBuckets::kNumBuckets;
+      hotspot.num_buckets = HotBuckets::kNumBuckets;
 
       // The difference between gc and eviction is that gc can be applied even if
       // the table can grow since we throw away logically deleted items.
@@ -831,8 +831,8 @@ auto DashTable<_Key, _Value, Policy>::InsertInternal(U&& key, V&& value, Evictio
         if (res) {
           // We succeeded to gc. Lets continue with the momentum.
           // In terms of API abuse it's an awful hack, just to see if it works.
-          /*unsigned start = (bid[HotspotBuckets::kNumBuckets - 1] + 1) % kLogicalBucketNum;
-          for (unsigned i = 0; i < HotspotBuckets::kNumBuckets; ++i) {
+          /*unsigned start = (bid[HotBuckets::kNumBuckets - 1] + 1) % kLogicalBucketNum;
+          for (unsigned i = 0; i < HotBuckets::kNumBuckets; ++i) {
             uint8_t id = (start + i) % kLogicalBucketNum;
             buckets.probes.arr[i] = bucket_iterator{this, target_seg_id, id};
           }

--- a/src/core/dash_test.cc
+++ b/src/core/dash_test.cc
@@ -143,7 +143,7 @@ constexpr size_t kSegSize = sizeof(Segment);
 
 class DashTest : public testing::Test {
  protected:
-  static void SetUpTestCase() {
+  static void SetUpTestSuite() {
     init_zmalloc_threadlocal(mi_heap_get_backing());
   }
 
@@ -669,7 +669,7 @@ struct TestEvictionPolicy {
   void RecordSplit(Dash64::Segment_t*) {
   }
 
-  unsigned Evict(const Dash64::HotspotBuckets& hotb, Dash64* me) const {
+  unsigned Evict(const Dash64::HotBuckets& hotb, Dash64* me) const {
     if (!evict_enabled)
       return 0;
 
@@ -840,7 +840,7 @@ struct A {
   }
 
   A& operator=(const A&) = delete;
-  A& operator=(A&& o) {
+  A& operator=(A&& o) noexcept {
     o.moved = o.moved + 1;
     a = o.a;
     o.a = -1;
@@ -988,8 +988,8 @@ struct SimpleEvictPolicy {
   // Required interface in case can_gc is true
   // returns number of items evicted from the table.
   // 0 means - nothing has been evicted.
-  unsigned Evict(const U64Dash::HotspotBuckets& hotb, U64Dash* me) {
-    constexpr unsigned kBucketNum = U64Dash::HotspotBuckets::kNumBuckets;
+  unsigned Evict(const U64Dash::HotBuckets& hotb, U64Dash* me) {
+    constexpr unsigned kBucketNum = U64Dash::HotBuckets::kNumBuckets;
 
     uint32_t bid = hotb.key_hash % kBucketNum;
 
@@ -1030,7 +1030,7 @@ struct ShiftRightPolicy {
   void RecordSplit(U64Dash::Segment_t* segment) {
   }
 
-  unsigned Evict(const U64Dash::HotspotBuckets& hotb, U64Dash* me) {
+  unsigned Evict(const U64Dash::HotBuckets& hotb, U64Dash* me) {
     constexpr unsigned kNumStashBuckets = ABSL_ARRAYSIZE(hotb.probes.by_type.stash_buckets);
 
     unsigned stash_pos = hotb.key_hash % kNumStashBuckets;


### PR DESCRIPTION
1. Currently, memory resource is not used - only passed if needed.
This is needed for https://github.com/dragonflydb/dragonfly/issues/5073

2. HotspotBuckets are renamed to HotBuckets.
3. Move TryInsertToBucket function to bucket level

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->