### PR TITLE
fix(parser): Parse correctly split simple response or error msg in client mode

### DIFF
--- a/src/facade/redis_parser.cc
+++ b/src/facade/redis_parser.cc
@@ -422,13 +422,18 @@ auto RedisParser::ParseArg(Buffer str) -> ResultConsumed {
   const char* s = reinterpret_cast<const char*>(str.data());
   const char* eol = reinterpret_cast<const char*>(memchr(s, '\n', str.size()));
 
-  // TODO: in client mode we still may not consume everything (see INPUT_PENDING below).
-  // It's not a problem, because we need consume all the input only in server mode.
-
   if (arg_c_ == '+' || arg_c_ == '-') {  // Simple string or error.
     DCHECK(!server_mode_);
     if (!eol) {
-      Result r = str.size() < 256 ? INPUT_PENDING : BAD_STRING;
+      // if eol is not found we should still read input as bulk string
+      cached_expr_->emplace_back(RespExpr::STRING);
+      cached_expr_->back().u = Buffer{};
+      bulk_len_ = str.length();
+      // eol is not found but if '\r' is present decrease bulk_len
+      if (s[bulk_len_ - 1] == '\r')
+        bulk_len_--;
+      state_ = BULK_STR_S;
+      Result r = str.size() < 256 ? OK : BAD_STRING;
       return {r, 0};
     }
 
@@ -479,6 +484,16 @@ auto RedisParser::ConsumeBulk(Buffer str) -> ResultConsumed {
   uint32_t consumed = 0;
   auto& bulk_str = get<Buffer>(cached_expr_->back().u);
 
+  bool extend = false;
+  // Handle split simple message or error in client mode
+  if (!server_mode_ && (arg_c_ == '+' || arg_c_ == '-') && !bulk_len_) {
+    // Search first '\r' in next partial message which ends bulk string
+    const char* s = reinterpret_cast<const char*>(str.data());
+    const char* pos = reinterpret_cast<const char*>(memchr(s, '\r', str.size()));
+    bulk_len_ = pos ? pos - s : str.size();
+    extend = true;
+  }
+
   if (str.size() >= bulk_len_) {
     consumed = bulk_len_;
     if (bulk_len_) {
@@ -487,6 +502,8 @@ auto RedisParser::ConsumeBulk(Buffer str) -> ResultConsumed {
       if (is_broken_token_) {
         memcpy(const_cast<uint8_t*>(bulk_str.end()), str.data(), bulk_len_);
         bulk_str = Buffer{bulk_str.data(), bulk_str.size() + bulk_len_};
+      } else if (extend) {
+        ExtendBulkString(Buffer(str.begin(), bulk_len_));
       } else {
         bulk_str = str.subspan(0, bulk_len_);
       }
@@ -565,6 +582,20 @@ void RedisParser::ExtendLastString(Buffer str) {
   memcpy(nb.data(), last_str.data(), last_str.size());
   memcpy(nb.data() + last_str.size(), str.data(), str.size());
   last_str = RespExpr::Buffer{nb.data(), last_str.size() + str.size()};
+  buf_stash_.back() = std::move(nb);
+}
+
+void RedisParser::ExtendBulkString(Buffer str) {
+  DCHECK(!cached_expr_->empty() && cached_expr_->back().type == RespExpr::STRING);
+
+  Buffer& bulk_str = get<Buffer>(cached_expr_->back().u);
+
+  DCHECK(bulk_str.data() == buf_stash_.back().data());
+
+  vector<uint8_t> nb(bulk_str.size() + str.size());
+  memcpy(nb.data(), bulk_str.data(), bulk_str.size());
+  memcpy(nb.data() + bulk_str.size(), str.data(), str.size());
+  bulk_str = RespExpr::Buffer{nb.data(), bulk_str.size() + str.size()};
   buf_stash_.back() = std::move(nb);
 }
 

--- a/src/facade/redis_parser.h
+++ b/src/facade/redis_parser.h
@@ -85,6 +85,7 @@ class RedisParser {
 
   void HandleFinishArg();
   void ExtendLastString(Buffer str);
+  void ExtendBulkString(Buffer str);
 
   enum State : uint8_t {
     INLINE_S,

--- a/src/facade/redis_parser_test.cc
+++ b/src/facade/redis_parser_test.cc
@@ -159,6 +159,44 @@ TEST_F(RedisParserTest, ClientMode) {
 
   ASSERT_EQ(RedisParser::OK, Parse("*3\r\n+OK\r\n$1\r\n1\r\n*2\r\n$1\r\n1\r\n$-1\r\n"));
   ASSERT_THAT(args_, ElementsAre("OK", "1", ArrLen(2)));
+
+  ASSERT_EQ(RedisParser::INPUT_PENDING, Parse("+O"));
+  EXPECT_EQ(2, consumed_);
+  ASSERT_EQ(RedisParser::INPUT_PENDING, Parse("K\r"));
+  EXPECT_EQ(2, consumed_);
+  ASSERT_EQ(RedisParser::OK, Parse("\n"));
+  ASSERT_THAT(args_, ElementsAre("OK"));
+  EXPECT_EQ(1, consumed_);
+
+  ASSERT_EQ(RedisParser::INPUT_PENDING, Parse("+OK\r"));
+  EXPECT_EQ(4, consumed_);
+  ASSERT_EQ(RedisParser::OK, Parse("\n"));
+  ASSERT_THAT(args_, ElementsAre("OK"));
+  EXPECT_EQ(1, consumed_);
+
+  ASSERT_EQ(RedisParser::INPUT_PENDING, Parse("+"));
+  EXPECT_EQ(1, consumed_);
+  ASSERT_EQ(RedisParser::INPUT_PENDING, Parse("O"));
+  EXPECT_EQ(1, consumed_);
+  ASSERT_EQ(RedisParser::INPUT_PENDING, Parse("K"));
+  EXPECT_EQ(1, consumed_);
+  ASSERT_EQ(RedisParser::INPUT_PENDING, Parse("\r"));
+  EXPECT_EQ(1, consumed_);
+  ASSERT_EQ(RedisParser::OK, Parse("\n"));
+  EXPECT_EQ(1, consumed_);
+  ASSERT_THAT(args_, ElementsAre("OK"));
+
+  ASSERT_EQ(RedisParser::INPUT_PENDING, Parse("-"));
+  EXPECT_EQ(1, consumed_);
+  ASSERT_EQ(RedisParser::OK, Parse("ERR\r\n"));
+  EXPECT_EQ(5, consumed_);
+  ASSERT_THAT(args_, ElementsAre(ErrArg("ERR")));
+
+  ASSERT_EQ(RedisParser::INPUT_PENDING, Parse("-ERR foo"));
+  EXPECT_EQ(8, consumed_);
+  ASSERT_EQ(RedisParser::OK, Parse("\r\n"));
+  EXPECT_EQ(2, consumed_);
+  ASSERT_THAT(args_, ElementsAre("ERR foo"));
 }
 
 TEST_F(RedisParserTest, Hierarchy) {


### PR DESCRIPTION
If simple response or error message is split we should still able to parse it correctly. If eol is not found in first message we are switching to bulk state where we consume messages until we read bulk correctly. Each split message will append data to bulk string until '\r\n' is found.

Fixes #5113

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->