### PR TITLE
WIP replication: Fix snapshot fiber joining on itself

### DIFF
--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -232,11 +232,12 @@ void SliceSnapshot::SwitchIncrementalFb(LSN lsn) {
     PushSerialized(true);
   } else {
     // We stopped but we didn't manage to send the whole stream.
+    // ReportError eventually cancels this snapshot operation by triggering the ReplicaInfo error
+    // handler.
     cntx_->ReportError(
         std::make_error_code(errc::state_not_recoverable),
         absl::StrCat("Partial sync was unsuccessful because entry #", lsn,
                      " was dropped from the buffer. Current lsn=", journal->GetLsn()));
-    FinalizeJournalStream(true);
   }
 }
 


### PR DESCRIPTION
On the error path for incremental snapshot, the stream is finalized from the snapshot fiber by calling `SliceSnapshot::FinalizeJournalStream`. This ends up with a join call to the snapshot fiber on itself, which triggers an assertion.

In this change the call is removed. The call is redundant and safe to remove because on the error path we call the ReportError method of the context. This context has an error handler set from the replica info, which cancels the replication. The cancel call chain ends up calling Finalize method, which makes the call removed in this change redundant.

FIXES https://github.com/dragonflydb/dragonfly/issues/5135