### PR TITLE
feat(search_family): Ignore unsupported options in the FT.CREATE command

### DIFF
--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -64,8 +64,6 @@ bool SendErrorIfOccurred(const ParseResult<T>& result, CmdArgParser* parser,
   return false;
 }
 
-static const set<string_view> kIgnoredOptions = {"WEIGHT", "SEPARATOR"};
-
 bool IsValidJsonPath(string_view path) {
   error_code ec;
   MakeJsonPathExpr(path, ec);
@@ -191,6 +189,11 @@ ParseResult<bool> ParseStopwords(CmdArgParser* parser, DocIndex* index) {
   return true;
 }
 
+constexpr std::array<const std::string_view, 6> kIgnoredOptions = {
+    "UNF"sv, "NOSTEM"sv, "CASESENSITIVE"sv, "WITHSUFFIXTRIE"sv, "INDEXMISSING"sv, "INDEXEMPTY"sv};
+constexpr std::array<const std::string_view, 3> kIgnoredOptionsWithArg = {"WEIGHT"sv, "SEPARATOR"sv,
+                                                                          "PHONETIC"sv};
+
 // SCHEMA field [AS alias] type [flags...]
 ParseResult<bool> ParseSchema(CmdArgParser* parser, DocIndex* index) {
   auto& schema = index->schema;
@@ -237,15 +240,27 @@ ParseResult<bool> ParseSchema(CmdArgParser* parser, DocIndex* index) {
       auto flag = parser->TryMapNext("NOINDEX", search::SchemaField::NOINDEX, "SORTABLE",
                                      search::SchemaField::SORTABLE);
       if (!flag) {
+        std::string_view option = parser->Peek();
+        if (std::find(kIgnoredOptions.begin(), kIgnoredOptions.end(), option) !=
+            kIgnoredOptions.end()) {
+          if (option != "INDEXMISSING"sv && option != "INDEXEMPTY"sv) {
+            LOG(WARNING) << "Ignoring unsupported field option in FT.CREATE: " << option;
+          }
+          // Ignore these options
+          parser->Skip(1);
+          continue;
+        } else if (std::find(kIgnoredOptionsWithArg.begin(), kIgnoredOptionsWithArg.end(),
+                             option) != kIgnoredOptionsWithArg.end()) {
+          LOG(WARNING) << "Ignoring unsupported field option in FT.CREATE: " << option;
+          // Ignore these options with argument
+          parser->Skip(2);
+          continue;
+        }
         break;
       }
 
       flags |= *flag;
     }
-
-    // Skip all trailing ignored parameters
-    while (kIgnoredOptions.count(parser->Peek()) > 0)
-      parser->Skip(2);
 
     schema.fields[field] = {field_type, flags, string{field_alias}, params};
     schema.field_names[field_alias] = field;

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -2767,4 +2767,38 @@ TEST_F(SearchFamilyTest, JsonSetIndexesBug) {
   resp = Run({"FT.AGGREGATE", "index", "*", "GROUPBY", "1", "@text"});
   EXPECT_THAT(resp, IsUnordArrayWithSize(IsMap("text", "some text")));
 }
+
+TEST_F(SearchFamilyTest, IgnoredOptionsInFtCreate) {
+  Run({"HSET", "doc:1", "title", "Test Document"});
+
+  // Create an index with various options, some of which should be ignored
+  // INDEXMISSING and INDEXEMPTY are supported by default
+  auto resp = Run({"FT.CREATE",
+                   "idx",
+                   "ON",
+                   "HASH",
+                   "SCHEMA",
+                   "title",
+                   "TEXT",
+                   "UNF",
+                   "NOSTEM",
+                   "CASESENSITIVE",
+                   "WITHSUFFIXTRIE",
+                   "INDEXMISSING",
+                   "INDEXEMPTY",
+                   "WEIGHT",
+                   "1",
+                   "SEPARATOR",
+                   "|",
+                   "PHONETIC",
+                   "dm:en",
+                   "SORTABLE"});
+
+  // Check that the response is OK, indicating the index was created successfully
+  EXPECT_THAT(resp, "OK");
+
+  // Verify that the index was created correctly
+  resp = Run({"FT.SEARCH", "idx", "*"});
+  EXPECT_THAT(resp, AreDocIds("doc:1"));
+}
 }  // namespace dfly


### PR DESCRIPTION
fixes #5186