### PR TITLE
[WIP] (string_family): Add support for MC GAT

### DIFF
--- a/src/facade/memcache_parser_test.cc
+++ b/src/facade/memcache_parser_test.cc
@@ -149,6 +149,20 @@ TEST_F(MCParserTest, Meta) {
   EXPECT_TRUE(cmd_.return_hit);
 }
 
+TEST_F(MCParserTest, Gat) {
+  auto res = parser_.Parse("gat 1000 foo bar baz\r\n", &consumed_, &cmd_);
+  EXPECT_EQ(MemcacheParser::OK, res);
+  EXPECT_EQ(consumed_, 22);
+  EXPECT_EQ(cmd_.type, MemcacheParser::GAT);
+  EXPECT_EQ(cmd_.key, "foo");
+  EXPECT_THAT(cmd_.keys_ext, UnorderedElementsAre("bar", "baz"));
+  EXPECT_EQ(cmd_.expire_ts, 1000);
+
+  cmd_ = {};
+  res = parser_.Parse("gat foo bar\r\n", &consumed_, &cmd_);
+  EXPECT_EQ(MemcacheParser::BAD_INT, res);
+}
+
 class MCParserNoreplyTest : public MCParserTest {
  protected:
   void RunTest(string_view str, bool noreply) {

--- a/src/server/acl/acl_family_test.cc
+++ b/src/server/acl/acl_family_test.cc
@@ -329,7 +329,7 @@ TEST_F(AclFamilyTest, TestCat) {
               UnorderedElementsAre("GETSET", "GETRANGE", "INCRBYFLOAT", "GETDEL", "DECRBY",
                                    "PREPEND", "SETEX", "MSET", "SET", "PSETEX", "SUBSTR", "DECR",
                                    "STRLEN", "INCR", "INCRBY", "MGET", "GET", "SETNX", "GETEX",
-                                   "APPEND", "MSETNX", "SETRANGE"));
+                                   "APPEND", "MSETNX", "SETRANGE", "GAT"));
 }
 
 TEST_F(AclFamilyTest, TestGetUser) {

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -149,6 +149,7 @@ struct ConnectionState {
 
   enum MCGetMask {
     FETCH_CAS_VER = 1,
+    SET_EXPIRY = 2,
   };
 
   size_t UsedMemory() const;
@@ -257,8 +258,10 @@ struct ConnectionState {
 
   // used for memcache set/get commands.
   // For set op - it's the flag value we are storing along with the value.
-  // For get op - we use it as a mask of MCGetMask values.
-  uint32_t memcache_flag = 0;
+  // For get op - we use it as a mask of MCGetMask values stored in the highest two bits
+  // For GAT and GATS - the expiry in seconds supplied is stored in the top 62 bits along with the
+  // MCGetMask values in the lower two bits
+  uint64_t memcache_flag = 0;
 
   ExecInfo exec_info;
   ReplicationInfo replication_info;

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -374,6 +374,25 @@ TEST_F(DflyEngineTest, Memcache) {
   EXPECT_THAT(resp, ElementsAre("VALUE key 1 3 0", "bar", "VALUE key2 2 8 0", "bar2val2", "END"));
 }
 
+TEST_F(DflyEngineTest, MemcacheGat) {
+  using m = MemcacheParser;
+
+  EXPECT_THAT(GetMC(m::GAT, {"1000", "foo", "bar"}), ElementsAre("END"));
+  EXPECT_THAT(RunMC(m::SET, "exp-key", "exp-val"), ElementsAre("STORED"));
+  EXPECT_THAT(GetMC(m::GAT, {"1", "exp-key"}), ElementsAre("VALUE exp-key 0 7", "exp-val", "END"));
+
+  AdvanceTime(2 * 1000);
+  EXPECT_THAT(RunMC(m::GET, "exp-key"), ElementsAre("END"));
+
+  EXPECT_THAT(RunMC(m::SET, "a", "a-val"), ElementsAre("STORED"));
+  EXPECT_THAT(RunMC(m::SET, "x", "x-val"), ElementsAre("STORED"));
+  EXPECT_THAT(GetMC(m::GAT, {"3", "a", "x", "z", "foo"}),
+              ElementsAre("VALUE a 0 5", "a-val", "VALUE x 0 5", "x-val", "END"));
+
+  AdvanceTime(2 * 1000);
+  EXPECT_THAT(GetMC(m::GAT, {"3", "a", "x", "z", "foo"}), ElementsAre("END"));
+}
+
 TEST_F(DflyEngineTest, MemcacheFlags) {
   using MP = MemcacheParser;
 

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -513,6 +513,9 @@ auto BaseFamilyTest::GetMC(MP::CmdType cmd_type, std::initializer_list<std::stri
   MP::Command cmd;
   cmd.type = cmd_type;
   auto src = list.begin();
+  if (cmd.type == MP::GAT || cmd.type == MP::GATS) {
+    CHECK(absl::SimpleAtoi(*src++, &cmd.expire_ts)) << "invalid expire seconds for " << cmd.type;
+  }
   cmd.key = *src++;
   for (; src != list.end(); ++src) {
     cmd.keys_ext.push_back(*src);


### PR DESCRIPTION
Support for GAT command is added in this change set.

The memcache protocol commands GAT and GATS will use the same code path as MC GET/GETS, and also touch expiry of keys which are found using the supplied expiry. 

The MGET code path is changed to optionally set expiry of keys it finds. 
