### PR TITLE
fix: ZCOUNT crash when min > max

### DIFF
--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1254,6 +1254,10 @@ OpResult<unsigned> OpCount(const OpArgs& op_args, std::string_view key,
   zrangespec range = GetZrangeSpec(false, interval);
   unsigned count = 0;
 
+  if (range.min > range.max) {
+    return 0;
+  }
+
   if (IsListPack(robj_wrapper)) {
     uint8_t* zl = (uint8_t*)robj_wrapper->inner_obj();
     uint8_t *eptr, *sptr;

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -284,17 +284,6 @@ TEST_F(ZSetFamilyTest, ZRandMember) {
   EXPECT_THAT(resp, ConsistsOfScoredElements({{"a", "1"}, {"b", "2"}, {"c", "3"}}));
 }
 
-TEST_F(ZSetFamilyTest, ZCountMinGreaterThanMax) {
-  // Add 1000 members to the sorted set
-  for (int i = 1; i <= 1000; ++i) {
-    Run({"zadd", "huge_key", absl::StrCat(i), absl::StrCat("member", i)});
-  }
-
-  // Expect ZCOUNT to return 0 when min > max
-  auto resp = Run({"zcount", "huge_key", "945", "261"});
-  EXPECT_THAT(resp, IntArg(0));
-}
-
 TEST_F(ZSetFamilyTest, ZMScore) {
   Run({"zadd", "zms", "3.14", "a"});
   Run({"zadd", "zms", "42", "another"});

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -284,6 +284,17 @@ TEST_F(ZSetFamilyTest, ZRandMember) {
   EXPECT_THAT(resp, ConsistsOfScoredElements({{"a", "1"}, {"b", "2"}, {"c", "3"}}));
 }
 
+TEST_F(ZSetFamilyTest, ZCountMinGreaterThanMax) {
+  // Add 1000 members to the sorted set
+  for (int i = 1; i <= 1000; ++i) {
+    Run({"zadd", "huge_key", absl::StrCat(i), absl::StrCat("member", i)});
+  }
+
+  // Expect ZCOUNT to return 0 when min > max
+  auto resp = Run({"zcount", "huge_key", "945", "261"});
+  EXPECT_THAT(resp, IntArg(0));
+}
+
 TEST_F(ZSetFamilyTest, ZMScore) {
   Run({"zadd", "zms", "3.14", "a"});
   Run({"zadd", "zms", "42", "another"});
@@ -1216,6 +1227,17 @@ TEST_F(ZSetFamilyTest, ZRangeZeroElements) {
   Run({"zadd", "myzset", "1", "one"});
   auto resp = Run({"ZRANGE", "myzset", "0", "-1", "LIMIT", "2", "10"});
   ASSERT_THAT(resp, ArrLen(0));
+}
+
+TEST_F(ZSetFamilyTest, ZCountMinGreaterThanMaxCrash) {
+  // Add 1000 members to the sorted set
+  for (int i = 1; i <= 1000; ++i) {
+    Run({"zadd", "huge_key", absl::StrCat(i), absl::StrCat("member", i)});
+  }
+
+  // Expect ZCOUNT to return 0 when min > max
+  auto resp = Run({"zcount", "huge_key", "945", "261"});
+  EXPECT_THAT(resp, IntArg(0));
 }
 
 }  // namespace dfly


### PR DESCRIPTION
Fixes: https://github.com/dragonflydb/dragonfly/issues/5204

The issue:
ZCOUNT command crashed with assertion failure when min > max (e.g., `ZCOUNT key 945 261`). The assertion `range.min <= range.max` in `SortedMap::Count()` was triggered, causing the server to crash.

The solution:
Added early validation in `OpCount()` function to return 0 immediately when `range.min > range.max`, before calling `SortedMap::Count()`.