### PR TITLE
fix(pytest): Sleep in sporadically failing test_slot_migration_oom pytest

### DIFF
--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -3276,6 +3276,10 @@ async def test_slot_migration_oom(df_factory):
     await wait_for_status(nodes[0].admin_client, nodes[1].id, "FATAL", 300)
     await wait_for_status(nodes[1].admin_client, nodes[0].id, "FATAL")
 
+    # There's a rare timing issue if we don't wait here. Status can be set to FATAL
+    # but error message is not still set for slot migration.
+    await asyncio.sleep(1)
+
     # Node_0 slot-migration-status
     status = await nodes[0].admin_client.execute_command(
         "DFLYCLUSTER", "SLOT-MIGRATION-STATUS", nodes[1].id


### PR DESCRIPTION
Add additional sleep between waiting for cluster status and SLOT-MIGRATION-STATUS request. There is rare timing issue when we set status to FATAL but error message is still not available.

Closes #5208

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->