### PR TITLE
fix(transaction): DCHECK fail in non-atomic transactions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,11 +8,13 @@ Checks: >
   -bugprone-easily-swappable-parameters,
   -bugprone-branch-clone,
   -bugprone-implicit-widening-of-multiplication-result,
+  -bugprone-too-small-loop-variable,
+  -bugprone-reserved-identifier,
   boost-use-to-string,
   performance*,
-  cert*,
   -cert-err58-cpp,
   -cert-dcl58-cpp,  # Ignore std changes
+  -cert-dcl51-cpp,  # bugprone-reserved-identifier
   # Doesn't work with abseil flags
   clang-analyzer*,
   google-*,

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1809,8 +1809,9 @@ void Connection::SendAsync(MessageHandle msg) {
   DCHECK_EQ(ProactorBase::me(), socket_->proactor());
 
   // "Closing" connections might be still processing commands, as we don't interrupt them.
-  // So we still want to deliver control messages to them (like checkpoints).
-  if (cc_->conn_closing && !msg.IsControl())
+  // So we still want to deliver control messages to them (like checkpoints) if
+  // async_fb_ is running (joinable).
+  if (cc_->conn_closing && (!msg.IsControl() || !async_fb_.IsJoinable()))
     return;
 
   // If we launch while closing, it won't be awaited. Control messages will be processed on cleanup.

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -998,6 +998,13 @@ TEST_F(MultiTest, NoKeyTransactional) {
   Run({"exec"});
 }
 
+TEST_F(MultiTest, NoKeyTransactionalMany) {
+  vector<vector<string>> cmds;
+  cmds.push_back({"rename", "x", "z"});
+  cmds.push_back({"ft._list"});
+  RunMany(cmds);
+}
+
 class MultiEvalTest : public BaseFamilyTest {
  protected:
   MultiEvalTest() : BaseFamilyTest() {

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -467,6 +467,25 @@ RespExpr BaseFamilyTest::Run(std::string_view id, ArgSlice slice) {
   return e;
 }
 
+void BaseFamilyTest::RunMany(const std::vector<std::vector<std::string>>& cmds) {
+  if (!ProactorBase::IsProactorThread()) {
+    return pp_->at(0)->Await([&] { return this->RunMany(cmds); });
+  }
+  TestConnWrapper* conn_wrapper = AddFindConn(Protocol::REDIS, GetId());
+  auto* context = conn_wrapper->cmd_cntx();
+  context->ns = &namespaces->GetDefaultNamespace();
+  vector<ArgSlice> args_vec(cmds.size());
+  vector<vector<string_view>> cmd_views(cmds.size());
+  for (size_t i = 0; i < cmds.size(); ++i) {
+    for (const auto& arg : cmds[i]) {
+      cmd_views[i].emplace_back(arg);
+    }
+    args_vec[i] = absl::MakeSpan(cmd_views[i]);
+  }
+  service_->DispatchManyCommands(absl::MakeSpan(args_vec), conn_wrapper->builder(), context);
+  DCHECK(context->transaction == nullptr);
+}
+
 auto BaseFamilyTest::RunMC(MP::CmdType cmd_type, string_view key, string_view value, uint32_t flags,
                            chrono::seconds ttl) -> MCResponse {
   if (!ProactorBase::IsProactorThread()) {

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -85,6 +85,7 @@ class BaseFamilyTest : public ::testing::Test {
   RespExpr Run(absl::Span<std::string> list);
 
   RespExpr Run(std::string_view id, ArgSlice list);
+  void RunMany(const std::vector<std::vector<std::string>>& cmds);
 
   using MCResponse = std::vector<std::string>;
   MCResponse RunMC(MemcacheParser::CmdType cmd_type, std::string_view key, std::string_view value,

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -225,7 +225,7 @@ class Transaction {
 
   // Cancel all blocking watches. Set COORD_CANCELLED.
   // Must be called from coordinator thread.
-  void CancelBlocking(std::function<OpStatus(ArgSlice)>);
+  void CancelBlocking(const std::function<OpStatus(ArgSlice)>&);
 
   // Prepare a squashed hop on given shards.
   // Only compatible with multi modes that acquire all locks ahead - global and lock_ahead.


### PR DESCRIPTION
Also fixes occasional DCHECK fail with ACL message being sent into a closing connection. (There is not test as its hard to reproduce with pytests).

The TX bug was that we did not reset references into kv_fp_ array when switching commands within non-atomic transactions. This resulted in dcheck fails.

Fixes #5212.

The fix:
1. added test that reproduces the issue
2. Reset the fp_start and fp_count fields in each shard data.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->