### PR TITLE
fix: seeder hset commands generation

### DIFF
--- a/tests/dragonfly/seeder/script-genlib.lua
+++ b/tests/dragonfly/seeder/script-genlib.lua
@@ -131,11 +131,7 @@ end
 
 function LG_funcs.mod_hash(key, keys)
     local idx = math.random(LG_funcs.csize)
-    if idx % 2 == 1 then
-        redis.apcall('HINCRBY', key, tostring(idx), 1)
-    else
-      redis.apcall('HSET', key, tostring(idx), randstr())
-    end
+    redis.apcall('HSET', key, tostring(idx), randstr())
 end
 
 -- sorted sets


### PR DESCRIPTION
During the  test_seeder_key_target we have a lot of warnings like "HINCRBY k-s32u3-105 5 1 failed with reason: hash value is not an integer"

The problem is that we generate random strings as fields of HSET, not integers.
