### PR TITLE
chore: minor changes in dash code

### DIFF
--- a/src/core/dash_test.cc
+++ b/src/core/dash_test.cc
@@ -700,6 +700,7 @@ TEST_F(DashTest, Eviction) {
 
   ASSERT_THROW(loop(), bad_alloc);
   ASSERT_LT(num, 5000);
+  ASSERT_EQ(2, dt_.unique_segments());
   EXPECT_LT(dt_.size(), ev.max_capacity);
   LOG(INFO) << "size is " << dt_.size();
 


### PR DESCRIPTION
Does not change functionality.
bucket_count is currently constant for a segment so the additional arithmetics do not affect bucket_count_.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->