### PR TITLE
feat (server): traverse buckets change traverse order

### DIFF
--- a/src/core/dash_internal.h
+++ b/src/core/dash_internal.h
@@ -704,6 +704,10 @@ class DashCursor {
     return val_ != 0;
   }
 
+  bool operator==(const DashCursor& other) const {
+    return val_ == other.val_;
+  }
+
  private:
   uint64_t val_;
 };


### PR DESCRIPTION
The motivation for changing the bucket traversal order is to address a limitation in the non-point-in-time snapshot algorithm.

In this mode, buckets are traversed without regard to the snapshot version. If an item is bumped within the dash table during traversal, it may be moved to a bucket that has already been processed, causing it to be missed during serialization.

By reversing the traversal order — going from the last bucket to the first — we ensure that any bumped items are still visited later in the traversal, preventing them from being skipped.