### PR TITLE
(string_family): Add priliminary support for GAT

### DIFF
--- a/src/facade/memcache_parser_test.cc
+++ b/src/facade/memcache_parser_test.cc
@@ -149,6 +149,20 @@ TEST_F(MCParserTest, Meta) {
   EXPECT_TRUE(cmd_.return_hit);
 }
 
+TEST_F(MCParserTest, Gat) {
+  auto res = parser_.Parse("gat 1000 foo bar baz\r\n", &consumed_, &cmd_);
+  EXPECT_EQ(MemcacheParser::OK, res);
+  EXPECT_EQ(consumed_, 22);
+  EXPECT_EQ(cmd_.type, MemcacheParser::GAT);
+  EXPECT_EQ(cmd_.key, "foo");
+  EXPECT_THAT(cmd_.keys_ext, UnorderedElementsAre("bar", "baz"));
+  EXPECT_EQ(cmd_.expire_ts, 1000);
+
+  cmd_ = {};
+  res = parser_.Parse("gat foo bar\r\n", &consumed_, &cmd_);
+  EXPECT_EQ(MemcacheParser::BAD_INT, res);
+}
+
 class MCParserNoreplyTest : public MCParserTest {
  protected:
   void RunTest(string_view str, bool noreply) {

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -149,6 +149,7 @@ struct ConnectionState {
 
   enum MCGetMask {
     FETCH_CAS_VER = 1,
+    SET_EXPIRY = 2,
   };
 
   size_t UsedMemory() const;
@@ -258,7 +259,9 @@ struct ConnectionState {
   // used for memcache set/get commands.
   // For set op - it's the flag value we are storing along with the value.
   // For get op - we use it as a mask of MCGetMask values.
-  uint32_t memcache_flag = 0;
+  // For GAT the lowest two bits are used to store MCGetMask values, the top 62 bits are used to
+  // store expiration timestamp in seconds.
+  uint64_t memcache_flag = 0;
 
   ExecInfo exec_info;
   ReplicationInfo replication_info;


### PR DESCRIPTION
When the GAT command is supplied, store the expiry within the memcache flag, also add and set an enum value for setting expiry within the same flag.

We still call MGETS for now, and the expiry value is unused. A future PR will implement the changes for applying the expiry.

a continuation of https://github.com/dragonflydb/dragonfly/pull/5199