### PR TITLE
chore: maintain meta information around continous transactions

### DIFF
--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -649,6 +649,7 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
   }
 
   bool update_stats = false;
+  ++poll_concurrent_factor_;
 
   auto run = [this, &update_stats](Transaction* tx, bool allow_removal) -> bool /* concluding */ {
     update_stats = true;
@@ -664,6 +665,9 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
     if ((is_self && disarmed) || continuation_trans_->DisarmInShard(sid)) {
       if (bool concludes = run(continuation_trans_, true); concludes) {
         continuation_trans_ = nullptr;
+        continuation_debug_id_.clear();
+      } else {
+        continuation_debug_id_ = continuation_trans_->DebugId(sid);
       }
     }
   }
@@ -704,6 +708,7 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
     if (bool concludes = run(head, true); !concludes) {
       DCHECK_EQ(head->DEBUG_GetTxqPosInShard(sid), TxQueue::kEnd) << head->DebugId(sid);
       continuation_trans_ = head;
+      continuation_debug_id_ = head->DebugId(sid);
     }
   }
 
@@ -729,6 +734,7 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
       LOG_IF(DFATAL, trans->DEBUG_GetTxqPosInShard(sid) == TxQueue::kEnd);
     }
   }
+  --poll_concurrent_factor_;
   if (update_stats) {
     CacheStats();
   }
@@ -737,6 +743,7 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
 void EngineShard::RemoveContTx(Transaction* tx) {
   if (continuation_trans_ == tx) {
     continuation_trans_ = nullptr;
+    continuation_debug_id_.clear();
   }
 }
 

--- a/src/server/engine_shard.h
+++ b/src/server/engine_shard.h
@@ -266,6 +266,8 @@ class EngineShard {
   // Logical ts used to order distributed transactions.
   TxId committed_txid_ = 0;
   Transaction* continuation_trans_ = nullptr;
+  std::string continuation_debug_id_;
+  unsigned poll_concurrent_factor_ = 0;
   journal::Journal* journal_ = nullptr;
   IntentLock shard_lock_;
 

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -565,8 +565,7 @@ string Transaction::DebugId(std::optional<ShardId> sid) const {
   if (sid) {
     absl::StrAppend(&res, ",mask[", *sid, "]=", int(shard_data_[SidToId(*sid)].local_mask),
                     ",is_armed=", DEBUG_IsArmedInShard(*sid),
-                    ",txqpos[]=", shard_data_[SidToId(*sid)].pq_pos,
-                    ",fail_state_print=", DEBUG_PrintFailState(*sid));
+                    ",txqpos[]=", shard_data_[SidToId(*sid)].pq_pos);
   }
   absl::StrAppend(&res, "}");
   return res;
@@ -978,6 +977,7 @@ const absl::flat_hash_set<std::pair<ShardId, LockFp>>& Transaction::GetMultiFps(
   return multi_->tag_fps;
 }
 
+#if 0
 string Transaction::DEBUG_PrintFailState(ShardId sid) const {
   auto res = StrCat(
       "usc: ", unique_shard_cnt_, ", name:", GetCId()->name(),
@@ -992,6 +992,7 @@ string Transaction::DEBUG_PrintFailState(ShardId sid) const {
   }
   return res;
 }
+#endif
 
 void Transaction::EnableShard(ShardId sid) {
   unique_shard_cnt_ = 1;

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -352,9 +352,6 @@ class Transaction {
   // Get keys multi transaction was initialized with, normalized and unique
   const absl::flat_hash_set<std::pair<ShardId, LockFp>>& GetMultiFps() const;
 
-  // Print in-dept failure state for debugging.
-  std::string DEBUG_PrintFailState(ShardId sid) const;
-
   uint32_t DEBUG_GetTxqPosInShard(ShardId sid) const {
     return shard_data_[SidToId(sid)].pq_pos;
   }


### PR DESCRIPTION
The motivation: to narrow down a rare crash issue happenning around stale continuation_trans_ pointer.

The goal is to inspect these variables when a similar crash happens again.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->