### PR TITLE
fix: dcheck trigger in JournalFlushGuard constructor

### DIFF
--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -764,7 +764,8 @@ void EngineShard::Heartbeat() {
   if (db_slice.WillBlockOnJournalWrite() || !can_acquire_global_lock) {
     const auto elapsed = std::chrono::system_clock::now() - start;
     if (elapsed > std::chrono::seconds(1)) {
-      LOG_EVERY_T(WARNING, 5) << "Stalled heartbeat() fiber for " << elapsed.count() << " seconds";
+      LOG_EVERY_T(WARNING, 5) << "Stalled heartbeat() fiber for " << elapsed.count()
+                              << " nanoseconds";
     }
     return;
   }

--- a/src/server/journal/journal.h
+++ b/src/server/journal/journal.h
@@ -46,7 +46,7 @@ class Journal {
 class JournalFlushGuard {
  public:
   explicit JournalFlushGuard(Journal* journal) : journal_(journal) {
-    if (journal_) {
+    if (journal_ && counter_ == 0) {
       journal_->SetFlushMode(false);
     }
     util::fb2::detail::EnterFiberAtomicSection();


### PR DESCRIPTION
The issue is that we nested `JournalFlushGuard` within `Heartbeat` which triggered the DCHECK. The constructor should only call `SetFlushMode(false)` only once when `counter_=0`. The same rules apply to the destructor which only called `SetFlushHMode` once (when `counter==0`)

resolves  #5219 #5221