### PR TITLE
fix: BITFIELD: overflow handling, type validation, and return values

### DIFF
--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -958,6 +958,9 @@ OpResult<vector<ResultType>> StateExecutor::Execute(const CommandList& commands)
   return results;
 }
 
+const char kInvalidBitfieldTypeErr[] =
+    "invalid bitfield type. use something like i16 u8. note that u64 is not supported but i64 is.";
+
 nonstd::expected<CommonAttributes, string> ParseCommonAttr(CmdArgParser* parser) {
   CommonAttributes parsed;
   using nonstd::make_unexpected;
@@ -974,9 +977,7 @@ nonstd::expected<CommonAttributes, string> ParseCommonAttr(CmdArgParser* parser)
   } else if (encoding[0] == 'i') {
     parsed.type = EncodingType::INT;
   } else {
-    return make_unexpected(
-        "invalid bitfield type. use something like i16 u8. note that u64 is not supported but i64 "
-        "is.");
+    return make_unexpected(kInvalidBitfieldTypeErr);
   }
 
   string_view bits = encoding.substr(1);
@@ -984,10 +985,7 @@ nonstd::expected<CommonAttributes, string> ParseCommonAttr(CmdArgParser* parser)
   // Additional validation: check if bits part contains any invalid characters
   for (char c : bits) {
     if (!std::isdigit(c)) {
-      return make_unexpected(
-          "invalid bitfield type. use something like i16 u8. note that u64 is not supported but "
-          "i64 "
-          "is.");
+      return make_unexpected(kInvalidBitfieldTypeErr);
     }
   }
 
@@ -996,15 +994,11 @@ nonstd::expected<CommonAttributes, string> ParseCommonAttr(CmdArgParser* parser)
   }
 
   if (parsed.encoding_bit_size <= 0 || parsed.encoding_bit_size > 64) {
-    return make_unexpected(
-        "invalid bitfield type. use something like i16 u8. note that u64 is not supported but i64 "
-        "is.");
+    return make_unexpected(kInvalidBitfieldTypeErr);
   }
 
   if (parsed.encoding_bit_size == 64 && parsed.type == EncodingType::UINT) {
-    return make_unexpected(
-        "invalid bitfield type. use something like i16 u8. note that u64 is not supported but i64 "
-        "is.");
+    return make_unexpected(kInvalidBitfieldTypeErr);
   }
 
   bool is_proxy = false;

--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -808,6 +808,10 @@ ResultType Set::ApplyTo(Overflow ov, string* bitfield) {
   }
 
   if (is_negative && attr_.type == EncodingType::INT && old_value > 0) {
+    // Sign extension for negative signed integers.
+    // Is creates a mask that sets all upper bits to 1
+    // and converts positive old_value (15) to correct negative value (-1)
+    // Example: 4-bit field 1111 should be -1, not 15.
     old_value |= -1L ^ ((1L << attr_.encoding_bit_size) - 1);
   }
 

--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -779,32 +779,67 @@ class Set {
 };
 
 ResultType Set::ApplyTo(Overflow ov, string* bitfield) {
-  string& bytes = *bitfield;
-  const int32_t total_bytes = static_cast<int32_t>(bytes.size());
-  auto last_byte_offset = GetByteIndex(attr_.offset + attr_.encoding_bit_size - 1) + 1;
-  if (last_byte_offset > total_bytes) {
-    bytes.resize(last_byte_offset, 0);
-  }
-
-  // First, extract the old value properly using the Get method
-  Get get(attr_);
-  auto old_value_result = get.ApplyTo(ov, &bytes);
-  int64_t old_value = old_value_result ? *old_value_result : 0;
-
-  // Apply overflow handling to the new value
   if (!HandleOverflow(ov)) {
     return {};
   }
 
-  uint32_t lsb = attr_.offset + attr_.encoding_bit_size - 1;
+  string& bytes = *bitfield;
+  const size_t start_byte = GetByteIndex(attr_.offset);
+  const size_t end_byte = GetByteIndex(attr_.offset + attr_.encoding_bit_size - 1);
+  const size_t initial_byte_size = bytes.size();
 
+  // Buffer to hold original bytes.
+  std::vector<uint8_t> old_bytes_buf;
+  if (start_byte < initial_byte_size) {
+    const size_t end_read = std::min(initial_byte_size, end_byte + 1);
+    const uint8_t* start_ptr = reinterpret_cast<const uint8_t*>(bytes.data()) + start_byte;
+    const uint8_t* end_ptr = reinterpret_cast<const uint8_t*>(bytes.data()) + end_read;
+    old_bytes_buf.assign(start_ptr, end_ptr);
+  }
+
+  auto get_old_byte = [&](const size_t index) -> uint8_t {
+    if (index < start_byte || index > end_byte)
+      return 0;  // Should not happen with correct usage
+    const size_t i = index - start_byte;
+    return i < old_bytes_buf.size() ? old_bytes_buf[i] : 0;
+  };
+
+  const size_t needed_byte_size = end_byte + 1;
+  if (needed_byte_size > bytes.size()) {
+    bytes.resize(needed_byte_size, 0);
+  }
+
+  int64_t old_value = 0;
+  bool was_negative = false;
+  if (attr_.type == EncodingType::INT) {
+    uint8_t msb_byte = get_old_byte(start_byte);
+    was_negative = CheckBitStatus(msb_byte, GetNormalizedBitIndex(attr_.offset));
+  }
+
+  uint32_t lsb = attr_.offset + attr_.encoding_bit_size - 1;
   for (size_t i = 0; i < attr_.encoding_bit_size; ++i) {
-    bool bit_value = (set_value_ >> i) & 0x01;
-    uint8_t byte{GetByteValue(bytes, lsb)};
-    int32_t index = GetNormalizedBitIndex(lsb);
-    byte = bit_value ? TurnBitOn(byte, index) : TurnBitOff(byte, index);
-    bytes[GetByteIndex(lsb)] = byte;
+    size_t current_byte_index = GetByteIndex(lsb);
+    int32_t bit_index_in_byte = GetNormalizedBitIndex(lsb);
+
+    uint8_t old_byte_val = get_old_byte(current_byte_index);
+    if (CheckBitStatus(old_byte_val, bit_index_in_byte)) {
+      old_value |= (1LL << i);
+    }
+
+    // Set new bit.
+    bool new_bit_value = (set_value_ >> i) & 1;
+    uint8_t& byte_to_modify = (uint8_t&)bytes[current_byte_index];
+    if (new_bit_value) {
+      byte_to_modify = TurnBitOn(byte_to_modify, bit_index_in_byte);
+    } else {
+      byte_to_modify = TurnBitOff(byte_to_modify, bit_index_in_byte);
+    }
+
     --lsb;
+  }
+
+  if (was_negative && old_value > 0) {
+    old_value |= -1L ^ ((1L << attr_.encoding_bit_size) - 1);
   }
 
   return old_value;

--- a/src/server/bitops_family_test.cc
+++ b/src/server/bitops_family_test.cc
@@ -855,4 +855,29 @@ TEST_F(BitOpsFamilyTest, BitFieldIssue5237_InvalidTypeUppercase_Get) {
   ASSERT_THAT(Run({"bitfield", "key:bitfield_get:wrong:args", "get", "I8", "0"}), expected_error);
 }
 
+TEST_F(BitOpsFamilyTest, BitFieldAdditionalWrongArguments) {
+  // Additional tests to match Python test coverage
+  const auto syntax_error = ErrArg("ERR syntax error");
+  auto expected_error = ErrArg(
+      "ERR invalid bitfield type. use something like i16 u8. note that u64 is not supported but "
+      "i64 is.");
+
+  // Additional invalid encoding types (from Python tests)
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i-42", "0"}), expected_error);
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i5?", "0"}), expected_error);
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i0", "0"}), expected_error);
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "i-42", "0", "0"}), expected_error);
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "i5?", "0", "0"}), expected_error);
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "i0", "0", "0"}), expected_error);
+
+  // Test negative offsets (should be syntax error)
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i16", "-1"}), syntax_error);
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "i16", "-1", "0"}), syntax_error);
+  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i16", "-1", "1"}), syntax_error);
+
+  // Test invalid values for SET and INCRBY (generates syntax error during parsing)
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "i16", "0", "foo"}), syntax_error);
+  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i16", "0", "bar"}), syntax_error);
+}
+
 }  // end of namespace dfly


### PR DESCRIPTION
Fixes: https://github.com/dragonflydb/dragonfly/issues/5237

- Fixed BITFIELD SET overflow saturation: Now correctly returns old values.
- Fixed BITFIELD INCRBY calculations: Corrected increment logic to return proper values.
- Fixed type validation: Now properly rejects uppercase type specifiers (e.g., "I8" instead of "i8").
- Fixed UIntOverflow wrap logic: Changed from modulo to bitwise AND for proper wrap-around behavior.
