### PR TITLE
Implementation of memcache GAT and GATS commands

### DIFF
--- a/src/facade/memcache_parser_test.cc
+++ b/src/facade/memcache_parser_test.cc
@@ -161,6 +161,15 @@ TEST_F(MCParserTest, Gat) {
   cmd_ = {};
   res = parser_.Parse("gat foo bar\r\n", &consumed_, &cmd_);
   EXPECT_EQ(MemcacheParser::BAD_INT, res);
+
+  cmd_ = {};
+  res = parser_.Parse("gats 1000 foo bar baz\r\n", &consumed_, &cmd_);
+  EXPECT_EQ(MemcacheParser::OK, res);
+  EXPECT_EQ(consumed_, 23);
+  EXPECT_EQ(cmd_.type, MemcacheParser::GATS);
+  EXPECT_EQ(cmd_.key, "foo");
+  EXPECT_THAT(cmd_.keys_ext, UnorderedElementsAre("bar", "baz"));
+  EXPECT_EQ(cmd_.expire_ts, 1000);
 }
 
 class MCParserNoreplyTest : public MCParserTest {

--- a/src/server/acl/acl_family_test.cc
+++ b/src/server/acl/acl_family_test.cc
@@ -329,7 +329,7 @@ TEST_F(AclFamilyTest, TestCat) {
               UnorderedElementsAre("GETSET", "GETRANGE", "INCRBYFLOAT", "GETDEL", "DECRBY",
                                    "PREPEND", "SETEX", "MSET", "SET", "PSETEX", "SUBSTR", "DECR",
                                    "STRLEN", "INCR", "INCRBY", "MGET", "GET", "SETNX", "GETEX",
-                                   "APPEND", "MSETNX", "SETRANGE"));
+                                   "APPEND", "MSETNX", "SETRANGE", "GAT"));
 }
 
 TEST_F(AclFamilyTest, TestGetUser) {

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -147,10 +147,7 @@ struct ConnectionState {
     const ConnectionContext* owner = nullptr;
   };
 
-  enum MCGetMask {
-    FETCH_CAS_VER = 1,
-    SET_EXPIRY = 2,
-  };
+  enum MCGetMask { FETCH_CAS_VER = 1 };
 
   size_t UsedMemory() const;
 
@@ -259,9 +256,7 @@ struct ConnectionState {
   // used for memcache set/get commands.
   // For set op - it's the flag value we are storing along with the value.
   // For get op - we use it as a mask of MCGetMask values.
-  // For GAT the lowest two bits are used to store MCGetMask values, the top 62 bits are used to
-  // store expiration timestamp in seconds.
-  uint64_t memcache_flag = 0;
+  uint32_t memcache_flag = 0;
 
   ExecInfo exec_info;
   ReplicationInfo replication_info;

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -372,6 +372,27 @@ TEST_F(DflyEngineTest, Memcache) {
 
   resp = GetMC(MP::GETS, {"key", "key2", "unknown"});
   EXPECT_THAT(resp, ElementsAre("VALUE key 1 3 0", "bar", "VALUE key2 2 8 0", "bar2val2", "END"));
+
+  EXPECT_THAT(RunMC(MP::SET, "foo", "bar"), ElementsAre("STORED"));
+  // The value here is 1 month + 1 second, memcache treats an expiry of greater than 1 month as
+  // absolute value. GAT expiry seconds are counted from epoch, setting expiry in the past results
+  // in the key being removed.
+  constexpr uint32_t short_expiry = 60 * 60 * 24 * 30 + 1;
+  EXPECT_THAT(GetMC(MP::GAT, {StrCat(short_expiry), "foo"}), ElementsAre("END"));
+
+  EXPECT_THAT(RunMC(MP::SET, "foo", "bar"), ElementsAre("STORED"));
+
+  // 30 seconds into the future
+  EXPECT_THAT(GetMC(MP::GAT, {"30", "foo", "abc", "def", "ghi"}),
+              ElementsAre("VALUE foo 0 3", "bar", "END"));
+
+  EXPECT_THAT(GetMC(MP::GAT, {"1000"}),
+              ElementsAre("SERVER_ERROR wrong number of arguments for 'gat' command"));
+
+  EXPECT_THAT(RunMC(MP::SET, "persisted-key", "bar"), ElementsAre("STORED"));
+  // expiry of 0 removes the key expiry
+  EXPECT_THAT(GetMC(MP::GAT, {"0", "persisted-key"}),
+              ElementsAre("VALUE persisted-key 0 3", "bar", "END"));
 }
 
 TEST_F(DflyEngineTest, MemcacheFlags) {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1603,8 +1603,11 @@ void Service::DispatchMC(const MemcacheParser::Command& cmd, std::string_view va
     case MemcacheParser::PREPEND:
       strcpy(cmd_name, "PREPEND");
       break;
-    case MemcacheParser::GAT:
+    case MemcacheParser::GATS:
       [[fallthrough]];
+    case MemcacheParser::GAT:
+      strcpy(cmd_name, "GAT");
+      break;
     case MemcacheParser::GET:
       [[fallthrough]];
     case MemcacheParser::GETS:
@@ -1629,12 +1632,6 @@ void Service::DispatchMC(const MemcacheParser::Command& cmd, std::string_view va
 
   args.emplace_back(cmd_name, strlen(cmd_name));
 
-  if (!cmd.key.empty()) {
-    char* key = const_cast<char*>(cmd.key.data());
-    args.emplace_back(key, cmd.key.size());
-  }
-
-  ConnectionContext* dfly_cntx = static_cast<ConnectionContext*>(cntx);
   // if expire_ts is greater than month it's a unix timestamp
   // https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L139
   constexpr uint32_t kExpireLimit = 60 * 60 * 24 * 30;
@@ -1642,6 +1639,19 @@ void Service::DispatchMC(const MemcacheParser::Command& cmd, std::string_view va
                                  ? cmd.expire_ts + time(nullptr)
                                  : cmd.expire_ts;
 
+  // For GAT/GATS commands, the expiry precedes the keys which will be looked up:
+  // GAT|GATS <expiry> key [key...]
+  if (cmd.type == MemcacheParser::GAT || cmd.type == MemcacheParser::GATS) {
+    char* next = absl::numbers_internal::FastIntToBuffer(expire_ts, ttl);
+    args.emplace_back(ttl, next - ttl);
+  }
+
+  if (!cmd.key.empty()) {
+    char* key = const_cast<char*>(cmd.key.data());
+    args.emplace_back(key, cmd.key.size());
+  }
+
+  ConnectionContext* dfly_cntx = static_cast<ConnectionContext*>(cntx);
   if (MemcacheParser::IsStoreCmd(cmd.type)) {
     char* v = const_cast<char*>(value.data());
     args.emplace_back(v, value.size());
@@ -1661,7 +1671,7 @@ void Service::DispatchMC(const MemcacheParser::Command& cmd, std::string_view va
       char* key = const_cast<char*>(s.data());
       args.emplace_back(key, s.size());
     }
-    if (cmd.type == MemcacheParser::GETS) {
+    if (cmd.type == MemcacheParser::GETS || cmd.type == MemcacheParser::GATS) {
       dfly_cntx->conn_state.memcache_flag |= ConnectionState::FETCH_CAS_VER;
     }
   } else {  // write commands.

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1664,10 +1664,6 @@ void Service::DispatchMC(const MemcacheParser::Command& cmd, std::string_view va
     if (cmd.type == MemcacheParser::GETS) {
       dfly_cntx->conn_state.memcache_flag |= ConnectionState::FETCH_CAS_VER;
     }
-
-    if (cmd.type == MemcacheParser::GAT) {
-      dfly_cntx->conn_state.memcache_flag |= ConnectionState::SET_EXPIRY | expire_ts << 2;
-    }
   } else {  // write commands.
     if (store_opt[0]) {
       args.emplace_back(store_opt, strlen(store_opt));

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -822,6 +822,58 @@ void IncrByGeneric(string_view key, int64_t val, Transaction* tx, SinkReplyBuild
   }
 }
 
+struct GetAndTouchParams {
+  const Transaction* t;
+  EngineShard* shard;
+  const DbSlice::ExpireParams& expire_params;
+  const string_view key;
+};
+
+OpResult<DbSlice::Iterator> FindKeyAndSetExpiry(const GetAndTouchParams& params) {
+  const DbContext& ctx = params.t->GetDbContext();
+  DbSlice& db_slice = params.t->GetDbSlice(params.shard->shard_id());
+  auto find_res = db_slice.FindMutable(ctx, params.key, OBJ_STRING);
+  if (!IsValid(find_res->it)) {
+    return OpStatus::KEY_NOTFOUND;
+  }
+
+  find_res->post_updater.Run();
+
+  auto update = db_slice.UpdateExpire(ctx, find_res->it, find_res->exp_it, params.expire_params);
+  if (!update.ok()) {
+    return update.status();
+  }
+
+  const int64_t value = update.value();
+  const bool expired = value == -1;
+  if (params.shard->journal()) {
+    const OpArgs& op_args = params.t->GetOpArgs(params.shard);
+    if (expired) {
+      RecordJournal(op_args, "DEL"sv, ArgSlice{(params.key)});
+    } else {
+      RecordJournal(op_args, "PEXPIREAT"sv, ArgSlice{(params.key), (absl::StrCat(value))});
+    }
+  }
+
+  if (expired) {
+    return OpStatus::KEY_NOTFOUND;
+  }
+  return find_res->it;
+}
+
+MGetResponse OpGAT(BlockingCounter wait_bc, uint8_t fetch_mask, const Transaction* t,
+                   EngineShard* shard, const DbSlice::ExpireParams& expire_params) {
+  SearchMut find_op = [&](string_view key) {
+    return FindKeyAndSetExpiry(GetAndTouchParams{
+        .t = t,
+        .shard = shard,
+        .expire_params = expire_params,
+        .key = key,
+    });
+  };
+  return CollectKeys(wait_bc, fetch_mask, t, shard, std::move(find_op));
+}
+
 }  // namespace
 
 StringValue StringValue::Read(DbIndex dbid, string_view key, const PrimeValue& pv,
@@ -1642,6 +1694,54 @@ void StringFamily::ClThrottle(CmdArgList args, const CommandContext& cmnd_cntx) 
   }
 }
 
+// Implements the memcache GAT command. The expected input is
+// GAT <expiry-in-seconds> key [keys...]
+void StringFamily::GAT(CmdArgList args, const CommandContext& cmnd_cntx) {
+  DCHECK_GE(args.size(), 1U);
+
+  auto* builder = cmnd_cntx.rb;
+  const Protocol protocol = builder->GetProtocol();
+  DCHECK(protocol == Protocol::MEMCACHE);
+
+  uint8_t fetch_mask = FETCH_MCFLAG;
+  if (cmnd_cntx.conn_cntx->conn_state.memcache_flag & ConnectionState::FETCH_CAS_VER)
+    fetch_mask |= FETCH_MCVER;
+
+  SinkReplyBuilder::ReplyScope scope(builder);
+  auto* rb = static_cast<MCReplyBuilder*>(builder);
+  DCHECK(dynamic_cast<CapturingReplyBuilder*>(builder) == nullptr);
+
+  CmdArgParser parser{args};
+  const int64_t expire_ts = parser.Next<uint64_t>();
+  if (parser.HasError()) {
+    return builder->SendError(parser.Error()->MakeReply());
+  }
+
+  BlockingCounter tiering_bc{0};
+  std::vector<MGetResponse> mget_resp(shard_set->size());
+  const DbSlice::ExpireParams expire_params{
+      .value = expire_ts, .absolute = true, .persist = expire_ts == 0};
+  auto cb = [&](Transaction* t, EngineShard* shard) {
+    mget_resp[shard->shard_id()] = OpGAT(tiering_bc, fetch_mask, t, shard, expire_params);
+    return OpStatus::OK;
+  };
+
+  const OpStatus result = cmnd_cntx.tx->ScheduleSingleHop(std::move(cb));
+  CHECK_EQ(OpStatus::OK, result);
+  tiering_bc->Wait();
+
+  absl::FixedArray<optional<GetResp>, 8> ordered_by_shard{args.size()};
+  ReorderShardResults(mget_resp, cmnd_cntx.tx, true, &ordered_by_shard);
+  for (const auto& entry : ordered_by_shard) {
+    if (entry) {
+      rb->SendValue(entry->key, entry->value, 0, entry->mc_flag, fetch_mask & FETCH_MCVER);
+    } else {
+      rb->SendMiss();
+    }
+  }
+  rb->SendGetEnd();
+}
+
 #define HFUNC(x) SetHandler(&StringFamily::x)
 
 void StringFamily::Register(CommandRegistry* registry) {
@@ -1649,31 +1749,32 @@ void StringFamily::Register(CommandRegistry* registry) {
       CO::WRITE | CO::DENYOOM | CO::INTERLEAVED_KEYS | CO::NO_AUTOJOURNAL;
 
   registry->StartFamily(acl::STRING);
-  *registry << CI{"SET", CO::WRITE | CO::DENYOOM | CO::NO_AUTOJOURNAL, -3, 1, 1}.HFUNC(Set)
-            << CI{"SETEX", CO::WRITE | CO::DENYOOM | CO::NO_AUTOJOURNAL, 4, 1, 1}.HFUNC(SetEx)
-            << CI{"PSETEX", CO::WRITE | CO::DENYOOM | CO::NO_AUTOJOURNAL, 4, 1, 1}.HFUNC(PSetEx)
-            << CI{"SETNX", CO::WRITE | CO::DENYOOM | CO::FAST, 3, 1, 1}.HFUNC(SetNx)
-            << CI{"APPEND", CO::WRITE | CO::DENYOOM | CO::FAST, 3, 1, 1}.HFUNC(Append)
-            << CI{"PREPEND", CO::WRITE | CO::DENYOOM | CO::FAST, 3, 1, 1}.HFUNC(Prepend)
-            << CI{"INCR", CO::WRITE | CO::FAST, 2, 1, 1}.HFUNC(Incr)
-            << CI{"DECR", CO::WRITE | CO::FAST, 2, 1, 1}.HFUNC(Decr)
-            << CI{"INCRBY", CO::WRITE | CO::FAST, 3, 1, 1}.HFUNC(IncrBy)
-            << CI{"INCRBYFLOAT", CO::WRITE | CO::FAST, 3, 1, 1}.HFUNC(IncrByFloat)
-            << CI{"DECRBY", CO::WRITE | CO::FAST, 3, 1, 1}.HFUNC(DecrBy)
-            << CI{"GET", CO::READONLY | CO::FAST, 2, 1, 1}.HFUNC(Get)
-            << CI{"GETDEL", CO::WRITE | CO::FAST, 2, 1, 1}.HFUNC(GetDel)
-            << CI{"GETEX", CO::WRITE | CO::DENYOOM | CO::FAST | CO::NO_AUTOJOURNAL, -2, 1, 1}.HFUNC(
-                   GetEx)
-            << CI{"GETSET", CO::WRITE | CO::DENYOOM | CO::FAST, 3, 1, 1}.HFUNC(GetSet)
-            << CI{"MGET", CO::READONLY | CO::FAST | CO::IDEMPOTENT, -2, 1, -1}.HFUNC(MGet)
-            << CI{"MSET", kMSetMask, -3, 1, -1}.HFUNC(MSet)
-            << CI{"MSETNX", kMSetMask, -3, 1, -1}.HFUNC(MSetNx)
-            << CI{"STRLEN", CO::READONLY | CO::FAST, 2, 1, 1}.HFUNC(StrLen)
-            << CI{"GETRANGE", CO::READONLY, 4, 1, 1}.HFUNC(GetRange)
-            << CI{"SUBSTR", CO::READONLY, 4, 1, 1}.HFUNC(GetRange)  // Alias for GetRange
-            << CI{"SETRANGE", CO::WRITE | CO::DENYOOM, 4, 1, 1}.HFUNC(SetRange)
-            << CI{"CL.THROTTLE", CO::WRITE | CO::DENYOOM | CO::FAST, -5, 1, 1, acl::THROTTLE}.HFUNC(
-                   ClThrottle);
+  *registry
+      << CI{"SET", CO::WRITE | CO::DENYOOM | CO::NO_AUTOJOURNAL, -3, 1, 1}.HFUNC(Set)
+      << CI{"SETEX", CO::WRITE | CO::DENYOOM | CO::NO_AUTOJOURNAL, 4, 1, 1}.HFUNC(SetEx)
+      << CI{"PSETEX", CO::WRITE | CO::DENYOOM | CO::NO_AUTOJOURNAL, 4, 1, 1}.HFUNC(PSetEx)
+      << CI{"SETNX", CO::WRITE | CO::DENYOOM | CO::FAST, 3, 1, 1}.HFUNC(SetNx)
+      << CI{"APPEND", CO::WRITE | CO::DENYOOM | CO::FAST, 3, 1, 1}.HFUNC(Append)
+      << CI{"PREPEND", CO::WRITE | CO::DENYOOM | CO::FAST, 3, 1, 1}.HFUNC(Prepend)
+      << CI{"INCR", CO::WRITE | CO::FAST, 2, 1, 1}.HFUNC(Incr)
+      << CI{"DECR", CO::WRITE | CO::FAST, 2, 1, 1}.HFUNC(Decr)
+      << CI{"INCRBY", CO::WRITE | CO::FAST, 3, 1, 1}.HFUNC(IncrBy)
+      << CI{"INCRBYFLOAT", CO::WRITE | CO::FAST, 3, 1, 1}.HFUNC(IncrByFloat)
+      << CI{"DECRBY", CO::WRITE | CO::FAST, 3, 1, 1}.HFUNC(DecrBy)
+      << CI{"GET", CO::READONLY | CO::FAST, 2, 1, 1}.HFUNC(Get)
+      << CI{"GETDEL", CO::WRITE | CO::FAST, 2, 1, 1}.HFUNC(GetDel)
+      << CI{"GETEX", CO::WRITE | CO::DENYOOM | CO::FAST | CO::NO_AUTOJOURNAL, -2, 1, 1}.HFUNC(GetEx)
+      << CI{"GETSET", CO::WRITE | CO::DENYOOM | CO::FAST, 3, 1, 1}.HFUNC(GetSet)
+      << CI{"MGET", CO::READONLY | CO::FAST | CO::IDEMPOTENT, -2, 1, -1}.HFUNC(MGet)
+      << CI{"MSET", kMSetMask, -3, 1, -1}.HFUNC(MSet)
+      << CI{"MSETNX", kMSetMask, -3, 1, -1}.HFUNC(MSetNx)
+      << CI{"STRLEN", CO::READONLY | CO::FAST, 2, 1, 1}.HFUNC(StrLen)
+      << CI{"GETRANGE", CO::READONLY, 4, 1, 1}.HFUNC(GetRange)
+      << CI{"SUBSTR", CO::READONLY, 4, 1, 1}.HFUNC(GetRange)  // Alias for GetRange
+      << CI{"SETRANGE", CO::WRITE | CO::DENYOOM, 4, 1, 1}.HFUNC(SetRange)
+      << CI{"CL.THROTTLE", CO::WRITE | CO::DENYOOM | CO::FAST, -5, 1, 1, acl::THROTTLE}.HFUNC(
+             ClThrottle)
+      << CI{"GAT", CO::WRITE | CO::DENYOOM | CO::NO_AUTOJOURNAL | CO::HIDDEN, -3, 2, -1}.HFUNC(GAT);
 }
 
 }  // namespace dfly

--- a/src/server/string_family.h
+++ b/src/server/string_family.h
@@ -47,6 +47,7 @@ class StringFamily {
   static void PSetEx(CmdArgList args, const CommandContext& cmnd_cntx);
 
   static void ClThrottle(CmdArgList args, const CommandContext& cmnd_cntx);
+  static void GAT(CmdArgList args, const CommandContext& cmnd_cntx);
 };
 
 }  // namespace dfly

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -532,7 +532,12 @@ auto BaseFamilyTest::GetMC(MP::CmdType cmd_type, std::initializer_list<std::stri
   MP::Command cmd;
   cmd.type = cmd_type;
   auto src = list.begin();
-  cmd.key = *src++;
+  if (cmd.type == MP::GAT || cmd.type == MP::GATS) {
+    CHECK(absl::SimpleAtoi(*src++, &cmd.expire_ts));
+  } else {
+    cmd.key = *src++;
+  }
+
   for (; src != list.end(); ++src) {
     cmd.keys_ext.push_back(*src);
   }


### PR DESCRIPTION
A new command is added to the string family called `GAT` which implements the memcache get and touch semantics. The command syntax is `GAT <expiry-seconds> key [keys...]`.

Most of the changes in the PR are related to extracting common code from the `MGET` path to be reused for `GAT`. 

A collection function is extracted which takes a search function to search for an individual key and collect results across many keys. Search has a dbslice iterator template parameter which can be mutable or immutable, depending on the command invoking it.

A runtime check is made such that a read only command does not invoke the helper with a mutable iterator.

Follow up of https://github.com/dragonflydb/dragonfly/pull/5199

The `GATS` command is also implemented, it returns a placeholder CAS version of 0 for now.

fixes https://github.com/dragonflydb/dragonfly/issues/5089