### PR TITLE
fix(transaction): Fix non-transactional multi/exec transaction access

### DIFF
--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -145,6 +145,7 @@ struct CmdArgParser {
     return *this;
   }
 
+  // Expect no more arguments and return if no error has occured
   bool Finalize() {
     if (HasNext()) {
       Report(UNPROCESSED, cur_i_);

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -173,11 +173,6 @@ void ConnectionContext::ChangeMonitor(bool start) {
   EnableMonitoring(start);
 }
 
-void ConnectionContext::SwitchTxCmd(const CommandId* cid) {
-  transaction->MultiSwitchCmd(cid);
-  this->cid = cid;
-}
-
 void ConnectionContext::ChangeSubscription(bool to_add, bool to_reply, CmdArgList args,
                                            facade::RedisReplyBuilder* rb) {
   vector<unsigned> result = ChangeSubscriptions(args, false, to_add, to_reply);

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -310,7 +310,6 @@ class ConnectionContext : public facade::ConnectionContext {
   void UnsubscribeAll(bool to_reply, facade::RedisReplyBuilder* rb);
   void PUnsubscribeAll(bool to_reply, facade::RedisReplyBuilder* rb);
   void ChangeMonitor(bool start);  // either start or stop monitor on a given connection
-  void SwitchTxCmd(const CommandId* cid);
 
   size_t UsedMemory() const override;
 

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -1459,7 +1459,7 @@ void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBat
         args_view.push_back(arg);
       }
       auto args_span = absl::MakeSpan(args_view);
-      local_cntx.SwitchTxCmd(cid);
+      stub_tx->MultiSwitchCmd(cid);
       crb.SetReplyMode(ReplyMode::NONE);
       stub_tx->InitByArgs(cntx_->ns, local_cntx.conn_state.db_index, args_span);
 
@@ -1481,8 +1481,8 @@ void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBat
         args_view.push_back(arg);
       }
       auto args_span = absl::MakeSpan(args_view);
-      local_cntx.SwitchTxCmd(cid);
       crb.SetReplyMode(ReplyMode::NONE);
+      stub_tx->MultiSwitchCmd(cid);
       stub_tx->InitByArgs(cntx_->ns, local_cntx.conn_state.db_index, args_span);
       sf_.service().InvokeCmd(cid, args_span,
                               CommandContext{local_cntx.transaction, &crb, &local_cntx});

--- a/src/server/list_family_test.cc
+++ b/src/server/list_family_test.cc
@@ -1109,7 +1109,7 @@ TEST_F(ListFamilyTest, LMPopInvalidSyntax) {
 
   // Zero keys
   resp = Run({"lmpop", "0", "LEFT", "COUNT", "1"});
-  EXPECT_THAT(resp, ErrArg("syntax error"));
+  EXPECT_THAT(resp, ErrArg("at least 1 input key is needed"));
 
   // Number of keys is not uint
   resp = Run({"lmpop", "aa", "a", "LEFT"});
@@ -1256,7 +1256,7 @@ TEST_F(ListFamilyTest, LMPopEdgeCases) {
 
   // Test with negative COUNT - should return error
   resp = Run({"lmpop", "1", "list", "LEFT", "COUNT", "-1"});
-  EXPECT_THAT(resp, RespArray(ElementsAre("list", RespArray(ElementsAre("b")))));
+  EXPECT_THAT(resp, ErrArg("value is not an integer or out of range"));
 }
 
 TEST_F(ListFamilyTest, LMPopDocExample) {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1351,6 +1351,7 @@ bool Service::InvokeCmd(const CommandId* cid, CmdArgList tail_args,
   DCHECK(!cid->Validate(tail_args));
 
   ConnectionContext* cntx = cmd_cntx.conn_cntx;
+  cntx->cid = cid;
   auto* builder = cmd_cntx.rb;
   DCHECK(builder);
   DCHECK(cntx);
@@ -2283,13 +2284,10 @@ void Service::Exec(CmdArgList args, const CommandContext& cmd_cntx) {
     } else {
       CmdArgVec arg_vec;
       for (const auto& scmd : exec_info.body) {
-        VLOG(2) << "TX CMD " << scmd.Cid()->name() << " " << scmd.NumArgs();
-
-        cntx->SwitchTxCmd(scmd.Cid());
-
         CmdArgList args = scmd.ArgList(&arg_vec);
 
         if (scmd.Cid()->IsTransactional()) {
+          cmd_cntx.tx->MultiSwitchCmd(scmd.Cid());
           OpStatus st = cmd_cntx.tx->InitByArgs(cntx->ns, cntx->conn_state.db_index, args);
           if (st != OpStatus::OK) {
             rb->SendError(st);

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -310,6 +310,26 @@ TEST_F(MultiTest, MultiRename) {
   EXPECT_FALSE(service_->IsShardSetLocked());
 }
 
+// Run multi without transactional commands
+TEST_F(MultiTest, MultiWithoutTx) {
+  Run({"multi"});
+  Run({"ping"});
+  auto resp = Run({"exec"});
+  EXPECT_EQ(resp, "PONG");
+
+  // EVAL without keys and default script flags should be non-transactional
+  Run({"multi"});
+  Run({"eval", "return 'OK1'", "0"});
+  Run({"ping"});
+  Run({"eval", "return 'OK2'", "0", "not-a-key"});
+  Run({"ping"});
+  Run({"eval", "return 'OK3'", "0", "not-a-key", "as-well"});
+  Run({"ping"});
+  resp = Run({"exec"});
+  EXPECT_EQ(resp.GetVec()[2], "OK2");
+  EXPECT_EQ(resp.GetVec()[4], "OK3");
+}
+
 TEST_F(MultiTest, MultiHop) {
   Run({"set", kKey1, "1"});
 

--- a/src/server/set_family_test.cc
+++ b/src/server/set_family_test.cc
@@ -115,6 +115,8 @@ TEST_F(SetFamilyTest, SInter) {
   EXPECT_THAT(resp, ErrArg("WRONGTYPE Operation against a key"));
   resp = Run({"sinterstore", "none1", "none2"});
   EXPECT_THAT(resp, IntArg(0));
+
+  EXPECT_THAT(Run({"sinter"}), ErrArg("wrong number of arguments"));
 }
 
 TEST_F(SetFamilyTest, SInterCard) {

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -318,10 +318,9 @@ void Transaction::StoreKeysInArgs(const KeyIndex& key_index) {
 }
 
 void Transaction::InitByKeys(const KeyIndex& key_index) {
-  if (key_index.start == full_args_.size()) {  // eval with 0 keys.
-    CHECK(absl::StartsWith(cid_->name(), "EVAL")) << cid_->name();
+  // Skip initialization for key-dependent transactions without keys
+  if ((key_index.end - key_index.start) + int(bool(key_index.bonus)) == 0)
     return;
-  }
 
   DCHECK_LT(key_index.start, full_args_.size());
 
@@ -1602,7 +1601,7 @@ OpResult<KeyIndex> DetermineKeys(const CommandId* cid, CmdArgList args) {
 
     if (num_custom_keys == 0 &&
         (absl::StartsWith(name, "ZDIFF") || absl::StartsWith(name, "ZUNION") ||
-         absl::StartsWith(name, "ZINTER"))) {
+         absl::StartsWith(name, "ZINTER") || absl::EndsWith(name, "MPOP"))) {
       return OpStatus::AT_LEAST_ONE_KEY;
     }
 

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -814,7 +814,7 @@ TEST_F(ZSetFamilyTest, ZMPopInvalidSyntax) {
 
   // Zero keys.
   resp = Run({"zmpop", "0", "MIN", "COUNT", "1"});
-  EXPECT_THAT(resp, ErrArg("syntax error"));
+  EXPECT_THAT(resp, ErrArg("at least 1 input key is needed"));
 
   // Number of keys not uint.
   resp = Run({"zmpop", "aa", "a", "MIN"});


### PR DESCRIPTION
Fixes #5247 

Issue:
1. Even when EVAL was non-transational (zero keys and no flags), it still initialized the transaction partially
2. MultiSwitchCmd was still called for non-transational commands, which was ok is the transaction was initialized fully or not at all
3. Combining (1) and (2), EVAL was wrongfully setting up a transation, which was then DCHECKed in (2)

Fix:
1. Correctly filter out zero keys commands
2. Call MultiSwitchCmd only for transactional (CO::Transactional) commands (includes empty eval)
3. Guard better against potential zero keys commands: lmpop, zmpop
4. Small list family cleanup