### PR TITLE
fix(search_family): Fix empty key bug

### DIFF
--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -223,7 +223,8 @@ std::optional<ShardDocIndex::DocId> ShardDocIndex::DocKeyIndex::Remove(string_vi
 
 string_view ShardDocIndex::DocKeyIndex::Get(DocId id) const {
   DCHECK_LT(id, keys_.size());
-  DCHECK_GT(keys_[id].size(), 0u);
+  // Check that this id was not removed
+  DCHECK(id < last_id_ && std::find(free_ids_.begin(), free_ids_.end(), id) == free_ids_.end());
 
   return keys_[id];
 }

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -2881,4 +2881,14 @@ TEST_F(SearchFamilyTest, SearchStatsInfoRace) {
   ASSERT_FALSE(service_->IsShardSetLocked());
 }
 
+TEST_F(SearchFamilyTest, EmptyKeyBug) {
+  auto resp = Run({"FT.CREATE", "index", "ON", "HASH", "SCHEMA", "field", "TEXT"});
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run({"HSET", "", "field", "value"});
+  EXPECT_THAT(resp, IntArg(1));
+
+  resp = Run({"FT.SEARCH", "index", "*"});
+  EXPECT_THAT(resp, AreDocIds(""));
+}
 }  // namespace dfly


### PR DESCRIPTION
Fix crash for empty keys in `ShardDocIndex::DocKeyIndex`