### PR TITLE
fix(json_family): Fix bugs where JSON commands were modifying values of other data types

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -607,17 +607,15 @@ auto DbSlice::FindInternal(const Context& cntx, string_view key, optional<unsign
   return res;
 }
 
-OpResult<DbSlice::ItAndUpdater> DbSlice::AddOrFind(const Context& cntx, string_view key,
-                                                   std::optional<unsigned> req_obj_type) {
-  return AddOrFindInternal(cntx, key, req_obj_type);
+OpResult<DbSlice::ItAndUpdater> DbSlice::AddOrFind(const Context& cntx, string_view key) {
+  return AddOrFindInternal(cntx, key);
 }
 
-OpResult<DbSlice::ItAndUpdater> DbSlice::AddOrFindInternal(const Context& cntx, string_view key,
-                                                           std::optional<unsigned> req_obj_type) {
+OpResult<DbSlice::ItAndUpdater> DbSlice::AddOrFindInternal(const Context& cntx, string_view key) {
   DCHECK(IsDbValid(cntx.db_index));
 
   DbTable& db = *db_arr_[cntx.db_index];
-  auto res = FindInternal(cntx, key, req_obj_type, UpdateStatsMode::kMutableStats);
+  auto res = FindInternal(cntx, key, std::nullopt, UpdateStatsMode::kMutableStats);
 
   if (res.ok()) {
     Iterator it(res->it, StringOrView::FromView(key));
@@ -638,10 +636,7 @@ OpResult<DbSlice::ItAndUpdater> DbSlice::AddOrFindInternal(const Context& cntx, 
     } else {
       res = OpStatus::KEY_NOTFOUND;
     }
-  } else if (res == OpStatus::WRONG_TYPE) {
-    return OpStatus::WRONG_TYPE;
   }
-
   auto status = res.status();
   CHECK(status == OpStatus::KEY_NOTFOUND || status == OpStatus::OUT_OF_MEMORY) << status;
 

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -306,8 +306,7 @@ class DbSlice {
   OpResult<ConstIterator> FindReadOnly(const Context& cntx, std::string_view key,
                                        unsigned req_obj_type) const;
 
-  OpResult<ItAndUpdater> AddOrFind(const Context& cntx, std::string_view key,
-                                   std::optional<unsigned> req_obj_type = std::nullopt);
+  OpResult<ItAndUpdater> AddOrFind(const Context& cntx, std::string_view key);
 
   // Same as AddOrSkip, but overwrites in case entry exists.
   OpResult<ItAndUpdater> AddOrUpdate(const Context& cntx, std::string_view key, PrimeValue obj,
@@ -584,8 +583,7 @@ class DbSlice {
 
   PrimeItAndExp ExpireIfNeeded(const Context& cntx, PrimeIterator it) const;
 
-  OpResult<ItAndUpdater> AddOrFindInternal(const Context& cntx, std::string_view key,
-                                           std::optional<unsigned> req_obj_type);
+  OpResult<ItAndUpdater> AddOrFindInternal(const Context& cntx, std::string_view key);
 
   OpResult<PrimeItAndExp> FindInternal(const Context& cntx, std::string_view key,
                                        std::optional<unsigned> req_obj_type,

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -429,8 +429,14 @@ std::optional<JsonType> ShardJsonFromString(std::string_view input) {
 }
 
 OpStatus SetFullJson(const OpArgs& op_args, string_view key, string_view json_str) {
-  auto it_res = op_args.GetDbSlice().AddOrFind(op_args.db_cntx, key, OBJ_JSON);
+  auto it_res = op_args.GetDbSlice().AddOrFind(op_args.db_cntx, key);
   RETURN_ON_BAD_STATUS(it_res);
+
+  auto type = it_res->it->second.ObjType();
+  if (type != OBJ_JSON && type != OBJ_STRING) {
+    // The object is not a JSON object and not a string, so we cannot set a full JSON value
+    return OpStatus::WRONG_TYPE;
+  }
 
   JsonAutoUpdater updater(op_args, key, *std::move(it_res));
 


### PR DESCRIPTION
fixes #5265 

~In this PR, I added `req_obj_type` to the `AddOrFind` method. I see that this method is also used in other data types, which could lead to bugs. Once this PR is approved, I will review other commands and possibly remove the version of `AddOrFind` that doesn't need `req_obj_type`.~

This PR fixes several bugs that are well described in the issue above::
1. Fixed bug in the `JSON.SET` command
2. Fixed bug in the `JSON.DEL` command
3. Add comment to the `JSON.GET` command