### PR TITLE
fix(reply_builder): Flush if last message didn't reply and flush but supose to

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1653,8 +1653,8 @@ void Connection::AsyncFiber() {
       // We keep the batch mode enabled as long as the dispatch queue is not empty, relying on the
       // last command to reply and flush. If it doesn't reply (i.e. is a control message like
       // migrate), we have to flush manually.
-      bool is_replaying = msg.IsReplying();
-      if (dispatch_q_.empty() && !is_replaying) {
+      bool is_replying = msg.IsReplying();
+      if (dispatch_q_.empty() && !is_replying) {
         reply_builder_->Flush();
       }
 
@@ -1669,9 +1669,9 @@ void Connection::AsyncFiber() {
       cc_->async_dispatch = true;
       std::visit(async_op, msg.handle);
       cc_->async_dispatch = false;
-      // If last msg in queue was replaying but nothing was replied during dispatch
+      // If last msg in queue was replying but nothing was replied during dispatch
       // (i.e. pubsub message was discarded) we have to manually flush now.
-      if (dispatch_q_.empty() && is_replaying &&
+      if (dispatch_q_.empty() && is_replying &&
           (replies_recorded_before == reply_builder_->RepliesRecorded())) {
         reply_builder_->Flush();
       }

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -184,12 +184,6 @@ void ConnectionContext::ChangeSubscription(bool to_add, bool to_reply, CmdArgLis
       rb->SendBulkString(action[to_add]);
       rb->SendBulkString(ArgS(args, i));
       rb->SendLong(result[i]);
-      // We are manually flushing reply builder here. It can happen that we are subscribed to
-      // channel and `UNSUBSCRIBE` is executed while we are receiving messages
-      // we can end up in `batched_` mode when dispatch_q_.size() > 1. In batch mode we
-      // are not sending back replay until condition is met - SinkReplyBuilder::FinishScope().
-      // If `UNSUBSCRIBE` is blocking call from client side this can lead to hang - ticket #5139.
-      rb->Flush();
     }
   }
 }

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -184,6 +184,12 @@ void ConnectionContext::ChangeSubscription(bool to_add, bool to_reply, CmdArgLis
       rb->SendBulkString(action[to_add]);
       rb->SendBulkString(ArgS(args, i));
       rb->SendLong(result[i]);
+      // We are manually flushing reply builder here. It can happen that we are subscribed to
+      // channel and `UNSUBSCRIBE` is executed while we are receiving messages
+      // we can end up in `batched_` mode when dispatch_q_.size() > 1. In batch mode we
+      // are not sending back replay until condition is met - SinkReplyBuilder::FinishScope().
+      // If `UNSUBSCRIBE` is blocking call from client side this can lead to hang - ticket #5139.
+      rb->Flush();
     }
   }
 }


### PR DESCRIPTION
When connection is subscribed to channel we are receiving async messages and sending them back to client. When UNSUBSCRIBE is received on same connection it can happen that we are starting to send back data in batch mode. In batch mode we will be aggregating responses until flush. Last message in queue should flush during reply but if it didn't (i.e. PubSub message was discarded) we are going to flush manually.

Fixes #5139 #5251

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->