### PR TITLE
fix(json): Ensure full deletion for multi-match JSONPaths

### DIFF
--- a/src/core/json/detail/jsoncons_dfs.cc
+++ b/src/core/json/detail/jsoncons_dfs.cc
@@ -106,7 +106,7 @@ Dfs Dfs::Mutate(absl::Span<const PathSegment> path, const MutateCallback& callba
         if (next_seg_id + 1 < path.size()) {
           stack.emplace_back(next, next_seg_id);
         } else {
-          // Terminal step: collect node for mutation if not seen before
+          // Terminal step: collect node for mutation
           nodes_to_mutate.push_back(next);
         }
       }
@@ -126,10 +126,11 @@ Dfs Dfs::Mutate(absl::Span<const PathSegment> path, const MutateCallback& callba
     }
   } while (!stack.empty());
 
-  // Apply mutations after DFS traversal is complete
+  // Apply mutations after DFS traversal is complete in reverse order
+  // This ensures that deeper mutations don't affect shallower ones
   const PathSegment& terminal_segment = path.back();
-  for (JsonType* node : nodes_to_mutate) {
-    dfs.MutateStep(terminal_segment, callback, node);
+  for (auto it = nodes_to_mutate.rbegin(); it != nodes_to_mutate.rend(); ++it) {
+    dfs.MutateStep(terminal_segment, callback, *it);
   }
 
   return dfs;

--- a/src/core/json/detail/jsoncons_dfs.cc
+++ b/src/core/json/detail/jsoncons_dfs.cc
@@ -71,8 +71,8 @@ Dfs Dfs::Traverse(absl::Span<const PathSegment> path, const JsonType& root, cons
   return dfs;
 }
 
-Dfs Dfs::Mutate(absl::Span<const PathSegment> path, const MutateCallback& callback,
-                JsonType* json) {
+Dfs Dfs::Mutate(absl::Span<const PathSegment> path, const MutateCallback& callback, JsonType* json,
+                bool reverse_traversal) {
   DCHECK(!path.empty());
 
   Dfs dfs;
@@ -126,11 +126,17 @@ Dfs Dfs::Mutate(absl::Span<const PathSegment> path, const MutateCallback& callba
     }
   } while (!stack.empty());
 
-  // Apply mutations after DFS traversal is complete in reverse order
-  // This ensures that deeper mutations don't affect shallower ones
+  // Apply mutations after DFS traversal is complete
   const PathSegment& terminal_segment = path.back();
-  for (auto it = nodes_to_mutate.rbegin(); it != nodes_to_mutate.rend(); ++it) {
-    dfs.MutateStep(terminal_segment, callback, *it);
+  if (reverse_traversal) {
+    // This ensures that deeper mutations don't affect shallower ones by iterating in reverse
+    for (auto it = nodes_to_mutate.rbegin(); it != nodes_to_mutate.rend(); ++it) {
+      dfs.MutateStep(terminal_segment, callback, *it);
+    }
+  } else {
+    for (auto it = nodes_to_mutate.begin(); it != nodes_to_mutate.end(); ++it) {
+      dfs.MutateStep(terminal_segment, callback, *it);
+    }
   }
 
   return dfs;

--- a/src/core/json/detail/jsoncons_dfs.h
+++ b/src/core/json/detail/jsoncons_dfs.h
@@ -113,7 +113,7 @@ class Dfs {
   // TODO: for some operations we need to know the type of mismatches.
   static Dfs Traverse(absl::Span<const PathSegment> path, const JsonType& json, const Cb& callback);
   static Dfs Mutate(absl::Span<const PathSegment> path, const MutateCallback& callback,
-                    JsonType* json);
+                    JsonType* json, bool reverse_traversal);
 
   unsigned matches() const {
     return matches_;

--- a/src/core/json/jsonpath_test.cc
+++ b/src/core/json/jsonpath_test.cc
@@ -599,4 +599,49 @@ TYPED_TEST(JsonPathTest, SubRange) {
   arr.clear();
 }
 
+TYPED_TEST(JsonPathTest, MutateDeleteNestedWithSameKey) {
+  // Test for deleting nested elements with the same key using "$..a"
+  // Corresponds to command: JSON.DEL doc1 "$..a"
+  ASSERT_EQ(0, this->Parse("$..a"));
+  Path path = this->driver_.TakePath();
+
+  TypeParam json = ValidJson<TypeParam>(R"({"a": 1, "nested": {"a": 2, "b": 3}})");
+
+  unsigned deleted_count = 0;
+  auto delete_cb = [&](optional<string_view> key, JsonType* val) {
+    // Delete all elements with key "a"
+    if (key && key.value() == "a") {
+      deleted_count++;
+      return true;  // delete element
+    }
+    return false;  // keep element
+  };
+
+  if constexpr (std::is_same_v<TypeParam, JsonType>) {
+    unsigned reported_matches = MutatePath(path, delete_cb, &json);
+
+    // Verify that exactly 2 elements were deleted
+    EXPECT_EQ(2, deleted_count);
+    // Verify that MutatePath reports 2 matches
+    EXPECT_EQ(2, reported_matches);
+
+    // Verify result after deletion: {"nested": {"b": 3}}
+    auto expected = ValidJson<JsonType>(R"({"nested": {"b": 3}})");
+    EXPECT_EQ(expected, json);
+  } else {
+    flexbuffers::Builder fbb;
+    unsigned reported_matches = MutatePath(path, delete_cb, json, &fbb);
+
+    // Verify that exactly 2 elements were deleted
+    EXPECT_EQ(2, deleted_count);
+    // Verify that MutatePath reports 2 matches
+    EXPECT_EQ(2, reported_matches);
+
+    // Verify result after deletion
+    FlatJson result = flexbuffers::GetRoot(fbb.GetBuffer());
+    auto expected = ValidJson<JsonType>(R"({"nested": {"b": 3}})");
+    EXPECT_EQ(expected, FromFlat(result));
+  }
+}
+
 }  // namespace dfly::json

--- a/src/core/json/jsonpath_test.cc
+++ b/src/core/json/jsonpath_test.cc
@@ -618,7 +618,7 @@ TYPED_TEST(JsonPathTest, MutateDeleteNestedWithSameKey) {
   };
 
   if constexpr (std::is_same_v<TypeParam, JsonType>) {
-    unsigned reported_matches = MutatePath(path, delete_cb, &json);
+    unsigned reported_matches = MutatePath(path, delete_cb, &json, true /* reverse_traversal */);
 
     // Verify that exactly 2 elements were deleted
     EXPECT_EQ(2, deleted_count);
@@ -630,7 +630,8 @@ TYPED_TEST(JsonPathTest, MutateDeleteNestedWithSameKey) {
     EXPECT_EQ(expected, json);
   } else {
     flexbuffers::Builder fbb;
-    unsigned reported_matches = MutatePath(path, delete_cb, json, &fbb);
+    unsigned reported_matches =
+        MutatePath(path, delete_cb, json, &fbb, true /* reverse_traversal */);
 
     // Verify that exactly 2 elements were deleted
     EXPECT_EQ(2, deleted_count);

--- a/src/core/json/path.cc
+++ b/src/core/json/path.cc
@@ -148,13 +148,14 @@ nonstd::expected<json::Path, string> ParsePath(string_view path) {
   return driver.TakePath();
 }
 
-unsigned MutatePath(const Path& path, MutateCallback callback, JsonType* json) {
+unsigned MutatePath(const Path& path, MutateCallback callback, JsonType* json,
+                    bool reverse_traversal) {
   if (path.empty()) {
     callback(nullopt, json);
     return 1;
   }
 
-  Dfs dfs = Dfs::Mutate(path, callback, json);
+  Dfs dfs = Dfs::Mutate(path, callback, json, reverse_traversal);
   return dfs.matches();
 }
 
@@ -285,9 +286,9 @@ void FromJsonType(const JsonType& src, flexbuffers::Builder* fbb) {
 }
 
 unsigned MutatePath(const Path& path, MutateCallback callback, FlatJson json,
-                    flexbuffers::Builder* fbb) {
+                    flexbuffers::Builder* fbb, bool reverse_traversal) {
   JsonType mut_json = FromFlat(json);
-  unsigned res = MutatePath(path, std::move(callback), &mut_json);
+  unsigned res = MutatePath(path, std::move(callback), &mut_json, reverse_traversal);
 
   // Populate the output builder 'fbb' with the resulting JSON state
   // (mutated or original if res == 0) and finalize it.

--- a/src/core/json/path.h
+++ b/src/core/json/path.h
@@ -134,9 +134,10 @@ void EvaluatePath(const Path& path, const JsonType& json, PathCallback callback)
 void EvaluatePath(const Path& path, FlatJson json, PathFlatCallback callback);
 
 // returns number of matches found with the given path.
-unsigned MutatePath(const Path& path, MutateCallback callback, JsonType* json);
+unsigned MutatePath(const Path& path, MutateCallback callback, JsonType* json,
+                    bool reverse_traversal = false);
 unsigned MutatePath(const Path& path, MutateCallback callback, FlatJson json,
-                    flexbuffers::Builder* fbb);
+                    flexbuffers::Builder* fbb, bool reverse_traversal = false);
 
 // utility function to parse a jsonpath. Returns an error message if a parse error was
 // encountered.

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -1048,7 +1048,8 @@ OpResult<long> OpDel(const OpArgs& op_args, string_view key, string_view path,
     JsonAutoUpdater updater(op_args, key, *std::move(it_res), true);
     const json::Path& path = json_path.AsJsonPath();
     long deletions = json::MutatePath(
-        path, [](optional<string_view>, JsonType* val) { return true; }, updater.GetJson());
+        path, [](optional<string_view>, JsonType* val) { return true; }, updater.GetJson(),
+        true /* reverse_traversal */);
     return deletions;
   }
 


### PR DESCRIPTION
Fixes: https://github.com/dragonflydb/dragonfly/issues/5259

This PR resolves an issue where JSON.DEL failed to remove all targeted elements when a JSONPath expression (e.g., $..a) matched multiple nodes within a JSON object.

The bug was caused by using forward iteration while deleting from a collection, which resulted in skipping elements as indices shifted during the mutation.

The solution implements a context-aware traversal strategy:
- Reverse traversal is now explicitly used for delete operations, guaranteeing that all matched nodes are processed and removed correctly.
- Forward traversal is preserved for non-destructive mutations (e.g., updates), for which it is safe and efficient.
This approach ensures JSON.DEL is robust and predictable without impacting other mutation commands.
