### PR TITLE
chore: minor fixes in dash table

### DIFF
--- a/src/core/dash_test.cc
+++ b/src/core/dash_test.cc
@@ -829,6 +829,16 @@ TEST_F(DashTest, CVCUponInsert) {
   dt.CVCUponInsert(1, i, cb);
 }
 
+TEST_F(DashTest, CVCUponInsertStress) {
+  VersionDT dt;
+  for (int i = 0; i < 5000; ++i) {
+    dt.CVCUponInsert(1, i, [](VersionDT::bucket_iterator) {
+      // empty callback
+    });
+    dt.Insert(i, 0);
+  }
+}
+
 struct A {
   int a = 0;
   unsigned moved = 0;
@@ -1039,7 +1049,7 @@ struct ShiftRightPolicy {
     stash_it += (U64Dash::kSlotNum - 1);  // go to the last slot.
 
     uint64_t k = stash_it->first;
-    DVLOG(1) << "Deleting key " << k << " from " << stash_it.bucket_id() << "/"
+    DVLOG(1) << "Deleting key " << k << " from " << unsigned(stash_it.bucket_id()) << "/"
              << stash_it.slot_id();
     evicted[k]++;
 

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -2446,9 +2446,9 @@ TEST_F(SearchFamilyTest, SearchNonNullFields) {
   EXPECT_THAT(Run({"ft.search", "num_idx", "*"}), AreDocIds("num:1", "num:2", "num:3"));
 
   // Testing vector indices with star query
-  string vector1 = "\\x00\\x00\\x80\\x3f\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00";  // [1,0,0]
-  string vector2 = "\\x00\\x00\\x00\\x00\\x00\\x00\\x80\\x3f\\x00\\x00\\x00\\x00";  // [0,1,0]
-  string vector3 = "\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x80\\x3f";  // [0,0,1]
+  string vector1 = R"(\x00\x00\x80\x3f\x00\x00\x00\x00\x00\x00\x00\x00)";  // [1,0,0]
+  string vector2 = R"(\x00\x00\x00\x00\x00\x00\x80\x3f\x00\x00\x00\x00)";  // [0,1,0]
+  string vector3 = R"(\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\x3f)";  // [0,0,1]
 
   Run({"hset", "vec:1", "embedding", vector1});
   Run({"hset", "vec:2", "embedding", vector2});
@@ -2456,10 +2456,9 @@ TEST_F(SearchFamilyTest, SearchNonNullFields) {
 
   // Testing star query with result limit
   auto limit_result = Run({"ft.search", "text_idx", "*", "LIMIT", "0", "2"});
-  ASSERT_GE(limit_result.GetVec().size(), 5);                 // Total count + 2 docs with fields
-  EXPECT_EQ(limit_result.GetVec()[0].GetInt(), 3);            // Total count is 3 (all matches)
-  EXPECT_EQ(limit_result.GetVec()[1].GetString(), "text:1");  // First doc
-  EXPECT_EQ(limit_result.GetVec()[3].GetString(), "text:2");  // Second doc
+
+  // No sorting, so results returned are in random order (implementation-dependent).
+  EXPECT_THAT(limit_result, RespElementsAre(IntArg(3), _, _, _, _));
 
   // Testing star query with sorting
   auto price_desc_result = Run({"ft.search", "num_idx", "*", "SORTBY", "price", "DESC"});


### PR DESCRIPTION
Also, relax SearchNonNullFields some checks that break if we change dashtable internals due to change of items ordering in the table.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->