### PR TITLE
feat (server): add on move hook to dash insert new and bumpup

### DIFF
--- a/src/core/dash.h
+++ b/src/core/dash.h
@@ -11,6 +11,74 @@
 
 namespace dfly {
 
+template <typename EvictionPolicy> class MoveCallback {
+ public:
+  // Constructor with 2 segments (source and destination), used in split flow
+  MoveCallback(EvictionPolicy& ev, uint8_t global_depth, uint32_t src_seg_id, uint32_t dest_seg_id)
+      : ev_(ev), global_depth_(global_depth), src_seg_id_(src_seg_id), dest_seg_id_(dest_seg_id) {
+  }
+
+  // Constructor for single segment (intra-segment move)
+  MoveCallback(EvictionPolicy& ev, uint8_t global_depth, uint32_t seg_id)
+      : ev_(ev), global_depth_(global_depth), src_seg_id_(seg_id), dest_seg_id_(seg_id) {
+  }
+
+  enum class MoveOpt {
+    kMoveInSourceSegment,
+    kMoveInDestSegment,
+    kMoveBetweenSegments,
+    kIntraSegment
+  };
+
+  void SetMoveInDest() {
+    move_opt_ = MoveOpt::kMoveInDestSegment;
+  }
+  void SetMoveInSource() {
+    move_opt_ = MoveOpt::kMoveInSourceSegment;
+  }
+  void SetMoveBeweenSegments() {
+    move_opt_ = MoveOpt::kMoveBetweenSegments;
+  }
+
+  using Cursor = detail::DashCursor;
+  void operator()(uint8_t src_bid, uint8_t dest_bid) const {
+    Cursor src_cursor{global_depth_, GetSrcSegId(), src_bid};
+    Cursor dest_cursor{global_depth_, GetDestSegId(), dest_bid};
+    ev_.OnMove(src_cursor, dest_cursor);
+  }
+
+ private:
+  EvictionPolicy& ev_;
+  uint8_t global_depth_;
+  uint32_t src_seg_id_;
+  uint32_t dest_seg_id_;
+  MoveOpt move_opt_ = MoveOpt::kIntraSegment;
+
+  uint32_t GetSrcSegId() const {
+    switch (move_opt_) {
+      case MoveOpt::kMoveInDestSegment:
+        return dest_seg_id_;
+      case MoveOpt::kIntraSegment:
+      case MoveOpt::kMoveInSourceSegment:
+      case MoveOpt::kMoveBetweenSegments:
+      default:
+        return src_seg_id_;
+    }
+  }
+
+  uint32_t GetDestSegId() const {
+    switch (move_opt_) {
+      case MoveOpt::kMoveInSourceSegment:
+        return src_seg_id_;
+      case MoveOpt::kIntraSegment:
+      case MoveOpt::kMoveInDestSegment:
+      case MoveOpt::kMoveBetweenSegments:
+      default:
+        return dest_seg_id_;
+    }
+  }
+};
+
 // DASH: Dynamic And Scalable Hashing.
 
 template <typename _Key, typename _Value, typename Policy>
@@ -83,6 +151,9 @@ class DashTable : public detail::DashTableBase {
 
     bool CanGrow(const DashTable&) {
       return true;
+    }
+
+    void OnMove(Cursor source, Cursor dest) {
     }
 
     void RecordSplit(SegmentType* segment) {
@@ -286,9 +357,10 @@ class DashTable : public detail::DashTableBase {
   // Returns true if an element was deleted i.e the rightmost slot was busy.
   bool ShiftRight(bucket_iterator it);
 
-  template <typename BumpPolicy> iterator BumpUp(iterator it, const BumpPolicy& bp) {
+  template <typename BumpPolicy> iterator BumpUp(iterator it, BumpPolicy& bp) {
+    MoveCallback move_cb(bp, global_depth_, it.seg_id_);
     SegmentIterator seg_it =
-        segment_[it.seg_id_]->BumpUp(it.bucket_id_, it.slot_id_, DoHash(it->first), bp);
+        segment_[it.seg_id_]->BumpUp(it.bucket_id_, it.slot_id_, DoHash(it->first), bp, move_cb);
 
     return iterator{this, it.seg_id_, seg_it.index, seg_it.slot};
   }
@@ -314,7 +386,7 @@ class DashTable : public detail::DashTableBase {
                                            InsertMode mode);
 
   void IncreaseDepth(unsigned new_depth);
-  void Split(uint32_t seg_id);
+  template <typename EvictionPolicy> void Split(uint32_t seg_id, EvictionPolicy& ev);
 
   // Segment directory contains multiple segment pointers, some of them pointing to
   // the same object. IterateDistinct goes over all distinct segments in the table.
@@ -786,12 +858,15 @@ auto DashTable<_Key, _Value, Policy>::InsertInternal(U&& key, V&& value, Evictio
     typename SegmentType::Iterator it;
     bool res = true;
     unsigned num_buckets = target->num_buckets();
+
+    MoveCallback move_cb(ev, global_depth_, target_seg_id);
     if (mode == InsertMode::kForceInsert) {
-      it = target->InsertUniq(std::forward<U>(key), std::forward<V>(value), key_hash, true);
+      it =
+          target->InsertUniq(std::forward<U>(key), std::forward<V>(value), key_hash, true, move_cb);
       res = it.found();
     } else {
-      std::tie(it, res) =
-          target->Insert(std::forward<U>(key), std::forward<V>(value), key_hash, EqPred(key));
+      std::tie(it, res) = target->Insert(std::forward<U>(key), std::forward<V>(value), key_hash,
+                                         EqPred(key), move_cb);
     }
 
     if (res) {  // success
@@ -846,7 +921,7 @@ auto DashTable<_Key, _Value, Policy>::InsertInternal(U&& key, V&& value, Evictio
       }
 
       auto hash_fn = [this](const auto& k) { return policy_.HashFn(k); };
-      unsigned moved = target->UnloadStash(hash_fn);
+      unsigned moved = target->UnloadStash(hash_fn, move_cb);
       if (moved > 0) {
         stash_unloaded_ += moved;
         continue;
@@ -876,7 +951,7 @@ auto DashTable<_Key, _Value, Policy>::InsertInternal(U&& key, V&& value, Evictio
     }
 
     ev.RecordSplit(target);
-    Split(target_seg_id);
+    Split(target_seg_id, ev);
   }
 
   return std::make_pair(iterator{}, false);
@@ -898,7 +973,8 @@ void DashTable<_Key, _Value, Policy>::IncreaseDepth(unsigned new_depth) {
 }
 
 template <typename _Key, typename _Value, typename Policy>
-void DashTable<_Key, _Value, Policy>::Split(uint32_t seg_id) {
+template <typename EvictionPolicy>
+void DashTable<_Key, _Value, Policy>::Split(uint32_t seg_id, EvictionPolicy& ev) {
   SegmentType* source = segment_[seg_id];
 
   size_t chunk_size = 1u << (global_depth_ - source->local_depth());
@@ -910,7 +986,9 @@ void DashTable<_Key, _Value, Policy>::Split(uint32_t seg_id) {
 
   // remove current segment bucket count.
   bucket_count_ -= (source->num_buckets() + target->num_buckets());
-  source->Split(std::move(hash_fn), target);  // increases the depth.
+
+  MoveCallback move_cb(ev, global_depth_, start_idx, start_idx + chunk_size / 2);
+  source->Split(std::move(hash_fn), target, move_cb);  // increases the depth.
 
   // add back the updated bucket count.
   bucket_count_ += (target->num_buckets() + source->num_buckets());

--- a/src/core/dash_internal.h
+++ b/src/core/dash_internal.h
@@ -405,10 +405,11 @@ class Segment {
 
   // Returns (iterator, true) if insert succeeds,
   // (iterator, false) for duplicate and (invalid-iterator, false) if it's full
-  template <typename K, typename V, typename Pred>
-  std::pair<Iterator, bool> Insert(K&& key, V&& value, Hash_t key_hash, Pred&& pred);
+  template <typename K, typename V, typename Pred, typename OnMoveCb>
+  std::pair<Iterator, bool> Insert(K&& key, V&& value, Hash_t key_hash, Pred&& pred, OnMoveCb& cb);
 
-  template <typename HashFn> void Split(HashFn&& hfunc, Segment* dest);
+  template <typename HashFn, typename OnMoveCb>
+  void Split(HashFn&& hfunc, Segment* dest, OnMoveCb& cb);
 
   void Delete(const Iterator& it, Hash_t key_hash);
 
@@ -515,8 +516,8 @@ class Segment {
   // otherwise chooses home bucket first.
   // TODO: I am actually not sure if spread optimization is helpful. Worth checking
   // whether we get higher occupancy rates when using it.
-  template <typename U, typename V>
-  Iterator InsertUniq(U&& key, V&& value, Hash_t key_hash, bool spread);
+  template <typename U, typename V, typename OnMoveCb>
+  Iterator InsertUniq(U&& key, V&& value, Hash_t key_hash, bool spread, OnMoveCb& cb);
 
   // capture version change in case of insert.
   // Returns ids of buckets whose version would cross ver_threshold upon insertion of key_hash
@@ -550,14 +551,15 @@ class Segment {
   }
 
   // Bumps up this entry making it more "important" for the eviction policy.
-  template <typename BumpPolicy>
-  Iterator BumpUp(PhysicalBid bid, SlotId slot, Hash_t key_hash, const BumpPolicy& ev);
+  template <typename BumpPolicy, typename OnMoveCb>
+  Iterator BumpUp(PhysicalBid bid, SlotId slot, Hash_t key_hash, const BumpPolicy& ev,
+                  OnMoveCb& cb);
 
   // Tries to move stash entries back to their normal buckets (exact or neighbour).
   // Returns number of entries that succeeded to unload.
   // Important! Affects versions of the moved items and the items in the destination
   // buckets.
-  template <typename HFunc> unsigned UnloadStash(HFunc&& hfunc);
+  template <typename HFunc, typename OnMoveCb> unsigned UnloadStash(HFunc&& hfunc, OnMoveCb& cb);
 
   unsigned num_buckets() const {
     return kBucketNum + kStashBucketNum;
@@ -1075,15 +1077,15 @@ auto Segment<Key, Value, Policy>::TryMoveFromStash(unsigned stash_id, unsigned s
 }
 
 template <typename Key, typename Value, typename Policy>
-template <typename U, typename V, typename Pred>
-auto Segment<Key, Value, Policy>::Insert(U&& key, V&& value, Hash_t key_hash, Pred&& pred)
-    -> std::pair<Iterator, bool> {
+template <typename U, typename V, typename Pred, typename OnMoveCb>
+auto Segment<Key, Value, Policy>::Insert(U&& key, V&& value, Hash_t key_hash, Pred&& pred,
+                                         OnMoveCb& on_move_cb) -> std::pair<Iterator, bool> {
   Iterator it = FindIt(key_hash, pred);
   if (it.found()) {
     return std::make_pair(it, false); /* duplicate insert*/
   }
 
-  it = InsertUniq(std::forward<U>(key), std::forward<V>(value), key_hash, true);
+  it = InsertUniq(std::forward<U>(key), std::forward<V>(value), key_hash, true, on_move_cb);
 
   return std::make_pair(it, it.found());
 }
@@ -1201,8 +1203,8 @@ void Segment<Key, Value, Policy>::Delete(const Iterator& it, Hash_t key_hash) {
 // Split items from the left segment to the right during the growth phase.
 // right segment will have all the items with lsb at local_depth ==1 .
 template <typename Key, typename Value, typename Policy>
-template <typename HFunc>
-void Segment<Key, Value, Policy>::Split(HFunc&& hfn, Segment* dest_right) {
+template <typename HFunc, typename MoveCb>
+void Segment<Key, Value, Policy>::Split(HFunc&& hfn, Segment* dest_right, MoveCb& move_cb) {
   ++local_depth_;
   dest_right->local_depth_ = local_depth_;
 
@@ -1233,9 +1235,10 @@ void Segment<Key, Value, Policy>::Split(HFunc&& hfn, Segment* dest_right) {
         return;  // keep this key in the source
 
       invalid_mask |= (1u << slot);
-
-      Iterator it = dest_right->InsertUniq(std::forward<Key_t>(bucket->key[slot]),
-                                           std::forward<Value_t>(bucket->value[slot]), hash, false);
+      move_cb.SetMoveInDest();
+      Iterator it =
+          dest_right->InsertUniq(std::forward<Key_t>(bucket->key[slot]),
+                                 std::forward<Value_t>(bucket->value[slot]), hash, false, move_cb);
 
       // we move items residing in a regular bucket to a new segment.
       // Note 1: in case we are somehow attacked with items that after the split
@@ -1257,6 +1260,8 @@ void Segment<Key, Value, Policy>::Split(HFunc&& hfn, Segment* dest_right) {
       // selective bias will be able to hit our dashtable with items with the same bucket id.
       assert(it.found());
       update_version(*bucket, it.index);
+      move_cb.SetMoveBeweenSegments();
+      move_cb(i, it.index);
     };
 
     bucket_[i].ForEachSlot(std::move(cb));
@@ -1277,17 +1282,23 @@ void Segment<Key, Value, Policy>::Split(HFunc&& hfn, Segment* dest_right) {
         Iterator it = TryMoveFromStash(i, slot, hash);
         if (it.found()) {
           invalid_mask |= (1u << slot);
+          move_cb.SetMoveInSource();
+          move_cb(i, it.index);
         }
 
         return;
       }
 
       invalid_mask |= (1u << slot);
-      auto it = dest_right->InsertUniq(std::forward<Key_t>(bucket->key[slot]),
-                                       std::forward<Value_t>(bucket->value[slot]), hash, false);
+      move_cb.SetMoveInDest();
+      auto it =
+          dest_right->InsertUniq(std::forward<Key_t>(bucket->key[slot]),
+                                 std::forward<Value_t>(bucket->value[slot]), hash, false, move_cb);
       (void)it;
       assert(it.index != kNanBid);
       update_version(*bucket, it.index);
+      move_cb.SetMoveBeweenSegments();
+      move_cb(i, it.index);
 
       // Remove stash reference pointing to stash bucket i.
       RemoveStashReference(i, hash);
@@ -1339,9 +1350,9 @@ bool Segment<Key, Value, Policy>::CheckIfMovesToOther(bool own_items, unsigned f
 }
 
 template <typename Key, typename Value, typename Policy>
-template <typename U, typename V>
-auto Segment<Key, Value, Policy>::InsertUniq(U&& key, V&& value, Hash_t key_hash, bool spread)
-    -> Iterator {
+template <typename U, typename V, typename OnMoveCb>
+auto Segment<Key, Value, Policy>::InsertUniq(U&& key, V&& value, Hash_t key_hash, bool spread,
+                                             OnMoveCb& on_move_cb) -> Iterator {
   const uint8_t bid = HomeIndex(key_hash);
   const uint8_t nid = NextBid(bid);
 
@@ -1376,6 +1387,7 @@ auto Segment<Key, Value, Policy>::InsertUniq(U&& key, V&& value, Hash_t key_hash
   int displace_index = MoveToOther(true, nid, NextBid(nid));
   if (displace_index >= 0) {
     neighbor.Insert(displace_index, std::forward<U>(key), std::forward<V>(value), meta_hash, true);
+    on_move_cb(nid, NextBid(nid));
     return Iterator{nid, uint8_t(displace_index)};
   }
 
@@ -1383,6 +1395,7 @@ auto Segment<Key, Value, Policy>::InsertUniq(U&& key, V&& value, Hash_t key_hash
   displace_index = MoveToOther(false, bid, prev_idx);
   if (displace_index >= 0) {
     target.Insert(displace_index, std::forward<U>(key), std::forward<V>(value), meta_hash, false);
+    on_move_cb(bid, prev_idx);
     return Iterator{bid, uint8_t(displace_index)};
   }
 
@@ -1587,9 +1600,9 @@ auto Segment<Key, Value, Policy>::FindValidStartingFrom(PhysicalBid bid, unsigne
 }
 
 template <typename Key, typename Value, typename Policy>
-template <typename BumpPolicy>
+template <typename BumpPolicy, typename OnMoveCb>
 auto Segment<Key, Value, Policy>::BumpUp(uint8_t bid, SlotId slot, Hash_t key_hash,
-                                         const BumpPolicy& bp) -> Iterator {
+                                         const BumpPolicy& bp, OnMoveCb& on_move_cb) -> Iterator {
   auto& from = GetBucket(bid);
 
   if (!bp.CanBump(from.key[slot])) {
@@ -1614,6 +1627,7 @@ auto Segment<Key, Value, Policy>::BumpUp(uint8_t bid, SlotId slot, Hash_t key_ha
   if (Iterator it = TryMoveFromStash(stash_pos, slot, key_hash); it.found()) {
     // TryMoveFromStash handles versions internally.
     from.Delete(slot);
+    on_move_cb(bid, it.index);
     return it;
   }
 
@@ -1680,12 +1694,14 @@ auto Segment<Key, Value, Policy>::BumpUp(uint8_t bid, SlotId slot, Hash_t key_ha
     swapb.SetStashPtr(stash_pos, swap_fp, bucket_ + next_bid);
   }
 
+  on_move_cb(bid, swap_bid);
+  on_move_cb(swap_bid, bid);
   return Iterator{swap_bid, kLastSlot};
 }
 
 template <typename Key, typename Value, typename Policy>
-template <typename HFunc>
-unsigned Segment<Key, Value, Policy>::UnloadStash(HFunc&& hfunc) {
+template <typename HFunc, typename OnMoveCb>
+unsigned Segment<Key, Value, Policy>::UnloadStash(HFunc&& hfunc, OnMoveCb& move_cb) {
   unsigned moved = 0;
 
   for (unsigned i = 0; i < kStashBucketNum; ++i) {
@@ -1700,6 +1716,7 @@ unsigned Segment<Key, Value, Policy>::UnloadStash(HFunc&& hfunc) {
       if (res.found()) {
         ++moved;
         invalid_mask |= (1u << slot);
+        move_cb(i, res.index);
       }
     };
 

--- a/src/core/dash_test.cc
+++ b/src/core/dash_test.cc
@@ -95,12 +95,6 @@ struct UInt64Policy : public BasicDashPolicy {
   }
 };
 
-struct RelaxedBumpPolicy {
-  bool CanBump(uint64_t key) const {
-    return true;
-  }
-};
-
 class CappedResource final : public PMR_NS::memory_resource {
  public:
   explicit CappedResource(size_t cap) : cap_(cap) {
@@ -136,6 +130,14 @@ class CappedResource final : public PMR_NS::memory_resource {
 
 using Segment = detail::Segment<uint64_t, Buf24>;
 using Dash64 = DashTable<uint64_t, uint64_t, UInt64Policy>;
+
+struct RelaxedBumpPolicy {
+  bool CanBump(uint64_t key) const {
+    return true;
+  }
+  void OnMove(Dash64::Cursor source, Dash64::Cursor dest) {
+  }
+};
 
 constexpr auto kSegTax = Segment::kTaxSize;
 constexpr size_t kMaxSize = Segment::kMaxSize;
@@ -174,7 +176,7 @@ class DashTest : public testing::Test {
 
 set<Segment::Key_t> DashTest::FillSegment(unsigned bid) {
   std::set<Segment::Key_t> keys;
-
+  auto cb = [](uint8_t a, uint8_t b) {};
   for (Segment::Key_t key = 0; key < 1000000u; ++key) {
     uint64_t hash = dt_.DoHash(key);
     unsigned bi = (hash >> 8) % Segment::kBucketNum;
@@ -183,7 +185,7 @@ set<Segment::Key_t> DashTest::FillSegment(unsigned bid) {
     uint8_t fp = hash & 0xFF;
     if (fp > 2)  // limit fps considerably to find interesting cases.
       continue;
-    auto [it, success] = segment_.Insert(key, 0, hash, EqTo(key));
+    auto [it, success] = segment_.Insert(key, 0, hash, EqTo(key), cb);
     if (!success) {
       LOG(INFO) << "Stopped at " << key;
       break;
@@ -217,8 +219,9 @@ TEST_F(DashTest, Basic) {
   Segment::Value_t val = 0;
   uint64_t hash = dt_.DoHash(key);
 
-  EXPECT_TRUE(segment_.Insert(key, val, hash, EqTo(key)).second);
-  auto [it, res] = segment_.Insert(key, val, hash, EqTo(key));
+  auto move_cb = [](uint8_t a, uint8_t b) {};
+  EXPECT_TRUE(segment_.Insert(key, val, hash, EqTo(key), move_cb).second);
+  auto [it, res] = segment_.Insert(key, val, hash, EqTo(key), move_cb);
   EXPECT_TRUE(!res && it.found());
 
   EXPECT_TRUE(Find(key, &val));
@@ -287,10 +290,10 @@ TEST_F(DashTest, Segment) {
 
 TEST_F(DashTest, SegmentFull) {
   std::equal_to<> eq;
-
+  auto cb = [](uint8_t a, uint8_t b) {};
   for (Segment::Key_t key = 8000; key < 15000u; ++key) {
     uint64_t hash = dt_.DoHash(key);
-    bool res = segment_.Insert(key, 0, hash, eq).second;
+    bool res = segment_.Insert(key, 0, hash, eq, cb).second;
     if (!res) {
       LOG(INFO) << "Stopped at " << key;
       break;
@@ -325,14 +328,14 @@ TEST_F(DashTest, SegmentFull) {
 
 TEST_F(DashTest, FirstStash) {
   constexpr unsigned kRegularCapacity = Segment::kBucketNum * Segment::kSlotNum;
-
+  auto cb = [](uint8_t a, uint8_t b) {};
   unsigned less_seventy = 0;
   for (unsigned j = 0; j < 100; ++j) {
     unsigned num_items = 0;
     for (unsigned i = 0; i < 1000; ++i) {
       uint64_t key = i + j * 2000;
       uint64_t hash = dt_.DoHash(key);
-      auto [it, inserted] = segment_.Insert(key, 0, hash, equal_to<>{});
+      auto [it, inserted] = segment_.Insert(key, 0, hash, equal_to<>{}, cb);
       ASSERT_TRUE(inserted);
       if (it.index >= Segment::kBucketNum) {  // stash iterator
         break;
@@ -356,7 +359,19 @@ TEST_F(DashTest, Split) {
   Segment::Value_t val;
   Segment s2{2, PMR_NS::get_default_resource()};  // segment with local depth 2.
 
-  segment_.Split(&UInt64Policy::HashFn, &s2);
+  class EmptyMoveCallback {
+   public:
+    void SetMoveInDest() {
+    }
+    void SetMoveInSource() {
+    }
+    void SetMoveBeweenSegments() {
+    }
+    void operator()(uint8_t a, uint8_t b) const {
+    }
+  };
+  EmptyMoveCallback move_cb;
+  segment_.Split(&UInt64Policy::HashFn, &s2, move_cb);
   unsigned sum[2] = {0};
   for (auto key : keys) {
     auto eq = [key](const auto& probe) { return key == probe; };
@@ -403,12 +418,21 @@ TEST_F(DashTest, BumpUp) {
   EXPECT_EQ(touched_bid[1], 1);
 
   // Bump up
-  segment_.BumpUp(kFirstStashId, 5, hash, RelaxedBumpPolicy{});
+  std::vector<std::pair<uint8_t, uint8_t>> moved_buckets;
+  auto move_cb = [&moved_buckets](uint8_t a, uint8_t b) {
+    moved_buckets.push_back(std::make_pair(a, b));
+  };
+  segment_.BumpUp(kFirstStashId, 5, hash, RelaxedBumpPolicy{}, move_cb);
 
   // expect the key to move
   EXPECT_TRUE(segment_.GetBucket(1).IsFull());
   EXPECT_FALSE(segment_.GetBucket(kFirstStashId).IsFull());
   EXPECT_EQ(segment_.Key(1, 2), key);
+  EXPECT_EQ(moved_buckets.size(), 1);
+  EXPECT_EQ(moved_buckets.at(0).first, kFirstStashId);
+  EXPECT_EQ(moved_buckets.at(0).second, 1);
+  moved_buckets.clear();
+
   EXPECT_TRUE(Contains(key));
 
   // 9 is just a random slot id.
@@ -423,17 +447,24 @@ TEST_F(DashTest, BumpUp) {
   EXPECT_EQ(touched_bid[1], 0);
   EXPECT_EQ(touched_bid[2], 1);
 
-  segment_.BumpUp(kSecondStashId, 9, hash, RelaxedBumpPolicy{});
+  auto it = segment_.BumpUp(kSecondStashId, 9, hash, RelaxedBumpPolicy{}, move_cb);
   ASSERT_TRUE(key == segment_.Key(0, kSlotNum - 1) || key == segment_.Key(1, kSlotNum - 1));
   EXPECT_TRUE(segment_.GetBucket(kSecondStashId).IsFull());
   EXPECT_TRUE(Contains(key));
   EXPECT_TRUE(segment_.Key(kSecondStashId, 9));
+  EXPECT_EQ(moved_buckets.size(), 2);
+  EXPECT_EQ(moved_buckets.at(0).first, kSecondStashId);
+  EXPECT_EQ(moved_buckets.at(0).second, it.index);
+  EXPECT_EQ(moved_buckets.at(1).first, it.index);
+  EXPECT_EQ(moved_buckets.at(1).second, kSecondStashId);
 }
 
 TEST_F(DashTest, BumpPolicy) {
   struct RestrictedBumpPolicy {
     bool CanBump(uint64_t key) const {
       return false;
+    }
+    void OnMove(Dash64::Cursor source, Dash64::Cursor dest) {
     }
   };
 
@@ -447,13 +478,14 @@ TEST_F(DashTest, BumpPolicy) {
   // check items are immovable in bucket
   Segment::Key_t key = segment_.Key(1, 2);
   uint64_t hash = dt_.DoHash(key);
-  segment_.BumpUp(1, 2, hash, RestrictedBumpPolicy{});
+  auto cb = [](uint8_t a, uint8_t b) {};
+  segment_.BumpUp(1, 2, hash, RestrictedBumpPolicy{}, cb);
   EXPECT_EQ(key, segment_.Key(1, 2));
 
   // check items don't swap from stash
   key = segment_.Key(kFirstStashId, 2);
   hash = dt_.DoHash(key);
-  segment_.BumpUp(kFirstStashId, 2, hash, RestrictedBumpPolicy{});
+  segment_.BumpUp(kFirstStashId, 2, hash, RestrictedBumpPolicy{}, cb);
   EXPECT_EQ(key, segment_.Key(kFirstStashId, 2));
 }
 
@@ -513,12 +545,15 @@ TEST_F(DashTest, Custom) {
 
 TEST_F(DashTest, FindByValue) {
   using ItemSegment = detail::Segment<Item, uint64_t>;
-
+  auto cb = [](uint8_t a, uint8_t b) {};
   // Insert three different values with the same hash
   ItemSegment segment{2, PMR_NS::get_default_resource()};
-  segment.Insert(Item{1}, 1, 42, [](const auto& pred) { return pred.buf[0] == 1; });
-  segment.Insert(Item{2}, 2, 42, [](const auto& pred) { return pred.buf[0] == 2; });
-  segment.Insert(Item{3}, 3, 42, [](const auto& pred) { return pred.buf[0] == 3; });
+  segment.Insert(
+      Item{1}, 1, 42, [](const auto& pred) { return pred.buf[0] == 1; }, cb);
+  segment.Insert(
+      Item{2}, 2, 42, [](const auto& pred) { return pred.buf[0] == 2; }, cb);
+  segment.Insert(
+      Item{3}, 3, 42, [](const auto& pred) { return pred.buf[0] == 3; }, cb);
 
   // We should be able to find the middle one by value
   auto it = segment.FindIt(42, [](const auto& key, const auto& value) { return value == 2; });
@@ -664,6 +699,8 @@ struct TestEvictionPolicy {
 
   bool CanGrow(const Dash64& tbl) const {
     return tbl.capacity() < max_capacity;
+  }
+  void OnMove(Dash64::Cursor source, Dash64::Cursor dest) {
   }
 
   void RecordSplit(Dash64::Segment_t*) {
@@ -983,6 +1020,9 @@ struct SimpleEvictPolicy {
     return tbl.capacity() + U64Dash::kSegCapacity < max_capacity;
   }
 
+  void OnMove(U64Dash::Cursor source, U64Dash::Cursor dest) {
+  }
+
   void RecordSplit(U64Dash::Segment_t* segment) {
   }
 
@@ -1029,6 +1069,9 @@ struct ShiftRightPolicy {
   }
 
   void RecordSplit(U64Dash::Segment_t* segment) {
+  }
+
+  void OnMove(U64Dash::Cursor source, U64Dash::Cursor dest) {
   }
 
   unsigned Evict(const U64Dash::HotBuckets& hotb, U64Dash* me) {
@@ -1120,8 +1163,11 @@ TEST_P(EvictionPolicyTest, HitRateZipf) {
       DVLOG(1) << "Inserted new key " << key << " to bucket " << it.bucket_id() << " slot "
                << it.slot_id();
     } else {
-      if (use_bumps)
-        dt_.BumpUp(it, RelaxedBumpPolicy{});
+      if (use_bumps) {
+        RelaxedBumpPolicy policy;
+        dt_.BumpUp(it, policy);
+      }
+
       ++hits;
     }
   }
@@ -1151,7 +1197,8 @@ TEST_P(EvictionPolicyTest, HitRateZipfShr) {
         }
       } else {
         if (use_bumps) {
-          dt_.BumpUp(it, RelaxedBumpPolicy{});
+          RelaxedBumpPolicy policy;
+          dt_.BumpUp(it, policy);
           DVLOG(1) << "Bump up key " << key << " " << it.bucket_id() << " slot " << it.slot_id();
         } else {
           DVLOG(1) << "Hit on key " << key;

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -98,6 +98,8 @@ class PrimeEvictionPolicy {
   void RecordSplit(PrimeTable::Segment_t* segment) {
     DVLOG(2) << "split: " << segment->SlowSize() << "/" << segment->capacity();
   }
+  void OnMove(PrimeTable::Cursor source, PrimeTable::Cursor dest) {
+  }
 
   bool CanGrow(const PrimeTable& tbl) const;
 
@@ -360,6 +362,8 @@ class DbSlice::PrimeBumpPolicy {
  public:
   bool CanBump(const CompactObj& obj) const {
     return !obj.IsSticky();
+  }
+  void OnMove(PrimeTable::Cursor source, PrimeTable::Cursor dest) {
   }
 };
 
@@ -1745,7 +1749,8 @@ void DbSlice::OnCbFinishBlocking() {
 
       // We must not change the bucket's internal order during serialization
       serialization_latch_.Wait();
-      auto bump_it = db.prime.BumpUp(it, PrimeBumpPolicy{});
+      PrimeBumpPolicy policy;
+      auto bump_it = db.prime.BumpUp(it, policy);
       if (bump_it != it) {  // the item was bumped
         ++events_.bumpups;
       }


### PR DESCRIPTION
In order to identify when items are moved in dash table to support no point in time replication algo we introduce OnMove callback that will be called every time we move existing items inside dash table.
Move of existing items in dash table is only in insert new items flow and in bumpup flow