### PR TITLE
chore: move MemoryBytesFlag to facade

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -57,10 +57,10 @@ ABSL_FLAG(string, admin_bind, "",
           "If set, the admin consol TCP connection would be bind the given address. "
           "This supports both HTTP and RESP protocols");
 
-ABSL_FLAG(uint64_t, request_cache_limit, 64_MB,
+ABSL_FLAG(facade::MemoryBytesFlag, request_cache_limit, 64_MB,
           "Amount of memory to use for request cache in bytes - per IO thread.");
 
-ABSL_FLAG(uint64_t, pipeline_buffer_limit, 128_MB,
+ABSL_FLAG(facade::MemoryBytesFlag, pipeline_buffer_limit, 128_MB,
           "Amount of memory to use for storing pipeline requests - per IO thread."
           "Please note that clients that send excecissively huge pipelines, "
           "may deadlock themselves. See https://github.com/dragonflydb/dragonfly/discussions/3997"
@@ -73,10 +73,10 @@ ABSL_FLAG(uint32_t, pipeline_queue_limit, 10000,
           "may require increasing this limit to prevent the risk of deadlocking."
           "See https://github.com/dragonflydb/dragonfly/discussions/3997 for details");
 
-ABSL_FLAG(uint64_t, publish_buffer_limit, 128_MB,
+ABSL_FLAG(facade::MemoryBytesFlag, publish_buffer_limit, 128_MB,
           "Amount of memory to use for storing pub commands in bytes - per IO thread");
 
-ABSL_FLAG(uint32_t, pipeline_squash, 10,
+ABSL_FLAG(uint32_t, pipeline_squash, 1,
           "Number of queued pipelined commands above which squashing is enabled, 0 means disabled");
 
 // When changing this constant, also update `test_large_cmd` test in connection_test.py.
@@ -88,7 +88,7 @@ ABSL_FLAG(uint64_t, max_bulk_len, 2u << 30,
           "Maximum bulk length that is "
           "allowed to be accepted when parsing RESP protocol");
 
-ABSL_FLAG(size_t, max_client_iobuf_len, 1u << 16,
+ABSL_FLAG(facade::MemoryBytesFlag, max_client_iobuf_len, 1u << 16,
           "Maximum io buffer length that is used to read client requests.");
 
 ABSL_FLAG(bool, migrate_connections, true,

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -9,6 +9,7 @@
 #include "facade/command_id.h"
 #include "facade/error.h"
 #include "facade/resp_expr.h"
+#include "strings/human_readable.h"
 
 namespace facade {
 
@@ -174,6 +175,83 @@ uint32_t CommandId::OptCount(uint32_t mask) {
 }
 
 __thread FacadeStats* tl_facade_stats = nullptr;
+
+static bool ParseHumanReadableBytes(std::string_view str, int64_t* num_bytes) {
+  if (str.empty())
+    return false;
+
+  const char* cstr = str.data();
+  bool neg = (*cstr == '-');
+  if (neg) {
+    cstr++;
+  }
+  char* end;
+  double d = strtod(cstr, &end);
+
+  if (end == cstr)  // did not succeed to advance
+    return false;
+
+  int64_t scale = 1;
+  switch (*end) {
+    // Considers just the first character after the number
+    // so it matches: 1G, 1GB, 1GiB and 1Gigabytes
+    // NB: an int64 can only go up to <8 EB.
+    case 'E':
+    case 'e':
+      scale <<= 10;  // Fall through...
+      ABSL_FALLTHROUGH_INTENDED;
+    case 'P':
+    case 'p':
+      scale <<= 10;
+      ABSL_FALLTHROUGH_INTENDED;
+    case 'T':
+    case 't':
+      scale <<= 10;
+      ABSL_FALLTHROUGH_INTENDED;
+    case 'G':
+    case 'g':
+      scale <<= 10;
+      ABSL_FALLTHROUGH_INTENDED;
+    case 'M':
+    case 'm':
+      scale <<= 10;
+      ABSL_FALLTHROUGH_INTENDED;
+    case 'K':
+    case 'k':
+      scale <<= 10;
+      ABSL_FALLTHROUGH_INTENDED;
+    case 'B':
+    case 'b':
+    case '\0':
+      break;  // To here.
+    default:
+      return false;
+  }
+  d *= scale;
+  if (int64_t(d) > INT64_MAX || d < 0)
+    return false;
+
+  *num_bytes = static_cast<int64_t>(d + 0.5);
+  if (neg) {
+    *num_bytes = -*num_bytes;
+  }
+  return true;
+}
+
+bool AbslParseFlag(std::string_view in, MemoryBytesFlag* flag, std::string* err) {
+  int64_t val;
+  if (ParseHumanReadableBytes(in, &val) && val >= 0) {
+    flag->value = val;
+    return true;
+  }
+
+  *err = "Use human-readable format, eg.: 500MB, 1G, 1TB";
+  return false;
+}
+
+std::string AbslUnparseFlag(const MemoryBytesFlag& flag) {
+  return strings::HumanReadableNumBytes(flag.value);
+}
 
 }  // namespace facade
 

--- a/src/facade/facade_types.h
+++ b/src/facade/facade_types.h
@@ -196,6 +196,21 @@ extern __thread FacadeStats* tl_facade_stats;
 
 void ResetStats();
 
+// TODO: move this flag to helio (base/flags.h)
+struct MemoryBytesFlag {
+  size_t value = 0;
+
+  MemoryBytesFlag(size_t s = 0) : value(s) {  // NOLINT
+  }
+
+  operator size_t() const {  // NOLINT
+    return value;
+  }
+};
+
+bool AbslParseFlag(std::string_view in, MemoryBytesFlag* flag, std::string* err);
+std::string AbslUnparseFlag(const MemoryBytesFlag& flag);
+
 // Constants for socket bufring.
 constexpr uint16_t kRecvSockGid = 0;
 

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -332,13 +332,6 @@ inline uint32_t MemberTimeSeconds(uint64_t now_ms) {
   return (now_ms / 1000) - kMemberExpiryBase;
 }
 
-struct MemoryBytesFlag {
-  uint64_t value = 0;
-};
-
-bool AbslParseFlag(std::string_view in, dfly::MemoryBytesFlag* flag, std::string* err);
-std::string AbslUnparseFlag(const dfly::MemoryBytesFlag& flag);
-
 // Helper class used to guarantee atomicity between serialization of buckets
 class ABSL_LOCKABLE ThreadLocalMutex {
  public:

--- a/src/server/engine_shard_set.cc
+++ b/src/server/engine_shard_set.cc
@@ -20,7 +20,7 @@ ABSL_FLAG(bool, cache_mode, false,
           "If true, the backend behaves like a cache, "
           "by evicting entries when getting close to maxmemory limit");
 
-ABSL_FLAG(dfly::MemoryBytesFlag, tiered_max_file_size, dfly::MemoryBytesFlag{},
+ABSL_FLAG(facade::MemoryBytesFlag, tiered_max_file_size, facade::MemoryBytesFlag{},
           "Limit on maximum file size that is used by the database for tiered storage. "
           "0 - means the program will automatically determine its maximum file size. "
           "default: 0");

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -97,7 +97,7 @@ ABSL_FLAG(bool, admin_nopass, false,
 ABSL_FLAG(bool, expose_http_api, false,
           "If set, will expose a POST /api handler for sending redis commands as json array.");
 
-ABSL_FLAG(dfly::MemoryBytesFlag, maxmemory, dfly::MemoryBytesFlag{},
+ABSL_FLAG(facade::MemoryBytesFlag, maxmemory, facade::MemoryBytesFlag{},
           "Limit on maximum-memory that is used by the database. "
           "0 - means the program will automatically determine its maximum memory usage. "
           "default: 0");


### PR DESCRIPTION
Use it for memory related flags

Also change pipeline_squash to 1 by default.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->