### PR TITLE
chore: get rid of quicklist encoding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
           echo Run ctest -V -L DFLY
 
           GLOG_alsologtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1,op_manager=1,op_manager_test=1 \
-          FLAGS_fiber_safety_margin=4096 FLAGS_list_experimental_v2=true timeout 20m ctest -V -L DFLY -E allocation_tracker_test
+          FLAGS_fiber_safety_margin=4096 timeout 20m ctest -V -L DFLY -E allocation_tracker_test
 
           # Run allocation tracker test separately without alsologtostderr because it generates a TON of logs.
           FLAGS_fiber_safety_margin=4096 timeout 5m ./allocation_tracker_test

--- a/src/core/qlist.h
+++ b/src/core/qlist.h
@@ -30,7 +30,6 @@ class QList {
    * attempted_compress: 1 bit, boolean, used for verifying during testing.
    * dont_compress: 1 bit, boolean, used for preventing compression of entry.
    * extra: 9 bits, free for future use; pads out the remainder of 32 bits
-   * NOTE: do not change the ABI of this struct as long as we support --list_experimental_v2=false
    * */
 
   typedef struct Node {

--- a/src/redis/redis_aux.c
+++ b/src/redis/redis_aux.c
@@ -5,7 +5,6 @@
 
 #include "crc64.h"
 #include "endianconv.h"
-#include "quicklist.h"
 #include "zmalloc.h"
 
 Server server;
@@ -48,56 +47,4 @@ void memrev64(void* p) {
 uint64_t intrev64(uint64_t v) {
   memrev64(&v);
   return v;
-}
-
-// Based on quicklistGetIteratorAtIdx but without allocations
-void quicklistInitIterator(quicklistIter* iter, quicklist *quicklist, int direction,
-                           const long long idx) {
-    quicklistNode *n = NULL;
-    unsigned long long accum = 0;
-    int forward = idx < 0 ? 0 : 1; /* < 0 -> reverse, 0+ -> forward */
-    unsigned long long index = forward ? idx : (-idx) - 1;
-
-    iter->direction = direction;
-    iter->quicklist = quicklist;
-    iter->current = NULL;
-    iter->zi = NULL;
-
-    if (index >= quicklist->count) return;
-
-    /* Seek in the other direction if that way is shorter. */
-    int seek_forward = forward;
-    unsigned long long seek_index = index;
-    if (index > (quicklist->count - 1) / 2) {
-        seek_forward = !forward;
-        seek_index = quicklist->count - 1 - index;
-    }
-
-    n = seek_forward ? quicklist->head : quicklist->tail;
-    while (likely(n)) {
-        if ((accum + n->count) > seek_index) {
-            break;
-        } else {
-            accum += n->count;
-            n = seek_forward ? n->next : n->prev;
-        }
-    }
-
-    if (!n)
-      return;
-
-    iter->current = n;
-
-    /* Fix accum so it looks like we seeked in the other direction. */
-    if (seek_forward != forward)
-      accum = quicklist->count - n->count - accum;
-
-    if (forward) {
-        /* forward = normal head-to-tail offset. */
-        iter->offset = index - accum;
-    } else {
-        /* reverse = need negative offset for tail-to-head, so undo
-         * the result of the original index = (-idx) - 1 above. */
-        iter->offset = (-index) - 1 + accum;
-    }
 }

--- a/src/redis/redis_aux.h
+++ b/src/redis/redis_aux.h
@@ -49,15 +49,10 @@ void InitRedisTables();
 #define OBJ_ENCODING_INTSET 6U  /* Encoded as intset */
 #define OBJ_ENCODING_SKIPLIST 7U  /* Encoded as skiplist */
 #define OBJ_ENCODING_EMBSTR 8U  /* Embedded sds string encoding */
-#define OBJ_ENCODING_QUICKLIST 9U /* Encoded as linked list of ziplists */
+// #define OBJ_ENCODING_QUICKLIST 9U /* Encoded as linked list of ziplists */
 #define OBJ_ENCODING_STREAM 10U /* Encoded as a radix tree of listpacks */
 #define OBJ_ENCODING_LISTPACK 11 /* Encoded as a listpack */
 #define OBJ_ENCODING_COMPRESS_INTERNAL 15U  /* Kept as lzf compressed, to pass compressed blob to another thread */
 
-typedef struct quicklistIter quicklistIter;
-typedef struct quicklist quicklist;
-
-void quicklistInitIterator(quicklistIter* iter, quicklist *quicklist, int direction, const long long idx);
-void quicklistCompressIterator(quicklistIter* iter);
 
 #endif /* __REDIS_AUX_H */

--- a/src/server/container_utils.cc
+++ b/src/server/container_utils.cc
@@ -139,40 +139,9 @@ OpResult<ShardFFResult> FindFirstNonEmpty(Transaction* trans, int req_obj_type) 
 
 using namespace std;
 
-quicklistEntry QLEntry() {
-  quicklistEntry res{.quicklist = NULL,
-                     .node = NULL,
-                     .zi = NULL,
-                     .value = NULL,
-                     .longval = 0,
-                     .sz = 0,
-                     .offset = 0};
-  return res;
-}
-
 bool IterateList(const PrimeValue& pv, const IterateFunc& func, long start, long end) {
   bool success = true;
 
-  if (pv.Encoding() == OBJ_ENCODING_QUICKLIST) {
-    quicklist* ql = static_cast<quicklist*>(pv.RObjPtr());
-    long llen = quicklistCount(ql);
-    if (end < 0 || end >= llen)
-      end = llen - 1;
-
-    quicklistIter* qiter = quicklistGetIteratorAtIdx(ql, AL_START_HEAD, start);
-    quicklistEntry entry = QLEntry();
-    long lrange = end - start + 1;
-
-    while (success && quicklistNext(qiter, &entry) && lrange-- > 0) {
-      if (entry.value) {
-        success = func(ContainerEntry{reinterpret_cast<char*>(entry.value), entry.sz});
-      } else {
-        success = func(ContainerEntry{entry.longval});
-      }
-    }
-    quicklistReleaseIterator(qiter);
-    return success;
-  }
   DCHECK_EQ(pv.Encoding(), kEncodingQL2);
   QList* ql = static_cast<QList*>(pv.RObjPtr());
 

--- a/src/server/container_utils.h
+++ b/src/server/container_utils.h
@@ -9,7 +9,6 @@
 
 extern "C" {
 #include "redis/listpack.h"
-#include "redis/quicklist.h"
 }
 
 #include <functional>
@@ -25,9 +24,6 @@ inline bool IsContainer(const PrimeValue& pv) {
   unsigned type = pv.ObjType();
   return (type == OBJ_LIST || type == OBJ_SET || type == OBJ_ZSET);
 }
-
-// Create empty quicklistEntry
-quicklistEntry QLEntry();
 
 // Stores either:
 // - A single long long value (longval) when value = nullptr

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -451,11 +451,7 @@ const char* EncodingName(unsigned obj_type, unsigned encoding) {
     case OBJ_STRING:
       return "raw";
     case OBJ_LIST:
-      switch (encoding) {
-        case kEncodingQL2:
-        case OBJ_ENCODING_QUICKLIST:
-          return "quicklist";
-      }
+      return "quicklist";
       break;
     case OBJ_SET:
       ABSL_FALLTHROUGH_INTENDED;

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -11,7 +11,6 @@ extern "C" {
 #include "redis/intset.h"
 #include "redis/listpack.h"
 #include "redis/lzfP.h" /* LZF compression library */
-#include "redis/quicklist.h"
 #include "redis/stream.h"
 #include "redis/util.h"
 #include "redis/ziplist.h"
@@ -56,7 +55,6 @@ extern "C" {
 ABSL_DECLARE_FLAG(int32_t, list_max_listpack_size);
 ABSL_DECLARE_FLAG(int32_t, list_compress_depth);
 ABSL_DECLARE_FLAG(uint32_t, dbnum);
-ABSL_DECLARE_FLAG(bool, list_experimental_v2);
 ABSL_FLAG(bool, rdb_load_dry_run, false, "Dry run RDB load without applying changes");
 ABSL_FLAG(bool, rdb_ignore_expiry, false, "Ignore Key Expiry when loding from RDB snapshot");
 
@@ -526,34 +524,22 @@ void RdbLoaderBase::OpaqueObjLoader::CreateHMap(const LoadTrace* ltrace) {
 }
 
 void RdbLoaderBase::OpaqueObjLoader::CreateList(const LoadTrace* ltrace) {
-  quicklist* ql = nullptr;
   QList* qlv2 = nullptr;
   if (config_.append) {
     if (pv_->ObjType() != OBJ_LIST) {
       ec_ = RdbError(errc::invalid_rdb_type);
       return;
     }
-    if (pv_->Encoding() == OBJ_ENCODING_QUICKLIST) {
-      ql = static_cast<quicklist*>(pv_->RObjPtr());
-    } else {
-      DCHECK_EQ(pv_->Encoding(), kEncodingQL2);
-      qlv2 = static_cast<QList*>(pv_->RObjPtr());
-    }
+    DCHECK_EQ(pv_->Encoding(), kEncodingQL2);
+    qlv2 = static_cast<QList*>(pv_->RObjPtr());
   } else {
-    if (absl::GetFlag(FLAGS_list_experimental_v2)) {
-      qlv2 = CompactObj::AllocateMR<QList>(GetFlag(FLAGS_list_max_listpack_size),
-                                           GetFlag(FLAGS_list_compress_depth));
-    } else {
-      ql = quicklistNew(GetFlag(FLAGS_list_max_listpack_size), GetFlag(FLAGS_list_compress_depth));
-    }
+    qlv2 = CompactObj::AllocateMR<QList>(GetFlag(FLAGS_list_max_listpack_size),
+                                         GetFlag(FLAGS_list_compress_depth));
   }
 
   auto cleanup = absl::Cleanup([&] {
     if (!config_.append) {
-      if (ql)
-        quicklistRelease(ql);
-      else
-        CompactObj::DeleteMR<QList>(qlv2);
+      CompactObj::DeleteMR<QList>(qlv2);
     }
   });
 
@@ -568,10 +554,7 @@ void RdbLoaderBase::OpaqueObjLoader::CreateList(const LoadTrace* ltrace) {
     if (container == QUICKLIST_NODE_CONTAINER_PLAIN) {
       lp = (uint8_t*)zmalloc(sv.size());
       ::memcpy(lp, (uint8_t*)sv.data(), sv.size());
-      if (ql)
-        quicklistAppendPlainNode(ql, lp, sv.size());
-      else
-        qlv2->AppendPlain(lp, sv.size());
+      qlv2->AppendPlain(lp, sv.size());
 
       return true;
     }
@@ -609,16 +592,13 @@ void RdbLoaderBase::OpaqueObjLoader::CreateList(const LoadTrace* ltrace) {
       lp = lpShrinkToFit(lp);
     }
 
-    if (ql)
-      quicklistAppendListpack(ql, lp);
-    else
-      qlv2->AppendListpack(lp);
+    qlv2->AppendListpack(lp);
     return true;
   });
 
   if (ec_)
     return;
-  if ((ql && quicklistCount(ql) == 0) || (qlv2 && qlv2->Size() == 0)) {
+  if (qlv2 && qlv2->Size() == 0) {
     ec_ = RdbError(errc::empty_key);
     return;
   }
@@ -626,10 +606,7 @@ void RdbLoaderBase::OpaqueObjLoader::CreateList(const LoadTrace* ltrace) {
   std::move(cleanup).Cancel();
 
   if (!config_.append) {
-    if (ql)
-      pv_->InitRobj(OBJ_LIST, OBJ_ENCODING_QUICKLIST, ql);
-    else
-      pv_->InitRobj(OBJ_LIST, kEncodingQL2, qlv2);
+    pv_->InitRobj(OBJ_LIST, kEncodingQL2, qlv2);
   }
 }
 

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -7,7 +7,6 @@
 
 extern "C" {
 #include "redis/lzfP.h"
-#include "redis/quicklist.h"
 }
 
 #include <optional>

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -423,9 +423,6 @@ class DflyInstanceFactory:
         if version > 1.27:
             args.setdefault("omit_basic_usage")
 
-        # If path is not set, we assume that we are running the latest dragonfly.
-        if not path:
-            args.setdefault("list_experimental_v2")
         args.setdefault("log_dir", self.params.log_dir)
 
         if version >= 1.21 and "serialization_max_chunk_size" not in args:


### PR DESCRIPTION
c-based quicklist code was being sunset since 01/25. This PR removes all the references to the quicklist encoding, greatly simplifying list related logic.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->