### PR TITLE
chore(string_family): Refactor to prep for adding the GAT command

### DIFF
--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -551,10 +551,9 @@ MGetResponse CollectKeys(BlockingCounter wait_bc, uint8_t fetch_mask, const Tran
   ShardArgs keys = t->GetShardArgs(shard->shard_id());
   DCHECK(!keys.Empty());
 
-  if constexpr (constexpr bool is_mut_iter = std::is_same_v<Iter, DbSlice::Iterator>) {
+  if constexpr (std::is_same_v<Iter, DbSlice::Iterator>) {
     const auto cid = t->GetCId();
-    DCHECK(!(cid->IsReadOnly() && is_mut_iter))
-        << "mutable iterator used with read-only command " << cid->name();
+    DCHECK(!cid->IsReadOnly()) << "mutable iterator used with read-only command " << cid->name();
   }
 
   MGetResponse response(keys.Size());

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -552,7 +552,7 @@ MGetResponse CollectKeys(BlockingCounter wait_bc, uint8_t fetch_mask, const Tran
   DCHECK(!keys.Empty());
 
   if constexpr (std::is_same_v<Iter, DbSlice::Iterator>) {
-    const auto cid = t->GetCId();
+    const CommandId* cid = t->GetCId();
     DCHECK(!cid->IsReadOnly()) << "mutable iterator used with read-only command " << cid->name();
   }
 

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -1320,8 +1320,8 @@ void StringFamily::DecrBy(CmdArgList args, const CommandContext& cmnd_cntx) {
 }
 
 void ReorderShardResults(const std::vector<MGetResponse>& mget_resp, const Transaction* t,
-                         absl::FixedArray<optional<GetResp>, 8>* dest,
-                         const bool is_memcache_protocol) {
+                         const bool is_memcache_protocol,
+                         absl::FixedArray<optional<GetResp>, 8>* dest) {
   for (ShardId sid = 0; sid < mget_resp.size(); ++sid) {
     if (!t->IsActive(sid))
       continue;
@@ -1373,7 +1373,7 @@ void StringFamily::MGet(CmdArgList args, const CommandContext& cmnd_cntx) {
 
   // reorder shard results back according to argument order
   absl::FixedArray<optional<GetResp>, 8> res(args.size());
-  ReorderShardResults(mget_resp, cmnd_cntx.tx, &res, is_memcache);
+  ReorderShardResults(mget_resp, cmnd_cntx.tx, is_memcache, &res);
 
   // The code below is safe in the context of squashing (uses CapturingReplyBuilder).
   // Specifically:


### PR DESCRIPTION
A couple of functions are extracted from the MGet command. In a follow up PR, the GAT command will be added which
will reuse some of the functions:

- A function to collect keys is extracted. This takes a function as input which will return an iterator for one key. The iterator can be mutable or immutable, for MGet it is immutable. For GAT it will be mutable.
- A check is added such that a read-only command does not use a function returning a mutable iterator.
- Another function is created to reorder collected results based on the shards of the keys and the original order of the keys in the command.

For context, the original PR is https://github.com/dragonflydb/dragonfly/pull/5257
