### PR TITLE
fix: partial replication data loss

### DIFF
--- a/src/server/cluster/incoming_slot_migration.cc
+++ b/src/server/cluster/incoming_slot_migration.cc
@@ -149,7 +149,9 @@ class ClusterShardMigration {
     }
 
     if (!tx_data.IsGlobalCmd()) {
-      return executor_.Execute(tx_data.dbid, tx_data.command);
+      auto res = executor_.Execute(tx_data.dbid, tx_data.command);
+      return res == facade::DispatchResult::OOM ? make_error_code(errc::not_enough_memory)
+                                                : error_code();
     } else {
       // TODO check which global commands should be supported
       std::string error =

--- a/src/server/journal/executor.h
+++ b/src/server/journal/executor.h
@@ -7,6 +7,7 @@
 #include <absl/types/span.h>
 
 #include "facade/reply_capture.h"
+#include "facade/service_interface.h"
 #include "server/cluster/cluster_defs.h"
 #include "server/journal/types.h"
 
@@ -22,8 +23,8 @@ class JournalExecutor {
 
   JournalExecutor(JournalExecutor&&) = delete;
 
-  void Execute(DbIndex dbid, absl::Span<journal::ParsedEntry::CmdData> cmds);
-  std::error_code Execute(DbIndex dbid, journal::ParsedEntry::CmdData& cmd);
+  // Return true is command executed without error
+  facade::DispatchResult Execute(DbIndex dbid, journal::ParsedEntry::CmdData& cmd);
 
   void FlushAll();  // Execute FLUSHALL.
   void FlushSlots(const cluster::SlotRange& slot_range);
@@ -33,7 +34,7 @@ class JournalExecutor {
   }
 
  private:
-  std::error_code Execute(journal::ParsedEntry::CmdData& cmd);
+  facade::DispatchResult Execute(journal::ParsedEntry::CmdData& cmd);
 
   // Select database. Ensure it exists if accessed for first time.
   void SelectDb(DbIndex dbid);

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -207,7 +207,7 @@ class DflyShardReplica : public ProtocolClient {
 
   void StableSyncDflyAcksFb(ExecutionState* cntx);
 
-  void ExecuteTx(TransactionData&& tx_data, ExecutionState* cntx);
+  bool ExecuteTx(TransactionData&& tx_data, ExecutionState* cntx);
 
   uint32_t FlowId() const;
 


### PR DESCRIPTION
The issue is that each journal entry is not always executed by the replica yet we increment the journal records executed. An example of that is when the context gets cancelled (e,g connection lost from master) before the command dispatches for execution. However, when the replica reconnects it will start from the next lsn, ignoring the journal entry which never dispatched leading to data loss. 

What's described was reproduced in https://github.com/dragonflydb/dragonfly/pull/5277

resolves #5275