### PR TITLE
fix: Unsupported status 4 (XCLAIM command)

### DIFF
--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -2833,6 +2833,11 @@ void StreamFamily::XClaim(CmdArgList args, const CommandContext& cmd_cntx) {
   };
   OpResult<ClaimInfo> result = cmd_cntx.tx->ScheduleSingleHopT(std::move(cb));
   if (!result) {
+    if (result.status() == OpStatus::SKIPPED) {
+      // Return empty result when operation is skipped
+      StreamReplies{cmd_cntx.rb}.SendClaimInfo(ClaimInfo{});
+      return;
+    }
     cmd_cntx.rb->SendError(result.status());
     return;
   }


### PR DESCRIPTION
Fixes: https://github.com/dragonflydb/dragonfly/issues/5287

- Added handling of missed internal status
- The unit test was not added because I couldn't find a scenario to reproduce it without fuzzing.