### PR TITLE
fix: Handle bonus key + init error in squashing

### DIFF
--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -153,10 +153,14 @@ bool MultiCommandSquasher::ExecuteStandalone(RedisReplyBuilder* rb, const Stored
   auto* tx = cntx_->transaction;
   if (cmd->Cid()->IsTransactional()) {
     tx->MultiSwitchCmd(cmd->Cid());
-    tx->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, args);
+    auto status = tx->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, args);
+    if (status != OpStatus::OK) {
+      rb->SendError(status);
+      rb->ConsumeLastError();
+      return !opts_.error_abort;
+    }
   }
   service_->InvokeCmd(cmd->Cid(), args, CommandContext{tx, rb, cntx_});
-
   return true;
 }
 
@@ -195,10 +199,13 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
     crb.SetReplyMode(dispatched.cmd->ReplyMode());
 
     local_tx->MultiSwitchCmd(dispatched.cmd->Cid());
-    local_tx->InitByArgs(cntx_->ns, local_cntx.conn_state.db_index, args);
-    service_->InvokeCmd(dispatched.cmd->Cid(), args,
-                        CommandContext{local_cntx.transaction, &crb, &local_cntx});
-
+    auto status = local_tx->InitByArgs(cntx_->ns, local_cntx.conn_state.db_index, args);
+    if (status != OpStatus::OK) {
+      crb.SendError(status);
+    } else {
+      service_->InvokeCmd(dispatched.cmd->Cid(), args,
+                          CommandContext{local_cntx.transaction, &crb, &local_cntx});
+    }
     move_reply(crb.Take(), &dispatched.reply);
 
     // Assert commands made no persistent state changes to stub context state

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -337,6 +337,7 @@ TEST_F(MultiTest, MultiCommandsWithBonusKeys) {
   EXPECT_EQ(Shard("za", shard_set->size()), Shard("zb", shard_set->size()));
   EXPECT_EQ(Shard("zb", shard_set->size()), Shard("ze", shard_set->size()));
 
+  // Check bonus keys are correctly processed with squashing
   Run({"multi"});
   Run({"zadd", "za", "1", "a", "2", "b"});
   Run({"zadd", "zb", "2", "b", "3", "c"});
@@ -344,6 +345,12 @@ TEST_F(MultiTest, MultiCommandsWithBonusKeys) {
   auto resp = Run({"exec"});
   EXPECT_THAT(resp.GetVec()[2], IntArg(1));
   EXPECT_THAT(Run({"zcard", "ze"}), IntArg(1));
+
+  // Check squashing correctly pre-validates commands
+  Run({"multi"});
+  Run({"zinterstore", "ze", "2", "za", "zb", "z one extra"});
+  resp = Run({"exec"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
 }
 
 TEST_F(MultiTest, MultiHop) {

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -307,12 +307,14 @@ void Transaction::PrepareMultiFps(CmdArgList keys) {
 }
 
 void Transaction::StoreKeysInArgs(const KeyIndex& key_index) {
-  DCHECK(!key_index.bonus);
   DCHECK(kv_fp_.empty());
   DCHECK(args_slices_.empty());
 
   // even for a single key we may have multiple arguments per key (MSET).
   args_slices_.emplace_back(key_index.start, key_index.end);
+  if (key_index.bonus)
+    args_slices_.emplace_back(*key_index.bonus, *key_index.bonus + 1);
+
   for (string_view key : key_index.Range(full_args_))
     kv_fp_.push_back(LockTag(key).Fingerprint());
 }

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -311,9 +311,9 @@ void Transaction::StoreKeysInArgs(const KeyIndex& key_index) {
   DCHECK(args_slices_.empty());
 
   // even for a single key we may have multiple arguments per key (MSET).
-  args_slices_.emplace_back(key_index.start, key_index.end);
   if (key_index.bonus)
     args_slices_.emplace_back(*key_index.bonus, *key_index.bonus + 1);
+  args_slices_.emplace_back(key_index.start, key_index.end);
 
   for (string_view key : key_index.Range(full_args_))
     kv_fp_.push_back(LockTag(key).Fingerprint());


### PR DESCRIPTION
Fixes #5272 

We have a fast path for single key commands - fast, because we know ahead it's single shard. I didn't implement bonus key handling there, because they always have at least two commands. Except when squashing, we choose this fast path as we know again ahead of time that it will be only a single shard.