### PR TITLE
chore(db_slice): Add object type to AddOrFind

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -607,15 +607,17 @@ auto DbSlice::FindInternal(const Context& cntx, string_view key, optional<unsign
   return res;
 }
 
-OpResult<DbSlice::ItAndUpdater> DbSlice::AddOrFind(const Context& cntx, string_view key) {
-  return AddOrFindInternal(cntx, key);
+OpResult<DbSlice::ItAndUpdater> DbSlice::AddOrFind(const Context& cntx, string_view key,
+                                                   std::optional<unsigned> req_obj_type) {
+  return AddOrFindInternal(cntx, key, req_obj_type);
 }
 
-OpResult<DbSlice::ItAndUpdater> DbSlice::AddOrFindInternal(const Context& cntx, string_view key) {
+OpResult<DbSlice::ItAndUpdater> DbSlice::AddOrFindInternal(const Context& cntx, string_view key,
+                                                           std::optional<unsigned> req_obj_type) {
   DCHECK(IsDbValid(cntx.db_index));
 
   DbTable& db = *db_arr_[cntx.db_index];
-  auto res = FindInternal(cntx, key, std::nullopt, UpdateStatsMode::kMutableStats);
+  auto res = FindInternal(cntx, key, req_obj_type, UpdateStatsMode::kMutableStats);
 
   if (res.ok()) {
     Iterator it(res->it, StringOrView::FromView(key));
@@ -636,7 +638,10 @@ OpResult<DbSlice::ItAndUpdater> DbSlice::AddOrFindInternal(const Context& cntx, 
     } else {
       res = OpStatus::KEY_NOTFOUND;
     }
+  } else if (res == OpStatus::WRONG_TYPE) {
+    return OpStatus::WRONG_TYPE;
   }
+
   auto status = res.status();
   CHECK(status == OpStatus::KEY_NOTFOUND || status == OpStatus::OUT_OF_MEMORY) << status;
 
@@ -1027,7 +1032,7 @@ OpResult<DbSlice::ItAndUpdater> DbSlice::AddOrUpdateInternal(const Context& cntx
                                                              bool force_update) {
   DCHECK(!obj.IsRef());
 
-  auto op_result = AddOrFind(cntx, key);
+  auto op_result = AddOrFind(cntx, key, std::nullopt);
   RETURN_ON_BAD_STATUS(op_result);
 
   auto& res = *op_result;

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -306,7 +306,16 @@ class DbSlice {
   OpResult<ConstIterator> FindReadOnly(const Context& cntx, std::string_view key,
                                        unsigned req_obj_type) const;
 
-  OpResult<ItAndUpdater> AddOrFind(const Context& cntx, std::string_view key);
+  // Consider using req_obj_type to specify the type of object you expect.
+  // Because it can evaluate to bugs like this:
+  // - We already have a key but with another type you expect.
+  // - During FindMutable we will not use req_obj_type, so the object type will not be checked.
+  // - AddOrFind will return the object with this key but with a different type.
+  // - Then you will update this object with a different type, which will lead to an error.
+  // If you proved the key type on your own, please add a comment there why don't specify
+  // req_obj_type
+  OpResult<ItAndUpdater> AddOrFind(const Context& cntx, std::string_view key,
+                                   std::optional<unsigned> req_obj_type);
 
   // Same as AddOrSkip, but overwrites in case entry exists.
   OpResult<ItAndUpdater> AddOrUpdate(const Context& cntx, std::string_view key, PrimeValue obj,
@@ -583,7 +592,8 @@ class DbSlice {
 
   PrimeItAndExp ExpireIfNeeded(const Context& cntx, PrimeIterator it) const;
 
-  OpResult<ItAndUpdater> AddOrFindInternal(const Context& cntx, std::string_view key);
+  OpResult<ItAndUpdater> AddOrFindInternal(const Context& cntx, std::string_view key,
+                                           std::optional<unsigned> req_obj_type);
 
   OpResult<PrimeItAndExp> FindInternal(const Context& cntx, std::string_view key,
                                        std::optional<unsigned> req_obj_type,

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -625,19 +625,19 @@ TEST_F(DflyEngineTest, Bug496) {
         db.RegisterOnChange([&cb_hits](DbIndex, const DbSlice::ChangeReq&) { cb_hits++; });
 
     {
-      auto res = *db.AddOrFind({}, "key-1");
+      auto res = *db.AddOrFind({}, "key-1", std::nullopt);
       EXPECT_TRUE(res.is_new);
       EXPECT_EQ(cb_hits, 1);
     }
 
     {
-      auto res = *db.AddOrFind({}, "key-1");
+      auto res = *db.AddOrFind({}, "key-1", std::nullopt);
       EXPECT_FALSE(res.is_new);
       EXPECT_EQ(cb_hits, 2);
     }
 
     {
-      auto res = *db.AddOrFind({}, "key-2");
+      auto res = *db.AddOrFind({}, "key-2", std::nullopt);
       EXPECT_TRUE(res.is_new);
       EXPECT_EQ(cb_hits, 3);
     }

--- a/src/server/hll_family.cc
+++ b/src/server/hll_family.cc
@@ -81,14 +81,12 @@ OpResult<int> AddToHll(const OpArgs& op_args, string_view key, CmdArgList values
 
   string hll;
 
-  auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
+  auto op_res = db_slice.AddOrFind(op_args.db_cntx, key, OBJ_STRING);
   RETURN_ON_BAD_STATUS(op_res);
   auto& res = *op_res;
   if (res.is_new) {
     hll.resize(getSparseHllInitSize());
     initSparseHll(StringToHllPtr(hll));
-  } else if (res.it->second.ObjType() != OBJ_STRING) {
-    return OpStatus::WRONG_TYPE;
   } else {
     res.it->second.GetString(&hll);
   }
@@ -299,7 +297,7 @@ OpResult<int> PFMergeInternal(CmdArgList args, Transaction* tx, SinkReplyBuilder
     string_view key = ArgS(args, 0);
     const OpArgs& op_args = t->GetOpArgs(shard);
     auto& db_slice = op_args.GetDbSlice();
-    auto op_res = db_slice.AddOrFind(t->GetDbContext(), key);
+    auto op_res = db_slice.AddOrFind(t->GetDbContext(), key, OBJ_STRING);
     RETURN_ON_BAD_STATUS(op_res);
     auto& res = *op_res;
     res.it->second.SetString(hll);

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -170,7 +170,7 @@ OpStatus IncrementValue(optional<string_view> prev_val, IncrByParam* param) {
 
 OpStatus OpIncrBy(const OpArgs& op_args, string_view key, string_view field, IncrByParam* param) {
   auto& db_slice = op_args.GetDbSlice();
-  auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
+  auto op_res = db_slice.AddOrFind(op_args.db_cntx, key, OBJ_HASH);
   RETURN_ON_BAD_STATUS(op_res);
   if (!op_res) {
     return op_res.status();
@@ -181,9 +181,6 @@ OpStatus OpIncrBy(const OpArgs& op_args, string_view key, string_view field, Inc
   if (add_res.is_new) {
     pv.InitRobj(OBJ_HASH, kEncodingListPack, lpNew(0));
   } else {
-    if (pv.ObjType() != OBJ_HASH)
-      return OpStatus::WRONG_TYPE;
-
     op_args.shard->search_indices()->RemoveDoc(key, op_args.db_cntx, add_res.it->second);
 
     if (pv.Encoding() == kEncodingListPack) {
@@ -675,7 +672,7 @@ OpResult<uint32_t> OpSet(const OpArgs& op_args, string_view key, CmdArgList valu
   VLOG(2) << "OpSet(" << key << ")";
 
   auto& db_slice = op_args.GetDbSlice();
-  auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
+  auto op_res = db_slice.AddOrFind(op_args.db_cntx, key, OBJ_HASH);
   RETURN_ON_BAD_STATUS(op_res);
   auto& add_res = *op_res;
 
@@ -691,9 +688,6 @@ OpResult<uint32_t> OpSet(const OpArgs& op_args, string_view key, CmdArgList valu
       pv.InitRobj(OBJ_HASH, kEncodingStrMap2, CompactObj::AllocateMR<StringMap>());
     }
   } else {
-    if (pv.ObjType() != OBJ_HASH)
-      return OpStatus::WRONG_TYPE;
-
     op_args.shard->search_indices()->RemoveDoc(key, op_args.db_cntx, it->second);
   }
 

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -429,7 +429,8 @@ std::optional<JsonType> ShardJsonFromString(std::string_view input) {
 }
 
 OpStatus SetFullJson(const OpArgs& op_args, string_view key, string_view json_str) {
-  auto it_res = op_args.GetDbSlice().AddOrFind(op_args.db_cntx, key);
+  // We check the type of the object later, because we allow here OBJ_JSON and OBJ_STRING
+  auto it_res = op_args.GetDbSlice().AddOrFind(op_args.db_cntx, key, std::nullopt);
   RETURN_ON_BAD_STATUS(it_res);
 
   auto type = it_res->it->second.ObjType();

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -684,7 +684,7 @@ OpResult<streamID> OpAdd(const OpArgs& op_args, string_view key, const AddOpts& 
     RETURN_ON_BAD_STATUS(res_it);
     add_res = std::move(*res_it);
   } else {
-    auto op_res = db_slice.AddOrFind(op_args.db_cntx, key);
+    auto op_res = db_slice.AddOrFind(op_args.db_cntx, key, OBJ_STREAM);
     RETURN_ON_BAD_STATUS(op_res);
     add_res = std::move(*op_res);
   }
@@ -696,8 +696,6 @@ OpResult<streamID> OpAdd(const OpArgs& op_args, string_view key, const AddOpts& 
   if (add_res.is_new) {
     stream* s = streamNew();
     it->second.InitRobj(OBJ_STREAM, OBJ_ENCODING_STREAM, s);
-  } else if (it->second.ObjType() != OBJ_STREAM) {
-    return OpStatus::WRONG_TYPE;
   }
 
   stream* stream_inst = (stream*)it->second.RObjPtr();

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1938,8 +1938,7 @@ OpResult<ZSetFamily::AddResult> ZSetFamily::OpAdd(const OpArgs& op_args,
 
   if (zparams.override && members.empty()) {
     auto res_it = db_slice.FindMutable(op_args.db_cntx, key, OBJ_ZSET);
-    RETURN_ON_BAD_STATUS(res_it);
-    if (IsValid(res_it->it)) {
+    if (res_it && IsValid(res_it->it)) {
       res_it->post_updater.Run();
       db_slice.Del(op_args.db_cntx, res_it->it);
     }


### PR DESCRIPTION
fixes dragonflydb#5271

This PR introduces an `unsigned req_obj_type` parameter to the `AddOrFind` method (with the main changes located in the db_slice files). It also verifies that all usages of AddOrFind across the codebase behave as expected.