### PR TITLE
fix(string_family): Add RemoveDoc for the SET command

### DIFF
--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -112,8 +112,8 @@ class SetCmd {
   OpStatus Set(const SetParams& params, std::string_view key, std::string_view value);
 
  private:
-  OpStatus SetExisting(const SetParams& params, const DbContext& db_cntx, DbSlice::Iterator it,
-                       DbSlice::ExpIterator e_it, std::string_view key, std::string_view value);
+  OpStatus SetExisting(const SetParams& params, DbSlice::Iterator it, DbSlice::ExpIterator e_it,
+                       std::string_view key, std::string_view value);
 
   void AddNew(const SetParams& params, DbSlice::Iterator it, std::string_view key,
               std::string_view value);
@@ -832,7 +832,7 @@ OpStatus SetCmd::Set(const SetParams& params, string_view key, string_view value
 
     if (params.flags & SET_IF_EXISTS) {
       if (IsValid(find_res.it)) {
-        return SetExisting(params, op_args_.db_cntx, find_res.it, find_res.exp_it, key, value);
+        return SetExisting(params, find_res.it, find_res.exp_it, key, value);
       } else {
         return OpStatus::SKIPPED;
       }
@@ -851,16 +851,15 @@ OpStatus SetCmd::Set(const SetParams& params, string_view key, string_view value
     if (auto status = CachePrevIfNeeded(params, op_res->it); status != OpStatus::OK)
       return status;
 
-    return SetExisting(params, op_args_.db_cntx, op_res->it, op_res->exp_it, key, value);
+    return SetExisting(params, op_res->it, op_res->exp_it, key, value);
   } else {
     AddNew(params, op_res->it, key, value);
     return OpStatus::OK;
   }
 }
 
-OpStatus SetCmd::SetExisting(const SetParams& params, const DbContext& db_cntx,
-                             DbSlice::Iterator it, DbSlice::ExpIterator e_it, string_view key,
-                             string_view value) {
+OpStatus SetCmd::SetExisting(const SetParams& params, DbSlice::Iterator it,
+                             DbSlice::ExpIterator e_it, string_view key, string_view value) {
   DCHECK_EQ(params.flags & SET_IF_NOTEXIST, 0);
 
   PrimeValue& prime_value = it->second;
@@ -895,7 +894,7 @@ OpStatus SetCmd::SetExisting(const SetParams& params, const DbContext& db_cntx,
   db_slice.SetMCFlag(op_args_.db_cntx.db_index, it->first.AsRef(), params.memcache_flags);
 
   // We need to remove the key from search indices, because we are overwriting it to OBJ_STRING
-  shard->search_indices()->RemoveDoc(key, db_cntx, prime_value);
+  shard->search_indices()->RemoveDoc(key, op_args_.db_cntx, prime_value);
 
   // If value is external, mark it as deleted
   if (prime_value.IsExternal()) {


### PR DESCRIPTION
fixes dragonflydb#5215

The problem was that the `StringFamily::Set` command could change the key's type. If the previous type was `HSET` or `JSON`, the key was indexed. When `StringFamily::Set` is called on such a key, it changes the type from HSET/JSON to STRING, but we forgot to remove the key from the indexes.

This PR adds a call to `RemoveDoc` inside `StringFamily::Set` to properly clean up the old index entry.

A snippet that reproduces the issue has been added to the tests, along with explanatory comments:
```
127.0.0.1:6379> ft.create index on hash schema field TEXT
OK
127.0.0.1:6379> hset k1 field value
(integer) 1
127.0.0.1:6379> set k1 anothervalue
OK
127.0.0.1:6379> rename k1 anotherkey
OK
127.0.0.1:6379> hset k1 field value
Error: Server closed the connection
(1.29s)
```