### PR TITLE
fix: prevent rename cmd crash

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -404,7 +404,11 @@ OpStatus Renamer::FinalizeRename() {
 
   transaction_->Execute(std::move(cb), true);
 
-  DCHECK(del_status == OpStatus::OK);
+  LOG_IF(DFATAL,
+         (deserialize_status != OpStatus::OK && deserialize_status != OpStatus::OUT_OF_MEMORY) ||
+             del_status != OpStatus::OK)
+      << "Error during rename command, deserialize_status: " << deserialize_status
+      << " del_status: " << del_status;
   return deserialize_status != OpStatus::OK ? deserialize_status : del_status;
 }
 


### PR DESCRIPTION
fixes: #5295
problem: we could return an error status for the deserialization operation during the transaction