### PR TITLE
fix(json): JSON.DEL recursive descent duplicate counting for nested same-key elements

### DIFF
--- a/src/core/json/detail/jsoncons_dfs.cc
+++ b/src/core/json/detail/jsoncons_dfs.cc
@@ -348,15 +348,9 @@ auto Dfs::DeleteStep(const PathSegment& segment, JsonType* node)
 
     case SegmentType::DESCENT:
     case SegmentType::WILDCARD: {
-      if (node->is_object()) {
-        size_t initial_size = node->size();
-        node->erase(node->object_range().begin(), node->object_range().end());
-        matches_ += initial_size;
-      } else if (node->is_array()) {
-        size_t initial_size = node->size();
-        node->erase(node->array_range().begin(), node->array_range().end());
-        matches_ += initial_size;
-      }
+      size_t initial_size = node->size();
+      node->clear();
+      matches_ += initial_size;
     } break;
     case SegmentType::FUNCTION:
       LOG(DFATAL) << "Function segment is not supported for deletion";

--- a/src/core/json/detail/jsoncons_dfs.h
+++ b/src/core/json/detail/jsoncons_dfs.h
@@ -113,7 +113,7 @@ class Dfs {
   // TODO: for some operations we need to know the type of mismatches.
   static Dfs Traverse(absl::Span<const PathSegment> path, const JsonType& json, const Cb& callback);
   static Dfs Mutate(absl::Span<const PathSegment> path, const MutateCallback& callback,
-                    JsonType* json, bool reverse_traversal);
+                    JsonType* json, bool deletion_mode);
 
   unsigned matches() const {
     return matches_;

--- a/src/core/json/jsonpath_test.cc
+++ b/src/core/json/jsonpath_test.cc
@@ -618,7 +618,7 @@ TYPED_TEST(JsonPathTest, MutateDeleteNestedWithSameKey) {
   };
 
   if constexpr (std::is_same_v<TypeParam, JsonType>) {
-    unsigned reported_matches = MutatePath(path, delete_cb, &json, true /* reverse_traversal */);
+    unsigned reported_matches = MutatePath(path, delete_cb, &json, true /* deletion_mode */);
 
     // Verify that exactly 2 elements were deleted
     EXPECT_EQ(2, deleted_count);
@@ -630,8 +630,7 @@ TYPED_TEST(JsonPathTest, MutateDeleteNestedWithSameKey) {
     EXPECT_EQ(expected, json);
   } else {
     flexbuffers::Builder fbb;
-    unsigned reported_matches =
-        MutatePath(path, delete_cb, json, &fbb, true /* reverse_traversal */);
+    unsigned reported_matches = MutatePath(path, delete_cb, json, &fbb, true /* deletion_mode */);
 
     // Verify that exactly 2 elements were deleted
     EXPECT_EQ(2, deleted_count);

--- a/src/core/json/path.cc
+++ b/src/core/json/path.cc
@@ -148,13 +148,24 @@ nonstd::expected<json::Path, string> ParsePath(string_view path) {
   return driver.TakePath();
 }
 
-unsigned MutatePath(const Path& path, MutateCallback callback, JsonType* json, bool deletion_mode) {
+unsigned MutatePath(const Path& path, MutateCallback callback, JsonType* json) {
   if (path.empty()) {
     callback(nullopt, json);
     return 1;
   }
 
-  Dfs dfs = Dfs::Mutate(path, callback, json, deletion_mode);
+  Dfs dfs = Dfs::Mutate(path, callback, json);
+  return dfs.matches();
+}
+
+unsigned DeletePath(const Path& path, JsonType* json) {
+  if (path.empty()) {
+    // For empty path, we cannot delete the root JSON itself within this function
+    // as it would require modifying the pointer itself. Return 0 for no deletion.
+    return 0;
+  }
+
+  Dfs dfs = Dfs::Delete(path, json);
   return dfs.matches();
 }
 
@@ -285,9 +296,9 @@ void FromJsonType(const JsonType& src, flexbuffers::Builder* fbb) {
 }
 
 unsigned MutatePath(const Path& path, MutateCallback callback, FlatJson json,
-                    flexbuffers::Builder* fbb, bool deletion_mode) {
+                    flexbuffers::Builder* fbb) {
   JsonType mut_json = FromFlat(json);
-  unsigned res = MutatePath(path, std::move(callback), &mut_json, deletion_mode);
+  unsigned res = MutatePath(path, std::move(callback), &mut_json);
 
   // Populate the output builder 'fbb' with the resulting JSON state
   // (mutated or original if res == 0) and finalize it.
@@ -298,6 +309,15 @@ unsigned MutatePath(const Path& path, MutateCallback callback, FlatJson json,
   fbb->Finish();                // Always finish the builder
 
   // Return the number of actual mutations that occurred.
+  return res;
+}
+
+unsigned DeletePath(const Path& path, FlatJson json, flexbuffers::Builder* fbb) {
+  JsonType mut_json = FromFlat(json);
+  unsigned res = DeletePath(path, &mut_json);
+
+  FromJsonType(mut_json, fbb);
+  fbb->Finish();
   return res;
 }
 

--- a/src/core/json/path.cc
+++ b/src/core/json/path.cc
@@ -148,14 +148,13 @@ nonstd::expected<json::Path, string> ParsePath(string_view path) {
   return driver.TakePath();
 }
 
-unsigned MutatePath(const Path& path, MutateCallback callback, JsonType* json,
-                    bool reverse_traversal) {
+unsigned MutatePath(const Path& path, MutateCallback callback, JsonType* json, bool deletion_mode) {
   if (path.empty()) {
     callback(nullopt, json);
     return 1;
   }
 
-  Dfs dfs = Dfs::Mutate(path, callback, json, reverse_traversal);
+  Dfs dfs = Dfs::Mutate(path, callback, json, deletion_mode);
   return dfs.matches();
 }
 
@@ -286,9 +285,9 @@ void FromJsonType(const JsonType& src, flexbuffers::Builder* fbb) {
 }
 
 unsigned MutatePath(const Path& path, MutateCallback callback, FlatJson json,
-                    flexbuffers::Builder* fbb, bool reverse_traversal) {
+                    flexbuffers::Builder* fbb, bool deletion_mode) {
   JsonType mut_json = FromFlat(json);
-  unsigned res = MutatePath(path, std::move(callback), &mut_json, reverse_traversal);
+  unsigned res = MutatePath(path, std::move(callback), &mut_json, deletion_mode);
 
   // Populate the output builder 'fbb' with the resulting JSON state
   // (mutated or original if res == 0) and finalize it.

--- a/src/core/json/path.h
+++ b/src/core/json/path.h
@@ -126,7 +126,7 @@ using PathCallback = absl::FunctionRef<void(std::optional<std::string_view>, con
 using PathFlatCallback = absl::FunctionRef<void(std::optional<std::string_view>, FlatJson)>;
 
 // Returns true if the entry should be deleted, false otherwise.
-using MutateCallback = absl::FunctionRef<bool(std::optional<std::string_view>, JsonType*)>;
+using MutateCallback = absl::FunctionRef<void(std::optional<std::string_view>, JsonType*)>;
 
 void EvaluatePath(const Path& path, const JsonType& json, PathCallback callback);
 
@@ -134,10 +134,13 @@ void EvaluatePath(const Path& path, const JsonType& json, PathCallback callback)
 void EvaluatePath(const Path& path, FlatJson json, PathFlatCallback callback);
 
 // returns number of matches found with the given path.
-unsigned MutatePath(const Path& path, MutateCallback callback, JsonType* json,
-                    bool deletion_mode = false);
+unsigned MutatePath(const Path& path, MutateCallback callback, JsonType* json);
 unsigned MutatePath(const Path& path, MutateCallback callback, FlatJson json,
-                    flexbuffers::Builder* fbb, bool deletion_mode = false);
+                    flexbuffers::Builder* fbb);
+
+// Simplified deletion operation without callback - more efficient for JSON.DEL operations
+unsigned DeletePath(const Path& path, JsonType* json);
+unsigned DeletePath(const Path& path, FlatJson json, flexbuffers::Builder* fbb);
 
 // utility function to parse a jsonpath. Returns an error message if a parse error was
 // encountered.

--- a/src/core/json/path.h
+++ b/src/core/json/path.h
@@ -135,9 +135,9 @@ void EvaluatePath(const Path& path, FlatJson json, PathFlatCallback callback);
 
 // returns number of matches found with the given path.
 unsigned MutatePath(const Path& path, MutateCallback callback, JsonType* json,
-                    bool reverse_traversal = false);
+                    bool deletion_mode = false);
 unsigned MutatePath(const Path& path, MutateCallback callback, FlatJson json,
-                    flexbuffers::Builder* fbb, bool reverse_traversal = false);
+                    flexbuffers::Builder* fbb, bool deletion_mode = false);
 
 // utility function to parse a jsonpath. Returns an error message if a parse error was
 // encountered.

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -1058,9 +1058,7 @@ OpResult<long> OpDel(const OpArgs& op_args, string_view key, string_view path,
   if (json_path.HoldsJsonPath()) {
     JsonAutoUpdater updater(op_args, key, *std::move(it_res), true);
     const json::Path& path = json_path.AsJsonPath();
-    long deletions = json::MutatePath(
-        path, [](optional<string_view>, JsonType* val) { return true; }, updater.GetJson(),
-        true /* deletion_mode */);
+    long deletions = json::DeletePath(path, updater.GetJson());
     return deletions;
   }
 

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -1060,7 +1060,7 @@ OpResult<long> OpDel(const OpArgs& op_args, string_view key, string_view path,
     const json::Path& path = json_path.AsJsonPath();
     long deletions = json::MutatePath(
         path, [](optional<string_view>, JsonType* val) { return true; }, updater.GetJson(),
-        true /* reverse_traversal */);
+        true /* deletion_mode */);
     return deletions;
   }
 

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -1262,21 +1262,23 @@ TEST_F(JsonFamilyTest, Del) {
   resp = Run({"JSON.GET", "json"});
   EXPECT_THAT(resp, ArgType(RespExpr::NIL));
 
-  // Test recursive delete with $..a path
-  resp = Run({"JSON.SET", "doc2", "$",
-              R"({"a": {"a": 2, "b": 3}, "b": ["a", "b"], "nested": {"b": [true, "a", "b"]}})"});
-  ASSERT_THAT(resp, "OK");
+  if (absl::GetFlag(FLAGS_jsonpathv2)) {
+    // Test recursive delete with $..a path
+    resp = Run({"JSON.SET", "doc2", "$",
+                R"({"a": {"a": 2, "b": 3}, "b": ["a", "b"], "nested": {"b": [true, "a", "b"]}})"});
+    ASSERT_THAT(resp, "OK");
 
-  resp = Run({"JSON.GET", "doc2"});
-  EXPECT_EQ(resp, R"({"a":{"a":2,"b":3},"b":["a","b"],"nested":{"b":[true,"a","b"]}})");
+    resp = Run({"JSON.GET", "doc2"});
+    EXPECT_EQ(resp, R"({"a":{"a":2,"b":3},"b":["a","b"],"nested":{"b":[true,"a","b"]}})");
 
-  // JSON.DEL with $..a should find and delete the key "a" at root level
-  // but not string values "a" inside arrays
-  resp = Run({"JSON.DEL", "doc2", "$..a"});
-  EXPECT_THAT(resp, IntArg(1));
+    // JSON.DEL with $..a should find and delete the key "a" at root level
+    // but not string values "a" inside arrays
+    resp = Run({"JSON.DEL", "doc2", "$..a"});
+    EXPECT_THAT(resp, IntArg(1));
 
-  resp = Run({"JSON.GET", "doc2"});
-  EXPECT_EQ(resp, R"({"b":["a","b"],"nested":{"b":[true,"a","b"]}})");
+    resp = Run({"JSON.GET", "doc2"});
+    EXPECT_EQ(resp, R"({"b":["a","b"],"nested":{"b":[true,"a","b"]}})");
+  }
 }
 
 TEST_F(JsonFamilyTest, DelLegacy) {

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -1261,6 +1261,22 @@ TEST_F(JsonFamilyTest, Del) {
 
   resp = Run({"JSON.GET", "json"});
   EXPECT_THAT(resp, ArgType(RespExpr::NIL));
+
+  // Test recursive delete with $..a path
+  resp = Run({"JSON.SET", "doc2", "$",
+              R"({"a": {"a": 2, "b": 3}, "b": ["a", "b"], "nested": {"b": [true, "a", "b"]}})"});
+  ASSERT_THAT(resp, "OK");
+
+  resp = Run({"JSON.GET", "doc2"});
+  EXPECT_EQ(resp, R"({"a":{"a":2,"b":3},"b":["a","b"],"nested":{"b":[true,"a","b"]}})");
+
+  // JSON.DEL with $..a should find and delete the key "a" at root level
+  // but not string values "a" inside arrays
+  resp = Run({"JSON.DEL", "doc2", "$..a"});
+  EXPECT_THAT(resp, IntArg(1));
+
+  resp = Run({"JSON.GET", "doc2"});
+  EXPECT_EQ(resp, R"({"b":["a","b"],"nested":{"b":[true,"a","b"]}})");
 }
 
 TEST_F(JsonFamilyTest, DelLegacy) {


### PR DESCRIPTION
Fixes: https://github.com/dragonflydb/dragonfly/issues/5259

Issue:
`JSON.DEL doc "$..a"` was returning 2 instead of 1 when deleting nested objects with the same key name, because both parent and child deletions were counted separately.

Solution:
Added filtering logic to avoid counting child nodes that are automatically deleted when their parent is removed. Only applies to recursive descent deletion operations where one object directly contains another with the same target key.

Testing:
- A unit test was added
- Fakeredis test was checked `poetry run pytest -s test/test_json/test_json.py  -k test_json_delete_with_dollar`