### PR TITLE
fix(json_family): Fix SetFullJson command for the STRING types

### DIFF
--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -432,15 +432,8 @@ std::optional<JsonType> ShardJsonFromString(std::string_view input) {
 }
 
 OpStatus SetFullJson(const OpArgs& op_args, string_view key, string_view json_str) {
-  // We check the type of the object later, because we allow here OBJ_JSON and OBJ_STRING
-  auto it_res = op_args.GetDbSlice().AddOrFind(op_args.db_cntx, key, std::nullopt);
+  auto it_res = op_args.GetDbSlice().AddOrFind(op_args.db_cntx, key, OBJ_JSON);
   RETURN_ON_BAD_STATUS(it_res);
-
-  auto type = it_res->it->second.ObjType();
-  if (type != OBJ_JSON && type != OBJ_STRING) {
-    // The object is not a JSON object and not a string, so we cannot set a full JSON value
-    return OpStatus::WRONG_TYPE;
-  }
 
   JsonAutoUpdater updater(op_args, key, *std::move(it_res));
 

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -3108,6 +3108,13 @@ TEST_F(JsonFamilyTest, JsonCommandsWorkingWithOtherTypesBug) {
 
   resp = Run({"HGET", "k2", "field"});
   EXPECT_THAT(resp, "value");
+
+  // Third bug: JSON.SET should not change the type of the string key
+  resp = Run({"SET", "k3", "value"});
+  EXPECT_EQ(resp, "OK");
+
+  resp = Run({"JSON.SET", "k3", "$", R"({"a":"b"})"});
+  ASSERT_THAT(resp, ErrArg(wrong_type_err));
 }
 
 }  // namespace dfly


### PR DESCRIPTION
I introduced recently a bug in json_family in this PR #5266 . I missed something and added logic that previously we didn't support :melting_face: 