### PR TITLE
test: enable test_multidim_knn python test

### DIFF
--- a/tests/dragonfly/search_test.py
+++ b/tests/dragonfly/search_test.py
@@ -280,7 +280,6 @@ NUM_POINTS = 100
 @dfly_args({"proactor_threads": 4})
 @pytest.mark.parametrize("index_type", [IndexType.HASH, IndexType.JSON])
 @pytest.mark.parametrize("algo_type", ["HNSW", "FLAT"])
-@pytest.mark.skip("Fails on ARM")
 async def test_multidim_knn(async_client: aioredis.Redis, index_type, algo_type):
     vector_field = VectorField(
         "pos",
@@ -316,7 +315,7 @@ async def test_multidim_knn(async_client: aioredis.Redis, index_type, algo_type)
     # Run 10 random queries
     for _ in range(10):
         center = rand_point()
-        limit = random.randint(1, NUM_POINTS / 10)
+        limit = random.randint(1, NUM_POINTS // 10)
 
         expected_ids = [
             f"k{i}"


### PR DESCRIPTION
Fixes all 4 parametrized test variants (HASH/JSON × HNSW/FLAT)