### PR TITLE
chore: add hdr_histogram to the project

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,6 +125,17 @@ add_third_party(
                     -DFLATBUFFERS_BUILD_FLATC=OFF"
 )
 
+add_third_party(
+  hdr_histogram
+  GIT_REPOSITORY https://github.com/HdrHistogram/HdrHistogram_c/
+  GIT_TAG 652d51bcc36744fd1a6debfeb1a8a5f58b14022c
+  GIT_SHALLOW 1
+  CMAKE_PASS_FLAGS "-DHDR_LOG_REQUIRED=OFF -DHDR_HISTOGRAM_BUILD_PROGRAMS=OFF
+                    -DHDR_HISTOGRAM_INSTALL_SHARED=OFF"
+  LIB libhdr_histogram_static.a
+)
+
+
 add_library(TRDP::jsoncons INTERFACE IMPORTED)
 add_dependencies(TRDP::jsoncons jsoncons_project)
 set_target_properties(TRDP::jsoncons PROPERTIES

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -82,7 +82,7 @@ if (WITH_AWS)
   add_definitions(-DWITH_AWS)
 endif()
 
-cxx_link(dfly_transaction dfly_core strings_lib TRDP::fast_float)
+cxx_link(dfly_transaction dfly_core strings_lib TRDP::fast_float TRDP::hdr_histogram)
 cxx_link(dragonfly_lib dfly_transaction dfly_facade redis_lib ${AWS_LIB} jsonpath
          strings_lib html_lib gcp_lib azure_lib
          http_client_lib absl::random_random TRDP::jsoncons TRDP::zstd TRDP::lz4

--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -1186,12 +1186,13 @@ std::variant<User::UpdateRequest, ErrorReply> AclFamily::ParseAclSetUser(
 }
 
 void AclFamily::BuildIndexers(RevCommandsIndexStore families) {
-  acl::NumberOfFamilies(families.size());
+  size_t family_count = acl::NumberOfFamilies(families.size());
   CommandsRevIndexer(std::move(families));
   CategoryToCommandsIndexStore index;
   cmd_registry_->Traverse([&](std::string_view, auto& cid) {
     const uint32_t cat = cid.acl_categories();
     const size_t family = cid.GetFamily();
+    DCHECK_LT(family, family_count);
     const uint64_t bit_index = cid.GetBitIndex();
     for (size_t i = 0; i < 32; ++i) {
       if (cat & 1 << i) {

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -132,7 +132,7 @@ CommandId::CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first
     : facade::CommandId(name, ImplicitCategories(mask), arity, first_key, last_key,
                         acl_categories.value_or(ImplicitAclCategories(mask))) {
   implicit_acl_ = !acl_categories.has_value();
-  struct hdr_histogram* hist = nullptr;
+  hdr_histogram* hist = nullptr;
   hdr_init(kLatencyHistogramMinValue, kLatencyHistogramMaxValue, kLatencyHistogramPrecision, &hist);
   latency_histogram_ = hist;
 }
@@ -156,7 +156,7 @@ CommandId CommandId::Clone(const std::string_view name) const {
   // explicit sharing of the object since it's an alias we can do that.
   // I am assuming that the source object lifetime is at least as of the cloned object.
   hdr_close(cloned.latency_histogram_);  // Free the histogram in the cloned object.
-  cloned.latency_histogram_ = static_cast<struct hdr_histogram*>(latency_histogram_);
+  cloned.latency_histogram_ = static_cast<hdr_histogram*>(latency_histogram_);
   return cloned;
 }
 

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -94,7 +94,7 @@ template <typename T> class MoveOnly {
   MoveOnly(const MoveOnly&) = delete;
   MoveOnly& operator=(const MoveOnly&) = delete;
 
-  explicit MoveOnly(MoveOnly&& t) noexcept : value_(std::move(t.value_)) {
+  MoveOnly(MoveOnly&& t) noexcept : value_(std::move(t.value_)) {
     t.value_ = T{};  // Reset the passed value to default state
   }
 
@@ -194,7 +194,7 @@ class CommandId : public facade::CommandId {
   std::unique_ptr<CmdCallStats[]> command_stats_;
   Handler3 handler_;
   ArgValidator validator_;
-  MoveOnly<struct hdr_histogram*> latency_histogram_;  // Histogram for command latency in usec
+  MoveOnly<hdr_histogram*> latency_histogram_;  // Histogram for command latency in usec
 };
 
 class CommandRegistry {

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -147,7 +147,7 @@ struct ConnectionState {
     const ConnectionContext* owner = nullptr;
   };
 
-  enum MCGetMask { FETCH_CAS_VER = 1 };
+  enum MCGetMask : uint8_t { FETCH_CAS_VER = 1 };
 
   size_t UsedMemory() const;
 
@@ -265,6 +265,7 @@ struct ConnectionState {
   std::unique_ptr<ScriptInfo> script_info;
   std::unique_ptr<SubscribeInfo> subscribe_info;
   ClientTracking tracking_info_;
+  uint64_t cmd_start_time_ns = 0;  // time when the last command started executing
 };
 
 class ConnectionContext : public facade::ConnectionContext {

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -49,8 +49,7 @@ class Service : public facade::ServiceInterface {
 
   // Verify command can be executed now (check out of memory), always called immediately before
   // execution
-  std::optional<facade::ErrorReply> VerifyCommandExecution(const CommandId* cid,
-                                                           const ConnectionContext* cntx,
+  std::optional<facade::ErrorReply> VerifyCommandExecution(const ConnectionContext* cntx,
                                                            CmdArgList tail_args);
 
   // Verify command prepares excution in correct state.


### PR DESCRIPTION
Mostly a boilerplate PR, should not change functionality.

1. reduce number of absl::GetCurrentTimeNanos() calls by one during the command execution.
2. add hdr_histogram object to CommandId but do not yet record anything into it.

First part to address #5092

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->