### PR TITLE
fix: data race when doing a snapshot in cache mode

### DIFF
--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -68,7 +68,7 @@ class SliceSnapshot : public journal::JournalConsumerInterface {
 
   // Initialize snapshot, start bucket iteration fiber, register listeners.
   // In journal streaming mode it needs to be stopped by either Stop or Cancel.
-  enum class SnapshotFlush { kAllow, kDisallow };
+  enum class SnapshotFlush : uint8_t { kAllow, kDisallow };
 
   void Start(bool stream_journal, SnapshotFlush allow_flush = SnapshotFlush::kDisallow);
 

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -26,14 +26,6 @@ M_STRESS = [pytest.mark.slow, pytest.mark.opt_only]
 M_NOT_EPOLL = [pytest.mark.exclude_epoll]
 
 
-async def wait_for_replicas_state(*clients, state="online", node_role="slave", timeout=0.05):
-    """Wait until all clients (replicas) reach passed state"""
-    while len(clients) > 0:
-        await asyncio.sleep(timeout)
-        roles = await asyncio.gather(*(c.role() for c in clients))
-        clients = [c for c, role in zip(clients, roles) if role[0] != node_role or role[3] != state]
-
-
 """
 Test full replication pipeline. Test full sync with streaming changes and stable state streaming.
 """

--- a/tests/dragonfly/tiering_test.py
+++ b/tests/dragonfly/tiering_test.py
@@ -1,14 +1,15 @@
 import async_timeout
 import asyncio
 import itertools
+import logging
 import pytest
 import random
 import redis.asyncio as aioredis
 
 from . import dfly_args
 from .seeder import DebugPopulateSeeder
-from .utility import info_tick_timer
-
+from .utility import info_tick_timer, wait_for_replicas_state
+from .instance import DflyInstanceFactory
 
 BASIC_ARGS = {"port": 6379, "proactor_threads": 4, "tiered_prefix": "/tmp/tiered/backing"}
 
@@ -87,3 +88,35 @@ async def test_mixed_append(async_client: aioredis.Redis):
     res = await p.execute()
 
     assert res == [10 * k for k in key_range]
+
+
+@pytest.mark.exclude_epoll
+@pytest.mark.opt_only
+@dfly_args(
+    {
+        "proactor_threads": 2,
+        "tiered_prefix": "/tmp/tiered/backing_master",
+        "maxmemory": "4G",
+        "cache_mode": True,
+        "tiered_offload_threshold": "0.2",
+        "tiered_storage_write_depth": 100,
+    }
+)
+async def test_full_sync(async_client: aioredis.Redis, df_factory: DflyInstanceFactory):
+    replica = df_factory.create(
+        proactor_threads=2,
+        cache_mode=True,
+        maxmemory="4G",
+        tiered_prefix="/tmp/tiered/backing_replica",
+        tiered_offload_threshold="0.2",
+        tiered_storage_write_depth=1000,
+    )
+    replica.start()
+    replica_client = replica.client()
+    await async_client.execute_command("debug", "populate", "3000000", "key", "2000")
+    await replica_client.replicaof(
+        "localhost", async_client.connection_pool.connection_kwargs["port"]
+    )
+    logging.info("Waiting for replica to sync")
+    async with async_timeout.timeout(120):
+        await wait_for_replicas_state(replica_client)

--- a/tests/dragonfly/utility.py
+++ b/tests/dragonfly/utility.py
@@ -848,3 +848,11 @@ def extract_int_after_prefix(prefix, line):
     match = re.search(prefix + "(\\d+)", line)
     assert match
     return int(match.group(1))
+
+
+async def wait_for_replicas_state(*clients, state="online", node_role="slave", timeout=0.05):
+    """Wait until all clients (replicas) reach passed state"""
+    while len(clients) > 0:
+        await asyncio.sleep(timeout)
+        roles = await asyncio.gather(*(c.role() for c in clients))
+        clients = [c for c, role in zip(clients, roles) if role[0] != node_role or role[3] != state]


### PR DESCRIPTION
The issue - during the snapshotting
we tried to fetch the same delayed entry which lead to data-races and deadlocks.
The fix - to pull the entry into a stack before preempting,
ensuring each fiber handles its own entry.

Fixes https://github.com/dragonflydb/dragonfly/issues/4965

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->