### PR TITLE
chore(search_family): Minor performance improvements to GetAllResults methods. FIRST PR

### DIFF
--- a/src/core/search/base.h
+++ b/src/core/search/base.h
@@ -13,6 +13,7 @@
 #include <string_view>
 #include <vector>
 
+#include "absl/container/flat_hash_set.h"
 #include "base/pmr/memory_resource.h"
 #include "core/string_map.h"
 
@@ -80,6 +81,11 @@ struct DocumentAccessor {
   virtual std::optional<StringList> GetTags(std::string_view active_field) const = 0;
 };
 
+// Represents a set of document IDs, used for merging results of inverse indices.
+using DocsList =
+    absl::flat_hash_set<DocId, absl::DefaultHashContainerHash<DocId>,
+                        absl::DefaultHashContainerEq<DocId>, PMR_NS::polymorphic_allocator<DocId>>;
+
 // Base class for type-specific indices.
 //
 // Queries should be done directly on subclasses with their distinc
@@ -92,9 +98,8 @@ struct BaseIndex {
   virtual void Remove(DocId id, const DocumentAccessor& doc, std::string_view field) = 0;
 
   // Returns documents that have non-null values for this field (used for @field:* queries)
-  virtual std::optional<std::vector<DocId>> GetAllResults() const {
-    return std::nullopt;
-  }
+  // Result must be sorted
+  virtual std::vector<DocId> GetAllDocsWithNonNullValues() const = 0;
 };
 
 // Base class for type-specific sorting indices.

--- a/src/core/search/base.h
+++ b/src/core/search/base.h
@@ -82,9 +82,9 @@ struct DocumentAccessor {
 };
 
 // Represents a set of document IDs, used for merging results of inverse indices.
-using DocsList =
-    absl::flat_hash_set<DocId, absl::DefaultHashContainerHash<DocId>,
-                        absl::DefaultHashContainerEq<DocId>, PMR_NS::polymorphic_allocator<DocId>>;
+template <typename Allocator = std::allocator<DocId>>
+using UniqueDocsList = absl::flat_hash_set<DocId, absl::DefaultHashContainerHash<DocId>,
+                                           absl::DefaultHashContainerEq<DocId>, Allocator>;
 
 // Base class for type-specific indices.
 //

--- a/src/core/search/indices.cc
+++ b/src/core/search/indices.cc
@@ -116,7 +116,7 @@ vector<DocId> NumericIndex::Range(double l, double r) const {
 }
 
 vector<DocId> NumericIndex::GetAllDocsWithNonNullValues() const {
-  DocsList unique_docs{entries_.get_allocator().resource()};
+  UniqueDocsList<> unique_docs;
   std::vector<DocId> result;
 
   unique_docs.reserve(entries_.size());
@@ -215,7 +215,7 @@ template <typename C> vector<string> BaseStringIndex<C>::GetTerms() const {
 }
 
 template <typename C> vector<DocId> BaseStringIndex<C>::GetAllDocsWithNonNullValues() const {
-  DocsList unique_docs{entries_.get_allocator().resource()};
+  UniqueDocsList<> unique_docs;
   std::vector<DocId> result;
 
   unique_docs.reserve(entries_.size());
@@ -303,11 +303,9 @@ const float* FlatVectorIndex::Get(DocId doc) const {
 }
 
 std::vector<DocId> FlatVectorIndex::GetAllDocsWithNonNullValues() const {
-  DocsList unique_docs{entries_.get_allocator().resource()};
   std::vector<DocId> result;
 
   size_t num_vectors = entries_.size() / dim_;
-  unique_docs.reserve(num_vectors);
   result.reserve(num_vectors);
 
   for (DocId id = 0; id < num_vectors; ++id) {
@@ -325,14 +323,12 @@ std::vector<DocId> FlatVectorIndex::GetAllDocsWithNonNullValues() const {
     }
 
     if (!is_zero_vector) {
-      auto [_, is_new] = unique_docs.insert(id);
-      if (is_new) {
-        result.push_back(id);
-      }
+      result.push_back(id);
     }
   }
 
-  std::sort(result.begin(), result.end());
+  // Result is already sorted by id, no need to sort again
+  // Also it has no duplicates
   return result;
 }
 

--- a/src/core/search/indices.h
+++ b/src/core/search/indices.h
@@ -35,9 +35,7 @@ struct NumericIndex : public BaseIndex {
 
   std::vector<DocId> Range(double l, double r) const;
 
-  std::optional<std::vector<DocId>> GetAllResults() const override {
-    return Range(-std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity());
-  }
+  std::vector<DocId> GetAllDocsWithNonNullValues() const override;
 
  private:
   using Entry = std::pair<double, DocId>;
@@ -62,19 +60,7 @@ template <typename C> struct BaseStringIndex : public BaseIndex {
   // Returns all the terms that appear as keys in the reverse index.
   std::vector<std::string> GetTerms() const;
 
-  std::optional<std::vector<DocId>> GetAllResults() const override {
-    absl::flat_hash_set<DocId> unique_docs;
-
-    for (const auto& [term, container] : entries_) {
-      for (const DocId& id : container) {
-        unique_docs.insert(id);
-      }
-    }
-
-    auto result = std::vector<DocId>(unique_docs.begin(), unique_docs.end());
-    std::sort(result.begin(), result.end());
-    return result;
-  }
+  std::vector<DocId> GetAllDocsWithNonNullValues() const override;
 
  protected:
   using StringList = DocumentAccessor::StringList;
@@ -152,31 +138,7 @@ struct FlatVectorIndex : public BaseVectorIndex {
   const float* Get(DocId doc) const;
 
   // Return all documents that have vectors in this index
-  std::optional<std::vector<DocId>> GetAllResults() const override {
-    std::vector<DocId> result;
-    size_t num_vectors = entries_.size() / dim_;
-    result.reserve(num_vectors);
-
-    for (DocId id = 0; id < num_vectors; ++id) {
-      // Check if the vector is not zero (all elements are 0)
-      // TODO: Valid vector can contain 0s, we should use a better approach
-      const float* vec = Get(id);
-      bool is_zero_vector = true;
-
-      for (size_t i = 0; i < dim_; ++i) {
-        if (vec[i] != 0.0f) {
-          is_zero_vector = false;
-          break;
-        }
-      }
-
-      if (!is_zero_vector) {
-        result.push_back(id);
-      }
-    }
-
-    return result;
-  }
+  std::vector<DocId> GetAllDocsWithNonNullValues() const override;
 
  protected:
   void AddVector(DocId id, const VectorPtr& vector) override;
@@ -187,10 +149,6 @@ struct FlatVectorIndex : public BaseVectorIndex {
 
 struct HnswlibAdapter;
 
-// This index does't have GetAllResults method
-// because it's not possible to get all vectors from the index
-// It depends on the Hnswlib implementation
-// TODO: Consider adding GetAllResults method in the future
 struct HnswVectorIndex : public BaseVectorIndex {
   HnswVectorIndex(const SchemaField::VectorParams& params, PMR_NS::memory_resource* mr);
   ~HnswVectorIndex();
@@ -200,6 +158,11 @@ struct HnswVectorIndex : public BaseVectorIndex {
   std::vector<std::pair<float, DocId>> Knn(float* target, size_t k, std::optional<size_t> ef) const;
   std::vector<std::pair<float, DocId>> Knn(float* target, size_t k, std::optional<size_t> ef,
                                            const std::vector<DocId>& allowed) const;
+
+  // TODO: Implement if needed
+  std::vector<DocId> GetAllDocsWithNonNullValues() const override {
+    return std::vector<DocId>{};
+  }
 
  protected:
   void AddVector(DocId id, const VectorPtr& vector) override;

--- a/src/core/search/sort_indices.cc
+++ b/src/core/search/sort_indices.cc
@@ -29,7 +29,8 @@ template <typename T> bool SimpleValueSortIndex<T>::ParsedSortValue::IsNullValue
 }
 
 template <typename T>
-SimpleValueSortIndex<T>::SimpleValueSortIndex(PMR_NS::memory_resource* mr) : values_{mr} {
+SimpleValueSortIndex<T>::SimpleValueSortIndex(PMR_NS::memory_resource* mr)
+    : values_{mr}, null_values_(mr) {
 }
 
 template <typename T> SortableValue SimpleValueSortIndex<T>::Lookup(DocId doc) const {
@@ -88,6 +89,28 @@ void SimpleValueSortIndex<T>::Remove(DocId id, const DocumentAccessor& doc,
 
   DCHECK_LT(id, values_.size());
   values_[id] = T{};
+}
+
+template <typename T>
+std::vector<DocId> SimpleValueSortIndex<T>::GetAllDocsWithNonNullValues() const {
+  DocsList unique_docs{values_.get_allocator().resource()};
+  std::vector<DocId> result;
+
+  unique_docs.reserve(values_.size());
+  result.reserve(values_.size());
+
+  auto empty_value = T{};
+  for (DocId id = 0; id < values_.size(); ++id) {
+    if (values_[id] != empty_value) {
+      auto [_, is_new] = unique_docs.insert(id);
+      if (is_new) {
+        result.push_back(id);
+      }
+    }
+  }
+
+  std::sort(result.begin(), result.end());
+  return result;
 }
 
 template <typename T> PMR_NS::memory_resource* SimpleValueSortIndex<T>::GetMemRes() const {

--- a/src/core/search/sort_indices.cc
+++ b/src/core/search/sort_indices.cc
@@ -93,23 +93,18 @@ void SimpleValueSortIndex<T>::Remove(DocId id, const DocumentAccessor& doc,
 
 template <typename T>
 std::vector<DocId> SimpleValueSortIndex<T>::GetAllDocsWithNonNullValues() const {
-  DocsList unique_docs{values_.get_allocator().resource()};
   std::vector<DocId> result;
-
-  unique_docs.reserve(values_.size());
   result.reserve(values_.size());
 
   auto empty_value = T{};
   for (DocId id = 0; id < values_.size(); ++id) {
     if (values_[id] != empty_value) {
-      auto [_, is_new] = unique_docs.insert(id);
-      if (is_new) {
-        result.push_back(id);
-      }
+      result.push_back(id);
     }
   }
 
-  std::sort(result.begin(), result.end());
+  // Result is already sorted by DocId
+  // Also it has no duplicates
   return result;
 }
 

--- a/src/core/search/sort_indices.h
+++ b/src/core/search/sort_indices.h
@@ -51,7 +51,7 @@ template <typename T> struct SimpleValueSortIndex : public BaseSortIndex {
 
  private:
   PMR_NS::vector<T> values_;
-  DocsList null_values_;
+  UniqueDocsList<PMR_NS::polymorphic_allocator<DocId>> null_values_;
 };
 
 struct NumericSortIndex : public SimpleValueSortIndex<double> {

--- a/src/core/search/sort_indices.h
+++ b/src/core/search/sort_indices.h
@@ -42,21 +42,7 @@ template <typename T> struct SimpleValueSortIndex : public BaseSortIndex {
   void Remove(DocId id, const DocumentAccessor& doc, std::string_view field) override;
 
   // Override GetAllResults to return all documents with non-null values
-  std::optional<std::vector<DocId>> GetAllResults() const override {
-    std::vector<DocId> result;
-
-    for (DocId id = 0; id < values_.size(); ++id) {
-      // Check if id is not present in null_values_
-      // Also need to handle deleted elements - in them T should be empty
-      // Different types of T have different "empty" values, but we can check
-      // if this value is the default for the given type
-      if (!null_values_.contains(id) && !(values_[id] == T{})) {
-        result.push_back(id);
-      }
-    }
-
-    return result;
-  }
+  std::vector<DocId> GetAllDocsWithNonNullValues() const override;
 
  protected:
   virtual ParsedSortValue Get(const DocumentAccessor& doc, std::string_view field_value) = 0;
@@ -65,7 +51,7 @@ template <typename T> struct SimpleValueSortIndex : public BaseSortIndex {
 
  private:
   PMR_NS::vector<T> values_;
-  absl::flat_hash_set<DocId> null_values_;
+  DocsList null_values_;
 };
 
 struct NumericSortIndex : public SimpleValueSortIndex<double> {


### PR DESCRIPTION
Fixes non-sortable results from GetAllResults methods and improves performance of these methods.

Changes in this PR:
1. Fix null_values in SortIndex. It didn't use polymorphic allocator before
2. Small performance improvement for `NumericIndex`: in the `GetAllResults` method we’re calling the `Range` method, which performs two `lower_bound` operations on the `entries_` tree. But this overhead is unnecessary — we just need to traverse the entire tree.
3. Small performance improvement for `SimpleValueSortIndex`: in the `GetAllResults` method we checked `!null_values.contains(id)`, but that doesn’t make sense — we don’t add null values to `values_`, and such entries also wouldn’t pass the check for an empty value

FIRST PR of perfomance improvements