### PR TITLE
fix: JSON.DEL to return 0 for non-existing keys instead of error

### DIFF
--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -1066,6 +1066,12 @@ OpResult<long> OpDel(const OpArgs& op_args, string_view key, string_view path,
   if (json_path.RefersToRootElement()) {
     auto& db_slice = op_args.GetDbSlice();
     auto res_it = db_slice.FindMutable(op_args.db_cntx, key, OBJ_JSON);
+
+    // For JSON.DEL, if key doesn't exist, return 0 instead of error
+    if (res_it.status() == OpStatus::KEY_NOTFOUND) {
+      return 0;
+    }
+
     RETURN_ON_BAD_STATUS(res_it);
 
     if (IsValid(res_it->it)) {

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -3155,4 +3155,18 @@ TEST_F(JsonFamilyTest, ResetStringKeyWithSetGet) {
   EXPECT_THAT(resp, R"({"a":"b"})");
 }
 
+TEST_F(JsonFamilyTest, DelNonExistingKey) {
+  auto resp = Run({"EXISTS", "nonexisting_key"});
+  EXPECT_THAT(resp, IntArg(0));
+
+  resp = Run({"JSON.DEL", "nonexisting_key", "."});
+  EXPECT_THAT(resp, IntArg(0));
+
+  resp = Run({"JSON.DEL", "nonexisting_key", "$"});
+  EXPECT_THAT(resp, IntArg(0));
+
+  resp = Run({"JSON.DEL", "nonexisting_key"});
+  EXPECT_THAT(resp, IntArg(0));
+}
+
 }  // namespace dfly


### PR DESCRIPTION
Fixes: https://github.com/dragonflydb/dragonfly/issues/5331

Fixes JSON.DEL command to return 0 for non-existing keys instead of throwing "ERR no such key" error.