### PR TITLE
chore: avoid deduplicating docs ids when not needed

### DIFF
--- a/src/core/search/indices.h
+++ b/src/core/search/indices.h
@@ -38,6 +38,7 @@ struct NumericIndex : public BaseIndex {
   std::vector<DocId> GetAllDocsWithNonNullValues() const override;
 
  private:
+  bool unique_ids_ = true;  // If true, docs ids are unique in the index, otherwise they can repeat.
   using Entry = std::pair<double, DocId>;
   absl::btree_set<Entry, std::less<Entry>, PMR_NS::polymorphic_allocator<Entry>> entries_;
 };
@@ -75,6 +76,7 @@ template <typename C> struct BaseStringIndex : public BaseIndex {
   Container* GetOrCreate(std::string_view word);
 
   bool case_sensitive_ = false;
+  bool unique_ids_ = true;  // If true, docs ids are unique in the index, otherwise they can repeat.
   search::RaxTreeMap<Container> entries_;
 };
 


### PR DESCRIPTION
When index consists of only singular values per document, we do not have to deduplicate doc ids during query time.

Benchmarks:

Before the PR:

```
Benchmark                  Time             CPU   Iterations
------------------------------------------------------------
BM_SearchDocIds/0       7238 ns         7238 ns       388043
BM_SearchDocIds/1      30202 ns        30200 ns        89480
BM_SearchDocIds/2      20986 ns        20984 ns       133450
```
After:

```
Benchmark                  Time             CPU   Iterations
------------------------------------------------------------
BM_SearchDocIds/0       7071 ns         7070 ns       406632
BM_SearchDocIds/1      13149 ns        13142 ns       218935
BM_SearchDocIds/2      11870 ns        11868 ns       236922
```

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->