### PR TITLE
fix: no set/hmap expiration during serialization

### DIFF
--- a/src/server/error.h
+++ b/src/server/error.h
@@ -83,6 +83,7 @@ enum errc {
   out_of_memory = 11,
   bad_json_string = 12,
   unsupported_operation = 13,
+  value_expired = 14,  // applying to set and hmap
 };
 
 }  // namespace rdb

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -525,6 +525,7 @@ void RdbLoaderBase::OpaqueObjLoader::CreateHMap(const LoadTrace* ltrace) {
     }
     if (string_map->Empty() && values_expired) {
       ec_ = RdbError(errc::value_expired);
+      return;
     } else {
       if (!config_.append) {
         pv_->InitRobj(OBJ_HASH, kEncodingStrMap2, string_map);

--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -310,7 +310,7 @@ class RdbLoader : protected RdbLoaderBase {
 
   void LoadItemsBuffer(DbIndex db_ind, const ItemsBuf& ib);
 
-  void CreateObjectOnShard(const DbContext& db_cntx, Item* item, DbSlice* db_slice);
+  void CreateObjectOnShard(const DbContext& db_cntx, const Item* item, DbSlice* db_slice);
 
   void LoadScriptFromAux(std::string&& value);
 

--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -278,6 +278,7 @@ class RdbLoader : protected RdbLoaderBase {
     std::atomic<Item*> next;
     bool is_sticky = false;
     bool has_mc_flags = false;
+    bool has_expired = false;
     uint32_t mc_flags = 0;
 
     LoadConfig load_config;
@@ -297,7 +298,7 @@ class RdbLoader : protected RdbLoaderBase {
 
   std::error_code LoadKeyValPair(int type, ObjSettings* settings);
   // Returns whether to discard the read key pair.
-  bool ShouldDiscardKey(std::string_view key, ObjSettings* settings) const;
+  bool ShouldDiscardKey(std::string_view key, const Item& item) const;
   void ResizeDb(size_t key_num, size_t expire_num);
   std::error_code HandleAux();
 
@@ -310,7 +311,7 @@ class RdbLoader : protected RdbLoaderBase {
 
   void LoadItemsBuffer(DbIndex db_ind, const ItemsBuf& ib);
 
-  void CreateObjectOnShard(const DbContext& db_cntx, const Item* item, DbSlice* db_slice);
+  void CreateObjectOnShard(const DbContext& db_cntx, Item* item, DbSlice* db_slice);
 
   void LoadScriptFromAux(std::string&& value);
 

--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -278,7 +278,6 @@ class RdbLoader : protected RdbLoaderBase {
     std::atomic<Item*> next;
     bool is_sticky = false;
     bool has_mc_flags = false;
-    bool has_expired = false;
     uint32_t mc_flags = 0;
 
     LoadConfig load_config;
@@ -298,7 +297,7 @@ class RdbLoader : protected RdbLoaderBase {
 
   std::error_code LoadKeyValPair(int type, ObjSettings* settings);
   // Returns whether to discard the read key pair.
-  bool ShouldDiscardKey(std::string_view key, const Item& item) const;
+  bool ShouldDiscardKey(std::string_view key, const ObjSettings& settings) const;
   void ResizeDb(size_t key_num, size_t expire_num);
   std::error_code HandleAux();
 

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -384,7 +384,11 @@ error_code RdbSerializer::SaveSetObject(const PrimeValue& obj) {
   if (obj.Encoding() == kEncodingStrMap2) {
     StringSet* set = (StringSet*)obj.RObjPtr();
 
-    RETURN_ON_ERR(SaveLen(set->SizeSlow()));
+    // We don't expire any data during serialization
+    set->set_time(0);
+
+    // due to we avoid expiring we can use UpperBoundSize() instead of SlowSize()
+    RETURN_ON_ERR(SaveLen(set->UpperBoundSize()));
     for (auto it = set->begin(); it != set->end();) {
       RETURN_ON_ERR(SaveString(string_view{*it, sdslen(*it)}));
       if (set->ExpirationUsed()) {
@@ -416,7 +420,11 @@ error_code RdbSerializer::SaveHSetObject(const PrimeValue& pv) {
   if (pv.Encoding() == kEncodingStrMap2) {
     StringMap* string_map = (StringMap*)pv.RObjPtr();
 
-    RETURN_ON_ERR(SaveLen(string_map->SizeSlow()));
+    // We don't expire any data during serialization
+    string_map->set_time(0);
+
+    // due to we avoid expiring we can use UpperBoundSize() instead of SlowSize()
+    RETURN_ON_ERR(SaveLen(string_map->UpperBoundSize()));
 
     for (auto it = string_map->begin(); it != string_map->end();) {
       const auto& [k, v] = *it;

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -403,6 +403,7 @@ error_code RdbSerializer::SaveSetObject(const PrimeValue& obj) {
         flush_state = FlushState::kFlushEndEntry;
       FlushIfNeeded(flush_state);
     }
+    set->set_time(MemberTimeSeconds(GetCurrentTimeMs()));
   } else {
     CHECK_EQ(obj.Encoding(), kEncodingIntSet);
     intset* is = (intset*)obj.RObjPtr();
@@ -442,6 +443,8 @@ error_code RdbSerializer::SaveHSetObject(const PrimeValue& pv) {
         flush_state = FlushState::kFlushEndEntry;
       FlushIfNeeded(flush_state);
     }
+
+    string_map->set_time(MemberTimeSeconds(GetCurrentTimeMs()));
   } else {
     CHECK_EQ(kEncodingListPack, pv.Encoding());
 

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -315,6 +315,46 @@ TEST_F(RdbTest, HashmapExpiry) {
               RespArray(UnorderedElementsAre("key1", "val1", "key2", "val2")));
 }
 
+TEST_F(RdbTest, SaveEmptyHmap) {
+  // Add expiring elements
+  Run({"hsetex", "hkey", "1", "key3", "val3", "key4", "val4"});
+
+  RespExpr resp = Run({"TYPE", "hkey"});
+  ASSERT_EQ(resp, "hash");
+
+  AdvanceTime(10'000);
+  resp = Run({"save", "RDB"});
+  ASSERT_EQ(resp, "OK");
+
+  resp = Run({"TYPE", "hkey"});
+  ASSERT_EQ(resp, "hash");
+
+  Run({"debug", "reload"});
+
+  resp = Run({"TYPE", "hkey"});
+  ASSERT_EQ(resp, "none");
+}
+
+TEST_F(RdbTest, SaveEmptySSet) {
+  // Add expiring elements
+  Run({"saddex", "skey", "1", "key3", "key4"});
+
+  RespExpr resp = Run({"TYPE", "skey"});
+  ASSERT_EQ(resp, "set");
+
+  AdvanceTime(10'000);
+  resp = Run({"save", "RDB"});
+  ASSERT_EQ(resp, "OK");
+
+  resp = Run({"TYPE", "skey"});
+  ASSERT_EQ(resp, "set");
+
+  Run({"debug", "reload"});
+
+  resp = Run({"TYPE", "skey"});
+  ASSERT_EQ(resp, "none");
+}
+
 TEST_F(RdbTest, SetExpiry) {
   // Add non-expiring elements
   Run({"sadd", "key", "key1", "key2"});

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -315,7 +315,7 @@ TEST_F(RdbTest, HashmapExpiry) {
               RespArray(UnorderedElementsAre("key1", "val1", "key2", "val2")));
 }
 
-TEST_F(RdbTest, SaveEmptyHmap) {
+TEST_F(RdbTest, SaveLoadExpiredValuesHmap) {
   // Add expiring elements
   Run({"hsetex", "hkey", "1", "key3", "val3", "key4", "val4"});
 
@@ -335,7 +335,37 @@ TEST_F(RdbTest, SaveEmptyHmap) {
   ASSERT_EQ(resp, "none");
 }
 
-TEST_F(RdbTest, SaveEmptySSet) {
+TEST_F(RdbTest, SaveLoadExpiredValuesHugeHmap) {
+  constexpr auto keys_num = 10000;
+  for (int i = 0; i < keys_num; ++i) {
+    Run({"hsetex", "hkey", "1", absl::StrCat("key", i), "val"});
+  }
+
+  ASSERT_EQ(keys_num, CheckedInt({"hlen", "hkey"}));
+
+  AdvanceTime(10'000);
+
+  Run({"debug", "reload"});
+
+  ASSERT_EQ(Run({"TYPE", "hkey"}), "none");
+
+  // with one value that isn't expired
+  for (int i = 0; i < keys_num; ++i) {
+    Run({"hsetex", "hkey", "1", absl::StrCat("key", i), "val"});
+  }
+
+  Run({"hset", "hkey", base::RandStr(20), "val"});
+
+  ASSERT_EQ(keys_num + 1, CheckedInt({"hlen", "hkey"}));
+
+  AdvanceTime(10'000);
+
+  Run({"debug", "reload"});
+
+  ASSERT_EQ(1, CheckedInt({"hlen", "hkey"}));
+}
+
+TEST_F(RdbTest, SaveLoadExpiredValuesSSet) {
   // Add expiring elements
   Run({"saddex", "skey", "1", "key3", "key4"});
 
@@ -353,6 +383,35 @@ TEST_F(RdbTest, SaveEmptySSet) {
 
   resp = Run({"TYPE", "skey"});
   ASSERT_EQ(resp, "none");
+}
+
+TEST_F(RdbTest, SaveLoadExpiredValuesHugeSet) {
+  constexpr auto keys_num = 10000;
+  for (int i = 0; i < keys_num; ++i) {
+    Run({"saddex", "skey", "1", absl::StrCat("key", i)});
+  }
+
+  ASSERT_EQ(keys_num, CheckedInt({"scard", "skey"}));
+
+  AdvanceTime(10'000);
+
+  Run({"debug", "reload"});
+
+  ASSERT_EQ(Run({"TYPE", "skey"}), "none");
+
+  // with one value that isn't expired
+  for (int i = 0; i < keys_num; ++i) {
+    Run({"saddex", "skey", "1", absl::StrCat("key", i)});
+  }
+  Run({"sadd", "skey", base::RandStr(20)});
+
+  ASSERT_EQ(keys_num + 1, CheckedInt({"scard", "skey"}));
+
+  AdvanceTime(10'000);
+
+  Run({"debug", "reload"});
+
+  ASSERT_EQ(1, CheckedInt({"scard", "skey"}));
 }
 
 TEST_F(RdbTest, SetExpiry) {


### PR DESCRIPTION
fixes: https://github.com/dragonflydb/dragonfly/issues/5299

problem: we do expiration during serialization and save 0-size hmap or set that is incorrect
fix: avoid expiration during serialization and filter out expired hmap and set during loading