### PR TITLE
fix(pytest): Increase allowed diff in test_partial_replication_on_same_source_master

### DIFF
--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -3041,7 +3041,7 @@ async def test_replica_snapshot_with_big_values_while_seeding(df_factory: DflyIn
 
 @pytest.mark.parametrize(
     "use_takeover, allowed_diff",
-    [(False, 2), (False, 0), (True, 0)],
+    [(False, 2), (False, 0), (True, 1)],
 )
 async def test_partial_replication_on_same_source_master(df_factory, use_takeover, allowed_diff):
     master = df_factory.create()


### PR DESCRIPTION
Increase allowed diff to be `1` instead of `0`. Reason for this is that extra PING is going to be sent during TAKEOVER so replica_1 and replica_2 are not going to be in sync. And no partial sync is done on second TAKEOVER.

Fixes #5359

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->