### PR TITLE
chore: add mimalloc2 third_party library

### DIFF
--- a/patches/mimalloc-v2.2.4.patch
+++ b/patches/mimalloc-v2.2.4.patch
@@ -1,0 +1,79 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5ce084f6..00eba70c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.18)
++cmake_minimum_required(VERSION 3.16)
+ project(libmimalloc C CXX)
+ 
+ set(CMAKE_C_STANDARD 11)
+@@ -44,7 +44,38 @@ option(MI_WIN_USE_FLS       "Use Fiber local storage on Windows to detect thread
+ option(MI_CHECK_FULL        "Use full internal invariant checking in DEBUG mode (deprecated, use MI_DEBUG_FULL instead)" OFF)
+ option(MI_USE_LIBATOMIC     "Explicitly link with -latomic (on older systems) (deprecated and detected automatically)" OFF)
+ 
+-include(CheckLinkerFlag)    # requires cmake 3.18
++function(CHECK_LINKER_FLAG _lang _flag _var)
++  get_property (_supported_languages GLOBAL PROPERTY ENABLED_LANGUAGES)
++  if (NOT _lang IN_LIST _supported_languages)
++    message (SEND_ERROR "check_linker_flag: ${_lang}: unknown language.")
++    return()
++  endif()
++  include (Check${_lang}SourceCompiles)
++  set(CMAKE_REQUIRED_LINK_OPTIONS "${_flag}")
++  # Normalize locale during test compilation.
++  set(_locale_vars LC_ALL LC_MESSAGES LANG)
++  foreach(v IN LISTS _locale_vars)
++    set(_locale_vars_saved_${v} "$ENV{${v}}")
++    set(ENV{${v}} C)
++  endforeach()
++  if (_lang MATCHES "^(C|CXX)$")
++    set (_source "int main() { return 0; }")
++  elseif (_lang STREQUAL "Fortran")
++    set (_source "       program test\n       stop\n       end program")
++  elseif (_lang MATCHES "^(OBJC|OBJCXX)$")
++    set (_source "#ifndef __OBJC__\n#  error \"Not an Objective-C++ compiler\"\n#endif\nint main(void) { return 0; }")
++  else()
++    message (SEND_ERROR "check_linker_flag: ${_lang}: unsupported language.")
++    return()
++  endif()
++  set(_common_patterns "")
++  check_c_source_compiles("${_source}" ${_var} ${_common_patterns})
++  foreach(v IN LISTS _locale_vars)
++    set(ENV{${v}} ${_locale_vars_saved_${v}})
++  endforeach()
++  set(${_var} "${${_var}}" PARENT_SCOPE)
++endfunction()
++
+ include(CheckIncludeFiles)
+ include(GNUInstallDirs)
+ include("cmake/mimalloc-config-version.cmake")
+diff --git a/src/alloc.c b/src/alloc.c
+index 0fed5e75..870f8d10 100644
+--- a/src/alloc.c
++++ b/src/alloc.c
+@@ -670,6 +670,24 @@ mi_decl_restrict void* _mi_heap_malloc_guarded(mi_heap_t* heap, size_t size, boo
+ }
+ #endif
+ 
++bool mi_heap_page_is_underutilized(mi_heap_t* heap, void* p, float ratio) mi_attr_noexcept {
++  mi_page_t* page = _mi_ptr_page(p);   // get the page that this belongs to
++
++  mi_heap_t* page_heap = (mi_heap_t*)(mi_atomic_load_acquire(&(page)->xheap));
++
++  // the heap id matches and it is not a full page
++  if (mi_likely(page_heap == heap && page->flags.x.in_full == 0)) {
++    // first in the list, meaning it's the head of page queue, thus being used for malloc
++    if (page->prev == NULL)
++      return false;
++
++    // this page belong to this heap and is not first in the page queue. Lets check its
++    // utilization.
++    return page->used <= (unsigned)(page->capacity * ratio);
++  }
++  return false;
++}
++
+ // ------------------------------------------------------
+ // ensure explicit external inline definitions are emitted!
+ // ------------------------------------------------------

--- a/src/external_libs.cmake
+++ b/src/external_libs.cmake
@@ -60,6 +60,25 @@ add_third_party(
   INSTALL_COMMAND ${DFLY_TOOLS_MAKE} install BUILD_SHARED=no PREFIX=${THIRD_PARTY_LIB_DIR}/lz4
 )
 
+set(MIMALLOC_INCLUDE_DIR ${THIRD_PARTY_LIB_DIR}/mimalloc2/include)
+
+set (MIMALLOC_PATCH_COMMAND patch -p1 -d ${THIRD_PARTY_DIR}/mimalloc2/ -i ${CMAKE_CURRENT_LIST_DIR}/../patches/mimalloc-v2.2.4.patch)
+
+add_third_party(mimalloc2
+   # GIT_REPOSITORY https://github.com/microsoft/mimalloc/
+   # GIT_TAG v2.2.4
+   URL https://github.com/microsoft/mimalloc/archive/refs/tags/v2.2.4.tar.gz
+   PATCH_COMMAND "${MIMALLOC_PATCH_COMMAND}"
+   # Add -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS=-O0 to debug
+   CMAKE_PASS_FLAGS "-DCMAKE_BUILD_TYPE=Release -DMI_BUILD_SHARED=OFF -DMI_BUILD_TESTS=OFF \
+                    -DMI_INSTALL_TOPLEVEL=ON -DMI_OVERRIDE=OFF -DMI_NO_PADDING=ON \ -DCMAKE_C_FLAGS=-g"
+
+  BUILD_COMMAND make -j4 mimalloc-static
+  INSTALL_COMMAND make install
+  COMMAND cp -r <SOURCE_DIR>/include/mimalloc ${MIMALLOC_INCLUDE_DIR}/
+  LIB ${HELIO_MIMALLOC_LIBNAME}
+)
+
 add_third_party(
   croncpp
   URL https://github.com/mariusbancila/croncpp/archive/refs/tags/v2023.03.30.tar.gz

--- a/src/external_libs.cmake
+++ b/src/external_libs.cmake
@@ -73,7 +73,7 @@ add_third_party(mimalloc2
    CMAKE_PASS_FLAGS "-DCMAKE_BUILD_TYPE=Release -DMI_BUILD_SHARED=OFF -DMI_BUILD_TESTS=OFF \
                     -DMI_INSTALL_TOPLEVEL=ON -DMI_OVERRIDE=OFF -DMI_NO_PADDING=ON \ -DCMAKE_C_FLAGS=-g"
 
-  BUILD_COMMAND make -j4 mimalloc-static
+  BUILD_COMMAND make mimalloc-static
   INSTALL_COMMAND make install
   COMMAND cp -r <SOURCE_DIR>/include/mimalloc ${MIMALLOC_INCLUDE_DIR}/
   LIB ${HELIO_MIMALLOC_LIBNAME}


### PR DESCRIPTION
This only adds it to the buld files.

We currently use helio dependency. This PR adds mimalloc of a newer version directly to dragonfly as mimalloc2. The goal is to switch to mimalloc2 in the future.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->