### PR TITLE
chore: remove unneeded mimalloc-specific code

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -8,7 +8,6 @@
 #include <absl/strings/match.h>
 #include <absl/strings/str_cat.h>
 #include <absl/time/time.h>
-#include <mimalloc.h>
 
 #include <numeric>
 #include <variant>
@@ -26,7 +25,6 @@
 #include "facade/redis_parser.h"
 #include "facade/service_interface.h"
 #include "facade/socket_utils.h"
-#include "glog/logging.h"
 #include "io/file.h"
 #include "util/fibers/fibers.h"
 #include "util/fibers/proactor_base.h"
@@ -403,16 +401,6 @@ Connection::MCPipelineMessage::MCPipelineMessage(MemcacheParser::Command cmd_in,
     key = {backing.get() + offset, key.size()};
     offset += key.size();
   }
-}
-
-void Connection::MessageDeleter::operator()(PipelineMessage* msg) const {
-  msg->~PipelineMessage();
-  mi_free(msg);
-}
-
-void Connection::MessageDeleter::operator()(PubMessage* msg) const {
-  msg->~PubMessage();
-  mi_free(msg);
 }
 
 void Connection::PipelineMessage::Reset(size_t nargs, size_t capacity) {
@@ -1184,8 +1172,8 @@ Connection::ParserStatus Connection::ParseRedis(unsigned max_busy_cycles) {
     service_->DispatchCommand(absl::MakeSpan(tmp_cmd_vec_), reply_builder_.get(), cc_.get());
   };
 
-  auto dispatch_async = [this, tlh = mi_heap_get_backing()]() -> MessageHandle {
-    return {FromArgs(std::move(tmp_parse_args_), tlh)};
+  auto dispatch_async = [this]() -> MessageHandle {
+    return {FromArgs(std::move(tmp_parse_args_))};
   };
 
   ReadBuffer read_buffer = GetReadBuffer();
@@ -1692,7 +1680,7 @@ void Connection::AsyncFiber() {
   qbp.pipeline_cnd.notify_all();
 }
 
-Connection::PipelineMessagePtr Connection::FromArgs(RespVec args, mi_heap_t* heap) {
+Connection::PipelineMessagePtr Connection::FromArgs(const RespVec& args) {
   DCHECK(!args.empty());
   size_t backed_sz = 0;
   for (const auto& arg : args) {
@@ -1701,17 +1689,14 @@ Connection::PipelineMessagePtr Connection::FromArgs(RespVec args, mi_heap_t* hea
   }
   DCHECK(backed_sz);
 
-  constexpr auto kReqSz = sizeof(PipelineMessage);
-  static_assert(kReqSz < MI_SMALL_SIZE_MAX);
   static_assert(alignof(PipelineMessage) == 8);
 
   PipelineMessagePtr ptr;
   if (ptr = GetFromPipelinePool(); ptr) {
     ptr->Reset(args.size(), backed_sz);
   } else {
-    void* heap_ptr = mi_heap_malloc_small(heap, sizeof(PipelineMessage));
     // We must construct in place here, since there is a slice that uses memory locations
-    ptr.reset(new (heap_ptr) PipelineMessage(args.size(), backed_sz));
+    ptr = make_unique<PipelineMessage>(args.size(), backed_sz);
   }
 
   ptr->SetArgs(args);
@@ -1783,8 +1768,7 @@ bool Connection::IsCurrentlyDispatching() const {
 }
 
 void Connection::SendPubMessageAsync(PubMessage msg) {
-  void* ptr = mi_malloc(sizeof(PubMessage));
-  SendAsync({PubMessagePtr{new (ptr) PubMessage{std::move(msg)}, MessageDeleter{}}});
+  SendAsync({make_unique<PubMessage>(std::move(msg))});
 }
 
 void Connection::SendMonitorMessageAsync(string msg) {

--- a/src/facade/dragonfly_listener.cc
+++ b/src/facade/dragonfly_listener.cc
@@ -4,6 +4,7 @@
 
 #include "facade/dragonfly_listener.h"
 
+#include <mimalloc.h>
 #include <openssl/err.h>
 
 #include <memory>


### PR DESCRIPTION
We override globally c++ new/delete in dfly_main.
Therefore it is not needed anymore to use custom mimalloc specific allocators.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->