### PR TITLE
chore: switch to mimalloc2

### DIFF
--- a/src/facade/CMakeLists.txt
+++ b/src/facade/CMakeLists.txt
@@ -11,7 +11,7 @@ if (DF_USE_SSL)
 endif()
 
 cxx_link(dfly_facade dfly_parser_lib http_server_lib fibers2
-         ${TLS_LIB} TRDP::mimalloc TRDP::dconv)
+         ${TLS_LIB} TRDP::mimalloc2 TRDP::dconv)
 
 add_library(facade_test facade_test.cc)
 cxx_link(facade_test dfly_facade gtest_main_ext)

--- a/src/redis/CMakeLists.txt
+++ b/src/redis/CMakeLists.txt
@@ -2,7 +2,7 @@ option(REDIS_ZMALLOC_MI "Implement zmalloc layer using mimalloc allocator" ON)
 
 if (REDIS_ZMALLOC_MI)
   set(ZMALLOC_SRC "zmalloc_mi.c")
-  set(ZMALLOC_DEPS "TRDP::mimalloc")
+  set(ZMALLOC_DEPS "TRDP::mimalloc2")
 else()
   set(ZMALLOC_SRC "zmalloc.c")
   set(ZMALLOC_DEPS "")

--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -119,7 +119,7 @@ unsigned kernel_version = 0;
 size_t max_memory_limit = 0;
 Namespaces* namespaces = nullptr;
 
-size_t FetchRssMemory(io::StatusData sdata) {
+size_t FetchRssMemory(const io::StatusData& sdata) {
   return sdata.vm_rss + sdata.hugetlb_pages;
 }
 

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -136,7 +136,7 @@ extern std::atomic_uint64_t rss_mem_peak;
 
 extern size_t max_memory_limit;
 
-size_t FetchRssMemory(io::StatusData sdata);
+size_t FetchRssMemory(const io::StatusData& sdata);
 
 extern Namespaces* namespaces;
 

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -770,8 +770,6 @@ Usage: dragonfly [FLAGS]
     LOG(INFO) << "listening on unix socket " << usock << ".";
   }
 
-  mi_stats_reset();
-
   if (GetFlag(FLAGS_dbnum) > dfly::kMaxDbId) {
     LOG(ERROR) << "dbnum is too big. Exiting...";
     return 1;
@@ -821,9 +819,13 @@ Usage: dragonfly [FLAGS]
 
   // Initialize mi_malloc options
   // export MIMALLOC_VERBOSE=1 to see the options before the override.
-  mi_option_enable(mi_option_show_errors);
-  mi_option_set(mi_option_max_warnings, 0);
-  mi_option_enable(mi_option_purge_decommits);
+  // _default functions override the default options vaues but if the options were set
+  // via the environment variables, they will not be overridden.
+  mi_option_set_enabled_default(mi_option_show_errors, true);
+  mi_option_set_default(mi_option_purge_delay, 0);
+
+  // To see the options after the override, use:
+  // mi_options_print();
 
   fb2::SetDefaultStackResource(&fb2::std_malloc_resource, kFiberDefaultStackSize);
 

--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -328,7 +328,7 @@ void MemoryCmd::ArenaStats(CmdArgList args) {
   }
 
   if (show_arenas) {
-    mi_debug_show_arenas(true, true, true);
+    mi_debug_show_arenas();
     return builder_->SendOk();
   }
 

--- a/tests/dragonfly/memory_test.py
+++ b/tests/dragonfly/memory_test.py
@@ -54,8 +54,8 @@ async def test_rss_used_mem_gap(df_factory, type, keys, val_size, elements):
         assert info["used_memory"] > min_rss, "Weak testcase: too little used memory"
         delta = info["used_memory_rss"] - info["used_memory"]
         # It could be the case that the machine is configured to use swap if this assertion fails
-        assert delta > 0
-        assert delta < max_unaccounted
+        assert delta > 0, info
+        assert delta < max_unaccounted, info
 
         if type != "STRING" and type != "JSON":
             # STRINGs keep some of the data inline, so not all of it is accounted in object_used_memory

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2102,12 +2102,14 @@ async def test_policy_based_eviction_propagation(df_factory, df_seeder_factory):
     await wait_available_async(c_replica)
 
     seeder = df_seeder_factory.create(
-        port=master.port, keys=500, val_size=1000, stop_on_failure=False
+        port=master.port, keys=600, val_size=1000, stop_on_failure=False
     )
     await seeder.run(target_deviation=0.1)
 
     info = await c_master.info("stats")
-    assert info["evicted_keys"] > 0, "Weak testcase: policy based eviction was not triggered."
+    assert (
+        info["evicted_keys"] > 0
+    ), f"Weak testcase: policy based eviction was not triggered. {await c_master.info()}"
 
     await check_all_replicas_finished([c_replica], c_master)
     keys_master = await c_master.execute_command("keys k*")


### PR DESCRIPTION
1. Use mimalloc 2.2.4 in Dragonfly project and stop relying on mimalloc in helio.
2. Fix a minor inefficiency in CanGrow, where we unnecessary called CanGrow twice.

Experimental runs on long-running production workloads show improvements with using mimalloc 2.2.4. Now it releases RSS more aggresively. The snapshot below demonstrates the improvement.

Before July 1, the datastore was running v1.29 and it is possible to see the huge difference between Used and RSS metrics. Since July 1, the datastore was running a version with mimalloc2 and it is possible to see how RSS memory follows `Used`. The peak on July 2, 18:00 is especially interesting as it shows a sudden spike in `Used` that caused RSS to grow significantly and then going back once `Used` went down. Before the switch the datastore did not decrease RSS after such peaks.  

 
![Screenshot from 2025-07-04 17-10-12](https://github.com/user-attachments/assets/11a5d65d-3134-4fe0-a2f6-dfb19d214225)


<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->