### PR TITLE
feat: add support for `BLMPOP` command

### DIFF
--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -1008,6 +1008,47 @@ void ListFamily::LMPop(CmdArgList args, const CommandContext& cmd_cntx) {
   }
 }
 
+void ListFamily::BLMPop(CmdArgList args, const CommandContext& cmd_cntx) {
+  auto* response_builder = static_cast<RedisReplyBuilder*>(cmd_cntx.rb);
+
+  CmdArgParser parser{args};
+  float timeout = parser.Next<float>();
+  if (auto err = parser.Error(); err)
+    return response_builder->SendError(err->MakeReply());
+
+  if (timeout < 0)
+    return response_builder->SendError("timeout is negative");
+
+  parser.Skip(parser.Next<size_t>());  // Skip numkeys and keys
+  ListDir dir = parser.MapNext("LEFT", ListDir::LEFT, "RIGHT", ListDir::RIGHT);
+
+  size_t pop_count = 1;
+  if (parser.Check("COUNT"))
+    pop_count = parser.Next<size_t>();
+
+  if (!parser.Finalize())
+    return response_builder->SendError(parser.Error()->MakeReply());
+
+  OpResult<StringVec> result;
+  auto cb = [&](Transaction* t, EngineShard* shard, string_view key) {
+    result = OpPop(t->GetOpArgs(shard), key, dir, pop_count, true, false);
+    return result.status();
+  };
+
+  ConnectionContext* conn_cntx = cmd_cntx.conn_cntx;
+  OpResult<string> popped_key = container_utils::RunCbOnFirstNonEmptyBlocking(
+      cmd_cntx.tx, OBJ_LIST, std::move(cb), unsigned(timeout * 1000), &conn_cntx->blocked,
+      &conn_cntx->paused);
+
+  if (popped_key.ok()) {
+    response_builder->StartArray(2);
+    response_builder->SendBulkString(*popped_key);
+    response_builder->SendBulkStrArr(*result);
+  } else {
+    response_builder->SendNull();
+  }
+}
+
 void ListFamily::LPush(CmdArgList args, const CommandContext& cmd_cntx) {
   return PushGeneric(ListDir::LEFT, false, args, cmd_cntx.tx, cmd_cntx.rb);
 }
@@ -1271,6 +1312,7 @@ constexpr uint32_t kLPush = WRITE | LIST | FAST;
 constexpr uint32_t kLPushX = WRITE | LIST | FAST;
 constexpr uint32_t kLPop = WRITE | LIST | FAST;
 constexpr uint32_t kLMPop = WRITE | LIST | FAST;
+constexpr uint32_t kBLMPop = WRITE | LIST | SLOW | BLOCKING;
 constexpr uint32_t kRPush = WRITE | LIST | FAST;
 constexpr uint32_t kRPushX = WRITE | LIST | FAST;
 constexpr uint32_t kRPop = WRITE | LIST | FAST;
@@ -1297,6 +1339,8 @@ void ListFamily::Register(CommandRegistry* registry) {
       << CI{"LPUSHX", CO::WRITE | CO::FAST | CO::DENYOOM, -3, 1, 1, acl::kLPushX}.HFUNC(LPushX)
       << CI{"LPOP", CO::WRITE | CO::FAST, -2, 1, 1, acl::kLPop}.HFUNC(LPop)
       << CI{"LMPOP", CO::WRITE | CO::SLOW | CO::VARIADIC_KEYS, -4, 2, 2, acl::kLMPop}.HFUNC(LMPop)
+      << CI{"BLMPOP", CO::WRITE | CO::SLOW | CO::VARIADIC_KEYS, -5, 3, 3, acl::kBLMPop}.HFUNC(
+             BLMPop)
       << CI{"RPUSH", CO::WRITE | CO::FAST | CO::DENYOOM, -3, 1, 1, acl::kRPush}.HFUNC(RPush)
       << CI{"RPUSHX", CO::WRITE | CO::FAST | CO::DENYOOM, -3, 1, 1, acl::kRPushX}.HFUNC(RPushX)
       << CI{"RPOP", CO::WRITE | CO::FAST, -2, 1, 1, acl::kRPop}.HFUNC(RPop)

--- a/src/server/list_family.h
+++ b/src/server/list_family.h
@@ -34,6 +34,7 @@ class ListFamily {
   static void BLPop(CmdArgList args, const CommandContext& cmd_cntx);
   static void BRPop(CmdArgList args, const CommandContext& cmd_cntx);
   static void LMPop(CmdArgList args, const CommandContext& cmd_cntx);
+  static void BLMPop(CmdArgList args, const CommandContext& cmd_cntx);
   static void LLen(CmdArgList args, const CommandContext& cmd_cntx);
   static void LPos(CmdArgList args, const CommandContext& cmd_cntx);
   static void LIndex(CmdArgList args, const CommandContext& cmd_cntx);

--- a/src/server/list_family_test.cc
+++ b/src/server/list_family_test.cc
@@ -5,14 +5,12 @@
 #include "server/list_family.h"
 
 #include <absl/strings/match.h>
-#include <gtest/gtest.h>
 
 #include <random>
 
 #include "base/gtest.h"
 #include "base/logging.h"
 #include "facade/facade_test.h"
-#include "gmock/gmock.h"
 #include "server/blocking_controller.h"
 #include "server/command_registry.h"
 #include "server/conn_context.h"
@@ -92,15 +90,15 @@ TEST_F(ListFamilyTest, BLMPopNonblocking) {
   EXPECT_THAT(resp, IntArg(4));
 
   resp = Run({"blmpop", "0.01", "2", kKey2, kKey1, "LEFT"});
-  EXPECT_THAT(resp, RespArray(ElementsAre(kKey1, RespArray(ElementsAre("4")))));
+  EXPECT_THAT(resp, RespElementsAre(kKey1, RespElementsAre("4")));
 
   resp = Run({"blmpop", "0.01", "2", kKey2, kKey1, "RIGHT", "COUNT", "2"});
-  EXPECT_THAT(resp, RespArray(ElementsAre(kKey1, RespArray(ElementsAre("1", "2")))));
+  EXPECT_THAT(resp, RespElementsAre(kKey1, RespElementsAre("1", "2")));
 
   // If the count exceeds the size of the key's values (but the key is non-empty) then return all of
   // the key's values
   resp = Run({"blmpop", "0.01", "1", kKey1, "RIGHT", "COUNT", "10"});
-  EXPECT_THAT(resp, RespArray(ElementsAre(kKey1, RespArray(ElementsAre("3")))));
+  EXPECT_THAT(resp, RespElementsAre(kKey1, RespElementsAre("3")));
 }
 
 TEST_F(ListFamilyTest, BLMPopInvalidSyntax) {
@@ -186,7 +184,7 @@ TEST_F(ListFamilyTest, BLMPopBlocking) {
   // key should be unlocked after being inserted to
   fb2.Join();
   ASSERT_FALSE(IsLocked(0, kKey1));
-  EXPECT_THAT(resp, RespArray(ElementsAre(kKey1, RespArray(ElementsAre("1")))));
+  EXPECT_THAT(resp, RespElementsAre(kKey1, RespElementsAre("1")));
 }
 
 TEST_F(ListFamilyTest, BLPopUnblocking) {

--- a/src/server/list_family_test.cc
+++ b/src/server/list_family_test.cc
@@ -5,12 +5,14 @@
 #include "server/list_family.h"
 
 #include <absl/strings/match.h>
+#include <gtest/gtest.h>
 
 #include <random>
 
 #include "base/gtest.h"
 #include "base/logging.h"
 #include "facade/facade_test.h"
+#include "gmock/gmock.h"
 #include "server/blocking_controller.h"
 #include "server/command_registry.h"
 #include "server/conn_context.h"
@@ -83,6 +85,108 @@ TEST_F(ListFamilyTest, Expire) {
 
   resp = Run({"lpush", kKey1, "1"});
   EXPECT_THAT(resp, IntArg(1));
+}
+
+TEST_F(ListFamilyTest, BLMPopNonblocking) {
+  auto resp = Run({"lpush", kKey1, "1", "2", "3", "4"});
+  EXPECT_THAT(resp, IntArg(4));
+
+  resp = Run({"blmpop", "0.01", "2", kKey2, kKey1, "LEFT"});
+  EXPECT_THAT(resp, RespArray(ElementsAre(kKey1, RespArray(ElementsAre("4")))));
+
+  resp = Run({"blmpop", "0.01", "2", kKey2, kKey1, "RIGHT", "COUNT", "2"});
+  EXPECT_THAT(resp, RespArray(ElementsAre(kKey1, RespArray(ElementsAre("1", "2")))));
+
+  // If the count exceeds the size of the key's values (but the key is non-empty) then return all of
+  // the key's values
+  resp = Run({"blmpop", "0.01", "1", kKey1, "RIGHT", "COUNT", "10"});
+  EXPECT_THAT(resp, RespArray(ElementsAre(kKey1, RespArray(ElementsAre("3")))));
+}
+
+TEST_F(ListFamilyTest, BLMPopInvalidSyntax) {
+  // Not enough arguments
+  auto resp = Run({"blmpop", "0.1", "1", kKey1});
+  EXPECT_THAT(resp, ErrArg("wrong number of arguments"));
+
+  // Timeout is not a float
+  resp = Run({"blmpop", "foo", "1", kKey1, "LEFT", "COUNT", "1"});
+  EXPECT_THAT(resp, ErrArg("value is not a valid float"));
+
+  // Negative timeout
+  resp = Run({"blmpop", "-0.01", "1", kKey1, "LEFT", "COUNT", "1"});
+  EXPECT_THAT(resp, ErrArg("timeout is negative"));
+
+  // Zero keys
+  resp = Run({"blmpop", "0.01", "0", "LEFT", "COUNT", "1"});
+  EXPECT_THAT(resp, ErrArg("at least 1 input key is needed"));
+
+  // Number of keys is not uint
+  resp = Run({"blmpop", "0.01", "aa", kKey1, "LEFT"});
+  EXPECT_THAT(resp, ErrArg("value is not an integer or out of range"));
+
+  // Missing LEFT/RIGHT
+  resp = Run({"blmpop", "0.01", "1", kKey1, "COUNT", "1"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
+
+  // Wrong number of keys
+  resp = Run({"blmpop", "0.01", "1", kKey1, kKey2, "LEFT"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
+
+  // COUNT without number
+  resp = Run({"blmpop", "0.01", "1", kKey1, "LEFT", "COUNT"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
+
+  // COUNT is not uint
+  resp = Run({"blmpop", "0.01", "1", kKey1, "LEFT", "COUNT", "boo"});
+  EXPECT_THAT(resp, ErrArg("value is not an integer or out of range"));
+
+  // Too many arguments
+  resp = Run({"blmpop", "0.01", "1", "c", "LEFT", "COUNT", "2", "foo"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
+}
+
+TEST_F(ListFamilyTest, BLMPopBlocking) {
+  // attempting to pop from empty key results in blocking and returns
+  // null if no values are pushed to the key.
+  RespExpr resp;
+  auto fb0 = pp_->at(0)->LaunchFiber(Launch::dispatch, [&] {
+    resp = Run({"blmpop", "0.1", "1", kKey1, "LEFT"});
+  });
+  ThisFiber::SleepFor(50us);
+  ASSERT_TRUE(IsLocked(0, kKey1));
+
+  fb0.Join();
+  ASSERT_FALSE(IsLocked(0, kKey1));
+  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
+
+  // BLMPOP should not block if there is a non-empty key available
+  resp = Run({"lpush", kKey1, "0"});
+  EXPECT_THAT(resp, IntArg(1));
+
+  auto fb1 = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] {
+    resp = Run({"blmpop", "0.1", "1", kKey1, "LEFT"});
+  });
+  ThisFiber::SleepFor(50us);
+  // shouldn't need to lock the key just pop immediately
+  ASSERT_FALSE(IsLocked(0, kKey1));
+  fb1.Join();
+
+  // should block until a key is available and then immediately unblock
+  auto fb2 = pp_->at(2)->LaunchFiber(Launch::dispatch, [&] {
+    resp = Run({"blmpop", "0.1", "1", kKey1, "LEFT"});
+  });
+  ThisFiber::SleepFor(50us);
+
+  // key should be locked while waiting
+  ASSERT_TRUE(IsLocked(0, kKey1));
+
+  auto push_resp = Run({"lpush", kKey1, "1"});
+  EXPECT_THAT(push_resp, IntArg(1));
+
+  // key should be unlocked after being inserted to
+  fb2.Join();
+  ASSERT_FALSE(IsLocked(0, kKey1));
+  EXPECT_THAT(resp, RespArray(ElementsAre(kKey1, RespArray(ElementsAre("1")))));
 }
 
 TEST_F(ListFamilyTest, BLPopUnblocking) {

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1590,6 +1590,8 @@ OpResult<KeyIndex> DetermineKeys(const CommandId* cid, CmdArgList args) {
     unsigned num_keys_index;
     if (absl::StartsWith(name, "EVAL"))
       num_keys_index = 1;
+    else if (name == "BLMPOP")
+      num_keys_index = 1;
     else
       num_keys_index = bonus ? *bonus + 1 : 0;
 

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1588,9 +1588,7 @@ OpResult<KeyIndex> DetermineKeys(const CommandId* cid, CmdArgList args) {
       bonus = 0;  // Z<xxx>STORE <key> commands
 
     unsigned num_keys_index;
-    if (absl::StartsWith(name, "EVAL"))
-      num_keys_index = 1;
-    else if (name == "BLMPOP")
+    if (absl::StartsWith(name, "EVAL") || name == "BLMPOP")
       num_keys_index = 1;
     else
       num_keys_index = bonus ? *bonus + 1 : 0;


### PR DESCRIPTION
Adding support for the BLMPOP redis command. The command description can be found [here](https://redis.io/docs/latest/commands/blmpop/).

Resolves #3876 