### PR TITLE
server_family: Expose command latency stats as part of info

### DIFF
--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -189,6 +189,9 @@ uint64_t CommandId::Invoke(CmdArgList args, const CommandContext& cmd_cntx) cons
   ++ent.first;
   ent.second += execution_time_usec;
 
+  if (hdr_histogram* cmd_histogram = latency_histogram_; cmd_histogram != nullptr) {
+    hdr_record_value(cmd_histogram, execution_time_usec);
+  }
   return execution_time_usec;
 }
 
@@ -210,6 +213,10 @@ optional<facade::ErrorReply> CommandId::Validate(CmdArgList tail_args) const {
   if (validator_)
     return validator_(tail_args);
   return nullopt;
+}
+
+hdr_histogram* CommandId::LatencyHist() const {
+  return latency_histogram_;
 }
 
 CommandRegistry::CommandRegistry() {
@@ -319,6 +326,15 @@ std::pair<const CommandId*, ArgSlice> CommandRegistry::FindExtended(string_view 
     }
   }
   return {res, tail_args};
+}
+
+absl::flat_hash_map<std::string, hdr_histogram*> CommandRegistry::LatencyMap() const {
+  absl::flat_hash_map<std::string, hdr_histogram*> cmd_latencies;
+  cmd_latencies.reserve(cmd_map_.size());
+  for (const auto& [cmd_name, cmd] : cmd_map_) {
+    cmd_latencies.insert({absl::AsciiStrToLower(cmd_name), cmd.LatencyHist()});
+  }
+  return cmd_latencies;
 }
 
 namespace CO {

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -32,6 +32,8 @@ ABSL_FLAG(vector<string>, command_alias, {},
           "Add an alias for given command(s), format is: <alias>=<original>, <alias>=<original>. "
           "Aliases must be set identically on replicas, if applicable");
 
+ABSL_FLAG(bool, latency_tracking, false, "If true, track latency for commands");
+
 namespace dfly {
 
 using namespace facade;
@@ -188,9 +190,11 @@ uint64_t CommandId::Invoke(CmdArgList args, const CommandContext& cmd_cntx) cons
 
   ++ent.first;
   ent.second += execution_time_usec;
-
-  if (hdr_histogram* cmd_histogram = latency_histogram_; cmd_histogram != nullptr) {
-    hdr_record_value(cmd_histogram, execution_time_usec);
+  static const bool is_latency_tracked = GetFlag(FLAGS_latency_tracking);
+  if (is_latency_tracked) {
+    if (hdr_histogram* cmd_histogram = latency_histogram_; cmd_histogram != nullptr) {
+      hdr_record_value(cmd_histogram, execution_time_usec);
+    }
   }
   return execution_time_usec;
 }

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -187,6 +187,8 @@ class CommandId : public facade::CommandId {
     return is_alias_;
   }
 
+  hdr_histogram* LatencyHist() const;
+
  private:
   // The following fields must copy manually in the move constructor.
   bool implicit_acl_;
@@ -248,6 +250,8 @@ class CommandRegistry {
 
   std::pair<const CommandId*, facade::ArgSlice> FindExtended(std::string_view cmd,
                                                              facade::ArgSlice tail_args) const;
+
+  absl::flat_hash_map<std::string, hdr_histogram*> LatencyMap() const;
 
  private:
   absl::flat_hash_map<std::string, CommandId> cmd_map_;

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -920,4 +920,18 @@ TEST_F(DflyCommandAliasTest, Aliasing) {
   EXPECT_THAT(metrics.cmd_stats_map, Contains(Pair("exec", Key(1))));
 }
 
+TEST_F(DflyCommandAliasTest, AliasesShareHistogramPtr) {
+  EXPECT_EQ(Run({"SET", "foo", "bar"}), "OK");
+  EXPECT_EQ(Run({"___SET", "a", "b"}), "OK");
+  EXPECT_EQ(Run({"___ping"}), "PONG");
+
+  const auto command_histograms = GetMetrics().cmd_latency_map;
+  for (const auto& key : {"set", "___set", "___ping", "ping"}) {
+    EXPECT_TRUE(command_histograms.contains(key));
+  }
+
+  EXPECT_EQ(command_histograms.at("set"), command_histograms.at("___set"));
+  EXPECT_EQ(command_histograms.at("ping"), command_histograms.at("___ping"));
+}
+
 }  // namespace dfly

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -28,6 +28,7 @@ ABSL_DECLARE_FLAG(std::vector<std::string>, rename_command);
 ABSL_DECLARE_FLAG(bool, lua_resp2_legacy_float);
 ABSL_DECLARE_FLAG(double, eviction_memory_budget_threshold);
 ABSL_DECLARE_FLAG(std::vector<std::string>, command_alias);
+ABSL_DECLARE_FLAG(bool, latency_tracking);
 
 namespace dfly {
 
@@ -887,7 +888,8 @@ TEST_F(DflyEngineTest, CommandMetricLabels) {
 class DflyCommandAliasTest : public DflyEngineTest {
  protected:
   DflyCommandAliasTest() {
-    absl::SetFlag(&FLAGS_command_alias, {"___set=set", "___ping=ping"});
+    SetFlag(&FLAGS_command_alias, {"___set=set", "___ping=ping"});
+    SetFlag(&FLAGS_latency_tracking, true);
   }
 
   absl::FlagSaver saver_;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -237,6 +237,13 @@ using strings::HumanReadableNumBytes;
 
 namespace {
 
+// TODO these should be configurable as command line flag and at runtime via config set
+constexpr std::array<double, 3> kLatencyPercentiles = {50.0, 99.0, 99.9};
+
+bool is_histogram_empty(const hdr_histogram* h) {
+  return hdr_min(h) == std::numeric_limits<int64_t>::max();
+}
+
 const auto kRedisVersion = "7.4.0";
 
 using EngineFunc = void (ServerFamily::*)(CmdArgList args, const CommandContext&);
@@ -2388,6 +2395,7 @@ Metrics ServerFamily::GetMetrics(Namespace* ns) const {
   UpdateMax(&peak_stats_.conn_read_buf_capacity, result.facade_stats.conn_stats.read_buf_capacity);
 
   result.peak_stats = peak_stats_;
+  result.cmd_latency_map = service_.mutable_registry()->LatencyMap();
 
   uint64_t delta_ms = (absl::GetCurrentTimeNanos() - start) / 1'000'000;
   if (delta_ms > 30) {
@@ -2871,6 +2879,31 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
     append("cluster_enabled", IsClusterEnabledOrEmulated());
     append("migration_errors_total", service_.cluster_family().MigrationsErrorsCount());
     append("total_migrated_keys", m.shard_stats.total_migrated_keys);
+  }
+
+  if (should_enter("LATENCYSTATS")) {
+    for (const auto& [cmd_name, hist] : m.cmd_latency_map) {
+      if (!hist) {
+        continue;
+      }
+
+      if (is_histogram_empty(hist)) {
+        continue;
+      }
+
+      absl::InlinedVector<std::string, 4> stats;
+      for (const auto percentile : kLatencyPercentiles) {
+        const auto value = hdr_value_at_percentile(hist, percentile);
+        // If the percentile is an integer, print it as an integer, otherwise print it as a double
+        if (std::trunc(percentile) == percentile) {
+          stats.emplace_back(absl::StrFormat("p%d=%d", static_cast<int64_t>(percentile), value));
+        } else {
+          stats.emplace_back(absl::StrFormat("p%g=%d", percentile, value));
+        }
+      }
+
+      append(absl::StrFormat("latency_percentiles_usec_%s", cmd_name), absl::StrJoin(stats, ","));
+    }
   }
 
   return info;

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -132,6 +132,8 @@ struct Metrics {
   size_t migration_errors_total;
 
   LoadingStats loading_stats;
+
+  absl::flat_hash_map<std::string, hdr_histogram*> cmd_latency_map;
 };
 
 struct LastSaveInfo {

--- a/tests/dragonfly/server_family_test.py
+++ b/tests/dragonfly/server_family_test.py
@@ -223,7 +223,8 @@ async def test_metric_labels(
             match_label_value(sample, "other", lambda v: v == 1)
 
 
-async def test_latency_metric(async_client: aioredis.Redis):
+@dfly_args({"latency_tracking": True})
+async def test_latency_stats(async_client: aioredis.Redis):
     for _ in range(100):
         await async_client.set("foo", "bar")
         await async_client.get("foo")
@@ -235,3 +236,9 @@ async def test_latency_metric(async_client: aioredis.Redis):
         key = f"latency_percentiles_usec_{expected}"
         assert key in latency_stats
         assert latency_stats[key].keys() == {"p50", "p99", "p99.9"}
+
+
+async def test_latency_stats_disabled_by_default(async_client: aioredis.Redis):
+    for _ in range(100):
+        await async_client.set("foo", "bar")
+    assert await async_client.info("LATENCYSTATS") == {}

--- a/tests/dragonfly/server_family_test.py
+++ b/tests/dragonfly/server_family_test.py
@@ -221,3 +221,17 @@ async def test_metric_labels(
         for sample in metrics["dragonfly_connected_clients"].samples:
             match_label_value(sample, "main", lambda v: v == 2)
             match_label_value(sample, "other", lambda v: v == 1)
+
+
+async def test_latency_metric(async_client: aioredis.Redis):
+    for _ in range(100):
+        await async_client.set("foo", "bar")
+        await async_client.get("foo")
+        await async_client.get("bar")
+        await async_client.hgetall("missing")
+
+    latency_stats = await async_client.info("LATENCYSTATS")
+    for expected in {"hgetall", "set", "get"}:
+        key = f"latency_percentiles_usec_{expected}"
+        assert key in latency_stats
+        assert latency_stats[key].keys() == {"p50", "p99", "p99.9"}


### PR DESCRIPTION
Command latency is recorded in its histogram when command is invoked. 

When `info latencystats` is run, the latency for a fixed set of percentiles (50,99,99.9 by default) is returned per command. 

Currently the percentiles are fixed, but in a later PR these should be made configurable as command line option as well as `config set`.

FIXES #5092 