### PR TITLE
fix(zset): expand parsing of rank arguments beyond int32

### DIFF
--- a/src/server/zset_family.h
+++ b/src/server/zset_family.h
@@ -25,7 +25,7 @@ class ZSetFamily {
  public:
   static void Register(CommandRegistry* registry);
 
-  using IndexInterval = std::pair<int32_t, int32_t>;
+  using IndexInterval = std::pair<int64_t, int64_t>;
   using MScoreResponse = std::vector<std::optional<double>>;
 
   struct Bound {
@@ -37,7 +37,7 @@ class ZSetFamily {
 
   struct LexBound {
     std::string_view val;
-    enum Type { PLUS_INF, MINUS_INF, OPEN, CLOSED } type = CLOSED;
+    enum Type : uint8_t { PLUS_INF, MINUS_INF, OPEN, CLOSED } type = CLOSED;
   };
 
   using LexInterval = std::pair<LexBound, LexBound>;
@@ -49,7 +49,7 @@ class ZSetFamily {
     uint32_t limit = UINT32_MAX;
     bool with_scores = false;
     bool reverse = false;
-    enum IntervalType { LEX, RANK, SCORE } interval_type = RANK;
+    enum IntervalType : uint8_t { LEX, RANK, SCORE } interval_type = RANK;
     std::optional<std::string_view> store_key = std::nullopt;
   };
 

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -305,7 +305,7 @@ TEST_F(ZSetFamilyTest, ZMScoreNonExistentKeys) {
               ElementsAre(ArgType(RespExpr::NIL), ArgType(RespExpr::NIL), ArgType(RespExpr::NIL)));
 }
 
-TEST_F(ZSetFamilyTest, ZRangeRank) {
+TEST_F(ZSetFamilyTest, ByScore) {
   Run({"zadd", "x", "1.1", "a", "2.1", "b"});
   EXPECT_THAT(Run({"zrangebyscore", "x", "0", "(1.1"}), ArrLen(0));
   EXPECT_THAT(Run({"zrangebyscore", "x", "-inf", "1.1", "limit", "0", "10"}), "a");
@@ -506,6 +506,9 @@ TEST_F(ZSetFamilyTest, ZRange) {
   resp = Run({"zrange", "key", "+", "[cool", "BYLEX", "LIMIT", "2", "2", "REV"});
   ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
   EXPECT_THAT(resp.GetVec(), ElementsAre("great", "foo"));
+
+  resp = Run({"zrange", "key", "5", "2147483648"});
+  ASSERT_THAT(resp, RespElementsAre("foo", "great", "hill", "omega"));
 }
 
 TEST_F(ZSetFamilyTest, ZRevRange) {


### PR DESCRIPTION
Fix clang-tidy warnings in zset_family code as well.

Fixes #5374

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->