### PR TITLE
chore: Make fakeredis part of the core CI checks

### DIFF
--- a/.github/workflows/test-fakeredis.yml
+++ b/.github/workflows/test-fakeredis.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  checks: write
 
 concurrency:
   group: dragonfly-${{ github.workflow }}-${{ github.ref }}
@@ -59,9 +60,13 @@ jobs:
       - name: Run tests
         working-directory: tests/fakeredis
         run: |
-          poetry run pytest -s test/ \
+          # Some tests are pending on #5383
+          poetry run pytest test/ \
+          --ignore test/test_hypothesis/test_transaction.py \
+          --ignore test/test_hypothesis/test_zset.py \
+          --ignore test/test_hypotesis_joint/test_joint.py \
           --junit-xml=results-tests.xml  --html=report-tests.html -v
-        continue-on-error: true  # For now to mark the flow as successful
+        continue-on-error: false  # Fail the job if tests fail
 
       - name: Show Dragonfly stats
         if: always()
@@ -88,7 +93,7 @@ jobs:
         with:
           report_paths: tests/fakeredis/results-tests.xml
           # Do not create a check run
-          annotate_only: true
+          # annotate_only: true
 
   publish-html-results:
     name: Publish HTML Test Results to GitHub Pages

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         name: Clang formatting
 
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 25.1.0
     hooks:
       - id: black
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,7 +40,7 @@ Message(STATUS "THIRD_PARTY_LIB_DIR ${THIRD_PARTY_LIB_DIR}")
 include(external_libs.cmake)
 
 if(ENABLE_GIT_VERSION)
-    include(GetGitRevisionDescription)
+    include(GetGitRevisionDescription.cmake)
     get_git_head_revision(GIT_REFSPEC GIT_SHA1)
     git_local_changes(GIT_CLEAN_DIRTY)
     if("${GIT_CLEAN_DIRTY}" STREQUAL "DIRTY")

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1141,11 +1141,9 @@ std::optional<ErrorReply> Service::VerifyCommandState(const CommandId* cid, CmdA
     return ErrorReply{"-READONLY You can't write against a read only replica."};
 
   if (multi_active) {
-    if (absl::EndsWith(cmd_name, "SUBSCRIBE"))
-      return ErrorReply{absl::StrCat("Can not call ", cmd_name, " within a transaction")};
-
-    if (cmd_name == "WATCH" || cmd_name == "FLUSHALL" || cmd_name == "FLUSHDB")
-      return ErrorReply{absl::StrCat("'", cmd_name, "' inside MULTI is not allowed")};
+    if (cmd_name == "WATCH" || cmd_name == "FLUSHALL" || cmd_name == "FLUSHDB" ||
+        absl::EndsWith(cmd_name, "SUBSCRIBE"))
+      return ErrorReply{absl::StrCat("'", cmd_name, "' not allowed inside a transaction")};
   }
 
   if (IsClusterEnabled()) {

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -69,7 +69,7 @@ TEST_F(MultiTest, MultiAndFlush) {
   resp = Run({"get", kKey1});
   ASSERT_EQ(resp, "QUEUED");
 
-  EXPECT_THAT(Run({"FLUSHALL"}), ErrArg("'FLUSHALL' inside MULTI is not allowed"));
+  EXPECT_THAT(Run({"FLUSHALL"}), ErrArg("not allowed inside a transaction"));
 }
 
 TEST_F(MultiTest, MultiWithError) {
@@ -509,7 +509,7 @@ TEST_F(MultiTest, Watch) {
 
   // Check watch doesn't run in multi.
   Run({"multi"});
-  ASSERT_THAT(Run({"watch", "a"}), ErrArg("'WATCH' inside MULTI is not allowed"));
+  ASSERT_THAT(Run({"watch", "a"}), ErrArg("not allowed inside a transaction"));
   Run({"discard"});
 
   // Check watch on existing key.

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -417,7 +417,7 @@ class DflyInstanceFactory:
         args.setdefault("noversion_check", None)
         # MacOs does not set it automatically, so we need to set it manually
         args.setdefault("maxmemory", "8G")
-        vmod = "dragonfly_connection=1,accept_server=1,listener_interface=1,main_service=1,rdb_save=1,replica=1,cluster_family=1,proactor_pool=1,dflycmd=1,snapshot=1,streamer=1"
+        vmod = "dragonfly_connection=1,db_slice=1,listener_interface=1,main_service=1,rdb_save=1,replica=1,cluster_family=1,engine_shard=1,dflycmd=1,snapshot=1,streamer=1"
         args.setdefault("vmodule", vmod)
         args.setdefault("jsonpathv2")
         if version > 1.27:

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2086,7 +2086,6 @@ async def test_policy_based_eviction_propagation(df_factory, df_seeder_factory):
         proactor_threads=2,
         cache_mode="true",
         maxmemory="512mb",
-        logtostdout="true",
         enable_heartbeat_eviction="false",
         rss_oom_deny_ratio=1.3,
     )


### PR DESCRIPTION
In addition, fixed the build break when running "make release".
Finally adjusted the verbosity level of files to be more useful in tests and
reformatted fakeredis to pass the black formatter.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->