### PR TITLE
fix(zset_family): Return early if range is expected to be zero

### DIFF
--- a/src/core/sorted_map.cc
+++ b/src/core/sorted_map.cc
@@ -688,10 +688,8 @@ size_t SortedMap::LexCount(const zlexrangespec& range) const {
   if (score_tree->Size() == 0)
     return 0;
 
-  // Ranges that will always be zero
-  if ((range.min == cminstring && range.max == cminstring) ||
-      (range.min == cmaxstring && range.max == cmaxstring) ||
-      (range.min == cmaxstring && range.max == cminstring)) {
+  // Ranges that will always be zero - (+inf, anything) or (anything, -inf)
+  if (range.min == cmaxstring || range.max == cminstring) {
     return 0;
   }
 

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -1185,10 +1185,18 @@ TEST_F(ZSetFamilyTest, Count) {
 
   EXPECT_THAT(CheckedInt({"zcount", "key", "-inf", "+inf"}), 129);
   EXPECT_THAT(CheckedInt({"zlexcount", "key", "-", "+"}), 129);
-  // Ranges that are expected to be zero
-  EXPECT_THAT(CheckedInt({"ZLEXCOUNT", "key", "-", "-"}), 0);
-  EXPECT_THAT(CheckedInt({"ZLEXCOUNT", "key", "+", "-"}), 0);
-  EXPECT_THAT(CheckedInt({"ZLEXCOUNT", "key", "+", "-"}), 0);
+
+  // Listpack object
+  Run({"ZADD", "short", "0", "A"});
+  EXPECT_THAT(CheckedInt({"ZLEXCOUNT", "short", "-", "-"}), 0);
+  EXPECT_THAT(CheckedInt({"ZLEXCOUNT", "short", "+", "+"}), 0);
+  EXPECT_THAT(CheckedInt({"ZLEXCOUNT", "short", "+", "-"}), 0);
+
+  // Sortedset object
+  Run({"ZADD", "long", "0", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"});
+  EXPECT_THAT(CheckedInt({"ZLEXCOUNT", "long", "-", "-"}), 0);
+  EXPECT_THAT(CheckedInt({"ZLEXCOUNT", "long", "+", "+"}), 0);
+  EXPECT_THAT(CheckedInt({"ZLEXCOUNT", "long", "+", "-"}), 0);
 }
 
 TEST_F(ZSetFamilyTest, RangeLimit) {


### PR DESCRIPTION
There are 2 ranges that can be used but they are always zero. Ranges are (+inf, anything) and (anything, -inf). Check and return early if they are used.

Fixes #5383

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->