### PR TITLE
fix: JSON.STRLEN behavior for non-existent keys

### DIFF
--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -904,7 +904,8 @@ OpResult<JsonCallbackResult<OptSize>> OpStrLen(const OpArgs& op_args, string_vie
   };
   return JsonReadOnlyOperation<OptSize>(
       op_args, key, json_path, std::move(cb),
-      {true, CallbackResultOptions::DefaultReadOnlyOptions(SavingOrder::kSaveFirst)});
+      {json_path.IsLegacyModePath(),
+       CallbackResultOptions::DefaultReadOnlyOptions(SavingOrder::kSaveFirst)});
 }
 
 OpResult<JsonCallbackResult<OptSize>> OpObjLen(const OpArgs& op_args, string_view key,

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -414,7 +414,7 @@ TEST_F(JsonFamilyTest, StrLen) {
   EXPECT_THAT(resp, IntArg(2));
 
   resp = Run({"JSON.STRLEN", "non_existent_key", "$.c.b"});
-  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
+  EXPECT_THAT(resp, ErrArg("no such key"));
 
   /*
   Test response from several possible values
@@ -469,6 +469,11 @@ TEST_F(JsonFamilyTest, StrLenLegacy) {
 
   resp = Run({"JSON.STRLEN", "json", ".d.*"});
   EXPECT_THAT(resp, IntArg(1));
+}
+
+TEST_F(JsonFamilyTest, StrLenNonExistentKey) {
+  auto resp = Run({"JSON.STRLEN", "non_existent_key", "$"});
+  EXPECT_THAT(resp, ErrArg("no such key"));
 }
 
 TEST_F(JsonFamilyTest, ObjLen) {


### PR DESCRIPTION
Makes JSON.STRLEN consistent with other JSON commands:
- Legacy mode (`.`): returns NIL for non-existent keys
- JSONPath v2 mode (`$`): returns "no such key" error