### PR TITLE
feat(pytest): Set and log random seed used in pytest

### DIFF
--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -95,7 +95,7 @@ def df_seeder_factory(request) -> DflySeederFactory:
         seed = random.randrange(sys.maxsize)
 
     random.seed(int(seed))
-    print(f"--- Random seed: {seed}, check: {random.randrange(100)} ---")
+    logging.debug(f"Random seed: {seed}, check: {random.randrange(100)}")
 
     return DflySeederFactory(request.config.getoption("--log-seeder"))
 

--- a/tests/dragonfly/seeder/script-generate.lua
+++ b/tests/dragonfly/seeder/script-generate.lua
@@ -21,6 +21,9 @@ local collection_size = tonumber(ARGV[9])
 -- Probability of each key in key_target to be a big value
 local huge_value_target = tonumber(ARGV[10])
 local huge_value_size = tonumber(ARGV[11])
+local seed = tonumber(ARGV[12])
+
+math.randomseed(seed)
 
 -- collect all keys belonging to this script
 -- assumes exclusive ownership


### PR DESCRIPTION
Set and print random seed used in python testing for tests that use Seeder and DflySeederFactory classes for generating commands.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->