### PR TITLE
feat: add snapshot-id field into dfs files

### DIFF
--- a/src/server/detail/save_stages_controller.cc
+++ b/src/server/detail/save_stages_controller.cc
@@ -100,7 +100,8 @@ GenericError ValidateFilename(const fs::path& filename, bool new_version) {
 }
 
 GenericError RdbSnapshot::Start(SaveMode save_mode, const std::string& path,
-                                const RdbSaver::GlobalData& glob_data) {
+                                const RdbSaver::GlobalData& glob_data,
+                                const std::string& snapshot_id) {
   VLOG(1) << "Saving RDB " << path;
 
   CHECK_NOTNULL(snapshot_storage_);
@@ -114,7 +115,7 @@ GenericError RdbSnapshot::Start(SaveMode save_mode, const std::string& path,
 
   is_linux_file_ = file_type & FileType::IO_URING;
   bool align_writes = (file_type & FileType::DIRECT) != 0;
-  saver_.reset(new RdbSaver(io_sink_.get(), save_mode, align_writes));
+  saver_.reset(new RdbSaver(io_sink_.get(), save_mode, align_writes, snapshot_id));
 
   return saver_->SaveHeader(std::move(glob_data));
 }
@@ -268,26 +269,28 @@ void SaveStagesController::SaveDfs() {
       SetExtension("summary", ext, &filename);
   }
 
+  absl::InsecureBitGen gen;
+  std::string snapshot_id = GetRandomHex(gen, 32);
   // Save summary file.
-  SaveDfsSingle(nullptr);
+  SaveDfsSingle(nullptr, snapshot_id);
 
   // Save shard files.
-  auto cb = [this](Transaction* t, EngineShard* shard) {
-    SaveDfsSingle(shard);
+  auto cb = [this, &snapshot_id](Transaction* t, EngineShard* shard) {
+    SaveDfsSingle(shard, snapshot_id);
     return OpStatus::OK;
   };
   trans_->ScheduleSingleHop(std::move(cb));
 }
 
 // Start saving a dfs file on shard
-void SaveStagesController::SaveDfsSingle(EngineShard* shard) {
+void SaveStagesController::SaveDfsSingle(EngineShard* shard, const std::string& snapshot_id) {
   // for summary file, shard=null and index=shard_set->size(), see SaveDfs() above
   auto& [snapshot, filename] = snapshots_[shard ? shard->shard_id() : shard_set->size()];
 
   SaveMode mode = shard == nullptr ? SaveMode::SUMMARY : SaveMode::SINGLE_SHARD;
   auto glob_data = shard == nullptr ? RdbSaver::GetGlobalData(service_) : RdbSaver::GlobalData{};
 
-  if (auto err = snapshot->Start(mode, filename, glob_data); err) {
+  if (auto err = snapshot->Start(mode, filename, glob_data, snapshot_id); err) {
     shared_err_ = err;
     snapshot.reset();
     return;
@@ -307,7 +310,8 @@ void SaveStagesController::SaveRdb() {
   if (!snapshot_storage_->IsCloud())
     filename += ".tmp";
 
-  if (auto err = snapshot->Start(SaveMode::RDB, filename, RdbSaver::GetGlobalData(service_)); err) {
+  if (auto err = snapshot->Start(SaveMode::RDB, filename, RdbSaver::GetGlobalData(service_), "");
+      err) {
     snapshot.reset();
     return;
   }

--- a/src/server/detail/save_stages_controller.h
+++ b/src/server/detail/save_stages_controller.h
@@ -45,7 +45,8 @@ class RdbSnapshot {
       : snapshot_storage_{snapshot_storage} {
   }
 
-  GenericError Start(SaveMode save_mode, const string& path, const RdbSaver::GlobalData& glob_data);
+  GenericError Start(SaveMode save_mode, const string& path, const RdbSaver::GlobalData& glob_data,
+                     const std::string& snapshot_id);
   void StartInShard(EngineShard* shard);
 
   error_code SaveBody();
@@ -109,7 +110,7 @@ struct SaveStagesController : public SaveStagesInputs {
   void SaveDfs();
 
   // Start saving a dfs file on shard
-  void SaveDfsSingle(EngineShard* shard);
+  void SaveDfsSingle(EngineShard* shard, const std::string& snapshot_id);
   void SaveSnashot(EngineShard* shard);
   void WaitSnapshotInShard(EngineShard* shard);
 

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -598,7 +598,7 @@ OpStatus DflyCmd::StartFullSyncInThread(FlowInfo* flow, ExecutionState* exec_st,
   // of the flows also contain them.
   SaveMode save_mode =
       shard->shard_id() == 0 ? SaveMode::SINGLE_SHARD_WITH_SUMMARY : SaveMode::SINGLE_SHARD;
-  flow->saver = std::make_unique<RdbSaver>(flow->conn->socket(), save_mode, false);
+  flow->saver = std::make_unique<RdbSaver>(flow->conn->socket(), save_mode, false, "");
 
   flow->cleanup = [flow, shard]() {
     // socket shutdown is needed before calling saver->Cancel(). Because

--- a/src/server/error.cc
+++ b/src/server/error.cc
@@ -36,6 +36,8 @@ string error_category::message(int ev) const {
       return "Wrong signature while trying to load from rdb file";
     case errc::out_of_memory:
       return "Out of memory, or used memory is too high";
+    case errc::incorrect_snapshot_id:
+      return "Snapshot id mismatch";
     default:
       return absl::StrCat("Internal error when loading RDB file ", ev);
       break;

--- a/src/server/error.h
+++ b/src/server/error.h
@@ -84,6 +84,7 @@ enum errc {
   bad_json_string = 12,
   unsupported_operation = 13,
   value_expired = 14,  // applying to set and hmap
+  incorrect_snapshot_id = 15,
 };
 
 }  // namespace rdb

--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -253,7 +253,7 @@ class RdbLoader : protected RdbLoaderBase {
     pause_ = pause;
   }
 
-  const std::string& SnapshotId() const {
+  const std::string& GetSnapshotId() const {
     return snapshot_id_;
   }
 

--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -210,7 +210,7 @@ class RdbLoaderBase {
 
 class RdbLoader : protected RdbLoaderBase {
  public:
-  explicit RdbLoader(Service* service);
+  explicit RdbLoader(Service* service, std::string snapshot_id = {});
 
   ~RdbLoader();
 
@@ -251,6 +251,10 @@ class RdbLoader : protected RdbLoaderBase {
 
   void Pause(bool pause) {
     pause_ = pause;
+  }
+
+  const std::string& SnapshotId() const {
+    return snapshot_id_;
   }
 
   // Return the offset that was received with a RDB_OPCODE_JOURNAL_OFFSET command,
@@ -299,7 +303,7 @@ class RdbLoader : protected RdbLoaderBase {
   // Returns whether to discard the read key pair.
   bool ShouldDiscardKey(std::string_view key, const ObjSettings& settings) const;
   void ResizeDb(size_t key_num, size_t expire_num);
-  std::error_code HandleAux();
+  std::error_code HandleAux(bool* correct_snapshot_id);
 
   std::error_code VerifyChecksum();
 
@@ -320,6 +324,7 @@ class RdbLoader : protected RdbLoaderBase {
 
  private:
   Service* service_;
+  std::string snapshot_id_;
   bool override_existing_keys_ = false;
   bool load_unowned_slots_ = false;
   bool rdb_ignore_expiry_;

--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -303,7 +303,7 @@ class RdbLoader : protected RdbLoaderBase {
   // Returns whether to discard the read key pair.
   bool ShouldDiscardKey(std::string_view key, const ObjSettings& settings) const;
   void ResizeDb(size_t key_num, size_t expire_num);
-  std::error_code HandleAux(bool* correct_snapshot_id);
+  std::error_code HandleAux();
 
   std::error_code VerifyChecksum();
 

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -1462,7 +1462,9 @@ error_code RdbSaver::SaveAux(const GlobalData& glob_state) {
   error_code ec;
 
   // Should be first
-  RETURN_ON_ERR(impl_->SaveAuxFieldStrStr("snapshot-id", snapshot_id_));
+  if (!snapshot_id_.empty()) {
+    RETURN_ON_ERR(impl_->SaveAuxFieldStrStr("snapshot-id", snapshot_id_));
+  }
 
   /* Add a few fields about the state when the RDB was created. */
   RETURN_ON_ERR(impl_->SaveAuxFieldStrStr("redis-ver", REDIS_VERSION));

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -84,7 +84,9 @@ class RdbSaver {
   // single_shard - false, means we capture all the data using a single RdbSaver instance
   // (corresponds to legacy, redis compatible mode)
   // if align_writes is true - writes data in aligned chunks of 4KB to fit direct I/O requirements.
-  explicit RdbSaver(::io::Sink* sink, SaveMode save_mode, bool align_writes);
+  // snapshot_id - allows to identify that group of files belongs to the same snapshot
+  explicit RdbSaver(::io::Sink* sink, SaveMode save_mode, bool align_writes,
+                    std::string snapshot_id);
 
   ~RdbSaver();
 
@@ -146,6 +148,7 @@ class RdbSaver {
   std::unique_ptr<Impl> impl_;
   SaveMode save_mode_;
   CompressionMode compression_mode_;
+  std::string snapshot_id_;
 };
 
 class SerializerBase {

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -76,15 +76,13 @@ io::FileSource RdbTest::GetSource(string name) {
 }
 
 TEST_F(RdbTest, SnapshotIdTest) {
-  num_threads_ = 4;
-  absl::SetFlag(&FLAGS_num_shards, num_threads_ - 1);
+  absl::SetFlag(&FLAGS_num_shards, num_threads_);
   ResetService();
 
   EXPECT_EQ(Run({"mset", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"}), "OK");
 
   Run({"save", "df", "test_dump"});
 
-  num_threads_ = 2;
   absl::SetFlag(&FLAGS_num_shards, num_threads_ - 1);
   ResetService();
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1122,7 +1122,18 @@ std::optional<fb2::Future<GenericError>> ServerFamily::Load(string_view load_pat
 
   auto aggregated_result = std::make_shared<AggregateLoadResult>();
 
+  std::string snapshot_id;
+  if (absl::EndsWith(load_path, "summary.dfs")) {
+    // we read summary first to get snapshot_id and load data correctly
+    auto load_result = LoadRdb(std::string(load_path), existing_keys, &snapshot_id);
+    if (!load_result.has_value())
+      aggregated_result->first_error = load_result.error();
+  }
+
   for (auto& path : paths) {
+    // we have already read summary so we skip it now
+    if (absl::EndsWith(path, "summary.dfs"))
+      continue;
     // For single file, choose thread that does not handle shards if possible.
     // This will balance out the CPU during the load.
     ProactorBase* proactor;
@@ -1132,8 +1143,11 @@ std::optional<fb2::Future<GenericError>> ServerFamily::Load(string_view load_pat
       proactor = pool.GetNextProactor();
     }
 
-    auto load_func = [this, aggregated_result, existing_keys, path = std::move(path)]() {
-      auto load_result = LoadRdb(path, existing_keys);
+    auto load_func = [this, aggregated_result, existing_keys, path = std::move(path),
+                      snapshot_id]() {
+      auto sid = snapshot_id;
+      auto load_result = LoadRdb(path, existing_keys, &sid);
+      DCHECK(sid == snapshot_id);
       if (load_result.has_value())
         aggregated_result->keys_read.fetch_add(*load_result);
       else
@@ -1200,9 +1214,11 @@ void ServerFamily::SnapshotScheduling() {
 }
 
 io::Result<size_t> ServerFamily::LoadRdb(const std::string& rdb_file,
-                                         LoadExistingKeys existing_keys) {
+                                         LoadExistingKeys existing_keys, std::string* snapshot_id) {
   VLOG(1) << "Loading data from " << rdb_file;
   CHECK(fb2::ProactorBase::IsProactorThread()) << "must be called from proactor thread";
+
+  std::string filt_snapshot_id = snapshot_id ? *snapshot_id : "";
 
   io::Result<size_t> result;
   ProactorBase* proactor = fb2::ProactorBase::me();
@@ -1215,18 +1231,22 @@ io::Result<size_t> ServerFamily::LoadRdb(const std::string& rdb_file,
 
     io::FileSource fs(*res);
 
-    RdbLoader loader{&service_};
+    RdbLoader loader{&service_, filt_snapshot_id};
     if (existing_keys == LoadExistingKeys::kOverride) {
       loader.SetOverrideExistingKeys(true);
     }
 
     auto ec = loader.Load(&fs);
-    if (ec) {
+    // we ignore incorrect_snapshot_id, it means we try to load file not from the snapshot
+    if (ec && (ec.value() != rdb::errc::incorrect_snapshot_id)) {
       result = nonstd::make_unexpected(ec);
     } else {
       VLOG(1) << "Done loading RDB from " << rdb_file << ", keys loaded: " << loader.keys_loaded();
       VLOG(1) << "Loading finished after " << strings::HumanReadableElapsedTime(loader.load_time());
       result = loader.keys_loaded();
+      if (snapshot_id && snapshot_id->empty()) {
+        *snapshot_id = loader.SnapshotId();
+      }
     }
   });
 

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -337,7 +337,8 @@ class ServerFamily {
                          ActionOnConnectionFail on_error) ABSL_LOCKS_EXCLUDED(replicaof_mu_);
 
   // Returns the number of loaded keys if successful.
-  io::Result<size_t> LoadRdb(const std::string& rdb_file, LoadExistingKeys existing_keys);
+  io::Result<size_t> LoadRdb(const std::string& rdb_file, LoadExistingKeys existing_keys,
+                             std::string* snapshot_id = nullptr);
 
   void SnapshotScheduling() ABSL_LOCKS_EXCLUDED(loading_stats_mu_);
 


### PR DESCRIPTION
fixes: https://github.com/dragonflydb/dragonfly/issues/5284

Problem: Currently, different dfs snapshot files can be loaded as part of the same logical snapshot if they have the same name pattern.

Fix: Added SnapshotId AUX field into dfs files to distinguish files that can belong to another snapshot