### PR TITLE
fix(values): fix typos in Helm README and values file

### DIFF
--- a/contrib/charts/dragonfly/README.md
+++ b/contrib/charts/dragonfly/README.md
@@ -70,7 +70,7 @@ helm upgrade --install dragonfly oci://ghcr.io/dragonflydb/dragonfly/helm/dragon
 | envFrom | list | `[]` | Extra environment variables from K8s objects |
 | securityContext | object | `{}` | Set securityContext for containers |
 | service.annotations | object | `{}` | Extra annotations for the service |
-| service.lablels | object | `{}` | Extra labels for the service |
+| service.labels | object | `{}` | Extra labels for the service |
 | service.metrics.portName | string | `"metrics"` | name for the metrics port |
 | service.metrics.serviceType | string | `"ClusterIP"` | serviceType for the metrics service |
 | service.port | int | `6379` | Dragonfly service port |

--- a/contrib/charts/dragonfly/values.yaml
+++ b/contrib/charts/dragonfly/values.yaml
@@ -62,7 +62,7 @@ service:
   # -- Extra annotations for the service
   annotations: {}
   # -- Extra labels for the service
-  lablels: {}
+  labels: {}
   metrics:
     # -- name for the metrics port
     portName: metrics


### PR DESCRIPTION
This PR fixes minor typos in the Helm chart documentation:

- Corrected a typo in the `values.yaml`
- Fixed a matching typo in the `README.md` file

These changes improve clarity and consistency for users deploying Dragonfly with Helm. 

No functional code changes were introduced.
