### PR TITLE
chore: flush after serializing big string

### DIFF
--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -240,6 +240,10 @@ std::error_code RdbSerializer::SaveValue(const PrimeValue& pv) {
         ec = SaveString(pv.GetSlice(&tmp_str_));
       }
     }
+    // We flush here because if the next element in the bucket we are serializing is a container,
+    // it will first serialize the first entry and then flush the internal buffer, even if
+    // crossed the limit.
+    FlushIfNeeded(FlushState::kFlushEndEntry);
   } else {
     ec = SaveObject(pv);
   }

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -240,10 +240,6 @@ std::error_code RdbSerializer::SaveValue(const PrimeValue& pv) {
         ec = SaveString(pv.GetSlice(&tmp_str_));
       }
     }
-    // We flush here because if the next element in the bucket we are serializing is a container,
-    // it will first serialize the first entry and then flush the internal buffer, even if
-    // crossed the limit.
-    FlushIfNeeded(FlushState::kFlushEndEntry);
   } else {
     ec = SaveObject(pv);
   }
@@ -313,6 +309,10 @@ io::Result<uint8_t> RdbSerializer::SaveEntry(const PrimeKey& pk, const PrimeValu
     return make_unexpected(ec);
   }
 
+  // We flush here because if the next element in the bucket we are serializing is a container,
+  // it will first serialize the first entry and then flush the internal buffer, even if
+  // crossed the limit.
+  FlushIfNeeded(FlushState::kFlushEndEntry);
   return rdb_type;
 }
 

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -780,6 +780,10 @@ error_code SerializerBase::FlushToSink(io::Sink* sink, SerializerBase::FlushStat
   if (bytes.empty())
     return error_code{};
 
+  if (bytes.size() > serialization_peak_bytes_) {
+    serialization_peak_bytes_ = bytes.size();
+  }
+
   DVLOG(2) << "FlushToSink " << bytes.size() << " bytes";
 
   // interrupt point.

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -183,6 +183,10 @@ class SerializerBase {
     return SaveString(io::View(io::Bytes{buf, len}));
   }
 
+  uint64_t GetSerializationPeakBytes() const {
+    return serialization_peak_bytes_;
+  }
+
  protected:
   // Prepare internal buffer for flush. Compress it.
   io::Bytes PrepareFlush(FlushState flush_state);
@@ -210,6 +214,8 @@ class SerializerBase {
   base::PODArray<uint8_t> tmp_buf_;
   std::unique_ptr<LZF_HSLOT[]> lzf_;
   size_t number_of_chunks_ = 0;
+
+  uint64_t serialization_peak_bytes_ = 0;
 };
 
 class RdbSerializer : public SerializerBase {

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -114,6 +114,7 @@ void SliceSnapshot::Start(bool stream_journal, SnapshotFlush allow_flush) {
       db_slice_->UnregisterOnMoved(moved_cb_id_);
     }
     consumer_->Finalize();
+    VLOG(1) << "Serialization peak bytes: " << serializer_->GetSerializationPeakBytes();
   });
 }
 

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -64,7 +64,7 @@ size_t SliceSnapshot::GetThreadLocalMemoryUsage() {
 }
 
 bool SliceSnapshot::IsSnaphotInProgress() {
-  return tl_slice_snapshots.size() > 0;
+  return !tl_slice_snapshots.empty();
 }
 
 void SliceSnapshot::Start(bool stream_journal, SnapshotFlush allow_flush) {

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -3391,26 +3391,27 @@ async def test_replication_onmove_flow(df_factory, serialization_max_size):
 
 @dfly_args({"proactor_threads": 1})
 async def test_big_strings(df_factory):
-    master = df_factory.create(proactor_threads=1, serialization_max_chunk_size=1)
-    replica = df_factory.create(proactor_threads=1, serialization_max_chunk_size=1)
+    master = df_factory.create(
+        proactor_threads=1, serialization_max_chunk_size=1, vmodule="snapshot=1"
+    )
+    replica = df_factory.create(proactor_threads=1)
 
     df_factory.start_all([master, replica])
     c_master = master.client()
     c_replica = replica.client()
+
+    # 500kb
+    value_size = 500_000
 
     async def get_memory(client, field):
         info = await client.info("memory")
         return info[field]
 
     capacity = await get_memory(c_master, "prime_capacity")
-    # sanity
-    assert capacity < 8000
-    logging.debug(f"Capacity is {capacity}")
 
     seeder = DebugPopulateSeeder(
         key_target=int(capacity * 0.8),
-        # 500kb
-        data_size=500_000,
+        data_size=value_size,
         collection_size=1,
         variance=1,
         samples=1,
@@ -3418,29 +3419,24 @@ async def test_big_strings(df_factory):
     )
     await seeder.run(c_master)
 
+    # sanity
+    capacity = await get_memory(c_master, "prime_capacity")
+    assert capacity < 8000
+
     await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
     await wait_for_replicas_state(c_replica)
 
-    # make sure capacity hasn't changed after seeding
-    new_capacity = await get_memory(c_master, "prime_capacity")
-    assert capacity == new_capacity
-
-    used_memory = await get_memory(c_master, "used_memory_rss")
-    peak_memory = await get_memory(c_master, "used_memory_peak_rss")
-
-    logging.info(f"Used memory {used_memory}, peak memory {peak_memory}")
-    five_mb = 5_000_000
-    # I got this value by experimenting. Basically, without flushing big strings early,
-    # the difference between peak and used is roughly 16mb. However, with flushing the
-    # diff is usually 0 locally so I assume that maybe now we are a little faster
-    # and the periodic fiber that updates the peak_rss does not run in the middle of the bucket
-    # serialization. I added a "grace range" of 5mb to this to account for other allocations
-    # inbetween. This is not a great test for this but we are limited because we can't fill
-    # a bucket with big strings as the memory in the gh runner is fairly limited. We at
-    # least check for correctness and *some* improvement in the memory foot print.
-    assert peak_memory < used_memory + five_mb
-
-    # Check replica data consistent
+    # Check if replica data is consistent
     replica_data = await DebugPopulateSeeder.capture(c_replica)
     master_data = await DebugPopulateSeeder.capture(c_master)
     assert master_data == replica_data
+
+    replica.stop()
+    master.stop()
+
+    lines = master.find_in_logs("Serialization peak bytes: ")
+    assert len(lines) == 1
+    # We test the serializtion path of command execution
+    line = lines[0]
+    peak_bytes = extract_int_after_prefix("Serialization peak bytes: ", line)
+    assert peak_bytes < value_size


### PR DESCRIPTION
Serializing entries of a bucket during snapshot might contain large strings which potentially cross the serialization threshold imposed by `FlushIfNeeded()`. If the next element in the bucket is a big value (let's say a hash table), we will first serialize its first element of the container and then Flush which can lead to memory pressure. To avoid that, we call `FlushIfNeeded()` after we serialize each string.

Resolves #5394