### PR TITLE
chore: Increase BLMPopBlocking sleep duration

### DIFF
--- a/src/server/list_family_test.cc
+++ b/src/server/list_family_test.cc
@@ -150,7 +150,7 @@ TEST_F(ListFamilyTest, BLMPopBlocking) {
   auto fb0 = pp_->at(0)->LaunchFiber(Launch::dispatch, [&] {
     resp = Run({"blmpop", "0.1", "1", kKey1, "LEFT"});
   });
-  ThisFiber::SleepFor(50us);
+  ThisFiber::SleepFor(1ms);
   ASSERT_TRUE(IsLocked(0, kKey1));
 
   fb0.Join();
@@ -164,7 +164,7 @@ TEST_F(ListFamilyTest, BLMPopBlocking) {
   auto fb1 = pp_->at(1)->LaunchFiber(Launch::dispatch, [&] {
     resp = Run({"blmpop", "0.1", "1", kKey1, "LEFT"});
   });
-  ThisFiber::SleepFor(50us);
+  ThisFiber::SleepFor(1ms);
   // shouldn't need to lock the key just pop immediately
   ASSERT_FALSE(IsLocked(0, kKey1));
   fb1.Join();
@@ -173,7 +173,7 @@ TEST_F(ListFamilyTest, BLMPopBlocking) {
   auto fb2 = pp_->at(2)->LaunchFiber(Launch::dispatch, [&] {
     resp = Run({"blmpop", "0.1", "1", kKey1, "LEFT"});
   });
-  ThisFiber::SleepFor(50us);
+  ThisFiber::SleepFor(1ms);
 
   // key should be locked while waiting
   ASSERT_TRUE(IsLocked(0, kKey1));


### PR DESCRIPTION
Test failed because sleep duration was too low. Increase to some reasonable value.

Closes #5402

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->