### PR TITLE
feat: add more auxillary strings to the snapshot

### DIFF
--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -561,7 +561,7 @@ void DflyCmd::ReplicaOffset(CmdArgList args, RedisReplyBuilder* rb) {
 void DflyCmd::Load(CmdArgList args, RedisReplyBuilder* rb, ConnectionContext* cntx) {
   CmdArgParser parser{args};
   parser.ExpectTag("LOAD");
-  string_view filename = parser.Next();
+  string filename = parser.Next<string>();
   ServerFamily::LoadExistingKeys existing_keys = ServerFamily::LoadExistingKeys::kFail;
 
   if (parser.HasNext()) {
@@ -569,7 +569,7 @@ void DflyCmd::Load(CmdArgList args, RedisReplyBuilder* rb, ConnectionContext* cn
     existing_keys = ServerFamily::LoadExistingKeys::kOverride;
   }
 
-  if (parser.Error() || parser.HasNext()) {
+  if (parser.Error() || parser.HasNext() || filename.empty()) {
     return rb->SendError(kSyntaxErr);
   }
 

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -46,7 +46,6 @@ ABSL_FLAG(dfly::CompressionMode, compression_mode, dfly::CompressionMode::MULTI_
           "set 2 for multi entry zstd compression on df snapshot and single entry on rdb snapshot,"
           "set 3 for multi entry lz4 compression on df snapshot and single entry on rdb snapshot");
 
-// TODO: to retire this flag in v1.31
 ABSL_RETIRED_FLAG(bool, stream_rdb_encode_v2, true,
                   "Retired. Uses format, compatible with redis 7.2 and Dragonfly v1.26+");
 
@@ -268,7 +267,10 @@ io::Result<uint8_t> RdbSerializer::SaveEntry(const PrimeKey& pk, const PrimeValu
   }
 
   DVLOG(3) << "Selecting " << dbid << " previous: " << last_entry_db_index_;
-  SelectDb(dbid);
+  auto ec = SelectDb(dbid);
+  if (ec) {
+    return make_unexpected(ec);
+  }
 
   /* Save the expire time */
   if (expire_ms > 0) {
@@ -1330,18 +1332,30 @@ RdbSaver::GlobalData RdbSaver::GetGlobalData(const Service* service) {
       script_bodies.push_back(std::move(data.body));
   }
 
-  {
-    shard_set->Await(0, [&] {
-      auto* indices = EngineShard::tlocal()->search_indices();
-      for (auto index_name : indices->GetIndexNames()) {
+  atomic<size_t> table_mem{0};
+  shard_set->RunBriefInParallel([&](EngineShard* shard) {
+    if (shard->shard_id() == 0) {
+      auto* indices = shard->search_indices();
+      for (const auto& index_name : indices->GetIndexNames()) {
         auto index_info = indices->GetIndex(index_name)->GetInfo();
         search_indices.emplace_back(
             absl::StrCat(index_name, " ", index_info.BuildRestoreCommand()));
       }
-    });
-  }
+    }
+    auto& db_slice = namespaces->GetDefaultNamespace().GetDbSlice(shard->shard_id());
+    size_t shard_table_mem = 0;
+    for (size_t db_id = 0; db_id < db_slice.db_array_size(); ++db_id) {
+      auto* db_table = db_slice.GetDBTable(db_id);
 
-  return RdbSaver::GlobalData{std::move(script_bodies), std::move(search_indices)};
+      if (db_table) {
+        shard_table_mem += db_table->table_memory();
+      }
+    }
+    table_mem.fetch_add(shard_table_mem, memory_order_relaxed);
+  });
+
+  return RdbSaver::GlobalData{std::move(script_bodies), std::move(search_indices),
+                              table_mem.load(memory_order_relaxed)};
 }
 
 void RdbSaver::Impl::FillFreqMap(RdbTypeFreqMap* dest) const {
@@ -1427,7 +1441,7 @@ error_code RdbSaver::SaveHeader(const GlobalData& glob_state) {
   CHECK_EQ(9u, sz);
 
   RETURN_ON_ERR(impl_->serializer()->WriteRaw(Bytes{reinterpret_cast<uint8_t*>(magic), sz}));
-  RETURN_ON_ERR(SaveAux(std::move(glob_state)));  // Should be first after magic
+  RETURN_ON_ERR(SaveAux(glob_state));  // Should be first after magic
   RETURN_ON_ERR(impl_->FlushSerializer());
   return error_code{};
 }
@@ -1457,10 +1471,6 @@ void RdbSaver::FillFreqMap(RdbTypeFreqMap* freq_map) {
 }
 
 error_code RdbSaver::SaveAux(const GlobalData& glob_state) {
-  static_assert(sizeof(void*) == 8, "");
-
-  error_code ec;
-
   // Should be first
   if (!snapshot_id_.empty()) {
     RETURN_ON_ERR(impl_->SaveAuxFieldStrStr("snapshot-id", snapshot_id_));
@@ -1490,6 +1500,14 @@ error_code RdbSaver::SaveAux(const GlobalData& glob_state) {
     DCHECK(save_mode_ != SaveMode::SINGLE_SHARD || glob_state.search_indices.empty());
     for (const string& s : glob_state.search_indices)
       RETURN_ON_ERR(impl_->SaveAuxFieldStrStr("search-index", s));
+    if (save_mode_ == SaveMode::SINGLE_SHARD_WITH_SUMMARY || save_mode_ == SaveMode::SUMMARY) {
+      // We save the shard id in the summary file, so that we can restore it later.
+      RETURN_ON_ERR(SaveAuxFieldStrInt("shard-count", shard_set->size()));
+      RETURN_ON_ERR(SaveAuxFieldStrInt("table-mem", glob_state.table_used_memory));
+    }
+    if (EngineShard* shard = EngineShard::tlocal(); shard) {
+      RETURN_ON_ERR(SaveAuxFieldStrInt("shard-id", shard->shard_id()));
+    }
   }
 
   // TODO: "repl-stream-db", "repl-id", "repl-offset"

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -77,6 +77,7 @@ class RdbSaver {
   struct GlobalData {
     const StringVec lua_scripts;     // bodies of lua scripts
     const StringVec search_indices;  // ft.create commands to re-create search indices
+    size_t table_used_memory = 0;    // total memory used by all tables in all shards
   };
 
   // single_shard - true means that we run RdbSaver on a single shard and we do not use
@@ -153,7 +154,7 @@ class RdbSaver {
 
 class SerializerBase {
  public:
-  enum class FlushState { kFlushMidEntry, kFlushEndEntry };
+  enum class FlushState : uint8_t { kFlushMidEntry, kFlushEndEntry };
 
   explicit SerializerBase(CompressionMode compression_mode);
   virtual ~SerializerBase() = default;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -17,7 +17,6 @@
 
 #include <algorithm>
 #include <chrono>
-#include <filesystem>
 #include <optional>
 
 #include "absl/strings/ascii.h"
@@ -226,8 +225,6 @@ std::string AbslUnparseFlag(const CronExprFlag& flag) {
 }
 
 namespace dfly {
-
-namespace fs = std::filesystem;
 
 using absl::GetFlag;
 using absl::StrCat;
@@ -959,7 +956,7 @@ void ServerFamily::LoadFromSnapshot() {
       snapshot_storage_->LoadPath(GetFlag(FLAGS_dir), GetFlag(FLAGS_dbfilename));
 
   if (load_path_result) {
-    const std::string load_path = *load_path_result;
+    const std::string& load_path = *load_path_result;
     if (!load_path.empty()) {
       auto future = Load(load_path, LoadExistingKeys::kFail);
       load_fiber_ = service_.proactor_pool().GetNextProactor()->LaunchFiber([future]() mutable {
@@ -1098,23 +1095,15 @@ void ServerFamily::FlushAll(Namespace* ns) {
 // Load starts as many fibers as there are files to load each one separately.
 // It starts one more fiber that waits for all load fibers to finish and returns the first
 // error (if any occured) with a future.
-std::optional<fb2::Future<GenericError>> ServerFamily::Load(string_view load_path,
+std::optional<fb2::Future<GenericError>> ServerFamily::Load(const std::string& path,
                                                             LoadExistingKeys existing_keys) {
-  std::string path(load_path);
-
-  if (load_path.empty()) {
-    fs::path dir_path(GetFlag(FLAGS_dir));
-    string filename = GetFlag(FLAGS_dbfilename);
-    dir_path.append(filename);
-    path = dir_path.generic_string();
-  }
-
+  DCHECK(!path.empty());
   DCHECK_GT(shard_count(), 0u);
 
   // TODO: to move it to helio.
   auto immediate = [](auto val) {
     fb2::Future<GenericError> future;
-    future.Resolve(val);
+    future.Resolve(std::move(val));
     return future;
   };
 
@@ -1144,21 +1133,22 @@ std::optional<fb2::Future<GenericError>> ServerFamily::Load(string_view load_pat
   vector<fb2::Fiber> load_fibers;
   load_fibers.reserve(paths.size());
 
-  auto aggregated_result = std::make_shared<AggregateLoadResult>();
-
-  std::string snapshot_id;
-  if (absl::EndsWith(load_path, "summary.dfs")) {
+  LoadOptions load_opts;
+  if (absl::EndsWith(path, "summary.dfs")) {
     // we read summary first to get snapshot_id and load data correctly
-    auto load_result = pool.GetNextProactor()->Await(
-        [&] { return LoadRdb(std::string(load_path), existing_keys, &snapshot_id); });
-    if (!load_result.has_value())
-      aggregated_result->first_error = load_result.error();
+    error_code load_ec =
+        pool.GetNextProactor()->Await([&] { return LoadRdb(path, existing_keys, &load_opts); });
+    if (load_ec)
+      return immediate(load_ec);
   }
 
-  for (auto& path : paths) {
+  auto aggregated_result = std::make_shared<AggregateLoadResult>();
+
+  for (const auto& file : paths) {
     // we have already read summary so we skip it now
-    if (absl::EndsWith(path, "summary.dfs"))
+    if (absl::EndsWith(file, "summary.dfs"))
       continue;
+
     // For single file, choose thread that does not handle shards if possible.
     // This will balance out the CPU during the load.
     ProactorBase* proactor;
@@ -1168,15 +1158,13 @@ std::optional<fb2::Future<GenericError>> ServerFamily::Load(string_view load_pat
       proactor = pool.GetNextProactor();
     }
 
-    auto load_func = [this, aggregated_result, existing_keys, path = std::move(path),
-                      snapshot_id]() {
-      auto sid = snapshot_id;
-      auto load_result = LoadRdb(path, existing_keys, &sid);
-      DCHECK(sid == snapshot_id);
-      if (load_result.has_value())
-        aggregated_result->keys_read.fetch_add(*load_result);
-      else
-        aggregated_result->first_error = load_result.error();
+    auto load_func = [=]() mutable {
+      error_code load_ec = LoadRdb(file, existing_keys, &load_opts);
+      if (load_ec) {
+        aggregated_result->first_error = load_ec;
+      } else {
+        aggregated_result->keys_read.fetch_add(load_opts.num_loaded_keys, memory_order_relaxed);
+      }
     };
     load_fibers.push_back(proactor->LaunchFiber(std::move(load_func)));
   }
@@ -1238,40 +1226,42 @@ void ServerFamily::SnapshotScheduling() {
   }
 }
 
-io::Result<size_t> ServerFamily::LoadRdb(const std::string& rdb_file,
-                                         LoadExistingKeys existing_keys, std::string* snapshot_id) {
+std::error_code ServerFamily::LoadRdb(const std::string& rdb_file, LoadExistingKeys existing_keys,
+                                      LoadOptions* load_opts) {
+  DCHECK(load_opts);
   VLOG(1) << "Loading data from " << rdb_file;
   CHECK(fb2::ProactorBase::IsProactorThread()) << "must be called from proactor thread";
 
-  std::string filt_snapshot_id = snapshot_id ? *snapshot_id : "";
+  const std::string& filt_snapshot_id = load_opts->snapshot_id;
 
-  io::Result<size_t> result;
   ProactorBase* proactor = fb2::ProactorBase::me();
+  error_code result;
   auto fb = proactor->LaunchFiber([&] {
     io::ReadonlyFileOrError res = snapshot_storage_->OpenReadFile(rdb_file);
     if (!res) {
-      result = nonstd::make_unexpected(res.error());
+      result = res.error();
       return;
     }
 
     io::FileSource fs(*res);
 
     RdbLoader loader{&service_, filt_snapshot_id};
+    loader.SetShardCount(load_opts->shard_count);
     if (existing_keys == LoadExistingKeys::kOverride) {
       loader.SetOverrideExistingKeys(true);
     }
 
     auto ec = loader.Load(&fs);
-    // we ignore incorrect_snapshot_id, it means we try to load file not from the snapshot
-    if (ec && (ec.value() != rdb::errc::incorrect_snapshot_id)) {
-      result = nonstd::make_unexpected(ec);
+    if (ec) {
+      // We ignore incorrect_snapshot_id, it means we try to load file from incorrect snapshot.
+      if (ec.value() != rdb::errc::incorrect_snapshot_id)
+        result = ec;
     } else {
       VLOG(1) << "Done loading RDB from " << rdb_file << ", keys loaded: " << loader.keys_loaded();
       VLOG(1) << "Loading finished after " << strings::HumanReadableElapsedTime(loader.load_time());
-      result = loader.keys_loaded();
-      if (snapshot_id && snapshot_id->empty()) {
-        *snapshot_id = loader.GetSnapshotId();
-      }
+      load_opts->num_loaded_keys = loader.keys_loaded();
+      load_opts->snapshot_id = loader.GetSnapshotId();
+      load_opts->shard_count = loader.shard_count();
     }
   });
 
@@ -1279,7 +1269,7 @@ io::Result<size_t> ServerFamily::LoadRdb(const std::string& rdb_file,
   return result;
 }
 
-enum MetricType { COUNTER, GAUGE, SUMMARY, HISTOGRAM };
+enum MetricType : uint8_t { COUNTER, GAUGE, SUMMARY, HISTOGRAM };
 
 const char* MetricTypeName(MetricType type) {
   switch (type) {

--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -49,12 +49,14 @@ struct Entry;
 // over the sink until explicitly stopped.
 class SliceSnapshot : public journal::JournalConsumerInterface {
  public:
-  // Represents a target for receiving snapshot data.
+  // Represents a target sink for receiving snapshot data. Specifically designed
+  // to send data to RdbSaver wrapping up a file shard or a socket.
   struct SnapshotDataConsumerInterface {
     virtual ~SnapshotDataConsumerInterface() = default;
 
     // Receives a chunk of snapshot data for processing
     virtual void ConsumeData(std::string data, ExecutionState* cntx) = 0;
+
     // Finalizes the snapshot writing
     virtual void Finalize() = 0;
   };


### PR DESCRIPTION
This PR adds aux-strings to the header of dfs files.
aux-strings do not break compatibility and potentially provide
better memory management and consistency checks during the snapshot load.

All in all this PR should not change functionality or compatibility
with older Dragonfly versons.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->