### PR TITLE
Lua library Integer overflow can cause the DragonFly crash. (CVE-2020-14147)

### DIFF
--- a/src/core/interpreter_test.cc
+++ b/src/core/interpreter_test.cc
@@ -522,4 +522,8 @@ TEST_F(InterpreterTest, AvoidIntOverflow) {
   EXPECT_EQ("str(0000FFFF)", ser_.res);
 }
 
+TEST_F(InterpreterTest, LuaIntOverflow) {
+  EXPECT_FALSE(Execute("EVAL \"struct.pack('>I2147483648', '10')\" 0"));
+}
+
 }  // namespace dfly

--- a/src/redis/lua/struct/lua_struct.c
+++ b/src/redis/lua/struct/lua_struct.c
@@ -82,18 +82,19 @@ typedef struct Header {
 } Header;
 
 
-static int getnum (const char **fmt, int df) {
+static int getnum (lua_State *L, const char **fmt, int df) {
   if (!isdigit(**fmt))  /* no number? */
     return df;  /* return default value */
   else {
     int a = 0;
     do {
+      if (a > (INT_MAX / 10) || a * 10 > (INT_MAX - (**fmt - '0')))
+        luaL_error(L, "integral size overflow");
       a = a*10 + *((*fmt)++) - '0';
     } while (isdigit(**fmt));
     return a;
   }
 }
-
 
 #define defaultoptions(h)	((h)->endian = native.endian, (h)->align = 1)
 
@@ -108,9 +109,9 @@ static size_t optsize (lua_State *L, char opt, const char **fmt) {
     case 'f':  return sizeof(float);
     case 'd':  return sizeof(double);
     case 'x': return 1;
-    case 'c': return  getnum(fmt, 1);
+    case 'c': return  getnum(L, fmt, 1);
     case 'i': case 'I': {
-      int sz = getnum(fmt, sizeof(int));
+      int sz = getnum(L, fmt, sizeof(int));
       if (sz > MAXINTSIZE)
         luaL_error(L, "integral size %d is larger than limit of %d",
                        sz, MAXINTSIZE);
@@ -143,7 +144,7 @@ static void controloptions (lua_State *L, int opt, const char **fmt,
     case '>': h->endian = BIG; return;
     case '<': h->endian = LITTLE; return;
     case '!': {
-      int a = getnum(fmt, MAXALIGN);
+      int a = getnum(L, fmt, MAXALIGN);
       if (!isp2(a))
         luaL_error(L, "alignment %d is not a power of 2", a);
       h->align = a;


### PR DESCRIPTION
This issue is related to #4996:

### **Describe the bug**

- CVE-2020-14147 was originally discovered in Redis, and the same vulnerability is reproducible in Dragonfly.
- The issue is an **integer overflow** that can lead to a **stack-based buffer overflow**.
- According to the Redis security advisory, this vulnerability can cause memory corruption, crashes (denial of service), or potentially allow bypassing of Lua sandbox restrictions.
- In Redis, this bug is a **reintroduction** of an older vulnerability, **CVE-2015-8080**, which had been previously patched.
- However, during a full Lua update in Redis, the original patch was unintentionally removed.
- In Dragonfly's PR [[[#4996](https://github.com/dragonflydb/dragonfly/pull/4996)](https://github.com/dragonflydb/dragonfly/pull/4996)](https://github.com/dragonflydb/dragonfly/pull/4996), the same mistake appears to have occurred: the PR author misunderstood the purpose of the original patch and removed it, leading to a reintroduction of the vulnerability.

### Aditional Information

**In Local**

- Draonfly version : **v1.31.0**
- Operating system : Linux
- Operating system, version and so on : Ubuntu 22.04.5 LTS 64bit

```bash
 ./dragonfly
                   .--::--.
   :+*=:          =@@@@@@@@=          :+*+:
  %@@@@@@%*=.     =@@@@@@@@-     .=*%@@@@@@#
  @@@@@@@@@@@@#+-. .%@@@@#. .-+#@@@@@@@@@@@%
  -@@@@@@@@@@@@@@@@*:#@@#:*@@@@@@@@@@@@@@@@-
    :+*********####-%@%%@%-####********++.
   .%@@@@@@@@@@@@@%:@@@@@@:@@@@@@@@@@@@@@%
   .@@@@@@@@%*+-:   =@@@@=  .:-+*%@@@@@@@%.
     =*+-:           ###*          .:-+*=
                     %@@%
                     *@@*
                     +@@=
                     :##:
                     :@@:
                      @@
                      ..
* Logs will be written to the first available of the following paths:
/tmp/dragonfly.*
./dragonfly.*
* For the available flags type dragonfly [--help | --helpfull]
* Documentation can be found at: <https://www.dragonflydb.io/docs>
*** SIGSEGV received at time=1751703721 on cpu 0 ***
PC: @     0x5e85b4978cb0  (unknown)  b_pack
Segmentation fault (core dumped)

```

- After the attack, the server disconnected.

```bash
$ redis-cli
127.0.0.1:6379> ping
PONG
127.0.0.1:6379>  EVAL "return bit.tohex(65535, -2147483648)" 0 //Payload
Could not connect to Redis at 127.0.0.1:6379: Connection refused
not connected>

```

**To reproduce**

To reproduce this error:

- Send this payload to the server.

```bash
EVAL "struct.pack('>I2147483648', '10')" 0

```

- Redis clients will be disconnected because of a crash.

### Details

Located in src/redis/lua/struct/lua_struct.c

```c

static int getnum (const char **fmt, int df) {
  if (!isdigit(**fmt))  /* no number? */
    return df;  /* return default value */
  else {
    int a = 0;
    do {
      a = a*10 + *((*fmt)++) - '0';
    } while (isdigit(**fmt));
    return a;
  }
}

```

- If the input number is very large, this calculation can cause an **integer overflow**.
- There is **no overflow check**, so the value of `a` can wrap around silently.
- If the result is later used for memory allocation or indexing, it may lead to a **stack-based buffer overflow**.
- The original `getnum` function is vulnerable to **integer overflow** when parsing large numbers.
- To fix it, an explicit overflow check is added **before** the multiplication:

```c
static int getnum (lua_State *L, const char **fmt, int df) {
  if (!isdigit(**fmt))  /* no number? */
    return df;  /* return default value */
  else {
    int a = 0;
    do {
			if (a > (INT_MAX / 10) || a * 10 > (INT_MAX - (**fmt - '0')))
			luaL_error(L, "integral size overflow");
			a = a*10 + *((*fmt)++) - '0';
    } while (isdigit(**fmt));
    return a;
  }

```

- This patch effectively mitigates the issue behind **CVE-2015-8080** and **CVE-2020-14147**.

### Solution

- Add the following code above line #L92,#L98~99, L#120, L#122, L#155, as shown in the redis commit.
    - https://github.com/redis/redis/commit/ef764dde1cca2f25d00686673d1bc89448819571#diff-7d9044671715bf8350ad8c1b3de56da474372e6a95fe5834cbb8a0104cb0cc96

```c
if (a > (INT_MAX / 10) || a * 10 > (INT_MAX - (**fmt - '0')))

```

- This code is a condition that prevents integer overflow.

```bash
127.0.0.1:6379> EVAL "struct.pack('>I2147483648', '10')" 0
(error) ERR Error running script (call to 0ba5d6867f8a0d59c13d2ee49dc170ebdb2889d7): @user_script:2: user_script:2: integral size overflow
127.0.0.1:6379> 
```

```bash
$ ./dragonfly
                   .--::--.                   
   :+*=:          =@@@@@@@@=          :+*+:   
  %@@@@@@%*=.     =@@@@@@@@-     .=*%@@@@@@#  
  @@@@@@@@@@@@#+-. .%@@@@#. .-+#@@@@@@@@@@@%  
  -@@@@@@@@@@@@@@@@*:#@@#:*@@@@@@@@@@@@@@@@-  
    :+*********####-%@%%@%-####********++.    
   .%@@@@@@@@@@@@@%:@@@@@@:@@@@@@@@@@@@@@%    
   .@@@@@@@@%*+-:   =@@@@=  .:-+*%@@@@@@@%.   
     =*+-:           ###*          .:-+*=     
                     %@@%                     
                     *@@*                     
                     +@@=                     
                     :##:                     
                     :@@:                     
                      @@                      
                      ..                      
* Logs will be written to the first available of the following paths:
/tmp/dragonfly.*
./dragonfly.*
* For the available flags type dragonfly [--help | --helpfull]
* Documentation can be found at: https://www.dragonflydb.io/docs
```

- After applying this code, here's what happens during an attack.
- Adding a check to stop integer overflow prevents the stack buffer from overflowing.