### PR TITLE
feat(search_family): Add BLOCKSIZE option for FT.CREATE

### DIFF
--- a/src/core/search/indices.cc
+++ b/src/core/search/indices.cc
@@ -94,7 +94,8 @@ void IterateAllSuffixes(const absl::flat_hash_set<string>& words,
 
 class RangeTreeAdapter : public NumericIndex::RangeTreeBase {
  public:
-  explicit RangeTreeAdapter(PMR_NS::memory_resource* mr) : range_tree_{mr} {
+  explicit RangeTreeAdapter(size_t max_range_block_size, PMR_NS::memory_resource* mr)
+      : range_tree_(mr, max_range_block_size) {
   }
 
   void Add(DocId id, absl::Span<double> values) override {
@@ -192,9 +193,9 @@ class BtreeSetImpl : public NumericIndex::RangeTreeBase {
   absl::btree_set<Entry, std::less<Entry>, PMR_NS::polymorphic_allocator<Entry>> entries_;
 };
 
-NumericIndex::NumericIndex(PMR_NS::memory_resource* mr) {
+NumericIndex::NumericIndex(size_t max_range_block_size, PMR_NS::memory_resource* mr) {
   if (absl::GetFlag(FLAGS_use_numeric_range_tree)) {
-    range_tree_ = make_unique<RangeTreeAdapter>(mr);
+    range_tree_ = make_unique<RangeTreeAdapter>(max_range_block_size, mr);
   } else {
     range_tree_ = make_unique<BtreeSetImpl>(mr);
   }

--- a/src/core/search/indices.h
+++ b/src/core/search/indices.h
@@ -46,7 +46,9 @@ struct NumericIndex : public BaseIndex {
     virtual ~RangeTreeBase() = default;
   };
 
-  explicit NumericIndex(PMR_NS::memory_resource* mr);
+  // max_range_block_size is the maximum number of entries in a single range block.
+  // It is used in RangeTree. Check RangeTree for details.
+  explicit NumericIndex(size_t max_range_block_size, PMR_NS::memory_resource* mr);
 
   bool Add(DocId id, const DocumentAccessor& doc, std::string_view field) override;
   void Remove(DocId id, const DocumentAccessor& doc, std::string_view field) override;

--- a/src/core/search/range_tree.h
+++ b/src/core/search/range_tree.h
@@ -40,7 +40,7 @@ class RangeTree {
   using Map = absl::btree_map<Key, RangeBlock, std::less<Key>,
                               PMR_NS::polymorphic_allocator<std::pair<const Key, RangeBlock>>>;
 
-  static constexpr size_t kDefaultMaxRangeBlockSize = 500000;
+  static constexpr size_t kDefaultMaxRangeBlockSize = 7000;
   static constexpr size_t kBlockSize = 400;
 
   explicit RangeTree(PMR_NS::memory_resource* mr,

--- a/src/core/search/range_tree.h
+++ b/src/core/search/range_tree.h
@@ -40,10 +40,11 @@ class RangeTree {
   using Map = absl::btree_map<Key, RangeBlock, std::less<Key>,
                               PMR_NS::polymorphic_allocator<std::pair<const Key, RangeBlock>>>;
 
-  static constexpr size_t kMaxRangeBlockSize = 500000;
+  static constexpr size_t kDefaultMaxRangeBlockSize = 500000;
   static constexpr size_t kBlockSize = 400;
 
-  explicit RangeTree(PMR_NS::memory_resource* mr, size_t max_range_block_size = kMaxRangeBlockSize);
+  explicit RangeTree(PMR_NS::memory_resource* mr,
+                     size_t max_range_block_size = kDefaultMaxRangeBlockSize);
 
   // Adds a document with a value to the index.
   void Add(DocId id, double value);

--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -568,9 +568,11 @@ void FieldIndices::CreateIndices(PMR_NS::memory_resource* mr) {
             make_unique<TextIndex>(mr, &options_.stopwords, synonyms_, tparams.with_suffixtrie);
         break;
       }
-      case SchemaField::NUMERIC:
-        indices_[field_ident] = make_unique<NumericIndex>(mr);
+      case SchemaField::NUMERIC: {
+        const auto& nparams = std::get<SchemaField::NumericParams>(field_info.special_params);
+        indices_[field_ident] = make_unique<NumericIndex>(nparams.block_size, mr);
         break;
+      }
       case SchemaField::TAG: {
         const auto& tparams = std::get<SchemaField::TagParams>(field_info.special_params);
         indices_[field_ident] = make_unique<TagIndex>(mr, tparams);

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -16,6 +16,7 @@
 
 #include "base/pmr/memory_resource.h"
 #include "core/search/base.h"
+#include "core/search/range_tree.h"
 #include "core/search/synonyms.h"
 
 namespace dfly::search {
@@ -49,7 +50,14 @@ struct SchemaField {
     bool with_suffixtrie = false;
   };
 
-  using ParamsVariant = std::variant<std::monostate, VectorParams, TagParams, TextParams>;
+  struct NumericParams {
+    // Block size of the range tree
+    // Check RangeTree for details.
+    size_t block_size = RangeTree::kDefaultMaxRangeBlockSize;
+  };
+
+  using ParamsVariant =
+      std::variant<std::monostate, VectorParams, TagParams, TextParams, NumericParams>;
 
   FieldType type;
   uint8_t flags;

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -167,6 +167,9 @@ string DocIndexInfo::BuildRestoreCommand() const {
                     [out = &out](const search::SchemaField::TextParams& params) {
                       if (params.with_suffixtrie)
                         absl::StrAppend(out, " ", "WITH_SUFFIXTRIE");
+                    },
+                    [out = &out](const search::SchemaField::NumericParams& params) {
+                      absl::StrAppend(out, " ", "BLOCKSIZE", " ", params.block_size);
                     }};
     visit(info, finfo.special_params);
   }

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -144,34 +144,34 @@ string DocIndexInfo::BuildRestoreCommand() const {
     absl::StrAppend(&out, " ", fident, " AS ", finfo.short_name, " ",
                     SearchFieldTypeToString(finfo.type));
 
+    // Store specific params
+    Overloaded info{
+        [](monostate) {},
+        [out = &out](const search::SchemaField::VectorParams& params) {
+          auto sim = params.sim == search::VectorSimilarity::L2 ? "L2" : "COSINE";
+          absl::StrAppend(out, " ", params.use_hnsw ? "HNSW" : "FLAT", " 6 ", "DIM ", params.dim,
+                          " DISTANCE_METRIC ", sim, " INITIAL_CAP ", params.capacity);
+        },
+        [out = &out](const search::SchemaField::TagParams& params) {
+          absl::StrAppend(out, " ", "SEPARATOR", " ", string{params.separator});
+          if (params.case_sensitive)
+            absl::StrAppend(out, " ", "CASESENSITIVE");
+        },
+        [out = &out](const search::SchemaField::TextParams& params) {
+          if (params.with_suffixtrie)
+            absl::StrAppend(out, " ", "WITH_SUFFIXTRIE");
+        },
+        [out = &out](const search::SchemaField::NumericParams& params) {
+          absl::StrAppend(out, " ", "BLOCKSIZE", " ", std::to_string(params.block_size));
+        }};
+    visit(info, finfo.special_params);
+
     // Store shared field flags
     if (finfo.flags & search::SchemaField::SORTABLE)
       absl::StrAppend(&out, " SORTABLE");
 
     if (finfo.flags & search::SchemaField::NOINDEX)
       absl::StrAppend(&out, " NOINDEX");
-
-    // Store specific params
-    Overloaded info{[](monostate) {},
-                    [out = &out](const search::SchemaField::VectorParams& params) {
-                      auto sim = params.sim == search::VectorSimilarity::L2 ? "L2" : "COSINE";
-                      absl::StrAppend(out, " ", params.use_hnsw ? "HNSW" : "FLAT", " 6 ", "DIM ",
-                                      params.dim, " DISTANCE_METRIC ", sim, " INITIAL_CAP ",
-                                      params.capacity);
-                    },
-                    [out = &out](const search::SchemaField::TagParams& params) {
-                      absl::StrAppend(out, " ", "SEPARATOR", " ", string{params.separator});
-                      if (params.case_sensitive)
-                        absl::StrAppend(out, " ", "CASESENSITIVE");
-                    },
-                    [out = &out](const search::SchemaField::TextParams& params) {
-                      if (params.with_suffixtrie)
-                        absl::StrAppend(out, " ", "WITH_SUFFIXTRIE");
-                    },
-                    [out = &out](const search::SchemaField::NumericParams& params) {
-                      absl::StrAppend(out, " ", "BLOCKSIZE", " ", params.block_size);
-                    }};
-    visit(info, finfo.special_params);
   }
 
   return out;

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -134,6 +134,14 @@ ParseResult<search::SchemaField::TextParams> ParseTextParams(CmdArgParser* parse
   return params;
 }
 
+search::SchemaField::NumericParams ParseNumericParams(CmdArgParser* parser) {
+  search::SchemaField::NumericParams params{};
+  if (parser->Check("BLOCKSIZE")) {
+    params.block_size = parser->Next<size_t>();
+  }
+  return params;
+}
+
 // breaks on ParamsVariant initialization
 #ifndef __clang__
 #pragma GCC diagnostic push
@@ -160,7 +168,7 @@ ParsedSchemaField ParseText(CmdArgParser* parser) {
 }
 
 ParsedSchemaField ParseNumeric(CmdArgParser* parser) {
-  return std::make_pair(search::SchemaField::NUMERIC, std::monostate{});
+  return std::make_pair(search::SchemaField::NUMERIC, ParseNumericParams(parser));
 }
 
 // Vector fields include: {algorithm} num_args args...

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -789,15 +789,22 @@ void SearchFamily::FtInfo(CmdArgList args, const CommandContext& cmd_cntx) {
     vector<string> info;
 
     string_view base[] = {"identifier"sv, string_view{field_ident},
-                          "attribute",    field_info.short_name,
+                          "attribute"sv,  field_info.short_name,
                           "type"sv,       SearchFieldTypeToString(field_info.type)};
     info.insert(info.end(), base, base + ABSL_ARRAYSIZE(base));
 
     if (field_info.flags & search::SchemaField::NOINDEX)
-      info.push_back("NOINDEX");
+      info.emplace_back("NOINDEX"sv);
 
     if (field_info.flags & search::SchemaField::SORTABLE)
-      info.push_back("SORTABLE");
+      info.emplace_back("SORTABLE"sv);
+
+    if (field_info.type == search::SchemaField::NUMERIC) {
+      auto& numeric_params =
+          std::get<search::SchemaField::NumericParams>(field_info.special_params);
+      info.emplace_back("blocksize"sv);
+      info.emplace_back(std::to_string(numeric_params.block_size));
+    }
 
     rb->SendSimpleStrArr(info);
   }

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -2724,10 +2724,10 @@ TEST_F(SearchFamilyTest, BlockSizeOptionFtCreate) {
   // Verify that the index was created successfully
   resp = Run({"FT.INFO", "index"});
   EXPECT_THAT(resp, IsArray(_, _, _, _, "attributes",
-                            IsArray(IsArray("identifier", "number2", "attribute", "number2", "type",
-                                            "NUMERIC", "blocksize", "1024"),
-                                    IsArray("identifier", "number1", "attribute", "number1", "type",
-                                            "NUMERIC", "blocksize", "2")),
+                            IsUnordArray(IsArray("identifier", "number1", "attribute", "number1",
+                                                 "type", "NUMERIC", "blocksize", "2"),
+                                         IsArray("identifier", "number2", "attribute", "number2",
+                                                 "type", "NUMERIC", "blocksize", "1024")),
                             "num_docs", IntArg(0)));
 
   // Add a document to the index

--- a/tests/dragonfly/search_test.py
+++ b/tests/dragonfly/search_test.py
@@ -134,14 +134,25 @@ async def test_management(async_client: aioredis.Redis):
     assert i1info["num_docs"] == 10
     assert sorted(i1info["attributes"]) == [
         ["identifier", "f1", "attribute", "f1", "type", "TEXT"],
-        ["identifier", "f2", "attribute", "f2", "type", "NUMERIC", "SORTABLE"],
+        ["identifier", "f2", "attribute", "f2", "type", "NUMERIC", "SORTABLE", "blocksize", "7000"],
     ]
 
     i2info = await i2.info()
     assert i2info["index_definition"] == ["key_type", "HASH", "prefix", "p2"]
     assert i2info["num_docs"] == 15
     assert sorted(i2info["attributes"]) == [
-        ["identifier", "f3", "attribute", "f3", "type", "NUMERIC", "NOINDEX", "SORTABLE"],
+        [
+            "identifier",
+            "f3",
+            "attribute",
+            "f3",
+            "type",
+            "NUMERIC",
+            "NOINDEX",
+            "SORTABLE",
+            "blocksize",
+            "7000",
+        ],
         ["identifier", "f4", "attribute", "f4", "type", "TAG"],
         ["identifier", "f5", "attribute", "f5", "type", "VECTOR"],
     ]


### PR DESCRIPTION
Introduce the BLOCKSIZE option for numeric fields in the FT.CREATE command.

This option allows fine-grained control over the block size used by the range tree for each numeric index independently.

**How to use it?**
To control the latency of your range queries, you can use the `BLOCKSIZE` option. If you know the average number of documents matched by your range queries, setting the block size close to that average can significantly speed them up.

Setting the block size higher or lower does not necessarily mean your queries will be faster or slower — it depends on the actual results of your range queries.

**Tip:**
To estimate how many documents your query matches, you can use the `FT.PROFILE` command. After collecting some statistics, you can then tune the BLOCKSIZE accordingly for optimal performance.

**Example of query**
Example of query: `FT.CREATE index ON HASH SCHEMA number1 NUMERIC BLOCKSIZE 2 number2 NUMERIC BLOCKSIZE 1024`.
You can also use `FT.INFO index` to get info about blocksize of the numeric index:
```
127.0.0.1:6379> FT.INFO index
...
5) attributes
6) 1) 1) identifier
      2) number2
      3) attribute
      4) number2
      5) type
      6) NUMERIC
      7) blocksize
      8) 1024
   2) 1) identifier
      2) number1
      3) attribute
      4) number1
      5) type
      6) NUMERIC
      7) blocksize
      8) 2
```