### PR TITLE
feat(search_family): Introduce SingleBlockRangeResult and TwoBlocksRangeResult

### DIFF
--- a/src/core/search/indices.cc
+++ b/src/core/search/indices.cc
@@ -109,12 +109,13 @@ class RangeTreeAdapter : public NumericIndex::RangeTreeBase {
     }
   }
 
-  vector<DocId> Range(double l, double r) const override {
-    return range_tree_.Range(l, r).MergeAllResults();
+  std::variant<RangeResult, std::vector<DocId>> Range(double l, double r) const override {
+    return range_tree_.Range(l, r);
   }
 
   vector<DocId> GetAllDocIds() const override {
-    return range_tree_.GetAllDocIds().MergeAllResults();
+    // TODO: remove take
+    return range_tree_.GetAllDocIds().Take();
   }
 
  private:
@@ -141,7 +142,7 @@ class BtreeSetImpl : public NumericIndex::RangeTreeBase {
     }
   }
 
-  vector<DocId> Range(double l, double r) const override {
+  std::variant<RangeResult, std::vector<DocId>> Range(double l, double r) const override {
     DCHECK(l <= r);
 
     auto it_l = entries_.lower_bound({l, 0});
@@ -214,9 +215,9 @@ void NumericIndex::Remove(DocId id, const DocumentAccessor& doc, string_view fie
   range_tree_->Remove(id, absl::MakeSpan(numbers));
 }
 
-vector<DocId> NumericIndex::Range(double l, double r) const {
+std::variant<RangeResult, std::vector<DocId>> NumericIndex::Range(double l, double r) const {
   if (r < l)
-    return {};
+    return std::vector<DocId>{};
   return range_tree_->Range(l, r);
 }
 

--- a/src/core/search/indices.h
+++ b/src/core/search/indices.h
@@ -38,7 +38,7 @@ struct NumericIndex : public BaseIndex {
     virtual void Remove(DocId id, absl::Span<double> values) = 0;
 
     // Returns all DocIds that match the range [l, r].
-    virtual std::vector<DocId> Range(double l, double r) const = 0;
+    virtual std::variant<RangeResult, std::vector<DocId>> Range(double l, double r) const = 0;
 
     // Returns all DocIds that have non-null values in the index.
     virtual std::vector<DocId> GetAllDocIds() const = 0;
@@ -51,7 +51,7 @@ struct NumericIndex : public BaseIndex {
   bool Add(DocId id, const DocumentAccessor& doc, std::string_view field) override;
   void Remove(DocId id, const DocumentAccessor& doc, std::string_view field) override;
 
-  std::vector<DocId> Range(double l, double r) const;
+  std::variant<RangeResult, std::vector<DocId>> Range(double l, double r) const;
 
   std::vector<DocId> GetAllDocsWithNonNullValues() const override;
 

--- a/src/core/search/range_tree.h
+++ b/src/core/search/range_tree.h
@@ -53,8 +53,12 @@ class RangeTree {
 
   // Returns all documents with values in the range [l, r].
   RangeResult Range(double l, double r) const;
+  // Same as Range, but returns the blocks that contain the results.
+  absl::InlinedVector<const RangeBlock*, 5> RangeBlocks(double l, double r) const;
 
   RangeResult GetAllDocIds() const;
+  // Returns all blocks in the tree.
+  absl::InlinedVector<const RangeBlock*, 5> GetAllBlocks() const;
 
  private:
   Map::iterator FindRangeBlock(double value);
@@ -71,26 +75,290 @@ class RangeTree {
   Map entries_;
 };
 
+/* This iterator filters out entries that are not in the range [l, r].
+   It is used to iterate over the RangeBlock and return only the entries
+   that are within the specified range.
+   The iterator is initialized with a range [l, r] and will skip entries
+   that are outside this range. */
+class RangeFilterIterator {
+ private:
+  using RangeBlock = RangeTree::RangeBlock;
+  using BaseIterator = RangeBlock::BlockListIterator;
+
+ public:
+  using iterator_category = BaseIterator::iterator_category;
+  using difference_type = BaseIterator::difference_type;
+  using value_type = DocId;
+  using pointer = value_type*;
+  using reference = value_type&;
+
+  RangeFilterIterator(BaseIterator begin, BaseIterator end, double l, double r);
+
+  value_type operator*() const;
+
+  RangeFilterIterator& operator++();
+
+  bool operator==(const RangeFilterIterator& other) const;
+  bool operator!=(const RangeFilterIterator& other) const;
+
+  bool HasReachedEnd() const;
+
+ private:
+  void SkipInvalidEntries(DocId last_id);
+
+  bool InRange(BaseIterator it) const;
+
+  double l_, r_;
+  BaseIterator current_, end_;
+};
+
+RangeFilterIterator MakeBegin(const RangeTree::RangeBlock& block, double l, double r);
+RangeFilterIterator MakeEnd(const RangeTree::RangeBlock& block, double l, double r);
+
+/* Separate class for merging results from a single RangeBlock.
+   It provides an iterator interface to iterate over the entries in the block
+   that are within the specified range [l, r].
+   This is used when the result of a range query is contained within a single block.
+
+   It is needed to avoid unnecessary complexity in the RangeResult class,
+   which can handle both single and multiple blocks.
+   It provides better performance and clarity when dealing with single block results. */
+class SingleBlockRangeResult {
+ public:
+  SingleBlockRangeResult(const RangeTree::RangeBlock* block, double l, double r);
+
+  RangeFilterIterator begin() const;
+  RangeFilterIterator end() const;
+
+  size_t size() const;
+
+ private:
+  double l_;
+  double r_;
+  const RangeTree::RangeBlock* block_ = nullptr;
+};
+
+/* Separate class for merging results from two RangeBlocks.
+   It provides an iterator interface to iterate over the entries in both blocks
+   that are within the specified range [l, r].
+   It automatically merges the results from both blocks and provides a unified view.
+   This is used when the result of a range query spans two blocks.
+
+   It provides a more efficient way to handle results that span multiple blocks,
+   avoiding unnecessary complexity in the RangeResult class.
+   TODO: Implement efficient merging for more than two blocks and remove this class. */
+class TwoBlocksRangeResult {
+ public:
+  TwoBlocksRangeResult(const RangeTree::RangeBlock* left_block,
+                       const RangeTree::RangeBlock* right_block, double l, double r);
+
+  size_t size() const;
+
+  class MergingIterator {
+   private:
+    static constexpr DocId kInvalidDocId = std::numeric_limits<DocId>::max();
+
+   public:
+    using iterator_category = RangeFilterIterator::iterator_category;
+    using difference_type = RangeFilterIterator::difference_type;
+    using value_type = RangeFilterIterator::value_type;
+    using pointer = RangeFilterIterator::pointer;
+    using reference = RangeFilterIterator::reference;
+
+    MergingIterator(RangeFilterIterator l, RangeFilterIterator r);
+
+    value_type operator*() const;
+
+    MergingIterator& operator++();
+
+    bool operator==(const MergingIterator& other) const;
+    bool operator!=(const MergingIterator& other) const;
+
+   private:
+    void InitializeMin();
+
+    DocId current_min_ = kInvalidDocId;
+    RangeFilterIterator l_;
+    RangeFilterIterator r_;
+  };
+
+  MergingIterator begin() const;
+  MergingIterator end() const;
+
+ private:
+  double l_;
+  double r_;
+  const RangeTree::RangeBlock* left_block_ = nullptr;
+  const RangeTree::RangeBlock* right_block_ = nullptr;
+};
+
+/* Represent the result of a range query on the RangeTree.
+   It can contain results from a single block, two blocks, or several blocks.
+   Several blocks are merged into a single result, which is represented by
+   vector<DocId>.
+
+   TODO: Implement efficient merging for more than two blocks */
 class RangeResult {
  private:
   using RangeBlockPointer = const RangeTree::RangeBlock*;
   using RangeBlockIterator = RangeTree::RangeBlock::BlockListIterator;
 
+  using DocsList = std::vector<DocId>;
+  using Variant = std::variant<DocsList, SingleBlockRangeResult, TwoBlocksRangeResult>;
+
  public:
   explicit RangeResult(absl::InlinedVector<RangeBlockPointer, 5> blocks);
   RangeResult(absl::InlinedVector<RangeBlockPointer, 5> blocks, double l, double r);
 
-  std::vector<DocId> MergeAllResults() const;
+  std::vector<DocId> Take();
 
-  // Used in tests
-  absl::InlinedVector<RangeBlockPointer, 5> GetBlocks() const {
-    return blocks_;
-  }
+  Variant& GetResult();
 
  private:
-  double l_ = -std::numeric_limits<double>::infinity();
-  double r_ = std::numeric_limits<double>::infinity();
-  absl::InlinedVector<RangeBlockPointer, 5> blocks_;
+  Variant result_;
 };
+
+// Implementation
+/******************************************************************/
+inline RangeFilterIterator::RangeFilterIterator(BaseIterator begin, BaseIterator end, double l,
+                                                double r)
+    : l_(l), r_(r), current_(begin), end_(end) {
+  SkipInvalidEntries(std::numeric_limits<DocId>::max());
+}
+
+inline RangeFilterIterator::value_type RangeFilterIterator::operator*() const {
+  return (*current_).first;
+}
+
+inline RangeFilterIterator& RangeFilterIterator::operator++() {
+  const DocId last_id = (*current_).first;
+  ++current_;
+  SkipInvalidEntries(last_id);
+  return *this;
+}
+
+inline bool RangeFilterIterator::operator==(const RangeFilterIterator& other) const {
+  return current_ == other.current_;
+}
+
+inline bool RangeFilterIterator::operator!=(const RangeFilterIterator& other) const {
+  return current_ != other.current_;
+}
+
+inline bool RangeFilterIterator::HasReachedEnd() const {
+  return current_ == end_;
+}
+
+inline void RangeFilterIterator::SkipInvalidEntries(DocId last_id) {
+  // Faster than using std::find_if
+  while (current_ != end_ && (!InRange(current_) || (*current_).first == last_id)) {
+    ++current_;
+  }
+}
+
+inline bool RangeFilterIterator::InRange(BaseIterator it) const {
+  return l_ <= (*it).second && (*it).second <= r_;
+}
+
+inline RangeFilterIterator MakeBegin(const RangeTree::RangeBlock& block, double l, double r) {
+  return {block.begin(), block.end(), l, r};
+}
+
+inline RangeFilterIterator MakeEnd(const RangeTree::RangeBlock& block, double l, double r) {
+  return {block.end(), block.end(), l, r};
+}
+
+inline SingleBlockRangeResult::SingleBlockRangeResult(const RangeTree::RangeBlock* block, double l,
+                                                      double r)
+    : l_(l), r_(r), block_(block) {
+  DCHECK(block_ != nullptr);
+}
+
+inline RangeFilterIterator SingleBlockRangeResult::begin() const {
+  return MakeBegin(*block_, l_, r_);
+}
+
+inline RangeFilterIterator SingleBlockRangeResult::end() const {
+  return MakeEnd(*block_, l_, r_);
+}
+
+inline size_t SingleBlockRangeResult::size() const {
+  return block_->Size();
+}
+
+inline TwoBlocksRangeResult::TwoBlocksRangeResult(const RangeTree::RangeBlock* left_block,
+                                                  const RangeTree::RangeBlock* right_block,
+                                                  double l, double r)
+    : l_(l), r_(r), left_block_(left_block), right_block_(right_block) {
+  DCHECK(left_block_ != nullptr);
+  DCHECK(right_block_ != nullptr);
+}
+
+inline size_t TwoBlocksRangeResult::size() const {
+  return left_block_->Size() + right_block_->Size();
+}
+
+inline TwoBlocksRangeResult::MergingIterator::MergingIterator(RangeFilterIterator l,
+                                                              RangeFilterIterator r)
+    : l_(std::move(l)), r_(std::move(r)) {
+  InitializeMin();
+}
+
+inline TwoBlocksRangeResult::MergingIterator::value_type
+TwoBlocksRangeResult::MergingIterator::operator*() const {
+  return current_min_;
+}
+
+inline TwoBlocksRangeResult::MergingIterator& TwoBlocksRangeResult::MergingIterator::operator++() {
+  auto increase_iterator = [&](RangeFilterIterator& it) {
+    ++it;
+    current_min_ = !it.HasReachedEnd() ? *it : std::numeric_limits<DocId>::max();
+  };
+
+  if (l_.HasReachedEnd()) {
+    increase_iterator(r_);
+  } else if (r_.HasReachedEnd()) {
+    increase_iterator(l_);
+  } else {
+    DCHECK(!l_.HasReachedEnd() && !r_.HasReachedEnd());
+    if (*l_ == current_min_) {
+      ++l_;
+    }
+    if (*r_ == current_min_) {
+      ++r_;
+    }
+    InitializeMin();
+  }
+
+  return *this;
+}
+
+inline bool TwoBlocksRangeResult::MergingIterator::operator==(
+    const TwoBlocksRangeResult::MergingIterator& other) const {
+  return l_ == other.l_ && r_ == other.r_;
+}
+
+inline bool TwoBlocksRangeResult::MergingIterator::operator!=(
+    const TwoBlocksRangeResult::MergingIterator& other) const {
+  return !(*this == other);
+}
+
+inline void TwoBlocksRangeResult::MergingIterator::InitializeMin() {
+  DocId left_value = !l_.HasReachedEnd() ? *l_ : std::numeric_limits<DocId>::max();
+  DocId right_value = !r_.HasReachedEnd() ? *r_ : std::numeric_limits<DocId>::max();
+  current_min_ = std::min(left_value, right_value);
+}
+
+inline TwoBlocksRangeResult::MergingIterator TwoBlocksRangeResult::begin() const {
+  return MergingIterator{MakeBegin(*left_block_, l_, r_), MakeBegin(*right_block_, l_, r_)};
+}
+
+inline TwoBlocksRangeResult::MergingIterator TwoBlocksRangeResult::end() const {
+  return MergingIterator{MakeEnd(*left_block_, l_, r_), MakeEnd(*right_block_, l_, r_)};
+}
+
+inline RangeResult::Variant& RangeResult::GetResult() {
+  return result_;
+}
 
 }  // namespace dfly::search


### PR DESCRIPTION
TODO: PR description


Before:

| Benchmark                                                   | Time (ns) | CPU (ns) | Iterations |
|-------------------------------------------------------------|-----------|----------|------------|
| BM_SearchSeveralNumericAndTagIndexes/num_docs:10000         |   345431  |  345381  |     2021    |
| BM_SearchSeveralNumericAndTagIndexes/num_docs:100000        |  3132211  | 3132008  |      224    |
| BM_SearchSeveralNumericAndTagIndexes/num_docs:1000000       | 45877866  |45861242  |       15    |


After:

| Benchmark                                                   | Time (ns) | CPU (ns) | Iterations |
|-------------------------------------------------------------|-----------|----------|------------|
| BM_SearchSeveralNumericAndTagIndexes/num_docs:10000         |   208139  |  208107  |     3352    |
| BM_SearchSeveralNumericAndTagIndexes/num_docs:100000        |  2642775  | 2642433  |      263    |
| BM_SearchSeveralNumericAndTagIndexes/num_docs:1000000       | 42896361  |42891550  |       17    |
