### PR TITLE
server_family: Support resetting latency histogram

### DIFF
--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -219,6 +219,13 @@ optional<facade::ErrorReply> CommandId::Validate(CmdArgList tail_args) const {
   return nullopt;
 }
 
+void CommandId::ResetStats(unsigned thread_index) {
+  command_stats_[thread_index] = {0, 0};
+  if (hdr_histogram* h = latency_histogram_; h != nullptr) {
+    hdr_reset(h);
+  }
+}
+
 hdr_histogram* CommandId::LatencyHist() const {
   return latency_histogram_;
 }

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -170,9 +170,7 @@ class CommandId : public facade::CommandId {
     return (last_key_ != first_key_) || (opt_mask_ & CO::VARIADIC_KEYS);
   }
 
-  void ResetStats(unsigned thread_index) {
-    command_stats_[thread_index] = {0, 0};
-  }
+  void ResetStats(unsigned thread_index);
 
   CmdCallStats GetStats(unsigned thread_index) const {
     return command_stats_[thread_index];

--- a/tests/dragonfly/server_family_test.py
+++ b/tests/dragonfly/server_family_test.py
@@ -236,6 +236,14 @@ async def test_latency_stats(async_client: aioredis.Redis):
         assert key in latency_stats
         assert latency_stats[key].keys() == {"p50", "p99", "p99.9"}
 
+    await async_client.config_resetstat()
+    latency_stats = await async_client.info("LATENCYSTATS")
+    # Only stats for the `config resetstat` command should remain in stats
+    assert (
+        len(latency_stats) == 1 and "latency_percentiles_usec_config" in latency_stats,
+        f"unexpected latency stats after reset: {latency_stats}",
+    )
+
 
 async def test_latency_stats_disabled_by_default(async_client: aioredis.Redis):
     for _ in range(100):


### PR DESCRIPTION
When command `config resetstat` is called, reset (clear out) all histograms for commands.