### PR TITLE
fix: acl log missing return after reply

### DIFF
--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -378,11 +378,11 @@ void AclFamily::Load(CmdArgList args, const CommandContext& cmd_cntx) {
 void AclFamily::Log(CmdArgList args, const CommandContext& cmd_cntx) {
   auto* rb = static_cast<facade::RedisReplyBuilder*>(cmd_cntx.rb);
   if (args.size() > 1) {
-    rb->SendError(facade::OpStatus::OUT_OF_RANGE);
+    return rb->SendError(facade::OpStatus::OUT_OF_RANGE);
   }
 
   size_t max_output = 10;
-  if (args.size() == 1) {
+  if (!args.empty()) {
     auto option = facade::ToSV(args[0]);
     if (absl::EqualsIgnoreCase(option, "RESET")) {
       pool_->AwaitFiberOnAll(
@@ -615,61 +615,6 @@ void AclFamily::DryRun(CmdArgList args, const CommandContext& cmd_cntx) {
 
   rb->SendBulkString(msg);
 }
-
-using MemberFunc = void (AclFamily::*)(CmdArgList args, const CommandContext& cmd_cntx);
-
-CommandId::Handler3 HandlerFunc(AclFamily* acl, MemberFunc f) {
-  return [=](CmdArgList args, const CommandContext& cmd_cntx) { return (acl->*f)(args, cmd_cntx); };
-}
-
-#define HFUNC(x) SetHandler(HandlerFunc(this, &AclFamily::x))
-
-constexpr uint32_t kAcl = acl::CONNECTION;
-constexpr uint32_t kList = acl::ADMIN | acl::SLOW | acl::DANGEROUS;
-constexpr uint32_t kSetUser = acl::ADMIN | acl::SLOW | acl::DANGEROUS;
-constexpr uint32_t kDelUser = acl::ADMIN | acl::SLOW | acl::DANGEROUS;
-constexpr uint32_t kWhoAmI = acl::SLOW;
-constexpr uint32_t kSave = acl::ADMIN | acl::SLOW | acl::DANGEROUS;
-constexpr uint32_t kLoad = acl::ADMIN | acl::SLOW | acl::DANGEROUS;
-constexpr uint32_t kLog = acl::ADMIN | acl::SLOW | acl::DANGEROUS;
-constexpr uint32_t kUsers = acl::ADMIN | acl::SLOW | acl::DANGEROUS;
-constexpr uint32_t kCat = acl::SLOW;
-constexpr uint32_t kGetUser = acl::ADMIN | acl::SLOW | acl::DANGEROUS;
-constexpr uint32_t kDryRun = acl::ADMIN | acl::SLOW | acl::DANGEROUS;
-constexpr uint32_t kGenPass = acl::SLOW;
-
-// We can't implement the ACL commands and its respective subcommands LIST, CAT, etc
-// the usual way, (that is, one command called ACL which then dispatches to the subcommand
-// based on the second argument) because each of the subcommands has different ACL
-// categories. Therefore, to keep it compatible with the CommandId, I need to treat them
-// as separate commands in the registry. This is the least intrusive change because it's very
-// easy to handle that case explicitly in `DispatchCommand`.
-
-void AclFamily::Register(dfly::CommandRegistry* registry) {
-  using CI = dfly::CommandId;
-  const uint32_t kAclMask = CO::ADMIN | CO::NOSCRIPT | CO::LOADING;
-  registry->StartFamily();
-  *registry << CI{"ACL", CO::NOSCRIPT | CO::LOADING, 0, 0, 0, acl::kAcl}.HFUNC(Acl);
-  *registry << CI{"ACL LIST", kAclMask, 1, 0, 0, acl::kList}.HFUNC(List);
-  *registry << CI{"ACL SETUSER", kAclMask, -2, 0, 0, acl::kSetUser}.HFUNC(SetUser);
-  *registry << CI{"ACL DELUSER", kAclMask, -2, 0, 0, acl::kDelUser}.HFUNC(DelUser);
-  *registry << CI{"ACL WHOAMI", kAclMask, 1, 0, 0, acl::kWhoAmI}.HFUNC(WhoAmI);
-  *registry << CI{"ACL SAVE", kAclMask, 1, 0, 0, acl::kSave}.HFUNC(Save);
-  *registry << CI{"ACL LOAD", kAclMask, 1, 0, 0, acl::kLoad}.HFUNC(Load);
-  *registry << CI{"ACL LOG", kAclMask, 0, 0, 0, acl::kLog}.HFUNC(Log);
-  *registry << CI{"ACL USERS", kAclMask, 1, 0, 0, acl::kUsers}.HFUNC(Users);
-  *registry << CI{"ACL CAT", kAclMask, -1, 0, 0, acl::kCat}.HFUNC(Cat);
-  *registry << CI{"ACL GETUSER", kAclMask, 2, 0, 0, acl::kGetUser}.HFUNC(GetUser);
-  *registry << CI{"ACL DRYRUN", kAclMask, 3, 0, 0, acl::kDryRun}.HFUNC(DryRun);
-  *registry << CI{"ACL GENPASS", CO::NOSCRIPT | CO::LOADING, -1, 0, 0, acl::kGenPass}.HFUNC(
-      GenPass);
-  cmd_registry_ = registry;
-
-  // build indexers
-  BuildIndexers(cmd_registry_->GetFamilies());
-}
-
-#undef HFUNC
 
 void AclFamily::Init(facade::Listener* main_listener, UserRegistry* registry) {
   main_listener_ = main_listener;
@@ -1212,5 +1157,60 @@ void AclFamily::BuildIndexers(RevCommandsIndexStore families) {
   }
   CategoryToIdx(std::move(idx_store));
 }
+
+using MemberFunc = void (AclFamily::*)(CmdArgList args, const CommandContext& cmd_cntx);
+
+CommandId::Handler3 HandlerFunc(AclFamily* acl, MemberFunc f) {
+  return [=](CmdArgList args, const CommandContext& cmd_cntx) { return (acl->*f)(args, cmd_cntx); };
+}
+
+#define HFUNC(x) SetHandler(HandlerFunc(this, &AclFamily::x))
+
+constexpr uint32_t kAcl = acl::CONNECTION;
+constexpr uint32_t kList = acl::ADMIN | acl::SLOW | acl::DANGEROUS;
+constexpr uint32_t kSetUser = acl::ADMIN | acl::SLOW | acl::DANGEROUS;
+constexpr uint32_t kDelUser = acl::ADMIN | acl::SLOW | acl::DANGEROUS;
+constexpr uint32_t kWhoAmI = acl::SLOW;
+constexpr uint32_t kSave = acl::ADMIN | acl::SLOW | acl::DANGEROUS;
+constexpr uint32_t kLoad = acl::ADMIN | acl::SLOW | acl::DANGEROUS;
+constexpr uint32_t kLog = acl::ADMIN | acl::SLOW | acl::DANGEROUS;
+constexpr uint32_t kUsers = acl::ADMIN | acl::SLOW | acl::DANGEROUS;
+constexpr uint32_t kCat = acl::SLOW;
+constexpr uint32_t kGetUser = acl::ADMIN | acl::SLOW | acl::DANGEROUS;
+constexpr uint32_t kDryRun = acl::ADMIN | acl::SLOW | acl::DANGEROUS;
+constexpr uint32_t kGenPass = acl::SLOW;
+
+// We can't implement the ACL commands and its respective subcommands LIST, CAT, etc
+// the usual way, (that is, one command called ACL which then dispatches to the subcommand
+// based on the second argument) because each of the subcommands has different ACL
+// categories. Therefore, to keep it compatible with the CommandId, I need to treat them
+// as separate commands in the registry. This is the least intrusive change because it's very
+// easy to handle that case explicitly in `DispatchCommand`.
+
+void AclFamily::Register(dfly::CommandRegistry* registry) {
+  using CI = dfly::CommandId;
+  const uint32_t kAclMask = CO::ADMIN | CO::NOSCRIPT | CO::LOADING;
+  registry->StartFamily();
+  *registry << CI{"ACL", CO::NOSCRIPT | CO::LOADING, 0, 0, 0, acl::kAcl}.HFUNC(Acl);
+  *registry << CI{"ACL LIST", kAclMask, 1, 0, 0, acl::kList}.HFUNC(List);
+  *registry << CI{"ACL SETUSER", kAclMask, -2, 0, 0, acl::kSetUser}.HFUNC(SetUser);
+  *registry << CI{"ACL DELUSER", kAclMask, -2, 0, 0, acl::kDelUser}.HFUNC(DelUser);
+  *registry << CI{"ACL WHOAMI", kAclMask, 1, 0, 0, acl::kWhoAmI}.HFUNC(WhoAmI);
+  *registry << CI{"ACL SAVE", kAclMask, 1, 0, 0, acl::kSave}.HFUNC(Save);
+  *registry << CI{"ACL LOAD", kAclMask, 1, 0, 0, acl::kLoad}.HFUNC(Load);
+  *registry << CI{"ACL LOG", kAclMask, 0, 0, 0, acl::kLog}.HFUNC(Log);
+  *registry << CI{"ACL USERS", kAclMask, 1, 0, 0, acl::kUsers}.HFUNC(Users);
+  *registry << CI{"ACL CAT", kAclMask, -1, 0, 0, acl::kCat}.HFUNC(Cat);
+  *registry << CI{"ACL GETUSER", kAclMask, 2, 0, 0, acl::kGetUser}.HFUNC(GetUser);
+  *registry << CI{"ACL DRYRUN", kAclMask, 3, 0, 0, acl::kDryRun}.HFUNC(DryRun);
+  *registry << CI{"ACL GENPASS", CO::NOSCRIPT | CO::LOADING, -1, 0, 0, acl::kGenPass}.HFUNC(
+      GenPass);
+  cmd_registry_ = registry;
+
+  // build indexers
+  BuildIndexers(cmd_registry_->GetFamilies());
+}
+
+#undef HFUNC
 
 }  // namespace dfly::acl

--- a/src/server/acl/acl_family_test.cc
+++ b/src/server/acl/acl_family_test.cc
@@ -558,4 +558,12 @@ TEST_F(AclFamilyTest, TestAlias) {
   EXPECT_EQ(Run({"ACL", "DRYRUN", "jarjar", "SET"}), "OK");
 }
 
+TEST_F(AclFamilyTest, TestAclLogUB) {
+  auto resp = Run({"ACL", "LOG"});
+  EXPECT_TRUE(resp.GetVec().empty());
+
+  resp = Run({"ACL", "LOG", "2", "RESET"});
+  EXPECT_THAT(resp, ErrArg("ERR index out of range"));
+}
+
 }  // namespace dfly


### PR DESCRIPTION
When `acl log` is called with more than one argument we replied twice because the error branch did not return.

* fix replying twice when acl log arguments overflow
* add test
* move registering acl functions at the end of the file