### PR TITLE
chore: allow initializing a separate huffman table for string values

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -363,7 +363,7 @@ struct TL {
   base::PODArray<uint8_t> tmp_buf;
   string tmp_str;
   size_t small_str_bytes;
-  Huffman huff_keys;
+  Huffman huff_keys, huff_string_values;
   uint64_t huff_encode_total = 0, huff_encode_success = 0;  // success/total metrics.
 };
 
@@ -736,6 +736,9 @@ bool CompactObj::InitHuffmanThreadLocal(HuffmanDomain domain, std::string_view h
   switch (domain) {
     case HUFF_KEYS:
       huffman = &tl.huff_keys;
+      break;
+    case HUFF_STRING_VALUES:
+      huffman = &tl.huff_string_values;
       break;
   }
 

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -397,6 +397,7 @@ class CompactObj {
 
   enum HuffmanDomain : uint8_t {
     HUFF_KEYS = 0,
+    HUFF_STRING_VALUES = 1,
     // TODO: add more domains.
   };
 

--- a/src/core/compact_object_test.cc
+++ b/src/core/compact_object_test.cc
@@ -654,13 +654,17 @@ TEST_F(CompactObjectTest, lpGetInteger) {
   lpFree(lp);
 }
 
-TEST_F(CompactObjectTest, HuffMan) {
+static void BuildEncoderAB(HuffmanEncoder* encoder) {
   array<unsigned, 256> hist;
   hist.fill(1);
   hist['a'] = 100;
   hist['b'] = 50;
+  CHECK(encoder->Build(hist.data(), hist.size() - 1, nullptr));
+}
+
+TEST_F(CompactObjectTest, HuffMan) {
   HuffmanEncoder encoder;
-  ASSERT_TRUE(encoder.Build(hist.data(), hist.size() - 1, nullptr));
+  BuildEncoderAB(&encoder);
   string bindata = encoder.Export();
   ASSERT_TRUE(CompactObj::InitHuffmanThreadLocal(CompactObj::HUFF_KEYS, bindata));
   for (unsigned i = 30; i < 2048; i += 10) {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -728,22 +728,27 @@ void SetHuffmanTable(const std::string& huffman_table) {
       continue;
     }
     string domain_str = absl::AsciiStrToUpper(kv[0]);
-    optional<CompactObj::HuffmanDomain> domain;
+    CompactObj::HuffmanDomain domain;
+
     if (domain_str == "KEYS") {
       domain = CompactObj::HUFF_KEYS;
+    } else if (domain_str == "STRINGS") {
+      domain = CompactObj::HUFF_STRING_VALUES;
     } else {
       LOG(ERROR) << "Unknown huffman domain: " << kv[0];
       continue;
     }
+
     string unescaped;
     if (!absl::Base64Unescape(kv[1], &unescaped)) {
       LOG(ERROR) << "Failed to decode base64 huffman table for domain " << kv[0] << " with value "
                  << kv[1];
       continue;
     }
+
     atomic_bool success = true;
     shard_set->RunBriefInParallel([&](auto* shard) {
-      if (!CompactObj::InitHuffmanThreadLocal(CompactObj::HUFF_KEYS, unescaped)) {
+      if (!CompactObj::InitHuffmanThreadLocal(domain, unescaped)) {
         success = false;
       }
     });


### PR DESCRIPTION
Before that, #4880 added huffman support for keys. This PR allows passing a separate table for string values. The table is not used by anything, so no functional changes are expected.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->