### PR TITLE
fix: add a sleep to relax slot migration process

### DIFF
--- a/src/server/journal/streamer.cc
+++ b/src/server/journal/streamer.cc
@@ -23,6 +23,9 @@ ABSL_FLAG(uint32_t, replication_stream_output_limit, 64_KB,
 
 ABSL_FLAG(uint32_t, migration_buckets_serialization_threshold, 100,
           "The Number of buckets to serialize on each iteration before yielding");
+ABSL_FLAG(uint32_t, migration_buckets_sleep_usec, 100,
+          "Sleep time in microseconds after each time we reach "
+          "migration_buckets_serialization_threshold");
 
 ABSL_FLAG(uint32_t, replication_dispatch_threshold, 1500,
           "Number of bytes to aggregate before replication");
@@ -39,6 +42,7 @@ iovec IoVec(io::Bytes src) {
 
 uint32_t replication_stream_output_limit_cached = 64_KB;
 uint32_t migration_buckets_serialization_threshold_cached = 100;
+uint32_t migration_buckets_sleep_usec_cached = 100;
 uint32_t replication_dispatch_threshold = 1500;
 uint32_t stalled_writer_base_period_ms = 10;
 
@@ -49,6 +53,7 @@ JournalStreamer::JournalStreamer(journal::Journal* journal, ExecutionState* cntx
     : cntx_(cntx), journal_(journal), is_stable_sync_(is_stable_sync), send_lsn_(send_lsn) {
   // cache the flag to avoid accessing it later.
   replication_stream_output_limit_cached = absl::GetFlag(FLAGS_replication_stream_output_limit);
+  migration_buckets_sleep_usec_cached = absl::GetFlag(FLAGS_migration_buckets_sleep_usec);
   replication_dispatch_threshold = absl::GetFlag(FLAGS_replication_dispatch_threshold);
   last_async_write_time_ = fb2::ProactorBase::GetMonotonicTimeNs() / 1000000;
 }
@@ -196,13 +201,42 @@ void JournalStreamer::ThrottleIfNeeded() {
   if (!cntx_->IsRunning() || !IsStalled())
     return;
 
-  auto next =
-      chrono::steady_clock::now() + chrono::milliseconds(absl::GetFlag(FLAGS_replication_timeout));
+  ++throttle_count_;
+  ++throttle_waiters_;
+
+  const auto start = chrono::steady_clock::now();
+  const auto next = start + chrono::milliseconds(absl::GetFlag(FLAGS_replication_timeout));
+  auto log_start = start;
   size_t inflight_start = in_flight_bytes_;
   size_t sent_start = total_sent_;
 
-  std::cv_status status =
-      waker_.await_until([this]() { return !IsStalled() || !cntx_->IsRunning(); }, next);
+  // Please note that ThrottleIfNeeded is unfair. Specifically with several producers pushing data
+  // to this JournalStreamer, one of them may be stalled and the other will be able to
+  // progress indefinitely. The stalled producer will be woken up only to verify again that the
+  // other one succeeded to push data before it.
+  // We currently do not solve this problem, but at least we will be more verbose about it.
+  std::cv_status status = waker_.await_until(
+      [&] {
+        bool finished = !IsStalled() || !cntx_->IsRunning();
+        if (finished)
+          return finished;
+
+        // Log every second that we are stalled and for how long.
+        auto current = chrono::steady_clock::now();
+        if (current - log_start > 1000ms) {
+          log_start = current;
+          LOG(WARNING) << "Waiting for "
+                       << chrono::duration_cast<chrono::milliseconds>(current - start).count()
+                       << "ms " << ThisFiber::GetName();
+        }
+
+        return false;
+      },
+      next);
+
+  --throttle_waiters_;
+  total_throttle_wait_usec_ +=
+      chrono::duration_cast<chrono::microseconds>(chrono::steady_clock::now() - start).count();
   if (status == std::cv_status::timeout) {
     LOG(WARNING) << "Stream timed out, inflight bytes/sent start: " << inflight_start << "/"
                  << sent_start << ", end: " << in_flight_bytes_ << "/" << total_sent_;
@@ -265,7 +299,18 @@ void RestoreStreamer::Run() {
   do {
     if (!cntx_->IsRunning())
       return;
-    cursor = pt->TraverseBuckets(cursor, [&](PrimeTable::bucket_iterator it) {
+
+    // If someone else is waiting for the inflight bytes to complete, give it priority.
+    // Apparently, continue goes through the loop by checking the condition below, so we check
+    // cursor here as well.
+    if (cursor &&
+        (throttle_waiters_ > 0 || inflight_bytes() > replication_stream_output_limit_cached / 3)) {
+      ThisFiber::SleepFor(300us);
+      stats_.iter_skips++;
+      continue;
+    }
+
+    cursor = pt->TraverseBuckets(cursor, [this](PrimeTable::bucket_iterator it) {
       if (!cntx_->IsRunning())  // Could be cancelled any time as Traverse may preempt
         return;
 
@@ -274,6 +319,9 @@ void RestoreStreamer::Run() {
 
       if (!cntx_->IsRunning())  // Could have been cancelled in above call too
         return;
+
+      // Do not progress if we are stalled.
+      ThrottleIfNeeded();
 
       std::lock_guard guard(big_value_mu_);
 
@@ -285,7 +333,8 @@ void RestoreStreamer::Run() {
     });
 
     if (++last_yield >= migration_buckets_serialization_threshold_cached) {
-      ThisFiber::Yield();
+      // TODO: to align this with how we sleep in SliceSnapshot::FlushSerialized.
+      ThisFiber::SleepFor(chrono::microseconds(migration_buckets_sleep_usec_cached));
       last_yield = 0;
     }
   } while (cursor);
@@ -300,7 +349,11 @@ void RestoreStreamer::SendFinalize(long attempt) {
           << " commands. Buckets looped " << stats_.buckets_loop << ", buckets on_db_update "
           << stats_.buckets_on_db_update << ", buckets skipped " << stats_.buckets_skipped
           << ", buckets written " << stats_.buckets_written << ". Keys skipped "
-          << stats_.keys_skipped << ", keys written " << stats_.keys_written;
+          << stats_.keys_skipped << ", keys written " << stats_.keys_written
+          << " throttle count: " << throttle_count_
+          << ", throttle on db update: " << stats_.throttle_on_db_update
+          << ", throttle usec on db update: " << stats_.throttle_usec_on_db_update
+          << ", iter_skips: " << stats_.iter_skips;
 
   journal::Entry entry(journal::Op::LSN, attempt);
 
@@ -391,6 +444,8 @@ void RestoreStreamer::OnDbChange(DbIndex db_index, const DbSlice::ChangeReq& req
 
   PrimeTable* table = db_slice_->GetTables(0).first;
 
+  uint64_t throttle_start = throttle_count_;
+  uint64_t throttle_usec_start = total_throttle_wait_usec_;
   if (const PrimeTable::bucket_iterator* bit = req.update()) {
     stats_.buckets_on_db_update += WriteBucket(*bit);
   } else {
@@ -400,6 +455,8 @@ void RestoreStreamer::OnDbChange(DbIndex db_index, const DbSlice::ChangeReq& req
       stats_.buckets_on_db_update += WriteBucket(it);
     });
   }
+  stats_.throttle_on_db_update += throttle_count_ - throttle_start;
+  stats_.throttle_usec_on_db_update += total_throttle_wait_usec_ - throttle_usec_start;
 }
 
 void RestoreStreamer::WriteEntry(string_view key, const PrimeValue& pk, const PrimeValue& pv,

--- a/src/server/journal/streamer.h
+++ b/src/server/journal/streamer.h
@@ -57,8 +57,15 @@ class JournalStreamer : public journal::JournalConsumerInterface {
 
   void WaitForInflightToComplete();
 
+  size_t inflight_bytes() const {
+    return in_flight_bytes_;
+  }
+
   util::FiberSocketBase* dest_ = nullptr;
   ExecutionState* cntx_;
+  uint64_t throttle_count_ = 0;
+  uint64_t total_throttle_wait_usec_ = 0;
+  uint32_t throttle_waiters_ = 0;
 
  private:
   void AsyncWrite(bool force_send);
@@ -118,13 +125,16 @@ class RestoreStreamer : public JournalStreamer {
                   uint64_t expire_ms);
 
   struct Stats {
-    size_t buckets_skipped = 0;
-    size_t buckets_written = 0;
-    size_t buckets_loop = 0;
-    size_t buckets_on_db_update = 0;
-    size_t keys_written = 0;
-    size_t keys_skipped = 0;
-    size_t commands = 0;
+    uint64_t buckets_skipped = 0;
+    uint64_t buckets_written = 0;
+    uint64_t buckets_loop = 0;
+    uint64_t buckets_on_db_update = 0;
+    uint64_t throttle_on_db_update = 0;
+    uint64_t throttle_usec_on_db_update = 0;
+    uint64_t keys_written = 0;
+    uint64_t keys_skipped = 0;
+    uint64_t commands = 0;
+    uint64_t iter_skips = 0;
   };
 
   DbSlice* db_slice_;


### PR DESCRIPTION
The problem: when slot migration runs, it takes up majority of scheduling time and throttles io connections greatly. As a result, the write traffic throughput goes down almost to 0.

The solution: it's an intermediate solution that adds a tunable sleep to the migrations fiber.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->