### PR TITLE
chore: add tls_caching flags

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -772,8 +772,8 @@ void Connection::HandleRequests() {
 
     if (!aresult) {
       // This can flood the logs -- don't change
-      LOG_EVERY_T(INFO, 10) << "Error handshaking " << aresult.error().message()
-                            << ", socket state: " + dfly::GetSocketInfo(socket_->native_handle());
+      LOG_EVERY_T(INFO, 1) << "Error handshaking " << aresult.error().message()
+                           << ", socket state: " + dfly::GetSocketInfo(socket_->native_handle());
       return;
     }
     is_tls_ = 1;

--- a/src/facade/tls_helpers.cc
+++ b/src/facade/tls_helpers.cc
@@ -104,7 +104,7 @@ SSL_CTX* CreateSslCntx(TlsContextRole role) {
     SSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_SERVER);
     SSL_CTX_sess_set_cache_size(ctx, GetFlag(FLAGS_tls_session_cache_size));
     SSL_CTX_set_timeout(ctx, GetFlag(FLAGS_tls_session_cache_timeout));
-    SSL_CTX_set_session_id_context(ctx, (const unsigned char*)"dragonfly", 5);
+    SSL_CTX_set_session_id_context(ctx, (const unsigned char*)"dragonfly", 9);
   }
   return ctx;
 }


### PR DESCRIPTION
Tls `session caching` and `tickets` allow to avoid `handshaking`.  For example, if a connection reconnects from an already existing session, the handshake is skipped.

`perf` showed 50% reduction in cpu spent in tls state machine when session caching is enabled.

* add tls flags for tls session caching and tickets
* relax LOG(INFO) because it floods the logs