### PR TITLE
chore(search): Simplify return field logic

### DIFF
--- a/src/server/search/doc_accessors.h
+++ b/src/server/search/doc_accessors.h
@@ -30,14 +30,7 @@ struct BaseAccessor : public search::DocumentAccessor {
 
   // Serialize selected fields
   virtual SearchDocData Serialize(const search::Schema& schema,
-                                  absl::Span<const SearchField> fields) const;
-
-  /*
-  Serialize the whole type, the default implementation is to serialize all fields.
-  For JSON in FT.SEARCH we need to get answer as {"$", <the whole document>}, but it is not an
-  indexed field
-  */
-  virtual SearchDocData SerializeDocument(const search::Schema& schema) const;
+                                  absl::Span<const FieldReference> fields) const;
 
   // Default implementation uses GetStrings
   virtual std::optional<VectorInfo> GetVector(std::string_view active_field) const override;
@@ -86,9 +79,8 @@ struct JsonAccessor : public BaseAccessor {
 
   // The JsonAccessor works with structured types and not plain strings, so an overload is needed
   SearchDocData Serialize(const search::Schema& schema,
-                          absl::Span<const SearchField> fields) const override;
+                          absl::Span<const FieldReference> fields) const override;
   SearchDocData Serialize(const search::Schema& schema) const override;
-  SearchDocData SerializeDocument(const search::Schema& schema) const override;
 
   static void RemoveFieldFromCache(std::string_view field);
 

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -60,53 +60,51 @@ bool IsSortableField(std::string_view field_identifier, const search::Schema& sc
 using SortIndiciesFieldsList =
     std::vector<std::pair<string_view /*identifier*/, string_view /*alias*/>>;
 
-std::pair<SearchFieldsList, SortIndiciesFieldsList> PreprocessAggregateFields(
+std::pair<std::vector<FieldReference>, SortIndiciesFieldsList> PreprocessAggregateFields(
     const search::Schema& schema, const AggregateParams& params,
-    const std::optional<SearchFieldsList>& load_fields) {
-  absl::flat_hash_map<std::string_view, SearchField> fields_by_identifier;
+    const std::optional<std::vector<FieldReference>>& load_fields) {
+  absl::flat_hash_map<std::string_view, FieldReference> fields_by_identifier;
   absl::flat_hash_map<std::string_view, std::string_view> sort_indicies_aliases;
   fields_by_identifier.reserve(schema.field_names.size());
   sort_indicies_aliases.reserve(schema.field_names.size());
 
   for (const auto& [fname, fident] : schema.field_names) {
     if (!IsSortableField(fident, schema)) {
-      fields_by_identifier[fident] = {StringOrView::FromView(fident), true,
-                                      StringOrView::FromView(fname)};
+      fields_by_identifier.emplace(fident, FieldReference{fident, fname});
     } else {
       sort_indicies_aliases[fident] = fname;
     }
   }
 
-  if (load_fields) {
-    for (const auto& field : load_fields.value()) {
-      const auto& fident = field.GetIdentifier(schema, false);
-      if (!IsSortableField(fident, schema)) {
-        fields_by_identifier[fident] = field.View();
-      } else {
-        sort_indicies_aliases[fident] = field.GetShortName();
-      }
+  for (const auto& field : load_fields.value_or(vector<FieldReference>{})) {
+    string_view fident = field.Identifier(schema, false);
+    if (!IsSortableField(fident, schema)) {
+      fields_by_identifier.insert_or_assign(fident, field);
+    } else {
+      sort_indicies_aliases[fident] = field.OutputName();
     }
   }
 
-  SearchFieldsList fields;
+  vector<FieldReference> fields;
   fields.reserve(fields_by_identifier.size());
   for (auto& [_, field] : fields_by_identifier) {
-    fields.emplace_back(std::move(field));
+    fields.emplace_back(field);
   }
 
-  SortIndiciesFieldsList sort_fields;
-  sort_fields.reserve(sort_indicies_aliases.size());
-  for (auto& [fident, fname] : sort_indicies_aliases) {
-    sort_fields.emplace_back(fident, fname);
-  }
-
-  return {std::move(fields), std::move(sort_fields)};
+  return {std::move(fields), {sort_indicies_aliases.begin(), sort_indicies_aliases.end()}};
 }
 
 }  // namespace
 
+bool FieldReference::IsJsonPath(std::string_view name) {
+  if (name.size() < 2) {
+    return false;
+  }
+  return name.front() == '$' && (name[1] == '.' || name[1] == '[');
+}
+
 bool SearchParams::ShouldReturnField(std::string_view alias) const {
-  auto cb = [alias](const auto& entry) { return entry.GetShortName() == alias; };
+  auto cb = [alias](const auto& entry) { return entry.OutputName() == alias; };
   return !return_fields || any_of(return_fields->begin(), return_fields->end(), cb);
 }
 
@@ -390,14 +388,14 @@ SearchResult ShardDocIndex::Search(const OpArgs& op_args, const SearchParams& pa
       limit = max(limit, ko->limit);
   }
 
-  auto return_fields = params.return_fields.value_or(SearchFieldsList{});
+  auto return_fields = params.return_fields.value_or(vector<FieldReference>{});
 
   // Apply SORTBY
   // TODO(vlad): Write profiling up to here
   vector<search::SortableValue> sort_scores;
   if (params.sort_option && !skip_sort) {
     const auto& so = *params.sort_option;
-    auto fident = so.field.GetIdentifier(base_->schema, false);
+    auto fident = so.field.Identifier(base_->schema, false);
     if (IsSortableField(fident, base_->schema)) {
       auto* idx = indices_->GetSortIndex(fident);
       sort_scores = idx->Sort(&result.ids, limit, so.order == SortOrder::DESC);
@@ -445,7 +443,7 @@ SearchResult ShardDocIndex::Search(const OpArgs& op_args, const SearchParams& pa
     // Load all specified fields from document
     SearchDocData fields{};
     if (params.ShouldReturnAllFields())
-      fields = accessor->SerializeDocument(base_->schema);
+      fields = accessor->Serialize(base_->schema);
 
     auto more_fields = accessor->Serialize(base_->schema, return_fields);
     fields.insert(make_move_iterator(more_fields.begin()), make_move_iterator(more_fields.end()));

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -57,96 +57,35 @@ struct SearchResult {
   std::optional<facade::ErrorReply> error;
 };
 
-/* SearchField represents a field that can store combinations of identifiers and aliases in various
-   forms: [identifier and alias], [alias and new_alias], [new identifier and alias] (used for JSON
-   data) This class provides methods to retrieve the actual identifier and alias for a field,
-   handling different naming conventions and resolving names based on the schema. */
-class SearchField {
- private:
-  static bool IsJsonPath(std::string_view name) {
-    if (name.size() < 2) {
-      return false;
-    }
-    return name.front() == '$' && (name[1] == '.' || name[1] == '[');
+// Field reference with optional alias as parsed from RETURN [field AS alias], LOAD, etc...
+struct FieldReference {
+  explicit FieldReference(std::string_view name, std::string_view alias = "")
+      : name_{name}, alias_{alias} {
   }
 
- public:
-  SearchField() = default;
-
-  explicit SearchField(StringOrView name) : name_(std::move(name)) {
-    is_short_name_ = !IsJsonPath(NameView());
+  std::string_view Identifier(const search::Schema& schema, bool is_json) const {
+    return (is_json && IsJsonPath(name_)) ? name_ : schema.LookupAlias(name_);
   }
 
-  SearchField(StringOrView name, bool is_short_name)
-      : name_(std::move(name)), is_short_name_(is_short_name) {
-  }
-
-  SearchField(StringOrView name, bool is_short_name, StringOrView new_alias)
-      : name_(std::move(name)), is_short_name_(is_short_name), new_alias_(std::move(new_alias)) {
-  }
-
-  std::string_view GetIdentifier(const search::Schema& schema, bool is_json_field) const {
-    auto as_view = NameView();
-    if (!is_short_name_ || (is_json_field && IsJsonPath(as_view))) {
-      return as_view;
-    }
-    return schema.LookupAlias(as_view);
-  }
-
-  std::string_view GetShortName() const {
-    if (HasNewAlias()) {
-      return AliasView();
-    }
-    return NameView();
-  }
-
-  std::string_view GetShortName(const search::Schema& schema) const {
-    if (HasNewAlias()) {
-      return AliasView();
-    }
-    return is_short_name_ ? NameView() : schema.LookupIdentifier(NameView());
-  }
-
-  /* Returns a new SearchField instance with name and alias stored as views to the values in this
-   * SearchField */
-  SearchField View() const {
-    if (HasNewAlias()) {
-      return SearchField{StringOrView::FromView(NameView()), is_short_name_,
-                         StringOrView::FromView(AliasView())};
-    }
-    return SearchField{StringOrView::FromView(NameView()), is_short_name_};
-  }
-
-  std::string_view NameView() const {
-    return name_.view();
+  std::string_view OutputName() const {
+    return alias_.empty() ? name_ : alias_;
   }
 
  private:
-  bool HasNewAlias() const {
-    return !new_alias_.empty();
-  }
+  static bool IsJsonPath(std::string_view name);
 
-  std::string_view AliasView() const {
-    return new_alias_.view();
-  }
-
- private:
-  StringOrView name_;
-  bool is_short_name_;
-  StringOrView new_alias_;
+  std::string_view name_, alias_;
 };
-
-using SearchFieldsList = std::vector<SearchField>;
 
 enum class SortOrder { ASC, DESC };
 
 struct SearchParams {
   struct SortOption {
-    SearchField field;
+    FieldReference field;
     SortOrder order = SortOrder::ASC;
 
     bool IsSame(const search::KnnScoreSortOption& knn_sort) const {
-      return knn_sort.score_field_alias == field.NameView();
+      return knn_sort.score_field_alias == field.OutputName();
     }
   };
 
@@ -160,14 +99,14 @@ struct SearchParams {
   2. If set but empty -> no fields should be returned
   3. If set and not empty -> return only these fields
   */
-  std::optional<SearchFieldsList> return_fields;
+  std::optional<std::vector<FieldReference>> return_fields;
 
   /*
     Fields that should be also loaded from the document.
 
     Only one of load_fields and return_fields should be set.
   */
-  std::optional<SearchFieldsList> load_fields;
+  std::optional<std::vector<FieldReference>> load_fields;
 
   std::optional<SortOption> sort_option;
   search::QueryParams query_params;
@@ -187,7 +126,7 @@ struct AggregateParams {
   std::string_view index, query;
   search::QueryParams params;
 
-  std::optional<SearchFieldsList> load_fields;
+  std::optional<std::vector<FieldReference>> load_fields;
   std::vector<aggregate::AggregationStep> steps;
 };
 


### PR DESCRIPTION
1. Remove effectively dead code:
  * `SearchField` never stores generated fields, so `string_view` is enough instead of StringOrView + View() + etc...
  * `SearchField::is_short_name` is always true
  * Remove `SearchField`'s dead functions
  * `DocumentAccessor::SerializeDocument` replaced `Serialize()`, but the latter was never removed. Remove and swap names back
 2. Add `ReturnOptionJson` that extensively tests RETURN with json
 3. Remove quotes for returning plain json fields (like RS)