### PR TITLE
chore: add more logs during replication

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1208,6 +1208,7 @@ Connection::ParserStatus Connection::ParseRedis(unsigned max_busy_cycles) {
       DispatchSingle(has_more, dispatch_sync, dispatch_async);
     }
     if (result != RedisParser::OK && result != RedisParser::INPUT_PENDING) {
+      // We do not expect that a replica sends an invalid command so we log if it happens.
       LOG_IF(WARNING, cntx()->replica_conn)
           << "Redis parser error: " << result << " during parse: " << ToSV(read_buffer.slice);
     }

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1207,6 +1207,10 @@ Connection::ParserStatus Connection::ParseRedis(unsigned max_busy_cycles) {
 
       DispatchSingle(has_more, dispatch_sync, dispatch_async);
     }
+    if (result != RedisParser::OK && result != RedisParser::INPUT_PENDING) {
+      LOG_IF(WARNING, cntx()->replica_conn)
+          << "Redis parser error: " << result << " during parse: " << ToSV(read_buffer.slice);
+    }
     read_buffer.Consume(consumed);
 
     // We must yield from time to time to allow other fibers to run.
@@ -1411,6 +1415,7 @@ auto Connection::IoLoop() -> variant<error_code, ParserStatus> {
     HandleMigrateRequest();
     ec = HandleRecvSocket();
     if (ec) {
+      LOG_IF(WARNING, cntx()->replica_conn) << "HandleRecvSocket() error: " << ec;
       return ec;
     }
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1224,6 +1224,7 @@ DispatchResult Service::DispatchCommand(ArgSlice args, SinkReplyBuilder* builder
   }
 
   if (auto err = VerifyCommandState(cid, args_no_cmd, *dfly_cntx); err) {
+    LOG_IF(WARNING, cntx->replica_conn) << "VerifyCommandState error: " << err->ToSv();
     if (auto& exec_info = dfly_cntx->conn_state.exec_info; exec_info.IsCollecting())
       exec_info.state = ConnectionState::ExecInfo::EXEC_ERROR;
 


### PR DESCRIPTION
Problem: During replication, we saw that the master disconnects from the replica. We don't have enough logs to understand the reason.

Fix: Added logs to 3 possible places where disconnecting can be triggered from.