### PR TITLE
feat: add debug segments command

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -262,6 +262,29 @@ void DoBuildObjHist(EngineShard* shard, ConnectionContext* cntx, ObjHistMap* obj
   }
 }
 
+struct SegmentInfo {
+  base::Histogram hist;
+};
+
+void DoSegmentHist(EngineShard* shard, ConnectionContext* cntx, SegmentInfo* info) {
+  auto& db_slice = cntx->ns->GetDbSlice(shard->shard_id());
+  DbTable* dbt = db_slice.GetDBTable(cntx->db_index());
+  if (dbt == nullptr)
+    return;
+
+  unsigned steps = 0;
+  auto& prime = dbt->prime;
+  for (size_t i = 0; i < prime.GetSegmentCount(); i = prime.NextSeg(i)) {
+    const auto* segment = prime.GetSegment(i);
+
+    info->hist.Add(segment->SlowSize());
+    if (steps++ >= 2000) {
+      steps = 0;
+      ThisFiber::Yield();
+    }
+  }
+}
+
 struct HufHist {
   static constexpr unsigned kMaxSymbol = 255;
   array<unsigned, kMaxSymbol + 1> hist;  // histogram of symbols.
@@ -605,6 +628,8 @@ void DebugCmd::Run(CmdArgList args, facade::SinkReplyBuilder* builder) {
         "IOSTATS [PS]",
         "    Prints IO stats per thread. If PS is specified, prints thread-level stats ",
         "    per second.",
+        "SEGMENTS",
+        "    Prints segment info for the current database.",
         "HELP",
         "    Prints this help.",
     };
@@ -682,6 +707,9 @@ void DebugCmd::Run(CmdArgList args, facade::SinkReplyBuilder* builder) {
 
   if (subcmd == "IOSTATS") {
     return IOStats(args.subspan(1), builder);
+  }
+  if (subcmd == "SEGMENTS") {
+    return Segments(args.subspan(1), builder);
   }
   string reply = UnknownSubCmd(subcmd, "DEBUG");
   return builder->SendError(reply, kSyntaxErrType);
@@ -1429,6 +1457,27 @@ void DebugCmd::IOStats(CmdArgList args, facade::SinkReplyBuilder* builder) {
   for (const auto& stat : stats) {
     stat.Print(rb);
   }
+}
+
+void DebugCmd::Segments(CmdArgList args, facade::SinkReplyBuilder* builder) {
+  auto* rb = static_cast<RedisReplyBuilder*>(builder);
+  vector<SegmentInfo> info(shard_set->size());
+
+  shard_set->RunBlockingInParallel([&](EngineShard* shard) {
+    auto& hist = info[shard->shard_id()];
+    DoSegmentHist(shard, cntx_, &hist);
+  });
+
+  base::Histogram hist;
+  for (const auto& seg_info : info) {
+    hist.Merge(seg_info.hist);
+  }
+  string result;
+  absl::StrAppend(&result, "___begin segment info___\n\n");
+  absl::StrAppend(&result, "Segment Capacity: ", PrimeTable::kSegCapacity, "\n");
+  absl::StrAppend(&result, "Segment Size Histogram: \n");
+  absl::StrAppend(&result, hist.ToString(), "\n");
+  rb->SendVerbatimString(result);
 }
 
 void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBatch& batch) {

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -278,8 +278,7 @@ void DoSegmentHist(EngineShard* shard, ConnectionContext* cntx, SegmentInfo* inf
     const auto* segment = prime.GetSegment(i);
 
     info->hist.Add(segment->SlowSize());
-    if (steps++ >= 2000) {
-      steps = 0;
+    if (++steps % 2000 == 0) {
       ThisFiber::Yield();
     }
   }

--- a/src/server/debugcmd.h
+++ b/src/server/debugcmd.h
@@ -60,6 +60,7 @@ class DebugCmd {
   void Keys(CmdArgList args, facade::SinkReplyBuilder* builder);
   void Compression(CmdArgList args, facade::SinkReplyBuilder* builder);
   void IOStats(CmdArgList args, facade::SinkReplyBuilder* builder);
+  void Segments(CmdArgList args, facade::SinkReplyBuilder* builder);
   struct PopulateBatch {
     DbIndex dbid;
     uint64_t index[32];


### PR DESCRIPTION
Currently, this command shows the histogram of segment sizes (occupancy) in the table.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->