### PR TITLE
feat: add RESP3 support for JSON.TYPE and JSON numeric operations

### DIFF
--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -337,7 +337,7 @@ template <typename T> void Send(const OpResult<T>& result, RedisReplyBuilder* rb
 }
 
 // Specialization for JSON numeric operations that return string results
-template <> void Send(const OpResult<string>& result, RedisReplyBuilder* rb) {
+void SendNumericData(const OpResult<string>& result, RedisReplyBuilder* rb) {
   RedisReplyBuilder::ReplyScope scope{rb};
   if (result) {
     const string& json_str = result.value();
@@ -2039,7 +2039,7 @@ void JsonFamily::NumIncrBy(CmdArgList args, const CommandContext& cmd_cntx) {
 
   OpResult<string> result = cmd_cntx.tx->ScheduleSingleHopT(std::move(cb));
   auto* rb = static_cast<RedisReplyBuilder*>(builder);
-  reply_generic::Send(result, rb);
+  reply_generic::SendNumericData(result, rb);
 }
 
 void JsonFamily::NumMultBy(CmdArgList args, const CommandContext& cmd_cntx) {
@@ -2056,7 +2056,7 @@ void JsonFamily::NumMultBy(CmdArgList args, const CommandContext& cmd_cntx) {
 
   OpResult<string> result = cmd_cntx.tx->ScheduleSingleHopT(std::move(cb));
   auto* rb = static_cast<RedisReplyBuilder*>(builder);
-  reply_generic::Send(result, rb);
+  reply_generic::SendNumericData(result, rb);
 }
 
 void JsonFamily::Toggle(CmdArgList args, const CommandContext& cmd_cntx) {

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -301,7 +301,6 @@ template <typename T> void Send(const JsonCallbackResult<T>& result, RedisReplyB
     /* The specified path was enhanced (starts with '$'), then the result is an array of multiple
      * values */
     const auto& arr = result.AsV2();
-
     Send(arr.begin(), arr.end(), rb);
   }
 }

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -2090,10 +2090,8 @@ void JsonFamily::Type(CmdArgList args, const CommandContext& cmd_cntx) {
     // Legacy path (.) - single value
     if (rb->IsResp3()) {
       rb->StartArray(1);
-      rb->SendBulkString(callback_result.AsV1());
-    } else {
-      rb->SendBulkString(callback_result.AsV1());
     }
+    rb->SendBulkString(callback_result.AsV1());
   } else {
     // Enhanced path ($) - array of values
     const auto& arr = callback_result.AsV2();

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -314,7 +314,6 @@ template <typename T> void Send(const OpResult<T>& result, RedisReplyBuilder* rb
   }
 }
 
-// Specialization for JSON numeric operations that return string results
 void SendNumericData(const OpResult<string>& result, RedisReplyBuilder* rb) {
   RedisReplyBuilder::ReplyScope scope{rb};
   if (result) {

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -11,6 +11,7 @@
 #include "base/logging.h"
 #include "facade/error.h"
 #include "facade/facade_test.h"
+#include "gmock/gmock.h"
 #include "server/command_registry.h"
 #include "server/test_utils.h"
 
@@ -1191,7 +1192,7 @@ TEST_F(JsonFamilyTest, NumericOperationsWithConversionsLegacy) {
 
 TEST_F(JsonFamilyTest, NumericOperationsResp2Resp3) {
   // Test RESP2 behavior
-  Run({"CONFIG", "SET", "resp", "2"});
+  Run({"HELLO", "2"});
 
   auto resp = Run({"JSON.SET", "a", "$", "1"});
   ASSERT_THAT(resp, "OK");
@@ -1209,7 +1210,7 @@ TEST_F(JsonFamilyTest, NumericOperationsResp2Resp3) {
   EXPECT_EQ(resp, "[4]");  // Currently returns string "[4]"
 
   // Test RESP3 behavior
-  Run({"CONFIG", "SET", "resp", "3"});
+  Run({"HELLO", "3"});
   Run({"FLUSHALL"});
 
   resp = Run({"JSON.SET", "a", "$", "1"});
@@ -1220,7 +1221,7 @@ TEST_F(JsonFamilyTest, NumericOperationsResp2Resp3) {
   EXPECT_THAT(resp, IntArg(2));
 
   resp = Run({"JSON.TYPE", "a", "$"});
-  EXPECT_EQ(resp, "[\"integer\"]");
+  EXPECT_THAT(resp, RespArray(ElementsAre("integer")));
 
   resp = Run({"JSON.TYPE", "a", "."});
   EXPECT_EQ(resp, "integer");

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -1189,6 +1189,47 @@ TEST_F(JsonFamilyTest, NumericOperationsWithConversionsLegacy) {
   EXPECT_EQ(resp, R"({"a":8.0})");  // Is converted to double
 }
 
+TEST_F(JsonFamilyTest, NumericOperationsResp2Resp3) {
+  // Test RESP2 behavior
+  Run({"CONFIG", "SET", "resp", "2"});
+
+  auto resp = Run({"JSON.SET", "a", "$", "1"});
+  ASSERT_THAT(resp, "OK");
+
+  resp = Run({"JSON.NUMINCRBY", "a", "$", "1"});
+  EXPECT_EQ(resp, "[2]");  // Currently returns string "[2]"
+
+  resp = Run({"JSON.TYPE", "a", "$"});
+  EXPECT_EQ(resp, "integer");
+
+  resp = Run({"JSON.TYPE", "a", "."});
+  EXPECT_EQ(resp, "integer");
+
+  resp = Run({"JSON.NUMMULTBY", "a", "$", "2"});
+  EXPECT_EQ(resp, "[4]");  // Currently returns string "[4]"
+
+  // Test RESP3 behavior
+  Run({"CONFIG", "SET", "resp", "3"});
+  Run({"FLUSHALL"});
+
+  resp = Run({"JSON.SET", "a", "$", "1"});
+  ASSERT_THAT(resp, "OK");
+
+  resp = Run({"JSON.NUMINCRBY", "a", "$", "1"});
+  // In RESP3, this should return a proper array with integer: 1) (integer) 2
+  EXPECT_THAT(resp, IntArg(2));
+
+  resp = Run({"JSON.TYPE", "a", "$"});
+  EXPECT_EQ(resp, "[\"integer\"]");
+
+  resp = Run({"JSON.TYPE", "a", "."});
+  EXPECT_EQ(resp, "integer");
+
+  resp = Run({"JSON.NUMMULTBY", "a", "$", "2"});
+  // In RESP3, this should return a proper array with integer: 1) (integer) 4
+  EXPECT_THAT(resp, IntArg(4));
+}
+
 TEST_F(JsonFamilyTest, Del) {
   string json = R"(
     {"a":{}, "b":{"a":1}, "c":{"a":1, "b":2}, "d":{"a":1, "b":2, "c":3}, "e": [1,2,3,4,5]}}

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -11,7 +11,6 @@
 #include "base/logging.h"
 #include "facade/error.h"
 #include "facade/facade_test.h"
-#include "gmock/gmock.h"
 #include "server/command_registry.h"
 #include "server/test_utils.h"
 


### PR DESCRIPTION
Fixes: https://github.com/dragonflydb/dragonfly/issues/5396

Implements proper RESP3 formatting for JSON commands:
- JSON.TYPE
- JSON.NUMINCRBY
- JSON.NUMMULTBY

Fixes JSON commands to follow RESP3 protocol.