### PR TITLE
chore: fix monitor preemption in atomic section

### DIFF
--- a/src/facade/conn_context.h
+++ b/src/facade/conn_context.h
@@ -55,9 +55,6 @@ class ConnectionContext {
   // Skip ACL validation, used by internal commands and commands run on admin port
   bool skip_acl_validation = false;
 
-  // Monitor shutdown
-  bool monitor_shutdown_conn = false;
-
   // How many async subscription sources are active: monitor and/or pubsub - at most 2.
   uint8_t subscriptions;
 

--- a/src/facade/conn_context.h
+++ b/src/facade/conn_context.h
@@ -55,6 +55,9 @@ class ConnectionContext {
   // Skip ACL validation, used by internal commands and commands run on admin port
   bool skip_acl_validation = false;
 
+  // Monitor shutdown
+  bool monitor_shutdown_conn = false;
+
   // How many async subscription sources are active: monitor and/or pubsub - at most 2.
   uint8_t subscriptions;
 

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1877,6 +1877,8 @@ void Connection::SendAsync(MessageHandle msg) {
   // Close MONITOR connection if we overflow pipeline limits
   if (msg.IsMonitor() &&
       qbp.IsPipelineBufferOverLimit(stats_->dispatch_queue_bytes, dispatch_q_.size())) {
+    // This might preempt if socket is a tls socket which violates the contract
+    // of SendAsync that should never block
     ShutdownSelf();
     return;
   }

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -231,7 +231,7 @@ class Connection : public util::Connection {
   void RegisterBreakHook(BreakerCb breaker_cb);
 
   // Manually shutdown self.
-  void ShutdownSelf();
+  void ShutdownSelfBlocking();
 
   // Migrate this connecton to a different thread.
   // Return true if Migrate succeeded
@@ -494,6 +494,8 @@ class Connection : public util::Connection {
       bool is_main_ : 1;
     };
   };
+
+  bool request_shutdown_ = false;
 };
 
 }  // namespace facade

--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -169,11 +169,12 @@ void AclFamily::EvictOpenConnectionsOnAllProactors(const absl::flat_hash_set<str
     auto connection = static_cast<facade::Connection*>(conn);
     auto ctx = static_cast<ConnectionContext*>(connection->cntx());
     if (ctx && users.contains(ctx->authed_username)) {
-      connection->ShutdownSelf();
+      connection->ShutdownSelfBlocking();
     }
   };
 
   if (main_listener_) {
+    // TODO(kostas) fix this it might preempt and TraverseConnection shall be atomic
     main_listener_->TraverseConnections(close_cb);
   }
 }
@@ -185,11 +186,12 @@ void AclFamily::EvictOpenConnectionsOnAllProactorsWithRegistry(
     auto connection = static_cast<facade::Connection*>(conn);
     auto ctx = static_cast<ConnectionContext*>(connection->cntx());
     if (ctx && ctx->authed_username != "default" && registry.contains(ctx->authed_username)) {
-      connection->ShutdownSelf();
+      connection->ShutdownSelfBlocking();
     }
   };
 
   if (main_listener_) {
+    // TODO(kostas) fix this it might preempt and TraverseConnection shall be atomic
     main_listener_->TraverseConnections(close_cb);
   }
 }

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1798,7 +1798,7 @@ void Service::Quit(CmdArgList args, const CommandContext& cmd_cntx) {
   cmd_cntx.rb->CloseConnection();
 
   DeactivateMonitoring(cmd_cntx.conn_cntx);
-  cmd_cntx.conn_cntx->conn()->ShutdownSelf();
+  cmd_cntx.conn_cntx->conn()->ShutdownSelfBlocking();
 }
 
 void Service::Multi(CmdArgList args, const CommandContext& cmd_cntx) {

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -569,7 +569,7 @@ void ClientKill(CmdArgList args, absl::Span<facade::Listener*> listeners, SinkRe
     for (auto& tcon : connections) {
       facade::Connection* conn = tcon.Get();
       if (conn && conn->socket()->proactor()->GetPoolIndex() == p->GetPoolIndex()) {
-        conn->ShutdownSelf();
+        conn->ShutdownSelfBlocking();
         killed_connections.fetch_add(1);
       }
     }

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -303,7 +303,7 @@ void ServerState::ConnectionsWatcherFb(util::ListenerInterface* main) {
       facade::Connection* conn = ref.Get();
       if (conn) {
         VLOG(1) << "Closing connection due to timeout: " << conn->GetClientInfo();
-        conn->ShutdownSelf();
+        conn->ShutdownSelfBlocking();
         stats.conn_timeout_events++;
       }
     }


### PR DESCRIPTION
The issue is that `SendAsync` might preempt if the monitor connection needs to shut down because the pipeline buffer is over the limit. The fix is to move the ShutdownSelfBlocking to allow the async fiber and set the con_clossing to true.


* shutdown the connection within AsyncFiber instead of SendAsync
* rename ShutdownSelf to ShutdownSelfBlocking