### PR TITLE
fix(acl): preemptive TlsSocket::Shutdown in atomic section

### DIFF
--- a/src/server/acl/acl_family.h
+++ b/src/server/acl/acl_family.h
@@ -164,6 +164,8 @@ class AclFamily final {
 
   size_t dbnum_ = 0;
 
+  template <typename P> void TraverseEvictImpl(P predicate);
+
   // Only for testing interface
  public:
   // Helper accessors for tests. Do not use them directly.

--- a/src/server/acl/acl_family.h
+++ b/src/server/acl/acl_family.h
@@ -164,8 +164,6 @@ class AclFamily final {
 
   size_t dbnum_ = 0;
 
-  template <typename P> void TraverseEvictImpl(P predicate);
-
   // Only for testing interface
  public:
   // Helper accessors for tests. Do not use them directly.


### PR DESCRIPTION
The issue is that we called `TlsSocket::Shutdown` while traversing the connections. Since Shutdown is preemptive, it violates the atomicity guarantees of the operation.

Helps with #5524
