### PR TITLE
refactor: Replace nonstd::expected with absl::StatusOr in JSON path processing

### DIFF
--- a/src/core/json/CMakeLists.txt
+++ b/src/core/json/CMakeLists.txt
@@ -6,7 +6,7 @@ cur_gen_dir(gen_dir)
 add_library(jsonpath lexer_impl.cc driver.cc path.cc
             ${gen_dir}/jsonpath_lexer.cc ${gen_dir}/jsonpath_grammar.cc json_object.cc
             detail/jsoncons_dfs.cc detail/flat_dfs.cc)
-target_link_libraries(jsonpath base absl::strings TRDP::reflex TRDP::jsoncons TRDP::flatbuffers)
+target_link_libraries(jsonpath base absl::strings absl::status absl::statusor TRDP::reflex TRDP::jsoncons TRDP::flatbuffers)
 
 cxx_test(jsonpath_test jsonpath LABELS DFLY)
 cxx_test(json_test jsonpath TRDP::jsoncons LABELS DFLY)

--- a/src/core/json/detail/flat_dfs.h
+++ b/src/core/json/detail/flat_dfs.h
@@ -8,7 +8,7 @@
 
 #include <variant>
 
-#include "base/expected.hpp"
+#include "absl/status/statusor.h"
 #include "core/flatbuffers.h"
 #include "core/json/detail/common.h"
 #include "core/json/path.h"
@@ -19,7 +19,7 @@ class FlatDfsItem {
  public:
   using ValueType = flexbuffers::Reference;
   using DepthState = std::pair<ValueType, unsigned>;  // object, segment_idx pair
-  using AdvanceResult = nonstd::expected<DepthState, MatchStatus>;
+  using AdvanceResult = absl::StatusOr<DepthState>;
 
   FlatDfsItem(ValueType val, unsigned idx = 0) : depth_state_(val, idx) {
   }
@@ -71,9 +71,8 @@ class FlatDfs {
  private:
   bool TraverseImpl(absl::Span<const PathSegment> path, const PathFlatCallback& callback);
 
-  nonstd::expected<void, MatchStatus> PerformStep(const PathSegment& segment,
-                                                  const flexbuffers::Reference node,
-                                                  const PathFlatCallback& callback);
+  absl::Status PerformStep(const PathSegment& segment, const flexbuffers::Reference node,
+                           const PathFlatCallback& callback);
 
   void DoCall(const PathFlatCallback& callback, std::optional<std::string_view> key,
               const flexbuffers::Reference node) {

--- a/src/core/json/path.cc
+++ b/src/core/json/path.cc
@@ -15,7 +15,6 @@
 #include "src/core/overloaded.h"
 
 using namespace std;
-using nonstd::make_unexpected;
 
 namespace dfly::json {
 
@@ -130,9 +129,9 @@ void EvaluatePath(const Path& path, const JsonType& json, PathCallback callback)
   callback(nullopt, val);
 }
 
-nonstd::expected<json::Path, string> ParsePath(string_view path) {
+absl::StatusOr<json::Path> ParsePath(string_view path) {
   if (path.size() > 8192)
-    return nonstd::make_unexpected("Path too long");
+    return absl::InvalidArgumentError("Path too long");
 
   VLOG(2) << "Parsing path: " << path;
 
@@ -142,7 +141,7 @@ nonstd::expected<json::Path, string> ParsePath(string_view path) {
   driver.SetInput(string(path));
   int res = parser();
   if (res != 0) {
-    return nonstd::make_unexpected(driver.msg);
+    return absl::InvalidArgumentError(driver.msg);
   }
 
   return driver.TakePath();

--- a/src/core/json/path.h
+++ b/src/core/json/path.h
@@ -10,7 +10,7 @@
 #include <variant>
 #include <vector>
 
-#include "base/expected.hpp"
+#include "absl/status/statusor.h"
 #include "core/flatbuffers.h"
 #include "core/json/json_object.h"
 
@@ -144,7 +144,7 @@ unsigned DeletePath(const Path& path, FlatJson json, flexbuffers::Builder* fbb);
 
 // utility function to parse a jsonpath. Returns an error message if a parse error was
 // encountered.
-nonstd::expected<Path, std::string> ParsePath(std::string_view path);
+absl::StatusOr<Path> ParsePath(std::string_view path);
 
 // Transforms FlatJson to JsonType.
 JsonType FromFlat(FlatJson src);

--- a/src/core/search/block_list_test.cc
+++ b/src/core/search/block_list_test.cc
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <random>
 #include <set>
 
 #include "base/gtest.h"

--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -6,8 +6,8 @@
 
 #include <bitset>
 
+#include "absl/status/statusor.h"
 #include "absl/strings/match.h"
-#include "base/expected.hpp"
 #include "base/logging.h"
 #include "facade/cmd_arg_parser.h"
 #include "facade/op_status.h"

--- a/src/server/search/doc_accessors.cc
+++ b/src/server/search/doc_accessors.cc
@@ -342,10 +342,10 @@ JsonAccessor::JsonPathContainer* JsonAccessor::GetPath(std::string_view field) c
   unique_ptr<JsonPathContainer> ptr;
   if (absl::GetFlag(FLAGS_jsonpathv2)) {
     auto path_expr = json::ParsePath(field);
-    if (path_expr) {
-      ptr.reset(new JsonPathContainer{std::move(path_expr.value())});
+    if (path_expr.ok()) {
+      ptr.reset(new JsonPathContainer{std::move(*path_expr)});
     } else {
-      ec_msg = path_expr.error();
+      ec_msg = path_expr.status().message();
     }
   } else {
     error_code ec;

--- a/src/server/serializer_commons.h
+++ b/src/server/serializer_commons.h
@@ -4,7 +4,7 @@
 
 #include <system_error>
 
-#include "base/expected.hpp"
+#include "absl/status/statusor.h"
 #include "io/io.h"
 #include "server/error.h"
 


### PR DESCRIPTION
 These changes are relevant to the absl library version update to the latest one: https://github.com/abseil/abseil-cpp/releases/tag/20250512.1
 The latest version doesn't have `base/expected.hpp` header. This header is internal chromium code.

These changes provide replacement third-party `nonstd::expected<T, E>` with native `absl::StatusOr<T>` in JSON path components for better Abseil integration.

Key changes:
  - Updated `json::ParsePath()` and internal traversal functions
  - Replaced `make_unexpected()` calls with appropriate `absl::*Error()` functions
  - Added required Abseil dependencies to build system
  
Relevant to this issue: https://github.com/dragonflydb/dragonfly/issues/5529