### PR TITLE
chore: lower mem usage of test_big_strings

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -20,6 +20,7 @@ extern "C" {
 #include <zdict.h>
 #include <zstd.h>
 
+#include <algorithm>
 #include <filesystem>
 
 #include "base/flags.h"
@@ -611,7 +612,7 @@ void DebugCmd::Run(CmdArgList args, facade::SinkReplyBuilder* builder) {
         "WATCHED",
         "    Shows the watched keys as a result of BLPOP and similar operations.",
         "POPULATE <count> [prefix] [size] [RAND] [SLOTS start end] [TYPE type] [ELEMENTS elements]"
-        "[EXPIRE start end]",
+        " [EXPIRE start end]",
         "    Create <count> string keys named key:<num> with value value:<num>.",
         "    If <prefix> is specified then it is used instead of the 'key' prefix.",
         "    If <size> is specified then X character is concatenated multiple times to value:<num>",
@@ -1209,8 +1210,8 @@ void DebugCmd::Shards(facade::SinkReplyBuilder* builder) {
     size_t minv = numeric_limits<size_t>::max();            \
     size_t maxv = 0;                                        \
     for (const auto& info : infos) {                        \
-      minv = min(minv, info.stat);                          \
-      maxv = max(maxv, info.stat);                          \
+      minv = std::min(minv, info.stat);                     \
+      maxv = std::max(maxv, info.stat);                     \
     }                                                       \
     absl::StrAppend(&out, "max_", #stat, ": ", maxv, "\n"); \
     absl::StrAppend(&out, "min_", #stat, ": ", minv, "\n"); \

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -3410,8 +3410,8 @@ async def test_big_strings(df_factory):
     c_master = master.client()
     c_replica = replica.client()
 
-    # 500kb
-    value_size = 500_000
+    # 200kb
+    value_size = 200_000
 
     async def get_memory(client, field):
         info = await client.info("memory")
@@ -3420,7 +3420,7 @@ async def test_big_strings(df_factory):
     capacity = await get_memory(c_master, "prime_capacity")
 
     seeder = DebugPopulateSeeder(
-        key_target=int(capacity * 0.8),
+        key_target=int(capacity * 0.7),
         data_size=value_size,
         collection_size=1,
         variance=1,


### PR DESCRIPTION
test_big_strings required a lot of ram and sometimes it OOMed the runner. Furthermore, fix macos build

* lower mem usage for test_big_strings
* fix macos build