### PR TITLE
feat(search_family): Speed up merging of index results

### DIFF
--- a/src/core/search/base.h
+++ b/src/core/search/base.h
@@ -128,12 +128,12 @@ inline size_t GetHighestPowerOfTwo(size_t n) {
 template <typename Iterator> void BasicSeekGE(DocId min_doc_id, const Iterator& end, Iterator* it) {
   using Category = typename std::iterator_traits<Iterator>::iterator_category;
 
-  auto less_than_min_doc_id = [&](const auto& value) {
+  auto extract_doc_id = [](const auto& value) {
     using T = std::decay_t<decltype(value)>;
     if constexpr (std::is_same_v<T, DocId>) {
-      return value < min_doc_id;
+      return value;
     } else {
-      return value.first < min_doc_id;
+      return value.first;
     }
   };
 
@@ -142,7 +142,7 @@ template <typename Iterator> void BasicSeekGE(DocId min_doc_id, const Iterator& 
     for (size_t step = details::GetHighestPowerOfTwo(length); step > 0; step >>= 1) {
       if (step < length) {
         auto next_it = *it + step;
-        if (less_than_min_doc_id(*next_it)) {
+        if (extract_doc_id(*next_it) < min_doc_id) {
           *it = next_it;
           length -= step;
         }
@@ -150,7 +150,7 @@ template <typename Iterator> void BasicSeekGE(DocId min_doc_id, const Iterator& 
     }
   }
 
-  while (*it != end && less_than_min_doc_id(**it)) {
+  while (*it != end && extract_doc_id(**it) < min_doc_id) {
     ++(*it);
   }
 }

--- a/src/core/search/block_list.cc
+++ b/src/core/search/block_list.cc
@@ -159,17 +159,17 @@ template <typename C> void BlockList<C>::BlockListIterator::SeekGE(DocId min_doc
     return;
   }
 
-  auto less_than_min_doc_id = [&](const auto& value) {
+  auto extract_doc_id = [](const auto& value) {
     using T = std::decay_t<decltype(value)>;
     if constexpr (std::is_same_v<T, DocId>) {
-      return value < min_doc_id;
+      return value;
     } else {
-      return value.first < min_doc_id;
+      return value.first;
     }
   };
 
   auto needed_block = [&](const auto& it) {
-    return it->begin() != it->end() && !less_than_min_doc_id(it->Back());
+    return it->begin() != it->end() && min_doc_id <= extract_doc_id(it->Back());
   };
 
   // Choose the first block that has the last element >= min_doc_id
@@ -189,7 +189,7 @@ template <typename C> void BlockList<C>::BlockListIterator::SeekGE(DocId min_doc
   }
 
   BasicSeekGE(min_doc_id, block_end, &block_it);
-  DCHECK(block_it != block_end && !less_than_min_doc_id(*block_it));
+  DCHECK(block_it != block_end && min_doc_id <= extract_doc_id(*block_it));
 }
 
 template class BlockList<CompressedSortedSet>;

--- a/src/core/search/block_list.cc
+++ b/src/core/search/block_list.cc
@@ -152,6 +152,52 @@ typename BlockList<C>::BlockListIterator& BlockList<C>::BlockListIterator::opera
   return *this;
 }
 
+template <typename C> void BlockList<C>::BlockListIterator::SeekGE(DocId min_doc_id) {
+  if constexpr (std::is_same_v<C, CompressedSortedSet>) {
+    do {
+      operator++();
+    } while (it != it_end && (block_it == block_end || *block_it < min_doc_id));
+  } else {
+    if (it == it_end) {
+      block_it = {};
+      block_end = {};
+      return;
+    }
+
+    auto less_than_min_doc_id = [&](const auto& value) {
+      using T = std::decay_t<decltype(value)>;
+      if constexpr (std::is_same_v<T, DocId>) {
+        return value < min_doc_id;
+      } else {
+        return value.first < min_doc_id;
+      }
+    };
+
+    auto needed_block = [&](const auto& it) {
+      return it->begin() != it->end() && !less_than_min_doc_id(it->Back());
+    };
+
+    // Choose the first block that has the last element >= min_doc_id
+    if (!needed_block(it)) {
+      while (++it != it_end) {
+        if (needed_block(it)) {
+          block_it = it->begin();
+          block_end = it->end();
+          break;
+        }
+      }
+      if (it == it_end) {
+        block_it = {};
+        block_end = {};
+        return;
+      }
+    }
+
+    BasicSeekGE(min_doc_id, block_end, &block_it);
+    DCHECK(block_it != block_end && !less_than_min_doc_id(*block_it));
+  }
+}
+
 template class BlockList<CompressedSortedSet>;
 template class BlockList<SortedVector<DocId>>;
 template class BlockList<SortedVector<std::pair<DocId, double>>>;

--- a/src/core/search/block_list.h
+++ b/src/core/search/block_list.h
@@ -84,7 +84,7 @@ template <typename Container /* underlying container */> class BlockList {
     blocks_.clear();
   }
 
-  struct BlockListIterator {
+  struct BlockListIterator : public SeekableTag {
     // To make it work with std container contructors
     using iterator_category = std::forward_iterator_tag;
     using difference_type = std::ptrdiff_t;
@@ -97,6 +97,7 @@ template <typename Container /* underlying container */> class BlockList {
     }
 
     BlockListIterator& operator++();
+    void SeekGE(DocId min_doc_id);
 
     friend class BlockList;
 
@@ -167,6 +168,10 @@ template <typename T> class SortedVector {
 
   void Clear() {
     entries_.clear();
+  }
+
+  const T& Back() const {
+    return entries_.back();
   }
 
   using iterator = typename PMR_NS::vector<T>::const_iterator;

--- a/src/core/search/compressed_sorted_set.cc
+++ b/src/core/search/compressed_sorted_set.cc
@@ -206,7 +206,12 @@ std::pair<CompressedSortedSet, CompressedSortedSet> CompressedSortedSet::Split()
 
   // Move iterator to middle position and save size of diffs tail
   auto it = begin();
-  std::advance(it, size_ / 2);
+  std::advance(it, (size_ - 1) / 2);
+
+  // Save last value in the first set
+  tail_value_ = *it;
+  ++it;
+
   size_t keep_bytes = it.last_read_.data() - diffs_.data();
 
   // Copy second half into second set
@@ -215,7 +220,6 @@ std::pair<CompressedSortedSet, CompressedSortedSet> CompressedSortedSet::Split()
 
   // Erase diffs tail
   diffs_.resize(keep_bytes);
-  tail_value_ = std::nullopt;
   size_ -= second.Size();
 
   return std::make_pair(std::move(*this), std::move(second));

--- a/src/core/search/compressed_sorted_set.h
+++ b/src/core/search/compressed_sorted_set.h
@@ -86,6 +86,11 @@ class CompressedSortedSet {
   // Split into two equally sized halves
   std::pair<CompressedSortedSet, CompressedSortedSet> Split() &&;
 
+  IntType Back() const {
+    DCHECK(!Empty() && tail_value_.has_value());
+    return tail_value_.value();
+  }
+
  private:
   struct EntryLocation {
     IntType value;                        // Value or 0

--- a/src/core/search/index_result.h
+++ b/src/core/search/index_result.h
@@ -111,9 +111,7 @@ template <typename Iterator> void Seek(DocId min_doc_id, const Iterator& end, It
   if constexpr (IsSeekableIterator<Iterator>) {
     it->SeekGE(min_doc_id);
   } else {
-    while (*it != end && **it < min_doc_id) {
-      ++(*it);
-    }
+    BasicSeekGE(min_doc_id, end, it);
   }
 }
 

--- a/src/core/search/range_tree.h
+++ b/src/core/search/range_tree.h
@@ -249,7 +249,9 @@ inline RangeFilterIterator& RangeFilterIterator::operator++() {
 }
 
 inline void RangeFilterIterator::SeekGE(DocId min_doc_id) {
-  while (current_ != end_ && (!InRange(current_) || (*current_).first < min_doc_id)) {
+  current_.SeekGE(min_doc_id);
+  while (current_ != end_ && !InRange(current_)) {
+    DCHECK((*current_).first >= min_doc_id);
     ++current_;
   }
 }


### PR DESCRIPTION
Add block-level jumps to the BlockList, as well as power-of-two-length jumps based for base vector iterators.
This optimization speeds up merging for all index types, not just numeric indexes.

Before:
| Benchmark                                                  | Time (ns)  | CPU (ns)   | Iterations |
|------------------------------------------------------------|------------|------------|------------|
| BM_SearchNumericAndTagIndexes/num_docs:10000               | 12752      | 12751      | 5392       |
| BM_SearchNumericAndTagIndexes/num_docs:100000              | 1407975    | 1407833    | 497        |
| BM_SearchNumericAndTagIndexes/num_docs:1000000             | 11055515   | 11054017   | 64         |
| BM_SearchSeveralNumericAndTagIndexes/num_docs:10000        | 154778     | 154766     | 4535       |
| BM_SearchSeveralNumericAndTagIndexes/num_docs:100000       | 2084997    | 2084989    | 335        |
| BM_SearchSeveralNumericAndTagIndexes/num_docs:1000000      | 40143853   | 40141445   | 17         |


After:
| Benchmark                                                  | Time (ns)  | CPU (ns)   | Iterations |
|------------------------------------------------------------|------------|------------|------------|
| BM_SearchNumericAndTagIndexes/num_docs:10000               | 19200      | 19197      | 35978      |
| BM_SearchNumericAndTagIndexes/num_docs:100000              | 35147      | 35141      | 19515      |
| BM_SearchNumericAndTagIndexes/num_docs:1000000             | 10574950   | 10571685   | 65         |
| BM_SearchSeveralNumericAndTagIndexes/num_docs:10000        | 32930      | 32926      | 21365      |
| BM_SearchSeveralNumericAndTagIndexes/num_docs:100000       | 37653      | 37652      | 18845      |
| BM_SearchSeveralNumericAndTagIndexes/num_docs:1000000      | 31691981   | 31686310   | 23         |
