### PR TITLE
chore: Command dispatch refactoring

### DIFF
--- a/src/server/cluster/incoming_slot_migration.cc
+++ b/src/server/cluster/incoming_slot_migration.cc
@@ -91,9 +91,9 @@ class ClusterShardMigration {
                   << " canceled due memory limit reached";
           return;
         }
-        if (!tx_data->command.cmd_args.empty()) {
+        if (!tx_data->command.command.empty()) {
           VLOG(1) << "Flow finalization failed " << source_shard_id_ << " by "
-                  << tx_data->command.cmd_args[0];
+                  << tx_data->command.command;
         } else {
           VLOG(1) << "Flow finalization failed " << source_shard_id_ << " by opcode "
                   << (int)tx_data->opcode;
@@ -155,9 +155,8 @@ class ClusterShardMigration {
                                                 : error_code();
     } else {
       // TODO check which global commands should be supported
-      std::string error =
-          absl::StrCat("We don't support command: ", ToSV(tx_data.command.cmd_args[0]),
-                       " in cluster migration process.");
+      std::string error = absl::StrCat("We don't support command: ", tx_data.command.command,
+                                       " in cluster migration process.");
       LOG(ERROR) << error;
       cntx->ReportError(error);
       in_migration_->ReportError(error);

--- a/src/server/journal/executor.h
+++ b/src/server/journal/executor.h
@@ -34,15 +34,26 @@ class JournalExecutor {
   }
 
  private:
+  struct ErrorCounter : public facade::CapturingReplyBuilder {
+    explicit ErrorCounter() : CapturingReplyBuilder(facade::ReplyMode::NONE) {
+    }
+
+    void SendError(std::string_view str, std::string_view type) override;
+    void Reset();
+
+    size_t num_oom = 0, num_other = 0;
+  };
+
   facade::DispatchResult Execute(journal::ParsedEntry::CmdData& cmd);
 
   // Select database. Ensure it exists if accessed for first time.
   void SelectDb(DbIndex dbid);
 
   Service* service_;
-  facade::CapturingReplyBuilder reply_builder_;
+  ErrorCounter reply_builder_;
   ConnectionContext conn_context_;
 
+  std::vector<std::string_view> tmp_scratch_;
   std::vector<bool> ensured_dbs_;
 };
 

--- a/src/server/journal/tx_executor.cc
+++ b/src/server/journal/tx_executor.cc
@@ -68,15 +68,14 @@ void TransactionData::AddEntry(journal::ParsedEntry&& entry) {
 }
 
 bool TransactionData::IsGlobalCmd() const {
-  if (command.cmd_args.empty()) {
+  string_view cmd = command.command;
+  if (cmd.empty()) {
     return false;
   }
 
-  auto& args = command.cmd_args;
-  if (absl::EqualsIgnoreCase(ToSV(args[0]), "FLUSHDB"sv) ||
-      absl::EqualsIgnoreCase(ToSV(args[0]), "FLUSHALL"sv) ||
-      (absl::EqualsIgnoreCase(ToSV(args[0]), "DFLYCLUSTER"sv) &&
-       absl::EqualsIgnoreCase(ToSV(args[1]), "FLUSHSLOTS"sv))) {
+  if (absl::EqualsIgnoreCase(cmd, "FLUSHDB"sv) || absl::EqualsIgnoreCase(cmd, "FLUSHALL"sv) ||
+      (absl::EqualsIgnoreCase(cmd, "DFLYCLUSTER"sv) &&
+       absl::EqualsIgnoreCase(cmd, "FLUSHSLOTS"sv))) {
     return true;
   }
 

--- a/src/server/journal/types.cc
+++ b/src/server/journal/types.cc
@@ -38,10 +38,14 @@ string Entry::ToString() const {
 
 string ParsedEntry::ToString() const {
   string rv = absl::StrCat("{op=", opcode, ", dbid=", dbid, ", cmd='");
-  for (auto& arg : cmd.cmd_args) {
-    absl::StrAppend(&rv, facade::ToSV(arg));
-    absl::StrAppend(&rv, " ");
+  absl::StrAppend(&rv, cmd.command, " ");
+
+  size_t offset = 0;
+  for (uint32_t sz : cmd.arg_sizes) {
+    absl::StrAppend(&rv, cmd.arg_buf.substr(offset, sz), " ");
+    offset += sz;
   }
+
   rv.pop_back();
   rv += "'}";
   return rv;

--- a/src/server/journal/types.h
+++ b/src/server/journal/types.h
@@ -73,7 +73,7 @@ struct ParsedEntry : public EntryBase {
   struct CmdData {
     std::string command;
     std::string arg_buf;
-    absl::InlinedVector<uint32_t, 4> arg_sizes;
+    absl::InlinedVector<uint32_t, 4> arg_sizes{};
   } cmd;
 
   std::string ToString() const;

--- a/src/server/journal/types.h
+++ b/src/server/journal/types.h
@@ -71,11 +71,10 @@ struct Entry : public EntryBase {
 
 struct ParsedEntry : public EntryBase {
   struct CmdData {
-    std::unique_ptr<uint8_t[]> command_buf;
-    CmdArgVec cmd_args;  // represents the parsed command.
-    size_t cmd_len{0};
-  };
-  CmdData cmd;
+    std::string command;
+    std::string arg_buf;
+    absl::InlinedVector<uint32_t, 4> arg_sizes;
+  } cmd;
 
   std::string ToString() const;
 };

--- a/src/server/journal/types.h
+++ b/src/server/journal/types.h
@@ -73,7 +73,7 @@ struct ParsedEntry : public EntryBase {
   struct CmdData {
     std::string command;
     std::string arg_buf;
-    absl::InlinedVector<uint32_t, 4> arg_sizes{};
+    std::vector<uint32_t> arg_sizes;
   } cmd;
 
   std::string ToString() const;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1330,6 +1330,10 @@ DispatchResult Service::DispatchCommand(ArgSlice args, SinkReplyBuilder* builder
   dfly_cntx->cid = cid;
   InvokeCmd(cid, args_no_cmd, CommandContext{dfly_cntx->transaction, builder, dfly_cntx});
 
+  if (!dispatching_in_multi) {
+    dfly_cntx->transaction = nullptr;
+  }
+
   if (auto err = builder->ConsumeLastError(); !err.empty()) {
     LOG_EVERY_T(WARNING, 1) << FailedCommandToString(cid->name(), args_no_cmd, err);
     if (err == facade::kOutOfMemory)
@@ -1337,9 +1341,6 @@ DispatchResult Service::DispatchCommand(ArgSlice args, SinkReplyBuilder* builder
     return DispatchResult::ERROR;
   }
 
-  if (!dispatching_in_multi) {
-    dfly_cntx->transaction = nullptr;
-  }
   return DispatchResult::OK;
 }
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1331,6 +1331,7 @@ DispatchResult Service::DispatchCommand(ArgSlice args, SinkReplyBuilder* builder
   InvokeCmd(cid, args_no_cmd, CommandContext{dfly_cntx->transaction, builder, dfly_cntx});
 
   if (auto err = builder->ConsumeLastError(); !err.empty()) {
+    LOG_EVERY_T(WARNING, 1) << FailedCommandToString(cid->name(), args_no_cmd, err);
     if (err == facade::kOutOfMemory)
       return DispatchResult::OOM;
     return DispatchResult::ERROR;

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -43,9 +43,8 @@ class Service : public facade::ServiceInterface {
   size_t DispatchManyCommands(absl::Span<ArgSlice> args_list, facade::SinkReplyBuilder* builder,
                               facade::ConnectionContext* cntx) final;
 
-  // Check VerifyCommandExecution and invoke command with args
-  facade::DispatchResult InvokeCmd(const CommandId* cid, CmdArgList tail_args,
-                                   const CommandContext& cmd_cntx);
+  // Check VerifyCommandExecution and invoke command with args. Reply to builder
+  void InvokeCmd(const CommandId* cid, CmdArgList tail_args, const CommandContext& cmd_cntx);
 
   // Verify command can be executed now (check out of memory), always called immediately before
   // execution

--- a/src/server/multi_command_squasher.h
+++ b/src/server/multi_command_squasher.h
@@ -23,7 +23,7 @@ namespace dfly {
 class MultiCommandSquasher {
  public:
   struct Opts {
-    bool verify_commands = false;   // Whether commands need to be verified before execution
+    bool verify_commands = true;    // Whether commands need to be verified before execution
     bool error_abort = false;       // Abort upon receiving error
     unsigned max_squash_size = 32;  // How many commands to squash at once
   };
@@ -32,6 +32,9 @@ class MultiCommandSquasher {
 
   // Run all commands until completion. Returns number of processed commands.
   size_t Run(absl::Span<const StoredCmd> cmds, facade::RedisReplyBuilder* rb);
+
+  // Execute separate non-squashed cmd. Return false if aborting on error.
+  bool ExecuteStandalone(facade::RedisReplyBuilder* rb, const StoredCmd& cmd);
 
   static void SetMaxBusySquashUsec(uint32_t usec);
 
@@ -60,9 +63,6 @@ class MultiCommandSquasher {
 
   // Retrun squash flags
   SquashResult TrySquash(const StoredCmd* cmd);
-
-  // Execute separate non-squashed cmd. Return false if aborting on error.
-  bool ExecuteStandalone(facade::RedisReplyBuilder* rb, const StoredCmd* cmd);
 
   // Callback that runs on shards during squashed hop.
   facade::OpStatus SquashedHopCb(EngineShard* es, facade::RespVersion resp_v);

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2390,11 +2390,11 @@ error_code RdbLoaderBase::HandleJournalBlob(Service* service) {
     SET_OR_RETURN(journal_reader_.ReadEntry(), entry);
     done++;
 
-    if (entry.cmd.cmd_args.empty())
+    string_view cmd = entry.cmd.command;
+    if (cmd.empty())
       return RdbError(errc::rdb_file_corrupted);
 
-    if (absl::EqualsIgnoreCase(facade::ToSV(entry.cmd.cmd_args[0]), "FLUSHALL") ||
-        absl::EqualsIgnoreCase(facade::ToSV(entry.cmd.cmd_args[0]), "FLUSHDB")) {
+    if (absl::EqualsIgnoreCase(cmd, "FLUSHALL") || absl::EqualsIgnoreCase(cmd, "FLUSHDB")) {
       // Applying a flush* operation in the middle of a load can cause out-of-sync deletions of
       // data that should not be deleted, see https://github.com/dragonflydb/dragonfly/issues/1231
       // By returning an error we are effectively restarting the replication.


### PR DESCRIPTION
Preparation for squashing from journal executor and general cleanup

1. Change ParsedEntry format to be convertible to StoredCmd
2. Update `InvokeCmd` error propagation
3. Update MultiCommandSquasher interface to allow passing commands after initialization