### PR TITLE
chore: excessive logging in dragonfly connection

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1153,9 +1153,9 @@ void Connection::ConnectionFlow() {
 
   if (ec && !FiberSocketBase::IsConnClosed(ec)) {
     string conn_info = service_->GetContextInfo(cc_.get()).Format();
-    LOG(WARNING) << "Socket error for connection " << conn_info << " " << GetName()
-                 << " during phase " << kPhaseName[phase_] << " : " << ec << " " << ec.message()
-                 << ", socket state: " + dfly::GetSocketInfo(socket_->native_handle());
+    LOG_EVERY_T(5) << "Socket error for connection " << conn_info << " " << GetName()
+                   << " during phase " << kPhaseName[phase_] << " : " << ec << " " << ec.message()
+                   << ", socket state: " + dfly::GetSocketInfo(socket_->native_handle());
   }
 }
 

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1153,9 +1153,9 @@ void Connection::ConnectionFlow() {
 
   if (ec && !FiberSocketBase::IsConnClosed(ec)) {
     string conn_info = service_->GetContextInfo(cc_.get()).Format();
-    LOG_EVERY_T(5) << "Socket error for connection " << conn_info << " " << GetName()
-                   << " during phase " << kPhaseName[phase_] << " : " << ec << " " << ec.message()
-                   << ", socket state: " + dfly::GetSocketInfo(socket_->native_handle());
+    LOG_EVERY_T(WARNING, 1) << "Socket error for connection " << conn_info << " " << GetName()
+                            << " during phase " << kPhaseName[phase_] << " : " << ec << " "
+                            << ec.message();
   }
 }
 


### PR DESCRIPTION
`GetSocketInfo` is slow and when used frequently within a `LOG()` statement it can impose a significant amount of latency. From perf, it showed that 40% of cpu time was spent in that function, and specifically in `ReadTcpInfo`.

This PR reduces the time we call `LOG()` and removes the call to `GetSocketInfo` for the flow that it always returns "socket not found" (because the socket no longer exists in /proc/net/tcp and parsing it takes a big cpu slice).