### PR TITLE
fix: Allow CLUSTER commands during LOADING state

### DIFF
--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -1108,7 +1108,7 @@ inline CommandId::Handler3 HandlerFunc(ClusterFamily* se, EngineFunc f) {
 
 void ClusterFamily::Register(CommandRegistry* registry) {
   registry->StartFamily();
-  *registry << CI{"CLUSTER", CO::READONLY, -2, 0, 0, acl::kCluster}.HFUNC(Cluster)
+  *registry << CI{"CLUSTER", CO::READONLY | CO::LOADING, -2, 0, 0, acl::kCluster}.HFUNC(Cluster)
             << CI{"DFLYCLUSTER",    CO::ADMIN | CO::GLOBAL_TRANS | CO::HIDDEN, -2, 0, 0,
                   acl::kDflyCluster}
                    .HFUNC(DflyCluster)


### PR DESCRIPTION
Fixes: https://github.com/dragonflydb/dragonfly/issues/5561

- `ClusterConfig` - stored in thread-local memory structures, independent of database storage
- Node topology information - configuration metadata, not affected by data loading
- Network/connection info - immutable system configuration (flags, connection context)
- `ClusterConfig::Current()` uses thread-local objects with atomic updates
- Commands are read-only operations that don't modify any state
- Worst case: client gets slightly stale but valid cluster information

