### PR TITLE
server: Check result of `hdr_init`

### DIFF
--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -135,7 +135,9 @@ CommandId::CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first
                         acl_categories.value_or(ImplicitAclCategories(mask))) {
   implicit_acl_ = !acl_categories.has_value();
   hdr_histogram* hist = nullptr;
-  hdr_init(kLatencyHistogramMinValue, kLatencyHistogramMaxValue, kLatencyHistogramPrecision, &hist);
+  const auto init_result = hdr_init(kLatencyHistogramMinValue, kLatencyHistogramMaxValue,
+                                    kLatencyHistogramPrecision, &hist);
+  CHECK_EQ(init_result, 0) << "failed to initialize histogram for command " << name;
   latency_histogram_ = hist;
 }
 

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -135,8 +135,8 @@ CommandId::CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first
                         acl_categories.value_or(ImplicitAclCategories(mask))) {
   implicit_acl_ = !acl_categories.has_value();
   hdr_histogram* hist = nullptr;
-  const auto init_result = hdr_init(kLatencyHistogramMinValue, kLatencyHistogramMaxValue,
-                                    kLatencyHistogramPrecision, &hist);
+  const int init_result = hdr_init(kLatencyHistogramMinValue, kLatencyHistogramMaxValue,
+                                   kLatencyHistogramPrecision, &hist);
   CHECK_EQ(init_result, 0) << "failed to initialize histogram for command " << name;
   latency_histogram_ = hist;
 }


### PR DESCRIPTION
If histogram init fails, we should crash instead of using a null pointer as a histogram. 

init can fail for non-memory related reasons such as validations on the distance between lowest and highest values.
