### PR TITLE
chore: Don't use point_in_time_replication = False in test_replication_all

### DIFF
--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -51,27 +51,27 @@ Test full replication pipeline. Test full sync with streaming changes and stable
         pytest.param(8, [8, 8], dict(key_target=1_000_000, units=16), 50_000, marks=M_STRESS),
     ],
 )
+@pytest.mark.parametrize("mode", [({}), ({"cache_mode": "true"})])
 # Disabled cache_mode until #5371 is fixed
-# @pytest.mark.parametrize("mode", [({}), ({"cache_mode": "true"})])
-@pytest.mark.parametrize("point_in_time_replication", [True, False])
+# @pytest.mark.parametrize("point_in_time_replication", [True, False])
 async def test_replication_all(
     df_factory: DflyInstanceFactory,
     t_master,
     t_replicas,
     seeder_config,
     stream_target,
-    # mode,
-    point_in_time_replication,
+    mode,
+    # point_in_time_replication,
 ):
     args = {}
-    # if mode:
-    #    args["cache_mode"] = "true"
-    #    args["maxmemory"] = str(t_master * 256) + "mb"
+    if mode:
+        args["cache_mode"] = "true"
+        args["maxmemory"] = str(t_master * 256) + "mb"
 
     master = df_factory.create(
         admin_port=ADMIN_PORT,
         proactor_threads=t_master,
-        point_in_time_snapshot=point_in_time_replication,
+        # point_in_time_snapshot=point_in_time_replication,
         **args,
     )
     replicas = [


### PR DESCRIPTION
Setting `point_in_time_replication` to `False` can result in failing test when master and replica have different values. 

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->