### PR TITLE
docker: Remove cmake dir from dockerfile which no longer exists, add patches dir

### DIFF
--- a/src/external_libs.cmake
+++ b/src/external_libs.cmake
@@ -60,7 +60,7 @@ add_third_party(
 
 set(MIMALLOC_INCLUDE_DIR ${THIRD_PARTY_LIB_DIR}/mimalloc2/include)
 
-set(MIMALLOC_PATCH_DIR ${CMAKE_CURRENT_LIST_DIR}/../patches/mimalloc-v2.2.4/)
+set(MIMALLOC_PATCH_DIR ${CMAKE_CURRENT_LIST_DIR}/../patches/mimalloc-v2.2.4)
 
 add_third_party(mimalloc2
    # GIT_REPOSITORY https://github.com/microsoft/mimalloc/

--- a/tools/packaging/Dockerfile.alpine-dev
+++ b/tools/packaging/Dockerfile.alpine-dev
@@ -21,7 +21,6 @@ COPY ./Makefile ./CMakeLists.txt ./
 COPY src ./src
 
 COPY .git ./.git
-COPY cmake ./cmake
 COPY helio ./helio
 
 RUN make release

--- a/tools/packaging/Dockerfile.alpine-dev
+++ b/tools/packaging/Dockerfile.alpine-dev
@@ -21,6 +21,7 @@ COPY ./Makefile ./CMakeLists.txt ./
 COPY src ./src
 
 COPY .git ./.git
+COPY patches ./patches
 COPY helio ./helio
 
 RUN make release

--- a/tools/packaging/Dockerfile.ubuntu-dev
+++ b/tools/packaging/Dockerfile.ubuntu-dev
@@ -7,7 +7,6 @@ COPY ./Makefile ./CMakeLists.txt ./
 COPY src ./src
 
 COPY .git ./.git
-COPY cmake ./cmake
 COPY helio ./helio
 
 RUN make release

--- a/tools/packaging/Dockerfile.ubuntu-dev
+++ b/tools/packaging/Dockerfile.ubuntu-dev
@@ -7,6 +7,7 @@ COPY ./Makefile ./CMakeLists.txt ./
 COPY src ./src
 
 COPY .git ./.git
+COPY patches ./patches
 COPY helio ./helio
 
 RUN make release


### PR DESCRIPTION
The top level `cmake` directory was removed in a recent PR, it is cleaned up from the dockerfile here so the https://github.com/dragonflydb/dragonfly/actions/workflows/docker-dev-release.yml action can run. 

Dockerfiles in that action still try to copy cmake directory and fail.

The patches directory is added because the build failed while trying to patch mimalloc2.