### PR TITLE
feat: remove crc calculation for migration

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -53,7 +53,7 @@ namespace {
 constexpr uint32_t kMaxTtl = (1UL << 26);
 constexpr size_t DUMP_FOOTER_SIZE = sizeof(uint64_t) + sizeof(uint16_t);  // version number and crc
 
-std::optional<RdbVersion> GetRdbVersion(std::string_view msg) {
+std::optional<RdbVersion> GetRdbVersion(std::string_view msg, bool ignore_crc = false) {
   if (msg.size() <= DUMP_FOOTER_SIZE) {
     LOG(WARNING) << "got restore payload that is too short - " << msg.size();
     return std::nullopt;
@@ -70,15 +70,18 @@ std::optional<RdbVersion> GetRdbVersion(std::string_view msg) {
     return std::nullopt;
   }
 
-  // Compute expected crc64 based on the actual data upto the expected crc64 field.
-  uint64_t actual_cs =
-      crc64(0, reinterpret_cast<const uint8_t*>(msg.data()), msg.size() - sizeof(uint64_t));
   uint64_t expected_cs = absl::little_endian::Load64(footer + 2);  // skip the version
 
-  if (actual_cs != expected_cs) {
-    LOG(WARNING) << "CRC check failed for restore command, expecting: " << expected_cs << " got "
-                 << actual_cs;
-    return std::nullopt;
+  if (!ignore_crc) {
+    // Compute expected crc64 based on the actual data upto the expected crc64 field.
+    uint64_t actual_cs =
+        crc64(0, reinterpret_cast<const uint8_t*>(msg.data()), msg.size() - sizeof(uint64_t));
+
+    if (actual_cs != expected_cs) {
+      LOG(WARNING) << "CRC check failed for restore command, expecting: " << expected_cs << " got "
+                   << actual_cs;
+      return std::nullopt;
+    }
   }
 
   return version;
@@ -1610,7 +1613,7 @@ void GenericFamily::Restore(CmdArgList args, const CommandContext& cmd_cntx) {
   std::string_view key = ArgS(args, 0);
   std::string_view serialized_value = ArgS(args, 2);
 
-  auto rdb_version = GetRdbVersion(serialized_value);
+  auto rdb_version = GetRdbVersion(serialized_value, cmd_cntx.conn_cntx->journal_emulated);
   auto* builder = cmd_cntx.rb;
   if (!rdb_version) {
     return builder->SendError(kInvalidDumpValueErr);

--- a/src/server/journal/cmd_serializer.cc
+++ b/src/server/journal/cmd_serializer.cc
@@ -213,7 +213,7 @@ void CmdSerializer::SerializeRestore(string_view key, const PrimeValue& pk, cons
   args.push_back(expire_str);
 
   io::StringSink value_dump_sink;
-  SerializerBase::DumpObject(pv, &value_dump_sink);
+  SerializerBase::DumpObject(pv, &value_dump_sink, true);
   args.push_back(value_dump_sink.str());
 
   args.push_back("ABSTTL");  // Means expire string is since epoch

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -828,14 +828,15 @@ VersionBuffer MakeRdbVersion() {
   return buf;
 }
 
-CrcBuffer MakeCheckSum(std::string_view dump_res) {
-  uint64_t chksum = crc64(0, reinterpret_cast<const uint8_t*>(dump_res.data()), dump_res.size());
+CrcBuffer MakeCheckSum(std::string_view dump_res, bool ignore_crc) {
+  uint64_t chksum =
+      ignore_crc ? 0 : crc64(0, reinterpret_cast<const uint8_t*>(dump_res.data()), dump_res.size());
   CrcBuffer buf;
   absl::little_endian::Store64(buf.data(), chksum);
   return buf;
 }
 
-void AppendFooter(io::StringSink* dump_res) {
+void AppendFooter(io::StringSink* dump_res, bool ignore_crc) {
   auto to_bytes = [](const auto& buf) {
     return io::Bytes(reinterpret_cast<const uint8_t*>(buf.data()), buf.size());
   };
@@ -848,12 +849,12 @@ void AppendFooter(io::StringSink* dump_res) {
    */
   const auto ver = MakeRdbVersion();
   dump_res->Write(to_bytes(ver));
-  const auto crc = MakeCheckSum(dump_res->str());
+  const auto crc = MakeCheckSum(dump_res->str(), ignore_crc);
   dump_res->Write(to_bytes(crc));
 }
 }  // namespace
 
-void SerializerBase::DumpObject(const CompactObj& obj, io::StringSink* out) {
+void SerializerBase::DumpObject(const CompactObj& obj, io::StringSink* out, bool ignore_crc) {
   CompressionMode compression_mode = GetDefaultCompressionMode();
   if (compression_mode != CompressionMode::NONE) {
     compression_mode = CompressionMode::SINGLE_ENTRY;
@@ -871,8 +872,8 @@ void SerializerBase::DumpObject(const CompactObj& obj, io::StringSink* out) {
   ec = serializer.SaveValue(obj);
   CHECK(!ec);  // make sure that fully was successful
   ec = serializer.FlushToSink(out, SerializerBase::FlushState::kFlushMidEntry);
-  CHECK(!ec);         // make sure that fully was successful
-  AppendFooter(out);  // version and crc
+  CHECK(!ec);                     // make sure that fully was successful
+  AppendFooter(out, ignore_crc);  // version and crc
   CHECK_GT(out->str().size(), 10u);
 }
 

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -160,7 +160,7 @@ class SerializerBase {
   virtual ~SerializerBase() = default;
 
   // Dumps `obj` in DUMP command format into `out`. Uses default compression mode.
-  static void DumpObject(const CompactObj& obj, io::StringSink* out);
+  static void DumpObject(const CompactObj& obj, io::StringSink* out, bool ignore_crc = false);
 
   // Internal buffer size. Might shrink after flush due to compression.
   size_t SerializedLen() const;


### PR DESCRIPTION
Problem: During the cluster migration process, we waste CPU resources on CRC calculation
Fix: ignore CRC during the  migration process