### PR TITLE
feat: fix lua memory deallocation and lua_mem_gc_threshold=0 disable lua force GC calls

### DIFF
--- a/src/core/interpreter.cc
+++ b/src/core/interpreter.cc
@@ -1224,10 +1224,10 @@ void InterpreterManager::Return(Interpreter* ir) {
     auto before = steady_clock::now();
     tl_stats().gc_freed_memory += ir->RunGC();
 
-    LOG_EVERY_T(INFO, 10) << "stats_used_bytes: " << tl_stats().used_bytes
-                          << " lua_mem_gc_threshold: " << max_memory_usage
-                          << " force_gc_calls: " << tl_stats().force_gc_calls
-                          << " freed_mem: " << tl_stats().gc_freed_memory;
+    VLOG(2) << "stats_used_bytes: " << tl_stats().used_bytes
+            << " lua_mem_gc_threshold: " << max_memory_usage
+            << " force_gc_calls: " << tl_stats().force_gc_calls
+            << " freed_mem: " << tl_stats().gc_freed_memory;
 
     auto after = steady_clock::now();
     tl_stats().gc_duration_ns += duration_cast<nanoseconds>(after - before).count();

--- a/src/core/interpreter.cc
+++ b/src/core/interpreter.cc
@@ -589,6 +589,8 @@ void* mimalloc_glue(void* ud, void* ptr, size_t osize, size_t nsize) {
 Interpreter::Interpreter() {
   InterpreterManager::tl_stats().interpreter_cnt++;
 
+  // interpreter can be runnned in different threads so we need to calculate
+  // used memory via &used_bytes_ additional parameter
   lua_ = lua_newstate(mimalloc_glue, &used_bytes_);
   InitLua(lua_);
   void** ptr = static_cast<void**>(lua_getextraspace(lua_));

--- a/src/core/interpreter.h
+++ b/src/core/interpreter.h
@@ -154,7 +154,7 @@ class Interpreter {
   unsigned cmd_depth_ = 0;
   RedisFunc redis_func_;
   std::string buffer_;
-  std::int64_t used_bytes_ = 0;
+  int64_t used_bytes_ = 0;
   char name_buffer_[32];  // backing storage for cmd name
 };
 

--- a/src/core/interpreter.h
+++ b/src/core/interpreter.h
@@ -90,9 +90,7 @@ class Interpreter {
   AddResult AddFunction(std::string_view sha, std::string_view body, std::string* error);
 
   int64_t TakeUsedBytes() {
-    int64_t tmp = used_bytes_;
-    used_bytes_ = 0;
-    return tmp;
+    return std::exchange(used_bytes_, 0);
   }
 
   bool Exists(std::string_view sha) const;
@@ -156,7 +154,7 @@ class Interpreter {
   unsigned cmd_depth_ = 0;
   RedisFunc redis_func_;
   std::string buffer_;
-  std::int64_t used_bytes_;
+  std::int64_t used_bytes_ = 0;
   char name_buffer_[32];  // backing storage for cmd name
 };
 

--- a/src/core/interpreter.h
+++ b/src/core/interpreter.h
@@ -89,6 +89,12 @@ class Interpreter {
   // Add function with sha and body to interpreter.
   AddResult AddFunction(std::string_view sha, std::string_view body, std::string* error);
 
+  int64_t TakeUsedBytes() {
+    int64_t tmp = used_bytes_;
+    used_bytes_ = 0;
+    return tmp;
+  }
+
   bool Exists(std::string_view sha) const;
 
   enum RunResult {
@@ -150,6 +156,7 @@ class Interpreter {
   unsigned cmd_depth_ = 0;
   RedisFunc redis_func_;
   std::string buffer_;
+  std::int64_t used_bytes_;
   char name_buffer_[32];  // backing storage for cmd name
 };
 

--- a/src/core/interpreter_test.cc
+++ b/src/core/interpreter_test.cc
@@ -573,8 +573,6 @@ TEST_F(InterpreterTest, LuaGcStatistic) {
   // force_gc_calls shouldn't be called
   im.Return(interpreter);
   EXPECT_EQ(force_gc_calls, InterpreterManager::tl_stats().force_gc_calls);
-
-  // im.Return() update statistic
   EXPECT_LE(used_bytes, InterpreterManager::tl_stats().used_bytes);
 
   used_bytes = InterpreterManager::tl_stats().used_bytes;


### PR DESCRIPTION
problem: incorrect calculation of memory allocation/deallocation in the lua script, because of script is executing in different threads but statistic is thread_local

fix: every script calculates the used memory and statistic updates only in the corresponding thread where the script was get/returned 