### PR TITLE
core: Minor cleanups in bloom filters

### DIFF
--- a/src/core/bloom.cc
+++ b/src/core/bloom.cc
@@ -19,7 +19,7 @@ using namespace std;
 
 namespace {
 
-inline XXH128_hash_t Hash(string_view str) {
+XXH128_hash_t Hash(string_view str) {
   return XXH3_128bits_withSeed(str.data(), str.size(), 0xc6a4a7935bd1e995ULL);  // murmur2 seed
 }
 
@@ -27,14 +27,14 @@ uint64_t GetMask(unsigned log) {
   return (1ULL << log) - 1;
 }
 
-inline uint64_t BitIndex(uint64_t low, uint64_t hi, unsigned i, uint64_t mask) {
+uint64_t BitIndex(uint64_t low, uint64_t hi, unsigned i, uint64_t mask) {
   return (low + hi * i) & mask;
 }
 
 constexpr double kDenom = M_LN2 * M_LN2;
 constexpr double kSBFErrorFactor = 0.5;
 
-inline double BPE(double fp_prob) {
+double BPE(double fp_prob) {
   return -log(fp_prob) / kDenom;
 }
 
@@ -44,7 +44,7 @@ Bloom::~Bloom() {
   CHECK(bf_ == nullptr);
 }
 
-Bloom::Bloom(Bloom&& o) : hash_cnt_(o.hash_cnt_), bit_log_(o.bit_log_), bf_(o.bf_) {
+Bloom::Bloom(Bloom&& o) noexcept : hash_cnt_(o.hash_cnt_), bit_log_(o.bit_log_), bf_(o.bf_) {
   o.bf_ = nullptr;
 }
 
@@ -100,13 +100,13 @@ bool Bloom::Exists(const uint64_t fp[2]) const {
   return true;
 }
 
-bool Bloom::Add(std::string_view str) {
+bool Bloom::Add(std::string_view str) const {
   XXH128_hash_t hash = Hash(str);
   uint64_t fp[2] = {hash.low64, hash.high64};
   return Add(fp);
 }
 
-bool Bloom::Add(const uint64_t fp[2]) {
+bool Bloom::Add(const uint64_t fp[2]) const {
   uint64_t mask = GetMask(bit_log_);
 
   unsigned changes = 0;
@@ -132,7 +132,7 @@ inline bool Bloom::IsSet(size_t bit_idx) const {
   return (b & (1 << bit_idx)) != 0;
 }
 
-inline bool Bloom::Set(size_t bit_idx) {
+inline bool Bloom::Set(size_t bit_idx) const {
   uint64_t byte_idx = bit_idx / 8;
   bit_idx %= 8;
 
@@ -166,7 +166,7 @@ SBF::~SBF() {
     f.Destroy(mr);
 }
 
-SBF& SBF::operator=(SBF&& src) {
+SBF& SBF::operator=(SBF&& src) noexcept {
   filters_.clear();
   filters_.swap(src.filters_);
   grow_factor_ = src.grow_factor_;

--- a/src/core/bloom.h
+++ b/src/core/bloom.h
@@ -14,11 +14,10 @@ namespace dfly {
 
 /// Bloom filter based on the design of https://github.com/jvirkki/libbloom
 class Bloom {
-  Bloom(const Bloom&) = delete;
-  Bloom& operator=(const Bloom&) = delete;
-
  public:
   Bloom() = default;
+  Bloom(const Bloom&) = delete;
+  Bloom& operator=(const Bloom&) = delete;
 
   // Note, that Destroy() must be called before calling the d'tor
   ~Bloom();
@@ -36,7 +35,7 @@ class Bloom {
   // resource - resource with which the object was initialized.
   void Destroy(PMR_NS::memory_resource* resource);
 
-  Bloom(Bloom&& o);
+  Bloom(Bloom&& o) noexcept;
 
   bool Exists(std::string_view str) const;
 
@@ -46,8 +45,8 @@ class Bloom {
   // Adds an item to the bloom filter.
   // Returns true if element was not present and was added,
   // false - if element (or a collision) had already been added previously.
-  bool Add(std::string_view str);
-  bool Add(const uint64_t fp[2]);
+  bool Add(std::string_view str) const;
+  bool Add(const uint64_t fp[2]) const;
 
   size_t bitlen() const {
     return 1ULL << bit_log_;
@@ -68,7 +67,7 @@ class Bloom {
 
  private:
   bool IsSet(size_t index) const;
-  bool Set(size_t index);  // return true if bit was set (i.e was 0 before)
+  bool Set(size_t index) const;  // return true if bit was set (i.e was 0 before)
 
   uint8_t hash_cnt_ = 0;
   uint8_t bit_log_ = 0;    // log of bit length of the filter. bit length is always power of 2.
@@ -84,10 +83,9 @@ class Bloom {
  * TODO: to test the actual rate of this filter.
  */
 class SBF {
-  SBF(const SBF&) = delete;
-
  public:
   SBF(uint64_t initial_capacity, double fp_prob, double grow_factor, PMR_NS::memory_resource* mr);
+  SBF(const SBF&) = delete;
 
   // C'tor used for loading persisted filters into SBF.
   // Should be followed by AddFilter.
@@ -95,7 +93,7 @@ class SBF {
       size_t current_size, PMR_NS::memory_resource* mr);
   ~SBF();
 
-  SBF& operator=(SBF&& src);
+  SBF& operator=(SBF&& src) noexcept;
 
   void AddFilter(const std::string& blob, unsigned hash_cnt);
 


### PR DESCRIPTION
* Make deleted member methods public, so that compilation failure due to these generates clearer errors such as `method is deleted`, rather than `method is private`
* Mark move c-tors noexcept so that they can be used by STL style containers instead of falling back to copying. The move ctors can be marked noexcept as they perform trivial moves.
* Remove some inline qualifiers from functions in anonymous namespace.
* Make some methods const - even though the `Add/Set` methods change state, they do so via pointer, so they qualify to be const as they do not reseat the pointer.