### PR TITLE
feat: introduce a CPU budget parameter to control slot migration pacing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,8 @@ jobs:
           EOF
 
           gdb -ix ./init.gdb --batch -ex r --args ./dragonfly_test --force_epoll
-          FLAGS_fiber_safety_margin=4096 FLAGS_force_epoll=true GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 timeout 20m ctest -V -L DFLY -E allocation_tracker_test
+          GLOG_alsologtostderr=1 FLAGS_fiber_safety_margin=4096 FLAGS_force_epoll=true GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 \
+          timeout 20m ctest -V -L DFLY -E allocation_tracker_test
 
           FLAGS_fiber_safety_margin=4096 FLAGS_force_epoll=true timeout 5m ./allocation_tracker_test
 

--- a/src/redis/zmalloc.h
+++ b/src/redis/zmalloc.h
@@ -128,6 +128,7 @@ int zmalloc_get_allocator_wasted_blocks(float ratio, size_t* allocated, size_t* 
  * This uses the current local thread heap.
  * return 0 if not, 1 if underutilized
  */
+struct mi_page_usage_stats_s;
 void zmalloc_page_is_underutilized(void* ptr, float ratio, int collect_stats, struct mi_page_usage_stats_s* result);
 char* zstrdup(const char* s);
 

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -458,7 +458,7 @@ DbSlice::AutoUpdater::AutoUpdater(AutoUpdater&& o) noexcept {
   *this = std::move(o);
 }
 
-DbSlice::AutoUpdater& DbSlice::AutoUpdater::operator=(AutoUpdater&& o) {
+DbSlice::AutoUpdater& DbSlice::AutoUpdater::operator=(AutoUpdater&& o) noexcept {
   Run();
   fields_ = o.fields_;
   o.Cancel();

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -153,7 +153,7 @@ class DbSlice {
     AutoUpdater(const AutoUpdater& o) = delete;
     AutoUpdater& operator=(const AutoUpdater& o) = delete;
     AutoUpdater(AutoUpdater&& o) noexcept;
-    AutoUpdater& operator=(AutoUpdater&& o);
+    AutoUpdater& operator=(AutoUpdater&& o) noexcept;
     ~AutoUpdater();
 
     // Removes the memory usage attributed to the iterator and resets orig_heap_size.
@@ -192,22 +192,7 @@ class DbSlice {
   };
 
   using Context = DbContext;
-
-  // ChangeReq - describes the change to the table.
-  struct ChangeReq {
-    // If iterator is set then it's an update to the existing bucket.
-    // Otherwise (string_view is set) then it's a new key that is going to be added to the table.
-    std::variant<PrimeTable::bucket_iterator, std::string_view> change;
-
-    explicit ChangeReq(PrimeTable::bucket_iterator it) : change(it) {
-    }
-    explicit ChangeReq(std::string_view key) : change(key) {
-    }
-
-    const PrimeTable::bucket_iterator* update() const {
-      return std::get_if<PrimeTable::bucket_iterator>(&change);
-    }
-  };
+  using ChangeReq = dfly::ChangeReq;
 
   // Called before deleting an element to notify the search indices.
   using DocDeletionCallback =
@@ -587,7 +572,7 @@ class DbSlice {
 
   void CreateDb(DbIndex index);
 
-  enum class UpdateStatsMode {
+  enum class UpdateStatsMode : uint8_t {
     kReadStats,
     kMutableStats,
   };

--- a/src/server/geo_family.cc
+++ b/src/server/geo_family.cc
@@ -826,12 +826,15 @@ void GeoFamily::GeoRadius(CmdArgList args, const CommandContext& cmd_cntx) {
         // an option requiring an argument was missing its argument.
         // The parser has already recorded the error. We retrieve it and send it.
         DCHECK(parser.Error().has_value());
+        LOG_EVERY_T(INFO, 1) << "GeoRadius parser error: " << parser.Error()->MakeReply().ToSv();
         return builder->SendError(parser.Error()->MakeReply());
     }
   }
 
   if (!parser.Finalize()) {
     auto error = parser.Error();
+    LOG_EVERY_T(INFO, 1) << "GeoRadius parser error: " << error->MakeReply().ToSv();
+
     switch (error->type) {
       case Errors::INVALID_LONG_LAT: {
         string err =

--- a/src/server/journal/cmd_serializer.cc
+++ b/src/server/journal/cmd_serializer.cc
@@ -18,14 +18,14 @@ class CommandAggregator {
   using WriteCmdCallback = std::function<void(absl::Span<const string_view>)>;
 
   CommandAggregator(string_view key, WriteCmdCallback cb, size_t max_agg_bytes)
-      : key_(key), cb_(cb), max_aggragation_bytes_(max_agg_bytes) {
+      : key_(key), cb_(std::move(cb)), max_aggragation_bytes_(max_agg_bytes) {
   }
 
   ~CommandAggregator() {
     CommitPending();
   }
 
-  enum class CommitMode { kAuto, kNoCommit };
+  enum class CommitMode : uint8_t { kAuto, kNoCommit };
 
   // Returns whether CommitPending() was called
   bool AddArg(string arg, CommitMode commit_mode = CommitMode::kAuto) {

--- a/src/server/journal/streamer.cc
+++ b/src/server/journal/streamer.cc
@@ -7,14 +7,19 @@
 #include <absl/functional/bind_front.h>
 #include <sys/socket.h>
 
+#include <chrono>
+
 #ifdef __linux__
 #include <netinet/tcp.h>
 #endif
 
 #include "base/flags.h"
 #include "base/logging.h"
+#include "server/db_slice.h"
 #include "server/engine_shard.h"
 #include "server/journal/cmd_serializer.h"
+#include "server/journal/serializer.h"
+#include "server/rdb_save.h"
 #include "server/server_state.h"
 #include "util/fibers/synchronization.h"
 
@@ -32,13 +37,16 @@ ABSL_FLAG(uint32_t, migration_buckets_sleep_usec, 100,
           "Sleep time in microseconds after each time we reach "
           "migration_buckets_serialization_threshold");
 
+ABSL_FLAG(float, migration_buckets_cpu_budget, 0.2,
+          "How much CPU budget to use for migration buckets serialization");
+
 ABSL_FLAG(uint32_t, replication_dispatch_threshold, 1500,
           "Number of bytes to aggregate before replication");
 
 namespace dfly {
 using namespace util;
 using namespace journal;
-
+using namespace std;
 namespace {
 
 iovec IoVec(io::Bytes src) {
@@ -370,9 +378,21 @@ void RestoreStreamer::Run() {
     // If someone else is waiting for the inflight bytes to complete, give it priority.
     // Apparently, continue goes through the loop by checking the condition below, so we check
     // cursor here as well.
-    if (cursor &&
-        (throttle_waiters_ > 0 || inflight_bytes() > replication_stream_output_limit_cached / 3)) {
+    // In addition if bucket writing was too intensive on CPU and we are overloaded.
+    // Note that we account for CPU time from OnDbChange and here as well (inside WriteBucket).
+    // But we only throttle here, so if we migrated lots of slots during mutations, we
+    // won't progress here but if we have not, then this fiber will progress withing the
+    // CPU budget we defined for it.
+    bool should_stall =
+        throttle_waiters_ > 0 || inflight_bytes() > replication_stream_output_limit_cached / 3 ||
+        cpu_aggregator_.IsOverloaded(absl::GetFlag(FLAGS_migration_buckets_cpu_budget));
+    if (cursor && should_stall) {
       ThisFiber::SleepFor(300us);
+
+      // We have a design bug in RealTimeAggregator that resets it measurements only when
+      // the next sample is taken. So we add this sample to ensure cpu_aggregator_
+      // refreshes its state.
+      base::CpuTimeGuard guard(&cpu_aggregator_);
       stats_.iter_skips++;
       continue;
     }
@@ -399,8 +419,11 @@ void RestoreStreamer::Run() {
       stats_.buckets_loop += WriteBucket(it);
     });
 
+    // TODO: FLAGS_migration_buckets_cpu_budget should eventually be a single configurable
+    // setting that controls how agressive we are with migration pace.
+    // Once we gain confidence with FLAGS_migration_buckets_cpu_budget we should retire
+    // migration_buckets_serialization_threshold and migration_buckets_sleep_usec.
     if (++last_yield >= migration_buckets_serialization_threshold_cached) {
-      // TODO: to align this with how we sleep in SliceSnapshot::FlushSerialized.
       ThisFiber::SleepFor(chrono::microseconds(migration_buckets_sleep_usec_cached));
       last_yield = 0;
     }
@@ -475,6 +498,8 @@ bool RestoreStreamer::WriteBucket(PrimeTable::bucket_iterator it) {
   bool written = false;
 
   if (!it.is_done() && it.GetVersion() < snapshot_version_) {
+    base::CpuTimeGuard guard(&cpu_aggregator_);
+
     stats_.buckets_written++;
 
     it.SetVersion(snapshot_version_);

--- a/src/server/table.h
+++ b/src/server/table.h
@@ -151,4 +151,20 @@ struct DbTable : boost::intrusive_ref_counter<DbTable, boost::thread_unsafe_coun
 // the snapshot process. We copy the pointers in StartSnapshotInShard function.
 using DbTableArray = std::vector<boost::intrusive_ptr<DbTable>>;
 
+// ChangeReq - describes the change to the table.
+struct ChangeReq {
+  // If iterator is set then it's an update to the existing bucket.
+  // Otherwise (string_view is set) then it's a new key that is going to be added to the table.
+  std::variant<PrimeTable::bucket_iterator, std::string_view> change;
+
+  explicit ChangeReq(PrimeTable::bucket_iterator it) : change(it) {
+  }
+  explicit ChangeReq(std::string_view key) : change(key) {
+  }
+
+  const PrimeTable::bucket_iterator* update() const {
+    return std::get_if<PrimeTable::bucket_iterator>(&change);
+  }
+};
+
 }  // namespace dfly


### PR DESCRIPTION
This heuristic should replace the previous flags like --migration_buckets_sleep_usec and --migration_buckets_serialization_threshold which are still present as safeguards.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->