### PR TITLE
docs(build): fix missing -D flag in minimal debug build command

### DIFF
--- a/docs/build-from-source.md
+++ b/docs/build-from-source.md
@@ -69,7 +69,7 @@ cd build-opt && ninja dragonfly
 Minimal debug build:
 
 ```bash
-./helio/blaze.sh -DWITH_AWS=OFF -DWITH_SEARCH=OFF -WITH_COLLECTION_CMDS=OFF -DWITH_EXTENSION_CMDS=OFF
+./helio/blaze.sh -DWITH_AWS=OFF -DWITH_SEARCH=OFF -DWITH_COLLECTION_CMDS=OFF -DWITH_EXTENSION_CMDS=OFF
 ```
 
 ## Step 4 - voilà


### PR DESCRIPTION
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->