### PR TITLE
feat: use SET instead of RESTORE for strings during slot migrations

### DIFF
--- a/src/server/journal/cmd_serializer.h
+++ b/src/server/journal/cmd_serializer.h
@@ -38,6 +38,7 @@ class CmdSerializer {
   size_t SerializeZSet(std::string_view key, const PrimeValue& pv);
   size_t SerializeHash(std::string_view key, const PrimeValue& pv);
   size_t SerializeList(std::string_view key, const PrimeValue& pv);
+  size_t SerializeString(std::string_view key, const PrimeValue& pv);
   void SerializeRestore(std::string_view key, const PrimeValue& pk, const PrimeValue& pv,
                         uint64_t expire_ms);
 


### PR DESCRIPTION
Problem: RESTORE uses more resources than SET
fixes: https://github.com/dragonflydb/dragonfly/issues/5610