### PR TITLE
chore: sort per shard sorted sets for SINTER

### DIFF
--- a/src/server/engine_shard_set_test.cc
+++ b/src/server/engine_shard_set_test.cc
@@ -30,36 +30,10 @@ using testing::Pair;
 
 class RoundRobinSharderTest : public BaseFamilyTest {
  protected:
-  RoundRobinSharderTest() : BaseFamilyTest() {
+  RoundRobinSharderTest() {
     absl::SetFlag(&FLAGS_shard_round_robin_prefix, "RR:");
     SetTestFlag("cluster_mode", "emulated");
     ResetService();
-  }
-
-  map<int, int> GetShardKeyCount() {
-    map<int, int> m;
-
-    auto res = Run({"debug", "shards"});
-    for (string_view line : absl::StrSplit(res.GetString(), '\n')) {
-      vector<string> parts = absl::StrSplit(line, ": ");
-      if (parts.size() != 2) {
-        continue;
-      }
-
-      string_view k = parts[0];
-      if (!absl::StartsWith(k, "shard") || !absl::EndsWith(k, "_key_count")) {
-        continue;
-      }
-
-      CHECK(absl::ConsumePrefix(&k, "shard")) << k;
-      CHECK(absl::ConsumeSuffix(&k, "_key_count")) << k;
-      int sid;
-      CHECK(absl::SimpleAtoi(k, &sid));
-      int count;
-      CHECK(absl::SimpleAtoi(parts[1], &count));
-      m[sid] = count;
-    }
-    return m;
   }
 };
 

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -428,10 +428,10 @@ OpResult<SvArray> InterResultVec(const ResultStringVec& result_vec, unsigned req
   }
 
   // Sort the per shard-sorted sets
-  std::sort(sorted_vec.begin(), sorted_vec.end(),
-            [](const auto* lhs, const auto* rhs) { return lhs->size() < rhs->size(); });
-
   if (!sorted_vec.empty()) {
+    std::sort(sorted_vec.begin(), sorted_vec.end(),
+              [](const auto* lhs, const auto* rhs) { return lhs->size() < rhs->size(); });
+
     for (const string& s : *sorted_vec[0]) {
       uniques.emplace(s, 1);
     }

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -419,22 +419,27 @@ OpResult<SvArray> InterResultVec(const ResultStringVec& result_vec, unsigned req
       return OpStatus::OK;  // empty set.
   }
 
-  bool first = true;
+  std::vector<const StringVec*> sorted_vec;
   for (const auto& res : result_vec) {
     if (res.status() == OpStatus::SKIPPED)
       continue;
-
     DCHECK(res);  // we handled it above.
+    sorted_vec.push_back(&res.value());
+  }
 
-    // I use this awkward 'first' condition instead of table[s]++ deliberately.
-    // I do not want to add keys that I know will not stay in the set.
-    if (first) {
-      for (const string& s : res.value()) {
-        uniques.emplace(s, 1);
-      }
-      first = false;
-    } else {
-      for (const string& s : res.value()) {
+  // Sort the per shard-sorted sets
+  std::sort(sorted_vec.begin(), sorted_vec.end(),
+            [](const auto* lhs, const auto* rhs) { return lhs->size() < rhs->size(); });
+
+  if (!sorted_vec.empty()) {
+    for (const string& s : *sorted_vec[0]) {
+      uniques.emplace(s, 1);
+    }
+    // Remove the smallest
+    sorted_vec.erase(sorted_vec.begin());
+
+    for (const auto& res : sorted_vec) {
+      for (const string& s : *res) {
         auto it = uniques.find(s);
         if (it != uniques.end()) {
           ++it->second;

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -783,6 +783,32 @@ void BaseFamilyTest::SetTestFlag(string_view flag_name, string_view new_value) {
   CHECK(flag->ParseFrom(new_value, &error)) << "Error: " << error;
 }
 
+std::map<int, int> BaseFamilyTest::GetShardKeyCount() {
+  map<int, int> m;
+
+  auto res = Run({"debug", "shards"});
+  for (string_view line : absl::StrSplit(res.GetString(), '\n')) {
+    vector<string> parts = absl::StrSplit(line, ": ");
+    if (parts.size() != 2) {
+      continue;
+    }
+
+    string_view k = parts[0];
+    if (!absl::StartsWith(k, "shard") || !absl::EndsWith(k, "_key_count")) {
+      continue;
+    }
+
+    CHECK(absl::ConsumePrefix(&k, "shard")) << k;
+    CHECK(absl::ConsumeSuffix(&k, "_key_count")) << k;
+    int sid;
+    CHECK(absl::SimpleAtoi(k, &sid));
+    int count;
+    CHECK(absl::SimpleAtoi(parts[1], &count));
+    m[sid] = count;
+  }
+  return m;
+}
+
 const acl::AclFamily* BaseFamilyTest::TestInitAclFam() {
   absl::SetFlag(&FLAGS_acllog_max_len, 0);
   return service_->TestInit();

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -70,7 +70,6 @@ class BaseFamilyTest : public ::testing::Test {
   void SetUp() override;
   void TearDown() override;
 
- protected:
   class TestConnWrapper;
 
   RespExpr Run(std::initializer_list<const std::string_view> list) {
@@ -159,6 +158,8 @@ class BaseFamilyTest : public ::testing::Test {
   static void SetTestFlag(std::string_view flag_name, std::string_view new_value);
 
   const acl::AclFamily* TestInitAclFam();
+
+  std::map<int, int> GetShardKeyCount();
 
   std::unique_ptr<util::ProactorPool> pp_;
   std::unique_ptr<Service> service_;

--- a/tests/dragonfly/set_test.py
+++ b/tests/dragonfly/set_test.py
@@ -23,21 +23,3 @@ async def test_sscan_regression(df_factory: DflyInstanceFactory):
     # Takes 3 seconds
     res = await client.execute_command("SLOWLOG GET 100")
     assert res == []
-
-
-@pytest.mark.asyncio
-async def test_sinter_regression(df_factory: DflyInstanceFactory):
-    df = df_factory.create(proactor_threads=4, shard_round_robin_prefix="prefix-")
-    df.start()
-
-    client = df.client()
-
-    await client.execute_command("DEBUG POPULATE 1 prefix- 5 RAND ELEMENTS 5000 TYPE SET")
-    # add a common element to SINTER on a small set
-    await client.execute_command("SADD prefix-:0 common")
-    # create another key prefix-foo with 3 elements
-    await client.execute_command("SADD prefix-foo bar hello common")
-    await client.execute_command("SINTER prefix-foo prefix-:0")
-
-    res = await client.execute_command("SLOWLOG GET 100")
-    assert res == []

--- a/tests/dragonfly/set_test.py
+++ b/tests/dragonfly/set_test.py
@@ -23,3 +23,21 @@ async def test_sscan_regression(df_factory: DflyInstanceFactory):
     # Takes 3 seconds
     res = await client.execute_command("SLOWLOG GET 100")
     assert res == []
+
+
+@pytest.mark.asyncio
+async def test_sinter_regression(df_factory: DflyInstanceFactory):
+    df = df_factory.create(proactor_threads=4, shard_round_robin_prefix="prefix-")
+    df.start()
+
+    client = df.client()
+
+    await client.execute_command("DEBUG POPULATE 1 prefix- 5 RAND ELEMENTS 5000 TYPE SET")
+    # add a common element to SINTER on a small set
+    await client.execute_command("SADD prefix-:0 common")
+    # create another key prefix-foo with 3 elements
+    await client.execute_command("SADD prefix-foo bar hello common")
+    await client.execute_command("SINTER prefix-foo prefix-:0")
+
+    res = await client.execute_command("SLOWLOG GET 100")
+    assert res == []


### PR DESCRIPTION
We ignored the cardinality of the produced shard sets. So, for some inputs we would copy the largest set. If for example a set_a on shard 1 had 600m elements and the second set_b had 5, we would create a hash table of 600m elements instead of 5.

Resolves #5590 