### PR TITLE
chore: allow replicaof in cluster mode when state is TAKEN_OVER

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1188,13 +1188,15 @@ std::optional<ErrorReply> Service::VerifyCommandState(const CommandId* cid, CmdA
     case GlobalState::SHUTTING_DOWN:
       allowed_by_state = false;
       break;
-    case GlobalState::TAKEN_OVER:
+    case GlobalState::TAKEN_OVER: {
       // Only PING, admin commands, and all commands via admin connections are allowed
       // we prohibit even read commands, because read commands running in pipeline can take a while
       // to send all data to a client which leads to fail in takeover
+      bool replicaof_in_cluster = cid->name() == "REPLICAOF" && IsClusterEnabled();
       allowed_by_state = dfly_cntx.conn()->IsPrivileged() || (cid->opt_mask() & CO::ADMIN) ||
-                         cid->name() == "PING";
+                         cid->name() == "PING" || replicaof_in_cluster;
       break;
+    }
     default:
       break;
   }

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1188,15 +1188,13 @@ std::optional<ErrorReply> Service::VerifyCommandState(const CommandId* cid, CmdA
     case GlobalState::SHUTTING_DOWN:
       allowed_by_state = false;
       break;
-    case GlobalState::TAKEN_OVER: {
+    case GlobalState::TAKEN_OVER:
       // Only PING, admin commands, and all commands via admin connections are allowed
       // we prohibit even read commands, because read commands running in pipeline can take a while
       // to send all data to a client which leads to fail in takeover
-      bool replicaof_in_cluster = cid->name() == "REPLICAOF" && IsClusterEnabled();
       allowed_by_state = dfly_cntx.conn()->IsPrivileged() || (cid->opt_mask() & CO::ADMIN) ||
-                         cid->name() == "PING" || replicaof_in_cluster;
+                         cid->name() == "PING";
       break;
-    }
     default:
       break;
   }


### PR DESCRIPTION
`REPLTAKEOVER` in cluster mode does not shut down master. Now a node that is in `TAKEN_OVER_STATE` (i,e, repltakeover) is allowed to become a replica of another node via the `REPLICAOF` command. 

* allow REPLICAOF command in TAKEN_OVER server state and only in cluster mode

Resolves #5611