### PR TITLE
fix: UB in georadius

### DIFF
--- a/src/server/geo_family.cc
+++ b/src/server/geo_family.cc
@@ -824,16 +824,14 @@ void GeoFamily::GeoRadius(CmdArgList args, const CommandContext& cmd_cntx) {
       default:
         // If MapNext failed, it means an unknown option was provided or
         // an option requiring an argument was missing its argument.
-        // The parser has already recorded the error. We retrieve it and send it.
-        DCHECK(parser.Error().has_value());
-        LOG_EVERY_T(INFO, 1) << "GeoRadius parser error: " << parser.Error()->MakeReply().ToSv();
-        return builder->SendError(parser.Error()->MakeReply());
+        // The parser has already recorded the error.
+        DCHECK(parser.HasError());
+        break;
     }
   }
 
   if (!parser.Finalize()) {
     auto error = parser.Error();
-    LOG_EVERY_T(INFO, 1) << "GeoRadius parser error: " << error->MakeReply().ToSv();
 
     switch (error->type) {
       case Errors::INVALID_LONG_LAT: {


### PR DESCRIPTION
fixes: #5612

problem: dereference empty optional, parser.Error() takes out the error from the parser and leaves nullopt instead of it. The next call returns an empty optional.

fix: use HasError() instead of Error() and remove extra logs