### PR TITLE
chore: more pipeline latency coverage

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -107,12 +107,11 @@ ABSL_FLAG(bool, always_flush_pipeline, false,
           "if true will flush pipeline response after each pipeline squashing");
 
 ABSL_FLAG(uint32_t, pipeline_squash_limit, 1 << 30, "Limit on the size of a squashed pipeline. ");
-ABSL_FLAG(uint32_t, pipeline_low_bound_stats, 0,
-          "If set, will not track pipeline stats below this threshold. ");
 
 using namespace util;
 using namespace std;
 using absl::GetFlag;
+using base::CycleClock;
 using nonstd::make_unexpected;
 
 namespace facade {
@@ -342,8 +341,6 @@ QueueBackpressure& GetQueueBackpressure() {
 thread_local uint64_t max_busy_read_cycles_cached = 1ULL << 32;
 thread_local bool always_flush_pipeline_cached = absl::GetFlag(FLAGS_always_flush_pipeline);
 thread_local uint32_t pipeline_squash_limit_cached = absl::GetFlag(FLAGS_pipeline_squash_limit);
-thread_local uint32_t pipeline_low_bound_stats_cached =
-    absl::GetFlag(FLAGS_pipeline_low_bound_stats);
 
 }  // namespace
 
@@ -870,7 +867,7 @@ unsigned Connection::GetSendWaitTimeSec() const {
 }
 
 void Connection::RegisterBreakHook(BreakerCb breaker_cb) {
-  breaker_cb_ = breaker_cb;
+  breaker_cb_ = std::move(breaker_cb);
 }
 
 pair<string, string> Connection::GetClientInfoBeforeAfterTid() const {
@@ -1258,6 +1255,7 @@ Connection::ParserStatus Connection::ParseRedis(unsigned max_busy_cycles) {
     // Specifically, if a client sends a huge chunk of data resulting in a very long pipeline,
     // we want to yield to allow AsyncFiber to actually execute on the pending pipeline.
     if (ThisFiber::GetRunningTimeCycles() > max_busy_cycles) {
+      stats_->num_read_yields++;
       ThisFiber::Yield();
     }
   } while (RedisParser::OK == result && read_buffer.available_bytes > 0 &&
@@ -1551,16 +1549,15 @@ void Connection::SquashPipeline() {
   vector<ArgSlice> squash_cmds;
   squash_cmds.reserve(dispatch_q_.size());
 
-  bool include_pipeline_for_stats = dispatch_q_.size() >= pipeline_low_bound_stats_cached;
-  for (auto& msg : dispatch_q_) {
+  uint64_t now = CycleClock::Now();
+  for (const auto& msg : dispatch_q_) {
     CHECK(holds_alternative<PipelineMessagePtr>(msg.handle))
         << msg.handle.index() << " on " << DebugInfo();
 
-    if (!include_pipeline_for_stats) {
-      msg.dispatch_ts = 0;  // resetting this will prevent stats to include this message
-    }
+    // measure the time spent in the pipeline  queue waiting for dispatch
+    stats_->pipelined_wait_latency += CycleClock::ToUsec(now - msg.dispatch_cycle);
     auto& pmsg = get<PipelineMessagePtr>(msg.handle);
-    squash_cmds.push_back(absl::MakeSpan(pmsg->args));
+    squash_cmds.emplace_back(absl::MakeSpan(pmsg->args));
     if (squash_cmds.size() >= pipeline_squash_limit_cached) {
       // We reached the limit of commands to squash, so we dispatch them.
       break;
@@ -1568,12 +1565,9 @@ void Connection::SquashPipeline() {
   }
 
   cc_->async_dispatch = true;
-  if (include_pipeline_for_stats) {
-    stats_->pipeline_dispatch_calls++;
-    stats_->pipeline_dispatch_commands += squash_cmds.size();
-  } else {
-    stats_->pipeline_stats_ignored++;
-  }
+  stats_->pipeline_dispatch_calls++;
+  stats_->pipeline_dispatch_commands += squash_cmds.size();
+
   size_t dispatched =
       service_->DispatchManyCommands(absl::MakeSpan(squash_cmds), reply_builder_.get(), cc_.get());
 
@@ -1586,6 +1580,8 @@ void Connection::SquashPipeline() {
       always_flush_pipeline_cached) {  // Flush if no new commands appeared
     reply_builder_->Flush();
     reply_builder_->SetBatchMode(false);  // in case the next dispatch is sync
+  } else {
+    stats_->skip_pipeline_flushing++;
   }
 
   cc_->async_dispatch = false;
@@ -1707,6 +1703,8 @@ void Connection::AsyncFiber() {
     } else {
       MessageHandle msg = std::move(dispatch_q_.front());
       dispatch_q_.pop_front();
+
+      stats_->pipelined_wait_latency += CycleClock::ToUsec(CycleClock::Now() - msg.dispatch_cycle);
 
       // We keep the batch mode enabled as long as the dispatch queue is not empty, relying on the
       // last command to reply and flush. If it doesn't reply (i.e. is a control message like
@@ -1913,7 +1911,7 @@ void Connection::SendAsync(MessageHandle msg) {
   stats_->dispatch_queue_entries++;
   stats_->dispatch_queue_bytes += used_mem;
 
-  msg.dispatch_ts = ProactorBase::GetMonotonicTimeNs();
+  msg.dispatch_cycle = CycleClock::Now();
   if (msg.IsPubMsg()) {
     qbp.subscriber_bytes.fetch_add(used_mem, memory_order_relaxed);
     stats_->dispatch_queue_subscriber_bytes += used_mem;
@@ -1952,9 +1950,9 @@ void Connection::RecycleMessage(MessageHandle msg) {
     stats_->dispatch_queue_subscriber_bytes -= used_mem;
   }
 
-  if (msg.IsPipelineMsg() && msg.dispatch_ts) {
+  if (msg.IsPipelineMsg() && msg.dispatch_cycle) {
     ++stats_->pipelined_cmd_cnt;
-    stats_->pipelined_cmd_latency += (ProactorBase::GetMonotonicTimeNs() - msg.dispatch_ts) / 1000;
+    stats_->pipelined_cmd_latency += CycleClock::ToUsec(CycleClock::Now() - msg.dispatch_cycle);
   }
 
   // Retain pipeline message in pool.
@@ -2188,10 +2186,6 @@ void Connection::SetAlwaysFlushPipelineThreadLocal(bool flush) {
 
 void Connection::SetPipelineSquashLimitThreadLocal(unsigned limit) {
   pipeline_squash_limit_cached = limit;
-}
-
-void Connection::SetPipelineLowBoundStats(unsigned limit) {
-  pipeline_low_bound_stats_cached = limit;
 }
 
 Connection::WeakRef::WeakRef(std::shared_ptr<Connection> ptr, unsigned thread_id,

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -169,8 +169,8 @@ class Connection : public util::Connection {
         handle;
 
     // time when the message was dispatched to the dispatch queue as reported by
-    // ProactorBase::GetMonotonicTimeNs()
-    uint64_t dispatch_ts = 0;
+    // CycleClock::Now()
+    uint64_t dispatch_cycle = 0;
   };
 
   static_assert(sizeof(MessageHandle) <= 80,
@@ -315,7 +315,6 @@ class Connection : public util::Connection {
   static void SetMaxBusyReadUsecThreadLocal(unsigned usec);
   static void SetAlwaysFlushPipelineThreadLocal(bool flush);
   static void SetPipelineSquashLimitThreadLocal(unsigned limit);
-  static void SetPipelineLowBoundStats(unsigned limit);
 
   unsigned idle_time() const {
     return time(nullptr) - last_interaction_;

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -20,7 +20,7 @@ using namespace std;
 constexpr size_t kSizeConnStats = sizeof(ConnectionStats);
 
 ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
-  static_assert(kSizeConnStats == 184u);
+  static_assert(kSizeConnStats == 192);
 
   ADD(read_buf_capacity);
   ADD(dispatch_queue_entries);
@@ -33,10 +33,12 @@ ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
   ADD(command_cnt_other);
   ADD(pipelined_cmd_cnt);
   ADD(pipelined_cmd_latency);
+  ADD(pipelined_wait_latency);
   ADD(conn_received_cnt);
   ADD(num_conns_main);
   ADD(num_conns_other);
   ADD(num_blocked_clients);
+  ADD(num_read_yields);
   ADD(num_migrations);
   ADD(num_recv_provided_calls);
   ADD(pipeline_throttle_count);
@@ -45,7 +47,7 @@ ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
   ADD(handshakes_completed);
   ADD(pipeline_dispatch_calls);
   ADD(pipeline_dispatch_commands);
-  ADD(pipeline_stats_ignored);
+  ADD(skip_pipeline_flushing);
 
   return *this;
 }

--- a/src/facade/facade_types.h
+++ b/src/facade/facade_types.h
@@ -104,11 +104,17 @@ struct ConnectionStats {
   uint64_t command_cnt_other = 0;
   uint64_t pipelined_cmd_cnt = 0;
   uint64_t pipelined_cmd_latency = 0;  // in microseconds
+
+  // in microseconds, time spent waiting for the pipelined commands to start executing
+  uint64_t pipelined_wait_latency = 0;
   uint64_t conn_received_cnt = 0;
 
   uint32_t num_conns_main = 0;
   uint32_t num_conns_other = 0;
   uint32_t num_blocked_clients = 0;
+
+  // number of times the connection yielded due to max_busy_read_usec limit
+  uint32_t num_read_yields = 0;
   uint64_t num_migrations = 0;
   uint64_t num_recv_provided_calls = 0;
 
@@ -122,7 +128,9 @@ struct ConnectionStats {
   uint64_t pipeline_throttle_count = 0;
   uint64_t pipeline_dispatch_calls = 0;
   uint64_t pipeline_dispatch_commands = 0;
-  uint64_t pipeline_stats_ignored = 0;
+
+  uint64_t skip_pipeline_flushing = 0;  // number of times we skipped flushing the pipeline
+
   ConnectionStats& operator+=(const ConnectionStats& o);
 };
 

--- a/src/server/config_registry.cc
+++ b/src/server/config_registry.cc
@@ -87,6 +87,15 @@ void ConfigRegistry::RegisterInternal(string_view config_name, bool is_mutable, 
   CHECK(inserted) << "Duplicate config name: " << name;
 }
 
+void ConfigRegistry::ValidateCustomSetter(std::string_view name, WriteCb setter) const {
+  absl::CommandLineFlag* flag = absl::FindCommandLineFlag(name);
+  CHECK(flag) << "Unknown config name: " << name;
+  if (setter) {
+    bool cb_match = setter(*flag);
+    CHECK(cb_match) << "Possible type mismatch with setter for flag " << name;
+  }
+}
+
 ConfigRegistry config_registry;
 
 }  // namespace dfly

--- a/src/server/config_registry.h
+++ b/src/server/config_registry.h
@@ -28,6 +28,9 @@ class ConfigRegistry {
 
   template <typename T>
   ConfigRegistry& RegisterSetter(std::string_view name, std::function<void(const T&)> f) {
+    ValidateCustomSetter(name,
+                         [](const absl::CommandLineFlag& flag) { return flag.IsOfType<T>(); });
+
     return RegisterMutable(name, [f](const absl::CommandLineFlag& flag) {
       auto res = flag.TryGet<T>();
       if (res.has_value()) {
@@ -57,6 +60,7 @@ class ConfigRegistry {
  private:
   void RegisterInternal(std::string_view name, bool is_mutable, WriteCb cb)
       ABSL_LOCKS_EXCLUDED(mu_);
+  void ValidateCustomSetter(std::string_view name, WriteCb setter) const;
 
   mutable util::fb2::Mutex mu_;
 

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -17,15 +17,21 @@
 #include "server/transaction.h"
 #include "server/tx_base.h"
 
+ABSL_FLAG(uint32_t, squash_stats_latency_lower_limit, 0,
+          "If set, will not track latency stats below this threshold (usec). ");
+
 namespace dfly {
 
 using namespace std;
 using namespace facade;
 using namespace util;
+using base::CycleClock;
 
 namespace {
 
 thread_local uint64_t max_busy_squash_cycles_cached = 1ULL << 32;
+thread_local uint32_t squash_stats_latency_lower_limit_cached =
+    absl::GetFlag(FLAGS_squash_stats_latency_lower_limit);
 
 void CheckConnStateClean(const ConnectionState& state) {
   DCHECK_EQ(state.exec_info.state, ConnectionState::ExecInfo::EXEC_INACTIVE);
@@ -135,8 +141,6 @@ MultiCommandSquasher::SquashResult MultiCommandSquasher::TrySquash(const StoredC
   sinfo.dispatched.push_back({.cmd = cmd, .reply = {}});
   order_.push_back(last_sid);
 
-  num_squashed_++;
-
   bool need_flush = sinfo.dispatched.size() >= opts_.max_squash_size;
   return need_flush ? SquashResult::SQUASHED_FULL : SquashResult::SQUASHED;
 }
@@ -234,10 +238,8 @@ bool MultiCommandSquasher::ExecuteSquashed(facade::RedisReplyBuilder* rb) {
   }
 
   Transaction* tx = cntx_->transaction;
-  ServerState::tlocal()->stats.multi_squash_executions++;
   ServerState::tlocal()->stats.squash_width_freq_arr[num_shards - 1]++;
-  ProactorBase* proactor = ProactorBase::me();
-  uint64_t start = proactor->GetMonotonicTimeNs();
+  uint64_t start = CycleClock::Now();
 
   // Atomic transactions (that have all keys locked) perform hops and run squashed commands via
   // stubs, non-atomic ones just run the commands in parallel.
@@ -258,8 +260,8 @@ bool MultiCommandSquasher::ExecuteSquashed(facade::RedisReplyBuilder* rb) {
       this->SquashedHopCb(EngineShard::tlocal(), rb->GetRespVersion());
       bc->Dec();
     };
-    unsigned run_usec = base::CycleClock::ToUsec(ThisFiber::GetRunningTimeCycles());
-    if (run_usec > 10'000) {
+    unsigned run_usec = CycleClock::ToUsec(ThisFiber::GetRunningTimeCycles());
+    if (run_usec > 5'000) {
       LOG_EVERY_T(WARNING, 1) << "Fiber run " << run_usec << " usec, squashed " << cmds_.size()
                               << " commands";
     }
@@ -270,7 +272,7 @@ bool MultiCommandSquasher::ExecuteSquashed(facade::RedisReplyBuilder* rb) {
     bc->Wait();
   }
 
-  uint64_t after_hop = proactor->GetMonotonicTimeNs();
+  uint64_t after_hop = CycleClock::Now();
   bool aborted = false;
 
   ServerState* fresh_ss = ServerState::SafeTLocal();
@@ -291,9 +293,16 @@ bool MultiCommandSquasher::ExecuteSquashed(facade::RedisReplyBuilder* rb) {
     if (aborted)
       break;
   }
-  uint64_t after_reply = proactor->GetMonotonicTimeNs();
-  fresh_ss->stats.multi_squash_exec_hop_usec += (after_hop - start) / 1000;
-  fresh_ss->stats.multi_squash_exec_reply_usec += (after_reply - after_hop) / 1000;
+  uint64_t after_reply = CycleClock::Now();
+  uint64_t total_usec = CycleClock::ToUsec(after_reply - start);
+  if (total_usec > squash_stats_latency_lower_limit_cached) {
+    fresh_ss->stats.multi_squash_exec_hop_usec += total_usec;
+    fresh_ss->stats.multi_squash_exec_reply_usec += CycleClock::ToUsec(after_reply - after_hop);
+    fresh_ss->stats.multi_squash_hops++;
+    fresh_ss->stats.squashed_commands += order_.size();
+  } else {
+    fresh_ss->stats.squash_stats_ignored++;
+  }
 
   tl_facade_stats->reply_stats.squashing_current_reply_size.fetch_sub(total_reply_size,
                                                                       std::memory_order_release);
@@ -307,7 +316,7 @@ bool MultiCommandSquasher::ExecuteSquashed(facade::RedisReplyBuilder* rb) {
   return !aborted;
 }
 
-size_t MultiCommandSquasher::Run(RedisReplyBuilder* rb) {
+void MultiCommandSquasher::Run(RedisReplyBuilder* rb) {
   DVLOG(1) << "Trying to squash " << cmds_.size() << " commands for transaction "
            << cntx_->transaction->DebugId();
 
@@ -343,9 +352,8 @@ size_t MultiCommandSquasher::Run(RedisReplyBuilder* rb) {
     }
   }
 
-  VLOG(1) << "Squashed " << num_squashed_ << " of " << cmds_.size()
-          << " commands, max fanout: " << num_shards_ << ", atomic: " << atomic_;
-  return num_squashed_;
+  VLOG(1) << "Handled " << cmds_.size() << " commands, max fanout: " << num_shards_
+          << ", atomic: " << atomic_;
 }
 
 bool MultiCommandSquasher::IsAtomic() const {
@@ -353,7 +361,11 @@ bool MultiCommandSquasher::IsAtomic() const {
 }
 
 void MultiCommandSquasher::SetMaxBusySquashUsec(uint32_t usec) {
-  max_busy_squash_cycles_cached = base::CycleClock::Frequency() * usec / 1000'000;
+  max_busy_squash_cycles_cached = CycleClock::FromUsec(usec);
+}
+
+void MultiCommandSquasher::SetSquashStatsLatencyLowerLimit(uint32_t usec) {
+  squash_stats_latency_lower_limit_cached = usec;
 }
 
 }  // namespace dfly

--- a/src/server/multi_command_squasher.h
+++ b/src/server/multi_command_squasher.h
@@ -29,12 +29,13 @@ class MultiCommandSquasher {
   };
 
   // Returns number of processed commands.
-  static size_t Execute(absl::Span<StoredCmd> cmds, facade::RedisReplyBuilder* rb,
-                        ConnectionContext* cntx, Service* service, const Opts& opts) {
-    return MultiCommandSquasher{cmds, cntx, service, opts}.Run(rb);
+  static void Execute(absl::Span<StoredCmd> cmds, facade::RedisReplyBuilder* rb,
+                      ConnectionContext* cntx, Service* service, const Opts& opts) {
+    MultiCommandSquasher{cmds, cntx, service, opts}.Run(rb);
   }
 
   static void SetMaxBusySquashUsec(uint32_t usec);
+  static void SetSquashStatsLatencyLowerLimit(uint32_t usec);
 
  private:
   // Per-shard execution info.
@@ -74,8 +75,7 @@ class MultiCommandSquasher {
   // Execute all currently squashed commands. Return false if aborting on error.
   bool ExecuteSquashed(facade::RedisReplyBuilder* rb);
 
-  // Run all commands until completion. Returns number of processed commands.
-  size_t Run(facade::RedisReplyBuilder* rb);
+  void Run(facade::RedisReplyBuilder* rb);
 
   bool IsAtomic() const;
 
@@ -91,7 +91,6 @@ class MultiCommandSquasher {
   std::vector<ShardExecInfo> sharded_;
   std::vector<ShardId> order_;  // reply order for squashed cmds
 
-  size_t num_squashed_ = 0;
   size_t num_shards_ = 0;
 
   std::vector<MutableSlice> tmp_keylist_;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1556,19 +1556,24 @@ void PrintPrometheusMetrics(uint64_t uptime, const Metrics& m, DflyCmd* dfly_cmd
                             MetricType::COUNTER, &resp->body());
   AppendMetricWithoutLabels("pipeline_dispatch_calls_total", "", conn_stats.pipeline_dispatch_calls,
                             MetricType::COUNTER, &resp->body());
-  AppendMetricWithoutLabels("pipeline_dispatch_stats_ignored_total", "",
-                            conn_stats.pipeline_stats_ignored, MetricType::COUNTER, &resp->body());
-
   AppendMetricWithoutLabels("pipeline_dispatch_commands_total", "",
-                            conn_stats.pipeline_dispatch_commands,
-
-                            MetricType::COUNTER, &resp->body());
+                            conn_stats.pipeline_dispatch_commands, MetricType::COUNTER,
+                            &resp->body());
+  AppendMetricWithoutLabels("pipeline_dispatch_skip_flush_total", "",
+                            conn_stats.skip_pipeline_flushing, MetricType::COUNTER, &resp->body());
 
   AppendMetricWithoutLabels("pipeline_commands_duration_seconds", "",
                             conn_stats.pipelined_cmd_latency * 1e-6, MetricType::COUNTER,
                             &resp->body());
+  AppendMetricWithoutLabels("pipeline_queue_wait_duration_seconds", "",
+                            conn_stats.pipelined_wait_latency * 1e-6, MetricType::COUNTER,
+                            &resp->body());
 
-  AppendMetricWithoutLabels("cmd_squash_hop_total", "", m.coordinator_stats.multi_squash_executions,
+  AppendMetricWithoutLabels("cmd_squash_stats_ignored_total", "",
+                            m.coordinator_stats.squash_stats_ignored, MetricType::COUNTER,
+                            &resp->body());
+
+  AppendMetricWithoutLabels("cmd_squash_hop_total", "", m.coordinator_stats.multi_squash_hops,
                             MetricType::COUNTER, &resp->body());
 
   AppendMetricWithoutLabels("cmd_squash_commands_total", "", m.coordinator_stats.squashed_commands,
@@ -1693,6 +1698,9 @@ void PrintPrometheusMetrics(uint64_t uptime, const Metrics& m, DflyCmd* dfly_cmd
   // Net metrics
   AppendMetricWithoutLabels("net_input_recv_total", "", conn_stats.io_read_cnt, MetricType::COUNTER,
                             &resp->body());
+  AppendMetricWithoutLabels("net_read_yields_total", "", conn_stats.num_read_yields,
+                            MetricType::COUNTER, &resp->body());
+
   AppendMetricWithoutLabels("net_input_bytes_total", "", conn_stats.io_read_bytes,
                             MetricType::COUNTER, &resp->body());
 

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -38,7 +38,7 @@ ServerState::Stats::Stats(unsigned num_shards)
 }
 
 ServerState::Stats& ServerState::Stats::Add(const ServerState::Stats& other) {
-  static_assert(sizeof(Stats) == 23 * 8, "Stats size mismatch");
+  static_assert(sizeof(Stats) == 24 * 8, "Stats size mismatch");
 
 #define ADD(x) this->x += (other.x)
 
@@ -52,11 +52,11 @@ ServerState::Stats& ServerState::Stats::Add(const ServerState::Stats& other) {
   ADD(tx_inline_runs);
   ADD(tx_schedule_cancel_cnt);
 
-  ADD(multi_squash_executions);
+  ADD(multi_squash_hops);
   ADD(multi_squash_exec_hop_usec);
   ADD(multi_squash_exec_reply_usec);
   ADD(squashed_commands);
-
+  ADD(squash_stats_ignored);
   ADD(blocked_on_interpreter);
   ADD(rdb_save_usec);
   ADD(rdb_save_count);

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -118,10 +118,11 @@ class ServerState {  // public struct - to allow initialization.
     uint64_t eval_shardlocal_coordination_cnt = 0;
     uint64_t eval_squashed_flushes = 0;
 
-    uint64_t multi_squash_executions = 0;
+    uint64_t multi_squash_hops = 0;
     uint64_t multi_squash_exec_hop_usec = 0;
     uint64_t multi_squash_exec_reply_usec = 0;
     uint64_t squashed_commands = 0;
+    uint64_t squash_stats_ignored = 0;
     uint64_t blocked_on_interpreter = 0;
 
     uint64_t rdb_save_usec = 0;

--- a/tools/local/monitoring/grafana/provisioning/dashboards/dragonfly.json
+++ b/tools/local/monitoring/grafana/provisioning/dashboards/dragonfly.json
@@ -1371,12 +1371,12 @@
           "editorMode": "code",
           "exemplar": true,
           "expr":
-              "irate(dragonfly_cmd_squash_hop_reply_seconds{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval])/irate(dragonfly_cmd_squash_hop_total{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval])",
+              "irate(dragonfly_pipeline_queue_wait_duration_seconds{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval])/irate(dragonfly_pipeline_commands_total{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "reply",
+          "legendFormat": "wait_queue",
           "range": true,
           "refId": "C",
           "step": 240
@@ -1871,8 +1871,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1987,8 +1986,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2028,7 +2026,7 @@
           },
           "editorMode": "code",
           "expr":
-              "irate(dragonfly_pipeline_dispatch_calls_total\n{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval])/(irate(dragonfly_pipeline_dispatch_calls_total{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval]) + irate(dragonfly_pipeline_dispatch_stats_ignored_total{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval]))",
+              "1 - irate(dragonfly_cmd_squash_hop_total\n{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval])/(irate(dragonfly_cmd_squash_hop_total{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval]) + irate(dragonfly_cmd_squash_stats_ignored_total{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval]))",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -2085,8 +2083,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2241,6 +2238,6 @@
   "timezone": "browser",
   "title": "Dragonfly Dashboard",
   "uid": "xDLNRKUWz",
-  "version": 14,
+  "version": 15,
   "weekStart": ""
 }


### PR DESCRIPTION
Partially covers https://github.com/dragonflydb/dragonfly/issues/5630

1. Remove `pipeline_low_bound_stats` and instead introduce `squash_stats_latency_lower_limit` flag
   that filters out latency stats based on the lower limit threshold.
2. Consolidate all the squashing metrics inside multi_command_squasher code.
3. Add `pipeline_queue_wait_duration_seconds`, `pipeline_dispatch_skip_flush_total`, `net_read_yields_total` metrics.
4. Reduce reliance on `ProactorBase::GetMonotonicTimeNs` as it's inaccurate - switch to CycleClock where possible.
5. Finally fix a bug where mismatch config type prevented us from using CONFIG SET and change the settings online.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->