### PR TITLE
refactor: CmdArgParser::Error()

### DIFF
--- a/src/facade/cmd_arg_parser.cc
+++ b/src/facade/cmd_arg_parser.cc
@@ -24,7 +24,12 @@ void CmdArgParser::ExpectTag(std::string_view tag) {
   }
 }
 
+CmdArgParser::ErrorInfo CmdArgParser::TakeError() {
+  return std::exchange(error_, {});
+}
+
 ErrorReply CmdArgParser::ErrorInfo::MakeReply() const {
+  DCHECK(operator bool());
   switch (type) {
     case INVALID_INT:
       return ErrorReply{kInvalidIntErr};
@@ -37,7 +42,7 @@ ErrorReply CmdArgParser::ErrorInfo::MakeReply() const {
 }
 
 CmdArgParser::~CmdArgParser() {
-  DCHECK(!error_.has_value()) << "Parsing error occured but not checked";
+  DCHECK(!error_) << "Parsing error occured but not checked";
   // TODO DCHECK(!HasNext()) << "Not all args were processed";
 }
 

--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -34,6 +34,7 @@ template <auto min, auto max> constexpr bool is_fint<FInt<min, max>> = true;
 // Utility class for easily parsing command options from argument lists.
 struct CmdArgParser {
   enum ErrorType {
+    NO_ERROR,
     OUT_OF_BOUNDS,
     SHORT_OPT_TAIL,
     INVALID_INT,
@@ -45,9 +46,12 @@ struct CmdArgParser {
   };
 
   struct ErrorInfo {
-    int type;
-    size_t index;
+    int type = NO_ERROR;
+    size_t index = 0;
 
+    operator bool() const {
+      return type != ErrorType::NO_ERROR;
+    }
     ErrorReply MakeReply() const;
   };
 
@@ -165,13 +169,10 @@ struct CmdArgParser {
   }
 
   bool HasError() {
-    return error_.has_value();
+    return error_.type != ErrorType::NO_ERROR;
   }
 
-  // Get optional error if occured
-  std::optional<ErrorInfo> Error() {
-    return std::exchange(error_, {});
-  }
+  ErrorInfo TakeError();
 
   bool HasAtLeast(size_t i) const {
     return cur_i_ + i <= args_.size() && !error_;
@@ -276,7 +277,7 @@ struct CmdArgParser {
   size_t cur_i_ = 0;
   CmdArgList args_;
 
-  std::optional<ErrorInfo> error_;
+  ErrorInfo error_;
 };
 
 }  // namespace facade

--- a/src/facade/cmd_arg_parser_test.cc
+++ b/src/facade/cmd_arg_parser_test.cc
@@ -44,7 +44,7 @@ TEST_F(CmdArgParserTest, BasicTypes) {
   EXPECT_EQ(b, 44u);
 
   EXPECT_FALSE(parser.HasNext());
-  EXPECT_FALSE(parser.Error());
+  EXPECT_FALSE(parser.HasError());
 }
 
 TEST_F(CmdArgParserTest, BoundError) {
@@ -52,10 +52,10 @@ TEST_F(CmdArgParserTest, BoundError) {
 
   EXPECT_EQ(absl::implicit_cast<string_view>(parser.Next()), ""sv);
 
-  auto err = parser.Error();
+  auto err = parser.TakeError();
   EXPECT_TRUE(err);
-  EXPECT_EQ(err->type, CmdArgParser::OUT_OF_BOUNDS);
-  EXPECT_EQ(err->index, 0);
+  EXPECT_EQ(err.type, CmdArgParser::OUT_OF_BOUNDS);
+  EXPECT_EQ(err.index, 0);
 }
 
 #ifndef __APPLE__
@@ -64,10 +64,10 @@ TEST_F(CmdArgParserTest, IntError) {
 
   EXPECT_EQ(parser.Next<size_t>(), 0u);
 
-  auto err = parser.Error();
+  auto err = parser.TakeError();
   EXPECT_TRUE(err);
-  EXPECT_EQ(err->type, CmdArgParser::INVALID_INT);
-  EXPECT_EQ(err->index, 0);
+  EXPECT_EQ(err.type, CmdArgParser::INVALID_INT);
+  EXPECT_EQ(err.index, 0);
 }
 #endif
 
@@ -86,13 +86,13 @@ TEST_F(CmdArgParserTest, NextStatement) {
   auto parser = Make({"TAG", "tag_2", "tag_3"});
 
   parser.ExpectTag("TAG");
-  EXPECT_FALSE(parser.Error());
+  EXPECT_FALSE(parser.TakeError());
 
   parser.ExpectTag("TAG_2");
-  EXPECT_FALSE(parser.Error());
+  EXPECT_FALSE(parser.TakeError());
 
   parser.ExpectTag("TAG_2");
-  EXPECT_TRUE(parser.Error());
+  EXPECT_TRUE(parser.TakeError());
 }
 
 TEST_F(CmdArgParserTest, CheckTailFail) {
@@ -106,7 +106,7 @@ TEST_F(CmdArgParserTest, CheckTailFail) {
 
   EXPECT_FALSE(parser.Check("TAG", &first, &second));
   EXPECT_TRUE(parser.Check("TAG", &first));
-  EXPECT_TRUE(parser.Error());
+  EXPECT_TRUE(parser.TakeError());
 }
 
 TEST_F(CmdArgParserTest, Map) {
@@ -115,10 +115,10 @@ TEST_F(CmdArgParserTest, Map) {
   EXPECT_EQ(parser.MapNext("ONE", 1, "TWO", 2), 2);
 
   EXPECT_EQ(parser.MapNext("ONE", 1, "TWO", 2), 0);
-  auto err = parser.Error();
+  auto err = parser.TakeError();
   EXPECT_TRUE(err);
-  EXPECT_EQ(err->type, CmdArgParser::INVALID_CASES);
-  EXPECT_EQ(err->index, 1);
+  EXPECT_EQ(err.type, CmdArgParser::INVALID_CASES);
+  EXPECT_EQ(err.index, 1);
 }
 
 TEST_F(CmdArgParserTest, TryMapNext) {
@@ -151,20 +151,20 @@ TEST_F(CmdArgParserTest, FixedRangeInt) {
     EXPECT_EQ((parser.Next<FInt<-11, 11>>().value), -10);
     EXPECT_EQ((parser.Next<FInt<-11, 11>>().value), 0);
 
-    auto err = parser.Error();
+    auto err = parser.TakeError();
     EXPECT_TRUE(err);
-    EXPECT_EQ(err->type, CmdArgParser::INVALID_INT);
-    EXPECT_EQ(err->index, 2);
+    EXPECT_EQ(err.type, CmdArgParser::INVALID_INT);
+    EXPECT_EQ(err.index, 2);
   }
 
   {
     auto parser = Make({"-12"});
     EXPECT_EQ((parser.Next<FInt<-11, 11>>().value), 0);
 
-    auto err = parser.Error();
+    auto err = parser.TakeError();
     EXPECT_TRUE(err);
-    EXPECT_EQ(err->type, CmdArgParser::INVALID_INT);
-    EXPECT_EQ(err->index, 0);
+    EXPECT_EQ(err.type, CmdArgParser::INVALID_INT);
+    EXPECT_EQ(err.index, 0);
   }
 }
 

--- a/src/server/bloom_family.cc
+++ b/src/server/bloom_family.cc
@@ -96,7 +96,7 @@ void BloomFamily::Reserve(CmdArgList args, const CommandContext& cmd_cntx) {
 
   tie(params.error, params.init_capacity) = parser.Next<double, uint32_t>();
 
-  if (parser.Error())
+  if (parser.TakeError())
     return cmd_cntx.rb->SendError(kSyntaxErr);
 
   if (!params.ok())

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -643,8 +643,8 @@ void ClusterFamily::DflyClusterGetSlotInfo(CmdArgList args, SinkReplyBuilder* bu
     slots_stats.emplace_back(sid, SlotStats{});
   } while (parser.HasNext());
 
-  if (auto err = parser.Error(); err)
-    return builder->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err)
+    return builder->SendError(err.MakeReply());
 
   fb2::Mutex mu;
 
@@ -693,8 +693,8 @@ void ClusterFamily::DflyClusterFlushSlots(CmdArgList args, SinkReplyBuilder* bui
     slot_ranges.emplace_back(SlotRange{slot_start, slot_end});
   } while (parser.HasNext());
 
-  if (auto err = parser.Error(); err)
-    return builder->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err)
+    return builder->SendError(err.MakeReply());
 
   DeleteSlots(SlotRanges(std::move(slot_ranges)));
 
@@ -747,8 +747,8 @@ void ClusterFamily::DflySlotMigrationStatus(CmdArgList args, SinkReplyBuilder* b
   string_view node_id;
   if (parser.HasNext()) {
     node_id = parser.Next<std::string_view>();
-    if (auto err = parser.Error(); err) {
-      return builder->SendError(err->MakeReply());
+    if (auto err = parser.TakeError(); err) {
+      return builder->SendError(err.MakeReply());
     }
   }
 
@@ -909,8 +909,8 @@ void ClusterFamily::InitMigration(CmdArgList args, SinkReplyBuilder* builder) {
     slots.emplace_back(SlotRange{slot_start, slot_end});
   } while (parser.HasNext());
 
-  if (auto err = parser.Error(); err)
-    return builder->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err)
+    return builder->SendError(err.MakeReply());
 
   SlotRanges slot_ranges(std::move(slots));
 
@@ -956,8 +956,8 @@ void ClusterFamily::DflyMigrateFlow(CmdArgList args, SinkReplyBuilder* builder,
   CmdArgParser parser{args};
   auto [source_id, shard_id] = parser.Next<std::string_view, uint32_t>();
 
-  if (auto err = parser.Error(); err) {
-    return builder->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err) {
+    return builder->SendError(err.MakeReply());
   }
 
   VLOG(1) << "Create flow " << source_id << " shard_id: " << shard_id;
@@ -1043,8 +1043,8 @@ void ClusterFamily::DflyMigrateAck(CmdArgList args, SinkReplyBuilder* builder) {
   CmdArgParser parser{args};
   auto [source_id, attempt] = parser.Next<std::string_view, long>();
 
-  if (auto err = parser.Error(); err) {
-    return builder->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err) {
+    return builder->SendError(err.MakeReply());
   }
 
   VLOG(1) << "DFLYMIGRATE ACK" << args;

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -864,7 +864,7 @@ optional<DebugCmd::PopulateOptions> DebugCmd::ParsePopulateArgs(CmdArgList args,
         auto [min_ttl, max_ttl] = parser.Next<uint32_t, uint32_t>();
         if (min_ttl >= max_ttl) {
           builder->SendError(kExpiryOutOfRange);
-          (void)parser.Error();
+          (void)parser.TakeError();
           return nullopt;
         }
         options.expire_ttl_range = std::make_pair(min_ttl, max_ttl);
@@ -876,7 +876,7 @@ optional<DebugCmd::PopulateOptions> DebugCmd::ParsePopulateArgs(CmdArgList args,
     }
   }
   if (parser.HasError()) {
-    builder->SendError(parser.Error()->MakeReply());
+    builder->SendError(parser.TakeError().MakeReply());
     return nullopt;
   }
   return options;
@@ -1465,7 +1465,7 @@ void DebugCmd::Compression(CmdArgList args, facade::SinkReplyBuilder* builder) {
   }
 
   if (parser.HasError()) {
-    return builder->SendError(parser.Error()->MakeReply());
+    return builder->SendError(parser.TakeError().MakeReply());
   }
 
   auto* rb = static_cast<RedisReplyBuilder*>(builder);

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -452,8 +452,8 @@ void DflyCmd::TakeOver(CmdArgList args, RedisReplyBuilder* rb, ConnectionContext
 
   string_view sync_id_str = parser.Next<std::string_view>();
 
-  if (auto err = parser.Error(); err)
-    return rb->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err)
+    return rb->SendError(err.MakeReply());
 
   VLOG(1) << "Got DFLY TAKEOVER " << sync_id_str << " time out:" << timeout;
 
@@ -577,7 +577,7 @@ void DflyCmd::Load(CmdArgList args, RedisReplyBuilder* rb, ConnectionContext* cn
     existing_keys = ServerFamily::LoadExistingKeys::kOverride;
   }
 
-  if (parser.Error() || parser.HasNext() || filename.empty()) {
+  if (parser.TakeError() || parser.HasNext() || filename.empty()) {
     return rb->SendError(kSyntaxErr);
   }
 

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1767,7 +1767,7 @@ void GenericFamily::Copy(CmdArgList args, const CommandContext& cmd_cntx) {
   bool replace = parser.Check("REPLACE");
 
   if (!parser.Finalize()) {
-    return cmd_cntx.rb->SendError(parser.Error()->MakeReply());
+    return cmd_cntx.rb->SendError(parser.TakeError().MakeReply());
   }
 
   if (k1 == k2) {

--- a/src/server/geo_family.cc
+++ b/src/server/geo_family.cc
@@ -647,8 +647,8 @@ void GeoFamily::GeoSearch(CmdArgList args, const CommandContext& cmd_cntx) {
   }
 
   if (!parser.Finalize()) {
-    auto error = parser.Error();
-    switch (error->type) {
+    auto error = parser.TakeError();
+    switch (error.type) {
       case Errors::INVALID_LONG_LAT: {
         string err =
             absl::StrCat("-ERR invalid longitude,latitude pair ", shape.xy[0], ",", shape.xy[1]);
@@ -658,7 +658,7 @@ void GeoFamily::GeoSearch(CmdArgList args, const CommandContext& cmd_cntx) {
         return builder->SendError("Unsupported unit provided. please use M, KM, FT, MI",
                                   kSyntaxErrType);
       default:
-        return builder->SendError(error->MakeReply());
+        return builder->SendError(error.MakeReply());
     }
   }
 
@@ -832,9 +832,9 @@ void GeoFamily::GeoRadius(CmdArgList args, const CommandContext& cmd_cntx) {
   }
 
   if (!parser.Finalize()) {
-    auto error = parser.Error();
+    auto error = parser.TakeError();
 
-    switch (error->type) {
+    switch (error.type) {
       case Errors::INVALID_LONG_LAT: {
         string err =
             absl::StrCat("-ERR invalid longitude,latitude pair ", shape.xy[0], ",", shape.xy[1]);
@@ -844,7 +844,7 @@ void GeoFamily::GeoRadius(CmdArgList args, const CommandContext& cmd_cntx) {
         return builder->SendError("Unsupported unit provided. please use M, KM, FT, MI",
                                   kSyntaxErrType);
       default:
-        return builder->SendError(error->MakeReply());
+        return builder->SendError(error.MakeReply());
     }
   }
 

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -804,7 +804,7 @@ void HSetEx(CmdArgList args, const CommandContext& cmd_cntx) {
   op_sp.ttl = parser.Next<uint32_t>();
 
   if (parser.HasError()) {
-    return cmd_cntx.rb->SendError(parser.Error()->MakeReply());
+    return cmd_cntx.rb->SendError(parser.TakeError().MakeReply());
   }
 
   constexpr uint32_t kMaxTtl = (1UL << 26);

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -1606,7 +1606,7 @@ void JsonFamily::Set(CmdArgList args, const CommandContext& cmd_cntx) {
   auto res = parser.TryMapNext("NX", 1, "XX", 2);
   bool is_xx_condition = (res == 2), is_nx_condition = (res == 1);
 
-  if (parser.Error() || parser.HasNext())  // also clear the parser error dcheck
+  if (parser.TakeError() || parser.HasNext())  // also clear the parser error dcheck
     return builder->SendError(kSyntaxErr);
 
   auto cb = [&, &key = key, &path = path, &json_str = json_str](Transaction* t,
@@ -1909,8 +1909,8 @@ void JsonFamily::ArrPop(CmdArgList args, const CommandContext& cmd_cntx) {
   int index = parser.NextOrDefault<int>(-1);
 
   auto* builder = static_cast<RedisReplyBuilder*>(cmd_cntx.rb);
-  if (auto err = parser.Error(); err) {
-    return builder->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err) {
+    return builder->SendError(err.MakeReply());
   }
 
   WrappedJsonPath json_path = GET_OR_SEND_UNEXPECTED(ParseJsonPath(path));
@@ -2128,8 +2128,8 @@ void JsonFamily::Get(CmdArgList args, const CommandContext& cmd_cntx) {
     return;  // ParseJsonGetParams should have already sent an error
   }
 
-  if (auto err = parser.Error(); err)
-    return builder->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err)
+    return builder->SendError(err.MakeReply());
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpJsonGet(t->GetOpArgs(shard), key, params.value());

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -656,8 +656,8 @@ void BRPopLPush(CmdArgList args, const CommandContext& cmd_cntx) {
   auto [src, dest] = parser.Next<string_view, string_view>();
   float timeout = parser.Next<float>();
   auto* builder = static_cast<RedisReplyBuilder*>(cmd_cntx.rb);
-  if (auto err = parser.Error(); err)
-    return builder->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err)
+    return builder->SendError(err.MakeReply());
 
   if (timeout < 0)
     return builder->SendError("timeout is negative");
@@ -689,8 +689,8 @@ void BLMove(CmdArgList args, const CommandContext& cmd_cntx) {
   ListDir dest_dir = ParseDir(&parser);
   float timeout = parser.Next<float>();
   auto* builder = static_cast<RedisReplyBuilder*>(cmd_cntx.rb);
-  if (auto err = parser.Error(); err)
-    return builder->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err)
+    return builder->SendError(err.MakeReply());
 
   if (timeout < 0)
     return builder->SendError("timeout is negative");
@@ -823,8 +823,8 @@ void PopGeneric(ListDir dir, CmdArgList args, Transaction* tx, SinkReplyBuilder*
     return_arr = true;
   }
 
-  if (auto err = parser.Error(); err)
-    return builder->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err)
+    return builder->SendError(err.MakeReply());
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpPop(t->GetOpArgs(shard), key, dir, count, true, false);
@@ -938,7 +938,7 @@ void ListFamily::LMPop(CmdArgList args, const CommandContext& cmd_cntx) {
     pop_count = parser.Next<size_t>();
 
   if (!parser.Finalize())
-    return response_builder->SendError(parser.Error()->MakeReply());
+    return response_builder->SendError(parser.TakeError().MakeReply());
 
   // Create a vector to store first found key for each shard
   vector<optional<pair<string_view, bool>>> found_keys_per_shard(shard_set->size());
@@ -1013,8 +1013,8 @@ void ListFamily::BLMPop(CmdArgList args, const CommandContext& cmd_cntx) {
 
   CmdArgParser parser{args};
   float timeout = parser.Next<float>();
-  if (auto err = parser.Error(); err)
-    return response_builder->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err)
+    return response_builder->SendError(err.MakeReply());
 
   if (timeout < 0)
     return response_builder->SendError("timeout is negative");
@@ -1027,7 +1027,7 @@ void ListFamily::BLMPop(CmdArgList args, const CommandContext& cmd_cntx) {
     pop_count = parser.Next<size_t>();
 
   if (!parser.Finalize())
-    return response_builder->SendError(parser.Error()->MakeReply());
+    return response_builder->SendError(parser.TakeError().MakeReply());
 
   OpResult<StringVec> result;
   auto cb = [&](Transaction* t, EngineShard* shard, string_view key) {
@@ -1119,8 +1119,8 @@ void ListFamily::LPos(CmdArgList args, const CommandContext& cmd_cntx) {
   if (rank == 0)
     return rb->SendError(kInvalidIntErr);
 
-  if (auto err = parser.Error(); err)
-    return rb->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err)
+    return rb->SendError(err.MakeReply());
 
   auto cb = [&, &key = key, &elem = elem](Transaction* t, EngineShard* shard) {
     return OpPos(t->GetOpArgs(shard), key, elem, rank, count, max_len);
@@ -1178,8 +1178,8 @@ void ListFamily::LInsert(CmdArgList args, const CommandContext& cmd_cntx) {
   InsertParam where = parser.MapNext("AFTER", INSERT_AFTER, "BEFORE", INSERT_BEFORE);
   auto [pivot, elem] = parser.Next<string_view, string_view>();
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx.rb);
-  if (auto err = parser.Error(); err)
-    return rb->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err)
+    return rb->SendError(err.MakeReply());
 
   DCHECK(pivot.data() && elem.data());
 
@@ -1297,8 +1297,8 @@ void ListFamily::LMove(CmdArgList args, const CommandContext& cmd_cntx) {
   ListDir src_dir = ParseDir(&parser);
   ListDir dest_dir = ParseDir(&parser);
 
-  if (auto err = parser.Error(); err)
-    return cmd_cntx.rb->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err)
+    return cmd_cntx.rb->SendError(err.MakeReply());
 
   MoveGeneric(src, dest, src_dir, dest_dir, cmd_cntx.tx, cmd_cntx.rb);
 }

--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -398,7 +398,7 @@ void MemoryCmd::Track(CmdArgList args) {
     std::tie(tracking_info.lower_bound, tracking_info.upper_bound, tracking_info.sample_odds) =
         parser.Next<size_t, size_t, double>();
     if (parser.HasError()) {
-      return builder_->SendError(parser.Error()->MakeReply());
+      return builder_->SendError(parser.TakeError().MakeReply());
     }
 
     atomic_bool error{false};
@@ -418,7 +418,7 @@ void MemoryCmd::Track(CmdArgList args) {
   if (parser.Check("REMOVE")) {
     auto [lower_bound, upper_bound] = parser.Next<size_t, size_t>();
     if (parser.HasError()) {
-      return builder_->SendError(parser.Error()->MakeReply());
+      return builder_->SendError(parser.TakeError().MakeReply());
     }
 
     atomic_bool error{false};
@@ -454,7 +454,7 @@ void MemoryCmd::Track(CmdArgList args) {
   if (parser.Check("ADDRESS")) {
     string_view ptr_str = parser.Next();
     if (parser.HasError()) {
-      return builder_->SendError(parser.Error()->MakeReply());
+      return builder_->SendError(parser.TakeError().MakeReply());
     }
 
     size_t ptr = 0;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -696,22 +696,22 @@ optional<ReplicaOfArgs> ReplicaOfArgs::FromCmdArgs(CmdArgList args, SinkReplyBui
   } else {
     replicaof_args.host = parser.Next<string>();
     replicaof_args.port = parser.Next<uint16_t>();
-    if (auto err = parser.Error(); err || replicaof_args.port < 1) {
+    if (auto err = parser.TakeError(); err || replicaof_args.port < 1) {
       builder->SendError("port is out of range");
       return nullopt;
     }
     if (parser.HasNext()) {
       auto [slot_start, slot_end] = parser.Next<SlotId, SlotId>();
       replicaof_args.slot_range = cluster::SlotRange{slot_start, slot_end};
-      if (auto err = parser.Error(); err || !replicaof_args.slot_range->IsValid()) {
+      if (auto err = parser.TakeError(); err || !replicaof_args.slot_range->IsValid()) {
         builder->SendError("Invalid slot range");
         return nullopt;
       }
     }
   }
 
-  if (auto err = parser.Error(); err) {
-    builder->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err) {
+    builder->SendError(err.MakeReply());
     return nullopt;
   }
   return replicaof_args;
@@ -3502,8 +3502,8 @@ void ServerFamily::ReplTakeOver(CmdArgList args, const CommandContext& cmd_cntx)
   if (parser.HasNext())
     return builder->SendError(absl::StrCat("Unsupported option:", string_view(parser.Next())));
 
-  if (auto err = parser.Error(); err)
-    return builder->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err)
+    return builder->SendError(err.MakeReply());
 
   // We allow zero timeouts for tests.
   if (timeout_sec < 0) {
@@ -3803,8 +3803,8 @@ void ServerFamily::ClientPauseCmd(CmdArgList args, SinkReplyBuilder* builder,
   if (parser.HasNext()) {
     pause_state = parser.MapNext("WRITE", ClientPause::WRITE, "ALL", ClientPause::ALL);
   }
-  if (auto err = parser.Error(); err) {
-    return builder->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err) {
+    return builder->SendError(err.MakeReply());
   }
 
   const auto timeout_ms = timeout * 1ms;

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -1256,8 +1256,8 @@ void SRandMember(CmdArgList args, const CommandContext& cmd_cntx) {
   if (parser.HasNext())
     return cmd_cntx.rb->SendError(WrongNumArgsError("SRANDMEMBER"));
 
-  if (auto err = parser.Error(); err)
-    return cmd_cntx.rb->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err)
+    return cmd_cntx.rb->SendError(err.MakeReply());
 
   const auto cb = [&](Transaction* t, EngineShard* shard) -> OpResult<StringVec> {
     return OpRandMember(t->GetOpArgs(shard), key, count);
@@ -1464,8 +1464,8 @@ void SAddEx(CmdArgList args, const CommandContext& cmd_cntx) {
   const bool keepttl = parser.Check("KEEPTTL");
   const uint32_t ttl_sec = parser.Next<uint32_t>();
 
-  if (auto err = parser.Error(); err) {
-    return cmd_cntx.rb->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err) {
+    return cmd_cntx.rb->SendError(err.MakeReply());
   }
   constexpr uint32_t kMaxTtl = (1UL << 26);
   if (ttl_sec == 0 || ttl_sec > kMaxTtl) {

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -1866,8 +1866,8 @@ void CreateGroup(facade::CmdArgParser* parser, Transaction* tx, SinkReplyBuilder
     opts.flags |= kCreateOptMkstream;
   }
 
-  if (auto err = parser->Error(); err)
-    return builder->SendError(err->MakeReply());
+  if (auto err = parser->TakeError(); err)
+    return builder->SendError(err.MakeReply());
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpCreate(t->GetOpArgs(shard), key, opts);
@@ -1885,8 +1885,8 @@ void CreateGroup(facade::CmdArgParser* parser, Transaction* tx, SinkReplyBuilder
 void DestroyGroup(facade::CmdArgParser* parser, Transaction* tx, SinkReplyBuilder* builder) {
   auto [key, gname] = parser->Next<string_view, string_view>();
 
-  if (auto err = parser->Error(); err)
-    return builder->SendError(err->MakeReply());
+  if (auto err = parser->TakeError(); err)
+    return builder->SendError(err.MakeReply());
 
   if (parser->HasNext())
     return builder->SendError(UnknownSubCmd("DESTROY", "XGROUP"));
@@ -1911,8 +1911,8 @@ void DestroyGroup(facade::CmdArgParser* parser, Transaction* tx, SinkReplyBuilde
 void CreateConsumer(facade::CmdArgParser* parser, Transaction* tx, SinkReplyBuilder* builder) {
   auto [key, gname, consumer] = parser->Next<string_view, string_view, string_view>();
 
-  if (auto err = parser->Error(); err)
-    return builder->SendError(err->MakeReply());
+  if (auto err = parser->TakeError(); err)
+    return builder->SendError(err.MakeReply());
 
   if (parser->HasNext())
     return builder->SendError(UnknownSubCmd("CREATECONSUMER", "XGROUP"));
@@ -1940,8 +1940,8 @@ void CreateConsumer(facade::CmdArgParser* parser, Transaction* tx, SinkReplyBuil
 void DelConsumer(facade::CmdArgParser* parser, Transaction* tx, SinkReplyBuilder* builder) {
   auto [key, gname, consumer] = parser->Next<string_view, string_view, string_view>();
 
-  if (auto err = parser->Error(); err)
-    return builder->SendError(err->MakeReply());
+  if (auto err = parser->TakeError(); err)
+    return builder->SendError(err.MakeReply());
 
   if (parser->HasNext())
     return builder->SendError(UnknownSubCmd("DELCONSUMER", "XGROUP"));
@@ -1977,8 +1977,8 @@ void SetId(facade::CmdArgParser* parser, Transaction* tx, SinkReplyBuilder* buil
     }
   }
 
-  if (auto err = parser->Error(); err)
-    return builder->SendError(err->MakeReply());
+  if (auto err = parser->TakeError(); err)
+    return builder->SendError(err.MakeReply());
 
   auto cb = [&, &key = key, &gname = gname, &id = id](Transaction* t, EngineShard* shard) {
     return OpSetId(t->GetOpArgs(shard), key, gname, id);
@@ -2661,8 +2661,8 @@ void StreamFamily::XAdd(CmdArgList args, const CommandContext& cmd_cntx) {
 
   auto parsed_add_opts = ParseAddOpts(&parser);
 
-  if (auto err = parser.Error(); err || !parsed_add_opts) {
-    rb->SendError(!parsed_add_opts ? parsed_add_opts.error() : err->MakeReply());
+  if (auto err = parser.TakeError(); err || !parsed_add_opts) {
+    rb->SendError(!parsed_add_opts ? parsed_add_opts.error() : err.MakeReply());
     return;
   }
 
@@ -2844,8 +2844,8 @@ void StreamFamily::XGroup(CmdArgList args, const CommandContext& cmd_cntx) {
                                      &DestroyGroup, "CREATECONSUMER", &CreateConsumer,
                                      "DELCONSUMER", &DelConsumer, "SETID", &SetId);
 
-  if (auto err = parser.Error(); err)
-    return cmd_cntx.rb->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err)
+    return cmd_cntx.rb->SendError(err.MakeReply());
 
   sub_cmd_func(&parser, cmd_cntx.tx, cmd_cntx.rb);
 }
@@ -3294,8 +3294,8 @@ void StreamFamily::XTrim(CmdArgList args, const CommandContext& cmd_cntx) {
 
   auto parsed_trim_opts = ParseTrimOpts(&parser);
   if (!parser.Finalize() || !parsed_trim_opts) {
-    auto err = parser.Error();
-    rb->SendError(!parsed_trim_opts ? parsed_trim_opts.error() : err->MakeReply());
+    auto err = parser.TakeError();
+    rb->SendError(!parsed_trim_opts ? parsed_trim_opts.error() : err.MakeReply());
     return;
   }
 

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -1037,8 +1037,8 @@ void StringFamily::Set(CmdArgList args, const CommandContext& cmnd_cntx) {
         exp_type) {
       auto int_arg = parser.Next<int64_t>();
 
-      if (auto err = parser.Error(); err) {
-        return builder->SendError(err->MakeReply());
+      if (auto err = parser.TakeError(); err) {
+        return builder->SendError(err.MakeReply());
       }
 
       // We can set expiry only once.
@@ -1084,8 +1084,8 @@ void StringFamily::Set(CmdArgList args, const CommandContext& cmnd_cntx) {
     }
   }
 
-  if (auto err = parser.Error(); err) {
-    return builder->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err) {
+    return builder->SendError(err.MakeReply());
   }
 
   auto has_mask = [&](uint16_t m) { return (sparams.flags & m) == m; };
@@ -1221,8 +1221,8 @@ void StringFamily::GetEx(CmdArgList args, const CommandContext& cmnd_cntx) {
                                           "PXAT", ExpT::PXAT);
         exp_type) {
       auto int_arg = parser.Next<int64_t>();
-      if (auto err = parser.Error(); err) {
-        return builder->SendError(err->MakeReply());
+      if (auto err = parser.TakeError(); err) {
+        return builder->SendError(err.MakeReply());
       }
 
       if (defined) {
@@ -1513,8 +1513,8 @@ void StringFamily::GetRange(CmdArgList args, const CommandContext& cmnd_cntx) {
   CmdArgParser parser(args);
   auto [key, start, end] = parser.Next<string_view, int32_t, int32_t>();
 
-  if (auto err = parser.Error(); err) {
-    return cmnd_cntx.rb->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err) {
+    return cmnd_cntx.rb->SendError(err.MakeReply());
   }
 
   auto cb = [&, &key = key, &start = start, &end = end](Transaction* t, EngineShard* shard) {
@@ -1529,8 +1529,8 @@ void StringFamily::SetRange(CmdArgList args, const CommandContext& cmnd_cntx) {
   auto [key, start, value] = parser.Next<string_view, int32_t, string_view>();
   auto* builder = cmnd_cntx.rb;
 
-  if (auto err = parser.Error(); err) {
-    return builder->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err) {
+    return builder->SendError(err.MakeReply());
   }
 
   if (start < 0) {
@@ -1675,7 +1675,7 @@ void StringFamily::GAT(CmdArgList args, const CommandContext& cmnd_cntx) {
   CmdArgParser parser{args};
   const int64_t expire_ts = parser.Next<uint64_t>();
   if (parser.HasError()) {
-    return builder->SendError(parser.Error()->MakeReply());
+    return builder->SendError(parser.TakeError().MakeReply());
   }
 
   BlockingCounter tiering_bc{0};

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1717,8 +1717,8 @@ void ZRangeGeneric(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder,
   using RP = ZSetFamily::RangeParams;
 
   while (true) {
-    if (auto err = parser.Error(); err)
-      return builder->SendError(err->MakeReply());
+    if (auto err = parser.TakeError(); err)
+      return builder->SendError(err.MakeReply());
 
     if (!parser.HasNext())
       break;
@@ -1780,7 +1780,7 @@ void ZRankGeneric(CmdArgList args, bool reverse, Transaction* tx, SinkReplyBuild
   }
 
   if (!parser.Finalize()) {
-    return builder->SendError(parser.Error()->MakeReply());
+    return builder->SendError(parser.TakeError().MakeReply());
   }
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
@@ -1887,7 +1887,7 @@ bool ValidateZMPopCommand(CmdArgList args, bool is_blocking, SinkReplyBuilder* b
   }
 
   if (!parser.Finalize()) {
-    builder->SendError(parser.Error()->MakeReply());
+    builder->SendError(parser.TakeError().MakeReply());
     return false;
   }
 
@@ -2692,8 +2692,8 @@ void ZSetFamily::ZRandMember(CmdArgList args, const CommandContext& cmd_cntx) {
   if (parser.HasNext())
     return rb->SendError(absl::StrCat("Unsupported option:", string_view(parser.Next())));
 
-  if (auto err = parser.Error(); err)
-    return rb->SendError(err->MakeReply());
+  if (auto err = parser.TakeError(); err)
+    return rb->SendError(err.MakeReply());
 
   const auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpRandMember(count, params, t->GetOpArgs(shard), key);


### PR DESCRIPTION
problem: The Error() method was risky and confusing because it removes the error.

fix: method was renamed to TakeError() and added DCHECK that an error exists.