### PR TITLE
chore: string_view overload for BaseFamilyTest::Run

### DIFF
--- a/src/server/set_family_test.cc
+++ b/src/server/set_family_test.cc
@@ -431,15 +431,15 @@ TEST_F(SetFamilyTest, SAddEx) {
 
 TEST_F(SetFamilyTest, CheckSetLinkExpiryTransfer) {
   for (int i = 0; i < 10; i++) {
-    EXPECT_THAT(Run({"SADDEX", "key", "5", absl::StrCat(i)}), IntArg(1));
+    EXPECT_THAT(Run(absl::StrCat("SADDEX key 5 ", i)), IntArg(1));
   }
   for (int i = 0; i < 9; i++) {
-    Run({"SREM", "key", absl::StrCat(i)});
+    Run(absl::StrCat("SREM key ", i));
   }
-  EXPECT_THAT(Run({"SCARD", "key"}), IntArg(1));
+  EXPECT_THAT(Run("SCARD key"), IntArg(1));
   AdvanceTime(6000);
-  Run({"SMEMBERS", "key"});
-  EXPECT_THAT(Run({"SCARD", "key"}), IntArg(0));
+  Run("SMEMBERS key");
+  EXPECT_THAT(Run("SCARD key"), IntArg(0));
 }
 
 }  // namespace dfly

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -404,6 +404,11 @@ RespExpr BaseFamilyTest::Run(ArgSlice list) {
   return Run(GetId(), list);
 }
 
+RespExpr BaseFamilyTest::Run(std::string_view command) {
+  std::vector<std::string_view> command_list = absl::StrSplit(command, ' ');
+  return Run(command_list);
+}
+
 RespExpr BaseFamilyTest::RunPrivileged(std::initializer_list<const std::string_view> list) {
   if (!ProactorBase::IsProactorThread()) {
     return pp_->at(0)->Await([&] { return this->RunPrivileged(list); });

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -85,6 +85,9 @@ class BaseFamilyTest : public ::testing::Test {
   RespExpr Run(absl::Span<std::string> list);
 
   RespExpr Run(std::string_view id, ArgSlice list);
+
+  RespExpr Run(std::string_view command);
+
   void RunMany(const std::vector<std::vector<std::string>>& cmds);
 
   using MCResponse = std::vector<std::string>;


### PR DESCRIPTION
It's cumbersome to call `Run()` every time with each command argument separately  