### PR TITLE
fix: FlushSlots test

### DIFF
--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -723,7 +723,7 @@ TEST_F(ClusterFamilyTest, FlushSlots) {
   ExpectConditionWithinTimeout([&]() {
     return RunPrivileged({"dflycluster", "flushslots", "0", "0"}) == "OK";
   });
-  util::ThisFiber::SleepFor(1ms);
+  util::ThisFiber::SleepFor(10ms);
   EXPECT_THAT(RunPrivileged({"dflycluster", "getslotinfo", "slots", "0", "1"}),
               RespArray(ElementsAre(
                   RespArray(ElementsAre(IntArg(0), "key_count", IntArg(0), "total_reads", _,
@@ -732,7 +732,7 @@ TEST_F(ClusterFamilyTest, FlushSlots) {
                                         "total_writes", _, "memory_bytes", _)))));
 
   EXPECT_EQ(RunPrivileged({"dflycluster", "flushslots", "0", "1"}), "OK");
-  util::ThisFiber::SleepFor(1ms);
+  util::ThisFiber::SleepFor(10ms);
   EXPECT_THAT(
       RunPrivileged({"dflycluster", "getslotinfo", "slots", "0", "1"}),
       RespArray(ElementsAre(RespArray(ElementsAre(IntArg(0), "key_count", IntArg(0), "total_reads",


### PR DESCRIPTION
fixes: #5309

problem: flush_slots is an async operation
```
void DbSlice::FlushSlots(const cluster::SlotRanges& slot_ranges) {
  cluster::SlotSet slot_set(slot_ranges);
  InvalidateSlotWatches(slot_set);
  fb2::Fiber("flush_slots", [this, slot_set = std::move(slot_set)]() mutable {
    FlushSlotsFb(slot_set);
  }).Detach();
}
```

fix: wait a little longer to be sure that operation is finished