### PR TITLE
fix: preserve null characters in hash values after HEXPIRE

### DIFF
--- a/src/core/string_map.cc
+++ b/src/core/string_map.cc
@@ -293,7 +293,10 @@ void* StringMap::ObjectClone(const void* obj, bool has_ttl, bool add_ttl) const 
   uint32_t ttl_sec = add_ttl ? 0 : (has_ttl ? ObjExpireTime(obj) : UINT32_MAX);
   sds str = (sds)obj;
   auto pair = detail::SdsPair(str, GetValue(str));
-  auto [newkey, sdsval_tag] = CreateEntry(pair->first, pair->second, time_now(), ttl_sec);
+  // Use explicit string_view constructor with length to preserve null characters
+  string_view key_sv(pair->first, sdslen(pair->first));
+  string_view value_sv(pair->second, sdslen(pair->second));
+  auto [newkey, sdsval_tag] = CreateEntry(key_sv, value_sv, time_now(), ttl_sec);
 
   return (void*)newkey;
 }

--- a/src/server/hset_family_test.cc
+++ b/src/server/hset_family_test.cc
@@ -478,6 +478,15 @@ TEST_F(HSetFamilyTest, HExpireNoAddNew) {
   EXPECT_THAT(Run({"HGETALL", "key"}), RespArray(ElementsAre()));
 }
 
+TEST_F(HSetFamilyTest, HExpireWithNullChar) {
+  string val_with_null("test\0test", 9);
+  Run({"HSET", "hash", "field", val_with_null});
+  string expected_val("test\0test", 9);
+  EXPECT_EQ(ToSV(Run({"HGET", "hash", "field"}).GetBuf()), expected_val);
+  Run({"HEXPIRE", "hash", "15", "FIELDS", "1", "field"});
+  EXPECT_EQ(ToSV(Run({"HGET", "hash", "field"}).GetBuf()), expected_val);
+}
+
 TEST_F(HSetFamilyTest, RandomFieldAllExpired) {
   for (int i = 0; i < 10; ++i) {
     EXPECT_EQ(CheckedInt({"HSETEX", "key", "10", absl::StrCat("k", i), "v"}), 1);


### PR DESCRIPTION
Fixes: https://github.com/dragonflydb/dragonfly/issues/5623

The problem occurred during the conversion from listpack to StringMap when HEXPIRE was called. In `StringMap::ObjectClone()`, sds values were implicitly converted to `string_view` using the `const char*` constructor, which uses `strlen()` and stops at the first null character.

Changes:
- Use explicit `string_view(ptr, len)` constructor with `sdslen()` in `ObjectClone()`
- Add test case to verify null character preservation after HEXPIRE