### PR TITLE
test: skip test_acl_del_user_while_running_lua_script becuase it constantly fails on CI

### DIFF
--- a/tests/dragonfly/acl_family_test.py
+++ b/tests/dragonfly/acl_family_test.py
@@ -268,6 +268,7 @@ end
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip("Flaky on CI, needs investigation")
 async def test_acl_del_user_while_running_lua_script(df_server):
     client = aioredis.Redis(port=df_server.port)
     await client.execute_command("ACL SETUSER kostas ON >kk +@string +@scripting ~*")


### PR DESCRIPTION
Hard to reproduce the failure locally. Let's skip this test for some time. Additional investigation needed.