### PR TITLE
core: Track objects skipped during defragmentation

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -581,6 +581,8 @@ bool RobjWrapper::DefragIfNeeded(PageUsage* page_usage) {
   } else if (type() == OBJ_ZSET) {
     return do_defrag(DefragZSet);
   }
+
+  page_usage->RecordNotSupported();
   return false;
 }
 
@@ -1063,7 +1065,7 @@ string_view CompactObj::GetSlice(string* scratch) const {
 bool CompactObj::DefragIfNeeded(PageUsage* page_usage) {
   switch (taglen_) {
     case ROBJ_TAG:
-      // currently only these objet types are supported for this operation
+      // currently only these object types are supported for this operation
       if (u_.r_obj.inner_obj() != nullptr) {
         return u_.r_obj.DefragIfNeeded(page_usage);
       }
@@ -1071,11 +1073,14 @@ bool CompactObj::DefragIfNeeded(PageUsage* page_usage) {
     case SMALL_TAG:
       return u_.small_str.DefragIfNeeded(page_usage);
     case INT_TAG:
+      page_usage->RecordNotRequired();
       // this is not relevant in this case
       return false;
     case EXTERNAL_TAG:
+      page_usage->RecordNotRequired();
       return false;
     default:
+      page_usage->RecordNotRequired();
       // This is the case when the object is at inline_str
       return false;
   }

--- a/src/core/page_usage_stats.cc
+++ b/src/core/page_usage_stats.cc
@@ -55,6 +55,8 @@ void CollectedPageStats::Merge(CollectedPageStats&& other, uint16_t shard_id) {
   this->pages_reserved_for_malloc += other.pages_reserved_for_malloc;
   this->pages_with_heap_mismatch += other.pages_with_heap_mismatch;
   this->pages_above_threshold += other.pages_above_threshold;
+  this->objects_skipped_not_required += other.objects_skipped_not_required;
+  this->objects_skipped_not_supported += other.objects_skipped_not_supported;
   shard_wide_summary.emplace(std::make_pair(shard_id, std::move(other.page_usage_hist)));
 }
 
@@ -79,6 +81,12 @@ std::string CollectedPageStats::ToString() const {
   StrAppend(&response, "Pages reserved for malloc: ", pages_reserved_for_malloc, "\n");
   StrAppend(&response, "Pages skipped due to heap mismatch: ", pages_with_heap_mismatch, "\n");
   StrAppend(&response, "Pages with usage above threshold: ", pages_above_threshold, "\n");
+  StrAppend(&response,
+            "Objects skipped (do not require defragmentation): ", objects_skipped_not_required,
+            "\n");
+  StrAppend(&response,
+            "Objects skipped (do not support defragmentation): ", objects_skipped_not_supported,
+            "\n");
   for (const auto& [shard_id, usage] : shard_wide_summary) {
     StrAppend(&response, "[Shard ", shard_id, "]\n");
     for (const auto& [percentage, count] : usage) {
@@ -135,6 +143,8 @@ CollectedPageStats PageUsage::UniquePages::CollectedStats() const {
                             .pages_reserved_for_malloc = pages_reserved_for_malloc.size,
                             .pages_with_heap_mismatch = pages_with_heap_mismatch.size,
                             .pages_above_threshold = pages_above_threshold.size,
+                            .objects_skipped_not_required = objects_skipped_not_required,
+                            .objects_skipped_not_supported = objects_skipped_not_supported,
                             .page_usage_hist = std::move(usage),
                             .shard_wide_summary = {}};
 }

--- a/src/core/page_usage_stats.h
+++ b/src/core/page_usage_stats.h
@@ -30,6 +30,8 @@ struct CollectedPageStats {
   uint64_t pages_reserved_for_malloc{0};
   uint64_t pages_with_heap_mismatch{0};
   uint64_t pages_above_threshold{0};
+  uint64_t objects_skipped_not_required{0};
+  uint64_t objects_skipped_not_supported{0};
 
   using ShardUsageSummary = absl::btree_map<uint8_t, uint64_t>;
   ShardUsageSummary page_usage_hist;
@@ -55,6 +57,14 @@ class PageUsage {
 
   bool ConsumePageStats(mi_page_usage_stats_t stats);
 
+  void RecordNotRequired() {
+    unique_pages_.objects_skipped_not_required += 1;
+  }
+
+  void RecordNotSupported() {
+    unique_pages_.objects_skipped_not_supported += 1;
+  }
+
  private:
   CollectPageStats collect_stats_{CollectPageStats::NO};
   float threshold_;
@@ -67,6 +77,9 @@ class PageUsage {
     FilterWithSize pages_with_heap_mismatch{};
     FilterWithSize pages_above_threshold{};
     hdr_histogram* page_usage_hist{};
+
+    uint64_t objects_skipped_not_required{0};
+    uint64_t objects_skipped_not_supported{0};
 
     explicit UniquePages();
     ~UniquePages();

--- a/src/core/page_usage_stats_test.cc
+++ b/src/core/page_usage_stats_test.cc
@@ -8,6 +8,7 @@
 
 #include "base/gtest.h"
 #include "base/logging.h"
+#include "core/compact_object.h"
 #include "core/mi_memory_resource.h"
 #include "core/score_map.h"
 #include "core/small_string.h"
@@ -65,14 +66,8 @@ class PageUsageStatsTest : public ::testing::Test {
   std::unique_ptr<StringSet> string_set_;
   std::unique_ptr<StringMap> string_map_;
   SmallString small_string_{};
+  CompactObj c_obj_{};
 };
-
-bool PageCannotRealloc(mi_page_usage_stats_t s) {
-  const bool page_full = s.flags & MI_DFLY_PAGE_FULL;
-  const bool heap_mismatch = s.flags & MI_DFLY_HEAP_MISMATCH;
-  const bool malloc_page = s.flags & MI_DFLY_PAGE_USED_FOR_MALLOC;
-  return page_full || heap_mismatch || malloc_page;
-}
 
 TEST_F(PageUsageStatsTest, Defrag) {
   score_map_->AddOrUpdate("test", 0.1);
@@ -81,6 +76,9 @@ TEST_F(PageUsageStatsTest, Defrag) {
   string_map_->AddOrUpdate("key", "value");
   small_string_.Assign("small-string");
 
+  // INT_TAG, defrag will be skipped
+  c_obj_.SetString("1");
+
   {
     PageUsage p{CollectPageStats::YES, 0.1};
     score_map_->begin().ReallocIfNeeded(&p);
@@ -88,9 +86,11 @@ TEST_F(PageUsageStatsTest, Defrag) {
     string_set_->begin().ReallocIfNeeded(&p);
     string_map_->begin().ReallocIfNeeded(&p);
     small_string_.DefragIfNeeded(&p);
+    c_obj_.DefragIfNeeded(&p);
 
     const auto stats = p.CollectedStats();
     EXPECT_GT(stats.pages_scanned, 0);
+    EXPECT_EQ(stats.objects_skipped_not_required, 1);
   }
 
   {


### PR DESCRIPTION
Objects which are skipped during defragmentation fall in two categories:

* not required (eg INT_TAG)
* not supported but will require support (eg qlist)

The counts for both are tracked and reported, to make it easier to understand where defragmentation did not have an effect.