### PR TITLE
fix(json): support json keys containing dots in bracket notation

### DIFF
--- a/src/core/json/jsonpath_grammar.y
+++ b/src/core/json/jsonpath_grammar.y
@@ -62,6 +62,7 @@ using namespace std;
 %nterm <PathSegment> bracket_index
 %nterm <std::string> single_quoted_string
 %nterm <std::string> double_quoted_string
+%nterm <std::string> quoted_content
 
 
 %%
@@ -94,9 +95,12 @@ bracket_index: single_quoted_string { $$ = PathSegment(SegmentType::IDENTIFIER, 
               | INT COLON { $$ = PathSegment(SegmentType::INDEX, IndexExpr($1, INT_MAX)); }
               | COLON INT { $$ = PathSegment(SegmentType::INDEX, IndexExpr::HalfOpen(0, $2)); }
 
-single_quoted_string: SINGLE_QUOTE UNQ_STR SINGLE_QUOTE { $$ = $2; }
+single_quoted_string: SINGLE_QUOTE quoted_content SINGLE_QUOTE { $$ = $2; }
 
-double_quoted_string: DOUBLE_QUOTE UNQ_STR DOUBLE_QUOTE { $$ = $2; }
+double_quoted_string: DOUBLE_QUOTE quoted_content DOUBLE_QUOTE { $$ = $2; }
+
+quoted_content: UNQ_STR { $$ = $1; }
+              | quoted_content DOT UNQ_STR { $$ = $1 + "." + $3; }
 
 function_expr: UNQ_STR { driver->AddFunction($1); } LPARENT ROOT relative_location RPARENT
 %%

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -3213,4 +3213,17 @@ TEST_F(JsonFamilyTest, DelNonExistingKey) {
   EXPECT_THAT(resp, IntArg(0));
 }
 
+TEST_F(JsonFamilyTest, JsonKeysWithDots) {
+  auto resp = Run(
+      {"JSON.SET", "OFFERS:DBX-AGG1611-IGN", "$",
+       R"({"Gallery": {"Images": {"bdz1xjm.jpeg": "some_value", "bdz1xjm": "another_value"}}})"});
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run({"JSON.GET", "OFFERS:DBX-AGG1611-IGN", "$['Gallery']['Images']['bdz1xjm']"});
+  EXPECT_THAT(resp, "[\"another_value\"]");
+
+  resp = Run({"JSON.GET", "OFFERS:DBX-AGG1611-IGN", "$['Gallery']['Images']['bdz1xjm.jpeg']"});
+  EXPECT_THAT(resp, "[\"some_value\"]");
+}
+
 }  // namespace dfly


### PR DESCRIPTION
Fixes: https://github.com/dragonflydb/dragonfly/issues/5643

Enhanced grammar rules in jsonpath_grammar.y to handle dots within quoted strings in brackets.
