### PR TITLE
fix: accounting of metrics under squash_stats_latency_lower_limit filter

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -141,6 +141,8 @@ ABSL_FLAG(uint32_t, uring_wake_mode, 1,
           "0 - use eventfd, 1 - use io_uring, 2 - use io_uring with immediate flush of the "
           "notification");
 
+ABSL_FLAG(uint32_t, uring_submit_threshold, 1u << 31, "");
+
 ABSL_FLAG(uint32_t, squash_stats_latency_lower_limit, 0,
           "If set, will not track latency stats below this threshold (usec). ");
 
@@ -763,6 +765,17 @@ void SetUringWakeMode(uint32_t mode) {
 #endif
 }
 
+void SetUringSubmitThreshold(uint32_t val) {
+#ifdef __linux__
+  shard_set->pool()->AwaitBrief([val](unsigned, fb2::ProactorBase* pb) {
+    if (pb->GetKind() == fb2::ProactorBase::IOURING) {
+      fb2::UringProactor* up = static_cast<fb2::UringProactor*>(pb);
+      up->SetSubmitQueueThreshold(val);
+    }
+  });
+#endif
+}
+
 void SetHuffmanTable(const std::string& huffman_table) {
   if (huffman_table.empty())
     return;
@@ -968,6 +981,8 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
 
   config_registry.RegisterSetter<uint32_t>("uring_wake_mode",
                                            [](uint32_t val) { SetUringWakeMode(val); });
+  config_registry.RegisterSetter<uint32_t>("uring_submit_threshold",
+                                           [](uint32_t val) { SetUringSubmitThreshold(val); });
 
   uint32_t shard_num = GetFlag(FLAGS_num_shards);
   if (shard_num == 0 || shard_num > pp_.size()) {

--- a/tools/local/monitoring/grafana/provisioning/dashboards/dragonfly.json
+++ b/tools/local/monitoring/grafana/provisioning/dashboards/dragonfly.json
@@ -1336,7 +1336,7 @@
           "editorMode": "code",
           "exemplar": true,
           "expr":
-              "irate(dragonfly_pipeline_commands_duration_seconds{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval])/irate(dragonfly_pipeline_commands_total{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval])",
+              "rate(dragonfly_pipeline_commands_duration_seconds{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval])/rate(dragonfly_pipeline_commands_total{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1353,7 +1353,7 @@
           "editorMode": "code",
           "exemplar": true,
           "expr":
-              "irate(dragonfly_cmd_squash_hop_duration_seconds{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval])/irate(dragonfly_cmd_squash_hop_total{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval])",
+              "rate(dragonfly_cmd_squash_hop_duration_seconds{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval])/rate(dragonfly_cmd_squash_hop_total{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1371,7 +1371,7 @@
           "editorMode": "code",
           "exemplar": true,
           "expr":
-              "irate(dragonfly_pipeline_queue_wait_duration_seconds{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval])/irate(dragonfly_pipeline_commands_total{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval])",
+              "rate(dragonfly_pipeline_queue_wait_duration_seconds{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval])/rate(dragonfly_pipeline_commands_total{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1389,7 +1389,7 @@
           "editorMode": "code",
           "exemplar": false,
           "expr":
-              "irate(dragonfly_pipeline_dispatch_flush_duration_seconds{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval])/irate(dragonfly_pipeline_dispatch_calls_total{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval])",
+              "rate(dragonfly_pipeline_dispatch_flush_duration_seconds{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval])/rate(dragonfly_pipeline_dispatch_calls_total{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2046,7 +2046,7 @@
           },
           "editorMode": "code",
           "expr":
-              "1 - irate(dragonfly_cmd_squash_hop_total\n{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval])/(irate(dragonfly_cmd_squash_hop_total{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval]) + irate(dragonfly_cmd_squash_stats_ignored_total{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval]))",
+              "1 - irate(dragonfly_pipeline_dispatch_calls_total\n{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval])/(irate(dragonfly_pipeline_dispatch_calls_total{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval]) + irate(dragonfly_cmd_squash_stats_ignored_total{namespace=\"$namespace\",pod=~\"$pod_name\"}[$__rate_interval]))",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -2358,6 +2358,6 @@
   "timezone": "browser",
   "title": "Dragonfly Dashboard",
   "uid": "xDLNRKUWz",
-  "version": 16,
+  "version": 3,
   "weekStart": ""
 }


### PR DESCRIPTION
Fix pipeline_queue_wait_duration_seconds and pipeline_commands_duration_seconds with pipeline_dispatch_commands_total that before that did not take into account squash_stats_latency_lower_limit filter.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->