### PR TITLE
chore(server): Semi-automatic flag updates

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1450,7 +1450,6 @@ auto Connection::IoLoop() -> variant<error_code, ParserStatus> {
   ParserStatus parse_status = OK;
 
   size_t max_iobfuf_len = GetFlag(FLAGS_max_client_iobuf_len);
-  max_busy_read_cycles_cached = GetFlag(FLAGS_max_busy_read_usec);
 
   auto* peer = socket_.get();
   recv_buf_.res_len = 0;
@@ -2172,7 +2171,7 @@ void Connection::UpdateFromFlags() {
   thread_queue_backpressure[tid].pipeline_buffer_limit = GetFlag(FLAGS_pipeline_buffer_limit);
   thread_queue_backpressure[tid].pipeline_cnd.notify_all();
 
-  max_busy_read_cycles_cached = GetFlag(FLAGS_max_busy_read_usec);
+  max_busy_read_cycles_cached = base::CycleClock::FromUsec(GetFlag(FLAGS_max_busy_read_usec));
   always_flush_pipeline_cached = GetFlag(FLAGS_always_flush_pipeline);
   pipeline_squash_limit_cached = GetFlag(FLAGS_pipeline_squash_limit);
   pipeline_wait_batch_usec = GetFlag(FLAGS_pipeline_wait_batch_usec);

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -22,6 +22,7 @@
 #include "core/heap_size.h"
 #include "facade/conn_context.h"
 #include "facade/dragonfly_listener.h"
+#include "facade/flag_utils.h"
 #include "facade/memcache_parser.h"
 #include "facade/redis_parser.h"
 #include "facade/service_interface.h"
@@ -1449,7 +1450,7 @@ auto Connection::IoLoop() -> variant<error_code, ParserStatus> {
   ParserStatus parse_status = OK;
 
   size_t max_iobfuf_len = GetFlag(FLAGS_max_client_iobuf_len);
-  SetMaxBusyReadUsecThreadLocal(GetFlag(FLAGS_max_busy_read_usec));
+  max_busy_read_cycles_cached = GetFlag(FLAGS_max_busy_read_usec);
 
   auto* peer = socket_.get();
   recv_buf_.res_len = 0;
@@ -2165,14 +2166,22 @@ bool Connection::IsReplySizeOverLimit() const {
   return over_limit;
 }
 
-void Connection::SetMaxQueueLenThreadLocal(unsigned tid, uint32_t val) {
-  thread_queue_backpressure[tid].pipeline_queue_max_len = val;
+void Connection::UpdateFromFlags() {
+  unsigned tid = fb2::ProactorBase::me()->GetPoolIndex();
+  thread_queue_backpressure[tid].pipeline_queue_max_len = GetFlag(FLAGS_pipeline_queue_limit);
+  thread_queue_backpressure[tid].pipeline_buffer_limit = GetFlag(FLAGS_pipeline_buffer_limit);
   thread_queue_backpressure[tid].pipeline_cnd.notify_all();
+
+  max_busy_read_cycles_cached = GetFlag(FLAGS_max_busy_read_usec);
+  always_flush_pipeline_cached = GetFlag(FLAGS_always_flush_pipeline);
+  pipeline_squash_limit_cached = GetFlag(FLAGS_pipeline_squash_limit);
+  pipeline_wait_batch_usec = GetFlag(FLAGS_pipeline_wait_batch_usec);
 }
 
-void Connection::SetPipelineBufferLimit(unsigned tid, size_t val) {
-  thread_queue_backpressure[tid].pipeline_buffer_limit = val;
-  thread_queue_backpressure[tid].pipeline_cnd.notify_all();
+std::vector<std::string> Connection::GetMutableFlagNames() {
+  return GetFlagNames(FLAGS_pipeline_queue_limit, FLAGS_pipeline_buffer_limit,
+                      FLAGS_max_busy_read_usec, FLAGS_always_flush_pipeline,
+                      FLAGS_pipeline_squash_limit, FLAGS_pipeline_wait_batch_usec);
 }
 
 void Connection::GetRequestSizeHistogramThreadLocal(std::string* hist) {
@@ -2191,22 +2200,6 @@ void Connection::TrackRequestSize(bool enable) {
 
 void Connection::EnsureMemoryBudget(unsigned tid) {
   thread_queue_backpressure[tid].EnsureBelowLimit();
-}
-
-void Connection::SetMaxBusyReadUsecThreadLocal(unsigned usec) {
-  max_busy_read_cycles_cached = base::CycleClock::FromUsec(usec);
-}
-
-void Connection::SetAlwaysFlushPipelineThreadLocal(bool flush) {
-  always_flush_pipeline_cached = flush;
-}
-
-void Connection::SetPipelineSquashLimitThreadLocal(unsigned limit) {
-  pipeline_squash_limit_cached = limit;
-}
-
-void Connection::SetPipelineWaitBatchUsecThreadLocal(unsigned usec) {
-  pipeline_wait_batch_usec = usec;
 }
 
 Connection::WeakRef::WeakRef(const std::shared_ptr<Connection>& ptr, unsigned thread_id,

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -306,16 +306,12 @@ class Connection : public util::Connection {
 
   bool IsHttp() const;
 
-  // Sets max queue length locally in the calling thread.
-  static void SetMaxQueueLenThreadLocal(unsigned tid, uint32_t val);
-  static void SetPipelineBufferLimit(unsigned tid, size_t val);
-  static void GetRequestSizeHistogramThreadLocal(std::string* hist);
+  static void UpdateFromFlags();                          // Set values from flags
+  static std::vector<std::string> GetMutableFlagNames();  // Triggers UpdateFromFlags
+
   static void TrackRequestSize(bool enable);
   static void EnsureMemoryBudget(unsigned tid);
-  static void SetMaxBusyReadUsecThreadLocal(unsigned usec);
-  static void SetAlwaysFlushPipelineThreadLocal(bool flush);
-  static void SetPipelineSquashLimitThreadLocal(unsigned limit);
-  static void SetPipelineWaitBatchUsecThreadLocal(unsigned usec);
+  static void GetRequestSizeHistogramThreadLocal(std::string* hist);
 
   unsigned idle_time() const {
     return time(nullptr) - last_interaction_;

--- a/src/facade/flag_utils.h
+++ b/src/facade/flag_utils.h
@@ -1,0 +1,15 @@
+// Copyright 2025, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "absl/flags/flag.h"
+
+namespace facade {
+template <typename... Ts> std::vector<std::string> GetFlagNames(const absl::Flag<Ts>&... flags) {
+  return std::vector<std::string>{std::string{absl::GetFlagReflectionHandle(flags).Name()}...};
+}
+}  // namespace facade

--- a/src/facade/flag_utils.h
+++ b/src/facade/flag_utils.h
@@ -10,6 +10,6 @@
 
 namespace facade {
 template <typename... Ts> std::vector<std::string> GetFlagNames(const absl::Flag<Ts>&... flags) {
-  return std::vector<std::string>{std::string{absl::GetFlagReflectionHandle(flags).Name()}...};
+  return {std::string{absl::GetFlagReflectionHandle(flags).Name()}...};
 }
 }  // namespace facade

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -961,6 +961,7 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
   Transaction::Init(shard_num);
 
   shard_set->pool()->AwaitBrief([](unsigned, auto*) {
+    facade::Connection::UpdateFromFlags();
     UpdateFromFlagsOnThread();
     UpdateUringFlagsOnThread();
   });

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -33,6 +33,7 @@ extern "C" {
 #include "base/logging.h"
 #include "facade/dragonfly_connection.h"
 #include "facade/error.h"
+#include "facade/flag_utils.h"
 #include "facade/reply_builder.h"
 #include "facade/reply_capture.h"
 #include "server/acl/acl_commands_def.h"
@@ -110,24 +111,6 @@ ABSL_RETIRED_FLAG(
     double, oom_deny_ratio, 1.1,
     "commands with flag denyoom will return OOM when the ratio between maxmemory and used "
     "memory is above this value");
-
-ABSL_FLAG(double, rss_oom_deny_ratio, 1.25,
-          "When the ratio between maxmemory and RSS memory exceeds this value, commands marked as "
-          "DENYOOM will fail with OOM error and new connections to non-admin port will be "
-          "rejected. Negative value disables this feature.");
-
-ABSL_FLAG(size_t, serialization_max_chunk_size, 64_KB,
-          "Maximum size of a value that may be serialized at once during snapshotting or full "
-          "sync. Values bigger than this threshold will be serialized using streaming "
-          "serialization. 0 - to disable streaming mode");
-ABSL_FLAG(uint32_t, max_squashed_cmd_num, 100,
-          "Max number of commands squashed in a single shard during squash optimizaiton");
-
-ABSL_FLAG(uint32_t, max_busy_squash_usec, 1000,
-          "Maximum time in microseconds to execute squashed commands before yielding.");
-
-ABSL_FLAG(uint32_t, log_squash_info_threshold_usec, 1 << 31,
-          "Threshold in microseconds above which to log squashing timings.");
 
 ABSL_FLAG(uint32_t, shard_thread_busy_polling_usec, 0,
           "If non-zero, overrides the busy polling parameter for shard threads.");
@@ -728,24 +711,18 @@ string FailedCommandToString(std::string_view command, facade::CmdArgList args,
   return result;
 }
 
-template <typename T> auto UpdateServerState(T ServerState::*member) {
-  return [member](T value) {
-    auto cb = [member, value](unsigned, auto*) { ServerState::tlocal()->*member = value; };
-    shard_set->pool()->AwaitBrief(cb);
-  };
+thread_local uint32_t squash_stats_latency_lower_limit_cached;
+
+void UpdateFromFlagsOnThread() {
+  if (uint32_t poll = GetFlag(FLAGS_shard_thread_busy_polling_usec);
+      poll > 0 && EngineShard::tlocal())
+    ProactorBase::me()->SetBusyPollUsec(poll);
+  squash_stats_latency_lower_limit_cached = GetFlag(FLAGS_squash_stats_latency_lower_limit);
 }
 
-thread_local uint32_t squash_stats_latency_lower_limit_cached =
-    absl::GetFlag(FLAGS_squash_stats_latency_lower_limit);
-
-void SetMaxBusySquashUsec(uint32_t val) {
-  shard_set->pool()->AwaitBrief(
-      [=](unsigned, auto*) { MultiCommandSquasher::SetMaxBusySquashUsec(val); });
-}
-
-void SetLogSquashInfoThreshold(uint32_t val) {
-  shard_set->pool()->AwaitBrief(
-      [=](unsigned, auto*) { MultiCommandSquasher::SetLogSquashThreshold(val); });
+std::vector<std::string> GetMutableFlagNames() {
+  return facade::GetFlagNames(FLAGS_shard_thread_busy_polling_usec,
+                              FLAGS_squash_stats_latency_lower_limit);
 }
 
 void SetShardThreadBusyPollingUsec(uint32_t val) {
@@ -759,29 +736,17 @@ void SetShardThreadBusyPollingUsec(uint32_t val) {
   });
 }
 
-void SetUringWakeMode(uint32_t mode) {
+void UpdateUringFlagsOnThread() {
 #ifdef __linux__
-  shard_set->pool()->AwaitBrief([mode](unsigned, fb2::ProactorBase* pb) {
-    if (pb->GetKind() == fb2::ProactorBase::IOURING) {
-      fb2::UringProactor* up = static_cast<fb2::UringProactor*>(pb);
-      bool use_msg_ring = mode > 0;
-      bool immediate_flush = mode == 2;
+  if (auto* pb = ProactorBase::me(); pb->GetKind() == fb2::ProactorBase::IOURING) {
+    fb2::UringProactor* up = static_cast<fb2::UringProactor*>(pb);
+    uint32_t mode = absl::GetFlag(FLAGS_uring_wake_mode);
+    uint32_t threshold = absl::GetFlag(FLAGS_uring_submit_threshold);
 
-      up->ConfigureMsgRing(use_msg_ring);
-      up->ConfigureSubmitWakeup(immediate_flush);
-    }
-  });
-#endif
-}
-
-void SetUringSubmitThreshold(uint32_t val) {
-#ifdef __linux__
-  shard_set->pool()->AwaitBrief([val](unsigned, fb2::ProactorBase* pb) {
-    if (pb->GetKind() == fb2::ProactorBase::IOURING) {
-      fb2::UringProactor* up = static_cast<fb2::UringProactor*>(pb);
-      up->SetSubmitQueueThreshold(val);
-    }
-  });
+    up->ConfigureMsgRing(mode > 0);
+    up->ConfigureSubmitWakeup(mode == 2);
+    up->SetSubmitQueueThreshold(threshold);
+  }
 #endif
 }
 
@@ -871,14 +836,19 @@ Service::~Service() {
   shard_set = nullptr;
 }
 
+void RegisterMutableFlags(ConfigRegistry* reg, absl::Span<const std::string> names,
+                          std::function<void()> f) {
+  auto cb = [f](auto&&) {
+    shard_set->pool()->AwaitBrief([f](unsigned tid, auto*) { f(); });
+    return true;
+  };
+  for (std::string_view name : names)
+    reg->RegisterMutable(name, cb);
+}
+
 void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> listeners) {
   InitRedisTables();
   facade::Connection::Init(pp_.size());
-
-  config_registry.RegisterSetter<MemoryBytesFlag>("maxmemory", [](const MemoryBytesFlag& flag) {
-    // TODO: reduce code reliance on constant direct access of max_memory_limit
-    max_memory_limit.store(flag.value, memory_order_relaxed);
-  });
 
   config_registry.RegisterMutable("dbfilename");
   config_registry.Register("dbnum");  // equivalent to databases in redis.
@@ -888,60 +858,36 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
   config_registry.RegisterMutable("masteruser");
   config_registry.RegisterMutable("max_eviction_per_heartbeat");
   config_registry.RegisterMutable("max_segment_to_consider");
-
-  config_registry.RegisterSetter<double>("rss_oom_deny_ratio",
-                                         UpdateServerState(&ServerState::rss_oom_deny_ratio));
-  config_registry.RegisterSetter<size_t>(
-      "serialization_max_chunk_size",
-      UpdateServerState(&ServerState::serialization_max_chunk_size));
-
   config_registry.RegisterMutable("pipeline_squash");
   config_registry.RegisterMutable("lua_mem_gc_threshold");
 
-  config_registry.RegisterSetter<uint32_t>("pipeline_queue_limit", [](uint32_t val) {
-    shard_set->pool()->AwaitBrief(
-        [val](unsigned tid, auto*) { facade::Connection::SetMaxQueueLenThreadLocal(tid, val); });
+  // Register ServerState flags
+  RegisterMutableFlags(&config_registry, ServerState::GetMutableFlagNames(),
+                       []() { ServerState::tlocal()->UpdateFromFlags(); });
+  // Register Connection flags
+  RegisterMutableFlags(&config_registry, facade::Connection::GetMutableFlagNames(),
+                       []() { facade::Connection::UpdateFromFlags(); });
+  // Register tiered storage flags
+  RegisterMutableFlags(&config_registry, TieredStorage::GetMutableFlagNames(), []() {
+    if (auto* es = EngineShard::tlocal(); es && es->tiered_storage()) {
+      es->tiered_storage()->UpdateFromFlags();
+    }
   });
+  // Register main service flags
+  RegisterMutableFlags(&config_registry, GetMutableFlagNames(),
+                       []() { UpdateFromFlagsOnThread(); });
+  // Register squsher flags
+  RegisterMutableFlags(&config_registry, MultiCommandSquasher::GetMutableFlagNames(),
+                       []() { MultiCommandSquasher::UpdateFromFlags(); });
+  // Register uring proactor flags
+  RegisterMutableFlags(&config_registry,
+                       facade::GetFlagNames(FLAGS_uring_wake_mode, FLAGS_uring_submit_threshold),
+                       []() { UpdateUringFlagsOnThread(); });
 
-  config_registry.RegisterSetter<facade::MemoryBytesFlag>(
-      "pipeline_buffer_limit", [](facade::MemoryBytesFlag val) {
-        shard_set->pool()->AwaitBrief(
-            [val](unsigned tid, auto*) { facade::Connection::SetPipelineBufferLimit(tid, val); });
-      });
-
-  config_registry.RegisterSetter<uint32_t>("max_busy_read_usec", [](uint32_t usec) {
-    shard_set->pool()->AwaitBrief(
-        [=](unsigned, auto*) { facade::Connection::SetMaxBusyReadUsecThreadLocal(usec); });
+  config_registry.RegisterSetter<MemoryBytesFlag>("maxmemory", [](const MemoryBytesFlag& flag) {
+    // TODO: reduce code reliance on constant direct access of max_memory_limit
+    max_memory_limit.store(flag.value, memory_order_relaxed);
   });
-
-  config_registry.RegisterSetter<bool>("always_flush_pipeline", [](bool val) {
-    shard_set->pool()->AwaitBrief(
-        [=](unsigned, auto*) { facade::Connection::SetAlwaysFlushPipelineThreadLocal(val); });
-  });
-
-  config_registry.RegisterSetter<unsigned>("pipeline_squash_limit", [](unsigned val) {
-    shard_set->pool()->AwaitBrief(
-        [=](unsigned, auto*) { facade::Connection::SetPipelineSquashLimitThreadLocal(val); });
-  });
-
-  config_registry.RegisterSetter<uint32_t>("pipeline_wait_batch_usec", [](uint32_t val) {
-    shard_set->pool()->AwaitBrief(
-        [=](unsigned, auto*) { facade::Connection::SetPipelineWaitBatchUsecThreadLocal(val); });
-  });
-
-  config_registry.RegisterSetter<uint32_t>("squash_stats_latency_lower_limit", [](uint32_t val) {
-    shard_set->pool()->AwaitBrief(
-        [=](unsigned, auto*) { squash_stats_latency_lower_limit_cached = val; });
-  });
-
-  config_registry.RegisterSetter<uint32_t>("max_squashed_cmd_num",
-                                           UpdateServerState(&ServerState::max_squash_cmd_num));
-  config_registry.RegisterSetter<uint32_t>("max_busy_squash_usec",
-                                           [](uint32_t val) { SetMaxBusySquashUsec(val); });
-  config_registry.RegisterSetter<uint32_t>(
-      "shard_thread_busy_polling_usec", [](uint32_t val) { SetShardThreadBusyPollingUsec(val); });
-  config_registry.RegisterSetter<uint32_t>("log_squash_info_threshold_usec",
-                                           [](uint32_t val) { SetLogSquashInfoThreshold(val); });
 
   config_registry.RegisterMutable("replica_partial_sync");
   config_registry.RegisterMutable("replication_timeout");
@@ -951,8 +897,6 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
   config_registry.RegisterMutable("timeout");
   config_registry.RegisterMutable("send_timeout");
   config_registry.RegisterMutable("managed_service_info");
-
-  RegisterTieringFlags();
 
   config_registry.RegisterMutable(
       "notify_keyspace_events", [pool = &pp_](const absl::CommandLineFlag& flag) {
@@ -978,11 +922,6 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
     shard_set->pool()->AwaitFiberOnAll(
         [val](auto index, auto* context) { ServerState::tlocal()->acl_log.SetTotalEntries(val); });
   });
-
-  config_registry.RegisterSetter<uint32_t>("uring_wake_mode",
-                                           [](uint32_t val) { SetUringWakeMode(val); });
-  config_registry.RegisterSetter<uint32_t>("uring_submit_threshold",
-                                           [](uint32_t val) { SetUringSubmitThreshold(val); });
 
   uint32_t shard_num = GetFlag(FLAGS_num_shards);
   if (shard_num == 0 || shard_num > pp_.size()) {
@@ -1021,16 +960,11 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
       [&](uint32_t index, ProactorBase* pb) { sharding::InitThreadLocals(shard_set->size()); });
   Transaction::Init(shard_num);
 
-  UpdateServerState (&ServerState::rss_oom_deny_ratio)(absl::GetFlag(FLAGS_rss_oom_deny_ratio));
-  UpdateServerState (&ServerState::serialization_max_chunk_size)(
-      absl::GetFlag(FLAGS_serialization_max_chunk_size));
-  UpdateServerState (&ServerState::max_squash_cmd_num)(absl::GetFlag(FLAGS_max_squashed_cmd_num));
-  SetHuffmanTable(absl::GetFlag(FLAGS_huffman_table));
-  SetMaxBusySquashUsec(absl::GetFlag(FLAGS_max_busy_squash_usec));
+  shard_set->pool()->AwaitBrief([](unsigned, auto*) {
+    UpdateFromFlagsOnThread();
+    UpdateUringFlagsOnThread();
+  });
   SetHuffmanTable(GetFlag(FLAGS_huffman_table));
-  SetShardThreadBusyPollingUsec(GetFlag(FLAGS_shard_thread_busy_polling_usec));
-  SetUringWakeMode(GetFlag(FLAGS_uring_wake_mode));
-  SetLogSquashInfoThreshold(GetFlag(FLAGS_log_squash_info_threshold_usec));
 
   // Requires that shard_set will be initialized before because server_family_.Init might
   // load the snapshot.

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -725,17 +725,6 @@ std::vector<std::string> GetMutableFlagNames() {
                               FLAGS_squash_stats_latency_lower_limit);
 }
 
-void SetShardThreadBusyPollingUsec(uint32_t val) {
-  if (val == 0)
-    return;
-
-  shard_set->pool()->AwaitBrief([=](unsigned, auto* pb) {
-    if (EngineShard::tlocal()) {
-      pb->SetBusyPollUsec(val);
-    }
-  });
-}
-
 void UpdateUringFlagsOnThread() {
 #ifdef __linux__
   if (auto* pb = ProactorBase::me(); pb->GetKind() == fb2::ProactorBase::IOURING) {

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -356,8 +356,8 @@ bool MultiCommandSquasher::ExecuteSquashed(facade::RedisReplyBuilder* rb) {
         << "Squashed " << order_.size() << " commands. "
         << "Total/Fanout/MaxSchedTime/ThreadCbTime/ThreadId/FiberCbTime/FiberSeq/MaxExecTime: "
         << total_usec << "/" << num_shards_ << "/" << max_sched_usec << "/" << proactor_running_usec
-        << "/" << max_sched_thread_id << "/" << fiber_running_usec << "/" << "/"
-        << max_sched_seq_num << "/" << max_exec_usec
+        << "/" << max_sched_thread_id << "/" << fiber_running_usec << "/"
+        << "/" << max_sched_seq_num << "/" << max_exec_usec
         << "\n past fibers: " << absl::StrJoin(past_fibers, ", ")
         << "\ncoordinator thread running time: "
         << CycleClock::ToUsec(ProactorBase::me()->GetCurrentBusyCycles());

--- a/src/server/multi_command_squasher.h
+++ b/src/server/multi_command_squasher.h
@@ -45,8 +45,8 @@ class MultiCommandSquasher {
     return sq.stats_;
   }
 
-  static void SetMaxBusySquashUsec(uint32_t usec);
-  static void SetLogSquashThreshold(uint32_t usec);
+  static void UpdateFromFlags();
+  static std::vector<std::string> GetMutableFlagNames();
 
  private:
   // Per-shard execution info.

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -310,6 +310,10 @@ class ServerState {  // public struct - to allow initialization.
   };
   void DecommitMemory(uint8_t flags);
 
+  void UpdateFromFlags();  // Update configration from vlags
+  static std::vector<std::string>
+  GetMutableFlagNames();  // Expects to trigger UpdateFromFlags on change
+
   // Exec descriptor frequency count for this thread.
   absl::flat_hash_map<std::string, unsigned> exec_freq_count;
   double rss_oom_deny_ratio;

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -310,9 +310,8 @@ class ServerState {  // public struct - to allow initialization.
   };
   void DecommitMemory(uint8_t flags);
 
-  void UpdateFromFlags();  // Update configration from vlags
-  static std::vector<std::string>
-  GetMutableFlagNames();  // Expects to trigger UpdateFromFlags on change
+  void UpdateFromFlags();                                 // Update configration from flags
+  static std::vector<std::string> GetMutableFlagNames();  // Dependencies of UpdateFromFlags
 
   // Exec descriptor frequency count for this thread.
   absl::flat_hash_map<std::string, unsigned> exec_freq_count;

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -16,6 +16,7 @@
 #include "absl/flags/internal/flag.h"
 #include "base/flags.h"
 #include "base/logging.h"
+#include "facade/flag_utils.h"
 #include "server/common.h"
 #include "server/db_slice.h"
 #include "server/engine_shard_set.h"
@@ -471,6 +472,11 @@ void TieredStorage::UpdateFromFlags() {
       .offload_threshold = absl::GetFlag(FLAGS_tiered_offload_threshold),
       .upload_threshold = absl::GetFlag(FLAGS_tiered_upload_threshold),
   };
+}
+
+std::vector<std::string> TieredStorage::GetMutableFlagNames() {
+  return facade::GetFlagNames(FLAGS_tiered_experimental_cooling, FLAGS_tiered_storage_write_depth,
+                              FLAGS_tiered_offload_threshold, FLAGS_tiered_upload_threshold);
 }
 
 bool TieredStorage::ShouldOffload() const {

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -6,6 +6,7 @@
 #include <boost/intrusive/list.hpp>
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "server/common.h"
 #include "server/table.h"
@@ -81,7 +82,9 @@ class TieredStorage {
 
   TieredStats GetStats() const;
 
-  void UpdateFromFlags();         // Update internal values based on current flag values
+  void UpdateFromFlags();  // Update internal values based on current flag values
+  static std::vector<std::string> GetMutableFlagNames();  // Triggers UpdateFromFlags
+
   bool ShouldOffload() const;     // True if below tiered_offload_threshold
   float WriteDepthUsage() const;  // Ratio (0-1) of used storage_write_depth for stashes
 

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -210,6 +210,10 @@ class TieredStorage {
   void UpdateFromFlags() {
   }
 
+  static std::vector<std::string> GetMutableFlagNames() {
+    return {};
+  }
+
   bool ShouldOffload() const {
     return false;
   }


### PR DESCRIPTION
Before I add a few scheduler flags, I'd like to avoid creating a million setters

The idea is that by providing two functions, `UpdateFromFlags` and `GetMutableFlagValues`, we can let the registry know that it has to call the former whenever a flag from the latter changes. This way each class cleanly keeps its flags in it's own codebase and mutability can be enabled in a single line