### PR TITLE
fix(json_family): Remove expiry of existing keys in JSON.SET

### DIFF
--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -505,6 +505,8 @@ OpStatus SetFullJson(const OpArgs& op_args, string_view key, string_view json_st
     return OpStatus::INVALID_JSON;
   }
 
+  op_args.GetDbSlice().RemoveExpire(op_args.db_cntx.db_index, it_res->it);
+
   if (JsonEnconding() == kEncodingJsonFlat) {
     flexbuffers::Builder fbb;
     json::FromJsonType(*parsed_json, &fbb);

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -3227,13 +3227,15 @@ TEST_F(JsonFamilyTest, JsonKeysWithDots) {
 }
 
 TEST_F(JsonFamilyTest, JsonSetDeleteExpiryOfExistingKey) {
-  auto resp = Run({"SET", "key", "foo", "EX", "1000"});
+  auto resp = Run("SET key foo EX 1000");
   ASSERT_THAT(resp, "OK");
-  resp = Run({"JSON.SET", "key", "$", "{}"});
+  resp = Run("JSON.SET key $ {}");
   ASSERT_THAT(resp, "OK");
-  resp = Run({"EXPIRE", "key", "100"});
+  resp = Run("TTL key");
+  ASSERT_THAT(resp, IntArg(-1));
+  resp = Run("EXPIRE key 100");
   ASSERT_THAT(resp, IntArg(1));
-  resp = Run({"TTL", "key"});
+  resp = Run("TTL key");
   EXPECT_THAT(resp.GetInt(), 100);
 }
 

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -3226,4 +3226,15 @@ TEST_F(JsonFamilyTest, JsonKeysWithDots) {
   EXPECT_THAT(resp, "[\"some_value\"]");
 }
 
+TEST_F(JsonFamilyTest, JsonSetDeleteExpiryOfExistingKey) {
+  auto resp = Run({"SET", "key", "foo", "EX", "1000"});
+  ASSERT_THAT(resp, "OK");
+  resp = Run({"JSON.SET", "key", "$", "{}"});
+  ASSERT_THAT(resp, "OK");
+  resp = Run({"EXPIRE", "key", "100"});
+  ASSERT_THAT(resp, IntArg(1));
+  resp = Run({"TTL", "key"});
+  EXPECT_THAT(resp.GetInt(), 100);
+}
+
 }  // namespace dfly


### PR DESCRIPTION
If key exists and it has expiry after we use JSON.SET expiry object will not be removed. Now when creating JSON object with same name remove previous expiry object if it exists.

Fixes #5653

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->