### PR TITLE
fix: prevent writeBucket if migration is canceled

### DIFF
--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -142,7 +142,7 @@ void OutgoingMigration::OnAllShards(
   });
 }
 
-void OutgoingMigration::Finish(GenericError error) {
+void OutgoingMigration::Finish(const GenericError& error) {
   auto next_state = MigrationState::C_FINISHED;
   if (error) {
     // If OOM error move to FATAL, non-recoverable  state
@@ -150,7 +150,7 @@ void OutgoingMigration::Finish(GenericError error) {
       next_state = MigrationState::C_FATAL;
     } else {
       next_state = MigrationState::C_ERROR;
-      exec_st_.ReportError(std::move(error));
+      exec_st_.ReportError(error);
     }
     LOG(WARNING) << "Finish outgoing migration for " << cf_->MyID() << ": "
                  << migration_info_.node_info.id << " with error: " << error.Format();

--- a/src/server/cluster/outgoing_slot_migration.h
+++ b/src/server/cluster/outgoing_slot_migration.h
@@ -30,7 +30,7 @@ class OutgoingMigration : private ProtocolClient {
   // if is_error = false mark migration as FINISHED and cancel migration if it's not finished yet
   // can be called from any thread, but only after Start()
   // if is_error = true and migration is in progress it will be restarted otherwise nothing happens
-  void Finish(GenericError error = {}) ABSL_LOCKS_EXCLUDED(state_mu_);
+  void Finish(const GenericError& error = {}) ABSL_LOCKS_EXCLUDED(state_mu_);
 
   MigrationState GetState() const ABSL_LOCKS_EXCLUDED(state_mu_);
 


### PR DESCRIPTION
fixes: https://github.com/dragonflydb/dragonfly/issues/5675

problem: we try to write a bucket after a migration is canceled

fix: added checks to prevent bucket writing if migration is canceled