### PR TITLE
feat: Implement GEORADIUS_RO command

### DIFF
--- a/src/server/geo_family.h
+++ b/src/server/geo_family.h
@@ -22,7 +22,9 @@ class GeoFamily {
   static void GeoDist(CmdArgList args, const CommandContext& cmd_cntx);
   static void GeoSearch(CmdArgList args, const CommandContext& cmd_cntx);
   static void GeoRadiusByMember(CmdArgList args, const CommandContext& cmd_cntx);
+  static void GeoRadiusGeneric(CmdArgList args, const CommandContext& cmd_cntx, bool read_only);
   static void GeoRadius(CmdArgList args, const CommandContext& cmd_cntx);
+  static void GeoRadiusRO(CmdArgList args, const CommandContext& cmd_cntx);
 };
 
 }  // namespace dfly

--- a/src/server/geo_family_test.cc
+++ b/src/server/geo_family_test.cc
@@ -293,6 +293,25 @@ TEST_F(GeoFamilyTest, GeoRadius) {
   EXPECT_THAT(resp, ErrArg("syntax error"));
 }
 
+TEST_F(GeoFamilyTest, GeoRadiusRO) {
+  // functionality for main GEORADIUS is already tested in the above function ensure that invalid
+  // arguments are not accepted
+  EXPECT_EQ(10, CheckedInt({"geoadd",  "Europe",    "13.4050", "52.5200", "Berlin",   "3.7038",
+                            "40.4168", "Madrid",    "9.1427",  "38.7369", "Lisbon",   "2.3522",
+                            "48.8566", "Paris",     "16.3738", "48.2082", "Vienna",   "4.8952",
+                            "52.3702", "Amsterdam", "10.7522", "59.9139", "Oslo",     "23.7275",
+                            "37.9838", "Athens",    "19.0402", "47.4979", "Budapest", "6.2603",
+                            "53.3498", "Dublin"}));
+
+  // GEORADIUS_RO should not accept arguments for storing (writing data)
+  auto resp =
+      Run({"GEORADIUS_RO", "Europe", "13.4050", "52.5200", "900", "KM", "STORE_DIST", "store_key"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
+
+  resp = Run({"GEORADIUS_RO", "Europe", "13.4050", "52.5200", "900", "KM", "STORE", "store_key"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
+}
+
 TEST_F(GeoFamilyTest, GeoRadiusByMemberUb) {
   Run({"GEOADD", "geo", "-118.2437", "34.0522", "972"});
   Run({"GEOADD", "geo", "-73.935242", "40.730610", "973"});

--- a/src/server/geo_family_test.cc
+++ b/src/server/geo_family_test.cc
@@ -294,8 +294,6 @@ TEST_F(GeoFamilyTest, GeoRadius) {
 }
 
 TEST_F(GeoFamilyTest, GeoRadiusRO) {
-  // functionality for main GEORADIUS is already tested in the above function ensure that invalid
-  // arguments are not accepted
   EXPECT_EQ(10, CheckedInt({"geoadd",  "Europe",    "13.4050", "52.5200", "Berlin",   "3.7038",
                             "40.4168", "Madrid",    "9.1427",  "38.7369", "Lisbon",   "2.3522",
                             "48.8566", "Paris",     "16.3738", "48.2082", "Vienna",   "4.8952",
@@ -310,6 +308,16 @@ TEST_F(GeoFamilyTest, GeoRadiusRO) {
 
   resp = Run({"GEORADIUS_RO", "Europe", "13.4050", "52.5200", "900", "KM", "STORE", "store_key"});
   EXPECT_THAT(resp, ErrArg("syntax error"));
+
+  resp = Run({"GEORADIUS_RO", "Europe", "13.4050", "52.5200", "500", "KM", "COUNT", "3",
+              "WITHCOORD", "WITHDIST"});
+  EXPECT_THAT(
+      resp,
+      RespArray(ElementsAre(
+          RespArray(ElementsAre("Berlin", DoubleArg(0.00017343178521311378),
+                                RespArray(ElementsAre(DoubleArg(13.4050), DoubleArg(52.5200))))),
+          RespArray(ElementsAre("Dublin", DoubleArg(487.5619030644293),
+                                RespArray(ElementsAre(DoubleArg(6.2603), DoubleArg(53.3498))))))));
 }
 
 TEST_F(GeoFamilyTest, GeoRadiusByMemberUb) {


### PR DESCRIPTION
Implements the `GEORADIUS_RO` command which is a read-only variant of the existing `GEORADIUS` command. Resolves #3882.

Command documentation can be found [here](https://redis.io/docs/latest/commands/georadius_ro/).