### PR TITLE
fix: RdbSaver: destroy SliceSnapshot on its shard thread to fix flaky crash on ARM64 with --force_epoll

### DIFF
--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -1125,20 +1125,18 @@ void RdbSaver::Impl::CleanShardSnapshots() {
     return;
   }
 
-  // Destroy SliceSnapshot in the correct shard thread, as it registers itself in a thread-local set.
+  // Destroy SliceSnapshot in the correct shard thread, as it registers itself in a thread-local
+  // set.
   if (shard_snapshots_.size() == 1) {
     if (single_owner_sid_.has_value()) {
-      shard_set->Await(*single_owner_sid_, [this] {
-        shard_snapshots_[0].reset();
-      });
+      shard_set->Await(*single_owner_sid_, [this] { shard_snapshots_[0].reset(); });
     } else {
       // Fallback if owner is unknown: destroy inline.
       shard_snapshots_[0].reset();
     }
   } else {
-    shard_set->RunBlockingInParallel([&](EngineShard* es) {
-      shard_snapshots_[es->shard_id()].reset();
-    });
+    shard_set->RunBlockingInParallel(
+        [&](EngineShard* es) { shard_snapshots_[es->shard_id()].reset(); });
   }
 }
 

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -1127,11 +1127,7 @@ void RdbSaver::Impl::CleanShardSnapshots() {
     shard_snapshots_[sid].reset();
   };
 
-  if (shard_snapshots_.size() == 1) {
-    cb(0);
-  } else {
-    shard_set->RunBlockingInParallel([&](EngineShard* es) { cb(es->shard_id()); });
-  }
+  shard_set->RunBlockingInParallel([&](EngineShard* es) { cb(es->shard_id()); });
 }
 
 RdbSaver::Impl::~Impl() {


### PR DESCRIPTION
Fixes regression crash: https://github.com/dragonflydb/dragonfly/actions/runs/17025808197/job/48261017365
Follow up: https://github.com/dragonflydb/dragonfly/pull/5655 

The Python test snapshot_test.py::test_parallel_snapshot_race_condition uncovered an additional case. It occurs only in the arm64/epoll environment.

I could reproduce it only on a large number of executions:
```
pytest -q tests/dragonfly/snapshot_test.py::test_parallel_snapshot_race_condition --df=force_epoll --df=proactor_threads=2 --df=num_shards=1 --repeat 20 -vv
```

Root cause: for single-snapshot flows (shard_snapshots_.size() == 1), the snapshot was destroyed from the caller thread, violating shard thread-affinity. In some paths, it could also lead to an indexing mismatch.

Fix: 
- Track the owning shard id on snapshot start (single_owner_sid_).
- For single-snapshot flows, destroy SliceSnapshot on the correct shard via shard_set->Await(owner_sid, ...).
- For multi-snapshot flows, destroy per shard via RunBlockingInParallel, indexing by es->shard_id().
- This enforces the SliceSnapshot thread-affinity invariant instead of weakening the DCHECK.