### PR TITLE
fix: stack corruption in MultiCommandSquasher

### DIFF
--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -432,6 +432,7 @@ int StreamAppendItem(stream* s, CmdArgList fields, uint64_t now_ms, streamID* ad
     /* Get a reference to the tail node listpack. */
     lp = (uint8_t*)ri.data;
     lp_bytes = lpBytes(lp);
+    CHECK_GT(lp_bytes, 0U);
   }
   raxStop(&ri);
 


### PR DESCRIPTION
Fixes https://github.com/dragonflydb/dragonfly/issues/5690 #5695 #5694 #5689 #5688

The problem: we accessed the caller stack variables (max_exec_cycles) in MultiCommandSquasher::ExecuteSquashed.
The access was done after the call to `bc.Dec()`, which unblocks ExecuteSquashed.
As a result, the callback function that was still running could corrupt memory contents of some other variable
as ExecuteSquashed could exit by that time.

In addition, harden checks in stream_family.cc in StreamAppendItem.
Finally, we update helio which fixes https://github.com/dragonflydb/dragonfly/issues/5693

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->