### PR TITLE
feat: improve target node latency during migration

### DIFF
--- a/src/server/cluster/incoming_slot_migration.cc
+++ b/src/server/cluster/incoming_slot_migration.cc
@@ -19,9 +19,10 @@
 #include "util/fibers/synchronization.h"
 
 ABSL_DECLARE_FLAG(int, migration_finalization_timeout_ms);
-ABSL_FLAG(uint32_t, slot_migration_throttle_us, 20,
+ABSL_FLAG(uint32_t, slot_migration_throttle_us, 0,
           "Incoming migration throttle time in us, we throttle every 100us of migration commands "
-          "processing, 0 to disable");
+          "processing, 0 to disable. Recommended value is 20. Values more than 50 can "
+          "significantly reduce migration speed.");
 
 namespace dfly::cluster {
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -886,6 +886,7 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
   config_registry.RegisterMutable("replica_partial_sync");
   config_registry.RegisterMutable("replication_timeout");
   config_registry.RegisterMutable("migration_finalization_timeout_ms");
+  config_registry.RegisterMutable("slot_migration_throttle_us");
   config_registry.RegisterMutable("table_growth_margin");
   config_registry.RegisterMutable("tcp_keepalive");
   config_registry.RegisterMutable("timeout");


### PR DESCRIPTION
fixes: #5648

I've tested different options, and the current implementation allows me to see p99 < 400us on my PC during the whole migration process. migration speed decreased by 5-10%