### PR TITLE
feat(search_family): Improve sorting and limiting in index joins

### DIFF
--- a/src/server/search/index_join.h
+++ b/src/server/search/index_join.h
@@ -61,8 +61,15 @@ using JoinExpressionsVec = Vector<JoinExpression>;
    {"index1", {{"field1", "other_index", "field2"}, {"field3", "other_index", "field4"}}} */
 using IndexesJoinExpressions = absl::Span<const JoinExpressionsVec>;
 
+using KeyIndex = size_t;
+using KeyIndexes = Vector<KeyIndex>;
+
 /* Joins all indexes in indexes_map using join_expressions.
    Join algorithm is used is hash join. */
+Vector<Vector<Key>> JoinAllIndexes(
+    EntriesPerIndex indexes_entries, IndexesJoinExpressions joins,
+    absl::FunctionRef<void(std::vector<KeyIndexes>*)> aggregate_after_join);
+
 Vector<Vector<Key>> JoinAllIndexes(EntriesPerIndex indexes_entries, IndexesJoinExpressions joins);
 
 }  // namespace dfly::join


### PR DESCRIPTION
Improve sorting and limiting in index joins.

Right now we apply SORTBY and LIMIT only after both join stages have finished—i.e., we (1) perform the join, and then (2) load all requested fields for every joined entry. Because there can be a lot of joined entries, we end up loading many fields we’ll later discard when sorting/limiting.

The fix is to apply SORTBY and LIMIT immediately after the first stage—right after we build the join result, but before we load per-entry fields. That way we only fetch fields for the top offset + total candidates (or whatever budget we choose), which speeds up the request — especially when most entries would be dropped by the final sort/limit anyway.