### PR TITLE
fix: macos and linux build

### DIFF
--- a/src/external_libs.cmake
+++ b/src/external_libs.cmake
@@ -121,7 +121,6 @@ add_third_party(
   hdr_histogram
   GIT_REPOSITORY https://github.com/HdrHistogram/HdrHistogram_c/
   GIT_TAG 652d51bcc36744fd1a6debfeb1a8a5f58b14022c
-  GIT_SHALLOW 1
   CMAKE_PASS_FLAGS "-DHDR_LOG_REQUIRED=OFF -DHDR_HISTOGRAM_BUILD_PROGRAMS=OFF
                     -DHDR_HISTOGRAM_INSTALL_SHARED=OFF"
   LIB libhdr_histogram_static.a


### PR DESCRIPTION
Fixes: https://github.com/dragonflydb/dragonfly/actions/runs/17200686960/

Remove GIT_SHALLOW: shallow clones may miss the pinned commit SHA (when it’s not at the tip), causing checkout failures. A full clone reliably fetches that commit while preserving the exact pin; the only trade-off is a slightly larger download.