### PR TITLE
server: fix max emission limit in throttle command (cherry-pick to v1.33)

### DIFF
--- a/src/server/engine_shard_set.h
+++ b/src/server/engine_shard_set.h
@@ -170,6 +170,10 @@ inline uint64_t GetCurrentTimeMs() {
   return TEST_current_time_ms ? TEST_current_time_ms : absl::GetCurrentTimeNanos() / 1000000;
 }
 
+inline uint64_t GetCurrentTimeNs() {
+  return TEST_current_time_ms ? TEST_current_time_ms * 1000000 : absl::GetCurrentTimeNanos();
+}
+
 extern EngineShardSet* shard_set;
 
 }  // namespace dfly

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -52,6 +52,9 @@ using CI = CommandId;
 enum class ExpT { EX, PX, EXAT, PXAT };
 
 constexpr uint32_t kMaxStrLen = 1 << 28;
+constexpr uint64_t kSecondToMilliSecond = 1000;
+constexpr uint64_t kMilliSecondToNanoSecond = 1000000;
+constexpr uint64_t kSecondToNanoSecond = 1000000000;
 
 // Either immediately available value or tiering future + result
 template <typename T> using TResultOrT = variant<T, TieredStorage::TResult<T>>;
@@ -379,31 +382,35 @@ OpStatus OpMSet(const OpArgs& op_args, const ShardArgs& args) {
   return result;
 }
 
-// emission_interval_ms assumed to be positive
+bool IsValueWithinBounds(const int64_t value, const int64_t bound) {
+  if (bound >= 0) {
+    return value >= INT64_MIN + bound;
+  }
+
+  return value <= INT64_MAX + bound;
+}
+
+// emission_interval_ns assumed to be positive
 // limit is assumed to be positive
 OpResult<array<int64_t, 5>> OpThrottle(const OpArgs& op_args, const string_view key,
-                                       const int64_t limit, const int64_t emission_interval_ms,
+                                       const int64_t limit, const int64_t emission_interval_ns,
                                        const uint64_t quantity) {
   auto& db_slice = op_args.GetDbSlice();
 
-  if (emission_interval_ms > INT64_MAX / limit) {
-    return OpStatus::INVALID_INT;
-  }
-  const int64_t delay_variation_tolerance_ms = emission_interval_ms * limit;  // should be positive
+  // Total size of the bucket
+  const int64_t delay_variation_tolerance_ns = emission_interval_ns * limit;  // should be positive
 
   int64_t remaining = 0;
-  int64_t reset_after_ms = -1000;
-  int64_t retry_after_ms = -1000;
+  int64_t reset_after_ms = -kSecondToMilliSecond;
+  int64_t retry_after_ms = -kSecondToMilliSecond;
 
-  if (quantity != 0 && static_cast<uint64_t>(emission_interval_ms) > INT64_MAX / quantity) {
-    return OpStatus::INVALID_INT;
-  }
-  const int64_t increment_ms = emission_interval_ms * quantity;  // should be nonnegative
+  // Cost of this request
+  const int64_t increment_ns = emission_interval_ns * quantity;  // should be nonnegative
 
   auto res = db_slice.FindMutable(op_args.db_cntx, key);
-  const int64_t now_ms = op_args.db_cntx.time_now_ms;
+  const int64_t now_ns = GetCurrentTimeNs();
 
-  int64_t tat_ms = now_ms;
+  int64_t tat_ns = now_ns;
   if (IsValid(res.it)) {
     if (res.it->second.ObjType() != OBJ_STRING) {
       return OpStatus::WRONG_TYPE;
@@ -413,56 +420,68 @@ OpResult<array<int64_t, 5>> OpThrottle(const OpArgs& op_args, const string_view 
     if (!opt_prev) {
       return OpStatus::INVALID_VALUE;
     }
-    tat_ms = *opt_prev;
+    tat_ns = *opt_prev;
   }
 
-  int64_t new_tat_ms = max(tat_ms, now_ms);
-  if (new_tat_ms > INT64_MAX - increment_ms) {
+  int64_t new_tat_ns = max(tat_ns, now_ns);
+  if (new_tat_ns > INT64_MAX - increment_ns) {
     return OpStatus::INVALID_INT;
   }
-  new_tat_ms += increment_ms;
+  new_tat_ns += increment_ns;
 
-  if (new_tat_ms < INT64_MIN + delay_variation_tolerance_ms) {
+  if (new_tat_ns < INT64_MIN + delay_variation_tolerance_ns) {
     return OpStatus::INVALID_INT;
   }
-  const int64_t allow_at_ms = new_tat_ms - delay_variation_tolerance_ms;
 
-  if (allow_at_ms >= 0 ? now_ms < INT64_MIN + allow_at_ms : now_ms > INT64_MAX + allow_at_ms) {
+  // The cutoff point before which a request is rejected (throttled) and at or after which a request
+  // is accepted.
+  const int64_t allow_at_ns = new_tat_ns - delay_variation_tolerance_ns;
+
+  if (!IsValueWithinBounds(now_ns, allow_at_ns)) {
     return OpStatus::INVALID_INT;
   }
-  const int64_t diff_ms = now_ms - allow_at_ms;
 
-  const bool limited = diff_ms < 0;
-  int64_t ttl_ms;
+  const int64_t diff_ns = now_ns - allow_at_ns;
+
+  const bool limited = diff_ns < 0;
+  int64_t ttl_ns;
   if (limited) {
-    if (increment_ms <= delay_variation_tolerance_ms) {
-      if (diff_ms == INT64_MIN) {
+    if (increment_ns <= delay_variation_tolerance_ns) {
+      if (diff_ns == INT64_MIN) {
         return OpStatus::INVALID_INT;
       }
-      retry_after_ms = -diff_ms;
+      retry_after_ms = (-diff_ns + kMilliSecondToNanoSecond - 1) / kMilliSecondToNanoSecond;
     }
 
-    if (now_ms >= 0 ? tat_ms < INT64_MIN + now_ms : tat_ms > INT64_MAX + now_ms) {
+    if (now_ns >= 0 ? tat_ns < INT64_MIN + now_ns : tat_ns > INT64_MAX + now_ns) {
       return OpStatus::INVALID_INT;
     }
-    ttl_ms = tat_ms - now_ms;
+    ttl_ns = tat_ns - now_ns;
   } else {
-    if (now_ms >= 0 ? new_tat_ms < INT64_MIN + now_ms : new_tat_ms > INT64_MAX + now_ms) {
+    if (!IsValueWithinBounds(new_tat_ns, now_ns)) {
       return OpStatus::INVALID_INT;
     }
-    ttl_ms = new_tat_ms - now_ms;
+    ttl_ns = new_tat_ns - now_ns;
   }
 
-  if (ttl_ms < delay_variation_tolerance_ms - INT64_MAX) {
+  if (ttl_ns < delay_variation_tolerance_ns - INT64_MAX) {
     return OpStatus::INVALID_INT;
   }
-  const int64_t next_ms = delay_variation_tolerance_ms - ttl_ms;
-  if (next_ms > -emission_interval_ms) {
-    remaining = next_ms / emission_interval_ms;
+  const int64_t next_ns = delay_variation_tolerance_ns - ttl_ns;
+  if (next_ns > -emission_interval_ns) {
+    remaining = next_ns / emission_interval_ns;
   }
-  reset_after_ms = ttl_ms;
+  reset_after_ms = (ttl_ns + kMilliSecondToNanoSecond - 1) / kMilliSecondToNanoSecond;
 
   if (!limited) {
+    // Although most computation so far is in nanoseconds, we must store expiry as milliseconds.
+    // While this causes loss of precision, the value stored against the throttle key is still in
+    // the nanosecond units. When the key is loaded, that value will be read and used as tat_ns. The
+    // loss of precision will cause the throttle key to be expired a bit earlier than expected, so
+    // to make up, we round up its expiry by at most 1 millisecond. Extending the key life does not
+    // break behavior because the tat_ns value will be used to check for throttling.
+    const int64_t new_tat_ms =
+        (new_tat_ns + kMilliSecondToNanoSecond - 1) / kMilliSecondToNanoSecond;
     if (IsValid(res.it)) {
       if (IsValid(res.exp_it)) {
         res.exp_it->second = db_slice.FromAbsoluteTime(new_tat_ms);
@@ -470,10 +489,10 @@ OpResult<array<int64_t, 5>> OpThrottle(const OpArgs& op_args, const string_view 
         db_slice.AddExpire(op_args.db_cntx.db_index, res.it, new_tat_ms);
       }
 
-      res.it->second.SetInt(new_tat_ms);
+      res.it->second.SetInt(new_tat_ns);
     } else {
       CompactObj cobj;
-      cobj.SetInt(new_tat_ms);
+      cobj.SetInt(new_tat_ns);
 
       auto res = db_slice.AddNew(op_args.db_cntx, key, std::move(cobj), new_tat_ms);
       if (!res) {
@@ -1600,17 +1619,27 @@ void StringFamily::ClThrottle(CmdArgList args, const CommandContext& cmnd_cntx) 
   }
   const int64_t limit = max_burst + 1;
 
-  if (period > UINT64_MAX / 1000 || count == 0 || period * 1000 / count > INT64_MAX) {
+  if (period > UINT64_MAX / kSecondToNanoSecond || count == 0 ||
+      period * kSecondToNanoSecond / count > INT64_MAX) {
     return cmnd_cntx.rb->SendError(kInvalidIntErr);
   }
-  const int64_t emission_interval_ms = period * 1000 / count;
 
-  if (emission_interval_ms == 0) {
+  const int64_t emission_interval_ns = period * kSecondToNanoSecond / count;
+
+  if (emission_interval_ns == 0) {
     return cmnd_cntx.rb->SendError("zero rates are not supported");
   }
 
+  if (emission_interval_ns > INT64_MAX / limit) {
+    return cmnd_cntx.rb->SendError(kInvalidIntErr);
+  }
+
+  if (quantity != 0 && static_cast<uint64_t>(emission_interval_ns) > INT64_MAX / quantity) {
+    return cmnd_cntx.rb->SendError(kInvalidIntErr);
+  }
+
   auto cb = [&](Transaction* t, EngineShard* shard) -> OpResult<array<int64_t, 5>> {
-    return OpThrottle(t->GetOpArgs(shard), key, limit, emission_interval_ms, quantity);
+    return OpThrottle(t->GetOpArgs(shard), key, limit, emission_interval_ns, quantity);
   };
 
   Transaction* trans = cmnd_cntx.tx;

--- a/src/server/string_family_test.cc
+++ b/src/server/string_family_test.cc
@@ -798,6 +798,12 @@ TEST_F(StringFamilyTest, ClThrottle) {
   resp = Run({"cl.throttle", "bar", "10", "0", "1"});
   ASSERT_EQ(RespExpr::ERROR, resp.type);
   EXPECT_THAT(resp, ErrArg(kInvalidIntErr));
+
+  // emission interval = 2000 nanoseconds, cost = 2 units
+  resp = Run({"cl.throttle", "bar", max_burst, "500000", "1", "2"});
+  ASSERT_EQ(RespExpr::ARRAY, resp.type);
+  ASSERT_THAT(resp.GetVec(),
+              ElementsAre(IntArg(0), IntArg(limit), IntArg(limit - 2), IntArg(-1), IntArg(1)));
 }
 
 TEST_F(StringFamilyTest, SetMGetWithNilResp3) {


### PR DESCRIPTION
* server: Use nanoseconds to measure duration in throttle algorithm

Previously we used milliseconds to measure time units. However this causes issues when a sub-millisecond refill interval is required for the algorithm. To fix this we move here to nanosecond time units.

There are some issues which arise because of this, all of which are acceptable:

* We have to use the current time at the point of throttle function call as a representation of "now", instead of the start of transaction time.

* The retry after/reset after timestamps are still in ms during throttle calculation, so they lose some precision.

The former is acceptable, as although it will cause slightly more lenient throttling, the measure is at a sub-millisecond level. Similarly in case of the latter, it is hard to imagine a client which will suffer from a sub-millisecond precision loss of a coarse value like retry interval.

Cherry-pick 090728b3e6b577f0771da1c6fee5379397f43ea4 to v.133 for release