### PR TITLE
chore: update task queue fiber priority to high

### DIFF
--- a/src/core/task_queue.cc
+++ b/src/core/task_queue.cc
@@ -9,6 +9,8 @@
 #include "base/logging.h"
 
 using namespace std;
+using namespace util::fb2;
+
 namespace dfly {
 
 __thread unsigned TaskQueue::blocked_submitters_ = 0;
@@ -25,7 +27,8 @@ void TaskQueue::Start(std::string_view base_name) {
     CHECK(!fb.IsJoinable());
 
     string name = absl::StrCat(base_name, "/", i);
-    fb = util::fb2::Fiber(name, [this] { queue_.Run(); });
+    fb =
+        Fiber(Fiber::Opts{.priority = FiberPriority::HIGH, .name = name}, [this] { queue_.Run(); });
   }
 }
 


### PR DESCRIPTION
TaskQueue is used to process callbacks from the requests. The hypothesis is that increasing its priority, we will reduce P99 latency of tasks that are being starved by other fibers.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->