### PR TITLE
feat: Implement GEORADIUSBYMEMBER_RO command

### DIFF
--- a/src/server/geo_family.h
+++ b/src/server/geo_family.h
@@ -21,7 +21,10 @@ class GeoFamily {
   static void GeoPos(CmdArgList args, const CommandContext& cmd_cntx);
   static void GeoDist(CmdArgList args, const CommandContext& cmd_cntx);
   static void GeoSearch(CmdArgList args, const CommandContext& cmd_cntx);
+  static void GeoRadiusByMemberGeneric(CmdArgList args, const CommandContext& cmd_cntx,
+                                       bool read_only);
   static void GeoRadiusByMember(CmdArgList args, const CommandContext& cmd_cntx);
+  static void GeoRadiusByMemberRO(CmdArgList args, const CommandContext& cmd_cntx);
   static void GeoRadiusGeneric(CmdArgList args, const CommandContext& cmd_cntx, bool read_only);
   static void GeoRadius(CmdArgList args, const CommandContext& cmd_cntx);
   static void GeoRadiusRO(CmdArgList args, const CommandContext& cmd_cntx);

--- a/src/server/geo_family_test.cc
+++ b/src/server/geo_family_test.cc
@@ -242,6 +242,34 @@ TEST_F(GeoFamilyTest, GeoRadiusByMember) {
   EXPECT_THAT(resp, ErrArg(err));
 }
 
+TEST_F(GeoFamilyTest, GeoRadiusByMemberRO) {
+  EXPECT_EQ(10, CheckedInt({"geoadd",  "Europe",    "13.4050", "52.5200", "Berlin",   "3.7038",
+                            "40.4168", "Madrid",    "9.1427",  "38.7369", "Lisbon",   "2.3522",
+                            "48.8566", "Paris",     "16.3738", "48.2082", "Vienna",   "4.8952",
+                            "52.3702", "Amsterdam", "10.7522", "59.9139", "Oslo",     "23.7275",
+                            "37.9838", "Athens",    "19.0402", "47.4979", "Budapest", "6.2603",
+                            "53.3498", "Dublin"}));
+
+  auto resp =
+      Run({"GEORADIUSBYMEMBER_RO", "Europe", "Madrid", "700", "KM", "WITHCOORD", "WITHDIST"});
+  EXPECT_THAT(
+      resp,
+      RespArray(ElementsAre(
+          RespArray(ElementsAre(
+              "Madrid", "0", RespArray(ElementsAre("3.7038007378578186", "40.416799319406216")))),
+          RespArray(
+              ElementsAre("Lisbon", "502.20769462704084",
+                          RespArray(ElementsAre("9.142698347568512", "38.736900197448534")))))));
+
+  // GEORADIUSBYMEMBER_RO should not accept arguments for storing (writing data)
+  resp =
+      Run({"GEORADIUSBYMEMBER_RO", "Europe", "Madrid", "700", "KM", "STOREDIST", "store_dist_key"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
+
+  resp = Run({"GEORADIUSBYMEMBER_RO", "Europe", "Madrid", "700", "KM", "STORE", "store_key"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
+}
+
 TEST_F(GeoFamilyTest, GeoRadius) {
   EXPECT_EQ(10, CheckedInt({"geoadd",  "Europe",    "13.4050", "52.5200", "Berlin",   "3.7038",
                             "40.4168", "Madrid",    "9.1427",  "38.7369", "Lisbon",   "2.3522",


### PR DESCRIPTION
This PR implements the read-only variant of the existing `GEORADIUSBYMEMBER_RO` command. The command documentation can be found [here](https://redis.io/docs/latest/commands/georadiusbymember_ro/).

Resolves #3881.