### PR TITLE
fix(range_tree): Fix default range block size

### DIFF
--- a/src/core/search/range_tree.h
+++ b/src/core/search/range_tree.h
@@ -40,7 +40,7 @@ class RangeTree {
   using Map = absl::btree_map<Key, RangeBlock, std::less<Key>,
                               PMR_NS::polymorphic_allocator<std::pair<const Key, RangeBlock>>>;
 
-  static constexpr size_t kDefaultMaxRangeBlockSize = 7000;
+  static constexpr size_t kDefaultMaxRangeBlockSize = 500000;
   static constexpr size_t kBlockSize = 400;
 
   explicit RangeTree(PMR_NS::memory_resource* mr,


### PR DESCRIPTION
Fixes default max size for the range block.

When initializing the index, if this number is too small, it can lead to a large number of splits, resulting in very long execution. To prevent this, we can increase the block size.