### PR TITLE
fix: reject geosearch count 0

### DIFF
--- a/src/server/geo_family.cc
+++ b/src/server/geo_family.cc
@@ -679,6 +679,8 @@ void GeoFamily::GeoSearch(CmdArgList args, const CommandContext& cmd_cntx) {
     return builder->SendError(kByRadiusBoxErr);
   } else if (geo_ops.sorting == Sorting::kError) {
     return builder->SendError(kAscDescErr);
+  } else if (geo_ops.count == 0) {
+    return builder->SendError(kCountError);
   }
 
   geo_ops.count = (geo_ops.count == UINT64_MAX) ? 0 : geo_ops.count;

--- a/src/server/geo_family_test.cc
+++ b/src/server/geo_family_test.cc
@@ -240,6 +240,10 @@ TEST_F(GeoFamilyTest, GeoRadiusByMember) {
       "ERR STORE option in GEORADIUSBYMEMBER is not compatible with WITHDIST, WITHHASH and WITHCOORDS options"sv;
   resp = Run("GEORADIUSBYMEMBER Sicily Agrigento 100 km WITHHASH store tmp");
   EXPECT_THAT(resp, ErrArg(err));
+
+  resp = Run("GEOADD t 13.361389 38.115556 a 13.3619 38.1159 b 13.3608 38.1152 c");
+  resp = Run("GEOSEARCH t FROMLONLAT 13.361389 38.115556 BYRADIUS 1 KM COUNT 0");
+  EXPECT_THAT(resp, ErrArg("ERR COUNT must be > 0"));
 }
 
 TEST_F(GeoFamilyTest, GeoRadius) {


### PR DESCRIPTION
`COUNT 0` should be rejected.

Resolves #5731