### PR TITLE
chore: Strict bounds when adding uknown command for INFO ALL stats

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1805,8 +1805,11 @@ void Service::DispatchMC(const MemcacheParser::Command& cmd, std::string_view va
 }
 
 ErrorReply Service::ReportUnknownCmd(string_view cmd_name) {
+  constexpr uint8_t kMaxUknownCommands = 64;
+  constexpr uint8_t kMaxUknownCommandLength = 20;
+
   lock_guard lk(mu_);
-  if (unknown_cmds_.size() < 1024)
+  if (unknown_cmds_.size() <= kMaxUknownCommands && cmd_name.size() <= kMaxUknownCommandLength)
     unknown_cmds_[cmd_name]++;
 
   return ErrorReply{StrCat("unknown command `", cmd_name, "`"), "unknown_cmd"};


### PR DESCRIPTION
Currently we allow 1024 uknown command with max length of 4096 characters to be stored in temporary vector. Create more strict rule that allows only 64 entries with max length of 20 chars.

Closes #5732

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->