### PR TITLE
fix: jsonPath parser for int values

### DIFF
--- a/src/core/json/jsonpath_grammar.y
+++ b/src/core/json/jsonpath_grammar.y
@@ -25,10 +25,19 @@
 
 #include "src/core/json/lexer_impl.h"
 #include "src/core/json/driver.h"
+#include <absl/strings/numbers.h>
+#include "base/logging.h"
 
 #define yylex driver->lexer()->Lex
 
 using namespace std;
+
+static int unsafe_stoi(std::string_view s) {
+  int value;
+  bool success = absl::SimpleAtoi(s, &value);
+  DCHECK(success);
+  return value;
+}
 }
 
 %parse-param { Driver *driver  }
@@ -56,7 +65,7 @@ using namespace std;
 // Needed 0 at the end to satisfy bison 3.5.1
 %token YYEOF 0
 %token <std::string> UNQ_STR "unquoted string"
-%token <int>  INT "integer"
+%token <std::string> INT "integer"
 
 %nterm <std::string> identifier
 %nterm <PathSegment> bracket_index
@@ -84,23 +93,28 @@ relative_path: identifier { driver->AddIdentifier($1); } opt_relative_location
         | bracket_expr
 
 identifier: UNQ_STR
+        | INT
 
 bracket_expr: LBRACKET bracket_index RBRACKET { driver->AddSegment($2); } opt_relative_location
 
 bracket_index: single_quoted_string { $$ = PathSegment(SegmentType::IDENTIFIER, $1); }
               | double_quoted_string { $$ = PathSegment(SegmentType::IDENTIFIER, $1); }
               | WILDCARD { $$ = PathSegment{SegmentType::INDEX, IndexExpr::All()}; }
-              | INT { $$ = PathSegment(SegmentType::INDEX, IndexExpr($1, $1)); }
-              | INT COLON INT { $$ = PathSegment(SegmentType::INDEX, IndexExpr::HalfOpen($1, $3)); }
-              | INT COLON { $$ = PathSegment(SegmentType::INDEX, IndexExpr($1, INT_MAX)); }
-              | COLON INT { $$ = PathSegment(SegmentType::INDEX, IndexExpr::HalfOpen(0, $2)); }
+              | INT { int tmp_idx = unsafe_stoi($1);
+                      $$ = PathSegment(SegmentType::INDEX, IndexExpr(tmp_idx, tmp_idx)); }
+              | INT COLON INT { $$ = PathSegment(SegmentType::INDEX, IndexExpr::HalfOpen(
+                unsafe_stoi($1), unsafe_stoi($3))); }
+              | INT COLON { $$ = PathSegment(SegmentType::INDEX, IndexExpr(unsafe_stoi($1), INT_MAX)); }
+              | COLON INT { $$ = PathSegment(SegmentType::INDEX, IndexExpr::HalfOpen(0, unsafe_stoi($2))); }
 
 single_quoted_string: SINGLE_QUOTE quoted_content SINGLE_QUOTE { $$ = $2; }
 
 double_quoted_string: DOUBLE_QUOTE quoted_content DOUBLE_QUOTE { $$ = $2; }
 
 quoted_content: UNQ_STR { $$ = $1; }
+              | INT { $$ = $1; }
               | quoted_content DOT UNQ_STR { $$ = $1 + "." + $3; }
+              | quoted_content DOT INT { $$ = $1 + "." + $3; }
 
 function_expr: UNQ_STR { driver->AddFunction($1); } LPARENT ROOT relative_location RPARENT
 %%

--- a/src/core/json/jsonpath_lexer.lex
+++ b/src/core/json/jsonpath_lexer.lex
@@ -4,11 +4,6 @@
 }
 
 
-%{
-  #include <absl/strings/numbers.h>
-  #include "base/logging.h"
-%}
-
 %o bison-cc-namespace="dfly.json" bison-cc-parser="Parser"
 %o namespace="dfly.json"
 
@@ -53,11 +48,7 @@
 ")"         return Parser::make_RPARENT(loc());
 "'"         return Parser::make_SINGLE_QUOTE(loc());
 "\""        return Parser::make_DOUBLE_QUOTE(loc());
--?[0-9]{1,9}  {
-              int val;
-              CHECK(absl::SimpleAtoi(str(), &val));
-              return Parser::make_INT(val, loc());
-            }
+-?[0-9]{1,9} return Parser::make_INT(str(), loc());
 
 [\w_\-]+    return Parser::make_UNQ_STR(str(), loc());
 <<EOF>>     return Parser::make_YYEOF(loc());

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -3239,4 +3239,26 @@ TEST_F(JsonFamilyTest, JsonSetDeleteExpiryOfExistingKey) {
   EXPECT_THAT(resp.GetInt(), 100);
 }
 
+TEST_F(JsonFamilyTest, JsonIntPathTest) {
+  auto resp = Run(
+      R"(JSON.SET test:images $ {"images":[{"id":1,"sizes":{"1":"small.jpg","10":"medium.jpg","14":"large.jpg","8":"thumb.jpg"}}]})");
+  ASSERT_THAT(resp, "OK");
+  resp = Run(R"(JSON.GET test:images $.images[0].sizes.10)");
+  EXPECT_THAT(resp, "[\"medium.jpg\"]");
+  resp = Run(R"(JSON.GET test:images $.images[0].sizes["10"])");
+  EXPECT_THAT(resp, "[\"medium.jpg\"]");
+  resp = Run(R"(JSON.GET test:images $.images[0].sizes['10'])");
+  EXPECT_THAT(resp, "[\"medium.jpg\"]");
+  resp = Run(R"(JSON.GET test:images $.images[0]["sizes"]["10"])");
+  EXPECT_THAT(resp, "[\"medium.jpg\"]");
+  resp = Run(R"(JSON.GET test:images $.images[0].sizes.8)");
+  EXPECT_THAT(resp, "[\"thumb.jpg\"]");
+  resp = Run(R"(JSON.GET test:images $.images[0].sizes.14)");
+  EXPECT_THAT(resp, "[\"large.jpg\"]");
+  resp = Run(R"(JSON.GET test:images $.images[0].sizes["8"])");
+  EXPECT_THAT(resp, "[\"thumb.jpg\"]");
+  resp = Run(R"(JSON.GET test:images $.images[0].sizes["14"])");
+  EXPECT_THAT(resp, "[\"large.jpg\"]");
+}
+
 }  // namespace dfly


### PR DESCRIPTION
fixes: #5337
problem: We always treat INT value as an integer, but it can be an identifier or part of the expression
fix: consider INT as a string and convert it to int only if context is correct