### PR TITLE
server: Drop contents of `exec_info` body on clear

### DIFF
--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -307,7 +307,7 @@ vector<unsigned> ConnectionContext::ChangeSubscriptions(CmdArgList channels, boo
 void ConnectionState::ExecInfo::Clear() {
   DCHECK(!preborrowed_interpreter);  // Must have been released properly
   state = EXEC_INACTIVE;
-  body.clear();
+  vector<StoredCmd>{}.swap(body);
   is_write = false;
   ClearWatched();
 }


### PR DESCRIPTION
Previously when clearing the exec info state we held the capacity of the body vector.

In a couple of cases this vector has been seen to be large enough to cause very high memory usage where each context object holds around 1MiB of memory and adds up to multiple GiBs.

The vector is now cleared and the capacity is also dropped to 0.
