### PR TITLE
fix: JSON RESP3 compatibility - remove extra nested arrays for most commands

### DIFF
--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -9,6 +9,8 @@
 #include <absl/strings/str_join.h>
 #include <absl/strings/str_split.h>
 
+#include <type_traits>
+
 #include "absl/cleanup/cleanup.h"
 #include "base/flags.h"
 #include "base/logging.h"
@@ -312,38 +314,10 @@ template <typename T> void Send(const JsonCallbackResult<T>& result, RedisReplyB
     if (rb->IsResp3()) {
       rb->StartArray(arr.size());
       for (const auto& item : arr) {
-        Send(item, rb);
-      }
-    } else {
-      Send(arr.begin(), arr.end(), rb);
-    }
-  }
-}
-
-// Specialized template for JsonCallbackResult<std::string> (JSON.TYPE)
-// to preserve nested array behavior for Redis compatibility
-template <> void Send(const JsonCallbackResult<std::string>& result, RedisReplyBuilder* rb) {
-  if (result.ShouldSendNil())
-    return rb->SendNull();
-
-  if (result.ShouldSendWrongType())
-    return rb->SendError(OpStatus::WRONG_JSON_TYPE);
-
-  if (result.IsV1()) {
-    /* The specified path was restricted (JSON legacy mode), then the result consists only of a
-     * single value */
-    if (rb->IsResp3()) {
-      rb->StartArray(1);
-    }
-    Send(result.AsV1(), rb);
-  } else {
-    /* The specified path was enhanced (starts with '$'), then the result is an array of multiple
-     * values */
-    const auto& arr = result.AsV2();
-    if (rb->IsResp3()) {
-      rb->StartArray(arr.size());
-      for (const auto& item : arr) {
-        rb->StartArray(1);
+        // For JSON.TYPE (std::string), preserve nested array behavior for compatibility
+        if constexpr (std::is_same_v<T, std::string>) {
+          rb->StartArray(1);
+        }
         Send(item, rb);
       }
     } else {

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -3262,10 +3262,10 @@ TEST_F(JsonFamilyTest, JsonIntPathTest) {
 }
 
 TEST_F(JsonFamilyTest, ARRLEN_RESP3NestedArrayBug) {
-  auto resp = Run({"HELLO", "3"});
+  Run({"HELLO", "3"});
 
   string json = R"({"a":[1], "b":{"a":[1,2,3]}, "c":{"x":"not_a"}})";
-  resp = Run({"JSON.SET", "doc", ".", json});
+  auto resp = Run({"JSON.SET", "doc", ".", json});
   ASSERT_THAT(resp, "OK");
 
   // In RESP3 mode, this should return [1, 3] (direct integers)
@@ -3285,10 +3285,9 @@ TEST_F(JsonFamilyTest, ARRLEN_RESP3NestedArrayBug) {
 }
 
 TEST_F(JsonFamilyTest, ARRAPPEND_RESP3NestedArrayBug) {
-  auto resp = Run({"HELLO", "3"});
-  (void)resp;
+  Run({"HELLO", "3"});
 
-  resp = Run({"JSON.SET", "doc", ".", R"({"a":[1], "b":{"a":[1,2,3]}})"});
+  auto resp = Run({"JSON.SET", "doc", ".", R"({"a":[1], "b":{"a":[1,2,3]}})"});
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.ARRAPPEND", "doc", "$..a", "2"});
@@ -3301,10 +3300,9 @@ TEST_F(JsonFamilyTest, ARRAPPEND_RESP3NestedArrayBug) {
 }
 
 TEST_F(JsonFamilyTest, ARRINDEX_RESP3NestedArrayBug) {
-  auto resp = Run({"HELLO", "3"});
-  (void)resp;
+  Run({"HELLO", "3"});
 
-  resp = Run({"JSON.SET", "doc", ".", R"({"a":["x","y"], "b":{"a":["y","z"]}})"});
+  auto resp = Run({"JSON.SET", "doc", ".", R"({"a":["x","y"], "b":{"a":["y","z"]}})"});
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.ARRINDEX", "doc", "$..a", R"("y")"});
@@ -3317,10 +3315,9 @@ TEST_F(JsonFamilyTest, ARRINDEX_RESP3NestedArrayBug) {
 }
 
 TEST_F(JsonFamilyTest, ARRPOP_RESP3NestedArrayBug) {
-  auto resp = Run({"HELLO", "3"});
-  (void)resp;
+  Run({"HELLO", "3"});
 
-  resp = Run({"JSON.SET", "doc", ".", R"({"a":[7], "b":{"a":[8]}})"});
+  auto resp = Run({"JSON.SET", "doc", ".", R"({"a":[7], "b":{"a":[8]}})"});
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.ARRPOP", "doc", "$..a"});
@@ -3331,10 +3328,9 @@ TEST_F(JsonFamilyTest, ARRPOP_RESP3NestedArrayBug) {
 }
 
 TEST_F(JsonFamilyTest, ARRTRIM_RESP3NestedArrayBug) {
-  auto resp = Run({"HELLO", "3"});
-  (void)resp;
+  Run({"HELLO", "3"});
 
-  resp = Run({"JSON.SET", "doc", ".", R"({"a":[1,2], "b":{"a":[3,4,5]}})"});
+  auto resp = Run({"JSON.SET", "doc", ".", R"({"a":[1,2], "b":{"a":[3,4,5]}})"});
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.ARRTRIM", "doc", "$..a", "0", "0"});
@@ -3347,10 +3343,9 @@ TEST_F(JsonFamilyTest, ARRTRIM_RESP3NestedArrayBug) {
 }
 
 TEST_F(JsonFamilyTest, STRLEN_RESP3NestedArrayBug) {
-  auto resp = Run({"HELLO", "3"});
-  (void)resp;
+  Run({"HELLO", "3"});
 
-  resp = Run({"JSON.SET", "doc", ".", R"({"s":"hi", "b":{"s":"abc"}})"});
+  auto resp = Run({"JSON.SET", "doc", ".", R"({"s":"hi", "b":{"s":"abc"}})"});
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.STRLEN", "doc", "$..s"});
@@ -3363,10 +3358,9 @@ TEST_F(JsonFamilyTest, STRLEN_RESP3NestedArrayBug) {
 }
 
 TEST_F(JsonFamilyTest, OBJLEN_RESP3NestedArrayBug) {
-  auto resp = Run({"HELLO", "3"});
-  (void)resp;
+  Run({"HELLO", "3"});
 
-  resp = Run({"JSON.SET", "doc", ".", R"({"o":{"k":1}, "b":{"o":{"k":1,"m":2}}})"});
+  auto resp = Run({"JSON.SET", "doc", ".", R"({"o":{"k":1}, "b":{"o":{"k":1,"m":2}}})"});
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.OBJLEN", "doc", "$..o"});
@@ -3379,10 +3373,9 @@ TEST_F(JsonFamilyTest, OBJLEN_RESP3NestedArrayBug) {
 }
 
 TEST_F(JsonFamilyTest, OBJKEYS_RESP3NestedArrayBug) {
-  auto resp = Run({"HELLO", "3"});
-  (void)resp;
+  Run({"HELLO", "3"});
 
-  resp = Run({"JSON.SET", "doc", ".", R"({"o":{"k":1}, "b":{"o":{"k":1,"m":2}}})"});
+  auto resp = Run({"JSON.SET", "doc", ".", R"({"o":{"k":1}, "b":{"o":{"k":1,"m":2}}})"});
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.OBJKEYS", "doc", "$..o"});
@@ -3399,10 +3392,9 @@ TEST_F(JsonFamilyTest, OBJKEYS_RESP3NestedArrayBug) {
 }
 
 TEST_F(JsonFamilyTest, STRAPPEND_RESP3NestedArrayBug) {
-  auto resp = Run({"HELLO", "3"});
-  (void)resp;
+  Run({"HELLO", "3"});
 
-  resp = Run({"JSON.SET", "doc", ".", R"({"s":"a", "b":{"s":"zz"}})"});
+  auto resp = Run({"JSON.SET", "doc", ".", R"({"s":"a", "b":{"s":"zz"}})"});
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.STRAPPEND", "doc", "$..s", R"("b")"});
@@ -3415,10 +3407,9 @@ TEST_F(JsonFamilyTest, STRAPPEND_RESP3NestedArrayBug) {
 }
 
 TEST_F(JsonFamilyTest, TOGGLE_RESP3NestedArrayBug) {
-  auto resp = Run({"HELLO", "3"});
-  (void)resp;
+  Run({"HELLO", "3"});
 
-  resp = Run({"JSON.SET", "doc", ".", R"({"b":true, "x":{"b":false}})"});
+  auto resp = Run({"JSON.SET", "doc", ".", R"({"b":true, "x":{"b":false}})"});
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.TOGGLE", "doc", "$..b"});

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -3261,9 +3261,7 @@ TEST_F(JsonFamilyTest, JsonIntPathTest) {
   EXPECT_THAT(resp, "[\"large.jpg\"]");
 }
 
-TEST_F(JsonFamilyTest, RESP3NestedArrayBug) {
-  // Test case for GitHub issue #5741
-  // Switch to RESP3 mode first
+TEST_F(JsonFamilyTest, ARRLEN_RESP3NestedArrayBug) {
   auto resp = Run({"HELLO", "3"});
 
   string json = R"({"a":[1], "b":{"a":[1,2,3]}, "c":{"x":"not_a"}})";
@@ -3284,6 +3282,152 @@ TEST_F(JsonFamilyTest, RESP3NestedArrayBug) {
   // Verify the actual values
   EXPECT_THAT(resp.GetVec()[0], IntArg(1));
   EXPECT_THAT(resp.GetVec()[1], IntArg(3));
+}
+
+TEST_F(JsonFamilyTest, ARRAPPEND_RESP3NestedArrayBug) {
+  auto resp = Run({"HELLO", "3"});
+  (void)resp;
+
+  resp = Run({"JSON.SET", "doc", ".", R"({"a":[1], "b":{"a":[1,2,3]}})"});
+  ASSERT_THAT(resp, "OK");
+
+  resp = Run({"JSON.ARRAPPEND", "doc", "$..a", "2"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  ASSERT_EQ(resp.GetVec().size(), 2);
+  EXPECT_THAT(resp.GetVec()[0], Not(ArgType(RespExpr::ARRAY)));
+  EXPECT_THAT(resp.GetVec()[1], Not(ArgType(RespExpr::ARRAY)));
+  EXPECT_THAT(resp.GetVec()[0], IntArg(2));
+  EXPECT_THAT(resp.GetVec()[1], IntArg(4));
+}
+
+TEST_F(JsonFamilyTest, ARRINDEX_RESP3NestedArrayBug) {
+  auto resp = Run({"HELLO", "3"});
+  (void)resp;
+
+  resp = Run({"JSON.SET", "doc", ".", R"({"a":["x","y"], "b":{"a":["y","z"]}})"});
+  ASSERT_THAT(resp, "OK");
+
+  resp = Run({"JSON.ARRINDEX", "doc", "$..a", R"("y")"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  ASSERT_EQ(resp.GetVec().size(), 2);
+  EXPECT_THAT(resp.GetVec()[0], Not(ArgType(RespExpr::ARRAY)));
+  EXPECT_THAT(resp.GetVec()[1], Not(ArgType(RespExpr::ARRAY)));
+  EXPECT_THAT(resp.GetVec()[0], IntArg(1));
+  EXPECT_THAT(resp.GetVec()[1], IntArg(0));
+}
+
+TEST_F(JsonFamilyTest, ARRPOP_RESP3NestedArrayBug) {
+  auto resp = Run({"HELLO", "3"});
+  (void)resp;
+
+  resp = Run({"JSON.SET", "doc", ".", R"({"a":[7], "b":{"a":[8]}})"});
+  ASSERT_THAT(resp, "OK");
+
+  resp = Run({"JSON.ARRPOP", "doc", "$..a"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  ASSERT_EQ(resp.GetVec().size(), 2);
+  EXPECT_THAT(resp.GetVec()[0], Not(ArgType(RespExpr::ARRAY)));
+  EXPECT_THAT(resp.GetVec()[1], Not(ArgType(RespExpr::ARRAY)));
+}
+
+TEST_F(JsonFamilyTest, ARRTRIM_RESP3NestedArrayBug) {
+  auto resp = Run({"HELLO", "3"});
+  (void)resp;
+
+  resp = Run({"JSON.SET", "doc", ".", R"({"a":[1,2], "b":{"a":[3,4,5]}})"});
+  ASSERT_THAT(resp, "OK");
+
+  resp = Run({"JSON.ARRTRIM", "doc", "$..a", "0", "0"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  ASSERT_EQ(resp.GetVec().size(), 2);
+  EXPECT_THAT(resp.GetVec()[0], Not(ArgType(RespExpr::ARRAY)));
+  EXPECT_THAT(resp.GetVec()[1], Not(ArgType(RespExpr::ARRAY)));
+  EXPECT_THAT(resp.GetVec()[0], IntArg(1));
+  EXPECT_THAT(resp.GetVec()[1], IntArg(1));
+}
+
+TEST_F(JsonFamilyTest, STRLEN_RESP3NestedArrayBug) {
+  auto resp = Run({"HELLO", "3"});
+  (void)resp;
+
+  resp = Run({"JSON.SET", "doc", ".", R"({"s":"hi", "b":{"s":"abc"}})"});
+  ASSERT_THAT(resp, "OK");
+
+  resp = Run({"JSON.STRLEN", "doc", "$..s"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  ASSERT_EQ(resp.GetVec().size(), 2);
+  EXPECT_THAT(resp.GetVec()[0], Not(ArgType(RespExpr::ARRAY)));
+  EXPECT_THAT(resp.GetVec()[1], Not(ArgType(RespExpr::ARRAY)));
+  EXPECT_THAT(resp.GetVec()[0], IntArg(2));
+  EXPECT_THAT(resp.GetVec()[1], IntArg(3));
+}
+
+TEST_F(JsonFamilyTest, OBJLEN_RESP3NestedArrayBug) {
+  auto resp = Run({"HELLO", "3"});
+  (void)resp;
+
+  resp = Run({"JSON.SET", "doc", ".", R"({"o":{"k":1}, "b":{"o":{"k":1,"m":2}}})"});
+  ASSERT_THAT(resp, "OK");
+
+  resp = Run({"JSON.OBJLEN", "doc", "$..o"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  ASSERT_EQ(resp.GetVec().size(), 2);
+  EXPECT_THAT(resp.GetVec()[0], Not(ArgType(RespExpr::ARRAY)));
+  EXPECT_THAT(resp.GetVec()[1], Not(ArgType(RespExpr::ARRAY)));
+  EXPECT_THAT(resp.GetVec()[0], IntArg(1));
+  EXPECT_THAT(resp.GetVec()[1], IntArg(2));
+}
+
+TEST_F(JsonFamilyTest, OBJKEYS_RESP3NestedArrayBug) {
+  auto resp = Run({"HELLO", "3"});
+  (void)resp;
+
+  resp = Run({"JSON.SET", "doc", ".", R"({"o":{"k":1}, "b":{"o":{"k":1,"m":2}}})"});
+  ASSERT_THAT(resp, "OK");
+
+  resp = Run({"JSON.OBJKEYS", "doc", "$..o"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  ASSERT_EQ(resp.GetVec().size(), 2);
+  // Each element should be array of keys, not array wrapped again
+  auto& el0 = resp.GetVec()[0];
+  auto& el1 = resp.GetVec()[1];
+  ASSERT_THAT(el0, ArgType(RespExpr::ARRAY));
+  ASSERT_THAT(el1, ArgType(RespExpr::ARRAY));
+  EXPECT_THAT(el0.GetVec(), ElementsAre("k"));
+  // Order of keys in objects is not guaranteed, so check size only for the second
+  EXPECT_EQ(el1.GetVec().size(), 2);
+}
+
+TEST_F(JsonFamilyTest, STRAPPEND_RESP3NestedArrayBug) {
+  auto resp = Run({"HELLO", "3"});
+  (void)resp;
+
+  resp = Run({"JSON.SET", "doc", ".", R"({"s":"a", "b":{"s":"zz"}})"});
+  ASSERT_THAT(resp, "OK");
+
+  resp = Run({"JSON.STRAPPEND", "doc", "$..s", R"("b")"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  ASSERT_EQ(resp.GetVec().size(), 2);
+  EXPECT_THAT(resp.GetVec()[0], Not(ArgType(RespExpr::ARRAY)));
+  EXPECT_THAT(resp.GetVec()[1], Not(ArgType(RespExpr::ARRAY)));
+  EXPECT_THAT(resp.GetVec()[0], IntArg(2));
+  EXPECT_THAT(resp.GetVec()[1], IntArg(3));
+}
+
+TEST_F(JsonFamilyTest, TOGGLE_RESP3NestedArrayBug) {
+  auto resp = Run({"HELLO", "3"});
+  (void)resp;
+
+  resp = Run({"JSON.SET", "doc", ".", R"({"b":true, "x":{"b":false}})"});
+  ASSERT_THAT(resp, "OK");
+
+  resp = Run({"JSON.TOGGLE", "doc", "$..b"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  ASSERT_EQ(resp.GetVec().size(), 2);
+  EXPECT_THAT(resp.GetVec()[0], Not(ArgType(RespExpr::ARRAY)));
+  EXPECT_THAT(resp.GetVec()[1], Not(ArgType(RespExpr::ARRAY)));
+  EXPECT_THAT(resp.GetVec()[0], IntArg(0));
+  EXPECT_THAT(resp.GetVec()[1], IntArg(1));
 }
 
 }  // namespace dfly


### PR DESCRIPTION
Fixes: https://github.com/dragonflydb/dragonfly/issues/5741

Fixes JSON RESP3 compatibility issue where JSON commands returned extra nested arrays instead of the expected format.