### PR TITLE
server: Enable lua legacy float response for RESP3

### DIFF
--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -837,7 +837,7 @@ TEST_F(DflyEngineTest, Latency) {
 
 TEST_F(DflyEngineTest, EvalBug2664) {
   absl::FlagSaver fs;
-  absl::SetFlag(&FLAGS_lua_resp2_legacy_float, true);
+  SetFlag(&FLAGS_lua_resp2_legacy_float, true);
 
   auto resp = Run({"eval", "return 42.9", "0"});
   EXPECT_THAT(resp, IntArg(42));

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -848,7 +848,7 @@ TEST_F(DflyEngineTest, EvalBug2664) {
   ASSERT_THAT(resp, ArrLen(14));
 
   resp = Run({"eval", "return 42.9", "0"});
-  EXPECT_THAT(resp, DoubleArg(42.9));
+  EXPECT_THAT(resp, IntArg(42));
 }
 
 TEST_F(DflyEngineTest, MemoryUsage) {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -348,11 +348,12 @@ class EvalSerializer : public ObjectExplorer {
   }
 
   void OnDouble(double d) final {
-    if (rb_->IsResp3() || !GetFlag(FLAGS_lua_resp2_legacy_float)) {
-      rb_->SendDouble(d);
-    } else {
-      long val = d >= 0 ? static_cast<long>(floor(d)) : static_cast<long>(ceil(d));
+    thread_local const bool send_double_as_long = GetFlag(FLAGS_lua_resp2_legacy_float);
+    if (send_double_as_long) {
+      const long val = d >= 0 ? static_cast<long>(floor(d)) : static_cast<long>(ceil(d));
       rb_->SendLong(val);
+    } else {
+      rb_->SendDouble(d);
     }
   }
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -348,8 +348,7 @@ class EvalSerializer : public ObjectExplorer {
   }
 
   void OnDouble(double d) final {
-    thread_local const bool send_double_as_long = GetFlag(FLAGS_lua_resp2_legacy_float);
-    if (send_double_as_long) {
+    if (GetFlag(FLAGS_lua_resp2_legacy_float)) {
       const long val = d >= 0 ? static_cast<long>(floor(d)) : static_cast<long>(ceil(d));
       rb_->SendLong(val);
     } else {


### PR DESCRIPTION
Previously when the lua legacy float flag was set, doubles would be sent as floats for RESP2 but for RESP3 this behavior was skipped. This changeset extends the behavior to RESP3 as well.

fixes https://github.com/dragonflydb/dragonfly/issues/5745

Note: the previous behavior was not a bug, but the flag needs to be extended to RESP3 now in response to real world requirements where third party libraries such as `redis_rate` use a RESP3 client but expect long values in response.