### PR TITLE
test: unskip epoll cluster and replication tests

### DIFF
--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -1471,7 +1471,6 @@ async def test_migration_with_key_ttl(df_factory):
     assert await nodes[1].client.execute_command("stick k_sticky") == 0
 
 
-@pytest.mark.exclude_epoll
 @dfly_args({"proactor_threads": 4, "cluster_mode": "yes", "migration_finalization_timeout_ms": 5})
 async def test_network_disconnect_during_migration(df_factory):
     instances = [
@@ -2029,7 +2028,6 @@ async def test_snapshoting_during_migration(
     # We can try to use FakeRedis with the DebugPopulateSeeder comparison here.
 
 
-@pytest.mark.exclude_epoll
 @dfly_args({"proactor_threads": 4, "cluster_mode": "yes"})
 @pytest.mark.asyncio
 async def test_cluster_migration_cancel(df_factory: DflyInstanceFactory):
@@ -2095,7 +2093,6 @@ async def test_cluster_migration_cancel(df_factory: DflyInstanceFactory):
 @dfly_args({"proactor_threads": 2, "cluster_mode": "yes"})
 @pytest.mark.asyncio
 @pytest.mark.opt_only
-@pytest.mark.exclude_epoll
 async def test_cluster_migration_huge_container(df_factory: DflyInstanceFactory):
     instances = [
         df_factory.create(port=next(next_port), admin_port=next(next_port)) for i in range(2)
@@ -2157,7 +2154,6 @@ async def test_cluster_migration_huge_container(df_factory: DflyInstanceFactory)
 )
 @pytest.mark.parametrize("chunk_size", [1_000_000, 30])
 @pytest.mark.asyncio
-@pytest.mark.exclude_epoll
 async def test_cluster_migration_while_seeding(
     df_factory: DflyInstanceFactory, df_seeder_factory: DflySeederFactory, chunk_size
 ):
@@ -2305,7 +2301,6 @@ async def await_no_lag(client: aioredis.Redis, timeout=10):
     raise RuntimeError("Lag did not reduced to 0!")
 
 
-@pytest.mark.exclude_epoll
 @dfly_args({"proactor_threads": 4})
 async def test_replicate_cluster(df_factory: DflyInstanceFactory, df_seeder_factory):
     """
@@ -2515,7 +2510,6 @@ async def await_eq_offset(client: aioredis.Redis, timeout=20):
     raise RuntimeError("offset not equal!")
 
 
-@pytest.mark.exclude_epoll
 @dfly_args({"proactor_threads": 4})
 async def test_replicate_redis_cluster(redis_cluster, df_factory, df_seeder_factory):
     """
@@ -2721,7 +2715,6 @@ async def test_cluster_memory_consumption_migration(df_factory: DflyInstanceFact
     await check_for_no_state_status([node.admin_client for node in nodes])
 
 
-@pytest.mark.exclude_epoll
 @pytest.mark.asyncio
 @dfly_args({"proactor_threads": 4, "cluster_mode": "yes", "migration_buckets_cpu_budget": 1})
 async def test_migration_timeout_on_sync(df_factory: DflyInstanceFactory, df_seeder_factory):
@@ -2881,7 +2874,6 @@ For each migration we start migration, wait for it to finish and once it is fini
 
 
 @pytest.mark.slow
-@pytest.mark.exclude_epoll
 @pytest.mark.asyncio
 @dfly_args({"proactor_threads": 4, "cluster_mode": "yes", "pause_wait_timeout": 10})
 async def test_migration_rebalance_node(df_factory: DflyInstanceFactory, df_seeder_factory):

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1158,7 +1158,6 @@ More details in https://github.com/dragonflydb/dragonfly/issues/1231
 
 
 @pytest.mark.slow
-@pytest.mark.exclude_epoll
 async def test_flushall_in_full_sync(df_factory):
     master = df_factory.create(proactor_threads=4)
     replica = df_factory.create(proactor_threads=2)
@@ -1246,7 +1245,6 @@ take_over_cases = [
 ]
 
 
-@pytest.mark.exclude_epoll
 @pytest.mark.parametrize("master_threads, replica_threads", take_over_cases)
 async def test_take_over_counters(df_factory, master_threads, replica_threads):
     master = df_factory.create(proactor_threads=master_threads)
@@ -1301,7 +1299,6 @@ async def test_take_over_counters(df_factory, master_threads, replica_threads):
         assert client_value == int(replicated_value)
 
 
-@pytest.mark.exclude_epoll
 @pytest.mark.parametrize("master_threads, replica_threads", take_over_cases)
 async def test_take_over_seeder(
     request, df_factory, df_seeder_factory, master_threads, replica_threads
@@ -1577,7 +1574,6 @@ async def test_tls_replication_without_ca(
     assert 100 == await c_replica.execute_command("dbsize")
 
 
-@pytest.mark.exclude_epoll
 async def test_ipv6_replication(df_factory: DflyInstanceFactory):
     """Test that IPV6 addresses work for replication, ::1 is 127.0.0.1 localhost"""
     master = df_factory.create(proactor_threads=1, bind="::1", port=1111)
@@ -2416,7 +2412,6 @@ async def test_replication_timeout_on_full_sync(df_factory: DflyInstanceFactory,
     await assert_replica_reconnections(replica, 0)
 
 
-@pytest.mark.exclude_epoll
 @dfly_args({"proactor_threads": 1})
 async def test_master_stalled_disconnect(df_factory: DflyInstanceFactory):
     # disconnect after 1 second of being blocked
@@ -2765,7 +2760,6 @@ async def test_replication_timeout_on_full_sync_heartbeat_expiry(
     await assert_replica_reconnections(replica, 0)
 
 
-@pytest.mark.exclude_epoll
 @dfly_args({"proactor_threads": 1})
 async def test_memory_on_big_string_loading(df_factory):
     """
@@ -2806,7 +2800,6 @@ async def test_memory_on_big_string_loading(df_factory):
     assert master_data == replica_data
 
 
-@pytest.mark.exclude_epoll
 @pytest.mark.parametrize(
     "element_size, elements_number",
     [(16, 30000), (30000, 16)],


### PR DESCRIPTION
I want to investigate the problem with epoll tests, so I want to unskip it for some time.