### PR TITLE
server: metrics to track stored command sizes

### DIFF
--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -323,7 +323,8 @@ vector<unsigned> ConnectionContext::ChangeSubscriptions(CmdArgList channels, boo
 void ConnectionState::ExecInfo::Clear() {
   DCHECK(!preborrowed_interpreter);  // Must have been released properly
   state = EXEC_INACTIVE;
-  ClearStoredCmds();
+  const size_t cleared_size = ClearStoredCmds();
+  ServerState::tlocal()->stats.stored_cmd_bytes -= cleared_size;
   is_write = false;
   ClearWatched();
 }

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -235,14 +235,10 @@ void ConnectionState::ExecInfo::AddStoredCmd(const CommandId* cid, bool own_args
 }
 
 size_t ConnectionState::ExecInfo::ClearStoredCmds() {
-  const size_t used = StoredCmdBytes();
+  const size_t used = GetStoredCmdBytes();
   vector<StoredCmd>{}.swap(body);
   stored_cmd_bytes = 0;
   return used;
-}
-
-size_t ConnectionState::ExecInfo::StoredCmdBytes() const {
-  return stored_cmd_bytes + body.capacity() * sizeof(StoredCmd);
 }
 
 size_t ConnectionState::ScriptInfo::UsedMemory() const {

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -94,7 +94,9 @@ struct ConnectionState {
     size_t ClearStoredCmds();
 
     // Returns memory used by the body field without iterating over each stored command
-    size_t StoredCmdBytes() const;
+    size_t GetStoredCmdBytes() const {
+      return stored_cmd_bytes + body.capacity() * sizeof(StoredCmd);
+    }
 
     ExecState state = EXEC_INACTIVE;
     std::vector<StoredCmd> body;

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -86,6 +86,16 @@ struct ConnectionState {
 
     size_t UsedMemory() const;
 
+    // Adds a StoredCmd and updates the stored_cmds_size
+    void AddStoredCmd(const CommandId* cid, bool own_args, CmdArgList args);
+
+    // Empties the body vector and resets stored_cmds_size to 0. Returns the size before data was
+    // cleared.
+    size_t ClearStoredCmds();
+
+    // Returns memory used by the body field without iterating over each stored command
+    size_t StoredCmdBytes() const;
+
     ExecState state = EXEC_INACTIVE;
     std::vector<StoredCmd> body;
     bool is_write = false;
@@ -99,6 +109,10 @@ struct ConnectionState {
     // executing the multi transaction, which can create deadlocks by blocking other transactions
     // that already borrowed all available interpreters but wait for keys to be unlocked.
     Interpreter* preborrowed_interpreter = nullptr;
+
+    // The total size of all stored commands kept in "body". Does not include memory allocated by
+    // the "body" vector.
+    size_t stored_cmd_bytes = 0;
   };
 
   // Lua-script related data.

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1346,9 +1346,12 @@ DispatchResult Service::DispatchCommand(ArgSlice args, SinkReplyBuilder* builder
   bool is_trans_cmd = CO::IsTransKind(cid->name());
   if (dfly_cntx->conn_state.exec_info.IsCollecting() && !is_trans_cmd) {
     // TODO: protect against aggregating huge transactions.
-    dfly_cntx->conn_state.exec_info.AddStoredCmd(cid, true, args_no_cmd);
+    auto& exec_info = dfly_cntx->conn_state.exec_info;
+    const size_t old_size = exec_info.StoredCmdBytes();
+    exec_info.AddStoredCmd(cid, true, args_no_cmd);
+    etl.stats.stored_cmd_bytes += exec_info.StoredCmdBytes() - old_size;
     if (cid->IsWriteOnly()) {
-      dfly_cntx->conn_state.exec_info.is_write = true;
+      exec_info.is_write = true;
     }
     builder->SendSimpleString("QUEUED");
     return DispatchResult::OK;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1346,7 +1346,7 @@ DispatchResult Service::DispatchCommand(ArgSlice args, SinkReplyBuilder* builder
   bool is_trans_cmd = CO::IsTransKind(cid->name());
   if (dfly_cntx->conn_state.exec_info.IsCollecting() && !is_trans_cmd) {
     // TODO: protect against aggregating huge transactions.
-    dfly_cntx->conn_state.exec_info.body.emplace_back(cid, true, args_no_cmd);
+    dfly_cntx->conn_state.exec_info.AddStoredCmd(cid, true, args_no_cmd);
     if (cid->IsWriteOnly()) {
       dfly_cntx->conn_state.exec_info.is_write = true;
     }

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1347,9 +1347,9 @@ DispatchResult Service::DispatchCommand(ArgSlice args, SinkReplyBuilder* builder
   if (dfly_cntx->conn_state.exec_info.IsCollecting() && !is_trans_cmd) {
     // TODO: protect against aggregating huge transactions.
     auto& exec_info = dfly_cntx->conn_state.exec_info;
-    const size_t old_size = exec_info.StoredCmdBytes();
+    const size_t old_size = exec_info.GetStoredCmdBytes();
     exec_info.AddStoredCmd(cid, true, args_no_cmd);
-    etl.stats.stored_cmd_bytes += exec_info.StoredCmdBytes() - old_size;
+    etl.stats.stored_cmd_bytes += exec_info.GetStoredCmdBytes() - old_size;
     if (cid->IsWriteOnly()) {
       exec_info.is_write = true;
     }

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1778,6 +1778,9 @@ void PrintPrometheusMetrics(uint64_t uptime, const Metrics& m, DflyCmd* dfly_cmd
   AppendMetricValue("memory_by_class_bytes", total.obj_memory_usage, {"class"}, {"object_used"},
                     &memory_by_class_bytes);
 
+  AppendMetricValue("memory_by_class_bytes", m.coordinator_stats.stored_cmd_bytes, {"class"},
+                    {"conn_stored_commands"}, &memory_by_class_bytes);
+
   // Command stats
   if (!m.cmd_stats_map.empty()) {
     string command_metrics;

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -53,7 +53,7 @@ ServerState::Stats::Stats(unsigned num_shards)
 }
 
 ServerState::Stats& ServerState::Stats::Add(const ServerState::Stats& other) {
-  static_assert(sizeof(Stats) == 24 * 8, "Stats size mismatch");
+  static_assert(sizeof(Stats) == 25 * 8, "Stats size mismatch");
 
 #define ADD(x) this->x += (other.x)
 
@@ -95,6 +95,8 @@ ServerState::Stats& ServerState::Stats::Add(const ServerState::Stats& other) {
   } else {
     this->squash_width_freq_arr = other.squash_width_freq_arr;
   }
+
+  ADD(stored_cmd_bytes);
   return *this;
 #undef ADD
 }

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -138,7 +138,7 @@ class ServerState {  // public struct - to allow initialization.
     std::valarray<uint64_t> tx_width_freq_arr, squash_width_freq_arr;
 
     // Memory size of stored commands during multi-exec in connections
-    uint64_t stored_cmd_bytes = 0;
+    size_t stored_cmd_bytes = 0;
   };
 
   // Unsafe version.

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -136,6 +136,9 @@ class ServerState {  // public struct - to allow initialization.
     uint32_t conn_timeout_events = 0;
     uint64_t psync_requests_total = 0;
     std::valarray<uint64_t> tx_width_freq_arr, squash_width_freq_arr;
+
+    // Memory size of stored commands during multi-exec in connections
+    uint64_t stored_cmd_bytes = 0;
   };
 
   // Unsafe version.


### PR DESCRIPTION
A new label `conn_stored_commands` is added to the metric `memory_by_class_bytes`. This value tracks the total size of the `StoredCmd` objects held in `ConnectionState::ExecInfo` objects in the `body` vector.

The size is added as a field on the `ExecInfo` object and a separate set of methods is added to read and write the size on this object. 

The reason for doing this and not directly using `UsedMemory` method on `ExecInfo` is that `ExecInfo::UsedMemory` will iterate over the vector to find the size. In order to update the metric, when storing a new command we must add the delta introduced by the command. For this we must find the used memory before and after the new command is stored, and `UsedMemory` must iterate over the entire vector. As the vector size grows this can become problematic as this operation must be done for each `DispatchCommand` within a multi-exec block.

The other option could be simply adding `StoredCmd::UsedMemory` to the metric each time we add a `StoredCmd` but this ignores the memory usage of the `body` container. 

The metric is decremented when the `ConnectionState::ExecInfo::Clear` method is called. This method now needs to access the connection ptr to decrement the metric.

FIXES https://github.com/dragonflydb/dragonfly/issues/5744

note: wrt https://github.com/dragonflydb/dragonfly/issues/5744 there is another relevant vector which is watched keys, a similar metric may need to be added for that if it is also known to grow to large sizes.