### PR TITLE
chore: implement the iterative fragmentation check

### DIFF
--- a/patches/mimalloc-v2.2.4/3_track_full_size.patch
+++ b/patches/mimalloc-v2.2.4/3_track_full_size.patch
@@ -1,0 +1,84 @@
+commit e0cda4eb4a54cfcd33afcd5fbd7ecd86510ac4f9
+Author: Roman Gershman <romange@gmail.com>
+Date:   Wed Sep 3 23:30:34 2025 +0300
+
+    chore: track comitted size of full pages in a heap
+    
+    Signed-off-by: Roman Gershman <romange@gmail.com>
+
+diff --git a/include/mimalloc/types.h b/include/mimalloc/types.h
+index a15d9cba..34d99a94 100644
+--- a/include/mimalloc/types.h
++++ b/include/mimalloc/types.h
+@@ -559,9 +559,10 @@ struct mi_heap_s {
+   uintptr_t             cookie;                              // random cookie to verify pointers (see `_mi_ptr_cookie`)
+   uintptr_t             keys[2];                             // two random keys used to encode the `thread_delayed_free` list
+   mi_random_ctx_t       random;                              // random number context used for secure allocation
+-  size_t                page_count;                          // total number of pages in the `pages` queues.
+-  size_t                page_retired_min;                    // smallest retired index (retired pages are fully free, but still in the page queues)
+-  size_t                page_retired_max;                    // largest retired index into the `pages` array.
++  uint32_t              page_count;                          // total number of pages in the `pages` queues.
++  uint16_t              page_retired_min;                    // smallest retired index (retired pages are fully free, but still in the page queues)
++  uint16_t              page_retired_max;                    // largest retired index into the `pages` array.
++  size_t                full_page_size;                      // total size of pages residing in MI_BIN_FULL bin.
+   long                  generic_count;                       // how often is `_mi_malloc_generic` called?
+   long                  generic_collect_count;               // how often is `_mi_malloc_generic` called without collecting?
+   mi_heap_t*            next;                                // list of heaps per thread
+diff --git a/src/init.c b/src/init.c
+index 3fc8b033..61ee4c76 100644
+--- a/src/init.c
++++ b/src/init.c
+@@ -118,6 +118,7 @@ mi_decl_cache_align const mi_heap_t _mi_heap_empty = {
+   { {0}, {0}, 0, true }, // random
+   0,                // page count
+   MI_BIN_FULL, 0,   // page retired min/max
++  0,                // full page size
+   0, 0,             // generic count
+   NULL,             // next
+   false,            // can reclaim
+@@ -167,6 +168,7 @@ mi_decl_cache_align mi_heap_t _mi_heap_main = {
+   { {0x846ca68b}, {0}, 0, true },  // random
+   0,                // page count
+   MI_BIN_FULL, 0,   // page retired min/max
++  0,                // full page size
+   0, 0,             // generic count
+   NULL,             // next heap
+   false,            // can reclaim
+diff --git a/src/page-queue.c b/src/page-queue.c
+index c719b626..524b09d8 100644
+--- a/src/page-queue.c
++++ b/src/page-queue.c
+@@ -232,6 +232,10 @@ static void mi_page_queue_remove(mi_page_queue_t* queue, mi_page_t* page) {
+   page->next = NULL;
+   page->prev = NULL;
+   // mi_atomic_store_ptr_release(mi_atomic_cast(void*, &page->heap), NULL);
++  if (mi_page_queue_is_full(queue)) {
++    mi_assert_internal(heap->full_page_size >= mi_page_block_size(page) * page->capacity);
++    heap->full_page_size -= mi_page_block_size(page) * page->capacity;
++  }
+   mi_page_set_in_full(page,false);
+ }
+ 
+@@ -246,6 +250,9 @@ static void mi_page_queue_push(mi_heap_t* heap, mi_page_queue_t* queue, mi_page_
+                       (mi_page_is_large_or_huge(page) && mi_page_queue_is_huge(queue)) ||
+                         (mi_page_is_in_full(page) && mi_page_queue_is_full(queue)));
+ 
++  if (mi_page_queue_is_full(queue)) {
++    heap->full_page_size += mi_page_block_size(page) * page->capacity;
++  }
+   mi_page_set_in_full(page, mi_page_queue_is_full(queue));
+   // mi_atomic_store_ptr_release(mi_atomic_cast(void*, &page->heap), heap);
+   page->next = queue->first;
+@@ -339,6 +346,12 @@ static void mi_page_queue_enqueue_from_ex(mi_page_queue_t* to, mi_page_queue_t*
+     }
+   }
+ 
++  if (mi_page_queue_is_full(to)) {
++    heap->full_page_size += mi_page_block_size(page) * page->capacity;
++  } else if (mi_page_queue_is_full(from)) {
++    mi_assert_internal(heap->full_page_size >= mi_page_block_size(page) * page->capacity);
++    heap->full_page_size -= mi_page_block_size(page) * page->capacity;
++  }
+   mi_page_set_in_full(page, mi_page_queue_is_full(to));
+ }
+ 

--- a/src/core/page_usage_stats.h
+++ b/src/core/page_usage_stats.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <absl/container/btree_map.h>
+
+#define MI_BUILD_RELEASE 1
 #include <mimalloc/types.h>
 
 #include "core/bloom.h"

--- a/src/core/segment_allocator.cc
+++ b/src/core/segment_allocator.cc
@@ -3,6 +3,7 @@
 //
 #include "core/segment_allocator.h"
 
+#define MI_BUILD_RELEASE 1
 #include <mimalloc/types.h>
 
 #include "base/logging.h"

--- a/src/external_libs.cmake
+++ b/src/external_libs.cmake
@@ -75,6 +75,7 @@ ExternalProject_Add(mimalloc2_project
       patch -p1 -d ${THIRD_PARTY_DIR}/mimalloc2/ -i ${MIMALLOC_PATCH_DIR}/0_base.patch
       COMMAND patch -p1 -d ${THIRD_PARTY_DIR}/mimalloc2/ -i ${MIMALLOC_PATCH_DIR}/1_add_stat_type.patch
       COMMAND patch -p1 -d ${THIRD_PARTY_DIR}/mimalloc2/ -i ${MIMALLOC_PATCH_DIR}/2_return_stat.patch
+      COMMAND patch -p1 -d ${THIRD_PARTY_DIR}/mimalloc2/ -i ${MIMALLOC_PATCH_DIR}/3_track_full_size.patch
   BUILD_COMMAND make mimalloc-static
 
   INSTALL_COMMAND make install

--- a/src/redis/zmalloc.h
+++ b/src/redis/zmalloc.h
@@ -122,6 +122,16 @@ Note that if a block is not used, it would not counted as wasted
 */
 int zmalloc_get_allocator_wasted_blocks(float ratio, size_t* allocated, size_t* commited,
                                         size_t* wasted);
+struct fragmentation_info {
+  size_t committed;
+  size_t wasted;
+  unsigned bin;
+};
+
+// Like zmalloc_get_allocator_wasted_blocks but incremental.
+// struct fragmentation_info must be passed first set to zero. Returns -1 needs to continue,
+// 0 if done.
+int zmalloc_get_allocator_fragmentation_step(float ratio, struct fragmentation_info* info);
 
 /*
  * checks whether a page that the pointer ptr located at is underutilized.

--- a/src/redis/zmalloc_mi.c
+++ b/src/redis/zmalloc_mi.c
@@ -4,6 +4,8 @@
 
 #include <assert.h>
 #include <mimalloc.h>
+
+#define MI_BUILD_RELEASE 1
 #include <mimalloc/types.h>
 #include <string.h>
 #include <unistd.h>
@@ -167,8 +169,47 @@ int zmalloc_get_allocator_wasted_blocks(float ratio, size_t* allocated, size_t* 
   *allocated = sum.allocated;
   *commited = sum.comitted;
   *wasted = sum.wasted;
-
   return 1;
+}
+
+// Implemented based on this mimalloc code:
+// https://github.com/microsoft/mimalloc/blob/main/src/heap.c#L27
+int zmalloc_get_allocator_fragmentation_step(float ratio, struct fragmentation_info* info) {
+  if (zmalloc_heap->page_count == 0 || info->bin >= MI_BIN_FULL) {
+    // We avoid iterating over full pages since they are fully utilized.
+    return 0;
+  }
+
+  mi_page_queue_t* pq = &zmalloc_heap->pages[info->bin];
+  const mi_page_t* page = pq->first;
+  while (page != NULL) {
+    const mi_page_t* next = page->next;
+
+    const size_t bsize = page->block_size;
+
+    size_t committed = page->capacity * bsize;
+    info->committed += committed;
+    if (page->used < page->capacity) {
+      size_t used = page->used * bsize;
+
+      size_t threshold = (double)committed * ratio;
+      if (used < threshold) {
+        info->wasted += (committed - used);
+      }
+    }
+    page = next;
+  }
+
+  info->bin++;
+  if (info->bin == MI_BIN_FULL) {  // reached end of bins, reset state
+    // Add total comitted size of MI_BIN_FULL that we do not traverse
+    // as its tracked by zmalloc_heap->full_page_size variable.
+    info->committed += zmalloc_heap->full_page_size;
+    info->bin = 0;
+    return 0;
+  }
+
+  return -1;
 }
 
 void init_zmalloc_threadlocal(void* heap) {
@@ -179,8 +220,7 @@ void init_zmalloc_threadlocal(void* heap) {
 
 void zmalloc_page_is_underutilized(void* ptr, float ratio, int collect_stats,
                                    mi_page_usage_stats_t* result) {
-  *result = mi_heap_page_is_underutilized(zmalloc_heap, ptr, ratio,
-                                          collect_stats);
+  *result = mi_heap_page_is_underutilized(zmalloc_heap, ptr, ratio, collect_stats);
 }
 
 char* zstrdup(const char* s) {

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -745,9 +745,7 @@ TEST_F(DflyEngineTest, Issue742) {
 }
 
 TEST_F(DefragDflyEngineTest, TestDefragOption) {
-  if (pp_->GetNextProactor()->GetKind() == util::ProactorBase::EPOLL) {
-    GTEST_SKIP() << "Defragmentation via idle task is only supported in io uring";
-  }
+  GTEST_SKIP() << "Defragmentation check takes too long. Disabling this test";
 
   // mem_defrag_threshold is based on RSS statistic, but we don't count it in the test
   absl::SetFlag(&FLAGS_mem_defrag_threshold, 0.0);

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -320,11 +320,11 @@ std::optional<CollectedPageStats> EngineShard::DoDefrag(CollectPageStats collect
   defrag_state_.UpdateScanState(cur.token());
 
   if (reallocations > 0) {
-    VLOG(1) << "shard " << slice.shard_id() << ": successfully defrag  " << reallocations
+    VLOG(2) << "shard " << slice.shard_id() << ": successfully defrag  " << reallocations
             << " times, did it in " << traverses_count << " cursor is at the "
             << (defrag_state_.cursor == kCursorDoneState ? "end" : "in progress");
   } else {
-    VLOG(1) << "shard " << slice.shard_id() << ": run the defrag " << traverses_count
+    VLOG(2) << "shard " << slice.shard_id() << ": run the defrag " << traverses_count
             << " times out of maximum " << kMaxTraverses << ", with cursor at "
             << (defrag_state_.cursor == kCursorDoneState ? "end" : "in progress")
             << " but no location for defrag were found";
@@ -711,7 +711,7 @@ void EngineShard::RetireExpiredAndEvict() {
       stats_.total_heartbeat_expired_keys += stats.deleted;
       stats_.total_heartbeat_expired_bytes += stats.deleted_bytes;
       ++stats_.total_heartbeat_expired_calls;
-      VLOG(1) << "Heartbeat expired " << stats.deleted << " keys with total bytes "
+      VLOG(2) << "Heartbeat expired " << stats.deleted << " keys with total bytes "
               << stats.deleted_bytes << " with total expire flow calls "
               << stats_.total_heartbeat_expired_calls;
     }


### PR DESCRIPTION
Before - we had relatively slow check for counting wasted fragmentation via zmalloc_get_allocator_wasted_blocks that took 10ms or more in production. The reason for that is that it iterate over all the memory pages on a single shard through the single call.

Now we implement an iterative version of it by iterating over a single page queue data-structure in the heap. Once we start the iterative process we will continue aggregating stats over all the page queues in the heap until we reach the end and then conclude if defragmentation is needed.

this should reduce the call time to EngineShard::DefragTaskState::CheckRequired by x70 (number of page queues in the heap).

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->