### PR TITLE
server: Adds metrics for background defrag task

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1910,6 +1910,14 @@ void PrintPrometheusMetrics(uint64_t uptime, const Metrics& m, DflyCmd* dfly_cmd
 
   absl::StrAppend(&resp->body(), db_key_metrics, db_key_expire_metrics, db_capacity_metrics,
                   memory_by_class_bytes);
+
+  AppendMetricHeader("defrag_stats", "Stats for defragmentation task", COUNTER, &resp->body());
+  AppendMetricWithoutLabels("defrag_invocations", "Defrag invocations",
+                            m.shard_stats.defrag_task_invocation_total, COUNTER, &resp->body());
+  AppendMetricWithoutLabels("defrag_attempts", "Objects examined",
+                            m.shard_stats.defrag_attempt_total, COUNTER, &resp->body());
+  AppendMetricWithoutLabels("defrag_invocations", "Objects moved",
+                            m.shard_stats.defrag_realloc_total, COUNTER, &resp->body());
 }
 
 void ServerFamily::ConfigureMetrics(util::HttpListenerBase* http_base) {


### PR DESCRIPTION
Note: metrics are not added for the manual execution of the task in this PR

partially fixes https://github.com/dragonflydb/dragonfly/issues/5705