### PR TITLE
facade/server: Use inline instead of extern to reduce loc

### DIFF
--- a/src/facade/error.h
+++ b/src/facade/error.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <atomic>
 #include <string>
 #include <string_view>
 
@@ -15,35 +14,37 @@ std::string ConfigSetFailed(std::string_view config_name);
 std::string InvalidExpireTime(std::string_view cmd);
 std::string UnknownSubCmd(std::string_view subcmd, std::string_view cmd);
 
-extern const char kSyntaxErr[];
-extern const char kWrongTypeErr[];
-extern const char kWrongJsonTypeErr[];
-extern const char kKeyNotFoundErr[];
-extern const char kInvalidIntErr[];
-extern const char kInvalidFloatErr[];
-extern const char kUintErr[];
-extern const char kIncrOverflow[];
-extern const char kDbIndOutOfRangeErr[];
-extern const char kInvalidDbIndErr[];
-extern const char kScriptNotFound[];
-extern const char kAuthRejected[];
-extern const char kExpiryOutOfRange[];
-extern const char kIndexOutOfRange[];
-extern const char kOutOfMemory[];
-extern const char kInvalidNumericResult[];
-extern const char kClusterNotConfigured[];
-extern const char kLoadingErr[];
-extern const char kUndeclaredKeyErr[];
-extern const char kInvalidDumpValueErr[];
-extern const char kInvalidJsonPathErr[];
-extern const char kJsonParseError[];
-extern const char kCrossSlotError[];
+inline constexpr char kSyntaxErr[] = "syntax error";
+inline constexpr char kWrongTypeErr[] =
+    "-WRONGTYPE Operation against a key holding the wrong kind of value";
+inline constexpr char kWrongJsonTypeErr[] = "-WRONGTYPE wrong JSON type of path value";
+inline constexpr char kKeyNotFoundErr[] = "no such key";
+inline constexpr char kInvalidIntErr[] = "value is not an integer or out of range";
+inline constexpr char kInvalidFloatErr[] = "value is not a valid float";
+inline constexpr char kUintErr[] = "value is out of range, must be positive";
+inline constexpr char kIncrOverflow[] = "increment or decrement would overflow";
+inline constexpr char kDbIndOutOfRangeErr[] = "DB index is out of range";
+inline constexpr char kInvalidDbIndErr[] = "invalid DB index";
+inline constexpr char kScriptNotFound[] = "-NOSCRIPT No matching script. Please use EVAL.";
+inline constexpr char kAuthRejected[] =
+    "-WRONGPASS invalid username-password pair or user is disabled.";
+inline constexpr char kExpiryOutOfRange[] = "expiry is out of range";
+inline constexpr char kIndexOutOfRange[] = "index out of range";
+inline constexpr char kOutOfMemory[] = "Out of memory";
+inline constexpr char kInvalidNumericResult[] = "result is not a number";
+inline constexpr char kClusterNotConfigured[] = "Cluster is not yet configured";
+inline constexpr char kLoadingErr[] = "-LOADING Dragonfly is loading the dataset in memory";
+inline constexpr char kUndeclaredKeyErr[] = "script tried accessing undeclared key";
+inline constexpr char kInvalidDumpValueErr[] = "DUMP payload version or checksum are wrong";
+inline constexpr char kInvalidJsonPathErr[] = "invalid JSON path";
+inline constexpr char kJsonParseError[] = "failed to parse JSON";
+inline constexpr char kCrossSlotError[] = "-CROSSSLOT Keys in request don't hash to the same slot";
 
-extern const char kSyntaxErrType[];
-extern const char kScriptErrType[];
-extern const char kConfigErrType[];
-extern const char kSearchErrType[];
-extern const char kWrongTypeErrType[];
-extern const char kRestrictDenied[];
+inline constexpr char kSyntaxErrType[] = "syntax_error";
+inline constexpr char kScriptErrType[] = "script_error";
+inline constexpr char kConfigErrType[] = "config_error";
+inline constexpr char kSearchErrType[] = "search_error";
+inline constexpr char kWrongTypeErrType[] = "wrong_type";
+inline constexpr char kRestrictDenied[] = "restrict_denied";
 
 }  // namespace facade

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -110,37 +110,6 @@ string ConfigSetFailed(string_view config_name) {
   return absl::StrCat("CONFIG SET failed (possibly related to argument '", config_name, "').");
 }
 
-const char kSyntaxErr[] = "syntax error";
-const char kWrongTypeErr[] = "-WRONGTYPE Operation against a key holding the wrong kind of value";
-const char kWrongJsonTypeErr[] = "-WRONGTYPE wrong JSON type of path value";
-const char kKeyNotFoundErr[] = "no such key";
-const char kInvalidIntErr[] = "value is not an integer or out of range";
-const char kInvalidFloatErr[] = "value is not a valid float";
-const char kUintErr[] = "value is out of range, must be positive";
-const char kIncrOverflow[] = "increment or decrement would overflow";
-const char kDbIndOutOfRangeErr[] = "DB index is out of range";
-const char kInvalidDbIndErr[] = "invalid DB index";
-const char kScriptNotFound[] = "-NOSCRIPT No matching script. Please use EVAL.";
-const char kAuthRejected[] = "-WRONGPASS invalid username-password pair or user is disabled.";
-const char kExpiryOutOfRange[] = "expiry is out of range";
-const char kIndexOutOfRange[] = "index out of range";
-const char kOutOfMemory[] = "Out of memory";
-const char kInvalidNumericResult[] = "result is not a number";
-const char kClusterNotConfigured[] = "Cluster is not yet configured";
-const char kLoadingErr[] = "-LOADING Dragonfly is loading the dataset in memory";
-const char kUndeclaredKeyErr[] = "script tried accessing undeclared key";
-const char kInvalidDumpValueErr[] = "DUMP payload version or checksum are wrong";
-const char kInvalidJsonPathErr[] = "invalid JSON path";
-const char kJsonParseError[] = "failed to parse JSON";
-const char kCrossSlotError[] = "-CROSSSLOT Keys in request don't hash to the same slot";
-
-const char kSyntaxErrType[] = "syntax_error";
-const char kScriptErrType[] = "script_error";
-const char kConfigErrType[] = "config_error";
-const char kSearchErrType[] = "search_error";
-const char kWrongTypeErrType[] = "wrong_type";
-const char kRestrictDenied[] = "restrict_denied";
-
 const char* RespExpr::TypeName(Type t) {
   switch (t) {
     case STRING:
@@ -181,8 +150,6 @@ CommandId::CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first
 uint32_t CommandId::OptCount(uint32_t mask) {
   return absl::popcount(mask);
 }
-
-__thread FacadeStats* tl_facade_stats = nullptr;
 
 static bool ParseHumanReadableBytes(std::string_view str, int64_t* num_bytes) {
   if (str.empty())

--- a/src/facade/facade_types.h
+++ b/src/facade/facade_types.h
@@ -201,15 +201,15 @@ struct ErrorReply {
   std::optional<OpStatus> status{std::nullopt};
 };
 
-constexpr inline unsigned long long operator""_MB(unsigned long long x) {
+constexpr unsigned long long operator""_MB(unsigned long long x) {
   return 1024L * 1024L * x;
 }
 
-constexpr inline unsigned long long operator""_KB(unsigned long long x) {
+constexpr unsigned long long operator""_KB(unsigned long long x) {
   return 1024L * x;
 }
 
-extern __thread FacadeStats* tl_facade_stats;
+inline thread_local FacadeStats* tl_facade_stats = nullptr;
 
 void ResetStats();
 

--- a/src/server/cluster_support.cc
+++ b/src/server/cluster_support.cc
@@ -47,12 +47,6 @@ optional<SlotId> UniqueSlotChecker::GetUniqueSlotId() const {
   return slot_id_ > kMaxSlotNum ? optional<SlotId>() : slot_id_;
 }
 
-namespace detail {
-ClusterMode cluster_mode = ClusterMode::kUninitialized;
-bool cluster_shard_by_slot = false;
-
-}  // namespace detail
-
 using namespace detail;
 
 void InitializeCluster() {

--- a/src/server/cluster_support.h
+++ b/src/server/cluster_support.h
@@ -19,8 +19,8 @@ enum class ClusterMode {
   kRealCluster,
 };
 
-extern ClusterMode cluster_mode;
-extern bool cluster_shard_by_slot;
+inline ClusterMode cluster_mode = ClusterMode::kUninitialized;
+inline bool cluster_shard_by_slot = false;
 
 };  // namespace detail
 

--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -110,13 +110,6 @@ std::string_view LockTagOptions::Tag(std::string_view key) const {
   return key.substr(start + 1, end - start - 1);
 }
 
-atomic_uint64_t used_mem_current(0);
-atomic_uint64_t rss_mem_current(0);
-atomic_uint64_t max_memory_limit(0);
-
-unsigned kernel_version = 0;
-Namespaces* namespaces = nullptr;
-
 const char* GlobalStateName(GlobalState s) {
   switch (s) {
     case GlobalState::ACTIVE:

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -129,16 +129,16 @@ bool ParseDouble(std::string_view src, double* value);
 const char* RdbTypeName(unsigned type);
 
 // Globally used atomics for memory readings
-extern std::atomic_uint64_t used_mem_current;
-extern std::atomic_uint64_t rss_mem_current;
+inline std::atomic_uint64_t used_mem_current{0};
+inline std::atomic_uint64_t rss_mem_current{0};
 // Current value of --maxmemory flag
-extern std::atomic_uint64_t max_memory_limit;
+inline std::atomic_uint64_t max_memory_limit{0};
 
-extern Namespaces* namespaces;
+inline Namespaces* namespaces = nullptr;
 
 // version 5.11 maps to 511 etc.
 // set upon server start.
-extern unsigned kernel_version;
+inline unsigned kernel_version = 0;
 
 const char* GlobalStateName(GlobalState gs);
 

--- a/src/server/config_registry.cc
+++ b/src/server/config_registry.cc
@@ -96,6 +96,4 @@ void ConfigRegistry::ValidateCustomSetter(std::string_view name, WriteCb setter)
   }
 }
 
-ConfigRegistry config_registry;
-
 }  // namespace dfly

--- a/src/server/config_registry.h
+++ b/src/server/config_registry.h
@@ -72,6 +72,6 @@ class ConfigRegistry {
   absl::flat_hash_map<std::string, Entry> registry_ ABSL_GUARDED_BY(mu_);
 };
 
-extern ConfigRegistry config_registry;
+inline ConfigRegistry config_registry;
 
 }  // namespace dfly


### PR DESCRIPTION
Since c++17 `inline` variables can be used for a _definition_ of a variable in a header file which is included in multiple source files. This avoids the need to use `extern` in the header and defining the variable in a source file.

The linker will merge the symbols from different translation units at link time.

https://en.cppreference.com/w/cpp/language/inline.html