### PR TITLE
fix: acl pubsub should only glob match the channel

### DIFF
--- a/src/server/acl/acl_family_test.cc
+++ b/src/server/acl/acl_family_test.cc
@@ -538,6 +538,15 @@ TEST_F(AclFamilyTest, TestPubSub) {
   vec = resp.GetVec();
   EXPECT_THAT(vec[8], "channels");
   EXPECT_THAT(vec[9], "resetchannels &foo");
+
+  resp =
+      Run("ACL setuser demo on resetkeys resetchannels ~app|managed-resources|* "
+          "&app|managed-resources|* +publish +ping >passwd");
+  resp = Run("AUTH demo passwd");
+  EXPECT_THAT(resp, "OK");
+
+  resp = Run("publish app|managed-resources|xyz test");
+  EXPECT_THAT(resp, IntArg(0));
 }
 
 TEST_F(AclFamilyTest, TestAlias) {

--- a/src/server/acl/validator.cc
+++ b/src/server/acl/validator.cc
@@ -50,9 +50,8 @@ bool ValidateCommand(const std::vector<uint64_t>& acl_commands, const CommandId&
 
   bool allowed = true;
   if (!pub_sub.all_channels) {
-    for (auto channel : tail_args) {
-      allowed &= iterate_globs(facade::ToSV(channel));
-    }
+    auto channel = tail_args[0];
+    allowed &= iterate_globs(facade::ToSV(channel));
   }
 
   return {allowed, AclLog::Reason::PUB_SUB};


### PR DESCRIPTION
publish command accepts only a single channel and a message, yet in `IsUserAllowedToInvokeCmd` we glob matched both the channel and the message which effectively rejected incorrectly the command execution because of permissions.

Fixes  #5763