### PR TITLE
chore: add self-testing code for heap->full_page_size computation

### DIFF
--- a/src/redis/zmalloc.h
+++ b/src/redis/zmalloc.h
@@ -124,6 +124,10 @@ int zmalloc_get_allocator_wasted_blocks(float ratio, size_t* allocated, size_t* 
                                         size_t* wasted);
 struct fragmentation_info {
   size_t committed;
+
+  // a temporary metric to compare against "committed" in production.
+  // TODO: delete it once we are confident committed is computed correctly.
+  size_t committed_golden;
   size_t wasted;
   unsigned bin;
 };

--- a/src/redis/zmalloc_mi.c
+++ b/src/redis/zmalloc_mi.c
@@ -202,9 +202,19 @@ int zmalloc_get_allocator_fragmentation_step(float ratio, struct fragmentation_i
 
   info->bin++;
   if (info->bin == MI_BIN_FULL) {  // reached end of bins, reset state
+    info->committed_golden = info->committed;
     // Add total comitted size of MI_BIN_FULL that we do not traverse
     // as its tracked by zmalloc_heap->full_page_size variable.
     info->committed += zmalloc_heap->full_page_size;
+
+    // TODO: it's a test code that makes sure `full_page_size` is correct.
+    // Remove it once we are confident with the implementation.
+    mi_page_queue_t* pq = &zmalloc_heap->pages[MI_BIN_FULL];
+    const mi_page_t* page = pq->first;
+    while (page != NULL) {
+      info->committed_golden += page->capacity * page->block_size;
+      page = page->next;
+    }
     info->bin = 0;
     return 0;
   }

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -231,7 +231,8 @@ bool EngineShard::DefragTaskState::CheckRequired() {
     return false;
   }
 
-  static thread_local fragmentation_info finfo{.committed = 0, .wasted = 0, .bin = 0};
+  thread_local fragmentation_info finfo{
+      .committed = 0, .committed_golden = 0, .wasted = 0, .bin = 0};
 
   const std::size_t global_threshold = double(limit) * GetFlag(FLAGS_mem_defrag_threshold);
   if (global_threshold > rss_mem_current.load(memory_order_relaxed)) {
@@ -249,19 +250,23 @@ bool EngineShard::DefragTaskState::CheckRequired() {
     }
 
     // start checking.
-    finfo.committed = finfo.wasted = 0;
+    finfo.committed = finfo.committed_golden = 0;
+    finfo.wasted = 0;
+    page_utilization_threshold = GetFlag(FLAGS_mem_defrag_page_utilization_threshold);
   }
 
   uint64_t start = absl::GetCurrentTimeNanos();
-  int res = zmalloc_get_allocator_fragmentation_step(
-      GetFlag(FLAGS_mem_defrag_page_utilization_threshold), &finfo);
+  int res = zmalloc_get_allocator_fragmentation_step(page_utilization_threshold, &finfo);
   uint64_t duration = absl::GetCurrentTimeNanos() - start;
-  VLOG_IF(1, duration > 20'000) << "Reading memory usage took " << duration / 1'000
-                                << " usec on bin " << finfo.bin;
+  VLOG(1) << "Reading memory usage took " << duration << " ns on bin " << finfo.bin - 1;
+
   if (res == 0) {
     // finished checking.
     last_check_time = time(nullptr);
-
+    if (finfo.committed != finfo.committed_golden) {
+      LOG_FIRST_N(ERROR, 100) << "committed memory computed incorrectly: " << finfo.committed
+                              << " vs " << finfo.committed_golden;
+    }
     const double waste_threshold = GetFlag(FLAGS_mem_defrag_waste_threshold);
     if (finfo.wasted > size_t(finfo.committed * waste_threshold)) {
       VLOG(1) << "memory fragmentation issue found: " << finfo.wasted << " " << finfo.committed;
@@ -359,7 +364,7 @@ uint32_t EngineShard::DefragTask() {
       return util::ProactorBase::kOnIdleMaxLevel;
     }
   }
-  return 3;  // priority.
+  return 6;  // priority.
 }
 
 EngineShard::EngineShard(util::ProactorBase* pb, mi_heap_t* heap)

--- a/src/server/engine_shard.h
+++ b/src/server/engine_shard.h
@@ -214,6 +214,7 @@ class EngineShard {
     size_t dbid = 0u;
     uint64_t cursor = 0u;
     time_t last_check_time = 0;
+    float page_utilization_threshold = 0.8;
 
     // check the current threshold and return true if
     // we need to do the defragmentation


### PR DESCRIPTION
Following #5766 I am adding self testing code just to make sure that the patch to mimalloc is correct. We compute full page size like we did before and compare to the fast method. If discrepancy is found we output the error.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->