### PR TITLE
chore: new ReplicaOf algorithm

### DIFF
--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -542,13 +542,6 @@ error_code Replica::InitiateDflySync(std::optional<LastMasterSyncData> last_mast
     JoinDflyFlows();
     if (sync_type == "full") {
       service_.RemoveLoadingState();
-    } else if (service_.IsLoadingExclusively()) {
-      // We need this check. We originally set the state unconditionally to LOADING
-      // when we call ReplicaOf command. If for some reason we fail to start full sync below
-      // or cancel the context, we still need to switch to ACTIVE state.
-      // TODO(kostasrim) we can remove this once my proposed changes for replication move forward
-      // as the state transitions for ReplicaOf command will be much clearer.
-      service_.SwitchState(GlobalState::LOADING, GlobalState::ACTIVE);
     }
     state_mask_ &= ~R_SYNCING;
     last_journal_LSNs_.reset();

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -63,6 +63,8 @@ ABSL_DECLARE_FLAG(uint16_t, announce_port);
 ABSL_FLAG(
     int, replica_priority, 100,
     "Published by info command for sentinel to pick replica based on score during a failover");
+ABSL_FLAG(bool, experimental_replicaof_v2, true,
+          "Use ReplicaOfV2 algorithm for initiating replication");
 
 namespace dfly {
 

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -373,7 +373,7 @@ class ServerFamily {
   void ReplicaOfInternal(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder,
                          ActionOnConnectionFail on_error) ABSL_LOCKS_EXCLUDED(replicaof_mu_);
 
-  void ReplicaOfNoOne(SinkReplyBuilder* builder);
+  void ReplicaOfNoOne(SinkReplyBuilder* builder) ABSL_LOCKS_EXCLUDED(replicaof_mu_);
   // REPLICAOF implementation without two phase locking.
   void ReplicaOfInternalV2(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder,
                            ActionOnConnectionFail on_error) ABSL_LOCKS_EXCLUDED(replicaof_mu_);

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -373,6 +373,11 @@ class ServerFamily {
   void ReplicaOfInternal(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder,
                          ActionOnConnectionFail on_error) ABSL_LOCKS_EXCLUDED(replicaof_mu_);
 
+  void ReplicaOfNoOne(SinkReplyBuilder* builder);
+  // REPLICAOF implementation without two phase locking.
+  void ReplicaOfInternalV2(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder,
+                           ActionOnConnectionFail on_error) ABSL_LOCKS_EXCLUDED(replicaof_mu_);
+
   struct LoadOptions {
     std::string snapshot_id;
     uint32_t shard_count = 0;      // Shard count of the snapshot being loaded.

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -448,9 +448,6 @@ async def test_cancel_replication_immediately(df_factory, df_seeder_factory: Dfl
     """
     Issue 100 replication commands. This checks that the replication state
     machine can handle cancellation well.
-    We assert that at least one command was cancelled.
-    After we finish the 'fuzzing' part, replicate the first master and check that
-    all the data is correct.
     """
     COMMANDS_TO_ISSUE = 100
 
@@ -469,12 +466,8 @@ async def test_cancel_replication_immediately(df_factory, df_seeder_factory: Dfl
             await asyncio.sleep(0.05)
 
     async def replicate():
-        try:
-            await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
-            return True
-        except redis.exceptions.ResponseError as e:
-            assert e.args[0] == "replication cancelled"
-            return False
+        await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
+        return True
 
     ping_job = asyncio.create_task(ping_status())
     replication_commands = [asyncio.create_task(replicate()) for _ in range(COMMANDS_TO_ISSUE)]
@@ -484,7 +477,7 @@ async def test_cancel_replication_immediately(df_factory, df_seeder_factory: Dfl
         num_successes += await result
 
     logging.info(f"succeses: {num_successes}")
-    assert COMMANDS_TO_ISSUE > num_successes, "At least one REPLICAOF must be cancelled"
+    assert COMMANDS_TO_ISSUE == num_successes
 
     await wait_available_async(c_replica)
     capture = await seeder.capture()
@@ -492,6 +485,12 @@ async def test_cancel_replication_immediately(df_factory, df_seeder_factory: Dfl
     assert await seeder.compare(capture, replica.port)
 
     ping_job.cancel()
+
+    replica.stop()
+    lines = replica.find_in_logs("Stopping replication")
+    # Cancelled 99 times by REPLICAOF command and once by Shutdown() because
+    # we stopped the instance
+    assert len(lines) == COMMANDS_TO_ISSUE
 
 
 """
@@ -2974,8 +2973,7 @@ async def test_replicaof_inside_multi(df_factory):
         num_successes += await result
 
     logging.info(f"succeses: {num_successes}")
-    assert MULTI_COMMANDS_TO_ISSUE > num_successes, "At least one REPLICAOF must be cancelled"
-    assert num_successes > 0, "At least one REPLICAOF must success"
+    assert MULTI_COMMANDS_TO_ISSUE == num_successes
 
 
 async def test_preempt_in_atomic_section_of_heartbeat(df_factory: DflyInstanceFactory):


### PR DESCRIPTION
This PR implements the new ReplicaOf algorithm that does not use two phase locking.

**How ReplicaOf worked previously**:

1. stop the old replica -> dragonfly is processing read only commands normally
2. Set the flag to loading -> dragonfly stops processing read only commands because state is loading
3. create a new replica object 
4. release the mutex
5. allow the new replica object to do IO by connecting to the new master and exchange the necessary info to actually start the replication flow. -> This may fail yet we prematurely set the flag to loading and stopped the old replica
6. relock the mutex after the greet, clean up if the context got cancelled (by another replicaof command) or start the main replication fiber to properly start replication.

There are multiple issue with this:

1. two phase locking, allows other replicaof commands to interleave (not serialized) which complicates state transitions
2. prematurely setting state to loading even if the connection fails later on after releasing the mutex
3. prematurely stopped replication even if the connection with the new master fails later on
4. prematurely stops processing read only commands. Masters might be rotating so we might enter partial sync immediately. We don't need to enter LOADING state for that.

**How it works now:**

The new algorithm is very simple and has only two steps:

1. Create a `Replica` object, Initiate connection to the new master, greet and exchange the necessary info to setup replication. (internally it’s just REPLCONF setting connection members and info). So far there is no update to the state. We merely check if we can establish a connection with the new master and that everything is ok.

2. If there are no errors, lock the mutex, update the replica_ object and start the MainReplicationFiber. Do not enter LOADING state prematurely. First check if partial sync is available in main replication fiber and if not, `then enter LOADING state` and do full sync.

Now all `ReplicaOfInternal` commands are serialized. Cancellation is not affected because the connection that enters the critical section of (b) will cancel/stop the previous one. This happens one after the other in a deterministic manner.

