### PR TITLE
fix: script error reply

### DIFF
--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -154,7 +154,7 @@ TEST_F(DflyEngineTest, LuaErrors) {
   EXPECT_THAT(resp, ErrArg("some error"));
 
   resp = Run({"eval", "return redis.pcall('foo', 'bar')", "0"});
-  EXPECT_THAT(resp, ErrArg("ERR Unknown Redis command called from script"));
+  EXPECT_THAT(resp, ErrArg("ERR unknown command"));
 
   resp = Run({"eval", "return redis.pcall('incrby', 'foo', 'bar')", "1"});
   EXPECT_THAT(resp, ErrArg("ERR Number of keys can't be greater than number of args"));

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -383,7 +383,11 @@ class EvalSerializer : public ObjectExplorer {
   }
 
   void OnError(string_view str) {
-    rb_->SendError(absl::StrCat("-", str));
+    if (!str.empty() && str.front() != '-') {
+      rb_->SendError(absl::StrCat("-", str));
+    } else {
+      rb_->SendError(str);
+    }
   }
 
  private:
@@ -411,7 +415,11 @@ void InterpreterReplier::PostItem() {
 void InterpreterReplier::SendError(string_view str, std::string_view type) {
   DCHECK(array_len_.empty());
   DVLOG(1) << "Lua/df_call error " << str;
-  explr_->OnError(str);
+  if (!str.empty() && str.front() != '-') {
+    explr_->OnError(absl::StrCat("-ERR ", str));
+  } else {
+    explr_->OnError(str);
+  }
 }
 
 void InterpreterReplier::SendSimpleString(string_view str) {


### PR DESCRIPTION
fixes: #5762
problem: inconsistent error reply, if the script uses redis.error_reply(err_str) method, the error type is the first word in err_str. In the current case, we returned "-ERR NOT FOUND", but expected result was "-NOT FOUND", where "NOT FOUND" is provided by the convoy script via redis.error_reply("NOT FOUND") call

fix: added SendScriptErrorReply() method that append "-" to  err_str in response if redis.error_reply() in the script was called;