### PR TITLE
fix: Scan on non-existing key should return zero cursor

### DIFF
--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -332,6 +332,7 @@ OpResult<StringVec> OpScan(const OpArgs& op_args, std::string_view key, uint64_t
 
   if (!find_res) {
     DVLOG(1) << "ScanOp: find failed: " << find_res << ", baling out";
+    *cursor = 0;
     return find_res.status();
   }
 

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -965,8 +965,10 @@ OpResult<StringVec> OpScan(const OpArgs& op_args, string_view key, uint64_t* cur
                            const ScanOpts& scan_op) {
   auto find_res = op_args.GetDbSlice().FindReadOnly(op_args.db_cntx, key, OBJ_SET);
 
-  if (!find_res)
+  if (!find_res) {
+    *cursor = 0;
     return find_res.status();
+  }
 
   auto it = find_res.value();
   StringVec res;

--- a/src/server/set_family_test.cc
+++ b/src/server/set_family_test.cc
@@ -335,6 +335,12 @@ TEST_F(SetFamilyTest, Empty) {
 }
 
 TEST_F(SetFamilyTest, SScan) {
+  auto resp = Run("sscan non-existing-key 100 count 5");
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  ASSERT_THAT(resp.GetVec(), ElementsAre(ArgType(RespExpr::STRING), ArgType(RespExpr::ARRAY)));
+  EXPECT_EQ(ToSV(resp.GetVec()[0].GetBuf()), "0");
+  EXPECT_EQ(StrArray(resp.GetVec()[1]).size(), 0);
+
   // Test for int set
   for (int i = 0; i < 15; i++) {
     Run({"sadd", "myintset", absl::StrCat(i)});
@@ -342,7 +348,7 @@ TEST_F(SetFamilyTest, SScan) {
 
   // Note that even though this limit by 4, it would return more because
   // all fields are on intlist
-  auto resp = Run({"sscan", "myintset", "0", "count", "4"});
+  resp = Run({"sscan", "myintset", "0", "count", "4"});
   auto vec = StrArray(resp.GetVec()[1]);
   EXPECT_THAT(vec.size(), 15);
 

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1408,8 +1408,10 @@ OpResult<StringVec> OpScan(const OpArgs& op_args, std::string_view key, uint64_t
                            const ScanOpts& scan_op) {
   auto find_res = op_args.GetDbSlice().FindReadOnly(op_args.db_cntx, key, OBJ_ZSET);
 
-  if (!find_res)
+  if (!find_res) {
+    *cursor = 0;
     return find_res.status();
+  }
 
   const PrimeValue& pv = (*find_res)->second;
   StringVec res;

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -543,6 +543,12 @@ TEST_F(ZSetFamilyTest, ZRevRange) {
 }
 
 TEST_F(ZSetFamilyTest, ZScan) {
+  auto resp = Run("zscan non-existing-key 100 count 5");
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  ASSERT_THAT(resp.GetVec(), ElementsAre(ArgType(RespExpr::STRING), ArgType(RespExpr::ARRAY)));
+  EXPECT_EQ(ToSV(resp.GetVec()[0].GetBuf()), "0");
+  EXPECT_EQ(StrArray(resp.GetVec()[1]).size(), 0);
+
   string prefix(128, 'a');
   for (unsigned i = 0; i < 100; ++i) {
     Run({"zadd", "key", "1", absl::StrCat(prefix, i)});


### PR DESCRIPTION
Fixes #5777

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->