### PR TITLE
chore: Resize vector in StringMap::RandomPairs

### DIFF
--- a/src/core/string_map.cc
+++ b/src/core/string_map.cc
@@ -166,9 +166,9 @@ void StringMap::RandomPairs(unsigned int count, std::vector<sds>& keys, std::vec
   for (unsigned int i = 0; i < index; ++i)
     ++itr;
 
-  keys.reserve(count);
+  keys.resize(count);
   if (with_value)
-    vals.reserve(count);
+    vals.resize(count);
 
   while (itr != end() && pick_index < count) {
     auto [key, val] = *itr;


### PR DESCRIPTION
Tested on GCC 15 accessing vector which is reserved and not resized can trigger assert. Use resize instead.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->