### PR TITLE
feat: SHUTDOWN: fast path for NOW/FORCE; unify SAVE/SAFE; support NOSAVE

### DIFF
--- a/src/facade/dragonfly_listener.cc
+++ b/src/facade/dragonfly_listener.cc
@@ -256,7 +256,7 @@ bool Listener::IsMainInterface() const {
 
 void Listener::PreShutdown() {
   // If NOW/FORCE requested, expedite shutdown without waiting.
-  if (g_shutdown_fast.load(std::memory_order_relaxed)) {
+  if (g_shutdown_fast.load(std::memory_order_acquire)) {
     return;
   }
 

--- a/src/facade/dragonfly_listener.cc
+++ b/src/facade/dragonfly_listener.cc
@@ -66,6 +66,9 @@ CONFIG_enum(tls_auth_clients, "yes", "", tls_auth_clients_enum, tls_auth_clients
 
 namespace facade {
 
+// See dragonfly_listener.h
+std::atomic<bool> g_shutdown_fast{false};
+
 using namespace util;
 using util::detail::SafeErrorMessage;
 
@@ -252,13 +255,12 @@ bool Listener::IsMainInterface() const {
 }
 
 void Listener::PreShutdown() {
-  // Iterate on all connections and allow them to finish their commands for
-  // a short period.
-  // Executed commands can be visible in snapshots or replicas, but if we close the client
-  // connections too fast we might not send the acknowledgment for those commands.
-  // This shouldn't take a long time: All clients should reject incoming commands
-  // at this stage since we're in SHUTDOWN mode.
-  // If a command is running for too long we give up and proceed.
+  // If NOW/FORCE requested, expedite shutdown without waiting.
+  if (g_shutdown_fast.load(std::memory_order_relaxed)) {
+    return;
+  }
+
+  // Otherwise: Iterate on all connections and allow them to finish their commands briefly.
   DispatchTracker tracker{{this}};
   tracker.TrackAll();
 

--- a/src/facade/dragonfly_listener.cc
+++ b/src/facade/dragonfly_listener.cc
@@ -260,7 +260,13 @@ void Listener::PreShutdown() {
     return;
   }
 
-  // Otherwise: Iterate on all connections and allow them to finish their commands briefly.
+  // Otherwise: Iterate on all connections and allow them to finish their commands for
+  // a short period.
+  // Executed commands can be visible in snapshots or replicas, but if we close the client
+  // connections too fast we might not send the acknowledgment for those commands.
+  // This shouldn't take a long time: All clients should reject incoming commands
+  // at this stage since we're in SHUTDOWN mode.
+  // If a command is running for too long we give up and proceed.
   DispatchTracker tracker{{this}};
   tracker.TrackAll();
 

--- a/src/facade/dragonfly_listener.h
+++ b/src/facade/dragonfly_listener.h
@@ -7,6 +7,7 @@
 #include <absl/base/internal/spinlock.h>
 #include <absl/time/time.h>
 
+#include <atomic>
 #include <memory>
 #include <system_error>
 #include <utility>
@@ -106,5 +107,10 @@ class DispatchTracker {
   bool ignore_paused_;
   bool ignore_blocked_;
 };
+
+// Global shutdown tuning flag, controlled by SHUTDOWN options.
+// When true, listeners perform expedited shutdown without waiting for
+// in-flight dispatches (used by NOW/FORCE).
+extern std::atomic<bool> g_shutdown_fast;
 
 }  // namespace facade

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -3859,8 +3859,8 @@ void ServerFamily::ShutdownCmd(CmdArgList args, const CommandContext& cmd_cntx) 
   CHECK_NOTNULL(acceptor_)->Stop();
   cmd_cntx.rb->SendOk();
 
-  // Reset flag for any subsequent restarts (defensive; process exits shortly).
-  facade::g_shutdown_fast.store(false, std::memory_order_relaxed);
+  // Reset flag for any subsequent restarts (mainly for tests).
+  facade::g_shutdown_fast.store(false, std::memory_order_seq_cst);
 }
 
 void ServerFamily::Dfly(CmdArgList args, const CommandContext& cmd_cntx) {

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -3854,7 +3854,7 @@ void ServerFamily::ShutdownCmd(CmdArgList args, const CommandContext& cmd_cntx) 
   }
 
   // Wire NOW/FORCE to a single fast-shutdown flag for listeners.
-  facade::g_shutdown_fast.store(opt_now || opt_force, std::memory_order_relaxed);
+  facade::g_shutdown_fast.store(opt_now || opt_force, std::memory_order_seq_cst);
 
   CHECK_NOTNULL(acceptor_)->Stop();
   cmd_cntx.rb->SendOk();


### PR DESCRIPTION
Fixes: https://github.com/dragonflydb/dragonfly/issues/5444

- Parse SHUTDOWN options: SAVE, NOSAVE, SAFE, NOW, FORCE, ABORT
- SAVE and SAFE: unified behavior; snapshot happens during shutdown (no immediate save)
- FORCE: disables snapshot (save_on_shutdown=false) and enables fast shutdown
- NOW/FORCE: enable fast shutdown (skip graceful wait in Listener::PreShutdown)
- ABORT: returns error (not supported yet)