### PR TITLE
core: Replace sbf with hyperloglog

### DIFF
--- a/src/core/page_usage_stats.cc
+++ b/src/core/page_usage_stats.cc
@@ -38,12 +38,6 @@ HllBufferPtr InitHllPtr() {
   return p;
 }
 
-uint64_t CheckedPFCount(const HllBufferPtr h) {
-  const int64_t count = pfcountSingle(h);
-  CHECK_GT(count, -1);
-  return static_cast<uint64_t>(count);
-}
-
 }  // namespace
 
 void CollectedPageStats::Merge(CollectedPageStats&& other, uint16_t shard_id) {
@@ -149,16 +143,17 @@ CollectedPageStats PageUsage::UniquePages::CollectedStats() const {
     usage[p] = hdr_value_at_percentile(page_usage_hist, p);
   }
 
-  return CollectedPageStats{.pages_scanned = CheckedPFCount(pages_scanned),
-                            .pages_marked_for_realloc = CheckedPFCount(pages_marked_for_realloc),
-                            .pages_full = CheckedPFCount(pages_full),
-                            .pages_reserved_for_malloc = CheckedPFCount(pages_reserved_for_malloc),
-                            .pages_with_heap_mismatch = CheckedPFCount(pages_with_heap_mismatch),
-                            .pages_above_threshold = CheckedPFCount(pages_above_threshold),
-                            .objects_skipped_not_required = objects_skipped_not_required,
-                            .objects_skipped_not_supported = objects_skipped_not_supported,
-                            .page_usage_hist = std::move(usage),
-                            .shard_wide_summary = {}};
+  return CollectedPageStats{
+      .pages_scanned = static_cast<uint64_t>(pfcountSingle(pages_scanned)),
+      .pages_marked_for_realloc = static_cast<uint64_t>(pfcountSingle(pages_marked_for_realloc)),
+      .pages_full = static_cast<uint64_t>(pfcountSingle(pages_full)),
+      .pages_reserved_for_malloc = static_cast<uint64_t>(pfcountSingle(pages_reserved_for_malloc)),
+      .pages_with_heap_mismatch = static_cast<uint64_t>(pfcountSingle(pages_with_heap_mismatch)),
+      .pages_above_threshold = static_cast<uint64_t>(pfcountSingle(pages_above_threshold)),
+      .objects_skipped_not_required = objects_skipped_not_required,
+      .objects_skipped_not_supported = objects_skipped_not_supported,
+      .page_usage_hist = std::move(usage),
+      .shard_wide_summary = {}};
 }
 
 PageUsage::PageUsage(CollectPageStats collect_stats, float threshold)

--- a/src/core/page_usage_stats.cc
+++ b/src/core/page_usage_stats.cc
@@ -12,8 +12,6 @@
 
 #include <string>
 
-#include "core/bloom.h"
-
 extern "C" {
 #include <unistd.h>
 
@@ -122,10 +120,8 @@ PageUsage::UniquePages::~UniquePages() {
 }
 
 void PageUsage::UniquePages::AddStat(mi_page_usage_stats_t stat) {
-  const auto address = stat.page_address;
-  const std::string s = std::to_string(address);
-  const auto data = reinterpret_cast<const unsigned char*>(s.data());
-  const size_t size = s.size();
+  const auto data = reinterpret_cast<const unsigned char*>(&stat.page_address);
+  constexpr size_t size = sizeof(stat.page_address);
   pfadd_dense(pages_scanned, data, size);
   if (stat.flags == MI_DFLY_PAGE_BELOW_THRESHOLD) {
     pfadd_dense(pages_marked_for_realloc, data, size);

--- a/src/core/page_usage_stats.h
+++ b/src/core/page_usage_stats.h
@@ -11,18 +11,15 @@
 
 #include "core/bloom.h"
 
+extern "C" {
+#include "redis/hyperloglog.h"
+}
+
 struct hdr_histogram;
 
 namespace dfly {
 
 enum class CollectPageStats : uint8_t { YES, NO };
-
-struct FilterWithSize {
-  FilterWithSize();
-  SBF sbf;
-  size_t size;
-  void Add(uintptr_t);
-};
 
 struct CollectedPageStats {
   double threshold{0.0};
@@ -72,12 +69,12 @@ class PageUsage {
   float threshold_;
 
   struct UniquePages {
-    FilterWithSize pages_scanned{};
-    FilterWithSize pages_marked_for_realloc{};
-    FilterWithSize pages_full{};
-    FilterWithSize pages_reserved_for_malloc{};
-    FilterWithSize pages_with_heap_mismatch{};
-    FilterWithSize pages_above_threshold{};
+    HllBufferPtr pages_scanned;
+    HllBufferPtr pages_marked_for_realloc;
+    HllBufferPtr pages_full;
+    HllBufferPtr pages_reserved_for_malloc;
+    HllBufferPtr pages_with_heap_mismatch;
+    HllBufferPtr pages_above_threshold;
     hdr_histogram* page_usage_hist{};
 
     uint64_t objects_skipped_not_required{0};

--- a/src/core/page_usage_stats.h
+++ b/src/core/page_usage_stats.h
@@ -9,8 +9,6 @@
 #define MI_BUILD_RELEASE 1
 #include <mimalloc/types.h>
 
-#include "core/bloom.h"
-
 extern "C" {
 #include "redis/hyperloglog.h"
 }

--- a/src/core/page_usage_stats_test.cc
+++ b/src/core/page_usage_stats_test.cc
@@ -156,9 +156,9 @@ TEST_F(PageUsageStatsTest, StatCollection) {
   EXPECT_GT(st.pages_scanned, 12000);
 
   // Expect a small error margin due to HLL
-  EXPECT_NEAR(st.pages_full, page_count_per_flag, 1);
-  EXPECT_NEAR(st.pages_reserved_for_malloc, page_count_per_flag, 1);
-  EXPECT_NEAR(st.pages_marked_for_realloc, page_count_per_flag, 1);
+  EXPECT_NEAR(st.pages_full, page_count_per_flag, 5);
+  EXPECT_NEAR(st.pages_reserved_for_malloc, page_count_per_flag, 5);
+  EXPECT_NEAR(st.pages_marked_for_realloc, page_count_per_flag, 5);
 
   const auto usage = st.shard_wide_summary;
 

--- a/src/core/page_usage_stats_test.cc
+++ b/src/core/page_usage_stats_test.cc
@@ -135,8 +135,6 @@ TEST_F(PageUsageStatsTest, StatCollection) {
   }
 
   constexpr auto page_count_per_flag = 150;
-  // allow for collisions in filter
-  constexpr auto expected_min_count = 140;
 
   auto start = 0;
   for (const uint8_t flag : {MI_DFLY_PAGE_FULL, MI_DFLY_PAGE_USED_FOR_MALLOC, MI_DFLY_HEAP_MISMATCH,
@@ -156,9 +154,11 @@ TEST_F(PageUsageStatsTest, StatCollection) {
   st.Merge(p.CollectedStats(), 1);
 
   EXPECT_GT(st.pages_scanned, 12000);
-  EXPECT_GT(st.pages_full, expected_min_count);
-  EXPECT_GT(st.pages_reserved_for_malloc, expected_min_count);
-  EXPECT_GT(st.pages_marked_for_realloc, expected_min_count);
+
+  // Expect a small error margin due to HLL
+  EXPECT_NEAR(st.pages_full, page_count_per_flag, 1);
+  EXPECT_NEAR(st.pages_reserved_for_malloc, page_count_per_flag, 1);
+  EXPECT_NEAR(st.pages_marked_for_realloc, page_count_per_flag, 1);
 
   const auto usage = st.shard_wide_summary;
 


### PR DESCRIPTION
Change bloom filter to hyperloglog as discussed in pr https://github.com/dragonflydb/dragonfly/pull/5560#issuecomment-3254082470

external usage of the page usage stats class does not change.

With HLL no storage is required for the page addresses which reduces memory usage, the code only needs to maintain a constant count of registers to estimate cardinality, which is what we need at the end of the defragment command.

Note: Dense hll is used here, sparse hll could be used and converted to dense (as a follow up). The count of page addresses per class can be less than the number of registers (16384), in this case sparse hll might take up lesser memory.