### PR TITLE
server: Reject caching command if tracking is not enabled

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -476,6 +476,11 @@ void ClientCaching(CmdArgList args, SinkReplyBuilder* builder, Transaction* tx,
     return builder->SendError(kSyntaxErr);
   }
 
+  if (!cntx->conn_state.tracking_info_.IsTrackingOn()) {
+    return builder->SendError(
+        "ERR CLIENT CACHING can only be called when the client is in tracking mode");
+  }
+
   using Tracking = ConnectionState::ClientTracking;
   CmdArgParser parser{args};
   if (parser.Check("YES")) {

--- a/src/server/server_family_test.cc
+++ b/src/server/server_family_test.cc
@@ -303,6 +303,10 @@ TEST_F(ServerFamilyTest, ClientTrackingOnAndOff) {
   // case 3. turn off client tracking
   resp = Run({"CLIENT", "TRACKING", "OFF"});
   EXPECT_THAT(resp.GetString(), "OK");
+
+  resp = Run({"CLIENT", "CACHING", "YES"});
+  EXPECT_THAT(resp,
+              ErrArg("ERR CLIENT CACHING can only be called when the client is in tracking mode"));
 }
 
 TEST_F(ServerFamilyTest, ClientTrackingReadKey) {


### PR DESCRIPTION
FIXES https://github.com/dragonflydb/dragonfly/issues/5785

If client tracking is off, caching commands should be rejected. relevant discussion https://github.com/dragonflydb/documentation/pull/465