### PR TITLE
dfly_bench: Show error on failing to make address

### DIFF
--- a/src/server/dfly_bench.cc
+++ b/src/server/dfly_bench.cc
@@ -842,8 +842,8 @@ void Driver::ParseRESP() {
           CHECK_EQ(2u, addr_parts.size());
 
           auto host = boost::asio::ip::make_address(addr_parts[0], ec);
-          CHECK(!ec) << "make_address failed with error:" << ec.message() << "while parsing address"
-                     << addr_parts[0];
+          CHECK(!ec) << "make_address failed with error: " << ec.message()
+                     << " while parsing address " << addr_parts[0];
 
           uint32_t port;
           CHECK(absl::SimpleAtoi(addr_parts[1], &port));

--- a/src/server/dfly_bench.cc
+++ b/src/server/dfly_bench.cc
@@ -821,6 +821,7 @@ void Driver::ParseRESP() {
   RedisParser::Result result = RedisParser::OK;
   RespVec parse_args;
   constexpr string_view kMovedErrorKey = "MOVED"sv;
+  boost::system::error_code ec;
 
   do {
     result = parser_.Parse(io_buf_.InputBuffer(), &consumed, &parse_args);
@@ -840,7 +841,9 @@ void Driver::ParseRESP() {
           vector<string_view> addr_parts = absl::StrSplit(parts[1], ':');
           CHECK_EQ(2u, addr_parts.size());
 
-          auto host = ::boost::asio::ip::make_address(addr_parts[0]);
+          auto host = boost::asio::ip::make_address(addr_parts[0], ec);
+          CHECK(!ec) << "make_address failed with error:" << ec.message() << "while parsing address"
+                     << addr_parts[0];
 
           uint32_t port;
           CHECK(absl::SimpleAtoi(addr_parts[1], &port));


### PR DESCRIPTION
Sometimes when dfly_bench parses a response to extract host to connect to, it fails inside boost make_address. This error is thrown up the stack causing the program to fail without clear indication of what the error was. 

See example run https://github.com/dragonflydb/controlplane/actions/runs/17032489974/job/48277888480

Changed to use the `error_code` variant of `boost::asio::ip::make_address` to print the error with the address which failed to parse.
