### PR TITLE
fix: add sleep to deliver reply to replica for takeover

### DIFF
--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -540,6 +540,9 @@ void DflyCmd::TakeOver(CmdArgList args, RedisReplyBuilder* rb, ConnectionContext
 
   // For non-cluster mode we shutdown
   if (detail::cluster_mode != detail::ClusterMode::kRealCluster) {
+    // we don't have flush() mechanism for ReplyBuilder, so we wait a bit to be sure that reply was
+    // delivered to the replica. See https://github.com/dragonflydb/dragonfly/issues/5782
+    ThisFiber::SleepFor(1s);
     VLOG(1) << "Takeover accepted, shutting down.";
     std::string save_arg = "NOSAVE";
     MutableSlice sargs(save_arg);


### PR DESCRIPTION
fixes: https://github.com/dragonflydb/dragonfly/issues/5782
problem: we don't have enough time to deliver the reply for the takeover, because the socket was closed to fast
fix: added sleep before shutdown