### PR TITLE
feat: Debug sync point for testing

### DIFF
--- a/src/server/debug_sync_point.h
+++ b/src/server/debug_sync_point.h
@@ -1,0 +1,44 @@
+// Copyright 205, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include <absl/container/flat_hash_set.h>
+
+#include "util/fibers/synchronization.h"
+
+namespace dfly {
+
+#ifdef NDEBUG
+#define DEBUG_SYNC(n, f)
+#else
+#define DEBUG_SYNC(n, f)          \
+  {                               \
+    if (debug_sync_point.Find(n)) \
+      f();                        \
+  }
+#endif
+
+class DebugSyncPoint {
+ public:
+  void Add(std::string_view name) {
+    util::fb2::LockGuard lk(mu_);
+    sync_points_.emplace(name);
+  }
+
+  void Del(std::string_view name) {
+    util::fb2::LockGuard lk(mu_);
+    sync_points_.erase(name);
+  }
+
+  bool Find(std::string_view name) {
+    return sync_points_.find(name) != sync_points_.end();
+  }
+
+ private:
+  absl::flat_hash_set<std::string> sync_points_;
+  util::fb2::Mutex mu_;
+};
+
+inline DebugSyncPoint debug_sync_point;
+
+}  // namespace dfly

--- a/src/server/debugcmd.h
+++ b/src/server/debugcmd.h
@@ -30,6 +30,12 @@ class DebugCmd {
     std::optional<std::pair<uint32_t, uint32_t>> expire_ttl_range;
   };
 
+  enum SyncFlags { SYNC_ADD, SYNC_DEL };
+  struct SyncOptions {
+    std::string sync_point_name;
+    SyncFlags sync_action;
+  };
+
  public:
   DebugCmd(ServerFamily* owner, cluster::ClusterFamily* cf, ConnectionContext* cntx);
 
@@ -42,6 +48,10 @@ class DebugCmd {
   static std::optional<PopulateOptions> ParsePopulateArgs(CmdArgList args,
                                                           facade::SinkReplyBuilder* builder);
   void PopulateRangeFiber(uint64_t from, uint64_t count, const PopulateOptions& opts);
+
+  static std::optional<SyncOptions> ParseSyncArgs(CmdArgList args,
+                                                  facade::SinkReplyBuilder* builder);
+  void Sync(CmdArgList args, facade::SinkReplyBuilder* builder);
 
   void Reload(CmdArgList args, facade::SinkReplyBuilder* builder);
   void Replica(CmdArgList args, facade::SinkReplyBuilder* builder);

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -26,6 +26,7 @@
 #include "server/command_registry.h"
 #include "server/common.h"
 #include "server/conn_context.h"
+#include "server/debug_sync_point.h"
 #include "server/engine_shard_set.h"
 #include "server/error.h"
 #include "server/family_utils.h"
@@ -1178,6 +1179,9 @@ void StringFamily::SetNx(CmdArgList args, const CommandContext& cmnd_cntx) {
 void StringFamily::Get(CmdArgList args, const CommandContext& cmnd_cntx) {
   auto cb = [key = ArgS(args, 0)](Transaction* tx, EngineShard* es) -> OpResult<StringResult> {
     auto it_res = tx->GetDbSlice(es->shard_id()).FindReadOnly(tx->GetDbContext(), key, OBJ_STRING);
+
+    DEBUG_SYNC("return_get_key_not_found", [&]() { it_res = OpStatus::KEY_NOTFOUND; })
+
     if (!it_res.ok())
       return it_res.status();
 


### PR DESCRIPTION
It can be useful that we can control execution of process by adding specific debug sync point which will be executed when debug sync name is set.

For now this is only basic functionality, but in future we can add functionality for example - WAIT FOR until sync point is added.

Debug sync point works with different fibers so we can synchronize execution.

Added simple example how this can be done (this should be removed if merged).

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->