### PR TITLE
chore: Limit expiry value to 32 bits.

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -398,6 +398,8 @@ class DbSlice::PrimeBumpPolicy {
 DbSlice::DbSlice(uint32_t index, bool cache_mode, EngineShard* owner)
     : shard_id_(index),
       cache_mode_(cache_mode),
+      expire_allowed_(true),
+      expire_base_index_(0),
       owner_(owner),
       client_tracking_map_(owner->memory_resource()) {
   db_arr_.emplace_back();

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -252,11 +252,11 @@ class DbSlice {
   }
 
   int64_t ExpireTime(const ExpirePeriod& val) const {
-    return expire_base_[0] + val.duration_ms();
+    return expire_base_[val.generation_id()] + val.duration_ms();
   }
 
   ExpirePeriod FromAbsoluteTime(uint64_t time_ms) const {
-    return ExpirePeriod{time_ms - expire_base_[0]};
+    return ExpirePeriod{time_ms - expire_base_[expire_base_index_], expire_base_index_};
   }
 
   struct ItAndUpdater {
@@ -612,11 +612,11 @@ class DbSlice {
 
   ShardId shard_id_;
   uint8_t cache_mode_ : 1;
-
+  uint8_t expire_allowed_ : 1;
+  uint8_t expire_base_index_ : 1;
   EngineShard* owner_;
 
   int64_t expire_base_[2];  // Used for expire logic, represents a real clock.
-  bool expire_allowed_ = true;
 
   uint64_t version_ = 1;  // Used to version entries in the PrimeTable.
   uint64_t next_moved_id_ = 1;

--- a/src/server/engine_shard.h
+++ b/src/server/engine_shard.h
@@ -258,6 +258,7 @@ class EngineShard {
   // context of the controlling thread will access this shard!
   // --------------------------------------------------------------------------
   uint32_t DefragTask();
+  uint32_t UpdateExpiresTask();
 
   TxQueue txq_;
   TaskQueue queue_, queue2_;
@@ -284,7 +285,9 @@ class EngineShard {
   journal::Journal* journal_ = nullptr;
   IntentLock shard_lock_;
 
-  uint32_t defrag_task_ = 0;
+  // Idle tasks.
+  uint32_t defrag_task_ = 0, update_expire_base_task_ = 0;
+
   EvictionTaskState eviction_state_;  // Used on eviction fiber
   util::fb2::Fiber fiber_heartbeat_periodic_;
   util::fb2::Done fiber_heartbeat_periodic_done_;


### PR DESCRIPTION
We use adaptive precision, where we keep "millis" precision if we can, and switch to seconds precision if the deadline is too large.

This actually was before but now I reduced the cut-off to 4B ms, or 49 days. Also, the ttl in seconds is now limited to 4B sec, with larger values quietly rounded down to this limit.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->