### PR TITLE
fix: stale pointer reference during slot migration and flush

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1054,7 +1054,7 @@ OpResult<int64_t> DbSlice::UpdateExpire(const Context& cntx, Iterator prime_it,
     Del(cntx, prime_it);
     return -1;
   } else if (IsValid(expire_it) && !params.persist) {
-    auto current = ExpireTime(expire_it);
+    int64_t current = ExpireTime(expire_it->second);
     if (params.expire_options & ExpireFlags::EXPIRE_NX) {
       return OpStatus::SKIPPED;
     }
@@ -1181,9 +1181,10 @@ bool DbSlice::CheckLock(IntentLock::Mode mode, DbIndex dbid, uint64_t fp) const 
   return true;
 }
 
-void DbSlice::PreUpdateBlocking(DbIndex db_ind, Iterator it) {
-  CallChangeCallbacks(db_ind, ChangeReq{it.GetInnerIt()});
-  it.GetInnerIt().SetVersion(NextVersion());
+void DbSlice::PreUpdateBlocking(DbIndex db_ind, const Iterator& it) {
+  CallChangeCallbacks(db_ind, ChangeReq{it.GetInnerIt()});  // blocking point.
+  auto inner_it = it.GetInnerIt();                          // must call again to launder.
+  inner_it.SetVersion(NextVersion());
 }
 
 void DbSlice::PostUpdate(DbIndex db_ind, std::string_view key) {
@@ -1234,10 +1235,10 @@ DbSlice::PrimeItAndExp DbSlice::ExpireIfNeeded(const Context& cntx, PrimeIterato
   }
 
   // TODO: to employ multi-generation update of expire-base and the underlying values.
-  time_t expire_time = ExpireTime(expire_it);
+  int64_t expire_time = ExpireTime(expire_it->second);
 
   // Never do expiration on replica or if expiration is disabled or global lock was taken.
-  if (time_t(cntx.time_now_ms) < expire_time || owner_->IsReplica() || !expire_allowed_ ||
+  if (int64_t(cntx.time_now_ms) < expire_time || owner_->IsReplica() || !expire_allowed_ ||
       !shard_owner()->shard_lock()->Check(IntentLock::Mode::EXCLUSIVE)) {
     return {it, expire_it};
   }
@@ -1357,7 +1358,7 @@ auto DbSlice::DeleteExpiredStep(const Context& cntx, unsigned count) -> DeleteEx
       return;
 
     result.traversed++;
-    time_t ttl = ExpireTime(it) - cntx.time_now_ms;
+    int64_t ttl = ExpireTime(it->second) - cntx.time_now_ms;
     if (ttl <= 0) {
       auto prime_it = db.prime.Find(it->first);
       if (prime_it.is_done()) {  // A workaround for the case our tables are inconsistent.

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -428,7 +428,7 @@ ObjInfo InspectOp(ConnectionContext* cntx, string_view key) {
       ExpireIterator exp_it = exp_t->Find(it->first);
       CHECK(!exp_it.is_done());
 
-      time_t exp_time = db_slice.ExpireTime(exp_it);
+      time_t exp_time = db_slice.ExpireTime(exp_it->second);
       oinfo.ttl = exp_time - GetCurrentTimeMs();
       oinfo.has_sec_precision = exp_it->second.is_second_precision();
     }

--- a/src/server/journal/cmd_serializer.cc
+++ b/src/server/journal/cmd_serializer.cc
@@ -71,7 +71,7 @@ CmdSerializer::CmdSerializer(FlushSerialized cb, size_t max_serialization_buffer
   serializer_ = std::make_unique<RdbSerializer>(GetDefaultCompressionMode());
 }
 
-size_t CmdSerializer::SerializeEntry(string_view key, const PrimeValue& pk, const PrimeValue& pv,
+size_t CmdSerializer::SerializeEntry(string_view key, const PrimeKey& pk, const PrimeValue& pv,
                                      uint64_t expire_ms) {
   // We send RESTORE commands objects we don't support breaking.
   bool use_restore_serialization = true;
@@ -134,7 +134,7 @@ void CmdSerializer::SerializeCommand(string_view cmd, absl::Span<const string_vi
   cb_(std::move(cmd_sink).str());
 }
 
-void CmdSerializer::SerializeStickIfNeeded(string_view key, const PrimeValue& pk) {
+void CmdSerializer::SerializeStickIfNeeded(string_view key, const PrimeKey& pk) {
   if (!pk.IsSticky()) {
     return;
   }
@@ -231,7 +231,7 @@ size_t CmdSerializer::SerializeString(string_view key, const PrimeValue& pv, uin
   return 1;
 }
 
-void CmdSerializer::SerializeRestore(string_view key, const PrimeValue& pk, const PrimeValue& pv,
+void CmdSerializer::SerializeRestore(string_view key, const PrimeKey& pk, const PrimeValue& pv,
                                      uint64_t expire_ms) {
   absl::InlinedVector<string_view, 5> args;
   args.push_back(key);

--- a/src/server/journal/cmd_serializer.h
+++ b/src/server/journal/cmd_serializer.h
@@ -26,12 +26,12 @@ class CmdSerializer {
   explicit CmdSerializer(FlushSerialized cb, size_t max_serialization_buffer_size);
 
   // Returns how many commands we broke this entry into (like multiple HSETs etc)
-  size_t SerializeEntry(std::string_view key, const PrimeValue& pk, const PrimeValue& pv,
+  size_t SerializeEntry(std::string_view key, const PrimeKey& pk, const PrimeValue& pv,
                         uint64_t expire_ms);
 
  private:
   void SerializeCommand(std::string_view cmd, absl::Span<const std::string_view> args);
-  void SerializeStickIfNeeded(std::string_view key, const PrimeValue& pk);
+  void SerializeStickIfNeeded(std::string_view key, const PrimeKey& pk);
   void SerializeExpireIfNeeded(std::string_view key, uint64_t expire_ms);
 
   size_t SerializeSet(std::string_view key, const PrimeValue& pv);
@@ -39,7 +39,7 @@ class CmdSerializer {
   size_t SerializeHash(std::string_view key, const PrimeValue& pv);
   size_t SerializeList(std::string_view key, const PrimeValue& pv);
   size_t SerializeString(std::string_view key, const PrimeValue& pv, uint64_t expire_ms);
-  void SerializeRestore(std::string_view key, const PrimeValue& pk, const PrimeValue& pv,
+  void SerializeRestore(std::string_view key, const PrimeKey& pk, const PrimeValue& pv,
                         uint64_t expire_ms);
 
   FlushSerialized cb_;

--- a/src/server/journal/streamer.h
+++ b/src/server/journal/streamer.h
@@ -120,9 +120,9 @@ class RestoreStreamer : public JournalStreamer {
   bool ShouldWrite(SlotId slot_id) const;
 
   // Returns true if any entry was actually written
-  bool WriteBucket(PrimeTable::bucket_iterator it);
+  bool WriteBucket(PrimeTable::bucket_iterator it, const ExpireTable& expire_table);
 
-  void WriteEntry(std::string_view key, const PrimeValue& pk, const PrimeValue& pv,
+  void WriteEntry(std::string_view key, const PrimeKey& pk, const PrimeValue& pv,
                   uint64_t expire_ms);
 
   struct Stats {

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -322,7 +322,8 @@ void SliceSnapshot::SerializeEntry(DbIndex db_indx, const PrimeKey& pk, const Pr
   time_t expire_time = 0;
   if (pv.HasExpire()) {
     auto eit = db_array_[db_indx]->expire.Find(pk);
-    expire_time = db_slice_->ExpireTime(eit);
+    CHECK(IsValid(eit));
+    expire_time = db_slice_->ExpireTime(eit->second);
   }
   uint32_t mc_flags = pv.HasFlag() ? db_slice_->GetMCFlag(db_indx, pk) : 0;
 

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -227,7 +227,7 @@ OpResult<StringResult> OpGetRange(const OpArgs& op_args, string_view key, int32_
   }
   RETURN_ON_BAD_STATUS(it_res);
 
-  if (const CompactObj& co = it_res.value()->second; co.IsExternal()) {
+  if (const PrimeValue& co = it_res.value()->second; co.IsExternal()) {
     fb2::Future<io::Result<std::string>> fut;
     op_args.shard->tiered_storage()->Read(
         op_args.db_cntx.db_index, key, co,

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -600,7 +600,7 @@ PrimeValue TieredStorage::DeleteCool(detail::TieredColdRecord* record) {
   auto it = CoolQueue::s_iterator_to(*record);
   cool_queue_.erase(it);
 
-  PrimeValue hot = std::move(record->value);
+  PrimeValue hot{std::move(record->value)};
   stats_.cool_memory_used -= (sizeof(detail::TieredColdRecord) + hot.MallocUsed());
   CompactObj::DeleteMR<detail::TieredColdRecord>(record);
   return hot;

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -1286,8 +1286,7 @@ async def test_cluster_flushall_during_migration(
         df_factory.create(
             port=next(next_port),
             admin_port=next(next_port),
-            vmodule="cluster_family=2,outgoing_slot_migration=2,incoming_slot_migration=2,streamer=2",
-            logtostdout=True,
+            vmodule="cluster_family=2,outgoing_slot_migration=2,incoming_slot_migration=2,streamer=2,server_family=1",
         )
         for i in range(2)
     ]


### PR DESCRIPTION
Also, some code clean ups.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->