### PR TITLE
fix(tiering): Cooldown grow grow retries

### DIFF
--- a/src/server/tiering/disk_storage.h
+++ b/src/server/tiering/disk_storage.h
@@ -64,10 +64,11 @@ class DiskStorage {
   uint64_t heap_buf_alloc_cnt_ = 0, reg_buf_alloc_cnt_ = 0;
 
   struct {
-    bool pending = false;
+    bool pending = false;  // whether currently in progress
     std::error_code last_err;
-    util::fb2::EventCount ev;
-  } grow_;
+    uint64_t timestamp_ns;     // when last os finished (with any status)
+    util::fb2::EventCount ev;  // woken up when in-progress op finishes
+  } grow_;                     // status of latest blocking Grow() operation
 
   std::unique_ptr<util::fb2::LinuxFile> backing_file_;
   ExternalAllocator alloc_;


### PR DESCRIPTION
Whenever we run out of space, we're stuck in a loop that constantly tries to fallocate more space for the backing file. This makes it try at most every 100 milliseconds.

I still don't like this solution, because we go every time through the `TryStash()` -> `OpManager::Stash()` -> `DiskStorage::Stash()` -> `DiskStorage::TryGrow()` chain, creating temporary values, polluting stats, etc. Instead, disk storage should provide a `max_real_file_size` that indicates the maximum really "reachable" file size, so `TieredStorage::TryStash` would adjust accordingly. But we still want to keep an expansion mechanism, so once space is freed on the device, it would notice and start growing again. So we either try growing every nth time (which breaks time dependence) or... keep a background routine? 