### PR TITLE
chore: support huffman encoding for string values

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -366,6 +366,10 @@ struct TL {
   size_t small_str_bytes;
   Huffman huff_keys, huff_string_values;
   uint64_t huff_encode_total = 0, huff_encode_success = 0;  // success/total metrics.
+
+  const HuffmanDecoder& GetHuffmanDecoder(bool is_key) const {
+    return is_key ? huff_keys.decoder : huff_string_values.decoder;
+  }
 };
 
 thread_local TL tl;
@@ -606,10 +610,9 @@ int RobjWrapper::ZsetAdd(double score, std::string_view ele, int in_flags, int* 
     bool gt = (in_flags & ZADD_IN_GT) != 0;
     bool lt = (in_flags & ZADD_IN_LT) != 0;
 
-    unsigned char* eptr;
     uint8_t* lp = (uint8_t*)inner_obj_;
-
-    if ((eptr = ZzlFind(lp, ele, &curscore)) != NULL) {
+    uint8_t* eptr = ZzlFind(lp, ele, &curscore);
+    if (eptr != NULL) {
       /* NX? Return, same element already exists. */
       if (nx) {
         *out_flags |= ZADD_OUT_NOP;
@@ -774,8 +777,10 @@ CompactObj& CompactObj::operator=(CompactObj&& o) noexcept {
   SetMeta(o.taglen_, o.mask_);  // Frees underlying resources if needed.
   memcpy(&u_, &o.u_, sizeof(u_));
 
+  tagbyte_ = o.tagbyte_;
+
   // SetMeta deallocates the object and we only want reset it.
-  o.taglen_ = 0;
+  o.tagbyte_ = 0;
   o.mask_ = 0;
 
   return *this;
@@ -1012,7 +1017,7 @@ void CompactObj::SetString(std::string_view str, bool is_key) {
     }
   }
 
-  EncodeString(str);
+  EncodeString(str, is_key);
 }
 
 void CompactObj::ReserveString(size_t size) {
@@ -1141,7 +1146,8 @@ void CompactObj::GetString(char* dest) const {
         next += slices[0].size() - 1;
         memcpy(next, slices[1].data(), slices[1].size());
         string_view src(reinterpret_cast<const char*>(tl.tmp_buf.data()), tl.tmp_buf.size());
-        CHECK(tl.huff_keys.decoder.Decode(src, decoded_len, dest));
+        const auto& decoder = tl.GetHuffmanDecoder(is_key_);
+        CHECK(decoder.Decode(src, decoded_len, dest));
         return;
       }
 
@@ -1237,7 +1243,7 @@ void CompactObj::Materialize(std::string_view blob, bool is_raw) {
       u_.r_obj.SetString(blob, tl.local_mr);
     }
   } else {
-    EncodeString(blob);
+    EncodeString(blob, false);
   }
 }
 
@@ -1245,7 +1251,7 @@ void CompactObj::Reset() {
   if (HasAllocated()) {
     Free();
   }
-  taglen_ = 0;
+  tagbyte_ = 0;
   mask_ = 0;
 }
 
@@ -1355,7 +1361,8 @@ bool CompactObj::CmpEncoded(string_view sv) const {
       constexpr size_t kMaxHuffLen = kInlineLen * 3;
       if (sz <= kMaxHuffLen) {
         char buf[kMaxHuffLen];
-        CHECK(tl.huff_keys.decoder.Decode({u_.inline_str + 1, size_t(taglen_ - 1)}, sz, buf));
+        const auto& decoder = tl.GetHuffmanDecoder(is_key_);
+        CHECK(decoder.Decode({u_.inline_str + 1, size_t(taglen_ - 1)}, sz, buf));
         return sv == string_view(buf, sz);
       }
     }
@@ -1437,7 +1444,7 @@ bool CompactObj::CmpEncoded(string_view sv) const {
   return false;
 }
 
-void CompactObj::EncodeString(string_view str) {
+void CompactObj::EncodeString(string_view str, bool is_key) {
   DCHECK_GT(str.size(), kInlineLen);
   DCHECK_EQ(NONE_ENC, mask_bits_.encoding);
 
@@ -1447,6 +1454,7 @@ void CompactObj::EncodeString(string_view str) {
   // We chose such length that we can store the decoded length delta into 1 byte.
   // The maximum huffman compression is 1/8, so 288 / 8 = 36.
   // 288 - 36 = 252, which is smaller than 256.
+  // TODO: introduce variable length huffman length.
   constexpr unsigned kMaxHuffLen = 288;
 
   // For sizes 17, 18 we would like to test ascii encoding first as it's more efficient.
@@ -1455,34 +1463,38 @@ void CompactObj::EncodeString(string_view str) {
       kUseAsciiEncoding && str.size() < 19 && detail::validate_ascii_fast(str.data(), str.size());
 
   // if !is_ascii, we try huffman encoding next.
-  if (!is_ascii && str.size() <= kMaxHuffLen && tl.huff_keys.encoder.valid()) {
-    unsigned dest_len = tl.huff_keys.encoder.CompressedBound(str.size());
-    // 1 byte for storing the size delta.
-    tl.tmp_buf.resize(1 + dest_len);
-    string err_msg;
-    ++tl.huff_encode_total;
-    bool res = tl.huff_keys.encoder.Encode(str, tl.tmp_buf.data() + 1, &dest_len, &err_msg);
-    if (res) {
-      // we accept huffman encoding only if it is:
-      // 1. smaller than the original string by 20%
-      // 2. allows us to store the encoded string in the inline buffer
-      if (dest_len && (dest_len < kInlineLen || (dest_len + dest_len / 5) < str.size())) {
-        huff_encoded = true;
-        tl.huff_encode_success++;
-        encoded = string_view{reinterpret_cast<char*>(tl.tmp_buf.data()), dest_len + 1};
-        unsigned delta = str.size() - dest_len;
-        DCHECK_LT(delta, 256u);
-        tl.tmp_buf[0] = static_cast<uint8_t>(delta);
-        mask_bits_.encoding = HUFFMAN_ENC;
-        if (encoded.size() <= kInlineLen) {
-          SetMeta(encoded.size(), mask_);
-          memcpy(u_.inline_str, tl.tmp_buf.data(), encoded.size());
-          return;
+  if (!is_ascii && str.size() <= kMaxHuffLen) {
+    auto& huffman = is_key ? tl.huff_keys : tl.huff_string_values;
+    if (huffman.encoder.valid()) {
+      unsigned dest_len = huffman.encoder.CompressedBound(str.size());
+      // 1 byte for storing the size delta.
+      tl.tmp_buf.resize(1 + dest_len);
+      string err_msg;
+      ++tl.huff_encode_total;
+      bool res = huffman.encoder.Encode(str, tl.tmp_buf.data() + 1, &dest_len, &err_msg);
+      if (res) {
+        // we accept huffman encoding only if it is:
+        // 1. smaller than the original string by 20%
+        // 2. allows us to store the encoded string in the inline buffer
+        if (dest_len && (dest_len < kInlineLen || (dest_len + dest_len / 5) < str.size())) {
+          huff_encoded = true;
+          tl.huff_encode_success++;
+          encoded = string_view{reinterpret_cast<char*>(tl.tmp_buf.data()), dest_len + 1};
+          unsigned delta = str.size() - dest_len;
+          DCHECK_LT(delta, 256u);
+          tl.tmp_buf[0] = static_cast<uint8_t>(delta);
+          mask_bits_.encoding = HUFFMAN_ENC;
+          is_key_ = is_key;
+          if (encoded.size() <= kInlineLen) {
+            SetMeta(encoded.size(), mask_);
+            memcpy(u_.inline_str, tl.tmp_buf.data(), encoded.size());
+            return;
+          }
         }
+      } else {
+        // Should not happen, means we have an internal buf.
+        LOG(DFATAL) << "Failed to encode string with huffman: " << err_msg;
       }
-    } else {
-      // Should not happen, means we have an internal buf.
-      LOG(DFATAL) << "Failed to encode string with huffman: " << err_msg;
     }
   }
 
@@ -1609,9 +1621,11 @@ size_t CompactObj::StrEncoding::Decode(std::string_view blob, char* dest) const 
     case ASCII2_ENC:
       detail::ascii_unpack(reinterpret_cast<const uint8_t*>(blob.data()), decoded_len, dest);
       break;
-    case HUFFMAN_ENC:
-      tl.huff_keys.decoder.Decode(blob.substr(1), decoded_len, dest);
+    case HUFFMAN_ENC: {
+      const auto& decoder = tl.GetHuffmanDecoder(is_key_);
+      decoder.Decode(blob.substr(1), decoded_len, dest);
       break;
+    }
   };
   return decoded_len;
 }

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -431,7 +431,7 @@ class CompactObj {
   StringOrView GetRawString() const;
 
   StrEncoding GetStrEncoding() const {
-    return StrEncoding{mask_bits_.encoding, bool(is_key_)};
+    return StrEncoding{mask_bits_.encoding, bool(huffman_domain_)};
   }
 
   bool HasAllocated() const;
@@ -550,7 +550,7 @@ class CompactObj {
     uint8_t tagbyte_ = 0;
     struct {
       uint8_t taglen_ : 5;
-      uint8_t is_key_ : 1;
+      uint8_t huffman_domain_ : 1;  // value from HuffmanDomain enum.
       uint8_t reserved : 2;
     };
   };

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -135,7 +135,7 @@ class CompactObj {
     NONE_ENC = 0,
     ASCII1_ENC = 1,
     ASCII2_ENC = 2,
-    HUFFMAN_ENC = 3,  // TBD
+    HUFFMAN_ENC = 3,
   };
 
  public:
@@ -147,12 +147,14 @@ class CompactObj {
 
    private:
     friend class CompactObj;
-    explicit StrEncoding(uint8_t enc) : enc_(static_cast<EncodingEnum>(enc)) {
+    explicit StrEncoding(uint8_t enc, bool is_key)
+        : enc_(static_cast<EncodingEnum>(enc)), is_key_(is_key) {
     }
 
     size_t DecodedSize(size_t compr_size, uint8_t first_byte) const;
 
     EncodingEnum enc_;
+    bool is_key_;
   };
 
   using PrefixArray = std::vector<std::string_view>;
@@ -183,7 +185,7 @@ class CompactObj {
   CompactObj AsRef() const {
     CompactObj res;
     memcpy(&res.u_, &u_, sizeof(u_));
-    res.taglen_ = taglen_;
+    res.tagbyte_ = tagbyte_;
     res.mask_ = mask_;
     res.mask_bits_.ref = 1;
 
@@ -429,7 +431,7 @@ class CompactObj {
   StringOrView GetRawString() const;
 
   StrEncoding GetStrEncoding() const {
-    return StrEncoding{mask_bits_.encoding};
+    return StrEncoding{mask_bits_.encoding, bool(is_key_)};
   }
 
   bool HasAllocated() const;
@@ -441,7 +443,7 @@ class CompactObj {
   }
 
  private:
-  void EncodeString(std::string_view str);
+  void EncodeString(std::string_view str, bool is_key);
 
   bool EqualNonInline(std::string_view sv) const;
 
@@ -544,7 +546,14 @@ class CompactObj {
   };
 
   // We currently reserve 5 bits for tags and 3 bits for extending the mask. currently reserved.
-  uint8_t taglen_ = 0;
+  union {
+    uint8_t tagbyte_ = 0;
+    struct {
+      uint8_t taglen_ : 5;
+      uint8_t is_key_ : 1;
+      uint8_t reserved : 2;
+    };
+  };
 };
 
 inline bool CompactObj::operator==(std::string_view sv) const {

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -1436,6 +1436,7 @@ void DebugCmd::Compression(CmdArgList args, facade::SinkReplyBuilder* builder) {
         if (type != OBJ_STRING) {  // Currently only string type is supported.
           return builder->SendError(kSyntaxErr);
         }
+        domain = CompactObj::HUFF_STRING_VALUES;
       }
       shard_set->RunBriefInParallel([&](EngineShard* shard) {
         if (!CompactObj::InitHuffmanThreadLocal(domain, raw)) {

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -937,6 +937,22 @@ TEST_F(DflyEngineTest, CommandMetricLabels) {
   EXPECT_EQ(metrics.facade_stats.conn_stats.num_conns_other, 0);
 }
 
+TEST_F(DflyEngineTest, Huffman) {
+  // enable compression for keys optimized for letter a.
+  auto resp = Run({"debug", "compression", "set", "GBDgCpXW/////7/pygS5t9x7792qU1trLQ=="});
+  EXPECT_EQ(resp, "OK");
+
+  // for string values optimized for letter x.
+  resp = Run({"debug", "compression", "set", "ChD4bAf/D/bPSwY=", "string"});
+  EXPECT_EQ(resp, "OK");
+  resp = Run({"debug", "populate", "200000", "aaaaaaaaaaaaaaaaaaaaaaaaaa", "32"});
+  EXPECT_EQ(resp, "OK");
+
+  auto metrics = GetMetrics();
+  EXPECT_EQ(metrics.events.huff_encode_success, 400000);  // each key and value
+  EXPECT_LT(metrics.heap_used_bytes, 14'000'000);         // less than 15mb
+}
+
 class DflyCommandAliasTest : public DflyEngineTest {
  protected:
   DflyCommandAliasTest() {


### PR DESCRIPTION
1. Differrentiate huffman encoding for strings and values.
2. Fix "debug compression" to set huffman table for both domains.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->