### PR TITLE
fix(server): Use correct messages for sharded pubsub

### DIFF
--- a/src/facade/command_id.h
+++ b/src/facade/command_id.h
@@ -88,21 +88,6 @@ class CommandId {
     opt_mask_ |= flag;
   }
 
-  // PUBLISH/SUBSCRIBE/UNSUBSCRIBE variant
-  bool IsPubSub() const {
-    return is_pub_sub_;
-  }
-
-  // PSUBSCRIBE/PUNSUBSCRIBE variant
-  bool IsPSub() const {
-    return is_p_pub_sub_;
-  }
-
-  // SSUBSCRIBE/SUNSUBSCRIBE variant
-  bool IsShardedPSub() const {
-    return is_sharded_pub_sub_;
-  }
-
  protected:
   std::string name_;
 
@@ -119,10 +104,6 @@ class CommandId {
 
   // Whether the command can only be used by admin connections.
   bool restricted_ = false;
-
-  bool is_pub_sub_ = false;
-  bool is_sharded_pub_sub_ = false;
-  bool is_p_pub_sub_ = false;
 };
 
 }  // namespace facade

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -529,10 +529,9 @@ void Connection::AsyncOperations::operator()(const PubMessage& pub_msg) {
       !base::_in(pub_msg.channel, {"unsubscribe", "punsubscribe"}))
     return;
 
-  // TODO: sharded? unclear to me
-  if (pub_msg.should_unsubscribe) {
+  if (pub_msg.force_unsubscribe) {
     rb->StartCollection(3, RedisReplyBuilder::CollectionType::PUSH);
-    rb->SendBulkString("unsubscribe");
+    rb->SendBulkString("sunsubscribe");
     rb->SendBulkString(pub_msg.channel);
     rb->SendLong(0);
     self->cntx()->Unsubscribe(pub_msg.channel);

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -542,7 +542,7 @@ void Connection::AsyncOperations::operator()(const PubMessage& pub_msg) {
   unsigned i = 0;
   array<string_view, 4> arr;
   if (pub_msg.pattern.empty()) {
-    arr[i++] = pub_msg.is_sharded ? "message" : "smessage";
+    arr[i++] = pub_msg.is_sharded ? "smessage" : "message";
   } else {
     arr[i++] = "pmessage";
     arr[i++] = pub_msg.pattern;

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -73,7 +73,8 @@ class Connection : public util::Connection {
     std::string pattern;                // non-empty for pattern subscriber
     std::shared_ptr<char[]> buf;        // stores channel name and message
     std::string_view channel, message;  // channel and message parts from buf
-    bool should_unsubscribe = false;    // unsubscribe from channel after sending the message
+    bool is_sharded = false;
+    bool should_unsubscribe = false;  // unsubscribe from channel after sending the message
   };
 
   // Pipeline message, accumulated Redis command to be executed.

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -74,7 +74,9 @@ class Connection : public util::Connection {
     std::shared_ptr<char[]> buf;        // stores channel name and message
     std::string_view channel, message;  // channel and message parts from buf
     bool is_sharded = false;
-    bool should_unsubscribe = false;  // unsubscribe from channel after sending the message
+
+    // Unsubscribe simultaneously when sending unsubscribe message. Used for cluster migrations
+    bool force_unsubscribe = false;
   };
 
   // Pipeline message, accumulated Redis command to be executed.

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -138,13 +138,6 @@ CommandId::CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first
       first_key_(first_key),
       last_key_(last_key),
       acl_categories_(acl_categories) {
-  if (name_ == "PUBLISH" || name_ == "SUBSCRIBE" || name_ == "UNSUBSCRIBE") {
-    is_pub_sub_ = true;
-  } else if (name_ == "PSUBSCRIBE" || name_ == "PUNSUBSCRIBE") {
-    is_p_pub_sub_ = true;
-  } else if (name_ == "SPUBLISH" || name_ == "SSUBSCRIBE" || name_ == "SUNSUBSCRIBE") {
-    is_sharded_pub_sub_ = true;
-  }
 }
 
 static bool ParseHumanReadableBytes(std::string_view str, int64_t* num_bytes) {

--- a/src/server/acl/validator.cc
+++ b/src/server/acl/validator.cc
@@ -78,10 +78,10 @@ bool ValidateCommand(const std::vector<uint64_t>& acl_commands, const CommandId&
 
   std::pair<bool, AclLog::Reason> auth_res;
 
-  if (id.IsPubSub() || id.IsShardedPSub()) {
-    auth_res = IsPubSubCommandAuthorized(false, cntx.acl_commands, cntx.pub_sub, tail_args, id);
-  } else if (id.IsPSub()) {
-    auth_res = IsPubSubCommandAuthorized(true, cntx.acl_commands, cntx.pub_sub, tail_args, id);
+  if (auto pkind = id.PubSubKind(); pkind) {
+    bool is_pattern = *pkind == CO::PubSubKind::PATTERN;
+    auth_res =
+        IsPubSubCommandAuthorized(is_pattern, cntx.acl_commands, cntx.pub_sub, tail_args, id);
   } else {
     auth_res = IsUserAllowedToInvokeCommandGeneric(cntx, id, tail_args);
   }

--- a/src/server/channel_store.cc
+++ b/src/server/channel_store.cc
@@ -37,12 +37,12 @@ auto BuildSender(string_view channel, facade::ArgRange messages, bool sharded = 
     }
   }
 
-  return [channel, buf = std::move(buf), views = std::move(views), unsubscribe, sharded](
+  return [channel, buf = std::move(buf), views = std::move(views), sharded, unsubscribe](
              facade::Connection* conn, string pattern) {
     string_view channel_view{buf.get(), channel.size()};
     for (std::string_view message_view : views) {
       conn->SendPubMessageAsync(
-          {std::move(pattern), buf, channel_view, message_view, unsubscribe, sharded});
+          {std::move(pattern), buf, channel_view, message_view, sharded, unsubscribe});
     }
   };
 }

--- a/src/server/channel_store.cc
+++ b/src/server/channel_store.cc
@@ -220,13 +220,14 @@ void ChannelStore::UnsubscribeAfterClusterSlotMigration(const cluster::SlotSet& 
   csu.ApplyAndUnsubscribe();
 }
 
+// TODO: Reuse common code with Send function
+// TODO: Find proper solution to hacky `force_unsubscribe` flag or at least move logic out of io
 void ChannelStore::UnsubscribeConnectionsFromDeletedSlots(const ChannelsSubMap& sub_map,
                                                           uint32_t idx) {
-  const bool should_unsubscribe = true;
   for (const auto& [channel, subscribers] : sub_map) {
     // ignored by pub sub handler because should_unsubscribe is true
     std::string msg = "__ignore__";
-    auto send = BuildSender(channel, {facade::ArgSlice{msg}}, false, should_unsubscribe);
+    auto send = BuildSender(channel, {facade::ArgSlice{msg}}, false, true);
 
     auto it = lower_bound(subscribers.begin(), subscribers.end(), idx,
                           ChannelStore::Subscriber::ByThreadId);

--- a/src/server/channel_store.h
+++ b/src/server/channel_store.h
@@ -59,7 +59,7 @@ class ChannelStore {
   ChannelStore();
 
   // Send messages to channel, block on connection backpressure
-  unsigned SendMessages(std::string_view channel, facade::ArgRange messages) const;
+  unsigned SendMessages(std::string_view channel, facade::ArgRange messages, bool sharded) const;
 
   // Fetch all subscribers for channel, including matching patterns.
   std::vector<Subscriber> FetchSubscribers(std::string_view channel) const;

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -310,7 +310,7 @@ class ConnectionContext : public facade::ConnectionContext {
     return conn_state.db_index;
   }
 
-  void ChangeSubscription(bool to_add, bool to_reply, CmdArgList args,
+  void ChangeSubscription(bool to_add, bool to_reply, bool sharded, CmdArgList args,
                           facade::RedisReplyBuilder* rb);
 
   void ChangePSubscription(bool to_add, bool to_reply, CmdArgList args,

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1398,7 +1398,7 @@ auto DbSlice::DeleteExpiredStep(const Context& cntx, unsigned count) -> DeleteEx
   // Send and clear accumulated expired key events
   if (auto& events = db_arr_[cntx.db_index]->expired_keys_events_; !events.empty()) {
     ChannelStore* store = ServerState::tlocal()->channel_store();
-    store->SendMessages(absl::StrCat("__keyevent@", cntx.db_index, "__:expired"), events);
+    store->SendMessages(absl::StrCat("__keyevent@", cntx.db_index, "__:expired"), events, false);
     events.clear();
   }
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1713,14 +1713,14 @@ DispatchManyResult Service::DispatchManyCommands(absl::Span<CmdArgList> args_lis
     // MULTI...EXEC commands need to be collected into a single context, so squashing is not
     // possible
     const bool is_multi = dfly_cntx->conn_state.exec_info.IsCollecting() ||
-                          cid->MultiControlKind() == CO::MultiControlKind::EXEC;
+                          (cid != nullptr && cid->MultiControlKind() == CO::MultiControlKind::EXEC);
 
     // Generally, executing any multi-transactions (including eval) is not possible because they
     // might request a stricter multi mode than non-atomic which is used for squashing.
     // TODO: By allowing promoting non-atomic multit transactions to lock-ahead for specific command
     // invocations, we can potentially execute multiple eval in parallel, which is very powerful
     // paired with shardlocal eval
-    const bool is_eval = cid->MultiControlKind() == CO::MultiControlKind::EVAL;
+    const bool is_eval = cid != nullptr && cid->MultiControlKind() == CO::MultiControlKind::EVAL;
     const bool is_blocking = cid != nullptr && cid->IsBlocking();
 
     if (!is_multi && !is_eval && !is_blocking && cid != nullptr) {

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -140,11 +140,8 @@ class Service : public facade::ServiceInterface {
   void EvalShaRo(CmdArgList args, const CommandContext& cmd_cntx);
   void Exec(CmdArgList args, const CommandContext& cmd_cntx);
   void Publish(CmdArgList args, const CommandContext& cmd_cntx);
-  void SPublish(CmdArgList args, const CommandContext& cmd_cntx);
   void Subscribe(CmdArgList args, const CommandContext& cmd_cntx);
-  void SSubscribe(CmdArgList args, const CommandContext& cmd_cntx);
   void Unsubscribe(CmdArgList args, const CommandContext& cmd_cntx);
-  void SUnsubscribe(CmdArgList args, const CommandContext& cmd_cntx);
   void PSubscribe(CmdArgList args, const CommandContext& cmd_cntx);
   void PUnsubscribe(CmdArgList args, const CommandContext& cmd_cntx);
   void Function(CmdArgList args, const CommandContext& cmd_cntx);

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -3068,16 +3068,16 @@ async def test_cluster_sharded_pub_sub(df_factory: DflyInstanceFactory):
 
     # Consume subscription message result from above
     message = consumer.get_sharded_message(target_node=node_a)
-    assert message == {"type": "subscribe", "pattern": None, "channel": b"kostas", "data": 1}
+    assert message == {"type": "ssubscribe", "pattern": None, "channel": b"kostas", "data": 1}
 
     message = consumer.get_sharded_message(target_node=node_a)
-    assert message == {"type": "message", "pattern": None, "channel": b"kostas", "data": b"hello"}
+    assert message == {"type": "smessage", "pattern": None, "channel": b"kostas", "data": b"hello"}
 
     consumer.sunsubscribe("kostas")
     await asyncio.sleep(2)
     await c_nodes[0].execute_command("SPUBLISH kostas new_message")
     message = consumer.get_sharded_message(target_node=node_a)
-    assert message == {"type": "unsubscribe", "pattern": None, "channel": b"kostas", "data": 0}
+    assert message == {"type": "sunsubscribe", "pattern": None, "channel": b"kostas", "data": 0}
 
 
 @dfly_args({"proactor_threads": 2, "cluster_mode": "yes"})
@@ -3209,9 +3209,9 @@ async def test_cluster_sharded_pub_sub_migration(df_factory: DflyInstanceFactory
 
     # Consume subscription message result from above
     message = consumer.get_sharded_message(target_node=node_a)
-    assert message == {"type": "subscribe", "pattern": None, "channel": b"kostas", "data": 1}
+    assert message == {"type": "ssubscribe", "pattern": None, "channel": b"kostas", "data": 1}
     message = consumer.get_sharded_message(target_node=node_a)
-    assert message == {"type": "unsubscribe", "pattern": None, "channel": b"kostas", "data": 0}
+    assert message == {"type": "sunsubscribe", "pattern": None, "channel": b"kostas", "data": 0}
 
 
 @dfly_args({"proactor_threads": 4, "cluster_mode": "yes"})


### PR DESCRIPTION
* Refactor CommandId/CommanRegistry to unifromly determine the command "kind" and expose it via limited interface. Previously we used different approaches up to the authors liking
* Introduce `is_sharded` field to `PubMessage` to choose between "message" and "smessage" when replying
* Add simple "pubsub" test in cluster_family_test (not best place, but there was one before it 🤷🏻‍♂️ )

Fixes #5738 