### PR TITLE
chore: skip arguments when logging failed auth cmd

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -723,8 +723,10 @@ string FailedCommandToString(std::string_view command, facade::CmdArgList args,
   string result;
   absl::StrAppend(&result, " ", command);
 
-  for (auto arg : args) {
-    absl::StrAppend(&result, " ", absl::CHexEscape(arg));
+  if (command != "AUTH") {
+    for (auto arg : args) {
+      absl::StrAppend(&result, " ", absl::CHexEscape(arg));
+    }
   }
 
   absl::StrAppend(&result, " failed with reason: ", reason);


### PR DESCRIPTION
We should not log the arguments for AUTH commands

fixes #5808