### PR TITLE
fix(server): Support FLUSH(ALL) SYNC

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -902,7 +902,7 @@ util::fb2::JoinHandle DbSlice::FlushDbIndexes(const std::vector<DbIndex>& indexe
   DbTableArray flush_db_arr(db_arr_.size());
 
   for (DbIndex index : indexes) {
-    if (!index) {
+    if (index == 0) {  // TODO: Async dealloc?
       owner_->search_indices()->DropAllIndices();
     }
 

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -893,7 +893,7 @@ void DbSlice::FlushSlots(const cluster::SlotRanges& slot_ranges) {
   }).Detach();
 }
 
-util::fb2::JoinHandle DbSlice::FlushDbIndexes(const std::vector<DbIndex>& indexes) {
+util::fb2::Fiber DbSlice::FlushDbIndexes(const std::vector<DbIndex>& indexes) {
   bool clear_tiered = owner_->tiered_storage() != nullptr;
 
   if (clear_tiered)
@@ -925,10 +925,10 @@ util::fb2::JoinHandle DbSlice::FlushDbIndexes(const std::vector<DbIndex>& indexe
                                           ServerState::kGlibcmalloc);
   };
 
-  return fb2::Fiber("flush_dbs", std::move(cb)).Detach();
+  return {"flush_dbs", std::move(cb)};
 }
 
-util::fb2::JoinHandle DbSlice::FlushDb(DbIndex db_ind) {
+util::fb2::Fiber DbSlice::FlushDb(DbIndex db_ind) {
   DVLOG(1) << "Flushing db " << db_ind;
 
   // clear client tracking map.

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -331,7 +331,7 @@ class DbSlice {
   constexpr static DbIndex kDbAll = 0xFFFF;
 
   // Flushes db_ind or all databases if kDbAll is passed
-  void FlushDb(DbIndex db_ind);
+  util::fb2::JoinHandle FlushDb(DbIndex db_ind);
 
   // Flushes the data of given slot ranges.
   void FlushSlots(const cluster::SlotRanges& slot_ranges);
@@ -551,7 +551,7 @@ class DbSlice {
                                              bool force_update);
 
   void FlushSlotsFb(const cluster::SlotSet& slot_ids);
-  void FlushDbIndexes(const std::vector<DbIndex>& indexes);
+  util::fb2::JoinHandle FlushDbIndexes(const std::vector<DbIndex>& indexes);
 
   // Invalidate all watched keys in database. Used on FLUSH.
   void InvalidateDbWatches(DbIndex db_indx);

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -331,7 +331,7 @@ class DbSlice {
   constexpr static DbIndex kDbAll = 0xFFFF;
 
   // Flushes db_ind or all databases if kDbAll is passed
-  util::fb2::JoinHandle FlushDb(DbIndex db_ind);
+  util::fb2::Fiber FlushDb(DbIndex db_ind);
 
   // Flushes the data of given slot ranges.
   void FlushSlots(const cluster::SlotRanges& slot_ranges);
@@ -551,7 +551,7 @@ class DbSlice {
                                              bool force_update);
 
   void FlushSlotsFb(const cluster::SlotSet& slot_ids);
-  util::fb2::JoinHandle FlushDbIndexes(const std::vector<DbIndex>& indexes);
+  util::fb2::Fiber FlushDbIndexes(const std::vector<DbIndex>& indexes);
 
   // Invalidate all watched keys in database. Used on FLUSH.
   void InvalidateDbWatches(DbIndex db_indx);

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -250,7 +250,8 @@ class ServerFamily {
 
   // Burns down and destroy all the data from the database.
   // if kDbAll is passed, burns all the databases to the ground.
-  std::vector<util::fb2::JoinHandle> Drakarys(Transaction* transaction, DbIndex db_ind);
+  // `wait` makes it wait for all fibers to finish and decommit
+  void Drakarys(Transaction* transaction, DbIndex db_ind, bool wait);
 
   SaveInfoData GetLastSaveInfo() const;
 

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -250,7 +250,7 @@ class ServerFamily {
 
   // Burns down and destroy all the data from the database.
   // if kDbAll is passed, burns all the databases to the ground.
-  std::error_code Drakarys(Transaction* transaction, DbIndex db_ind);
+  std::vector<util::fb2::JoinHandle> Drakarys(Transaction* transaction, DbIndex db_ind);
 
   SaveInfoData GetLastSaveInfo() const;
 
@@ -344,7 +344,6 @@ class ServerFamily {
   void Dfly(CmdArgList args, const CommandContext& cmd_cntx);
   void Memory(CmdArgList args, const CommandContext& cmd_cntx);
   void FlushDb(CmdArgList args, const CommandContext& cmd_cntx);
-  void FlushAll(CmdArgList args, const CommandContext& cmd_cntx);
   void Info(CmdArgList args, const CommandContext& cmd_cntx) ABSL_LOCKS_EXCLUDED(replicaof_mu_);
   void Hello(CmdArgList args, const CommandContext& cmd_cntx);
   void LastSave(CmdArgList args, const CommandContext& cmd_cntx);


### PR DESCRIPTION
Add SYNC option to FLUSHDB and FLUSHALL. SYNC doens't block other commands, it just waits for the flush to finish. The pytest asserts that immediately after FLUSHALL SYNC we have free RSS memory

Fixes https://github.com/dragonflydb/dragonfly/issues/5581