### PR TITLE
ci: Allow overriding log level for modules when repeating tests

### DIFF
--- a/.github/actions/repeat/action.yml
+++ b/.github/actions/repeat/action.yml
@@ -32,6 +32,9 @@ inputs:
   epoll:
     required: true
     type: string
+  vmodule_expression:
+    required: true
+    type: string
 
 runs:
   using: "composite"
@@ -52,8 +55,13 @@ runs:
         else
           FORCE_EPOLL=""
         fi
-        echo Running command: timeout ${{ inputs.timeout }} pytest ${{ inputs.expression }} --drop-data-after-each-test ${FORCE_EPOLL} --color=yes --json-report --json-report-file=report.json --log-cli-level=DEBUG --count=${{ inputs.count }}
-        timeout ${{ inputs.timeout }} pytest ${{ inputs.expression }} --drop-data-after-each-test ${FORCE_EPOLL} --color=yes --json-report --json-report-file=report.json --log-cli-level=DEBUG --count=${{ inputs.count }} || code=$?
+        if [[ $"{{ inputs.vmodule_expression }}" != "" ]]; then
+          VMOD="--df vmodule=${{ inputs.vmodule_expression }}"
+        else
+          VMOD=""
+        fi
+        echo Running command: timeout ${{ inputs.timeout }} pytest ${{ inputs.expression }} --drop-data-after-each-test ${FORCE_EPOLL} ${VMOD} --color=yes --json-report --json-report-file=report.json --log-cli-level=DEBUG --count=${{ inputs.count }}
+        timeout ${{ inputs.timeout }} pytest ${{ inputs.expression }} --drop-data-after-each-test ${FORCE_EPOLL} ${VMOD} --color=yes --json-report --json-report-file=report.json --log-cli-level=DEBUG --count=${{ inputs.count }} || code=$?
         # timeout returns 124 if we exceeded the timeout duration
         if [[ $code -eq 124 ]]; then
           # Add an extra new line here because when tests timeout the first line below continues from the test failure name

--- a/.github/workflows/repeat-tests.yml
+++ b/.github/workflows/repeat-tests.yml
@@ -31,6 +31,11 @@ on:
         required: false
         type: string
         default: "no"
+      vmodule_expression:
+        description: "Emit verbose dragonfly logs for modules, eg x=2,y=3"
+        required: false
+        type: string
+        default: ""
 
 jobs:
   build:
@@ -61,25 +66,28 @@ jobs:
           ulimit -a
           env
 
+      - name: Fetch release
+        shell: bash
+        if: ${{ inputs.use_release == 'yes' }}
+        run: |
+          mkdir "${GITHUB_WORKSPACE}"/build
+          cd "${GITHUB_WORKSPACE}"/build
+          wget -q https://github.com/dragonflydb/dragonfly/releases/latest/download/dragonfly-x86_64.tar.gz
+          tar xf dragonfly-x86_64.tar.gz
+          mv dragonfly-x86_64 dragonfly
+          ls -l
+
       - name: Configure & Build
         shell: bash
+        if: ${{ inputs.use_release != 'yes' }}
         run: |
-          if [[ "${{ inputs.use_release }}" == "yes" ]]; then
-            mkdir "${GITHUB_WORKSPACE}"/build
-            cd "${GITHUB_WORKSPACE}"/build
-            wget -q https://github.com/dragonflydb/dragonfly/releases/latest/download/dragonfly-x86_64.tar.gz
-            tar xf dragonfly-x86_64.tar.gz
-            mv dragonfly-x86_64 dragonfly
-            ls -l
-          else
-            # -no-pie to disable address randomization so we could symbolize stacktraces
-            cmake -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -GNinja \
-                  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DPRINT_STACKTRACES_ON_SIGNAL=ON \
-                  -DCMAKE_CXX_FLAGS=-no-pie -DHELIO_STACK_CHECK:STRING=4096
-            cd ${GITHUB_WORKSPACE}/build  && ninja dragonfly
-            pwd
-            ls -l ..
-          fi
+          # -no-pie to disable address randomization so we could symbolize stacktraces
+          cmake -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -GNinja \
+                -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DPRINT_STACKTRACES_ON_SIGNAL=ON \
+                -DCMAKE_CXX_FLAGS=-no-pie -DHELIO_STACK_CHECK:STRING=4096
+          cd ${GITHUB_WORKSPACE}/build  && ninja dragonfly
+          pwd
+          ls -l ..
 
       - name: Run tests on repeat
         uses: ./.github/actions/repeat
@@ -94,6 +102,7 @@ jobs:
           count: ${{ inputs.count }}
           timeout: ${{ inputs.timeout }}
           epoll: ${{ inputs.epoll }}
+          vmodule_expression: ${{ inputs.vmodule_expression }}
 
       - name: Upload logs on failure
         if: failure()


### PR DESCRIPTION
Allows setting vmodule level for tests, eg:

```
gh workflow run "Repeat Tests" --ref abhijat/feat/vmodule-on-repeat-tests -f branch=abhijat/feat/vmodule-on-repeat-tests -f count=500 -f expression="-xv dragonfly -k test_client_kill" -f timeout=300m -f epoll=epoll -f vmodule_expression="server_family=2,dragonfly_connection=2,listener_interface=2"
```

note `-f vmodule_expression="server_family=2,dragonfly_connection=2,listener_interface=2"`

Also clean up to use `if` expression suggested in https://github.com/dragonflydb/dragonfly/pull/5805#discussion_r2349348492