### PR TITLE
feat(search): FT.SEARCH FILTER option

### DIFF
--- a/src/core/search/base.h
+++ b/src/core/search/base.h
@@ -38,6 +38,19 @@ struct QueryParams {
   absl::flat_hash_map<std::string, std::string> params;
 };
 
+// Base class for optional search filters
+
+class AstNode;
+
+struct OptionalFilterBase {
+  virtual bool IsEmpty() const = 0;
+  virtual AstNode Node(std::string field) = 0;
+  virtual ~OptionalFilterBase() = default;
+};
+
+using OptionalFilters =
+    absl::flat_hash_map<std::string /*field*/, std::unique_ptr<OptionalFilterBase> /* filter */>;
+
 // Values are either sortable as doubles or strings, or not sortable at all.
 using SortableValue = std::variant<std::monostate, double, std::string>;
 

--- a/src/core/search/query_driver.cc
+++ b/src/core/search/query_driver.cc
@@ -22,6 +22,14 @@ void QueryDriver::Error(const Parser::location_type& loc, std::string_view msg) 
   VLOG(1) << "Parse error " << loc << ": " << msg;
 }
 
+void QueryDriver::SetOptionalFilters(const OptionalFilters* filters) {
+  if (filters) {
+    for (auto& [field, filter] : *filters) {
+      expr_ = AstLogicalNode(std::move(expr_), filter->Node(field), AstLogicalNode::AND);
+    }
+  }
+}
+
 }  // namespace search
 
 }  // namespace dfly

--- a/src/core/search/query_driver.h
+++ b/src/core/search/query_driver.h
@@ -30,6 +30,8 @@ class QueryDriver {
     scanner_->SetParams(params);
   }
 
+  void SetOptionalFilters(const OptionalFilters* filters);
+
   Parser::symbol_type Lex() {
     return scanner()->Lex();
   }

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -24,6 +24,35 @@ namespace dfly::search {
 struct AstNode;
 struct TextIndex;
 
+// Optional FILTER
+struct OptionalNumericFilter : public OptionalFilterBase {
+  OptionalNumericFilter(size_t lo, size_t hi) : empty_(false), lo_(lo), hi_(hi) {
+  }
+
+  bool IsEmpty() const override {
+    return empty_;
+  }
+
+  AstNode Node(std::string field) override;
+
+  void AddRange(size_t lo, size_t hi) {
+    if (empty_) {
+      return;
+    }
+    if ((hi_ < lo) || (hi < lo_)) {
+      empty_ = true;
+    } else {
+      lo_ = std::max(lo_, lo);
+      hi_ = std::min(hi_, hi);
+    }
+  }
+
+ private:
+  bool empty_;
+  size_t lo_;
+  size_t hi_;
+};
+
 // Describes a specific index field
 struct SchemaField {
   enum FieldType { TAG, TEXT, NUMERIC, VECTOR };
@@ -164,8 +193,9 @@ class SearchAlgorithm {
   SearchAlgorithm();
   ~SearchAlgorithm();
 
-  // Init with query and return true if successful.
-  bool Init(std::string_view query, const QueryParams* params);
+  // Init with query and optional filters and return true if successful.
+  bool Init(std::string_view query, const QueryParams* params,
+            const OptionalFilters* filters = nullptr);
 
   SearchResult Search(const FieldIndices* index) const;
 

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -113,6 +113,9 @@ struct SearchParams {
   std::optional<std::vector<FieldReference>> load_fields;
 
   std::optional<SortOption> sort_option;
+
+  search::OptionalFilters optional_filters;
+
   search::QueryParams query_params;
 
   bool ShouldReturnAllFields() const {


### PR DESCRIPTION
Even it is deprecated FILTER can still be used as part of FT.SEARCH
command. Add support for it by reconstruction of AST tree.
    
Closes #5822

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->