### PR TITLE
Allow snapshotting on master only

### DIFF
--- a/src/server/detail/save_stages_controller.cc
+++ b/src/server/detail/save_stages_controller.cc
@@ -15,6 +15,7 @@
 #include "server/main_service.h"
 #include "server/namespaces.h"
 #include "server/script_mgr.h"
+#include "server/server_family.h"
 #include "server/transaction.h"
 #include "strings/human_readable.h"
 
@@ -179,6 +180,11 @@ SaveStagesController::~SaveStagesController() {
 }
 
 std::optional<SaveInfo> SaveStagesController::Init() {
+  if (absl::GetFlag(FLAGS_master_only_snapshot) && !service_->server_family()->IsMaster()) {
+    VLOG(1) << "Skipping snapshot on replica";
+    return SaveInfo{};
+  }
+
   if (auto err = BuildFullPath(); err) {
     shared_err_ = err;
     return GetSaveInfo();

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -4058,4 +4058,9 @@ void ServerFamily::Register(CommandRegistry* registry) {
       << CI{"MODULE", CO::ADMIN, 2, 0, 0, acl::kModule}.HFUNC(Module);
 }
 
+bool ServerFamily::IsMaster() const {
+  fb2::LockGuard lk(replicaof_mu_);
+  return !replica_;
+}
+
 }  // namespace dfly

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -310,6 +310,8 @@ class ServerFamily {
 
   void UpdateMemoryGlobalStats();
 
+  bool IsMaster() const;
+
   // Return true if no replicas are registered or if all replicas reached stable sync
   // Used in debug populate to DCHECK insocsistent flows that violate transaction gurantees
   bool AreAllReplicasInStableSync() const {

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -22,6 +22,7 @@
 
 ABSL_FLAG(bool, point_in_time_snapshot, true, "If true replication uses point in time snapshoting");
 ABSL_FLAG(bool, background_snapshotting, false, "Whether to run snapshot as a background fiber");
+ABSL_FLAG(bool, master_only_snapshot, false, "If true, allows snapshotting on master only");
 
 namespace dfly {
 


### PR DESCRIPTION
Introduce a `master_only_snapshot` flag that skips snapshotting on replicas if set to true