### PR TITLE
cmake: Optionally download prometheus binary as part of cmake config step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
             -DCMAKE_CXX_FLAGS="${{matrix.cxx_flags}}" -DWITH_AWS:BOOL=OFF \
             -DWITH_ASAN="${ASAN}" \
             -DWITH_USAN="${USAN}" \
+            -DUSE_PROMETHEUS=ON \
             -L
 
           cd ${GITHUB_WORKSPACE}/build && pwd

--- a/.github/workflows/epoll-regression-tests.yml
+++ b/.github/workflows/epoll-regression-tests.yml
@@ -39,7 +39,7 @@ jobs:
           # -no-pie to disable address randomization so we could symbolize stacktraces
           cmake -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -GNinja \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DPRINT_STACKTRACES_ON_SIGNAL=ON \
-                -DCMAKE_CXX_FLAGS=-no-pie -DHELIO_STACK_CHECK:STRING=4096
+                -DCMAKE_CXX_FLAGS=-no-pie -DHELIO_STACK_CHECK:STRING=4096 -DUSE_PROMETHEUS=ON
 
           cd ${GITHUB_WORKSPACE}/build  && ninja dragonfly
           pwd

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -39,7 +39,7 @@ jobs:
           # -no-pie to disable address randomization so we could symbolize stacktraces
           cmake -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -GNinja \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DPRINT_STACKTRACES_ON_SIGNAL=ON \
-                -DCMAKE_CXX_FLAGS=-no-pie -DHELIO_STACK_CHECK:STRING=4096
+                -DCMAKE_CXX_FLAGS=-no-pie -DHELIO_STACK_CHECK:STRING=4096 -DUSE_PROMETHEUS=ON
 
           cd ${GITHUB_WORKSPACE}/build  && ninja dragonfly
           pwd

--- a/.github/workflows/repeat-tests.yml
+++ b/.github/workflows/repeat-tests.yml
@@ -75,7 +75,7 @@ jobs:
             # -no-pie to disable address randomization so we could symbolize stacktraces
             cmake -B ${GITHUB_WORKSPACE}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -GNinja \
                   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DPRINT_STACKTRACES_ON_SIGNAL=ON \
-                  -DCMAKE_CXX_FLAGS=-no-pie -DHELIO_STACK_CHECK:STRING=4096
+                  -DCMAKE_CXX_FLAGS=-no-pie -DHELIO_STACK_CHECK:STRING=4096 -DUSE_PROMETHEUS=ON
             cd ${GITHUB_WORKSPACE}/build  && ninja dragonfly
             pwd
             ls -l ..

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,8 @@ option(ENABLE_GIT_VERSION "Build with Git metadata" OFF)
 option(USE_SIMSIMD "Enable SimSIMD vector optimizations" OFF)
 option(WITH_SEARCH "Enable compilation of search module" ON)
 
+option(USE_PROMETHEUS "Download prometheus binary for tests" OFF)
+
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
   set(DFLY_TOOLS_MAKE "gmake")
 else()

--- a/src/external_libs.cmake
+++ b/src/external_libs.cmake
@@ -201,3 +201,16 @@ if(USE_SIMSIMD)
   set_target_properties(TRDP::simsimd PROPERTIES
                         INTERFACE_INCLUDE_DIRECTORIES "${SIMSIMD_INCLUDE_DIR}")
 endif()
+
+if (USE_PROMETHEUS)
+  FetchContent_Declare(
+          prometheus
+          DOWNLOAD_EXTRACT_TIMESTAMP true
+          URL "https://github.com/prometheus/prometheus/releases/download/v3.5.0/prometheus-3.5.0.linux-amd64.tar.gz"
+  )
+  FetchContent_MakeAvailable(prometheus)
+  FetchContent_GetProperties(prometheus)
+  if (prometheus_POPULATED)
+    file(COPY ${prometheus_SOURCE_DIR}/prometheus DESTINATION ${CMAKE_BINARY_DIR})
+  endif (prometheus_POPULATED)
+endif (USE_PROMETHEUS)


### PR DESCRIPTION
This PR sets up prometheus in the build directory which will be used for pytests for sanity checking metrics by consuming them.

This pr is standalone to focus on the mechanism of pulling in the prometheus binary, there are multiple possible options for this but I have used cmake and fetchcontent here.

A new cmake option: `USE_PROMETHEUS` which is off by default should be turned on only where pytests are expected to be run.