### PR TITLE
fix: macOS build. CMAKE_POLICY_VERSION_MINIMUM=3.5

### DIFF
--- a/src/external_libs.cmake
+++ b/src/external_libs.cmake
@@ -20,6 +20,7 @@ endif()
 add_third_party(
   dconv
   URL https://github.com/google/double-conversion/archive/refs/tags/v3.3.0.tar.gz
+  CMAKE_PASS_FLAGS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
   PATCH_COMMAND ${SED_REPL} "/static const std::ctype/d"
                 <SOURCE_DIR>/double-conversion/string-to-double.cc
   COMMAND ${SED_REPL} "/std::use_facet</d" <SOURCE_DIR>/double-conversion/string-to-double.cc


### PR DESCRIPTION
macOS build. CMAKE_POLICY_VERSION_MINIMUM=3.5 for hnsw and dconv libraries