### PR TITLE
tests: Add test for prometheus metrics sanity check

### DIFF
--- a/tests/dragonfly/requirements.txt
+++ b/tests/dragonfly/requirements.txt
@@ -27,3 +27,5 @@ pytest-timeout==2.2.0
 asyncio==3.4.3
 fakeredis[json]==2.26.2
 hiredis==2.4.0
+PyYAML>=6.0
+testcontainers>=3.7.1


### PR DESCRIPTION
Adds a test which starts a prometheus container, the container scrapes dragonfly and runs for a few seconds.

The test confirms that there are no warning or error logs seen in the container.

FIXES https://github.com/dragonflydb/dragonfly/issues/5831