### PR TITLE
feat(search): Implement GEO index and support for RADIUS search

### DIFF
--- a/src/core/search/ast_expr.cc
+++ b/src/core/search/ast_expr.cc
@@ -20,6 +20,10 @@ AstRangeNode::AstRangeNode(double lo, bool lo_excl, double hi, bool hi_excl)
     : lo{lo_excl ? nextafter(lo, hi) : lo}, hi{hi_excl ? nextafter(hi, lo) : hi} {
 }
 
+AstGeoNode::AstGeoNode(double lon, double lat, double radius, std::string unit)
+    : lon(lon), lat(lat), radius(radius), unit(std::move(unit)) {
+}
+
 AstNegateNode::AstNegateNode(AstNode&& node) : node{make_unique<AstNode>(std::move(node))} {
 }
 

--- a/src/core/search/ast_expr.h
+++ b/src/core/search/ast_expr.h
@@ -45,6 +45,13 @@ struct AstRangeNode {
   double lo, hi;
 };
 
+struct AstGeoNode {
+  AstGeoNode(double lon, double lat, double radius, std::string unit);
+  double lon, lat;
+  double radius;
+  std::string unit;
+};
+
 // Negates subtree
 struct AstNegateNode {
   AstNegateNode(AstNode&& node);
@@ -112,7 +119,7 @@ struct AstKnnNode {
 using NodeVariants =
     std::variant<std::monostate, AstStarNode, AstStarFieldNode, AstTermNode, AstPrefixNode,
                  AstSuffixNode, AstInfixNode, AstRangeNode, AstNegateNode, AstLogicalNode,
-                 AstFieldNode, AstTagsNode, AstKnnNode>;
+                 AstFieldNode, AstTagsNode, AstKnnNode, AstGeoNode>;
 
 struct AstNode : public NodeVariants {
   using variant::variant;

--- a/src/core/search/lexer.lex
+++ b/src/core/search/lexer.lex
@@ -68,6 +68,10 @@ astrsk_ch  \*
 "KNN"          return Parser::make_KNN (loc());
 "AS"           return Parser::make_AS (loc());
 "EF_RUNTIME"   return Parser::make_EF_RUNTIME (loc());
+"M"            return Parser::make_GEOUNIT_M (loc());
+"KM"           return Parser::make_GEOUNIT_KM (loc());
+"MI"           return Parser::make_GEOUNIT_MI (loc());
+"FT"           return Parser::make_GEOUNIT_FT (loc());
 
 [0-9]{1,9}                          return Parser::make_UINT32(str(), loc());
 [+-]?(([0-9]*[.])?[0-9]+|inf)       return Parser::make_DOUBLE(str(), loc());

--- a/src/core/search/parser.y
+++ b/src/core/search/parser.y
@@ -61,6 +61,10 @@ double toDouble(string_view src);
   KNN         "KNN"
   AS          "AS"
   EF_RUNTIME  "EF_RUNTIME"
+  GEOUNIT_M   "GEOUNIT_M"
+  GEOUNIT_KM  "GEOUNIT_KM"
+  GEOUNIT_MI  "GEOUNIT_MI"
+  GEOUNIT_FT  "GEOUNIT_FT"
 ;
 
 %token AND_OP
@@ -77,14 +81,13 @@ double toDouble(string_view src);
 
 %token <std::string> DOUBLE "double"
 %token <std::string> UINT32 "uint32"
-%nterm <double> generic_number
-%nterm <bool> opt_lparen
-%nterm <AstExpr> final_query filter search_expr search_unary_expr search_or_expr search_and_expr numeric_filter_expr
+%nterm <AstExpr> final_query filter search_expr search_unary_expr search_or_expr search_and_expr bracket_filter_expr
 %nterm <AstExpr> field_cond field_cond_expr field_unary_expr field_or_expr field_and_expr tag_list
 %nterm <AstTagsNode::TagValueProxy> tag_list_element
 
 %nterm <AstKnnNode> knn_query
 %nterm <std::string> opt_knn_alias
+%nterm <std::string> geounit
 %nterm <std::optional<size_t>> opt_ef_runtime
 
 %printer { yyo << $$; } <*>;
@@ -149,23 +152,55 @@ field_cond:
   | STAR                                                { $$ = AstStarFieldNode();           }
   | NOT_OP field_cond                                   { $$ = AstNegateNode(std::move($2)); }
   | LPAREN field_cond_expr RPAREN                       { $$ = std::move($2); }
-  | LBRACKET numeric_filter_expr RBRACKET               { $$ = std::move($2); }
+  | LBRACKET bracket_filter_expr RBRACKET               { $$ = std::move($2); }
   | LCURLBR tag_list RCURLBR                            { $$ = std::move($2); }
   | PREFIX                                              { $$ = AstPrefixNode(std::move($1)); }
   | SUFFIX                                              { $$ = AstSuffixNode(std::move($1)); }
   | INFIX                                               { $$ = AstInfixNode(std::move($1));  }
 
-numeric_filter_expr:
-  opt_lparen generic_number opt_lparen generic_number         { $$ = AstRangeNode($2, $1, $4, $3); }
-  | opt_lparen generic_number COMMA opt_lparen generic_number { $$ = AstRangeNode($2, $1, $5, $4); }
+bracket_filter_expr:
+  /* Numeric filter has form [(] UINT32|DOUBLE [COMMA] [(] UINT32|DOUBLE */
+  DOUBLE DOUBLE                                { $$ = AstRangeNode(toDouble($1), false, toDouble($2), false); }
+  | LPAREN DOUBLE DOUBLE                       { $$ = AstRangeNode(toDouble($2), true, toDouble($3), false); }
+  | DOUBLE LPAREN DOUBLE                       { $$ = AstRangeNode(toDouble($1), false, toDouble($3), true); }
+  | LPAREN DOUBLE LPAREN DOUBLE                { $$ = AstRangeNode(toDouble($2), true, toDouble($4), true); }
+  | DOUBLE UINT32                              { $$ = AstRangeNode(toDouble($1), false, toUint32($2), false); }
+  | LPAREN DOUBLE UINT32                       { $$ = AstRangeNode(toDouble($2), true, toUint32($3), false); }
+  | DOUBLE LPAREN UINT32                       { $$ = AstRangeNode(toDouble($1), false, toUint32($3), true); }
+  | LPAREN DOUBLE LPAREN UINT32                { $$ = AstRangeNode(toDouble($2), true, toUint32($4), true); }
+  | UINT32 DOUBLE                              { $$ = AstRangeNode(toUint32($1), false, toDouble($2), false); }
+  | LPAREN UINT32 DOUBLE                       { $$ = AstRangeNode(toUint32($2), true, toDouble($3), false); }
+  | UINT32 LPAREN DOUBLE                       { $$ = AstRangeNode(toUint32($1), false, toDouble($3), true); }
+  | LPAREN UINT32 LPAREN DOUBLE                { $$ = AstRangeNode(toUint32($2), true, toDouble($4), true); }
+  | UINT32 UINT32                              { $$ = AstRangeNode(toUint32($1), false, toUint32($2), false); }
+  | LPAREN UINT32 UINT32                       { $$ = AstRangeNode(toUint32($2), true, toUint32($3), false); }
+  | UINT32 LPAREN UINT32                       { $$ = AstRangeNode(toUint32($1), false, toUint32($3), true); }
+  | LPAREN UINT32 LPAREN UINT32                { $$ = AstRangeNode(toUint32($2), true, toUint32($4), true); }
+  | DOUBLE COMMA DOUBLE                        { $$ = AstRangeNode(toDouble($1), false, toDouble($3), false); }
+  | DOUBLE COMMA UINT32                        { $$ = AstRangeNode(toDouble($1), false, toUint32($3), false); }
+  | UINT32 COMMA DOUBLE                        { $$ = AstRangeNode(toUint32($1), false, toDouble($3), false); }
+  | UINT32 COMMA UINT32                        { $$ = AstRangeNode(toUint32($1), false, toUint32($3), false); }
+  | LPAREN DOUBLE COMMA DOUBLE                 { $$ = AstRangeNode(toDouble($2), true, toDouble($4), false); }
+  | DOUBLE COMMA LPAREN DOUBLE                 { $$ = AstRangeNode(toDouble($1), false, toDouble($4), true); }
+  | LPAREN DOUBLE COMMA LPAREN DOUBLE          { $$ = AstRangeNode(toDouble($2), true, toDouble($5), true); }
+  | LPAREN DOUBLE COMMA UINT32                 { $$ = AstRangeNode(toDouble($2), true, toUint32($4), false); }
+  | DOUBLE COMMA LPAREN UINT32                 { $$ = AstRangeNode(toDouble($1), false, toUint32($4), true); }
+  | LPAREN DOUBLE COMMA LPAREN UINT32          { $$ = AstRangeNode(toDouble($2), true, toUint32($5), true); }
+  | LPAREN UINT32 COMMA DOUBLE                 { $$ = AstRangeNode(toUint32($2), true, toDouble($4), false); }
+  | UINT32 COMMA LPAREN DOUBLE                 { $$ = AstRangeNode(toUint32($1), false, toDouble($4), true); }
+  | LPAREN UINT32 COMMA LPAREN DOUBLE          { $$ = AstRangeNode(toUint32($2), true, toDouble($5), true); }
+  | LPAREN UINT32 COMMA UINT32                 { $$ = AstRangeNode(toUint32($2), true, toUint32($4), false); }
+  | UINT32 COMMA LPAREN UINT32                 { $$ = AstRangeNode(toUint32($1), false, toUint32($4), true); }
+  | LPAREN UINT32 COMMA LPAREN UINT32          { $$ = AstRangeNode(toUint32($2), true, toUint32($5), true); }
+  /* GEO filter */
+  | DOUBLE DOUBLE UINT32 geounit               { $$ = AstGeoNode(toDouble($1), toDouble($2), toUint32($3), std::move($4)); }
+  | DOUBLE DOUBLE DOUBLE geounit               { $$ = AstGeoNode(toDouble($1), toDouble($2), toDouble($3), std::move($4)); }
 
-generic_number:
-  DOUBLE { $$ = toDouble($1); }
-  | UINT32 { $$ = toUint32($1); }
-
-opt_lparen:
-  /* empty */ { $$ = false; }
-  | LPAREN { $$ = true; }
+geounit:
+  GEOUNIT_M     { $$ = "M"; }
+  | GEOUNIT_KM  { $$ = "KM"; }
+  | GEOUNIT_MI  { $$ = "MI"; }
+  | GEOUNIT_FT  { $$ = "FT"; }
 
 field_cond_expr:
   field_unary_expr { $$ = std::move($1); }

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -55,7 +55,7 @@ struct OptionalNumericFilter : public OptionalFilterBase {
 
 // Describes a specific index field
 struct SchemaField {
-  enum FieldType { TAG, TEXT, NUMERIC, VECTOR };
+  enum FieldType { TAG, TEXT, NUMERIC, VECTOR, GEO };
   enum FieldFlags : uint8_t { NOINDEX = 1 << 0, SORTABLE = 1 << 1 };
 
   struct VectorParams {

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -136,6 +136,8 @@ string_view SearchFieldTypeToString(search::SchemaField::FieldType type) {
       return "NUMERIC";
     case search::SchemaField::VECTOR:
       return "VECTOR";
+    case search::SchemaField::GEO:
+      return "GEO";
   }
   ABSL_UNREACHABLE();
   return "";

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -195,6 +195,10 @@ ParsedSchemaField ParseVector(CmdArgParser* parser) {
   return std::make_pair(search::SchemaField::VECTOR, vector_params);
 }
 
+ParsedSchemaField ParseGeo(CmdArgParser* parser) {
+  return std::make_pair(search::SchemaField::GEO, std::monostate{});
+}
+
 // ON HASH | JSON
 ParseResult<bool> ParseOnOption(CmdArgParser* parser, DocIndex* index) {
   index->type = parser->MapNext("HASH"sv, DocIndex::HASH, "JSON"sv, DocIndex::JSON);
@@ -249,8 +253,9 @@ ParseResult<bool> ParseSchema(CmdArgParser* parser, DocIndex* index) {
 
     // Determine type
     using search::SchemaField;
-    auto params_parser = parser->TryMapNext("TAG"sv, &ParseTag, "TEXT"sv, &ParseText, "NUMERIC"sv,
-                                            &ParseNumeric, "VECTOR"sv, &ParseVector);
+    auto params_parser =
+        parser->TryMapNext("TAG"sv, &ParseTag, "TEXT"sv, &ParseText, "NUMERIC"sv, &ParseNumeric,
+                           "VECTOR"sv, &ParseVector, "GEO", &ParseGeo);
     if (!params_parser) {
       return CreateSyntaxError(
           absl::StrCat("Field type "sv, parser->Next(), " is not supported"sv));


### PR DESCRIPTION
Implementation of GEO index use boost::geometry::index::rtree as
structure to store/search/remove points.

Search is done in a way that we construct polygon of 4 points with 90
degrees angle difference around search point with fixed distance and bounding
box around that polygon to cover whole area of possible points that fit in
radius. For each point we calculate haversine distance between found
point and search point.

Fixes https://github.com/dragonflydb/dragonfly/issues/4536

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->