### PR TITLE
chore: lock free info command with replicaof v2

### DIFF
--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -166,6 +166,7 @@ void OutgoingMigration::Finish(const GenericError& error) {
     switch (state_) {
       case MigrationState::C_FATAL:
       case MigrationState::C_FINISHED:
+        CloseSocket();
         return;  // Already finished, nothing else to do
 
       case MigrationState::C_CONNECTING:
@@ -192,6 +193,9 @@ void OutgoingMigration::Finish(const GenericError& error) {
     });
     exec_st_.JoinErrorHandler();
   }
+
+  // Close socket for clean disconnect.
+  CloseSocket();
 }
 
 MigrationState OutgoingMigration::GetState() const {

--- a/src/server/protocol_client.cc
+++ b/src/server/protocol_client.cc
@@ -109,23 +109,21 @@ ProtocolClient::ProtocolClient(string host, uint16_t port) {
 #ifdef DFLY_USE_SSL
   MaybeInitSslCtx();
 #endif
+  // We initialize the proactor thread here such that it never races with Sock().
+  // ProtocolClient is never migrated to a different thread, so this is safe.
+  socket_thread_ = ProactorBase::me();
 }
+
 ProtocolClient::ProtocolClient(ServerContext context) : server_context_(std::move(context)) {
 #ifdef DFLY_USE_SSL
   MaybeInitSslCtx();
 #endif
+  socket_thread_ = ProactorBase::me();
 }
 
 ProtocolClient::~ProtocolClient() {
   exec_st_.JoinErrorHandler();
 
-  // FIXME: We should close the socket explictly outside of the destructor. This currently
-  // breaks test_cancel_replication_immediately.
-  if (sock_) {
-    std::error_code ec;
-    sock_->proactor()->Await([this, &ec]() { ec = sock_->Close(); });
-    LOG_IF(ERROR, ec) << "Error closing socket " << ec;
-  }
 #ifdef DFLY_USE_SSL
   if (ssl_ctx_) {
     SSL_CTX_free(ssl_ctx_);
@@ -162,6 +160,7 @@ error_code ProtocolClient::ResolveHostDns() {
 error_code ProtocolClient::ConnectAndAuth(std::chrono::milliseconds connect_timeout_ms,
                                           ExecutionState* cntx) {
   ProactorBase* mythread = ProactorBase::me();
+  DCHECK(mythread == socket_thread_);
   CHECK(mythread);
   {
     unique_lock lk(sock_mu_);
@@ -235,6 +234,9 @@ void ProtocolClient::CloseSocket() {
         auto ec = sock_->Shutdown(SHUT_RDWR);
         LOG_IF(ERROR, ec) << "Could not shutdown socket " << ec;
       }
+      auto ec = sock_->Close();  // Quietly close.
+
+      LOG_IF(WARNING, ec) << "Error closing socket " << ec << "/" << ec.message();
     });
   }
 }
@@ -385,11 +387,11 @@ void ProtocolClient::ResetParser(RedisParser::Mode mode) {
 }
 
 uint64_t ProtocolClient::LastIoTime() const {
-  return last_io_time_;
+  return last_io_time_.load(std::memory_order_relaxed);
 }
 
 void ProtocolClient::TouchIoTime() {
-  last_io_time_ = Proactor()->GetMonotonicTimeNs();
+  last_io_time_.store(Proactor()->GetMonotonicTimeNs(), std::memory_order_relaxed);
 }
 
 }  // namespace dfly

--- a/src/server/protocol_client.cc
+++ b/src/server/protocol_client.cc
@@ -109,16 +109,12 @@ ProtocolClient::ProtocolClient(string host, uint16_t port) {
 #ifdef DFLY_USE_SSL
   MaybeInitSslCtx();
 #endif
-  // We initialize the proactor thread here such that it never races with Sock().
-  // ProtocolClient is never migrated to a different thread, so this is safe.
-  socket_thread_ = ProactorBase::me();
 }
 
 ProtocolClient::ProtocolClient(ServerContext context) : server_context_(std::move(context)) {
 #ifdef DFLY_USE_SSL
   MaybeInitSslCtx();
 #endif
-  socket_thread_ = ProactorBase::me();
 }
 
 ProtocolClient::~ProtocolClient() {
@@ -160,7 +156,6 @@ error_code ProtocolClient::ResolveHostDns() {
 error_code ProtocolClient::ConnectAndAuth(std::chrono::milliseconds connect_timeout_ms,
                                           ExecutionState* cntx) {
   ProactorBase* mythread = ProactorBase::me();
-  DCHECK(mythread == socket_thread_);
   CHECK(mythread);
   {
     unique_lock lk(sock_mu_);

--- a/src/server/protocol_client.cc
+++ b/src/server/protocol_client.cc
@@ -157,6 +157,7 @@ error_code ProtocolClient::ConnectAndAuth(std::chrono::milliseconds connect_time
                                           ExecutionState* cntx) {
   ProactorBase* mythread = ProactorBase::me();
   CHECK(mythread);
+  socket_thread_ = ProactorBase::me();
   {
     unique_lock lk(sock_mu_);
     // The context closes sock_. So if the context error handler has already

--- a/src/server/protocol_client.h
+++ b/src/server/protocol_client.h
@@ -45,13 +45,6 @@ class ProtocolClient {
   uint64_t LastIoTime() const;
   void TouchIoTime();
 
-  // Used to set the socket_thread_ prior the initialization of sock_.
-  // That way Proactor() returns the right thread even when the sock_ is
-  // not yet initialized
-  void SetSocketThread(util::fb2::ProactorBase* sock_thread) {
-    socket_thread_ = sock_thread;
-  }
-
  protected:
   struct ServerContext {
     std::string host;
@@ -114,7 +107,7 @@ class ProtocolClient {
   }
 
   auto* Proactor() const {
-    return socket_thread_;
+    return sock_->proactor();
   }
 
   util::FiberSocketBase* Sock() const {

--- a/src/server/protocol_client.h
+++ b/src/server/protocol_client.h
@@ -107,7 +107,8 @@ class ProtocolClient {
   }
 
   auto* Proactor() const {
-    return sock_->proactor();
+    DCHECK(socket_thread_);
+    return socket_thread_;
   }
 
   util::FiberSocketBase* Sock() const {

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -516,7 +516,7 @@ void Replica::InitializeShardFlows() {
 
   for (size_t i = 0; i < shard_flows_.size(); ++i) {
     uint64_t partial_sync_lsn = 0;
-    if (!shard_flows_.empty() && shard_flows_[i]) {
+    if (shard_flows_[i]) {
       partial_sync_lsn = shard_flows_[i]->JournalExecutedCount();
     }
     shard_flows_[i].reset(

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -152,6 +152,8 @@ void Replica::StartMainReplicationFiber(std::optional<LastMasterSyncData> last_m
 void Replica::EnableReplication() {
   VLOG(1) << "Enabling replication";
 
+  socket_thread_ = ProactorBase::me();
+
   state_mask_ = R_ENABLED;                                           // set replica state to enabled
   sync_fb_ = MakeFiber(&Replica::MainReplicationFb, this, nullopt);  // call replication fiber
 }

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -64,7 +64,7 @@ ABSL_DECLARE_FLAG(uint16_t, announce_port);
 ABSL_FLAG(
     int, replica_priority, 100,
     "Published by info command for sentinel to pick replica based on score during a failover");
-ABSL_FLAG(bool, experimental_replicaof_v2, true,
+ABSL_FLAG(bool, experimental_replicaof_v2, false,
           "Use ReplicaOfV2 algorithm for initiating replication");
 
 namespace dfly {

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -154,6 +154,8 @@ class Replica : ProtocolClient {
   size_t GetRecCountExecutedPerShard(const std::vector<unsigned>& indexes) const;
 
  private:
+  void InitializeShardFlows();
+
   util::fb2::ProactorBase* proactor_ = nullptr;
   Service& service_;
   MasterContext master_context_;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1992,7 +1992,7 @@ std::optional<ReplicaOffsetInfo> ServerFamily::GetReplicaOffsetInfo() {
 
   // Switch to primary mode.
   if (!ServerState::tlocal()->is_master) {
-    auto repl_ptr = tl_replica;
+    auto repl_ptr = replica_;
     CHECK(repl_ptr);
     return ReplicaOffsetInfo{repl_ptr->GetSyncId(), repl_ptr->GetReplicaOffset()};
   }

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -243,6 +243,11 @@ using detail::SaveStagesController;
 using http::StringResponse;
 using strings::HumanReadableNumBytes;
 
+// Initialized by REPLICAOF
+thread_local std::shared_ptr<Replica> tl_replica = nullptr;
+// Initialized by ADDREPLICAOF
+thread_local std::vector<std::shared_ptr<Replica>> tl_cluster_replicas;
+
 namespace {
 
 // TODO these should be configurable as command line flag and at runtime via config set
@@ -1049,6 +1054,7 @@ ServerFamily::ServerFamily(Service* service) : service_(*service) {
   ValidateClientTlsFlags();
   dfly_cmd_ = make_unique<DflyCmd>(this);
   legacy_format_metrics_ = GetFlag(FLAGS_keep_legacy_memory_metrics);
+  use_replica_of_v2_ = GetFlag(FLAGS_experimental_replicaof_v2);
 }
 
 ServerFamily::~ServerFamily() {
@@ -1231,6 +1237,7 @@ void ServerFamily::Shutdown() {
       replica_->Stop();
     }
     StopAllClusterReplicas();
+    UpdateReplicationThreadLocals(nullptr);
 
     dfly_cmd_->Shutdown();
     DebugCmd::Shutdown();
@@ -1985,7 +1992,7 @@ std::optional<ReplicaOffsetInfo> ServerFamily::GetReplicaOffsetInfo() {
 
   // Switch to primary mode.
   if (!ServerState::tlocal()->is_master) {
-    auto repl_ptr = replica_;
+    auto repl_ptr = tl_replica;
     CHECK(repl_ptr);
     return ReplicaOffsetInfo{repl_ptr->GetSyncId(), repl_ptr->GetReplicaOffset()};
   }
@@ -2004,6 +2011,17 @@ vector<facade::Listener*> ServerFamily::GetNonPriviligedListeners() const {
 }
 
 optional<Replica::Summary> ServerFamily::GetReplicaSummary() const {
+  /// Without lock
+  if (use_replica_of_v2_) {
+    if (tl_replica == nullptr) {
+      return nullopt;
+    }
+    auto replica = tl_replica;
+    return replica->GetSummary();
+  }
+
+  // With lock
+  // TODO deprecate this in favor of v2
   util::fb2::LockGuard lk(replicaof_mu_);
   if (replica_ == nullptr) {
     return nullopt;
@@ -3126,16 +3144,24 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
   };
 
   auto add_repl_info = [&] {
+    std::shared_ptr<Replica> replica;
+    std::vector<std::shared_ptr<Replica>> cluster_replicas;
     bool is_master = true;
     // Thread local var is_master is updated under mutex replicaof_mu_ together with replica_,
     // ensuring eventual consistency of is_master. When determining if the server is a replica and
     // accessing the replica_ object, we must lock replicaof_mu_. Using is_master alone is
     // insufficient in this scenario.
     // Please note that we we do not use Metrics object here.
-    {
+    if (use_replica_of_v2_) {
+      // Deep copy because tl_replica might be overwritten inbetween
+      replica = tl_replica;
+      cluster_replicas = tl_cluster_replicas;
+      is_master = !replica;
+    } else {
       fb2::LockGuard lk(replicaof_mu_);
       is_master = !replica_;
     }
+
     if (is_master) {
       vector<ReplicaRoleInfo> replicas_info = dfly_cmd_->GetReplicasRoleInfo();
       append("role", "master");
@@ -3169,13 +3195,22 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
         append("psync_attempts", rinfo.psync_attempts);
         append("psync_successes", rinfo.psync_successes);
       };
-      fb2::LockGuard lk(replicaof_mu_);
 
-      replication_info_cb(replica_->GetSummary());
-
-      // Special case, when multiple masters replicate to a single replica.
-      for (const auto& replica : cluster_replicas_) {
+      if (use_replica_of_v2_) {
         replication_info_cb(replica->GetSummary());
+
+        // Special case, when multiple masters replicate to a single replica.
+        for (const auto& replica : cluster_replicas) {
+          replication_info_cb(replica->GetSummary());
+        }
+      } else {
+        fb2::LockGuard lk(replicaof_mu_);
+        replication_info_cb(replica_->GetSummary());
+
+        // Special case, when multiple masters replicate to a single replica.
+        for (const auto& replica : cluster_replicas_) {
+          replication_info_cb(replica->GetSummary());
+        }
       }
     }
   };
@@ -3461,7 +3496,7 @@ void ServerFamily::AddReplicaOf(CmdArgList args, const CommandContext& cmd_cntx)
   }
   LOG(INFO) << "Add Replica " << *replicaof_args;
 
-  auto add_replica = make_unique<Replica>(replicaof_args->host, replicaof_args->port, &service_,
+  auto add_replica = make_shared<Replica>(replicaof_args->host, replicaof_args->port, &service_,
                                           master_replid(), replicaof_args->slot_range);
   GenericError ec = add_replica->Start();
   if (ec) {
@@ -3470,6 +3505,9 @@ void ServerFamily::AddReplicaOf(CmdArgList args, const CommandContext& cmd_cntx)
   }
   add_replica->StartMainReplicationFiber(nullopt);
   cluster_replicas_.push_back(std::move(add_replica));
+  service_.proactor_pool().AwaitFiberOnAll(
+      [this](auto index, auto* cntx)
+          ABSL_NO_THREAD_SAFETY_ANALYSIS { tl_cluster_replicas = cluster_replicas_; });
   cmd_cntx.rb->SendOk();
 }
 
@@ -3589,8 +3627,7 @@ void ServerFamily::StopAllClusterReplicas() {
 }
 
 void ServerFamily::ReplicaOf(CmdArgList args, const CommandContext& cmd_cntx) {
-  const bool use_replica_of_v2 = absl::GetFlag(FLAGS_experimental_replicaof_v2);
-  if (use_replica_of_v2) {
+  if (use_replica_of_v2_) {
     ReplicaOfInternalV2(args, cmd_cntx.tx, cmd_cntx.rb, ActionOnConnectionFail::kReturnOnError);
     return;
   }
@@ -3607,8 +3644,7 @@ void ServerFamily::Replicate(string_view host, string_view port) {
   CmdArgList args_list = absl::MakeSpan(args_vec);
   io::NullSink sink;
   facade::RedisReplyBuilder rb(&sink);
-  const bool use_replica_of_v2 = absl::GetFlag(FLAGS_experimental_replicaof_v2);
-  if (use_replica_of_v2) {
+  if (use_replica_of_v2_) {
     ReplicaOfInternalV2(args_list, nullptr, &rb, ActionOnConnectionFail::kContinueReplication);
     return;
   }
@@ -3628,6 +3664,7 @@ void ServerFamily::ReplicaOfNoOne(SinkReplyBuilder* builder) {
     last_master_data_ = replica_->Stop();
     replica_.reset();
     StopAllClusterReplicas();
+    UpdateReplicationThreadLocals(nullptr);
   }
 
   // May not switch to ACTIVE if the process is, for example, shutting down at the same time.
@@ -3699,8 +3736,8 @@ void ServerFamily::ReplicaOfInternalV2(CmdArgList args, Transaction* tx, SinkRep
   if (ServerState::tlocal()->gstate() == GlobalState::TAKEN_OVER)
     service_.SwitchState(GlobalState::TAKEN_OVER, GlobalState::LOADING);
 
-  // TODO Update thread locals. That way INFO never blocks
   replica_ = new_replica;
+  UpdateReplicationThreadLocals(new_replica);
   SetMasterFlagOnAllThreads(false);
 
   if (on_error == ActionOnConnectionFail::kReturnOnError) {
@@ -3766,6 +3803,8 @@ void ServerFamily::ReplTakeOver(CmdArgList args, const CommandContext& cmd_cntx)
 
   last_master_data_ = replica_->Stop();
   replica_.reset();
+
+  UpdateReplicationThreadLocals(nullptr);
 
   SetMasterFlagOnAllThreads(true);
   return builder->SendOk();
@@ -3866,6 +3905,12 @@ void ServerFamily::ReplConf(CmdArgList args, const CommandContext& cmd_cntx) {
 }
 
 void ServerFamily::Role(CmdArgList args, const CommandContext& cmd_cntx) {
+  // New version without mutex lock
+  if (use_replica_of_v2_) {
+    return RoleV2(args, cmd_cntx);
+  }
+
+  // Old algorithm with mutex lock
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx.rb);
   util::fb2::LockGuard lk(replicaof_mu_);
   // Thread local var is_master is updated under mutex replicaof_mu_ together with replica_,
@@ -3905,6 +3950,54 @@ void ServerFamily::Role(CmdArgList args, const CommandContext& cmd_cntx) {
     send_replica_info(replica_->GetSummary());
     for (const auto& replica : cluster_replicas_) {
       send_replica_info(replica->GetSummary());
+    }
+  }
+}
+
+void ServerFamily::RoleV2(CmdArgList args, const CommandContext& cmd_cntx) {
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx.rb);
+  // Thread local var is_master is updated under mutex replicaof_mu_ together with replica_,
+  // ensuring eventual consistency of is_master. When determining if the server is a replica and
+  // accessing the replica_ object, we must lock replicaof_mu_. Using is_master alone is
+  // insufficient in this scenario.
+  if (!tl_replica) {
+    rb->StartArray(2);
+    rb->SendBulkString("master");
+    auto vec = dfly_cmd_->GetReplicasRoleInfo();
+    rb->StartArray(vec.size());
+    for (auto& data : vec) {
+      rb->StartArray(3);
+      rb->SendBulkString(data.address);
+      rb->SendBulkString(absl::StrCat(data.listening_port));
+      rb->SendBulkString(data.state);
+    }
+
+  } else {
+    // Deep copy because tl_replica might be overwritten inbetween
+    auto replica = tl_replica;
+    auto cluster_replicas = tl_cluster_replicas;
+
+    rb->StartArray(4 + cluster_replicas.size() * 3);
+    rb->SendBulkString(GetFlag(FLAGS_info_replication_valkey_compatible) ? "slave" : "replica");
+
+    auto send_replica_info = [rb](Replica::Summary rinfo) {
+      rb->SendBulkString(rinfo.host);
+      rb->SendBulkString(absl::StrCat(rinfo.port));
+      if (rinfo.full_sync_done) {
+        rb->SendBulkString(GetFlag(FLAGS_info_replication_valkey_compatible) ? "online"
+                                                                             : "stable_sync");
+      } else if (rinfo.full_sync_in_progress) {
+        rb->SendBulkString("full_sync");
+      } else if (rinfo.master_link_established) {
+        rb->SendBulkString("preparation");
+      } else {
+        rb->SendBulkString("connecting");
+      }
+    };
+
+    send_replica_info(replica->GetSummary());
+    for (const auto& repl : cluster_replicas) {
+      send_replica_info(repl->GetSummary());
     }
   }
 }
@@ -4094,6 +4187,13 @@ void ServerFamily::ClientPauseCmd(CmdArgList args, SinkReplyBuilder* builder,
   } else {
     builder->SendError("Failed to pause all running clients");
   }
+}
+
+void ServerFamily::UpdateReplicationThreadLocals(std::shared_ptr<Replica> repl) {
+  service_.proactor_pool().AwaitFiberOnAll([repl](auto index, auto* context) {
+    tl_replica = repl;
+    tl_cluster_replicas.clear();
+  });
 }
 
 #define HFUNC(x) SetHandler(HandlerFunc(this, &ServerFamily::x))


### PR DESCRIPTION
Following #5774, this PR removes locking the `replica_of_mu_` from info command and uses the thread locals && replica of v2 algorithm.


No more locking and blocking for INFO command during `replicaof` or `takeover` 🥳 🎉 🌮 