### PR TITLE
fix: crash when WITH_SEARCH=OFF

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -970,7 +970,9 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
   config_registry.RegisterMutable("timeout");
   config_registry.RegisterMutable("send_timeout");
   config_registry.RegisterMutable("managed_service_info");
+#ifdef WITH_SEARCH
   config_registry.RegisterMutable("MAXSEARCHRESULTS");
+#endif
 
   config_registry.RegisterMutable(
       "notify_keyspace_events", [pool = &pp_](const absl::CommandLineFlag& flag) {


### PR DESCRIPTION
problem: we can't register MAXSEARCHRESULTS flag when search is OFF
fix: add #ifdef check 