### PR TITLE
fix(docker): prevent zombie processes and improve healthcheck

### DIFF
--- a/tools/docker/healthcheck.sh
+++ b/tools/docker/healthcheck.sh
@@ -1,8 +1,17 @@
 #!/bin/sh
 
+# Cleanup function to prevent zombie processes (issue #5844)
+# This is critical when dragonfly runs as PID 1 without an init system
+cleanup() {
+  # Wait for all background/child processes to finish
+  wait 2>/dev/null || true
+}
+
+# Set trap to ensure cleanup runs on exit, regardless of how the script exits
+trap cleanup EXIT
+
 HOST="localhost"
 PORT=$HEALTHCHECK_PORT
-
 
 if [ -z "$HEALTHCHECK_PORT" ]; then
   # try unpriveleged version first. This should cover cases when the container is running
@@ -20,8 +29,24 @@ if [ -z "$HEALTHCHECK_PORT" ]; then
   PORT=$(echo $DF_NET | grep -oE ':[0-9]+' | cut -c2- | tail -n 1)
 fi
 
-_healthcheck="nc -q1 $HOST $PORT"
+# Use redis-cli instead of nc for better reliability
+# and to properly check loading state (issue #5863)
+REDIS_CLI="redis-cli -h $HOST -p $PORT"
 
-echo PING | ${_healthcheck}
+# Step 1: Basic PING check
+if ! timeout 3 $REDIS_CLI PING 2>/dev/null | grep -q "PONG"; then
+  exit 1
+fi
 
-exit $?
+# Step 2: Check if server is in LOADING state
+# During snapshot loading, the server responds to PING but is not ready for traffic
+# Note: 'loading' field is in PERSISTENCE section
+INFO_OUTPUT=$(timeout 3 $REDIS_CLI INFO PERSISTENCE 2>/dev/null)
+
+# Server is ready when loading:0
+if echo "$INFO_OUTPUT" | grep -q "^loading:0"; then
+  exit 0
+fi
+
+# If loading:1 or can't determine state, fail to be safe
+exit 1

--- a/tools/docker/healthcheck.sh
+++ b/tools/docker/healthcheck.sh
@@ -17,11 +17,11 @@ if [ -z "$HEALTHCHECK_PORT" ]; then
   # try unpriveleged version first. This should cover cases when the container is running
   # without root, for example:
   # docker run  --group-add 999  --cap-drop=ALL --user 999 docker.dragonflydb.io/dragonflydb/dragonfly
-  DF_NET=$(netstat -tlnp | grep "1/dragonfly")
+  DF_NET=$(netstat -tlnp | grep "/dragonfly")
   if [ -z "$DF_NET" ]; then
     # if we failed, then lets try the priveleged version. is triggerred by the regular command:
     # docker run docker.dragonflydb.io/dragonflydb/dragonfly
-    DF_NET=$(su dfly -c "netstat -tlnp" | grep "1/dragonfly")
+    DF_NET=$(su dfly -c "netstat -tlnp" | grep "/dragonfly")
   fi
 
   # check all the TCP ports, and fetch the port.

--- a/tools/packaging/Dockerfile.alpine-dev
+++ b/tools/packaging/Dockerfile.alpine-dev
@@ -35,7 +35,7 @@ COPY tools/docker/healthcheck.sh /usr/local/bin/healthcheck.sh
 COPY --from=builder /build/build-release/dragonfly /usr/local/bin/
 
 RUN apk --no-cache add libgcc libstdc++  \
-     setpriv netcat-openbsd boost-context && ldd /usr/local/bin/dragonfly
+     setpriv netcat-openbsd boost-context tini && ldd /usr/local/bin/dragonfly
 
 RUN addgroup -S -g 1000 dfly && adduser -S -G dfly -u 999 dfly
 RUN mkdir /data && chown dfly:dfly /data
@@ -44,7 +44,9 @@ VOLUME /data
 WORKDIR /data
 
 HEALTHCHECK CMD /usr/local/bin/healthcheck.sh
-ENTRYPOINT ["entrypoint.sh"]
+
+# Use tini as PID 1 to properly reap zombie processes (issue #5844)
+ENTRYPOINT ["/sbin/tini", "--", "entrypoint.sh"]
 
 EXPOSE 6379
 

--- a/tools/packaging/Dockerfile.ubuntu-dev
+++ b/tools/packaging/Dockerfile.ubuntu-dev
@@ -19,7 +19,7 @@ FROM ubuntu:22.04
 RUN --mount=type=tmpfs,target=/var/cache/apt \
     --mount=type=tmpfs,target=/var/lib/apt/lists \
     apt update && \
-    apt install -q -y --no-install-recommends netcat-openbsd ca-certificates redis-tools net-tools
+    apt install -q -y --no-install-recommends netcat-openbsd ca-certificates redis-tools net-tools tini
 
 RUN groupadd -r -g 999 dfly && useradd -r -g dfly -u 999 dfly
 RUN mkdir /data && chown dfly:dfly /data
@@ -32,7 +32,9 @@ COPY tools/docker/healthcheck.sh /usr/local/bin/healthcheck.sh
 COPY --from=builder /build/build-release/dragonfly /usr/local/bin/
 
 HEALTHCHECK CMD /usr/local/bin/healthcheck.sh
-ENTRYPOINT ["entrypoint.sh"]
+
+# Use tini as PID 1 to properly reap zombie processes (issue #5844)
+ENTRYPOINT ["/usr/bin/tini", "--", "entrypoint.sh"]
 
 # For inter-container communication.
 EXPOSE 6379

--- a/tools/packaging/Dockerfile.ubuntu-prod
+++ b/tools/packaging/Dockerfile.ubuntu-prod
@@ -20,7 +20,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN --mount=type=tmpfs,target=/var/cache/apt \
     --mount=type=tmpfs,target=/var/lib/apt/lists \
     apt -q update && \
-    apt install -q -y --no-install-recommends netcat-openbsd ca-certificates redis-tools net-tools
+    apt install -q -y --no-install-recommends netcat-openbsd ca-certificates redis-tools net-tools tini
 
 RUN groupadd -r -g 999 dfly && useradd -r -g dfly -u 999 dfly
 RUN mkdir /data && chown dfly:dfly /data
@@ -33,7 +33,9 @@ COPY tools/docker/healthcheck.sh /usr/local/bin/healthcheck.sh
 COPY --from=builder /build/dragonfly /usr/local/bin/
 
 HEALTHCHECK CMD /usr/local/bin/healthcheck.sh
-ENTRYPOINT ["entrypoint.sh"]
+
+# Use tini as PID 1 to properly reap zombie processes (issue #5844)
+ENTRYPOINT ["/usr/bin/tini", "--", "entrypoint.sh"]
 
 # For inter-container communication.
 EXPOSE 6379


### PR DESCRIPTION
Fixes zombie process accumulation (#5844) and snapshot loading detection (#5863) in Docker healthcheck.

Key Changes:
- Add `tini` as PID 1 to reap zombie processes
- Use `redis-cli` + `trap cleanup EXIT` for reliable subprocess management  
- Check `INFO PERSISTENCE` loading state to prevent traffic during snapshot loading
- Fix process detection to work with tini (`/dragonfly` vs `1/dragonfly`)

Impact:
- Eliminates zombie process buildup
- Prevents 3+ minute downtime during Kubernetes rollouts

Fixes: #5844
Fixes: #5863