### PR TITLE
feat(search): Add DD option support for FT.DROPINDEX command

### DIFF
--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -242,6 +242,19 @@ size_t ShardDocIndex::DocKeyIndex::Size() const {
   return ids_.size();
 }
 
+std::vector<std::string> ShardDocIndex::DocKeyIndex::GetAllKeys() const {
+  std::vector<std::string> keys;
+  keys.reserve(ids_.size());
+
+  for (const auto& [key, id] : ids_) {
+    if (!key.empty()) {
+      keys.push_back(key);
+    }
+  }
+
+  return keys;
+}
+
 uint8_t DocIndex::GetObjCode() const {
   return type == JSON ? OBJ_JSON : OBJ_HASH;
 }
@@ -605,6 +618,10 @@ ShardDocIndex::FieldsValuesPerDocId ShardDocIndex::LoadKeysData(
 
 DocIndexInfo ShardDocIndex::GetInfo() const {
   return {*base_, key_index_.Size()};
+}
+
+std::vector<std::string> ShardDocIndex::GetAllKeys() const {
+  return key_index_.GetAllKeys();
 }
 
 io::Result<StringVec, ErrorReply> ShardDocIndex::GetTagVals(string_view field) const {

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -224,6 +224,9 @@ class ShardDocIndex {
     std::string_view Get(DocId id) const;
     size_t Size() const;
 
+    // Get all keys in the index
+    std::vector<std::string> GetAllKeys() const;
+
    private:
     absl::flat_hash_map<std::string, DocId> ids_;
     std::vector<std::string> keys_;
@@ -261,6 +264,9 @@ class ShardDocIndex {
   void RemoveDoc(std::string_view key, const DbContext& db_cntx, const PrimeValue& pv);
 
   DocIndexInfo GetInfo() const;
+
+  // Get all document keys in this index
+  std::vector<std::string> GetAllKeys() const;
 
   io::Result<StringVec, facade::ErrorReply> GetTagVals(std::string_view field) const;
 

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -224,8 +224,10 @@ class ShardDocIndex {
     std::string_view Get(DocId id) const;
     size_t Size() const;
 
-    // Get all keys in the index
-    std::vector<std::string> GetAllKeys() const;
+    // Get const reference to the internal ids map
+    const absl::flat_hash_map<std::string, DocId>& GetDocKeysMap() const {
+      return ids_;
+    }
 
    private:
     absl::flat_hash_map<std::string, DocId> ids_;
@@ -265,9 +267,6 @@ class ShardDocIndex {
 
   DocIndexInfo GetInfo() const;
 
-  // Get all document keys in this index
-  std::vector<std::string> GetAllKeys() const;
-
   io::Result<StringVec, facade::ErrorReply> GetTagVals(std::string_view field) const;
 
   // Get synonym manager for this shard
@@ -282,6 +281,11 @@ class ShardDocIndex {
   // Rebuild indices only for documents containing terms from the updated synonym group
   void RebuildForGroup(const OpArgs& op_args, const std::string_view& group_id,
                        const std::vector<std::string_view>& terms);
+
+  // Public access to key index for direct operations (e.g., when dropping index with DD)
+  const DocKeyIndex& key_index() const {
+    return key_index_;
+  }
 
  private:
   // Clears internal data. Traverses all matching documents and assigns ids.
@@ -315,8 +319,8 @@ class ShardDocIndices {
   void InitIndex(const OpArgs& op_args, std::string_view name,
                  std::shared_ptr<const DocIndex> index);
 
-  // Drop index, return true if it existed and was dropped
-  bool DropIndex(std::string_view name);
+  // Drop index, return the dropped index if it existed or nullptr otherwise
+  std::unique_ptr<ShardDocIndex> DropIndex(std::string_view name);
 
   // Drop all indices
   void DropAllIndices();

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -1120,7 +1120,6 @@ void SearchFamily::FtAlter(CmdArgList args, const CommandContext& cmd_cntx) {
   // Rebuild index
   // TODO: Introduce partial rebuild
   auto upd_cb = [idx_name, index_info](Transaction* tx, EngineShard* es) {
-    // Drop the old index (we don't need the documents)
     (void)es->search_indices()->DropIndex(idx_name);
     es->search_indices()->InitIndex(tx->GetOpArgs(es), idx_name, index_info);
     return OpStatus::OK;
@@ -1179,7 +1178,6 @@ void SearchFamily::FtDropIndex(CmdArgList args, const CommandContext& cmd_cntx) 
   DCHECK(num_deleted == 0u || num_deleted == shard_set->size());
   if (num_deleted == 0u)
     return cmd_cntx.rb->SendError("-Unknown Index name");
-
   return cmd_cntx.rb->SendOk();
 }
 

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -1136,10 +1136,9 @@ void SearchFamily::FtDropIndex(CmdArgList args, const CommandContext& cmd_cntx) 
   bool delete_docs = false;
   if (args.size() > 1) {
     string_view option = ArgS(args, 1);
+    // Only check for DD option, ignore other arguments for compatibility
     if (absl::EqualsIgnoreCase(option, "DD")) {
       delete_docs = true;
-    } else {
-      return cmd_cntx.rb->SendError("Unknown argument");
     }
   }
 

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -3328,4 +3328,80 @@ TEST_F(SearchFamilyTest, InvalidConfigOptions) {
   EXPECT_THAT(resp, IsArray());
 }
 
+TEST_F(SearchFamilyTest, DropIndexWithDD) {
+  // Create an index on HASH documents
+  Run({"FT.CREATE", "idx", "ON", "HASH", "PREFIX", "1", "doc:", "SCHEMA", "name", "TEXT"});
+
+  // Add some documents
+  Run({"HSET", "doc:1", "name", "Alice"});
+  Run({"HSET", "doc:2", "name", "Bob"});
+  Run({"HSET", "doc:3", "name", "Charlie"});
+
+  // Verify documents exist
+  auto resp = Run({"EXISTS", "doc:1", "doc:2", "doc:3"});
+  EXPECT_THAT(resp, IntArg(3));
+
+  // Verify index works
+  resp = Run({"FT.SEARCH", "idx", "*"});
+  EXPECT_THAT(resp, AreDocIds("doc:1", "doc:2", "doc:3"));
+
+  // Drop index WITHOUT DD - documents should remain
+  Run({"FT.DROPINDEX", "idx"});
+  resp = Run({"EXISTS", "doc:1", "doc:2", "doc:3"});
+  EXPECT_THAT(resp, IntArg(3));
+
+  // Create index again
+  Run({"FT.CREATE", "idx", "ON", "HASH", "PREFIX", "1", "doc:", "SCHEMA", "name", "TEXT"});
+
+  // Verify index works again
+  resp = Run({"FT.SEARCH", "idx", "*"});
+  EXPECT_THAT(resp, AreDocIds("doc:1", "doc:2", "doc:3"));
+
+  // Drop index WITH DD - documents should be deleted
+  Run({"FT.DROPINDEX", "idx", "DD"});
+  resp = Run({"EXISTS", "doc:1", "doc:2", "doc:3"});
+  EXPECT_THAT(resp, IntArg(0));
+}
+
+TEST_F(SearchFamilyTest, DropIndexWithDDJson) {
+  // Create an index on JSON documents
+  Run({"FT.CREATE", "jidx", "ON", "JSON", "PREFIX", "1", "jdoc:", "SCHEMA", "$.name", "AS", "name",
+       "TEXT"});
+
+  // Add some JSON documents
+  Run({"JSON.SET", "jdoc:1", "$", R"({"name": "Alice"})"});
+  Run({"JSON.SET", "jdoc:2", "$", R"({"name": "Bob"})"});
+  Run({"JSON.SET", "jdoc:3", "$", R"({"name": "Charlie"})"});
+
+  // Verify documents exist
+  auto resp = Run({"EXISTS", "jdoc:1", "jdoc:2", "jdoc:3"});
+  EXPECT_THAT(resp, IntArg(3));
+
+  // Verify index works
+  resp = Run({"FT.SEARCH", "jidx", "*"});
+  EXPECT_THAT(resp, AreDocIds("jdoc:1", "jdoc:2", "jdoc:3"));
+
+  // Drop index WITH DD - documents should be deleted
+  Run({"FT.DROPINDEX", "jidx", "DD"});
+  resp = Run({"EXISTS", "jdoc:1", "jdoc:2", "jdoc:3"});
+  EXPECT_THAT(resp, IntArg(0));
+}
+
+TEST_F(SearchFamilyTest, DropIndexWithInvalidOption) {
+  // Create an index
+  Run({"FT.CREATE", "idx", "ON", "HASH", "PREFIX", "1", "doc:", "SCHEMA", "name", "TEXT"});
+
+  // Try to drop with invalid option
+  auto resp = Run({"FT.DROPINDEX", "idx", "INVALID"});
+  EXPECT_THAT(resp, ErrArg("Unknown argument"));
+
+  // Index should still exist - verify it can be searched
+  Run({"HSET", "doc:1", "name", "test"});
+  resp = Run({"FT.SEARCH", "idx", "*"});
+  EXPECT_THAT(resp, AreDocIds("doc:1"));
+
+  // Clean up
+  Run({"FT.DROPINDEX", "idx", "DD"});
+}
+
 }  // namespace dfly

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -3390,18 +3390,18 @@ TEST_F(SearchFamilyTest, DropIndexWithDDJson) {
 TEST_F(SearchFamilyTest, DropIndexWithInvalidOption) {
   // Create an index
   Run({"FT.CREATE", "idx", "ON", "HASH", "PREFIX", "1", "doc:", "SCHEMA", "name", "TEXT"});
-
-  // Try to drop with invalid option
-  auto resp = Run({"FT.DROPINDEX", "idx", "INVALID"});
-  EXPECT_THAT(resp, ErrArg("Unknown argument"));
-
-  // Index should still exist - verify it can be searched
   Run({"HSET", "doc:1", "name", "test"});
-  resp = Run({"FT.SEARCH", "idx", "*"});
-  EXPECT_THAT(resp, AreDocIds("doc:1"));
+
+  // Drop with unrecognized option (should be ignored, index dropped but documents remain)
+  auto resp = Run({"FT.DROPINDEX", "idx", "INVALID"});
+  EXPECT_THAT(resp, "OK");
+
+  // Document should still exist
+  resp = Run({"EXISTS", "doc:1"});
+  EXPECT_THAT(resp, IntArg(1));
 
   // Clean up
-  Run({"FT.DROPINDEX", "idx", "DD"});
+  Run({"DEL", "doc:1"});
 }
 
 }  // namespace dfly


### PR DESCRIPTION
Implements the `DD` (Delete Documents) option for `FT.DROPINDEX` command.

Fixes: https://github.com/dragonflydb/dragonfly/issues/5513

