### PR TITLE
fix: Add type safety to FindMutable calls

### DIFF
--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -481,9 +481,11 @@ OpResult<uint32_t> OpAdd(const OpArgs& op_args, std::string_view key, const NewE
   // to overwrite the key. However, if the set is empty it means we should delete the
   // key if it exists.
   if (overwrite && (vals_it.begin() == vals_it.end())) {
-    auto it = db_slice.FindMutable(op_args.db_cntx, key).it;  // post_updater will run immediately
-    if (IsValid(it)) {
-      db_slice.Del(op_args.db_cntx, it);
+    // Use type-safe deletion with OBJ_SET (fixes #5316)
+    auto res_it = db_slice.FindMutable(op_args.db_cntx, key, OBJ_SET);
+    if (res_it) {
+      res_it->post_updater.Run();
+      db_slice.Del(op_args.db_cntx, res_it->it);
       if (journal_update && op_args.shard->journal()) {
         RecordJournal(op_args, "DEL"sv, ArgSlice{key});
       }

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -285,9 +285,13 @@ OpResult<int64_t> OpIncrBy(const OpArgs& op_args, string_view key, int64_t incr,
   auto& db_slice = op_args.GetDbSlice();
 
   // we avoid using AddOrFind because of skip_on_missing option for memcache.
-  auto res = db_slice.FindMutable(op_args.db_cntx, key);
+  // Use type-safe FindMutable with OBJ_STRING (fixes #5316)
+  auto res = db_slice.FindMutable(op_args.db_cntx, key, OBJ_STRING);
 
-  if (!IsValid(res.it)) {
+  if (!res) {
+    if (res.status() == OpStatus::WRONG_TYPE)
+      return res.status();
+
     if (skip_on_missing)
       return OpStatus::KEY_NOTFOUND;
 
@@ -300,11 +304,8 @@ OpResult<int64_t> OpIncrBy(const OpArgs& op_args, string_view key, int64_t incr,
     return incr;
   }
 
-  if (res.it->second.ObjType() != OBJ_STRING) {
-    return OpStatus::WRONG_TYPE;
-  }
-
-  auto opt_prev = res.it->second.TryGetInt();
+  // Type is already checked by FindMutable (OBJ_STRING)
+  auto opt_prev = res->it->second.TryGetInt();
   if (!opt_prev) {
     return OpStatus::INVALID_VALUE;
   }
@@ -316,8 +317,8 @@ OpResult<int64_t> OpIncrBy(const OpArgs& op_args, string_view key, int64_t incr,
   }
 
   int64_t new_val = prev + incr;
-  DCHECK(!res.it->second.IsExternal());
-  res.it->second.SetInt(new_val);
+  DCHECK(!res->it->second.IsExternal());
+  res->it->second.SetInt(new_val);
 
   return new_val;
 }
@@ -383,20 +384,20 @@ OpResult<array<int64_t, 5>> OpThrottle(const OpArgs& op_args, const string_view 
   // Cost of this request
   const int64_t increment_ns = emission_interval_ns * quantity;  // should be nonnegative
 
-  auto res = db_slice.FindMutable(op_args.db_cntx, key);
+  // Use type-safe FindMutable with OBJ_STRING (fixes #5316)
+  auto res = db_slice.FindMutable(op_args.db_cntx, key, OBJ_STRING);
   const int64_t now_ns = GetCurrentTimeNs();
 
   int64_t tat_ns = now_ns;
-  if (IsValid(res.it)) {
-    if (res.it->second.ObjType() != OBJ_STRING) {
-      return OpStatus::WRONG_TYPE;
-    }
-
-    auto opt_prev = res.it->second.TryGetInt();
+  if (res) {
+    // Type is already checked by FindMutable (OBJ_STRING)
+    auto opt_prev = res->it->second.TryGetInt();
     if (!opt_prev) {
       return OpStatus::INVALID_VALUE;
     }
     tat_ns = *opt_prev;
+  } else if (res.status() == OpStatus::WRONG_TYPE) {
+    return res.status();
   }
 
   int64_t new_tat_ns = max(tat_ns, now_ns);
@@ -458,14 +459,14 @@ OpResult<array<int64_t, 5>> OpThrottle(const OpArgs& op_args, const string_view 
     // break behavior because the tat_ns value will be used to check for throttling.
     const int64_t new_tat_ms =
         (new_tat_ns + kMilliSecondToNanoSecond - 1) / kMilliSecondToNanoSecond;
-    if (IsValid(res.it)) {
-      if (IsValid(res.exp_it)) {
-        res.exp_it->second = db_slice.FromAbsoluteTime(new_tat_ms);
+    if (res) {
+      if (IsValid(res->exp_it)) {
+        res->exp_it->second = db_slice.FromAbsoluteTime(new_tat_ms);
       } else {
-        db_slice.AddExpire(op_args.db_cntx.db_index, res.it, new_tat_ms);
+        db_slice.AddExpire(op_args.db_cntx.db_index, res->it, new_tat_ms);
       }
 
-      res.it->second.SetInt(new_tat_ns);
+      res->it->second.SetInt(new_tat_ns);
     } else {
       CompactObj cobj;
       cobj.SetInt(new_tat_ns);


### PR DESCRIPTION
Fixes: https://github.com/dragonflydb/dragonfly/issues/5316
Adds explicit type checking to `FindMutable` calls in string, set, and hash family commands to prevent accidentally deleting objects of the wrong type.

Changes:
- `string_family.cc`: `OpIncrBy`, `OpThrottle` → added `OBJ_STRING`
- `set_family.cc`: `OpAdd` → added `OBJ_SET`
- `hset_family.cc`: `HRandField` → added `OBJ_HASH`

This ensures that operations fail fast with `WRONG_TYPE` instead of potentially corrupting data by operating on objects of unexpected types.
