### PR TITLE
feat: add symbols search in tag

### DIFF
--- a/src/core/search/lexer.lex
+++ b/src/core/search/lexer.lex
@@ -37,7 +37,7 @@ sq         \'
 esc_chars  ['"\?\\abfnrtv]
 esc_seq    \\{esc_chars}
 term_ch    \w
-tag_val_ch {term_ch}|\\[,.<>{}\[\]\\\"\':;!@#$%^&*()\-+=~\/ ]
+tag_val_ch [^,.<>{}\[\]\\\"\?':;!@#$%^&*()\-+=~\/| ]|\\.
 astrsk_ch  \*
 
 

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -545,6 +545,18 @@ TEST_F(SearchFamilyTest, TagOptions) {
   EXPECT_THAT(Run({"ft.search", "i1", "@color:{blue}"}), AreDocIds("d:2", "d:4"));
 }
 
+TEST_F(SearchFamilyTest, SymbolsInTag) {
+  Run({"FT.CREATE", "demo_idx", "ON", "HASH", "PREFIX", "1", "doc:", "SCHEMA", "tags", "TAG"});
+  Run({"HSET", "doc:1", "name", "First Item", "tags", "@first"});
+  Run({"HSET", "doc:2", "name", "Second Item", "tags", "?second"});
+  Run({"HSET", "doc:3", "name", "Third Item", "tags", ":third"});
+  Run({"HSET", "doc:4", "name", "Fourth Item", "tags", "\"fourth"});
+  EXPECT_THAT(Run({"FT.SEARCH", "demo_idx", R"(@tags:{\?second})"}), AreDocIds("doc:2"));
+  EXPECT_THAT(Run({"FT.SEARCH", "demo_idx", R"(@tags:{\@first})"}), AreDocIds("doc:1"));
+  EXPECT_THAT(Run({"FT.SEARCH", "demo_idx", R"(@tags:{\:third})"}), AreDocIds("doc:3"));
+  EXPECT_THAT(Run({"FT.SEARCH", "demo_idx", R"(@tags:{\"fourth})"}), AreDocIds("doc:4"));
+}
+
 TEST_F(SearchFamilyTest, TagNumbers) {
   Run({"hset", "d:1", "number", "1"});
   Run({"hset", "d:2", "number", "2"});


### PR DESCRIPTION
fixes: #4999

Added the ability to search for any symbols in the tag