### PR TITLE
server: Remove unused variable and field

### DIFF
--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -754,11 +754,6 @@ error_code Replica::ConsumeDflyStream() {
   };
   RETURN_ON_ERR(exec_st_.SwitchErrorHandler(std::move(err_handler)));
 
-  size_t total_flows_to_finish_partial = 0;
-  for (const auto& flow : thread_flow_map_) {
-    total_flows_to_finish_partial += flow.size();
-  }
-
   LOG(INFO) << "Transitioned into stable sync";
   // Transition flows into stable sync.
   {

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -264,7 +264,6 @@ class DflyShardReplica : public ProtocolClient {
 
   std::shared_ptr<MultiShardExecution> multi_shard_exe_;
   uint32_t flow_id_ = UINT32_MAX;  // Flow id if replica acts as a dfly flow.
-  uint64_t lsn_to_finish_partial_ = 0;
 };
 
 }  // namespace dfly


### PR DESCRIPTION
`total_flows_to_finish_partial` is calculated but unused. It seems to be related to `lsn_to_finish_partial_` field but that is unset and unused elsewhere, both are removed here, if they should have been used anywhere (log them or something similar) the PR can be changed to do that.