### PR TITLE
chore(deps): bump actions/setup-node from 4 to 5 in the actions group

### DIFF
--- a/.github/workflows/mastodon-ruby-tests.yml
+++ b/.github/workflows/mastodon-ruby-tests.yml
@@ -67,9 +67,6 @@ jobs:
       - name: Enable corepack
         shell: bash
         run: corepack enable
-      - name: Corepack prepare yarn
-        shell: bash
-        run: corepack prepare yarn@4.10.3 --activate
       - name: Install all production yarn packages
         shell: bash
         run: yarn workspaces focus --production


### PR DESCRIPTION
* bump up setup-node from 4 to 5

Also, `setup-node@5` uses corepack to manage `yarn` versions.  Move `corepack activate` before such that it can use it.