### PR TITLE
fix(search): prevent crash on HSET with same key across databases

### DIFF
--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -323,6 +323,10 @@ void ShardDocIndex::AddDoc(string_view key, const DbContext& db_cntx, const Prim
   if (!indices_)
     return;
 
+  // Only index documents from database 0
+  if (db_cntx.db_index != 0)
+    return;
+
   auto accessor = GetAccessor(db_cntx, pv);
   DocId id = key_index_.Add(key);
   if (!indices_->Add(id, *accessor)) {
@@ -332,6 +336,10 @@ void ShardDocIndex::AddDoc(string_view key, const DbContext& db_cntx, const Prim
 
 void ShardDocIndex::RemoveDoc(string_view key, const DbContext& db_cntx, const PrimeValue& pv) {
   if (!indices_)
+    return;
+
+  // Only handle documents from database 0
+  if (db_cntx.db_index != 0)
     return;
 
   auto accessor = GetAccessor(db_cntx, pv);


### PR DESCRIPTION
Fixes: https://github.com/dragonflydb/dragonfly/issues/5215

Simple example to reproduce the crash:
```
FT.CREATE "idx" "ON" "HASH" "SCHEMA" "field1" "TEXT"
HSET "hash1" "field1" "value1"
SELECT 1
HSET "hash1" "field1" "another_value"
```