### PR TITLE
fix(metrics): Prevent underflow in connected_clients

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -2142,10 +2142,13 @@ void Connection::IncrNumConns() {
 }
 
 void Connection::DecrNumConns() {
-  if (IsMainOrMemcache())
-    --stats_->num_conns_main;
-  else
-    --stats_->num_conns_other;
+  if (IsMainOrMemcache()) {
+    if (stats_->num_conns_main > 0)
+      --stats_->num_conns_main;
+  } else {
+    if (stats_->num_conns_other > 0)
+      --stats_->num_conns_other;
+  }
 }
 
 bool Connection::IsReplySizeOverLimit() const {


### PR DESCRIPTION
We have issues with the `dragonfly_connected_clients` under flowing and becoming a very huge value. I am not sure if this is the result of a race condition or an unbalanced number of increment/decrement calls. This is an attempt to add a check to prevent the underflow from happening.

<img width="3234" height="498" alt="image" src="https://github.com/user-attachments/assets/640483e8-a0a5-4d11-9e02-b0173e7228f0" />

 