### PR TITLE
fix(stream): prevent assert failure in XDEL with non-existent ID

### DIFF
--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -1596,9 +1596,11 @@ OpResult<uint32_t> OpDel(const OpArgs& op_args, string_view key, absl::Span<stre
     } else if (first_entry) {
       streamGetEdgeID(stream_inst, 1, 1, &stream_inst->first_id);
     }
+    // Only update size tracking if we actually deleted something.
+    // This avoids issues with memory tracking noise from other operations
+    // in the same thread.
+    tracker.UpdateStreamSize(cobj);
   }
-
-  tracker.UpdateStreamSize(cobj);
   return deleted;
 }
 

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -1311,4 +1311,13 @@ TEST_F(StreamFamilyTest, XClaimWithNonExistentGroup) {
   EXPECT_THAT(resp, ArrLen(0));
 }
 
+TEST_F(StreamFamilyTest, XDelNonExistentId) {
+  string key = R"(k1 "v1" k2 "v2 with spaces" "k3 with spaces" "v3")";
+  Run({"XADD", key, "0", "set1", "member1"});
+
+  // Try to delete a non-existent ID - should not crash (issue #5202)
+  auto resp = Run({"XDEL", key, "46-867"});
+  EXPECT_THAT(resp, IntArg(0));  // Nothing deleted
+}
+
 }  // namespace dfly


### PR DESCRIPTION
Fixes: https://github.com/dragonflydb/dragonfly/issues/5202

When calling `XDEL` with an ID that doesn't exist in the stream, the command would trigger a `DCHECK` assertion failure in debug mode.
The root cause was that `UpdateStreamSize()` was called unconditionally in `OpDel`, even when no entries were deleted. 