### PR TITLE
fix: Allow JSON.DEBUG HELP to work without key parameter

### DIFF
--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -2632,6 +2632,16 @@ TEST_F(JsonFamilyTest, MGetLegacy) {
   EXPECT_THAT(resp.GetVec(), ElementsAre(R"(3)", R"(6)"));
 }
 
+TEST_F(JsonFamilyTest, DebugHelp) {
+  auto resp = Run({"JSON.DEBUG", "HELP"});
+  ASSERT_EQ(RespExpr::ARRAY, resp.type);
+  EXPECT_EQ(resp.GetVec().size(), 3);
+
+  EXPECT_THAT(resp.GetVec()[0].GetString(), HasSubstr("MEMORY"));
+  EXPECT_THAT(resp.GetVec()[1].GetString(), HasSubstr("FIELDS"));
+  EXPECT_THAT(resp.GetVec()[2].GetString(), HasSubstr("HELP"));
+}
+
 TEST_F(JsonFamilyTest, DebugFields) {
   string json = R"(
     [1, 2.3, "foo", true, null, {}, [], {"a":1, "b":2}, [1,2,3]]


### PR DESCRIPTION
`JSON.DEBUG HELP` was requiring an unnecessary key parameter due to the command registration expecting minimum 3 arguments and key position at index 2.

- Changed command registration from `-3, 2, 2` to `-2, 0, 0` (min 2 args, no key required)
- Refactored `JSON.DEBUG MEMORY` and `JSON.DEBUG FIELDS` to use `shard_set->Await()` instead of transaction-based execution
- This allows HELP to work without a key while MEMORY/FIELDS still functions correctly
