### PR TITLE
server: Yield fiber if running for over 1ms

### DIFF
--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -693,11 +693,16 @@ error_code Replica::ConsumeRedisStream() {
   };
   RETURN_ON_ERR(exec_st_.SwitchErrorHandler(std::move(err_handler)));
 
-  facade::CmdArgVec args_vector;
+  CmdArgVec args_vector;
 
   acks_fb_ = fb2::Fiber("redis_acks", &Replica::RedisStreamAcksFb, this);
 
   while (true) {
+    // Yield if the fiber has been running for long.
+    if (base::CycleClock::ToUsec(ThisFiber::GetRunningTimeCycles()) > 1000) {  // 1ms
+      ThisFiber::Yield();
+    }
+
     auto response = ReadRespReply(&io_buf, /*copy_msg=*/false);
     if (!response.has_value()) {
       LOG_REPL_ERROR("Error in Redis Stream at phase "


### PR DESCRIPTION
When using epoll as the event loop in debug mode, it can be observed that the stream consumption fiber in stable state can monopolize the core allowing no other fibers to run. This causes CI failures when running on epoll + debug + single proactor thread.

To avoid this a yield is added similar to `ListenerInterface::RunAcceptLoop()`

FIXES https://github.com/dragonflydb/dragonfly/issues/4451