### PR TITLE
chore: non preemptive ProtocolClient destructor

### DIFF
--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -161,6 +161,8 @@ void OutgoingMigration::Finish(const GenericError& error) {
   }
 
   bool should_cancel_flows = false;
+  absl::Cleanup on_exit([this]() { CloseSocket(); });
+
   {
     util::fb2::LockGuard lk(state_mu_);
     switch (state_) {
@@ -313,6 +315,7 @@ void OutgoingMigration::SyncFb() {
     break;
   }
 
+  CloseSocket();
   VLOG(1) << "Exiting outgoing migration fiber for migration " << migration_info_.ToString();
 }
 

--- a/src/server/protocol_client.cc
+++ b/src/server/protocol_client.cc
@@ -119,13 +119,6 @@ ProtocolClient::ProtocolClient(ServerContext context) : server_context_(std::mov
 ProtocolClient::~ProtocolClient() {
   exec_st_.JoinErrorHandler();
 
-  // FIXME: We should close the socket explictly outside of the destructor. This currently
-  // breaks test_cancel_replication_immediately.
-  if (sock_) {
-    std::error_code ec;
-    sock_->proactor()->Await([this, &ec]() { ec = sock_->Close(); });
-    LOG_IF(ERROR, ec) << "Error closing socket " << ec;
-  }
 #ifdef DFLY_USE_SSL
   if (ssl_ctx_) {
     SSL_CTX_free(ssl_ctx_);
@@ -235,6 +228,9 @@ void ProtocolClient::CloseSocket() {
         auto ec = sock_->Shutdown(SHUT_RDWR);
         LOG_IF(ERROR, ec) << "Could not shutdown socket " << ec;
       }
+
+      auto ec = sock_->Close();  // Quietly close.
+      LOG_IF(WARNING, ec) << "Error closing socket " << ec << "/" << ec.message();
     });
   }
 }
@@ -385,11 +381,11 @@ void ProtocolClient::ResetParser(RedisParser::Mode mode) {
 }
 
 uint64_t ProtocolClient::LastIoTime() const {
-  return last_io_time_;
+  return last_io_time_.load(std::memory_order_relaxed);
 }
 
 void ProtocolClient::TouchIoTime() {
-  last_io_time_ = Proactor()->GetMonotonicTimeNs();
+  last_io_time_.store(Proactor()->GetMonotonicTimeNs(), std::memory_order_relaxed);
 }
 
 }  // namespace dfly

--- a/src/server/protocol_client.h
+++ b/src/server/protocol_client.h
@@ -132,7 +132,7 @@ class ProtocolClient {
   std::string last_cmd_;
   std::string last_resp_;
 
-  uint64_t last_io_time_ = 0;  // in ns, monotonic clock.
+  std::atomic<uint64_t> last_io_time_ = 0;  // in ns, monotonic clock.
 
 #ifdef DFLY_USE_SSL
 


### PR DESCRIPTION
Preempting in the destructor of ProtocolClient is error prone when a thread local shared_ptr releases the underline object as part of an (operator=) assignment statement. The assignment on the thread local will block while the ProtocolClient is released and another fiber can grab a copy of it while the object is in a mixed state.

Furthermore, there is a data race in `GetSummary()` and `ProtocolClient::Sock()` initialization. Even though `Sock()` is not yet initialized, we know prior on which proactor its fiber will run. Therefore, we can remove the call to `Sock()` and dispatch the callback directly to socket the thread avoiding the data race.

* remove preemption from ~ProtocolClient
* fix rare race condition  last_io_time_ by making it atomic
* always dispatch in socket thread for Replica::GetSummary()
