### PR TITLE
test: fix shutdown_test by waiting for server to be ready after restart

### DIFF
--- a/tests/dragonfly/shutdown_test.py
+++ b/tests/dragonfly/shutdown_test.py
@@ -5,6 +5,7 @@ from redis import asyncio as aioredis
 from pathlib import Path
 
 from . import dfly_args
+from .utility import wait_available_async
 
 BASIC_ARGS = {"dir": "{DRAGONFLY_TMP}/"}
 
@@ -104,6 +105,7 @@ class TestShutdownOptions:
         # Restart and verify data persisted
         df_server.start()
         client = aioredis.Redis(port=df_server.port)
+        await wait_available_async(client)
         val = await client.get("safe_key")
         assert val == b"safe_value"
         await client.connection_pool.disconnect()
@@ -130,6 +132,7 @@ class TestShutdownOptions:
 
         df_server.start()
         client = aioredis.Redis(port=df_server.port)
+        await wait_available_async(client)
         val = await client.get("save_key")
         assert val == b"save_value"
         await client.connection_pool.disconnect()


### PR DESCRIPTION
The `test_shutdown_save_persists_snapshot` test was failing with `BusyLoadingError: Dragonfly is loading the dataset in memory`.
After the server restart, the test immediately attempted to execute a GET command while the server was still loading the snapshot from disk.

Solution:
Added `wait_available_async()` calls after server restarts in both:
- `test_shutdown_safe_persists_snapshot`
- `test_shutdown_save_persists_snapshot`