### PR TITLE
chore: reduce frequency of  clock invocations

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -960,7 +960,10 @@ OpResult<uint64_t> OpTtl(Transaction* t, EngineShard* shard, string_view key) {
   auto opExpireTimeResult = OpExpireTime(t, shard, key);
 
   if (opExpireTimeResult) {
-    int64_t ttl_ms = opExpireTimeResult.value() - t->GetDbContext().time_now_ms;
+    auto now = t->GetDbContext().time_now_ms;
+    DCHECK_GT(now, 0u);
+
+    int64_t ttl_ms = opExpireTimeResult.value() - now;
     DCHECK_GT(ttl_ms, 0);  // Otherwise FindReadOnly would return null.
     return ttl_ms;
   } else {
@@ -1898,6 +1901,7 @@ void GenericFamily::Time(CmdArgList args, const CommandContext& cmd_cntx) {
   } else {
     now_usec = absl::GetCurrentTimeNanos() / 1000;
   }
+  DCHECK_GT(now_usec, 0u);
 
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx.rb);
   rb->StartArray(2);

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -3886,7 +3886,7 @@ void ServerFamily::Role(CmdArgList args, const CommandContext& cmd_cntx) {
     rb->StartArray(4 + cluster_replicas_.size() * 3);
     rb->SendBulkString(GetFlag(FLAGS_info_replication_valkey_compatible) ? "slave" : "replica");
 
-    auto send_replica_info = [rb](Replica::Summary rinfo) {
+    auto send_replica_info = [rb](const Replica::Summary& rinfo) {
       rb->SendBulkString(rinfo.host);
       rb->SendBulkString(absl::StrCat(rinfo.port));
       if (rinfo.full_sync_done) {
@@ -3908,7 +3908,7 @@ void ServerFamily::Role(CmdArgList args, const CommandContext& cmd_cntx) {
 }
 
 void ServerFamily::Script(CmdArgList args, const CommandContext& cmd_cntx) {
-  script_mgr_->Run(std::move(args), cmd_cntx.tx, cmd_cntx.rb, cmd_cntx.conn_cntx);
+  script_mgr_->Run(args, cmd_cntx.tx, cmd_cntx.rb, cmd_cntx.conn_cntx);
 }
 
 void ServerFamily::LastSave(CmdArgList args, const CommandContext& cmd_cntx) {

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -2808,8 +2808,10 @@ void StreamFamily::XClaim(CmdArgList args, const CommandContext& cmd_cntx) {
   if (!ParseXclaimOptions(args, opts, cmd_cntx.rb))
     return;
 
-  if (uint64_t now = cmd_cntx.tx->GetDbContext().time_now_ms;
-      opts.delivery_time < 0 || static_cast<uint64_t>(opts.delivery_time) > now)
+  uint64_t now = cmd_cntx.tx->GetDbContext().time_now_ms;
+  DCHECK_GT(now, 0u);
+
+  if (opts.delivery_time < 0 || static_cast<uint64_t>(opts.delivery_time) > now)
     opts.delivery_time = now;
 
   auto cb = [&](Transaction* t, EngineShard* shard) {

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -599,9 +599,11 @@ TEST_F(StreamFamilyTest, Xclaim) {
   resp = Run({"xclaim", "foo", "group", "alice", "0", "1-4", "TIME",
               absl::StrCat(TEST_current_time_ms - 500), "justid"});
   EXPECT_THAT(resp.GetString(), "1-4");
+
   // min idle time is exceeded for this entry
   resp = Run({"xclaim", "foo", "group", "bob", "600", "1-4"});
-  EXPECT_THAT(resp, ArrLen(0));
+  ASSERT_THAT(resp, ArrLen(0));
+
   resp = Run({"xclaim", "foo", "group", "bob", "400", "1-4", "justid"});
   EXPECT_THAT(resp.GetString(), "1-4");
 


### PR DESCRIPTION
Partially addresses #5942 as now squashing transactions call clock only once. Moreover for most transactions we called clock twice - in the c'tor and during scheduling. 
<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->