### PR TITLE
server: Exit consume-redis-stream loop on error

### DIFF
--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -707,11 +707,10 @@ error_code Replica::ConsumeRedisStream() {
     // If the acks-fb or something else triggered a shutdown, then do not attempt to read from the
     // stream.
     if (!exec_st_.IsRunning()) {
-      if (exec_st_.IsError()) {
-        LOG_REPL_ERROR("Stopping stream consumer in phase "
-                       << GetCurrentPhase()
-                       << " because of external error: " << exec_st_.GetError().Format());
-      }
+      DCHECK(exec_st_.IsError());
+      LOG_REPL_ERROR("Stopping stream consumer in phase "
+                     << GetCurrentPhase()
+                     << " because of external error: " << exec_st_.GetError().Format());
       acks_fb_.JoinIfNeeded();
       return exec_st_.GetError();
     }


### PR DESCRIPTION
Recently a yield was added to the consume-redis-stream loop in https://github.com/dragonflydb/dragonfly/pull/5924. 

It is possible that when the fiber is scheduled again, things have changed in the interim, likely because the redis acks fiber detected an error while writing (such as peer disconnected) and caused a shutdown of the socket. 

If so we now exit from the loop instead of trying to read from a possibly closed socket.

fixes https://github.com/dragonflydb/dragonfly/issues/5947
