### PR TITLE
chore: add a task that periodically updates the expire base time

### DIFF
--- a/src/core/expire_period.h
+++ b/src/core/expire_period.h
@@ -10,13 +10,13 @@ namespace dfly {
 
 class ExpirePeriod {
  public:
-  static constexpr size_t kMaxGenId = 15;
+  static constexpr std::size_t kMaxGenId = 15;
 
   ExpirePeriod() : val_(0), gen_(0), precision_(0) {
     static_assert(sizeof(ExpirePeriod) == 8);  // TODO
   }
 
-  explicit ExpirePeriod(uint64_t ms, unsigned gen = 0) : ExpirePeriod() {
+  explicit ExpirePeriod(uint64_t ms, unsigned gen = 0) : gen_(gen) {
     Set(ms);
   }
 
@@ -35,7 +35,9 @@ class ExpirePeriod {
 
   void Set(uint64_t ms);
 
-  bool is_second_precision() { return precision_ == 1;}
+  bool is_second_precision() {
+    return precision_ == 1;
+  }
 
  private:
   uint64_t val_ : 59;
@@ -48,13 +50,13 @@ inline void ExpirePeriod::Set(uint64_t ms) {
 
   if (ms < kBarrier) {
     val_ = ms;
-    precision_ = 0;   // ms
+    precision_ = 0;  // ms
     return;
   }
 
   precision_ = 1;
   if (ms < kBarrier << 10) {
-    ms = (ms + 500) / 1000;   // seconds
+    ms = (ms + 500) / 1000;  // seconds
   }
   val_ = ms >= kBarrier ? kBarrier - 1 : ms;
 }

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -872,7 +872,7 @@ optional<DebugCmd::PopulateOptions> DebugCmd::ParsePopulateArgs(CmdArgList args,
       }
       case FLAG_EXPIRE: {
         auto [min_ttl, max_ttl] = parser.Next<uint32_t, uint32_t>();
-        if (min_ttl >= max_ttl) {
+        if (min_ttl > max_ttl) {
           builder->SendError(kExpiryOutOfRange);
           (void)parser.TakeError();
           return nullopt;
@@ -1641,7 +1641,8 @@ void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBat
     if (options.expire_ttl_range.has_value()) {
       uint32_t start = options.expire_ttl_range->first;
       uint32_t end = options.expire_ttl_range->second;
-      uint32_t expire_ttl = rand() % (end - start) + start;
+      uint32_t expire_ttl = start + ((end > start) ? rand() % (end - start) : 0);
+
       VLOG(1) << "set key " << key << " expire ttl as " << expire_ttl;
       auto cid = sf_.service().mutable_registry()->Find("EXPIRE");
       absl::InlinedVector<string, 5> args;

--- a/src/server/engine_shard.h
+++ b/src/server/engine_shard.h
@@ -49,6 +49,7 @@ class EngineShard {
     uint64_t total_heartbeat_expired_keys = 0;
     uint64_t total_heartbeat_expired_bytes = 0;
     uint64_t total_heartbeat_expired_calls = 0;
+    uint64_t total_update_expire_calls = 0;
 
     // cluster stats
     uint64_t total_migrated_keys = 0;
@@ -258,6 +259,7 @@ class EngineShard {
   // context of the controlling thread will access this shard!
   // --------------------------------------------------------------------------
   uint32_t DefragTask();
+  uint32_t UpdateExpiresTask();
 
   TxQueue txq_;
   TaskQueue queue_, queue2_;
@@ -284,8 +286,18 @@ class EngineShard {
   journal::Journal* journal_ = nullptr;
   IntentLock shard_lock_;
 
-  uint32_t defrag_task_ = 0;
+  // Idle tasks.
+  uint32_t defrag_task_ = 0, update_expire_base_task_ = 0;
+
   EvictionTaskState eviction_state_;  // Used on eviction fiber
+  struct UpdateExpireState {
+    uint64_t cursor = 0;
+    DbIndex db_index = 0;
+    uint64_t stale_entries = 0;
+  };
+
+  UpdateExpireState* update_expire_state_ = nullptr;
+
   util::fb2::Fiber fiber_heartbeat_periodic_;
   util::fb2::Done fiber_heartbeat_periodic_done_;
 

--- a/src/server/namespaces.cc
+++ b/src/server/namespaces.cc
@@ -22,7 +22,7 @@ Namespace::Namespace() {
     CHECK(es != nullptr);
     ShardId sid = es->shard_id();
     shard_db_slices_[sid] = make_unique<DbSlice>(sid, absl::GetFlag(FLAGS_cache_mode), es);
-    shard_db_slices_[sid]->UpdateExpireBase(absl::GetCurrentTimeNanos() / 1000000, 0);
+    shard_db_slices_[sid]->NextExpireGen(absl::GetCurrentTimeNanos() / 1000000);
   });
 }
 

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -255,7 +255,7 @@ void BaseFamilyTest::ResetService() {
   TEST_current_time_ms = absl::GetCurrentTimeNanos() / 1000000;
   auto default_ns = &namespaces->GetDefaultNamespace();
   auto cb = [&](EngineShard* s) {
-    default_ns->GetDbSlice(s->shard_id()).UpdateExpireBase(TEST_current_time_ms - 1000, 0);
+    default_ns->GetDbSlice(s->shard_id()).NextExpireGen(TEST_current_time_ms - 1000);
   };
   shard_set->RunBriefInParallel(cb);
 


### PR DESCRIPTION
The task is run during cpu idle periods. It starts refreshing the base after several days. During the updates there are two bases and only one that is currently active: expire_gen_id_

1. The update process concludes when it reaches end of the traversal and it did not skip any values that should be updated.

2. It skips values when it encounters expired times as it can not delete values in the scope of the task.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->