### PR TITLE
fix(tiering): Remove disk store files on exit

### DIFF
--- a/src/server/tiering/disk_storage.h
+++ b/src/server/tiering/disk_storage.h
@@ -70,6 +70,7 @@ class DiskStorage {
     util::fb2::EventCount ev;  // woken up when in-progress op finishes
   } grow_;                     // status of latest blocking Grow() operation
 
+  std::string backing_file_path_;
   std::unique_ptr<util::fb2::LinuxFile> backing_file_;
   ExternalAllocator alloc_;
 };

--- a/src/server/tiering/disk_storage_test.cc
+++ b/src/server/tiering/disk_storage_test.cc
@@ -32,7 +32,9 @@ struct DiskStorageTest : public PoolTestBase {
   void Close() {
     storage_->Close();
     storage_.reset();
-    unlink(filename_.c_str());
+
+    // Disk storage deletes its files on exit
+    EXPECT_FALSE(std::filesystem::exists(filename_));
   }
 
   void Stash(size_t index, string value) {

--- a/src/server/tiering/op_manager_test.cc
+++ b/src/server/tiering/op_manager_test.cc
@@ -54,7 +54,6 @@ struct OpManagerTest : PoolTestBase, OpManager {
 
   void Close() {
     OpManager::Close();
-    EXPECT_EQ(unlink("op_manager_test_backing"), 0);
   }
 
   util::fb2::Future<std::string> Read(EntryId id, DiskSegment segment) {


### PR DESCRIPTION
There's no reason for those files to exist when the instance stops. They're never re-used