### PR TITLE
feat(charts): Add Helm Chart mode for statefulset deployment without …

### DIFF
--- a/contrib/charts/dragonfly/README.md
+++ b/contrib/charts/dragonfly/README.md
@@ -1,6 +1,6 @@
 # dragonfly
 
-![Version: v0.12.0](https://img.shields.io/badge/Version-v0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.12.0](https://img.shields.io/badge/AppVersion-v0.12.0-informational?style=flat-square)
+![Version: v1.34.2](https://img.shields.io/badge/Version-v1.34.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.34.2](https://img.shields.io/badge/AppVersion-v1.34.2-informational?style=flat-square)
 
 Dragonfly is a modern in-memory datastore, fully compatible with Redis and Memcached APIs.
 
@@ -32,21 +32,29 @@ helm upgrade --install dragonfly oci://ghcr.io/dragonflydb/dragonfly/helm/dragon
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity for pod assignment |
 | command | list | `[]` | Allow overriding the container's command |
+| env | list | `[]` | extra environment variables |
+| envFrom | list | `[]` | extra environment variables from K8s objects |
 | extraArgs | list | `[]` | Extra arguments to pass to the dragonfly binary |
 | extraContainers | list | `[]` | Additional sidecar containers |
 | extraObjects | list | `[]` | extra K8s manifests to deploy |
 | extraVolumeMounts | list | `[]` | Extra volume mounts corresponding to the volumes mounted above |
 | extraVolumes | list | `[]` | Extra volumes to mount into the pods |
 | fullnameOverride | string | `""` | String to fully override dragonfly.fullname |
+| hostNetwork | bool | `false` | Set hostNetwork for pod |
 | image.pullPolicy | string | `"IfNotPresent"` | Dragonfly image pull policy |
 | image.repository | string | `"docker.dragonflydb.io/dragonflydb/dragonfly"` | Container Image Registry to pull the image from |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Container Registry Secret names in an array |
 | initContainers | list | `[]` | A list of initContainers to run before each pod starts |
+| mode | string | `"deployment"` | Valid values are "deployment" or "statefulset". |
 | nameOverride | string | `""` | String to partially override dragonfly.fullname |
 | nodeSelector | object | `{}` | Node labels for pod assignment |
+| passwordFromSecret.enable | bool | `false` |  |
+| passwordFromSecret.existingSecret.key | string | `""` |  |
+| passwordFromSecret.existingSecret.name | string | `""` |  |
 | podAnnotations | object | `{}` | Annotations for pods |
 | podSecurityContext | object | `{}` | Set securityContext for pod itself |
+| priorityClassName | string | `""` | Priority class name for pod assignment |
 | probes.livenessProbe.exec.command[0] | string | `"/bin/sh"` |  |
 | probes.livenessProbe.exec.command[1] | string | `"/usr/local/bin/healthcheck.sh"` |  |
 | probes.livenessProbe.failureThreshold | int | `3` |  |
@@ -66,11 +74,11 @@ helm upgrade --install dragonfly oci://ghcr.io/dragonflydb/dragonfly/helm/dragon
 | replicaCount | int | `1` | Number of replicas to deploy |
 | resources.limits | object | `{}` | The resource limits for the containers |
 | resources.requests | object | `{}` | The requested resources for the containers |
-| env | list | `[]` | Extra environment variables |
-| envFrom | list | `[]` | Extra environment variables from K8s objects |
 | securityContext | object | `{}` | Set securityContext for containers |
 | service.annotations | object | `{}` | Extra annotations for the service |
+| service.clusterIP | string | `""` | Cluster IP address to assign to the service. Leave empty to auto-allocate |
 | service.labels | object | `{}` | Extra labels for the service |
+| service.loadBalancerIP | string | `""` | Load balancer static ip to use when service type is set to LoadBalancer |
 | service.metrics.portName | string | `"metrics"` | name for the metrics port |
 | service.metrics.serviceType | string | `"ClusterIP"` | serviceType for the metrics service |
 | service.port | int | `6379` | Dragonfly service port |
@@ -92,10 +100,12 @@ helm upgrade --install dragonfly oci://ghcr.io/dragonflydb/dragonfly/helm/dragon
 | tls.duration | string | `"87600h0m0s"` | duration or ttl of the validity of the created certificate |
 | tls.enabled | bool | `false` | enable TLS |
 | tls.existing_secret | string | `""` | use TLS certificates from existing secret |
+| tls.issuer.group | string | `"cert-manager.io"` | group of the referenced issuer if you are using an external issuer, change this to that issuer group. |
 | tls.issuer.kind | string | `"ClusterIssuer"` | cert-manager issuer kind. Usually Issuer or ClusterIssuer |
 | tls.issuer.name | string | `"selfsigned"` | name of the referenced issuer |
 | tls.key | string | `""` | TLS private key |
 | tolerations | list | `[]` | Tolerations for pod assignment |
+| topologySpreadConstraints | list | `[]` | Topology Spread Constraints for pod assignment |
 
 ----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/contrib/charts/dragonfly/templates/deployment.yaml
+++ b/contrib/charts/dragonfly/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.storage.enabled }}
+{{- if and (not .Values.storage.enabled) (eq .Values.mode "deployment") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/contrib/charts/dragonfly/templates/service.yaml
+++ b/contrib/charts/dragonfly/templates/service.yaml
@@ -19,8 +19,10 @@ spec:
   {{- if and (eq .Values.service.type "LoadBalancer") (ne .Values.service.loadBalancerIP "") }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
-  {{- if or (and (eq .Values.service.type "ClusterIP") (ne .Values.service.clusterIP "")) (eq .Values.service.type "") }}
+  {{- if and (eq .Values.service.type "ClusterIP") (ne .Values.service.clusterIP "") }}
   clusterIP: {{ .Values.service.clusterIP }}
+  {{- else if eq .Values.service.type ""}}
+  clusterIP: None
   {{- end }}
   ports:
     - port: {{ .Values.service.port }}

--- a/contrib/charts/dragonfly/templates/service.yaml
+++ b/contrib/charts/dragonfly/templates/service.yaml
@@ -19,7 +19,7 @@ spec:
   {{- if and (eq .Values.service.type "LoadBalancer") (ne .Values.service.loadBalancerIP "") }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
-  {{- if or (and (eq .Values.service.type "ClusterIP") (ne .Values.service.clusterIP "")) (eq .Values.service.type "")  }}
+  {{- if or (and (eq .Values.service.type "ClusterIP") (ne .Values.service.clusterIP "")) (eq .Values.service.type "") }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
   ports:

--- a/contrib/charts/dragonfly/templates/service.yaml
+++ b/contrib/charts/dragonfly/templates/service.yaml
@@ -13,11 +13,13 @@ metadata:
     {{- end }}
     {{- include "dragonfly.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.service.type }}
   type: {{ .Values.service.type }}
+  {{- end }}
   {{- if and (eq .Values.service.type "LoadBalancer") (ne .Values.service.loadBalancerIP "") }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
-  {{- if and (eq .Values.service.type "ClusterIP") (ne .Values.service.clusterIP "") }}
+  {{- if or (and (eq .Values.service.type "ClusterIP") (ne .Values.service.clusterIP "")) (eq .Values.service.type "")  }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
   ports:

--- a/contrib/charts/dragonfly/templates/service.yaml
+++ b/contrib/charts/dragonfly/templates/service.yaml
@@ -19,10 +19,8 @@ spec:
   {{- if and (eq .Values.service.type "LoadBalancer") (ne .Values.service.loadBalancerIP "") }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
-  {{- if and (eq .Values.service.type "ClusterIP") (ne .Values.service.clusterIP "") }}
+  {{- if or (and (eq .Values.service.type "ClusterIP") (ne .Values.service.clusterIP "")) (eq .Values.service.type "") }}
   clusterIP: {{ .Values.service.clusterIP }}
-  {{- else if eq .Values.service.type ""}}
-  clusterIP: None
   {{- end }}
   ports:
     - port: {{ .Values.service.port }}

--- a/contrib/charts/dragonfly/templates/statefulset.yaml
+++ b/contrib/charts/dragonfly/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.storage.enabled }}
+{{- if or (.Values.storage.enabled) (eq .Values.mode "statefulset") }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -25,6 +25,7 @@ spec:
         {{- include "dragonfly.selectorLabels" . | nindent 8 }}
     spec:
       {{- include "dragonfly.pod" . | trim | nindent 6 }}
+  {{- if .Values.storage.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: "{{ .Release.Name }}-data"
@@ -34,4 +35,5 @@ spec:
         resources:
           requests:
             storage: {{ .Values.storage.requests }}
+  {{- end }}
 {{- end }}

--- a/contrib/charts/dragonfly/values.schema.json
+++ b/contrib/charts/dragonfly/values.schema.json
@@ -86,7 +86,8 @@
           "enum": [
             "ClusterIP",
             "NodePort",
-            "LoadBalancer"
+            "LoadBalancer",
+            ""
           ]
         },
         "loadBalancerIP": {

--- a/contrib/charts/dragonfly/values.schema.json
+++ b/contrib/charts/dragonfly/values.schema.json
@@ -1,0 +1,332 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Dragonfly Helm Chart Values Schema",
+  "type": "object",
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of replicas to deploy"
+    },
+    "mode": {
+      "type": "string",
+      "enum": [
+        "deployment",
+        "statefulset"
+      ],
+      "default": "deployment",
+      "description": "Valid values are 'deployment' or 'statefulset'"
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": {
+          "type": "string"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": [
+            "Always",
+            "IfNotPresent",
+            "Never"
+          ]
+        },
+        "tag": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "repository",
+        "pullPolicy"
+      ]
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "podAnnotations": {
+      "type": "object"
+    },
+    "podSecurityContext": {
+      "type": "object"
+    },
+    "securityContext": {
+      "type": "object"
+    },
+    "hostNetwork": {
+      "type": "boolean"
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "ClusterIP",
+            "NodePort",
+            "LoadBalancer"
+          ]
+        },
+        "loadBalancerIP": {
+          "type": "string"
+        },
+        "clusterIP": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "labels": {
+          "type": "object"
+        },
+        "metrics": {
+          "type": "object",
+          "properties": {
+            "portName": {
+              "type": "string"
+            },
+            "serviceType": {
+              "type": "string",
+              "enum": [
+                "ClusterIP",
+                "NodePort",
+                "LoadBalancer"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "serviceMonitor": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "labels": {
+          "type": "object"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "interval": {
+          "type": "string"
+        },
+        "scrapeTimeout": {
+          "type": "string"
+        }
+      }
+    },
+    "prometheusRule": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "spec": {
+          "type": "array"
+        }
+      }
+    },
+    "storage": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "storageClassName": {
+          "type": "string"
+        },
+        "requests": {
+          "type": "string"
+        }
+      }
+    },
+    "tls": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "createCerts": {
+          "type": "boolean"
+        },
+        "duration": {
+          "type": "string"
+        },
+        "issuer": {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "group": {
+              "type": "string"
+            }
+          }
+        },
+        "existing_secret": {
+          "type": "string"
+        },
+        "cert": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        }
+      }
+    },
+    "passwordFromSecret": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean"
+        },
+        "existingSecret": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "key": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "probes": {
+      "type": "object",
+      "properties": {
+        "livenessProbe": {
+          "type": "object"
+        },
+        "readinessProbe": {
+          "type": "object"
+        }
+      }
+    },
+    "command": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "extraArgs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "extraVolumes": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "initContainers": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraContainers": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraObjects": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "resources": {
+      "type": "object",
+      "properties": {
+        "requests": {
+          "type": "object"
+        },
+        "limits": {
+          "type": "object"
+        }
+      }
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "envFrom": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "priorityClassName": {
+      "type": "string"
+    },
+    "nodeSelector": {
+      "type": "object"
+    },
+    "tolerations": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "affinity": {
+      "type": "object"
+    },
+    "topologySpreadConstraints": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  "required": [
+    "replicaCount",
+    "mode",
+    "image"
+  ]
+}

--- a/contrib/charts/dragonfly/values.schema.json
+++ b/contrib/charts/dragonfly/values.schema.json
@@ -94,7 +94,10 @@
           "type": "string"
         },
         "clusterIP": {
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "port": {
           "type": "integer"

--- a/contrib/charts/dragonfly/values.yaml
+++ b/contrib/charts/dragonfly/values.yaml
@@ -5,6 +5,9 @@
 # -- Number of replicas to deploy
 replicaCount: 1
 
+# -- Valid values are "deployment" or "statefulset".
+mode: "deployment"
+
 image:
   # -- Container Image Registry to pull the image from
   repository: docker.dragonflydb.io/dragonflydb/dragonfly


### PR DESCRIPTION
This change introduces a new Helm chart value mode, which allows users to deploy Dragonfly as a StatefulSet even when no persistent storage is defined.

Previously, the chart only created a StatefulSet when persistence (storage.enabled) was configured. With this update, users can explicitly choose the deployment type via:

```
mode: "deployment"    # default
# or
mode: "statefulset"
```

This provides greater flexibility for testing and ephemeral environments where a StatefulSet is desired but persistence is not required.

helm-docs has automatically updated the README with some new entries, including the new mode value.

The previous implementation remains unchanged.