### PR TITLE
fix(tiering): Grow backing async

### DIFF
--- a/src/server/tiering/disk_storage.cc
+++ b/src/server/tiering/disk_storage.cc
@@ -194,7 +194,8 @@ DiskStorage::Stats DiskStorage::GetStats() const {
 }
 
 error_code DiskStorage::RequestGrow(off_t grow_size) {
-  if (alloc_.capacity() + ExternalAllocator::kExtAlignment >= static_cast<size_t>(max_size_))
+  DCHECK_EQ(grow_size % ExternalAllocator::kExtAlignment, 0u);
+  if (alloc_.capacity() + grow_size >= static_cast<size_t>(max_size_))
     return make_error_code(errc::file_too_large);
 
   // Don't try again immediately, most likely it won't succeed ever.

--- a/src/server/tiering/disk_storage.h
+++ b/src/server/tiering/disk_storage.h
@@ -51,7 +51,7 @@ class DiskStorage {
   Stats GetStats() const;
 
  private:
-  // Try growing backing file by requested size async
+  // Try asynchronously growing backing file by requested size
   std::error_code RequestGrow(off_t grow_size);
 
   // Returns a buffer with size greater or equal to len.


### PR DESCRIPTION
Must preceed #5984 

* TryGrow() was changed to RequestGrow() that calls `LinuxFile::FallocateAsync`. 
* Not having enough space requests the async grow and fails the stash operation. 
* Can lead to small inefficiency with, for example, background offloading scheduling many operations that end with nothing.
* We shill have the "farsighted" grow that requests it when we have less than 15% capacity left