### PR TITLE
tests: Fix order of used memory counter reset

### DIFF
--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -564,7 +564,6 @@ TEST_F(DflyEngineTest, StickyEviction) {
 #endif
 
 TEST_F(DflyEngineTest, ZeroAllocationEviction) {
-  GTEST_SKIP() << "Currently being fixed, unblock CI";
   max_memory_limit = 500000;  // 0.5mb
   shard_set->TEST_EnableCacheMode();
 

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -249,8 +249,11 @@ void BaseFamilyTest::ResetService() {
   pp_->Run();
   service_ = std::make_unique<Service>(pp_.get());
 
-  service_->Init(nullptr, {});
+  // Must be reset before starting the service. Engine shard heartbeat task updates this
+  // value, and if reset after some invocations of heartbeat have run, the accumulated data is
+  // lost and can cause test failure.
   used_mem_current = 0;
+  service_->Init(nullptr, {});
 
   TEST_current_time_ms = absl::GetCurrentTimeNanos() / 1000000;
   auto default_ns = &namespaces->GetDefaultNamespace();


### PR DESCRIPTION
Used memory counter was previously reset after starting service. This opened up the possibility that a few cycles of engine shard memory accounting in `EngineShard::CacheStats` already ran, which incremented used memory, and then this value was reset. 

This resulted in lost bytes and tests which rely on this value, for example to measure eviction, could fail. Here the order is switched so that used memory is reset first and then service is started.

fixes https://github.com/dragonflydb/dragonfly/issues/5562