### PR TITLE
fix(search): Allow colon in tag values for query syntax

### DIFF
--- a/src/core/search/lexer.lex
+++ b/src/core/search/lexer.lex
@@ -37,7 +37,8 @@ sq         \'
 esc_chars  ['"\?\\abfnrtv]
 esc_seq    \\{esc_chars}
 term_ch    \w
-tag_val_ch [^,.<>{}\[\]\\\"\?':;!@#$%^&*()\-+=~\/| ]|\\.
+tag_val_base_ch [^,.<>{}\[\]\\\"\?':;!@#$%^&*()\-+=~\/| ]|\\.
+tag_val_ch {tag_val_base_ch}+(:+{tag_val_base_ch}*)*
 astrsk_ch  \*
 
 

--- a/src/core/search/search_parser_test.cc
+++ b/src/core/search/search_parser_test.cc
@@ -153,6 +153,14 @@ TEST_F(SearchParserTest, Scanner) {
   NEXT_EQ(TOK_TAG_VAL, string, "blue]1#-");
   NEXT_TOK(TOK_RCURLBR);
 
+  // Colon in tag value (unescaped)
+  SetInput("@t:{Tag:value}");
+  NEXT_EQ(TOK_FIELD, string, "@t");
+  NEXT_TOK(TOK_COLON);
+  NEXT_TOK(TOK_LCURLBR);
+  NEXT_EQ(TOK_TAG_VAL, string, "Tag:value");
+  NEXT_TOK(TOK_RCURLBR);
+
   // Prefix simple
   SetInput("pre*");
   NEXT_EQ(TOK_PREFIX, string, "pre");
@@ -231,6 +239,11 @@ TEST_F(SearchParserTest, Parse) {
   EXPECT_EQ(0, Parse("@foo:{1|hello|3.0|world|4}"));
 
   EXPECT_EQ(0, Parse("@name:{escape\\-err*}"));
+
+  // Colon in tag value
+  EXPECT_EQ(0, Parse("@t:{Tag:value}"));
+  EXPECT_EQ(0, Parse("@t:{Tag:*}"));
+  EXPECT_EQ(0, Parse("@category:{Product:Electronics}"));
 
   EXPECT_EQ(1, Parse(" -(foo "));
   EXPECT_EQ(1, Parse(" foo:bar "));


### PR DESCRIPTION
Fixes tag query parsing to support colons (`:`) in tag values, addressing "Query syntax error" in integration tests.

 Changes:
  Lexer: Modified `tag_val_ch` pattern to allow colons within tag values while preserving correct tokenization for field
  expressions
    - Pattern: `{tag_val_base_ch}+(:+{tag_val_base_ch}*)*` allows colons inside/at end of tags but not at the beginning
    - This ensures `@field:hello` still tokenizes as `@field` + `:` + `hello` (3 tokens)
    - While `@t:{Tag:value}` correctly parses `Tag:value` as a single tag value

+1 passed test in valkey-search integration tests.
43 failed, 27 passed