### PR TITLE
fix(takeover): pick correct replica to reconcile slots

### DIFF
--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -44,13 +44,15 @@ class ClusterFamily {
 
   size_t MigrationsErrorsCount() const ABSL_LOCKS_EXCLUDED(migration_mu_);
 
-  // Helper function to be used during takeover from both nodes (master and replica).
+  // Helper functions to be used during takeover from both nodes (master and replica).
   // It reconciles the cluster configuration for both nodes to reflect the node
   // role changes after the takeover.
   // For the taking over node it's called at the end of the ReplTakeOver flow
   // and for the taken over node it's called at the end of the dflycmd::TakeOver
-  void ReconcileMasterReplicaTakeoverSlots(bool was_master)
+  void ReconcileMasterSlots(std::string_view repl_id)
       ABSL_LOCKS_EXCLUDED(set_config_mu, migration_mu_);
+
+  void ReconcileReplicaSlots() ABSL_LOCKS_EXCLUDED(set_config_mu, migration_mu_);
 
  private:
   using SinkReplyBuilder = facade::SinkReplyBuilder;
@@ -124,9 +126,6 @@ class ClusterFamily {
   std::optional<ClusterShardInfos> GetShardInfos(ConnectionContext* cntx) const;
 
   ClusterShardInfo GetEmulatedShardInfo(ConnectionContext* cntx) const;
-
-  void ReconcileMasterFlow() ABSL_EXCLUSIVE_LOCKS_REQUIRED(set_config_mu, migration_mu_);
-  void ReconcileReplicaFlow() ABSL_EXCLUSIVE_LOCKS_REQUIRED(set_config_mu, migration_mu_);
 
   // Guards set configuration, so that we won't handle 2 in parallel.
   mutable util::fb2::Mutex set_config_mu;

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -596,7 +596,7 @@ void DflyCmd::TakeOver(CmdArgList args, RedisReplyBuilder* rb, ConnectionContext
     return;
   }
 
-  sf_->service().cluster_family().ReconcileMasterReplicaTakeoverSlots(true);
+  sf_->service().cluster_family().ReconcileMasterSlots(replica_ptr->id);
 }
 
 void DflyCmd::Expire(CmdArgList args, Transaction* tx, RedisReplyBuilder* rb) {

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -3764,7 +3764,7 @@ void ServerFamily::ReplTakeOver(CmdArgList args, const CommandContext& cmd_cntx)
   LOG(INFO) << "Takeover successful, promoting this instance to master.";
 
   if (IsClusterEnabled()) {
-    service().cluster_family().ReconcileMasterReplicaTakeoverSlots(false);
+    service().cluster_family().ReconcileReplicaSlots();
   }
 
   last_master_data_ = replica_->Stop();


### PR DESCRIPTION
The changes in https://github.com/dragonflydb/dragonfly/pull/5621 allowed master to not shutdown after takeover and redirect cluster shard requests to the new promoted node. However, the logic broke when there were multiple registered replicas. For that case, dragonfly blindly picked the first replica in the topology to reconcile with.

* Use replica ID to figure out which node from the replica set is the one promoted
* Small refactor: remove bool parameter and split functions