### PR TITLE
feat(helm): adds common label support to the helm chart

### DIFF
--- a/contrib/charts/dragonfly/README.md
+++ b/contrib/charts/dragonfly/README.md
@@ -32,6 +32,7 @@ helm upgrade --install dragonfly oci://ghcr.io/dragonflydb/dragonfly/helm/dragon
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity for pod assignment |
 | command | list | `[]` | Allow overriding the container's command |
+| commonLabels | object | `{}` | Common labels to add to all K8s resources |
 | extraArgs | list | `[]` | Extra arguments to pass to the dragonfly binary |
 | extraContainers | list | `[]` | Additional sidecar containers |
 | extraObjects | list | `[]` | extra K8s manifests to deploy |

--- a/contrib/charts/dragonfly/ci/commonlabels-values.golden.yaml
+++ b/contrib/charts/dragonfly/ci/commonlabels-values.golden.yaml
@@ -1,0 +1,101 @@
+---
+# Source: dragonfly/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-dragonfly
+  namespace: default
+  labels:
+    app.kubernetes.io/name: dragonfly
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "v1.34.2"
+    app.kubernetes.io/managed-by: Helm
+    project: cache-infrastructure
+    team: platform
+---
+# Source: dragonfly/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-dragonfly
+  namespace: default
+  labels:
+    app.kubernetes.io/name: dragonfly
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "v1.34.2"
+    app.kubernetes.io/managed-by: Helm
+    project: cache-infrastructure
+    team: platform
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      targetPort: dragonfly
+      protocol: TCP
+      name: dragonfly
+  selector:
+    app.kubernetes.io/name: dragonfly
+    app.kubernetes.io/instance: test
+---
+# Source: dragonfly/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-dragonfly
+  namespace: default
+  labels:
+    app.kubernetes.io/name: dragonfly
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "v1.34.2"
+    app.kubernetes.io/managed-by: Helm
+    project: cache-infrastructure
+    team: platform
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dragonfly
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      annotations:
+      labels:
+        app.kubernetes.io/name: dragonfly
+        app.kubernetes.io/instance: test
+        project: cache-infrastructure
+        team: platform
+    spec:
+      serviceAccountName: test-dragonfly
+      containers:
+        - name: dragonfly
+          image: "docker.dragonflydb.io/dragonflydb/dragonfly:v1.34.2"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: dragonfly
+              containerPort: 6379
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - /usr/local/bin/healthcheck.sh
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - /usr/local/bin/healthcheck.sh
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          args:
+            - "--alsologtostderr"
+          resources:
+            limits: {}
+            requests: {}

--- a/contrib/charts/dragonfly/ci/commonlabels-values.yaml
+++ b/contrib/charts/dragonfly/ci/commonlabels-values.yaml
@@ -1,0 +1,3 @@
+commonLabels:
+  team: platform
+  project: cache-infrastructure

--- a/contrib/charts/dragonfly/templates/_helpers.tpl
+++ b/contrib/charts/dragonfly/templates/_helpers.tpl
@@ -40,6 +40,18 @@ helm.sh/chart: {{ include "dragonfly.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- include "dragonfly.commonLabels" . }}
+{{- end }}
+
+{{/*
+User-defined common labels
+*/}}
+{{- define "dragonfly.commonLabels" -}}
+{{- if .Values.commonLabels }}
+{{- range $key, $value := .Values.commonLabels }}
+{{ $key }}: {{ $value }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/contrib/charts/dragonfly/templates/deployment.yaml
+++ b/contrib/charts/dragonfly/templates/deployment.yaml
@@ -22,6 +22,9 @@ spec:
         {{- end }}
       labels:
         {{- include "dragonfly.selectorLabels" . | nindent 8 }}
+        {{- if .Values.commonLabels }}
+        {{- include "dragonfly.commonLabels" . | trim | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "dragonfly.pod" . | trim | nindent 6 }}
 {{- end }}

--- a/contrib/charts/dragonfly/templates/statefulset.yaml
+++ b/contrib/charts/dragonfly/templates/statefulset.yaml
@@ -23,6 +23,9 @@ spec:
         {{- end }}
       labels:
         {{- include "dragonfly.selectorLabels" . | nindent 8 }}
+        {{- if .Values.commonLabels }}
+        {{- include "dragonfly.commonLabels" . | trim | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "dragonfly.pod" . | trim | nindent 6 }}
   volumeClaimTemplates:

--- a/contrib/charts/dragonfly/values.yaml
+++ b/contrib/charts/dragonfly/values.yaml
@@ -22,6 +22,9 @@ nameOverride: ""
 # -- String to fully override dragonfly.fullname
 fullnameOverride: ""
 
+# -- Common labels to add to all resources
+commonLabels: {}
+
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
Fixes #6041 

This PR adds commonLabels support to the Helm chart, allowing users to specify custom labels that are automatically applied across all Kubernetes resources (Deployment, StatefulSet, etc.) and pod templates. The implementation adds `commonLabels` field to `values.yaml`, updates the `dragonfly.labels` helper in `_helpers.tpl` to merge these labels, and modifies both `deployment.yaml` and `statefulset.yaml` to include commonLabels in pod template metadata.

The change follows patterns used by major Helm charts like Bitnami, and includes a full test case with golden test output to ensure correctness of the change made.