### PR TITLE
feat: add KEY dimenstion for memory usage

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -1660,10 +1660,12 @@ bool CompactObj::JsonWrapper::DefragIfNeeded(PageUsage* page_usage) {
   return flat.DefragIfNeeded(page_usage);
 }
 
-constexpr std::pair<CompactObjType, std::string_view> kObjTypeToString[8] = {
-    {OBJ_STRING, "string"sv},  {OBJ_LIST, "list"sv},    {OBJ_SET, "set"sv},
-    {OBJ_ZSET, "zset"sv},      {OBJ_HASH, "hash"sv},    {OBJ_STREAM, "stream"sv},
-    {OBJ_JSON, "ReJSON-RL"sv}, {OBJ_SBF, "MBbloom--"sv}};
+constexpr std::pair<CompactObjType, std::string_view> kObjTypeToString[] =
+    {
+        {OBJ_STRING, "string"sv},  {OBJ_LIST, "list"sv},    {OBJ_SET, "set"sv},
+        {OBJ_ZSET, "zset"sv},      {OBJ_HASH, "hash"sv},    {OBJ_STREAM, "stream"sv},
+        {OBJ_KEY, "key"sv},  // pseudo-type used for memory tracking
+        {OBJ_JSON, "ReJSON-RL"sv}, {OBJ_SBF, "MBbloom--"sv}};
 
 std::string_view ObjTypeToString(CompactObjType type) {
   for (auto& p : kObjTypeToString) {

--- a/src/redis/redis_aux.h
+++ b/src/redis/redis_aux.h
@@ -9,6 +9,9 @@
 #define OBJ_JSON 15U
 #define OBJ_SBF  16U
 
+// A pseudo type for keys stored in the db, same as OBJ_MODULE which is not used in Dragonfly.
+#define OBJ_KEY  5U
+
 /* How many types of objects exist */
 #define OBJ_TYPE_MAX 17U
 

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -174,7 +174,7 @@ class DbSlice {
       std::string_view key;
 
       // The following fields are calculated at init time
-      size_t orig_heap_size = 0;
+      size_t orig_value_heap_size = 0;
     };
 
     AutoUpdater(DbIndex db_ind, std::string_view key, const Iterator& it, DbSlice* db_slice);
@@ -570,7 +570,7 @@ class DbSlice {
 
   // Clear tiered storage entries for the specified indices. Called during flushing some indices.
   void RemoveOffloadedEntriesFromTieredStorage(absl::Span<const DbIndex> indices,
-                                               const DbTableArray& db_arr);
+                                               const DbTableArray& db_arr) const;
 
   void PerformDeletionAtomic(const Iterator& del_it, const ExpIterator& exp_it, DbTable* table);
 

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -953,6 +953,12 @@ TEST_F(DflyEngineTest, Huffman) {
   EXPECT_LT(metrics.heap_used_bytes, 14'000'000);         // less than 15mb
 }
 
+TEST_F(DflyEngineTest, MemoryKeys) {
+  Run({"debug", "populate", "10000", "abcd_efgh_ijkl_mnop", "10"});
+  auto metrics = GetMetrics();
+  EXPECT_GT(metrics.db_stats[0].memory_usage_by_type[OBJ_KEY], 100000);
+}
+
 class DflyCommandAliasTest : public DflyEngineTest {
  protected:
   DflyCommandAliasTest() {

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -346,7 +346,7 @@ void EngineShard::Shutdown() {
 }
 
 void EngineShard::StopPeriodicFiber() {
-  ProactorBase::me()->RemoveOnIdleTask(defrag_task_);
+  ProactorBase::me()->RemoveOnIdleTask(defrag_task_id_);
   fiber_heartbeat_periodic_done_.Notify();
   if (fiber_heartbeat_periodic_.IsJoinable()) {
     fiber_heartbeat_periodic_.Join();
@@ -393,7 +393,7 @@ void EngineShard::StartPeriodicHeartbeatFiber(util::ProactorBase* pb) {
   fiber_heartbeat_periodic_ = fb2::Fiber(fb_opts, [this, period_ms, heartbeat]() mutable {
     RunFPeriodically(heartbeat, period_ms, "heartbeat", &fiber_heartbeat_periodic_done_);
   });
-  defrag_task_ = pb->AddOnIdleTask([this]() { return DefragTask(); });
+  defrag_task_id_ = pb->AddOnIdleTask([this]() { return DefragTask(); });
 }
 
 void EngineShard::StartPeriodicShardHandlerFiber(util::ProactorBase* pb,

--- a/src/server/engine_shard.h
+++ b/src/server/engine_shard.h
@@ -294,7 +294,7 @@ class EngineShard {
   journal::Journal* journal_ = nullptr;
   IntentLock shard_lock_;
 
-  uint32_t defrag_task_ = 0;
+  uint32_t defrag_task_id_ = 0;
   EvictionTaskState eviction_state_;  // Used on eviction fiber
   util::fb2::Fiber fiber_heartbeat_periodic_;
   util::fb2::Done fiber_heartbeat_periodic_done_;


### PR DESCRIPTION
Before: key memory and string memory were reported as one.
Now: metrics and info memory will have a separate dimension for keys
using heap memory.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->