### PR TITLE
actions: Add a volume mount to container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,11 @@ jobs:
     container:
       image: ghcr.io/romange/${{ matrix.container }}
       options: --security-opt seccomp=unconfined --sysctl "net.ipv6.conf.all.disable_ipv6=0"
+      # Some tests which launch their own containers need a mounted volume to write through files
+      # into child containers
+      volumes:
+        - /mnt:/mnt
+
     steps:
     - uses: actions/checkout@v5
       with:


### PR DESCRIPTION
Some tests launch their own docker containers (using testcontainers lib). 

These tests also may need to pass through files to child containers which will be mounted. 

Since containers can only share files via the host filesystem when mounting said files, a volume is added which can be used for such operations.

Volume mount is already available in CI but was missing in the release action.

FIXES https://github.com/dragonflydb/dragonfly/issues/6047