### PR TITLE
fix(core): Account for size change on json object defragment

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -1633,11 +1633,25 @@ MemoryResource* CompactObj::memory_resource() {
 }
 
 bool CompactObj::JsonConsT::DefragIfNeeded(PageUsage* page_usage) {
-  if (JsonType* old = json_ptr; ShouldDefragment(page_usage)) {
+  if (ShouldDefragment(page_usage)) {
+    const MiMemoryResource* mr = static_cast<MiMemoryResource*>(memory_resource());
+
+    const int64_t before = static_cast<int64_t>(mr->used());
+    DCHECK_GE(before, 0) << "Memory usage is more than int64_t max value";
+
+    JsonType* old = json_ptr;
     json_ptr = AllocateMR<JsonType>(DeepCopyJSON(old));
     DeleteMR<JsonType>(old);
+
+    const int64_t after = static_cast<int64_t>(mr->used());
+    DCHECK_GE(after, 0) << "Memory usage is more than int64_t max value";
+
+    if (const int64_t delta = after - before; delta != 0) {
+      bytes_used = UpdateSize(bytes_used, delta);
+    }
     return true;
   }
+
   return false;
 }
 


### PR DESCRIPTION
For JSON type, after defragmentation used size may change. The change is propagated to the db stats object, so that metrics observe the change and reduction in memory usage (if any) correctly.

The JSON object records the change by observing the diff in bytes used by the memory resource, this is the same pattern used in `json_family.cc` etc. Once the change is determined it is set in the `bytes_used` field for the json object.

The delta update is in effect for all objects whose size changes, not just JSON type objects.