### PR TITLE
chore(facade): Handle Socket::Recv() returning 0 explicitly

### DIFF
--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -382,7 +382,7 @@ class Connection : public util::Connection {
   PipelineMessagePtr GetFromPipelinePool();
 
   void HandleMigrateRequest();
-  std::error_code HandleRecvSocket();
+  io::Result<size_t> HandleRecvSocket();
 
   bool ShouldEndAsyncFiber(const MessageHandle& msg);
 
@@ -406,17 +406,11 @@ class Connection : public util::Connection {
     size_t available_bytes;
     io::Bytes slice;
 
-    bool ShouldAdvance() const {
-      return slice.empty();
-    }
-
     void Consume(size_t len) {
       available_bytes -= len;
       slice.remove_prefix(len);
     }
   };
-
-  io::Bytes NextBundleBuffer(size_t total_len);
 
   void IncrNumConns();
   void DecrNumConns();


### PR DESCRIPTION
Currently helio translates 0 in Socket:Recv to ECONNABORTED. This works logically well unless we want to differrentiate between properly closed sockets (result=0) and those that were closed due to an error. This PR starts handling result=0 states for sockets even though helio does not yet return them.


Also clean up leftovers from the provided buffers.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->