### PR TITLE
docs(build-from-source): update LTO instructions to use USE_MOLD option

### DIFF
--- a/docs/build-from-source.md
+++ b/docs/build-from-source.md
@@ -5,11 +5,6 @@
 Dragonfly runs on linux. We advise running it on linux version 5.11 or later
 but you can also run Dragonfly on older kernels as well.
 
-> :warning: **Dragonfly releases are compiled with LTO (link time optimization)**:
-  Depending on the workload this can notably improve performance. If you want to
-  benchmark Dragonfly or use it in production, you should enable LTO by giving
-  `blaze.sh` the `-DCMAKE_CXX_FLAGS="-flto"` argument.
-
 ## Step 1 - install dependencies
 
 On Debian/Ubuntu:
@@ -59,12 +54,14 @@ cd build-opt && ninja dragonfly
 
 ### Build options
 
-| Option | Description |
-|--|--|
-| WITH_AWS | Include AWS client. Required for cloud snapshots |
-| WITH_SEARCH | Include Search module |
-| WITH_COLLECTION_CMDS | Include commands for collections (SET, HSET, ZSET) |
-| WITH_EXTENSION_CMDS | Include extension commands (Bloom, HLL, JSON, ...) |
+
+| Option               | Description                                                                                                                                                                                                                              |
+| ---------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| WITH_AWS             | Include AWS client. Required for cloud snapshots                                                                                                                                                                                         |
+| WITH_SEARCH          | Include Search module                                                                                                                                                                                                                    |
+| WITH_COLLECTION_CMDS | Include commands for collections (SET, HSET, ZSET)                                                                                                                                                                                       |
+| WITH_EXTENSION_CMDS  | Include extension commands (Bloom, HLL, JSON, ...)                                                                                                                                                                                       |
+| USE_MOLD             | Uses the mold linker to reduce link time overhead while enabling Link Time Optimization (LTO) for improved runtime performance. Recommended for benchmarking and production. |
 
 Minimal debug build:
 


### PR DESCRIPTION
The previous instructions for enabling Link Time Optimization (LTO) using -DCMAKE_CXX_FLAGS="-flto" did not work as expected.

Updated the documentation to recommend using -DUSE_MOLD=ON, which enables LTO and uses the mold linker for improved build performance and benchmarking. I've validated that it does work using readelf.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->