### PR TITLE
fix: suppress BUSYGROUP warning logs

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1669,7 +1669,9 @@ DispatchResult Service::InvokeCmd(const CommandId* cid, CmdArgList tail_args,
       res = DispatchResult::OOM;
     }
     VLOG(2) << FailedCommandToString(cid->name(), tail_args, reason);
-    LOG_EVERY_T(WARNING, 1) << FailedCommandToString(cid->name(), tail_args, reason);
+    if (!absl::StartsWith(reason, "-BUSYGROUP")) {
+      LOG_EVERY_T(WARNING, 1) << FailedCommandToString(cid->name(), tail_args, reason);
+    }
   }
 
   auto cid_name = cid->name();


### PR DESCRIPTION
Suppress WARNING logs for `-BUSYGROUP` errors when groups already exist. These are expected errors that were spamming logs during operation.

- BUSYGROUP errors still logged at VLOG(2) for debugging
- Other errors continue to be logged as WARNING