### PR TITLE
fix: replica of self

### DIFF
--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -423,7 +423,9 @@ std::error_code Replica::ConfigureDflyMaster() {
   // this reason to send this here is that in other context we can get an error reply
   // since we are budy with the replication
   RETURN_ON_ERR(SendCommandAndReadResponse(StrCat("REPLCONF CLIENT-ID ", id_)));
-  PC_RETURN_ON_BAD_RESPONSE(CheckRespIsSimpleReply("OK"));
+  if (!CheckRespIsSimpleReply("OK")) {
+    LOG(WARNING) << "Bad REPLCONF CLIENT-ID response";
+  }
 
   RETURN_ON_ERR(
       SendCommandAndReadResponse(StrCat("REPLCONF CLIENT-VERSION ", DflyVersion::CURRENT_VER)));

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -3748,7 +3748,6 @@ void ServerFamily::ReplicaOfInternalV2(CmdArgList args, Transaction* tx, SinkRep
   };
 
   if (ec || new_replica->IsContextCancelled()) {
-    new_replica->Stop();
     return builder->SendError(ec ? ec.Format() : "replication cancelled");
   }
 


### PR DESCRIPTION
The new replica of algorithm does not prematurely change the state of dragonfly to loading. When `replica of` points to self it will try to connect to itself and succeed, change the state to loading and get stuck trying to call replconf on itself (which fails because now !master).

The fix is to check if we got connected on the same node and simply do not start replication at all.

Fixes #6091