### PR TITLE
chore: cleanup redundant access specifiers

### DIFF
--- a/src/core/interpreter.h
+++ b/src/core/interpreter.h
@@ -174,7 +174,6 @@ class InterpreterManager {
     int64_t gc_freed_memory = 0;
   };
 
- public:
   InterpreterManager(unsigned num) : waker_{}, available_{}, storage_{} {
     // We pre-allocate the backing storage during initialization and
     // start storing pointers to slots in the available vector.

--- a/src/core/search/block_list.h
+++ b/src/core/search/block_list.h
@@ -143,7 +143,6 @@ template <typename Container /* underlying container */> class BlockList {
 
   friend SplitResult Split(BlockList<SortedVector<std::pair<DocId, double>>>&& block_list);
 
- private:
   const size_t block_size_ = 1000;
   size_t size_ = 0;
   PMR_NS::vector<Container> blocks_;

--- a/src/core/search/compressed_sorted_set.h
+++ b/src/core/search/compressed_sorted_set.h
@@ -53,7 +53,6 @@ class CompressedSortedSet {
 
   using iterator = ConstIterator;
 
- public:
   explicit CompressedSortedSet(PMR_NS::memory_resource* mr);
 
   ConstIterator begin() const;
@@ -98,7 +97,6 @@ class CompressedSortedSet {
     absl::Span<const uint8_t> diff_span;  // Location of value encoded diff, empty if none read
   };
 
- private:
   // Find EntryLocation of first entry that is not less than value (std::lower_bound)
   EntryLocation LowerBound(IntType value) const;
 
@@ -112,7 +110,6 @@ class CompressedSortedSet {
   // Decode integer with variable length encoding from source
   static std::pair<IntType /*value*/, size_t /*read*/> ReadVarLen(absl::Span<const uint8_t> source);
 
- private:
   uint32_t size_{0};
 
   std::optional<IntType> tail_value_{};

--- a/src/core/search/query_driver.h
+++ b/src/core/search/query_driver.h
@@ -56,7 +56,6 @@ class QueryDriver {
 
   void Error(const Parser::location_type& loc, std::string_view msg);
 
- public:
   Parser::location_type location;
 
  private:

--- a/src/core/search/range_tree.h
+++ b/src/core/search/range_tree.h
@@ -73,7 +73,6 @@ class RangeTree {
   // Used for DCHECKs
   bool TreeIsInCorrectState() const;
 
- private:
   // The maximum size of a range block. If a block exceeds this size, it will be split
   size_t max_range_block_size_;
   Map entries_;

--- a/src/core/search/scanner.h
+++ b/src/core/search/scanner.h
@@ -52,7 +52,6 @@ class Scanner : public Lexer {
     return Parser::make_UINT32(std::string{str}, loc);
   }
 
- private:
   const QueryParams* params_;
 };
 

--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -273,7 +273,6 @@ struct CmdArgParser {
     return {};
   }
 
- private:
   size_t cur_i_ = 0;
   CmdArgList args_;
 

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -103,7 +103,7 @@ class SinkReplyBuilder {
     return tl_facade_stats->reply_stats;
   }
 
- public:  // High level interface
+  // High level interface
   virtual Protocol GetProtocol() const = 0;
 
   virtual void SendLong(long val) = 0;
@@ -134,7 +134,6 @@ class SinkReplyBuilder {
   void FinishScope();  // Called when scope ends to flush buffer if needed
   void Send();
 
- protected:
   size_t replies_recorded_ = 0;
   std::string last_error_;
 

--- a/src/facade/reply_capture.h
+++ b/src/facade/reply_capture.h
@@ -35,7 +35,6 @@ class CapturingReplyBuilder : public RedisReplyBuilder {
   void SendNullArray() override;
   void SendNull() override;
 
- public:
   using Error = std::pair<std::string, std::string>;  // SendError (msg, type)
   using Null = std::nullptr_t;                        // SendNull or SendNullArray
 

--- a/src/server/channel_store.h
+++ b/src/server/channel_store.h
@@ -117,7 +117,6 @@ class ChannelStore {
     util::fb2::Mutex update_mu;  // locked during updates.
   };
 
- private:
   static ControlBlock control_block;
 
   ChannelStore(ChannelMap* channels, ChannelMap* patterns);
@@ -155,7 +154,6 @@ class ChannelStoreUpdater {
   // Apply modify operation to target map.
   void Modify(ChannelMap* target, std::string_view key);
 
- private:
   bool pattern_;
   bool to_add_;
   ConnectionContext* cntx_;

--- a/src/server/cluster/outgoing_slot_migration.h
+++ b/src/server/cluster/outgoing_slot_migration.h
@@ -92,7 +92,6 @@ class OutgoingMigration : private ProtocolClient {
 
   void OnAllShards(std::function<void(std::unique_ptr<SliceSlotMigration>&)>);
 
- private:
   MigrationInfo migration_info_;
   std::vector<std::unique_ptr<SliceSlotMigration>> slot_migrations_;
   ServerFamily* server_family_;

--- a/src/server/cluster/slot_set.h
+++ b/src/server/cluster/slot_set.h
@@ -93,7 +93,6 @@ class SlotSet {
     slots_ = std::move(s);
   }
 
- private:
   std::unique_ptr<TBitSet> slots_;
 };
 

--- a/src/server/detail/wrapped_json_path.h
+++ b/src/server/detail/wrapped_json_path.h
@@ -127,7 +127,6 @@ class WrappedJsonPath {
  private:
   CallbackResultOptions InitializePathType(CallbackResultOptions options) const;
 
- private:
   std::variant<json::Path, JsonExpression> parsed_path_;
   StringOrView path_;
   JsonPathType path_type_ = kDefaultJsonPathType;

--- a/src/server/dfly_bench.cc
+++ b/src/server/dfly_bench.cc
@@ -226,7 +226,6 @@ class ShardSlots {
     }
   };
 
- private:
   fb2::SharedMutex mu_;
   absl::flat_hash_map<tcp::endpoint, IntervalSet, Hasher, Eq> shards_slots_;
 };

--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -129,7 +129,6 @@ class DflyCmd {
     util::fb2::SharedMutex shared_mu;  // See top of header for locking levels.
   };
 
- public:
   DflyCmd(ServerFamily* server_family);
 
   void Run(CmdArgList args, Transaction* tx, facade::RedisReplyBuilder* rb,

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -343,7 +343,6 @@ class Renamer {
     bool sticky;
   };
 
- private:
   Transaction* const transaction_;
 
   const std::string_view src_key_;

--- a/src/server/journal/serializer.h
+++ b/src/server/journal/serializer.h
@@ -28,7 +28,6 @@ class JournalWriter {
   void Write(std::string_view sv);  // Write string.
   void Write(const journal::Entry::Payload& payload);
 
- private:
   io::Sink* sink_;
   std::optional<DbIndex> cur_dbid_{};
 };
@@ -59,7 +58,6 @@ struct JournalReader {
   // Read argument array into string buffer.
   std::error_code ReadCommand(journal::ParsedEntry::CmdData* entry);
 
- private:
   io::Source* source_;
   base::IoBuf buf_;
   DbIndex dbid_;

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -144,7 +144,6 @@ class JsonAutoUpdater {
     }
   }
 
- private:
   const OpArgs& op_args_;
   string_view key_;
   DbSlice::ItAndUpdater it_;

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -107,7 +107,7 @@ class Replica : ProtocolClient {
   // Send DFLY ${kind} to the master instance.
   std::error_code SendNextPhaseRequest(std::string_view kind);
 
- private: /* Utility */
+  /* Utility */
   struct PSyncResponse {
     // string - end of sync token (diskless)
     // size_t - size of the full sync blob (disk-based).

--- a/src/server/script_mgr.h
+++ b/src/server/script_mgr.h
@@ -43,7 +43,6 @@ class ScriptMgr {
     ScriptKey(std::string_view sha);
   };
 
- public:
   using SinkReplyBuilder = facade::SinkReplyBuilder;
 
   ScriptMgr();
@@ -78,7 +77,6 @@ class ScriptMgr {
 
   void UpdateScriptCaches(ScriptKey sha, ScriptParams params) const;
 
- private:
   struct InternalScriptData : public ScriptParams {
     std::unique_ptr<char[]> body{};
     std::unique_ptr<char[]> orig_body{};

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -299,7 +299,6 @@ class ShardDocIndex {
                                                     const SearchParams::SortOption& sort,
                                                     const OpArgs& op_args) const;
 
- private:
   std::shared_ptr<const DocIndex> base_;
   std::optional<search::FieldIndices> indices_;
   DocKeyIndex key_index_;
@@ -340,7 +339,6 @@ class ShardDocIndices {
   // Clean caches that might have data from this index
   void DropIndexCache(const dfly::ShardDocIndex& shard_doc_index);
 
- private:
   MiMemoryResource local_mr_;
   absl::flat_hash_map<std::string, std::unique_ptr<ShardDocIndex>> indices_;
 };

--- a/src/server/tiering/op_manager.h
+++ b/src/server/tiering/op_manager.h
@@ -82,7 +82,6 @@ class OpManager {
   // Notify delete. Return true if the filled segment needs to be marked as free.
   virtual bool NotifyDelete(DiskSegment segment) = 0;
 
- protected:
   // Describes pending futures for a single entry
   struct EntryOps {
     EntryOps(OwnedEntryId id, DiskSegment segment, const Decoder& decoder);
@@ -119,7 +118,6 @@ class OpManager {
   // Called once Stash finished
   void ProcessStashed(EntryId id, unsigned version, const io::Result<DiskSegment>& segment);
 
- protected:
   DiskStorage storage_;
 
   absl::flat_hash_map<size_t /* offset */, ReadOp> pending_reads_;

--- a/src/server/tiering/small_bins.h
+++ b/src/server/tiering/small_bins.h
@@ -75,7 +75,6 @@ class SmallBins {
   // Flush current bin
   FilledBin FlushBin();
 
- private:
   struct StashInfo {
     uint8_t entries = 0;
     uint16_t bytes = 0;

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -644,7 +644,6 @@ class Transaction {
 
   std::function<void(Transaction* trans)> tracking_cb_;
 
- private:
   struct TLTmpSpace {
     std::vector<PerShardCache>& GetShardIndex(unsigned size);
 


### PR DESCRIPTION
Cleaned up redundant access scope spefiers using

```
run-clang-tidy -p build-dbg -checks="-*,readability-redundant-access-specifiers" src/ -header-filter=.* -fix
```

Checked manually that the changes were correct