### PR TITLE
chore: expose more information when takeover fails on master.

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1621,19 +1621,19 @@ void Connection::ClearPipelinedMessages() {
 string Connection::DebugInfo() const {
   string info = "{";
 
-  absl::StrAppend(&info, "address=", uint64_t(this), ", ");
+  absl::StrAppend(&info, "id=", id_, ", ");
   absl::StrAppend(&info, "phase=", phase_, ", ");
   if (cc_) {
     // In some rare cases cc_ can be null, see https://github.com/dragonflydb/dragonfly/pull/3873
     absl::StrAppend(&info, "dispatch(s/a)=", cc_->sync_dispatch, " ", cc_->async_dispatch, ", ");
     absl::StrAppend(&info, "closing=", cc_->conn_closing, ", ");
   }
-  absl::StrAppend(&info, "dispatch_fiber:joinable=", async_fb_.IsJoinable(), ", ");
+  absl::StrAppend(&info, "df:joinable=", async_fb_.IsJoinable(), ", ");
 
   bool intrusive_front = !dispatch_q_.empty() && dispatch_q_.front().IsControl();
-  absl::StrAppend(&info, "dispatch_queue:size=", dispatch_q_.size(), ", ");
-  absl::StrAppend(&info, "dispatch_queue:pipelined=", pending_pipeline_cmd_cnt_, ", ");
-  absl::StrAppend(&info, "dispatch_queue:intrusive=", intrusive_front, ", ");
+  absl::StrAppend(&info, "dq:size=", dispatch_q_.size(), ", ");
+  absl::StrAppend(&info, "dq:pipelined=", pending_pipeline_cmd_cnt_, ", ");
+  absl::StrAppend(&info, "dq:intrusive=", intrusive_front, ", ");
 
   if (cc_) {
     absl::StrAppend(&info, "state=");
@@ -1642,8 +1642,9 @@ string Connection::DebugInfo() const {
     if (cc_->blocked)
       absl::StrAppend(&info, "b");
   }
+  time_t now = time(nullptr);
+  absl::StrAppend(&info, " age=", now - creation_time_, " idle=", now - last_interaction_, "}");
 
-  absl::StrAppend(&info, "}");
   return info;
 }
 

--- a/src/facade/dragonfly_listener.h
+++ b/src/facade/dragonfly_listener.h
@@ -88,8 +88,8 @@ class Listener : public util::ListenerInterface {
 // visible to all commands and no commands are still running according to the old state / config.
 class DispatchTracker {
  public:
-  DispatchTracker(absl::Span<facade::Listener* const>, facade::Connection* issuer = nullptr,
-                  bool ignore_paused = false, bool ignore_blocked = false);
+  DispatchTracker(absl::Span<facade::Listener* const>, facade::Connection* issuer,
+                  bool ignore_paused, bool ignore_blocked);
 
   void TrackAll();       // Track busy connection on all threads
   void TrackOnThread();  // Track busy connections on current thread

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -510,7 +510,7 @@ void DflyCmd::TakeOver(CmdArgList args, RedisReplyBuilder* rb, ConnectionContext
 
   // We need to await for all dispatches to finish: Otherwise a transaction might be scheduled
   // after this function exits but before the actual shutdown.
-  facade::DispatchTracker tracker{sf_->GetNonPriviligedListeners(), cntx->conn()};
+  facade::DispatchTracker tracker{sf_->GetNonPriviligedListeners(), cntx->conn(), false, false};
   shard_set->pool()->AwaitFiberOnAll([&](unsigned index, auto* pb) {
     sf_->CancelBlockingOnThread();
     tracker.TrackOnThread();

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -200,17 +200,11 @@ void Replica::Pause(bool pause) {
   });
 }
 
-std::error_code Replica::TakeOver(std::string_view timeout, bool save_flag) {
-  VLOG(1) << "Taking over";
-
-  // Parse timeout value for socket timeout
-  int timeout_sec = 0;
-  if (!absl::SimpleAtoi(timeout, &timeout_sec)) {
-    return make_error_code(errc::invalid_argument);
-  }
+std::error_code Replica::TakeOver(unsigned timeout_sec, bool save_flag) {
+  VLOG(1) << "Taking over " << timeout_sec << " seconds, save_flag=" << save_flag;
 
   std::error_code ec;
-  auto takeOverCmd = absl::StrCat("TAKEOVER ", timeout, (save_flag ? " SAVE" : ""));
+  auto takeOverCmd = absl::StrCat("TAKEOVER ", timeout_sec, (save_flag ? " SAVE" : ""));
   Proactor()->Await([this, &ec, cmd = std::move(takeOverCmd), timeout_sec] {
     // Set socket timeout to prevent hanging on unresponsive master
     // Add buffer time for master processing (timeout + 10 seconds)

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -75,7 +75,7 @@ class Replica : ProtocolClient {
 
   void Pause(bool pause);
 
-  std::error_code TakeOver(std::string_view timeout, bool save_flag);
+  std::error_code TakeOver(unsigned timeout, bool save_flag);
 
   bool IsContextCancelled() const {
     return !exec_st_.IsRunning();

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -985,7 +985,7 @@ std::optional<fb2::Fiber> Pause(std::vector<facade::Listener*> listeners, Namesp
   // blocked connections because: a) If the connection is blocked it is puased. b) We read pause
   // state after waking from blocking so if the trasaction was waken by another running
   //    command that did not pause on the new state yet we will pause after waking up.
-  DispatchTracker tracker{std::move(listeners), conn, true /* ignore paused commands */,
+  DispatchTracker tracker{listeners, conn, true /* ignore paused commands */,
                           true /*ignore blocking*/};
   shard_set->pool()->AwaitFiberOnAll([&tracker, pause_state](unsigned, util::ProactorBase*) {
     // Commands don't suspend before checking the pause state, so
@@ -3824,7 +3824,7 @@ void ServerFamily::ReplTakeOver(CmdArgList args, const CommandContext& cmd_cntx)
     return builder->SendError("Full sync not done");
   }
 
-  std::error_code res = replica_->TakeOver(ArgS(args, 0), save_flag);
+  std::error_code res = replica_->TakeOver(timeout_sec, save_flag);
   if (res) {
     LOG(WARNING) << "Takeover failed with error: " << res << " - " << res.message();
     return builder->SendError(absl::StrCat("Couldn't execute takeover: ", res.message()));


### PR DESCRIPTION
1. Provide more debug info on current connections
2. Show the failed condition of DispatchTracker if it fails.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->