### PR TITLE
chore(core): Remove some unused CompactObj code

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -787,7 +787,8 @@ CompactObj& CompactObj::operator=(CompactObj&& o) noexcept {
   huffman_domain_ = o.huffman_domain_;
 
   o.taglen_ = 0;  // forget all data
-  o.Reset();
+  o.huffman_domain_ = 0;
+  o.mask_ = 0;
   return *this;
 }
 

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -168,11 +168,11 @@ class CompactObj {
   CompactObj() : taglen_{0}, huffman_domain_{0} {  // default - empty string
   }
 
-  explicit CompactObj(std::string_view str, bool is_key) {
+  explicit CompactObj(std::string_view str, bool is_key) : CompactObj() {
     SetString(str, is_key);
   }
 
-  CompactObj(CompactObj&& cs) noexcept {
+  CompactObj(CompactObj&& cs) noexcept : CompactObj() {
     operator=(std::move(cs));
   };
 


### PR DESCRIPTION
Relevant to #6137 

1. Spit tagbyte union<uint8, struct{bitfields}> into just two bitfields
2. Remove some unused functions
3. Rename Cmp function, add dchecks