### PR TITLE
chore: force shutdown connections on takeover

### DIFF
--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -183,6 +183,11 @@ class DflyCmd {
   // Switch to stable state replication.
   void StartStable(CmdArgList args, Transaction* tx, RedisReplyBuilder* rb);
 
+  // Helper for takeover flow. Sometimes connections get stuck on send (because of pipelines)
+  // and this causes the takeover flow to fail because checkpoint messages are not processed.
+  // This function force shuts down those connection and allows the node to complete the takeover.
+  void ForceShutdownStuckConnections(uint64_t timeout);
+
   // TAKEOVER <syncid>
   // Shut this master down atomically with replica promotion.
   void TakeOver(CmdArgList args, RedisReplyBuilder* rb, ConnectionContext* cntx);

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -3666,3 +3666,54 @@ async def test_replica_of_self(async_client):
 
     with pytest.raises(redis.exceptions.ResponseError):
         await async_client.execute_command(f"replicaof 127.0.0.1 {port}")
+
+
+@dfly_args({"proactor_threads": 2})
+async def test_takeover_with_stuck_connections(df_factory: DflyInstanceFactory):
+    master = df_factory.create()
+    master.start()
+
+    async_client = master.client()
+    await async_client.execute_command("debug populate 2000")
+
+    reader, writer = await asyncio.open_connection("127.0.0.1", master.port)
+    writer.write(f"client setname writer_test\n".encode())
+    await writer.drain()
+    assert "OK" in (await reader.readline()).decode()
+    size = 1024 * 1024
+    writer.write(f"SET a {'v'*size}\n".encode())
+    await writer.drain()
+
+    async def get_task():
+        while True:
+            writer.write(f"GET a\n".encode())
+            await writer.drain()
+            await asyncio.sleep(0.1)
+
+    get = asyncio.create_task(get_task())
+
+    @assert_eventually(times=600)
+    async def wait_for_stuck_on_send():
+        clients = await async_client.client_list()
+        logging.info("wait_for_stuck_on_send clients: %s", clients)
+        phase = next(
+            (client["phase"] for client in clients if client["name"] == "writer_test"), None
+        )
+        assert phase == "send"
+
+    await wait_for_stuck_on_send()
+
+    replica = df_factory.create()
+    replica.start()
+
+    replica_cl = replica.client()
+
+    res = await replica_cl.execute_command(f"replicaof localhost {master.port}")
+    assert res == "OK"
+
+    # Wait for all replicas to transition into stable sync
+    async with async_timeout.timeout(240):
+        await wait_for_replicas_state(replica_cl)
+
+    with pytest.raises(redis.exceptions.ResponseError) as e:
+        await replica_cl.execute_command("REPLTAKEOVER 5")


### PR DESCRIPTION
## TakeOver algorithm as is

Imagine the simple setup: node 1 master, node 2 replica and node 2 attempts takeover on node 1.

`For node 1:`

### Steps that affect TakeOver result/state:

1. Switch state to TAKEN_OVER -> connections will get their commands rejected
2. Wait for all connections to finish dispatches -> send Checkpoint message on each conn and wait for it to be processed
* New step here from this PR. Optionally force shutdown all open connections. This does not break data parity. The connection is stuck on send, will break with an error but the transaction data will get replicated anyway (we already wrote to the journal the change).
3. Wait for the replica to catch up (reach the same LSN as master) -> data parity
4. Reply with OK. At this point the TAKEOVER is considered complete, node 2 is master.

### Optional steps that improve other flows:

1. Optionally: if there are more nodes registered as replicas, wait for those to catch up. This does not affect the takeover but allows waiting for all of the replicas to fully sync. (Also needed for partial sync data integrity)
2. Optionally: Take a snapshot
3. Optionally: for cluster mode do not shutdown such that the node can redirect requests

## Notes

* Dragonfly is still accepting new connections during the takeover. However, once dragonfly switches to TAKEN_OVER state, connections won’t be able to execute commands and they will get “busy loading” error

* Checkpoints are needed for data integrity. Once all the connections process the checkpoints it means that any other command in their dispatch queue will fail with busy loading. Hence, after step(2) there won’t be any change in the state (storage) and after step(3) the taking over node is on data parity.

## This PR:

A step between 2 and 3 to fix non responding connections and force the takeover by forcefully shutting them down.

Follows up #6135. Add a flag `experimental_force_takeover`. If takeover times out and this flag is set dragonfly will force shutdown open connections such that it doesn't fail the takeover.

Resolves: #6114