### PR TITLE
fix: Remove index docs on eviction and cluster migration (#6062)

### DIFF
--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -322,11 +322,10 @@ class DbSlice {
   // Creates a database with index `db_ind`. If such database exists does nothing.
   void ActivateDb(DbIndex db_ind);
 
-  // Delete a key referred by its iterator.
-  void PerformDeletion(Iterator del_it, DbTable* table);
-
   // Deletes the iterator. The iterator must be valid.
-  void Del(Context cntx, Iterator it);
+  // Context argument is used only for document removal and it just needs
+  // timestamp field. Last argument, db_table, is optional and is used only in FlushSlotsCb.
+  void Del(Context cntx, Iterator it, DbTable* db_table = nullptr);
 
   constexpr static DbIndex kDbAll = 0xFFFF;
 
@@ -447,7 +446,7 @@ class DbSlice {
   // Evicts items with dynamically allocated data from the primary table.
   // Does not shrink tables.
   // Returns number of (elements,bytes) freed due to evictions.
-  std::pair<uint64_t, size_t> FreeMemWithEvictionStepAtomic(DbIndex db_indx,
+  std::pair<uint64_t, size_t> FreeMemWithEvictionStepAtomic(DbIndex db_indx, const Context& cntx,
                                                             size_t starting_segment_id,
                                                             size_t increase_goal_bytes);
 

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -688,7 +688,7 @@ void EngineShard::RetireExpiredAndEvict() {
     if (eviction_goal) {
       uint32_t starting_segment_id = rand() % pt->GetSegmentCount();
       auto [evicted_items, evicted_bytes] =
-          db_slice.FreeMemWithEvictionStepAtomic(i, starting_segment_id, eviction_goal);
+          db_slice.FreeMemWithEvictionStepAtomic(i, db_cntx, starting_segment_id, eviction_goal);
 
       VLOG(2) << "Heartbeat eviction: Expected to evict " << eviction_goal
               << " bytes. Actually evicted " << evicted_items << " items, " << evicted_bytes

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -181,6 +181,14 @@ async def wait_for_status(admin_client, node_id, status, timeout=10):
             assert len(states) != 0 and all(state[2] in status for state in states), states
 
 
+async def wait_for_ft_index_creation(client, idx_name, timeout=5):
+    get_status = lambda: client.execute_command("FT.INFO", idx_name)
+
+    async for states, breaker in tick_timer(get_status, timeout=timeout):
+        with breaker:
+            assert len(states) != 0, states
+
+
 async def wait_for_error(admin_client, node_id, error, timeout=10):
     get_status = lambda: admin_client.execute_command(
         "DFLYCLUSTER", "SLOT-MIGRATION-STATUS", node_id
@@ -3442,3 +3450,101 @@ async def test_replica_takeover_moved(
     await m1.client.execute_command(f"replicaof localhost {r1.instance.port}")
     await check_all_replicas_finished([m1.client], r1.client)
     assert await m1.client.execute_command("GET newk") == "foo"
+
+
+@dfly_args({"proactor_threads": 4, "cluster_mode": "yes"})
+async def test_SearchRequestDistribution(df_factory: DflyInstanceFactory):
+    """
+    Create cluster of 3 nodes.
+    Send FT.CREATE to first node and check that index was created on all nodes.
+    """
+
+    instances = [
+        df_factory.create(port=next(next_port), admin_port=next(next_port), vmodule="coordinator=2")
+        for i in range(3)
+    ]
+
+    df_factory.start_all(instances)
+
+    nodes = [(await create_node_info(instance)) for instance in instances]
+    nodes[0].slots = [(0, 5259)]
+    nodes[1].slots = [(5260, 10519)]
+    nodes[2].slots = [(10520, 16383)]
+
+    await push_config(json.dumps(generate_config(nodes)), [node.admin_client for node in nodes])
+
+    assert (
+        await nodes[0].client.execute_command(
+            "FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "title", "TEXT"
+        )
+        == "OK"
+    )
+
+    await asyncio.sleep(3)
+    for node in nodes:
+        await wait_for_ft_index_creation(node.client, "idx")
+
+
+async def verify_keys_match_number_of_index_docs(client, expected_num_keys):
+    # Get number of docs in index
+    index_info = await client.execute_command(f"FT.INFO idx")
+    index_info_num_docs = index_info[9]
+
+    # Get number of keys in database
+    keyspace_info = await client.info("keyspace")
+    keyspace_keys = keyspace_info["db0"]["keys"]
+
+    assert index_info_num_docs == keyspace_keys
+    assert index_info_num_docs == expected_num_keys
+    assert keyspace_keys == expected_num_keys
+
+
+@dfly_args({"proactor_threads": 2, "cluster_mode": "yes"})
+async def test_remove_docs_on_cluster_migration(df_factory):
+    instances = [
+        df_factory.create(port=next(next_port), admin_port=next(next_port)) for i in range(2)
+    ]
+
+    df_factory.start_all(instances)
+
+    nodes = [(await create_node_info(instance)) for instance in instances]
+    nodes[0].slots = [(0, 16383)]
+    nodes[1].slots = []
+
+    await push_config(json.dumps(generate_config(nodes)), [node.admin_client for node in nodes])
+
+    # Create index on both nodes
+    await nodes[0].client.execute_command(
+        "FT.CREATE", "idx", "ON", "HASH", "PREFIX", "1", "doc:", "SCHEMA", "v", "TEXT"
+    )
+
+    # Populate node 0
+    keys = 100
+    for i in range(0, keys):
+        random_string = "".join(random.choices(string.ascii_letters + string.digits, k=1_000))
+        await nodes[0].client.execute_command("HSET", f"doc:{i}", "v", random_string)
+
+    # Verify on node 0 that keys are added and index is populated
+    await verify_keys_match_number_of_index_docs(nodes[0].client, keys)
+
+    nodes[0].migrations.append(
+        MigrationInfo("127.0.0.1", instances[1].port, [(0, 16383)], nodes[1].id)
+    )
+    logging.debug("Start migration")
+    await push_config(json.dumps(generate_config(nodes)), [node.admin_client for node in nodes])
+
+    await wait_for_status(nodes[0].admin_client, nodes[1].id, "FINISHED")
+
+    nodes[0].migrations = []
+    nodes[0].slots = []
+    nodes[1].slots = [(0, 16383)]
+    logging.debug("finalize migration")
+    await push_config(json.dumps(generate_config(nodes)), [node.admin_client for node in nodes])
+
+    await asyncio.sleep(1)
+
+    # Verify on node 1 that keys are moved and index is populated
+    await verify_keys_match_number_of_index_docs(nodes[1].client, keys)
+
+    # Verify that node 0 doesn't have any keys and no index docs
+    await verify_keys_match_number_of_index_docs(nodes[0].client, 0)

--- a/tests/dragonfly/memory_test.py
+++ b/tests/dragonfly/memory_test.py
@@ -315,3 +315,45 @@ async def test_throttle_on_commands_squashing_replies_bytes(df_factory: DflyInst
     df.stop()
     found = df.find_in_logs("Commands squashing current reply size is overlimit")
     assert len(found) > 0
+
+
+@pytest.mark.asyncio
+async def test_remove_docs_on_eviction(df_factory):
+    max_memory = 256 * 1024**2  # 256MB
+    df_server = df_factory.create(
+        proactor_threads=1,
+        cache_mode="yes",
+        maxmemory=max_memory,
+        vmodule="engine_shard=2",
+        eviction_memory_budget_threshold=0.99,
+        enable_heartbeat_rss_eviction="no",
+    )
+    df_server.start()
+    client = df_server.client()
+
+    await client.execute_command(
+        "FT.CREATE", "idx", "ON", "HASH", "PREFIX", "1", "doc:", "SCHEMA", "v", "TEXT"
+    )
+
+    i = 0
+    while True:
+        random_string = "".join(random.choices(string.ascii_letters + string.digits, k=1_000))
+        await client.execute_command("HSET", f"doc:{i}", "v", random_string)
+        stats_info = await client.info("stats")
+        # Done when see at least 50 evictions
+        if stats_info["evicted_keys"] > 50:
+            break
+        i = i + 1
+
+    # Give some time to eviction stabilize
+    await asyncio.sleep(1)
+
+    # Get number of docs in index
+    index_info = await client.execute_command(f"FT.INFO idx")
+    index_info_num_docs = index_info[9]
+
+    # Get number of keys in database
+    keyspace_info = await client.info("keyspace")
+    keyspace_keys = keyspace_info["db0"]["keys"]
+
+    assert index_info_num_docs == keyspace_keys


### PR DESCRIPTION
When we evict keys or during slot migration we should also remove index docs.


(cherry picked from commit 0fbcbca7588084751a6764edf0a10b156a46b597)
