### PR TITLE
fix: incorrect stalled heartbeat warning

### DIFF
--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -691,21 +691,24 @@ void EngineShard::Heartbeat() {
 
   // TODO: iterate over all namespaces
   DbSlice& db_slice = namespaces->GetDefaultNamespace().GetDbSlice(shard_id());
-  // Skip heartbeat if we are serializing a big value
-  static auto start = std::chrono::system_clock::now();
+
   // Skip heartbeat if global transaction is in process.
   // This is determined by attempting to check if shard lock can be acquired.
   const bool can_acquire_global_lock = shard_lock()->Check(IntentLock::Mode::EXCLUSIVE);
 
   if (db_slice.WillBlockOnJournalWrite() || !can_acquire_global_lock) {
-    const auto elapsed = std::chrono::system_clock::now() - start;
-    if (elapsed > std::chrono::seconds(1)) {
-      const auto elapsed_seconds = std::chrono::duration_cast<std::chrono::seconds>(elapsed);
-      LOG_EVERY_T(WARNING, 5) << "Stalled heartbeat() fiber for " << elapsed_seconds.count()
+    uint64_t now = absl::GetCurrentTimeNanos();
+
+    uint64_t elapsed_ms = (now - stalled_start_ns_) / 1000000;
+
+    if (stalled_start_ns_ && elapsed_ms > 1000) {
+      LOG_EVERY_T(WARNING, 5) << "Stalled heartbeat() fiber for " << elapsed_ms / 1000
                               << " seconds";
     }
+    stalled_start_ns_ = now;
     return;
   }
+  stalled_start_ns_ = 0;
 
   thread_local bool check_huffman = (shard_id_ == 0);  // run it only on shard 0.
   if (check_huffman) {

--- a/src/server/engine_shard.h
+++ b/src/server/engine_shard.h
@@ -309,7 +309,7 @@ class EngineShard {
   std::unique_ptr<TieredStorage> tiered_storage_;
   // TODO: Move indices to Namespace
   std::unique_ptr<ShardDocIndices> shard_search_indices_;
-
+  uint64_t stalled_start_ns_ = 0;
   using Counter = util::SlidingCounter<7>;
 
   Counter counter_[COUNTER_TOTAL];


### PR DESCRIPTION
Before: start time was never updated or reset, which rendered the warning useless and having false positives.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->