### PR TITLE
ci: use OIDC for AWS authentication in regression tests

### DIFF
--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -20,11 +20,13 @@ inputs:
     required: false
     type: string
   aws-access-key-id:
-    required: true
+    required: false
     type: string
+    description: "AWS access key ID (optional if using OIDC - credentials set by workflow)"
   aws-secret-access-key:
-    required: true
+    required: false
     type: string
+    description: "AWS secret access key (optional if using OIDC - credentials set by workflow)"
   s3-bucket:
     required: true
     type: string
@@ -78,10 +80,12 @@ runs:
         fi
       env:
         # Add environment variables to enable the S3 snapshot test.
+        # AWS credentials: if inputs provided, use them; otherwise rely on workflow OIDC auth
         DRAGONFLY_S3_BUCKET: ${{ inputs.s3-bucket }}
-        AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
-        AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}
-        AWS_REGION: us-east-1
+        AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id || env.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key || env.AWS_SECRET_ACCESS_KEY }}
+        AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
+        AWS_REGION: ${{ env.AWS_REGION || 'us-east-1' }}
 
     - name: Send notification on failure
       if: failure() && github.ref == 'refs/heads/main'

--- a/.github/actions/repeat/action.yml
+++ b/.github/actions/repeat/action.yml
@@ -15,11 +15,13 @@ inputs:
     required: false
     type: string
   aws-access-key-id:
-    required: true
+    required: false
     type: string
+    description: "AWS access key ID (optional if using OIDC - credentials set by workflow)"
   aws-secret-access-key:
-    required: true
+    required: false
     type: string
+    description: "AWS secret access key (optional if using OIDC - credentials set by workflow)"
   s3-bucket:
     required: true
     type: string
@@ -81,7 +83,9 @@ runs:
         fi
       env:
         # Add environment variables to enable the S3 snapshot test.
+        # AWS credentials: if inputs provided, use them; otherwise rely on workflow OIDC auth
         DRAGONFLY_S3_BUCKET: ${{ inputs.s3-bucket }}
-        AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
-        AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}
-        AWS_REGION: us-east-1
+        AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id || env.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key || env.AWS_SECRET_ACCESS_KEY }}
+        AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
+        AWS_REGION: ${{ env.AWS_REGION || 'us-east-1' }}

--- a/.github/workflows/docker-dev-release.yml
+++ b/.github/workflows/docker-dev-release.yml
@@ -52,10 +52,9 @@ jobs:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_S3_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_S3_ACCESS_SECRET }}
+          role-to-assume: ${{ secrets.AWS_CI_S3_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get Build Information

--- a/.github/workflows/epoll-regression-tests.yml
+++ b/.github/workflows/epoll-regression-tests.yml
@@ -17,6 +17,10 @@ jobs:
 
     runs-on: ${{ matrix.runner }}
 
+    permissions:
+      id-token: write
+      contents: read
+
     container:
       image: ghcr.io/romange/${{ matrix.container }}
       options: --security-opt seccomp=unconfined --sysctl "net.ipv6.conf.all.disable_ipv6=0"
@@ -45,6 +49,12 @@ jobs:
           pwd
           ls -l ..
 
+      - name: Authenticate to AWS
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CI_S3_ROLE_ARN }}
+          aws-region: us-east-1
+
       - name: Run regression tests action
         uses: ./.github/actions/regression-tests
         with:
@@ -52,8 +62,6 @@ jobs:
           gspace-secret: ${{ secrets.GSPACES_BOT_DF_BUILD }}
           build-folder-name: build
           filter: ${{ matrix.build-type == 'Release' && 'not empty' || 'not opt_only' }}
-          aws-access-key-id: ${{ secrets.AWS_S3_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_S3_ACCESS_SECRET }}
           s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}
           # Chain ternary oprator of the form (which can be nested)
           # (expression == condition && <true expression> || <false expression>)

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -17,6 +17,10 @@ jobs:
 
     runs-on: ${{ matrix.runner }}
 
+    permissions:
+      id-token: write
+      contents: read
+
     container:
       image: ghcr.io/romange/${{ matrix.container }}
       options: --security-opt seccomp=unconfined --sysctl "net.ipv6.conf.all.disable_ipv6=0"
@@ -45,6 +49,12 @@ jobs:
           pwd
           ls -l ..
 
+      - name: Authenticate to AWS
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CI_S3_ROLE_ARN }}
+          aws-region: us-east-1
+
       - name: Run regression tests action
         uses: ./.github/actions/regression-tests
         with:
@@ -52,8 +62,6 @@ jobs:
           gspace-secret: ${{ secrets.GSPACES_BOT_DF_BUILD }}
           build-folder-name: build
           filter: ${{ matrix.build-type == 'Release' && 'not debug_only' || 'not opt_only' }}
-          aws-access-key-id: ${{ secrets.AWS_S3_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_S3_ACCESS_SECRET }}
           s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}
 
       - name: Upload logs on failure

--- a/.github/workflows/repeat-tests.yml
+++ b/.github/workflows/repeat-tests.yml
@@ -48,6 +48,10 @@ jobs:
 
     runs-on: ${{ matrix.runner }}
 
+    permissions:
+      id-token: write
+      contents: read
+
     container:
       image: ghcr.io/romange/${{ matrix.container }}
       options: --security-opt seccomp=unconfined --sysctl "net.ipv6.conf.all.disable_ipv6=0"
@@ -89,14 +93,18 @@ jobs:
           pwd
           ls -l ..
 
+      - name: Authenticate to AWS
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CI_S3_ROLE_ARN }}
+          aws-region: us-east-1
+
       - name: Run tests on repeat
         uses: ./.github/actions/repeat
         with:
           run-only-on-ubuntu-latest: true
           dfly-executable: dragonfly
           build-folder-name: build
-          aws-access-key-id: ${{ secrets.AWS_S3_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_S3_ACCESS_SECRET }}
           s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}
           expression: ${{ inputs.expression }}
           count: ${{ inputs.count }}


### PR DESCRIPTION
## Summary

Replace AWS IAM user access keys with OIDC (OpenID Connect) federation for AWS authentication in CI workflows.

## Changes

### Composite Actions
- `.github/actions/regression-tests/action.yml` - Made AWS credentials optional, added session token support
- `.github/actions/repeat/action.yml` - Made AWS credentials optional, added session token support

### Workflows
- `.github/workflows/regression-tests.yml` - Use `role-to-assume` instead of access keys
- `.github/workflows/epoll-regression-tests.yml` - Use `role-to-assume` instead of access keys  
- `.github/workflows/repeat-tests.yml` - Use `role-to-assume` instead of access keys
- `.github/workflows/docker-dev-release.yml` - Use `role-to-assume` instead of access keys
