### PR TITLE
tests: Use AWS public docker registry

### DIFF
--- a/tests/dragonfly/package_install_test.py
+++ b/tests/dragonfly/package_install_test.py
@@ -11,7 +11,7 @@ def check(container: DockerContainer, cmd: str):
 
 @pytest.mark.skipif(platform.processor() != "x86_64", reason="rpm is only built for x86_64")
 async def test_install_package_on_fedora():
-    with DockerContainer(image="fedora:latest", tty=True) as fedora:
+    with DockerContainer(image="public.ecr.aws/docker/library/fedora:latest", tty=True) as fedora:
         check(
             fedora,
             "dnf config-manager addrepo --from-repofile=https://packages.dragonflydb.io/dragonfly.repo",
@@ -21,7 +21,7 @@ async def test_install_package_on_fedora():
 
 
 async def test_install_package_on_ubuntu():
-    with DockerContainer(image="ubuntu:latest", tty=True) as ubuntu:
+    with DockerContainer(image="public.ecr.aws/docker/library/ubuntu:noble", tty=True) as ubuntu:
         check(ubuntu, "apt update")
         check(ubuntu, "apt install -y curl")
         check(


### PR DESCRIPTION
The default docker registry heavily throttles pull requests. Switch to AWS docker registry to avoid throttling which causes tests to fail.

FIXES https://github.com/dragonflydb/dragonfly/issues/6109