### PR TITLE
chore: introduce ParsedArguments class

### DIFF
--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -56,7 +56,7 @@ struct CmdArgParser {
   };
 
  public:
-  CmdArgParser(CmdArgList args) : args_{args} {
+  CmdArgParser(ArgSlice args) : args_{args} {
   }
 
   // Debug asserts sure error was consumed
@@ -159,7 +159,7 @@ struct CmdArgParser {
   }
 
   // Return remaining arguments
-  CmdArgList Tail() const {
+  ArgSlice Tail() const {
     return args_.subspan(cur_i_);
   }
 
@@ -168,7 +168,7 @@ struct CmdArgParser {
     return cur_i_ < args_.size() && !error_;
   }
 
-  bool HasError() {
+  bool HasError() const {
     return error_.type != ErrorType::NO_ERROR;
   }
 
@@ -275,7 +275,7 @@ struct CmdArgParser {
 
  private:
   size_t cur_i_ = 0;
-  CmdArgList args_;
+  ArgSlice args_;
 
   ErrorInfo error_;
 };

--- a/src/facade/command_id.h
+++ b/src/facade/command_id.h
@@ -4,16 +4,14 @@
 
 #pragma once
 
+#include <cstdint>
+#include <string>
 #include <string_view>
-
-#include "facade/facade_types.h"
 
 namespace facade {
 
 class CommandId {
  public:
-  using CmdArgList = facade::CmdArgList;
-
   /**
    * @brief Construct a new Command Id object
    *

--- a/src/facade/facade_types.h
+++ b/src/facade/facade_types.h
@@ -41,6 +41,37 @@ using CmdArgVec = std::vector<std::string_view>;
 using ArgSlice = absl::Span<const std::string_view>;
 using OwnedArgSlice = absl::Span<const std::string>;
 
+class ParsedArgs {
+ public:
+  ParsedArgs() = default;
+
+  explicit ParsedArgs(ArgSlice args) : args_(args) {  // NOLINT google-explicit-constructor
+  }
+
+  size_t size() const {
+    return args_.size();
+  }
+
+  bool empty() const {
+    return args_.empty();
+  }
+
+  ParsedArgs Tail() const {
+    return ParsedArgs{args_.subspan(1)};
+  }
+
+  std::string_view Front() const {
+    return args_.front();
+  }
+
+  ArgSlice ToSlice() const {
+    return args_;
+  }
+
+ private:
+  absl::Span<const std::string_view> args_;
+};
+
 inline std::string_view ToSV(std::string_view slice) {
   return slice;
 }

--- a/src/facade/ok_main.cc
+++ b/src/facade/ok_main.cc
@@ -22,13 +22,13 @@ namespace {
 
 class OkService : public ServiceInterface {
  public:
-  DispatchResult DispatchCommand(ArgSlice args, SinkReplyBuilder* builder,
+  DispatchResult DispatchCommand(ParsedArgs args, SinkReplyBuilder* builder,
                                  ConnectionContext* cntx) final {
     builder->SendOk();
     return DispatchResult::OK;
   }
 
-  DispatchManyResult DispatchManyCommands(absl::Span<ArgSlice> args_lists,
+  DispatchManyResult DispatchManyCommands(absl::Span<ParsedArgs> args_lists,
                                           SinkReplyBuilder* builder,
                                           ConnectionContext* cntx) final {
     for (auto args : args_lists)

--- a/src/facade/service_interface.h
+++ b/src/facade/service_interface.h
@@ -36,10 +36,10 @@ class ServiceInterface {
   virtual ~ServiceInterface() {
   }
 
-  virtual DispatchResult DispatchCommand(ArgSlice args, SinkReplyBuilder* builder,
+  virtual DispatchResult DispatchCommand(ParsedArgs args, SinkReplyBuilder* builder,
                                          ConnectionContext* cntx) = 0;
 
-  virtual DispatchManyResult DispatchManyCommands(absl::Span<ArgSlice> commands,
+  virtual DispatchManyResult DispatchManyCommands(absl::Span<ParsedArgs> commands,
                                                   SinkReplyBuilder* builder,
                                                   ConnectionContext* cntx) = 0;
 

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -325,17 +325,17 @@ CommandRegistry::FamiliesVec CommandRegistry::GetFamilies() {
   return std::move(family_of_commands_);
 }
 
-std::pair<const CommandId*, ArgSlice> CommandRegistry::FindExtended(string_view cmd,
-                                                                    ArgSlice tail_args) const {
+std::pair<const CommandId*, ParsedArgs> CommandRegistry::FindExtended(string_view cmd,
+                                                                      ParsedArgs tail_args) const {
   if (cmd == RenamedOrOriginal("ACL"sv)) {
     if (tail_args.empty()) {
       return {Find(cmd), {}};
     }
 
-    auto second_cmd = absl::AsciiStrToUpper(ArgS(tail_args, 0));
+    auto second_cmd = absl::AsciiStrToUpper(tail_args.Front());
     string full_cmd = absl::StrCat(cmd, " ", second_cmd);
 
-    return {Find(full_cmd), tail_args.subspan(1)};
+    return {Find(full_cmd), tail_args.Tail()};
   }
 
   const CommandId* res = Find(cmd);
@@ -344,7 +344,7 @@ std::pair<const CommandId*, ArgSlice> CommandRegistry::FindExtended(string_view 
 
   // A workaround for XGROUP HELP that does not fit our static taxonomy of commands.
   if (tail_args.size() == 1 && res->name() == "XGROUP") {
-    if (absl::EqualsIgnoreCase(ArgS(tail_args, 0), "HELP")) {
+    if (absl::EqualsIgnoreCase(tail_args.Front(), "HELP")) {
       res = Find("_XGROUP_HELP");
     }
   }

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -14,6 +14,7 @@
 
 #include "base/function2.hpp"
 #include "facade/command_id.h"
+#include "facade/facade_types.h"
 
 namespace facade {
 class SinkReplyBuilder;
@@ -107,6 +108,8 @@ template <typename T> class MoveOnly {
 
 class CommandId : public facade::CommandId {
  public:
+  using CmdArgList = facade::CmdArgList;
+
   // NOTICE: name must be a literal string, otherwise metrics break! (see cmd_stats_map in
   // server_state.h)
   CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first_key, int8_t last_key,
@@ -251,8 +254,8 @@ class CommandRegistry {
   using FamiliesVec = std::vector<std::vector<std::string>>;
   FamiliesVec GetFamilies();
 
-  std::pair<const CommandId*, facade::ArgSlice> FindExtended(std::string_view cmd,
-                                                             facade::ArgSlice tail_args) const;
+  std::pair<const CommandId*, facade::ParsedArgs> FindExtended(std::string_view cmd,
+                                                               facade::ParsedArgs tail_args) const;
 
   absl::flat_hash_map<std::string, hdr_histogram*> LatencyMap() const;
 

--- a/src/server/http_api.cc
+++ b/src/server/http_api.cc
@@ -198,7 +198,7 @@ void HttpAPI(const http::QueryArgs& args, HttpRequest&& req, Service* service,
   facade::CapturingReplyBuilder reply_builder;
 
   // TODO: to finish this.
-  service->DispatchCommand(absl::MakeSpan(cmd_slices), &reply_builder, context);
+  service->DispatchCommand(facade::ParsedArgs{cmd_slices}, &reply_builder, context);
   facade::CapturingReplyBuilder::Payload payload = reply_builder.Take();
 
   auto response = http::MakeStringResponse();

--- a/src/server/journal/executor.cc
+++ b/src/server/journal/executor.cc
@@ -65,8 +65,8 @@ void JournalExecutor::FlushSlots(const cluster::SlotRange& slot_range) {
 }
 
 facade::DispatchResult JournalExecutor::Execute(journal::ParsedEntry::CmdData& cmd) {
-  auto span = CmdArgList{cmd.cmd_args.data(), cmd.cmd_args.size()};
-  return service_->DispatchCommand(span, &reply_builder_, &conn_context_);
+  return service_->DispatchCommand(facade::ParsedArgs{cmd.cmd_args}, &reply_builder_,
+                                   &conn_context_);
 }
 
 void JournalExecutor::SelectDb(DbIndex dbid) {

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -36,11 +36,11 @@ class Service : public facade::ServiceInterface {
   void Shutdown();
 
   // Prepare command execution, verify and execute, reply to context
-  facade::DispatchResult DispatchCommand(ArgSlice args, facade::SinkReplyBuilder* builder,
+  facade::DispatchResult DispatchCommand(facade::ParsedArgs args, facade::SinkReplyBuilder* builder,
                                          facade::ConnectionContext* cntx) final;
 
   // Execute multiple consecutive commands, possibly in parallel by squashing
-  facade::DispatchManyResult DispatchManyCommands(absl::Span<ArgSlice> args_list,
+  facade::DispatchManyResult DispatchManyCommands(absl::Span<facade::ParsedArgs> args_list,
                                                   facade::SinkReplyBuilder* builder,
                                                   facade::ConnectionContext* cntx) final;
 

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2866,7 +2866,7 @@ void LoadSearchCommandFromAux(Service* service, string&& def, string_view comman
   string cmd_str{command_name};
   arg_vec.insert(arg_vec.begin(), MutableSlice{cmd_str.data(), cmd_str.size()});
 
-  service->DispatchCommand(absl::MakeSpan(arg_vec), &crb, &cntx);
+  service->DispatchCommand(facade::ParsedArgs{arg_vec}, &crb, &cntx);
 
   auto response = crb.Take();
   if (auto err = facade::CapturingReplyBuilder::TryExtractError(response); err) {

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -761,8 +761,7 @@ error_code Replica::ConsumeRedisStream() {
         }
 
         facade::RespExpr::VecToArgList(LastResponseArgs(), &args_vector);
-        CmdArgList arg_list{args_vector.data(), args_vector.size()};
-        service_.DispatchCommand(arg_list, &null_builder, &conn_context);
+        service_.DispatchCommand(facade::ParsedArgs{args_vector}, &null_builder, &conn_context);
       }
     }
 

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -454,7 +454,7 @@ RespExpr BaseFamilyTest::Run(std::string_view id, ArgSlice slice) {
 
   DCHECK(context->transaction == nullptr) << id;
 
-  service_->DispatchCommand(CmdArgList{args}, conn_wrapper->builder(), context);
+  service_->DispatchCommand(ParsedArgs{args}, conn_wrapper->builder(), context);
 
   DCHECK(context->transaction == nullptr);
 
@@ -486,13 +486,13 @@ void BaseFamilyTest::RunMany(const std::vector<std::vector<std::string>>& cmds) 
   TestConnWrapper* conn_wrapper = AddFindConn(Protocol::REDIS, GetId());
   auto* context = conn_wrapper->cmd_cntx();
   context->ns = &namespaces->GetDefaultNamespace();
-  vector<ArgSlice> args_vec(cmds.size());
+  vector<facade::ParsedArgs> args_vec(cmds.size());
   vector<vector<string_view>> cmd_views(cmds.size());
   for (size_t i = 0; i < cmds.size(); ++i) {
     for (const auto& arg : cmds[i]) {
       cmd_views[i].emplace_back(arg);
     }
-    args_vec[i] = absl::MakeSpan(cmd_views[i]);
+    args_vec[i] = ParsedArgs{cmd_views[i]};
   }
   service_->DispatchManyCommands(absl::MakeSpan(args_vec), conn_wrapper->builder(), context);
   DCHECK(context->transaction == nullptr);


### PR DESCRIPTION
Currently we use ArgSlice, CmdArgList everywhere where we want a span on string_views. As a result, it's very hard to understand the requirements from the passed classes.

This PR introduces a new ParsedArguments class and reduces the API surface for the passed object. Make sure to unwind ParsedArguments to ArgSlice only when we start executing the command.

We will clean-up redundant aliases in the futures.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->