### PR TITLE
chore: introduce common directory

### DIFF
--- a/src/common/heap_size.h
+++ b/src/common/heap_size.h
@@ -25,7 +25,7 @@
 #include <type_traits>
 #include <vector>
 
-namespace dfly {
+namespace cmn {
 
 namespace heap_size_detail {
 
@@ -142,4 +142,4 @@ template <typename Container> size_t AccumulateContainer(const Container& c) {
 }
 }  // namespace heap_size_detail
 
-}  // namespace dfly
+}  // namespace cmn

--- a/src/common/string_or_view.h
+++ b/src/common/string_or_view.h
@@ -1,4 +1,4 @@
-// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// Copyright 2025, DragonflyDB authors.  All rights reserved.
 // See LICENSE for licensing terms.
 //
 
@@ -8,7 +8,7 @@
 #include <string_view>
 #include <variant>
 
-namespace dfly {
+namespace cmn {
 
 class StringOrView {
  public:
@@ -84,4 +84,4 @@ class StringOrView {
   std::variant<std::string_view, std::string> val_;
 };
 
-}  // namespace dfly
+}  // namespace cmn

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -11,10 +11,10 @@
 #include <type_traits>
 
 #include "base/pmr/memory_resource.h"
+#include "common/string_or_view.h"
 #include "core/json/json_object.h"
 #include "core/mi_memory_resource.h"
 #include "core/small_string.h"
-#include "core/string_or_view.h"
 
 namespace dfly {
 
@@ -28,6 +28,7 @@ constexpr unsigned kEncodingJsonFlat = 1;
 class SBF;
 class PageUsage;
 
+using cmn::StringOrView;
 namespace detail {
 
 // redis objects or blobs of upto 4GB size.

--- a/src/core/compact_object_test.cc
+++ b/src/core/compact_object_test.cc
@@ -18,7 +18,6 @@
 #include "core/mi_memory_resource.h"
 #include "core/page_usage/page_usage_stats.h"
 #include "core/string_map.h"
-#include "core/string_or_view.h"
 #include "core/string_set.h"
 
 extern "C" {

--- a/src/core/search/indices.cc
+++ b/src/core/search/indices.cc
@@ -31,6 +31,7 @@ ABSL_FLAG(bool, use_numeric_range_tree, true,
 namespace dfly::search {
 
 using namespace std;
+using cmn::StringOrView;
 
 namespace {
 

--- a/src/core/search/indices.h
+++ b/src/core/search/indices.h
@@ -32,8 +32,8 @@
 #include "core/search/rax_tree.h"
 
 // TODO: move core field definitions out of big header
+#include "common/string_or_view.h"
 #include "core/search/search.h"
-#include "core/string_or_view.h"
 
 namespace dfly::search {
 
@@ -112,7 +112,7 @@ template <typename C> struct BaseStringIndex : public BaseIndex {
   // Used by Add & Remove to tokenize text value
   virtual absl::flat_hash_set<std::string> Tokenize(std::string_view value) const = 0;
 
-  StringOrView NormalizeQueryWord(std::string_view word) const;
+  cmn::StringOrView NormalizeQueryWord(std::string_view word) const;
   static Container* GetOrCreate(search::RaxTreeMap<Container>* map, std::string_view word);
   static void Remove(search::RaxTreeMap<Container>* map, DocId id, std::string_view word);
 

--- a/src/facade/conn_context.cc
+++ b/src/facade/conn_context.cc
@@ -7,12 +7,9 @@
 #include "absl/flags/internal/flag.h"
 #include "base/flags.h"
 #include "base/logging.h"
+#include "common/heap_size.h"
 #include "facade/dragonfly_connection.h"
 #include "facade/reply_builder.h"
-
-ABSL_RETIRED_FLAG(bool, experimental_new_io, true,
-                  "Use new replying code - should "
-                  "reduce latencies for pipelining");  // TODO remove in 1/2/25
 
 namespace facade {
 ConnectionContext::ConnectionContext(Connection* owner) : owner_(owner) {
@@ -30,7 +27,7 @@ ConnectionContext::ConnectionContext(Connection* owner) : owner_(owner) {
 }
 
 size_t ConnectionContext::UsedMemory() const {
-  return dfly::HeapSize(authed_username) + dfly::HeapSize(acl_commands);
+  return cmn::HeapSize(authed_username) + cmn::HeapSize(acl_commands);
 }
 
 }  // namespace facade

--- a/src/facade/conn_context.h
+++ b/src/facade/conn_context.h
@@ -9,7 +9,6 @@
 #include <memory>
 #include <string_view>
 
-#include "core/heap_size.h"
 #include "facade/acl_commands_def.h"
 #include "facade/facade_types.h"
 #include "facade/reply_builder.h"

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -20,7 +20,7 @@
 #include "base/io_buf.h"
 #include "base/logging.h"
 #include "base/stl_util.h"
-#include "core/heap_size.h"
+#include "common/heap_size.h"
 #include "facade/conn_context.h"
 #include "facade/dragonfly_listener.h"
 #include "facade/memcache_parser.h"
@@ -2034,10 +2034,10 @@ bool Connection::IsHttp() const {
 }
 
 Connection::MemoryUsage Connection::GetMemoryUsage() const {
-  size_t mem = sizeof(*this) + dfly::HeapSize(dispatch_q_) + dfly::HeapSize(name_) +
-               dfly::HeapSize(tmp_parse_args_) + dfly::HeapSize(tmp_cmd_vec_) +
-               dfly::HeapSize(memcache_parser_) + dfly::HeapSize(redis_parser_) +
-               dfly::HeapSize(cc_) + dfly::HeapSize(reply_builder_);
+  size_t mem = sizeof(*this) + cmn::HeapSize(dispatch_q_) + cmn::HeapSize(name_) +
+               cmn::HeapSize(tmp_parse_args_) + cmn::HeapSize(tmp_cmd_vec_) +
+               cmn::HeapSize(memcache_parser_) + cmn::HeapSize(redis_parser_) + cmn::HeapSize(cc_) +
+               cmn::HeapSize(reply_builder_);
 
   // We add a hardcoded 9k value to accomodate for the part of the Fiber stack that is in use.
   // The allocated stack is actually larger (~130k), but only a small fraction of that (9k

--- a/src/facade/redis_parser.cc
+++ b/src/facade/redis_parser.cc
@@ -8,7 +8,7 @@
 #include <absl/strings/numbers.h>
 
 #include "base/logging.h"
-#include "core/heap_size.h"
+#include "common/heap_size.h"
 
 namespace facade {
 
@@ -602,7 +602,7 @@ void RedisParser::ExtendBulkString(Buffer str) {
 }
 
 size_t RedisParser::UsedMemory() const {
-  return dfly::HeapSize(parse_stack_) + dfly::HeapSize(stash_) + dfly::HeapSize(buf_stash_);
+  return cmn::HeapSize(parse_stack_) + cmn::HeapSize(stash_) + cmn::HeapSize(buf_stash_);
 }
 
 }  // namespace facade

--- a/src/facade/redis_parser_test.cc
+++ b/src/facade/redis_parser_test.cc
@@ -10,7 +10,7 @@
 #include "absl/strings/str_cat.h"
 #include "base/gtest.h"
 #include "base/logging.h"
-#include "core/heap_size.h"
+#include "common/heap_size.h"
 #include "facade/facade_test.h"
 
 using namespace testing;
@@ -280,7 +280,7 @@ TEST_F(RedisParserTest, UsedMemory) {
   for (size_t i = 0; i < 100; ++i) {
     blobs.emplace_back(vector<uint8_t>(200));
   }
-  EXPECT_GT(dfly::HeapSize(blobs), 20000);
+  EXPECT_GT(cmn::HeapSize(blobs), 20000);
 
   std::vector<std::unique_ptr<RespVec>> stash;
   RespVec vec;
@@ -292,7 +292,7 @@ TEST_F(RedisParserTest, UsedMemory) {
   for (unsigned i = 0; i < 100; i++) {
     stash.emplace_back(new RespExpr::Vec(vec));
   }
-  EXPECT_GT(dfly::HeapSize(stash), 30000);
+  EXPECT_GT(cmn::HeapSize(stash), 30000);
 }
 
 TEST_F(RedisParserTest, Eol) {

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -14,7 +14,6 @@
 #include "absl/strings/escaping.h"
 #include "absl/types/span.h"
 #include "base/logging.h"
-#include "core/heap_size.h"
 #include "facade/error.h"
 #include "util/fibers/proactor_base.h"
 

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -5,7 +5,7 @@
 #include "server/conn_context.h"
 
 #include "base/logging.h"
-#include "core/heap_size.h"
+#include "common/heap_size.h"
 #include "facade/acl_commands_def.h"
 #include "facade/reply_builder.h"
 #include "server/acl/acl_commands_def.h"
@@ -21,6 +21,7 @@ namespace dfly {
 
 using namespace std;
 using namespace facade;
+using cmn::HeapSize;
 
 static void SendSubscriptionChangedResponse(string_view action, std::optional<string_view> topic,
                                             unsigned count, RedisReplyBuilder* rb) {
@@ -228,7 +229,7 @@ void ConnectionContext::PUnsubscribeAll(bool to_reply, facade::RedisReplyBuilder
 }
 
 size_t ConnectionState::ExecInfo::UsedMemory() const {
-  return dfly::HeapSize(body) + dfly::HeapSize(watched_keys);
+  return HeapSize(body) + HeapSize(watched_keys);
 }
 
 void ConnectionState::ExecInfo::AddStoredCmd(const CommandId* cid, bool own_args, CmdArgList args) {
@@ -244,19 +245,19 @@ size_t ConnectionState::ExecInfo::ClearStoredCmds() {
 }
 
 size_t ConnectionState::ScriptInfo::UsedMemory() const {
-  return dfly::HeapSize(lock_tags) + async_cmds_heap_mem;
+  return HeapSize(lock_tags) + async_cmds_heap_mem;
 }
 
 size_t ConnectionState::SubscribeInfo::UsedMemory() const {
-  return dfly::HeapSize(channels) + dfly::HeapSize(patterns);
+  return HeapSize(channels) + HeapSize(patterns);
 }
 
 size_t ConnectionState::UsedMemory() const {
-  return dfly::HeapSize(exec_info) + dfly::HeapSize(script_info) + dfly::HeapSize(subscribe_info);
+  return HeapSize(exec_info) + HeapSize(script_info) + HeapSize(subscribe_info);
 }
 
 size_t ConnectionContext::UsedMemory() const {
-  return facade::ConnectionContext::UsedMemory() + dfly::HeapSize(conn_state);
+  return facade::ConnectionContext::UsedMemory() + HeapSize(conn_state);
 }
 
 void ConnectionContext::Unsubscribe(std::string_view channel) {

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
+#include "common/string_or_view.h"
 #include "core/mi_memory_resource.h"
-#include "core/string_or_view.h"
 #include "facade/dragonfly_connection.h"
 #include "facade/op_status.h"
 #include "server/common.h"

--- a/src/server/detail/wrapped_json_path.h
+++ b/src/server/detail/wrapped_json_path.h
@@ -9,9 +9,9 @@
 #include <variant>
 
 #include "base/logging.h"
+#include "common/string_or_view.h"
 #include "core/json/json_object.h"
 #include "core/json/path.h"
-#include "core/string_or_view.h"
 #include "facade/op_status.h"
 
 namespace dfly {
@@ -95,9 +95,9 @@ class WrappedJsonPath {
   static constexpr std::string_view kV1PathRootElement = ".";
   static constexpr std::string_view kV2PathRootElement = "$";
 
-  WrappedJsonPath(json::Path json_path, StringOrView path, JsonPathType path_type);
+  WrappedJsonPath(json::Path json_path, cmn::StringOrView path, JsonPathType path_type);
 
-  WrappedJsonPath(JsonExpression expression, StringOrView path, JsonPathType path_type);
+  WrappedJsonPath(JsonExpression expression, cmn::StringOrView path, JsonPathType path_type);
 
   template <typename T>
   JsonCallbackResult<T> ExecuteReadOnlyCallback(const JsonType* json_entry,
@@ -129,7 +129,7 @@ class WrappedJsonPath {
 
  private:
   std::variant<json::Path, JsonExpression> parsed_path_;
-  StringOrView path_;
+  cmn::StringOrView path_;
   JsonPathType path_type_ = kDefaultJsonPathType;
 };
 
@@ -207,12 +207,12 @@ template <typename T> bool JsonCallbackResult<T>::ShouldSendWrongType() const {
   return false;
 }
 
-inline WrappedJsonPath::WrappedJsonPath(json::Path json_path, StringOrView path,
+inline WrappedJsonPath::WrappedJsonPath(json::Path json_path, cmn::StringOrView path,
                                         JsonPathType path_type)
     : parsed_path_(std::move(json_path)), path_(std::move(path)), path_type_(path_type) {
 }
 
-inline WrappedJsonPath::WrappedJsonPath(JsonExpression expression, StringOrView path,
+inline WrappedJsonPath::WrappedJsonPath(JsonExpression expression, cmn::StringOrView path,
                                         JsonPathType path_type)
     : parsed_path_(std::move(expression)), path_(std::move(path)), path_type_(path_type) {
 }

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -10,7 +10,6 @@
 #include "base/cycle_clock.h"
 #include "base/flags.h"
 #include "base/logging.h"
-#include "core/heap_size.h"
 #include "server/db_slice.h"
 #include "server/engine_shard_set.h"
 #include "server/journal/journal.h"

--- a/src/server/tiering/decoders.h
+++ b/src/server/tiering/decoders.h
@@ -10,7 +10,6 @@
 #include <string_view>
 
 #include "core/compact_object.h"
-#include "core/string_or_view.h"
 
 namespace dfly::tiering {
 


### PR DESCRIPTION
We introduce a new directory that will contain low-level common utilities and classes that can be used by any other components: facade, core and server. We move StringOrView and HeapSize there.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->