### PR TITLE
chore: fix data corruption bug

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -86,8 +86,6 @@ ABSL_FLAG(uint32_t, memcached_port, 0, "Memcached port");
 
 ABSL_FLAG(uint32_t, num_shards, 0, "Number of database shards, 0 - to choose automatically");
 
-ABSL_RETIRED_FLAG(uint32_t, multi_exec_mode, 2, "DEPRECATED. Sets multi exec atomicity mode");
-
 ABSL_FLAG(bool, multi_exec_squash, true,
           "Whether multi exec will squash single shard commands to optimize performance");
 

--- a/src/server/multi_command_squasher.h
+++ b/src/server/multi_command_squasher.h
@@ -66,7 +66,7 @@ class MultiCommandSquasher {
     boost::intrusive_ptr<Transaction> local_tx;  // stub-mode tx for use inside shard
   };
 
-  enum class SquashResult : uint8_t { SQUASHED, SQUASHED_FULL, NOT_SQUASHED, ERROR };
+  enum class SquashResult : uint8_t { SQUASHED, SQUASHED_FULL, NOT_SQUASHED };
 
   MultiCommandSquasher(absl::Span<StoredCmd> cmds, ConnectionContext* cntx, Service* Service,
                        const Opts& opts);

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -1416,7 +1416,6 @@ async def test_client_migrate(df_server: DflyInstance):
     assert resp == 1  # migrated successfully
 
 
-@dfly_args({})
 async def test_issue_5931_malformed_protocol_crash(df_server: DflyInstance):
     """
     Regression test for #5931
@@ -1461,7 +1460,6 @@ async def test_issue_5931_malformed_protocol_crash(df_server: DflyInstance):
     assert await client.ping() == True
 
 
-@dfly_args({})
 async def test_issue_5949_nil_bulk_string_crash(df_server: DflyInstance):
     """
     Regression test for #5949
@@ -1504,3 +1502,20 @@ async def test_issue_5949_nil_bulk_string_crash(df_server: DflyInstance):
     client = df_server.client()
     await client.ping()
     assert await client.ping() == True
+
+
+async def test_issue_6165_squash_invalid_syntax(async_client):
+    pipe = async_client.pipeline(transaction=False)
+    pipe.set("k", "v")
+    pipe.execute_command("RENAME bar")
+    res = await pipe.execute(raise_on_error=False)
+
+    assert res[0] == True  # SET key1
+    assert isinstance(res[1], aioredis.ResponseError)  # INVALID SYNTAX COMMAND
+
+    pip = async_client.pipeline(transaction=False)
+    pip.set("k", "v")
+    pip.execute_command("ZUNION 2 set1")
+    res = await pip.execute(raise_on_error=False)
+    assert res[0] == True  # SET key1
+    assert isinstance(res[1], aioredis.ResponseError)  # INVALID SYNTAX


### PR DESCRIPTION
The bug happenned when an command with less than required arguments was processed during the squashing.

The test:
1. Reproduces the original bug
2. Reproduces the fact that the ERROR in squashing was not handled correctly

The fix: removes the ERROR state, adds a verification step that ensures we fail before accessing non-existing index. Fixes #6165

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->