### PR TITLE
tests: Skip package installer tests on CI

### DIFF
--- a/tests/dragonfly/package_install_test.py
+++ b/tests/dragonfly/package_install_test.py
@@ -3,6 +3,11 @@ import platform
 import pytest
 from testcontainers.core.container import DockerContainer
 
+pytest.skip(
+    "These tests will only be run for the action that generates the package repository",
+    allow_module_level=True,
+)
+
 
 def check(container: DockerContainer, cmd: str):
     result = container.exec(cmd)


### PR DESCRIPTION
Package installer tests routinely fail due to throttling on docker registry.

These tests also do not make sense when run as part of CI suite, they should only be run when new releases are created. Here these tests are skipped in CI. In the next PR they will be wired to run only as part of the action which sets up the package repository.