### PR TITLE
fix(search): Fix numeric tree finalization

### DIFF
--- a/src/core/search/range_tree.h
+++ b/src/core/search/range_tree.h
@@ -78,6 +78,7 @@ class RangeTree {
   // Returns all blocks in the tree.
   absl::InlinedVector<const RangeBlock*, 5> GetAllBlocks() const;
 
+  // Build tree ouf of a single block after replication
   void FinalizeInitialization();
 
   struct Stats {

--- a/src/core/search/range_tree_test.cc
+++ b/src/core/search/range_tree_test.cc
@@ -472,7 +472,7 @@ TEST_F(RangeTreeTest, RangeResultTwoBlocks) {
 }
 
 TEST_F(RangeTreeTest, FinalizeInitialization) {
-  RangeTree tree{PMR_NS::get_default_resource(), 1, false};
+  RangeTree tree{PMR_NS::get_default_resource(), 2, false};
 
   // Add some values
   tree.Add(1, 10.0);
@@ -491,10 +491,21 @@ TEST_F(RangeTreeTest, FinalizeInitialization) {
   tree.FinalizeInitialization();
 
   result = tree.RangeBlocks(10.0, 40.0);
-  EXPECT_THAT(
-      result,
-      BlocksAre(
-          {{{1, 10.0}}, {{2, 20.0}, {3, 20.0}, {5, 20.0}}, {{4, 30.0}, {6, 30.0}}, {{7, 40.0}}}));
+  EXPECT_THAT(result, BlocksAre({{{1, 10.0}, {2, 20.0}, {3, 20.0}, {5, 20.0}},
+                                 {{4, 30.0}, {6, 30.0}},
+                                 {{7, 40.0}}}));
+}
+
+// Test tree doesn't create unnecessary nodes after initialization
+TEST_F(RangeTreeTest, DiscreteIntialization) {
+  RangeTree tree{PMR_NS::get_default_resource(), 4, false};
+  for (size_t i = 0; i < 32; i++) {
+    tree.Add(i, i % 4);
+  }
+
+  tree.FinalizeInitialization();
+  auto result = tree.GetAllBlocks();
+  EXPECT_EQ(result.size(), 4u);
 }
 
 // Benchmark tree insertion performance with set of discrete values


### PR DESCRIPTION
During finalization the tree doesn't put entries with the same value inside a single block which breaks the logical invariant