### PR TITLE
chore: improve backed_args by allowing random access to its arguments

### DIFF
--- a/src/facade/facade_types.h
+++ b/src/facade/facade_types.h
@@ -85,13 +85,11 @@ class ParsedArgs {
 
     const cmn::BackedArguments* args_;
     uint32_t index_ = 0;
-    uint32_t ofs_bytes_ = 0;
 
     ParsedArgs Tail() const {
       ParsedArgs res(*args_);
       WrapperBacked* wb = std::get_if<WrapperBacked>(&res.args_);
       wb->index_ = index_ + 1;
-      wb->ofs_bytes_ = ofs_bytes_ + args_->elem_capacity(index_);
       return res;
     };
 
@@ -100,16 +98,11 @@ class ParsedArgs {
     }
 
     std::string_view front() const {
-      return args_->at(index_, ofs_bytes_);
+      return args_->at(index_);
     }
 
     ArgSlice ToSlice(CmdArgVec* scratch) const {
-      scratch->resize(size());
-      size_t offset = ofs_bytes_;
-      for (size_t i = 0; i < scratch->size(); ++i) {
-        (*scratch)[i] = args_->at(index_ + i, offset);
-        offset += args_->elem_capacity(index_ + i);
-      }
+      scratch->assign(args_->begin() + index_, args_->end());
       return ArgSlice{scratch->data(), scratch->size()};
     }
   };

--- a/src/facade/memcache_parser.cc
+++ b/src/facade/memcache_parser.cc
@@ -333,8 +333,8 @@ auto MP::Parse(string_view str, uint32_t* consumed, Command* cmd) -> Result {
   tokens_view.remove_prefix(1);
   cmd->clear();
 
-  if (cmd->type <= CAS) {                                    // Store command
-    if (tokens_view.size() < 4 || tokens[0].size() > 250) {  // key length limit
+  if (cmd->type <= CAS) {                                         // Store command
+    if (tokens_view.size() < 4 || tokens_view[0].size() > 250) {  // key length limit
       return MP::PARSE_ERROR;
     }
 

--- a/src/facade/memcache_parser.h
+++ b/src/facade/memcache_parser.h
@@ -61,7 +61,7 @@ class MemcacheParser {
     CmdType type = INVALID;
 
     std::string_view key() const {
-      return lens_.empty() ? std::string_view{} : Front();
+      return empty() ? std::string_view{} : Front();
     }
     union {
       uint64_t cas_unique = 0;  // for CAS COMMAND

--- a/src/facade/memcache_parser_test.cc
+++ b/src/facade/memcache_parser_test.cc
@@ -23,9 +23,7 @@ class MCParserTest : public testing::Test {
   }
 
   vector<string_view> ToArgs() {
-    vector<string_view> res;
-    ParsedArgs{cmd_}.ToSlice(&res);
-    return res;
+    return {cmd_.begin(), cmd_.end()};
   }
 
   MemcacheParser parser_;


### PR DESCRIPTION
Change BackedArguments to keep prefix sums of all lengths of its items Based on the idea from https://github.com/dragonflydb/dragonfly/pull/6176#discussion_r2601861597

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->