### PR TITLE
chore: hold memcache value in BackedArguments

### DIFF
--- a/src/common/backed_args.h
+++ b/src/common/backed_args.h
@@ -133,6 +133,13 @@ class BackedArguments {
     storage_.clear();
   }
 
+  // Reserves space for additional argument of given length at the end.
+  void PushArg(size_t len) {
+    size_t old_size = storage_.size();
+    offsets_.push_back(old_size);
+    storage_.resize(old_size + len + 1);
+  }
+
  protected:
   absl::InlinedVector<uint32_t, kLenCap> offsets_;
   StorageType storage_;

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -84,12 +84,7 @@ class Connection : public util::Connection {
   using PipelineMessage = cmn::BackedArguments;
 
   // Pipeline message, accumulated Memcached command to be executed.
-  struct MCPipelineMessage {
-    MCPipelineMessage(MemcacheParser::Command&& cmd, std::string_view value);
-
-    MemcacheParser::Command cmd;
-    std::string value;
-  };
+  using MCPipelineMessage = MemcacheParser::Command;
 
   // Monitor message, carries a simple payload with the registered event to be sent.
   struct MonitorMessage : public std::string {};
@@ -414,6 +409,7 @@ class Connection : public util::Connection {
   io::IoBuf io_buf_;  // used in io loop and parsers
   std::unique_ptr<RedisParser> redis_parser_;
   std::unique_ptr<MemcacheParser> memcache_parser_;
+  MemcacheParser::Command mc_cmd_;
 
   uint32_t id_;
   Protocol protocol_;

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -507,9 +507,10 @@ auto BaseFamilyTest::RunMC(MP::CmdType cmd_type, string_view key, string_view va
 
   MP::Command cmd;
   cmd.type = cmd_type;
-  cmd.Assign(&key, &key + 1, 1);
+
+  string_view kv[2] = {key, value};
+  cmd.Assign(kv, kv + 2, 2);
   cmd.flags = flags;
-  cmd.bytes_len = value.size();
   cmd.expire_ts = ttl.count();
 
   TestConnWrapper* conn = AddFindConn(Protocol::MEMCACHE, GetId());


### PR DESCRIPTION
STORE-like memached commands have exactly two arguments: a key and a value. This PR aggregates both under the same BackedArguments object and simplifies the logic around MemcacheParser::Command.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->