### PR TITLE
chore: to move some of the command-specific state into CommandContext

### DIFF
--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -284,7 +284,6 @@ struct ConnectionState {
   std::unique_ptr<ScriptInfo> script_info;
   std::unique_ptr<SubscribeInfo> subscribe_info;
   ClientTracking tracking_info_;
-  uint64_t cmd_start_time_ns = 0;  // time when the last command started executing
 };
 
 class ConnectionContext : public facade::ConnectionContext {
@@ -295,9 +294,6 @@ class ConnectionContext : public facade::ConnectionContext {
   struct DebugInfo {
     uint32_t shards_count = 0;
     TxClock clock = 0;
-
-    // number of commands in the last exec body.
-    unsigned exec_body_len = 0;
   };
 
   DebugInfo last_command_debug;
@@ -305,7 +301,7 @@ class ConnectionContext : public facade::ConnectionContext {
   // TODO: to introduce proper accessors.
   Namespace* ns = nullptr;
   Transaction* transaction = nullptr;
-  const CommandId* cid = nullptr;
+  // const CommandId* cid = nullptr;
 
   ConnectionState conn_state;
 

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -1632,8 +1632,8 @@ void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBat
       crb.SetReplyMode(ReplyMode::NONE);
       stub_tx->InitByArgs(cntx_->ns, local_cntx.conn_state.db_index, args_span);
 
-      sf_.service().InvokeCmd(cid, args_span,
-                              CommandContext{local_cntx.transaction, &crb, &local_cntx});
+      CommandContext cmd_cntx{cid, local_cntx.transaction, &crb, &local_cntx};
+      sf_.service().InvokeCmd(args_span, &cmd_cntx);
     }
 
     if (options.expire_ttl_range.has_value()) {
@@ -1653,8 +1653,8 @@ void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBat
       crb.SetReplyMode(ReplyMode::NONE);
       stub_tx->MultiSwitchCmd(cid);
       stub_tx->InitByArgs(cntx_->ns, local_cntx.conn_state.db_index, args_span);
-      sf_.service().InvokeCmd(cid, args_span,
-                              CommandContext{local_cntx.transaction, &crb, &local_cntx});
+      CommandContext cmd_cntx{cid, local_cntx.transaction, &crb, &local_cntx};
+      sf_.service().InvokeCmd(args_span, &cmd_cntx);
     }
   }
 

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -592,7 +592,7 @@ void DflyCmd::TakeOver(CmdArgList args, RedisReplyBuilder* rb, ConnectionContext
     VLOG(1) << "Takeover accepted, shutting down.";
     std::string save_arg = "NOSAVE";
     MutableSlice sargs(save_arg);
-    sf_->ShutdownCmd(CmdArgList(&sargs, 1), CommandContext{nullptr, rb, nullptr});
+    sf_->ShutdownCmd(CmdArgList(&sargs, 1), CommandContext{nullptr, nullptr, rb, nullptr});
     return;
   }
 

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -547,7 +547,7 @@ void HSetEx(CmdArgList args, const CommandContext& cmd_cntx) {
   OpSetParams op_sp;
 
   const auto option_already_set = [&cmd_cntx] {
-    return cmd_cntx.rb->SendError(WrongNumArgsError(cmd_cntx.conn_cntx->cid->name()));
+    return cmd_cntx.rb->SendError(WrongNumArgsError(cmd_cntx.cid->name()));
   };
 
   while (true) {
@@ -580,8 +580,7 @@ void HSetEx(CmdArgList args, const CommandContext& cmd_cntx) {
   CmdArgList fields = parser.Tail();
 
   if (fields.size() % 2 != 0) {
-    return cmd_cntx.rb->SendError(facade::WrongNumArgsError(cmd_cntx.conn_cntx->cid->name()),
-                                  kSyntaxErrType);
+    return cmd_cntx.rb->SendError(facade::WrongNumArgsError(cmd_cntx.cid->name()), kSyntaxErrType);
   }
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
@@ -851,7 +850,7 @@ void HSetFamily::HScan(CmdArgList args, const CommandContext& cmd_cntx) {
 void HSetFamily::HSet(CmdArgList args, const CommandContext& cmd_cntx) {
   string_view key = ArgS(args, 0);
 
-  string_view cmd{cmd_cntx.conn_cntx->cid->name()};
+  string_view cmd{cmd_cntx.cid->name()};
 
   if (args.size() % 2 != 1) {
     return cmd_cntx.rb->SendError(facade::WrongNumArgsError(cmd), kSyntaxErrType);

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -45,12 +45,11 @@ class Service : public facade::ServiceInterface {
                                                   facade::ConnectionContext* cntx) final;
 
   // Check VerifyCommandExecution and invoke command with args
-  facade::DispatchResult InvokeCmd(const CommandId* cid, CmdArgList tail_args,
-                                   const CommandContext& cmd_cntx);
+  facade::DispatchResult InvokeCmd(CmdArgList tail_args, CommandContext* cmd_cntx);
 
   // Verify command can be executed now (check out of memory), always called immediately before
   // execution
-  std::optional<facade::ErrorReply> VerifyCommandExecution(const ConnectionContext* cntx,
+  std::optional<facade::ErrorReply> VerifyCommandExecution(const CommandContext& cmd_cntx,
                                                            CmdArgList tail_args);
 
   // Verify command prepares excution in correct state.

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -2608,7 +2608,8 @@ void XReadGeneric2(CmdArgList args, bool read_group, Transaction* tx, SinkReplyB
 }
 
 void HelpSubCmd(facade::CmdArgParser* parser, Transaction* tx, SinkReplyBuilder* builder) {
-  XGroupHelp(parser->Tail(), CommandContext{tx, builder, nullptr});
+  CommandContext cmd_cntx{nullptr, tx, builder, nullptr};
+  XGroupHelp(parser->Tail(), cmd_cntx);
 }
 
 bool ParseXpendingOptions(CmdArgList& args, PendingOpts& opts, SinkReplyBuilder* builder) {

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -722,7 +722,7 @@ void ExtendGeneric(CmdArgList args, bool prepend, Transaction* tx, SinkReplyBuil
 // Wrapper to call SetCmd::Set in ScheduleSingleHop
 OpStatus SetGeneric(const SetCmd::SetParams& sparams, string_view key, string_view value,
                     const CommandContext& ctx) {
-  bool explicit_journal = ctx.conn_cntx->cid->opt_mask() & CO::NO_AUTOJOURNAL;
+  bool explicit_journal = ctx.cid->opt_mask() & CO::NO_AUTOJOURNAL;
   return ctx.tx->ScheduleSingleHop([&](Transaction* t, EngineShard* shard) {
     return SetCmd(t->GetOpArgs(shard), explicit_journal).Set(sparams, key, value);
   });
@@ -1093,7 +1093,7 @@ void StringFamily::Set(CmdArgList args, const CommandContext& cmnd_cntx) {
 
 /// (P)SETEX key seconds (milliseconds) value
 void StringFamily::SetExGeneric(CmdArgList args, const CommandContext& cmd_cntx) {
-  string_view cmd_name = cmd_cntx.conn_cntx->cid->name();
+  string_view cmd_name = cmd_cntx.cid->name();
 
   CmdArgParser parser{args};
   auto [key, exp_int, value] = parser.Next<string_view, int64_t, string_view>();


### PR DESCRIPTION
Main change is around command latency measurement, where we concentrate the logic in one central place: CommandContext::RecordLatency.

Related to #6196

This PR is first step to extend the responsibility of CommandContext so that all the context related to specific command execution would only be held there. Specifically here we delete a few fields stored in ConnectionContext that in fact were relevant only for the currently executed command. We move these fields to CommandContext.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->