### PR TITLE
docs: add antigravity agent instructions

### DIFF
--- a/.agent/rules/ANTIGRAVITY_INSTRUCTIONS.md
+++ b/.agent/rules/ANTIGRAVITY_INSTRUCTIONS.md
@@ -52,7 +52,7 @@ Dragonfly is a high-performance, Redis and Memcached compatible in-memory data s
 - **Commits**:
   - **Must be signed**: `git commit -s`.
   - **Format**: Conventional Commits (`type(scope): description`).
-    - Types: `feat`, `fix`, `chore`, `test`, `refactor`, `perf`, `docs`.
+    - Types: `feat`, `fix`, `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `revert`, `style`, `test`.
 
 ### 4. Key Directories
 - `src/server`: Core server logic (`dfly_main.cc`, `main_service.cc`).


### PR DESCRIPTION
This PR adds the Antigravity agent instructions to . These instructions cover build, test, and style guidelines for the Dragonfly project.