### PR TITLE
chore(server): polish CommandContext data structure

### DIFF
--- a/src/facade/conn_context.cc
+++ b/src/facade/conn_context.cc
@@ -19,7 +19,6 @@ ConnectionContext::ConnectionContext(Connection* owner) : owner_(owner) {
   authenticated = false;
   async_dispatch = false;
   sync_dispatch = false;
-  journal_emulated = false;
   paused = false;
   blocked = false;
 

--- a/src/facade/conn_context.h
+++ b/src/facade/conn_context.h
@@ -43,9 +43,8 @@ class ConnectionContext {
   bool req_auth : 1;
   bool replica_conn : 1;  // whether it's a replica connection on the master side.
   bool authenticated : 1;
-  bool async_dispatch : 1;    // whether this connection is amid an async dispatch
-  bool sync_dispatch : 1;     // whether this connection is amid a sync dispatch
-  bool journal_emulated : 1;  // whether it is used to dispatch journal commands
+  bool async_dispatch : 1;  // whether this connection is amid an async dispatch
+  bool sync_dispatch : 1;   // whether this connection is amid a sync dispatch
 
   bool paused = false;  // whether this connection is paused due to CLIENT PAUSE
   // whether it's blocked on blocking commands like BLPOP, needs to be addressable

--- a/src/server/bloom_family.cc
+++ b/src/server/bloom_family.cc
@@ -93,7 +93,7 @@ void CmdReserve(CmdArgList args, CommandContext* cmd_cntx) {
   SbfParams params;
 
   tie(params.error, params.init_capacity) = parser.Next<double, uint32_t>();
-  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb);
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (parser.TakeError())
     return rb->SendError(kSyntaxErr);
 
@@ -123,12 +123,12 @@ void CmdAdd(CmdArgList args, CommandContext* cmd_cntx) {
   OpStatus status = res.status();
   if (res) {
     if (res->front())
-      return cmd_cntx->rb->SendLong(*res->front());
+      return cmd_cntx->rb()->SendLong(*res->front());
     else
       status = res->front().status();
   }
 
-  return cmd_cntx->rb->SendError(status);
+  return cmd_cntx->SendError(status);
 }
 
 void CmdExists(CmdArgList args, CommandContext* cmd_cntx) {
@@ -139,7 +139,7 @@ void CmdExists(CmdArgList args, CommandContext* cmd_cntx) {
   };
 
   OpResult res = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
-  return cmd_cntx->rb->SendLong(res ? res->front() : 0);
+  return cmd_cntx->rb()->SendLong(res ? res->front() : 0);
 }
 
 void CmdMAdd(CmdArgList args, CommandContext* cmd_cntx) {
@@ -150,7 +150,7 @@ void CmdMAdd(CmdArgList args, CommandContext* cmd_cntx) {
     return OpAdd(t->GetOpArgs(shard), key, args);
   };
 
-  RedisReplyBuilder* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb);
+  RedisReplyBuilder* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   OpResult res = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
   if (!res) {
     return rb->SendError(res.status());
@@ -177,7 +177,7 @@ void CmdMExists(CmdArgList args, CommandContext* cmd_cntx) {
 
   OpResult res = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb);
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   RedisReplyBuilder::ArrayScope scope{rb, args.size()};
   for (size_t i = 0; i < args.size(); ++i) {
     rb->SendLong(res ? res->at(i) : 0);

--- a/src/server/bloom_family.h
+++ b/src/server/bloom_family.h
@@ -9,7 +9,6 @@
 namespace dfly {
 
 class CommandRegistry;
-struct CommandContext;
 
 class BloomFamily {
  public:

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -416,7 +416,7 @@ void ClusterFamily::Cluster(CmdArgList args, CommandContext* cmd_cntx) {
   // instances is thus 1.
   string sub_cmd = absl::AsciiStrToUpper(ArgS(args, 0));
 
-  auto* builder = cmd_cntx->rb;
+  auto* builder = cmd_cntx->rb();
   if (!IsClusterEnabledOrEmulated()) {
     return builder->SendError(kClusterDisabled);
   }
@@ -429,7 +429,7 @@ void ClusterFamily::Cluster(CmdArgList args, CommandContext* cmd_cntx) {
     return builder->SendError(WrongNumArgsError(absl::StrCat("CLUSTER ", sub_cmd)));
   }
 
-  auto* cntx = cmd_cntx->conn_cntx;
+  auto* cntx = cmd_cntx->server_conn_cntx();
   if (sub_cmd == "HELP") {
     return ClusterHelp(builder);
   } else if (sub_cmd == "MYID") {
@@ -448,19 +448,19 @@ void ClusterFamily::Cluster(CmdArgList args, CommandContext* cmd_cntx) {
 }
 
 void ClusterFamily::ReadOnly(CmdArgList args, CommandContext* cmd_cntx) {
-  cmd_cntx->rb->SendOk();
+  cmd_cntx->rb()->SendOk();
 }
 
 void ClusterFamily::ReadWrite(CmdArgList args, CommandContext* cmd_cntx) {
   if (!IsClusterEmulated()) {
-    return cmd_cntx->rb->SendError(kClusterDisabled);
+    return cmd_cntx->SendError(kClusterDisabled);
   }
-  cmd_cntx->rb->SendOk();
+  cmd_cntx->rb()->SendOk();
 }
 
 void ClusterFamily::DflyCluster(CmdArgList args, CommandContext* cmd_cntx) {
-  auto* builder = cmd_cntx->rb;
-  auto* cntx = cmd_cntx->conn_cntx;
+  auto* builder = cmd_cntx->rb();
+  auto* cntx = cmd_cntx->server_conn_cntx();
   if (!(IsClusterEnabled() || (IsClusterEmulated() && cntx->journal_emulated))) {
     return builder->SendError("Cluster is disabled. Use --cluster_mode=yes to enable.");
   }
@@ -798,11 +798,11 @@ void ClusterFamily::DflyMigrate(CmdArgList args, CommandContext* cmd_cntx) {
   string sub_cmd = absl::AsciiStrToUpper(ArgS(args, 0));
 
   args.remove_prefix(1);
-  auto* builder = cmd_cntx->rb;
+  auto* builder = cmd_cntx->rb();
   if (sub_cmd == "INIT") {
     InitMigration(args, builder);
   } else if (sub_cmd == "FLOW") {
-    DflyMigrateFlow(args, builder, cmd_cntx->conn_cntx);
+    DflyMigrateFlow(args, builder, cmd_cntx->server_conn_cntx());
   } else if (sub_cmd == "ACK") {
     DflyMigrateAck(args, builder);
   } else {

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -138,14 +138,15 @@ void CommandContext::RecordLatency(facade::ArgSlice tail_args) const {
 
   cid->RecordLatency(ss->thread_index(), execution_time_usec);
 
-  DCHECK(conn_cntx != nullptr);
+  DCHECK(conn_cntx_ != nullptr);
 
   // TODO: we should probably discard more commands here,
   // not just the blocking ones
-  const auto* conn = conn_cntx->conn();
-  if (conn_cntx->conn_state.squashing_info) {
+  const auto* conn = server_conn_cntx()->conn();
+  auto& conn_state = server_conn_cntx()->conn_state;
+  if (conn_state.squashing_info) {
     // We run from the squashed transaction.
-    conn = conn_cntx->conn_state.squashing_info->owner->conn();
+    conn = conn_state.squashing_info->owner->conn();
   }
 
   if (!(cid->opt_mask() & CO::BLOCKING) && conn != nullptr &&
@@ -167,13 +168,13 @@ void CommandContext::RecordLatency(facade::ArgSlice tail_args) const {
 }
 
 void CommandContext::SendError(std::string_view str, std::string_view type) const {
-  rb->SendError(str, type);
+  rb()->SendError(str, type);
 }
 void CommandContext::SendError(facade::OpStatus status) const {
-  rb->SendError(status);
+  rb()->SendError(status);
 }
 void CommandContext::SendError(facade::ErrorReply error) const {
-  rb->SendError(std::move(error));
+  rb()->SendError(std::move(error));
 }
 
 CommandId::CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first_key,

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -16,14 +16,8 @@
 #include "facade/command_id.h"
 #include "facade/facade_types.h"
 
-namespace facade {
-class SinkReplyBuilder;
-}  // namespace facade
-
 namespace dfly {
 
-class ConnectionContext;
-class Transaction;
 namespace CO {
 
 enum CommandOpt : uint32_t {
@@ -71,28 +65,7 @@ enum class MultiControlKind : uint8_t {
 using CmdCallStats = std::pair<uint64_t, uint64_t>;
 
 class CommandId;
-
-struct CommandContext {
-  CommandContext(const CommandId* _cid, Transaction* _tx, facade::SinkReplyBuilder* _rb,
-                 ConnectionContext* cntx)
-      : cid(_cid), tx(_tx), rb(_rb), conn_cntx(cntx) {
-  }
-
-  const CommandId* cid;
-  Transaction* tx;
-  facade::SinkReplyBuilder* rb;
-  ConnectionContext* conn_cntx;
-
-  uint64_t start_time_ns = 0;
-
-  // number of commands in the last exec body.
-  unsigned exec_body_len = 0;
-
-  void RecordLatency(facade::ArgSlice tail_args) const;
-  void SendError(std::string_view str, std::string_view type = std::string_view{}) const;
-  void SendError(facade::OpStatus status) const;
-  void SendError(facade::ErrorReply error) const;
-};
+class CommandContext;
 
 // TODO: move it to helio
 // Makes sure that the POD T that is passed to the constructor is reset to default state

--- a/src/server/generic_family.h
+++ b/src/server/generic_family.h
@@ -16,7 +16,7 @@ using facade::CmdArgList;
 using facade::OpResult;
 
 class CommandRegistry;
-struct CommandContext;
+class CommandContext;
 
 class GenericFamily {
  public:

--- a/src/server/geo_family.cc
+++ b/src/server/geo_family.cc
@@ -227,7 +227,7 @@ void GeoFamily::GeoAdd(CmdArgList args, CommandContext* cmd_cntx) {
     }
   }
 
-  auto* builder = cmd_cntx->rb;
+  auto* builder = cmd_cntx->rb();
   args.remove_prefix(i);
   if (args.empty() || args.size() % 3 != 0) {
     builder->SendError(kSyntaxErr);
@@ -268,7 +268,7 @@ void GeoFamily::GeoAdd(CmdArgList args, CommandContext* cmd_cntx) {
 }
 
 void GeoFamily::GeoHash(CmdArgList args, CommandContext* cmd_cntx) {
-  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb);
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
   OpResult<MScoreResponse> result = ZSetFamily::ZGetMembers(args, cmd_cntx->tx, rb);
 
@@ -288,7 +288,7 @@ void GeoFamily::GeoHash(CmdArgList args, CommandContext* cmd_cntx) {
 }
 
 void GeoFamily::GeoPos(CmdArgList args, CommandContext* cmd_cntx) {
-  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb);
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
   OpResult<MScoreResponse> result = ZSetFamily::ZGetMembers(args, cmd_cntx->tx, rb);
 
@@ -311,7 +311,7 @@ void GeoFamily::GeoPos(CmdArgList args, CommandContext* cmd_cntx) {
 
 void GeoFamily::GeoDist(CmdArgList args, CommandContext* cmd_cntx) {
   double distance_multiplier = 1;
-  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb);
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
   if (args.size() == 4) {
     string_view unit = ArgS(args, 3);
@@ -594,7 +594,7 @@ void GeoFamily::GeoSearch(CmdArgList args, CommandContext* cmd_cntx) {
   int from_set = 0;
   // BYRADIUS or BYBOX is set
   int by_set = 0;
-  auto* builder = cmd_cntx->rb;
+  auto* builder = cmd_cntx->rb();
 
   CmdArgParser parser(args);
   string_view key = parser.Next();
@@ -696,7 +696,7 @@ void GeoFamily::GeoRadiusByMemberGeneric(CmdArgList args, CommandContext* cmd_cn
   // member to latlong, set shape.xy
   string_view member = ArgS(args, 1);
 
-  auto* builder = cmd_cntx->rb;
+  auto* builder = cmd_cntx->rb();
   if (!ParseDouble(ArgS(args, 2), &shape.t.radius)) {
     return builder->SendError(kInvalidFloatErr);
   }
@@ -788,7 +788,7 @@ void GeoFamily::GeoRadiusGeneric(CmdArgList args, CommandContext* cmd_cntx, bool
   GeoShape shape = {};
   GeoSearchOpts geo_ops;
 
-  auto* builder = cmd_cntx->rb;
+  auto* builder = cmd_cntx->rb();
 
   CmdArgParser parser(args);
 

--- a/src/server/geo_family.h
+++ b/src/server/geo_family.h
@@ -9,7 +9,7 @@
 namespace dfly {
 
 class CommandRegistry;
-struct CommandContext;
+class CommandContext;
 
 class GeoFamily {
  public:

--- a/src/server/hll_family.cc
+++ b/src/server/hll_family.cc
@@ -141,7 +141,7 @@ void PFAdd(CmdArgList args, CommandContext* cmd_cntx) {
   };
 
   OpResult<int> res = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
-  HandleOpValueResult(res, cmd_cntx->rb);
+  HandleOpValueResult(res, cmd_cntx->rb());
 }
 
 OpResult<int64_t> CountHllsSingle(const OpArgs& op_args, string_view key) {
@@ -255,9 +255,9 @@ void PFCount(CmdArgList args, CommandContext* cmd_cntx) {
     };
 
     OpResult<int64_t> res = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
-    HandleOpValueResult(res, cmd_cntx->rb);
+    HandleOpValueResult(res, cmd_cntx->rb());
   } else {
-    HandleOpValueResult(PFCountMulti(args, cmd_cntx), cmd_cntx->rb);
+    HandleOpValueResult(PFCountMulti(args, cmd_cntx), cmd_cntx->rb());
   }
 }
 
@@ -314,7 +314,7 @@ OpResult<int> PFMergeInternal(CmdArgList args, Transaction* tx, SinkReplyBuilder
 }
 
 void PFMerge(CmdArgList args, CommandContext* cmd_cntx) {
-  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb);
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   OpResult<int> result = PFMergeInternal(args, cmd_cntx->tx, rb);
   if (result.ok()) {
     if (result.value() == 0) {

--- a/src/server/json_family.h
+++ b/src/server/json_family.h
@@ -13,7 +13,7 @@ class SinkReplyBuilder;
 namespace dfly {
 
 class CommandRegistry;
-struct CommandContext;
+class CommandContext;
 
 class JsonFamily {
  public:

--- a/src/server/list_family.h
+++ b/src/server/list_family.h
@@ -12,7 +12,6 @@ namespace dfly {
 using facade::OpResult;
 
 class CommandRegistry;
-struct CommandContext;
 
 class ListFamily {
  public:

--- a/src/server/search/search_family.h
+++ b/src/server/search/search_family.h
@@ -15,7 +15,7 @@ class SinkReplyBuilder;
 
 namespace dfly {
 class CommandRegistry;
-struct CommandContext;
+class CommandContext;
 
 class SearchFamily {
   using SinkReplyBuilder = facade::SinkReplyBuilder;

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -41,7 +41,7 @@ namespace journal {
 class Journal;
 }  // namespace journal
 
-struct CommandContext;
+class CommandContext;
 class CommandRegistry;
 class Service;
 class ScriptMgr;

--- a/src/server/string_family.h
+++ b/src/server/string_family.h
@@ -6,13 +6,8 @@
 
 #include "facade/facade_types.h"
 
-namespace facade {
-class SinkReplyBuilder;
-}  // namespace facade
-
 namespace dfly {
 
-struct CommandContext;
 class CommandRegistry;
 
 class StringFamily {

--- a/src/server/zset_family.h
+++ b/src/server/zset_family.h
@@ -17,7 +17,6 @@ class SinkReplyBuilder;
 namespace dfly {
 
 class CommandRegistry;
-struct CommandContext;
 class Transaction;
 struct OpArgs;
 


### PR DESCRIPTION
To allow async execution, the i/o module (facade) should pass CommandContext to the server module. Currently this bridge is absent.

Before we can set up such bridge, we need to polish CommandContext.

This PR:
1. Moves CommandContext to conn_context.h
2. Hides `conn_cntx_` behind accessor server_conn_cntx().
3. Change the that accessed raw conn_cntx member to use server_conn_cntx.
3. Unrelated: moves server flag `journal_emulated` out of facade.

No functional changes.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->