### PR TITLE
chore: pass ParsedCommand to DispatchMC

### DIFF
--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -399,6 +399,7 @@ class Connection : public util::Connection {
   void DecrNumConns();
 
   bool IsReplySizeOverLimit() const;
+  void CreateParsedCommand();
 
   std::deque<MessageHandle> dispatch_q_;  // dispatch queue
   util::fb2::CondVarAny cnd_;             // dispatch queue waker

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -8,6 +8,8 @@
 #include "base/logging.h"
 #include "facade/command_id.h"
 #include "facade/error.h"
+#include "facade/parsed_command.h"
+#include "facade/reply_builder.h"
 #include "facade/resp_expr.h"
 #include "strings/human_readable.h"
 
@@ -215,6 +217,18 @@ bool AbslParseFlag(std::string_view in, MemoryBytesFlag* flag, std::string* err)
 
 std::string AbslUnparseFlag(const MemoryBytesFlag& flag) {
   return strings::HumanReadableNumBytes(flag.value);
+}
+
+void ParsedCommand::SendError(std::string_view str, std::string_view type) const {
+  rb_->SendError(str, type);
+}
+
+void ParsedCommand::SendError(facade::OpStatus status) const {
+  rb_->SendError(status);
+}
+
+void ParsedCommand::SendError(facade::ErrorReply error) const {
+  rb_->SendError(std::move(error));
 }
 
 }  // namespace facade

--- a/src/facade/ok_main.cc
+++ b/src/facade/ok_main.cc
@@ -42,9 +42,8 @@ class OkService : public ServiceInterface {
     return result;
   }
 
-  void DispatchMC(const MemcacheParser::Command& cmd, std::string_view value,
-                  MCReplyBuilder* builder, ConnectionContext* cntx) final {
-    builder->SendError("");
+  void DispatchMC(ParsedCommand* cmd) final {
+    cmd->rb()->SendError("");
   }
 
   ConnectionContext* CreateContext(Connection* owner) final {

--- a/src/facade/service_interface.h
+++ b/src/facade/service_interface.h
@@ -7,7 +7,7 @@
 #include <string>
 
 #include "facade/facade_types.h"
-#include "facade/memcache_parser.h"
+#include "facade/parsed_command.h"
 #include "util/fiber_socket_base.h"
 
 namespace util {
@@ -43,10 +43,17 @@ class ServiceInterface {
                                                   unsigned count, SinkReplyBuilder* builder,
                                                   ConnectionContext* cntx) = 0;
 
-  virtual void DispatchMC(const MemcacheParser::Command& cmd, std::string_view value,
-                          MCReplyBuilder* builder, ConnectionContext* cntx) = 0;
+  virtual void DispatchMC(ParsedCommand* cmd) = 0;
 
   virtual ConnectionContext* CreateContext(Connection* owner) = 0;
+
+  virtual ParsedCommand* AllocateParsedCommand() {
+    return new ParsedCommand();
+  }
+
+  virtual void FreeParsedCommand(ParsedCommand* cmd) {
+    delete cmd;
+  }
 
   virtual void ConfigureHttpHandlers(util::HttpListenerBase* base, bool is_privileged) {
   }

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -167,16 +167,6 @@ void CommandContext::RecordLatency(facade::ArgSlice tail_args) const {
   }
 }
 
-void CommandContext::SendError(std::string_view str, std::string_view type) const {
-  rb()->SendError(str, type);
-}
-void CommandContext::SendError(facade::OpStatus status) const {
-  rb()->SendError(status);
-}
-void CommandContext::SendError(facade::ErrorReply error) const {
-  rb()->SendError(std::move(error));
-}
-
 CommandId::CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first_key,
                      int8_t last_key, std::optional<uint32_t> acl_categories)
     : facade::CommandId(name, ImplicitCategories(mask), arity, first_key, last_key,

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -58,10 +58,11 @@ class Service : public facade::ServiceInterface {
   std::optional<facade::ErrorReply> VerifyCommandState(const CommandId& cid, ArgSlice tail_args,
                                                        const ConnectionContext& cntx);
 
-  void DispatchMC(const MemcacheParser::Command& cmd, std::string_view value,
-                  facade::MCReplyBuilder* builder, facade::ConnectionContext* cntx) final;
+  void DispatchMC(facade::ParsedCommand* parsed_cmd) final;
 
   facade::ConnectionContext* CreateContext(facade::Connection* owner) final;
+  facade::ParsedCommand* AllocateParsedCommand() final;
+  void FreeParsedCommand(facade::ParsedCommand* cmd) final;
 
   const CommandId* FindCmd(std::string_view) const;
 

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -76,8 +76,8 @@ static vector<string> SplitLines(const std::string& src) {
   return res;
 }
 
-TestConnection::TestConnection(Protocol protocol)
-    : facade::Connection(protocol, nullptr, nullptr, nullptr) {
+TestConnection::TestConnection(facade::ServiceInterface* si, Protocol protocol)
+    : facade::Connection(protocol, nullptr, nullptr, si) {
   cc_.reset(new dfly::ConnectionContext(this, {}));
   cc_->skip_acl_validation = true;
   SetSocket(ProactorBase::me()->CreateSocket());
@@ -114,7 +114,7 @@ void TransactionSuspension::Terminate() {
 
 class BaseFamilyTest::TestConnWrapper {
  public:
-  TestConnWrapper(Protocol proto);
+  TestConnWrapper(facade::ServiceInterface* si, Protocol proto);
   ~TestConnWrapper();
 
   CmdArgVec Args(ArgSlice list);
@@ -159,8 +159,8 @@ class BaseFamilyTest::TestConnWrapper {
   std::unique_ptr<SinkReplyBuilder> builder_;
 };
 
-BaseFamilyTest::TestConnWrapper::TestConnWrapper(Protocol proto)
-    : dummy_conn_(new TestConnection(proto)) {
+BaseFamilyTest::TestConnWrapper::TestConnWrapper(facade::ServiceInterface* si, Protocol proto)
+    : dummy_conn_(new TestConnection(si, proto)) {
   switch (proto) {
     case Protocol::REDIS:
       builder_.reset(new RedisReplyBuilder{&sink_});
@@ -219,6 +219,7 @@ void BaseFamilyTest::SetUp() {
 void BaseFamilyTest::TearDown() {
   CHECK_EQ(NumLocked(), 0U);
 
+  connections_.clear();
   ShutdownService();
 
   const TestInfo* const test_info = UnitTest::GetInstance()->current_test_info();
@@ -506,13 +507,14 @@ auto BaseFamilyTest::RunMC(MP::CmdType cmd_type, string_view key, string_view va
   }
 
   TestConnWrapper* conn = AddFindConn(Protocol::MEMCACHE, GetId());
-  cmn::BackedArguments cmd_backed_args;
-  MP::Command cmd;
-  cmd.backed_args = &cmd_backed_args;
+
+  CommandContext cmd_cntx{nullptr, nullptr, conn->builder(), conn->cmd_cntx()};
+  cmd_cntx.CreateMemcacheCommand();
+  auto& cmd = *cmd_cntx.mc_command();
   cmd.type = cmd_type;
 
   string_view kv[2] = {key, value};
-  cmd_backed_args.Assign(kv, kv + 2, 2);
+  cmd_cntx.Assign(kv, kv + 2, 2);
   cmd.flags = flags;
   cmd.expire_ts = ttl.count();
 
@@ -520,7 +522,7 @@ auto BaseFamilyTest::RunMC(MP::CmdType cmd_type, string_view key, string_view va
 
   DCHECK(context->transaction == nullptr);
 
-  service_->DispatchMC(cmd, value, static_cast<MCReplyBuilder*>(conn->builder()), context);
+  service_->DispatchMC(&cmd_cntx);
 
   DCHECK(context->transaction == nullptr);
 
@@ -545,19 +547,18 @@ auto BaseFamilyTest::GetMC(MP::CmdType cmd_type, std::initializer_list<std::stri
   }
 
   TestConnWrapper* conn = AddFindConn(Protocol::MEMCACHE, GetId());
-  MP::Command cmd;
-  cmn::BackedArguments cmd_backed_args;
-  cmd.backed_args = &cmd_backed_args;
+
+  CommandContext cmd_cntx{nullptr, nullptr, conn->builder(), conn->cmd_cntx()};
+  cmd_cntx.CreateMemcacheCommand();
+  auto& cmd = *cmd_cntx.mc_command();
   cmd.type = cmd_type;
   auto src = list.begin();
   if (cmd.type == MP::GAT || cmd.type == MP::GATS) {
     CHECK(absl::SimpleAtoi(*src++, &cmd.expire_ts));
   }
 
-  cmd_backed_args.Assign(src, list.end(), list.end() - src);
-
-  auto* context = conn->cmd_cntx();
-  service_->DispatchMC(cmd, string_view{}, static_cast<MCReplyBuilder*>(conn->builder()), context);
+  cmd_cntx.Assign(src, list.end(), list.end() - src);
+  service_->DispatchMC(&cmd_cntx);
 
   return conn->SplitLines();
 }
@@ -697,7 +698,7 @@ auto BaseFamilyTest::AddFindConn(Protocol proto, std::string_view id) -> TestCon
   auto [it, inserted] = connections_.emplace(id, nullptr);
 
   if (inserted) {
-    it->second.reset(new TestConnWrapper(proto));
+    it->second = make_unique<TestConnWrapper>(service_.get(), proto);
   } else {
     it->second->ClearSink();
   }

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -25,7 +25,7 @@ void TEST_InvalidateLockTagOptions();
 
 class TestConnection : public facade::Connection {
  public:
-  explicit TestConnection(Protocol protocol);
+  explicit TestConnection(facade::ServiceInterface* si, Protocol protocol);
   std::string RemoteEndpointStr() const override;
 
   void SendPubMessageAsync(PubMessage pmsg) final;


### PR DESCRIPTION
close the flow memcache end-to-end and allow dispatching ParsedCommand into main service.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->