### PR TITLE
feat(search): Yield when rebuilding index

### DIFF
--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -48,6 +48,10 @@ void TraverseAllMatching(const DocIndex& index, const OpArgs& op_args, F&& f) {
   PrimeTable::Cursor cursor;
   do {
     cursor = prime_table->Traverse(cursor, cb);
+    // Yield if the fiber has been running for long.
+    if (base::CycleClock::ToUsec(util::ThisFiber::GetRunningTimeCycles()) > 500) {  // 500us
+      util::ThisFiber::Yield();
+    }
   } while (cursor);
 }
 


### PR DESCRIPTION
Rebuilding index or creating index from keys that are in memory can be slow and can make process unresponsive. We now yield every 500us to make it more responsive.

Closes #6105

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->