### PR TITLE
chore: switch dev docker to GCC 14

### DIFF
--- a/tools/packaging/Dockerfile.ubuntu-dev
+++ b/tools/packaging/Dockerfile.ubuntu-dev
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM ghcr.io/romange/ubuntu-dev:20 AS builder
+FROM ghcr.io/romange/ubuntu-dev:20-gcc14 AS builder
 
 WORKDIR /build
 


### PR DESCRIPTION
Switch dev docker builder to GCC 14 by updating the base image tag in `tools/packaging/Dockerfile.ubuntu-dev`.

Checked here: https://github.com/dragonflydb/dragonfly/actions/runs/20263836386/job/58182045885
