### PR TITLE
chore: factor out reply payload

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -478,7 +478,7 @@ void Connection::AsyncOperations::operator()(const PubMessage& pub_msg) {
     return;
 
   if (pub_msg.force_unsubscribe) {
-    rb->StartCollection(3, RedisReplyBuilder::CollectionType::PUSH);
+    rb->StartCollection(3, CollectionType::PUSH);
     rb->SendBulkString("sunsubscribe");
     rb->SendBulkString(pub_msg.channel);
     rb->SendLong(0);
@@ -498,8 +498,7 @@ void Connection::AsyncOperations::operator()(const PubMessage& pub_msg) {
   arr[i++] = pub_msg.channel;
   arr[i++] = pub_msg.message;
 
-  rb->SendBulkStrArr(absl::Span<string_view>{arr.data(), i},
-                     RedisReplyBuilder::CollectionType::PUSH);
+  rb->SendBulkStrArr(absl::Span<string_view>{arr.data(), i}, CollectionType::PUSH);
 }
 
 void Connection::AsyncOperations::operator()(Connection::PipelineMessage& msg) {
@@ -531,7 +530,7 @@ void Connection::AsyncOperations::operator()(CheckpointMessage msg) {
 void Connection::AsyncOperations::operator()(const InvalidationMessage& msg) {
   RedisReplyBuilder* rbuilder = (RedisReplyBuilder*)builder;
   DCHECK(rbuilder->IsResp3());
-  rbuilder->StartCollection(2, facade::RedisReplyBuilder::CollectionType::PUSH);
+  rbuilder->StartCollection(2, facade::CollectionType::PUSH);
   rbuilder->SendBulkString("invalidate");
   if (msg.invalidate_due_to_flush) {
     rbuilder->SendNull();

--- a/src/facade/facade_types.h
+++ b/src/facade/facade_types.h
@@ -35,6 +35,7 @@ constexpr size_t kSanitizerOverhead = 0u;
 #endif
 
 enum class Protocol : uint8_t { MEMCACHE = 1, REDIS = 2 };
+enum class CollectionType : uint8_t { ARRAY, SET, MAP, PUSH };
 
 using MutableSlice = std::string_view;
 using CmdArgList = absl::Span<const std::string_view>;

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -346,17 +346,17 @@ void RedisReplyBuilderBase::SendNullArray() {
 }
 
 constexpr static const char START_SYMBOLS2[4][2] = {"*", "~", "%", ">"};
-static_assert(START_SYMBOLS2[RedisReplyBuilderBase::MAP][0] == '%' &&
-              START_SYMBOLS2[RedisReplyBuilderBase::SET][0] == '~');
+static_assert(START_SYMBOLS2[unsigned(CollectionType::MAP)][0] == '%' &&
+              START_SYMBOLS2[unsigned(CollectionType::SET)][0] == '~');
 
 void RedisReplyBuilderBase::StartCollection(unsigned len, CollectionType ct) {
   if (!IsResp3()) {  // RESP2 supports only arrays
-    if (ct == MAP)
+    if (ct == CollectionType::MAP)
       len *= 2;
-    ct = ARRAY;
+    ct = CollectionType::ARRAY;
   }
   ReplyScope scope(this);
-  WritePieces(START_SYMBOLS2[ct], len, kCRLF);
+  WritePieces(START_SYMBOLS2[unsigned(ct)], len, kCRLF);
 }
 
 void RedisReplyBuilderBase::SendError(std::string_view str, std::string_view type) {

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -229,7 +229,6 @@ class MCReplyBuilder : public SinkReplyBuilder {
 // Redis reply builder interface for sending RESP data.
 class RedisReplyBuilderBase : public SinkReplyBuilder {
  public:
-  enum CollectionType { ARRAY, SET, MAP, PUSH };
   enum VerbatimFormat { TXT, MARKDOWN };
 
   explicit RedisReplyBuilderBase(io::Sink* sink) : SinkReplyBuilder(sink) {
@@ -280,7 +279,6 @@ class RedisReplyBuilderBase : public SinkReplyBuilder {
 // Non essential redis reply builder functions implemented on top of the base resp protocol
 class RedisReplyBuilder : public RedisReplyBuilderBase {
  public:
-  using RedisReplyBuilderBase::CollectionType;
   using ScoredArray = absl::Span<const std::pair<std::string, double>>;
 
   RedisReplyBuilder(io::Sink* sink) : RedisReplyBuilderBase(sink) {
@@ -296,7 +294,7 @@ class RedisReplyBuilder : public RedisReplyBuilderBase {
   };
 
   void SendSimpleStrArr(const facade::ArgRange& strs);
-  void SendBulkStrArr(const facade::ArgRange& strs, CollectionType ct = ARRAY);
+  void SendBulkStrArr(const facade::ArgRange& strs, CollectionType ct = CollectionType::ARRAY);
   template <typename I> void SendLongArr(absl::Span<const I> longs);
 
   void SendScoredArray(ScoredArray arr, bool with_scores);

--- a/src/facade/reply_builder_test.cc
+++ b/src/facade/reply_builder_test.cc
@@ -726,13 +726,13 @@ TEST_F(RedisReplyBuilderTest, SendStringArrayAsMap) {
   const std::vector<std::string> map_array{"k1", "v1", "k2", "v2"};
 
   builder_->SetRespVersion(RespVersion::kResp2);
-  builder_->SendBulkStrArr(map_array, builder_->MAP);
+  builder_->SendBulkStrArr(map_array, CollectionType::MAP);
   ASSERT_TRUE(NoErrors());
   ASSERT_EQ(TakePayload(), "*4\r\n$2\r\nk1\r\n$2\r\nv1\r\n$2\r\nk2\r\n$2\r\nv2\r\n")
       << "SendStringArrayAsMap Resp2 Failed.";
 
   builder_->SetRespVersion(RespVersion::kResp3);
-  builder_->SendBulkStrArr(map_array, builder_->MAP);
+  builder_->SendBulkStrArr(map_array, CollectionType::MAP);
   ASSERT_TRUE(NoErrors());
   ASSERT_EQ(TakePayload(), "%2\r\n$2\r\nk1\r\n$2\r\nv1\r\n$2\r\nk2\r\n$2\r\nv2\r\n")
       << "SendStringArrayAsMap Resp3 Failed.";
@@ -742,13 +742,13 @@ TEST_F(RedisReplyBuilderTest, SendStringArrayAsSet) {
   const std::vector<std::string> set_array{"e1", "e2", "e3"};
 
   builder_->SetRespVersion(RespVersion::kResp2);
-  builder_->SendBulkStrArr(set_array, builder_->SET);
+  builder_->SendBulkStrArr(set_array, CollectionType::SET);
   ASSERT_TRUE(NoErrors());
   ASSERT_EQ(TakePayload(), "*3\r\n$2\r\ne1\r\n$2\r\ne2\r\n$2\r\ne3\r\n")
       << "SendStringArrayAsSet Resp2 Failed.";
 
   builder_->SetRespVersion(RespVersion::kResp3);
-  builder_->SendBulkStrArr(set_array, builder_->SET);
+  builder_->SendBulkStrArr(set_array, CollectionType::SET);
   ASSERT_TRUE(NoErrors());
   ASSERT_EQ(TakePayload(), "~3\r\n$2\r\ne1\r\n$2\r\ne2\r\n$2\r\ne3\r\n")
       << "SendStringArrayAsSet Resp3 Failed.";
@@ -847,8 +847,8 @@ TEST_F(RedisReplyBuilderTest, BasicCapture) {
       [](RRB* r) { r->SendError("e1", "e2"); },
       [kTestSws](RRB* r) { r->SendSimpleStrArr(kTestSws); },
       [kTestSws](RRB* r) { r->SendBulkStrArr(kTestSws); },
-      [kTestSws](RRB* r) { r->SendBulkStrArr(kTestSws, RRB::SET); },
-      [kTestSws](RRB* r) { r->SendBulkStrArr(kTestSws, RRB::MAP); },
+      [kTestSws](RRB* r) { r->SendBulkStrArr(kTestSws, CollectionType::SET); },
+      [kTestSws](RRB* r) { r->SendBulkStrArr(kTestSws, CollectionType::MAP); },
       [kTestSws](RRB* r) {
         r->StartArray(3);
         r->SendLong(1L);

--- a/src/facade/reply_capture.cc
+++ b/src/facade/reply_capture.cc
@@ -16,11 +16,12 @@
 namespace facade {
 
 using namespace std;
+using namespace payload;
 
 void CapturingReplyBuilder::SendError(std::string_view str, std::string_view type) {
   last_error_ = str;
   SKIP_LESS(ReplyMode::ONLY_ERR);
-  Capture(Error{str, type});
+  Capture(make_unique<pair<string, string>>(str, type));
 }
 
 void CapturingReplyBuilder::SendNullArray() {
@@ -55,7 +56,8 @@ void CapturingReplyBuilder::SendBulkString(std::string_view str) {
 
 void CapturingReplyBuilder::StartCollection(unsigned len, CollectionType type) {
   SKIP_LESS(ReplyMode::FULL);
-  stack_.emplace(make_unique<CollectionPayload>(len, type), type == MAP ? len * 2 : len);
+  stack_.emplace(make_unique<CollectionPayload>(len, type),
+                 type == CollectionType::MAP ? len * 2 : len);
 
   // If we added an empty collection, it must be collapsed immediately.
   CollapseFilledCollections();
@@ -102,11 +104,6 @@ void CapturingReplyBuilder::CollapseFilledCollections() {
   }
 }
 
-CapturingReplyBuilder::CollectionPayload::CollectionPayload(unsigned len, CollectionType type)
-    : len{len}, type{type}, arr{} {
-  arr.reserve(type == MAP ? len * 2 : len);
-}
-
 struct CaptureVisitor {
   void operator()(monostate) {
   }
@@ -119,32 +116,32 @@ struct CaptureVisitor {
     rb->SendDouble(v);
   }
 
-  void operator()(const CapturingReplyBuilder::SimpleString& ss) {
+  void operator()(const payload::SimpleString& ss) {
     rb->SendSimpleString(ss);
   }
 
-  void operator()(const CapturingReplyBuilder::BulkString& bs) {
+  void operator()(const payload::BulkString& bs) {
     rb->SendBulkString(bs);
   }
 
-  void operator()(CapturingReplyBuilder::Null) {
+  void operator()(payload::Null) {
     rb->SendNull();
   }
 
-  void operator()(CapturingReplyBuilder::Error err) {
-    rb->SendError(err.first, err.second);
+  void operator()(const payload::Error& err) {
+    rb->SendError(err->first, err->second);
   }
 
   void operator()(OpStatus status) {
     rb->SendError(status);
   }
 
-  void operator()(const unique_ptr<CapturingReplyBuilder::CollectionPayload>& cp) {
+  void operator()(const unique_ptr<payload::CollectionPayload>& cp) {
     if (!cp) {
       rb->SendNullArray();
       return;
     }
-    if (cp->len == 0 && cp->type == RedisReplyBuilder::ARRAY) {
+    if (cp->len == 0 && cp->type == CollectionType::ARRAY) {
       rb->SendEmptyArray();
       return;
     }
@@ -176,7 +173,7 @@ void CapturingReplyBuilder::SetReplyMode(ReplyMode mode) {
 optional<CapturingReplyBuilder::ErrorRef> CapturingReplyBuilder::TryExtractError(
     const Payload& pl) {
   if (auto* err = get_if<Error>(&pl); err != nullptr) {
-    return ErrorRef{err->first, err->second};
+    return ErrorRef{(*err)->first, (*err)->second};
   }
   return nullopt;
 }

--- a/src/facade/reply_payload.h
+++ b/src/facade/reply_payload.h
@@ -1,0 +1,36 @@
+// Copyright 2025, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <variant>
+
+#include "facade/facade_types.h"
+
+namespace facade::payload {
+
+// SendError (msg, type)
+using Error = std::unique_ptr<std::pair<std::string, std::string>>;
+using Null = std::nullptr_t;  // SendNull or SendNullArray
+
+struct CollectionPayload;
+struct SimpleString : public std::string {};  // SendSimpleString
+struct BulkString : public std::string {};    // SendBulkString
+
+using Payload = std::variant<std::monostate, Null, Error, long, double, SimpleString, BulkString,
+                             std::unique_ptr<CollectionPayload>>;
+
+struct CollectionPayload {
+  CollectionPayload(unsigned _len, CollectionType _type) : len{_len}, type{_type} {
+    arr.reserve(type == CollectionType::MAP ? len * 2 : len);
+  }
+
+  unsigned len;
+  CollectionType type;
+  std::vector<Payload> arr;
+};
+
+}  // namespace facade::payload

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -25,7 +25,7 @@ using cmn::HeapSize;
 
 static void SendSubscriptionChangedResponse(string_view action, std::optional<string_view> topic,
                                             unsigned count, RedisReplyBuilder* rb) {
-  rb->StartCollection(3, RedisReplyBuilder::CollectionType::PUSH);
+  rb->StartCollection(3, CollectionType::PUSH);
   rb->SendBulkString(action);
   if (topic.has_value())
     rb->SendBulkString(topic.value());

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -524,7 +524,7 @@ void IOStat::From(const facade::FacadeStats& fs) {
 }
 
 void IOStat::Print(RedisReplyBuilder* rb) const {
-  rb->StartCollection(6, RedisReplyBuilder::CollectionType::MAP);
+  rb->StartCollection(6, CollectionType::MAP);
   rb->SendSimpleString("connections_received");
   rb->SendLong(conn_received);
   rb->SendSimpleString("current_conn_count");
@@ -1519,7 +1519,7 @@ void DebugCmd::Compression(CmdArgList args, CommandContext* cmnd_cntx) {
 
   unsigned map_len = print_bintable ? 6 : 5;
 
-  rb->StartCollection(map_len, RedisReplyBuilder::CollectionType::MAP);
+  rb->StartCollection(map_len, CollectionType::MAP);
   rb->SendSimpleString("max_symbol");
   rb->SendLong(hist.max_symbol);
 

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -96,7 +96,7 @@ template <typename It> int64_t GetExpireTime(const DbSlice& db_slice, const It& 
 
 class InMemSource : public ::io::Source {
  public:
-  InMemSource(std::string_view buf) : buf_(buf) {
+  explicit InMemSource(std::string_view buf) : buf_(buf) {
   }
 
   ::io::Result<size_t> ReadSome(const iovec* v, uint32_t len) final;
@@ -1589,7 +1589,7 @@ void SortGeneric(CmdArgList args, CommandContext* cmd_cntx, bool is_read_only) {
     if (!bool(store_key)) {
       bool is_set = (result_type == OBJ_SET || result_type == OBJ_ZSET);
       rb->StartCollection(std::distance(start_it, end_it),
-                          is_set ? RedisReplyBuilder::SET : RedisReplyBuilder::ARRAY);
+                          is_set ? CollectionType::SET : CollectionType::ARRAY);
 
       for (auto it = start_it; it != end_it; ++it) {
         rb->SendBulkString(it->key);

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -521,8 +521,7 @@ void HGetGeneric(CmdArgList args, uint8_t getall_mask, Transaction* tx, SinkRepl
     case OpStatus::OK:
     case OpStatus::KEY_NOTFOUND: {
       bool is_map = (getall_mask == (VALUES | FIELDS));
-      return rb->SendBulkStrArr(*result,
-                                is_map ? RedisReplyBuilder::MAP : RedisReplyBuilder::ARRAY);
+      return rb->SendBulkStrArr(*result, is_map ? CollectionType::MAP : CollectionType::ARRAY);
     }
     default:
       return rb->SendError(result.status());
@@ -1007,7 +1006,7 @@ void CmdHRandField(CmdArgList args, CommandContext* cmd_cntx) {
         rb->SendBulkString((*result)[i + 1]);
       }
     } else
-      rb->SendBulkStrArr(*result, RedisReplyBuilder::ARRAY);
+      rb->SendBulkStrArr(*result, CollectionType::ARRAY);
   } else if (result.status() == OpStatus::KEY_NOTFOUND) {
     if (args.size() == 1)
       rb->SendNull();

--- a/src/server/http_api.cc
+++ b/src/server/http_api.cc
@@ -15,8 +15,7 @@ namespace dfly {
 using namespace util;
 using namespace std;
 namespace h2 = boost::beast::http;
-using facade::CapturingReplyBuilder;
-
+namespace payload = facade::payload;
 namespace {
 
 bool IsVectorOfStrings(flexbuffers::Reference req) {
@@ -111,32 +110,32 @@ struct CaptureVisitor {
     absl::StrAppend(&str, v);
   }
 
-  void operator()(const CapturingReplyBuilder::SimpleString& ss) {
+  void operator()(const payload::SimpleString& ss) {
     absl::StrAppend(&str, "\"", ss, "\"");
   }
 
-  void operator()(const CapturingReplyBuilder::BulkString& bs) {
+  void operator()(const payload::BulkString& bs) {
     absl::StrAppend(&str, JsonEscape(bs));
   }
 
-  void operator()(CapturingReplyBuilder::Null) {
+  void operator()(payload::Null) {
     absl::StrAppend(&str, "null");
   }
 
-  void operator()(CapturingReplyBuilder::Error err) {
-    str = absl::StrCat(R"({"error": ")", err.first, "\"");
+  void operator()(const payload::Error& err) {
+    str = absl::StrCat(R"({"error": ")", err->first, "\"");
   }
 
   void operator()(facade::OpStatus status) {
     absl::StrAppend(&str, "\"", facade::StatusToMsg(status), "\"");
   }
 
-  void operator()(unique_ptr<CapturingReplyBuilder::CollectionPayload> cp) {
+  void operator()(unique_ptr<payload::CollectionPayload> cp) {
     if (!cp) {
       absl::StrAppend(&str, "null");
       return;
     }
-    if (cp->len == 0 && cp->type == facade::RedisReplyBuilder::ARRAY) {
+    if (cp->len == 0 && cp->type == facade::CollectionType::ARRAY) {
       absl::StrAppend(&str, "[]");
       return;
     }

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -411,7 +411,7 @@ class EvalSerializer : public ObjectExplorer {
   }
 
   void OnMapStart(unsigned len) final {
-    rb_->StartCollection(len, RedisReplyBuilder::MAP);
+    rb_->StartCollection(len, CollectionType::MAP);
   }
 
   void OnMapEnd() final {
@@ -500,7 +500,7 @@ void InterpreterReplier::SendBulkString(string_view str) {
 }
 
 void InterpreterReplier::StartCollection(unsigned len, CollectionType type) {
-  if (type == MAP)
+  if (type == CollectionType::MAP)
     len *= 2;
   explr_->OnArrayStart(len);
 

--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -286,7 +286,7 @@ void MemoryCmd::Stats() {
                        &stats);
 
   auto* rb = static_cast<RedisReplyBuilder*>(builder_);
-  rb->StartCollection(stats.size(), RedisReplyBuilder::MAP);
+  rb->StartCollection(stats.size(), CollectionType::MAP);
   for (const auto& [k, v] : stats) {
     rb->SendBulkString(k);
     rb->SendLong(v);

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -45,32 +45,29 @@ void CheckConnStateClean(const ConnectionState& state) {
 
 size_t Size(const CapturingReplyBuilder::Payload& payload) {
   size_t payload_size = sizeof(CapturingReplyBuilder::Payload);
-  return visit(
-      Overloaded{
-          [&](monostate) { return payload_size; },
-          [&](long) { return payload_size; },
-          [&](double) { return payload_size; },
-          [&](OpStatus) { return payload_size; },
-          [&](CapturingReplyBuilder::Null) { return payload_size; },
-          // ignore SSO because it's insignificant
-          [&](const CapturingReplyBuilder::SimpleString& data) {
-            return payload_size + data.size();
-          },
-          [&](const CapturingReplyBuilder::BulkString& data) { return payload_size + data.size(); },
-          [&](const CapturingReplyBuilder::Error& data) {
-            return payload_size + data.first.size() + data.second.size();
-          },
-          [&](const unique_ptr<CapturingReplyBuilder::CollectionPayload>& data) {
-            if (!data || (data->len == 0 && data->type == RedisReplyBuilder::ARRAY)) {
-              return payload_size;
-            }
-            for (const auto& pl : data->arr) {
-              payload_size += Size(pl);
-            }
-            return payload_size;
-          },
-      },
-      payload);
+  return visit(Overloaded{
+                   [&](monostate) { return payload_size; },
+                   [&](long) { return payload_size; },
+                   [&](double) { return payload_size; },
+                   [&](OpStatus) { return payload_size; },
+                   [&](payload::Null) { return payload_size; },
+                   // ignore SSO because it's insignificant
+                   [&](const payload::SimpleString& data) { return payload_size + data.size(); },
+                   [&](const payload::BulkString& data) { return payload_size + data.size(); },
+                   [&](const payload::Error& data) {
+                     return payload_size + data->first.size() + data->second.size();
+                   },
+                   [&](const unique_ptr<payload::CollectionPayload>& data) {
+                     if (!data || (data->len == 0 && data->type == CollectionType::ARRAY)) {
+                       return payload_size;
+                     }
+                     for (const auto& pl : data->arr) {
+                       payload_size += Size(pl);
+                     }
+                     return payload_size;
+                   },
+               },
+               payload);
 }
 
 }  // namespace

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -960,7 +960,7 @@ void SendSerializedDoc(const SerializedSearchDoc& doc, SinkReplyBuilder* builder
   auto* rb = static_cast<RedisReplyBuilder*>(builder);
   auto sortable_value_sender = SortableValueSender(rb);
 
-  rb->StartCollection(doc.values.size(), RedisReplyBuilder::MAP);
+  rb->StartCollection(doc.values.size(), CollectionType::MAP);
   for (const auto& [k, v] : doc.values) {
     rb->SendBulkString(k);
     visit(sortable_value_sender, v);
@@ -1433,14 +1433,14 @@ void SearchFamily::FtInfo(CmdArgList args, CommandContext* cmd_cntx) {
   const auto& info = infos.front();
   const auto& schema = info.base_index.schema;
 
-  rb->StartCollection(5, RedisReplyBuilder::MAP);
+  rb->StartCollection(5, CollectionType::MAP);
 
   rb->SendSimpleString("index_name");
   rb->SendSimpleString(idx_name);
 
   rb->SendSimpleString("index_definition");
   {
-    rb->StartCollection(3, RedisReplyBuilder::MAP);
+    rb->StartCollection(3, CollectionType::MAP);
     rb->SendSimpleString("key_type");
     rb->SendSimpleString(info.base_index.type == DocIndex::JSON ? "JSON" : "HASH");
     rb->SendSimpleString("prefixes");
@@ -1727,7 +1727,7 @@ void SearchFamily::FtProfile(CmdArgList args, CommandContext* cmd_cntx) {
   rb->StartArray(shards_count + 1);
 
   // General stats
-  rb->StartCollection(3, RedisReplyBuilder::MAP);
+  rb->StartCollection(3, CollectionType::MAP);
   rb->SendBulkString("took");
   rb->SendLong(absl::ToInt64Microseconds(took));
   rb->SendBulkString("hits");
@@ -1737,7 +1737,7 @@ void SearchFamily::FtProfile(CmdArgList args, CommandContext* cmd_cntx) {
 
   // Per-shard stats
   for (size_t shard_id = 0; shard_id < shards_count; shard_id++) {
-    rb->StartCollection(2, RedisReplyBuilder::MAP);
+    rb->StartCollection(2, CollectionType::MAP);
     rb->SendBulkString("took");
     rb->SendLong(absl::ToInt64Microseconds(profile_results[shard_id]));
     rb->SendBulkString("tree");
@@ -1763,7 +1763,7 @@ void SearchFamily::FtProfile(CmdArgList args, CommandContext* cmd_cntx) {
         }
       }
 
-      rb->StartCollection(4 + (children > 0), RedisReplyBuilder::MAP);
+      rb->StartCollection(4 + (children > 0), CollectionType::MAP);
       rb->SendSimpleString("total_time");
       rb->SendLong(event.micros);
       rb->SendSimpleString("operation");
@@ -1814,7 +1814,7 @@ void SearchFamily::FtTagVals(CmdArgList args, CommandContext* cmd_cntx) {
   shard_results.clear();
   vector<string> vec(result_set.begin(), result_set.end());
 
-  rb->SendBulkStrArr(vec, RedisReplyBuilder::SET);
+  rb->SendBulkStrArr(vec, CollectionType::SET);
 }
 
 void SearchFamily::FtAggregate(CmdArgList args, CommandContext* cmd_cntx) {
@@ -2094,7 +2094,7 @@ void FtConfigGet(CmdArgParser* parser, RedisReplyBuilder* rb) {
       res.push_back(flag->CurrentValue());
     }
   }
-  return rb->SendBulkStrArr(res, RedisReplyBuilder::MAP);
+  return rb->SendBulkStrArr(res, CollectionType::MAP);
 }
 
 void FtConfigSet(CmdArgParser* parser, RedisReplyBuilder* rb) {

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2585,7 +2585,7 @@ void ServerFamily::Config(CmdArgList args, CommandContext* cmnd_cntx) {
       }
     }
     auto* rb = static_cast<RedisReplyBuilder*>(builder);
-    return rb->SendBulkStrArr(res, RedisReplyBuilder::MAP);
+    return rb->SendBulkStrArr(res, CollectionType::MAP);
   }
 
   if (sub_cmd == "REWRITE") {
@@ -3542,7 +3542,7 @@ void ServerFamily::Hello(CmdArgList args, CommandContext* cmnd_cntx) {
   const int fields_count = az.empty() ? 7 : 8;
 
   SinkReplyBuilder::ReplyAggregator agg(rb);
-  rb->StartCollection(fields_count, RedisReplyBuilder::MAP);
+  rb->StartCollection(fields_count, CollectionType::MAP);
   rb->SendBulkString("server");
   rb->SendBulkString("redis");
   rb->SendBulkString("version");
@@ -4162,14 +4162,14 @@ void ServerFamily::Module(CmdArgList args, CommandContext* cmnd_cntx) {
   rb->StartArray(2);
 
   // Json
-  rb->StartCollection(2, RedisReplyBuilder::MAP);
+  rb->StartCollection(2, CollectionType::MAP);
   rb->SendSimpleString("name");
   rb->SendSimpleString("ReJSON");
   rb->SendSimpleString("ver");
   rb->SendLong(20'808);
 
   // Search
-  rb->StartCollection(2, RedisReplyBuilder::MAP);
+  rb->StartCollection(2, CollectionType::MAP);
   rb->SendSimpleString("name");
   rb->SendSimpleString("search");
   rb->SendSimpleString("ver");

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -1015,7 +1015,7 @@ struct SetReplies {
     if (script)  // output is sorted under scripts
       sort(sv->begin(), sv->end());
 
-    rb->SendBulkStrArr(*sv, RedisReplyBuilder::SET);
+    rb->SendBulkStrArr(*sv, CollectionType::SET);
   }
 
   void Send(const ResultSetView& rsv) {
@@ -1163,7 +1163,7 @@ void SPop(CmdArgList args, CommandContext* cmd_cntx) {
         rb->SendBulkString(result.value().front());
       }
     } else {  // SPOP key cnt
-      rb->SendBulkStrArr(*result, RedisReplyBuilder::SET);
+      rb->SendBulkStrArr(*result, CollectionType::SET);
     }
     return;
   }
@@ -1281,7 +1281,7 @@ void SRandMember(CmdArgList args, CommandContext* cmd_cntx) {
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (result || result == OpStatus::KEY_NOTFOUND) {
     if (is_count) {
-      rb->SendBulkStrArr(*result, RedisReplyBuilder::SET);
+      rb->SendBulkStrArr(*result, CollectionType::SET);
     } else if (result->size()) {
       rb->SendBulkString(result->front());
     } else {

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -2470,7 +2470,7 @@ void XReadBlock(ReadOpts* opts, Transaction* tx, SinkReplyBuilder* builder,
   if (result) {
     SinkReplyBuilder::ReplyAggregator agg(rb);
     if (opts->read_group && rb->IsResp3()) {
-      rb->StartCollection(1, RedisReplyBuilder::CollectionType::MAP);
+      rb->StartCollection(1, CollectionType::MAP);
     } else {
       rb->StartArray(1);
       rb->StartArray(2);
@@ -2565,7 +2565,7 @@ void XReadGeneric2(CmdArgList args, bool read_group, CommandContext* cmd_cntx) {
   SinkReplyBuilder::ReplyScope scope(rb);
   if (opts->read_group) {
     if (rb->IsResp3()) {
-      rb->StartCollection(opts->stream_ids.size(), RedisReplyBuilder::CollectionType::MAP);
+      rb->StartCollection(opts->stream_ids.size(), CollectionType::MAP);
       for (size_t i = 0; i < opts->stream_ids.size(); i++) {
         string_view key = ArgS(args, i + opts->streams_arg);
         StreamReplies{rb}.SendStreamRecords(key, results[i]);
@@ -2580,7 +2580,7 @@ void XReadGeneric2(CmdArgList args, bool read_group, CommandContext* cmd_cntx) {
     }
   } else {
     if (rb->IsResp3()) {
-      rb->StartCollection(resolved_streams, RedisReplyBuilder::CollectionType::MAP);
+      rb->StartCollection(resolved_streams, CollectionType::MAP);
       for (size_t i = 0; i < results.size(); ++i) {
         if (results[i].empty()) {
           continue;
@@ -2900,7 +2900,7 @@ void CmdXInfo(CmdArgList args, CommandContext* cmd_cntx) {
         for (const auto& ginfo : *result) {
           string last_id = StreamIdRepr(ginfo.last_id);
 
-          rb->StartCollection(6, RedisReplyBuilder::MAP);
+          rb->StartCollection(6, CollectionType::MAP);
           rb->SendBulkString("name");
           rb->SendBulkString(ginfo.name);
           rb->SendBulkString("consumers");
@@ -2964,9 +2964,9 @@ void CmdXInfo(CmdArgList args, CommandContext* cmd_cntx) {
       OpResult<StreamInfo> sinfo = shard_set->Await(sid, std::move(cb));
       if (sinfo) {
         if (full) {
-          rb->StartCollection(9, RedisReplyBuilder::MAP);
+          rb->StartCollection(9, CollectionType::MAP);
         } else {
-          rb->StartCollection(10, RedisReplyBuilder::MAP);
+          rb->StartCollection(10, CollectionType::MAP);
         }
 
         rb->SendBulkString("length");
@@ -2997,7 +2997,7 @@ void CmdXInfo(CmdArgList args, CommandContext* cmd_cntx) {
           rb->SendBulkString("groups");
           rb->StartArray(sinfo->cgroups.size());
           for (const auto& ginfo : sinfo->cgroups) {
-            rb->StartCollection(7, RedisReplyBuilder::MAP);
+            rb->StartCollection(7, CollectionType::MAP);
 
             rb->SendBulkString("name");
             rb->SendBulkString(ginfo.name);
@@ -3034,7 +3034,7 @@ void CmdXInfo(CmdArgList args, CommandContext* cmd_cntx) {
             rb->SendBulkString("consumers");
             rb->StartArray(ginfo.consumer_info_vec.size());
             for (const auto& consumer_info : ginfo.consumer_info_vec) {
-              rb->StartCollection(5, RedisReplyBuilder::MAP);
+              rb->StartCollection(5, CollectionType::MAP);
 
               rb->SendBulkString("name");
               rb->SendBulkString(consumer_info.name);
@@ -3100,7 +3100,7 @@ void CmdXInfo(CmdArgList args, CommandContext* cmd_cntx) {
           int64_t active = consumer_info.active_time;
           int64_t inactive = active != -1 ? now_ms - active : -1;
 
-          rb->StartCollection(4, RedisReplyBuilder::MAP);
+          rb->StartCollection(4, CollectionType::MAP);
           rb->SendBulkString("name");
           rb->SendBulkString(consumer_info.name);
           rb->SendBulkString("pending");


### PR DESCRIPTION
Pull out CapturingReplyBuilder::Payload into a separate namespace. This is needed so we could reuse the payload in ParsedCommand. Also, change the Error type to be unique_ptr of pair to reduce the overall size of Payload variant.

No functional changes besides that.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->