### PR TITLE
chore: further replace SendError calls with CommandContext

### DIFF
--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -224,11 +224,15 @@ void ParsedCommand::SendError(std::string_view str, std::string_view type) const
 }
 
 void ParsedCommand::SendError(facade::OpStatus status) const {
-  rb_->SendError(status);
+  if (status == OpStatus::OK)
+    return rb_->SendSimpleString("OK");
+  rb_->SendError(StatusToMsg(status));
 }
 
-void ParsedCommand::SendError(facade::ErrorReply error) const {
-  rb_->SendError(std::move(error));
+void ParsedCommand::SendError(const facade::ErrorReply& error) const {
+  if (error.status)
+    return SendError(*error.status);
+  SendError(error.ToSv(), error.kind);
 }
 
 }  // namespace facade

--- a/src/facade/parsed_command.h
+++ b/src/facade/parsed_command.h
@@ -58,7 +58,7 @@ class ParsedCommand : public cmn::BackedArguments {
 
   void SendError(std::string_view str, std::string_view type = std::string_view{}) const;
   void SendError(facade::OpStatus status) const;
-  void SendError(facade::ErrorReply error) const;
+  void SendError(const facade::ErrorReply& error) const;
 };
 
 static_assert(sizeof(ParsedCommand) == 200);

--- a/src/facade/reply_capture.cc
+++ b/src/facade/reply_capture.cc
@@ -132,10 +132,6 @@ struct CaptureVisitor {
     rb->SendError(err->first, err->second);
   }
 
-  void operator()(OpStatus status) {
-    rb->SendError(status);
-  }
-
   void operator()(const unique_ptr<payload::CollectionPayload>& cp) {
     if (!cp) {
       rb->SendNullArray();

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -372,6 +372,10 @@ class CommandContext : public facade::ParsedCommand {
   facade::Connection* conn() const {
     return conn_cntx_->conn();
   }
+
+  facade::SinkReplyBuilder* SwapReplier(facade::SinkReplyBuilder* new_rb) {
+    return std::exchange(rb_, new_rb);
+  }
 };
 
 }  // namespace dfly

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -168,15 +168,15 @@ class Service : public facade::ServiceInterface {
                                                        const ConnectionContext& dfly_cntx);
 
   void EvalInternal(CmdArgList args, const EvalArgs& eval_args, Interpreter* interpreter,
-                    SinkReplyBuilder* builder, ConnectionContext* cntx, bool read_only);
-  void CallSHA(CmdArgList args, std::string_view sha, Interpreter* interpreter,
-               SinkReplyBuilder* builder, ConnectionContext* cntx, bool read_only);
+                    bool read_only, CommandContext* cmd_cntx);
+  void CallSHA(CmdArgList args, std::string_view sha, Interpreter* interpreter, bool read_only,
+               CommandContext* cmd_cntx);
 
   // Return optional payload - first received error that occured when executing commands.
   std::optional<facade::CapturingReplyBuilder::Payload> FlushEvalAsyncCmds(ConnectionContext* cntx,
                                                                            bool force = false);
 
-  void CallFromScript(ConnectionContext* cntx, Interpreter::CallArgs& args);
+  void CallFromScript(Interpreter::CallArgs& args, CommandContext* cmd_cntx);
 
   OpResult<KeyIndex> FindKeys(const CommandId* cid, CmdArgList args);
 

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -1006,27 +1006,25 @@ void SendNumeric(OpResult<uint32_t> result, SinkReplyBuilder* builder) {
 }
 
 struct SetReplies {
-  SetReplies(SinkReplyBuilder* builder, bool _script)
-      : rb(static_cast<RedisReplyBuilder*>(builder)), script(_script) {
-    DCHECK(dynamic_cast<RedisReplyBuilder*>(builder));
+  SetReplies(CommandContext* cntx, bool _script) : cmd_cntx(cntx), script(_script) {
   }
 
   template <typename T> void Send(vector<T>* sv) {
     if (script)  // output is sorted under scripts
       sort(sv->begin(), sv->end());
 
-    rb->SendBulkStrArr(*sv, CollectionType::SET);
+    static_cast<RedisReplyBuilder*>(cmd_cntx->rb())->SendBulkStrArr(*sv, CollectionType::SET);
   }
 
   void Send(const ResultSetView& rsv) {
     if (!rsv)
-      return rb->SendError(rsv.status());
+      return cmd_cntx->SendError(rsv.status());
 
     SvArray arr = ToSvArray(rsv.value());
     Send(&arr);
   }
 
-  RedisReplyBuilder* rb;
+  CommandContext* cmd_cntx;
   bool script;
 };
 
@@ -1044,7 +1042,7 @@ void SAdd(CmdArgList args, CommandContext* cmd_cntx) {
     return rb->SendLong(result.value());
   }
 
-  rb->SendError(result.status());
+  cmd_cntx->SendError(result.status());
 }
 
 void SIsMember(CmdArgList args, CommandContext* cmd_cntx) {
@@ -1103,7 +1101,7 @@ void SMove(CmdArgList args, CommandContext* cmd_cntx) {
   OpResult<unsigned> result = mover.Commit(cmd_cntx->tx);
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (!result) {
-    return rb->SendError(result.status());
+    return cmd_cntx->SendError(result.status());
   }
 
   rb->SendLong(result.value());
@@ -1190,7 +1188,7 @@ void SDiff(CmdArgList args, CommandContext* cmd_cntx) {
 
   cmd_cntx->tx->ScheduleSingleHop(std::move(cb));
   ResultSetView rsv = DiffResultVec(result_set, src_shard);
-  SetReplies{cmd_cntx->rb(), bool(cmd_cntx->server_conn_cntx()->conn_state.script_info)}.Send(rsv);
+  SetReplies{cmd_cntx, bool(cmd_cntx->server_conn_cntx()->conn_state.script_info)}.Send(rsv);
 }
 
 void SDiffStore(CmdArgList args, CommandContext* cmd_cntx) {
@@ -1253,7 +1251,7 @@ void SMembers(CmdArgList args, CommandContext* cmd_cntx) {
   OpResult<StringVec> result = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
 
   if (result || result.status() == OpStatus::KEY_NOTFOUND) {
-    SetReplies{cmd_cntx->rb(), bool(cmd_cntx->server_conn_cntx()->conn_state.script_info)}.Send(
+    SetReplies{cmd_cntx, bool(cmd_cntx->server_conn_cntx()->conn_state.script_info)}.Send(
         &result.value());
   } else {
     cmd_cntx->SendError(result.status());
@@ -1304,8 +1302,7 @@ void SInter(CmdArgList args, CommandContext* cmd_cntx) {
   cmd_cntx->tx->ScheduleSingleHop(std::move(cb));
   OpResult<SvArray> result = InterResultVec(result_set, cmd_cntx->tx->GetUniqueShardCnt());
   if (result) {
-    SetReplies{cmd_cntx->rb(), bool(cmd_cntx->server_conn_cntx()->conn_state.script_info)}.Send(
-        &*result);
+    SetReplies{cmd_cntx, bool(cmd_cntx->server_conn_cntx()->conn_state.script_info)}.Send(&*result);
   } else {
     cmd_cntx->SendError(result.status());
   }
@@ -1389,8 +1386,7 @@ void SUnion(CmdArgList args, CommandContext* cmd_cntx) {
   cmd_cntx->tx->ScheduleSingleHop(std::move(cb));
 
   ResultSetView unionset = UnionResultVec(result_set);
-  SetReplies{cmd_cntx->rb(), bool(cmd_cntx->server_conn_cntx()->conn_state.script_info)}.Send(
-      unionset);
+  SetReplies{cmd_cntx, bool(cmd_cntx->server_conn_cntx()->conn_state.script_info)}.Send(unionset);
 }
 
 void SUnionStore(CmdArgList args, CommandContext* cmd_cntx) {


### PR DESCRIPTION
The goal is that all reply calls will go through CommandContext. Right now I am transitioning SendError calls.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->