### PR TITLE
chore: minor fixes around async execution

### DIFF
--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -398,6 +398,7 @@ class Connection : public util::Connection {
   void ExecuteMCBatch(bool has_more);
   void CreateParsedCommand();
   void EnqueueParsedCommand();
+  void ReleaseParsedCommand(ParsedCommand* cmd, bool is_pipelined);
 
   std::deque<MessageHandle> dispatch_q_;  // dispatch queue
   util::fb2::CondVarAny cnd_;             // dispatch queue waker
@@ -480,6 +481,8 @@ class Connection : public util::Connection {
       // if the flag is set.
       bool is_tls_ : 1;
       bool is_main_ : 1;
+      bool ioloop_v2_ : 1;  // whether this connection is running on ioloop v2
+
       // If post migration is allowed to call RegisterRecv
       bool migration_allowed_to_register_ : 1;
     };

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -219,20 +219,57 @@ std::string AbslUnparseFlag(const MemoryBytesFlag& flag) {
   return strings::HumanReadableNumBytes(flag.value);
 }
 
-void ParsedCommand::SendError(std::string_view str, std::string_view type) const {
-  rb_->SendError(str, type);
+void ParsedCommand::ResetForReuse() {
+  reply_direct_ = true;
+  reply_payload_ = std::monostate{};
+  dispatch_async_ = false;
+
+  offsets_.clear();
+  if (HeapMemory() > 1024) {
+    storage_.clear();  // also deallocates the heap.
+    offsets_.shrink_to_fit();
+  }
 }
 
-void ParsedCommand::SendError(facade::OpStatus status) const {
-  if (status == OpStatus::OK)
-    return rb_->SendSimpleString("OK");
-  rb_->SendError(StatusToMsg(status));
+void ParsedCommand::SendError(std::string_view str, std::string_view type) {
+  if (reply_direct_) {
+    rb_->SendError(str, type);
+  } else {
+    reply_payload_ = payload::make_error(str, type);
+  }
 }
 
-void ParsedCommand::SendError(const facade::ErrorReply& error) const {
+void ParsedCommand::SendError(facade::OpStatus status) {
+  if (status == OpStatus::OK) {
+    if (reply_direct_) {
+      rb_->SendSimpleString("OK");
+    } else {
+      reply_payload_ = payload::SimpleString{"OK"};
+    }
+  } else {
+    if (reply_direct_) {
+      rb_->SendError(StatusToMsg(status));
+    } else {
+      reply_payload_ = payload::make_error(StatusToMsg(status));
+    }
+  }
+}
+
+void ParsedCommand::SendError(const facade::ErrorReply& error) {
   if (error.status)
     return SendError(*error.status);
   SendError(error.ToSv(), error.kind);
+}
+
+void ParsedCommand::SendStored(bool ok) {
+  if (reply_direct_) {
+    if (ok)
+      rb_->SendStored();
+    else
+      rb_->SendSetSkipped();
+  } else {
+    reply_payload_ = payload::StoredReply{ok};
+  }
 }
 
 }  // namespace facade

--- a/src/facade/reply_capture.cc
+++ b/src/facade/reply_capture.cc
@@ -21,7 +21,7 @@ using namespace payload;
 void CapturingReplyBuilder::SendError(std::string_view str, std::string_view type) {
   last_error_ = str;
   SKIP_LESS(ReplyMode::ONLY_ERR);
-  Capture(make_unique<pair<string, string>>(str, type));
+  Capture(make_error(str, type));
 }
 
 void CapturingReplyBuilder::SendNullArray() {
@@ -130,6 +130,14 @@ struct CaptureVisitor {
 
   void operator()(const payload::Error& err) {
     rb->SendError(err->first, err->second);
+  }
+
+  void operator()(payload::StoredReply sr) {
+    if (sr.ok) {
+      rb->SendStored();
+    } else {
+      rb->SendSetSkipped();
+    }
   }
 
   void operator()(const unique_ptr<payload::CollectionPayload>& cp) {

--- a/src/facade/reply_payload.h
+++ b/src/facade/reply_payload.h
@@ -19,9 +19,12 @@ using Null = std::nullptr_t;  // SendNull or SendNullArray
 struct CollectionPayload;
 struct SimpleString : public std::string {};  // SendSimpleString
 struct BulkString : public std::string {};    // SendBulkString
+struct StoredReply {
+  bool ok;  // true for SendStored, false for SendSetSkipped
+};
 
 using Payload = std::variant<std::monostate, Null, Error, long, double, SimpleString, BulkString,
-                             std::unique_ptr<CollectionPayload>>;
+                             std::unique_ptr<CollectionPayload>, StoredReply>;
 
 struct CollectionPayload {
   CollectionPayload(unsigned _len, CollectionType _type) : len{_len}, type{_type} {
@@ -32,5 +35,9 @@ struct CollectionPayload {
   CollectionType type;
   std::vector<Payload> arr;
 };
+
+inline Error make_error(std::string_view msg, std::string_view type = "") {
+  return std::make_unique<std::pair<std::string, std::string>>(msg, type);
+}
 
 };  // namespace facade::payload

--- a/src/server/http_api.cc
+++ b/src/server/http_api.cc
@@ -122,6 +122,14 @@ struct CaptureVisitor {
     absl::StrAppend(&str, "null");
   }
 
+  void operator()(payload::StoredReply sr) {
+    if (sr.ok) {
+      operator()(payload::SimpleString{"OK"});
+    } else {
+      operator()(payload::Null{});
+    }
+  }
+
   void operator()(const payload::Error& err) {
     str = absl::StrCat(R"({"error": ")", err->first, "\"");
   }

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1573,22 +1573,22 @@ class ReplyGuard {
         (static_cast<MCReplyBuilder*>(cmd_cntx.rb())->NoReply() || cid_name_ == "QUIT");
     const bool should_dcheck = !is_one_of && !is_script && !is_no_reply_memcache;
     if (should_dcheck) {
-      builder_ = cmd_cntx.rb();
-      replies_recorded_ = builder_->RepliesRecorded();
+      cmd_cntx_ = &cmd_cntx;
+      replies_recorded_ = cmd_cntx.rb()->RepliesRecorded();
     }
   }
 
   ~ReplyGuard() {
-    if (builder_) {
-      DCHECK_GT(builder_->RepliesRecorded(), replies_recorded_)
-          << cid_name_ << " " << typeid(*builder_).name();
+    if (cmd_cntx_ && cmd_cntx_->reply_direct()) {
+      auto* rb = cmd_cntx_->rb();
+      DCHECK_GT(rb->RepliesRecorded(), replies_recorded_) << cid_name_ << " " << typeid(*rb).name();
     }
   }
 
  private:
+  const CommandContext* cmd_cntx_ = nullptr;
   size_t replies_recorded_ = 0;
   std::string_view cid_name_;
-  SinkReplyBuilder* builder_ = nullptr;
 };
 
 OpResult<void> OpTrackKeys(const OpArgs slice_args, const facade::Connection::WeakRef& conn_ref,

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -1059,7 +1059,7 @@ void CmdSet(CmdArgList args, CommandContext* cmnd_cntx) {
     return cmnd_cntx->SendError(kSyntaxErr);
   }
 
-  if (cmnd_cntx->dispatch_async) {
+  if (cmnd_cntx->dispatch_async()) {
     // TODO: run asynchronous flow and exit.
     // 1.
     //    a. Transaction should support non-blocking execution for single hop/single shard commands.


### PR DESCRIPTION
1. Introduced StoredReply to reply payload so that we could reply STORED/SKIPPED in MC protocol.
2. reorganized code in facade.
3. ReplyGuard does not crash now if async commands did not reply.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->