### PR TITLE
chore: implement async dispatching for memcache SET command

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1828,6 +1828,8 @@ void Service::DispatchMC(facade::ParsedCommand* parsed_cmd) {
       break;
     case MemcacheParser::SET:
       strcpy(cmd_name, "SET");
+      if (cntx->conn()->IsIoLoopV2())
+        parsed_cmd->AllowAsyncExecution();  // Enable for SET command.
       break;
     case MemcacheParser::ADD:
       strcpy(cmd_name, "SET");


### PR DESCRIPTION
Such execution work only for experimental_io_loop_v2 enabled as we
need to wake up socket reads when deferred replies are ready.

While it is possible to process a SET or pipeline of SET commands asynchronously,
the option of processing SET with other subsequent commands is broken,
until we implement deferred replies support for all MC commands.
Therefore, experimental_io_loop_v2 with memcache is not usable for production yet.

Single connection benchmark:
`./dfly_bench    -h $SERVER_IP -n 1500000 -p 11211 --nogreet --qps=0  -d 256 --key_maximum=200000000   --ratio=1:0  --pipeline=30 -c 1 --proactor_threads=1 -P memcache_text`

- `experimental_io_loop_v2=false` (i.e. no async dispatching):
`QPS:  28092, P99 lat: 1189.25us`

- `experimental_io_loop_v2=true` (i.e. async SET dispatching):
`QPS: 83352, P99 lat: 444.992us`

- against memcached:
`QPS: 136105, P99 lat: 239.993us`


Huge improvement though still far from optimum.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->