### PR TITLE
chore(core): remove unused num_used_buckets_ from DenseSet

### DIFF
--- a/src/core/dense_set.cc
+++ b/src/core/dense_set.cc
@@ -221,7 +221,6 @@ uint32_t DenseSet::ClearStep(uint32_t start, uint32_t count) {
 
   if (size_ == 0) {
     entries_.clear();
-    num_used_buckets_ = 0;
     num_links_ = 0;
     expiration_used_ = false;
   }
@@ -390,7 +389,6 @@ void DenseSet::ShrinkBucket(size_t bucket_idx) {
   // Take the entire bucket to avoid infinite loop when new_bid == bucket_idx
   DensePtr bucket = entries_[bucket_idx];
   entries_[bucket_idx].Reset();
-  --num_used_buckets_;
 
   // Process the taken bucket chain
   while (!bucket.IsEmpty()) {
@@ -414,7 +412,6 @@ void DenseSet::ShrinkBucket(size_t bucket_idx) {
 
     uint32_t new_bid = BucketId(obj, 0);
     DVLOG(2) << " Shrink: Moving from " << bucket_idx << " to " << new_bid;
-    num_used_buckets_ += entries_[new_bid].IsEmpty();
     PushFront(entries_.begin() + new_bid, obj, has_ttl);
   }
 }
@@ -583,7 +580,6 @@ void DenseSet::AddUnique(void* obj, bool has_ttl, uint64_t hashcode) {
       if (std::distance(entries_.begin(), list) != bucket_id) {
         list->SetDisplaced(std::distance(entries_.begin() + bucket_id, list));
       }
-      ++num_used_buckets_;
       ++size_;
       return;
     }
@@ -697,9 +693,7 @@ void DenseSet::Delete(DensePtr* prev, DensePtr* ptr) {
   if (ptr->IsObject()) {
     obj = ptr->Raw();
     ptr->Reset();
-    if (prev == nullptr) {
-      --num_used_buckets_;
-    } else {
+    if (prev) {
       DCHECK(prev->IsLink());
 
       DenseLinkKey* plink = prev->AsLink();
@@ -772,10 +766,6 @@ void* DenseSet::PopInternal() {
   auto bucket_iter = GetRandomChain();  // Find first non empty chain
   if (bucket_iter == entries_.end())
     return nullptr;
-
-  if (bucket_iter->IsObject()) {
-    --num_used_buckets_;
-  }
 
   // unlink the first node in the first non-empty chain
   obj_malloc_used_ -= ObjectAllocSize(bucket_iter->GetObject());

--- a/src/core/dense_set.h
+++ b/src/core/dense_set.h
@@ -237,10 +237,6 @@ class DenseSet {
     return entries_.size();
   }
 
-  size_t NumUsedBuckets() const {
-    return num_used_buckets_;
-  }
-
   size_t ObjMallocUsed() const {
     return obj_malloc_used_;
   }
@@ -412,9 +408,8 @@ class DenseSet {
   std::vector<DensePtr, DensePtrAllocator> entries_;
 
   mutable size_t obj_malloc_used_ = 0;
-  mutable uint32_t size_ = 0;              // number of elements in the set.
-  mutable uint32_t num_links_ = 0;         // number of links in the set.
-  mutable uint32_t num_used_buckets_ = 0;  // number of buckets used in entries_ array.
+  mutable uint32_t size_ = 0;       // number of elements in the set.
+  mutable uint32_t num_links_ = 0;  // number of links in the set.
   unsigned capacity_log_ = 0;
 
   uint32_t time_now_ = 0;


### PR DESCRIPTION
Remove `num_used_buckets_` field and `NumUsedBuckets()` method - they were being maintained but never read.