### PR TITLE
fix: reset obj_malloc_used_ in DenseSet::Clear

### DIFF
--- a/src/core/dense_set.cc
+++ b/src/core/dense_set.cc
@@ -222,6 +222,7 @@ uint32_t DenseSet::ClearStep(uint32_t start, uint32_t count) {
   if (size_ == 0) {
     entries_.clear();
     num_links_ = 0;
+    obj_malloc_used_ = 0;
     expiration_used_ = false;
   }
   return end;

--- a/src/core/string_set_test.cc
+++ b/src/core/string_set_test.cc
@@ -523,6 +523,24 @@ TEST_F(StringSetTest, Fill) {
   }
 }
 
+TEST_F(StringSetTest, ClearResetsObjMallocUsed) {
+  // Add some items
+  for (size_t i = 0; i < 100; ++i) {
+    ss_->Add(random_string(generator_, 10));
+  }
+
+  // Verify ObjMallocUsed() > 0 after adding items
+  EXPECT_GT(ss_->ObjMallocUsed(), 0u);
+  EXPECT_GT(ss_->UpperBoundSize(), 0u);
+
+  // Clear the set
+  ss_->Clear();
+
+  // Verify ObjMallocUsed() is reset to 0 after Clear
+  EXPECT_EQ(ss_->ObjMallocUsed(), 0u);
+  EXPECT_EQ(ss_->UpperBoundSize(), 0u);
+}
+
 TEST_F(StringSetTest, IterateEmpty) {
   for (const auto& s : *ss_) {
     // We're iterating to make sure there is no crash. However, if we got here, it's a bug


### PR DESCRIPTION
- Fix memory accounting bug where `obj_malloc_used_` was not reset to 0 in `DenseSet::Clear()`
- Add test `ClearResetsObjMallocUsed` to verify the fix
