### PR TITLE
chore(server): Remove some manual acl

### DIFF
--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -1380,27 +1380,16 @@ OpResult<int64_t> FindFirstBitWithValue(const OpArgs& op_args, string_view key, 
 
 }  // namespace
 
-namespace acl {
-constexpr uint32_t kBitPos = READ | BITMAP | SLOW;
-constexpr uint32_t kBitCount = READ | BITMAP | SLOW;
-constexpr uint32_t kBitField = WRITE | BITMAP | SLOW;
-constexpr uint32_t kBitFieldRo = READ | BITMAP | FAST;
-constexpr uint32_t kBitOp = WRITE | BITMAP | SLOW;
-constexpr uint32_t kGetBit = READ | BITMAP | FAST;
-constexpr uint32_t kSetBit = WRITE | BITMAP | SLOW;
-}  // namespace acl
-
 void BitOpsFamily::Register(CommandRegistry* registry) {
   using CI = CommandId;
-  registry->StartFamily();
-  *registry << CI{"BITPOS", CO::CommandOpt::READONLY, -3, 1, 1, acl::kBitPos}.SetHandler(&BitPos)
-            << CI{"BITCOUNT", CO::READONLY, -2, 1, 1, acl::kBitCount}.SetHandler(&BitCount)
-            << CI{"BITFIELD", CO::JOURNALED, -2, 1, 1, acl::kBitField}.SetHandler(&BitField)
-            << CI{"BITFIELD_RO", CO::READONLY, -2, 1, 1, acl::kBitFieldRo}.SetHandler(&BitFieldRo)
-            << CI{"BITOP", CO::JOURNALED | CO::NO_AUTOJOURNAL, -4, 2, -1, acl::kBitOp}.SetHandler(
-                   &BitOp)
-            << CI{"GETBIT", CO::READONLY | CO::FAST, 3, 1, 1, acl::kGetBit}.SetHandler(&GetBit)
-            << CI{"SETBIT", CO::JOURNALED | CO::DENYOOM, 4, 1, 1, acl::kSetBit}.SetHandler(&SetBit);
+  registry->StartFamily(acl::BITMAP);
+  *registry << CI{"BITPOS", CO::CommandOpt::READONLY, -3, 1, 1}.SetHandler(&BitPos)
+            << CI{"BITCOUNT", CO::READONLY, -2, 1, 1}.SetHandler(&BitCount)
+            << CI{"BITFIELD", CO::JOURNALED, -2, 1, 1}.SetHandler(&BitField)
+            << CI{"BITFIELD_RO", CO::FAST | CO::READONLY, -2, 1, 1}.SetHandler(&BitFieldRo)
+            << CI{"BITOP", CO::JOURNALED | CO::NO_AUTOJOURNAL, -4, 2, -1}.SetHandler(&BitOp)
+            << CI{"GETBIT", CO::READONLY | CO::FAST, 3, 1, 1}.SetHandler(&GetBit)
+            << CI{"SETBIT", CO::JOURNALED | CO::DENYOOM, 4, 1, 1}.SetHandler(&SetBit);
 }
 
 }  // namespace dfly

--- a/src/server/geo_family.cc
+++ b/src/server/geo_family.cc
@@ -897,34 +897,18 @@ void GeoFamily::GeoRadiusRO(CmdArgList args, CommandContext* cmd_cntx) {
 
 #define HFUNC(x) SetHandler(&GeoFamily::x)
 
-namespace acl {
-constexpr uint32_t kGeoAdd = WRITE | GEO | SLOW;
-constexpr uint32_t kGeoHash = READ | GEO | SLOW;
-constexpr uint32_t kGeoPos = READ | GEO | SLOW;
-constexpr uint32_t kGeoDist = READ | GEO | SLOW;
-constexpr uint32_t kGeoSearch = READ | GEO | SLOW;
-constexpr uint32_t kGeoRadiusByMember = WRITE | GEO | SLOW;
-constexpr uint32_t kGeoRadiusByMemberRO = READ | GEO | SLOW;
-constexpr uint32_t kGeoRadius = WRITE | GEO | SLOW;
-constexpr uint32_t kGeoRadiusRO = READ | GEO | SLOW;
-}  // namespace acl
-
 void GeoFamily::Register(CommandRegistry* registry) {
-  registry->StartFamily();
-  *registry << CI{"GEOADD", CO::FAST | CO::JOURNALED | CO::DENYOOM, -5, 1, 1, acl::kGeoAdd}.HFUNC(
-                   GeoAdd)
-            << CI{"GEOHASH", CO::FAST | CO::READONLY, -2, 1, 1, acl::kGeoHash}.HFUNC(GeoHash)
-            << CI{"GEOPOS", CO::FAST | CO::READONLY, -2, 1, 1, acl::kGeoPos}.HFUNC(GeoPos)
-            << CI{"GEODIST", CO::READONLY, -4, 1, 1, acl::kGeoDist}.HFUNC(GeoDist)
-            << CI{"GEOSEARCH", CO::READONLY, -7, 1, 1, acl::kGeoSearch}.HFUNC(GeoSearch)
-            << CI{"GEORADIUSBYMEMBER",    CO::JOURNALED | CO::STORE_LAST_KEY, -5, 1, 1,
-                  acl::kGeoRadiusByMember}
-                   .HFUNC(GeoRadiusByMember)
-            << CI{"GEORADIUSBYMEMBER_RO", CO::READONLY, -5, 1, 1, acl::kGeoRadiusByMemberRO}.HFUNC(
-                   GeoRadiusByMemberRO)
-            << CI{"GEORADIUS", CO::JOURNALED | CO::STORE_LAST_KEY, -6, 1, 1, acl::kGeoRadius}.HFUNC(
-                   GeoRadius)
-            << CI{"GEORADIUS_RO", CO::READONLY, -6, 1, 1, acl::kGeoRadiusRO}.HFUNC(GeoRadiusRO);
+  registry->StartFamily(acl::GEO);
+  *registry << CI{"GEOADD", CO::JOURNALED | CO::DENYOOM, -5, 1, 1}.HFUNC(GeoAdd)
+            << CI{"GEOHASH", CO::READONLY, -2, 1, 1}.HFUNC(GeoHash)
+            << CI{"GEOPOS", CO::READONLY, -2, 1, 1}.HFUNC(GeoPos)
+            << CI{"GEODIST", CO::READONLY, -4, 1, 1}.HFUNC(GeoDist)
+            << CI{"GEOSEARCH", CO::READONLY, -7, 1, 1}.HFUNC(GeoSearch)
+            << CI{"GEORADIUSBYMEMBER", CO::JOURNALED | CO::STORE_LAST_KEY, -5, 1, 1}.HFUNC(
+                   GeoRadiusByMember)
+            << CI{"GEORADIUSBYMEMBER_RO", CO::READONLY, -5, 1, 1}.HFUNC(GeoRadiusByMemberRO)
+            << CI{"GEORADIUS", CO::JOURNALED | CO::STORE_LAST_KEY, -6, 1, 1}.HFUNC(GeoRadius)
+            << CI{"GEORADIUS_RO", CO::READONLY, -6, 1, 1}.HFUNC(GeoRadiusRO);
 }
 
 }  // namespace dfly

--- a/src/server/hll_family.cc
+++ b/src/server/hll_family.cc
@@ -330,19 +330,12 @@ void PFMerge(CmdArgList args, CommandContext* cmd_cntx) {
 
 }  // namespace
 
-namespace acl {
-constexpr uint32_t kPFAdd = WRITE | HYPERLOGLOG | FAST;
-constexpr uint32_t kPFCount = READ | HYPERLOGLOG | SLOW;
-constexpr uint32_t kPFMerge = WRITE | HYPERLOGLOG | SLOW;
-}  // namespace acl
-
 void HllFamily::Register(CommandRegistry* registry) {
   using CI = CommandId;
-  registry->StartFamily();
-  *registry << CI{"PFADD", CO::JOURNALED, -3, 1, 1, acl::kPFAdd}.SetHandler(PFAdd)
-            << CI{"PFCOUNT", CO::READONLY, -2, 1, -1, acl::kPFCount}.SetHandler(PFCount)
-            << CI{"PFMERGE", CO::JOURNALED | CO::NO_AUTOJOURNAL, -2, 1, -1, acl::kPFMerge}
-                   .SetHandler(PFMerge);
+  registry->StartFamily(acl::HYPERLOGLOG);
+  *registry << CI{"PFADD", CO::FAST | CO::JOURNALED, -3, 1, 1}.SetHandler(PFAdd)
+            << CI{"PFCOUNT", CO::READONLY, -2, 1, -1}.SetHandler(PFCount)
+            << CI{"PFMERGE", CO::JOURNALED | CO::NO_AUTOJOURNAL, -2, 1, -1}.SetHandler(PFMerge);
 }
 
 const char HllFamily::kInvalidHllErr[] = "Key is not a valid HyperLogLog string value.";


### PR DESCRIPTION
Remove some of the manual acl, verified before and after catergories are the same

keeping for future checks:
```py
import redis
import collections

r = redis.Redis(decode_responses=True)

r.set_response_callback("COMMAND", lambda rsp: rsp)
cmds = r.execute_command("COMMAND")
cmds = {c[0]: c[6] for c in cmds}
cmds = sorted(cmds.items())

for c in cmds:
    print(c)
```