### PR TITLE
chore: an issue of destruction of in-flight parsed commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Other languages:  [简体中文](README.zh-CN.md) [日本語](README.ja-JP.md) [
 
 [Website](https://www.dragonflydb.io/) • [Docs](https://dragonflydb.io/docs) • [Quick Start](https://www.dragonflydb.io/docs/getting-started) • [Community Discord](https://discord.gg/HsPjXGVH85) • [Dragonfly Forum](https://dragonfly.discourse.group/) • [Join the Dragonfly Community](https://www.dragonflydb.io/community)
 
-[GitHub Discussions](https://github.com/dragonflydb/dragonfly/discussions) • [GitHub Issues](https://github.com/dragonflydb/dragonfly/issues) • [Contributing](https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md) • [Dragonfly Cloud](https://www.dragonflydb.io/cloud)
+[GitHub Discussions](https://github.com/dragonflydb/dragonfly/discussions) • [GitHub Issues](https://github.com/dragonflydb/dragonfly/issues) • [Contributing](https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md) • [AI Agents Guide](AGENTS.md) • [Dragonfly Cloud](https://www.dragonflydb.io/cloud)
 
 ## The world's most efficient in-memory data store
 

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -407,6 +407,7 @@ class Connection : public util::Connection {
   void CreateParsedCommand();
   void EnqueueParsedCommand();
   void ReleaseParsedCommand(ParsedCommand* cmd, bool is_pipelined);
+  void DestroyParsedQueue();
 
   std::deque<MessageHandle> dispatch_q_;  // dispatch queue
   util::fb2::CondVarAny cnd_;             // dispatch queue waker

--- a/src/facade/service_interface.h
+++ b/src/facade/service_interface.h
@@ -51,10 +51,6 @@ class ServiceInterface {
     return new ParsedCommand();
   }
 
-  virtual void FreeParsedCommand(ParsedCommand* cmd) {
-    delete cmd;
-  }
-
   virtual void ConfigureHttpHandlers(util::HttpListenerBase* base, bool is_privileged) {
   }
 

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -355,6 +355,10 @@ class CommandContext : public facade::ParsedCommand {
     Init(rb, cntx);
   }
 
+  virtual size_t GetSize() const override {
+    return sizeof(CommandContext);
+  }
+
   const CommandId* cid = nullptr;
   Transaction* tx = nullptr;
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1579,7 +1579,7 @@ class ReplyGuard {
   }
 
   ~ReplyGuard() {
-    if (cmd_cntx_ && cmd_cntx_->reply_direct()) {
+    if (cmd_cntx_ && !cmd_cntx_->IsDeferredReply()) {
       auto* rb = cmd_cntx_->rb();
       DCHECK_GT(rb->RepliesRecorded(), replies_recorded_) << cid_name_ << " " << typeid(*rb).name();
     }
@@ -1984,10 +1984,6 @@ facade::ConnectionContext* Service::CreateContext(facade::Connection* owner) {
 
 facade::ParsedCommand* Service::AllocateParsedCommand() {
   return new CommandContext{};
-}
-
-void Service::FreeParsedCommand(facade::ParsedCommand* cmd) {
-  delete static_cast<CommandContext*>(cmd);
 }
 
 const CommandId* Service::FindCmd(std::string_view cmd) const {

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -62,7 +62,6 @@ class Service : public facade::ServiceInterface {
 
   facade::ConnectionContext* CreateContext(facade::Connection* owner) final;
   facade::ParsedCommand* AllocateParsedCommand() final;
-  void FreeParsedCommand(facade::ParsedCommand* cmd) final;
 
   const CommandId* FindCmd(std::string_view) const;
 

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -1059,7 +1059,7 @@ void CmdSet(CmdArgList args, CommandContext* cmnd_cntx) {
     return cmnd_cntx->SendError(kSyntaxErr);
   }
 
-  if (cmnd_cntx->dispatch_async()) {
+  if (cmnd_cntx->AsyncExecutionAllowed()) {
     // TODO: run asynchronous flow and exit.
     // 1.
     //    a. Transaction should support non-blocking execution for single hop/single shard commands.


### PR DESCRIPTION
Also, make ParsedCommand polymorthic to be able to deallocate it easier.
In addition, expose GetSize method that returns the real object size for
ParsedCommand derivatives.

Finally, rename async_reply to is_deferred_reply_ and  reply_direct_ to allow_async_execution_, which imho has more clarity regarding their meanings.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->