### PR TITLE
chore: MemcacheParser now consumes all the input.

### DIFF
--- a/src/facade/memcache_parser.h
+++ b/src/facade/memcache_parser.h
@@ -123,11 +123,12 @@ class MemcacheParser {
   }
 
   size_t UsedMemory() const {
-    return 0;
+    return tmp_buf_.capacity();
   }
 
   void Reset() {
     val_len_to_read_ = 0;
+    tmp_buf_.clear();
   }
 
   Result Parse(std::string_view str, uint32_t* consumed, Command* res);
@@ -136,6 +137,7 @@ class MemcacheParser {
   Result ConsumeValue(std::string_view str, uint32_t* consumed, Command* dest);
   Result ParseInternal(ArgSlice tokens_view, Command* cmd);
   uint32_t val_len_to_read_ = 0;
+  std::string tmp_buf_;
 };
 
 }  // namespace facade

--- a/src/facade/memcache_parser_test.cc
+++ b/src/facade/memcache_parser_test.cc
@@ -112,10 +112,10 @@ TEST_F(MCParserTest, NoreplyBasic) {
 TEST_F(MCParserTest, Meta) {
   MemcacheParser::Result st = Parse("ms key1 ");
   EXPECT_EQ(MemcacheParser::INPUT_PENDING, st);
-  EXPECT_EQ(0, consumed_);
-  st = Parse("ms key1 6 T1 F2\r\naaaaaa\r\n");
+  EXPECT_EQ(8, consumed_);
+  st = parser_.Parse("6 T1 F2\r\naaaaaa\r\n", &consumed_, &cmd_);
   EXPECT_EQ(MemcacheParser::OK, st);
-  EXPECT_EQ(25, consumed_);
+  EXPECT_EQ(17, consumed_);
   EXPECT_EQ(MemcacheParser::SET, cmd_.type);
   EXPECT_EQ("key1", cmd_.key());
   EXPECT_EQ(2, cmd_.flags);


### PR DESCRIPTION
Before, the parser did not consume the input when it returned INPUT_PENDING. Now it caches the partial input internally and consumes everything.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->