### PR TITLE
chore(common): Include cstdint to fix build error on newer fedora versions

### DIFF
--- a/src/common/backed_args.h
+++ b/src/common/backed_args.h
@@ -6,6 +6,7 @@
 
 #include <absl/container/inlined_vector.h>
 
+#include <cstdint>
 #include <string_view>
 
 namespace cmn {


### PR DESCRIPTION
On fedora 42 (and possibly any newer versions after 38 looking at online bug reports) `uint32_t` has to be explicitly imported via cstdint. Not doing this causes build failures starting at `backed_args.h`.
