### PR TITLE
chore: get rid of command specific flags in MCReplyBuilder

### DIFF
--- a/src/facade/memcache_parser.h
+++ b/src/facade/memcache_parser.h
@@ -80,6 +80,10 @@ class MemcacheParser {
       return backed_args->data(1);
     }
 
+    bool replies_cas_token() const {
+      return type == GETS || type == GATS;
+    }
+
     union {
       uint64_t cas_unique = 0;  // for CAS COMMAND
       uint64_t delta;           // for DECR/INCR commands.

--- a/src/facade/parsed_command.h
+++ b/src/facade/parsed_command.h
@@ -24,6 +24,8 @@ class MCRender {
   std::string RenderMiss() const;
   std::string RenderDeleted() const;
   std::string RenderGetEnd() const;
+  std::string RenderStored() const;
+  std::string RenderNotStored() const;
 
  private:
   MemcacheCmdFlags flags_;
@@ -160,6 +162,8 @@ class ParsedCommand : public cmn::BackedArguments {
  private:
   bool CheckDoneAndMarkHead();
   void NotifyReplied();
+
+  void SendDirect(const payload::StoredReply& sr);
 
   // Synchronization state bits. The reply callback in a shard thread sets ASYNC_REPLY_DONE
   // when payload is filled. It also notifies the connection if the command is marked as HEAD_REPLY.

--- a/src/facade/reply_capture.cc
+++ b/src/facade/reply_capture.cc
@@ -132,14 +132,6 @@ struct CaptureVisitor {
     rb->SendError(err->first, err->second);
   }
 
-  void operator()(payload::StoredReply sr) {
-    if (sr.ok) {
-      rb->SendStored();
-    } else {
-      rb->SendSetSkipped();
-    }
-  }
-
   void operator()(const unique_ptr<payload::CollectionPayload>& cp) {
     auto* builder = static_cast<RedisReplyBuilder*>(rb);
     if (!cp) {
@@ -153,6 +145,10 @@ struct CaptureVisitor {
     builder->StartCollection(cp->len, cp->type);
     for (auto& pl : cp->arr)
       visit(*this, std::move(pl));
+  }
+
+  void operator()(payload::StoredReply sr) {
+    LOG(FATAL) << "StoredReply not supported in non-capturing builder";
   }
 
   SinkReplyBuilder* rb;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1569,8 +1569,7 @@ class ReplyGuard {
     const bool is_one_of = (cid_name_ == "REPLCONF" || cid_name_ == "DFLY");
     bool is_mcache = cmd_cntx.mc_command() != nullptr;
     const bool is_no_reply_memcache =
-        is_mcache &&
-        (static_cast<MCReplyBuilder*>(cmd_cntx.rb())->NoReply() || cid_name_ == "QUIT");
+        (is_mcache && cmd_cntx.mc_command()->cmd_flags.no_reply) || cid_name_ == "QUIT";
     const bool should_dcheck = !is_one_of && !is_script && !is_no_reply_memcache;
     if (should_dcheck) {
       cmd_cntx_ = &cmd_cntx;
@@ -1821,15 +1820,6 @@ void Service::DispatchMC(facade::ParsedCommand* parsed_cmd) {
   char ttl[absl::numbers_internal::kFastToBufferSize];
   char store_opt[32] = {0};
   char ttl_op[] = "EXAT";
-
-  mc_builder->SetNoreply(cmd.cmd_flags.no_reply);
-  mc_builder->SetMeta(cmd.cmd_flags.meta);
-  if (cmd.cmd_flags.meta) {
-    mc_builder->SetBase64(cmd.cmd_flags.base64);
-    mc_builder->SetReturnMCFlag(cmd.cmd_flags.return_flags);
-    mc_builder->SetReturnValue(cmd.cmd_flags.return_value);
-    mc_builder->SetReturnVersion(cmd.cmd_flags.return_version);
-  }
 
   switch (cmd.type) {
     case MemcacheParser::REPLACE:


### PR DESCRIPTION
Before - we passed memcache command specific flags to MCReplyBuilder to remember the response configuration. However, this does not work with asynchronous dispatch, as a command can be replied at a differrent time from when these flags were set. We need to use flags kept inside ParsedCommand to have consistent behavior.

Also, we can not render memcache replies via CapturingReplyBuilder as it is stateless with respect to these flags, hence we move rendering of StoredReply response to ParsedCommand.

The other response that can not be rendered using CapturingReplyBuilder visitor is MGET response, as it requires keys and memcache specific flags to render the response correctly. This logic will be added in the subsequent PR.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->