### PR TITLE
chore: swap ParsedEntry::CmdData with BackedArguments

### DIFF
--- a/src/common/backed_args.h
+++ b/src/common/backed_args.h
@@ -82,6 +82,11 @@ class BackedArguments {
 
   template <typename I> void Assign(I begin, I end, size_t len);
 
+  void Reserve(size_t arg_cnt, size_t total_size) {
+    offsets_.reserve(arg_cnt);
+    storage_.reserve(total_size);
+  }
+
   size_t HeapMemory() const {
     size_t s1 = offsets_.capacity() <= kLenCap ? 0 : offsets_.capacity() * sizeof(uint32_t);
     size_t s2 = storage_.capacity() <= kStorageCap ? 0 : storage_.capacity();
@@ -135,8 +140,9 @@ class BackedArguments {
   }
 
   void clear() {
-    offsets_.clear();
-    storage_.clear();
+    // Clear the contents without deallocating memory. clear() deallocates inlined_vector.
+    offsets_.resize(0);
+    storage_.resize(0);
   }
 
   std::string_view back() const {

--- a/src/server/journal/journal_test.cc
+++ b/src/server/journal/journal_test.cc
@@ -43,7 +43,7 @@ struct EntryPayloadVisitor {
 
 // Extract payload from entry in string form.
 std::string ExtractPayload(ParsedEntry& entry) {
-  std::string out = ConCat(entry.cmd.cmd_args);
+  std::string out = ConCat(entry.cmd);
 
   if (!out.empty())
     out.pop_back();
@@ -114,16 +114,17 @@ TEST(Journal, WriteRead) {
   io::BufSource source{&buf};
   JournalReader reader{&source, 0};
 
+  ParsedEntry res;
   for (unsigned i = 0; i < test_entries.size(); i++) {
     auto& expected = test_entries[i];
 
-    auto res = reader.ReadEntry();
-    ASSERT_TRUE(res.has_value());
+    auto ec = reader.ReadEntry(&res);
+    ASSERT_FALSE(ec);
 
-    ASSERT_EQ(expected.opcode, res->opcode);
-    ASSERT_EQ(expected.txid, res->txid);
-    ASSERT_EQ(expected.dbid, res->dbid);
-    ASSERT_EQ(ExtractPayload(expected), ExtractPayload(*res));
+    ASSERT_EQ(expected.opcode, res.opcode);
+    ASSERT_EQ(expected.txid, res.txid);
+    ASSERT_EQ(expected.dbid, res.dbid);
+    ASSERT_EQ(ExtractPayload(expected), ExtractPayload(res));
   }
 }
 

--- a/src/server/journal/serializer.h
+++ b/src/server/journal/serializer.h
@@ -44,7 +44,7 @@ struct JournalReader {
   void SetSource(io::Source* source);
 
   // Try reading entry from source.
-  io::Result<journal::ParsedEntry> ReadEntry();
+  std::error_code ReadEntry(journal::ParsedEntry* dest);
 
  private:
   // Read from source until buffer contains at least num bytes.
@@ -53,8 +53,8 @@ struct JournalReader {
   // Read unsigned integer in packed encoding.
   template <typename UT> io::Result<UT> ReadUInt();
 
-  // Read and copy to buffer, return size.
-  io::Result<size_t> ReadString(io::MutableBytes buffer);
+  // Reads exactly buffer.size() bytes and copies them to buffer.
+  std::error_code ReadString(io::MutableBytes buffer);
 
   // Read argument array into string buffer.
   std::error_code ReadCommand(journal::ParsedEntry::CmdData* entry);

--- a/src/server/journal/tx_executor.h
+++ b/src/server/journal/tx_executor.h
@@ -43,8 +43,6 @@ struct TransactionData {
 
   bool IsGlobalCmd() const;
 
-  static TransactionData FromEntry(journal::ParsedEntry&& entry);
-
   TxId txid{0};
   DbIndex dbid{0};
   journal::ParsedEntry::CmdData command;
@@ -59,7 +57,8 @@ struct TransactionData {
 struct TransactionReader {
   TransactionReader(std::optional<uint64_t> lsn = std::nullopt) : lsn_(lsn) {
   }
-  std::optional<TransactionData> NextTxData(JournalReader* reader, ExecutionState* cntx);
+
+  bool NextTxData(JournalReader* reader, ExecutionState* cntx, TransactionData* dest);
 
  private:
   std::optional<uint64_t> lsn_ = 0;

--- a/src/server/journal/types.cc
+++ b/src/server/journal/types.cc
@@ -38,9 +38,8 @@ string Entry::ToString() const {
 
 string ParsedEntry::ToString() const {
   string rv = absl::StrCat("{op=", opcode, ", dbid=", dbid, ", cmd='");
-  for (auto& arg : cmd.cmd_args) {
-    absl::StrAppend(&rv, facade::ToSV(arg));
-    absl::StrAppend(&rv, " ");
+  for (string_view arg : cmd) {
+    absl::StrAppend(&rv, arg, " ");
   }
   rv.pop_back();
   rv += "'}";

--- a/src/server/journal/types.h
+++ b/src/server/journal/types.h
@@ -70,12 +70,11 @@ struct Entry : public EntryBase {
 };
 
 struct ParsedEntry : public EntryBase {
-  struct CmdData {
-    std::unique_ptr<uint8_t[]> command_buf;
-    CmdArgVec cmd_args;  // represents the parsed command.
-    size_t cmd_len{0};
-  };
+  using CmdData = cmn::BackedArguments;
   CmdData cmd;
+
+  ParsedEntry(const ParsedEntry&) = delete;
+  ParsedEntry() = default;
 
   std::string ToString() const;
 };


### PR DESCRIPTION
Before - we used a custom implementation for buffer backed arguments.
Now - we switch to standard cmn::BackedArguments, which provides all the functionality
out of the box. Bonus points - change the interfaces to be able to reuse already existing objects
that allocate heap memory.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->