### PR TITLE
chore: deferred mget

### DIFF
--- a/src/facade/reply_capture.cc
+++ b/src/facade/reply_capture.cc
@@ -151,6 +151,10 @@ struct CaptureVisitor {
     LOG(FATAL) << "StoredReply not supported in non-capturing builder";
   }
 
+  void operator()(const unique_ptr<payload::SingleGetReply[]>& arr) {
+    LOG(FATAL) << "SingleGetReply not supported in non-capturing builder";
+  }
+
   SinkReplyBuilder* rb;
 };
 

--- a/src/facade/reply_payload.h
+++ b/src/facade/reply_payload.h
@@ -20,11 +20,22 @@ struct CollectionPayload;
 struct SimpleString : public std::string {};  // SendSimpleString
 struct BulkString : public std::string {};    // SendBulkString
 struct StoredReply {
-  bool ok;  // true for SendStored, false for SendSetSkipped
+  bool ok = false;  // true for SendStored, false for SendSetSkipped
 };
 
+struct SingleGetReply {
+  std::string value;
+  uint64_t mc_ver = 0;
+  uint32_t mc_flag = 0;
+  bool is_found = false;
+};
+
+using MGetReply = std::unique_ptr<SingleGetReply[]>;
+
 using Payload = std::variant<std::monostate, Null, Error, long, double, SimpleString, BulkString,
-                             std::unique_ptr<CollectionPayload>, StoredReply>;
+                             std::unique_ptr<CollectionPayload>, StoredReply, MGetReply>;
+
+static_assert(sizeof(Payload) == 40);
 
 struct CollectionPayload {
   CollectionPayload(unsigned _len, CollectionType _type) : len{_len}, type{_type} {

--- a/src/server/http_api.cc
+++ b/src/server/http_api.cc
@@ -130,6 +130,9 @@ struct CaptureVisitor {
     }
   }
 
+  void operator()(const payload::MGetReply& arr) {
+  }
+
   void operator()(const payload::Error& err) {
     str = absl::StrCat(R"({"error": ")", err->first, "\"");
   }


### PR DESCRIPTION
This does not implement async dispatching for MC/mget, just merely supports
replies in the correct order for cases where the previous command was dispatched
asynchronously. We meed to implement it for every MC command to preserve the correctness.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->