### PR TITLE
chore: change DispatchCommand interface

### DIFF
--- a/src/common/backed_args.h
+++ b/src/common/backed_args.h
@@ -93,6 +93,11 @@ class BackedArguments {
     return s1 + s2;
   }
 
+  void SwapArgs(cmn::BackedArguments& other) {
+    offsets_.swap(other.offsets_);
+    storage_.swap(other.storage_);
+  }
+
   // The capacity is chosen so that we allocate a fully utilized (128 bytes) block.
   using StorageType = absl::InlinedVector<char, kStorageCap>;
 

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -82,9 +82,6 @@ class Connection : public util::Connection {
     bool force_unsubscribe = false;
   };
 
-  // Pipeline message, accumulated Redis command to be executed.
-  using PipelineMessage = cmn::BackedArguments;
-
   // Monitor message, carries a simple payload with the registered event to be sent.
   struct MonitorMessage : public std::string {};
 
@@ -110,8 +107,8 @@ class Connection : public util::Connection {
     bool invalidate_due_to_flush = false;
   };
 
-  // Requests are allocated on the mimalloc heap and thus require a custom deleter.
-  using PipelineMessagePtr = std::unique_ptr<PipelineMessage>;
+  // Pipeline message, accumulated Redis command to be executed.
+  using PipelineMessagePtr = std::unique_ptr<ParsedCommand>;
   using PubMessagePtr = std::unique_ptr<PubMessage>;
 
   using AclUpdateMessagePtr = std::unique_ptr<AclUpdateMessage>;
@@ -384,7 +381,7 @@ class Connection : public util::Connection {
   // Returns true on successful execution, false on reply builder error.
   bool ReplyMCBatch();
 
-  void CreateParsedCommand();
+  ParsedCommand* CreateParsedCommand();
   void EnqueueParsedCommand();
   void ReleaseParsedCommand(ParsedCommand* cmd, bool is_pipelined);
   void DestroyParsedQueue();

--- a/src/facade/ok_main.cc
+++ b/src/facade/ok_main.cc
@@ -23,9 +23,8 @@ namespace {
 
 class OkService : public ServiceInterface {
  public:
-  DispatchResult DispatchCommand(ParsedArgs args, SinkReplyBuilder* builder,
-                                 ConnectionContext* cntx) final {
-    builder->SendOk();
+  DispatchResult DispatchCommand(ParsedArgs args, ParsedCommand* cmd) final {
+    cmd->rb()->SendOk();
     return DispatchResult::OK;
   }
 
@@ -34,7 +33,11 @@ class OkService : public ServiceInterface {
                                           ConnectionContext* cntx) final {
     for (unsigned i = 0; i < count; i++) {
       ParsedArgs args = arg_gen();
-      DispatchCommand(args, builder, cntx);
+      ParsedCommand* cmd = AllocateParsedCommand();
+      cmd->Init(builder, cntx);
+
+      DispatchCommand(args, cmd);
+      delete cmd;
     }
     DispatchManyResult result{
         .processed = static_cast<uint32_t>(count),

--- a/src/facade/resp_expr.cc
+++ b/src/facade/resp_expr.cc
@@ -8,13 +8,11 @@
 
 namespace facade {
 
-void RespExpr::VecToArgList(const Vec& src, CmdArgVec* dest) {
-  dest->resize(src.size());
-  for (size_t i = 0; i < src.size(); ++i) {
-    DCHECK(src[i].type == RespExpr::STRING);
+void FillBackedArgs(const RespVec& src, cmn::BackedArguments* dest) {
+  auto map = [](const RespExpr& expr) { return expr.GetView(); };
+  auto range = base::it::Transform(map, base::it::Range(src.begin(), src.end()));
 
-    (*dest)[i] = ToSV(src[i].GetBuf());
-  }
+  dest->Assign(range.begin(), range.end(), src.size());
 }
 
 }  // namespace facade

--- a/src/facade/resp_expr.h
+++ b/src/facade/resp_expr.h
@@ -62,8 +62,6 @@ class RespExpr {
   }
 
   static const char* TypeName(Type t);
-
-  static void VecToArgList(const Vec& src, CmdArgVec* dest);
 };
 
 using RespVec = RespExpr::Vec;
@@ -72,6 +70,8 @@ using RespSpan = absl::Span<const RespExpr>;
 inline std::string_view ToSV(RespExpr::Buffer buf) {
   return std::string_view{reinterpret_cast<const char*>(buf.data()), buf.size()};
 }
+
+void FillBackedArgs(const RespVec& src, cmn::BackedArguments* dest);
 
 }  // namespace facade
 

--- a/src/facade/service_interface.h
+++ b/src/facade/service_interface.h
@@ -36,8 +36,7 @@ class ServiceInterface {
   virtual ~ServiceInterface() {
   }
 
-  virtual DispatchResult DispatchCommand(ParsedArgs args, SinkReplyBuilder* builder,
-                                         ConnectionContext* cntx) = 0;
+  virtual DispatchResult DispatchCommand(ParsedArgs args, ParsedCommand* cmd) = 0;
 
   virtual DispatchManyResult DispatchManyCommands(std::function<ParsedArgs()> arg_gen,
                                                   unsigned count, SinkReplyBuilder* builder,

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -280,7 +280,6 @@ struct ConnectionState {
   ClientTracking tracking_info_;
 };
 
-class CommandContext;
 class ConnectionContext : public facade::ConnectionContext {
  public:
   ConnectionContext(facade::Connection* owner, dfly::acl::UserCredentials cred);
@@ -327,10 +326,6 @@ class ConnectionContext : public facade::ConnectionContext {
 
   // Reference to a FlowInfo for this connection if from a master to a replica.
   FlowInfo* replication_flow = nullptr;
-
-  // A temporary variable, to allow passing CommandContext from DispatchMC to
-  // DispatchCommand without changing the function signature.
-  CommandContext* cmnd_ctx = nullptr;
 
   // The related connection is bound to main listener or serves the memcached protocol
   bool has_main_or_memcache_listener = false;

--- a/src/server/journal/executor.h
+++ b/src/server/journal/executor.h
@@ -37,7 +37,7 @@ class JournalExecutor {
   }
 
  private:
-  facade::DispatchResult Execute(journal::ParsedEntry::CmdData& cmd);
+  facade::DispatchResult Execute(CommandContext* cmd_cntx);
 
   // Select database. Ensure it exists if accessed for first time.
   void SelectDb(DbIndex dbid);

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -36,8 +36,8 @@ class Service : public facade::ServiceInterface {
   void Shutdown();
 
   // Prepare command execution, verify and execute, reply to context
-  facade::DispatchResult DispatchCommand(facade::ParsedArgs args, facade::SinkReplyBuilder* builder,
-                                         facade::ConnectionContext* cntx) final;
+  facade::DispatchResult DispatchCommand(facade::ParsedArgs args,
+                                         facade::ParsedCommand* parsed_cmd) final;
 
   // Execute multiple consecutive commands, possibly in parallel by squashing
   facade::DispatchManyResult DispatchManyCommands(std::function<facade::ParsedArgs()> arg_gen,

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2863,28 +2863,29 @@ void LoadSearchCommandFromAux(Service* service, string&& def, string_view comman
     return;
   }
 
-  CmdArgVec arg_vec;
-  facade::RespExpr::VecToArgList(resp_vec, &arg_vec);
-
   // Temporary migration fix for backwards compatibility with old snapshots where TAG fields were
   // serialized as "TAG SORTABLE SEPARATOR x" but parser expects "TAG SEPARATOR x SORTABLE".
   // Reorder arguments if needed.
   // TODO: Remove this workaround after Apr 2026.
-  for (size_t i = 0; i + 2 < arg_vec.size(); ++i) {
-    std::string_view cur{arg_vec[i].data(), arg_vec[i].size()};
-    std::string_view next{arg_vec[i + 1].data(), arg_vec[i + 1].size()};
+  for (size_t i = 0; i + 2 < resp_vec.size(); ++i) {
+    std::string_view cur = resp_vec[i].GetView();
+    std::string_view next = resp_vec[i + 1].GetView();
     if (absl::EqualsIgnoreCase(cur, "SORTABLE") && absl::EqualsIgnoreCase(next, "SEPARATOR")) {
       // SORTABLE SEPARATOR x -> SEPARATOR x SORTABLE
-      std::swap(arg_vec[i], arg_vec[i + 1]);      // SEPARATOR SORTABLE x
-      std::swap(arg_vec[i + 1], arg_vec[i + 2]);  // SEPARATOR x SORTABLE
+      std::swap(resp_vec[i], resp_vec[i + 1]);      // SEPARATOR SORTABLE x
+      std::swap(resp_vec[i + 1], resp_vec[i + 2]);  // SEPARATOR x SORTABLE
     }
   }
 
   // Prepend command name (FT.CREATE or FT.SYNUPDATE)
-  string cmd_str{command_name};
-  arg_vec.insert(arg_vec.begin(), MutableSlice{cmd_str.data(), cmd_str.size()});
+  CommandContext cntx_cmd;
+  cntx_cmd.Init(&crb, &cntx);
 
-  service->DispatchCommand(facade::ParsedArgs{arg_vec}, &crb, &cntx);
+  cntx_cmd.PushArg(command_name);
+  for (unsigned i = 0; i < resp_vec.size(); i++) {
+    cntx_cmd.PushArg(resp_vec[i].GetView());
+  }
+  service->DispatchCommand(facade::ParsedArgs{cntx_cmd}, &cntx_cmd);
 
   auto response = crb.Take();
   if (auto err = facade::CapturingReplyBuilder::TryExtractError(response); err) {

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -451,12 +451,14 @@ RespExpr BaseFamilyTest::Run(std::string_view id, ArgSlice slice) {
 
   CmdArgVec args = conn_wrapper->Args(slice);
 
-  auto* context = conn_wrapper->cmd_cntx();
+  ConnectionContext* context = conn_wrapper->cmd_cntx();
   context->ns = &namespaces->GetDefaultNamespace();
 
   DCHECK(context->transaction == nullptr) << id;
-
-  service_->DispatchCommand(ParsedArgs{args}, conn_wrapper->builder(), context);
+  CommandContext cmd_cntx;
+  cmd_cntx.Init(conn_wrapper->builder(), context);
+  cmd_cntx.Assign(args.begin(), args.end(), args.size());
+  service_->DispatchCommand(ParsedArgs{cmd_cntx}, &cmd_cntx);
 
   DCHECK(context->transaction == nullptr);
 


### PR DESCRIPTION
This PR refactors the DispatchCommand interface to consolidate command execution context. The main change simplifies the interface from taking separate SinkReplyBuilder* and ConnectionContext* parameters to accepting a single ParsedCommand* parameter that encapsulates both.

The DispatchCommand method signature is updated throughout the codebase to use ParsedCommand* instead of separate builder and context parameters
A CommandContext class (which extends ParsedCommand) is now used to carry command state, removing the temporary cmnd_ctx field from ConnectionContext
Helper functions like VecToArgList are refactored to populate BackedArguments directly,

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->