### PR TITLE
chore: remove Stored and Deleted interfaces from ParsedCommand

### DIFF
--- a/src/facade/parsed_command.h
+++ b/src/facade/parsed_command.h
@@ -24,8 +24,7 @@ class MCRender {
   std::string RenderMiss() const;
   std::string RenderDeleted() const;
   std::string RenderGetEnd() const;
-  std::string RenderStored() const;
-  std::string RenderNotStored() const;
+  std::string RenderStored(bool ok) const;
 
  private:
   MemcacheCmdFlags flags_;
@@ -118,8 +117,6 @@ class ParsedCommand : public cmn::BackedArguments {
     SendSimpleString("OK");
   }
 
-  void SendStored(bool ok /* true - ok, false - skipped*/);
-
   void SendNotFound() {  // For MC only.
     SendSimpleString(MCRender{mc_cmd_->cmd_flags}.RenderNotFound());
   }
@@ -128,12 +125,11 @@ class ParsedCommand : public cmn::BackedArguments {
     SendSimpleString(MCRender{mc_cmd_->cmd_flags}.RenderMiss());
   }
 
+  void SendLong(long val);
+  void SendNull();
+
   void SendGetEnd() {  // For MC only.
     SendSimpleString(MCRender{mc_cmd_->cmd_flags}.RenderGetEnd());
-  }
-
-  void SendDeleted() {  // For MC only.
-    SendSimpleString(MCRender{mc_cmd_->cmd_flags}.RenderDeleted());
   }
 
   // If payload exists, sends it to reply builder, resets it and returns true.
@@ -165,8 +161,6 @@ class ParsedCommand : public cmn::BackedArguments {
  private:
   bool CheckDoneAndMarkHead();
   void NotifyReplied();
-
-  void SendDirect(const payload::StoredReply& sr);
 
   // Synchronization state bits. The reply callback in a shard thread sets ASYNC_REPLY_DONE
   // when payload is filled. It also notifies the connection if the command is marked as HEAD_REPLY.

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -243,6 +243,8 @@ void MCReplyBuilder::SendValue(MemcacheCmdFlags cmd_flags, std::string_view key,
 }
 
 void MCReplyBuilder::SendSimpleString(std::string_view str) {
+  if (str.empty())
+    return;
   ReplyScope scope(this);
   WritePieces(str, kCRLF);
 }

--- a/src/facade/reply_capture.cc
+++ b/src/facade/reply_capture.cc
@@ -147,8 +147,8 @@ struct CaptureVisitor {
       visit(*this, std::move(pl));
   }
 
-  void operator()(payload::StoredReply sr) {
-    LOG(FATAL) << "StoredReply not supported in non-capturing builder";
+  void operator()(payload::ReplyFunction&& rf) {
+    rf(rb);
   }
 
   SinkReplyBuilder* rb;

--- a/src/server/http_api.cc
+++ b/src/server/http_api.cc
@@ -122,12 +122,7 @@ struct CaptureVisitor {
     absl::StrAppend(&str, "null");
   }
 
-  void operator()(payload::StoredReply sr) {
-    if (sr.ok) {
-      operator()(payload::SimpleString{"OK"});
-    } else {
-      operator()(payload::Null{});
-    }
+  void operator()(payload::ReplyFunction&& sr) {
   }
 
   void operator()(const payload::Error& err) {

--- a/src/server/string_family_test.cc
+++ b/src/server/string_family_test.cc
@@ -232,7 +232,7 @@ TEST_F(StringFamilyTest, MGetSet) {
   auto mget_fb = pp_->at(0)->LaunchFiber([&] {
     for (size_t i = 0; i < 1000; ++i) {
       RespExpr resp = Run({"mget", "b", "x"});
-      ASSERT_EQ(RespExpr::ARRAY, resp.type);
+      ASSERT_THAT(resp, ArrLen(2));
       auto ivec = ToIntArr(resp);
 
       ASSERT_GE(ivec[1], ivec[0]);

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -90,8 +90,24 @@ class BaseFamilyTest : public ::testing::Test {
   void RunMany(const std::vector<std::vector<std::string>>& cmds);
 
   using MCResponse = std::vector<std::string>;
-  MCResponse RunMC(MemcacheParser::CmdType cmd_type, std::string_view key, std::string_view value,
-                   uint32_t flags = 0, std::chrono::seconds ttl = std::chrono::seconds{});
+
+  struct MCArgs {
+    std::string_view value;
+    uint32_t val_flags;
+    std::chrono::seconds ttl;
+    uint64_t delta;
+
+    explicit MCArgs(std::string_view v = {}, uint32_t f = 0) : value(v), val_flags(f) {
+      ttl = std::chrono::seconds{0};
+      delta = 0;
+    }
+
+    explicit MCArgs(uint64_t d) : MCArgs() {
+      delta = d;
+    }
+  };
+
+  MCResponse RunMC(MemcacheParser::CmdType cmd_type, std::string_view key, MCArgs args);
   MCResponse RunMC(MemcacheParser::CmdType cmd_type, std::string_view key = std::string_view{});
   MCResponse GetMC(MemcacheParser::CmdType cmd_type, std::initializer_list<std::string_view> list);
 

--- a/tests/dragonfly/pymemcached_test.py
+++ b/tests/dragonfly/pymemcached_test.py
@@ -12,119 +12,6 @@ from .instance import DflyInstance
 DEFAULT_ARGS = {"memcached_port": 11212, "proactor_threads": 4}
 
 
-# Generic basic tests
-
-
-@dfly_args(DEFAULT_ARGS)
-def test_basic(memcached_client: MCClient):
-    assert not memcached_client.default_noreply
-
-    # set -> replace -> add -> get
-    assert memcached_client.set("key1", "value1")
-    assert memcached_client.replace("key1", "value2")
-    assert not memcached_client.add("key1", "value3")
-    assert memcached_client.get("key1") == b"value2"
-
-    # add -> get
-    assert memcached_client.add("key2", "value1")
-    assert memcached_client.get("key2") == b"value1"
-
-    # delete
-    assert memcached_client.delete("key1")
-    assert not memcached_client.delete("key3")
-    assert memcached_client.get("key1") is None
-
-    # prepend append
-    assert memcached_client.set("key4", "B")
-    assert memcached_client.prepend("key4", "A")
-    assert memcached_client.append("key4", "C")
-    assert memcached_client.get("key4") == b"ABC"
-
-    # incr
-    memcached_client.set("key5", 0)
-    assert memcached_client.incr("key5", 1) == 1
-    assert memcached_client.incr("key5", 1) == 2
-    assert memcached_client.decr("key5", 1) == 1
-
-    assert memcached_client.gets("key5") == (b"1", b"0")
-
-
-# Noreply (and pipeline) tests
-
-
-@dfly_args(DEFAULT_ARGS)
-async def test_noreply_pipeline(df_server: DflyInstance, memcached_client: MCClient):
-    """
-    With the noreply option the python client doesn't wait for replies,
-    so all the commands are pipelined. Assert pipelines work correctly and the
-    succeeding regular command receives a reply (it should join the pipeline as last).
-    """
-
-    client = df_server.client()
-    for attempts in range(2):
-        keys = [f"k{i}" for i in range(1000)]
-        values = [f"d{i}" for i in range(len(keys))]
-
-        for k, v in zip(keys, values):
-            memcached_client.set(k, v, noreply=True)
-
-        # quick follow up before the pipeline finishes
-        assert memcached_client.get("k10") == b"d10"
-        # check all commands were executed
-        assert memcached_client.get_many(keys) == {k: v.encode() for k, v in zip(keys, values)}
-
-        info = await client.info()
-        if info["total_pipelined_commands"] > 100:
-            return
-        logging.warning(
-            f"Have not identified pipelining at attempt {attempts} Info: \n" + str(info)
-        )
-        await client.flushall()
-
-    assert False, "Pipelining not detected"
-
-
-@dfly_args(DEFAULT_ARGS)
-def test_noreply_alternating(memcached_client: MCClient):
-    """
-    Assert alternating noreply works correctly, will cause many dispatch queue emptyings.
-    """
-    for i in range(200):
-        if i % 2 == 0:
-            memcached_client.set(f"k{i}", "D1", noreply=True)
-            memcached_client.set(f"k{i}", "D2", noreply=True)
-            memcached_client.set(f"k{i}", "D3", noreply=True)
-        assert memcached_client.add(f"k{i}", "DX", noreply=False) == (i % 2 != 0)
-
-
-# Raw connection tests
-
-
-@dfly_args(DEFAULT_ARGS)
-def test_length_in_set_command(df_server: DflyInstance, memcached_client: MCClient):
-    """
-    Test parser correctly reads value based on length and complains about bad chunks
-    """
-    cases = [b"NOTFOUR", b"FOUR", b"F4\r\n", b"\r\n\r\n"]
-
-    for case in cases:
-        client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        client.connect(("127.0.0.1", int(df_server["memcached_port"])))
-
-        logging.info(f"Case {case}")
-        client.sendall(b"set foo 0 0 4\r\n" + case + b"\r\n")
-        response = client.recv(256).decode()
-        if len(case) == 4:
-            assert response == "STORED\r\n"
-        else:
-            # response should follow up with ERROR due to OUR\r\n being
-            # parsed as unknown command but we can not guarantee that
-            # it will be read in the same recv call, so just check the prefix.
-            assert response.startswith("CLIENT_ERROR bad data chunk\r\n")
-
-        client.close()
-
-
 def read_response(client, expected_len):
     response = b""
     while len(response) < expected_len:
@@ -135,74 +22,162 @@ def read_response(client, expected_len):
     return response
 
 
+# Generic basic tests
 @dfly_args(DEFAULT_ARGS)
-def test_error_in_pipeline(df_server: DflyInstance, memcached_client: MCClient):
-    """
-    Verify correct responses to  "get x\r\ngetaa\r\nget y z\r\n"
-    """
-    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    client.settimeout(5)
-    client.connect(("127.0.0.1", int(df_server["memcached_port"])))
+class TestMemcached:
+    def test_basic(self, memcached_client: MCClient):
+        assert not memcached_client.default_noreply
 
-    client.sendall(b"get x\r\ngetaa\r\nget y z\r\n")
+        # set -> replace -> add -> get
+        assert memcached_client.set("key1", "value1")
+        assert memcached_client.replace("key1", "value2")
+        assert not memcached_client.add("key1", "value3")
+        assert memcached_client.get("key1") == b"value2"
 
-    expected = b"END\r\nERROR\r\nEND\r\n"
-    response = read_response(client, len(expected))
-    client.close()
+        # add -> get
+        assert memcached_client.add("key2", "value1")
+        assert memcached_client.get("key2") == b"value1"
 
-    assert response == expected
+        # delete
+        assert memcached_client.delete("key1")
+        assert not memcached_client.delete("key3")
+        assert memcached_client.get("key1") is None
 
+        # prepend append
+        assert memcached_client.set("key4", "B")
+        assert memcached_client.prepend("key4", "A")
+        assert memcached_client.append("key4", "C")
+        assert memcached_client.get("key4") == b"ABC"
 
-# Auxiliary tests
+        # incr
+        memcached_client.set("key5", 0)
+        assert memcached_client.incr("key5", 1) == 1
+        assert memcached_client.incr("key5", 1) == 2
+        assert memcached_client.decr("key5", 1) == 1
 
+        assert memcached_client.gets("key5") == (b"1", b"0")
 
-@dfly_args(DEFAULT_ARGS)
-def test_large_request(memcached_client):
-    assert memcached_client.set(b"key1", b"d" * 4096, noreply=False)
-    assert memcached_client.set(b"key2", b"d" * 4096 * 2, noreply=False)
+    # Noreply (and pipeline) tests
+    async def test_noreply_pipeline(self, df_server: DflyInstance, memcached_client: MCClient):
+        """
+        With the noreply option the python client doesn't wait for replies,
+        so all the commands are pipelined. Assert pipelines work correctly and the
+        succeeding regular command receives a reply (it should join the pipeline as last).
+        """
 
+        client = df_server.client()
+        for attempts in range(2):
+            keys = [f"k{i}" for i in range(1000)]
+            values = [f"d{i}" for i in range(len(keys))]
 
-@dfly_args(DEFAULT_ARGS)
-def test_version(memcached_client: MCClient):
-    """
-    php-memcached client expects version to be in the format of "n.n.n", so we return 1.5.0 emulating an old memcached server.
-    Our real version is being returned in the stats command.
-    Also verified manually that php client parses correctly the version string that ends with "DF".
-    """
-    assert b"1.6.0 DF" == memcached_client.version()
-    stats = memcached_client.stats()
-    version = stats[b"version"].decode("utf-8")
-    assert version.startswith("v") or version == "dev"
+            for k, v in zip(keys, values):
+                memcached_client.set(k, v, noreply=True)
 
+            # quick follow up before the pipeline finishes
+            assert memcached_client.get("k10") == b"d10"
+            # check all commands were executed
+            assert memcached_client.get_many(keys) == {k: v.encode() for k, v in zip(keys, values)}
 
-@dfly_args(DEFAULT_ARGS)
-def test_flags(memcached_client: MCClient):
-    for i in range(1, 20):
-        flags = random.randrange(50, 1000)
-        memcached_client.set("a", "real-value", flags=flags, noreply=True)
+            info = await client.info()
+            if info["total_pipelined_commands"] > 100:
+                return
+            logging.warning(
+                f"Have not identified pipelining at attempt {attempts} Info: \n" + str(info)
+            )
+            await client.flushall()
 
-        res = memcached_client.raw_command("get a", "END\r\n").split()
-        # workaround sometimes memcached_client.raw_command returns empty str
-        if len(res) > 0:
-            assert res[2].decode() == str(flags)
+        assert False, "Pipelining not detected"
 
+    def test_noreply_alternating(self, memcached_client: MCClient):
+        """
+        Assert alternating noreply works correctly, will cause many dispatch queue emptyings.
+        """
+        for i in range(200):
+            if i % 2 == 0:
+                memcached_client.set(f"k{i}", "D1", noreply=True)
+                memcached_client.set(f"k{i}", "D2", noreply=True)
+                memcached_client.set(f"k{i}", "D3", noreply=True)
+            assert memcached_client.add(f"k{i}", "DX", noreply=False) == (i % 2 != 0)
 
-@dfly_args(DEFAULT_ARGS)
-def test_expiration(memcached_client: MCClient):
-    assert not memcached_client.default_noreply
+    def test_length_in_set_command(self, df_server: DflyInstance, memcached_client: MCClient):
+        """
+        Test parser correctly reads value based on length and complains about bad chunks
+        """
+        cases = [b"NOTFOUR", b"FOUR", b"F4\r\n", b"\r\n\r\n"]
 
-    assert memcached_client.set("key1", "value1", 2)
-    assert memcached_client.set("key2", "value2", int(time.time()) + 2)
-    assert memcached_client.set("key3", "value3", int(time.time()) + 200)
-    assert memcached_client.get("key1") == b"value1"
-    assert memcached_client.get("key2") == b"value2"
-    assert memcached_client.get("key3") == b"value3"
-    assert memcached_client.set("key3", "value3", int(time.time()) - 200)
-    assert memcached_client.get("key3") == None
-    time.sleep(2)
-    assert memcached_client.get("key1") == None
-    assert memcached_client.get("key2") == None
-    assert memcached_client.get("key3") == None
+        for case in cases:
+            client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            client.connect(("127.0.0.1", int(df_server["memcached_port"])))
+
+            logging.info(f"Case {case}")
+            client.sendall(b"set foo 0 0 4\r\n" + case + b"\r\n")
+            response = client.recv(256).decode()
+            if len(case) == 4:
+                assert response == "STORED\r\n"
+            else:
+                # response should follow up with ERROR due to OUR\r\n being
+                # parsed as unknown command but we can not guarantee that
+                # it will be read in the same recv call, so just check the prefix.
+                assert response.startswith("CLIENT_ERROR bad data chunk\r\n")
+
+            client.close()
+
+    def test_error_in_pipeline(self, df_server: DflyInstance, memcached_client: MCClient):
+        """
+        Verify correct responses to  "get x\r\ngetaa\r\nget y z\r\n"
+        """
+        client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        client.settimeout(5)
+        client.connect(("127.0.0.1", int(df_server["memcached_port"])))
+
+        client.sendall(b"get x\r\ngetaa\r\nget y z\r\n")
+
+        expected = b"END\r\nERROR\r\nEND\r\n"
+        response = read_response(client, len(expected))
+        client.close()
+
+        assert response == expected
+
+    def test_large_request(self, memcached_client):
+        assert memcached_client.set(b"key1", b"d" * 4096, noreply=False)
+        assert memcached_client.set(b"key2", b"d" * 4096 * 2, noreply=False)
+
+    def test_version(self, memcached_client: MCClient):
+        """
+        php-memcached client expects version to be in the format of "n.n.n", so we return 1.5.0 emulating an old memcached server.
+        Our real version is being returned in the stats command.
+        Also verified manually that php client parses correctly the version string that ends with "DF".
+        """
+        assert b"1.6.0 DF" == memcached_client.version()
+        stats = memcached_client.stats()
+        version = stats[b"version"].decode("utf-8")
+        assert version.startswith("v") or version == "dev"
+
+    def test_flags(self, memcached_client: MCClient):
+        for i in range(1, 20):
+            flags = random.randrange(50, 1000)
+            memcached_client.set("a", "real-value", flags=flags, noreply=True)
+
+            res = memcached_client.raw_command("get a", "END\r\n").split()
+            # workaround sometimes memcached_client.raw_command returns empty str
+            if len(res) > 0:
+                assert res[2].decode() == str(flags)
+
+    def test_expiration(self, memcached_client: MCClient):
+        assert not memcached_client.default_noreply
+
+        assert memcached_client.set("key1", "value1", 2)
+        assert memcached_client.set("key2", "value2", int(time.time()) + 2)
+        assert memcached_client.set("key3", "value3", int(time.time()) + 200)
+        assert memcached_client.get("key1") == b"value1"
+        assert memcached_client.get("key2") == b"value2"
+        assert memcached_client.get("key3") == b"value3"
+        assert memcached_client.set("key3", "value3", int(time.time()) - 200)
+        assert memcached_client.get("key3") is None
+        time.sleep(2)
+        assert memcached_client.get("key1") is None
+        assert memcached_client.get("key2") is None
+        assert memcached_client.get("key3") is None
 
 
 @dfly_args(DEFAULT_ARGS)


### PR DESCRIPTION
As disscussed internally, we remove protocol related logic from ParsedCommand and move it back to appropriate commands. This PR handles mc commands: INCR,DEL and SET,

Also, reformatting memcache pytests to be part of a single class.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->