### PR TITLE
chore: simplify GAT command arguments

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -2012,7 +2012,7 @@ bool Connection::ParseMCBatch() {
       CreateParsedCommand();
     }
     uint32_t consumed = 0;
-
+    memcache_parser_->set_last_unix_time(time(nullptr));
     MemcacheParser::Result result = memcache_parser_->Parse(io::View(io_buf_.InputBuffer()),
                                                             &consumed, parsed_cmd_->mc_command());
 

--- a/src/facade/memcache_parser.h
+++ b/src/facade/memcache_parser.h
@@ -89,8 +89,7 @@ class MemcacheParser {
       uint64_t delta;           // for DECR/INCR commands.
     };
 
-    uint32_t expire_ts =
-        0;  // relative (expire_ts <= month) or unix time (expire_ts > month) in seconds
+    int64_t expire_ts = 0;  // unix time (expire_ts > month) in seconds
 
     // flags for STORE commands
     uint32_t flags = 0;
@@ -127,11 +126,17 @@ class MemcacheParser {
 
   Result Parse(std::string_view str, uint32_t* consumed, Command* res);
 
+  void set_last_unix_time(int64_t t) {
+    last_unix_time_ = t;
+  }
+
  private:
   Result ConsumeValue(std::string_view str, uint32_t* consumed, Command* dest);
   Result ParseInternal(ArgSlice tokens_view, Command* cmd);
+
   uint32_t val_len_to_read_ = 0;
   std::string tmp_buf_;
+  int64_t last_unix_time_ = 0;
 };
 
 }  // namespace facade

--- a/src/facade/memcache_parser_test.cc
+++ b/src/facade/memcache_parser_test.cc
@@ -173,6 +173,11 @@ TEST_F(MCParserTest, Gat) {
   EXPECT_EQ(cmd_.type, MemcacheParser::GATS);
   EXPECT_THAT(ToArgs(), ElementsAre("foo", "bar", "baz"));
   EXPECT_EQ(cmd_.expire_ts, 1000);
+
+  parser_.set_last_unix_time(2000);
+  res = Parse("gats 1000 foo bar baz\r\n");
+  EXPECT_EQ(MemcacheParser::OK, res);
+  EXPECT_EQ(cmd_.expire_ts, 3000);
 }
 
 TEST_F(MCParserTest, ValueState) {

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -386,16 +386,12 @@ TEST_F(DflyEngineTest, Memcache) {
   EXPECT_THAT(resp, ElementsAre("VALUE key 1 3 0", "bar", "VALUE key2 2 8 0", "bar2val2", "END"));
 
   EXPECT_THAT(RunMC(MP::SET, "foo", "bar"), ElementsAre("STORED"));
-  // The value here is 1 month + 1 second, memcache treats an expiry of greater than 1 month as
-  // absolute value. GAT expiry seconds are counted from epoch, setting expiry in the past results
-  // in the key being removed.
-  constexpr uint32_t short_expiry = 60 * 60 * 24 * 30 + 1;
-  EXPECT_THAT(GetMC(MP::GAT, {StrCat(short_expiry), "foo"}), ElementsAre("END"));
 
   EXPECT_THAT(RunMC(MP::SET, "foo", "bar"), ElementsAre("STORED"));
 
   // 30 seconds into the future
-  EXPECT_THAT(GetMC(MP::GAT, {"30", "foo", "abc", "def", "ghi"}),
+  auto future_ts = time(nullptr) + 30;
+  EXPECT_THAT(GetMC(MP::GAT, {StrCat(future_ts), "foo", "abc", "def", "ghi"}),
               ElementsAre("VALUE foo 0 3", "bar", "END"));
 
   EXPECT_THAT(GetMC(MP::GAT, {"1000"}),

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1876,20 +1876,6 @@ void Service::DispatchMC(facade::ParsedCommand* parsed_cmd) {
 
   args.emplace_back(cmd_name, strlen(cmd_name));
 
-  // if expire_ts is greater than month it's a unix timestamp
-  // https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L139
-  constexpr uint32_t kExpireLimit = 60 * 60 * 24 * 30;
-  const uint64_t expire_ts = cmd.expire_ts && cmd.expire_ts <= kExpireLimit
-                                 ? cmd.expire_ts + time(nullptr)
-                                 : cmd.expire_ts;
-
-  // For GAT/GATS commands, the expiry precedes the keys which will be looked up:
-  // GAT|GATS <expiry> key [key...]
-  if (cmd.type == MemcacheParser::GAT || cmd.type == MemcacheParser::GATS) {
-    char* next = absl::numbers_internal::FastIntToBuffer(expire_ts, ttl);
-    args.emplace_back(ttl, next - ttl);
-  }
-
   if (!cmd.backed_args->empty()) {
     args.emplace_back(cmd.key());
   }
@@ -1902,8 +1888,8 @@ void Service::DispatchMC(facade::ParsedCommand* parsed_cmd) {
       args.emplace_back(store_opt, strlen(store_opt));
     }
 
-    if (expire_ts && memcmp(cmd_name, "SET", 3) == 0) {
-      char* next = absl::numbers_internal::FastIntToBuffer(expire_ts, ttl);
+    if (cmd.expire_ts && memcmp(cmd_name, "SET", 3) == 0) {
+      char* next = absl::numbers_internal::FastIntToBuffer(cmd.expire_ts, ttl);
       args.emplace_back(ttl_op, 4);
       args.emplace_back(ttl, next - ttl);
     }


### PR DESCRIPTION
Before - Dragonfly GAT command used `<TS> key1 .. keyn ` format to pass expiry timestamp information further.
Now, we have memcache context as part of the ParsedCommand structure so we can access expire_ts directly.

This change moves the logic of parsing the correct timestamp to the parser and removes the first <TS> argument from GAT. This will help with consolidating GAT and MGET code down the road.

This change is possible as we do not need to replicate GAT as is, as it is translated to PEXPIREAT or DEL commands.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->