### PR TITLE
chore: move more reply calls to CommandContext API

### DIFF
--- a/src/server/bloom_family.cc
+++ b/src/server/bloom_family.cc
@@ -122,7 +122,7 @@ void CmdAdd(CmdArgList args, CommandContext* cmd_cntx) {
   OpStatus status = res.status();
   if (res) {
     if (res->front())
-      return cmd_cntx->rb()->SendLong(*res->front());
+      return cmd_cntx->SendLong(*res->front());
     else
       status = res->front().status();
   }
@@ -138,7 +138,7 @@ void CmdExists(CmdArgList args, CommandContext* cmd_cntx) {
   };
 
   OpResult res = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
-  return cmd_cntx->rb()->SendLong(res ? res->front() : 0);
+  return cmd_cntx->SendLong(res ? res->front() : 0);
 }
 
 void CmdMAdd(CmdArgList args, CommandContext* cmd_cntx) {

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1170,7 +1170,7 @@ void GenericFamily::Exists(CmdArgList args, CommandContext* cmd_cntx) {
   OpStatus status = cmd_cntx->tx->ScheduleSingleHop(std::move(cb));
   CHECK_EQ(OpStatus::OK, status);
 
-  return cmd_cntx->rb()->SendLong(result.load(memory_order_acquire));
+  return cmd_cntx->SendLong(result.load(memory_order_acquire));
 }
 
 void GenericFamily::Persist(CmdArgList args, CommandContext* cmd_cntx) {
@@ -1179,7 +1179,7 @@ void GenericFamily::Persist(CmdArgList args, CommandContext* cmd_cntx) {
   auto cb = [&](Transaction* t, EngineShard* shard) { return OpPersist(t->GetOpArgs(shard), key); };
 
   OpStatus status = cmd_cntx->tx->ScheduleSingleHop(std::move(cb));
-  cmd_cntx->rb()->SendLong(status == OpStatus::OK);
+  cmd_cntx->SendLong(status == OpStatus::OK);
 }
 
 void GenericFamily::Expire(CmdArgList args, CommandContext* cmd_cntx) {
@@ -1209,7 +1209,7 @@ void GenericFamily::Expire(CmdArgList args, CommandContext* cmd_cntx) {
   };
 
   OpStatus status = cmd_cntx->tx->ScheduleSingleHop(std::move(cb));
-  cmd_cntx->rb()->SendLong(status == OpStatus::OK);
+  cmd_cntx->SendLong(status == OpStatus::OK);
 }
 
 void GenericFamily::ExpireAt(CmdArgList args, CommandContext* cmd_cntx) {
@@ -1238,7 +1238,7 @@ void GenericFamily::ExpireAt(CmdArgList args, CommandContext* cmd_cntx) {
     return cmd_cntx->SendError(kExpiryOutOfRange);
   }
 
-  cmd_cntx->rb()->SendLong(status == OpStatus::OK);
+  cmd_cntx->SendLong(status == OpStatus::OK);
 }
 
 void GenericFamily::Keys(CmdArgList args, CommandContext* cmd_cntx) {
@@ -1289,7 +1289,7 @@ void GenericFamily::PexpireAt(CmdArgList args, CommandContext* cmd_cntx) {
   if (status == OpStatus::OUT_OF_RANGE) {
     return cmd_cntx->SendError(kExpiryOutOfRange);
   } else {
-    cmd_cntx->rb()->SendLong(status == OpStatus::OK);
+    cmd_cntx->SendLong(status == OpStatus::OK);
   }
 }
 
@@ -1323,7 +1323,7 @@ void GenericFamily::Pexpire(CmdArgList args, CommandContext* cmd_cntx) {
   if (status == OpStatus::OUT_OF_RANGE) {
     return cmd_cntx->SendError(kExpiryOutOfRange);
   }
-  cmd_cntx->rb()->SendLong(status == OpStatus::OK);
+  cmd_cntx->SendLong(status == OpStatus::OK);
 }
 
 void GenericFamily::Stick(CmdArgList args, CommandContext* cmd_cntx) {
@@ -1346,7 +1346,7 @@ void GenericFamily::Stick(CmdArgList args, CommandContext* cmd_cntx) {
   DVLOG(2) << "Stick ts " << transaction->txid();
 
   uint32_t match_cnt = result.load(memory_order_relaxed);
-  cmd_cntx->rb()->SendLong(match_cnt);
+  cmd_cntx->SendLong(match_cnt);
 }
 
 // Used to conditionally store double score
@@ -1694,7 +1694,7 @@ void GenericFamily::FieldTtl(CmdArgList args, CommandContext* cmd_cntx) {
   OpResult<long> result = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
 
   if (result) {
-    cmd_cntx->rb()->SendLong(*result);
+    cmd_cntx->SendLong(*result);
     return;
   }
 

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -599,7 +599,7 @@ struct HSetReplies {
     switch (result.status()) {
       case OpStatus::OK:
       case OpStatus::KEY_NOTFOUND:
-        return cmd_cntx->rb()->SendLong(result.value_or(0));
+        return cmd_cntx->SendLong(result.value_or(0));
       default:
         return cmd_cntx->SendError(result.status());
     };
@@ -743,7 +743,7 @@ void CmdHIncrBy(CmdArgList args, CommandContext* cmd_cntx) {
   OpStatus status = cmd_cntx->tx->ScheduleSingleHop(std::move(cb));
 
   if (status == OpStatus::OK) {
-    cmd_cntx->rb()->SendLong(get<int64_t>(param));
+    cmd_cntx->SendLong(get<int64_t>(param));
   } else {
     switch (status) {
       case OpStatus::INVALID_VALUE:

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -804,7 +804,7 @@ void PushGeneric(ListDir dir, bool skip_notexists, CmdArgList args, CommandConte
 
   OpResult<uint32_t> result = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
   if (result) {
-    return cmd_cntx->rb()->SendLong(result.value());
+    return cmd_cntx->SendLong(result.value());
   }
 
   return cmd_cntx->SendError(result.status());
@@ -1074,9 +1074,9 @@ void CmdLLen(CmdArgList args, CommandContext* cmd_cntx) {
   auto cb = [&](Transaction* t, EngineShard* shard) { return OpLen(t->GetOpArgs(shard), key); };
   OpResult<uint32_t> result = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
   if (result) {
-    cmd_cntx->rb()->SendLong(result.value());
+    cmd_cntx->SendLong(result.value());
   } else if (result.status() == OpStatus::KEY_NOTFOUND) {
-    cmd_cntx->rb()->SendLong(0);
+    cmd_cntx->SendLong(0);
   } else {
     cmd_cntx->SendError(result.status());
   }
@@ -1251,7 +1251,7 @@ void CmdLRem(CmdArgList args, CommandContext* cmd_cntx) {
   };
   OpResult<uint32_t> result = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
   if (result || result == OpStatus::KEY_NOTFOUND) {
-    return cmd_cntx->rb()->SendLong(result.value_or(0));
+    return cmd_cntx->SendLong(result.value_or(0));
   }
   cmd_cntx->SendError(result.status());
 }

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2588,7 +2588,7 @@ void Service::Publish(CmdArgList args, CommandContext* cmd_cntx) {
   string_view messages[] = {ArgS(args, 1)};
 
   auto* cs = ServerState::tlocal()->channel_store();
-  cmd_cntx->rb()->SendLong(cs->SendMessages(channel, messages, sharded));
+  cmd_cntx->SendLong(cs->SendMessages(channel, messages, sharded));
 }
 
 void Service::Subscribe(CmdArgList args, CommandContext* cmd_cntx) {

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -1904,9 +1904,9 @@ void DestroyGroup(facade::CmdArgParser* parser, CommandContext* cmd_cntx) {
   OpStatus result = cmd_cntx->tx->ScheduleSingleHop(std::move(cb));
   switch (result) {
     case OpStatus::OK:
-      return cmd_cntx->rb()->SendLong(1);
+      return cmd_cntx->SendLong(1);
     case OpStatus::SKIPPED:
-      return cmd_cntx->rb()->SendLong(0);
+      return cmd_cntx->SendLong(0);
     case OpStatus::KEY_NOTFOUND:
       return cmd_cntx->SendError(kXGroupKeyNotFound);
     default:
@@ -1930,9 +1930,9 @@ void CreateConsumer(facade::CmdArgParser* parser, CommandContext* cmd_cntx) {
 
   switch (result.status()) {
     case OpStatus::OK:
-      return cmd_cntx->rb()->SendLong(1);
+      return cmd_cntx->SendLong(1);
     case OpStatus::KEY_EXISTS:
-      return cmd_cntx->rb()->SendLong(0);
+      return cmd_cntx->SendLong(0);
     case OpStatus::SKIPPED:
       return cmd_cntx->SendError(NoGroupError(key, gname));
     case OpStatus::KEY_NOTFOUND:
@@ -1959,7 +1959,7 @@ void DelConsumer(facade::CmdArgParser* parser, CommandContext* cmd_cntx) {
 
   switch (result.status()) {
     case OpStatus::OK:
-      return cmd_cntx->rb()->SendLong(*result);
+      return cmd_cntx->SendLong(*result);
     case OpStatus::SKIPPED:
       return cmd_cntx->SendError(NoGroupError(key, gname));
     case OpStatus::KEY_NOTFOUND:
@@ -2847,7 +2847,7 @@ void CmdXDel(CmdArgList args, CommandContext* cmd_cntx) {
 
   OpResult<uint32_t> result = cmd_cntx->tx->ScheduleSingleHopT(cb);
   if (result || result.status() == OpStatus::KEY_NOTFOUND) {
-    return cmd_cntx->rb()->SendLong(*result);
+    return cmd_cntx->SendLong(*result);
   }
 
   cmd_cntx->SendError(result.status());
@@ -3128,7 +3128,7 @@ void CmdXLen(CmdArgList args, CommandContext* cmd_cntx) {
 
   OpResult<uint32_t> result = cmd_cntx->tx->ScheduleSingleHopT(cb);
   if (result || result.status() == OpStatus::KEY_NOTFOUND) {
-    return cmd_cntx->rb()->SendLong(*result);
+    return cmd_cntx->SendLong(*result);
   }
 
   return cmd_cntx->SendError(result.status());
@@ -3354,7 +3354,7 @@ void CmdXAck(CmdArgList args, CommandContext* cmd_cntx) {
 
   OpResult<uint32_t> result = cmd_cntx->tx->ScheduleSingleHopT(cb);
   if (result || result.status() == OpStatus::KEY_NOTFOUND) {
-    return cmd_cntx->rb()->SendLong(*result);
+    return cmd_cntx->SendLong(*result);
   }
 
   cmd_cntx->SendError(result.status());

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1711,7 +1711,7 @@ void ZRangeInternal(CmdArgList args, ZSetFamily::RangeParams range_params,
   }
   LOG_IF(WARNING, !add_result) << "Unexpected status " << add_result.status();
 
-  return cmd_cntx->rb()->SendLong(range_result->size());
+  return cmd_cntx->SendLong(range_result->size());
 }
 
 void ZRangeGeneric(CmdArgList args, ZSetFamily::RangeParams range_params,
@@ -1816,7 +1816,7 @@ void ZRemRangeGeneric(string_view key, const ZSetFamily::ZRangeSpec& range_spec,
   if (result.status() == OpStatus::WRONG_TYPE) {
     cmd_cntx->SendError(kWrongTypeErr);
   } else {
-    cmd_cntx->rb()->SendLong(*result);
+    cmd_cntx->SendLong(*result);
   }
 }
 
@@ -2211,7 +2211,7 @@ void CmdZCard(CmdArgList args, CommandContext* cmd_cntx) {
     return;
   }
 
-  cmd_cntx->rb()->SendLong(result.value());
+  cmd_cntx->SendLong(result.value());
 }
 
 void CmdZCount(CmdArgList args, CommandContext* cmd_cntx) {
@@ -2233,7 +2233,7 @@ void CmdZCount(CmdArgList args, CommandContext* cmd_cntx) {
   if (result.status() == OpStatus::WRONG_TYPE) {
     cmd_cntx->SendError(kWrongTypeErr);
   } else {
-    cmd_cntx->rb()->SendLong(*result);
+    cmd_cntx->SendLong(*result);
   }
 }
 
@@ -2599,7 +2599,7 @@ void CmdZLexCount(CmdArgList args, CommandContext* cmd_cntx) {
   if (result.status() == OpStatus::WRONG_TYPE) {
     cmd_cntx->SendError(kWrongTypeErr);
   } else {
-    cmd_cntx->rb()->SendLong(*result);
+    cmd_cntx->SendLong(*result);
   }
 }
 
@@ -2702,7 +2702,7 @@ void CmdZRem(CmdArgList args, CommandContext* cmd_cntx) {
   if (result.status() == OpStatus::WRONG_TYPE) {
     cmd_cntx->SendError(kWrongTypeErr);
   } else {
-    cmd_cntx->rb()->SendLong(*result);
+    cmd_cntx->SendLong(*result);
   }
 }
 

--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -320,7 +320,8 @@ def memcached_client(df_server: DflyInstance):
 
     yield client
 
-    client.flush_all()
+    client.flush_all()  # clean up after test
+    client.quit()
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
1. Replace SendLong everywhere to use CommandContext directly
2. Replace all the ReplyBuilder direct calls in set_family.cc with CommandContext APIs.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->