### PR TITLE
chore: Refactor squashed command execution to avoid stub ConnectionContext

### DIFF
--- a/src/server/acl/acl_family.cc
+++ b/src/server/acl/acl_family.cc
@@ -585,7 +585,7 @@ void AclFamily::DryRun(CmdArgList args, CommandContext* cmd_cntx) {
 
   const auto& user = registry.find(username)->second;
   // Stub, used to mimic connection context for a user.
-  ConnectionContext stub(nullptr, nullptr);
+  ConnectionContext stub(nullptr, acl::UserCredentials{});
   stub.acl_commands = user.AclCommandsRef();
   // "mock" without an actual connection we can't know which db is active so we skip this check
   // for DryRun.

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -143,12 +143,6 @@ void CommandContext::RecordLatency(facade::ArgSlice tail_args) const {
   // TODO: we should probably discard more commands here,
   // not just the blocking ones
   const auto* conn = server_conn_cntx()->conn();
-  auto& conn_state = server_conn_cntx()->conn_state;
-  if (conn_state.squashing_info) {
-    // We run from the squashed transaction.
-    conn = conn_state.squashing_info->owner->conn();
-  }
-
   if (!(cid->opt_mask() & CO::BLOCKING) && conn != nullptr &&
       // Use SafeTLocal() to avoid accessing the wrong thread local instance
       ServerState::SafeTLocal()->ShouldLogSlowCmd(execution_time_usec)) {

--- a/src/server/common.cc
+++ b/src/server/common.cc
@@ -390,7 +390,7 @@ void ThreadLocalMutex::unlock() {
 BorrowedInterpreter::BorrowedInterpreter(Transaction* tx, ConnectionState* state) {
   // Ensure squashing ignores EVAL. We can't run on a stub context, because it doesn't have our
   // preborrowed interpreter (which can't be shared on multiple threads).
-  CHECK(!state->squashing_info);
+  CHECK(!tx->IsSquashedStub());
 
   if (auto borrowed = state->exec_info.preborrowed_interpreter; borrowed) {
     // Ensure a preborrowed interpreter is only set for an already running MULTI transaction.

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -68,28 +68,6 @@ ConnectionContext::ConnectionContext(facade::Connection* owner, acl::UserCredent
   acl_db_idx = cred.db;
 }
 
-ConnectionContext::ConnectionContext(const ConnectionContext* owner, Transaction* tx)
-    : facade::ConnectionContext(nullptr), transaction{tx} {
-  if (owner) {
-    acl_commands = owner->acl_commands;
-    keys = owner->keys;
-    pub_sub = owner->pub_sub;
-    skip_acl_validation = owner->skip_acl_validation;
-    acl_db_idx = owner->acl_db_idx;
-    ns = owner->ns;
-    if (owner->conn()) {
-      has_main_or_memcache_listener = owner->conn()->IsMainOrMemcache();
-    }
-  } else {
-    acl_commands = std::vector<uint64_t>(acl::NumberOfFamilies(), acl::NONE_COMMANDS);
-  }
-  if (tx) {  // If we have a carrier transaction, this context is used for squashing
-    DCHECK(owner);
-    conn_state.db_index = owner->conn_state.db_index;
-    conn_state.squashing_info = {owner};
-  }
-}
-
 void ConnectionContext::ChangeMonitor(bool start) {
   // This will either remove or register a new connection
   // at the "top level" thread --> ServerState context

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -274,7 +274,6 @@ struct ConnectionState {
   ExecInfo exec_info;
   ReplicationInfo replication_info;
 
-  std::optional<SquashingInfo> squashing_info;
   std::unique_ptr<ScriptInfo> script_info;
   std::unique_ptr<SubscribeInfo> subscribe_info;
   ClientTracking tracking_info_;
@@ -283,7 +282,6 @@ struct ConnectionState {
 class ConnectionContext : public facade::ConnectionContext {
  public:
   ConnectionContext(facade::Connection* owner, dfly::acl::UserCredentials cred);
-  ConnectionContext(const ConnectionContext* owner, Transaction* tx);
 
   struct DebugInfo {
     uint32_t shards_count = 0;

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -1596,8 +1596,8 @@ void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBat
 
   absl::InlinedVector<string_view, 5> args_view;
   facade::CapturingReplyBuilder crb;
-  ConnectionContext local_cntx{cntx_, stub_tx.get()};
   absl::InsecureBitGen gen;
+
   for (unsigned i = 0; i < batch.sz; ++i) {
     string key = StrCat(options.prefix, ":", batch.index[i]);
     uint32_t elements_left = options.elements;
@@ -1628,9 +1628,9 @@ void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBat
       auto args_span = absl::MakeSpan(args_view);
       stub_tx->MultiSwitchCmd(cid);
       crb.SetReplyMode(ReplyMode::NONE);
-      stub_tx->InitByArgs(cntx_->ns, local_cntx.conn_state.db_index, args_span);
+      stub_tx->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, args_span);
 
-      CommandContext cmnd_cntx{cid, stub_tx.get(), &crb, &local_cntx};
+      CommandContext cmnd_cntx{cid, stub_tx.get(), &crb, cntx_};
       sf_.service().InvokeCmd(args_span, &cmnd_cntx);
     }
 
@@ -1650,8 +1650,8 @@ void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBat
       auto args_span = absl::MakeSpan(args_view);
       crb.SetReplyMode(ReplyMode::NONE);
       stub_tx->MultiSwitchCmd(cid);
-      stub_tx->InitByArgs(cntx_->ns, local_cntx.conn_state.db_index, args_span);
-      CommandContext cmnd_cntx{cid, stub_tx.get(), &crb, &local_cntx};
+      stub_tx->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, args_span);
+      CommandContext cmnd_cntx{cid, stub_tx.get(), &crb, cntx_};
       sf_.service().InvokeCmd(args_span, &cmnd_cntx);
     }
   }

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1843,7 +1843,7 @@ void GenericFamily::Select(CmdArgList args, CommandContext* cmd_cntx) {
 
   // Only global/non-atomic multi transactions can change dbs safely,
   // locked-ahead transactions acquired keys ahead for a specific dbindex
-  if (auto* tx = cntx->transaction; tx && tx->IsMulti()) {
+  if (auto* tx = cmd_cntx->tx; tx && tx->IsMulti()) {
     if (tx->GetMultiMode() == Transaction::LOCK_AHEAD)
       return cmd_cntx->SendError("SELECT is not allowed in regular EXEC/EVAL");
   }

--- a/src/server/journal/executor.cc
+++ b/src/server/journal/executor.cc
@@ -32,7 +32,7 @@ template <typename... Ts> void BuildFromParts(cmn::BackedArguments* dest, Ts... 
 JournalExecutor::JournalExecutor(Service* service)
     : service_{service},
       reply_builder_{new facade::CapturingReplyBuilder{facade::ReplyMode::NONE}},
-      conn_context_{nullptr, nullptr} {
+      conn_context_{nullptr, acl::UserCredentials{}} {
   conn_context_.is_replicating = true;
   conn_context_.journal_emulated = true;
   conn_context_.skip_acl_validation = true;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -292,9 +292,6 @@ std::string MakeMonitorMessage(const ConnectionContext* cntx, const CommandId* c
                                CmdArgList tail_args) {
   std::string message = absl::StrCat(CreateMonitorTimestamp(), " [", cntx->conn_state.db_index);
 
-  if (cntx->conn_state.squashing_info)
-    cntx = cntx->conn_state.squashing_info->owner;
-
   string endpoint;
   if (cntx->conn_state.script_info) {
     endpoint = "lua";
@@ -1255,12 +1252,6 @@ optional<ErrorReply> CheckKeysDeclared(const ConnectionState::ScriptInfo& eval_i
 static optional<ErrorReply> VerifyConnectionAclStatus(const CommandId* cid,
                                                       const ConnectionContext* cntx,
                                                       string_view error_msg, ArgSlice tail_args) {
-  // If we are on a squashed context we need to use the owner, because the
-  // context we are operating on is a stub and the acl username is not copied
-  // See: MultiCommandSquasher::SquashedHopCb
-  if (cntx->conn_state.squashing_info)
-    cntx = cntx->conn_state.squashing_info->owner;
-
   if (!acl::IsUserAllowedToInvokeCommand(*cntx, *cid, tail_args)) {
     return ErrorReply(absl::StrCat("-NOPERM ", cntx->authed_username, " ", error_msg));
   }

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2841,8 +2841,9 @@ namespace {
 
 void LoadSearchCommandFromAux(Service* service, string&& def, string_view command_name,
                               string_view error_context) {
-  facade::CapturingReplyBuilder crb{};
-  ConnectionContext cntx{nullptr, nullptr};
+  facade::CapturingReplyBuilder crb;
+
+  ConnectionContext cntx{nullptr, acl::UserCredentials{}};
   cntx.is_replicating = true;
   cntx.journal_emulated = true;
   cntx.skip_acl_validation = true;

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -352,6 +352,10 @@ class Transaction {
   // Get keys multi transaction was initialized with, normalized and unique
   const absl::flat_hash_set<std::pair<ShardId, LockFp>>& GetMultiFps() const;
 
+  bool IsSquashedStub() const {
+    return multi_ && multi_->role == SQUASHED_STUB;
+  }
+
   uint32_t DEBUG_GetTxqPosInShard(ShardId sid) const {
     return shard_data_[SidToId(sid)].pq_pos;
   }


### PR DESCRIPTION
Removes the creation of a local ConnectionContext on the stack during squashed command execution (in MultiCommandSquasher and DebugCmd). This reduces stack usage and simplifies the logic by using the original connection context directly.

Consequently, special handling for squashed contexts (unwrapping squashing_info) in main_service.cc (for Monitor and ACL checks)
is no longer needed and has been removed. The assumption is that we do not update context from the commands we squash.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->