### PR TITLE
chore: Reused parsed messages for memcache workloads

### DIFF
--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -320,9 +320,6 @@ class Connection : public util::Connection {
   // Updates memory stats and pooling, must be called for all used messages
   void RecycleMessage(MessageHandle msg);
 
-  // Create new pipeline request, re-use from pool when possible.
-  PipelineMessagePtr FromArgs(const RespVec& args);
-
   ParserStatus ParseRedis(unsigned max_busy_cycles);
   ParserStatus ParseMemcache();
 
@@ -332,7 +329,7 @@ class Connection : public util::Connection {
   void ShrinkPipelinePool();
 
   // Returns non-null request ptr if pool has vacant entries.
-  PipelineMessagePtr GetFromPipelinePool();
+  PipelineMessagePtr GetFromPoolOrCreate();
 
   void HandleMigrateRequest();
   io::Result<size_t> HandleRecvSocket();

--- a/src/facade/ok_main.cc
+++ b/src/facade/ok_main.cc
@@ -21,6 +21,11 @@ namespace facade {
 
 namespace {
 
+struct CmdContext : public facade::ParsedCommand {
+  void ReuseInternal() final {
+  }
+};
+
 class OkService : public ServiceInterface {
  public:
   DispatchResult DispatchCommand(ParsedArgs args, ParsedCommand* cmd) final {
@@ -52,6 +57,10 @@ class OkService : public ServiceInterface {
 
   ConnectionContext* CreateContext(Connection* owner) final {
     return new ConnectionContext{owner};
+  }
+
+  ParsedCommand* AllocateParsedCommand() final {
+    return new CmdContext{};
   }
 };
 

--- a/src/facade/parsed_command.cc
+++ b/src/facade/parsed_command.cc
@@ -57,6 +57,7 @@ void ParsedCommand::ResetForReuse() {
     storage_.clear();  // also deallocates the heap.
     offsets_.shrink_to_fit();
   }
+  ReuseInternal();
 }
 
 void ParsedCommand::SendError(std::string_view str, std::string_view type) {

--- a/src/facade/parsed_command.h
+++ b/src/facade/parsed_command.h
@@ -64,9 +64,14 @@ class ParsedCommand : public cmn::BackedArguments {
     conn_cntx_ = conn_cntx;
   }
 
-  void CreateMemcacheCommand() {
-    mc_cmd_ = std::make_unique<MemcacheParser::Command>();
-    mc_cmd_->backed_args = this;
+  // If true, creates mc specific fields, false - destroys them.
+  void ConfigureMCExtension(bool is_mc) {
+    if (is_mc && !mc_cmd_) {
+      mc_cmd_ = std::make_unique<MemcacheParser::Command>();
+      mc_cmd_->backed_args = this;
+    } else if (!is_mc) {
+      mc_cmd_.reset();
+    }
   }
 
   SinkReplyBuilder* rb() const {
@@ -158,6 +163,9 @@ class ParsedCommand : public cmn::BackedArguments {
     // If the reply is already done, we can destroy it now.
     return (prev_state & ASYNC_REPLY_DONE) != 0;
   }
+
+ protected:
+  virtual void ReuseInternal() = 0;
 
  private:
   bool CheckDoneAndMarkHead();

--- a/src/facade/service_interface.h
+++ b/src/facade/service_interface.h
@@ -46,9 +46,7 @@ class ServiceInterface {
 
   virtual ConnectionContext* CreateContext(Connection* owner) = 0;
 
-  virtual ParsedCommand* AllocateParsedCommand() {
-    return new ParsedCommand();
-  }
+  virtual ParsedCommand* AllocateParsedCommand() = 0;
 
   virtual void ConfigureHttpHandlers(util::HttpListenerBase* base, bool is_privileged) {
   }

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -286,4 +286,11 @@ bool ConnectionState::ClientTracking::ShouldTrackKeys() const {
   return option_ == OPTIN ? match : !match;
 }
 
+void CommandContext::ReuseInternal() {
+  cid = nullptr;
+  tx = nullptr;
+  start_time_ns = 0;
+  exec_body_len = 0;
+}
+
 }  // namespace dfly

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -375,6 +375,9 @@ class CommandContext : public facade::ParsedCommand {
   facade::SinkReplyBuilder* SwapReplier(facade::SinkReplyBuilder* new_rb) {
     return std::exchange(rb_, new_rb);
   }
+
+ protected:
+  void ReuseInternal() final;
 };
 
 }  // namespace dfly

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1808,6 +1808,8 @@ void Service::DispatchMC(facade::ParsedCommand* parsed_cmd) {
   const auto& cmd = *parsed_cmd->mc_command();
   string_view value = cmd.value();
   auto* cntx = cmd_ctx->server_conn_cntx();
+  DCHECK(cntx->transaction == nullptr);
+
   char cmd_name[16];
   char ttl[absl::numbers_internal::kFastToBufferSize];
   char store_opt[32] = {0};

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -511,7 +511,7 @@ auto BaseFamilyTest::RunMC(MP::CmdType cmd_type, string_view key, MCArgs args) -
   TestConnWrapper* conn = AddFindConn(Protocol::MEMCACHE, GetId());
 
   CommandContext cmd_cntx{nullptr, nullptr, conn->builder(), conn->cmd_cntx()};
-  cmd_cntx.CreateMemcacheCommand();
+  cmd_cntx.ConfigureMCExtension(true);
   auto& cmd = *cmd_cntx.mc_command();
   cmd.type = cmd_type;
 
@@ -557,7 +557,7 @@ auto BaseFamilyTest::GetMC(MP::CmdType cmd_type, std::initializer_list<std::stri
   TestConnWrapper* conn = AddFindConn(Protocol::MEMCACHE, GetId());
 
   CommandContext cmd_cntx{nullptr, nullptr, conn->builder(), conn->cmd_cntx()};
-  cmd_cntx.CreateMemcacheCommand();
+  cmd_cntx.ConfigureMCExtension(true);
   auto& cmd = *cmd_cntx.mc_command();
   cmd.type = cmd_type;
   auto src = list.begin();


### PR DESCRIPTION
Also setup batch reply for multiple messages.
When running `./dfly_bench  -n 5000000 -p 11211 --nogreet --qps=0  -d 128 --key_maximum=20000000   --ratio=1:0  --pipeline=30 -c 3  -P memcache_text` I get:

1572K qps before the change, and 2168K qps after the change. It's still a bit worse (10% higher latency and 10% lower throughtput) than running the same benchmark with RESP SET protocol with dragonfly running `--experimental_io_loop_v2=false`.

`experimental_io_loop_v2` has a worse performance in general for both modes but it is a must for using async dispatching, as we can not block on Socket::Recv unconditionally.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->