### PR TITLE
fix: helm push issue

### DIFF
--- a/.github/workflows/docker-release2.yml
+++ b/.github/workflows/docker-release2.yml
@@ -278,6 +278,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v6
       with:
+        token: ${{ secrets.DRAGONFLY_TOKEN }}  # PAT to push to main
         fetch-depth: 0
 
     - name: Install helm
@@ -319,11 +320,10 @@ jobs:
         helm push dragonfly-${{ env.TAG_NAME }}.tgz oci://ghcr.io/${{ github.repository }}/helm
 
     - name: GitHub Push
-      uses: CasperWA/push-protected@v2
       if: env.IS_PRERELEASE != 'true'
-      with:
-        token: ${{ secrets.DRAGONFLY_TOKEN }}
-        branch: main
+      run: |
+        # Push directly using the authenticated origin
+        git push origin main
 
     - name: Discord notification
       env:


### PR DESCRIPTION
Helm chart action stopped pushing to main. This PR fixes this. Proof:
https://github.com/dragonflydb/dragonfly/actions/runs/20781587679/job/59680363019

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->