### PR TITLE
fix(search): support parenthesized star in FT.SEARCH queries

### DIFF
--- a/src/core/search/parser.y
+++ b/src/core/search/parser.y
@@ -81,7 +81,7 @@ double toDouble(string_view src);
 
 %token <std::string> DOUBLE "double"
 %token <std::string> UINT32 "uint32"
-%nterm <AstExpr> final_query filter search_expr search_unary_expr search_or_expr search_and_expr bracket_filter_expr
+%nterm <AstExpr> final_query filter star_expr search_expr search_unary_expr search_or_expr search_and_expr bracket_filter_expr
 %nterm <AstExpr> field_cond field_cond_expr field_unary_expr field_or_expr field_and_expr tag_list
 %nterm <AstTagsNode::TagValueProxy> tag_list_element
 
@@ -129,7 +129,11 @@ opt_ef_runtime:
 
 filter:
   search_expr               { $$ = std::move($1); }
-  | STAR                    { $$ = AstStarNode(); }
+  | star_expr               { $$ = std::move($1); }
+
+star_expr:
+  STAR                      { $$ = AstStarNode(); }
+  | LPAREN star_expr RPAREN { $$ = std::move($2); }
 
 search_expr:
   search_unary_expr         { $$ = std::move($1); }

--- a/src/core/search/search_parser_test.cc
+++ b/src/core/search/search_parser_test.cc
@@ -240,6 +240,11 @@ TEST_F(SearchParserTest, Parse) {
 
   EXPECT_EQ(0, Parse("@name:{escape\\-err*}"));
 
+  // Parenthesized star - used by LangChain for KNN queries (issue #6342)
+  EXPECT_EQ(0, Parse("(*)"));
+  EXPECT_EQ(0, Parse("((*))"));
+  EXPECT_EQ(0, Parse("(((*)))"));
+
   // Colon in tag value
   EXPECT_EQ(0, Parse("@t:{Tag:value}"));
   EXPECT_EQ(0, Parse("@t:{Tag:*}"));

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -1844,6 +1844,16 @@ TEST_F(SearchFamilyTest, KnnSearchOptions) {
   resp = Run({"FT.SEARCH", "my_index", "*=>[KNN 1 @vector $query_vector]", "PARAMS", "2",
               "query_vector", query_vector, "LIMIT", "0", "2"});
   EXPECT_THAT(resp, AreDocIds("doc:1"));
+
+  // Parenthesized star - used by LangChain for KNN queries (issue #6342)
+  resp = Run({"FT.SEARCH", "my_index", "(*)=>[KNN 2 @vector $query_vector]", "PARAMS", "2",
+              "query_vector", query_vector});
+  EXPECT_THAT(resp, AreDocIds("doc:1", "doc:2"));
+
+  // Double parenthesized star
+  resp = Run({"FT.SEARCH", "my_index", "((*))=>[KNN 2 @vector $query_vector]", "PARAMS", "2",
+              "query_vector", query_vector});
+  EXPECT_THAT(resp, AreDocIds("doc:1", "doc:2"));
 }
 
 TEST_F(SearchFamilyTest, KnnWithSortBy) {


### PR DESCRIPTION
Add support for `(*)` and nested parentheses around `*` in FT.SEARCH queries.
KNN queries like `(*)=>[KNN 3 @vector $vec]` now work, which previously failed with a syntax error.
Added recursive `star_expr` grammar rule to handle any nesting level.

Fixes #6342