### PR TITLE
facade: adopt RespSrvParser in server connections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@
 - **Summary**: 1-2 sentences explaining *what* changed and *why*.
 - **Changes**: Bullet points for key changes.
 - **Fixes**: Link issues (e.g., "Fixes #123").
+- **Commit messages**: Keep every line (subject and body) <= 100 characters; wrap long descriptions.
 ---
 
 ### GitHub Copilot

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -18,7 +18,6 @@
 #include "facade/connection_ref.h"
 #include "facade/facade_types.h"
 #include "facade/parsed_command.h"
-#include "facade/resp_expr.h"
 #include "io/io_buf.h"
 #include "util/connection.h"
 #include "util/fibers/fibers.h"
@@ -45,9 +44,9 @@ constexpr size_t kReqStorageSize = 120;
 namespace facade {
 
 class ConnectionContext;
-class RedisParser;
 class ServiceInterface;
 class SinkReplyBuilder;
+class RespSrvParser;
 
 // Connection represents an active connection for a client.
 //
@@ -398,7 +397,7 @@ class Connection : public util::Connection {
 
   util::FiberSocketBase::ProvidedBuffer recv_buf_;
   io::IoBuf io_buf_;  // used in io loop and parsers
-  std::unique_ptr<RedisParser> redis_parser_;
+  std::unique_ptr<RespSrvParser> redis_parser_;
   std::unique_ptr<MemcacheParser> memcache_parser_;
   ParsedCommand* parsed_cmd_ = nullptr;
 
@@ -452,10 +451,6 @@ class Connection : public util::Connection {
   unsigned parser_error_ = 0;
 
   BreakerCb breaker_cb_;
-
-  // Used by redis parser to avoid allocations
-  RespVec tmp_parse_args_;
-  CmdArgVec tmp_cmd_vec_;
 
   // Used to keep track of borrowed references. Does not really own itself
   std::shared_ptr<Connection> self_;


### PR DESCRIPTION
Switch Connection to RespSrvParser so parsed commands stay in-place, drop the temporary RespVec allocations, and feed BackedArguments into the traffic logger. This removes redundant string conversions and prepares the pipeline for using the RESP service parser throughout the server stack.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->