### PR TITLE
fix(set): SPOP random member even if it contains null bytes

### DIFF
--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -279,8 +279,10 @@ StringVec RandMemberStrSetPicky(StringSet* strset, size_t count) {
   picks.reserve(count);
 
   size_t tries = 0;
-  while (picks.size() < count && tries++ < count * 2)
-    picks.insert(picks.end(), string{*strset->GetRandomMember()});
+  while (picks.size() < count && tries++ < count * 2) {
+    auto member = *strset->GetRandomMember();
+    picks.insert(picks.end(), {member, sdslen(member)});
+  }
 
   if constexpr (is_same_v<StringVec, C>)
     return picks;

--- a/tests/dragonfly/set_test.py
+++ b/tests/dragonfly/set_test.py
@@ -23,3 +23,23 @@ async def test_sscan_regression(df_factory: DflyInstanceFactory):
     # Takes 3 seconds
     res = await client.execute_command("SLOWLOG GET 100")
     assert res == []
+
+
+@pytest.mark.asyncio
+async def test_spop_with_null_byte_members(df_factory: DflyInstanceFactory):
+    df = df_factory.create(proactor_threads=1)
+
+    df.start()
+
+    client = df.client()
+
+    num_members = 10
+
+    for i in range(num_members):
+        await client.sadd("set", "b'MEMBER\x01\x02\x00_KEY{i}'".format(i=i))
+
+    assert await client.scard("set") == num_members
+
+    await client.spop("set")
+
+    assert await client.scard("set") == num_members - 1


### PR DESCRIPTION
If member contains null bytes we will not read complete member identifier and it will not be removed from set.

Fixes #6355

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->