### PR TITLE
chore: encapsulate tx object within CommandContext

### DIFF
--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -552,7 +552,7 @@ void BitPos(CmdArgList args, CommandContext* cmd_cntx) {
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return FindFirstBitWithValue(t->GetOpArgs(shard), key, value, start, end, as_bit);
   };
-  OpResult<int64_t> res = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
+  OpResult<int64_t> res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
   HandleOpValueResult(res, builder);
 }
 
@@ -579,7 +579,7 @@ void BitCount(CmdArgList args, CommandContext* cmd_cntx) {
   auto cb = [&, start_end](Transaction* t, EngineShard* shard) {
     return CountBitsForValue(t->GetOpArgs(shard), key, start_end.first, start_end.second, as_bit);
   };
-  OpResult<std::size_t> res = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
+  OpResult<std::size_t> res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
   HandleOpValueResult(res, cmd_cntx->rb());
 }
 
@@ -1131,11 +1131,11 @@ void BitFieldGeneric(CmdArgList args, bool read_only, Transaction* tx, SinkReply
 }
 
 void BitField(CmdArgList args, CommandContext* cmd_cntx) {
-  BitFieldGeneric(args, false, cmd_cntx->tx, cmd_cntx->rb());
+  BitFieldGeneric(args, false, cmd_cntx->tx(), cmd_cntx->rb());
 }
 
 void BitFieldRo(CmdArgList args, CommandContext* cmd_cntx) {
-  BitFieldGeneric(args, true, cmd_cntx->tx, cmd_cntx->rb());
+  BitFieldGeneric(args, true, cmd_cntx->tx(), cmd_cntx->rb());
 }
 
 #ifndef __clang__
@@ -1175,12 +1175,12 @@ void BitOp(CmdArgList args, CommandContext* cmd_cntx) {
     return OpStatus::OK;
   };
 
-  cmd_cntx->tx->Execute(std::move(shard_bitop), false);  // we still have more work to do
+  cmd_cntx->tx()->Execute(std::move(shard_bitop), false);  // we still have more work to do
   // All result from each shard
   const auto joined_results = CombineResultOp(result_set, op);
   // Second phase - save to target key if successful
   if (!joined_results) {
-    cmd_cntx->tx->Conclude();
+    cmd_cntx->tx()->Conclude();
     cmd_cntx->SendError(joined_results.status());
     return;
   } else {
@@ -1211,7 +1211,7 @@ void BitOp(CmdArgList args, CommandContext* cmd_cntx) {
       return OpStatus::OK;
     };
 
-    cmd_cntx->tx->Execute(std::move(store_cb), true);
+    cmd_cntx->tx()->Execute(std::move(store_cb), true);
     builder->SendLong(op_result.size());
   }
 }
@@ -1229,7 +1229,7 @@ void GetBit(CmdArgList args, CommandContext* cmd_cntx) {
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return ReadValueBitsetAt(t->GetOpArgs(shard), key, offset);
   };
-  OpResult<bool> res = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
+  OpResult<bool> res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
   HandleOpValueResult(res, cmd_cntx->rb());
 }
 
@@ -1248,7 +1248,7 @@ void SetBit(CmdArgList args, CommandContext* cmd_cntx) {
     return BitNewValue(t->GetOpArgs(shard), key, offset, value != 0);
   };
 
-  OpResult<bool> res = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
+  OpResult<bool> res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
   HandleOpValueResult(res, cmd_cntx->rb());
 }
 

--- a/src/server/bloom_family.cc
+++ b/src/server/bloom_family.cc
@@ -103,7 +103,7 @@ void CmdReserve(CmdArgList args, CommandContext* cmd_cntx) {
     return OpReserve(params, t->GetOpArgs(shard), key);
   };
 
-  OpStatus res = cmd_cntx->tx->ScheduleSingleHop(std::move(cb));
+  OpStatus res = cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));
   if (res == OpStatus::KEY_EXISTS) {
     return rb->SendError("item exists");
   }
@@ -118,7 +118,7 @@ void CmdAdd(CmdArgList args, CommandContext* cmd_cntx) {
     return OpAdd(t->GetOpArgs(shard), key, args);
   };
 
-  OpResult res = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
+  OpResult res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
   OpStatus status = res.status();
   if (res) {
     if (res->front())
@@ -137,7 +137,7 @@ void CmdExists(CmdArgList args, CommandContext* cmd_cntx) {
     return OpExists(t->GetOpArgs(shard), key, args);
   };
 
-  OpResult res = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
+  OpResult res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
   return cmd_cntx->SendLong(res ? res->front() : 0);
 }
 
@@ -150,7 +150,7 @@ void CmdMAdd(CmdArgList args, CommandContext* cmd_cntx) {
   };
 
   RedisReplyBuilder* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
-  OpResult res = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
+  OpResult res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
   if (!res) {
     return rb->SendError(res.status());
   }
@@ -174,7 +174,7 @@ void CmdMExists(CmdArgList args, CommandContext* cmd_cntx) {
     return OpExists(t->GetOpArgs(shard), key, args);
   };
 
-  OpResult res = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
+  OpResult res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
 
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   RedisReplyBuilder::ArrayScope scope{rb, args.size()};

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -266,7 +266,7 @@ bool ConnectionState::ClientTracking::ShouldTrackKeys() const {
 
 void CommandContext::ReuseInternal() {
   cid = nullptr;
-  tx = nullptr;
+  tx_ = nullptr;
   start_time_ns = 0;
   exec_body_len = 0;
 }

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -344,8 +344,13 @@ class CommandContext : public facade::ParsedCommand {
 
   CommandContext(const CommandId* _cid, Transaction* _tx, facade::SinkReplyBuilder* rb,
                  ConnectionContext* cntx)
-      : cid(_cid), tx(_tx) {
+      : cid(_cid), tx_(_tx) {
     Init(rb, cntx);
+  }
+
+  void SetupTx(const CommandId* _cid, Transaction* tx) {
+    cid = _cid;
+    tx_ = tx;
   }
 
   virtual size_t GetSize() const override {
@@ -353,7 +358,6 @@ class CommandContext : public facade::ParsedCommand {
   }
 
   const CommandId* cid = nullptr;
-  Transaction* tx = nullptr;
 
   uint64_t start_time_ns = 0;
 
@@ -374,8 +378,13 @@ class CommandContext : public facade::ParsedCommand {
     return std::exchange(rb_, new_rb);
   }
 
+  Transaction* tx() const {
+    return tx_;
+  }
+
  protected:
   void ReuseInternal() final;
+  Transaction* tx_ = nullptr;
 };
 
 }  // namespace dfly

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -596,7 +596,7 @@ DebugCmd::DebugCmd(ServerFamily* owner, cluster::ClusterFamily* cf, ConnectionCo
     : sf_(*owner), cf_(*cf), cntx_(cntx) {
 }
 
-void DebugCmd::Run(CmdArgList args, CommandContext* cmnd_cntx) {
+void DebugCmd::Run(CmdArgList args, CommandContext* cmd_cntx) {
   string subcmd = absl::AsciiStrToUpper(ArgS(args, 0));
   if (subcmd == "HELP") {
     string_view help_arr[] = {
@@ -672,89 +672,89 @@ void DebugCmd::Run(CmdArgList args, CommandContext* cmnd_cntx) {
         "HELP",
         "    Prints this help.",
     };
-    auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+    auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
     return rb->SendSimpleStrArr(help_arr);
   }
 
   VLOG(1) << "subcmd " << subcmd;
 
   if (subcmd == "POPULATE") {
-    return Populate(args, cmnd_cntx);
+    return Populate(args, cmd_cntx);
   }
 
   if (subcmd == "RELOAD") {
-    return Reload(args, cmnd_cntx);
+    return Reload(args, cmd_cntx);
   }
 
   if (subcmd == "REPLICA" && args.size() == 2) {
-    return Replica(args, cmnd_cntx);
+    return Replica(args, cmd_cntx);
   }
 
   if (subcmd == "MIGRATION" && args.size() == 2) {
-    return Migration(args, cmnd_cntx);
+    return Migration(args, cmd_cntx);
   }
 
   if (subcmd == "WATCHED") {
-    return Watched(cmnd_cntx);
+    return Watched(cmd_cntx);
   }
 
   if (subcmd == "OBJECT" && args.size() >= 2) {
     string_view key = ArgS(args, 1);
     args.remove_prefix(2);
-    return Inspect(key, args, cmnd_cntx);
+    return Inspect(key, args, cmd_cntx);
   }
 
   if (subcmd == "TX") {
-    return TxAnalysis(cmnd_cntx);
+    return TxAnalysis(cmd_cntx);
   }
 
   if (subcmd == "OBJHIST") {
-    return ObjHist(cmnd_cntx);
+    return ObjHist(cmd_cntx);
   }
 
   if (subcmd == "STACKTRACE") {
-    return Stacktrace(cmnd_cntx);
+    return Stacktrace(cmd_cntx);
   }
 
   if (subcmd == "SHARDS") {
-    return Shards(cmnd_cntx);
+    return Shards(cmd_cntx);
   }
 
   if (subcmd == "EXEC") {
-    return Exec(cmnd_cntx);
+    return Exec(cmd_cntx);
   }
 
   if (subcmd == "TRAFFIC") {
-    return LogTraffic(args.subspan(1), cmnd_cntx);
+    return LogTraffic(args.subspan(1), cmd_cntx);
   }
 
   if (subcmd == "RECVSIZE" && args.size() == 2) {
-    return RecvSize(ArgS(args, 1), cmnd_cntx);
+    return RecvSize(ArgS(args, 1), cmd_cntx);
   }
 
   if (subcmd == "TOPK" && args.size() >= 2) {
-    return Topk(args.subspan(1), cmnd_cntx);
+    return Topk(args.subspan(1), cmd_cntx);
   }
 
   if (subcmd == "KEYS" && args.size() >= 2) {
-    return Keys(args.subspan(1), cmnd_cntx);
+    return Keys(args.subspan(1), cmd_cntx);
   }
 
   if (subcmd == "VALUES" && args.size() >= 2) {
-    return Values(args.subspan(1), cmnd_cntx);
+    return Values(args.subspan(1), cmd_cntx);
   }
   if (subcmd == "COMPRESSION") {
-    return Compression(args.subspan(1), cmnd_cntx);
+    return Compression(args.subspan(1), cmd_cntx);
   }
 
   if (subcmd == "IOSTATS") {
-    return IOStats(args.subspan(1), cmnd_cntx);
+    return IOStats(args.subspan(1), cmd_cntx);
   }
   if (subcmd == "SEGMENTS") {
-    return Segments(args.subspan(1), cmnd_cntx);
+    return Segments(args.subspan(1), cmd_cntx);
   }
   string reply = UnknownSubCmd(subcmd, "DEBUG");
-  return cmnd_cntx->SendError(reply, kSyntaxErrType);
+  return cmd_cntx->SendError(reply, kSyntaxErrType);
 }
 
 void DebugCmd::Shutdown() {
@@ -762,10 +762,10 @@ void DebugCmd::Shutdown() {
   shard_set->pool()->AwaitFiberOnAll([](auto*) { facade::Connection::StopTrafficLogging(); });
 }
 
-void DebugCmd::Reload(CmdArgList args, CommandContext* cmnd_cntx) {
+void DebugCmd::Reload(CmdArgList args, CommandContext* cmd_cntx) {
   bool save = true;
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   for (size_t i = 1; i < args.size(); ++i) {
     string opt = absl::AsciiStrToUpper(ArgS(args, i));
     VLOG(1) << "opt " << opt;
@@ -773,7 +773,7 @@ void DebugCmd::Reload(CmdArgList args, CommandContext* cmnd_cntx) {
     if (opt == "NOSAVE") {
       save = false;
     } else {
-      return cmnd_cntx->SendError("DEBUG RELOAD only supports the NOSAVE options.");
+      return cmd_cntx->SendError("DEBUG RELOAD only supports the NOSAVE options.");
     }
   }
 
@@ -783,7 +783,7 @@ void DebugCmd::Reload(CmdArgList args, CommandContext* cmnd_cntx) {
 
     GenericError ec = sf_.DoSave();
     if (ec) {
-      return cmnd_cntx->SendError(ec.Format());
+      return cmd_cntx->SendError(ec.Format());
     }
   }
 
@@ -796,19 +796,19 @@ void DebugCmd::Reload(CmdArgList args, CommandContext* cmnd_cntx) {
     if (ec) {
       string msg = ec.Format();
       LOG(WARNING) << "Could not load file " << msg;
-      return cmnd_cntx->SendError(msg);
+      return cmd_cntx->SendError(msg);
     }
   }
 
   rb->SendOk();
 }
 
-void DebugCmd::Replica(CmdArgList args, CommandContext* cmnd_cntx) {
+void DebugCmd::Replica(CmdArgList args, CommandContext* cmd_cntx) {
   args.remove_prefix(1);
 
   string opt = absl::AsciiStrToUpper(ArgS(args, 0));
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (opt == "PAUSE" || opt == "RESUME") {
     sf_.PauseReplication(opt == "PAUSE");
     return rb->SendOk();
@@ -823,22 +823,22 @@ void DebugCmd::Replica(CmdArgList args, CommandContext* cmnd_cntx) {
       }
       return;
     } else {
-      return cmnd_cntx->SendError("I am master");
+      return cmd_cntx->SendError("I am master");
     }
   }
-  return cmnd_cntx->SendError(UnknownSubCmd("replica", "DEBUG"));
+  return cmd_cntx->SendError(UnknownSubCmd("replica", "DEBUG"));
 }
 
-void DebugCmd::Migration(CmdArgList args, CommandContext* cmnd_cntx) {
+void DebugCmd::Migration(CmdArgList args, CommandContext* cmd_cntx) {
   args.remove_prefix(1);
 
   string opt = absl::AsciiStrToUpper(ArgS(args, 0));
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (opt == "PAUSE" || opt == "RESUME") {
     cf_.PauseAllIncomingMigrations(opt == "PAUSE");
     return rb->SendOk();
   }
-  return cmnd_cntx->SendError(UnknownSubCmd("MIGRATION", "DEBUG"));
+  return cmd_cntx->SendError(UnknownSubCmd("MIGRATION", "DEBUG"));
 }
 
 enum PopulateFlag { FLAG_RAND, FLAG_TYPE, FLAG_ELEMENTS, FLAG_SLOT, FLAG_EXPIRE, FLAG_UNKNOWN };
@@ -847,7 +847,7 @@ enum PopulateFlag { FLAG_RAND, FLAG_TYPE, FLAG_ELEMENTS, FLAG_SLOT, FLAG_EXPIRE,
 // required: (total count) (key prefix) (val size)
 // optional: [RAND | TYPE typename | ELEMENTS element num | SLOTS (key value)+ | EXPIRE start end]
 optional<DebugCmd::PopulateOptions> DebugCmd::ParsePopulateArgs(CmdArgList args,
-                                                                CommandContext* cmnd_cntx) {
+                                                                CommandContext* cmd_cntx) {
   CmdArgParser parser(args.subspan(1));
   PopulateOptions options;
 
@@ -875,7 +875,7 @@ optional<DebugCmd::PopulateOptions> DebugCmd::ParsePopulateArgs(CmdArgList args,
       case FLAG_EXPIRE: {
         auto [min_ttl, max_ttl] = parser.Next<uint32_t, uint32_t>();
         if (min_ttl >= max_ttl) {
-          cmnd_cntx->SendError(kExpiryOutOfRange);
+          cmd_cntx->SendError(kExpiryOutOfRange);
           (void)parser.TakeError();
           return nullopt;
         }
@@ -888,14 +888,14 @@ optional<DebugCmd::PopulateOptions> DebugCmd::ParsePopulateArgs(CmdArgList args,
     }
   }
   if (parser.HasError()) {
-    cmnd_cntx->SendError(parser.TakeError().MakeReply());
+    cmd_cntx->SendError(parser.TakeError().MakeReply());
     return nullopt;
   }
   return options;
 }
 
-void DebugCmd::Populate(CmdArgList args, CommandContext* cmnd_cntx) {
-  optional<PopulateOptions> options = ParsePopulateArgs(args, cmnd_cntx);
+void DebugCmd::Populate(CmdArgList args, CommandContext* cmd_cntx) {
+  optional<PopulateOptions> options = ParsePopulateArgs(args, cmd_cntx);
   if (!options.has_value()) {
     return;
   }
@@ -925,7 +925,7 @@ void DebugCmd::Populate(CmdArgList args, CommandContext* cmnd_cntx) {
   for (auto& fb : fb_arr)
     fb.Join();
 
-  cmnd_cntx->rb()->SendOk();
+  cmd_cntx->rb()->SendOk();
 
   DCHECK(sf_.AreAllReplicasInStableSync());
 }
@@ -996,7 +996,7 @@ void DebugCmd::PopulateRangeFiber(uint64_t from, uint64_t num_of_keys,
   });
 }
 
-void DebugCmd::Exec(CommandContext* cmnd_cntx) {
+void DebugCmd::Exec(CommandContext* cmd_cntx) {
   EngineShardSet& ess = *shard_set;
   fb2::Mutex mu;
   std::map<string, unsigned> freq_cnt;
@@ -1014,15 +1014,15 @@ void DebugCmd::Exec(CommandContext* cmnd_cntx) {
   }
   StrAppend(&res, "--------------------------\n");
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   rb->SendVerbatimString(res);
 }
 
-void DebugCmd::LogTraffic(CmdArgList args, CommandContext* cmnd_cntx) {
+void DebugCmd::LogTraffic(CmdArgList args, CommandContext* cmd_cntx) {
   optional<string> path;
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (ProactorBase::me()->GetKind() != ProactorBase::IOURING) {
-    return cmnd_cntx->SendError("Traffic recording supported only on iouring");
+    return cmd_cntx->SendError("Traffic recording supported only on iouring");
   }
 
   if (args.size() == 1 && absl::AsciiStrToUpper(facade::ToSV(args.front())) != "STOP"sv) {
@@ -1041,7 +1041,7 @@ void DebugCmd::LogTraffic(CmdArgList args, CommandContext* cmnd_cntx) {
   rb->SendOk();
 }
 
-void DebugCmd::Inspect(string_view key, CmdArgList args, CommandContext* cmnd_cntx) {
+void DebugCmd::Inspect(string_view key, CmdArgList args, CommandContext* cmd_cntx) {
   EngineShardSet& ess = *shard_set;
   ShardId sid = Shard(key, ess.size());
   VLOG(1) << "DebugCmd::Inspect " << key;
@@ -1051,12 +1051,12 @@ void DebugCmd::Inspect(string_view key, CmdArgList args, CommandContext* cmnd_cn
     check_compression = absl::AsciiStrToUpper(ArgS(args, 0)) == "COMPRESS";
   }
   string resp;
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (check_compression) {
     auto cb = [&] { return EstimateCompression(cntx_, key); };
     auto res = ess.Await(sid, std::move(cb));
     if (!res) {
-      cmnd_cntx->SendError(res.status());
+      cmd_cntx->SendError(res.status());
       return;
     }
     StrAppend(&resp, "raw_size: ", res->raw_size, ", compressed_size: ", res->compressed_size);
@@ -1069,7 +1069,7 @@ void DebugCmd::Inspect(string_view key, CmdArgList args, CommandContext* cmnd_cn
     ObjInfo res = ess.Await(sid, std::move(cb));
 
     if (!res.found) {
-      cmnd_cntx->SendError(kKeyNotFoundErr);
+      cmd_cntx->SendError(kKeyNotFoundErr);
       return;
     }
 
@@ -1102,7 +1102,7 @@ void DebugCmd::Inspect(string_view key, CmdArgList args, CommandContext* cmnd_cn
   rb->SendSimpleString(resp);
 }
 
-void DebugCmd::Watched(CommandContext* cmnd_cntx) {
+void DebugCmd::Watched(CommandContext* cmd_cntx) {
   fb2::Mutex mu;
 
   vector<string> watched_keys;
@@ -1121,7 +1121,7 @@ void DebugCmd::Watched(CommandContext* cmnd_cntx) {
     }
   };
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   shard_set->RunBlockingInParallel(cb);
   rb->StartArray(4);
   rb->SendBulkString("awaked");
@@ -1130,7 +1130,7 @@ void DebugCmd::Watched(CommandContext* cmnd_cntx) {
   rb->SendBulkStrArr(watched_keys);
 }
 
-void DebugCmd::TxAnalysis(CommandContext* cmnd_cntx) {
+void DebugCmd::TxAnalysis(CommandContext* cmd_cntx) {
   vector<EngineShard::TxQueueInfo> shard_info(shard_set->size());
 
   auto cb = [&](EngineShard* shard) {
@@ -1145,11 +1145,11 @@ void DebugCmd::TxAnalysis(CommandContext* cmnd_cntx) {
     const auto& info = shard_info[i];
     StrAppend(&result, "shard", i, ":\n", info.Format(), "\n");
   }
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   rb->SendVerbatimString(result);
 }
 
-void DebugCmd::ObjHist(CommandContext* cmnd_cntx) {
+void DebugCmd::ObjHist(CommandContext* cmd_cntx) {
   vector<ObjHistMap> obj_hist_map_arr(shard_set->size());
   auto cb = [&obj_hist_map_arr](PrimeIterator it) {
     unsigned obj_type = it->second.ObjType();
@@ -1184,12 +1184,12 @@ void DebugCmd::ObjHist(CommandContext* cmnd_cntx) {
   }
 
   absl::StrAppend(&result, "___end object histogram___\n");
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   rb->SendVerbatimString(result);
 }
 
-void DebugCmd::Stacktrace(CommandContext* cmnd_cntx) {
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+void DebugCmd::Stacktrace(CommandContext* cmd_cntx) {
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   fb2::Mutex m;
   shard_set->pool()->AwaitFiberOnAll([&m](unsigned index, ProactorBase* base) {
     EngineShard* es = EngineShard::tlocal();
@@ -1206,7 +1206,7 @@ void DebugCmd::Stacktrace(CommandContext* cmnd_cntx) {
   rb->SendOk();
 }
 
-void DebugCmd::Shards(CommandContext* cmnd_cntx) {
+void DebugCmd::Shards(CommandContext* cmd_cntx) {
   struct ShardInfo {
     uint64_t used_memory = 0;
     uint64_t key_count = 0;
@@ -1263,12 +1263,12 @@ void DebugCmd::Shards(CommandContext* cmnd_cntx) {
 
 #undef ADD_STAT
 #undef MAXMIN_STAT
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   rb->SendVerbatimString(out);
 }
 
-void DebugCmd::RecvSize(string_view param, CommandContext* cmnd_cntx) {
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+void DebugCmd::RecvSize(string_view param, CommandContext* cmd_cntx) {
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   uint8_t enable = 2;
   if (absl::EqualsIgnoreCase(param, "ENABLE"))
     enable = 1;
@@ -1283,7 +1283,7 @@ void DebugCmd::RecvSize(string_view param, CommandContext* cmnd_cntx) {
 
   unsigned tid;
   if (!absl::SimpleAtoi(param, &tid) || tid >= shard_set->pool()->size()) {
-    return cmnd_cntx->SendError(kUintErr);
+    return cmd_cntx->SendError(kUintErr);
   }
 
   string hist;
@@ -1292,8 +1292,8 @@ void DebugCmd::RecvSize(string_view param, CommandContext* cmnd_cntx) {
   rb->SendVerbatimString(hist);
 }
 
-void DebugCmd::Topk(CmdArgList args, CommandContext* cmnd_cntx) {
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+void DebugCmd::Topk(CmdArgList args, CommandContext* cmd_cntx) {
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   DCHECK_GE(args.size(), 1u);
 
   string_view subcmd = ArgS(args, 0);
@@ -1301,7 +1301,7 @@ void DebugCmd::Topk(CmdArgList args, CommandContext* cmnd_cntx) {
     uint32_t min_freq = 100;
     if (args.size() > 1) {
       if (!absl::SimpleAtoi(ArgS(args, 1), &min_freq))
-        return cmnd_cntx->SendError(kUintErr);
+        return cmd_cntx->SendError(kUintErr);
     }
     shard_set->RunBriefInParallel([&](EngineShard* es) {
       cntx_->ns->GetDbSlice(es->shard_id()).StartSampleTopK(cntx_->db_index(), min_freq);
@@ -1315,7 +1315,7 @@ void DebugCmd::Topk(CmdArgList args, CommandContext* cmnd_cntx) {
 
     if (args.size() > 1) {
       if (!absl::SimpleAtoi(ArgS(args, 1), &max_keys))
-        return cmnd_cntx->SendError(kUintErr);
+        return cmd_cntx->SendError(kUintErr);
     }
 
     shard_set->RunBriefInParallel([&](EngineShard* es) {
@@ -1346,12 +1346,12 @@ void DebugCmd::Topk(CmdArgList args, CommandContext* cmnd_cntx) {
     return;
   }
 
-  return cmnd_cntx->SendError(kSyntaxErr);
+  return cmd_cntx->SendError(kSyntaxErr);
 }
 
-void DebugCmd::Keys(CmdArgList args, CommandContext* cmnd_cntx) {
+void DebugCmd::Keys(CmdArgList args, CommandContext* cmd_cntx) {
   string_view subcmd = ArgS(args, 0);
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (absl::EqualsIgnoreCase(subcmd, "ON")) {
     shard_set->RunBriefInParallel([&](EngineShard* es) {
       cntx_->ns->GetDbSlice(es->shard_id()).StartSampleKeys(cntx_->db_index());
@@ -1372,12 +1372,12 @@ void DebugCmd::Keys(CmdArgList args, CommandContext* cmnd_cntx) {
     return rb->SendLongArr(absl::MakeConstSpan(arr));
   }
 
-  return cmnd_cntx->SendError(kSyntaxErr);
+  return cmd_cntx->SendError(kSyntaxErr);
 }
 
-void DebugCmd::Values(CmdArgList args, CommandContext* cmnd_cntx) {
+void DebugCmd::Values(CmdArgList args, CommandContext* cmd_cntx) {
   string_view subcmd = ArgS(args, 0);
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (absl::EqualsIgnoreCase(subcmd, "ON")) {
     shard_set->RunBriefInParallel([&](EngineShard* es) {
       cntx_->ns->GetDbSlice(es->shard_id()).StartSampleValues(cntx_->db_index());
@@ -1401,7 +1401,7 @@ void DebugCmd::Values(CmdArgList args, CommandContext* cmnd_cntx) {
     return rb->SendVerbatimString(merged_histogram.ToString());
   }
 
-  return cmnd_cntx->SendError(kSyntaxErr);
+  return cmd_cntx->SendError(kSyntaxErr);
 }
 
 static size_t PostProcessHist(HufHist* dest) {
@@ -1432,13 +1432,13 @@ static size_t PostProcessHist(HufHist* dest) {
   return total_freq;
 }
 
-void DebugCmd::Compression(CmdArgList args, CommandContext* cmnd_cntx) {
+void DebugCmd::Compression(CmdArgList args, CommandContext* cmd_cntx) {
   CompactObjType type = kInvalidCompactObjType;
   CmdArgParser parser(args);
   string bintable;
   bool print_bintable = false;
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (parser.Check("SET", &bintable)) {
     // SET <bintable> [type]
     string raw;
@@ -1449,7 +1449,7 @@ void DebugCmd::Compression(CmdArgList args, CommandContext* cmnd_cntx) {
         string_view type_str = parser.Next();
         type = ObjTypeFromString(type_str);
         if (type != OBJ_STRING) {  // Currently only string type is supported.
-          return cmnd_cntx->SendError(kSyntaxErr);
+          return cmd_cntx->SendError(kSyntaxErr);
         }
         domain = CompactObj::HUFF_STRING_VALUES;
       }
@@ -1459,7 +1459,7 @@ void DebugCmd::Compression(CmdArgList args, CommandContext* cmnd_cntx) {
         }
       });
     }
-    return succeed ? rb->SendOk() : cmnd_cntx->SendError("Failed to set bintable");
+    return succeed ? rb->SendOk() : cmd_cntx->SendError("Failed to set bintable");
   }
 
   if (parser.Check("EXPORT")) {
@@ -1476,11 +1476,11 @@ void DebugCmd::Compression(CmdArgList args, CommandContext* cmnd_cntx) {
     string_view type_str = parser.Next();
     type = ObjTypeFromString(type_str);
     if (type == kInvalidCompactObjType) {
-      return cmnd_cntx->SendError(kSyntaxErr);
+      return cmd_cntx->SendError(kSyntaxErr);
     }
   }
 
-  RETURN_ON_PARSE_ERROR(parser, cmnd_cntx);
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   fb2::Mutex mu;
   HufHist hist;
@@ -1500,12 +1500,12 @@ void DebugCmd::Compression(CmdArgList args, CommandContext* cmnd_cntx) {
 
     if (bintable.empty()) {
       if (!huff_enc.Build(hist.hist.data(), HufHist::kMaxSymbol, &err_msg)) {
-        return cmnd_cntx->SendError(StrCat("Internal error: ", err_msg));
+        return cmd_cntx->SendError(StrCat("Internal error: ", err_msg));
       }
     } else {
       // Try to read the bintable and create a ctable from it.
       if (!huff_enc.Load(bintable, &err_msg)) {
-        return cmnd_cntx->SendError(StrCat("Internal error: ", err_msg));
+        return cmd_cntx->SendError(StrCat("Internal error: ", err_msg));
       }
     }
     num_bits = huff_enc.num_bits();
@@ -1539,8 +1539,8 @@ void DebugCmd::Compression(CmdArgList args, CommandContext* cmnd_cntx) {
   }
 }
 
-void DebugCmd::IOStats(CmdArgList args, CommandContext* cmnd_cntx) {
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+void DebugCmd::IOStats(CmdArgList args, CommandContext* cmd_cntx) {
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
   bool per_second = !args.empty() && absl::EqualsIgnoreCase(args[0], "PS");
   vector<IOStat> stats(shard_set->pool()->size());
@@ -1566,8 +1566,8 @@ void DebugCmd::IOStats(CmdArgList args, CommandContext* cmnd_cntx) {
   }
 }
 
-void DebugCmd::Segments(CmdArgList args, CommandContext* cmnd_cntx) {
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+void DebugCmd::Segments(CmdArgList args, CommandContext* cmd_cntx) {
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   vector<SegmentInfo> info(shard_set->size());
 
   shard_set->RunBlockingInParallel([&](EngineShard* shard) {
@@ -1630,8 +1630,8 @@ void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBat
       crb.SetReplyMode(ReplyMode::NONE);
       stub_tx->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, args_span);
 
-      CommandContext cmnd_cntx{cid, stub_tx.get(), &crb, cntx_};
-      sf_.service().InvokeCmd(args_span, &cmnd_cntx);
+      CommandContext cmd_cntx{cid, stub_tx.get(), &crb, cntx_};
+      sf_.service().InvokeCmd(args_span, &cmd_cntx);
     }
 
     if (options.expire_ttl_range.has_value()) {
@@ -1651,8 +1651,8 @@ void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBat
       crb.SetReplyMode(ReplyMode::NONE);
       stub_tx->MultiSwitchCmd(cid);
       stub_tx->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, args_span);
-      CommandContext cmnd_cntx{cid, stub_tx.get(), &crb, cntx_};
-      sf_.service().InvokeCmd(args_span, &cmnd_cntx);
+      CommandContext cmd_cntx{cid, stub_tx.get(), &crb, cntx_};
+      sf_.service().InvokeCmd(args_span, &cmd_cntx);
     }
   }
 

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -354,7 +354,7 @@ void DflyCmd::Sync(CmdArgList args, CommandContext* cmd_cntx) {
 
   // Start full sync.
   {
-    Transaction::Guard tg{cmd_cntx->tx};
+    Transaction::Guard tg{cmd_cntx->tx()};
     AggregateStatus status;
 
     // Use explicit assignment for replica_ptr, because capturing structured bindings is C++20.
@@ -404,7 +404,7 @@ void DflyCmd::StartStable(CmdArgList args, CommandContext* cmd_cntx) {
   }
 
   {
-    Transaction::Guard tg{cmd_cntx->tx};
+    Transaction::Guard tg{cmd_cntx->tx()};
     AggregateStatus status;
 
     auto cb = [this, &status, replica_ptr = replica_ptr](EngineShard* shard) {
@@ -607,7 +607,7 @@ void DflyCmd::TakeOver(CmdArgList args, CommandContext* cmd_cntx) {
 }
 
 void DflyCmd::Expire(CmdArgList args, CommandContext* cmd_cntx) {
-  cmd_cntx->tx->ScheduleSingleHop([](Transaction* t, EngineShard* shard) {
+  cmd_cntx->tx()->ScheduleSingleHop([](Transaction* t, EngineShard* shard) {
     t->GetDbSlice(shard->shard_id()).ExpireAllIfNeeded();
     return OpStatus::OK;
   });

--- a/src/server/geo_family.cc
+++ b/src/server/geo_family.cc
@@ -282,7 +282,7 @@ void CmdGeoAdd(CmdArgList args, CommandContext* cmd_cntx) {
 
     members.emplace_back(bits, member);
   }
-  DCHECK(cmd_cntx->tx);
+  DCHECK(cmd_cntx->tx());
 
   absl::Span memb_sp{members.data(), members.size()};
   ZSetFamily::ZAddGeneric(key, zparams, memb_sp, cmd_cntx);
@@ -291,7 +291,7 @@ void CmdGeoAdd(CmdArgList args, CommandContext* cmd_cntx) {
 void CmdGeoHash(CmdArgList args, CommandContext* cmd_cntx) {
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
-  OpResult<MScoreResponse> result = ZSetFamily::ZGetMembers(args, cmd_cntx->tx, rb);
+  OpResult<MScoreResponse> result = ZSetFamily::ZGetMembers(args, cmd_cntx->tx(), rb);
 
   if (result.status() == OpStatus::WRONG_TYPE) {
     return rb->SendError(kWrongTypeErr);
@@ -311,7 +311,7 @@ void CmdGeoHash(CmdArgList args, CommandContext* cmd_cntx) {
 void CmdGeoPos(CmdArgList args, CommandContext* cmd_cntx) {
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
-  OpResult<MScoreResponse> result = ZSetFamily::ZGetMembers(args, cmd_cntx->tx, rb);
+  OpResult<MScoreResponse> result = ZSetFamily::ZGetMembers(args, cmd_cntx->tx(), rb);
 
   if (result.status() != OpStatus::OK) {
     return rb->SendError(result.status());
@@ -345,7 +345,7 @@ void CmdGeoDist(CmdArgList args, CommandContext* cmd_cntx) {
     return rb->SendError(kSyntaxErr);
   }
 
-  OpResult<MScoreResponse> result = ZSetFamily::ZGetMembers(args, cmd_cntx->tx, rb);
+  OpResult<MScoreResponse> result = ZSetFamily::ZGetMembers(args, cmd_cntx->tx(), rb);
 
   if (result.status() != OpStatus::OK) {
     return rb->SendError(result.status());
@@ -693,7 +693,7 @@ void CmdGeoSearch(CmdArgList args, CommandContext* cmd_cntx) {
   }
 
   geo_ops.count = (geo_ops.count == UINT64_MAX) ? 0 : geo_ops.count;
-  GeoSearchStoreGeneric(cmd_cntx->tx, builder, shape, key, member, geo_ops);
+  GeoSearchStoreGeneric(cmd_cntx->tx(), builder, shape, key, member, geo_ops);
 }
 
 void GeoRadiusByMemberGeneric(CmdArgList args, CommandContext* cmd_cntx, bool read_only) {
@@ -781,7 +781,7 @@ void GeoRadiusByMemberGeneric(CmdArgList args, CommandContext* cmd_cntx, bool re
   }
 
   geo_ops.count = (geo_ops.count == UINT64_MAX) ? 0 : geo_ops.count;
-  GeoSearchStoreGeneric(cmd_cntx->tx, builder, shape, key, member, geo_ops);
+  GeoSearchStoreGeneric(cmd_cntx->tx(), builder, shape, key, member, geo_ops);
 }
 
 void GeoRadiusGeneric(CmdArgList args, CommandContext* cmd_cntx, bool read_only) {
@@ -871,7 +871,7 @@ void GeoRadiusGeneric(CmdArgList args, CommandContext* cmd_cntx, bool read_only)
   }
 
   geo_ops.count = (geo_ops.count == UINT64_MAX) ? 0 : geo_ops.count;
-  GeoSearchStoreGeneric(cmd_cntx->tx, builder, shape, key, "", geo_ops);
+  GeoSearchStoreGeneric(cmd_cntx->tx(), builder, shape, key, "", geo_ops);
 }
 
 void CmdGeoRadiusByMember(CmdArgList args, CommandContext* cmd_cntx) {

--- a/src/server/hll_family.cc
+++ b/src/server/hll_family.cc
@@ -137,7 +137,7 @@ void PFAdd(CmdArgList args, CommandContext* cmd_cntx) {
     return AddToHll(t->GetOpArgs(shard), key, args);
   };
 
-  OpResult<int> res = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
+  OpResult<int> res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
   HandleOpValueResult(res, cmd_cntx->rb());
 }
 
@@ -225,7 +225,7 @@ OpResult<int64_t> PFCountMulti(CmdArgList args, CommandContext* cmd_cntx) {
     return OpStatus::OK;
   };
 
-  OpStatus cb_status = cmd_cntx->tx->ScheduleSingleHop(std::move(cb));
+  OpStatus cb_status = cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));
   if (cb_status != OpStatus::OK) {
     return cb_status;
   }
@@ -251,7 +251,7 @@ void PFCount(CmdArgList args, CommandContext* cmd_cntx) {
       return CountHllsSingle(t->GetOpArgs(shard), key);
     };
 
-    OpResult<int64_t> res = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
+    OpResult<int64_t> res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
     HandleOpValueResult(res, cmd_cntx->rb());
   } else {
     HandleOpValueResult(PFCountMulti(args, cmd_cntx), cmd_cntx->rb());
@@ -312,7 +312,7 @@ OpResult<int> PFMergeInternal(CmdArgList args, Transaction* tx, SinkReplyBuilder
 
 void PFMerge(CmdArgList args, CommandContext* cmd_cntx) {
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
-  OpResult<int> result = PFMergeInternal(args, cmd_cntx->tx, rb);
+  OpResult<int> result = PFMergeInternal(args, cmd_cntx->tx(), rb);
   if (result.ok()) {
     if (result.value() == 0) {
       rb->SendOk();

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -518,7 +518,7 @@ void HGetGeneric(CmdArgList args, uint8_t getall_mask, CommandContext* cmd_cntx)
     return res;
   };
 
-  OpResult<vector<string>> result = ExecuteRO(cmd_cntx->tx, cb);
+  OpResult<vector<string>> result = ExecuteRO(cmd_cntx->tx(), cb);
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   switch (result.status()) {
     case OpStatus::OK:
@@ -589,7 +589,7 @@ void HSetEx(CmdArgList args, CommandContext* cmd_cntx) {
     return OpSet(t->GetOpArgs(shard), key, fields, op_sp);
   };
 
-  OpResult<uint32_t> result = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
+  OpResult<uint32_t> result = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
   if (result) {
     rb->SendLong(*result);
   } else {
@@ -618,7 +618,7 @@ void CmdHDel(CmdArgList args, CommandContext* cmd_cntx) {
       deleted += hw.Erase(s);
     return deleted;
   };
-  HSetReplies{cmd_cntx}.Send(cmd_cntx->tx->ScheduleSingleHopT(WrapW(cb)));
+  HSetReplies{cmd_cntx}.Send(cmd_cntx->tx()->ScheduleSingleHopT(WrapW(cb)));
 }
 
 void CmdHExpire(CmdArgList args, CommandContext* cmd_cntx) {
@@ -653,7 +653,7 @@ void CmdHExpire(CmdArgList args, CommandContext* cmd_cntx) {
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpHExpire(t->GetOpArgs(shard), key, ttl_sec, flags, fields);
   };
-  OpResult<vector<long>> result = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
+  OpResult<vector<long>> result = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
 
   switch (result.status()) {
     case OpStatus::OK:
@@ -672,7 +672,7 @@ void CmdHGet(CmdArgList args, CommandContext* cmd_cntx) {
     return OpStatus::KEY_NOTFOUND;
   };
 
-  OpResult<string> result = ExecuteRO(cmd_cntx->tx, cb);
+  OpResult<string> result = ExecuteRO(cmd_cntx->tx(), cb);
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   switch (result.status()) {
     case OpStatus::OK:
@@ -688,7 +688,7 @@ void CmdHMGet(CmdArgList args, CommandContext* cmd_cntx) {
   auto fields = args.subspan(1);
   auto cb = [fields](const HMapWrap& hw) { return OpHMGet(hw, fields); };
 
-  OpResult<vector<OptStr>> result = ExecuteRO(cmd_cntx->tx, cb);
+  OpResult<vector<OptStr>> result = ExecuteRO(cmd_cntx->tx(), cb);
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   switch (result.status()) {
     case OpStatus::OK:
@@ -712,19 +712,19 @@ void CmdHStrLen(CmdArgList args, CommandContext* cmd_cntx) {
       return it->second.length();
     return OpStatus::KEY_NOTFOUND;
   };
-  HSetReplies{cmd_cntx}.Send(ExecuteRO(cmd_cntx->tx, cb));
+  HSetReplies{cmd_cntx}.Send(ExecuteRO(cmd_cntx->tx(), cb));
 }
 
 void CmdHLen(CmdArgList args, CommandContext* cmd_cntx) {
   auto cb = [](const HMapWrap& hw) -> OpResult<uint32_t> { return hw.Length(); };
-  HSetReplies{cmd_cntx}.Send(ExecuteRO(cmd_cntx->tx, cb));
+  HSetReplies{cmd_cntx}.Send(ExecuteRO(cmd_cntx->tx(), cb));
 }
 
 void CmdHExists(CmdArgList args, CommandContext* cmd_cntx) {
   auto cb = [field = args[1]](const HMapWrap& hw) -> OpResult<uint32_t> {
     return hw.Find(field) ? 1 : 0;
   };
-  HSetReplies{cmd_cntx}.Send(ExecuteRO(cmd_cntx->tx, cb));
+  HSetReplies{cmd_cntx}.Send(ExecuteRO(cmd_cntx->tx(), cb));
 }
 
 void CmdHIncrBy(CmdArgList args, CommandContext* cmd_cntx) {
@@ -743,7 +743,7 @@ void CmdHIncrBy(CmdArgList args, CommandContext* cmd_cntx) {
     return OpIncrBy(t->GetOpArgs(shard), key, field, &param);
   };
 
-  OpStatus status = cmd_cntx->tx->ScheduleSingleHop(std::move(cb));
+  OpStatus status = cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));
 
   if (status == OpStatus::OK) {
     cmd_cntx->SendLong(get<int64_t>(param));
@@ -778,7 +778,7 @@ void CmdHIncrByFloat(CmdArgList args, CommandContext* cmd_cntx) {
     return OpIncrBy(t->GetOpArgs(shard), key, field, &param);
   };
 
-  OpStatus status = cmd_cntx->tx->ScheduleSingleHop(std::move(cb));
+  OpStatus status = cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));
 
   if (status == OpStatus::OK) {
     auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
@@ -830,7 +830,7 @@ void CmdHScan(CmdArgList args, CommandContext* cmd_cntx) {
   const ScanOpts& scan_op = ops.value();
   auto cb = [&](const HMapWrap& hw) { return OpScan(hw, &cursor, scan_op); };
 
-  OpResult<StringVec> result = ExecuteRO(cmd_cntx->tx, cb);
+  OpResult<StringVec> result = ExecuteRO(cmd_cntx->tx(), cb);
   switch (result.status()) {
     case OpStatus::KEY_NOTFOUND:
       cursor = 0;
@@ -860,7 +860,7 @@ void CmdHSet(CmdArgList args, CommandContext* cmd_cntx) {
     return OpSet(t->GetOpArgs(shard), key, args);
   };
 
-  OpResult<uint32_t> result = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
+  OpResult<uint32_t> result = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
 
   if (result && cmd == "HSET") {
     rb->SendLong(*result);
@@ -875,7 +875,7 @@ void CmdHSetNx(CmdArgList args, CommandContext* cmd_cntx) {
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpSet(t->GetOpArgs(shard), key, args.subspan(1), OpSetParams{.skip_if_exists = true});
   };
-  HSetReplies{cmd_cntx}.Send(cmd_cntx->tx->ScheduleSingleHopT(cb));
+  HSetReplies{cmd_cntx}.Send(cmd_cntx->tx()->ScheduleSingleHopT(cb));
 }
 
 void StrVecEmplaceBack(StringVec& str_vec, const listpackEntry& lp) {
@@ -990,7 +990,7 @@ void CmdHRandField(CmdArgList args, CommandContext* cmd_cntx) {
     return str_vec;
   };
 
-  OpResult<StringVec> result = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
+  OpResult<StringVec> result = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
   if (result) {
     if (result->size() == 1 && args.size() == 1)
       rb->SendBulkString(result->front());

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -870,15 +870,15 @@ OpResult<void> OpTrackKeys(const OpArgs slice_args, const facade::Connection::We
   return OpStatus::OK;
 }
 
-void TrackIfNeeded(CommandContext* cmnd_cntx) {
-  auto* cntx = cmnd_cntx->server_conn_cntx();
+void TrackIfNeeded(CommandContext* cmd_cntx) {
+  auto* cntx = cmd_cntx->server_conn_cntx();
   auto& info = cntx->conn_state.tracking_info_;
-  if (auto* tx = cmnd_cntx->tx; tx) {
+  if (auto* tx = cmd_cntx->tx(); tx) {
     // Reset it, because in multi/exec the transaction pointer is the same and
     // we will end up triggerring the callback on the following commands. To avoid this
     // we reset it.
     tx->SetTrackingCallback({});
-    if (cmnd_cntx->cid->IsReadOnly() && info.ShouldTrackKeys()) {
+    if (cmd_cntx->cid->IsReadOnly() && info.ShouldTrackKeys()) {
       auto conn = cntx->conn()->Borrow();
       tx->SetTrackingCallback([conn](Transaction* trans) {
         auto* shard = EngineShard::tlocal();
@@ -1422,8 +1422,8 @@ DispatchResult Service::DispatchCommand(facade::ParsedArgs args,
     return DispatchResult::ERROR;
   }
 
-  CommandContext* cmnd_cntx = static_cast<CommandContext*>(parsed_cmd);
-  ConnectionContext* dfly_cntx = cmnd_cntx->server_conn_cntx();
+  CommandContext* cmd_cntx = static_cast<CommandContext*>(parsed_cmd);
+  ConnectionContext* dfly_cntx = cmd_cntx->server_conn_cntx();
   bool under_script = bool(dfly_cntx->conn_state.script_info);
   bool under_exec = dfly_cntx->conn_state.exec_info.IsRunning();
   bool dispatching_in_multi = under_script || under_exec;
@@ -1431,8 +1431,8 @@ DispatchResult Service::DispatchCommand(facade::ParsedArgs args,
   CmdArgVec tmp_vec;
   ArgSlice tail_args = args_no_cmd.ToSlice(&tmp_vec);
 
-  if (cmnd_cntx->conn()) {  // no owner in replica context.
-    auto* conn = cmnd_cntx->conn();
+  if (cmd_cntx->conn()) {  // no owner in replica context.
+    auto* conn = cmd_cntx->conn();
 
     if (VLOG_IS_ON(2)) {
       LOG(INFO) << "Got (" << conn->GetClientId() << "): " << (under_script ? "LUA " : "")
@@ -1470,7 +1470,7 @@ DispatchResult Service::DispatchCommand(facade::ParsedArgs args,
       }
     }
     DCHECK(!err->status);
-    cmnd_cntx->SendError(err->ToSv(), err->kind);
+    cmd_cntx->SendError(err->ToSv(), err->kind);
     return DispatchResult::ERROR;
   }
 
@@ -1488,7 +1488,7 @@ DispatchResult Service::DispatchCommand(facade::ParsedArgs args,
     if (cid->IsJournaled()) {
       exec_info.is_write = true;
     }
-    cmnd_cntx->SendSimpleString("QUEUED");
+    cmd_cntx->SendSimpleString("QUEUED");
     return DispatchResult::OK;
   }
 
@@ -1503,7 +1503,7 @@ DispatchResult Service::DispatchCommand(facade::ParsedArgs args,
           dfly_cntx->ns, dfly_cntx->conn_state.db_index, tail_args);
 
       if (status != OpStatus::OK) {
-        cmnd_cntx->SendError(status);
+        cmd_cntx->SendError(status);
         return DispatchResult::ERROR;
       }
     }
@@ -1518,7 +1518,7 @@ DispatchResult Service::DispatchCommand(facade::ParsedArgs args,
         if (auto st =
                 dist_trans->InitByArgs(dfly_cntx->ns, dfly_cntx->conn_state.db_index, tail_args);
             st != OpStatus::OK) {
-          cmnd_cntx->SendError(StatusToMsg(st));
+          cmd_cntx->SendError(StatusToMsg(st));
           return DispatchResult::ERROR;
         }
       }
@@ -1531,13 +1531,13 @@ DispatchResult Service::DispatchCommand(facade::ParsedArgs args,
   }
 
   DispatchResult res = DispatchResult::ERROR;
-  cmnd_cntx->cid = cid;
-  cmnd_cntx->tx = dfly_cntx->transaction;
-  res = InvokeCmd(tail_args, cmnd_cntx);
+  cmd_cntx->SetupTx(cid, dfly_cntx->transaction);
+
+  res = InvokeCmd(tail_args, cmd_cntx);
 
   if ((res != DispatchResult::OK) && (res != DispatchResult::OOM)) {
-    cmnd_cntx->SendError("Internal Error");
-    cmnd_cntx->rb()->CloseConnection();
+    cmd_cntx->SendError("Internal Error");
+    cmd_cntx->rb()->CloseConnection();
   }
 
   if (!dispatching_in_multi) {
@@ -1606,7 +1606,7 @@ DispatchResult Service::InvokeCmd(CmdArgList tail_args, CommandContext* cmd_cntx
 
   ServerState::tlocal()->RecordCmd(cntx->has_main_or_memcache_listener);
   TrackIfNeeded(cmd_cntx);
-  auto* tx = cmd_cntx->tx;
+  auto* tx = cmd_cntx->tx();
 
 #ifndef NDEBUG
   // Verifies that we reply to the client when needed.
@@ -1978,7 +1978,7 @@ void Service::Watch(CmdArgList args, CommandContext* cmd_cntx) {
     keys_existed.fetch_add(res.value_or(0), memory_order_relaxed);
     return OpStatus::OK;
   };
-  cmd_cntx->tx->ScheduleSingleHop(std::move(cb));
+  cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));
 
   // Duplicate keys are stored to keep correct count.
   exec_info.watched_existed += keys_existed.load(memory_order_relaxed);
@@ -2025,7 +2025,7 @@ optional<CapturingReplyBuilder::Payload> Service::FlushEvalAsyncCmds(ConnectionC
 }
 
 void Service::CallFromScript(Interpreter::CallArgs& ca, CommandContext* cmd_cntx) {
-  auto* tx = cmd_cntx->tx;
+  auto* tx = cmd_cntx->tx();
   DCHECK(tx);
   DVLOG(2) << "CallFromScript " << ca.args[0];
 
@@ -2076,7 +2076,7 @@ void Service::Eval(CmdArgList args, CommandContext* cmd_cntx, bool read_only) {
   }
 
   auto* cntx = cmd_cntx->server_conn_cntx();
-  BorrowedInterpreter interpreter{cmd_cntx->tx, &cntx->conn_state};
+  BorrowedInterpreter interpreter{cmd_cntx->tx(), &cntx->conn_state};
   auto res = server_family_.script_mgr()->Insert(body, interpreter);
   if (!res)
     return cmd_cntx->SendError(res.error().Format(), facade::kScriptErrType);
@@ -2093,7 +2093,7 @@ void Service::EvalRo(CmdArgList args, CommandContext* cmd_cntx) {
 void Service::EvalSha(CmdArgList args, CommandContext* cmd_cntx, bool read_only) {
   string sha = absl::AsciiStrToLower(ArgS(args, 0));
   auto* cntx = cmd_cntx->server_conn_cntx();
-  BorrowedInterpreter interpreter{cmd_cntx->tx, &cntx->conn_state};
+  BorrowedInterpreter interpreter{cmd_cntx->tx(), &cntx->conn_state};
   CallSHA(args, sha, interpreter, read_only, cmd_cntx);
 }
 
@@ -2234,7 +2234,7 @@ void Service::EvalInternal(CmdArgList args, const EvalArgs& eval_args, Interpret
   }
 
   sinfo->async_cmds_heap_limit = GetFlag(FLAGS_multi_eval_squash_buffer);
-  Transaction* tx = cmd_cntx->tx;
+  Transaction* tx = cmd_cntx->tx();
   CHECK(tx != nullptr);
 
   Interpreter::RunResult result;
@@ -2464,7 +2464,7 @@ void Service::Exec(CmdArgList args, CommandContext* cmd_cntx) {
   // We borrow a single interpreter for all the EVALs/Script load inside. Returned by MultiCleanup
   if (state != ExecScriptUse::NONE) {
     exec_info.preborrowed_interpreter =
-        BorrowedInterpreter(cmd_cntx->tx, &cntx->conn_state).Release();
+        BorrowedInterpreter(cmd_cntx->tx(), &cntx->conn_state).Release();
   }
 
   // Determine according multi mode, not only only flag, but based on presence of global commands
@@ -2479,7 +2479,7 @@ void Service::Exec(CmdArgList args, CommandContext* cmd_cntx) {
   // EXEC should not run if any of the watched keys expired.
   if (!exec_info.watched_keys.empty() &&
       !CheckWatchedKeyExpiry(cntx, registry_.Find("EXISTS"), exec_cid_)) {
-    cmd_cntx->tx->UnlockMulti();
+    cmd_cntx->tx()->UnlockMulti();
     return rb->SendNull();
   }
 
@@ -2492,7 +2492,7 @@ void Service::Exec(CmdArgList args, CommandContext* cmd_cntx) {
   rb->StartArray(exec_info.body.size());
 
   if (!exec_info.body.empty()) {
-    string descr = CreateExecDescriptor(exec_info.body, cmd_cntx->tx->GetUniqueShardCnt());
+    string descr = CreateExecDescriptor(exec_info.body, cmd_cntx->tx()->GetUniqueShardCnt());
     ServerState::tlocal()->exec_freq_count[descr]++;
 
     if (GetFlag(FLAGS_multi_exec_squash) && state != ExecScriptUse::SCRIPT_RUN &&
@@ -2508,8 +2508,8 @@ void Service::Exec(CmdArgList args, CommandContext* cmd_cntx) {
         CmdArgList args = scmd.ArgList(&arg_vec);
 
         if (scmd.Cid()->IsTransactional()) {
-          cmd_cntx->tx->MultiSwitchCmd(scmd.Cid());
-          OpStatus st = cmd_cntx->tx->InitByArgs(cntx->ns, cntx->conn_state.db_index, args);
+          cmd_cntx->tx()->MultiSwitchCmd(scmd.Cid());
+          OpStatus st = cmd_cntx->tx()->InitByArgs(cntx->ns, cntx->conn_state.db_index, args);
           if (st != OpStatus::OK) {
             cmd_cntx->SendError(st);
             break;
@@ -2530,7 +2530,7 @@ void Service::Exec(CmdArgList args, CommandContext* cmd_cntx) {
 
   if (scheduled) {
     VLOG(2) << "Exec unlocking " << exec_info.body.size() << " commands";
-    cmd_cntx->tx->UnlockMulti();
+    cmd_cntx->tx()->UnlockMulti();
   }
 
   // Dispatch at the end manually to have (MULTI, cmds..., EXEC) order

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -367,20 +367,20 @@ std::optional<cron::cronexpr> InferSnapshotCronExpr() {
   return std::nullopt;
 }
 
-void ClientSetName(CmdArgList args, CommandContext* cmnd_cntx) {
+void ClientSetName(CmdArgList args, CommandContext* cmd_cntx) {
   if (args.size() == 1) {
-    cmnd_cntx->conn()->SetName(string{ArgS(args, 0)});
-    return cmnd_cntx->rb()->SendOk();
+    cmd_cntx->conn()->SetName(string{ArgS(args, 0)});
+    return cmd_cntx->rb()->SendOk();
   }
-  return cmnd_cntx->SendError(facade::kSyntaxErr);
+  return cmd_cntx->SendError(facade::kSyntaxErr);
 }
 
-void ClientGetName(CmdArgList args, CommandContext* cmnd_cntx) {
+void ClientGetName(CmdArgList args, CommandContext* cmd_cntx) {
   if (!args.empty()) {
-    return cmnd_cntx->SendError(facade::kSyntaxErr);
+    return cmd_cntx->SendError(facade::kSyntaxErr);
   }
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
-  if (auto name = cmnd_cntx->conn()->GetName(); !name.empty()) {
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+  if (auto name = cmd_cntx->conn()->GetName(); !name.empty()) {
     return rb->SendBulkString(name);
   } else {
     return rb->SendNull();
@@ -388,9 +388,9 @@ void ClientGetName(CmdArgList args, CommandContext* cmnd_cntx) {
 }
 
 void ClientList(CmdArgList args, absl::Span<facade::Listener*> listeners,
-                CommandContext* cmnd_cntx) {
+                CommandContext* cmd_cntx) {
   if (!args.empty()) {
-    return cmnd_cntx->SendError(facade::kSyntaxErr);
+    return cmd_cntx->SendError(facade::kSyntaxErr);
   }
 
   vector<string> client_info;
@@ -411,19 +411,19 @@ void ClientList(CmdArgList args, absl::Span<facade::Listener*> listeners,
 
   string result = absl::StrJoin(client_info, "\n");
   result.append("\n");
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   return rb->SendVerbatimString(result);
 }
 
-void ClientTracking(CmdArgList args, CommandContext* cmnd_cntx) {
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+void ClientTracking(CmdArgList args, CommandContext* cmd_cntx) {
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (!rb->IsResp3())
-    return cmnd_cntx->SendError(
+    return cmd_cntx->SendError(
         "Client tracking is currently not supported for RESP2. Please use RESP3.");
 
   CmdArgParser parser{args};
   if (!parser.HasAtLeast(1) || args.size() > 3)
-    return cmnd_cntx->SendError(kSyntaxErr);
+    return cmd_cntx->SendError(kSyntaxErr);
 
   bool is_on = false;
   using Tracking = ConnectionState::ClientTracking;
@@ -431,7 +431,7 @@ void ClientTracking(CmdArgList args, CommandContext* cmnd_cntx) {
   if (parser.Check("ON")) {
     is_on = true;
   } else if (!parser.Check("OFF")) {
-    return cmnd_cntx->SendError(kSyntaxErr);
+    return cmd_cntx->SendError(kSyntaxErr);
   }
 
   bool noloop = false;
@@ -444,7 +444,7 @@ void ClientTracking(CmdArgList args, CommandContext* cmnd_cntx) {
     } else if (parser.Check("NOLOOP")) {
       noloop = true;
     } else {
-      return cmnd_cntx->SendError(kSyntaxErr);
+      return cmd_cntx->SendError(kSyntaxErr);
     }
   }
 
@@ -452,11 +452,11 @@ void ClientTracking(CmdArgList args, CommandContext* cmnd_cntx) {
     if (!noloop && parser.Check("NOLOOP")) {
       noloop = true;
     } else {
-      return cmnd_cntx->SendError(kSyntaxErr);
+      return cmd_cntx->SendError(kSyntaxErr);
     }
   }
 
-  auto* conn_cntx = cmnd_cntx->server_conn_cntx();
+  auto* conn_cntx = cmd_cntx->server_conn_cntx();
   if (is_on) {
     ++conn_cntx->subscriptions;
   }
@@ -464,22 +464,22 @@ void ClientTracking(CmdArgList args, CommandContext* cmnd_cntx) {
   conn_cntx->conn_state.tracking_info_.SetClientTracking(is_on);
   conn_cntx->conn_state.tracking_info_.SetOption(option);
   conn_cntx->conn_state.tracking_info_.SetNoLoop(noloop);
-  return cmnd_cntx->rb()->SendOk();
+  return cmd_cntx->rb()->SendOk();
 }
 
-void ClientCaching(CmdArgList args, CommandContext* cmnd_cntx) {
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+void ClientCaching(CmdArgList args, CommandContext* cmd_cntx) {
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (!rb->IsResp3())
-    return cmnd_cntx->SendError(
+    return cmd_cntx->SendError(
         "Client caching is currently not supported for RESP2. Please use RESP3.");
 
   if (args.size() != 1) {
-    return cmnd_cntx->SendError(kSyntaxErr);
+    return cmd_cntx->SendError(kSyntaxErr);
   }
 
-  auto* cntx = cmnd_cntx->server_conn_cntx();
+  auto* cntx = cmd_cntx->server_conn_cntx();
   if (!cntx->conn_state.tracking_info_.IsTrackingOn()) {
-    return cmnd_cntx->SendError(
+    return cmd_cntx->SendError(
         "CLIENT CACHING can be called only when the client is in tracking mode with OPTIN or "
         "OPTOUT mode enabled");
   }
@@ -489,32 +489,32 @@ void ClientCaching(CmdArgList args, CommandContext* cmnd_cntx) {
 
   if (parser.Check("YES")) {
     if (!cntx->conn_state.tracking_info_.HasOption(Tracking::OPTIN)) {
-      return cmnd_cntx->SendError(
+      return cmd_cntx->SendError(
           "CLIENT CACHING YES is only valid when tracking is enabled in OPTIN mode");
     }
   } else if (parser.Check("NO")) {
     if (!cntx->conn_state.tracking_info_.HasOption(Tracking::OPTOUT)) {
-      return cmnd_cntx->SendError(
+      return cmd_cntx->SendError(
           "CLIENT CACHING NO is only valid when tracking is enabled in OPTOUT mode");
     }
     cntx->conn_state.tracking_info_.ResetCachingSequenceNumber();
   } else {
-    return cmnd_cntx->SendError(kSyntaxErr);
+    return cmd_cntx->SendError(kSyntaxErr);
   }
 
-  bool is_multi = cmnd_cntx->tx && cmnd_cntx->tx->IsMulti();
+  bool is_multi = cmd_cntx->tx() && cmd_cntx->tx()->IsMulti();
   cntx->conn_state.tracking_info_.SetCachingSequenceNumber(is_multi);
-  cmnd_cntx->rb()->SendOk();
+  cmd_cntx->rb()->SendOk();
 }
 
-void ClientSetInfo(CmdArgList args, CommandContext* cmnd_cntx) {
+void ClientSetInfo(CmdArgList args, CommandContext* cmd_cntx) {
   if (args.size() != 2) {
-    return cmnd_cntx->SendError(kSyntaxErr);
+    return cmd_cntx->SendError(kSyntaxErr);
   }
 
-  auto* conn = cmnd_cntx->conn();
+  auto* conn = cmd_cntx->conn();
   if (conn == nullptr) {
-    return cmnd_cntx->SendError("No connection");
+    return cmd_cntx->SendError("No connection");
   }
 
   string type = absl::AsciiStrToUpper(ArgS(args, 0));
@@ -525,22 +525,22 @@ void ClientSetInfo(CmdArgList args, CommandContext* cmnd_cntx) {
   } else if (type == "LIB-VER") {
     conn->SetLibVersion(string(val));
   } else {
-    return cmnd_cntx->SendError(kSyntaxErr);
+    return cmd_cntx->SendError(kSyntaxErr);
   }
 
-  cmnd_cntx->rb()->SendOk();
+  cmd_cntx->rb()->SendOk();
 }
 
-void ClientId(CmdArgList args, CommandContext* cmnd_cntx) {
+void ClientId(CmdArgList args, CommandContext* cmd_cntx) {
   if (args.size() != 0) {
-    return cmnd_cntx->SendError(kSyntaxErr);
+    return cmd_cntx->SendError(kSyntaxErr);
   }
 
-  return cmnd_cntx->rb()->SendLong(cmnd_cntx->conn()->GetClientId());
+  return cmd_cntx->rb()->SendLong(cmd_cntx->conn()->GetClientId());
 }
 
 void ClientKill(CmdArgList args, absl::Span<facade::Listener*> listeners,
-                CommandContext* cmnd_cntx) {
+                CommandContext* cmd_cntx) {
   std::function<bool(facade::Connection * conn)> evaluator;
 
   if (args.size() == 1) {
@@ -571,10 +571,10 @@ void ClientKill(CmdArgList args, absl::Span<facade::Listener*> listeners,
   }
 
   if (!evaluator) {
-    return cmnd_cntx->SendError(kSyntaxErr);
+    return cmd_cntx->SendError(kSyntaxErr);
   }
 
-  const bool is_admin_request = cmnd_cntx->conn()->IsPrivileged();
+  const bool is_admin_request = cmd_cntx->conn()->IsPrivileged();
 
   atomic<uint32_t> killed_connections = 0;
   atomic<uint32_t> kill_errors = 0;
@@ -609,28 +609,28 @@ void ClientKill(CmdArgList args, absl::Span<facade::Listener*> listeners,
   shard_set->pool()->AwaitFiberOnAll(cb);
 
   if (kill_errors.load() == 0) {
-    return cmnd_cntx->rb()->SendLong(killed_connections.load());
+    return cmd_cntx->rb()->SendLong(killed_connections.load());
   } else {
-    return cmnd_cntx->SendError(absl::StrCat("Killed ", killed_connections.load(),
-                                             " client(s), but unable to kill ", kill_errors.load(),
-                                             " admin client(s)."));
+    return cmd_cntx->SendError(absl::StrCat("Killed ", killed_connections.load(),
+                                            " client(s), but unable to kill ", kill_errors.load(),
+                                            " admin client(s)."));
   }
 }
 
 void ClientMigrate(CmdArgList args, absl::Span<facade::Listener*> listeners,
-                   CommandContext* cmnd_cntx) {
+                   CommandContext* cmd_cntx) {
   if (args.size() != 2) {
-    return cmnd_cntx->SendError(kSyntaxErr);
+    return cmd_cntx->SendError(kSyntaxErr);
   }
 
   uint32_t id;
   if (!absl::SimpleAtoi(args[0], &id)) {
-    return cmnd_cntx->SendError("Invalid client id");
+    return cmd_cntx->SendError("Invalid client id");
   }
 
   uint32_t tid = 0;
   if (!absl::SimpleAtoi(args[1], &tid) || tid >= shard_set->pool()->size()) {
-    return cmnd_cntx->SendError("Invalid thread id");
+    return cmd_cntx->SendError("Invalid thread id");
   }
 
   unsigned migrated = 0;
@@ -657,7 +657,7 @@ void ClientMigrate(CmdArgList args, absl::Span<facade::Listener*> listeners,
 
   shard_set->pool()->AwaitBrief(cb_brief);
 
-  return cmnd_cntx->rb()->SendLong(migrated);
+  return cmd_cntx->rb()->SendLong(migrated);
 }
 
 std::string_view GetOSString() {
@@ -898,17 +898,17 @@ bool IsMaster() {
 }  // namespace
 
 void SlowLogGet(dfly::CmdArgList args, std::string_view sub_cmd, util::ProactorPool* pp,
-                CommandContext* cmnd_cntx) {
+                CommandContext* cmd_cntx) {
   size_t requested_slow_log_length = UINT32_MAX;
   size_t argc = args.size();
   if (argc >= 3) {
-    return cmnd_cntx->SendError(facade::UnknownSubCmd(sub_cmd, "SLOWLOG"), facade::kSyntaxErrType);
+    return cmd_cntx->SendError(facade::UnknownSubCmd(sub_cmd, "SLOWLOG"), facade::kSyntaxErrType);
   } else if (argc == 2) {
     string_view length = facade::ArgS(args, 1);
     int64_t num;
     if ((!absl::SimpleAtoi(length, &num)) || (num < -1)) {
-      return cmnd_cntx->SendError("count should be greater than or equal to -1",
-                                  facade::kSyntaxErrType);
+      return cmd_cntx->SendError("count should be greater than or equal to -1",
+                                 facade::kSyntaxErrType);
     }
     if (num >= 0) {
       requested_slow_log_length = num;
@@ -935,7 +935,7 @@ void SlowLogGet(dfly::CmdArgList args, std::string_view sub_cmd, util::ProactorP
 
   requested_slow_log_length = std::min(merged_slow_log.size(), requested_slow_log_length);
 
-  auto* rb = static_cast<facade::RedisReplyBuilder*>(cmnd_cntx->rb());
+  auto* rb = static_cast<facade::RedisReplyBuilder*>(cmd_cntx->rb());
   rb->StartArray(requested_slow_log_length);
   for (size_t i = 0; i < requested_slow_log_length; ++i) {
     const auto& entry = merged_slow_log[i].first;
@@ -2281,10 +2281,10 @@ SaveInfoData ServerFamily::GetLastSaveInfo() const {
   return thread_safe_save_info_.Get();
 }
 
-void ServerFamily::DbSize(CmdArgList args, CommandContext* cmnd_cntx) {
+void ServerFamily::DbSize(CmdArgList args, CommandContext* cmd_cntx) {
   atomic_ulong num_keys{0};
 
-  auto* cntx = cmnd_cntx->server_conn_cntx();
+  auto* cntx = cmd_cntx->server_conn_cntx();
   shard_set->RunBriefInParallel(
       [&](EngineShard* shard) {
         auto db_size = cntx->ns->GetDbSlice(shard->shard_id()).DbSize(cntx->conn_state.db_index);
@@ -2292,7 +2292,7 @@ void ServerFamily::DbSize(CmdArgList args, CommandContext* cmnd_cntx) {
       },
       [](ShardId) { return true; });
 
-  return cmnd_cntx->rb()->SendLong(num_keys.load(memory_order_relaxed));
+  return cmd_cntx->rb()->SendLong(num_keys.load(memory_order_relaxed));
 }
 
 void ServerFamily::CancelBlockingOnThread(std::function<OpStatus(ArgSlice)> status_cb) {
@@ -2343,16 +2343,16 @@ void ServerFamily::SendInvalidationMessages() const {
   }
 }
 
-void ServerFamily::FlushDb(CmdArgList args, CommandContext* cmnd_cntx) {
+void ServerFamily::FlushDb(CmdArgList args, CommandContext* cmd_cntx) {
   if (args.size() > 1)
-    return cmnd_cntx->SendError(kSyntaxErr);
+    return cmd_cntx->SendError(kSyntaxErr);
 
   bool sync = CmdArgParser{args}.Check("SYNC");
-  string_view cmd_name = cmnd_cntx->tx->GetCId()->name();
-  DbIndex index = cmd_name == "FLUSHALL" ? DbSlice::kDbAll : cmnd_cntx->tx->GetDbIndex();
-  Drakarys(cmnd_cntx->tx, index, sync);
+  string_view cmd_name = cmd_cntx->tx()->GetCId()->name();
+  DbIndex index = cmd_name == "FLUSHALL" ? DbSlice::kDbAll : cmd_cntx->tx()->GetDbIndex();
+  Drakarys(cmd_cntx->tx(), index, sync);
   SendInvalidationMessages();
-  cmnd_cntx->rb()->SendOk();
+  cmd_cntx->rb()->SendOk();
 }
 
 bool ServerFamily::DoAuth(ConnectionContext* cntx, std::string_view username,
@@ -2384,12 +2384,12 @@ bool ServerFamily::DoAuth(ConnectionContext* cntx, std::string_view username,
   return is_authorized;
 }
 
-void ServerFamily::Auth(CmdArgList args, CommandContext* cmnd_cntx) {
+void ServerFamily::Auth(CmdArgList args, CommandContext* cmd_cntx) {
   if (args.size() > 2) {
-    return cmnd_cntx->SendError(kSyntaxErr);
+    return cmd_cntx->SendError(kSyntaxErr);
   }
 
-  ConnectionContext* cntx = cmnd_cntx->server_conn_cntx();
+  ConnectionContext* cntx = cmd_cntx->server_conn_cntx();
   // non admin port auth
   if (!cntx->conn()->IsPrivileged()) {
     const bool one_arg = args.size() == 1;
@@ -2397,16 +2397,16 @@ void ServerFamily::Auth(CmdArgList args, CommandContext* cmnd_cntx) {
     const size_t index = one_arg ? 0 : 1;
     std::string_view password = facade::ToSV(args[index]);
     if (DoAuth(cntx, username, password)) {
-      return cmnd_cntx->rb()->SendOk();
+      return cmd_cntx->rb()->SendOk();
     }
     auto& log = ServerState::tlocal()->acl_log;
     using Reason = acl::AclLog::Reason;
     log.Add(*cntx, "AUTH", Reason::AUTH, std::string(username));
-    return cmnd_cntx->SendError(facade::kAuthRejected);
+    return cmd_cntx->SendError(facade::kAuthRejected);
   }
 
   if (!cntx->req_auth) {
-    return cmnd_cntx->SendError(
+    return cmd_cntx->SendError(
         "AUTH <password> called without any password configured for "
         "admin port. Are you sure your configuration is correct?");
   }
@@ -2414,18 +2414,18 @@ void ServerFamily::Auth(CmdArgList args, CommandContext* cmnd_cntx) {
   string_view pass = ArgS(args, 0);
   if (pass == GetPassword()) {
     cntx->authenticated = true;
-    cmnd_cntx->rb()->SendOk();
+    cmd_cntx->rb()->SendOk();
   } else {
-    return cmnd_cntx->SendError(facade::kAuthRejected);
+    return cmd_cntx->SendError(facade::kAuthRejected);
   }
 }
 
-void ServerFamily::ClientUnPauseCmd(CmdArgList args, CommandContext* cmnd_cntx) {
+void ServerFamily::ClientUnPauseCmd(CmdArgList args, CommandContext* cmd_cntx) {
   if (!args.empty()) {
-    return cmnd_cntx->SendError(facade::kSyntaxErr);
+    return cmd_cntx->SendError(facade::kSyntaxErr);
   }
   is_c_pause_in_progress_.store(false, std::memory_order_relaxed);
-  cmnd_cntx->rb()->SendOk();
+  cmd_cntx->rb()->SendOk();
 }
 
 void ServerFamily::ChangeConnectionAccept(bool accept) {
@@ -2477,44 +2477,44 @@ void ClientHelp(SinkReplyBuilder* builder) {
   return rb->SendSimpleStrArr(help_arr);
 }
 
-void ServerFamily::Client(CmdArgList args, CommandContext* cmnd_cntx) {
+void ServerFamily::Client(CmdArgList args, CommandContext* cmd_cntx) {
   string sub_cmd = absl::AsciiStrToUpper(ArgS(args, 0));
   CmdArgList sub_args = args.subspan(1);
-  auto* builder = cmnd_cntx->rb();
+  auto* builder = cmd_cntx->rb();
 
   if (sub_cmd == "SETNAME") {
-    return ClientSetName(sub_args, cmnd_cntx);
+    return ClientSetName(sub_args, cmd_cntx);
   } else if (sub_cmd == "GETNAME") {
-    return ClientGetName(sub_args, cmnd_cntx);
+    return ClientGetName(sub_args, cmd_cntx);
   } else if (sub_cmd == "LIST") {
-    return ClientList(sub_args, absl::MakeSpan(listeners_), cmnd_cntx);
+    return ClientList(sub_args, absl::MakeSpan(listeners_), cmd_cntx);
   } else if (sub_cmd == "PAUSE") {
-    return ClientPauseCmd(sub_args, cmnd_cntx);
+    return ClientPauseCmd(sub_args, cmd_cntx);
   } else if (sub_cmd == "UNPAUSE") {
-    return ClientUnPauseCmd(sub_args, cmnd_cntx);
+    return ClientUnPauseCmd(sub_args, cmd_cntx);
   } else if (sub_cmd == "TRACKING") {
-    return ClientTracking(sub_args, cmnd_cntx);
+    return ClientTracking(sub_args, cmd_cntx);
   } else if (sub_cmd == "KILL") {
-    return ClientKill(sub_args, absl::MakeSpan(listeners_), cmnd_cntx);
+    return ClientKill(sub_args, absl::MakeSpan(listeners_), cmd_cntx);
   } else if (sub_cmd == "CACHING") {
-    return ClientCaching(sub_args, cmnd_cntx);
+    return ClientCaching(sub_args, cmd_cntx);
   } else if (sub_cmd == "SETINFO") {
-    return ClientSetInfo(sub_args, cmnd_cntx);
+    return ClientSetInfo(sub_args, cmd_cntx);
   } else if (sub_cmd == "ID") {
-    return ClientId(sub_args, cmnd_cntx);
+    return ClientId(sub_args, cmd_cntx);
   } else if (sub_cmd == "MIGRATE") {
-    return ClientMigrate(sub_args, absl::MakeSpan(listeners_), cmnd_cntx);
+    return ClientMigrate(sub_args, absl::MakeSpan(listeners_), cmd_cntx);
   } else if (sub_cmd == "HELP") {
     return ClientHelp(builder);
   }
 
-  return cmnd_cntx->SendError(UnknownSubCmd(sub_cmd, "CLIENT"), kSyntaxErrType);
+  return cmd_cntx->SendError(UnknownSubCmd(sub_cmd, "CLIENT"), kSyntaxErrType);
 }
 
-void ServerFamily::Config(CmdArgList args, CommandContext* cmnd_cntx) {
+void ServerFamily::Config(CmdArgList args, CommandContext* cmd_cntx) {
   string sub_cmd = absl::AsciiStrToUpper(ArgS(args, 0));
 
-  auto* builder = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+  auto* builder = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (sub_cmd == "HELP") {
     string_view help_arr[] = {
         "CONFIG <subcommand> [<arg> [value] [opt] ...]. Subcommands are:",
@@ -2535,7 +2535,7 @@ void ServerFamily::Config(CmdArgList args, CommandContext* cmnd_cntx) {
 
   if (sub_cmd == "SET") {
     if (args.size() != 3) {
-      return cmnd_cntx->SendError(WrongNumArgsError("config|set"), kConfigErrType);
+      return cmd_cntx->SendError(WrongNumArgsError("config|set"), kConfigErrType);
     }
 
     string param = absl::AsciiStrToLower(ArgS(args, 1));
@@ -2547,16 +2547,16 @@ void ServerFamily::Config(CmdArgList args, CommandContext* cmnd_cntx) {
       case ConfigRegistry::SetResult::OK:
         return builder->SendOk();
       case ConfigRegistry::SetResult::UNKNOWN:
-        return cmnd_cntx->SendError(
+        return cmd_cntx->SendError(
             absl::StrCat("Unknown option or number of arguments for CONFIG SET - '", param, "'"),
             kConfigErrType);
 
       case ConfigRegistry::SetResult::READONLY:
-        return cmnd_cntx->SendError(
+        return cmd_cntx->SendError(
             absl::StrCat(kErrPrefix, param, "') - can't set immutable config"), kConfigErrType);
       case ConfigRegistry::SetResult::INVALID:
-        return cmnd_cntx->SendError(absl::StrCat(kErrPrefix, param, "') - argument can not be set"),
-                                    kConfigErrType);
+        return cmd_cntx->SendError(absl::StrCat(kErrPrefix, param, "') - argument can not be set"),
+                                   kConfigErrType);
     }
     ABSL_UNREACHABLE();
   }
@@ -2590,34 +2590,34 @@ void ServerFamily::Config(CmdArgList args, CommandContext* cmnd_cntx) {
 
   if (sub_cmd == "REWRITE") {
     if (auto ec = RewriteConfigFile(); ec) {
-      return cmnd_cntx->SendError(ec.Format(), kConfigErrType);
+      return cmd_cntx->SendError(ec.Format(), kConfigErrType);
     }
     return builder->SendOk();
   }
 
   if (sub_cmd == "RESETSTAT") {
-    ResetStat(cmnd_cntx->server_conn_cntx()->ns);
+    ResetStat(cmd_cntx->server_conn_cntx()->ns);
     return builder->SendOk();
   } else {
-    return cmnd_cntx->SendError(UnknownSubCmd(sub_cmd, "CONFIG"), kSyntaxErrType);
+    return cmd_cntx->SendError(UnknownSubCmd(sub_cmd, "CONFIG"), kSyntaxErrType);
   }
 }
 
-void ServerFamily::Debug(CmdArgList args, CommandContext* cmnd_cntx) {
-  DebugCmd dbg_cmd{this, &service_.cluster_family(), cmnd_cntx->server_conn_cntx()};
+void ServerFamily::Debug(CmdArgList args, CommandContext* cmd_cntx) {
+  DebugCmd dbg_cmd{this, &service_.cluster_family(), cmd_cntx->server_conn_cntx()};
 
-  return dbg_cmd.Run(args, cmnd_cntx);
+  return dbg_cmd.Run(args, cmd_cntx);
 }
 
-void ServerFamily::Memory(CmdArgList args, CommandContext* cmnd_cntx) {
-  MemoryCmd mem_cmd{this, cmnd_cntx};
+void ServerFamily::Memory(CmdArgList args, CommandContext* cmd_cntx) {
+  MemoryCmd mem_cmd{this, cmd_cntx};
 
   return mem_cmd.Run(args);
 }
 
-void ServerFamily::Shrink(CmdArgList args, CommandContext* cmnd_cntx) {
+void ServerFamily::Shrink(CmdArgList args, CommandContext* cmd_cntx) {
   string_view key = ArgS(args, 0);
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
   auto cb = [key](Transaction* t, EngineShard* shard) -> OpResult<int64_t> {
     auto& db_slice = t->GetDbSlice(shard->shard_id());
@@ -2656,16 +2656,16 @@ void ServerFamily::Shrink(CmdArgList args, CommandContext* cmnd_cntx) {
     return bucket_bytes_before - bucket_bytes_after;
   };
 
-  OpResult<int64_t> result = cmnd_cntx->tx->ScheduleSingleHopT(std::move(cb));
+  OpResult<int64_t> result = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
 
   if (result.status() == OpStatus::KEY_NOTFOUND) {
     return rb->SendNull();
   }
   if (result.status() == OpStatus::WRONG_TYPE) {
-    return cmnd_cntx->SendError("WRONGTYPE Key is not a set or hash with DenseSet encoding");
+    return cmd_cntx->SendError("WRONGTYPE Key is not a set or hash with DenseSet encoding");
   }
   if (!result) {
-    return cmnd_cntx->SendError(result.status());
+    return cmd_cntx->SendError(result.status());
   }
 
   rb->SendLong(*result);
@@ -2679,9 +2679,9 @@ void ServerFamily::BgSaveFb(boost::intrusive_ptr<Transaction> trans) {
 }
 
 std::optional<SaveCmdOptions> ServerFamily::GetSaveCmdOpts(CmdArgList args,
-                                                           CommandContext* cmnd_cntx) {
+                                                           CommandContext* cmd_cntx) {
   if (args.size() > 3) {
-    cmnd_cntx->SendError(kSyntaxErr);
+    cmd_cntx->SendError(kSyntaxErr);
     return {};
   }
 
@@ -2695,7 +2695,7 @@ std::optional<SaveCmdOptions> ServerFamily::GetSaveCmdOpts(CmdArgList args,
     } else if (sub_cmd == "RDB") {
       save_cmd_opts.new_version = false;
     } else {
-      cmnd_cntx->SendError(UnknownSubCmd(sub_cmd, "SAVE"), kSyntaxErrType);
+      cmd_cntx->SendError(UnknownSubCmd(sub_cmd, "SAVE"), kSyntaxErrType);
       return {};
     }
   }
@@ -2726,35 +2726,35 @@ std::optional<SaveCmdOptions> ServerFamily::GetSaveCmdOpts(CmdArgList args,
 
 // SAVE [DF|RDB] [CLOUD_URI] [BASENAME]
 // TODO add missing [SCHEDULE]
-void ServerFamily::BgSave(CmdArgList args, CommandContext* cmnd_cntx) {
-  auto maybe_res = GetSaveCmdOpts(args, cmnd_cntx);
+void ServerFamily::BgSave(CmdArgList args, CommandContext* cmd_cntx) {
+  auto maybe_res = GetSaveCmdOpts(args, cmd_cntx);
   if (!maybe_res) {
     return;
   }
 
   DoSaveCheckAndStartOpts opts{.bg_save = true};
-  if (auto ec = DoSaveCheckAndStart(*maybe_res, cmnd_cntx->tx, opts); ec) {
-    return cmnd_cntx->SendError(ec.Format());
+  if (auto ec = DoSaveCheckAndStart(*maybe_res, cmd_cntx->tx(), opts); ec) {
+    return cmd_cntx->SendError(ec.Format());
   }
   bg_save_fb_.JoinIfNeeded();
   bg_save_fb_ = fb2::Fiber("bg_save_fiber", &ServerFamily::BgSaveFb, this,
-                           boost::intrusive_ptr<Transaction>(cmnd_cntx->tx));
-  cmnd_cntx->rb()->SendOk();
+                           boost::intrusive_ptr<Transaction>(cmd_cntx->tx()));
+  cmd_cntx->rb()->SendOk();
 }
 
 // SAVE [DF|RDB] [CLOUD_URI] [BASENAME]
 // Allows saving the snapshot of the dataset on disk, potentially overriding the format
 // and the snapshot name.
-void ServerFamily::Save(CmdArgList args, CommandContext* cmnd_cntx) {
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
-  auto maybe_res = GetSaveCmdOpts(args, cmnd_cntx);
+void ServerFamily::Save(CmdArgList args, CommandContext* cmd_cntx) {
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+  auto maybe_res = GetSaveCmdOpts(args, cmd_cntx);
   if (!maybe_res) {
     return;
   }
 
-  GenericError ec = DoSave(*maybe_res, cmnd_cntx->tx);
+  GenericError ec = DoSave(*maybe_res, cmd_cntx->tx());
   if (ec) {
-    return cmnd_cntx->SendError(ec.Format());
+    return cmd_cntx->SendError(ec.Format());
   } else {
     rb->SendOk();
   }
@@ -3426,7 +3426,7 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
   return info;
 }
 
-void ServerFamily::Info(CmdArgList args, CommandContext* cmnd_cntx) {
+void ServerFamily::Info(CmdArgList args, CommandContext* cmd_cntx) {
   std::vector<std::string> sections;
   bool need_metrics{false};  // Save time - do not fetch metrics if we don't need them.
   Metrics metrics;
@@ -3441,13 +3441,13 @@ void ServerFamily::Info(CmdArgList args, CommandContext* cmnd_cntx) {
   }
 
   if (need_metrics || sections.empty()) {
-    metrics = GetMetrics(cmnd_cntx->server_conn_cntx()->ns);
+    metrics = GetMetrics(cmd_cntx->server_conn_cntx()->ns);
   } else if (!IsMaster()) {
     metrics.replica_side_info = GetReplicaSummary();
   }
 
   std::string info;
-  bool is_priveleged = cmnd_cntx->conn()->IsPrivileged();
+  bool is_priveleged = cmd_cntx->conn()->IsPrivileged();
   // For multiple requested sections, invalid section names are ignored (not included in the
   // output). The command does not abort or return an error if some sections are invalid. This
   // matches Valkey behavior.
@@ -3468,11 +3468,11 @@ void ServerFamily::Info(CmdArgList args, CommandContext* cmnd_cntx) {
     }
   }
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   rb->SendVerbatimString(info);
 }
 
-void ServerFamily::Hello(CmdArgList args, CommandContext* cmnd_cntx) {
+void ServerFamily::Hello(CmdArgList args, CommandContext* cmd_cntx) {
   // If no arguments are provided default to RESP2.
   bool is_resp3 = false;
   bool has_auth = false;
@@ -3481,13 +3481,13 @@ void ServerFamily::Hello(CmdArgList args, CommandContext* cmnd_cntx) {
   string_view password;
   string_view clientname;
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (!args.empty()) {
     string_view proto_version = ArgS(args, 0);
     is_resp3 = proto_version == "3";
     bool valid_proto_version = proto_version == "2" || is_resp3;
     if (!valid_proto_version) {
-      cmnd_cntx->SendError(UnknownCmd("HELLO", args));
+      cmd_cntx->SendError(UnknownCmd("HELLO", args));
       return;
     }
 
@@ -3504,19 +3504,19 @@ void ServerFamily::Hello(CmdArgList args, CommandContext* cmnd_cntx) {
         clientname = ArgS(args, i + 1);
         i += 1;
       } else {
-        cmnd_cntx->SendError(kSyntaxErr);
+        cmd_cntx->SendError(kSyntaxErr);
         return;
       }
     }
   }
 
-  ConnectionContext* cntx = cmnd_cntx->server_conn_cntx();
+  ConnectionContext* cntx = cmd_cntx->server_conn_cntx();
   if (has_auth && !DoAuth(cntx, username, password)) {
-    return cmnd_cntx->SendError(facade::kAuthRejected);
+    return cmd_cntx->SendError(facade::kAuthRejected);
   }
 
   if (cntx->req_auth && !cntx->authenticated) {
-    cmnd_cntx->SendError(
+    cmd_cntx->SendError(
         "-NOAUTH HELLO must be called with the client already "
         "authenticated, otherwise the HELLO <proto> AUTH <user> <pass> "
         "option can be used to authenticate the client and "
@@ -3565,21 +3565,21 @@ void ServerFamily::Hello(CmdArgList args, CommandContext* cmnd_cntx) {
   }
 }
 
-void ServerFamily::AddReplicaOf(CmdArgList args, CommandContext* cmnd_cntx) {
+void ServerFamily::AddReplicaOf(CmdArgList args, CommandContext* cmd_cntx) {
   util::fb2::LockGuard lk(replicaof_mu_);
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (IsMaster()) {
-    return cmnd_cntx->SendError(
+    return cmd_cntx->SendError(
         "Calling ADDREPLICAOFF allowed only after server is already a replica");
   }
   CHECK(replica_);
 
   auto replicaof_args = ReplicaOfArgs::FromCmdArgs(args);
   if (!replicaof_args.has_value()) {
-    return cmnd_cntx->SendError(replicaof_args.error());
+    return cmd_cntx->SendError(replicaof_args.error());
   }
   if (replicaof_args->IsReplicaOfNoOne()) {
-    return cmnd_cntx->SendError("ADDREPLICAOF does not support no one");
+    return cmd_cntx->SendError("ADDREPLICAOF does not support no one");
   }
   LOG(INFO) << "Add Replica " << *replicaof_args;
 
@@ -3587,14 +3587,14 @@ void ServerFamily::AddReplicaOf(CmdArgList args, CommandContext* cmnd_cntx) {
                                           master_replid(), replicaof_args->slot_range);
   GenericError ec = add_replica->Start();
   if (ec) {
-    return cmnd_cntx->SendError(ec.Format());
+    return cmd_cntx->SendError(ec.Format());
   }
   add_replica->StartMainReplicationFiber(nullopt);
   cluster_replicas_.push_back(std::move(add_replica));
   rb->SendOk();
 }
 
-void ServerFamily::ReplicaOfInternal(CmdArgList args, CommandContext* cmnd_cntx,
+void ServerFamily::ReplicaOfInternal(CmdArgList args, CommandContext* cmd_cntx,
                                      ActionOnConnectionFail on_err) {
   std::shared_ptr<Replica> new_replica;
   std::optional<Replica::LastMasterSyncData> last_master_data;
@@ -3604,13 +3604,13 @@ void ServerFamily::ReplicaOfInternal(CmdArgList args, CommandContext* cmnd_cntx,
     // We should not execute replica of command while loading from snapshot.
     ServerState* ss = ServerState::tlocal();
     if (ss->is_master && ss->gstate() == GlobalState::LOADING) {
-      cmnd_cntx->SendError(kLoadingErr);
+      cmd_cntx->SendError(kLoadingErr);
       return;
     }
 
     auto replicaof_args = ReplicaOfArgs::FromCmdArgs(args);
     if (!replicaof_args.has_value()) {
-      cmnd_cntx->SendError(replicaof_args.error());
+      cmd_cntx->SendError(replicaof_args.error());
       return;
     }
 
@@ -3632,7 +3632,7 @@ void ServerFamily::ReplicaOfInternal(CmdArgList args, CommandContext* cmnd_cntx,
       // May not switch to ACTIVE if the process is, for example, shutting down at the same time.
       service_.SwitchState(GlobalState::LOADING, GlobalState::ACTIVE);
 
-      return cmnd_cntx->rb()->SendOk();
+      return cmd_cntx->rb()->SendOk();
     }
 
     // If any replication is in progress, stop it, cancellation should kick in immediately
@@ -3647,7 +3647,7 @@ void ServerFamily::ReplicaOfInternal(CmdArgList args, CommandContext* cmnd_cntx,
     } else if (auto new_state = service_.SwitchState(GlobalState::ACTIVE, GlobalState::LOADING);
                new_state != GlobalState::LOADING) {
       LOG(WARNING) << new_state << " in progress, ignored";
-      cmnd_cntx->SendError("Invalid state");
+      cmd_cntx->SendError("Invalid state");
       return;
     }
 
@@ -3689,7 +3689,7 @@ void ServerFamily::ReplicaOfInternal(CmdArgList args, CommandContext* cmnd_cntx,
       SetMasterFlagOnAllThreads(true);
       replica_.reset();
     }
-    cmnd_cntx->SendError(ec ? ec.Format() : "replication cancelled");
+    cmd_cntx->SendError(ec ? ec.Format() : "replication cancelled");
     return;
   }
   // Successfully connected now we flush
@@ -3698,7 +3698,7 @@ void ServerFamily::ReplicaOfInternal(CmdArgList args, CommandContext* cmnd_cntx,
   if (on_err == ActionOnConnectionFail::kReturnOnError) {
     new_replica->StartMainReplicationFiber(last_master_data);
   }
-  cmnd_cntx->rb()->SendOk();
+  cmd_cntx->rb()->SendOk();
 }
 
 void ServerFamily::StopAllClusterReplicas() {
@@ -3710,13 +3710,13 @@ void ServerFamily::StopAllClusterReplicas() {
   cluster_replicas_.clear();
 }
 
-void ServerFamily::ReplicaOf(CmdArgList args, CommandContext* cmnd_cntx) {
+void ServerFamily::ReplicaOf(CmdArgList args, CommandContext* cmd_cntx) {
   const bool use_replica_of_v2 = absl::GetFlag(FLAGS_experimental_replicaof_v2);
   if (use_replica_of_v2) {
-    ReplicaOfInternalV2(args, cmnd_cntx, ActionOnConnectionFail::kReturnOnError);
+    ReplicaOfInternalV2(args, cmd_cntx, ActionOnConnectionFail::kReturnOnError);
     return;
   }
-  ReplicaOfInternal(args, cmnd_cntx, ActionOnConnectionFail::kReturnOnError);
+  ReplicaOfInternal(args, cmd_cntx, ActionOnConnectionFail::kReturnOnError);
 }
 
 void ServerFamily::Replicate(string_view host, string_view port) {
@@ -3730,12 +3730,12 @@ void ServerFamily::Replicate(string_view host, string_view port) {
   io::NullSink sink;
   facade::RedisReplyBuilder rb(&sink);
   const bool use_replica_of_v2 = absl::GetFlag(FLAGS_experimental_replicaof_v2);
-  CommandContext cmnd_cntx{nullptr, nullptr, &rb, nullptr};
+  CommandContext cmd_cntx{nullptr, nullptr, &rb, nullptr};
   if (use_replica_of_v2) {
-    ReplicaOfInternalV2(args_list, &cmnd_cntx, ActionOnConnectionFail::kContinueReplication);
+    ReplicaOfInternalV2(args_list, &cmd_cntx, ActionOnConnectionFail::kContinueReplication);
     return;
   }
-  ReplicaOfInternal(args_list, &cmnd_cntx, ActionOnConnectionFail::kContinueReplication);
+  ReplicaOfInternal(args_list, &cmd_cntx, ActionOnConnectionFail::kContinueReplication);
 }
 
 void ServerFamily::ReplicaOfNoOne(SinkReplyBuilder* builder) {
@@ -3758,12 +3758,12 @@ void ServerFamily::ReplicaOfNoOne(SinkReplyBuilder* builder) {
   return builder->SendOk();
 }
 
-void ServerFamily::ReplicaOfInternalV2(CmdArgList args, CommandContext* cmnd_cntx,
+void ServerFamily::ReplicaOfInternalV2(CmdArgList args, CommandContext* cmd_cntx,
                                        ActionOnConnectionFail on_error)
     ABSL_LOCKS_EXCLUDED(replicaof_mu_) {
   auto replicaof_args = ReplicaOfArgs::FromCmdArgs(args);
   if (!replicaof_args.has_value()) {
-    return cmnd_cntx->SendError(replicaof_args.error());
+    return cmd_cntx->SendError(replicaof_args.error());
   }
 
   LOG(INFO) << "Initiate replication with: " << *replicaof_args;
@@ -3781,12 +3781,12 @@ void ServerFamily::ReplicaOfInternalV2(CmdArgList args, CommandContext* cmnd_cnt
   ServerState* ss = ServerState::tlocal();
 
   if (IsMaster() && ss->gstate() == GlobalState::LOADING) {
-    return cmnd_cntx->SendError(kLoadingErr);
+    return cmd_cntx->SendError(kLoadingErr);
   }
 
   // replicaof no one
   if (replicaof_args->IsReplicaOfNoOne()) {
-    return ReplicaOfNoOne(cmnd_cntx->rb());
+    return ReplicaOfNoOne(cmd_cntx->rb());
   }
 
   auto new_replica = make_shared<Replica>(replicaof_args->host, replicaof_args->port, &service_,
@@ -3802,7 +3802,7 @@ void ServerFamily::ReplicaOfInternalV2(CmdArgList args, CommandContext* cmnd_cnt
   };
 
   if (ec || new_replica->IsContextCancelled()) {
-    return cmnd_cntx->SendError(ec ? ec.Format() : "replication cancelled");
+    return cmd_cntx->SendError(ec ? ec.Format() : "replication cancelled");
   }
 
   // Critical section.
@@ -3828,12 +3828,12 @@ void ServerFamily::ReplicaOfInternalV2(CmdArgList args, CommandContext* cmnd_cnt
     replica_->StartMainReplicationFiber(last_master_data);
   }
 
-  cmnd_cntx->rb()->SendOk();
+  cmd_cntx->rb()->SendOk();
 }
 
 // REPLTAKEOVER <seconds> [SAVE]
 // SAVE is used only by tests.
-void ServerFamily::ReplTakeOver(CmdArgList args, CommandContext* cmnd_cntx) {
+void ServerFamily::ReplTakeOver(CmdArgList args, CommandContext* cmd_cntx) {
   VLOG(1) << "ReplTakeOver start";
 
   CmdArgParser parser{args};
@@ -3841,15 +3841,15 @@ void ServerFamily::ReplTakeOver(CmdArgList args, CommandContext* cmnd_cntx) {
   int timeout_sec = parser.Next<int>();
   bool save_flag = static_cast<bool>(parser.Check("SAVE"));
 
-  auto* builder = cmnd_cntx->rb();
+  auto* builder = cmd_cntx->rb();
   if (parser.HasNext())
-    return cmnd_cntx->SendError(absl::StrCat("Unsupported option:", string_view(parser.Next())));
+    return cmd_cntx->SendError(absl::StrCat("Unsupported option:", string_view(parser.Next())));
 
-  RETURN_ON_PARSE_ERROR(parser, cmnd_cntx);
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   // We allow zero timeouts for tests.
   if (timeout_sec < 0) {
-    return cmnd_cntx->SendError("timeout is negative");
+    return cmd_cntx->SendError("timeout is negative");
   }
 
   // We return OK, to support idempotency semantics.
@@ -3871,13 +3871,13 @@ void ServerFamily::ReplTakeOver(CmdArgList args, CommandContext* cmnd_cntx) {
 
   auto info = replica_->GetSummary();
   if (!info.full_sync_done) {
-    return cmnd_cntx->SendError("Full sync not done");
+    return cmd_cntx->SendError("Full sync not done");
   }
 
   std::error_code res = replica_->TakeOver(timeout_sec, save_flag);
   if (res) {
     LOG(WARNING) << "Takeover failed with error: " << res << " - " << res.message();
-    return cmnd_cntx->SendError(absl::StrCat("Couldn't execute takeover: ", res.message()));
+    return cmd_cntx->SendError(absl::StrCat("Couldn't execute takeover: ", res.message()));
   }
 
   LOG(INFO) << "Takeover successful, promoting this instance to master.";
@@ -3893,24 +3893,24 @@ void ServerFamily::ReplTakeOver(CmdArgList args, CommandContext* cmnd_cntx) {
   return builder->SendOk();
 }
 
-void ServerFamily::ReplConf(CmdArgList args, CommandContext* cmnd_cntx) {
-  auto* builder = cmnd_cntx->rb();
+void ServerFamily::ReplConf(CmdArgList args, CommandContext* cmd_cntx) {
+  auto* builder = cmd_cntx->rb();
   {
     util::fb2::LockGuard lk(replicaof_mu_);
     if (!IsMaster()) {
-      return cmnd_cntx->SendError("Replicating a replica is unsupported");
+      return cmd_cntx->SendError("Replicating a replica is unsupported");
     }
   }
 
   auto err_cb = [&]() mutable {
     LOG(ERROR) << "Error in receiving command: " << args;
-    cmnd_cntx->SendError(kSyntaxErr);
+    cmd_cntx->SendError(kSyntaxErr);
   };
 
   if (args.size() % 2 == 1)
     return err_cb();
 
-  ConnectionContext* cntx = cmnd_cntx->server_conn_cntx();
+  ConnectionContext* cntx = cmd_cntx->server_conn_cntx();
   for (unsigned i = 0; i < args.size(); i += 2) {
     DCHECK_LT(i + 1, args.size());
 
@@ -3938,7 +3938,7 @@ void ServerFamily::ReplConf(CmdArgList args, CommandContext* cmnd_cntx) {
     } else if (cmd == "LISTENING-PORT") {
       uint32_t replica_listening_port;
       if (!absl::SimpleAtoi(arg, &replica_listening_port)) {
-        return cmnd_cntx->SendError(kInvalidIntErr);
+        return cmd_cntx->SendError(kInvalidIntErr);
       }
       cntx->conn_state.replication_info.repl_listening_port = replica_listening_port;
       // We set a default value of ip_address here, because LISTENING-PORT is a mandatory field
@@ -3957,7 +3957,7 @@ void ServerFamily::ReplConf(CmdArgList args, CommandContext* cmnd_cntx) {
     } else if (cmd == "CLIENT-VERSION" && args.size() == 2) {
       unsigned version;
       if (!absl::SimpleAtoi(arg, &version)) {
-        return cmnd_cntx->SendError(kInvalidIntErr);
+        return cmd_cntx->SendError(kInvalidIntErr);
       }
       dfly_cmd_->SetDflyClientVersion(&cntx->conn_state, DflyVersion(version));
     } else if (cmd == "ACK" && args.size() == 2) {
@@ -3986,8 +3986,8 @@ void ServerFamily::ReplConf(CmdArgList args, CommandContext* cmnd_cntx) {
   return builder->SendOk();
 }
 
-void ServerFamily::Role(CmdArgList args, CommandContext* cmnd_cntx) {
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+void ServerFamily::Role(CmdArgList args, CommandContext* cmd_cntx) {
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   util::fb2::LockGuard lk(replicaof_mu_);
   // Thread local var is_master is updated under mutex replicaof_mu_ together with replica_,
   // ensuring eventual consistency of is_master. When determining if the server is a replica and
@@ -4030,27 +4030,27 @@ void ServerFamily::Role(CmdArgList args, CommandContext* cmnd_cntx) {
   }
 }
 
-void ServerFamily::Script(CmdArgList args, CommandContext* cmnd_cntx) {
-  script_mgr_->Run(args, cmnd_cntx->tx, cmnd_cntx->rb(), cmnd_cntx->server_conn_cntx());
+void ServerFamily::Script(CmdArgList args, CommandContext* cmd_cntx) {
+  script_mgr_->Run(args, cmd_cntx->tx(), cmd_cntx->rb(), cmd_cntx->server_conn_cntx());
 }
 
-void ServerFamily::LastSave(CmdArgList args, CommandContext* cmnd_cntx) {
+void ServerFamily::LastSave(CmdArgList args, CommandContext* cmd_cntx) {
   auto info = thread_safe_save_info_.Get();
-  cmnd_cntx->rb()->SendLong(info.save_time);
+  cmd_cntx->rb()->SendLong(info.save_time);
 }
 
-void ServerFamily::Latency(CmdArgList args, CommandContext* cmnd_cntx) {
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+void ServerFamily::Latency(CmdArgList args, CommandContext* cmd_cntx) {
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   string sub_cmd = absl::AsciiStrToUpper(ArgS(args, 0));
 
   if (sub_cmd == "LATEST" || sub_cmd == "HISTOGRAM") {
     return rb->SendEmptyArray();
   }
 
-  return cmnd_cntx->SendError(UnknownSubCmd(sub_cmd, "LATENCY"), kSyntaxErrType);
+  return cmd_cntx->SendError(UnknownSubCmd(sub_cmd, "LATENCY"), kSyntaxErrType);
 }
 
-void ServerFamily::ShutdownCmd(CmdArgList args, CommandContext* cmnd_cntx) {
+void ServerFamily::ShutdownCmd(CmdArgList args, CommandContext* cmd_cntx) {
   // Supported options (case-insensitive):
   // SAVE | NOSAVE, NOW, FORCE, ABORT, SAFE (Valkey-specific, the same as SAVE in Dragonfly)
   enum ShutBits : uint32_t {
@@ -4071,16 +4071,16 @@ void ServerFamily::ShutdownCmd(CmdArgList args, CommandContext* cmnd_cntx) {
     sb |= static_cast<uint32_t>(opt);
   }
 
-  RETURN_ON_PARSE_ERROR(parser, cmnd_cntx);
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   // Conflicting toggles
   if ((sb & SB_SAVE) && (sb & SB_NOSAVE)) {
-    return cmnd_cntx->SendError(kSyntaxErr);
+    return cmd_cntx->SendError(kSyntaxErr);
   }
 
   if (sb & SB_ABORT) {
     // We currently do not support aborting an in-progress shutdown sequence.
-    return cmnd_cntx->SendError("SHUTDOWN ABORT is not supported");
+    return cmd_cntx->SendError("SHUTDOWN ABORT is not supported");
   }
 
   // Configure save behavior on shutdown according to options.
@@ -4097,19 +4097,19 @@ void ServerFamily::ShutdownCmd(CmdArgList args, CommandContext* cmnd_cntx) {
   facade::g_shutdown_fast.store((sb & (SB_NOW | SB_FORCE)) != 0, std::memory_order_seq_cst);
 
   CHECK_NOTNULL(acceptor_)->Stop();
-  cmnd_cntx->rb()->SendOk();
+  cmd_cntx->rb()->SendOk();
 
   // Reset flag for any subsequent restarts (mainly for tests).
   facade::g_shutdown_fast.store(false, std::memory_order_seq_cst);
 }
 
-void ServerFamily::Dfly(CmdArgList args, CommandContext* cmnd_cntx) {
-  dfly_cmd_->Run(args, cmnd_cntx);
+void ServerFamily::Dfly(CmdArgList args, CommandContext* cmd_cntx) {
+  dfly_cmd_->Run(args, cmd_cntx);
 }
 
-void ServerFamily::SlowLog(CmdArgList args, CommandContext* cmnd_cntx) {
+void ServerFamily::SlowLog(CmdArgList args, CommandContext* cmd_cntx) {
   string sub_cmd = absl::AsciiStrToUpper(ArgS(args, 0));
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (sub_cmd == "HELP") {
     string_view help[] = {
         "SLOWLOG <subcommand> [<arg> [value] [opt] ...]. Subcommands are:",
@@ -4146,17 +4146,17 @@ void ServerFamily::SlowLog(CmdArgList args, CommandContext* cmnd_cntx) {
   }
 
   if (sub_cmd == "GET") {
-    return SlowLogGet(args, sub_cmd, &service_.proactor_pool(), cmnd_cntx);
+    return SlowLogGet(args, sub_cmd, &service_.proactor_pool(), cmd_cntx);
   }
-  cmnd_cntx->SendError(UnknownSubCmd(sub_cmd, "SLOWLOG"), kSyntaxErrType);
+  cmd_cntx->SendError(UnknownSubCmd(sub_cmd, "SLOWLOG"), kSyntaxErrType);
 }
 
-void ServerFamily::Module(CmdArgList args, CommandContext* cmnd_cntx) {
+void ServerFamily::Module(CmdArgList args, CommandContext* cmd_cntx) {
   string sub_cmd = absl::AsciiStrToUpper(ArgS(args, 0));
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
   if (sub_cmd != "LIST")
-    return cmnd_cntx->SendError(kSyntaxErr);
+    return cmd_cntx->SendError(kSyntaxErr);
 
   rb->StartArray(2);
 
@@ -4175,7 +4175,7 @@ void ServerFamily::Module(CmdArgList args, CommandContext* cmnd_cntx) {
   rb->SendLong(21'015);  // we target v2
 }
 
-void ServerFamily::ClientPauseCmd(CmdArgList args, CommandContext* cmnd_cntx) {
+void ServerFamily::ClientPauseCmd(CmdArgList args, CommandContext* cmd_cntx) {
   CmdArgParser parser(args);
   auto listeners = GetNonPriviligedListeners();
 
@@ -4184,7 +4184,7 @@ void ServerFamily::ClientPauseCmd(CmdArgList args, CommandContext* cmnd_cntx) {
   if (parser.HasNext()) {
     pause_state = parser.MapNext("WRITE", ClientPause::WRITE, "ALL", ClientPause::ALL);
   }
-  RETURN_ON_PARSE_ERROR(parser, cmnd_cntx);
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   const auto timeout_ms = timeout * 1ms;
   auto is_pause_in_progress = [this, end_time = chrono::steady_clock::now() + timeout_ms] {
@@ -4197,16 +4197,16 @@ void ServerFamily::ClientPauseCmd(CmdArgList args, CommandContext* cmnd_cntx) {
     client_pause_ec_.notify();
   };
 
-  ConnectionContext* cntx = cmnd_cntx->server_conn_cntx();
+  ConnectionContext* cntx = cmd_cntx->server_conn_cntx();
   if (auto pause_fb_opt = Pause(listeners, cntx->ns, cntx->conn(), pause_state,
                                 std::move(is_pause_in_progress), cleanup);
       pause_fb_opt) {
     is_c_pause_in_progress_.store(true);
     active_pauses_.fetch_add(1);
     pause_fb_opt->Detach();
-    return cmnd_cntx->rb()->SendOk();
+    return cmd_cntx->rb()->SendOk();
   }
-  cmnd_cntx->SendError("Failed to pause all running clients");
+  cmd_cntx->SendError("Failed to pause all running clients");
 }
 
 #define HFUNC(x) SetHandler(HandlerFunc(this, &ServerFamily::x))

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -685,27 +685,27 @@ struct GetReplies {
   RedisReplyBuilder* rb;
 };
 
-void ExtendGeneric(CmdArgList args, bool prepend, CommandContext* cmnd_cntx) {
+void ExtendGeneric(CmdArgList args, bool prepend, CommandContext* cmd_cntx) {
   string_view key = ArgS(args, 0);
   string_view value = ArgS(args, 1);
   VLOG(2) << "ExtendGeneric(" << key << ", " << value << ")";
 
-  if (cmnd_cntx->mc_command() == nullptr) {
+  if (cmd_cntx->mc_command() == nullptr) {
     auto cb = [&](Transaction* t, EngineShard* shard) {
       return OpExtend(t->GetOpArgs(shard), key, value, prepend);
     };
 
-    RedisReplyBuilder* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
-    GetReplies{rb}.Send(cmnd_cntx->tx->ScheduleSingleHopT(cb));
+    RedisReplyBuilder* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+    GetReplies{rb}.Send(cmd_cntx->tx()->ScheduleSingleHopT(cb));
   } else {
     // Memcached skips if key is missing
     auto cb = [&](Transaction* t, EngineShard* shard) {
       return ExtendOrSkip(t->GetOpArgs(shard), key, value, prepend);
     };
 
-    OpResult<bool> result = cmnd_cntx->tx->ScheduleSingleHopT(std::move(cb));
-    MCRender render(cmnd_cntx->mc_command()->cmd_flags);
-    cmnd_cntx->SendSimpleString(render.RenderStored(result.value_or(false)));
+    OpResult<bool> result = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
+    MCRender render(cmd_cntx->mc_command()->cmd_flags);
+    cmd_cntx->SendSimpleString(render.RenderStored(result.value_or(false)));
   }
 }
 
@@ -713,38 +713,38 @@ void ExtendGeneric(CmdArgList args, bool prepend, CommandContext* cmnd_cntx) {
 OpStatus SetGeneric(const SetCmd::SetParams& sparams, string_view key, string_view value,
                     const CommandContext& ctx) {
   bool explicit_journal = ctx.cid->opt_mask() & CO::NO_AUTOJOURNAL;
-  return ctx.tx->ScheduleSingleHop([&](Transaction* t, EngineShard* shard) {
+  return ctx.tx()->ScheduleSingleHop([&](Transaction* t, EngineShard* shard) {
     return SetCmd(t->GetOpArgs(shard), explicit_journal).Set(sparams, key, value);
   });
 }
 
-void IncrByGeneric(string_view key, int64_t val, CommandContext* cmnd_cntx) {
-  bool skip_on_missing = (cmnd_cntx->mc_command() != nullptr);
+void IncrByGeneric(string_view key, int64_t val, CommandContext* cmd_cntx) {
+  bool skip_on_missing = (cmd_cntx->mc_command() != nullptr);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     OpResult<int64_t> res = OpIncrBy(t->GetOpArgs(shard), key, val, skip_on_missing);
     return res;
   };
 
-  OpResult<int64_t> result = cmnd_cntx->tx->ScheduleSingleHopT(std::move(cb));
+  OpResult<int64_t> result = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
 
   DVLOG(2) << "IncrByGeneric " << key << "/" << result.value();
 
   switch (result.status()) {
     case OpStatus::OK:
-      cmnd_cntx->SendLong(result.value());
+      cmd_cntx->SendLong(result.value());
       break;
     case OpStatus::INVALID_VALUE:
-      cmnd_cntx->SendError(kInvalidIntErr);
+      cmd_cntx->SendError(kInvalidIntErr);
       break;
     case OpStatus::OUT_OF_RANGE:
-      cmnd_cntx->SendError(kIncrOverflow);
+      cmd_cntx->SendError(kIncrOverflow);
       break;
     case OpStatus::KEY_NOTFOUND:  // Relevant only for MC
-      cmnd_cntx->SendNotFound();
+      cmd_cntx->SendNotFound();
       break;
     default:
-      cmnd_cntx->SendError(result.status());
+      cmd_cntx->SendError(result.status());
       break;
   }
 }
@@ -980,15 +980,15 @@ OpStatus SetCmd::CachePrevIfNeeded(const SetCmd::SetParams& params, DbSlice::Ite
   return OpStatus::OK;
 }
 
-void CmdSet(CmdArgList args, CommandContext* cmnd_cntx) {
+void CmdSet(CmdArgList args, CommandContext* cmd_cntx) {
   facade::CmdArgParser parser{args};
 
   auto [key, value] = parser.Next<string_view, string_view>();
 
   SetCmd::SetParams sparams;
 
-  sparams.memcache_flags = cmnd_cntx->mc_command() ? cmnd_cntx->mc_command()->flags : 0;
-  auto* builder = cmnd_cntx->rb();
+  sparams.memcache_flags = cmd_cntx->mc_command() ? cmd_cntx->mc_command()->flags : 0;
+  auto* builder = cmd_cntx->rb();
 
   while (parser.HasNext()) {
     if (auto exp_type = parser.TryMapNext("EX", ExpT::EX, "PX", ExpT::PX, "EXAT", ExpT::EXAT,
@@ -1001,13 +1001,13 @@ void CmdSet(CmdArgList args, CommandContext* cmnd_cntx) {
 
       // We can set expiry only once.
       if (sparams.flags & SetCmd::SET_EXPIRE_AFTER_MS)
-        return cmnd_cntx->SendError(kSyntaxErr);
+        return cmd_cntx->SendError(kSyntaxErr);
 
       sparams.flags |= SetCmd::SET_EXPIRE_AFTER_MS;
 
       // Since PXAT/EXAT can change this, we need to check this ahead
       if (int_arg <= 0) {
-        return cmnd_cntx->SendError(InvalidExpireTime("set"));
+        return cmd_cntx->SendError(InvalidExpireTime("set"));
       }
 
       DbSlice::ExpireParams expiry{
@@ -1019,20 +1019,20 @@ void CmdSet(CmdArgList args, CommandContext* cmnd_cntx) {
       int64_t now_ms = GetCurrentTimeMs();
       auto [rel_ms, abs_ms] = expiry.Calculate(now_ms, false);
       if (abs_ms < 0)
-        return cmnd_cntx->SendError(InvalidExpireTime("set"));
+        return cmd_cntx->SendError(InvalidExpireTime("set"));
 
       // Remove existed key if the key is expired already
       if (rel_ms < 0) {
-        cmnd_cntx->tx->ScheduleSingleHop([](const Transaction* tx, EngineShard* es) {
+        cmd_cntx->tx()->ScheduleSingleHop([](const Transaction* tx, EngineShard* es) {
           ShardArgs args = tx->GetShardArgs(es->shard_id());
           GenericFamily::OpDel(tx->GetOpArgs(es), args, false);
           return OpStatus::OK;
         });
-        if (cmnd_cntx->mc_command() != nullptr) {
-          cmnd_cntx->SendSimpleString(
-              MCRender{cmnd_cntx->mc_command()->cmd_flags}.RenderStored(true));
+        if (cmd_cntx->mc_command() != nullptr) {
+          cmd_cntx->SendSimpleString(
+              MCRender{cmd_cntx->mc_command()->cmd_flags}.RenderStored(true));
         } else {
-          cmnd_cntx->SendOk();
+          cmd_cntx->SendOk();
         }
         return;
       }
@@ -1048,16 +1048,16 @@ void CmdSet(CmdArgList args, CommandContext* cmnd_cntx) {
     }
   }
 
-  RETURN_ON_PARSE_ERROR(parser, cmnd_cntx);
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   auto has_mask = [&](uint16_t m) { return (sparams.flags & m) == m; };
 
   if (has_mask(SetCmd::SET_IF_EXISTS | SetCmd::SET_IF_NOTEXIST) ||
       has_mask(SetCmd::SET_KEEP_EXPIRE | SetCmd::SET_EXPIRE_AFTER_MS)) {
-    return cmnd_cntx->SendError(kSyntaxErr);
+    return cmd_cntx->SendError(kSyntaxErr);
   }
 
-  if (cmnd_cntx->AsyncExecutionAllowed()) {
+  if (cmd_cntx->AsyncExecutionAllowed()) {
     // TODO: run asynchronous flow and exit.
     // 1.
     //    a. Transaction should support non-blocking execution for single hop/single shard commands.
@@ -1077,36 +1077,36 @@ void CmdSet(CmdArgList args, CommandContext* cmnd_cntx) {
     //    to worry about reordering of responses, as pipelined ParsedCommands will be
     //    already ordered.
 
-    boost::intrusive_ptr<Transaction> tr_ptr(cmnd_cntx->tx);
-    auto cb = [cmnd_cntx, sparams, tr_ptr]() {
+    boost::intrusive_ptr<Transaction> tr_ptr(cmd_cntx->tx());
+    auto cb = [cmd_cntx, sparams, tr_ptr]() {
       EngineShard* shard = EngineShard::tlocal();
-      bool explicit_journal = cmnd_cntx->cid->opt_mask() & CO::NO_AUTOJOURNAL;
+      bool explicit_journal = cmd_cntx->cid->opt_mask() & CO::NO_AUTOJOURNAL;
       SetCmd set_cmd(OpArgs{shard, nullptr, tr_ptr->GetDbContext()}, explicit_journal);
 
       // If we are here, it's Memcache SET (because AsyncExecutionAllowed is true).
       // So we can use mc_command data.
       // For Memcache, we use the values from the command.
       // TODO: we will need to get arguments in a different way for Redis protocol.
-      DCHECK(cmnd_cntx->mc_command());
-      std::string_view key = cmnd_cntx->mc_command()->key();
-      std::string_view value = cmnd_cntx->mc_command()->value();
+      DCHECK(cmd_cntx->mc_command());
+      std::string_view key = cmd_cntx->mc_command()->key();
+      std::string_view value = cmd_cntx->mc_command()->value();
 
       OpStatus status = set_cmd.Set(sparams, key, value);
 
       if (status == OpStatus::SKIPPED || status == OpStatus::OK) {
         // Relevant to MC.
-        MCRender render(cmnd_cntx->mc_command()->cmd_flags);
-        cmnd_cntx->SendSimpleString(render.RenderStored(status == OpStatus::OK));
+        MCRender render(cmd_cntx->mc_command()->cmd_flags);
+        cmd_cntx->SendSimpleString(render.RenderStored(status == OpStatus::OK));
         return;
       }
       if (status == OpStatus::OUT_OF_MEMORY) {
-        return cmnd_cntx->SendError(kOutOfMemory);
+        return cmd_cntx->SendError(kOutOfMemory);
       }
       LOG(FATAL) << "TBD " << status;
     };
 
-    cmnd_cntx->SetDeferredReply();  // we defer the reply for sure.
-    ShardId shard_id = cmnd_cntx->tx->GetUniqueShard();
+    cmd_cntx->SetDeferredReply();  // we defer the reply for sure.
+    ShardId shard_id = cmd_cntx->tx()->GetUniqueShard();
     shard_set->Add(shard_id, cb);
 
     return;
@@ -1119,7 +1119,7 @@ void CmdSet(CmdArgList args, CommandContext* cmnd_cntx) {
   optional<util::fb2::Future<bool>> backpressure;
   sparams.backpressure = &backpressure;
 
-  OpStatus result = SetGeneric(sparams, key, value, *cmnd_cntx);
+  OpStatus result = SetGeneric(sparams, key, value, *cmd_cntx);
   if (result == OpStatus::WRONG_TYPE) {
     return builder->SendError(kWrongTypeErr);
   }
@@ -1130,35 +1130,35 @@ void CmdSet(CmdArgList args, CommandContext* cmnd_cntx) {
   }
 
   if (sparams.flags & SetCmd::SET_GET) {
-    return GetReplies{cmnd_cntx->rb()}.Send(std::move(prev));
+    return GetReplies{cmd_cntx->rb()}.Send(std::move(prev));
   }
 
   if (result == OpStatus::OUT_OF_MEMORY) {
-    return cmnd_cntx->SendError(kOutOfMemory);
+    return cmd_cntx->SendError(kOutOfMemory);
   }
 
-  if (cmnd_cntx->mc_command() != nullptr) {
-    MCRender render(cmnd_cntx->mc_command()->cmd_flags);
-    return cmnd_cntx->SendSimpleString(render.RenderStored(result == OpStatus::OK));
+  if (cmd_cntx->mc_command() != nullptr) {
+    MCRender render(cmd_cntx->mc_command()->cmd_flags);
+    return cmd_cntx->SendSimpleString(render.RenderStored(result == OpStatus::OK));
   }
   if (result == OpStatus::OK) {
-    cmnd_cntx->SendOk();
+    cmd_cntx->SendOk();
   } else {
-    cmnd_cntx->SendNull();
+    cmd_cntx->SendNull();
   }
 }
 
 /// (P)SETEX key seconds (milliseconds) value
-void CmdSetExGeneric(CmdArgList args, CommandContext* cmnd_cntx) {
-  string_view cmd_name = cmnd_cntx->cid->name();
+void CmdSetExGeneric(CmdArgList args, CommandContext* cmd_cntx) {
+  string_view cmd_name = cmd_cntx->cid->name();
 
   CmdArgParser parser{args};
   auto [key, exp_int, value] = parser.Next<string_view, int64_t, string_view>();
 
-  RETURN_ON_PARSE_ERROR(parser, cmnd_cntx);
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   if (exp_int < 1)
-    return cmnd_cntx->SendError(InvalidExpireTime(cmd_name));
+    return cmd_cntx->SendError(InvalidExpireTime(cmd_name));
 
   DbSlice::ExpireParams expiry{
       .value = exp_int,
@@ -1169,36 +1169,36 @@ void CmdSetExGeneric(CmdArgList args, CommandContext* cmnd_cntx) {
   int64_t now_ms = GetCurrentTimeMs();
   auto [_, abs_ms] = expiry.Calculate(now_ms, false);
   if (abs_ms < 0)
-    return cmnd_cntx->SendError(InvalidExpireTime("set"));
+    return cmd_cntx->SendError(InvalidExpireTime("set"));
 
   SetCmd::SetParams sparams;
   sparams.flags |= SetCmd::SET_EXPIRE_AFTER_MS;
   sparams.expire_after_ms = expiry.Calculate(now_ms, true).first;
-  cmnd_cntx->SendError(SetGeneric(sparams, key, value, *cmnd_cntx));
+  cmd_cntx->SendError(SetGeneric(sparams, key, value, *cmd_cntx));
 }
 
-void CmdSetNx(CmdArgList args, CommandContext* cmnd_cntx) {
+void CmdSetNx(CmdArgList args, CommandContext* cmd_cntx) {
   string_view key = ArgS(args, 0);
   string_view value = ArgS(args, 1);
 
   SetCmd::SetParams sparams;
   sparams.flags |= SetCmd::SET_IF_NOTEXIST;
-  if (cmnd_cntx->mc_command())
-    sparams.memcache_flags = cmnd_cntx->mc_command()->flags;
+  if (cmd_cntx->mc_command())
+    sparams.memcache_flags = cmd_cntx->mc_command()->flags;
 
-  switch (SetGeneric(sparams, key, value, *cmnd_cntx)) {
+  switch (SetGeneric(sparams, key, value, *cmd_cntx)) {
     case OpStatus::OK:
-      return cmnd_cntx->SendLong(1);  // Successfully set the value
+      return cmd_cntx->SendLong(1);  // Successfully set the value
     case OpStatus::OUT_OF_MEMORY:
-      return cmnd_cntx->SendError(kOutOfMemory);
+      return cmd_cntx->SendError(kOutOfMemory);
     case OpStatus::SKIPPED:
-      return cmnd_cntx->SendLong(0);  // Existed, zero updates performed
+      return cmd_cntx->SendLong(0);  // Existed, zero updates performed
     default:
       LOG(FATAL) << "Invalid result";
   }
 }
 
-void CmdGet(CmdArgList args, CommandContext* cmnd_cntx) {
+void CmdGet(CmdArgList args, CommandContext* cmd_cntx) {
   auto cb = [key = ArgS(args, 0)](Transaction* tx, EngineShard* es) -> OpResult<StringResult> {
     auto it_res = tx->GetDbSlice(es->shard_id()).FindReadOnly(tx->GetDbContext(), key, OBJ_STRING);
     if (!it_res.ok())
@@ -1207,10 +1207,10 @@ void CmdGet(CmdArgList args, CommandContext* cmnd_cntx) {
     return ReadString(tx->GetDbIndex(), key, (*it_res)->second, es);
   };
 
-  GetReplies{cmnd_cntx->rb()}.Send(cmnd_cntx->tx->ScheduleSingleHopT(cb));
+  GetReplies{cmd_cntx->rb()}.Send(cmd_cntx->tx()->ScheduleSingleHopT(cb));
 }
 
-void CmdGetDel(CmdArgList args, CommandContext* cmnd_cntx) {
+void CmdGetDel(CmdArgList args, CommandContext* cmd_cntx) {
   auto cb = [key = ArgS(args, 0)](Transaction* tx, EngineShard* es) -> OpResult<StringResult> {
     auto& db_slice = tx->GetDbSlice(es->shard_id());
     auto it_res = db_slice.FindMutable(tx->GetDbContext(), key, OBJ_STRING);
@@ -1222,50 +1222,50 @@ void CmdGetDel(CmdArgList args, CommandContext* cmnd_cntx) {
     return value;
   };
 
-  GetReplies{cmnd_cntx->rb()}.Send(cmnd_cntx->tx->ScheduleSingleHopT(cb));
+  GetReplies{cmd_cntx->rb()}.Send(cmd_cntx->tx()->ScheduleSingleHopT(cb));
 }
 
-void CmdGetSet(CmdArgList args, CommandContext* cmnd_cntx) {
+void CmdGetSet(CmdArgList args, CommandContext* cmd_cntx) {
   string_view key = ArgS(args, 0);
   string_view value = ArgS(args, 1);
 
   optional<StringResult> prev;
   SetCmd::SetParams sparams{.prev_val = &prev};
 
-  if (OpStatus status = SetGeneric(sparams, key, value, *cmnd_cntx); status != OpStatus::OK)
-    return cmnd_cntx->SendError(status);
+  if (OpStatus status = SetGeneric(sparams, key, value, *cmd_cntx); status != OpStatus::OK)
+    return cmd_cntx->SendError(status);
 
-  GetReplies{cmnd_cntx->rb()}.Send(std::move(prev));
+  GetReplies{cmd_cntx->rb()}.Send(std::move(prev));
 }
 
-void CmdAppend(CmdArgList args, CommandContext* cmnd_cntx) {
-  ExtendGeneric(args, false, cmnd_cntx);
+void CmdAppend(CmdArgList args, CommandContext* cmd_cntx) {
+  ExtendGeneric(args, false, cmd_cntx);
 }
 
-void CmdPrepend(CmdArgList args, CommandContext* cmnd_cntx) {
-  ExtendGeneric(args, true, cmnd_cntx);
+void CmdPrepend(CmdArgList args, CommandContext* cmd_cntx) {
+  ExtendGeneric(args, true, cmd_cntx);
 }
 
-void CmdGetEx(CmdArgList args, CommandContext* cmnd_cntx) {
+void CmdGetEx(CmdArgList args, CommandContext* cmd_cntx) {
   CmdArgParser parser{args};
   string_view key = parser.Next();
 
   DbSlice::ExpireParams exp_params;
   bool defined = false;
-  auto* builder = cmnd_cntx->rb();
+  auto* builder = cmd_cntx->rb();
   while (parser.HasNext()) {
     if (auto exp_type = parser.TryMapNext("EX", ExpT::EX, "PX", ExpT::PX, "EXAT", ExpT::EXAT,
                                           "PXAT", ExpT::PXAT);
         exp_type) {
       auto int_arg = parser.Next<int64_t>();
-      RETURN_ON_PARSE_ERROR(parser, cmnd_cntx);
+      RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
       if (defined) {
-        return cmnd_cntx->SendError(kSyntaxErr, kSyntaxErrType);
+        return cmd_cntx->SendError(kSyntaxErr, kSyntaxErrType);
       }
 
       if (int_arg <= 0) {
-        return cmnd_cntx->SendError(InvalidExpireTime("getex"));
+        return cmd_cntx->SendError(InvalidExpireTime("getex"));
       }
 
       exp_params.absolute = *exp_type == ExpT::EXAT || *exp_type == ExpT::PXAT;
@@ -1309,67 +1309,67 @@ void CmdGetEx(CmdArgList args, CommandContext* cmnd_cntx) {
     return value;
   };
 
-  GetReplies{cmnd_cntx->rb()}.Send(cmnd_cntx->tx->ScheduleSingleHopT(cb));
+  GetReplies{cmd_cntx->rb()}.Send(cmd_cntx->tx()->ScheduleSingleHopT(cb));
 }
 
-void CmdIncr(CmdArgList args, CommandContext* cmnd_cntx) {
+void CmdIncr(CmdArgList args, CommandContext* cmd_cntx) {
   string_view key = ArgS(args, 0);
-  return IncrByGeneric(key, 1, cmnd_cntx);
+  return IncrByGeneric(key, 1, cmd_cntx);
 }
 
-void CmdIncrBy(CmdArgList args, CommandContext* cmnd_cntx) {
+void CmdIncrBy(CmdArgList args, CommandContext* cmd_cntx) {
   string_view key = ArgS(args, 0);
   string_view sval = ArgS(args, 1);
   int64_t val;
 
   if (!absl::SimpleAtoi(sval, &val)) {
-    return cmnd_cntx->SendError(kInvalidIntErr);
+    return cmd_cntx->SendError(kInvalidIntErr);
   }
-  return IncrByGeneric(key, val, cmnd_cntx);
+  return IncrByGeneric(key, val, cmd_cntx);
 }
 
-void CmdIncrByFloat(CmdArgList args, CommandContext* cmnd_cntx) {
+void CmdIncrByFloat(CmdArgList args, CommandContext* cmd_cntx) {
   string_view key = ArgS(args, 0);
   string_view sval = ArgS(args, 1);
   double val;
 
   if (!absl::SimpleAtod(sval, &val)) {
-    return cmnd_cntx->SendError(kInvalidFloatErr);
+    return cmd_cntx->SendError(kInvalidFloatErr);
   }
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpIncrFloat(t->GetOpArgs(shard), key, val);
   };
 
-  OpResult<double> result = cmnd_cntx->tx->ScheduleSingleHopT(std::move(cb));
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+  OpResult<double> result = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
   DVLOG(2) << "IncrByGeneric " << key << "/" << result.value();
   if (!result) {
-    return cmnd_cntx->SendError(result.status());
+    return cmd_cntx->SendError(result.status());
   }
 
   rb->SendDouble(result.value());
 }
 
-void CmdDecr(CmdArgList args, CommandContext* cmnd_cntx) {
+void CmdDecr(CmdArgList args, CommandContext* cmd_cntx) {
   string_view key = ArgS(args, 0);
-  return IncrByGeneric(key, -1, cmnd_cntx);
+  return IncrByGeneric(key, -1, cmd_cntx);
 }
 
-void CmdDecrBy(CmdArgList args, CommandContext* cmnd_cntx) {
+void CmdDecrBy(CmdArgList args, CommandContext* cmd_cntx) {
   string_view key = ArgS(args, 0);
   string_view sval = ArgS(args, 1);
   int64_t val;
 
   if (!absl::SimpleAtoi(sval, &val)) {
-    return cmnd_cntx->SendError(kInvalidIntErr);
+    return cmd_cntx->SendError(kInvalidIntErr);
   }
   if (val == INT64_MIN) {
-    return cmnd_cntx->SendError(kIncrOverflow);
+    return cmd_cntx->SendError(kIncrOverflow);
   }
 
-  return IncrByGeneric(key, -val, cmnd_cntx);
+  return IncrByGeneric(key, -val, cmd_cntx);
 }
 
 // Reorder per-shard results according to argument order of primary command
@@ -1393,14 +1393,14 @@ void ReorderShardResults(absl::Span<MGetResponse> mget_resp, const Transaction* 
   }
 }
 
-void MGetGeneric(CmdArgList args, CommandContext* cmnd_cntx,
+void MGetGeneric(CmdArgList args, CommandContext* cmd_cntx,
                  const DbSlice::ExpireParams* gat_params) {
   DCHECK_GE(args.size(), 1U);
 
   MemcacheCmdFlags cmd_flags;
 
-  if (cmnd_cntx->mc_command()) {
-    cmd_flags = cmnd_cntx->mc_command()->cmd_flags;
+  if (cmd_cntx->mc_command()) {
+    cmd_flags = cmd_cntx->mc_command()->cmd_flags;
   }
 
   fb2::BlockingCounter tiering_bc{0};  // Count of pending tiered reads
@@ -1414,42 +1414,42 @@ void MGetGeneric(CmdArgList args, CommandContext* cmnd_cntx,
     return OpStatus::OK;
   };
 
-  OpStatus result = cmnd_cntx->tx->ScheduleSingleHop(std::move(cb));
+  OpStatus result = cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));
   CHECK_EQ(OpStatus::OK, result);
 
   // wait for all tiered reads to finish and check for errors
   tiering_bc->Wait();
   if (auto err = std::move(tiering_err).Destroy(); err)
-    return cmnd_cntx->SendError(err.message());
+    return cmd_cntx->SendError(err.message());
 
   size_t arg_len = args.size();
 
   unique_ptr<optional<GetResp>[]> mget_results(new optional<GetResp>[arg_len]);
-  ReorderShardResults(absl::MakeSpan(mget_resp.get(), shard_set->size()), cmnd_cntx->tx,
+  ReorderShardResults(absl::MakeSpan(mget_resp.get(), shard_set->size()), cmd_cntx->tx(),
                       absl::MakeSpan(mget_results.get(), arg_len));
 
-  if (cmnd_cntx->mc_command()) {
+  if (cmd_cntx->mc_command()) {
     // We can not access `args` inside the lambda below if it runs asynchronously.
-    // Access to arguments must be done via cmnd_cntx.
-    auto replier = [mget_results = std::move(mget_results), cmnd_cntx](SinkReplyBuilder* builder) {
+    // Access to arguments must be done via cmd_cntx.
+    auto replier = [mget_results = std::move(mget_results), cmd_cntx](SinkReplyBuilder* builder) {
       auto* mc_builder = static_cast<MCReplyBuilder*>(builder);
-      facade::MCRender mc_render{cmnd_cntx->mc_command()->cmd_flags};
-      for (size_t i = 0; i < cmnd_cntx->size(); ++i) {
+      facade::MCRender mc_render{cmd_cntx->mc_command()->cmd_flags};
+      for (size_t i = 0; i < cmd_cntx->size(); ++i) {
         const auto& entry = mget_results[i];
         if (entry) {
-          mc_builder->SendValue(cmnd_cntx->mc_command()->cmd_flags, cmnd_cntx->at(i), entry->value,
-                                0, entry->mc_flag, entry->ttl_sec);
+          mc_builder->SendValue(cmd_cntx->mc_command()->cmd_flags, cmd_cntx->at(i), entry->value, 0,
+                                entry->mc_flag, entry->ttl_sec);
         } else {
           mc_builder->SendSimpleString(mc_render.RenderMiss());
         }
       }
       mc_builder->SendSimpleString(mc_render.RenderGetEnd());
     };
-    cmnd_cntx->ReplyWith(std::move(replier));
+    cmd_cntx->ReplyWith(std::move(replier));
   } else {
-    // TODO: remove arg_len capture once we store RESP arguments inside cmnd_cntx.
+    // TODO: remove arg_len capture once we store RESP arguments inside cmd_cntx.
     auto replier = [arg_len, mget_results = std::move(mget_results),
-                    cmnd_cntx](SinkReplyBuilder* builder) {
+                    cmd_cntx](SinkReplyBuilder* builder) {
       auto* redis_builder = static_cast<RedisReplyBuilder*>(builder);
       redis_builder->StartArray(arg_len);
       for (size_t i = 0; i < arg_len; ++i) {
@@ -1461,32 +1461,32 @@ void MGetGeneric(CmdArgList args, CommandContext* cmnd_cntx,
         }
       }
     };
-    cmnd_cntx->ReplyWith(std::move(replier));
+    cmd_cntx->ReplyWith(std::move(replier));
   }
 }
 
-void CmdMGet(CmdArgList args, CommandContext* cmnd_cntx) {
-  MGetGeneric(args, cmnd_cntx, nullptr);
+void CmdMGet(CmdArgList args, CommandContext* cmd_cntx) {
+  MGetGeneric(args, cmd_cntx, nullptr);
 }
 
 // Implements the memcache GAT command. The expected input is
 // GAT key [keys...]
 // The expiry argument is stored in mc_command()->expire_ts
-void CmdGAT(CmdArgList args, CommandContext* cmnd_cntx) {
-  DCHECK(cmnd_cntx->mc_command());
-  int64_t expire_ts = cmnd_cntx->mc_command()->expire_ts;
+void CmdGAT(CmdArgList args, CommandContext* cmd_cntx) {
+  DCHECK(cmd_cntx->mc_command());
+  int64_t expire_ts = cmd_cntx->mc_command()->expire_ts;
   const DbSlice::ExpireParams expire_params{
       .value = expire_ts, .absolute = true, .persist = expire_ts == 0};
-  MGetGeneric(args, cmnd_cntx, &expire_params);
+  MGetGeneric(args, cmd_cntx, &expire_params);
 }
 
-void CmdMSet(CmdArgList args, CommandContext* cmnd_cntx) {
+void CmdMSet(CmdArgList args, CommandContext* cmd_cntx) {
   if (VLOG_IS_ON(2)) {
     string str;
     for (size_t i = 1; i < args.size(); ++i) {
       absl::StrAppend(&str, " ", ArgS(args, i));
     }
-    LOG(INFO) << "MSET/" << cmnd_cntx->tx->GetUniqueShardCnt() << str;
+    LOG(INFO) << "MSET/" << cmd_cntx->tx()->GetUniqueShardCnt() << str;
   }
 
   AggregateStatus result;
@@ -1497,17 +1497,17 @@ void CmdMSet(CmdArgList args, CommandContext* cmnd_cntx) {
     return OpStatus::OK;
   };
 
-  if (auto status = cmnd_cntx->tx->ScheduleSingleHop(std::move(cb)); status != OpStatus::OK)
+  if (auto status = cmd_cntx->tx()->ScheduleSingleHop(std::move(cb)); status != OpStatus::OK)
     result = status;
 
   if (*result == OpStatus::OK) {
-    cmnd_cntx->SendOk();
+    cmd_cntx->SendOk();
   } else {
-    cmnd_cntx->SendError(*result);
+    cmd_cntx->SendError(*result);
   }
 }
 
-void CmdMSetNx(CmdArgList args, CommandContext* cmnd_cntx) {
+void CmdMSetNx(CmdArgList args, CommandContext* cmd_cntx) {
   atomic_bool exists{false};
 
   auto cb = [&](Transaction* t, EngineShard* es) {
@@ -1526,7 +1526,7 @@ void CmdMSetNx(CmdArgList args, CommandContext* cmnd_cntx) {
     return OpStatus::OK;
   };
 
-  cmnd_cntx->tx->Execute(std::move(cb), false);
+  cmd_cntx->tx()->Execute(std::move(cb), false);
   const bool to_skip = exists.load(memory_order_relaxed);
 
   AggregateStatus result;
@@ -1539,37 +1539,37 @@ void CmdMSetNx(CmdArgList args, CommandContext* cmnd_cntx) {
       result = status;
     return OpStatus::OK;
   };
-  cmnd_cntx->tx->Execute(std::move(epilog_cb), true);
+  cmd_cntx->tx()->Execute(std::move(epilog_cb), true);
 
-  cmnd_cntx->SendLong(to_skip || (*result != OpStatus::OK) ? 0 : 1);
+  cmd_cntx->SendLong(to_skip || (*result != OpStatus::OK) ? 0 : 1);
 }
 
-void CmdStrLen(CmdArgList args, CommandContext* cmnd_cntx) {
+void CmdStrLen(CmdArgList args, CommandContext* cmd_cntx) {
   auto cb = [key = ArgS(args, 0)](Transaction* t, EngineShard* shard) {
     return OpStrLen(t->GetOpArgs(shard), key);
   };
-  GetReplies{cmnd_cntx->rb()}.Send(cmnd_cntx->tx->ScheduleSingleHopT(cb));
+  GetReplies{cmd_cntx->rb()}.Send(cmd_cntx->tx()->ScheduleSingleHopT(cb));
 }
 
-void CmdGetRange(CmdArgList args, CommandContext* cmnd_cntx) {
+void CmdGetRange(CmdArgList args, CommandContext* cmd_cntx) {
   CmdArgParser parser(args);
   auto [key, start, end] = parser.Next<string_view, int32_t, int32_t>();
 
-  RETURN_ON_PARSE_ERROR(parser, cmnd_cntx);
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   auto cb = [&, &key = key, &start = start, &end = end](Transaction* t, EngineShard* shard) {
     return OpGetRange(t->GetOpArgs(shard), key, start, end);
   };
 
-  GetReplies{cmnd_cntx->rb()}.Send(cmnd_cntx->tx->ScheduleSingleHopT(cb));
+  GetReplies{cmd_cntx->rb()}.Send(cmd_cntx->tx()->ScheduleSingleHopT(cb));
 }
 
-void CmdSetRange(CmdArgList args, CommandContext* cmnd_cntx) {
+void CmdSetRange(CmdArgList args, CommandContext* cmd_cntx) {
   CmdArgParser parser(args);
   auto [key, start, value] = parser.Next<string_view, int32_t, string_view>();
-  auto* builder = cmnd_cntx->rb();
+  auto* builder = cmd_cntx->rb();
 
-  RETURN_ON_PARSE_ERROR(parser, cmnd_cntx);
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   if (start < 0) {
     return builder->SendError("offset is out of range");
@@ -1582,7 +1582,7 @@ void CmdSetRange(CmdArgList args, CommandContext* cmnd_cntx) {
   auto cb = [&, &key = key, &start = start, &value = value](Transaction* t, EngineShard* shard) {
     return OpSetRange(t->GetOpArgs(shard), key, start, value);
   };
-  GetReplies{builder}.Send(cmnd_cntx->tx->ScheduleSingleHopT(cb));
+  GetReplies{builder}.Send(cmd_cntx->tx()->ScheduleSingleHopT(cb));
 }
 
 /* CL.THROTTLE <key> <max_burst> <count per period> <period> [<quantity>] */
@@ -1598,11 +1598,11 @@ void CmdSetRange(CmdArgList args, CommandContext* cmnd_cntx) {
  *  5. The number of seconds until the limit will reset to its maximum capacity.
  * Equivalent to X-RateLimit-Reset.
  */
-void CmdClThrottle(CmdArgList args, CommandContext* cmnd_cntx) {
+void CmdClThrottle(CmdArgList args, CommandContext* cmd_cntx) {
   constexpr uint64_t kSecondToNanoSecond = 1000000000;
   const string_view key = ArgS(args, 0);
 
-  auto* rb = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   // Allow max burst in number of tokens
   uint64_t max_burst;
   const string_view max_burst_str = ArgS(args, 1);
@@ -1651,22 +1651,22 @@ void CmdClThrottle(CmdArgList args, CommandContext* cmnd_cntx) {
   }
 
   if (emission_interval_ns > INT64_MAX / limit) {
-    return cmnd_cntx->SendError(kInvalidIntErr);
+    return cmd_cntx->SendError(kInvalidIntErr);
   }
 
   if (quantity != 0 && static_cast<uint64_t>(emission_interval_ns) > INT64_MAX / quantity) {
-    return cmnd_cntx->SendError(kInvalidIntErr);
+    return cmd_cntx->SendError(kInvalidIntErr);
   }
 
   auto cb = [&](Transaction* t, EngineShard* shard) -> OpResult<array<int64_t, 5>> {
     return OpThrottle(t->GetOpArgs(shard), key, limit, emission_interval_ns, quantity);
   };
 
-  Transaction* trans = cmnd_cntx->tx;
+  Transaction* trans = cmd_cntx->tx();
   OpResult<array<int64_t, 5>> result = trans->ScheduleSingleHopT(std::move(cb));
 
   if (result) {
-    RedisReplyBuilder* redis_builder = static_cast<RedisReplyBuilder*>(cmnd_cntx->rb());
+    RedisReplyBuilder* redis_builder = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
     redis_builder->StartArray(result->size());
     auto& array = result.value();
 
@@ -1688,17 +1688,17 @@ void CmdClThrottle(CmdArgList args, CommandContext* cmnd_cntx) {
   } else {
     switch (result.status()) {
       case OpStatus::WRONG_TYPE:
-        cmnd_cntx->SendError(kWrongTypeErr);
+        cmd_cntx->SendError(kWrongTypeErr);
         break;
       case OpStatus::INVALID_INT:
       case OpStatus::INVALID_VALUE:
-        cmnd_cntx->SendError(kInvalidIntErr);
+        cmd_cntx->SendError(kInvalidIntErr);
         break;
       case OpStatus::OUT_OF_MEMORY:
-        cmnd_cntx->SendError(kOutOfMemory);
+        cmd_cntx->SendError(kOutOfMemory);
         break;
       default:
-        cmnd_cntx->SendError(result.status());
+        cmd_cntx->SendError(result.status());
         break;
     }
   }


### PR DESCRIPTION
1. Just syntactic changes. Added an accessor  CommandContext::tx() and moved the pointer to private scope.

2. Renamed cmnd_cntx to cmd_cntx everywhere as sometimes it was former and sometimes the latter. This increases consistency across the codebase.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->