### PR TITLE
chore: Update CommandContext c'tor

### DIFF
--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -368,11 +368,8 @@ class ConnectionContext : public facade::ConnectionContext {
 class CommandContext : public facade::ParsedCommand {
  public:
   CommandContext() = default;
-
-  CommandContext(const CommandId* _cid, Transaction* _tx, facade::SinkReplyBuilder* rb,
-                 ConnectionContext* cntx)
-      : tx_(_tx), cid_(_cid) {
-    Init(rb, cntx);
+  CommandContext(facade::SinkReplyBuilder* rb, facade::ConnectionContext* conn_cntx) {
+    Init(rb, conn_cntx);
   }
 
   void SetupTx(const CommandId* cid, Transaction* tx) {

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -598,7 +598,7 @@ void DflyCmd::TakeOver(CmdArgList args, CommandContext* cmd_cntx) {
     VLOG(1) << "Takeover accepted, shutting down.";
     std::string save_arg = "NOSAVE";
     MutableSlice sargs(save_arg);
-    CommandContext child_cmd_cntx{nullptr, nullptr, cmd_cntx->rb(), nullptr};
+    CommandContext child_cmd_cntx{cmd_cntx->rb(), nullptr};
     sf_->ShutdownCmd(CmdArgList(&sargs, 1), &child_cmd_cntx);
     return;
   }

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -170,7 +170,8 @@ bool MultiCommandSquasher::ExecuteStandalone(RedisReplyBuilder* rb, const Stored
       return !opts_.error_abort;
     }
   }
-  CommandContext cmd_cntx{cmd->Cid(), tx, rb, cntx_};
+  CommandContext cmd_cntx{rb, cntx_};
+  cmd_cntx.SetupTx(cmd->Cid(), tx);
   service_->InvokeCmd(args, &cmd_cntx);
   return true;
 }
@@ -182,6 +183,8 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
   auto* local_tx = sinfo.local_tx.get();
   CapturingReplyBuilder crb(ReplyMode::FULL, resp_v);
   CmdArgVec arg_vec;
+  CommandContext cmd_cntx{&crb, cntx_};
+  cmd_cntx.SetupTx(nullptr, local_tx);
 
   auto move_reply = [&sinfo](CapturingReplyBuilder::Payload&& src,
                              CapturingReplyBuilder::Payload* dst) {
@@ -209,7 +212,7 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
     if (status != OpStatus::OK) {
       crb.SendError(status);
     } else {
-      CommandContext cmd_cntx{dispatched.cmd->Cid(), local_tx, &crb, cntx_};
+      cmd_cntx.UpdateCid(dispatched.cmd->Cid());
       service_->InvokeCmd(args, &cmd_cntx);
     }
     move_reply(crb.Take(), &dispatched.reply);

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -3730,7 +3730,7 @@ void ServerFamily::Replicate(string_view host, string_view port) {
   io::NullSink sink;
   facade::RedisReplyBuilder rb(&sink);
   const bool use_replica_of_v2 = absl::GetFlag(FLAGS_experimental_replicaof_v2);
-  CommandContext cmd_cntx{nullptr, nullptr, &rb, nullptr};
+  CommandContext cmd_cntx{&rb, nullptr};
   if (use_replica_of_v2) {
     ReplicaOfInternalV2(args_list, &cmd_cntx, ActionOnConnectionFail::kContinueReplication);
     return;

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -510,7 +510,7 @@ auto BaseFamilyTest::RunMC(MP::CmdType cmd_type, string_view key, MCArgs args) -
 
   TestConnWrapper* conn = AddFindConn(Protocol::MEMCACHE, GetId());
 
-  CommandContext cmd_cntx{nullptr, nullptr, conn->builder(), conn->cmd_cntx()};
+  CommandContext cmd_cntx{conn->builder(), conn->cmd_cntx()};
   cmd_cntx.ConfigureMCExtension(true);
   auto& cmd = *cmd_cntx.mc_command();
   cmd.type = cmd_type;
@@ -556,7 +556,7 @@ auto BaseFamilyTest::GetMC(MP::CmdType cmd_type, std::initializer_list<std::stri
 
   TestConnWrapper* conn = AddFindConn(Protocol::MEMCACHE, GetId());
 
-  CommandContext cmd_cntx{nullptr, nullptr, conn->builder(), conn->cmd_cntx()};
+  CommandContext cmd_cntx{conn->builder(), conn->cmd_cntx()};
   cmd_cntx.ConfigureMCExtension(true);
   auto& cmd = *cmd_cntx.mc_command();
   cmd.type = cmd_type;


### PR DESCRIPTION
Reduce it to set fields that usually do not change through the lifecycle of the CommandContext and reuse the same CommandContext instance in batch scenarios.

The change is done to reflect the actual state changes we make on this object.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->