### PR TITLE
feat: Add CMS (Count-Min Sketch) implementation

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 add_subdirectory(json)
 add_subdirectory(page_usage)
 
-add_library(dfly_core allocation_tracker.cc bloom.cc compact_object.cc dense_set.cc
+add_library(dfly_core allocation_tracker.cc bloom.cc cms.cc compact_object.cc dense_set.cc
     dragonfly_core.cc extent_tree.cc huff_coder.cc
     interpreter.cc glob_matcher.cc mi_memory_resource.cc qlist.cc sds_utils.cc
     segment_allocator.cc score_map.cc small_string.cc sorted_map.cc task_queue.cc

--- a/src/core/cms.cc
+++ b/src/core/cms.cc
@@ -1,0 +1,99 @@
+// Copyright 2025, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "core/cms.h"
+
+#include <xxhash.h>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace dfly {
+
+CMS::CMS(uint32_t width, uint32_t depth, PMR_NS::memory_resource* mr)
+    : width_(width), depth_(depth), count_(0), counters_(mr) {
+  // Initialize counter matrix with zeros
+  counters_.resize(static_cast<size_t>(width_) * depth_, 0);
+}
+
+CMS* CMS::FromErrorRate(double error, double probability, PMR_NS::memory_resource* mr) {
+  // Width = ceil(e / error) where e is Euler's number
+  // Depth = ceil(ln(1 / probability))
+  uint32_t width = static_cast<uint32_t>(std::ceil(std::exp(1.0) / error));
+  uint32_t depth = static_cast<uint32_t>(std::ceil(std::log(1.0 / probability)));
+
+  // Ensure minimum dimensions
+  width = std::max(width, 1u);
+  depth = std::max(depth, 1u);
+
+  return new CMS(width, depth, mr);
+}
+
+uint32_t CMS::Hash(std::string_view item, uint32_t seed) const {
+  uint64_t hash = XXH3_64bits_withSeed(item.data(), item.size(), seed);
+  return static_cast<uint32_t>(hash % width_);
+}
+
+int64_t CMS::IncrBy(std::string_view item, int64_t increment) {
+  count_ += increment;
+
+  int64_t min_count = std::numeric_limits<int64_t>::max();
+
+  for (uint32_t i = 0; i < depth_; ++i) {
+    uint32_t index = Hash(item, i);
+    size_t offset = static_cast<size_t>(i) * width_ + index;
+    counters_[offset] += increment;
+    min_count = std::min(min_count, counters_[offset]);
+  }
+
+  return min_count;
+}
+
+int64_t CMS::Query(std::string_view item) const {
+  int64_t min_count = std::numeric_limits<int64_t>::max();
+
+  for (uint32_t i = 0; i < depth_; ++i) {
+    uint32_t index = Hash(item, i);
+    size_t offset = static_cast<size_t>(i) * width_ + index;
+    min_count = std::min(min_count, counters_[offset]);
+  }
+
+  return min_count;
+}
+
+bool CMS::Merge(const CMS* other, int64_t weight) {
+  // Dimensions must match
+  if (width_ != other->width_ || depth_ != other->depth_) {
+    return false;
+  }
+
+  // Add weighted counters from other CMS
+  for (size_t i = 0; i < counters_.size(); ++i) {
+    counters_[i] += other->counters_[i] * weight;
+  }
+
+  count_ += other->count_ * weight;
+  return true;
+}
+
+void CMS::MergeCounters(const std::vector<int64_t>& counters, int64_t src_count, int64_t weight) {
+  // Caller must ensure counters.size() == width_ * depth_
+  for (size_t i = 0; i < counters_.size() && i < counters.size(); ++i) {
+    counters_[i] += counters[i] * weight;
+  }
+  count_ += src_count * weight;
+}
+
+void CMS::Reset() {
+  std::fill(counters_.begin(), counters_.end(), 0);
+  count_ = 0;
+}
+
+size_t CMS::MallocUsed() const {
+  // Approximate memory usage: counters + object overhead
+  return counters_.capacity() * sizeof(int64_t) + sizeof(CMS);
+}
+
+}  // namespace dfly

--- a/src/core/cms.h
+++ b/src/core/cms.h
@@ -1,0 +1,91 @@
+// Copyright 2025, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+#include <vector>
+
+#include "base/pmr/memory_resource.h"
+
+namespace dfly {
+
+/// Redis-compatible Count-Min Sketch implementation.
+/// This is a probabilistic data structure for frequency estimation.
+/// It allows counting the frequency of items in a stream with sub-linear space.
+class CMS {
+ public:
+  // Construct CMS with explicit dimensions
+  // width - number of counters per row (hash buckets)
+  // depth - number of rows (hash functions)
+  CMS(uint32_t width, uint32_t depth, PMR_NS::memory_resource* mr);
+
+  // Construct CMS from error rate and probability parameters
+  // error - the acceptable error rate (0 < error < 1)
+  // probability - the acceptable probability of exceeding error (0 < probability < 1)
+  // Width is calculated as ceil(e / error)
+  // Depth is calculated as ceil(ln(1 / probability))
+  static CMS* FromErrorRate(double error, double probability, PMR_NS::memory_resource* mr);
+
+  CMS(const CMS&) = delete;
+  CMS& operator=(const CMS&) = delete;
+
+  ~CMS() = default;
+
+  // Increment the count for an item by the given value
+  // Returns the new estimated count after increment
+  int64_t IncrBy(std::string_view item, int64_t increment);
+
+  // Query the estimated count for an item
+  int64_t Query(std::string_view item) const;
+
+  // Merge another CMS into this one with optional weight
+  // The source CMS must have the same dimensions
+  // Returns true on success, false if dimensions don't match
+  bool Merge(const CMS* other, int64_t weight = 1);
+
+  // Getters for dimensions
+  uint32_t Width() const {
+    return width_;
+  }
+  uint32_t Depth() const {
+    return depth_;
+  }
+
+  // Total count of all increments
+  int64_t Count() const {
+    return count_;
+  }
+
+  // Memory usage estimation
+  size_t MallocUsed() const;
+
+  // Get read-only access to counters (for serialization/cross-shard merge)
+  const std::vector<int64_t, PMR_NS::polymorphic_allocator<int64_t>>& Counters() const {
+    return counters_;
+  }
+
+  // Merge from raw counter vector (for cross-shard merge)
+  // counters must have size = width * depth
+  // src_count is the total count from the source CMS
+  void MergeCounters(const std::vector<int64_t>& counters, int64_t src_count, int64_t weight = 1);
+
+  // Reset all counters to zero (used before merge to replace instead of add)
+  void Reset();
+
+ private:
+  // Hash function using XXH3 with seed
+  uint32_t Hash(std::string_view item, uint32_t seed) const;
+
+  uint32_t width_;
+  uint32_t depth_;
+  int64_t count_;  // Total of all increments
+
+  // Counter matrix: depth rows x width columns
+  // Using a flat vector for better cache locality
+  std::vector<int64_t, PMR_NS::polymorphic_allocator<int64_t>> counters_;
+};
+
+}  // namespace dfly

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -26,6 +26,7 @@ constexpr unsigned kEncodingJsonCons = 0;
 constexpr unsigned kEncodingJsonFlat = 1;
 
 class SBF;
+class CMS;
 class PageUsage;
 
 using cmn::StringOrView;
@@ -125,6 +126,7 @@ class CompactObj {
     EXTERNAL_TAG = 20,
     JSON_TAG = 21,
     SBF_TAG = 22,
+    CMS_TAG = 23,
   };
 
   // String encoding types.
@@ -314,6 +316,12 @@ class CompactObj {
   void SetSBF(uint64_t initial_capacity, double fp_prob, double grow_factor);
   SBF* GetSBF() const;
 
+  void SetCMS(CMS* cms) {
+    SetMeta(CMS_TAG);
+    u_.cms = cms;
+  }
+  CMS* GetCMS() const;
+
   // dest must have at least Size() bytes available
   void GetString(char* dest) const;
 
@@ -497,6 +505,7 @@ class CompactObj {
     // using 'packed' to reduce alignement of U to 1.
     JsonWrapper json_obj __attribute__((packed));
     SBF* sbf __attribute__((packed));
+    CMS* cms __attribute__((packed));
     int64_t ival __attribute__((packed));
     ExternalPtr ext_ptr;
 

--- a/src/redis/redis_aux.h
+++ b/src/redis/redis_aux.h
@@ -8,12 +8,13 @@
  * this will add enough place for Redis types to grow */
 #define OBJ_JSON 15U
 #define OBJ_SBF  16U
+#define OBJ_CMS  17U  /* Count-Min Sketch object. */
 
 // A pseudo type for keys stored in the db, same as OBJ_MODULE which is not used in Dragonfly.
 #define OBJ_KEY  5U
 
 /* How many types of objects exist */
-#define OBJ_TYPE_MAX 17U
+#define OBJ_TYPE_MAX 18U
 
 #define CONFIG_RUN_ID_SIZE 40U
 

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -49,7 +49,7 @@ endif()
 
 # Optionally compile extension commands
 if (WITH_EXTENSION_CMDS)
-  list(APPEND DF_FAMILY_SRCS geo_family.cc hll_family.cc bitops_family.cc bloom_family.cc json_family.cc)
+  list(APPEND DF_FAMILY_SRCS geo_family.cc hll_family.cc bitops_family.cc bloom_family.cc json_family.cc cms_family.cc)
   add_definitions(-DWITH_EXTENSION_CMDS)
 endif()
 
@@ -147,6 +147,7 @@ helio_cxx_test(json_family_memory_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(journal/journal_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(hll_family_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(bloom_family_test dfly_test_lib LABELS DFLY)
+helio_cxx_test(cms_family_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(cluster/cluster_config_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(cluster/cluster_family_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(acl/acl_family_test dfly_test_lib LABELS DFLY)

--- a/src/server/acl/acl_commands_def.h
+++ b/src/server/acl/acl_commands_def.h
@@ -44,7 +44,8 @@ enum AclCat {
   BLOOM = 1ULL << 28,
   FT_SEARCH = 1ULL << 29,
   THROTTLE = 1ULL << 30,
-  JSON = 1ULL << 31
+  JSON = 1ULL << 31,
+  CMS = 1ULL << 32
 };
 
 constexpr uint64_t ALL_COMMANDS = std::numeric_limits<uint64_t>::max();

--- a/src/server/cms_family.cc
+++ b/src/server/cms_family.cc
@@ -1,0 +1,489 @@
+// Copyright 2025, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include <cmath>
+#include <mutex>
+
+#include "core/cms.h"
+#include "facade/cmd_arg_parser.h"
+#include "facade/error.h"
+#include "facade/reply_builder.h"
+#include "server/acl/acl_commands_def.h"
+#include "server/command_families.h"
+#include "server/command_registry.h"
+#include "server/conn_context.h"
+#include "server/engine_shard_set.h"
+#include "server/error.h"
+#include "server/transaction.h"
+
+namespace dfly {
+
+using namespace facade;
+using namespace std;
+
+namespace {
+
+// CMS.INITBYDIM key width depth
+OpStatus OpInitByDim(const OpArgs& op_args, string_view key, uint32_t width, uint32_t depth) {
+  auto& db_slice = op_args.GetDbSlice();
+  auto op_res = db_slice.AddOrFind(op_args.db_cntx, key, OBJ_CMS);
+  RETURN_ON_BAD_STATUS(op_res);
+
+  if (!op_res->is_new)
+    return OpStatus::KEY_EXISTS;
+
+  PrimeValue& pv = op_res->it->second;
+  CMS* cms = CompactObj::AllocateMR<CMS>(width, depth, CompactObj::memory_resource());
+  pv.SetCMS(cms);
+
+  return OpStatus::OK;
+}
+
+// CMS.INITBYPROB key error probability
+OpStatus OpInitByProb(const OpArgs& op_args, string_view key, double error, double probability) {
+  auto& db_slice = op_args.GetDbSlice();
+  auto op_res = db_slice.AddOrFind(op_args.db_cntx, key, OBJ_CMS);
+  RETURN_ON_BAD_STATUS(op_res);
+
+  if (!op_res->is_new)
+    return OpStatus::KEY_EXISTS;
+
+  // Calculate width and depth from error and probability
+  // Width = ceil(e / error) where e is Euler's number
+  // Depth = ceil(ln(1 / probability))
+  uint32_t width = static_cast<uint32_t>(std::ceil(std::exp(1.0) / error));
+  uint32_t depth = static_cast<uint32_t>(std::ceil(std::log(1.0 / probability)));
+
+  // Ensure minimum dimensions
+  width = std::max(width, 1u);
+  depth = std::max(depth, 1u);
+
+  PrimeValue& pv = op_res->it->second;
+  CMS* cms = CompactObj::AllocateMR<CMS>(width, depth, CompactObj::memory_resource());
+  pv.SetCMS(cms);
+
+  return OpStatus::OK;
+}
+
+// CMS.INCRBY key item increment [item increment ...]
+OpResult<vector<int64_t>> OpIncrBy(const OpArgs& op_args, string_view key, CmdArgList args) {
+  auto& db_slice = op_args.GetDbSlice();
+  auto op_res = db_slice.FindMutable(op_args.db_cntx, key, OBJ_CMS);
+
+  if (!op_res)
+    return op_res.status();
+
+  CMS* cms = op_res->it->second.GetCMS();
+  vector<int64_t> results;
+  results.reserve(args.size() / 2);
+
+  for (size_t i = 0; i < args.size(); i += 2) {
+    string_view item = ToSV(args[i]);
+    string_view incr_str = ToSV(args[i + 1]);
+
+    int64_t increment;
+    if (!absl::SimpleAtoi(incr_str, &increment)) {
+      return OpStatus::INVALID_INT;
+    }
+
+    int64_t count = cms->IncrBy(item, increment);
+    results.push_back(count);
+  }
+
+  return results;
+}
+
+// CMS.QUERY key item [item ...]
+OpResult<vector<int64_t>> OpQuery(const OpArgs& op_args, string_view key, CmdArgList items) {
+  auto& db_slice = op_args.GetDbSlice();
+  auto op_res = db_slice.FindReadOnly(op_args.db_cntx, key, OBJ_CMS);
+
+  if (!op_res)
+    return op_res.status();
+
+  const CMS* cms = op_res.value()->second.GetCMS();
+  vector<int64_t> results;
+  results.reserve(items.size());
+
+  for (auto& item : items) {
+    results.push_back(cms->Query(ToSV(item)));
+  }
+
+  return results;
+}
+
+// CMS.INFO key
+struct CmsInfo {
+  uint32_t width;
+  uint32_t depth;
+  int64_t count;
+};
+
+OpResult<CmsInfo> OpInfo(const OpArgs& op_args, string_view key) {
+  auto& db_slice = op_args.GetDbSlice();
+  auto op_res = db_slice.FindReadOnly(op_args.db_cntx, key, OBJ_CMS);
+
+  if (!op_res)
+    return op_res.status();
+
+  const CMS* cms = op_res.value()->second.GetCMS();
+  return CmsInfo{cms->Width(), cms->Depth(), cms->Count()};
+}
+
+// Command handlers
+
+void CmdInitByDim(CmdArgList args, CommandContext* cmd_cntx) {
+  CmdArgParser parser(args);
+  string_view key = parser.Next();
+  uint32_t width = parser.Next<uint32_t>();
+  uint32_t depth = parser.Next<uint32_t>();
+
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+
+  if (auto err = parser.TakeError(); err) {
+    return rb->SendError(err.MakeReply());
+  }
+
+  if (width == 0) {
+    return rb->SendError("CMS: width must be a positive integer");
+  }
+  if (depth == 0) {
+    return rb->SendError("CMS: depth must be a positive integer");
+  }
+
+  const auto cb = [&](Transaction* t, EngineShard* shard) {
+    return OpInitByDim(t->GetOpArgs(shard), key, width, depth);
+  };
+
+  OpStatus res = cmd_cntx->tx->ScheduleSingleHop(std::move(cb));
+  if (res == OpStatus::KEY_EXISTS) {
+    return rb->SendError("CMS: key already exists");
+  }
+  if (res == OpStatus::OK) {
+    return rb->SendOk();
+  }
+  return rb->SendError(res);
+}
+
+void CmdInitByProb(CmdArgList args, CommandContext* cmd_cntx) {
+  CmdArgParser parser(args);
+  string_view key = parser.Next();
+  double error_rate = parser.Next<double>();
+  double probability = parser.Next<double>();
+
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+
+  if (auto err = parser.TakeError(); err) {
+    return rb->SendError(err.MakeReply());
+  }
+
+  if (error_rate <= 0 || error_rate >= 1) {
+    return rb->SendError("CMS: error must be a value between 0 and 1 exclusive");
+  }
+  if (probability <= 0 || probability >= 1) {
+    return rb->SendError("CMS: probability must be a value between 0 and 1 exclusive");
+  }
+
+  const auto cb = [&](Transaction* t, EngineShard* shard) {
+    return OpInitByProb(t->GetOpArgs(shard), key, error_rate, probability);
+  };
+
+  OpStatus res = cmd_cntx->tx->ScheduleSingleHop(std::move(cb));
+  if (res == OpStatus::KEY_EXISTS) {
+    return rb->SendError("CMS: key already exists");
+  }
+  if (res == OpStatus::OK) {
+    return rb->SendOk();
+  }
+  return rb->SendError(res);
+}
+
+void CmdIncrBy(CmdArgList args, CommandContext* cmd_cntx) {
+  string_view key = ArgS(args, 0);
+  args.remove_prefix(1);
+
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+
+  // Must have pairs of item/increment
+  if (args.size() % 2 != 0) {
+    return rb->SendError(kSyntaxErr);
+  }
+
+  const auto cb = [&](Transaction* t, EngineShard* shard) {
+    return OpIncrBy(t->GetOpArgs(shard), key, args);
+  };
+
+  OpResult<vector<int64_t>> res = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
+
+  if (!res) {
+    if (res.status() == OpStatus::KEY_NOTFOUND) {
+      return rb->SendError("CMS: key does not exist");
+    }
+    if (res.status() == OpStatus::INVALID_INT) {
+      return rb->SendError("CMS: Cannot parse number");
+    }
+    return rb->SendError(res.status());
+  }
+
+  rb->StartArray(res->size());
+  for (int64_t count : *res) {
+    rb->SendLong(count);
+  }
+}
+
+void CmdQuery(CmdArgList args, CommandContext* cmd_cntx) {
+  string_view key = ArgS(args, 0);
+  args.remove_prefix(1);
+
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+
+  const auto cb = [&](Transaction* t, EngineShard* shard) {
+    return OpQuery(t->GetOpArgs(shard), key, args);
+  };
+
+  OpResult<vector<int64_t>> res = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
+
+  if (!res) {
+    if (res.status() == OpStatus::KEY_NOTFOUND) {
+      return rb->SendError("CMS: key does not exist");
+    }
+    return rb->SendError(res.status());
+  }
+
+  rb->StartArray(res->size());
+  for (int64_t count : *res) {
+    rb->SendLong(count);
+  }
+}
+
+void CmdInfo(CmdArgList args, CommandContext* cmd_cntx) {
+  string_view key = ArgS(args, 0);
+
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+
+  const auto cb = [&](Transaction* t, EngineShard* shard) {
+    return OpInfo(t->GetOpArgs(shard), key);
+  };
+
+  OpResult<CmsInfo> res = cmd_cntx->tx->ScheduleSingleHopT(std::move(cb));
+
+  if (!res) {
+    if (res.status() == OpStatus::KEY_NOTFOUND) {
+      return rb->SendError("CMS: key does not exist");
+    }
+    return rb->SendError(res.status());
+  }
+
+  rb->StartArray(6);
+  rb->SendBulkString("width");
+  rb->SendLong(res->width);
+  rb->SendBulkString("depth");
+  rb->SendLong(res->depth);
+  rb->SendBulkString("count");
+  rb->SendLong(res->count);
+}
+
+// CMS.MERGE destination numkeys source [source ...] [WEIGHTS weight [weight ...]]
+void CmdMerge(CmdArgList args, CommandContext* cmd_cntx) {
+  CmdArgParser parser(args);
+  string_view dest_key = parser.Next();
+  uint32_t num_keys = parser.Next<uint32_t>();
+
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+
+  if (auto err = parser.TakeError(); err) {
+    return rb->SendError(err.MakeReply());
+  }
+
+  if (num_keys == 0) {
+    return rb->SendError("CMS: wrong number of arguments");
+  }
+
+  // Parse source keys
+  vector<string_view> source_keys;
+  source_keys.reserve(num_keys);
+  for (uint32_t i = 0; i < num_keys && parser.HasNext(); ++i) {
+    source_keys.push_back(parser.Next());
+  }
+
+  if (source_keys.size() != num_keys) {
+    return rb->SendError("CMS: wrong number of keys");
+  }
+
+  // Parse optional WEIGHTS
+  vector<int64_t> weights(num_keys, 1);
+  if (parser.HasNext()) {
+    string_view weights_keyword = parser.Next();
+    if (!absl::EqualsIgnoreCase(weights_keyword, "WEIGHTS")) {
+      return rb->SendError(kSyntaxErr);
+    }
+
+    for (uint32_t i = 0; i < num_keys && parser.HasNext(); ++i) {
+      int64_t weight = parser.Next<int64_t>();
+      if (auto err = parser.TakeError(); err) {
+        return rb->SendError(err.MakeReply());
+      }
+      weights[i] = weight;
+    }
+  }
+
+  // Structure to hold CMS data including full counter arrays
+  struct CmsData {
+    uint32_t width = 0;
+    uint32_t depth = 0;
+    int64_t count = 0;
+    vector<int64_t> counters;  // Full counter array for cross-shard merge
+    bool found = false;        // Track if source key was found
+  };
+
+  vector<CmsData> cms_data(num_keys);
+  atomic<OpStatus> error_status{OpStatus::OK};
+  mutex data_mutex;  // Protect concurrent writes to cms_data
+
+  // Destination info (checked during read phase)
+  atomic<bool> dest_found{false};
+  atomic<uint32_t> dest_width{0};
+  atomic<uint32_t> dest_depth{0};
+
+  // First phase: Read all source CMS data and verify destination exists
+  auto read_cb = [&](Transaction* t, EngineShard* shard) {
+    auto& db_slice = t->GetOpArgs(shard).GetDbSlice();
+    ShardArgs shard_args = t->GetShardArgs(shard->shard_id());
+
+    for (string_view skey : shard_args) {
+      // Check if this is the destination key
+      if (skey == dest_key) {
+        auto op_res = db_slice.FindReadOnly(t->GetDbContext(), dest_key, OBJ_CMS);
+        if (op_res) {
+          const CMS* cms = op_res.value()->second.GetCMS();
+          dest_found.store(true, memory_order_relaxed);
+          dest_width.store(cms->Width(), memory_order_relaxed);
+          dest_depth.store(cms->Depth(), memory_order_relaxed);
+        } else if (op_res.status() != OpStatus::KEY_NOTFOUND) {
+          error_status.store(op_res.status(), memory_order_relaxed);
+        }
+        continue;
+      }
+
+      // Find which source key this is
+      for (uint32_t i = 0; i < num_keys; ++i) {
+        if (source_keys[i] != skey) {
+          continue;
+        }
+
+        auto op_res = db_slice.FindReadOnly(t->GetDbContext(), skey, OBJ_CMS);
+
+        if (!op_res) {
+          if (op_res.status() != OpStatus::KEY_NOTFOUND) {
+            error_status.store(op_res.status(), memory_order_relaxed);
+          }
+          continue;
+        }
+
+        const CMS* cms = op_res.value()->second.GetCMS();
+
+        // Copy CMS data including full counter array
+        lock_guard<mutex> lock(data_mutex);
+        cms_data[i].width = cms->Width();
+        cms_data[i].depth = cms->Depth();
+        cms_data[i].count = cms->Count();
+        cms_data[i].found = true;
+        // Copy counters for cross-shard merge
+        const auto& src_counters = cms->Counters();
+        cms_data[i].counters.assign(src_counters.begin(), src_counters.end());
+      }
+    }
+    return OpStatus::OK;
+  };
+
+  cmd_cntx->tx->Execute(std::move(read_cb), false);
+
+  // Check for errors
+  OpStatus stored_error = error_status.load(memory_order_relaxed);
+  if (stored_error != OpStatus::OK) {
+    cmd_cntx->tx->Conclude();
+    return rb->SendError(stored_error);
+  }
+
+  // Check destination exists
+  if (!dest_found.load(memory_order_relaxed)) {
+    cmd_cntx->tx->Conclude();
+    return rb->SendError("CMS: key does not exist");
+  }
+
+  // Check all source keys were found (Redis requires all sources to exist)
+  for (uint32_t i = 0; i < num_keys; ++i) {
+    if (!cms_data[i].found) {
+      cmd_cntx->tx->Conclude();
+      return rb->SendError("CMS: key does not exist");
+    }
+  }
+
+  // Get dimensions from first source (all must match)
+  uint32_t expected_width = cms_data[0].width;
+  uint32_t expected_depth = cms_data[0].depth;
+
+  // Verify all sources have same dimensions
+  for (uint32_t i = 1; i < num_keys; ++i) {
+    if (cms_data[i].width != expected_width || cms_data[i].depth != expected_depth) {
+      cmd_cntx->tx->Conclude();
+      return rb->SendError("CMS: width/depth of source keys must match");
+    }
+  }
+
+  // Verify destination has same dimensions
+  if (dest_width.load(memory_order_relaxed) != expected_width ||
+      dest_depth.load(memory_order_relaxed) != expected_depth) {
+    cmd_cntx->tx->Conclude();
+    return rb->SendError("CMS: width/depth of source keys must match");
+  }
+
+  // Second phase: Update destination with merged data
+  auto write_cb = [&](Transaction* t, EngineShard* shard) {
+    auto& db_slice = t->GetOpArgs(shard).GetDbSlice();
+
+    auto op_res = db_slice.FindMutable(t->GetDbContext(), dest_key, OBJ_CMS);
+    if (!op_res) {
+      // Should not happen since we verified in read phase
+      return OpStatus::OK;
+    }
+
+    CMS* dest_cms = op_res->it->second.GetCMS();
+
+    // Reset destination before merging (Redis replaces, doesn't add)
+    dest_cms->Reset();
+
+    // Merge all source CMS data from stored counter arrays
+    for (uint32_t i = 0; i < num_keys; ++i) {
+      dest_cms->MergeCounters(cms_data[i].counters, cms_data[i].count, weights[i]);
+    }
+
+    return OpStatus::OK;
+  };
+
+  cmd_cntx->tx->ScheduleSingleHop(std::move(write_cb));
+  rb->SendOk();
+}
+
+}  // namespace
+
+using CI = CommandId;
+
+#define HFUNC(x) SetHandler(&Cmd##x)
+
+void RegisterCmsFamily(CommandRegistry* registry) {
+  registry->StartFamily();
+
+  *registry
+      << CI{"CMS.INITBYDIM", CO::JOURNALED | CO::DENYOOM | CO::FAST, 4, 1, 1, acl::CMS}.HFUNC(
+             InitByDim)
+      << CI{"CMS.INITBYPROB", CO::JOURNALED | CO::DENYOOM | CO::FAST, 4, 1, 1, acl::CMS}.HFUNC(
+             InitByProb)
+      << CI{"CMS.INCRBY", CO::JOURNALED | CO::DENYOOM | CO::FAST, -4, 1, 1, acl::CMS}.HFUNC(IncrBy)
+      << CI{"CMS.QUERY", CO::READONLY | CO::FAST, -3, 1, 1, acl::CMS}.HFUNC(Query)
+      << CI{"CMS.INFO", CO::READONLY | CO::FAST, 2, 1, 1, acl::CMS}.HFUNC(Info)
+      << CI{"CMS.MERGE", CO::JOURNALED | CO::DENYOOM, -4, 1, -1, acl::CMS}.HFUNC(Merge);
+}
+
+}  // namespace dfly

--- a/src/server/cms_family_test.cc
+++ b/src/server/cms_family_test.cc
@@ -1,0 +1,245 @@
+// Copyright 2025, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "facade/facade_test.h"
+#include "server/test_utils.h"
+
+namespace dfly {
+
+using testing::ElementsAre;
+
+class CmsFamilyTest : public BaseFamilyTest {
+ protected:
+};
+
+TEST_F(CmsFamilyTest, InitByDim) {
+  auto resp = Run({"cms.initbydim", "cms1", "1000", "5"});
+  EXPECT_EQ(resp, "OK");
+  EXPECT_EQ(Run({"type", "cms1"}), "CMSk-TYPE-");
+
+  // Should fail on existing key
+  resp = Run({"cms.initbydim", "cms1", "1000", "5"});
+  EXPECT_THAT(resp, ErrArg("key already exists"));
+
+  // Invalid width
+  resp = Run({"cms.initbydim", "cms2", "0", "5"});
+  EXPECT_THAT(resp, ErrArg("width must be a positive integer"));
+
+  // Invalid depth
+  resp = Run({"cms.initbydim", "cms3", "1000", "0"});
+  EXPECT_THAT(resp, ErrArg("depth must be a positive integer"));
+}
+
+TEST_F(CmsFamilyTest, InitByProb) {
+  auto resp = Run({"cms.initbyprob", "cms1", "0.01", "0.001"});
+  EXPECT_EQ(resp, "OK");
+  EXPECT_EQ(Run({"type", "cms1"}), "CMSk-TYPE-");
+
+  // Should fail on existing key
+  resp = Run({"cms.initbyprob", "cms1", "0.01", "0.001"});
+  EXPECT_THAT(resp, ErrArg("key already exists"));
+
+  // Invalid error rate
+  resp = Run({"cms.initbyprob", "cms2", "0", "0.001"});
+  EXPECT_THAT(resp, ErrArg("error must be a value between 0 and 1 exclusive"));
+
+  resp = Run({"cms.initbyprob", "cms3", "1", "0.001"});
+  EXPECT_THAT(resp, ErrArg("error must be a value between 0 and 1 exclusive"));
+
+  // Invalid probability
+  resp = Run({"cms.initbyprob", "cms4", "0.01", "0"});
+  EXPECT_THAT(resp, ErrArg("probability must be a value between 0 and 1 exclusive"));
+
+  resp = Run({"cms.initbyprob", "cms5", "0.01", "1"});
+  EXPECT_THAT(resp, ErrArg("probability must be a value between 0 and 1 exclusive"));
+}
+
+TEST_F(CmsFamilyTest, IncrBy) {
+  // IncrBy on non-existing key should fail (Redis behavior)
+  auto resp = Run({"cms.incrby", "noexist", "item1", "5"});
+  EXPECT_THAT(resp, ErrArg("key does not exist"));
+
+  // Create CMS first
+  Run({"cms.initbydim", "cms1", "100", "5"});
+
+  // Single item increment
+  resp = Run({"cms.incrby", "cms1", "foo", "3"});
+  EXPECT_THAT(resp, IntArg(3));  // Single-element array collapsed by test framework
+
+  // Multiple items
+  resp = Run({"cms.incrby", "cms1", "foo", "4", "bar", "1"});
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(7), IntArg(1))));
+
+  // Query to verify
+  resp = Run({"cms.query", "cms1", "foo", "bar"});
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(7), IntArg(1))));
+
+  // Query non-existing item returns 0
+  resp = Run({"cms.query", "cms1", "noexist"});
+  EXPECT_THAT(resp, IntArg(0));  // Single-element array collapsed by test framework
+
+  // Wrong type
+  Run({"set", "str", "foo"});
+  resp = Run({"cms.incrby", "str", "item1", "5"});
+  EXPECT_THAT(resp, ErrArg("WRONGTYPE"));
+
+  // Invalid increment
+  resp = Run({"cms.incrby", "cms1", "foo", "invalid"});
+  EXPECT_THAT(resp, ErrArg("Cannot parse number"));
+}
+
+TEST_F(CmsFamilyTest, Query) {
+  Run({"cms.initbydim", "cms1", "1000", "5"});
+  Run({"cms.incrby", "cms1", "item1", "10", "item2", "20", "item3", "30"});
+
+  auto resp = Run({"cms.query", "cms1", "item1", "item2", "item3", "item4"});
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(10), IntArg(20), IntArg(30), IntArg(0))));
+
+  // Query non-existing key should fail (Redis behavior)
+  resp = Run({"cms.query", "nonexistent", "item1"});
+  EXPECT_THAT(resp, ErrArg("key does not exist"));
+
+  // Wrong type
+  Run({"set", "str", "foo"});
+  resp = Run({"cms.query", "str", "item1"});
+  EXPECT_THAT(resp, ErrArg("WRONGTYPE"));
+}
+
+TEST_F(CmsFamilyTest, Info) {
+  Run({"cms.initbydim", "cms1", "1000", "5"});
+  Run({"cms.incrby", "cms1", "item1", "10", "item2", "20"});
+
+  auto resp = Run({"cms.info", "cms1"});
+  EXPECT_THAT(resp, RespArray(ElementsAre("width", IntArg(1000), "depth", IntArg(5), "count",
+                                          IntArg(30))));
+
+  // Non-existing key should fail (Redis behavior)
+  resp = Run({"cms.info", "nonexistent"});
+  EXPECT_THAT(resp, ErrArg("key does not exist"));
+}
+
+TEST_F(CmsFamilyTest, Merge) {
+  // Create source and destination sketches
+  Run({"cms.initbydim", "src1", "1000", "5"});
+  Run({"cms.initbydim", "dest", "1000", "5"});
+  Run({"cms.incrby", "src1", "item1", "10", "item2", "20"});
+
+  // Merge single source into destination
+  auto resp = Run({"cms.merge", "dest", "1", "src1"});
+  EXPECT_EQ(resp, "OK");
+
+  // Verify destination has the merged data
+  resp = Run({"cms.query", "dest", "item1", "item2"});
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(10), IntArg(20))));
+
+  // Verify info shows correct count
+  resp = Run({"cms.info", "dest"});
+  ASSERT_THAT(resp, ArrLen(6));
+  EXPECT_THAT(resp.GetVec()[1], IntArg(1000));  // width
+  EXPECT_THAT(resp.GetVec()[3], IntArg(5));     // depth
+  EXPECT_THAT(resp.GetVec()[5], IntArg(30));    // count = 10 + 20
+
+  // Merge on non-existing destination should fail
+  resp = Run({"cms.merge", "noexist", "1", "src1"});
+  EXPECT_THAT(resp, ErrArg("key does not exist"));
+
+  // Merge with non-existing source should fail
+  resp = Run({"cms.merge", "dest", "1", "noexist"});
+  EXPECT_THAT(resp, ErrArg("key does not exist"));
+}
+
+TEST_F(CmsFamilyTest, MergeDimensionMismatch) {
+  Run({"cms.initbydim", "src1", "1000", "5"});
+  Run({"cms.initbydim", "src2", "2000", "5"});  // Different width
+  Run({"cms.initbydim", "dest", "1000", "5"});
+
+  // Sources have different dimensions
+  auto resp = Run({"cms.merge", "dest", "2", "src1", "src2"});
+  EXPECT_THAT(resp, ErrArg("width/depth"));
+
+  // Destination has different dimensions than source
+  Run({"cms.initbydim", "dest2", "500", "5"});
+  resp = Run({"cms.merge", "dest2", "1", "src1"});
+  EXPECT_THAT(resp, ErrArg("width/depth"));
+}
+
+TEST_F(CmsFamilyTest, IncrByNegative) {
+  Run({"cms.initbydim", "cms1", "1000", "5"});
+  Run({"cms.incrby", "cms1", "item1", "100"});
+  Run({"cms.incrby", "cms1", "item1", "-30"});
+
+  auto resp = Run({"cms.query", "cms1", "item1"});
+  EXPECT_THAT(resp, IntArg(70));
+}
+
+TEST_F(CmsFamilyTest, MergeMultipleSources) {
+  // Create two source sketches and destination with same dimensions
+  Run({"cms.initbydim", "src1", "1000", "5"});
+  Run({"cms.initbydim", "src2", "1000", "5"});
+  Run({"cms.initbydim", "dest", "1000", "5"});
+
+  // Add different items to each source
+  Run({"cms.incrby", "src1", "foo", "10", "bar", "20"});
+  Run({"cms.incrby", "src2", "baz", "30", "qux", "40"});
+
+  // Merge both sources into destination
+  auto resp = Run({"cms.merge", "dest", "2", "src1", "src2"});
+  EXPECT_EQ(resp, "OK");
+
+  // Verify all items from both sources are in destination
+  resp = Run({"cms.query", "dest", "foo", "bar", "baz", "qux"});
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(10), IntArg(20), IntArg(30), IntArg(40))));
+
+  // Verify total count
+  resp = Run({"cms.info", "dest"});
+  EXPECT_THAT(resp, RespArray(ElementsAre("width", IntArg(1000), "depth", IntArg(5), "count",
+                                          IntArg(100))));  // 10+20+30+40 = 100
+}
+
+TEST_F(CmsFamilyTest, MergeWithWeights) {
+  Run({"cms.initbydim", "src1", "1000", "5"});
+  Run({"cms.initbydim", "src2", "1000", "5"});
+  Run({"cms.initbydim", "dest", "1000", "5"});
+
+  Run({"cms.incrby", "src1", "item", "10"});
+  Run({"cms.incrby", "src2", "item", "10"});
+
+  // Merge with weights: src1*2 + src2*3 = 10*2 + 10*3 = 50
+  auto resp = Run({"cms.merge", "dest", "2", "src1", "src2", "WEIGHTS", "2", "3"});
+  EXPECT_EQ(resp, "OK");
+
+  resp = Run({"cms.query", "dest", "item"});
+  EXPECT_THAT(resp, IntArg(50));
+}
+
+TEST_F(CmsFamilyTest, MergeReplaces) {
+  // Test that merge replaces destination instead of adding to it (Redis behavior)
+  Run({"cms.initbydim", "A", "1000", "5"});
+  Run({"cms.initbydim", "B", "1000", "5"});
+  Run({"cms.initbydim", "C", "1000", "5"});
+
+  Run({"cms.incrby", "A", "foo", "5", "bar", "3", "baz", "9"});
+  Run({"cms.incrby", "B", "foo", "2", "bar", "3", "baz", "1"});
+
+  // First merge: C = A + B
+  auto resp = Run({"cms.merge", "C", "2", "A", "B"});
+  EXPECT_EQ(resp, "OK");
+  resp = Run({"cms.query", "C", "foo", "bar", "baz"});
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(7), IntArg(6), IntArg(10))));
+
+  // Second merge with weights: C = A*1 + B*2 (should REPLACE, not add to existing C)
+  resp = Run({"cms.merge", "C", "2", "A", "B", "WEIGHTS", "1", "2"});
+  EXPECT_EQ(resp, "OK");
+  // Expected: foo=5*1+2*2=9, bar=3*1+3*2=9, baz=9*1+1*2=11
+  resp = Run({"cms.query", "C", "foo", "bar", "baz"});
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(9), IntArg(9), IntArg(11))));
+
+  // Verify count is replaced too
+  resp = Run({"cms.info", "C"});
+  // count = (5+3+9)*1 + (2+3+1)*2 = 17 + 12 = 29
+  EXPECT_THAT(resp, RespArray(ElementsAre("width", IntArg(1000), "depth", IntArg(5), "count",
+                                          IntArg(29))));
+}
+
+}  // namespace dfly

--- a/src/server/command_families.h
+++ b/src/server/command_families.h
@@ -17,5 +17,6 @@ void RegisterGeoFamily(CommandRegistry*);
 void RegisterHllFamily(CommandRegistry*);
 void RegisterBloomFamily(CommandRegistry*);
 void RegisterJsonFamily(CommandRegistry*);
+void RegisterCmsFamily(CommandRegistry*);
 
 }  // namespace dfly

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -3024,6 +3024,7 @@ void Service::RegisterCommands() {
   RegisterHllFamily(&registry_);
   RegisterBloomFamily(&registry_);
   RegisterJsonFamily(&registry_);
+  RegisterCmsFamily(&registry_);
 #endif
 
 #ifdef WITH_SEARCH

--- a/tests/fakeredis/test/test_stack/test_cms.py
+++ b/tests/fakeredis/test/test_stack/test_cms.py
@@ -6,11 +6,6 @@ from test import testtools
 json_tests = pytest.importorskip("probables")
 
 pytestmark = []
-pytestmark.extend(
-    [
-        pytest.mark.unsupported_server_types("dragonfly"),
-    ]
-)
 
 
 def test_cms_create(r: redis.Redis):

--- a/tools/cms_benchmark/Dockerfile.benchmark
+++ b/tools/cms_benchmark/Dockerfile.benchmark
@@ -1,0 +1,9 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir redis
+
+COPY benchmark.py .
+
+ENTRYPOINT ["python", "-u", "benchmark.py"]

--- a/tools/cms_benchmark/Dockerfile.dragonfly
+++ b/tools/cms_benchmark/Dockerfile.dragonfly
@@ -1,0 +1,28 @@
+# Dockerfile to build Dragonfly with CMS support from local source
+FROM ghcr.io/dragonflydb/dragonfly-builder:ubuntu24-latest AS builder
+
+WORKDIR /src
+
+# Copy the source code
+COPY . .
+
+# Initialize submodules and build
+RUN git submodule update --init --recursive || true
+RUN ./helio/blaze.sh -release -DWITH_SEARCH=OFF -DWITH_AWS=OFF -DWITH_GCP=OFF
+RUN cd build-opt && ninja dragonfly
+
+# Runtime stage
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libssl3 \
+    libunwind8 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=builder /src/build-opt/dragonfly /app/dragonfly
+
+EXPOSE 6379
+
+ENTRYPOINT ["/app/dragonfly"]
+CMD ["--logtostderr"]

--- a/tools/cms_benchmark/Dockerfile.dragonfly-build
+++ b/tools/cms_benchmark/Dockerfile.dragonfly-build
@@ -1,0 +1,60 @@
+# Self-contained multi-stage build for Dragonfly with CMS optimizations
+FROM ubuntu:22.04 AS builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    git \
+    cmake \
+    ninja-build \
+    g++ \
+    libssl-dev \
+    libunwind-dev \
+    libboost-fiber-dev \
+    libboost-context-dev \
+    autoconf \
+    libtool \
+    libxml2-dev \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Copy full source tree
+COPY . .
+
+# Initialize submodules and build release (minimal config for speed)
+RUN git config --global --add safe.directory /build && \
+    git config --global --add safe.directory /build/helio && \
+    git submodule update --init --recursive
+
+RUN ./helio/blaze.sh -release \
+    -DWITH_SEARCH=OFF \
+    -DWITH_AWS=OFF \
+    -DWITH_GCP=OFF \
+    -DWITH_TIERING=OFF
+
+RUN cd build-opt && ninja dragonfly
+
+# Runtime stage
+FROM ubuntu:22.04
+
+RUN apt-get update && \
+    apt-get install -q -y --no-install-recommends \
+        netcat-openbsd ca-certificates redis-tools net-tools tini && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd -r -g 999 dfly && \
+    useradd -r -g dfly -u 999 dfly && \
+    mkdir /data && chown dfly:dfly /data
+
+COPY tools/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY tools/docker/healthcheck.sh /usr/local/bin/healthcheck.sh
+COPY --from=builder /build/build-opt/dragonfly /usr/local/bin/
+
+VOLUME /data
+WORKDIR /data
+
+HEALTHCHECK CMD /usr/local/bin/healthcheck.sh
+ENTRYPOINT ["/usr/bin/tini", "--", "entrypoint.sh"]
+EXPOSE 6379
+CMD ["dragonfly", "--logtostderr"]

--- a/tools/cms_benchmark/benchmark.py
+++ b/tools/cms_benchmark/benchmark.py
@@ -1,0 +1,712 @@
+#!/usr/bin/env python3 -u
+"""
+CMS (Count-Min Sketch) Benchmark: Dragonfly vs Redis Stack
+
+This benchmark compares the performance of CMS operations between
+Dragonfly's native implementation and Redis Stack's RedisBloom module.
+
+Usage:
+    python benchmark.py [--dragonfly-host HOST] [--redis-host HOST] [--iterations N]
+"""
+
+import argparse
+import random
+import statistics
+import string
+import sys
+import time
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from typing import Callable, List, Tuple
+
+import redis
+
+
+@dataclass
+class BenchmarkResult:
+    """Results from a single benchmark run."""
+    operation: str
+    server: str
+    iterations: int
+    total_time_ms: float
+    avg_time_ms: float
+    min_time_ms: float
+    max_time_ms: float
+    p50_time_ms: float
+    p95_time_ms: float
+    p99_time_ms: float
+    ops_per_sec: float
+
+
+def generate_random_items(count: int, length: int = 10) -> List[str]:
+    """Generate random string items for testing."""
+    return [
+        "".join(random.choices(string.ascii_lowercase + string.digits, k=length))
+        for _ in range(count)
+    ]
+
+
+def measure_latencies(func: Callable, iterations: int) -> List[float]:
+    """Execute a function multiple times and measure latencies in ms."""
+    latencies = []
+    for _ in range(iterations):
+        start = time.perf_counter()
+        func()
+        end = time.perf_counter()
+        latencies.append((end - start) * 1000)  # Convert to ms
+    return latencies
+
+
+def compute_stats(
+    operation: str, server: str, latencies: List[float]
+) -> BenchmarkResult:
+    """Compute statistics from latency measurements."""
+    sorted_latencies = sorted(latencies)
+    total = sum(latencies)
+    count = len(latencies)
+
+    return BenchmarkResult(
+        operation=operation,
+        server=server,
+        iterations=count,
+        total_time_ms=total,
+        avg_time_ms=statistics.mean(latencies),
+        min_time_ms=min(latencies),
+        max_time_ms=max(latencies),
+        p50_time_ms=sorted_latencies[int(count * 0.50)],
+        p95_time_ms=sorted_latencies[int(count * 0.95)],
+        p99_time_ms=sorted_latencies[int(count * 0.99)],
+        ops_per_sec=(count / total) * 1000 if total > 0 else 0,
+    )
+
+
+def print_result(result: BenchmarkResult):
+    """Print a formatted benchmark result."""
+    print(f"  {result.server}:")
+    print(f"    Total time:    {result.total_time_ms:>10.2f} ms")
+    print(f"    Avg latency:   {result.avg_time_ms:>10.4f} ms")
+    print(f"    Min latency:   {result.min_time_ms:>10.4f} ms")
+    print(f"    Max latency:   {result.max_time_ms:>10.4f} ms")
+    print(f"    P50 latency:   {result.p50_time_ms:>10.4f} ms")
+    print(f"    P95 latency:   {result.p95_time_ms:>10.4f} ms")
+    print(f"    P99 latency:   {result.p99_time_ms:>10.4f} ms")
+    print(f"    Throughput:    {result.ops_per_sec:>10.0f} ops/sec")
+
+
+def print_comparison(df_result: BenchmarkResult, redis_result: BenchmarkResult):
+    """Print comparison between Dragonfly and Redis results."""
+    speedup = redis_result.avg_time_ms / df_result.avg_time_ms if df_result.avg_time_ms > 0 else 0
+    print(f"  Speedup (Dragonfly vs Redis): {speedup:.2f}x")
+    if speedup > 1:
+        print(f"  → Dragonfly is {speedup:.2f}x faster")
+    elif speedup < 1:
+        print(f"  → Redis is {1/speedup:.2f}x faster")
+    else:
+        print("  → Performance is similar")
+
+
+class CMSBenchmark:
+    """CMS Benchmark suite."""
+
+    def __init__(
+        self,
+        dragonfly_client: redis.Redis,
+        redis_client: redis.Redis,
+        iterations: int = 1000,
+    ):
+        self.df = dragonfly_client
+        self.redis = redis_client
+        self.iterations = iterations
+        self.results: List[Tuple[BenchmarkResult, BenchmarkResult]] = []
+
+    def setup(self):
+        """Clean up any existing keys."""
+        for client in [self.df, self.redis]:
+            try:
+                client.flushall()
+            except Exception as e:
+                print(f"Warning: Could not flush: {e}")
+
+    def benchmark_initbydim(self, width: int = 1000, depth: int = 5):
+        """Benchmark CMS.INITBYDIM operation."""
+        print(f"\n{'='*60}")
+        print(f"Benchmark: CMS.INITBYDIM (width={width}, depth={depth})")
+        print(f"Iterations: {self.iterations}")
+        print("=" * 60)
+
+        # Dragonfly
+        key_counter = [0]
+
+        def df_init():
+            key = f"cms_df_{key_counter[0]}"
+            key_counter[0] += 1
+            self.df.execute_command("CMS.INITBYDIM", key, width, depth)
+
+        df_latencies = measure_latencies(df_init, self.iterations)
+        df_result = compute_stats("INITBYDIM", "Dragonfly", df_latencies)
+
+        # Redis
+        key_counter[0] = 0
+
+        def redis_init():
+            key = f"cms_redis_{key_counter[0]}"
+            key_counter[0] += 1
+            self.redis.execute_command("CMS.INITBYDIM", key, width, depth)
+
+        redis_latencies = measure_latencies(redis_init, self.iterations)
+        redis_result = compute_stats("INITBYDIM", "Redis Stack", redis_latencies)
+
+        print_result(df_result)
+        print_result(redis_result)
+        print_comparison(df_result, redis_result)
+
+        self.results.append((df_result, redis_result))
+        return df_result, redis_result
+
+    def benchmark_incrby(self, num_items: int = 100, increments_per_call: int = 10):
+        """Benchmark CMS.INCRBY operation."""
+        print(f"\n{'='*60}")
+        print(f"Benchmark: CMS.INCRBY ({increments_per_call} items per call)")
+        print(f"Iterations: {self.iterations}")
+        print("=" * 60)
+
+        # Setup CMS structures
+        self.df.execute_command("CMS.INITBYDIM", "bench_df", 2000, 7)
+        self.redis.execute_command("CMS.INITBYDIM", "bench_redis", 2000, 7)
+
+        items = generate_random_items(num_items)
+
+        # Dragonfly
+        def df_incrby():
+            batch_items = random.sample(items, increments_per_call)
+            args = []
+            for item in batch_items:
+                args.extend([item, random.randint(1, 100)])
+            self.df.execute_command("CMS.INCRBY", "bench_df", *args)
+
+        df_latencies = measure_latencies(df_incrby, self.iterations)
+        df_result = compute_stats("INCRBY", "Dragonfly", df_latencies)
+
+        # Redis
+        def redis_incrby():
+            batch_items = random.sample(items, increments_per_call)
+            args = []
+            for item in batch_items:
+                args.extend([item, random.randint(1, 100)])
+            self.redis.execute_command("CMS.INCRBY", "bench_redis", *args)
+
+        redis_latencies = measure_latencies(redis_incrby, self.iterations)
+        redis_result = compute_stats("INCRBY", "Redis Stack", redis_latencies)
+
+        print_result(df_result)
+        print_result(redis_result)
+        print_comparison(df_result, redis_result)
+
+        self.results.append((df_result, redis_result))
+        return df_result, redis_result
+
+    def benchmark_query(self, num_items: int = 100, queries_per_call: int = 10):
+        """Benchmark CMS.QUERY operation."""
+        print(f"\n{'='*60}")
+        print(f"Benchmark: CMS.QUERY ({queries_per_call} items per call)")
+        print(f"Iterations: {self.iterations}")
+        print("=" * 60)
+
+        # Setup: Create and populate CMS structures
+        self.df.execute_command("CMS.INITBYDIM", "query_df", 2000, 7)
+        self.redis.execute_command("CMS.INITBYDIM", "query_redis", 2000, 7)
+
+        items = generate_random_items(num_items)
+
+        # Populate with data
+        for i in range(0, len(items), 10):
+            batch = items[i : i + 10]
+            args = []
+            for item in batch:
+                args.extend([item, random.randint(1, 1000)])
+            self.df.execute_command("CMS.INCRBY", "query_df", *args)
+            self.redis.execute_command("CMS.INCRBY", "query_redis", *args)
+
+        # Dragonfly
+        def df_query():
+            batch_items = random.sample(items, queries_per_call)
+            self.df.execute_command("CMS.QUERY", "query_df", *batch_items)
+
+        df_latencies = measure_latencies(df_query, self.iterations)
+        df_result = compute_stats("QUERY", "Dragonfly", df_latencies)
+
+        # Redis
+        def redis_query():
+            batch_items = random.sample(items, queries_per_call)
+            self.redis.execute_command("CMS.QUERY", "query_redis", *batch_items)
+
+        redis_latencies = measure_latencies(redis_query, self.iterations)
+        redis_result = compute_stats("QUERY", "Redis Stack", redis_latencies)
+
+        print_result(df_result)
+        print_result(redis_result)
+        print_comparison(df_result, redis_result)
+
+        self.results.append((df_result, redis_result))
+        return df_result, redis_result
+
+    def benchmark_info(self):
+        """Benchmark CMS.INFO operation."""
+        print(f"\n{'='*60}")
+        print("Benchmark: CMS.INFO")
+        print(f"Iterations: {self.iterations}")
+        print("=" * 60)
+
+        # Setup CMS structures
+        self.df.execute_command("CMS.INITBYDIM", "info_df", 2000, 7)
+        self.redis.execute_command("CMS.INITBYDIM", "info_redis", 2000, 7)
+
+        # Dragonfly
+        def df_info():
+            self.df.execute_command("CMS.INFO", "info_df")
+
+        df_latencies = measure_latencies(df_info, self.iterations)
+        df_result = compute_stats("INFO", "Dragonfly", df_latencies)
+
+        # Redis
+        def redis_info():
+            self.redis.execute_command("CMS.INFO", "info_redis")
+
+        redis_latencies = measure_latencies(redis_info, self.iterations)
+        redis_result = compute_stats("INFO", "Redis Stack", redis_latencies)
+
+        print_result(df_result)
+        print_result(redis_result)
+        print_comparison(df_result, redis_result)
+
+        self.results.append((df_result, redis_result))
+        return df_result, redis_result
+
+    def benchmark_merge(self, num_sources: int = 3):
+        """Benchmark CMS.MERGE operation."""
+        print(f"\n{'='*60}")
+        print(f"Benchmark: CMS.MERGE ({num_sources} sources)")
+        print(f"Iterations: {self.iterations}")
+        print("=" * 60)
+
+        items = generate_random_items(50)
+        merge_iterations = min(self.iterations, 500)  # Merge is heavier
+
+        # Setup for Dragonfly
+        for i in range(num_sources):
+            self.df.execute_command("CMS.INITBYDIM", f"merge_src_df_{i}", 1000, 5)
+            args = []
+            for item in random.sample(items, 10):
+                args.extend([item, random.randint(1, 100)])
+            self.df.execute_command("CMS.INCRBY", f"merge_src_df_{i}", *args)
+
+        # Setup for Redis
+        for i in range(num_sources):
+            self.redis.execute_command("CMS.INITBYDIM", f"merge_src_redis_{i}", 1000, 5)
+            args = []
+            for item in random.sample(items, 10):
+                args.extend([item, random.randint(1, 100)])
+            self.redis.execute_command("CMS.INCRBY", f"merge_src_redis_{i}", *args)
+
+        # Create destination keys
+        dest_counter = [0]
+
+        # Dragonfly
+        def df_merge():
+            dest = f"merge_dest_df_{dest_counter[0]}"
+            dest_counter[0] += 1
+            self.df.execute_command("CMS.INITBYDIM", dest, 1000, 5)
+            sources = [f"merge_src_df_{i}" for i in range(num_sources)]
+            self.df.execute_command("CMS.MERGE", dest, num_sources, *sources)
+
+        df_latencies = measure_latencies(df_merge, merge_iterations)
+        df_result = compute_stats("MERGE", "Dragonfly", df_latencies)
+
+        # Redis
+        dest_counter[0] = 0
+
+        def redis_merge():
+            dest = f"merge_dest_redis_{dest_counter[0]}"
+            dest_counter[0] += 1
+            self.redis.execute_command("CMS.INITBYDIM", dest, 1000, 5)
+            sources = [f"merge_src_redis_{i}" for i in range(num_sources)]
+            self.redis.execute_command("CMS.MERGE", dest, num_sources, *sources)
+
+        redis_latencies = measure_latencies(redis_merge, merge_iterations)
+        redis_result = compute_stats("MERGE", "Redis Stack", redis_latencies)
+
+        print_result(df_result)
+        print_result(redis_result)
+        print_comparison(df_result, redis_result)
+
+        self.results.append((df_result, redis_result))
+        return df_result, redis_result
+
+    def benchmark_mixed_workload(self, read_ratio: float = 0.7):
+        """Benchmark mixed read/write workload."""
+        print(f"\n{'='*60}")
+        print(f"Benchmark: Mixed Workload ({int(read_ratio*100)}% reads)")
+        print(f"Iterations: {self.iterations}")
+        print("=" * 60)
+
+        # Setup
+        self.df.execute_command("CMS.INITBYDIM", "mixed_df", 2000, 7)
+        self.redis.execute_command("CMS.INITBYDIM", "mixed_redis", 2000, 7)
+
+        items = generate_random_items(100)
+
+        # Pre-populate
+        for item in items[:50]:
+            self.df.execute_command("CMS.INCRBY", "mixed_df", item, 100)
+            self.redis.execute_command("CMS.INCRBY", "mixed_redis", item, 100)
+
+        # Dragonfly mixed workload
+        def df_mixed():
+            if random.random() < read_ratio:
+                # Read operation
+                batch = random.sample(items, 5)
+                self.df.execute_command("CMS.QUERY", "mixed_df", *batch)
+            else:
+                # Write operation
+                batch = random.sample(items, 3)
+                args = []
+                for item in batch:
+                    args.extend([item, random.randint(1, 10)])
+                self.df.execute_command("CMS.INCRBY", "mixed_df", *args)
+
+        df_latencies = measure_latencies(df_mixed, self.iterations)
+        df_result = compute_stats("MIXED", "Dragonfly", df_latencies)
+
+        # Redis mixed workload
+        def redis_mixed():
+            if random.random() < read_ratio:
+                batch = random.sample(items, 5)
+                self.redis.execute_command("CMS.QUERY", "mixed_redis", *batch)
+            else:
+                batch = random.sample(items, 3)
+                args = []
+                for item in batch:
+                    args.extend([item, random.randint(1, 10)])
+                self.redis.execute_command("CMS.INCRBY", "mixed_redis", *args)
+
+        redis_latencies = measure_latencies(redis_mixed, self.iterations)
+        redis_result = compute_stats("MIXED", "Redis Stack", redis_latencies)
+
+        print_result(df_result)
+        print_result(redis_result)
+        print_comparison(df_result, redis_result)
+
+        self.results.append((df_result, redis_result))
+        return df_result, redis_result
+
+    def benchmark_baseline_get_set(self):
+        """Benchmark basic GET/SET to compare framework overhead."""
+        print(f"\n{'='*60}")
+        print("Benchmark: BASELINE GET/SET (framework overhead comparison)")
+        print(f"Iterations: {self.iterations}")
+        print("=" * 60)
+
+        # Setup: Create keys with values
+        for i in range(100):
+            self.df.set(f"bench_key_{i}", f"value_{i}" * 10)
+            self.redis.set(f"bench_key_{i}", f"value_{i}" * 10)
+
+        # Dragonfly GET
+        def df_get():
+            key = f"bench_key_{random.randint(0, 99)}"
+            self.df.get(key)
+
+        df_latencies = measure_latencies(df_get, self.iterations)
+        df_result = compute_stats("GET", "Dragonfly", df_latencies)
+
+        # Redis GET
+        def redis_get():
+            key = f"bench_key_{random.randint(0, 99)}"
+            self.redis.get(key)
+
+        redis_latencies = measure_latencies(redis_get, self.iterations)
+        redis_result = compute_stats("GET", "Redis Stack", redis_latencies)
+
+        print_result(df_result)
+        print_result(redis_result)
+        print_comparison(df_result, redis_result)
+
+        self.results.append((df_result, redis_result))
+
+        # Now test SET
+        print(f"\n{'-'*60}")
+        print("SET operation:")
+        print("-" * 60)
+
+        counter = [0]
+
+        # Dragonfly SET
+        def df_set():
+            key = f"bench_set_{counter[0]}"
+            counter[0] += 1
+            self.df.set(key, "x" * 100)
+
+        df_latencies = measure_latencies(df_set, self.iterations)
+        df_result_set = compute_stats("SET", "Dragonfly", df_latencies)
+
+        counter[0] = 0
+
+        # Redis SET
+        def redis_set():
+            key = f"bench_set_{counter[0]}"
+            counter[0] += 1
+            self.redis.set(key, "x" * 100)
+
+        redis_latencies = measure_latencies(redis_set, self.iterations)
+        redis_result_set = compute_stats("SET", "Redis Stack", redis_latencies)
+
+        print_result(df_result_set)
+        print_result(redis_result_set)
+        print_comparison(df_result_set, redis_result_set)
+
+        self.results.append((df_result_set, redis_result_set))
+
+        return df_result, redis_result
+
+    def print_summary(self):
+        """Print a summary table of all results."""
+        print(f"\n{'='*60}")
+        print("SUMMARY")
+        print("=" * 60)
+        print(
+            f"{'Operation':<15} {'Dragonfly (ops/s)':<20} {'Redis (ops/s)':<20} {'Speedup':<10}"
+        )
+        print("-" * 65)
+
+        for df_result, redis_result in self.results:
+            speedup = (
+                redis_result.avg_time_ms / df_result.avg_time_ms
+                if df_result.avg_time_ms > 0
+                else 0
+            )
+            speedup_str = f"{speedup:.2f}x"
+            if speedup > 1:
+                speedup_str = f"\033[92m{speedup_str}\033[0m"  # Green
+            elif speedup < 1:
+                speedup_str = f"\033[91m{1/speedup:.2f}x slower\033[0m"  # Red
+
+            print(
+                f"{df_result.operation:<15} {df_result.ops_per_sec:<20.0f} "
+                f"{redis_result.ops_per_sec:<20.0f} {speedup_str:<10}"
+            )
+
+    def run_all(self):
+        """Run all benchmarks."""
+        self.setup()
+
+        # First: baseline GET/SET to measure framework overhead
+        self.benchmark_baseline_get_set()
+        self.setup()
+
+        self.benchmark_initbydim()
+        self.setup()
+
+        self.benchmark_incrby()
+        self.setup()
+
+        self.benchmark_query()
+        self.setup()
+
+        self.benchmark_info()
+        self.setup()
+
+        self.benchmark_merge()
+        self.setup()
+
+        self.benchmark_mixed_workload()
+
+        self.print_summary()
+
+
+def benchmark_concurrent(host: str, port: int, operation: Callable,
+                         num_threads: int, ops_per_thread: int, name: str) -> dict:
+    """Run concurrent benchmark with multiple threads."""
+
+    def worker(thread_id: int) -> int:
+        """Each worker creates its own connection and runs operations."""
+        client = redis.Redis(host=host, port=port, decode_responses=True)
+        count = 0
+        for _ in range(ops_per_thread):
+            operation(client, thread_id)
+            count += 1
+        client.close()
+        return count
+
+    start = time.perf_counter()
+    total_ops = 0
+
+    with ThreadPoolExecutor(max_workers=num_threads) as executor:
+        futures = [executor.submit(worker, i) for i in range(num_threads)]
+        for future in as_completed(futures):
+            total_ops += future.result()
+
+    elapsed = time.perf_counter() - start
+    ops_per_sec = total_ops / elapsed
+
+    return {
+        "name": name,
+        "total_ops": total_ops,
+        "elapsed_sec": elapsed,
+        "ops_per_sec": ops_per_sec,
+        "threads": num_threads
+    }
+
+
+def wait_for_server(client: redis.Redis, name: str, max_retries: int = 30):
+    """Wait for a server to be ready."""
+    for i in range(max_retries):
+        try:
+            client.ping()
+            print(f"✓ {name} is ready")
+            return True
+        except redis.ConnectionError:
+            if i < max_retries - 1:
+                print(f"  Waiting for {name}... ({i+1}/{max_retries})")
+                time.sleep(1)
+    print(f"✗ Failed to connect to {name}")
+    return False
+
+
+def run_concurrent_cms_benchmark(df_host: str, df_port: int,
+                                  redis_host: str, redis_port: int,
+                                  num_threads: int, ops_per_thread: int):
+    """Run concurrent CMS benchmark."""
+    print(f"\n{'='*70}")
+    print(f"CONCURRENT CMS BENCHMARK ({num_threads} threads, {ops_per_thread} ops/thread)")
+    print("=" * 70)
+
+    items = generate_random_items(1000)
+
+    # Setup CMS on both servers - CREATE MULTIPLE KEYS FOR SHARDING
+    num_keys = num_threads  # One CMS per thread for max parallelism
+    df_setup = redis.Redis(host=df_host, port=df_port, decode_responses=True)
+    redis_setup = redis.Redis(host=redis_host, port=redis_port, decode_responses=True)
+
+    df_setup.flushall()
+    redis_setup.flushall()
+
+    for i in range(num_keys):
+        df_setup.execute_command("CMS.INITBYDIM", f"bench_cms_{i}", 2000, 7)
+        redis_setup.execute_command("CMS.INITBYDIM", f"bench_cms_{i}", 2000, 7)
+
+    df_setup.close()
+    redis_setup.close()
+
+    # CMS.INCRBY operation - each thread uses its own key
+    def cms_incrby(client, thread_id):
+        key = f"bench_cms_{thread_id % num_keys}"
+        batch_items = random.sample(items, 5)
+        args = []
+        for item in batch_items:
+            args.extend([item, random.randint(1, 100)])
+        client.execute_command("CMS.INCRBY", key, *args)
+
+    # CMS.QUERY operation - each thread uses its own key
+    def cms_query(client, thread_id):
+        key = f"bench_cms_{thread_id % num_keys}"
+        batch_items = random.sample(items, 5)
+        client.execute_command("CMS.QUERY", key, *batch_items)
+
+    # Test INCRBY
+    print(f"\n--- CMS.INCRBY (5 items/call) ---")
+    df_result = benchmark_concurrent(df_host, df_port, cms_incrby,
+                                      num_threads, ops_per_thread, "Dragonfly")
+    redis_result = benchmark_concurrent(redis_host, redis_port, cms_incrby,
+                                         num_threads, ops_per_thread, "Redis")
+
+    print(f"  Dragonfly: {df_result['ops_per_sec']:>12,.0f} ops/sec")
+    print(f"  Redis:     {redis_result['ops_per_sec']:>12,.0f} ops/sec")
+    speedup = df_result['ops_per_sec'] / redis_result['ops_per_sec']
+    if speedup > 1:
+        print(f"  → Dragonfly is {speedup:.2f}x FASTER ✅")
+    else:
+        print(f"  → Redis is {1/speedup:.2f}x faster")
+
+    # Test QUERY
+    print(f"\n--- CMS.QUERY (5 items/call) ---")
+    df_result = benchmark_concurrent(df_host, df_port, cms_query,
+                                      num_threads, ops_per_thread, "Dragonfly")
+    redis_result = benchmark_concurrent(redis_host, redis_port, cms_query,
+                                         num_threads, ops_per_thread, "Redis")
+
+    print(f"  Dragonfly: {df_result['ops_per_sec']:>12,.0f} ops/sec")
+    print(f"  Redis:     {redis_result['ops_per_sec']:>12,.0f} ops/sec")
+    speedup = df_result['ops_per_sec'] / redis_result['ops_per_sec']
+    if speedup > 1:
+        print(f"  → Dragonfly is {speedup:.2f}x FASTER ✅")
+    else:
+        print(f"  → Redis is {1/speedup:.2f}x faster")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="CMS Benchmark: Dragonfly vs Redis Stack"
+    )
+    parser.add_argument(
+        "--dragonfly-host", default="localhost", help="Dragonfly host (default: localhost)"
+    )
+    parser.add_argument(
+        "--dragonfly-port", type=int, default=6380, help="Dragonfly port (default: 6380)"
+    )
+    parser.add_argument(
+        "--redis-host", default="localhost", help="Redis host (default: localhost)"
+    )
+    parser.add_argument(
+        "--redis-port", type=int, default=6381, help="Redis port (default: 6381)"
+    )
+    parser.add_argument(
+        "--iterations", type=int, default=1000, help="Number of iterations (default: 1000)"
+    )
+    parser.add_argument(
+        "--concurrent", action="store_true", help="Run concurrent benchmark only"
+    )
+    parser.add_argument(
+        "--threads", type=int, default=50, help="Number of threads for concurrent test"
+    )
+    args = parser.parse_args()
+
+    print("=" * 60)
+    print("CMS Benchmark: Dragonfly vs Redis Stack")
+    print("=" * 60)
+
+    # Connect to servers
+    print("\nConnecting to servers...")
+
+    df_client = redis.Redis(
+        host=args.dragonfly_host, port=args.dragonfly_port, decode_responses=True
+    )
+    redis_client = redis.Redis(
+        host=args.redis_host, port=args.redis_port, decode_responses=True
+    )
+
+    if not wait_for_server(df_client, "Dragonfly"):
+        sys.exit(1)
+    if not wait_for_server(redis_client, "Redis Stack"):
+        sys.exit(1)
+
+    if args.concurrent:
+        # Run concurrent benchmark only
+        run_concurrent_cms_benchmark(
+            args.dragonfly_host, args.dragonfly_port,
+            args.redis_host, args.redis_port,
+            num_threads=args.threads,
+            ops_per_thread=args.iterations
+        )
+    else:
+        # Run sequential benchmarks
+        benchmark = CMSBenchmark(df_client, redis_client, iterations=args.iterations)
+        benchmark.run_all()
+
+    # Cleanup
+    df_client.close()
+    redis_client.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/cms_benchmark/docker-compose.yml
+++ b/tools/cms_benchmark/docker-compose.yml
@@ -1,0 +1,44 @@
+services:
+  dragonfly:
+    image: dragonfly:cms-opt
+    container_name: cms-bench-dragonfly
+    ports:
+      - "6380:6379"
+    ulimits:
+      memlock: -1
+    command: >
+      --proactor_threads=4
+      --cache_mode=false
+    networks:
+      - cms-bench
+
+  redis-stack:
+    image: redis/redis-stack-server:latest
+    container_name: cms-bench-redis
+    ports:
+      - "6381:6379"
+    networks:
+      - cms-bench
+
+  benchmark:
+    build:
+      context: .
+      dockerfile: Dockerfile.benchmark
+    container_name: cms-bench-runner
+    depends_on:
+      - dragonfly
+      - redis-stack
+    command: >
+      --dragonfly-host dragonfly
+      --dragonfly-port 6379
+      --redis-host redis-stack
+      --redis-port 6379
+      --iterations 1000
+    networks:
+      - cms-bench
+    profiles:
+      - bench
+
+networks:
+  cms-bench:
+    driver: bridge

--- a/tools/cms_benchmark/run_benchmark.sh
+++ b/tools/cms_benchmark/run_benchmark.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# CMS Benchmark Runner
+# Compares Dragonfly CMS implementation vs Redis Stack (RedisBloom)
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}╔════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${GREEN}║       CMS Benchmark: Dragonfly vs Redis Stack              ║${NC}"
+echo -e "${GREEN}╚════════════════════════════════════════════════════════════╝${NC}"
+
+# Parse arguments
+ITERATIONS=${1:-1000}
+DRAGONFLY_IMAGE=${DRAGONFLY_IMAGE:-"docker.dragonflydb.io/dragonflydb/dragonfly:latest"}
+
+echo -e "\n${YELLOW}Configuration:${NC}"
+echo "  Iterations: $ITERATIONS"
+echo "  Dragonfly Image: $DRAGONFLY_IMAGE"
+
+# Check if docker compose is available
+if command -v docker-compose &> /dev/null; then
+    COMPOSE_CMD="docker-compose"
+elif docker compose version &> /dev/null 2>&1; then
+    COMPOSE_CMD="docker compose"
+else
+    echo -e "${RED}Error: docker-compose or docker compose not found${NC}"
+    exit 1
+fi
+
+echo -e "\n${YELLOW}Starting containers...${NC}"
+$COMPOSE_CMD up -d
+
+echo -e "\n${YELLOW}Waiting for services to be ready...${NC}"
+sleep 3
+
+# Get the host IP for the remote docker context
+DOCKER_HOST_IP=$(docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null | sed 's|tcp://\([^:]*\):.*|\1|' || echo "localhost")
+
+if [ "$DOCKER_HOST_IP" = "" ] || [ "$DOCKER_HOST_IP" = "localhost" ]; then
+    # Try to get from docker info
+    DOCKER_HOST_IP="localhost"
+fi
+
+echo "  Docker Host: $DOCKER_HOST_IP"
+
+echo -e "\n${YELLOW}Running benchmark...${NC}"
+python3 benchmark.py \
+    --dragonfly-host "$DOCKER_HOST_IP" \
+    --dragonfly-port 6380 \
+    --redis-host "$DOCKER_HOST_IP" \
+    --redis-port 6381 \
+    --iterations "$ITERATIONS"
+
+echo -e "\n${YELLOW}Cleaning up...${NC}"
+$COMPOSE_CMD down
+
+echo -e "\n${GREEN}Benchmark complete!${NC}"


### PR DESCRIPTION
Implement Redis-compatible CMS commands:
- CMS.INITBYDIM: Initialize with width/depth
- CMS.INITBYPROB: Initialize with error/probability
- CMS.INCRBY: Increment counters for items
- CMS.QUERY: Query estimated counts
- CMS.INFO: Get sketch dimensions and count
- CMS.MERGE: Merge multiple sketches with optional weights

Implementation details:
- Core CMS class using XXH3 hash function
- PMR memory allocator support
- Cross-shard merge support for distributed operations
- Comprehensive unit tests

Also includes:
- Benchmark tool comparing Dragonfly vs Redis Stack
- Docker Compose setup for easy benchmarking
