### PR TITLE
chore: wrap list operations within ListWrapper

### DIFF
--- a/src/core/qlist.h
+++ b/src/core/qlist.h
@@ -39,21 +39,24 @@ class QList {
    * items). recompress: 1 bit, bool, true if node is temporary decompressed for usage.
    * attempted_compress: 1 bit, boolean, used for verifying during testing.
    * dont_compress: 1 bit, boolean, used for preventing compression of entry.
-   * extra: 9 bits, free for future use; pads out the remainder of 32 bits
    * */
 
   struct Node {
     Node* prev;
     Node* next;
     unsigned char* entry;
-    size_t sz;                           /* entry size in bytes */
-    unsigned int count : 16;             /* count of items in listpack */
-    unsigned int encoding : 2;           /* RAW==1 or LZF==2 */
-    unsigned int container : 2;          /* PLAIN==1 or PACKED==2 */
-    unsigned int recompress : 1;         /* was this node previous compressed? */
-    unsigned int attempted_compress : 1; /* node can't compress; too small */
-    unsigned int dont_compress : 1;      /* prevent compression of entry that will be used later */
-    unsigned int extra : 25;             /* more bits to steal for future usage */
+    size_t sz : 48;    /* entry size in bytes */
+    size_t count : 16; /* count of items in listpack */
+
+    uint16_t encoding : 2;           /* RAW==1 or LZF==2 */
+    uint16_t container : 2;          /* PLAIN==1 or PACKED==2 */
+    uint16_t recompress : 1;         /* was this node previous compressed? */
+    uint16_t attempted_compress : 1; /* node can't compress; too small */
+    uint16_t dont_compress : 1;      /* prevent compression of entry that will be used later */
+    uint16_t reserved1 : 9;          /* reserved for future use */
+
+    uint16_t reserved2; /* more bits to steal for future usage */
+    uint32_t reserved3; /* more bits to steal for future usage */
 
     bool IsCompressed() const {
       return encoding != QUICKLIST_NODE_ENCODING_RAW;

--- a/src/server/common.h
+++ b/src/server/common.h
@@ -24,8 +24,6 @@
 
 namespace dfly {
 
-enum class ListDir : uint8_t { LEFT, RIGHT };
-
 // Dependent on ExpirePeriod representation of the value.
 constexpr int64_t kMaxExpireDeadlineSec = (1u << 28) - 1;  // 8.5 years
 constexpr int64_t kMaxExpireDeadlineMs = kMaxExpireDeadlineSec * 1000;


### PR DESCRIPTION
This is done to make the list logic neutral with respect to any encoding we would implement inside ListWrapper. Currently only QList is used but in the future, we could provide listpack or tiered storage.

The motivation - we can use listpack directly for tiny lists bypassing qlist layers.
When qlist is created for larger lists - we can also make it larger and have more metdata in it and it won't matter in relative terms. Specifically, we can add a state that will track tiering. 

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->