### PR TITLE
chore: support listpack with lists

### DIFF
--- a/src/core/collection_entry.h
+++ b/src/core/collection_entry.h
@@ -21,6 +21,8 @@ struct CollectionEntry {
   explicit CollectionEntry(long long longval) : value_{nullptr}, longval_{longval} {
   }
 
+  CollectionEntry& operator=(const CollectionEntry&) = default;
+
   std::string ToString() const {
     if (value_)
       return {value_, length_};

--- a/src/core/detail/listpack.cc
+++ b/src/core/detail/listpack.cc
@@ -88,15 +88,11 @@ bool ListPack::Insert(string_view pivot, string_view elem, QList::InsertOpt inse
   return false;
 }
 
-unsigned ListPack::Remove(string_view elem, unsigned count, QList::Where where) {
+unsigned ListPack::Remove(const CollectionEntry& elem, unsigned count, QList::Where where) {
   unsigned removed = 0;
-  int64_t ival;
-
-  // try parsing the element into an integer.
-  int is_int = lpStringToInt64(elem.data(), elem.size(), &ival);
 
   auto is_match = [&](const QList::Entry& entry) {
-    return is_int ? entry.is_int() && entry.ival() == ival : entry == elem;
+    return elem.is_int() ? entry.is_int() && entry.ival() == elem.ival() : entry == elem.view();
   };
 
   uint8_t* p = GetFirst(where);

--- a/src/core/detail/listpack.h
+++ b/src/core/detail/listpack.h
@@ -50,7 +50,7 @@ class ListPack {
   bool Insert(std::string_view pivot, std::string_view elem, QList::InsertOpt insert_opt);
 
   // Removes up to count occurrences of elem from the specified direction.
-  unsigned Remove(std::string_view elem, unsigned count, QList::Where where);
+  unsigned Remove(const CollectionEntry& elem, unsigned count, QList::Where where);
 
   // Replaces the element at the specified index with a new value.
   bool Replace(long index, std::string_view elem);
@@ -66,7 +66,7 @@ class ListPack {
   }
 
  private:
-  static QList::Entry GetEntry(uint8_t* pos);
+  static CollectionEntry GetEntry(uint8_t* pos);
 
   uint8_t* GetFirst(QList::Where where) const {
     return (where == QList::HEAD) ? lpFirst(lp_) : lpLast(lp_);

--- a/src/core/listpack_test.cc
+++ b/src/core/listpack_test.cc
@@ -39,6 +39,10 @@ class ListPackTest : public ::testing::Test {
     EXPECT_EQ(zmalloc_used_memory_tl, 0);
   }
 
+  unsigned Remove(string_view elem, unsigned count, QList::Where where) {
+    return lp_.Remove(CollectionEntry{elem.data(), elem.size()}, count, where);
+  }
+
   ListPack lp_;
   uint8_t* ptr_ = nullptr;
 };
@@ -59,7 +63,7 @@ TEST_F(ListPackTest, RemoveIntegerFromHead) {
   lp_.Push("3", QList::TAIL);
 
   // Remove integer value "1" from head
-  unsigned removed = lp_.Remove("1", 0, QList::HEAD);
+  unsigned removed = Remove("1", 0, QList::HEAD);
   EXPECT_EQ(2, removed);
   EXPECT_EQ(2, lp_.Size());
 
@@ -76,7 +80,7 @@ TEST_F(ListPackTest, RemoveFromTailAll) {
   lp_.Push("a", QList::TAIL);
 
   // Remove all "a" from tail direction
-  unsigned removed = lp_.Remove("a", 0, QList::TAIL);
+  unsigned removed = Remove("a", 0, QList::TAIL);
   EXPECT_EQ(3, removed);
   EXPECT_EQ(2, lp_.Size());
 
@@ -94,7 +98,7 @@ TEST_F(ListPackTest, RemoveFromTailWithCount) {
   lp_.Push("a", QList::TAIL);
 
   // Remove only 2 occurrences of "a" from tail (removes indices 4 and 2)
-  unsigned removed = lp_.Remove("a", 2, QList::TAIL);
+  unsigned removed = Remove("a", 2, QList::TAIL);
   EXPECT_EQ(2, removed);
   EXPECT_EQ(3, lp_.Size());
 
@@ -113,7 +117,7 @@ TEST_F(ListPackTest, RemoveFromTailConsecutive) {
   lp_.Push("target", QList::TAIL);
   lp_.Push("target", QList::TAIL);
 
-  unsigned removed = lp_.Remove("target", 0, QList::TAIL);
+  unsigned removed = Remove("target", 0, QList::TAIL);
   EXPECT_EQ(3, removed);
   EXPECT_EQ(1, lp_.Size());
   EXPECT_EQ("x", lp_.At(0));
@@ -129,7 +133,7 @@ TEST_F(ListPackTest, RemoveFromTailDeletesHead) {
   lp_.Push("b", QList::TAIL);
   lp_.Push("c", QList::TAIL);
 
-  unsigned removed = lp_.Remove("a", 0, QList::TAIL);
+  unsigned removed = Remove("a", 0, QList::TAIL);
   EXPECT_EQ(1, removed);
   EXPECT_EQ(2, lp_.Size());
 

--- a/src/core/qlist.cc
+++ b/src/core/qlist.cc
@@ -1264,6 +1264,21 @@ bool QList::Erase(const long start, unsigned count) {
   return true;
 }
 
+uint8_t* QList::TryExtractListpack() {
+  // TODO: enable this once we support listpack encoding for lists.
+  return nullptr;
+
+  if (len_ != 1 || QL_NODE_IS_PLAIN(head_) || !ShouldStoreAsListPack(head_->sz) ||
+      head_->IsCompressed()) {
+    return nullptr;
+  }
+
+  uint8_t* res = std::exchange(head_->entry, nullptr);
+  DelNode(head_);
+
+  return res;
+}
+
 bool QList::Iterator::Next() {
   if (!current_)
     return false;

--- a/src/core/qlist.h
+++ b/src/core/qlist.h
@@ -27,6 +27,14 @@ namespace dfly {
 
 class PageUsage;
 
+// Heuristic: for values smaller than 2 KiB we prefer the compact listpack
+// representation. 2048 was chosen as a conservative threshold that matches
+// common quicklist usage patterns and avoids creating very large listpacks
+// that are costly to reallocate or compress.
+inline bool ShouldStoreAsListPack(size_t size) {
+  return size < 2048;
+}
+
 class QList {
  public:
   enum Where : uint8_t { TAIL, HEAD };
@@ -143,8 +151,8 @@ class QList {
   // Returns the popped value. Precondition: list is not empty.
   std::string Pop(Where where);
 
-  void AppendListpack(unsigned char* zl);
-  void AppendPlain(unsigned char* zl, size_t sz);
+  void AppendListpack(uint8_t* zl);
+  void AppendPlain(uint8_t* zl, size_t sz);
 
   // Returns true if pivot found and elem inserted, false otherwise.
   bool Insert(std::string_view pivot, std::string_view elem, InsertOpt opt);
@@ -191,6 +199,11 @@ class QList {
   const Node* Tail() const {
     return _Tail();
   }
+
+  // Returns nullptr if quicklist does not fit the necessary requirements
+  // to be converted to listpack, and listpack otherwise. The ownership over the listpack
+  // blob is moved to the caller.
+  uint8_t* TryExtractListpack();
 
   void set_fill(int fill) {
     fill_ = fill;

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -622,7 +622,13 @@ void RdbLoaderBase::OpaqueObjLoader::CreateList(const LoadTrace* ltrace) {
   std::move(cleanup).Cancel();
 
   if (!config_.append) {
-    pv_->InitRobj(OBJ_LIST, kEncodingQL2, qlv2);
+    // Try to convert to listpack if it's a single-node quicklist
+    if (uint8_t* lp = qlv2->TryExtractListpack()) {
+      CompactObj::DeleteMR<QList>(qlv2);
+      pv_->InitRobj(OBJ_LIST, kEncodingListPack, lp);
+    } else {
+      pv_->InitRobj(OBJ_LIST, kEncodingQL2, qlv2);
+    }
   }
 }
 


### PR DESCRIPTION
The code handles listpack encoding but it's effectively disabled as the code that creates
the data-structure creates only qlist.

The next step would be to create listpack as well as implement promotion to qlist when needed.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->