### PR TITLE
chore: clarify IterateList interface

### DIFF
--- a/src/core/qlist.h
+++ b/src/core/qlist.h
@@ -187,6 +187,7 @@ class QList {
 
   size_t MallocUsed(bool slow) const;
 
+  // Iterates over entries from start to end (inclusive).
   void Iterate(IterateFunc cb, long start, long end) const;
 
   // Returns an iterator to tail or the head of the list.

--- a/src/server/container_utils.h
+++ b/src/server/container_utils.h
@@ -69,10 +69,12 @@ using IterateFunc = std::function<bool(ContainerEntry)>;
 using IterateSortedFunc = std::function<bool(ContainerEntry, double)>;
 using IterateKVFunc = std::function<bool(ContainerEntry, ContainerEntry)>;
 
-// Iterate over all values and call func(val). Iteration stops as soon
+// Iterate over all values in [start, end] range (inclusive) and call func(val).
+// Iteration stops as soon
 // as func return false. Returns true if it successfully processed all elements
-// without stopping.
-bool IterateList(const PrimeValue& pv, const IterateFunc& func, long start = 0, long end = -1);
+// without breaking.
+bool IterateList(const PrimeValue& pv, const IterateFunc& func, size_t start = 0,
+                 size_t end = SIZE_MAX);
 
 // Iterate over all values and call func(val). Iteration stops as soon
 // as func return false. Returns true if it successfully processed all elements
@@ -82,8 +84,8 @@ bool IterateSet(const PrimeValue& pv, const IterateFunc& func);
 // Iterate over all values and call func(val). Iteration stops as soon
 // as func return false. Returns true if it successfully processed all elements
 // without stopping.
-bool IterateSortedSet(const PrimeValue& pv, const IterateSortedFunc& func, int32_t start = 0,
-                      int32_t end = -1, bool reverse = false, bool use_score = false);
+bool IterateSortedSet(const PrimeValue& pv, const IterateSortedFunc& func, size_t start = 0,
+                      size_t end = SIZE_MAX, bool reverse = false, bool use_score = false);
 
 bool IterateMap(const PrimeValue& pv, const IterateKVFunc& func);
 

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -174,7 +174,7 @@ void AddObjHist(PrimeIterator it, ObjHist* hist) {
   hist->key_len.Add(it->first.MallocUsed());
 
   if (pv.ObjType() == OBJ_LIST) {
-    IterateList(pv, per_entry_cb, 0, -1);
+    IterateList(pv, per_entry_cb);
     if (pv.Encoding() == kEncodingQL2) {
       const QList* ql = static_cast<QList*>(pv.RObjPtr());
       val_len = ql->MallocUsed(true);

--- a/src/server/journal/cmd_serializer.cc
+++ b/src/server/journal/cmd_serializer.cc
@@ -176,7 +176,7 @@ size_t CmdSerializer::SerializeZSet(string_view key, const PrimeValue& pv) {
         commands += aggregator.AddArg(ce.ToString());
         return true;
       },
-      /*start=*/0, /*end=*/-1, /*reverse=*/false, /*use_score=*/true);
+      /*start=*/0, /*end=*/SIZE_MAX, /*reverse=*/false, /*use_score=*/true);
   return commands;
 }
 

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -360,6 +360,20 @@ error_code RdbSerializer::SaveObject(const PrimeValue& pv) {
 
 error_code RdbSerializer::SaveListObject(const PrimeValue& pv) {
   /* Save a list value */
+  if (pv.Encoding() == kEncodingListPack) {
+    uint8_t* lp = (uint8_t*)pv.RObjPtr();
+    size_t len = 1;  // 1 node
+    RETURN_ON_ERR(SaveLen(len));
+
+    // Node 1
+    RETURN_ON_ERR(SaveLen(QUICKLIST_NODE_CONTAINER_PACKED));
+    size_t lp_bytes = lpBytes(lp);
+    RETURN_ON_ERR(SaveString(lp, lp_bytes));
+
+    FlushIfNeeded(FlushState::kFlushEndEntry);
+    return error_code{};
+  }
+
   DCHECK_EQ(pv.Encoding(), kEncodingQL2);
   QList* ql = reinterpret_cast<QList*>(pv.RObjPtr());
   const QList::Node* node = ql->Head();

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -421,7 +421,10 @@ void IntervalVisitor::ActionRange(unsigned start, unsigned end) {
 
   // Calculate new start and end given offset and limit.
   start += params_.offset;
-  end = static_cast<uint32_t>(min(1ULL * start + params_.limit - 1, 1ULL * end));
+  end = min<size_t>(size_t(start) + params_.limit - 1, end);
+  if (start > end) {
+    return;
+  }
 
   container_utils::IterateSortedSet(
       *pv_,


### PR DESCRIPTION
Also, handle kEncodingListPack for lists in compact_objects and rdb_save. This encoding does not yet exists for lists so the changes are preparational to reduce the size of the next PR around list family.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->