### PR TITLE
fix: static assert on macos

### DIFF
--- a/src/facade/parsed_command.h
+++ b/src/facade/parsed_command.h
@@ -193,6 +193,8 @@ class ParsedCommand : public cmn::BackedArguments {
   std::variant<payload::Payload, AsyncTask> reply_;
 };
 
+#ifdef __linux__
 static_assert(sizeof(ParsedCommand) == 232);
+#endif
 
 }  // namespace facade


### PR DESCRIPTION
This static_assert is flaky on macOS:
https://github.com/dragonflydb/dragonfly/pull/6239
https://github.com/dragonflydb/dragonfly/pull/6293

I suggest leaving it for Linux only.