### PR TITLE
chore: add ListPack class that wraps c listpack

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -28,7 +28,7 @@ add_library(dfly_core allocation_tracker.cc bloom.cc compact_object.cc dense_set
     interpreter.cc glob_matcher.cc mi_memory_resource.cc qlist.cc sds_utils.cc
     segment_allocator.cc score_map.cc small_string.cc sorted_map.cc task_queue.cc
     tx_queue.cc string_set.cc string_map.cc top_keys.cc detail/bitpacking.cc detail/listpack_wrap.cc
-    count_min_sketch.cc oah_entry.cc)
+    detail/listpack.cc count_min_sketch.cc oah_entry.cc)
 
 cxx_link(dfly_core base dfly_search_core dfly_page_usage fibers2 jsonpath
     absl::flat_hash_map absl::str_format absl::random_random redis_lib
@@ -55,6 +55,7 @@ helio_cxx_test(flatbuffers_test dfly_core TRDP::flatbuffers LABELS DFLY)
 helio_cxx_test(bloom_test dfly_core LABELS DFLY)
 helio_cxx_test(allocation_tracker_test dfly_core absl::random_random LABELS DFLY)
 helio_cxx_test(qlist_test dfly_core DATA testdata/list.txt.zst LABELS DFLY)
+helio_cxx_test(listpack_test dfly_core redis_lib LABELS DFLY)
 helio_cxx_test(zstd_test dfly_core TRDP::zstd LABELS DFLY)
 helio_cxx_test(top_keys_test dfly_core LABELS DFLY)
 helio_cxx_test(page_usage_stats_test dfly_core LABELS DFLY)

--- a/src/core/detail/listpack.cc
+++ b/src/core/detail/listpack.cc
@@ -1,0 +1,142 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "core/detail/listpack.h"
+
+#include "base/logging.h"
+
+namespace dfly {
+namespace detail {
+
+using namespace std;
+
+QList::Entry ListPack::GetEntry(uint8_t* pos) {
+  unsigned int slen;
+  long long lval;
+  uint8_t* vstr = lpGetValue(pos, &slen, &lval);
+  return vstr ? QList::Entry(reinterpret_cast<char*>(vstr), slen) : QList::Entry(lval);
+}
+
+string ListPack::Pop(QList::Where where) {
+  uint8_t* pos = GetFirst(where);
+  DCHECK(pos);
+
+  string res = GetEntry(pos).to_string();
+  lp_ = lpDelete(lp_, pos, nullptr);
+  return res;
+}
+
+void ListPack::Push(string_view value, QList::Where where) {
+  if (where == QList::HEAD) {
+    lp_ = lpPrepend(lp_, (unsigned char*)value.data(), value.size());
+  } else {
+    lp_ = lpAppend(lp_, (unsigned char*)value.data(), value.size());
+  }
+}
+
+string ListPack::First(QList::Where where) const {
+  uint8_t* pos = GetFirst(where);
+  DCHECK(pos);
+
+  return GetEntry(pos).to_string();
+}
+
+std::optional<string> ListPack::At(long index) const {
+  uint8_t* pos = lpSeek(lp_, index);
+  if (!pos)
+    return nullopt;
+
+  return GetEntry(pos).to_string();
+}
+
+vector<uint32_t> ListPack::Pos(string_view element, uint32_t rank, uint32_t count, uint32_t max_len,
+                               QList::Where where) const {
+  DCHECK_GT(rank, 0u);
+  vector<uint32_t> matches;
+
+  uint8_t* p = GetFirst(where);
+  unsigned index = 0;
+  while (p && (max_len == 0 || index < max_len)) {
+    if (GetEntry(p) == element) {
+      if (rank == 1) {
+        size_t sz = lpLength(lp_);
+        auto k = (where == QList::HEAD) ? index : sz - index - 1;
+        matches.push_back(k);
+        if (count && matches.size() >= count)
+          break;
+      } else {
+        rank--;
+      }
+    }
+    index++;
+    p = (where == QList::HEAD) ? lpNext(lp_, p) : lpPrev(lp_, p);
+  }
+  return matches;
+}
+
+bool ListPack::Insert(string_view pivot, string_view elem, QList::InsertOpt insert_opt) {
+  uint8_t* p = lpFirst(lp_);
+  while (p) {
+    if (GetEntry(p) == pivot) {
+      int where = (insert_opt == QList::BEFORE) ? LP_BEFORE : LP_AFTER;
+      lp_ = lpInsertString(lp_, (unsigned char*)elem.data(), elem.size(), p, where, nullptr);
+      return true;
+    }
+    p = lpNext(lp_, p);
+  }
+  return false;
+}
+
+unsigned ListPack::Remove(string_view elem, unsigned count, QList::Where where) {
+  unsigned removed = 0;
+  int64_t ival;
+
+  // try parsing the element into an integer.
+  int is_int = lpStringToInt64(elem.data(), elem.size(), &ival);
+
+  auto is_match = [&](const QList::Entry& entry) {
+    return is_int ? entry.is_int() && entry.ival() == ival : entry == elem;
+  };
+
+  uint8_t* p = GetFirst(where);
+
+  while (p) {
+    if (is_match(GetEntry(p))) {
+      // lpDelete returns pointer to the element AFTER the deleted one (toward tail)
+      lp_ = lpDelete(lp_, p, &p);
+
+      if (where == QList::TAIL) {
+        // Iterating backward (from TAIL): need to get the previous element
+        if (p) {
+          p = lpPrev(lp_, p);
+        } else {
+          // Deleted the tail element, lpDelete returned nullptr (no element after tail).
+          // We need to continue from the new tail to keep moving towards HEAD.
+          p = lpLast(lp_);
+        }
+      }
+      // For HEAD direction, 'p' already points to the next element to check
+
+      removed++;
+      if (count && removed == count)
+        break;
+      continue;
+    }
+
+    p = (where == QList::HEAD) ? lpNext(lp_, p) : lpPrev(lp_, p);
+  }
+
+  return removed;
+}
+
+bool ListPack::Replace(long index, string_view elem) {
+  uint8_t* p = lpSeek(lp_, index);
+  if (!p)
+    return false;
+  lp_ = lpReplace(lp_, &p, (unsigned char*)elem.data(), elem.size());
+  return true;
+}
+
+}  // namespace detail
+}  // namespace dfly

--- a/src/core/detail/listpack.h
+++ b/src/core/detail/listpack.h
@@ -1,0 +1,79 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "core/qlist.h"
+
+extern "C" {
+#include "redis/listpack.h"
+}
+
+namespace dfly {
+namespace detail {
+
+// A listpack wrapper that provides basic list operations.
+// Unfortunately, we already have a listpack wrapper in core/detail/listpack_wrap.h but
+// it's more map oriented and doesn't provide the basic list operations we need here.
+// TODO: to unify both wrappers into one.
+class ListPack {
+ public:
+  explicit ListPack(uint8_t* lp = nullptr) : lp_(lp) {
+  }
+
+  size_t Size() const {
+    return lpLength(lp_);
+  }
+
+  // Removes and returns an element from the specified end (HEAD or TAIL).
+  std::string Pop(QList::Where where);
+
+  // Adds an element to the specified end (HEAD or TAIL).
+  void Push(std::string_view value, QList::Where where);
+
+  // Returns the first element from the specified end without removing it.
+  std::string First(QList::Where where) const;
+
+  // Returns the element at the specified index, or std::nullopt if out of bounds.
+  std::optional<std::string> At(long index) const;
+
+  // Finds positions of an element matching the given criteria.
+  std::vector<uint32_t> Pos(std::string_view element, uint32_t rank, uint32_t count,
+                            uint32_t max_len, QList::Where where) const;
+
+  // Inserts an element before or after the specified pivot element.
+  bool Insert(std::string_view pivot, std::string_view elem, QList::InsertOpt insert_opt);
+
+  // Removes up to count occurrences of elem from the specified direction.
+  unsigned Remove(std::string_view elem, unsigned count, QList::Where where);
+
+  // Replaces the element at the specified index with a new value.
+  bool Replace(long index, std::string_view elem);
+
+  // Removes count elements starting from the specified index.
+  void Erase(long start, long count) {
+    lp_ = lpDeleteRange(lp_, start, count);
+  }
+
+  // Returns the raw listpack pointer.
+  uint8_t* GetPointer() const {
+    return lp_;
+  }
+
+ private:
+  static QList::Entry GetEntry(uint8_t* pos);
+
+  uint8_t* GetFirst(QList::Where where) const {
+    return (where == QList::HEAD) ? lpFirst(lp_) : lpLast(lp_);
+  }
+
+  uint8_t* lp_;
+};
+
+}  // namespace detail
+}  // namespace dfly

--- a/src/core/listpack_test.cc
+++ b/src/core/listpack_test.cc
@@ -1,0 +1,208 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "core/detail/listpack.h"
+
+#include <gmock/gmock.h>
+#include <mimalloc.h>
+
+#include "base/gtest.h"
+#include "base/logging.h"
+
+extern "C" {
+#include "redis/listpack.h"
+#include "redis/zmalloc.h"
+}
+
+namespace dfly {
+namespace detail {
+
+using namespace std;
+using namespace testing;
+
+class ListPackTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    init_zmalloc_threadlocal(mi_heap_get_backing());
+  }
+
+  void SetUp() override {
+    ptr_ = lpNew(0);
+    lp_ = ListPack(ptr_);
+  }
+
+  void TearDown() override {
+    ptr_ = lp_.GetPointer();
+    lpFree(ptr_);
+    // Ensure there are no memory leaks after every test
+    EXPECT_EQ(zmalloc_used_memory_tl, 0);
+  }
+
+  ListPack lp_;
+  uint8_t* ptr_ = nullptr;
+};
+
+TEST_F(ListPackTest, InsertPivotNotFound) {
+  lp_.Push("first", QList::TAIL);
+  lp_.Push("third", QList::TAIL);
+
+  // Try to insert with non-existent pivot
+  EXPECT_FALSE(lp_.Insert("notfound", "second", QList::BEFORE));
+  EXPECT_EQ(2, lp_.Size());
+}
+
+TEST_F(ListPackTest, RemoveIntegerFromHead) {
+  lp_.Push("1", QList::TAIL);
+  lp_.Push("2", QList::TAIL);
+  lp_.Push("1", QList::TAIL);
+  lp_.Push("3", QList::TAIL);
+
+  // Remove integer value "1" from head
+  unsigned removed = lp_.Remove("1", 0, QList::HEAD);
+  EXPECT_EQ(2, removed);
+  EXPECT_EQ(2, lp_.Size());
+
+  EXPECT_EQ("2", lp_.At(0));
+  EXPECT_EQ("3", lp_.At(1));
+}
+
+TEST_F(ListPackTest, RemoveFromTailAll) {
+  // List: a, b, a, c, a
+  lp_.Push("a", QList::TAIL);
+  lp_.Push("b", QList::TAIL);
+  lp_.Push("a", QList::TAIL);
+  lp_.Push("c", QList::TAIL);
+  lp_.Push("a", QList::TAIL);
+
+  // Remove all "a" from tail direction
+  unsigned removed = lp_.Remove("a", 0, QList::TAIL);
+  EXPECT_EQ(3, removed);
+  EXPECT_EQ(2, lp_.Size());
+
+  // Remaining elements: b, c
+  EXPECT_EQ("b", lp_.At(0));
+  EXPECT_EQ("c", lp_.At(1));
+}
+
+TEST_F(ListPackTest, RemoveFromTailWithCount) {
+  // List: a, b, a, c, a
+  lp_.Push("a", QList::TAIL);
+  lp_.Push("b", QList::TAIL);
+  lp_.Push("a", QList::TAIL);
+  lp_.Push("c", QList::TAIL);
+  lp_.Push("a", QList::TAIL);
+
+  // Remove only 2 occurrences of "a" from tail (removes indices 4 and 2)
+  unsigned removed = lp_.Remove("a", 2, QList::TAIL);
+  EXPECT_EQ(2, removed);
+  EXPECT_EQ(3, lp_.Size());
+
+  // Remaining elements: a, b, c
+  EXPECT_EQ("a", lp_.At(0));
+  EXPECT_EQ("b", lp_.At(1));
+  EXPECT_EQ("c", lp_.At(2));
+}
+
+// Test removing consecutive tail elements - verifies lpLast is called correctly
+// after deleting the tail element to continue finding remaining matches.
+TEST_F(ListPackTest, RemoveFromTailConsecutive) {
+  // List: x, target, target, target - three consecutive at tail
+  lp_.Push("x", QList::TAIL);
+  lp_.Push("target", QList::TAIL);
+  lp_.Push("target", QList::TAIL);
+  lp_.Push("target", QList::TAIL);
+
+  unsigned removed = lp_.Remove("target", 0, QList::TAIL);
+  EXPECT_EQ(3, removed);
+  EXPECT_EQ(1, lp_.Size());
+  EXPECT_EQ("x", lp_.At(0));
+}
+
+// Test removing the head element while iterating from TAIL direction.
+// After checking all elements from tail to head and deleting the head,
+// lpDelete returns pointer to element after head, and lpPrev on that returns nullptr,
+// correctly ending iteration.
+TEST_F(ListPackTest, RemoveFromTailDeletesHead) {
+  // List: a, b, c - removing "a" (at head) while iterating from tail
+  lp_.Push("a", QList::TAIL);
+  lp_.Push("b", QList::TAIL);
+  lp_.Push("c", QList::TAIL);
+
+  unsigned removed = lp_.Remove("a", 0, QList::TAIL);
+  EXPECT_EQ(1, removed);
+  EXPECT_EQ(2, lp_.Size());
+
+  EXPECT_EQ("b", lp_.At(0));
+  EXPECT_EQ("c", lp_.At(1));
+}
+
+TEST_F(ListPackTest, ReplaceAtIndex) {
+  lp_.Push("first", QList::TAIL);
+  lp_.Push("second", QList::TAIL);
+  lp_.Push("third", QList::TAIL);
+
+  // Replace element at index 1
+  EXPECT_TRUE(lp_.Replace(1, "replaced"));
+  EXPECT_EQ(3, lp_.Size());
+
+  EXPECT_EQ("first", lp_.At(0));
+  EXPECT_EQ("replaced", lp_.At(1));
+  EXPECT_EQ("third", lp_.At(2));
+}
+
+TEST_F(ListPackTest, ReplaceAtNegativeIndex) {
+  lp_.Push("first", QList::TAIL);
+  lp_.Push("second", QList::TAIL);
+  lp_.Push("third", QList::TAIL);
+
+  // Replace element at index -1 (last element)
+  EXPECT_TRUE(lp_.Replace(-1, "new_last"));
+  EXPECT_EQ(3, lp_.Size());
+
+  EXPECT_EQ("first", lp_.At(0));
+  EXPECT_EQ("second", lp_.At(1));
+  EXPECT_EQ("new_last", lp_.At(2));
+}
+
+TEST_F(ListPackTest, ReplaceOutOfBounds) {
+  lp_.Push("first", QList::TAIL);
+  lp_.Push("second", QList::TAIL);
+
+  // Replace at out-of-bounds index should return false
+  EXPECT_FALSE(lp_.Replace(5, "nope"));
+  EXPECT_FALSE(lp_.Replace(-5, "nope"));
+  EXPECT_EQ(2, lp_.Size());
+
+  // Original elements unchanged
+  EXPECT_EQ("first", lp_.At(0));
+  EXPECT_EQ("second", lp_.At(1));
+}
+
+TEST_F(ListPackTest, ReplaceWithLargerString) {
+  lp_.Push("a", QList::TAIL);
+  lp_.Push("b", QList::TAIL);
+
+  // Replace with a much larger string
+  string large(500, 'x');
+  EXPECT_TRUE(lp_.Replace(0, large));
+  EXPECT_EQ(2, lp_.Size());
+
+  EXPECT_EQ(large, lp_.At(0));
+  EXPECT_EQ("b", lp_.At(1));
+}
+
+TEST_F(ListPackTest, ReplaceWithEmptyString) {
+  lp_.Push("first", QList::TAIL);
+  lp_.Push("second", QList::TAIL);
+
+  // Replace with empty string
+  EXPECT_TRUE(lp_.Replace(0, ""));
+  EXPECT_EQ(2, lp_.Size());
+
+  EXPECT_EQ("", lp_.At(0));
+  EXPECT_EQ("second", lp_.At(1));
+}
+
+}  // namespace detail
+}  // namespace dfly


### PR DESCRIPTION
Its APIs are aligned with actual actions needed by list_family.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->