### PR TITLE
feat(search): Build vector index by using data pointer for HSET objects

### DIFF
--- a/src/core/page_usage_stats_test.cc
+++ b/src/core/page_usage_stats_test.cc
@@ -470,7 +470,7 @@ class MockDocument final : public search::DocumentAccessor {
   std::optional<StringList> GetStrings(std::string_view active_field) const override {
     return {{words[absl::GetCurrentTimeNanos() % words.size()]}};
   }
-  std::optional<VectorInfo> GetVector(std::string_view active_field) const override {
+  std::optional<VectorInfo> GetVector(std::string_view active_field, size_t dim) const override {
     return std::nullopt;
   }
   std::optional<NumsList> GetNumbers(std::string_view active_field) const override {

--- a/src/core/search/base.h
+++ b/src/core/search/base.h
@@ -41,6 +41,7 @@ inline std::pair<ShardId, DocId> DecomposeGlobalDocId(GlobalDocId id) {
 enum class VectorSimilarity { L2, IP, COSINE };
 
 using OwnedFtVector = std::pair<std::unique_ptr<float[]>, size_t /* dimension (size) */>;
+using BorrowedFtVector = const char*;
 
 // Query params represent named parameters for queries supplied via PARAMS.
 struct QueryParams {
@@ -73,7 +74,7 @@ using SortableValue = std::variant<std::monostate, double, std::string>;
 
 // Interface for accessing document values with different data structures underneath.
 struct DocumentAccessor {
-  using VectorInfo = search::OwnedFtVector;
+  using VectorInfo = std::variant<search::OwnedFtVector, search::BorrowedFtVector>;
   using StringList = absl::InlinedVector<std::string_view, 1>;
   using NumsList = absl::InlinedVector<double, 1>;
 
@@ -83,7 +84,7 @@ struct DocumentAccessor {
   virtual std::optional<StringList> GetStrings(std::string_view active_field) const = 0;
 
   /* Returns nullopt if the specified field is not a vector */
-  virtual std::optional<VectorInfo> GetVector(std::string_view active_field) const = 0;
+  virtual std::optional<VectorInfo> GetVector(std::string_view active_field, size_t dim) const = 0;
 
   /* Return nullopt if the specified field is not a list of doubles */
   virtual std::optional<NumsList> GetNumbers(std::string_view active_field) const = 0;

--- a/src/core/search/hnsw_index.cc
+++ b/src/core/search/hnsw_index.cc
@@ -61,18 +61,18 @@ struct HnswlibAdapter {
   // Default setting of hnswlib/hnswalg
   constexpr static size_t kDefaultEfRuntime = 10;
 
-  explicit HnswlibAdapter(const SchemaField::VectorParams& params)
-      : space_{params.dim, params.sim},
-        world_{&space_, params.capacity, params.hnsw_m, params.hnsw_ef_construction,
-               100 /* seed*/} {
+  explicit HnswlibAdapter(const SchemaField::VectorParams& params, bool copy_vector)
+      : space_{params.dim, params.sim}, world_{&space_,       params.capacity,
+                                               params.hnsw_m, params.hnsw_ef_construction,
+                                               100 /* seed*/, copy_vector} {
   }
 
-  void Add(const float* data, GlobalDocId id) {
+  void Add(const void* data, GlobalDocId id) {
     while (true) {
       try {
         MRMWMutexLock lock(&mrmw_mutex_, MRMWMutex::LockMode::kWriteLock);
         absl::ReaderMutexLock resize_lock(&resize_mutex_);
-        world_.addPoint(data, id);
+        world_.addPoint(data ? data : world_.null_vector_, id);
         return;
       } catch (const std::exception& e) {
         std::string error_msg = e.what();
@@ -214,8 +214,11 @@ struct HnswlibAdapter {
   mutable MRMWMutex mrmw_mutex_;
 };
 
-HnswVectorIndex::HnswVectorIndex(const SchemaField::VectorParams& params, PMR_NS::memory_resource*)
-    : dim_{params.dim}, sim_{params.sim}, adapter_{make_unique<HnswlibAdapter>(params)} {
+HnswVectorIndex::HnswVectorIndex(const SchemaField::VectorParams& params, bool copy_vector,
+                                 PMR_NS::memory_resource*)
+    : dim_{params.dim},
+      sim_{params.sim},
+      adapter_{make_unique<HnswlibAdapter>(params, copy_vector)} {
   DCHECK(params.use_hnsw);
   // TODO: Patch hnsw to use MR
 }
@@ -224,20 +227,18 @@ HnswVectorIndex::~HnswVectorIndex() {
 }
 
 bool HnswVectorIndex::Add(GlobalDocId id, const DocumentAccessor& doc, std::string_view field) {
-  auto vector = doc.GetVector(field);
+  auto vector_ptr = doc.GetVector(field, dim_);
 
-  if (!vector) {
+  if (!vector_ptr) {
     return false;
   }
 
-  auto& [ptr, size] = vector.value();
-
-  if (ptr && size != dim_) {
-    return false;
-  }
-
-  if (ptr) {
-    adapter_->Add(ptr.get(), id);
+  if (std::holds_alternative<OwnedFtVector>(*vector_ptr)) {
+    const auto& owned_vector = std::get<OwnedFtVector>(*vector_ptr);
+    adapter_->Add(owned_vector.first.get(), id);
+  } else {
+    const auto& borrowed_vector = std::get<BorrowedFtVector>(*vector_ptr);
+    adapter_->Add(borrowed_vector, id);
   }
 
   return true;

--- a/src/core/search/hnsw_index.h
+++ b/src/core/search/hnsw_index.h
@@ -44,7 +44,7 @@ struct HnswNodeData {
 struct HnswlibAdapter;
 class HnswVectorIndex {
  public:
-  explicit HnswVectorIndex(const search::SchemaField::VectorParams& params,
+  explicit HnswVectorIndex(const search::SchemaField::VectorParams& params, bool copy_vector,
                            PMR_NS::memory_resource* mr = PMR_NS::get_default_resource());
 
   ~HnswVectorIndex();

--- a/src/core/search/indices.h
+++ b/src/core/search/indices.h
@@ -169,8 +169,7 @@ struct BaseVectorIndex : public BaseIndex {
  protected:
   BaseVectorIndex(size_t dim, VectorSimilarity sim);
 
-  using VectorPtr = decltype(std::declval<OwnedFtVector>().first);
-  virtual void AddVector(DocId id, const VectorPtr& vector) = 0;
+  virtual void AddVector(DocId id, const void* vector) = 0;
 
   size_t dim_;
   VectorSimilarity sim_;
@@ -189,7 +188,7 @@ struct FlatVectorIndex : public BaseVectorIndex {
   std::vector<DocId> GetAllDocsWithNonNullValues() const override;
 
  protected:
-  void AddVector(DocId id, const VectorPtr& vector) override;
+  void AddVector(DocId id, const void* vector) override;
 
  private:
   PMR_NS::vector<float> entries_;

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -63,11 +63,11 @@ struct MockedDocument : public DocumentAccessor {
     return GetStrings(field);
   }
 
-  std::optional<VectorInfo> GetVector(string_view field) const override {
+  std::optional<VectorInfo> GetVector(string_view field, size_t dim) const override {
     auto strings_list = GetStrings(field);
     if (!strings_list)
       return std::nullopt;
-    return !strings_list->empty() ? BytesToFtVectorSafe(strings_list->front()) : VectorInfo{};
+    return !strings_list->empty() ? BytesToFtVectorSafe(strings_list->front()) : OwnedFtVector{};
   }
 
   std::optional<NumsList> GetNumbers(std::string_view field) const override {

--- a/src/server/search/doc_accessors.h
+++ b/src/server/search/doc_accessors.h
@@ -34,7 +34,8 @@ struct BaseAccessor : public search::DocumentAccessor {
                                   absl::Span<const FieldReference> fields) const;
 
   // Default implementation uses GetStrings
-  virtual std::optional<VectorInfo> GetVector(std::string_view active_field) const override;
+  virtual std::optional<VectorInfo> GetVector(std::string_view active_field,
+                                              size_t dim) const override;
   virtual std::optional<NumsList> GetNumbers(std::string_view active_field) const override;
   virtual std::optional<StringList> GetTags(std::string_view active_field) const override;
 };
@@ -71,7 +72,7 @@ struct JsonAccessor : public BaseAccessor {
   }
 
   std::optional<StringList> GetStrings(std::string_view field) const override;
-  std::optional<VectorInfo> GetVector(std::string_view field) const override;
+  std::optional<VectorInfo> GetVector(std::string_view field, size_t dim) const override;
   std::optional<NumsList> GetNumbers(std::string_view active_field) const override;
   std::optional<StringList> GetTags(std::string_view active_field) const override;
 

--- a/src/server/search/global_hnsw_index.cc
+++ b/src/server/search/global_hnsw_index.cc
@@ -29,7 +29,8 @@ GlobalHnswIndexRegistry& GlobalHnswIndexRegistry::Instance() {
 }
 
 bool GlobalHnswIndexRegistry::Create(std::string_view index_name, std::string_view field_name,
-                                     const search::SchemaField::VectorParams& params) {
+                                     const search::SchemaField::VectorParams& params,
+                                     DocIndex::DataType data_type) {
   std::string key = MakeKey(index_name, field_name);
 
   std::unique_lock<std::shared_mutex> lock(registry_mutex_);
@@ -39,7 +40,9 @@ bool GlobalHnswIndexRegistry::Create(std::string_view index_name, std::string_vi
   if (it != indices_.end())
     return false;
 
-  indices_[key] = std::make_shared<search::HnswVectorIndex>(params);
+  const bool copy_vector = (data_type != DocIndex::HASH);
+
+  indices_[key] = std::make_shared<search::HnswVectorIndex>(params, copy_vector);
 
   return true;
 }

--- a/src/server/search/global_hnsw_index.h
+++ b/src/server/search/global_hnsw_index.h
@@ -24,7 +24,7 @@ class GlobalHnswIndexRegistry {
   static GlobalHnswIndexRegistry& Instance();
 
   bool Create(std::string_view index_name, std::string_view field_name,
-              const search::SchemaField::VectorParams& params);
+              const search::SchemaField::VectorParams& params, DocIndex::DataType data_type);
 
   bool Remove(std::string_view index_name, std::string_view field_name);
 

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -1266,8 +1266,8 @@ void CmdFtCreate(CmdArgList args, CommandContext* cmd_cntx) {
     if (field_info.type == search::SchemaField::VECTOR &&
         !(field_info.flags & search::SchemaField::NOINDEX)) {
       const auto& vparams = std::get<search::SchemaField::VectorParams>(field_info.special_params);
-      if (vparams.use_hnsw &&
-          !GlobalHnswIndexRegistry::Instance().Create(idx_name, field_info.short_name, vparams)) {
+      if (vparams.use_hnsw && !GlobalHnswIndexRegistry::Instance().Create(
+                                  idx_name, field_info.short_name, vparams, idx_ptr->type)) {
         cmd_cntx->tx()->Conclude();
         return builder->SendError("Index already exists");
       }


### PR DESCRIPTION
For hash set objects don't construct temporary vector and pass pointer to data during index adding. If pointer is null (i.e. field doesn't exists) use special null_pointer_ (created in hnsw index) to use as data. For JSON objects we still need to copy vector.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->