### PR TITLE
feat(server): add protected mode to bind localhost when no password is set

### DIFF
--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -223,7 +223,7 @@ void RunEngine(ProactorPool* pool, AcceptServer* acceptor) {
   // Only enabled when running under systemd (INVOCATION_ID is set) to avoid
   // breaking containerized deployments where binding to localhost would make
   // the service unreachable from the host.
-  // GetPassword() checks both --requirepass flag and DFLY_requirepass env var.
+  // GetPassword() checks both --requirepass flag and DFLY_PASSWORD env var.
   bool running_under_systemd = getenv("INVOCATION_ID") != nullptr;
   bool protected_mode = running_under_systemd && bind.empty() && GetPassword().empty();
   const char* bind_addr = nullptr;


### PR DESCRIPTION
## Summary
- Bind to localhost (127.0.0.1) when no password and no bind address are configured
- Only enabled when running under systemd (checks `INVOCATION_ID` env var)
- Log warning message informing users about protected mode
- Apply same protection to memcached port
- Use `GetPassword()` to check both `--requirepass` flag and `DFLY_requirepass` env var

## Test plan
- [x] Without INVOCATION_ID: binds to all interfaces (0.0.0.0)
- [x] With INVOCATION_ID + no password: binds to localhost (127.0.0.1) + warning
- [x] With INVOCATION_ID + password: binds to all interfaces
- [x] With --bind specified: uses specified address

### Test results
```
Test 1: No INVOCATION_ID, no password
  -> listening on 0.0.0.0:16383 (no protected mode - container safe)

Test 2: INVOCATION_ID=test123, no password  
  -> listening on 127.0.0.1:16384 + warning (protected mode active)

Test 3: INVOCATION_ID + --requirepass
  -> listening on 0.0.0.0 (password set, no protected mode)
```

Fixes #6336