### PR TITLE
tests: Check if tx is initialized before accessing its state

### DIFF
--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -304,9 +304,11 @@ void BaseFamilyTest::ResetService() {
           }
 
           LOG(ERROR) << "Transaction for shard " << es->shard_id();
+          std::unique_lock conn_lck{mu_};
           for (auto& conn : connections_) {
             auto* context = conn.second->cmd_cntx();
-            if (context->transaction && context->transaction->IsActive(es->shard_id())) {
+            if (context->transaction && context->transaction->IsScheduled() &&
+                context->transaction->IsActive(es->shard_id())) {
               LOG(ERROR) << context->transaction->DebugId(es->shard_id());
             }
           }


### PR DESCRIPTION
A transaction may be created (non null) but not fully initialized yet. The watchdog timer in test-utils can find a tx in such a place, resulting in a crash due to the asserts in the tx member variables, specifically the inlined vector that holds shard data.

Also adds a lock while accessing connections within test utils, since another assert was seen recently when accessing that field.

FIXES https://github.com/dragonflydb/dragonfly/issues/6435