### PR TITLE
chore: create smalls lists as listpacks

### DIFF
--- a/src/core/collection_entry.h
+++ b/src/core/collection_entry.h
@@ -21,6 +21,7 @@ struct CollectionEntry {
   explicit CollectionEntry(long long longval) : value_{nullptr}, longval_{longval} {
   }
 
+  CollectionEntry(const CollectionEntry&) = default;
   CollectionEntry& operator=(const CollectionEntry&) = default;
 
   std::string ToString() const {

--- a/src/core/detail/listpack.cc
+++ b/src/core/detail/listpack.cc
@@ -75,17 +75,15 @@ vector<uint32_t> ListPack::Pos(string_view element, uint32_t rank, uint32_t coun
   return matches;
 }
 
-bool ListPack::Insert(string_view pivot, string_view elem, QList::InsertOpt insert_opt) {
+uint8_t* ListPack::Find(std::string_view elem) const {
   uint8_t* p = lpFirst(lp_);
   while (p) {
-    if (GetEntry(p) == pivot) {
-      int where = (insert_opt == QList::BEFORE) ? LP_BEFORE : LP_AFTER;
-      lp_ = lpInsertString(lp_, (unsigned char*)elem.data(), elem.size(), p, where, nullptr);
-      return true;
+    if (GetEntry(p) == elem) {
+      return p;
     }
     p = lpNext(lp_, p);
   }
-  return false;
+  return nullptr;
 }
 
 unsigned ListPack::Remove(const CollectionEntry& elem, unsigned count, QList::Where where) {
@@ -124,14 +122,6 @@ unsigned ListPack::Remove(const CollectionEntry& elem, unsigned count, QList::Wh
   }
 
   return removed;
-}
-
-bool ListPack::Replace(long index, string_view elem) {
-  uint8_t* p = lpSeek(lp_, index);
-  if (!p)
-    return false;
-  lp_ = lpReplace(lp_, &p, (unsigned char*)elem.data(), elem.size());
-  return true;
 }
 
 }  // namespace detail

--- a/src/core/detail/listpack.h
+++ b/src/core/detail/listpack.h
@@ -46,14 +46,25 @@ class ListPack {
   std::vector<uint32_t> Pos(std::string_view element, uint32_t rank, uint32_t count,
                             uint32_t max_len, QList::Where where) const;
 
+  uint8_t* Find(std::string_view elem) const;
+
+  uint8_t* Seek(long index) const {
+    return lpSeek(lp_, index);
+  }
+
   // Inserts an element before or after the specified pivot element.
-  bool Insert(std::string_view pivot, std::string_view elem, QList::InsertOpt insert_opt);
+  void Insert(uint8_t* pivot, std::string_view elem, QList::InsertOpt insert_opt) {
+    int where = (insert_opt == QList::BEFORE) ? LP_BEFORE : LP_AFTER;
+    lp_ = lpInsertString(lp_, (unsigned char*)elem.data(), elem.size(), pivot, where, nullptr);
+  }
 
   // Removes up to count occurrences of elem from the specified direction.
   unsigned Remove(const CollectionEntry& elem, unsigned count, QList::Where where);
 
   // Replaces the element at the specified index with a new value.
-  bool Replace(long index, std::string_view elem);
+  void Replace(uint8_t* pos, std::string_view elem) {
+    lp_ = lpReplace(lp_, &pos, (unsigned char*)elem.data(), elem.size());
+  }
 
   // Removes count elements starting from the specified index.
   void Erase(long start, long count) {

--- a/src/core/listpack_test.cc
+++ b/src/core/listpack_test.cc
@@ -47,13 +47,11 @@ class ListPackTest : public ::testing::Test {
   uint8_t* ptr_ = nullptr;
 };
 
-TEST_F(ListPackTest, InsertPivotNotFound) {
+TEST_F(ListPackTest, FindNotFound) {
   lp_.Push("first", QList::TAIL);
   lp_.Push("third", QList::TAIL);
 
-  // Try to insert with non-existent pivot
-  EXPECT_FALSE(lp_.Insert("notfound", "second", QList::BEFORE));
-  EXPECT_EQ(2, lp_.Size());
+  EXPECT_EQ(lp_.Find("second"), nullptr);
 }
 
 TEST_F(ListPackTest, RemoveIntegerFromHead) {
@@ -147,7 +145,9 @@ TEST_F(ListPackTest, ReplaceAtIndex) {
   lp_.Push("third", QList::TAIL);
 
   // Replace element at index 1
-  EXPECT_TRUE(lp_.Replace(1, "replaced"));
+  uint8_t* pos = lp_.Seek(1);
+  EXPECT_NE(pos, nullptr);
+  lp_.Replace(pos, "replaced");
   EXPECT_EQ(3, lp_.Size());
 
   EXPECT_EQ("first", lp_.At(0));
@@ -161,7 +161,9 @@ TEST_F(ListPackTest, ReplaceAtNegativeIndex) {
   lp_.Push("third", QList::TAIL);
 
   // Replace element at index -1 (last element)
-  EXPECT_TRUE(lp_.Replace(-1, "new_last"));
+  uint8_t* pos = lp_.Seek(-1);
+  EXPECT_NE(pos, nullptr);
+  lp_.Replace(pos, "new_last");
   EXPECT_EQ(3, lp_.Size());
 
   EXPECT_EQ("first", lp_.At(0));
@@ -174,13 +176,10 @@ TEST_F(ListPackTest, ReplaceOutOfBounds) {
   lp_.Push("second", QList::TAIL);
 
   // Replace at out-of-bounds index should return false
-  EXPECT_FALSE(lp_.Replace(5, "nope"));
-  EXPECT_FALSE(lp_.Replace(-5, "nope"));
-  EXPECT_EQ(2, lp_.Size());
-
-  // Original elements unchanged
-  EXPECT_EQ("first", lp_.At(0));
-  EXPECT_EQ("second", lp_.At(1));
+  uint8_t* pos = lp_.Seek(5);
+  EXPECT_EQ(pos, nullptr);
+  pos = lp_.Seek(-5);
+  EXPECT_EQ(pos, nullptr);
 }
 
 TEST_F(ListPackTest, ReplaceWithLargerString) {
@@ -189,7 +188,9 @@ TEST_F(ListPackTest, ReplaceWithLargerString) {
 
   // Replace with a much larger string
   string large(500, 'x');
-  EXPECT_TRUE(lp_.Replace(0, large));
+  uint8_t* pos = lp_.Seek(0);
+  EXPECT_NE(pos, nullptr);
+  lp_.Replace(pos, large);
   EXPECT_EQ(2, lp_.Size());
 
   EXPECT_EQ(large, lp_.At(0));
@@ -201,7 +202,9 @@ TEST_F(ListPackTest, ReplaceWithEmptyString) {
   lp_.Push("second", QList::TAIL);
 
   // Replace with empty string
-  EXPECT_TRUE(lp_.Replace(0, ""));
+  uint8_t* pos = lp_.Seek(0);
+  EXPECT_NE(pos, nullptr);
+  lp_.Replace(pos, "");
   EXPECT_EQ(2, lp_.Size());
 
   EXPECT_EQ("", lp_.At(0));

--- a/src/core/qlist.cc
+++ b/src/core/qlist.cc
@@ -1265,9 +1265,6 @@ bool QList::Erase(const long start, unsigned count) {
 }
 
 uint8_t* QList::TryExtractListpack() {
-  // TODO: enable this once we support listpack encoding for lists.
-  return nullptr;
-
   if (len_ != 1 || QL_NODE_IS_PLAIN(head_) || !ShouldStoreAsListPack(head_->sz) ||
       head_->IsCompressed()) {
     return nullptr;

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -178,6 +178,9 @@ void AddObjHist(PrimeIterator it, ObjHist* hist) {
     if (pv.Encoding() == kEncodingQL2) {
       const QList* ql = static_cast<QList*>(pv.RObjPtr());
       val_len = ql->MallocUsed(true);
+    } else if (pv.Encoding() == kEncodingListPack) {
+      val_len = pv.MallocUsed();
+      hist->listpack.Add(val_len);
     }
   } else if (pv.ObjType() == OBJ_ZSET) {
     IterateSortedSet(pv, [&](ContainerEntry entry, double) { return per_entry_cb(entry); });
@@ -466,7 +469,12 @@ const char* EncodingName(unsigned obj_type, unsigned encoding) {
     case OBJ_STRING:
       return "raw";
     case OBJ_LIST:
-      return "quicklist";
+      switch (encoding) {
+        case kEncodingQL2:
+          return "quicklist";
+        case kEncodingListPack:
+          return "listpack";
+      }
       break;
     case OBJ_SET:
       ABSL_FALLTHROUGH_INTENDED;

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -929,13 +929,18 @@ TEST_F(DflyEngineTest, DebugObject) {
   auto resp = Run({"debug", "object", "key"});
   EXPECT_THAT(resp.GetString(), HasSubstr("encoding:raw"));
   resp = Run({"debug", "object", "l1"});
-  EXPECT_THAT(resp.GetString(), HasSubstr("encoding:quicklist"));
+  EXPECT_THAT(resp.GetString(), HasSubstr("encoding:listpack"));
   resp = Run({"debug", "object", "s1"});
   EXPECT_THAT(resp.GetString(), HasSubstr("encoding:intset"));
   resp = Run({"debug", "object", "s2"});
   EXPECT_THAT(resp.GetString(), HasSubstr("encoding:dense_set"));
   resp = Run({"debug", "object", "z1"});
   EXPECT_THAT(resp.GetString(), HasSubstr("encoding:listpack"));
+
+  // Test promotion to quicklist
+  Run({"lpush", "l1", string(3000, 'x')});
+  resp = Run({"debug", "object", "l1"});
+  EXPECT_THAT(resp.GetString(), HasSubstr("encoding:quicklist"));
 }
 
 TEST_F(DflyEngineTest, StreamMemInfo) {


### PR DESCRIPTION
When they grow we promote them to qlists.
With `debug POPULATE 1000000 key 10 TYPE list ELEMENTS 5`,

before: 216MB, after: 140MB.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->