### PR TITLE
feat(search): Omit key defrag is vector data is used as reference

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -1013,6 +1013,11 @@ bool CompactObj::DefragIfNeeded(PageUsage* page_usage) {
   static const bool disable_json_defragmentation =
       absl::GetFlag(FLAGS_disable_json_defragmentation);
 
+  if (OmitDefrag()) {
+    page_usage->RecordNotRequired();
+    return false;
+  }
+
   switch (taglen_) {
     case ROBJ_TAG:
       // currently only these object types are supported for this operation

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -233,6 +233,14 @@ class CompactObj {
 
   bool DefragIfNeeded(PageUsage* page_usage);
 
+  void SetOmitDefrag(bool v) {
+    mask_bits_.omit_defrag = v;
+  }
+
+  bool OmitDefrag() const {
+    return mask_bits_.omit_defrag;
+  }
+
   bool HasStashPending() const {
     return mask_bits_.io_pending;
   }
@@ -505,6 +513,8 @@ class CompactObj {
       // reached this item while travering the database to set items as cold.
       // https://junchengyang.com/publication/nsdi24-SIEVE.pdf
       uint8_t touched : 1;  // used to mark keys that were accessed.
+
+      uint8_t omit_defrag : 1;  // mark object to skip defragmentation.
     } mask_bits_;
   };
 

--- a/src/core/search/hnsw_index.cc
+++ b/src/core/search/hnsw_index.cc
@@ -216,7 +216,8 @@ struct HnswlibAdapter {
 
 HnswVectorIndex::HnswVectorIndex(const SchemaField::VectorParams& params, bool copy_vector,
                                  PMR_NS::memory_resource*)
-    : dim_{params.dim},
+    : copy_vector_(copy_vector),
+      dim_{params.dim},
       sim_{params.sim},
       adapter_{make_unique<HnswlibAdapter>(params, copy_vector)} {
   DCHECK(params.use_hnsw);

--- a/src/core/search/hnsw_index.h
+++ b/src/core/search/hnsw_index.h
@@ -52,6 +52,10 @@ class HnswVectorIndex {
   bool Add(search::GlobalDocId id, const search::DocumentAccessor& doc, std::string_view field);
   void Remove(search::GlobalDocId id, const search::DocumentAccessor& doc, std::string_view field);
 
+  bool IsVectorCopied() const {
+    return copy_vector_;
+  }
+
   std::vector<std::pair<float, GlobalDocId>> Knn(float* target, size_t k,
                                                  std::optional<size_t> ef) const;
   std::vector<std::pair<float, GlobalDocId>> Knn(float* target, size_t k, std::optional<size_t> ef,
@@ -68,6 +72,7 @@ class HnswVectorIndex {
   std::vector<HnswNodeData> GetNodesRange(size_t start, size_t end) const;
 
  private:
+  bool copy_vector_;
   size_t dim_;
   VectorSimilarity sim_;
   std::unique_ptr<HnswlibAdapter> adapter_;

--- a/src/server/family_utils.h
+++ b/src/server/family_utils.h
@@ -82,7 +82,7 @@ streamConsumer* StreamCreateConsumer(streamCG* cg, std::string_view name, uint64
 
 /* Use these methods to add or remove documents from the indexes for generic commands when the key
  * being modified could potentially be of type HSET or JSON. */
-void AddKeyToIndexesIfNeeded(std::string_view key, const DbContext& db_cntx, const PrimeValue& pv,
+void AddKeyToIndexesIfNeeded(std::string_view key, const DbContext& db_cntx, PrimeValue& pv,
                              EngineShard* shard);
 void RemoveKeyFromIndexesIfNeeded(std::string_view key, const DbContext& db_cntx,
                                   const PrimeValue& pv, EngineShard* shard);
@@ -113,10 +113,10 @@ inline std::vector<long> ExpireElements(DenseSet* owner, facade::CmdArgList valu
   return res;
 }
 
-inline void AddKeyToIndexesIfNeeded(std::string_view key, const DbContext& db_cntx,
-                                    const PrimeValue& pv, EngineShard* shard) {
+inline void AddKeyToIndexesIfNeeded(std::string_view key, const DbContext& db_cntx, PrimeValue& pv,
+                                    EngineShard* shard) {
   if (IsIndexedKeyType(pv)) {
-    shard->search_indices()->AddDoc(key, db_cntx, pv);
+    shard->search_indices()->AddDoc(key, db_cntx, &pv);
   }
 }
 

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -240,7 +240,7 @@ template <typename F> auto WrapW(F&& f) {
     if (hw.Length() == 0)
       DeleteHw(hw, op_args, key);
     else
-      op_args.shard->search_indices()->AddDoc(key, op_args.db_cntx, pv);
+      op_args.shard->search_indices()->AddDoc(key, op_args.db_cntx, &pv);
 
     return res;
   };
@@ -339,7 +339,7 @@ OpStatus OpIncrBy(const OpArgs& op_args, string_view key, string_view field, Inc
   }
 
   hw.Launder(pv);
-  op_args.shard->search_indices()->AddDoc(key, op_args.db_cntx, pv);
+  op_args.shard->search_indices()->AddDoc(key, op_args.db_cntx, &pv);
 
   return OpStatus::OK;
 }
@@ -495,7 +495,7 @@ OpResult<uint32_t> OpSet(const OpArgs& op_args, string_view key, CmdArgList valu
     }
   }
 
-  op_args.shard->search_indices()->AddDoc(key, op_args.db_cntx, pv);
+  op_args.shard->search_indices()->AddDoc(key, op_args.db_cntx, &pv);
 
   if (auto* ts = op_args.shard->tiered_storage(); ts) {
     StashPrimeValue(op_args.db_cntx.db_index, key, false, &pv, ts);
@@ -1151,7 +1151,7 @@ vector<long> HSetFamily::SetFieldsExpireTime(const OpArgs& op_args, uint32_t ttl
   // This needs to be explicitly fetched again since the pv might have changed.
   StringMap* sm = container_utils::GetStringMap(*pv, op_args.db_cntx);
   vector<long> res = UpdateTTL(values, ttl_sec, flags, sm);
-  op_args.shard->search_indices()->AddDoc(key, op_args.db_cntx, *pv);
+  op_args.shard->search_indices()->AddDoc(key, op_args.db_cntx, pv);
   return res;
 }
 

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -99,7 +99,7 @@ class JsonAutoUpdater {
   }
 
   void AddDocToIndexes() {
-    op_args_.shard->search_indices()->AddDoc(key_, op_args_.db_cntx, GetPrimeValue());
+    op_args_.shard->search_indices()->AddDoc(key_, op_args_.db_cntx, &GetPrimeValue());
   }
 
   ~JsonAutoUpdater() {
@@ -510,7 +510,7 @@ OpStatus SetFullJson(const OpArgs& op_args, string_view key, string_view json_st
       VLOG(1) << "got invalid JSON string '" << json_str << "' cannot be saved";
       if (type == OBJ_JSON) {
         // We need to add the document to the indexes, because we removed it before
-        op_args.shard->search_indices()->AddDoc(key, op_args.db_cntx, updater.GetPrimeValue());
+        op_args.shard->search_indices()->AddDoc(key, op_args.db_cntx, &updater.GetPrimeValue());
       }
       return OpStatus::INVALID_JSON;
     }
@@ -533,7 +533,7 @@ OpStatus SetFullJson(const OpArgs& op_args, string_view key, string_view json_st
   updater.SetJsonSize();
 
   // We need to manually run add document here
-  op_args.shard->search_indices()->AddDoc(key, op_args.db_cntx, updater.GetPrimeValue());
+  op_args.shard->search_indices()->AddDoc(key, op_args.db_cntx, &updater.GetPrimeValue());
 
   return OpStatus::OK;
 }

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -36,14 +36,13 @@ void TraverseAllMatching(const DocIndex& index, const OpArgs& op_args, F&& f) {
 
   string scratch;
   auto cb = [&](PrimeTable::iterator it) {
-    const PrimeValue& pv = it->second;
+    PrimeValue& pv = it->second;
     string_view key = it->first.GetSlice(&scratch);
 
     if (!index.Matches(key, pv.ObjType()))
       return;
 
-    auto accessor = GetAccessor(op_args.db_cntx, pv);
-    f(key, *accessor);
+    f(key, op_args.db_cntx, pv);
   };
 
   PrimeTable::Cursor cursor;
@@ -275,9 +274,10 @@ void ShardDocIndex::Rebuild(const OpArgs& op_args, PMR_NS::memory_resource* mr) 
   key_index_ = DocKeyIndex{};
   indices_.emplace(base_->schema, base_->options, mr, &synonyms_);
 
-  auto cb = [this](string_view key, const BaseAccessor& doc) {
+  auto cb = [this](string_view key, const DbContext& db_cntx, PrimeValue& pv) {
+    auto doc = GetAccessor(db_cntx, pv);
     DocId id = key_index_.Add(key);
-    if (!indices_->Add(id, doc)) {
+    if (!indices_->Add(id, *doc)) {
       key_index_.Remove(id);
     }
   };
@@ -376,8 +376,8 @@ void ShardDocIndex::RemoveDoc(DocId id, const DbContext& db_cntx, const PrimeVal
 
 void ShardDocIndex::AddDocToGlobalVectorIndex(std::string_view index_name,
                                               ShardDocIndex::DocId doc_id, const DbContext& db_cntx,
-                                              const PrimeValue& pv) {
-  auto accessor = GetAccessor(db_cntx, pv);
+                                              PrimeValue* pv) {
+  auto accessor = GetAccessor(db_cntx, *pv);
 
   GlobalDocId global_id = search::CreateGlobalDocId(EngineShard::tlocal()->shard_id(), doc_id);
 
@@ -386,7 +386,10 @@ void ShardDocIndex::AddDocToGlobalVectorIndex(std::string_view index_name,
         !(field_info.flags & search::SchemaField::NOINDEX)) {
       if (auto index = GlobalHnswIndexRegistry::Instance().Get(index_name, field_info.short_name);
           index) {
-        index->Add(global_id, *accessor, field_ident);
+        bool added = index->Add(global_id, *accessor, field_ident);
+        if (added && !index->IsVectorCopied()) {
+          pv->SetOmitDefrag(true);
+        }
       }
     }
   }
@@ -410,11 +413,13 @@ void ShardDocIndex::RemoveDocFromGlobalVectorIndex(std::string_view index_name,
 }
 
 void ShardDocIndex::RebuildGlobalVectorIndices(std::string_view index_name, const OpArgs& op_args) {
-  auto cb = [this, index_name](string_view key, const BaseAccessor& doc) {
+  auto cb = [this, index_name](string_view key, const DbContext& db_cntx, PrimeValue& pv) {
     auto local_id = key_index_.Find(key);
 
     if (!local_id)
       return;
+
+    auto doc = GetAccessor(db_cntx, pv);
 
     GlobalDocId global_id = search::CreateGlobalDocId(EngineShard::tlocal()->shard_id(), *local_id);
 
@@ -423,7 +428,10 @@ void ShardDocIndex::RebuildGlobalVectorIndices(std::string_view index_name, cons
           !(field_info.flags & search::SchemaField::NOINDEX)) {
         if (auto index = GlobalHnswIndexRegistry::Instance().Get(index_name, field_info.short_name);
             index) {
-          index->Add(global_id, doc, field_ident);
+          bool added = index->Add(global_id, *doc, field_ident);
+          if (added && !index->IsVectorCopied()) {
+            pv.SetOmitDefrag(true);
+          }
         }
       }
     }
@@ -806,11 +814,11 @@ vector<string> ShardDocIndices::GetIndexNames() const {
   return names;
 }
 
-void ShardDocIndices::AddDoc(string_view key, const DbContext& db_cntx, const PrimeValue& pv) {
-  DCHECK(IsIndexedKeyType(pv));
+void ShardDocIndices::AddDoc(string_view key, const DbContext& db_cntx, PrimeValue* pv) {
+  DCHECK(IsIndexedKeyType(*pv));
   for (auto& [index_name, index] : indices_) {
-    if (index->Matches(key, pv.ObjType())) {
-      std::optional<search::DocId> doc_id = index->AddDoc(key, db_cntx, pv);
+    if (index->Matches(key, pv->ObjType())) {
+      std::optional<search::DocId> doc_id = index->AddDoc(key, db_cntx, *pv);
       if (doc_id) {
         index->AddDocToGlobalVectorIndex(index_name, *doc_id, db_cntx, pv);
       }

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -301,7 +301,7 @@ class ShardDocIndex {
   }
 
   void AddDocToGlobalVectorIndex(std::string_view index_name, ShardDocIndex::DocId doc_id,
-                                 const DbContext& db_cntx, const PrimeValue& pv);
+                                 const DbContext& db_cntx, PrimeValue* pv);
   void RemoveDocFromGlobalVectorIndex(std::string_view index_name, ShardDocIndex::DocId doc_id,
                                       const DbContext& db_cntx, const PrimeValue& pv);
   void RebuildGlobalVectorIndices(std::string_view index_name, const OpArgs& op_args);
@@ -363,7 +363,7 @@ class ShardDocIndices {
   std::vector<std::string> GetIndexNames() const;
 
   /* Use AddDoc and RemoveDoc only if pv object type is json or hset */
-  void AddDoc(std::string_view key, const DbContext& db_cnt, const PrimeValue& pv);
+  void AddDoc(std::string_view key, const DbContext& db_cnt, PrimeValue* pv);
   void RemoveDoc(std::string_view key, const DbContext& db_cnt, const PrimeValue& pv);
 
   size_t GetUsedMemory() const;

--- a/src/server/search/doc_index_fallback.cc
+++ b/src/server/search/doc_index_fallback.cc
@@ -14,7 +14,7 @@ using namespace std;
 ShardDocIndices::ShardDocIndices() : local_mr_(nullptr) {
 }
 
-void ShardDocIndices::AddDoc(std::string_view key, const DbContext& db_cnt, const PrimeValue& pv) {
+void ShardDocIndices::AddDoc(std::string_view key, const DbContext& db_cnt, PrimeValue* pv) {
 }
 void ShardDocIndices::RemoveDoc(std::string_view key, const DbContext& db_cnt,
                                 const PrimeValue& pv) {


### PR DESCRIPTION
If we don't copy vector data and use it as reference in vector index we should skip defragmentation of key. Change functions definitions so that PrimeValue object can be modified when needed.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->