### PR TITLE
fix(server): ignore SIGHUP to prevent termination on session closing

### DIFF
--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -906,6 +906,9 @@ Usage: dragonfly [FLAGS]
   sigemptyset(&act.sa_mask);
   sigaction(SIGILL, &act, nullptr);
 
+  // Ignore SIGHUP to prevent termination when the parent shell exits
+  signal(SIGHUP, SIG_IGN);
+
   if (GetFlag(FLAGS_port) == 0u) {
     string usock = GetFlag(FLAGS_unixsocket);
     if (usock.length() == 0u) {


### PR DESCRIPTION

## Description
This PR changes the [dragonfly](cci:1://file:///Users/boomballa/Desktop/Dev/AwesomeProject/df2redis/scripts/reproduce_dragonfly_crash.sh:86:0-108:1) server behavior to explicitly ignore `SIGHUP` signals.
Previously, [dragonfly](cci:1://file:///Users/boomballa/Desktop/Dev/AwesomeProject/df2redis/scripts/reproduce_dragonfly_crash.sh:86:0-108:1) did not handle `SIGHUP`, causing the process to terminate immediately if the parent shell session ended (e.g., SSH session timeout on a jump host, or simply closing the terminal while the process is running in the background without `nohup`).
This behavior led to abrupt terminations which triggered the deadlock described in #6431 (Deadlock in JournalStreamer::Cancel upon Abrupt Disconnection).
## Changes
- Added `signal(SIGHUP, SIG_IGN);` in [src/server/dfly_main.cc](cci:7://file:///Users/boomballa/Desktop/Dev/AwesomeProject/df2redis/dragonfly/src/server/dfly_main.cc:0:0-0:0) to ignore the hangup signal.
  - This brings the behavior in line with standard daemon practices, ensuring the server survives parent session termination.
## Verification
**Manual Test:**
1. Built the binary with the fix.
2. Launched dragonfly in background: `./dragonfly-x86_64 ... &`.
3. Sent SIGHUP signal: `kill -HUP <pid>`.
4. Verified that the process **did not terminate** and continued serving requests.
Before this fix, the same `kill -HUP` command caused the process to exit immediately.
## Related Issues
Fixes the root cause of the crash reported in #6431.