### PR TITLE
chore(tiering): polish type system for better clarity and safety

### DIFF
--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -198,7 +198,8 @@ OpResult<T> ExecuteRO(Transaction* tx, F&& f) {
         fut.Resolve(f(hw));
       };
 
-      es->tiered_storage()->Read(op_args.db_cntx.db_index, key, pv, D{}, std::move(read_cb));
+      es->tiered_storage()->Read(op_args.db_cntx.db_index, key, pv.GetExternalSlice(), D{},
+                                 std::move(read_cb));
       return CbVariant<T>{std::move(fut)};
     }
 

--- a/src/server/tiering/common.h
+++ b/src/server/tiering/common.h
@@ -7,8 +7,6 @@
 #include <memory>
 #include <optional>
 
-#include "util/fibers/synchronization.h"
-
 namespace dfly::tiering {
 
 inline namespace literals {
@@ -27,10 +25,6 @@ constexpr size_t kPageSize = 4_KB;
 
 // Location on the offloaded blob, measured in bytes
 struct DiskSegment {
-  DiskSegment ContainingPages() const {
-    return {offset / kPageSize * kPageSize, (length + kPageSize - 1) / kPageSize * kPageSize};
-  }
-
   DiskSegment() = default;
   DiskSegment(size_t offset, size_t length) : offset{offset}, length{length} {
   }
@@ -39,6 +33,10 @@ struct DiskSegment {
 
   bool operator==(const DiskSegment& other) const {
     return offset == other.offset && length == other.length;
+  }
+
+  DiskSegment ContainingPages() const {
+    return {offset / kPageSize * kPageSize, (length + kPageSize - 1) / kPageSize * kPageSize};
   }
 
   size_t offset = 0, length = 0;

--- a/src/server/tiering/decoders.cc
+++ b/src/server/tiering/decoders.cc
@@ -60,10 +60,6 @@ Decoder::UploadMetrics StringDecoder::GetMetrics() const {
   };
 }
 
-std::string_view StringDecoder::Read() const {
-  return value_.view();
-}
-
 std::string* StringDecoder::Write() {
   modified_ = true;
   return value_.GetMutable();

--- a/src/server/tiering/decoders.h
+++ b/src/server/tiering/decoders.h
@@ -57,7 +57,10 @@ struct StringDecoder : public Decoder {
   UploadMetrics GetMetrics() const override;
   void Upload(CompactObj* obj) override;
 
-  std::string_view Read() const;
+  std::string_view GetView() const {
+    return value_.view();
+  }
+
   std::string* Write();
 
  private:

--- a/src/server/tiering/entry_map.h
+++ b/src/server/tiering/entry_map.h
@@ -31,9 +31,9 @@ struct Eq {
 };
 }  // namespace detail
 
+using DbKeyId = std::pair<DbIndex, std::string>;
+
 // Map of key (db index, string key) -> T with heterogeneous lookup
-template <typename T>
-using EntryMap =
-    absl::flat_hash_map<std::pair<DbIndex, std::string>, T, detail::Hasher, detail::Eq>;
+template <typename T> using EntryMap = absl::flat_hash_map<DbKeyId, T, detail::Hasher, detail::Eq>;
 
 }  // namespace dfly::tiering


### PR DESCRIPTION
1. Rename EntryId to PendingId and move OwnedEntryId to private scope.
2. Pass DiskSegment directly to the most generic Read method, removing PrimeValue dependency.
3. Update NotifyStashed/NotifyFetched signatures to use const OwnedEntryId& as EntryId did not save any allocations.
4. The only functional change: changing the signature of one of the Read functions to pass string_view instead of string  which saves a copy and allocation.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->