### PR TITLE
fix(facade): add explicit socket close to await pending IO

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1102,6 +1102,13 @@ void Connection::ConnectionFlow() {
                             << " during phase " << kPhaseName[phase_] << " : " << ec << " "
                             << ec.message();
   }
+
+  // Explicitly close the socket as the final step.
+  // For TLS sockets, this forces TlsSocket to WaitForPendingIO() (handling detached
+  // TrySend/TryRecv calls) before the socket is destroyed.
+  if (is_tls_) {
+    socket_->Close();
+  }
 }
 
 void Connection::DispatchSingle(bool has_more, absl::FunctionRef<void()> invoke_cb,


### PR DESCRIPTION
Added an explicit socket_->Close() call at the end of connection handling.
This ensures that for TLS sockets, any pending asynchronous read or write operations are properly awaited via WaitForPendingIO before destruction.
Addresses crashes seen in regression tests due to incomplete IO cleanup.
