### PR TITLE
chore(tiering): refactor Read/Modify to free functions

### DIFF
--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -430,7 +430,8 @@ void SliceSnapshot::SerializeExternal(DbIndex db_index, PrimeKey key, const Prim
                                       time_t expire_time, uint32_t mc_flags) {
   // We prefer avoid blocking, so we just schedule a tiered read and append
   // it to the delayed entries.
-  auto future = EngineShard::tlocal()->tiered_storage()->Read(db_index, key.ToString(), pv);
+  auto future =
+      ReadTieredString(db_index, key.ToString(), pv, EngineShard::tlocal()->tiered_storage());
   delayed_entries_.push_back({db_index, std::move(key), std::move(future), expire_time, mc_flags});
   ++type_freq_map_[RDB_TYPE_STRING];
 }


### PR DESCRIPTION
Move TieredStorage::Read/Modify methods to standalone ReadTiered/ModifyTiered functions that take explicit TieredStorage* parameter for cleaner API design.

Add additional ReadTiered and ReadTieredString overloads that simplify tiered reads in several places across the codebase.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->