### PR TITLE
chore(tiering): refactor stashing to determine serialization upfront

### DIFF
--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -497,8 +497,9 @@ OpResult<uint32_t> OpSet(const OpArgs& op_args, string_view key, CmdArgList valu
 
   op_args.shard->search_indices()->AddDoc(key, op_args.db_cntx, pv);
 
-  if (auto* ts = op_args.shard->tiered_storage(); ts)
-    ts->TryStash(op_args.db_cntx.db_index, key, &pv);
+  if (auto* ts = op_args.shard->tiered_storage(); ts) {
+    StashPrimeValue(op_args.db_cntx.db_index, key, false, &pv, ts);
+  }
 
   return created;
 }

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2690,7 +2690,7 @@ void RdbLoader::CreateObjectOnShard(const DbContext& db_cntx, const Item* item, 
   }
 
   if (auto* ts = db_slice->shard_owner()->tiered_storage(); ts) {
-    ts->TryStash(db_cntx.db_index, item->key, &res.it->second);
+    StashPrimeValue(db_cntx.db_index, item->key, false, &res.it->second, ts);
 
     // Block, if tiered storage is active, but can't keep up
     while (db_slice->shard_owner()->ShouldThrottleForTiering())

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -936,9 +936,9 @@ void SetCmd::PostEdit(const SetParams& params, std::string_view key, std::string
   EngineShard* shard = op_args_.shard;
 
   // Currently we always try to offload, but Stash may ignore it, if disk I/O is overloaded.
-  // If we are beyond the offloading threshold, TryStash might return a backpressure future.
+  // If we are beyond the offloading threshold, StashPrimeValue might return a backpressure future.
   if (auto* ts = shard->tiered_storage(); ts) {
-    auto bp = ts->TryStash(op_args_.db_cntx.db_index, key, pv, true);
+    auto bp = StashPrimeValue(op_args_.db_cntx.db_index, key, true, pv, ts);
     if (bp && params.backpressure)
       *params.backpressure = std::move(*bp);
   }

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -15,6 +15,7 @@
 #include "absl/cleanup/cleanup.h"
 #include "absl/flags/internal/flag.h"
 #include "absl/functional/bind_front.h"
+#include "absl/functional/overload.h"
 #include "base/flag_utils.h"
 #include "base/flags.h"
 #include "base/logging.h"
@@ -85,19 +86,17 @@ tiering::DiskSegment FromCoolItem(const PrimeValue::CoolItem& item) {
 // Determine required byte size and encoding type based on value.
 // Do NOT enforce rules depending on dynamic runtime values as this is called
 // when scheduling stash and just before succeeeding and is expected to return the same results
-pair<size_t /*size*/, CompactObj::ExternalRep> DetermineSerializationParams(const PrimeValue& pv) {
+TieredStorage::StashDescriptor DetermineSerializationParams(const PrimeValue& pv) {
   switch (pv.ObjType()) {
     case OBJ_STRING: {
       if (pv.IsInline())
         return {};
       auto strs = pv.GetRawString();
-      return std::make_pair(strs[0].size() + strs[1].size(), CompactObj::ExternalRep::STRING);
+      return {strs, CompactObj::ExternalRep::STRING};
     }
     case OBJ_HASH: {
       if (pv.Encoding() == kEncodingListPack) {
-        detail::ListpackWrap lw{static_cast<uint8_t*>(pv.RObjPtr())};
-        return std::make_pair(tiering::SerializedMap::EstimateSize(lw.UsedBytes(), lw.size()),
-                              CompactObj::ExternalRep::SERIALIZED_MAP);
+        return {static_cast<uint8_t*>(pv.RObjPtr()), CompactObj::ExternalRep::SERIALIZED_MAP};
       }
       return {};
     }
@@ -106,36 +105,45 @@ pair<size_t /*size*/, CompactObj::ExternalRep> DetermineSerializationParams(cons
   };
 }
 
-size_t Serialize(CompactObj::ExternalRep rep, const PrimeValue& pv, io::MutableBytes buffer) {
-  DCHECK_LE(DetermineSerializationParams(pv).first, buffer.size());
+string SerializeToString(const TieredStorage::StashDescriptor& blobs) {
+  size_t est_size = blobs.EstimatedSerializedSize();
+  string s(est_size, 0);
+  size_t written = blobs.Serialize({reinterpret_cast<uint8_t*>(s.data()), s.size()});
+  s.resize(written);
+  return s;
+}
+
+}  // anonymous namespace
+
+size_t TieredStorage::StashDescriptor::EstimatedSerializedSize() const {
+  return visit(
+      absl::Overload{[](const array<string_view, 2>& a) { return a[0].size() + a[1].size(); },
+                     [](uint8_t* ptr) {
+                       detail::ListpackWrap lw{ptr};
+                       return tiering::SerializedMap::EstimateSize(lw.UsedBytes(), lw.size());
+                     }},
+      blob);
+};
+
+size_t TieredStorage::StashDescriptor::Serialize(io::MutableBytes buffer) const {
+  DCHECK_LE(EstimatedSerializedSize(), buffer.size());
+
   switch (rep) {
     case CompactObj::ExternalRep::STRING: {
-      auto strs = pv.GetRawString();
+      auto strs = std::get<std::array<std::string_view, 2>>(blob);
       memcpy(buffer.data(), strs[0].data(), strs[0].size());
       if (!strs[1].empty())
         memcpy(buffer.data() + strs[0].size(), strs[1].data(), strs[1].size());
       return strs[0].size() + strs[1].size();
     }
     case CompactObj::ExternalRep::SERIALIZED_MAP: {
-      DCHECK_EQ(pv.Encoding(), kEncodingListPack);
-      detail::ListpackWrap lw{static_cast<uint8_t*>(pv.RObjPtr())};
+      detail::ListpackWrap lw{static_cast<uint8_t*>(std::get<uint8_t*>(blob))};
       return tiering::SerializedMap::Serialize(
           lw, {reinterpret_cast<char*>(buffer.data()), buffer.length()});
     }
   };
   return 0;
 }
-
-// TODO: Remove with proper no-copy serialization
-string SerializeToString(const PrimeValue& pv) {
-  auto [size, type] = DetermineSerializationParams(pv);
-  string s(size, 0);
-  size_t written = Serialize(type, pv, {reinterpret_cast<uint8_t*>(s.data()), s.size()});
-  s.resize(written);
-  return s;
-}
-
-}  // anonymous namespace
 
 class TieredStorage::ShardOpManager : public tiering::OpManager {
   friend class TieredStorage;
@@ -226,13 +234,13 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
       stats->tiered_used_bytes += segment.length;
       stats_.total_stashes++;
 
-      CompactObj::ExternalRep rep = DetermineSerializationParams(*pv).second;
+      StashDescriptor blobs = DetermineSerializationParams(*pv);
       if (ts_->config_.experimental_cooling) {
         RetireColdEntries(pv->MallocUsed());
-        ts_->CoolDown(key.first, key.second, segment, rep, pv);
+        ts_->CoolDown(key.first, key.second, segment, blobs.rep, pv);
       } else {
         stats->AddTypeMemoryUsage(pv->ObjType(), -pv->MallocUsed());
-        pv->SetExternal(segment.offset, segment.length, rep);
+        pv->SetExternal(segment.offset, segment.length, blobs.rep);
       }
     } else {
       LOG(DFATAL) << "Should not reach here";
@@ -448,32 +456,24 @@ template TieredStorage::TResult<size_t> TieredStorage::Modify(
     DbIndex dbid, std::string_view key, const PrimeValue& value,
     std::function<size_t(std::string*)> modf);
 
-std::optional<util::fb2::Future<bool>> TieredStorage::TryStash(DbIndex dbid, string_view key,
-                                                               PrimeValue* value, bool provide_bp) {
-  if (!ShouldStash(*value))
-    return {};
-
+std::optional<util::fb2::Future<bool>> TieredStorage::Stash(DbIndex dbid, string_view key,
+                                                            const StashDescriptor& blobs,
+                                                            bool provide_bp) {
   CHECK(!bins_->IsPending(dbid, key));  // Because has stash pending is false (ShouldStash checks)
 
-  // Limit write depth. TODO: Provide backpressure?
-  if (op_manager_->GetStats().pending_stash_cnt >= config_.write_depth_limit) {
-    ++stats_.stash_overflow_cnt;
-    return {};
-  }
-
-  auto [est_size, rep] = DetermineSerializationParams(*value);
+  size_t est_size = blobs.EstimatedSerializedSize();
   DCHECK_GT(est_size, 0u);
 
   tiering::OpManager::PendingId id;
   error_code ec;
 
-  value->SetStashPending(true);  // Optimistically set ahead, unset in case of error
+  // value->SetStashPending(true);  // Optimistically set ahead, unset in case of error
 
   if (OccupiesWholePages(est_size)) {  // large enough for own page
     id = KeyRef(dbid, key);
-    auto serialize = absl::bind_front(Serialize, rep, cref(*value));
+    auto serialize = absl::bind_front(&StashDescriptor::Serialize, &blobs);
     ec = op_manager_->PrepareAndStash(id, est_size, serialize);
-  } else if (auto bin = bins_->Stash(dbid, key, SerializeToString(*value)); bin) {
+  } else if (auto bin = bins_->Stash(dbid, key, SerializeToString(blobs)); bin) {
     id = bin->id;
     auto serialize = absl::bind_front(&tiering::SmallBins::SerializeBin, bins_.get(), &*bin);
     ec = op_manager_->PrepareAndStash(id, 4_KB, serialize);
@@ -522,7 +522,8 @@ void TieredStorage::CancelStash(DbIndex dbid, std::string_view key, PrimeValue* 
     std::move(node.mapped()).Resolve(false);
 
   // TODO: Don't recompute size estimate, try-delete bin first
-  size_t size = DetermineSerializationParams(*value).first;
+  auto blobs = DetermineSerializationParams(*value);
+  size_t size = blobs.EstimatedSerializedSize();
   if (OccupiesWholePages(size)) {
     op_manager_->CancelPending(KeyRef(dbid, key));
   } else if (auto bin = bins_->Delete(dbid, key); bin) {
@@ -621,12 +622,14 @@ void TieredStorage::RunOffloading(DbIndex dbid) {
   string tmp;
   auto cb = [this, dbid, &tmp](PrimeIterator it) mutable {
     stats_.offloading_steps++;
-    if (ShouldStash(it->second)) {
+    auto blobs = ShouldStash(it->second);
+    if (blobs) {
       if (it->second.WasTouched()) {
         it->second.SetTouched(false);
       } else {
         stats_.offloading_stashes++;
-        TryStash(dbid, it->first.GetSlice(&tmp), &it->second);
+        it->second.SetStashPending(true);
+        Stash(dbid, it->first.GetSlice(&tmp), *blobs, false);
       }
     }
   };
@@ -680,22 +683,32 @@ size_t TieredStorage::ReclaimMemory(size_t goal) {
   return gained;
 }
 
-bool TieredStorage::ShouldStash(const PrimeValue& pv) const {
+auto TieredStorage::ShouldStash(const PrimeValue& pv) const -> std::optional<StashDescriptor> {
   // Check value state
   if (pv.IsExternal() || pv.HasStashPending())
-    return false;
+    return nullopt;
 
   // For now, hash offloading is conditional
   if (pv.ObjType() == OBJ_HASH && !config_.experimental_hash_offload)
-    return false;
+    return nullopt;
 
   // Estimate value size
-  auto [size, rep] = DetermineSerializationParams(pv);
-  if (size < config_.min_value_size)
-    return false;
+  StashDescriptor blobs = DetermineSerializationParams(pv);
+  size_t estimated_size = blobs.EstimatedSerializedSize();
+  if (estimated_size < config_.min_value_size)
+    return nullopt;
+
+  // Limit write depth. TODO: Provide backpressure?
+  if (op_manager_->GetStats().pending_stash_cnt >= config_.write_depth_limit) {
+    ++stats_.stash_overflow_cnt;
+    return {};
+  }
 
   const auto& disk_stats = op_manager_->GetStats().disk_stats;
-  return disk_stats.allocated_bytes + tiering::kPageSize + size < disk_stats.max_file_size;
+  if (disk_stats.allocated_bytes + tiering::kPageSize + estimated_size < disk_stats.max_file_size) {
+    return blobs;
+  }
+  return nullopt;
 }
 
 void TieredStorage::CoolDown(DbIndex db_ind, std::string_view str,
@@ -740,6 +753,16 @@ detail::TieredColdRecord* TieredStorage::PopCool() {
   cool_queue_.pop_back();
   stats_.cool_memory_used -= (sizeof(detail::TieredColdRecord) + res.value.MallocUsed());
   return &res;
+}
+
+std::optional<util::fb2::Future<bool>> StashPrimeValue(DbIndex dbid, std::string_view key,
+                                                       bool provide_bp, PrimeValue* pv,
+                                                       TieredStorage* ts) {
+  if (auto blobs = ts->ShouldStash(*pv); blobs) {
+    pv->SetStashPending(true);
+    return ts->Stash(dbid, key, *blobs, provide_bp);
+  }
+  return std::nullopt;
 }
 
 }  // namespace dfly


### PR DESCRIPTION
Goal - another change that breaks down dependency on PrimeValue.

This time - change the stash flow:

1. Changes ShouldStash to return optional `StashDescriptor` instead of bool, allowing serialization parameters to be determined once and reused.
2. Renames TryStash to Stash with explicit `SerializationBlobs` parameter.
3. Adds helper StashPrimeValue function to simplify call sites across hset_family, string_family, and rdb_load.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->