### PR TITLE
chore: sync rax and stream code with Valkey

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -143,14 +143,14 @@ size_t streamRadixTreeMemoryUsage(rax* rax) {
 
 size_t MallocUsedStream(stream* s) {
   size_t asize = sizeof(*s);
-  asize += streamRadixTreeMemoryUsage(s->rax_tree);
+  asize += streamRadixTreeMemoryUsage(s->rax);
 
   /* Now we have to add the listpacks. The last listpack is often non
    * complete, so we estimate the size of the first N listpacks, and
    * use the average to compute the size of the first N-1 listpacks, and
    * finally add the real size of the last node. */
   raxIterator ri;
-  raxStart(&ri, s->rax_tree);
+  raxStart(&ri, s->rax);
   raxSeek(&ri, "^", NULL, 0);
   size_t lpsize = 0, samples = 0;
   while (raxNext(&ri)) {
@@ -159,12 +159,12 @@ size_t MallocUsedStream(stream* s) {
     lpsize += zmalloc_size(lp);
     samples++;
   }
-  if (s->rax_tree->numele <= samples) {
+  if (s->rax->numele <= samples) {
     asize += lpsize;
   } else {
     if (samples)
       lpsize /= samples; /* Compute the average. */
-    asize += lpsize * (s->rax_tree->numele - 1);
+    asize += lpsize * (s->rax->numele - 1);
     /* No need to check if seek succeeded, we enter this branch only
      * if there are a few elements in the radix tree. */
     raxSeek(&ri, "$", NULL, 0);

--- a/src/core/search/rax_tree.h
+++ b/src/core/search/rax_tree.h
@@ -180,7 +180,7 @@ template <typename V> struct RaxTreeMap {
   }
 
   FindIterator find(std::string_view key) const {
-    if (void* ptr = raxFind(tree_, to_key_ptr(key), key.size()); ptr != raxNotFound)
+    if (void* ptr = nullptr; raxFind(tree_, to_key_ptr(key), key.size(), &ptr))
       return FindIterator{std::pair<std::string, V&>(std::string(key), *reinterpret_cast<V*>(ptr))};
 
     return FindIterator{std::nullopt};

--- a/src/redis/rax.c
+++ b/src/redis/rax.c
@@ -2,7 +2,7 @@
  *
  * Version 1.2 -- 7 February 2019
  *
- * Copyright (c) 2017-2019, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2017-2019, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -45,11 +45,6 @@
 
 #include RAX_MALLOC_INCLUDE
 
-/* This is a special pointer that is guaranteed to never have the same value
- * of a radix tree node. It's used in order to report "not found" error without
- * requiring the function to have multiple return values. */
-void *raxNotFound = (void*)"rax-not-found-pointer";
-
 /* -------------------------------- Debugging ------------------------------ */
 
 void raxDebugShowNode(const char *msg, raxNode *n);
@@ -60,17 +55,17 @@ void raxDebugShowNode(const char *msg, raxNode *n);
  * debugging on/off in order to enable it only when you suspect there is an
  * operation causing a bug using the function raxSetDebugMsg(). */
 #ifdef RAX_DEBUG_MSG
-#define debugf(...)                                                            \
-    if (raxDebugMsg) {                                                         \
-        printf("%s:%s:%d:\t", __FILE__, __func__, __LINE__);                   \
-        printf(__VA_ARGS__);                                                   \
-        fflush(stdout);                                                        \
+#define debugf(...)                                          \
+    if (raxDebugMsg) {                                       \
+        printf("%s:%s:%d:\t", __FILE__, __func__, __LINE__); \
+        printf(__VA_ARGS__);                                 \
+        fflush(stdout);                                      \
     }
 
-#define debugnode(msg,n) raxDebugShowNode(msg,n)
+#define debugnode(msg, n) raxDebugShowNode(msg, n)
 #else
 #define debugf(...)
-#define debugnode(msg,n)
+#define debugnode(msg, n)
 #endif
 
 /* By default log debug info if RAX_DEBUG_MSG is defined. */
@@ -103,16 +98,16 @@ static inline void raxStackInit(raxStack *ts) {
 static inline int raxStackPush(raxStack *ts, void *ptr) {
     if (ts->items == ts->maxitems) {
         if (ts->stack == ts->static_items) {
-            ts->stack = rax_malloc(sizeof(void*)*ts->maxitems*2);
+            ts->stack = rax_malloc(sizeof(void *) * ts->maxitems * 2);
             if (ts->stack == NULL) {
                 ts->stack = ts->static_items;
                 ts->oom = 1;
                 errno = ENOMEM;
                 return 0;
             }
-            memcpy(ts->stack,ts->static_items,sizeof(void*)*ts->maxitems);
+            memcpy(ts->stack, ts->static_items, sizeof(void *) * ts->maxitems);
         } else {
-            void **newalloc = rax_realloc(ts->stack,sizeof(void*)*ts->maxitems*2);
+            void **newalloc = rax_realloc(ts->stack, sizeof(void *) * ts->maxitems * 2);
             if (newalloc == NULL) {
                 ts->oom = 1;
                 errno = ENOMEM;
@@ -139,7 +134,7 @@ static inline void *raxStackPop(raxStack *ts) {
  * it. */
 static inline void *raxStackPeek(raxStack *ts) {
     if (ts->items == 0) return NULL;
-    return ts->stack[ts->items-1];
+    return ts->stack[ts->items - 1];
 }
 
 /* Free the stack in case we used heap allocation. */
@@ -155,41 +150,32 @@ static inline void raxStackFree(raxStack *ts) {
  * 'nodesize'. The padding is needed to store the child pointers to aligned
  * addresses. Note that we add 4 to the node size because the node has a four
  * bytes header. */
-#define raxPadding(nodesize) ((sizeof(void*)-(((nodesize)+4) % sizeof(void*))) & (sizeof(void*)-1))
+#define raxPadding(nodesize) ((sizeof(void *) - (((nodesize) + 4) % sizeof(void *))) & (sizeof(void *) - 1))
 
 /* Return the pointer to the last child pointer in a node. For the compressed
  * nodes this is the only child pointer. */
-#define raxNodeLastChildPtr(n) ((raxNode**) ( \
-    ((char*)(n)) + \
-    raxNodeCurrentLength(n) - \
-    sizeof(raxNode*) - \
-    (((n)->iskey && !(n)->isnull) ? sizeof(void*) : 0) \
-))
+#define raxNodeLastChildPtr(n)                                                  \
+    ((raxNode **)(((char *)(n)) + raxNodeCurrentLength(n) - sizeof(raxNode *) - \
+                  (((n)->iskey && !(n)->isnull) ? sizeof(void *) : 0)))
 
 /* Return the pointer to the first child pointer. */
-#define raxNodeFirstChildPtr(n) ((raxNode**) ( \
-    (n)->data + \
-    (n)->size + \
-    raxPadding((n)->size)))
+#define raxNodeFirstChildPtr(n) ((raxNode **)((n)->data + (n)->size + raxPadding((n)->size)))
 
 /* Return the current total size of the node. Note that the second line
  * computes the padding after the string of characters, needed in order to
  * save pointers to aligned addresses. */
-#define raxNodeCurrentLength(n) ( \
-    sizeof(raxNode)+(n)->size+ \
-    raxPadding((n)->size)+ \
-    ((n)->iscompr ? sizeof(raxNode*) : sizeof(raxNode*)*(n)->size)+ \
-    (((n)->iskey && !(n)->isnull)*sizeof(void*)) \
-)
+#define raxNodeCurrentLength(n)                                           \
+    (sizeof(raxNode) + (n)->size + raxPadding((n)->size) +                \
+     ((n)->iscompr ? sizeof(raxNode *) : sizeof(raxNode *) * (n)->size) + \
+     (((n)->iskey && !(n)->isnull) * sizeof(void *)))
 
 /* Allocate a new non compressed node with the specified number of children.
  * If datafield is true, the allocation is made large enough to hold the
  * associated data pointer.
  * Returns the new node pointer. On out of memory NULL is returned. */
 raxNode *raxNewNode(size_t children, int datafield) {
-    size_t nodesize = sizeof(raxNode)+children+raxPadding(children)+
-                      sizeof(raxNode*)*children;
-    if (datafield) nodesize += sizeof(void*);
+    size_t nodesize = sizeof(raxNode) + children + raxPadding(children) + sizeof(raxNode *) * children;
+    if (datafield) nodesize += sizeof(void *);
     raxNode *node = rax_malloc(nodesize);
     if (node == NULL) return NULL;
     node->iskey = 0;
@@ -206,11 +192,12 @@ rax *raxNew(void) {
     if (rax == NULL) return NULL;
     rax->numele = 0;
     rax->numnodes = 1;
-    rax->head = raxNewNode(0,0);
+    rax->head = raxNewNode(0, 0);
     if (rax->head == NULL) {
         rax_free(rax);
         return NULL;
     } else {
+        rax->alloc_size = rax_ptr_alloc_size(rax) + rax_ptr_alloc_size(rax->head);
         return rax;
     }
 }
@@ -220,7 +207,7 @@ rax *raxNew(void) {
 raxNode *raxReallocForData(raxNode *n, void *data) {
     if (data == NULL) return n; /* No reallocation needed, setting isnull=1 */
     size_t curlen = raxNodeCurrentLength(n);
-    return rax_realloc(n,curlen+sizeof(void*));
+    return rax_realloc(n, curlen + sizeof(void *));
 }
 
 /* Set the node auxiliary data to the specified pointer. */
@@ -228,9 +215,8 @@ void raxSetData(raxNode *n, void *data) {
     n->iskey = 1;
     if (data != NULL) {
         n->isnull = 0;
-        void **ndata = (void**)
-            ((char*)n+raxNodeCurrentLength(n)-sizeof(void*));
-        memcpy(ndata,&data,sizeof(data));
+        void **ndata = (void **)((char *)n + raxNodeCurrentLength(n) - sizeof(void *));
+        memcpy(ndata, &data, sizeof(data));
     } else {
         n->isnull = 1;
     }
@@ -239,9 +225,9 @@ void raxSetData(raxNode *n, void *data) {
 /* Get the node auxiliary data. */
 void *raxGetData(raxNode *n) {
     if (n->isnull) return NULL;
-    void **ndata =(void**)((char*)n+raxNodeCurrentLength(n)-sizeof(void*));
+    void **ndata = (void **)((char *)n + raxNodeCurrentLength(n) - sizeof(void *));
     void *data;
-    memcpy(&data,ndata,sizeof(data));
+    memcpy(&data, ndata, sizeof(data));
     return data;
 }
 
@@ -264,11 +250,11 @@ raxNode *raxAddChild(raxNode *n, unsigned char c, raxNode **childptr, raxNode **
                   success at the end. */
 
     /* Alloc the new child we will link to 'n'. */
-    raxNode *child = raxNewNode(0,0);
+    raxNode *child = raxNewNode(0, 0);
     if (child == NULL) return NULL;
 
     /* Make space in the original node. */
-    raxNode *newn = rax_realloc(n,newlen);
+    raxNode *newn = rax_realloc(n, newlen);
     if (newn == NULL) {
         rax_free(child);
         return NULL;
@@ -316,9 +302,9 @@ raxNode *raxAddChild(raxNode *n, unsigned char c, raxNode **childptr, raxNode **
      */
     unsigned char *src, *dst;
     if (n->iskey && !n->isnull) {
-        src = ((unsigned char*)n+curlen-sizeof(void*));
-        dst = ((unsigned char*)n+newlen-sizeof(void*));
-        memmove(dst,src,sizeof(void*));
+        src = ((unsigned char *)n + curlen - sizeof(void *));
+        dst = ((unsigned char *)n + newlen - sizeof(void *));
+        memmove(dst, src, sizeof(void *));
     }
 
     /* Compute the "shift", that is, how many bytes we need to move the
@@ -332,7 +318,7 @@ raxNode *raxAddChild(raxNode *n, unsigned char c, raxNode **childptr, raxNode **
      * Another way to think at the shift is, how many bytes we need to
      * move child pointers forward *other than* the obvious sizeof(void*)
      * needed for the additional pointer itself. */
-    size_t shift = newlen - curlen - sizeof(void*);
+    size_t shift = newlen - curlen - sizeof(void *);
 
     /* We said we are adding a node with edge 'c'. The insertion
      * point is between 'b' and 'd', so the 'pos' variable value is
@@ -344,10 +330,8 @@ raxNode *raxAddChild(raxNode *n, unsigned char c, raxNode **childptr, raxNode **
      *
      * [HDR*][abde][Aptr][Bptr][....][....][Dptr][Eptr]|AUXP|
      */
-    src = n->data+n->size+
-          raxPadding(n->size)+
-          sizeof(raxNode*)*pos;
-    memmove(src+shift+sizeof(raxNode*),src,sizeof(raxNode*)*(n->size-pos));
+    src = n->data + n->size + raxPadding(n->size) + sizeof(raxNode *) * pos;
+    memmove(src + shift + sizeof(raxNode *), src, sizeof(raxNode *) * (n->size - pos));
 
     /* Move the pointers to the left of the insertion position as well. Often
      * we don't need to do anything if there was already some padding to use. In
@@ -359,8 +343,8 @@ raxNode *raxAddChild(raxNode *n, unsigned char c, raxNode **childptr, raxNode **
      * [HDR*][abde][....][Aptr][Bptr][....][Dptr][Eptr]|AUXP|
      */
     if (shift) {
-        src = (unsigned char*) raxNodeFirstChildPtr(n);
-        memmove(src+shift,src,sizeof(raxNode*)*pos);
+        src = (unsigned char *)raxNodeFirstChildPtr(n);
+        memmove(src + shift, src, sizeof(raxNode *) * pos);
     }
 
     /* Now make the space for the additional char in the data section,
@@ -369,8 +353,8 @@ raxNode *raxAddChild(raxNode *n, unsigned char c, raxNode **childptr, raxNode **
      *
      * [HDR*][ab.d][e...][Aptr][Bptr][....][Dptr][Eptr]|AUXP|
      */
-    src = n->data+pos;
-    memmove(src+1,src,n->size-pos);
+    src = n->data + pos;
+    memmove(src + 1, src, n->size - pos);
 
     /* We can now set the character and its child node pointer to get:
      *
@@ -379,9 +363,9 @@ raxNode *raxAddChild(raxNode *n, unsigned char c, raxNode **childptr, raxNode **
      */
     n->data[pos] = c;
     n->size++;
-    src = (unsigned char*) raxNodeFirstChildPtr(n);
-    raxNode **childfield = (raxNode**)(src+sizeof(raxNode*)*pos);
-    memcpy(childfield,&child,sizeof(child));
+    src = (unsigned char *)raxNodeFirstChildPtr(n);
+    raxNode **childfield = (raxNode **)(src + sizeof(raxNode *) * pos);
+    memcpy(childfield, &child, sizeof(child));
     *childptr = child;
     *parentlink = childfield;
     return n;
@@ -400,19 +384,19 @@ raxNode *raxCompressNode(raxNode *n, unsigned char *s, size_t len, raxNode **chi
     void *data = NULL; /* Initialized only to avoid warnings. */
     size_t newsize;
 
-    debugf("Compress node: %.*s\n", (int)len,s);
+    debugf("Compress node: %.*s\n", (int)len, s);
 
     /* Allocate the child to link to this node. */
-    *child = raxNewNode(0,0);
+    *child = raxNewNode(0, 0);
     if (*child == NULL) return NULL;
 
     /* Make space in the parent node. */
-    newsize = sizeof(raxNode)+len+raxPadding(len)+sizeof(raxNode*);
+    newsize = sizeof(raxNode) + len + raxPadding(len) + sizeof(raxNode *);
     if (n->iskey) {
         data = raxGetData(n); /* To restore it later. */
-        if (!n->isnull) newsize += sizeof(void*);
+        if (!n->isnull) newsize += sizeof(void *);
     }
-    raxNode *newn = rax_realloc(n,newsize);
+    raxNode *newn = rax_realloc(n, newsize);
     if (newn == NULL) {
         rax_free(*child);
         return NULL;
@@ -421,10 +405,10 @@ raxNode *raxCompressNode(raxNode *n, unsigned char *s, size_t len, raxNode **chi
 
     n->iscompr = 1;
     n->size = len;
-    memcpy(n->data,s,len);
-    if (n->iskey) raxSetData(n,data);
+    memcpy(n->data, s, len);
+    if (n->iskey) raxSetData(n, data);
     raxNode **childfield = raxNodeLastChildPtr(n);
-    memcpy(childfield,child,sizeof(*child));
+    memcpy(childfield, child, sizeof(*child));
     return n;
 }
 
@@ -457,14 +441,15 @@ raxNode *raxCompressNode(raxNode *n, unsigned char *s, size_t len, raxNode **chi
  * means that the current node represents the key (that is, none of the
  * compressed node characters are needed to represent the key, just all
  * its parents nodes). */
-static inline size_t raxLowWalk(rax *rax, unsigned char *s, size_t len, raxNode **stopnode, raxNode ***plink, int *splitpos, raxStack *ts) {
+static inline size_t
+raxLowWalk(rax *rax, unsigned char *s, size_t len, raxNode **stopnode, raxNode ***plink, int *splitpos, raxStack *ts) {
     raxNode *h = rax->head;
     raxNode **parentlink = &rax->head;
 
     size_t i = 0; /* Position in the string. */
     size_t j = 0; /* Position in the node children (or bytes if compressed).*/
-    while(h->size && i < len) {
-        debugnode("Lookup current node",h);
+    while (h->size && i < len) {
+        debugnode("Lookup current node", h);
         unsigned char *v = h->data;
 
         if (h->iscompr) {
@@ -483,17 +468,17 @@ static inline size_t raxLowWalk(rax *rax, unsigned char *s, size_t len, raxNode 
             i++;
         }
 
-        if (ts) raxStackPush(ts,h); /* Save stack of parent nodes. */
+        if (ts) raxStackPush(ts, h); /* Save stack of parent nodes. */
         raxNode **children = raxNodeFirstChildPtr(h);
         if (h->iscompr) j = 0; /* Compressed node only child is at index 0. */
-        memcpy(&h,children+j,sizeof(h));
-        parentlink = children+j;
+        memcpy(&h, children + j, sizeof(h));
+        parentlink = children + j;
         j = 0; /* If the new node is non compressed and we do not
                   iterate again (since i == len) set the split
                   position to 0 to signal this node represents
                   the searched key. */
     }
-    debugnode("Lookup stop node is",h);
+    debugnode("Lookup stop node is", h);
     if (stopnode) *stopnode = h;
     if (plink) *plink = parentlink;
     if (splitpos && h->iscompr) *splitpos = j;
@@ -516,7 +501,7 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
     raxNode *h, **parentlink;
 
     debugf("### Insert %.*s with value %p\n", (int)len, s, data);
-    i = raxLowWalk(rax,s,len,&h,&parentlink,&j,NULL);
+    i = raxLowWalk(rax, s, len, &h, &parentlink, &j, NULL);
 
     /* If i == len we walked following the whole string. If we are not
      * in the middle of a compressed node, the string is either already
@@ -527,8 +512,12 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
         debugf("### Insert: node representing key exists\n");
         /* Make space for the value pointer if needed. */
         if (!h->iskey || (h->isnull && overwrite)) {
-            h = raxReallocForData(h,data);
-            if (h) memcpy(parentlink,&h,sizeof(h));
+            size_t oldalloc = rax_ptr_alloc_size(h);
+            h = raxReallocForData(h, data);
+            if (h) {
+                memcpy(parentlink, &h, sizeof(h));
+                rax->alloc_size = rax->alloc_size - oldalloc + rax_ptr_alloc_size(h);
+            }
         }
         if (h == NULL) {
             errno = ENOMEM;
@@ -538,14 +527,14 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
         /* Update the existing key if there is already one. */
         if (h->iskey) {
             if (old) *old = raxGetData(h);
-            if (overwrite) raxSetData(h,data);
+            if (overwrite) raxSetData(h, data);
             errno = 0;
             return 0; /* Element already exists. */
         }
 
         /* Otherwise set the node as a key. Note that raxSetData()
          * will set h->iskey. */
-        raxSetData(h,data);
+        raxSetData(h, data);
         rax->numele++;
         return 1; /* Element inserted. */
     }
@@ -676,17 +665,16 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
 
     /* ------------------------- ALGORITHM 1 --------------------------- */
     if (h->iscompr && i != len) {
-        debugf("ALGO 1: Stopped at compressed node %.*s (%p)\n",
-            h->size, h->data, (void*)h);
-        debugf("Still to insert: %.*s\n", (int)(len-i), s+i);
-        debugf("Splitting at %d: '%c'\n", j, ((char*)h->data)[j]);
+        debugf("ALGO 1: Stopped at compressed node %.*s (%p)\n", h->size, h->data, (void *)h);
+        debugf("Still to insert: %.*s\n", (int)(len - i), s + i);
+        debugf("Splitting at %d: '%c'\n", j, ((char *)h->data)[j]);
         debugf("Other (key) letter is '%c'\n", s[i]);
 
         /* 1: Save next pointer. */
         raxNode **childfield = raxNodeLastChildPtr(h);
         raxNode *next;
-        memcpy(&next,childfield,sizeof(next));
-        debugf("Next is %p\n", (void*)next);
+        memcpy(&next, childfield, sizeof(next));
+        debugf("Next is %p\n", (void *)next);
         debugf("iskey %d\n", h->iskey);
         if (h->iskey) {
             debugf("key value is %p\n", raxGetData(h));
@@ -705,23 +693,18 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
         raxNode *postfix = NULL;
 
         if (trimmedlen) {
-            nodesize = sizeof(raxNode)+trimmedlen+raxPadding(trimmedlen)+
-                       sizeof(raxNode*);
-            if (h->iskey && !h->isnull) nodesize += sizeof(void*);
+            nodesize = sizeof(raxNode) + trimmedlen + raxPadding(trimmedlen) + sizeof(raxNode *);
+            if (h->iskey && !h->isnull) nodesize += sizeof(void *);
             trimmed = rax_malloc(nodesize);
         }
 
         if (postfixlen) {
-            nodesize = sizeof(raxNode)+postfixlen+raxPadding(postfixlen)+
-                       sizeof(raxNode*);
+            nodesize = sizeof(raxNode) + postfixlen + raxPadding(postfixlen) + sizeof(raxNode *);
             postfix = rax_malloc(nodesize);
         }
 
         /* OOM? Abort now that the tree is untouched. */
-        if (splitnode == NULL ||
-            (trimmedlen && trimmed == NULL) ||
-            (postfixlen && postfix == NULL))
-        {
+        if (splitnode == NULL || (trimmedlen && trimmed == NULL) || (postfixlen && postfix == NULL)) {
             rax_free(splitnode);
             rax_free(trimmed);
             rax_free(postfix);
@@ -729,30 +712,32 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
             return 0;
         }
         splitnode->data[0] = h->data[j];
+        rax->alloc_size += rax_ptr_alloc_size(splitnode);
 
         if (j == 0) {
             /* 3a: Replace the old node with the split node. */
             if (h->iskey) {
                 void *ndata = raxGetData(h);
-                raxSetData(splitnode,ndata);
+                raxSetData(splitnode, ndata);
             }
-            memcpy(parentlink,&splitnode,sizeof(splitnode));
+            memcpy(parentlink, &splitnode, sizeof(splitnode));
         } else {
             /* 3b: Trim the compressed node. */
             trimmed->size = j;
-            memcpy(trimmed->data,h->data,j);
+            memcpy(trimmed->data, h->data, j);
             trimmed->iscompr = j > 1 ? 1 : 0;
             trimmed->iskey = h->iskey;
             trimmed->isnull = h->isnull;
             if (h->iskey && !h->isnull) {
                 void *ndata = raxGetData(h);
-                raxSetData(trimmed,ndata);
+                raxSetData(trimmed, ndata);
             }
             raxNode **cp = raxNodeLastChildPtr(trimmed);
-            memcpy(cp,&splitnode,sizeof(splitnode));
-            memcpy(parentlink,&trimmed,sizeof(trimmed));
+            memcpy(cp, &splitnode, sizeof(splitnode));
+            memcpy(parentlink, &trimmed, sizeof(trimmed));
             parentlink = cp; /* Set parentlink to splitnode parent. */
             rax->numnodes++;
+            rax->alloc_size += rax_ptr_alloc_size(trimmed);
         }
 
         /* 4: Create the postfix node: what remains of the original
@@ -763,10 +748,11 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
             postfix->isnull = 0;
             postfix->size = postfixlen;
             postfix->iscompr = postfixlen > 1;
-            memcpy(postfix->data,h->data+j+1,postfixlen);
+            memcpy(postfix->data, h->data + j + 1, postfixlen);
             raxNode **cp = raxNodeLastChildPtr(postfix);
-            memcpy(cp,&next,sizeof(next));
+            memcpy(cp, &next, sizeof(next));
             rax->numnodes++;
+            rax->alloc_size += rax_ptr_alloc_size(postfix);
         } else {
             /* 4b: just use next as postfix node. */
             postfix = next;
@@ -774,27 +760,26 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
 
         /* 5: Set splitnode first child as the postfix node. */
         raxNode **splitchild = raxNodeLastChildPtr(splitnode);
-        memcpy(splitchild,&postfix,sizeof(postfix));
+        memcpy(splitchild, &postfix, sizeof(postfix));
 
         /* 6. Continue insertion: this will cause the splitnode to
          * get a new child (the non common character at the currently
          * inserted key). */
+        rax->alloc_size -= rax_ptr_alloc_size(h);
         rax_free(h);
         h = splitnode;
     } else if (h->iscompr && i == len) {
-    /* ------------------------- ALGORITHM 2 --------------------------- */
-        debugf("ALGO 2: Stopped at compressed node %.*s (%p) j = %d\n",
-            h->size, h->data, (void*)h, j);
+        /* ------------------------- ALGORITHM 2 --------------------------- */
+        debugf("ALGO 2: Stopped at compressed node %.*s (%p) j = %d\n", h->size, h->data, (void *)h, j);
 
         /* Allocate postfix & trimmed nodes ASAP to fail for OOM gracefully. */
         size_t postfixlen = h->size - j;
-        size_t nodesize = sizeof(raxNode)+postfixlen+raxPadding(postfixlen)+
-                          sizeof(raxNode*);
-        if (data != NULL) nodesize += sizeof(void*);
+        size_t nodesize = sizeof(raxNode) + postfixlen + raxPadding(postfixlen) + sizeof(raxNode *);
+        if (data != NULL) nodesize += sizeof(void *);
         raxNode *postfix = rax_malloc(nodesize);
 
-        nodesize = sizeof(raxNode)+j+raxPadding(j)+sizeof(raxNode*);
-        if (h->iskey && !h->isnull) nodesize += sizeof(void*);
+        nodesize = sizeof(raxNode) + j + raxPadding(j) + sizeof(raxNode *);
+        if (h->iskey && !h->isnull) nodesize += sizeof(void *);
         raxNode *trimmed = rax_malloc(nodesize);
 
         if (postfix == NULL || trimmed == NULL) {
@@ -807,81 +792,87 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
         /* 1: Save next pointer. */
         raxNode **childfield = raxNodeLastChildPtr(h);
         raxNode *next;
-        memcpy(&next,childfield,sizeof(next));
+        memcpy(&next, childfield, sizeof(next));
 
         /* 2: Create the postfix node. */
         postfix->size = postfixlen;
         postfix->iscompr = postfixlen > 1;
         postfix->iskey = 1;
         postfix->isnull = 0;
-        memcpy(postfix->data,h->data+j,postfixlen);
-        raxSetData(postfix,data);
+        memcpy(postfix->data, h->data + j, postfixlen);
+        raxSetData(postfix, data);
         raxNode **cp = raxNodeLastChildPtr(postfix);
-        memcpy(cp,&next,sizeof(next));
+        memcpy(cp, &next, sizeof(next));
         rax->numnodes++;
+        rax->alloc_size += rax_ptr_alloc_size(postfix);
 
         /* 3: Trim the compressed node. */
         trimmed->size = j;
         trimmed->iscompr = j > 1;
         trimmed->iskey = 0;
         trimmed->isnull = 0;
-        memcpy(trimmed->data,h->data,j);
-        memcpy(parentlink,&trimmed,sizeof(trimmed));
+        memcpy(trimmed->data, h->data, j);
+        memcpy(parentlink, &trimmed, sizeof(trimmed));
         if (h->iskey) {
             void *aux = raxGetData(h);
-            raxSetData(trimmed,aux);
+            raxSetData(trimmed, aux);
         }
+        rax->alloc_size += rax_ptr_alloc_size(trimmed);
 
         /* Fix the trimmed node child pointer to point to
          * the postfix node. */
         cp = raxNodeLastChildPtr(trimmed);
-        memcpy(cp,&postfix,sizeof(postfix));
+        memcpy(cp, &postfix, sizeof(postfix));
 
         /* Finish! We don't need to continue with the insertion
          * algorithm for ALGO 2. The key is already inserted. */
         rax->numele++;
+        rax->alloc_size -= rax_ptr_alloc_size(h);
         rax_free(h);
         return 1; /* Key inserted. */
     }
 
     /* We walked the radix tree as far as we could, but still there are left
      * chars in our string. We need to insert the missing nodes. */
-    while(i < len) {
+    while (i < len) {
         raxNode *child;
+        size_t oldalloc = rax_ptr_alloc_size(h);
 
         /* If this node is going to have a single child, and there
          * are other characters, so that that would result in a chain
          * of single-childed nodes, turn it into a compressed node. */
-        if (h->size == 0 && len-i > 1) {
+        if (h->size == 0 && len - i > 1) {
             debugf("Inserting compressed node\n");
-            size_t comprsize = len-i;
-            if (comprsize > RAX_NODE_MAX_SIZE)
-                comprsize = RAX_NODE_MAX_SIZE;
-            raxNode *newh = raxCompressNode(h,s+i,comprsize,&child);
+            size_t comprsize = len - i;
+            if (comprsize > RAX_NODE_MAX_SIZE) comprsize = RAX_NODE_MAX_SIZE;
+            raxNode *newh = raxCompressNode(h, s + i, comprsize, &child);
             if (newh == NULL) goto oom;
             h = newh;
-            memcpy(parentlink,&h,sizeof(h));
+            memcpy(parentlink, &h, sizeof(h));
             parentlink = raxNodeLastChildPtr(h);
             i += comprsize;
         } else {
             debugf("Inserting normal node\n");
             raxNode **new_parentlink;
-            raxNode *newh = raxAddChild(h,s[i],&child,&new_parentlink);
+            raxNode *newh = raxAddChild(h, s[i], &child, &new_parentlink);
             if (newh == NULL) goto oom;
             h = newh;
-            memcpy(parentlink,&h,sizeof(h));
+            memcpy(parentlink, &h, sizeof(h));
             parentlink = new_parentlink;
             i++;
         }
         rax->numnodes++;
+        rax->alloc_size = rax->alloc_size - oldalloc + rax_ptr_alloc_size(h) + rax_ptr_alloc_size(child);
         h = child;
     }
-    raxNode *newh = raxReallocForData(h,data);
+    size_t oldalloc = rax_ptr_alloc_size(h);
+    raxNode *newh = raxReallocForData(h, data);
     if (newh == NULL) goto oom;
     h = newh;
     if (!h->iskey) rax->numele++;
-    raxSetData(h,data);
-    memcpy(parentlink,&h,sizeof(h));
+    raxSetData(h, data);
+    memcpy(parentlink, &h, sizeof(h));
+    rax->alloc_size = rax->alloc_size - oldalloc + rax_ptr_alloc_size(h);
     return 1; /* Element inserted. */
 
 oom:
@@ -890,7 +881,6 @@ oom:
      * do that only if the node is a terminal node, otherwise if the OOM
      * happened reallocating a node in the middle, we don't need to free
      * anything. */
-    fprintf(stderr, "OOM during raxGenericInsert");
     if (h->size == 0) {
         h->isnull = 1;
         h->iskey = 1;
@@ -904,28 +894,28 @@ oom:
 /* Overwriting insert. Just a wrapper for raxGenericInsert() that will
  * update the element if there is already one for the same key. */
 int raxInsert(rax *rax, unsigned char *s, size_t len, void *data, void **old) {
-    return raxGenericInsert(rax,s,len,data,old,1);
+    return raxGenericInsert(rax, s, len, data, old, 1);
 }
 
-/* Non overwriting insert function: this if an element with the same key
+/* Non overwriting insert function: if an element with the same key
  * exists, the value is not updated and the function returns 0.
- * This is a just a wrapper for raxGenericInsert(). */
+ * This is just a wrapper for raxGenericInsert(). */
 int raxTryInsert(rax *rax, unsigned char *s, size_t len, void *data, void **old) {
-    return raxGenericInsert(rax,s,len,data,old,0);
+    return raxGenericInsert(rax, s, len, data, old, 0);
 }
 
-/* Find a key in the rax, returns raxNotFound special void pointer value
- * if the item was not found, otherwise the value associated with the
- * item is returned. */
-void *raxFind(rax *rax, unsigned char *s, size_t len) {
+/* Find a key in the rax: return 1 if the item is found, 0 otherwise.
+ * If there is an item and 'value' is passed in a non-NULL pointer,
+ * the value associated with the item is set at that address. */
+int raxFind(rax *rax, unsigned char *s, size_t len, void **value) {
     raxNode *h;
 
     debugf("### Lookup: %.*s\n", (int)len, s);
     int splitpos = 0;
-    size_t i = raxLowWalk(rax,s,len,&h,NULL,&splitpos,NULL);
-    if (i != len || (h->iscompr && splitpos != 0) || !h->iskey)
-        return raxNotFound;
-    return raxGetData(h);
+    size_t i = raxLowWalk(rax, s, len, &h, NULL, &splitpos, NULL);
+    if (i != len || (h->iscompr && splitpos != 0) || !h->iskey) return 0;
+    if (value != NULL) *value = raxGetData(h);
+    return 1;
 }
 
 /* Return the memory address where the 'parent' node stores the specified
@@ -936,8 +926,8 @@ void *raxFind(rax *rax, unsigned char *s, size_t len) {
 raxNode **raxFindParentLink(raxNode *parent, raxNode *child) {
     raxNode **cp = raxNodeFirstChildPtr(parent);
     raxNode *c;
-    while(1) {
-        memcpy(&c,cp,sizeof(c));
+    while (1) {
+        memcpy(&c, cp, sizeof(c));
         if (c == child) break;
         cp++;
     }
@@ -959,7 +949,7 @@ raxNode *raxRemoveChild(raxNode *parent, raxNode *child) {
         parent->isnull = 0;
         parent->iscompr = 0;
         parent->size = 0;
-        if (parent->iskey) raxSetData(parent,data);
+        if (parent->iskey) raxSetData(parent, data);
         debugnode("raxRemoveChild after", parent);
         return parent;
     }
@@ -975,9 +965,9 @@ raxNode *raxRemoveChild(raxNode *parent, raxNode *child) {
 
     /* 2. Search the child pointer to remove inside the array of children
      *    pointers. */
-    while(1) {
+    while (1) {
         raxNode *aux;
-        memcpy(&aux,c,sizeof(aux));
+        memcpy(&aux, c, sizeof(aux));
         if (aux == child) break;
         c++;
         e++;
@@ -987,7 +977,7 @@ raxNode *raxRemoveChild(raxNode *parent, raxNode *child) {
      *    pointer and edge bytes one position before. */
     int taillen = parent->size - (e - parent->data) - 1;
     debugf("raxRemoveChild tail len: %d\n", taillen);
-    memmove(e,e+1,taillen);
+    memmove(e, e + 1, taillen);
 
     /* Compute the shift, that is the amount of bytes we should move our
      * child pointers to the left, since the removal of one edge character
@@ -995,22 +985,21 @@ raxNode *raxRemoveChild(raxNode *parent, raxNode *child) {
      * We just check if in the old version of the node there was at the
      * end just a single byte and all padding: in that case removing one char
      * will remove a whole sizeof(void*) word. */
-    size_t shift = ((parent->size+4) % sizeof(void*)) == 1 ? sizeof(void*) : 0;
+    size_t shift = ((parent->size + 4) % sizeof(void *)) == 1 ? sizeof(void *) : 0;
 
     /* Move the children pointers before the deletion point. */
-    if (shift)
-        memmove(((char*)cp)-shift,cp,(parent->size-taillen-1)*sizeof(raxNode**));
+    if (shift) memmove(((char *)cp) - shift, cp, (parent->size - taillen - 1) * sizeof(raxNode **));
 
     /* Move the remaining "tail" pointers at the right position as well. */
-    size_t valuelen = (parent->iskey && !parent->isnull) ? sizeof(void*) : 0;
-    memmove(((char*)c)-shift,c+1,taillen*sizeof(raxNode**)+valuelen);
+    size_t valuelen = (parent->iskey && !parent->isnull) ? sizeof(void *) : 0;
+    memmove(((char *)c) - shift, c + 1, taillen * sizeof(raxNode **) + valuelen);
 
     /* 4. Update size. */
     parent->size--;
 
     /* realloc the node according to the theoretical memory usage, to free
      * data if we are over-allocating right now. */
-    raxNode *newnode = rax_realloc(parent,raxNodeCurrentLength(parent));
+    raxNode *newnode = rax_realloc(parent, raxNodeCurrentLength(parent));
     if (newnode) {
         debugnode("raxRemoveChild after", newnode);
     }
@@ -1028,7 +1017,7 @@ int raxRemove(rax *rax, unsigned char *s, size_t len, void **old) {
     debugf("### Delete: %.*s\n", (int)len, s);
     raxStackInit(&ts);
     int splitpos = 0;
-    size_t i = raxLowWalk(rax,s,len,&h,NULL,&splitpos,&ts);
+    size_t i = raxLowWalk(rax, s, len, &h, NULL, &splitpos, &ts);
     if (i != len || (h->iscompr && splitpos != 0) || !h->iskey) {
         raxStackFree(&ts);
         return 0;
@@ -1049,30 +1038,32 @@ int raxRemove(rax *rax, unsigned char *s, size_t len, void **old) {
     if (h->size == 0) {
         debugf("Key deleted in node without children. Cleanup needed.\n");
         raxNode *child = NULL;
-        while(h != rax->head) {
+        while (h != rax->head) {
             child = h;
-            debugf("Freeing child %p [%.*s] key:%d\n", (void*)child,
-                (int)child->size, (char*)child->data, child->iskey);
+            debugf("Freeing child %p [%.*s] key:%d\n", (void *)child, (int)child->size, (char *)child->data,
+                   child->iskey);
+            rax->alloc_size -= rax_ptr_alloc_size(child);
             rax_free(child);
             rax->numnodes--;
             h = raxStackPop(&ts);
-             /* If this node has more then one child, or actually holds
-              * a key, stop here. */
+            /* If this node has more then one child, or actually holds
+             * a key, stop here. */
             if (h->iskey || (!h->iscompr && h->size != 1)) break;
         }
         if (child) {
-            debugf("Unlinking child %p from parent %p\n",
-                (void*)child, (void*)h);
-            raxNode *new = raxRemoveChild(h,child);
+            debugf("Unlinking child %p from parent %p\n", (void *)child, (void *)h);
+            size_t oldalloc = rax_ptr_alloc_size(h);
+            raxNode *new = raxRemoveChild(h, child);
+            rax->alloc_size = rax->alloc_size - oldalloc + rax_ptr_alloc_size(new);
             if (new != h) {
                 raxNode *parent = raxStackPeek(&ts);
                 raxNode **parentlink;
                 if (parent == NULL) {
                     parentlink = &rax->head;
                 } else {
-                    parentlink = raxFindParentLink(parent,h);
+                    parentlink = raxFindParentLink(parent, h);
                 }
-                memcpy(parentlink,&new,sizeof(new));
+                memcpy(parentlink, &new, sizeof(new));
             }
 
             /* If after the removal the node has just a single child
@@ -1137,28 +1128,27 @@ int raxRemove(rax *rax, unsigned char *s, size_t len, void **old) {
      */
     if (trycompress) {
         debugf("After removing %.*s:\n", (int)len, s);
-        debugnode("Compression may be needed",h);
+        debugnode("Compression may be needed", h);
         debugf("Seek start node\n");
 
         /* Try to reach the upper node that is compressible.
          * At the end of the loop 'h' will point to the first node we
          * can try to compress and 'parent' to its parent. */
         raxNode *parent;
-        while(1) {
+        while (1) {
             parent = raxStackPop(&ts);
-            if (!parent || parent->iskey ||
-                (!parent->iscompr && parent->size != 1)) break;
+            if (!parent || parent->iskey || (!parent->iscompr && parent->size != 1)) break;
             h = parent;
-            debugnode("Going up to",h);
+            debugnode("Going up to", h);
         }
         raxNode *start = h; /* Compression starting node. */
 
         /* Scan chain of nodes we can compress. */
         size_t comprsize = h->size;
         int nodes = 1;
-        while(h->size != 0) {
+        while (h->size != 0) {
             raxNode **cp = raxNodeLastChildPtr(h);
-            memcpy(&h,cp,sizeof(h));
+            memcpy(&h, cp, sizeof(h));
             if (h->iskey || (!h->iscompr && h->size != 1)) break;
             /* Stop here if going to the next node would result into
              * a compressed node larger than h->size can hold. */
@@ -1168,8 +1158,7 @@ int raxRemove(rax *rax, unsigned char *s, size_t len, void **old) {
         }
         if (nodes > 1) {
             /* If we can compress, create the new node and populate it. */
-            size_t nodesize =
-                sizeof(raxNode)+comprsize+raxPadding(comprsize)+sizeof(raxNode*);
+            size_t nodesize = sizeof(raxNode) + comprsize + raxPadding(comprsize) + sizeof(raxNode *);
             raxNode *new = rax_malloc(nodesize);
             /* An out of memory here just means we cannot optimize this
              * node, but the tree is left in a consistent state. */
@@ -1182,38 +1171,41 @@ int raxRemove(rax *rax, unsigned char *s, size_t len, void **old) {
             new->iscompr = 1;
             new->size = comprsize;
             rax->numnodes++;
+            rax->alloc_size += rax_ptr_alloc_size(new);
 
             /* Scan again, this time to populate the new node content and
              * to fix the new node child pointer. At the same time we free
              * all the nodes that we'll no longer use. */
             comprsize = 0;
             h = start;
-            while(h->size != 0) {
-                memcpy(new->data+comprsize,h->data,h->size);
+            while (h->size != 0) {
+                memcpy(new->data + comprsize, h->data, h->size);
                 comprsize += h->size;
                 raxNode **cp = raxNodeLastChildPtr(h);
                 raxNode *tofree = h;
-                memcpy(&h,cp,sizeof(h));
-                rax_free(tofree); rax->numnodes--;
+                memcpy(&h, cp, sizeof(h));
+                rax->alloc_size -= rax_ptr_alloc_size(tofree);
+                rax_free(tofree);
+                rax->numnodes--;
                 if (h->iskey || (!h->iscompr && h->size != 1)) break;
+                if (comprsize + h->size > RAX_NODE_MAX_SIZE) break;
             }
-            debugnode("New node",new);
+            debugnode("New node", new);
 
             /* Now 'h' points to the first node that we still need to use,
              * so our new node child pointer will point to it. */
             raxNode **cp = raxNodeLastChildPtr(new);
-            memcpy(cp,&h,sizeof(h));
+            memcpy(cp, &h, sizeof(h));
 
             /* Fix parent link. */
             if (parent) {
-                raxNode **parentlink = raxFindParentLink(parent,start);
-                memcpy(parentlink,&new,sizeof(new));
+                raxNode **parentlink = raxFindParentLink(parent, start);
+                memcpy(parentlink, &new, sizeof(new));
             } else {
                 rax->head = new;
             }
 
-            debugf("Compressed %d nodes, %d total bytes\n",
-                nodes, (int)comprsize);
+            debugf("Compressed %d nodes, %d total bytes\n", nodes, (int)comprsize);
         }
     }
     raxStackFree(&ts);
@@ -1226,15 +1218,14 @@ void raxRecursiveFree(rax *rax, raxNode *n, void (*free_callback)(void*, void*),
     debugnode("free traversing",n);
     int numchildren = n->iscompr ? 1 : n->size;
     raxNode **cp = raxNodeLastChildPtr(n);
-    while(numchildren--) {
+    while (numchildren--) {
         raxNode *child;
-        memcpy(&child,cp,sizeof(child));
+        memcpy(&child, cp, sizeof(child));
         raxRecursiveFree(rax,child,free_callback,argument);
         cp--;
     }
-    debugnode("free depth-first",n);
-    if (free_callback && n->iskey && !n->isnull)
-        free_callback(raxGetData(n),argument);
+    debugnode("free depth-first", n);
+    if (free_callback && n->iskey && !n->isnull) free_callback(raxGetData(n), argument);
     rax_free(n);
     rax->numnodes--;
 }
@@ -1242,7 +1233,7 @@ void raxRecursiveFree(rax *rax, raxNode *n, void (*free_callback)(void*, void*),
 /* Free the entire radix tree, invoking a free_callback function for each key's data. 
  * An additional argument is passed to the free_callback function.*/
  void raxFreeWithCallbackAndArgument(rax *rax, void (*free_callback)(void*, void*), void* argument) {
-    raxRecursiveFree(rax,rax->head,free_callback,argument);
+    raxRecursiveFree(rax,rax->head,free_callback, argument);
     assert(rax->numnodes == 0);
     rax_free(rax);
 }
@@ -1264,7 +1255,7 @@ void raxFreeWithCallback(rax *rax, void (*free_callback)(void*)) {
 
 /* Free a whole radix tree. */
 void raxFree(rax *rax) {
-    raxFreeWithCallback(rax,NULL);
+    raxFreeWithCallback(rax, NULL);
 }
 
 /* ------------------------------- Iterator --------------------------------- */
@@ -1288,22 +1279,21 @@ void raxStart(raxIterator *it, rax *rt) {
  * the user. Returns 0 on out of memory, otherwise 1 is returned. */
 int raxIteratorAddChars(raxIterator *it, unsigned char *s, size_t len) {
     if (len == 0) return 1;
-    if (it->key_max < it->key_len+len) {
-        unsigned char *old = (it->key == it->key_static_string) ? NULL :
-                                                                  it->key;
-        size_t new_max = (it->key_len+len)*2;
-        it->key = rax_realloc(old,new_max);
+    if (it->key_max < it->key_len + len) {
+        unsigned char *old = (it->key == it->key_static_string) ? NULL : it->key;
+        size_t new_max = (it->key_len + len) * 2;
+        it->key = rax_realloc(old, new_max);
         if (it->key == NULL) {
             it->key = (!old) ? it->key_static_string : old;
             errno = ENOMEM;
             return 0;
         }
-        if (old == NULL) memcpy(it->key,it->key_static_string,it->key_len);
+        if (old == NULL) memcpy(it->key, it->key_static_string, it->key_len);
         it->key_max = new_max;
     }
     /* Use memmove since there could be an overlap between 's' and
      * it->key when we use the current key in order to re-seek. */
-    memmove(it->key+it->key_len,s,len);
+    memmove(it->key + it->key_len, s, len);
     it->key_len += len;
     return 1;
 }
@@ -1342,22 +1332,20 @@ int raxIteratorNextStep(raxIterator *it, int noup) {
     size_t orig_stack_items = it->stack.items;
     raxNode *orig_node = it->node;
 
-    while(1) {
+    while (1) {
         int children = it->node->iscompr ? 1 : it->node->size;
         if (!noup && children) {
             debugf("GO DEEPER\n");
             /* Seek the lexicographically smaller key in this subtree, which
              * is the first one found always going towards the first child
              * of every successive node. */
-            if (!raxStackPush(&it->stack,it->node)) return 0;
+            if (!raxStackPush(&it->stack, it->node)) return 0;
             raxNode **cp = raxNodeFirstChildPtr(it->node);
-            if (!raxIteratorAddChars(it,it->node->data,
-                it->node->iscompr ? it->node->size : 1)) return 0;
-            memcpy(&it->node,cp,sizeof(it->node));
+            if (!raxIteratorAddChars(it, it->node->data, it->node->iscompr ? it->node->size : 1)) return 0;
+            memcpy(&it->node, cp, sizeof(it->node));
             /* Call the node callback if any, and replace the node pointer
              * if the callback returns true. */
-            if (it->node_cb && it->node_cb(&it->node))
-                memcpy(cp,&it->node,sizeof(it->node));
+            if (it->node_cb && it->node_cb(&it->node)) memcpy(cp, &it->node, sizeof(it->node));
             /* For "next" step, stop every time we find a key along the
              * way, since the key is lexicographically smaller compared to
              * what follows in the sub-children. */
@@ -1370,7 +1358,7 @@ int raxIteratorNextStep(raxIterator *it, int noup) {
              * new one: go upper until a node is found where there are
              * children representing keys lexicographically greater than the
              * current key. */
-            while(1) {
+            while (1) {
                 int old_noup = noup;
 
                 /* Already on head? Can't go up, iteration finished. */
@@ -1383,7 +1371,7 @@ int raxIteratorNextStep(raxIterator *it, int noup) {
                 }
                 /* If there are no children at the current node, try parent's
                  * next child. */
-                unsigned char prevchild = it->key[it->key_len-1];
+                unsigned char prevchild = it->key[it->key_len - 1];
                 if (!noup) {
                     it->node = raxStackPop(&it->stack);
                 } else {
@@ -1392,7 +1380,7 @@ int raxIteratorNextStep(raxIterator *it, int noup) {
                 /* Adjust the current key to represent the node we are
                  * at. */
                 int todel = it->node->iscompr ? it->node->size : 1;
-                raxIteratorDelChars(it,todel);
+                raxIteratorDelChars(it, todel);
 
                 /* Try visiting the next child if there was at least one
                  * additional child. */
@@ -1407,13 +1395,12 @@ int raxIteratorNextStep(raxIterator *it, int noup) {
                     }
                     if (i != it->node->size) {
                         debugf("SCAN found a new node\n");
-                        raxIteratorAddChars(it,it->node->data+i,1);
-                        if (!raxStackPush(&it->stack,it->node)) return 0;
-                        memcpy(&it->node,cp,sizeof(it->node));
+                        raxIteratorAddChars(it, it->node->data + i, 1);
+                        if (!raxStackPush(&it->stack, it->node)) return 0;
+                        memcpy(&it->node, cp, sizeof(it->node));
                         /* Call the node callback if any, and replace the node
                          * pointer if the callback returns true. */
-                        if (it->node_cb && it->node_cb(&it->node))
-                            memcpy(cp,&it->node,sizeof(it->node));
+                        if (it->node_cb && it->node_cb(&it->node)) memcpy(cp, &it->node, sizeof(it->node));
                         if (it->node->iskey) {
                             it->data = raxGetData(it->node);
                             return 1;
@@ -1430,17 +1417,15 @@ int raxIteratorNextStep(raxIterator *it, int noup) {
  * out of memory, otherwise 1. This is a helper function for different
  * iteration functions below. */
 int raxSeekGreatest(raxIterator *it) {
-    while(it->node->size) {
+    while (it->node->size) {
         if (it->node->iscompr) {
-            if (!raxIteratorAddChars(it,it->node->data,
-                it->node->size)) return 0;
+            if (!raxIteratorAddChars(it, it->node->data, it->node->size)) return 0;
         } else {
-            if (!raxIteratorAddChars(it,it->node->data+it->node->size-1,1))
-                return 0;
+            if (!raxIteratorAddChars(it, it->node->data + it->node->size - 1, 1)) return 0;
         }
         raxNode **cp = raxNodeLastChildPtr(it->node);
-        if (!raxStackPush(&it->stack,it->node)) return 0;
-        memcpy(&it->node,cp,sizeof(it->node));
+        if (!raxStackPush(&it->stack, it->node)) return 0;
+        memcpy(&it->node, cp, sizeof(it->node));
     }
     return 1;
 }
@@ -1462,7 +1447,7 @@ int raxIteratorPrevStep(raxIterator *it, int noup) {
     size_t orig_stack_items = it->stack.items;
     raxNode *orig_node = it->node;
 
-    while(1) {
+    while (1) {
         int old_noup = noup;
 
         /* Already on head? Can't go up, iteration finished. */
@@ -1474,7 +1459,7 @@ int raxIteratorPrevStep(raxIterator *it, int noup) {
             return 1;
         }
 
-        unsigned char prevchild = it->key[it->key_len-1];
+        unsigned char prevchild = it->key[it->key_len - 1];
         if (!noup) {
             it->node = raxStackPop(&it->stack);
         } else {
@@ -1484,13 +1469,13 @@ int raxIteratorPrevStep(raxIterator *it, int noup) {
         /* Adjust the current key to represent the node we are
          * at. */
         int todel = it->node->iscompr ? it->node->size : 1;
-        raxIteratorDelChars(it,todel);
+        raxIteratorDelChars(it, todel);
 
         /* Try visiting the prev child if there is at least one
          * child. */
         if (!it->node->iscompr && it->node->size > (old_noup ? 0 : 1)) {
             raxNode **cp = raxNodeLastChildPtr(it->node);
-            int i = it->node->size-1;
+            int i = it->node->size - 1;
             while (i >= 0) {
                 debugf("SCAN PREV %c\n", it->node->data[i]);
                 if (it->node->data[i] < prevchild) break;
@@ -1503,9 +1488,9 @@ int raxIteratorPrevStep(raxIterator *it, int noup) {
             if (i != -1) {
                 debugf("SCAN found a new node\n");
                 /* Enter the node we just found. */
-                if (!raxIteratorAddChars(it,it->node->data+i,1)) return 0;
-                if (!raxStackPush(&it->stack,it->node)) return 0;
-                memcpy(&it->node,cp,sizeof(it->node));
+                if (!raxIteratorAddChars(it, it->node->data + i, 1)) return 0;
+                if (!raxStackPush(&it->stack, it->node)) return 0;
+                memcpy(&it->node, cp, sizeof(it->node));
                 /* Seek sub-tree max. */
                 if (!raxSeekGreatest(it)) return 0;
             }
@@ -1562,7 +1547,7 @@ int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len) {
     if (first) {
         /* Seeking the first key greater or equal to the empty string
          * is equivalent to seeking the smaller key available. */
-        return raxSeek(it,">=",NULL,0);
+        return raxSeek(it, ">=", NULL, 0);
     }
 
     if (last) {
@@ -1579,45 +1564,40 @@ int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len) {
      * perform a lookup, and later invoke the prev/next key code that
      * we already use for iteration. */
     int splitpos = 0;
-    size_t i = raxLowWalk(it->rt,ele,len,&it->node,NULL,&splitpos,&it->stack);
+    size_t i = raxLowWalk(it->rt, ele, len, &it->node, NULL, &splitpos, &it->stack);
 
     /* Return OOM on incomplete stack info. */
     if (it->stack.oom) return 0;
 
-    if (eq && i == len && (!it->node->iscompr || splitpos == 0) &&
-        it->node->iskey)
-    {
+    if (eq && i == len && (!it->node->iscompr || splitpos == 0) && it->node->iskey) {
         /* We found our node, since the key matches and we have an
          * "equal" condition. */
-        if (!raxIteratorAddChars(it,ele,len)) return 0; /* OOM. */
+        if (!raxIteratorAddChars(it, ele, len)) return 0; /* OOM. */
         it->data = raxGetData(it->node);
     } else if (lt || gt) {
         /* Exact key not found or eq flag not set. We have to set as current
          * key the one represented by the node we stopped at, and perform
          * a next/prev operation to seek. */
-        raxIteratorAddChars(it, ele, i-splitpos);
+        raxIteratorAddChars(it, ele, i - splitpos);
 
         /* We need to set the iterator in the correct state to call next/prev
          * step in order to seek the desired element. */
-        debugf("After initial seek: i=%d len=%d key=%.*s\n",
-            (int)i, (int)len, (int)it->key_len, it->key);
+        debugf("After initial seek: i=%d len=%d key=%.*s\n", (int)i, (int)len, (int)it->key_len, it->key);
         if (i != len && !it->node->iscompr) {
             /* If we stopped in the middle of a normal node because of a
              * mismatch, add the mismatching character to the current key
              * and call the iterator with the 'noup' flag so that it will try
              * to seek the next/prev child in the current node directly based
              * on the mismatching character. */
-            if (!raxIteratorAddChars(it,ele+i,1)) return 0;
-            debugf("Seek normal node on mismatch: %.*s\n",
-                (int)it->key_len, (char*)it->key);
+            if (!raxIteratorAddChars(it, ele + i, 1)) return 0;
+            debugf("Seek normal node on mismatch: %.*s\n", (int)it->key_len, (char *)it->key);
 
             it->flags &= ~RAX_ITER_JUST_SEEKED;
-            if (lt && !raxIteratorPrevStep(it,1)) return 0;
-            if (gt && !raxIteratorNextStep(it,1)) return 0;
+            if (lt && !raxIteratorPrevStep(it, 1)) return 0;
+            if (gt && !raxIteratorNextStep(it, 1)) return 0;
             it->flags |= RAX_ITER_JUST_SEEKED; /* Ignore next call. */
         } else if (i != len && it->node->iscompr) {
-            debugf("Compressed mismatch: %.*s\n",
-                (int)it->key_len, (char*)it->key);
+            debugf("Compressed mismatch: %.*s\n", (int)it->key_len, (char *)it->key);
             /* In case of a mismatch within a compressed node. */
             int nodechar = it->node->data[splitpos];
             int keychar = ele[i];
@@ -1627,11 +1607,10 @@ int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len) {
                  * than our seek element, continue forward, otherwise set the
                  * state in order to go back to the next sub-tree. */
                 if (nodechar > keychar) {
-                    if (!raxIteratorNextStep(it,0)) return 0;
+                    if (!raxIteratorNextStep(it, 0)) return 0;
                 } else {
-                    if (!raxIteratorAddChars(it,it->node->data,it->node->size))
-                        return 0;
-                    if (!raxIteratorNextStep(it,1)) return 0;
+                    if (!raxIteratorAddChars(it, it->node->data, it->node->size)) return 0;
+                    if (!raxIteratorNextStep(it, 1)) return 0;
                 }
             }
             if (lt) {
@@ -1643,15 +1622,13 @@ int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len) {
                     if (!raxSeekGreatest(it)) return 0;
                     it->data = raxGetData(it->node);
                 } else {
-                    if (!raxIteratorAddChars(it,it->node->data,it->node->size))
-                        return 0;
-                    if (!raxIteratorPrevStep(it,1)) return 0;
+                    if (!raxIteratorAddChars(it, it->node->data, it->node->size)) return 0;
+                    if (!raxIteratorPrevStep(it, 1)) return 0;
                 }
             }
             it->flags |= RAX_ITER_JUST_SEEKED; /* Ignore next call. */
         } else {
-            debugf("No mismatch: %.*s\n",
-                (int)it->key_len, (char*)it->key);
+            debugf("No mismatch: %.*s\n", (int)it->key_len, (char *)it->key);
             /* If there was no mismatch we are into a node representing the
              * key, (but which is not a key or the seek operator does not
              * include 'eq'), or we stopped in the middle of a compressed node
@@ -1673,8 +1650,8 @@ int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len) {
                  * So in that case, we don't seek backward. */
                 it->data = raxGetData(it->node);
             } else {
-                if (gt && !raxIteratorNextStep(it,0)) return 0;
-                if (lt && !raxIteratorPrevStep(it,0)) return 0;
+                if (gt && !raxIteratorNextStep(it, 0)) return 0;
+                if (lt && !raxIteratorPrevStep(it, 0)) return 0;
             }
             it->flags |= RAX_ITER_JUST_SEEKED; /* Ignore next call. */
         }
@@ -1690,7 +1667,7 @@ int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len) {
  * If EOF (or out of memory) is reached, 0 is returned, otherwise 1 is
  * returned. In case 0 is returned because of OOM, errno is set to ENOMEM. */
 int raxNext(raxIterator *it) {
-    if (!raxIteratorNextStep(it,0)) {
+    if (!raxIteratorNextStep(it, 0)) {
         errno = ENOMEM;
         return 0;
     }
@@ -1705,7 +1682,7 @@ int raxNext(raxIterator *it) {
  * If EOF (or out of memory) is reached, 0 is returned, otherwise 1 is
  * returned. In case 0 is returned because of OOM, errno is set to ENOMEM. */
 int raxPrev(raxIterator *it) {
-    if (!raxIteratorPrevStep(it,0)) {
+    if (!raxIteratorPrevStep(it, 0)) {
         errno = ENOMEM;
         return 0;
     }
@@ -1735,31 +1712,31 @@ int raxRandomWalk(raxIterator *it, size_t steps) {
     }
 
     if (steps == 0) {
-        size_t fle = 1+floor(log(it->rt->numele));
+        size_t fle = 1 + floor(log(it->rt->numele));
         fle *= 2;
         steps = 1 + rand() % fle;
     }
 
     raxNode *n = it->node;
-    while(steps > 0 || !n->iskey) {
+    while (steps > 0 || !n->iskey) {
         int numchildren = n->iscompr ? 1 : n->size;
-        int r = rand() % (numchildren+(n != it->rt->head));
+        int r = rand() % (numchildren + (n != it->rt->head));
 
         if (r == numchildren) {
             /* Go up to parent. */
             n = raxStackPop(&it->stack);
             int todel = n->iscompr ? n->size : 1;
-            raxIteratorDelChars(it,todel);
+            raxIteratorDelChars(it, todel);
         } else {
             /* Select a random child. */
             if (n->iscompr) {
-                if (!raxIteratorAddChars(it,n->data,n->size)) return 0;
+                if (!raxIteratorAddChars(it, n->data, n->size)) return 0;
             } else {
-                if (!raxIteratorAddChars(it,n->data+r,1)) return 0;
+                if (!raxIteratorAddChars(it, n->data + r, 1)) return 0;
             }
-            raxNode **cp = raxNodeFirstChildPtr(n)+r;
-            if (!raxStackPush(&it->stack,n)) return 0;
-            memcpy(&n,cp,sizeof(n));
+            raxNode **cp = raxNodeFirstChildPtr(n) + r;
+            if (!raxStackPush(&it->stack, n)) return 0;
+            memcpy(&n, cp, sizeof(n));
         }
         if (n->iskey) steps--;
     }
@@ -1775,12 +1752,15 @@ int raxCompare(raxIterator *iter, const char *op, unsigned char *key, size_t key
     int eq = 0, lt = 0, gt = 0;
 
     if (op[0] == '=' || op[1] == '=') eq = 1;
-    if (op[0] == '>') gt = 1;
-    else if (op[0] == '<') lt = 1;
-    else if (op[1] != '=') return 0; /* Syntax error. */
+    if (op[0] == '>')
+        gt = 1;
+    else if (op[0] == '<')
+        lt = 1;
+    else if (op[1] != '=')
+        return 0; /* Syntax error. */
 
     size_t minlen = key_len < iter->key_len ? key_len : iter->key_len;
-    int cmp = memcmp(iter->key,key,minlen);
+    int cmp = memcmp(iter->key, key, minlen);
 
     /* Handle == */
     if (lt == 0 && gt == 0) return cmp == 0 && key_len == iter->key_len;
@@ -1788,10 +1768,14 @@ int raxCompare(raxIterator *iter, const char *op, unsigned char *key, size_t key
     /* Handle >, >=, <, <= */
     if (cmp == 0) {
         /* Same prefix: longer wins. */
-        if (eq && key_len == iter->key_len) return 1;
-        else if (lt) return iter->key_len < key_len;
-        else if (gt) return iter->key_len > key_len;
-        else return 0; /* Avoid warning, just 'eq' is handled before. */
+        if (eq && key_len == iter->key_len)
+            return 1;
+        else if (lt)
+            return iter->key_len < key_len;
+        else if (gt)
+            return iter->key_len > key_len;
+        else
+            return 0; /* Avoid warning, just 'eq' is handled before. */
     } else if (cmp > 0) {
         return gt ? 1 : 0;
     } else /* (cmp < 0) */ {
@@ -1816,6 +1800,11 @@ int raxEOF(raxIterator *it) {
 /* Return the number of elements inside the radix tree. */
 uint64_t raxSize(rax *rax) {
     return rax->numele;
+}
+
+/* Return the rax tree allocation size in bytes */
+size_t raxAllocSize(rax *rax) {
+    return rax->alloc_size;
 }
 
 /* ----------------------------- Introspection ------------------------------ */
@@ -1852,7 +1841,7 @@ void raxRecursiveShow(int level, int lpad, raxNode *n) {
 
     int numchars = printf("%c%.*s%c", s, n->size, n->data, e);
     if (n->iskey) {
-        numchars += printf("=%p",raxGetData(n));
+        numchars += printf("=%p", raxGetData(n));
     }
 
     int numchildren = n->iscompr ? 1 : n->size;
@@ -1868,35 +1857,34 @@ void raxRecursiveShow(int level, int lpad, raxNode *n) {
         if (numchildren > 1) {
             printf("\n");
             for (int j = 0; j < lpad; j++) putchar(' ');
-            printf(branch,n->data[i]);
+            printf(branch, n->data[i]);
         } else {
             printf(" -> ");
         }
         raxNode *child;
-        memcpy(&child,cp,sizeof(child));
-        raxRecursiveShow(level+1,lpad,child);
+        memcpy(&child, cp, sizeof(child));
+        raxRecursiveShow(level + 1, lpad, child);
         cp++;
     }
 }
 
 /* Show a tree, as outlined in the comment above. */
 void raxShow(rax *rax) {
-    raxRecursiveShow(0,0,rax->head);
+    raxRecursiveShow(0, 0, rax->head);
     putchar('\n');
 }
 
 /* Used by debugnode() macro to show info about a given node. */
 void raxDebugShowNode(const char *msg, raxNode *n) {
     if (raxDebugMsg == 0) return;
-    printf("%s: %p [%.*s] key:%u size:%u children:",
-        msg, (void*)n, (int)n->size, (char*)n->data, n->iskey, n->size);
+    printf("%s: %p [%.*s] key:%u size:%u children:", msg, (void *)n, (int)n->size, (char *)n->data, n->iskey, n->size);
     int numcld = n->iscompr ? 1 : n->size;
-    raxNode **cldptr = raxNodeLastChildPtr(n) - (numcld-1);
-    while(numcld--) {
+    raxNode **cldptr = raxNodeLastChildPtr(n) - (numcld - 1);
+    while (numcld--) {
         raxNode *child;
-        memcpy(&child,cldptr,sizeof(child));
+        memcpy(&child, cldptr, sizeof(child));
         cldptr++;
-        printf("%p ", (void*)child);
+        printf("%p ", (void *)child);
     }
     printf("\n");
     fflush(stdout);
@@ -1920,7 +1908,7 @@ void raxDebugShowNode(const char *msg, raxNode *n) {
  *    before the moment the tree is corrupted, to see what happens.
  */
 unsigned long raxTouch(raxNode *n) {
-    debugf("Touching %p\n", (void*)n);
+    debugf("Touching %p\n", (void *)n);
     unsigned long sum = 0;
     if (n->iskey) {
         sum += (unsigned long)raxGetData(n);
@@ -1934,8 +1922,8 @@ unsigned long raxTouch(raxNode *n) {
             sum += (long)n->data[i];
         }
         raxNode *child;
-        memcpy(&child,cp,sizeof(child));
-        if (child == (void*)0x65d1760) count++;
+        memcpy(&child, cp, sizeof(child));
+        if (child == (void *)0x65d1760) count++;
         if (count > 1) exit(1);
         sum += raxTouch(child);
         cp++;

--- a/src/redis/rax.h
+++ b/src/redis/rax.h
@@ -1,6 +1,6 @@
 /* Rax -- A radix tree implementation.
  *
- * Copyright (c) 2017-2018, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2017-2018, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -93,12 +93,13 @@
  * it must be compressed back into a single node.
  *
  */
-#define RAX_NODE_MAX_SIZE ((1<<29)-1)
+
+#define RAX_NODE_MAX_SIZE ((1 << 29) - 1)
 typedef struct raxNode {
-    uint32_t iskey:1;     /* Does this node contain a key? */
-    uint32_t isnull:1;    /* Associated value is NULL (don't store it). */
-    uint32_t iscompr:1;   /* Node is compressed. */
-    uint32_t size:29;     /* Number of children, or compressed string len. */
+    uint32_t iskey : 1;   /* Does this node contain a key? */
+    uint32_t isnull : 1;  /* Associated value is NULL (don't store it). */
+    uint32_t iscompr : 1; /* Node is compressed. */
+    uint32_t size : 29;   /* Number of children, or compressed string len. */
     /* Data layout is as follows:
      *
      * If node is not compressed we have 'size' bytes, one for each children
@@ -130,9 +131,10 @@ typedef struct raxNode {
 } raxNode;
 
 typedef struct rax {
-    raxNode *head;
-    uint64_t numele;
-    uint64_t numnodes;
+    raxNode *head;     /* Pointer to root node of tree */
+    uint64_t numele;   /* Number of keys in the tree */
+    uint64_t numnodes; /* Number of rax nodes in the tree */
+    size_t alloc_size; /* Total allocation size of the tree in bytes */
 } rax;
 
 /* Stack data structure used by raxLowWalk() in order to, optionally, return
@@ -140,7 +142,7 @@ typedef struct rax {
  * field for space concerns, so we use the auxiliary stack when needed. */
 #define RAX_STACK_STATIC_ITEMS 32
 typedef struct raxStack {
-    void **stack; /* Points to static_items or an heap allocated array. */
+    void **stack;           /* Points to static_items or an heap allocated array. */
     size_t items, maxitems; /* Number of items contained and total space. */
     /* Up to RAXSTACK_STACK_ITEMS items we avoid to allocate on the heap
      * and use this static array of pointers instead. */
@@ -158,41 +160,38 @@ typedef struct raxStack {
  * This callback is used to perform very low level analysis of the radix tree
  * structure, scanning each possible node (but the root node), or in order to
  * reallocate the nodes to reduce the allocation fragmentation (this is the
- * Redis application for this callback).
+ * server's application for this callback).
  *
  * This is currently only supported in forward iterations (raxNext) */
 typedef int (*raxNodeCallback)(raxNode **noderef);
 
 /* Radix tree iterator state is encapsulated into this data structure. */
 #define RAX_ITER_STATIC_LEN 128
-#define RAX_ITER_JUST_SEEKED (1<<0) /* Iterator was just seeked. Return current
-                                       element for the first iteration and
-                                       clear the flag. */
-#define RAX_ITER_EOF (1<<1)    /* End of iteration reached. */
-#define RAX_ITER_SAFE (1<<2)   /* Safe iterator, allows operations while
-                                  iterating. But it is slower. */
+#define RAX_ITER_JUST_SEEKED (1 << 0) /* Iterator was just seeked. Return current \
+                                         element for the first iteration and      \
+                                         clear the flag. */
+#define RAX_ITER_EOF (1 << 1)         /* End of iteration reached. */
+#define RAX_ITER_SAFE (1 << 2)        /* Safe iterator, allows operations while \
+                                         iterating. But it is slower. */
 typedef struct raxIterator {
     int flags;
-    rax *rt;                /* Radix tree we are iterating. */
-    unsigned char *key;     /* The current string. */
-    void *data;             /* Data associated to this key. */
-    size_t key_len;         /* Current key length. */
-    size_t key_max;         /* Max key len the current key buffer can hold. */
+    rax *rt;            /* Radix tree we are iterating. */
+    unsigned char *key; /* The current string. */
+    void *data;         /* Data associated to this key. */
+    size_t key_len;     /* Current key length. */
+    size_t key_max;     /* Max key len the current key buffer can hold. */
     unsigned char key_static_string[RAX_ITER_STATIC_LEN];
-    raxNode *node;          /* Current node. Only for unsafe iteration. */
-    raxStack stack;         /* Stack used for unsafe iteration. */
+    raxNode *node;           /* Current node. Only for unsafe iteration. */
+    raxStack stack;          /* Stack used for unsafe iteration. */
     raxNodeCallback node_cb; /* Optional node callback. Normally set to NULL. */
 } raxIterator;
-
-/* A special pointer returned for not found items. */
-extern void *raxNotFound;
 
 /* Exported API. */
 rax *raxNew(void);
 int raxInsert(rax *rax, unsigned char *s, size_t len, void *data, void **old);
 int raxTryInsert(rax *rax, unsigned char *s, size_t len, void *data, void **old);
 int raxRemove(rax *rax, unsigned char *s, size_t len, void **old);
-void *raxFind(rax *rax, unsigned char *s, size_t len);
+int raxFind(rax *rax, unsigned char *s, size_t len, void **value);
 void raxFree(rax *rax);
 void raxFreeWithCallback(rax *rax, void (*free_callback)(void*));
 void raxFreeWithCallbackAndArgument(rax *rax, void (*free_callback)(void*, void*), void* argument);
@@ -206,6 +205,7 @@ void raxStop(raxIterator *it);
 int raxEOF(raxIterator *it);
 void raxShow(rax *rax);
 uint64_t raxSize(rax *rax);
+size_t raxAllocSize(rax *rax);
 unsigned long raxTouch(raxNode *n);
 void raxSetDebugMsg(int onoff);
 

--- a/src/redis/rax_malloc.h
+++ b/src/redis/rax_malloc.h
@@ -1,6 +1,6 @@
 /* Rax -- A radix tree implementation.
  *
- * Copyright (c) 2017, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2017, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -41,4 +41,5 @@
 #define rax_malloc zmalloc
 #define rax_realloc zrealloc
 #define rax_free zfree
+#define rax_ptr_alloc_size zmalloc_size
 #endif

--- a/src/redis/stream.h
+++ b/src/redis/stream.h
@@ -14,18 +14,18 @@ typedef struct redisObject robj;
  * millisecond if the clock jumped backward) will use the millisecond time
  * of the latest generated ID and an incremented sequence. */
 typedef struct streamID {
-    uint64_t ms;        /* Unix time in milliseconds. */
-    uint64_t seq;       /* Sequence number. */
+    uint64_t ms;  /* Unix time in milliseconds. */
+    uint64_t seq; /* Sequence number. */
 } streamID;
 
 typedef struct stream {
-    rax *rax_tree;               /* The radix tree holding the stream. */
-    uint64_t length;        /* Current number of elements inside this stream. */
-    streamID last_id;       /* Zero if there are yet no items. */
-    streamID first_id;      /* The first non-tombstone entry, zero if empty. */
-    streamID max_deleted_entry_id;  /* The maximal ID that was deleted. */
-    uint64_t entries_added; /* All time count of elements added. */
-    rax *cgroups;           /* Consumer groups dictionary: name -> streamCG */
+    struct rax *rax;                      /* The radix tree holding the stream. */
+    uint64_t length;               /* Current number of elements inside this stream. */
+    streamID last_id;              /* Zero if there are yet no items. */
+    streamID first_id;             /* The first non-tombstone entry, zero if empty. */
+    streamID max_deleted_entry_id; /* The maximal ID that was deleted. */
+    uint64_t entries_added;        /* All time count of elements added. */
+    struct rax *cgroups;                  /* Consumer groups dictionary: name -> streamCG */
 } stream;
 
 /* We define an iterator to iterate stream items in an abstract way, without
@@ -79,26 +79,26 @@ typedef struct streamCG {
 
 /* A specific consumer in a consumer group.  */
 typedef struct streamConsumer {
-    mstime_t seen_time;         /* Last time this consumer tried to perform an action (attempted reading/claiming). */
-    mstime_t active_time;       /* Last time this consumer was active (successful reading/claiming). */
-    sds name;                   /* Consumer name. This is how the consumer
-                                   will be identified in the consumer group
-                                   protocol. Case sensitive. */
-    rax *pel;                   /* Consumer specific pending entries list: all
-                                   the pending messages delivered to this
-                                   consumer not yet acknowledged. Keys are
-                                   big endian message IDs, while values are
-                                   the same streamNACK structure referenced
-                                   in the "pel" of the consumer group structure
-                                   itself, so the value is shared. */
+    mstime_t seen_time;   /* Last time this consumer tried to perform an action (attempted reading/claiming). */
+    mstime_t active_time; /* Last time this consumer was active (successful reading/claiming). */
+    sds name;             /* Consumer name. This is how the consumer
+                             will be identified in the consumer group
+                             protocol. Case sensitive. */
+    rax *pel;             /* Consumer specific pending entries list: all
+                             the pending messages delivered to this
+                             consumer not yet acknowledged. Keys are
+                             big endian message IDs, while values are
+                             the same streamNACK structure referenced
+                             in the "pel" of the consumer group structure
+                             itself, so the value is shared. */
 } streamConsumer;
 
 /* Pending (yet not acknowledged) message in a consumer group. */
 typedef struct streamNACK {
-    mstime_t delivery_time;     /* Last time this message was delivered. */
-    uint64_t delivery_count;    /* Number of times this message was delivered.*/
-    streamConsumer *consumer;   /* The consumer this message was delivered to
-                                   in the last delivery. */
+    mstime_t delivery_time;   /* Last time this message was delivered. */
+    uint64_t delivery_count;  /* Number of times this message was delivered.*/
+    streamConsumer *consumer; /* The consumer this message was delivered to
+                                 in the last delivery. */
 } streamNACK;
 
 
@@ -126,9 +126,9 @@ typedef struct {
 // struct client;
 
 /* Flags for streamCreateConsumer */
-#define SCC_DEFAULT       0
-#define SCC_NO_NOTIFY     (1<<0) /* Do not notify key space if consumer created */
-#define SCC_NO_DIRTIFY    (1<<1) /* Do not dirty++ if consumer created */
+#define SCC_DEFAULT 0
+#define SCC_NO_NOTIFY (1 << 0)  /* Do not notify key space if consumer created */
+#define SCC_NO_DIRTIFY (1 << 1) /* Do not dirty++ if consumer created */
 
 #define SCG_INVALID_ENTRIES_READ -1
 #define SCG_INVALID_LAG -1
@@ -139,10 +139,13 @@ typedef struct {
 
 stream *streamNew(void);
 void freeStream(stream *s);
-// size_t streamReplyWithRange(client *c, stream *s, streamID *start, streamID *end, size_t count, int rev, streamCG *group, streamConsumer *consumer, int flags, streamPropInfo *spi);
 void streamIteratorStart(streamIterator *si, stream *s, streamID *start, streamID *end, int rev);
 int streamIteratorGetID(streamIterator *si, streamID *id, int64_t *numfields);
-void streamIteratorGetField(streamIterator *si, unsigned char **fieldptr, unsigned char **valueptr, int64_t *fieldlen, int64_t *valuelen);
+void streamIteratorGetField(streamIterator *si,
+                            unsigned char **fieldptr,
+                            unsigned char **valueptr,
+                            int64_t *fieldlen,
+                            int64_t *valuelen);
 void streamIteratorRemoveEntry(streamIterator *si, streamID *current);
 void streamIteratorStop(streamIterator *si);
 streamCG *streamLookupCG(stream *s, sds groupname);

--- a/src/redis/t_stream.c
+++ b/src/redis/t_stream.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2017, Redis Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,9 +40,9 @@
 /* Every stream item inside the listpack, has a flags field that is used to
  * mark the entry as deleted, or having the same field as the "master"
  * entry at the start of the listpack> */
-#define STREAM_ITEM_FLAG_NONE 0             /* No special flags. */
-#define STREAM_ITEM_FLAG_DELETED (1<<0)     /* Entry is deleted. Skip it. */
-#define STREAM_ITEM_FLAG_SAMEFIELDS (1<<1)  /* Same fields as master entry. */
+#define STREAM_ITEM_FLAG_NONE 0              /* No special flags. */
+#define STREAM_ITEM_FLAG_DELETED (1 << 0)    /* Entry is deleted. Skip it. */
+#define STREAM_ITEM_FLAG_SAMEFIELDS (1 << 1) /* Same fields as primary entry. */
 
 /* For stream commands that require multiple IDs
  * when the number of IDs is less than 'STREAMID_STATIC_VECTOR_LEN',
@@ -57,9 +57,10 @@
  * doing so can lead to an overflow (trying to store more than 32bit length
  * into the listpack header), or actually an assertion since lpInsert
  * will return NULL. */
-#define STREAM_LISTPACK_MAX_SIZE (1<<30)
+#define STREAM_LISTPACK_MAX_SIZE (1 << 30)
 
 void streamFreeCG(streamCG *cg);
+static void streamFreeCGVoid(void *cg);
 void streamFreeNACK(streamNACK *na);
 
 /* -----------------------------------------------------------------------
@@ -69,7 +70,7 @@ void streamFreeNACK(streamNACK *na);
 /* Create a new stream data structure. */
 stream *streamNew(void) {
     stream *s = zmalloc(sizeof(*s));
-    s->rax_tree = raxNew();
+    s->rax = raxNew();
     s->length = 0;
     s->first_id.ms = 0;
     s->first_id.seq = 0;
@@ -82,11 +83,14 @@ stream *streamNew(void) {
     return s;
 }
 
+static void lpFreeVoid(void *lp) {
+    lpFree(lp);
+}
+
 /* Free a stream, including the listpacks stored inside the radix tree. */
 void freeStream(stream *s) {
-    raxFreeWithCallback(s->rax_tree,(void(*)(void*))lpFree);
-    if (s->cgroups)
-        raxFreeWithCallback(s->cgroups,(void(*)(void*))streamFreeCG);
+    raxFreeWithCallback(s->rax, lpFreeVoid);
+    if (s->cgroups) raxFreeWithCallback(s->cgroups, streamFreeCGVoid);
     zfree(s);
 }
 
@@ -138,17 +142,16 @@ int streamDecrID(streamID *id) {
  * fail with an assertion. */
 static inline int64_t lpGetIntegerIfValid(unsigned char *ele, int *valid) {
     int64_t v;
-    unsigned char *e = lpGet(ele,&v,NULL);
+    unsigned char *e = lpGet(ele, &v, NULL);
     if (e == NULL) {
-        if (valid)
-            *valid = 1;
+        if (valid) *valid = 1;
         return v;
     }
     /* The following code path should never be used for how listpacks work:
      * they should always be able to store an int64_t value in integer
      * encoded form. However the implementation may change. */
     long long ll;
-    int ret = string2ll((char*)e,v,&ll);
+    int ret = string2ll((char *)e, v, &ll);
     if (valid)
         *valid = ret;
     else
@@ -222,12 +225,12 @@ int lpGetEdgeStreamID(unsigned char *lp, int first, streamID *master_id, streamI
  * for development and debugging. */
 void streamLogListpackContent(unsigned char *lp) {
     unsigned char *p = lpFirst(lp);
-    while(p) {
+    while (p) {
         unsigned char buf[LP_INTBUF_SIZE];
         int64_t v;
-        unsigned char *ele = lpGet(p,&v,buf);
-        serverLog(LL_WARNING,"- [%d] '%.*s'", (int)v, (int)v, ele);
-        p = lpNext(lp,p);
+        unsigned char *ele = lpGet(p, &v, buf);
+        serverLog(LL_WARNING, "- [%d] '%.*s'", (int)v, (int)v, ele);
+        p = lpNext(lp, p);
     }
 }
 
@@ -237,7 +240,7 @@ void streamEncodeID(void *buf, streamID *id) {
     uint64_t e[2];
     e[0] = htonu64(id->ms);
     e[1] = htonu64(id->seq);
-    memcpy(buf,e,sizeof(e));
+    memcpy(buf, e, sizeof(e));
 }
 
 /* This is the reverse of streamEncodeID(): the decoded ID will be stored
@@ -245,18 +248,22 @@ void streamEncodeID(void *buf, streamID *id) {
  * to a 128 bit big-endian encoded ID. */
 void streamDecodeID(void *buf, streamID *id) {
     uint64_t e[2];
-    memcpy(e,buf,sizeof(e));
+    memcpy(e, buf, sizeof(e));
     id->ms = ntohu64(e[0]);
     id->seq = ntohu64(e[1]);
 }
 
 /* Compare two stream IDs. Return -1 if a < b, 0 if a == b, 1 if a > b. */
 int streamCompareID(streamID *a, streamID *b) {
-    if (a->ms > b->ms) return 1;
-    else if (a->ms < b->ms) return -1;
+    if (a->ms > b->ms)
+        return 1;
+    else if (a->ms < b->ms)
+        return -1;
     /* The ms part is the same. Check the sequence part. */
-    else if (a->seq > b->seq) return 1;
-    else if (a->seq < b->seq) return -1;
+    else if (a->seq > b->seq)
+        return 1;
+    else if (a->seq < b->seq)
+        return -1;
     /* Everything is the same: IDs are equal. */
     return 0;
 }
@@ -264,13 +271,12 @@ int streamCompareID(streamID *a, streamID *b) {
 /* Retrieves the ID of the stream edge entry. An edge is either the first or
  * the last ID in the stream, and may be a tombstone. To filter out tombstones,
  * set the'skip_tombstones' argument to 1. */
-void streamGetEdgeID(stream *s, int first, int skip_tombstones, streamID *edge_id)
-{
+void streamGetEdgeID(stream *s, int first, int skip_tombstones, streamID *edge_id) {
     streamIterator si;
     int64_t numfields;
-    streamIteratorStart(&si,s,NULL,NULL,!first);
+    streamIteratorStart(&si, s, NULL, NULL, !first);
     si.skip_tombstones = skip_tombstones;
-    int found = streamIteratorGetID(&si,edge_id,&numfields);
+    int found = streamIteratorGetID(&si, edge_id, &numfields);
     if (!found) {
         streamID min_id = {0, 0}, max_id = {UINT64_MAX, UINT64_MAX};
         *edge_id = first ? max_id : min_id;
@@ -315,24 +321,21 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
     int64_t limit = args->limit;
     int trim_strategy = args->trim_strategy;
 
-    if (trim_strategy == TRIM_STRATEGY_NONE)
-        return 0;
+    if (trim_strategy == TRIM_STRATEGY_NONE) return 0;
 
     raxIterator ri;
-    raxStart(&ri,s->rax_tree);
-    raxSeek(&ri,"^",NULL,0);
+    raxStart(&ri, s->rax);
+    raxSeek(&ri, "^", NULL, 0);
 
     int64_t deleted = 0;
     while (raxNext(&ri)) {
-        if (trim_strategy == TRIM_STRATEGY_MAXLEN && s->length <= maxlen)
-            break;
+        if (trim_strategy == TRIM_STRATEGY_MAXLEN && s->length <= maxlen) break;
 
         unsigned char *lp = ri.data, *p = lpFirst(lp);
         int64_t entries = lpGetInteger(p);
 
         /* Check if we exceeded the amount of work we could do */
-        if (limit && (deleted + entries) > limit)
-            break;
+        if (limit && (deleted + entries) > limit) break;
 
         /* Check if we can remove the whole node. */
         int remove_node;
@@ -353,7 +356,7 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
 
         if (remove_node) {
             lpFree(lp);
-            checkedRaxRemove(s->rax_tree, ri.key, ri.key_len, NULL);
+            checkedRaxRemove(s->rax, ri.key, ri.key_len, NULL);
             raxSeek(&ri,">=",ri.key,ri.key_len);
             s->length -= entries;
             deleted += entries;
@@ -408,19 +411,18 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
                  * tree is sorted, no point of continuing. */
                 stop = streamCompareID(&currid, id) >= 0;
             }
-            if (stop)
-                break;
+            if (stop) break;
 
             if (flags & STREAM_ITEM_FLAG_SAMEFIELDS) {
                 to_skip = master_fields_count;
             } else {
                 to_skip = lpGetInteger(p); /* Get num-fields. */
-                p = lpNext(lp,p); /* Skip num-fields. */
-                to_skip *= 2; /* Fields and values. */
+                p = lpNext(lp, p);         /* Skip num-fields. */
+                to_skip *= 2;              /* Fields and values. */
             }
 
-            while(to_skip--) p = lpNext(lp,p); /* Skip the whole entry. */
-            p = lpNext(lp,p); /* Skip the final lp-count field. */
+            while (to_skip--) p = lpNext(lp, p); /* Skip the whole entry. */
+            p = lpNext(lp, p);                   /* Skip the final lp-count field. */
 
             /* Mark the entry as deleted. */
             if (!(flags & STREAM_ITEM_FLAG_DELETED)) {
@@ -436,22 +438,22 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
 
         /* Now we update the entries/deleted counters. */
         p = lpFirst(lp);
-        lp = lpReplaceInteger(lp,&p,entries-deleted_from_lp);
-        p = lpNext(lp,p); /* Skip deleted field. */
+        lp = lpReplaceInteger(lp, &p, entries - deleted_from_lp);
+        p = lpNext(lp, p); /* Skip deleted field. */
         int64_t marked_deleted = lpGetInteger(p);
-        lp = lpReplaceInteger(lp,&p,marked_deleted+deleted_from_lp);
-        p = lpNext(lp,p); /* Skip num-of-fields in the master entry. */
+        lp = lpReplaceInteger(lp, &p, marked_deleted + deleted_from_lp);
+        p = lpNext(lp, p); /* Skip num-of-fields in the primary entry. */
 
         /* Here we should perform garbage collection in case at this point
          * there are too many entries deleted inside the listpack. */
         entries -= deleted_from_lp;
         marked_deleted += deleted_from_lp;
-        if (entries + marked_deleted > 10 && marked_deleted > entries/2) {
+        if (entries + marked_deleted > 10 && marked_deleted > entries / 2) {
             /* TODO: perform a garbage collection. */
         }
 
         /* Update the listpack with the new pointer. */
-        raxInsert(s->rax_tree,ri.key,ri.key_len,lp,NULL);
+        raxInsert(s->rax, ri.key, ri.key_len, lp, NULL);
         checkListPackNotEmpty(lp);
 
         break; /* If we are here, there was enough to delete in the current
@@ -464,7 +466,7 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
         s->first_id.ms = 0;
         s->first_id.seq = 0;
     } else if (deleted) {
-        streamGetEdgeID(s,1,1,&s->first_id);
+        streamGetEdgeID(s, 1, 1, &s->first_id);
     }
 
     return deleted;
@@ -472,23 +474,19 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
 
 /* Trims a stream by length. Returns the number of deleted items. */
 int64_t streamTrimByLength(stream *s, long long maxlen, int approx) {
-    streamAddTrimArgs args = {
-        .trim_strategy = TRIM_STRATEGY_MAXLEN,
-        .approx_trim = approx,
-        .limit = approx ? 100 * server.stream_node_max_entries : 0,
-        .maxlen = maxlen
-    };
+    streamAddTrimArgs args = {.trim_strategy = TRIM_STRATEGY_MAXLEN,
+                              .approx_trim = approx,
+                              .limit = approx ? 100 * server.stream_node_max_entries : 0,
+                              .maxlen = maxlen};
     return streamTrim(s, &args);
 }
 
 /* Trims a stream by minimum ID. Returns the number of deleted items. */
 int64_t streamTrimByID(stream *s, streamID minid, int approx) {
-    streamAddTrimArgs args = {
-        .trim_strategy = TRIM_STRATEGY_MINID,
-        .approx_trim = approx,
-        .limit = approx ? 100 * server.stream_node_max_entries : 0,
-        .minid = minid
-    };
+    streamAddTrimArgs args = {.trim_strategy = TRIM_STRATEGY_MINID,
+                              .approx_trim = approx,
+                              .limit = approx ? 100 * server.stream_node_max_entries : 0,
+                              .minid = minid};
     return streamTrim(s, &args);
 }
 
@@ -517,56 +515,56 @@ void streamIteratorStart(streamIterator *si, stream *s, streamID *start, streamI
     /* Initialize the iterator and translates the iteration start/stop
      * elements into a 128 big big-endian number. */
     if (start) {
-        streamEncodeID(si->start_key,start);
+        streamEncodeID(si->start_key, start);
     } else {
         si->start_key[0] = 0;
         si->start_key[1] = 0;
     }
 
     if (end) {
-        streamEncodeID(si->end_key,end);
+        streamEncodeID(si->end_key, end);
     } else {
         si->end_key[0] = UINT64_MAX;
         si->end_key[1] = UINT64_MAX;
     }
 
     /* Seek the correct node in the radix tree. */
-    raxStart(&si->ri,s->rax_tree);
+    raxStart(&si->ri, s->rax);
     if (!rev) {
         if (start && (start->ms || start->seq)) {
-            raxSeek(&si->ri,"<=",(unsigned char*)si->start_key,
-                    sizeof(si->start_key));
-            if (raxEOF(&si->ri)) raxSeek(&si->ri,"^",NULL,0);
+            raxSeek(&si->ri, "<=", (unsigned char *)si->start_key, sizeof(si->start_key));
+            if (raxEOF(&si->ri)) raxSeek(&si->ri, "^", NULL, 0);
         } else {
-            raxSeek(&si->ri,"^",NULL,0);
+            raxSeek(&si->ri, "^", NULL, 0);
         }
     } else {
         if (end && (end->ms || end->seq)) {
-            raxSeek(&si->ri,"<=",(unsigned char*)si->end_key,
-                    sizeof(si->end_key));
-            if (raxEOF(&si->ri)) raxSeek(&si->ri,"$",NULL,0);
+            raxSeek(&si->ri, "<=", (unsigned char *)si->end_key, sizeof(si->end_key));
+            if (raxEOF(&si->ri)) raxSeek(&si->ri, "$", NULL, 0);
         } else {
-            raxSeek(&si->ri,"$",NULL,0);
+            raxSeek(&si->ri, "$", NULL, 0);
         }
     }
     si->stream = s;
-    si->lp = NULL;     /* There is no current listpack right now. */
-    si->lp_ele = NULL; /* Current listpack cursor. */
-    si->rev = rev;     /* Direction, if non-zero reversed, from end to start. */
-    si->skip_tombstones = 1;    /* By default tombstones aren't emitted. */
+    si->lp = NULL;           /* There is no current listpack right now. */
+    si->lp_ele = NULL;       /* Current listpack cursor. */
+    si->rev = rev;           /* Direction, if non-zero reversed, from end to start. */
+    si->skip_tombstones = 1; /* By default tombstones aren't emitted. */
 }
 
 /* Return 1 and store the current item ID at 'id' if there are still
  * elements within the iteration range, otherwise return 0 in order to
  * signal the iteration terminated. */
 int streamIteratorGetID(streamIterator *si, streamID *id, int64_t *numfields) {
-    while(1) { /* Will stop when element > stop_key or end of radix tree. */
+    while (1) { /* Will stop when element > stop_key or end of radix tree. */
         /* If the current listpack is set to NULL, this is the start of the
          * iteration or the previous listpack was completely iterated.
          * Go to the next node. */
         if (si->lp == NULL || si->lp_ele == NULL) {
-            if (!si->rev && !raxNext(&si->ri)) return 0;
-            else if (si->rev && !raxPrev(&si->ri)) return 0;
+            if (!si->rev && !raxNext(&si->ri))
+                return 0;
+            else if (si->rev && !raxPrev(&si->ri))
+                return 0;
             serverAssert(si->ri.key_len == sizeof(streamID));
             /* Get the master ID. */
             streamDecodeID(si->ri.key,&si->master_id);
@@ -598,14 +596,14 @@ int streamIteratorGetID(streamIterator *si, streamID *id, int64_t *numfields) {
              * emitted the current entry, and have to go back to the previous
              * one. */
             int64_t lp_count = lpGetInteger(si->lp_ele);
-            while(lp_count--) si->lp_ele = lpPrev(si->lp,si->lp_ele);
+            while (lp_count--) si->lp_ele = lpPrev(si->lp, si->lp_ele);
             /* Seek lp-count of prev entry. */
-            si->lp_ele = lpPrev(si->lp,si->lp_ele);
+            si->lp_ele = lpPrev(si->lp, si->lp_ele);
         }
 
         /* For every radix tree node, iterate the corresponding listpack,
          * returning elements when they are within range. */
-        while(1) {
+        while (1) {
             if (!si->rev) {
                 /* If we are going forward, skip the previous entry
                  * lp-count field (or in case of the master entry, the zero
@@ -634,11 +632,11 @@ int streamIteratorGetID(streamIterator *si, streamID *id, int64_t *numfields) {
              * ID and this entry ID. */
             *id = si->master_id;
             id->ms += lpGetInteger(si->lp_ele);
-            si->lp_ele = lpNext(si->lp,si->lp_ele);
+            si->lp_ele = lpNext(si->lp, si->lp_ele);
             id->seq += lpGetInteger(si->lp_ele);
-            si->lp_ele = lpNext(si->lp,si->lp_ele);
+            si->lp_ele = lpNext(si->lp, si->lp_ele);
             unsigned char buf[sizeof(streamID)];
-            streamEncodeID(buf,id);
+            streamEncodeID(buf, id);
 
             /* The number of entries is here or not depending on the
              * flags. */
@@ -646,9 +644,9 @@ int streamIteratorGetID(streamIterator *si, streamID *id, int64_t *numfields) {
                 *numfields = si->master_fields_count;
             } else {
                 *numfields = lpGetInteger(si->lp_ele);
-                si->lp_ele = lpNext(si->lp,si->lp_ele);
+                si->lp_ele = lpNext(si->lp, si->lp_ele);
             }
-            serverAssert(*numfields>=0);
+            serverAssert(*numfields >= 0);
 
             /* If current >= start, and the entry is not marked as
              * deleted or tombstones are included, emit it. */
@@ -664,11 +662,9 @@ int streamIteratorGetID(streamIterator *si, streamID *id, int64_t *numfields) {
                     return 1; /* Valid item returned. */
                 }
             } else {
-                if (memcmp(buf,si->end_key,sizeof(streamID)) <= 0 &&
-                    (!si->skip_tombstones || !(flags & STREAM_ITEM_FLAG_DELETED)))
-                {
-                    if (memcmp(buf,si->start_key,sizeof(streamID)) < 0)
-                        return 0; /* We are already out of range. */
+                if (memcmp(buf, si->end_key, sizeof(streamID)) <= 0 &&
+                    (!si->skip_tombstones || !(flags & STREAM_ITEM_FLAG_DELETED))) {
+                    if (memcmp(buf, si->start_key, sizeof(streamID)) < 0) return 0; /* We are already out of range. */
                     si->entry_flags = flags;
                     if (flags & STREAM_ITEM_FLAG_SAMEFIELDS)
                         si->master_fields_ptr = si->master_fields_start;
@@ -680,10 +676,8 @@ int streamIteratorGetID(streamIterator *si, streamID *id, int64_t *numfields) {
              * forward, or seek the previous entry if we are going
              * backward. */
             if (!si->rev) {
-                int64_t to_discard = (flags & STREAM_ITEM_FLAG_SAMEFIELDS) ?
-                                      *numfields : *numfields*2;
-                for (int64_t i = 0; i < to_discard; i++)
-                    si->lp_ele = lpNext(si->lp,si->lp_ele);
+                int64_t to_discard = (flags & STREAM_ITEM_FLAG_SAMEFIELDS) ? *numfields : *numfields * 2;
+                for (int64_t i = 0; i < to_discard; i++) si->lp_ele = lpNext(si->lp, si->lp_ele);
             } else {
                 int64_t prev_times = 4; /* flag + id ms + id seq + one more to
                                            go back to the previous entry "count"
@@ -691,7 +685,7 @@ int streamIteratorGetID(streamIterator *si, streamID *id, int64_t *numfields) {
                 /* If the entry was not flagged SAMEFIELD we also read the
                  * number of fields, so go back one more. */
                 if (!(flags & STREAM_ITEM_FLAG_SAMEFIELDS)) prev_times++;
-                while(prev_times--) si->lp_ele = lpPrev(si->lp,si->lp_ele);
+                while (prev_times--) si->lp_ele = lpPrev(si->lp, si->lp_ele);
             }
         }
 
@@ -710,11 +704,11 @@ void streamIteratorGetField(streamIterator *si, unsigned char **fieldptr, unsign
         *fieldptr = lpGet(si->master_fields_ptr,fieldlen,si->field_buf);
         si->master_fields_ptr = lpNext(si->lp,si->master_fields_ptr);
     } else {
-        *fieldptr = lpGet(si->lp_ele,fieldlen,si->field_buf);
-        si->lp_ele = lpNext(si->lp,si->lp_ele);
+        *fieldptr = lpGet(si->lp_ele, fieldlen, si->field_buf);
+        si->lp_ele = lpNext(si->lp, si->lp_ele);
     }
-    *valueptr = lpGet(si->lp_ele,valuelen,si->value_buf);
-    si->lp_ele = lpNext(si->lp,si->lp_ele);
+    *valueptr = lpGet(si->lp_ele, valuelen, si->value_buf);
+    si->lp_ele = lpNext(si->lp, si->lp_ele);
 }
 
 /* Remove the current entry from the stream: can be called after the
@@ -738,7 +732,7 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
      * We start flagging: */
     int64_t flags = lpGetInteger(si->lp_flags);
     flags |= STREAM_ITEM_FLAG_DELETED;
-    lp = lpReplaceInteger(lp,&si->lp_flags,flags);
+    lp = lpReplaceInteger(lp, &si->lp_flags, flags);
 
     /* Change the valid/deleted entries count in the master entry. */
     unsigned char *p = lpFirst(lp);
@@ -748,17 +742,17 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
         /* If this is the last element in the listpack, we can remove the whole
          * node. */
         lpFree(lp);
-        checkedRaxRemove(si->stream->rax_tree, si->ri.key, si->ri.key_len, NULL);
+        checkedRaxRemove(si->stream->rax, si->ri.key, si->ri.key_len, NULL);
     } else {
         /* In the base case we alter the counters of valid/deleted entries. */
-        lp = lpReplaceInteger(lp,&p,aux-1);
-        p = lpNext(lp,p); /* Seek deleted field. */
+        lp = lpReplaceInteger(lp, &p, aux - 1);
+        p = lpNext(lp, p); /* Seek deleted field. */
         aux = lpGetInteger(p);
-        lp = lpReplaceInteger(lp,&p,aux+1);
+        lp = lpReplaceInteger(lp, &p, aux + 1);
 
         /* Update the listpack with the new pointer. */
         if (si->lp != lp)
-            raxInsert(si->stream->rax_tree,si->ri.key,si->ri.key_len,lp,NULL);
+            raxInsert(si->stream->rax,si->ri.key,si->ri.key_len,lp,NULL);
 
         checkListPackNotEmpty(lp);
     }
@@ -769,14 +763,14 @@ void streamIteratorRemoveEntry(streamIterator *si, streamID *current) {
     /* Re-seek the iterator to fix the now messed up state. */
     streamID start, end;
     if (si->rev) {
-        streamDecodeID(si->start_key,&start);
+        streamDecodeID(si->start_key, &start);
         end = *current;
     } else {
         start = *current;
-        streamDecodeID(si->end_key,&end);
+        streamDecodeID(si->end_key, &end);
     }
     streamIteratorStop(si);
-    streamIteratorStart(si,si->stream,&start,&end,si->rev);
+    streamIteratorStart(si, si->stream, &start, &end, si->rev);
 
     /* TODO: perform a garbage collection here if the ratio between
      * deleted and valid goes over a certain limit. */
@@ -792,14 +786,13 @@ void streamIteratorStop(streamIterator *si) {
 /* Return 1 if `id` exists in `s` (and not marked as deleted) */
 int streamEntryExists(stream *s, streamID *id) {
     streamIterator si;
-    streamIteratorStart(&si,s,id,id,0);
+    streamIteratorStart(&si, s, id, id, 0);
     streamID myid;
     int64_t numfields;
-    int found = streamIteratorGetID(&si,&myid,&numfields);
+    int found = streamIteratorGetID(&si, &myid, &numfields);
     streamIteratorStop(&si);
-    if (!found)
-        return 0;
-    serverAssert(streamCompareID(id,&myid) == 0);
+    if (!found) return 0;
+    serverAssert(streamCompareID(id, &myid) == 0);
     return 1;
 }
 
@@ -808,11 +801,11 @@ int streamEntryExists(stream *s, streamID *id) {
 int streamDeleteItem(stream *s, streamID *id) {
     int deleted = 0;
     streamIterator si;
-    streamIteratorStart(&si,s,id,id,0);
+    streamIteratorStart(&si, s, id, id, 0);
     streamID myid;
     int64_t numfields;
-    if (streamIteratorGetID(&si,&myid,&numfields)) {
-        streamIteratorRemoveEntry(&si,&myid);
+    if (streamIteratorGetID(&si, &myid, &numfields)) {
+        streamIteratorRemoveEntry(&si, &myid);
         deleted = 1;
     }
     streamIteratorStop(&si);
@@ -820,12 +813,11 @@ int streamDeleteItem(stream *s, streamID *id) {
 }
 
 /* Get the last valid (non-tombstone) streamID of 's'. */
-void streamLastValidID(stream *s, streamID *maxid)
-{
+void streamLastValidID(stream *s, streamID *maxid) {
     streamIterator si;
-    streamIteratorStart(&si,s,NULL,NULL,1);
+    streamIteratorStart(&si, s, NULL, NULL, 1);
     int64_t numfields;
-    if (!streamIteratorGetID(&si,maxid,&numfields) && s->length)
+    if (!streamIteratorGetID(&si, maxid, &numfields) && s->length)
         serverPanic("Corrupt stream, length is %llu, but no max id", (unsigned long long)s->length);
     streamIteratorStop(&si);
 }
@@ -868,9 +860,8 @@ int streamRangeHasTombstones(stream *s, streamID *start, streamID *end) {
         end_id.seq = UINT64_MAX;
     }
 
-    if (streamCompareID(&start_id,&s->max_deleted_entry_id) <= 0 &&
-        streamCompareID(&s->max_deleted_entry_id,&end_id) <= 0)
-    {
+    if (streamCompareID(&start_id, &s->max_deleted_entry_id) <= 0 &&
+        streamCompareID(&s->max_deleted_entry_id, &end_id) <= 0) {
         /* start_id <= max_deleted_entry_id <= end_id: The range does include a tombstone. */
         return 1;
     }
@@ -909,11 +900,11 @@ long long streamEstimateDistanceFromFirstEverEntry(stream *s, streamID *id) {
 
     /* In the empty stream, if the ID is smaller or equal to the last ID,
      * it can set to the current added_entries value. */
-    if (!s->length && streamCompareID(id,&s->last_id) < 1) {
+    if (!s->length && streamCompareID(id, &s->last_id) < 1) {
         return s->entries_added;
     }
 
-    int cmp_last = streamCompareID(id,&s->last_id);
+    int cmp_last = streamCompareID(id, &s->last_id);
     if (cmp_last == 0) {
         /* Return the exact counter of the last entry in the stream. */
         return s->entries_added;
@@ -922,8 +913,8 @@ long long streamEstimateDistanceFromFirstEverEntry(stream *s, streamID *id) {
         return SCG_INVALID_ENTRIES_READ;
     }
 
-    int cmp_id_first = streamCompareID(id,&s->first_id);
-    int cmp_xdel_first = streamCompareID(&s->max_deleted_entry_id,&s->first_id);
+    int cmp_id_first = streamCompareID(id, &s->first_id);
+    int cmp_xdel_first = streamCompareID(&s->max_deleted_entry_id, &s->first_id);
     if (streamIDEqZero(&s->max_deleted_entry_id) || cmp_xdel_first < 0) {
         /* There's definitely no fragmentation ahead. */
         if (cmp_id_first < 0) {
@@ -1002,8 +993,8 @@ long long streamCGLag(stream *s, streamCG *cg) {
  *
  * The final argument 'spi' (stream propagation info pointer) is a structure
  * filled with information needed to propagate the command execution to AOF
- * and slaves, in the case a consumer group was passed: we need to generate
- * XCLAIM commands to create the pending list into AOF/slaves in that case.
+ * and replicas, in the case a consumer group was passed: we need to generate
+ * XCLAIM commands to create the pending list into AOF/replicas in that case.
  *
  * If 'spi' is set to NULL no propagation will happen even if the group was
  * given, but currently such a feature is never used by the code base that
@@ -1017,10 +1008,11 @@ long long streamCGLag(stream *s, streamCG *cg) {
  * PEL by ID) to the client. This is the use case for the STREAM_RWR_RAWENTRIES
  * flag.
  */
-#define STREAM_RWR_NOACK (1<<0)         /* Do not create entries in the PEL. */
-#define STREAM_RWR_RAWENTRIES (1<<1)    /* Do not emit protocol for array
-                                           boundaries, just the entries. */
-#define STREAM_RWR_HISTORY (1<<2)       /* Only serve consumer local PEL. */
+#define STREAM_RWR_NOACK (1 << 0) /* Do not create entries in the PEL. */
+#define STREAM_RWR_RAWENTRIES                                         \
+    (1 << 1)                        /* Do not emit protocol for array \
+                                       boundaries, just the entries. */
+#define STREAM_RWR_HISTORY (1 << 2) /* Only serve consumer local PEL. */
 
 
 /* -----------------------------------------------------------------------
@@ -1045,46 +1037,54 @@ void streamFreeConsumer(streamConsumer *sc) {
     zfree(sc);
 }
 
+/* Used for generic free functions. */
+static void streamFreeConsumerVoid(void *sc) {
+    streamFreeConsumer((streamConsumer *)sc);
+}
+
 /* Create a new consumer group in the context of the stream 's', having the
  * specified name, last server ID and reads counter. If a consumer group with
  * the same name already exists NULL is returned, otherwise the pointer to the
  * consumer group is returned. */
 streamCG *streamCreateCG(stream *s, const char *name, size_t namelen, streamID *id, long long entries_read) {
     if (s->cgroups == NULL) s->cgroups = raxNew();
-    if (raxFind(s->cgroups,(unsigned char*)name,namelen) != raxNotFound)
-        return NULL;
+    if (raxFind(s->cgroups, (unsigned char *)name, namelen, NULL)) return NULL;
 
     streamCG *cg = zmalloc(sizeof(*cg));
     cg->pel = raxNew();
     cg->consumers = raxNew();
     cg->last_id = *id;
     cg->entries_read = entries_read;
-    raxInsert(s->cgroups,(unsigned char*)name,namelen,cg,NULL);
+    raxInsert(s->cgroups, (unsigned char *)name, namelen, cg, NULL);
     return cg;
 }
 
 /* Free a consumer group and all its associated data. */
 void streamFreeCG(streamCG *cg) {
-    raxFreeWithCallback(cg->pel,(void(*)(void*))streamFreeNACK);
-    raxFreeWithCallback(cg->consumers,(void(*)(void*))streamFreeConsumer);
+    raxFreeWithCallback(cg->pel, zfree);
+    raxFreeWithCallback(cg->consumers, streamFreeConsumerVoid);
     zfree(cg);
+}
+
+/* Used for generic free functions. */
+static void streamFreeCGVoid(void *cg) {
+    streamFreeCG((streamCG *)cg);
 }
 
 /* Lookup the consumer group in the specified stream and returns its
  * pointer, otherwise if there is no such group, NULL is returned. */
 streamCG *streamLookupCG(stream *s, sds groupname) {
     if (s->cgroups == NULL) return NULL;
-    streamCG *cg = raxFind(s->cgroups,(unsigned char*)groupname,
-                           sdslen(groupname));
-    return (cg == raxNotFound) ? NULL : cg;
+    void *cg = NULL;
+    raxFind(s->cgroups, (unsigned char *)groupname, sdslen(groupname), &cg);
+    return cg;
 }
 
 /* Lookup the consumer with the specified name in the group 'cg' */
 streamConsumer *streamLookupConsumer(streamCG *cg, sds name) {
     if (cg == NULL) return NULL;
-    streamConsumer *consumer = raxFind(cg->consumers,(unsigned char*)name,
-                                       sdslen(name));
-    if (consumer == raxNotFound) return NULL;
+    void *consumer = NULL;
+    raxFind(cg->consumers, (unsigned char *)name, sdslen(name), &consumer);
     return consumer;
 }
 
@@ -1093,18 +1093,17 @@ void streamDelConsumer(streamCG *cg, streamConsumer *consumer) {
     /* Iterate all the consumer pending messages, deleting every corresponding
      * entry from the global entry. */
     raxIterator ri;
-    raxStart(&ri,consumer->pel);
-    raxSeek(&ri,"^",NULL,0);
-    while(raxNext(&ri)) {
+    raxStart(&ri, consumer->pel);
+    raxSeek(&ri, "^", NULL, 0);
+    while (raxNext(&ri)) {
         streamNACK *nack = ri.data;
-        raxRemove(cg->pel,ri.key,ri.key_len,NULL);
+        raxRemove(cg->pel, ri.key, ri.key_len, NULL);
         streamFreeNACK(nack);
     }
     raxStop(&ri);
 
     /* Deallocate the consumer. */
-    raxRemove(cg->consumers,(unsigned char*)consumer->name,
-              sdslen(consumer->name),NULL);
+    raxRemove(cg->consumers, (unsigned char *)consumer->name, sdslen(consumer->name), NULL);
     streamFreeConsumer(consumer);
 }
 
@@ -1118,8 +1117,7 @@ int streamValidateListpackIntegrity(unsigned char *lp, size_t size, int deep) {
 
     /* Since we don't want to run validation of all records twice, we'll
      * run the listpack validation of just the header and do the rest here. */
-    if (!lpValidateIntegrity(lp, size, 0, NULL, NULL))
-        return 0;
+    if (!lpValidateIntegrity(lp, size, 0, NULL, NULL)) return 0;
 
     /* In non-deep mode we just validated the listpack header (encoded size) */
     if (!deep) return 1;
@@ -1131,17 +1129,20 @@ int streamValidateListpackIntegrity(unsigned char *lp, size_t size, int deep) {
     /* entry count */
     int64_t entry_count = lpGetIntegerIfValid(p, &valid_record);
     if (!valid_record) return 0;
-    p = next; if (!lpValidateNext(lp, &next, size)) return 0;
+    p = next;
+    if (!lpValidateNext(lp, &next, size)) return 0;
 
     /* deleted */
     int64_t deleted_count = lpGetIntegerIfValid(p, &valid_record);
     if (!valid_record) return 0;
-    p = next; if (!lpValidateNext(lp, &next, size)) return 0;
+    p = next;
+    if (!lpValidateNext(lp, &next, size)) return 0;
 
     /* num-of-fields */
     int64_t master_fields = lpGetIntegerIfValid(p, &valid_record);
     if (!valid_record) return 0;
-    p = next; if (!lpValidateNext(lp, &next, size)) return 0;
+    p = next;
+    if (!lpValidateNext(lp, &next, size)) return 0;
 
     /* the field names */
     for (int64_t j = 0; j < master_fields; j++) {
@@ -1151,7 +1152,8 @@ int streamValidateListpackIntegrity(unsigned char *lp, size_t size, int deep) {
     /* the zero master entry terminator. */
     int64_t zero = lpGetIntegerIfValid(p, &valid_record);
     if (!valid_record || zero != 0) return 0;
-    p = next; if (!lpValidateNext(lp, &next, size)) return 0;
+    p = next;
+    if (!lpValidateNext(lp, &next, size)) return 0;
 
     entry_count += deleted_count;
     while (entry_count--) {
@@ -1159,25 +1161,30 @@ int streamValidateListpackIntegrity(unsigned char *lp, size_t size, int deep) {
         int64_t fields = master_fields, extra_fields = 3;
         int64_t flags = lpGetIntegerIfValid(p, &valid_record);
         if (!valid_record) return 0;
-        p = next; if (!lpValidateNext(lp, &next, size)) return 0;
+        p = next;
+        if (!lpValidateNext(lp, &next, size)) return 0;
 
         /* entry id */
         lpGetIntegerIfValid(p, &valid_record);
         if (!valid_record) return 0;
-        p = next; if (!lpValidateNext(lp, &next, size)) return 0;
+        p = next;
+        if (!lpValidateNext(lp, &next, size)) return 0;
         lpGetIntegerIfValid(p, &valid_record);
         if (!valid_record) return 0;
-        p = next; if (!lpValidateNext(lp, &next, size)) return 0;
+        p = next;
+        if (!lpValidateNext(lp, &next, size)) return 0;
 
         if (!(flags & STREAM_ITEM_FLAG_SAMEFIELDS)) {
             /* num-of-fields */
             fields = lpGetIntegerIfValid(p, &valid_record);
             if (!valid_record) return 0;
-            p = next; if (!lpValidateNext(lp, &next, size)) return 0;
+            p = next;
+            if (!lpValidateNext(lp, &next, size)) return 0;
 
             /* the field names */
             for (int64_t j = 0; j < fields; j++) {
-                p = next; if (!lpValidateNext(lp, &next, size)) return 0;
+                p = next;
+                if (!lpValidateNext(lp, &next, size)) return 0;
             }
 
             extra_fields += fields + 1;
@@ -1185,19 +1192,19 @@ int streamValidateListpackIntegrity(unsigned char *lp, size_t size, int deep) {
 
         /* the values */
         for (int64_t j = 0; j < fields; j++) {
-            p = next; if (!lpValidateNext(lp, &next, size)) return 0;
+            p = next;
+            if (!lpValidateNext(lp, &next, size)) return 0;
         }
 
         /* lp-count */
         int64_t lp_count = lpGetIntegerIfValid(p, &valid_record);
         if (!valid_record) return 0;
         if (lp_count != fields + extra_fields) return 0;
-        p = next; if (!lpValidateNext(lp, &next, size)) return 0;
+        p = next;
+        if (!lpValidateNext(lp, &next, size)) return 0;
     }
 
-    if (next)
-        return 0;
+    if (next) return 0;
 
     return 1;
 }
-

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -743,7 +743,7 @@ void RdbLoaderBase::OpaqueObjLoader::CreateStream(const LoadTrace* ltrace) {
     ::memcpy(copy_lp, lp, data.size());
     /* Insert the key in the radix tree. */
     int retval =
-        raxTryInsert(s->rax_tree, (unsigned char*)nodekey.data(), nodekey.size(), copy_lp, NULL);
+        raxTryInsert(s->rax, (unsigned char*)nodekey.data(), nodekey.size(), copy_lp, NULL);
     if (!retval) {
       zfree(copy_lp);
       LOG(ERROR) << "Listpack re-added with existing key";
@@ -823,8 +823,9 @@ void RdbLoaderBase::OpaqueObjLoader::CreateStream(const LoadTrace* ltrace) {
        * consumer. */
       for (const auto& rawid : cons.nack_arr) {
         uint8_t* ptr = const_cast<uint8_t*>(rawid.data());
-        streamNACK* nack = (streamNACK*)raxFind(cgroup->pel, ptr, rawid.size());
-        if (nack == raxNotFound) {
+        streamNACK* nack = nullptr;
+        int fres = raxFind(cgroup->pel, ptr, rawid.size(), (void**)&nack);
+        if (fres == 0) {
           LOG(ERROR) << "Consumer entry not found in group global PEL";
           ec_ = RdbError(errc::rdb_file_corrupted);
           return;

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -526,9 +526,7 @@ error_code RdbSerializer::SaveZSetObject(const PrimeValue& pv) {
 error_code RdbSerializer::SaveStreamObject(const PrimeValue& pv) {
   /* Store how many listpacks we have inside the radix tree. */
   stream* s = (stream*)pv.RObjPtr();
-  rax* rax = s->rax_tree;
-
-  const size_t rax_size = raxSize(rax);
+  const size_t rax_size = raxSize(s->rax);
 
   RETURN_ON_ERR(SaveLen(rax_size));
 
@@ -536,7 +534,7 @@ error_code RdbSerializer::SaveStreamObject(const PrimeValue& pv) {
    * when loading back, we'll use the first entry of each listpack
    * to insert it back into the radix tree. */
   raxIterator ri;
-  raxStart(&ri, rax);
+  raxStart(&ri, s->rax);
   raxSeek(&ri, "^", NULL, 0);
 
   auto stop_listpacks_rax = absl::MakeCleanup([&] { raxStop(&ri); });

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -425,7 +425,7 @@ int StreamAppendItem(stream* s, CmdArgList fields, uint64_t now_ms, streamID* ad
 
   /* Add the new entry. */
   raxIterator ri;
-  raxStart(&ri, s->rax_tree);
+  raxStart(&ri, s->rax);
   raxSeek(&ri, "$", NULL, 0);
 
   size_t lp_bytes = 0;      /* Total bytes in the tail listpack. */
@@ -500,7 +500,7 @@ int StreamAppendItem(stream* s, CmdArgList fields, uint64_t now_ms, streamID* ad
       /* Shrink extra pre-allocated memory */
       lp = lpShrinkToFit(lp);
       if (ri.data != lp)
-        raxInsert(s->rax_tree, ri.key, ri.key_len, lp, NULL);
+        raxInsert(s->rax, ri.key, ri.key_len, lp, NULL);
       lp = NULL;
     }
   }
@@ -528,7 +528,7 @@ int StreamAppendItem(stream* s, CmdArgList fields, uint64_t now_ms, streamID* ad
       lp = lpAppend(lp, SafePtr(field), field.size());
     }
     lp = lpAppendInteger(lp, 0); /* Master entry zero terminator. */
-    raxInsert(s->rax_tree, (unsigned char*)&rax_key, sizeof(rax_key), lp, NULL);
+    raxInsert(s->rax, (unsigned char*)&rax_key, sizeof(rax_key), lp, NULL);
     // TODO remove this check
     CHECK_GT(lpBytes(lp), 0U);
     /* The first entry we insert, has obviously the same fields of the
@@ -616,7 +616,7 @@ int StreamAppendItem(stream* s, CmdArgList fields, uint64_t now_ms, streamID* ad
 
   /* Insert back into the tree in order to update the listpack pointer. */
   if (ri.data != lp) {
-    raxInsert(s->rax_tree, (unsigned char*)&rax_key, sizeof(rax_key), lp, NULL);
+    raxInsert(s->rax, (unsigned char*)&rax_key, sizeof(rax_key), lp, NULL);
     // TODO remove this
     CHECK_GT(lpBytes(lp), 0U);
   }
@@ -842,8 +842,8 @@ OpResult<RecordVec> OpRange(const OpArgs& op_args, string_view key, const RangeO
        * or update it if the consumer is the same as before. */
       if (group_inserted == 0) {
         streamFreeNACK(nack);
-        nack = static_cast<streamNACK*>(raxFind(opts.group->pel, buf, sizeof(buf)));
-        DCHECK(nack != raxNotFound);
+        int fres = raxFind(opts.group->pel, buf, sizeof(buf), (void**)&nack);
+        DCHECK(fres);
         raxRemove(nack->consumer->pel, buf, sizeof(buf), NULL);
         LOG_IF(DFATAL, nack->consumer->pel->numnodes == 0) << "Invalid rax state";
 
@@ -1118,8 +1118,8 @@ OpResult<StreamInfo> OpStreams(const DbContext& db_cntx, string_view key, Engine
   StreamInfo sinfo;
   sinfo.length = s->length;
 
-  sinfo.radix_tree_keys = raxSize(s->rax_tree);
-  sinfo.radix_tree_nodes = s->rax_tree->numnodes;
+  sinfo.radix_tree_keys = raxSize(s->rax);
+  sinfo.radix_tree_nodes = s->rax->numnodes;
   sinfo.last_generated_id = s->last_id;
   sinfo.max_deleted_entry_id = s->max_deleted_entry_id;
   sinfo.entries_added = s->entries_added;
@@ -1362,9 +1362,10 @@ OpResult<ClaimInfo> OpClaim(const OpArgs& op_args, string_view key, const ClaimO
     std::array<uint8_t, sizeof(streamID)> buf;
     StreamEncodeID(buf.begin(), &id);
 
-    streamNACK* nack = (streamNACK*)raxFind(cgr_res->cg->pel, buf.begin(), sizeof(buf));
+    streamNACK* nack = nullptr;
+    int fres = raxFind(cgr_res->cg->pel, buf.begin(), sizeof(buf), (void**)&nack);
     if (!streamEntryExists(cgr_res->s, &id)) {
-      if (nack != raxNotFound) {
+      if (fres) {
         /* Release the NACK */
         raxRemove(cgr_res->cg->pel, buf.begin(), sizeof(buf), nullptr);
         raxRemove(nack->consumer->pel, buf.begin(), sizeof(buf), nullptr);
@@ -1376,14 +1377,14 @@ OpResult<ClaimInfo> OpClaim(const OpArgs& op_args, string_view key, const ClaimO
 
     // We didn't find a nack but the FORCE option is given.
     // Create the NACK forcefully.
-    if ((opts.flags & kClaimForce) && nack == raxNotFound) {
+    if ((opts.flags & kClaimForce) && fres == 0) {
       /* Create the NACK. */
       nack = StreamCreateNACK(nullptr, now_ms);
       raxInsert(cgr_res->cg->pel, buf.begin(), sizeof(buf), nack, nullptr);
     }
 
     // We found the nack, continue.
-    if (nack != raxNotFound) {
+    if (nack) {
       // First check if the entry id exceeds the `min_idle_time`.
       if (nack->consumer && opts.min_idle_time) {
         mstime_t this_idle = now_ms - nack->delivery_time;
@@ -1627,8 +1628,9 @@ OpResult<uint32_t> OpAck(const OpArgs& op_args, string_view key, string_view gna
     // Lookup the ID in the group PEL: it will have a reference to the
     // NACK structure that will have a reference to the consumer, so that
     // we are able to remove the entry from both PELs.
-    streamNACK* nack = (streamNACK*)raxFind(res->cg->pel, buf, sizeof(buf));
-    if (nack != raxNotFound) {
+    streamNACK* nack = nullptr;
+    int fres = raxFind(res->cg->pel, buf, sizeof(buf), (void**)&nack);
+    if (fres) {
       raxRemove(res->cg->pel, buf, sizeof(buf), nullptr);
       raxRemove(nack->consumer->pel, buf, sizeof(buf), nullptr);
       streamFreeNACK(nack);


### PR DESCRIPTION
Update rax (radix tree) and stream implementations with latest Valkey
changes. I synced only **non-functional** changes (whitespace, some field renames and change of raxFind interface).
- Reformat code for consistency (spacing, alignment)
- Update copyright headers to Redis Ltd.
- Replace raxNotFound sentinel with int return value in raxFind()
- Add alloc_size tracking to rax struct
- Rename stream.rax_tree to stream.rax

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->