### PR TITLE
chore: add tiering params and stats to qlist

### DIFF
--- a/src/core/qlist_test.cc
+++ b/src/core/qlist_test.cc
@@ -409,6 +409,15 @@ TEST_F(QListTest, DefragmentListpackCompressed) {
   ASSERT_EQ(i, total_items);
 }
 
+TEST_F(QListTest, Tiering) {
+  QList::stats.offload_requests = 0;
+  ql_.SetTieringParams(QList::TieringParams{.node_depth_threshold = 1});
+  for (int i = 0; i < 8000; i++) {
+    ql_.Push(absl::StrCat("value", i), QList::TAIL);
+  }
+  EXPECT_EQ(QList::stats.offload_requests, 9);
+}
+
 using FillCompress = tuple<int, unsigned, QList::COMPR_METHOD>;
 
 class PrintToFillCompress {


### PR DESCRIPTION
Add infrastructure for tracking node access patterns and preparing for
tiered storage offloading:
- Add TieringParams to configure offloading thresholds
- Track node_id in Iterator and propagate through insert/update paths
- Add CoolOff() method to evaluate compression and potential offloading
- Rename TryDecompress to TryDecompressInternal for clarity
- Add stats for middle node reads and offloading requests

Known issues requiring follow-up:
- node_id tracking incorrect in InsertNode BEFORE case (line 704)
- node_id unknown in ListpackMerge, hardcoded to 0 (line 1027)
- node_id may be incorrect after merges in Replace (lines 858-860)

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->