### PR TITLE
chore: add more invariant checks for streams (#6459)

### DIFF
--- a/src/redis/t_stream.c
+++ b/src/redis/t_stream.c
@@ -331,7 +331,9 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
     while (raxNext(&ri)) {
         if (trim_strategy == TRIM_STRATEGY_MAXLEN && s->length <= maxlen) break;
 
-        unsigned char *lp = ri.data, *p = lpFirst(lp);
+        unsigned char *lp = ri.data;
+        checkListPackNotEmpty(lp);
+        unsigned char *p = lpFirst(lp);
         int64_t entries = lpGetInteger(p);
 
         /* Check if we exceeded the amount of work we could do */

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -353,9 +353,9 @@ void StreamNextID(uint64_t now_ms, const streamID* last_id, streamID* new_id) {
 
 /* Convert the specified stream entry ID as a 128 bit big endian number, so
  * that the IDs can be sorted lexicographically. */
-inline void StreamEncodeID(uint8_t* buf, streamID* id) {
-  absl::big_endian::Store64(buf, id->ms);
-  absl::big_endian::Store64(buf + 8, id->seq);
+inline void StreamEncodeID(uint8_t* buf, const streamID& id) {
+  absl::big_endian::Store64(buf, id.ms);
+  absl::big_endian::Store64(buf + 8, id.seq);
 }
 
 /* Adds a new item into the stream 's' having the specified number of
@@ -431,19 +431,20 @@ int StreamAppendItem(stream* s, CmdArgList fields, uint64_t now_ms, streamID* ad
   size_t lp_bytes = 0;      /* Total bytes in the tail listpack. */
   unsigned char* lp = NULL; /* Tail listpack pointer. */
 
-  if (!raxEOF(&ri)) {
-    /* Get a reference to the tail node listpack. */
-    lp = (uint8_t*)ri.data;
-    lp_bytes = lpBytes(lp);
-    CHECK_GT(lp_bytes, 0U);
-  }
-  raxStop(&ri);
-
   /* We have to add the key into the radix tree in lexicographic order,
    * to do so we consider the ID as a single 128 bit number written in
    * big endian, so that the most significant bytes are the first ones. */
   uint8_t rax_key[16]; /* Key in the radix tree containing the listpack.*/
   streamID master_id;  /* ID of the master entry in the listpack. */
+
+  if (!raxEOF(&ri)) {
+    /* Get a reference to the tail node listpack. */
+    lp = (uint8_t*)ri.data;
+    lp_bytes = lpBytes(lp);
+    CHECK_GT(lp_bytes, 0U);
+    DCHECK(ri.key_len == sizeof(rax_key));
+    memcpy(rax_key, ri.key, sizeof(rax_key));
+  }
 
   /* Create a new listpack and radix tree node if needed. Note that when
    * a new listpack is created, we populate it with a "master entry". This
@@ -499,6 +500,9 @@ int StreamAppendItem(stream* s, CmdArgList fields, uint64_t now_ms, streamID* ad
     if (new_node) {
       /* Shrink extra pre-allocated memory */
       lp = lpShrinkToFit(lp);
+      if (ri.key_len != sizeof(rax_key) || memcmp(ri.key, rax_key, sizeof(rax_key)) != 0) {
+        LOG(DFATAL) << "StreamAppendItem: Key mismatch";
+      }
       if (ri.data != lp)
         raxInsert(s->rax, ri.key, ri.key_len, lp, NULL);
       lp = NULL;
@@ -507,9 +511,10 @@ int StreamAppendItem(stream* s, CmdArgList fields, uint64_t now_ms, streamID* ad
 
   int flags = 0;
   unsigned numfields = fields.size() / 2;
+  uint8_t* old_lp = lp;
   if (lp == NULL) {
     master_id = id;
-    StreamEncodeID(rax_key, &id);
+    StreamEncodeID(rax_key, id);
     /* Create the listpack having the master entry ID and fields.
      * Pre-allocate some bytes when creating listpack to avoid realloc on
      * every XADD. Since listpack.c uses malloc_size, it'll grow in steps,
@@ -529,14 +534,14 @@ int StreamAppendItem(stream* s, CmdArgList fields, uint64_t now_ms, streamID* ad
     }
     lp = lpAppendInteger(lp, 0); /* Master entry zero terminator. */
     raxInsert(s->rax, (unsigned char*)&rax_key, sizeof(rax_key), lp, NULL);
-    // TODO remove this check
-    CHECK_GT(lpBytes(lp), 0U);
+    old_lp = lp;
     /* The first entry we insert, has obviously the same fields of the
      * master entry. */
     flags |= STREAM_ITEM_FLAG_SAMEFIELDS;
-  } else {
-    serverAssert(ri.key_len == sizeof(rax_key));
-    memcpy(rax_key, ri.key, sizeof(rax_key));
+  } else {  // lp != NULL
+    if (ri.key_len != sizeof(rax_key) || memcmp(ri.key, rax_key, sizeof(rax_key)) != 0) {
+      LOG(DFATAL) << "StreamAppendItem: Key mismatch";
+    }
 
     /* Read the master ID from the radix tree key. */
     streamDecodeID(rax_key, &master_id);
@@ -615,14 +620,19 @@ int StreamAppendItem(stream* s, CmdArgList fields, uint64_t now_ms, streamID* ad
   lp = lpAppendInteger(lp, lp_count);
 
   /* Insert back into the tree in order to update the listpack pointer. */
-  if (ri.data != lp) {
+  if (old_lp != lp) {
     raxInsert(s->rax, (unsigned char*)&rax_key, sizeof(rax_key), lp, NULL);
-    // TODO remove this
-    CHECK_GT(lpBytes(lp), 0U);
   }
   s->length++;
   s->entries_added++;
   s->last_id = id;
+
+  // Must find the last entry as we just inserted it.
+  CHECK_EQ(1, raxSeek(&ri, "$", NULL, 0));
+  lp_bytes = lpBytes((uint8_t*)ri.data);
+  CHECK_GT(lp_bytes, 0U);
+  raxStop(&ri);
+
   if (s->length == 1)
     s->first_id = id;
   if (added_id)
@@ -826,7 +836,7 @@ OpResult<RecordVec> OpRange(const OpArgs& op_args, string_view key, const RangeO
 
     if (opts.group && !opts.noack) {
       unsigned char buf[sizeof(streamID)];
-      StreamEncodeID(buf, &id);
+      StreamEncodeID(buf, id);
       uint64_t now_ms = op_args.db_cntx.time_now_ms;
 
       /* Try to add a new NACK. Most of the time this will work and
@@ -880,8 +890,8 @@ OpResult<RecordVec> OpRangeFromConsumerPEL(const OpArgs& op_args, string_view ke
   auto sstart = opts.start.val;
   auto send = opts.end.val;
 
-  StreamEncodeID(start_key, &sstart);
-  StreamEncodeID(end_key, &send);
+  StreamEncodeID(start_key, sstart);
+  StreamEncodeID(end_key, send);
   raxIterator ri;
 
   raxStart(&ri, opts.consumer->pel);
@@ -1360,7 +1370,7 @@ OpResult<ClaimInfo> OpClaim(const OpArgs& op_args, string_view key, const ClaimO
 
   for (streamID id : ids) {
     std::array<uint8_t, sizeof(streamID)> buf;
-    StreamEncodeID(buf.begin(), &id);
+    StreamEncodeID(buf.begin(), id);
 
     streamNACK* nack = nullptr;
     int fres = raxFind(cgr_res->cg->pel, buf.begin(), sizeof(buf), (void**)&nack);
@@ -1551,6 +1561,17 @@ ErrorReply OpXSetId(const OpArgs& op_args, string_view key, const streamID& sid)
   }
 
   stream_inst->last_id = sid;
+  raxIterator ri;
+  raxStart(&ri, stream_inst->rax);
+  raxSeek(&ri, "$", NULL, 0);
+
+  if (!raxEOF(&ri)) {
+    /* Get a reference to the tail node listpack. */
+    size_t lp_bytes = lpBytes((uint8_t*)ri.data);
+    CHECK_GT(lp_bytes, 0U);
+  }
+  raxStop(&ri);
+
   if (entries_added != -1)
     stream_inst->entries_added = entries_added;
   if (!streamIDEqZero(&max_xdel_id))
@@ -1622,7 +1643,7 @@ OpResult<uint32_t> OpAck(const OpArgs& op_args, string_view key, string_view gna
   StreamMemTracker mem_tracker;
   for (auto& id : ids) {
     unsigned char buf[sizeof(streamID)];
-    streamEncodeID(buf, &id);
+    StreamEncodeID(buf, id);
 
     // From Redis' xackCommand's implemenation
     // Lookup the ID in the group PEL: it will have a reference to the
@@ -1662,7 +1683,7 @@ OpResult<ClaimInfo> OpAutoClaim(const OpArgs& op_args, string_view key, const Cl
 
   unsigned char start_key[sizeof(streamID)];
   streamID start_id = opts.start;
-  streamEncodeID(start_key, &start_id);
+  StreamEncodeID(start_key, start_id);
   raxIterator ri;
   raxStart(&ri, group->pel);
   raxSeek(&ri, ">=", start_key, sizeof(start_key));
@@ -1810,8 +1831,8 @@ PendingExtendedResultList GetPendingExtendedResult(uint64_t now_ms, streamCG* cg
   unsigned char end_key[sizeof(streamID)];
   raxIterator ri;
 
-  StreamEncodeID(start_key, &sstart);
-  StreamEncodeID(end_key, &send);
+  StreamEncodeID(start_key, sstart);
+  StreamEncodeID(end_key, send);
   raxStart(&ri, pel);
   raxSeek(&ri, ">=", start_key, sizeof(start_key));
 


### PR DESCRIPTION
1. Check rax validity in more places in stream_family.cc
2. Cover streamTrim function and check lp validity  following the assert-fail in the tests.
3. Move raxStop to bottop of StreamAppendItem function though it's not clear that raxStop can
   actually cause the bug as ri.key is always 16 bytes and is never allocated on heap.

Addresses https://github.com/dragonflydb/dragonfly/issues/6409 though not necessary fixes it.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->