### PR TITLE
[DRAFT] test: reproduce stale iterator bug in stream XADD (issue #6409)

### DIFF
--- a/src/redis/rax.c
+++ b/src/redis/rax.c
@@ -1787,6 +1787,10 @@ int raxCompare(raxIterator *iter, const char *op, unsigned char *key, size_t key
 void raxStop(raxIterator *it) {
     if (it->key != it->key_static_string) rax_free(it->key);
     raxStackFree(&it->stack);
+
+    /* TEMPORARY: Poison pointers to detect use-after-stop bugs (issue #6409) */
+    it->key = NULL;
+    it->data = NULL;
 }
 
 /* Return if the iterator is in an EOF state. This happens when raxSeek()

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -1318,4 +1318,11 @@ TEST_F(StreamFamilyTest, XDelNonExistentId) {
   EXPECT_THAT(resp, IntArg(0));  // Nothing deleted
 }
 
+// Minimal test to reproduce stale iterator bug (issue #6409)
+// After raxStop(), code at line 539 uses stale ri.key causing segfault.
+TEST_F(StreamFamilyTest, StaleIteratorBug) {
+  Run({"xadd", "s", "*", "f", "v1"});  // Creates first entry
+  Run({"xadd", "s", "*", "f", "v2"});  // Bug: uses ri.key after raxStop()
+}
+
 }  // namespace dfly


### PR DESCRIPTION
This PR adds reproduction for the stale iterator bug that causes rare crashes in CI.

The bug: after raxStop() frees ri.key at line 440 in StreamAppendItem(), the code continues to use ri.key. This is use-after-free.

To detect this bug, I added NULL poisoning in raxStop() - it sets it->key and it->data to NULL after freeing. This makes the bug crash immediately instead of corrupting data silently.

Without NULL poisoning, the bug reads freed memory, which still contains "valid-looking" data, so raxInsert() succeeds but stores the pointer at the wrong key in the rax tree. Much later, another operation reads the correct key and gets a stale pointer, leading to the assertion failure in lpValidateNext().

With NULL poisoning, the bug crashes immediately at line 539 with SIGSEGV when trying to dereference NULL. The stack trace points directly to the root cause.

The minimal test is just 2 XADD operations - the second one crashes every time.

This PR only reproduces the issue. The actual fix will save ri.key before raxStop() and use the saved value afterwards.

BTW, the Dragonfly test set has other test crashes after this poisoning.

Related to #6409

```
*** SIGSEGV received at time=1769617731 on cpu 0 ***
PC: @     0x62eaf8ffb7f4  (unknown)  dfly::(anonymous namespace)::StreamAppendItem()
    @     0x62eafb7936b0         80  absl::lts_20250512::WriteFailureInfo()
    @     0x62eafb7939cd        112  absl::lts_20250512::AbslFailureSignalHandler()
    @     0x79e7562d3330       2608  (unknown)
    @     0x62eaf8ffd852        912  dfly::(anonymous namespace)::OpAdd()
    @     0x62eaf902714d        176  dfly::CmdXAdd()::{lambda()#1}::operator()()
    @     0x62eaf9055bdc         96  dfly::Transaction::ScheduleSingleHopT<>()::{lambda()#1}::operator()()
    @     0x62eaf908bf35         80  std::__invoke_impl<>()
    @     0x62eaf908734d         64  std::__invoke<>()
    @     0x62eaf907f862         64  std::invoke<>()
    @     0x62eaf907596c        112  absl::lts_20250512::functional_internal::InvokeObject<>()
    @     0x62eafa6a1c90         80  absl::lts_20250512::FunctionRef<>::operator()()
    @     0x62eafa66ce54        240  dfly::Transaction::RunCallback()
    @     0x62eafa67acdd        400  dfly::Transaction::ScheduleInShard()
    @     0x62eafa66ffa5        320  dfly::Transaction::ScheduleInternal()
    @     0x62eafa673d70         64  dfly::Transaction::Execute()
    @     0x62eafa6724a8         48  dfly::Transaction::ScheduleSingleHop()
    @     0x62eaf9055ebf        128  dfly::Transaction::ScheduleSingleHopT<>()
    @     0x62eaf9027b2d        480  dfly::CmdXAdd()
    @     0x62eaf8ce482d         80  fu2::abi_400::detail::invocation::invoke<>()
    @     0x62eaf8ce075f         96  fu2::abi_400::detail::type_erasure::invocation_table::function_trait<>::internal_invoker<>::invoke()
    @     0x62eaf973fb79        128  fu2::abi_400::detail::type_erasure::tables::vtable<>::invoke<>()
    @     0x62eaf973fdc8        112  fu2::abi_400::detail::type_erasure::erasure<>::invoke<>()
    @     0x62eaf973fecb         80  fu2::abi_400::detail::type_erasure::invocation_table::operator_impl<>::operator()()
    @     0x62eaf9733e72         48  dfly::CommandId::Invoke()
    @     0x62eaf966e80c        464  dfly::Service::InvokeCmd()
    @     0x62eaf966d018        528  dfly::Service::DispatchCommand()
    @     0x62eaf85d2c0c        656  dfly::BaseFamilyTest::Run()
    @     0x62eaf85d0e0e        160  dfly::BaseFamilyTest::Run()
    @     0x62eaf85d0963         80  dfly::BaseFamilyTest::Run()::{lambda()#1}::operator()()
    @     0x62eaf85e5f82         96  util::detail::ResultMover<>::Apply<>()
    @     0x62eaf85e07c3         48  util::fb2::ProactorBase::Await<>()::{lambda()#1}::operator()()
    @     0x62eaf86260bd         48  std::__invoke_impl<>()
    @ ... and at least 11 more frames
```