### PR TITLE
fix: prevent connected_clients counter leak on replica connection migration

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -630,11 +630,7 @@ void Connection::OnPreMigrateThread() {
   socket_->CancelOnErrorCb();
   DCHECK(!async_fb_.IsJoinable()) << GetClientId();
 
-  // Decrement connection counter on the old thread before migration.
-  // This balances the IncrNumConns() that was called in ConnectionFlow().
-  // OnPostMigrateThread() will increment it again on the new thread.
-  DecrNumConns();
-  stats_->read_buf_capacity -= io_buf_.Capacity();
+  DecreaseConnStats();
 }
 
 void Connection::OnPostMigrateThread() {
@@ -662,8 +658,7 @@ void Connection::OnPostMigrateThread() {
   }
 
   stats_ = &tl_facade_stats->conn_stats;
-  IncrNumConns();
-  stats_->read_buf_capacity += io_buf_.Capacity();
+  IncreaseConnStats();
 }
 
 void Connection::OnConnectionStart() {
@@ -1004,9 +999,8 @@ io::Result<bool> Connection::CheckForHttpProto() {
 void Connection::ConnectionFlow() {
   DCHECK(reply_builder_);
 
-  IncrNumConns();
+  IncreaseConnStats();
   ++stats_->conn_received_cnt;
-  stats_->read_buf_capacity += io_buf_.Capacity();
 
   ++local_stats_.read_cnt;
   local_stats_.net_bytes_in += io_buf_.InputLen();
@@ -1063,7 +1057,7 @@ void Connection::ConnectionFlow() {
   DCHECK(!HasPendingMessages());
 
   service_->OnConnectionClose(cc_.get());
-  DecreaseStatsOnClose();
+  DecreaseConnStats();
 
   if (ioloop_v2_) {
     socket_->ResetOnRecvHook();
@@ -1299,8 +1293,6 @@ void Connection::HandleMigrateRequest() {
 
     stats_->num_migrations++;
     migration_request_ = nullptr;
-
-    DecreaseStatsOnClose();
 
     // We need to return early as the socket is closing and IoLoop will clean up.
     // The reason that this is true is because of the following DCHECK
@@ -2047,9 +2039,20 @@ Connection::MemoryUsage Connection::GetMemoryUsage() const {
   };
 }
 
-void Connection::DecreaseStatsOnClose() {
+void Connection::IncreaseConnStats() {
+  if (IsMainOrMemcache())
+    ++stats_->num_conns_main;
+  else
+    ++stats_->num_conns_other;
+  stats_->read_buf_capacity += io_buf_.Capacity();
+}
+
+void Connection::DecreaseConnStats() {
+  if (IsMainOrMemcache())
+    --stats_->num_conns_main;
+  else
+    --stats_->num_conns_other;
   stats_->read_buf_capacity -= io_buf_.Capacity();
-  DecrNumConns();
 }
 
 void Connection::BreakOnce(uint32_t ev_mask) {
@@ -2059,20 +2062,6 @@ void Connection::BreakOnce(uint32_t ev_mask) {
     DCHECK(!breaker_cb_);
     fun(ev_mask);
   }
-}
-
-void Connection::IncrNumConns() {
-  if (IsMainOrMemcache())
-    ++stats_->num_conns_main;
-  else
-    ++stats_->num_conns_other;
-}
-
-void Connection::DecrNumConns() {
-  if (IsMainOrMemcache())
-    --stats_->num_conns_main;
-  else
-    --stats_->num_conns_other;
 }
 
 bool Connection::IsReplySizeOverLimit() const {

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -325,7 +325,8 @@ class Connection : public util::Connection {
 
   std::pair<std::string, std::string> GetClientInfoBeforeAfterTid() const;
 
-  void DecreaseStatsOnClose();
+  void IncreaseConnStats();
+  void DecreaseConnStats();
   void BreakOnce(uint32_t ev_mask);
 
   // The read buffer with read data that needs to be parsed and processed.
@@ -340,9 +341,6 @@ class Connection : public util::Connection {
       slice.remove_prefix(len);
     }
   };
-
-  void IncrNumConns();
-  void DecrNumConns();
 
   bool IsReplySizeOverLimit() const;
 


### PR DESCRIPTION
`connected_clients` metric leaked ~2-3 connections per replica reconnection cycle, accumulating over time with unstable replica connections.

Root Cause:
When replica connections migrate between threads during `DFLY FLOW`:
1. `ConnectionFlow()` increments counter on Thread A
2. `OnPostMigrateThread()` increments the counter on Thread B after migration
3. If the connection closes during/after migration, only one decrement occurs
4. Result: one thread leaks +1, causing unbounded growth

Changes:
Added `DecrNumConns()` in `OnPreMigrateThread()` to decrement the counter on the old thread before migration, balancing the increment from `ConnectionFlow()`.

This ensures proper accounting:
- Thread A: +1 (ConnectionFlow) -1 (OnPreMigrateThread) = 0
- Thread B: +1 (OnPostMigrateThread) -1 (DecreaseStatsOnClose) = 0

Fixes #6414