### PR TITLE
refactor: update HSNW serialization format NOT READY FOR REVIEW

### DIFF
--- a/src/core/search/hnsw_index.cc
+++ b/src/core/search/hnsw_index.cc
@@ -149,8 +149,8 @@ struct HnswlibAdapter {
 
     for (size_t internal_id = start; internal_id < end; ++internal_id) {
       HnswNodeData node_data;
-      node_data.internal_id = internal_id;
-      node_data.global_id = world_.getExternalLabel(internal_id);
+      node_data.key = std::to_string(world_.getExternalLabel(internal_id));
+      node_data.internal_id = static_cast<int32_t>(internal_id);
       node_data.level = world_.element_levels_[internal_id];
 
       node_data.levels_links.resize(node_data.level + 1);

--- a/src/core/search/hnsw_index.h
+++ b/src/core/search/hnsw_index.h
@@ -24,16 +24,16 @@ struct HnswIndexMetadata {
 
 // Node data structure for HNSW serialization
 struct HnswNodeData {
-  uint32_t internal_id;
-  GlobalDocId global_id;
+  std::string key;
+  int32_t internal_id;
   int level;
   std::vector<std::vector<uint32_t>> levels_links;  // Links for each level (0 to level)
 
   // Returns the total serialized size in bytes.
-  // Format: internal_id(4) + global_id(8) + level(4)
+  // Format: key(variable) + internal_id(4) + level(4)
   //         + for each level: links_num(4) + links(4 each)
   size_t TotalSize() const {
-    size_t size = 4 + 8 + 4;  // internal_id + global_id + level
+    size_t size = key.size() + 4 + 4;  // key + internal_id + level
     for (const auto& links : levels_links) {
       size += 4 + links.size() * 4;  // links_num + links
     }

--- a/src/server/rdb_extensions.h
+++ b/src/server/rdb_extensions.h
@@ -47,7 +47,7 @@ constexpr uint32_t DF_MASK_FLAG_STICKY = (1 << 0);
 constexpr uint32_t DF_MASK_FLAG_MC_FLAGS = (1 << 1);
 
 // Opcode to store HNSW vector index node data for global indices
-// Format: [index_name, elements_number, internal_id, global_id, level, zero_level_links_num,
-// zero_level_links,
+// Format: [index_name, elements_number,
+//          then for each node: key, internal_id, level, zero_level_links_num, zero_level_links,
 //          higher_level_links_num (only if level > 0), higher_level_links (only if level > 0)]
 constexpr uint8_t RDB_OPCODE_VECTOR_INDEX = 222;

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2215,9 +2215,10 @@ error_code RdbLoader::Load(io::Source* src) {
     if (type == RDB_OPCODE_VECTOR_INDEX) {
       // Stub: read and ignore HNSW vector index data
       // Binary format: [index_name, elements_number,
-      //   then for each node (little-endian):
-      //     internal_id (4 bytes), global_id (8 bytes), level (4 bytes),
-      //     for each level (0 to level): links_num (4 bytes) + links (4 bytes each)]
+      //   then for each node:
+      //     key (variable length string), internal_id (4 bytes), level (4 bytes),
+      //     for each level (0 to level): links_num (4 bytes) + links (4 bytes each, all
+      //     little-endian)]
       string index_key;
       SET_OR_RETURN(FetchGenericString(), index_key);
 
@@ -2225,10 +2226,10 @@ error_code RdbLoader::Load(io::Source* src) {
       SET_OR_RETURN(LoadLen(nullptr), elements_number);
 
       for (uint64_t elem = 0; elem < elements_number; ++elem) {
-        [[maybe_unused]] uint32_t internal_id;
-        SET_OR_RETURN(FetchInt<uint32_t>(), internal_id);
-        [[maybe_unused]] uint64_t global_id;
-        SET_OR_RETURN(FetchInt<uint64_t>(), global_id);
+        [[maybe_unused]] string key;
+        SET_OR_RETURN(FetchGenericString(), key);
+        [[maybe_unused]] int32_t internal_id;
+        SET_OR_RETURN(FetchInt<int32_t>(), internal_id);
         uint32_t level;
         SET_OR_RETURN(FetchInt<uint32_t>(), level);
 

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -175,7 +175,7 @@ void SliceSnapshot::SerializeGlobalHnswIndices() {
 
   for (const auto& [index_key, index] : all_indices) {
     // Format: [RDB_OPCODE_VECTOR_INDEX, index_name, elements_number,
-    //          then for each node: binary encoded entry via SaveHNSWEntry]
+    //          then for each node: key, internal_id, level, links per level]
     if (auto ec = serializer_->WriteOpcode(RDB_OPCODE_VECTOR_INDEX); ec)
       continue;
     if (auto ec = serializer_->SaveString(index_key); ec)


### PR DESCRIPTION
Update HNSW serialization format, instead of GlobalID we use key directly