### PR TITLE
fix(tiering): Handle string that are encoded as LONG LONG objects

### DIFF
--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -365,10 +365,6 @@ class CompactObj {
     return taglen_ <= kInlineLen;
   }
 
-  bool IsIntTag() const {
-    return taglen_ == INT_TAG;
-  }
-
   uint8_t GetFirstByte() const;
 
   struct Stats {

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -89,7 +89,7 @@ tiering::DiskSegment FromCoolItem(const PrimeValue::CoolItem& item) {
 TieredStorage::StashDescriptor DetermineSerializationParams(const PrimeValue& pv) {
   switch (pv.ObjType()) {
     case OBJ_STRING: {
-      if (pv.IsInline() || pv.IsIntTag())
+      if (!pv.HasAllocated())
         return {};
       auto strs = pv.GetRawString();
       return {strs, CompactObj::ExternalRep::STRING};


### PR DESCRIPTION
Don't get raw string representation of string object that don't have allocated data.

Fixes #6521

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->