### PR TITLE
fix: search and dfly lib circular dep

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -43,6 +43,10 @@ cxx_link(dfly_transaction dfly_core strings_lib TRDP::fast_float TRDP::hdr_histo
 
 # Include search module
 add_subdirectory(search)
+if(NOT DEFINED DF_SEARCH_SRCS)
+  message(FATAL_ERROR "Search source files not exported via DF_SEARCH_SRCS")
+endif()
+
 if (WITH_SEARCH)
   add_definitions(-DWITH_SEARCH)
 endif()
@@ -79,7 +83,7 @@ endif()
 add_library(dragonfly_lib
             engine_shard.cc engine_shard_set.cc
             config_registry.cc conn_context.cc
-            debugcmd.cc dflycmd.cc error.cc family_utils.cc
+            debugcmd.cc dflycmd.cc error.cc family_utils.cc ${DF_SEARCH_SRCS}
             server_family.cc string_family.cc list_family.cc generic_family.cc
             ${DF_FAMILY_SRCS}
             main_service.cc memory_cmd.cc rdb_load.cc rdb_save.cc replica.cc http_api.cc
@@ -112,7 +116,7 @@ if (WITH_GCP)
   add_definitions(-DWITH_GCP)
 endif()
 
-cxx_link(dragonfly_lib dfly_transaction dfly_facade dfly_search_server dfly_tiering
+cxx_link(dragonfly_lib dfly_transaction dfly_facade dfly_tiering
          redis_lib ${AWS_LIB} ${GCP_LIB} azure_lib jsonpath
          strings_lib html_lib
          http_client_lib absl::random_random TRDP::jsoncons TRDP::zstd TRDP::lz4
@@ -159,3 +163,11 @@ add_dependencies(check_dfly dragonfly_test json_family_test list_family_test
                  bitops_family_test set_family_test zset_family_test geo_family_test
                  hll_family_test cluster_config_test cluster_family_test acl_family_test
                  json_family_memory_test)
+
+if (WITH_SEARCH)
+  helio_cxx_test(search/search_family_test dfly_test_lib LABELS DFLY)
+  helio_cxx_test(search/aggregator_test dfly_test_lib LABELS DFLY)
+  helio_cxx_test(search/index_join_test dfly_test_lib LABELS DFLY)
+
+  add_dependencies(check_dfly search_family_test aggregator_test index_join_test)
+endif()

--- a/src/server/search/CMakeLists.txt
+++ b/src/server/search/CMakeLists.txt
@@ -1,17 +1,13 @@
 if (NOT WITH_SEARCH)
-  add_library(dfly_search_server doc_index_fallback.cc)
-  target_link_libraries(dfly_search_server dfly_transaction dfly_facade redis_lib jsonpath TRDP::jsoncons)
-  return()
+  SET(DF_SEARCH_SRCS search/doc_index_fallback.cc PARENT_SCOPE)
+else()
+  SET(DF_SEARCH_SRCS
+    search/aggregator.cc
+    search/doc_accessors.cc
+    search/doc_index.cc
+    search/search_family.cc
+    search/index_join.cc
+    search/global_hnsw_index.cc
+    search/index_builder.cc
+    PARENT_SCOPE)
 endif()
-
-add_library(dfly_search_server aggregator.cc doc_accessors.cc doc_index.cc search_family.cc index_join.cc
-             global_hnsw_index.cc index_builder.cc)
-target_link_libraries(dfly_search_server dfly_transaction dragonfly_lib dfly_facade redis_lib jsonpath TRDP::jsoncons)
-
-
-helio_cxx_test(search_family_test dfly_test_lib LABELS DFLY)
-helio_cxx_test(aggregator_test dfly_test_lib LABELS DFLY)
-helio_cxx_test(index_join_test dfly_test_lib LABELS DFLY)
-
-
-add_dependencies(check_dfly search_family_test aggregator_test index_join_test)


### PR DESCRIPTION
There is `circular dependency` between dragonfly search server and dragonfly lib as both link against each other.

I understand the rationale of wanting to separate search as separate library. It's also important to switch off/on search for a cmake build. What we did here however is not correct and in fact, `search` is a `part` of dragonfly lib. If you think otherwise, read `search_family.cc`. This unit belongs to dragonfly lib.

Therefore this PR:

* removes search library all together and moves it as part of dragonfly lib
* allow to optionally compile search (to respect previous use cases)
* keeps original folder hierarchy same (all search units go to server/search/*)


resolves #6479
