### PR TITLE
json: Add test for pool shrinking

### DIFF
--- a/src/core/json/detail/interned_string.cc
+++ b/src/core/json/detail/interned_string.cc
@@ -56,8 +56,13 @@ void InternedString::Release() {
     pool_ref.erase(entry_);
     InternedBlobHandle::Destroy(entry_);
 
+    // When pool is underutilized, shrink it by swapping.
     if (const auto load_factor = pool_ref.load_factor();
         ABSL_PREDICT_FALSE(load_factor > 0 && load_factor < kLoadFactorToShrinkPool)) {
+      // The LHS of swap is a new pool constructed from the original pool reference. The RHS is the
+      // original pool. After the swap, the temporary is destroyed. Note that this is not a strict
+      // shrink. The new pool internally allocates enough capacity so that the load factor is around
+      // 0.8. So the capacity after swap is still larger than size, but the load factor is improved.
       InternedBlobPool(pool_ref).swap(pool_ref);
     }
   }

--- a/src/core/json/detail/interned_string.h
+++ b/src/core/json/detail/interned_string.h
@@ -106,7 +106,9 @@ class InternedString {
   // Increments the refcount if the entry is not null
   void Acquire();
 
-  // Decrements the refcount, removes entry from the pool if necessary, destroying the interned blob
+  // Decrements the refcount, removes entry from the pool if necessary, destroying the interned
+  // blob. A side effect may be shrinking the pool if the load factor is suboptimal (see
+  // kLoadFactorToShrinkPool in the implementation)
   void Release();
 
   // Wraps a null pointer by default


### PR DESCRIPTION
follow up from https://github.com/dragonflydb/dragonfly/pull/6511 https://github.com/dragonflydb/dragonfly/pull/6511#discussion_r2763891890

The test exercises that we don't have to grow capacity after a potential shrink.