### PR TITLE
test: add search with replication for 1.36

### DIFF
--- a/tests/dragonfly/search_test.py
+++ b/tests/dragonfly/search_test.py
@@ -6,7 +6,7 @@ Search correctness should be ensured with unit tests.
 import copy
 
 import numpy as np
-from redis.commands.search.field import TextField, NumericField, TagField, VectorField
+from redis.commands.search.field import TextField, NumericField, TagField, VectorField, GeoField
 from redis.commands.search.indexDefinition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
@@ -692,3 +692,315 @@ async def test_ft_info_concurrent_create_drop(df_server):
     client = aioredis.Redis(port=port)
     assert await client.ping()
     await client.close()
+
+
+@pytest.mark.parametrize(
+    "master_threads,replica_threads",
+    [
+        (4, 4),  # Same thread count
+        (4, 3),  # Master has more threads
+        (3, 4),  # Replica has more threads
+    ],
+)
+async def test_replicate_all_index_types(df_factory, master_threads, replica_threads):
+    """
+    Test that all index types (text, numeric, tag, geo, and vector) can be replicated
+    via full sync rebuild on the replica side. Uses 10000 elements for stress testing.
+    Tests with different thread counts between master and replica to ensure proper
+    shard handling during replication.
+    """
+    from .instance import DflyInstanceFactory
+
+    master = df_factory.create(proactor_threads=master_threads)
+    replica = df_factory.create(proactor_threads=replica_threads)
+
+    df_factory.start_all([master, replica])
+
+    c_master = master.client()
+    c_replica = replica.client()
+
+    # Create an index with all field types on master
+    await c_master.execute_command(
+        "FT.CREATE",
+        "all_types_idx",
+        "ON",
+        "HASH",
+        "PREFIX",
+        "1",
+        "item:",
+        "SCHEMA",
+        "name",
+        "TEXT",
+        "price",
+        "NUMERIC",
+        "SORTABLE",
+        "category",
+        "TAG",
+        "location",
+        "GEO",
+        "embedding",
+        "VECTOR",
+        "HNSW",
+        "6",
+        "TYPE",
+        "FLOAT32",
+        "DIM",
+        "2",
+        "DISTANCE_METRIC",
+        "L2",
+    )
+
+    # Insert 10000 test documents
+    NUM_DOCS = 10000
+    pipe = c_master.pipeline(transaction=False)
+    for i in range(NUM_DOCS):
+        lat = 37.0 + (i % 100) * 0.01  # Varying latitudes
+        lon = -122.0 + (i // 100) * 0.01  # Varying longitudes
+        category = "electronics" if i % 3 == 0 else ("clothing" if i % 3 == 1 else "food")
+        embedding = np.array([float(i % 100), float(i // 100)], dtype=np.float32).tobytes()
+        pipe.hset(
+            f"item:{i}",
+            mapping={
+                "name": f"Product {i}",
+                "price": i,
+                "category": category,
+                "location": f"{lon},{lat}",
+                "embedding": embedding,
+            },
+        )
+        # Execute in batches to avoid memory issues
+        if i % 1000 == 999:
+            await pipe.execute()
+            pipe = c_master.pipeline(transaction=False)
+    await pipe.execute()
+
+    # Verify searches work on master
+    master_idx = c_master.ft("all_types_idx")
+
+    # Text search
+    text_result = await master_idx.search("Product 100")
+    assert text_result.total >= 1
+
+    # Numeric search
+    numeric_result = await master_idx.search("@price:[1000 2000]")
+    assert numeric_result.total == 1001  # prices 1000-2000
+
+    # Tag search - every 3rd item is electronics (0, 3, 6, ...)
+    tag_result = await master_idx.search(Query("@category:{electronics}").paging(0, 0))
+    expected_electronics = (NUM_DOCS + 2) // 3  # ceil(10000/3)
+    assert tag_result.total == expected_electronics
+
+    # Geo search - search around (-122.0, 37.0) with 10km radius
+    geo_result = await master_idx.search("@location:[-122.0 37.0 10 km]")
+    assert geo_result.total > 0
+
+    # Vector search (KNN)
+    query_vec = np.array([50.0, 50.0], dtype=np.float32).tobytes()
+    knn_result = await c_master.execute_command(
+        "FT.SEARCH",
+        "all_types_idx",
+        "*=>[KNN 10 @embedding $vec]",
+        "PARAMS",
+        "2",
+        "vec",
+        query_vec,
+    )
+    assert knn_result[0] >= 1  # At least one result
+
+    # Start replication
+    await c_replica.execute_command("REPLICAOF", "localhost", master.port)
+    await wait_available_async(c_replica)
+
+    # Wait for replication to complete and index to be rebuilt
+    await asyncio.sleep(2)
+
+    # Verify index exists on replica
+    indices = await c_replica.execute_command("FT._LIST")
+    assert b"all_types_idx" in indices or "all_types_idx" in indices
+
+    replica_idx = c_replica.ft("all_types_idx")
+
+    # Verify all search types work on replica
+
+    # Text search
+    replica_text = await replica_idx.search("Product 100")
+    assert replica_text.total >= 1
+
+    # Numeric search
+    replica_numeric = await replica_idx.search("@price:[1000 2000]")
+    assert replica_numeric.total == 1001
+
+    # Tag search
+    replica_tag = await replica_idx.search(Query("@category:{electronics}").paging(0, 0))
+    assert replica_tag.total == expected_electronics
+
+    # Geo search
+    replica_geo = await replica_idx.search("@location:[-122.0 37.0 10 km]")
+    assert replica_geo.total > 0
+
+    # Vector search (KNN)
+    replica_knn = await c_replica.execute_command(
+        "FT.SEARCH",
+        "all_types_idx",
+        "*=>[KNN 10 @embedding $vec]",
+        "PARAMS",
+        "2",
+        "vec",
+        query_vec,
+    )
+    assert replica_knn[0] >= 1
+
+
+@dfly_args({"proactor_threads": 4})
+async def test_vector_search_with_geo_and_tags(async_client: aioredis.Redis):
+    """
+    Test combining vector search (KNN) with geo radius filter and category tags.
+    This tests complex queries that use multiple index types together with 10000 elements.
+    """
+    idx = async_client.ft("combined_idx")
+
+    # Create index with vector, geo, and tag fields
+    await idx.create_index(
+        [
+            TextField("name"),
+            TagField("category"),
+            GeoField("location"),
+            VectorField(
+                "embedding",
+                algorithm="HNSW",
+                attributes={
+                    "TYPE": "FLOAT32",
+                    "DIM": 3,
+                    "DISTANCE_METRIC": "L2",
+                    "INITIAL_CAP": 10000,
+                },
+            ),
+        ],
+        definition=IndexDefinition(index_type=IndexType.HASH, prefix=["place:"]),
+    )
+
+    # Insert 10000 places with varying locations and categories
+    NUM_PLACES = 10000
+    categories = ["restaurant", "cafe", "bar", "shop", "hotel"]
+
+    pipe = async_client.pipeline(transaction=False)
+    for i in range(NUM_PLACES):
+        # Distribute locations across a grid
+        lat = 37.0 + (i % 100) * 0.01  # 100 different latitudes
+        lon = -122.5 + (i // 100) * 0.01  # 100 different longitudes
+        category = categories[i % len(categories)]
+        # Create embeddings that form clusters based on category
+        cat_offset = (i % len(categories)) * 10
+        embedding = np.array(
+            [float(i % 100) + cat_offset, float(i // 100), float(i % 10)], dtype=np.float32
+        )
+        pipe.hset(
+            f"place:{i}",
+            mapping={
+                "name": f"Place {i}",
+                "category": category,
+                "location": f"{lon},{lat}",
+                "embedding": embedding.tobytes(),
+            },
+        )
+        # Execute in batches
+        if i % 1000 == 999:
+            await pipe.execute()
+            pipe = async_client.pipeline(transaction=False)
+    await pipe.execute()
+
+    # Test 1: Vector search only - find places with embeddings closest to a point
+    query_vec = np.array([50.0, 50.0, 5.0], dtype=np.float32).tobytes()
+    result = await async_client.execute_command(
+        "FT.SEARCH",
+        "combined_idx",
+        "*=>[KNN 10 @embedding $vec]",
+        "PARAMS",
+        "2",
+        "vec",
+        query_vec,
+        "RETURN",
+        "1",
+        "name",
+    )
+    assert result[0] == 10
+
+    # Test 2: Vector search filtered by tag - only restaurants (every 5th item starting from 0)
+    result = await async_client.execute_command(
+        "FT.SEARCH",
+        "combined_idx",
+        "@category:{restaurant}=>[KNN 10 @embedding $vec]",
+        "PARAMS",
+        "2",
+        "vec",
+        query_vec,
+        "RETURN",
+        "2",
+        "name",
+        "category",
+    )
+    assert result[0] == 10
+    # Verify all results are restaurants
+    result_str = str(result)
+    for cat in ["cafe", "bar", "shop", "hotel"]:
+        # The category field should not contain other categories
+        assert (
+            f"'category', '{cat}'" not in result_str and f"b'category', b'{cat}'" not in result_str
+        )
+
+    # Test 3: Vector search filtered by geo - only places near center (within 5km)
+    result = await async_client.execute_command(
+        "FT.SEARCH",
+        "combined_idx",
+        "@location:[-122.0 37.5 5 km]=>[KNN 20 @embedding $vec]",
+        "PARAMS",
+        "2",
+        "vec",
+        query_vec,
+        "RETURN",
+        "2",
+        "name",
+        "location",
+    )
+    # Should find places within the geo radius
+    assert result[0] >= 1
+    assert result[0] <= 20
+
+    # Test 4: Combined - vector search with both geo AND tag filters
+    # Find cafes (category index 1) near a specific location
+    query_vec_cafe = np.array([60.0, 50.0, 5.0], dtype=np.float32).tobytes()  # Near cafe cluster
+    result = await async_client.execute_command(
+        "FT.SEARCH",
+        "combined_idx",
+        "@category:{cafe} @location:[-122.0 37.5 20 km]=>[KNN 10 @embedding $vec]",
+        "PARAMS",
+        "2",
+        "vec",
+        query_vec_cafe,
+        "RETURN",
+        "2",
+        "name",
+        "category",
+    )
+    # Should find cafes within the geo and vector constraints
+    assert result[0] >= 1
+    result_str = str(result)
+    # Should not contain other categories
+    assert "restaurant" not in result_str.lower() or "category" not in result_str
+
+    # Test 5: Tag search with geo filter (no vector)
+    result = await idx.search(
+        Query("@category:{restaurant} @location:[-122.0 37.5 50 km]").paging(0, 0)
+    )
+    # Should find restaurants within 50km radius
+    assert result.total >= 1
+
+    # Test 6: Count documents per category
+    for cat in categories:
+        result = await idx.search(Query(f"@category:{{{cat}}}").paging(0, 0))
+        expected_count = NUM_PLACES // len(categories)
+        assert (
+            result.total == expected_count
+        ), f"Expected {expected_count} {cat}s, got {result.total}"
+
+    await idx.dropindex()


### PR DESCRIPTION
1. Make sure we can replicate all indices (both search and vector) via rebuild.
2. We can run vector search together with geo radius and category tags

PR was tested on v1.36-branch