### PR TITLE
feat(hnsw): Use cosine distance

### DIFF
--- a/src/core/search/hnsw_index.cc
+++ b/src/core/search/hnsw_index.cc
@@ -34,6 +34,11 @@ class HnswSpace : public hnswlib::SpaceInterface<float> {
                       *static_cast<const unsigned*>(param));
   }
 
+  static float CosineDistanceStatic(const void* pVect1, const void* pVect2, const void* param) {
+    return CosineDistance(static_cast<const float*>(pVect1), static_cast<const float*>(pVect2),
+                          *static_cast<const unsigned*>(param));
+  }
+
  public:
   explicit HnswSpace(size_t dim, VectorSimilarity sim) : dim_(dim), sim_(sim) {
   }
@@ -45,6 +50,8 @@ class HnswSpace : public hnswlib::SpaceInterface<float> {
   hnswlib::DISTFUNC<float> get_dist_func() {
     if (sim_ == VectorSimilarity::L2) {
       return L2DistanceStatic;
+    } else if (sim_ == VectorSimilarity::COSINE) {
+      return CosineDistanceStatic;
     } else {
       return IPDistanceStatic;
     }

--- a/src/core/search/vector_utils.h
+++ b/src/core/search/vector_utils.h
@@ -19,6 +19,7 @@ std::optional<OwnedFtVector> BytesToFtVectorSafe(std::string_view value);
 
 float L2Distance(const float* u, const float* v, size_t dims);
 float IPDistance(const float* u, const float* v, size_t dims);
+float CosineDistance(const float* u, const float* v, size_t dims);
 float VectorDistance(const float* u, const float* v, size_t dims, VectorSimilarity sim);
 
 }  // namespace dfly::search

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -8,6 +8,7 @@
 #include <absl/strings/str_format.h>
 
 #include <algorithm>
+#include <string_view>
 
 #include "base/gtest.h"
 #include "base/logging.h"
@@ -24,6 +25,29 @@ using namespace facade;
 
 ABSL_DECLARE_FLAG(bool, search_reject_legacy_field);
 ABSL_DECLARE_FLAG(size_t, search_query_string_bytes);
+
+namespace {
+
+// Verify and extract score field from vector search result
+auto vector_score = [](std::string_view score_name, const RespExpr::Vec& score_field) -> float {
+  EXPECT_THAT(score_field.size(), 2);
+  EXPECT_THAT(score_field[0].GetString(), score_name);
+  float score;
+  bool success = absl::SimpleAtof(score_field[1].GetView(), &score);
+  EXPECT_TRUE(success);
+  return score;
+};
+
+// Helper to convert float array to binary format
+auto Vec3ToBytes = [](float x, float y, float z) -> string {
+  string result;
+  result.append(reinterpret_cast<const char*>(&x), sizeof(float));
+  result.append(reinterpret_cast<const char*>(&y), sizeof(float));
+  result.append(reinterpret_cast<const char*>(&z), sizeof(float));
+  return result;
+};
+
+}  // namespace
 
 namespace dfly {
 
@@ -3662,6 +3686,348 @@ TEST_F(SearchFamilyTest, KnnHnsw) {
               query_vec});
   // Should return documents with "even": "yes" sorted by vector distance to 2.0
   EXPECT_THAT(resp, AreDocIds("doc3", "doc1"));
+}
+
+TEST_F(SearchFamilyTest, KnnHnswCosineDistanceCalculation) {
+  // Create index with 3D vectors using COSINE distance metric with HNSW
+  auto resp = Run({"FT.CREATE", "cosine_idx", "ON", "HASH", "SCHEMA", "vec", "VECTOR", "HNSW", "6",
+                   "TYPE", "FLOAT32", "DIM", "3", "DISTANCE_METRIC", "COSINE"});
+  EXPECT_EQ(resp, "OK");
+
+  // Query vector will be [1, 0, 0]
+  // Cosine distance = 1 - cosine_similarity = 1 - (dot_product / (norm1 * norm2))
+
+  // doc1: [1, 0, 0] - identical to query, distance = 0
+  Run({"HSET", "doc1", "vec", Vec3ToBytes(1.0f, 0.0f, 0.0f)});
+
+  // doc2: [0, 1, 0] - orthogonal (y-axis), distance = 1
+  Run({"HSET", "doc2", "vec", Vec3ToBytes(0.0f, 1.0f, 0.0f)});
+
+  // doc3: [0, 0, 1] - orthogonal (z-axis), distance = 1
+  Run({"HSET", "doc3", "vec", Vec3ToBytes(0.0f, 0.0f, 1.0f)});
+
+  // doc4: [-1, 0, 0] - opposite direction, distance = 2
+  Run({"HSET", "doc4", "vec", Vec3ToBytes(-1.0f, 0.0f, 0.0f)});
+
+  // doc5: [2, 0, 0] - same direction, 2x magnitude, distance = 0 (cosine is magnitude-invariant)
+  Run({"HSET", "doc5", "vec", Vec3ToBytes(2.0f, 0.0f, 0.0f)});
+
+  // doc6: [0, 0, 0] - EDGE CASE: zero vector (undefined cosine, implementation-dependent)
+  Run({"HSET", "doc6", "vec", Vec3ToBytes(0.0f, 0.0f, 0.0f)});
+
+  // doc7: [1, 1, 0] - 45° angle in xy-plane, cos_sim = 1/√2 ≈ 0.707, distance ≈ 0.293
+  Run({"HSET", "doc7", "vec", Vec3ToBytes(1.0f, 1.0f, 0.0f)});
+
+  // doc8: [1, 1, 1] - equal components, cos_sim = 1/√3 ≈ 0.577, distance ≈ 0.423
+  Run({"HSET", "doc8", "vec", Vec3ToBytes(1.0f, 1.0f, 1.0f)});
+
+  // doc9: [0.1, 0, 0] - EDGE CASE: very small magnitude, same direction, distance = 0
+  Run({"HSET", "doc9", "vec", Vec3ToBytes(0.1f, 0.0f, 0.0f)});
+
+  // doc10: [10, 0, 0] - EDGE CASE: very large magnitude, same direction, distance = 0
+  Run({"HSET", "doc10", "vec", Vec3ToBytes(10.0f, 0.0f, 0.0f)});
+
+  // Query with [1, 0, 0]
+  string query_vec = Vec3ToBytes(1.0f, 0.0f, 0.0f);
+
+  // Test: Verify all distance scores
+  resp = Run({"FT.SEARCH", "cosine_idx", "*=>[KNN 10 @vec $query_vec AS score]", "PARAMS", "2",
+              "query_vec", query_vec, "RETURN", "1", "score", "SORTBY", "score"});
+
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  auto results = resp.GetVec();
+  ASSERT_GE(results.size(), 3);  // At least count + 1 doc
+
+  // Gather all scores
+  std::map<string, double> doc_scores;
+  for (size_t i = 1; i < results.size(); i += 2) {
+    string doc_id = results[i].GetString();
+    double score = vector_score("score", results[i + 1].GetVec());
+    doc_scores[doc_id] = score;
+  }
+
+  // Verify expected distances (with tolerance for floating-point)
+  // doc1, doc5, doc9, doc10 should all have distance ≈ 0 (same direction, magnitude-invariant)
+  if (doc_scores.contains("doc1")) {
+    EXPECT_LT(doc_scores["doc1"], 0.01);
+  }
+
+  if (doc_scores.contains("doc5")) {
+    EXPECT_LT(doc_scores["doc5"], 0.01);
+  }
+
+  if (doc_scores.contains("doc9")) {
+    EXPECT_LT(doc_scores["doc9"], 0.01);
+  }
+
+  if (doc_scores.contains("doc10")) {
+    EXPECT_LT(doc_scores["doc10"], 0.01);
+  }
+
+  // doc7: 45° angle, distance ≈ 1 - 1/√2 ≈ 0.293
+  if (doc_scores.contains("doc7")) {
+    EXPECT_GT(doc_scores["doc7"], 0.25);
+    EXPECT_LT(doc_scores["doc7"], 0.35);
+  }
+
+  // doc8: distance ≈ 1 - 1/√3 ≈ 0.423
+  if (doc_scores.contains("doc8")) {
+    EXPECT_GT(doc_scores["doc8"], 0.38);
+    EXPECT_LT(doc_scores["doc8"], 0.47);
+  }
+
+  // doc2, doc3: orthogonal, distance = 1
+  if (doc_scores.contains("doc2")) {
+    EXPECT_GT(doc_scores["doc2"], 0.95);
+    EXPECT_LT(doc_scores["doc2"], 1.05);
+  }
+
+  if (doc_scores.contains("doc3")) {
+    EXPECT_GT(doc_scores["doc3"], 0.95);
+    EXPECT_LT(doc_scores["doc3"], 1.05);
+  }
+
+  // doc4: opposite direction, distance = 2
+  if (doc_scores.contains("doc4")) {
+    EXPECT_GT(doc_scores["doc4"], 1.95);
+    EXPECT_LT(doc_scores["doc4"], 2.05);
+  }
+
+  // doc6: zero vector - EDGE CASE, behavior is implementation-dependent
+  // Most implementations treat it as maximum distance or handle specially
+}
+
+TEST_F(SearchFamilyTest, KnnHnswL2DistanceCalculation) {
+  // Create index with 3D vectors using L2 (Euclidean) distance metric with HNSW
+  auto resp = Run({"FT.CREATE", "l2_idx", "ON", "HASH", "SCHEMA", "vec", "VECTOR", "HNSW", "6",
+                   "TYPE", "FLOAT32", "DIM", "3", "DISTANCE_METRIC", "L2"});
+  EXPECT_EQ(resp, "OK");
+
+  // Query vector will be [1, 0, 0]
+  // L2_distance = sqrt(sum((a[i] - b[i])^2))
+
+  // doc1: [1, 0, 0] - identical to query, distance = 0
+  Run({"HSET", "doc1", "vec", Vec3ToBytes(1.0f, 0.0f, 0.0f)});
+
+  // doc2: [0, 1, 0] - orthogonal, distance = sqrt(1 + 1 + 0) = √2 ≈ 1.414
+  Run({"HSET", "doc2", "vec", Vec3ToBytes(0.0f, 1.0f, 0.0f)});
+
+  // doc3: [0, 0, 1] - orthogonal, distance = sqrt(1 + 0 + 1) = √2 ≈ 1.414
+  Run({"HSET", "doc3", "vec", Vec3ToBytes(0.0f, 0.0f, 1.0f)});
+
+  // doc4: [-1, 0, 0] - opposite direction, distance = sqrt(4 + 0 + 0) = 2
+  Run({"HSET", "doc4", "vec", Vec3ToBytes(-1.0f, 0.0f, 0.0f)});
+
+  // doc5: [2, 0, 0] - same direction, 2x magnitude, distance = sqrt(1 + 0 + 0) = 1
+  Run({"HSET", "doc5", "vec", Vec3ToBytes(2.0f, 0.0f, 0.0f)});
+
+  // doc6: [0, 0, 0] - EDGE CASE: zero vector, distance = sqrt(1 + 0 + 0) = 1
+  Run({"HSET", "doc6", "vec", Vec3ToBytes(0.0f, 0.0f, 0.0f)});
+
+  // doc7: [1, 1, 0] - distance = sqrt(0 + 1 + 0) = 1
+  Run({"HSET", "doc7", "vec", Vec3ToBytes(1.0f, 1.0f, 0.0f)});
+
+  // doc8: [1, 1, 1] - distance = sqrt(0 + 1 + 1) = √2 ≈ 1.414
+  Run({"HSET", "doc8", "vec", Vec3ToBytes(1.0f, 1.0f, 1.0f)});
+
+  // doc9: [0.1, 0, 0] - EDGE CASE: very small magnitude, distance = sqrt(0.81 + 0 + 0) = 0.9
+  Run({"HSET", "doc9", "vec", Vec3ToBytes(0.1f, 0.0f, 0.0f)});
+
+  // doc10: [10, 0, 0] - EDGE CASE: very large magnitude, distance = sqrt(81 + 0 + 0) = 9
+  Run({"HSET", "doc10", "vec", Vec3ToBytes(10.0f, 0.0f, 0.0f)});
+
+  // Query with [1, 0, 0]
+  string query_vec = Vec3ToBytes(1.0f, 0.0f, 0.0f);
+
+  // Test: Verify all distance scores
+  resp = Run({"FT.SEARCH", "l2_idx", "*=>[KNN 10 @vec $query_vec AS score]", "PARAMS", "2",
+              "query_vec", query_vec, "RETURN", "1", "score", "SORTBY", "score"});
+
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  auto results = resp.GetVec();
+  ASSERT_GE(results.size(), 3);  // At least count + 1 doc
+
+  // Gather all scores
+  std::map<string, double> doc_scores;
+  for (size_t i = 1; i < results.size(); i += 2) {
+    string doc_id = results[i].GetString();
+    double score = vector_score("score", results[i + 1].GetVec());
+    doc_scores[doc_id] = score;
+  }
+
+  // Verify expected distances (with tolerance for floating-point)
+  // doc1: distance = 0 (identical)
+  if (doc_scores.contains("doc1")) {
+    EXPECT_LT(doc_scores["doc1"], 0.01);
+  }
+
+  // doc9: distance = 0.9 (small magnitude, same direction)
+  if (doc_scores.contains("doc9")) {
+    EXPECT_GT(doc_scores["doc9"], 0.85);
+    EXPECT_LT(doc_scores["doc9"], 0.95);
+  }
+
+  // doc5, doc6, doc7: distance = 1
+  if (doc_scores.contains("doc5")) {
+    EXPECT_GT(doc_scores["doc5"], 0.95);
+    EXPECT_LT(doc_scores["doc5"], 1.05);
+  }
+
+  if (doc_scores.contains("doc6")) {
+    EXPECT_GT(doc_scores["doc6"], 0.95);
+    EXPECT_LT(doc_scores["doc6"], 1.05);
+  }
+
+  if (doc_scores.contains("doc7")) {
+    EXPECT_GT(doc_scores["doc7"], 0.95);
+    EXPECT_LT(doc_scores["doc7"], 1.05);
+  }
+
+  // doc2, doc3, doc8: distance = √2 ≈ 1.414
+  if (doc_scores.contains("doc2")) {
+    EXPECT_GT(doc_scores["doc2"], 1.37);
+    EXPECT_LT(doc_scores["doc2"], 1.46);
+  }
+
+  if (doc_scores.contains("doc3")) {
+    EXPECT_GT(doc_scores["doc3"], 1.37);
+    EXPECT_LT(doc_scores["doc3"], 1.46);
+  }
+
+  if (doc_scores.contains("doc8")) {
+    EXPECT_GT(doc_scores["doc8"], 1.37);
+    EXPECT_LT(doc_scores["doc8"], 1.46);
+  }
+
+  // doc4: distance = 2 (opposite direction)
+  if (doc_scores.contains("doc4")) {
+    EXPECT_GT(doc_scores["doc4"], 1.95);
+    EXPECT_LT(doc_scores["doc4"], 2.05);
+  }
+
+  // doc10: distance = 9 (large magnitude, same direction)
+  if (doc_scores.contains("doc10")) {
+    EXPECT_GT(doc_scores["doc10"], 8.95);
+    EXPECT_LT(doc_scores["doc10"], 9.05);
+  }
+}
+
+TEST_F(SearchFamilyTest, KnnHnswIPDistanceCalculation) {
+  // Create index with 3D vectors using IP (Inner Product) distance metric with HNSW
+  auto resp = Run({"FT.CREATE", "ip_idx", "ON", "HASH", "SCHEMA", "vec", "VECTOR", "HNSW", "6",
+                   "TYPE", "FLOAT32", "DIM", "3", "DISTANCE_METRIC", "IP"});
+  EXPECT_EQ(resp, "OK");
+
+  // Comprehensive test cases with edge cases - SAME VECTORS as other tests
+  // Query vector will be [1, 0, 0]
+  // IP_distance = 1 - dot_product(a, b)
+
+  // doc1: [1, 0, 0] - dot = 1, distance = 0
+  Run({"HSET", "doc1", "vec", Vec3ToBytes(1.0f, 0.0f, 0.0f)});
+
+  // doc2: [0, 1, 0] - dot = 0, distance = 1
+  Run({"HSET", "doc2", "vec", Vec3ToBytes(0.0f, 1.0f, 0.0f)});
+
+  // doc3: [0, 0, 1] - dot = 0, distance = 1
+  Run({"HSET", "doc3", "vec", Vec3ToBytes(0.0f, 0.0f, 1.0f)});
+
+  // doc4: [-1, 0, 0] - dot = -1, distance = 2
+  Run({"HSET", "doc4", "vec", Vec3ToBytes(-1.0f, 0.0f, 0.0f)});
+
+  // doc5: [2, 0, 0] - dot = 2, distance = -1 (NOT magnitude-invariant like cosine)
+  Run({"HSET", "doc5", "vec", Vec3ToBytes(2.0f, 0.0f, 0.0f)});
+
+  // doc6: [0, 0, 0] - EDGE CASE: zero vector, dot = 0, distance = 1
+  Run({"HSET", "doc6", "vec", Vec3ToBytes(0.0f, 0.0f, 0.0f)});
+
+  // doc7: [1, 1, 0] - dot = 1, distance = 0
+  Run({"HSET", "doc7", "vec", Vec3ToBytes(1.0f, 1.0f, 0.0f)});
+
+  // doc8: [1, 1, 1] - dot = 1, distance = 0
+  Run({"HSET", "doc8", "vec", Vec3ToBytes(1.0f, 1.0f, 1.0f)});
+
+  // doc9: [0.1, 0, 0] - EDGE CASE: dot = 0.1, distance = 0.9
+  Run({"HSET", "doc9", "vec", Vec3ToBytes(0.1f, 0.0f, 0.0f)});
+
+  // doc10: [10, 0, 0] - EDGE CASE: dot = 10, distance = -9
+  Run({"HSET", "doc10", "vec", Vec3ToBytes(10.0f, 0.0f, 0.0f)});
+
+  // Query with [1, 0, 0]
+  string query_vec = Vec3ToBytes(1.0f, 0.0f, 0.0f);
+
+  // Test: Verify all distance scores
+  // For IP, lower distance means higher dot product (better match)
+  resp = Run({"FT.SEARCH", "ip_idx", "*=>[KNN 10 @vec $query_vec AS score]", "PARAMS", "2",
+              "query_vec", query_vec, "RETURN", "1", "score", "SORTBY", "score"});
+
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  auto results = resp.GetVec();
+  ASSERT_GE(results.size(), 3);  // At least count + 1 doc
+
+  // Gather all scores
+  std::map<string, double> doc_scores;
+  for (size_t i = 1; i < results.size(); i += 2) {
+    string doc_id = results[i].GetString();
+    double score = vector_score("score", results[i + 1].GetVec());
+    doc_scores[doc_id] = score;
+  }
+
+  // Verify expected distances (with tolerance for floating-point)
+  // doc10: distance = -9 (dot = 10, EDGE CASE: large magnitude advantage)
+  if (doc_scores.contains("doc10")) {
+    EXPECT_GT(doc_scores["doc10"], -9.05);
+    EXPECT_LT(doc_scores["doc10"], -8.95);
+  }
+
+  // doc5: distance = -1 (dot = 2, shows magnitude matters for IP unlike cosine)
+  if (doc_scores.contains("doc5")) {
+    EXPECT_GT(doc_scores["doc5"], -1.05);
+    EXPECT_LT(doc_scores["doc5"], -0.95);
+  }
+
+  // doc1, doc7, doc8: distance = 0 (dot = 1)
+  if (doc_scores.contains("doc1")) {
+    EXPECT_GT(doc_scores["doc1"], -0.05);
+    EXPECT_LT(doc_scores["doc1"], 0.05);
+  }
+
+  if (doc_scores.contains("doc7")) {
+    EXPECT_GT(doc_scores["doc7"], -0.05);
+    EXPECT_LT(doc_scores["doc7"], 0.05);
+  }
+
+  if (doc_scores.contains("doc8")) {
+    EXPECT_GT(doc_scores["doc8"], -0.05);
+    EXPECT_LT(doc_scores["doc8"], 0.05);
+  }
+
+  // doc9: distance = 0.9 (dot = 0.1, EDGE CASE: small magnitude penalty)
+  if (doc_scores.contains("doc9")) {
+    EXPECT_GT(doc_scores["doc9"], 0.85);
+    EXPECT_LT(doc_scores["doc9"], 0.95);
+  }
+
+  // doc2, doc3, doc6: distance = 1 (dot = 0)
+  if (doc_scores.contains("doc2")) {
+    EXPECT_GT(doc_scores["doc2"], 0.95);
+    EXPECT_LT(doc_scores["doc2"], 1.05);
+  }
+
+  if (doc_scores.contains("doc3")) {
+    EXPECT_GT(doc_scores["doc3"], 0.95);
+    EXPECT_LT(doc_scores["doc3"], 1.05);
+  }
+
+  if (doc_scores.contains("doc6")) {
+    EXPECT_GT(doc_scores["doc6"], 0.95);
+    EXPECT_LT(doc_scores["doc6"], 1.05);
+  }
+
+  // doc4: distance = 2 (dot = -1, opposite direction is worst)
+  if (doc_scores.contains("doc4")) {
+    EXPECT_GT(doc_scores["doc4"], 1.95);
+    EXPECT_LT(doc_scores["doc4"], 2.05);
+  }
 }
 
 TEST_F(SearchFamilyTest, ParseCSSResponse) {


### PR DESCRIPTION
Use cosine distance instead of IP.
Used AI and added test to verify distances for L2, Cosine and IP.

Vector used in test:

doc1: [1, 0, 0] - identical to query vector
doc2: [0, 1, 0] - orthogonal on y-axis
doc3: [0, 0, 1] - orthogonal on z-axis
doc4: [-1, 0, 0] - opposite direction (anti-parallel)
doc5: [2, 0, 0] - same direction, 2x magnitude
doc6: [0, 0, 0] - zero vector
doc7: [1, 1, 0] - 45° angle in xy-plane
doc8: [1, 1, 1] - equal components in all dimensions
doc9: [0.1, 0, 0] - very small magnitude
doc10: [10, 0, 0] - very large magnitude

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->