### PR TITLE
chore: supress maint_notifications client errors

### DIFF
--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -37,8 +37,6 @@
 #include "util/fibers/synchronization.h"
 using namespace std;
 
-ABSL_RETIRED_FLAG(uint32_t, allow_partial_sync_with_lsn_diff, 0,
-                  "Do partial sync in case lsn diff is less than the given threshold");
 ABSL_DECLARE_FLAG(bool, info_replication_valkey_compatible);
 ABSL_DECLARE_FLAG(uint32_t, replication_timeout);
 ABSL_DECLARE_FLAG(uint32_t, shard_repl_backlog_len);

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -49,9 +49,6 @@ ABSL_FLAG(dfly::CompressionMode, compression_mode, dfly::CompressionMode::MULTI_
           "set 2 for multi entry zstd compression on df snapshot and single entry on rdb snapshot,"
           "set 3 for multi entry lz4 compression on df snapshot and single entry on rdb snapshot");
 
-ABSL_RETIRED_FLAG(bool, stream_rdb_encode_v2, true,
-                  "Retired. Uses format, compatible with redis 7.2 and Dragonfly v1.26+");
-
 // Flip this value to 'true' in March 2026.
 ABSL_FLAG(bool, rdb_sbf_chunked, false, "Enable new save format for saving SBFs in chunks.");
 


### PR DESCRIPTION
Summary: Reduces warning-log noise by suppressing expected failures for CLIENT maint_notifications (and -BUSYGROUP) via a centralized ShouldLogError() helper.
Changes: Cleans up several deprecated ABSL_RETIRED_FLAG declarations that are no longer needed.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->