### PR TITLE
server: Record values in histogram atomically

### DIFF
--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -219,6 +219,7 @@ void CommandId::ResetStats(unsigned thread_index) {
   command_stats_[thread_index] = {0, 0};
   if (hdr_histogram* h = latency_histogram_; h != nullptr) {
     hdr_reset(h);
+    std::atomic_thread_fence(std::memory_order_seq_cst);
   }
 }
 
@@ -229,7 +230,7 @@ void CommandId::RecordLatency(unsigned tid, uint64_t latency_usec) const {
   ent.second += latency_usec;
 
   if (latency_histogram_) {
-    hdr_record_value(latency_histogram_, latency_usec);
+    hdr_record_value_atomic(latency_histogram_, latency_usec);
   }
 }
 


### PR DESCRIPTION
The histogram is attached to command ids, which are shared among shards. It is unsafe to update the histogram without atomics.

The change records values atomically.

The new method forbids non-atomic and atomic call mixing, but we have now switched the only update to atomic calls:


```
 * Will record this value atomically, however the whole structure may appear inconsistent
 * when read concurrently with this update.  Do NOT mix calls to this method with calls
 * to non-atomic updates.
```

Inconsistency or eventual consistency in reads should be acceptable for metrics use case.