### PR TITLE
chore: get rid of deprecated DFLY_PASSWORD env checks

### DIFF
--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -849,13 +849,6 @@ void PrintBasicUsageInfo() {
 }
 
 void ParseFlagsFromEnv() {
-  if (getenv("DFLY_PASSWORD")) {
-    LOG(FATAL) << "DFLY_PASSWORD environment variable was deprecated in favor of DFLY_requirepass";
-  }
-
-  // Allowed environment variable names that can have
-  // DFLY_ prefix, but don't necessarily have an ABSL flag created
-  absl::flat_hash_set<std::string_view> ignored_environment_flag_names = {"DEV_ENV", "PASSWORD"};
   const auto& flags = absl::GetAllFlags();
   for (char** env = environ; *env != nullptr; env++) {
     constexpr string_view kPrefix = "DFLY_";
@@ -866,9 +859,10 @@ void ParseFlagsFromEnv() {
       pair<string_view, string_view> environ_pair =
           absl::StrSplit(absl::StripPrefix(environ_var, kPrefix), absl::MaxSplits('=', 1));
       const auto& [flag_name, flag_value] = environ_pair;
-      if (ignored_environment_flag_names.contains(flag_name)) {
-        continue;
+      if (flag_name == "DEV_ENV") {
+        continue;  // DFLY_DEV_ENV is used to skip version check.
       }
+
       auto entry = flags.find(flag_name);
       if (entry != flags.end()) {
         if (absl::flags_internal::WasPresentOnCommandLine(flag_name)) {


### PR DESCRIPTION
DFLY_PASSWORD was deprecated years ago and this code is stale.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->