### PR TITLE
refactor: store hnsw metadata in separate AUX field

### DIFF
--- a/src/core/search/hnsw_index.cc
+++ b/src/core/search/hnsw_index.cc
@@ -132,11 +132,6 @@ struct HnswlibAdapter {
     metadata.cur_element_count = world_.cur_element_count.load();
     metadata.maxlevel = world_.maxlevel_;
     metadata.enterpoint_node = world_.enterpoint_node_;
-    metadata.M = world_.M_;
-    metadata.maxM = world_.maxM_;
-    metadata.maxM0 = world_.maxM0_;
-    metadata.ef_construction = world_.ef_construction_;
-    metadata.mult = world_.mult_;
     return metadata;
   }
 

--- a/src/core/search/hnsw_index.h
+++ b/src/core/search/hnsw_index.h
@@ -15,11 +15,6 @@ struct HnswIndexMetadata {
   size_t cur_element_count = 0;  // Current number of elements in the index
   int maxlevel = -1;             // Maximum level of the graph
   size_t enterpoint_node = 0;    // Entry point node for the graph
-  size_t M = 0;                  // Number of established connections per element
-  size_t maxM = 0;               // Maximum connections for upper layers
-  size_t maxM0 = 0;              // Maximum connections for layer 0
-  size_t ef_construction = 0;    // Size of dynamic candidate list for construction
-  double mult = 0.0;             // Multiplier for random level generation
 };
 
 // Node data structure for HNSW serialization

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -45,6 +45,7 @@ extern "C" {
 #include "server/rdb_extensions.h"
 #include "server/script_mgr.h"
 #include "server/search/doc_index.h"
+#include "server/search/global_hnsw_index.h"
 #include "server/serializer_commons.h"
 #include "server/server_state.h"
 #include "server/set_family.h"
@@ -2593,6 +2594,8 @@ error_code RdbLoader::HandleAux() {
     /* Just ignored. */
   } else if (auxkey == "search-index") {
     LoadSearchIndexDefFromAux(std::move(auxval));
+  } else if (auxkey == "hnsw-index-metadata") {
+    LoadHnswIndexMetadataFromAux(std::move(auxval));
   } else if (auxkey == "search-synonyms") {
     LoadSearchSynonymsFromAux(std::move(auxval));
   } else if (auxkey == "shard-count") {
@@ -2988,41 +2991,13 @@ std::vector<std::string> RdbLoader::TakePendingSynonymCommands() {
 }
 
 void RdbLoader::LoadSearchIndexDefFromAux(string&& def) {
-  string index_name;
-  string full_cmd;
-
-  // Check if this is new JSON format (starts with '{') or old format ("index_name cmd")
-  if (!def.empty() && def[0] == '{') {
-    // New JSON format with HNSW metadata (from summary file)
-    try {
-      auto json_opt = JsonFromString(def);
-      if (!json_opt) {
-        LOG(ERROR) << "Invalid search index JSON: " << def;
-        return;
-      }
-      const auto& json = *json_opt;
-      index_name = json["name"].as<string>();
-      string cmd = json["cmd"].as<string>();
-
-      // TODO: restore HNSW metadata from json["hnsw_metadata"] if present
-      // Currently we just restore the index definition, HNSW graph will be rebuilt
-
-      full_cmd = absl::StrCat(index_name, " ", cmd);
-    } catch (const std::exception& e) {
-      LOG(ERROR) << "Failed to parse search index JSON: " << e.what() << " def: " << def;
-      return;
-    }
-  } else {
-    // Simple format: "index_name cmd" - from per-shard DFS files or old format
-    // Extract index name (first token before space)
-    size_t space_pos = def.find(' ');
-    if (space_pos == string::npos) {
-      LOG(ERROR) << "Invalid search index definition: " << def;
-      return;
-    }
-    index_name = def.substr(0, space_pos);
-    full_cmd = std::move(def);
+  // Simple format: "index_name cmd"
+  size_t space_pos = def.find(' ');
+  if (space_pos == string::npos) {
+    LOG(ERROR) << "Invalid search index definition: " << def;
+    return;
   }
+  string index_name = def.substr(0, space_pos);
 
   // Thread-safe check-and-mark to prevent duplicate creation attempts from concurrent shard files.
   // We track which indices we've already attempted to create to avoid race conditions where
@@ -3036,7 +3011,33 @@ void RdbLoader::LoadSearchIndexDefFromAux(string&& def) {
     }
   }
 
-  LoadSearchCommandFromAux(service_, std::move(full_cmd), "FT.CREATE", "index definition");
+  LoadSearchCommandFromAux(service_, std::move(def), "FT.CREATE", "index definition");
+}
+
+void RdbLoader::LoadHnswIndexMetadataFromAux(string&& def) {
+  try {
+    auto json_opt = JsonFromString(def);
+    if (!json_opt) {
+      LOG(ERROR) << "Invalid HNSW index metadata JSON: " << def;
+      return;
+    }
+    const auto& json = *json_opt;
+
+    PendingHnswMetadata phm;
+    phm.index_name = json["index_name"].as<string>();
+    phm.field_name = json["field_name"].as<string>();
+    phm.metadata.max_elements = json["max_elements"].as<size_t>();
+    phm.metadata.cur_element_count = json["cur_element_count"].as<size_t>();
+    phm.metadata.maxlevel = json["maxlevel"].as<int>();
+    phm.metadata.enterpoint_node = json["enterpoint_node"].as<size_t>();
+
+    LOG(INFO) << "Loaded HNSW metadata for index=" << phm.index_name << " field=" << phm.field_name
+              << " elements=" << phm.metadata.cur_element_count;
+
+    pending_hnsw_metadata_.emplace_back(std::move(phm));
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Failed to parse HNSW index metadata JSON: " << e.what() << " def: " << def;
+  }
 }
 
 void RdbLoader::LoadSearchSynonymsFromAux(string&& def) {

--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -15,6 +15,7 @@ extern "C" {
 #include "base/pod_array.h"
 #include "base/spinlock.h"
 #include "core/search/base.h"
+#include "core/search/hnsw_index.h"
 #include "io/io.h"
 #include "io/io_buf.h"
 #include "server/common.h"
@@ -334,6 +335,9 @@ class RdbLoader : protected RdbLoaderBase {
   // issues an FT.CREATE call, but does not start indexing
   void LoadSearchIndexDefFromAux(std::string&& value);
 
+  // Load HNSW index metadata from JSON, sets metadata on the GlobalHnswIndexRegistry
+  void LoadHnswIndexMetadataFromAux(std::string&& value);
+
   // Load synonyms from RESP string and issue FT.SYNUPDATE call
   void LoadSearchSynonymsFromAux(std::string&& value);
 
@@ -352,6 +356,14 @@ class RdbLoader : protected RdbLoaderBase {
     std::vector<std::pair<std::string, search::DocId>> mappings;
   };
   std::vector<PendingIndexMapping> pending_index_mappings_;
+
+  // HNSW metadata loaded from "hnsw-index-metadata" AUX fields, keyed by index_name:field_name
+  struct PendingHnswMetadata {
+    std::string index_name;
+    std::string field_name;
+    search::HnswIndexMetadata metadata;
+  };
+  std::vector<PendingHnswMetadata> pending_hnsw_metadata_;
 
   std::string snapshot_id_;
   bool override_existing_keys_ = false;

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -1408,11 +1408,14 @@ error_code RdbSaver::Impl::FlushSerializer() {
 
 namespace {
 
-// Collect search index definitions. If as_json is true, collects JSON with HNSW metadata
-// and synonyms (for summary file). Otherwise collects simple restore commands (for per-shard).
+// Collect search index definitions and optionally HNSW metadata.
+// search_indices always gets simple "index_name cmd" restore commands.
+// For summary shards, hnsw_index_metadata gets JSON with HNSW graph metadata,
+// and search_synonyms gets synonym group restore commands.
 void CollectSearchIndices([[maybe_unused]] EngineShard* shard,
                           [[maybe_unused]] StringVec* search_indices,
                           [[maybe_unused]] StringVec* search_synonyms,
+                          [[maybe_unused]] StringVec* hnsw_index_metadata,
                           [[maybe_unused]] bool is_summary) {
 #ifdef WITH_SEARCH
   auto* indices = shard->search_indices();
@@ -1420,11 +1423,12 @@ void CollectSearchIndices([[maybe_unused]] EngineShard* shard,
     auto* index = indices->GetIndex(index_name);
     auto index_info = index->GetInfo();
 
-    if (!is_summary) {
-      std::string restore_cmd = absl::StrCat(index_name, " ", index_info.BuildRestoreCommand());
-      search_indices->emplace_back(std::move(restore_cmd));
+    // Always store the simple restore command format
+    std::string restore_cmd = absl::StrCat(index_name, " ", index_info.BuildRestoreCommand());
+    search_indices->emplace_back(std::move(restore_cmd));
+
+    if (!is_summary)
       continue;
-    }
 
     // Collect HNSW metadata for vector field (first one found)
     for (const auto& [fident, finfo] : index_info.base_index.schema.fields) {
@@ -1432,33 +1436,19 @@ void CollectSearchIndices([[maybe_unused]] EngineShard* shard,
           !(finfo.flags & search::SchemaField::NOINDEX)) {
         if (auto hnsw_index = GlobalHnswIndexRegistry::Instance().Get(index_name, finfo.short_name);
             hnsw_index) {
-          index_info.hnsw_metadata = hnsw_index->GetMetadata();
+          auto meta = hnsw_index->GetMetadata();
+          TmpJson meta_json;
+          meta_json["index_name"] = index_name;
+          meta_json["field_name"] = finfo.short_name;
+          meta_json["max_elements"] = meta.max_elements;
+          meta_json["cur_element_count"] = meta.cur_element_count;
+          meta_json["maxlevel"] = meta.maxlevel;
+          meta_json["enterpoint_node"] = meta.enterpoint_node;
+          hnsw_index_metadata->emplace_back(meta_json.to_string());
           break;
         }
       }
     }
-
-    // Save index definition as JSON with HNSW metadata
-    TmpJson index_json;
-    index_json["name"] = index_name;
-    index_json["cmd"] = index_info.BuildRestoreCommand();
-
-    if (index_info.hnsw_metadata.has_value()) {
-      const auto& meta = index_info.hnsw_metadata.value();
-      TmpJson hnsw_meta;
-      hnsw_meta["max_elements"] = meta.max_elements;
-      hnsw_meta["cur_element_count"] = meta.cur_element_count;
-      hnsw_meta["maxlevel"] = meta.maxlevel;
-      hnsw_meta["enterpoint_node"] = meta.enterpoint_node;
-      hnsw_meta["M"] = meta.M;
-      hnsw_meta["maxM"] = meta.maxM;
-      hnsw_meta["maxM0"] = meta.maxM0;
-      hnsw_meta["ef_construction"] = meta.ef_construction;
-      hnsw_meta["mult"] = meta.mult;
-      index_json["hnsw_metadata"] = std::move(hnsw_meta);
-    }
-
-    search_indices->emplace_back(index_json.to_string());
 
     // Save synonym groups
     const auto& synonym_groups = index->GetSynonyms().GetGroups();
@@ -1476,16 +1466,18 @@ void CollectSearchIndices([[maybe_unused]] EngineShard* shard,
 }  // namespace
 
 RdbSaver::GlobalData RdbSaver::GetGlobalData(const Service* service, bool is_summary) {
-  StringVec script_bodies, search_indices, search_synonyms;
+  StringVec script_bodies, search_indices, search_synonyms, hnsw_index_metadata;
   size_t table_mem_result = 0;
 
   if (!is_summary) {
     shard_set->RunBriefInParallel([&](EngineShard* shard) {
       if (shard->shard_id() == 0)
-        CollectSearchIndices(shard, &search_indices, &search_synonyms, is_summary);
+        CollectSearchIndices(shard, &search_indices, &search_synonyms, &hnsw_index_metadata,
+                             is_summary);
     });
     return RdbSaver::GlobalData{std::move(script_bodies), std::move(search_indices),
-                                std::move(search_synonyms), table_mem_result};
+                                std::move(search_synonyms), std::move(hnsw_index_metadata),
+                                table_mem_result};
   }
   {
     // For summary file: collect all global data
@@ -1498,7 +1490,8 @@ RdbSaver::GlobalData RdbSaver::GetGlobalData(const Service* service, bool is_sum
   atomic<size_t> table_mem{0};
   shard_set->RunBriefInParallel([&](EngineShard* shard) {
     if (shard->shard_id() == 0)
-      CollectSearchIndices(shard, &search_indices, &search_synonyms, is_summary);
+      CollectSearchIndices(shard, &search_indices, &search_synonyms, &hnsw_index_metadata,
+                           is_summary);
 
     auto& db_slice = namespaces->GetDefaultNamespace().GetDbSlice(shard->shard_id());
     size_t shard_table_mem = 0;
@@ -1512,7 +1505,8 @@ RdbSaver::GlobalData RdbSaver::GetGlobalData(const Service* service, bool is_sum
   });
 
   return RdbSaver::GlobalData{std::move(script_bodies), std::move(search_indices),
-                              std::move(search_synonyms), table_mem.load(memory_order_relaxed)};
+                              std::move(search_synonyms), std::move(hnsw_index_metadata),
+                              table_mem.load(memory_order_relaxed)};
 }
 
 void RdbSaver::Impl::FillFreqMap(RdbTypeFreqMap* dest) const {
@@ -1648,9 +1642,13 @@ error_code RdbSaver::SaveAux(const GlobalData& glob_state) {
     if (!glob_state.search_indices.empty())
       LOG(WARNING) << "Dragonfly search index data is incompatible with the RDB format";
   } else {
-    // Search index definitions (JSON for summary, simple restore cmd for per-shard)
+    // Search index definitions (simple "index_name cmd" restore commands)
     for (const string& s : glob_state.search_indices)
       RETURN_ON_ERR(impl_->SaveAuxFieldStrStr("search-index", s));
+
+    // HNSW index metadata (JSON, summary only)
+    for (const string& s : glob_state.hnsw_index_metadata)
+      RETURN_ON_ERR(impl_->SaveAuxFieldStrStr("hnsw-index-metadata", s));
 
     // Save synonyms only in summary file
     DCHECK(save_mode_ != SaveMode::SINGLE_SHARD || glob_state.search_synonyms.empty());

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -82,10 +82,11 @@ class RdbSaver {
  public:
   // Global data which doesn't belong to shards and is serialized in header
   struct GlobalData {
-    const StringVec lua_scripts;      // bodies of lua scripts
-    const StringVec search_indices;   // ft.create commands to re-create search indices
-    const StringVec search_synonyms;  // ft.synupdate commands to restore synonyms
-    size_t table_used_memory = 0;     // total memory used by all tables in all shards
+    const StringVec lua_scripts;          // bodies of lua scripts
+    const StringVec search_indices;       // ft.create commands to re-create search indices
+    const StringVec search_synonyms;      // ft.synupdate commands to restore synonyms
+    const StringVec hnsw_index_metadata;  // HNSW metadata JSON (summary only)
+    size_t table_used_memory = 0;         // total memory used by all tables in all shards
   };
 
   // single_shard - true means that we run RdbSaver on a single shard and we do not use


### PR DESCRIPTION
removed extra fields from HNSW metadata serialization
store HNSW metadata in a separate AUX field