### PR TITLE
build: add optional ASAN support for release builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,15 @@ endif
 # all the release builds are performed by gcc.
 LINKER_FLAGS += -static-libstdc++ -static-libgcc
 
+# Optional ASAN support: make ASAN=1 release
+ifdef ASAN
+SANITIZE_COMPILE_FLAGS = -fsanitize=address -Wno-maybe-uninitialized
+SANITIZE_LINK_FLAGS = -fsanitize=address
+endif
+
 HELIO_FLAGS = -DHELIO_RELEASE_FLAGS="-g" \
-			  -DCMAKE_EXE_LINKER_FLAGS="$(LINKER_FLAGS)" \
+			  -DCMAKE_CXX_FLAGS="$(SANITIZE_COMPILE_FLAGS)" \
+			  -DCMAKE_EXE_LINKER_FLAGS="$(LINKER_FLAGS) $(SANITIZE_LINK_FLAGS)" \
               -DBoost_USE_STATIC_LIBS=$(HELIO_USE_STATIC_LIBS) \
               -DOPENSSL_USE_STATIC_LIBS=$(HELIO_OPENSSL_USE_STATIC_LIBS) \
               -DENABLE_GIT_VERSION=$(HELIO_ENABLE_GIT_VERSION) \


### PR DESCRIPTION
Add optional AddressSanitizer support for release builds via `make ASAN=1 release`.

Passes `-fsanitize=address` to both compiler and linker via `CMAKE_CXX_FLAGS` and `CMAKE_EXE_LINKER_FLAGS` (using `HELIO_RELEASE_FLAGS` doesn't work because `internal.cmake` wraps it in a generator expression that breaks with multiple flags).