### PR TITLE
fix: reject GAT command sent via Redis protocol instead of crashing

### DIFF
--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -1545,7 +1545,9 @@ void CmdMGet(CmdArgList args, CommandContext* cmd_cntx) {
 // GAT key [keys...]
 // The expiry argument is stored in mc_command()->expire_ts
 void CmdGAT(CmdArgList args, CommandContext* cmd_cntx) {
-  DCHECK(cmd_cntx->mc_command());
+  if (!cmd_cntx->mc_command()) {
+    return cmd_cntx->SendError("GAT is a memcache-only command");
+  }
   int64_t expire_ts = cmd_cntx->mc_command()->expire_ts;
   const DbSlice::ExpireParams expire_params{
       .value = expire_ts, .absolute = true, .persist = expire_ts == 0};

--- a/src/server/string_family_test.cc
+++ b/src/server/string_family_test.cc
@@ -978,6 +978,14 @@ TEST_F(StringFamilyTest, Digest) {
   EXPECT_THAT(Run({"digest", "list"}), ErrArg("WRONGTYPE"));
 }
 
+// GAT is a memcache-only command. Sending it via Redis RESP protocol should return an error
+// instead of crashing (DCHECK on mc_command()).
+TEST_F(StringFamilyTest, GatViaRedisProtocol) {
+  Run({"set", "key", "val"});
+  auto resp = Run({"GAT", "key"});
+  EXPECT_THAT(resp, ErrArg("memcache-only"));
+}
+
 TEST_F(StringFamilyTest, MSetNxOddArgs) {
   auto resp = Run({"msetnx", "key", "value", "key2"});
   EXPECT_THAT(resp, ErrArg("wrong number of arguments"));


### PR DESCRIPTION
GAT is a memcache-only command, but it was reachable via Redis RESP protocol, causing a crash on the `DCHECK(cmd_cntx->mc_command())` assertion. Replace the DCHECK with a runtime check that returns an error to the client.

Changes:
- Return an error when GAT is invoked without a memcache context
- Add regression test that sends GAT via Redis protocol

Fixes #6591