### PR TITLE
fix(tls): ub in HandleRequests after first socket read

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -714,7 +714,7 @@ void Connection::HandleRequests() {
     uint8_t buf[2];
     auto read_sz = socket_->Read(io::MutableBytes(buf));
     if (!read_sz || *read_sz < sizeof(buf)) {
-      auto msg = read_sz ? absl::StrCat("*read_size < sizeof(buf)") : read_sz.error().message();
+      auto msg = read_sz ? absl::StrCat(*read_sz, " < ", sizeof(buf)) : read_sz.error().message();
       LOG_EVERY_T(INFO, 1) << "Error reading from peer " << remote_ep << " " << msg
                            << ", socket state: " + dfly::GetSocketInfo(socket_->native_handle());
       stats_->tls_accept_disconnects++;

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -1601,15 +1601,10 @@ async def test_tls_partial_header_read(
     server.start()
 
     # Connect with raw socket and send only 1 byte (less than the 2-byte TLS header check)
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    try:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.connect(("localhost", server.port))
         # Send 1 byte (less than the 2-byte TLS header that dragonfly expects)
         sock.send(b"\x16")
-        # Close immediately after sending partial data
-        time.sleep(0.1)  # Give server time to process
-    finally:
-        sock.close()
 
     # If the server crashes due to UB, it will fail. Otherwise this test passes.
     # The server should handle this gracefully without crashing.


### PR DESCRIPTION
The bug:

```
if (!read_sz || *read_sz < sizeof(buf)) { 
   LOG_EVERY_T(INFO, 1) << "Error reading from peer " << remote_ep << " " << read_sz.error().message()                                                                                                                                                                              
                        << ", socket state: " + dfly::GetSocketInfo(socket_->native_handle());         
```

When read_size is the expected value, the expression `read_sz.error()` triggers UB since the active union member is not the error but the expected value!

* add test
* fix