### PR TITLE
fix: handle MEMORY USAGE without key argument instead of crashing

### DIFF
--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -919,6 +919,13 @@ TEST_F(DflyEngineTest, MemoryUsage) {
   EXPECT_GT(*resp.GetInt(), 100000);
 }
 
+// MEMORY USAGE without a key caused a DCHECK crash in CmdArgParser destructor
+// because the parser error was never consumed.
+TEST_F(DflyEngineTest, MemoryUsageNoKey) {
+  auto resp = Run({"memory", "usage"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
+}
+
 TEST_F(DflyEngineTest, DebugObject) {
   Run({"set", "key", "value"});
   Run({"lpush", "l1", "a", "b"});

--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -147,7 +147,10 @@ void MemoryCmd::Run(CmdArgList args) {
     return Stats();
   }
 
-  if (parser.Check("USAGE") && args.size() > 1) {
+  if (parser.Check("USAGE")) {
+    if (!parser.HasNext()) {
+      return cmd_cntx_->SendError(kSyntaxErr);
+    }
     string_view key = parser.Next();
     bool account_key_memory_usage = !parser.Check("WITHOUTKEY");
     return Usage(key, account_key_memory_usage);


### PR DESCRIPTION
`MEMORY USAGE` without a key caused a DCHECK crash in `CmdArgParser` destructor because `parser.Check("USAGE")` consumed the token, but the branch was skipped due to `args.size() > 1` being false, leaving a parser error unchecked.

Return `syntax error` when the key argument is missing.

Fixes #6596
