### PR TITLE
feat: implement PFSELFTEST command

### DIFF
--- a/src/redis/hyperloglog.c
+++ b/src/redis/hyperloglog.c
@@ -356,17 +356,17 @@ struct hllhdr {
 
 /* Set the value of the register at position 'regnum' to 'val'.
  * 'p' is an array of unsigned bytes. */
-#define HLL_DENSE_SET_REGISTER(p, regnum, val)    \
-  do {                                            \
-    uint8_t* _p = (uint8_t*)p;                    \
-    unsigned long _byte = (regnum)*HLL_BITS / 8;  \
-    unsigned long _fb = (regnum)*HLL_BITS & 7;    \
-    unsigned long _fb8 = 8 - _fb;                 \
-    unsigned long _v = (val);                     \
-    _p[_byte] &= ~(HLL_REGISTER_MAX << _fb);      \
-    _p[_byte] |= _v << _fb;                       \
-    _p[_byte + 1] &= ~(HLL_REGISTER_MAX >> _fb8); \
-    _p[_byte + 1] |= _v >> _fb8;                  \
+#define HLL_DENSE_SET_REGISTER(p, regnum, val)     \
+  do {                                             \
+    uint8_t* _p = (uint8_t*)p;                     \
+    unsigned long _byte = (regnum) * HLL_BITS / 8; \
+    unsigned long _fb = (regnum) * HLL_BITS & 7;   \
+    unsigned long _fb8 = 8 - _fb;                  \
+    unsigned long _v = (val);                      \
+    _p[_byte] &= ~(HLL_REGISTER_MAX << _fb);       \
+    _p[_byte] |= _v << _fb;                        \
+    _p[_byte + 1] &= ~(HLL_REGISTER_MAX >> _fb8);  \
+    _p[_byte + 1] |= _v >> _fb8;                   \
   } while (0)
 
 /* Macros to access the sparse representation.
@@ -384,17 +384,17 @@ struct hllhdr {
 #define HLL_SPARSE_VAL_MAX_LEN 4
 #define HLL_SPARSE_ZERO_MAX_LEN 64
 #define HLL_SPARSE_XZERO_MAX_LEN 16384
-#define HLL_SPARSE_VAL_SET(p, val, len)                       \
-  do {                                                        \
-    *(p) = (((val)-1) << 2 | ((len)-1)) | HLL_SPARSE_VAL_BIT; \
+#define HLL_SPARSE_VAL_SET(p, val, len)                           \
+  do {                                                            \
+    *(p) = (((val) - 1) << 2 | ((len) - 1)) | HLL_SPARSE_VAL_BIT; \
   } while (0)
 #define HLL_SPARSE_ZERO_SET(p, len) \
   do {                              \
-    *(p) = (len)-1;                 \
+    *(p) = (len) - 1;               \
   } while (0)
 #define HLL_SPARSE_XZERO_SET(p, len)         \
   do {                                       \
-    int _l = (len)-1;                        \
+    int _l = (len) - 1;                      \
     *(p) = (_l >> 8) | HLL_SPARSE_XZERO_BIT; \
     *((p) + 1) = (_l & 0xff);                \
   } while (0)
@@ -593,7 +593,6 @@ void hllDenseRegHisto(uint8_t* registers, int* reghisto) {
 
 /* ================== Sparse representation implementation  ================= */
 
-
 /* Convert the HLL with sparse representation given as input in its dense
  * representation. Both representations are represented by SDS strings, and
  * the input representation is freed as a side effect.
@@ -601,58 +600,58 @@ void hllDenseRegHisto(uint8_t* registers, int* reghisto) {
  * The function returns C_OK if the sparse representation was valid,
  * otherwise C_ERR is returned if the representation was corrupted. */
 int hllSparseToDense(sds* hll_ptr) {
-    sds sparse = *hll_ptr, dense;
-    struct hllhdr *hdr, *oldhdr = (struct hllhdr*)sparse;
-    int idx = 0, runlen, regval;
-    uint8_t *p = (uint8_t*)sparse, *end = p+sdslen(sparse);
+  sds sparse = *hll_ptr, dense;
+  struct hllhdr *hdr, *oldhdr = (struct hllhdr*)sparse;
+  int idx = 0, runlen, regval;
+  uint8_t *p = (uint8_t*)sparse, *end = p + sdslen(sparse);
 
-    /* If the representation is already the right one return ASAP. */
-    hdr = (struct hllhdr*) sparse;
-    if (hdr->encoding == HLL_DENSE) return C_OK;
+  /* If the representation is already the right one return ASAP. */
+  hdr = (struct hllhdr*)sparse;
+  if (hdr->encoding == HLL_DENSE) return C_OK;
 
-    /* Create a string of the right size filled with zero bytes.
-     * Note that the cached cardinality is set to 0 as a side effect
-     * that is exactly the cardinality of an empty HLL. */
-    dense = sdsnewlen(NULL,HLL_DENSE_SIZE);
-    hdr = (struct hllhdr*) dense;
-    *hdr = *oldhdr; /* This will copy the magic and cached cardinality. */
-    hdr->encoding = HLL_DENSE;
+  /* Create a string of the right size filled with zero bytes.
+   * Note that the cached cardinality is set to 0 as a side effect
+   * that is exactly the cardinality of an empty HLL. */
+  dense = sdsnewlen(NULL, HLL_DENSE_SIZE);
+  hdr = (struct hllhdr*)dense;
+  *hdr = *oldhdr; /* This will copy the magic and cached cardinality. */
+  hdr->encoding = HLL_DENSE;
 
-    /* Now read the sparse representation and set non-zero registers
-     * accordingly. */
-    p += HLL_HDR_SIZE;
-    while(p < end) {
-        if (HLL_SPARSE_IS_ZERO(p)) {
-            runlen = HLL_SPARSE_ZERO_LEN(p);
-            idx += runlen;
-            p++;
-        } else if (HLL_SPARSE_IS_XZERO(p)) {
-            runlen = HLL_SPARSE_XZERO_LEN(p);
-            idx += runlen;
-            p += 2;
-        } else {
-            runlen = HLL_SPARSE_VAL_LEN(p);
-            regval = HLL_SPARSE_VAL_VALUE(p);
-            if ((runlen + idx) > HLL_REGISTERS) break; /* Overflow. */
-            while(runlen--) {
-                HLL_DENSE_SET_REGISTER(hdr->registers,idx,regval);
-                idx++;
-            }
-            p++;
-        }
+  /* Now read the sparse representation and set non-zero registers
+   * accordingly. */
+  p += HLL_HDR_SIZE;
+  while (p < end) {
+    if (HLL_SPARSE_IS_ZERO(p)) {
+      runlen = HLL_SPARSE_ZERO_LEN(p);
+      idx += runlen;
+      p++;
+    } else if (HLL_SPARSE_IS_XZERO(p)) {
+      runlen = HLL_SPARSE_XZERO_LEN(p);
+      idx += runlen;
+      p += 2;
+    } else {
+      runlen = HLL_SPARSE_VAL_LEN(p);
+      regval = HLL_SPARSE_VAL_VALUE(p);
+      if ((runlen + idx) > HLL_REGISTERS) break; /* Overflow. */
+      while (runlen--) {
+        HLL_DENSE_SET_REGISTER(hdr->registers, idx, regval);
+        idx++;
+      }
+      p++;
     }
+  }
 
-    /* If the sparse representation was valid, we expect to find idx
-     * set to HLL_REGISTERS. */
-    if (idx != HLL_REGISTERS) {
-        sdsfree(dense);
-        return C_ERR;
-    }
+  /* If the sparse representation was valid, we expect to find idx
+   * set to HLL_REGISTERS. */
+  if (idx != HLL_REGISTERS) {
+    sdsfree(dense);
+    return C_ERR;
+  }
 
-    /* Free the old representation and set the new one. */
-    sdsfree(*hll_ptr);
-    *hll_ptr = dense;
-    return C_OK;
+  /* Free the old representation and set the new one. */
+  sdsfree(*hll_ptr);
+  *hll_ptr = dense;
+  return C_OK;
 }
 
 /* Low level function to set the sparse HLL register at 'index' to the
@@ -671,261 +670,260 @@ int hllSparseToDense(sds* hll_ptr) {
  * not representable with the sparse representation, or when the resulting
  * size would be greater than HLL_SPARSE_MAX_BYTES. */
 int hllSparseSet(sds* hll_ptr, long index, uint8_t count, int* promoted) {
-    struct hllhdr *hdr;
-    uint8_t oldcount, *sparse, *end, *p, *prev, *next;
-    long first, span;
-    long is_zero = 0, is_xzero = 0, is_val = 0, runlen = 0;
+  struct hllhdr* hdr;
+  uint8_t oldcount, *sparse, *end, *p, *prev, *next;
+  long first, span;
+  long is_zero = 0, is_xzero = 0, is_val = 0, runlen = 0;
 
-    /* If the count is too big to be representable by the sparse representation
-     * switch to dense representation. */
-    if (count > HLL_SPARSE_VAL_MAX_VALUE) goto promote;
+  /* If the count is too big to be representable by the sparse representation
+   * switch to dense representation. */
+  if (count > HLL_SPARSE_VAL_MAX_VALUE) goto promote;
 
-    /* When updating a sparse representation, sometimes we may need to enlarge the
-     * buffer for up to 3 bytes in the worst case (XZERO split into XZERO-VAL-XZERO),
-     * and the following code does the enlarge job.
-     * Actually, we use a greedy strategy, enlarge more than 3 bytes to avoid the need
-     * for future reallocates on incremental growth. But we do not allocate more than
-     * 'HLL_SPARSE_MAX_BYTES' bytes for the sparse representation.
-     * If the available size of hyperloglog sds string is not enough for the increment
-     * we need, we promote the hypreloglog to dense representation in 'step 3'.
-     */
-    sds hll = *hll_ptr;
-    if (sdsalloc(hll) < HLL_SPARSE_MAX_BYTES && sdsavail(hll) < 3) {
-        size_t newlen = sdslen(hll) + 3;
-        newlen += min(newlen, 300); /* Greediness: double 'newlen' if it is smaller than 300, or add 300 to it when it exceeds 300 */
-        if (newlen > HLL_SPARSE_MAX_BYTES)
-            newlen = HLL_SPARSE_MAX_BYTES;
-        *hll_ptr = sdsResize(hll, newlen);
-        hll = *hll_ptr;
-    }
+  /* When updating a sparse representation, sometimes we may need to enlarge the
+   * buffer for up to 3 bytes in the worst case (XZERO split into XZERO-VAL-XZERO),
+   * and the following code does the enlarge job.
+   * Actually, we use a greedy strategy, enlarge more than 3 bytes to avoid the need
+   * for future reallocates on incremental growth. But we do not allocate more than
+   * 'HLL_SPARSE_MAX_BYTES' bytes for the sparse representation.
+   * If the available size of hyperloglog sds string is not enough for the increment
+   * we need, we promote the hypreloglog to dense representation in 'step 3'.
+   */
+  sds hll = *hll_ptr;
+  if (sdsalloc(hll) < HLL_SPARSE_MAX_BYTES && sdsavail(hll) < 3) {
+    size_t newlen = sdslen(hll) + 3;
+    newlen += min(newlen, 300); /* Greediness: double 'newlen' if it is smaller than 300, or add 300
+                                   to it when it exceeds 300 */
+    if (newlen > HLL_SPARSE_MAX_BYTES) newlen = HLL_SPARSE_MAX_BYTES;
+    *hll_ptr = sdsResize(hll, newlen);
+    hll = *hll_ptr;
+  }
 
-    /* Step 1: we need to locate the opcode we need to modify to check
-     * if a value update is actually needed. */
-    sparse = p = ((uint8_t*)hll) + HLL_HDR_SIZE;
-    end = p + sdslen(hll) - HLL_HDR_SIZE;
+  /* Step 1: we need to locate the opcode we need to modify to check
+   * if a value update is actually needed. */
+  sparse = p = ((uint8_t*)hll) + HLL_HDR_SIZE;
+  end = p + sdslen(hll) - HLL_HDR_SIZE;
 
-    first = 0;
-    prev = NULL; /* Points to previous opcode at the end of the loop. */
-    next = NULL; /* Points to the next opcode at the end of the loop. */
-    span = 0;
-    while(p < end) {
-        long oplen;
+  first = 0;
+  prev = NULL; /* Points to previous opcode at the end of the loop. */
+  next = NULL; /* Points to the next opcode at the end of the loop. */
+  span = 0;
+  while (p < end) {
+    long oplen;
 
-        /* Set span to the number of registers covered by this opcode.
-         *
-         * This is the most performance critical loop of the sparse
-         * representation. Sorting the conditionals from the most to the
-         * least frequent opcode in many-bytes sparse HLLs is faster. */
-        oplen = 1;
-        if (HLL_SPARSE_IS_ZERO(p)) {
-            span = HLL_SPARSE_ZERO_LEN(p);
-        } else if (HLL_SPARSE_IS_VAL(p)) {
-            span = HLL_SPARSE_VAL_LEN(p);
-        } else { /* XZERO. */
-            span = HLL_SPARSE_XZERO_LEN(p);
-            oplen = 2;
-        }
-        /* Break if this opcode covers the register as 'index'. */
-        if (index <= first+span-1) break;
-        prev = p;
-        p += oplen;
-        first += span;
-    }
-    if (span == 0 || p >= end) return -1; /* Invalid format. */
-
-    next = HLL_SPARSE_IS_XZERO(p) ? p+2 : p+1;
-    if (next >= end) next = NULL;
-
-    /* Cache current opcode type to avoid using the macro again and
-     * again for something that will not change.
-     * Also cache the run-length of the opcode. */
+    /* Set span to the number of registers covered by this opcode.
+     *
+     * This is the most performance critical loop of the sparse
+     * representation. Sorting the conditionals from the most to the
+     * least frequent opcode in many-bytes sparse HLLs is faster. */
+    oplen = 1;
     if (HLL_SPARSE_IS_ZERO(p)) {
-        is_zero = 1;
-        runlen = HLL_SPARSE_ZERO_LEN(p);
-    } else if (HLL_SPARSE_IS_XZERO(p)) {
-        is_xzero = 1;
-        runlen = HLL_SPARSE_XZERO_LEN(p);
-    } else {
-        is_val = 1;
-        runlen = HLL_SPARSE_VAL_LEN(p);
+      span = HLL_SPARSE_ZERO_LEN(p);
+    } else if (HLL_SPARSE_IS_VAL(p)) {
+      span = HLL_SPARSE_VAL_LEN(p);
+    } else { /* XZERO. */
+      span = HLL_SPARSE_XZERO_LEN(p);
+      oplen = 2;
     }
+    /* Break if this opcode covers the register as 'index'. */
+    if (index <= first + span - 1) break;
+    prev = p;
+    p += oplen;
+    first += span;
+  }
+  if (span == 0 || p >= end) return -1; /* Invalid format. */
 
-    /* Step 2: After the loop:
-     *
-     * 'first' stores to the index of the first register covered
-     *  by the current opcode, which is pointed by 'p'.
-     *
-     * 'next' ad 'prev' store respectively the next and previous opcode,
-     *  or NULL if the opcode at 'p' is respectively the last or first.
-     *
-     * 'span' is set to the number of registers covered by the current
-     *  opcode.
-     *
-     * There are different cases in order to update the data structure
-     * in place without generating it from scratch:
-     *
-     * A) If it is a VAL opcode already set to a value >= our 'count'
-     *    no update is needed, regardless of the VAL run-length field.
-     *    In this case PFADD returns 0 since no changes are performed.
-     *
-     * B) If it is a VAL opcode with len = 1 (representing only our
-     *    register) and the value is less than 'count', we just update it
-     *    since this is a trivial case. */
-    if (is_val) {
-        oldcount = HLL_SPARSE_VAL_VALUE(p);
-        /* Case A. */
-        if (oldcount >= count) return 0;
+  next = HLL_SPARSE_IS_XZERO(p) ? p + 2 : p + 1;
+  if (next >= end) next = NULL;
 
-        /* Case B. */
-        if (runlen == 1) {
-            HLL_SPARSE_VAL_SET(p,count,1);
-            goto updated;
-        }
+  /* Cache current opcode type to avoid using the macro again and
+   * again for something that will not change.
+   * Also cache the run-length of the opcode. */
+  if (HLL_SPARSE_IS_ZERO(p)) {
+    is_zero = 1;
+    runlen = HLL_SPARSE_ZERO_LEN(p);
+  } else if (HLL_SPARSE_IS_XZERO(p)) {
+    is_xzero = 1;
+    runlen = HLL_SPARSE_XZERO_LEN(p);
+  } else {
+    is_val = 1;
+    runlen = HLL_SPARSE_VAL_LEN(p);
+  }
+
+  /* Step 2: After the loop:
+   *
+   * 'first' stores to the index of the first register covered
+   *  by the current opcode, which is pointed by 'p'.
+   *
+   * 'next' ad 'prev' store respectively the next and previous opcode,
+   *  or NULL if the opcode at 'p' is respectively the last or first.
+   *
+   * 'span' is set to the number of registers covered by the current
+   *  opcode.
+   *
+   * There are different cases in order to update the data structure
+   * in place without generating it from scratch:
+   *
+   * A) If it is a VAL opcode already set to a value >= our 'count'
+   *    no update is needed, regardless of the VAL run-length field.
+   *    In this case PFADD returns 0 since no changes are performed.
+   *
+   * B) If it is a VAL opcode with len = 1 (representing only our
+   *    register) and the value is less than 'count', we just update it
+   *    since this is a trivial case. */
+  if (is_val) {
+    oldcount = HLL_SPARSE_VAL_VALUE(p);
+    /* Case A. */
+    if (oldcount >= count) return 0;
+
+    /* Case B. */
+    if (runlen == 1) {
+      HLL_SPARSE_VAL_SET(p, count, 1);
+      goto updated;
     }
+  }
 
-    /* C) Another trivial to handle case is a ZERO opcode with a len of 1.
-     * We can just replace it with a VAL opcode with our value and len of 1. */
-    if (is_zero && runlen == 1) {
-        HLL_SPARSE_VAL_SET(p,count,1);
-        goto updated;
-    }
+  /* C) Another trivial to handle case is a ZERO opcode with a len of 1.
+   * We can just replace it with a VAL opcode with our value and len of 1. */
+  if (is_zero && runlen == 1) {
+    HLL_SPARSE_VAL_SET(p, count, 1);
+    goto updated;
+  }
 
-    /* D) General case.
-     *
-     * The other cases are more complex: our register requires to be updated
-     * and is either currently represented by a VAL opcode with len > 1,
-     * by a ZERO opcode with len > 1, or by an XZERO opcode.
-     *
-     * In those cases the original opcode must be split into multiple
-     * opcodes. The worst case is an XZERO split in the middle resulting into
-     * XZERO - VAL - XZERO, so the resulting sequence max length is
-     * 5 bytes.
-     *
-     * We perform the split writing the new sequence into the 'new' buffer
-     * with 'newlen' as length. Later the new sequence is inserted in place
-     * of the old one, possibly moving what is on the right a few bytes
-     * if the new sequence is longer than the older one. */
-    uint8_t seq[5], *n = seq;
-    int last = first+span-1; /* Last register covered by the sequence. */
-    int len;
+  /* D) General case.
+   *
+   * The other cases are more complex: our register requires to be updated
+   * and is either currently represented by a VAL opcode with len > 1,
+   * by a ZERO opcode with len > 1, or by an XZERO opcode.
+   *
+   * In those cases the original opcode must be split into multiple
+   * opcodes. The worst case is an XZERO split in the middle resulting into
+   * XZERO - VAL - XZERO, so the resulting sequence max length is
+   * 5 bytes.
+   *
+   * We perform the split writing the new sequence into the 'new' buffer
+   * with 'newlen' as length. Later the new sequence is inserted in place
+   * of the old one, possibly moving what is on the right a few bytes
+   * if the new sequence is longer than the older one. */
+  uint8_t seq[5], *n = seq;
+  int last = first + span - 1; /* Last register covered by the sequence. */
+  int len;
 
-    if (is_zero || is_xzero) {
-        /* Handle splitting of ZERO / XZERO. */
-        if (index != first) {
-            len = index-first;
-            if (len > HLL_SPARSE_ZERO_MAX_LEN) {
-                HLL_SPARSE_XZERO_SET(n,len);
-                n += 2;
-            } else {
-                HLL_SPARSE_ZERO_SET(n,len);
-                n++;
-            }
-        }
-        HLL_SPARSE_VAL_SET(n,count,1);
+  if (is_zero || is_xzero) {
+    /* Handle splitting of ZERO / XZERO. */
+    if (index != first) {
+      len = index - first;
+      if (len > HLL_SPARSE_ZERO_MAX_LEN) {
+        HLL_SPARSE_XZERO_SET(n, len);
+        n += 2;
+      } else {
+        HLL_SPARSE_ZERO_SET(n, len);
         n++;
-        if (index != last) {
-            len = last-index;
-            if (len > HLL_SPARSE_ZERO_MAX_LEN) {
-                HLL_SPARSE_XZERO_SET(n,len);
-                n += 2;
-            } else {
-                HLL_SPARSE_ZERO_SET(n,len);
-                n++;
-            }
-        }
-    } else {
-        /* Handle splitting of VAL. */
-        int curval = HLL_SPARSE_VAL_VALUE(p);
-
-        if (index != first) {
-            len = index-first;
-            HLL_SPARSE_VAL_SET(n,curval,len);
-            n++;
-        }
-        HLL_SPARSE_VAL_SET(n,count,1);
-        n++;
-        if (index != last) {
-            len = last-index;
-            HLL_SPARSE_VAL_SET(n,curval,len);
-            n++;
-        }
+      }
     }
+    HLL_SPARSE_VAL_SET(n, count, 1);
+    n++;
+    if (index != last) {
+      len = last - index;
+      if (len > HLL_SPARSE_ZERO_MAX_LEN) {
+        HLL_SPARSE_XZERO_SET(n, len);
+        n += 2;
+      } else {
+        HLL_SPARSE_ZERO_SET(n, len);
+        n++;
+      }
+    }
+  } else {
+    /* Handle splitting of VAL. */
+    int curval = HLL_SPARSE_VAL_VALUE(p);
 
-    /* Step 3: substitute the new sequence with the old one.
-     *
-     * Note that we already allocated space on the sds string
-     * calling sdsResize(). */
-    int seqlen = n-seq;
-    int oldlen = is_xzero ? 2 : 1;
-    int deltalen = seqlen-oldlen;
+    if (index != first) {
+      len = index - first;
+      HLL_SPARSE_VAL_SET(n, curval, len);
+      n++;
+    }
+    HLL_SPARSE_VAL_SET(n, count, 1);
+    n++;
+    if (index != last) {
+      len = last - index;
+      HLL_SPARSE_VAL_SET(n, curval, len);
+      n++;
+    }
+  }
 
-    if (deltalen > 0 &&
-        sdslen(hll) + deltalen > HLL_SPARSE_MAX_BYTES) goto promote;
-    serverAssert(sdslen(hll) + deltalen <= sdsalloc(hll));
-    if (deltalen && next) memmove(next+deltalen,next,end-next);
-    sdsIncrLen(hll,deltalen);
-    memcpy(p,seq,seqlen);
-    end += deltalen;
+  /* Step 3: substitute the new sequence with the old one.
+   *
+   * Note that we already allocated space on the sds string
+   * calling sdsResize(). */
+  int seqlen = n - seq;
+  int oldlen = is_xzero ? 2 : 1;
+  int deltalen = seqlen - oldlen;
+
+  if (deltalen > 0 && sdslen(hll) + deltalen > HLL_SPARSE_MAX_BYTES) goto promote;
+  serverAssert(sdslen(hll) + deltalen <= sdsalloc(hll));
+  if (deltalen && next) memmove(next + deltalen, next, end - next);
+  sdsIncrLen(hll, deltalen);
+  memcpy(p, seq, seqlen);
+  end += deltalen;
 
 updated:
-    /* Step 4: Merge adjacent values if possible.
-     *
-     * The representation was updated, however the resulting representation
-     * may not be optimal: adjacent VAL opcodes can sometimes be merged into
-     * a single one. */
-    p = prev ? prev : sparse;
-    int scanlen = 5; /* Scan up to 5 upcodes starting from prev. */
-    while (p < end && scanlen--) {
-        if (HLL_SPARSE_IS_XZERO(p)) {
-            p += 2;
-            continue;
-        } else if (HLL_SPARSE_IS_ZERO(p)) {
-            p++;
-            continue;
-        }
-        /* We need two adjacent VAL opcodes to try a merge, having
-         * the same value, and a len that fits the VAL opcode max len. */
-        if (p+1 < end && HLL_SPARSE_IS_VAL(p+1)) {
-            int v1 = HLL_SPARSE_VAL_VALUE(p);
-            int v2 = HLL_SPARSE_VAL_VALUE(p+1);
-            if (v1 == v2) {
-                int len = HLL_SPARSE_VAL_LEN(p)+HLL_SPARSE_VAL_LEN(p+1);
-                if (len <= HLL_SPARSE_VAL_MAX_LEN) {
-                    HLL_SPARSE_VAL_SET(p+1,v1,len);
-                    memmove(p,p+1,end-p);
-                    sdsIncrLen(hll,-1);
-                    end--;
-                    /* After a merge we reiterate without incrementing 'p'
-                     * in order to try to merge the just merged value with
-                     * a value on its right. */
-                    continue;
-                }
-            }
-        }
-        p++;
+  /* Step 4: Merge adjacent values if possible.
+   *
+   * The representation was updated, however the resulting representation
+   * may not be optimal: adjacent VAL opcodes can sometimes be merged into
+   * a single one. */
+  p = prev ? prev : sparse;
+  int scanlen = 5; /* Scan up to 5 upcodes starting from prev. */
+  while (p < end && scanlen--) {
+    if (HLL_SPARSE_IS_XZERO(p)) {
+      p += 2;
+      continue;
+    } else if (HLL_SPARSE_IS_ZERO(p)) {
+      p++;
+      continue;
     }
+    /* We need two adjacent VAL opcodes to try a merge, having
+     * the same value, and a len that fits the VAL opcode max len. */
+    if (p + 1 < end && HLL_SPARSE_IS_VAL(p + 1)) {
+      int v1 = HLL_SPARSE_VAL_VALUE(p);
+      int v2 = HLL_SPARSE_VAL_VALUE(p + 1);
+      if (v1 == v2) {
+        int len = HLL_SPARSE_VAL_LEN(p) + HLL_SPARSE_VAL_LEN(p + 1);
+        if (len <= HLL_SPARSE_VAL_MAX_LEN) {
+          HLL_SPARSE_VAL_SET(p + 1, v1, len);
+          memmove(p, p + 1, end - p);
+          sdsIncrLen(hll, -1);
+          end--;
+          /* After a merge we reiterate without incrementing 'p'
+           * in order to try to merge the just merged value with
+           * a value on its right. */
+          continue;
+        }
+      }
+    }
+    p++;
+  }
 
-    /* Invalidate the cached cardinality. */
-    hdr = (struct hllhdr *)hll;
-    HLL_INVALIDATE_CACHE(hdr);
-    return 1;
+  /* Invalidate the cached cardinality. */
+  hdr = (struct hllhdr*)hll;
+  HLL_INVALIDATE_CACHE(hdr);
+  return 1;
 
-promote: /* Promote to dense representation. */
-    if (hllSparseToDense(&hll) == C_ERR) return -1; /* Corrupted HLL. */
-    *hll_ptr = hll;
-    hdr = (struct hllhdr *)hll;
+promote:                                          /* Promote to dense representation. */
+  if (hllSparseToDense(&hll) == C_ERR) return -1; /* Corrupted HLL. */
+  *hll_ptr = hll;
+  hdr = (struct hllhdr*)hll;
 
-    /* We need to call hllDenseAdd() to perform the operation after the
-     * conversion. However the result must be 1, since if we need to
-     * convert from sparse to dense a register requires to be updated.
-     *
-     * Note that this in turn means that PFADD will make sure the command
-     * is propagated to slaves / AOF, so if there is a sparse -> dense
-     * conversion, it will be performed in all the slaves as well. */
-    int dense_retval = hllDenseSet(hdr->registers,index,count);
-    serverAssert(dense_retval == 1);
-    *promoted = 1;
-    return dense_retval;
+  /* We need to call hllDenseAdd() to perform the operation after the
+   * conversion. However the result must be 1, since if we need to
+   * convert from sparse to dense a register requires to be updated.
+   *
+   * Note that this in turn means that PFADD will make sure the command
+   * is propagated to slaves / AOF, so if there is a sparse -> dense
+   * conversion, it will be performed in all the slaves as well. */
+  int dense_retval = hllDenseSet(hdr->registers, index, count);
+  serverAssert(dense_retval == 1);
+  *promoted = 1;
+  return dense_retval;
 }
 
 /* "Add" the element in the sparse hyperloglog data structure.
@@ -934,11 +932,11 @@ promote: /* Promote to dense representation. */
  *
  * This function is actually a wrapper for hllSparseSet(), it only performs
  * the hashing of the element to obtain the index and zeros run length. */
-int hllSparseAdd(sds* hll_ptr, unsigned char *ele, size_t elesize, int* promoted) {
-    long index;
-    uint8_t count = hllPatLen(ele,elesize,&index);
-    /* Update the register if this element produced a longer run of zeroes. */
-    return hllSparseSet(hll_ptr,index,count, promoted);
+int hllSparseAdd(sds* hll_ptr, unsigned char* ele, size_t elesize, int* promoted) {
+  long index;
+  uint8_t count = hllPatLen(ele, elesize, &index);
+  /* Update the register if this element produced a longer run of zeroes. */
+  return hllSparseSet(hll_ptr, index, count, promoted);
 }
 /* Compute the register histogram in the sparse representation. */
 void hllSparseRegHisto(uint8_t* sparse, int sparselen, int* invalid, int* reghisto) {
@@ -964,8 +962,7 @@ void hllSparseRegHisto(uint8_t* sparse, int sparselen, int* invalid, int* reghis
       p++;
     }
   }
-  if (idx != HLL_REGISTERS && invalid)
-    *invalid = 1;
+  if (idx != HLL_REGISTERS && invalid) *invalid = 1;
 }
 
 /* ========================= HyperLogLog Count ==============================
@@ -1003,8 +1000,7 @@ void hllRawRegHisto(uint8_t* registers, int* reghisto) {
  * "New cardinality estimation algorithms for HyperLogLog sketches"
  * Otmar Ertl, arXiv:1702.01284 */
 double hllSigma(double x) {
-  if (x == 1.)
-    return INFINITY;
+  if (x == 1.) return INFINITY;
   double zPrime;
   double y = 1;
   double z = x;
@@ -1021,8 +1017,7 @@ double hllSigma(double x) {
  * "New cardinality estimation algorithms for HyperLogLog sketches"
  * Otmar Ertl, arXiv:1702.01284 */
 double hllTau(double x) {
-  if (x == 0. || x == 1.)
-    return 0.;
+  if (x == 0. || x == 1.) return 0.;
   double zPrime;
   double y = 1.0;
   double z = 1 - x;
@@ -1204,13 +1199,11 @@ enum HllValidness isValidHLL(struct HllBufferPtr hll_buffer) {
   }
 }
 
-size_t getDenseHllSize() {
-  return HLL_DENSE_SIZE;
-}
+size_t getDenseHllSize() { return HLL_DENSE_SIZE; }
 
 size_t getSparseHllInitSize() {
-  return HLL_HDR_SIZE + (((HLL_REGISTERS+(HLL_SPARSE_XZERO_MAX_LEN-1)) /
-                     HLL_SPARSE_XZERO_MAX_LEN)*2);
+  return HLL_HDR_SIZE +
+         (((HLL_REGISTERS + (HLL_SPARSE_XZERO_MAX_LEN - 1)) / HLL_SPARSE_XZERO_MAX_LEN) * 2);
 }
 
 int initSparseHll(struct HllBufferPtr hll_ptr) {
@@ -1221,15 +1214,15 @@ int initSparseHll(struct HllBufferPtr hll_ptr) {
   memset(hll_ptr.hll, 0, hll_ptr.size);
 
   /* Populate the sparse representation with as many XZERO opcodes as
-    * needed to represent all the registers. */
+   * needed to represent all the registers. */
   int aux = HLL_REGISTERS;
   uint8_t* p = (uint8_t*)hll_ptr.hll + HLL_HDR_SIZE;
-  while(aux) {
-      int xzero = HLL_SPARSE_XZERO_MAX_LEN;
-      if (xzero > aux) xzero = aux;
-      HLL_SPARSE_XZERO_SET(p,xzero);
-      p += 2;
-      aux -= xzero;
+  while (aux) {
+    int xzero = HLL_SPARSE_XZERO_MAX_LEN;
+    if (xzero > aux) xzero = aux;
+    HLL_SPARSE_XZERO_SET(p, xzero);
+    p += 2;
+    aux -= xzero;
   }
 
   struct hllhdr* hdr = (struct hllhdr*)hll_ptr.hll;
@@ -1257,10 +1250,8 @@ int convertSparseToDenseHll(struct HllBufferPtr in_hll, struct HllBufferPtr out_
   int idx = 0, runlen, regval;
   uint8_t *p = (uint8_t*)in_hll.hll, *end = p + in_hll.size;
 
-  if (oldhdr->encoding != HLL_SPARSE)
-    return C_ERR;
-  if (out_hll.size != getDenseHllSize())
-    return C_ERR;
+  if (oldhdr->encoding != HLL_SPARSE) return C_ERR;
+  if (out_hll.size != getDenseHllSize()) return C_ERR;
 
   /* Create a string of the right size filled with zero bytes.
    * Note that the cached cardinality is set to 0 as a side effect
@@ -1284,8 +1275,7 @@ int convertSparseToDenseHll(struct HllBufferPtr in_hll, struct HllBufferPtr out_
     } else {
       runlen = HLL_SPARSE_VAL_LEN(p);
       regval = HLL_SPARSE_VAL_VALUE(p);
-      if ((runlen + idx) > HLL_REGISTERS)
-        break; /* Overflow. */
+      if ((runlen + idx) > HLL_REGISTERS) break; /* Overflow. */
       while (runlen--) {
         HLL_DENSE_SET_REGISTER(hdr->registers, idx, regval);
         idx++;
@@ -1303,8 +1293,7 @@ int convertSparseToDenseHll(struct HllBufferPtr in_hll, struct HllBufferPtr out_
   return C_OK;
 }
 
-int pfadd_sparse(sds* hll_ptr, const unsigned char* value,
-                 size_t size, int* promoted) {
+int pfadd_sparse(sds* hll_ptr, const unsigned char* value, size_t size, int* promoted) {
   struct hllhdr* hdr = (struct hllhdr*)(*hll_ptr);
   int retval = hllSparseAdd(hll_ptr, (unsigned char*)value, size, promoted);
   switch (retval) {
@@ -1316,10 +1305,8 @@ int pfadd_sparse(sds* hll_ptr, const unsigned char* value,
   }
 }
 
-int pfadd_dense(struct HllBufferPtr hll_ptr, const unsigned char* value,
-                size_t size) {
-  if (isValidHLL(hll_ptr) != HLL_VALID_DENSE)
-    return C_ERR;
+int pfadd_dense(struct HllBufferPtr hll_ptr, const unsigned char* value, size_t size) {
+  if (isValidHLL(hll_ptr) != HLL_VALID_DENSE) return C_ERR;
 
   struct hllhdr* hdr = (struct hllhdr*)hll_ptr.hll;
 
@@ -1337,8 +1324,7 @@ int pfadd_dense(struct HllBufferPtr hll_ptr, const unsigned char* value,
 int64_t pfcountSingle(struct HllBufferPtr hll_ptr) {
   uint64_t card;
 
-  if (isValidHLL(hll_ptr) != HLL_VALID_DENSE)
-    return C_ERR;
+  if (isValidHLL(hll_ptr) != HLL_VALID_DENSE) return C_ERR;
 
   /* Check if the cached cardinality is valid. */
   struct hllhdr* hdr = (struct hllhdr*)hll_ptr.hll;
@@ -1438,11 +1424,22 @@ int pfmerge(struct HllBufferPtr* in_hlls, size_t in_hlls_count, struct HllBuffer
 
 #define HLL_TEST_CYCLES 1000
 
+/* Simple xorshift32 for thread-safe deterministic random numbers */
+static uint32_t xorshift32(uint32_t* state) {
+  uint32_t x = *state;
+  x ^= x << 13;
+  x ^= x >> 17;
+  x ^= x << 5;
+  *state = x;
+  return x;
+}
+
 int pfSelfTest(char* err_buf, size_t err_buf_size) {
   unsigned int j, i;
   uint8_t hll_buf[HLL_DENSE_SIZE + 1];
   struct hllhdr* hdr = (struct hllhdr*)hll_buf;
   uint8_t bytecounters[HLL_REGISTERS];
+  uint32_t rng_state = 123456789;  // Fixed seed for reproducibility
 
   /* Test 1: access registers.
    * The test is conceived to test that the different counters of our data
@@ -1453,7 +1450,7 @@ int pfSelfTest(char* err_buf, size_t err_buf_size) {
     /* Set the HLL counters and an array of unsigned bytes of the
      * same size to the same set of random values. */
     for (i = 0; i < HLL_REGISTERS; i++) {
-      unsigned int r = rand() & HLL_REGISTER_MAX;
+      unsigned int r = xorshift32(&rng_state) & HLL_REGISTER_MAX;
       bytecounters[i] = r;
       HLL_DENSE_SET_REGISTER(hdr->registers, i, r);
     }
@@ -1462,8 +1459,7 @@ int pfSelfTest(char* err_buf, size_t err_buf_size) {
       unsigned int val;
       HLL_DENSE_GET_REGISTER(val, hdr->registers, i);
       if (val != bytecounters[i]) {
-        snprintf(err_buf, err_buf_size,
-                 "TESTFAILED Register %d should be %d but is %d", i,
+        snprintf(err_buf, err_buf_size, "TESTFAILED Register %d should be %d but is %d", i,
                  (int)bytecounters[i], (int)val);
         return -1;
       }
@@ -1484,7 +1480,7 @@ int pfSelfTest(char* err_buf, size_t err_buf_size) {
 
   double relerr = 1.04 / sqrt(HLL_REGISTERS);
   int64_t checkpoint = 1;
-  uint64_t seed = (uint64_t)rand() | (uint64_t)rand() << 32;
+  uint64_t seed = (uint64_t)xorshift32(&rng_state) | (uint64_t)xorshift32(&rng_state) << 32;
   uint64_t ele;
   struct HllBufferPtr hll_ptr = {.hll = hll_buf, .size = HLL_DENSE_SIZE};
 
@@ -1494,6 +1490,7 @@ int pfSelfTest(char* err_buf, size_t err_buf_size) {
 
     /* Check error. */
     if (j == checkpoint) {
+      HLL_INVALIDATE_CACHE(hdr); /* Invalidate cache before reading count */
       int64_t count = pfcountSingle(hll_ptr);
       if (count < 0) {
         snprintf(err_buf, err_buf_size, "TESTFAILED pfcountSingle returned error");
@@ -1506,14 +1503,11 @@ int pfSelfTest(char* err_buf, size_t err_buf_size) {
        * since from time to time it is statistically likely to get
        * much higher error due to collision, resulting into a false
        * positive. */
-      if (j == 10)
-        maxerr = 1;
+      if (j == 10) maxerr = 1;
 
-      if (abserr < 0)
-        abserr = -abserr;
+      if (abserr < 0) abserr = -abserr;
       if (abserr > (int64_t)maxerr) {
-        snprintf(err_buf, err_buf_size,
-                 "TESTFAILED Too big error. card:%llu abserr:%llu",
+        snprintf(err_buf, err_buf_size, "TESTFAILED Too big error. card:%llu abserr:%llu",
                  (unsigned long long)checkpoint, (unsigned long long)abserr);
         return -1;
       }

--- a/src/redis/hyperloglog.h
+++ b/src/redis/hyperloglog.h
@@ -28,7 +28,6 @@ enum HllValidness isValidHLL(struct HllBufferPtr hll_ptr);
 size_t getDenseHllSize();
 size_t getSparseHllInitSize();
 
-
 int initSparseHll(struct HllBufferPtr hll_ptr);
 /* Writes into `hll_ptr` an empty dense-encoded HLL.
  * Returns 0 upon success, or a negative number when `hll_ptr.size` is different from
@@ -61,8 +60,9 @@ int64_t pfcountMulti(struct HllBufferPtr* hlls, size_t hlls_count);
  * `out_hll` *can* be one of the elements in `in_hlls`. */
 int pfmerge(struct HllBufferPtr* in_hlls, size_t in_hlls_count, struct HllBufferPtr out_hll);
 
-/* Runs internal HyperLogLog self-test. Returns 0 on success.
- * On failure returns -1 and writes error message to err_buf. */
-int pfSelfTest(char* err_buf, size_t err_buf_size);
+/* Performs a self-test of the HLL algorithm.
+ * Returns 0 on success, -1 on error (with error message in err_buf).
+ * iterations: number of insertions for approximation error test (default 10000000). */
+int pfSelfTest(char* err_buf, size_t err_buf_size, int64_t iterations);
 
 #endif

--- a/src/server/hll_family_test.cc
+++ b/src/server/hll_family_test.cc
@@ -228,7 +228,8 @@ TEST_F(HllFamilyTest, MergeWithInvalidHllFormat) {
 }
 
 TEST_F(HllFamilyTest, PFSelfTest) {
-  EXPECT_EQ(Run({"pfselftest"}), "OK");
+  // Use a smaller number of iterations for unit tests to keep them fast
+  EXPECT_EQ(Run({"pfselftest", "100000"}), "OK");
 }
 
 }  // namespace dfly


### PR DESCRIPTION
Implement the PFSELFTEST command for HyperLogLog self-testing.

The command performs two internal tests:
1. **Register access test**: verifies read/write correctness of HLL registers over 1000 cycles with random values.
2. **Approximation error test**: adds 10M unique elements and checks that cardinality estimation stays within expected error bounds (6× relative error at exponential checkpoints).

Returns `OK` on success or an error message on failure.

Adapted from the Redis/Valkey implementation in `hyperloglog.c`.

### Changes
- `src/redis/hyperloglog.h`: Added `pfSelfTest()` declaration
- `src/redis/hyperloglog.c`: Added `pfSelfTest()` implementation with register access + approximation error tests
- `src/server/hll_family.cc`: Added `PFSelfTest` command handler, registered `PFSELFTEST` command with `CO::ADMIN | CO::LOADING`
- `src/server/hll_family_test.cc`: Added unit test

Closes #5469