### PR TITLE
fix: reject SCRIPT FLAGS with invalid SHA length instead of crashing

### DIFF
--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -893,6 +893,10 @@ TEST_F(MultiTest, ScriptFlagsCommand) {
   }
 }
 
+TEST_F(MultiTest, ScriptFlagsInvalidSha) {
+  EXPECT_THAT(Run({"script", "flags", "short", "allow-undeclared-keys"}), ErrArg(""));
+}
+
 TEST_F(MultiTest, ScriptFlagsEmbedded) {
   const char* s1 = R"(
   --!df flags=allow-undeclared-keys

--- a/src/server/script_mgr.cc
+++ b/src/server/script_mgr.cc
@@ -171,8 +171,13 @@ void ScriptMgr::LoadCmd(CmdArgList args, Transaction* tx, SinkReplyBuilder* buil
 }
 
 void ScriptMgr::ConfigCmd(CmdArgList args, Transaction* tx, SinkReplyBuilder* builder) {
+  string_view sha = ArgS(args, 1);
+  if (sha.size() != ScriptKey{}.size()) {
+    return builder->SendError(kSyntaxErr);
+  }
+
   lock_guard lk{mu_};
-  ScriptKey key{ArgS(args, 1)};
+  ScriptKey key{sha};
   auto& data = db_[key];
 
   for (auto flag : args.subspan(2)) {


### PR DESCRIPTION
Validate SHA length in `SCRIPT FLAGS` before constructing `ScriptKey`.
Previously, a non-40-character SHA triggered a `DCHECK` crash.

Fixes: #6602