### PR TITLE
Refactor bitops/stream updater storage

### DIFF
--- a/src/server/bitops_family_test.cc
+++ b/src/server/bitops_family_test.cc
@@ -12,6 +12,7 @@
 #include "base/gtest.h"
 #include "base/logging.h"
 #include "facade/facade_test.h"
+#include "server/common.h"
 #include "server/conn_context.h"
 #include "server/engine_shard_set.h"
 #include "server/error.h"
@@ -445,6 +446,32 @@ TEST_F(BitOpsFamilyTest, BitOpsNot) {
   EXPECT_EQ(res, NOT_RESULTS);
 }
 
+TEST_F(BitOpsFamilyTest, BitOpOverwritesNonStringKeyAccounting) {
+  string long_value(128, 'a');
+  auto resp = Run({"set", "src", long_value});
+  EXPECT_EQ(resp, "OK");
+
+  resp = Run({"rpush", "dest", "a", "b", "c"});
+  EXPECT_THAT(resp, IntArg(3));
+
+  Metrics before = GetMetrics();
+  ASSERT_FALSE(before.db_stats.empty());
+  const size_t list_before = before.db_stats[0].memory_usage_by_type[OBJ_LIST];
+  const size_t str_before = before.db_stats[0].memory_usage_by_type[OBJ_STRING];
+  ASSERT_GT(list_before, 0u);
+
+  resp = Run({"bitop", "or", "dest", "src"});
+  EXPECT_THAT(resp, IntArg(128));
+  EXPECT_EQ(Run({"type", "dest"}), "string");
+  EXPECT_EQ(Run({"get", "dest"}), long_value);
+
+  Metrics after = GetMetrics();
+  const size_t list_after = after.db_stats[0].memory_usage_by_type[OBJ_LIST];
+  const size_t str_after = after.db_stats[0].memory_usage_by_type[OBJ_STRING];
+  EXPECT_EQ(0, list_after);
+  EXPECT_GT(str_after, str_before);
+}
+
 TEST_F(BitOpsFamilyTest, BitPos) {
   ASSERT_EQ(Run({"set", "a", "\x00\x00\x06\xff\xf0"_b}), "OK");
 
@@ -612,7 +639,7 @@ TEST_F(BitOpsFamilyTest, BitFieldOverflowUnderflow) {
 
   // unsigned 63bit
   int64_t max = std::numeric_limits<int64_t>::max();
-  Run({"bitfield", "foo", "set", "i64", "0", absl::StrCat(max)});
+  Run({"bitfield", "foo", "set", "i64", "0", StrCat(max)});
   ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i64", "0", "1"}), IntArg(-max - 1));
 
   // signed 1 bit
@@ -623,11 +650,11 @@ TEST_F(BitOpsFamilyTest, BitFieldOverflowUnderflow) {
   ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i1", "0", "-3"}), IntArg(-1));
 
   int64_t min = std::numeric_limits<int64_t>::min();
-  Run({"bitfield", "foo", "set", "i8", "0", absl::StrCat(min)});
+  Run({"bitfield", "foo", "set", "i8", "0", StrCat(min)});
   ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "0"}), IntArg(0));
 
   // signed 64 bit
-  Run({"bitfield", "foo", "set", "i64", "0", absl::StrCat(min)});
+  Run({"bitfield", "foo", "set", "i64", "0", StrCat(min)});
   ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i64", "0", "-1"}), IntArg(max));
 
   // overflow sat
@@ -639,7 +666,7 @@ TEST_F(BitOpsFamilyTest, BitFieldOverflowUnderflow) {
 
   // unsigned 63 bit
   Run({"bitfield", "foo", "set", "u63", "0", "0"});
-  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "set", "u63", "0", absl::StrCat(max)}),
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "set", "u63", "0", StrCat(max)}),
               IntArg(0));
   ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "incrby", "u63", "0", "10"}), IntArg(max));
 
@@ -652,12 +679,12 @@ TEST_F(BitOpsFamilyTest, BitFieldOverflowUnderflow) {
 
   // signed 64 bit
   Run({"bitfield", "foo", "set", "i64", "0", "0"});
-  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "set", "i64", "0", absl::StrCat(max)}),
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "set", "i64", "0", StrCat(max)}),
               IntArg(0));
   ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "incrby", "i64", "0", "100"}),
               IntArg(max));
   ASSERT_THAT(Run({"bitfield", "foo", "get", "i64", "0"}), IntArg(max));
-  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "set", "i64", "0", absl::StrCat(min)}),
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "set", "i64", "0", StrCat(min)}),
               IntArg(max));
   ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "incrby", "i64", "0", "-100"}),
               IntArg(min));

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -548,9 +548,8 @@ void SliceSnapshot::OnMoved(DbIndex id, const DbSlice::MovedItemsVec& items) {
 }
 
 // For any key any journal entry must arrive at the replica strictly after its first original rdb
-// value. This is guaranteed by the fact that OnJournalEntry runs always after OnDbChange, and
-// no database switch can be performed between those two calls, because they are part of one
-// transaction.
+// value. This is guaranteed because journal change callbacks run after OnDbChange, and no
+// database switch can be performed between those two calls, as they are part of one transaction.
 void SliceSnapshot::ConsumeJournalChange(const journal::JournalChangeItem& item) {
   // We grab the lock in case we are in the middle of serializing a bucket, so it serves as a
   // barrier here for atomic serialization.

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -1288,8 +1288,7 @@ OpStatus OpCreate(const OpArgs& op_args, string_view key, const CreateOpts& opts
 struct FindGroupResult {
   stream* s = nullptr;
   streamCG* cg = nullptr;
-  DbSlice::AutoUpdater post_updater;
-  DbSlice::Iterator it;
+  DbSlice::ItAndUpdater it;
 };
 
 OpResult<FindGroupResult> FindGroup(const OpArgs& op_args, string_view key, string_view gname,
@@ -1304,7 +1303,7 @@ OpResult<FindGroupResult> FindGroup(const OpArgs& op_args, string_view key, stri
   if (skip_group && !cg)
     return OpStatus::SKIPPED;
 
-  return FindGroupResult{s, cg, std::move(res_it->post_updater), res_it->it};
+  return FindGroupResult{s, cg, std::move(*res_it)};
 }
 
 // Try to get the consumer. If not found, create a new one.
@@ -1467,7 +1466,7 @@ OpResult<ClaimInfo> OpClaim(const OpArgs& op_args, string_view key, const ClaimO
       // TODO: propagate this change with streamPropagateXCLAIM
     }
   }
-  tracker.UpdateStreamSize(cgr_res->it->second);
+  tracker.UpdateStreamSize(cgr_res->it.it->second);
   return result;
 }
 
@@ -1480,7 +1479,7 @@ OpStatus OpDestroyGroup(const OpArgs& op_args, string_view key, string_view gnam
   raxRemove(cgr_res->s->cgroups, (uint8_t*)(gname.data()), gname.size(), NULL);
   streamFreeCG(cgr_res->cg);
 
-  mem_tracker.UpdateStreamSize(cgr_res->it->second);
+  mem_tracker.UpdateStreamSize(cgr_res->it.it->second);
 
   // Awake readers blocked on this group
   auto blocking_controller = op_args.db_cntx.ns->GetBlockingController(op_args.shard->shard_id());
@@ -1512,7 +1511,7 @@ OpResult<uint32_t> OpCreateConsumer(const OpArgs& op_args, string_view key, stri
   streamConsumer* consumer = StreamCreateConsumer(
       cgroup_res->cg, consumer_name, op_args.db_cntx.time_now_ms, SCC_NO_NOTIFY | SCC_NO_DIRTIFY);
 
-  mem_tracker.UpdateStreamSize(cgroup_res->it->second);
+  mem_tracker.UpdateStreamSize(cgroup_res->it.it->second);
   return consumer ? OpStatus::OK : OpStatus::KEY_EXISTS;
 }
 
@@ -1530,7 +1529,7 @@ OpResult<uint32_t> OpDelConsumer(const OpArgs& op_args, string_view key, string_
     streamDelConsumer(cgroup_res->cg, consumer);
   }
 
-  mem_tracker.UpdateStreamSize(cgroup_res->it->second);
+  mem_tracker.UpdateStreamSize(cgroup_res->it.it->second);
   return pending;
 }
 
@@ -1685,7 +1684,7 @@ OpResult<uint32_t> OpAck(const OpArgs& op_args, string_view key, string_view gna
       acknowledged++;
     }
   }
-  mem_tracker.UpdateStreamSize(res->it->second);
+  mem_tracker.UpdateStreamSize(res->it.it->second);
   return acknowledged;
 }
 
@@ -1782,7 +1781,7 @@ OpResult<ClaimInfo> OpAutoClaim(const OpArgs& op_args, string_view key, const Cl
   raxStop(&ri);
   result.end_id = end_id;
 
-  mem_tracker.UpdateStreamSize(cgr_res->it->second);
+  mem_tracker.UpdateStreamSize(cgr_res->it.it->second);
 
   return result;
 }


### PR DESCRIPTION
This PR refactors the storage of `DbSlice::ItAndUpdater` in the `ElementAccess` class (used in bitops operations) and the `FindGroupResult` struct (used in stream operations) to consolidate iterator and updater state. The refactoring simplifies code by routing `AutoUpdater` usage through `ItAndUpdater` instead of storing separate fields for iterator, updater, and other state.

**Changes:**
- Simplified `ElementAccess` class by replacing separate `added_`, `element_iter_`, `shard_`, and `post_updater_` fields with a single `updater_` field of type `DbSlice::ItAndUpdater`
- Consolidated `FindGroupResult` struct to use a single `it` field of type `DbSlice::ItAndUpdater` instead of separate `post_updater` and `it` fields
- Updated all usage sites to access iterator through the nested `it.it->second` pattern, consistent with other code using `ItAndUpdater`
- Fixed a bug with wrong memory account in case of blind writes into a data-structure of a different type.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->