### PR TITLE
make migration more stable

### DIFF
--- a/src/server/journal/streamer.h
+++ b/src/server/journal/streamer.h
@@ -59,7 +59,7 @@ class JournalStreamer : public journal::JournalConsumerInterface {
     return cntx_->IsRunning();
   }
 
-  void WaitForInflightToComplete(bool with_timeout = false);
+  void WaitForInflightToComplete(bool with_timeout);
 
   size_t inflight_bytes() const {
     return in_flight_bytes_;


### PR DESCRIPTION
To finalize the migration on the master, we do the following:
1) PAUSE
2) send LSN for every shard connection 
3) send ACK for main connection and wait for OK to finalize the migration

If we send LSN and after LSN we send any command via journal (pause prevents new command, but we can have some that haven't finished yet), it prevents finalization. 
So to make migration more stable, we can wait until all data is transferred.

**Summary:** Makes slot migration finalization more stable by draining any in-flight journal writes before emitting the finalize (LSN) marker.
**Why:** Avoids the incoming side seeing new journal traffic after the finalize marker, which can prevent/undo finalization.

