### PR TITLE
feat(dash): implement Segment merge algorithm

### DIFF
--- a/src/server/debugcmd.h
+++ b/src/server/debugcmd.h
@@ -62,6 +62,7 @@ class DebugCmd {
   void Compression(CmdArgList args, CommandContext* cmd_cntx);
   void IOStats(CmdArgList args, CommandContext* cmd_cntx);
   void Segments(CmdArgList args, CommandContext* cmd_cntx);
+  void TableGC(CmdArgList args, CommandContext* cmd_cntx);
   struct PopulateBatch {
     DbIndex dbid;
     uint64_t index[32];

--- a/src/server/engine_shard.h
+++ b/src/server/engine_shard.h
@@ -214,6 +214,9 @@ class EngineShard {
     return defrag_state_.cursor;
   }
 
+  // Return total segments merged.
+  size_t TableGC(double threshold);
+
  private:
   struct DefragTaskState {
     size_t dbid = 0u;

--- a/tests/dragonfly/test_table_gc.py
+++ b/tests/dragonfly/test_table_gc.py
@@ -1,0 +1,44 @@
+import asyncio
+from redis import asyncio as aioredis
+from . import dfly_args
+import logging
+
+
+@dfly_args({"proactor_threads": 2, "maxmemory": "1G"})
+async def test_gc_merges_segments_and_reclaims_memory(async_client: aioredis.Redis):
+    value_size = 50
+    target_keys = 10_000
+    value = "x" * value_size
+
+    batch_size = 100
+    for batch_start in range(0, target_keys, batch_size):
+        batch_end = min(batch_start + batch_size, target_keys)
+        pipeline = async_client.pipeline()
+        for i in range(batch_start, batch_end):
+            pipeline.set(f"key{i}", value)
+        await pipeline.execute()
+
+    await asyncio.sleep(0.5)
+
+    info_before = await async_client.info("MEMORY")
+
+    # Delete 90% of keys to create very sparse segments
+    keys_to_delete = [f"key{i}" for i in range(target_keys) if i % 10 != 0]
+    keys_left = [f"key{i}" for i in range(target_keys) if i % 10 == 0]
+
+    for batch_start in range(0, len(keys_to_delete), 1000):
+        await async_client.delete(*keys_to_delete[batch_start : batch_start + 1000])
+
+    # Run GC with aggressive threshold to trigger merges
+    segments_merged = await async_client.execute_command("DEBUG", "TABLE_GC", "0.5")
+
+    await asyncio.sleep(1.0)
+
+    info_after = await async_client.info("MEMORY")
+
+    assert segments_merged > 0
+
+    logging.info(f"TABLE✓GC merged {segments_merged} segments")
+    for key in keys_left:
+        res = await async_client.get(key)
+        assert res == value


### PR DESCRIPTION
This PR implements Segment merging for dash table. It does not implement Directory merging (the inverse of Grow() operation). Interestingly the dash table does not mention segment merging but the original paper for extendible hashing does: https://dl.acm.org/doi/pdf/10.1145/320083.320092 

When a segment splits:

* One segments becomes two buddies
* Local depth increases by 1
* Items redistribute across the new segments

When buddies merge:
* Two buddies become one segment
* Depth decreases by 1
* Items get merged into one segment

The algorithm in pseudocode:

```
for segment in segments:
   Buddy = FindBuddy(segment)    
   if(!buddy) continue
   size = buddy->elements() + segment->elements()
   if(size > threshold * segment->capacity()) {     
     continue
   }
   Merge(segment, buddy)
}

Merge:
  Move all elements from buddy to segment
  Update buddy to point to segment
  Deallocate buddy
  Decrease depth
```

* add command debug table_gc [threshold]
* add test
* implement Merge() — inverse of Split() in dash table

First steps to  #7