### PR TITLE
fix: crash on EVALSHA with empty sha

### DIFF
--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -278,6 +278,9 @@ TEST_F(DflyEngineTest, EvalSha) {
   resp = Run({"evalsha", "foobar", "0"});
   EXPECT_THAT(resp, ErrArg("No matching"));
 
+  resp = Run({"evalsha", "", "0"});
+  EXPECT_THAT(resp, ErrArg("No matching"));
+
   resp = Run({"script", "load", "\n return 5"});
 
   // Important to keep spaces in order to be compatible with Redis.

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2204,8 +2204,6 @@ static bool CanRunSingleShardMulti(bool one_shard, Transaction::MultiMode multi_
 
 void Service::EvalInternal(CmdArgList args, const EvalArgs& eval_args, Interpreter* interpreter,
                            bool read_only, CommandContext* cmd_cntx) {
-  DCHECK(!eval_args.sha.empty());
-
   // Sanitizing the input to avoid code injection.
   if (eval_args.sha.size() != 40 || !IsSHA(eval_args.sha)) {
     return cmd_cntx->SendError(facade::kScriptNotFound);


### PR DESCRIPTION
Remove DCHECK(!eval_args.sha.empty()) in EvalInternal that crashes on EVALSHA with an empty string argument. The subsequent size/format check already handles this case gracefully by returning NOSCRIPT error.

Fixes #6619