### PR TITLE
fix(memcache): reject gat/gats without key instead of crashing

### DIFF
--- a/src/facade/memcache_parser.cc
+++ b/src/facade/memcache_parser.cc
@@ -134,6 +134,9 @@ MP::Result ParseValueless(ArgSlice tokens, int64_t now, MP::Command* res) {
     return MP::PARSE_ERROR;
   }
 
+  if (key_pos >= num_tokens)
+    return MP::PARSE_ERROR;
+
   res->cmd_flags.return_cas = (res->type == MP::GETS || res->type == MP::GATS);
   res->cmd_flags.return_value = true;
   res->cmd_flags.return_flags = true;

--- a/src/facade/memcache_parser_test.cc
+++ b/src/facade/memcache_parser_test.cc
@@ -178,6 +178,12 @@ TEST_F(MCParserTest, Gat) {
   res = Parse("gats 1000 foo bar baz\r\n");
   EXPECT_EQ(MemcacheParser::OK, res);
   EXPECT_EQ(cmd_.expire_ts, 3000);
+
+  res = Parse("gats 100\r\n");
+  EXPECT_EQ(MemcacheParser::PARSE_ERROR, res);
+
+  res = Parse("gat 100\r\n");
+  EXPECT_EQ(MemcacheParser::PARSE_ERROR, res);
 }
 
 TEST_F(MCParserTest, ValueState) {


### PR DESCRIPTION
`gat`/`gats` commands with an expiry but no key (e.g. `gats 100\r\n`) caused an out-of-bounds access in `ParseValueless` - after consuming the expiry token, `key_pos` exceeded `num_tokens` but was used to index `tokens[]` without a bounds check.

Added a bounds check to return `PARSE_ERROR` instead.

Fixes #6637