### PR TITLE
fix(server/journal): Add bytes limit for repl backlog

### DIFF
--- a/src/server/journal/journal_slice.cc
+++ b/src/server/journal/journal_slice.cc
@@ -187,6 +187,7 @@ size_t JournalSlice::GetRingBufferBytes() const {
 
 void JournalSlice::ResetRingBuffer() {
   ring_buffer_.clear();
+  ring_buffer_bytes_ = 0;
 }
 
 }  // namespace journal

--- a/src/server/journal/journal_slice.cc
+++ b/src/server/journal/journal_slice.cc
@@ -15,8 +15,8 @@
 
 ABSL_FLAG(uint32_t, shard_repl_backlog_len, 8192,
           "The length of the circular replication log per shard");
-ABSL_FLAG(uint32_t, shard_repl_backlog_max_bytes, 0,
-          "The maximum bytes the circular replication log can hold (0 is unlimited)");
+ABSL_FLAG(uint64_t, shard_repl_backlog_max_bytes_soft, 0,
+          "Soft limit for number of bytes held in replication log (0 is unlimited)");
 
 namespace dfly {
 namespace journal {
@@ -35,7 +35,7 @@ void JournalSlice::Init() {
     return;
 
   ring_buffer_.set_capacity(absl::GetFlag(FLAGS_shard_repl_backlog_len));
-  ring_buffer_max_bytes_ = absl::GetFlag(FLAGS_shard_repl_backlog_max_bytes);
+  ring_buffer_max_bytes_ = absl::GetFlag(FLAGS_shard_repl_backlog_max_bytes_soft);
 }
 
 bool JournalSlice::IsLSNInBuffer(LSN lsn) const {
@@ -110,16 +110,9 @@ void JournalSlice::CallOnChange(JournalChangeItem* change_item) {
   }
   auto& item = change_item->journal_item;
 
-  // Drain the buffer until it is smaller than max bytes, only if the limit is set and the buffer is
-  // not empty. If the item is large enough that it will not fit into the buffer, still accommodate
-  // it as the sole element after draining the entire buffer.
-  const auto new_item_size = sizeof(item) + item.data.size();
-  while (ring_buffer_max_bytes_ && !ring_buffer_.empty() &&
-         ring_buffer_bytes_ + new_item_size > ring_buffer_max_bytes_) {
-    const size_t bytes_removed = ring_buffer_.front().data.size() + sizeof(item);
-    DCHECK_GE(ring_buffer_bytes_, bytes_removed);
-    ring_buffer_bytes_ -= bytes_removed;
-    ring_buffer_.pop_front();
+  if (const auto new_item_size = sizeof(item) + item.data.size();
+      ring_buffer_max_bytes_ && ring_buffer_bytes_ + new_item_size > ring_buffer_max_bytes_) {
+    EvictEntries(new_item_size);
   }
 
   // We preserve order here. After ConsumeJournalChange there can reordering
@@ -139,6 +132,33 @@ void JournalSlice::CallOnChange(JournalChangeItem* change_item) {
       k_v.second->ThrottleIfNeeded();
     }
   }
+}
+
+void JournalSlice::EvictEntries(size_t new_item_size) {
+  // Do not evict more than sqrt of current size. Using sqrt instead of a fixed percentage here
+  // makes sure that the eviction target grows with size, but gently, so as not to spend too much
+  // time on eviction. The idea is that repeated adding of records slowly brings the buffer size
+  // closer to the target of ring_buffer_max_bytes_, rather than all at once. The limit can be
+  // breached temporarily. The max(1) part ensures progress if the size of buffer is too small. In
+  // pathological cases (stream of huge entries) there will be one or more evictions per addition,
+  // in this cases the limits should be increased.
+  size_t max_to_evict = static_cast<size_t>(std::max(1.0, sqrt(ring_buffer_.size())));
+  VLOG(2) << "Evicting " << max_to_evict << " items to reach " << ring_buffer_max_bytes_
+          << ", total size " << ring_buffer_.size() << ", total bytes " << ring_buffer_bytes_;
+  size_t items_evicted = 0;
+  size_t bytes_evicted = 0;
+  while (!ring_buffer_.empty() && ring_buffer_bytes_ + new_item_size > ring_buffer_max_bytes_ &&
+         max_to_evict-- > 0) {
+    const size_t bytes_removed = ring_buffer_.front().data.size() + sizeof(JournalItem);
+    DCHECK_GE(ring_buffer_bytes_, bytes_removed);
+    ring_buffer_bytes_ -= bytes_removed;
+    ring_buffer_.pop_front();
+
+    items_evicted++;
+    bytes_evicted += bytes_removed;
+  }
+
+  VLOG(2) << "Evicted " << items_evicted << " items to free up " << bytes_evicted << " bytes";
 }
 
 uint32_t JournalSlice::RegisterOnChange(JournalConsumerInterface* consumer) {

--- a/src/server/journal/journal_slice.cc
+++ b/src/server/journal/journal_slice.cc
@@ -4,13 +4,9 @@
 
 #include "server/journal/journal_slice.h"
 
-#include <absl/container/inlined_vector.h>
 #include <absl/flags/flag.h>
 #include <absl/strings/escaping.h>
-#include <absl/strings/str_cat.h>
 #include <fcntl.h>
-
-#include <filesystem>
 
 #include "base/function2.hpp"
 #include "base/logging.h"

--- a/src/server/journal/journal_slice.cc
+++ b/src/server/journal/journal_slice.cc
@@ -115,24 +115,24 @@ void JournalSlice::CallOnChange(JournalChangeItem* change_item) {
   // it as the sole element after draining the entire buffer.
   const auto new_item_size = sizeof(item) + item.data.size();
   while (ring_buffer_max_bytes_ && !ring_buffer_.empty() &&
-         ring_buffer_bytes + new_item_size > ring_buffer_max_bytes_) {
+         ring_buffer_bytes_ + new_item_size > ring_buffer_max_bytes_) {
     const size_t bytes_removed = ring_buffer_.front().data.size() + sizeof(item);
-    DCHECK_GE(ring_buffer_bytes, bytes_removed);
-    ring_buffer_bytes -= bytes_removed;
+    DCHECK_GE(ring_buffer_bytes_, bytes_removed);
+    ring_buffer_bytes_ -= bytes_removed;
     ring_buffer_.pop_front();
   }
 
   // We preserve order here. After ConsumeJournalChange there can reordering
   if (ring_buffer_.size() == ring_buffer_.capacity()) {
     const size_t bytes_removed = ring_buffer_.front().data.size() + sizeof(item);
-    DCHECK_GE(ring_buffer_bytes, bytes_removed);
-    ring_buffer_bytes -= bytes_removed;
+    DCHECK_GE(ring_buffer_bytes_, bytes_removed);
+    ring_buffer_bytes_ -= bytes_removed;
   }
   if (!ring_buffer_.empty()) {
     DCHECK(item.lsn == ring_buffer_.back().lsn + 1);
   }
   ring_buffer_.push_back(std::move(item));
-  ring_buffer_bytes += sizeof(item) + ring_buffer_.back().data.size();
+  ring_buffer_bytes_ += sizeof(item) + ring_buffer_.back().data.size();
 
   if (enable_journal_flush_) {
     for (auto k_v : journal_consumers_arr_) {
@@ -162,7 +162,7 @@ size_t JournalSlice::GetRingBufferSize() const {
 }
 
 size_t JournalSlice::GetRingBufferBytes() const {
-  return ring_buffer_bytes;
+  return ring_buffer_bytes_;
 }
 
 void JournalSlice::ResetRingBuffer() {

--- a/src/server/journal/journal_slice.h
+++ b/src/server/journal/journal_slice.h
@@ -80,7 +80,7 @@ class JournalSlice {
   std::error_code status_ec_;
   bool enable_journal_flush_ = true;
 
-  size_t ring_buffer_bytes = 0;
+  size_t ring_buffer_bytes_ = 0;
   size_t ring_buffer_max_bytes_ = 0;
 };
 

--- a/src/server/journal/journal_slice.h
+++ b/src/server/journal/journal_slice.h
@@ -68,6 +68,8 @@ class JournalSlice {
 
  private:
   void CallOnChange(JournalChangeItem* item);
+  // Evicts entries to progress towards ring_buffer_max_bytes_
+  void EvictEntries(size_t new_item_size);
   boost::circular_buffer<JournalItem> ring_buffer_;
   base::IoBuf ring_serialize_buf_;
 

--- a/src/server/journal/journal_slice.h
+++ b/src/server/journal/journal_slice.h
@@ -81,6 +81,7 @@ class JournalSlice {
   bool enable_journal_flush_ = true;
 
   size_t ring_buffer_bytes = 0;
+  size_t ring_buffer_max_bytes_ = 0;
 };
 
 }  // namespace journal


### PR DESCRIPTION
`shard_repl_backlog_max_bytes_soft` is used to control backlog size. 

It is 0 by default which means unlimited. It must be opted in by the user.

When set to a non 0 value, it acts as a soft limit. On each addition the limit is checked. If it has been breached, then we try to evict upto a maximum of sqrt of total buffer item count.

The eviction does not aim to fix the size breach immediately. Instead it evicts a small amount of entries from the front. This means the limit is temporarily breached. Then on every subsequent addition we attempt to evict small number of entries from the front, until the size is slowly brought back in line.

Using `sqrt` instead of `X` percent or `X` items lets the eviction target grow gently. So for example with 8000 items in buffer, we only evict around 90 instead of say 800, whereas for 100 items we evict 10. This is less aggressive for buffers with large number of items, but prioritizes not making the hot path slower. 

There are pathological cases where for example we have a constant stream of huge entries. If the limit is set, there the eviction tries to fix things but will mostly fail, evicting a few entries per addition. In those cases the limit must be increased. A possible way to identify those cases:

* keep track of consecutive evictions (where each insert triggers one eviction)
* one every say N*1000 evictions log a warning (or once per minute)

This signals that the eviction fails to keep up. But this is not implemented in this PR.

FIXES https://github.com/dragonflydb/dragonfly/issues/5432