### PR TITLE
test(ci): exclude flaky BullMQ tests

### DIFF
--- a/.github/workflows/bullmq-tests.yml
+++ b/.github/workflows/bullmq-tests.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Run BullMQ tests
         run: |
           cd ${GITHUB_WORKSPACE}/bullmq
-          BULLMQ_TEST_PREFIX={b} yarn test --grep "handle errors.*for flows|Flows - addBulk.*handle errors" --invert
+          BULLMQ_TEST_PREFIX={b} yarn test --grep "handle errors.*for flows|Flows - addBulk.*handle errors|removes deduplication key|rejects with missing key for job message|emits waiting when a job has been added|gets all workers for this queue only" --invert
 
       - name: Upload logs on failure
         if: failure()


### PR DESCRIPTION
Exclude 4 intermittent BullMQ test failures from the nightly bullmq-tests workflow.
These tests fail non-deterministically across runs, each time with a different subset:

- `removes deduplication key` — requires keyspace notifications beyond `Ex` (expired), which Dragonfly does not yet support
- `rejects with missing key for job message` — race between job completion and removeOnComplete
- `emits waiting when a job has been added` — connection teardown race in test cleanup
- `gets all workers for this queue only` — CLIENT LIST timing on BullMQ side; worker emits `ready` before ioredis sends CLIENT SETNAME

None of these indicates Dragonfly regressions. The BullMQ fork (dragonflydb/bullmq) has not been updated since Feb 2025.