### PR TITLE
refactor(mc): async MGET/GAT

### DIFF
--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -1462,7 +1462,11 @@ void MGetCmd::Reply(SinkReplyBuilder* rb) {
       // Note: Missed keys are silent.
       if (res.has_value()) {
         string value;
-        if (holds_alternative<string>(res->val)) {
+
+        if (mc_cmd_flags_.meta && !mc_cmd_flags_.return_value) {
+          // If it's a Meta command and the client didn't ask for the value,
+          // we don't need to materialize the string or wait for disk I/O.
+        } else if (holds_alternative<string>(res->val)) {
           value = get<string>(std::move(res->val));
         } else {
           auto io_res = get<TieredRes>(std::move(res->val)).Get();


### PR DESCRIPTION
This refactor migrates MGET and GAT to SimpleContext, enabling async
support as part of the final push for IO loop v2 for Memcached.

* Migrated from synchronous BlockingCounter to SimpleContext for
parallel shard execution and deferred replies.

* Distinguish soft errors (KEY_NOTFOUND, WRONG_TYPE) to return nil,
while capturing hard errors (OOM) via atomic status storage.

* Fixed SendValue parameter order to correctly propagate CAS and TTL
according to the Memcached protocol requirements.

* Optimized flag reading by caching deduplication settings in the
Prepare() phase to reduce per-shard overhead.


