### PR TITLE
fix(tiering): Track all keys mutation callback for cluster migration

### DIFF
--- a/src/server/journal/streamer.cc
+++ b/src/server/journal/streamer.cc
@@ -602,6 +602,11 @@ bool RestoreStreamer::WriteBucket(PrimeTable::bucket_iterator it, const ExpireTa
   // Only track tiered keys when needed and flush delayed entries
   // 1. When we have tiered storage
   // 2. We're called from a OnDbChange callback
+  //
+  // We need to track all keys in bucket with tiering. Even if they are not set as external. There
+  // is situation when we request externalization of key and key is read - marking it as not
+  // external but not yet flushed. When OnDbChange callback is called we need to flush it and than
+  // write journal changes - so we cannot realy on IsExternal flag and need to track all keys.
   const bool track_tiered_keys =
       on_db_change_cb && EngineShard::tlocal()->tiered_storage() != nullptr;
 
@@ -622,7 +627,7 @@ bool RestoreStreamer::WriteBucket(PrimeTable::bucket_iterator it, const ExpireTa
           expire = db_slice_->ExpireTime(eit->second);
         }
         // Track tiered keys that will need delayed entry flushing
-        if (track_tiered_keys && pv.IsExternal() && !pv.IsCool()) {
+        if (track_tiered_keys) {
           tiered_keys.emplace(key);
         }
         WriteEntry(key, it->first, pv, expire);
@@ -636,9 +641,8 @@ bool RestoreStreamer::WriteBucket(PrimeTable::bucket_iterator it, const ExpireTa
     // for force-flushing their delayed entries
     if (track_tiered_keys) {
       for (it.AdvanceIfNotOccupied(); !it.is_done(); ++it) {
-        const auto& pv = it->second;
         string_view key = it->first.GetSlice(&key_buffer);
-        if (ShouldWrite(key) && pv.IsExternal() && !pv.IsCool()) {
+        if (ShouldWrite(key)) {
           tiered_keys.emplace(key);
         }
       }

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -3735,6 +3735,10 @@ async def test_cluster_migration_with_tiering_and_deletes(df_factory: DflyInstan
     keys = 1000000
     await nodes[0].client.execute_command(f"DEBUG POPULATE {keys} key 440")
 
+    # Expect that number of added keys is 1000000
+    info = await nodes[0].client.info("keyspace")
+    assert info["db0"]["keys"] == keys
+
     # Wait for some data to be offloaded to tiered storage
     await asyncio.sleep(10)
 


### PR DESCRIPTION
During OnDbChange callback we need to track all keys in bucket when
tiering is used. When key is external and we have already request it to be
fetched from tiered storage it can happen that this externalization
request is already processed - removing external flag but not yet
serialized. When mutation is executed we cannot relay that key is marked
as external and need to check all keys in bucket to be first serialized.
    
Fixes #6683

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
