### PR TITLE
ci: exclude flaky BullMQ getWorkers shared connection test

### DIFF
--- a/.github/workflows/bullmq-tests.yml
+++ b/.github/workflows/bullmq-tests.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Run BullMQ tests
         run: |
           cd ${GITHUB_WORKSPACE}/bullmq
-          BULLMQ_TEST_PREFIX={b} yarn test --grep "handle errors.*for flows|Flows - addBulk.*handle errors|removes deduplication key|rejects with missing key for job message|emits waiting when a job has been added|gets all workers for this queue only" --invert
+          BULLMQ_TEST_PREFIX={b} yarn test --grep "handle errors.*for flows|Flows - addBulk.*handle errors|removes deduplication key|rejects with missing key for job message|emits waiting when a job has been added|gets all workers for this queue only|gets all workers for a given queue" --invert
 
       - name: Upload logs on failure
         if: failure()


### PR DESCRIPTION
Exclude "gets all workers for a given queue" (shared connection variant) from BullMQ CI tests.

The test has a 1-second fallback timeout for worker connection setup. On slow CI machines, this fires before `CLIENT SETNAME` reaches the server, causing `CLIENT LIST` to miss the worker. This is a client-side race - Dragonfly handles `CLIENT SETNAME`/`CLIENT LIST` correctly.

Fixes: https://github.com/dragonflydb/dragonfly/actions/runs/22272600819