### PR TITLE
feat(facade): enable experimental_io_loop_v2 by default and clean CI

### DIFF
--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -33,10 +33,6 @@ inputs:
   epoll:
     required: false
     type: string
-  df-arg:
-    default: ""
-    required: false
-    type: string
 
 runs:
   using: "composite"
@@ -103,12 +99,6 @@ runs:
         export DRAGONFLY_PATH="${GITHUB_WORKSPACE}/${{inputs.build-folder-name}}/${{inputs.dfly-executable}}"
         export ROOT_DIR="${GITHUB_WORKSPACE}/tests/dragonfly/valkey_search"
         export UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 # to crash on errors
-
-        if [[ "${{inputs.df-arg}}" == 'experimental_io_loop_v2' ]]; then
-          echo "df-arg: experimental io loop v2"
-          export DF_ARG="--df experimental_io_loop_v2=true"
-        fi
-
         export FILTER="${{inputs.filter}}"
 
         # Exclude large tests unless explicitly requested
@@ -123,10 +113,10 @@ runs:
         if [[ "${{inputs.epoll}}" == 'epoll' ]]; then
           FILTER="$FILTER and not exclude_epoll"
           # Run only replication tests with epoll
-          timeout 80m pytest -m "$FILTER" --durations=10 --timeout=300 --color=yes --json-report --json-report-file=report.json dragonfly $DF_ARG --df force_epoll=true --log-cli-level=INFO || code=$?
+          timeout 80m pytest -m "$FILTER" --durations=10 --timeout=300 --color=yes --json-report --json-report-file=report.json dragonfly --df force_epoll=true --log-cli-level=INFO || code=$?
         else
           # Run only replication tests with iouring
-          timeout 80m pytest -m "$FILTER" --durations=10 --timeout=300 --color=yes --json-report --json-report-file=report.json dragonfly $DF_ARG --log-cli-level=INFO || code=$?
+          timeout 80m pytest -m "$FILTER" --durations=10 --timeout=300 --color=yes --json-report --json-report-file=report.json dragonfly --log-cli-level=INFO || code=$?
         fi
 
         # timeout returns 124 if we exceeded the timeout duration

--- a/.github/workflows/ioloop-v2-regtests.yml
+++ b/.github/workflows/ioloop-v2-regtests.yml
@@ -64,7 +64,6 @@ jobs:
           build-folder-name: build
           filter: ${{ matrix.build-type == 'Release' && 'not debug_only and not tls' || 'not opt_only and not tls' }}
           s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}
-          df-arg: "experimental_io_loop_v2"
 
       - name: Upload logs on failure
         if: failure()

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -118,7 +118,7 @@ ABSL_FLAG(uint32_t, pipeline_wait_batch_usec, 0,
           "If non-zero, waits for this time for more I/O "
           " events to come for the connection in case there is only one command in the pipeline. ");
 
-ABSL_FLAG(bool, experimental_io_loop_v2, false, "new io loop");
+ABSL_FLAG(bool, experimental_io_loop_v2, true, "new io loop");
 
 using namespace util;
 using namespace std;


### PR DESCRIPTION
Flipped the experimental_io_loop_v2 flag to true by default. This
activates the new asynchronous I/O loop for Memcached connections,
allowing for significantly improved throughput via asynchronous
command execution and deferred replies.

This change follows the successful implementation of async support for
all major Memcached string commands, including MGET, GAT, and
arithmetic operations.

CI / Testing Cleanup:
Removed the obsolete df-arg parameter from the regression tests
GitHub Action (action.yml) and its caller workflows.

Signed-off-by: Gil Levkovich <69595609+glevkovich@users.noreply.github.com>
