### PR TITLE
fix(tiering): Increase write depth

### DIFF
--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -43,7 +43,7 @@ ABSL_FLAG(bool, tiered_experimental_cooling, true,
           "If true, uses intermediate cooling layer "
           "when offloading values to storage");
 
-ABSL_FLAG(unsigned, tiered_storage_write_depth, 50,
+ABSL_FLAG(unsigned, tiered_storage_write_depth, 200,
           "Maximum number of concurrent stash requests issued by background offload");
 
 ABSL_FLAG(float, tiered_offload_threshold, 0.5,

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -639,7 +639,7 @@ async def test_tiered_entries(async_client: aioredis.Redis):
         "dbfilename": "tiered-entries",
         "tiered_prefix": "/tmp/tiered/backing",
         "tiered_offload_threshold": "0.5",  # ask to keep below 0.5 * 2G
-        "tiered_storage_write_depth": 50,
+        "tiered_storage_write_depth": 500,
         "tiered_experimental_cooling": "false",
     }
 )


### PR DESCRIPTION
1. Increase default write depth
2. Increase write depth of test

it timed out, so I assume this was the bottleneck as similar workloads finish more quikcly