### PR TITLE
server: move blob loading logic into respective family classes

### DIFF
--- a/src/server/collection_family_fallback.cc
+++ b/src/server/collection_family_fallback.cc
@@ -3,11 +3,12 @@
 //
 
 #ifndef WITH_COLLECTION_CMDS
+
 #include "base/logging.h"
 #include "server/hset_family.h"
 #include "server/set_family.h"
 #include "server/stream_family.h"
-
+#include "server/zset_family.h"
 namespace dfly {
 
 using namespace std;
@@ -37,6 +38,70 @@ StringSet* SetFamily::ConvertToStrSet(const intset* is, size_t expected_len) {
 uint32_t SetFamily::MaxIntsetEntries() {
   Fail();
   return 0;
+}
+
+LoadBlobResult SetFamily::LoadLPSetBlob(std::string_view blob, PrimeValue* pv) {
+  Fail();
+  return LoadBlobResult::kCorrupted;
+}
+
+LoadBlobResult SetFamily::LoadIntSetBlob(std::string_view blob, PrimeValue* pv) {
+  Fail();
+  return LoadBlobResult::kCorrupted;
+}
+
+LoadBlobResult HSetFamily::LoadZiplistBlob(std::string_view blob, PrimeValue* pv) {
+  Fail();
+  return LoadBlobResult::kCorrupted;
+}
+
+LoadBlobResult HSetFamily::LoadListpackBlob(std::string_view blob, PrimeValue* pv) {
+  Fail();
+  return LoadBlobResult::kCorrupted;
+}
+
+LoadBlobResult ZSetFamily::LoadZiplistBlob(std::string_view blob, PrimeValue* pv) {
+  Fail();
+  return LoadBlobResult::kCorrupted;
+}
+
+LoadBlobResult ZSetFamily::LoadListpackBlob(std::string_view blob, PrimeValue* pv) {
+  Fail();
+  return LoadBlobResult::kCorrupted;
+}
+
+OpResult<ZSetFamily::MScoreResponse> ZSetFamily::ZGetMembers(CmdArgList args, Transaction* tx,
+                                                             SinkReplyBuilder* builder) {
+  Fail();
+  return {};
+}
+
+OpResult<ZSetFamily::AddResult> ZSetFamily::OpAdd(const OpArgs& op_args, const ZParams& zparams,
+                                                  std::string_view key, ScoredMemberSpan members) {
+  Fail();
+  return {};
+}
+
+OpResult<double> ZSetFamily::OpScore(const OpArgs& op_args, std::string_view key,
+                                     std::string_view member) {
+  Fail();
+  return 0;
+}
+
+void ZSetFamily::ZAddGeneric(std::string_view key, const ZParams& zparams, ScoredMemberSpan memb_sp,
+                             CommandContext* cmd_cntx) {
+  Fail();
+}
+
+OpResult<void> ZSetFamily::OpKeyExisted(const OpArgs& op_args, std::string_view key) {
+  Fail();
+  return {};
+}
+
+OpResult<std::vector<ZSetFamily::ScoredArray>> ZSetFamily::OpRanges(
+    const std::vector<ZRangeSpec>& range_specs, const OpArgs& op_args, std::string_view key) {
+  Fail();
+  return {};
 }
 
 }  // namespace dfly

--- a/src/server/common_types.h
+++ b/src/server/common_types.h
@@ -33,6 +33,13 @@ enum class GlobalState : uint8_t {
 
 enum class TimeUnit : uint8_t { SEC, MSEC };
 
+enum class LoadBlobResult : uint8_t {
+  kSuccess,
+  kCorrupted,
+  kOutOfMemory,
+  kEmpty,
+};
+
 enum ExpireFlags {
   EXPIRE_ALWAYS = 0,
   EXPIRE_NX = 1 << 0,  // Set expiry only when key has no expiry

--- a/src/server/family_utils.h
+++ b/src/server/family_utils.h
@@ -87,6 +87,10 @@ void AddKeyToIndexesIfNeeded(std::string_view key, const DbContext& db_cntx, Pri
 void RemoveKeyFromIndexesIfNeeded(std::string_view key, const DbContext& db_cntx,
                                   const PrimeValue& pv, EngineShard* shard);
 
+// Validate and convert field/value ziplist pairs into listpack.
+// Returns 1 on success, 0 on integrity failure.
+int ZiplistPairsConvertAndValidateIntegrity(const uint8_t* zl, size_t size, unsigned char** lp);
+
 // Returns true if this key type could potentially be indexed.
 // Or in other words, if the key is of type HSET or JSON.
 bool IsIndexedKeyType(const PrimeValue& pv);

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -230,7 +230,7 @@ OpResult<DbSlice::ItAndUpdater> RdbRestoreValue::Add(string_view key, string_vie
       config.append = true;
     }
     if (pending_read_.remaining > 0) {
-      config.streamed = true;
+      config.chunked = true;
     }
     config.reserve = pending_read_.reserve;
 

--- a/src/server/hset_family.h
+++ b/src/server/hset_family.h
@@ -20,6 +20,9 @@ class HSetFamily {
  public:
   static void Register(CommandRegistry* registry);
 
+  static LoadBlobResult LoadZiplistBlob(std::string_view blob, PrimeValue* pv);
+  static LoadBlobResult LoadListpackBlob(std::string_view blob, PrimeValue* pv);
+
   // Does not free lp.
   static StringMap* ConvertToStrMap(uint8_t* lp);
 

--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -135,10 +135,10 @@ class RdbLoaderBase {
   };
 
   struct LoadConfig {
-    bool streamed = false;  // Big value streamed incrementally
+    bool chunked = false;   // Big value streamed incrementally
     size_t reserve = 0;     // Number of elements to reserve to optimize big value load
-    bool append = false;    // Append stream to existing object
-    bool finalize = false;  // Last portion of stream, finalize object
+    bool append = false;    // Append chunk to existing object
+    bool finalize = false;  // Last portion of chunked stream, finalize object
   };
 
   class OpaqueObjLoader;
@@ -378,9 +378,9 @@ class RdbLoader : protected RdbLoaderBase {
   // A free pool of allocated unused items.
   base::MPSCIntrusiveQueue<Item> item_queue_;
 
-  // Map of currently streamed big values
-  std::unordered_map<std::string, std::unique_ptr<PrimeValue>> now_streamed_;
-  base::SpinLock now_streamed_mu_;  // guards now_streamed_
+  // Map of currently chunked big values
+  std::unordered_map<std::string, std::unique_ptr<PrimeValue>> now_chunked_;
+  base::SpinLock now_chunked_mu_;  // guards now_chunked_
 
   std::string last_key_loaded_;
 };

--- a/src/server/set_family.h
+++ b/src/server/set_family.h
@@ -20,6 +20,9 @@ class SetFamily {
  public:
   static void Register(CommandRegistry* registry);
 
+  static LoadBlobResult LoadIntSetBlob(std::string_view blob, PrimeValue* pv);
+  static LoadBlobResult LoadLPSetBlob(std::string_view blob, PrimeValue* pv);
+
   static uint32_t MaxIntsetEntries();
 
   // Returns nullptr on OOM.

--- a/src/server/zset_family.h
+++ b/src/server/zset_family.h
@@ -9,6 +9,7 @@
 
 #include "facade/op_status.h"
 #include "server/common.h"
+#include "server/table.h"
 
 namespace facade {
 class SinkReplyBuilder;
@@ -21,6 +22,9 @@ struct OpArgs;
 class ZSetFamily {
  public:
   static void Register(CommandRegistry* registry);
+
+  static LoadBlobResult LoadZiplistBlob(std::string_view blob, PrimeValue* pv);
+  static LoadBlobResult LoadListpackBlob(std::string_view blob, PrimeValue* pv);
 
   using IndexInterval = std::pair<int64_t, int64_t>;
   using MScoreResponse = std::vector<std::optional<double>>;


### PR DESCRIPTION
## Summary

- Refactors `HandleBlob()` in `rdb_load.cc` to delegate type-specific loading to each data family class (`SetFamily`, `HSetFamily`, `ZSetFamily`)
- Introduces `LoadBlobResult` enum (`kSuccess`, `kCorrupted`, `kOutOfMemory`, `kEmpty`) in `common_types.h` as a common return type
- Moves `ZiplistPairsConvertAndValidateIntegrity` from `rdb_load.cc` to `family_utils.cc` for reuse

## Changes

- Add `LoadBlobResult` enum to `common_types.h`
- Add `SetFamily::LoadIntSetBlob` / `LoadLPSetBlob`
- Add `HSetFamily::LoadZiplistBlob` / `LoadListpackBlob`
- Add `ZSetFamily::LoadZiplistBlob` / `LoadListpackBlob`
- Move `ZiplistPairsConvertAndValidateIntegrity` to `family_utils.cc`
- Rename `LoadConfig::streamed` → `chunked` for clarity
- Fix `CreateSet` incorrectly checking `RDB_TYPE_HASH` instead of `RDB_TYPE_SET`

🤖 Generated with [Claude Code](https://claude.com/claude-code)