### PR TITLE
chore(ci): Replace direct push with PR for helm chart updates

### DIFF
--- a/.github/workflows/docker-release2.yml
+++ b/.github/workflows/docker-release2.yml
@@ -273,6 +273,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
       pull-requests: write
     steps:
     - name: print_env


### PR DESCRIPTION
Replace the direct `git push origin main` step in the docker-release2 workflow with a PR-based flow, as requested in #6708.

Changes:
- Remove the "GitHub Push" step that pushed unsigned commits directly to main
- Create a new branch `helm-chart-update/<TAG_NAME>` from `origin/main` for helm chart changes
- Add a "Create Helm Chart PR" step at the end of the job that opens a PR via `gh pr create`
- Add `contents: write` and `pull-requests: write` permissions to the job

Notes:
- The commit in the PR branch is unsigned (created by `git commit` in CI).
- The reviewer is set to `vyavdoshenko` only. Since `DRAGONFLY_TOKEN` is romange's PAT,
  the PR is authored by romange, and GitHub does not allow requesting a review from the PR author.

Fixes #6708

Tested here: https://github.com/dragonflydb/dragonfly/pull/6716