### PR TITLE
fix(fuzz): skip missing RECORD files in replay_crash.py

### DIFF
--- a/fuzz/replay_crash.py
+++ b/fuzz/replay_crash.py
@@ -55,10 +55,6 @@ def main():
     pattern = os.path.join(crash_dir, f"RECORD:{crash_id},cnt:*")
     records = sorted(glob.glob(pattern))
 
-    if not records:
-        print(f"\033[0;31m[ERROR]\033[0m No RECORD files for crash {crash_id}")
-        sys.exit(1)
-
     # Find crash input file
     crash_files = [
         f


### PR DESCRIPTION
- Allow `replay_crash.py` to work when no RECORD files exist (e.g. when `AFL_PERSISTENT_RECORD` was not set)
- Previously, the script exited with an error; now it skips straight to the crash input file