### PR TITLE
fix(rdb_load): Fix dry run with shard optimization

### DIFF
--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2798,13 +2798,7 @@ void RdbLoader::LoadItemsBuffer(DbIndex db_ind, const ItemsBuf& ib) {
 
   DCHECK(!db_slice.IsCacheMode());
 
-  bool dry_run = absl::GetFlag(FLAGS_rdb_load_dry_run);
-
   for (const auto* item : ib) {
-    if (dry_run) {
-      continue;
-    }
-
     CreateObjectOnShard(db_cntx, item, &db_slice);
     if (stop_early_) {
       return;
@@ -2828,6 +2822,7 @@ error_code RdbLoader::LoadKeyValPair(int type, ObjSettings* settings) {
   SET_OR_RETURN(ReadKey(), key);
   last_key_loaded_ = key;
 
+  bool dry_run = absl::GetFlag(FLAGS_rdb_load_dry_run);
   bool streamed = false;
   do {
     // If there is a cached Item in the free pool, take it, otherwise allocate
@@ -2853,6 +2848,9 @@ error_code RdbLoader::LoadKeyValPair(int type, ObjSettings* settings) {
       pending_read_.reserve = 0;
       continue;
     }
+
+    if (dry_run)
+      continue;
 
     item->load_config.finalize = pending_read_.remaining == 0;
     if (!item->load_config.finalize) {


### PR DESCRIPTION
We have this short cut with inline runs with `EngineShard::tlocal()->id  == dest_id` that ignores the dry run flag. I wanted to do it first in CreateObjectOnShard, but we actually don't even have to populate the item, so I moved it further upstream