### PR TITLE
ci: add memcache fuzzing to regular campaign

### DIFF
--- a/.github/actions/fuzzing/action.yml
+++ b/.github/actions/fuzzing/action.yml
@@ -6,6 +6,11 @@ inputs:
     description: "Fuzzing mode: 'smoke' (stop on first crash) or 'long' (collect all crashes)"
     required: true
     type: string
+  target:
+    description: "Fuzz target: 'resp' or 'memcache'"
+    required: false
+    default: 'resp'
+    type: string
   duration-minutes:
     description: "Fuzzing duration in minutes"
     required: true
@@ -15,7 +20,7 @@ inputs:
     required: true
     type: string
   extra-seeds-dir:
-    description: "Directory with additional .resp seed files (initial fuzzer inputs) to merge into the corpus"
+    description: "Directory with additional seed files (initial fuzzer inputs) to merge into the corpus"
     required: false
     default: ''
   focus-commands:
@@ -59,12 +64,13 @@ runs:
       if: ${{ inputs.extra-seeds-dir != '' }}
       run: |
         EXTRA_DIR="${{ inputs.extra-seeds-dir }}"
-        SEEDS_DIR="fuzz/seeds/resp"
+        SEEDS_DIR="fuzz/seeds/${{ inputs.target }}"
 
-        if [ -d "$EXTRA_DIR" ] && [ -n "$(ls -A "$EXTRA_DIR"/*.resp 2>/dev/null)" ]; then
-          COUNT=$(ls "$EXTRA_DIR"/*.resp 2>/dev/null | wc -l)
+        # Copy only seed files, skip metadata like focus_commands.json
+        COUNT=$(find "$EXTRA_DIR" -maxdepth 1 -type f ! -name '*.json' 2>/dev/null | wc -l)
+        if [ "$COUNT" -gt 0 ]; then
           echo "Merging ${COUNT} targeted seeds into corpus"
-          cp "$EXTRA_DIR"/*.resp "$SEEDS_DIR/"
+          find "$EXTRA_DIR" -maxdepth 1 -type f ! -name '*.json' -exec cp -t "$SEEDS_DIR/" {} +
         else
           echo "No targeted seed files to merge"
         fi
@@ -77,6 +83,7 @@ runs:
 
         echo "Starting AFL++ fuzzing..."
         echo "Configuration:"
+        echo "  Target: ${{ inputs.target }}"
         echo "  Mode: ${MODE}"
         echo "  Duration: ${DURATION_MINUTES} minutes"
 
@@ -84,7 +91,7 @@ runs:
         export BUILD_DIR="${GITHUB_WORKSPACE}/build-dbg"
 
         # Run fuzzer with timeout
-        timeout ${DURATION_MINUTES}m ./run_fuzzer.sh || EXIT_CODE=$?
+        timeout ${DURATION_MINUTES}m ./run_fuzzer.sh "${{ inputs.target }}" || EXIT_CODE=$?
 
         # timeout returns 124 if it timed out (expected), 0 if finished naturally
         if [ "${EXIT_CODE:-0}" -eq 124 ]; then
@@ -115,9 +122,10 @@ runs:
       run: |
         echo "Analyzing fuzzing results..."
 
-        CRASHES_DIR="fuzz/artifacts/resp/default/crashes"
-        HANGS_DIR="fuzz/artifacts/resp/default/hangs"
-        QUEUE_DIR="fuzz/artifacts/resp/default/queue"
+        TARGET="${{ inputs.target }}"
+        CRASHES_DIR="fuzz/artifacts/${TARGET}/default/crashes"
+        HANGS_DIR="fuzz/artifacts/${TARGET}/default/hangs"
+        QUEUE_DIR="fuzz/artifacts/${TARGET}/default/queue"
 
         # Count results
         CRASH_COUNT=0
@@ -143,7 +151,7 @@ runs:
 
         # Show statistics for long mode
         if [ "${{ inputs.mode }}" = "long" ]; then
-          STATS_FILE="fuzz/artifacts/resp/default/fuzzer_stats"
+          STATS_FILE="fuzz/artifacts/${TARGET}/default/fuzzer_stats"
           if [ -f "$STATS_FILE" ]; then
             echo ""
             echo "Key Statistics:"
@@ -174,7 +182,7 @@ runs:
       shell: bash
       if: failure()
       run: |
-        CRASHES_DIR="$(pwd)/fuzz/artifacts/resp/default/crashes"
+        CRASHES_DIR="$(pwd)/fuzz/artifacts/${{ inputs.target }}/default/crashes"
 
         if [ ! -d "$CRASHES_DIR" ] || [ -z "$(ls -A "$CRASHES_DIR" 2>/dev/null)" ]; then
           echo "No crash artifacts to package"
@@ -204,9 +212,9 @@ runs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
-        name: fuzz-${{ inputs.mode }}-crashes-${{ inputs.run-number }}
+        name: fuzz-${{ inputs.mode }}-${{ inputs.target }}-crashes-${{ inputs.run-number }}
         path: |
           fuzz/packaged/*.tar.gz
-          fuzz/artifacts/resp/default/fuzzer_stats
+          fuzz/artifacts/${{ inputs.target }}/default/fuzzer_stats
         retention-days: 10
         if-no-files-found: ignore

--- a/.github/workflows/fuzz-long.yml
+++ b/.github/workflows/fuzz-long.yml
@@ -6,10 +6,15 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
     inputs:
-      duration_minutes:
-        description: 'Fuzzing duration in minutes'
+      resp_duration:
+        description: 'RESP fuzzing duration in minutes'
         required: false
         default: '60'
+        type: string
+      memcache_duration:
+        description: 'Memcache fuzzing duration in minutes'
+        required: false
+        default: '30'
         type: string
 
 concurrency:
@@ -20,6 +25,15 @@ jobs:
   fuzz-long:
     runs-on: CI-LARGE-86
     timeout-minutes: 120
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: resp
+            duration: '60'
+          - target: memcache
+            duration: '30'
 
     container:
       image: ghcr.io/romange/ubuntu-dev:24-afl
@@ -34,18 +48,19 @@ jobs:
         with:
           submodules: true
 
-      - name: Run AFL++ long fuzzing campaign
+      - name: Run AFL++ long fuzzing campaign (${{ matrix.target }})
         uses: ./.github/actions/fuzzing
         with:
           mode: long
-          duration-minutes: ${{ github.event.inputs.duration_minutes || '30' }}
+          target: ${{ matrix.target }}
+          duration-minutes: ${{ matrix.target == 'resp' && (github.event.inputs.resp_duration || matrix.duration) || (github.event.inputs.memcache_duration || matrix.duration) }}
           run-number: ${{ github.run_number }}
 
       - name: Send notification on failure
         if: failure() && github.ref == 'refs/heads/main'
         run: |
           job_link="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          message="AFL++ fuzzing found crashes.\\n Commit: ${{github.sha}}\\n Job Link: ${job_link}\\n"
+          message="AFL++ ${{ matrix.target }} fuzzing found crashes.\\n Commit: ${{github.sha}}\\n Job Link: ${job_link}\\n"
 
           curl -s \
             -X POST \


### PR DESCRIPTION
Add memcache protocol fuzzing to the nightly AFL++ campaign, reusing the existing fuzzing action.

- Add `target` input to the fuzzing action (`resp` default, backward compatible)
- Run resp (60 min) and memcache (30 min) in parallel via matrix strategy
- Separate `workflow_dispatch` duration inputs per target
- Filter out metadata files (e.g. `focus_commands.json`) when merging seeds