### PR TITLE
feat(set_family): Reserve vector on OpInter in advance

### DIFF
--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -820,6 +820,7 @@ OpResult<StringVec> OpInter(const Transaction* t, EngineShard* es, bool remove_f
       ss->set_time(MemberTimeSeconds(t->GetDbContext().time_now_ms));
     }
 
+    result.reserve(pv.Size());
     container_utils::IterateSet(find_res.value()->second,
                                 [&result](container_utils::ContainerEntry ce) {
                                   result.push_back(ce.ToString());
@@ -857,6 +858,7 @@ OpResult<StringVec> OpInter(const Transaction* t, EngineShard* es, bool remove_f
   std::sort(sets.begin(), sets.end(), comp);
 
   int encoding = sets.front().second;
+  result.reserve(SetTypeLen(t->GetDbContext(), sets.front()));
   if (encoding == kEncodingIntSet) {
     int ii = 0;
     intset* is = (intset*)sets.front().first;


### PR DESCRIPTION
For the set family, In certain cases vectors grow up to 250 MiB and are repeatedly reallocated. An up front reservation lets the movements between reallocations disappear.

The main improvement is with respect to time because the vector payload does not have to be shuffled around on each reallocation. 

However, with reserve the peak used memory may be higher, this is because whereas before different commands slowly built up their vector to peak allocation, now all commands immediately reach peak allocation, and the coincidence of huge allocations is more likely.

On the same sample workload stored from an earlier test, without reserve the traffic replay finishes in 5m6s whereas with reserve it finishes in 4m14s. 

On the other hand, with reserve it takes peak of 4.9 Gib whereas without reserve the peak is just over 4 GiB. In both cases the extra memory drops quickly.

without (left) vs with reserve (right)
<img width="3397" height="1145" alt="image" src="https://github.com/user-attachments/assets/fad40abe-c547-49db-a945-4f515f692c39" />

FIXES https://github.com/dragonflydb/dragonfly/issues/5877