### PR TITLE
chore: stream family boilerplate to a function

### DIFF
--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -1594,4 +1594,11 @@ TEST_F(StreamFamilyTest, XAddOnOrphanedStreamMemoryTracking) {
   EXPECT_THAT(resp, IntArg(0));
 }
 
+TEST_F(StreamFamilyTest, XAutoClaimEmptyConsumer) {
+  Run({"xadd", "stream4", "*", "field", "val1"});
+  Run({"xgroup", "create", "stream4", "group2", "0"});
+  auto resp = Run({"xautoclaim", "stream4", "group2", "", "0", "0-0"});
+  EXPECT_THAT(resp, AnyOf(ErrArg(""), ArgType(RespExpr::ARRAY)));
+}
+
 }  // namespace dfly


### PR DESCRIPTION
Replace
```
  if (!res_it)
    return res_it.status();
```
with
```
  RETURN_ON_BAD_STATUS(res_it);
```
for consistency.

Also, put common code to a function `ReassignNACKToConsumer`