### PR TITLE
ci: extract BullMQ skipped tests into a documented file

### DIFF
--- a/.github/bullmq-skipped-tests.txt
+++ b/.github/bullmq-skipped-tests.txt
@@ -1,0 +1,36 @@
+# BullMQ tests excluded from CI runs against Dragonfly
+#
+# Format: one pattern per line (used as JS regex in mocha --grep --invert)
+# Categories:
+#   DRAGONFLY_BUG  - Dragonfly does not support this behaviour yet
+#   FLAKY          - Test has race conditions / timing issues unrelated to Dragonfly
+
+# ── DRAGONFLY BUG ────────────────────────────────────────────────────────────
+# BullMQ Lua scripts access keys that are not declared in KEYS[].
+# Dragonfly enforces strict Lua key declaration; allow-undeclared-keys causes
+# global transaction mode and breaks other tests.
+handle errors.*for flows
+Flows - addBulk.*handle errors
+
+# Job.finished: job hash persists after removeOnComplete instead of being deleted.
+rejects with missing key for job message
+
+# ── FLAKY ─────────────────────────────────────────────────────────────────────
+# deduplication key removal races with the 'deduplicated' QueueEvents listener.
+# XREAD from '$' is noted as unstable in upstream BullMQ code.
+removes deduplication key
+
+# QueueEvents 'waiting' event: XREAD from '$' is unstable on CI.
+# Upstream comment: "additional delay since XREAD from '$' is unstable"
+emits waiting when a job has been added
+
+# getWorkers: race between worker 'ready' event and assertion.
+gets all workers for this queue only
+
+# getWorkers (shared connection): upstream test file has comment
+# "Test is very flaky on CI, so we skip it for now."
+gets all workers for a given queue
+
+# Job Scheduler monthly repeat: sinon fake-timer races with real Redis async ops.
+# The worker loop does not advance in time before the 200 s timeout expires.
+should repeat 7:th day every month at 9:25

--- a/.github/workflows/bullmq-tests.yml
+++ b/.github/workflows/bullmq-tests.yml
@@ -72,7 +72,12 @@ jobs:
       - name: Run BullMQ tests
         run: |
           cd ${GITHUB_WORKSPACE}/bullmq
-          BULLMQ_TEST_PREFIX={b} yarn test --grep "handle errors.*for flows|Flows - addBulk.*handle errors|removes deduplication key|rejects with missing key for job message|emits waiting when a job has been added|gets all workers for this queue only|gets all workers for a given queue" --invert
+          SKIP_PATTERN=$(grep -v '^#' ${GITHUB_WORKSPACE}/.github/bullmq-skipped-tests.txt | grep -v '^[[:space:]]*$' | paste -sd '|' || true)
+          if [ -n "${SKIP_PATTERN}" ]; then
+            BULLMQ_TEST_PREFIX={b} yarn test --grep "${SKIP_PATTERN}" --invert
+          else
+            BULLMQ_TEST_PREFIX={b} yarn test
+          fi
 
       - name: Upload logs on failure
         if: failure()


### PR DESCRIPTION
The list of excluded BullMQ tests was a single unreadable regex string that grew with every flaky failure. There was no record of why each test was excluded.

Move the list to `.github/bullmq-skipped-tests.txt`, where each entry has a comment explaining the root cause and is grouped by category:
- `DRAGONFLY_BUG` – Dragonfly limitation
- `FLAKY` – timing/race condition in the test itself

The workflow now builds the grep pattern dynamically from that file.
Adding or removing a test going forward only requires editing the txt file.

Also excludes `should repeat 7:th day every month at 9:25` which is timed out in today's scheduled run (sinon fake-timer race with Redis async ops). https://github.com/dragonflydb/dragonfly/actions/runs/22515876270