### PR TITLE
refactor: move stream alloc/free into compact_object and fix rdb_load cleanup

### DIFF
--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -16,6 +16,8 @@
 #include "core/mi_memory_resource.h"
 #include "core/small_string.h"
 
+typedef struct stream stream;
+
 namespace dfly {
 
 constexpr unsigned kEncodingIntSet = 0;
@@ -586,5 +588,8 @@ struct TieredColdRecord : public ::boost::intrusive::list_base_hook<
 static_assert(sizeof(TieredColdRecord) == 48);
 
 };  // namespace detail
+
+stream* streamNew();
+void freeStream(stream* s);
 
 }  // namespace dfly

--- a/src/redis/stream.h
+++ b/src/redis/stream.h
@@ -144,8 +144,6 @@ typedef struct {
 #define STREAM_ITEM_FLAG_DELETED (1 << 0)    /* Entry is deleted. Skip it. */
 #define STREAM_ITEM_FLAG_SAMEFIELDS (1 << 1) /* Same fields as primary entry. */
 
-stream *streamNew(void);
-void freeStream(stream *s);
 void streamIteratorStart(streamIterator *si, stream *s, streamID *start, streamID *end, int rev);
 int streamIteratorGetID(streamIterator *si, streamID *id, int64_t *numfields);
 void streamIteratorGetField(streamIterator *si,

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -694,7 +694,7 @@ void RdbLoaderBase::OpaqueObjLoader::CreateStream(const LoadTrace* ltrace) {
   }
 
   auto cleanup = absl::Cleanup([&] {
-    if (config_.append) {
+    if (!config_.append) {
       freeStream(s);
     }
   });

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -71,7 +71,7 @@ int StreamIncrID(streamID* id) {
 }
 
 /* Set 'id' to be its predecessor stream ID.
- * If 'id' is the minimal possible id, it remains 0-0 and C_ERR is returned. */
+ * If 'id' is the minimal possible id, it resets to UINT64_MAX and C_ERR is returned. */
 int StreamDecrID(streamID* id) {
   int ret = C_OK;
   if (id->seq == 0) {


### PR DESCRIPTION
## Summary
Move `streamNew`, `freeStream`, and their internal helpers from `t_stream.c` into
`compact_object.cc` under the `dfly` namespace, removing the dependency on `stream.h`
for stream allocation/deallocation.

Fix an inverted cleanup condition in `rdb_load.cc` `CreateStream` — the stream was
freed when `append` was true (successfully handed off) instead of when false (locally owned).

## Changes
- Move `streamNew`, `freeStream`, `streamFreeConsumer`, `streamFreeCGVoid`, `lpFreeVoid` to `compact_object.cc`
- Declare `streamNew`/`freeStream` in `compact_object.h`
- Fix `!config_.append` cleanup guard in `rdb_load.cc`
- Correct `StreamDecrID` comment in `stream_family.cc`