### PR TITLE
fix: return WOULD_BLOCK for STATS/VERSION in MC pipeline

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1864,9 +1864,13 @@ DispatchResult Service::DispatchMC(facade::ParsedCommand* parsed_cmd,
       cmd_name = "QUIT";
       break;
     case MemcacheParser::STATS:
+      if (apref == AsyncPreference::ONLY_ASYNC)
+        return DispatchResult::WOULD_BLOCK;
       server_family_.StatsMC(cmd.key(), cmd_ctx);
       return DispatchResult::OK;
     case MemcacheParser::VERSION:
+      if (apref == AsyncPreference::ONLY_ASYNC)
+        return DispatchResult::WOULD_BLOCK;
       cmd_ctx->SendSimpleString("VERSION 1.6.0 DF");
       return DispatchResult::OK;
     default:


### PR DESCRIPTION
`DispatchMC` for `STATS` and `VERSION` executed synchronously regardless of the `AsyncPreference` parameter. When pipelined after an async command (e.g. `GET`), they were dispatched while not being the head command, triggering `DCHECK(is_head)` in `ExecuteMCBatch`.

Changes:
- Return `WOULD_BLOCK` from `DispatchMC` for `STATS`/`VERSION` when `ONLY_ASYNC` is requested
- Add regression test: `get nokey\r\nstats\r\n` and `get nokey\r\nversion\r\n` pipelined in one packet

Fixes #6761