### PR TITLE
feat(server): add stream access pattern metrics

### DIFF
--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -225,7 +225,7 @@ string EngineShard::TxQueueInfo::Format() const {
 }
 
 EngineShard::Stats& EngineShard::Stats::operator+=(const Stats& o) {
-  static_assert(sizeof(Stats) == 128);
+  static_assert(sizeof(Stats) == 152);
 
 #define ADD(x) x += o.x
 
@@ -245,6 +245,9 @@ EngineShard::Stats& EngineShard::Stats::operator+=(const Stats& o) {
   ADD(total_heartbeat_expired_calls);
   ADD(total_migrated_keys);
   ADD(huffman_tables_built);
+  ADD(stream_sequential_accesses);
+  ADD(stream_random_accesses);
+  ADD(stream_fetch_all_accesses);
 
 #undef ADD
   return *this;

--- a/src/server/engine_shard.h
+++ b/src/server/engine_shard.h
@@ -53,6 +53,11 @@ class EngineShard {
     // how many huffman tables were built successfully in the background
     uint32_t huffman_tables_built = 0;
 
+    // Stream access pattern metrics (per-command, not per-entry).
+    uint64_t stream_sequential_accesses = 0;  // head/tail: XADD, XREAD recent, XTRIM, etc.
+    uint64_t stream_random_accesses = 0;      // arbitrary-ID lookups: XRANGE partial, XDEL, XCLAIM
+    uint64_t stream_fetch_all_accesses = 0;   // full stream scan from beginning
+
     Stats& operator+=(const Stats&);
   };
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2084,6 +2084,19 @@ void PrintPrometheusMetrics(uint64_t uptime, const Metrics& m, DflyCmd* dfly_cmd
     AppendMetricValue("tiered_list_events", m.qlist_stats.onload_requests, {"type"}, {"onload"},
                       &resp->body());
   }
+
+  // Stream access pattern metrics
+  if (m.shard_stats.stream_sequential_accesses || m.shard_stats.stream_random_accesses ||
+      m.shard_stats.stream_fetch_all_accesses) {
+    AppendMetricHeader("stream_accesses_total", "Total stream accesses by type",
+                       MetricType::COUNTER, &resp->body());
+    AppendMetricValue("stream_accesses_total", m.shard_stats.stream_sequential_accesses,
+                      {"access_type"}, {"sequential"}, &resp->body());
+    AppendMetricValue("stream_accesses_total", m.shard_stats.stream_random_accesses,
+                      {"access_type"}, {"random"}, &resp->body());
+    AppendMetricValue("stream_accesses_total", m.shard_stats.stream_fetch_all_accesses,
+                      {"access_type"}, {"fetch_all"}, &resp->body());
+  }
 }
 
 void ServerFamily::ConfigureMetrics(util::HttpListenerBase* http_base) {


### PR DESCRIPTION
## Summary

- Track stream access patterns (sequential/random/fetch-all) per command
- Expose via Prometheus `stream_accesses_total` counter
- Informs optimization decisions for stream data structure

## Changes

- **engine_shard.h/cc**: Add 3 counters (`stream_sequential_accesses`, `stream_random_accesses`, `stream_fetch_all_accesses`) to `EngineShard::Stats`
- **stream_family.cc**: Add `StreamAccessKind` enum, `RecordStreamAccess` helper, and `access_kind` field in `RangeOpts`. Instrument XADD, XREAD, XRANGE, XTRIM, XDEL, XCLAIM, XAUTOCLAIM, XSETID, XINFO STREAM. Record access only after key/group validation succeeds (OpClaim, OpAutoClaim, OpRangeFromConsumerPEL)
- **server_family.cc**: Expose metrics in Prometheus output

## Test plan

- [x] `stream_family_test` — all tests pass
- [x] Build succeeds, pre-commit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)