### PR TITLE
fix: prevent empty hash on HINCRBYFLOAT with NaN/Inf

### DIFF
--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -786,6 +786,10 @@ void CmdHIncrByFloat(CmdArgList args, CommandContext* cmd_cntx) {
     return cmd_cntx->SendError(kInvalidFloatErr);
   }
 
+  if (isnan(dval) || isinf(dval)) {
+    return cmd_cntx->SendError(kNanOrInfDuringIncr);
+  }
+
   IncrByParam param{dval};
 
   auto cb = [&](Transaction* t, EngineShard* shard) {


### PR DESCRIPTION
`OpIncrBy` called `AddOrFind` (which allocates an empty listpack for new keys) before validating the increment. When `IncrementValue` rejected a NaN/Inf increment, it returned early — leaving an orphaned empty hash in the DB. Any subsequent `HRANDFIELD` on that key hit the CHECK.

Fix:
Validate NaN/Inf in the increment value before touching the DB. For a new key `prev_val` is 0.0, so `0.0 + NaN/Inf` is always invalid — reject it upfront without calling `AddOrFind`.

Fixes: #6764