### PR TITLE
tests: Protect connections with mutex

### DIFF
--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -221,7 +221,11 @@ void BaseFamilyTest::SetUp() {
 void BaseFamilyTest::TearDown() {
   CHECK_EQ(NumLocked(), 0U);
 
-  connections_.clear();
+  {
+    std::unique_lock conn_lck{mu_};
+    connections_.clear();
+  }
+
   ShutdownService();
 
   const TestInfo* const test_info = UnitTest::GetInstance()->current_test_info();


### PR DESCRIPTION
During a test failure, when in the watchdog lambda in `BaseFamilyTest::ResetService` there is a crash because of concurrent hash set access. Earlier a similar crash was fixed inside watchdog by acquiring a lock on the `connections_` member. But the same map is cleared in Teardown without a lock.

It is not immediately clear if the crash was due to Teardown, but that is the only non-protected write access to the `connections_` hash map, so a lock is added there.

FIXES https://github.com/dragonflydb/dragonfly/issues/6742