### PR TITLE
chore(tiering): pass FragmentRef instead of PrimeValue in tiered storage

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,26 @@
-# GitHub Copilot Instructions for Dragonfly
+---
+description: 'Code review guidelines for GitHub copilot in this project'
+applyTo: '**'
+excludeAgent: ["coding-agent"]
+---
 
-**READ [AGENTS.md](../AGENTS.md)**
+# Code Review Instructions
 
-All project information, workflows, patterns, and guidelines are in `AGENTS.md`.
+Keep reviews high-signal and minimal. Only comment on real bugs with high confidence.
+
+## Comment Only When
+- The issue is a correctness, security, concurrency, or architecture problem.
+- The impact is clear and non-trivial.
+- You can point to concrete evidence in the diff (not speculation).
+
+## Avoid
+- Style, formatting, naming, or minor performance nits.
+- Optional refactors or “nice to have” suggestions.
+- Praise, restating the code, or long explanations.
+- Duplicate comments for the same root cause.
+
+## Review Style
+- Be terse: 1-2 sentences per issue.
+- Include file and line references when possible.
+- If no issues are found, say “No issues found.”
+- Provide concrete suggestions for fixes when possible, or examples to illustrate the problem.

--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -1141,7 +1141,7 @@ CompactObj::ExternalRep CompactObj::GetExternalRep() const {
 }
 
 void CompactObj::SetCool(size_t offset, uint32_t sz, ExternalRep rep,
-                         tiering::TieredColdRecord* record) {
+                         tiering::TieredCoolRecord* record) {
   encoding_ = record->value.encoding_;
   SetMeta(EXTERNAL_TAG, record->value.mask_);
 

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -20,7 +20,7 @@ typedef struct stream stream;
 namespace dfly {
 
 namespace tiering {
-struct TieredColdRecord;
+struct TieredCoolRecord;
 }
 
 constexpr unsigned kEncodingIntSet = 0;
@@ -336,12 +336,12 @@ class CompactObj {
 
   // Assigns a cooling record to the object together with its external slice.
   void SetCool(size_t offset, uint32_t serialized_size, ExternalRep rep,
-               tiering::TieredColdRecord* record);
+               tiering::TieredCoolRecord* record);
 
   struct CoolItem {
     uint16_t page_offset;
     size_t serialized_size;
-    tiering::TieredColdRecord* record;
+    tiering::TieredCoolRecord* record;
   };
 
   // Prerequisite: IsCool() is true.
@@ -453,7 +453,7 @@ class CompactObj {
     uint8_t first_byte;
 
     // We do not have enough space in the common area to store page_index together with
-    // cool_record pointer. Therefore, we moved this field into TieredColdRecord itself.
+    // cool_record pointer. Therefore, we moved this field into TieredCoolRecord itself.
     struct Offload {
       uint32_t page_index;
       uint32_t reserved;
@@ -461,7 +461,7 @@ class CompactObj {
 
     union {
       Offload offload;
-      tiering::TieredColdRecord* cool_record;
+      tiering::TieredCoolRecord* cool_record;
     };
   } __attribute__((packed));
   static_assert(sizeof(ExternalPtr) == 16);

--- a/src/core/tiering_types.cc
+++ b/src/core/tiering_types.cc
@@ -27,4 +27,12 @@ auto FragmentRef::GetDescr(const CompactValue* pv) -> SerializationDescr {
   };
 }
 
+TieredCoolRecord* FragmentRef::GetCoolRecord() const {
+  return std::visit(
+      [](auto* pv) -> TieredCoolRecord* {
+        return pv->IsExternal() && pv->IsCool() ? pv->GetCool().record : nullptr;
+      },
+      val_);
+}
+
 }  // namespace dfly::tiering

--- a/src/core/tiering_types.h
+++ b/src/core/tiering_types.h
@@ -10,14 +10,19 @@
 
 namespace dfly::tiering {
 
-struct TieredColdRecord : public ::boost::intrusive::list_base_hook<
+// TieredCoolRecord is part of the cooling cache. It allows offloading values to disk
+// while still keeping some of them in-memory to avoid disk reads in case they are requested again
+// soon after offloading. When a value is moved to the cold storage, TieredCoolRecord and only
+// the external reference is kept. When the value is warmed up, the record is removed from the cool
+// storage and the value is read back to memory.
+struct TieredCoolRecord : public ::boost::intrusive::list_base_hook<
                               boost::intrusive::link_mode<boost::intrusive::normal_link>> {
   uint64_t key_hash;  // Allows searching the entry in the dbslice.
   CompactValue value;
   uint16_t db_index;
   uint32_t page_index;
 };
-static_assert(sizeof(TieredColdRecord) == 48);
+static_assert(sizeof(TieredCoolRecord) == 48);
 
 class FragmentRef {
  public:
@@ -38,6 +43,11 @@ class FragmentRef {
     return std::visit([](auto* pv) { return pv->IsExternal(); }, val_);
   }
 
+  // Resets offloaded state for this fragment.
+  void ClearOffloaded() {
+    std::visit([](auto* pv) { pv->RemoveExternal(); }, val_);
+  }
+
   bool HasStashPending() const {
     return std::visit([](auto* pv) { return pv->HasStashPending(); }, val_);
   }
@@ -55,9 +65,18 @@ class FragmentRef {
     return std::visit([](auto* pv) { return GetDescr(pv); }, val_);
   }
 
+  // Returns a pointer to TieredCoolRecord if this fragment is cool, and null otherwise.
+  TieredCoolRecord* GetCoolRecord() const;
+
+  // Returns the external slice of the offloaded value. Only valid if IsOffloaded() is true.
+  std::pair<size_t, size_t> GetExternalSlice() const {
+    return std::visit([](auto* pv) { return pv->GetExternalSlice(); }, val_);
+  }
+
  private:
   static SerializationDescr GetDescr(const CompactValue* pv);
 
+  // TODO: to support more types, for example Node* from qlist.h.
   std::variant<CompactValue*> val_;
 };
 

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -58,10 +58,9 @@ namespace dfly {
 
 using namespace std;
 using namespace util;
-
 using tiering::FragmentRef;
 using tiering::KeyRef;
-using tiering::TieredColdRecord;
+using tiering::TieredCoolRecord;
 
 namespace {
 
@@ -434,20 +433,16 @@ std::optional<util::fb2::Future<bool>> TieredStorage::Stash(DbIndex dbid, string
   return {};
 }
 
-void TieredStorage::Delete(DbIndex dbid, PrimeValue* value) {
-  DCHECK(value->IsExternal());
-  DCHECK(!value->HasStashPending());
-
+void TieredStorage::Delete(DbIndex dbid, FragmentRef fragment_ref) {
+  DCHECK(!fragment_ref.HasStashPending());
   ++stats_.total_deletes;
 
-  tiering::DiskSegment segment = value->GetExternalSlice();
-  if (value->IsCool()) {
-    auto hot = DeleteCool(value->GetCool().record);
+  tiering::DiskSegment segment = fragment_ref.GetExternalSlice();
+  if (auto* cool = fragment_ref.GetCoolRecord(); cool) {
+    auto hot = DeleteCool(cool);
     DCHECK_EQ(hot.ObjType(), OBJ_STRING);
   }
-
-  // In any case we delete the offloaded segment and reset the value.
-  value->RemoveExternal();
+  fragment_ref.ClearOffloaded();
   op_manager_->DeleteOffloaded(dbid, segment);
 }
 
@@ -593,7 +588,7 @@ size_t TieredStorage::ReclaimMemory(size_t goal) {
   size_t gained = 0;
   do {
     size_t memory_before = stats_.cool_memory_used;
-    TieredColdRecord* record = PopCool();
+    TieredCoolRecord* record = PopCool();
     if (record == nullptr)  // nothing to pull anymore
       break;
 
@@ -615,7 +610,7 @@ size_t TieredStorage::ReclaimMemory(size_t goal) {
 
     auto* stats = op_manager_->GetDbTableStats(record->db_index);
     stats->AddTypeMemoryUsage(record->value.ObjType(), -record->value.MallocUsed());
-    CompactObj::DeleteMR<TieredColdRecord>(record);
+    CompactObj::DeleteMR<TieredCoolRecord>(record);
   } while (gained < goal);
 
   return gained;
@@ -653,9 +648,9 @@ auto TieredStorage::ShouldStash(const tiering::FragmentRef& fragment_ref) const
 void TieredStorage::CoolDown(DbIndex db_ind, std::string_view str,
                              const tiering::DiskSegment& segment, CompactObj::ExternalRep rep,
                              PrimeValue* pv) {
-  TieredColdRecord* record = CompactObj::AllocateMR<TieredColdRecord>();
+  TieredCoolRecord* record = CompactObj::AllocateMR<TieredCoolRecord>();
   cool_queue_.push_front(*record);
-  stats_.cool_memory_used += (sizeof(TieredColdRecord) + pv->MallocUsed());
+  stats_.cool_memory_used += (sizeof(TieredCoolRecord) + pv->MallocUsed());
 
   record->key_hash = CompactObj::HashCode(str);
   record->db_index = db_ind;
@@ -674,23 +669,23 @@ PrimeValue TieredStorage::Warmup(DbIndex dbid, PrimeValue::CoolItem item) {
   return hot;
 }
 
-PrimeValue TieredStorage::DeleteCool(TieredColdRecord* record) {
+PrimeValue TieredStorage::DeleteCool(TieredCoolRecord* record) {
   auto it = CoolQueue::s_iterator_to(*record);
   cool_queue_.erase(it);
 
   PrimeValue hot{std::move(record->value)};
-  stats_.cool_memory_used -= (sizeof(TieredColdRecord) + hot.MallocUsed());
-  CompactObj::DeleteMR<TieredColdRecord>(record);
+  stats_.cool_memory_used -= (sizeof(TieredCoolRecord) + hot.MallocUsed());
+  CompactObj::DeleteMR<TieredCoolRecord>(record);
   return hot;
 }
 
-TieredColdRecord* TieredStorage::PopCool() {
+TieredCoolRecord* TieredStorage::PopCool() {
   if (cool_queue_.empty())
     return nullptr;
 
-  TieredColdRecord& res = cool_queue_.back();
+  TieredCoolRecord& res = cool_queue_.back();
   cool_queue_.pop_back();
-  stats_.cool_memory_used -= (sizeof(TieredColdRecord) + res.value.MallocUsed());
+  stats_.cool_memory_used -= (sizeof(TieredCoolRecord) + res.value.MallocUsed());
   return &res;
 }
 

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -89,7 +89,7 @@ class TieredStorage : public TieredStorageBase {
                                                const StashDescriptor& blobs, bool provide_bp);
 
   // Delete value, must be offloaded (external type)
-  void Delete(DbIndex dbid, PrimeValue* value);
+  void Delete(DbIndex dbid, tiering::FragmentRef fragment_ref);
 
   // Cancel pending stash for the fragment, must have HasStashPending() true.
   void CancelStash(DbIndex dbid, std::string_view key, tiering::FragmentRef fragment_ref);
@@ -126,8 +126,8 @@ class TieredStorage : public TieredStorageBase {
   void CoolDown(DbIndex db_ind, std::string_view str, const tiering::DiskSegment& segment,
                 CompactObj::ExternalRep rep, PrimeValue* pv);
 
-  PrimeValue DeleteCool(tiering::TieredColdRecord* record);
-  tiering::TieredColdRecord* PopCool();
+  PrimeValue DeleteCool(tiering::TieredCoolRecord* record);
+  tiering::TieredCoolRecord* PopCool();
 
   PrimeTable::Cursor offloading_cursor_;  // where RunOffloading left off
 
@@ -137,7 +137,7 @@ class TieredStorage : public TieredStorageBase {
   std::unique_ptr<ShardOpManager> op_manager_;
   std::unique_ptr<tiering::SmallBins> bins_;
 
-  using CoolQueue = ::boost::intrusive::list<tiering::TieredColdRecord>;
+  using CoolQueue = ::boost::intrusive::list<tiering::TieredCoolRecord>;
   CoolQueue cool_queue_;
 
   struct {


### PR DESCRIPTION
Wrap PrimeValue references in a FragmentRef type to encapsulate tiering
metadata access. Update Delete, CancelStash, and ShouldStash to accept
FragmentRef instead of raw PrimeValue pointers.

This removes PrimeValue references from the external APIs for tiered storage.
Next step would be to support Node* in FragmentRef and provide support for listpacks/blobs
for qlist.

Also - rename `TieredColdRecord` to `TieredCoolRecord` for consistency. 
"Cool" state is where items reside both on disk and in memory and can be immediately evicted any moment.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>