### PR TITLE
test(tiering): add ABA stash-delete-restash test for OpManager

### DIFF
--- a/src/server/tiering/op_manager.cc
+++ b/src/server/tiering/op_manager.cc
@@ -55,7 +55,7 @@ void OpManager::Enqueue(PendingId id, DiskSegment segment, const Decoder& decode
   // Fill pages for prepared read as it has no penalty and potentially covers more small segments
   PrepareRead(segment.ContainingPages())
       .ForSegment(segment, id, decoder)
-      .callbacks.emplace_back(std::move(cb));
+      .read_cbs.emplace_back(std::move(cb));
 }
 
 void OpManager::CancelPending(PendingId id) {
@@ -141,25 +141,25 @@ void OpManager::ProcessRead(size_t offset, io::Result<std::string_view> page) {
   // If we already have a page read for defragmentation pending and some other read for the
   // sub-segment is enqueued, we first must handle the sub-segment read, only then the full page
   // read
-  for (size_t i = 0; i + 1 < info->key_ops.size(); i++) {
-    if (info->key_ops[i].segment.offset % kPageSize == 0) {
-      std::swap(info->key_ops[i], info->key_ops.back());
+  for (size_t i = 0; i + 1 < info->entry_ops.size(); i++) {
+    if (info->entry_ops[i].segment.offset % kPageSize == 0) {
+      std::swap(info->entry_ops[i], info->entry_ops.back());
       break;
     }
   }
 
   bool deleting_full = false;
 
-  // Notify functions in the loop may append items to info->key_ops during the traversal
-  for (size_t i = 0; i < info->key_ops.size(); i++) {
-    auto& ko = info->key_ops[i];
+  // Notify functions in the loop may append items to info->entry_ops during the traversal
+  for (size_t i = 0; i < info->entry_ops.size(); i++) {
+    auto& ko = info->entry_ops[i];
     if (page) {
       size_t offset = ko.segment.offset - info->segment.offset;
       ko.decoder->Initialize(page->substr(offset, ko.segment.length));
-      for (auto& cb : ko.callbacks)
+      for (auto& cb : ko.read_cbs)
         cb(&*ko.decoder);
     } else {
-      for (auto& cb : ko.callbacks)
+      for (auto& cb : ko.read_cbs)
         cb(page.get_unexpected());
     }
 
@@ -191,17 +191,17 @@ OpManager::EntryOps& OpManager::ReadOp::ForSegment(DiskSegment key_segment, Pend
   DCHECK_GE(key_segment.offset, segment.offset);
   DCHECK_LE(key_segment.length, segment.length);
 
-  for (auto& ops : key_ops) {
+  for (auto& ops : entry_ops) {
     if (ops.segment.offset == key_segment.offset) {
       DCHECK(typeid(*ops.decoder) == typeid(decoder));
       return ops;
     }
   }
-  return key_ops.emplace_back(ToOwned(id), key_segment, decoder);
+  return entry_ops.emplace_back(ToOwned(id), key_segment, decoder);
 }
 
 OpManager::EntryOps* OpManager::ReadOp::Find(DiskSegment key_segment) {
-  for (auto& ops : key_ops) {
+  for (auto& ops : entry_ops) {
     if (ops.segment.offset == key_segment.offset)
       return &ops;
   }

--- a/src/server/tiering/op_manager.h
+++ b/src/server/tiering/op_manager.h
@@ -88,14 +88,18 @@ class OpManager {
   // Notify delete. Return true if the filled segment needs to be marked as free.
   virtual bool NotifyDelete(DiskSegment segment) = 0;
 
-  // Describes pending futures for a single entry
+  // Describes pending read futures for a single entry
   struct EntryOps {
     EntryOps(OwnedEntryId id, DiskSegment segment, const Decoder& decoder);
 
     // unique identifier for the entry being read. Used to notify higher layers.
     OwnedEntryId id;
+
+    // For multi-bin reads is a precise segment of the entry within a page.
     DiskSegment segment;
-    absl::InlinedVector<ReadCallback, 1> callbacks;
+
+    // We may have multiple callbacks for the same entry.
+    absl::InlinedVector<ReadCallback, 1> read_cbs;
     std::unique_ptr<Decoder> decoder;
     bool deleting = false;
   };
@@ -111,8 +115,11 @@ class OpManager {
     // Find if there are operations for the given segment, return nullptr otherwise
     EntryOps* Find(DiskSegment segment);
 
-    DiskSegment segment;                       // spanning segment of whole read
-    absl::InlinedVector<EntryOps, 1> key_ops;  // enqueued operations for different keys
+    DiskSegment segment;  // spanning segment of whole read
+
+    // enqueued operations for different keys for this segment.
+    // Has size() > 1 only for small-bin pages with multiple items, otherwise size() == 1.
+    absl::InlinedVector<EntryOps, 1> entry_ops;
   };
 
   // Prepare read operation for aligned segment or return pending if it exists.
@@ -132,6 +139,10 @@ class OpManager {
 
   DiskStorage storage_;
 
+  // Pending read operations are keyed by the offset of their aligned segment.
+  // This prevents an ABA problem in scenarios like: read (pending) → delete → stash → read.
+  // After the stash, the second read targets a different segment offset, so it won't
+  // interfere with the first read's pending operation, even for the same PendingId.
   absl::flat_hash_map<size_t /* offset */, ReadOp> pending_reads_;
 
   size_t pending_stash_counter_ = 0;

--- a/src/server/tiering/op_manager_test.cc
+++ b/src/server/tiering/op_manager_test.cc
@@ -89,6 +89,11 @@ struct OpManagerTest : PoolTestBase, OpManager {
     });
   }
 
+  void WaitForPendingStashes() {
+    while (GetStats().pending_stash_cnt > 0)
+      util::ThisFiber::SleepFor(1ms);
+  }
+
   absl::flat_hash_map<OwnedEntryId, std::string> fetched_;
   absl::flat_hash_map<OwnedEntryId, DiskSegment> stashed_;
 };
@@ -104,8 +109,7 @@ TEST_F(OpManagerTest, SimpleStashesWithReads) {
     }
 
     EXPECT_EQ(GetStats().pending_stash_cnt, 100);
-    while (GetStats().disk_stats.pending_ops > 0)
-      util::ThisFiber::SleepFor(1ms);
+    WaitForPendingStashes();
 
     EXPECT_EQ(stashed_.size(), 100u);
     EXPECT_EQ(GetStats().disk_stats.allocated_bytes, 100 * kPageSize) << GetStats();
@@ -126,8 +130,7 @@ TEST_F(OpManagerTest, DeleteAfterReads) {
     Open();
 
     EXPECT_FALSE(Stash(0u, absl::StrCat("DATA")));
-    while (stashed_.empty())
-      util::ThisFiber::SleepFor(1ms);
+    WaitForPendingStashes();
 
     std::vector<util::fb2::Future<std::string>> reads;
     for (unsigned i = 0; i < 100; i++)
@@ -155,8 +158,7 @@ TEST_F(OpManagerTest, ReadSamePageDifferentOffsets) {
     }
 
     EXPECT_FALSE(Stash(0u, numbers));
-    while (stashed_.empty())
-      util::ThisFiber::SleepFor(1ms);
+    WaitForPendingStashes();
 
     EXPECT_EQ(stashed_[0u].offset, 0u);
 
@@ -172,13 +174,59 @@ TEST_F(OpManagerTest, ReadSamePageDifferentOffsets) {
   });
 }
 
+// Test ABA scenario: stash an entry, issue an async read, delete it and re-stash a new value
+// under the same id - all without yielding so the read I/O stays in flight. When I/O completes,
+// version tracking in pending_stash_ver_ must ensure only the new stash triggers NotifyStashed
+// while the old one is silently discarded (its segment freed).
+//
+// NOTE: We cannot guarantee that the first read completes after the second stash because we have
+// no control over io_uring completion ordering. In practice, the read submitted first likely
+// completes before or around the same time as the stash. To fully test the interleaving where
+// the new entry's read is issued while the original read is still in flight, we would need a
+// mock DiskStorage that allows explicit control over when I/O completions are delivered.
+// TODO: Add a DiskStorage mock to enable deterministic I/O completion ordering in tests.
+TEST_F(OpManagerTest, StashDeleteRestashWhileReading) {
+  pp_->at(0)->Await([this] {
+    Open();
+
+    // Stash initial value under id 0
+    EXPECT_FALSE(Stash(0u, "ORIGINAL"));
+    WaitForPendingStashes();
+
+    DiskSegment original_segment = stashed_.at(0u);
+
+    // Issue an async read - don't wait on it yet so it stays in flight.
+    auto read_fut = Read(0u, original_segment);
+
+    // Without yielding: delete the entry, clear tracking, re-stash under the same id.
+    // At this point the read for ORIGINAL is still pending in io_uring, and we're issuing
+    // a new stash for id 0 with a bumped version.
+    DeleteOffloaded(original_segment);
+    stashed_.clear();
+    EXPECT_FALSE(Stash(0u, "REPLACEMENT"));
+
+    // Both the read and the new stash are now in flight. Let them complete.
+    WaitForPendingStashes();
+    EXPECT_EQ(read_fut.Get(), "ORIGINAL");
+
+    // Verify only the replacement was notified (single entry in stashed_).
+    ASSERT_EQ(stashed_.size(), 1u);
+    ASSERT_EQ(1, stashed_.count(0u));
+    DiskSegment new_segment = stashed_.at(0u);
+
+    // Read the replacement and verify correctness
+    EXPECT_EQ(Read(0u, new_segment).Get(), "REPLACEMENT");
+
+    Close();
+  });
+}
+
 TEST_F(OpManagerTest, Modify) {
   pp_->at(0)->Await([this] {
     Open();
 
     std::ignore = Stash(0u, "D");
-    while (stashed_.empty())
-      util::ThisFiber::SleepFor(1ms);
+    WaitForPendingStashes();
 
     // Atomically issue sequence of modify-read operations
     std::vector<util::fb2::Future<std::string>> futures;


### PR DESCRIPTION
## Summary
- Add `StashDeleteRestashWhileReading` test covering the ABA scenario where an entry is stashed, read is issued, deleted and re-stashed under the same id while the original read is in flight
- Refactor existing tests to use `WaitForPendingStashes()` helper instead of ad-hoc spin loops
- Add TODO for a DiskStorage mock to enable deterministic I/O completion ordering

Also refactor existing tests to use WaitForPendingStashes() helper
instead of ad-hoc spin loops. **No functional changes.**

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Roman Gershman <roman@dragonflydb.io>