### PR TITLE
chore(tiering): move TieredColdRecord to tiering namespace, update op_manager types

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -31,6 +31,7 @@ extern "C" {
 #include "core/sorted_map.h"
 #include "core/string_map.h"
 #include "core/string_set.h"
+#include "core/tiering_types.h"
 
 ABSL_FLAG(bool, experimental_flat_json, false, "If true uses flat json implementation.");
 ABSL_FLAG(bool, disable_json_defragmentation, false, "If true disable json object defragmentation");
@@ -1140,7 +1141,7 @@ CompactObj::ExternalRep CompactObj::GetExternalRep() const {
 }
 
 void CompactObj::SetCool(size_t offset, uint32_t sz, ExternalRep rep,
-                         detail::TieredColdRecord* record) {
+                         tiering::TieredColdRecord* record) {
   encoding_ = record->value.encoding_;
   SetMeta(EXTERNAL_TAG, record->value.mask_);
 

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -6,7 +6,6 @@
 
 #include <absl/base/internal/endian.h>
 
-#include <boost/intrusive/list_hook.hpp>
 #include <optional>
 #include <type_traits>
 
@@ -19,6 +18,10 @@
 typedef struct stream stream;
 
 namespace dfly {
+
+namespace tiering {
+struct TieredColdRecord;
+}
 
 constexpr unsigned kEncodingIntSet = 0;
 constexpr unsigned kEncodingStrMap2 = 2;  // for set/map encodings of strings using DenseSet
@@ -99,8 +102,6 @@ class RobjWrapper {
 } __attribute__((packed));
 
 static_assert(sizeof(RobjWrapper) == 16);
-
-struct TieredColdRecord;
 
 }  // namespace detail
 
@@ -335,12 +336,12 @@ class CompactObj {
 
   // Assigns a cooling record to the object together with its external slice.
   void SetCool(size_t offset, uint32_t serialized_size, ExternalRep rep,
-               detail::TieredColdRecord* record);
+               tiering::TieredColdRecord* record);
 
   struct CoolItem {
     uint16_t page_offset;
     size_t serialized_size;
-    detail::TieredColdRecord* record;
+    tiering::TieredColdRecord* record;
   };
 
   // Prerequisite: IsCool() is true.
@@ -460,7 +461,7 @@ class CompactObj {
 
     union {
       Offload offload;
-      detail::TieredColdRecord* cool_record;
+      tiering::TieredColdRecord* cool_record;
     };
   } __attribute__((packed));
   static_assert(sizeof(ExternalPtr) == 16);
@@ -583,19 +584,6 @@ std::string_view ObjTypeToString(CompactObjType type);
 
 // Returns kInvalidCompactObjType if sv is not a valid type.
 CompactObjType ObjTypeFromString(std::string_view sv);
-
-namespace detail {
-
-struct TieredColdRecord : public ::boost::intrusive::list_base_hook<
-                              boost::intrusive::link_mode<boost::intrusive::normal_link>> {
-  uint64_t key_hash;  // Allows searching the entry in the dbslice.
-  CompactValue value;
-  uint16_t db_index;
-  uint32_t page_index;
-};
-static_assert(sizeof(TieredColdRecord) == 48);
-
-};  // namespace detail
 
 stream* streamNew();
 void freeStream(stream* s);

--- a/src/core/tiering_types.h
+++ b/src/core/tiering_types.h
@@ -1,0 +1,22 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <boost/intrusive/list_hook.hpp>
+
+#include "core/compact_object.h"
+
+namespace dfly::tiering {
+
+struct TieredColdRecord : public ::boost::intrusive::list_base_hook<
+                              boost::intrusive::link_mode<boost::intrusive::normal_link>> {
+  uint64_t key_hash;  // Allows searching the entry in the dbslice.
+  CompactValue value;
+  uint16_t db_index;
+  uint32_t page_index;
+};
+static_assert(sizeof(TieredColdRecord) == 48);
+
+}  // namespace dfly::tiering

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -59,7 +59,8 @@ namespace dfly {
 using namespace std;
 using namespace util;
 
-using KeyRef = tiering::OpManager::KeyRef;
+using tiering::KeyRef;
+using tiering::TieredColdRecord;
 
 namespace {
 
@@ -612,7 +613,7 @@ size_t TieredStorage::ReclaimMemory(size_t goal) {
   size_t gained = 0;
   do {
     size_t memory_before = stats_.cool_memory_used;
-    detail::TieredColdRecord* record = PopCool();
+    TieredColdRecord* record = PopCool();
     if (record == nullptr)  // nothing to pull anymore
       break;
 
@@ -634,7 +635,7 @@ size_t TieredStorage::ReclaimMemory(size_t goal) {
 
     auto* stats = op_manager_->GetDbTableStats(record->db_index);
     stats->AddTypeMemoryUsage(record->value.ObjType(), -record->value.MallocUsed());
-    CompactObj::DeleteMR<detail::TieredColdRecord>(record);
+    CompactObj::DeleteMR<TieredColdRecord>(record);
   } while (gained < goal);
 
   return gained;
@@ -671,9 +672,9 @@ auto TieredStorage::ShouldStash(const PrimeValue& pv) const -> std::optional<Sta
 void TieredStorage::CoolDown(DbIndex db_ind, std::string_view str,
                              const tiering::DiskSegment& segment, CompactObj::ExternalRep rep,
                              PrimeValue* pv) {
-  detail::TieredColdRecord* record = CompactObj::AllocateMR<detail::TieredColdRecord>();
+  TieredColdRecord* record = CompactObj::AllocateMR<TieredColdRecord>();
   cool_queue_.push_front(*record);
-  stats_.cool_memory_used += (sizeof(detail::TieredColdRecord) + pv->MallocUsed());
+  stats_.cool_memory_used += (sizeof(TieredColdRecord) + pv->MallocUsed());
 
   record->key_hash = CompactObj::HashCode(str);
   record->db_index = db_ind;
@@ -692,23 +693,23 @@ PrimeValue TieredStorage::Warmup(DbIndex dbid, PrimeValue::CoolItem item) {
   return hot;
 }
 
-PrimeValue TieredStorage::DeleteCool(detail::TieredColdRecord* record) {
+PrimeValue TieredStorage::DeleteCool(TieredColdRecord* record) {
   auto it = CoolQueue::s_iterator_to(*record);
   cool_queue_.erase(it);
 
   PrimeValue hot{std::move(record->value)};
-  stats_.cool_memory_used -= (sizeof(detail::TieredColdRecord) + hot.MallocUsed());
-  CompactObj::DeleteMR<detail::TieredColdRecord>(record);
+  stats_.cool_memory_used -= (sizeof(TieredColdRecord) + hot.MallocUsed());
+  CompactObj::DeleteMR<TieredColdRecord>(record);
   return hot;
 }
 
-detail::TieredColdRecord* TieredStorage::PopCool() {
+TieredColdRecord* TieredStorage::PopCool() {
   if (cool_queue_.empty())
     return nullptr;
 
-  detail::TieredColdRecord& res = cool_queue_.back();
+  TieredColdRecord& res = cool_queue_.back();
   cool_queue_.pop_back();
-  stats_.cool_memory_used -= (sizeof(detail::TieredColdRecord) + res.value.MallocUsed());
+  stats_.cool_memory_used -= (sizeof(TieredColdRecord) + res.value.MallocUsed());
   return &res;
 }
 

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "core/tiering_types.h"
 #include "io/io.h"  // for io::Result (TODO: replace with nonstd/expected)
 #include "server/stats.h"
 #include "server/table.h"
@@ -122,8 +123,8 @@ class TieredStorage : public TieredStorageBase {
   void CoolDown(DbIndex db_ind, std::string_view str, const tiering::DiskSegment& segment,
                 CompactObj::ExternalRep rep, PrimeValue* pv);
 
-  PrimeValue DeleteCool(detail::TieredColdRecord* record);
-  detail::TieredColdRecord* PopCool();
+  PrimeValue DeleteCool(tiering::TieredColdRecord* record);
+  tiering::TieredColdRecord* PopCool();
 
   PrimeTable::Cursor offloading_cursor_{};  // where RunOffloading left off
 
@@ -133,7 +134,7 @@ class TieredStorage : public TieredStorageBase {
   std::unique_ptr<ShardOpManager> op_manager_;
   std::unique_ptr<tiering::SmallBins> bins_;
 
-  using CoolQueue = ::boost::intrusive::list<detail::TieredColdRecord>;
+  using CoolQueue = ::boost::intrusive::list<tiering::TieredColdRecord>;
   CoolQueue cool_queue_;
 
   struct {

--- a/src/server/tiering/common.h
+++ b/src/server/tiering/common.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <optional>
+#include <variant>
 
 namespace dfly::tiering {
 
@@ -45,5 +46,12 @@ struct DiskSegment {
     return os << "[" << ds.offset << ", " << ds.length << "]";
   }
 };
+
+using KeyRef = std::pair<uint16_t /* DbIndex */, std::string_view>;
+
+// Two separate keyspaces are provided - one for strings, one for numeric identifiers.
+// Ids can be used to track auxiliary values that don't map to real keys (like a page index).
+// Specifically, we track page indexes when serializing small-bin pages with multiple items.
+using PendingId = std::variant<uintptr_t, KeyRef>;
 
 };  // namespace dfly::tiering

--- a/src/server/tiering/op_manager.cc
+++ b/src/server/tiering/op_manager.cc
@@ -16,16 +16,16 @@ namespace dfly::tiering {
 
 using namespace std;
 
-OpManager::OwnedEntryId OpManager::ToOwned(OpManager::PendingId id) {
-  Overloaded convert{[](unsigned i) -> OpManager::OwnedEntryId { return i; },
-                     [](std::pair<DbIndex, std::string_view> p) -> OwnedEntryId {
-                       return std::make_pair(p.first, std::string{p.second});
-                     }};
-  return std::visit(convert, id);
+OpManager::OwnedEntryId OpManager::ToOwned(PendingId id) {
+  return std::visit(Overloaded{[](uintptr_t i) -> OpManager::OwnedEntryId { return i; },
+                               [](std::pair<DbIndex, std::string_view> p) -> OwnedEntryId {
+                                 return std::make_pair(p.first, std::string{p.second});
+                               }},
+                    id);
 }
 
 string OpManager::ToString(const OwnedEntryId& id) {
-  if (const auto* i = std::get_if<unsigned>(&id); i) {
+  if (const auto* i = std::get_if<uintptr_t>(&id); i) {
     return absl::StrCat(*i);
   }
   const auto& key = std::get<DbKeyId>(id);

--- a/src/server/tiering/op_manager.h
+++ b/src/server/tiering/op_manager.h
@@ -29,12 +29,9 @@ class OpManager {
     size_t pending_stash_cnt = 0;
   };
 
-  using KeyRef = std::pair<DbIndex, std::string_view>;
+  using KeyRef = ::dfly::tiering::KeyRef;
 
-  // Two separate keyspaces are provided - one for strings, one for numeric identifiers.
-  // Ids can be used to track auxiliary values that don't map to real keys (like a page index).
-  // Specifically, we track page indexes when serializing small-bin pages with multiple items.
-  using PendingId = std::variant<unsigned, KeyRef>;
+  using PendingId = ::dfly::tiering::PendingId;
 
   explicit OpManager(size_t max_size);
   virtual ~OpManager();
@@ -75,7 +72,7 @@ class OpManager {
   Stats GetStats() const;
 
  protected:
-  using OwnedEntryId = std::variant<unsigned, DbKeyId>;
+  using OwnedEntryId = std::variant<uintptr_t, DbKeyId>;
 
   // Notify that a stash succeeded and the entry was stored at the provided segment or failed with
   // given error


### PR DESCRIPTION
## Summary
- Extract `TieredColdRecord` struct into `core/tiering_types.h` under `tiering` namespace
- Centralize `KeyRef` and `PendingId` type aliases in `tiering/common.h`
- Change `OwnedEntryId` variant from `unsigned` to `uintptr_t` in op_manager
- Update `compact_object.h/cc` to reference `tiering::TieredColdRecord`

Non-functional refactoring; no behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)