### PR TITLE
fix(ci): fix no-op cluster tests and move slow tests to large CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,10 +182,12 @@ jobs:
 
       - name: C++ Unit Tests - IoUring with cluster mode
         run: |
+          cd ${GITHUB_WORKSPACE}/build
           FLAGS_fiber_safety_margin=4096 FLAGS_cluster_mode=emulated timeout 20m ctest -V -L DFLY
 
       - name: C++ Unit Tests - IoUring with cluster mode and FLAGS_lock_on_hashtags
         run: |
+          cd ${GITHUB_WORKSPACE}/build
           FLAGS_fiber_safety_margin=4096 FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true timeout 20m ctest -V -L DFLY
 
       - name: Upload unit logs on failure

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -2162,6 +2162,7 @@ async def test_cluster_migration_huge_container(df_factory: DflyInstanceFactory)
 @dfly_args(
     {"proactor_threads": 2, "cluster_mode": "yes", "migration_buckets_serialization_threshold": 1}
 )
+@pytest.mark.large
 @pytest.mark.parametrize("chunk_size", [1_000_000, 30])
 @pytest.mark.asyncio
 @pytest.mark.exclude_epoll
@@ -2728,6 +2729,7 @@ async def test_cluster_memory_consumption_migration(df_factory: DflyInstanceFact
     await check_for_no_state_status([node.admin_client for node in nodes])
 
 
+@pytest.mark.large
 @pytest.mark.exclude_epoll
 @pytest.mark.asyncio
 @dfly_args({"proactor_threads": 4, "cluster_mode": "yes", "migration_buckets_cpu_budget": 1})
@@ -3129,6 +3131,7 @@ async def test_cluster_sharded_pubsub_shard_commands(df_factory: DflyInstanceFac
     assert message == []
 
 
+@pytest.mark.large
 @dfly_args({"proactor_threads": 2, "cluster_mode": "yes"})
 async def test_cluster_migration_errors_num(df_factory: DflyInstanceFactory):
     # create cluster with several nodes and create migrations from one node to others

--- a/tests/dragonfly/memory_test.py
+++ b/tests/dragonfly/memory_test.py
@@ -152,6 +152,7 @@ async def test_rss_oom_ratio(df_factory: DflyInstanceFactory, admin_port):
     await client.execute_command("set x y")
 
 
+@pytest.mark.large
 @pytest.mark.asyncio
 @dfly_args(
     {

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -2219,6 +2219,7 @@ async def test_journal_doesnt_yield_issue_2500(df_factory, df_seeder_factory):
     assert set(keys_master) == set(keys_replica)
 
 
+@pytest.mark.large
 async def test_saving_replica(df_factory):
     master = df_factory.create(proactor_threads=1)
     replica = df_factory.create(proactor_threads=1, dbfilename=f"dump_{tmp_file_name()}")
@@ -2823,6 +2824,7 @@ async def test_replica_of_replica(df_factory):
     assert await c_replica2.execute_command(f"REPLICAOF localhost {master.port}") == "OK"
 
 
+@pytest.mark.large
 async def test_replication_timeout_on_full_sync_heartbeat_expiry(
     df_factory: DflyInstanceFactory, df_seeder_factory
 ):
@@ -3083,6 +3085,7 @@ async def test_replicaof_inside_multi(df_factory):
     assert MULTI_COMMANDS_TO_ISSUE == num_successes
 
 
+@pytest.mark.large
 async def test_preempt_in_atomic_section_of_heartbeat(df_factory: DflyInstanceFactory):
     master = df_factory.create(proactor_threads=1, serialization_max_chunk_size=100000000000)
     replicas = [df_factory.create(proactor_threads=1) for i in range(2)]
@@ -3112,6 +3115,7 @@ async def test_preempt_in_atomic_section_of_heartbeat(df_factory: DflyInstanceFa
     await fill_task
 
 
+@pytest.mark.large
 async def test_bug_in_json_memory_tracking(df_factory: DflyInstanceFactory):
     """
     This test reproduces a bug in the JSON memory tracking.
@@ -3609,6 +3613,7 @@ async def test_replication_onmove_flow(df_factory, serialization_max_size):
         assert moved_saved > 0
 
 
+@pytest.mark.large
 @dfly_args({"proactor_threads": 1})
 async def test_big_strings(df_factory):
     master = df_factory.create(


### PR DESCRIPTION
Fix two cluster mode unit test steps that ran `ctest` from the wrong directory (repo root instead of `build/`), making them silent no-ops.
Also, move 9 regression tests that take 30s+ to the large CI set.
