### PR TITLE
refactor(tiering): introduce FragmentRef abstraction for serialization

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -27,7 +27,7 @@ add_library(dfly_core allocation_tracker.cc bloom.cc compact_object.cc dense_set
     dragonfly_core.cc extent_tree.cc huff_coder.cc
     interpreter.cc glob_matcher.cc mi_memory_resource.cc qlist.cc sds_utils.cc
     segment_allocator.cc score_map.cc small_string.cc sorted_map.cc task_queue.cc
-    tx_queue.cc string_set.cc string_map.cc top_keys.cc
+    tx_queue.cc string_set.cc string_map.cc tiering_types.cc top_keys.cc
     detail/bitpacking.cc detail/listpack_wrap.cc detail/listpack.cc
     count_min_sketch.cc oah_entry.cc)
 

--- a/src/core/tiering_types.cc
+++ b/src/core/tiering_types.cc
@@ -1,0 +1,30 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "core/tiering_types.h"
+
+#include "redis/redis_aux.h"
+
+namespace dfly::tiering {
+
+auto FragmentRef::GetDescr(const CompactValue* pv) -> SerializationDescr {
+  switch (pv->ObjType()) {
+    case OBJ_STRING: {
+      if (!pv->HasAllocated())
+        return {};
+      auto strs = pv->GetRawString();
+      return {strs, CompactObj::ExternalRep::STRING};
+    }
+    case OBJ_HASH: {
+      if (pv->Encoding() == kEncodingListPack) {
+        return {static_cast<uint8_t*>(pv->RObjPtr()), CompactObj::ExternalRep::SERIALIZED_MAP};
+      }
+      return {};
+    }
+    default:
+      return {};
+  };
+}
+
+}  // namespace dfly::tiering

--- a/src/core/tiering_types.h
+++ b/src/core/tiering_types.h
@@ -19,4 +19,46 @@ struct TieredColdRecord : public ::boost::intrusive::list_base_hook<
 };
 static_assert(sizeof(TieredColdRecord) == 48);
 
+class FragmentRef {
+ public:
+  // Describes how this fragment should be serialized for offloading.
+  // Used by stashing flow.
+  struct SerializationDescr {
+    std::variant<std::array<std::string_view, 2>, uint8_t*> blob;
+    CompactObj::ExternalRep rep = CompactObj::ExternalRep::STRING;
+  };
+
+  FragmentRef(CompactValue& pv) : val_(&pv) {  // NOLINT
+  }
+
+  FragmentRef(CompactValue* pv) : val_(pv) {  // NOLINT
+  }
+
+  bool IsOffloaded() const {
+    return std::visit([](auto* pv) { return pv->IsExternal(); }, val_);
+  }
+
+  bool HasStashPending() const {
+    return std::visit([](auto* pv) { return pv->HasStashPending(); }, val_);
+  }
+
+  void ClearStashPending() {
+    std::visit([](auto* pv) { pv->SetStashPending(false); }, val_);
+  }
+
+  CompactObjType ObjType() const {
+    return std::visit([](auto* pv) { return pv->ObjType(); }, val_);
+  }
+
+  // Determine required byte size and encoding type based on value.
+  SerializationDescr GetSerializationDescr() const {
+    return std::visit([](auto* pv) { return GetDescr(pv); }, val_);
+  }
+
+ private:
+  static SerializationDescr GetDescr(const CompactValue* pv);
+
+  std::variant<CompactValue*> val_;
+};
+
 }  // namespace dfly::tiering

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -59,6 +59,7 @@ namespace dfly {
 using namespace std;
 using namespace util;
 
+using tiering::FragmentRef;
 using tiering::KeyRef;
 using tiering::TieredColdRecord;
 
@@ -80,28 +81,6 @@ void RecordDeleted(const PrimeValue& pv, size_t tiered_len, DbTableStats* stats)
 
 tiering::DiskSegment FromCoolItem(const PrimeValue::CoolItem& item) {
   return {item.record->page_index * tiering::kPageSize + item.page_offset, item.serialized_size};
-}
-
-// Determine required byte size and encoding type based on value.
-// Do NOT enforce rules depending on dynamic runtime values as this is called
-// when scheduling stash and just before succeeeding and is expected to return the same results
-TieredStorage::StashDescriptor DetermineSerializationParams(const PrimeValue& pv) {
-  switch (pv.ObjType()) {
-    case OBJ_STRING: {
-      if (!pv.HasAllocated())
-        return {};
-      auto strs = pv.GetRawString();
-      return {strs, CompactObj::ExternalRep::STRING};
-    }
-    case OBJ_HASH: {
-      if (pv.Encoding() == kEncodingListPack) {
-        return {static_cast<uint8_t*>(pv.RObjPtr()), CompactObj::ExternalRep::SERIALIZED_MAP};
-      }
-      return {};
-    }
-    default:
-      return {};
-  };
 }
 
 string SerializeToString(const TieredStorage::StashDescriptor& blobs) {
@@ -233,7 +212,7 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
       stats->tiered_used_bytes += segment.length;
       stats_.total_stashes++;
 
-      StashDescriptor blobs = DetermineSerializationParams(*pv);
+      StashDescriptor blobs{FragmentRef{*pv}.GetSerializationDescr()};
       if (ts_->config_.experimental_cooling) {
         RetireColdEntries(pv->MallocUsed());
         ts_->CoolDown(key.first, key.second, segment, blobs.rep, pv);
@@ -472,22 +451,23 @@ void TieredStorage::Delete(DbIndex dbid, PrimeValue* value) {
   op_manager_->DeleteOffloaded(dbid, segment);
 }
 
-void TieredStorage::CancelStash(DbIndex dbid, std::string_view key, PrimeValue* value) {
-  DCHECK(value->HasStashPending());
+void TieredStorage::CancelStash(DbIndex dbid, std::string_view key,
+                                tiering::FragmentRef fragment_ref) {
+  DCHECK(fragment_ref.HasStashPending());
 
   // If any previous write was happening, it has been cancelled
   if (auto node = stash_backpressure_.extract(make_pair(dbid, key)); !node.empty())
     std::move(node.mapped()).Resolve(false);
 
   // TODO: Don't recompute size estimate, try-delete bin first
-  auto blobs = DetermineSerializationParams(*value);
+  StashDescriptor blobs{fragment_ref.GetSerializationDescr()};
   size_t size = blobs.EstimatedSerializedSize();
   if (OccupiesWholePages(size)) {
     op_manager_->CancelPending(KeyRef(dbid, key));
   } else if (auto bin = bins_->Delete(dbid, key); bin) {
     op_manager_->CancelPending(*bin);
   }
-  value->SetStashPending(false);
+  fragment_ref.ClearStashPending();
 }
 
 TieredStats TieredStorage::GetStats() const {
@@ -641,17 +621,18 @@ size_t TieredStorage::ReclaimMemory(size_t goal) {
   return gained;
 }
 
-auto TieredStorage::ShouldStash(const PrimeValue& pv) const -> std::optional<StashDescriptor> {
+auto TieredStorage::ShouldStash(const tiering::FragmentRef& fragment_ref) const
+    -> std::optional<StashDescriptor> {
   // Check value state
-  if (pv.IsExternal() || pv.HasStashPending())
+  if (fragment_ref.IsOffloaded() || fragment_ref.HasStashPending())
     return nullopt;
 
   // For now, hash offloading is conditional
-  if (pv.ObjType() == OBJ_HASH && !config_.experimental_hash_offload)
+  if (fragment_ref.ObjType() == OBJ_HASH && !config_.experimental_hash_offload)
     return nullopt;
 
   // Estimate value size
-  StashDescriptor blobs = DetermineSerializationParams(pv);
+  StashDescriptor blobs{fragment_ref.GetSerializationDescr()};
   size_t estimated_size = blobs.EstimatedSerializedSize();
   if (estimated_size < config_.min_value_size)
     return nullopt;

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -30,9 +30,12 @@ struct Decoder;
 struct TieredStorageBase {
   // Min sizes of values taking up full page on their own
   const static size_t kMinOccupancySize = tiering::kPageSize / 2;
-  struct StashDescriptor {
-    std::variant<std::array<std::string_view, 2>, uint8_t*> blob;
-    CompactObj::ExternalRep rep;
+  struct StashDescriptor : public tiering::FragmentRef::SerializationDescr {
+    StashDescriptor() = default;
+
+    StashDescriptor(const tiering::FragmentRef::SerializationDescr& params)  // NOLINT
+        : tiering::FragmentRef::SerializationDescr(params) {
+    }
 
     size_t EstimatedSerializedSize() const;
     size_t Serialize(io::MutableBytes buffer) const;
@@ -78,7 +81,7 @@ class TieredStorage : public TieredStorageBase {
   }
 
   // Returns StashDescriptor if a value should be stashed.
-  std::optional<StashDescriptor> ShouldStash(const PrimeValue& pv) const;
+  std::optional<StashDescriptor> ShouldStash(const tiering::FragmentRef& fragment_ref) const;
 
   // Stash value, returns optional future for backpressure
   // if `provide_bp` is set and conditions are met.
@@ -88,8 +91,8 @@ class TieredStorage : public TieredStorageBase {
   // Delete value, must be offloaded (external type)
   void Delete(DbIndex dbid, PrimeValue* value);
 
-  // Cancel pending stash for value, must have IO_PENDING flag set
-  void CancelStash(DbIndex dbid, std::string_view key, PrimeValue* value);
+  // Cancel pending stash for the fragment, must have HasStashPending() true.
+  void CancelStash(DbIndex dbid, std::string_view key, tiering::FragmentRef fragment_ref);
 
   // Run offloading loop until i/o device is loaded or all entries were traversed
   void RunOffloading(DbIndex dbid);
@@ -126,7 +129,7 @@ class TieredStorage : public TieredStorageBase {
   PrimeValue DeleteCool(tiering::TieredColdRecord* record);
   tiering::TieredColdRecord* PopCool();
 
-  PrimeTable::Cursor offloading_cursor_{};  // where RunOffloading left off
+  PrimeTable::Cursor offloading_cursor_;  // where RunOffloading left off
 
   // Stash operations waiting for completion to throttle
   tiering::EntryMap<::util::fb2::Future<bool>> stash_backpressure_;
@@ -225,7 +228,7 @@ class TieredStorage : public TieredStorageBase {
     return {};
   }
 
-  std::optional<StashDescriptor> ShouldStash(const PrimeValue& pv) const {
+  std::optional<StashDescriptor> ShouldStash(const tiering::FragmentRef& fragment) const {
     return {};
   }
 
@@ -249,7 +252,7 @@ class TieredStorage : public TieredStorageBase {
     return 0;
   }
 
-  void CancelStash(DbIndex dbid, std::string_view key, PrimeValue* value) {
+  void CancelStash(DbIndex dbid, std::string_view key, tiering::FragmentRef fragment_ref) {
   }
 
   TieredStats GetStats() const {


### PR DESCRIPTION
FragmentRef is the primitive that wraps all the pieces we would potentially
offload to disk. Currently it hides PrimeValue object but in the future it will
also handle other blobs like listpacks from QList::Node or in streams.

## Changes
Move DetermineSerializationParams logic into a new FragmentRef class in
the tiering namespace. FragmentRef wraps a CompactValue* and exposes
IsOffloaded, HasStashPending, ClearStashPending, ObjType, and
GetSerializationDescr methods. StashDescriptor now inherits from
FragmentRef::SerializationDescr. CancelStash and ShouldStash updated to
accept FragmentRef instead of PrimeValue*.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>