### PR TITLE
ci: split build/unit-tests and regression-tests into separate jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,7 @@ jobs:
 
   lint-test-chart:
     runs-on: ubuntu-latest
-    needs: [build-unit, regression-tests]
+    needs: [build-unit]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/lint-test-chart


### PR DESCRIPTION
Split the monolithic 'build' job into:
- build-unit: builds and runs C++ unit tests on CI-LARGE-86 and CI-LARGE-ARM
- regression-tests: downloads built binary and runs pytest regression suite

The build-unit job uploads the dragonfly binary as an artifact for regression-eligible matrix legs (ubuntu-dev:20-gcc14, gcc, NoSanitizers). The regression-tests job downloads matching arch/build-type artifacts and runs .github/actions/regression-tests against them.

This separation allows independent scaling and faster feedback for unit vs regression failures.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
