### PR TITLE
refactor: deduplicate build steps into reusable composite action

### DIFF
--- a/.github/actions/builder/action.yml
+++ b/.github/actions/builder/action.yml
@@ -35,7 +35,12 @@ inputs:
   with-aws:
     description: "Build with AWS support"
     required: false
-    default: 'OFF'
+    default: 'ON'
+    type: string
+  targets:
+    description: "Build targets to compile"
+    required: false
+    default: 'src/all'
     type: string
 
 runs:
@@ -90,5 +95,5 @@ runs:
       shell: bash
       run: |
         cd ${GITHUB_WORKSPACE}/${{ inputs.build-dir }}
-        echo "Building target: src/all"
-        ninja src/all
+        echo "Building target: ${{ inputs.targets }}"
+        ninja ${{ inputs.targets }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
           cxx-compiler: ${{matrix.compiler.cxx}}
           cxx-flags: ${{matrix.cxx_flags}}
           sanitizers: ${{matrix.sanitizers}}
+          with-aws: 'OFF'
 
       - name: PostFail
         if: failure()
@@ -226,7 +227,7 @@ jobs:
         uses: ./.github/actions/builder
         with:
           build-type: Release
-          with-aws: 'ON'
+          targets: 'dragonfly'
 
       - name: Authenticate to AWS
         uses: aws-actions/configure-aws-credentials@v5

--- a/.github/workflows/epoll-regression-tests.yml
+++ b/.github/workflows/epoll-regression-tests.yml
@@ -44,7 +44,7 @@ jobs:
         uses: ./.github/actions/builder
         with:
           build-type: ${{matrix.build-type}}
-          with-aws: 'ON'
+          targets: 'dragonfly'
 
       - name: Authenticate to AWS
         uses: aws-actions/configure-aws-credentials@v5

--- a/.github/workflows/heavy-tests.yml
+++ b/.github/workflows/heavy-tests.yml
@@ -45,7 +45,7 @@ jobs:
         uses: ./.github/actions/builder
         with:
           build-type: ${{matrix.build-type}}
-          with-aws: 'ON'
+          targets: 'dragonfly'
 
       - name: Authenticate to AWS
         uses: aws-actions/configure-aws-credentials@v5

--- a/.github/workflows/ioloop-v2-regtests.yml
+++ b/.github/workflows/ioloop-v2-regtests.yml
@@ -43,7 +43,7 @@ jobs:
         uses: ./.github/actions/builder
         with:
           build-type: ${{matrix.build-type}}
-          with-aws: 'ON'
+          targets: 'dragonfly'
 
       - name: Authenticate to AWS
         uses: aws-actions/configure-aws-credentials@v5

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -45,7 +45,7 @@ jobs:
         uses: ./.github/actions/builder
         with:
           build-type: ${{matrix.build-type}}
-          with-aws: 'ON'
+          targets: 'dragonfly'
 
       - name: Authenticate to AWS
         uses: aws-actions/configure-aws-credentials@v5

--- a/.github/workflows/repeat-tests.yml
+++ b/.github/workflows/repeat-tests.yml
@@ -86,7 +86,7 @@ jobs:
         uses: ./.github/actions/builder
         with:
           build-type: ${{matrix.build-type}}
-          with-aws: 'ON'
+          targets: 'dragonfly'
 
       - name: Sync valkey tests
         uses: ./.github/actions/sync-valkey-tests


### PR DESCRIPTION
Create .github/actions/builder to eliminate duplicated CMake/Ninja commands across 7 workflow files, reducing 94 lines to 39.

Hardcoded options: GCP=OFF, unwind=OFF, gperf=OFF, stacktraces=ON. Removed ccache and simplified to single target (ninja src/all).

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
