### PR TITLE
feat: add pending keys to HNSW index during full sync phase

### DIFF
--- a/src/core/search/hnsw_index.cc
+++ b/src/core/search/hnsw_index.cc
@@ -560,6 +560,10 @@ void HnswVectorIndex::Remove(GlobalDocId id, const DocumentAccessor& doc, string
   adapter_->Remove(id);
 }
 
+void HnswVectorIndex::Remove(GlobalDocId id) {
+  adapter_->Remove(id);
+}
+
 HnswIndexMetadata HnswVectorIndex::GetMetadata() const {
   return adapter_->GetMetadata();
 }

--- a/src/core/search/hnsw_index.h
+++ b/src/core/search/hnsw_index.h
@@ -49,6 +49,7 @@ class HnswVectorIndex {
 
   bool Add(search::GlobalDocId id, const search::DocumentAccessor& doc, std::string_view field);
   void Remove(search::GlobalDocId id, const search::DocumentAccessor& doc, std::string_view field);
+  void Remove(search::GlobalDocId id);
 
   bool IsVectorCopied() const {
     return copy_vector_;

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -338,7 +338,15 @@ void ShardDocIndex::Rebuild(const OpArgs& op_args, PMR_NS::memory_resource* mr, 
   // the existing DocIds to add documents to the regular indices.
   if (!is_restored) {
     key_index_ = DocKeyIndex{};
+    // Full rebuild handles all documents — discard any buffered state from LOADING.
+    is_restoring_vectors_ = false;
+    pending_vector_updates_.clear();
+  } else {
+    // Restored path: VectorLoop will call RestoreGlobalVectorIndices which drains
+    // the buffers. Until then, buffer any journal-driven mutations.
+    is_restoring_vectors_ = true;
   }
+
   indices_.emplace(base_->schema, base_->options, mr, &synonyms_);
 
   // Create builder and start indexing
@@ -447,6 +455,13 @@ void ShardDocIndex::RemoveDoc(DocId id, const DbContext& db_cntx, const PrimeVal
 
 void ShardDocIndex::AddDocToGlobalVectorIndex(ShardDocIndex::DocId doc_id, const DbContext& db_cntx,
                                               PrimeValue* pv) {
+  if (is_restoring_vectors_) {
+    // Buffer the key — will be re-applied after RestoreGlobalVectorIndices completes.
+    std::string_view key = key_index_.Get(doc_id);
+    pending_vector_updates_.emplace(key);
+    return;
+  }
+
   auto accessor = GetAccessor(db_cntx, *pv);
   GlobalDocId global_id = search::CreateGlobalDocId(EngineShard::tlocal()->shard_id(), doc_id);
 
@@ -463,6 +478,13 @@ void ShardDocIndex::AddDocToGlobalVectorIndex(ShardDocIndex::DocId doc_id, const
 
 void ShardDocIndex::RemoveDocFromGlobalVectorIndex(ShardDocIndex::DocId doc_id,
                                                    const DbContext& db_cntx, const PrimeValue& pv) {
+  if (is_restoring_vectors_) {
+    // Buffer the key — will be re-applied after RestoreGlobalVectorIndices completes.
+    std::string_view key = key_index_.Get(doc_id);
+    pending_vector_updates_.emplace(key);
+    return;
+  }
+
   auto accessor = GetAccessor(db_cntx, pv);
   GlobalDocId global_id = search::CreateGlobalDocId(EngineShard::tlocal()->shard_id(), doc_id);
 
@@ -470,6 +492,16 @@ void ShardDocIndex::RemoveDocFromGlobalVectorIndex(ShardDocIndex::DocId doc_id,
     if (auto index = GlobalHnswIndexRegistry::Instance().Get(base_->name, field_info.short_name);
         index) {
       index->Remove(global_id, *accessor, field_ident);
+    }
+  }
+}
+
+void ShardDocIndex::RemoveFromAllHnswIndices(search::DocId doc_id) {
+  GlobalDocId global_id = search::CreateGlobalDocId(EngineShard::tlocal()->shard_id(), doc_id);
+  for (const auto& [field_ident, field_info] : GetIndexedHnswFields(base_->schema)) {
+    if (auto index = GlobalHnswIndexRegistry::Instance().Get(base_->name, field_info.short_name);
+        index) {
+      index->Remove(global_id);
     }
   }
 }
@@ -531,6 +563,44 @@ void ShardDocIndex::RestoreGlobalVectorIndices(std::string_view index_name, cons
   } else {
     VLOG(1) << "Restored vectors for index " << index_name << ": " << successful_updates << "/"
             << total_docs << " documents";
+  }
+
+  // Drain pending vector updates that arrived via journal during the LOADING window.
+  // Clear the flag BEFORE draining so that AddDoc/AddDocToGlobalVectorIndex work normally.
+  is_restoring_vectors_ = false;
+
+  if (!pending_vector_updates_.empty()) {
+    LOG(INFO) << "Draining " << pending_vector_updates_.size()
+              << " pending vector updates for index '" << index_name << "' on shard "
+              << EngineShard::tlocal()->shard_id();
+
+    for (const auto& key : pending_vector_updates_) {
+      auto local_id = key_index_.Find(key);
+      auto it = db_slice.FindMutable(op_args.db_cntx, key, base_->GetObjCode());
+
+      if (it && IsValid(it->it)) {
+        // Key exists in DB — ensure it's properly indexed with current data.
+        PrimeValue& pv = it->it->second;
+
+        if (local_id) {
+          // Already in key_index_ (from snapshot). Remove old HNSW node and re-add
+          // with current vector data to match master state.
+          RemoveFromAllHnswIndices(*local_id);
+          AddDocToGlobalVectorIndex(*local_id, op_args.db_cntx, &pv);
+        } else {
+          // New document not in key_index_ (added during full sync).
+          auto doc_id = AddDoc(key, op_args.db_cntx, pv);
+          if (doc_id) {
+            AddDocToGlobalVectorIndex(*doc_id, op_args.db_cntx, &pv);
+          }
+        }
+      } else if (local_id) {
+        // Key absent from DB — remove stale HNSW node and key_index_ entry.
+        RemoveFromAllHnswIndices(*local_id);
+        key_index_.Remove(*local_id);
+      }
+    }
+    pending_vector_updates_.clear();
   }
 }
 

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -377,6 +377,9 @@ class ShardDocIndex {
                                                     const SearchParams::SortOption& sort,
                                                     const OpArgs& op_args) const;
 
+  // Remove a DocId from all HNSW indices for this index.
+  void RemoveFromAllHnswIndices(search::DocId doc_id);
+
  private:
   std::shared_ptr<const DocIndex> base_;
   std::optional<search::FieldIndices> indices_;
@@ -384,6 +387,12 @@ class ShardDocIndex {
   Synonyms synonyms_;
 
   std::unique_ptr<search::IndexBuilder> builder_;
+
+  // Buffered state for journal events arriving while HNSW vector indices
+  // are being restored from serialized graph data (is_restoring_vectors_ == true).
+  // Drained by RestoreGlobalVectorIndices after the graph is fully restored.
+  absl::flat_hash_set<std::string> pending_vector_updates_;
+  bool is_restoring_vectors_ = false;
 };
 
 // Stores shard doc indices by name on a specific shard.

--- a/src/server/search/index_builder.cc
+++ b/src/server/search/index_builder.cc
@@ -99,6 +99,11 @@ void IndexBuilder::VectorLoop(dfly::DbTable* table, DbContext db_cntx) {
     return;
   }
 
+  // Non-restored path: rebuilding HNSW from scratch. Clear the restoring flag and discard
+  // any pending updates — the full table traversal below will pick up all current documents.
+  index_->is_restoring_vectors_ = false;
+  index_->pending_vector_updates_.clear();
+
   auto cb = [this, db_cntx, scratch = std::string{}](PrimeTable::iterator it) mutable {
     PrimeValue& pv = it->second;
     std::string_view key = it->first.GetSlice(&scratch);


### PR DESCRIPTION
feat: add pending keys to HNSW index during full sync phase
   
    During replication full sync, journal events (adds, updates, deletes) can
    arrive at the replica while HNSW vector indices are being restored from RDB.
    Without buffering, these mutations are lost, causing index inconsistency.
    
    This change introduces pending_vector_updates_ to buffer document keys that
    are modified during the LOADING window (while is_restoring_vectors_ is true).
    After RestoreGlobalVectorIndices completes, the buffer is drained:
    - For updated documents: Remove old HNSW node and add new one
    - For new documents: Add to both regular and vector indices
    - For deleted documents: Remove HNSW node and key_index_ entry
    
    The buffering prevents journal events from being lost and ensures HNSW
    graph consistency between master and replica after full sync completes.