### PR TITLE
fix(pipeline): fix missing SetDeferredReply bugs

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -2315,10 +2315,11 @@ bool Connection::ExecuteMCBatch() {
     // Enforce the pipeline invariant between the IO loop (producer) and AsyncFiber (consumer).
     // To prevent stream corruption, the command state must satisfy ONE of these rules:
     // 1. It is the head command (safely writes to the socket directly).
-    // 2. It executed asynchronously (dispatch_res is not WOULD_BLOCK) AND buffered its reply
-    // locally (is_deferred = true).
-    // 3. It stalled the pipeline (dispatch_res is WOULD_BLOCK) AND did NOT buffer a reply
-    //    (is_deferred = false).
+    // 2. It did not stall the pipeline (dispatch_res != WOULD_BLOCK) and therefore
+    //    must have buffered its reply locally (is_deferred == true).
+    // 3. It stalled the pipeline because it requires synchronous execution
+    //    (dispatch_res == WOULD_BLOCK) and therefore must NOT have buffered
+    //    a reply (is_deferred == false).
     bool is_deferred = cmd->IsDeferredReply();
     DCHECK(is_head || (is_deferred == (dispatch_res != DispatchResult::WOULD_BLOCK)))
         << "Pipeline contract breach! Invalid state for non-head command. "

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1485,6 +1485,10 @@ DispatchResult Service::DispatchCommand(facade::ParsedArgs args, facade::ParsedC
   DCHECK(!args.empty());
   DCHECK_NE(0u, shard_set->size()) << "Init was not called";
 
+  // We must resolve the command ID (cid) before the guard block.
+  // The following switch statement relies on the command's metadata
+  // (e.g., SupportsAsync()) to evaluate execution preferences,
+  // making this lookup a hard dependency for the logic below.
   string cmd = absl::AsciiStrToUpper(args.Front());
   const auto [cid, args_no_cmd] = registry_.FindExtended(cmd, args.Tail());
   if (cid == nullptr) {

--- a/tests/dragonfly/pymemcached_test.py
+++ b/tests/dragonfly/pymemcached_test.py
@@ -231,14 +231,17 @@ class TestMemcached:
             response += data
         client_sock.close()
 
-        # We expect: strict ordering: STORED -> VALUE -> CLIENT_ERROR
+        # Ensure strict ordering: STORED -> GETS (VALUE + END) -> CLIENT_ERROR
         idx_stored = response.find(b"STORED\r\n")
         idx_value = response.find(b"VALUE mykey")
         idx_error = response.find(b"CLIENT_ERROR bad command line format")
-        # Ensure all responses actually exist
-        assert idx_stored != -1 and idx_value != -1 and idx_error != -1
-        # Ensure they arrived in the exact correct order
-        assert idx_stored < idx_value < idx_error, f"Responses out of order: {response}"
+        # Look for the GETS terminator specifically AFTER the value
+        idx_end = response.find(b"END\r\n", idx_value)
+
+        assert idx_stored != -1 and idx_value != -1 and idx_error != -1 and idx_end != -1
+        assert (
+            idx_stored < idx_value < idx_end < idx_error
+        ), f"Responses out of order/interleaved: {response}"
 
         # Final sanity check to ensure the connection/server is still healthy
         assert memcached_client.set("sanity_check", "alive")


### PR DESCRIPTION
Fix two pipeline synchronization bugs where early command validation errors were written synchronously to the socket out-of-order, corrupting the stream.

* First bug (fuzzer found): The default block in DispatchMC lacked SetDeferredReply() for unsupported commands like CAS.

* Second bug: The cid == nullptr check in DispatchCommand for unknown commands lacked SetDeferredReply().

Also:
* Enforced the async pipeline invariant by adding a DCHECK in ExecuteMCBatch to catch non-head commands that fail to buffer replies or stall.

* Added a regression test in pymemcached_test.py to verify that pipelined errors are correctly buffered.
