### PR TITLE
ci(fuzz): switch AFL++ compiler from afl-clang-lto to afl-clang-fast

### DIFF
--- a/.github/actions/fuzzing/action.yml
+++ b/.github/actions/fuzzing/action.yml
@@ -50,9 +50,9 @@ runs:
         afl-fuzz -h | head -5 || true
 
         # Verify AFL++ compilers are available
-        which afl-clang-lto
-        which afl-clang-lto++
-        afl-clang-lto --version
+        which afl-clang-fast
+        which afl-clang-fast++
+        afl-clang-fast --version
 
     - name: Configure system for fuzzing
       shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,8 @@ option(USE_AFL "Enable AFL++ fuzzing" OFF)
 if(USE_AFL)
   # Automatically set AFL++ compilers if not already set
   if(NOT CMAKE_C_COMPILER MATCHES "afl-" AND NOT CMAKE_CXX_COMPILER MATCHES "afl-")
-    # Try to find afl-clang-fast
-    find_program(AFL_CC afl-clang-lto)
-    find_program(AFL_CXX afl-clang-lto++)
+    find_program(AFL_CC afl-clang-fast)
+    find_program(AFL_CXX afl-clang-fast++)
 
     if(AFL_CC AND AFL_CXX)
       message(STATUS "AFL++ fuzzing enabled - setting compilers")


### PR DESCRIPTION
Switch the AFL++ fuzzing build from `afl-clang-lto` to `afl-clang-fast`.

LTO instrumentation changes code layout and inlining decisions relative to a regular debug build, causing crashes found by the fuzzer to not reproduce during triage (false positives). `afl-clang-fast` produces a binary closer to the standard debug build, making crashes reliably reproducible.
