### PR TITLE
chore: remove shard_cnt/EXPIRED arguments in journal

### DIFF
--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -542,8 +542,7 @@ void WriteFlushSlotsToJournal(const SlotRanges& slot_ranges) {
 
     // Send journal entry
     // TODO: Break slot migration upon FLUSHSLOTS
-    journal::RecordEntry(/* txid= */ 0, journal::Op::COMMAND, /* dbid= */ 0,
-                         /* shard_cnt= */ shard_set->size(), nullopt,
+    journal::RecordEntry(/* txid= */ 0, journal::Op::COMMAND, /* dbid= */ 0, nullopt,
                          Payload("DFLYCLUSTER", args_view));
   };
   shard_set->pool()->AwaitFiberOnAll(std::move(cb));

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -88,7 +88,7 @@ bool WaitReplicaFlowToCatchup(absl::Time end_time, const DflyCmd::ReplicaInfo* r
     // PING forces replica to send the most recent last_acked_lsn.
     // ACKS from the replica are send only every X commands or every 3 seconds (flag configurable)
     // or when forced (by the PING above).
-    journal::RecordEntry(0, journal::Op::PING, 0, 0, nullopt, {});
+    journal::RecordEntry(0, journal::Op::PING, 0, nullopt, {});
   }
 
   const FlowInfo* flow = &replica->flows[shard->shard_id()];

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -764,11 +764,6 @@ uint64_t ScanGeneric(uint64_t cursor, const ScanOpts& scan_opts, StringVec* keys
   return cursor;
 }
 
-void RecordDelete(DbIndex dbid, string_view key) {
-  journal::RecordEntry(0, journal::Op::COMMAND, dbid, 1, KeySlot(key),
-                       journal::Entry::Payload("DEL", ArgSlice{key}));
-}
-
 void OpScanAndDelete(const OpArgs& op_args, const ScanOpts& scan_opts, uint64_t* cursor,
                      uint32_t* deleted) {
   StringVec keys;

--- a/src/server/journal/cmd_serializer.cc
+++ b/src/server/journal/cmd_serializer.cc
@@ -162,7 +162,6 @@ void CmdSerializer::SerializeCommand(string_view cmd, absl::Span<const string_vi
   journal::Entry entry(0,                     // txid
                        journal::Op::COMMAND,  // single command
                        0,                     // db index
-                       1,                     // shard count
                        0,                     // slot-id, but it is ignored at this level
                        journal::Entry::Payload(cmd, ArgSlice(args)));
 

--- a/src/server/journal/journal.cc
+++ b/src/server/journal/journal.cc
@@ -71,9 +71,9 @@ LSN GetLsn() {
   return journal_slice.cur_lsn();
 }
 
-void RecordEntry(TxId txid, Op opcode, DbIndex dbid, unsigned shard_cnt, std::optional<SlotId> slot,
+void RecordEntry(TxId txid, Op opcode, DbIndex dbid, std::optional<SlotId> slot,
                  Entry::Payload payload) {
-  journal_slice.AddLogRecord(Entry{txid, opcode, dbid, shard_cnt, slot, std::move(payload)});
+  journal_slice.AddLogRecord(Entry{txid, opcode, dbid, slot, std::move(payload)});
 }
 
 void SetFlushMode(bool allow_flush) {

--- a/src/server/journal/journal.h
+++ b/src/server/journal/journal.h
@@ -30,7 +30,7 @@ LSN GetLsn();
 uint32_t RegisterConsumer(JournalConsumerInterface* consumer);
 void UnregisterConsumer(uint32_t id);
 
-void RecordEntry(TxId txid, Op opcode, DbIndex dbid, unsigned shard_cnt, std::optional<SlotId> slot,
+void RecordEntry(TxId txid, Op opcode, DbIndex dbid, std::optional<SlotId> slot,
                  Entry::Payload payload);
 
 size_t LsnBufferSize();

--- a/src/server/journal/journal_test.cc
+++ b/src/server/journal/journal_test.cc
@@ -97,13 +97,13 @@ TEST(Journal, WriteRead) {
   using Payload = Entry::Payload;
 
   std::vector<Entry> test_entries = {
-      {0, Op::COMMAND, 0, 2, nullopt, Payload("MSET", slice("A", "1", "B", "2"))},
-      {0, Op::COMMAND, 0, 2, nullopt, Payload("MSET", slice("C", "3"))},
-      {1, Op::COMMAND, 0, 2, nullopt, Payload("DEL", list("A", "B"))},
-      {2, Op::COMMAND, 1, 1, nullopt, Payload("LPUSH", list("l", "v1", "v2"))},
-      {3, Op::COMMAND, 0, 1, nullopt, Payload("MSET", slice("D", "4"))},
-      {4, Op::COMMAND, 1, 1, nullopt, Payload("DEL", list("l1"))},
-      {5, Op::COMMAND, 2, 1, nullopt, Payload("DEL", list("E", "2"))}};
+      {0, Op::COMMAND, 0, nullopt, Payload("MSET", slice("A", "1", "B", "2"))},
+      {0, Op::COMMAND, 0, nullopt, Payload("MSET", slice("C", "3"))},
+      {1, Op::COMMAND, 0, nullopt, Payload("DEL", list("A", "B"))},
+      {2, Op::COMMAND, 1, nullopt, Payload("LPUSH", list("l", "v1", "v2"))},
+      {3, Op::COMMAND, 0, nullopt, Payload("MSET", slice("D", "4"))},
+      {4, Op::COMMAND, 1, nullopt, Payload("DEL", list("l1"))},
+      {5, Op::COMMAND, 2, nullopt, Payload("DEL", list("E", "2"))}};
 
   // Write all entries to a buffer.
   base::IoBuf buf;

--- a/src/server/journal/serializer.cc
+++ b/src/server/journal/serializer.cc
@@ -75,12 +75,12 @@ void JournalWriter::Write(const journal::Entry& entry) {
     case journal::Op::PING:
       return;
     case journal::Op::COMMAND:
-    case journal::Op::EXPIRED:
       Write(entry.txid);
-      Write(entry.shard_cnt);
+      Write(1u);  // deprecated field, kept for backward compatibility.
       Write(entry.payload);
       break;
     default:
+      LOG(FATAL) << "Unknown journal opcode: " << static_cast<int>(entry.opcode);
       break;
   };
 }
@@ -226,7 +226,9 @@ std::error_code JournalReader::ReadEntry(journal::ParsedEntry* dest) {
   }
 
   SET_OR_RETURN(ReadUInt<uint64_t>(), dest->txid);
-  SET_OR_RETURN(ReadUInt<uint32_t>(), dest->shard_cnt);
+  [[maybe_unused]] uint32_t unused;
+
+  SET_OR_RETURN(ReadUInt<uint32_t>(), unused);
 
   VLOG(1) << "Read entry " << dest->ToString();
 

--- a/src/server/journal/types.h
+++ b/src/server/journal/types.h
@@ -14,14 +14,12 @@
 namespace dfly {
 namespace journal {
 
-enum class Op : uint8_t { SELECT = 6, EXPIRED = 9, COMMAND = 10, PING = 13, LSN = 15 };
+enum class Op : uint8_t { SELECT = 6, EXPIRED = 9 /* sunset*/, COMMAND = 10, PING = 13, LSN = 15 };
 
 struct EntryBase {
   TxId txid;
   Op opcode;
   DbIndex dbid;
-  uint32_t shard_cnt;  // This field is no longer used by the replica, but we continue to serialize
-                       // and deserialize it to maintain backward compatibility.
   std::optional<SlotId> slot;
   LSN lsn{0};
 };
@@ -44,21 +42,19 @@ struct Entry : public EntryBase {
     }
   };
 
-  Entry(TxId txid, Op opcode, DbIndex dbid, uint32_t shard_cnt, std::optional<SlotId> slot_id,
-        Payload pl)
-      : EntryBase{txid, opcode, dbid, shard_cnt, slot_id}, payload{pl} {
+  Entry(TxId txid, Op opcode, DbIndex dbid, std::optional<SlotId> slot_id, Payload pl)
+      : EntryBase{txid, opcode, dbid, slot_id}, payload{std::move(pl)} {
   }
 
   Entry(journal::Op opcode, DbIndex dbid, std::optional<SlotId> slot_id)
-      : EntryBase{0, opcode, dbid, 0, slot_id, 0} {
+      : EntryBase{0, opcode, dbid, slot_id, 0} {
   }
 
-  Entry(journal::Op opcode, LSN lsn) : EntryBase{0, opcode, 0, 0, std::nullopt, lsn} {
+  Entry(journal::Op opcode, LSN lsn) : EntryBase{0, opcode, 0, std::nullopt, lsn} {
   }
 
-  Entry(TxId txid, journal::Op opcode, DbIndex dbid, uint32_t shard_cnt,
-        std::optional<SlotId> slot_id)
-      : EntryBase{txid, opcode, dbid, shard_cnt, slot_id, 0} {
+  Entry(TxId txid, journal::Op opcode, DbIndex dbid, std::optional<SlotId> slot_id)
+      : EntryBase{txid, opcode, dbid, slot_id, 0} {
   }
 
   bool HasPayload() const {

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -1028,7 +1028,7 @@ void DflyShardReplica::StableSyncDflyReadFb(ExecutionState* cntx) {
       if (EngineShard::tlocal() && EngineShard::tlocal()->journal()) {
         // We must register this entry to the journal to allow partial sync
         // if journal is active.
-        journal::RecordEntry(0, journal::Op::PING, 0, 0, nullopt, {});
+        journal::RecordEntry(0, journal::Op::PING, 0, nullopt, {});
       }
     } else {
       const bool is_successful = ExecuteTx(std::move(tx_data), cntx);

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1572,11 +1572,11 @@ void Transaction::LogAutoJournalOnShard(EngineShard* shard, RunnableResult resul
   }
   // Record to journal autojournal commands, here we allow await which anables writing to sync
   // the journal change.
-  LogJournalOnShard(std::move(entry_payload), unique_shard_cnt_);
+  LogJournalOnShard(std::move(entry_payload));
 }
 
-void Transaction::LogJournalOnShard(journal::Entry::Payload&& payload, uint32_t shard_cnt) const {
-  journal::RecordEntry(txid_, journal::Op::COMMAND, db_index_, shard_cnt,
+void Transaction::LogJournalOnShard(journal::Entry::Payload&& payload) const {
+  journal::RecordEntry(txid_, journal::Op::COMMAND, db_index_,
                        unique_slot_checker_.GetUniqueSlotId(), std::move(payload));
 }
 

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -348,7 +348,7 @@ class Transaction {
   std::string DebugId(std::optional<ShardId> sid = std::nullopt) const;
 
   // Write a journal entry to a shard journal with the given payload.
-  void LogJournalOnShard(journal::Entry::Payload&& payload, uint32_t shard_cnt) const;
+  void LogJournalOnShard(journal::Entry::Payload&& payload) const;
 
   // Re-enable auto journal for commands marked as NO_AUTOJOURNAL. Call during setup.
   void ReviveAutoJournal();

--- a/src/server/tx_base.cc
+++ b/src/server/tx_base.cc
@@ -52,23 +52,21 @@ size_t ShardArgs::Size() const {
   return sz;
 }
 
-void RecordJournal(const OpArgs& op_args, string_view cmd, const ShardArgs& args,
-                   uint32_t shard_cnt) {
+void RecordJournal(const OpArgs& op_args, string_view cmd, const ShardArgs& args, uint32_t unused) {
   DCHECK(op_args.tx);
   VLOG(2) << "Logging command " << cmd << " from txn " << op_args.tx->txid();
-  op_args.tx->LogJournalOnShard(Payload(cmd, args), shard_cnt);
+  op_args.tx->LogJournalOnShard(Payload(cmd, args));
 }
 
 void RecordJournal(const OpArgs& op_args, std::string_view cmd, facade::ArgSlice args,
-                   uint32_t shard_cnt) {
+                   uint32_t unused) {
   DCHECK(op_args.tx);
   VLOG(2) << "Logging command " << cmd << " from txn " << op_args.tx->txid();
-  op_args.tx->LogJournalOnShard(Payload(cmd, args), shard_cnt);
+  op_args.tx->LogJournalOnShard(Payload(cmd, args));
 }
 
-void RecordExpiryBlocking(DbIndex dbid, string_view key) {
-  journal::RecordEntry(0, journal::Op::EXPIRED, dbid, 1, KeySlot(key),
-                       Payload("DEL", ArgSlice{key}));
+void RecordDelete(DbIndex dbid, string_view key) {
+  journal::RecordEntry(0, journal::Op::COMMAND, dbid, KeySlot(key), Payload("DEL", ArgSlice{key}));
 }
 
 LockTag::LockTag(std::string_view key) {

--- a/src/server/tx_base.h
+++ b/src/server/tx_base.h
@@ -207,13 +207,16 @@ class ShardArgs {
 
 // Record non auto journal command with own txid and dbid.
 void RecordJournal(const OpArgs& op_args, std::string_view cmd, const ShardArgs& args,
-                   uint32_t shard_cnt = 1);
-void RecordJournal(const OpArgs& op_args, std::string_view cmd, ArgSlice args,
-                   uint32_t shard_cnt = 1);
+                   uint32_t unused = 1);
+void RecordJournal(const OpArgs& op_args, std::string_view cmd, ArgSlice args, uint32_t unused = 1);
+
+void RecordDelete(DbIndex dbid, std::string_view key);
 
 // Record expiry in journal with independent transaction.
 // Must be called from shard thread owning key.
 // Might block the calling fiber unless journal::SetFlushMode(false) is called.
-void RecordExpiryBlocking(DbIndex dbid, std::string_view key);
+inline void RecordExpiryBlocking(DbIndex dbid, std::string_view key) {
+  RecordDelete(dbid, key);
+}
 
 }  // namespace dfly


### PR DESCRIPTION
1. shard_cnt is not being used on replica side, so we just keep the wire format intact but remove the argument.
2. EXPIRED is handled exactly like COMMAND, so we sunset EXPIRED argument and pass the COMMAND opcode.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
