### PR TITLE
doc(serialization): expand shard serialization design with tiered analysis and roadmap

### DIFF
--- a/docs/shard-serialization.md
+++ b/docs/shard-serialization.md
@@ -672,10 +672,10 @@ See Roadmap items 3, 5, 6.
 ### 3. Shared serializer buffer and wire-format coupling
 
 **Problem.** `ConsumeJournalChange` and `SerializeBucket` write to the same `serializer_`
-buffer (the "buffer exclusivity" role from [§2](#2-shard-wide-stall-under-big_value_mu_)).
+buffer (the "buffer exclusivity" role from [§1](#1-shard-wide-stall-under-big_value_mu_)).
 Even with separate buffers, interleaved output from two serializers cannot be demuxed by the
 consumer without a framing protocol — a journal entry injected mid-RDB-entry produces an
-unparseable byte stream (see the [eviction counter-example](#2-shard-wide-stall-under-big_value_mu_)
+unparseable byte stream (see the [eviction counter-example](#1-shard-wide-stall-under-big_value_mu_)
 for a concrete scenario).
 
 **Goal.** Decouple journal and bucket serialization so they can produce data independently,


### PR DESCRIPTION
## Summary

- Restructure "Open Questions" (3 sections) into "Inefficiencies and
  Improvement Goals" (5 sections) with problem/goal/approach structure
- Add analysis of journal entries that bypass `OnDbChange` (expiry,
  eviction, control signals) and tiered delayed serialization semantics
- Add phased technical roadmap (Phases 0–4, items 1–17) for
  incremental `big_value_mu_` decoupling and removal

## Changes

- Define self-contained vs baseline-dependent journal entry terminology
- Add "Journal Entries Without `OnDbChange`" section with bypass-path
  table and deferred deletion queue proposal
- Add counter-example: byte-stream corruption from inline eviction
  without `ConsumeJournalChange` mutex
- Add "Delayed Serialization of tiered entities" section with
  `RestoreStreamer` note and two notions of bucket completion
- Clarify `CVCUponInsert` non-usage in non-PIT mode
- Restructure improvement goals into 5 sections:
  §1 bucket completion tracking, §2 shard-wide stall,
  §3 shared serializer buffer, §4 non-PIT journal traffic,
  §5 mutex-role-to-replacement summary table
- Add 17-item technical roadmap across 5 phases
- Update flowchart with expiry/eviction path
- Document `OnDbChange` blocking latency tradeoff and large-value
  lock-release stability (bucket versioning + `OnDbChange` blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)