### PR TITLE
doc(serialization): document ordering invariants in code comments

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1364,6 +1364,13 @@ uint64_t DbSlice::RegisterOnMove(MovedCallback cb) {
   return next_moved_id_;
 }
 
+// Ordering invariant (PIT mode):
+//   When the traversal fiber visits a bucket in BucketSaveCb, earlier-registered snapshots
+//   (those with snapshot_version_ < this snapshot's version) may not have serialized this bucket
+//   yet. FlushChangeToEarlierCallbacks invokes their OnDbChange callbacks so they serialize the
+//   bucket before the current snapshot stamps it with its own version. Without this, an earlier
+//   snapshot could miss the bucket entirely — its traversal already passed it, and the version
+//   stamp from the current snapshot would cause the earlier snapshot's OnDbChange to skip it.
 void DbSlice::FlushChangeToEarlierCallbacks(DbIndex db_ind, Iterator it, uint64_t upper_bound) {
   unique_lock<LocalLatch> lk(serialization_latch_);
 

--- a/src/server/journal/streamer.cc
+++ b/src/server/journal/streamer.cc
@@ -663,6 +663,11 @@ bool RestoreStreamer::WriteBucket(PrimeTable::bucket_iterator it, const ExpireTa
   return written;
 }
 
+// Ordering invariant (PIT mode, slot migration):
+//   Same as SliceSnapshot::OnDbChange — for any key K the baseline must be sent before any
+//   journal entry that mutates K. RestoreStreamer always uses PIT mode (snapshot_version_ != 0)
+//   and serializes-before-mutate via CVCUponInsert (inserts) or WriteBucket (updates).
+//   big_value_mu_ prevents interleaving with the traversal fiber's WriteBucket.
 void RestoreStreamer::OnDbChange(DbIndex db_index, const DbSlice::ChangeReq& req) {
   std::lock_guard guard(big_value_mu_);
   DCHECK_EQ(db_index, 0) << "Restore migration only allowed in cluster mode in db0";

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -327,7 +327,8 @@ void SliceSnapshot::IterateBucketsFb(bool send_full_sync_cut) {
   // serialized + side_saved must be equal to the total saved.
   VLOG(1) << "Exit SnapshotSerializer loop_serialized: " << stats_.loop_serialized
           << ", side_saved " << stats_.side_saved << ", cbcalls " << stats_.savecb_calls
-          << ", journal_saved " << stats_.jounal_changes << ", moved_saved " << stats_.moved_saved;
+          << ", journal_saved " << stats_.jounal_changes << ", moved_saved " << stats_.moved_saved
+          << ", flushed_under_lock " << stats_.flushed_under_lock;
 }
 
 bool SliceSnapshot::BucketSaveCb(DbIndex db_index, PrimeTable::bucket_iterator it) {
@@ -413,6 +414,9 @@ void SliceSnapshot::HandleFlushData(std::string data) {
   if (data.empty())
     return;
 
+  if (big_value_mu_.is_locked()) {
+    ++stats_.flushed_under_lock;
+  }
   size_t serialized = data.size();
   uint64_t id = rec_id_++;
 
@@ -523,11 +527,22 @@ void SliceSnapshot::SerializeExternal(DbIndex db_index, PrimeKey key, const Prim
   ++type_freq_map_[RDB_TYPE_STRING];
 }
 
+// Ordering invariant (both modes):
+//   For any key K, the replica must receive K's baseline value strictly before any journal entry
+//   that mutates K. This is required for baseline-dependent journal entries (e.g., HSET, LPUSH)
+//   which cannot be replayed without the prior value.
+//
+// PIT mode: enforced by serialize-before-mutate. OnDbChange serializes the bucket before the
+//   mutation commits; ConsumeJournalChange runs after the mutation on the same fiber, so the
+//   baseline is always first. big_value_mu_ prevents interleaving with the traversal fiber's
+//   SerializeBucket (which can preempt via consume_fun_).
+//
+// Non-PIT mode: OnDbChange only acquires big_value_mu_ as a barrier — no serialization. The
+//   mutex prevents journaling mutations from slipping in the middle of bucket serialization
+//   on the traversal fiber — see ConsumeJournalChange for details. OnMoved handles items
+//   displaced across the traversal cursor.
 void SliceSnapshot::OnDbChange(DbIndex db_index, const DbSlice::ChangeReq& req) {
   std::lock_guard guard(big_value_mu_);
-  // Only when creating point in time snapshot we need to serialize the bucket before we change the
-  // db entry. When creating no point in time snapshot we need to call OnDbChange which will take
-  // the big_value_mu_ to make sure we do not mutate the bucket while serializing it.
   if (use_snapshot_version_) {
     PrimeTable* table = db_slice_->GetTables(db_index).first;
     const PrimeTable::bucket_iterator* bit = req.update();
@@ -573,13 +588,26 @@ void SliceSnapshot::OnMoved(DbIndex id, const DbSlice::MovedItemsVec& items) {
   }
 }
 
-// For any key any journal entry must arrive at the replica strictly after its first original rdb
-// value. This is guaranteed because journal change callbacks run after OnDbChange, and no
-// database switch can be performed between those two calls, as they are part of one transaction.
+// big_value_mu_ prevents expiry/eviction DEL journal entries from interleaving with an
+// in-progress SaveEntry for a large value. SaveEntry may yield mid-entry (emitting chunks
+// across multiple scheduler turns); expiry paths emit DEL via RecordDelete directly,
+// bypassing OnDbChange. Without the lock, such a DEL could be written between two chunks
+// of the same entry, producing an invalid wire format for the downstream consumer.
+//
+// Note: even if the protocol were extended to support interleaved chunks, the lock would
+// still be required semantically: a DEL journal entry must not be applied on the replica
+// while the entry's baseline is still being loaded. The delayed deletion queue proposal
+// in the design doc addresses this without a shard-wide lock.
+//
+// Note: for transaction-driven mutations, baseline-before-journal ordering is already
+// guaranteed by call order on the mutation fiber (OnDbChange precedes ConsumeJournalChange);
+// big_value_mu_ is not needed for that ordering.
 void SliceSnapshot::ConsumeJournalChange(const journal::JournalChangeItem& item) {
-  // We grab the lock in case we are in the middle of serializing a bucket, so it serves as a
-  // barrier here for atomic serialization.
   std::lock_guard barrier(big_value_mu_);
+
+  // remove when we support interleaving chunks.
+  LOG_IF(DFATAL, serialize_bucket_running_)
+      << "Internal error: can not run interleave journal and bucket serialization";
   std::ignore = serializer_->WriteJournalEntry(item.journal_item.data);
   ++stats_.jounal_changes;
 }

--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -191,6 +191,7 @@ class SliceSnapshot : public journal::JournalConsumerInterface {
     size_t keys_total = 0;
     size_t jounal_changes = 0;
     size_t moved_saved = 0;
+    size_t flushed_under_lock = 0;
   } stats_;
 
   ThreadLocalMutex big_value_mu_;

--- a/src/server/synchronization.h
+++ b/src/server/synchronization.h
@@ -19,6 +19,9 @@ class ABSL_LOCKABLE ThreadLocalMutex {
 
   void lock() ABSL_EXCLUSIVE_LOCK_FUNCTION();
   void unlock() ABSL_UNLOCK_FUNCTION();
+  bool is_locked() const {
+    return flag_;
+  }
 
  private:
   EngineShard* shard_;


### PR DESCRIPTION
## Summary
- Document the baseline-before-journal ordering invariant at all enforcement points (`SliceSnapshot::OnDbChange`, `ConsumeJournalChange`, `RestoreStreamer::OnDbChange`, `FlushChangeToEarlierCallbacks`)
- Add runtime guard (`LOG_IF(DFATAL)`) to detect journal/bucket-serialization interleaving
- Add `ThreadLocalMutex::is_locked()` helper and `flushed_under_lock` stat counter

## Test plan
- [x] Verified that `ConsumeJournalChange` locking is covered by `test_replication_all` tests (lock removal fails them)
- [x] Verified that `OnDbChange` ordering is covered by the replication tests (lock removal fails many tests)

Fixes #6828 and #6829.

🤖 Generated with [Claude Code](https://claude.com/claude-code)