### PR TITLE
chore: Set HNSW label with setExternalLabel

### DIFF
--- a/src/core/search/hnsw_alg.h
+++ b/src/core/search/hnsw_alg.h
@@ -206,10 +206,6 @@ template <typename dist_t> class HierarchicalNSW : public hnswlib::AlgorithmInte
            sizeof(labeltype));
   }
 
-  inline labeltype* getExternalLabeLp(tableint internal_id) const {
-    return (labeltype*)(data_level0_memory_ + internal_id * size_data_per_element_ + label_offset_);
-  }
-
   inline char* getDataPtrByInternalId(tableint internal_id) const {
     return (data_level0_memory_ + internal_id * size_data_per_element_ + offsetData_);
   }
@@ -1269,7 +1265,7 @@ template <typename dist_t> class HierarchicalNSW : public hnswlib::AlgorithmInte
     }
 
     // Initialisation of the data and label
-    memcpy(getExternalLabeLp(cur_c), &label, sizeof(labeltype));
+    setExternalLabel(cur_c, label);
 
     if (copy_vector_) {
       memcpy(getDataByInternalId(cur_c), data_point_in, data_size_);


### PR DESCRIPTION
Using getExternalLabeLp can return misaligned address when accessed.
Instead use SetExternalLabel.

Closes #6813

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
