### PR TITLE
chore: Fix clang compilation issues for ZSetFamily structs

### DIFF
--- a/src/server/zset_family.h
+++ b/src/server/zset_family.h
@@ -32,6 +32,9 @@ class ZSetFamily {
   struct Bound {
     double val;
     bool is_open = false;
+    Bound() = default;
+    Bound(double v, bool open) : val(v), is_open(open) {
+    }
   };
 
   using ScoreInterval = std::pair<Bound, Bound>;
@@ -39,6 +42,9 @@ class ZSetFamily {
   struct LexBound {
     std::string_view val;
     enum Type : uint8_t { PLUS_INF, MINUS_INF, OPEN, CLOSED } type = CLOSED;
+    LexBound() = default;
+    LexBound(std::string_view v, Type t) : val(v), type(t) {
+    }
   };
 
   using LexInterval = std::pair<LexBound, LexBound>;


### PR DESCRIPTION
Add constructor and copy constructor for Lex and LexBound. Compilation with clang 18 fails because of these missing.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
