### PR TITLE
fix(tiering): fix flaky op_manager_test by waiting for cancelled stash IOs

### DIFF
--- a/src/server/tiering/op_manager_test.cc
+++ b/src/server/tiering/op_manager_test.cc
@@ -90,7 +90,11 @@ struct OpManagerTest : PoolTestBase, OpManager {
   }
 
   void WaitForPendingStashes() {
-    while (GetStats().pending_stash_cnt > 0)
+    // Wait for both: pending_stash_cnt tracks entries awaiting version-matching IO completion,
+    // but cancelled stash IOs (version-mismatched, superseded by newer stashes for the same id)
+    // may still be in flight. Their callbacks free the allocated segments via MarkAsFree,
+    // so we must also wait for pending_ops to drain to ensure allocated_bytes is accurate.
+    while (GetStats().pending_stash_cnt > 0 || GetStats().disk_stats.pending_ops > 0)
       util::ThisFiber::SleepFor(1ms);
   }
 


### PR DESCRIPTION
## Summary
- Fix sporadic `SimpleStashesWithReads` failure where `allocated_bytes` was one page (4096 bytes) higher than expected
- `WaitForPendingStashes` now also waits for `pending_ops` to drain, ensuring cancelled stash IO callbacks (which free segments via `MarkAsFree`) complete before assertions check `allocated_bytes`

## Details
When multiple stashes are submitted for the same id, only the latest version is kept. The superseded stash IOs complete asynchronously and free their segments in the callback. The previous wait condition only checked `pending_stash_cnt` (version-matching completions), so cancelled IO callbacks could still be in flight when `allocated_bytes` was asserted.

Failed CI run: https://github.com/dragonflydb/dragonfly/actions/runs/22869010155/job/66343536677?pr=6845#step:9:20953

## Test plan
- [x] `op_manager_test` passes all 5 tests
- [x] `SimpleStashesWithReads` passes 10/10 consecutive runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)