### PR TITLE
chore(server): Optimize coroutine code

### DIFF
--- a/src/facade/parsed_command.cc
+++ b/src/facade/parsed_command.cc
@@ -138,15 +138,15 @@ void ParsedCommand::SendReply() {
     return CapturingReplyBuilder::Apply(std::move(std::get<payload::Payload>(reply_)), rb_);
 
   // Otherwise handle responder of async task
-  dfly::Overloaded ov{[this](ReplyFunc& f) { f(rb_); },
-                      [](std::coroutine_handle<> h) { h.resume(); }};
-  std::visit(ov, std::get<AsyncTask>(reply_).replier);
+  std::get<AsyncTask>(reply_).Reply(rb_);
 }
 
 ParsedCommand::AsyncTask::~AsyncTask() {
   // We must destroy the unfinished coroutine to free resources
-  if (std::holds_alternative<std::coroutine_handle<>>(replier))
-    std::get<std::coroutine_handle<>>(replier).destroy();
+  if (std::holds_alternative<std::coroutine_handle<>>(replier)) {
+    auto h = std::get<std::coroutine_handle<>>(replier);
+    h.destroy();
+  }
   replier = {};
 }
 
@@ -155,8 +155,7 @@ void ParsedCommand::AsyncTask::Reply(facade::SinkReplyBuilder* rb) {
     DCHECK(h.done()) << "Only one suspension point is supported";
     h.resume();
   };
-  dfly::Overloaded ov{[rb](ReplyFunc& f) { f(rb); }, coro_cb};
-  std::visit(ov, replier);
+  std::visit(dfly::Overloaded{[rb](ReplyFunc& f) { f(rb); }, coro_cb}, replier);
   replier = {};  // reset replier after its done
 }
 

--- a/src/facade/parsed_command.cc
+++ b/src/facade/parsed_command.cc
@@ -4,12 +4,16 @@
 
 #include "facade/parsed_command.h"
 
+#include <coroutine>
+#include <variant>
+
 #include "base/logging.h"
 #include "core/overloaded.h"
 #include "facade/conn_context.h"
 #include "facade/dragonfly_connection.h"
 #include "facade/reply_builder.h"
 #include "facade/reply_capture.h"
+#include "facade/reply_payload.h"
 
 namespace facade {
 
@@ -129,10 +133,31 @@ bool ParsedCommand::CanReply() const {
 }
 
 void ParsedCommand::SendReply() {
-  dfly::Overloaded ov{
-      [this](payload::Payload& pl) { CapturingReplyBuilder::Apply(std::move(pl), rb_); },
-      [this](AsyncTask& task) { return task.replier(rb_); }};
-  return std::visit(ov, reply_);
+  // If the reply is stored, consume it
+  if (std::holds_alternative<payload::Payload>(reply_))
+    return CapturingReplyBuilder::Apply(std::move(std::get<payload::Payload>(reply_)), rb_);
+
+  // Otherwise handle responder of async task
+  dfly::Overloaded ov{[this](ReplyFunc& f) { f(rb_); },
+                      [](std::coroutine_handle<> h) { h.resume(); }};
+  std::visit(ov, std::get<AsyncTask>(reply_).replier);
+}
+
+ParsedCommand::AsyncTask::~AsyncTask() {
+  // We must destroy the unfinished coroutine to free resources
+  if (std::holds_alternative<std::coroutine_handle<>>(replier))
+    std::get<std::coroutine_handle<>>(replier).destroy();
+  replier = {};
+}
+
+void ParsedCommand::AsyncTask::Reply(facade::SinkReplyBuilder* rb) {
+  auto coro_cb = [](std::coroutine_handle<> h) {
+    DCHECK(h.done()) << "Only one suspension point is supported";
+    h.resume();
+  };
+  dfly::Overloaded ov{[rb](ReplyFunc& f) { f(rb); }, coro_cb};
+  std::visit(ov, replier);
+  replier = {};  // reset replier after its done
 }
 
 }  // namespace facade

--- a/src/facade/parsed_command.h
+++ b/src/facade/parsed_command.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <coroutine>
 #include <variant>
 
 #include "base/function2.hpp"
@@ -161,7 +162,11 @@ class ParsedCommand : public cmn::BackedArguments {
 
   // Resolve deferred command with async task
   void Resolve(util::fb2::EmbeddedBlockingCounter* blocker, ReplyFunc replier) {
-    reply_ = AsyncTask{blocker, std::move(replier)};
+    reply_ = AsyncTask(blocker, std::move(replier));
+  }
+
+  void Resolve(util::fb2::EmbeddedBlockingCounter* blocker, std::coroutine_handle<> coro) {
+    reply_ = AsyncTask(blocker, coro);
   }
 
  protected:
@@ -169,9 +174,19 @@ class ParsedCommand : public cmn::BackedArguments {
 
  private:
   // Pending async command. Once blocker is ready, replier can be called
+  // TOOD: Use only typed coroutine handle to access blocker through promise directly
   struct AsyncTask {
+    AsyncTask(util::fb2::EmbeddedBlockingCounter* blocker, auto replier)
+        : blocker{blocker}, replier{std::move(replier)} {
+    }
+    AsyncTask(AsyncTask&&) = default;
+    AsyncTask& operator=(AsyncTask&&) = default;
+
+    ~AsyncTask();
+    void Reply(facade::SinkReplyBuilder*);
+
     util::fb2::EmbeddedBlockingCounter* blocker;
-    ReplyFunc replier;
+    std::variant<ReplyFunc, std::coroutine_handle<>> replier;
   };
 
   // if false then the reply was sent directly to reply builder,
@@ -182,7 +197,7 @@ class ParsedCommand : public cmn::BackedArguments {
 };
 
 #ifdef __linux__
-static_assert(sizeof(ParsedCommand) == 232);
+static_assert(sizeof(ParsedCommand) == 240);
 #endif
 
 }  // namespace facade

--- a/src/server/cmd_support.h
+++ b/src/server/cmd_support.h
@@ -175,14 +175,18 @@ struct CmdR::Coro {
 
   // Custom new operator to avoid allocating coroutines if stack space is available and enough
   static void* operator new(std::size_t size, facade::CmdArgList /*unused*/, CommandContext* cntx) {
-    if (size <= CommandContext::kReservedStack && cntx->reseved_stack)
-      return cntx->reseved_stack;
-    return std::malloc(size);
+    // Allocate one byte more to store in last byte whether stack is local (1) or heap allocated (2)
+    bool local = size + 1 <= CommandContext::kReservedStack && cntx->reseved_stack;
+    void* ptr = local ? cntx->reseved_stack : std::malloc(size + 1);
+    static_cast<char*>(ptr)[size] = local ? 1u : 2u;
+    return ptr;
   }
 
+  // See operator new() above
   static void operator delete(void* ptr, std::size_t size) {
-    auto* promise = reinterpret_cast<promise_type*>(ptr);
-    if (size > CommandContext::kReservedStack || promise->cmd_cntx->reseved_stack == nullptr)
+    char type = static_cast<char*>(ptr)[size];
+    DCHECK(type == 1 || type == 2) << int(type);  // zero means it was not tagged
+    if (type == 2)
       std::free(ptr);
   }
 

--- a/src/server/cmd_support.h
+++ b/src/server/cmd_support.h
@@ -10,6 +10,7 @@
 #include <variant>
 
 #include "facade/error.h"
+#include "facade/facade_types.h"
 #include "facade/op_status.h"
 #include "server/conn_context.h"
 #include "server/engine_shard.h"
@@ -172,6 +173,19 @@ struct CmdR::Coro {
     return SingleHopWaiterT<RT>{cmd_cntx, callback};
   }
 
+  // Custom new operator to avoid allocating coroutines if stack space is available and enough
+  static void* operator new(std::size_t size, facade::CmdArgList /*unused*/, CommandContext* cntx) {
+    if (size <= CommandContext::kReservedStack && cntx->reseved_stack)
+      return cntx->reseved_stack;
+    return std::malloc(size);
+  }
+
+  static void operator delete(void* ptr, std::size_t size) {
+    auto* promise = reinterpret_cast<promise_type*>(ptr);
+    if (size > CommandContext::kReservedStack || promise->cmd_cntx->reseved_stack == nullptr)
+      std::free(ptr);
+  }
+
   // Return error
   void return_value(const facade::ErrorReply& err) const noexcept;
 
@@ -194,5 +208,19 @@ struct CmdR::Coro {
 
   CommandContext* cmd_cntx;
 };
+
+// Wrap coroutine call into a void-returning functor that also enable coroutine allocation
+// optimization by using the stack for synchronous calls
+inline auto Wrap(auto f) {
+  return [f](ArgSlice args, CommandContext* cntx) {
+    if (cntx->IsDeferredReply()) {
+      f(args, cntx);
+    } else {
+      std::byte stack_space[CommandContext::kReservedStack];
+      cntx->reseved_stack = stack_space;
+      f(args, cntx);
+    }
+  };
+}
 
 }  // namespace dfly::cmd

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -301,6 +301,7 @@ void CommandContext::ReuseInternal() {
   tx_ = nullptr;
   arg_slice_backing.clear();
   start_time_ns = 0;
+  reseved_stack = nullptr;
 }
 
 void CommandContext::RecordLatency(facade::ArgSlice tail_args) const {

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -418,6 +418,12 @@ class CommandContext : public facade::ParsedCommand {
   // Stores backing array for tail args slice
   CmdArgVec arg_slice_backing;
 
+  // Fixed size of reserved stack if not nullptr
+  static constexpr size_t kReservedStack = 256;
+
+  // Pointer to reserved stack buffer that can be used to avoid coroutine allocatio
+  std::byte* reseved_stack = nullptr;
+
  protected:
   void ReuseInternal() final;
 


### PR DESCRIPTION
1. Optimize double indirection by waking up directly std::coroutine_handle from the connection loop
2. Allow avoiding allocations by using a 256 byte buffer for synchronous dispatches