### PR TITLE
fix(cluster): Validate slot IDs in DFLYCLUSTER FLUSHSLOTS to prevent out-of-bounds crash

### DIFF
--- a/src/server/cluster/cluster_defs.h
+++ b/src/server/cluster/cluster_defs.h
@@ -10,10 +10,14 @@
 #include <string_view>
 #include <vector>
 
+#include "facade/cmd_arg_parser.h"
 #include "facade/facade_types.h"
 #include "server/cluster_support.h"
 
 namespace dfly::cluster {
+
+// A SlotId validated to be within [0, kMaxSlotNum], usable directly with CmdArgParser::Next().
+using ParsedSlotId = facade::FInt<SlotId{0}, SlotId{kMaxSlotNum}>;
 
 struct SlotRange {
   static constexpr SlotId kMaxSlotId = 0x3FFF;

--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -730,11 +730,13 @@ void ClusterFamily::DflyClusterFlushSlots(CmdArgList args, CommandContext* cmd_c
 
   CmdArgParser parser(args);
   do {
-    auto [slot_start, slot_end] = parser.Next<SlotId, SlotId>();
+    auto [slot_start, slot_end] = parser.Next<ParsedSlotId, ParsedSlotId>();
+    RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
+    if (slot_start > slot_end) {
+      return cmd_cntx->SendError("Invalid slot range");
+    }
     slot_ranges.emplace_back(SlotRange{slot_start, slot_end});
   } while (parser.HasNext());
-
-  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   DeleteSlots(SlotRanges(std::move(slot_ranges)));
 

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -818,6 +818,15 @@ TEST_F(ClusterFamilyTest, FlushSlots) {
                                                   _, "total_writes", _, "memory_bytes", _)))));
 }
 
+TEST_F(ClusterFamilyTest, FlushSlotsOutOfBounds) {
+  EXPECT_THAT(RunPrivileged({"dflycluster", "flushslots", "0", "16384"}),
+              ErrArg("value is not an integer or out of range"));
+  EXPECT_THAT(RunPrivileged({"dflycluster", "flushslots", "16384", "16384"}),
+              ErrArg("value is not an integer or out of range"));
+  EXPECT_THAT(RunPrivileged({"dflycluster", "flushslots", "100", "50"}),
+              ErrArg("Invalid slot range"));
+}
+
 TEST_F(ClusterFamilyTest, FlushSlotsAndImmediatelySetValue) {
   for (int count : {1, 10, 100, 1000, 10000, 100000}) {
     ConfigSingleNodeCluster(GetMyId());


### PR DESCRIPTION
- `DFLYCLUSTER FLUSHSLOTS` did not validate that slot IDs are within the valid range [0, 16383]
- Passing `end=16384` caused `SlotSet::Set()` to call `std::bitset<16384>::set(16384)`, which throws `std::out_of_range` and crashes the server
- Added bounds check

Fixes: #6856
