### PR TITLE
chore: another way to track per object memory

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -73,8 +73,6 @@ void AccountObjectMemory(string_view key, unsigned type, int64_t size, DbTable* 
     return;
 
   DbTableStats& stats = db->stats;
-  DCHECK_GE(static_cast<int64_t>(stats.obj_memory_usage) + size, 0)
-      << "Can't decrease " << size << " from " << stats.obj_memory_usage;
 
   stats.AddTypeMemoryUsage(type, size);
 
@@ -146,27 +144,44 @@ bool PrimeEvictionPolicy::CanGrow(const PrimeTable& tbl) const {
     return true;
 
   DCHECK_LE(tbl.size(), tbl.capacity());
+  DCHECK_GT(tbl.size(), 0u);
 
   // We take a conservative stance here -
   // we estimate how much memory we will take with the current capacity
   // even though we may currently use less memory.
   // see https://github.com/dragonflydb/dragonfly/issues/256#issuecomment-1227095503
-  size_t table_free_items = ((tbl.capacity() - tbl.size()) + PrimeTable::kSegCapacity) *
-                            GetFlag(FLAGS_table_growth_margin);
+  size_t table_free_items = ((tbl.capacity() - tbl.size()) + PrimeTable::kSegCapacity);
 
-  size_t obj_bytes_estimation = db_slice_->bytes_per_object() * table_free_items;
-  bool res = mem_available > int64_t(PrimeTable::kSegBytes + obj_bytes_estimation);
-  if (res) {
-    VLOG(1) << "free_items: " << table_free_items
-            << ", obj_bytes: " << db_slice_->bytes_per_object() << " "
+  size_t obj_memory_usage = db_slice_->GetDBTable(cntx_.db_index)->stats.obj_memory_usage;
+  size_t avg_obj_size = obj_memory_usage / tbl.size();
+
+  // Catch significant discrepancies in average object size estimation.
+  // Note that this may happen if for example, db0 hosts a lot of small keys,
+  // db1 hosts huge keys etc. The goal of this comparison is to detect these cases and
+  // confirm that discrepancy is justified. Once we gather empirical evidence,
+  // we can remove this check and drop `db_slice_->bytes_per_object()` computation entirely.
+  if (avg_obj_size * 20 < db_slice_->bytes_per_object() ||
+      avg_obj_size > db_slice_->bytes_per_object() * 20) {
+    LOG_EVERY_T(WARNING, 1) << "Avg object size estimation for the table is " << avg_obj_size
+                            << " vs "
+                            << " overall object size estimation " << db_slice_->bytes_per_object();
+  }
+  size_t obj_bytes_estimation =
+      (avg_obj_size * table_free_items) * GetFlag(FLAGS_table_growth_margin);
+
+  bool can_grow = mem_available > int64_t(PrimeTable::kSegBytes + obj_bytes_estimation);
+  if (can_grow) {
+    VLOG(1) << "free_items: " << table_free_items << ", obj_bytes: " << avg_obj_size << " vs "
+            << db_slice_->bytes_per_object() << " "
             << " mem_available: " << mem_available;
   } else {
     LOG_EVERY_T(INFO, 1) << "Can't grow, free_items " << table_free_items
-                         << ", obj_bytes: " << db_slice_->bytes_per_object() << " "
+                         << ", obj_bytes: " << avg_obj_size << " vs "
+                         << db_slice_->bytes_per_object() << " "
                          << " mem_available: " << mem_available;
   }
 
-  return res;
+  return can_grow;
 }
 
 unsigned PrimeEvictionPolicy::GarbageCollect(const PrimeTable::HotBuckets& eb, PrimeTable* me) {

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -1242,12 +1242,14 @@ void DebugCmd::Shards(CommandContext* cmd_cntx) {
     uint64_t prime_capacity = 0;
     uint64_t expire_count = 0;
     uint64_t key_reads = 0;
+    size_t avg_object_size = 0;
   };
 
   vector<ShardInfo> infos(shard_set->size());
   shard_set->RunBriefInParallel([&](EngineShard* shard) {
     auto sid = shard->shard_id();
-    auto slice_stats = cntx_->ns->GetDbSlice(sid).GetStats();
+    auto& db_slice = cntx_->ns->GetDbSlice(sid);
+    auto slice_stats = db_slice.GetStats();
     auto& stats = infos[sid];
 
     stats.used_memory = shard->UsedMemory();
@@ -1256,6 +1258,7 @@ void DebugCmd::Shards(CommandContext* cmd_cntx) {
       stats.prime_capacity += db_stats.prime_capacity;
       stats.expire_count += db_stats.expire_count;
     }
+    stats.avg_object_size = db_slice.bytes_per_object();
     stats.key_reads = slice_stats.events.hits + slice_stats.events.misses;
   });
 
@@ -1280,9 +1283,11 @@ void DebugCmd::Shards(CommandContext* cmd_cntx) {
     ADD_STAT(i, key_count);
     ADD_STAT(i, expire_count);
     ADD_STAT(i, key_reads);
+
     absl::StrAppend(&out, "shard", i,
                     "_prime_utilization: ", double(infos[i].key_count) / infos[i].prime_capacity,
                     "\n");
+    absl::StrAppend(&out, "shard", i, "_avg_object_size: ", infos[i].avg_object_size, "\n");
   }
 
   MAXMIN_STAT(used_memory);

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -1024,6 +1024,9 @@ void EngineShard::CacheStats() {
   size_t obj_memory = table_memory <= used_mem ? used_mem - table_memory : 0;
   size_t bytes_per_obj = entries > 0 ? obj_memory / entries : 0;
 
+  VLOG_EVERY_N(1, 500) << "Entries count " << entries << " "
+                       << "obj_memory: " << obj_memory << ", bytes_per_obj: " << bytes_per_obj;
+
   db_slice.UpdateMemoryParams(free_mem / shard_set->size(), bytes_per_obj);
   last_mem_params_ = {now, used_mem};
 }

--- a/src/server/table.cc
+++ b/src/server/table.cc
@@ -19,11 +19,21 @@ unsigned kInitSegmentLog = 3;
 
 void DbTableStats::AddTypeMemoryUsage(unsigned type, int64_t delta) {
   if (type >= memory_usage_by_type.size()) {
-    LOG_FIRST_N(WARNING, 1) << "Encountered unknown type when aggregating per-type memory: "
-                            << type;
-    DCHECK(false) << "Unsupported type " << type;
+    LOG(DFATAL) << "Encountered unknown type when aggregating per-type memory: " << type;
     return;
   }
+
+  DCHECK_GE(obj_memory_usage, memory_usage_by_type[type]);
+
+  if (delta < 0 && memory_usage_by_type[type] < size_t(-delta)) {
+    LOG_EVERY_T(ERROR, 1) << "Encountered underflow memory usage when aggregating per-type memory: "
+                          << obj_memory_usage << " + " << delta << ", type: " << type;
+
+    // Truncate delta to avoid underflow, but keep the memory usage consistent with the sum of
+    // per-type usage.
+    delta = -static_cast<int64_t>(memory_usage_by_type[type]);
+  }
+
   obj_memory_usage += delta;
   memory_usage_by_type[type] += delta;
 }


### PR DESCRIPTION
Before: we estimated average object size by using global metrics like used_memory and table memory

Now as we have rather precise computation of object memory per db table, switch to use those stats.
Add warnings if both metrics have huge discrepancies (which may happen).

Signed-off-by: Roman Gershman <roman@dragonflydb.io>

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
