### PR TITLE
fix(regtests): Make Python 3.9 available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,7 @@ jobs:
 
       - name: Authenticate to AWS
         uses: aws-actions/configure-aws-credentials@v5
+        continue-on-error: true
         with:
           role-to-assume: ${{ secrets.AWS_CI_S3_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/epoll-regression-tests.yml
+++ b/.github/workflows/epoll-regression-tests.yml
@@ -39,6 +39,7 @@ jobs:
           cat /proc/cpuinfo
           ulimit -a
           env
+          python3 -V
 
       - name: Build Dragonfly
         uses: ./.github/actions/builder

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -40,6 +40,7 @@ jobs:
           ulimit -a
           env
           lsblk -l
+          python3 -V
 
       - name: Build Dragonfly
         uses: ./.github/actions/builder


### PR DESCRIPTION
Needs https://github.com/romange/container-foundry/pull/30 to update the container and have a more recent python version out of the box (3.10)