### PR TITLE
[WIP] feat(server): Snapshot decision point to send tagged chunks

### DIFF
--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -77,6 +77,9 @@ bool SliceSnapshot::IsSnaphotInProgress() {
 void SliceSnapshot::Start(bool stream_journal, SnapshotFlush allow_flush) {
   DCHECK(!snapshot_fb_.IsJoinable());
 
+  // gate on stream_journal to make sure RDB save path does not send tagged chunks
+  send_tagged_chunks_ = stream_journal && replica_dfly_version_ >= DflyVersion::VER7;
+
   auto db_cb = [this](DbIndex db_index, const DbSlice::ChangeReq& req) {
     OnDbChange(db_index, req);
   };

--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -190,6 +190,7 @@ class SliceSnapshot : public journal::JournalConsumerInterface {
   bool use_background_mode_ = false;
   bool use_snapshot_version_ = true;
   DflyVersion replica_dfly_version_ = DflyVersion::CURRENT_VER;
+  bool send_tagged_chunks_ = false;
 
   uint64_t rec_id_ = 1, last_pushed_id_ = 0;
 

--- a/src/server/version.h
+++ b/src/server/version.h
@@ -42,8 +42,10 @@ enum class DflyVersion {
   // - hnsw-index-metadata AUX field
   VER6,
 
+  // Sends tagged chunks to replicas to differentiate between journal and baseline data.
+  VER7,
   // Always points to the latest version
-  CURRENT_VER = VER6,
+  CURRENT_VER = VER7,
 };
 
 }  // namespace dfly


### PR DESCRIPTION
As part of https://github.com/dragonflydb/dragonfly/issues/6831

Snapshot decides whether to send or not tagged chunks https://github.com/dragonflydb/dragonfly/pull/6886

The decision is made on two points:

* version >= 7 (new version)
* snapshot is not writing to file (`stream_journal` is false)

The flag is set but not used yet. 