### PR TITLE
chore: add CMS type in CompactObject and AclFamily

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -24,6 +24,7 @@ extern "C" {
 #include "base/logging.h"
 #include "base/pod_array.h"
 #include "core/bloom.h"
+#include "core/cms.h"
 #include "core/detail/bitpacking.h"
 #include "core/huff_coder.h"
 #include "core/page_usage/page_usage_stats.h"
@@ -818,6 +819,10 @@ CompactObjType CompactObj::ObjType() const {
     return OBJ_SBF;
   }
 
+  if (taglen_ == CMS_TAG) {
+    return OBJ_CMS;
+  }
+
   LOG(FATAL) << "TBD " << int(taglen_);
   return kInvalidCompactObjType;
 }
@@ -934,6 +939,20 @@ void CompactObj::SetSBF(uint64_t initial_capacity, double fp_prob, double grow_f
 SBF* CompactObj::GetSBF() const {
   DCHECK_EQ(SBF_TAG, taglen_);
   return u_.sbf;
+}
+
+void CompactObj::SetCMS(uint32_t width, uint32_t depth) {
+  if (taglen_ == CMS_TAG) {
+    *u_.cms = CMS(width, depth, tl.local_mr);
+  } else {
+    SetMeta(CMS_TAG);
+    u_.cms = AllocateMR<CMS>(width, depth, tl.local_mr);
+  }
+}
+
+CMS* CompactObj::GetCMS() const {
+  DCHECK_EQ(CMS_TAG, taglen_);
+  return u_.cms;
 }
 
 void CompactObj::SetString(std::string_view str) {
@@ -1053,14 +1072,15 @@ bool CompactObj::HasAllocated() const {
       (taglen_ == ROBJ_TAG && u_.r_obj.inner_obj() == nullptr))
     return false;
 
-  DCHECK(taglen_ == ROBJ_TAG || taglen_ == SMALL_TAG || taglen_ == JSON_TAG || taglen_ == SBF_TAG);
+  DCHECK(taglen_ == ROBJ_TAG || taglen_ == SMALL_TAG || taglen_ == JSON_TAG || taglen_ == SBF_TAG ||
+         taglen_ == CMS_TAG);
   return true;
 }
 
 bool CompactObj::TagAllowsEmptyValue() const {
   const auto type = ObjType();
   return type == OBJ_JSON || type == OBJ_STREAM || type == OBJ_STRING || type == OBJ_SBF ||
-         type == OBJ_SET;
+         type == OBJ_CMS || type == OBJ_SET;
 }
 
 void __attribute__((noinline)) CompactObj::GetString(string* res) const {
@@ -1350,6 +1370,8 @@ void CompactObj::Free() {
     }
   } else if (taglen_ == SBF_TAG) {
     DeleteMR<SBF>(u_.sbf);
+  } else if (taglen_ == CMS_TAG) {
+    DeleteMR<CMS>(u_.cms);
   } else {
     LOG(FATAL) << "Unsupported tag " << int(taglen_);
   }
@@ -1381,6 +1403,10 @@ size_t CompactObj::MallocUsed(bool slow) const {
 
   if (taglen_ == SBF_TAG) {
     return u_.sbf->MallocUsed();
+  }
+
+  if (taglen_ == CMS_TAG) {
+    return u_.cms->MallocUsed();
   }
   LOG(DFATAL) << "should not reach";
   return 0;
@@ -1678,12 +1704,11 @@ bool CompactObj::JsonWrapper::DefragIfNeeded(PageUsage* page_usage) {
   return flat.DefragIfNeeded(page_usage);
 }
 
-constexpr std::pair<CompactObjType, std::string_view> kObjTypeToString[] =
-    {
-        {OBJ_STRING, "string"sv},  {OBJ_LIST, "list"sv},    {OBJ_SET, "set"sv},
-        {OBJ_ZSET, "zset"sv},      {OBJ_HASH, "hash"sv},    {OBJ_STREAM, "stream"sv},
-        {OBJ_KEY, "key"sv},  // pseudo-type used for memory tracking
-        {OBJ_JSON, "ReJSON-RL"sv}, {OBJ_SBF, "MBbloom--"sv}};
+constexpr std::pair<CompactObjType, std::string_view> kObjTypeToString[] = {
+    {OBJ_STRING, "string"sv},  {OBJ_LIST, "list"sv},     {OBJ_SET, "set"sv},
+    {OBJ_ZSET, "zset"sv},      {OBJ_HASH, "hash"sv},     {OBJ_STREAM, "stream"sv},
+    {OBJ_KEY, "key"sv},  // pseudo-type used for memory tracking
+    {OBJ_JSON, "ReJSON-RL"sv}, {OBJ_SBF, "MBbloom--"sv}, {OBJ_CMS, "CMSk-TYPE"sv}};
 
 std::string_view ObjTypeToString(CompactObjType type) {
   for (auto& p : kObjTypeToString) {

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -31,6 +31,7 @@ constexpr unsigned kEncodingJsonCons = 0;
 constexpr unsigned kEncodingJsonFlat = 1;
 
 class SBF;
+class CMS;
 class PageUsage;
 
 using cmn::StringOrView;
@@ -125,6 +126,7 @@ class CompactObj {
     EXTERNAL_TAG = 20,
     JSON_TAG = 21,
     SBF_TAG = 22,
+    CMS_TAG = 23,
   };
 
   // String encoding types.
@@ -309,6 +311,14 @@ class CompactObj {
 
   void SetSBF(uint64_t initial_capacity, double fp_prob, double grow_factor);
   SBF* GetSBF() const;
+
+  void SetCMS(CMS* cms) {
+    SetMeta(CMS_TAG);
+    u_.cms = cms;
+  }
+
+  void SetCMS(uint32_t width, uint32_t depth);
+  CMS* GetCMS() const;
 
   // dest must have at least Size() bytes available
   void GetString(char* dest) const;
@@ -498,6 +508,7 @@ class CompactObj {
     // using 'packed' to reduce alignement of U to 1.
     JsonWrapper json_obj __attribute__((packed));
     SBF* sbf __attribute__((packed));
+    CMS* cms __attribute__((packed));
     int64_t ival __attribute__((packed));
     ExternalPtr ext_ptr;
 

--- a/src/redis/redis_aux.h
+++ b/src/redis/redis_aux.h
@@ -8,12 +8,13 @@
  * this will add enough place for Redis types to grow */
 #define OBJ_JSON 15U
 #define OBJ_SBF  16U
+#define OBJ_CMS  17U
 
 // A pseudo type for keys stored in the db, same as OBJ_MODULE which is not used in Dragonfly.
 #define OBJ_KEY  5U
 
 /* How many types of objects exist */
-#define OBJ_TYPE_MAX 17U
+#define OBJ_TYPE_MAX 18U
 
 #define CONFIG_RUN_ID_SIZE 40U
 

--- a/src/server/acl/acl_commands_def.h
+++ b/src/server/acl/acl_commands_def.h
@@ -44,6 +44,7 @@ enum AclCat {
   SCRIPTING = 1ULL << 20,
 
   // Extensions
+  CMS = 1ULL << 27,
   BLOOM = 1ULL << 28,
   FT_SEARCH = 1ULL << 29,
   THROTTLE = 1ULL << 30,

--- a/src/server/acl/acl_family.h
+++ b/src/server/acl/acl_family.h
@@ -129,6 +129,7 @@ class AclFamily final {
                                       {"CONNECTION", CONNECTION},
                                       {"TRANSACTION", TRANSACTION},
                                       {"SCRIPTING", SCRIPTING},
+                                      // Uncomment when CMS family is added {"CMS", CMS},
                                       {"BLOOM", BLOOM},
                                       {"FT_SEARCH", FT_SEARCH},
                                       {"SEARCH", FT_SEARCH},  // Alias for FT_SEARCH


### PR DESCRIPTION
No added functionality. Add CMS type support in `CompactObject` and `AclFamily`.


Split from #6882
Part 1/3