### PR TITLE
chore: update pytests for more modern redis-py client

### DIFF
--- a/tests/dragonfly/acl_family_test.py
+++ b/tests/dragonfly/acl_family_test.py
@@ -733,7 +733,7 @@ async def test_acl_revoke_pub_sub_while_subscribed(df_factory):
     subscribe_task = asyncio.create_task(subscribe_worker(subscriber_obj))
     await publisher.execute_command("ACL SETUSER kostas resetchannels")
     await publish_worker(publisher)
-    with pytest.raises(redis.exceptions.ConnectionError):
+    with pytest.raises((redis.exceptions.ConnectionError, redis.exceptions.NoPermissionError)):
         await subscribe_task
 
 

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -13,6 +13,7 @@ from .utility import *
 from .replication_test import check_all_replicas_finished
 from redis.cluster import RedisCluster
 from redis.cluster import ClusterNode
+from redis.exceptions import MovedError
 from .proxy import Proxy
 from .seeder import Seeder, SeederBase, DebugPopulateSeeder
 
@@ -256,7 +257,9 @@ class TestEmulated:
 
     def test_cluster_help_command(self, cluster_client: redis.RedisCluster):
         # `target_nodes` is necessary because CLUSTER HELP is not mapped on redis-py
-        res = cluster_client.execute_command("CLUSTER HELP", target_nodes=redis.RedisCluster.RANDOM)
+        res = cluster_client.execute_command(
+            "CLUSTER", "HELP", target_nodes=redis.RedisCluster.RANDOM
+        )
         assert "HELP" in res
         assert "SLOTS" in res
 
@@ -677,10 +680,10 @@ async def test_cluster_slot_ownership_changes(df_factory: DflyInstanceFactory):
     assert (await c_nodes[0].get("KEY0")) == "value"
 
     # Make sure that "KEY1" is not owned by node1
-    with pytest.raises(redis.exceptions.ResponseError) as e:
+    with pytest.raises((MovedError, aioredis.ResponseError)) as e:
         await c_nodes[1].set("KEY1", "value")
 
-    assert e.value.args[0] == f"MOVED 5259 localhost:{nodes[0].port}"
+    assert e.value.args[0].endswith(f"5259 localhost:{nodes[0].port}")
 
     # And that node1 only has 1 key ("KEY2")
     assert await c_nodes[1].execute_command("DBSIZE") == 1
@@ -705,10 +708,10 @@ async def test_cluster_slot_ownership_changes(df_factory: DflyInstanceFactory):
     assert await c_nodes[1].execute_command("DBSIZE") == 1
 
     # Now node0 should reply with MOVED for "KEY1"
-    with pytest.raises(redis.exceptions.ResponseError) as e:
+    with pytest.raises((MovedError, aioredis.ResponseError)) as e:
         await c_nodes[0].set("KEY1", "value")
 
-    assert e.value.args[0] == f"MOVED 5259 localhost:{nodes[1].port}"
+    assert e.value.args[0].endswith(f"5259 localhost:{nodes[1].port}")
 
     # And node1 should own it and allow using it
     assert await c_nodes[1].set("KEY1", "value")
@@ -836,11 +839,11 @@ async def test_cluster_replica_sets_non_owned_keys(df_factory: DflyInstanceFacto
         assert await c_replica.execute_command("dbsize") == 2
 
         # The replica should still reply with MOVED, despite having that key.
-        with pytest.raises(redis.exceptions.ResponseError) as e:
+        with pytest.raises((MovedError, aioredis.ResponseError)) as e:
             await c_replica.get("key2")
             assert False, "Should not be able to get key on non-owner cluster node"
 
-        assert re.match(r"MOVED \d+ localhost:1111", e.value.args[0])
+        assert re.search(r"\d+ localhost:1111", e.value.args[0])
 
         await push_config(replica_config, [c_master_admin])
         await check_all_replicas_finished([c_replica], c_master)
@@ -3059,10 +3062,10 @@ async def test_cluster_sharded_pub_sub(df_factory: DflyInstanceFactory):
 
     await push_config(json.dumps(generate_config(nodes_info)), [node.client for node in nodes_info])
     # channel name kostas crc is at slot 2883 which is part of the first node.
-    with pytest.raises(redis.exceptions.ResponseError) as moved_error:
+    with pytest.raises((MovedError, aioredis.ResponseError)) as moved_error:
         await c_nodes[1].execute_command("SSUBSCRIBE kostas")
 
-    assert str(moved_error.value) == f"MOVED 2833 127.0.0.1:{nodes[0].port}"
+    assert str(moved_error.value).endswith(f"2833 127.0.0.1:{nodes[0].port}")
 
     node_a = ClusterNode("localhost", nodes[0].port)
     node_b = ClusterNode("localhost", nodes[1].port)
@@ -3213,10 +3216,10 @@ async def test_cluster_sharded_pub_sub_migration(df_factory: DflyInstanceFactory
     await push_config(json.dumps(generate_config(nodes)), [node.client for node in nodes])
 
     # channel name kostas crc is at slot 2883 which is part of the second now.
-    with pytest.raises(redis.exceptions.ResponseError) as moved_error:
+    with pytest.raises((MovedError, aioredis.ResponseError)) as moved_error:
         await c_nodes[0].execute_command("SSUBSCRIBE kostas")
 
-    assert str(moved_error.value) == f"MOVED 2833 127.0.0.1:{instances[1].port}"
+    assert str(moved_error.value).endswith(f"2833 127.0.0.1:{instances[1].port}")
 
     # Consume subscription message result from above
     message = consumer.get_sharded_message(target_node=node_a)
@@ -3272,15 +3275,15 @@ async def test_readonly_replication(
         json.dumps(generate_config(master_nodes)), [node.admin_client for node in nodes]
     )
 
-    with pytest.raises(redis.exceptions.ResponseError) as moved_error:
+    with pytest.raises((MovedError, aioredis.ResponseError)) as moved_error:
         await r1_node.client.execute_command("GET X")
 
-    assert str(moved_error.value) == f"MOVED 7165 127.0.0.1:{instances[0].port}"
+    assert str(moved_error.value).endswith(f"7165 127.0.0.1:{instances[0].port}")
 
-    with pytest.raises(redis.exceptions.ResponseError) as moved_error:
+    with pytest.raises((MovedError, aioredis.ResponseError)) as moved_error:
         await r1_node.client.execute_command("GET Y")
 
-    assert str(moved_error.value) == f"MOVED 3036 127.0.0.1:{instances[0].port}"
+    assert str(moved_error.value).endswith(f"3036 127.0.0.1:{instances[0].port}")
 
 
 @dfly_args({"proactor_threads": 2, "cluster_mode": "yes"})
@@ -3421,15 +3424,15 @@ async def test_replica_takeover_moved(
     assert await r1.client.execute_command("GET X") == "1"
     assert await r1.client.execute_command("REPLTAKEOVER 20") == "OK"
 
-    with pytest.raises(redis.exceptions.ResponseError) as moved_error:
+    with pytest.raises((MovedError, aioredis.ResponseError)) as moved_error:
         await m1.client.execute_command("GET X")
 
-    assert str(moved_error.value) == f"MOVED 7165 127.0.0.1:{r1.instance.port}"
+    assert str(moved_error.value).endswith(f"7165 127.0.0.1:{r1.instance.port}")
 
-    with pytest.raises(redis.exceptions.ResponseError) as moved_error:
+    with pytest.raises((MovedError, aioredis.ResponseError)) as moved_error:
         await m1.client.execute_command("GET FOOX")
 
-    assert str(moved_error.value) == f"MOVED 16022 127.0.0.1:{m2.instance.port}"
+    assert str(moved_error.value).endswith(f"16022 127.0.0.1:{m2.instance.port}")
 
     # Try write command on the new master. It should succeed because during takeover,
     # we updated the config as well

--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -28,6 +28,8 @@ from .instance import DflyInstance, DflyParams, DflyInstanceFactory, RedisServer
 from .utility import DflySeederFactory, gen_ca_cert, gen_certificate, skip_if_not_in_github
 
 logging.getLogger("asyncio").setLevel(logging.WARNING)
+# Suppress "Unclosed ClusterNode" warnings from redis-py topology refreshes (not actionable)
+logging.getLogger("asyncio").addFilter(lambda r: "Unclosed ClusterNode" not in r.getMessage())
 
 DATABASE_INDEX = 0
 BASE_LOG_DIR = "/tmp/dragonfly_logs/"

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -13,6 +13,8 @@ import pytest
 import redis as base_redis
 from redis import asyncio as aioredis
 from redis.cache import CacheConfig
+from redis.backoff import NoBackoff
+from redis.retry import Retry
 from redis.exceptions import ConnectionError, ResponseError
 
 from . import dfly_args
@@ -1400,7 +1402,9 @@ async def test_tls_client_kill_preemption(
     server = df_factory.create(proactor_threads=4, port=BASE_PORT, **with_ca_tls_server_args)
     server.start()
 
-    client = aioredis.Redis(port=server.port, **with_ca_tls_client_args)
+    client = server.client(
+        single_connection_client=True, retry=Retry(NoBackoff(), 0), **with_ca_tls_client_args
+    )
     assert await client.dbsize() == 0
 
     # Get the list of clients
@@ -1410,15 +1414,14 @@ async def test_tls_client_kill_preemption(
     kill_id = clients_info[0]["id"]
 
     async def seed():
-        with pytest.raises(aioredis.ConnectionError) as roe:
+        try:
             while True:
                 p = client.pipeline(transaction=True)
-                expected = []
                 for i in range(100):
                     p.lpush(str(i), "V")
-                    expected.append(f"LPUSH {i} V")
-
                 await p.execute()
+        except (aioredis.ConnectionError, asyncio.CancelledError):
+            pass
 
     task = asyncio.create_task(seed())
 
@@ -1427,7 +1430,21 @@ async def test_tls_client_kill_preemption(
     cl = aioredis.Redis(port=server.port, **with_ca_tls_client_args)
     await cl.execute_command(f"CLIENT KILL ID {kill_id}")
 
+    # Ensure that the killed client actually disconnects before we cancel the worker task.
+    for _ in range(100):
+        try:
+            await client.ping()
+        except aioredis.ConnectionError:
+            break
+        await asyncio.sleep(0.05)
+    else:
+        pytest.fail("Killed client did not disconnect")
+
+    # Give the server time to process the kill and write logs
+    await asyncio.sleep(0.5)
+    task.cancel()
     await task
+
     server.stop()
     lines = server.find_in_logs("Preempting inside of atomic section, fiber")
     assert len(lines) == 0

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1363,7 +1363,7 @@ async def test_take_over_read_commands(df_factory, master_threads, replica_threa
     replica = df_factory.create(proactor_threads=replica_threads)
     df_factory.start_all([master, replica])
 
-    c_master = master.client()
+    c_master = master.client(socket_timeout=1, socket_connect_timeout=1)
     await c_master.execute_command("SET foo bar")
 
     c_replica = replica.client()
@@ -1372,15 +1372,17 @@ async def test_take_over_read_commands(df_factory, master_threads, replica_threa
 
     async def prompt():
         client = replica.client()
-        for i in range(50):
+        master_alive = True
+        for i in range(10):
             # TODO remove try block when we no longer shut down master after take over
-            try:
-                res = await c_master.execute_command("GET foo")
-                assert res == "bar"
-                res = await c_master.execute_command("CONFIG SET aclfile myfile")
-                assert res == "OK"
-            except:
-                pass
+            if master_alive:
+                try:
+                    res = await c_master.execute_command("GET foo")
+                    assert res == "bar"
+                    res = await c_master.execute_command("CONFIG SET aclfile myfile")
+                    assert res == "OK"
+                except:
+                    master_alive = False
             res = await client.execute_command("GET foo")
             assert res == "bar"
 
@@ -2072,7 +2074,14 @@ async def test_replicaof_reject_on_load(df_factory, df_seeder_factory):
 
     replica.stop()
     replica.start()
-    c_replica = replica.client()
+    # Disable retries so that BusyLoadingError is raised immediately.
+    # redis-py >= 7 retries on ConnectionError by default, and BusyLoadingError
+    # inherits from ConnectionError, causing the REPLICAOF to be silently
+    # retried until loading finishes.
+    from redis.retry import Retry
+    from redis.backoff import NoBackoff
+
+    c_replica = replica.client(retry=Retry(NoBackoff(), 0))
 
     @assert_eventually
     async def check_replica_isloading():

--- a/tests/dragonfly/search_test.py
+++ b/tests/dragonfly/search_test.py
@@ -7,7 +7,11 @@ import copy
 
 import numpy as np
 from redis.commands.search.field import TextField, NumericField, TagField, VectorField, GeoField
-from redis.commands.search.indexDefinition import IndexDefinition, IndexType
+
+try:
+    from redis.commands.search.indexDefinition import IndexDefinition, IndexType
+except ModuleNotFoundError:
+    from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from . import dfly_args

--- a/tests/dragonfly/server_family_test.py
+++ b/tests/dragonfly/server_family_test.py
@@ -4,6 +4,8 @@ import aiohttp
 from prometheus_client.samples import Sample
 from pymemcache import Client
 
+from redis.exceptions import ResponseError
+
 from . import dfly_args
 from .instance import DflyInstance
 from .utility import *
@@ -77,11 +79,14 @@ async def test_get_databases(async_client: aioredis.Redis):
     assert dbnum == {"databases": "16"}
 
 
-@pytest.mark.exclude_epoll  # Failing test. It should be turned on as soon as it is fixed.
 async def test_client_kill(df_factory):
     with df_factory.create(port=1111, admin_port=1112) as instance:
-        client = aioredis.Redis(port=instance.port)
-        admin_client = aioredis.Redis(port=instance.admin_port)
+        instance: DflyInstance
+        from redis.backoff import NoBackoff
+        from redis.asyncio.retry import Retry
+
+        client = instance.client(retry=Retry(NoBackoff(), 0))
+        admin_client = instance.admin_client()
         await admin_client.ping()
 
         # This creates `client_conn` as a non-auto-reconnect client
@@ -90,13 +95,13 @@ async def test_client_kill(df_factory):
             assert len(await admin_client.execute_command("CLIENT LIST")) == 2
 
             # Can't kill admin from regular connection
-            with pytest.raises(Exception) as e_info:
+            with pytest.raises(ResponseError) as e_info:
                 await client_conn.execute_command("CLIENT KILL LADDR 127.0.0.1:1112")
 
             assert len(await admin_client.execute_command("CLIENT LIST")) == 2
             await admin_client.execute_command("CLIENT KILL LADDR 127.0.0.1:1111")
             assert len(await admin_client.execute_command("CLIENT LIST")) == 1
-            with pytest.raises(Exception) as e_info:
+            with pytest.raises(redis.exceptions.ConnectionError) as e_info:
                 await client_conn.ping()
 
 


### PR DESCRIPTION
## Summary

Update pytest suite to be compatible with modern redis-py (v7+) client library.

## Changes

- **cluster_test.py**: Handle `MovedError` (now a distinct exception type in redis-py v7) alongside `ResponseError`; use `endswith()` for MOVED assertion strings since the prefix format changed; split `CLUSTER HELP` into two args for proper command routing
- **connection_test.py**: Disable redis-py v7 automatic retries (`Retry(NoBackoff(), 0)`) in `test_tls_client_kill_preemption` so connection kills are observed immediately; fix race condition by polling for client disconnect before cancelling the seed task
- **replication_test.py**: Disable auto-retries in `test_replicaof_reject_on_load` so `BusyLoadingError` (which now inherits from `ConnectionError`) is raised instead of silently retried; add `socket_timeout` in `test_take_over_read_commands` and stop querying master after it goes down
- **search_test.py**: Handle module rename `indexDefinition` → `index_definition` across redis-py versions via try/except import
- **server_family_test.py**: Disable auto-retries in `test_client_kill`; use specific exception types (`ResponseError`, `ConnectionError`) instead of bare `Exception`
- **acl_family_test.py**: Accept `NoPermissionError` alongside `ConnectionError` for revoked pub/sub
- **conftest.py**: Suppress noisy "Unclosed ClusterNode" asyncio warnings from redis-py topology refreshes