### PR TITLE
[WIP] feat(server): Receiver logic for tagged chunks

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -96,7 +96,7 @@ add_library(dragonfly_lib
             ${DF_CLUSTER_SRCS}
             acl/user.cc acl/user_registry.cc acl/acl_family.cc
             acl/validator.cc
-            sharding.cc cmd_support.cc)
+            sharding.cc cmd_support.cc tagged_chunk.cc)
 
 if (DF_ENABLE_MEMORY_TRACKING)
   target_compile_definitions(dragonfly_lib PRIVATE DFLY_ENABLE_MEMORY_TRACKING)
@@ -159,6 +159,7 @@ helio_cxx_test(cluster/cluster_family_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(acl/acl_family_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(engine_shard_set_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(serializer_base_test dfly_test_lib LABELS DFLY)
+helio_cxx_test(tagged_chunk_test dfly_test_lib LABELS DFLY)
 
 add_dependencies(check_dfly dragonfly_test json_family_test list_family_test
                  generic_family_test memcache_parser_test rdb_test journal_test

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -8,6 +8,7 @@
 #include "absl/strings/match.h"
 #include "facade/service_interface.h"
 #include "server/engine_shard.h"
+#include "server/tagged_chunk.h"
 
 extern "C" {
 #include "redis/rdb.h"
@@ -961,7 +962,15 @@ void DflyShardReplica::FullSyncDflyFb(std::string eof_token, BlockingCounter bc,
   rdb_loader_->SetOverrideExistingKeys(true);
 
   // Load incoming rdb stream.
-  if (std::error_code ec = rdb_loader_->Load(&ps); ec) {
+
+  io::Source* src = &ps;
+
+  TagStrippingSource tss{&ps};
+  if (master_context_.version >= DflyVersion::VER7) {
+    src = &tss;
+  }
+
+  if (std::error_code ec = rdb_loader_->Load(src); ec) {
     cntx->ReportError(ec, "Error loading rdb format");
     return;
   }

--- a/src/server/tagged_chunk.cc
+++ b/src/server/tagged_chunk.cc
@@ -1,0 +1,43 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "server/tagged_chunk.h"
+
+#include "base/endian.h"
+#include "base/logging.h"
+
+namespace dfly {
+
+using nonstd::make_unexpected;
+
+std::array<char, 8> TaggedChunkHeader::Serialize() const {
+  std::array<char, 8> output;
+  base::LE::StoreT(static_cast<uint32_t>(tag), output.data());
+  base::LE::StoreT(payload_size, output.data() + 4);
+  return output;
+}
+
+io::Result<TaggedChunkHeader> TaggedChunkHeader::Deserialize(const char* buffer) {
+  const auto tag = base::LE::LoadT<uint32_t>(buffer);
+  if (tag != 0) {
+    return make_unexpected(std::make_error_code(std::errc::illegal_byte_sequence));
+  }
+
+  const auto payload_size = base::LE::LoadT<uint32_t>(buffer + 4);
+  return TaggedChunkHeader{static_cast<ChunkTag>(tag), payload_size};
+}
+
+std::error_code PrependChunkHeader(const ChunkTag tag, std::string* payload) {
+  const size_t payload_size = payload->size();
+  if (payload_size > std::numeric_limits<uint32_t>::max())
+    return std::make_error_code(std::errc::result_out_of_range);
+
+  const TaggedChunkHeader header{tag, static_cast<uint32_t>(payload_size)};
+  const auto serialized = header.Serialize();
+  payload->insert(0, serialized.data(), TaggedChunkHeader::kHeaderSize);
+
+  return {};
+}
+
+}  // namespace dfly

--- a/src/server/tagged_chunk.cc
+++ b/src/server/tagged_chunk.cc
@@ -4,6 +4,8 @@
 
 #include "server/tagged_chunk.h"
 
+#include <absl/container/inlined_vector.h>
+
 #include "base/endian.h"
 #include "base/logging.h"
 
@@ -38,6 +40,81 @@ std::error_code PrependChunkHeader(const ChunkTag tag, std::string* payload) {
   payload->insert(0, serialized.data(), TaggedChunkHeader::kHeaderSize);
 
   return {};
+}
+
+absl::InlinedVector<iovec, 4> TagStrippingSource::GetCappedVec(const iovec* v, uint32_t len) const {
+  // A copy of iovecs. Usually restricted to just one when the caller uses ReadAtLeast, but should
+  // work for the general case.
+  absl::InlinedVector<iovec, 4> capped(v, v + len);
+
+  size_t curr_index = 0;
+  uint32_t to_read = remaining_payload_bytes_;
+
+  // Make sure that we restrict the capped container, so that the combined iovec capacity
+  // matches remaining_payload_bytes_. If remaining_payload_bytes_ is too large, then effectively
+  // capped is same as v.
+  for (; curr_index < len; ++curr_index) {
+    // Stop when remaining bytes will only partially fill the current iovec
+    if (to_read <= v[curr_index].iov_len) {
+      capped[curr_index].iov_len = to_read;
+      break;
+    }
+
+    to_read -= v[curr_index].iov_len;
+  }
+
+  // If the loop stopped at the first element, curr_index_ = 0. Reserve 1 element.
+  // If it stopped when curr_index = len + 1, ie remaining bytes don't fit, reserve len elements.
+  capped.resize(std::min(curr_index + 1, size_t{len}));
+
+  return capped;
+}
+
+io::Result<unsigned long> TagStrippingSource::ReadSome(const iovec* v, uint32_t len) {
+  // Handle possible messages with 0 size payload by moving onto the next message
+  while (remaining_payload_bytes_ == 0 && !eof_) {
+    if (auto header_read = ReadHeader(); !header_read) {
+      return header_read;
+    }
+  }
+
+  // Found end of stream while parsing headers
+  if (eof_) {
+    return 0;
+  }
+
+  auto capped = GetCappedVec(v, len);
+  auto n = upstream_->ReadSome(capped.data(), capped.size());
+  if (!n) {
+    return n;
+  }
+
+  remaining_payload_bytes_ -= n.value();
+  return n;
+}
+
+io::Result<unsigned long> TagStrippingSource::ReadHeader() {
+  const io::MutableBytes dest{reinterpret_cast<unsigned char*>(header_.data()), header_.size()};
+  auto header_read = upstream_->ReadAtLeast(dest, TaggedChunkHeader::kHeaderSize);
+  if (!header_read) {
+    return header_read;
+  }
+
+  if (header_read.value() == 0) {
+    eof_ = true;
+    return header_read;
+  }
+
+  const auto result = TaggedChunkHeader::Deserialize(reinterpret_cast<const char*>(dest.data()));
+  if (!result) {
+    return make_unexpected(result.error());
+  }
+
+  // Tag is thrown away right now. It should be stored and used later on.
+  const auto [tag, payload_size] = result.value();
+
+  remaining_payload_bytes_ = payload_size;
+  return header_read;
 }
 
 }  // namespace dfly

--- a/src/server/tagged_chunk.h
+++ b/src/server/tagged_chunk.h
@@ -1,0 +1,29 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+
+#include "io/io.h"
+
+namespace dfly {
+
+enum class ChunkTag : uint8_t {
+  Baseline = 0,
+};
+
+struct TaggedChunkHeader {
+  static constexpr std::size_t kHeaderSize = 8;
+  ChunkTag tag;
+  uint32_t payload_size;
+  std::array<char, 8> Serialize() const;
+  static io::Result<TaggedChunkHeader> Deserialize(const char* buffer);
+};
+
+[[nodiscard]] std::error_code PrependChunkHeader(ChunkTag tag, std::string* payload);
+
+}  // namespace dfly

--- a/src/server/tagged_chunk.h
+++ b/src/server/tagged_chunk.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <absl/container/inlined_vector.h>
+
 #include <array>
 #include <cstdint>
 #include <string>
@@ -25,5 +27,34 @@ struct TaggedChunkHeader {
 };
 
 [[nodiscard]] std::error_code PrependChunkHeader(ChunkTag tag, std::string* payload);
+
+// For each message, reads header from upstream and then returns the bytes without header
+class TagStrippingSource : public io::Source {
+ public:
+  explicit TagStrippingSource(Source* upstream) : upstream_{upstream} {
+  }
+
+  TagStrippingSource(const TagStrippingSource&) = delete;
+  TagStrippingSource& operator=(const TagStrippingSource&) = delete;
+  TagStrippingSource(TagStrippingSource&&) = delete;
+  TagStrippingSource& operator=(TagStrippingSource&&) = delete;
+
+  io::Result<unsigned long> ReadSome(const iovec* v, uint32_t len) override;
+
+ private:
+  // Reads the header (tag, payload size) off the upstream. Sets payload size for later reads which
+  // will be sent to downstream readers.
+  io::Result<unsigned long> ReadHeader();
+
+  // Copies the given iovec collection, caps to remaining_payload_bytes_, so the next read ends at
+  // most at the current chunk boundary.
+  absl::InlinedVector<iovec, 4> GetCappedVec(const iovec* v, uint32_t len) const;
+
+  Source* upstream_;
+  std::array<char, TaggedChunkHeader::kHeaderSize> header_{};
+
+  uint32_t remaining_payload_bytes_ = 0;
+  bool eof_{false};
+};
 
 }  // namespace dfly

--- a/src/server/tagged_chunk_test.cc
+++ b/src/server/tagged_chunk_test.cc
@@ -1,0 +1,42 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "server/tagged_chunk.h"
+
+#include "base/endian.h"
+#include "base/gtest.h"
+#include "base/logging.h"
+
+using namespace dfly;
+
+TEST(TaggedChunk, RoundTrip) {
+  const TaggedChunkHeader header{ChunkTag::Baseline, 514};
+  const auto serialized = header.Serialize();
+  constexpr std::array<char, 8> expected{0, 0, 0, 0, 2, 2, 0, 0};
+  EXPECT_EQ(serialized, expected);
+  const auto [tag, payload_size] = TaggedChunkHeader::Deserialize(serialized.data()).value();
+  EXPECT_EQ(tag, header.tag);
+  EXPECT_EQ(payload_size, header.payload_size);
+}
+
+TEST(TaggedChunk, InvalidTag) {
+  std::array<char, 8> output;
+  base::LE::StoreT(uint32_t{42}, output.data());
+  base::LE::StoreT(uint32_t{99}, output.data() + 4);
+  auto result = TaggedChunkHeader::Deserialize(output.data());
+  EXPECT_EQ(result.error(), std::errc::illegal_byte_sequence);
+}
+
+TEST(TaggedChunk, PrependHeader) {
+  std::string payload{"this is a string"};
+  const auto original_size = payload.size();
+
+  EXPECT_EQ(std::error_code{}, PrependChunkHeader(ChunkTag::Baseline, &payload));
+  EXPECT_EQ(payload.size(), original_size + TaggedChunkHeader::kHeaderSize);
+
+  const auto [tag, payload_size] = TaggedChunkHeader::Deserialize(payload.data()).value();
+
+  EXPECT_EQ(tag, ChunkTag::Baseline);
+  EXPECT_EQ(payload_size, original_size);
+}

--- a/src/server/tagged_chunk_test.cc
+++ b/src/server/tagged_chunk_test.cc
@@ -40,3 +40,58 @@ TEST(TaggedChunk, PrependHeader) {
   EXPECT_EQ(tag, ChunkTag::Baseline);
   EXPECT_EQ(payload_size, original_size);
 }
+
+namespace {
+
+std::string DrainSource(TagStrippingSource& src) {
+  std::string output;
+  uint8_t buffer[4];
+
+  iovec v{buffer, 4};
+
+  while (true) {
+    auto result = src.ReadSome(&v, 1);
+    EXPECT_TRUE(result);
+    if (result.value() == 0) {
+      break;
+    }
+    output.append(reinterpret_cast<const char*>(buffer), result.value());
+  }
+
+  return output;
+}
+
+void AppendStringWithHeader(std::string_view msg, std::string* out) {
+  std::string payload{msg};
+  std::ignore = PrependChunkHeader(ChunkTag::Baseline, &payload);
+  out->append(payload);
+}
+
+}  // namespace
+
+TEST(TagStrippingSource, SimpleStream) {
+  std::string payload;
+  AppendStringWithHeader("this is a string", &payload);
+  AppendStringWithHeader("this is another string", &payload);
+  AppendStringWithHeader("this is yet another string", &payload);
+
+  io::BytesSource upstream{payload};
+  TagStrippingSource source{&upstream};
+
+  const auto output = DrainSource(source);
+
+  EXPECT_EQ(output, "this is a stringthis is another stringthis is yet another string");
+}
+
+TEST(TagStrippingSource, ZeroLenMsg) {
+  std::string payload;
+  AppendStringWithHeader("", &payload);
+  AppendStringWithHeader("second msg", &payload);
+
+  io::BytesSource upstream{payload};
+  TagStrippingSource source{&upstream};
+
+  const auto output = DrainSource(source);
+
+  EXPECT_EQ(output, "second msg");
+}

--- a/src/server/version.h
+++ b/src/server/version.h
@@ -42,6 +42,8 @@ enum class DflyVersion {
   // - hnsw-index-metadata AUX field
   VER6,
 
+  // Sends tagged chunks to replicas to differentiate between journal and baseline data.
+  VER7,
   // Always points to the latest version
   CURRENT_VER = VER6,
 };


### PR DESCRIPTION
Child PR of https://github.com/dragonflydb/dragonfly/pull/6886

* Introduces new version 7 for use as gate - the new version is not `CURRENT_VER` - that will only be done when the sender code changes. The receiver checks the version, if it is 7, tags are expected.
* The sender code is not changed yet, so tags are not sent within this PR.
* Adds new io source which can parse and strip off headers and tag
* The parsed tag is discarded for now. After future work in https://github.com/dragonflydb/dragonfly/blob/main/docs/shard-serialization.md the parsed tag can be used for demultiplexing.
* The rdb loader will optionally receive the prefix source wrapped in this new source, if the version check passes. The loader still reads the same blob as before, it is not concerned with header which has been stripped out before reaching the loader.
