### PR TITLE
fix(search): Fix null vector detection in FlatVectorIndex

### DIFF
--- a/src/core/search/indices.cc
+++ b/src/core/search/indices.cc
@@ -523,59 +523,53 @@ bool BaseVectorIndex::Add(DocId id, const DocumentAccessor& doc, std::string_vie
   return true;
 }
 
+// Each document occupies (dim_ + 1) floats in entries_: dim_ floats for the vector data,
+// followed by one float as a presence marker (1.0 = present, 0.0 = absent/removed).
+// This avoids the previous heuristic of treating all-zero vectors as null.
+static constexpr float kPresent = 1.0f;
+static constexpr float kAbsent = 0.0f;
+
 FlatVectorIndex::FlatVectorIndex(const SchemaField::VectorParams& params,
                                  PMR_NS::memory_resource* mr)
     : BaseVectorIndex{params.dim, params.sim}, entries_{mr} {
   DCHECK(!params.use_hnsw);
-  entries_.reserve(params.capacity * params.dim);
+  entries_.reserve(params.capacity * (params.dim + 1));
 }
 
 void FlatVectorIndex::AddVector(DocId id, const void* vector) {
-  DCHECK_LE(id * dim_, entries_.size());
-  if (id * dim_ == entries_.size())
-    entries_.resize((id + 1) * dim_);
+  const size_t stride = dim_ + 1;
+  DCHECK_LE(id * stride, entries_.size());
+  if (id * stride == entries_.size())
+    entries_.resize((id + 1) * stride, 0.0f);
 
-  // TODO: Let get vector write to buf itself
   if (vector) {
-    memcpy(&entries_[id * dim_], vector, dim_ * sizeof(float));
+    memcpy(&entries_[id * stride], vector, dim_ * sizeof(float));
+    entries_[id * stride + dim_] = kPresent;
   }
 }
 
 void FlatVectorIndex::Remove(DocId id, const DocumentAccessor& doc, string_view field) {
-  // noop
+  const size_t stride = dim_ + 1;
+  if (id * stride + dim_ < entries_.size())
+    entries_[id * stride + dim_] = kAbsent;
 }
 
 const float* FlatVectorIndex::Get(DocId doc) const {
-  return &entries_[doc * dim_];
+  const size_t stride = dim_ + 1;
+  if (doc * stride + dim_ >= entries_.size() || entries_[doc * stride + dim_] != kPresent)
+    return nullptr;
+  return &entries_[doc * stride];
 }
 
 std::vector<DocId> FlatVectorIndex::GetAllDocsWithNonNullValues() const {
+  const size_t stride = dim_ + 1;
+  size_t num_slots = entries_.size() / stride;
   std::vector<DocId> result;
-
-  size_t num_vectors = entries_.size() / dim_;
-  result.reserve(num_vectors);
-
-  for (DocId id = 0; id < num_vectors; ++id) {
-    // Check if the vector is not zero (all elements are 0)
-    // TODO: Valid vector can contain 0s, we should use a better approach
-    const float* vec = Get(id);
-    bool is_zero_vector = true;
-
-    // TODO: Consider don't use check for zero vector
-    for (size_t i = 0; i < dim_; ++i) {
-      if (vec[i] != 0.0f) {  // TODO: Consider using a threshold for float comparison
-        is_zero_vector = false;
-        break;
-      }
-    }
-
-    if (!is_zero_vector) {
+  result.reserve(num_slots);
+  for (DocId id = 0; id < num_slots; ++id) {
+    if (entries_[id * stride + dim_] == kPresent)
       result.push_back(id);
-    }
   }
-
-  // Result is already sorted by id, no need to sort again
-  // Also it has no duplicates
   return result;
 }
 

--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -340,7 +340,10 @@ struct BasicSearch {
     auto cb = [&](auto* set) {
       auto [dim, sim] = vec_index->Info();
       for (DocId matched_doc : *set) {
-        float dist = VectorDistance(knn.vec.first.get(), vec_index->Get(matched_doc), dim, sim);
+        const float* vec = vec_index->Get(matched_doc);
+        if (!vec)
+          continue;
+        float dist = VectorDistance(knn.vec.first.get(), vec, dim, sim);
         knn_distances_.emplace_back(dist, matched_doc);
       }
     };
@@ -356,7 +359,10 @@ struct BasicSearch {
     const auto& all_docs = indices_->GetAllDocs();
     auto [dim, sim] = vec_index->Info();
     for (DocId doc : all_docs) {
-      float dist = VectorDistance(node.vec.first.get(), vec_index->Get(doc), dim, sim);
+      const float* vec = vec_index->Get(doc);
+      if (!vec)
+        continue;
+      float dist = VectorDistance(node.vec.first.get(), vec, dim, sim);
       if (dist <= static_cast<float>(node.radius)) {
         knn_scores_.emplace_back(doc, dist);
       }

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -736,6 +736,50 @@ TEST_F(VectorRangeTest, FlatRangeDistancesStoredInScores) {
   EXPECT_EQ(result.knn_scores.size(), 3u);
 }
 
+TEST_F(VectorRangeTest, FlatStarQueryZeroVectorIsValid) {
+  // Regression: @field:* on a FLAT vector index uses GetAllDocsWithNonNullValues(), which
+  // incorrectly skips zero vectors. The zero vector [0.0,...,0.0] is a valid embedding.
+  auto schema = MakeSimpleSchema({{"pos", SchemaField::VECTOR}});
+  schema.fields["pos"].special_params = SchemaField::VectorParams{false, 2};
+  FieldIndices indices{schema, kEmptyOptions, PMR_NS::get_default_resource(), nullptr};
+
+  // doc 0: zero vector [0.0, 0.0] — valid embedding, must not be skipped
+  indices.Add(0, MockedDocument{Map{{"pos", ToBytes({0.0f, 0.0f})}}});
+  // doc 1: non-zero vector [1.0, 0.0]
+  indices.Add(1, MockedDocument{Map{{"pos", ToBytes({1.0f, 0.0f})}}});
+
+  SearchAlgorithm algo{};
+  QueryParams params;
+  algo.Init("@pos:*", &params);
+  auto result = algo.Search(&indices);
+  // Both docs must appear — zero vector is NOT null
+  EXPECT_THAT(result.ids, testing::UnorderedElementsAre(0, 1));
+}
+
+TEST_F(VectorRangeTest, FlatStarQueryRemovedDocNotMatched) {
+  // Regression: @field:* on a FLAT vector index uses GetAllDocsWithNonNullValues(), which
+  // iterates entries_ directly and does NOT respect all_ids_. After Remove(), the doc's
+  // slot in entries_ is still non-zero, so the removed doc incorrectly appears in results.
+  auto schema = MakeSimpleSchema({{"pos", SchemaField::VECTOR}});
+  schema.fields["pos"].special_params = SchemaField::VectorParams{false, 1};
+  FieldIndices indices{schema, kEmptyOptions, PMR_NS::get_default_resource(), nullptr};
+
+  indices.Add(0, MockedDocument{Map{{"pos", ToBytes({1.0f})}}});
+  indices.Add(1, MockedDocument{Map{{"pos", ToBytes({2.0f})}}});
+  indices.Add(2, MockedDocument{Map{{"pos", ToBytes({3.0f})}}});
+
+  // Remove doc 1
+  MockedDocument doc1{Map{{"pos", ToBytes({2.0f})}}};
+  indices.Remove(1, doc1);
+
+  SearchAlgorithm algo{};
+  QueryParams params;
+  algo.Init("@pos:*", &params);
+  auto result = algo.Search(&indices);
+  // Doc 1 was removed, only docs 0 and 2 should appear
+  EXPECT_THAT(result.ids, testing::UnorderedElementsAre(0, 2));
+}
+
 TEST_F(KnnTest, Simple1D) {
   auto schema = MakeSimpleSchema({{"even", SchemaField::TAG}, {"pos", SchemaField::VECTOR}});
   schema.fields["pos"].special_params = SchemaField::VectorParams{false, 1};


### PR DESCRIPTION
Fix two bugs in `FlatVectorIndex`:

1. Zero vector falsely treated as null - `GetAllDocsWithNonNullValues` skipped documents whose vector was `[0.0, 0.0, ..., 0.0]`, even though it's a valid embedding.
2. `Remove()` was a no-op - removed documents continued to appear in `@field:*` queries.

Root cause: null detection relied on an all-zeros heuristic with no way to distinguish "no vector set" from a valid zero vector.

Fix: each document now occupies `dim + 1` floats in `entries_`. The extra float acts as a presence marker (`1.0` = present, `0.0` = absent). `Remove()` clears the marker; `GetAllDocsWithNonNullValues` checks it instead of scanning all floats.

No API changes — `Get(doc)` still returns `const float*` to the vector data. Index is rebuilt on restart, so no persistence impact.

Fixes #6884