### PR TITLE
chore: offload connection backpressure to disk

### DIFF
--- a/src/facade/disk_backed_queue.cc
+++ b/src/facade/disk_backed_queue.cc
@@ -60,8 +60,8 @@ std::error_code DiskBackedQueue::Close() {
 
     std::string backing = absl::StrCat(absl::GetFlag(FLAGS_disk_backpressure_folder), id_);
     int errc = unlink(backing.c_str());
-    LOG_IF(ERROR, errc != 0) << "Failed to unlink backing file: "
-                             << std::error_code{errc, std::system_category()};
+    LOG_IF(ERROR, errc == -1) << "Failed to unlink backing file: "
+                              << std::error_code{errno, std::system_category()};
     return ec;
   }
 
@@ -71,6 +71,10 @@ std::error_code DiskBackedQueue::Close() {
 // Check if backing file is empty, i.e. backing file has 0 bytes.
 bool DiskBackedQueue::Empty() const {
   return total_backing_bytes_ == 0;
+}
+
+size_t DiskBackedQueue::TotalBytes() const {
+  return total_backing_bytes_;
 }
 
 bool DiskBackedQueue::HasEnoughBackingSpaceFor(size_t bytes) const {

--- a/src/facade/disk_backed_queue.h
+++ b/src/facade/disk_backed_queue.h
@@ -36,6 +36,9 @@ class DiskBackedQueue {
   // Check if backing file is empty, i.e. backing file has 0 bytes.
   bool Empty() const;
 
+  // Total bytes currently buffered on disk (not yet consumed).
+  size_t TotalBytes() const;
+
   std::error_code Close();
 
  private:

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1133,6 +1133,11 @@ void Connection::ConnectionFlow() {
 
   phase_ = PRECLOSE;
 
+  if (disk_queue_) {
+    std::ignore = disk_queue_->Close();
+    disk_queue_.reset();
+  }
+
   ClearPipelinedMessages();
   DCHECK(!HasPendingMessages());
 
@@ -1214,19 +1219,30 @@ void Connection::DispatchSingle(bool has_more, absl::FunctionRef<void()> invoke_
                              << ", Connection parsed_cmd_q_bytes_: " << parsed_cmd_q_bytes_
                              << ", Connection parsed commands queue size: " << parsed_cmd_q_len_
                              << ", consider increasing pipeline_buffer_limit/pipeline_queue_limit";
-    fb2::NoOpLock noop;
-    qbp.pipeline_cnd.wait(noop, [this, &qbp, &can_dispatch_sync_fn] {
-      // Wait until at least one is true:
-      // 1) Connection is closing.
-      // 2) Can dispatch synchronously.
-      // 3) Not over limits (for an async dispatch).
-      bool can_dispatch_sync = can_dispatch_sync_fn();
-      if (can_dispatch_sync)
-        return true;
-      bool over_limits = qbp.IsPipelineBufferOverLimit(
-          tl_facade_stats->conn_stats.pipeline_queue_bytes, parsed_cmd_q_len_);
-      return !over_limits || cc_->conn_closing;
-    });
+
+    // If disk offloading is available, signal ParseRedis to stop consuming io_buf_
+    // so IoLoop can push the remaining raw bytes to disk instead of blocking here.
+    // Note: the command that triggered this (the one currently being dispatched) is
+    // still enqueued normally below — it is a one-command overshoot over the limit,
+    // which is acceptable. All subsequent commands remain in io_buf_ and are offloaded.
+    InitDiskQueueIfNeeded();
+    if (disk_queue_) {
+      disk_offload_requested_ = true;
+    } else {
+      fb2::NoOpLock noop;
+      qbp.pipeline_cnd.wait(noop, [this, &qbp, &can_dispatch_sync_fn] {
+        // Wait until at least one is true:
+        // 1) Connection is closing.
+        // 2) Can dispatch synchronously.
+        // 3) Not over limits (for an async dispatch).
+        bool can_dispatch_sync = can_dispatch_sync_fn();
+        if (can_dispatch_sync)
+          return true;
+        bool over_limits = qbp.IsPipelineBufferOverLimit(
+            tl_facade_stats->conn_stats.pipeline_queue_bytes, parsed_cmd_q_len_);
+        return !over_limits || cc_->conn_closing;
+      });
+    }
 
     // prefer synchronous dispatching to save memory.
     optimize_for_async = false;
@@ -1300,6 +1316,9 @@ Connection::ParserStatus Connection::ParseRedis(unsigned max_busy_cycles, bool e
         dispatch_async();
       else
         DispatchSingle(has_more, dispatch_sync, dispatch_async);
+
+      if (disk_offload_requested_)
+        break;
     }
     if (result != RespSrvParser::OK && result != RespSrvParser::INPUT_PENDING) {
       // We do not expect that a replica sends an invalid command so we log if it happens.
@@ -1429,6 +1448,55 @@ io::Result<size_t> Connection::HandleRecvSocket() {
   return recv_sz;
 }
 
+void Connection::InitDiskQueueIfNeeded() {
+  if (disk_queue_)
+    return;
+  disk_queue_ = std::make_unique<DiskBackedQueue>(id_);
+  if (auto ec = disk_queue_->Init(); ec) {
+    LOG(WARNING) << "Failed to initialize disk-backed queue for connection " << id_ << ": " << ec;
+    disk_queue_.reset();
+  }
+}
+
+void Connection::PushToDiskSync(io::Bytes bytes) {
+  fb2::Done done;
+  std::error_code push_ec;
+  const size_t nbytes = bytes.size();
+  disk_queue_->PushAsync(bytes, [&done, &push_ec](std::error_code ec) {
+    push_ec = ec;
+    done.Notify();
+  });
+  done.Wait();
+  if (push_ec) {
+    LOG(ERROR) << "Disk push error for connection " << id_ << ": " << push_ec;
+    return;
+  }
+  VLOG(2) << "conn=" << id_ << " offloaded " << nbytes << " bytes to disk"
+          << ", disk_total=" << disk_queue_->TotalBytes() << " bytes";
+}
+
+size_t Connection::PopFromDiskSync(io::MutableBytes buf) {
+  fb2::Done done;
+  size_t result = 0;
+  std::error_code pop_ec;
+  disk_queue_->PopAsync(buf, [&done, &result, pop_ec](io::Result<size_t> res) mutable {
+    if (res) {
+      result = *res;
+    } else {
+      pop_ec = res.error();
+    }
+    done.Notify();
+  });
+  done.Wait();
+  if (pop_ec) {
+    LOG(ERROR) << "Disk pop error for connection " << id_ << ": " << pop_ec;
+    return 0;
+  }
+  VLOG(2) << "conn=" << id_ << " restored " << result << " bytes from disk"
+          << ", disk_remaining=" << disk_queue_->TotalBytes() << " bytes";
+  return result;
+}
+
 variant<error_code, Connection::ParserStatus> Connection::IoLoop() {
   error_code ec;
   ParserStatus parse_status = OK;
@@ -1439,13 +1507,32 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoop() {
 
   do {
     HandleMigrateRequest();
-    auto recv_sz = HandleRecvSocket();
-    if (!recv_sz) {
-      LOG_IF(WARNING, cntx()->replica_conn) << "HandleRecvSocket() error: " << recv_sz.error();
-      return recv_sz.error();
+
+    bool got_data_from_disk = false;
+
+    // If disk has buffered bytes, drain them when the pipeline has room.
+    if (disk_queue_ && !disk_queue_->Empty()) {
+      QueueBackpressure& qbp = GetQueueBackpressure();
+      auto& conn_stats = tl_facade_stats->conn_stats;
+      if (!qbp.IsPipelineBufferOverLimit(conn_stats.pipeline_queue_bytes, parsed_cmd_q_len_)) {
+        UpdateIoBufCapacity(io_buf_, &conn_stats, [&]() { io_buf_.EnsureCapacity(64); });
+        size_t n = PopFromDiskSync(io_buf_.AppendBuffer());
+        if (n > 0) {
+          io_buf_.CommitWrite(n);
+          got_data_from_disk = true;
+        }
+      }
     }
-    if (*recv_sz == 0) {
-      break;
+
+    if (!got_data_from_disk) {
+      auto recv_sz = HandleRecvSocket();
+      if (!recv_sz) {
+        LOG_IF(WARNING, cntx()->replica_conn) << "HandleRecvSocket() error: " << recv_sz.error();
+        return recv_sz.error();
+      }
+      if (*recv_sz == 0) {
+        break;
+      }
     }
 
     phase_ = PROCESS;
@@ -1456,6 +1543,19 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoop() {
     } else {
       DCHECK(memcache_parser_);
       parse_status = ParseLoop();
+    }
+
+    // ParseRedis broke out early because DispatchSingle requested disk offloading.
+    // Push the remaining unparsed bytes from io_buf_ to disk so we can keep
+    // draining the socket without blocking.
+    if (disk_offload_requested_) {
+      disk_offload_requested_ = false;
+      if (io_buf_.InputLen() > 0 && disk_queue_->HasEnoughBackingSpaceFor(io_buf_.InputLen())) {
+        PushToDiskSync(io_buf_.InputBuffer());
+        io_buf_.ConsumeInput(io_buf_.InputLen());
+      }
+      parse_status = OK;
+      continue;
     }
 
     if (reply_builder_->GetError()) {

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -14,6 +14,7 @@
 #include <variant>
 
 #include "facade/connection_ref.h"
+#include "facade/disk_backed_queue.h"
 #include "facade/facade_types.h"
 #include "facade/parsed_command.h"
 #include "io/io_buf.h"
@@ -340,6 +341,11 @@ class Connection : public util::Connection {
   void DecreaseConnStats();
   void BreakOnce(uint32_t ev_mask);
 
+  // Disk-backed queue helpers for pipeline backpressure offloading.
+  void InitDiskQueueIfNeeded();
+  void PushToDiskSync(io::Bytes bytes);
+  size_t PopFromDiskSync(io::MutableBytes buf);
+
   // The read buffer with read data that needs to be parsed and processed.
   // For io_uring bundles we may have available_bytes larger than slice.size()
   // which means that there are more buffers available to read.
@@ -511,6 +517,15 @@ class Connection : public util::Connection {
   };
 
   bool request_shutdown_ = false;
+
+  // Disk-backed queue for offloading raw socket bytes when pipeline queue is over limit.
+  // Initialized lazily on first use.
+  std::unique_ptr<DiskBackedQueue> disk_queue_;
+
+  // Set by DispatchSingle when disk offloading is preferred over blocking.
+  // ParseRedis checks this flag to stop parsing early, leaving the remaining
+  // io_buf_ bytes for IoLoop to push to disk.
+  bool disk_offload_requested_ = false;
 };
 
 }  // namespace facade

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -1792,3 +1792,32 @@ async def test_pubsub_pipeline_starvation(df_server: DflyInstance):
         await flood_task
         writer.close()
         await writer.wait_closed()
+
+
+async def test_disk_backpressure_offload(df_factory: DflyInstanceFactory):
+    server = df_factory.create(
+        proactor_threads=1,
+        pipeline_queue_limit=10,
+        disk_backpressure_folder="/tmp/",
+        vmodule="dragonfly_connection=2",
+    )
+    server.start()
+
+    async def producer():
+        _, writer = await asyncio.open_connection("localhost", server.port)
+        payload = b"".join(f"SET k{i % 100} val{i}\r\n".encode() for i in range(10_000))
+        writer.write(payload)
+        await writer.drain()
+        await asyncio.sleep(0.3)
+        writer.close()
+        await writer.wait_closed()
+
+    await asyncio.gather(*[producer() for _ in range(5)])
+
+    server.stop()
+
+    offload_lines = server.find_in_logs("offloaded.*bytes to disk")
+    restore_lines = server.find_in_logs("restored.*bytes from disk")
+
+    assert len(offload_lines) > 1, f"Expected >1 disk-offload log lines, got {len(offload_lines)}"
+    assert len(restore_lines) > 1, f"Expected >1 disk-restore log lines, got {len(restore_lines)}"


### PR DESCRIPTION
Currently, even under `ioloop-v2`, resp flows use a two fiber (producer/consumer) approach.

In this PR, I add support to offload connection backpressure to disk via `DiskBackedQueue`. 

*note* that `DispatchSingle` will `dispatch once even if pipeline queue is above limit` since the request is already parsed and there is no way to backtrack it. This is fine, all the data read after it will go straight to the disk based queue.

Once we switch to a single multiplexer fiber for connections, we should use the pure `Async` variants and adhere to the dogma of "everything should be async/multiplexed".

* add synchronous wrappers temporarily for the async disk operations
* use disk backed queue in dragonfly connection
* test

completes #6030
