### PR TITLE
chore: add cms family

### DIFF
--- a/src/core/cms.cc
+++ b/src/core/cms.cc
@@ -8,8 +8,7 @@
 
 #include <algorithm>
 #include <cmath>
-
-#include "base/logging.h"
+#include <limits>
 
 namespace dfly {
 namespace {
@@ -22,53 +21,45 @@ uint32_t Offset(uint64_t h1, uint64_t h2, uint32_t row, uint32_t width) {
 }  // namespace
 
 CMS::CMS(uint32_t width, uint32_t depth, PMR_NS::memory_resource* mr)
-    : width_(width), depth_(depth), mr_(mr) {
-  DCHECK(mr_);
-  DCHECK(width_ > 0 && depth_ > 0);
-  size_t len = size();
-  counters_ = static_cast<int64_t*>(mr_->allocate(len * sizeof(int64_t), alignof(int64_t)));
-  std::fill_n(counters_, len, 0);
+    : width_(width),
+      depth_(depth),
+      counters_(static_cast<size_t>(width) * depth, 0, PMR_NS::polymorphic_allocator<int64_t>(mr)) {
 }
 
-CMS::CMS(ErrorRateTag /*tag*/, double error, double probability, PMR_NS::memory_resource* mr)
-    : CMS(static_cast<uint32_t>(std::ceil(M_E / error)),
-          static_cast<uint32_t>(std::ceil(std::log(1.0 / probability))), mr) {
-}
-
-CMS::~CMS() {
-  if (counters_) {
-    mr_->deallocate(counters_, size() * sizeof(int64_t), alignof(int64_t));
-  }
+CMS::CMS(uint32_t width, uint32_t depth, int64_t total_count, const int64_t* data, size_t count,
+         PMR_NS::memory_resource* mr)
+    : width_(width),
+      depth_(depth),
+      count_(total_count),
+      counters_(data, data + count, PMR_NS::polymorphic_allocator<int64_t>(mr)) {
 }
 
 CMS::CMS(CMS&& other) noexcept
     : width_(other.width_),
       depth_(other.depth_),
-      mr_(other.mr_),
       count_(other.count_),
-      counters_(other.counters_) {
+      counters_(std::move(other.counters_)) {
   other.width_ = 0;
   other.depth_ = 0;
   other.count_ = 0;
-  other.counters_ = nullptr;
 }
 
 CMS& CMS::operator=(CMS&& other) noexcept {
   if (this != &other) {
-    if (counters_) {
-      mr_->deallocate(counters_, size() * sizeof(int64_t), alignof(int64_t));
-    }
     width_ = other.width_;
     depth_ = other.depth_;
-    mr_ = other.mr_;
     count_ = other.count_;
-    counters_ = other.counters_;
+    counters_ = std::move(other.counters_);
     other.width_ = 0;
     other.depth_ = 0;
     other.count_ = 0;
-    other.counters_ = nullptr;
   }
   return *this;
+}
+
+CMS::CMS(ErrorRateTag /*tag*/, double error, double probability, PMR_NS::memory_resource* mr)
+    : CMS(static_cast<uint32_t>(std::ceil(M_E / error)),
+          static_cast<uint32_t>(std::ceil(std::log(1.0 / probability))), mr) {
 }
 
 int64_t CMS::IncrBy(std::string_view item, int64_t increment) {
@@ -107,12 +98,21 @@ bool CMS::MergeFrom(const CMS& other, int64_t weight) {
     return false;
   }
 
-  for (size_t i = 0; i < size(); ++i) {
+  for (size_t i = 0; i < counters_.size(); ++i) {
     counters_[i] += other.counters_[i] * weight;
   }
 
   count_ += other.count_ * weight;
   return true;
+}
+
+void CMS::Reset() {
+  std::fill(counters_.begin(), counters_.end(), 0);
+  count_ = 0;
+}
+
+size_t CMS::MallocUsed() const {
+  return counters_.size() * sizeof(int64_t);
 }
 
 }  // namespace dfly

--- a/src/core/cms.h
+++ b/src/core/cms.h
@@ -15,19 +15,14 @@ namespace dfly {
 /// Count-Min Sketch implementation compatible with Redis CMS commands.
 class CMS {
  public:
-  // Tag type to disambiguate CMS construction by error rate and probability.
-  struct ErrorRateTag {};
-
   // Create a CMS with given width and depth dimensions.
   // width: number of counters per row
   // depth: number of rows (hash functions)
   CMS(uint32_t width, uint32_t depth, PMR_NS::memory_resource* mr);
 
-  // Create a CMS from error rate and probability parameters.
-  // error: relative error (e.g. 0.01 for 1%), must be in (0, 1).
-  // probability: probability of exceeding the error, must be in (0, 1).
-  // width = ceil(e / error), depth = ceil(ln(1 / probability)).
-  CMS(ErrorRateTag, double error, double probability, PMR_NS::memory_resource* mr);
+  // Create a CMS from raw counter data.
+  CMS(uint32_t width, uint32_t depth, int64_t total_count, const int64_t* data, size_t count,
+      PMR_NS::memory_resource* mr);
 
   CMS(const CMS&) = delete;
   CMS& operator=(const CMS&) = delete;
@@ -35,7 +30,16 @@ class CMS {
   CMS(CMS&& other) noexcept;
   CMS& operator=(CMS&& other) noexcept;
 
-  ~CMS();
+  ~CMS() = default;
+
+  // Tag type to disambiguate CMS construction by error rate and probability.
+  struct ErrorRateTag {};
+
+  // Create a CMS from error rate and probability parameters.
+  // error: relative error (e.g. 0.01 for 1%), must be in (0, 1).
+  // probability: probability of exceeding the error, must be in (0, 1).
+  // width = ceil(e / error), depth = ceil(ln(1 / probability)).
+  CMS(ErrorRateTag, double error, double probability, PMR_NS::memory_resource* mr);
 
   // Increment the count for an item by the given value.
   // Returns the new estimated count for the item.
@@ -48,6 +52,9 @@ class CMS {
   // The other CMS must have the same dimensions.
   // Returns false if dimensions don't match.
   bool MergeFrom(const CMS& other, int64_t weight = 1);
+
+  // Reset all counters and total count to zero.
+  void Reset();
 
   // Accessors for CMS properties
   uint32_t width() const {
@@ -64,20 +71,22 @@ class CMS {
   }
 
   // Memory usage in bytes
-  size_t MallocUsed() const {
-    return size() * sizeof(int64_t);
+  size_t MallocUsed() const;
+
+  // For serialization - returns the raw counter data
+  size_t CounterBytes() const {
+    return counters_.size() * sizeof(int64_t);
+  }
+
+  const int64_t* Data() const {
+    return counters_.data();
   }
 
  private:
-  size_t size() const {
-    return static_cast<size_t>(width_) * depth_;
-  }
-
   uint32_t width_;
   uint32_t depth_;
-  PMR_NS::memory_resource* mr_ = nullptr;
   int64_t count_ = 0;  // Total count of all IncrBy operations
-  int64_t* counters_ = nullptr;
+  std::vector<int64_t, PMR_NS::polymorphic_allocator<int64_t>> counters_;
 };
 
 }  // namespace dfly

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -76,7 +76,7 @@ endif()
 
 # Optionally compile extension commands
 if (WITH_EXTENSION_CMDS)
-  list(APPEND DF_FAMILY_SRCS geo_family.cc hll_family.cc bitops_family.cc bloom_family.cc json_family.cc)
+  list(APPEND DF_FAMILY_SRCS geo_family.cc hll_family.cc bitops_family.cc bloom_family.cc cms_family.cc json_family.cc)
   add_definitions(-DWITH_EXTENSION_CMDS)
 endif()
 
@@ -154,6 +154,7 @@ helio_cxx_test(journal/journal_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(hll_family_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(string_stats_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(bloom_family_test dfly_test_lib LABELS DFLY)
+helio_cxx_test(cms_family_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(cluster/cluster_config_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(cluster/cluster_family_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(acl/acl_family_test dfly_test_lib LABELS DFLY)

--- a/src/server/acl/acl_family.h
+++ b/src/server/acl/acl_family.h
@@ -129,7 +129,7 @@ class AclFamily final {
                                       {"CONNECTION", CONNECTION},
                                       {"TRANSACTION", TRANSACTION},
                                       {"SCRIPTING", SCRIPTING},
-                                      // Uncomment when CMS family is added {"CMS", CMS},
+                                      {"CMS", CMS},
                                       {"BLOOM", BLOOM},
                                       {"FT_SEARCH", FT_SEARCH},
                                       {"SEARCH", FT_SEARCH},  // Alias for FT_SEARCH
@@ -144,7 +144,7 @@ class AclFamily final {
       "KEYSPACE",  "READ",      "WRITE",     "SET",       "SORTEDSET",  "LIST",        "HASH",
       "STRING",    "BITMAP",    "HYPERLOG",  "GEO",       "STREAM",     "PUBSUB",      "ADMIN",
       "FAST",      "SLOW",      "BLOCKING",  "DANGEROUS", "CONNECTION", "TRANSACTION", "SCRIPTING",
-      "_RESERVED", "_RESERVED", "_RESERVED", "_RESERVED", "_RESERVED",  "_RESERVED",   "_RESERVED",
+      "_RESERVED", "_RESERVED", "_RESERVED", "_RESERVED", "_RESERVED",  "_RESERVED",   "CMS",
       "BLOOM",     "FT_SEARCH", "THROTTLE",  "JSON"};
 
   // We need this to act as a const member, since the initialization of const data members

--- a/src/server/cms_family.cc
+++ b/src/server/cms_family.cc
@@ -1,0 +1,506 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "core/cms.h"
+#include "facade/cmd_arg_parser.h"
+#include "facade/error.h"
+#include "facade/reply_builder.h"
+#include "server/acl/acl_commands_def.h"
+#include "server/command_families.h"
+#include "server/command_registry.h"
+#include "server/conn_context.h"
+#include "server/db_slice.h"
+#include "server/engine_shard_set.h"
+#include "server/error.h"
+#include "server/transaction.h"
+
+namespace dfly {
+
+using namespace facade;
+using namespace std;
+
+namespace {
+
+constexpr char kCmsNotFound[] = "CMS: key does not exist";
+constexpr char kCmsWrongNumKeys[] = "CMS: wrong number of keys";
+constexpr char kCmsWrongNumKeysWeights[] = "CMS: wrong number of keys/weights";
+constexpr char kCmsCannotParseNumber[] = "CMS: Cannot parse number";
+
+OpStatus OpInitByDim(const OpArgs& op_args, string_view key, uint32_t width, uint32_t depth) {
+  auto& db_slice = op_args.GetDbSlice();
+  auto op_res = db_slice.AddOrFind(op_args.db_cntx, key, OBJ_CMS);
+  RETURN_ON_BAD_STATUS(op_res);
+
+  if (!op_res->is_new)
+    return OpStatus::KEY_EXISTS;
+
+  PrimeValue& pv = op_res->it->second;
+  pv.SetCMS(width, depth);
+
+  return OpStatus::OK;
+}
+
+OpStatus OpInitByProb(const OpArgs& op_args, string_view key, double error, double probability) {
+  auto& db_slice = op_args.GetDbSlice();
+  auto op_res = db_slice.AddOrFind(op_args.db_cntx, key, OBJ_CMS);
+  RETURN_ON_BAD_STATUS(op_res);
+
+  if (!op_res->is_new)
+    return OpStatus::KEY_EXISTS;
+
+  PrimeValue& pv = op_res->it->second;
+  CMS* cms = CompactObj::AllocateMR<CMS>(CMS::ErrorRateTag{}, error, probability,
+                                         CompactObj::memory_resource());
+  pv.SetCMS(cms);
+
+  return OpStatus::OK;
+}
+
+OpResult<vector<int64_t>> OpIncrBy(const OpArgs& op_args, string_view key,
+                                   const vector<pair<string_view, int64_t>>& items) {
+  auto& db_slice = op_args.GetDbSlice();
+  OpResult op_res = db_slice.FindMutable(op_args.db_cntx, key, OBJ_CMS);
+  if (!op_res)
+    return op_res.status();
+
+  CMS* cms = op_res->it->second.GetCMS();
+  vector<int64_t> result;
+  result.reserve(items.size());
+
+  for (const auto& [item, incr] : items) {
+    result.push_back(cms->IncrBy(item, incr));
+  }
+
+  return result;
+}
+
+OpResult<vector<int64_t>> OpQuery(const OpArgs& op_args, string_view key, CmdArgList items) {
+  auto& db_slice = op_args.GetDbSlice();
+  OpResult op_res = db_slice.FindReadOnly(op_args.db_cntx, key, OBJ_CMS);
+  if (!op_res)
+    return op_res.status();
+
+  const CMS* cms = op_res.value()->second.GetCMS();
+  vector<int64_t> result;
+  result.reserve(items.size());
+
+  for (auto arg : items) {
+    result.push_back(cms->Query(ToSV(arg)));
+  }
+
+  return result;
+}
+
+struct CmsInfo {
+  uint32_t width = 0;
+  uint32_t depth = 0;
+  int64_t count = 0;
+};
+
+OpResult<CmsInfo> OpInfo(const OpArgs& op_args, string_view key) {
+  auto& db_slice = op_args.GetDbSlice();
+  OpResult op_res = db_slice.FindReadOnly(op_args.db_cntx, key, OBJ_CMS);
+  if (!op_res)
+    return op_res.status();
+
+  const CMS* cms = op_res.value()->second.GetCMS();
+  return CmsInfo{cms->width(), cms->depth(), cms->total_count()};
+}
+
+void CmdInitByDim(CmdArgList args, CommandContext* cmd_cntx) {
+  CmdArgParser parser(args);
+  string_view key = parser.Next();
+  uint32_t width, depth;
+
+  tie(width, depth) = parser.Next<uint32_t, uint32_t>();
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+  RETURN_ON_PARSE_ERROR(parser, rb);
+
+  if (width == 0 || depth == 0) {
+    return rb->SendError("CMS: width and depth must be greater than 0");
+  }
+
+  const auto cb = [&](Transaction* t, EngineShard* shard) {
+    return OpInitByDim(t->GetOpArgs(shard), key, width, depth);
+  };
+
+  OpStatus res = cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));
+  if (res == OpStatus::KEY_EXISTS) {
+    return rb->SendError("item exists");
+  }
+  if (res == OpStatus::OK) {
+    return rb->SendOk();
+  }
+  return rb->SendError(res);
+}
+
+void CmdInitByProb(CmdArgList args, CommandContext* cmd_cntx) {
+  CmdArgParser parser(args);
+  string_view key = parser.Next();
+  double error, probability;
+
+  tie(error, probability) = parser.Next<double, double>();
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+  RETURN_ON_PARSE_ERROR(parser, rb);
+
+  if (error <= 0 || error >= 1) {
+    return rb->SendError("CMS: error must be between 0 and 1 exclusive");
+  }
+  if (probability <= 0 || probability >= 1) {
+    return rb->SendError("CMS: probability must be between 0 and 1 exclusive");
+  }
+
+  const auto cb = [&](Transaction* t, EngineShard* shard) {
+    return OpInitByProb(t->GetOpArgs(shard), key, error, probability);
+  };
+
+  OpStatus res = cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));
+  if (res == OpStatus::KEY_EXISTS) {
+    return rb->SendError("item exists");
+  }
+  if (res == OpStatus::OK) {
+    return rb->SendOk();
+  }
+  return rb->SendError(res);
+}
+
+void CmdIncrBy(CmdArgList args, CommandContext* cmd_cntx) {
+  string_view key = ArgS(args, 0);
+  args.remove_prefix(1);
+
+  // Parse item/increment pairs
+  if (args.size() < 2 || args.size() % 2 != 0) {
+    return cmd_cntx->SendError(kSyntaxErr);
+  }
+
+  vector<pair<string_view, int64_t>> items;
+  items.reserve(args.size() / 2);
+
+  for (size_t i = 0; i < args.size(); i += 2) {
+    string_view item = ToSV(args[i]);
+    int64_t incr;
+    if (!absl::SimpleAtoi(ToSV(args[i + 1]), &incr)) {
+      return cmd_cntx->SendError(kCmsCannotParseNumber);
+    }
+    if (incr <= 0) {
+      return cmd_cntx->SendError("CMS: increment must be a positive integer");
+    }
+    items.emplace_back(item, incr);
+  }
+
+  const auto cb = [&](Transaction* t, EngineShard* shard) {
+    return OpIncrBy(t->GetOpArgs(shard), key, items);
+  };
+
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+  OpResult<vector<int64_t>> res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
+  if (!res) {
+    if (res.status() == OpStatus::KEY_NOTFOUND) {
+      return rb->SendError(kCmsNotFound);
+    }
+    return rb->SendError(res.status());
+  }
+
+  SinkReplyBuilder::ReplyScope scope(rb);
+  rb->StartArray(res->size());
+  for (int64_t count : *res) {
+    rb->SendLong(count);
+  }
+}
+
+void CmdQuery(CmdArgList args, CommandContext* cmd_cntx) {
+  string_view key = ArgS(args, 0);
+  args.remove_prefix(1);
+
+  if (args.empty()) {
+    return cmd_cntx->SendError(kSyntaxErr);
+  }
+
+  const auto cb = [&](Transaction* t, EngineShard* shard) {
+    return OpQuery(t->GetOpArgs(shard), key, args);
+  };
+
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+  OpResult<vector<int64_t>> res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
+  if (!res) {
+    if (res.status() == OpStatus::KEY_NOTFOUND) {
+      return rb->SendError(kCmsNotFound);
+    }
+    return rb->SendError(res.status());
+  }
+
+  SinkReplyBuilder::ReplyScope scope(rb);
+  rb->StartArray(res->size());
+  for (int64_t count : *res) {
+    rb->SendLong(count);
+  }
+}
+
+void CmdInfo(CmdArgList args, CommandContext* cmd_cntx) {
+  string_view key = ArgS(args, 0);
+
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+
+  const auto cb = [&](Transaction* t, EngineShard* shard) {
+    return OpInfo(t->GetOpArgs(shard), key);
+  };
+
+  OpResult<CmsInfo> res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
+  if (!res) {
+    if (res.status() == OpStatus::KEY_NOTFOUND) {
+      return rb->SendError(kCmsNotFound);
+    }
+    return rb->SendError(res.status());
+  }
+
+  {
+    SinkReplyBuilder::ReplyScope scope(rb);
+    rb->StartArray(6);
+    rb->SendBulkString("width");
+    rb->SendLong(res->width);
+    rb->SendBulkString("depth");
+    rb->SendLong(res->depth);
+    rb->SendBulkString("count");
+    rb->SendLong(res->count);
+  }
+}
+
+// Structure to hold CMS data collected from a shard when merging
+struct CmsShardData {
+  size_t src_index = 0;
+  string_view key;
+  uint32_t width = 0;
+  uint32_t depth = 0;
+  int64_t count = 0;
+  vector<int64_t> counters;
+
+  CmsShardData(size_t src_idx, string_view k, uint32_t w, uint32_t d, int64_t c,
+               const int64_t* data, size_t size)
+      : src_index(src_idx), key(k), width(w), depth(d), count(c), counters(data, data + size) {
+  }
+};
+
+struct CmsMergeArgs {
+  string_view dest_key;
+  vector<string_view> src_keys;
+  vector<int64_t> weights;
+};
+
+bool ParseMergeArgs(CmdArgList args, RedisReplyBuilder* rb, CmsMergeArgs* out) {
+  CmdArgParser parser(args);
+  uint32_t num_keys;
+
+  out->dest_key = parser.Next();
+  num_keys = parser.Next<uint32_t>();
+  if (auto err = parser.TakeError(); err) {
+    rb->SendError(err.MakeReply());
+    return false;
+  }
+
+  if (num_keys == 0) {
+    rb->SendError(kCmsWrongNumKeys);
+    return false;
+  }
+
+  if (parser.Tail().size() < num_keys) {
+    rb->SendError(kSyntaxErr);
+    return false;
+  }
+
+  out->src_keys.reserve(num_keys);
+  for (uint32_t i = 0; i < num_keys; ++i) {
+    out->src_keys.push_back(parser.Next());
+  }
+
+  if (parser.HasNext()) {
+    string_view weights_kw = parser.Next();
+    if (!absl::EqualsIgnoreCase(weights_kw, "WEIGHTS")) {
+      rb->SendError(kCmsWrongNumKeysWeights);
+      return false;
+    }
+
+    out->weights.reserve(num_keys);
+    for (uint32_t i = 0; i < num_keys; ++i) {
+      if (!parser.HasNext()) {
+        rb->SendError(kCmsWrongNumKeysWeights);
+        return false;
+      }
+
+      int64_t weight;
+      if (!absl::SimpleAtoi(parser.Next(), &weight)) {
+        rb->SendError(kCmsCannotParseNumber);
+        return false;
+      }
+      out->weights.push_back(weight);
+    }
+  }
+
+  if (parser.HasNext()) {
+    rb->SendError(kCmsWrongNumKeysWeights);
+    return false;
+  }
+
+  if (out->weights.empty()) {
+    out->weights.resize(num_keys, 1);
+  }
+
+  return true;
+}
+
+// Merge multiple CMS structures into a destination key.
+void CmdMerge(CmdArgList args, CommandContext* cmd_cntx) {
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+  CmsMergeArgs merge_args;
+  if (!ParseMergeArgs(args, rb, &merge_args)) {
+    return;
+  }
+
+  // multi-shard implementation
+  // 1. fetch from all shards
+  // 2. merge to dest
+  Transaction* tx = cmd_cntx->tx();
+
+  vector<OpResult<vector<CmsShardData>>> shard_results(shard_set->size(), OpStatus::SKIPPED);
+
+  auto read_cb = [&](Transaction* t, EngineShard* shard) -> OpStatus {
+    auto& db_slice = t->GetOpArgs(shard).GetDbSlice();
+    const DbContext& db_cntx = t->GetDbContext();
+    vector<CmsShardData> cms_list;
+
+    // Check each source key to see if it belongs to this shard
+    for (size_t src_idx = 0; src_idx < merge_args.src_keys.size(); ++src_idx) {
+      string_view key = merge_args.src_keys[src_idx];
+      ShardId key_shard = Shard(key, shard_set->size());
+      if (key_shard != shard->shard_id()) {
+        continue;
+      }
+
+      OpResult src_res = db_slice.FindReadOnly(db_cntx, key, OBJ_CMS);
+      if (!src_res) {
+        shard_results[shard->shard_id()] = src_res.status();
+        return OpStatus::OK;
+      }
+
+      const CMS* cms = src_res.value()->second.GetCMS();
+      size_t counter_count = cms->CounterBytes() / sizeof(int64_t);
+      cms_list.emplace_back(src_idx, key, cms->width(), cms->depth(), cms->total_count(),
+                            cms->Data(), counter_count);
+    }
+
+    if (!cms_list.empty()) {
+      shard_results[shard->shard_id()] = std::move(cms_list);
+    }
+    return OpStatus::OK;
+  };
+
+  tx->Execute(read_cb, false /* do not conclude */);
+
+  // Validate dimensions and make sure we found data for every source.
+  uint32_t ref_width = 0, ref_depth = 0;
+  size_t seen_sources = 0;
+
+  // Check for errors and validate dimensions.
+  for (auto& result : shard_results) {
+    if (result.status() == OpStatus::SKIPPED)
+      continue;
+
+    if (!result) {
+      tx->Conclude();
+      if (result.status() == OpStatus::KEY_NOTFOUND) {
+        return rb->SendError(kCmsNotFound);
+      }
+      return rb->SendError(result.status());
+    }
+
+    for (auto& cms_data : result.value()) {
+      if (seen_sources == 0) {
+        ref_width = cms_data.width;
+        ref_depth = cms_data.depth;
+      } else if (cms_data.width != ref_width || cms_data.depth != ref_depth) {
+        tx->Conclude();
+        return rb->SendError("CMS: dimension mismatch");
+      }
+      ++seen_sources;
+    }
+  }
+
+  if (seen_sources != merge_args.src_keys.size()) {
+    tx->Conclude();
+    return rb->SendError(kCmsNotFound);
+  }
+
+  // Now write merged data to destination shard
+  ShardId dest_shard_id = Shard(merge_args.dest_key, shard_set->size());
+  OpStatus write_result = OpStatus::OK;
+
+  auto write_cb = [&](Transaction* t, EngineShard* shard) -> OpStatus {
+    if (shard->shard_id() != dest_shard_id) {
+      return OpStatus::OK;
+    }
+
+    auto& db_slice = t->GetOpArgs(shard).GetDbSlice();
+    OpResult dest_res = db_slice.FindMutable(t->GetDbContext(), merge_args.dest_key, OBJ_CMS);
+    if (!dest_res) {
+      write_result = dest_res.status();
+      return OpStatus::OK;
+    }
+
+    CMS* dest_cms = dest_res->it->second.GetCMS();
+
+    // Validate destination dimensions
+    if (ref_width != dest_cms->width() || ref_depth != dest_cms->depth()) {
+      write_result = OpStatus::INVALID_VALUE;
+      return OpStatus::OK;
+    }
+
+    // Reset destination before merging so the result is the weighted sum of sources only.
+    dest_cms->Reset();
+
+    for (const auto& result : shard_results) {
+      if (result.status() == OpStatus::SKIPPED)
+        continue;
+
+      for (const auto& cms_data : result.value()) {
+        CMS temp_cms(cms_data.width, cms_data.depth, cms_data.count, cms_data.counters.data(),
+                     cms_data.counters.size(), CompactObj::memory_resource());
+
+        if (!dest_cms->MergeFrom(temp_cms, merge_args.weights[cms_data.src_index])) {
+          write_result = OpStatus::INVALID_VALUE;
+          return OpStatus::OK;
+        }
+      }
+    }
+
+    return OpStatus::OK;
+  };
+
+  tx->Execute(write_cb, true /* conclude */);
+
+  if (write_result == OpStatus::KEY_NOTFOUND) {
+    return rb->SendError(kCmsNotFound);
+  }
+  if (write_result == OpStatus::INVALID_VALUE) {
+    return rb->SendError("CMS: dimension mismatch");
+  }
+  return rb->SendOk();
+}
+
+}  // namespace
+
+using CI = CommandId;
+
+#define HFUNC(x) SetHandler(&Cmd##x)
+
+void RegisterCmsFamily(CommandRegistry* registry) {
+  registry->StartFamily(acl::CMS);
+
+  *registry << CI{"CMS.INITBYDIM", CO::DENYOOM | CO::FAST, 4, 1, 1}.HFUNC(InitByDim)
+            << CI{"CMS.INITBYPROB", CO::DENYOOM | CO::FAST, 4, 1, 1}.HFUNC(InitByProb)
+            << CI{"CMS.INCRBY", CO::DENYOOM | CO::FAST, -4, 1, 1}.HFUNC(IncrBy)
+            << CI{"CMS.QUERY", CO::READONLY | CO::FAST, -3, 1, 1}.HFUNC(Query)
+            << CI{"CMS.INFO", CO::READONLY | CO::FAST, 2, 1, 1}.HFUNC(Info)
+            << CI{"CMS.MERGE", CO::DENYOOM | CO::VARIADIC_KEYS, -4, 3, 3}.HFUNC(Merge);
+}
+
+}  // namespace dfly

--- a/src/server/cms_family.h
+++ b/src/server/cms_family.h
@@ -1,0 +1,13 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+namespace dfly {
+
+class CommandRegistry;
+
+void RegisterCmsFamily(CommandRegistry*);
+
+}  // namespace dfly

--- a/src/server/cms_family_test.cc
+++ b/src/server/cms_family_test.cc
@@ -1,0 +1,204 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+#include "facade/facade_test.h"
+#include "server/test_utils.h"
+
+namespace dfly {
+
+using testing::ElementsAre;
+
+class CmsFamilyTest : public BaseFamilyTest {
+ protected:
+};
+
+TEST_F(CmsFamilyTest, InitByDim) {
+  auto resp = Run("cms.initbydim cms1 1000 5");
+  EXPECT_EQ(resp, "OK");
+  EXPECT_EQ(Run("type cms1"), "CMSk-TYPE");
+
+  resp = Run("cms.initbydim cms1 100 5");
+  EXPECT_THAT(resp, ErrArg("item exists"));
+
+  resp = Run("cms.initbydim cms2 0 5");
+  EXPECT_THAT(resp, ErrArg("width and depth must be greater than 0"));
+
+  resp = Run("cms.initbydim cms3 5 0");
+  EXPECT_THAT(resp, ErrArg("width and depth must be greater than 0"));
+}
+
+TEST_F(CmsFamilyTest, InitByProb) {
+  auto resp = Run("cms.initbyprob cms1 0.01 0.01");
+  EXPECT_EQ(resp, "OK");
+
+  resp = Run("cms.initbyprob cms1 0.01 0.01");
+  EXPECT_THAT(resp, ErrArg("item exists"));
+
+  resp = Run("cms.initbyprob cms2 2 0.01");
+  EXPECT_THAT(resp, ErrArg("error must be between 0 and 1"));
+
+  resp = Run("cms.initbyprob cms3 0.01 0");
+  EXPECT_THAT(resp, ErrArg("probability must be between 0 and 1"));
+}
+
+TEST_F(CmsFamilyTest, IncrBy) {
+  Run("cms.initbydim cms 100 5");
+
+  auto resp = Run("cms.incrby cms foo 3");
+  EXPECT_THAT(resp, IntArg(3));
+
+  resp = Run("cms.incrby cms foo 4 bar 1");
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(7), IntArg(1))));
+
+  // Should fail on non-existent key
+  resp = Run("cms.incrby noexist foo 1");
+  EXPECT_THAT(resp, ErrArg("CMS: key does not exist"));
+
+  // Should fail with invalid number
+  resp = Run("cms.incrby cms foo notanumber");
+  EXPECT_THAT(resp, ErrArg("CMS: Cannot parse number"));
+}
+
+TEST_F(CmsFamilyTest, Query) {
+  Run("cms.initbydim cms 100 5");
+  Run("cms.incrby cms foo 5 bar 3");
+
+  auto resp = Run("cms.query cms foo");
+  EXPECT_THAT(resp, IntArg(5));
+
+  resp = Run("cms.query cms foo bar");
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(5), IntArg(3))));
+
+  resp = Run("cms.query cms noexist");
+  EXPECT_THAT(resp, IntArg(0));
+
+  resp = Run("cms.query noexist foo");
+  EXPECT_THAT(resp, ErrArg("CMS: key does not exist"));
+}
+
+TEST_F(CmsFamilyTest, Info) {
+  Run("cms.initbydim cms 1000 5");
+  Run("cms.incrby cms foo 5 bar 3 baz 9");
+
+  auto resp = Run("cms.info cms");
+  EXPECT_THAT(
+      resp, RespArray(ElementsAre("width", IntArg(1000), "depth", IntArg(5), "count", IntArg(17))));
+
+  resp = Run("cms.info noexist");
+  EXPECT_THAT(resp, ErrArg("CMS: key does not exist"));
+}
+
+TEST_F(CmsFamilyTest, Merge) {
+  Run("cms.initbydim A 100 5");
+  Run("cms.initbydim B 100 5");
+  Run("cms.initbydim C 100 5");
+
+  Run("cms.incrby A foo 5 bar 3 baz 9");
+  Run("cms.incrby B foo 2 foobar 3 baz 1");
+
+  auto resp = Run("cms.query A foo bar baz");
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(5), IntArg(3), IntArg(9))));
+
+  resp = Run("cms.query B foo foobar baz");
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(2), IntArg(3), IntArg(1))));
+
+  resp = Run("cms.merge C 2 A B");
+  EXPECT_EQ(resp, "OK");
+
+  resp = Run("cms.query C foo bar baz foobar");
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(7), IntArg(3), IntArg(10), IntArg(3))));
+
+  resp = Run("cms.merge noexist 1 A");
+  EXPECT_THAT(resp, ErrArg("CMS: key does not exist"));
+
+  resp = Run("cms.merge C 0 A");
+  EXPECT_THAT(resp, ErrArg("CMS: wrong number of keys"));
+
+  resp = Run("cms.merge A 1 B WEIGHTS 4 3");
+  EXPECT_THAT(resp, ErrArg("CMS: wrong number of keys/weights"));
+
+  resp = Run("cms.merge A 2 B noexist WEIGHTS 4 3");
+  EXPECT_THAT(resp, ErrArg("CMS: key does not exist"));
+
+  // Merge A into B, should return A values (destination is reset before merge)
+  resp = Run("cms.merge B 1 A");
+  EXPECT_EQ(resp, "OK");
+  resp = Run("cms.query B foo bar baz");
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(5), IntArg(3), IntArg(9))));
+}
+
+TEST_F(CmsFamilyTest, MergeWithWeights) {
+  Run("cms.initbydim A 100 5");
+  Run("cms.initbydim B 100 5");
+  Run("cms.initbydim C 100 5");
+
+  Run("cms.incrby A foo 5 bar 3 baz 9");
+  Run("cms.incrby B foo 2 bar 3 baz 1");
+
+  // Merge with weights: A contributes 2x, B contributes 3x
+  // foo: 5*2 + 2*3 = 16
+  // bar: 3*2 + 3*3 = 15
+  // baz: 9*2 + 1*3 = 21
+  auto resp = Run("cms.merge C 2 A B WEIGHTS 2 3");
+  EXPECT_EQ(resp, "OK");
+
+  resp = Run("cms.query C foo bar baz");
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(16), IntArg(15), IntArg(21))));
+}
+
+TEST_F(CmsFamilyTest, MergeWithDuplicateSourceKeysPreservesWeightOrder) {
+  Run("cms.initbydim A 100 5");
+  Run("cms.initbydim C 100 5");
+
+  Run("cms.incrby A foo 2 bar 4");
+
+  auto resp = Run("cms.merge C 2 A A WEIGHTS 1 3");
+  EXPECT_EQ(resp, "OK");
+
+  resp = Run("cms.query C foo bar");
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(8), IntArg(16))));
+
+  resp = Run("cms.info C");
+  EXPECT_THAT(
+      resp, RespArray(ElementsAre("width", IntArg(100), "depth", IntArg(5), "count", IntArg(24))));
+}
+
+// Backported from tests/fakeredis/test/test_stack/test_cms.py::test_cms_info
+TEST_F(CmsFamilyTest, InfoAfterMerges) {
+  Run("cms.initbydim A 1000 5");
+  Run("cms.initbydim B 1000 5");
+  Run("cms.initbydim C 1000 5");
+
+  Run("cms.incrby A foo 5 bar 3 baz 9");
+  Run("cms.incrby B foo 2 bar 3 baz 1");
+
+  auto resp = Run("cms.query A foo bar baz");
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(5), IntArg(3), IntArg(9))));
+
+  resp = Run("cms.query B foo bar baz");
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(2), IntArg(3), IntArg(1))));
+
+  resp = Run("cms.merge C 2 A B");
+  EXPECT_EQ(resp, "OK");
+  resp = Run("cms.query C foo bar baz");
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(7), IntArg(6), IntArg(10))));
+
+  resp = Run("cms.merge C 2 A B WEIGHTS 1 2");
+  EXPECT_EQ(resp, "OK");
+  resp = Run("cms.query C foo bar baz");
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(9), IntArg(9), IntArg(11))));
+
+  resp = Run("cms.merge C 2 A B WEIGHTS 2 3");
+  EXPECT_EQ(resp, "OK");
+  resp = Run("cms.query C foo bar baz");
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(16), IntArg(15), IntArg(21))));
+
+  resp = Run("cms.info A");
+  EXPECT_THAT(
+      resp, RespArray(ElementsAre("width", IntArg(1000), "depth", IntArg(5), "count", IntArg(17))));
+
+  resp = Run("cms.info noexist");
+  EXPECT_THAT(resp, ErrArg("CMS: key does not exist"));
+}
+
+}  // namespace dfly

--- a/src/server/command_families.h
+++ b/src/server/command_families.h
@@ -16,6 +16,7 @@ void RegisterBitopsFamily(CommandRegistry*);
 void RegisterGeoFamily(CommandRegistry*);
 void RegisterHllFamily(CommandRegistry*);
 void RegisterBloomFamily(CommandRegistry*);
+void RegisterCmsFamily(CommandRegistry*);
 void RegisterJsonFamily(CommandRegistry*);
 
 }  // namespace dfly

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -3076,6 +3076,7 @@ void Service::RegisterCommands() {
   RegisterBitopsFamily(&registry_);
   RegisterHllFamily(&registry_);
   RegisterBloomFamily(&registry_);
+  RegisterCmsFamily(&registry_);
   RegisterJsonFamily(&registry_);
 #endif
 

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1656,8 +1656,8 @@ OpResult<KeyIndex> DetermineKeys(const CommandId* cid, CmdArgList args) {
       return OpStatus::SYNTAX_ERR;
     }
 
-    if (absl::EndsWith(name, "STORE"))
-      bonus = 0;  // Z<xxx>STORE <key> commands
+    if (absl::EndsWith(name, "STORE") || name == "CMS.MERGE")
+      bonus = 0;  // Z<xxx>STORE and CMS.MERGE <dest> commands
 
     unsigned num_keys_index;
     if (absl::StartsWith(name, "EVAL") || name == "BLMPOP" || name == "BZMPOP")

--- a/tests/fakeredis/test/test_stack/test_cms.py
+++ b/tests/fakeredis/test/test_stack/test_cms.py
@@ -6,11 +6,6 @@ from test import testtools
 json_tests = pytest.importorskip("probables")
 
 pytestmark = []
-pytestmark.extend(
-    [
-        pytest.mark.unsupported_server_types("dragonfly"),
-    ]
-)
 
 
 def test_cms_create(r: redis.Redis):
@@ -58,9 +53,7 @@ def test_cms_incrby(r: redis.Redis):
     with pytest.raises(redis.exceptions.ResponseError, match="CMS: key does not exist"):
         r.cms().incrby("noexist", ["foo", "bar"], [3, 4])
 
-    with pytest.raises(
-        redis.exceptions.ResponseError, match="CMS: Cannot parse number"
-    ):
+    with pytest.raises(redis.exceptions.ResponseError, match="CMS: Cannot parse number"):
         r.cms().incrby("cmsDim", ["foo", "bar"], [3, "four"])
 
 
@@ -76,8 +69,10 @@ def test_cms_merge(r: redis.Redis):
     with pytest.raises(redis.exceptions.ResponseError, match="CMS: key does not exist"):
         r.cms().merge("noexist", 1, ["cms2"])
 
+    # This shared test hard-coded one error string, but the FakeStrictRedis run can raise a different one.
     with pytest.raises(
-        redis.exceptions.ResponseError, match="CMS: wrong number of keys"
+        redis.exceptions.ResponseError,
+        match=r"CMS: (wrong number of keys|Number of keys must be positive)",
     ):
         r.cms().merge("cms2", 0, ["cmsDim"])
 
@@ -87,9 +82,7 @@ def test_cms_merge(r: redis.Redis):
     ):
         r.cms().merge("cms2", 1, [])
 
-    with pytest.raises(
-        redis.exceptions.ResponseError, match="CMS: wrong number of keys/weights"
-    ):
+    with pytest.raises(redis.exceptions.ResponseError, match="CMS: wrong number of keys/weights"):
         r.cms().merge("cmsDim", 1, ["cms2", "cms1"], [4, 3])
 
     with pytest.raises(redis.exceptions.ResponseError, match="CMS: key does not exist"):


### PR DESCRIPTION
Implements all CMS family functions in dragonfly.

* add cms family
* add unit tests
* small refactor cms.{h/cc}

This PR does not include rdb load/save and journal (write commands are not journaled atm) which will be added in the last PR (also cms.merge needs a journal rewrite)

Split from #6882
PR 2/3

