### PR TITLE
chore: add BullMQ/sidekiq tests, fix celery worker teardown timeout

### DIFF
--- a/tests/dragonfly/bull_sidekiq_test.py
+++ b/tests/dragonfly/bull_sidekiq_test.py
@@ -1,0 +1,89 @@
+import json
+import logging
+import time
+import uuid
+
+from redis import asyncio as aioredis
+
+# from bullmq import Queue
+# from . import dfly_args
+
+
+# BULLMQ_QUEUE_NAME = "{test_queue}"
+
+# @pytest.fixture
+# async def bullmq_queue(df_server):
+#     queue = Queue(BULLMQ_QUEUE_NAME, {"connection": {"host": "localhost", "port": df_server.port}})
+#     yield queue
+#     await queue.close()
+
+
+# @dfly_args({"lock_on_hashtags": True})
+# async def test_bullmq_push_jobs(async_client: aioredis.Redis, bullmq_queue: Queue):
+#     """Push 200 jobs and verify they are stored in Dragonfly."""
+#     for i in range(200):
+#         await bullmq_queue.add(
+#             "process_job",
+#             {"job_id": f"job{i}", "payload": f"data for job {i}"},
+#         )
+
+#     # BullMQ stores waiting jobs in a list key: bull:<queue_name>:wait
+#     wait_key = f"bull:{BULLMQ_QUEUE_NAME}:wait"
+#     queue_len = await async_client.llen(wait_key)
+#     assert queue_len == 200
+
+#     # Verify a job can be read back
+#     raw = await async_client.lindex(wait_key, 0)
+#     assert raw is not None
+#     mem_usage = await async_client.memory_usage(wait_key)
+#     logging.info(f"Queue '{wait_key}' MEMORY USAGE: {mem_usage:,} bytes ({queue_len} jobs)")
+
+
+def _make_sidekiq_job(i: int) -> str:
+    """Generate a job payload matching the Sidekiq wire format.
+
+    Verified against sidekiq/lib/sidekiq/client.rb (atomic_push) and
+    sidekiq/lib/sidekiq/job_util.rb (normalize_item).
+    """
+    jid = uuid.uuid4().hex[:24]  # SecureRandom.hex(12)
+    now = time.time()  # Time.now.to_f
+    return json.dumps(
+        {
+            "class": "ProcessJobWorker",
+            "args": [
+                f"job{i}",
+                {"user_id": 100000 + i, "action": "process", "priority": "normal"},
+            ],
+            "retry": True,
+            "queue": "default",
+            "jid": jid,
+            "created_at": now,
+            "enqueued_at": now,
+        }
+    )
+
+
+async def test_sidekiq_push_jobs(async_client: aioredis.Redis):
+    """Push 2000 Sidekiq jobs and verify they are stored correctly."""
+    queue_key = "queue:default"
+    num_jobs = 2000
+
+    pipe = async_client.pipeline()
+    for i in range(num_jobs):
+        pipe.lpush(queue_key, _make_sidekiq_job(i))
+    await pipe.execute()
+
+    queue_len = await async_client.llen(queue_key)
+    assert queue_len == num_jobs
+
+    # Verify readability
+    first = await async_client.lindex(queue_key, 0)
+    last = await async_client.lindex(queue_key, -1)
+    assert first is not None and last is not None
+    parsed = json.loads(first)
+    assert parsed["class"] == "ProcessJobWorker"
+
+    mem_usage = await async_client.memory_usage(queue_key)
+    logging.info(
+        f"Queue '{queue_key}' MEMORY USAGE: {mem_usage:,} bytes ({queue_len} Sidekiq jobs)"
+    )

--- a/tests/dragonfly/celery_test.py
+++ b/tests/dragonfly/celery_test.py
@@ -58,7 +58,10 @@ def celery_worker(celery_app):
     # Must explicitly stop the daemon to prevent it from entering a tight
     # reconnection spin loop when the test abruptly destroys the Redis socket.
     worker.stop()
-    t.join()
+    # Use a timeout because the worker thread may be blocked on socket.recv()
+    # in the kombu event loop and never notice the stop flag.
+    # The thread is a daemon, so it will be cleaned up on process exit.
+    t.join(timeout=10)
 
 
 async def test_celery_push_jobs(async_client: aioredis.Redis, celery_app):
@@ -70,6 +73,8 @@ async def test_celery_push_jobs(async_client: aioredis.Redis, celery_app):
 
     queue_len = await async_client.llen("my_queue")
     assert queue_len == 200
+    mem_usage = await async_client.memory_usage("my_queue")
+    logging.info(f"Queue 'my_queue' MEMORY USAGE: {mem_usage:,} bytes ({queue_len} jobs)")
 
 
 def test_celery_inspect(celery_app, celery_worker):

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -188,7 +188,7 @@ class DflyInstance:
             self._check_status()
             try:
                 self.get_port_from_psutil()
-                logging.debug(
+                logging.info(
                     f"Process {self.proc.pid} started after {time.time() - s:.2f} seconds. port={self.port}"
                 )
                 break
@@ -284,7 +284,7 @@ class DflyInstance:
             stdout=None if self.params.direct_output else subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )
-        logging.debug(f"Starting {real_path} {' '.join(all_args)}, pid {self.proc.pid}")
+        logging.info(f"Starting {real_path} {' '.join(all_args)}, pid {self.proc.pid}")
 
     def _check_status(self):
         if not self.params.existing_port:

--- a/tests/dragonfly/requirements.txt
+++ b/tests/dragonfly/requirements.txt
@@ -30,3 +30,4 @@ hiredis==2.4.0
 PyYAML>=6.0
 valkey>=6.0.2
 celery>=5.3.0
+# bullmq>=2.0.0


### PR DESCRIPTION
- Fix celery_worker fixture teardown: add timeout to t.join() to prevent
  hanging when worker thread is blocked on socket.recv()
- Log queue memory usage in test_celery_push_jobs
- Change instance.py startup logging from debug to info

- Add test_sidekiq_push_jobs: pushes 2000 jobs in Sidekiq wire format
  (verified against sidekiq/lib/sidekiq/client.rb)
- Sidekiq uses plain LPUSH to queue:default, no Lua scripts
- Added commented out bullmq test - unfortunately it does not work with python3.8 that we currently run in CI.

Signed-off-by: Roman Gershman <roman@dragonflydb.io>