### PR TITLE
[WIP] feat(server): Send tagged chunks

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -96,7 +96,7 @@ add_library(dragonfly_lib
             ${DF_CLUSTER_SRCS}
             acl/user.cc acl/user_registry.cc acl/acl_family.cc
             acl/validator.cc
-            sharding.cc cmd_support.cc)
+            sharding.cc cmd_support.cc tagged_chunk.cc)
 
 if (DF_ENABLE_MEMORY_TRACKING)
   target_compile_definitions(dragonfly_lib PRIVATE DFLY_ENABLE_MEMORY_TRACKING)
@@ -159,6 +159,7 @@ helio_cxx_test(cluster/cluster_family_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(acl/acl_family_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(engine_shard_set_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(serializer_base_test dfly_test_lib LABELS DFLY)
+helio_cxx_test(tagged_chunk_test dfly_test_lib LABELS DFLY)
 
 add_dependencies(check_dfly dragonfly_test json_family_test list_family_test
                  generic_family_test memcache_parser_test rdb_test journal_test

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -8,6 +8,7 @@
 #include "absl/strings/match.h"
 #include "facade/service_interface.h"
 #include "server/engine_shard.h"
+#include "server/tagged_chunk.h"
 
 extern "C" {
 #include "redis/rdb.h"
@@ -961,7 +962,15 @@ void DflyShardReplica::FullSyncDflyFb(std::string eof_token, BlockingCounter bc,
   rdb_loader_->SetOverrideExistingKeys(true);
 
   // Load incoming rdb stream.
-  if (std::error_code ec = rdb_loader_->Load(&ps); ec) {
+
+  io::Source* src = &ps;
+
+  TagStrippingSource tss{&ps};
+  if (master_context_.version >= DflyVersion::VER7) {
+    src = &tss;
+  }
+
+  if (std::error_code ec = rdb_loader_->Load(src); ec) {
     cntx->ReportError(ec, "Error loading rdb format");
     return;
   }

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -21,6 +21,7 @@
 #include "server/search/global_hnsw_index.h"
 #include "server/server_state.h"
 #include "server/tiered_storage.h"
+#include "tagged_chunk.h"
 #include "util/fibers/stacktrace.h"
 #include "util/fibers/synchronization.h"
 

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -78,6 +78,10 @@ bool SliceSnapshot::IsSnaphotInProgress() {
 void SliceSnapshot::Start(bool stream_journal, SnapshotFlush allow_flush) {
   DCHECK(!snapshot_fb_.IsJoinable());
 
+  if (replica_dfly_version_ >= DflyVersion::VER7 && stream_journal) {
+    send_tagged_chunks_ = true;
+  }
+
   auto db_cb = [this](DbIndex db_index, const DbSlice::ChangeReq& req) {
     OnDbChange(db_index, req);
   };
@@ -434,6 +438,13 @@ void SliceSnapshot::SerializeEntry(DbIndex db_indx, const PrimeKey& pk, const Pr
 void SliceSnapshot::HandleFlushData(std::string data) {
   if (data.empty())
     return;
+
+  if (send_tagged_chunks_) {
+    const uint32_t payload_size = data.size();
+    data.insert(0, 8, '\0');
+    absl::little_endian::Store32(data.data(), static_cast<uint32_t>(ChunkHeaderTag::Baseline));
+    absl::little_endian::Store32(data.data() + 4, payload_size);
+  }
 
   if (big_value_mu_.is_locked()) {
     ++stats_.flushed_under_lock;

--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -208,6 +208,8 @@ class SliceSnapshot : public journal::JournalConsumerInterface {
 
   SnapshotDataConsumerInterface* consumer_;
   ExecutionState* cntx_;
+
+  bool send_tagged_chunks_ = false;
 };
 
 }  // namespace dfly

--- a/src/server/tagged_chunk.cc
+++ b/src/server/tagged_chunk.cc
@@ -1,0 +1,72 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "server/tagged_chunk.h"
+
+#include <absl/container/inlined_vector.h>
+
+#include "base/endian.h"
+
+namespace dfly {
+
+absl::InlinedVector<iovec, 4> TagStrippingSource::GetCappedVec(const iovec* v, uint32_t len) const {
+  absl::InlinedVector<iovec, 4> capped(v, v + len);
+
+  size_t curr_index = 0;
+  uint32_t to_read = remaining_payload_bytes_;
+
+  for (; curr_index < len; ++curr_index) {
+    if (to_read <= v[curr_index].iov_len) {
+      capped[curr_index].iov_len = to_read;
+      break;
+    }
+
+    to_read -= v[curr_index].iov_len;
+  }
+
+  capped.resize(std::min(curr_index + 1, size_t{len}));
+
+  return capped;
+}
+
+io::Result<unsigned long> TagStrippingSource::ReadSome(const iovec* v, uint32_t len) {
+  while (remaining_payload_bytes_ == 0 && !eof_) {
+    if (auto header_read = ReadHeader(); !header_read) {
+      return header_read;
+    }
+  }
+
+  if (eof_) {
+    return 0;
+  }
+
+  // len is probably always 1
+  auto capped = GetCappedVec(v, len);
+  return upstream_->ReadSome(capped.data(), capped.size()).transform([&](auto size) {
+    remaining_payload_bytes_ -= size;
+    return size;
+  });
+}
+
+io::Result<unsigned long> TagStrippingSource::ReadHeader() {
+  const io::MutableBytes dest{reinterpret_cast<unsigned char*>(header_.data()), header_.size()};
+  return upstream_->ReadAtLeast(dest, 8).and_then([&](auto size) -> io::Result<unsigned long> {
+    if (size == 0) {
+      eof_ = true;
+      return size;
+    }
+
+    const uint32_t tag = absl::little_endian::Load32(dest.data());
+    const uint32_t payload_size = absl::little_endian::Load32(dest.data() + 4);
+
+    if (tag != static_cast<uint32_t>(ChunkHeaderTag::Baseline)) {
+      return nonstd::make_unexpected(std::make_error_code(std::errc::illegal_byte_sequence));
+    }
+
+    remaining_payload_bytes_ = payload_size;
+    return size;
+  });
+}
+
+}  // namespace dfly

--- a/src/server/tagged_chunk.h
+++ b/src/server/tagged_chunk.h
@@ -1,0 +1,38 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <absl/container/inlined_vector.h>
+
+#include <array>
+#include <cstdint>
+
+#include "io/io.h"
+
+namespace dfly {
+
+enum class ChunkHeaderTag {
+  Baseline = 0,
+};
+
+class TagStrippingSource : public io::Source {
+ public:
+  explicit TagStrippingSource(Source* upstream) : upstream_{upstream} {
+  }
+
+  io::Result<unsigned long> ReadSome(const iovec* v, uint32_t len) override;
+
+ private:
+  io::Result<unsigned long> ReadHeader();
+  absl::InlinedVector<iovec, 4> GetCappedVec(const iovec* v, uint32_t len) const;
+
+  Source* upstream_;
+  std::array<char, 8> header_{};
+
+  uint32_t remaining_payload_bytes_ = 0;
+  bool eof_{false};
+};
+
+}  // namespace dfly

--- a/src/server/tagged_chunk_test.cc
+++ b/src/server/tagged_chunk_test.cc
@@ -1,0 +1,49 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "server/tagged_chunk.h"
+
+#include "base/endian.h"
+#include "base/gtest.h"
+#include "base/logging.h"
+
+using namespace dfly;
+
+namespace {
+
+void AppendStringWithHeader(std::string_view msg, std::string* out) {
+  std::string payload{msg};
+  const uint32_t sz = msg.size();
+  payload.insert(0, 8, '\0');
+  absl::little_endian::Store32(payload.data(), 0);
+  absl::little_endian::Store32(payload.data() + 4, sz);
+  out->append(payload);
+}
+
+}  // namespace
+
+TEST(TagStrippingSource, SimpleStream) {
+  std::string payload;
+  AppendStringWithHeader("", &payload);
+  AppendStringWithHeader("this is a string", &payload);
+  AppendStringWithHeader("this is another string", &payload);
+
+  io::BytesSource upstream{payload};
+  TagStrippingSource source{&upstream};
+
+  std::string output;
+  uint8_t buffer[4];
+
+  iovec v{buffer, 4};
+
+  size_t n = 0;
+  do {
+    auto result = source.ReadSome(&v, 1);
+    EXPECT_TRUE(result);
+    n = result.value();
+    output.append(reinterpret_cast<const char*>(buffer), n);
+  } while (n > 0);
+
+  EXPECT_EQ(output, "this is a stringthis is another string");
+}

--- a/src/server/version.h
+++ b/src/server/version.h
@@ -42,6 +42,8 @@ enum class DflyVersion {
   // - hnsw-index-metadata AUX field
   VER6,
 
+  // Sends tagged chunks to replicas to differentiate between journal and baseline data.
+  VER7,
   // Always points to the latest version
   CURRENT_VER = VER6,
 };

--- a/src/server/version.h
+++ b/src/server/version.h
@@ -45,7 +45,7 @@ enum class DflyVersion {
   // Sends tagged chunks to replicas to differentiate between journal and baseline data.
   VER7,
   // Always points to the latest version
-  CURRENT_VER = VER6,
+  CURRENT_VER = VER7,
 };
 
 }  // namespace dfly


### PR DESCRIPTION
* Master sends a tag in header to replica if:
  * the replica version is `>=` 7 and
  * the stream journal arg is true (to differentiate from rdb file save code path)
* A new IO source is passed to rdb loader. It reads and removes the header if present
* Right now the tag is only set to 0. It is not used by the replica, just parsed and validated.

FIXES https://github.com/dragonflydb/dragonfly/issues/6831