### PR TITLE
fix(search): two crash fixes — non-finite NUMERIC values and KeepTopKSorted OOB

### DIFF
--- a/src/core/search/base.cc
+++ b/src/core/search/base.cc
@@ -20,7 +20,7 @@ std::string& QueryParams::operator[](std::string_view k) {
 
 std::optional<double> ParseNumericField(std::string_view value) {
   double value_as_double;
-  if (absl::SimpleAtod(value, &value_as_double))
+  if (absl::SimpleAtod(value, &value_as_double) && std::isfinite(value_as_double))
     return value_as_double;
   return std::nullopt;
 }

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -788,6 +788,10 @@ SearchResult ShardDocIndex::Search(const OpArgs& op_args, const SearchParams& pa
       sort_scores = idx->Sort(&result.ids, limit, so.order == SortOrder::DESC);
     } else {
       sort_scores = KeepTopKSorted(&result.ids, limit, so, op_args);
+      // KeepTopKSorted only fills the first sort_scores.size() entries of result.ids;
+      // trim the rest to avoid out-of-bounds access on sort_scores in the loop below.
+      if (!sort_scores.empty())
+        result.ids.resize(sort_scores.size());
       if (params.ShouldReturnAllFields())
         return_fields.push_back(so.field);
     }

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -4414,4 +4414,46 @@ TEST_F(SearchFamilyTest, VectorFieldWrongSizeDoesNotCrash) {
   EXPECT_THAT(resp, Not(ErrArg("")));
 }
 
+TEST_F(SearchFamilyTest, SortBySkipsDocsWithoutSortField) {
+  // KeepTopKSorted skips docs that don't have the sort field, returning fewer sort scores
+  // than result.ids.size(). The loop then accesses sort_scores[i] out-of-bounds.
+  Run({"FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "val", "NUMERIC"});
+
+  Run({"HSET", "valid:1", "val", "123"});
+  Run({"HSET", "valid:2", "val", "456"});
+  Run({"HSET", "valid:3", "val", "789"});
+
+  // These docs are indexed (no prefix restriction) but lack the sort field.
+  // They appear in '*' search results but are skipped by KeepTopKSorted.
+  for (int i = 0; i < 97; i++)
+    Run({"HSET", absl::StrCat("nofield:", i), "txt", "garbage"});
+
+  auto resp = Run({"FT.SEARCH", "idx", "*", "SORTBY", "val", "LIMIT", "0", "100"});
+  auto vec = resp.GetVec();
+
+  // Extract doc keys from the response (indices 1, 3, 5, ...).
+  vector<string> keys;
+  for (size_t i = 1; i < vec.size(); i += 2)
+    keys.push_back(vec[i].GetString());
+
+  EXPECT_THAT(keys, ElementsAre("valid:1", "valid:2", "valid:3"));
+}
+
+TEST_F(SearchFamilyTest, NumericIndexRejectsNonFiniteValues) {
+  // Regression test: HSET with inf/nan values on a NUMERIC field used to crash with
+  // DCHECK(std::isfinite(value)) in RangeTree::Add, because absl::SimpleAtod accepts
+  // "inf", "-inf", "nan" etc. as valid doubles.
+  Run({"FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "val", "NUMERIC"});
+
+  Run({"HSET", "doc:1", "val", "inf"});
+  Run({"HSET", "doc:2", "val", "-inf"});
+  Run({"HSET", "doc:3", "val", "+inf"});
+  Run({"HSET", "doc:4", "val", "nan"});
+  Run({"HSET", "doc:5", "val", "42"});  // finite — must still be indexed
+
+  // Non-finite docs are not in the numeric index; only doc:5 should match the range query.
+  auto resp = Run({"FT.SEARCH", "idx", "@val:[-inf +inf]"});
+  EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(1), "doc:5", _)));
+}
+
 }  // namespace dfly


### PR DESCRIPTION
1. Reject non-finite values in NUMERIC fields: (`src/core/search/base.cc`) `absl::SimpleAtod` accepts `"inf"`, `"-inf"`, `"nan"` etc. as valid doubles. `ParseNumericField` passed them through to `RangeTree::Add` which asserts `std::isfinite(value)` → SIGABRT. Non-finite values are now silently ignored (document is not indexed for that field), consistent with unparseable values.

2. Trim result ids after `KeepTopKSorted`: (`src/server/search/doc_index.cc`) `KeepTopKSorted` skips documents that lack the SORTBY field, so `sort_scores.size()` can be less than `result.ids.size()`. The subsequent loop accessed `sort_scores[i]` out-of-bounds → SIGSEGV or SIGABRT (`std::length_error` → `LOG(FATAL)`). Fixed by resizing `result.ids` to `sort_scores.size()` when non-empty.

Fixes #6909