### PR TITLE
fix(CI): conditionally use pip flags

### DIFF
--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -59,7 +59,12 @@ runs:
       shell: bash
       run: |
         cd ${GITHUB_WORKSPACE}/tests
-        pip3 install --break-system-packages -r dragonfly/requirements.txt
+        # https://peps.python.org/pep-0668/#keep-the-marker-file-in-container-images
+        if compgen -G '/usr/lib/python3.*/EXTERNALLY-MANAGED' > /dev/null; then
+          pip3 install --break-system-packages -r dragonfly/requirements.txt
+        else
+          pip3 install -r dragonfly/requirements.txt
+        fi
 
     - name: Run S3 snapshot tests with MinIO
       if: inputs.s3-bucket != ''


### PR DESCRIPTION
Avoids applying `--break-system-packages` on distros which are old and where pip does not have this option such as ubuntu-20