### PR TITLE
chore: stack reduction and small helio clean-ups

### DIFF
--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -240,7 +240,6 @@ bool MultiCommandSquasher::ExecuteSquashed(facade::RedisReplyBuilder* rb) {
   base::SpinLock lock;
   uint64_t fiber_running_cycles{0}, proactor_running_cycles{0};
   uint32_t max_sched_thread_id{0}, max_sched_seq_num{0};
-  vector<string> past_fibers;
 
   // Atomic transactions (that have all keys locked) perform hops and run squashed commands via
   // stubs, non-atomic ones just run the commands in parallel.
@@ -272,7 +271,6 @@ bool MultiCommandSquasher::ExecuteSquashed(facade::RedisReplyBuilder* rb) {
             proactor_running_cycles = ProactorBase::me()->GetCurrentBusyCycles();
             max_sched_thread_id = ProactorBase::me()->GetPoolIndex();
             max_sched_seq_num = fb2::GetFiberRunSeq();
-            past_fibers = fb2::GetPastFiberNames();
           }
           break;
         }
@@ -340,9 +338,7 @@ bool MultiCommandSquasher::ExecuteSquashed(facade::RedisReplyBuilder* rb) {
         << "Total/Fanout/MaxSchedTime/ThreadCbTime/ThreadId/FiberCbTime/FiberSeq/"
         << "MaxExecTime: " << total_usec << "/" << num_shards_ << "/" << max_sched_usec << "/"
         << proactor_running_usec << "/" << max_sched_thread_id << "/" << fiber_running_usec << "/"
-        << "/" << max_sched_seq_num << "/" << max_exec_usec
-        << "\n past fibers: " << absl::StrJoin(past_fibers, ", ")
-        << "\ncoordinator thread running time: "
+        << "/" << max_sched_seq_num << "/" << max_exec_usec << "\ncoordinator thread running time: "
         << CycleClock::ToUsec(ProactorBase::me()->GetCurrentBusyCycles());
   }
 

--- a/src/server/tiering/disk_storage.cc
+++ b/src/server/tiering/disk_storage.cc
@@ -12,6 +12,7 @@
 #include "server/error.h"
 #include "server/tiering/common.h"
 #include "server/tiering/external_alloc.h"
+#include "util/fibers/uring_file.h"
 #include "util/fibers/uring_proactor.h"
 
 using namespace ::dfly::tiering::literals;
@@ -28,25 +29,27 @@ using namespace ::util::fb2;
 
 namespace {
 
-UringBuf AllocateTmpBuf(size_t size) {
+constexpr unsigned kHeapSliceId = UINT_MAX;
+
+RegisteredSlice AllocateTmpBuf(size_t size) {
   size = (size + kPageSize - 1) / kPageSize * kPageSize;
   VLOG(2) << "Fallback to temporary allocation: " << size;
 
   uint8_t* buf = new (align_val_t(kPageSize)) uint8_t[size];
-  return UringBuf{{buf, size}, nullopt};
+  return RegisteredSlice{{buf, size}, kHeapSliceId};
 }
 
-void DestroyTmpBuf(UringBuf buf) {
-  DCHECK(!buf.buf_idx);
+void DestroyTmpBuf(RegisteredSlice buf) {
+  DCHECK_EQ(buf.buf_idx, kHeapSliceId);
   ::operator delete[](buf.bytes.data(), align_val_t(kPageSize));
 }
 
-void ReturnBuf(UringBuf buf) {
+void ReturnBuf(RegisteredSlice buf) {
   DCHECK_EQ(ProactorBase::me()->GetKind(), ProactorBase::IOURING);
   auto* up = static_cast<UringProactor*>(ProactorBase::me());
 
-  if (buf.buf_idx)
-    up->ReturnBuffer(buf);
+  if (buf.buf_idx != kHeapSliceId)
+    up->ReturnRegisteredSlice(buf);
   else
     DestroyTmpBuf(buf);
 }
@@ -64,6 +67,9 @@ template <typename... Ts> error_code DoFiberCall(void (SubmitEntry::*c)(Ts...), 
 }  // anonymous namespace
 
 DiskStorage::DiskStorage(size_t max_size) : max_size_(max_size) {
+}
+
+DiskStorage::~DiskStorage() {
 }
 
 error_code DiskStorage::Open(string_view path) {
@@ -121,7 +127,7 @@ void DiskStorage::Read(DiskSegment segment, ReadCb cb) {
   DCHECK_EQ(segment.offset % kPageSize, 0u);
 
   size_t len = segment.length;
-  UringBuf buf = PrepareBuf(len);
+  RegisteredSlice buf = PrepareBuf(len);
   auto io_cb = [this, cb = std::move(cb), buf, len](int io_res) {
     if (io_res < 0) {
       cb(nonstd::make_unexpected(error_code{-io_res, system_category()}));
@@ -133,8 +139,8 @@ void DiskStorage::Read(DiskSegment segment, ReadCb cb) {
   };
 
   pending_ops_++;
-  if (buf.buf_idx)
-    backing_file_->ReadFixedAsync(buf.bytes, segment.offset, *buf.buf_idx, std::move(io_cb));
+  if (buf.buf_idx != kHeapSliceId)
+    backing_file_->ReadFixedAsync(buf.bytes, segment.offset, buf.buf_idx, std::move(io_cb));
   else
     backing_file_->ReadAsync(buf.bytes, segment.offset, std::move(io_cb));
 }
@@ -146,7 +152,7 @@ void DiskStorage::MarkAsFree(DiskSegment segment) {
   alloc_.Free(segment.offset, segment.length);
 }
 
-io::Result<std::pair<size_t, UringBuf>> DiskStorage::PrepareStash(size_t length) {
+io::Result<std::pair<size_t, RegisteredSlice>> DiskStorage::PrepareStash(size_t length) {
   using namespace nonstd;
 
   int64_t offset = alloc_.Malloc(length);
@@ -168,8 +174,8 @@ io::Result<std::pair<size_t, UringBuf>> DiskStorage::PrepareStash(size_t length)
   return std::make_pair(offset, PrepareBuf(length));
 }
 
-void DiskStorage::Stash(DiskSegment segment, UringBuf buf, StashCb cb) {
-  auto io_cb = [this, cb, buf, segment](int io_res) {
+void DiskStorage::Stash(DiskSegment segment, RegisteredSlice buf, StashCb cb) {
+  auto io_cb = [this, cb = std::move(cb), buf, segment](int io_res) {
     if (io_res < 0) {
       MarkAsFree(segment);
       cb(error_code{-io_res, std::system_category()});
@@ -182,8 +188,8 @@ void DiskStorage::Stash(DiskSegment segment, UringBuf buf, StashCb cb) {
 
   pending_ops_++;
   size_t offset = segment.offset;
-  if (buf.buf_idx)
-    backing_file_->WriteFixedAsync(buf.bytes, offset, *buf.buf_idx, std::move(io_cb));
+  if (buf.buf_idx != kHeapSliceId)
+    backing_file_->WriteFixedAsync(buf.bytes, offset, buf.buf_idx, std::move(io_cb));
   else
     backing_file_->WriteAsync(buf.bytes, offset, std::move(io_cb));
 
@@ -232,11 +238,11 @@ error_code DiskStorage::RequestGrow(off_t grow_size) {
   return {};
 }
 
-UringBuf DiskStorage::PrepareBuf(size_t size) {
+RegisteredSlice DiskStorage::PrepareBuf(size_t size) {
   DCHECK_EQ(ProactorBase::me()->GetKind(), ProactorBase::IOURING);
   auto* up = static_cast<UringProactor*>(ProactorBase::me());
 
-  if (auto borrowed = up->RequestBuffer(size); borrowed) {
+  if (auto borrowed = up->RequestRegisteredSlice(size); borrowed) {
     ++reg_buf_alloc_cnt_;
     return *borrowed;
   }

--- a/src/server/tiering/disk_storage.h
+++ b/src/server/tiering/disk_storage.h
@@ -9,8 +9,11 @@
 #include "io/io.h"
 #include "server/tiering/common.h"
 #include "server/tiering/external_alloc.h"
-#include "util/fibers/uring_file.h"
-#include "util/fibers/uring_proactor.h"  // for UringBuf
+#include "util/fibers/uring_types.h"
+
+namespace util::fb2 {
+class LinuxFile;
+}  // namespace util::fb2
 
 namespace dfly::tiering {
 
@@ -32,6 +35,7 @@ class DiskStorage {
   using StashCb = std::function<void(std::error_code)>;
 
   explicit DiskStorage(size_t max_size);
+  ~DiskStorage();
 
   std::error_code Open(std::string_view path);
   void Close();
@@ -45,10 +49,11 @@ class DiskStorage {
   // Allocate segment of at least given length and prepare buffer. Might block to grow backing file.
   // Return error if not enough space is available or growing failed.
   // Every successful preparation must end in a Stash(), otherwise resources are leaked.
-  io::Result<std::pair<size_t /* offset */, util::fb2::UringBuf>> PrepareStash(size_t length);
+  io::Result<std::pair<size_t /* offset */, util::fb2::RegisteredSlice>> PrepareStash(
+      size_t length);
 
   // Write prepared buffer to given segment and resolve completion callback when write is done.
-  void Stash(DiskSegment segment, util::fb2::UringBuf buf, StashCb cb);
+  void Stash(DiskSegment segment, util::fb2::RegisteredSlice buf, StashCb cb);
 
   Stats GetStats() const;
 
@@ -57,7 +62,7 @@ class DiskStorage {
   std::error_code RequestGrow(off_t grow_size);
 
   // Returns a buffer with size greater or equal to len.
-  util::fb2::UringBuf PrepareBuf(size_t len);
+  util::fb2::RegisteredSlice PrepareBuf(size_t len);
 
   off_t max_size_;
   size_t pending_ops_ = 0;  // number of ongoing ops for safe shutdown

--- a/src/server/tiering/op_manager.cc
+++ b/src/server/tiering/op_manager.cc
@@ -79,7 +79,8 @@ void OpManager::DeleteOffloaded(DiskSegment segment) {
   }
 }
 
-void OpManager::Stash(PendingId id_ref, tiering::DiskSegment segment, util::fb2::UringBuf buf) {
+void OpManager::Stash(PendingId id_ref, tiering::DiskSegment segment,
+                      util::fb2::RegisteredSlice buf) {
   auto id = ToOwned(id_ref);
   unsigned version = ++pending_stash_counter_;
   pending_stash_ver_[id] = version;

--- a/src/server/tiering/op_manager.h
+++ b/src/server/tiering/op_manager.h
@@ -9,6 +9,7 @@
 
 #include <variant>
 
+#include "base/function2.hpp"
 #include "server/tiering/common.h"
 #include "server/tiering/decoders.h"
 #include "server/tiering/disk_storage.h"
@@ -62,7 +63,7 @@ class OpManager {
   }
 
   // Stash value to be offloaded. It is opaque to OpManager.
-  void Stash(PendingId id, tiering::DiskSegment segment, util::fb2::UringBuf buf);
+  void Stash(PendingId id, tiering::DiskSegment segment, util::fb2::RegisteredSlice buf);
 
   // PrepareStash + Stash via function
   std::error_code PrepareAndStash(

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -2965,47 +2965,53 @@ void ZSetFamily::Register(CommandRegistry* registry) {
       CO::JOURNALED | CO::VARIADIC_KEYS | CO::DENYOOM | CO::NO_AUTOJOURNAL;
   registry->StartFamily(acl::SORTEDSET);
   // TODO: to add support for SCRIPT for BZPOPMIN, BZPOPMAX similarly to BLPOP.
-  *registry
-      << CI{"ZADD", CO::FAST | CO::JOURNALED | CO::DENYOOM, -4, 1, 1}.HFUNC(ZAdd)
-      << CI{"BZPOPMIN", CO::JOURNALED | CO::NOSCRIPT | CO::BLOCKING | CO::NO_AUTOJOURNAL, -3, 1, -2}
-             .HFUNC(BZPopMin)
-      << CI{"BZPOPMAX", CO::JOURNALED | CO::NOSCRIPT | CO::BLOCKING | CO::NO_AUTOJOURNAL, -3, 1, -2}
-             .HFUNC(BZPopMax)
-      << CI{"ZCARD", CO::FAST | CO::READONLY, 2, 1, 1}.HFUNC(ZCard)
-      << CI{"ZCOUNT", CO::FAST | CO::READONLY, 4, 1, 1}.HFUNC(ZCount)
-      << CI{"ZDIFF", CO::READONLY | CO::VARIADIC_KEYS, -3, 2, 2}.HFUNC(ZDiff)
-      << CI{"ZDIFFSTORE", kStoreMask, -4, 3, 3}.HFUNC(ZDiffStore)
-      << CI{"ZINCRBY", CO::FAST | CO::JOURNALED, 4, 1, 1}.HFUNC(ZIncrBy)
-      << CI{"ZINTERSTORE", kStoreMask, -4, 3, 3}.HFUNC(ZInterStore)
-      << CI{"ZINTER", CO::READONLY | CO::VARIADIC_KEYS, -3, 2, 2}.HFUNC(ZInter)
-      << CI{"ZINTERCARD", CO::READONLY | CO::VARIADIC_KEYS, -3, 2, 2}.HFUNC(ZInterCard)
-      << CI{"ZLEXCOUNT", CO::READONLY, 4, 1, 1}.HFUNC(ZLexCount)
-      << CI{"ZMPOP", CO::JOURNALED | CO::VARIADIC_KEYS | CO::NO_AUTOJOURNAL, -4, 2, 2}.HFUNC(ZMPop)
-      << CI{"BZMPOP", CO::JOURNALED | CO::VARIADIC_KEYS | CO::BLOCKING | CO::NO_AUTOJOURNAL, -5, 3,
-            3}
-             .HFUNC(BZMPop)
-      << CI{"ZPOPMAX", CO::FAST | CO::JOURNALED, -2, 1, 1}.HFUNC(ZPopMax)
-      << CI{"ZPOPMIN", CO::FAST | CO::JOURNALED, -2, 1, 1}.HFUNC(ZPopMin)
-      << CI{"ZREM", CO::FAST | CO::JOURNALED, -3, 1, 1}.HFUNC(ZRem)
-      << CI{"ZRANGE", CO::READONLY, -4, 1, 1}.HFUNC(ZRange)
-      << CI{"ZRANDMEMBER", CO::READONLY, -2, 1, 1}.HFUNC(ZRandMember)
-      << CI{"ZRANK", CO::READONLY | CO::FAST, -3, 1, 1}.HFUNC(ZRank)
-      << CI{"ZRANGEBYLEX", CO::READONLY, -4, 1, 1}.HFUNC(ZRangeByLex)
-      << CI{"ZRANGEBYSCORE", CO::READONLY, -4, 1, 1}.HFUNC(ZRangeByScore)
-      << CI{"ZRANGESTORE", CO::JOURNALED | CO::DENYOOM | CO::NO_AUTOJOURNAL, -5, 1, 2}.HFUNC(
-             ZRangeStore)
-      << CI{"ZSCORE", CO::READONLY | CO::FAST, 3, 1, 1}.HFUNC(ZScore)
-      << CI{"ZMSCORE", CO::READONLY | CO::FAST, -3, 1, 1}.HFUNC(ZMScore)
-      << CI{"ZREMRANGEBYRANK", CO::JOURNALED, 4, 1, 1}.HFUNC(ZRemRangeByRank)
-      << CI{"ZREMRANGEBYSCORE", CO::JOURNALED, 4, 1, 1}.HFUNC(ZRemRangeByScore)
-      << CI{"ZREMRANGEBYLEX", CO::JOURNALED, 4, 1, 1}.HFUNC(ZRemRangeByLex)
-      << CI{"ZREVRANGE", CO::READONLY, -4, 1, 1}.HFUNC(ZRevRange)
-      << CI{"ZREVRANGEBYLEX", CO::READONLY, -4, 1, 1}.HFUNC(ZRevRangeByLex)
-      << CI{"ZREVRANGEBYSCORE", CO::READONLY, -4, 1, 1}.HFUNC(ZRevRangeByScore)
-      << CI{"ZREVRANK", CO::READONLY | CO::FAST, -3, 1, 1}.HFUNC(ZRevRank)
-      << CI{"ZSCAN", CO::READONLY, -3, 1, 1}.HFUNC(ZScan)
-      << CI{"ZUNION", CO::READONLY | CO::VARIADIC_KEYS, -3, 2, 2}.HFUNC(ZUnion)
-      << CI{"ZUNIONSTORE", kStoreMask, -4, 3, 3}.HFUNC(ZUnionStore);
+  // We break up chain into multiple calls to reduce stack usage in this function.
+  *registry << CI{"ZADD", CO::FAST | CO::JOURNALED | CO::DENYOOM, -4, 1, 1}.HFUNC(ZAdd)
+            << CI{"BZPOPMIN", CO::JOURNALED | CO::NOSCRIPT | CO::BLOCKING | CO::NO_AUTOJOURNAL, -3,
+                  1, -2}
+                   .HFUNC(BZPopMin)
+            << CI{"BZPOPMAX", CO::JOURNALED | CO::NOSCRIPT | CO::BLOCKING | CO::NO_AUTOJOURNAL, -3,
+                  1, -2}
+                   .HFUNC(BZPopMax)
+            << CI{"ZCARD", CO::FAST | CO::READONLY, 2, 1, 1}.HFUNC(ZCard)
+            << CI{"ZCOUNT", CO::FAST | CO::READONLY, 4, 1, 1}.HFUNC(ZCount)
+            << CI{"ZDIFF", CO::READONLY | CO::VARIADIC_KEYS, -3, 2, 2}.HFUNC(ZDiff);
+
+  *registry << CI{"ZDIFFSTORE", kStoreMask, -4, 3, 3}.HFUNC(ZDiffStore)
+            << CI{"ZINCRBY", CO::FAST | CO::JOURNALED, 4, 1, 1}.HFUNC(ZIncrBy)
+            << CI{"ZINTERSTORE", kStoreMask, -4, 3, 3}.HFUNC(ZInterStore)
+            << CI{"ZINTER", CO::READONLY | CO::VARIADIC_KEYS, -3, 2, 2}.HFUNC(ZInter)
+            << CI{"ZINTERCARD", CO::READONLY | CO::VARIADIC_KEYS, -3, 2, 2}.HFUNC(ZInterCard)
+            << CI{"ZLEXCOUNT", CO::READONLY, 4, 1, 1}.HFUNC(ZLexCount)
+            << CI{"ZMPOP", CO::JOURNALED | CO::VARIADIC_KEYS | CO::NO_AUTOJOURNAL, -4, 2, 2}.HFUNC(
+                   ZMPop)
+            << CI{"BZMPOP", CO::JOURNALED | CO::VARIADIC_KEYS | CO::BLOCKING | CO::NO_AUTOJOURNAL,
+                  -5, 3, 3}
+                   .HFUNC(BZMPop);
+
+  *registry << CI{"ZPOPMAX", CO::FAST | CO::JOURNALED, -2, 1, 1}.HFUNC(ZPopMax)
+            << CI{"ZPOPMIN", CO::FAST | CO::JOURNALED, -2, 1, 1}.HFUNC(ZPopMin)
+            << CI{"ZREM", CO::FAST | CO::JOURNALED, -3, 1, 1}.HFUNC(ZRem)
+            << CI{"ZRANGE", CO::READONLY, -4, 1, 1}.HFUNC(ZRange)
+            << CI{"ZRANDMEMBER", CO::READONLY, -2, 1, 1}.HFUNC(ZRandMember)
+            << CI{"ZRANK", CO::READONLY | CO::FAST, -3, 1, 1}.HFUNC(ZRank)
+            << CI{"ZRANGEBYLEX", CO::READONLY, -4, 1, 1}.HFUNC(ZRangeByLex)
+            << CI{"ZRANGEBYSCORE", CO::READONLY, -4, 1, 1}.HFUNC(ZRangeByScore)
+            << CI{"ZRANGESTORE", CO::JOURNALED | CO::DENYOOM | CO::NO_AUTOJOURNAL, -5, 1, 2}.HFUNC(
+                   ZRangeStore);
+
+  *registry << CI{"ZSCORE", CO::READONLY | CO::FAST, 3, 1, 1}.HFUNC(ZScore)
+            << CI{"ZMSCORE", CO::READONLY | CO::FAST, -3, 1, 1}.HFUNC(ZMScore)
+            << CI{"ZREMRANGEBYRANK", CO::JOURNALED, 4, 1, 1}.HFUNC(ZRemRangeByRank)
+            << CI{"ZREMRANGEBYSCORE", CO::JOURNALED, 4, 1, 1}.HFUNC(ZRemRangeByScore)
+            << CI{"ZREMRANGEBYLEX", CO::JOURNALED, 4, 1, 1}.HFUNC(ZRemRangeByLex)
+            << CI{"ZREVRANGE", CO::READONLY, -4, 1, 1}.HFUNC(ZRevRange)
+            << CI{"ZREVRANGEBYLEX", CO::READONLY, -4, 1, 1}.HFUNC(ZRevRangeByLex)
+            << CI{"ZREVRANGEBYSCORE", CO::READONLY, -4, 1, 1}.HFUNC(ZRevRangeByScore)
+            << CI{"ZREVRANK", CO::READONLY | CO::FAST, -3, 1, 1}.HFUNC(ZRevRank)
+            << CI{"ZSCAN", CO::READONLY, -3, 1, 1}.HFUNC(ZScan)
+            << CI{"ZUNION", CO::READONLY | CO::VARIADIC_KEYS, -3, 2, 2}.HFUNC(ZUnion)
+            << CI{"ZUNIONSTORE", kStoreMask, -4, 3, 3}.HFUNC(ZUnionStore);
 }
 
 }  // namespace dfly


### PR DESCRIPTION
1. Remove uage of deprecated UringBuf in favor of RegisteredSlice.
2. Split ZSetFamily::Register chaining into multiple calls.
3. Remove deprecated call to GetPastFiberNames.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
