### PR TITLE
CI: allow commit to repeat test

### DIFF
--- a/.github/workflows/repeat-tests.yml
+++ b/.github/workflows/repeat-tests.yml
@@ -40,6 +40,14 @@ on:
         required: false
         type: string
         default: ""
+      build_type:
+        description: "Build type: Debug or Release"
+        required: false
+        type: choice
+        options:
+          - Debug
+          - Release
+        default: "Debug"
 
 jobs:
   build:
@@ -47,7 +55,7 @@ jobs:
       matrix:
         container: ["ubuntu-dev:20-gcc14"]
         proactor: [Uring]
-        build-type: [Debug]
+        build-type: ["${{ inputs.build_type || 'Debug' }}"]
         runner: [ubuntu-latest]
 
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
Two new args added, commit and build type, to trigger eg

```
gh workflow run "Repeat Tests" --ref abhijat/temp/allow-repeat-on-sha -f commit=75d36fd2f509b804779d3e1b9cbd08537a069e08 -f expression="-xv dragonfly -k test_keys_expiration_during_migration" -f count=300 -f build_type=Release
```

build types are Release and Debug