### PR TITLE
chore: switch actions to ubuntu-dev:24

### DIFF
--- a/.github/workflows/cov.yml
+++ b/.github/workflows/cov.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - container: "ubuntu-dev:20-gcc14"
+          - container: "ubuntu-dev:24"
             build-type: Debug
             compiler: {cxx: g++, c: gcc}
             cxx_flags: "-fprofile-arcs -ftest-coverage"

--- a/.github/workflows/epoll-regression-tests.yml
+++ b/.github/workflows/epoll-regression-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # Test of these containers
-        container: ["ubuntu-dev:20-gcc14"]
+        container: ["ubuntu-dev:24"]
         proactor: [Epoll]
         build-type: [Debug]
         runner: [ubuntu-latest, [self-hosted, linux, ARM64]]

--- a/.github/workflows/heavy-tests.yml
+++ b/.github/workflows/heavy-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # Test of these containers
-        container: ["ubuntu-dev:20-gcc14"]
+        container: ["ubuntu-dev:24"]
         proactor: [Uring]
         build-type: [Release]
         runner: [CI-LARGE-86, CI-LARGE-ARM]

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # Test of these containers
-        container: ["ubuntu-dev:20-gcc14"]
+        container: ["ubuntu-dev:24"]
         proactor: [Uring]
         build-type: [Debug, Release]
         runner: [ubuntu-latest, [self-hosted, linux, ARM64]]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           - name: debian
             container: ubuntu-dev:20-gcc14
           - name: rpm
-            container: fedora:30
+            container: fedora:30-gcc14
     container:
       image: ghcr.io/romange/${{ matrix.container }}
       options: --security-opt seccomp=unconfined --sysctl "net.ipv6.conf.all.disable_ipv6=0"
@@ -89,7 +89,7 @@ jobs:
           git describe --always --tags ${{ github.sha }}
 
           # set WITH_SIMSIMD=OFF for fedora:30
-          if [ "${{ matrix.container }}" == 'fedora:30' ]; then
+          if [ "${{ matrix.name }}" == 'rpm' ]; then
             export WITH_SIMSIMD="OFF"
           fi
           ./tools/release.sh
@@ -102,18 +102,10 @@ jobs:
             ./tools/packaging/rpm/build_rpm.sh ${{ env.RELEASE_DIR }}/dragonfly-x86_64.tar.gz ${{github.ref_name}}
           fi
 
-    - name: Run regression tests
-      # Fedora 30 has older python packages, so this fails during requirements installation.
-      if: matrix.container != 'fedora:30'
-      uses: ./.github/actions/regression-tests
-      with:
-        dfly-executable: dragonfly-x86_64
-        gspace-secret: ${{ secrets.GSPACES_BOT_DF_BUILD }}
-        build-folder-name: ${{ env.RELEASE_DIR }}
-        filter: 'not debug_only'
     - name: Save artifacts
       run: |
           # place all artifacts at the same location
+          set -euo pipefail
           mkdir -p results-artifacts
           if [ -f /etc/debian_version ]; then
             mv ${{ env.RELEASE_DIR }}/dragonfly-*tar.gz results-artifacts
@@ -129,9 +121,51 @@ jobs:
       with:
         name: dragonfly-amd64-${{ matrix.name }}
         path: results-artifacts/*
+
+  test-regression:
+    needs: [build-native, build-arm]
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - name: amd64
+            runner: ubuntu-latest
+            artifact: dragonfly-amd64-debian
+            binary: dragonfly-x86_64
+          - name: arm64
+            runner: ubuntu-24.04-arm
+            artifact: dragonfly-aarch64
+            binary: dragonfly-aarch64
+    container:
+      image: ghcr.io/romange/ubuntu-dev:24
+      options: --security-opt seccomp=unconfined --sysctl "net.ipv6.conf.all.disable_ipv6=0"
+      volumes:
+        - /mnt:/mnt
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        submodules: true
+    - name: Download artifacts
+      uses: actions/download-artifact@v7
+      with:
+        name: ${{ matrix.artifact }}
+        path: results-artifacts
+    - name: Extract artifacts
+      run: |
+        set -euo pipefail
+        mkdir -p ${{ env.RELEASE_DIR }}
+        tar -xzf results-artifacts/dragonfly-*dbgsym.tar.gz -C ${{ env.RELEASE_DIR }}
+    - name: Run regression tests
+      uses: ./.github/actions/regression-tests
+      with:
+        dfly-executable: ${{ matrix.binary }}
+        gspace-secret: ${{ secrets.GSPACES_BOT_DF_BUILD }}
+        build-folder-name: ${{ env.RELEASE_DIR }}
+        filter: 'not debug_only'
+
   publish_release:
     runs-on: ubuntu-latest
-    needs: [build-native, build-arm]
+    needs: test-regression
     steps:
       - uses: actions/download-artifact@v7
         name: Download files

--- a/.github/workflows/repeat-tests.yml
+++ b/.github/workflows/repeat-tests.yml
@@ -41,7 +41,7 @@ jobs:
   build:
     strategy:
       matrix:
-        container: ["ubuntu-dev:20-gcc14"]
+        container: ["ubuntu-dev:24"]
         proactor: [Uring]
         build-type: [Debug]
         runner: [ubuntu-latest]


### PR DESCRIPTION
Keep build step in the release pipeline with ubuntu-dev:20.

Confirmed that both Heavy and Regression tests pass.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
