### PR TITLE
chore(server): remove expire table

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -57,15 +57,9 @@ using Payload = journal::Entry::Payload;
 namespace {
 
 constexpr auto kPrimeSegmentSize = PrimeTable::kSegBytes;
-constexpr auto kExpireSegmentSize = ExpireTable::kSegBytes;
-constexpr auto kExpireRegularSize = ExpireTable::kSegRegularBytes;
+
 // mi_malloc good size is 32768. i.e. we have malloc waste of 1.5%.
 static_assert(kPrimeSegmentSize <= 32304);
-
-// 20480 is the next goodsize so we are loosing ~300 bytes or 1.5%.
-// 24576
-static_assert(kExpireSegmentSize <= 23544);
-static_assert(double(kExpireRegularSize) / kExpireSegmentSize > 0.9);
 
 void AccountObjectMemory(string_view key, unsigned type, int64_t size, DbTable* db) {
   DCHECK_NE(db, nullptr);
@@ -359,14 +353,12 @@ inline bool MayDeleteAsynchronously(const PrimeValue& pv) {
 
 DbStats& DbStats::operator+=(const DbStats& o) {
   constexpr size_t kDbSz = sizeof(DbStats) - sizeof(DbTableStats);
-  static_assert(kDbSz == 40);
+  static_assert(kDbSz == 24);
 
   DbTableStats::operator+=(o);
 
   ADD(key_count);
-  ADD(expire_count);
   ADD(prime_capacity);
-  ADD(expire_capacity);
   ADD(table_mem_usage);
 
   return *this;
@@ -457,8 +449,6 @@ auto DbSlice::GetStats() const -> Stats {
     stats = db_wrap.stats;
     stats.key_count = db_wrap.prime.size();
     stats.prime_capacity = db_wrap.prime.capacity();
-    stats.expire_capacity = db_wrap.expire.capacity();
-    stats.expire_count = db_wrap.expire.size();
     stats.table_mem_usage = db_wrap.table_memory();
   }
   auto co_stats = CompactObj::GetStatsThreadLocal();
@@ -563,18 +553,6 @@ OpResult<DbSlice::ItAndUpdater> DbSlice::FindMutableInternal(const Context& cntx
   // PreUpdate() might have caused a deletion of `it`
   if (res->it.IsOccupied()) {
     DCHECK_GE(db_arr_[cntx.db_index]->stats.obj_memory_usage, res->it->second.MallocUsed());
-
-    if (IsValid(res->exp_it)) {  // This code added for DEBUG purpose to check that exp_it is still
-                                 // valid after
-                                 // PreUpdateBlocking.
-      auto fresh_it = db_arr_[cntx.db_index]->expire.Find(key);
-      LOG_IF(DFATAL, fresh_it != res->exp_it)
-          << "Inconsistent state after PreUpdateBlocking for key " << key
-          << ", db_index: " << cntx.db_index
-          << ", prime table size: " << db_arr_[cntx.db_index]->prime.size()
-          << ", expire table size: " << db_arr_[cntx.db_index]->expire.size()
-          << util::fb2::GetStacktrace();
-    }
 
     return {{it, exp_it, AutoUpdater{cntx.db_index, key, it, this}}};
   } else {
@@ -701,17 +679,6 @@ OpResult<DbSlice::ItAndUpdater> DbSlice::AddOrFindInternal(const Context& cntx, 
 
     // PreUpdate() might have caused a deletion of `it`
     if (res->it.IsOccupied()) {
-      if (IsValid(res->exp_it)) {  // This code added for DEBUG purpose to check that exp_it is
-                                   // still valid after
-                                   // PreUpdateBlocking.
-        auto fresh_it = db_arr_[cntx.db_index]->expire.Find(key);
-        LOG_IF(DFATAL, fresh_it != res->exp_it)
-            << "Inconsistent state after PreUpdateBlocking for key " << key
-            << ", db_index: " << cntx.db_index
-            << ", prime table size: " << db_arr_[cntx.db_index]->prime.size()
-            << ", expire table size: " << db_arr_[cntx.db_index]->expire.size()
-            << util::fb2::GetStacktrace();
-      }
       return ItAndUpdater{
           .it = it, .exp_it = exp_it, .post_updater{cntx.db_index, key, it, this}, .is_new = false};
     } else {
@@ -854,11 +821,6 @@ void DbSlice::Del(Context cntx, Iterator it, DbTable* db_table, bool async) {
     string tmp;
     string_view key = it->first.GetSlice(&tmp);
     doc_del_cb_(key, cntx, it->second);
-  }
-
-  if (it->first.HasExpire()) {
-    exp_it = ExpIterator::FromPrime(table->expire.Find(it->first));
-    DCHECK(!exp_it.is_done());
   }
 
   PerformDeletionAtomic(it, exp_it, table, async);
@@ -1009,38 +971,45 @@ util::fb2::Fiber DbSlice::FlushDb(DbIndex db_ind) {
 }
 
 void DbSlice::AddExpire(DbIndex db_ind, const Iterator& main_it, uint64_t at) {
-  uint64_t delta = at - expire_base_[0];  // TODO: employ multigen expire updates.
+  bool had_expire = main_it->first.HasExpire();
+  bool was_inline = main_it->first.IsInline();
+  ssize_t old_malloc = static_cast<ssize_t>(main_it->first.MallocUsed());
+
+  main_it->first.SetExpireTime(at);
+
   auto& db = *db_arr_[db_ind];
-  size_t table_before = db.expire.mem_usage();
-  CHECK(db.expire.Insert(main_it->first.AsRef(), ExpirePeriod(delta)).second);
-  table_memory_ += (db.expire.mem_usage() - table_before);
-  main_it->first.SetExpire(true);
+  ssize_t new_malloc = static_cast<ssize_t>(main_it->first.MallocUsed());
+  if (was_inline && !main_it->first.IsInline()) {
+    --db.stats.inline_keys;
+    AccountObjectMemory(main_it.key(), OBJ_KEY, new_malloc, &db);
+  } else if (new_malloc != old_malloc) {
+    AccountObjectMemory(main_it.key(), OBJ_KEY, new_malloc - old_malloc, &db);
+  }
+
+  if (!had_expire)
+    ++db.stats.expire_count;
 }
 
 bool DbSlice::RemoveExpire(DbIndex db_ind, const Iterator& main_it) {
-  if (main_it->first.HasExpire()) {
-    auto& db = *db_arr_[db_ind];
-    size_t table_before = db.expire.mem_usage();
-    CHECK_EQ(1u, db.expire.Erase(main_it->first));
-    main_it->first.SetExpire(false);
-    table_memory_ += (db.expire.mem_usage() - table_before);
-    return true;
-  }
-  return false;
-}
+  if (!main_it->first.HasExpire())
+    return false;
 
-// Returns true if a state has changed, false otherwise.
-bool DbSlice::UpdateExpire(DbIndex db_ind, const Iterator& it, uint64_t at) {
-  if (at == 0) {
-    return RemoveExpire(db_ind, it);
-  }
+  DCHECK(!main_it->first.IsInline());  // SDS_TTL_TAG is never inline
+  ssize_t old_malloc = static_cast<ssize_t>(main_it->first.MallocUsed());
 
-  if (!it->first.HasExpire() && at) {
-    AddExpire(db_ind, it, at);
-    return true;
+  main_it->first.ClearExpireTime();
+
+  auto& db = *db_arr_[db_ind];
+  ssize_t new_malloc = static_cast<ssize_t>(main_it->first.MallocUsed());
+  if (main_it->first.IsInline()) {
+    AccountObjectMemory(main_it.key(), OBJ_KEY, -old_malloc, &db);
+    ++db.stats.inline_keys;
+  } else if (new_malloc != old_malloc) {
+    AccountObjectMemory(main_it.key(), OBJ_KEY, new_malloc - old_malloc, &db);
   }
 
-  return false;
+  --db.stats.expire_count;
+  return true;
 }
 
 bool DbSlice::SetMCFlag(DbIndex db_ind, const PrimeKey& key, uint32_t flag) {
@@ -1125,8 +1094,8 @@ OpResult<int64_t> DbSlice::UpdateExpire(const Context& cntx, Iterator prime_it,
   int64_t current_cmp = numeric_limits<int64_t>::max();  // inf if no expiry is set
   bool satisfied = params.expire_options == ExpireFlags::EXPIRE_ALWAYS;
 
-  if (IsValid(expire_it)) {
-    current_cmp = ExpireTime(expire_it->second);
+  if (prime_it->first.HasExpire()) {
+    current_cmp = prime_it->first.GetExpireTime();
     satisfied |= (params.expire_options & ExpireFlags::EXPIRE_XX);
   } else {
     satisfied |= (params.expire_options & ExpireFlags::EXPIRE_NX);
@@ -1144,11 +1113,7 @@ OpResult<int64_t> DbSlice::UpdateExpire(const Context& cntx, Iterator prime_it,
     return -1;
   }
 
-  // Update or add expiration
-  if (IsValid(expire_it))
-    expire_it->second = FromAbsoluteTime(abs_msec);
-  else
-    AddExpire(cntx.db_index, prime_it, abs_msec);
+  AddExpire(cntx.db_index, prime_it, abs_msec);
   return abs_msec;
 }
 
@@ -1165,28 +1130,14 @@ OpResult<DbSlice::ItAndUpdater> DbSlice::AddOrUpdateInternal(const Context& cntx
   if (!res.is_new && !force_update)  // have not inserted.
     return op_result;
 
-  auto& db = *db_arr_[cntx.db_index];
   auto& it = res.it;
 
   it->second = std::move(obj);
 
   if (expire_at_ms) {
-    it->first.SetExpire(true);
-    uint64_t delta = expire_at_ms - expire_base_[0];
-    if (IsValid(res.exp_it) && force_update) {
-      res.exp_it->second = ExpirePeriod(delta);
-    } else {
-      size_t table_before = db.expire.mem_usage();
-      auto exp_it = db.expire.InsertNew(it->first.AsRef(), ExpirePeriod(delta));
-      res.exp_it = ExpIterator(exp_it, StringOrView::FromView(key));
-      table_memory_ += (db.expire.mem_usage() - table_before);
-    }
+    AddExpire(cntx.db_index, it, expire_at_ms);
   } else {
-    // If the key had an expiry but the new value should have none, clear it.
-    if (IsValid(res.exp_it)) {
-      RemoveExpire(cntx.db_index, res.it);
-      res.exp_it = ExpIterator{};
-    }
+    RemoveExpire(cntx.db_index, it);
   }
 
   return op_result;
@@ -1305,23 +1256,11 @@ DbSlice::PrimeItAndExp DbSlice::ExpireIfNeeded(const Context& cntx, PrimeIterato
     return {it, ExpireIterator{}};
   }
 
-  auto& db = db_arr_[cntx.db_index];
-  auto expire_it = db->expire.Find(it->first);
-
-  if (!IsValid(expire_it)) {
-    LOG(DFATAL) << "Internal error, entry " << it->first.ToString()
-                << " not found in expire table, db_index: " << cntx.db_index
-                << ", expire table size: " << db->expire.size()
-                << ", prime table size: " << db->prime.size() << util::fb2::GetStacktrace();
-    return {it, ExpireIterator{}};
-  }
-
-  // TODO: to employ multi-generation update of expire-base and the underlying values.
-  int64_t expire_time = ExpireTime(expire_it->second);
+  int64_t expire_time = it->first.GetExpireTime();
 
   // Never do expiration on replica or if expiration is disabled.
   if (int64_t(cntx.time_now_ms) < expire_time || owner_->IsReplica() || !expire_allowed_) {
-    return {it, expire_it};
+    return {it, ExpireIterator{}};
   }
 
   string scratch;
@@ -1332,6 +1271,7 @@ DbSlice::PrimeItAndExp DbSlice::ExpireIfNeeded(const Context& cntx, PrimeIterato
     RecordExpiryBlocking(cntx.db_index, key);
   }
 
+  auto& db = db_arr_[cntx.db_index];
   if (expired_keys_events_recording_)
     db->expired_keys_events_.emplace_back(key);
 
@@ -1340,9 +1280,8 @@ DbSlice::PrimeItAndExp DbSlice::ExpireIfNeeded(const Context& cntx, PrimeIterato
     doc_del_cb_(key, cntx, it->second);
   }
 
-  const_cast<DbSlice*>(this)->PerformDeletionAtomic(
-      Iterator(it, StringOrView::FromView(key)),
-      ExpIterator(expire_it, StringOrView::FromView(key)), db.get());
+  const_cast<DbSlice*>(this)->PerformDeletionAtomic(Iterator(it, StringOrView::FromView(key)),
+                                                    ExpIterator{}, db.get());
 
   ++events_.expired_keys;
   db->stats.events.expired_keys++;
@@ -1362,18 +1301,15 @@ void DbSlice::ExpireAllIfNeeded() {
       continue;
     auto& db = *db_arr_[db_index];
 
-    auto cb = [&](ExpireTable::iterator exp_it) {
-      auto prime_it = db.prime.Find(exp_it->first);
-      if (!IsValid(prime_it)) {
-        LOG(DFATAL) << "Expire entry " << exp_it->first.ToString() << " not found in prime table";
-        return;
+    auto cb = [&](PrimeTable::iterator prime_it) {
+      if (prime_it->first.HasExpire()) {
+        ExpireIfNeeded(Context{nullptr, db_index, GetCurrentTimeMs()}, prime_it);
       }
-      ExpireIfNeeded(Context{nullptr, db_index, GetCurrentTimeMs()}, prime_it);
     };
 
-    ExpireTable::Cursor cursor;
+    PrimeTable::Cursor cursor;
     do {
-      cursor = db.expire.Traverse(cursor, cb);
+      cursor = db.prime.Traverse(cursor, cb);
     } while (cursor);
   }
 }
@@ -1441,25 +1377,19 @@ auto DbSlice::DeleteExpiredStep(const Context& cntx, unsigned count) -> DeleteEx
 
   std::string stash;
 
-  auto cb = [&](ExpireIterator it) {
+  auto cb = [&](PrimeTable::iterator it) {
+    if (!it->first.HasExpire())
+      return;
+
     string_view key = it->first.GetSlice(&stash);
     if (!CheckLock(IntentLock::EXCLUSIVE, cntx.db_index, key))
       return;
 
     result.traversed++;
-    int64_t ttl = ExpireTime(it->second) - cntx.time_now_ms;
+    int64_t ttl = it->first.GetExpireTime() - cntx.time_now_ms;
     if (ttl <= 0) {
-      auto prime_it = db.prime.Find(it->first);
-      if (prime_it.is_done()) {  // A workaround for the case our tables are inconsistent.
-        LOG(DFATAL) << "Expired key " << key
-                    << " not found in prime table, expire_done: " << it.is_done();
-        if (!it.is_done()) {
-          db.expire.Erase(it->first);
-        }
-      } else {
-        result.deleted_bytes += prime_it->first.MallocUsed() + prime_it->second.MallocUsed();
-        ExpireIfNeeded(cntx, prime_it);
-      }
+      result.deleted_bytes += it->first.MallocUsed() + it->second.MallocUsed();
+      ExpireIfNeeded(cntx, it);
       ++result.deleted;
     } else {
       result.survivor_ttl_sum += ttl;
@@ -1474,13 +1404,13 @@ auto DbSlice::DeleteExpiredStep(const Context& cntx, unsigned count) -> DeleteEx
   };
 
   for (; i < count / 3 && quota_remains(); ++i) {
-    db.expire_cursor = db.expire.Traverse(db.expire_cursor, cb);
+    db.expire_cursor = db.prime.Traverse(db.expire_cursor, cb);
   }
 
   // continue traversing only if we had strong deletion rate based on the first sample.
   if (result.deleted * 4 > result.traversed) {
     for (; i < count && quota_remains(); ++i) {
-      db.expire_cursor = db.expire.Traverse(db.expire_cursor, cb);
+      db.expire_cursor = db.prime.Traverse(db.expire_cursor, cb);
     }
   }
 
@@ -1848,9 +1778,6 @@ void DbSlice::PerformDeletionAtomic(const Iterator& del_it, const ExpIterator& e
                                     DbTable* table, bool async) {
   FiberAtomicGuard guard;
   size_t table_before = table->table_memory();
-  if (!exp_it.is_done()) {
-    table->expire.Erase(exp_it.GetInnerIt());
-  }
 
   if (del_it->second.HasFlag()) {
     if (!SetMCFlag(table->index, del_it->first, 0)) {
@@ -1860,6 +1787,10 @@ void DbSlice::PerformDeletionAtomic(const Iterator& del_it, const ExpIterator& e
   }
 
   DbTableStats& stats = table->stats;
+
+  if (del_it->first.HasExpire())
+    --stats.expire_count;
+
   PrimeValue& pv = del_it->second;
 
   if (pv.HasStashPending()) {

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -34,14 +34,8 @@ struct DbStats : public DbTableStats {
   // number of active keys.
   size_t key_count = 0;
 
-  // number of keys that have expiry deadline.
-  size_t expire_count = 0;
-
   // total number of slots in prime dictionary (key capacity).
   size_t prime_capacity = 0;
-
-  // total number of slots in prime dictionary (key capacity).
-  size_t expire_capacity = 0;
 
   // Memory used by dictionaries.
   size_t table_mem_usage = 0;
@@ -312,18 +306,13 @@ class DbSlice {
   facade::OpResult<int64_t> UpdateExpire(const Context& cntx, Iterator prime_it, ExpIterator exp_it,
                                          const ExpireParams& params);
 
-  // Adds expiry information.
+  // Adds expiry on a key. If the key already has expiry, updates it.
   void AddExpire(DbIndex db_ind, const Iterator& main_it, uint64_t at);
 
-  // Removes the corresponing expiry information if exists.
-  // Returns true if expiry existed (and removed).
+  // Removes expiry from a key. Returns true if expiry existed and was removed.
   bool RemoveExpire(DbIndex db_ind, const Iterator& main_it);
 
-  // Either adds or removes (if at == 0) expiry. Returns true if a change was made.
-  // Does not change expiry if at != 0 and expiry already exists.
-  bool UpdateExpire(DbIndex db_ind, const Iterator& main_it, uint64_t at);
-
-  // false if no action was taken, true if the mc flag was set or removed.
+  // Returns false if no action was taken, true if the mc flag was set or removed.
   bool SetMCFlag(DbIndex db_ind, const PrimeKey& key, uint32_t flag);
 
   uint32_t GetMCFlag(DbIndex db_ind, const PrimeKey& key) const;
@@ -390,7 +379,7 @@ class DbSlice {
   }
 
   std::pair<PrimeTable*, ExpireTable*> GetTables(DbIndex id) {
-    return std::pair<PrimeTable*, ExpireTable*>(&db_arr_[id]->prime, &db_arr_[id]->expire);
+    return std::pair<PrimeTable*, ExpireTable*>(&db_arr_[id]->prime, nullptr);
   }
 
   // Returns existing keys count in the db.

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -372,7 +372,7 @@ void DoComputeHist(CompactObjType type, EngineShard* shard, ConnectionContext* c
 ObjInfo InspectOp(ConnectionContext* cntx, string_view key) {
   auto& db_slice = cntx->ns->GetCurrentDbSlice();
   auto db_index = cntx->db_index();
-  auto [pt, exp_t] = db_slice.GetTables(db_index);
+  auto* pt = db_slice.GetTables(db_index).first;
 
   PrimeIterator it = pt->Find(key);
   ObjInfo oinfo;
@@ -403,12 +403,9 @@ ObjInfo InspectOp(ConnectionContext* cntx, string_view key) {
     }
 
     if (it->first.HasExpire()) {
-      ExpireIterator exp_it = exp_t->Find(it->first);
-      CHECK(!exp_it.is_done());
-
-      time_t exp_time = db_slice.ExpireTime(exp_it->second);
+      time_t exp_time = it->first.GetExpireTime();
       oinfo.ttl = exp_time - GetCurrentTimeMs();
-      oinfo.has_sec_precision = exp_it->second.is_second_precision();
+      oinfo.has_sec_precision = false;  // Embedded TTL is always ms precision.
     }
   }
 
@@ -423,7 +420,7 @@ ObjInfo InspectOp(ConnectionContext* cntx, string_view key) {
 OpResult<ValueCompressInfo> EstimateCompression(ConnectionContext* cntx, string_view key) {
   auto& db_slice = cntx->ns->GetCurrentDbSlice();
   auto db_index = cntx->db_index();
-  auto [pt, exp_t] = db_slice.GetTables(db_index);
+  auto* pt = db_slice.GetTables(db_index).first;
 
   PrimeIterator it = pt->Find(key);
   if (!IsValid(it)) {

--- a/src/server/detail/table.h
+++ b/src/server/detail/table.h
@@ -46,7 +46,7 @@ struct PrimeTablePolicy {
 };
 
 struct ExpireTablePolicy {
-  enum { kSlotNum = 14, kBucketNum = 56 };
+  enum : uint8_t { kSlotNum = 14, kBucketNum = 56 };
   static constexpr bool kUseVersion = false;
 
   static uint64_t HashFn(const PrimeKey& s) {
@@ -61,17 +61,10 @@ struct ExpireTablePolicy {
     cs.Reset();
   }
 
-  static void DestroyValue(ExpirePeriod e) {
-  }
-
   static void DestroyValue(uint32_t val) {
   }
 
   static bool Equal(const PrimeKey& s1, std::string_view s2) {
-    return s1 == s2;
-  }
-
-  static bool Equal(const PrimeKey& s1, const PrimeKey& s2) {
     return s1 == s2;
   }
 };

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -1018,6 +1018,49 @@ TEST_F(DflyEngineTest, MemoryKeys) {
   EXPECT_GT(metrics.db_stats[0].memory_usage_by_type[OBJ_KEY], 100000);
 }
 
+// Verify that inline_keys, expire_count, and OBJ_KEY memory stay consistent
+// when expire is added/removed on inline keys (regression for memory underflow bug).
+TEST_F(DflyEngineTest, ExpireInlineKeyAccounting) {
+  // Keys short enough to be stored inline (kInlineLen = 16).
+  constexpr int kCount = 10;
+  for (int i = 0; i < kCount; i++)
+    Run({"set", absl::StrCat("k", i), "v"});
+
+  auto stats = GetMetrics().db_stats[0];
+  EXPECT_EQ(stats.inline_keys, kCount);
+  EXPECT_EQ(stats.expire_count, 0u);
+  EXPECT_EQ(stats.memory_usage_by_type[OBJ_KEY], 0);
+
+  // Setting expire transitions inline -> SDS_TTL_TAG (heap-allocated).
+  for (int i = 0; i < kCount; i++)
+    Run({"expire", absl::StrCat("k", i), "3600"});
+
+  stats = GetMetrics().db_stats[0];
+  EXPECT_EQ(stats.inline_keys, 0u);
+  EXPECT_EQ(stats.expire_count, kCount);
+  EXPECT_GT(stats.memory_usage_by_type[OBJ_KEY], 0);
+
+  // PERSIST transitions SDS_TTL_TAG -> inline again.
+  for (int i = 0; i < kCount; i++)
+    Run({"persist", absl::StrCat("k", i)});
+
+  stats = GetMetrics().db_stats[0];
+  EXPECT_EQ(stats.inline_keys, kCount);
+  EXPECT_EQ(stats.expire_count, 0u);
+  EXPECT_EQ(stats.memory_usage_by_type[OBJ_KEY], 0);
+
+  // Re-expire then delete: prior bug caused memory accounting underflow on deletion.
+  for (int i = 0; i < kCount; i++)
+    Run({"expire", absl::StrCat("k", i), "3600"});
+  for (int i = 0; i < kCount; i++)
+    Run({"del", absl::StrCat("k", i)});
+
+  stats = GetMetrics().db_stats[0];
+  EXPECT_EQ(stats.inline_keys, 0u);
+  EXPECT_EQ(stats.expire_count, 0u);
+  EXPECT_EQ(stats.memory_usage_by_type[OBJ_KEY], 0);
+}
+
 class DflyCommandAliasTest : public DflyEngineTest {
  protected:
   DflyCommandAliasTest() {

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -356,7 +356,7 @@ std::optional<CollectedPageStats> EngineShard::DoDefrag(PageUsage* page_usage) {
   }
 
   DCHECK(slice.IsDbValid(defrag_state_.dbid));
-  auto [prime_table, expire_table] = slice.GetTables(defrag_state_.dbid);
+  auto [prime_table, _unused_expire] = slice.GetTables(defrag_state_.dbid);
   PrimeTable::Cursor cur{defrag_state_.cursor};
   uint64_t reallocations = 0;
   uint64_t attempts = 0;
@@ -848,8 +848,8 @@ void EngineShard::RetireExpiredAndEvict() {
       continue;
 
     db_cntx.db_index = i;
-    auto [pt, expt] = db_slice.GetTables(i);
-    if (!expt->Empty()) {
+    auto [pt, _unused_expt] = db_slice.GetTables(i);
+    if (pt->size() > 0) {
       DbSlice::DeleteExpiredStats stats = db_slice.DeleteExpiredStep(db_cntx, ttl_delete_target);
 
       deleted_bytes += stats.deleted_bytes;

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -475,8 +475,9 @@ void Renamer::SerializeSrc(Transaction* t, EngineShard* shard) {
   OpResult<string> res = DumpToString(src_key_, it->second, t->GetOpArgs(shard));
   if (res.ok()) {
     optional rdb_version = GetRdbVersion(*res);
-    serialized_value_ = SerializedValue{std::move(*res), rdb_version,
-                                        GetExpireTime(db_slice, exp_it), it->first.IsSticky()};
+    int64_t exp_time = it->first.GetExpireTime();
+    serialized_value_ =
+        SerializedValue{std::move(*res), rdb_version, exp_time, it->first.IsSticky()};
   } else {
     serialized_value_ = res.status();
   }
@@ -573,12 +574,8 @@ OpStatus OpPersist(const OpArgs& op_args, string_view key) {
   if (!IsValid(res.it)) {
     return OpStatus::KEY_NOTFOUND;
   } else {
-    if (IsValid(res.exp_it)) {
-      // The SKIPPED not really used, just placeholder for error
-      return db_slice.UpdateExpire(op_args.db_cntx.db_index, res.it, 0) ? OpStatus::OK
-                                                                        : OpStatus::SKIPPED;
-    }
-    return OpStatus::SKIPPED;  // fall though - key does not have expiry
+    bool cleared = db_slice.RemoveExpire(op_args.db_cntx.db_index, res.it);
+    return cleared ? OpStatus::OK : OpStatus::SKIPPED;
   }
 }
 
@@ -691,7 +688,7 @@ void OpScan(const OpArgs& op_args, const ScanOpts& scan_opts, uint64_t* cursor, 
           << db_slice.DbSize(op_args.db_cntx.db_index);
 
   PrimeTable::Cursor cur{*cursor};
-  auto [prime_table, expire_table] = db_slice.GetTables(op_args.db_cntx.db_index);
+  auto* prime_table = db_slice.GetTables(op_args.db_cntx.db_index).first;
 
   const auto start_cycles = base::CycleClock::Now();
 
@@ -937,10 +934,10 @@ OpResult<uint64_t> OpExpireTime(Transaction* t, EngineShard* shard, string_view 
   if (!IsValid(it))
     return OpStatus::KEY_NOTFOUND;
 
-  if (!IsValid(expire_it))
+  if (!it->first.HasExpire())
     return OpStatus::SKIPPED;
 
-  int64_t ttl_ms = db_slice.ExpireTime(expire_it->second);
+  int64_t ttl_ms = it->first.GetExpireTime();
   DCHECK_GT(ttl_ms, 0);  // Otherwise FindReadOnly would return null.
   return ttl_ms;
 }
@@ -967,12 +964,9 @@ OpStatus OpMove(const OpArgs& op_args, string_view key, DbIndex target_db) {
     return OpStatus::KEY_EXISTS;
 
   bool sticky = from_res.it->first.IsSticky();
-  uint64_t exp_ts = GetExpireTime(db_slice, from_res.exp_it);
+  uint64_t exp_ts = from_res.it->first.GetExpireTime();
   from_res.post_updater.Run();
   PrimeValue from_obj = std::move(from_res.it->second);
-
-  // Restore expire flag after std::move.
-  from_res.it->first.SetExpire(IsValid(from_res.exp_it));
 
   db_slice.Del(op_args.db_cntx, from_res.it);
   auto op_result = db_slice.AddNew(target_cntx, key, std::move(from_obj), exp_ts);
@@ -1013,24 +1007,22 @@ OpResult<void> OpRen(const OpArgs& op_args, string_view from_key, string_view to
   RemoveKeyFromIndexesIfNeeded(from_key, op_args.db_cntx, from_res.it->second, op_args.shard);
 
   bool sticky = from_res.it->first.IsSticky();
-  uint64_t exp_ts = GetExpireTime(db_slice, from_res.exp_it);
+  uint64_t exp_ts = from_res.it->first.GetExpireTime();
   from_res.post_updater.ReduceHeapUsage();
 
   // we keep the value we want to move.
   PrimeValue from_obj = std::move(from_res.it->second);
 
-  // Restore the expire flag on 'from' so we could delete it from expire table.
-  from_res.it->first.SetExpire(IsValid(from_res.exp_it));
-
   if (IsValid(to_res.it)) {
     to_res.post_updater.ReduceHeapUsage();
     to_res.it->second = std::move(from_obj);
-    to_res.it->first.SetExpire(IsValid(to_res.exp_it));  // keep the expire flag on 'to'.
 
-    // It is guaranteed that UpdateExpire() call does not erase the element because then
-    // from_it would be invalid. Therefore, UpdateExpire does not invalidate any iterators,
-    // therefore we can delete 'from_it'.
-    db_slice.UpdateExpire(op_args.db_cntx.db_index, to_res.it, exp_ts);
+    if (exp_ts) {
+      db_slice.AddExpire(op_args.db_cntx.db_index, to_res.it, exp_ts);
+    } else {
+      db_slice.RemoveExpire(op_args.db_cntx.db_index, to_res.it);
+    }
+
     to_res.it->first.SetSticky(sticky);
     to_res.post_updater.Run();
 
@@ -2570,8 +2562,8 @@ void GenericFamily::RandomKey(CmdArgList args, CommandContext* cmd_cntx) {
 
   shard_set->RunBriefInParallel(
       [&](EngineShard* shard) {
-        auto [prime_table, expire_table] =
-            cntx->ns->GetDbSlice(shard->shard_id()).GetTables(db_cntx.db_index);
+        auto* prime_table =
+            cntx->ns->GetDbSlice(shard->shard_id()).GetTables(db_cntx.db_index).first;
         if (prime_table->size() == 0) {
           return;
         }

--- a/src/server/journal/streamer.cc
+++ b/src/server/journal/streamer.cc
@@ -448,7 +448,6 @@ void RestoreStreamer::Run() {
   // Explicitly copy table smart pointer to keep reference count up (flushall drops it)
   boost::intrusive_ptr<DbTable> table = db_array_.front();
   PrimeTable* pt = &table->prime;
-  ExpireTable& expire_table = table->expire;
 
   do {
     if (!cntx_->IsRunning())
@@ -497,7 +496,7 @@ void RestoreStreamer::Run() {
         auto* blocking_counter = db_slice_->GetLatch();
         lock_guard blocking_counter_guard(*blocking_counter);
 
-        stats_.buckets_loop += WriteBucket(it, expire_table, false);
+        stats_.buckets_loop += WriteBucket(it, false);
       }
 
       // We could have delayed entries that are watiting so we want to flush them
@@ -592,8 +591,7 @@ bool RestoreStreamer::ShouldWrite(SlotId slot_id) const {
   return my_slots_.Contains(slot_id);
 }
 
-bool RestoreStreamer::WriteBucket(PrimeTable::bucket_iterator it, const ExpireTable& expire_table,
-                                  bool on_db_change_cb) {
+bool RestoreStreamer::WriteBucket(PrimeTable::bucket_iterator it, bool on_db_change_cb) {
   auto& shard_stats = EngineShard::tlocal()->stats();
   bool written = false;
   absl::flat_hash_set<string> tiered_keys;
@@ -620,12 +618,7 @@ bool RestoreStreamer::WriteBucket(PrimeTable::bucket_iterator it, const ExpireTa
       if (ShouldWrite(key)) {
         ++stats_.keys_written;
         ++shard_stats.total_migrated_keys;
-        uint64_t expire = 0;
-        if (it->first.HasExpire()) {
-          auto eit = expire_table.Find(it->first);
-          CHECK(IsValid(eit)) << " " << expire_table.size();
-          expire = db_slice_->ExpireTime(eit->second);
-        }
+        uint64_t expire = it->first.GetExpireTime();
         // Track tiered keys that will need delayed entry flushing
         if (track_tiered_keys) {
           tiered_keys.emplace(key);
@@ -673,7 +666,6 @@ void RestoreStreamer::OnDbChange(DbIndex db_index, const DbSlice::ChangeReq& req
   DCHECK_EQ(db_index, 0) << "Restore migration only allowed in cluster mode in db0";
 
   PrimeTable* table = db_slice_->GetTables(0).first;
-  ExpireTable* expire_table = db_slice_->GetTables(0).second;
   uint64_t throttle_start = throttle_count_;
   uint64_t throttle_usec_start = total_throttle_wait_usec_;
   if (const PrimeTable::bucket_iterator* bit = req.update()) {
@@ -681,14 +673,14 @@ void RestoreStreamer::OnDbChange(DbIndex db_index, const DbSlice::ChangeReq& req
       // If snapshot_version_ is 0, it means that Cancel() was called and we shouldn't proceed.
       return;
     }
-    stats_.buckets_on_db_update += WriteBucket(*bit, *expire_table, true);
+    stats_.buckets_on_db_update += WriteBucket(*bit, true);
   } else {
     string_view key = get<string_view>(req.change);
     table->CVCUponInsert(snapshot_version_, key, [&](PrimeTable::bucket_iterator it) {
       if (snapshot_version_ != 0) {  // we need this check because lambda can be called several
                                      // times and we can preempt in WriteBucket
         DCHECK_LT(it.GetVersion(), snapshot_version_);
-        stats_.buckets_on_db_update += WriteBucket(it, *expire_table, true);
+        stats_.buckets_on_db_update += WriteBucket(it, true);
       }
     });
   }

--- a/src/server/journal/streamer.h
+++ b/src/server/journal/streamer.h
@@ -128,8 +128,7 @@ class RestoreStreamer : public JournalStreamer {
   bool ShouldWrite(SlotId slot_id) const;
 
   // Returns true if any entry was actually written
-  bool WriteBucket(PrimeTable::bucket_iterator it, const ExpireTable& expire_table,
-                   bool on_db_change);
+  bool WriteBucket(PrimeTable::bucket_iterator it, bool on_db_change);
 
   void WriteEntry(std::string_view key, const PrimeKey& pk, const PrimeValue& pv,
                   uint64_t expire_ms);

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2013,10 +2013,8 @@ void PrintPrometheusMetrics(uint64_t uptime, const Metrics& m, DflyCmd* dfly_cmd
   for (size_t i = 0; i < m.db_stats.size(); ++i) {
     AppendMetricValue("db_keys", m.db_stats[i].key_count, {"db"}, {StrCat("db", i)},
                       &db_key_metrics);
-    AppendMetricValue("db_capacity", m.db_stats[i].prime_capacity, {"db", "type"},
-                      {StrCat("db", i), "prime"}, &db_capacity_metrics);
-    AppendMetricValue("db_capacity", m.db_stats[i].expire_capacity, {"db", "type"},
-                      {StrCat("db", i), "expire"}, &db_capacity_metrics);
+    AppendMetricValue("db_capacity", m.db_stats[i].prime_capacity, {"db"}, {StrCat("db", i)},
+                      &db_capacity_metrics);
 
     AppendMetricValue("db_keys_expiring", m.db_stats[i].expire_count, {"db"}, {StrCat("db", i)},
                       &db_key_expire_metrics);
@@ -3163,7 +3161,6 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
     }
     append("table_used_memory", total.table_mem_usage);
     append("prime_capacity", total.prime_capacity);
-    append("expire_capacity", total.expire_capacity);
     append("num_entries", total.key_count);
     append("inline_keys", total.inline_keys);
     append("small_string_bytes", m.small_string_bytes);

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -405,19 +405,7 @@ void SliceSnapshot::SerializeEntry(DbIndex db_indx, const PrimeKey& pk, const Pr
   if (pv.IsExternal() && pv.IsCool())
     return SerializeEntry(db_indx, pk, pv.GetCool().record->value);
 
-  time_t expire_time = 0;
-  if (pk.HasExpire()) {
-    auto eit = db_array_[db_indx]->expire.Find(pk);
-    if (!IsValid(eit)) {
-      LOG(DFATAL) << "Internal error, entry " << pk.ToString()
-                  << " not found in expire table, db_index: " << db_indx
-                  << ", expire table size: " << db_array_[db_indx]->expire.size()
-                  << ", prime table size: " << db_array_[db_indx]->prime.size()
-                  << util::fb2::GetStacktrace();
-    } else {
-      expire_time = db_slice_->ExpireTime(eit->second);
-    }
-  }
+  time_t expire_time = pk.GetExpireTime();
   uint32_t mc_flags = pv.HasFlag() ? db_slice_->GetMCFlag(db_indx, pk) : 0;
 
   if (pv.IsExternal()) {

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -464,12 +464,7 @@ OpResult<array<int64_t, 5>> OpThrottle(const OpArgs& op_args, const string_view 
     const int64_t new_tat_ms =
         (new_tat_ns + kMilliSecondToNanoSecond - 1) / kMilliSecondToNanoSecond;
     if (res) {
-      if (IsValid(res->exp_it)) {
-        res->exp_it->second = db_slice.FromAbsoluteTime(new_tat_ms);
-      } else {
-        db_slice.AddExpire(op_args.db_cntx.db_index, res->it, new_tat_ms);
-      }
-
+      db_slice.AddExpire(op_args.db_cntx.db_index, res->it, new_tat_ms);
       res->it->second.SetInt(new_tat_ns);
     } else {
       PrimeValue pv;
@@ -599,8 +594,7 @@ MGetResponse CollectKeys(BlockingCounter wait_bc, AggregateError* err, MemcacheC
     // Note - correct behavior is to return TTL before it was updated by GAT,
     // but this is complex to implement so we return the updated TTL.
     if (it->first.HasExpire() && cmd_flags.return_ttl) {
-      auto exp_it = db_slice.GetDBTable(t->GetDbIndex())->expire.Find(it->first);
-      int64_t expire_time_ms = db_slice.ExpireTime(exp_it->second);
+      int64_t expire_time_ms = it->first.GetExpireTime();
       int64_t ttl_ms = expire_time_ms - t->GetDbContext().time_now_ms;
       resp.ttl_sec = ttl_ms > 0 ? static_cast<uint32_t>((ttl_ms + 999) / 1000) : 0;
     }
@@ -876,14 +870,8 @@ OpStatus SetCmd::SetExisting(const SetParams& params, string_view value,
       params.expire_after_ms ? params.expire_after_ms + op_args_.db_cntx.time_now_ms : 0;
 
   if (!(params.flags & SET_KEEP_EXPIRE)) {
-    if (at_ms) {  // Command has an expiry paramater.
-      if (IsValid(it_upd->exp_it)) {
-        // Updated existing expiry information.
-        it_upd->exp_it->second = db_slice.FromAbsoluteTime(at_ms);
-      } else {
-        // Add new expiry information.
-        db_slice.AddExpire(op_args_.db_cntx.db_index, it_upd->it, at_ms);
-      }
+    if (at_ms) {
+      db_slice.AddExpire(op_args_.db_cntx.db_index, it_upd->it, at_ms);
     } else {
       db_slice.RemoveExpire(op_args_.db_cntx.db_index, it_upd->it);
     }

--- a/src/server/table.cc
+++ b/src/server/table.cc
@@ -40,9 +40,10 @@ void DbTableStats::AddTypeMemoryUsage(unsigned type, int64_t delta) {
 
 DbTableStats& DbTableStats::operator+=(const DbTableStats& o) {
   constexpr size_t kDbSz = sizeof(DbTableStats) - sizeof(memory_usage_by_type);
-  static_assert(kDbSz == 64);
+  static_assert(kDbSz == 72);
 
   ADD(inline_keys);
+  ADD(expire_count);
   ADD(obj_memory_usage);
   ADD(tiered_entries);
   ADD(tiered_used_bytes);
@@ -102,7 +103,6 @@ DbTable::SampleUniqueKeys::~SampleUniqueKeys() {
 
 DbTable::DbTable(PMR_NS::memory_resource* mr, DbIndex db_index)
     : prime(kInitSegmentLog, detail::PrimeTablePolicy{}, mr),
-      expire(0, detail::ExpireTablePolicy{}, mr),
       mcflag(0, detail::ExpireTablePolicy{}, mr),
       index(db_index) {
   if (IsClusterEnabled()) {
@@ -120,7 +120,6 @@ DbTable::~DbTable() {
 void DbTable::Clear() {
   prime.size();
   prime.Clear();
-  expire.Clear();
   mcflag.Clear();
   stats = DbTableStats{};
 }

--- a/src/server/table.h
+++ b/src/server/table.h
@@ -66,6 +66,9 @@ struct DbTableStats {
   // Number of inline keys.
   uint64_t inline_keys = 0;
 
+  // number of keys with ttls set.
+  uint64_t expire_count = 0;
+
   // Object memory usage besides hash-table capacity.
   // Applies for any non-inline objects.
   size_t obj_memory_usage = 0;
@@ -127,7 +130,7 @@ class LockTable {
 // A single Db table that represents a table that can be chosen with "SELECT" command.
 struct DbTable : boost::intrusive_ref_counter<DbTable, boost::thread_unsafe_counter> {
   PrimeTable prime;
-  ExpireTable expire;
+  // ExpireTable expire;  // TTL is now embedded in CompactKey via SDS_TTL_TAG.
   DashTable<PrimeKey, uint32_t, detail::ExpireTablePolicy> mcflag;
 
   // Contains transaction locks
@@ -141,7 +144,7 @@ struct DbTable : boost::intrusive_ref_counter<DbTable, boost::thread_unsafe_coun
 
   mutable DbTableStats stats;
   std::unique_ptr<SlotStats[]> slots_stats;
-  ExpireTable::Cursor expire_cursor;
+  PrimeTable::Cursor expire_cursor;
 
   struct SampleTopKeys {
     TopKeys* top_keys = nullptr;
@@ -177,7 +180,7 @@ struct DbTable : boost::intrusive_ref_counter<DbTable, boost::thread_unsafe_coun
   PrimeIterator Launder(PrimeIterator it, std::string_view key);
 
   size_t table_memory() const {
-    return expire.mem_usage() + prime.mem_usage();
+    return prime.mem_usage();
   }
 };
 


### PR DESCRIPTION
## Summary

Each expiring key previously required both a prime-table entry and a
separate `ExpireTable` entry (~26-35 extra bytes per key). Building on the
SDS_TTL_TAG CompactKey support from PR #6925, the TTL is now embedded
directly inside the key, making the per-shard `ExpireTable` redundant.

- Replace expire table insert/lookup/erase with `SetExpireTime` /
  `GetExpireTime` / `ClearExpireTime` on `CompactKey`
- Scan prime table for expiry instead of expire table
- Fix memory accounting in `AddExpire`/`RemoveExpire` for inline <->
  `SDS_TTL_TAG` key transitions (`inline_keys` counter + `OBJ_KEY` heap tracking)
- Add regression test for inline key accounting

## Benchmark

`debug populate 10000000 key 16 EXPIRE 300 1000`

| | Used memory |
|-|-------------|
| Before | 900 MB |
| After  | 665 MB |
------------------------------------------------------------------------------
**Next step:** clean up of  redundant types and arguments, simplify the interfaces (ExpireIterator, AsRef() etc).