### PR TITLE
feat(core): embed TTL directly in CompactKey via SDS_TTL_TAG

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -1446,17 +1446,24 @@ size_t CompactObj::MallocUsed(bool slow) const {
   return 0;
 }
 
-bool CompactObj::operator==(const CompactObj& o) const {
+// TODO: we need this operator ONLY because we search in prime-table based on the ExpireKey
+// which is a reference to the CompactKey. Therefore operator== currently works
+// specifically for this particular use-case.
+// So once we remove the expire table, we can remove this operator too.
+// In addition - we MUST remove AsRef/IsRef api as well as it will break
+// once we start using SetTtl/ClearTtl methods. All in all, we will free up two additional bits.
+bool CompactKey::operator==(const CompactKey& o) const {
   DCHECK(taglen_ != JSON_TAG && o.taglen_ != JSON_TAG) << "cannot use JSON type to check equal";
 
-  uint8_t m1 = encoding_;
-  uint8_t m2 = o.encoding_;
-  // TODO: Dangerous with dynamic encoding rules as equal values can have different encodings
-  if (m1 != m2)
+  // Cross-tag/encoding comparison: fall back to decoded string comparison for OBJ_STRING.
+  // This handles e.g. SDS_TTL_TAG vs ROBJ_TAG/inline/INT_TAG with same logical content.
+  if (taglen_ != o.taglen_ || encoding_ != o.encoding_) {
+    if (ObjType() == OBJ_STRING && o.ObjType() == OBJ_STRING) {
+      std::string tmp;
+      return *this == o.GetSlice(&tmp);
+    }
     return false;
-
-  if (taglen_ != o.taglen_)
-    return false;
+  }
 
   if (taglen_ == ROBJ_TAG)
     return u_.r_obj.Equal(o.u_.r_obj);
@@ -1467,9 +1474,8 @@ bool CompactObj::operator==(const CompactObj& o) const {
   if (taglen_ == SMALL_TAG)
     return u_.small_str.Equal(o.u_.small_str);
 
-  if (taglen_ == SDS_TTL_TAG) {
+  if (taglen_ == SDS_TTL_TAG)
     return u_.sds_ttl.view() == o.u_.sds_ttl.view();
-  }
 
   DCHECK(IsInline() && o.IsInline());
 
@@ -1790,6 +1796,8 @@ CompactObjType ObjTypeFromString(std::string_view sv) {
 }
 
 void CompactKey::SetTtl(int64_t abs_ms) {
+  DCHECK(!IsRef() && !IsExternal());
+
   // Already SDS_TTL_TAG — update TTL in place.
   if (taglen_ == SDS_TTL_TAG) {
     u_.sds_ttl.ttl_ms = abs_ms;
@@ -1829,6 +1837,7 @@ void CompactKey::SetTtl(int64_t abs_ms) {
 void CompactKey::ClearTtl() {
   if (taglen_ != SDS_TTL_TAG)
     return;
+  DCHECK(!IsRef() && !IsExternal());
 
   string decoded;
   GetString(&decoded);

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -209,22 +209,6 @@ class CompactObj {
   uint64_t HashCode() const;
   static uint64_t HashCode(std::string_view str);
 
-  bool operator==(const CompactObj& o) const;
-
-  bool operator==(std::string_view sl) const;
-
-  bool operator!=(std::string_view sl) const {
-    return !(*this == sl);
-  }
-
-  friend bool operator!=(const CompactObj& lhs, const CompactObj& rhs) {
-    return !(lhs == rhs);
-  }
-
-  friend bool operator==(std::string_view sl, const CompactObj& o) {
-    return o.operator==(sl);
-  }
-
   bool HasFlag() const {
     return mask_bits_.mc_flag;
   }
@@ -562,16 +546,6 @@ class CompactObj {
   uint8_t encoding_ : 2;  // Encoding of string values
 };
 
-inline bool CompactObj::operator==(std::string_view sv) const {
-  if (encoding_)
-    return CmpEncoded(sv);
-
-  if (IsInline()) {
-    return std::string_view{u_.inline_str, taglen_} == sv;
-  }
-  return CmpNonInline(sv);
-}
-
 struct CompactKey : public CompactObj {
   CompactKey() : CompactObj(true) {
   }
@@ -606,7 +580,38 @@ struct CompactKey : public CompactObj {
 
   // Read the embedded TTL. Precondition: HasExpire() is true and tag is SDS_TTL_TAG.
   int64_t GetTtl() const;
+
+  CompactKey& operator=(std::string_view sv) noexcept {
+    SetString(sv);
+    return *this;
+  }
+
+  bool operator==(const CompactKey& o) const;
+
+  bool operator==(std::string_view sl) const;
+
+  bool operator!=(std::string_view sl) const {
+    return !(*this == sl);
+  }
+
+  friend bool operator!=(const CompactKey& lhs, const CompactKey& rhs) {
+    return !(lhs == rhs);
+  }
+
+  friend bool operator==(std::string_view sl, const CompactKey& o) {
+    return o.operator==(sl);
+  }
 };
+
+inline bool CompactKey::operator==(std::string_view sv) const {
+  if (encoding_)
+    return CmpEncoded(sv);
+
+  if (IsInline()) {
+    return std::string_view{u_.inline_str, taglen_} == sv;
+  }
+  return CmpNonInline(sv);
+}
 
 struct CompactValue : public CompactObj {
   CompactValue() : CompactObj(false) {

--- a/src/core/compact_object_test.cc
+++ b/src/core/compact_object_test.cc
@@ -3,6 +3,7 @@
 //
 #include "core/compact_object.h"
 
+#include <absl/functional/overload.h>
 #include <absl/strings/str_cat.h>
 #include <gtest/gtest.h>
 #include <mimalloc.h>
@@ -118,6 +119,7 @@ class CompactObjectTest : public ::testing::Test {
   }
 
   CompactValue cobj_;
+  CompactKey ckey_;
   string tmp_;
 };
 
@@ -260,7 +262,7 @@ TEST_F(CompactObjectTest, WastedMemoryDontCount) {
 
 TEST_F(CompactObjectTest, NonInline) {
   string s(22, 'a');
-  CompactValue obj{s};
+  CompactKey obj{s};
 
   uint64_t expected_val = XXH3_64bits_withSeed(s.data(), s.size(), kSeed);
   EXPECT_EQ(18261733907982517826UL, expected_val);
@@ -282,12 +284,12 @@ TEST_F(CompactObjectTest, InlineAsciiEncoded) {
 }
 
 TEST_F(CompactObjectTest, Int) {
-  cobj_.SetString("0");
-  EXPECT_EQ(0, cobj_.TryGetInt());
-  EXPECT_EQ(1, cobj_.Size());
-  EXPECT_EQ(cobj_, "0");
-  EXPECT_EQ("0", cobj_.GetSlice(&tmp_));
-  EXPECT_EQ(OBJ_STRING, cobj_.ObjType());
+  ckey_.SetString("0");
+  EXPECT_EQ(0, ckey_.TryGetInt());
+  EXPECT_EQ(1, ckey_.Size());
+  EXPECT_EQ(ckey_, "0");
+  EXPECT_EQ("0", ckey_.GetSlice(&tmp_));
+  EXPECT_EQ(OBJ_STRING, ckey_.ObjType());
 }
 
 TEST_F(CompactObjectTest, Expire) {
@@ -428,6 +430,27 @@ TEST_F(CompactObjectTest, SdsTtlTag) {
   {
     CompactKey key("hello");
     key.SetTtl(5000);
+  }
+
+  // 11. Cross-tag operator== (SDS_TTL_TAG vs inline/INT_TAG).
+  {
+    CompactKey a("hello");
+    CompactKey b("hello");
+    b.SetTtl(999);
+    // b is SDS_TTL_TAG, a is inline — must compare equal as OBJ_STRING.
+    EXPECT_TRUE(a == b);
+    EXPECT_TRUE(b == a);
+
+    CompactKey c("42");
+    CompactKey d("42");
+    d.SetTtl(1);
+    EXPECT_TRUE(c == d);
+    EXPECT_TRUE(d == c);
+
+    // Different content must not compare equal.
+    CompactKey e("world");
+    e.SetTtl(1);
+    EXPECT_FALSE(a == e);
   }
 }
 
@@ -895,6 +918,7 @@ TEST_F(CompactObjectTest, Huffman) {
   HuffmanEncoder encoder;
   BuildEncoderAB(&encoder);
   string bindata = encoder.Export();
+
   for (CompactObj::HuffmanDomain domain : {CompactObj::HUFF_KEYS, CompactObj::HUFF_STRING_VALUES}) {
     ASSERT_TRUE(CompactObj::InitHuffmanThreadLocal(domain, bindata));
     for (unsigned i = 30; i < 2048; i += 10) {
@@ -914,7 +938,8 @@ TEST_F(CompactObjectTest, Huffman) {
       string actual;
       cobj.GetString(&actual);
       EXPECT_EQ(data, actual);
-      EXPECT_EQ(cobj, data);
+      visit(absl::Overload{[&](CompactKey& co) { EXPECT_EQ(co, data); }, [&](CompactValue& co) {}},
+            obj_backing);
     }
   }
 }

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -771,13 +771,12 @@ OpResult<DbSlice::ItAndUpdater> DbSlice::AddOrFindInternal(const Context& cntx, 
 
   // Fast-path if change_cb_ is empty so we Find or Add using
   // the insert operation: twice more efficient.
-  PrimeKey co_key{key};
   PrimeIterator it;
 
   ssize_t table_before = db.prime.mem_usage();
 
   try {
-    it = db.prime.InsertNew(std::move(co_key), PrimeValue{}, evp);
+    it = db.prime.InsertNew(key, PrimeValue{}, evp);
   } catch (bad_alloc& e) {
     LOG_EVERY_T(WARNING, 1) << "AddOrFind: InsertNew failed, budget: " << memory_budget_
                             << " reclaimed: " << reclaimed << " offset: " << memory_offset;


### PR DESCRIPTION
## Summary
- Add `SDS_TTL_TAG` to `CompactObj` that stores key string as SDS alongside an int64 TTL, removing the need for separate expiry table lookups
- Refactor encoded blob retrieval into `GetEncodedBlob()` to deduplicate logic across `GetString` and `GetByteAtIndex`
- Add `CompactKey::SetTtl`/`ClearTtl`/`GetTtl` API with full support for converting from all existing tag types (inline, INT, SMALL, ROBJ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)