### PR TITLE
chore: improve naming and get rid of references for mcflag

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -1451,7 +1451,8 @@ size_t CompactObj::MallocUsed(bool slow) const {
 // specifically for this particular use-case.
 // So once we remove the expire table, we can remove this operator too.
 // In addition - we MUST remove AsRef/IsRef api as well as it will break
-// once we start using SetTtl/ClearTtl methods. All in all, we will free up two additional bits.
+// once we start using SetExpireTime/ClearExpireTime methods.
+// All in all, we will free up two additional bits.
 bool CompactKey::operator==(const CompactKey& o) const {
   DCHECK(taglen_ != JSON_TAG && o.taglen_ != JSON_TAG) << "cannot use JSON type to check equal";
 
@@ -1795,12 +1796,12 @@ CompactObjType ObjTypeFromString(std::string_view sv) {
   return kInvalidCompactObjType;
 }
 
-void CompactKey::SetTtl(int64_t abs_ms) {
+void CompactKey::SetExpireTime(uint64_t abs_ms) {
   DCHECK(!IsRef() && !IsExternal());
 
   // Already SDS_TTL_TAG — update TTL in place.
   if (taglen_ == SDS_TTL_TAG) {
-    u_.sds_ttl.ttl_ms = abs_ms;
+    u_.sds_ttl.exp_ms = abs_ms;
     return;
   }
 
@@ -1825,18 +1826,18 @@ void CompactKey::SetTtl(int64_t abs_ms) {
     new_sds = sdsnewlen(view.data(), view.size());
     u_.r_obj.Free(tl.local_mr);
   } else {
-    LOG(FATAL) << "Unexpected tag for SetTtl: " << int(taglen_);
+    LOG(FATAL) << "Unexpected tag for SetExpireTime: " << int(taglen_);
   }
 
   u_.sds_ttl.sds_ptr = new_sds;
-  u_.sds_ttl.ttl_ms = abs_ms;
+  u_.sds_ttl.exp_ms = abs_ms;
   taglen_ = SDS_TTL_TAG;
   mask_bits_.expire = 1;
 }
 
-void CompactKey::ClearTtl() {
+bool CompactKey::ClearExpireTime() {
   if (taglen_ != SDS_TTL_TAG)
-    return;
+    return false;
   DCHECK(!IsRef() && !IsExternal());
 
   string decoded;
@@ -1846,11 +1847,14 @@ void CompactKey::ClearTtl() {
   mask_bits_.expire = 0;
 
   SetString(decoded);
+  return true;
 }
 
-int64_t CompactKey::GetTtl() const {
-  DCHECK_EQ(taglen_, SDS_TTL_TAG);
-  return u_.sds_ttl.ttl_ms;
+uint64_t CompactKey::GetExpireTime() const {
+  if (taglen_ != SDS_TTL_TAG)
+    return 0;
+  DCHECK(!IsRef() && !IsExternal());
+  return u_.sds_ttl.exp_ms;
 }
 
 size_t CompactObj::StrEncoding::DecodedSize(string_view blob) const {

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -468,8 +468,8 @@ class CompactObj {
   static_assert(sizeof(ExternalPtr) == 16);
 
   struct SdsTtlString {
-    char* sds_ptr;   // SDS string (length via sdslen)
-    int64_t ttl_ms;  // absolute expiry in ms
+    char* sds_ptr;    // SDS string (length via sdslen)
+    uint64_t exp_ms;  // absolute expiry time in ms
 
     std::string_view view() const;
   } __attribute__((packed));
@@ -572,14 +572,16 @@ struct CompactKey : public CompactObj {
     mask_bits_.expire = e;
   }
 
-  // Embed TTL directly in the key by converting to SDS_TTL_TAG.
-  void SetTtl(int64_t abs_ms);
+  // Embed expire time directly in the key by converting to SDS_TTL_TAG.
+  void SetExpireTime(uint64_t abs_ms);
 
-  // Remove embedded TTL and convert back to optimal string form.
-  void ClearTtl();
+  // Remove embedded expire time and convert back to optimal string form.
+  bool ClearExpireTime();
 
-  // Read the embedded TTL. Precondition: HasExpire() is true and tag is SDS_TTL_TAG.
-  int64_t GetTtl() const;
+  // Read the embedded expire time.
+  // Returns 0 if there is no embedded expire time, otherwise
+  // returns the absolute expire time in ms.
+  uint64_t GetExpireTime() const;
 
   CompactKey& operator=(std::string_view sv) noexcept {
     SetString(sv);

--- a/src/core/compact_object_test.cc
+++ b/src/core/compact_object_test.cc
@@ -309,9 +309,9 @@ TEST_F(CompactObjectTest, SdsTtlTag) {
     ASSERT_TRUE(key.IsInline());
     uint64_t hash_before = key.HashCode();
 
-    key.SetTtl(1000);
+    key.SetExpireTime(1000);
     EXPECT_TRUE(key.HasExpire());
-    EXPECT_EQ(1000, key.GetTtl());
+    EXPECT_EQ(1000, key.GetExpireTime());
     EXPECT_EQ(hash_before, key.HashCode());
     EXPECT_TRUE(key == string_view("hello"));
     EXPECT_EQ(5, key.Size());
@@ -328,9 +328,9 @@ TEST_F(CompactObjectTest, SdsTtlTag) {
     ASSERT_TRUE(key.TryGetInt().has_value());
     uint64_t hash_before = key.HashCode();
 
-    key.SetTtl(2000);
+    key.SetExpireTime(2000);
     EXPECT_TRUE(key.HasExpire());
-    EXPECT_EQ(2000, key.GetTtl());
+    EXPECT_EQ(2000, key.GetExpireTime());
     EXPECT_TRUE(key == string_view("42"));
     EXPECT_EQ(hash_before, key.HashCode());
     // No longer INT_TAG — TryGetInt should return nullopt.
@@ -345,15 +345,15 @@ TEST_F(CompactObjectTest, SdsTtlTag) {
     CompactKey key(s);
     uint64_t hash_before = key.HashCode();
 
-    key.SetTtl(3000);
+    key.SetExpireTime(3000);
     EXPECT_TRUE(key.HasExpire());
-    EXPECT_EQ(3000, key.GetTtl());
+    EXPECT_EQ(3000, key.GetExpireTime());
     EXPECT_TRUE(key == string_view(s));
     EXPECT_EQ(hash_before, key.HashCode());
     EXPECT_EQ(s.size(), key.Size());
   }
 
-  // 4. ROBJ_TAG key + SetTtl
+  // 4. ROBJ_TAG key + SetExpireTime
   {
     string s(512, 'z');
     for (size_t i = 0; i < s.size(); ++i)
@@ -361,32 +361,31 @@ TEST_F(CompactObjectTest, SdsTtlTag) {
     CompactKey key(s);
     uint64_t hash_before = key.HashCode();
 
-    key.SetTtl(4000);
+    key.SetExpireTime(4000);
     EXPECT_TRUE(key.HasExpire());
-    EXPECT_EQ(4000, key.GetTtl());
+    EXPECT_EQ(4000, key.GetExpireTime());
     EXPECT_TRUE(key == string_view(s));
     EXPECT_EQ(hash_before, key.HashCode());
     EXPECT_EQ(s.size(), key.Size());
   }
 
-  // 5. TTL update in-place
+  // 5. ExpireTime update in-place
   {
     CompactKey key("hello");
-    key.SetTtl(1000);
-    EXPECT_EQ(1000, key.GetTtl());
+    key.SetExpireTime(1000);
+    EXPECT_EQ(1000, key.GetExpireTime());
 
-    key.SetTtl(2000);
-    EXPECT_EQ(2000, key.GetTtl());
+    key.SetExpireTime(2000);
+    EXPECT_EQ(2000, key.GetExpireTime());
     EXPECT_TRUE(key == string_view("hello"));
   }
 
   // 6. ClearTtl (inline recovery)
   {
     CompactKey key("hello");
-    key.SetTtl(1000);
-    EXPECT_TRUE(key.HasExpire());
+    key.SetExpireTime(1000);
+    EXPECT_TRUE(key.ClearExpireTime());
 
-    key.ClearTtl();
     EXPECT_FALSE(key.HasExpire());
     EXPECT_TRUE(key.IsInline());
     EXPECT_TRUE(key == string_view("hello"));
@@ -395,10 +394,8 @@ TEST_F(CompactObjectTest, SdsTtlTag) {
   // 7. ClearTtl (INT recovery)
   {
     CompactKey key("42");
-    key.SetTtl(1000);
-    EXPECT_TRUE(key.HasExpire());
-
-    key.ClearTtl();
+    key.SetExpireTime(1000);
+    EXPECT_TRUE(key.ClearExpireTime());
     EXPECT_FALSE(key.HasExpire());
     EXPECT_TRUE(key.TryGetInt().has_value());
     EXPECT_EQ(42, key.TryGetInt().value());
@@ -410,8 +407,8 @@ TEST_F(CompactObjectTest, SdsTtlTag) {
     for (size_t i = 0; i < s.size(); ++i)
       s[i] = 'a' + (i % 26);
     CompactKey key(s);
-    key.SetTtl(1000);
-    key.ClearTtl();
+    key.SetExpireTime(1000);
+    EXPECT_TRUE(key.ClearExpireTime());
     EXPECT_FALSE(key.HasExpire());
     EXPECT_TRUE(key == string_view(s));
   }
@@ -419,37 +416,37 @@ TEST_F(CompactObjectTest, SdsTtlTag) {
   // 9. Move semantics
   {
     CompactKey a("test");
-    a.SetTtl(100);
+    a.SetExpireTime(100);
     CompactKey b(std::move(a));
     EXPECT_TRUE(b.HasExpire());
-    EXPECT_EQ(100, b.GetTtl());
+    EXPECT_EQ(100, b.GetExpireTime());
     EXPECT_TRUE(b == string_view("test"));
   }
 
   // 10. Free/destructor — just verify no leaks (TearDown catches them).
   {
     CompactKey key("hello");
-    key.SetTtl(5000);
+    key.SetExpireTime(5000);
   }
 
   // 11. Cross-tag operator== (SDS_TTL_TAG vs inline/INT_TAG).
   {
     CompactKey a("hello");
     CompactKey b("hello");
-    b.SetTtl(999);
+    b.SetExpireTime(999);
     // b is SDS_TTL_TAG, a is inline — must compare equal as OBJ_STRING.
     EXPECT_TRUE(a == b);
     EXPECT_TRUE(b == a);
 
     CompactKey c("42");
     CompactKey d("42");
-    d.SetTtl(1);
+    d.SetExpireTime(1);
     EXPECT_TRUE(c == d);
     EXPECT_TRUE(d == c);
 
     // Different content must not compare equal.
     CompactKey e("world");
-    e.SetTtl(1);
+    e.SetExpireTime(1);
     EXPECT_FALSE(a == e);
   }
 }

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1043,19 +1043,29 @@ bool DbSlice::UpdateExpire(DbIndex db_ind, const Iterator& it, uint64_t at) {
   return false;
 }
 
-void DbSlice::SetMCFlag(DbIndex db_ind, PrimeKey key, uint32_t flag) {
+bool DbSlice::SetMCFlag(DbIndex db_ind, const PrimeKey& key, uint32_t flag) {
+  DCHECK(!key.IsRef());
+
   auto& db = *db_arr_[db_ind];
-  if (flag == 0) {
-    db.mcflag.Erase(key);
-  } else {
-    auto [it, _] = db.mcflag.Insert(std::move(key), flag);
+  string scratch;
+  if (flag == 0 && !db.mcflag.Empty()) {
+    auto mcit = db.mcflag.Find(key.GetSlice(&scratch));
+    if (mcit != db.mcflag.end()) {
+      db.mcflag.Erase(mcit);
+      return true;
+    }
+  } else if (flag != 0) {
+    auto [it, _] = db.mcflag.Insert(key.GetSlice(&scratch), flag);
     it->second = flag;
+    return true;
   }
+  return false;
 }
 
 uint32_t DbSlice::GetMCFlag(DbIndex db_ind, const PrimeKey& key) const {
   auto& db = *db_arr_[db_ind];
-  auto it = db.mcflag.Find(key);
+  string scratch;
+  auto it = db.mcflag.Find(key.GetSlice(&scratch));
   if (it.is_done()) {
     LOG(DFATAL) << "Internal error, inconsistent state, mcflag should be present but not found "
                 << key.ToString();
@@ -1843,7 +1853,7 @@ void DbSlice::PerformDeletionAtomic(const Iterator& del_it, const ExpIterator& e
   }
 
   if (del_it->second.HasFlag()) {
-    if (table->mcflag.Erase(del_it->first) == 0) {
+    if (!SetMCFlag(table->index, del_it->first, 0)) {
       LOG(DFATAL) << "Internal error, inconsistent state, mcflag should be present but not found "
                   << del_it->first.ToString();
     }

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -323,7 +323,9 @@ class DbSlice {
   // Does not change expiry if at != 0 and expiry already exists.
   bool UpdateExpire(DbIndex db_ind, const Iterator& main_it, uint64_t at);
 
-  void SetMCFlag(DbIndex db_ind, PrimeKey key, uint32_t flag);
+  // false if no action was taken, true if the mc flag was set or removed.
+  bool SetMCFlag(DbIndex db_ind, const PrimeKey& key, uint32_t flag);
+
   uint32_t GetMCFlag(DbIndex db_ind, const PrimeKey& key) const;
 
   // Creates a database with index `db_ind`. If such database exists does nothing.

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2703,7 +2703,7 @@ void RdbLoader::CreateObjectOnShard(const DbContext& db_cntx, const Item* item, 
   updater.it->first.SetSticky(item->is_sticky);
   if (item->has_mc_flags) {
     updater.it->second.SetFlag(true);
-    db_slice->SetMCFlag(db_cntx.db_index, updater.it->first.AsRef(), item->mc_flags);
+    db_slice->SetMCFlag(db_cntx.db_index, updater.it->first, item->mc_flags);
   }
 
   if (!override_existing_keys_ && !updater.is_new) {

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -898,8 +898,9 @@ OpStatus SetCmd::SetExisting(const SetParams& params, string_view value,
   it_upd->post_updater.ReduceHeapUsage();
 
   // Update flags
+  // TODO: avoid calling SetMCFlag if flags are not changed
   prime_value.SetFlag(params.memcache_flags != 0);
-  db_slice.SetMCFlag(op_args_.db_cntx.db_index, key.AsRef(), params.memcache_flags);
+  db_slice.SetMCFlag(op_args_.db_cntx.db_index, key, params.memcache_flags);
 
   // We need to remove the key from search indices, because we are overwriting it to OBJ_STRING
   RemoveKeyFromIndexesIfNeeded(it_upd->it.key(), op_args_.db_cntx, prime_value, shard);
@@ -930,7 +931,7 @@ void SetCmd::AddNew(const SetParams& params, const DbSlice::Iterator& it, std::s
 
   if (params.memcache_flags) {
     it->second.SetFlag(true);
-    db_slice.SetMCFlag(op_args_.db_cntx.db_index, it->first.AsRef(), params.memcache_flags);
+    db_slice.SetMCFlag(op_args_.db_cntx.db_index, it->first, params.memcache_flags);
   }
 
   if (params.flags & SET_STICK) {


### PR DESCRIPTION
1. CompactObj references are fragile and will be removed. This Pr removes them from mcflag table.
2. The Ttl API in CompactKey was wrong - we keep the expire time, and not the ttl there.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
