### PR TITLE
fix(core): Optimize SortedMap::GetRange

### DIFF
--- a/src/core/sorted_map.cc
+++ b/src/core/sorted_map.cc
@@ -194,22 +194,29 @@ SortedMap::ScoredArray CollectByPath(BPTreePath<SortedMap::ScoreSds> path, const
       return {};
   }
 
-  SortedMap::ScoredArray out;
-
-  // With small limit, reserve possibly more space but avoid traversing twice to count items
-  if (limit <= 100) {
-    out.reserve(limit);
-
+  // Iterate over path and call cb
+  auto loop = [&](auto cb) {
     while (limit--) {
       auto ele = path.Terminal();
       double score = GetObjScore(ele);
       if (range.max < score || (range.max == score && range.maxex))
         break;
 
-      out.emplace_back(string{(sds)ele, sdslen((sds)ele)}, score);
+      cb(ele, score);
       if (!path.Next())
         break;
     }
+  };
+
+  SortedMap::ScoredArray out;
+
+  // With small limit, reserve possibly more space but avoid traversing twice to count items
+  const unsigned kSmallPreallocateSize = 100;
+  if (limit <= kSmallPreallocateSize) {
+    out.reserve(limit);
+    loop([&](void* ele, double score) {
+      out.emplace_back(string{(sds)ele, sdslen((sds)ele)}, score);
+    });
 
     return out;
   }
@@ -218,16 +225,7 @@ SortedMap::ScoredArray CollectByPath(BPTreePath<SortedMap::ScoreSds> path, const
   size_t num_elems = 0;
 
   // Count the number of elements in the range.
-  while (limit--) {
-    auto ele = path.Terminal();
-
-    double score = GetObjScore(ele);
-    if (range.max < score || (range.max == score && range.maxex))
-      break;
-    ++num_elems;
-    if (!path.Next())
-      break;
-  }
+  loop([&](void*, double) { ++num_elems; });
 
   // Traverse again and save all items
   out.resize(num_elems);

--- a/src/core/sorted_map_test.cc
+++ b/src/core/sorted_map_test.cc
@@ -300,7 +300,7 @@ TEST_F(SortedMapTest, ReallocIfNeeded) {
 }
 
 // Benchmark GetRange call with range starting always at -inf and with no right bound
-// with diffenent size/limit configurations
+// with different size/limit configurations
 static void BM_GetRangeForwardInf(benchmark::State& state) {
   auto* tlh = mi_heap_get_backing();
   init_zmalloc_threadlocal(tlh);


### PR DESCRIPTION
Optimize GetRange by avoiding double traversal for small reads.

Benchmark results: about 1.5-2 faster range operations for the target read configuration. Everything else keeps unchanged

Before
```
2026-03-22T13:25:14+01:00
Running ./sorted_map_test
Run on (16 X 4600 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 1280 KiB (x8)
  L3 Unified 20480 KiB (x1)
Load Average: 0.72, 0.96, 1.01
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
-------------------------------------------------------------------------------------------------
Benchmark                                                       Time             CPU   Iterations
-------------------------------------------------------------------------------------------------
BM_GetRangeForwardInf/elements:1000/limit:10                  209 ns          208 ns      3395068
BM_GetRangeForwardInf/elements:10000/limit:10                 220 ns          219 ns      3183634
BM_GetRangeForwardInf/elements:100000/limit:10                239 ns          239 ns      2955616
BM_GetRangeForwardInf/elements:1000/limit:100                1420 ns         1418 ns       481649
BM_GetRangeForwardInf/elements:10000/limit:100               1497 ns         1495 ns       464655
BM_GetRangeForwardInf/elements:100000/limit:100              1477 ns         1474 ns       474913
BM_GetRangeForwardInf/elements:1000/limit:1000              15062 ns        15038 ns        46984
BM_GetRangeForwardInf/elements:10000/limit:1000             14980 ns        14960 ns        46719
BM_GetRangeForwardInf/elements:100000/limit:1000            15222 ns        15199 ns        46520
BM_GetRangeForwardInf/elements:1000/limit:4294967295        15053 ns        15032 ns        46350
BM_GetRangeForwardInf/elements:10000/limit:4294967295      143167 ns       142930 ns         4938
BM_GetRangeForwardInf/elements:100000/limit:4294967295    1665882 ns      1660033 ns          445
```

After
```
Run on (16 X 4600 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 1280 KiB (x8)
  L3 Unified 20480 KiB (x1)
Load Average: 0.53, 0.83, 0.95
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
-------------------------------------------------------------------------------------------------
Benchmark                                                       Time             CPU   Iterations
-------------------------------------------------------------------------------------------------
BM_GetRangeForwardInf/elements:1000/limit:10                  115 ns          114 ns      5791115
BM_GetRangeForwardInf/elements:10000/limit:10                 127 ns          127 ns      5449430
BM_GetRangeForwardInf/elements:100000/limit:10                143 ns          143 ns      4957038
BM_GetRangeForwardInf/elements:1000/limit:100                 808 ns          807 ns       869442
BM_GetRangeForwardInf/elements:10000/limit:100                825 ns          824 ns       844548
BM_GetRangeForwardInf/elements:100000/limit:100               854 ns          853 ns       816653
BM_GetRangeForwardInf/elements:1000/limit:1000              14953 ns        14935 ns        46754
BM_GetRangeForwardInf/elements:10000/limit:1000             14965 ns        14947 ns        46560
BM_GetRangeForwardInf/elements:100000/limit:1000            15133 ns        15114 ns        46779
BM_GetRangeForwardInf/elements:1000/limit:4294967295        15075 ns        15055 ns        46381
BM_GetRangeForwardInf/elements:10000/limit:4294967295      142625 ns       142391 ns         4951
BM_GetRangeForwardInf/elements:100000/limit:4294967295    1590744 ns      1586976 ns          463
```