### PR TITLE
chore(tiering): Move external storage metadata to fragment object

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -715,6 +715,12 @@ CompactObj& CompactObj::operator=(CompactObj&& o) noexcept {
   encoding_ = o.encoding_;
   memcpy(&u_, &o.u_, sizeof(u_));
 
+  // If this is external object, we need to update the fragment's
+  // pointer to this object, since it has been moved.
+  if (taglen_ == EXTERNAL_TAG) {
+    u_.fragment->UpdateValue(static_cast<CompactValue*>(this));
+  }
+
   o.taglen_ = 0;  // forget all data
   o.encoding_ = 0;
   o.mask_ = 0;
@@ -735,9 +741,9 @@ size_t CompactObj::Size() const {
       return decoded_str_size(u_.small_str.size(), u_.small_str.first_byte());
     case EXTERNAL_TAG:
       if (ObjType() == OBJ_STRING)
-        return decoded_str_size(u_.ext_ptr.serialized_size, GetFirstByte());
+        return decoded_str_size(u_.fragment->Size(), GetFirstByte());
       else
-        return u_.ext_ptr.serialized_size;
+        return u_.fragment->Size();
     case ROBJ_TAG:
       if (size_t size = u_.r_obj.Size(); u_.r_obj.type() != OBJ_STRING)
         return size;
@@ -810,7 +816,7 @@ CompactObjType CompactObj::ObjType() const {
     return OBJ_STRING;
 
   if (taglen_ == EXTERNAL_TAG) {
-    switch (static_cast<ExternalRep>(u_.ext_ptr.representation)) {
+    switch (u_.fragment->GetExternalRep()) {
       case ExternalRep::STRING:
         return OBJ_STRING;
       case ExternalRep::SERIALIZED_MAP:
@@ -1170,59 +1176,58 @@ void CompactObj::GetString(char* dest) const {
   LOG(FATAL) << "Bad tag " << int(taglen_);
 }
 
-void CompactObj::SetExternal(size_t offset, uint32_t sz, ExternalRep rep) {
-  uint8_t first_byte = 0;
-  if (encoding_ == HUFFMAN_ENC) {
-    CHECK(rep == ExternalRep::STRING);
-    first_byte = GetFirstByte();
+void CompactObj::SetExternal(tiering::Fragment* fragment) {
+  if (fragment->IsCool()) {
+    auto* record = fragment->GetCoolRecord();
+    encoding_ = record->value.encoding_;
+    SetMeta(EXTERNAL_TAG, record->value.mask_);
+  } else {
+    // Save first_byte for Huffman encoding before we lose the value data.
+    if (encoding_ == HUFFMAN_ENC) {
+      CHECK(fragment->GetExternalRep() == ExternalRep::STRING);
+      fragment->SetFirstByte(GetFirstByte());
+    }
+    SetMeta(EXTERNAL_TAG, mask_);
   }
-  SetMeta(EXTERNAL_TAG, mask_);
+  u_.fragment = fragment;
+}
 
-  u_.ext_ptr.is_cool = 0;
-  u_.ext_ptr.representation = static_cast<uint8_t>(rep);
-  u_.ext_ptr.first_byte = first_byte;
-  u_.ext_ptr.page_offset = offset % 4096;
-  u_.ext_ptr.serialized_size = sz;
-  u_.ext_ptr.offload.page_index = offset / 4096;
+tiering::Fragment* CompactObj::GetFragment() const {
+  DCHECK(IsExternal());
+  return u_.fragment;
+}
+
+bool CompactObj::IsCool() const {
+  assert(IsExternal());
+  return u_.fragment->IsCool();
 }
 
 CompactObj::ExternalRep CompactObj::GetExternalRep() const {
   DCHECK(IsExternal());
-  return static_cast<CompactObj::ExternalRep>(u_.ext_ptr.representation);
-}
-
-void CompactObj::SetCool(size_t offset, uint32_t sz, ExternalRep rep,
-                         tiering::TieredCoolRecord* record) {
-  encoding_ = record->value.encoding_;
-  SetMeta(EXTERNAL_TAG, record->value.mask_);
-
-  u_.ext_ptr.is_cool = 1;
-  u_.ext_ptr.representation = static_cast<uint8_t>(rep);
-  u_.ext_ptr.page_offset = offset % 4096;
-  u_.ext_ptr.serialized_size = sz;
-  u_.ext_ptr.cool_record = record;
+  return u_.fragment->GetExternalRep();
 }
 
 auto CompactObj::GetCool() const -> CoolItem {
-  DCHECK(IsExternal() && u_.ext_ptr.is_cool);
+  DCHECK(IsExternal() && IsCool());
+  auto* record = u_.fragment->GetCoolRecord();
 
   CoolItem res;
-  res.page_offset = u_.ext_ptr.page_offset;
-  res.serialized_size = u_.ext_ptr.serialized_size;
-  res.record = u_.ext_ptr.cool_record;
+  res.offset = u_.fragment->Offset();
+  res.serialized_size = u_.fragment->Size();
+  res.record = record;
   return res;
 }
 
 void CompactObj::Freeze(size_t offset, size_t sz) {
-  SetExternal(offset, sz, GetExternalRep());
+  DCHECK(IsExternal());
+  DCHECK_EQ(offset, u_.fragment->Offset());
+  DCHECK_EQ(sz, u_.fragment->Size());
+  u_.fragment->SetCoolRecord(nullptr);
 }
 
 std::pair<size_t, size_t> CompactObj::GetExternalSlice() const {
   DCHECK_EQ(EXTERNAL_TAG, taglen_);
-  auto& ext = u_.ext_ptr;
-  size_t offset = ext.page_offset;
-  offset += size_t(ext.is_cool ? ext.cool_record->page_index : ext.offload.page_index) * 4096;
-  return {offset, size_t(u_.ext_ptr.serialized_size)};
+  return u_.fragment->GetExternalSlice();
 }
 
 string_view CompactObj::GetEncodedBlob(StrEncoding str_encoding, char* opt_dest) const {
@@ -1253,7 +1258,7 @@ string_view CompactObj::GetEncodedBlob(StrEncoding str_encoding, char* opt_dest)
 
 void CompactObj::Materialize(std::string_view blob, bool is_raw) {
   CHECK(IsExternal()) << int(taglen_);
-  DCHECK_EQ(u_.ext_ptr.representation, static_cast<uint8_t>(ExternalRep::STRING));
+  DCHECK(u_.fragment->GetExternalRep() == ExternalRep::STRING);
   DCHECK_GT(blob.size(), kInlineLen);  // There are no mutable commands that shrink strings
 
   if (is_raw) {
@@ -1301,11 +1306,11 @@ uint8_t CompactObj::GetFirstByte() const {
   }
 
   if (taglen_ == EXTERNAL_TAG) {
-    if (u_.ext_ptr.is_cool) {
-      const CompactObj& cooled_obj = u_.ext_ptr.cool_record->value;
+    if (u_.fragment->IsCool()) {
+      const CompactObj& cooled_obj = u_.fragment->GetCoolRecord()->value;
       return cooled_obj.GetFirstByte();
     }
-    return u_.ext_ptr.first_byte;
+    return u_.fragment->GetFirstByte();
   }
 
   LOG(DFATAL) << "Bad tag " << int(taglen_);

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -21,7 +21,8 @@ namespace dfly {
 
 namespace tiering {
 struct TieredCoolRecord;
-}
+class Fragment;
+}  // namespace tiering
 
 constexpr unsigned kEncodingIntSet = 0;
 constexpr unsigned kEncodingStrMap2 = 2;  // for set/map encodings of strings using DenseSet
@@ -319,14 +320,17 @@ class CompactObj {
     return taglen_ == EXTERNAL_TAG;
   }
 
-  // returns true if the value is stored in the cooling storage. Cooling storage has an item both
+  // Returns true if the value is stored in the cooling storage. Cooling storage has an item both
   // on disk and in memory.
-  bool IsCool() const {
-    assert(IsExternal());
-    return u_.ext_ptr.is_cool;
-  }
+  bool IsCool() const;
 
-  void SetExternal(size_t offset, uint32_t sz, ExternalRep rep);
+  // Sets the object to external state, freeing in-memory value data.
+  void SetExternal(tiering::Fragment* fragment);
+
+  // Prerequisite: IsExternal() is true.
+  // Returns the fragment holding external value.
+  tiering::Fragment* GetFragment() const;
+
   ExternalRep GetExternalRep() const;
 
   // Switches to empty, non-external string.
@@ -336,13 +340,9 @@ class CompactObj {
     SetMeta(0, mask_);
   }
 
-  // Assigns a cooling record to the object together with its external slice.
-  void SetCool(size_t offset, uint32_t serialized_size, ExternalRep rep,
-               tiering::TieredCoolRecord* record);
-
   struct CoolItem {
-    uint16_t page_offset;
     size_t serialized_size;
+    size_t offset;
     tiering::TieredCoolRecord* record;
   };
 
@@ -451,28 +451,6 @@ class CompactObj {
     mask_ = mask;
   }
 
-  struct ExternalPtr {
-    uint32_t serialized_size;
-    uint16_t page_offset;  // 0 for multi-page blobs. != 0 for small blobs.
-    uint8_t is_cool : 1;
-    uint8_t representation : 2;  // See ExternalRep
-    uint8_t is_reserved : 5;
-    uint8_t first_byte;
-
-    // We do not have enough space in the common area to store page_index together with
-    // cool_record pointer. Therefore, we moved this field into TieredCoolRecord itself.
-    struct Offload {
-      uint32_t page_index;
-      uint32_t reserved;
-    };
-
-    union {
-      Offload offload;
-      tiering::TieredCoolRecord* cool_record;
-    };
-  } __attribute__((packed));
-  static_assert(sizeof(ExternalPtr) == 16);
-
   struct SdsTtlString {
     char* sds_ptr;    // SDS string (length via sdslen)
     uint64_t exp_ms;  // absolute expiry time in ms
@@ -516,7 +494,7 @@ class CompactObj {
     TOPK* topk __attribute__((packed));
     CMS* cms __attribute__((packed));
     int64_t ival __attribute__((packed));
-    ExternalPtr ext_ptr;
+    tiering::Fragment* fragment __attribute__((packed));
     SdsTtlString sds_ttl;
 
     U() : r_obj() {

--- a/src/core/compact_object_test.cc
+++ b/src/core/compact_object_test.cc
@@ -20,6 +20,7 @@
 #include "core/page_usage/page_usage_stats.h"
 #include "core/string_map.h"
 #include "core/string_set.h"
+#include "core/tiering_types.h"
 
 extern "C" {
 #include "redis/intset.h"
@@ -820,12 +821,16 @@ TEST_F(CompactObjectTest, StrEncodingAndMaterialize) {
       EXPECT_EQ(test_str, enc.Decode(raw_str).Take());
 
       // Test Materialize
-      obj.SetExternal(0, 0, CompactObj::ExternalRep::STRING);  // dummy values
+      tiering::Fragment frag1(&obj);
+      frag1.SetSegmentInfo(0, 0, CompactObj::ExternalRep::STRING);
+      obj.SetExternal(&frag1);
       obj.Materialize(raw_str, true);
       EXPECT_EQ(test_str, obj.ToString());
 
       // Restore from external again, but not as a raw value
-      obj.SetExternal(0, 0, CompactObj::ExternalRep::STRING);
+      tiering::Fragment frag2(&obj);
+      frag2.SetSegmentInfo(0, 0, CompactObj::ExternalRep::STRING);
+      obj.SetExternal(&frag2);
       auto test_str2 = test_str + "updated";
       obj.Materialize(test_str2, false);
       EXPECT_EQ(obj.ToString(), test_str2);
@@ -837,15 +842,21 @@ TEST_F(CompactObjectTest, ExternalRepresentation) {
   {
     CompactValue obj;
     obj.SetString("test");
-    obj.SetExternal(0, 4, CompactObj::ExternalRep::STRING);
+    tiering::Fragment frag(&obj);
+    frag.SetSegmentInfo(0, 4, CompactObj::ExternalRep::STRING);
+    obj.SetExternal(&frag);
     EXPECT_EQ(obj.ObjType(), OBJ_STRING);
+    obj.RemoveExternal();
   }
   {
     StringMap sm{};
     CompactValue obj;
     obj.SetRObjPtr(&sm);
-    obj.SetExternal(0, 4, CompactObj::ExternalRep::SERIALIZED_MAP);
+    tiering::Fragment frag(&obj);
+    frag.SetSegmentInfo(0, 4, CompactObj::ExternalRep::SERIALIZED_MAP);
+    obj.SetExternal(&frag);
     EXPECT_EQ(obj.ObjType(), OBJ_HASH);
+    obj.RemoveExternal();
   }
 }
 

--- a/src/core/tiering_types.cc
+++ b/src/core/tiering_types.cc
@@ -4,11 +4,36 @@
 
 #include "core/tiering_types.h"
 
+#include "core/compact_object.h"
 #include "redis/redis_aux.h"
 
 namespace dfly::tiering {
 
-auto FragmentRef::GetDescr(const CompactValue* pv) -> SerializationDescr {
+bool Fragment::IsExternal() const {
+  return std::visit([](CompactValue* pv) { return pv->IsExternal(); }, val_);
+}
+
+void Fragment::RemoveExternal() {
+  std::visit([](CompactValue* pv) { pv->RemoveExternal(); }, val_);
+}
+
+void Fragment::SetExternal() {
+  std::visit([this](CompactValue* pv) { pv->SetExternal(this); }, val_);
+}
+
+bool Fragment::HasStashPending() const {
+  return std::visit([](CompactValue* pv) { return pv->HasStashPending(); }, val_);
+}
+
+void Fragment::SetStashPending(bool b) {
+  std::visit([b](CompactValue* pv) { pv->SetStashPending(b); }, val_);
+}
+
+CompactObjType Fragment::ObjType() const {
+  return std::visit([](CompactValue* pv) { return pv->ObjType(); }, val_);
+}
+
+auto Fragment::GetDescr(const CompactValue* pv) -> SerializationDescr {
   switch (pv->ObjType()) {
     case OBJ_STRING: {
       if (!pv->HasAllocated())
@@ -27,12 +52,22 @@ auto FragmentRef::GetDescr(const CompactValue* pv) -> SerializationDescr {
   };
 }
 
-TieredCoolRecord* FragmentRef::GetCoolRecord() const {
-  return std::visit(
-      [](auto* pv) -> TieredCoolRecord* {
-        return pv->IsExternal() && pv->IsCool() ? pv->GetCool().record : nullptr;
-      },
-      val_);
+auto Fragment::GetSerializationDescr() const -> SerializationDescr {
+  return std::visit([](CompactValue* pv) { return GetDescr(pv); }, val_);
+}
+
+std::pair<size_t, size_t> Fragment::GetExternalSlice() const {
+  return {offset_, serialized_size_};
+}
+
+void Fragment::SetSegmentInfo(size_t offset, size_t length, CompactObj::ExternalRep rep) {
+  offset_ = offset;
+  serialized_size_ = length;
+  representation_ = static_cast<uint8_t>(rep);
+}
+
+CompactObj::ExternalRep Fragment::GetExternalRep() const {
+  return static_cast<CompactObj::ExternalRep>(representation_);
 }
 
 }  // namespace dfly::tiering

--- a/src/core/tiering_types.h
+++ b/src/core/tiering_types.h
@@ -18,13 +18,12 @@ namespace dfly::tiering {
 struct TieredCoolRecord : public ::boost::intrusive::list_base_hook<
                               boost::intrusive::link_mode<boost::intrusive::normal_link>> {
   uint64_t key_hash;  // Allows searching the entry in the dbslice.
-  CompactValue value;
   uint16_t db_index;
-  uint32_t page_index;
+  CompactValue value;
 };
 static_assert(sizeof(TieredCoolRecord) == 48);
 
-class FragmentRef {
+class Fragment {
  public:
   // Describes how this fragment should be serialized for offloading.
   // Used by stashing flow.
@@ -33,51 +32,91 @@ class FragmentRef {
     CompactObj::ExternalRep rep = CompactObj::ExternalRep::STRING;
   };
 
-  FragmentRef(CompactValue& pv) : val_(&pv) {  // NOLINT
+  using FragmentType = std::variant<CompactValue*>;
+
+  Fragment(CompactValue& pv) : val_(&pv) {  // NOLINT
   }
 
-  FragmentRef(CompactValue* pv) : val_(pv) {  // NOLINT
+  Fragment(CompactValue* pv) : val_(pv) {  // NOLINT
   }
 
-  bool IsOffloaded() const {
-    return std::visit([](auto* pv) { return pv->IsExternal(); }, val_);
-  }
+  bool IsExternal() const;
+  void RemoveExternal();
+  void SetExternal();
 
-  // Resets offloaded state for this fragment.
-  void ClearOffloaded() {
-    std::visit([](auto* pv) { pv->RemoveExternal(); }, val_);
-  }
+  bool HasStashPending() const;
+  void SetStashPending(bool b);
 
-  bool HasStashPending() const {
-    return std::visit([](auto* pv) { return pv->HasStashPending(); }, val_);
-  }
-
-  void ClearStashPending() {
-    std::visit([](auto* pv) { pv->SetStashPending(false); }, val_);
-  }
-
-  CompactObjType ObjType() const {
-    return std::visit([](auto* pv) { return pv->ObjType(); }, val_);
-  }
+  CompactObjType ObjType() const;
 
   // Determine required byte size and encoding type based on value.
-  SerializationDescr GetSerializationDescr() const {
-    return std::visit([](auto* pv) { return GetDescr(pv); }, val_);
+  SerializationDescr GetSerializationDescr() const;
+
+  bool IsCool() const {
+    return is_cool_;
   }
 
-  // Returns a pointer to TieredCoolRecord if this fragment is cool, and null otherwise.
-  TieredCoolRecord* GetCoolRecord() const;
+  void SetCoolRecord(TieredCoolRecord* record) {
+    cool_record_ = record;
+    is_cool_ = (record != nullptr);
+  }
 
-  // Returns the external slice of the offloaded value. Only valid if IsOffloaded() is true.
-  std::pair<size_t, size_t> GetExternalSlice() const {
-    return std::visit([](auto* pv) { return pv->GetExternalSlice(); }, val_);
+  TieredCoolRecord* GetCoolRecord() const {
+    return cool_record_;
+  }
+
+  std::pair<size_t, size_t> GetExternalSlice() const;
+
+  void SetSegmentInfo(size_t offset, size_t length, CompactObj::ExternalRep rep);
+
+  size_t Offset() const {
+    return offset_;
+  }
+
+  size_t Size() const {
+    return serialized_size_;
+  }
+
+  CompactObj::ExternalRep GetExternalRep() const;
+
+  void SetFirstByte(uint8_t byte) {
+    first_byte_ = byte;
+  }
+
+  uint8_t GetFirstByte() const {
+    return first_byte_;
+  }
+
+  void UpdateValue(CompactValue* pv) {
+    val_ = pv;
+  }
+
+  void SetId(size_t id) {
+    id_ = id;
+  }
+
+  size_t Id() const {
+    return id_;
   }
 
  private:
   static SerializationDescr GetDescr(const CompactValue* pv);
 
-  // TODO: to support more types, for example Node* from qlist.h.
-  std::variant<CompactValue*> val_;
+  size_t id_ = 0;
+
+  uint8_t is_cool_ : 1 = 0;         // Whether the values is in the cooling storage.
+  uint8_t representation_ : 2 = 0;  // See ExternalRep
+  uint8_t reserved_ : 5 = 0;
+
+  TieredCoolRecord* cool_record_ = nullptr;
+
+  uint32_t serialized_size_ = 0;
+  size_t offset_ = 0;
+
+  // First byte of the value if Huffman encoded
+  uint8_t first_byte_ = 0;
+
+  FragmentType val_;
 };
 
 }  // namespace dfly::tiering

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -640,12 +640,12 @@ auto DbSlice::FindInternal(const Context& cntx, string_view key, optional<unsign
   // Rationale: we either look it up for reads - and then it's hot, or alternatively,
   // we follow up with modifications, so the pending stash becomes outdated.
   if (pv.HasStashPending()) {
-    owner_->tiered_storage()->CancelStash(cntx.db_index, key, &pv);
+    owner_->tiered_storage()->CancelStash(std::make_pair(cntx.db_index, key));
   }
 
   // Fetch back cool items
   if (pv.IsExternal() && pv.IsCool()) {
-    pv = owner_->tiered_storage()->Warmup(cntx.db_index, pv.GetCool());
+    pv = owner_->tiered_storage()->Warmup(cntx.db_index, pv);
   }
 
   // Mark this entry as being looked up. We use key (first) deliberately to preserve the hotness
@@ -1571,9 +1571,9 @@ void DbSlice::RemoveOffloadedEntriesFromTieredStorage(absl::Span<const DbIndex> 
     do {
       cursor = db_ptr->prime.Traverse(cursor, [&](PrimeIterator it) {
         if (it->second.IsExternal()) {
-          tiered_storage->Delete(index, &it->second);
+          tiered_storage->Delete(index, it->second.GetFragment());
         } else if (it->second.HasStashPending()) {
-          tiered_storage->CancelStash(index, it->first.GetSlice(&scratch), &it->second);
+          tiered_storage->CancelStash(std::make_pair(index, it->first.GetSlice(&scratch)));
         }
       });
     } while (cursor);
@@ -1782,9 +1782,9 @@ void DbSlice::PerformDeletionAtomic(const Iterator& del_it, DbTable* table, bool
   if (pv.HasStashPending()) {
     string scratch;
     string_view key = del_it->first.GetSlice(&scratch);
-    shard_owner()->tiered_storage()->CancelStash(table->index, key, &pv);
+    shard_owner()->tiered_storage()->CancelStash(std::make_pair(table->index, key));
   } else if (pv.IsExternal()) {
-    shard_owner()->tiered_storage()->Delete(table->index, &del_it->second);
+    shard_owner()->tiered_storage()->Delete(table->index, pv.GetFragment());
   }
 
   ssize_t value_heap_size = pv.MallocUsed(), key_size_used = del_it->first.MallocUsed();

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -896,9 +896,8 @@ OpStatus SetCmd::SetExisting(const SetParams& params, string_view value,
   // We need to remove the key from search indices, because we are overwriting it to OBJ_STRING
   RemoveKeyFromIndexesIfNeeded(it_upd->it.key(), op_args_.db_cntx, prime_value, shard);
 
-  // If value is external, mark it as deleted
   if (prime_value.IsExternal()) {
-    shard->tiered_storage()->Delete(op_args_.db_cntx.db_index, &prime_value);
+    shard->tiered_storage()->Delete(op_args_.db_cntx.db_index, prime_value.GetFragment());
   }
 
   // overwrite existing entry.

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -58,7 +58,7 @@ namespace dfly {
 
 using namespace std;
 using namespace util;
-using tiering::FragmentRef;
+using tiering::Fragment;
 using tiering::KeyRef;
 using tiering::TieredCoolRecord;
 
@@ -79,7 +79,7 @@ void RecordDeleted(const PrimeValue& pv, size_t tiered_len, DbTableStats* stats)
 }
 
 tiering::DiskSegment FromCoolItem(const PrimeValue::CoolItem& item) {
-  return {item.record->page_index * tiering::kPageSize + item.page_offset, item.serialized_size};
+  return {item.offset, item.serialized_size};
 }
 
 string SerializeToString(const TieredStorage::StashDescriptor& blobs) {
@@ -134,6 +134,8 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
   void ClearStashPending(OpManager::KeyRef key) {
     UnblockBackpressure(key, false);
     if (auto pv = Find(key.first, key.second); pv) {
+      auto* fragment = ts_->TakePendingFragment(key);
+      ts_->RemoveFragment(fragment);
       pv->SetStashPending(false);
       stats_.total_cancels++;
     }
@@ -189,11 +191,12 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
       case CompactObj::ExternalRep::STRING:
         pv->Materialize(value, true);
         break;
-      case CompactObj::ExternalRep::SERIALIZED_MAP:
+      case CompactObj::ExternalRep::SERIALIZED_MAP: {
         tiering::SerializedMapDecoder decoder{};
         decoder.Initialize(value);
         decoder.Upload(pv);
         break;
+      }
     };
 
     RecordDeleted(*pv, value.size(), GetDbTableStats(dbid));
@@ -211,14 +214,17 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
       stats->tiered_used_bytes += segment.length;
       stats_.total_stashes++;
 
-      StashDescriptor blobs{FragmentRef{*pv}.GetSerializationDescr()};
+      tiering::Fragment* fragment = ts_->TakePendingFragment({key.first, std::string{key.second}});
+      auto blobs = fragment->GetSerializationDescr();
+      fragment->SetSegmentInfo(segment.offset, segment.length, blobs.rep);
+
       if (ts_->config_.experimental_cooling) {
         RetireColdEntries(pv->MallocUsed());
-        ts_->CoolDown(key.first, key.second, segment, blobs.rep, pv);
+        ts_->CoolDown(key.first, key.second, segment, pv, fragment);
       } else {
         stats->AddTypeMemoryUsage(pv->ObjType(), -pv->MallocUsed());
-        pv->SetExternal(segment.offset, segment.length, blobs.rep);
       }
+      fragment->SetExternal();
     } else {
       LOG(DFATAL) << "Should not reach here";
     }
@@ -262,12 +268,14 @@ void TieredStorage::ShardOpManager::Defragment(tiering::DiskSegment segment, str
 
     stats_.total_defrags++;
     PrimeValue& pv = it->second;
+    tiering::Fragment* frag = pv.GetFragment();
     if (pv.IsCool()) {
       PrimeValue::CoolItem item = pv.GetCool();
       tiering::DiskSegment segment = FromCoolItem(item);
 
       // We remove it from both cool storage and the offline storage.
       pv = ts_->DeleteCool(item.record);
+      ts_->RemoveFragment(frag);
       auto* stats = GetDbTableStats(dbid);
       stats->tiered_entries--;
       stats->tiered_used_bytes -= segment.length;
@@ -275,6 +283,7 @@ void TieredStorage::ShardOpManager::Defragment(tiering::DiskSegment segment, str
       // Cut out relevant part of value and restore it to memory
       string_view value = page.substr(item_segment.offset - segment.offset, item_segment.length);
       Upload(dbid, value, &pv);
+      ts_->RemoveFragment(frag);
     }
   }
 }
@@ -309,8 +318,10 @@ bool TieredStorage::ShardOpManager::NotifyFetched(const OwnedEntryId& id,
   if (pv && pv->IsExternal() && segment == pv->GetExternalSlice()) {
     if (metrics.modified || pv->WasTouched()) {
       ++stats_.total_uploads;
+      tiering::Fragment* frag = pv->GetFragment();
       decoder->Upload(pv);
       RecordDeleted(*pv, segment.length, GetDbTableStats(key.first));
+      ts_->RemoveFragment(frag);
       return true;
     }
     pv->SetTouched(true);
@@ -405,7 +416,7 @@ void TieredStorage::Stash(DbIndex dbid, string_view key, const StashDescriptor& 
   size_t est_size = blobs.EstimatedSerializedSize();
   DCHECK_GT(est_size, 0u);
 
-  tiering::OpManager::PendingId id;
+  tiering::PendingId id;
   error_code ec;
 
   if (OccupiesWholePages(est_size)) {  // large enough for own page
@@ -438,36 +449,41 @@ void TieredStorage::Stash(DbIndex dbid, string_view key, const StashDescriptor& 
   }
 }
 
-void TieredStorage::Delete(DbIndex dbid, FragmentRef fragment_ref) {
-  DCHECK(!fragment_ref.HasStashPending());
+void TieredStorage::Delete(DbIndex dbid, Fragment* fragment) {
+  DCHECK(!fragment->HasStashPending());
   ++stats_.total_deletes;
 
-  tiering::DiskSegment segment = fragment_ref.GetExternalSlice();
-  if (auto* cool = fragment_ref.GetCoolRecord(); cool) {
-    auto hot = DeleteCool(cool);
+  tiering::DiskSegment segment = fragment->GetExternalSlice();
+  if (fragment->IsCool()) {
+    auto hot = DeleteCool(fragment->GetCoolRecord());
     DCHECK_EQ(hot.ObjType(), OBJ_STRING);
   }
-  fragment_ref.ClearOffloaded();
+  fragment->RemoveExternal();
+  RemoveFragment(fragment);
   op_manager_->DeleteOffloaded(dbid, segment);
 }
 
-void TieredStorage::CancelStash(DbIndex dbid, std::string_view key,
-                                tiering::FragmentRef fragment_ref) {
-  DCHECK(fragment_ref.HasStashPending());
+void TieredStorage::CancelStash(tiering::PendingId id) {
+  DCHECK(std::holds_alternative<KeyRef>(id));
+  KeyRef key = std::get<KeyRef>(id);
+
+  tiering::Fragment* fragment = TakePendingFragment(key);
+  DCHECK(fragment->HasStashPending());
 
   // If any previous write was happening, it has been cancelled
-  if (auto node = stash_backpressure_.extract(make_pair(dbid, key)); !node.empty())
+  if (auto node = stash_backpressure_.extract(key); !node.empty())
     std::move(node.mapped()).Resolve(false);
 
   // TODO: Don't recompute size estimate, try-delete bin first
-  StashDescriptor blobs{fragment_ref.GetSerializationDescr()};
+  StashDescriptor blobs{fragment->GetSerializationDescr()};
   size_t size = blobs.EstimatedSerializedSize();
   if (OccupiesWholePages(size)) {
-    op_manager_->CancelPending(KeyRef(dbid, key));
-  } else if (auto bin = bins_->Delete(dbid, key); bin) {
+    op_manager_->CancelPending(key);
+  } else if (auto bin = bins_->Delete(key.first, key.second); bin) {
     op_manager_->CancelPending(*bin);
   }
-  fragment_ref.ClearStashPending();
+  fragment->SetStashPending(false);
+  RemoveFragment(fragment);
 }
 
 TieredStats TieredStorage::GetStats() const {
@@ -567,7 +583,9 @@ void TieredStorage::RunOffloading(DbIndex dbid) {
       } else {
         stats_.offloading_stashes++;
         it->second.SetStashPending(true);
-        Stash(dbid, it->first.GetSlice(&tmp), *blobs, nullptr);
+        string_view key_sv = it->first.GetSlice(&tmp);
+        AddFragment(dbid, key_sv, &it->second);
+        Stash(dbid, key_sv, *blobs, nullptr);
       }
     }
   };
@@ -621,18 +639,18 @@ size_t TieredStorage::ReclaimMemory(size_t goal) {
   return gained;
 }
 
-auto TieredStorage::ShouldStash(const tiering::FragmentRef& fragment_ref) const
+auto TieredStorage::ShouldStash(const tiering::Fragment& fragment) const
     -> std::optional<StashDescriptor> {
   // Check value state
-  if (fragment_ref.IsOffloaded() || fragment_ref.HasStashPending())
+  if (fragment.IsExternal() || fragment.HasStashPending())
     return nullopt;
 
   // For now, hash offloading is conditional
-  if (fragment_ref.ObjType() == OBJ_HASH && !config_.experimental_hash_offload)
+  if (fragment.ObjType() == OBJ_HASH && !config_.experimental_hash_offload)
     return nullopt;
 
   // Estimate value size
-  StashDescriptor blobs{fragment_ref.GetSerializationDescr()};
+  StashDescriptor blobs{fragment.GetSerializationDescr()};
   size_t estimated_size = blobs.EstimatedSerializedSize();
   if (estimated_size < config_.min_value_size)
     return nullopt;
@@ -651,26 +669,30 @@ auto TieredStorage::ShouldStash(const tiering::FragmentRef& fragment_ref) const
 }
 
 void TieredStorage::CoolDown(DbIndex db_ind, std::string_view str,
-                             const tiering::DiskSegment& segment, CompactObj::ExternalRep rep,
-                             PrimeValue* pv) {
+                             const tiering::DiskSegment& segment, PrimeValue* pv,
+                             tiering::Fragment* fragment) {
   TieredCoolRecord* record = CompactObj::AllocateMR<TieredCoolRecord>();
   cool_queue_.push_front(*record);
   stats_.cool_memory_used += (sizeof(TieredCoolRecord) + pv->MallocUsed());
 
   record->key_hash = CompactObj::HashCode(str);
   record->db_index = db_ind;
-  record->page_index = segment.offset / tiering::kPageSize;
   record->value = std::move(*pv);
 
-  pv->SetCool(segment.offset, segment.length, rep, record);
+  // Store cool record in the fragment and point CompactObj to it.
+  fragment->SetCoolRecord(record);
 }
 
-PrimeValue TieredStorage::Warmup(DbIndex dbid, PrimeValue::CoolItem item) {
+PrimeValue TieredStorage::Warmup(DbIndex dbid, PrimeValue& pv) {
+  DCHECK(pv.IsExternal() && pv.IsCool());
+  PrimeValue::CoolItem item = pv.GetCool();
+  tiering::Fragment* frag = pv.GetFragment();
   tiering::DiskSegment segment = FromCoolItem(item);
 
   // We remove it from both cool storage and the offline storage.
   PrimeValue hot = DeleteCool(item.record);
   op_manager_->DeleteOffloaded(dbid, segment);
+  RemoveFragment(frag);
   return hot;
 }
 
@@ -694,10 +716,37 @@ TieredCoolRecord* TieredStorage::PopCool() {
   return &res;
 }
 
+tiering::Fragment* TieredStorage::AddFragment(DbIndex dbid, std::string_view key,
+                                              tiering::Fragment::FragmentType val) {
+  size_t id = next_fragment_id_++;
+  auto [it, inserted] = tiered_fragments_.emplace(
+      id, std::visit([](auto* pv) { return tiering::Fragment{pv}; }, val));
+  DCHECK(inserted);
+  it->second.SetId(id);
+  pending_fragments_[{dbid, std::string{key}}] = id;
+  return &it->second;
+}
+
+void TieredStorage::RemoveFragment(tiering::Fragment* fragment) {
+  size_t erased = tiered_fragments_.erase(fragment->Id());
+  DCHECK_EQ(erased, 1u);
+}
+
+tiering::Fragment* TieredStorage::TakePendingFragment(const KeyRef& key) {
+  auto it = pending_fragments_.find(key);
+  DCHECK(it != pending_fragments_.end());
+  size_t id = it->second;
+  pending_fragments_.erase(it);
+  auto frag_it = tiered_fragments_.find(id);
+  DCHECK(frag_it != tiered_fragments_.end());
+  return &frag_it->second;
+}
+
 void StashPrimeValue(DbIndex dbid, std::string_view key, PrimeValue* pv, TieredStorage* ts,
                      BackPressureFuture* backpressure) {
-  if (auto blobs = ts->ShouldStash(*pv); blobs) {
+  if (auto blobs = ts->ShouldStash(pv); blobs) {
     pv->SetStashPending(true);
+    ts->AddFragment(dbid, key, pv);
     ts->Stash(dbid, key, *blobs, backpressure);
   }
 }

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -3,7 +3,7 @@
 //
 #pragma once
 
-#include <absl/container/flat_hash_map.h>
+#include <absl/container/node_hash_map.h>
 
 #include <boost/intrusive/list.hpp>
 #include <memory>
@@ -30,11 +30,11 @@ struct Decoder;
 struct TieredStorageBase {
   // Min sizes of values taking up full page on their own
   const static size_t kMinOccupancySize = tiering::kPageSize / 2;
-  struct StashDescriptor : public tiering::FragmentRef::SerializationDescr {
+  struct StashDescriptor : public tiering::Fragment::SerializationDescr {
     StashDescriptor() = default;
 
-    StashDescriptor(const tiering::FragmentRef::SerializationDescr& params)  // NOLINT
-        : tiering::FragmentRef::SerializationDescr(params) {
+    StashDescriptor(const tiering::Fragment::SerializationDescr& params)  // NOLINT
+        : tiering::Fragment::SerializationDescr(params) {
     }
 
     size_t EstimatedSerializedSize() const;
@@ -83,7 +83,7 @@ class TieredStorage : public TieredStorageBase {
   }
 
   // Returns StashDescriptor if a value should be stashed.
-  std::optional<StashDescriptor> ShouldStash(const tiering::FragmentRef& fragment_ref) const;
+  std::optional<StashDescriptor> ShouldStash(const tiering::Fragment& fragment) const;
 
   // Stash value, returns optional future for backpressure is not null.
   // if `provide_bp` is set and conditions are met.
@@ -91,13 +91,14 @@ class TieredStorage : public TieredStorageBase {
              BackPressureFuture* backpressure);
 
   // Delete value, must be offloaded (external type)
-  void Delete(DbIndex dbid, tiering::FragmentRef fragment_ref);
+  void Delete(DbIndex dbid, tiering::Fragment* fragment);
 
   // Returns true if there is a pending modification for the given segment.
   bool HasModificationPending(tiering::DiskSegment segment) const;
 
-  // Cancel pending stash for the fragment, must have HasStashPending() true.
-  void CancelStash(DbIndex dbid, std::string_view key, tiering::FragmentRef fragment_ref);
+  // Cancel pending stash for the value. Pending fragment will be matched by (dbid, key)
+  // and removed from pending fragment container. Must have HasStashPending() true.
+  void CancelStash(tiering::PendingId id);
 
   // Run offloading loop until i/o device is loaded or all entries were traversed
   void RunOffloading(DbIndex dbid);
@@ -106,7 +107,8 @@ class TieredStorage : public TieredStorageBase {
   size_t ReclaimMemory(size_t goal);
 
   // Returns the primary value, and deletes the cool item as well as its offloaded storage.
-  PrimeValue Warmup(DbIndex dbid, PrimeValue::CoolItem item);
+  // Also deregisters the fragment from the central container.
+  PrimeValue Warmup(DbIndex dbid, PrimeValue& pv);
 
   TieredStats GetStats() const;
 
@@ -122,6 +124,12 @@ class TieredStorage : public TieredStorageBase {
     return stats_.cool_memory_used;
   }
 
+  // Create a Fragment for the given value and register it as pending under (dbid, key).
+  // Returns a stable pointer (node_hash_map guarantees pointer stability).
+  tiering::Fragment* AddFragment(DbIndex dbid, std::string_view key,
+                                 tiering::Fragment::FragmentType pv);
+  void RemoveFragment(tiering::Fragment* fragment);
+
  private:
   void ReadInternal(DbIndex dbid, std::string_view key, const tiering::DiskSegment& segment,
                     const tiering::Decoder& decoder,
@@ -129,7 +137,7 @@ class TieredStorage : public TieredStorageBase {
 
   // Moves pv contents to the cool storage and updates pv to point to it.
   void CoolDown(DbIndex db_ind, std::string_view str, const tiering::DiskSegment& segment,
-                CompactObj::ExternalRep rep, PrimeValue* pv);
+                PrimeValue* pv, tiering::Fragment* fragment);
 
   PrimeValue DeleteCool(tiering::TieredCoolRecord* record);
   tiering::TieredCoolRecord* PopCool();
@@ -144,6 +152,18 @@ class TieredStorage : public TieredStorageBase {
 
   using CoolQueue = ::boost::intrusive::list<tiering::TieredCoolRecord>;
   CoolQueue cool_queue_;
+
+  // Fragment container — keyed by monotonic id, pointer-stable.
+  using TieredFragments = absl::node_hash_map<size_t, tiering::Fragment>;
+  size_t next_fragment_id_ = 0;
+  TieredFragments tiered_fragments_;
+
+  // Maps (dbid, key) -> fragment id for stash-pending entries.
+  // Safe against DashTable relocations (keys are copied strings).
+  tiering::EntryMap<size_t> pending_fragments_;
+
+  // Look up and remove a pending fragment by (dbid, key). Returns the Fragment pointer.
+  tiering::Fragment* TakePendingFragment(const tiering::KeyRef& key);
 
   struct {
     size_t min_value_size;
@@ -234,7 +254,7 @@ class TieredStorage : public TieredStorageBase {
     return {};
   }
 
-  std::optional<StashDescriptor> ShouldStash(const tiering::FragmentRef& fragment) const {
+  std::optional<StashDescriptor> ShouldStash(const tiering::Fragment& fragment) const {
     return {};
   }
 
@@ -242,7 +262,7 @@ class TieredStorage : public TieredStorageBase {
              BackPressureFuture* backpressure) {
   }
 
-  void Delete(DbIndex dbid, PrimeValue* value) {
+  void Delete(DbIndex dbid, tiering::Fragment* fragment) {
   }
 
   bool HasModificationPending(tiering::DiskSegment segment) const {
@@ -261,7 +281,7 @@ class TieredStorage : public TieredStorageBase {
     return 0;
   }
 
-  void CancelStash(DbIndex dbid, std::string_view key, tiering::FragmentRef fragment_ref) {
+  void CancelStash(tiering::PendingId id) {
   }
 
   TieredStats GetStats() const {
@@ -286,8 +306,16 @@ class TieredStorage : public TieredStorageBase {
     return 0;
   }
 
-  PrimeValue Warmup(DbIndex dbid, PrimeValue::CoolItem item) {
+  PrimeValue Warmup(DbIndex dbid, PrimeValue& pv) {
     return PrimeValue{};
+  }
+
+  tiering::Fragment* AddFragment(DbIndex dbid, std::string_view key,
+                                 tiering::Fragment::FragmentType pv) {
+    return nullptr;
+  }
+
+  void RemoveFragment(tiering::Fragment* fragment) {
   }
 };
 


### PR DESCRIPTION
Replace CompactObj::ExternalPtr inline union member with a pointer to a heap-allocated tiering::Fragment. Fragment now owns all external storage metadata (disk offset, serialized size, representation, cool record, Huffman first byte) that was previously packed into the 16-byte ExternalPtr struct.

1. Rename FragmentRef to Fragment
2. Replace ExternalPtr union member with tiering::Fragment* pointer
3. Store Fragments in TieredStorage::tiered_fragments_ (node_hash_map) keyed by monotonic IDs for pointer stability
4. Track pending stashes via EntryMap<size_t> keyed by (dbid, key) to be safe against DashTable entry relocations

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
