### PR TITLE
fix(search): cap GROUPBY nargs before reserve to prevent DoS crash

### DIFF
--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -524,7 +524,7 @@ ParseResult<AggregateParams::JoinParams> ParseAggregatorJoinParams(
   known_indexes->insert(join_params.index_alias);
 
   size_t num_fields = parser->Next<size_t>();
-  join_params.conditions.reserve(num_fields);
+  join_params.conditions.reserve(std::min(num_fields, parser->Tail().size()));
   // Conditions are in the form index.field=foreign_index.field or foreign_index.field=index.field
   while (parser->HasNext() && num_fields > 0) {
     auto [left, right] = Split(parser->Next(), '=');

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -4619,12 +4619,12 @@ TEST_F(SearchFamilyTest, AggregateGroupByHugeNargsDoesNotCrash) {
   // Intentionally invalid float32 value (1 byte instead of 4).
   Run({"HSET", "d", "vec", "x"});
 
-  // GROUPBY 9999999999999 — exceeds the 128 TiB x86-64 virtual address space, so
-  // fields.reserve() always fails regardless of RLIMIT_AS.  Must return an error, not crash.
+  // GROUPBY 9999999999999 — after the reserve() cap, the parser sees "REDUCE" where it
+  // expects a field name starting with '@', and returns a syntax error.  Must not crash.
   auto resp = Run({"FT.AGGREGATE", "idx",
                    "@vec:[VECTOR_RANGE 0.01 $vec]=>{$YIELD_DISTANCE_AS: dist}", "PARAMS", "2",
                    "vec", "far", "GROUPBY", "9999999999999", "REDUCE", "COUNT", "0", "AS", "cnt"});
-  EXPECT_THAT(resp, ErrArg("bad arguments"));
+  EXPECT_THAT(resp, ErrArg("bad arguments: Field name should start with '@'"));
 
   // Server must still be alive and respond correctly after the oversized GROUPBY.
   EXPECT_THAT(Run({"PING"}), "PONG");


### PR DESCRIPTION
ParseAggregatorParams() passed the user-supplied GROUPBY nargs value directly to fields.reserve() without any bounds check.  An attacker could send a single FT.AGGREGATE command with GROUPBY 9999999999999 to trigger a ~320 TiB
allocation.  On memory-constrained systems (containers with RLIMIT_AS, Docker --memory, Kubernetes resources.limits) mimalloc calls abort() instead of throwing std::bad_alloc, crashing the server.

Fix: cap num_fields to parser->Tail().size() before calling reserve(), so the allocation is bounded by the number of tokens actually remaining in the command.