### PR TITLE
chore(core): retire LZ4 compression from qlist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,12 +55,12 @@
 
 ```bash
 # Debug build (for development)
-./helio/blaze.sh
+./helio/blaze.sh -DWITH_AWS=OFF -DWITH_GCP=OFF
 cd build-dbg && ninja dragonfly              # Build main binary
 cd build-dbg && ninja generic_family_test    # Build specific test
 
-# Release build (for production/benchmarking)
-./helio/blaze.sh -release
+# Release build for local benchmarking
+./helio/blaze.sh -release -DWITH_AWS=OFF -DWITH_GCP=OFF
 cd build-opt && ninja dragonfly
 ```
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -34,7 +34,7 @@ add_library(dfly_core allocation_tracker.cc bloom.cc topk.cc compact_object.cc c
 cxx_link(dfly_core base dfly_search_core dfly_page_usage fibers2 jsonpath
     absl::flat_hash_map absl::str_format absl::random_random redis_lib
     TRDP::lua lua_modules
-    OpenSSL::Crypto TRDP::dconv TRDP::lz4 TRDP::hdr_histogram)
+    OpenSSL::Crypto TRDP::dconv TRDP::hdr_histogram)
 
 add_executable(dash_bench dash_bench.cc)
 cxx_link(dash_bench dfly_core redis_test_lib)

--- a/src/core/qlist.cc
+++ b/src/core/qlist.cc
@@ -14,7 +14,6 @@ extern "C" {
 #include <absl/base/optimization.h>
 #include <absl/strings/escaping.h>
 #include <absl/strings/str_cat.h>
-#include <lz4frame.h>
 
 #include "base/logging.h"
 #include "core/page_usage/page_usage_stats.h"
@@ -220,8 +219,7 @@ using quicklistLZF = struct quicklistLZF {
 };
 
 inline quicklistLZF* GetLzf(QList::Node* node) {
-  DCHECK(node->encoding == QUICKLIST_NODE_ENCODING_LZF ||
-         node->encoding == QLIST_NODE_ENCODING_LZ4);
+  DCHECK(node->encoding == QUICKLIST_NODE_ENCODING_LZF);
   return (quicklistLZF*)node->entry;
 }
 
@@ -251,46 +249,10 @@ bool CompressLZF(QList::Node* node) {
   return true;
 }
 
-bool CompressLZ4(QList::Node* node) {
-  LZ4F_cctx* cntx;
-  LZ4F_errorCode_t code = LZ4F_createCompressionContext(&cntx, LZ4F_VERSION);
-  CHECK(!LZ4F_isError(code));
-
-  LZ4F_preferences_t lz4_pref = LZ4F_INIT_PREFERENCES;
-  lz4_pref.compressionLevel = -1;
-  lz4_pref.frameInfo.contentSize = node->sz;
-  size_t buf_size = LZ4F_compressFrameBound(node->sz, &lz4_pref);
-
-  // We reuse quicklistLZF struct for LZ4 metadata.
-  quicklistLZF* dest = (quicklistLZF*)zmalloc(sizeof(quicklistLZF) + buf_size);
-  size_t compr_sz = LZ4F_compressFrame_usingCDict(cntx, dest->compressed, buf_size, node->entry,
-                                                  node->sz, nullptr /* dict */, &lz4_pref);
-  CHECK(!LZ4F_isError(compr_sz));
-
-  code = LZ4F_freeCompressionContext(cntx);
-  CHECK(!LZ4F_isError(code));
-
-  if (compr_sz + MIN_COMPRESS_IMPROVE >= node->sz) {
-    QList::stats.bad_compression_attempts++;
-    zfree(dest);
-    return false;
-  }
-
-  dest->sz = compr_sz;
-  dest = (quicklistLZF*)zrealloc(dest, sizeof(quicklistLZF) + compr_sz);
-  QList::stats.compressed_bytes += compr_sz;
-  QList::stats.raw_compressed_bytes += node->sz;
-
-  zfree(node->entry);
-  node->entry = (unsigned char*)dest;
-  node->encoding = QLIST_NODE_ENCODING_LZ4;
-  return true;
-}
-
 /* Compress the listpack in 'node' and update encoding details.
  * Returns true if listpack compressed successfully.
  * Returns false if compression failed or if listpack too small to compress. */
-bool CompressRaw(QList::Node* node, unsigned method) {
+bool CompressRaw(QList::Node* node) {
   DCHECK(node->encoding == QUICKLIST_NODE_ENCODING_RAW);
   DCHECK(!node->dont_compress);
 
@@ -304,19 +266,15 @@ bool CompressRaw(QList::Node* node, unsigned method) {
     return false;
 
   QList::stats.compression_attempts++;
-  if (method == static_cast<unsigned>(QList::LZF)) {
-    return CompressLZF(node);
-  }
-
-  return CompressLZ4(node);
+  return CompressLZF(node);
 }
 
-ssize_t TryCompress(QList::Node* node, unsigned method) {
+ssize_t TryCompress(QList::Node* node) {
   DCHECK(node);
   if (node->encoding == QUICKLIST_NODE_ENCODING_RAW) {
     node->attempted_compress = 1;
     if (!node->dont_compress) {
-      if (CompressRaw(node, method))
+      if (CompressRaw(node))
         return ssize_t(GetLzf(node)->sz) - node->sz;
     }
   }
@@ -326,8 +284,7 @@ ssize_t TryCompress(QList::Node* node, unsigned method) {
 /* Uncompress the listpack in 'node' and update encoding details.
  * Returns 1 on successful decode, 0 on failure to decode. */
 bool DecompressRaw(bool recompress, QList::Node* node) {
-  DCHECK(node->encoding == QUICKLIST_NODE_ENCODING_LZF ||
-         node->encoding == QLIST_NODE_ENCODING_LZ4);
+  DCHECK(node->encoding == QUICKLIST_NODE_ENCODING_LZF);
 
   node->recompress = int(recompress);
 
@@ -337,23 +294,11 @@ bool DecompressRaw(bool recompress, QList::Node* node) {
   QList::stats.compressed_bytes -= lzf->sz;
   QList::stats.raw_compressed_bytes -= node->sz;
 
-  if (node->encoding == QLIST_NODE_ENCODING_LZ4) {
-    LZ4F_dctx* dctx = nullptr;
-    LZ4F_errorCode_t code = LZ4F_createDecompressionContext(&dctx, LZ4F_VERSION);
-    CHECK(!LZ4F_isError(code));
-    size_t decompressed_sz = node->sz;
-    size_t left =
-        LZ4F_decompress(dctx, decompressed, &decompressed_sz, lzf->compressed, &lzf->sz, nullptr);
-    CHECK_EQ(left, 0u);
-    CHECK_EQ(decompressed_sz, node->sz);
-    LZ4F_freeDecompressionContext(dctx);
-  } else {
-    if (lzf_decompress(lzf->compressed, lzf->sz, decompressed, node->sz) == 0) {
-      LOG(DFATAL) << "Invalid LZF compressed data";
-      /* Someone requested decompress, but we can't decompress.  Not good. */
-      zfree(decompressed);
-      return false;
-    }
+  if (lzf_decompress(lzf->compressed, lzf->sz, decompressed, node->sz) == 0) {
+    LOG(DFATAL) << "Invalid LZF compressed data";
+    /* Someone requested decompress, but we can't decompress.  Not good. */
+    zfree(decompressed);
+    return false;
   }
   zfree(lzf);
   node->entry = (uint8_t*)decompressed;
@@ -375,9 +320,9 @@ ssize_t TryDecompressInternal(bool recompress, QList::Node* node) {
   return 0;
 }
 
-ssize_t RecompressOnly(QList::Node* node, unsigned method) {
+ssize_t RecompressOnly(QList::Node* node) {
   if (node->recompress && !node->dont_compress) {
-    if (CompressRaw(node, method))
+    if (CompressRaw(node))
       return (GetLzf(node))->sz - node->sz;
   }
   return 0;
@@ -436,7 +381,7 @@ QList::Stats& QList::Stats::operator+=(const Stats& other) {
 }
 
 size_t QList::Node::GetLZF(void** data) const {
-  DCHECK(encoding == QUICKLIST_NODE_ENCODING_LZF || encoding == QLIST_NODE_ENCODING_LZ4);
+  DCHECK(encoding == QUICKLIST_NODE_ENCODING_LZF);
   quicklistLZF* lzf = (quicklistLZF*)entry;
   *data = lzf->compressed;
   return lzf->sz;
@@ -475,7 +420,6 @@ void QList::SetTieringParams(const TieringParams& params) {
 }
 
 QList::QList(int fill, int compress) : fill_(fill), compress_(compress), bookmark_count_(0) {
-  compr_method_ = 0;
 }
 
 QList::QList(QList&& other) noexcept
@@ -783,7 +727,7 @@ void QList::Insert(Iterator it, std::string_view elem, InsertOpt insert_opt) {
     uint8_t* new_entry = LP_Insert(node->entry, elem, it.zi_, after ? LP_AFTER : LP_BEFORE);
     malloc_size_ += NodeSetEntry(node, new_entry);
     node->count++;
-    malloc_size_ += RecompressOnly(node, compr_method_);
+    malloc_size_ += RecompressOnly(node);
   } else {
     bool insert_tail = at_tail && after;
     bool insert_head = at_head && !after;
@@ -794,8 +738,8 @@ void QList::Insert(Iterator it, std::string_view elem, InsertOpt insert_opt) {
       AccessForReads(true, new_node);
       malloc_size_ += NodeSetEntry(new_node, LP_Prepend(new_node->entry, elem));
       new_node->count++;
-      malloc_size_ += RecompressOnly(new_node, compr_method_);
-      malloc_size_ += RecompressOnly(node, compr_method_);
+      malloc_size_ += RecompressOnly(new_node);
+      malloc_size_ += RecompressOnly(node);
     } else if (insert_head && avail_prev) {
       /* If we are: at head, previous has free space, and inserting before:
        *   - insert entry at tail of previous node. */
@@ -803,8 +747,8 @@ void QList::Insert(Iterator it, std::string_view elem, InsertOpt insert_opt) {
       AccessForReads(true, new_node);
       malloc_size_ += NodeSetEntry(new_node, LP_Append(new_node->entry, elem));
       new_node->count++;
-      malloc_size_ += RecompressOnly(new_node, compr_method_);
-      malloc_size_ += RecompressOnly(node, compr_method_);
+      malloc_size_ += RecompressOnly(new_node);
+      malloc_size_ += RecompressOnly(node);
     } else if (insert_tail || insert_head) {
       /* If we are: full, and our prev/next has no available space, then:
        *   - create new node and attach to qlist */
@@ -943,7 +887,7 @@ void QList::CoolOff(Node* node, uint32_t node_id) {
    * If compress depth is larger than the entire list, we return immediately. */
 
   if (node->recompress)
-    CompressRaw(node, this->compr_method_);
+    CompressRaw(node);
   else
     this->CompressByDepth(node);
 }
@@ -984,11 +928,11 @@ void QList::CompressByDepth(Node* node) {
   }
 
   if (!in_depth && node) {
-    malloc_size_ += TryCompress(node, this->compr_method_);
+    malloc_size_ += TryCompress(node);
   }
   /* At this point, forward and reverse are one node beyond depth */
-  malloc_size_ += TryCompress(forward, this->compr_method_);
-  malloc_size_ += TryCompress(reverse, this->compr_method_);
+  malloc_size_ += TryCompress(forward);
+  malloc_size_ += TryCompress(reverse);
 }
 
 void QList::AccessForReads(bool recompress, Node* node) {
@@ -1364,7 +1308,7 @@ bool QList::Erase(const long start, unsigned count) {
       if (node->count == 0) {
         DelNode(node);
       } else {
-        malloc_size_ += RecompressOnly(node, compr_method_);
+        malloc_size_ += RecompressOnly(node);
       }
     }
 

--- a/src/core/qlist.h
+++ b/src/core/qlist.h
@@ -18,8 +18,6 @@
 /* quicklist node encodings */
 #define QUICKLIST_NODE_ENCODING_RAW 1
 #define QUICKLIST_NODE_ENCODING_LZF 2
-#define QLIST_NODE_ENCODING_LZ4 3
-
 /* quicklist node container formats */
 #define QUICKLIST_NODE_CONTAINER_PLAIN 1
 #define QUICKLIST_NODE_CONTAINER_PACKED 2
@@ -39,7 +37,6 @@ inline bool ShouldStoreAsListPack(size_t size) {
 class QList {
  public:
   enum Where : uint8_t { TAIL, HEAD };
-  enum COMPR_METHOD : uint8_t { LZF = 0, LZ4 = 1 };
 
   /* Node is a 40 byte struct describing a listpack for a quicklist.
    * We use bit fields keep the Node at 40 bytes.
@@ -58,7 +55,7 @@ class QList {
     size_t sz : 48;    /* entry size in bytes */
     size_t count : 16; /* count of items in listpack */
 
-    uint16_t encoding : 2;           /* RAW==1 or LZF==2 */
+    uint16_t encoding : 2;           /* RAW==1, LZF==2 */
     uint16_t container : 2;          /* PLAIN==1 or PACKED==2 */
     uint16_t recompress : 1;         /* was this node previous compressed? */
     uint16_t attempted_compress : 1; /* node can't compress; too small */
@@ -217,10 +214,6 @@ class QList {
     fill_ = fill;
   }
 
-  void set_compr_method(COMPR_METHOD cm) {
-    compr_method_ = static_cast<unsigned>(cm);
-  }
-
   static void SetPackedThreshold(unsigned threshold);
 
   // Moves nodes away from underused pages by reallocating if the underlying page usage is low.
@@ -291,12 +284,11 @@ class QList {
   void InitIteratorEntry(Iterator* it) const;
 
   Node* head_ = nullptr;
-  size_t malloc_size_ = 0;    // size of the quicklist struct
-  uint32_t count_ = 0;        /* total count of all entries in all listpacks */
-  uint32_t len_ = 0;          /* number of quicklistNodes */
-  int16_t fill_;              /* fill factor for individual nodes */
-  int16_t compr_method_ : 2;  // 0 - lzf, 1 - lz4
-  int16_t reserved1_ : 14;
+  size_t malloc_size_ = 0;  // size of the quicklist struct
+  uint32_t count_ = 0;      /* total count of all entries in all listpacks */
+  uint32_t len_ = 0;        /* number of quicklistNodes */
+  int16_t fill_;            /* fill factor for individual nodes */
+  int16_t reserved1_;
   unsigned compress_ : QL_COMP_BITS; /* depth of end nodes not to compress;0=off */
   unsigned bookmark_count_ : QL_BM_BITS;
   unsigned reserved2_ : 12;

--- a/src/core/qlist_test.cc
+++ b/src/core/qlist_test.cc
@@ -418,17 +418,15 @@ TEST_F(QListTest, Tiering) {
   EXPECT_EQ(QList::stats.offload_requests, 9);
 }
 
-using FillCompress = tuple<int, unsigned, QList::COMPR_METHOD>;
+using FillCompress = tuple<int, unsigned>;
 
 class PrintToFillCompress {
  public:
   std::string operator()(const TestParamInfo<FillCompress>& info) const {
     int fill = get<0>(info.param);
     int compress = get<1>(info.param);
-    QList::COMPR_METHOD method = get<2>(info.param);
     string fill_str = fill >= 0 ? absl::StrCat("f", fill) : absl::StrCat("fminus", -fill);
-    string method_str = method == QList::LZF ? "lzf" : "lz4";
-    return absl::StrCat(fill_str, "compr", compress, method_str);
+    return absl::StrCat(fill_str, "compr", compress);
   }
 };
 
@@ -436,13 +434,13 @@ class OptionsTest : public QListTest, public WithParamInterface<FillCompress> {}
 
 INSTANTIATE_TEST_SUITE_P(Matrix, OptionsTest,
                          Combine(Values(-5, -4, -3, -2, -1, 0, 1, 2, 32, 66, 128, 999),
-                                 Values(0, 1, 2, 3, 4, 5, 6, 10), Values(QList::LZF, QList::LZ4)),
+                                 Values(0, 1, 2, 3, 4, 5, 6, 10)),
                          PrintToFillCompress());
 
 TEST_P(OptionsTest, Numbers) {
-  auto [fill, compress, method] = GetParam();
+  auto [fill, compress] = GetParam();
   ql_ = QList(fill, compress);
-  ql_.set_compr_method(method);
+
   array<int64_t, 5000> nums;
 
   for (unsigned i = 0; i < nums.size(); i++) {
@@ -464,9 +462,8 @@ TEST_P(OptionsTest, Numbers) {
 }
 
 TEST_P(OptionsTest, NumbersIndex) {
-  auto [fill, compress, method] = GetParam();
+  auto [fill, compress] = GetParam();
   ql_ = QList(fill, compress);
-  ql_.set_compr_method(method);
 
   long long nums[5000];
   for (int i = 0; i < 760; i++) {
@@ -485,9 +482,9 @@ TEST_P(OptionsTest, NumbersIndex) {
 }
 
 TEST_P(OptionsTest, DelRangeA) {
-  auto [fill, compress, method] = GetParam();
+  auto [fill, compress] = GetParam();
   ql_ = QList(fill, compress);
-  ql_.set_compr_method(method);
+
   long long nums[5000];
   for (int i = 0; i < 33; i++) {
     nums[i] = -5157318210846258176 + i;
@@ -510,9 +507,8 @@ TEST_P(OptionsTest, DelRangeA) {
 }
 
 TEST_P(OptionsTest, DelRangeB) {
-  auto [fill, _, method] = GetParam();
+  auto [fill, _] = GetParam();
   ql_ = QList(fill, QUICKLIST_NOCOMPRESS);  // ignore compress parameter
-  ql_.set_compr_method(method);
 
   long long nums[5000];
   for (int i = 0; i < 33; i++) {
@@ -550,9 +546,8 @@ TEST_P(OptionsTest, DelRangeB) {
 }
 
 TEST_P(OptionsTest, DelRangeC) {
-  auto [fill, compress, method] = GetParam();
+  auto [fill, compress] = GetParam();
   ql_ = QList(fill, compress);
-  ql_.set_compr_method(method);
 
   long long nums[5000];
   for (int i = 0; i < 33; i++) {
@@ -575,9 +570,8 @@ TEST_P(OptionsTest, DelRangeC) {
 }
 
 TEST_P(OptionsTest, DelRangeD) {
-  auto [fill, compress, method] = GetParam();
+  auto [fill, compress] = GetParam();
   ql_ = QList(fill, compress);
-  ql_.set_compr_method(method);
 
   long long nums[5000];
   for (int i = 0; i < 33; i++) {
@@ -593,9 +587,8 @@ TEST_P(OptionsTest, DelRangeD) {
 }
 
 TEST_P(OptionsTest, DelRangeNode) {
-  auto [_, compress, method] = GetParam();
+  auto [_, compress] = GetParam();
   ql_ = QList(-2, compress);
-  ql_.set_compr_method(method);
 
   for (int i = 0; i < 32; i++)
     ql_.Push(StrCat("hello", i), QList::HEAD);
@@ -606,9 +599,8 @@ TEST_P(OptionsTest, DelRangeNode) {
 }
 
 TEST_P(OptionsTest, DelRangeNodeOverflow) {
-  auto [_, compress, method] = GetParam();
+  auto [_, compress] = GetParam();
   ql_ = QList(-2, compress);
-  ql_.set_compr_method(method);
 
   for (int i = 0; i < 32; i++)
     ql_.Push(StrCat("hello", i), QList::HEAD);
@@ -618,7 +610,7 @@ TEST_P(OptionsTest, DelRangeNodeOverflow) {
 }
 
 TEST_P(OptionsTest, DelRangeMiddle100of500) {
-  auto [_, compress, method] = GetParam();
+  auto [_, compress] = GetParam();
   ql_ = QList(32, compress);
 
   for (int i = 0; i < 500; i++)
@@ -630,7 +622,7 @@ TEST_P(OptionsTest, DelRangeMiddle100of500) {
 }
 
 TEST_P(OptionsTest, DelLessFillAcrossNodes) {
-  auto [_, compress, method] = GetParam();
+  auto [_, compress] = GetParam();
   ql_ = QList(32, compress);
 
   for (int i = 0; i < 500; i++)
@@ -641,7 +633,7 @@ TEST_P(OptionsTest, DelLessFillAcrossNodes) {
 }
 
 TEST_P(OptionsTest, DelNegOne) {
-  auto [_, compress, method] = GetParam();
+  auto [_, compress] = GetParam();
   ql_ = QList(32, compress);
   for (int i = 0; i < 500; i++)
     ql_.Push(StrCat("hello", i + 1), QList::TAIL);
@@ -651,7 +643,7 @@ TEST_P(OptionsTest, DelNegOne) {
 }
 
 TEST_P(OptionsTest, DelNegOneOverflow) {
-  auto [_, compress, method] = GetParam();
+  auto [_, compress] = GetParam();
   ql_ = QList(32, compress);
   for (int i = 0; i < 500; i++)
     ql_.Push(StrCat("hello", i + 1), QList::TAIL);
@@ -663,7 +655,7 @@ TEST_P(OptionsTest, DelNegOneOverflow) {
 }
 
 TEST_P(OptionsTest, DelNeg100From500) {
-  auto [_, compress, method] = GetParam();
+  auto [_, compress] = GetParam();
   ql_ = QList(32, compress);
   for (int i = 0; i < 500; i++)
     ql_.Push(StrCat("hello", i + 1), QList::TAIL);
@@ -676,7 +668,7 @@ TEST_P(OptionsTest, DelNeg100From500) {
 }
 
 TEST_P(OptionsTest, DelMin10_5_from50) {
-  auto [_, compress, method] = GetParam();
+  auto [_, compress] = GetParam();
   ql_ = QList(32, compress);
 
   for (int i = 0; i < 50; i++)
@@ -687,7 +679,7 @@ TEST_P(OptionsTest, DelMin10_5_from50) {
 }
 
 TEST_P(OptionsTest, DelElems) {
-  auto [fill, compress, method] = GetParam();
+  auto [fill, compress] = GetParam();
   ql_ = QList(fill, compress);
 
   const char* words[] = {"abc", "foo", "bar", "foobar", "foobared", "zap", "bar", "test", "foo"};
@@ -735,7 +727,7 @@ TEST_P(OptionsTest, DelElems) {
 }
 
 TEST_P(OptionsTest, IterateReverse) {
-  auto [_, compress, method] = GetParam();
+  auto [_, compress] = GetParam();
   ql_ = QList(32, compress);
 
   for (int i = 0; i < 500; i++)
@@ -752,7 +744,7 @@ TEST_P(OptionsTest, IterateReverse) {
 }
 
 TEST_P(OptionsTest, Iterate500) {
-  auto [_, compress, method] = GetParam();
+  auto [_, compress] = GetParam();
   ql_ = QList(32, compress);
   for (int i = 0; i < 500; i++)
     ql_.Push(StrCat("hello", i), QList::HEAD);
@@ -780,7 +772,7 @@ TEST_P(OptionsTest, Iterate500) {
 }
 
 TEST_P(OptionsTest, IterateAfterOne) {
-  auto [_, compress, method] = GetParam();
+  auto [_, compress] = GetParam();
   ql_ = QList(-2, compress);
   ql_.Push("hello", QList::HEAD);
 
@@ -801,7 +793,7 @@ TEST_P(OptionsTest, IterateAfterOne) {
 }
 
 TEST_P(OptionsTest, IterateDelete) {
-  auto [fill, compress, method] = GetParam();
+  auto [fill, compress] = GetParam();
   ql_ = QList(fill, compress);
 
   ql_.Push("abc", QList::TAIL);
@@ -823,7 +815,7 @@ TEST_P(OptionsTest, IterateDelete) {
 }
 
 TEST_P(OptionsTest, InsertBeforeOne) {
-  auto [_, compress, method] = GetParam();
+  auto [_, compress] = GetParam();
   ql_ = QList(-2, compress);
 
   ql_.Push("hello", QList::HEAD);
@@ -843,7 +835,7 @@ TEST_P(OptionsTest, InsertBeforeOne) {
 }
 
 TEST_P(OptionsTest, InsertWithHeadFull) {
-  auto [_, compress, method] = GetParam();
+  auto [_, compress] = GetParam();
   ql_ = QList(4, compress);
 
   for (int i = 0; i < 10; i++)
@@ -859,7 +851,7 @@ TEST_P(OptionsTest, InsertWithHeadFull) {
 }
 
 TEST_P(OptionsTest, InsertWithTailFull) {
-  auto [_, compress, method] = GetParam();
+  auto [_, compress] = GetParam();
   ql_ = QList(4, compress);
   for (int i = 0; i < 10; i++)
     ql_.Push(StrCat("hello", i), QList::HEAD);
@@ -874,7 +866,7 @@ TEST_P(OptionsTest, InsertWithTailFull) {
 }
 
 TEST_P(OptionsTest, InsertOnceWhileIterating) {
-  auto [fill, compress, method] = GetParam();
+  auto [fill, compress] = GetParam();
   ql_ = QList(fill, compress);
 
   ql_.Push("abc", QList::TAIL);
@@ -900,7 +892,7 @@ TEST_P(OptionsTest, InsertOnceWhileIterating) {
 }
 
 TEST_P(OptionsTest, InsertBefore250NewInMiddleOf500Elements) {
-  auto [fill, compress, method] = GetParam();
+  auto [fill, compress] = GetParam();
   ql_ = QList(fill, compress);
   for (int i = 0; i < 500; i++) {
     string val = StrCat("hello", i);
@@ -920,7 +912,7 @@ TEST_P(OptionsTest, InsertBefore250NewInMiddleOf500Elements) {
 }
 
 TEST_P(OptionsTest, InsertAfter250NewInMiddleOf500Elements) {
-  auto [fill, compress, method] = GetParam();
+  auto [fill, compress] = GetParam();
   ql_ = QList(fill, compress);
   for (int i = 0; i < 500; i++)
     ql_.Push(StrCat("hello", i), QList::HEAD);
@@ -939,7 +931,7 @@ TEST_P(OptionsTest, InsertAfter250NewInMiddleOf500Elements) {
 }
 
 TEST_P(OptionsTest, NextPlain) {
-  auto [_, compress, method] = GetParam();
+  auto [_, compress] = GetParam();
   ql_ = QList(-2, compress);
 
   QList::SetPackedThreshold(3);
@@ -960,7 +952,7 @@ TEST_P(OptionsTest, NextPlain) {
 }
 
 TEST_P(OptionsTest, IndexFrom500) {
-  auto [fill, compress, method] = GetParam();
+  auto [fill, compress] = GetParam();
   ql_ = QList(fill, compress);
   for (int i = 0; i < 500; i++)
     ql_.Push(StrCat("hello", i + 1), QList::TAIL);
@@ -1003,8 +995,7 @@ static void BM_QListCompress(benchmark::State& state) {
 
   VLOG(1) << "Read " << lines.size() << " lines " << state.range(0);
   while (state.KeepRunning()) {
-    QList ql(-2, state.range(0));  // uses differrent compression modes, see below.
-    ql.set_compr_method(state.range(1) == 0 ? QList::LZF : QList::LZ4);
+    QList ql(-2, state.range(0));
 
     for (const string& l : lines) {
       ql.Push(l, QList::TAIL);
@@ -1014,9 +1005,9 @@ static void BM_QListCompress(benchmark::State& state) {
   CHECK_EQ(0, zmalloc_used_memory_tl);
 }
 BENCHMARK(BM_QListCompress)
-    ->ArgsProduct({{1, 4, 0}, {0, 1}});  // x - compression depth, y compression method.
-                                         // x = 0 no compression, 1 - compress all nodes but edges,
-                                         // 4 - compress all but 4 nodes from edges.
+    ->ArgsProduct({{1, 4, 0}});  // compression depth:
+                                 // 0 - no compression, 1 - compress all nodes but edges,
+                                 // 4 - compress all but 4 nodes from edges.
 
 static void BM_QListUncompress(benchmark::State& state) {
   SetupMalloc();
@@ -1027,7 +1018,6 @@ static void BM_QListUncompress(benchmark::State& state) {
   io::LineReader lr(*src, TAKE_OWNERSHIP);
   string_view line;
   QList ql(-2, state.range(0));
-  ql.set_compr_method(state.range(1) == 0 ? QList::LZF : QList::LZ4);
   QList::stats.compression_attempts = 0;
 
   CHECK_EQ(QList::stats.compressed_bytes, 0u);
@@ -1062,6 +1052,6 @@ static void BM_QListUncompress(benchmark::State& state) {
     CHECK_EQ(line_len, actual_len);
   }
 }
-BENCHMARK(BM_QListUncompress)->ArgsProduct({{1, 4, 0}, {0, 1}});
+BENCHMARK(BM_QListUncompress)->ArgsProduct({{1, 4, 0}});
 
 }  // namespace dfly

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -398,8 +398,6 @@ error_code RdbSerializer::SaveListObject(const PrimeValue& pv) {
     if (node->IsCompressed()) {
       void* data;
       size_t compress_len = node->GetLZF(&data);
-      // TODO: LZ4 compression mode is not enabled for list objects yet.
-      // If it will be enabled in the future, we need to adjust here accordingly.
       RETURN_ON_ERR(SaveLzfBlob(Bytes{reinterpret_cast<uint8_t*>(data), compress_len}, node->sz));
     } else {
       RETURN_ON_ERR(SaveString(node->entry, node->sz));


### PR DESCRIPTION
LZ4 was never enabled in production for qlist nodes (default was always LZF). Remove the CompressLZ4 function, COMPR_METHOD enum, compr_method_ field, LZ4 decompression path, and lz4 link dependency from dfly_core. Test parametrization halved accordingly.

RDB-level LZ4 snapshot compression (MULTI_ENTRY_LZ4) is unrelated and remains unchanged. 

This is done in preparation to introduce dictionary based zstd compression.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
