### PR TITLE
fix(search): Simplify hnsw indexing

### DIFF
--- a/src/core/search/hnsw_alg.h
+++ b/src/core/search/hnsw_alg.h
@@ -48,6 +48,7 @@ template <typename dist_t> class HierarchicalNSW : public hnswlib::AlgorithmInte
   // Locks operations with element by label value
   mutable std::vector<std::mutex> label_op_locks_;
 
+  // Before changing it, grep for "global-hnsw-mutex" in the codebase!
   std::mutex global;
   std::vector<std::mutex> link_list_locks_;
 

--- a/src/server/search/index_builder.cc
+++ b/src/server/search/index_builder.cc
@@ -121,18 +121,15 @@ void IndexBuilder::VectorLoop(dfly::DbTable* table, DbContext db_cntx) {
       index_->AddDocToGlobalVectorIndex(*local_id, db_cntx, &pv);
   };
 
-  // Because order of acquiring mutexes for global vector indices is not determined, we must run
-  // all accesses on a single thread through the shard queue to have a single linear order
-  // TODO: this prevents asynchronous indexing for vector fields
-  auto shard_cb = [&] {
-    PrimeTable::Cursor cursor;
-    do {
-      cursor = table->prime.Traverse(cursor, cb);
-      if (base::CycleClock::ToUsec(util::ThisFiber::GetRunningTimeCycles()) > 500)
-        util::ThisFiber::Yield();
-    } while (cursor && state_.IsRunning());
-  };
-  shard_set->Await(EngineShard::tlocal()->shard_id(), std::move(shard_cb));
+  // NOTE(global-hnsw-mutex): HNSW (hnsw_alg) index uses a thread-blocking mutex making
+  // AddDocToGlobalVectorIndex non-fiber-suspendable from a fiber point of view. This makes it safe
+  // to perform add keys without locking them while sleeping of a mutex.
+  PrimeTable::Cursor cursor;
+  do {
+    cursor = table->prime.Traverse(cursor, cb);
+    if (base::CycleClock::ToUsec(util::ThisFiber::GetRunningTimeCycles()) > 500)
+      util::ThisFiber::Yield();
+  } while (cursor && state_.IsRunning());
 }
 
 }  // namespace dfly::search


### PR DESCRIPTION
```
  // Because order of acquiring mutexes for global vector indices is not determined, we must run
  // all accesses on a single thread through the shard queue to have a single linear order
```

This comment is wrong because the shard queue is not the only place where commands execute - we have L2 queue and inlined execution.

Nonetheless, this safeguard is not needed now because global hnsw index uses thread based mutex that suspends the whole thread, being actually "invisible" to something living in a fiber based world