### PR TITLE
refactor: DenseSet entry removing

### DIFF
--- a/src/core/dense_set.cc
+++ b/src/core/dense_set.cc
@@ -62,7 +62,7 @@ void DenseSet::IteratorBase::SetExpiryTime(uint32_t ttl_sec) {
 
     // Important: we set the ttl bit on the wrapping pointer.
     curr_entry_->SetTtl(true);
-    owner_->ObjDelete(src, false);
+    owner_->ObjDelete(src);
     src = new_obj;
 
     // Because setting TTL requires an extra 4 bytes for the key, the allocated size may push the
@@ -292,7 +292,7 @@ void DenseSet::ClearBatch(unsigned len, ClearItem* items) {
     for (unsigned i = 0; i < len; ++i) {
       auto& src = items[i];
       if (src.obj) {
-        ObjDelete(src.obj, src.has_ttl);
+        ObjDelete(src.obj);
         --size_;
         src.obj = nullptr;
       }
@@ -301,7 +301,7 @@ void DenseSet::ClearBatch(unsigned len, ClearItem* items) {
         continue;
 
       if (src.ptr.IsObject()) {
-        ObjDelete(src.ptr.Raw(), src.has_ttl);
+        ObjDelete(src.ptr.Raw());
         --size_;
       } else {
         auto& dest = items[dest_id++];
@@ -406,7 +406,7 @@ void DenseSet::ShrinkBucket(size_t bucket_idx) {
     }
 
     if (has_ttl && ObjExpireTime(obj) <= time_now_) {
-      ObjDelete(obj, true);
+      ObjDelete(obj);
       --size_;
       continue;
     }
@@ -722,7 +722,7 @@ void* DenseSet::Delete(DensePtr* prev, DensePtr* ptr, bool detach) {
   if (detach) {
     return obj;
   }
-  ObjDelete(obj, false);
+  ObjDelete(obj);
   return nullptr;
 }
 

--- a/src/core/dense_set.h
+++ b/src/core/dense_set.h
@@ -277,7 +277,7 @@ class DenseSet {
   virtual size_t ObjectAllocSize(const void* obj) const = 0;
   virtual uint32_t ObjExpireTime(const void* obj) const = 0;
   virtual void ObjUpdateExpireTime(const void* obj, uint32_t ttl_sec) = 0;
-  virtual void ObjDelete(void* obj, bool has_ttl) const = 0;
+  virtual void ObjDelete(void* obj) const = 0;
   virtual void* ObjectClone(const void* obj, bool has_ttl, bool add_ttl) const = 0;
 
   void CollectExpired();

--- a/src/core/score_map.cc
+++ b/src/core/score_map.cc
@@ -53,7 +53,7 @@ pair<void*, bool> ScoreMap::AddOrUpdate(string_view field, double value) {
   // Replace the whole entry.
   sds prev_entry = (sds)AddOrReplaceObj(newkey, false);
   if (prev_entry) {
-    ObjDelete(prev_entry, false);
+    ObjDelete(prev_entry);
     return {newkey, false};
   }
 
@@ -133,7 +133,7 @@ void ScoreMap::ObjUpdateExpireTime(const void* obj, uint32_t ttl_sec) {
   // Should not reach.
 }
 
-void ScoreMap::ObjDelete(void* obj, bool has_ttl) const {
+void ScoreMap::ObjDelete(void* obj) const {
   sds s1 = (sds)obj;
   sdsfree(s1);
 }

--- a/src/core/score_map.h
+++ b/src/core/score_map.h
@@ -127,8 +127,8 @@ class ScoreMap : public DenseSet {
   bool ObjEqual(const void* left, const void* right, uint32_t right_cookie) const final;
   size_t ObjectAllocSize(const void* obj) const final;
   uint32_t ObjExpireTime(const void* obj) const final;
-  void ObjUpdateExpireTime(const void* obj, uint32_t ttl_sec) override;
-  void ObjDelete(void* obj, bool has_ttl) const override;
+  void ObjUpdateExpireTime(const void* obj, uint32_t ttl_sec) final;
+  void ObjDelete(void* obj) const final;
   void* ObjectClone(const void* obj, bool has_ttl, bool add_ttl) const final;
 };
 

--- a/src/core/string_map.cc
+++ b/src/core/string_map.cc
@@ -67,20 +67,16 @@ StringMap::~StringMap() {
 
 bool StringMap::AddOrUpdate(std::string_view field, std::string_view value, uint32_t ttl_sec,
                             bool keepttl) {
-  sds prev = AddOrExchange(field, value, ttl_sec, keepttl);
-  if (prev) {
-    ObjDelete(prev, false);
-    return false;
-  }
-  return true;
+  SdsEntry prev = AddOrExchange(field, value, ttl_sec, keepttl);
+  return !prev;
 }
 
-sds StringMap::AddOrExchange(std::string_view field, std::string_view value, uint32_t ttl_sec,
-                             bool keepttl) {
+StringMap::SdsEntry StringMap::AddOrExchange(std::string_view field, std::string_view value,
+                                             uint32_t ttl_sec, bool keepttl) {
   const uint32_t computed_ttl = ComputeTtl(field, ttl_sec, keepttl);
   auto [newkey, sdsval_tag] = CreateEntry(field, value, time_now(), computed_ttl);
   auto prev_entry = static_cast<sds>(AddOrReplaceObj(newkey, sdsval_tag & kValTtlBit));
-  return prev_entry;
+  return SdsEntry(prev_entry, DeleteEntry);
 }
 
 uint32_t StringMap::ComputeTtl(string_view field, uint32_t ttl_sec, bool keepttl) const {
@@ -114,13 +110,14 @@ bool StringMap::Erase(string_view key) {
 }
 
 StringMap::SdsEntry StringMap::Extract(string_view key) {
-  return SdsEntry(static_cast<sds>(DetachInternal(const_cast<string_view*>(&key), 1)), DeleteEntry);
+  return SdsEntry(DetachInternal(const_cast<string_view*>(&key), 1), DeleteEntry);
 }
 
-void StringMap::DeleteEntry(sds entry) {
-  sds value = GetValue(entry);
+void StringMap::DeleteEntry(void* entry) {
+  sds s1 = (sds)entry;
+  sds value = GetValue(s1);
   sdsfree(value);
-  sdsfree(entry);
+  sdsfree(s1);
 }
 
 bool StringMap::Contains(string_view field) const {
@@ -310,7 +307,7 @@ void StringMap::ObjUpdateExpireTime(const void* obj, uint32_t ttl_sec) {
   return SdsUpdateExpireTime(obj, time_now() + ttl_sec, 8);
 }
 
-void StringMap::ObjDelete(void* obj, bool has_ttl) const {
+void StringMap::ObjDelete(void* obj) const {
   sds s1 = (sds)obj;
   sds value = GetValue(s1);
   sdsfree(value);

--- a/src/core/string_map.h
+++ b/src/core/string_map.h
@@ -114,11 +114,13 @@ class StringMap : public DenseSet {
   bool AddOrUpdate(std::string_view field, std::string_view value, uint32_t ttl_sec = UINT32_MAX,
                    bool keepttl = false);
 
-  // Like AddOrUpdate but on update returns the previous sds entry
-  // instead of deleting it. Caller must free the returned entry via DeleteEntry().
+  using SdsEntry = std::unique_ptr<void, void (*)(void*)>;
+
+  // Like AddOrUpdate but on update returns the previous entry wrapped in SdsEntry
+  // instead of deleting it. The returned SdsEntry automatically frees the entry on destruction.
   // Returns nullptr if a new field was added.
-  sds AddOrExchange(std::string_view field, std::string_view value, uint32_t ttl_sec = UINT32_MAX,
-                    bool keepttl = false);
+  SdsEntry AddOrExchange(std::string_view field, std::string_view value,
+                         uint32_t ttl_sec = UINT32_MAX, bool keepttl = false);
 
   // Returns true if field was added
   // false, if already exists. In that case no update is done.
@@ -126,14 +128,12 @@ class StringMap : public DenseSet {
 
   bool Erase(std::string_view s1);
 
-  using SdsEntry = std::unique_ptr<char, void (*)(sds)>;
-
   // Removes and returns the sds entry for the given key without freeing it.
   // Returns nullptr if the key was not found.
   SdsEntry Extract(std::string_view s1);
 
   // Frees a StringMap sds entry (key + embedded value).
-  static void DeleteEntry(sds entry);
+  static void DeleteEntry(void* entry);
 
   bool Contains(std::string_view s1) const;
 
@@ -186,8 +186,8 @@ class StringMap : public DenseSet {
   bool ObjEqual(const void* left, const void* right, uint32_t right_cookie) const final;
   size_t ObjectAllocSize(const void* obj) const final;
   uint32_t ObjExpireTime(const void* obj) const final;
-  void ObjUpdateExpireTime(const void* obj, uint32_t ttl_sec) override;
-  void ObjDelete(void* obj, bool has_ttl) const override;
+  void ObjUpdateExpireTime(const void* obj, uint32_t ttl_sec) final;
+  void ObjDelete(void* obj) const final;
   void* ObjectClone(const void* obj, bool has_ttl, bool add_ttl) const final;
 };
 

--- a/src/core/string_map_test.cc
+++ b/src/core/string_map_test.cc
@@ -283,7 +283,7 @@ TEST_F(StringMapTest, ExtractExisting) {
   ASSERT_TRUE(entry);
 
   // Verify the extracted entry has the correct value
-  sds val = StringMap::GetValue(entry.get());
+  sds val = StringMap::GetValue(static_cast<sds>(entry.get()));
   EXPECT_EQ(string_view(val, sdslen(val)), "v1");
 
   // Verify it was removed from the map
@@ -301,8 +301,8 @@ TEST_F(StringMapTest, ExtractNonExisting) {
 
 TEST_F(StringMapTest, AddOrExchangeNew) {
   // Adding a new field returns nullptr (no previous entry)
-  sds prev = sm_->AddOrExchange("f1", "v1");
-  EXPECT_EQ(prev, nullptr);
+  auto prev = sm_->AddOrExchange("f1", "v1");
+  EXPECT_FALSE(prev);
   EXPECT_TRUE(sm_->Contains("f1"));
   EXPECT_STREQ(sm_->Find("f1")->second, "v1");
 }
@@ -311,27 +311,27 @@ TEST_F(StringMapTest, AddOrExchangeReplace) {
   sm_->AddOrUpdate("f1", "old_value");
   EXPECT_EQ(sm_->UpperBoundSize(), 1u);
 
-  sds prev = sm_->AddOrExchange("f1", "new_value");
-  ASSERT_NE(prev, nullptr);
+  auto prev = sm_->AddOrExchange("f1", "new_value");
+  ASSERT_TRUE(prev);
 
-  // Verify the extracted entry has the old value
-  sds val = StringMap::GetValue(prev);
+  // Verify the returned entry has the old value
+  sds prev_key = static_cast<sds>(prev.get());
+  sds val = StringMap::GetValue(prev_key);
   EXPECT_EQ(string_view(val, sdslen(val)), "old_value");
 
   // Verify map now has the new value
   EXPECT_STREQ(sm_->Find("f1")->second, "new_value");
   EXPECT_EQ(sm_->UpperBoundSize(), 1u);
-
-  StringMap::DeleteEntry(prev);
 }
 
 TEST_F(StringMapTest, AddOrExchangeWithTtl) {
   sm_->AddOrUpdate("f1", "v1", 100);
 
-  sds prev = sm_->AddOrExchange("f1", "v2", 200);
-  ASSERT_NE(prev, nullptr);
+  auto prev = sm_->AddOrExchange("f1", "v2", 200);
+  ASSERT_TRUE(prev);
 
-  sds val = StringMap::GetValue(prev);
+  sds prev_key = static_cast<sds>(prev.get());
+  sds val = StringMap::GetValue(prev_key);
   EXPECT_EQ(string_view(val, sdslen(val)), "v1");
 
   // Make sure new entry has correct value and ttl
@@ -339,8 +339,6 @@ TEST_F(StringMapTest, AddOrExchangeWithTtl) {
   EXPECT_STREQ(it->second, "v2");
   EXPECT_TRUE(it.HasExpiry());
   EXPECT_EQ(it.ExpiryTime(), 200u);
-
-  StringMap::DeleteEntry(prev);
 }
 
 TEST_F(StringMapTest, ExtractMultiple) {

--- a/src/core/string_set.cc
+++ b/src/core/string_set.cc
@@ -173,7 +173,7 @@ void StringSet::ObjUpdateExpireTime(const void* obj, uint32_t ttl_sec) {
   return SdsUpdateExpireTime(obj, time_now() + ttl_sec, 0);
 }
 
-void StringSet::ObjDelete(void* obj, bool has_ttl) const {
+void StringSet::ObjDelete(void* obj) const {
   sdsfree((sds)obj);
 }
 

--- a/src/core/string_set.h
+++ b/src/core/string_set.h
@@ -109,17 +109,17 @@ class StringSet : public DenseSet {
   }
 
  protected:
-  uint64_t Hash(const void* ptr, uint32_t cookie) const override;
+  uint64_t Hash(const void* ptr, uint32_t cookie) const final;
 
   unsigned AddBatch(absl::Span<std::string_view> span, uint32_t ttl_sec, bool keepttl);
 
-  bool ObjEqual(const void* left, const void* right, uint32_t right_cookie) const override;
+  bool ObjEqual(const void* left, const void* right, uint32_t right_cookie) const final;
 
-  size_t ObjectAllocSize(const void* s1) const override;
-  uint32_t ObjExpireTime(const void* obj) const override;
-  void ObjUpdateExpireTime(const void* obj, uint32_t ttl_sec) override;
-  void ObjDelete(void* obj, bool has_ttl) const override;
-  void* ObjectClone(const void* obj, bool has_ttl, bool add_ttl) const override;
+  size_t ObjectAllocSize(const void* s1) const final;
+  uint32_t ObjExpireTime(const void* obj) const final;
+  void ObjUpdateExpireTime(const void* obj, uint32_t ttl_sec) final;
+  void ObjDelete(void* obj) const final;
+  void* ObjectClone(const void* obj, bool has_ttl, bool add_ttl) const final;
   sds MakeSetSds(std::string_view src, uint32_t ttl_sec) const;
 
  private:


### PR DESCRIPTION
Summary: Refactors DenseSet’s deletion interface by removing the redundant has_ttl parameter from ObjDelete and updates all call sites accordingly.

Changes:

- Simplified DenseSet::ObjDelete to ObjDelete(void*) and adjusted DenseSet deletion paths (expiry, shrink, clear, detach).
- Updated DenseSet implementations (ScoreMap, StringMap, StringSet) to match the new signature.
- Refactored StringMap::AddOrExchange to return an RAII wrapper (SdsEntry) so previous entries are automatically freed.
- Adapted unit tests to the new ownership model and explicit casts when extracting raw sds pointers.
- Technical Notes: TTL tagging remains on the wrapping DensePtr; object pointers passed to deletion remain untagged via Raw().

Prepare entries extraction for HNSW external data storage 