### PR TITLE
chore(core): implement ZSTD dict based compression

### DIFF
--- a/src/core/qlist.cc
+++ b/src/core/qlist.cc
@@ -17,6 +17,7 @@ extern "C" {
 #include <zstd.h>
 
 #include "base/logging.h"
+#include "core/dict_builder.h"
 #include "core/page_usage/page_usage_stats.h"
 
 using namespace std;
@@ -48,7 +49,27 @@ namespace dfly {
 
 namespace {
 
-static_assert(sizeof(QList) == 56);
+struct ZstdDictState {
+  ZSTD_CDict* cdict = nullptr;
+  ZSTD_DDict* ddict = nullptr;
+  ZSTD_CCtx* cctx = nullptr;  // Reused across compressions to avoid per-call alloc/free.
+  ZSTD_DCtx* dctx = nullptr;  // Reused across decompressions to avoid per-call alloc/free.
+
+  ~ZstdDictState() {
+    if (cdict)
+      ZSTD_freeCDict(cdict);
+    if (ddict)
+      ZSTD_freeDDict(ddict);
+    if (cctx)
+      ZSTD_freeCCtx(cctx);
+    if (dctx)
+      ZSTD_freeDCtx(dctx);
+  }
+};
+
+thread_local ZstdDictState* tl_zstd_dict = nullptr;
+
+static_assert(sizeof(QList) == 48);
 static_assert(sizeof(QList::Node) == 40);
 
 enum IterDir : uint8_t { FWD = 1, REV = 0 };
@@ -286,7 +307,7 @@ ssize_t TryCompress(QList::Node* node) {
 /* Uncompress the listpack in 'node' and update encoding details.
  * Returns 1 on successful decode, 0 on failure to decode.
  * ddict is required for ZSTD-compressed nodes (encoding == QLIST_NODE_ENCODING_ZSTD). */
-bool DecompressRaw(bool recompress, QList::Node* node, ZSTD_DDict* ddict) {
+bool DecompressRaw(bool recompress, QList::Node* node) {
   DCHECK(node->encoding == QUICKLIST_NODE_ENCODING_LZF ||
          node->encoding == QLIST_NODE_ENCODING_ZSTD);
 
@@ -299,14 +320,15 @@ bool DecompressRaw(bool recompress, QList::Node* node, ZSTD_DDict* ddict) {
   QList::stats.raw_compressed_bytes -= node->sz;
 
   if (node->encoding == QLIST_NODE_ENCODING_ZSTD) {
-    CHECK(ddict);
-    ZSTD_DCtx* dctx = ZSTD_createDCtx();
-    CHECK(dctx != nullptr);
-    size_t dsz =
-        ZSTD_decompress_usingDDict(dctx, decompressed, node->sz, lzf->compressed, lzf->sz, ddict);
-    CHECK(!ZSTD_isError(dsz)) << "ZSTD decompression error: " << ZSTD_getErrorName(dsz);
-    CHECK_EQ(dsz, node->sz);
-    ZSTD_freeDCtx(dctx);
+    DCHECK(tl_zstd_dict && tl_zstd_dict->dctx);
+    ZSTD_DCtx_reset(tl_zstd_dict->dctx, ZSTD_reset_session_only);
+    size_t dsz = ZSTD_decompress_usingDDict(tl_zstd_dict->dctx, decompressed, node->sz,
+                                            lzf->compressed, lzf->sz, tl_zstd_dict->ddict);
+    if (ZSTD_isError(dsz) || dsz != node->sz) {
+      LOG(DFATAL) << "ZSTD decompression error: " << ZSTD_getErrorName(dsz);
+      zfree(decompressed);
+      return false;
+    }
   } else {
     if (lzf_decompress(lzf->compressed, lzf->sz, decompressed, node->sz) == 0) {
       LOG(DFATAL) << "Invalid LZF compressed data";
@@ -325,20 +347,12 @@ bool DecompressRaw(bool recompress, QList::Node* node, ZSTD_DDict* ddict) {
    recompress: if true, the node will be marked for recompression after decompression.
    returns by how much the size of the node has increased.
 */
-ssize_t TryDecompressInternal(bool recompress, QList::Node* node, ZSTD_DDict* ddict) {
+ssize_t TryDecompressInternal(bool recompress, QList::Node* node) {
   if (node->encoding != QUICKLIST_NODE_ENCODING_RAW) {
     size_t compressed_sz = GetLzf(node)->sz;
-    if (DecompressRaw(recompress, node, ddict)) {
+    if (DecompressRaw(recompress, node)) {
       return node->sz - compressed_sz;
     }
-  }
-  return 0;
-}
-
-ssize_t RecompressOnly(QList::Node* node) {
-  if (node->recompress && !node->dont_compress) {
-    if (CompressRaw(node))
-      return (GetLzf(node))->sz - node->sz;
   }
   return 0;
 }
@@ -374,18 +388,6 @@ QList::Node* SplitNode(QList::Node* node, int offset, bool after, ssize_t* diff)
 }
 
 }  // namespace
-
-struct QList::ZstdDictState {
-  ZSTD_CDict* cdict = nullptr;
-  ZSTD_DDict* ddict = nullptr;
-
-  ~ZstdDictState() {
-    if (cdict)
-      ZSTD_freeCDict(cdict);
-    if (ddict)
-      ZSTD_freeDDict(ddict);
-  }
-};
 
 __thread QList::Stats QList::stats;
 
@@ -447,7 +449,13 @@ void QList::SetTieringParams(const TieringParams& params) {
   tiering_params_ = make_unique<TieringParams>(params);
 }
 
-QList::QList(int fill, int compress) : fill_(fill), compress_(compress), bookmark_count_(0) {
+QList::QList(int fill, int compress)
+    : fill_(fill),
+      dict_learning_failed_(0),
+      dict_compress_failed_(0),
+      dict_bulk_finished_(0),
+      compress_(compress),
+      bookmark_count_(0) {
 }
 
 QList::QList(QList&& other) noexcept
@@ -455,11 +463,13 @@ QList::QList(QList&& other) noexcept
       count_(other.count_),
       len_(other.len_),
       fill_(other.fill_),
+      dict_learning_failed_(other.dict_learning_failed_),
+      dict_compress_failed_(other.dict_compress_failed_),
+      dict_bulk_finished_(other.dict_bulk_finished_),
       compress_(other.compress_),
       bookmark_count_(other.bookmark_count_),
       num_offloaded_nodes_(other.num_offloaded_nodes_),
-      tiering_params_(std::move(other.tiering_params_)),
-      zstd_dict_(std::move(other.zstd_dict_)) {
+      tiering_params_(std::move(other.tiering_params_)) {
   other.head_ = nullptr;
   other.len_ = other.count_ = 0;
   other.num_offloaded_nodes_ = 0;
@@ -476,10 +486,12 @@ QList& QList::operator=(QList&& other) noexcept {
     len_ = other.len_;
     count_ = other.count_;
     fill_ = other.fill_;
+    dict_learning_failed_ = other.dict_learning_failed_;
+    dict_compress_failed_ = other.dict_compress_failed_;
+    dict_bulk_finished_ = other.dict_bulk_finished_;
     compress_ = other.compress_;
     bookmark_count_ = other.bookmark_count_;
     tiering_params_ = std::move(other.tiering_params_);
-    zstd_dict_ = std::move(other.zstd_dict_);
     num_offloaded_nodes_ = other.num_offloaded_nodes_;
     other.head_ = nullptr;
     other.len_ = other.count_ = other.num_offloaded_nodes_ = 0;
@@ -760,7 +772,7 @@ void QList::Insert(Iterator it, std::string_view elem, InsertOpt insert_opt) {
     uint8_t* new_entry = LP_Insert(node->entry, elem, it.zi_, after ? LP_AFTER : LP_BEFORE);
     malloc_size_ += NodeSetEntry(node, new_entry);
     node->count++;
-    malloc_size_ += RecompressOnly(node);
+    malloc_size_ += RecompressNode(node);
   } else {
     bool insert_tail = at_tail && after;
     bool insert_head = at_head && !after;
@@ -771,8 +783,8 @@ void QList::Insert(Iterator it, std::string_view elem, InsertOpt insert_opt) {
       AccessForReads(true, new_node);
       malloc_size_ += NodeSetEntry(new_node, LP_Prepend(new_node->entry, elem));
       new_node->count++;
-      malloc_size_ += RecompressOnly(new_node);
-      malloc_size_ += RecompressOnly(node);
+      malloc_size_ += RecompressNode(new_node);
+      malloc_size_ += RecompressNode(node);
     } else if (insert_head && avail_prev) {
       /* If we are: at head, previous has free space, and inserting before:
        *   - insert entry at tail of previous node. */
@@ -780,8 +792,8 @@ void QList::Insert(Iterator it, std::string_view elem, InsertOpt insert_opt) {
       AccessForReads(true, new_node);
       malloc_size_ += NodeSetEntry(new_node, LP_Append(new_node->entry, elem));
       new_node->count++;
-      malloc_size_ += RecompressOnly(new_node);
-      malloc_size_ += RecompressOnly(node);
+      malloc_size_ += RecompressNode(new_node);
+      malloc_size_ += RecompressNode(node);
     } else if (insert_tail || insert_head) {
       /* If we are: full, and our prev/next has no available space, then:
        *   - create new node and attach to qlist */
@@ -916,29 +928,57 @@ void QList::CoolOff(Node* node, uint32_t node_id) {
         traverse_node_id++;
       }
     }
+  } else if (zstd_threshold_ > 0 && !AllowLZFCompression()) {
+    // ZSTD dictionary compression (mutually exclusive with LZF depth-compression).
+    if (dict_bulk_finished_) {
+      // Steady state: compress individual nodes as they appear.
+      if (!dict_compress_failed_ && tl_zstd_dict && node != head_ && node->next != nullptr) {
+        CompressNodeWithDict(node);
+      }
+    } else if (tl_zstd_dict) {
+      // Dict exists (trained by this or another instance), bulk-compress all interior nodes.
+      CompressWithZstdDict();
+      dict_bulk_finished_ = 1;
+    } else if (!dict_learning_failed_ && malloc_size_ >= zstd_threshold_ && len_ >= 2) {
+      // No dict yet, try to train one.
+      TrainZstdDict();
+    }
+  } else {
+    /* Force 'quicklist' to meet compression guidelines set by compress depth.
+     * The only way to guarantee interior nodes get compressed is to iterate
+     * to our "interior" compress depth then compress the next node we find.
+     * If compress depth is larger than the entire list, we return immediately. */
+    if (node->recompress)
+      CompressRaw(node);
+    else
+      this->CompressByDepth(node);
   }
-
-  /* Force 'quicklist' to meet compression guidelines set by compress depth.
-   * The only way to guarantee interior nodes get compressed is to iterate
-   * to our "interior" compress depth then compress the next node we find.
-   * If compress depth is larger than the entire list, we return immediately. */
-
-  if (node->recompress)
-    CompressRaw(node);
-  else
-    this->CompressByDepth(node);
 }
 
 void QList::CompressByDepth(Node* node) {
   if (len_ == 0)
     return;
 
+  // In ZSTD dict mode (LZF disabled), depth-based LZF compression doesn't apply.
+  // Handle the recompress flag via dict and return.
+  if (zstd_threshold_ > 0 && !AllowLZFCompression()) {
+    if (node && node->recompress && tl_zstd_dict && !dict_compress_failed_ && node != head_ &&
+        node->next != nullptr) {
+      size_t sz = node->sz;
+      if (CompressNodeWithDict(node)) {
+        node->recompress = 0;
+        malloc_size_ += ssize_t(((quicklistLZF*)node->entry)->sz) - sz;
+      }
+    }
+    return;
+  }
+
   /* The head and tail should never be compressed (we should not attempt to recompress them) */
   DCHECK(head_->recompress == 0 && head_->prev->recompress == 0);
 
   /* If length is less than our compress depth (from both sides),
    * we can't compress anything. */
-  if (!AllowCompression() || len_ < (unsigned int)(compress_ * 2))
+  if (!AllowLZFCompression() || len_ < (unsigned int)(compress_ * 2))
     return;
 
   /* Iterate until we reach compress depth for both sides of the list.a
@@ -949,11 +989,9 @@ void QList::CompressByDepth(Node* node) {
   int depth = 0;
   int in_depth = 0;
 
-  DCHECK(!zstd_dict_);
-
   while (depth++ < compress_) {
-    malloc_size_ += TryDecompressInternal(false, forward, nullptr);
-    malloc_size_ += TryDecompressInternal(false, reverse, nullptr);
+    malloc_size_ += TryDecompressInternal(false, forward);
+    malloc_size_ += TryDecompressInternal(false, reverse);
 
     if (forward == node || reverse == node)
       in_depth = 1;
@@ -987,8 +1025,7 @@ void QList::AccessForReads(bool recompress, Node* node) {
   if (len_ > 2 && node != head_ && node->next != nullptr) {
     stats.interior_node_reads++;
   }
-  ZSTD_DDict* ddict = zstd_dict_ ? zstd_dict_->ddict : nullptr;
-  ssize_t res = TryDecompressInternal(recompress, node, ddict);
+  ssize_t res = TryDecompressInternal(recompress, node);
   malloc_size_ += res;
 }
 
@@ -1349,7 +1386,7 @@ bool QList::Erase(const long start, unsigned count) {
       if (node->count == 0) {
         DelNode(node);
       } else {
-        malloc_size_ += RecompressOnly(node);
+        malloc_size_ += RecompressNode(node);
       }
     }
 
@@ -1435,6 +1472,154 @@ auto QList::Iterator::Get() const -> Entry {
   uint8_t* ptr = lpGetValue(zi_, &sz, &val);
 
   return ptr ? Entry(reinterpret_cast<char*>(ptr), sz) : Entry(val);
+}
+
+bool QList::TrainZstdDict() {
+  DCHECK_GE(malloc_size_, zstd_threshold_);
+  DCHECK_GE(len_, 2u);
+
+  // If the thread-local dictionary is already trained, reuse it.
+  if (tl_zstd_dict) {
+    return true;
+  }
+
+  // Collect raw data from all nodes for estimation and training.
+  // We must decompress any already-compressed nodes first.
+  vector<pair<const uint8_t*, size_t>> data_pieces;
+  data_pieces.reserve(len_);
+
+  for (Node* node = head_; node; node = node->next) {
+    DCHECK_EQ(node->encoding, QUICKLIST_NODE_ENCODING_RAW);
+    data_pieces.emplace_back(node->entry, size_t(node->sz));
+  }
+
+  // Estimate compressibility.
+  double ratio = EstimateCompressibility(data_pieces, 2);
+  if (ratio > 0.6) {
+    VLOG(2) << "QList data not compressible (ratio=" << ratio << ")";
+    dict_learning_failed_ = 1;
+    return false;
+  }
+
+  // Train dictionary.
+  string dict_raw = TrainDictionary(data_pieces, 8192, 64);
+  if (dict_raw.empty()) {
+    dict_learning_failed_ = 1;
+    return false;
+  }
+
+  auto* state = new ZstdDictState();
+  state->cdict = ZSTD_createCDict(dict_raw.data(), dict_raw.size(), 1);
+  state->ddict = ZSTD_createDDict(dict_raw.data(), dict_raw.size());
+  state->cctx = ZSTD_createCCtx();
+  state->dctx = ZSTD_createDCtx();
+  if (!state->cdict || !state->ddict || !state->cctx || !state->dctx) {
+    delete state;
+    dict_learning_failed_ = 1;
+    return false;
+  }
+  tl_zstd_dict = state;
+
+  return true;
+}
+
+void QList::CompressWithZstdDict() {
+  DCHECK(tl_zstd_dict);
+
+  // Bulk-compress all interior nodes.
+  bool any_compressed = false;
+  bool any_attempted = false;
+  for (Node* node = head_; node; node = node->next) {
+    if (node == head_ || node->next == nullptr)
+      continue;
+    any_attempted = true;
+    if (CompressNodeWithDict(node))
+      any_compressed = true;
+  }
+
+  // Only mark failure if we actually tried to compress nodes and all failed.
+  if (any_attempted && !any_compressed) {
+    dict_compress_failed_ = 1;
+  }
+
+  // Recalculate malloc_size_.
+  malloc_size_ = 0;
+  for (Node* node = head_; node; node = node->next) {
+    malloc_size_ += zmalloc_usable_size(node->entry) + sizeof(Node);
+  }
+  malloc_size_ += znallocx(sizeof(QList));
+}
+
+bool QList::CompressNodeWithDict(Node* node) {
+  DCHECK(tl_zstd_dict);
+
+  if (node->encoding != QUICKLIST_NODE_ENCODING_RAW)
+    return false;
+  if (node->sz < MIN_COMPRESS_BYTES)
+    return false;
+
+  size_t bound = ZSTD_compressBound(node->sz);
+  quicklistLZF* dest = (quicklistLZF*)zmalloc(sizeof(quicklistLZF) + bound);
+  ZSTD_CCtx_reset(tl_zstd_dict->cctx, ZSTD_reset_session_only);
+  size_t csz = ZSTD_compress_usingCDict(tl_zstd_dict->cctx, dest->compressed, bound, node->entry,
+                                        node->sz, tl_zstd_dict->cdict);
+  CHECK(!ZSTD_isError(csz)) << ZSTD_getErrorName(csz);
+
+  if (csz + MIN_COMPRESS_IMPROVE >= node->sz) {
+    zfree(dest);
+    return false;
+  }
+
+  dest->sz = csz;
+  dest = (quicklistLZF*)zrealloc(dest, sizeof(quicklistLZF) + csz);
+  stats.compressed_bytes += csz;
+  stats.raw_compressed_bytes += node->sz;
+  stats.zstd_dict_compressions++;
+
+  zfree(node->entry);
+  node->entry = (unsigned char*)dest;
+  node->encoding = QLIST_NODE_ENCODING_ZSTD;
+  return true;
+}
+
+ssize_t QList::RecompressNode(Node* node) {
+  if (!node->recompress || node->dont_compress)
+    return 0;
+  if (zstd_threshold_ > 0 && !AllowLZFCompression() && tl_zstd_dict && !dict_compress_failed_ &&
+      node != head_ && node->next != nullptr) {
+    size_t sz = node->sz;
+    if (CompressNodeWithDict(node)) {
+      node->recompress = 0;
+      return ssize_t(((quicklistLZF*)node->entry)->sz) - sz;
+    }
+  } else if (CompressRaw(node)) {
+    return ssize_t(GetLzf(node)->sz) - node->sz;
+  }
+  return 0;
+}
+
+bool QList::DecompressZstdNode(const Node* node, std::string* dest) {
+  if (node->encoding != QLIST_NODE_ENCODING_ZSTD)
+    return false;
+  if (!tl_zstd_dict) {
+    LOG(DFATAL) << "ZSTD-compressed node found but no thread-local dict during save";
+    return false;
+  }
+  const quicklistLZF* lzf = (const quicklistLZF*)node->entry;
+  dest->resize(node->sz);
+  ZSTD_DCtx_reset(tl_zstd_dict->dctx, ZSTD_reset_session_only);
+  size_t dsz = ZSTD_decompress_usingDDict(tl_zstd_dict->dctx, dest->data(), dest->size(),
+                                          lzf->compressed, lzf->sz, tl_zstd_dict->ddict);
+  if (ZSTD_isError(dsz)) {
+    LOG(ERROR) << "ZSTD decompression error during save: " << ZSTD_getErrorName(dsz);
+    return false;
+  }
+  return true;
+}
+
+void QList::ShutdownThread() {
+  delete tl_zstd_dict;
+  tl_zstd_dict = nullptr;
 }
 
 }  // namespace dfly

--- a/src/core/qlist.h
+++ b/src/core/qlist.h
@@ -218,6 +218,15 @@ class QList {
 
   static void SetPackedThreshold(unsigned threshold);
 
+  // Frees the thread-local ZSTD dictionary state. Must be called once per thread
+  // during service shutdown.
+  static void ShutdownThread();
+
+  // Decompresses a ZSTD-encoded node into dest using the thread-local dict.
+  // Returns false if the node is not ZSTD-encoded or decompression fails.
+  // Used during RDB save to avoid persisting ZSTD bytes as LZF.
+  static bool DecompressZstdNode(const Node* node, std::string* dest);
+
   // Moves nodes away from underused pages by reallocating if the underlying page usage is low.
   // Returns count of nodes reallocated to help in testing.
   size_t DefragIfNeeded(PageUsage* page_usage);
@@ -257,7 +266,7 @@ class QList {
   static __thread Stats stats;
 
  private:
-  bool AllowCompression() const {
+  bool AllowLZFCompression() const {
     return compress_ != 0;
   }
 
@@ -274,8 +283,24 @@ class QList {
   // compressing the node based on its position in the list.
   void CoolOff(Node* node, uint32_t node_id);
 
+  // Like the RecompressOnly free function, but also handles ZSTD dict mode.
+  // Returns the size delta (negative means compression reduced memory usage).
+  ssize_t RecompressNode(Node* node);
+
   void Replace(Iterator it, std::string_view elem);
   void CompressByDepth(Node* node);
+
+  // Trains a ZSTD dictionary from all node data and stores it in thread-local state.
+  // Returns true if a dictionary was successfully trained (or already exists).
+  // Sets dict_learning_failed_ on failure.
+  bool TrainZstdDict();
+
+  // Bulk-compresses all interior nodes using the thread-local ZSTD dictionary.
+  // Sets dict_compress_failed_ if no nodes could be compressed.
+  void CompressWithZstdDict();
+
+  // Compresses a single node using the thread-local ZSTD dictionary.
+  bool CompressNodeWithDict(Node* node);
 
   // Prepares the node for read access.
   void AccessForReads(bool recompress, Node* node);
@@ -294,20 +319,20 @@ class QList {
   void InitIteratorEntry(Iterator* it) const;
 
   Node* head_ = nullptr;
-  size_t malloc_size_ = 0;  // size of the quicklist struct
-  uint32_t count_ = 0;      /* total count of all entries in all listpacks */
-  uint32_t len_ = 0;        /* number of quicklistNodes */
-  int16_t fill_;            /* fill factor for individual nodes */
-  int16_t reserved1_;
+  size_t malloc_size_ = 0;            // size of the quicklist struct
+  uint32_t count_ = 0;                /* total count of all entries in all listpacks */
+  uint32_t len_ = 0;                  /* number of quicklistNodes */
+  int16_t fill_;                      /* fill factor for individual nodes */
+  uint16_t dict_learning_failed_ : 1; /* thread-local dict training failed for this list's data */
+  uint16_t dict_compress_failed_ : 1; /* compression with thread-local dict failed for this list */
+  uint16_t dict_bulk_finished_ : 1;   /* bulk compression done, per-node compression active */
+  uint16_t reserved1_ : 13;
   unsigned compress_ : QL_COMP_BITS; /* depth of end nodes not to compress;0=off */
   unsigned bookmark_count_ : QL_BM_BITS;
   unsigned reserved2_ : 12;
   uint32_t num_offloaded_nodes_ = 0;
   uint32_t zstd_threshold_ = 0;  // 0 = disabled
   std::unique_ptr<TieringParams> tiering_params_;
-
-  struct ZstdDictState;
-  std::unique_ptr<ZstdDictState> zstd_dict_;
 };
 
 }  // namespace dfly

--- a/src/core/qlist_test.cc
+++ b/src/core/qlist_test.cc
@@ -1077,4 +1077,171 @@ static void BM_QListUncompress(benchmark::State& state) {
 }
 BENCHMARK(BM_QListUncompress)->ArgsProduct({{1, 4, 0}});
 
+class QListZstdTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    SetupMalloc();
+  }
+
+  void TearDown() override {
+    // Reset thread-local ZSTD dictionary between tests so each test starts clean.
+    QList::ShutdownThread();
+  }
+
+  // Generate Celery-like JSON entries.
+  void PopulateWithCeleryData(QList& ql, unsigned count) {
+    for (unsigned i = 0; i < count; ++i) {
+      string id = to_string(100000 + i);
+      string entry =
+          "{\"body\": \"W10=\", \"content-encoding\": \"utf-8\", "
+          "\"content-type\": \"application/json\", "
+          "\"headers\": {\"lang\": \"py\", \"task\": \"process_job\", "
+          "\"id\": \"b3e4b923-8a77-4053-aff0-" +
+          id +
+          "\", \"shadow\": null, \"eta\": null, "
+          "\"expires\": null, \"group\": null, \"retries\": 0, "
+          "\"timelimit\": [null, null], "
+          "\"root_id\": \"b3e4b923-8a77-4053-aff0-" +
+          id +
+          "\", \"parent_id\": null, "
+          "\"argsrepr\": \"('job" +
+          to_string(i) +
+          "',)\", \"kwargsrepr\": \"{}\", "
+          "\"origin\": \"gen917779@hut\"}, "
+          "\"properties\": {\"correlation_id\": \"b3e4b923\", "
+          "\"reply_to\": \"9933040c\", \"delivery_mode\": 2, "
+          "\"delivery_info\": {\"exchange\": \"\", \"routing_key\": \"my_queue\"}, "
+          "\"priority\": 0}}";
+      ql.Push(entry, QList::TAIL);
+    }
+  }
+};
+
+TEST_F(QListZstdTest, CompressAndReadAll) {
+  QList ql(-1, 0);            // 4KB nodes, no depth-based compression (ZSTD dict replaces it)
+  ql.set_compr_threshold(1);  // threshold 1 = trigger as soon as possible
+  PopulateWithCeleryData(ql, 500);
+
+  size_t after = ql.MallocUsed(true);
+  LOG(INFO) << "Node count: " << ql.node_count() << ", total entries: " << ql.Size()
+            << ", MallocUsed: " << after;
+
+  // Verify all entries are readable.
+  unsigned count = 0;
+  ql.Iterate(
+      [&](const QList::Entry& e) {
+        EXPECT_NE(e.data(), nullptr);
+        EXPECT_GT(e.view().size(), 100u);
+        ++count;
+        return true;
+      },
+      0, -1);
+  EXPECT_EQ(count, 500u);
+}
+
+TEST_F(QListZstdTest, PushAfterCompress) {
+  QList ql(-1, 0);
+  ql.set_compr_threshold(1);
+  PopulateWithCeleryData(ql, 500);
+
+  // Push new entries after compression.
+  ql.Push("new_head_entry", QList::HEAD);
+  ql.Push("new_tail_entry", QList::TAIL);
+  EXPECT_EQ(ql.Size(), 502u);
+
+  // Verify head and tail are readable.
+  auto it = ql.GetIterator(QList::HEAD);
+  ASSERT_TRUE(it.Valid());
+  EXPECT_EQ(it.Get().view(), "new_head_entry");
+
+  it = ql.GetIterator(QList::TAIL);
+  ASSERT_TRUE(it.Valid());
+  EXPECT_EQ(it.Get().view(), "new_tail_entry");
+}
+
+TEST_F(QListZstdTest, PopAfterCompress) {
+  QList ql(-1, 0);
+  ql.set_compr_threshold(1);
+  PopulateWithCeleryData(ql, 500);
+
+  EXPECT_EQ(ql.Size(), 500u);
+
+  string head = ql.Pop(QList::HEAD);
+  string tail = ql.Pop(QList::TAIL);
+  EXPECT_EQ(ql.Size(), 498u);
+  EXPECT_FALSE(head.empty());
+  EXPECT_FALSE(tail.empty());
+}
+
+TEST_F(QListZstdTest, SmallListSkipped) {
+  QList ql(-2, 0);  // compress=0 so ZSTD path is active (LZF disabled)
+  PopulateWithCeleryData(ql, 5);
+
+  size_t size = ql.MallocUsed(true);
+  // Set threshold higher than the list size — dict should not be trained.
+  ql.set_compr_threshold(size + 1000);
+
+  auto initial_compressions = QList::stats.zstd_dict_compressions;
+  PopulateWithCeleryData(ql, 5);
+  EXPECT_EQ(initial_compressions, QList::stats.zstd_dict_compressions);
+}
+
+TEST_F(QListZstdTest, IndexAccess) {
+  QList ql(-1, 0);
+  ql.set_compr_threshold(1);
+  PopulateWithCeleryData(ql, 500);
+
+  // Access by positive index.
+  auto it = ql.GetIterator(50);
+  ASSERT_TRUE(it.Valid());
+  auto entry = it.Get();
+  EXPECT_NE(entry.data(), nullptr);
+  EXPECT_GT(entry.view().size(), 100u);
+
+  // Access by negative index (from tail).
+  it = ql.GetIterator(-1);
+  ASSERT_TRUE(it.Valid());
+  entry = it.Get();
+  EXPECT_NE(entry.data(), nullptr);
+}
+
+TEST_F(QListZstdTest, IncrementalCompression) {
+  // Verify that a newly interior node gets compressed incrementally.
+  QList ql(-1, 0);
+  ql.set_compr_threshold(1);
+  PopulateWithCeleryData(ql, 500);
+
+  // Head and tail must be uncompressed.
+  EXPECT_EQ(ql.Head()->encoding, QUICKLIST_NODE_ENCODING_RAW);
+  EXPECT_EQ(ql.Tail()->encoding, QUICKLIST_NODE_ENCODING_RAW);
+
+  // Remember the old head node — it will become interior after a head push
+  // that creates a new node.
+  const QList::Node* old_head = ql.Head();
+
+  // Push enough data to force a new head node (fill=-1 means 4KB nodes).
+  for (int i = 0; i < 20; ++i) {
+    ql.Push("padding_head_" + to_string(i), QList::HEAD);
+  }
+
+  // The old head should now be an interior node and compressed.
+  // (It's not head_ anymore, and it's not tail.)
+  EXPECT_NE(ql.Head(), old_head);
+  EXPECT_TRUE(old_head->IsCompressed());
+
+  // New head/tail must remain uncompressed.
+  EXPECT_EQ(ql.Head()->encoding, QUICKLIST_NODE_ENCODING_RAW);
+  EXPECT_EQ(ql.Tail()->encoding, QUICKLIST_NODE_ENCODING_RAW);
+
+  // Verify all entries are still readable.
+  unsigned count = 0;
+  ql.Iterate(
+      [&](const QList::Entry& e) {
+        ++count;
+        return true;
+      },
+      0, -1);
+  EXPECT_EQ(count, ql.Size());
+}
+
 }  // namespace dfly

--- a/src/core/zstd_test.cc
+++ b/src/core/zstd_test.cc
@@ -2,6 +2,8 @@
 // See LICENSE for licensing terms.
 //
 
+#define ZSTD_STATIC_LINKING_ONLY
+
 #include <absl/base/macros.h>
 #include <gmock/gmock.h>
 #include <zstd.h>
@@ -51,6 +53,14 @@ class ZStdTest : public ::testing::Test {
     return res;
   }
 };
+
+TEST_F(ZStdTest, EstimateDictSize) {
+  ZSTD_compressionParameters cParams = ZSTD_getCParams(1, 8192, 8192);
+
+  ZSTD_dictLoadMethod_e dictLoadMethod = ZSTD_dlm_byCopy;
+  size_t estimatedMemory = ZSTD_estimateCDictSize_advanced(4096, cParams, dictLoadMethod);
+  EXPECT_GT(estimatedMemory, 200000);
+}
 
 // Dictionary works well for small messages where we do not have enough data to reference
 // previous stream to have significant savings.

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -13,6 +13,7 @@
 #include "base/flags.h"
 #include "core/huff_coder.h"
 #include "core/page_usage/page_usage_stats.h"
+#include "core/qlist.h"
 #include "io/proc_reader.h"
 
 extern "C" {
@@ -589,6 +590,7 @@ void EngineShard::DestroyThreadLocal() {
 
   shard_->Shutdown();
 
+  QList::ShutdownThread();
   detail::InternedString::ResetPool();
   shard_->~EngineShard();
   CleanupStatelessAllocMR();

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -65,6 +65,9 @@ ABSL_FLAG(int32_t, list_max_listpack_size, -2, "Maximum listpack size, default i
 ABSL_FLAG(int32_t, list_compress_depth, 0, "Compress depth of the list. Default is no compression");
 ABSL_FLAG(unsigned, list_tiering_threshold, 0,
           "Tiering threshold for lists. Default - no tiering.");
+ABSL_FLAG(uint32_t, list_experimental_zstd_dict_threshold, 0,
+          "Minimum list malloc usage in bytes before attempting ZSTD dictionary compression. "
+          "0 disables. Experimental: compression is synchronous and may block the thread.");
 
 namespace dfly {
 
@@ -100,6 +103,10 @@ class ListWrapper {
     if (GetFlag(FLAGS_list_tiering_threshold) > 0) {
       ql->SetTieringParams(
           QList::TieringParams{.node_depth_threshold = GetFlag(FLAGS_list_tiering_threshold)});
+    }
+    if (uint32_t zstd_thresh = GetFlag(FLAGS_list_experimental_zstd_dict_threshold);
+        zstd_thresh > 0) {
+      ql->set_compr_threshold(zstd_thresh);
     }
     if (lp.Size() > 0) {
       ql->AppendListpack(lp.GetPointer());

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -391,6 +391,7 @@ error_code RdbSerializer::SaveListObject(const PrimeValue& pv) {
 
   DCHECK_EQ(pv.Encoding(), kEncodingQL2);
   QList* ql = reinterpret_cast<QList*>(pv.RObjPtr());
+
   const QList::Node* node = ql->Head();
   size_t len = ql->node_count();
 
@@ -402,7 +403,19 @@ error_code RdbSerializer::SaveListObject(const PrimeValue& pv) {
 
     // Use listpack encoding
     RETURN_ON_ERR(SaveLen(node->container));
-    if (node->IsCompressed()) {
+    if (node->encoding == QLIST_NODE_ENCODING_ZSTD) {
+      // ZSTD-compressed nodes cannot be saved using RDB LZF encoding — the loader would
+      // call lzf_decompress on ZSTD bytes and corrupt the data. Decompress to raw first.
+      std::string raw;
+      if (!QList::DecompressZstdNode(node, &raw)) {
+        return make_error_code(errc::invalid_argument);
+      }
+      RETURN_ON_ERR(SaveString(string_view{raw.data(), raw.size()}));
+      FlushState flush_state = FlushState::kFlushMidEntry;
+      if (node->next == nullptr)
+        flush_state = FlushState::kFlushEndEntry;
+      PushToConsumerIfNeeded(flush_state);
+    } else if (node->IsCompressed()) {
       void* data;
       size_t compress_len = node->GetLZF(&data);
       RETURN_ON_ERR(SaveLzfBlob(Bytes{reinterpret_cast<uint8_t*>(data), compress_len}, node->sz));


### PR DESCRIPTION
Move ZstdDictState from per-QList unique_ptr to a thread-local raw
pointer shared across all QList instances on the same thread.
Motivation: ZSTD_CDict and ZSTD_DDict take 200-300KB each and holding them
per list kills the main motivation to save memory.

- Rename AllowCompression -> AllowLZFCompression
- Split TrainAndCompressZstdDict into TrainZstdDict,
  CompressWithZstdDict, and CompressNodeWithDict
- Add bit fields for tracking compression state:
  dict_learning_failed, dict_compress_failed, dict_bulk_finished
- CoolOff ZSTD branch: 3-state machine
  (train -> bulk compress -> per-node compress)
- Add ShutdownThread() to free thread-local dict on shard teardown
- Wire list_experimental_zstd_dict_threshold flag in list_family
- Add QListZstdTest suite with 6 tests

Test: `./dfly_bench  -n 80000 -p 6379 -qps=0  -d 64 --key_maximum=10  --command="lpush __key__ foooooooooobbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaarrrrrrrrrrrrrrrrrrrrrrrrr" --pipeline=5`

1. With list_experimental_zstd_dict_threshold=0 (disabled, default): used_memory_human:2.56GiB QPS: 1723935, P99 lat: 6ms
2. With list_experimental_zstd_dict_threshold=100000: used_memory_human: 32.84MiB, QPS: 1784274 P99 - 5.5ms

75 times less memory consumption for this synthetic use-case.
For real-world use-cases I expect to have 3-10x reduction in some cases.

Fixes #6899 

Signed-off-by: Roman Gershman <roman@dragonflydb.io>