### PR TITLE
fix: FT.AGGREGATE SORTBY crash with huge nargs value

### DIFF
--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -175,7 +175,7 @@ struct CmdArgParser {
   ErrorInfo TakeError();
 
   bool HasAtLeast(size_t i) const {
-    return cur_i_ + i <= args_.size() && !error_;
+    return !error_ && i <= args_.size() - cur_i_;
   }
 
   size_t GetCurrentIndex() const {

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -463,6 +463,10 @@ ParseResult<SearchParams> ParseSearchParams(CmdArgParser* parser) {
 ParseResult<aggregate::SortParams> ParseAggregatorSortParams(CmdArgParser* parser) {
   size_t strings_num = parser->Next<size_t>();
 
+  if (!parser->HasError() && !parser->HasAtLeast(strings_num)) {
+    return CreateSyntaxError("bad arguments for SORTBY: specified invalid number of strings"sv);
+  }
+
   aggregate::SortParams sort_params;
   sort_params.fields.reserve(strings_num / 2);
 

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -1845,6 +1845,10 @@ TEST_F(SearchFamilyTest, AggregateSortByParsingErrors) {
   // Test SORTBY with an invalid value
   resp = Run({"FT.AGGREGATE", "index", "*", "SORTBY", "notvalue", "@name"});
   EXPECT_THAT(resp, ErrArg(kInvalidIntErr));
+
+  // Test SORTBY with a huge nargs value that exceeds available arguments
+  resp = Run({"FT.AGGREGATE", "index", "*", "SORTBY", "19999999999600", "@name"});
+  EXPECT_THAT(resp, ErrArg("bad arguments for SORTBY: specified invalid number of strings"));
 }
 
 TEST_F(SearchFamilyTest, AggregateSortByParsingErrorsWithoutAt) {


### PR DESCRIPTION
Validate SORTBY nargs against available arguments before calling reserve(), preventing OOM crash when a client sends a huge number (e.g. 1999999999960).

Fixes #6971