### PR TITLE
fix: handle expired set members in SDIFFSTORE/SDIFF

### DIFF
--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -769,7 +769,10 @@ OpResult<StringVec> OpDiff(const OpArgs& op_args, ShardArgs::Iterator start,
     return true;
   });
 
-  DCHECK(!uniques.empty());  // otherwise the key would not exist.
+  // All members may have expired (per-member TTL via SADDEX), leaving an empty set.
+  if (uniques.empty()) {
+    return StringVec{};
+  }
 
   for (++start; start != end; ++start) {
     auto diff_res = db_slice.FindReadOnly(op_args.db_cntx, *start, OBJ_SET);

--- a/src/server/set_family_test.cc
+++ b/src/server/set_family_test.cc
@@ -472,6 +472,27 @@ TEST_F(SetFamilyTest, CheckSetLinkExpiryTransfer) {
   EXPECT_THAT(Run("SCARD key"), IntArg(0));
 }
 
+TEST_F(SetFamilyTest, SDiffStoreExpiredMembers) {
+  TEST_current_time_ms = kMemberExpiryBase * 1000;
+
+  // Create a set with per-member TTL using SADDEX
+  EXPECT_THAT(Run({"saddex", "src", "1", "a", "b", "c"}), IntArg(3));
+
+  // Create another set for diffing
+  EXPECT_THAT(Run({"sadd", "other", "x"}), IntArg(1));
+
+  // Advance time so all members expire
+  AdvanceTime(2000);
+
+  // SDIFFSTORE should handle expired members gracefully, not crash
+  auto resp = Run({"sdiffstore", "dest", "src", "other"});
+  EXPECT_THAT(resp, IntArg(0));
+
+  // Also test SDIFF (read-only variant)
+  resp = Run({"sdiff", "src", "other"});
+  EXPECT_THAT(resp.GetVec(), IsEmpty());
+}
+
 TEST_F(SetFamilyTest, SetInter_5590) {
   absl::FlagSaver fs;
   SetTestFlag("num_shards", "2");


### PR DESCRIPTION
- Fix crash (`DCHECK(!uniques.empty())`) in `OpDiff` when all set members have expired via per-member TTL (`SADDEX`)
- `FindReadOnly` finds the key (key-level exists), but `IterateSet` lazily expires all members, leaving an empty result

Fixes #6973