### PR TITLE
fix: null ptr deref in JournalXReadGroupIfNeeded for XREAD BLOCK with replication

### DIFF
--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -2959,26 +2959,16 @@ void JournalConsumerCreationIfNeeded(OpArgs op_args, const ReadOpts& opts, std::
 // creation.
 void JournalXReadGroupIfNeeded(OpArgs op_args, const ReadOpts& opts, const RecordVec& records,
                                std::string_view key) {
-  if (!op_args.shard->journal()) {
+  if (!op_args.shard->journal() || !opts.read_group || records.empty()) {
     return;
   }
 
-  const bool serve_history = opts.stream_ids.at(key).serve_history;
+  const auto& sitem = opts.stream_ids.at(key);
+  const bool serve_history = sitem.serve_history;
 
   if (serve_history) {
     return;
   }
-
-  // Reading from >
-  auto journal_xgroup = [&opts, op_args](const auto& records, std::string_view key) {
-    if (!records.empty()) {
-      const auto& sitem = opts.stream_ids.at(key);
-      auto id = absl::StrCat(records.back().id.ms, "-", records.back().id.seq);
-      auto entries_read = absl::StrCat(sitem.group->entries_read);
-      CmdArgVec journal_args = {"SETID", key, opts.group_name, id, "ENTRIESREAD", entries_read};
-      RecordJournal(op_args, "XGROUP"sv, journal_args);
-    }
-  };
 
   // If NOACK is *not* set we add entries to PEL. Consumer is created as a side
   // effect of XCLAIM.
@@ -2992,11 +2982,12 @@ void JournalXReadGroupIfNeeded(OpArgs op_args, const ReadOpts& opts, const Recor
 
       RecordJournal(op_args, "XCLAIM"sv, journal_args);
     }
-    journal_xgroup(records, key);
-    return;
   }
 
-  journal_xgroup(records, key);
+  auto id = absl::StrCat(records.back().id.ms, "-", records.back().id.seq);
+  auto entries_read = absl::StrCat(sitem.group->entries_read);
+  CmdArgVec journal_args = {"SETID", key, opts.group_name, id, "ENTRIESREAD", entries_read};
+  RecordJournal(op_args, "XGROUP"sv, journal_args);
 }
 
 // Set is_consumer_new to true if the consumer is created. Only relevant for,

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -4008,6 +4008,42 @@ async def test_xreadgroup_replication(df_factory):
 
 
 """
+Regression test for SIGSEGV when XREAD BLOCK unblocks with replication active.
+JournalXReadGroupIfNeeded accessed sitem.group->entries_read without checking that
+group is non-null (group is always null for XREAD, only set for XREADGROUP).
+"""
+
+
+@dfly_args({"proactor_threads": 2})
+async def test_xread_block_replication_crash_6975(df_factory):
+    master = df_factory.create()
+    replica = df_factory.create()
+
+    master.start()
+    replica.start()
+
+    c_master = master.client()
+    c_replica = replica.client()
+
+    await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
+    await wait_for_replicas_state(c_replica)
+
+    await c_master.execute_command("XADD mystream * tmp tmp")
+
+    # Start blocking XREAD - this will crash the server on unblock with replication active
+    # because JournalXReadGroupIfNeeded dereferences a null group pointer
+    read_task = asyncio.create_task(c_master.execute_command("XREAD BLOCK 0 STREAMS mystream $"))
+    await asyncio.sleep(0.1)
+    assert not read_task.done(), "XREAD BLOCK should still be blocking"
+
+    await c_master.execute_command("XADD mystream * field value")
+    result = await read_task
+
+    assert result is not None
+    await check_all_replicas_finished([c_replica], c_master)
+
+
+"""
 Test replication with mismatched dbnum between master and replica.
 """
 


### PR DESCRIPTION
## Summary

- `JournalXReadGroupIfNeeded` crashed with SIGSEGV when `XREAD BLOCK` unblocked while replication was active
- `sitem.group` is always `nullptr` for plain XREAD (only set for XREADGROUP), but the function dereferenced it unconditionally via `sitem.group->entries_read`
- Fix: add `|| !opts.read_group || records.empty()` to the early-return guard; remove now-unnecessary `journal_xgroup` lambda

## Root Cause

In `XReadBlock`'s `range_cb`, `JournalXReadGroupIfNeeded` was called without checking `opts->read_group`. With a replica connected (journal non-null), the function would proceed into the lambda and dereference a null `group` pointer.

Crash observed in production at: `JournalXReadGroupIfNeeded()::{lambda()#1}::operator<>()`

## Changes

- `src/server/stream_family.cc`: guard + refactor `JournalXReadGroupIfNeeded`
- `tests/dragonfly/replication_test.py`: regression test `test_xread_block_replication_crash`

Fixes https://github.com/dragonflydb/dragonfly/issues/6975