### PR TITLE
fix: JSON.NUMINCRBY negative result overflow

### DIFF
--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -1066,8 +1066,13 @@ void BinOpApply(double num, bool num_is_double, ArithmeticOpType op, JsonType* v
 
   if (val->is_double() || num_is_double) {
     *val = result;
-  } else {
+  } else if (result >= 0) {
     *val = static_cast<uint64_t>(result);
+  } else if (result >= static_cast<double>(std::numeric_limits<int64_t>::min())) {
+    *val = static_cast<int64_t>(result);
+  } else {
+    *overflow = true;
+    return;
   }
   *overflow = false;
 }

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -715,6 +715,26 @@ TEST_F(JsonFamilyTest, NumIncrBy) {
   auto resp = Run({"JSON.SET", "json", ".", json});
   ASSERT_THAT(resp, "OK");
 
+  // Incrementing by a negative value should produce a negative result, not uint64 overflow
+  resp = Run({"JSON.NUMINCRBY", "json", "$.a", "-2"});
+  EXPECT_EQ(resp, "[-1]");
+
+  // Large positive integer (> INT64_MAX) should remain positive after increment.
+  // At 2^63 the double ULP is 2048, so use an increment of 2048 to get an exact result.
+  resp = Run({"JSON.SET", "json", ".", R"({"a":9223372036854775808})"});  // 2^63 = INT64_MAX + 1
+  ASSERT_THAT(resp, "OK");
+  resp = Run({"JSON.NUMINCRBY", "json", "$.a", "2048"});
+  EXPECT_EQ(resp, "[9223372036854777856]");
+
+  // Result below INT64_MIN should report overflow
+  resp = Run({"JSON.SET", "json", ".", R"({"a":-9223372036854775808})"});  // INT64_MIN
+  ASSERT_THAT(resp, "OK");
+  resp = Run({"JSON.NUMINCRBY", "json", "$.a", "-9223372036854775808"});
+  EXPECT_THAT(resp, ErrArg("ERR result is not a number"));
+
+  resp = Run({"JSON.SET", "json", ".", json});
+  ASSERT_THAT(resp, "OK");
+
   resp = Run({"JSON.NUMINCRBY", "json", "$.a", "1.1"});
   EXPECT_EQ(resp, "[2.1]");
 


### PR DESCRIPTION
## Summary
Casting negative double results to `uint64_t` in `BinOpApply` caused `JSON.NUMINCRBY` to return huge positive values instead of negative numbers (e.g., `1 + (-2)` returned `18446744073709551615` instead of `-1`).

## Changes
- Cast integer arithmetic results to `int64_t` instead of `uint64_t`
- Add regression test for negative increment on integer JSON values