### PR TITLE
fix(test): Increase RSS memory usage in test_eviction_on_rss_treshold

### DIFF
--- a/tests/dragonfly/memory_test.py
+++ b/tests/dragonfly/memory_test.py
@@ -202,7 +202,7 @@ async def test_eval_with_oom(df_factory: DflyInstanceFactory):
 
 @pytest.mark.parametrize("heartbeat_rss_eviction", [True, False])
 async def test_eviction_on_rss_treshold(df_factory: DflyInstanceFactory, heartbeat_rss_eviction):
-    max_memory = 1024 * 1024**2  # 10242mb
+    max_memory = 1024 * 1024**2  # 1024 mb
 
     df_server = df_factory.create(
         proactor_threads=3,
@@ -210,6 +210,7 @@ async def test_eviction_on_rss_treshold(df_factory: DflyInstanceFactory, heartbe
         maxmemory=max_memory,
         enable_heartbeat_eviction="false",
         enable_heartbeat_rss_eviction=heartbeat_rss_eviction,
+        vmodule="engine_shard=2",
     )
     df_server.start()
     client = df_server.client()
@@ -237,7 +238,7 @@ async def test_eviction_on_rss_treshold(df_factory: DflyInstanceFactory, heartbe
 
     # This will increase only RSS memory above treshold
     p = client.pipeline()
-    for _ in range(50):
+    for _ in range(150):
         p.execute_command("LRANGE list_1 0 -1")
         p.execute_command("LRANGE list_2 0 -1")
     await p.execute()


### PR DESCRIPTION
On some test setups we don't trigger high RSS memory usage so
increase number of pipelined LRANGE commands. Enable extra logging.

Closes #6160

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
