### PR TITLE
fix: SPOP crash when set members have expired per-member TTLs

### DIFF
--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -990,7 +990,21 @@ OpResult<StringVec> OpPop(const OpArgs& op_args, string_view key, unsigned count
   auto [removed, is_empty] = RemoveSet(db_cntx, result, &co);
   find_res->post_updater.Run();
 
-  CHECK(!is_empty);
+  // Lazy per-member TTL expiry during RandMemberSet iteration may have emptied
+  // the set (Size() includes expired members, but iteration skips them).
+  if (is_empty) {
+    db_slice.DelMutable(db_cntx, std::move(*find_res));
+    if (op_args.shard->journal()) {
+      RecordJournal(op_args, "DEL"sv, ArgSlice{key});
+    }
+    // Return KEY_NOTFOUND when nothing was actually popped so that CmdSPop
+    // replies with NULL for the single-arg form instead of dereferencing an
+    // empty vector.
+    if (result.empty()) {
+      return OpStatus::KEY_NOTFOUND;
+    }
+    return result;
+  }
 
   // Replicate as SREM with removed keys, because SPOP is not deterministic.
   if (removed && op_args.shard->journal()) {

--- a/src/server/set_family_test.cc
+++ b/src/server/set_family_test.cc
@@ -586,4 +586,32 @@ TEST_F(SetFamilyTest, SetOpsDeleteEmptyAfterExpiry) {
   EXPECT_THAT(Run({"exists", "s2"}), IntArg(0));
 }
 
+TEST_F(SetFamilyTest, SPopWithExpiredMembers) {
+  TEST_current_time_ms = kMemberExpiryBase * 1000;
+
+  // Add members with a short TTL. After expiry Size() still reports them.
+  Run({"saddex", "key", "1", "a", "b", "c"});
+
+  // Let all members expire.
+  AdvanceTime(2000);
+
+  // SPOP 2: Size()=3 (stale), picks_count=min(2,3)=2 < 3 → CASE 2.
+  // Iteration lazy-expires all 3 → set becomes empty → CHECK(!is_empty) crash.
+  auto resp = Run({"spop", "key", "2"});
+  // All members are expired, so nothing is actually popped.
+  ASSERT_THAT(resp, ArrLen(0));
+
+  // The key should be deleted after lazy expiry emptied the set.
+  EXPECT_THAT(Run({"exists", "key"}), IntArg(0));
+
+  // Single-arg form: SPOP key (no count). Must return NULL, not crash on
+  // empty vector dereference.
+  Run({"saddex", "key2", "1", "x", "y"});
+  AdvanceTime(2000);
+
+  resp = Run({"spop", "key2"});
+  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
+  EXPECT_THAT(Run({"exists", "key2"}), IntArg(0));
+}
+
 }  // namespace dfly


### PR DESCRIPTION
Fix crash at `set_family.cc:993` (`CHECK(!is_empty)`) triggered when `SPOP` operates on a set whose members have expired via per-member TTL

Fixes #6989