### PR TITLE
fix: SPOP crash when randomly picked set members have expired TTLs

### DIFF
--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -1011,6 +1011,13 @@ OpResult<StringVec> OpPop(const OpArgs& op_args, string_view key, unsigned count
     return result;
   }
 
+  // Lazy expiry may have removed all picked members even though the set is
+  // not fully empty yet (Size() counts stale entries). Return KEY_NOTFOUND so
+  // CmdSPop replies with NULL instead of dereferencing an empty vector.
+  if (result.empty()) {
+    return OpStatus::KEY_NOTFOUND;
+  }
+
   // Replicate as SREM with removed keys, because SPOP is not deterministic.
   if (removed && op_args.shard->journal()) {
     vector<string_view> mapped(result.size() + 1);

--- a/src/server/set_family_test.cc
+++ b/src/server/set_family_test.cc
@@ -631,4 +631,27 @@ TEST_F(SetFamilyTest, SPopWithExpiredMembers) {
   EXPECT_THAT(Run({"exists", "key2"}), IntArg(0));
 }
 
+TEST_F(SetFamilyTest, SPopSingleArgExpiredCase2) {
+  TEST_current_time_ms = kMemberExpiryBase * 1000;
+
+  for (int attempt = 0; attempt < 50; ++attempt) {
+    string key = absl::StrCat("key", attempt);
+
+    Run({"sadd", key, "live"});
+    Run({"saddex", key, "1", "a", "b", "c"});
+
+    // Let TTL members expire.
+    AdvanceTime(2000);
+
+    auto resp = Run({"spop", key});
+    // Must be either "live" or nil — never a DCHECK crash.
+    if (resp.type == RespExpr::NIL) {
+      // The live member must still be in the set.
+      EXPECT_THAT(Run({"sismember", key, "live"}), IntArg(1));
+      continue;
+    }
+    EXPECT_THAT(resp, "live");
+  }
+}
+
 }  // namespace dfly


### PR DESCRIPTION
SPOP on a set with a mix of live and expired members could crash with DCHECK_EQ(1u, result.value().size()) in CmdSPop In OpPop CASE 2 (count < Size()), the random index generator uses stale Size(), which counts expired members, but Range() iteration skips them - if the picked index exceeds the live entry count, the result is empty while is_empty is false.

Fixes #6995