### PR TITLE
fix: restart migration if can not reconnect

### DIFF
--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -342,6 +342,7 @@ bool OutgoingMigration::FinalizeMigration(long attempt) {
       LOG(WARNING) << "Couldn't connect to " << cf_->MyID() << " : " << migration_info_.node_info.id
                    << " attempt " << attempt << ": " << ec.message()
                    << ", socket state: " + GetSocketInfo(Sock()->native_handle());
+      Finish(GenericError(ec, "Finalize reconnect failed"));
       return false;
     }
   }

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -1480,8 +1480,7 @@ async def test_migration_with_key_ttl(df_factory):
     assert await nodes[1].client.execute_command("stick k_sticky") == 0
 
 
-@pytest.mark.exclude_epoll
-@dfly_args({"proactor_threads": 4, "cluster_mode": "yes", "migration_finalization_timeout_ms": 5})
+@dfly_args({"proactor_threads": 4, "cluster_mode": "yes", "migration_finalization_timeout_ms": 100})
 async def test_network_disconnect_during_migration(df_factory):
     instances = [
         df_factory.create(


### PR DESCRIPTION
fix: #6894

We have an infinite loop during migration finalization: it happens if we have already transferred all data and try to finalize the migration. When the proxy is off, we detect the main connection dropped only, but not for the flow connections, because there is no more data for them, so we try to reconnect the main connection endlessly. This fix restarts the migration if we can not reconnect the main connection during the finalization process. When we do Finish() call with error, the migration process restarts, and we can see the error in the status.
Restart the migration if we can not reconnect during finalization