### PR TITLE
fix: crash in srandmember durin lazy expiration

### DIFF
--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -300,7 +300,10 @@ StringVec RandMemberStrSetPicky(StringSet* strset, size_t count) {
 
   size_t tries = 0;
   while (picks.size() < count && tries++ < count * 2) {
-    auto member = *strset->GetRandomMember();
+    auto it = strset->GetRandomMember();
+    if (it == strset->end())
+      break;
+    sds member = *it;
     picks.insert(picks.end(), {member, sdslen(member)});
   }
 
@@ -915,13 +918,14 @@ OpResult<StringVec> OpInter(const Transaction* t, EngineShard* es, bool remove_f
 }
 
 OpResult<StringVec> OpRandMember(const OpArgs& op_args, std::string_view key, int count) {
-  auto find_res = op_args.GetDbSlice().FindReadOnly(op_args.db_cntx, key, OBJ_SET);
+  auto& db_slice = op_args.GetDbSlice();
+  auto find_res = db_slice.FindReadOnly(op_args.db_cntx, key, OBJ_SET);
   if (!find_res)
     return find_res.status();
 
-  const CompactObj& co = find_res.value()->second;
+  const PrimeValue& pv = find_res.value()->second;
 
-  const std::uint32_t size = co.Size();
+  const std::uint32_t size = pv.Size();
   const bool picks_are_unique = count >= 0;
   const std::uint32_t picks_count =
       picks_are_unique ? std::min(static_cast<std::uint32_t>(count), size) : std::abs(count);
@@ -934,7 +938,13 @@ OpResult<StringVec> OpRandMember(const OpArgs& op_args, std::string_view key, in
     }
   }();
 
-  return RandMemberSet(op_args.db_cntx, co, *generator, picks_count);
+  auto result = RandMemberSet(op_args.db_cntx, pv, *generator, picks_count);
+
+  // pv may be invalidated by DeleteSetIfEmpty (FindMutable + DelMutable), so
+  // we must not reference it afterwards.
+  DeleteSetIfEmpty(db_slice, op_args.db_cntx, key, pv);
+
+  return result;
 }
 
 // count - how many elements to pop.

--- a/src/server/set_family_test.cc
+++ b/src/server/set_family_test.cc
@@ -654,4 +654,46 @@ TEST_F(SetFamilyTest, SPopSingleArgExpiredCase2) {
   }
 }
 
+// Regression test: SRANDMEMBER crashes (SIGSEGV) when all set members have
+// expired via per-member TTL.  OpRandMember reads co.Size() before lazy expiry,
+// then RandMemberStrSetPicky dereferences GetRandomMember() on an empty set.
+// To hit the RandMemberStrSetPicky path we need picks_count*5 < UpperBoundSize(),
+// so with count=1 we need at least 6 members.
+TEST_F(SetFamilyTest, SRandMemberWithExpiredMembers) {
+  TEST_current_time_ms = kMemberExpiryBase * 1000;
+
+  // 6+ members so UpperBoundSize() > 5, triggering the RandMemberStrSetPicky path.
+  Run({"saddex", "key", "1", "a", "b", "c", "d", "e", "f"});
+  AdvanceTime(2000);
+
+  // Without count — should return NIL, not crash.
+  auto resp = Run({"srandmember", "key"});
+  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
+  EXPECT_THAT(Run({"exists", "key"}), IntArg(0));
+
+  // With positive count — unique picks path.
+  Run({"saddex", "key2", "1", "a", "b", "c", "d", "e", "f"});
+  AdvanceTime(2000);
+
+  resp = Run({"srandmember", "key2", "1"});
+  EXPECT_THAT(resp, ArrLen(0));
+  EXPECT_THAT(Run({"exists", "key2"}), IntArg(0));
+
+  // With negative count — non-unique picks, picky path (count*5 < UpperBoundSize).
+  Run({"saddex", "key3", "1", "a", "b", "c", "d", "e", "f"});
+  AdvanceTime(2000);
+
+  resp = Run({"srandmember", "key3", "-1"});
+  EXPECT_THAT(resp, ArrLen(0));
+  EXPECT_THAT(Run({"exists", "key3"}), IntArg(0));
+
+  // Large negative count — exercises the iteration path (picks_count*5 >= UpperBoundSize).
+  Run({"saddex", "key4", "1", "a", "b", "c", "d", "e", "f"});
+  AdvanceTime(2000);
+
+  resp = Run({"srandmember", "key4", "-25"});
+  EXPECT_THAT(resp, ArrLen(0));
+  EXPECT_THAT(Run({"exists", "key4"}), IntArg(0));
+}
+
 }  // namespace dfly


### PR DESCRIPTION
Adds a regression test and hardens SRANDMEMBER handling to prevent crashes when per-member TTL lazy expiration empties a set during random selection.

Changes:

- Add regression coverage for SRANDMEMBER on sets whose members have expired via per-member TTL.
- Prevent dereferencing an invalid iterator in the “picky” random-pick path when the set becomes empty during lazy expiry.
- Ensure empty sets are deleted after SRANDMEMBER triggers lazy expiry.