### PR TITLE
fix: migrate glog references to helio wrappers

### DIFF
--- a/src/core/json/detail/interned_blob.cc
+++ b/src/core/json/detail/interned_blob.cc
@@ -3,9 +3,9 @@
 
 #include "core/json/detail/interned_blob.h"
 
-#include <glog/logging.h>
 #include <mimalloc.h>
 
+#include "base/logging.h"
 #include "core/detail/stateless_allocator.h"
 
 namespace {

--- a/src/core/json/detail/jsoncons_dfs.cc
+++ b/src/core/json/detail/jsoncons_dfs.cc
@@ -3,20 +3,26 @@
 //
 
 // clang-format off
-#include <glog/logging.h>
+#include "base/logging.h"
 // clang-format on
 
 #include "core/json/detail/jsoncons_dfs.h"
 
-namespace dfly::json::detail {
+namespace dfly::json {
 
 using namespace std;
-using nonstd::make_unexpected;
 
 ostream& operator<<(ostream& os, const PathSegment& ps) {
   os << SegmentName(ps.type());
   return os;
 }
+
+}  // namespace dfly::json
+
+namespace dfly::json::detail {
+
+using namespace std;
+using nonstd::make_unexpected;
 
 inline bool IsRecursive(jsoncons::json_type type) {
   return type == jsoncons::json_type::object_value || type == jsoncons::json_type::array_value;

--- a/src/core/page_usage/page_usage_stats.cc
+++ b/src/core/page_usage/page_usage_stats.cc
@@ -7,12 +7,12 @@
 #include <absl/container/flat_hash_set.h>
 #include <absl/strings/ascii.h>
 #include <absl/strings/str_join.h>
-#include <glog/logging.h>
 #include <hdr/hdr_histogram.h>
 
 #include <string>
 
 #include "base/cycle_clock.h"
+#include "base/logging.h"
 
 extern "C" {
 #include <unistd.h>

--- a/src/server/cluster/incoming_slot_migration.cc
+++ b/src/server/cluster/incoming_slot_migration.cc
@@ -214,8 +214,8 @@ bool IncomingSlotMigration::Join(long attempt) {
   while (true) {
     const absl::Time now = absl::Now();
     const absl::Duration passed = now - start;
-    VLOG_EVERY_N(1, 10000) << "Checking whether to continue with join " << passed << " vs "
-                           << timeout;
+    LOG_EVERY_T(INFO, 30) << "Checking whether to continue with join " << passed << " vs "
+                          << timeout;
     if (passed >= timeout) {
       LOG(WARNING) << "Can't join migration in time for " << source_id_;
       ReportError(GenericError("Can't join migration in time"));

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -363,7 +363,7 @@ void RunEngine(ProactorPool* pool, AcceptServer* acceptor) {
 
   // Start the acceptor loop and wait for the server to shutdown.
   acceptor->Run();
-  google::FlushLogFiles(google::INFO);  // Flush the header.
+  base::FlushLogs();
 
   acceptor->Wait();
 

--- a/src/server/journal/serializer.cc
+++ b/src/server/journal/serializer.cc
@@ -7,7 +7,6 @@
 #include <system_error>
 
 #include "base/logging.h"
-#include "glog/logging.h"
 #include "io/io.h"
 #include "io/io_buf.h"
 #include "server/error.h"

--- a/src/server/journal/tx_executor.cc
+++ b/src/server/journal/tx_executor.cc
@@ -108,8 +108,9 @@ bool TransactionReader::NextTxData(JournalReader* reader, ExecutionState* cntx,
 
   if (lsn_.has_value() && dest->opcode == journal::Op::LSN) {
     DCHECK_NE(dest->lsn, 0u);
-    LOG_IF_EVERY_N(WARNING, dest->lsn != *lsn_, 10000)
-        << "master lsn:" << dest->lsn << " replica lsn" << *lsn_;
+    if (dest->lsn != *lsn_) {
+      LOG_EVERY_T(WARNING, 2) << "master lsn:" << dest->lsn << " replica lsn" << *lsn_;
+    }
     DCHECK_EQ(dest->lsn, *lsn_);
   }
   return true;

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -1,9 +1,9 @@
 // Copyright 2022, DragonflyDB authors.  All rights reserved.
 // See LICENSE for licensing terms.
 //
-#include <absl/flags/flag.h>
 #include <absl/strings/str_replace.h>
 
+#include "base/flags.h"
 #include "base/gtest.h"
 #include "base/logging.h"
 #include "facade/error.h"

--- a/src/server/protocol_client.cc
+++ b/src/server/protocol_client.cc
@@ -10,7 +10,6 @@ extern "C" {
 }
 
 #include <absl/cleanup/cleanup.h>
-#include <absl/flags/flag.h>
 #include <absl/functional/bind_front.h>
 #include <absl/strings/escaping.h>
 #include <absl/strings/str_cat.h>
@@ -19,6 +18,7 @@ extern "C" {
 #include <boost/asio/ip/tcp.hpp>
 #include <string>
 
+#include "base/flags.h"
 #include "base/logging.h"
 #include "facade/dragonfly_connection.h"
 #include "facade/redis_parser.h"

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -14,7 +14,6 @@ extern "C" {
 }
 
 #include <absl/cleanup/cleanup.h>
-#include <absl/flags/flag.h>
 #include <absl/functional/bind_front.h>
 #include <absl/strings/escaping.h>
 #include <absl/strings/str_cat.h>
@@ -24,6 +23,7 @@ extern "C" {
 #include <memory>
 #include <utility>
 
+#include "base/flags.h"
 #include "base/logging.h"
 #include "facade/redis_parser.h"
 #include "facade/reply_capture.h"

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -4,13 +4,13 @@
 
 #include "server/search/search_family.h"
 
-#include <absl/flags/flag.h>
 #include <absl/strings/str_format.h>
 
 #include <algorithm>
 #include <atomic>
 #include <string_view>
 
+#include "base/flags.h"
 #include "base/gtest.h"
 #include "base/logging.h"
 #include "core/detail/gen_utils.h"

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -71,12 +71,12 @@ void RecordTxScheduleStats(const Transaction* tx) {
   ++ss->stats.tx_width_freq_arr[tx->GetUniqueShardCnt() - 1];
 }
 
-std::ostream& operator<<(std::ostream& os, Transaction::time_point tp) {
+std::string FormatTp(Transaction::time_point tp) {
   using namespace chrono;
   if (tp == Transaction::time_point::max())
-    return os << "inf";
+    return "inf";
   size_t ms = duration_cast<milliseconds>(tp - Transaction::time_point::clock::now()).count();
-  return os << ms << "ms";
+  return absl::StrCat(ms, "ms");
 }
 
 uint16_t trans_id(const Transaction* ptr) {
@@ -1377,7 +1377,7 @@ OpStatus Transaction::WaitOnWatch(const time_point& tp, WaitKeys wkeys, KeyReady
 
   auto* stats = ServerState::tl_connection_stats();
   ++stats->num_blocked_clients;
-  DVLOG(1) << "WaitOnWatch wait for " << tp << " " << DebugId();
+  DVLOG(1) << "WaitOnWatch wait for " << FormatTp(tp) << " " << DebugId();
 
   // Wait for the blocking barrier to be closed.
   // Note: It might return immediately if another thread already notified us.


### PR DESCRIPTION
## Summary

- Fix ADL issues where `operator<<` in wrong namespace wasn't found by absl log templates
- Replace `VLOG_EVERY_N`

## Test plan
- [x] `ninja dragonfly` builds cleanly in debug mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)