### PR TITLE
fix: preserve M and EF_CONSTRUCTION in HNSW index restore command

### DIFF
--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -181,27 +181,33 @@ string DocIndexInfo::BuildRestoreCommand() const {
                     SearchFieldTypeToString(finfo.type));
 
     // Store specific params
-    Overloaded info{
-        [](monostate) {},
-        [out = &out](const search::SchemaField::VectorParams& params) {
-          auto sim = params.sim == search::VectorSimilarity::L2   ? "L2"
-                     : params.sim == search::VectorSimilarity::IP ? "IP"
-                                                                  : "COSINE";
-          absl::StrAppend(out, " ", params.use_hnsw ? "HNSW" : "FLAT", " 6 ", "DIM ", params.dim,
-                          " DISTANCE_METRIC ", sim, " INITIAL_CAP ", params.capacity);
-        },
-        [out = &out](const search::SchemaField::TagParams& params) {
-          absl::StrAppend(out, " ", "SEPARATOR", " ", string{params.separator});
-          if (params.case_sensitive)
-            absl::StrAppend(out, " ", "CASESENSITIVE");
-        },
-        [out = &out](const search::SchemaField::TextParams& params) {
-          if (params.with_suffixtrie)
-            absl::StrAppend(out, " ", "WITH_SUFFIXTRIE");
-        },
-        [out = &out](const search::SchemaField::NumericParams& params) {
-          absl::StrAppend(out, " ", "BLOCKSIZE", " ", std::to_string(params.block_size));
-        }};
+    Overloaded info{[](monostate) {},
+                    [out = &out](const search::SchemaField::VectorParams& params) {
+                      auto sim = params.sim == search::VectorSimilarity::L2   ? "L2"
+                                 : params.sim == search::VectorSimilarity::IP ? "IP"
+                                                                              : "COSINE";
+                      if (params.use_hnsw) {
+                        absl::StrAppend(out, " HNSW 10 DIM ", params.dim, " DISTANCE_METRIC ", sim,
+                                        " INITIAL_CAP ", params.capacity, " M ", params.hnsw_m,
+                                        " EF_CONSTRUCTION ", params.hnsw_ef_construction);
+                      } else {
+                        absl::StrAppend(out, " FLAT 6 DIM ", params.dim, " DISTANCE_METRIC ", sim,
+                                        " INITIAL_CAP ", params.capacity);
+                      }
+                    },
+                    [out = &out](const search::SchemaField::TagParams& params) {
+                      absl::StrAppend(out, " ", "SEPARATOR", " ", string{params.separator});
+                      if (params.case_sensitive)
+                        absl::StrAppend(out, " ", "CASESENSITIVE");
+                    },
+                    [out = &out](const search::SchemaField::TextParams& params) {
+                      if (params.with_suffixtrie)
+                        absl::StrAppend(out, " ", "WITH_SUFFIXTRIE");
+                    },
+                    [out = &out](const search::SchemaField::NumericParams& params) {
+                      absl::StrAppend(out, " ", "BLOCKSIZE", " ",
+                                      std::to_string(params.block_size));
+                    }};
     visit(info, finfo.special_params);
 
     // Store shared field flags

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -17,6 +17,7 @@
 #include "facade/error.h"
 #include "facade/facade_test.h"
 #include "facade/resp_parser.h"
+#include "server/search/doc_index.h"
 #include "server/test_utils.h"
 
 using namespace testing;
@@ -4920,6 +4921,51 @@ TEST_F(SearchFamilyTest, FtAggregateFilterSemanticRouting) {
   EXPECT_THAT(resp, IsUnordArrayWithSize(IsMap("route_name", "cooking", "avg_dist", "0.2"),
                                          IsMap("route_name", "technology", "avg_dist", "0.6"),
                                          IsMap("route_name", "sports", "avg_dist", "0.6")));
+}
+
+// Verify that BuildRestoreCommand round-trips all HNSW parameters.
+// Regression test: M and EF_CONSTRUCTION were previously omitted, causing
+// replication to silently reconstruct the index with wrong defaults.
+TEST(BuildRestoreCommandTest, HnswVectorPreservesAllParams) {
+  using dfly::DocIndex;
+  using dfly::DocIndexInfo;
+  using dfly::search::IndicesOptions;
+  using dfly::search::SchemaField;
+  using dfly::search::VectorSimilarity;
+
+  SchemaField field;
+  field.type = SchemaField::VECTOR;
+  field.flags = 0;
+  field.short_name = "embedding";
+
+  SchemaField::VectorParams vparams;
+  vparams.use_hnsw = true;
+  vparams.dim = 4;
+  vparams.sim = VectorSimilarity::COSINE;
+  vparams.capacity = 500;
+  vparams.hnsw_m = 32;
+  vparams.hnsw_ef_construction = 400;
+  field.special_params = vparams;
+
+  DocIndex base;
+  base.type = DocIndex::HASH;
+  base.prefixes = {"doc:"};
+  base.options = IndicesOptions(absl::flat_hash_set<std::string>{});
+  base.schema.fields["embedding"] = std::move(field);
+
+  DocIndexInfo info;
+  info.base_index = std::move(base);
+
+  std::string cmd = info.BuildRestoreCommand();
+
+  // "HNSW 10" — the arg count must be 10 (5 key-value pairs), otherwise the
+  // parser stops early and silently drops M / EF_CONSTRUCTION on restore.
+  EXPECT_THAT(cmd, HasSubstr("HNSW 10"));
+  EXPECT_THAT(cmd, HasSubstr("DIM 4"));
+  EXPECT_THAT(cmd, HasSubstr("DISTANCE_METRIC COSINE"));
+  EXPECT_THAT(cmd, HasSubstr("INITIAL_CAP 500"));
+  EXPECT_THAT(cmd, HasSubstr("M 32"));
+  EXPECT_THAT(cmd, HasSubstr("EF_CONSTRUCTION 400"));
 }
 
 }  // namespace dfly


### PR DESCRIPTION
`BuildRestoreCommand` serialized HNSW VECTOR fields with a hardcoded argument count of 6, covering only DIM, DISTANCE_METRIC, and INITIAL_CAP. M and EF_CONSTRUCTION were silently dropped.

On replication or RDB restore, the HNSW index was reconstructed with default values (M=16, EF_CONSTRUCTION=200) regardless of what the user had configured.

Fix: emit all 5 HNSW parameters (arg count 10) and separate the HNSW and FLAT branches since FLAT legitimately takes only 3 parameters.

Related to #7013