### PR TITLE
feat: add tls_handshakes_total labeled metric to /metrics

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1599,6 +1599,13 @@ void PrintPrometheusMetrics(uint64_t uptime, const Metrics& m, DflyCmd* dfly_cmd
                     &resp->body());
   AppendMetricValue("connected_clients", conn_stats.num_conns_other, {"listener"}, {"other"},
                     &resp->body());
+  AppendMetricHeader("tls_handshakes_total", "Total TLS handshakes by status", MetricType::COUNTER,
+                     &resp->body());
+  AppendMetricValue("tls_handshakes_total", conn_stats.handshakes_started, {"status"}, {"started"},
+                    &resp->body());
+  AppendMetricValue("tls_handshakes_total", conn_stats.handshakes_completed, {"status"},
+                    {"completed"}, &resp->body());
+
   AppendMetricWithoutLabels("blocked_clients", "", conn_stats.num_blocked_clients,
                             MetricType::GAUGE, &resp->body());
   AppendMetricWithoutLabels("pipeline_queue_length", "", conn_stats.pipeline_queue_entries,


### PR DESCRIPTION
Add a Prometheus counter metric `tls_handshakes_total` with `status` label (`started`/`completed`) to the `/metrics` endpoint.

This exposes the existing `total_handshakes_started` and `total_handshakes_completed` INFO stats as a proper labeled Prometheus metric, making it easy to monitor TLS handshake rates and success ratios in Grafana/Prometheus.

**Output example:**
```
# HELP dragonfly_tls_handshakes_total Total TLS handshakes by status
# TYPE dragonfly_tls_handshakes_total counter
dragonfly_tls_handshakes_total{status="started"} 42
dragonfly_tls_handshakes_total{status="completed"} 40
```

**Changes:**
- `src/server/server_family.cc`: Added labeled metric in `PrintPrometheusMetrics()`