### PR TITLE
fix: remove race condition in proxy during close

### DIFF
--- a/tests/dragonfly/proxy.py
+++ b/tests/dragonfly/proxy.py
@@ -87,6 +87,10 @@ class Proxy:
             cb()
         self.stop_connections = []
 
+        # Yield so that accepted-but-not-yet-started handler tasks begin
+        # executing and register themselves in _handler_tasks.
+        await asyncio.sleep(0)
+
         # Cancel all handler tasks, including ones that haven't registered
         # their cleanup callbacks yet (race between accept and close).
         # Loop until no tasks remain so late-starting handlers are caught.


### PR DESCRIPTION
fix: #6894
 
 How the Proxy works                                                                                                                                                      
                                                                                                                                                                           
  The Proxy sits between node[0] and node[1]. Every TCP connection from node[0] goes through the proxy:     

  node[0]  →  Proxy (port 30151)  →  node[1] (port 30150)                                                                                                                                              
                                                                                                                                                                           
  When a connection arrives, the proxy spawns a handle() task that:                                                                                                        
  1. Opens a forwarding connection to node[1]                                                                                                                              
  2. Registers a cleanup callback in self.stop_connections                                                                                                                 
  3. Forwards data in both directions until done            
                                                                                                                                                                           
  The race condition
                                                                                                                                                                           
  When the test calls proxy.close(), it does this:                                                                                                                         
  
  1. Stop accepting NEW connections          (server.close())                                                                                                              
  2. Close all KNOWN connections             (iterate self.stop_connections)                                                                                               
  3. Clear the list                          (self.stop_connections = [])                                                                                                  
  4. Wait for the server to fully shut down  (await task)                                                                                                                  
                                                                                                                                                                           
  The problem is between steps 1 and 2. The proxy accepted the FLOW connections (TCP handshake done), but the handle() tasks for those connections haven't started yet —  they're queued in the event loop. So their cleanup callbacks are NOT in self.stop_connections.                                                                           
                                                                                                                                                                           
  Timeline:                                                 
  ─────────────────────────────────────────────────────
    node[0] connects 3 FLOW sockets to proxy                                                                                                                               
    proxy ACCEPTS them (TCP level) but handle() is QUEUED, not running yet test sees SYNC status → calls proxy.close()                                                                                                                            
    proxy.close() iterates stop_connections → FLOW cleanups NOT THERE                                                                                                      
    proxy.close() clears stop_connections = []                                                                                                                             
    proxy.close() reaches "await task" → event loop runs    
    NOW the queued handle() tasks start → open forwarding to node[1]                                                                                                       
    handle() adds cleanup to stop_connections → but close() already passed that step                                                                                       
    handle() runs forever (forwarding data) → close() BLOCKS forever                                                                                                       
  ─────────────────────────────────────────────────────                                                                                                                    
                                                                                                                                                                           
  Consequences                                                                                                                                                             
                                                            
  1. proxy.close() blocks forever at step 4 — waiting for handle() tasks that will never finish                                                                            
  2. proxy.start() on the next line is never reached — the proxy never reopens
  3. Outgoing migration retries connecting to port 30151 → "Connection refused" (no one is listening)                                                                      
  4. Incoming flows are stuck reading from the leaked forwarding connections — they never get EOF                                                                          
  5. Everything hangs until pytest kills the processes (~5 minutes)                                                                                                        
                                                                                                                                                                           
  The fix                                                                                                                                                                  
                                                                                                                                                                           
  Track all handler tasks (not just ones that registered cleanup callbacks), and cancel them in close():                                                                   
  
  - self._handler_tasks — a set that every handle() task adds itself to on entry and removes on exit                                                                       
  - In close(), after the existing cleanup loop, explicitly cancel every task in _handler_tasks and wait for them to finish
                                                                                                                                                                           
  This guarantees that even the "late" handle() tasks (accepted but not yet started) get cancelled when close() runs, so close() returns promptly and proxy.start() can proceed.                      