### PR TITLE
feat(tiering): Experimental list node tiering

### DIFF
--- a/src/core/qlist.cc
+++ b/src/core/qlist.cc
@@ -426,6 +426,14 @@ void QList::Node::SetExternal(size_t offset, uint32_t size) {
   ext_size = size;
 }
 
+void QList::Node::Upload(QList* ql, std::string_view val) {
+  entry = static_cast<unsigned char*>(zmalloc(val.size()));
+  memcpy(entry, val.data(), val.size());
+  ql->AdjustMallocSize(val.size());
+  ql->AdjustOffloadNodeCount(-1);
+  offloaded = 0;
+}
+
 void QList::SetPackedThreshold(unsigned threshold) {
   packed_threshold = threshold;
 }
@@ -480,10 +488,9 @@ QList::QList(QList&& other) noexcept
       tiering_enabled_(other.tiering_enabled_),
       compress_(other.compress_),
       bookmark_count_(other.bookmark_count_),
-      num_offloaded_nodes_(other.num_offloaded_nodes_) {
+      tiering_params_(std::move(other.tiering_params_)) {
   other.head_ = nullptr;
   other.len_ = other.count_ = 0;
-  other.num_offloaded_nodes_ = 0;
 }
 
 QList::~QList() {
@@ -503,9 +510,9 @@ QList& QList::operator=(QList&& other) noexcept {
     tiering_enabled_ = other.tiering_enabled_;
     compress_ = other.compress_;
     bookmark_count_ = other.bookmark_count_;
-    num_offloaded_nodes_ = other.num_offloaded_nodes_;
     other.head_ = nullptr;
-    other.len_ = other.count_ = other.num_offloaded_nodes_ = 0;
+    other.len_ = other.count_ = 0;
+    tiering_params_ = std::move(other.tiering_params_);
   }
   return *this;
 }
@@ -519,7 +526,7 @@ void QList::Clear() noexcept {
     // If entry is offloaded we should skip freeing its memory.
     bool free_entry = current->offloaded == 0;
     if (tiering_enabled_ && (current->offloaded || current->io_pending)) {
-      CleanupOffloadedNode(current);
+      tiering_params_->cleanup(this, current);
     } else {
       if (current->encoding != QUICKLIST_NODE_ENCODING_RAW) {
         quicklistLZF* lzf = (quicklistLZF*)current->entry;
@@ -540,7 +547,6 @@ void QList::Clear() noexcept {
   head_ = nullptr;
   count_ = 0;
   malloc_size_ = 0;
-  num_offloaded_nodes_ = 0;
 }
 
 void QList::Push(string_view value, Where where) {
@@ -915,6 +921,9 @@ void QList::Replace(Iterator it, std::string_view elem) {
 
 void QList::CoolOff(Node* node, uint32_t node_id) {
   if (tiering_enabled_) {
+    uint32_t threshold = tiering_params_->node_depth_threshold;
+    uint32_t num_offloaded_nodes = tiering_params_->num_offloaded_nodes;
+
     // Dry run for offloading decision.
     // a. Node id is withing the offloadable depth - offload it if not already offloaded.
     // b. Node id is outside the offloadable depth - but we have too many nodes that are not
@@ -925,12 +934,11 @@ void QList::CoolOff(Node* node, uint32_t node_id) {
     //    we won't need to traverse them again for "trivial" access patterns unless they
     //    get accessed again. Another reason for missing offloaded nodes is that node_id can be
     //    off due to merges (can be improved in future).
-    if (node_id >= tiering_node_depth_threshold_ &&
-        node_id + tiering_node_depth_threshold_ < len_) {
+    if (node_id >= threshold && node_id + threshold < len_) {
       if (!node->offloaded && !node->io_pending) {
-        OffloadNode(node);
+        tiering_params_->offload(this, node);
       }
-    } else if (num_offloaded_nodes_ * 2 + tiering_node_depth_threshold_ * 2 < len_) {
+    } else if (num_offloaded_nodes * 2 + threshold * 2 < len_) {
       // We check `num_offloaded_nodes_ * 2` above to avoid frequent traversals.
       // So only when the gap between offloaded and non-offloaded nodes is large enough,
       // we do a traversal to offload more nodes.
@@ -940,16 +948,15 @@ void QList::CoolOff(Node* node, uint32_t node_id) {
 
       // Traverse from both ends towards the middle as we expect more offloads towards the ends
       // due to usual access patterns of adding items via lpush/rpush.
-      while (traverse_node_id <= len_ / 2 &&
-             (num_offloaded_nodes_ + 2 * tiering_node_depth_threshold_) < len_) {
-        if (traverse_node_id >= tiering_node_depth_threshold_) {
+      while (traverse_node_id <= len_ / 2 && (num_offloaded_nodes + 2 * threshold) < len_) {
+        if (traverse_node_id >= threshold) {
           if (fw->offloaded == 0 && fw->io_pending == 0) {
-            OffloadNode(fw);
+            tiering_params_->offload(this, fw);
           }
 
           // Avoid offloading the same node twice when fw and rev meet in the middle.
           if (rev != fw && rev->offloaded == 0 && rev->io_pending == 0) {
-            OffloadNode(rev);
+            tiering_params_->offload(this, rev);
           }
         }
         fw = fw->next;
@@ -1047,12 +1054,12 @@ void QList::Materialize(Node* node) {
 
   // Cancel stash in progress before loading.
   if (node->io_pending) {
-    CleanupOffloadedNode(node);
+    tiering_params_->cleanup(this, node);
   }
 
   // Load the offloaded node data back into memory.
   if (node->offloaded) {
-    ReadOffloadedNode(node);
+    tiering_params_->load(this, node);
   }
 
   DCHECK(!node->offloaded);
@@ -1195,7 +1202,7 @@ void QList::DelNode(Node* node) {
   }
 
   if (tiering_enabled_ && (node->offloaded || node->io_pending)) {
-    CleanupOffloadedNode(node);
+    tiering_params_->cleanup(this, node);
   }
 
   /* If we deleted a node within our compress depth, we
@@ -1243,18 +1250,22 @@ bool QList::DelPackedIndex(Node* node, uint8_t* p) {
   return false;
 }
 
-void QList::OffloadNode(Node* node) const {
-  DCHECK(tiering_enabled_ && node->offloaded == 0 && node->io_pending == 0);
-  stats.offload_requests++;
-  node->io_pending = 1;
-}
-
-void QList::ReadOffloadedNode(QList::Node* node) const {
-  stats.onload_requests++;
-}
-
-void QList::CleanupOffloadedNode(QList::Node* node) const {
-  node->io_pending = 0;
+void QList::SetDbIndex(DbIndex db_id) {
+  if (db_id_ == db_id) {
+    return;
+  }
+  // With tiering enabled, we materialize all offloaded nodes before reassigning the db_id.
+  // This is suboptimal: pending nodes could be canceled, and fully offloaded nodes only need
+  // a statistics update — they don't depend on db_id, only on their storage offset.
+  if (tiering_enabled_ && tiering_params_->num_offloaded_nodes > 0) {
+    Node* node = head_;
+    while (node) {
+      Node* next = node->next;
+      Materialize(node);
+      node = (next == head_) ? nullptr : next;
+    }
+  }
+  db_id_ = db_id;
 }
 
 void QList::InitIteratorEntry(Iterator* it) const {

--- a/src/core/qlist.h
+++ b/src/core/qlist.h
@@ -12,6 +12,7 @@
 #include <string>
 
 #include "core/collection_entry.h"
+#include "server/common_types.h"
 
 #define QL_COMP_BITS 16
 #define QL_BM_BITS 4
@@ -85,6 +86,7 @@ class QList {
     size_t GetLZF(void** data) const;
 
     void SetExternal(size_t offset, uint32_t sz);
+    void Upload(QList* ql, std::string_view val);
     std::pair<size_t, size_t> GetExternalSlice() const {
       return std::make_pair(size_t(ext_offset), size_t(ext_size));
     }
@@ -122,9 +124,22 @@ class QList {
   }
 
   // Add to the number of offloaded nodes by one.
-  void IncrementNumOffloadedNodes(int delta) {
-    num_offloaded_nodes_ += delta;
+  void AdjustOffloadNodeCount(int delta) {
+    if (tiering_enabled_) {
+      tiering_params_->num_offloaded_nodes += delta;
+    }
   }
+
+  DbIndex GetDbIndex() const {
+    return db_id_;
+  }
+  struct TieringParams {
+    uint32_t num_offloaded_nodes = 0;
+    uint32_t node_depth_threshold = 0;
+    void (*offload)(QList* ql, Node* node) = nullptr;
+    void (*load)(QList* ql, Node* node) = nullptr;
+    void (*cleanup)(QList* ql, Node* node) = nullptr;
+  };
 
   /**
    * fill: The number of entries allowed per internal list node can be specified
@@ -260,11 +275,14 @@ class QList {
     zstd_threshold_ = threshold;
   }
 
-  // Enable tiered storage and set node depth threshold
-  void EnableTiering(uint32_t threshold) {
+  // Enable tiered storage.
+  void EnableTiering(const TieringParams& params) {
     tiering_enabled_ = 1;
-    tiering_node_depth_threshold_ = threshold;
+    tiering_params_ = std::make_unique<TieringParams>(params);
   }
+
+  // Updates the db index associated with this list.
+  void SetDbIndex(DbIndex db_id);
 
   struct Stats {
     uint64_t compression_attempts = 0;
@@ -340,13 +358,6 @@ class QList {
   void DelNode(Node* node);
   bool DelPackedIndex(Node* node, uint8_t* p);
 
-  // Offload node to tiered storage
-  void OffloadNode(Node* node) const;
-  // Read offloaded node from tiered storage
-  void ReadOffloadedNode(Node* node) const;
-  // Delete offloaded node or cancel offloading of node
-  void CleanupOffloadedNode(Node* node) const;
-
   // Initializes iterator's zi_ to point to the element at offset_.
   // Decompresses the node if needed. Assumes current_ is not null.
   void InitIteratorEntry(Iterator* it) const;
@@ -364,9 +375,9 @@ class QList {
   unsigned compress_ : QL_COMP_BITS; /* depth of end nodes not to compress;0=off */
   unsigned bookmark_count_ : QL_BM_BITS;
   unsigned reserved2_ : 12;
-  uint32_t num_offloaded_nodes_ = 0;
-  uint32_t zstd_threshold_ = 0;                // 0 = disabled
-  uint32_t tiering_node_depth_threshold_ = 0;  // 0 = disabled
+  uint16_t db_id_ = kInvalidDbId;
+  uint32_t zstd_threshold_ = 0;  // 0 = disabled
+  std::unique_ptr<TieringParams> tiering_params_;
 };
 
 }  // namespace dfly

--- a/src/core/qlist_test.cc
+++ b/src/core/qlist_test.cc
@@ -411,20 +411,6 @@ TEST_F(QListTest, DefragmentListpackCompressed) {
   ASSERT_EQ(i, total_items);
 }
 
-TEST_F(QListTest, Tiering) {
-  QList::stats.offload_requests = 0;
-  QList tiered_ql;
-
-  // Enable tiering and set node_depth_threshold = 1
-  tiered_ql.EnableTiering(1);
-
-  for (int i = 0; i < 8000; i++) {
-    tiered_ql.Push(absl::StrCat("value", i), QList::TAIL);
-  }
-
-  EXPECT_EQ(QList::stats.offload_requests, 9);
-}
-
 // MergeNodes must not follow the head_->prev circular link when looking for
 // adjacent nodes to merge.  Splitting a full head node and calling MergeNodes
 // on the right half used to traverse new_head->prev (= tail), merging two

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1566,6 +1566,12 @@ void DbSlice::RemoveOffloadedEntriesFromTieredStorage(absl::Span<const DbIndex> 
         } else if (it->second.HasStashPending()) {
           tiered_storage->CancelStash(std::make_pair(index, it->first.GetSlice(&scratch)),
                                       &it->second);
+        } else if (it->second.ObjType() == OBJ_LIST && it->second.Encoding() == kEncodingQL2) {
+          // Nodes can be offloaded to tiered storage, but the main object doesn't have external or
+          // pending flag set. We need to clear the list explicitly.
+          if (auto* ql = static_cast<QList*>(it->second.RObjPtr()); ql) {
+            ql->Clear();
+          }
         }
       });
     } while (cursor);

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -974,6 +974,14 @@ OpStatus OpMove(const OpArgs& op_args, string_view key, DbIndex target_db) {
   auto& add_res = *op_result;
   add_res.it->first.SetSticky(sticky);
 
+  // When tiering is enabled, update tiered-storage metadata for partial moved values.
+  if (EngineShard::tlocal()->tiered_storage()) {
+    if (add_res.it->second.ObjType() == OBJ_LIST && add_res.it->second.Encoding() == kEncodingQL2) {
+      auto* ql = static_cast<QList*>(add_res.it->second.RObjPtr());
+      ql->SetDbIndex(target_db);
+    }
+  }
+
   auto bc = op_args.db_cntx.ns->GetBlockingController(op_args.shard->shard_id());
   if (add_res.it->second.ObjType() == OBJ_LIST && bc) {
     bc->Awaken(target_db, key);

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -26,6 +26,7 @@ extern "C" {
 #include "server/error.h"
 #include "server/family_utils.h"
 #include "server/namespaces.h"
+#include "server/tiered_storage.h"
 #include "server/transaction.h"
 
 namespace rng = std::ranges;
@@ -83,6 +84,37 @@ using time_point = Transaction::time_point;
 
 namespace {
 
+void OffloadListNode(QList* ql, QList::Node* node) {
+  TieredStorage* ts = EngineShard::tlocal()->tiered_storage();
+  DCHECK(ts);
+  QList::stats.offload_requests++;
+  StashListNode(ql->GetDbIndex(), ql, node, ts, nullptr);
+}
+
+void LoadListNode(QList* ql, QList::Node* node) {
+  TieredStorage* ts = EngineShard::tlocal()->tiered_storage();
+  DCHECK(ts);
+  QList::stats.onload_requests++;
+  auto res = ReadTieredListNode(ql->GetDbIndex(), ql, node, node->GetExternalSlice(), ts).Get();
+  if (!res) {
+    LOG(WARNING) << "Failed to load list node from tiered storage: " << res.error().message();
+  }
+}
+
+void CleanupListNode(QList* ql, QList::Node* node) {
+  TieredStorage* ts = EngineShard::tlocal()->tiered_storage();
+  DCHECK(ts);
+  if (!ts->IsClosed()) {
+    if (node->io_pending) {
+      ts->CancelStash(tiering::ListNodeId{ql->GetDbIndex(), ql, node}, node);
+    } else {
+      // We don't pass QList pointer so we need to decrease num_offloaded_nodes_ now.
+      ql->AdjustOffloadNodeCount(-1);
+      ts->Delete(ql->GetDbIndex(), node);
+    }
+  }
+}
+
 class ListWrapper {
   using LP = detail::ListPack;
 
@@ -106,9 +138,18 @@ class ListWrapper {
     QList* ql = CompactObj::AllocateMR<QList>(GetFlag(FLAGS_list_max_listpack_size),
                                               GetFlag(FLAGS_list_compress_depth));
 
+    // Set db index for new QList
+    ql->SetDbIndex(db_id_);
+
     const uint32_t tiering_node_depth_threshold = absl::GetFlag(FLAGS_list_tiering_threshold);
     if (tiering_node_depth_threshold > 0 && EngineShard::tlocal()->tiered_storage()) {
-      ql->EnableTiering(tiering_node_depth_threshold);
+      QList::TieringParams params{
+          .node_depth_threshold = tiering_node_depth_threshold,
+          .offload = OffloadListNode,
+          .load = LoadListNode,
+          .cleanup = CleanupListNode,
+      };
+      ql->EnableTiering(params);
     }
 
     if (uint32_t zstd_thresh = GetFlag(FLAGS_list_experimental_zstd_dict_threshold);

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -160,6 +160,9 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
     stats_.total_cancels++;
     QList::Node* node = reinterpret_cast<QList::Node*>(std::get<2>(id));
     node->io_pending = 0;
+    // If stashing failed we need to decrease offloaded nodes count.
+    QList* ql = reinterpret_cast<QList*>(std::get<1>(id));
+    ql->AdjustOffloadNodeCount(-1);
   }
 
   void CancelStash(tiering::KeyRef id, size_t size) {
@@ -173,6 +176,8 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
   }
 
   void CancelStash(tiering::ListNodeId id) {
+    QList* ql = reinterpret_cast<QList*>(std::get<1>(id));
+    ql->AdjustOffloadNodeCount(-1);
     CancelPending(id);
   }
 
@@ -276,7 +281,15 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
     stats_.total_stashes++;
 
     QList::Node* node = reinterpret_cast<QList::Node*>(std::get<2>(id));
+    QList* ql = reinterpret_cast<QList*>(std::get<1>(id));
+
     node->io_pending = 0;
+
+    // Adjust parent QList node malloc size / number of offloaded nodes.
+    ql->AdjustMallocSize(-segment.length);
+    node->SetExternal(segment.offset, segment.length);
+
+    stats->AddTypeMemoryUsage(OBJ_LIST, -segment.length);
   }
 
   // If any backpressure (throttling) is active, notify that the operation finished
@@ -333,15 +346,6 @@ bool TieredStorage::ShardOpManager::NotifyFetched(const OwnedEntryId& id,
                                                   tiering::Decoder* decoder) {
   ++stats_.total_fetches;
 
-  if (const auto* key = std::get_if<tiering::ListNodeId>(&id); key) {
-    DbIndex db_id = std::get<0>(*key);
-    QList::Node* node = reinterpret_cast<QList::Node*>(std::get<2>(*key));
-    ++stats_.total_uploads;
-    decoder->Upload(node);
-    RecordDeleted(node, segment.length, GetDbTableStats(db_id));
-    return true;
-  }
-
   if (const auto* i = std::get_if<uintptr_t>(&id); i) {
     if (*i == kFragmentedBin) {  // Generally we read whole bins only for defrag
       auto* bdecoder = static_cast<tiering::BareDecoder*>(decoder);
@@ -353,28 +357,41 @@ bool TieredStorage::ShardOpManager::NotifyFetched(const OwnedEntryId& id,
   tiering::Decoder::UploadMetrics metrics = decoder->GetMetrics();
 
   // 1. When modified is true we MUST upload the value back to memory.
-  // 2. On the other hand, if read is caused by snapshotting we do not want to fetch it.
+  // 2. On the other hand, if read is caused by snapshotting we:
+  //    a. Don't fetch it if it is PrimeValue
+  //    b. We allow fetching for ListNodes because they need to be materialized.
   //    Currently, our heuristic is not very smart, because we stop uploading any reads during
   //    the snapshotting.
   // TODO: to revisit this when we rewrite it with more efficient snapshotting algorithm.
   bool should_upload = metrics.modified;
-  should_upload |= (ts_->UploadBudget() > int64_t(metrics.estimated_mem_usage)) &&
-                   !SliceSnapshot::IsSnaphotInProgress();
+  should_upload |=
+      (ts_->UploadBudget() > int64_t(metrics.estimated_mem_usage)) &&
+      (!SliceSnapshot::IsSnaphotInProgress() || std::holds_alternative<tiering::ListNodeId>(id));
 
   if (!should_upload)
     return false;
 
-  const auto& key = get<tiering::DbKeyId>(id);
-  auto* pv = Find(key.first, key.second);
-  if (pv && pv->IsExternal() && segment == pv->GetExternalSlice()) {
-    if (metrics.modified || pv->WasTouched()) {
-      ++stats_.total_uploads;
-      decoder->Upload(pv);
-      RecordDeleted(*pv, segment.length, GetDbTableStats(key.first));
-      return true;
+  if (const auto* key = std::get_if<tiering::ListNodeId>(&id); key) {
+    DbIndex db_id = std::get<0>(*key);
+    QList::Node* node = reinterpret_cast<QList::Node*>(std::get<2>(*key));
+    ++stats_.total_uploads;
+    decoder->Upload(node);
+    RecordDeleted(node, segment.length, GetDbTableStats(db_id));
+    return true;
+  }
+
+  if (const auto* key = std::get_if<tiering::DbKeyId>(&id); key) {
+    auto* pv = Find(key->first, key->second);
+    if (pv && pv->IsExternal() && segment == pv->GetExternalSlice()) {
+      if (metrics.modified || pv->WasTouched()) {
+        ++stats_.total_uploads;
+        decoder->Upload(pv);
+        RecordDeleted(*pv, segment.length, GetDbTableStats(key->first));
+        return true;
+      }
+      pv->SetTouched(true);
+      return false;
     }
-    pv->SetTouched(true);
-    return false;
   }
 
   LOG(DFATAL) << "Internal error, should not reach this";
@@ -769,6 +786,18 @@ void StashPrimeValue(DbIndex dbid, std::string_view key, PrimeValue* pv, TieredS
   }
 }
 
+bool StashListNode(DbIndex dbid, QList* ql, QList::Node* node, TieredStorage* ts,
+                   BackPressureFuture* backpressure) {
+  if (auto blobs = ts->ShouldStash(*node); blobs) {
+    // Increment before stashing; decremented on failure in `ClearStashPending`
+    ql->AdjustOffloadNodeCount(1);
+    node->io_pending = 1;
+    ts->StashPartialValue(tiering::ListNodeId{dbid, ql, node}, *blobs, backpressure);
+    return true;
+  }
+  return false;
+}
+
 void TieredStorage::StashPartialValue(tiering::PendingId id, const StashDescriptor& blobs,
                                       BackPressureFuture* backpressure) {
   size_t est_size = blobs.EstimatedSerializedSize();
@@ -792,6 +821,18 @@ void ReadTiered(DbIndex dbid, std::string_view key, const PrimeValue& value,
   };
   ts->Read(KeyRef{dbid, key}, value.GetExternalSlice(), tiering::StringDecoder{value},
            std::move(cb));
+}
+
+TieredStorage::TResult<bool> ReadTieredListNode(DbIndex dbid, QList* ql, QList::Node* node,
+                                                const tiering::DiskSegment& segment,
+                                                TieredStorage* ts) {
+  TieredStorage::TResult<bool> fut;
+  auto read_cb = [fut](const io::Result<tiering::ListNodeDecoder*>& res) mutable {
+    fut.Resolve(res.transform([](tiering::ListNodeDecoder* d) { return true; }));
+  };
+  ts->Read(tiering::ListNodeId{dbid, ql, node}, segment, tiering::ListNodeDecoder{ql},
+           std::move(read_cb));
+  return fut;
 }
 
 template <typename T>

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -199,6 +199,10 @@ inline TieredStorage::TResult<std::string> ReadTieredString(DbIndex dbid, std::s
       dbid, key, value, [](std::string_view val) { return std::string(val); }, ts);
 }
 
+TieredStorage::TResult<bool> ReadTieredListNode(DbIndex dbid, QList* ql, QList::Node* node,
+                                                const tiering::DiskSegment& segment,
+                                                TieredStorage* ts);
+
 // Reads offloaded value, and applies modifications on it and return generic result from callback.
 // Unlike with immutable Reads - the modified value will be uploaded back to memory.
 // This is handled by OpManager when modf completes.
@@ -210,6 +214,11 @@ TieredStorage::TResult<T> ModifyTiered(DbIndex dbid, std::string_view key, const
 // nullptr, assign/set the backpressure future to `*backpressure`.
 void StashPrimeValue(DbIndex dbid, std::string_view key, PrimeValue* pv, TieredStorage* ts,
                      BackPressureFuture* backpressure);
+
+// Stash list node if it meets criteria.
+// Returns true if stash was initiated, false otherwise.
+bool StashListNode(DbIndex dbid, QList* ql, QList::Node* node, TieredStorage* ts,
+                   BackPressureFuture* backpressure);
 
 #else
 
@@ -254,7 +263,7 @@ class TieredStorage : public TieredStorageBase {
              BackPressureFuture* backpressure) {
   }
 
-  void Delete(DbIndex dbid, PrimeValue* value) {
+  void Delete(DbIndex dbid, tiering::FragmentRef fragment_ref) {
   }
 
   bool HasModificationPending(tiering::DiskSegment segment) const {
@@ -323,6 +332,12 @@ inline TieredStorage::TResult<std::string> ReadTieredString(DbIndex dbid, std::s
   return {};
 }
 
+inline TieredStorage::TResult<bool> ReadTieredListNode(DbIndex dbid, QList* ql, QList::Node* node,
+                                                       const tiering::DiskSegment& segment,
+                                                       TieredStorage* ts) {
+  return {};
+}
+
 template <typename T>
 TieredStorage::TResult<T> ModifyTiered(DbIndex dbid, std::string_view key, const PrimeValue& value,
                                        std::function<T(std::string*)> modf, TieredStorage* ts) {
@@ -331,6 +346,11 @@ TieredStorage::TResult<T> ModifyTiered(DbIndex dbid, std::string_view key, const
 
 inline void StashPrimeValue(DbIndex dbid, std::string_view key, PrimeValue* pv, TieredStorage* ts,
                             BackPressureFuture* backpressure) {
+}
+
+inline bool StashListNode(DbIndex dbid, QList* ql, QList::Node* node, TieredStorage* ts,
+                          BackPressureFuture* backpressure) {
+  return false;
 }
 
 #endif  // WITH_TIERING

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -29,6 +29,9 @@ ABSL_DECLARE_FLAG(unsigned, tiered_storage_write_depth);
 ABSL_DECLARE_FLAG(bool, tiered_experimental_cooling);
 ABSL_DECLARE_FLAG(uint64_t, registered_buffer_size);
 ABSL_DECLARE_FLAG(bool, tiered_experimental_hash_support);
+ABSL_DECLARE_FLAG(bool, tiered_experimental_list_support);
+ABSL_DECLARE_FLAG(unsigned, list_tiering_threshold);
+ABSL_DECLARE_FLAG(int32_t, list_max_listpack_size);
 
 namespace dfly {
 
@@ -608,6 +611,371 @@ TEST_P(LatentCoolingTSTest, SimpleHash) {
     auto v = string{31, 'x'} + 'f';
     EXPECT_EQ(resp, v);
   }
+}
+
+class ListNodeTieringTest : public TieredStorageTest {
+  void SetUp() override {
+    fs.emplace();
+    SetFlag(&FLAGS_tiered_offload_threshold, 1.0f);
+    SetFlag(&FLAGS_tiered_experimental_cooling, false);
+    // One entry per QList node
+    SetFlag(&FLAGS_list_max_listpack_size, 1);
+    // Offload nodes at depth >= 2 from both ends
+    SetFlag(&FLAGS_list_tiering_threshold, 2u);
+    SetFlag(&FLAGS_tiered_experimental_list_support, true);
+    TieredStorageTest::SetUp();
+  }
+  optional<absl::FlagSaver> fs;
+};
+
+// Push 6 large values; verify that at least one QList node is offloaded to disk.
+TEST_F(ListNodeTieringTest, StashOccurs) {
+  // 2048-byte values ensure QList creation on the very first RPUSH.
+  // 6 pushes produce 6 nodes; CoolOff on the 5th push offloads node 2.
+  const int kItems = 6;
+  for (int i = 0; i < kItems; i++) {
+    Run({"RPUSH", "mylist", BuildString(2048, static_cast<char>('a' + i))});
+  }
+
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
+
+  EXPECT_GE(GetMetrics().tiered_stats.total_stashes, 1u);
+}
+
+TEST_F(ListNodeTieringTest, LLenCorrectAfterStash) {
+  const int kItems = 6;
+  for (int i = 0; i < kItems; i++) {
+    Run({"RPUSH", "mylist", BuildString(2048, static_cast<char>('a' + i))});
+  }
+
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
+
+  EXPECT_THAT(Run({"LLEN", "mylist"}), IntArg(kItems));
+
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
+}
+
+// DEL a list that has fully-offloaded nodes.
+TEST_F(ListNodeTieringTest, DeleteAfterStash) {
+  const int kItems = 6;
+  for (int i = 0; i < kItems; i++) {
+    Run({"RPUSH", "mylist", BuildString(2048, static_cast<char>('a' + i))});
+  }
+
+  // Wait until stash is complete (io_pending cleared, offloaded=1) before DEL
+  // to avoid the io_pending use-after-free path.
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
+
+  EXPECT_THAT(Run({"DEL", "mylist"}), IntArg(1));
+  EXPECT_THAT(Run({"EXISTS", "mylist"}), IntArg(0));
+}
+
+// LRANGE all elements forces the QList iterator to call AccessForReads on every
+// node, including those that were offloaded to disk. The onload_cb must
+// synchronously restore node->entry before returning so LRANGE returns the
+// correct values.
+TEST_F(ListNodeTieringTest, LoadOccurs) {
+  const int kItems = 6;
+  vector<string> expected;
+  for (int i = 0; i < kItems; i++) {
+    string val = BuildString(2048, static_cast<char>('a' + i));
+    expected.push_back(val);
+    Run({"RPUSH", "mylist", val});
+  }
+
+  // Wait for at least one interior node to be offloaded.
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
+
+  // LRANGE 0 -1 must traverse all nodes, triggering onload_cb for offloaded
+  // interior nodes, and return the correct values.
+  auto resp = Run({"LRANGE", "mylist", "0", "-1"});
+  const auto& elements = resp.GetVec();
+  ASSERT_EQ(static_cast<int>(elements.size()), kItems);
+  for (int i = 0; i < kItems; i++) {
+    EXPECT_EQ(elements[i].GetString(), expected[i]) << "index " << i;
+  }
+
+  // LLEN must still be correct after the load.
+  EXPECT_THAT(Run({"LLEN", "mylist"}), IntArg(kItems));
+}
+
+// Verify that every element read back from a list with offloaded matches the original.
+TEST_F(ListNodeTieringTest, StashedDataMatchesOnLoad) {
+  const int kItems = 8;
+
+  // Build values with a unique fill character per position so any swap or
+  // corruption is immediately visible.
+  vector<string> expected;
+  for (int i = 0; i < kItems; i++) {
+    expected.push_back(BuildString(2048, static_cast<char>('A' + i)));
+    Run({"RPUSH", "mylist", expected.back()});
+  }
+
+  // Wait until at least one interior node has been flushed to disk.
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
+
+  const auto fetches_before = GetMetrics().tiered_stats.total_fetches;
+
+  // Read every element individually via LINDEX — this forces node-level access
+  // and triggers onload_cb for each offloaded node.
+  for (int i = 0; i < kItems; i++) {
+    auto resp = Run({"LINDEX", "mylist", absl::StrCat(i)});
+    EXPECT_EQ(resp, expected[i]) << "LINDEX mismatch at position " << i;
+  }
+
+  // At least one fetch must have gone to disk .
+  EXPECT_GT(GetMetrics().tiered_stats.total_fetches, fetches_before);
+
+  // Also verify the bulk read path returns identical data.
+  auto resp = Run({"LRANGE", "mylist", "0", "-1"});
+  const auto& elements = resp.GetVec();
+  ASSERT_EQ(static_cast<int>(elements.size()), kItems);
+  for (int i = 0; i < kItems; i++) {
+    EXPECT_EQ(elements[i].GetString(), expected[i]) << "LRANGE mismatch at position " << i;
+  }
+
+  EXPECT_THAT(Run({"LLEN", "mylist"}), IntArg(kItems));
+}
+
+// DEL a list whose interior nodes have io_pending=1.
+TEST_F(ListNodeTieringTest, DeleteWhileNodePending) {
+  const int kItems = 6;
+  for (int i = 0; i < kItems; i++) {
+    Run({"RPUSH", "mylist", BuildString(2048, static_cast<char>('a' + i))});
+  }
+
+  // DEL immediately — do NOT wait for stashes to complete.
+  EXPECT_THAT(Run({"DEL", "mylist"}), IntArg(1));
+  EXPECT_THAT(Run({"EXISTS", "mylist"}), IntArg(0));
+
+  // Drain any still-in-flight stash I/Os so allocation counters are final.
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_stash_cnt == 0; });
+
+  auto metrics = GetMetrics();
+  EXPECT_EQ(metrics.db_stats[0].tiered_entries, 0u);
+
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.allocated_bytes == 0; });
+}
+
+// RENAME a list whose interior nodes are fully offloaded.
+TEST_F(ListNodeTieringTest, RenameWithStashedNodes) {
+  const int kItems = 6;
+  vector<string> expected;
+  for (int i = 0; i < kItems; i++) {
+    expected.push_back(BuildString(2048, static_cast<char>('a' + i)));
+    Run({"RPUSH", "src", expected.back()});
+  }
+
+  // Wait for interior nodes to be fully offloaded to disk.
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
+
+  // RENAME fetches data from disk (for offloaded nodes), creates the destination
+  // key, and deletes the source — all node delete_cb calls must not crash.
+  EXPECT_EQ(Run({"RENAME", "src", "dst"}), "OK");
+  EXPECT_THAT(Run({"EXISTS", "src"}), IntArg(0));
+  EXPECT_THAT(Run({"LLEN", "dst"}), IntArg(kItems));
+
+  // Verify every element is intact after the rename.
+  for (int i = 0; i < kItems; i++) {
+    EXPECT_EQ(Run({"LINDEX", "dst", absl::StrCat(i)}), expected[i]) << "index " << i;
+  }
+
+  auto metrics = GetMetrics();
+  EXPECT_EQ(metrics.db_stats[0].tiered_entries, 0u);  // after reads nodes come back to memory
+}
+
+// RENAME a list while its nodes are still io_pending.
+TEST_F(ListNodeTieringTest, RenameWhileNodesPending) {
+  const int kItems = 6;
+  vector<string> expected;
+  for (int i = 0; i < kItems; i++) {
+    expected.push_back(BuildString(2048, static_cast<char>('a' + i)));
+    Run({"RPUSH", "src", expected.back()});
+  }
+
+  // RENAME immediately without waiting for stash I/Os to complete.
+  EXPECT_EQ(Run({"RENAME", "src", "dst"}), "OK");
+  EXPECT_THAT(Run({"EXISTS", "src"}), IntArg(0));
+  EXPECT_THAT(Run({"LLEN", "dst"}), IntArg(kItems));
+
+  // Verify data integrity in the renamed key.
+  for (int i = 0; i < kItems; i++) {
+    EXPECT_EQ(Run({"LINDEX", "dst", absl::StrCat(i)}), expected[i]) << "index " << i;
+  }
+
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_stash_cnt == 0; });
+}
+
+// PEXPIRE a list while its nodes are fully offloaded.
+TEST_F(ListNodeTieringTest, ExpireListWithStashedNodes) {
+  const int kItems = 6;
+  for (int i = 0; i < kItems; i++) {
+    Run({"RPUSH", "mylist", BuildString(2048, static_cast<char>('a' + i))});
+  }
+
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
+
+  // Set a 1 ms TTL and advance time past it.
+  Run({"PEXPIRE", "mylist", "1"});
+  AdvanceTime(10);
+
+  // Trigger expiry collection.
+  Run({"SET", "trigger", "x"});
+
+  EXPECT_THAT(Run({"EXISTS", "mylist"}), IntArg(0));
+
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_stash_cnt == 0; });
+
+  auto metrics = GetMetrics();
+  EXPECT_EQ(metrics.db_stats[0].tiered_entries, 0u);
+
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.allocated_bytes == 0; });
+}
+
+// PEXPIRE a list while its nodes are still io_pending
+TEST_F(ListNodeTieringTest, ExpireListWhileNodesPending) {
+  const int kItems = 6;
+  for (int i = 0; i < kItems; i++) {
+    Run({"RPUSH", "mylist", BuildString(2048, static_cast<char>('a' + i))});
+  }
+
+  // Set TTL and advance time before awaiting any stash completion.
+  Run({"PEXPIRE", "mylist", "1"});
+  AdvanceTime(10);
+  Run({"SET", "trigger", "x"});
+
+  EXPECT_THAT(Run({"EXISTS", "mylist"}), IntArg(0));
+
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_stash_cnt == 0; });
+
+  auto metrics = GetMetrics();
+  EXPECT_EQ(metrics.db_stats[0].tiered_entries, 0u);
+
+  // Wait so that all allocated bytes for stashed nodes are freed
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.allocated_bytes == 0; });
+}
+
+// FLUSHALL while list nodes are io_pending or fully offloaded.
+TEST_F(ListNodeTieringTest, FlushAllWithTieredListNodes) {
+  const int kLists = 4;
+  const int kItems = 6;
+
+  for (int l = 0; l < kLists; l++) {
+    string key = absl::StrCat("list", l);
+    for (int i = 0; i < kItems; i++) {
+      Run({"RPUSH", key, BuildString(2048, static_cast<char>('a' + i))});
+    }
+  }
+
+  // Wait for at least some nodes to be stashed across any list.
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
+
+  // FLUSHALL while more stashes may be in flight (mixed pending/stashed state).
+  Run({"FLUSHALL"});
+
+  for (int l = 0; l < kLists; l++) {
+    EXPECT_THAT(Run({"EXISTS", absl::StrCat("list", l)}), IntArg(0));
+  }
+
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_stash_cnt == 0; });
+
+  auto metrics = GetMetrics();
+  EXPECT_EQ(metrics.db_stats[0].tiered_entries, 0u);
+
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.allocated_bytes == 0; });
+}
+
+// LPOP exhausts a list whose interior nodes were offloaded to disk..
+TEST_F(ListNodeTieringTest, LPopStashedNodes) {
+  const int kItems = 8;
+  vector<string> expected;
+  for (int i = 0; i < kItems; i++) {
+    expected.push_back(BuildString(2048, static_cast<char>('A' + i)));
+    Run({"RPUSH", "mylist", expected.back()});
+  }
+
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
+
+  // Pop every element and verify order and content.
+  for (int i = 0; i < kItems; i++) {
+    EXPECT_EQ(Run({"LPOP", "mylist"}), expected[i]) << "pop index " << i;
+  }
+
+  // List must be gone after all elements are popped.
+  EXPECT_THAT(Run({"EXISTS", "mylist"}), IntArg(0));
+}
+
+// MOVE a list whose interior nodes are fully offloaded to a different DB.
+TEST_F(ListNodeTieringTest, MoveWithStashedNodes) {
+  const int kItems = 6;
+  vector<string> expected;
+  for (int i = 0; i < kItems; i++) {
+    expected.push_back(BuildString(2048, static_cast<char>('a' + i)));
+    Run({"RPUSH", "src", expected.back()});
+  }
+
+  // Wait for interior nodes to be fully offloaded to disk.
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
+
+  // MOVE to db 1 — SetDbIndex materializes all offloaded nodes.
+  EXPECT_THAT(Run({"MOVE", "src", "1"}), IntArg(1));
+  EXPECT_THAT(Run({"EXISTS", "src"}), IntArg(0));
+
+  // Verify the key exists in db 1 with correct length and contents.
+  Run({"SELECT", "1"});
+  EXPECT_THAT(Run({"LLEN", "src"}), IntArg(kItems));
+  for (int i = 0; i < kItems; i++) {
+    EXPECT_EQ(Run({"LINDEX", "src", absl::StrCat(i)}), expected[i]) << "index " << i;
+  }
+
+  // No nodes should remain offloaded after the move.
+  // auto metrics = GetMetrics();
+  // EXPECT_EQ(metrics.db_stats[1].tiered_entries, 0u);
+}
+
+// MOVE a list whose interior nodes are still io_pending (stash in flight).
+TEST_F(ListNodeTieringTest, MoveWhileNodesPending) {
+  const int kItems = 6;
+  vector<string> expected;
+  for (int i = 0; i < kItems; i++) {
+    expected.push_back(BuildString(2048, static_cast<char>('a' + i)));
+    Run({"RPUSH", "src", expected.back()});
+  }
+
+  // MOVE immediately without waiting for stash I/Os to complete.
+  EXPECT_THAT(Run({"MOVE", "src", "1"}), IntArg(1));
+  EXPECT_THAT(Run({"EXISTS", "src"}), IntArg(0));
+
+  // Drain any in-flight stash I/Os.
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.pending_stash_cnt == 0; });
+
+  // Verify the key exists in db 1 with correct length and contents.
+  Run({"SELECT", "1"});
+  EXPECT_THAT(Run({"LLEN", "src"}), IntArg(kItems));
+  for (int i = 0; i < kItems; i++) {
+    EXPECT_EQ(Run({"LINDEX", "src", absl::StrCat(i)}), expected[i]) << "index " << i;
+  }
+
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.allocated_bytes == 0; });
+}
+
+// RPOP exhausts a list from the tail side
+TEST_F(ListNodeTieringTest, RPopStashedNodes) {
+  const int kItems = 8;
+  vector<string> expected;
+  for (int i = 0; i < kItems; i++) {
+    expected.push_back(BuildString(2048, static_cast<char>('A' + i)));
+    Run({"RPUSH", "mylist", expected.back()});
+  }
+
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
+
+  // Pop from tail → values arrive in reverse order.
+  for (int i = kItems - 1; i >= 0; i--) {
+    EXPECT_EQ(Run({"RPOP", "mylist"}), expected[i]) << "pop index " << i;
+  }
+
+  EXPECT_THAT(Run({"EXISTS", "mylist"}), IntArg(0));
 }
 
 }  // namespace dfly

--- a/src/server/tiering/decoders.cc
+++ b/src/server/tiering/decoders.cc
@@ -101,16 +101,16 @@ std::unique_ptr<Decoder> ListNodeDecoder::Clone() const {
 }
 
 void ListNodeDecoder::Initialize(std::string_view slice) {
-  this->slice = slice;
+  slice_ = slice;
 }
 
 void ListNodeDecoder::Upload(void* obj) {
-  ABSL_UNREACHABLE();
+  QList::Node* node_obj = reinterpret_cast<QList::Node*>(obj);
+  node_obj->Upload(ql_, slice_);
 }
 
 Decoder::UploadMetrics ListNodeDecoder::GetMetrics() const {
-  ABSL_UNREACHABLE();
-  return UploadMetrics{};
+  return UploadMetrics{.modified = false, .estimated_mem_usage = slice_.size()};
 }
 
 }  // namespace dfly::tiering

--- a/src/server/tiering/decoders.h
+++ b/src/server/tiering/decoders.h
@@ -97,7 +97,7 @@ struct ListNodeDecoder : public Decoder {
 
  private:
   QList* ql_;
-  std::string_view slice;
+  std::string_view slice_;
 };
 
 }  // namespace dfly::tiering

--- a/tests/dragonfly/tiering_test.py
+++ b/tests/dragonfly/tiering_test.py
@@ -247,3 +247,74 @@ async def test_tiered_replication_with_hashes(
 
     await check_all_replicas_finished([replica_client], async_client, timeout=500)
     monitor.assert_no_match()
+
+
+@pytest.mark.large
+@pytest.mark.exclude_epoll
+@pytest.mark.opt_only
+async def test_tiered_replication_with_lists(df_factory: DflyInstanceFactory):
+    master = df_factory.create(
+        proactor_threads=2,
+        maxmemory="512MB",
+        tiered_prefix="/tmp/tiered/backing_master_list",
+        tiered_offload_threshold="1.0",
+        tiered_storage_write_depth=1500,
+        tiered_experimental_cooling="false",
+        list_max_listpack_size=1,
+        list_tiering_threshold=2,
+        tiered_experimental_list_support="true",
+    )
+    master.start()
+    master_client = master.client()
+
+    # 100 lists x 8 elements x 3500 bytes. Values must be >= kMinOccupancySize (2 KB)
+    # so nodes qualify for whole-page tiered offloading.
+    await master_client.execute_command("DEBUG POPULATE 100 lst 3500 RAND TYPE LIST ELEMENTS 8")
+
+    # Wait for at least one list node to be stashed to disk before starting replication.
+    async for info, breaker in info_tick_timer(master_client, section="TIERED", timeout=60):
+        with breaker:
+            assert info["tiered_total_stashes"] > 0
+
+    replica = df_factory.create(
+        proactor_threads=1,
+        dbfilename="",
+    )
+    replica.start()
+    replica_client = replica.client()
+
+    monitor = LogMonitor(replica, "Internal error when loading RDB")
+    monitor.start()
+
+    await replica_client.replicaof("localhost", master.port)
+    logging.info("Waiting for replica to sync")
+
+    try:
+        async with async_timeout.timeout(300):
+            wait_task = asyncio.create_task(wait_for_replicas_state(replica_client))
+            done, _ = await asyncio.wait(
+                [wait_task, monitor.task], return_when=asyncio.FIRST_COMPLETED
+            )
+            if monitor.task in done:
+                wait_task.cancel()
+                await asyncio.gather(wait_task, return_exceptions=True)
+                monitor.assert_no_match()
+            if wait_task in done:
+                wait_task.result()  # propagate exceptions
+    except asyncio.TimeoutError:
+        master_info = await master_client.info("ALL")
+        replica_info = await replica_client.info("ALL")
+        pytest.fail(
+            f"Replica did not sync in time. \nmaster: {master_info} \n\nreplica: {replica_info}"
+        )
+    finally:
+        await monitor.stop()
+
+    await check_all_replicas_finished([replica_client], master_client, timeout=300)
+    monitor.assert_no_match()
+
+    # Verify data consistency between master and replica
+    hashes = await asyncio.gather(
+        *(SeederV2.capture(c, types=["LIST"]) for c in [master_client, replica_client])
+    )
+    assert len(set(hashes)) == 1, "Inconsistency detected between master and replica lists."


### PR DESCRIPTION
Decoupline QList from TieredStorage implementation details via
TieringParams structure callbacks.

- Introduce TieringParams struct holding function callbacks and offload state
- Add Node::Upload() to restore an externally-loaded node back into memory
- Add QList::SetDbIndex() to handle db reassignment, materializing offloaded
  nodes when tiering is active
- Add StashListNode / ReadTieredListNode in TieredStorage
- Add tiered_storage_test.cc coverage for list node offload/reload lifecycle
- Add tiering_test.py integration tests for list tiering behavior

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
