### PR TITLE
fix(cms): reject NaN in CMS.INITBYPROB to prevent RENAME crash

### DIFF
--- a/src/server/cms_family.cc
+++ b/src/server/cms_family.cc
@@ -144,10 +144,10 @@ void CmdInitByProb(CmdArgList args, CommandContext* cmd_cntx) {
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   RETURN_ON_PARSE_ERROR(parser, rb);
 
-  if (error <= 0 || error >= 1) {
+  if (!(error > 0 && error < 1)) {
     return rb->SendError("CMS: error must be between 0 and 1 exclusive");
   }
-  if (probability <= 0 || probability >= 1) {
+  if (!(probability > 0 && probability < 1)) {
     return rb->SendError("CMS: probability must be between 0 and 1 exclusive");
   }
 

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -518,6 +518,21 @@ TEST_F(GenericFamilyTest, RenameSameShard) {
   EXPECT_EQ(Run({"rename", "x", "y"}), "OK");
 }
 
+TEST_F(GenericFamilyTest, RenameCmsNanCrash) {
+  num_threads_ = 2;
+  ResetService();
+
+  // With 2 shards (XXH64 seed 120577240643): myset -> shard 0, dst -> shard 1.
+  // NaN must be rejected: !(NaN > 0 && NaN < 1) is true for both checks.
+  // Before the fix, NaN bypassed <= 0 / >= 1 guards (NaN comparisons are always
+  // false), creating a CMS with width=0 and depth=0.  The subsequent cross-shard
+  // RENAME triggered Renamer::FinalizeRename -> DeserializeDest -> ReadCMS,
+  // which rejected width==0 -> INVALID_VALUE -> DFATAL (SIGABRT in debug builds).
+  EXPECT_THAT(Run({"cms.initbyprob", "myset", "NaN", "NaN"}), ErrArg("between 0 and 1"));
+  EXPECT_THAT(Run({"exists", "myset"}), IntArg(0));
+  EXPECT_THAT(Run({"rename", "myset", "dst"}), ErrArg("no such key"));
+}
+
 TEST_F(GenericFamilyTest, Stick) {
   // check stick returns zero on non-existent keys
   ASSERT_THAT(Run({"stick", "a", "b"}), IntArg(0));


### PR DESCRIPTION
`CMS.INITBYPROB` validated error and probability with `<= 0 || >= 1`, which always evaluates to false for NaN, allowing NaN arguments through. This created a CMS object with width=0 and depth=0 (undefined behaviour when casting NaN to uint32_t, yields 0 on x86-64).

When such a key was subsequently renamed across shards, `DeserializeDest` called `ReadCMS`, which correctly rejects width==0 with `errc::rdb_file_corrupted`.  The resulting `INVALID_VALUE` status triggered `LOG_IF(DFATAL)` in `FinalizeRename`, aborting the process in debug builds (SIGABRT, sig:06).

Fix: replace `x <= 0 || x >= 1` with `!(x > 0 && x < 1)`.  The negated conjunction rejects NaN because NaN comparisons always return false.

Fixes #7017