### PR TITLE
fix: prevent master connection closing during await_synced_all

### DIFF
--- a/tests/dragonfly/redis_replication_test.py
+++ b/tests/dragonfly/redis_replication_test.py
@@ -27,8 +27,6 @@ async def await_synced(c_master: aioredis.Redis, c_replica: aioredis.Redis, dbco
             await asyncio.sleep(1)
 
             timeout -= 1
-        await c_master.close()
-        await c_replica.close()
         assert timeout > 0, "Timeout while waiting for replica to sync"
 
 
@@ -134,7 +132,6 @@ replication_specs = [
 ]
 
 
-@pytest.mark.skip("Fails on CI")
 @pytest.mark.parametrize("t_replicas, seeder_config", replication_specs)
 async def test_redis_replication_all(
     df_factory: DflyInstanceFactory,


### PR DESCRIPTION
The bug was in await_synced(): it calls c_master.close() inside the loop body.  await_synced_all() passes the same c_master to await_synced() for each of the replicas.  After the first replica check succeeds, c_master is closed. For other replicas, c_master.set(key, "dummy") operates on a closed connection — the key either isn't set on the master, or the reconnection race means it doesn't propagate through the replication stream in time, causing the 30-second timeout.