### PR TITLE
CI: Add script to handle pip install

### DIFF
--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -57,14 +57,7 @@ runs:
 
     - name: Install Python test requirements
       shell: bash
-      run: |
-        cd ${GITHUB_WORKSPACE}/tests
-        # https://peps.python.org/pep-0668/#keep-the-marker-file-in-container-images
-        if compgen -G '/usr/lib/python3.*/EXTERNALLY-MANAGED' > /dev/null; then
-          pip3 install --break-system-packages -r dragonfly/requirements.txt
-        else
-          pip3 install -r dragonfly/requirements.txt
-        fi
+      run: ${GITHUB_WORKSPACE}/.github/scripts/install-pytest-requirements.sh
 
     - name: Run S3 snapshot tests with MinIO
       if: inputs.s3-bucket != ''

--- a/.github/actions/repeat/action.yml
+++ b/.github/actions/repeat/action.yml
@@ -48,7 +48,7 @@ runs:
         ls -l ${GITHUB_WORKSPACE}/
         cd ${GITHUB_WORKSPACE}/tests
         echo "Current commit is ${{github.sha}}"
-        pip3 install -r dragonfly/requirements.txt
+        ${GITHUB_WORKSPACE}/.github/scripts/install-pytest-requirements.sh
         # used by PyTests
         export DRAGONFLY_PATH="${GITHUB_WORKSPACE}/${{inputs.build-folder-name}}/${{inputs.dfly-executable}}"
         export UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 # to crash on errors

--- a/.github/scripts/install-pytest-requirements.sh
+++ b/.github/scripts/install-pytest-requirements.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# https://peps.python.org/pep-0668/#keep-the-marker-file-in-container-images
+
+set -eu
+
+REQUIREMENTS_FILE="${GITHUB_WORKSPACE}/tests/dragonfly/requirements.txt"
+
+if compgen -G '/usr/lib/python3.*/EXTERNALLY-MANAGED' > /dev/null; then
+  pip3 install --break-system-packages -r "$REQUIREMENTS_FILE"
+else
+  pip3 install -r "$REQUIREMENTS_FILE"
+fi

--- a/.github/workflows/cov.yml
+++ b/.github/workflows/cov.yml
@@ -63,14 +63,7 @@ jobs:
 
       - name: Install Python test requirements
         shell: bash
-        run: |
-          cd ${GITHUB_WORKSPACE}/tests
-          # https://peps.python.org/pep-0668/#keep-the-marker-file-in-container-images
-          if compgen -G '/usr/lib/python3.*/EXTERNALLY-MANAGED' > /dev/null; then
-            pip3 install --break-system-packages -r dragonfly/requirements.txt
-          else
-            pip3 install -r dragonfly/requirements.txt
-          fi
+        run: ${GITHUB_WORKSPACE}/.github/scripts/install-pytest-requirements.sh
 
       - name: Configure CMake
         run: |


### PR DESCRIPTION
Add script to handle package install for pip across ubuntu 24 and older versions, and use it where required.
