### PR TITLE
fix: prevent OOM crash in FT.CREATE with huge PREFIX/STOPWORDS count

### DIFF
--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -227,9 +227,15 @@ ParseResult<bool> ParseOnOption(CmdArgParser* parser, DocIndex* index) {
 // PREFIX count prefix [prefix ...]
 ParseResult<bool> ParsePrefix(CmdArgParser* parser, DocIndex* index) {
   size_t count = parser->Next<size_t>();
-  index->prefixes.reserve(count);
-  for (size_t i = 0; i < count; i++) {
+  size_t i = 0;
+  for (; i < count && parser->HasNext(); i++) {
     index->prefixes.push_back(parser->Next<std::string>());
+  }
+  // If fewer prefixes were consumed than promised, trigger an out-of-bounds error.
+  // This prevents unbounded loops for huge user-supplied counts while
+  // preserving the existing syntax-error behavior for mismatched counts.
+  if (i < count) {
+    parser->Next();  // triggers OUT_OF_BOUNDS
   }
   return true;
 }
@@ -237,8 +243,13 @@ ParseResult<bool> ParsePrefix(CmdArgParser* parser, DocIndex* index) {
 // STOPWORDS count [words...]
 ParseResult<bool> ParseStopwords(CmdArgParser* parser, DocIndex* index) {
   index->options.stopwords.clear();
-  for (size_t num = parser->Next<size_t>(); num > 0; num--) {
+  size_t count = parser->Next<size_t>();
+  size_t i = 0;
+  for (; i < count && parser->HasNext(); i++) {
     index->options.stopwords.emplace(parser->Next());
+  }
+  if (i < count) {
+    parser->Next();  // triggers OUT_OF_BOUNDS
   }
   return true;
 }

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -467,6 +467,27 @@ TEST_F(SearchFamilyTest, Errors) {
               ErrArg("Tag separator must be a single character. Got ``"));
 }
 
+// Regression test: FT.CREATE with a huge PREFIX/STOPWORDS count must not OOM-crash the server.
+// Previously, ParsePrefix called index->prefixes.reserve(count) with a user-supplied count,
+// causing a 3.2 TB allocation for count=99999999999.
+// ParseStopwords had the same unbounded-loop issue.
+TEST_F(SearchFamilyTest, HugeCountNoOOM) {
+  // PREFIX: 99999999999 * sizeof(std::string) = ~3.2 TB — must return syntax error, not crash
+  EXPECT_THAT(Run({"ft.create", "idx1", "ON", "HASH", "PREFIX", "99999999999", "doc:", "SCHEMA",
+                   "content", "TEXT"}),
+              ErrArg(kSyntaxErr));
+  EXPECT_THAT(Run({"ft.info", "idx1"}), ErrArg(""));  // index must not have been created
+
+  // STOPWORDS: same unbounded-loop protection
+  EXPECT_THAT(Run({"ft.create", "idx2", "ON", "HASH", "STOPWORDS", "99999999999", "the", "a", "an",
+                   "SCHEMA", "content", "TEXT"}),
+              ErrArg(kSyntaxErr));
+  EXPECT_THAT(Run({"ft.info", "idx2"}), ErrArg(""));
+
+  // Verify the server is still alive
+  EXPECT_EQ(Run({"ping"}), "PONG");
+}
+
 TEST_F(SearchFamilyTest, NoPrefix) {
   Run({"hset", "d:1", "a", "one", "k", "v"});
   Run({"hset", "d:2", "a", "two", "k", "v"});


### PR DESCRIPTION
Fix unbounded memory allocation in FT.CREATE when a user-supplied count in PREFIX or STOPWORDS is larger than available arguments.

Fixes #7045