### PR TITLE
fix: increase timeout for test_network_disconnect_during_migration

### DIFF
--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -1480,7 +1480,7 @@ async def test_migration_with_key_ttl(df_factory):
     assert await nodes[1].client.execute_command("stick k_sticky") == 0
 
 
-@dfly_args({"proactor_threads": 4, "cluster_mode": "yes", "migration_finalization_timeout_ms": 5})
+@dfly_args({"proactor_threads": 4, "cluster_mode": "yes", "migration_finalization_timeout_ms": 50})
 async def test_network_disconnect_during_migration(df_factory):
     instances = [
         df_factory.create(


### PR DESCRIPTION
fixes: #6894


5ms timeout for debug build, cancel data receiving and creates an infinite loop during finalization
https://github.com/dragonflydb/dragonfly/actions/runs/23862487353/job/69572605102
https://github.com/dragonflydb/dragonfly/actions/runs/23862468700/job/69572541125