### PR TITLE
fix: dev container build failure on ARM runners

### DIFF
--- a/.github/workflows/docker-dev-release.yml
+++ b/.github/workflows/docker-dev-release.yml
@@ -97,7 +97,7 @@ jobs:
           image_tags=(${{ steps.metadata.outputs.tags }})
 
           # install redis-tools
-          sudo apt-get install redis-tools -y
+          sudo apt-get update && sudo apt-get install redis-tools -y
 
           for image_tag in "${image_tags[@]}"; do
             echo "Testing image: ${image_tag}"


### PR DESCRIPTION
Add `apt-get update` before installing `redis-tools` in the Test Image step.
The ARM runner's package cache is stale, causing 404 errors when fetching `redis-tools` - this has been failing nightly builds for the past 5 days, preventing `:ubuntu` and `:alpine` manifest tags from being updated.