### PR TITLE
fix: support VECTOR_RANGE query without YIELD_DISTANCE_AS clause

### DIFF
--- a/src/core/search/parser.y
+++ b/src/core/search/parser.y
@@ -146,6 +146,20 @@ vector_range_query:
                                 std::move(alias));
       }
     }
+  | FIELD COLON LBRACKET VECTOR_RANGE vec_range_radius TERM RBRACKET
+    {
+      double radius = $5;
+      auto field = std::move($1);
+      auto vec_result = BytesToFtVectorSafe($6);
+      if (!vec_result) {
+        auto empty_vec = std::make_unique<float[]>(0);
+        $$ = AstVectorRangeNode(std::move(field), radius,
+                                {std::move(empty_vec), size_t{0}}, std::string{});
+      } else {
+        $$ = AstVectorRangeNode(std::move(field), radius, std::move(*vec_result),
+                                std::string{});
+      }
+    }
 
 vec_range_radius:
   DOUBLE  { $$ = toDouble($1); }

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -710,6 +710,30 @@ TEST_F(VectorRangeTest, FlatRange1D) {
   }
 }
 
+TEST_F(VectorRangeTest, FlatRangeWithoutYieldDistanceAs) {
+  auto schema = MakeSimpleSchema({{"pos", SchemaField::VECTOR}});
+  schema.fields["pos"].special_params = SchemaField::VectorParams{false, 1};
+  FieldIndices indices{schema, kEmptyOptions, PMR_NS::get_default_resource(), nullptr};
+
+  for (size_t i = 0; i < 10; i++) {
+    MockedDocument doc{Map{{"pos", ToBytes({float(i + 1)})}}};
+    indices.Add(i, doc);
+  }
+
+  SearchAlgorithm algo{};
+  QueryParams params;
+
+  // VECTOR_RANGE without =>{$YIELD_DISTANCE_AS: ...} — must parse and return correct results
+  params["vec"] = ToBytes({5.0f});
+  algo.Init("@pos:[VECTOR_RANGE 1.5 $vec]", &params);
+  auto result = algo.Search(&indices);
+  EXPECT_THAT(result.ids, testing::UnorderedElementsAre(3, 4, 5));
+
+  // score_alias should be empty when not specified
+  ASSERT_NE(nullptr, algo.GetVectorRangeNode());
+  EXPECT_TRUE(algo.GetVectorRangeNode()->score_alias.empty());
+}
+
 TEST_F(VectorRangeTest, FlatRangeDistancesStoredInScores) {
   auto schema = MakeSimpleSchema({{"pos", SchemaField::VECTOR}});
   schema.fields["pos"].special_params = SchemaField::VectorParams{false, 1};

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -4373,6 +4373,26 @@ TEST_F(SearchFamilyTest, HnswVectorRange) {
   EXPECT_THAT(vals_desc, ElementsAre(60, 50, 40));
 }
 
+TEST_F(SearchFamilyTest, HnswVectorRangeWithoutYieldDistanceAs) {
+  auto FloatToBytes = [](float f) -> string {
+    return string(reinterpret_cast<const char*>(&f), sizeof(float));
+  };
+
+  Run({"FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "pos", "VECTOR", "HNSW", "6", "TYPE", "FLOAT32",
+       "DIM", "1", "DISTANCE_METRIC", "L2"});
+
+  for (int i = 0; i < 10; i++) {
+    Run({"HSET", absl::StrFormat("k%d", i), "pos", FloatToBytes(static_cast<float>(i))});
+  }
+
+  string query_vec = FloatToBytes(5.0f);
+
+  // VECTOR_RANGE without =>{$YIELD_DISTANCE_AS: ...} — must work like Redis Stack
+  auto resp = Run({"FT.SEARCH", "idx", "@pos:[VECTOR_RANGE 1.5 $vec]", "PARAMS", "2", "vec",
+                   query_vec, "LIMIT", "0", "10"});
+  EXPECT_THAT(resp, AreDocIds("k4", "k5", "k6"));
+}
+
 TEST_F(SearchFamilyTest, VectorRangeAggregate) {
   auto FloatToBytes = [](float f) -> string {
     return string(reinterpret_cast<const char*>(&f), sizeof(float));


### PR DESCRIPTION
Redis Stack accepts VECTOR_RANGE queries both with and without the `=>{$YIELD_DISTANCE_AS: alias}` suffix. DragonflyDB only accepted the full form, returning "Query syntax error" for the short form.

This breaks LangChain/redisvl, which sends: `@embedding:[VECTOR_RANGE 1.5 $vec]`

Add an alternative parser rule that accepts `VECTOR_RANGE` without the yield clause, using an empty score_alias. The existing code already handles empty `score_alias` correctly (skips distance injection).