### PR TITLE
feat(server): Make parallel delayed entry processing safe

### DIFF
--- a/src/server/serializer_base.cc
+++ b/src/server/serializer_base.cc
@@ -35,8 +35,28 @@ void DelayedEntryHandler::ProcessDelayedEntries(bool force, BucketIdentity flush
   if (delayed_entries_.size() > kMaxDelayedEntries)
     force |= true;
 
-  auto serialize_entry = [&](auto it) {
-    auto& entry = it->second;
+  // Extract ahead because of possible iterator invalidation during suspension (Get/Serialize)
+  // if multiple fibers progress on delayed entries
+  std::vector<decltype(delayed_entries_)::node_type> targets;
+
+  // Flush all entries of bucket if provided
+  if (flush_bucket) {
+    auto [it, end] = delayed_entries_.equal_range(flush_bucket);
+    while (it != end)
+      targets.push_back(delayed_entries_.extract(it++));
+  }
+
+  // Serialize the delayed entries that are resolved, or all if force it true
+  for (auto it = delayed_entries_.begin(); it != delayed_entries_.end();) {
+    if (!force && !it->second->value.IsResolved())
+      it++;
+    else
+      targets.push_back(delayed_entries_.extract(it++));
+  }
+
+  // Serialize all targets
+  for (auto& target : targets) {
+    auto& entry = target.mapped();
     auto value = entry->value.Get();
 
     if (!value.has_value()) {
@@ -47,23 +67,6 @@ void DelayedEntryHandler::ProcessDelayedEntries(bool force, BucketIdentity flush
 
     PrimeValue pv{*value};
     SerializeFetchedEntry(*entry, pv);
-    delayed_entries_.erase(it++);
-  };
-
-  // Flush all entries of bucket
-  if (flush_bucket) {
-    auto range = delayed_entries_.equal_range(flush_bucket);
-    for (auto it = range.first; it != range.second;) {
-      serialize_entry(it++);
-    }
-  }
-
-  // Serialize the delayed entries that are resolved, or all if force it true.
-  for (auto it = delayed_entries_.begin(); it != delayed_entries_.end();) {
-    if (!force && !it->second->value.IsResolved())
-      it++;
-    else
-      serialize_entry(it++);
   }
 }
 


### PR DESCRIPTION
Make it possible to call ProcessDelayedEntries from multiple fibers. Currently this is impossible due to big_value_mu_ guarding all paths, but in the future we want to unlock this behaviour