### PR TITLE
test: add reproducers for pub/sub PUBLISH loss under concurrent load

### DIFF
--- a/tests/dragonfly/celery_test.py
+++ b/tests/dragonfly/celery_test.py
@@ -1,9 +1,11 @@
 import logging
+import time
 import threading
 from redis import asyncio as aioredis
 
 import pytest
-from celery import Celery
+from celery import Celery, group
+from celery.result import allow_join_result
 from celery.contrib.testing.worker import (
     setup_app_for_worker,
     TestWorkController,
@@ -102,3 +104,88 @@ def test_celery_inspect(celery_app, celery_worker):
     stats = inspector.stats()
     logging.info(f"Stats response: {stats}")
     assert worker_name in stats
+
+
+# Reproducer for #7056: PUBLISH lost under concurrent Celery group().get().
+
+
+def _noop_task(i):
+    time.sleep(0.02)
+    return i
+
+
+def _group_get_task(batch_size, get_timeout=5):
+    """Dispatch a group of subtasks and call .get() — the pattern that triggers the bug."""
+    from celery import current_app
+
+    with allow_join_result():
+        g = group(current_app.tasks["noop"].s(i) for i in range(batch_size))()
+        try:
+            g.get(timeout=get_timeout)
+            return 0
+        except Exception:
+            import redis
+
+            conn = redis.Redis.from_url(current_app.conf.result_backend)
+            keys = [f"celery-task-meta-{r.id}" for r in g.results]
+            stored = sum(1 for v in conn.mget(keys) if v is not None)
+            conn.close()
+            return stored  # tasks completed but PUBLISH was lost
+        finally:
+            g.revoke()
+            g.forget()
+
+
+@pytest.fixture
+def pubsub_celery_app(df_server):
+    broker = f"redis://localhost:{df_server.port}/0"
+    backend = f"redis://localhost:{df_server.port}/1"
+    app = Celery("pubsub_test", broker=broker, backend=backend)
+    app.conf.update(task_serializer="json", result_serializer="json", accept_content=["json"])
+    app.task(name="noop")(_noop_task)
+    app.task(name="group_get", bind=False)(_group_get_task)
+    yield app
+
+    if hasattr(app, "backend"):
+        app.backend.remove_pending_result = lambda *args, **kwargs: None
+    app.close()
+
+
+@pytest.fixture
+def pubsub_worker(pubsub_celery_app):
+    setup_app_for_worker(pubsub_celery_app, loglevel="WARNING", logfile=None)
+    w = TestWorkController(
+        app=pubsub_celery_app,
+        concurrency=32,
+        pool="prefork",
+        loglevel="WARNING",
+        without_heartbeat=True,
+        without_mingle=True,
+        without_gossip=True,
+    )
+    t = threading.Thread(target=w.start, daemon=True)
+    t.start()
+    w.ensure_started()
+    _set_task_join_will_block(False)
+    yield w
+
+    pubsub_celery_app.control.purge()
+    w.stop()
+    t.join(timeout=10)
+
+
+def test_pubsub_publish_not_lost(pubsub_celery_app, pubsub_worker):
+    """#7056: PUBLISH notifications must not be silently lost under Celery group().get()."""
+    dispatch = pubsub_celery_app.tasks["group_get"]
+    BATCH, CONCURRENT, ROUNDS, TIMEOUT = 50, 16, 5, 5
+
+    total_lost = 0
+    for rnd in range(1, ROUNDS + 1):
+        results = [dispatch.delay(BATCH, get_timeout=TIMEOUT) for _ in range(CONCURRENT)]
+        round_lost = 0
+        for ar in results:
+            try:
+                round_lost += ar.get(timeout=TIMEOUT + 10)
+            except Exception:
+                round_lost += BATCH
+        assert round_lost == 0, f"Round {rnd}/{ROUNDS}: {round_lost} PUBLISH messages lost"

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import multiprocessing
 import random
 import socket
 import ssl
@@ -1792,3 +1793,98 @@ async def test_pubsub_pipeline_starvation(df_server: DflyInstance):
         await flood_task
         writer.close()
         await writer.wait_closed()
+
+
+# Reproducer for #7056: PUBLISH lost under rapid SUBSCRIBE/UNSUBSCRIBE churn.
+
+
+def _pubsub_churn_sub(port, task_ids, result_queue, barrier):
+    """Subscribe upfront, on 'S' (started) do unsub/resub, collect 'D' (done)."""
+    import redis
+
+    conn = redis.Redis(host="localhost", port=port, db=1, decode_responses=True)
+    ps = conn.pubsub()
+    try:
+        channels = {f"ch-{tid}": tid for tid in task_ids}
+        got_done = set()
+
+        ps.subscribe(*channels.keys())
+        barrier.wait(timeout=30)
+
+        deadline = time.monotonic() + 5.0
+        while len(got_done) < len(task_ids) and time.monotonic() < deadline:
+            msg = ps.get_message(ignore_subscribe_messages=True, timeout=0.01)
+            if not msg or msg["type"] != "message" or msg["channel"] not in channels:
+                continue
+            if msg["data"] == "S":
+                # Unsub/resub churn — the pattern that triggers the race
+                ps.unsubscribe(msg["channel"])
+                ps.get_message(timeout=0.1)
+                ps.subscribe(msg["channel"])
+            elif msg["data"] == "D":
+                got_done.add(channels[msg["channel"]])
+
+        lost = sum(1 for tid in task_ids if tid not in got_done and conn.get(f"ch-{tid}") == "D")
+        result_queue.put(lost)
+    finally:
+        ps.close()
+        conn.close()
+
+
+def _pubsub_churn_pub(port, task_ids, barrier):
+    """MULTI { SET + PUBLISH 'S' }, brief pause, MULTI { SET + PUBLISH 'D' }."""
+    import redis
+
+    conn = redis.Redis(host="localhost", port=port, db=1, decode_responses=True)
+    try:
+        barrier.wait(timeout=30)
+        for tid in task_ids:
+            ch = f"ch-{tid}"
+            pipe = conn.pipeline(transaction=True)
+            pipe.set(ch, "S")
+            pipe.publish(ch, "S")
+            pipe.execute()
+
+            time.sleep(random.uniform(0.001, 0.010))
+
+            pipe = conn.pipeline(transaction=True)
+            pipe.set(ch, "D")
+            pipe.publish(ch, "D")
+            pipe.execute()
+    finally:
+        conn.close()
+
+
+async def test_pubsub_subscribe_churn_publish_lost(df_server: DflyInstance):
+    """#7056: PUBLISH lost under rapid SUBSCRIBE/UNSUBSCRIBE/re-SUBSCRIBE churn."""
+    N = 8  # parallel worker pairs (subscriber + publisher)
+    BATCH = 50  # channels per worker
+    ROUNDS = 2
+    port = df_server.port
+
+    total_lost = 0
+    for rnd in range(ROUNDS):
+        result_queue = multiprocessing.Queue()
+        barrier = multiprocessing.Barrier(N * 2)
+        all_ids = [f"r{rnd}-{i}" for i in range(N * BATCH)]
+        chunks = [all_ids[i::N] for i in range(N)]
+
+        procs = []
+        for chunk in chunks:
+            p = multiprocessing.Process(
+                target=_pubsub_churn_sub, args=(port, chunk, result_queue, barrier)
+            )
+            p.start()
+            procs.append(p)
+        for chunk in chunks:
+            p = multiprocessing.Process(target=_pubsub_churn_pub, args=(port, chunk, barrier))
+            p.start()
+            procs.append(p)
+
+        for p in procs:
+            p.join(timeout=30)
+            if p.is_alive():
+                p.kill()
+
+        round_lost = sum(result_queue.get(timeout=5) for _ in range(N))
+        assert round_lost == 0, f"Round {rnd + 1}/{ROUNDS}: {round_lost} PUBLISH messages lost"


### PR DESCRIPTION
## Summary
- Adds two test reproducers for #7056 (PUBLISH notifications silently lost under concurrent Celery workloads)
- `connection_test.py::test_pubsub_subscribe_churn_publish_lost` — self-contained reproducer using multiprocessing with rapid SUBSCRIBE/UNSUBSCRIBE/re-SUBSCRIBE cycles (no Celery dependency, ~5s)
- `celery_test.py::test_pubsub_publish_not_lost` — end-to-end reproducer using Celery's `group().get()` pattern with prefork pool (~20s)

Reproduces #7056

🤖 Generated with [Claude Code](https://claude.com/claude-code)