### PR TITLE
feat(server): Journal omits

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -4,7 +4,10 @@
 
 #include "server/db_slice.h"
 
+#include <ranges>
+
 #include "core/dense_set.h"
+#include "core/overloaded.h"
 #include "strings/human_readable.h"
 
 extern "C" {
@@ -377,7 +380,7 @@ DbStats& DbStats::operator+=(const DbStats& o) {
 }
 
 SliceEvents& SliceEvents::operator+=(const SliceEvents& o) {
-  static_assert(sizeof(SliceEvents) == 136, "You should update this function with new fields");
+  static_assert(sizeof(SliceEvents) == 144, "You should update this function with new fields");
 
   ADD(evicted_keys);
   ADD(hard_evictions);
@@ -396,6 +399,7 @@ SliceEvents& SliceEvents::operator+=(const SliceEvents& o) {
   ADD(ram_misses);
   ADD(huff_encode_total);
   ADD(huff_encode_success);
+  ADD(journal_omit);
   return *this;
 }
 
@@ -551,12 +555,11 @@ OpResult<DbSlice::ItAndUpdater> DbSlice::FindMutable(const Context& cntx, string
 OpResult<DbSlice::ItAndUpdater> DbSlice::FindMutableInternal(const Context& cntx, string_view key,
                                                              std::optional<unsigned> req_obj_type) {
   auto res = FindInternal(cntx, key, req_obj_type, UpdateStatsMode::kMutableStats);
-  if (!res.ok()) {
-    return res.status();
-  }
+  RETURN_ON_BAD_STATUS(res);
 
   auto it = Iterator(*res, StringOrView::FromView(key));
   PreUpdateBlocking(cntx.db_index, it);
+
   // PreUpdate() might have caused a deletion of `it`
   if (res->IsOccupied()) {
     DCHECK_GE(db_arr_[cntx.db_index]->stats.obj_memory_usage, (*res)->second.MallocUsed());
@@ -679,11 +682,17 @@ OpResult<DbSlice::ItAndUpdater> DbSlice::AddOrFindInternal(const Context& cntx, 
 
   if (res.ok()) {
     Iterator it(*res, StringOrView::FromView(key));
-    PreUpdateBlocking(cntx.db_index, it);
+
+    bool omitted_journal = IsOmittableWrite(cntx, it.GetInnerIt());
+    if (!omitted_journal)
+      PreUpdateBlocking(cntx.db_index, it);
 
     // PreUpdate() might have caused a deletion of `it`
     if (res->IsOccupied()) {
-      return ItAndUpdater{.it = it, .post_updater{cntx.db_index, key, it, this}, .is_new = false};
+      return ItAndUpdater{.it = it,
+                          .post_updater{cntx.db_index, key, it, this},
+                          .is_new = false,
+                          .omitted_journal = omitted_journal};
     } else {
       res = OpStatus::KEY_NOTFOUND;
     }
@@ -696,9 +705,15 @@ OpResult<DbSlice::ItAndUpdater> DbSlice::AddOrFindInternal(const Context& cntx, 
   CHECK(status == OpStatus::KEY_NOTFOUND || status == OpStatus::OUT_OF_MEMORY) << status;
 
   // Call change callbacks on the computed set of buckets that can be affected by the insert
+  bool omit_journal = false;
   if (!change_cb_.empty()) {
     for (bool consistent = false; !consistent;) {
       auto bucket_set = db.prime.CVCUponInsert(key);
+
+      // We skip calling callbacks, so the bucket set is consistent and we break
+      if (omit_journal = IsOmittableWrite(cntx, {bucket_set}); omit_journal)
+        break;
+
       CallChangeCallbacks(cntx.db_index, bucket_set);
 
       // Repeat the change callbacks if the target set changed
@@ -794,7 +809,9 @@ OpResult<DbSlice::ItAndUpdater> DbSlice::AddOrFindInternal(const Context& cntx, 
   }
 
   DCHECK_EQ(it->second.MallocUsed(), 0UL);  // Make sure accounting is no-op
-  it.SetVersion(NextVersion());
+
+  if (!omit_journal)
+    it.SetVersion(NextVersion());
 
   TouchTopKeysIfNeeded(key, db.sample_top_keys);
   TouchHllIfNeeded(key, db.sample_unique_keys);
@@ -812,7 +829,8 @@ OpResult<DbSlice::ItAndUpdater> DbSlice::AddOrFindInternal(const Context& cntx, 
   return ItAndUpdater{
       .it = Iterator(it, StringOrView::FromView(key)),
       .post_updater{cntx.db_index, key, Iterator(it, StringOrView::FromView(key)), this},
-      .is_new = true};
+      .is_new = true,
+      .omitted_journal = omit_journal};
 }
 
 void DbSlice::ActivateDb(DbIndex db_ind) {
@@ -1937,6 +1955,29 @@ void DbSlice::CallChangeCallbacks(DbIndex id, const ChangeReq& cr) const {
   unique_lock<LocalLatch> lk(change_cb_latch_);
   for (auto* cb : change_cb_ | std::views::take(change_cb_.size()))
     cb->OnChange(id, cr);
+}
+
+// We can omit the journal write if:
+// 1. it supports mutation hints and uses only a single key
+// 2. there is a single eventually-consistent snapshot (i.e. replica full sync)
+// 3. there are no other journal consumers
+// 4. the snapshot did not reach the bucket yet
+bool DbSlice::IsOmittableWrite(const Context& cntx, ChangeReq req) {
+  auto cb1 = [](PrimeTable::bucket_iterator it) { return it.GetVersion(); };
+  auto cb2 = [cb1](const PrimeTable::BucketSet& bs) -> uint64_t {
+    DCHECK(!std::ranges::empty(bs.buckets()));
+    return std::ranges::max(bs.buckets(), {}, cb1).GetVersion();
+  };
+
+  bool omit_update = false;
+  if (cntx.is_omittable_operation && change_cb_.size() == 1) {
+    uint64_t max_v = std::visit(Overloaded{cb1, cb2}, req);
+    auto* cb = change_cb_.front();
+    omit_update = cb->eventually_consistent_ && max_v < cb->snapshot_version_ &&
+                  journal::GetCallbackCount() == 1;
+    events_.journal_omit += unsigned(omit_update);
+  }
+  return omit_update;
 }
 
 }  // namespace dfly

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -74,6 +74,9 @@ struct SliceEvents {
   // how many updates and insertions of keys between snapshot intervals
   size_t update = 0;
 
+  // how many journal omit optimizations were performed
+  size_t journal_omit = 0;
+
   uint64_t huff_encode_total = 0, huff_encode_success = 0;
 
   SliceEvents& operator+=(const SliceEvents& o);
@@ -99,6 +102,7 @@ class DbSlice {
     virtual void WaitForNoBucketBlocked() const {
     }
 
+    bool eventually_consistent_ = false;
     uint64_t snapshot_version_ = 0;
   };
 
@@ -266,6 +270,10 @@ class DbSlice {
     Iterator it;
     AutoUpdater post_updater;
     bool is_new = false;
+
+    // Set if DbContext::is_omittable_operation was set and the conditions were met.
+    // Means that the journal write should NOT be performed.
+    bool omitted_journal = false;
   };
 
   ItAndUpdater FindMutable(const Context& cntx, std::string_view key);
@@ -555,6 +563,9 @@ class DbSlice {
   void SendQueuedInvalidationMessagesAsync();
 
   void CreateDb(DbIndex index);
+
+  // Returns true if this write could be ignored during replication without losing consistency
+  bool IsOmittableWrite(const Context& cntx, ChangeReq req);
 
   enum class UpdateStatsMode : uint8_t {
     kReadStats,

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -837,7 +837,7 @@ OpStatus OpExpire(const OpArgs& op_args, string_view key, const DbSlice::ExpireP
 OpResult<vector<long>> OpFieldExpire(const OpArgs& op_args, string_view key, uint32_t ttl_sec,
                                      CmdArgList values) {
   auto& db_slice = op_args.GetDbSlice();
-  auto [it, auto_updater, is_new] = db_slice.FindMutable(op_args.db_cntx, key);
+  auto [it, auto_updater, is_new, _] = db_slice.FindMutable(op_args.db_cntx, key);
 
   if (!IsValid(it) || (it->second.ObjType() != OBJ_SET && it->second.ObjType() != OBJ_HASH)) {
     std::vector<long> res(values.size(), -2);

--- a/src/server/journal/journal.cc
+++ b/src/server/journal/journal.cc
@@ -56,8 +56,8 @@ error_code Close() {
   return {};
 }
 
-bool HasRegisteredCallbacks() {
-  return journal_slice.HasRegisteredCallbacks();
+unsigned GetCallbackCount() {
+  return journal_slice.OnChangeCbCount();
 }
 
 bool IsLSNInBuffer(LSN lsn) {

--- a/src/server/journal/journal.h
+++ b/src/server/journal/journal.h
@@ -24,7 +24,10 @@ std::error_code Close();
 
 //******* The following functions must be called in the context of the owning shard *********//
 
-bool HasRegisteredCallbacks();
+unsigned GetCallbackCount();
+inline bool HasRegisteredCallbacks() {
+  return GetCallbackCount() > 0;
+}
 
 bool IsLSNInBuffer(LSN lsn);
 

--- a/src/server/journal/journal_slice.h
+++ b/src/server/journal/journal_slice.h
@@ -41,8 +41,8 @@ class JournalSlice {
   uint32_t RegisterOnChange(JournalConsumerInterface* consumer);
   void UnregisterOnChange(uint32_t);
 
-  bool HasRegisteredCallbacks() const {
-    return !journal_consumers_arr_.empty();
+  unsigned OnChangeCbCount() const {
+    return journal_consumers_arr_.size();
   }
 
   /// Returns whether the journal entry with this LSN is available

--- a/src/server/journal/streamer.cc
+++ b/src/server/journal/streamer.cc
@@ -432,7 +432,7 @@ void RestoreStreamer::Start(util::FiberSocketBase* dest) {
     return;
 
   VLOG(1) << "RestoreStreamer start";
-  SerializerBase::RegisterChangeListener();
+  SerializerBase::RegisterChangeListener(true);
   JournalStreamer::Start(dest);
 }
 

--- a/src/server/serializer_base.cc
+++ b/src/server/serializer_base.cc
@@ -138,10 +138,10 @@ SerializerBase::~SerializerBase() {
 //   same fiber, so the baseline is serialized first. big_value_mu_ prevents this callback path
 //   from interleaving with the traversal fiber's bucket serialization, which may preempt while
 //   emitting large values.
-void SerializerBase::RegisterChangeListener(bool replica) {
+void SerializerBase::RegisterChangeListener(bool replication) {
   db_array_ = db_slice_->databases();  // copy pointers to survive flush
   db_slice_->RegisterOnChange(this);
-  eventually_consistent_ = replica;
+  eventually_consistent_ = replication;
 }
 
 void SerializerBase::UnregisterChangeListener() {

--- a/src/server/serializer_base.cc
+++ b/src/server/serializer_base.cc
@@ -138,9 +138,10 @@ SerializerBase::~SerializerBase() {
 //   same fiber, so the baseline is serialized first. big_value_mu_ prevents this callback path
 //   from interleaving with the traversal fiber's bucket serialization, which may preempt while
 //   emitting large values.
-void SerializerBase::RegisterChangeListener() {
+void SerializerBase::RegisterChangeListener(bool replica) {
   db_array_ = db_slice_->databases();  // copy pointers to survive flush
   db_slice_->RegisterOnChange(this);
+  eventually_consistent_ = replica;
 }
 
 void SerializerBase::UnregisterChangeListener() {
@@ -152,7 +153,7 @@ void SerializerBase::UnregisterChangeListener() {
 bool SerializerBase::ProcessBucket(DbIndex db_index, PrimeTable::bucket_iterator it,
                                    bool on_update) {
   // Check if this bucket is stale
-  if (it.is_done() || it.GetVersion() >= snapshot_version_) {
+  if (it.GetVersion() >= snapshot_version_) {
     stats_.buckets_skipped++;
 
     // Update versions for empty buckets
@@ -165,6 +166,12 @@ bool SerializerBase::ProcessBucket(DbIndex db_index, PrimeTable::bucket_iterator
 
     // Wait for all dependencies to be resolved
     BucketDependencies::Wait(it.bucket_address());
+    return false;
+  }
+
+  // TODO: Flushing to earlier callbacks
+  if (it.is_done()) {
+    it.SetVersion(snapshot_version_);
     return false;
   }
 

--- a/src/server/serializer_base.cc
+++ b/src/server/serializer_base.cc
@@ -153,10 +153,11 @@ void SerializerBase::UnregisterChangeListener() {
 bool SerializerBase::ProcessBucket(DbIndex db_index, PrimeTable::bucket_iterator it,
                                    bool on_update) {
   // Check if this bucket is stale
-  if (it.GetVersion() >= snapshot_version_) {
+  if (it.is_done() || it.GetVersion() >= snapshot_version_) {
     stats_.buckets_skipped++;
 
-    // Update versions for empty buckets
+    // Update versions for empty buckets to mark that won't visit them anymore
+    // TODO: Flush changes to earlier callbacks
     if (it.GetVersion() < snapshot_version_)
       it.SetVersion(snapshot_version_);
 
@@ -166,12 +167,6 @@ bool SerializerBase::ProcessBucket(DbIndex db_index, PrimeTable::bucket_iterator
 
     // Wait for all dependencies to be resolved
     BucketDependencies::Wait(it.bucket_address());
-    return false;
-  }
-
-  // TODO: Flushing to earlier callbacks
-  if (it.is_done()) {
-    it.SetVersion(snapshot_version_);
     return false;
   }
 

--- a/src/server/serializer_base.h
+++ b/src/server/serializer_base.h
@@ -105,7 +105,8 @@ class SerializerBase : public BucketDependencies,
   virtual ~SerializerBase();
 
   // Register db_slice change listener and save snapshot version.
-  void RegisterChangeListener(bool replica);
+  // Pass whether this is replication (true) or snapshotting (false)
+  void RegisterChangeListener(bool replication);
 
   // Unregisters the callback.  Safe to call if already unregistered.
   void UnregisterChangeListener();

--- a/src/server/serializer_base.h
+++ b/src/server/serializer_base.h
@@ -105,7 +105,7 @@ class SerializerBase : public BucketDependencies,
   virtual ~SerializerBase();
 
   // Register db_slice change listener and save snapshot version.
-  void RegisterChangeListener();
+  void RegisterChangeListener(bool replica);
 
   // Unregisters the callback.  Safe to call if already unregistered.
   void UnregisterChangeListener();

--- a/src/server/serializer_base_test.cc
+++ b/src/server/serializer_base_test.cc
@@ -145,7 +145,7 @@ struct TestDriver : public SerializerBase, journal::JournalConsumerInterface {
   }
 
   void Start() {
-    SerializerBase::RegisterChangeListener();
+    SerializerBase::RegisterChangeListener(false);
     journal::StartInThread();
     journal_id_ = journal::RegisterConsumer(this);
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -3365,6 +3365,8 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
     append("lua_force_gc_calls", m.lua_stats.force_gc_calls);
     append("lua_gc_freed_memory_total", m.lua_stats.gc_freed_memory);
     append("lua_gc_duration_total_sec", m.lua_stats.gc_duration_ns * 1e-9);
+
+    append("total_journal_omits", m.events.journal_omit);
   };
 
   auto add_tiered_info = [&] {

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -77,7 +77,7 @@ void SliceSnapshot::Start(bool stream_journal, SnapshotFlush allow_flush) {
   DCHECK(!snapshot_fb_.IsJoinable());
 
   use_background_mode_ = absl::GetFlag(FLAGS_background_snapshotting);
-  SerializerBase::RegisterChangeListener();
+  SerializerBase::RegisterChangeListener(stream_journal);
 
   if (stream_journal) {
     journal_cb_id_ = journal::RegisterConsumer(this);

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -110,8 +110,9 @@ class SetCmd {
 
   OpStatus CachePrevIfNeeded(const SetParams& params, DbSlice::Iterator it);
 
-  const OpArgs op_args_;
+  OpArgs op_args_;
   bool explicit_journal_;  // call RecordJournal (auto journaling disabled)
+  bool skip_journal_ = false;
 };
 
 size_t SetRangeInternal(std::string* value, size_t start, std::string_view range) {
@@ -836,9 +837,13 @@ OpStatus SetCmd::Set(const SetParams& params, string_view key, string_view value
     }
   }
 
+  // Enable journal omits for this operation
+  op_args_.db_cntx.is_omittable_operation = true;
+
   // We can use std::nullopt here because SET command can change the key type to string
   auto op_res = db_slice.AddOrFind(op_args_.db_cntx, key, std::nullopt);
   RETURN_ON_BAD_STATUS(op_res);
+  skip_journal_ = op_res->omitted_journal;
 
   if (!op_res->is_new) {
     if (auto status = CachePrevIfNeeded(params, op_res->it); status != OpStatus::OK)
@@ -934,7 +939,7 @@ void SetCmd::PostEdit(const SetParams& params, std::string_view key, std::string
     StashPrimeValue(op_args_.db_cntx.db_index, key, pv, ts, params.backpressure);
   }
 
-  if (explicit_journal_ && op_args_.shard->journal()) {
+  if (!skip_journal_ && explicit_journal_ && op_args_.shard->journal()) {
     RecordJournal(params, key, value);
   }
 }

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -939,8 +939,12 @@ void SetCmd::PostEdit(const SetParams& params, std::string_view key, std::string
     StashPrimeValue(op_args_.db_cntx.db_index, key, pv, ts, params.backpressure);
   }
 
-  if (!skip_journal_ && explicit_journal_ && op_args_.shard->journal()) {
-    RecordJournal(params, key, value);
+  if (explicit_journal_ && op_args_.shard->journal()) {
+    // Skipping a journal write breaks the LSN buffer, so clear it
+    if (skip_journal_)
+      journal::ClearBuffer();
+    else
+      RecordJournal(params, key, value);
   }
 }
 

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -940,7 +940,9 @@ void SetCmd::PostEdit(const SetParams& params, std::string_view key, std::string
   }
 
   if (explicit_journal_ && op_args_.shard->journal()) {
-    // Skipping a journal write breaks the LSN buffer, so clear it
+    // A skipped journal write is not added to the journal ring buffer, so it goes unnoticed for
+    // partial sync. To fix that, we clear the ring buffer, so partial sync is no longer possible.
+    // TODO: Record journal, but only into ring buffer.
     if (skip_journal_)
       journal::ClearBuffer();
     else

--- a/src/server/tx_base.h
+++ b/src/server/tx_base.h
@@ -61,6 +61,11 @@ struct DbContext {
   DbIndex db_index = 0;
   uint64_t time_now_ms = 0;
 
+  // Set if this operation can be safely not reported to eventually consistent
+  // snapshots (replicas) - the change callbacks and journal consumers.
+  // Optimizes unnecessary serialization reordering
+  bool is_omittable_operation = false;
+
   // Convenience method.
   DbSlice& GetDbSlice(ShardId shard_id) const;
 };

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -256,7 +256,7 @@ async def test_replication_all(
         # it's usually close to 1% but there are some that are close to 3.
         assert preemptions <= (key_capacity * 0.03)
 
-    if len(replicas) == 1:
+    if len(replicas) == 1 and seeder_config["key_target"] > 100_000:
         print("total omits", info["total_journal_omits"])
         assert info["total_journal_omits"] > 0
 
@@ -3495,8 +3495,9 @@ async def test_partial_replication_on_same_source_master_with_replica_lsn_inc(df
     # Make server 4 replica of server 2
     await c_s4.execute_command(f"REPLICAOF localhost {server2.port}")
     # Send some write command for lsn inc
+    # NOTE: using append temporarily because SET is omit-optimized with disables partial sync
     for i in range(100):
-        await c_s2.set(i, "val")
+        await c_s2.append(i, "val")
     # Make server 3 replica of server 2
     await c_s3.execute_command(f"REPLICAOF localhost {server2.port}")
 

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -152,6 +152,8 @@ async def compare_datasets(c_master, c_replica):
             2, [2], dict(key_target=1_000, data_size=10_000, huge_value_target=0), 100, marks=M_SLOW
         ),
         # Stress test
+        # Single replica process might have additional optimizations that need to be verified
+        pytest.param(4, [4], dict(key_target=500_000, types=["STRING"]), 100_000, marks=M_STRESS),
         pytest.param(8, [8, 8], dict(key_target=1_000_000, units=16), 50_000, marks=M_STRESS),
     ],
 )
@@ -241,7 +243,8 @@ async def test_replication_all(
         f"Compressed blobs {compressed_blobs} .Capacity {key_capacity}. Preemptions {preemptions}"
     )
 
-    assert preemptions >= seeder.huge_value_target * 0.5
+    if len(replicas) > 1:
+        assert preemptions >= seeder.huge_value_target * 0.5
     assert compressed_blobs > 0
     # Because data size could be 10k and for that case there will be almost a preemption
     # per bucket.
@@ -252,6 +255,10 @@ async def test_replication_all(
         # the size of the hug value and the serialization max chunk size. For the test cases here,
         # it's usually close to 1% but there are some that are close to 3.
         assert preemptions <= (key_capacity * 0.03)
+
+    if len(replicas) == 1:
+        print("total omits", info["total_journal_omits"])
+        assert info["total_journal_omits"] > 0
 
     # Assert select calls are properly optimized
     for replica in c_replicas:

--- a/tests/dragonfly/seeder/script-genlib.lua
+++ b/tests/dragonfly/seeder/script-genlib.lua
@@ -53,11 +53,15 @@ end
 function LG_funcs.mod_string(key)
     -- APPEND and SETRANGE are the only modifying operations for strings,
     -- issue APPEND rarely to not grow data too much
-    if math.random() < 0.05 then
-        redis.apcall('APPEND', key, '+')
-    else
+    -- replace the whole string fully sometimes
+    local p = math.random()
+    if p < 0.2 then
+        redis.apcall('APPEND', key, dragonfly.randstr(2))
+    elseif p < 0.9 then
         local replacement = dragonfly.randstr(LG_funcs.dsize // 2)
         redis.apcall('SETRANGE', key, math.random(0, LG_funcs.dsize // 2), replacement)
+    else
+        redis.apcall('SET', key, dragonfly.randstr(LG_funcs.dsize))
     end
 end
 


### PR DESCRIPTION
Experimental journal omits

Implements `DbSlice::IsOmittableWrite` that can skip the CallOnChangeCallbacks + version update and has to notify the command to omit the journal write. 

This is safe if we have one eventually consistent snapshot (replica, migration) and the bucket was not visited yet. It will be fully serialized once the iteration loop reaches it

<img width="1400" height="1200" alt="image" src="https://github.com/user-attachments/assets/921bc7eb-333b-436f-94cc-628ad46f4918" />
