### PR TITLE
chore: Add pubsub-stress.py tool

### DIFF
--- a/tools/pubsub-stress.py
+++ b/tools/pubsub-stress.py
@@ -1,7 +1,8 @@
 """
 Pub/sub stress test.
 
-Phase 1 (--subscribe): ramp up to --sub-max-channels subscriptions at --sub-rate/sec.
+Phase 1 (--subscribe): ramp up --sub-max-channels additional subscriptions at --sub-rate/sec
+                       (on top of any --pre-subscribe baseline).
                        Subscriptions remain open as background load during the publish phase.
 Phase 2 (--publish):  create --pub-sub-connections dedicated subscriber connections,
                       publish at --pub-rate msgs/sec across --pub-workers publisher connections,
@@ -389,6 +390,18 @@ if __name__ == "__main__":
         help="Number of subscriber connections in publish phase",
     )
     args = parser.parse_args()
+
+    errors = []
+    if args.sub_rate < 1:
+        errors.append("--sub-rate must be >= 1")
+    if args.sub_channels < 1:
+        errors.append("--sub-channels must be >= 1")
+    if args.pub_workers < 1:
+        errors.append("--pub-workers must be >= 1")
+    if args.pub_sub_connections < 1:
+        errors.append("--pub-sub-connections must be >= 1")
+    if errors:
+        parser.error("\n  ".join(errors))
 
     if args.uri:
         host, port, password, ssl = parse_uri(args.uri)


### PR DESCRIPTION
A two-phase pub/sub stress tool for measuring subscription scalability and
publish/delivery latency. Useful for profiling Dragonfly under realistic pub/sub workloads.

Option 1 (--subscribe): ramp up subscriptions on a single connection at a controlled 
rate (--sub-rate batches/sec, --sub-channels channels/batch) up to --sub-max-channels total.
An optional --pre-subscribe N silently establishes a baseline of N channels before the visible 
ramp starts, useful for testing with a large pre-existing subscription load. Subscriptions remain
open throughout, so the publish phase runs against a live background load.

A dedicated worker thread owns the pubsub socket exclusively. All subscribe calls are 
serialized through a queue so there is no concurrent use of the connection and subscribe 
confirmations are counted unambiguously per batch.

Option 2 (--publish): creates --pub-sub-connections dedicated subscriber connections 
(one channel each, isolated from the ramp-up socket), then drives --pub-rate publishes/sec across 
--pub-workers parallel publisher connections for --pub-duration seconds. The publisher embeds a 
perf_counter timestamp in each message payload so that listener threads can compute end-to-end 
delivery latency independently of publish RTT.

Two latency metrics are reported per second:
- Publish RTT: time for r.publish() to return (round-trip to server)
- Delivery latency: time from publish() call to receipt in the listener

Usage examples:

```
  # Publish-only: 1000 msgs/sec across 128 subscriber connections for 60s 
  
  python pubsub-stress.py --publish --pub-rate 1000 --pub-duration 60 --pub-sub-connections 128

  # Full: ramp to 150k subscriptions, then measure publish latency on top 

  python pubsub-stress.py --subscribe --publish --sub-max-channels 150000 --pub-rate 1000 
                                                --pub-workers 4 --pub-duration 60

  # Pre-establish 100k channels silently, ramp 50k more, then publish 

  python pubsub-stress.py --subscribe --publish --pre-subscribe 100000 --sub-max-channels 50000 
                                                --pub-rate 500 --pub-duration 30

  # TLS connection via URI 
  
  python pubsub-stress.py --publish --uri rediss://:password@host:6380
```

Script is created with Claude code.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
