### PR TITLE
fix(server): SIGSEGV in HRANDFIELD with expired hash fields

### DIFF
--- a/src/core/dense_set.cc
+++ b/src/core/dense_set.cc
@@ -942,7 +942,8 @@ void DenseSet::CollectExpired() {
 }
 
 size_t DenseSet::SizeSlow() {
-  CollectExpired();
+  if (expiration_used_)
+    CollectExpired();
   return size_;
 }
 

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -1009,15 +1009,18 @@ void CmdHRandField(CmdArgList args, CommandContext* cmd_cntx) {
           str_vec.emplace_back(key, sdslen(key));
         }
       } else {
+        size_t real_size = string_map->SizeSlow();
         size_t actual_count =
-            (count >= 0) ? std::min(size_t(count), string_map->UpperBoundSize()) : abs(count);
+            (count >= 0) ? std::min(size_t(count), real_size) : size_t(-int64_t(count));
         std::vector<sds> keys, vals;
-        if (count >= 0) {
-          string_map->RandomPairsUnique(actual_count, keys, vals, with_values);
-        } else {
-          string_map->RandomPairs(actual_count, keys, vals, with_values);
+        if (real_size > 0 && actual_count > 0) {
+          if (count >= 0) {
+            string_map->RandomPairsUnique(actual_count, keys, vals, with_values);
+          } else {
+            string_map->RandomPairs(actual_count, keys, vals, with_values);
+          }
         }
-        for (size_t i = 0; i < actual_count; ++i) {
+        for (size_t i = 0; i < keys.size(); ++i) {
           str_vec.emplace_back(keys[i], sdslen(keys[i]));
           if (with_values) {
             str_vec.emplace_back(vals[i], sdslen(vals[i]));

--- a/src/server/hset_family_test.cc
+++ b/src/server/hset_family_test.cc
@@ -712,6 +712,28 @@ TEST_F(HSetFamilyTest, RandomField1NotExpired) {
   EXPECT_THAT(Run({"HRANDFIELD", "key"}), "keep");
 }
 
+// Regression test for SIGSEGV in CmdHRandField when expired fields
+// cause UpperBoundSize() > SizeSlow(). CmdHRandField uses UpperBoundSize()
+// for actual_count but RandomPairsUnique uses SizeSlow(), returning fewer
+// elements than the loop expects -> out-of-bounds access.
+TEST_F(HSetFamilyTest, HRandFieldCountWithExpiredFields) {
+  // Add fields with short TTL so they expire.
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_EQ(CheckedInt({"HSETEX", "key", "1", absl::StrCat("k", i), "v"}), 1);
+  }
+  // Add one permanent field.
+  EXPECT_EQ(CheckedInt({"HSET", "key", "keep", "v"}), 1);
+
+  AdvanceTime(2000);
+
+  // Request count=42 (positive) with expired fields.
+  // UpperBoundSize()=11 but SizeSlow()=1. Must not crash.
+  Run({"HRANDFIELD", "key", "42"});
+
+  // With WITHVALUES.
+  Run({"HRANDFIELD", "key", "42", "WITHVALUES"});
+}
+
 TEST_F(HSetFamilyTest, EmptyHashBug) {
   EXPECT_THAT(Run({"HSET", "foo", "a_field", "a_value"}), IntArg(1));
   EXPECT_THAT(Run({"HSETEX", "foo", "1", "b_field", "b_value"}), IntArg(1));


### PR DESCRIPTION
`CmdHRandField` used `UpperBoundSize()` to cap the count passed to `RandomPairsUnique`/`RandomPairs`, but those functions internally use `SizeSlow()`, which excludes expired fields. When hash fields created via `HSETEX` expire, `UpperBoundSize()` over-counts, causing:

- **positive count**: `RandomPairsUnique` returns fewer entries than the loop iterates -> out-of-bounds read -> SIGSEGV
- **negative count / all expired**: `RandomPairs` does `rand() % 0` (division by zero) when `SizeSlow() == 0` -> SIGSEGV

Fixes #7073
