### PR TITLE
fix(core): prevent MergeNodes from merging non-adjacent head and tail nodes

### DIFF
--- a/src/core/qlist.cc
+++ b/src/core/qlist.cc
@@ -1087,10 +1087,12 @@ auto QList::MergeNodes(Node* center) -> Node* {
   Node *prev = NULL, *prev_prev = NULL, *next = NULL;
   Node *next_next = NULL, *target = NULL;
 
-  if (center->prev) {
+  // head_->prev is a circular shortcut to the tail, not a real predecessor.
+  // Only follow ->prev chains when we are not at the head node.
+  if (center != head_) {
     prev = center->prev;
-    if (center->prev->prev)
-      prev_prev = center->prev->prev;
+    if (prev != head_)
+      prev_prev = prev->prev;
   }
 
   if (center->next) {
@@ -1112,7 +1114,7 @@ auto QList::MergeNodes(Node* center) -> Node* {
   }
 
   /* Try to merge center node and previous node */
-  if (NodeAllowMerge(center, center->prev, fill_)) {
+  if (center != head_ && NodeAllowMerge(center, center->prev, fill_)) {
     target = ListpackMerge(center->prev, center);
     center = NULL; /* center could have been deleted, invalidate it. */
   } else {

--- a/src/core/qlist_test.cc
+++ b/src/core/qlist_test.cc
@@ -425,6 +425,34 @@ TEST_F(QListTest, Tiering) {
   EXPECT_EQ(QList::stats.offload_requests, 9);
 }
 
+// MergeNodes must not follow the head_->prev circular link when looking for
+// adjacent nodes to merge.  Splitting a full head node and calling MergeNodes
+// on the right half used to traverse new_head->prev (= tail), merging two
+// non-adjacent nodes and corrupting element order.
+TEST_F(QListTest, InsertSplitHeadMergeOrder) {
+  QList ql(5, 0);
+
+  // 3 nodes: [v0..v4](head,full) -> [v5..v9] -> [v10](tail,1 elem)
+  for (int i = 0; i < 11; i++) {
+    ql.Push(StrCat("v", i), QList::TAIL);
+  }
+  ASSERT_EQ(3u, ql.node_count());
+
+  // Insert in the middle of the full head triggers split + MergeNodes.
+  ql.Insert("v2", "x", QList::BEFORE);
+
+  vector<string> items;
+  ql.Iterate(
+      [&](const QList::Entry& e) {
+        items.push_back(e.to_string());
+        return true;
+      },
+      0, ql.Size());
+
+  EXPECT_THAT(items,
+              ElementsAre("v0", "v1", "x", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10"));
+}
+
 TEST_F(QListTest, InsertPivotSplitMergeMallocSize) {
   QList ql(2, 0);  // fill=2: at most 2 elements per node
   ql.Push("x", QList::TAIL);


### PR DESCRIPTION
QList uses head_->prev as a circular shortcut to the tail node. MergeNodes treated this link as a regular predecessor pointer, which caused it to merge the tail with the head when they are not adjacent. This corrupted element order and could lead to use-after-free / SIGSEGV when the freed tail node was later accessed through a stale pointer.

The fix skips ->prev traversal when the node is at or adjacent to the head, so only genuinely adjacent nodes are considered for merging.

Fixes #7031