### PR TITLE
feat(bloom): Implement LOADCHUNK cmd for SBF

### DIFF
--- a/src/core/bloom.cc
+++ b/src/core/bloom.cc
@@ -234,4 +234,102 @@ size_t SBF::MallocUsed() const {
   return res;
 }
 
+SBFDumpIterator::SBFDumpIterator(const SBF& sbf, int64_t cursor) : sbf_{sbf}, cursor_{cursor} {
+  ResolveCursorToPos();
+}
+
+SBFChunk SBFDumpIterator::Next() {
+  if (!header_sent_) {
+    header_sent_ = true;
+    cursor_ = 1;
+    return {cursor_, SerializeHeader()};
+  }
+
+  if (filter_index_ >= sbf_.num_filters()) {
+    return {0, {}};
+  }
+
+  const string_view data = sbf_.data(filter_index_);
+  const size_t remaining = data.size() - byte_offset_;
+  const size_t chunk_len = std::min(kMaxChunkSize, remaining);
+  const string_view chunk = data.substr(byte_offset_, chunk_len);
+
+  byte_offset_ += chunk_len;
+  cursor_ += chunk_len;
+
+  if (byte_offset_ >= data.size()) {
+    filter_index_++;
+    byte_offset_ = 0;
+  }
+
+  return {cursor_, string{chunk}};
+}
+
+bool SBFDumpIterator::Done() const {
+  return filter_index_ >= sbf_.num_filters() && header_sent_;
+}
+
+std::string SBFDumpIterator::SerializeHeader() const {
+  constexpr uint32_t kSbfDumpVersion = 1;
+
+  constexpr size_t kDumpHeaderFixedSize = 48;  // version + 5x u64 + num_filters
+  constexpr size_t kDumpFilterMetaSize = 12;   // hash_cnt + data_length
+
+  const uint32_t num_filters = sbf_.num_filters();
+
+  std::string out;
+  out.reserve(kDumpHeaderFixedSize + num_filters * kDumpFilterMetaSize);
+
+  auto append_u32 = [&out](uint32_t v) {
+    char buf[sizeof(v)];
+    absl::little_endian::Store32(buf, v);
+    out.append(buf, sizeof(buf));
+  };
+
+  auto append_u64 = [&out](uint64_t v) {
+    char buf[sizeof(v)];
+    absl::little_endian::Store64(buf, v);
+    out.append(buf, sizeof(buf));
+  };
+
+  append_u32(kSbfDumpVersion);
+  append_u64(std::bit_cast<uint64_t>(sbf_.grow_factor()));
+  append_u64(std::bit_cast<uint64_t>(sbf_.fp_probability()));
+  append_u64(sbf_.prev_size());
+  append_u64(sbf_.current_size());
+  append_u64(sbf_.max_capacity());
+  append_u32(num_filters);
+
+  for (uint32_t i = 0; i < num_filters; ++i) {
+    append_u32(sbf_.hashfunc_cnt(i));
+    append_u64(sbf_.data(i).size());
+  }
+
+  return out;
+}
+
+void SBFDumpIterator::ResolveCursorToPos() {
+  header_sent_ = cursor_ > 0;
+  if (cursor_ == 0) {
+    filter_index_ = 0;
+    byte_offset_ = 0;
+    return;
+  }
+
+  size_t global_offset = cursor_ - 1;
+  for (uint32_t i = 0; i < sbf_.num_filters(); ++i) {
+    const size_t curr_filter_size = sbf_.data(i).size();
+    if (global_offset < curr_filter_size) {
+      filter_index_ = i;
+      byte_offset_ = global_offset;
+      return;
+    }
+    global_offset -= curr_filter_size;
+  }
+
+  // cursor is beyond data boundary
+  filter_index_ = sbf_.num_filters();
+  byte_offset_ = 0;
+}
+
 }  // namespace dfly

--- a/src/core/bloom.cc
+++ b/src/core/bloom.cc
@@ -12,6 +12,7 @@
 #include <cmath>
 
 #include "base/logging.h"
+#include "core/compact_object.h"
 
 namespace dfly {
 
@@ -33,6 +34,10 @@ uint64_t BitIndex(uint64_t low, uint64_t hi, unsigned i, uint64_t mask) {
 
 constexpr double kDenom = M_LN2 * M_LN2;
 constexpr double kSBFErrorFactor = 0.5;
+
+constexpr uint32_t kSbfDumpVersion = 1;
+constexpr size_t kDumpHeaderFixedSize = 48;  // version(4) + 5x u64(40) + num_filters(4)
+constexpr size_t kDumpFilterMetaSize = 12;   // hash_cnt(4) + data_length(8)
 
 double BPE(double fp_prob) {
   return -log(fp_prob) / kDenom;
@@ -234,6 +239,13 @@ size_t SBF::MallocUsed() const {
   return res;
 }
 
+void SBF::AddEmptyFilter(size_t size, unsigned hash_cnt) {
+  PMR_NS::memory_resource* mr = filters_.get_allocator().resource();
+  const auto ptr = static_cast<uint8_t*>(mr->allocate(size, 1));
+  memset(ptr, 0, size);
+  filters_.emplace_back().Init(ptr, size, hash_cnt);
+}
+
 SBFDumpIterator::SBFDumpIterator(const SBF& sbf, int64_t cursor) : sbf_{sbf}, cursor_{cursor} {
   ResolveCursorToPos();
 }
@@ -270,11 +282,6 @@ bool SBFDumpIterator::Done() const {
 }
 
 std::string SBFDumpIterator::SerializeHeader() const {
-  constexpr uint32_t kSbfDumpVersion = 1;
-
-  constexpr size_t kDumpHeaderFixedSize = 48;  // version + 5x u64 + num_filters
-  constexpr size_t kDumpFilterMetaSize = 12;   // hash_cnt + data_length
-
   const uint32_t num_filters = sbf_.num_filters();
 
   std::string out;
@@ -308,28 +315,95 @@ std::string SBFDumpIterator::SerializeHeader() const {
   return out;
 }
 
+std::optional<SBFDataPosition> ResolveSBFCursor(const SBF& sbf, int64_t cursor) {
+  if (cursor < 1)
+    return std::nullopt;
+
+  size_t global_offset = cursor - 1;
+  for (uint32_t i = 0; i < sbf.num_filters(); ++i) {
+    const size_t filter_size = sbf.data(i).size();
+    if (global_offset < filter_size) {
+      return SBFDataPosition{i, global_offset};
+    }
+    global_offset -= filter_size;
+  }
+
+  return std::nullopt;
+}
+
 void SBFDumpIterator::ResolveCursorToPos() {
-  header_sent_ = cursor_ > 0;
   if (cursor_ == 0) {
+    header_sent_ = false;
     filter_index_ = 0;
     byte_offset_ = 0;
     return;
   }
 
-  size_t global_offset = cursor_ - 1;
-  for (uint32_t i = 0; i < sbf_.num_filters(); ++i) {
-    const size_t curr_filter_size = sbf_.data(i).size();
-    if (global_offset < curr_filter_size) {
-      filter_index_ = i;
-      byte_offset_ = global_offset;
-      return;
-    }
-    global_offset -= curr_filter_size;
+  header_sent_ = true;
+  if (const auto pos = ResolveSBFCursor(sbf_, cursor_)) {
+    filter_index_ = pos->filter_index;
+    byte_offset_ = pos->byte_offset;
+  } else {
+    filter_index_ = sbf_.num_filters();
+    byte_offset_ = 0;
+  }
+}
+
+SBF* SBFDumpHeader::Create(PMR_NS::memory_resource* mr) {
+  SBF* sbf =
+      CompactObj::AllocateMR<SBF>(grow_factor, fp_prob, max_capacity, prev_size, current_size, mr);
+  for (const auto& [hash_cnt, data_length] : filters) {
+    sbf->AddEmptyFilter(data_length, hash_cnt);
+  }
+  return sbf;
+}
+
+std::optional<SBFDumpHeader> ParseSBFDumpHeader(std::string_view data) {
+  if (data.size() < kDumpHeaderFixedSize)
+    return std::nullopt;
+
+  const char* ptr = data.data();
+
+  auto read_u32 = [&ptr] {
+    const auto v = absl::little_endian::Load32(ptr);
+    ptr += sizeof(v);
+    return v;
+  };
+
+  auto read_u64 = [&ptr] {
+    const auto v = absl::little_endian::Load64(ptr);
+    ptr += sizeof(v);
+    return v;
+  };
+
+  if (const auto version = read_u32(); version != kSbfDumpVersion)
+    return std::nullopt;
+
+  SBFDumpHeader header;
+  header.grow_factor = std::bit_cast<double>(read_u64());
+  header.fp_prob = std::bit_cast<double>(read_u64());
+  header.prev_size = read_u64();
+  header.current_size = read_u64();
+  header.max_capacity = read_u64();
+  if (header.current_size >= header.max_capacity)
+    return std::nullopt;
+
+  const auto num_filters = read_u32();
+
+  if (const size_t expected_size = kDumpHeaderFixedSize + num_filters * kDumpFilterMetaSize;
+      data.size() != expected_size || num_filters == 0)
+    return std::nullopt;
+
+  header.filters.resize(num_filters);
+  for (uint32_t i = 0; i < num_filters; ++i) {
+    header.filters[i].hash_cnt = read_u32();
+    header.filters[i].data_length = read_u64();
+    if (header.filters[i].hash_cnt == 0 || header.filters[i].data_length == 0 ||
+        !has_single_bit(header.filters[i].data_length))
+      return std::nullopt;
   }
 
-  // cursor is beyond data boundary
-  filter_index_ = sbf_.num_filters();
-  byte_offset_ = 0;
+  return header;
 }
 
 }  // namespace dfly

--- a/src/core/bloom.h
+++ b/src/core/bloom.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -64,6 +65,10 @@ class Bloom {
 
   unsigned hash_cnt() const {
     return hash_cnt_;
+  }
+
+  uint8_t* mutable_data() {  // NOLINT cannot be made const, hands out mutable ptr
+    return bf_;
   }
 
  private:
@@ -130,12 +135,20 @@ class SBF {
     return filters_[idx].hash_cnt();
   }
 
+  uint8_t* filter_data(size_t idx) {
+    return filters_[idx].mutable_data();
+  }
+
   // max capacity of the current filter.
   size_t max_capacity() const {
     return max_capacity_;
   }
 
   size_t MallocUsed() const;
+
+  // Adds empty filter with zero memory, for use in LOADCHUNK where the caller will later supply
+  // data to be filled in
+  void AddEmptyFilter(size_t size, unsigned hash_cnt);
 
  private:
   // multiple filters from the smallest to the largest.
@@ -146,6 +159,14 @@ class SBF {
   size_t current_size_ = 0;
   size_t max_capacity_;
 };
+
+struct SBFDataPosition {
+  uint32_t filter_index;
+  size_t byte_offset;
+};
+
+// Resolves cursor to a filter index and byte offset in filter
+std::optional<SBFDataPosition> ResolveSBFCursor(const SBF& sbf, int64_t cursor);
 
 struct SBFChunk {
   int64_t cursor;
@@ -177,5 +198,24 @@ class SBFDumpIterator {
   uint32_t filter_index_ = 0;
   size_t byte_offset_ = 0;
 };
+
+struct SBFDumpHeader {
+  double grow_factor;
+  double fp_prob;
+  uint64_t prev_size;
+  uint64_t current_size;
+  uint64_t max_capacity;
+
+  struct FilterMeta {
+    uint32_t hash_cnt;
+    uint64_t data_length;
+  };
+  std::vector<FilterMeta> filters;
+
+  // Creates SBF using current header data using given mr
+  SBF* Create(PMR_NS::memory_resource*);
+};
+
+std::optional<SBFDumpHeader> ParseSBFDumpHeader(std::string_view data);
 
 }  // namespace dfly

--- a/src/core/bloom.h
+++ b/src/core/bloom.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -144,6 +145,37 @@ class SBF {
   size_t prev_size_ = 0;
   size_t current_size_ = 0;
   size_t max_capacity_;
+};
+
+struct SBFChunk {
+  int64_t cursor;
+  std::string data;
+};
+
+class SBFDumpIterator {
+ public:
+  static constexpr uint64_t kMaxChunkSize = 16 * 1024 * 1024;
+
+  SBFDumpIterator(const SBF& sbf, int64_t cursor);
+
+  // Returns (next cursor, data between current and next cursor)
+  // Once the filter is fully read returns 0,""
+  SBFChunk Next();
+  bool Done() const;
+
+ private:
+  // On first call to Next(), serializes metadata. The SBF wide data is written first, then the per
+  // filter data in sequence (hash count and size per filter)
+  std::string SerializeHeader() const;
+  // Converts a cursor to the specific filter and the offset inside it
+  // O(n) in number of filters
+  void ResolveCursorToPos();
+
+  const SBF& sbf_;
+  int64_t cursor_;
+  bool header_sent_ = false;
+  uint32_t filter_index_ = 0;
+  size_t byte_offset_ = 0;
 };
 
 }  // namespace dfly

--- a/src/core/bloom_test.cc
+++ b/src/core/bloom_test.cc
@@ -88,6 +88,74 @@ TEST_F(BloomTest, SBF) {
   EXPECT_LE(collisions, kNumElems * 0.008);
 }
 
+TEST_F(BloomTest, DumpSBFInChunks) {
+  using namespace absl::little_endian;
+
+  SBF sbf(10, 0.001, 2, PMR_NS::get_default_resource());
+
+  constexpr unsigned kNumElems = 200;
+  for (unsigned i = 0; i < kNumElems; ++i) {
+    sbf.Add(absl::StrCat("item", i));
+  }
+
+  SBFDumpIterator it(sbf, 0);
+  std::vector<SBFChunk> chunks;
+  while (!it.Done())
+    chunks.push_back(it.Next());
+
+  // First chunk is the header with cursor=1
+  ASSERT_GE(chunks.size(), 2u);
+  EXPECT_EQ(chunks[0].cursor, 1);
+
+  const auto& header_data = chunks[0].data;
+  ASSERT_GE(header_data.size(), 48u);
+
+  const uint8_t* p = reinterpret_cast<const uint8_t*>(header_data.data());
+
+  // kSbfDumpVersion
+  EXPECT_EQ(Load32(p + 0), 1u);
+
+  EXPECT_DOUBLE_EQ(std::bit_cast<double>(Load64(p + 4)), sbf.grow_factor());
+  EXPECT_DOUBLE_EQ(std::bit_cast<double>(Load64(p + 12)), sbf.fp_probability());
+  EXPECT_EQ(Load64(p + 20), sbf.prev_size());
+  EXPECT_EQ(Load64(p + 28), sbf.current_size());
+  EXPECT_EQ(Load64(p + 36), sbf.max_capacity());
+
+  const uint32_t num_filters = Load32(p + 44);
+  EXPECT_EQ(num_filters, sbf.num_filters());
+
+  ASSERT_EQ(header_data.size(), 48u + num_filters * 12u);
+
+  std::vector<uint64_t> filter_sizes;
+  size_t filter_start_offset = 48u;
+
+  for (uint32_t i = 0; i < num_filters; ++i, filter_start_offset += 12) {
+    auto hash_cnt = Load32(p + filter_start_offset);
+    auto size = Load64(p + filter_start_offset + 4);
+
+    EXPECT_EQ(hash_cnt, sbf.hashfunc_cnt(i));
+    EXPECT_EQ(size, sbf.data(i).size());
+
+    filter_sizes.emplace_back(size);
+  }
+
+  // header is finished, read data
+  std::string all_data;
+  for (size_t i = 1; i < chunks.size(); ++i) {
+    all_data.append(chunks[i].data);
+  }
+
+  size_t offset = 0;
+  for (uint32_t i = 0; i < num_filters; ++i) {
+    const auto filter_size = filter_sizes[i];
+    ASSERT_LE(offset + filter_size, all_data.size());
+    string_view chunk_data(all_data.data() + offset, filter_size);
+    EXPECT_EQ(chunk_data, sbf.data(i));
+    offset += filter_size;
+  }
+  EXPECT_EQ(offset, all_data.size());
+}
+
 static void BM_BloomExist(benchmark::State& state) {
   constexpr size_t kCapacity = 1U << 22;
   Bloom bloom;

--- a/src/server/bloom_family.cc
+++ b/src/server/bloom_family.cc
@@ -168,6 +168,40 @@ void CmdMAdd(CmdArgList args, CommandContext* cmd_cntx) {
   }
 }
 
+void CmdScanDump(CmdArgList args, CommandContext* cmd_cntx) {
+  CmdArgParser parser(args);
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+  const string_view key = parser.Next();
+  const int64_t cursor = parser.Next<int64_t>();
+  if (cursor < 0)
+    return rb->SendError(kInvalidIntErr);
+
+  if (const auto err = parser.TakeError(); err)
+    return rb->SendError(err.MakeReply());
+
+  const auto cb = [&](Transaction* t, EngineShard* shard) -> OpResult<SBFChunk> {
+    const auto& db_slice = t->GetDbSlice(shard->shard_id());
+    OpResult op_res = db_slice.FindReadOnly(t->GetOpArgs(shard).db_cntx, key, OBJ_SBF);
+    if (!op_res)
+      return op_res.status();
+
+    const SBF* sbf = op_res.value()->second.GetSBF();
+    SBFDumpIterator it(*sbf, cursor);
+    return it.Next();
+  };
+
+  OpResult<SBFChunk> res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
+  if (!res) {
+    return rb->SendError(res.status());
+  }
+
+  RedisReplyBuilder::ArrayScope scope{rb, 2};
+  rb->SendLong(res->cursor);
+  if (res->cursor == 0)
+    DCHECK(res->data.empty()) << " scan ended with inconsistent state";
+  rb->SendBulkString(res->data);
+}
+
 void CmdMExists(CmdArgList args, CommandContext* cmd_cntx) {
   string_view key = ArgS(args, 0);
   args.remove_prefix(1);
@@ -200,7 +234,8 @@ void RegisterBloomFamily(CommandRegistry* registry) {
             << CI{"BF.MADD", CO::JOURNALED | CO::DENYOOM | CO::FAST, -3, 1, 1, acl::BLOOM}.HFUNC(
                    MAdd)
             << CI{"BF.EXISTS", CO::READONLY | CO::FAST, 3, 1, 1, acl::BLOOM}.HFUNC(Exists)
-            << CI{"BF.MEXISTS", CO::READONLY | CO::FAST, -3, 1, 1, acl::BLOOM}.HFUNC(MExists);
+            << CI{"BF.MEXISTS", CO::READONLY | CO::FAST, -3, 1, 1, acl::BLOOM}.HFUNC(MExists)
+            << CI{"BF.SCANDUMP", CO::READONLY, 3, 1, 1, acl::BLOOM}.HFUNC(ScanDump);
 };
 
 }  // namespace dfly

--- a/src/server/bloom_family.cc
+++ b/src/server/bloom_family.cc
@@ -202,6 +202,67 @@ void CmdScanDump(CmdArgList args, CommandContext* cmd_cntx) {
   rb->SendBulkString(res->data);
 }
 
+void CmdLoadChunk(CmdArgList args, CommandContext* cmd_cntx) {
+  CmdArgParser parser(args);
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+  string_view key = parser.Next();
+
+  const int64_t cursor = parser.Next<int64_t>();
+  if (const auto err = parser.TakeError(); err)
+    return rb->SendError(err.MakeReply());
+
+  if (cursor <= 0)
+    return rb->SendError(kInvalidIntErr);
+
+  string_view data = parser.Next();
+  std::optional<SBFDumpHeader> header;
+  if (cursor == 1) {
+    header = ParseSBFDumpHeader(data);
+    if (!header)
+      return rb->SendError("INVALIDOBJ invalid bloom dump payload");
+  }
+
+  const auto cb = [&](Transaction* t, EngineShard* shard) -> OpStatus {
+    auto op_args = t->GetOpArgs(shard);
+    auto& db_slice = op_args.GetDbSlice();
+
+    // First chunk contains metadata. use it to create empty SBF
+    if (cursor == 1) {
+      auto op_res = db_slice.AddOrFind(op_args.db_cntx, key, OBJ_SBF);
+      if (!op_res)
+        return op_res.status();
+
+      op_res->it->second.SetSBF(header->Create(CompactObj::memory_resource()));
+      return OpStatus::OK;
+    }
+
+    // >1 chunks contain data to write into filters at cursor position
+    auto op_res = db_slice.FindMutable(op_args.db_cntx, key, OBJ_SBF);
+    if (!op_res)
+      return op_res.status();
+
+    SBF* sbf = op_res->it->second.GetSBF();
+    int64_t write_cursor = cursor - static_cast<int64_t>(data.size());
+    auto pos = ResolveSBFCursor(*sbf, write_cursor);
+    if (!pos)
+      return OpStatus::OUT_OF_RANGE;
+
+    // The data supplied must fit in a single filter, not span multiple filters
+    if (const size_t filter_size = sbf->data(pos->filter_index).size();
+        pos->byte_offset + data.size() > filter_size)
+      return OpStatus::OUT_OF_RANGE;
+
+    memcpy(sbf->filter_data(pos->filter_index) + pos->byte_offset, data.data(), data.size());
+    return OpStatus::OK;
+  };
+
+  OpStatus res = cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));
+  if (res == OpStatus::OK) {
+    return rb->SendOk();
+  }
+  return rb->SendError(res);
+}
+
 void CmdMExists(CmdArgList args, CommandContext* cmd_cntx) {
   string_view key = ArgS(args, 0);
   args.remove_prefix(1);
@@ -228,14 +289,15 @@ using CI = CommandId;
 void RegisterBloomFamily(CommandRegistry* registry) {
   registry->StartFamily();
 
-  *registry << CI{"BF.RESERVE", CO::JOURNALED | CO::DENYOOM | CO::FAST, -4, 1, 1, acl::BLOOM}.HFUNC(
-                   Reserve)
-            << CI{"BF.ADD", CO::JOURNALED | CO::DENYOOM | CO::FAST, 3, 1, 1, acl::BLOOM}.HFUNC(Add)
-            << CI{"BF.MADD", CO::JOURNALED | CO::DENYOOM | CO::FAST, -3, 1, 1, acl::BLOOM}.HFUNC(
-                   MAdd)
-            << CI{"BF.EXISTS", CO::READONLY | CO::FAST, 3, 1, 1, acl::BLOOM}.HFUNC(Exists)
-            << CI{"BF.MEXISTS", CO::READONLY | CO::FAST, -3, 1, 1, acl::BLOOM}.HFUNC(MExists)
-            << CI{"BF.SCANDUMP", CO::READONLY, 3, 1, 1, acl::BLOOM}.HFUNC(ScanDump);
+  *registry
+      << CI{"BF.RESERVE", CO::JOURNALED | CO::DENYOOM | CO::FAST, -4, 1, 1, acl::BLOOM}.HFUNC(
+             Reserve)
+      << CI{"BF.ADD", CO::JOURNALED | CO::DENYOOM | CO::FAST, 3, 1, 1, acl::BLOOM}.HFUNC(Add)
+      << CI{"BF.MADD", CO::JOURNALED | CO::DENYOOM | CO::FAST, -3, 1, 1, acl::BLOOM}.HFUNC(MAdd)
+      << CI{"BF.EXISTS", CO::READONLY | CO::FAST, 3, 1, 1, acl::BLOOM}.HFUNC(Exists)
+      << CI{"BF.MEXISTS", CO::READONLY | CO::FAST, -3, 1, 1, acl::BLOOM}.HFUNC(MExists)
+      << CI{"BF.SCANDUMP", CO::READONLY, 3, 1, 1, acl::BLOOM}.HFUNC(ScanDump)
+      << CI{"BF.LOADCHUNK", CO::JOURNALED | CO::DENYOOM, 4, 1, 1, acl::BLOOM}.HFUNC(LoadChunk);
 };
 
 }  // namespace dfly

--- a/src/server/bloom_family_test.cc
+++ b/src/server/bloom_family_test.cc
@@ -48,4 +48,55 @@ TEST_F(BloomFamilyTest, Multiple) {
   EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(1), IntArg(1), IntArg(1))));
 }
 
+TEST_F(BloomFamilyTest, ScanDump) {
+  Run({"bf.reserve", "b1", "0.01", "1000"});
+  for (int i = 0; i < 100; ++i) {
+    Run({"bf.add", "b1", absl::StrCat("item", i)});
+  }
+
+  auto resp = Run({"bf.scandump", "b1", "0"});
+  auto vec = resp.GetVec();
+
+  ASSERT_EQ(vec.size(), 2u);
+  int64_t cursor = *vec[0].GetInt();
+
+  EXPECT_EQ(cursor, 1);
+  EXPECT_EQ(vec[1].type, RespExpr::STRING);
+
+  int chunk_count = 1;
+  while (cursor != 0) {
+    resp = Run({"bf.scandump", "b1", std::to_string(cursor)});
+    vec = resp.GetVec();
+    ASSERT_EQ(vec.size(), 2u);
+
+    const auto next_cursor = *vec[0].GetInt();
+    ASSERT_TRUE(next_cursor > cursor || next_cursor == 0);
+    cursor = next_cursor;
+
+    EXPECT_EQ(vec[1].type, RespExpr::STRING);
+    if (cursor != 0) {
+      ++chunk_count;
+      EXPECT_FALSE(vec[1].GetBuf().empty());
+    } else {
+      EXPECT_TRUE(vec[1].GetBuf().empty());
+    }
+  }
+
+  EXPECT_GE(chunk_count, 1);
+}
+
+TEST_F(BloomFamilyTest, ScanDumpPastEnd) {
+  Run({"bf.reserve", "b1", "0.01", "100"});
+  Run({"bf.add", "b1", "x"});
+
+  const auto resp = Run({"bf.scandump", "b1", "999999"});
+  const auto& vec = resp.GetVec();
+
+  ASSERT_EQ(vec.size(), 2u);
+
+  EXPECT_EQ(*vec[0].GetInt(), 0);
+  EXPECT_EQ(vec[1].type, RespExpr::STRING);
+  EXPECT_TRUE(vec[1].GetBuf().empty());
+}
+
 }  // namespace dfly

--- a/src/server/bloom_family_test.cc
+++ b/src/server/bloom_family_test.cc
@@ -48,41 +48,60 @@ TEST_F(BloomFamilyTest, Multiple) {
   EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(1), IntArg(1), IntArg(1))));
 }
 
-TEST_F(BloomFamilyTest, ScanDump) {
+TEST_F(BloomFamilyTest, ScanDumpAndLoadChunk) {
+  constexpr int kNumItems = 100;
+
   Run({"bf.reserve", "b1", "0.01", "1000"});
-  for (int i = 0; i < 100; ++i) {
+  for (int i = 0; i < kNumItems; ++i) {
     Run({"bf.add", "b1", absl::StrCat("item", i)});
   }
 
-  auto resp = Run({"bf.scandump", "b1", "0"});
-  auto vec = resp.GetVec();
+  struct Chunk {
+    int64_t cursor;
+    std::string data;
+  };
+  std::vector<Chunk> chunks;
 
-  ASSERT_EQ(vec.size(), 2u);
-  int64_t cursor = *vec[0].GetInt();
-
-  EXPECT_EQ(cursor, 1);
-  EXPECT_EQ(vec[1].type, RespExpr::STRING);
-
-  int chunk_count = 1;
-  while (cursor != 0) {
-    resp = Run({"bf.scandump", "b1", std::to_string(cursor)});
-    vec = resp.GetVec();
+  int64_t cursor = 0;
+  do {
+    auto resp = Run({"bf.scandump", "b1", std::to_string(cursor)});
+    const auto& vec = resp.GetVec();
     ASSERT_EQ(vec.size(), 2u);
 
-    const auto next_cursor = *vec[0].GetInt();
+    int64_t next_cursor = *vec[0].GetInt();
     ASSERT_TRUE(next_cursor > cursor || next_cursor == 0);
-    cursor = next_cursor;
 
-    EXPECT_EQ(vec[1].type, RespExpr::STRING);
-    if (cursor != 0) {
-      ++chunk_count;
+    if (next_cursor != 0) {
+      EXPECT_EQ(vec[1].type, RespExpr::STRING);
       EXPECT_FALSE(vec[1].GetBuf().empty());
-    } else {
-      EXPECT_TRUE(vec[1].GetBuf().empty());
+      chunks.push_back({next_cursor, vec[1].GetString()});
     }
-  }
+    cursor = next_cursor;
+  } while (cursor != 0);
 
-  EXPECT_GE(chunk_count, 1);
+  ASSERT_GE(chunks.size(), 2);
+
+  // Load the header separately
+  const auto& [crs, data] = chunks.front();
+  EXPECT_EQ(Run({"bf.loadchunk", "b2", std::to_string(crs), data}), "OK");
+
+  // Test that payload > filter size triggers validation failure
+  std::string oversized = chunks[1].data;
+  oversized.push_back('x');
+  EXPECT_THAT(Run({"bf.loadchunk", "b2", std::to_string(chunks[1].cursor), oversized}),
+              ErrArg("index out of range"));
+
+  // Load all data chunks into new key
+  for (auto it = chunks.begin() + 1; it != chunks.end(); ++it)
+    EXPECT_EQ(Run({"bf.loadchunk", "b2", std::to_string(it->cursor), it->data}), "OK")
+        << "failed to add cursor " << it->cursor;
+
+  for (int i = 0; i < kNumItems; ++i)
+    EXPECT_THAT(Run({"bf.exists", "b2", absl::StrCat("item", i)}), IntArg(1))
+        << "missing item " << i;
+  for (int i = kNumItems; i < kNumItems + 50; ++i)
+    EXPECT_THAT(Run({"bf.exists", "b2", absl::StrCat("item", i)}), IntArg(0))
+        << "false positive for item " << i;
 }
 
 TEST_F(BloomFamilyTest, ScanDumpPastEnd) {
@@ -97,6 +116,14 @@ TEST_F(BloomFamilyTest, ScanDumpPastEnd) {
   EXPECT_EQ(*vec[0].GetInt(), 0);
   EXPECT_EQ(vec[1].type, RespExpr::STRING);
   EXPECT_TRUE(vec[1].GetBuf().empty());
+}
+
+TEST_F(BloomFamilyTest, LoadChunkErrors) {
+  Run({"bf.reserve", "b1", "0.01", "100"});
+  Run({"bf.add", "b1", "x"});
+
+  EXPECT_THAT(Run({"bf.loadchunk", "b1", "0", "data"}), ErrArg("not an integer"));
+  EXPECT_THAT(Run({"bf.loadchunk", "b1", "-1", "data"}), ErrArg("not an integer"));
 }
 
 }  // namespace dfly


### PR DESCRIPTION
follow up PR after https://github.com/dragonflydb/dragonfly/pull/7092 is merged

implements LOADCHUNK command for SBF
creates a new SBF, then progressively loads data into its filters.

The command expects key,cursor,byte data

On cursor=1, the byte data is expected to be SBF metadata (fp, filter count etc). It is used to create a new empty SBF with all buffers preallocated and zeroed out.

Subsequent cursors will in the data at the specific positions in the buffers. The cursors and data are return values from previous SCANDUMP commands.

The filter should not be modified externally until the LOADCHUNK commands are finished.