### PR TITLE
feat(core): Introduce zero-alloc StreamNodeObj tagged pointer

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -26,7 +26,7 @@ add_subdirectory(page_usage)
 add_library(dfly_core allocation_tracker.cc bloom.cc topk.cc compact_object.cc cms.cc dense_set.cc
     dragonfly_core.cc extent_tree.cc huff_coder.cc
     interpreter.cc glob_matcher.cc mi_memory_resource.cc qlist.cc dict_builder.cc sds_utils.cc
-    segment_allocator.cc score_map.cc small_string.cc sorted_map.cc task_queue.cc
+    segment_allocator.cc score_map.cc small_string.cc sorted_map.cc stream_node.cc task_queue.cc
     tx_queue.cc string_set.cc string_map.cc tiering_types.cc top_keys.cc
     detail/bitpacking.cc detail/listpack_wrap.cc detail/listpack.cc
     oah_entry.cc)

--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -9,6 +9,8 @@
 
 #include <array>
 
+#include "core/stream_node.h"
+
 extern "C" {
 #include "redis/intset.h"
 #include "redis/listpack.h"
@@ -159,9 +161,8 @@ size_t MallocUsedStream(stream* s) {
   raxSeek(&ri, "^", NULL, 0);
   size_t lpsize = 0, samples = 0;
   while (raxNext(&ri)) {
-    uint8_t* lp = (uint8_t*)ri.data;
     /* Use the allocated size, since we overprovision the node initially. */
-    lpsize += zmalloc_size(lp);
+    lpsize += StreamNodeObj(ri.data).MallocSize();
     samples++;
   }
   if (s->rax->numele <= samples) {
@@ -175,7 +176,7 @@ size_t MallocUsedStream(stream* s) {
     raxSeek(&ri, "$", NULL, 0);
     raxNext(&ri);
     /* Use the allocated size, since we overprovision the node initially. */
-    asize += zmalloc_size(ri.data);
+    asize += StreamNodeObj(ri.data).MallocSize();
   }
   raxStop(&ri);
 
@@ -385,6 +386,12 @@ struct TL {
     return huffman_domain == CompactObj::HUFF_KEYS ? huff_keys.decoder : huff_string_values.decoder;
   }
 };
+
+// Callback function used in redis/t_stream.cc implementation to
+// extract listpack data from a stream rax entry.
+uint8_t* StreamNodeGetLp(const void* p) {
+  return StreamNodeObj(const_cast<void*>(p)).GetListpack();
+}
 
 thread_local TL tl;
 
@@ -1945,6 +1952,7 @@ stream* streamNew() {
   s->max_deleted_entry_id.ms = 0;
   s->entries_added = 0;
   s->cgroups = NULL; /* Created on demand to save memory when not used. */
+  s->getNodeLp = StreamNodeGetLp;
   return s;
 }
 
@@ -1973,13 +1981,13 @@ static void streamFreeCGVoid(void* cg_) {
   zfree(cg);
 }
 
-static void lpFreeVoid(void* lp) {
-  lpFree((uint8_t*)lp);
-}
-
-/* Free a stream, including the listpacks stored inside the radix tree. */
+/* Free a stream, including the listpack nodes stored inside the radix tree. */
 void freeStream(stream* s) {
-  raxFreeWithCallback(s->rax, lpFreeVoid);
+  raxFreeWithCallback(s->rax, [](void* p) {
+    if (p) {
+      StreamNodeObj(p).Free();
+    }
+  });
   if (s->cgroups)
     raxFreeWithCallback(s->cgroups, streamFreeCGVoid);
   zfree(s);

--- a/src/core/stream_node.cc
+++ b/src/core/stream_node.cc
@@ -1,0 +1,33 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#include "core/stream_node.h"
+
+#include "base/logging.h"
+
+extern "C" {
+#include "redis/listpack.h"
+#include "redis/zmalloc.h"
+}
+
+namespace dfly {
+
+uint8_t* StreamNodeObj::GetListpack() const {
+  DCHECK(IsRaw());
+  return Ptr();
+}
+
+uint32_t StreamNodeObj::UncompressedSize() const {
+  DCHECK(IsRaw());
+  return static_cast<uint32_t>(lpBytes(Ptr()));
+}
+
+void StreamNodeObj::Free() const {
+  zfree(Ptr());
+}
+
+size_t StreamNodeObj::MallocSize() const {
+  return zmalloc_size(Ptr());
+}
+
+}  // namespace dfly

--- a/src/core/stream_node.h
+++ b/src/core/stream_node.h
@@ -1,0 +1,69 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#pragma once
+
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+
+namespace dfly {
+
+// StreamNodeObj represents a stream node stored in the rax tree.
+//
+// Each node is:
+//   - Raw: a pointer to a listpack
+//
+// The representation is explicit and zero-copy.
+class StreamNodeObj {
+ public:
+  static constexpr uintptr_t kTagMask = 1ULL << 52;
+
+  // Construct from a raw tagged value retrieved from the rax tree.
+  explicit StreamNodeObj(void* p = nullptr) : ptr_(reinterpret_cast<uintptr_t>(p)) {
+  }
+
+  bool operator==(StreamNodeObj other) const {
+    return ptr_ == other.ptr_;
+  }
+  bool operator!=(StreamNodeObj other) const {
+    return ptr_ != other.ptr_;
+  }
+
+  static StreamNodeObj Raw(const uint8_t* lp) {
+    StreamNodeObj r;
+    r.ptr_ = reinterpret_cast<uintptr_t>(lp);
+    return r;
+  }
+
+  bool IsRaw() const {
+    return (ptr_ & kTagMask) == 0;
+  }
+
+  // Raw pointer with tag bits stripped.
+  uint8_t* Ptr() const {
+    return std::bit_cast<uint8_t*>(ptr_ & ~kTagMask);
+  }
+
+  // Raw tagged pointer
+  void* Get() const {
+    return std::bit_cast<void*>(ptr_);
+  }
+
+  // Returns the uncompressed listpack pointer.
+  uint8_t* GetListpack() const;
+
+  // Uncompressed listpack size in bytes.
+  uint32_t UncompressedSize() const;
+
+  // Frees the node's underlying pointer
+  void Free() const;
+
+  // Total allocated bytes for this node.
+  size_t MallocSize() const;
+
+ private:
+  uintptr_t ptr_;
+};
+
+}  // namespace dfly

--- a/src/redis/stream.h
+++ b/src/redis/stream.h
@@ -26,6 +26,7 @@ typedef struct stream {
     streamID max_deleted_entry_id; /* The maximal ID that was deleted. */
     uint64_t entries_added;        /* All time count of elements added. */
     struct rax *cgroups;                  /* Consumer groups dictionary: name -> streamCG */
+    unsigned char *(*getNodeLp)(const void *node); /* Stream node data to a listpack. */
 } stream;
 
 /* We define an iterator to iterate stream items in an abstract way, without

--- a/src/redis/t_stream.c
+++ b/src/redis/t_stream.c
@@ -205,7 +205,7 @@ int streamIteratorGetID(streamIterator *si, streamID *id, int64_t *numfields) {
             /* Get the master ID. */
             streamDecodeID(si->ri.key,&si->master_id);
             /* Get the master fields count. */
-            si->lp = si->ri.data;
+            si->lp = si->stream->getNodeLp(si->ri.data);  /* Get raw listpack from stream node. */
             si->lp_ele = lpFirst(si->lp);           /* Seek items count */
             si->lp_ele = lpNext(si->lp,si->lp_ele); /* Seek deleted count. */
             si->lp_ele = lpNext(si->lp,si->lp_ele); /* Seek num fields. */

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -759,7 +759,6 @@ void RdbLoaderBase::OpaqueObjLoader::CreateStream(const LoadTrace* ltrace) {
     CHECK(lpFirst(lp) != NULL);
     uint8_t* copy_lp = (uint8_t*)zmalloc(data.size());
     ::memcpy(copy_lp, lp, data.size());
-    /* Insert the key in the radix tree. */
     int retval =
         raxTryInsert(s->rax, (unsigned char*)nodekey.data(), nodekey.size(), copy_lp, NULL);
     if (!retval) {

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -767,6 +767,7 @@ void RdbLoaderBase::OpaqueObjLoader::CreateStream(const LoadTrace* ltrace) {
     CHECK(lpFirst(lp) != NULL);
     uint8_t* copy_lp = (uint8_t*)zmalloc(data.size());
     ::memcpy(copy_lp, lp, data.size());
+    /* Insert the key in the radix tree. */
     int retval =
         raxTryInsert(s->rax, (unsigned char*)nodekey.data(), nodekey.size(), copy_lp, NULL);
     if (!retval) {

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -767,7 +767,6 @@ void RdbLoaderBase::OpaqueObjLoader::CreateStream(const LoadTrace* ltrace) {
     CHECK(lpFirst(lp) != NULL);
     uint8_t* copy_lp = (uint8_t*)zmalloc(data.size());
     ::memcpy(copy_lp, lp, data.size());
-    /* Insert the key in the radix tree. */
     int retval =
         raxTryInsert(s->rax, (unsigned char*)nodekey.data(), nodekey.size(), copy_lp, NULL);
     if (!retval) {

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -11,6 +11,8 @@
 #include <bit>
 #include <queue>
 
+#include "core/stream_node.h"
+
 extern "C" {
 #include "redis/crc64.h"
 #include "redis/intset.h"
@@ -566,8 +568,9 @@ error_code RdbSerializer::SaveStreamObject(const PrimeValue& pv) {
   auto stop_listpacks_rax = absl::MakeCleanup([&] { raxStop(&ri); });
 
   for (size_t i = 0; raxNext(&ri); i++) {
-    uint8_t* lp = (uint8_t*)ri.data;
-    size_t lp_bytes = lpBytes(lp);
+    StreamNodeObj node(ri.data);
+    uint8_t* lp = node.GetListpack();
+    size_t lp_bytes = node.UncompressedSize();
 
     RETURN_ON_ERR(SaveString((uint8_t*)ri.key, ri.key_len));
     RETURN_ON_ERR(SaveString(lp, lp_bytes));

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -8,6 +8,8 @@
 #include <absl/strings/ascii.h>
 #include <absl/strings/str_cat.h>
 
+#include "core/stream_node.h"
+
 extern "C" {
 #include "redis/redis_aux.h"
 #include "redis/stream.h"
@@ -166,6 +168,7 @@ int64_t LpGetInteger(uint8_t* ele) {
 }
 
 void StreamIteratorRemoveEntry(streamIterator* si, streamID* current) {
+  StreamNodeObj node(si->ri.data);
   uint8_t* lp = static_cast<uint8_t*>(si->lp);
   int64_t aux;
 
@@ -177,7 +180,7 @@ void StreamIteratorRemoveEntry(streamIterator* si, streamID* current) {
   aux = LpGetInteger(p);
 
   if (aux == 1) {
-    lpFree(lp);
+    node.Free();
     checkedRaxRemove(si->stream->rax, si->ri.key, si->ri.key_len, NULL);
   } else {
     lp = lpReplaceInteger(lp, &p, aux - 1);
@@ -185,7 +188,7 @@ void StreamIteratorRemoveEntry(streamIterator* si, streamID* current) {
     aux = LpGetInteger(p);
     lp = lpReplaceInteger(lp, &p, aux + 1);
     if (si->lp != lp)
-      raxInsert(si->stream->rax, si->ri.key, si->ri.key_len, lp, NULL);
+      raxInsert(si->stream->rax, si->ri.key, si->ri.key_len, lp, nullptr);
     CHECK_GT(lpBytes(lp), 0u);
   }
 
@@ -368,8 +371,9 @@ int64_t StreamTrim(stream* s, streamAddTrimArgs* args) {
     if (trim_strategy == TRIM_STRATEGY_MAXLEN && s->length <= maxlen)
       break;
 
-    uint8_t* lp = static_cast<uint8_t*>(ri.data);
-    CHECK_GT(lpBytes(lp), 0u);
+    StreamNodeObj node(ri.data);
+    uint8_t* lp = node.GetListpack();
+    CHECK_GT(node.UncompressedSize(), 0u);
     uint8_t* p = lpFirst(lp);
     int64_t entries = LpGetInteger(p);
 
@@ -388,7 +392,7 @@ int64_t StreamTrim(stream* s, streamAddTrimArgs* args) {
     }
 
     if (remove_node) {
-      lpFree(lp);
+      node.Free();
       checkedRaxRemove(s->rax, ri.key, ri.key_len, NULL);
       raxSeek(&ri, ">=", ri.key, ri.key_len);
       s->length -= entries;
@@ -463,8 +467,7 @@ int64_t StreamTrim(stream* s, streamAddTrimArgs* args) {
     p = lpNext(lp, p);
     int64_t marked_deleted = LpGetInteger(p);
     lp = lpReplaceInteger(lp, &p, marked_deleted + deleted_from_lp);
-
-    raxInsert(s->rax, ri.key, ri.key_len, lp, NULL);
+    raxInsert(s->rax, ri.key, ri.key_len, lp, nullptr);
     CHECK_GT(lpBytes(lp), 0u);
     break;
   }
@@ -909,10 +912,13 @@ int StreamAppendItem(stream* s, CmdArgList fields, uint64_t now_ms, streamID* ad
   uint8_t rax_key[16]; /* Key in the radix tree containing the listpack.*/
   streamID master_id;  /* ID of the master entry in the listpack. */
 
+  uint8_t* current_node = nullptr;  // Pointer to the current tail node listpack, if any.
+
   if (!raxEOF(&ri)) {
     /* Get a reference to the tail node listpack. */
-    lp = (uint8_t*)ri.data;
-    lp_bytes = lpBytes(lp);
+    current_node = StreamNodeObj(ri.data).Ptr();
+    lp = current_node;
+    lp_bytes = lpBytes(current_node);
     CHECK_GT(lp_bytes, 0U);
     DCHECK(ri.key_len == sizeof(rax_key));
     memcpy(rax_key, ri.key, sizeof(rax_key));
@@ -955,10 +961,7 @@ int StreamAppendItem(stream* s, CmdArgList fields, uint64_t now_ms, streamID* ad
    * the current node is full. */
   if (lp != NULL) {
     int new_node = 0;
-    size_t node_max_bytes = kStreamNodeMaxBytes;
-    if (node_max_bytes == 0 || node_max_bytes > STREAM_LISTPACK_MAX_SIZE)
-      node_max_bytes = STREAM_LISTPACK_MAX_SIZE;
-    if (lp_bytes + totelelen >= node_max_bytes) {
+    if (lp_bytes + totelelen >= kStreamNodeMaxBytes) {
       new_node = 1;
     } else if (kStreamNodeMaxEntries) {
       unsigned char* lp_ele = lpFirst(lp);
@@ -975,15 +978,16 @@ int StreamAppendItem(stream* s, CmdArgList fields, uint64_t now_ms, streamID* ad
       if (ri.key_len != sizeof(rax_key) || memcmp(ri.key, rax_key, sizeof(rax_key)) != 0) {
         LOG(DFATAL) << "StreamAppendItem: Key mismatch";
       }
-      if (ri.data != lp)
-        raxInsert(s->rax, ri.key, ri.key_len, lp, NULL);
+      if (lp != current_node) {
+        raxInsert(s->rax, rax_key, sizeof(rax_key), lp, nullptr);
+      }
+      current_node = nullptr;
       lp = NULL;
     }
   }
 
   int flags = 0;
   unsigned numfields = fields.size() / 2;
-  uint8_t* old_lp = lp;
   if (lp == NULL) {
     master_id = id;
     StreamEncodeID(rax_key, id);
@@ -1005,8 +1009,8 @@ int StreamAppendItem(stream* s, CmdArgList fields, uint64_t now_ms, streamID* ad
       lp = lpAppend(lp, SafePtr(field), field.size());
     }
     lp = lpAppendInteger(lp, 0); /* Master entry zero terminator. */
-    raxInsert(s->rax, (unsigned char*)&rax_key, sizeof(rax_key), lp, NULL);
-    old_lp = lp;
+    raxInsert(s->rax, rax_key, sizeof(rax_key), lp, nullptr);
+    current_node = lp;
     /* The first entry we insert, has obviously the same fields of the
      * master entry. */
     flags |= STREAM_ITEM_FLAG_SAMEFIELDS;
@@ -1092,8 +1096,8 @@ int StreamAppendItem(stream* s, CmdArgList fields, uint64_t now_ms, streamID* ad
   lp = lpAppendInteger(lp, lp_count);
 
   /* Insert back into the tree in order to update the listpack pointer. */
-  if (old_lp != lp) {
-    raxInsert(s->rax, (unsigned char*)&rax_key, sizeof(rax_key), lp, NULL);
+  if (lp != current_node) {
+    raxInsert(s->rax, rax_key, sizeof(rax_key), lp, nullptr);
   }
   s->length++;
   s->entries_added++;
@@ -1101,8 +1105,7 @@ int StreamAppendItem(stream* s, CmdArgList fields, uint64_t now_ms, streamID* ad
 
   // Must find the last entry as we just inserted it.
   CHECK_EQ(1, raxSeek(&ri, "$", NULL, 0));
-  lp_bytes = lpBytes((uint8_t*)ri.data);
-  CHECK_GT(lp_bytes, 0U);
+  CHECK_GT(lpBytes(lp), 0U);
   raxStop(&ri);
 
   if (s->length == 1)
@@ -2092,8 +2095,7 @@ ErrorReply OpXSetId(const OpArgs& op_args, string_view key, const streamID& sid)
 
   if (!raxEOF(&ri)) {
     /* Get a reference to the tail node listpack. */
-    size_t lp_bytes = lpBytes((uint8_t*)ri.data);
-    CHECK_GT(lp_bytes, 0U);
+    CHECK_GT(StreamNodeObj(ri.data).UncompressedSize(), 0U);
   }
   raxStop(&ri);
 


### PR DESCRIPTION
Replace raw ri.data casts throughout the stream code with StreamNodeObj,
a zero-alloc value type wrapping the void* stored in stream rax nodes.

The class uses a tag bit scheme (bit 52) to distinguish encodings,
laying the groundwork for future compressed or tiered node types without
changing the rax storage layout.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
