### PR TITLE
fix(sort): delete destination key when SORT STORE produces empty result

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1725,6 +1725,15 @@ OpResult<uint32_t> OpStore(const OpArgs& op_args, std::string_view key, Iterator
   }
   len = ql_v2->Size();
 
+  if (len == 0) {
+    CompactObj::DeleteMR<QList>(ql_v2);
+    auto it_res = op_args.GetDbSlice().FindMutable(op_args.db_cntx, key);
+    if (IsValid(it_res.it)) {
+      op_args.GetDbSlice().DelMutable(op_args.db_cntx, std::move(it_res));
+    }
+    return 0;
+  }
+
   PrimeValue pv;
   pv.InitRobj(OBJ_LIST, kEncodingQL2, ql_v2);
 

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -880,6 +880,23 @@ TEST_F(GenericFamilyTest, SortStore) {
               ElementsAre("1.2", "2.20", "3.5", "10.1", "200"));
 }
 
+// Regression test for SORT ... STORE with empty result must delete destination key,
+// not leave an empty list which crashes SAVE (DFATAL in rdb_save.cc).
+TEST_F(GenericFamilyTest, SortStoreEmptyResult) {
+  Run({"lpush", "list-src", "3", "1", "2"});
+
+  // LIMIT offset beyond list length -> empty result
+  auto resp = Run({"sort", "list-src", "LIMIT", "10", "5", "store", "dest"});
+  EXPECT_EQ(0, resp.GetInt());
+  EXPECT_EQ(0, Run({"exists", "dest"}).GetInt()) << "empty SORT STORE must not leave a key";
+
+  // LIMIT count=0 -> empty result
+  Run({"set", "dest", "old"});  // pre-existing key should be deleted
+  resp = Run({"sort", "list-src", "LIMIT", "0", "0", "store", "dest"});
+  EXPECT_EQ(0, resp.GetInt());
+  EXPECT_EQ(0, Run({"exists", "dest"}).GetInt()) << "empty SORT STORE must delete existing key";
+}
+
 TEST_F(GenericFamilyTest, SortStoreResetsExpiry) {
   // SORT set STORE dest, where dest has an expiry — dest expiry must be cleared.
   Run({"del", "src", "dest"});


### PR DESCRIPTION
- SORT ... STORE with an empty result (e.g. LIMIT offset beyond list size) stored an empty QList in the database instead of deleting the destination key
- Empty OBJ_LIST with ROBJ_TAG is not allowed by `TagAllowsEmptyValue()`, so SAVE/BGSAVE crashed with DFATAL in `RdbSerializer::SaveEntry()`
- Now `OpStore` checks for empty result: frees the QList and deletes the destination key

Fixes #7105