### PR TITLE
fix: handle STORE in unsorted path (SORT BY nosort STORE)

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -2124,7 +2124,7 @@ void SortGeneric(CmdArgList args, CommandContext* cmd_cntx, bool is_read_only) {
     return;
   }
 
-  // No sorting required, just reply with fetched raw elements (with LIMIT if any)
+  // No sorting required — either reply with raw elements or store them.
   DVLOG(1) << "Replying with unsorted " << raw_elements.size() << " elements from key " << key;
   DCHECK(!raw_elements.empty());
 
@@ -2141,6 +2141,46 @@ void SortGeneric(CmdArgList args, CommandContext* cmd_cntx, bool is_read_only) {
         [&](size_t elem_idx, size_t pattern_idx, string value) {
           get_values_per_element[elem_idx][pattern_idx] = std::move(value);
         });
+  }
+
+  if (params.store_key) {
+    // STORE path: build SortEntryBase vector from raw elements (with GET pattern
+    // values when present) and reuse OpStore — same as the sorted STORE path.
+    auto [start_it, end_it] = GetSortRange(raw_elements, params.bounds);
+    size_t start_idx = start_it - raw_elements.begin();
+    size_t count = end_it - start_it;
+
+    vector<SortEntryBase> entries;
+    entries.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+      SortEntryBase entry;
+      entry.key = std::move(raw_elements[start_idx + i]);
+      if (!get_values_per_element.empty()) {
+        entry.get_values = std::move(get_values_per_element[start_idx + i]);
+      }
+      entries.push_back(std::move(entry));
+    }
+
+    string_view store_key_sv = params.store_key.value();
+    ShardId dest_sid = Shard(store_key_sv, shard_set->size());
+    OpResult<uint32_t> store_len;
+    bool has_get_patterns = !params.get_patterns.empty();
+
+    auto store_cb = [&](Transaction* t, EngineShard* shard) {
+      if (shard->shard_id() == dest_sid) {
+        store_len = OpStore(t->GetOpArgs(shard), store_key_sv, entries.begin(), entries.end(),
+                            has_get_patterns);
+      }
+      return OpStatus::OK;
+    };
+    cmd_cntx->tx()->Execute(std::move(store_cb), true);
+
+    if (store_len) {
+      cmd_cntx->SendLong(store_len.value());
+    } else {
+      cmd_cntx->SendError(store_len.status());
+    }
+    return;
   }
 
   auto replier = [raw_elements = std::move(raw_elements), params, source_type,

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -8,6 +8,7 @@ extern "C" {
 #include "redis/rdb.h"
 }
 
+#include "base/flags.h"
 #include "base/gtest.h"
 #include "base/logging.h"
 #include "facade/facade_test.h"
@@ -15,6 +16,8 @@ extern "C" {
 #include "server/engine_shard_set.h"
 #include "server/test_utils.h"
 #include "server/transaction.h"
+
+ABSL_DECLARE_FLAG(bool, multi_exec_squash);
 
 using namespace testing;
 using namespace std;
@@ -1758,6 +1761,34 @@ TEST_F(GenericFamilyTest, RmDeletesMatchingKeys) {
   EXPECT_EQ(Run({"exists", "foo0"}), 0);
   EXPECT_EQ(Run({"exists", "bar0"}), 1);
   EXPECT_EQ(Run({"dbsize"}), 5);
+}
+
+// Regression test for SORT BY nosort STORE inside MULTI/EXEC does a
+// non-concluding Execute() hop to fetch elements, then falls through to the
+// unsorted reply path without a concluding hop or Conclude().
+// This leaves the parent transaction as continuation_trans_ on the shard.
+// When the EXEC transaction is later destroyed, continuation_trans_ becomes
+// a dangling pointer, crashing in DisarmInShard() on the next EXEC.
+TEST_F(GenericFamilyTest, SortByNosortStoreInMulti) {
+  absl::FlagSaver fs;
+  absl::SetFlag(&FLAGS_multi_exec_squash, true);
+
+  Run({"lpush", "mylist", "c", "b", "a"});
+
+  // SORT BY nosort STORE goes through ExecuteStandalone (multi-key, possibly
+  // cross-shard) and calls Execute(fetch_cb, conclude=false) on the parent
+  // EXEC transaction but never concludes it.
+  for (int i = 0; i < 10; ++i) {
+    Run({"multi"});
+    Run({"set", "x", StrCat(i)});
+    Run({"sort", "mylist", "BY", "nosort", "STORE", "dest"});
+    auto resp = Run({"exec"});
+    ASSERT_THAT(resp, ArrLen(2));
+  }
+
+  // Verify the store actually happened and the server is healthy.
+  EXPECT_THAT(Run({"lrange", "dest", "0", "-1"}), ArrLen(3));
+  EXPECT_EQ(Run({"get", "x"}), "9");
 }
 
 }  // namespace dfly


### PR DESCRIPTION
SORT with `BY nosort STORE dest` hit a code path (`fetch_unsorted=true`, `to_sort=false`) that fetched elements but never executed the STORE hop - it fell through to the reply-only branch, silently discarding the STORE option.

This had two consequences:
1. **Data loss**: the destination key was never written.
2. **Crash (Fixes #7107)**: when executed inside MULTI/EXEC with squashing, the first fetch hop called `Execute(cb, conclude=false)` on the parent transaction, but the missing concluding hop left it as `continuation_trans_` on the shard. After the EXEC transaction was destroyed, `continuation_trans_` became a dangling pointer, crashing in `Transaction::DisarmInShard()` on the next EXEC.

The fix adds a store hop with `Execute(cb, true)` for the unsorted+STORE path, matching what `SortVisitor` already does for the sorted+STORE path.