### PR TITLE
feat: search memory now more accurately reported

### DIFF
--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -661,7 +661,16 @@ const vector<DocId>& FieldIndices::GetAllDocs() const {
 }
 
 size_t FieldIndices::GetNonPmrMemoryUsage() const {
-  return all_ids_.capacity() * sizeof(DocId);
+  // all_ids_ scales with document count — the dominant untracked cost.
+  size_t mem = all_ids_.capacity() * sizeof(DocId);
+  // Hash map bucket arrays scale with field count (typically small).
+  constexpr size_t kIndicesSlotSize =
+      sizeof(absl::flat_hash_map<std::string_view, std::unique_ptr<BaseIndex>>::value_type) + 1;
+  constexpr size_t kSortSlotSize =
+      sizeof(absl::flat_hash_map<std::string_view, std::unique_ptr<BaseSortIndex>>::value_type) + 1;
+  mem += indices_.bucket_count() * kIndicesSlotSize;
+  mem += sort_indices_.bucket_count() * kSortSlotSize;
+  return mem;
 }
 
 const Schema& FieldIndices::GetSchema() const {

--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -660,6 +660,10 @@ const vector<DocId>& FieldIndices::GetAllDocs() const {
   return all_ids_;
 }
 
+size_t FieldIndices::GetNonPmrMemoryUsage() const {
+  return all_ids_.capacity() * sizeof(DocId);
+}
+
 const Schema& FieldIndices::GetSchema() const {
   return schema_;
 }

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -150,12 +150,17 @@ class FieldIndices {
 
   DefragmentResult Defragment(PageUsage* page_usage);
 
+  // Returns memory used by containers with default allocator, not tracked through search local_mr_
+  size_t GetNonPmrMemoryUsage() const;
+
  private:
   void CreateIndices(PMR_NS::memory_resource* mr);
   void CreateSortIndices();
 
   const Schema& schema_;
   const IndicesOptions& options_;
+  // NOTE: all_ids_ uses default allocator — tracked manually via GetNonPmrMemoryUsage().
+  // If adding new untracked containers, update GetNonPmrMemoryUsage() accordingly.
   std::vector<DocId> all_ids_;
   absl::flat_hash_map<std::string_view, std::unique_ptr<BaseIndex>> indices_;
   absl::flat_hash_map<std::string_view, std::unique_ptr<BaseSortIndex>> sort_indices_;

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -159,8 +159,8 @@ class FieldIndices {
 
   const Schema& schema_;
   const IndicesOptions& options_;
-  // NOTE: all_ids_ uses default allocator — tracked manually via GetNonPmrMemoryUsage().
-  // If adding new untracked containers, update GetNonPmrMemoryUsage() accordingly.
+  // These containers use default allocators — tracked manually via GetNonPmrMemoryUsage().
+  // If adding new default-allocator containers, update GetNonPmrMemoryUsage() accordingly.
   std::vector<DocId> all_ids_;
   absl::flat_hash_map<std::string_view, std::unique_ptr<BaseIndex>> indices_;
   absl::flat_hash_map<std::string_view, std::unique_ptr<BaseSortIndex>> sort_indices_;

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -1168,7 +1168,6 @@ unique_ptr<ShardDocIndex> ShardDocIndices::DropIndex(string_view name) {
   DropIndexCache(*it->second);
   auto index = std::move(it->second);
   indices_.erase(it);
-
   return index;
 }
 

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -1172,10 +1172,16 @@ unique_ptr<ShardDocIndex> ShardDocIndices::DropIndex(string_view name) {
 }
 
 void ShardDocIndices::DropAllIndices() {
-  for (const auto& [_, idx] : indices_)
+  // Move indices out before destroying — ShardDocIndex destructors can yield
+  // (CancelBuilder joins a fiber), and destroying inside the map would trigger
+  // Abseil's reentrance assert if the heartbeat iterates indices_ mid-clear.
+  decltype(indices_) to_destroy;
+  std::swap(to_destroy, indices_);
+  for (auto& [_, idx] : to_destroy) {
     DropIndexCache(*idx);
-  indices_.clear();
+  }
   GlobalHnswIndexRegistry::Instance().Reset();
+  // to_destroy goes out of scope here — destructors run outside the map mutation
 }
 
 void ShardDocIndices::DropIndexCache(const dfly::ShardDocIndex& shard_doc_index) {

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -291,7 +291,7 @@ std::optional<ShardDocIndex::DocId> ShardDocIndex::DocKeyIndex::Find(string_view
 }
 
 void ShardDocIndex::DocKeyIndex::Remove(DocId id) {
-  ids_.extract(keys_[id]);
+  ids_.erase(std::string_view(keys_[id]));
   keys_[id] = "";
   free_ids_.push_back(id);
 }
@@ -323,7 +323,7 @@ std::vector<std::pair<std::string, search::DocId>> ShardDocIndex::DocKeyIndex::S
   result.reserve(ids_.size());
   for (search::DocId id = 0; id < keys_.size(); ++id) {
     if (!keys_[id].empty()) {
-      result.emplace_back(keys_[id], id);
+      result.emplace_back(std::string(keys_[id]), id);
     }
   }
   return result;
@@ -344,7 +344,7 @@ void ShardDocIndex::DocKeyIndex::Restore(
 
   // Restore the mappings
   for (const auto& [key, doc_id] : mappings) {
-    keys_[doc_id] = key;
+    keys_[doc_id].assign(key.data(), key.size());
     ids_[key] = doc_id;
   }
 
@@ -360,8 +360,9 @@ void ShardDocIndex::DocKeyIndex::Restore(const std::vector<std::string>& keys) {
   DCHECK(ids_.empty()) << "Restore should only be called on an empty DocKeyIndex";
   keys_.resize(keys.size());
   for (DocId id = 0; id < static_cast<DocId>(keys.size()); ++id) {
-    keys_[id] = keys[id];
-    ids_[keys[id]] = id;
+    keys_[id].assign(keys[id].data(), keys[id].size());
+    std::string_view sv(keys[id]);
+    ids_[sv] = id;
   }
   last_id_ = static_cast<DocId>(keys.size());
 }
@@ -1105,6 +1106,13 @@ ShardDocIndex::FieldsValuesPerDocId ShardDocIndex::LoadKeysData(
   return result;
 }
 
+size_t ShardDocIndex::GetNonPmrMemoryUsage() const {
+  size_t mem = 0;
+  if (indices_)
+    mem += indices_->GetNonPmrMemoryUsage();
+  return mem;
+}
+
 DocIndexInfo ShardDocIndex::GetInfo() const {
   return {.base_index = *base_,
           .num_docs = key_index_.Size(),
@@ -1241,7 +1249,10 @@ void ShardDocIndices::RemoveDoc(string_view key, const DbContext& db_cntx, Prime
 }
 
 size_t ShardDocIndices::GetUsedMemory() const {
-  return local_mr_.used();
+  size_t mem = local_mr_.used();
+  for (const auto& [_, index] : indices_)
+    mem += index->GetNonPmrMemoryUsage();
+  return mem;
 }
 
 SearchStats ShardDocIndices::GetStats() const {

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -308,7 +308,7 @@ bool ShardDocIndex::DocKeyIndex::IsValid(DocId id) const {
   if (id >= last_id_ || id >= keys_.size())
     return false;
   // Check if the key at this slot is still tracked in the reverse map with the same id.
-  // This correctly handles empty keys: freed slots have their key extracted from ids_,
+  // This correctly handles empty keys: freed slots have their key erased from ids_,
   // while valid empty-key docs still have ids_[""] == id.
   auto it = ids_.find(keys_[id]);
   return it != ids_.end() && it->second == id;
@@ -342,10 +342,11 @@ void ShardDocIndex::DocKeyIndex::Restore(
   keys_.resize(max_id + 1);
   last_id_ = max_id + 1;
 
-  // Restore the mappings
+  // Restore the mappings — insert into ids_ using keys_[doc_id] (the persistent
+  // StatelessString storage) to avoid implicit cross-allocator conversion from std::string.
   for (const auto& [key, doc_id] : mappings) {
     keys_[doc_id].assign(key.data(), key.size());
-    ids_[key] = doc_id;
+    ids_[std::string_view(keys_[doc_id])] = doc_id;
   }
 
   // Build free_ids_ list for any gaps in the id sequence
@@ -361,8 +362,7 @@ void ShardDocIndex::DocKeyIndex::Restore(const std::vector<std::string>& keys) {
   keys_.resize(keys.size());
   for (DocId id = 0; id < static_cast<DocId>(keys.size()); ++id) {
     keys_[id].assign(keys[id].data(), keys[id].size());
-    std::string_view sv(keys[id]);
-    ids_[sv] = id;
+    ids_[std::string_view(keys_[id])] = id;
   }
   last_id_ = static_cast<DocId>(keys.size());
 }

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -18,6 +18,7 @@
 #include "core/search/base.h"
 #include "core/search/hnsw_index.h"
 #include "core/search/search.h"
+#include "core/search/sort_indices.h"
 #include "core/search/synonyms.h"
 #include "server/search/aggregator.h"
 #include "server/search/index_join.h"
@@ -286,6 +287,24 @@ class ShardDocIndex {
 
   // DocKeyIndex manages mapping document keys to ids and vice versa through a simple interface.
   struct DocKeyIndex {
+    // Hash/Eq for heterogeneous lookup on TrackedIdsMap with string_view keys.
+    struct StringViewHash {
+      using is_transparent = void;
+      size_t operator()(std::string_view sv) const {
+        return absl::HashOf(sv);
+      }
+    };
+    struct StringViewEq {
+      using is_transparent = void;
+      bool operator()(std::string_view a, std::string_view b) const {
+        return a == b;
+      }
+    };
+
+    using TrackedIdsMap = absl::flat_hash_map<
+        search::StatelessString, DocId, StringViewHash, StringViewEq,
+        StatelessSearchAllocator<std::pair<const search::StatelessString, DocId>>>;
+
     DocId Add(std::string_view key);
 
     // Like Add but always allocates a fresh DocId, never reusing free_ids_.
@@ -299,8 +318,7 @@ class ShardDocIndex {
     std::optional<DocId> Find(std::string_view key) const;
     size_t Size() const;
 
-    // Get const reference to the internal ids map
-    const absl::flat_hash_map<std::string, DocId>& GetDocKeysMap() const {
+    const TrackedIdsMap& GetDocKeysMap() const {
       return ids_;
     }
 
@@ -314,9 +332,9 @@ class ShardDocIndex {
     void Restore(const std::vector<std::string>& keys);
 
    private:
-    absl::flat_hash_map<std::string, DocId> ids_;
-    std::vector<std::string> keys_;
-    std::vector<DocId> free_ids_;
+    TrackedIdsMap ids_;
+    search::StatelessVector<search::StatelessString> keys_;
+    search::StatelessVector<DocId> free_ids_;
     DocId last_id_ = 0;
   };
 
@@ -433,6 +451,9 @@ class ShardDocIndex {
   void RestoreKeyIndex(const std::vector<std::string>& keys) {
     key_index_.Restore(keys);
   }
+
+  // Returns memory used by containers with default allocator, not tracked through search local_mr_
+  size_t GetNonPmrMemoryUsage() const;
 
  private:
   // Common doc-loading loop used by SearchForAggregator and LoadHnswRangeDocsForAggregator.

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -356,30 +356,46 @@ TEST_F(SearchFamilyTest, Stats) {
 // Verify that search memory tracking accounts for DocKeyIndex and FieldIndices allocations
 TEST_F(SearchFamilyTest, MemoryTrackingDocKeyIndex) {
   constexpr size_t kNumDocs = 500;
-  constexpr size_t kKeyLen = 30;  // "doc-XXXX-padding-padding-pad" ~30 chars
+  // "doc-0000-padding-padding-pad" = 28 chars, above SSO threshold so heap-allocated
+  constexpr size_t kKeyLen = 28;
 
   EXPECT_EQ(Run({"ft.create", "idx", "ON", "HASH", "PREFIX", "1", "doc-", "SCHEMA", "name", "TAG"}),
             "OK");
 
-  auto metrics_before = GetMetrics();
-  size_t mem_before = metrics_before.search_stats.used_memory;
+  size_t mem_before = GetMetrics().search_stats.used_memory;
 
   for (size_t i = 0; i < kNumDocs; i++) {
-    // Use long keys so their memory contribution is significant
     Run({"hset", absl::StrCat("doc-", absl::Dec(i, absl::kZeroPad4), "-padding-padding-pad"),
          "name", absl::StrCat("tag", i % 10)});
   }
 
-  auto metrics_after = GetMetrics();
-  size_t mem_after = metrics_after.search_stats.used_memory;
+  size_t mem_after = GetMetrics().search_stats.used_memory;
+  ASSERT_GE(mem_after, mem_before) << "Memory should not decrease after adding documents";
   size_t mem_delta = mem_after - mem_before;
 
-  // DocKeyIndex stores each key twice (in ids_ map and keys_ vector), plus DocId vectors.
-  // FieldIndices::all_ids_ stores one DocId per doc.
-  // Minimum expected: kNumDocs * kKeyLen for keys_ vector string data alone.
-  size_t min_key_memory = kNumDocs * kKeyLen;
-  EXPECT_GE(mem_delta, min_key_memory)
-      << "Search memory tracking should account for DocKeyIndex key storage";
+  // Per document, tracked allocations via local_mr_:
+  //   keys_ vector:  StatelessString object (sizeof(string)=32) + heap chars (~kKeyLen)
+  //   ids_ map:      StatelessString key (32 + kKeyLen heap) + DocId + slot/control overhead
+  //   all_ids_:      one DocId (4 bytes) via GetNonPmrMemoryUsage
+  // Lower bound: just the string heap data (stored twice) + DocId.
+  // Upper bound: generous per-doc estimate covering allocator rounding and index metadata.
+  constexpr size_t kMinPerDoc = 2 * kKeyLen + sizeof(search::DocId);
+  constexpr size_t kMaxPerDoc = 2 * (sizeof(std::string) + kKeyLen + 16 /*allocator rounding*/) +
+                                sizeof(search::DocId) + 64 /*tag index + map slot overhead*/;
+  EXPECT_GE(mem_delta, kNumDocs * kMinPerDoc)
+      << "Memory tracking should account for DocKeyIndex and FieldIndices storage";
+  EXPECT_LE(mem_delta, kNumDocs * kMaxPerDoc)
+      << "Memory tracking should not over-count (possible double tracking)";
+
+  // Delete half the documents and verify memory decreases proportionally
+  for (size_t i = 0; i < kNumDocs / 2; i++) {
+    Run({"del", absl::StrCat("doc-", absl::Dec(i, absl::kZeroPad4), "-padding-padding-pad")});
+  }
+
+  size_t mem_after_delete = GetMetrics().search_stats.used_memory;
+  EXPECT_LT(mem_after_delete, mem_after) << "Memory should decrease after removing documents";
+  EXPECT_GE(mem_after_delete - mem_before, (kNumDocs / 2) * kMinPerDoc)
+      << "Remaining half should still be tracked";
 }
 
 // Test how asynchronous indexing indexes documents and reports its progress

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -349,7 +349,37 @@ TEST_F(SearchFamilyTest, Stats) {
   size_t expected_usage = 2 * (50 + 3 /* number of distinct words*/) * (24 + 48 /* kv size */) +
                           50 * 2 * 1 /* posting list entries */;
   EXPECT_GE(metrics.search_stats.used_memory, expected_usage);
-  EXPECT_LE(metrics.search_stats.used_memory, 3 * expected_usage);
+  // Upper bound accounts for index data + DocKeyIndex + FieldIndices overhead
+  EXPECT_LE(metrics.search_stats.used_memory, 4 * expected_usage);
+}
+
+// Verify that search memory tracking accounts for DocKeyIndex and FieldIndices allocations
+TEST_F(SearchFamilyTest, MemoryTrackingDocKeyIndex) {
+  constexpr size_t kNumDocs = 500;
+  constexpr size_t kKeyLen = 30;  // "doc-XXXX-padding-padding-pad" ~30 chars
+
+  EXPECT_EQ(Run({"ft.create", "idx", "ON", "HASH", "PREFIX", "1", "doc-", "SCHEMA", "name", "TAG"}),
+            "OK");
+
+  auto metrics_before = GetMetrics();
+  size_t mem_before = metrics_before.search_stats.used_memory;
+
+  for (size_t i = 0; i < kNumDocs; i++) {
+    // Use long keys so their memory contribution is significant
+    Run({"hset", absl::StrCat("doc-", absl::Dec(i, absl::kZeroPad4), "-padding-padding-pad"),
+         "name", absl::StrCat("tag", i % 10)});
+  }
+
+  auto metrics_after = GetMetrics();
+  size_t mem_after = metrics_after.search_stats.used_memory;
+  size_t mem_delta = mem_after - mem_before;
+
+  // DocKeyIndex stores each key twice (in ids_ map and keys_ vector), plus DocId vectors.
+  // FieldIndices::all_ids_ stores one DocId per doc.
+  // Minimum expected: kNumDocs * kKeyLen for keys_ vector string data alone.
+  size_t min_key_memory = kNumDocs * kKeyLen;
+  EXPECT_GE(mem_delta, min_key_memory)
+      << "Search memory tracking should account for DocKeyIndex key storage";
 }
 
 // Test how asynchronous indexing indexes documents and reports its progress


### PR DESCRIPTION
Summary: Improves accuracy of reported Search memory usage (fixes https://github.com/dragonflydb/dragonfly/issues/7111) by accounting for allocations that bypass the shard-local search PMR.

Changes:

- Adds non-PMR memory reporting for FieldIndices (tracks all_ids_ capacity)
- Migrates DocKeyIndex containers to stateless allocators tied to the shard search memory resource
- Extends ShardDocIndices::GetUsedMemory() to include per-index non-PMR memory and updates/adds tests