### PR TITLE
fix: prevent inline execution while shard lock is held

### DIFF
--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1622,8 +1622,21 @@ void Transaction::CancelBlocking(const std::function<OpStatus(ArgSlice)>& status
 bool Transaction::CanRunInlined() const {
   auto* ss = ServerState::tlocal();
   auto* es = EngineShard::tlocal();
+
+  // When a global transaction (e.g. SAVE) runs inline, its callback may yield during I/O
+  // (OpenWriteFile, SaveHeader).  While it is yielded another connection's command may enter
+  // CanRunInlined(), pass every check (callbacks are not registered yet), and get placed into
+  // the TxQueue behind the global transaction.  When the global transaction resumes and
+  // concludes, the inline PollExecution continues draining the queue and executes the queued
+  // command on the *connection* fiber instead of the shard-queue fiber.  If the global
+  // transaction registered snapshot change-listeners before concluding, OnChangeBlocking fires
+  // on the wrong fiber and hits the DFATAL assertion.
+  //
+  // Checking that the shard lock is free prevents inlining while a global transaction is in
+  // progress, so the queued command is dispatched through the shard queue instead.
   if (unique_shard_cnt_ == 1 && unique_shard_id_ == ss->thread_index() &&
-      ss->AllowInlineScheduling() && !GetDbSlice(es->shard_id()).HasRegisteredCallbacks()) {
+      ss->AllowInlineScheduling() && !GetDbSlice(es->shard_id()).HasRegisteredCallbacks() &&
+      es->shard_lock()->IsFree()) {
     ss->stats.tx_inline_runs++;
     return true;
   }

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -596,6 +596,64 @@ async def test_bgsave_and_save(async_client: aioredis.Redis):
     await async_client.execute_command("SAVE")
 
 
+@dfly_args({"proactor_threads": 1, "dbfilename": "test-save-del-crash", "dir": "{DRAGONFLY_TMP}/"})
+async def test_save_with_concurrent_mutations(df_server):
+    """
+    Regression test: SIGABRT in OnChangeBlocking on a non-shard fiber.
+
+    With proactor_threads=1 the single shard and all connections live on the same
+    thread.  CanRunInlined() may let a write command execute directly on a
+    connection fiber while a concurrent SAVE has already registered snapshot change
+    listeners.  The write then fires OnChangeBlocking on the wrong fiber, hitting
+    the DFATAL assertion in serializer_base.cc.
+
+    We reproduce this by running SAVE and SET/DEL concurrently from separate
+    connections until the race manifests (typically < 5 s on a debug build).
+    """
+
+    client = df_server.client()
+    for i in range(10):
+        await client.set(f"k{i}", f"val{i}")
+
+    save_done = asyncio.Event()
+
+    async def save_loop():
+        """Issue SAVE in a tight loop on a dedicated connection."""
+        c = df_server.client()
+        while not save_done.is_set():
+            try:
+                await c.execute_command("SAVE")
+            except Exception:
+                pass
+        await c.close()
+
+    async def mutate_loop(worker_id):
+        """Issue SET/DEL on a dedicated connection to race with SAVE."""
+        c = df_server.client()
+        i = 0
+        while not save_done.is_set():
+            key = f"k{i % 10}"
+            try:
+                await c.set(key, "v")
+                await c.delete(key)
+                await c.set(key, "v")
+            except Exception:
+                pass
+            i += 1
+        await c.close()
+
+    tasks = [asyncio.create_task(save_loop())]
+    tasks += [asyncio.create_task(mutate_loop(i)) for i in range(3)]
+
+    await asyncio.sleep(5)
+    save_done.set()
+    await asyncio.gather(*tasks)
+
+    # If we get here the server survived — the bug is fixed.
+    assert await client.ping()
+    await client.close()
+
+
 @pytest.mark.exclude_epoll
 @dfly_args(
     {


### PR DESCRIPTION
When `proactor_threads=1` a global transaction like SAVE runs inline on a connection fiber and may yield during file I/O (`OpenWriteFile`/`SaveHeader`). While it is yielded, another connection's write command passes the `CanRunInlined()` check (snapshot callbacks are not registered yet) and enters the TxQueue behind SAVE.  When SAVE resumes and concludes, the inline `PollExecution` drains the queue and executes the queued command on the **connection fiber** instead of the shard-queue fiber - firing `OnChangeBlocking` on the wrong fiber and hitting the DFATAL assertion in `serializer_base.cc:203`.

Changes:
- **`CanRunInlined()`**: add `shard_lock()->IsFree()` check.  While a global transaction holds the shard lock, no command can run inline - it goes through the shard queue instead, so the change callback always fires on the correct fiber.
- **Regression test**: `test_save_with_concurrent_mutations` runs SAVE and SET/DEL concurrently from separate connections with `proactor_threads=1`, reproducing the crash within seconds on a debug build.

Fixes #7103