### PR TITLE
fix: replica stuck during flushall

### DIFF
--- a/src/server/journal/tx_executor.cc
+++ b/src/server/journal/tx_executor.cc
@@ -18,6 +18,12 @@ namespace dfly {
 bool MultiShardExecution::InsertTxToSharedMap(TxId txid, uint32_t shard_cnt) {
   std::unique_lock lk(map_mu);
   auto [it, was_insert] = tx_sync_execution.emplace(txid, shard_cnt);
+  // If CancelAllBlockingEntities() already ran, cancel the new entry immediately
+  // to prevent shard fibers from blocking on entries that will never complete.
+  if (cancelled_) {
+    it->second.barrier.Cancel();
+    it->second.block->Cancel();
+  }
   lk.unlock();
 
   VLOG(2) << "txid: " << txid << " unique_shard_cnt_: " << shard_cnt
@@ -42,6 +48,7 @@ void MultiShardExecution::Erase(TxId txid) {
 
 void MultiShardExecution::CancelAllBlockingEntities() {
   lock_guard lk{map_mu};
+  cancelled_ = true;
   for (auto& tx_data : tx_sync_execution) {
     tx_data.second.barrier.Cancel();
     tx_data.second.block->Cancel();

--- a/src/server/journal/tx_executor.h
+++ b/src/server/journal/tx_executor.h
@@ -34,6 +34,7 @@ class MultiShardExecution {
  private:
   util::fb2::Mutex map_mu;
   std::unordered_map<TxId, TxExecutionSync> tx_sync_execution;
+  bool cancelled_{false};  // Protected by map_mu
 };
 
 // This class holds the commands of transaction in single shard.

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -1153,7 +1153,7 @@ bool DflyShardReplica::ExecuteTx(TransactionData&& tx_data, ExecutionState* cntx
   // and replica recieved all the commands from all shards.
   multi_shard_data.block->Wait();
   // Check if we woke up due to cancellation.
-  if (!exec_st_.IsRunning())
+  if (!cntx->IsRunning())
     return false;
   VLOG(2) << "Execute txid: " << tx_data.txid << " block wait finished";
 
@@ -1161,7 +1161,7 @@ bool DflyShardReplica::ExecuteTx(TransactionData&& tx_data, ExecutionState* cntx
   // Wait until all shards flows get to execution step of this transaction.
   multi_shard_data.barrier.Wait();
   // Check if we woke up due to cancellation.
-  if (!exec_st_.IsRunning())
+  if (!cntx->IsRunning())
     return false;
   // Global command will be executed only from one flow fiber. This ensure corectness of data in
   // replica.
@@ -1173,7 +1173,7 @@ bool DflyShardReplica::ExecuteTx(TransactionData&& tx_data, ExecutionState* cntx
   // executed.
   multi_shard_data.barrier.Wait();
   // Check if we woke up due to cancellation.
-  if (!exec_st_.IsRunning())
+  if (!cntx->IsRunning())
     return false;
 
   // Erase from map can be done only after all flow fibers executed the transaction commands.

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -4525,3 +4525,55 @@ async def test_set_member_expiry_replication(
         f"Replica still has 'myset' after lazy expiry triggered by {trigger_cmd[0]}. "
         "DeleteSetIfEmpty must journal the deletion so the replica stays in sync."
     )
+
+
+@dfly_args({"proactor_threads": 4})
+@pytest.mark.timeout(60)
+async def test_replica_no_deadlock_on_disconnect(df_factory: DflyInstanceFactory):
+    """Replica must not deadlock when the master dies while a global command
+    (FLUSHALL) is being replicated across shards. The bug: one shard reads
+    the FLUSHALL from its socket buffer and enters Barrier::Wait inside
+    ExecuteTx, but CancelAllBlockingEntities already ran (triggered by
+    another shard whose socket broke first), so the new entry is never
+    cancelled and the shard fiber hangs forever."""
+    master = df_factory.create(proactor_threads=4)
+    replica = df_factory.create(proactor_threads=4)
+    df_factory.start_all([master, replica])
+
+    c_master = master.client()
+    c_replica = replica.client()
+
+    await c_master.execute_command("DEBUG", "POPULATE", "1000")
+    await c_replica.execute_command("REPLICAOF", "localhost", str(master.port))
+    await wait_available_async(c_replica)
+    await check_all_replicas_finished([c_replica], c_master)
+
+    # Stream Lua-based multi-shard traffic that generates global commands,
+    # then kill the master. The seeder's Lua scripts create complex multi-shard
+    # operations that widen the race window for the barrier deadlock.
+    stream_seeder = SeederV2(key_target=1000)
+    seed_task = asyncio.create_task(stream_seeder.run(c_master, target_deviation=0.1))
+    await asyncio.sleep(0.5)
+    await c_master.execute_command("FLUSHALL")
+    master.stop(kill=True)
+    seed_task.cancel()
+    try:
+        await seed_task
+    except (asyncio.CancelledError, Exception):
+        pass
+
+    # Restart master and re-point the replica.
+    master.start()
+    c_master = master.client()
+    await wait_available_async(c_master)
+    await c_master.execute_command("DEBUG", "POPULATE", "500")
+
+    # Re-point replica to the new master port. If the replica is deadlocked
+    # in an ExecuteTx barrier, even this command won't help it recover.
+    await c_replica.execute_command("REPLICAOF", "localhost", str(master.port))
+
+    await asyncio.wait_for(wait_for_replicas_state(c_replica), timeout=20)
+    await check_all_replicas_finished([c_replica], c_master, timeout=20)
+
+    assert await c_replica.dbsize() == await c_master.dbsize()
+    await c_replica.execute_command("REPLICAOF", "NO", "ONE")


### PR DESCRIPTION
Fixed 2 bugs:
Bug 1 (in MultiShardExecution): Race between CancelAllBlockingEntities() and InsertTxToSharedMap() —
  a new entry created after cancellation was never cancelled, causing block->Wait() / barrier.Wait() to hang
  forever.

Bug 2 (in ExecuteTx): After barrier/block waits, the cancellation checks used
  exec_st_.IsRunning() — the flow's own ExecutionState, which is never set to ERROR by the error handler. Should
  use cntx->IsRunning() — the Replica's ExecutionState, which IS set to ERROR when the connection breaks. This
  caused flows to continue executing global commands (like FLUSHALL via executor_->Execute()) even after
  cancellation, potentially blocking on the cross-shard transaction scheduling.


Changes:

- Track a cancellation flag in MultiShardExecution and immediately cancel any tx sync entry inserted after cancellation.
- Set the cancellation flag when CancelAllBlockingEntities() runs.
- In DflyShardReplica::ExecuteTx, use the replica’s ExecutionState (cntx) for post-wait cancellation checks instead of the flow-local state.
- Add a regression test that kills the master during FLUSHALL under load and verifies the replica can recover and resync.