### PR TITLE
docs: Add GPG signing guidance to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,26 @@ pre-commit install
 
 This step must be done on each machine you wish to develop and contribute from to activate the `commit-msg` and `commit` hooks client-side.
 
+### Signing commits with GPG
+
+We require all commits to be signed with a GPG key. To set this up:
+
+```sh
+# List your GPG keys
+gpg --list-secret-keys --keyid-format=long
+
+# If you don't have a key, create one
+gpg --full-generate-key
+
+# Configure git to use your GPG key for signing (replace KEY_ID with your actual key)
+git config --global user.signingkey KEY_ID
+
+# Enable automatic signing for all commits
+git config --global commit.gpgsign true
+```
+
+All commits must be signed (this is enforced by the pre-commit hooks). When you commit, you'll be prompted for your GPG passphrase if it's not cached.
+
 Once you have done these things, we look forward to adding your contributions and improvements to the Dragonfly DB project.
 
 ## Unit testing


### PR DESCRIPTION
## Summary
Add comprehensive GPG key signing setup instructions to the "Before you make your changes" section in CONTRIBUTING.md.

## Changes
- Added new "Signing commits with GPG" subsection
- Includes steps to list, create, and configure GPG keys
- Clarifies that automatic signing is required
- Notes about GPG passphrase prompts during commits

## Type
Documentation update