### PR TITLE
feat(helm): add cluster mode values for Dragonfly chart

### DIFF
--- a/contrib/charts/dragonfly/templates/_pod.tpl
+++ b/contrib/charts/dragonfly/templates/_pod.tpl
@@ -86,6 +86,21 @@ containers:
     {{- with .Values.extraArgs }}
       {{- toYaml . | trim | nindent 6 }}
     {{- end }}
+    {{- with .Values.cluster }}
+    {{- $modeRaw := .mode | default "" }}
+    {{- $clusterMode := "" }}
+    {{- if kindIs "bool" $modeRaw }}
+      {{- if $modeRaw }}{{- $clusterMode = "yes" }}{{- end }}
+    {{- else }}
+      {{- $clusterMode = $modeRaw | toString }}
+    {{- end }}
+    {{- if ne $clusterMode "" }}
+      - "--cluster_mode={{ $clusterMode }}"
+    {{- end }}
+    {{- if and (ne $clusterMode "") .experimentalShardBySlot }}
+      - "--experimental_cluster_shard_by_slot=true"
+    {{- end }}
+    {{- end }}
     {{- if .Values.tls.enabled }}
       - "--tls"
       - "--tls_cert_file=/etc/dragonfly/tls/tls.crt"

--- a/contrib/charts/dragonfly/values.yaml
+++ b/contrib/charts/dragonfly/values.yaml
@@ -173,6 +173,16 @@ command: []
 # -- Extra arguments to pass to the dragonfly binary
 extraArgs: []
 
+cluster:
+  # -- Redis cluster protocol mode passed to Dragonfly as --cluster_mode.
+  # -- Accepts "emulated" or "yes". Unquoted `yes` (parsed as boolean by YAML)
+  # -- is also supported and treated as the string "yes".
+  # -- Leave empty to disable cluster mode.
+  mode: ""
+  # -- When cluster mode is enabled, pass --experimental_cluster_shard_by_slot=true
+  # -- so sharding follows slots instead of hash tags.
+  experimentalShardBySlot: false
+
 # -- Extra volumes to mount into the pods
 extraVolumes: []
 


### PR DESCRIPTION
## Summary
Adds predefined Helm values for Redis-compatible cluster mode so users can enable Dragonfly cluster flags without hand-writing `extraArgs`.

## Changes
- `values.yaml`: new `cluster.mode` (maps to `--cluster_mode`) and `cluster.experimentalShardBySlot` (maps to `--experimental_cluster_shard_by_slot=true` when mode is set)
- `templates/_pod.tpl`: append the corresponding CLI args when `cluster.mode` is non-empty

## Notes
Valid `cluster.mode` values match the Dragonfly flag: `emulated`, `yes`, or empty to leave cluster mode disabled. See server `cluster_support.cc` for flag semantics.

Fixes https://github.com/dragonflydb/dragonfly/issues/3861
