### PR TITLE
fix: prevent SIGSEGV during HNSW index restoration with external vectors

### DIFF
--- a/src/core/search/hnsw_index.cc
+++ b/src/core/search/hnsw_index.cc
@@ -436,11 +436,23 @@ struct HnswlibAdapter {
              world_.size_data_per_element_);
       world_.setExternalLabel(internal_id, node.global_id);
 
-      // In copy mode, zero the vector memory so distance computations don't use
-      // uninitialized data for nodes that are marked deleted.
       if (world_.copy_vector_) {
+        // In copy mode, zero the vector memory so distance computations don't use
+        // uninitialized data for nodes that are marked deleted.
         char* data_ptr = world_.data_vector_memory_ + internal_id * world_.data_size_;
         memset(data_ptr, 0, world_.data_size_);
+      } else {
+        // Borrowed-vector mode: point to a valid placeholder so graph traversal
+        // never dereferences nullptr. Filled with 1.0f (not zeros) because
+        // CosineDistance returns 0 for zero-norm vectors, biasing traversal.
+        if (!restore_placeholder_buf_) {
+          restore_placeholder_buf_.reset(new char[data_size_]);
+          auto* fp = reinterpret_cast<float*>(restore_placeholder_buf_.get());
+          std::fill(fp, fp + data_size_ / sizeof(float), 1.0f);
+        }
+        char* safe_ptr = restore_placeholder_buf_.get();
+        char* ptr_location = world_.getDataPtrByInternalId(internal_id);
+        memcpy(ptr_location, &safe_ptr, sizeof(void*));
       }
 
       // Allocate upper layer links if needed
@@ -534,6 +546,9 @@ struct HnswlibAdapter {
   size_t data_size_;                    // Byte size of a single vector.
   mutable base::SpinLock deferred_mu_;  // Protects deferred_ops_.
   absl::flat_hash_map<GlobalDocId, DeferredOp> deferred_ops_;  // GUARDED_BY(deferred_mu_)
+
+  // Non-zero placeholder for borrowed-vector nodes during RestoreFromNodes().
+  std::unique_ptr<char[]> restore_placeholder_buf_;
 };
 
 HnswVectorIndex::HnswVectorIndex(const SchemaField::VectorParams& params, bool copy_vector,

--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -624,13 +624,19 @@ bool FieldIndices::Add(DocId doc, const DocumentAccessor& access) {
 }
 
 void FieldIndices::Remove(DocId doc, const DocumentAccessor& access) {
+  auto it = lower_bound(all_ids_.begin(), all_ids_.end(), doc);
+  if (it == all_ids_.end() || *it != doc) {
+    // During index restoration CursorLoop may not have indexed this document
+    // yet, so it is absent from all_ids_ and every per-field index. Nothing
+    // to remove — the caller already took care of key_index_.
+    return;
+  }
+
   for (auto& [field, index] : indices_)
     index->Remove(doc, access, field);
   for (auto& [field, sort_index] : sort_indices_)
     sort_index->Remove(doc, access, field);
 
-  auto it = lower_bound(all_ids_.begin(), all_ids_.end(), doc);
-  DCHECK(it != all_ids_.end() && *it == doc);
   all_ids_.erase(it);
 }
 

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -560,8 +560,9 @@ void HnswShardIndex::Remove(search::GlobalDocId id, const BaseAccessor& doc, Pri
 }
 
 void HnswShardIndex::RemoveById(search::GlobalDocId id) {
-  [[maybe_unused]] bool sync = global_index_->Remove(id);
-  DCHECK(sync) << "RemoveById should only be called when no read lock is held";
+  // During restoration a concurrent operation (e.g. Add from a journal event)
+  // may hold the MRMW lock, so the remove can be deferred — that is fine.
+  global_index_->Remove(id);
 }
 
 bool HnswShardIndex::UpdateVectorData(search::GlobalDocId id, const BaseAccessor& doc) {

--- a/src/server/search/index_builder.cc
+++ b/src/server/search/index_builder.cc
@@ -4,6 +4,7 @@
 
 #include "server/search/index_builder.h"
 
+#include <algorithm>
 #include <ranges>
 
 #include "server/db_slice.h"
@@ -64,11 +65,16 @@ void IndexBuilder::CursorLoop(dfly::DbTable* table, DbContext db_cntx) {
       // GlobalDocIds stored in the serialized HNSW graph. Only add to regular indices
       // (text/tag/numeric); vector indices are handled separately by VectorLoop.
       if (auto doc_id = index_->key_index().Find(key); doc_id) {
-        auto accessor = GetAccessor(db_cntx, pv);
-        if (!index_->indices_->Add(*doc_id, *accessor)) {
-          LOG(WARNING) << "Failed to restore index entry for key: " << key
-                       << ", removing from key index";
-          index_->key_index_.Remove(*doc_id);
+        // A journal event may have already indexed this doc while CursorLoop
+        // was still running.  Check all_ids_ to avoid duplicate entries.
+        const auto& all = index_->indices_->GetAllDocs();
+        if (!std::binary_search(all.begin(), all.end(), *doc_id)) {
+          auto accessor = GetAccessor(db_cntx, pv);
+          if (!index_->indices_->Add(*doc_id, *accessor)) {
+            LOG(WARNING) << "Failed to restore index entry for key: " << key
+                         << ", removing from key index";
+            index_->key_index_.Remove(*doc_id);
+          }
         }
       } else {
         // New document not in the restored key_index_ (added by journal events during

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -4313,7 +4313,6 @@ async def test_sbf_chunked_replication_chunk_size(df_factory: DflyInstanceFactor
     assert peak_bytes < MAX_SBF_CHUNK_SIZE
 
 
-@pytest.mark.skip(reason="unstable")
 @pytest.mark.parametrize(
     "master_threads, replica_threads, num_dims",
     [
@@ -4391,6 +4390,43 @@ async def test_hnsw_search_replication_with_network_disruptions(
         search_task.cancel()
         replica_search_task.cancel()
         await proxy.close(proxy_task)
+
+
+@dfly_args({"proactor_threads": 4})
+async def test_hnsw_external_vector_replication_crash(df_factory: DflyInstanceFactory):
+    """
+    Minimal reproducer for SIGSEGV during HNSW replication with external vectors.
+
+    The HNSW graph is global (shared across shards) but is_restoring_vectors_ is per-shard.
+    When one shard finishes RestoreGlobalVectorIndices and starts accepting new HSETs,
+    addPoint() traverses the global graph and may dereference nullptr data pointers
+    from nodes belonging to shards that haven't finished restoration yet.
+    """
+    master = df_factory.create(proactor_threads=4)
+    replica = df_factory.create(proactor_threads=4)
+    df_factory.start_all([master, replica])
+
+    c_master = master.client()
+    c_replica = replica.client()
+
+    # dim=256 forces external vectors (copy_vector=false).
+    # 500 docs creates a larger HNSW graph, widening the restoration window.
+    seeder = HnswSearchSeeder(num_initial_docs=500, num_dims=256)
+    await seeder.create_index(c_master)
+    await seeder.seed_initial_docs(c_master)
+
+    # Start heavy traffic on master BEFORE replication begins.
+    # This ensures journal events (HSETs) arrive on the replica while HNSW graph
+    # is being restored, triggering addPoint() with nullptr data pointers.
+    traffic_task = asyncio.create_task(seeder.run_traffic(c_master, sleep_interval=0.001))
+
+    await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
+    await wait_available_async(c_replica)
+
+    seeder.stop()
+    await traffic_task
+
+    await check_all_replicas_finished([c_replica], c_master, timeout=60)
 
 
 async def test_rm_replication(df_factory: DflyInstanceFactory):


### PR DESCRIPTION
During a full replica sync, the HNSW graph structure is restored from RDB with all nodes marked DELETED. In borrowed-vector mode (dim >= 256), data pointers are left as nullptr. hnswlib's graph traversal computes distances even to DELETED nodes (entry point, neighbor exploration), causing nullptr dereference when concurrent writes or searches trigger addPoint()/searchKnn().

Root cause: the HNSW graph is global (shared across shards), but vector restoration runs per-shard. When one shard finishes and accepts new writes, addPoint() traverses nodes from other shards that still have nullptr pointers.

Changes:
- Set restored borrowed-vector nodes to point to a non-zero placeholder (1.0f) instead of nullptr so distance computation is safe during the restoration window. Uses 1.0f rather than zeros because CosineDistance() returns 0 for zero-norm vectors, which would bias graph traversal toward DELETED nodes.
- Make FieldIndices::Remove() tolerate docs not yet indexed by CursorLoop, fixing a DCHECK crash when journal events race with index rebuilding
- Skip duplicate FieldIndices::Add() in CursorLoop for docs already indexed by a concurrent journal event
- Allow HnswShardIndex::RemoveById() to defer when the MRMW lock is held, fixing a DCHECK crash during RestoreGlobalVectorIndices()
- Remove skip marker from test_hnsw_search_replication_with_network_disruptions
- Add minimal reproducer test_hnsw_external_vector_replication_crash