### PR TITLE
feat: deffer HNSW index updates during restoration

### DIFF
--- a/src/core/search/hnsw_index.cc
+++ b/src/core/search/hnsw_index.cc
@@ -486,9 +486,15 @@ struct HnswlibAdapter {
       world_.cur_element_count.store(++restored_count);
 
       // Mark node as deleted until UpdateVectorData provides valid vector data.
-      // This prevents crashes from dereferencing uninitialised data pointers
-      // (especially in borrowed-vector mode).
       world_.markDeletedInternal(internal_id);
+
+      // In borrowed mode, deleted nodes are still traversed by addPoint.
+      // Point to stub_vector_ so distance computations don't dereference nullptr.
+      if (!copy_vector_) {
+        const char* safe_ptr = reinterpret_cast<const char*>(stub_vector_.data());
+        char* ptr_location = world_.getDataPtrByInternalId(internal_id);
+        memcpy(ptr_location, &safe_ptr, sizeof(void*));
+      }
     }
 
     // Set the metadata for the graph

--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -624,13 +624,18 @@ bool FieldIndices::Add(DocId doc, const DocumentAccessor& access) {
 }
 
 void FieldIndices::Remove(DocId doc, const DocumentAccessor& access) {
+  auto it = lower_bound(all_ids_.begin(), all_ids_.end(), doc);
+  if (it == all_ids_.end() || *it != doc) {
+    // During index restoration CursorLoop may not have indexed this document
+    // yet, so it is absent from all_ids_. Nothing to remove.
+    return;
+  }
+
   for (auto& [field, index] : indices_)
     index->Remove(doc, access, field);
   for (auto& [field, sort_index] : sort_indices_)
     sort_index->Remove(doc, access, field);
 
-  auto it = lower_bound(all_ids_.begin(), all_ids_.end(), doc);
-  DCHECK(it != all_ids_.end() && *it == doc);
   all_ids_.erase(it);
 }
 

--- a/src/server/rdb_load_context.cc
+++ b/src/server/rdb_load_context.cc
@@ -389,9 +389,23 @@ void RdbLoadContext::PerformPostLoad(Service* service, bool is_error) {
     LoadSearchCommandFromAux(service, std::move(syn_cmd), "FT.SYNUPDATE", "synonym definition");
   }
 
-  // Wait until index building ends
+  // Wait until index building ends (all shards' vector data populated).
   shard_set->RunBlockingInParallel(
       [](EngineShard* es) { es->search_indices()->BlockUntilConstructionEnd(); });
+
+  // All shards completed restoration — drain pending ops.
+  // DrainPendingVectorUpdates sets kBuilding which allows Add calls.
+  if (has_hnsw_restore) {
+    shard_set->AwaitRunningOnShardQueue([](EngineShard* es) {
+      OpArgs op_args{es, nullptr,
+                     DbContext{&namespaces->GetDefaultNamespace(), 0, GetCurrentTimeMs()}};
+      for (const auto& name : es->search_indices()->GetIndexNames()) {
+        if (auto* idx = es->search_indices()->GetIndex(name)) {
+          idx->DrainPendingVectorUpdates(op_args);
+        }
+      }
+    });
+  }
 #endif
 }
 

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -406,12 +406,12 @@ void ShardDocIndex::Rebuild(const OpArgs& op_args, PMR_NS::memory_resource* mr, 
   if (!is_restored) {
     key_index_ = DocKeyIndex{};
     // Full rebuild handles all documents — discard any buffered state from LOADING.
-    is_restoring_vectors_ = false;
+    hnsw_state_ = HnswState::kBuilding;
     pending_vector_updates_.clear();
   } else {
-    // Restored path: VectorLoop will call RestoreGlobalVectorIndices which drains
-    // the buffers. Until then, buffer any journal-driven mutations.
-    is_restoring_vectors_ = true;
+    // Restored path: buffer journal-driven mutations until PerformPostLoad drains
+    // them after all shards complete vector restoration.
+    hnsw_state_ = HnswState::kRestoring;
   }
 
   indices_.emplace(base_->schema, base_->options, mr, &synonyms_);
@@ -541,26 +541,8 @@ void HnswShardIndex::Remove(search::GlobalDocId id, const BaseAccessor& doc, Pri
     return;
   }
 
-  if (global_index_->IsVectorCopied())
-    return;
-
-  // Remove was deferred and this index uses external vectors — preserve the old sds
-  // so the deferred Remove can still dereference hnswlib's stored pointer.
-  if (!modified_fields.empty() &&
-      rng::find(modified_fields, field_ident_) == modified_fields.end()) {
-    return;
-  }
-
-  // Use the cache to extract each field at most once per document.
-  // When multiple search indices reference the same hash field, they share
-  // ownership of the original sds via shared_ptr.
-  auto [it, inserted] = cache->emplace(field_ident_, nullptr);
-  if (inserted) {
-    it->second = ExtractField(pv, field_ident_);
-  }
-  if (it->second) {
-    preserved_field_data_.push_back(it->second);
-  }
+  // Remove was deferred — preserve old sds so hnswlib's stored pointer stays valid.
+  MaybePreserveField(pv, modified_fields, cache);
 }
 
 void HnswShardIndex::RemoveById(search::GlobalDocId id) {
@@ -578,6 +560,22 @@ bool HnswShardIndex::IsVectorCopied() const {
 
 void HnswShardIndex::ClearPreservedData() {
   preserved_field_data_.clear();
+}
+
+void HnswShardIndex::MaybePreserveField(PrimeValue& pv,
+                                        absl::Span<const std::string_view> modified_fields,
+                                        FieldExtractionCache* cache) {
+  if (global_index_->IsVectorCopied())
+    return;
+  if (!modified_fields.empty() && rng::find(modified_fields, field_ident_) == modified_fields.end())
+    return;
+  auto [it, inserted] = cache->emplace(field_ident_, nullptr);
+  if (inserted) {
+    it->second = ExtractField(pv, field_ident_);
+  }
+  if (it->second) {
+    preserved_field_data_.push_back(it->second);
+  }
 }
 
 // --- ShardDocIndex HNSW methods ---
@@ -600,7 +598,7 @@ void ShardDocIndex::InitHnswShardIndices() {
 
 void ShardDocIndex::AddDocToGlobalVectorIndex(ShardDocIndex::DocId doc_id, const DbContext& db_cntx,
                                               PrimeValue* pv) {
-  if (is_restoring_vectors_) {
+  if (hnsw_state_ != HnswState::kBuilding) {
     std::string_view key = key_index_.Get(doc_id);
     pending_vector_updates_.emplace(key);
     return;
@@ -619,9 +617,13 @@ void ShardDocIndex::AddDocToGlobalVectorIndex(ShardDocIndex::DocId doc_id, const
 void ShardDocIndex::RemoveDocFromGlobalVectorIndex(
     ShardDocIndex::DocId doc_id, const DbContext& db_cntx, PrimeValue& pv,
     absl::Span<const std::string_view> modified_fields, FieldExtractionCache* cache) {
-  if (is_restoring_vectors_) {
+  if (hnsw_state_ != HnswState::kBuilding) {
     std::string_view key = key_index_.Get(doc_id);
     pending_vector_updates_.emplace(key);
+
+    // Preserve old sds so HNSW pointers set by UpdateVectorData stay valid.
+    for (auto& hnsw : hnsw_shard_indices_)
+      hnsw.MaybePreserveField(pv, modified_fields, cache);
     return;
   }
 
@@ -652,7 +654,7 @@ void ShardDocIndex::RestoreGlobalVectorIndices(std::string_view index_name, cons
 
   size_t processed = 0;
   size_t successful_updates = 0;
-  size_t failed_updates = 0;
+  size_t deferred_updates = 0;
   size_t missing_documents = 0;
 
   // Collect missing document IDs to remove after the loop (can't modify key_index_ during
@@ -684,6 +686,7 @@ void ShardDocIndex::RestoreGlobalVectorIndices(std::string_view index_name, cons
     auto doc = GetAccessor(op_args.db_cntx, pv);
     GlobalDocId global_id = search::CreateGlobalDocId(EngineShard::tlocal()->shard_id(), local_id);
 
+    bool any_deferred = false;
     for (auto& hnsw : hnsw_shard_indices_) {
       bool success = hnsw.UpdateVectorData(global_id, *doc);
       if (success) {
@@ -692,18 +695,15 @@ void ShardDocIndex::RestoreGlobalVectorIndices(std::string_view index_name, cons
           pv.SetOmitDefrag(true);
         }
       } else {
-        // Node not in restored HNSW graph (new doc added during full sync via journal
-        // events before index was created). Fall back to Add.
-        bool added = hnsw.Add(global_id, *doc);
-        if (added) {
-          ++successful_updates;
-          if (!hnsw.IsVectorCopied()) {
-            pv.SetOmitDefrag(true);
-          }
-        } else {
-          ++failed_updates;
-        }
+        // Node not in restored graph — defer to pending_vector_updates_ so
+        // addPoint (which traverses the graph) only runs after every restored
+        // node has valid vector data.
+        any_deferred = true;
       }
+    }
+    if (any_deferred) {
+      pending_vector_updates_.emplace(key);
+      ++deferred_updates;
     }
 
     // Yield periodically to avoid blocking the fiber
@@ -728,52 +728,55 @@ void ShardDocIndex::RestoreGlobalVectorIndices(std::string_view index_name, cons
 
   // Log summary of vector restoration
   size_t total_docs = doc_keys_snapshot.size();
-  if (failed_updates > 0 || missing_documents > 0) {
+  if (deferred_updates > 0 || missing_documents > 0) {
     LOG(WARNING) << "Restored vectors for index " << index_name << ": " << successful_updates
-                 << " successful, " << failed_updates << " failed (missing vector field), "
-                 << missing_documents << " missing documents out of " << total_docs << " total";
+                 << " successful, " << deferred_updates << " deferred, " << missing_documents
+                 << " missing documents out of " << total_docs << " total";
   } else {
     VLOG(1) << "Restored vectors for index " << index_name << ": " << successful_updates << "/"
             << total_docs << " documents";
   }
 
-  // Drain pending vector updates that arrived via journal during the LOADING window.
-  // Clear the flag BEFORE draining so that AddDoc/AddDocToGlobalVectorIndex work normally.
-  is_restoring_vectors_ = false;
+  // Stay in kRestoring — other shards may not have populated their vector data
+  // yet (the HNSW graph is global). PerformPostLoad calls DrainPendingVectorUpdates
+  // after BlockUntilConstructionEnd ensures ALL shards completed.
+}
 
-  if (!pending_vector_updates_.empty()) {
-    LOG(INFO) << "Draining " << pending_vector_updates_.size()
-              << " pending vector updates for index '" << index_name << "' on shard "
-              << EngineShard::tlocal()->shard_id();
+void ShardDocIndex::DrainPendingVectorUpdates(const OpArgs& op_args) {
+  // All shards have valid vector data now — allow normal HNSW operations.
+  hnsw_state_ = HnswState::kBuilding;
 
-    for (const auto& key : pending_vector_updates_) {
-      auto local_id = key_index_.Find(key);
-      auto it = db_slice.FindMutable(op_args.db_cntx, key, base_->GetObjCode());
+  if (pending_vector_updates_.empty())
+    return;
 
-      if (it && IsValid(it->it)) {
-        // Key exists in DB — ensure it's properly indexed with current data.
-        PrimeValue& pv = it->it->second;
+  auto& db_slice = op_args.GetDbSlice();
 
-        if (local_id) {
-          // Already in key_index_ (from snapshot). Remove old HNSW node and re-add
-          // with current vector data to match master state.
-          RemoveFromAllHnswIndices(*local_id);
-          AddDocToGlobalVectorIndex(*local_id, op_args.db_cntx, &pv);
-        } else {
-          // New document not in key_index_ (added during full sync).
-          auto doc_id = AddDoc(key, op_args.db_cntx, pv);
-          if (doc_id) {
-            AddDocToGlobalVectorIndex(*doc_id, op_args.db_cntx, &pv);
-          }
-        }
-      } else if (local_id) {
-        // Key absent from DB — remove stale HNSW node and key_index_ entry.
+  LOG(INFO) << "Draining " << pending_vector_updates_.size() << " pending vector updates on shard "
+            << EngineShard::tlocal()->shard_id();
+
+  for (const auto& key : pending_vector_updates_) {
+    auto local_id = key_index_.Find(key);
+    auto it = db_slice.FindMutable(op_args.db_cntx, key, base_->GetObjCode());
+
+    if (it && IsValid(it->it)) {
+      PrimeValue& pv = it->it->second;
+
+      if (local_id) {
         RemoveFromAllHnswIndices(*local_id);
-        key_index_.Remove(*local_id);
+        AddDocToGlobalVectorIndex(*local_id, op_args.db_cntx, &pv);
+      } else {
+        auto doc_id = AddDoc(key, op_args.db_cntx, pv);
+        if (doc_id) {
+          AddDocToGlobalVectorIndex(*doc_id, op_args.db_cntx, &pv);
+        }
       }
+    } else if (local_id) {
+      RemoveFromAllHnswIndices(*local_id);
+      key_index_.Remove(*local_id);
     }
-    pending_vector_updates_.clear();
   }
+  pending_vector_updates_.clear();
+  ClearAllHnswPreservedData();
 }
 
 ShardDocIndex::SerializedEntryWithKey ShardDocIndex::SerializeDocWithKey(

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -253,6 +253,10 @@ class HnswShardIndex {
 
   void ClearPreservedData();
 
+  // Preserve old sds entry for borrowed-vector mode so HNSW pointers stay valid.
+  void MaybePreserveField(PrimeValue& pv, absl::Span<const std::string_view> modified_fields,
+                          FieldExtractionCache* cache);
+
   const std::string& field_ident() const {
     return field_ident_;
   }
@@ -424,6 +428,10 @@ class ShardDocIndex {
   // for nodes whose graph structure was already restored from RDB.
   void RestoreGlobalVectorIndices(std::string_view index_name, const OpArgs& op_args);
 
+  // Drain buffered HNSW updates and set kBuilding. Called from PerformPostLoad
+  // after all shards complete restoration.
+  void DrainPendingVectorUpdates(const OpArgs& op_args);
+
   // Serialize doc and return with key name
   using SerializedEntryWithKey = std::optional<std::pair<std::string_view, SearchDocData>>;
   SerializedEntryWithKey SerializeDocWithKey(
@@ -493,11 +501,14 @@ class ShardDocIndex {
   // Per-shard HNSW wrappers, one per indexed vector field.
   std::vector<HnswShardIndex> hnsw_shard_indices_;
 
-  // Buffered state for journal events arriving while HNSW vector indices
-  // are being restored from serialized graph data (is_restoring_vectors_ == true).
-  // Drained by RestoreGlobalVectorIndices after the graph is fully restored.
+  // HNSW vector index lifecycle state.
+  // kProhibit: default after InitIndex during LOADING. All HNSW ops buffered.
+  // kRestoring: set by Rebuild(is_restored=true). Ops buffered until drain.
+  // kBuilding: normal operation. HNSW adds/removes execute immediately.
+  enum class HnswState : uint8_t { kProhibit, kRestoring, kBuilding };
+
   absl::flat_hash_set<std::string> pending_vector_updates_;
-  bool is_restoring_vectors_ = false;
+  HnswState hnsw_state_ = HnswState::kProhibit;
 };
 
 // Stores shard doc indices by name on a specific shard.

--- a/src/server/search/index_builder.cc
+++ b/src/server/search/index_builder.cc
@@ -110,7 +110,7 @@ void IndexBuilder::VectorLoop(dfly::DbTable* table, DbContext db_cntx) {
 
   // Non-restored path: rebuilding HNSW from scratch. Clear the restoring flag and discard
   // any pending updates — the full table traversal below will pick up all current documents.
-  index_->is_restoring_vectors_ = false;
+  index_->hnsw_state_ = ShardDocIndex::HnswState::kBuilding;
   index_->pending_vector_updates_.clear();
 
   auto cb = [this, db_cntx, scratch = std::string{}](PrimeTable::iterator it) mutable {

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -4577,3 +4577,40 @@ async def test_replica_no_deadlock_on_disconnect(df_factory: DflyInstanceFactory
 
     assert await c_replica.dbsize() == await c_master.dbsize()
     await c_replica.execute_command("REPLICAOF", "NO", "ONE")
+
+
+@dfly_args({"proactor_threads": 4})
+async def test_hnsw_external_vector_replication_crash(df_factory: DflyInstanceFactory):
+    """
+    Minimal reproducer for SIGSEGV during HNSW replication with external vectors.
+
+    The HNSW graph is global (shared across shards) but is_restoring_vectors_ is per-shard.
+    When one shard finishes RestoreGlobalVectorIndices and starts accepting new HSETs,
+    addPoint() traverses the global graph and may dereference nullptr data pointers
+    from nodes belonging to shards that haven't finished restoration yet.
+    """
+    master = df_factory.create(proactor_threads=4)
+    replica = df_factory.create(proactor_threads=4)
+    df_factory.start_all([master, replica])
+
+    c_master = master.client()
+    c_replica = replica.client()
+
+    # dim=256 forces external vectors (copy_vector=false).
+    # 500 docs creates a larger HNSW graph, widening the restoration window.
+    seeder = HnswSearchSeeder(num_initial_docs=500, num_dims=256)
+    await seeder.create_index(c_master)
+    await seeder.seed_initial_docs(c_master)
+
+    # Start heavy traffic on master BEFORE replication begins.
+    # This ensures journal events (HSETs) arrive on the replica while HNSW graph
+    # is being restored, triggering addPoint() with nullptr data pointers.
+    traffic_task = asyncio.create_task(seeder.run_traffic(c_master, sleep_interval=0.001))
+
+    await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
+    await wait_available_async(c_replica)
+
+    seeder.stop()
+    await traffic_task
+
+    await check_all_replicas_finished([c_replica], c_master, timeout=60)

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -4313,7 +4313,6 @@ async def test_sbf_chunked_replication_chunk_size(df_factory: DflyInstanceFactor
     assert peak_bytes < MAX_SBF_CHUNK_SIZE
 
 
-@pytest.mark.skip(reason="unstable")
 @pytest.mark.parametrize(
     "master_threads, replica_threads, num_dims",
     [


### PR DESCRIPTION
Fixes SIGSEGV during HNSW vector index replication when journal events arrive while the graph is being restored
   with uninitialized vector data.                                                                               
                                                                                                                 
  Problem                                                         

  During full sync replication, the HNSW graph is restored from the RDB stream with all nodes marked as deleted  
  and vector data uninitialized. Journal events embedded in the RDB stream (or arriving during LOADING) can
  trigger addPoint/searchBaseLayer which traverses these nodes and dereferences null pointers in borrowed-vector 
  mode — causing a crash.                                         

  The root cause has two parts:                                                                                  
  1. Timing gap: ShardDocIndex was created during LOADING with is_restoring_vectors_=false (default). The flag
  was only set to true by Rebuild(), which runs later in PerformPostLoad. Journal events arriving in between     
  bypassed the guard.                                                                                       
  2. Cross-shard traversal: The HNSW graph is global (shared across shards) but restoration runs per-shard. When 
  one shard completes and starts accepting writes, addPoint traverses nodes from other shards that still have
  null pointers.                                                                                                 
   
  Changes                                                                                                        
                                                                  
  - 3-state lifecycle enum (kProhibit/kRestoring/kBuilding) replaces bool is_restoring_vectors_ on ShardDocIndex.
   Default kProhibit blocks all HNSW ops from index creation, closing the timing gap.
  - stub_vector_ for deleted nodes in RestoreFromNodes: borrowed-mode nodes point to a safe 1.0f-filled buffer   
  instead of nullptr, preventing SIGSEGV during cross-shard graph traversal.                                     
  - Deferred drain in PerformPostLoad: pending vector updates are drained only after BlockUntilConstructionEnd
  ensures ALL shards completed, so addPoint never traverses uninitialized nodes.                                 
  - Field preservation during restoration: when journal HSETs modify documents during kRestoring, the old sds
  entries are preserved (via ExtractField) so HNSW pointers set by UpdateVectorData remain valid.                
  - Extracted MaybePreserveField: deduplicates the sds preservation logic between HnswShardIndex::Remove and
  RemoveDocFromGlobalVectorIndex.  