### PR TITLE
fix: empty name doc for search

### DIFF
--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -322,7 +322,7 @@ std::vector<std::pair<std::string, search::DocId>> ShardDocIndex::DocKeyIndex::S
   std::vector<std::pair<std::string, search::DocId>> result;
   result.reserve(ids_.size());
   for (search::DocId id = 0; id < keys_.size(); ++id) {
-    if (!keys_[id].empty()) {
+    if (IsValid(id)) {
       result.emplace_back(std::string(keys_[id]), id);
     }
   }
@@ -349,9 +349,12 @@ void ShardDocIndex::DocKeyIndex::Restore(
     ids_[std::string_view(keys_[doc_id])] = doc_id;
   }
 
-  // Build free_ids_ list for any gaps in the id sequence
+  // Build free_ids_ list for any gaps in the id sequence.
+  // We cannot simply check keys_[id].empty() because a valid empty-key
+  // document has keys_[id] == "". Instead, verify via the reverse map.
   for (DocId id = 0; id <= max_id; ++id) {
-    if (keys_[id].empty()) {
+    auto it = ids_.find(keys_[id]);
+    if (it == ids_.end() || it->second != id) {
       free_ids_.push_back(id);
     }
   }

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -285,6 +285,7 @@ class ShardDocIndex {
   // Used in FieldsValuesPerDocId to store values for each field per document
   using FieldsValues = absl::InlinedVector<search::SortableValue, 4>;
 
+ public:
   // DocKeyIndex manages mapping document keys to ids and vice versa through a simple interface.
   struct DocKeyIndex {
     // Hash/Eq for heterogeneous lookup on TrackedIdsMap with string_view keys.
@@ -337,8 +338,6 @@ class ShardDocIndex {
     search::StatelessVector<DocId> free_ids_;
     DocId last_id_ = 0;
   };
-
- public:
   // Index must be rebuilt at least once after intialization
   explicit ShardDocIndex(std::shared_ptr<const DocIndex> index);
 

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -14,6 +14,7 @@
 #include "base/gtest.h"
 #include "base/logging.h"
 #include "core/detail/gen_utils.h"
+#include "core/search/stateless_allocator.h"
 #include "facade/error.h"
 #include "facade/facade_test.h"
 #include "facade/resp_parser.h"
@@ -5395,6 +5396,52 @@ TEST_F(SearchFamilyTest, InfoIndexDefaultStopwordsOmitted) {
 
   // Collection size is 7 (no stopwords_list field).
   EXPECT_THAT(info, IsArray(_, _, _, _, _, _, _, _, "num_docs", _, "indexing", _, _, _));
+}
+
+// DocKeyIndex: empty-key documents must survive Serialize/Restore and not be
+// confused with freed slots (which also have keys_[id] == "").
+
+class DocKeyIndexTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    InitTLSearchMR(PMR_NS::get_default_resource());
+  }
+  void TearDown() override {
+    InitTLSearchMR(nullptr);
+  }
+};
+
+TEST_F(DocKeyIndexTest, SerializeDistinguishesEmptyKeyFromFreedSlot) {
+  ShardDocIndex::DocKeyIndex index;
+  auto id0 = index.Add("doc1");
+  auto id1 = index.Add("");  // valid empty-key document
+  auto id2 = index.Add("doc2");
+  index.Remove(id0);  // freed slot, also keys_[id0] == ""
+
+  auto serialized = index.Serialize();
+  ASSERT_EQ(serialized.size(), 2u);  // id1 + id2, not the freed id0
+
+  sort(serialized.begin(), serialized.end(),
+       [](const auto& a, const auto& b) { return a.second < b.second; });
+  EXPECT_EQ(serialized[0], make_pair(string(""), id1));
+  EXPECT_EQ(serialized[1], make_pair(string("doc2"), id2));
+}
+
+TEST_F(DocKeyIndexTest, RestoreRoundTripsEmptyKey) {
+  ShardDocIndex::DocKeyIndex index;
+  auto id0 = index.Add("doc1");
+  auto id1 = index.Add("");
+  auto id2 = index.Add("doc2");
+  index.Remove(id0);
+
+  ShardDocIndex::DocKeyIndex restored;
+  restored.Restore(index.Serialize());
+
+  EXPECT_FALSE(restored.IsValid(id0));  // gap slot stays free
+  EXPECT_TRUE(restored.IsValid(id1));   // empty-key doc survives
+  EXPECT_TRUE(restored.IsValid(id2));
+  EXPECT_EQ(restored.Get(id1), "");
+  EXPECT_EQ(restored.Add("doc3"), id0);  // freed slot is reused
 }
 
 }  // namespace dfly


### PR DESCRIPTION
Summary: Fixes serialization/restoration of search document key mappings when a document key is the empty string.

Changes:

- Serialize `DocKeyIndex` entries using `IsValid()` instead of `key.empty()` so empty-key documents are preserved
- Adjust `DocKeyIndex::Restore()` gap detection to avoid treating empty-key documents as free slots
- Expose `ShardDocIndex::DocKeyIndex` for direct unit testing and add coverage for empty-key round-trips