### PR TITLE
fix: use after free in HNSW

### DIFF
--- a/src/core/search/hnsw_index.cc
+++ b/src/core/search/hnsw_index.cc
@@ -76,7 +76,8 @@ struct HnswlibAdapter {
         world_{&space_,       params.capacity, params.hnsw_m, params.hnsw_ef_construction,
                100 /* seed*/, copy_vector},
         copy_vector_{copy_vector},
-        data_size_{params.dim * sizeof(float)} {
+        data_size_{params.dim * sizeof(float)},
+        safe_data_(data_size_ / sizeof(float), 1.0f) {
   }
 
   // Adds a point to the index. If the write lock cannot be acquired (e.g.
@@ -298,10 +299,24 @@ struct HnswlibAdapter {
   }
 
   void DoRemove(GlobalDocId id) {
+    auto it = copy_vector_ ? world_.label_lookup_.end() : world_.label_lookup_.find(id);
+
     HnswErrorStatus status = world_.markDelete(id);
     if (status != HnswErrorStatus::SUCCESS) {
       VLOG(1) << "HnswlibAdapter::Remove failed with status: " << static_cast<int>(status)
               << " for global id: " << id;
+      return;
+    }
+
+    // In borrowed mode the node stays in the graph after markDelete and
+    // traversal still computes distances for it.  Replace the external
+    // pointer with safe_data_ so the caller can free the original data.
+    // Uses 1.0f (not zero) because CosineDistance(v, 0) = 0 would bias
+    // traversal toward deleted nodes.
+    if (it != world_.label_lookup_.end()) {
+      const char* safe_ptr = reinterpret_cast<const char*>(safe_data_.data());
+      char* ptr_location = world_.getDataPtrByInternalId(it->second);
+      memcpy(ptr_location, &safe_ptr, sizeof(void*));
     }
   }
 
@@ -532,6 +547,7 @@ struct HnswlibAdapter {
 
   bool copy_vector_;                    // Whether vectors are copied into hnswlib.
   size_t data_size_;                    // Byte size of a single vector.
+  std::vector<float> safe_data_;        // Non-zero data for deleted nodes in borrowed mode.
   mutable base::SpinLock deferred_mu_;  // Protects deferred_ops_.
   absl::flat_hash_map<GlobalDocId, DeferredOp> deferred_ops_;  // GUARDED_BY(deferred_mu_)
 };

--- a/src/core/search/hnsw_index.cc
+++ b/src/core/search/hnsw_index.cc
@@ -77,7 +77,7 @@ struct HnswlibAdapter {
                100 /* seed*/, copy_vector},
         copy_vector_{copy_vector},
         data_size_{params.dim * sizeof(float)},
-        safe_data_(data_size_ / sizeof(float), 1.0f) {
+        stub_vector_(data_size_ / sizeof(float), 1.0f) {
   }
 
   // Adds a point to the index. If the write lock cannot be acquired (e.g.
@@ -310,11 +310,11 @@ struct HnswlibAdapter {
 
     // In borrowed mode the node stays in the graph after markDelete and
     // traversal still computes distances for it.  Replace the external
-    // pointer with safe_data_ so the caller can free the original data.
+    // pointer with stub_vector_ so the caller can free the original data.
     // Uses 1.0f (not zero) because CosineDistance(v, 0) = 0 would bias
     // traversal toward deleted nodes.
     if (it != world_.label_lookup_.end()) {
-      const char* safe_ptr = reinterpret_cast<const char*>(safe_data_.data());
+      const char* safe_ptr = reinterpret_cast<const char*>(stub_vector_.data());
       char* ptr_location = world_.getDataPtrByInternalId(it->second);
       memcpy(ptr_location, &safe_ptr, sizeof(void*));
     }
@@ -547,7 +547,7 @@ struct HnswlibAdapter {
 
   bool copy_vector_;                    // Whether vectors are copied into hnswlib.
   size_t data_size_;                    // Byte size of a single vector.
-  std::vector<float> safe_data_;        // Non-zero data for deleted nodes in borrowed mode.
+  std::vector<float> stub_vector_;      // Non-zero data for deleted nodes in borrowed mode.
   mutable base::SpinLock deferred_mu_;  // Protects deferred_ops_.
   absl::flat_hash_map<GlobalDocId, DeferredOp> deferred_ops_;  // GUARDED_BY(deferred_mu_)
 };

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -1210,7 +1210,7 @@ TEST_P(HnswSerializationTest, RoundTrip) {
 // Regression: in borrowed mode (copy_vector=false), Remove marks the node deleted
 // but hnswlib still traverses it and dereferences its data pointer.  If the external
 // data is freed (as happens after DEL), the pointer dangles.  The fix in DoRemove
-// replaces it with safe_data_.  This test catches the use-after-free under ASAN;
+// replaces it with stub_vector_.  This test catches the use-after-free under ASAN;
 // without ASAN it exercises the code path but freed memory may still be readable.
 TEST(HnswBorrowedMode, DanglingPointerAfterRemove) {
   constexpr size_t kDim = 256;

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -1207,6 +1207,81 @@ TEST_P(HnswSerializationTest, RoundTrip) {
   }
 }
 
+// Regression: in borrowed mode (copy_vector=false), Remove marks the node deleted
+// but hnswlib still traverses it and dereferences its data pointer.  If the external
+// data is freed (as happens after DEL), the pointer dangles.  The fix in DoRemove
+// replaces it with safe_data_.  This test catches the use-after-free under ASAN;
+// without ASAN it exercises the code path but freed memory may still be readable.
+TEST(HnswBorrowedMode, DanglingPointerAfterRemove) {
+  constexpr size_t kDim = 256;
+  constexpr size_t kN = 50;
+
+  InitTLSearchMR(PMR_NS::get_default_resource());
+  absl::Cleanup cleanup = [] { InitTLSearchMR(nullptr); };
+
+  SchemaField::VectorParams params;
+  params.use_hnsw = true;
+  params.dim = kDim;
+  params.sim = VectorSimilarity::L2;
+  params.capacity = kN * 2;
+  params.hnsw_m = 16;
+  params.hnsw_ef_construction = 200;
+  HnswVectorIndex index(params, /*copy_vector=*/false);
+
+  struct BorrowedDoc : public DocumentAccessor {
+    const char* data;
+    explicit BorrowedDoc(const char* d) : data(d) {
+    }
+    std::optional<VectorInfo> GetVector(string_view, size_t) const override {
+      return BorrowedFtVector{data};
+    }
+    std::optional<StringList> GetStrings(string_view) const override {
+      return std::nullopt;
+    }
+    std::optional<StringList> GetTags(string_view) const override {
+      return std::nullopt;
+    }
+    std::optional<NumsList> GetNumbers(string_view) const override {
+      return std::nullopt;
+    }
+  };
+
+  std::mt19937 rng(42);
+  std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+
+  auto MakeBuf = [&] {
+    auto buf = std::make_unique<float[]>(kDim);
+    for (size_t d = 0; d < kDim; d++)
+      buf[d] = dist(rng);
+    return buf;
+  };
+
+  // Add nodes — graph stores pointers into these buffers.
+  std::vector<std::unique_ptr<float[]>> bufs(kN);
+  for (size_t i = 0; i < kN; i++) {
+    bufs[i] = MakeBuf();
+    BorrowedDoc doc(reinterpret_cast<const char*>(bufs[i].get()));
+    index.Add(i, doc, "vec");
+  }
+
+  // Remove + free first 10 (simulates DEL freeing PrimeValue).
+  for (size_t i = 0; i < 10; i++) {
+    index.Remove(i);
+    bufs[i].reset();
+  }
+
+  // Add new nodes — addPoint traverses deleted nodes with freed data.
+  for (size_t i = kN; i < kN + 10; i++) {
+    bufs.push_back(MakeBuf());
+    BorrowedDoc doc(reinterpret_cast<const char*>(bufs.back().get()));
+    index.Add(i, doc, "vec");
+  }
+
+  vector<float> query(kDim, 0.0f);
+  auto results = index.Knn(query.data(), 5, std::nullopt);
+  EXPECT_GT(results.size(), 0u);
+}
+
 INSTANTIATE_TEST_SUITE_P(HnswSer, HnswSerializationTest,
                          testing::Values(HnswSerParam{0, 2, VectorSimilarity::L2},
                                          HnswSerParam{10, 2, VectorSimilarity::L2},


### PR DESCRIPTION
  ## Summary
  In borrowed-vector mode (copy_vector=false), after markDelete the HNSW node                                    
  stays in the graph with links intact. hnswlib traversal computes distances for
  all visited nodes including deleted ones. When the caller frees the external                                   
  data (DEL frees PrimeValue, HSET replaces SDS), the pointer dangles and                                        
  subsequent addPoint/KNN traversal crashes in the distance function.                                            
                                                                                                                 
  The fix replaces the external pointer with a safe 1.0f-filled buffer in                                        
  DoRemove after markDelete succeeds. Uses 1.0f (not zero) because                                               
  CosineDistance(v, zero) = 0 would bias traversal toward deleted nodes.                                         
                                                                                                                 
  ## How to reproduce                                                                                            
                                                                                                                 
  Build with ASAN and run the new test:                                                                          
  
 ```
 bash                                                                                                        
  ./helio/blaze.sh -DWITH_ASAN=ON -DWITH_AWS=OFF -DWITH_GCP=OFF   
  cd build-dbg && ninja search_test                                                                              
  ./search_test --gtest_filter="HnswBorrowedMode.DanglingPointerAfterRemove"                                     
                                                                                                                 
  Without the fix ASAN reports heap-use-after-free in L2DistanceStatic                                           
  called from addPoint → updatePoint → searchBaseLayer.                    
```