### PR TITLE
refactor(rdb): use std::bit_cast (Fixes private #188)

### DIFF
--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -1169,9 +1169,6 @@ io::Result<double> RdbLoaderBase::FetchBinaryDouble() {
   uint8_t buf[8];
   mem_buf_->ReadAndConsume(8, buf);
   uint64_t val = base::LE::LoadT<uint64_t>(buf);
-
-  // std::bit_cast is the C++20-sanctioned way to reinterpret the bits of a double.
-  // Using reinterpret_cast/union approach is an undefined behavior under strict aliasing.
   return std::bit_cast<double>(val);
 }
 

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -22,6 +22,7 @@ extern "C" {
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_split.h>
 
+#include <bit>
 #include <cmath>
 #include <cstring>
 
@@ -1161,20 +1162,17 @@ auto RdbLoaderBase::FetchIntegerObject(int enctype) -> io::Result<string> {
 }
 
 io::Result<double> RdbLoaderBase::FetchBinaryDouble() {
-  union {
-    uint64_t val;
-    double d;
-  } u;
-
-  static_assert(sizeof(u) == sizeof(uint64_t));
   auto ec = EnsureRead(8);
   if (ec)
     return make_unexpected(ec);
 
   uint8_t buf[8];
   mem_buf_->ReadAndConsume(8, buf);
-  u.val = base::LE::LoadT<uint64_t>(buf);
-  return u.d;
+  uint64_t val = base::LE::LoadT<uint64_t>(buf);
+
+  // std::bit_cast is the C++20-sanctioned way to reinterpret the bits of a double.
+  // Using reinterpret_cast/union approach is an undefined behavior under strict aliasing.
+  return std::bit_cast<double>(val);
 }
 
 io::Result<double> RdbLoaderBase::FetchDouble() {

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -8,6 +8,7 @@
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
 
+#include <bit>
 #include <queue>
 
 extern "C" {
@@ -776,9 +777,12 @@ error_code RdbSerializer::SaveLongLongAsString(int64_t value) {
  * Return -1 on error, the size of the serialized value on success. */
 error_code RdbSerializer::SaveBinaryDouble(double val) {
   static_assert(sizeof(val) == 8);
-  const uint64_t* src = reinterpret_cast<const uint64_t*>(&val);
+
+  // std::bit_cast is the C++20-sanctioned way to reinterpret the bits of a double.
+  // Using reinterpret_cast/union approach is an undefined behavior under strict aliasing.
+  uint64_t src = std::bit_cast<uint64_t>(val);
   uint8_t buf[8];
-  absl::little_endian::Store64(buf, *src);
+  absl::little_endian::Store64(buf, src);
 
   return WriteRaw(Bytes{buf, sizeof(buf)});
 }

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -777,9 +777,6 @@ error_code RdbSerializer::SaveLongLongAsString(int64_t value) {
  * Return -1 on error, the size of the serialized value on success. */
 error_code RdbSerializer::SaveBinaryDouble(double val) {
   static_assert(sizeof(val) == 8);
-
-  // std::bit_cast is the C++20-sanctioned way to reinterpret the bits of a double.
-  // Using reinterpret_cast/union approach is an undefined behavior under strict aliasing.
   uint64_t src = std::bit_cast<uint64_t>(val);
   uint8_t buf[8];
   absl::little_endian::Store64(buf, src);


### PR DESCRIPTION
Replace reinterpret_cast/union type-punning with std::bit_cast in SaveBinaryDouble/FetchBinaryDouble.

The previous patterns violate C++ strict-aliasing rules, triggering undefined behavior that compilers may exploit at -O3 optimization levels.

std::bit_cast (C++20) provides safe, well-defined bit-level type reinterpretation.
