### PR TITLE
feat(server): complete AzureSnapshotStorage implementation

### DIFF
--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -30,6 +30,14 @@ inputs:
   s3-bucket:
     required: true
     type: string
+  azure-container:
+    required: false
+    type: string
+    description: "Azure Blob Storage container name for snapshot tests"
+  azure-storage-connection-string:
+    required: false
+    type: string
+    description: "Azure Storage connection string"
   epoll:
     required: false
     type: string
@@ -127,6 +135,9 @@ runs:
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key || env.AWS_SECRET_ACCESS_KEY }}
         AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
         AWS_REGION: ${{ env.AWS_REGION || 'us-east-1' }}
+        # Azure credentials for snapshot tests (optional)
+        DRAGONFLY_AZURE_CONTAINER: ${{ inputs.azure-container }}
+        AZURE_STORAGE_CONNECTION_STRING: ${{ inputs.azure-storage-connection-string }}
 
     - name: Send notification on failure
       if: failure() && github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,8 @@ jobs:
           # Non-release build will not run tests marked as opt_only
           # "not empty" string is needed for release build because pytest command can not get empty string for filter
           filter: ${{ matrix.build-type == 'Release' && 'not debug_only' || 'not opt_only' }}
+          azure-container: ${{ secrets.AZURE_REGTEST_CONTAINER }}
+          azure-storage-connection-string: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}
 
       - name: Upload regression logs on failure
         if: failure()
@@ -319,6 +321,8 @@ jobs:
           run-only-on-ubuntu-latest: true
           filter: large
           s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}
+          azure-container: ${{ secrets.AZURE_REGTEST_CONTAINER }}
+          azure-storage-connection-string: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}
 
       - name: Upload logs on failure
         if: failure()

--- a/src/server/detail/snapshot_storage.cc
+++ b/src/server/detail/snapshot_storage.cc
@@ -45,7 +45,12 @@ constexpr string_view kSummarySuffix = "summary.dfs"sv;
 
 pair<string, string> GetBucketPath(string_view path) {
   string_view clean = path;
-  auto prefix = absl::StartsWith(clean, kS3Prefix) ? kS3Prefix : kGCSPrefix;
+  string_view prefix = kGCSPrefix;
+  if (absl::StartsWith(clean, kS3Prefix)) {
+    prefix = kS3Prefix;
+  } else if (absl::StartsWith(clean, kAzurePrefix)) {
+    prefix = kAzurePrefix;
+  }
   clean = absl::StripPrefix(clean, prefix);
 
   size_t pos = clean.find('/');
@@ -407,29 +412,44 @@ AzureSnapshotStorage::AzureSnapshotStorage() {
 }
 
 AzureSnapshotStorage::~AzureSnapshotStorage() {
-  util::http::TlsClient::FreeContext(ctx_);
+  if (ctx_)
+    util::http::TlsClient::FreeContext(ctx_);
 }
 
 error_code AzureSnapshotStorage::Init(unsigned connect_ms) {
-  error_code ec = creds_provider_->Init(connect_ms);
-  if (!ec) {
+  RETURN_ERROR(creds_provider_->Init(connect_ms));
+  if (creds_provider_->IsHttps()) {
     ctx_ = util::http::TlsClient::CreateSslContext();
   }
-  return ec;
+
+  return {};
 }
 
 io::Result<std::pair<io::Sink*, uint8_t>, GenericError> AzureSnapshotStorage::OpenWriteFile(
     const std::string& path) {
-  return nonstd::make_unexpected(GenericError("Not implemented"));
+  auto [container, key] = GetBucketPath(path);
+  cloud::azure::WriteFileOptions opts;
+  opts.creds_provider = creds_provider_.get();
+  opts.ssl_cntx = ctx_;
+
+  io::Result<io::WriteFile*> dest_res = cloud::azure::OpenWriteFile(container, key, opts);
+  if (!dest_res) {
+    return nonstd::make_unexpected(GenericError(dest_res.error(), "Could not open file"));
+  }
+
+  return std::pair(*dest_res, FileType::CLOUD);
 }
 
 io::ReadonlyFileOrError AzureSnapshotStorage::OpenReadFile(const std::string& path) {
   if (!IsAzurePath(path))
     return nonstd::make_unexpected(GenericError("Invalid azure path"));
 
-  auto [bucket, key] = GetBucketPath(path);
+  auto [container, key] = GetBucketPath(path);
+  cloud::azure::ReadFileOptions opts;
+  opts.creds_provider = creds_provider_.get();
+  opts.ssl_cntx = ctx_;
 
-  return nonstd::make_unexpected(GenericError("Not implemented"));
+  return cloud::azure::OpenReadFile(container, key, opts);
 }
 
 io::Result<std::string, GenericError> AzureSnapshotStorage::LoadPath(string_view dir,
@@ -449,7 +469,7 @@ io::Result<std::string, GenericError> AzureSnapshotStorage::LoadPath(string_view
   io::Result<vector<SnapStat>, GenericError> keys =
       proactor->Await([this, bucket_name = bucket_name,
                        prefix = prefix]() -> io::Result<vector<SnapStat>, GenericError> {
-        cloud::azure::Storage azure((cloud::azure::Credentials*)creds_provider_.get());
+        cloud::azure::Storage azure(creds_provider_.get());
         vector<SnapStat> res;
         error_code ec =
             azure.List(bucket_name, prefix, false, 500, [&res](const cloud::StorageListItem& item) {
@@ -466,7 +486,7 @@ io::Result<std::string, GenericError> AzureSnapshotStorage::LoadPath(string_view
 
   auto match_key = FindMatchingFile(prefix, dbfilename, *keys);
   if (!match_key.empty()) {
-    return absl::StrCat(kGCSPrefix, bucket_name, "/", match_key);
+    return absl::StrCat(kAzurePrefix, bucket_name, "/", match_key);
   }
   return nonstd::make_unexpected(GenericError(
       std::make_error_code(std::errc::no_such_file_or_directory), "Snapshot not found"));

--- a/src/server/detail/snapshot_storage.h
+++ b/src/server/detail/snapshot_storage.h
@@ -28,6 +28,7 @@
 
 #include "io/io.h"
 #include "server/execution_state.h"
+#include "util/cloud/azure/creds_provider.h"
 #include "util/cloud/utils.h"
 #include "util/fibers/fiberqueue_threadpool.h"
 #include "util/fibers/uring_file.h"

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -328,8 +328,17 @@ std::shared_ptr<detail::SnapshotStorage> CreateCloudSnapshotStorage(std::string_
     LOG(ERROR) << "Compiled without GCP support";
     exit(1);
 #endif
+  } else if (detail::IsAzurePath(uri)) {
+    auto azure = std::make_shared<detail::AzureSnapshotStorage>();
+    auto ec = shard_set->pool()->GetNextProactor()->Await(
+        [&] { return azure->Init(detail::kBucketConnectMs); });
+    if (ec) {
+      LOG(ERROR) << "Failed to initialize Azure snapshot storage: " << ec.message();
+      exit(1);
+    }
+    return azure;
   } else {
-    LOG(ERROR) << "Uknown cloud storage " << uri;
+    LOG(ERROR) << "Unknown cloud storage " << uri;
     exit(1);
   }
 }
@@ -2872,7 +2881,7 @@ std::optional<SaveCmdOptions> ServerFamily::GetSaveCmdOpts(CmdArgList args,
       LOG(ERROR) << "Compiled without AWS support";
       exit(1);
 #endif
-    } else if (detail::IsGCSPath(ArgS(args, 1))) {
+    } else if (detail::IsGCSPath(ArgS(args, 1)) || detail::IsAzurePath(ArgS(args, 1))) {
       save_cmd_opts.cloud_uri = ArgS(args, 1);
     } else {
       // no cloud_uri get basename and return

--- a/tests/dragonfly/requirements.txt
+++ b/tests/dragonfly/requirements.txt
@@ -20,6 +20,7 @@ numpy
 pytest-json-report>=1.5.0
 psutil>=5.9.5
 boto3>=1.28.55
+azure-storage-blob>=12.19.0
 redis-om>=0.3.3
 pytest-emoji>=0.2.0
 pytest-icdiff>=0.8

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -8,6 +8,7 @@ import redis
 from redis import asyncio as aioredis
 from pathlib import Path
 import boto3
+from azure.storage.blob import BlobServiceClient
 from .instance import DflyInstanceFactory, RedisServer
 from random import randint as rand
 import string
@@ -474,6 +475,51 @@ async def test_s3_save_local_dir(async_client, tmp_dir):
         delete_s3_objects(
             os.environ["DRAGONFLY_S3_BUCKET"],
             str(tmp_dir)[1:] + "/s3_dump",
+        )
+
+
+def _missing_azure_test_env():
+    return (
+        "DRAGONFLY_AZURE_CONTAINER" not in os.environ
+        or os.environ["DRAGONFLY_AZURE_CONTAINER"] == ""
+        or "AZURE_STORAGE_CONNECTION_STRING" not in os.environ
+        or os.environ["AZURE_STORAGE_CONNECTION_STRING"] == ""
+    )
+
+
+def delete_azure_objects(container, prefix):
+    conn_str = os.environ["AZURE_STORAGE_CONNECTION_STRING"]
+    blob_service = BlobServiceClient.from_connection_string(conn_str)
+    container_client = blob_service.get_container_client(container)
+    blobs = container_client.list_blobs(name_starts_with=prefix)
+    for blob in blobs:
+        container_client.delete_blob(blob.name)
+
+
+@pytest.mark.skipif(
+    _missing_azure_test_env(),
+    reason="Azure storage container or credentials are not configured",
+)
+@dfly_args({**BASIC_ARGS})
+async def test_azure_snapshot(async_client, tmp_dir):
+    seeder = DebugPopulateSeeder(key_target=10_000)
+    await seeder.run(async_client)
+
+    start_capture = await DebugPopulateSeeder.capture(async_client)
+    az_path = "az://" + os.environ["DRAGONFLY_AZURE_CONTAINER"] + str(tmp_dir)
+
+    try:
+        # save to Azure + flush + load from Azure
+        await async_client.execute_command("SAVE", "DF", az_path, "snapshot")
+        assert await async_client.flushall()
+        await async_client.execute_command("DFLY", "LOAD", az_path + "/snapshot-summary.dfs")
+
+        assert await DebugPopulateSeeder.capture(async_client) == start_capture
+
+    finally:
+        delete_azure_objects(
+            os.environ["DRAGONFLY_AZURE_CONTAINER"],
+            str(tmp_dir)[1:],
         )
 
 


### PR DESCRIPTION
## Summary
- Complete `AzureSnapshotStorage`: implement `OpenWriteFile` and `OpenReadFile` using the `cloud::azure` API
- Fix `GetBucketPath` to handle `az://` prefix; fix `LoadPath` bug returning `kGCSPrefix` instead of `kAzurePrefix`
- Wire `AzureSnapshotStorage` into `CreateCloudSnapshotStorage` so `az://` URIs are routed correctly
- Only create SSL context when the endpoint is HTTPS (enables Azurite emulator support)
- Update helio submodule with Azure HTTP endpoint support and `AccountInfo` refactor
- Add `test_azure_snapshot` to `snapshot_test.py` (skips without real credentials)
- Add `azure-storage-blob` to test requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)