### PR TITLE
fix: memory calculation after GC

### DIFF
--- a/src/core/interpreter.cc
+++ b/src/core/interpreter.cc
@@ -1255,13 +1255,15 @@ void InterpreterManager::Return(Interpreter* ir) {
   const uint64_t max_memory_usage = absl::GetFlag(FLAGS_lua_mem_gc_threshold);
   using namespace chrono;
   ++tl_stats().interpreter_return;
-  tl_stats().used_bytes += ir->TakeUsedBytes();
-  if (max_memory_usage != 0 && tl_stats().used_bytes > max_memory_usage) {
+  int64_t delta = ir->TakeUsedBytes();
+  if (max_memory_usage != 0 && (tl_stats().used_bytes + delta) > max_memory_usage) {
     ++tl_stats().force_gc_calls;
     auto before = steady_clock::now();
     tl_stats().gc_freed_memory += ir->RunGC();
+    // Include memory freed by GC in delta so used_bytes gets the net result.
+    delta += ir->TakeUsedBytes();
 
-    VLOG(2) << "stats_used_bytes: " << tl_stats().used_bytes
+    VLOG(2) << "stats_used_bytes: " << tl_stats().used_bytes + delta
             << " lua_mem_gc_threshold: " << max_memory_usage
             << " force_gc_calls: " << tl_stats().force_gc_calls
             << " freed_mem: " << tl_stats().gc_freed_memory;
@@ -1269,6 +1271,7 @@ void InterpreterManager::Return(Interpreter* ir) {
     auto after = steady_clock::now();
     tl_stats().gc_duration_ns += duration_cast<nanoseconds>(after - before).count();
   }
+  tl_stats().used_bytes += delta;
   if (ir >= storage_.data() && ir < storage_.data() + storage_.size()) {
     available_.push_back(ir);
     waker_.notify();

--- a/src/core/interpreter_test.cc
+++ b/src/core/interpreter_test.cc
@@ -9,6 +9,8 @@ extern "C" {
 #include <lua.h>
 }
 
+#include <absl/flags/flag.h>
+#include <absl/flags/reflection.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_replace.h>
 #include <gmock/gmock.h>
@@ -22,6 +24,8 @@ extern "C" {
 extern "C" {
 #include "redis/zmalloc.h"
 }
+
+ABSL_DECLARE_FLAG(uint64_t, lua_mem_gc_threshold);
 
 namespace dfly {
 using namespace std;
@@ -598,6 +602,40 @@ TEST_F(InterpreterTest, LuaGcStatistic) {
 
   im.Return(interpreter);
   EXPECT_GE(used_bytes, InterpreterManager::tl_stats().used_bytes);
+}
+
+// Verifies that Return() drains used_bytes_ after RunGC().
+// Without this, freed memory is never reflected in tl_stats().used_bytes,
+// so every Return() past the threshold triggers a full LUA_GCCOLLECT.
+TEST_F(InterpreterTest, GcAccountingAfterReturn) {
+  absl::FlagSaver fs;
+  absl::SetFlag(&FLAGS_lua_mem_gc_threshold, uint64_t{1});
+
+  InterpreterManager im(1);
+  auto* interpreter = im.Get();
+
+  // Generate ~100KB of garbage.
+  string script = "local s = string.rep('x', 1024 * 100) return #s";
+  char sha_buf[64];
+  Interpreter::FuncSha1(script, sha_buf);
+
+  string result;
+  ASSERT_EQ(Interpreter::ADD_OK,
+            interpreter->AddFunction({sha_buf, strlen(sha_buf)}, script, &result));
+  ASSERT_EQ(Interpreter::RUN_OK, interpreter->RunFunction({sha_buf, strlen(sha_buf)}, &error_));
+
+  auto& stats = InterpreterManager::tl_stats();
+  uint64_t gc_before = stats.force_gc_calls;
+  im.Return(interpreter);
+  ASSERT_GT(stats.force_gc_calls, gc_before);
+
+  // Re-borrow: if Return() drained used_bytes_ after GC, residual is 0.
+  // Bug: without the fix, residual is ~-300KB (stale freed bytes never drained).
+  interpreter = im.Get();
+  EXPECT_EQ(0, interpreter->TakeUsedBytes());
+
+  absl::SetFlag(&FLAGS_lua_mem_gc_threshold, uint64_t{0});
+  im.Return(interpreter);
 }
 
 }  // namespace dfly


### PR DESCRIPTION
Summary: Fixes Lua interpreter pool memory accounting so forced GC decisions reflect net memory change after GC.

Changes:

- In InterpreterManager::Return(), track a signed delta from TakeUsedBytes() and incorporate the post-RunGC() delta.
- Update tl_stats().used_bytes using the net delta and adjust VLOG output accordingly.
- Add GcAccountingAfterReturn test to ensure freed bytes are drained and repeated forced GCs don’t occur.