### PR TITLE
fix: delete empty hash after field expiry in FIELDTTL

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -897,6 +897,7 @@ OpResult<long> OpFieldTtl(Transaction* t, EngineShard* shard, string_view key, s
   } else {
     DCHECK_EQ(OBJ_HASH, it->second.ObjType());
     res = HSetFamily::FieldExpireTime(db_cntx, it->second, field);
+    HSetFamily::DeleteIfEmpty(db_slice, db_cntx, key, it->second);
   }
   return res <= 0 ? res : int32_t(res - MemberTimeSeconds(db_cntx.time_now_ms));
 }

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -31,6 +31,7 @@ extern "C" {
 #include "server/tiering/decoders.h"
 #include "server/tiering/serialized_map.h"
 #include "server/transaction.h"
+#include "server/tx_base.h"
 
 using namespace std;
 
@@ -1237,6 +1238,9 @@ bool HSetFamily::DeleteIfEmpty(DbSlice& db_slice, const DbContext& db_cntx, std:
 
   if (auto res = db_slice.FindMutable(db_cntx, key, OBJ_HASH); res) {
     db_slice.DelMutable(db_cntx, std::move(*res));
+    if (db_slice.shard_owner()->journal()) {
+      RecordDelete(db_cntx.db_index, key);
+    }
     return true;
   }
   return false;

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -1227,6 +1227,21 @@ int32_t HSetFamily::FieldExpireTime(const DbContext& db_context, const PrimeValu
   }
 }
 
+bool HSetFamily::DeleteIfEmpty(DbSlice& db_slice, const DbContext& db_cntx, std::string_view key,
+                               const PrimeValue& pv) {
+  if (pv.Encoding() != kEncodingStrMap2)
+    return false;
+
+  if (auto* sm = static_cast<StringMap*>(pv.RObjPtr()); !sm->Empty())
+    return false;
+
+  if (auto res = db_slice.FindMutable(db_cntx, key, OBJ_HASH); res) {
+    db_slice.DelMutable(db_cntx, std::move(*res));
+    return true;
+  }
+  return false;
+}
+
 // returns vector of results for each field in values:
 // -2 if the provided key does not exist.
 // 0 if the specified NX | XX | GT | LT condition has not been met.

--- a/src/server/hset_family.h
+++ b/src/server/hset_family.h
@@ -29,6 +29,11 @@ class HSetFamily {
   static int32_t FieldExpireTime(const DbContext& db_context, const PrimeValue& pv,
                                  std::string_view field);
 
+  // Delete the hash key if it became empty after lazy field expiry.
+  // Returns true if the key was deleted.
+  static bool DeleteIfEmpty(DbSlice& db_slice, const DbContext& db_cntx, std::string_view key,
+                            const PrimeValue& pv);
+
   static std::vector<long> SetFieldsExpireTime(const OpArgs& op_args, uint32_t ttl_sec,
                                                ExpireFlags flags, std::string_view key,
                                                CmdArgList values, PrimeValue* pv);

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -592,6 +592,32 @@ async def test_bgsave_and_save(async_client: aioredis.Redis):
     await async_client.execute_command("SAVE")
 
 
+@dfly_args({"proactor_threads": 1, "dbfilename": "test-hsetex-save", "dir": "{DRAGONFLY_TMP}/"})
+async def test_save_hash_with_expired_fields(async_client: aioredis.Redis):
+    """
+    HSETEX creates a hash with field-level TTL.  After all fields
+    expire, the hash key remains in the DB with Size()==0.  SAVE then hits the
+    DFATAL check in SaveEntry because OBJ_HASH does not allow empty values.
+
+    Reproduction: HSETEX with short TTL -> SAVE (while field is alive) ->
+    wait for expiry -> second SAVE -> crash.
+    """
+
+    await async_client.execute_command("HSETEX", "mykey", "1", "f1", "v1")
+    await async_client.execute_command("SAVE")
+
+    await asyncio.sleep(1.5)
+
+    # Trigger lazy expiry of the field — the key remains but has 0 fields.
+    assert await async_client.execute_command("FIELDTTL", "mykey", "f1") == -3
+
+    # This SAVE crashes on unfixed code: SaveEntry sees empty hash → DFATAL.
+    await async_client.execute_command("SAVE")
+
+    # If we get here, the server survived.
+    assert await async_client.ping()
+
+
 @dfly_args({"proactor_threads": 1, "dbfilename": "test-save-del-crash", "dir": "{DRAGONFLY_TMP}/"})
 async def test_save_with_concurrent_mutations(df_server):
     """


### PR DESCRIPTION
FIELDTTL triggers lazy expiry inside StringMap::Find(), which removes expired fields.  When the last field expires, the hash becomes empty (Size()==0), but the key stays in the database.  A subsequent SAVE hits the DFATAL in SaveEntry (rdb_save.cc:274) because OBJ_HASH does not allow empty values, crashing the server.

The fix mirrors what already exists for sets (DeleteSetIfEmpty) and for HEXPIRE/HPERSIST: after FieldExpireTime() returns, check whether the StringMap is empty and delete the key.

Fixes #7133