### PR TITLE
fix: support LEGACY_GLOG=OFF

### DIFF
--- a/src/server/detail/snapshot_storage.h
+++ b/src/server/detail/snapshot_storage.h
@@ -12,6 +12,8 @@
 #include "util/cloud/aws/s3_storage.h"
 #endif
 
+#include "util/cloud/azure/creds_provider.h"
+
 #ifdef WITH_GCP
 #include "util/cloud/gcp/gcp_creds_provider.h"
 #include "util/cloud/gcp/gcs.h"
@@ -162,7 +164,7 @@ class AzureSnapshotStorage : public SnapshotStorage {
 
   std::error_code CheckPath(const std::string& path) final;
 
-  std::unique_ptr<util::cloud::CredentialsProvider> creds_provider_;
+  std::unique_ptr<util::cloud::azure::Credentials> creds_provider_;
   SSL_CTX* ctx_ = NULL;
 };
 

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -85,6 +85,10 @@ ABSL_DECLARE_FLAG(strings::MemoryBytesFlag, maxmemory);
 ABSL_DECLARE_FLAG(uint32_t, proactor_threads);
 ABSL_DECLARE_FLAG(std::string, dbfilename);
 
+#ifdef USE_ABSL_LOG
+ABSL_FLAG(bool, alsologtostderr, false, "also log messages to stderr in addition to logfiles");
+#endif
+
 ABSL_FLAG(string, bind, "",
           "Bind address. If empty - binds on all interfaces. "
           "It's not advised due to security implications.");
@@ -997,7 +1001,7 @@ void PrintBasicUsageInfo() {
       "                      ..                      \n"
       "* Logs will be written to the first available of the following paths:\n";
 
-  for (const auto& dir : google::GetLoggingDirectories()) {
+  for (const auto& dir : base::GetLoggingDirectories()) {
     const string_view maybe_slash = absl::EndsWith(dir, "/") ? "" : "/";
     absl::StrAppend(&output, dir, maybe_slash, "dragonfly.*\n");
   }
@@ -1062,12 +1066,23 @@ Usage: dragonfly [FLAGS]
   };
 
   absl::SetFlagsUsageConfig(config);
+
+#ifndef USE_ABSL_LOG
   google::InitGoogleLogging(argv[0]);
   google::SetLogFilenameExtension(".log");
+#endif
 
   MainInitGuard guard(&argc, &argv);
 
   ParseFlagsFromEnv();
+
+#ifdef USE_ABSL_LOG
+  // alsologtostderr: route all logs to stderr in addition to files.
+  // logtostderr is handled by FileLogSink::Init() in helio.
+  if (GetFlag(FLAGS_alsologtostderr)) {
+    absl::SetStderrThreshold(absl::LogSeverityAtLeast::kInfo);
+  }
+#endif
 
   if (!GetFlag(FLAGS_omit_basic_usage)) {
     PrintBasicUsageInfo();

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -1037,8 +1037,10 @@ void EngineShard::CacheStats() {
   size_t obj_memory = table_memory <= used_mem ? used_mem - table_memory : 0;
   size_t bytes_per_obj = entries > 0 ? obj_memory / entries : 0;
 
-  VLOG_EVERY_N(1, 500) << "Entries count " << entries << " "
-                       << "obj_memory: " << obj_memory << ", bytes_per_obj: " << bytes_per_obj;
+  if (VLOG_IS_ON(1)) {
+    LOG_EVERY_T(INFO, 1) << "Entries count " << entries << " "
+                         << "obj_memory: " << obj_memory << ", bytes_per_obj: " << bytes_per_obj;
+  }
 
   db_slice.UpdateMemoryParams(free_mem / shard_set->size(), bytes_per_obj);
   last_mem_params_ = {now, used_mem};

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -149,7 +149,11 @@ ShutdownWatchdog::ShutdownWatchdog(util::ProactorPool& pp) : pool{pp} {
   watchdog_fb = pool.GetNextProactor()->LaunchFiber("shutdown_watchdog", [&] {
     if (!watchdog_done.WaitFor(20s)) {
       LOG(ERROR) << "Deadlock detected during shutdown";
+#ifdef USE_ABSL_LOG
+      absl::SetStderrThreshold(absl::LogSeverityAtLeast::kInfo);
+#else
       absl::SetFlag(&FLAGS_alsologtostderr, true);
+#endif
       util::fb2::Mutex m;
       pool.AwaitFiberOnAll([&m](unsigned index, auto*) {
         util::ThisFiber::SetName(absl::StrFormat("print_stack_fib_%u", index));

--- a/src/server/serializer_base.cc
+++ b/src/server/serializer_base.cc
@@ -179,7 +179,7 @@ bool SerializerBase::ProcessBucketInternal(DbIndex db_index, PrimeTable::bucket_
 
   // Assert the version is equal to a snapshot version (might be a different concurrent one),
   // to prove no concurrent modifications are possible (they would've assigned a different version)
-#if DCHECK_IS_ON()
+#if !defined(NDEBUG)
   DCHECK_GE(it.GetVersion(), snapshot_version_);
   auto current_snapshots = db_slice_->SnapshotVersions();
   DCHECK(std::ranges::find(current_snapshots, it.GetVersion()) != current_snapshots.end())

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -272,7 +272,11 @@ void BaseFamilyTest::ResetService() {
 
     if (!watchdog_done_.WaitFor(20s)) {
       LOG(ERROR) << "Deadlock detected!!!!";
+#ifdef USE_ABSL_LOG
+      absl::SetStderrThreshold(absl::LogSeverityAtLeast::kInfo);
+#else
       absl::SetFlag(&FLAGS_alsologtostderr, true);
+#endif
       fb2::Mutex m;
       shard_set->pool()->AwaitFiberOnAll([&m, this](unsigned index, ProactorBase* base) {
         ThisFiber::SetName("Watchdog");


### PR DESCRIPTION
This PR makes it easier to switch to LEGACY_GLOG=OFF where we use absl+helio based logging and do not use glog library for this. 

No functional changes as we do not change LEGACY_GLOG option.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
