### PR TITLE
fix: sign helm chart PR commits via GitHub API

### DIFF
--- a/.github/workflows/docker-release2.yml
+++ b/.github/workflows/docker-release2.yml
@@ -328,14 +328,14 @@ jobs:
       if: env.IS_PRERELEASE != 'true'
       uses: peter-evans/create-pull-request@v7
       with:
-        token: ${{ secrets.DRAGONFLY_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         branch: helm-chart-update/${{ env.TAG_NAME }}
         base: main
         title: 'chore(helm-chart): update to ${{ env.TAG_NAME }}'
         body: 'Automated Helm chart version bump to ${{ env.TAG_NAME }}.'
         commit-message: 'chore(helm-chart): update to ${{ env.TAG_NAME }}'
         sign-commits: true
-        reviewers: vyavdoshenko
+        reviewers: romange,vyavdoshenko
         add-paths: |
           contrib/charts/dragonfly/Chart.yaml
           contrib/charts/dragonfly/ci

--- a/.github/workflows/docker-release2.yml
+++ b/.github/workflows/docker-release2.yml
@@ -291,27 +291,16 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v6
 
-    - name: Configure Git
-      if: env.IS_PRERELEASE != 'true'
-      run: |
-        git config user.name "$GITHUB_ACTOR"
-        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
     - name: Update helm chart
       if: env.IS_PRERELEASE != 'true'
       run: |
-        git checkout -b helm-chart-update/${{ env.TAG_NAME }} origin/main
+        git checkout main
         sed -Ei \
             -e 's/^(version\:) .*/\1 '${{ env.TAG_NAME }}'/g' \
             -e 's/^(appVersion\:) .*/\1 "'${{ env.TAG_NAME }}'"/g' \
             contrib/charts/dragonfly/Chart.yaml
 
         go test ./contrib/charts/dragonfly/... -update
-
-        git commit \
-          -m 'chore(helm-chart): update to ${{ env.TAG_NAME }}' \
-          contrib/charts/dragonfly/Chart.yaml \
-          contrib/charts/dragonfly/ci || true
 
     - name: Push Helm chart as OCI to Github
       if: env.IS_PRERELEASE != 'true'
@@ -337,13 +326,16 @@ jobs:
 
     - name: Create Helm Chart PR
       if: env.IS_PRERELEASE != 'true'
-      env:
-        GH_TOKEN: ${{ secrets.DRAGONFLY_TOKEN }}
-      run: |
-        git push origin helm-chart-update/${{ env.TAG_NAME }}
-        gh pr create \
-          --base main \
-          --head helm-chart-update/${{ env.TAG_NAME }} \
-          --title 'chore(helm-chart): update to ${{ env.TAG_NAME }}' \
-          --body 'Automated Helm chart version bump to ${{ env.TAG_NAME }}.' \
-          --reviewer vyavdoshenko
+      uses: peter-evans/create-pull-request@v7
+      with:
+        token: ${{ secrets.DRAGONFLY_TOKEN }}
+        branch: helm-chart-update/${{ env.TAG_NAME }}
+        base: main
+        title: 'chore(helm-chart): update to ${{ env.TAG_NAME }}'
+        body: 'Automated Helm chart version bump to ${{ env.TAG_NAME }}.'
+        commit-message: 'chore(helm-chart): update to ${{ env.TAG_NAME }}'
+        sign-commits: true
+        reviewers: vyavdoshenko
+        add-paths: |
+          contrib/charts/dragonfly/Chart.yaml
+          contrib/charts/dragonfly/ci


### PR DESCRIPTION
Use peter-evans/create-pull-request with sign-commits: true and GITHUB_TOKEN to create verified commits for automated helm chart PRs.

Tested: 
https://github.com/dragonflydb/dragonfly/pull/7140
https://github.com/dragonflydb/dragonfly/actions/runs/24400198339/job/71268417708