### PR TITLE
fix: correct per-type memory accounting when object type changes in AutoUpdater

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -473,9 +473,10 @@ DbSlice::AutoUpdater::~AutoUpdater() {
 }
 
 void DbSlice::AutoUpdater::ReduceHeapUsage() {
-  AccountObjectMemory(fields_.key, fields_.it->second.ObjType(), -fields_.orig_value_heap_size,
+  AccountObjectMemory(fields_.key, fields_.orig_obj_type, -fields_.orig_value_heap_size,
                       fields_.db_slice->GetDBTable(fields_.db_ind));
-  fields_.orig_value_heap_size = 0;  // Reset to avoid double accounting.
+  fields_.orig_value_heap_size = 0;                      // Reset to avoid double accounting.
+  fields_.orig_obj_type = fields_.it->second.ObjType();  // Sync type after accounting.
 }
 
 void DbSlice::AutoUpdater::Run() {
@@ -490,10 +491,22 @@ void DbSlice::AutoUpdater::Run() {
 
   CHECK_NE(fields_.db_slice, nullptr);
 
-  ssize_t delta = static_cast<int64_t>(fields_.it->second.MallocUsed()) -
-                  static_cast<int64_t>(fields_.orig_value_heap_size);
-  AccountObjectMemory(fields_.key, fields_.it->second.ObjType(), delta,
-                      fields_.db_slice->GetDBTable(fields_.db_ind));
+  CompactObjType current_type = fields_.it->second.ObjType();
+  int64_t current_size = static_cast<int64_t>(fields_.it->second.MallocUsed());
+  DbTable* table = fields_.db_slice->GetDBTable(fields_.db_ind);
+
+  if (current_type != fields_.orig_obj_type) {
+    // Type changed: remove old size from old type, add new size to new type separately.
+    // Applying (current_size - orig_size) to the new type would incorrectly subtract
+    // from a counter that never had the original bytes added to it.
+    AccountObjectMemory(fields_.key, fields_.orig_obj_type,
+                        -static_cast<int64_t>(fields_.orig_value_heap_size), table);
+    AccountObjectMemory(fields_.key, current_type, current_size, table);
+  } else {
+    ssize_t delta = current_size - static_cast<int64_t>(fields_.orig_value_heap_size);
+    AccountObjectMemory(fields_.key, current_type, delta, table);
+  }
+
   fields_.db_slice->PostUpdate(fields_.db_ind, fields_.key);
   Cancel();  // Reset to not run again
 }
@@ -508,7 +521,8 @@ DbSlice::AutoUpdater::AutoUpdater(DbIndex db_ind, std::string_view key, const It
               .db_ind = db_ind,
               .it = it,
               .key = key,
-              .orig_value_heap_size = it->second.MallocUsed()} {
+              .orig_value_heap_size = it->second.MallocUsed(),
+              .orig_obj_type = it->second.ObjType()} {
   DCHECK(IsValid(it));
 }
 

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -175,6 +175,7 @@ class DbSlice {
 
       // The following fields are calculated at init time
       size_t orig_value_heap_size = 0;
+      CompactObjType orig_obj_type = 0;
     };
 
     AutoUpdater(DbIndex db_ind, std::string_view key, const Iterator& it, DbSlice* db_slice);

--- a/src/server/table.cc
+++ b/src/server/table.cc
@@ -26,8 +26,13 @@ void DbTableStats::AddTypeMemoryUsage(unsigned type, int64_t delta) {
   DCHECK_GE(obj_memory_usage, memory_usage_by_type[type]);
 
   if (delta < 0 && memory_usage_by_type[type] < size_t(-delta)) {
-    LOG_EVERY_T(ERROR, 1) << "Encountered underflow memory usage when aggregating per-type memory: "
-                          << obj_memory_usage << " + " << delta << ", type: " << type;
+#ifdef NDEBUG
+    LOG_EVERY_T(ERROR, 1)
+#else
+    LOG_EVERY_T(FATAL, 1)
+#endif
+        << "Encountered underflow memory usage when aggregating per-type memory: "
+        << memory_usage_by_type[type] << " + " << delta << ", type: " << type;
 
     // Truncate delta to avoid underflow, but keep the memory usage consistent with the sum of
     // per-type usage.


### PR DESCRIPTION
## Summary

- `AutoUpdater::Run()` was applying `(new_size - orig_size)` to the **current** object type. When `AddOrUpdate` replaces a value with a different type (e.g., SORT STORE overwriting a SET with a LIST), the original bytes were tracked under the old type but the delta was subtracted from the new type's counter — which never held those bytes — causing an underflow crash in `AddTypeMemoryUsage`.
- Fix by capturing `orig_obj_type` at `AutoUpdater` construction and, on type change, separately removing `orig_size` from the old type and adding `current_size` to the new type.

## Changes

- `src/server/db_slice.h`: Add `CompactObjType orig_obj_type` field to `AutoUpdater::Fields`
- `src/server/db_slice.cc`:
  - `AutoUpdater` constructor: capture `orig_obj_type = it->second.ObjType()` at init time
  - `Run()`: detect type changes; when changed, split into two `AccountObjectMemory` calls (remove from old type, add to new type) instead of one signed delta on the new type
  - `ReduceHeapUsage()`: use `orig_obj_type` for accounting; sync to current type afterward so subsequent `Run()` remains consistent
- `src/server/table.cc`: `AddTypeMemoryUsage()` now `FATAL` (not `ERROR`) in debug builds on underflow; log the per-type counter value instead of `obj_memory_usage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)