### PR TITLE
feat(facade):  add connection migration support for IO loop V2

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -697,6 +697,7 @@ void Connection::OnPostMigrateThread() {
   }
 
   if (ioloop_v2_ && socket_ && socket_->IsOpen() && migration_allowed_to_register_) {
+    MaybeEnableRecvMultishot();
     socket_->RegisterOnRecv([this](const FiberSocketBase::RecvNotification& n) {
       NotifyOnRecv(n);
       io_event_.notify();
@@ -1390,22 +1391,28 @@ void Connection::OnBreakCb(int32_t mask) {
 }
 
 void Connection::HandleMigrateRequest() {
-  if (cc_->conn_closing || !migration_request_)
+  if (!migration_request_)
     return;
 
-  DCHECK(!ioloop_v2_);
+  if (cc_->conn_closing) {
+    migration_request_ = nullptr;
+    return;
+  }
+
   ProactorBase* dest = migration_request_;
-  if (async_fb_.IsJoinable()) {
+
+  // V1 loop: we must coordinate with and shutdown the AsyncFiber before migration.
+  // V2 loop: is single-fiber and handles this by breaking the dispatch_q loop.
+  if (!ioloop_v2_ && async_fb_.IsJoinable()) {
     SendAsync({MigrationRequestMessage{}});
     async_fb_.Join();
   }
 
-  // We don't support migrating with subscriptions as it would require moving thread local
-  // handles. We can't check above, as the queue might have contained a subscribe request.
-
+  // We don't support migrating with subscriptions as it would require moving thread-local handles.
   if (cc_->subscriptions == 0) {
     // RegisterOnErrorCb might be called on POLLHUP and the join above is a preemption point.
     // So, it could be the case that after this fiber wakes up the connection might be closing.
+    // Re-check closing status after the potential V1 Join() or any preemption.
     if (cc_->conn_closing) {
       return;
     }
@@ -1413,15 +1420,17 @@ void Connection::HandleMigrateRequest() {
     tl_facade_stats->conn_stats.num_migrations++;
     migration_request_ = nullptr;
 
-    // We need to return early as the socket is closing and IoLoop will clean up.
-    // The reason that this is true is because of the following DCHECK
-    DCHECK(!async_fb_.IsJoinable());
+    // Verify that no background command processing is active.
+    // V1 loop: Join() ensures this.
+    // V2 loop: it is guaranteed by the single-fiber loop.
+    DCHECK(ioloop_v2_ || !async_fb_.IsJoinable());
 
-    // which can never trigger since we Joined on the async_fb_ above and we are
-    // atomic in respect to our proactor meaning that no other fiber will
-    // launch the DispatchFiber.
     std::ignore = !this->Migrate(dest);
   }
+
+  // Note: If cc_->subscriptions > 0, we skip the hop but leave migration_request_
+  // set. This defers the migration, retrying at the start of every subsequent
+  // loop iteration until all subscriptions are cleared.
 }
 
 io::Result<size_t> Connection::HandleRecvSocket() {
@@ -2178,13 +2187,18 @@ facade::ConnectionContext* Connection::cntx() {
 }
 
 void Connection::RequestAsyncMigration(util::fb2::ProactorBase* dest, bool force) {
-  if ((!force && !migration_enabled_) || cc_ == nullptr || ioloop_v2_) {
+  if ((!force && !migration_enabled_) || cc_ == nullptr) {
     return;
   }
 
   // Connections can migrate at most once.
   migration_enabled_ = false;
   migration_request_ = dest;
+
+  // Wake up the V2 loop so it can immediately process the migration request.
+  if (ioloop_v2_) {
+    io_event_.notify();
+  }
 }
 
 void Connection::StartTrafficLogging(string_view path) {
@@ -2722,9 +2736,24 @@ void Connection::CheckIoBufCapacity(bool is_iobuf_full) {
   }
 }
 
+void Connection::MaybeEnableRecvMultishot() {
+#ifdef __linux__
+  if (fb2::ProactorBase::me()->GetKind() == fb2::ProactorBase::Kind::IOURING) {
+    auto* up = static_cast<fb2::UringProactor*>(fb2::ProactorBase::me());
+    // Only enable if the buffer ring is configured and we aren't using TLS
+    if (up->BufRingEntrySize(kRecvSockGid) > 0 && !is_tls_) {
+      static_cast<fb2::UringSocket*>(socket_.get())->EnableRecvMultishot();
+      pending_input_ = false;
+    }
+  }
+#endif
+}
+
 variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
   auto* peer = socket_.get();
   recv_buf_.res_len = 0;
+
+  auto is_ready_to_migrate = [this]() { return migration_request_ && (cc_->subscriptions == 0); };
 
   // Don't proceed with RegisterOnRecv() if socket is closed (possible cancellation)
   if (!peer->IsOpen())
@@ -2736,15 +2765,7 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
   migration_allowed_to_register_ = true;
   pending_input_ = true;
 
-  if (fb2::ProactorBase::me()->GetKind() == fb2::ProactorBase::Kind::IOURING) {
-#ifdef __linux__
-    fb2::UringProactor* up = static_cast<fb2::UringProactor*>(fb2::ProactorBase::me());
-    if (up->BufRingEntrySize(kRecvSockGid) > 0 && !is_tls_) {
-      static_cast<fb2::UringSocket*>(peer)->EnableRecvMultishot();
-      pending_input_ = false;
-    }
-#endif
-  }
+  MaybeEnableRecvMultishot();
 
   peer->RegisterOnRecv([this](const FiberSocketBase::RecvNotification& n) {
     DVLOG(2) << "Calling DoReadOnRecv iobuf_len: " << io_buf_.InputLen();
@@ -2782,11 +2803,21 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
 
     // await block (no data to read)
     if (io_buf_.InputLen() == 0) {
-      io_event_.await([this]() {
+      io_event_.await([this, &is_ready_to_migrate]() {
         // TODO: optimize CanReply with looking up waiter key
         // io_buf_.InputLen() > 0 is still needed for multishot flow.
+
+        // We wake up if:
+        // 1. New data arrived or is pending (io_buf_.InputLen() > 0 || pending_input_).
+        // 2. A parsed command is ready to execute (HeadReadyToDispatch()).
+        // 3. An executed command is ready to send its reply (parsed_head_ &&
+        //    parsed_head_->CanReply()).
+        // 4. Control-plane messages arrived (!dispatch_q_.empty()).
+        // 5. The socket encountered an error/closed (io_ec_).
+        // 6. A migration to another thread was requested AND is actionable now (no subscriptions).
         return io_buf_.InputLen() > 0 || pending_input_ || HeadReadyToDispatch() ||
-               (parsed_head_ && parsed_head_->CanReply()) || !dispatch_q_.empty() || io_ec_;
+               (parsed_head_ && parsed_head_->CanReply()) || !dispatch_q_.empty() || io_ec_ ||
+               is_ready_to_migrate();
       });
     }
 
@@ -2798,9 +2829,15 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
       while (!dispatch_q_.empty()) {
         auto msg = std::move(dispatch_q_.front());
         dispatch_q_.pop_front();
-        // Temporary; ProcessAdminMessage logic doesn't apply here (migrations for example)
-        std::visit(AsyncOperations{reply_builder_.get(), this}, msg.handle);
         UpdateDispatchStats(msg, false /* subtract */);
+
+        // If a MigrationRequestMessage arrives via the dispatch queue, stop processing
+        // and let the loop iterate back to HandleMigrateRequest() at the top.
+        if (std::holds_alternative<MigrationRequestMessage>(msg.handle)) {
+          break;
+        }
+
+        std::visit(AsyncOperations{reply_builder_.get(), this}, msg.handle);
       }
 
       // TODO: Possibly don't flush unconditionally - optimize it
@@ -2875,19 +2912,21 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
         // us "deaf" to future memory relief.
         auto sub_key = qbp.v2_pipeline_backpressure_ec.subscribe_persistent(&backpressure_waiter);
 
-        io_event_.await([this]() {
+        io_event_.await([this, &is_ready_to_migrate]() {
           bool cmd_ready = parsed_head_ && parsed_head_->CanReply();
           bool under_limit = !GetQueueBackpressure().IsPipelineBufferOverLimit(
               GetLocalConnStats().pipeline_queue_bytes, parsed_cmd_q_len_);
-
           // We wake up and exit the backpressure wait if:
           // 1. Memory is freed (under_limit) or we can free it ourselves (cmd_ready).
           // 2. Control-plane messages need processing (!dispatch_q_.empty()).
           // 3. The connection is terminating (io_ec_).
-          return under_limit || cmd_ready || !dispatch_q_.empty() || io_ec_;
+          // 4. A migration was requested AND is actionable now (migration_request_ with no
+          // subscriptions).
+          return under_limit || cmd_ready || !dispatch_q_.empty() || io_ec_ ||
+                 is_ready_to_migrate();
         });
       }
-    }
+    }  // else Execute and reply
 
     if (reply_builder_->GetError()) {
       return reply_builder_->GetError();
@@ -2900,11 +2939,18 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
       return std::exchange(io_ec_, {});
     }
 
+    if ((parse_status != OK) && (parse_status != NEED_MORE)) {
+      break;
+    }
+
+    // Migration requested and actionable: skip buffer bookkeeping, jump to HandleMigrateRequest().
+    if (is_ready_to_migrate()) {
+      continue;
+    }
+
     if (parse_status == NEED_MORE) {
       parse_status = OK;
       CheckIoBufCapacity(is_iobuf_full);
-    } else if (parse_status != OK) {
-      break;
     }
   } while (peer->IsOpen());
 

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -279,6 +279,11 @@ class Connection : public util::Connection {
 
   void NotifyOnRecv(const util::FiberSocketBase::RecvNotification& n);
 
+  // Enables io_uring multishot receives for the connection if the current thread supports it.
+  // This is required during initial setup or after migrating to a new thread/proactor,
+  // provided the buffer ring is configured and the connection is not using TLS.
+  void MaybeEnableRecvMultishot();
+
   // Drains currently available bytes from socket into io_buf_ using non-blocking reads.
   void ReadPendingInput();
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -666,8 +666,8 @@ void ClientMigrate(CmdArgList args, absl::Span<facade::Listener*> listeners,
     return cmd_cntx->SendError("Invalid thread id");
   }
 
-  unsigned migrated = 0;
-  auto cb_brief = [&](unsigned current_tid, ProactorBase* p) {
+  std::atomic<unsigned> migrated{0};
+  auto search_and_migrate_cb = [&](unsigned current_tid, ProactorBase* p) {
     if (current_tid == tid) {
       return;  // we should not migrate to the same thread
     }
@@ -675,7 +675,7 @@ void ClientMigrate(CmdArgList args, absl::Span<facade::Listener*> listeners,
     auto traverse_cb = [&](unsigned, util::Connection* conn) {
       facade::Connection* dconn = static_cast<facade::Connection*>(conn);
       if (dconn->GetClientId() == id) {
-        ++migrated;
+        migrated.fetch_add(1, std::memory_order_relaxed);
         dconn->RequestAsyncMigration(shard_set->pool()->at(tid), true /* force */);
       }
     };
@@ -688,7 +688,7 @@ void ClientMigrate(CmdArgList args, absl::Span<facade::Listener*> listeners,
     }
   };
 
-  shard_set->pool()->AwaitBrief(cb_brief);
+  shard_set->pool()->AwaitFiberOnAll(search_and_migrate_cb);
 
   return cmd_cntx->rb()->SendLong(migrated);
 }

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -818,7 +818,10 @@ async def test_parser_while_script_running(async_client: aioredis.Redis, df_serv
 """
 
 
-@dfly_args({"proactor_threads": "4", "pipeline_squash": 0})
+@dfly_multi_test_args(
+    {"proactor_threads": "4", "pipeline_squash": 0, "experimental_io_loop_v2": "false"},
+    {"proactor_threads": "4", "pipeline_squash": 0, "experimental_io_loop_v2": "true"},
+)
 async def test_pipeline_batching_while_migrating(
     async_client: aioredis.Redis, df_server: DflyInstance
 ):
@@ -1367,6 +1370,7 @@ async def test_pipeline_overlimit(df_factory: DflyInstanceFactory):
         assert all(
             r == "a" * 1024 * 5 for r in res
         ), "Pipeline returned corrupted data after backpressure"
+        await c.aclose()
 
     pipeline_tasks = [asyncio.create_task(pipe_overlimit()) for _ in range(20)]
 
@@ -1410,7 +1414,9 @@ async def test_pipeline_backpressure_v2_correctness(df_server: DflyInstance):
         pipe = c.pipeline()
         for i in range(num_keys):
             pipe.get(f"bp:{i}")
-        return await pipe.execute()
+        res = await pipe.execute()
+        await c.aclose()
+        return res
 
     tasks = [asyncio.create_task(run_pipeline()) for _ in range(20)]
     results = await asyncio.gather(*tasks)
@@ -1463,6 +1469,7 @@ async def test_pipeline_backpressure_disconnect(df_factory: DflyInstanceFactory)
             pipe.get("x")
         res = await pipe.execute()
         assert len(res) == 1000
+        await c.aclose()
 
     flood_tasks = [asyncio.create_task(pipe_flood()) for _ in range(20)]
     await asyncio.sleep(2)
@@ -1594,7 +1601,10 @@ async def test_tls_client_kill_preemption(
     assert len(lines) == 0
 
 
-@dfly_args({"proactor_threads": 4})
+@dfly_multi_test_args(
+    {"proactor_threads": 4, "experimental_io_loop_v2": "false"},
+    {"proactor_threads": 4, "experimental_io_loop_v2": "true"},
+)
 async def test_client_migrate(df_server: DflyInstance):
     """
     Test that we can migrate a client with "CLIENT MIGRATE" command.
@@ -1615,6 +1625,10 @@ async def test_client_migrate(df_server: DflyInstance):
     assert resp == 1  # migrated successfully
 
 
+@dfly_multi_test_args(
+    {"proactor_threads": 4, "experimental_io_loop_v2": "false"},
+    {"proactor_threads": 4, "experimental_io_loop_v2": "true"},
+)
 async def test_client_migrate_no_conn_leak(df_server: DflyInstance):
     admin = df_server.client()
     resp = await admin.execute_command("DFLY THREAD")
@@ -1655,6 +1669,169 @@ async def test_client_migrate_no_conn_leak(df_server: DflyInstance):
     for c in clients:
         await c.aclose()
     await admin.aclose()
+
+
+@dfly_multi_test_args(
+    {
+        "proactor_threads": 4,
+        "pipeline_queue_limit": 10,
+        "pipeline_buffer_limit": "1024",
+        "experimental_io_loop_v2": "false",
+    },
+    {
+        "proactor_threads": 4,
+        "pipeline_queue_limit": 10,
+        "pipeline_buffer_limit": "1024",
+        "experimental_io_loop_v2": "true",
+    },
+)
+@pytest.mark.timeout(30)
+async def test_migration_during_backpressure(df_server: DflyInstance):
+    """Verify that a connection parked on pipeline backpressure can be migrated
+    to another thread without crashing or corrupting data.
+
+    Uses a raw TCP connection for the migrant so we can delay reading responses,
+    causing TCP send-buffer saturation and pipeline queue buildup past the limit.
+    Concurrent flood clients ensure global memory pressure (proven pattern from
+    test_pipeline_overlimit / test_pipeline_backpressure_disconnect).
+    """
+    admin = df_server.client()
+    await admin.set("x", "a" * 1024 * 5)
+
+    num_threads = (await admin.execute_command("DFLY THREAD"))[1]
+
+    # Raw TCP migrant — not reading responses forces TCP buffer saturation.
+    reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
+    writer.write(b"CLIENT SETNAME migrant\r\n")
+    await writer.drain()
+    await reader.readline()  # +OK
+
+    clients = await admin.client_list()
+    migrant_info = next(c for c in clients if c["name"] == "migrant")
+    migrant_id = int(migrant_info["id"])
+
+    # Flood without reading to saturate TCP send buffer -> queue exceeds limit.
+    writer.write(b"GET x\r\n" * 1000)
+    await writer.drain()
+
+    # Concurrent flood clients for global memory pressure.
+    async def pipe_flood():
+        c = df_server.client()
+        pipe = c.pipeline()
+        for _ in range(1000):
+            pipe.get("x")
+        res = await pipe.execute()
+        assert len(res) == 1000
+        assert all(
+            r == "a" * 1024 * 5 for r in res
+        ), "Pipeline returned corrupted data after backpressure"
+        await c.aclose()
+
+    flood_tasks = [asyncio.create_task(pipe_flood()) for _ in range(20)]
+    await asyncio.sleep(2)
+
+    # Verify backpressure was hit.
+    # V1 increments pipeline_throttle_total reliably because DispatchSingle parks the fiber.
+    # V2's self-regulating ParseLoop drains the queue each iteration, so the counter may not fire.
+    info = await admin.info("stats")
+    is_v2 = df_server.args.get("experimental_io_loop_v2") == "true"
+    if not is_v2:
+        assert int(info["pipeline_throttle_total"]) > 0, "Expected pipeline_throttle_total > 0"
+
+    # Migrate the parked connection to a different thread.
+    migrated = False
+    for dest_tid in range(num_threads):
+        resp = await admin.execute_command("CLIENT", "MIGRATE", migrant_id, dest_tid)
+        if resp == 1:
+            migrated = True
+            break
+    assert migrated, "CLIENT MIGRATE should succeed for at least one destination thread"
+
+    # Lift BOTH limits so parked fibers can resume.
+    # Raise byte limit FIRST: if queue-limit is raised first, connections wake and
+    # immediately re-hit the byte ceiling, causing a needless thundering-herd wakeup.
+    await admin.config_set("pipeline_buffer_limit", 1024 * 1024 * 50)  # 50 MB
+    await admin.config_set("pipeline_queue_limit", 10000)
+
+    # Drain the raw socket so the Dragonfly connection can flush its send buffer.
+    expected_resp = b"$" + str(1024 * 5).encode() + b"\r\n" + (b"a" * 1024 * 5) + b"\r\n"
+    for i in range(1000):
+        res = await asyncio.wait_for(reader.readexactly(len(expected_resp)), timeout=15.0)
+        assert res == expected_resp
+
+    await asyncio.wait_for(asyncio.gather(*flood_tasks), timeout=15.0)
+
+    # Verify server is still healthy after migration + backpressure.
+    assert await admin.ping() is True
+
+    writer.close()
+    await writer.wait_closed()
+    await admin.aclose()
+
+
+@dfly_multi_test_args(
+    {
+        "proactor_threads": 4,
+        "pipeline_buffer_limit": "1024",
+        "pipeline_queue_limit": 10,
+        "experimental_io_loop_v2": "false",
+    },
+    {
+        "proactor_threads": 4,
+        "pipeline_buffer_limit": "1024",
+        "pipeline_queue_limit": 10,
+        "experimental_io_loop_v2": "true",
+    },
+)
+@pytest.mark.timeout(30)
+async def test_pipeline_global_memory_relief(df_server: DflyInstance):
+    """Verify that raising pipeline_buffer_limit via CONFIG SET wakes parked
+    connections through NotifyPipelineWaiters (V2) / pipeline_cnd (V1).
+
+    Uses 4 proactor threads with both limits set low to reliably trigger
+    backpressure.  20 concurrent pipeline clients flood the server.  We then
+    raise pipeline_buffer_limit (exercising NotifyPipelineWaiters for V2)
+    followed by pipeline_queue_limit to fully unblock all connections.
+
+    Crucial for V2's v2_pipeline_waiters broadcast mechanism that notifies
+    all parked io_event_ waiters when the global memory budget changes.
+    """
+    client = df_server.client()
+
+    await client.set("x", "a" * 1024 * 5)  # 5 KB value
+
+    async def pipe_flood():
+        c = df_server.client()
+        pipe = c.pipeline()
+        for _ in range(1000):
+            pipe.get("x")
+        res = await pipe.execute()
+        assert len(res) == 1000
+        assert all(
+            r == "a" * 1024 * 5 for r in res
+        ), "Pipeline returned corrupted data after backpressure"
+        await c.aclose()
+
+    tasks = [asyncio.create_task(pipe_flood()) for _ in range(20)]
+    await asyncio.sleep(2)
+
+    # Verify backpressure was hit.
+    # V1 increments pipeline_throttle_total reliably because DispatchSingle parks the fiber.
+    # V2's self-regulating ParseLoop drains the queue each iteration, so the counter may not fire.
+    info = await client.info("stats")
+    is_v2 = df_server.args.get("experimental_io_loop_v2") == "true"
+    if not is_v2:
+        assert int(info["pipeline_throttle_total"]) > 0, "Expected pipeline_throttle_total > 0"
+
+    # Raise buffer limit first — triggers NotifyPipelineWaiters for V2.
+    # Connections wake, re-evaluate, but queue_limit (10) still holds them.
+    await client.config_set("pipeline_buffer_limit", str(1024 * 1024))
+
+    # Raise queue limit to fully unblock all parked connections.
+    await client.config_set("pipeline_queue_limit", 10000)
+
+    await asyncio.wait_for(asyncio.gather(*tasks), timeout=15.0)
+    assert await client.ping() is True
 
 
 async def test_issue_5931_malformed_protocol_crash(df_server: DflyInstance):


### PR DESCRIPTION
This Pr includes 2 separate commits:

1) feat(facade): support V2 loop conn migration

Enable CLIENT MIGRATE for connections using the experimental IoLoopV2.

C++ core changes:
* Extract MaybeEnableRecvMultishot() helper and invoke it after
  migration in OnPostMigrateThread() to re-arm io_uring.
* Remove ioloop_v2_ early-return in RequestAsyncMigration and trigger
  io_event_.notify() so the V2 loop wakes up immediately.
* Lift DCHECK(!ioloop_v2_) in HandleMigrateRequest and safely guard
  the V1-only async_fb_.Join() call.
* Add migration_request_ to io_event_.await() predicates so the loop
  breaks out of read/backpressure park states.
* Handle MigrationRequestMessage in dispatch_q by breaking back to
  the top-of-loop migration check.

Test additions & infrastructure:
* Extend migration and pipeline batching tests with explicit V1/V2
  variants using @dfly_multi_test_args.
* Add test_migration_during_backpressure to verify migrating a
  connection while parked on pipeline backpressure.
* Add test_pipeline_global_memory_relief to verify CONFIG SET safely
  wakes parked V2 connections via NotifyPipelineWaiters.

2) Fix two bugs in ClientMigrate:

a. Dispatcher fiber sleep violation (AwaitBrief misuse)
   AwaitBrief executes callbacks directly on the dispatcher fiber,
   which must never sleep. ClientMigrate's callback calls
   TraverseConnectionsOnThread, which yields via SleepFor to
   prevent event-loop starvation. This caused "Should not preempt
   dispatcher" CHECK failures.

   Fixed by using AwaitFiberOnAll, which wraps the callback in a
   dedicated fiber allowed to sleep.

b. Data race on migrated counter
   AwaitFiberOnAll runs callbacks concurrently on all proactor
   threads. The bare `unsigned migrated = 0` with `++migrated` is
   a textbook data race (UB), even though only one thread should
   find the matching client ID.

   Fixed by using std::atomic<unsigned> with relaxed ordering.

Both bugs were uncovered by test_client_migrate_no_conn_leak,
which migrates 20 clients concurrently.
