### PR TITLE
fix: race condition during flush slots

### DIFF
--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -854,6 +854,62 @@ TEST_F(ClusterFamilyTest, FlushSlotsAndImmediatelySetValue) {
   }
 }
 
+// Regression: FlushSlots launches an async fiber. Entries inserted after FlushSlots returns
+// but before the fiber runs must survive, because they were created after the flush was
+// initiated. The bug was that RegisterOnChange (which captures the version threshold) ran
+// inside the detached fiber instead of synchronously in FlushSlots, so the version threshold
+// was captured too late and freshly-inserted entries appeared "old" to the flush.
+TEST_F(ClusterFamilyTest, FlushSlotsDoesNotDeleteEntriesInsertedAfterFlush) {
+  ConfigSingleNodeCluster(GetMyId());
+
+  // Run on a shard proactor to control fiber scheduling precisely.
+  pp_->at(0)->Await([&] {
+    auto* es = EngineShard::tlocal();
+    ASSERT_NE(es, nullptr);
+
+    auto& db_slice = namespaces->GetDefaultNamespace().GetDbSlice(es->shard_id());
+
+    // Step 0: Insert pre-existing entries that must be deleted by the flush.
+    // This ensures we can verify the flush fiber actually ran (not just that it was scheduled).
+    DbContext cntx{&namespaces->GetDefaultNamespace(), 0, GetCurrentTimeMs()};
+    for (int i = 0; i < 10; i++) {
+      string key = absl::StrCat("pre:", i);
+      PrimeValue val;
+      val.SetString("old");
+      auto res = db_slice.AddOrUpdate(cntx, key, std::move(val), 0);
+      CHECK(res.ok());
+    }
+    EXPECT_EQ(db_slice.DbSize(0), 10u);
+
+    // Step 1: FlushSlots creates a detached fiber. We do NOT yield, so the fiber
+    // cannot run yet.
+    cluster::SlotRanges ranges({{0, 16383}});
+    db_slice.FlushSlots(ranges);
+
+    // Step 2: Insert entries WITHOUT yielding — the flush fiber still has not executed.
+    // Each insert calls NextVersion(), advancing the global counter.
+    for (int i = 0; i < 50; i++) {
+      string key = absl::StrCat("key:", i);
+      PrimeValue val;
+      val.SetString("val");
+      auto res = db_slice.AddOrUpdate(cntx, key, std::move(val), 0);
+      CHECK(res.ok());
+    }
+    EXPECT_EQ(db_slice.DbSize(0), 60u);
+
+    // Step 3: Yield — the detached flush fiber gets scheduled and runs.
+    // BUG: the fiber calls RegisterOnChange NOW, capturing a version AFTER the 50 inserts.
+    //   All 50 entries have version < next_version → deleted.
+    // FIX: version was captured in FlushSlots (step 1), so entries have version > next_version
+    //   → survive.
+    util::ThisFiber::SleepFor(50ms);
+
+    // Step 4: Verify pre-existing entries were flushed (proving the fiber ran) and
+    // post-flush entries survived.
+    EXPECT_EQ(db_slice.DbSize(0), 50u);
+  });
+}
+
 TEST_F(ClusterFamilyTest, ClusterCrossSlot) {
   ConfigSingleNodeCluster(GetMyId());
 

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -810,12 +810,15 @@ void DbSlice::DelMutable(Context cntx, ItAndUpdater it_updater) {
   Del(cntx, it_updater.it);
 }
 
-void DbSlice::FlushSlotsFb(const cluster::SlotSet& slot_ids) {
+void DbSlice::FlushSlotsFb(const cluster::SlotSet& slot_ids, uint64_t next_version,
+                           uint64_t cb_id) {
   VLOG(1) << "Start FlushSlotsFb";
   // Slot deletion can take time as it traverses all the database, hence it runs in fiber.
-  // We want to flush all the data of a slot that was added till the time the call to FlushSlotsFb
-  // was made. Therefore we delete slots entries with version < next_version
-  uint64_t next_version = 0;
+  // We want to flush all the data of a slot that was added till the time the call to FlushSlots
+  // was made. Therefore we delete slots entries with version < next_version.
+  // next_version and the on_change callback are registered synchronously in FlushSlots
+  // so that entries inserted after the flush was initiated (e.g. by concurrent RDB loading)
+  // get version >= next_version and survive.
   uint64_t del_count = 0;
 
   // Explicitly copy table smart pointer to keep reference count up (flushall drops it)
@@ -841,22 +844,6 @@ void DbSlice::FlushSlotsFb(const cluster::SlotSet& slot_ids) {
     }
   };
 
-  auto on_change = [&](DbIndex db_index, const ChangeReq& req) {
-    FiberAtomicGuard fg;
-
-    if (const auto* bit = std::get_if<PrimeTable::bucket_iterator>(&req)) {
-      if (!bit->is_done() && bit->GetVersion() < next_version) {
-        iterate_bucket(*bit);
-      }
-    } else {
-      for (auto it : std::get<PrimeTable::BucketSet>(req).buckets()) {
-        if (!it.is_done() && it.GetVersion() < next_version)
-          iterate_bucket(it);
-      }
-    }
-  };
-  next_version = RegisterOnChange(std::move(on_change));
-
   ServerState& etl = *ServerState::tlocal();
   PrimeTable* pt = &table->prime;
   PrimeTable::Cursor cursor;
@@ -868,7 +855,7 @@ void DbSlice::FlushSlotsFb(const cluster::SlotSet& slot_ids) {
   } while (cursor && etl.gstate() != GlobalState::SHUTTING_DOWN);
 
   VLOG(1) << "FlushSlotsFb del count is: " << del_count;
-  UnregisterOnChange(next_version);
+  UnregisterOnChange(cb_id);
 
   if (absl::GetFlag(FLAGS_cluster_flush_decommit_memory)) {
     int64_t start = absl::GetCurrentTimeNanos();
@@ -884,8 +871,53 @@ void DbSlice::FlushSlotsFb(const cluster::SlotSet& slot_ids) {
 void DbSlice::FlushSlots(const cluster::SlotRanges& slot_ranges) {
   cluster::SlotSet slot_set(slot_ranges);
   InvalidateSlotWatches(slot_set);
-  fb2::Fiber("flush_slots", [this, slot_set = std::move(slot_set)]() mutable {
-    FlushSlotsFb(slot_set);
+
+  // Capture the version threshold synchronously, before launching the fiber.
+  // Entries inserted after this point get version >= next_version and survive the flush.
+  uint64_t next_version = NextVersion();
+
+  auto shared_slots = std::make_shared<cluster::SlotSet>(std::move(slot_set));
+  boost::intrusive_ptr<DbTable> table = db_arr_.front();
+
+  // Register the on_change callback synchronously so that bucket modifications between
+  // FlushSlots returning and the fiber starting are caught (the callback deletes old entries
+  // before the bucket version is bumped, preventing the traversal from skipping them).
+  auto on_change = [this, shared_slots, next_version, table](DbIndex db_index,
+                                                             const ChangeReq& req) {
+    FiberAtomicGuard fg;
+
+    auto process_bucket = [&](PrimeTable::bucket_iterator it) {
+      std::string tmp;
+      it.AdvanceIfNotOccupied();
+      while (!it.is_done()) {
+        std::string_view key = it->first.GetSlice(&tmp);
+        SlotId sid = KeySlot(key);
+        if (shared_slots->Contains(sid) && it.GetVersion() < next_version) {
+          DbContext cntx;
+          cntx.time_now_ms = GetCurrentTimeMs();
+          cntx.db_index = db_index;
+          Del(cntx, Iterator::FromPrime(it), table.get());
+        }
+        ++it;
+      }
+    };
+
+    if (const auto* bit = std::get_if<PrimeTable::bucket_iterator>(&req)) {
+      if (!bit->is_done() && bit->GetVersion() < next_version) {
+        process_bucket(*bit);
+      }
+    } else {
+      for (auto it : std::get<PrimeTable::BucketSet>(req).buckets()) {
+        if (!it.is_done() && it.GetVersion() < next_version)
+          process_bucket(it);
+      }
+    }
+  };
+
+  uint64_t cb_id = RegisterOnChange(std::move(on_change));
+
+  fb2::Fiber("flush_slots", [this, shared_slots, next_version, cb_id]() {
+    FlushSlotsFb(*shared_slots, next_version, cb_id);
   }).Detach();
 }
 

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -525,7 +525,7 @@ class DbSlice {
                                              PrimeValue obj, uint64_t expire_at_ms,
                                              bool force_update);
 
-  void FlushSlotsFb(const cluster::SlotSet& slot_ids);
+  void FlushSlotsFb(const cluster::SlotSet& slot_ids, uint64_t next_version, uint64_t cb_id);
   util::fb2::Fiber FlushDbIndexes(const std::vector<DbIndex>& indexes);
 
   // Invalidate all watched keys in database. Used on FLUSH.


### PR DESCRIPTION
fixes: #7058

Fixes a race in cluster FLUSHSLOTS where the async traversal could capture the version threshold too late and delete keys inserted immediately after the flush started.
