### PR TITLE
test: upgrade pytest-asyncio and add loop scoping

### DIFF
--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -250,13 +250,6 @@ def parse_args(args: List[str]) -> Dict[str, Union[str, None]]:
     return args_dict
 
 
-@pytest_asyncio.fixture(scope="class")
-def event_loop():
-    loop = asyncio.new_event_loop()
-    yield loop
-    loop.close()
-
-
 @pytest_asyncio.fixture(scope="class", params=[{}])
 async def df_factory(
     request,
@@ -363,15 +356,22 @@ async def async_pool(df_server: DflyInstance):
 
 
 @pytest_asyncio.fixture(scope="function")
-async def async_client(async_pool):
+async def async_client(df_server: DflyInstance):
     """
     Return an async client to the default instance with all entries flushed.
     """
-    client = aioredis.Redis(connection_pool=async_pool)
+    client = aioredis.Redis(
+        host="localhost",
+        port=df_server.port,
+        db=DATABASE_INDEX,
+        decode_responses=True,
+        max_connections=32,
+    )
     await client.client_setname("default-async-fixture")
     await client.flushall()
     await client.select(DATABASE_INDEX)
     yield client
+    await client.aclose()
 
 
 def pytest_addoption(parser):

--- a/tests/dragonfly/requirements.txt
+++ b/tests/dragonfly/requirements.txt
@@ -6,11 +6,11 @@ packaging>=23.1
 pluggy>=1.0.0
 py>=1.11.0
 pyparsing>=3.0.9
-pytest>=7.1.2
+pytest>=8.3,<9.0
 redis>=5.2.1
 tomli>=2.0.1
 wrapt>=1.14.1
-pytest-asyncio==0.20.1
+pytest-asyncio>=0.24.0,<0.25.0
 pytest-repeat>=0.9.3
 pymemcache>=4.0.0
 meta_memcache>=2

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -390,7 +390,8 @@ async def test_exit_on_s3_snapshot_load_err(df_factory):
     reason="AWS S3 snapshots bucket or credentials are not configured",
 )
 @dfly_args({**BASIC_ARGS})
-async def test_s3_snapshot(async_client, tmp_dir):
+async def test_s3_snapshot(df_server, tmp_dir):
+    async_client = df_server.client()
     seeder = DebugPopulateSeeder(key_target=10_000)
     await seeder.run(async_client)
 
@@ -460,7 +461,8 @@ async def test_s3_reload_snapshot_after_restart(df_factory, tmp_dir):
     reason="AWS S3 snapshots bucket or credentials are not configured",
 )
 @dfly_args({**BASIC_ARGS})
-async def test_s3_save_local_dir(async_client, tmp_dir):
+async def test_s3_save_local_dir(df_server, tmp_dir):
+    async_client = df_server.client()
     seeder = DebugPopulateSeeder(key_target=10_000)
     await seeder.run(async_client)
 

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -5,6 +5,7 @@ log_date_format = %Y-%m-%d %H:%M:%S
 log_file_level=INFO
 log_cli = true
 asyncio_mode=auto
+asyncio_default_fixture_loop_scope=session
 addopts = -ra --emoji --showlocals -m "not large"
 markers =
 # Tests that should only run on release builds and take significant amount of time to run.


### PR DESCRIPTION
Upgrade pytest-asyncio from 0.20.1 to 0.24.0+ and configure
event loop scope to prevent fixture crashes.

requirements.txt changes:
- pytest>=8.3,<9.0 (was >=7.1.2)
- pytest-asyncio>=0.24.0,<0.25.0 (was ==0.20.1)

conftest.py changes:
- Remove manual event_loop fixture override (deprecated in 0.24+)
- Rewrite async_client fixture to bypass async_pool. With
  session-scoped loops, the standalone ConnectionPool in async_pool
  retains connections with stale loop references when df_server
  restarts between test classes. Now async_client creates Redis
  directly with connection params, letting Redis manage its own
  internal pool and adding proper aclose() cleanup. This fixes 7
  failing tests (test_publish_stuck, test_nested_client_pause,
  test_cron_snapshot, test_set_cron_snapshot, test_basic_memory_usage,
  test_mixed_append, test_tiered_replication_with_hashes).

pytest.ini changes:
- Add asyncio_default_fixture_loop_scope=session

pytest-asyncio 0.24+ forbids manual event_loop overrides and
requires explicit loop scope configuration. We use session scope
because:
1. df_factory and other fixtures are class-scoped
2. Many async tests are module-level functions (not in classes)
3. session scope supports both patterns without UsageError

Upper bounds prevent pip from installing pytest 9.x and
pytest-asyncio 1.x, which conflict with dragonfly-fakeredis-tests.

snapshot_test.py changes:
- test_s3_snapshot, test_s3_save_local_dir: replace async_client
  fixture with df_server.client(). With session-scoped loops,
  the shared async_client pool holds stale connections from a
  previous df_server instance, causing "Future attached to a
  different loop". Creating a fresh client per test avoids this
  (same pattern used by test_s3_reload_snapshot_after_restart).

