### PR TITLE
fix(server): Reduce mutex scope in snapshot/streamer

### DIFF
--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -8,7 +8,6 @@
 #include <absl/container/flat_hash_set.h>
 
 #include <atomic>
-#include <ranges>
 
 #include "common/string_or_view.h"
 #include "core/mi_memory_resource.h"
@@ -398,10 +397,6 @@ class DbSlice {
 
   bool HasRegisteredCallbacks() const {
     return !change_cb_.empty();
-  }
-
-  auto SnapshotVersions() const {
-    return change_cb_ | std::views::keys;
   }
 
   // Call registered callbacks with version less than upper_bound.

--- a/src/server/journal/streamer.cc
+++ b/src/server/journal/streamer.cc
@@ -495,10 +495,7 @@ void RestoreStreamer::Run() {
   } while (cursor);
 
   // Force serialize of all delayed entries.
-  {
-    std::lock_guard guard(big_value_mu_);
-    ProcessDelayedEntries(true, 0, cntx_);
-  }
+  ProcessDelayedEntries(true, 0, cntx_);
 
   VLOG(1) << "RestoreStreamer finished loop of " << my_slots_.ToSlotRanges().ToString()
           << ", shard " << db_slice_->shard_id() << ". Buckets looped " << stats_.buckets_loop;
@@ -601,6 +598,7 @@ unsigned RestoreStreamer::SerializeBucketLocked(DbIndex /* unused */,
 }
 
 void RestoreStreamer::SerializeFetchedEntry(const TieredDelayedEntry& tde, const PrimeValue& pv) {
+  std::lock_guard lk{stream_mu_};
   cmd_serializer_->SerializeEntry(tde.key.ToString(), tde.key, pv, tde.expire);
 }
 
@@ -618,6 +616,7 @@ void RestoreStreamer::WriteEntry(BucketIdentity bucket, string_view key, const P
       EnqueueOffloaded(bucket, 0, PrimeKey{key}, pv, expire_ms, mc_flags);
     }
   } else {
+    std::lock_guard lk{stream_mu_};
     stats_.commands += cmd_serializer_->SerializeEntry(key, pk, pv, expire_ms);
   }
 }

--- a/src/server/serializer_base.cc
+++ b/src/server/serializer_base.cc
@@ -141,14 +141,6 @@ void SerializerBase::UnregisterChangeListener() {
 
 bool SerializerBase::ProcessBucket(DbIndex db_index, PrimeTable::bucket_iterator it,
                                    bool on_update) {
-  std::lock_guard guard(big_value_mu_);
-  return ProcessBucketInternal(db_index, it, on_update);
-}
-
-bool SerializerBase::ProcessBucketInternal(DbIndex db_index, PrimeTable::bucket_iterator it,
-                                           bool on_update) {
-  DCHECK(big_value_mu_.is_locked());
-
   // Check if this bucket is stale
   if (it.is_done() || it.GetVersion() >= snapshot_version_) {
     stats_.buckets_skipped++;
@@ -157,12 +149,11 @@ bool SerializerBase::ProcessBucketInternal(DbIndex db_index, PrimeTable::bucket_
       return false;
 
     // Force flush all delayed entries in the touched bucket
-    if (EngineShard::tlocal()->tiered_storage() != nullptr && on_update && !it.is_done())
+    if (EngineShard::tlocal()->tiered_storage() != nullptr && on_update)
       ProcessDelayedEntries(false, it.bucket_address(), base_cntx_);
 
-    // Expected to be fully serialized due to big_value_mu_ guarding all paths
-    // Otherwise, this needs to be changed to a wait
-    DCHECK(!BucketDependencies::DEBUG_IsBusy(it.bucket_address()));
+    // Wait for all dependencies to be resolved
+    BucketDependencies::Wait(it.bucket_address());
     return false;
   }
 
@@ -177,6 +168,10 @@ bool SerializerBase::ProcessBucketInternal(DbIndex db_index, PrimeTable::bucket_
     db_guard.emplace(*db_slice_->GetLatch());
   }
 
+  // The block above with updating earlier callbacks is not exlusive - check version again
+  if (it.GetVersion() >= snapshot_version_)
+    return ProcessBucket(db_index, it, on_update);  // for the false path
+
   // We call it before SerializeBucketLocked because it dchecks on bucket version.
   it.SetVersion(snapshot_version_);
   BucketDependencies::Increment(it.bucket_address());
@@ -186,15 +181,6 @@ bool SerializerBase::ProcessBucketInternal(DbIndex db_index, PrimeTable::bucket_
   stats_.buckets_on_change += unsigned(on_update);
 
   BucketDependencies::Decrement(it.bucket_address());
-
-  // Assert the version is equal to a snapshot version (might be a different concurrent one),
-  // to prove no concurrent modifications are possible (they would've assigned a different version)
-#if !defined(NDEBUG)
-  DCHECK_GE(it.GetVersion(), snapshot_version_);
-  auto current_snapshots = db_slice_->SnapshotVersions();
-  DCHECK(std::ranges::find(current_snapshots, it.GetVersion()) != current_snapshots.end())
-      << absl::StrJoin(current_snapshots, " ") << " does not contain " << it.GetVersion();
-#endif
 
   if (EngineShard::tlocal()->tiered_storage() != nullptr)
     ProcessDelayedEntries(false, on_update ? it.bucket_address() : 0, base_cntx_);
@@ -215,15 +201,10 @@ void SerializerBase::OnChangeBlocking(DbIndex db_index, PrimeTable::bucket_itera
   ProcessBucket(db_index, it, true);
 }
 
-void SerializerBase::OnChangeBlocking(DbIndex db_index, const PrimeTable::BucketSet& set) {
-  // We must acquire the mutex ahead and process all buckets under the same lock.
-  // This ensures that bucket processing and the table insertion that invoked this callback
-  // will be operating on the same state as all writes are linarly ordered by this mutex.
-  std::unique_lock lk{big_value_mu_};
-
+void SerializerBase::OnChangeBlocking(DbIndex db_index, const PrimeTable::BucketSet& bucket_set) {
   // We call Process even for up-to-date buckets to ensure all operations (delayed) are finished.
-  for (auto it : set.buckets())
-    ProcessBucketInternal(db_index, it, true);
+  for (auto it : bucket_set.buckets())
+    ProcessBucket(db_index, it, true);
 }
 
 }  // namespace dfly

--- a/src/server/serializer_base.cc
+++ b/src/server/serializer_base.cc
@@ -73,12 +73,32 @@ void DelayedEntryHandler::ProcessDelayedEntries(bool force, BucketIdentity flush
   if (delayed_entries_.size() > kMaxDelayedEntries)
     force |= true;
 
-  auto serialize_entry = [&](decltype(delayed_entries_)::iterator it) {
-    auto& entry = it->second;
+  // Extract ahead because of possible iterator invalidation during suspension (Get/Serialize)
+  // if multiple fibers progress on delayed entries
+  std::vector<decltype(delayed_entries_)::node_type> targets;
+
+  // Flush all entries of bucket if provided
+  if (flush_bucket) {
+    auto [it, end] = delayed_entries_.equal_range(flush_bucket);
+    while (it != end)
+      targets.push_back(delayed_entries_.extract(it++));
+  }
+
+  // Serialize the delayed entries that are resolved, or all if force it true
+  for (auto it = delayed_entries_.begin(); it != delayed_entries_.end();) {
+    if (!force && !it->second->value.IsResolved())
+      it++;
+    else
+      targets.push_back(delayed_entries_.extract(it++));
+  }
+
+  // Serialize all targets
+  for (auto& target : targets) {
+    auto& entry = target.mapped();
     auto value = entry->value.Get();
 
     if (!value.has_value()) {
-      deps_.Decrement(it->first);
+      deps_.Decrement(target.key());
       cntx->ReportError(make_error_code(std::errc::io_error),
                         absl::StrCat("Failed to read tiered key: ", entry->key.ToString()));
       return;
@@ -87,25 +107,8 @@ void DelayedEntryHandler::ProcessDelayedEntries(bool force, BucketIdentity flush
     PrimeValue pv{*value};
     SerializeFetchedEntry(*entry, pv);
 
-    deps_.Decrement(it->first);
-    delayed_entries_.erase(it++);
+    deps_.Decrement(target.key());
   };
-
-  // Flush all entries of bucket
-  if (flush_bucket) {
-    auto range = delayed_entries_.equal_range(flush_bucket);
-    for (auto it = range.first; it != range.second;) {
-      serialize_entry(it++);
-    }
-  }
-
-  // Serialize the delayed entries that are resolved, or all if force it true.
-  for (auto it = delayed_entries_.begin(); it != delayed_entries_.end();) {
-    if (!force && !it->second->value.IsResolved())
-      it++;
-    else
-      serialize_entry(it++);
-  }
 }
 
 SerializerBase::SerializerBase(DbSlice* slice, ExecutionState* cntx)

--- a/src/server/serializer_base.h
+++ b/src/server/serializer_base.h
@@ -125,8 +125,11 @@ class SerializerBase : public BucketDependencies, public DelayedEntryHandler {
   DbTableArray db_array_;
 
   uint64_t snapshot_version_ = 0;
-  ThreadLocalMutex big_value_mu_;
   Stats stats_;
+
+  // Guards output stream (serializer) to not be used from multiple fibers
+  // as buffered changes can be flushed amid writing a value (logical stream)
+  ThreadLocalMutex stream_mu_;
 
  private:
   // Process single bucket and call SerializeBucket. Return true if processed, false if skipped

--- a/src/server/serializer_base.h
+++ b/src/server/serializer_base.h
@@ -132,9 +132,6 @@ class SerializerBase : public BucketDependencies, public DelayedEntryHandler {
   ThreadLocalMutex stream_mu_;
 
  private:
-  // Process single bucket and call SerializeBucket. Return true if processed, false if skipped
-  bool ProcessBucketInternal(DbIndex db_index, PrimeTable::bucket_iterator it, bool on_update);
-
   uint64_t change_cb_id_ = 0;
 };
 

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -198,12 +198,8 @@ void SliceSnapshot::IterateBucketsFb(bool send_full_sync_cut) {
       }
     } while (snapshot_cursor_);
 
-    DVLOG(2) << "after loop " << ThisFiber::GetName();
     // Wait for all the outstanding delayed entries and serialize them as well.
-    {
-      std::lock_guard guard(big_value_mu_);
-      ProcessDelayedEntries(true, 0, cntx_);
-    }
+    ProcessDelayedEntries(true, 0, cntx_);
 
     PushSerialized(true);
   }  // for (dbindex)
@@ -246,6 +242,7 @@ unsigned SliceSnapshot::SerializeBucketLocked(DbIndex db_index, PrimeTable::buck
 }
 
 void SliceSnapshot::SerializeFetchedEntry(const TieredDelayedEntry& tde, const PrimeValue& pv) {
+  std::lock_guard lk{stream_mu_};
   auto res = serializer_->SaveEntry(tde.key, pv, tde.expire, tde.mc_flags, tde.dbid);
   CHECK(res);
 }
@@ -263,6 +260,7 @@ void SliceSnapshot::SerializeEntry(BucketIdentity bucket, DbIndex db_indx, const
     EnqueueOffloaded(bucket, db_indx, PrimeKey{pk.ToString()}, pv, expire_time, mc_flags);
     ++type_freq_map_[RDB_TYPE_STRING];
   } else {
+    std::lock_guard lk{stream_mu_};
     io::Result<uint8_t> res = serializer_->SaveEntry(pk, pv, expire_time, mc_flags, db_indx);
     CHECK(res);
     ++type_freq_map_[*res];
@@ -273,7 +271,7 @@ void SliceSnapshot::HandleFlushData(std::string data) {
   if (data.empty())
     return;
 
-  if (big_value_mu_.is_locked()) {
+  if (stream_mu_.is_locked()) {
     ++stats_.flushed_under_lock;
   }
   size_t serialized = data.size();
@@ -345,7 +343,7 @@ bool SliceSnapshot::PushSerialized(bool force) {
 // guaranteed by call order on the mutation fiber (OnChange precedes ConsumeJournalChange);
 // big_value_mu_ is not needed for that ordering.
 void SliceSnapshot::ConsumeJournalChange(const journal::JournalChangeItem& item) {
-  std::lock_guard barrier(big_value_mu_);
+  std::lock_guard lk{stream_mu_};
 
   // remove when we support interleaving chunks.
   LOG_IF(DFATAL, serialize_bucket_running_)


### PR DESCRIPTION
* Rename big_value_mu_ to stream_mu_ as it guards the "logical" stream - there's only one without tagged chunks
* Narrow down the scope of the mutex to guard only writes, not per bucket actions
* Account for the fact that "multiple" fibers can now start serializing