### PR TITLE
fix: fix 'occured' -> 'occurred' typos across multiple files

### DIFF
--- a/src/facade/cmd_arg_parser.cc
+++ b/src/facade/cmd_arg_parser.cc
@@ -42,7 +42,7 @@ ErrorReply CmdArgParser::ErrorInfo::MakeReply() const {
 }
 
 CmdArgParser::~CmdArgParser() {
-  DCHECK(!error_) << "Parsing error occured but not checked";
+  DCHECK(!error_) << "Parsing error occurred but not checked";
   // TODO DCHECK(!HasNext()) << "Not all args were processed";
 }
 

--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -149,7 +149,7 @@ struct CmdArgParser {
     return *this;
   }
 
-  // Expect no more arguments and return if no error has occured
+  // Expect no more arguments and return if no error has occurred
   bool Finalize() {
     if (HasNext()) {
       Report(UNPROCESSED, cur_i_);
@@ -163,7 +163,7 @@ struct CmdArgParser {
     return args_.subspan(cur_i_);
   }
 
-  // Return true if arguments are left and no errors occured
+  // Return true if arguments are left and no errors occurred
   bool HasNext() {
     return cur_i_ < args_.size() && !error_;
   }

--- a/src/server/execution_state.h
+++ b/src/server/execution_state.h
@@ -121,7 +121,7 @@ class ExecutionState {
   GenericError GetError() const;
 
   // Report an error by submitting arguments for GenericError.
-  // If this is the first error that occured, then the error handler is run
+  // If this is the first error that occurred, then the error handler is run
   // and the context state set to ERROR.
   // If the state is CANCELLED does nothing
   template <typename... T> GenericError ReportError(T&&... ts) {

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -170,7 +170,7 @@ class Service : public facade::ServiceInterface {
   void CallSHA(CmdArgList args, std::string_view sha, Interpreter* interpreter, bool read_only,
                CommandContext* cmd_cntx);
 
-  // Return optional payload - first received error that occured when executing commands.
+  // Return optional payload - first received error that occurred when executing commands.
   std::optional<facade::payload::Payload> FlushEvalAsyncCmds(ConnectionContext* cntx,
                                                              bool force = false);
 

--- a/src/server/tiering/op_manager.cc
+++ b/src/server/tiering/op_manager.cc
@@ -141,7 +141,7 @@ void OpManager::ProcessStashed(const OwnedEntryId& id, unsigned version,
     pending_stash_ver_.erase(it);
     NotifyStashed(id, segment);
   } else if (segment) {
-    // Throw away the value because it's no longer up-to-date even if no error occured
+    // Throw away the value because it's no longer up-to-date even if no error occurred
     VLOG(1) << "Releasing segment " << *segment << ", id: " << ToString(id);
     storage_.MarkAsFree(*segment);
   } else {


### PR DESCRIPTION
Five files contained `occured` in comments/DCHECK messages:

| File | Line |
|------|------|
| `src/facade/cmd_arg_parser.cc` | 45 |
| `src/facade/cmd_arg_parser.h` | 152, 166 |
| `src/server/tiering/op_manager.cc` | 144 |
| `src/server/execution_state.h` | 124 |
| `src/server/main_service.h` | 173 |

Fixed to `occurred`. Comment/DCHECK-only change; no behavior change.