### PR TITLE
fix(v2): set READ_SOCKET phase and refresh heartbeat for timeouts

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -2665,6 +2665,7 @@ void Connection::NotifyOnRecv(const util::FiberSocketBase::RecvNotification& n) 
     io::MutableBytes buf = std::get<io::MutableBytes>(n.read_result);
     UpdateIoBufCapacity(io_buf_, &tl_facade_stats->conn_stats,
                         [&]() { io_buf_.WriteAndCommit(buf.data(), buf.size()); });
+    last_interaction_ = time(nullptr);
   } else {
     LOG(FATAL) << "Should not reach here";
   }
@@ -2693,6 +2694,7 @@ void Connection::ReadPendingInput() {
       break;
     }
 
+    last_interaction_ = time(nullptr);
     io_buf_.CommitWrite(*res);
     buf = io_buf_.AppendBuffer();
   }
@@ -2803,6 +2805,8 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
 
     // await block (no data to read)
     if (io_buf_.InputLen() == 0) {
+      phase_ = READ_SOCKET;
+
       io_event_.await([this, &is_ready_to_migrate]() {
         // TODO: optimize CanReply with looking up waiter key
         // io_buf_.InputLen() > 0 is still needed for multishot flow.

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -1195,9 +1195,6 @@ async def wait_for_conn_drop(async_client):
 
 @dfly_args({"timeout": 1})
 async def test_timeout(df_server: DflyInstance, async_client: aioredis.Redis):
-    # TODO investigate why it fails -- client is not stuck.
-    if df_server.has_arg("experimental_io_loop_v2"):
-        pytest.skip(f"Fails in the assertion below")
 
     another_client = df_server.client()
     await another_client.ping()


### PR DESCRIPTION
V2's IoLoopV2() remained in PROCESS phase while parked, which prevented
ConnectionsWatcherFb (the background reaper) from timing out idle
connections. The reaper requires (phase == READ_SOCKET &&
idle_time > timeout) to trigger eviction.

Furthermore, V2 data paths did not refresh the last_interaction_
timestamp.
This could lead to premature timeouts for clients streaming large or
slow requests, as the idle timer would not reset between partial reads.

Changes:
- Set phase_ = READ_SOCKET before the io_event_.await() block to signal
  the connection is waiting for I/O, matching the V1 pattern. The phase
  resets to PROCESS upon waking.
- Update last_interaction_ in ReadPendingInput() and NotifyOnRecv()
  whenever data is successfully received to refresh the heartbeat and
  prevent disconnection during active data transfer.

Re-enables test_timeout in connection_test.py.