### PR TITLE
refactor: remove duplication logic for HNSW doc deffer processing

### DIFF
--- a/src/core/search/hnsw_index.cc
+++ b/src/core/search/hnsw_index.cc
@@ -4,7 +4,6 @@
 
 #include "core/search/hnsw_index.h"
 
-#include <absl/container/flat_hash_map.h>
 #include <absl/strings/match.h>
 #include <hnswlib/hnswlib.h>
 #include <hnswlib/space_ip.h>
@@ -80,51 +79,17 @@ struct HnswlibAdapter {
         stub_vector_(data_size_ / sizeof(float), 1.0f) {
   }
 
-  // Adds a point to the index. If the write lock cannot be acquired (e.g.
-  // serialization holds a read lock), the operation is deferred and will be
-  // replayed by a subsequent write or TryProcessDeferred() call.
-  // When copy_vector_ is false the index stores a raw pointer to external data,
-  // so we must add the point synchronously before the caller's pointer goes out
-  // of scope — use a blocking write lock in that case.
   void Add(const void* data, GlobalDocId id) {
-    if (copy_vector_) {
-      {
-        MRMWMutexLock lock(&mrmw_mutex_, MRMWMutex::LockMode::kWriteLock, std::try_to_lock);
-        if (lock.locked()) {
-          ProcessDeferred();
-          DoAdd(data, id);
-          return;
-        }
-      }
-      // Could not acquire write lock — defer the operation.
-      AddDeferredOp(id, DeferredOp(true, data, data_size_, /*copy=*/true));
-      TryProcessDeferred();
-    } else {
-      MRMWMutexLock lock(&mrmw_mutex_, MRMWMutex::LockMode::kWriteLock);
-      ProcessDeferred();
-      DoAdd(data, id);
-    }
+    MRMWMutexLock lock(&mrmw_mutex_, MRMWMutex::LockMode::kWriteLock);
+    DoAdd(data, id);
   }
 
-  // Removes a point from the index. If the write lock cannot be acquired, the
-  // operation is deferred. Returns true when the operation was executed
-  // synchronously (write lock acquired, deferred queue drained).
-  bool Remove(GlobalDocId id) {
-    {
-      MRMWMutexLock lock(&mrmw_mutex_, MRMWMutex::LockMode::kWriteLock, std::try_to_lock);
-      if (lock.locked()) {
-        ProcessDeferred();
-        DoRemove(id);
-        return true;
-      }
-    }
-    AddDeferredOp(id, DeferredOp(false, nullptr, 0, false));
-    TryProcessDeferred();
-    return false;
+  void Remove(GlobalDocId id) {
+    MRMWMutexLock lock(&mrmw_mutex_, MRMWMutex::LockMode::kWriteLock);
+    DoRemove(id);
   }
 
   vector<pair<float, GlobalDocId>> Knn(float* target, size_t k, std::optional<size_t> ef) {
-    TryProcessDeferred();
     world_.setEf(ef.value_or(kDefaultEfRuntime));
     MRMWMutexLock lock(&mrmw_mutex_, MRMWMutex::LockMode::kReadLock);
     return QueueToVec(world_.searchKnn(target, k));
@@ -137,12 +102,11 @@ struct HnswlibAdapter {
         return binary_search(allowed->begin(), allowed->end(), id);
       }
 
-      BinsearchFilter(const vector<GlobalDocId>* allowed) : allowed{allowed} {
+      explicit BinsearchFilter(const vector<GlobalDocId>* allowed) : allowed{allowed} {
       }
       const vector<GlobalDocId>* allowed;
     };
 
-    TryProcessDeferred();
     world_.setEf(ef.value_or(kDefaultEfRuntime));
     BinsearchFilter filter{&allowed};
     MRMWMutexLock lock(&mrmw_mutex_, MRMWMutex::LockMode::kReadLock);
@@ -161,7 +125,6 @@ struct HnswlibAdapter {
   // Uses dynamic-range exploration (searchRange) to correctly handle cases where
   // the entry point is farther than radius.
   vector<pair<float, GlobalDocId>> RangeSearch(float* target, float radius) {
-    TryProcessDeferred();
     MRMWMutexLock lock(&mrmw_mutex_, MRMWMutex::LockMode::kReadLock);
     return world_.searchRange(target, radius);
   }
@@ -240,45 +203,6 @@ struct HnswlibAdapter {
   }
 
  private:
-  // A single deferred Add or Remove operation.
-  struct DeferredOp {
-    bool is_add;
-    bool owns_data;        // If true, data_ptr was allocated by us and must be freed.
-    const void* data_ptr;  // Pointer to vector data (owned or borrowed).
-
-    DeferredOp(bool is_add, const void* data, size_t data_size, bool copy)
-        : is_add(is_add), owns_data(copy && data != nullptr) {
-      if (owns_data) {
-        void* buf = mi_malloc(data_size);
-        memcpy(buf, data, data_size);
-        data_ptr = buf;
-      } else {
-        data_ptr = data;
-      }
-    }
-
-    ~DeferredOp() {
-      if (owns_data)
-        mi_free(const_cast<void*>(data_ptr));
-    }
-
-    DeferredOp(DeferredOp&& o) noexcept
-        : is_add(o.is_add), owns_data(o.owns_data), data_ptr(o.data_ptr) {
-      o.owns_data = false;
-      o.data_ptr = nullptr;
-    }
-
-    DeferredOp& operator=(DeferredOp&& o) noexcept {
-      auto lhs = std::tie(is_add, owns_data, data_ptr);
-      auto rhs = std::tie(o.is_add, o.owns_data, o.data_ptr);
-      std::swap(lhs, rhs);
-      return *this;
-    }
-
-    DeferredOp(const DeferredOp&) = delete;
-    DeferredOp& operator=(const DeferredOp&) = delete;
-  };
-
   // Actually add the point. Must be called while holding mrmw write lock.
   void DoAdd(const void* data, GlobalDocId id) {
     while (true) {
@@ -320,42 +244,6 @@ struct HnswlibAdapter {
     }
   }
 
-  // Add a deferred operation, replacing any previous one for the same document.
-  void AddDeferredOp(GlobalDocId id, DeferredOp op) {
-    std::lock_guard g(deferred_mu_);
-    deferred_ops_.insert_or_assign(id, std::move(op));
-  }
-
-  // Take all deferred operations out of the queue.
-  absl::flat_hash_map<GlobalDocId, DeferredOp> TakeDeferredOps() {
-    std::lock_guard g(deferred_mu_);
-    absl::flat_hash_map<GlobalDocId, DeferredOp> ops;
-    ops.swap(deferred_ops_);
-    return ops;
-  }
-
-  // Drain the deferred operations queue. Must be called while holding the mrmw
-  // write lock.  Only copy_vector_=true adds and removes can be deferred, so
-  // ordering within the queue does not matter.
-  void ProcessDeferred() {
-    auto ops = TakeDeferredOps();
-    for (auto& [id, op] : ops) {
-      if (op.is_add) {
-        DoAdd(op.data_ptr, id);
-      } else {
-        DoRemove(id);
-      }
-    }
-  }
-
-  // Non-blocking attempt to drain the deferred queue.
-  void TryProcessDeferred() {
-    MRMWMutexLock lock(&mrmw_mutex_, MRMWMutex::LockMode::kWriteLock, std::try_to_lock);
-    if (lock.locked()) {
-      ProcessDeferred();
-    }
-  }
-
   // Function requires that we hold mutex while resizing index. resizeIndex is not thread safe with
   // insertion (https://github.com/nmslib/hnswlib/issues/267)
   void ResizeIfFull() {
@@ -392,14 +280,6 @@ struct HnswlibAdapter {
   }
 
  public:
-  // Block until the write lock is acquired and all deferred ops are drained.
-  // Returns the held write lock so the caller can keep it alive.
-  MRMWMutexLock DrainPendingOps() {
-    MRMWMutexLock lock(&mrmw_mutex_, MRMWMutex::LockMode::kWriteLock);
-    ProcessDeferred();
-    return lock;
-  }
-
   // Restore HNSW graph structure from serialized nodes with metadata
   void RestoreFromNodes(const std::vector<HnswNodeData>& nodes, const HnswIndexMetadata& metadata) {
     MRMWMutexLock lock(&mrmw_mutex_, MRMWMutex::LockMode::kWriteLock);
@@ -509,7 +389,6 @@ struct HnswlibAdapter {
   // Update vector data for an existing node (used after RestoreFromNodes).
   // Returns false if the node doesn't exist in the index.
   bool UpdateVectorData(GlobalDocId id, const void* data) {
-    TryProcessDeferred();
     MRMWMutexLock lock(&mrmw_mutex_, MRMWMutex::LockMode::kWriteLock);
 
     // Find the internal id for this label
@@ -551,11 +430,9 @@ struct HnswlibAdapter {
   absl::Mutex resize_mutex_;
   mutable MRMWMutex mrmw_mutex_;
 
-  bool copy_vector_;                    // Whether vectors are copied into hnswlib.
-  size_t data_size_;                    // Byte size of a single vector.
-  std::vector<float> stub_vector_;      // Non-zero data for deleted nodes in borrowed mode.
-  mutable base::SpinLock deferred_mu_;  // Protects deferred_ops_.
-  absl::flat_hash_map<GlobalDocId, DeferredOp> deferred_ops_;  // GUARDED_BY(deferred_mu_)
+  bool copy_vector_;                // Whether vectors are copied into hnswlib.
+  size_t data_size_;                // Byte size of a single vector.
+  std::vector<float> stub_vector_;  // Non-zero data for deleted nodes in borrowed mode.
 };
 
 HnswVectorIndex::HnswVectorIndex(const SchemaField::VectorParams& params, bool copy_vector,
@@ -613,12 +490,8 @@ std::vector<std::pair<float, GlobalDocId>> HnswVectorIndex::RangeQuery(float* ta
   return adapter_->RangeSearch(target, radius);
 }
 
-bool HnswVectorIndex::Remove(GlobalDocId id, const DocumentAccessor& doc, string_view field) {
-  return adapter_->Remove(id);
-}
-
-bool HnswVectorIndex::Remove(GlobalDocId id) {
-  return adapter_->Remove(id);
+void HnswVectorIndex::Remove(GlobalDocId id) {
+  adapter_->Remove(id);
 }
 
 HnswIndexMetadata HnswVectorIndex::GetMetadata() const {
@@ -667,10 +540,6 @@ bool HnswVectorIndex::UpdateVectorData(GlobalDocId id, const DocumentAccessor& d
 
 MRMWMutexLock HnswVectorIndex::GetReadLock() const {
   return adapter_->GetReadLock();
-}
-
-MRMWMutexLock HnswVectorIndex::DrainPendingOps() {
-  return adapter_->DrainPendingOps();
 }
 
 }  // namespace dfly::search

--- a/src/core/search/hnsw_index.h
+++ b/src/core/search/hnsw_index.h
@@ -52,10 +52,7 @@ class HnswVectorIndex {
 
   bool Add(search::GlobalDocId id, const search::DocumentAccessor& doc, std::string_view field);
 
-  // Remove a point. Returns true when the operation was executed synchronously
-  // (write lock acquired, deferred queue drained). False means it was deferred.
-  bool Remove(search::GlobalDocId id, const search::DocumentAccessor& doc, std::string_view field);
-  bool Remove(search::GlobalDocId id);
+  void Remove(search::GlobalDocId id);
 
   bool IsVectorCopied() const {
     return copy_vector_;
@@ -100,10 +97,6 @@ class HnswVectorIndex {
   // Acquire a read lock on the internal MRMW mutex.
   // Use this during serialization to block concurrent Add/Remove (write) operations.
   MRMWMutexLock GetReadLock() const;
-
-  // Block until the write lock is acquired and all deferred ops are executed.
-  // Returns the held write lock so the caller can keep it alive until safe.
-  MRMWMutexLock DrainPendingOps();
 
  private:
   bool copy_vector_;

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -1299,164 +1299,6 @@ INSTANTIATE_TEST_SUITE_P(HnswSer, HnswSerializationTest,
                            return name.str();
                          });
 
-// Test fixture for HNSW deferred operations.
-// Verifies that Add/Remove called while a read lock is held are properly
-// deferred and replayed once the lock is released.
-class HnswDeferredOpsTest : public ::testing::Test {
- protected:
-  static constexpr size_t kDim = 4;
-  static constexpr size_t kCapacity = 100;
-
-  void SetUp() override {
-    InitTLSearchMR(PMR_NS::get_default_resource());
-
-    SchemaField::VectorParams params;
-    params.use_hnsw = true;
-    params.dim = kDim;
-    params.sim = VectorSimilarity::L2;
-    params.capacity = kCapacity;
-    params.hnsw_m = 16;
-    params.hnsw_ef_construction = 200;
-    index_ = std::make_unique<HnswVectorIndex>(params, /*copy_vector=*/true);
-  }
-
-  void TearDown() override {
-    index_.reset();
-    InitTLSearchMR(nullptr);
-  }
-
-  MockedDocument MakeDoc(std::initializer_list<float> coords) {
-    return MockedDocument::Map{{"vec", ToBytes(coords)}};
-  }
-
-  // Helper: run KNN for the zero vector and return the set of found GlobalDocIds.
-  absl::flat_hash_set<GlobalDocId> KnnIds(size_t k) {
-    vector<float> q(kDim, 0.0f);
-    auto results = index_->Knn(q.data(), k, std::nullopt);
-    absl::flat_hash_set<GlobalDocId> ids;
-    for (auto& [dist, id] : results)
-      ids.insert(id);
-    return ids;
-  }
-
-  std::unique_ptr<HnswVectorIndex> index_;
-};
-
-TEST_F(HnswDeferredOpsTest, AddWhileReadLocked) {
-  // Hold a read lock (simulating serialization), then add elements.
-  auto doc0 = MakeDoc({1, 0, 0, 0});
-  auto doc1 = MakeDoc({0, 1, 0, 0});
-
-  {
-    auto lock = index_->GetReadLock();
-
-    // These Adds cannot acquire the write lock and must be deferred.
-    index_->Add(0, doc0, "vec");
-    index_->Add(1, doc1, "vec");
-
-    // While the read lock is still held, KNN should not find the deferred docs.
-    auto ids = KnnIds(10);
-    EXPECT_TRUE(ids.empty());
-  }
-
-  // After the read lock is released, deferred ops should replay.
-  // The next operation that touches the index triggers ProcessDeferred.
-  auto ids = KnnIds(10);
-  EXPECT_EQ(ids.size(), 2u);
-  EXPECT_TRUE(ids.contains(0));
-  EXPECT_TRUE(ids.contains(1));
-}
-
-TEST_F(HnswDeferredOpsTest, RemoveWhileReadLocked) {
-  // Pre-populate the index.
-  auto doc0 = MakeDoc({1, 0, 0, 0});
-  auto doc1 = MakeDoc({0, 1, 0, 0});
-  auto doc2 = MakeDoc({0, 0, 1, 0});
-  index_->Add(0, doc0, "vec");
-  index_->Add(1, doc1, "vec");
-  index_->Add(2, doc2, "vec");
-
-  {
-    auto lock = index_->GetReadLock();
-
-    // Remove doc1 while read-locked — should be deferred.
-    index_->Remove(1, doc1, "vec");
-
-    // doc1 is still visible because the remove is deferred.
-    auto ids = KnnIds(10);
-    EXPECT_EQ(ids.size(), 3u);
-  }
-
-  // After releasing the lock, removal should take effect.
-  auto ids = KnnIds(10);
-  EXPECT_EQ(ids.size(), 2u);
-  EXPECT_TRUE(ids.contains(0));
-  EXPECT_TRUE(ids.contains(2));
-  EXPECT_FALSE(ids.contains(1));
-}
-
-TEST_F(HnswDeferredOpsTest, DuplicateDeferredOpsKeepLatest) {
-  // Pre-populate with doc0.
-  auto doc0 = MakeDoc({1, 0, 0, 0});
-  index_->Add(0, doc0, "vec");
-
-  auto doc1 = MakeDoc({0, 1, 0, 0});
-
-  {
-    auto lock = index_->GetReadLock();
-
-    // Add doc1, then remove doc1 — both deferred for the same id.
-    // Only the last operation (remove) should survive.
-    index_->Add(1, doc1, "vec");
-    index_->Remove(1, doc1, "vec");
-  }
-
-  // After lock release, doc1 should not exist (remove was last).
-  auto ids = KnnIds(10);
-  EXPECT_EQ(ids.size(), 1u);
-  EXPECT_TRUE(ids.contains(0));
-  EXPECT_FALSE(ids.contains(1));
-}
-
-TEST_F(HnswDeferredOpsTest, DuplicateDeferredOpsAddOverridesRemove) {
-  // Pre-populate with doc0 and doc1.
-  auto doc0 = MakeDoc({1, 0, 0, 0});
-  auto doc1 = MakeDoc({0, 1, 0, 0});
-  index_->Add(0, doc0, "vec");
-  index_->Add(1, doc1, "vec");
-
-  auto doc1_new = MakeDoc({0, 0, 1, 0});
-
-  {
-    auto lock = index_->GetReadLock();
-
-    // Remove doc1, then re-add it with new data — the add should win.
-    index_->Remove(1, doc1, "vec");
-    index_->Add(1, doc1_new, "vec");
-  }
-
-  // After lock release, doc1 should still be present with updated data.
-  auto ids = KnnIds(10);
-  EXPECT_EQ(ids.size(), 2u);
-  EXPECT_TRUE(ids.contains(0));
-  EXPECT_TRUE(ids.contains(1));
-}
-
-// Verify that Remove without a read lock also works correctly.
-TEST_F(HnswDeferredOpsTest, RemoveWithoutReadLock) {
-  auto doc0 = MakeDoc({1, 0, 0, 0});
-  auto doc1 = MakeDoc({0, 1, 0, 0});
-  index_->Add(0, doc0, "vec");
-  index_->Add(1, doc1, "vec");
-
-  index_->Remove(1, doc1, "vec");
-
-  auto ids = KnnIds(10);
-  EXPECT_EQ(ids.size(), 1u);
-  EXPECT_TRUE(ids.contains(0));
-  EXPECT_FALSE(ids.contains(1));
-}
-
 class HnswSubsetKnnTest : public ::testing::TestWithParam<VectorSimilarity> {
  protected:
   void SetUp() override {
@@ -1639,7 +1481,7 @@ TEST_P(HnswSubsetKnnTest, AllDeletedDocuments) {
 
   // Delete all documents
   for (size_t i = 0; i < 5; i++) {
-    index.Remove(i, docs[i], "vec");
+    index.Remove(i);
   }
 
   vector<float> query = {2.5f};
@@ -1674,7 +1516,7 @@ TEST_P(HnswSubsetKnnTest, MixedDeletedAndValidDocs) {
 
   // Delete even documents
   for (size_t i = 0; i < 10; i += 2) {
-    index.Remove(i, docs[i], "vec");
+    index.Remove(i);
   }
 
   vector<float> query = {5.0f};

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -531,23 +531,8 @@ bool HnswShardIndex::Add(search::GlobalDocId id, const BaseAccessor& doc) {
   return global_index_->Add(id, doc, field_ident_);
 }
 
-void HnswShardIndex::Remove(search::GlobalDocId id, const BaseAccessor& doc, PrimeValue& pv,
-                            absl::Span<const std::string_view> modified_fields,
-                            FieldExtractionCache* cache) {
-  bool sync = global_index_->Remove(id, doc, field_ident_);
-  if (sync) {
-    // Write lock acquired, ProcessDeferred drained all pending ops for this field.
-    ClearPreservedData();
-    return;
-  }
-
-  // Remove was deferred — preserve old sds so hnswlib's stored pointer stays valid.
-  MaybePreserveField(pv, modified_fields, cache);
-}
-
-void HnswShardIndex::RemoveById(search::GlobalDocId id) {
-  [[maybe_unused]] bool sync = global_index_->Remove(id);
-  DCHECK(sync) << "RemoveById should only be called when no read lock is held";
+void HnswShardIndex::Remove(search::GlobalDocId id) {
+  global_index_->Remove(id);
 }
 
 bool HnswShardIndex::UpdateVectorData(search::GlobalDocId id, const BaseAccessor& doc) {
@@ -627,18 +612,17 @@ void ShardDocIndex::RemoveDocFromGlobalVectorIndex(
     return;
   }
 
-  auto accessor = GetAccessor(db_cntx, pv);
   GlobalDocId global_id = search::CreateGlobalDocId(EngineShard::tlocal()->shard_id(), doc_id);
 
   for (auto& hnsw : hnsw_shard_indices_) {
-    hnsw.Remove(global_id, *accessor, pv, modified_fields, cache);
+    hnsw.Remove(global_id);
   }
 }
 
 void ShardDocIndex::RemoveFromAllHnswIndices(search::DocId doc_id) {
   GlobalDocId global_id = search::CreateGlobalDocId(EngineShard::tlocal()->shard_id(), doc_id);
   for (auto& hnsw : hnsw_shard_indices_) {
-    hnsw.RemoveById(global_id);
+    hnsw.Remove(global_id);
   }
 }
 
@@ -718,7 +702,7 @@ void ShardDocIndex::RestoreGlobalVectorIndices(std::string_view index_name, cons
   // Re-validate each entry: concurrent fibers may have freed and reused the DocId.
   for (const auto& [key, local_id, global_id] : missing_doc_ids) {
     for (auto& hnsw : hnsw_shard_indices_) {
-      hnsw.RemoveById(global_id);
+      hnsw.Remove(global_id);
     }
     // Only remove from key_index_ if the mapping still matches the snapshot.
     if (key_index_.Find(key) == local_id) {
@@ -742,8 +726,22 @@ void ShardDocIndex::RestoreGlobalVectorIndices(std::string_view index_name, cons
   // after BlockUntilConstructionEnd ensures ALL shards completed.
 }
 
+void ShardDocIndex::SetHnswSerializing() {
+  // Only transition from kBuilding. If already in another non-building state
+  // (e.g. kRestoring during load), ops are already being buffered — no change needed.
+  if (hnsw_state_ == HnswState::kBuilding) {
+    hnsw_state_ = HnswState::kSerializing;
+  }
+}
+
+void ShardDocIndex::DrainSerializationUpdates(const OpArgs& op_args) {
+  if (hnsw_state_ != HnswState::kSerializing)
+    return;
+  DrainPendingVectorUpdates(op_args);
+}
+
 void ShardDocIndex::DrainPendingVectorUpdates(const OpArgs& op_args) {
-  // All shards have valid vector data now — allow normal HNSW operations.
+  // Allow normal HNSW operations (used after restoration or serialization).
   hnsw_state_ = HnswState::kBuilding;
 
   if (pending_vector_updates_.empty())

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -232,7 +232,7 @@ class ShardDocIndices;
 using FieldExtractionCache = absl::flat_hash_map<std::string_view, std::shared_ptr<void>>;
 
 // Per-shard wrapper around a global HnswVectorIndex. Encapsulates shard-local state
-// (preserved field data for deferred removes) and delegates to the global index.
+// (preserved field data while HNSW ops are buffered) and delegates to the global index.
 // One instance per HNSW field per shard.
 class HnswShardIndex {
  public:
@@ -240,11 +240,7 @@ class HnswShardIndex {
 
   bool Add(search::GlobalDocId id, const BaseAccessor& doc);
 
-  void Remove(search::GlobalDocId id, const BaseAccessor& doc, PrimeValue& pv,
-              absl::Span<const std::string_view> modified_fields, FieldExtractionCache* cache);
-
-  // Unconditional remove by id (no preservation). Used during restoration.
-  void RemoveById(search::GlobalDocId id);
+  void Remove(search::GlobalDocId id);
 
   // Update vector data for an existing HNSW node (used during restoration).
   bool UpdateVectorData(search::GlobalDocId id, const BaseAccessor& doc);
@@ -273,7 +269,7 @@ class HnswShardIndex {
   std::shared_ptr<search::HnswVectorIndex> global_index_;
   std::string field_ident_;  // actual hash key, not AS alias
 
-  // Old sds entries kept alive until deferred HNSW removes complete.
+  // Old sds entries kept alive while HNSW ops are buffered (serializing/restoring).
   // shared_ptr because multiple search indices may reference the same sds.
   std::vector<std::shared_ptr<void>> preserved_field_data_;
 };
@@ -428,9 +424,18 @@ class ShardDocIndex {
   // for nodes whose graph structure was already restored from RDB.
   void RestoreGlobalVectorIndices(std::string_view index_name, const OpArgs& op_args);
 
-  // Drain buffered HNSW updates and set kBuilding. Called from PerformPostLoad
-  // after all shards complete restoration.
+  // Transition to kSerializing — buffer all HNSW ops until drain.
+  // Called before HNSW graph serialization starts.
+  void SetHnswSerializing();
+
+  // Drain buffered HNSW updates and set kBuilding. Called after restoration
+  // completes (kRestoring -> kBuilding) or after serialization finishes
+  // (kSerializing -> kBuilding).
   void DrainPendingVectorUpdates(const OpArgs& op_args);
+
+  // Drain only if in kSerializing state. No-op for kRestoring/kProhibit,
+  // so serialization cannot interfere with a concurrent restoration.
+  void DrainSerializationUpdates(const OpArgs& op_args);
 
   // Serialize doc and return with key name
   using SerializedEntryWithKey = std::optional<std::pair<std::string_view, SearchDocData>>;
@@ -504,8 +509,9 @@ class ShardDocIndex {
   // HNSW vector index lifecycle state.
   // kProhibit: default after InitIndex during LOADING. All HNSW ops buffered.
   // kRestoring: set by Rebuild(is_restored=true). Ops buffered until drain.
+  // kSerializing: set before HNSW serialization. Ops buffered until drain.
   // kBuilding: normal operation. HNSW adds/removes execute immediately.
-  enum class HnswState : uint8_t { kProhibit, kRestoring, kBuilding };
+  enum class HnswState : uint8_t { kProhibit, kRestoring, kSerializing, kBuilding };
 
   absl::flat_hash_set<std::string> pending_vector_updates_;
   HnswState hnsw_state_ = HnswState::kProhibit;

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -407,8 +407,9 @@ class ShardDocIndex {
   void AddDocToGlobalVectorIndex(ShardDocIndex::DocId doc_id, const DbContext& db_cntx,
                                  PrimeValue* pv);
 
-  // Remove doc from all HNSW indices. When a Remove is deferred (read lock held),
-  // preserves the old sds entries internally so deferred ops remain safe.
+  // Remove doc from all HNSW indices. When hnsw_state_ != kBuilding, the remove
+  // is buffered in pending_vector_updates_ and old sds entries are preserved so
+  // HNSW pointers remain valid until the buffer is drained.
   // modified_fields: when non-empty, only preserve fields being mutated.
   // cache: shared across search indices so each sds field is extracted at most once.
   void RemoveDocFromGlobalVectorIndex(ShardDocIndex::DocId doc_id, const DbContext& db_cntx,
@@ -417,7 +418,7 @@ class ShardDocIndex {
                                       FieldExtractionCache* cache);
 
   // Clear preserved field data on all per-shard HNSW indices.
-  // Called after serialization drains deferred ops under held write locks.
+  // Called after DrainPendingVectorUpdates completes buffered operations.
   void ClearAllHnswPreservedData();
 
   // Rebuild global vector indices from restored key index, updating vector data
@@ -547,9 +548,9 @@ class ShardDocIndices {
   /* Use AddDoc and RemoveDoc only if pv object type is json or hset */
   void AddDoc(std::string_view key, const DbContext& db_cnt, PrimeValue* pv);
 
-  // Remove doc from all matching indices. When the HNSW write lock can't be
-  // acquired (e.g., serialization holds a read lock), external vector data is
-  // preserved so deferred HNSW ops can still dereference vector pointers.
+  // Remove doc from all matching indices. When HNSW ops are buffered
+  // (serializing/restoring), external vector data is preserved so HNSW
+  // pointers remain valid until the buffer is drained.
   // pv is non-const because preservation swaps sds entries in StringMap.
   void RemoveDoc(std::string_view key, const DbContext& db_cnt, PrimeValue& pv,
                  absl::Span<const std::string_view> modified_fields = {});

--- a/src/server/search/serialization_utils.cc
+++ b/src/server/search/serialization_utils.cc
@@ -5,11 +5,14 @@
 #include "server/search/serialization_utils.h"
 
 #include "base/logging.h"
+#include "server/common.h"
 #include "server/engine_shard.h"
 #include "server/engine_shard_set.h"
 #include "server/error.h"
+#include "server/namespaces.h"
 #include "server/rdb_extensions.h"
 #include "server/rdb_save.h"
+#include "server/search/doc_index.h"
 #include "server/search/global_hnsw_index.h"
 
 namespace dfly {
@@ -65,6 +68,18 @@ void SearchSerializer::SerializeGlobalHnswIndices() const {
     return;
 
   auto all_indices = GlobalHnswIndexRegistry::Instance().GetAll();
+  if (all_indices.empty())
+    return;
+
+  // Buffer all HNSW mutations at the doc_index level so they don't reach
+  // the HNSW graph while we hold the read lock for serialization.
+  shard_set->RunBriefInParallel([](EngineShard* es) {
+    for (const auto& index_name : es->search_indices()->GetIndexNames()) {
+      if (auto* shard_index = es->search_indices()->GetIndex(index_name)) {
+        shard_index->SetHnswSerializing();
+      }
+    }
+  });
 
   // Preallocate buffer for HNSW entry serialization.
   std::vector<uint8_t> tmp_buf;
@@ -72,8 +87,6 @@ void SearchSerializer::SerializeGlobalHnswIndices() const {
   for (const auto& [index_key, index] : all_indices) {
     {
       // Acquire a read lock to ensure a consistent snapshot of the graph.
-      // While held, Add/Remove calls will defer into the adapter's internal list
-      // and will be replayed automatically on the next write operation.
       auto read_lock = index->GetReadLock();
 
       // Format: [RDB_OPCODE_VECTOR_INDEX, index_name, elements_number,
@@ -107,24 +120,18 @@ void SearchSerializer::SerializeGlobalHnswIndices() const {
     push_fun_();
   }
 
-  // All read locks released — drain deferred ops so all removes complete,
-  // then clear preserved field data on all shards while still holding the
-  // write locks. Holding write locks ensures no new Remove can be deferred
-  // (MRMW allows concurrent writers, so Removes execute synchronously).
-  if (!all_indices.empty()) {
-    std::vector<search::MRMWMutexLock> write_locks;
-    write_locks.reserve(all_indices.size());
-    for (const auto& [index_key, index] : all_indices) {
-      write_locks.push_back(index->DrainPendingOps());
-    }
-    shard_set->RunBriefInParallel([](EngineShard* es) {
-      for (const auto& index_name : es->search_indices()->GetIndexNames()) {
-        if (auto* shard_index = es->search_indices()->GetIndex(index_name)) {
-          shard_index->ClearAllHnswPreservedData();
-        }
+  // Drain buffered HNSW updates on all shards and transition back to kBuilding.
+  // Uses DrainSerializationUpdates which only acts on indices in kSerializing
+  // state, so it cannot interfere with concurrent restoration.
+  shard_set->AwaitRunningOnShardQueue([](EngineShard* es) {
+    OpArgs op_args{es, nullptr,
+                   DbContext{&namespaces->GetDefaultNamespace(), 0, GetCurrentTimeMs()}};
+    for (const auto& index_name : es->search_indices()->GetIndexNames()) {
+      if (auto* shard_index = es->search_indices()->GetIndex(index_name)) {
+        shard_index->DrainSerializationUpdates(op_args);
       }
-    });
-  }
+    }
+  });
 }
 #endif
 

--- a/src/server/search/serialization_utils.cc
+++ b/src/server/search/serialization_utils.cc
@@ -123,6 +123,7 @@ void SearchSerializer::SerializeGlobalHnswIndices() const {
   // Drain buffered HNSW updates on all shards and transition back to kBuilding.
   // Uses DrainSerializationUpdates which only acts on indices in kSerializing
   // state, so it cannot interfere with concurrent restoration.
+  // Search indices are restricted to db 0 in the default namespace (enforced by FT.CREATE).
   shard_set->AwaitRunningOnShardQueue([](EngineShard* es) {
     OpArgs op_args{es, nullptr,
                    DbContext{&namespaces->GetDefaultNamespace(), 0, GetCurrentTimeMs()}};


### PR DESCRIPTION
fixes: #7113

Summary                                                                                                        
         
  - Merge two HNSW deferred update mechanisms into a single one at the doc_index level                           
  - Remove internal deferred ops machinery from HnswlibAdapter (DeferredOp, deferred_ops_, ProcessDeferred,      
  TryProcessDeferred, DrainPendingOps)                                                                           
  - Add kSerializing state to ShardDocIndex::HnswState so HNSW mutations are buffered at the doc_index level     
  during serialization, reusing the same pending_vector_updates_ mechanism already used for restoration          
  - Simplify HnswVectorIndex::Remove — single-arg, returns void, always synchronous
  - Merge HnswShardIndex::RemoveById into HnswShardIndex::Remove (identical after simplification)   