### PR TITLE
fix: delete empty hash after FIELDEXPIRE lazy expiry

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -873,8 +873,11 @@ OpResult<vector<long>> OpFieldExpire(const OpArgs& op_args, string_view key, uin
     SetFamily::DeleteSetIfEmpty(db_slice, op_args.db_cntx, key, *pv);
     return result;
   } else {
-    return HSetFamily::SetFieldsExpireTime(op_args, ttl_sec, ExpireFlags::EXPIRE_ALWAYS, key,
-                                           values, pv);
+    auto result = HSetFamily::SetFieldsExpireTime(op_args, ttl_sec, ExpireFlags::EXPIRE_ALWAYS, key,
+                                                  values, pv);
+    auto_updater.Run();
+    HSetFamily::DeleteIfEmpty(db_slice, op_args.db_cntx, key, *pv);
+    return result;
   }
 }
 

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -1360,6 +1360,25 @@ TEST_F(GenericFamilyTest, FieldExpireNoSuchKey) {
               RespArray(ElementsAre(IntArg(-2), IntArg(-2))));
 }
 
+// Regression: OpFieldExpire for hashes calls SetFieldsExpireTime which triggers
+// lazy field expiry via StringMap::Find(), but does not call DeleteIfEmpty
+// afterward.  When all fields have expired, the hash remains in the DB with
+// Size()==0.  A subsequent SAVE hits the DFATAL in SaveEntry.
+TEST_F(GenericFamilyTest, FieldExpireHashDeletesEmptyHash) {
+  // Create a hash with a short field-level TTL.
+  Run({"HSETEX", "key", "1", "f1", "v1"});
+  EXPECT_EQ(1, CheckedInt({"EXISTS", "key"}));
+
+  AdvanceTime(2000);
+
+  // FIELDEXPIRE on the already-expired field triggers lazy expiry via Find()
+  // inside UpdateTTL.  Without the fix the hash remains as a zombie key.
+  Run({"FIELDEXPIRE", "key", "5", "f1"});
+
+  // The key must have been removed.
+  EXPECT_EQ(0, CheckedInt({"EXISTS", "key"}));
+}
+
 TEST_F(GenericFamilyTest, ExpireTime) {
   EXPECT_EQ(-2, CheckedInt({"EXPIRETIME", "foo"}));
   EXPECT_EQ(-2, CheckedInt({"PEXPIRETIME", "foo"}));


### PR DESCRIPTION
OpFieldExpire for hashes calls SetFieldsExpireTime which triggers lazy field expiry via StringMap::Find(), but did not call DeleteIfEmpty afterward.  When all fields have expired, the hash remains in the DB with Size()==0, and a subsequent SAVE hits the DFATAL in SaveEntry.

Related to: https://github.com/dragonflydb/dragonfly/issues/7133