### PR TITLE
fix: delete empty container after SHRINK compaction

### DIFF
--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -1360,6 +1360,32 @@ TEST_F(GenericFamilyTest, FieldExpireNoSuchKey) {
               RespArray(ElementsAre(IntArg(-2), IntArg(-2))));
 }
 
+// SHRINK calls set_time() then DenseSet::Shrink() which expires entries during
+// bucket compaction.  If all entries expire, the key must be deleted.
+TEST_F(GenericFamilyTest, ShrinkDeletesEmptyContainer) {
+  for (int i = 0; i < 128; ++i) {
+    Run({"HSETEX", "hkey", "1", absl::StrCat("f", i), "v"});
+  }
+  for (int i = 4; i < 128; ++i) {
+    Run({"HDEL", "hkey", absl::StrCat("f", i)});
+  }
+
+  for (int i = 0; i < 128; ++i) {
+    Run({"SADDEX", "skey", "1", absl::StrCat("m", i)});
+  }
+  for (int i = 4; i < 128; ++i) {
+    Run({"SREM", "skey", absl::StrCat("m", i)});
+  }
+
+  AdvanceTime(2000);
+
+  Run({"SHRINK", "hkey"});
+  Run({"SHRINK", "skey"});
+
+  EXPECT_EQ(0, CheckedInt({"EXISTS", "hkey"}));
+  EXPECT_EQ(0, CheckedInt({"EXISTS", "skey"}));
+}
+
 TEST_F(GenericFamilyTest, ExpireTime) {
   EXPECT_EQ(-2, CheckedInt({"EXPIRETIME", "foo"}));
   EXPECT_EQ(-2, CheckedInt({"PEXPIRETIME", "foo"}));

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2826,6 +2826,14 @@ void ServerFamily::Shrink(CmdArgList args, CommandContext* cmd_cntx) {
     ds->Shrink(optimal_size);
     size_t bucket_bytes_after = ds->BucketCount() * sizeof(void*);
 
+    // Shrink expires entries during bucket compaction.  If all entries expired,
+    // delete the now-empty key to prevent zombie keys that crash SAVE.
+    if (ds->Empty()) {
+      if (auto res = db_slice.FindMutable(t->GetDbContext(), key, obj_type); res) {
+        db_slice.DelMutable(t->GetDbContext(), std::move(*res));
+      }
+    }
+
     return bucket_bytes_before - bucket_bytes_after;
   };
 


### PR DESCRIPTION
SHRINK calls set_time() then DenseSet::Shrink() which expires entries during bucket compaction. If all entries expire, the key must be deleted to prevent zombie keys that crash SAVE.

Related to: https://github.com/dragonflydb/dragonfly/issues/7133