### PR TITLE
fix: clean up empty set after SORT lazy expiry

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1661,7 +1661,15 @@ OpResult<CompactObjType> OpFetchSortEntries(const OpArgs& op_args, std::string_v
   if (!success)
     return OpStatus::INVALID_NUMERIC_RESULT;
 
-  return it->second.ObjType();
+  auto obj_type = it->second.ObjType();
+
+  // IterateSet may trigger lazy member expiry on sets with member-level TTL.
+  // If all members expired, delete the now-empty key.
+  if (obj_type == OBJ_SET && it->second.Size() == 0) {
+    SetFamily::DeleteSetIfEmpty(op_args.GetDbSlice(), op_args.db_cntx, key, it->second);
+  }
+
+  return obj_type;
 }
 
 // Fetch container elements as strings (for BY pattern support)

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -1375,6 +1375,22 @@ TEST_F(GenericFamilyTest, ExpireTime) {
   EXPECT_EQ(expire_time_in_ms, CheckedInt({"PEXPIRETIME", "foo"}));
 }
 
+TEST_F(GenericFamilyTest, SortDeletesEmptySet) {
+  for (int i = 0; i < 20; ++i) {
+    Run({"SADDEX", "skey", "1", absl::StrCat("m", i)});
+  }
+
+  AdvanceTime(2000);
+
+  Run({"SISMEMBER", "skey", "m0"});
+  // SISMEMBER must not delete the key by itself — SORT is the one that should clean up.
+  EXPECT_EQ(1, CheckedInt({"EXISTS", "skey"}));
+
+  Run({"SORT", "skey"});
+
+  EXPECT_EQ(0, CheckedInt({"EXISTS", "skey"}));
+}
+
 TEST_F(GenericFamilyTest, RestoreOOM) {
   max_memory_limit = 20000000;
   Run({"set", "src", string(5000, 'x')});


### PR DESCRIPTION
OpFetchSortEntries iterates sets via IterateSet which can trigger lazy member expiry if time_now_ was set by a prior command. If all members expired, delete the now-empty key.

Related to: https://github.com/dragonflydb/dragonfly/issues/7133