### PR TITLE
fix: clean up empty set after SORT BY pattern lazy expiry

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1685,7 +1685,19 @@ OpResult<pair<vector<string>, CompactObjType>> OpFetchContainerElements(const Op
     return true;
   });
 
-  return std::make_pair(std::move(elements), it->second.ObjType());
+  auto obj_type = it->second.ObjType();
+
+  // Iterate may trigger lazy expiry.  Clean up empty containers.
+  if (it->second.Size() == 0) {
+    auto& db_slice = op_args.GetDbSlice();
+    if (obj_type == OBJ_SET) {
+      SetFamily::DeleteSetIfEmpty(db_slice, op_args.db_cntx, key, it->second);
+    } else if (obj_type == OBJ_HASH) {
+      HSetFamily::DeleteIfEmpty(db_slice, op_args.db_cntx, key, it->second);
+    }
+  }
+
+  return std::make_pair(std::move(elements), obj_type);
 }
 
 // Fetch a string value from a key (for BY pattern lookups)

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -21,6 +21,7 @@ extern "C" {
 #include "base/logging.h"
 #include "core/glob_matcher.h"
 #include "core/qlist.h"
+#include "core/string_set.h"
 #include "redis/rdb.h"
 #include "server/acl/acl_commands_def.h"
 #include "server/blocking_controller.h"
@@ -1691,21 +1692,24 @@ OpResult<pair<vector<string>, CompactObjType>> OpFetchContainerElements(const Op
   vector<string> elements;
   elements.reserve(it->second.Size());
 
+  auto obj_type = it->second.ObjType();
+
+  // Enable lazy per-member expiry before iterating dense sets.  Without this,
+  // IterateSet would skip expiry entirely and empty-set cleanup below would
+  // depend on a prior command having set time_now_.
+  if (obj_type == OBJ_SET && it->second.Encoding() == kEncodingStrMap2) {
+    static_cast<StringSet*>(it->second.RObjPtr())
+        ->set_time(MemberTimeSeconds(op_args.db_cntx.time_now_ms));
+  }
+
   Iterate(it->second, [&elements](const ContainerEntry& entry) {
     elements.emplace_back(entry.ToString());
     return true;
   });
 
-  auto obj_type = it->second.ObjType();
-
-  // Iterate may trigger lazy expiry.  Clean up empty containers.
-  if (it->second.Size() == 0) {
-    auto& db_slice = op_args.GetDbSlice();
-    if (obj_type == OBJ_SET) {
-      SetFamily::DeleteSetIfEmpty(db_slice, op_args.db_cntx, key, it->second);
-    } else if (obj_type == OBJ_HASH) {
-      HSetFamily::DeleteIfEmpty(db_slice, op_args.db_cntx, key, it->second);
-    }
+  // IterateSet may trigger lazy member expiry.  Clean up empty set.
+  if (obj_type == OBJ_SET && it->second.Size() == 0) {
+    SetFamily::DeleteSetIfEmpty(op_args.GetDbSlice(), op_args.db_cntx, key, it->second);
   }
 
   return std::make_pair(std::move(elements), obj_type);

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -1360,6 +1360,19 @@ TEST_F(GenericFamilyTest, FieldExpireNoSuchKey) {
               RespArray(ElementsAre(IntArg(-2), IntArg(-2))));
 }
 
+TEST_F(GenericFamilyTest, SortByPatternDeletesEmptySet) {
+  for (int i = 0; i < 20; ++i) {
+    Run({"SADDEX", "skey", "1", absl::StrCat("m", i)});
+  }
+
+  AdvanceTime(2000);
+
+  Run({"SISMEMBER", "skey", "m0"});
+  Run({"SORT", "skey", "BY", "nosort"});
+
+  EXPECT_EQ(0, CheckedInt({"EXISTS", "skey"}));
+}
+
 TEST_F(GenericFamilyTest, ExpireTime) {
   EXPECT_EQ(-2, CheckedInt({"EXPIRETIME", "foo"}));
   EXPECT_EQ(-2, CheckedInt({"PEXPIRETIME", "foo"}));

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -1364,10 +1364,13 @@ TEST_F(GenericFamilyTest, SortByPatternDeletesEmptySet) {
   for (int i = 0; i < 20; ++i) {
     Run({"SADDEX", "skey", "1", absl::StrCat("m", i)});
   }
+  EXPECT_EQ(1, CheckedInt({"EXISTS", "skey"}));
 
   AdvanceTime(2000);
 
-  Run({"SISMEMBER", "skey", "m0"});
+  // SORT BY nosort iterates the set, triggering lazy member expiry.
+  // The empty set must be cleaned up on its own — no prior command touching
+  // the set is needed.
   Run({"SORT", "skey", "BY", "nosort"});
 
   EXPECT_EQ(0, CheckedInt({"EXISTS", "skey"}));


### PR DESCRIPTION
OpFetchContainerElements iterates sets via IterateSet which can trigger lazy member expiry. If all members expired, delete the now-empty key.

Related to: https://github.com/dragonflydb/dragonfly/issues/7133