### PR TITLE
fix: clean up empty set after ZUNIONSTORE lazy expiry

### DIFF
--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -1360,6 +1360,19 @@ TEST_F(GenericFamilyTest, FieldExpireNoSuchKey) {
               RespArray(ElementsAre(IntArg(-2), IntArg(-2))));
 }
 
+TEST_F(GenericFamilyTest, ZUnionStoreDeletesEmptySet) {
+  for (int i = 0; i < 20; ++i) {
+    Run({"SADDEX", "skey", "1", absl::StrCat("m", i)});
+  }
+
+  AdvanceTime(2000);
+
+  Run({"SISMEMBER", "skey", "m0"});
+  Run({"ZUNIONSTORE", "zdest", "1", "skey"});
+
+  EXPECT_EQ(0, CheckedInt({"EXISTS", "skey"}));
+}
+
 TEST_F(GenericFamilyTest, ExpireTime) {
   EXPECT_EQ(-2, CheckedInt({"EXPIRETIME", "foo"}));
   EXPECT_EQ(-2, CheckedInt({"PEXPIRETIME", "foo"}));

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -1364,13 +1364,33 @@ TEST_F(GenericFamilyTest, ZUnionStoreDeletesEmptySet) {
   for (int i = 0; i < 20; ++i) {
     Run({"SADDEX", "skey", "1", absl::StrCat("m", i)});
   }
+  EXPECT_EQ(1, CheckedInt({"EXISTS", "skey"}));
 
   AdvanceTime(2000);
 
-  Run({"SISMEMBER", "skey", "m0"});
+  // ZUNIONSTORE iterates skey via IterateSet (inside ScoreMapFromSet),
+  // triggering lazy expiry.  The empty set must be cleaned up.
   Run({"ZUNIONSTORE", "zdest", "1", "skey"});
 
   EXPECT_EQ(0, CheckedInt({"EXISTS", "skey"}));
+}
+
+// Iterator invalidation: deleting one input set must not break iteration over
+// the remaining ones in UnionShardKeysWithScore.
+TEST_F(GenericFamilyTest, ZUnionStoreMultipleEmptySets) {
+  for (int i = 0; i < 20; ++i) {
+    Run({"SADDEX", "s1", "1", absl::StrCat("a", i)});
+    Run({"SADDEX", "s2", "1", absl::StrCat("b", i)});
+    Run({"SADDEX", "s3", "1", absl::StrCat("c", i)});
+  }
+
+  AdvanceTime(2000);
+
+  Run({"ZUNIONSTORE", "zdest", "3", "s1", "s2", "s3"});
+
+  EXPECT_EQ(0, CheckedInt({"EXISTS", "s1"}));
+  EXPECT_EQ(0, CheckedInt({"EXISTS", "s2"}));
+  EXPECT_EQ(0, CheckedInt({"EXISTS", "s3"}));
 }
 
 TEST_F(GenericFamilyTest, SortByPatternDeletesEmptySet) {

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -29,6 +29,7 @@ extern "C" {
 #include "server/error.h"
 #include "server/family_utils.h"
 #include "server/namespaces.h"
+#include "server/set_family.h"
 #include "server/transaction.h"
 
 namespace rng = std::ranges;
@@ -803,7 +804,8 @@ void InterScoredMap(ScoredMap* dest, ScoredMap* src, AggType agg_type) {
 
 using KeyIterWeightVec = vector<pair<DbSlice::ConstIterator, double>>;
 
-ScoredMap UnionShardKeysWithScore(const KeyIterWeightVec& key_iter_weight_vec, AggType agg_type) {
+ScoredMap UnionShardKeysWithScore(const KeyIterWeightVec& key_iter_weight_vec, AggType agg_type,
+                                  DbSlice& db_slice, const DbContext& db_cntx) {
   ScoredMap result;
   for (const auto& [it, weight] : key_iter_weight_vec) {
     if (it.is_done()) {
@@ -816,6 +818,10 @@ ScoredMap UnionShardKeysWithScore(const KeyIterWeightVec& key_iter_weight_vec, A
     else {
       DCHECK_EQ(it->second.ObjType(), OBJ_SET);
       sm = ScoreMapFromSet(it->second, weight);
+      // IterateSet may trigger lazy expiry.  Clean up empty set.
+      if (it->second.Size() == 0) {
+        SetFamily::DeleteSetIfEmpty(db_slice, db_cntx, it.key(), it->second);
+      }
     }
     if (result.empty()) {
       result.swap(sm);
@@ -895,7 +901,8 @@ OpResult<ScoredMap> OpUnion(EngineShard* shard, Transaction* t, string_view dest
   if (key_vec_res->empty())
     return OpStatus::OK;
 
-  return UnionShardKeysWithScore(*key_vec_res, agg_type);
+  auto& db_slice = t->GetDbSlice(shard->shard_id());
+  return UnionShardKeysWithScore(*key_vec_res, agg_type, db_slice, t->GetDbContext());
 }
 
 OpResult<ScoredMap> OpInter(EngineShard* shard, Transaction* t, string_view dest, AggType agg_type,

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -16,6 +16,7 @@ extern "C" {
 #include "base/logging.h"
 #include "base/stl_util.h"
 #include "core/sorted_map.h"
+#include "core/string_set.h"
 #include "facade/cmd_arg_parser.h"
 #include "facade/error.h"
 #include "server/acl/acl_commands_def.h"
@@ -736,7 +737,13 @@ ScoredMap FromObject(const PrimeValue& co, double weight) {
   return res;
 }
 
-ScoredMap ScoreMapFromSet(const PrimeValue& pv, double weight) {
+ScoredMap ScoreMapFromSet(const PrimeValue& pv, double weight, const DbContext& db_cntx) {
+  // Enable lazy member expiry before iterating dense sets so expired members
+  // do not pollute the result (and so the caller can detect an emptied set).
+  if (pv.Encoding() == kEncodingStrMap2) {
+    static_cast<StringSet*>(pv.RObjPtr())->set_time(MemberTimeSeconds(db_cntx.time_now_ms));
+  }
+
   ScoredMap result;
   container_utils::IterateSet(pv, [&result, weight](container_utils::ContainerEntry ce) {
     result.emplace(ce.ToString(), weight);
@@ -807,20 +814,23 @@ using KeyIterWeightVec = vector<pair<DbSlice::ConstIterator, double>>;
 ScoredMap UnionShardKeysWithScore(const KeyIterWeightVec& key_iter_weight_vec, AggType agg_type,
                                   DbSlice& db_slice, const DbContext& db_cntx) {
   ScoredMap result;
+  // Collect keys of sets that got emptied by lazy expiry during iteration.
+  // Deleting them inside the loop would invalidate other PrimeTable iterators
+  // held in key_iter_weight_vec.
+  absl::InlinedVector<std::string, 2> emptied_set_keys;
   for (const auto& [it, weight] : key_iter_weight_vec) {
     if (it.is_done()) {
       continue;
     }
 
     ScoredMap sm;
-    if (it->second.ObjType() == OBJ_ZSET)
+    if (it->second.ObjType() == OBJ_ZSET) {
       sm = FromObject(it->second, weight);
-    else {
+    } else {
       DCHECK_EQ(it->second.ObjType(), OBJ_SET);
-      sm = ScoreMapFromSet(it->second, weight);
-      // IterateSet may trigger lazy expiry.  Clean up empty set.
+      sm = ScoreMapFromSet(it->second, weight, db_cntx);
       if (it->second.Size() == 0) {
-        SetFamily::DeleteSetIfEmpty(db_slice, db_cntx, it.key(), it->second);
+        emptied_set_keys.emplace_back(it.key());
       }
     }
     if (result.empty()) {
@@ -829,6 +839,14 @@ ScoredMap UnionShardKeysWithScore(const KeyIterWeightVec& key_iter_weight_vec, A
       UnionScoredMap(&result, &sm, agg_type);
     }
   }
+
+  // Safe to delete now — the loop above no longer references iterators.
+  for (const auto& key : emptied_set_keys) {
+    if (auto res = db_slice.FindReadOnly(db_cntx, key, OBJ_SET); res) {
+      SetFamily::DeleteSetIfEmpty(db_slice, db_cntx, key, (*res)->second);
+    }
+  }
+
   return result;
 }
 
@@ -926,7 +944,7 @@ OpResult<ScoredMap> OpInter(EngineShard* shard, Transaction* t, string_view dest
       sm = FromObject(it->second, weight);
     else {
       DCHECK_EQ(it->second.ObjType(), OBJ_SET);
-      sm = ScoreMapFromSet(it->second, weight);
+      sm = ScoreMapFromSet(it->second, weight, t->GetDbContext());
     }
     if (result.empty())
       result.swap(sm);


### PR DESCRIPTION
ScoreMapFromSet iterates sets via IterateSet which can trigger lazy member expiry. If all members expired, delete the empty set.

Related to: https://github.com/dragonflydb/dragonfly/issues/7133