### PR TITLE
fix: clean up empty set after ZINTERSTORE lazy expiry

### DIFF
--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -1364,12 +1364,15 @@ TEST_F(GenericFamilyTest, ZInterStoreDeletesEmptySet) {
   for (int i = 0; i < 20; ++i) {
     Run({"SADDEX", "skey", "1", absl::StrCat("m", i)});
   }
+  // ZINTERSTORE needs at least one non-empty input to reach ScoreMapFromSet.
   Run({"ZADD", "zkey", "1", "m0"});
+  EXPECT_EQ(1, CheckedInt({"EXISTS", "skey"}));
 
   AdvanceTime(2000);
 
-  Run({"SISMEMBER", "skey", "m0"});
-  Expand commentComment on line R1371 Run({"ZINTERSTORE", "zdest", "2", "skey", "zkey"});
+  // ZINTERSTORE iterates skey via IterateSet (inside ScoreMapFromSet),
+  // triggering lazy expiry.  The empty set must be cleaned up.
+  Run({"ZINTERSTORE", "zdest", "2", "skey", "zkey"});
 
   EXPECT_EQ(0, CheckedInt({"EXISTS", "skey"}));
 }

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -1360,6 +1360,20 @@ TEST_F(GenericFamilyTest, FieldExpireNoSuchKey) {
               RespArray(ElementsAre(IntArg(-2), IntArg(-2))));
 }
 
+TEST_F(GenericFamilyTest, ZInterStoreDeletesEmptySet) {
+  for (int i = 0; i < 20; ++i) {
+    Run({"SADDEX", "skey", "1", absl::StrCat("m", i)});
+  }
+  Run({"ZADD", "zkey", "1", "m0"});
+
+  AdvanceTime(2000);
+
+  Run({"SISMEMBER", "skey", "m0"});
+  Run({"ZINTERSTORE", "zdest", "2", "skey", "zkey"});
+
+  EXPECT_EQ(0, CheckedInt({"EXISTS", "skey"}));
+}
+
 TEST_F(GenericFamilyTest, ExpireTime) {
   EXPECT_EQ(-2, CheckedInt({"EXPIRETIME", "foo"}));
   EXPECT_EQ(-2, CheckedInt({"PEXPIRETIME", "foo"}));

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -934,20 +934,23 @@ OpResult<ScoredMap> OpInter(EngineShard* shard, Transaction* t, string_view dest
     return OpStatus::SKIPPED;
 
   ScoredMap result;
+  // Collect keys of sets that got emptied by lazy expiry during iteration.
+  // Deleting them inside the loop would invalidate other PrimeTable iterators
+  // held in key_vec_res.
+  absl::InlinedVector<std::string, 2> emptied_set_keys;
   for (const auto& [it, weight] : *key_vec_res) {
     if (it.is_done()) {
       return ScoredMap{};
     }
 
     ScoredMap sm;
-    if (it->second.ObjType() == OBJ_ZSET)
+    if (it->second.ObjType() == OBJ_ZSET) {
       sm = FromObject(it->second, weight);
-    else {
+    } else {
       DCHECK_EQ(it->second.ObjType(), OBJ_SET);
       sm = ScoreMapFromSet(it->second, weight, t->GetDbContext());
       if (it->second.Size() == 0) {
-        auto& db_slice = t->GetDbSlice(shard->shard_id());
-        SetFamily::DeleteSetIfEmpty(db_slice, t->GetDbContext(), it.key(), it->second);
+        emptied_set_keys.emplace_back(it.key());
       }
     }
     if (result.empty())
@@ -956,7 +959,15 @@ OpResult<ScoredMap> OpInter(EngineShard* shard, Transaction* t, string_view dest
       InterScoredMap(&result, &sm, agg_type);
 
     if (result.empty())
-      return result;
+      break;
+  }
+
+  // Safe to delete now — the loop above no longer references iterators.
+  auto& db_slice = t->GetDbSlice(shard->shard_id());
+  for (const auto& key : emptied_set_keys) {
+    if (auto res = db_slice.FindReadOnly(t->GetDbContext(), key, OBJ_SET); res) {
+      SetFamily::DeleteSetIfEmpty(db_slice, t->GetDbContext(), key, (*res)->second);
+    }
   }
 
   return result;

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -29,6 +29,7 @@ extern "C" {
 #include "server/error.h"
 #include "server/family_utils.h"
 #include "server/namespaces.h"
+#include "server/set_family.h"
 #include "server/transaction.h"
 
 namespace rng = std::ranges;
@@ -920,6 +921,10 @@ OpResult<ScoredMap> OpInter(EngineShard* shard, Transaction* t, string_view dest
     else {
       DCHECK_EQ(it->second.ObjType(), OBJ_SET);
       sm = ScoreMapFromSet(it->second, weight);
+      if (it->second.Size() == 0) {
+        auto& db_slice = t->GetDbSlice(shard->shard_id());
+        SetFamily::DeleteSetIfEmpty(db_slice, t->GetDbContext(), it.key(), it->second);
+      }
     }
     if (result.empty())
       result.swap(sm);


### PR DESCRIPTION
OpInter calls ScoreMapFromSet which iterates sets via IterateSet, triggering lazy member expiry. If all members expired, delete the empty set.

Related to: https://github.com/dragonflydb/dragonfly/issues/7133