### PR TITLE
fix: clean up empty containers after DEBUG OBJHIST/UNIQ-STRS

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -561,7 +561,9 @@ IOStat& IOStat::operator-=(const IOStat& other) {
   return *this;
 }
 
-// Traverse over all entries on all databases, manage cpu time automatically
+// Traverse over all entries on all databases, manage cpu time automatically.
+// The callback receives (DbIndex, PrimeIterator) — the DbIndex identifies
+// which database is currently being iterated.
 template <typename F> void TraverseAllEntries(bool background, ConnectionContext* cntx, F&& f) {
   util::fb2::BlockingCounter bc{0};
   for (uint32_t i = 0; i < shard_set->size(); ++i) {
@@ -577,9 +579,11 @@ template <typename F> void TraverseAllEntries(bool background, ConnectionContext
         if (!dbt)
           continue;
 
+        DbIndex dbid = static_cast<DbIndex>(i);
+        auto bound_f = [&f, dbid](PrimeIterator it) { f(dbid, it); };
         PrimeTable::Cursor cursor;
         do {
-          cursor = dbt->prime.Traverse(cursor, f);
+          cursor = dbt->prime.Traverse(cursor, bound_f);
           if (background) {
             ThisFiber::Yield();
           } else if (base::CycleClock::ToUsec(ThisFiber::GetRunningTimeCycles()) >= 500) {
@@ -1179,7 +1183,7 @@ void DebugCmd::TxAnalysis(CommandContext* cmd_cntx) {
 
 void DebugCmd::ObjHist(CommandContext* cmd_cntx) {
   vector<ObjHistMap> obj_hist_map_arr(shard_set->size());
-  auto cb = [&obj_hist_map_arr, cntx = cntx_](PrimeIterator it) {
+  auto cb = [&obj_hist_map_arr, cntx = cntx_](DbIndex dbid, PrimeIterator it) {
     unsigned obj_type = it->second.ObjType();
     auto& hist_ptr = obj_hist_map_arr[EngineShard::tlocal()->shard_id()][obj_type];
     if (!hist_ptr) {
@@ -1187,10 +1191,11 @@ void DebugCmd::ObjHist(CommandContext* cmd_cntx) {
     }
     AddObjHist(it, hist_ptr.get());
 
-    // IterateMap/IterateSet may trigger lazy expiry.  Clean up empty containers.
+    // IterateMap/IterateSet may trigger lazy expiry.  Clean up empty containers
+    // in the currently traversed DB (not the connection-selected one).
     if (it->second.Size() == 0 && it->second.Encoding() == kEncodingStrMap2) {
       auto& db_slice = cntx->ns->GetDbSlice(EngineShard::tlocal()->shard_id());
-      DbContext db_cntx{cntx->ns, cntx->db_index(), GetCurrentTimeMs()};
+      DbContext db_cntx{cntx->ns, dbid, GetCurrentTimeMs()};
       string key;
       it->first.GetString(&key);
       if (obj_type == OBJ_SET)
@@ -1658,7 +1663,7 @@ void DebugCmd::CountUniqueStrings(const CommandContext* cmd_cntx) const {
   using PerShardStats = std::array<std::unique_ptr<UniqueStrings>, OBJ_HASH + 1>;
 
   vector<PerShardStats> all_shards(shard_set->size());
-  auto cb = [&all_shards, cntx = cntx_](PrimeIterator it) {
+  auto cb = [&all_shards, cntx = cntx_](DbIndex dbid, PrimeIterator it) {
     const unsigned obj_type = it->second.ObjType();
     if (obj_type != OBJ_HASH && obj_type != OBJ_LIST && obj_type != OBJ_SET &&
         obj_type != OBJ_ZSET) {
@@ -1679,10 +1684,11 @@ void DebugCmd::CountUniqueStrings(const CommandContext* cmd_cntx) const {
     else if (obj_type == OBJ_ZSET)
       entry->AddZSet(it->second);
 
-    // IterateMap/IterateSet may trigger lazy expiry.  Clean up empty containers.
+    // IterateMap/IterateSet may trigger lazy expiry.  Clean up empty containers
+    // in the currently traversed DB (not the connection-selected one).
     if (it->second.Size() == 0 && it->second.Encoding() == kEncodingStrMap2) {
       auto& db_slice = cntx->ns->GetDbSlice(EngineShard::tlocal()->shard_id());
-      DbContext db_cntx{cntx->ns, cntx->db_index(), GetCurrentTimeMs()};
+      DbContext db_cntx{cntx->ns, dbid, GetCurrentTimeMs()};
       string key;
       it->first.GetString(&key);
       if (obj_type == OBJ_SET)

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -39,11 +39,13 @@ extern "C" {
 #include "server/container_utils.h"
 #include "server/engine_shard_set.h"
 #include "server/error.h"
+#include "server/hset_family.h"
 #include "server/main_service.h"
 #include "server/multi_command_squasher.h"
 #include "server/namespaces.h"
 #include "server/rdb_load.h"
 #include "server/server_state.h"
+#include "server/set_family.h"
 #include "server/string_stats.h"
 #include "server/transaction.h"
 
@@ -1177,13 +1179,25 @@ void DebugCmd::TxAnalysis(CommandContext* cmd_cntx) {
 
 void DebugCmd::ObjHist(CommandContext* cmd_cntx) {
   vector<ObjHistMap> obj_hist_map_arr(shard_set->size());
-  auto cb = [&obj_hist_map_arr](PrimeIterator it) {
+  auto cb = [&obj_hist_map_arr, cntx = cntx_](PrimeIterator it) {
     unsigned obj_type = it->second.ObjType();
     auto& hist_ptr = obj_hist_map_arr[EngineShard::tlocal()->shard_id()][obj_type];
     if (!hist_ptr) {
       hist_ptr.reset(new struct ObjHist);
     }
     AddObjHist(it, hist_ptr.get());
+
+    // IterateMap/IterateSet may trigger lazy expiry.  Clean up empty containers.
+    if (it->second.Size() == 0 && it->second.Encoding() == kEncodingStrMap2) {
+      auto& db_slice = cntx->ns->GetDbSlice(EngineShard::tlocal()->shard_id());
+      DbContext db_cntx{cntx->ns, cntx->db_index(), GetCurrentTimeMs()};
+      string key;
+      it->first.GetString(&key);
+      if (obj_type == OBJ_SET)
+        SetFamily::DeleteSetIfEmpty(db_slice, db_cntx, key, it->second);
+      else if (obj_type == OBJ_HASH)
+        HSetFamily::DeleteIfEmpty(db_slice, db_cntx, key, it->second);
+    }
   };
   TraverseAllEntries(absl::GetFlag(FLAGS_background_debug_jobs), cntx_, cb);
 
@@ -1644,7 +1658,7 @@ void DebugCmd::CountUniqueStrings(const CommandContext* cmd_cntx) const {
   using PerShardStats = std::array<std::unique_ptr<UniqueStrings>, OBJ_HASH + 1>;
 
   vector<PerShardStats> all_shards(shard_set->size());
-  auto cb = [&all_shards](PrimeIterator it) {
+  auto cb = [&all_shards, cntx = cntx_](PrimeIterator it) {
     const unsigned obj_type = it->second.ObjType();
     if (obj_type != OBJ_HASH && obj_type != OBJ_LIST && obj_type != OBJ_SET &&
         obj_type != OBJ_ZSET) {
@@ -1664,6 +1678,18 @@ void DebugCmd::CountUniqueStrings(const CommandContext* cmd_cntx) const {
       entry->AddSet(it->second);
     else if (obj_type == OBJ_ZSET)
       entry->AddZSet(it->second);
+
+    // IterateMap/IterateSet may trigger lazy expiry.  Clean up empty containers.
+    if (it->second.Size() == 0 && it->second.Encoding() == kEncodingStrMap2) {
+      auto& db_slice = cntx->ns->GetDbSlice(EngineShard::tlocal()->shard_id());
+      DbContext db_cntx{cntx->ns, cntx->db_index(), GetCurrentTimeMs()};
+      string key;
+      it->first.GetString(&key);
+      if (obj_type == OBJ_SET)
+        SetFamily::DeleteSetIfEmpty(db_slice, db_cntx, key, it->second);
+      else if (obj_type == OBJ_HASH)
+        HSetFamily::DeleteIfEmpty(db_slice, db_cntx, key, it->second);
+    }
   };
 
   TraverseAllEntries(absl::GetFlag(FLAGS_background_debug_jobs), cntx_, cb);

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -1393,6 +1393,33 @@ TEST_F(GenericFamilyTest, DebugUniqStrsDeletesEmptyContainers) {
   EXPECT_EQ(0, CheckedInt({"EXISTS", "skey"}));
 }
 
+// Regression: TraverseAllEntries walks every DB but the callback used the
+// connection-selected DB for deletion.  A zombie in DB 1 could cause a
+// same-named non-empty key in DB 0 to be deleted incorrectly.
+TEST_F(GenericFamilyTest, DebugObjHistMultiDbCorrectDb) {
+  // Live hash in DB 0 under the same key name as the zombie in DB 1.
+  Run({"SELECT", "0"});
+  Run({"HSET", "shared", "alive", "value"});
+
+  Run({"SELECT", "1"});
+  for (int i = 0; i < 64; ++i) {
+    Run({"HSETEX", "shared", "1", absl::StrCat("f", i), "v"});
+  }
+
+  AdvanceTime(2000);
+
+  Run({"HGET", "shared", "f0"});  // enable lazy expiry on DB 1's hash
+  Run({"DEBUG", "OBJHIST"});
+
+  // Zombie in DB 1 must be deleted.
+  EXPECT_EQ(0, CheckedInt({"EXISTS", "shared"}));
+
+  // Live hash in DB 0 must survive.
+  Run({"SELECT", "0"});
+  EXPECT_EQ(1, CheckedInt({"EXISTS", "shared"}));
+  EXPECT_EQ("value", Run({"HGET", "shared", "alive"}));
+}
+
 TEST_F(GenericFamilyTest, ZInterStoreDeletesEmptySet) {
   for (int i = 0; i < 20; ++i) {
     Run({"SADDEX", "skey", "1", absl::StrCat("m", i)});

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -1360,6 +1360,39 @@ TEST_F(GenericFamilyTest, FieldExpireNoSuchKey) {
               RespArray(ElementsAre(IntArg(-2), IntArg(-2))));
 }
 
+TEST_F(GenericFamilyTest, IterateMapSetStaleTimeZombie) {
+  for (int i = 0; i < 64; ++i) {
+    Run({"HSETEX", "hkey", "1", absl::StrCat("f", i), "v"});
+    Run({"SADDEX", "skey", "1", absl::StrCat("m", i)});
+  }
+
+  AdvanceTime(2000);
+
+  Run({"HGET", "hkey", "f0"});
+  Run({"SISMEMBER", "skey", "m0"});
+
+  Run({"DEBUG", "OBJHIST"});
+
+  EXPECT_EQ(0, CheckedInt({"EXISTS", "hkey"}));
+  EXPECT_EQ(0, CheckedInt({"EXISTS", "skey"}));
+}
+
+TEST_F(GenericFamilyTest, DebugUniqStrsDeletesEmptyContainers) {
+  for (int i = 0; i < 64; ++i) {
+    Run({"HSETEX", "hkey", "1", absl::StrCat("f", i), "v"});
+    Run({"SADDEX", "skey", "1", absl::StrCat("m", i)});
+  }
+
+  AdvanceTime(2000);
+
+  Run({"HGET", "hkey", "f0"});
+  Run({"SISMEMBER", "skey", "m0"});
+  Run({"DEBUG", "UNIQ-STRS"});
+
+  EXPECT_EQ(0, CheckedInt({"EXISTS", "hkey"}));
+  EXPECT_EQ(0, CheckedInt({"EXISTS", "skey"}));
+}
+
 TEST_F(GenericFamilyTest, ExpireTime) {
   EXPECT_EQ(-2, CheckedInt({"EXPIRETIME", "foo"}));
   EXPECT_EQ(-2, CheckedInt({"PEXPIRETIME", "foo"}));


### PR DESCRIPTION
DEBUG OBJHIST and DEBUG UNIQ-STRS traverse the entire DB and iterate hashes/sets via IterateMap/IterateSet. If time_now_ was set by a prior command, the iteration triggers lazy expiry. If all entries expired, the empty container must be deleted.

Related to: https://github.com/dragonflydb/dragonfly/issues/7133