### PR TITLE
fix: delete empty hash after FT.SEARCH lazy field expiry

### DIFF
--- a/src/server/search/doc_accessors.cc
+++ b/src/server/search/doc_accessors.cc
@@ -22,6 +22,9 @@
 #include "core/search/vector_utils.h"
 #include "core/string_map.h"
 #include "server/container_utils.h"
+#include "server/engine_shard.h"
+#include "server/hset_family.h"
+#include "server/namespaces.h"
 
 extern "C" {
 #include "redis/listpack.h"
@@ -168,6 +171,18 @@ SearchDocData ListPackAccessor::Serialize(const search::Schema& schema) const {
     }
   }
   return out;
+}
+
+StringMapAccessor::~StringMapAccessor() {
+  // Reads (e.g. Serialize/GetStrings) trigger lazy field expiry on the
+  // underlying StringMap.  If all fields expired during our lifetime,
+  // delete the now-empty hash so a later SAVE does not hit the DFATAL for
+  // empty OBJ_HASH in rdb_save.cc.
+  if (cleanup_key_.empty() || !hset_ || !hset_->Empty())
+    return;
+
+  auto& db_slice = db_cntx_.ns->GetDbSlice(EngineShard::tlocal()->shard_id());
+  HSetFamily::DeleteIfEmpty(db_slice, db_cntx_, cleanup_key_, *cleanup_pv_);
 }
 
 std::optional<BaseAccessor::StringList> StringMapAccessor::GetStrings(
@@ -399,7 +414,8 @@ void JsonAccessor::RemoveFieldFromCache(string_view field) {
 thread_local absl::flat_hash_map<std::string, std::unique_ptr<JsonAccessor::JsonPathContainer>>
     JsonAccessor::path_cache_;
 
-unique_ptr<BaseAccessor> GetAccessor(const DbContext& db_cntx, const PrimeValue& pv) {
+unique_ptr<BaseAccessor> GetAccessor(const DbContext& db_cntx, const PrimeValue& pv,
+                                     std::string_view cleanup_key) {
   DCHECK(pv.ObjType() == OBJ_HASH || pv.ObjType() == OBJ_JSON);
 
   if (pv.ObjType() == OBJ_JSON) {
@@ -412,7 +428,9 @@ unique_ptr<BaseAccessor> GetAccessor(const DbContext& db_cntx, const PrimeValue&
     return make_unique<ListPackAccessor>(ptr);
   } else {
     auto* sm = container_utils::GetStringMap(pv, db_cntx);
-    return make_unique<StringMapAccessor>(sm);
+    if (cleanup_key.empty())
+      return make_unique<StringMapAccessor>(sm);
+    return make_unique<StringMapAccessor>(sm, std::string{cleanup_key}, db_cntx, &pv);
   }
 }
 

--- a/src/server/search/doc_accessors.h
+++ b/src/server/search/doc_accessors.h
@@ -7,6 +7,7 @@
 #include <absl/container/flat_hash_map.h>
 #include <absl/types/span.h>
 
+#include <functional>
 #include <string>
 
 #include "core/detail/listpack_wrap.h"
@@ -50,16 +51,30 @@ struct ListPackAccessor : public BaseAccessor {
   detail::ListpackWrap lw_;
 };
 
-// Accessor for hashes stored with StringMap
+// Accessor for hashes stored with StringMap.
+// If cleanup context is supplied, the destructor deletes the underlying key
+// when the StringMap becomes empty (e.g. from lazy field expiry during
+// Serialize).  This keeps post-access cleanup out of search logic.
 struct StringMapAccessor : public BaseAccessor {
   explicit StringMapAccessor(StringMap* hset) : hset_{hset} {
   }
+
+  StringMapAccessor(StringMap* hset, std::string cleanup_key, DbContext db_cntx,
+                    const PrimeValue* pv)
+      : hset_{hset}, cleanup_key_{std::move(cleanup_key)}, db_cntx_{db_cntx}, cleanup_pv_{pv} {
+  }
+
+  ~StringMapAccessor() override;
 
   std::optional<StringList> GetStrings(std::string_view field) const override;
   SearchDocData Serialize(const search::Schema& schema) const override;
 
  private:
   StringMap* hset_;
+  // Cleanup state (empty key means no cleanup requested).
+  std::string cleanup_key_;
+  DbContext db_cntx_{};
+  const PrimeValue* cleanup_pv_ = nullptr;
 };
 
 // Accessor for json values
@@ -97,6 +112,9 @@ struct JsonAccessor : public BaseAccessor {
 };
 
 // Get accessor for value
-std::unique_ptr<BaseAccessor> GetAccessor(const DbContext& db_cntx, const PrimeValue& pv);
+// If cleanup_key is non-empty, the returned StringMapAccessor (if any) will
+// delete the DB key in its destructor when the hash has become empty.
+std::unique_ptr<BaseAccessor> GetAccessor(const DbContext& db_cntx, const PrimeValue& pv,
+                                          std::string_view cleanup_key = {});
 
 }  // namespace dfly

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -20,6 +20,7 @@
 #include "server/db_slice.h"
 #include "server/engine_shard_set.h"
 #include "server/family_utils.h"
+#include "server/hset_family.h"
 #include "server/search/doc_accessors.h"
 #include "server/search/global_hnsw_index.h"
 #include "server/search/index_builder.h"
@@ -947,6 +948,18 @@ SearchResult ShardDocIndex::Search(const OpArgs& op_args, const SearchParams& pa
     auto more_fields = accessor->Serialize(base_->schema, return_fields);
     fields.insert(make_move_iterator(more_fields.begin()), make_move_iterator(more_fields.end()));
     out.push_back({result.ids[i], string{key}, std::move(fields), knn_score, sort_score});
+
+    // Serialize iterates StringMap, triggering lazy field expiry.
+    // If all fields expired, delete the now-empty hash.
+    if (base_->GetObjCode() == OBJ_HASH) {
+      auto chk = op_args.GetDbSlice().FindReadOnly(op_args.db_cntx, key, OBJ_HASH);
+      if (chk && IsValid(*chk) && (*chk)->second.Size() == 0) {
+        // Copy key: DelMutable inside DeleteIfEmpty may trigger a doc-deletion
+        // callback that mutates key_index_ and invalidates our string_view.
+        string owned_key{key};
+        HSetFamily::DeleteIfEmpty(op_args.GetDbSlice(), op_args.db_cntx, owned_key, (*chk)->second);
+      }
+    }
   }
 
   return {result.total - expired_count, std::move(out), std::move(result.profile)};

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -20,7 +20,6 @@
 #include "server/db_slice.h"
 #include "server/engine_shard_set.h"
 #include "server/family_utils.h"
-#include "server/hset_family.h"
 #include "server/search/doc_accessors.h"
 #include "server/search/global_hnsw_index.h"
 #include "server/search/index_builder.h"
@@ -810,7 +809,8 @@ optional<ShardDocIndex::LoadedEntry> ShardDocIndex::LoadEntry(DocId id,
   if (!it || !IsValid(*it))
     return std::nullopt;
 
-  return {{key, GetAccessor(op_args.db_cntx, (*it)->second)}};
+  // Pass key so StringMapAccessor can clean up if lazy expiry empties the hash.
+  return {{key, GetAccessor(op_args.db_cntx, (*it)->second, key)}};
 }
 
 vector<search::SortableValue> ShardDocIndex::KeepTopKSorted(vector<DocId>* ids, size_t limit,
@@ -948,18 +948,6 @@ SearchResult ShardDocIndex::Search(const OpArgs& op_args, const SearchParams& pa
     auto more_fields = accessor->Serialize(base_->schema, return_fields);
     fields.insert(make_move_iterator(more_fields.begin()), make_move_iterator(more_fields.end()));
     out.push_back({result.ids[i], string{key}, std::move(fields), knn_score, sort_score});
-
-    // Serialize iterates StringMap, triggering lazy field expiry.
-    // If all fields expired, delete the now-empty hash.
-    if (base_->GetObjCode() == OBJ_HASH) {
-      auto chk = op_args.GetDbSlice().FindReadOnly(op_args.db_cntx, key, OBJ_HASH);
-      if (chk && IsValid(*chk) && (*chk)->second.Size() == 0) {
-        // Copy key: DelMutable inside DeleteIfEmpty may trigger a doc-deletion
-        // callback that mutates key_index_ and invalidates our string_view.
-        string owned_key{key};
-        HSetFamily::DeleteIfEmpty(op_args.GetDbSlice(), op_args.db_cntx, owned_key, (*chk)->second);
-      }
-    }
   }
 
   return {result.total - expired_count, std::move(out), std::move(result.profile)};

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -5444,4 +5444,26 @@ TEST_F(DocKeyIndexTest, RestoreRoundTripsEmptyKey) {
   EXPECT_EQ(restored.Add("doc3"), id0);  // freed slot is reused
 }
 
+// FT.SEARCH loads documents via GetAccessor → GetStringMap (set_time) → Serialize
+// which iterates the StringMap triggering lazy field expiry.  If all fields expired,
+// the hash must be cleaned up — not left as a zombie that crashes SAVE.
+TEST_F(SearchFamilyTest, SearchDeletesEmptyHash) {
+  Run({"ft.create", "idx", "PREFIX", "1", "d:", "SCHEMA", "foo", "TEXT"});
+
+  // Create documents with field-level TTL.
+  for (int i = 0; i < 10; ++i) {
+    Run({"HSETEX", absl::StrCat("d:", i), "1", "foo", absl::StrCat("bar", i)});
+  }
+
+  AdvanceTime(2000);
+
+  // FT.SEARCH triggers GetStringMap(set_time) + Serialize which iterates all fields.
+  // Lazy expiry deletes them.  Without fix, empty hashes remain as zombies.
+  Run({"ft.search", "idx", "*"});
+
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_EQ(0, CheckedInt({"EXISTS", absl::StrCat("d:", i)}));
+  }
+}
+
 }  // namespace dfly


### PR DESCRIPTION
FT.SEARCH loads documents via GetAccessor -> GetStringMap (which sets time_now_) -> Serialize (which iterates the StringMap). The iteration triggers lazy field expiry. If all fields expired, the hash must be deleted to prevent zombie keys that crash SAVE.

Related to: https://github.com/dragonflydb/dragonfly/issues/7133