### PR TITLE
fix: disable lazy expiry during migration serialization

### DIFF
--- a/src/server/journal/cmd_serializer.cc
+++ b/src/server/journal/cmd_serializer.cc
@@ -6,11 +6,9 @@
 
 #include "core/string_map.h"
 #include "core/string_set.h"
-#include "server/common.h"
 #include "server/container_utils.h"
 #include "server/db_slice.h"
 #include "server/engine_shard.h"
-#include "server/engine_shard_set.h"
 #include "server/journal/serializer.h"
 #include "server/rdb_save.h"
 #include "server/tiered_storage.h"
@@ -165,8 +163,10 @@ size_t CmdSerializer::SerializeSet(string_view key, const PrimeValue& pv) {
   // Disable lazy expiry during serialization (same as rdb_save.cc).
   // We are called under bucket lock so DeleteIfEmpty is not possible.
   StringSet* ss = nullptr;
+  uint32_t prev_time = 0;
   if (pv.Encoding() == kEncodingStrMap2) {
     ss = static_cast<StringSet*>(pv.RObjPtr());
+    prev_time = ss->time_now();
     ss->set_time(0);
   }
 
@@ -180,9 +180,9 @@ size_t CmdSerializer::SerializeSet(string_view key, const PrimeValue& pv) {
     return true;
   });
 
-  // Restore time so subsequent operations can trigger lazy expiry again.
+  // Restore previous time so subsequent operations can trigger lazy expiry.
   if (ss)
-    ss->set_time(MemberTimeSeconds(GetCurrentTimeMs()));
+    ss->set_time(prev_time);
 
   return commands;
 }
@@ -207,8 +207,10 @@ size_t CmdSerializer::SerializeZSet(string_view key, const PrimeValue& pv) {
 size_t CmdSerializer::SerializeHash(string_view key, const PrimeValue& pv) {
   // Disable lazy expiry during serialization (same as rdb_save.cc).
   StringMap* sm = nullptr;
+  uint32_t prev_time = 0;
   if (pv.Encoding() == kEncodingStrMap2) {
     sm = static_cast<StringMap*>(pv.RObjPtr());
+    prev_time = sm->time_now();
     sm->set_time(0);
   }
 
@@ -224,9 +226,9 @@ size_t CmdSerializer::SerializeHash(string_view key, const PrimeValue& pv) {
         return true;
       });
 
-  // Restore time so subsequent operations can trigger lazy expiry again.
+  // Restore previous time so subsequent operations can trigger lazy expiry.
   if (sm)
-    sm->set_time(MemberTimeSeconds(GetCurrentTimeMs()));
+    sm->set_time(prev_time);
 
   return commands;
 }

--- a/src/server/journal/cmd_serializer.cc
+++ b/src/server/journal/cmd_serializer.cc
@@ -88,8 +88,7 @@ size_t CmdSerializer::SerializeEntry(string_view key, const PrimeKey& pk, const 
   // We send RESTORE commands objects we don't support breaking.
   bool use_restore_serialization = true;
   size_t commands = 1;
-  auto obj_type = pv.ObjType();
-  switch (obj_type) {
+  switch (pv.ObjType()) {
     case OBJ_SET:
       commands = SerializeSet(key, pv);
       use_restore_serialization = false;

--- a/src/server/journal/cmd_serializer.cc
+++ b/src/server/journal/cmd_serializer.cc
@@ -6,9 +6,11 @@
 
 #include "core/string_map.h"
 #include "core/string_set.h"
+#include "server/common.h"
 #include "server/container_utils.h"
 #include "server/db_slice.h"
 #include "server/engine_shard.h"
+#include "server/engine_shard_set.h"
 #include "server/journal/serializer.h"
 #include "server/rdb_save.h"
 #include "server/tiered_storage.h"
@@ -163,8 +165,11 @@ void CmdSerializer::SerializeExpireIfNeeded(string_view key, uint64_t expire_ms)
 size_t CmdSerializer::SerializeSet(string_view key, const PrimeValue& pv) {
   // Disable lazy expiry during serialization (same as rdb_save.cc).
   // We are called under bucket lock so DeleteIfEmpty is not possible.
-  if (pv.Encoding() == kEncodingStrMap2)
-    static_cast<StringSet*>(pv.RObjPtr())->set_time(0);
+  StringSet* ss = nullptr;
+  if (pv.Encoding() == kEncodingStrMap2) {
+    ss = static_cast<StringSet*>(pv.RObjPtr());
+    ss->set_time(0);
+  }
 
   CommandAggregator aggregator(
       key, [&](absl::Span<const string_view> args) { SerializeCommand("SADD", args); },
@@ -175,6 +180,11 @@ size_t CmdSerializer::SerializeSet(string_view key, const PrimeValue& pv) {
     commands += aggregator.AddArg(ce.ToString());
     return true;
   });
+
+  // Restore time so subsequent operations can trigger lazy expiry again.
+  if (ss)
+    ss->set_time(MemberTimeSeconds(GetCurrentTimeMs()));
+
   return commands;
 }
 
@@ -197,8 +207,11 @@ size_t CmdSerializer::SerializeZSet(string_view key, const PrimeValue& pv) {
 
 size_t CmdSerializer::SerializeHash(string_view key, const PrimeValue& pv) {
   // Disable lazy expiry during serialization (same as rdb_save.cc).
-  if (pv.Encoding() == kEncodingStrMap2)
-    static_cast<StringMap*>(pv.RObjPtr())->set_time(0);
+  StringMap* sm = nullptr;
+  if (pv.Encoding() == kEncodingStrMap2) {
+    sm = static_cast<StringMap*>(pv.RObjPtr());
+    sm->set_time(0);
+  }
 
   CommandAggregator aggregator(
       key, [&](absl::Span<const string_view> args) { SerializeCommand("HSET", args); },
@@ -211,6 +224,11 @@ size_t CmdSerializer::SerializeHash(string_view key, const PrimeValue& pv) {
         commands += aggregator.AddArg(v.ToString());
         return true;
       });
+
+  // Restore time so subsequent operations can trigger lazy expiry again.
+  if (sm)
+    sm->set_time(MemberTimeSeconds(GetCurrentTimeMs()));
+
   return commands;
 }
 

--- a/src/server/journal/cmd_serializer.cc
+++ b/src/server/journal/cmd_serializer.cc
@@ -4,6 +4,8 @@
 
 #include "server/journal/cmd_serializer.h"
 
+#include "core/string_map.h"
+#include "core/string_set.h"
 #include "server/container_utils.h"
 #include "server/db_slice.h"
 #include "server/engine_shard.h"
@@ -84,7 +86,8 @@ size_t CmdSerializer::SerializeEntry(string_view key, const PrimeKey& pk, const 
   // We send RESTORE commands objects we don't support breaking.
   bool use_restore_serialization = true;
   size_t commands = 1;
-  switch (pv.ObjType()) {
+  auto obj_type = pv.ObjType();
+  switch (obj_type) {
     case OBJ_SET:
       commands = SerializeSet(key, pv);
       use_restore_serialization = false;
@@ -158,6 +161,11 @@ void CmdSerializer::SerializeExpireIfNeeded(string_view key, uint64_t expire_ms)
 }
 
 size_t CmdSerializer::SerializeSet(string_view key, const PrimeValue& pv) {
+  // Disable lazy expiry during serialization (same as rdb_save.cc).
+  // We are called under bucket lock so DeleteIfEmpty is not possible.
+  if (pv.Encoding() == kEncodingStrMap2)
+    static_cast<StringSet*>(pv.RObjPtr())->set_time(0);
+
   CommandAggregator aggregator(
       key, [&](absl::Span<const string_view> args) { SerializeCommand("SADD", args); },
       max_serialization_buffer_size_);
@@ -188,6 +196,10 @@ size_t CmdSerializer::SerializeZSet(string_view key, const PrimeValue& pv) {
 }
 
 size_t CmdSerializer::SerializeHash(string_view key, const PrimeValue& pv) {
+  // Disable lazy expiry during serialization (same as rdb_save.cc).
+  if (pv.Encoding() == kEncodingStrMap2)
+    static_cast<StringMap*>(pv.RObjPtr())->set_time(0);
+
   CommandAggregator aggregator(
       key, [&](absl::Span<const string_view> args) { SerializeCommand("HSET", args); },
       max_serialization_buffer_size_);

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -1431,6 +1431,55 @@ async def test_cluster_data_migration(df_factory: DflyInstanceFactory, interrupt
     await check_for_no_state_status([node.admin_client for node in nodes])
 
 
+@dfly_args({"proactor_threads": 2, "cluster_mode": "yes"})
+async def test_migration_serializer_expired_fields(df_factory):
+    """
+    CmdSerializer uses IterateMap/IterateSet during migration.  If time_now_
+    was set by a prior command (HGET), the iteration triggers lazy expiry.
+    After serialization the source has an empty hash — SAVE must not crash.
+    """
+    instances = [
+        df_factory.create(port=next(next_port), admin_port=next(next_port)) for i in range(2)
+    ]
+    df_factory.start_all(instances)
+
+    nodes = [(await create_node_info(instance)) for instance in instances]
+    nodes[0].slots = [(0, 16383)]
+    nodes[1].slots = []
+    await push_config(json.dumps(generate_config(nodes)), [node.admin_client for node in nodes])
+
+    # Many fields with short TTL spread across DenseSet buckets.
+    for i in range(64):
+        await nodes[0].client.execute_command("HSETEX", "hkey", "1", f"f{i}", "v")
+        await nodes[0].client.execute_command("SADDEX", "skey", "1", f"m{i}")
+    await nodes[0].client.execute_command("SET", "normal", "val")
+
+    await asyncio.sleep(1.5)
+
+    # HGET/SISMEMBER update time_now_ but only partially expire (one bucket).
+    # ExecuteRO sees UpperBoundSize > 0, doesn't clean up.
+    await nodes[0].client.execute_command("HGET", "hkey", "f0")
+    await nodes[0].client.execute_command("SISMEMBER", "skey", "m0")
+
+    # Start migration — serializer iterates all DenseSet buckets, expiring rest.
+    nodes[0].migrations.append(
+        MigrationInfo("127.0.0.1", instances[1].port, [(0, 16383)], nodes[1].id)
+    )
+    await push_config(json.dumps(generate_config(nodes)), [node.admin_client for node in nodes])
+    await wait_for_status(nodes[0].admin_client, nodes[1].id, "FINISHED")
+
+    # Without the fix, SAVE on source crashes (DFATAL on empty hash).
+    await nodes[0].admin_client.execute_command("SAVE", "RDB", "test_zombie.rdb")
+
+    nodes[0].migrations = []
+    nodes[0].slots = []
+    nodes[1].slots = [(0, 16383)]
+    await push_config(json.dumps(generate_config(nodes)), [node.admin_client for node in nodes])
+
+    assert await nodes[1].client.execute_command("GET", "normal") == "val"
+    # Server survived — no zombie crash.
+
+
 @dfly_args({"proactor_threads": 2, "cluster_mode": "yes", "cache_mode": "true"})
 async def test_migration_with_key_ttl(df_factory):
     instances = [

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -1454,7 +1454,8 @@ async def test_migration_serializer_expired_fields(df_factory):
         await nodes[0].client.execute_command("SADDEX", "skey", "1", f"m{i}")
     await nodes[0].client.execute_command("SET", "normal", "val")
 
-    await asyncio.sleep(1.5)
+    # TTL is 1s; wait generously to tolerate slow/loaded CI runners.
+    await asyncio.sleep(2.0)
 
     # HGET/SISMEMBER update time_now_ but only partially expire (one bucket).
     # ExecuteRO sees UpperBoundSize > 0, doesn't clean up.
@@ -1469,7 +1470,7 @@ async def test_migration_serializer_expired_fields(df_factory):
     await wait_for_status(nodes[0].admin_client, nodes[1].id, "FINISHED")
 
     # Without the fix, SAVE on source crashes (DFATAL on empty hash).
-    await nodes[0].admin_client.execute_command("SAVE", "RDB", "test_zombie.rdb")
+    assert await nodes[0].admin_client.execute_command("SAVE", "RDB", "test_zombie.rdb")
 
     nodes[0].migrations = []
     nodes[0].slots = []


### PR DESCRIPTION
CmdSerializer::SerializeHash/SerializeSet use IterateMap/IterateSet which can trigger lazy field expiry if time_now_ was set by a prior command. Since serialization runs under bucket lock, DeleteIfEmpty is not possible. Instead, disable lazy expiry with set_time(0) before iteration (same pattern as rdb_save.cc).

Related to: https://github.com/dragonflydb/dragonfly/issues/7133
