### PR TITLE
fix: call flushSlots under transaction to avoid race condition

### DIFF
--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -31,6 +31,7 @@
 #include "server/namespaces.h"
 #include "server/server_family.h"
 #include "server/server_state.h"
+#include "server/transaction.h"
 #include "util/fibers/synchronization.h"
 
 namespace rng = std::ranges;
@@ -490,19 +491,19 @@ void ClusterFamily::ClusterMyId(SinkReplyBuilder* builder) {
 
 namespace {
 
-void DeleteSlots(const SlotRanges& slots_ranges) {
+// FlushSlots calls RegisterOnChange which requires the shard lock to be held (see #7153).
+// Execute under a global transaction so the shard lock is acquired properly.
+void DeleteSlots(Transaction* trans, const SlotRanges& slots_ranges) {
   if (slots_ranges.Empty()) {
     return;
   }
 
-  auto cb = [&](auto*) {
-    EngineShard* shard = EngineShard::tlocal();
-    if (shard == nullptr)
-      return;
-
-    namespaces->GetDefaultNamespace().GetDbSlice(shard->shard_id()).FlushSlots(slots_ranges);
-  };
-  shard_set->pool()->AwaitFiberOnAll(std::move(cb));
+  trans->Execute(
+      [&slots_ranges](Transaction* t, EngineShard* shard) {
+        namespaces->GetDefaultNamespace().GetDbSlice(shard->shard_id()).FlushSlots(slots_ranges);
+        return OpStatus::OK;
+      },
+      true);
 
   auto* channel_store = ServerState::tlocal()->channel_store();
   auto deleted = SlotSet(slots_ranges);
@@ -570,7 +571,8 @@ void ClusterFamily::DflyClusterConfig(CmdArgList args, CommandContext* cmd_cntx)
     util::fb2::LockGuard gu(set_config_mu);
 
     outgoing_migrations = TakeOutOutgoingMigrations(new_config, ClusterConfig::Current());
-    RemoveIncomingMigrations(new_config->GetFinishedIncomingMigrations(ClusterConfig::Current()));
+    auto incoming_slots_to_flush = RemoveIncomingMigrations(
+        new_config->GetFinishedIncomingMigrations(ClusterConfig::Current()));
 
     SlotRanges enable_slots, disable_slots;
 
@@ -625,7 +627,8 @@ void ClusterFamily::DflyClusterConfig(CmdArgList args, CommandContext* cmd_cntx)
     if (ServerState::tlocal()->is_master) {
       auto deleted_slots = (before.GetRemovedSlots(after)).ToSlotRanges();
       deleted_slots.Merge(outgoing_migrations.slot_ranges);
-      DeleteSlots(deleted_slots);
+      deleted_slots.Merge(incoming_slots_to_flush);
+      DeleteSlots(cmd_cntx->tx(), deleted_slots);
       LOG_IF(INFO, !deleted_slots.Empty())
           << "Flushing newly unowned slots: " << deleted_slots.ToString();
       WriteFlushSlotsToJournal(deleted_slots);
@@ -737,7 +740,7 @@ void ClusterFamily::DflyClusterFlushSlots(CmdArgList args, CommandContext* cmd_c
     slot_ranges.emplace_back(SlotRange{slot_start, slot_end});
   } while (parser.HasNext());
 
-  DeleteSlots(SlotRanges(std::move(slot_ranges)));
+  DeleteSlots(cmd_cntx->tx(), SlotRanges(std::move(slot_ranges)));
 
   return cmd_cntx->SendOk();
 }
@@ -894,20 +897,21 @@ ClusterFamily::TakeOutOutgoingMigrations(shared_ptr<ClusterConfig> new_config,
 
 namespace {
 
-// returns removed incoming migration
-bool RemoveIncomingMigrationImpl(std::vector<std::shared_ptr<IncomingSlotMigration>>& jobs,
-                                 string_view source_id) {
+// Removes an incoming migration and returns non-owned slot ranges that need flushing.
+// Flushing is done by the caller together with other slot deletions.
+SlotRanges RemoveIncomingMigrationImpl(std::vector<std::shared_ptr<IncomingSlotMigration>>& jobs,
+                                       string_view source_id) {
   auto it = rng::find_if(jobs, [source_id](const auto& im) {
     // we can have only one migration per target-source pair
     return source_id == im->GetSourceID();
   });
   if (it == jobs.end()) {
-    return false;
+    return {};
   }
   DCHECK(it->get() != nullptr);
   std::shared_ptr<IncomingSlotMigration> migration = *it;
 
-  // Flush non-owned migrations
+  // Compute non-owned migration slots that need flushing.
   SlotSet migration_slots(migration->GetSlots());
   SlotSet removed = migration_slots.GetRemovedSlots(ClusterConfig::Current()->GetOwnedSlots());
 
@@ -915,25 +919,26 @@ bool RemoveIncomingMigrationImpl(std::vector<std::shared_ptr<IncomingSlotMigrati
   // all migration fibers has migration shared_ptr so the object can be removed later
   jobs.erase(it);
 
-  // TODO make it outside in one run with other slots that should be flushed
   if (!removed.Empty()) {
     auto removed_ranges = removed.ToSlotRanges();
     LOG_IF(WARNING, migration->GetState() == MigrationState::C_FINISHED)
         << "Flushing slots of removed FINISHED migration " << migration->GetSourceID()
         << ", slots: " << removed_ranges.ToString();
-    DeleteSlots(removed_ranges);
+    return removed_ranges;
   }
 
-  return true;
+  return {};
 }
 }  // namespace
 
-void ClusterFamily::RemoveIncomingMigrations(const std::vector<MigrationInfo>& migrations) {
+SlotRanges ClusterFamily::RemoveIncomingMigrations(const std::vector<MigrationInfo>& migrations) {
   util::fb2::LockGuard lk(migration_mu_);
+  SlotRanges removed_slots;
   for (const auto& m : migrations) {
-    RemoveIncomingMigrationImpl(incoming_migrations_jobs_, m.node_info.id);
+    removed_slots.Merge(RemoveIncomingMigrationImpl(incoming_migrations_jobs_, m.node_info.id));
     VLOG(1) << "Migration was canceled from: " << m.node_info.id;
   }
+  return removed_slots;
 }
 
 void ClusterFamily::InitMigration(CmdArgList args, CommandContext* cmd_cntx) {
@@ -977,7 +982,12 @@ void ClusterFamily::InitMigration(CmdArgList args, CommandContext* cmd_cntx) {
     auto slots = migration->GetSlots();
     LOG(INFO) << "Flushing slots during migration reinitialization " << migration->GetSourceID()
               << ", slots: " << slots.ToString();
-    DeleteSlots(slots);
+    // DFLYMIGRATE is not a global-trans command, so create a temporary transaction
+    // to hold the shard lock during FlushSlots (see #7153).
+    boost::intrusive_ptr<Transaction> flush_tx(
+        new Transaction{server_family_->service().FindCmd("DFLYCLUSTER")});
+    flush_tx->InitByArgs(&namespaces->GetDefaultNamespace(), 0, {});
+    DeleteSlots(flush_tx.get(), slots);
   }
 
   if (migration->GetState() == MigrationState::C_FATAL) {

--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -111,7 +111,8 @@ class ClusterFamily {
   [[nodiscard]] PreparedToRemoveOutgoingMigrations TakeOutOutgoingMigrations(
       std::shared_ptr<ClusterConfig> new_config, std::shared_ptr<ClusterConfig> old_config)
       ABSL_LOCKS_EXCLUDED(migration_mu_);
-  void RemoveIncomingMigrations(const std::vector<MigrationInfo>& migrations)
+  // Returns non-owned slot ranges from removed migrations for the caller to flush.
+  SlotRanges RemoveIncomingMigrations(const std::vector<MigrationInfo>& migrations)
       ABSL_LOCKS_EXCLUDED(migration_mu_);
 
   mutable util::fb2::Mutex migration_mu_;  // guard migrations operations

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -882,9 +882,11 @@ TEST_F(ClusterFamilyTest, FlushSlotsDoesNotDeleteEntriesInsertedAfterFlush) {
     EXPECT_EQ(db_slice.DbSize(0), 10u);
 
     // Step 1: FlushSlots creates a detached fiber. We do NOT yield, so the fiber
-    // cannot run yet.
+    // cannot run yet. Acquire the shard lock because RegisterOnChange requires it (#7153).
     cluster::SlotRanges ranges({{0, 16383}});
+    es->shard_lock()->Acquire(IntentLock::EXCLUSIVE);
     db_slice.FlushSlots(ranges);
+    es->shard_lock()->Release(IntentLock::EXCLUSIVE);
 
     // Step 2: Insert entries WITHOUT yielding — the flush fiber still has not executed.
     // Each insert calls NextVersion(), advancing the global counter.

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1333,7 +1333,7 @@ void DbSlice::ExpireAllIfNeeded() {
 }
 
 uint64_t DbSlice::RegisterOnChange(ChangeCallback cb) {
-  // DCHECK(!owner_->shard_lock()->IsFree());
+  DCHECK(!owner_->shard_lock()->IsFree());
   return change_cb_.emplace_back(NextVersion(), std::move(cb)).first;
 }
 

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -702,8 +702,11 @@ TEST_F(DflyEngineTest, Bug496) {
     auto& db = namespaces->GetDefaultNamespace().GetDbSlice(shard->shard_id());
 
     int cb_hits = 0;
+    // RegisterOnChange requires the shard lock to be held (see #7153).
+    shard->shard_lock()->Acquire(IntentLock::EXCLUSIVE);
     uint32_t cb_id =
         db.RegisterOnChange([&cb_hits](DbIndex, const DbSlice::ChangeReq&) { cb_hits++; });
+    shard->shard_lock()->Release(IntentLock::EXCLUSIVE);
 
     {
       auto res = *db.AddOrFind({}, "key-1", std::nullopt);


### PR DESCRIPTION
fixes: #7153

Summary: This PR fixes a race around cluster slot flushing by ensuring the shard lock is held when registering DB change callbacks.

Changes:

- Run slot flushes via a global Transaction so DbSlice::FlushSlots() executes while the shard lock is held.
- Refactor incoming-migration removal to return slot ranges to flush, and flush them together with other deleted-slot ranges under the transaction.
- Re-enable the DCHECK in DbSlice::RegisterOnChange() to enforce the shard-lock invariant.
- Update unit tests to explicitly acquire the shard lock when calling FlushSlots/RegisterOnChange directly.