### PR TITLE
feat(bloom): Implement LOADCHUNK cmd for SBF

### DIFF
--- a/src/core/bloom.cc
+++ b/src/core/bloom.cc
@@ -196,11 +196,11 @@ SBF& SBF::operator=(SBF&& src) noexcept {
   return *this;
 }
 
-void SBF::AddFilter(const std::string& blob, unsigned hash_cnt) {
+uint8_t* SBF::AllocateFilter(size_t alloc_size, unsigned hash_cnt) {
   PMR_NS::memory_resource* mr = filters_.get_allocator().resource();
-  uint8_t* ptr = (uint8_t*)mr->allocate(blob.size());
-  memcpy(ptr, blob.data(), blob.size());
-  filters_.emplace_back().Init(ptr, blob.size(), hash_cnt);
+  const auto ptr = static_cast<uint8_t*>(mr->allocate(alloc_size));
+  filters_.emplace_back().Init(ptr, alloc_size, hash_cnt);
+  return ptr;
 }
 
 bool SBF::Add(std::string_view str) {
@@ -387,51 +387,80 @@ void SBFDumpIterator::ResolveCursorToPos() {
 
 nonstd::expected<SBF*, SBFLoadResult> LoadSBFHeader(std::string_view header_data,
                                                     PMR_NS::memory_resource* mr) {
+  using enum SBFLoadResult;
+  using nonstd::make_unexpected;
+
   if (header_data.size() < kDumpHeaderSize)
-    return nonstd::make_unexpected(SBFLoadResult::kTruncatedInput);
+    return make_unexpected(kTruncatedInput);
+
+  if (header_data.size() > kDumpHeaderSize)
+    return make_unexpected(kBadInput);
 
   const char* ptr = header_data.data();
   if (const uint32_t version = absl::little_endian::Load32(ptr); version != kSbfDumpVersion)
-    return nonstd::make_unexpected(SBFLoadResult::kBadVersion);
+    return make_unexpected(kBadVersion);
 
   const double grow_factor = std::bit_cast<double>(absl::little_endian::Load64(ptr + 4));
+  if (!std::isfinite(grow_factor) || grow_factor < 1.0)
+    return make_unexpected(kBadInput);
+
   // Initialize everything to 0, later filters will overwrite these values
   return CompactObj::AllocateMR<SBF>(grow_factor, 0.0, 0UL, 0UL, 0UL, mr);
 }
 
 SBFLoadResult AddNewFilterToSBF(std::string_view data, SBF* sbf) {
+  using enum SBFLoadResult;
+
   if (data.size() < kDumpFilterMetaSize)
-    return SBFLoadResult::kTruncatedInput;
+    return kTruncatedInput;
 
   auto [hash_cnt, data_length, state] = SBFFilterMeta::Parse(data.data());
+  if (hash_cnt == 0)
+    return kBadInput;
+
+  if (hash_cnt > std::numeric_limits<uint8_t>::max())
+    return kBadInput;
+
+  if (data_length == 0 || !absl::has_single_bit(data_length))
+    return kBadInput;
+
+  // probability should be 0 to 1 (probably less than 1)
+  if (!std::isfinite(state.fp_prob) || state.fp_prob <= 0.0 || state.fp_prob >= 1.0)
+    return kBadInput;
+
+  if (state.max_capacity == 0 || state.current_size >= state.max_capacity)
+    return kBadInput;
+
   const size_t payload = data.size() - kDumpFilterMetaSize;
   if (payload > data_length)
-    return SBFLoadResult::kOutOfRange;
+    return kOutOfRange;
 
   sbf->ApplyStateUpdate(state);
 
   const uint32_t new_index = sbf->num_filters();
   // TODO validate variables against bloom invariants (power of two etc)
-  sbf->AddFilter(std::string(data_length, '\0'), hash_cnt);
+  auto* ptr = sbf->AllocateFilter(data_length, hash_cnt);
+  memset(ptr, 0, data_length);
 
   if (payload > 0)
     memcpy(sbf->filter_data(new_index), data.data() + kDumpFilterMetaSize, payload);
 
-  return SBFLoadResult::kOk;
+  return kOk;
 }
 
 SBFLoadResult LoadSBFChunk(int64_t cursor, std::string_view data, SBF* sbf) {
   DCHECK_NE(sbf, nullptr) << "Input ptr must be valid SBF";
 
-  // TODO on implementing LOADCHUNK there should be closer validation of the data fed into the SBF.
-  // This current implementation is mostly a test helper and proof that the SCANDUMP algorithm is
-  // actually loadable.
+  const int64_t write_pos = cursor - static_cast<int64_t>(data.size());
+  if (write_pos < 1)
+    return SBFLoadResult::kOutOfRange;
 
-  size_t global_offset = cursor - static_cast<int64_t>(data.size()) - 1;
-
+  size_t global_offset = write_pos - 1;
   for (uint32_t i = 0; i < sbf->num_filters(); ++i) {
     const size_t filter_span = kDumpFilterMetaSize + sbf->data(i).size();
     if (global_offset < filter_span) {
+      // we should never have a write position inside the header. The header is always fully
+      // written.
       if (global_offset < kDumpFilterMetaSize)
         return SBFLoadResult::kOutOfRange;
 
@@ -448,7 +477,24 @@ SBFLoadResult LoadSBFChunk(int64_t cursor, std::string_view data, SBF* sbf) {
   if (global_offset != 0)
     return SBFLoadResult::kOutOfRange;
 
+  // global offset is 0, ie ended exactly at the end of the filter. data goes into a new filter.
   return AddNewFilterToSBF(data, sbf);
+}
+
+const char* ToString(SBFLoadResult res) {
+  switch (res) {
+    case SBFLoadResult::kOk:
+      return "ok";
+    case SBFLoadResult::kBadInput:
+      return "bad_input";
+    case SBFLoadResult::kOutOfRange:
+      return "out_of_range";
+    case SBFLoadResult::kTruncatedInput:
+      return "truncated_input";
+    case SBFLoadResult::kBadVersion:
+      return "bad_version";
+  }
+  return "unknown";
 }
 
 }  // namespace dfly

--- a/src/core/bloom.cc
+++ b/src/core/bloom.cc
@@ -196,11 +196,11 @@ SBF& SBF::operator=(SBF&& src) noexcept {
   return *this;
 }
 
-void SBF::AddFilter(const std::string& blob, unsigned hash_cnt) {
+uint8_t* SBF::AllocateFilter(size_t alloc_size, unsigned hash_cnt) {
   PMR_NS::memory_resource* mr = filters_.get_allocator().resource();
-  uint8_t* ptr = (uint8_t*)mr->allocate(blob.size());
-  memcpy(ptr, blob.data(), blob.size());
-  filters_.emplace_back().Init(ptr, blob.size(), hash_cnt);
+  const auto ptr = static_cast<uint8_t*>(mr->allocate(alloc_size));
+  filters_.emplace_back().Init(ptr, alloc_size, hash_cnt);
+  return ptr;
 }
 
 bool SBF::Add(std::string_view str) {
@@ -387,51 +387,79 @@ void SBFDumpIterator::ResolveCursorToPos() {
 
 nonstd::expected<SBF*, SBFLoadResult> LoadSBFHeader(std::string_view header_data,
                                                     PMR_NS::memory_resource* mr) {
+  using enum SBFLoadResult;
+  using nonstd::make_unexpected;
+
   if (header_data.size() < kDumpHeaderSize)
-    return nonstd::make_unexpected(SBFLoadResult::kTruncatedInput);
+    return make_unexpected(kTruncatedInput);
+
+  if (header_data.size() > kDumpHeaderSize)
+    return make_unexpected(kBadInput);
 
   const char* ptr = header_data.data();
   if (const uint32_t version = absl::little_endian::Load32(ptr); version != kSbfDumpVersion)
-    return nonstd::make_unexpected(SBFLoadResult::kBadVersion);
+    return make_unexpected(kBadVersion);
 
   const double grow_factor = std::bit_cast<double>(absl::little_endian::Load64(ptr + 4));
+  if (!std::isfinite(grow_factor) || grow_factor < 1.0)
+    return make_unexpected(kBadInput);
+
   // Initialize everything to 0, later filters will overwrite these values
   return CompactObj::AllocateMR<SBF>(grow_factor, 0.0, 0UL, 0UL, 0UL, mr);
 }
 
 SBFLoadResult AddNewFilterToSBF(std::string_view data, SBF* sbf) {
+  using enum SBFLoadResult;
+
   if (data.size() < kDumpFilterMetaSize)
-    return SBFLoadResult::kTruncatedInput;
+    return kTruncatedInput;
 
   auto [hash_cnt, data_length, state] = SBFFilterMeta::Parse(data.data());
+  if (hash_cnt == 0)
+    return kBadInput;
+
+  if (hash_cnt > std::numeric_limits<uint8_t>::max())
+    return kBadInput;
+
+  if (data_length == 0 || !absl::has_single_bit(data_length))
+    return kBadInput;
+
+  // probability should be 0 to 1 (probably less than 1)
+  if (!std::isfinite(state.fp_prob) || state.fp_prob <= 0.0 || state.fp_prob >= 1.0)
+    return kBadInput;
+
+  if (state.max_capacity == 0 || state.current_size >= state.max_capacity)
+    return kBadInput;
+
   const size_t payload = data.size() - kDumpFilterMetaSize;
   if (payload > data_length)
-    return SBFLoadResult::kOutOfRange;
+    return kOutOfRange;
 
   sbf->ApplyStateUpdate(state);
 
   const uint32_t new_index = sbf->num_filters();
-  // TODO validate variables against bloom invariants (power of two etc)
-  sbf->AddFilter(std::string(data_length, '\0'), hash_cnt);
+  auto* ptr = sbf->AllocateFilter(data_length, hash_cnt);
+  memset(ptr, 0, data_length);
 
   if (payload > 0)
     memcpy(sbf->filter_data(new_index), data.data() + kDumpFilterMetaSize, payload);
 
-  return SBFLoadResult::kOk;
+  return kOk;
 }
 
 SBFLoadResult LoadSBFChunk(int64_t cursor, std::string_view data, SBF* sbf) {
   DCHECK_NE(sbf, nullptr) << "Input ptr must be valid SBF";
 
-  // TODO on implementing LOADCHUNK there should be closer validation of the data fed into the SBF.
-  // This current implementation is mostly a test helper and proof that the SCANDUMP algorithm is
-  // actually loadable.
+  const int64_t write_pos = cursor - static_cast<int64_t>(data.size());
+  if (write_pos < 1)
+    return SBFLoadResult::kOutOfRange;
 
-  size_t global_offset = cursor - static_cast<int64_t>(data.size()) - 1;
-
+  size_t global_offset = write_pos - 1;
   for (uint32_t i = 0; i < sbf->num_filters(); ++i) {
     const size_t filter_span = kDumpFilterMetaSize + sbf->data(i).size();
     if (global_offset < filter_span) {
+      // we should never have a write position inside the header. The header is always fully
+      // written.
       if (global_offset < kDumpFilterMetaSize)
         return SBFLoadResult::kOutOfRange;
 
@@ -448,7 +476,24 @@ SBFLoadResult LoadSBFChunk(int64_t cursor, std::string_view data, SBF* sbf) {
   if (global_offset != 0)
     return SBFLoadResult::kOutOfRange;
 
+  // global offset is 0, ie ended exactly at the end of the filter. data goes into a new filter.
   return AddNewFilterToSBF(data, sbf);
+}
+
+const char* ToString(SBFLoadResult res) {
+  switch (res) {
+    case SBFLoadResult::kOk:
+      return "ok";
+    case SBFLoadResult::kBadInput:
+      return "bad_input";
+    case SBFLoadResult::kOutOfRange:
+      return "out_of_range";
+    case SBFLoadResult::kTruncatedInput:
+      return "truncated_input";
+    case SBFLoadResult::kBadVersion:
+      return "bad_version";
+  }
+  return "unknown";
 }
 
 }  // namespace dfly

--- a/src/core/bloom.h
+++ b/src/core/bloom.h
@@ -22,6 +22,8 @@ enum class SBFLoadResult : uint8_t {
   kOutOfRange,
 };
 
+const char* ToString(SBFLoadResult res);
+
 /// Bloom filter based on the design of https://github.com/jvirkki/libbloom
 class Bloom {
  public:
@@ -102,14 +104,14 @@ class SBF {
   SBF(const SBF&) = delete;
 
   // C'tor used for loading persisted filters into SBF.
-  // Should be followed by AddFilter.
+  // Should be followed by AllocateFilter.
   SBF(double grow_factor, double fp_prob, size_t max_capacity, size_t prev_size,
       size_t current_size, PMR_NS::memory_resource* mr);
   ~SBF();
 
   SBF& operator=(SBF&& src) noexcept;
 
-  void AddFilter(const std::string& blob, unsigned hash_cnt);
+  uint8_t* AllocateFilter(size_t alloc_size, unsigned hash_cnt);
 
   bool Add(std::string_view str);
   bool Exists(std::string_view str) const;
@@ -190,6 +192,34 @@ struct SBFChunk {
 // maximum of 16MiB in size. The first chunk sent back contains only the SBF metadata. Following
 // chunks contain filter data and a state of the SBF. The loader uses per filter data to update the
 // SBF as it encounters new filter items.
+
+/*
+SCANDUMP wire output format (all fields little-endian)
+
+  cursor=1 returns the SBF header (12 bytes):
+  +-------------------+--------------------+
+  | version (4B)      | grow_factor (8B)   |
+  +-------------------+--------------------+
+
+  cursor>1 chunks carry filter data. Each filter begins with
+  44 bytes of metadata, followed by the raw filter bytes.
+  A single filter may span multiple chunks.
+
+  First chunk of a filter:
+  +-----------------+----------------+------------+---------------------+
+  | hash_cnt 4B     | data_length 8B | fp_prob 8B | max_capacity 8B     |
+  +-----------------+----------------+------------+---------------------+
+  | current_size 8B | prev_size 8B   | filter bytes (up to 16MiB - 44B) |
+  +-----------------+----------------+------------ ... -----------------+
+
+  Continuation chunks (same filter, if >16MiB):
+  +------------------------ ... -------------------------+
+  | filter bytes (up to 16MiB)                           |
+  +------------------------ ... -------------------------+
+
+  cursor=0 signals end of iteration (empty data).
+*/
+
 class SBFDumpIterator {
  public:
   static constexpr uint64_t kMaxChunkSize = 16 * 1024 * 1024;
@@ -203,10 +233,6 @@ class SBFDumpIterator {
   SBFChunk Next();
 
  private:
-  // Sends the SBF wide header (little endian):
-  // +-------------------+-------------------+
-  // | version (4 bytes) | grow_factor (8B)  |
-  // +-------------------+-------------------+
   std::string SerializeHeader() const;
 
   // Converts a cursor to the specific filter and the offset inside it

--- a/src/core/bloom.h
+++ b/src/core/bloom.h
@@ -256,4 +256,8 @@ nonstd::expected<SBF*, SBFLoadResult> LoadSBFHeader(std::string_view header_data
 // returned by SBFDumpIterator for chunks with cursor > 1.
 SBFLoadResult LoadSBFChunk(int64_t cursor, std::string_view data, SBF* sbf);
 
+inline bool IsBeingLoaded(const SBF* sbf) {
+  return sbf->num_filters() == 0;
+}
+
 }  // namespace dfly

--- a/src/facade/error.h
+++ b/src/facade/error.h
@@ -52,4 +52,6 @@ inline constexpr char kRestrictDenied[] = "restrict_denied";
 inline constexpr char kNoGroupErrType[] = "no_group_error";
 inline constexpr char kNoAuthErrType[] = "no_auth";
 
+inline constexpr char kBloomFilterLoadInProgress[] = "bloom filter load in progress";
+
 }  // namespace facade

--- a/src/facade/op_status.cc
+++ b/src/facade/op_status.cc
@@ -44,6 +44,8 @@ std::string_view StatusToMsg(OpStatus status) {
       return kNanOrInfDuringIncr;
     case OpStatus::IO_ERROR:
       return kTieredIoError;
+    case OpStatus::BLOOM_FILTER_LOAD_IN_PROGRESS:
+      return kBloomFilterLoadInProgress;
     default:
       LOG(ERROR) << "Unsupported status " << status;
       return "Internal error";

--- a/src/facade/op_status.h
+++ b/src/facade/op_status.h
@@ -35,6 +35,7 @@ enum class OpStatus : uint16_t {
   INVALID_JSON,
   IO_ERROR,
   NAN_OR_INF_DURING_INCR,
+  BLOOM_FILTER_LOAD_IN_PROGRESS,
 };
 
 class OpResultBase {

--- a/src/server/bloom_family.cc
+++ b/src/server/bloom_family.cc
@@ -12,6 +12,7 @@
 #include "server/db_slice.h"
 #include "server/engine_shard_set.h"
 #include "server/error.h"
+#include "server/family_utils.h"
 #include "server/transaction.h"
 
 namespace dfly {
@@ -202,6 +203,76 @@ void CmdScanDump(CmdArgList args, CommandContext* cmd_cntx) {
   rb->SendBulkString(res->data);
 }
 
+void CmdLoadChunk(CmdArgList args, CommandContext* cmd_cntx) {
+  CmdArgParser parser(args);
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+  const std::string_view key = parser.Next();
+
+  const int64_t cursor = parser.Next<int64_t>();
+  if (const auto err = parser.TakeError(); err)
+    return rb->SendError(err.MakeReply());
+
+  if (cursor <= 0)
+    return rb->SendError(kInvalidIntErr);
+
+  const std::string_view blob = parser.Next();
+
+  const auto cb = [&](Transaction* t, EngineShard* shard) -> OpStatus {
+    auto op_args = t->GetOpArgs(shard);
+    auto& db_slice = op_args.GetDbSlice();
+
+    if (cursor == 1) {
+      auto load_result = LoadSBFHeader(blob, CompactObj::memory_resource());
+      if (!load_result.has_value()) {
+        LOG_EVERY_T(WARNING, 10) << "BF.LOADCHUNK invalid header"
+                                 << " key=" << key << " cursor=" << cursor
+                                 << " blob_size=" << blob.size()
+                                 << " load_res=" << ToString(load_result.error());
+        return OpStatus::INVALID_VALUE;
+      }
+
+      // type set to nullopt to find any type key and overwrite it, not just SBF
+      auto op_res = db_slice.AddOrFind(op_args.db_cntx, key, std::nullopt);
+      if (!op_res) {
+        CompactObj::DeleteMR<SBF>(load_result.value());
+        return op_res.status();
+      }
+
+      // LOADCHUNK overwrites existing key
+      if (!op_res->is_new) {
+        // existing key might not necessarily be SBF, it could be HASH/JSON, and indexed
+        RemoveKeyFromIndexesIfNeeded(key, op_args.db_cntx, op_res->it->second, op_args.shard);
+        db_slice.RemoveExpire(op_args.db_cntx.db_index, op_res->it);
+      }
+
+      op_res->it->second.SetSBF(load_result.value());
+      return OpStatus::OK;
+    }
+
+    auto op_res = db_slice.FindMutable(op_args.db_cntx, key, OBJ_SBF);
+    if (!op_res)
+      return op_res.status();
+
+    SBF* sbf = op_res->it->second.GetSBF();
+    if (auto load_res = LoadSBFChunk(cursor, blob, sbf); load_res != SBFLoadResult::kOk) {
+      LOG_EVERY_T(WARNING, 10) << "BF.LOADCHUNK invalid chunk"
+                               << " key=" << key << " cursor=" << cursor
+                               << " blob_size=" << blob.size()
+                               << " load_res=" << ToString(load_res);
+      return OpStatus::OUT_OF_RANGE;
+    }
+
+    return OpStatus::OK;
+  };
+
+  const OpStatus res = cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));
+  if (res == OpStatus::OK)
+    return rb->SendOk();
+  if (res == OpStatus::INVALID_VALUE)
+    return rb->SendError("INVALIDOBJ invalid bloom dump payload");
+  return rb->SendError(res);
+}
+
 void CmdMExists(CmdArgList args, CommandContext* cmd_cntx) {
   string_view key = ArgS(args, 0);
   args.remove_prefix(1);
@@ -228,14 +299,15 @@ using CI = CommandId;
 void RegisterBloomFamily(CommandRegistry* registry) {
   registry->StartFamily();
 
-  *registry << CI{"BF.RESERVE", CO::JOURNALED | CO::DENYOOM | CO::FAST, -4, 1, 1, acl::BLOOM}.HFUNC(
-                   Reserve)
-            << CI{"BF.ADD", CO::JOURNALED | CO::DENYOOM | CO::FAST, 3, 1, 1, acl::BLOOM}.HFUNC(Add)
-            << CI{"BF.MADD", CO::JOURNALED | CO::DENYOOM | CO::FAST, -3, 1, 1, acl::BLOOM}.HFUNC(
-                   MAdd)
-            << CI{"BF.EXISTS", CO::READONLY | CO::FAST, 3, 1, 1, acl::BLOOM}.HFUNC(Exists)
-            << CI{"BF.MEXISTS", CO::READONLY | CO::FAST, -3, 1, 1, acl::BLOOM}.HFUNC(MExists)
-            << CI{"BF.SCANDUMP", CO::READONLY, 3, 1, 1, acl::BLOOM}.HFUNC(ScanDump);
+  *registry
+      << CI{"BF.RESERVE", CO::JOURNALED | CO::DENYOOM | CO::FAST, -4, 1, 1, acl::BLOOM}.HFUNC(
+             Reserve)
+      << CI{"BF.ADD", CO::JOURNALED | CO::DENYOOM | CO::FAST, 3, 1, 1, acl::BLOOM}.HFUNC(Add)
+      << CI{"BF.MADD", CO::JOURNALED | CO::DENYOOM | CO::FAST, -3, 1, 1, acl::BLOOM}.HFUNC(MAdd)
+      << CI{"BF.EXISTS", CO::READONLY | CO::FAST, 3, 1, 1, acl::BLOOM}.HFUNC(Exists)
+      << CI{"BF.MEXISTS", CO::READONLY | CO::FAST, -3, 1, 1, acl::BLOOM}.HFUNC(MExists)
+      << CI{"BF.SCANDUMP", CO::READONLY, 3, 1, 1, acl::BLOOM}.HFUNC(ScanDump)
+      << CI{"BF.LOADCHUNK", CO::JOURNALED | CO::DENYOOM, 4, 1, 1, acl::BLOOM}.HFUNC(LoadChunk);
 };
 
 }  // namespace dfly

--- a/src/server/bloom_family.cc
+++ b/src/server/bloom_family.cc
@@ -37,6 +37,10 @@ struct SbfParams {
 using AddResult = absl::InlinedVector<OpResult<bool>, 4>;
 using ExistsResult = absl::InlinedVector<bool, 4>;
 
+bool IsBeingLoaded(const SBF* sbf) {
+  return sbf->num_filters() == 0;
+}
+
 OpStatus OpReserve(const SbfParams& params, const OpArgs& op_args, string_view key) {
   auto& db_slice = op_args.GetDbSlice();
   auto op_res = db_slice.AddOrFind(op_args.db_cntx, key, OBJ_SBF);
@@ -65,6 +69,9 @@ OpResult<AddResult> OpAdd(const OpArgs& op_args, string_view key, CmdArgList ite
   }
 
   SBF* sbf = pv.GetSBF();
+  if (IsBeingLoaded(sbf))
+    return OpStatus::INVALID_VALUE;
+
   AddResult result(items.size());
   for (size_t i = 0; i < items.size(); ++i) {
     result[i] = sbf->Add(ToSV(items[i]));
@@ -80,6 +87,9 @@ OpResult<ExistsResult> OpExists(const OpArgs& op_args, string_view key, CmdArgLi
   auto it = (*op_res);
 
   const SBF* sbf = it->second.GetSBF();
+  if (IsBeingLoaded(sbf))
+    return OpStatus::INVALID_VALUE;
+
   ExistsResult result(items.size());
 
   for (size_t i = 0; i < items.size(); ++i) {
@@ -130,6 +140,9 @@ void CmdAdd(CmdArgList args, CommandContext* cmd_cntx) {
       status = res->front().status();
   }
 
+  if (status == OpStatus::INVALID_VALUE)
+    return cmd_cntx->SendError("ERR bloom filter load is incomplete");
+
   return cmd_cntx->SendError(status);
 }
 
@@ -141,6 +154,10 @@ void CmdExists(CmdArgList args, CommandContext* cmd_cntx) {
   };
 
   OpResult res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
+
+  if (!res && res.status() == OpStatus::INVALID_VALUE)
+    return cmd_cntx->SendError("ERR bloom filter load is incomplete");
+
   return cmd_cntx->SendLong(res ? res->front() : 0);
 }
 
@@ -155,6 +172,8 @@ void CmdMAdd(CmdArgList args, CommandContext* cmd_cntx) {
   RedisReplyBuilder* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   OpResult res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
   if (!res) {
+    if (res.status() == OpStatus::INVALID_VALUE)
+      return rb->SendError("ERR bloom filter load is incomplete");
     return rb->SendError(res.status());
   }
   const AddResult& add_res = *res;
@@ -187,12 +206,17 @@ void CmdScanDump(CmdArgList args, CommandContext* cmd_cntx) {
       return op_res.status();
 
     const SBF* sbf = op_res.value()->second.GetSBF();
+    if (IsBeingLoaded(sbf))
+      return OpStatus::INVALID_VALUE;
+
     SBFDumpIterator it(*sbf, cursor);
     return it.Next();
   };
 
   OpResult<SBFChunk> res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
   if (!res) {
+    if (res.status() == OpStatus::INVALID_VALUE)
+      return rb->SendError("ERR bloom filter load is incomplete");
     return rb->SendError(res.status());
   }
 
@@ -282,8 +306,11 @@ void CmdMExists(CmdArgList args, CommandContext* cmd_cntx) {
   };
 
   OpResult res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
-
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+
+  if (!res && res.status() == OpStatus::INVALID_VALUE)
+    return rb->SendError("ERR bloom filter load is incomplete");
+
   RedisReplyBuilder::ArrayScope scope{rb, args.size()};
   for (size_t i = 0; i < args.size(); ++i) {
     rb->SendLong(res ? res->at(i) : 0);

--- a/src/server/bloom_family.cc
+++ b/src/server/bloom_family.cc
@@ -202,6 +202,66 @@ void CmdScanDump(CmdArgList args, CommandContext* cmd_cntx) {
   rb->SendBulkString(res->data);
 }
 
+void CmdLoadChunk(CmdArgList args, CommandContext* cmd_cntx) {
+  CmdArgParser parser(args);
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+  const std::string_view key = parser.Next();
+
+  const int64_t cursor = parser.Next<int64_t>();
+  if (const auto err = parser.TakeError(); err)
+    return rb->SendError(err.MakeReply());
+
+  if (cursor <= 0)
+    return rb->SendError(kInvalidIntErr);
+
+  const std::string_view blob = parser.Next();
+
+  const auto cb = [&](Transaction* t, EngineShard* shard) -> OpStatus {
+    auto op_args = t->GetOpArgs(shard);
+    auto& db_slice = op_args.GetDbSlice();
+
+    if (cursor == 1) {
+      auto load_result = LoadSBFHeader(blob, CompactObj::memory_resource());
+      if (!load_result.has_value()) {
+        LOG_EVERY_T(WARNING, 10) << "BF.LOADCHUNK invalid header"
+                                 << " key=" << key << " cursor=" << cursor
+                                 << " blob_size=" << blob.size()
+                                 << " load_res=" << ToString(load_result.error());
+        return OpStatus::INVALID_VALUE;
+      }
+
+      auto op_res = db_slice.AddOrFind(op_args.db_cntx, key, OBJ_SBF);
+      if (!op_res)
+        return op_res.status();
+
+      op_res->it->second.SetSBF(load_result.value());
+      return OpStatus::OK;
+    }
+
+    auto op_res = db_slice.FindMutable(op_args.db_cntx, key, OBJ_SBF);
+    if (!op_res)
+      return op_res.status();
+
+    SBF* sbf = op_res->it->second.GetSBF();
+    if (auto load_res = LoadSBFChunk(cursor, blob, sbf); load_res != SBFLoadResult::kOk) {
+      LOG_EVERY_T(WARNING, 10) << "BF.LOADCHUNK invalid chunk"
+                               << " key=" << key << " cursor=" << cursor
+                               << " blob_size=" << blob.size()
+                               << " load_res=" << ToString(load_res);
+      return OpStatus::OUT_OF_RANGE;
+    }
+
+    return OpStatus::OK;
+  };
+
+  const OpStatus res = cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));
+  if (res == OpStatus::OK)
+    return rb->SendOk();
+  if (res == OpStatus::INVALID_VALUE)
+    return rb->SendError("INVALIDOBJ invalid bloom dump payload");
+  return rb->SendError(res);
+}
+
 void CmdMExists(CmdArgList args, CommandContext* cmd_cntx) {
   string_view key = ArgS(args, 0);
   args.remove_prefix(1);
@@ -228,14 +288,15 @@ using CI = CommandId;
 void RegisterBloomFamily(CommandRegistry* registry) {
   registry->StartFamily();
 
-  *registry << CI{"BF.RESERVE", CO::JOURNALED | CO::DENYOOM | CO::FAST, -4, 1, 1, acl::BLOOM}.HFUNC(
-                   Reserve)
-            << CI{"BF.ADD", CO::JOURNALED | CO::DENYOOM | CO::FAST, 3, 1, 1, acl::BLOOM}.HFUNC(Add)
-            << CI{"BF.MADD", CO::JOURNALED | CO::DENYOOM | CO::FAST, -3, 1, 1, acl::BLOOM}.HFUNC(
-                   MAdd)
-            << CI{"BF.EXISTS", CO::READONLY | CO::FAST, 3, 1, 1, acl::BLOOM}.HFUNC(Exists)
-            << CI{"BF.MEXISTS", CO::READONLY | CO::FAST, -3, 1, 1, acl::BLOOM}.HFUNC(MExists)
-            << CI{"BF.SCANDUMP", CO::READONLY, 3, 1, 1, acl::BLOOM}.HFUNC(ScanDump);
+  *registry
+      << CI{"BF.RESERVE", CO::JOURNALED | CO::DENYOOM | CO::FAST, -4, 1, 1, acl::BLOOM}.HFUNC(
+             Reserve)
+      << CI{"BF.ADD", CO::JOURNALED | CO::DENYOOM | CO::FAST, 3, 1, 1, acl::BLOOM}.HFUNC(Add)
+      << CI{"BF.MADD", CO::JOURNALED | CO::DENYOOM | CO::FAST, -3, 1, 1, acl::BLOOM}.HFUNC(MAdd)
+      << CI{"BF.EXISTS", CO::READONLY | CO::FAST, 3, 1, 1, acl::BLOOM}.HFUNC(Exists)
+      << CI{"BF.MEXISTS", CO::READONLY | CO::FAST, -3, 1, 1, acl::BLOOM}.HFUNC(MExists)
+      << CI{"BF.SCANDUMP", CO::READONLY, 3, 1, 1, acl::BLOOM}.HFUNC(ScanDump)
+      << CI{"BF.LOADCHUNK", CO::JOURNALED | CO::DENYOOM, 4, 1, 1, acl::BLOOM}.HFUNC(LoadChunk);
 };
 
 }  // namespace dfly

--- a/src/server/bloom_family.cc
+++ b/src/server/bloom_family.cc
@@ -64,6 +64,9 @@ OpResult<AddResult> OpAdd(const OpArgs& op_args, string_view key, CmdArgList ite
   }
 
   SBF* sbf = pv.GetSBF();
+  if (IsBeingLoaded(sbf))
+    return OpStatus::INVALID_VALUE;
+
   AddResult result(items.size());
   for (size_t i = 0; i < items.size(); ++i) {
     result[i] = sbf->Add(ToSV(items[i]));
@@ -79,6 +82,9 @@ OpResult<ExistsResult> OpExists(const OpArgs& op_args, string_view key, CmdArgLi
   auto it = (*op_res);
 
   const SBF* sbf = it->second.GetSBF();
+  if (IsBeingLoaded(sbf))
+    return OpStatus::INVALID_VALUE;
+
   ExistsResult result(items.size());
 
   for (size_t i = 0; i < items.size(); ++i) {
@@ -129,6 +135,9 @@ void CmdAdd(CmdArgList args, CommandContext* cmd_cntx) {
       status = res->front().status();
   }
 
+  if (status == OpStatus::INVALID_VALUE)
+    return cmd_cntx->SendError("ERR bloom filter load is incomplete");
+
   return cmd_cntx->SendError(status);
 }
 
@@ -140,6 +149,10 @@ void CmdExists(CmdArgList args, CommandContext* cmd_cntx) {
   };
 
   OpResult res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
+
+  if (!res && res.status() == OpStatus::INVALID_VALUE)
+    return cmd_cntx->SendError("ERR bloom filter load is incomplete");
+
   return cmd_cntx->SendLong(res ? res->front() : 0);
 }
 
@@ -154,6 +167,8 @@ void CmdMAdd(CmdArgList args, CommandContext* cmd_cntx) {
   RedisReplyBuilder* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   OpResult res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
   if (!res) {
+    if (res.status() == OpStatus::INVALID_VALUE)
+      return rb->SendError("ERR bloom filter load is incomplete");
     return rb->SendError(res.status());
   }
   const AddResult& add_res = *res;
@@ -186,12 +201,17 @@ void CmdScanDump(CmdArgList args, CommandContext* cmd_cntx) {
       return op_res.status();
 
     const SBF* sbf = op_res.value()->second.GetSBF();
+    if (IsBeingLoaded(sbf))
+      return OpStatus::INVALID_VALUE;
+
     SBFDumpIterator it(*sbf, cursor);
     return it.Next();
   };
 
   OpResult<SBFChunk> res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
   if (!res) {
+    if (res.status() == OpStatus::INVALID_VALUE)
+      return rb->SendError("ERR bloom filter load is incomplete");
     return rb->SendError(res.status());
   }
 
@@ -271,8 +291,11 @@ void CmdMExists(CmdArgList args, CommandContext* cmd_cntx) {
   };
 
   OpResult res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
-
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+
+  if (!res && res.status() == OpStatus::INVALID_VALUE)
+    return rb->SendError("ERR bloom filter load is incomplete");
+
   RedisReplyBuilder::ArrayScope scope{rb, args.size()};
   for (size_t i = 0; i < args.size(); ++i) {
     rb->SendLong(res ? res->at(i) : 0);

--- a/src/server/bloom_family.cc
+++ b/src/server/bloom_family.cc
@@ -70,7 +70,7 @@ OpResult<AddResult> OpAdd(const OpArgs& op_args, string_view key, CmdArgList ite
 
   SBF* sbf = pv.GetSBF();
   if (IsBeingLoaded(sbf))
-    return OpStatus::INVALID_VALUE;
+    return OpStatus::BLOOM_FILTER_LOAD_IN_PROGRESS;
 
   AddResult result(items.size());
   for (size_t i = 0; i < items.size(); ++i) {
@@ -88,7 +88,7 @@ OpResult<ExistsResult> OpExists(const OpArgs& op_args, string_view key, CmdArgLi
 
   const SBF* sbf = it->second.GetSBF();
   if (IsBeingLoaded(sbf))
-    return OpStatus::INVALID_VALUE;
+    return OpStatus::BLOOM_FILTER_LOAD_IN_PROGRESS;
 
   ExistsResult result(items.size());
 
@@ -188,9 +188,6 @@ void CmdAdd(CmdArgList args, CommandContext* cmd_cntx) {
       status = res->front().status();
   }
 
-  if (status == OpStatus::INVALID_VALUE)
-    return cmd_cntx->SendError("ERR bloom filter load is incomplete");
-
   return cmd_cntx->SendError(status);
 }
 
@@ -203,8 +200,8 @@ void CmdExists(CmdArgList args, CommandContext* cmd_cntx) {
 
   OpResult res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
 
-  if (!res && res.status() == OpStatus::INVALID_VALUE)
-    return cmd_cntx->SendError("ERR bloom filter load is incomplete");
+  if (!res && res.status() == OpStatus::BLOOM_FILTER_LOAD_IN_PROGRESS)
+    return cmd_cntx->SendError(res.status());
 
   return cmd_cntx->SendLong(res ? res->front() : 0);
 }
@@ -219,11 +216,8 @@ void CmdMAdd(CmdArgList args, CommandContext* cmd_cntx) {
 
   RedisReplyBuilder* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   OpResult res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
-  if (!res) {
-    if (res.status() == OpStatus::INVALID_VALUE)
-      return rb->SendError("ERR bloom filter load is incomplete");
+  if (!res)
     return rb->SendError(res.status());
-  }
   const AddResult& add_res = *res;
 
   RedisReplyBuilder::ArrayScope scope{rb, add_res.size()};
@@ -255,18 +249,15 @@ void CmdScanDump(CmdArgList args, CommandContext* cmd_cntx) {
 
     const SBF* sbf = op_res.value()->second.GetSBF();
     if (IsBeingLoaded(sbf))
-      return OpStatus::INVALID_VALUE;
+      return OpStatus::BLOOM_FILTER_LOAD_IN_PROGRESS;
 
     SBFDumpIterator it(*sbf, cursor);
     return it.Next();
   };
 
   OpResult<SBFChunk> res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
-  if (!res) {
-    if (res.status() == OpStatus::INVALID_VALUE)
-      return rb->SendError("ERR bloom filter load is incomplete");
+  if (!res)
     return rb->SendError(res.status());
-  }
 
   RedisReplyBuilder::ArrayScope scope{rb, 2};
   rb->SendLong(res->cursor);
@@ -312,8 +303,8 @@ void CmdMExists(CmdArgList args, CommandContext* cmd_cntx) {
   OpResult res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
-  if (!res && res.status() == OpStatus::INVALID_VALUE)
-    return rb->SendError("ERR bloom filter load is incomplete");
+  if (!res && res.status() == OpStatus::BLOOM_FILTER_LOAD_IN_PROGRESS)
+    return rb->SendError(res.status());
 
   RedisReplyBuilder::ArrayScope scope{rb, args.size()};
   for (size_t i = 0; i < args.size(); ++i) {

--- a/src/server/bloom_family.cc
+++ b/src/server/bloom_family.cc
@@ -99,6 +99,54 @@ OpResult<ExistsResult> OpExists(const OpArgs& op_args, string_view key, CmdArgLi
   return result;
 }
 
+OpStatus OpLoadChunk(const OpArgs& op_args, std::string_view blob, std::string_view key,
+                     int64_t cursor) {
+  auto& db_slice = op_args.GetDbSlice();
+
+  if (cursor == 1) {  // Init phase
+    auto load_result = LoadSBFHeader(blob, CompactObj::memory_resource());
+    if (!load_result.has_value()) {
+      LOG_EVERY_T(WARNING, 10) << "BF.LOADCHUNK invalid header"
+                               << " key=" << key << " cursor=" << cursor
+                               << " blob_size=" << blob.size()
+                               << " load_res=" << ToString(load_result.error());
+      return OpStatus::INVALID_VALUE;
+    }
+
+    // type set to nullopt to find any type key and overwrite it, not just SBF
+    auto op_res = db_slice.AddOrFind(op_args.db_cntx, key, std::nullopt);
+    if (!op_res) {
+      CompactObj::DeleteMR<SBF>(load_result.value());
+      return op_res.status();
+    }
+
+    // LOADCHUNK overwrites existing key
+    if (!op_res->is_new) {
+      // existing key might not necessarily be SBF, it could be HASH/JSON, and indexed
+      RemoveKeyFromIndexesIfNeeded(key, op_args.db_cntx, op_res->it->second, op_args.shard);
+      db_slice.RemoveExpire(op_args.db_cntx.db_index, op_res->it);
+    }
+
+    op_res->it->second.SetSBF(load_result.value());
+    return OpStatus::OK;
+  }  // cursor == 1 (Init phase)
+
+  // Continue loading chunks into not-yet-fully-loaded filter.
+  auto op_res = db_slice.FindMutable(op_args.db_cntx, key, OBJ_SBF);
+  if (!op_res)
+    return op_res.status();
+
+  SBF* sbf = op_res->it->second.GetSBF();
+  if (auto load_res = LoadSBFChunk(cursor, blob, sbf); load_res != SBFLoadResult::kOk) {
+    LOG_EVERY_T(WARNING, 10) << "BF.LOADCHUNK invalid chunk"
+                             << " key=" << key << " cursor=" << cursor
+                             << " blob_size=" << blob.size() << " load_res=" << ToString(load_res);
+    return OpStatus::OUT_OF_RANGE;
+  }
+
+  return OpStatus::OK;
+}
+
 void CmdReserve(CmdArgList args, CommandContext* cmd_cntx) {
   CmdArgParser parser(args);
   string_view key = parser.Next();
@@ -241,52 +289,8 @@ void CmdLoadChunk(CmdArgList args, CommandContext* cmd_cntx) {
 
   const std::string_view blob = parser.Next();
 
-  const auto cb = [&](Transaction* t, EngineShard* shard) -> OpStatus {
-    auto op_args = t->GetOpArgs(shard);
-    auto& db_slice = op_args.GetDbSlice();
-
-    if (cursor == 1) {
-      auto load_result = LoadSBFHeader(blob, CompactObj::memory_resource());
-      if (!load_result.has_value()) {
-        LOG_EVERY_T(WARNING, 10) << "BF.LOADCHUNK invalid header"
-                                 << " key=" << key << " cursor=" << cursor
-                                 << " blob_size=" << blob.size()
-                                 << " load_res=" << ToString(load_result.error());
-        return OpStatus::INVALID_VALUE;
-      }
-
-      // type set to nullopt to find any type key and overwrite it, not just SBF
-      auto op_res = db_slice.AddOrFind(op_args.db_cntx, key, std::nullopt);
-      if (!op_res) {
-        CompactObj::DeleteMR<SBF>(load_result.value());
-        return op_res.status();
-      }
-
-      // LOADCHUNK overwrites existing key
-      if (!op_res->is_new) {
-        // existing key might not necessarily be SBF, it could be HASH/JSON, and indexed
-        RemoveKeyFromIndexesIfNeeded(key, op_args.db_cntx, op_res->it->second, op_args.shard);
-        db_slice.RemoveExpire(op_args.db_cntx.db_index, op_res->it);
-      }
-
-      op_res->it->second.SetSBF(load_result.value());
-      return OpStatus::OK;
-    }
-
-    auto op_res = db_slice.FindMutable(op_args.db_cntx, key, OBJ_SBF);
-    if (!op_res)
-      return op_res.status();
-
-    SBF* sbf = op_res->it->second.GetSBF();
-    if (auto load_res = LoadSBFChunk(cursor, blob, sbf); load_res != SBFLoadResult::kOk) {
-      LOG_EVERY_T(WARNING, 10) << "BF.LOADCHUNK invalid chunk"
-                               << " key=" << key << " cursor=" << cursor
-                               << " blob_size=" << blob.size()
-                               << " load_res=" << ToString(load_res);
-      return OpStatus::OUT_OF_RANGE;
-    }
-
-    return OpStatus::OK;
+  const auto cb = [&](Transaction* t, EngineShard* shard) {
+    return OpLoadChunk(t->GetOpArgs(shard), blob, key, cursor);
   };
 
   const OpStatus res = cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));

--- a/src/server/bloom_family_test.cc
+++ b/src/server/bloom_family_test.cc
@@ -85,6 +85,47 @@ TEST_F(BloomFamilyTest, ScanDump) {
   EXPECT_GE(chunk_count, 1);
 }
 
+TEST_F(BloomFamilyTest, ChunkRoundTrip) {
+  constexpr int total_items = 100;
+
+  Run({"bf.reserve", "b1", "0.01", "1000"});
+  for (int i = 0; i < total_items; ++i)
+    Run({"bf.add", "b1", absl::StrCat("item", i)});
+
+  struct Chunk {
+    int64_t cursor;
+    std::string data;
+  };
+  std::vector<Chunk> chunks;
+
+  int64_t cursor = 0;
+  do {
+    auto resp = Run({"bf.scandump", "b1", std::to_string(cursor)});
+    const auto& vec = resp.GetVec();
+    ASSERT_EQ(vec.size(), 2u);
+
+    const int64_t next_cursor = *vec[0].GetInt();
+    ASSERT_TRUE(next_cursor > cursor || next_cursor == 0);
+
+    if (next_cursor != 0) {
+      EXPECT_EQ(vec[1].type, RespExpr::STRING);
+      EXPECT_FALSE(vec[1].GetBuf().empty());
+      chunks.push_back({next_cursor, vec[1].GetString()});
+    }
+    cursor = next_cursor;
+  } while (cursor != 0);
+
+  ASSERT_GE(chunks.size(), 2);
+
+  // Load all chunks into new key
+  for (const auto& [crs, data] : chunks)
+    EXPECT_EQ(Run({"bf.loadchunk", "b2", std::to_string(crs), data}), "OK");
+
+  // Verify all items exist in the loaded copy
+  for (int i = 0; i < total_items; ++i)
+    EXPECT_THAT(Run({"bf.exists", "b2", absl::StrCat("item", i)}), IntArg(1));
+}
+
 TEST_F(BloomFamilyTest, ScanDumpPastEnd) {
   Run({"bf.reserve", "b1", "0.01", "100"});
   Run({"bf.add", "b1", "x"});
@@ -97,6 +138,11 @@ TEST_F(BloomFamilyTest, ScanDumpPastEnd) {
   EXPECT_EQ(*vec[0].GetInt(), 0);
   EXPECT_EQ(vec[1].type, RespExpr::STRING);
   EXPECT_TRUE(vec[1].GetBuf().empty());
+}
+
+TEST_F(BloomFamilyTest, LoadChunkErrors) {
+  EXPECT_THAT(Run({"bf.loadchunk", "b1", "0", "data"}), ErrArg("not an integer"));
+  EXPECT_THAT(Run({"bf.loadchunk", "b1", "-1", "data"}), ErrArg("not an integer"));
 }
 
 }  // namespace dfly

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -292,7 +292,9 @@ void RdbLoaderBase::OpaqueObjLoader::operator()(const RdbSBF& src) {
       CompactObj::AllocateMR<SBF>(src.grow_factor, src.fp_prob, src.max_capacity, src.prev_size,
                                   src.current_size, CompactObj::memory_resource());
   for (unsigned i = 0; i < src.filters.size(); ++i) {
-    sbf->AddFilter(src.filters[i].blob, src.filters[i].hash_cnt);
+    const auto& blob = src.filters[i].blob;
+    auto* ptr = sbf->AllocateFilter(blob.size(), src.filters[i].hash_cnt);
+    memcpy(ptr, blob.data(), blob.size());
   }
   pv_->SetSBF(sbf);
 }


### PR DESCRIPTION
implements LOADCHUNK command for SBF
creates a new SBF, then progressively loads data into its filters.

The command expects `key,cursor,byte data`

On cursor=1, the byte data is expected to be SBF metadata: version and growth factor. It is used to create a new empty (valid) SBF.

Subsequent cursors will add new filters and update the SBF state such as fp prob, max capacity etc.

While the SBF is in a partially loaded state (determined by `num_filters == 0`) most commands on it are rejected. The commands are unblocked after the first filter is loaded.

# Concurrent write risks

**The filter should not be modified with `BF.ADD` until the `LOADCHUNK` commands are finished.** 

When the SBF is created initially it has no filters. There are guards put into place in this PR to avoid insert or query at this stage. But once some chunks have been loaded and filters are non-zero those checks are relaxed.

If `BF.ADD` is run in parallel, the SBF state may be overwritten (if the `BF.ADD` triggers filter growth), and subsequent `LOADCHUNK` commands on that SBF will fail due to validation checks. Example scenario:

* SBF is created with `LOADCHUNK ... 1` with 0 filters
* `BF.ADD` executes, is blocked due to 0 filters validation
* next `LOADCHUNK` adds one filter
* many `BF.ADD` execute and write to filter, resulting in SBF growth.
* next `LOADCHUNK` runs. Either it will overwrite the new filter, or fail validation if size does not match
* The SBF now contains inconsistent data in filters, and `LOADCHUNK` commands may fail at validation

It is not possible to lock the SBF until the last chunk has been loaded, because there is no way to determine which chunk is the last on the server, only the client has that information in the current wire protocol.