### PR TITLE
refactor: move ExecutionState out of ProtocolClient

### DIFF
--- a/src/server/cluster/coordinator.cc
+++ b/src/server/cluster/coordinator.cc
@@ -146,6 +146,8 @@ class Coordinator::CrossShardClient : public ProtocolClient {
   }
 
  private:
+  ExecutionState exec_st_;
+
   std::queue<std::shared_ptr<CrossShardRequest>> send_queue_;
   std::queue<std::shared_ptr<CrossShardRequest>> resp_queue_;
 

--- a/src/server/cluster/outgoing_slot_migration.cc
+++ b/src/server/cluster/outgoing_slot_migration.cc
@@ -109,6 +109,7 @@ class OutgoingMigration::SliceSlotMigration : private ProtocolClient {
   using ProtocolClient::CloseSocket;
 
  private:
+  ExecutionState exec_st_;
   RestoreStreamer streamer_;
 };
 

--- a/src/server/cluster/outgoing_slot_migration.h
+++ b/src/server/cluster/outgoing_slot_migration.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "server/cluster/cluster_defs.h"
+#include "server/execution_state.h"
 #include "server/protocol_client.h"
 #include "server/transaction.h"
 
@@ -88,6 +89,8 @@ class OutgoingMigration : private ProtocolClient {
   bool ChangeState(MigrationState new_state) ABSL_LOCKS_EXCLUDED(state_mu_);
 
   void OnAllShards(std::function<void(UniqueSliceSlotMigration&)>);
+
+  ExecutionState exec_st_;
 
   MigrationInfo migration_info_;
   std::vector<std::unique_ptr<SliceSlotMigration>> slot_migrations_;

--- a/src/server/protocol_client.cc
+++ b/src/server/protocol_client.cc
@@ -123,8 +123,6 @@ ProtocolClient::ProtocolClient(ServerContext context) : server_context_(std::mov
 }
 
 ProtocolClient::~ProtocolClient() {
-  exec_st_.JoinErrorHandler();
-
 #ifdef DFLY_USE_SSL
   if (ssl_ctx_) {
     SSL_CTX_free(ssl_ctx_);

--- a/src/server/protocol_client.h
+++ b/src/server/protocol_client.h
@@ -12,7 +12,6 @@
 #include "facade/redis_parser.h"
 #include "facade/resp_parser.h"
 #include "io/io_buf.h"
-#include "server/execution_state.h"
 #include "server/version.h"
 #include "util/fiber_socket_base.h"
 

--- a/src/server/protocol_client.h
+++ b/src/server/protocol_client.h
@@ -153,8 +153,6 @@ class ProtocolClient {
   util::fb2::Mutex sock_mu_;
 
  protected:
-  ExecutionState exec_st_;  // context for tasks in replica.
-
   std::string last_cmd_;
   std::string last_resp_;
 

--- a/src/server/protocol_client.h
+++ b/src/server/protocol_client.h
@@ -12,6 +12,7 @@
 #include "facade/redis_parser.h"
 #include "facade/resp_parser.h"
 #include "io/io_buf.h"
+#include "server/execution_state.h"
 #include "server/version.h"
 #include "util/fiber_socket_base.h"
 

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -101,6 +101,7 @@ Replica::Replica(string host, uint16_t port, Service* se, std::string_view id,
 Replica::~Replica() {
   sync_fb_.JoinIfNeeded();
   acks_fb_.JoinIfNeeded();
+  exec_st_.JoinErrorHandler();
 }
 
 static const char kConnErr[] = "could not connect to master: ";
@@ -869,7 +870,7 @@ io::Result<bool> DflyShardReplica::StartSyncFlow(
   proactor_index_ = ProactorBase::me()->GetPoolIndex();
 
   RETURN_ON_ERR_T(make_unexpected,
-                  ConnectAndAuth(absl::GetFlag(FLAGS_master_connect_timeout_ms) * 1ms, &exec_st_));
+                  ConnectAndAuth(absl::GetFlag(FLAGS_master_connect_timeout_ms) * 1ms, cntx));
 
   VLOG(1) << "Sending on flow " << master_context_.master_repl_id << " "
           << master_context_.dfly_session_id << " " << flow_id_ << " lsn: " << lsn.value_or(-1);

--- a/src/server/replica.h
+++ b/src/server/replica.h
@@ -138,6 +138,8 @@ class Replica : ProtocolClient {
   size_t GetRecCountExecutedPerShard(const std::vector<unsigned>& indexes) const;
 
  private:
+  ExecutionState exec_st_;
+
   util::fb2::ProactorBase* proactor_ = nullptr;
   Service& service_;
   MasterContext master_context_;


### PR DESCRIPTION
`ProtocolClient::exec_st_` is a shared field even though it's only meaningful to specific subclasses. For example, exec_st_ of each replica flow is ignored (and the parent/main replica connection exec_st_ is passed around instead). This is confusing on the API level were *some* users of the ProtocolClient require the exec_st_ (main repl connection) while others don't at all (replica flows).

This PR moves it down to the classes that actually use it -- Replica, OutgoingMigration, SliceSlotMigration, and CrossShardClient. 

Also updates DflyShardReplica::StartSyncFlow to pass the correct context pointer instead of the now-removed base field.