### PR TITLE
ci: Use Azure mirror for cgroup test to fix apt failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,11 +217,16 @@ jobs:
           # Verify the binary's runtime dependencies and install them in a local image.
           # The binary is built in ubuntu-dev:24 and links dynamically against Boost,
           # which is not present in the minimal ubuntu:24.04 image.
+          #
+          # Note: GitHub Actions runners are hosted on Azure. We rewrite the apt sources
+          # to use Azure's internal Ubuntu mirror to prevent CI failures caused by
+          # rate-limited or corrupted public Canonical mirrors.
           echo "Runtime deps of dragonfly binary:"
           ldd build/dragonfly
           docker build -t df-cgroup-test - <<'EOF'
           FROM ubuntu:24.04
-          RUN apt-get update -qq && \
+          RUN sed -i -E 's@http://(archive|security)\.ubuntu\.com@http://azure.archive.ubuntu.com@g' /etc/apt/sources.list.d/ubuntu.sources && \
+              apt-get update -qq && \
               apt-get install -y --no-install-recommends libboost-context1.83.0 libssl3 && \
               rm -rf /var/lib/apt/lists/*
           EOF


### PR DESCRIPTION
GitHub Actions runners encountered persistent apt-get failures due to corrupted Packages.gz from archive.ubuntu.com (size mismatch errors). This happened multiple times to me.
Here we switch to azure.archive.ubuntu.com since Github runners are on Azure infrastructure, providing local, faster, reliable package fetching.

Changes:
- Rewrite ubuntu.sources to use Azure mirror in cgroup test Dockerfile
