### PR TITLE
fix: SHRINK command memory accounting causes DCHECK crash

### DIFF
--- a/src/core/dense_set.cc
+++ b/src/core/dense_set.cc
@@ -406,6 +406,9 @@ void DenseSet::ShrinkBucket(size_t bucket_idx) {
     }
 
     if (has_ttl && ObjExpireTime(obj) <= time_now_) {
+      size_t obj_size = ObjectAllocSize(obj);
+      DCHECK_GE(obj_malloc_used_, obj_size);
+      obj_malloc_used_ -= obj_size;
       ObjDelete(obj);
       --size_;
       continue;

--- a/src/server/hset_family_test.cc
+++ b/src/server/hset_family_test.cc
@@ -853,4 +853,45 @@ TEST_F(HSetFamilyTest, HIncrByFloatNaNDoesNotCreateKey) {
   EXPECT_THAT(Run({"HRANDFIELD", "key"}), ArgType(RespExpr::NIL));
 }
 
+// SHRINK uses FindReadOnly but mutates the DenseSet (bucket array + links).
+// When ShrinkBucket consolidates live items into fewer buckets, the number of
+// internal links can increase, raising MallocUsed() above the tracked
+// obj_memory_usage.  The next FindMutable then hits
+//   DCHECK_GE(obj_memory_usage, MallocUsed())
+// because obj_memory_usage was never updated by SHRINK.
+TEST_F(HSetFamilyTest, ShrinkMemoryAccountingHash) {
+  TEST_current_time_ms = kMemberExpiryBase * 1000;
+
+  // Phase 1: Grow the DenseSet to a large bucket count by adding many fields.
+  // Growth at 87.5% load: 8→16 at 7, 16→32 at 14, 32→64 at 28, 64→128 at 56.
+  for (int i = 0; i < 60; i++) {
+    Run({"HSETEX", "h1", "1000", absl::StrCat("temp", i), absl::StrCat("v", i)});
+  }
+  // bucket_count = 128 (grown at 56th item).
+
+  // Phase 2: Remove most fields to keep a large bucket_count with few live items.
+  for (int i = 0; i < 50; i++) {
+    Run({"HDEL", "h1", absl::StrCat("temp", i)});
+  }
+  // 10 live fields (temp50-temp59), bucket_count = 128.
+
+  // Phase 3: Add fields with short TTL that will expire.
+  for (int i = 0; i < 10; i++) {
+    Run({"HSETEX", "h1", "1", absl::StrCat("exp", i), absl::StrCat("v", i)});
+  }
+  // 20 total (10 long + 10 short), bucket_count = 128.
+
+  // Phase 4: Expire the short-TTL fields.
+  AdvanceTime(2000);
+
+  // UpperBoundSize = 20, optimal = max(8, 32) = 32 < 128 → Shrink.
+  // ShrinkBucket removes 10 expired, consolidates 10 live into 32 buckets.
+  int64_t shrink_result = CheckedInt({"SHRINK", "h1"});
+  EXPECT_GT(shrink_result, 0) << "SHRINK must actually shrink the hash";
+
+  // The write triggers FindMutable → DCHECK.  Must not crash.
+  Run({"HDEL", "h1", "temp50"});
+  EXPECT_EQ(9, CheckedInt({"HLEN", "h1"}));
+}
+
 }  // namespace dfly

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2794,35 +2794,53 @@ void ServerFamily::Shrink(CmdArgList args, CommandContext* cmd_cntx) {
 
   auto cb = [key](Transaction* t, EngineShard* shard) -> OpResult<int64_t> {
     auto& db_slice = t->GetDbSlice(shard->shard_id());
-    auto it = db_slice.FindReadOnly(t->GetDbContext(), key);
-    if (!IsValid(it)) {
-      return OpStatus::KEY_NOTFOUND;
+
+    // First, do a read-only check: validate type/encoding and decide whether
+    // shrink is needed.  This avoids bumping the key version, firing WATCH
+    // invalidations, or running PostUpdate for no-op / WRONGTYPE paths.
+    {
+      auto it = db_slice.FindReadOnly(t->GetDbContext(), key);
+      if (!IsValid(it)) {
+        return OpStatus::KEY_NOTFOUND;
+      }
+
+      const PrimeValue& pv = it->second;
+      unsigned encoding = pv.Encoding();
+      unsigned obj_type = pv.ObjType();
+
+      if (encoding != kEncodingStrMap2 || (obj_type != OBJ_SET && obj_type != OBJ_HASH)) {
+        return OpStatus::WRONG_TYPE;
+      }
+
+      DenseSet* ds = static_cast<DenseSet*>(pv.RObjPtr());
+      ds->set_time(MemberTimeSeconds(t->GetDbContext().time_now_ms));
+      size_t current_size = ds->UpperBoundSize();
+      size_t bucket_count = ds->BucketCount();
+
+      if (current_size == 0 || bucket_count == 0) {
+        return 0;
+      }
+
+      size_t optimal_size = std::max(size_t(8), absl::bit_ceil(current_size));
+      if (optimal_size >= bucket_count) {
+        return 0;
+      }
     }
 
-    const PrimeValue& pv = it->second;
-    unsigned encoding = pv.Encoding();
-    unsigned obj_type = pv.ObjType();
-
-    // Only DenseSet-based structures (set or hash with kEncodingStrMap2)
-    if (encoding != kEncodingStrMap2 || (obj_type != OBJ_SET && obj_type != OBJ_HASH)) {
-      return OpStatus::WRONG_TYPE;
+    // Shrink is needed — use FindMutable so the AutoUpdater tracks the
+    // MallocUsed() delta (bucket array resize, link changes, expired-entry
+    // deletions) and keeps obj_memory_usage in sync.
+    auto it_res = db_slice.FindMutable(t->GetDbContext(), key);
+    if (!IsValid(it_res.it)) {
+      return OpStatus::KEY_NOTFOUND;  // raced away between the two lookups
     }
 
+    PrimeValue& pv = it_res.it->second;
     DenseSet* ds = static_cast<DenseSet*>(pv.RObjPtr());
     ds->set_time(MemberTimeSeconds(t->GetDbContext().time_now_ms));
-    size_t current_size = ds->UpperBoundSize();
-    size_t bucket_count = ds->BucketCount();
 
-    if (current_size == 0 || bucket_count == 0) {
-      return 0;
-    }
-
-    size_t optimal_size = std::max(size_t(8), absl::bit_ceil(current_size));
-    if (optimal_size >= bucket_count) {
-      return 0;
-    }
-
-    size_t bucket_bytes_before = bucket_count * sizeof(void*);
+    size_t bucket_bytes_before = ds->BucketCount() * sizeof(void*);
+    size_t optimal_size = std::max(size_t(8), absl::bit_ceil(ds->UpperBoundSize()));
     ds->Shrink(optimal_size);
     size_t bucket_bytes_after = ds->BucketCount() * sizeof(void*);
 

--- a/src/server/set_family_test.cc
+++ b/src/server/set_family_test.cc
@@ -788,4 +788,37 @@ TEST_F(SetFamilyTest, FieldTtlDeletesEmptySet) {
   EXPECT_THAT(Run({"exists", "key"}), IntArg(0));
 }
 
+// Regression test for github.com/dragonflydb/dragonfly/issues/7171
+// Same bug as ShrinkMemoryAccountingHash but for sets with SADDEX/SREM.
+TEST_F(SetFamilyTest, ShrinkMemoryAccountingSet) {
+  TEST_current_time_ms = kMemberExpiryBase * 1000;
+
+  // Phase 1: Grow bucket_count to 128 by adding 60 members.
+  for (int i = 0; i < 60; i++) {
+    Run({"SADDEX", "s1", "1000", absl::StrCat("temp", i)});
+  }
+
+  // Phase 2: Remove 50, keep 10, bucket_count stays 128.
+  for (int i = 0; i < 50; i++) {
+    Run({"SREM", "s1", absl::StrCat("temp", i)});
+  }
+
+  // Phase 3: Add 10 members with short TTL.
+  for (int i = 0; i < 10; i++) {
+    Run({"SADDEX", "s1", "1", absl::StrCat("exp", i)});
+  }
+  // 20 total (10 long + 10 short), bucket_count = 128.
+
+  // Phase 4: Expire the short-TTL members.
+  AdvanceTime(2000);
+
+  // UpperBoundSize = 20, optimal = 32 < 128 → Shrink.
+  int64_t shrink_result = CheckedInt({"SHRINK", "s1"});
+  EXPECT_GT(shrink_result, 0) << "SHRINK must actually shrink the set";
+
+  // Must not crash in FindMutable → DCHECK.
+  Run({"SREM", "s1", "temp50"});
+  EXPECT_THAT(Run({"SCARD", "s1"}), IntArg(9));
+}
+
 }  // namespace dfly


### PR DESCRIPTION
SHRINK used FindReadOnly but mutated the DenseSet, so obj_memory_usage was never updated via AutoUpdater. Link consolidation during bucket shrink could increase SetMallocUsed(), making MallocUsed() > obj_memory_usage and crashing on the next FindMutable.
ShrinkBucket deleted expired entries via ObjDelete without decrementing obj_malloc_used_, corrupting internal DenseSet memory accounting.

Fixes #7171