### PR TITLE
fix: SHRINK build break from obj_type out of scope after merge

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2847,9 +2847,7 @@ void ServerFamily::Shrink(CmdArgList args, CommandContext* cmd_cntx) {
     // Shrink expires entries during bucket compaction.  If all entries expired,
     // delete the now-empty key to prevent zombie keys that crash SAVE.
     if (ds->Empty()) {
-      if (auto res = db_slice.FindMutable(t->GetDbContext(), key, obj_type); res) {
-        db_slice.DelMutable(t->GetDbContext(), std::move(*res));
-      }
+      db_slice.DelMutable(t->GetDbContext(), std::move(it_res));
     }
 
     return bucket_bytes_before - bucket_bytes_after;


### PR DESCRIPTION
The merge of #7160 (SHRINK zombie cleanup) and #7173 (SHRINK memory accounting refactor) left `obj_type` used out of its scope, breaking the build on all platforms.

Root cause:
#7173 moved the type/encoding check into an inner block `{ ... }` where `obj_type` is declared. #7160's empty-container cleanup was kept outside that block, but still referenced `obj_type`, which no longer exists there.

Fix:
The mutable iterator `it_res` (already obtained a few lines above for the actual Shrink call) can be reused for deletion - no second `FindMutable` is needed. This also drops the redundant lookup.
