### PR TITLE
chore(server): Extended SerializerBase test

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -165,6 +165,7 @@ helio_cxx_test(cluster/cluster_config_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(cluster/cluster_family_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(acl/acl_family_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(engine_shard_set_test dfly_test_lib LABELS DFLY)
+helio_cxx_test(serializer_base_test dfly_test_lib LABELS DFLY)
 
 add_dependencies(check_dfly dragonfly_test json_family_test list_family_test
                  generic_family_test memcache_parser_test rdb_test journal_test

--- a/src/server/serializer_base.h
+++ b/src/server/serializer_base.h
@@ -18,6 +18,7 @@
 namespace dfly {
 
 class ExecutionState;
+struct TestDriver;
 
 // Opaque identity for a physical DashTable bucket — its memory address.
 // Unique across all databases/segments for the lifetime of a serialization.
@@ -66,6 +67,8 @@ struct DelayedEntryHandler {
   }
 
  private:
+  friend struct TestDriver;
+
   BucketDependencies& deps_;
 
   // Entries that are waiting for tiered storage reads to complete before they can be serialized.

--- a/src/server/serializer_base_test.cc
+++ b/src/server/serializer_base_test.cc
@@ -137,8 +137,8 @@ struct TestDriver : public SerializerBase, journal::JournalConsumerInterface {
   }
 
   void RecordSerialized(std::string key) {
-    EXPECT_FALSE(emitted_baselines_.contains(key));
-    EXPECT_FALSE(seen_journal_keys_.contains(key));  // No journal entries must exist for this key
+    CHECK(!emitted_baselines_.contains(key));
+    CHECK(!journal_writes_.contains(key));  // No journal entries must exist for this key
     emitted_baselines_.emplace(std::move(key));
   }
 
@@ -149,17 +149,21 @@ struct TestDriver : public SerializerBase, journal::JournalConsumerInterface {
 
     snapshot_fb_ = util::fb2::Fiber{[this] {
       Loop();
-      journal::UnregisterConsumer(journal_id_);
       UnregisterChangeListener();
     }};
 
     delay_driver_.Start();
   }
 
-  auto Finish() {
-    delay_driver_.Stop();
+  void Wait() {
     snapshot_fb_.JoinIfNeeded();
-    return std::make_pair(GetStats(), std::move(emitted_baselines_));
+  }
+
+  auto Finish() {
+    Wait();
+    delay_driver_.Stop();
+    journal::UnregisterConsumer(journal_id_);
+    return std::tuple(GetStats(), std::move(emitted_baselines_), std::move(journal_writes_));
   }
 
   Params params_;
@@ -175,7 +179,7 @@ struct TestDriver : public SerializerBase, journal::JournalConsumerInterface {
   TestDelayDriver delay_driver_;
 
   absl::flat_hash_set<std::string> emitted_baselines_;
-  absl::flat_hash_set<std::string> seen_journal_keys_;
+  absl::flat_hash_map<std::string, unsigned> journal_writes_;
 };
 
 void TestDriver::Loop() {
@@ -232,7 +236,7 @@ void TestDriver::ConsumeJournalChange(const journal::JournalChangeItem& item) {
   auto keys = DetermineKeys(cid, str_vec);
   CHECK(keys);
   for (auto key : keys->Range(str_vec))
-    seen_journal_keys_.emplace(key);
+    journal_writes_[key]++;
 }
 
 unsigned TestDriver::SerializeBucketLocked(DbIndex db_index, PrimeTable::bucket_iterator it,
@@ -298,13 +302,10 @@ class SerializerBaseTest : public BaseFamilyTest {
   std::optional<TestDriver> driver_;
 };
 
-// Check that serialization of debug populate is successful
+// Check that basic serialization of debug populate is successful and fullfils all driver asserts
 TEST_F(SerializerBaseTest, StaticDebugPopulate) {
-  // Fill databse with keys
   const size_t kKeys = 10000;
   Run({"DEBUG", "POPULATE", std::to_string(kKeys)});
-
-  // Start snapshot
   Start();
 
   // Issue appends at the same time
@@ -317,26 +318,29 @@ TEST_F(SerializerBaseTest, StaticDebugPopulate) {
   });
 
   // Finish and join worker
-  auto stats = Finish();
+  auto [stats, baselines, _] = Finish();
   running = false;
   worker.Join();
 
   // Expect serialized keys
-  EXPECT_EQ(stats.first.keys_serialized, kKeys);
+  EXPECT_EQ(stats.keys_serialized, kKeys);
   for (unsigned i = 0; i < kKeys; i++)
-    EXPECT_TRUE(stats.second.contains(absl::StrCat("key:", i)));
+    EXPECT_TRUE(baselines.contains(absl::StrCat("key:", i)));
 }
 
-// Check that serialization of debug populate is successful
-TEST_F(SerializerBaseTest, NewValues) {
-  // Fill databse with keys
+// Check serialization of lists is successful with parallel additions to list.
+// Each operation (including creation) adds one item to the list
+// and each operation causes either serialization or a journal write.
+// So at the end the number of writes (baseline and journal) must be equal to the list length
+// TODO: Add multiple drivers
+// TODO: Will be wrong with journal omits
+TEST_F(SerializerBaseTest, IncreasingLists) {
   const size_t kKeys = 5000;
-  Run({"DEBUG", "POPULATE", std::to_string(kKeys), "key", "100", "TYPE", "LIST", "ELEMENTS", "11"});
-
-  // Start snapshot
+  Run({"DEBUG", "POPULATE", std::to_string(kKeys), "key", "100", "TYPE", "LIST", "ELEMENTS", "1"});
   Start();
 
-  // Issue appends at the same time in range [0, 2 * kKeys] to have a balance of new keys
+  // Issue single value appends at the same time
+  // Select keys in range [0, 2 * kKeys] to have a balance of new and existing keys
   std::atomic_bool running = true;
   std::vector<util::fb2::Fiber> workers;
   for (size_t w = 0; w < 3; w++) {
@@ -355,11 +359,31 @@ TEST_F(SerializerBaseTest, NewValues) {
     workers.push_back(std::move(worker));
   }
 
-  // Finish and join worker
-  auto stats = Finish();
+  // Wait for main loop
+  Change([](TestDriver& d) { d.Wait(); });
+
+  // Stop all writers and finish
   running = false;
   for (auto& w : workers)
     w.Join();
+  auto [stats, baselines, journal_writes] = Finish();
+
+  // Verify invariants (see comment at function top)
+  unsigned seen = 0;
+  for (size_t i = 0; i < kKeys * 2; i++) {
+    auto key = absl::StrCat("key:", i);
+    if (Run({"exists", key}).GetInt() == 0)
+      continue;
+
+    seen++;
+    unsigned len = Run({"LLEN", key}).GetInt().value_or(0);
+    unsigned base_written = baselines.contains(key);
+    unsigned journal_written = journal_writes.contains(key) ? journal_writes.at(key) : 0u;
+
+    EXPECT_EQ(len, base_written + journal_written);
+  }
+
+  EXPECT_THAT(Run({"dbsize"}), IntArg(seen));
 }
 
 // During delayed read of a tiered value, it can be come expired.
@@ -367,6 +391,8 @@ TEST_F(SerializerBaseTest, NewValues) {
 // Serialization code has many paths that omit empty bucket checks at all -
 // assert those "lost" delayed reads are correctly flushed before new changes
 TEST_F(SerializerBaseTest, DelayedAllDeleted) {
+  GTEST_SKIP() << "To be fixed";
+
   // 1-2 ms
   driver_params = {.delay_prob = 0.9, .delay_lat_us = {1000, 2000}};
 
@@ -387,7 +413,7 @@ TEST_F(SerializerBaseTest, DelayedAllDeleted) {
   for (unsigned i = 0; i < kKeys; i++)
     EXPECT_THAT(Run({"GET", absl::StrCat("key:", i)}), ArgType(RespExpr::NIL));
 
-  // Reallow resolution
+  // Reallow delayed entry resolution
   Change([](TestDriver& d) { d.delay_driver_.Resume(); });
 
   // Trigger changes with dels

--- a/src/server/serializer_base_test.cc
+++ b/src/server/serializer_base_test.cc
@@ -53,6 +53,7 @@ struct TestDelayDriver {
     auto tp = std::chrono::steady_clock::now() + std::chrono::microseconds(delay_us);
     Fut future{};
     q_.emplace(tp, future);
+    var_.notify_one();
     return future;
   }
 
@@ -204,7 +205,7 @@ void TestDriver::Loop() {
     } while (snapshot_cursor_);
 
     {
-      std::lock_guard guard(big_value_mu_);
+      std::lock_guard guard(stream_mu_);
       ProcessDelayedEntries(true, 0, base_cntx_);
     }
 
@@ -245,6 +246,7 @@ unsigned TestDriver::SerializeBucketLocked(DbIndex db_index, PrimeTable::bucket_
   for (it.AdvanceIfNotOccupied(); !it.is_done(); ++it) {
     DCHECK_EQ(it.GetVersion(), snapshot_version_);
 
+    std::lock_guard lk{stream_mu_};
     Serialize(it.bucket_address(), it->first.ToString());
     ++serialized;
 

--- a/src/server/serializer_base_test.cc
+++ b/src/server/serializer_base_test.cc
@@ -1,0 +1,264 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "server/serializer_base.h"
+
+#include <absl/container/flat_hash_map.h>
+#include <absl/random/distributions.h>
+#include <absl/random/random.h>
+
+#include <atomic>
+#include <boost/smart_ptr/intrusive_ptr.hpp>
+
+#include "base/gtest.h"
+#include "base/logging.h"
+#include "io/io.h"
+#include "server/command_registry.h"
+#include "server/common.h"
+#include "server/conn_context.h"
+#include "server/db_slice.h"
+#include "server/engine_shard.h"
+#include "server/execution_state.h"
+#include "server/journal/journal.h"
+#include "server/journal/serializer.h"
+#include "server/journal/types.h"
+#include "server/test_utils.h"
+#include "server/transaction.h"
+#include "util/fibers/fibers.h"
+
+namespace dfly {
+
+struct TestDriver : public SerializerBase, journal::JournalConsumerInterface {
+  TestDriver(DbSlice* slice, ExecutionState* cntx, CommandRegistry* reg)
+      : SerializerBase(slice, cntx), reg_{reg} {
+  }
+
+  unsigned SerializeBucketLocked(DbIndex db_index, PrimeTable::bucket_iterator it,
+                                 bool on_update) override;
+
+  void SerializeFetchedEntry(const TieredDelayedEntry& tde, const PrimeValue& pv) override {
+    Serialize(tde.key.ToString());
+  }
+
+  void ConsumeJournalChange(const journal::JournalChangeItem& item) override;
+
+  void ThrottleIfNeeded() override {
+  }
+
+  // TODO: possibly replace with unified loop if we decide on this?
+  void Loop();
+
+  void Serialize(std::string key) {
+    EXPECT_FALSE(seen_journal_keys_.contains(key));  // No journal entries must exist for this key
+    emitted_baselines_.emplace(std::move(key));
+  }
+
+  void Start() {
+    SerializerBase::RegisterChangeListener();
+    journal::StartInThread();
+    journal_id_ = journal::RegisterConsumer(this);
+
+    snapshot_fb_ = util::fb2::Fiber{[this] {
+      Loop();
+      journal::UnregisterConsumer(journal_id_);
+      UnregisterChangeListener();
+    }};
+  }
+
+  auto Finish() {
+    snapshot_fb_.JoinIfNeeded();
+    return std::make_pair(GetStats(), std::move(emitted_baselines_));
+  }
+
+  CommandRegistry* reg_;
+
+  absl::InsecureBitGen bg_;
+
+  util::fb2::Fiber snapshot_fb_;
+  PrimeTable::Cursor snapshot_cursor_;
+  uint32_t journal_id_;
+
+  absl::flat_hash_set<std::string> emitted_baselines_;
+  absl::flat_hash_set<std::string> seen_journal_keys_;
+};
+
+void TestDriver::Loop() {
+  for (DbIndex snapshot_db_indx = 0; snapshot_db_indx < db_array_.size(); ++snapshot_db_indx) {
+    if (!base_cntx_->IsRunning())
+      return;
+
+    if (!db_array_[snapshot_db_indx])
+      continue;
+
+    PrimeTable* pt = &db_array_[snapshot_db_indx]->prime;
+    do {
+      if (!base_cntx_->IsRunning()) {
+        return;
+      }
+
+      snapshot_cursor_ = pt->TraverseBuckets(snapshot_cursor_, [this, snapshot_db_indx](auto it) {
+        ProcessBucket(snapshot_db_indx, it, false);
+      });
+
+      util::ThisFiber::Yield();
+    } while (snapshot_cursor_);
+
+    {
+      std::lock_guard guard(big_value_mu_);
+      ProcessDelayedEntries(true, 0, base_cntx_);
+    }
+
+    util::ThisFiber::Yield();
+  }  // for (dbindex)
+}
+
+void TestDriver::ConsumeJournalChange(const journal::JournalChangeItem& item) {
+  io::BytesSource bytes{item.journal_item.data};
+  JournalReader reader{&bytes, 0};
+
+  // Check entry is parsable
+  journal::ParsedEntry entry;
+  auto ec = reader.ReadEntry(&entry);
+  CHECK(!ec) << ec;
+
+  // Check entry is a command trace
+  if (entry.opcode != journal::Op::COMMAND)
+    return;
+
+  // Extract cid + original args
+  auto cid = reg_->Find(entry.cmd.Front());
+  std::vector<std::string_view> str_vec;
+  for (auto v : entry.cmd.view())
+    str_vec.push_back(v);
+  str_vec.erase(str_vec.begin());
+
+  // Check all keys were baseline emitted before
+  auto keys = DetermineKeys(cid, str_vec);
+  CHECK(keys);
+  for (auto key : keys->Range(str_vec))
+    seen_journal_keys_.emplace(key);
+}
+
+unsigned TestDriver::SerializeBucketLocked(DbIndex db_index, PrimeTable::bucket_iterator it,
+                                           bool on_update) {
+  unsigned serialized = 0;
+  for (it.AdvanceIfNotOccupied(); !it.is_done(); ++it) {
+    DCHECK_EQ(it.GetVersion(), snapshot_version_);
+
+    Serialize(it->first.ToString());
+    ++serialized;
+
+    while (absl::Bernoulli(bg_, 0.3)) {
+      for (unsigned it = absl::Uniform(bg_, 1, 10); it > 0; it--)
+        util::ThisFiber::Yield();
+    }
+  }
+  return serialized;
+}
+
+class SerializerBaseTest : public BaseFamilyTest {
+ public:
+  void SetUp() {
+    num_threads_ = 1;
+    BaseFamilyTest::SetUp();
+  }
+
+ protected:
+  void Start() {
+    pp_->at(0)->Await([this] { StartOnThread(); });
+  }
+
+  auto Finish() {
+    std::decay_t<decltype(driver_->Finish())> res;
+    pp_->at(0)->Await([this, &res] {
+      res = driver_->Finish();
+      driver_.reset();  // must be destroyed in this thread
+    });
+
+    return res;
+  }
+
+ private:
+  void StartOnThread() {
+    auto* reg = service_->mutable_registry();
+
+    boost::intrusive_ptr<Transaction> tx = new Transaction{reg->Find("SAVE")};
+    tx->InitByArgs(&namespaces->GetDefaultNamespace(), 0, {});
+
+    tx->ScheduleSingleHop([this, reg](Transaction* t, EngineShard* es) {
+      driver_.emplace(&t->GetDbSlice(es->shard_id()), &cntx_, reg);
+      driver_->Start();
+      return OpStatus::OK;
+    });
+  }
+
+  ExecutionState cntx_;
+  std::optional<TestDriver> driver_;
+};
+
+// Check that serialization of debug populate is successful
+TEST_F(SerializerBaseTest, StaticDebugPopulate) {
+  // Fill databse with keys
+  const size_t kKeys = 10000;
+  Run({"DEBUG", "POPULATE", std::to_string(kKeys)});
+
+  // Start snapshot
+  Start();
+
+  // Issue appends at the same time
+  std::atomic_bool running = true;
+  auto worker = pp_->at(0)->LaunchFiber([&] {
+    for (unsigned i = 0; running.load(std::memory_order_relaxed) && i < kKeys; i++) {
+      Run("W1", {"APPEND", absl::StrCat("key:", i), "D"});
+      util::ThisFiber::Yield();
+    }
+  });
+
+  // Finish and join worker
+  auto stats = Finish();
+  running = false;
+  worker.Join();
+
+  // Expect serialized keys
+  EXPECT_EQ(stats.first.keys_serialized, kKeys);
+  for (unsigned i = 0; i < kKeys; i++)
+    EXPECT_TRUE(stats.second.contains(absl::StrCat("key:", i)));
+}
+
+// Check that serialization of debug populate is successful
+TEST_F(SerializerBaseTest, NewValues) {
+  // Fill databse with keys
+  const size_t kKeys = 5000;
+  Run({"DEBUG", "POPULATE", std::to_string(kKeys), "key", "100", "TYPE", "LIST", "ELEMENTS", "11"});
+
+  // Start snapshot
+  Start();
+
+  // Issue appends at the same time in range [0, 2 * kKeys] to have a balance of new keys
+  std::atomic_bool running = true;
+  std::vector<util::fb2::Fiber> workers;
+  for (size_t w = 0; w < 3; w++) {
+    auto worker = pp_->at(w % pp_->size())->LaunchFiber([&, w] {
+      std::string id = absl::StrCat("w", w);
+      absl::InsecureBitGen bg;
+
+      while (running.load(std::memory_order_relaxed)) {
+        size_t i = absl::Uniform(bg, 0u, 2 * kKeys);
+        size_t j = absl::Uniform(bg, 0u, 1000u);
+
+        Run(id, {"LPUSH", absl::StrCat("key:", i), absl::StrCat("v", j)});
+        util::ThisFiber::Yield();
+      }
+    });
+    workers.push_back(std::move(worker));
+  }
+
+  // Finish and join worker
+  auto stats = Finish();
+  running = false;
+  for (auto& w : workers)
+    w.Join();
+}
+
+}  // namespace dfly

--- a/src/server/serializer_base_test.cc
+++ b/src/server/serializer_base_test.cc
@@ -7,12 +7,16 @@
 #include <absl/container/flat_hash_map.h>
 #include <absl/random/distributions.h>
 #include <absl/random/random.h>
+#include <gtest/gtest.h>
 
 #include <atomic>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
+#include <chrono>
+#include <queue>
 
-#include "base/gtest.h"
 #include "base/logging.h"
+#include "facade/facade_test.h"
+#include "facade/resp_expr.h"
 #include "io/io.h"
 #include "server/command_registry.h"
 #include "server/common.h"
@@ -23,22 +27,93 @@
 #include "server/journal/journal.h"
 #include "server/journal/serializer.h"
 #include "server/journal/types.h"
+#include "server/table.h"
 #include "server/test_utils.h"
 #include "server/transaction.h"
 #include "util/fibers/fibers.h"
+#include "util/fibers/synchronization.h"
+
+using namespace std::chrono_literals;
 
 namespace dfly {
 
+// Driver for "artificially" resolving delayed entries with some delay
+// driven by a fiber in the background
+struct TestDelayDriver {
+  using Fut = util::fb2::Future<io::Result<std::string>>;
+  using OrdEntry = std::pair<std::chrono::steady_clock::time_point, Fut>;
+
+  struct Comp {
+    bool operator()(const OrdEntry& e1, const OrdEntry& e2) const {
+      return e1.first > e2.first;
+    }
+  };
+
+  Fut Enqeue(unsigned delay_us) {
+    auto tp = std::chrono::steady_clock::now() + std::chrono::microseconds(delay_us);
+    Fut future{};
+    q_.emplace(tp, future);
+    return future;
+  }
+
+  void Loop() {
+    while (!done) {
+      util::fb2::NoOpLock lock;
+      var_.wait(lock, [this]() { return done || (!paused && !q_.empty()); });
+
+      while (!paused && !done && !q_.empty()) {
+        auto entry = q_.top();
+        q_.pop();
+
+        util::ThisFiber::SleepUntil(entry.first);
+        entry.second.Resolve(std::string{});
+      }
+    }
+  }
+
+  void Pause() {
+    paused = true;
+    var_.notify_all();
+  }
+
+  void Resume() {
+    paused = false;
+    var_.notify_all();
+  }
+
+  void Start() {
+    resolver_fb_ = {std::bind_front(&TestDelayDriver::Loop, this)};
+  }
+
+  void Stop() {
+    done = true;
+    var_.notify_all();
+    resolver_fb_.JoinIfNeeded();
+  }
+
+  bool done = false;
+  bool paused = false;
+  util::fb2::CondVarAny var_;
+
+  std::priority_queue<OrdEntry, std::vector<OrdEntry>, Comp> q_;
+  util::fb2::Fiber resolver_fb_;
+};
+
 struct TestDriver : public SerializerBase, journal::JournalConsumerInterface {
-  TestDriver(DbSlice* slice, ExecutionState* cntx, CommandRegistry* reg)
-      : SerializerBase(slice, cntx), reg_{reg} {
+  struct Params {
+    float delay_prob = 0.0;
+    std::pair<unsigned, unsigned> delay_lat_us = {0, 100};
+  };
+
+  TestDriver(Params params, DbSlice* slice, ExecutionState* cntx, CommandRegistry* reg)
+      : SerializerBase(slice, cntx), params_{params}, reg_{reg} {
   }
 
   unsigned SerializeBucketLocked(DbIndex db_index, PrimeTable::bucket_iterator it,
                                  bool on_update) override;
 
   void SerializeFetchedEntry(const TieredDelayedEntry& tde, const PrimeValue& pv) override {
-    Serialize(tde.key.ToString());
+    RecordSerialized(tde.key.ToString());
   }
 
   void ConsumeJournalChange(const journal::JournalChangeItem& item) override;
@@ -49,7 +124,20 @@ struct TestDriver : public SerializerBase, journal::JournalConsumerInterface {
   // TODO: possibly replace with unified loop if we decide on this?
   void Loop();
 
-  void Serialize(std::string key) {
+  void Serialize(BucketIdentity bucket, std::string key) {
+    if (absl::Bernoulli(bg_, params_.delay_prob)) {
+      DelayedEntryHandler::deps_.Increment(bucket);
+      unsigned delay = absl::Uniform(bg_, params_.delay_lat_us.first, params_.delay_lat_us.second);
+      auto de = std::make_unique<TieredDelayedEntry>(0, CompactKey{key},
+                                                     delay_driver_.Enqeue(delay), 0, 0);
+      DelayedEntryHandler::delayed_entries_.emplace(bucket, std::move(de));
+    } else {
+      RecordSerialized(std::move(key));
+    }
+  }
+
+  void RecordSerialized(std::string key) {
+    EXPECT_FALSE(emitted_baselines_.contains(key));
     EXPECT_FALSE(seen_journal_keys_.contains(key));  // No journal entries must exist for this key
     emitted_baselines_.emplace(std::move(key));
   }
@@ -64,13 +152,17 @@ struct TestDriver : public SerializerBase, journal::JournalConsumerInterface {
       journal::UnregisterConsumer(journal_id_);
       UnregisterChangeListener();
     }};
+
+    delay_driver_.Start();
   }
 
   auto Finish() {
+    delay_driver_.Stop();
     snapshot_fb_.JoinIfNeeded();
     return std::make_pair(GetStats(), std::move(emitted_baselines_));
   }
 
+  Params params_;
   CommandRegistry* reg_;
 
   absl::InsecureBitGen bg_;
@@ -78,6 +170,9 @@ struct TestDriver : public SerializerBase, journal::JournalConsumerInterface {
   util::fb2::Fiber snapshot_fb_;
   PrimeTable::Cursor snapshot_cursor_;
   uint32_t journal_id_;
+
+  // subdriver for delayed entries
+  TestDelayDriver delay_driver_;
 
   absl::flat_hash_set<std::string> emitted_baselines_;
   absl::flat_hash_set<std::string> seen_journal_keys_;
@@ -146,7 +241,7 @@ unsigned TestDriver::SerializeBucketLocked(DbIndex db_index, PrimeTable::bucket_
   for (it.AdvanceIfNotOccupied(); !it.is_done(); ++it) {
     DCHECK_EQ(it.GetVersion(), snapshot_version_);
 
-    Serialize(it->first.ToString());
+    Serialize(it.bucket_address(), it->first.ToString());
     ++serialized;
 
     while (absl::Bernoulli(bg_, 0.3)) {
@@ -179,6 +274,12 @@ class SerializerBaseTest : public BaseFamilyTest {
     return res;
   }
 
+  void Change(auto cb) {
+    pp_->at(0)->Await([this, cb] { cb(*driver_); });
+  }
+
+  TestDriver::Params driver_params;
+
  private:
   void StartOnThread() {
     auto* reg = service_->mutable_registry();
@@ -187,7 +288,7 @@ class SerializerBaseTest : public BaseFamilyTest {
     tx->InitByArgs(&namespaces->GetDefaultNamespace(), 0, {});
 
     tx->ScheduleSingleHop([this, reg](Transaction* t, EngineShard* es) {
-      driver_.emplace(&t->GetDbSlice(es->shard_id()), &cntx_, reg);
+      driver_.emplace(driver_params, &t->GetDbSlice(es->shard_id()), &cntx_, reg);
       driver_->Start();
       return OpStatus::OK;
     });
@@ -261,4 +362,38 @@ TEST_F(SerializerBaseTest, NewValues) {
     w.Join();
 }
 
+// During delayed read of a tiered value, it can be come expired.
+// Mass expity of items can cause previously occupied buckets to become empty.
+// Serialization code has many paths that omit empty bucket checks at all -
+// assert those "lost" delayed reads are correctly flushed before new changes
+TEST_F(SerializerBaseTest, DelayedAllDeleted) {
+  // 1-2 ms
+  driver_params = {.delay_prob = 0.9, .delay_lat_us = {1000, 2000}};
+
+  // Fill database with some keys
+  const size_t kKeys = 10000;
+  Run({"DEBUG", "POPULATE", std::to_string(kKeys)});
+
+  // Set short expiry (10ms)
+  for (unsigned i = 0; i < kKeys; i++)
+    Run({"PEXPIRE", absl::StrCat("key:", i), "10"});
+
+  // Start and pause reolution of delayed entries
+  Start();
+  Change([](TestDriver& d) { d.delay_driver_.Pause(); });
+
+  // Let all values to be expire deleted
+  TEST_current_time_ms = TEST_current_time_ms + 100;
+  for (unsigned i = 0; i < kKeys; i++)
+    EXPECT_THAT(Run({"GET", absl::StrCat("key:", i)}), ArgType(RespExpr::NIL));
+
+  // Reallow resolution
+  Change([](TestDriver& d) { d.delay_driver_.Resume(); });
+
+  // Trigger changes with dels
+  for (unsigned i = 0; i < kKeys; i++)
+    Run({"SET", absl::StrCat("key:", i), "V"});
+
+  Finish();
+}
 }  // namespace dfly


### PR DESCRIPTION
Introduce extended serializer base test with more intricate testing scenarions

The TestDriver extends SerializerBase and becomes one more "consumer" akin to a replica or cluster node. However instead of sending the data, it processes it immediately and verifies additional invariants 