### PR TITLE
feat(s3): make AwsS3SnapshotStorage always available; AWS SDK backend optional

### DIFF
--- a/src/server/detail/snapshot_storage.cc
+++ b/src/server/detail/snapshot_storage.cc
@@ -344,12 +344,17 @@ io::Result<std::string, GenericError> GcsSnapshotStorage::LoadPath(string_view d
                        prefix = prefix]() -> io::Result<vector<SnapStat>, GenericError> {
         cloud::GCS gcs(&creds_provider_, ctx_, proactor);
         vector<SnapStat> res;
-        error_code ec =
-            gcs.List(bucket_name, prefix, false, [&res](const cloud::StorageListItem& item) {
-              res.emplace_back(SnapStat{string(item.key), item.mtime_ns});
-            });
-        if (ec)
-          return nonstd::make_unexpected(GenericError(ec, "Failed to list objects"));
+        string cursor;
+        do {
+          error_code ec = gcs.List(
+              bucket_name, prefix, false, 500,
+              [&res](const cloud::StorageListItem& item) {
+                res.emplace_back(string(item.key), item.mtime_ns);
+              },
+              &cursor);
+          if (ec)
+            return nonstd::make_unexpected(GenericError(ec, "Failed to list objects"));
+        } while (!cursor.empty());
         return res;
       });
 
@@ -380,25 +385,30 @@ io::Result<vector<string>, GenericError> GcsSnapshotStorage::ExpandFromPath(
 
   // Find snapshot shard files if we're loading DFS.
   fb2::ProactorBase* proactor = shard_set->pool()->GetNextProactor();
-  auto paths = proactor->Await([&, &bucket_name =
-                                       bucket_name]() -> io::Result<vector<string>, GenericError> {
-    vector<string> res;
-    cloud::GCS gcs(&creds_provider_, ctx_, proactor);
+  auto paths = proactor->Await(
+      [&, &bucket_name = bucket_name]() -> io::Result<vector<string>, GenericError> {
+        vector<string> res;
+        cloud::GCS gcs(&creds_provider_, ctx_, proactor);
+        string cursor;
 
-    error_code ec = gcs.List(bucket_name, prefix, false, [&](const cloud::StorageListItem& item) {
-      std::smatch m;
-      string key{item.key};
-      if (std::regex_match(key, m, re)) {
-        res.push_back(absl::StrCat(kGCSPrefix, bucket_name, "/", item.key));
-      }
-    });
+        do {
+          error_code ec = gcs.List(
+              bucket_name, prefix, false, 500,
+              [&](const cloud::StorageListItem& item) {
+                std::smatch m;
+                string key{item.key};
+                if (std::regex_match(key, m, re)) {
+                  res.push_back(absl::StrCat(kGCSPrefix, bucket_name, "/", item.key));
+                }
+              },
+              &cursor);
 
-    if (ec) {
-      return nonstd::make_unexpected(ec);
-    }
-
-    return res;
-  });
+          if (ec) {
+            return nonstd::make_unexpected(ec);
+          }
+        } while (!cursor.empty());
+        return res;
+      });
 
   if (!paths || paths->empty()) {
     return nonstd::make_unexpected(
@@ -480,12 +490,18 @@ io::Result<std::string, GenericError> AzureSnapshotStorage::LoadPath(string_view
                        prefix = prefix]() -> io::Result<vector<SnapStat>, GenericError> {
         cloud::azure::Storage azure(creds_provider_.get());
         vector<SnapStat> res;
-        error_code ec =
-            azure.List(bucket_name, prefix, false, 500, [&res](const cloud::StorageListItem& item) {
-              res.emplace_back(string(item.key), item.mtime_ns);
-            });
-        if (ec)
-          return nonstd::make_unexpected(GenericError(ec, "Failed to list objects"));
+        string cursor;
+        do {
+          error_code ec = azure.List(
+              bucket_name, prefix, false, 500,
+              [&res](const cloud::StorageListItem& item) {
+                res.emplace_back(string(item.key), item.mtime_ns);
+              },
+              &cursor);
+          if (ec)
+            return nonstd::make_unexpected(GenericError(ec, "Failed to list objects"));
+        } while (!cursor.empty());
+
         return res;
       });
 
@@ -520,19 +536,23 @@ io::Result<vector<string>, GenericError> AzureSnapshotStorage::ExpandFromPath(
       [&, &bucket_name = bucket_name]() -> io::Result<vector<string>, GenericError> {
         vector<string> res;
         cloud::azure::Storage azure(static_cast<cloud::azure::Credentials*>(creds_provider_.get()));
+        string cursor;
+        do {
+          error_code ec = azure.List(
+              bucket_name, prefix, false, 500,
+              [&](const cloud::StorageListItem& item) {
+                std::smatch m;
+                string key{item.key};
+                if (std::regex_match(key, m, re)) {
+                  res.push_back(absl::StrCat(kAzurePrefix, bucket_name, "/", item.key));
+                }
+              },
+              &cursor);
 
-        error_code ec =
-            azure.List(bucket_name, prefix, false, 500, [&](const cloud::StorageListItem& item) {
-              std::smatch m;
-              string key{item.key};
-              if (std::regex_match(key, m, re)) {
-                res.push_back(absl::StrCat(kAzurePrefix, bucket_name, "/", item.key));
-              }
-            });
-
-        if (ec) {
-          return nonstd::make_unexpected(ec);
-        }
+          if (ec) {
+            return nonstd::make_unexpected(ec);
+          }
+        } while (!cursor.empty());
 
         return res;
       });
@@ -767,23 +787,28 @@ AwsS3SnapshotStorage::ListObjects(std::string_view bucket_name, std::string_view
   fb2::ProactorBase* proactor = shard_set->pool()->GetNextProactor();
 
   if (use_helio_) {
-    // TODO: use continuation_token.
     string adjusted_prefix(prefix);
     if (!prefix.empty() && prefix.back() != '/') {
       adjusted_prefix.push_back('/');
     }
+    string cursor;
 
-    error_code ec = proactor->Await([&]() -> error_code {
-      cloud::aws::S3Storage s3(&creds_provider_, ctx_, proactor);
-      return s3.List(bucket_name, adjusted_prefix, false, 1000,
-                     [&keys](const cloud::StorageListItem& item) {
-                       keys.emplace_back(string(item.key), item.mtime_ns);
-                     });
-    });
+    do {
+      error_code ec = proactor->Await([&]() -> error_code {
+        cloud::aws::S3Storage s3(&creds_provider_, ctx_, proactor);
+        return s3.List(
+            bucket_name, adjusted_prefix, false, 1000,
+            [&keys](const cloud::StorageListItem& item) {
+              keys.emplace_back(string(item.key), item.mtime_ns);
+            },
+            &cursor);
+      });
 
-    if (ec) {
-      return nonstd::make_unexpected(GenericError(ec, "Failed list objects in S3 bucket"));
-    }
+      if (ec) {
+        return nonstd::make_unexpected(GenericError(ec, "Failed list objects in S3 bucket"));
+      }
+    } while (!cursor.empty());
+
     return keys;
   }
 

--- a/src/server/detail/snapshot_storage.cc
+++ b/src/server/detail/snapshot_storage.cc
@@ -3,6 +3,8 @@
 
 #include "server/detail/snapshot_storage.h"
 
+#include <absl/base/optimization.h>
+#include <absl/flags/flag.h>
 #include <absl/strings/str_replace.h>
 #include <absl/strings/strip.h>
 
@@ -19,6 +21,8 @@
 #include "util/aws/s3_write_file.h"
 #endif
 
+#include "util/cloud/aws/s3_storage.h"
+
 #ifdef WITH_GCP
 #include "util/cloud/gcp/gcs_file.h"
 #endif
@@ -31,6 +35,11 @@
 #include "util/cloud/azure/creds_provider.h"
 #include "util/cloud/azure/storage.h"
 #include "util/fibers/fiber_file.h"
+
+// Selects between the helio-native S3 client (util::cloud::aws) and aws-sdk-cpp.
+// Only meaningful when WITH_AWS is compiled in; otherwise the helio client is used.
+ABSL_FLAG(bool, s3_use_helio_client, true,
+          "If true, use helio's native S3 client; if false, use aws-sdk-cpp");
 
 namespace rng = std::ranges;
 namespace dfly {
@@ -541,12 +550,34 @@ error_code AzureSnapshotStorage::CheckPath(const std::string& path) {
   return {};
 }
 
-#if defined(WITH_AWS_CLOUD) || defined(WITH_AWS)
-
 AwsS3SnapshotStorage::AwsS3SnapshotStorage(const std::string& endpoint, bool https,
                                            bool ec2_metadata, bool sign_payload) {
 #ifdef WITH_AWS
+  use_helio_ = absl::GetFlag(FLAGS_s3_use_helio_client);
+#else
+  use_helio_ = true;
+#endif
+
+  if (use_helio_) {
+    https_ = https;
+    if (!ec2_metadata) {
+      setenv("AWS_EC2_METADATA_DISABLED", "true", 0);
+    }
+    // AwsCredsProvider reads AWS_S3_ENDPOINT at ServiceEndpoint() time; setting it here lets
+    // callers override the default S3 endpoint (e.g. for MinIO tests).
+    if (!endpoint.empty()) {
+      string endpoint_url = absl::StrCat(https ? "https://" : "http://", endpoint);
+      setenv("AWS_S3_ENDPOINT", endpoint_url.c_str(), 1);
+    }
+    (void)sign_payload;  // Uploads in cloud::aws always use UNSIGNED-PAYLOAD.
+    LOG(INFO) << "Creating AWS S3 client (helio); https=" << std::boolalpha << https
+              << "; endpoint=" << endpoint;
+    return;
+  }
+
+#ifdef WITH_AWS
   shard_set->pool()->GetNextProactor()->Await([&] {
+    util::aws::Init();
     if (!ec2_metadata) {
       setenv("AWS_EC2_METADATA_DISABLED", "true", 0);
     }
@@ -556,8 +587,8 @@ AwsS3SnapshotStorage::AwsS3SnapshotStorage(const std::string& endpoint, bool htt
     s3_conf.checksumConfig.responseChecksumValidation =
         Aws::Client::ResponseChecksumValidation::WHEN_REQUIRED;
 
-    LOG(INFO) << "Creating AWS S3 client; region=" << s3_conf.region << "; https=" << std::boolalpha
-              << https << "; endpoint=" << endpoint;
+    LOG(INFO) << "Creating AWS S3 client (sdk); region=" << s3_conf.region
+              << "; https=" << std::boolalpha << https << "; endpoint=" << endpoint;
     if (!sign_payload) {
       s3_conf.payloadSigningPolicy = Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never;
     }
@@ -572,34 +603,45 @@ AwsS3SnapshotStorage::AwsS3SnapshotStorage(const std::string& endpoint, bool htt
 }
 
 AwsS3SnapshotStorage::~AwsS3SnapshotStorage() {
-#if defined(WITH_AWS_CLOUD) && !defined(WITH_AWS)
-  util::http::TlsClient::FreeContext(ctx_);
-#endif
+  if (ctx_) {
+    util::http::TlsClient::FreeContext(ctx_);
+  }
 }
 
 error_code AwsS3SnapshotStorage::Init(unsigned connect_ms) {
-#if defined(WITH_AWS_CLOUD) && !defined(WITH_AWS)
-  error_code ec = creds_provider_.Init(connect_ms);
-  if (ec)
-    return ec;
-
-  ctx_ = util::http::TlsClient::CreateSslContext();
-  if (!ctx_) {
-    return make_error_code(std::errc::operation_not_permitted);
+  if (!use_helio_) {
+    return {};
   }
-#endif
+
+  RETURN_ERROR(creds_provider_.Init(connect_ms));
+
+  if (https_) {
+    ctx_ = util::http::TlsClient::CreateSslContext();
+    if (!ctx_) {
+      return make_error_code(std::errc::operation_not_permitted);
+    }
+  }
   return {};
 }
 
 io::Result<std::pair<io::Sink*, uint8_t>, GenericError> AwsS3SnapshotStorage::OpenWriteFile(
     const std::string& path) {
-#ifdef WITH_AWS
-  optional<pair<string, string>> bucket_path = GetBucketPath(path);
-  if (!bucket_path) {
-    return nonstd::make_unexpected(GenericError("Invalid S3 path"));
-  }
-  auto [bucket, key] = *bucket_path;
+  if (use_helio_) {
+    auto [bucket, key] = GetBucketPath(path);
+    cloud::aws::WriteFileOptions opts;
+    opts.creds_provider = &creds_provider_;
+    opts.ssl_cntx = ctx_;
 
+    io::Result<io::WriteFile*> dest_res = cloud::aws::OpenWriteFile(bucket, key, opts);
+    if (!dest_res) {
+      return nonstd::make_unexpected(GenericError(dest_res.error(), "Could not open file"));
+    }
+
+    return std::pair<io::Sink*, uint8_t>(*dest_res, FileType::CLOUD);
+  }
+
+#ifdef WITH_AWS
+  auto [bucket, key] = GetBucketPath(path);
   fb2::ProactorBase* proactor = ProactorBase::me();
 
   // We run S3 operations via a temporary fiber to avoid agressive stack consumption.
@@ -619,22 +661,27 @@ io::Result<std::pair<io::Sink*, uint8_t>, GenericError> AwsS3SnapshotStorage::Op
 
   return result;
 #else
-  return nonstd::make_unexpected(GenericError("AWS support not compiled in"));
+  ABSL_UNREACHABLE();
 #endif
 }
 
-io::ReadonlyFileOrError AwsS3SnapshotStorage::OpenReadFile(
-    [[maybe_unused]] const std::string& path) {
-#ifdef WITH_AWS
+io::ReadonlyFileOrError AwsS3SnapshotStorage::OpenReadFile(const std::string& path) {
   VLOG(1) << "Opening S3 read file: " << path;
-  std::optional<std::pair<std::string, std::string>> bucket_path = GetBucketPath(path);
-  if (!bucket_path) {
+  if (!IsS3Path(path))
     return nonstd::make_unexpected(GenericError("Invalid S3 path"));
+
+  auto [bucket, key] = GetBucketPath(path);
+  if (use_helio_) {
+    cloud::aws::ReadFileOptions opts;
+    opts.creds_provider = &creds_provider_;
+    opts.ssl_cntx = ctx_;
+    return cloud::aws::OpenReadFile(bucket, key, opts);
   }
-  auto [bucket, key] = *bucket_path;
+
+#ifdef WITH_AWS
   return new aws::S3ReadFile(bucket, key, s3_);
 #else
-  return nonstd::make_unexpected(GenericError("AWS support not compiled in"));
+  ABSL_UNREACHABLE();
 #endif
 }
 
@@ -719,7 +766,28 @@ AwsS3SnapshotStorage::ListObjects(std::string_view bucket_name, std::string_view
   // We use a random proactor because this function might be called from the main thread.
   fb2::ProactorBase* proactor = shard_set->pool()->GetNextProactor();
 
-#if defined(WITH_AWS)
+  if (use_helio_) {
+    // TODO: use continuation_token.
+    string adjusted_prefix(prefix);
+    if (!prefix.empty() && prefix.back() != '/') {
+      adjusted_prefix.push_back('/');
+    }
+
+    error_code ec = proactor->Await([&]() -> error_code {
+      cloud::aws::S3Storage s3(&creds_provider_, ctx_, proactor);
+      return s3.List(bucket_name, adjusted_prefix, false, 1000,
+                     [&keys](const cloud::StorageListItem& item) {
+                       keys.emplace_back(string(item.key), item.mtime_ns);
+                     });
+    });
+
+    if (ec) {
+      return nonstd::make_unexpected(GenericError(ec, "Failed list objects in S3 bucket"));
+    }
+    return keys;
+  }
+
+#ifdef WITH_AWS
   do {
     Aws::S3::Model::ListObjectsV2Request request;
     request.SetBucket(std::string(bucket_name));
@@ -775,30 +843,11 @@ AwsS3SnapshotStorage::ListObjects(std::string_view bucket_name, std::string_view
                                                   outcome.GetError().GetExceptionName()});
     }
   } while (!continuation_token.empty());
-#elif defined(WITH_AWS_CLOUD)
-  string adjusted_prefix;
-  if (!prefix.empty()) {
-    adjusted_prefix = prefix.back() == '/' ? prefix : absl::StrCat(prefix, "/");
-  }
-
-  error_code ec = proactor->Await([&]() -> error_code {
-    cloud::aws::S3Storage s3(&creds_provider_, ctx_, proactor);
-    return s3.List(bucket_name, adjusted_prefix, false, 1000,
-                   [&keys](const cloud::StorageListItem& item) {
-                     keys.emplace_back(string(item.key), item.mtime_ns);
-                   });
-  });
-
-  if (ec) {
-    return nonstd::make_unexpected(GenericError(ec, "Failed list objects in S3 bucket"));
-  }
-#else
-  return nonstd::make_unexpected(GenericError("AWS support not compiled in"));
-#endif
   return keys;
+#else
+  ABSL_UNREACHABLE();
+#endif
 }
-
-#endif  // WITH_AWS_CLOUD || WITH_AWS
 
 #ifdef __linux__
 io::Result<size_t> LinuxWriteWrapper::WriteSome(const iovec* v, uint32_t len) {

--- a/src/server/detail/snapshot_storage.h
+++ b/src/server/detail/snapshot_storage.h
@@ -7,11 +7,8 @@
 #include <aws/s3/S3Client.h>
 #endif
 
-#ifdef WITH_AWS_CLOUD
 #include "util/cloud/aws/aws_creds_provider.h"
 #include "util/cloud/aws/s3_storage.h"
-#endif
-
 #include "util/cloud/azure/creds_provider.h"
 
 #ifdef WITH_GCP
@@ -169,7 +166,6 @@ class AzureSnapshotStorage : public SnapshotStorage {
   SSL_CTX* ctx_ = NULL;
 };
 
-#if defined(WITH_AWS_CLOUD) || defined(WITH_AWS)
 class AwsS3SnapshotStorage : public SnapshotStorage {
  public:
   AwsS3SnapshotStorage(const std::string& endpoint, bool https, bool ec2_metadata,
@@ -200,15 +196,17 @@ class AwsS3SnapshotStorage : public SnapshotStorage {
   io::Result<std::vector<SnapStat>, GenericError> ListObjects(std::string_view bucket_name,
                                                               std::string_view prefix);
 
+  // Chosen at construction: true -> helio cloud::aws client; false -> aws-sdk-cpp.
+  // Forced to helio when WITH_AWS is not compiled in.
+  bool use_helio_;
+
 #ifdef WITH_AWS
   std::shared_ptr<Aws::S3::S3Client> s3_;
-#elif WITH_AWS_CLOUD
+#endif
   util::cloud::aws::AwsCredsProvider creds_provider_;
   SSL_CTX* ctx_ = nullptr;
-#endif
+  bool https_ = true;
 };
-
-#endif
 
 #ifdef __linux__
 // takes ownership over the file.

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -300,10 +300,6 @@ string UnknownCmd(string cmd, CmdArgList args) {
 
 std::shared_ptr<detail::SnapshotStorage> CreateCloudSnapshotStorage(std::string_view uri) {
   if (detail::IsS3Path(uri)) {
-#if defined(WITH_AWS) || defined(WITH_AWS_CLOUD)
-#ifdef WITH_AWS
-    shard_set->pool()->GetNextProactor()->Await([&] { util::aws::Init(); });
-#endif
     auto aws = std::make_shared<detail::AwsS3SnapshotStorage>(
         absl::GetFlag(FLAGS_s3_endpoint), absl::GetFlag(FLAGS_s3_use_https),
         absl::GetFlag(FLAGS_s3_ec2_metadata), absl::GetFlag(FLAGS_s3_sign_payload));
@@ -314,10 +310,6 @@ std::shared_ptr<detail::SnapshotStorage> CreateCloudSnapshotStorage(std::string_
       exit(1);
     }
     return aws;
-#else
-    LOG(ERROR) << "Compiled without AWS support";
-    exit(1);
-#endif
   } else if (detail::IsGCSPath(uri)) {
 #ifdef WITH_GCP
     auto gcs = std::make_shared<detail::GcsSnapshotStorage>();
@@ -2933,12 +2925,7 @@ std::optional<SaveCmdOptions> ServerFamily::GetSaveCmdOpts(CmdArgList args,
 
   if (args.size() >= 2) {
     if (detail::IsS3Path(ArgS(args, 1))) {
-#ifdef WITH_AWS
       save_cmd_opts.cloud_uri = ArgS(args, 1);
-#else
-      LOG(ERROR) << "Compiled without AWS support";
-      exit(1);
-#endif
     } else if (detail::IsGCSPath(ArgS(args, 1)) || detail::IsAzurePath(ArgS(args, 1))) {
       save_cmd_opts.cloud_uri = ArgS(args, 1);
     } else {

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -297,10 +297,6 @@ string UnknownCmd(string cmd, CmdArgList args) {
 
 std::shared_ptr<detail::SnapshotStorage> CreateCloudSnapshotStorage(std::string_view uri) {
   if (detail::IsS3Path(uri)) {
-#if defined(WITH_AWS) || defined(WITH_AWS_CLOUD)
-#ifdef WITH_AWS
-    shard_set->pool()->GetNextProactor()->Await([&] { util::aws::Init(); });
-#endif
     auto aws = std::make_shared<detail::AwsS3SnapshotStorage>(
         absl::GetFlag(FLAGS_s3_endpoint), absl::GetFlag(FLAGS_s3_use_https),
         absl::GetFlag(FLAGS_s3_ec2_metadata), absl::GetFlag(FLAGS_s3_sign_payload));
@@ -311,10 +307,6 @@ std::shared_ptr<detail::SnapshotStorage> CreateCloudSnapshotStorage(std::string_
       exit(1);
     }
     return aws;
-#else
-    LOG(ERROR) << "Compiled without AWS support";
-    exit(1);
-#endif
   } else if (detail::IsGCSPath(uri)) {
 #ifdef WITH_GCP
     auto gcs = std::make_shared<detail::GcsSnapshotStorage>();
@@ -2899,12 +2891,7 @@ std::optional<SaveCmdOptions> ServerFamily::GetSaveCmdOpts(CmdArgList args,
 
   if (args.size() >= 2) {
     if (detail::IsS3Path(ArgS(args, 1))) {
-#ifdef WITH_AWS
       save_cmd_opts.cloud_uri = ArgS(args, 1);
-#else
-      LOG(ERROR) << "Compiled without AWS support";
-      exit(1);
-#endif
     } else if (detail::IsGCSPath(ArgS(args, 1)) || detail::IsAzurePath(ArgS(args, 1))) {
       save_cmd_opts.cloud_uri = ArgS(args, 1);
     } else {


### PR DESCRIPTION
## Summary
- `AwsS3SnapshotStorage` is now always compiled — it uses helio's native `util::cloud::aws` client by default.
- The aws-sdk-cpp backend stays gated on `WITH_AWS` and is selected at runtime via `--s3_use_helio_client=false` (default `true`). When `WITH_AWS` is off the flag is forced to `true` and the SDK code is elided.

## Details
- `AwsS3SnapshotStorage` holds the helio members unconditionally (`creds_provider_`, `ctx_`, `https_`) plus an optional `s3_` SDK client under `#ifdef WITH_AWS`, and a `use_helio_` bool captured in the ctor.
- Every method (ctor, dtor, `Init`, `OpenReadFile`, `OpenWriteFile`, `ListObjects`) dispatches on `use_helio_`. Unreachable fallthroughs in the `!WITH_AWS` case use `ABSL_UNREACHABLE()`.
- Helio path forwards `--s3_endpoint` + `--s3_use_https` to `AwsCredsProvider::ServiceEndpoint` via the `AWS_S3_ENDPOINT` env var — keeps MinIO tests working. SSL ctx only created when `https=true`.
- `util::aws::Init()` moved from `server_family.cc` into the SDK branch of the storage ctor.
- `server_family.cc`: the `WITH_AWS` / `WITH_AWS_CLOUD` guards around S3 snapshot creation and `SAVE s3://...` parsing are gone — S3 is always available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)