### PR TITLE
feat(search): add WITHSCORES, SCORER, ADDSCORES command support for FT.SEARCH/FT.AGGREGATE

### DIFF
--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -904,7 +904,7 @@ SearchResult ShardDocIndex::Search(const OpArgs& op_args, const SearchParams& pa
 
     // If we sorted with knn_scores present, rearrange them
     if (!sort_scores.empty() && !result.knn_scores.empty()) {
-      unordered_map<DocId, size_t> score_lookup(result.knn_scores.begin(), result.knn_scores.end());
+      unordered_map<DocId, float> score_lookup(result.knn_scores.begin(), result.knn_scores.end());
       for (size_t i = 0; i < min(limit, result.ids.size()); i++)
         result.knn_scores[i] = {result.ids[i], score_lookup[result.ids[i]]};
     }
@@ -913,6 +913,11 @@ SearchResult ShardDocIndex::Search(const OpArgs& op_args, const SearchParams& pa
   // Cut off unnecessary items
   result.ids.resize(min(result.ids.size(), limit));
 
+  // Build text score lookup (DocId -> score) if available
+  absl::flat_hash_map<search::DocId, float> text_score_map;
+  for (const auto& [doc, score] : result.text_scores)
+    text_score_map[doc] = score;
+
   // Serialize documents
   vector<SerializedSearchDoc> out;
   out.reserve(min(limit, result.ids.size()));
@@ -920,12 +925,15 @@ SearchResult ShardDocIndex::Search(const OpArgs& op_args, const SearchParams& pa
   size_t expired_count = 0;
   for (size_t i = 0; i < result.ids.size(); i++) {
     float knn_score = result.knn_scores.empty() ? 0 : result.knn_scores[i].second;
+    float text_score = 0;
+    if (auto it = text_score_map.find(result.ids[i]); it != text_score_map.end())
+      text_score = it->second;
     auto sort_score = sort_scores.empty() ? std::monostate{} : std::move(sort_scores[i]);
 
     // Don't load entry if we need only its key. Ignore expiration.
     if (params.IdsOnly()) {
       string_view key = key_index_.Get(result.ids[i]);
-      out.push_back({result.ids[i], string{key}, {}, knn_score, sort_score});
+      out.push_back({result.ids[i], string{key}, {}, knn_score, text_score, sort_score});
       continue;
     }
 
@@ -944,7 +952,8 @@ SearchResult ShardDocIndex::Search(const OpArgs& op_args, const SearchParams& pa
 
     auto more_fields = accessor->Serialize(base_->schema, return_fields);
     fields.insert(make_move_iterator(more_fields.begin()), make_move_iterator(more_fields.end()));
-    out.push_back({result.ids[i], string{key}, std::move(fields), knn_score, sort_score});
+    out.push_back(
+        {result.ids[i], string{key}, std::move(fields), knn_score, text_score, sort_score});
   }
 
   return {result.total - expired_count, std::move(out), std::move(result.profile)};
@@ -969,13 +978,22 @@ vector<SearchDocData> ShardDocIndex::SearchForAggregator(
       knn_score_map[doc_id] = dist;
   }
 
-  return LoadDocEntriesWithScores(op_args, params, search_results.ids, score_alias, knn_score_map);
+  // Build text score lookup for ADDSCORES injection (keyed by DocId, safe across expired docs)
+  absl::flat_hash_map<DocId, float> text_score_map;
+  if (params.add_scores && !search_results.text_scores.empty()) {
+    text_score_map.reserve(search_results.text_scores.size());
+    for (auto& [doc_id, score] : search_results.text_scores)
+      text_score_map[doc_id] = score;
+  }
+
+  return LoadDocEntriesWithScores(op_args, params, search_results.ids, score_alias, knn_score_map,
+                                  text_score_map);
 }
 
 vector<SearchDocData> ShardDocIndex::LoadHnswRangeDocsForAggregator(
     const OpArgs& op_args, const AggregateParams& params,
-    absl::Span<const std::pair<search::DocId, float>> doc_distances,
-    std::string_view score_alias) const {
+    absl::Span<const std::pair<search::DocId, float>> doc_distances, std::string_view score_alias,
+    const absl::flat_hash_map<search::DocId, float>& text_score_map) const {
   vector<DocId> ids;
   absl::flat_hash_map<DocId, float> score_map;
   ids.reserve(doc_distances.size());
@@ -984,13 +1002,13 @@ vector<SearchDocData> ShardDocIndex::LoadHnswRangeDocsForAggregator(
     ids.push_back(doc_id);
     score_map[doc_id] = dist;
   }
-  return LoadDocEntriesWithScores(op_args, params, ids, score_alias, score_map);
+  return LoadDocEntriesWithScores(op_args, params, ids, score_alias, score_map, text_score_map);
 }
 
 vector<SearchDocData> ShardDocIndex::LoadDocEntriesWithScores(
     const OpArgs& op_args, const AggregateParams& params, absl::Span<const search::DocId> ids,
-    std::string_view score_alias,
-    const absl::flat_hash_map<search::DocId, float>& score_map) const {
+    std::string_view score_alias, const absl::flat_hash_map<search::DocId, float>& score_map,
+    const absl::flat_hash_map<search::DocId, float>& text_score_map) const {
   auto [fields_to_load, sort_indicies] =
       PreprocessAggregateFields(base_->schema, params, params.load_fields);
 
@@ -1016,6 +1034,11 @@ vector<SearchDocData> ShardDocIndex::LoadDocEntriesWithScores(
       auto it = score_map.find(doc);
       if (it != score_map.end())
         out.back()[string{score_alias}] = static_cast<double>(it->second);
+    }
+
+    if (!text_score_map.empty()) {
+      if (auto it = text_score_map.find(doc); it != text_score_map.end())
+        out.back()["__score"] = static_cast<double>(it->second);
     }
   }
   return out;

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -366,7 +366,7 @@ class ShardDocIndex {
   std::vector<SearchDocData> LoadHnswRangeDocsForAggregator(
       const OpArgs& op_args, const AggregateParams& params,
       absl::Span<const std::pair<search::DocId, float>> doc_distances, std::string_view score_alias,
-      const absl::flat_hash_map<search::DocId, float>& text_score_map = {}) const;
+      const absl::flat_hash_map<search::DocId, float>& text_score_map) const;
 
   // Methods needed for join operation
   join::Vector<join::OwnedEntry> PreagregateDataForJoin(
@@ -481,7 +481,7 @@ class ShardDocIndex {
   std::vector<SearchDocData> LoadDocEntriesWithScores(
       const OpArgs& op_args, const AggregateParams& params, absl::Span<const search::DocId> ids,
       std::string_view score_alias, const absl::flat_hash_map<search::DocId, float>& score_map,
-      const absl::flat_hash_map<search::DocId, float>& text_score_map = {}) const;
+      const absl::flat_hash_map<search::DocId, float>& text_score_map) const;
 
   // Clears internal data. Traverses all matching documents and assigns ids.
   void Rebuild(const OpArgs& op_args, PMR_NS::memory_resource* mr, bool is_restored = false);

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -44,7 +44,8 @@ struct SerializedSearchDoc {
   search::DocId id;
   std::string key;
   SearchDocData values;
-  float knn_score;
+  float knn_score = 0;
+  float text_score = 0;
   search::SortableValue sort_score;
 };
 
@@ -129,6 +130,9 @@ struct SearchParams {
 
   search::QueryParams query_params;
 
+  bool with_scores = false;                  // WITHSCORES flag
+  std::optional<search::ScorerType> scorer;  // SCORER parameter
+
   bool ShouldReturnAllFields() const {
     return !return_fields.has_value();
   }
@@ -191,6 +195,9 @@ struct AggregateParams {
 
   std::optional<std::vector<FieldReference>> load_fields;
   std::vector<aggregate::AggregationStep> steps;
+
+  bool add_scores = false;                   // ADDSCORES flag
+  std::optional<search::ScorerType> scorer;  // SCORER parameter
 };
 
 // Stores basic info about a document index.
@@ -358,8 +365,8 @@ class ShardDocIndex {
   // from the global HNSW index rather than a per-shard search.
   std::vector<SearchDocData> LoadHnswRangeDocsForAggregator(
       const OpArgs& op_args, const AggregateParams& params,
-      absl::Span<const std::pair<search::DocId, float>> doc_distances,
-      std::string_view score_alias) const;
+      absl::Span<const std::pair<search::DocId, float>> doc_distances, std::string_view score_alias,
+      const absl::flat_hash_map<search::DocId, float>& text_score_map = {}) const;
 
   // Methods needed for join operation
   join::Vector<join::OwnedEntry> PreagregateDataForJoin(
@@ -473,8 +480,8 @@ class ShardDocIndex {
   // Loads, serializes, and (optionally) injects the YIELD_DISTANCE_AS alias for each doc.
   std::vector<SearchDocData> LoadDocEntriesWithScores(
       const OpArgs& op_args, const AggregateParams& params, absl::Span<const search::DocId> ids,
-      std::string_view score_alias,
-      const absl::flat_hash_map<search::DocId, float>& score_map) const;
+      std::string_view score_alias, const absl::flat_hash_map<search::DocId, float>& score_map,
+      const absl::flat_hash_map<search::DocId, float>& text_score_map = {}) const;
 
   // Clears internal data. Traverses all matching documents and assigns ids.
   void Rebuild(const OpArgs& op_args, PMR_NS::memory_resource* mr, bool is_restored = false);

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -2217,6 +2217,11 @@ void CmdFtAggregate(CmdArgList args, CommandContext* cmd_cntx) {
 
     auto [knn_node, knn] = TryPopHnswKnnNode(search_algo, params->index);
 
+    // Per-shard text scores from prefilter for __score injection in ADDSCORES mode.
+    // Indexed by shard_id because local DocIds are not unique across shards.
+    // Always allocated to shard_set->size() so the callback can index unconditionally.
+    std::vector<absl::flat_hash_map<search::DocId, float>> prefilter_text_scores(shard_set->size());
+
     // Build a shard-load callback for HNSW results (KNN or VECTOR_RANGE).
     // The returned lambda captures shard_docs and text_scores by const-reference —
     // the caller must ensure they outlive the ScheduleSingleHop / Execute call.
@@ -2229,19 +2234,13 @@ void CmdFtAggregate(CmdArgList args, CommandContext* cmd_cntx) {
             auto* index = es->search_indices()->GetIndex(params->index);
             if (!index || shard_docs[es->shard_id()].empty())
               return OpStatus::OK;
-            static const absl::flat_hash_map<search::DocId, float> kEmptyScores;
-            const auto& shard_text_scores =
-                text_scores.empty() ? kEmptyScores : text_scores[es->shard_id()];
+            DCHECK_LT(es->shard_id(), text_scores.size());
             query_results[es->shard_id()] = index->LoadHnswRangeDocsForAggregator(
                 t->GetOpArgs(es), params.value(), shard_docs[es->shard_id()], score_alias,
-                shard_text_scores);
+                text_scores[es->shard_id()]);
             return OpStatus::OK;
           };
         };
-
-    // Per-shard text scores from prefilter for __score injection in ADDSCORES mode.
-    // Indexed by shard_id because local DocIds are not unique across shards.
-    std::vector<absl::flat_hash_map<search::DocId, float>> prefilter_text_scores(shard_set->size());
 
     if (knn) {
       auto hnsw_index = GlobalHnswIndexRegistry::Instance().Get(params->index, knn->field);
@@ -2306,7 +2305,8 @@ void CmdFtAggregate(CmdArgList args, CommandContext* cmd_cntx) {
 
       auto shard_docs = GroupByShardId(range_results, shard_set->size());
 
-      cmd_cntx->tx()->ScheduleSingleHop(make_load_cb(shard_docs, hnsw_range->score_alias, {}));
+      cmd_cntx->tx()->ScheduleSingleHop(
+          make_load_cb(shard_docs, hnsw_range->score_alias, prefilter_text_scores));
     } else {
       cmd_cntx->tx()->ScheduleSingleHop([&](Transaction* t, EngineShard* es) {
         if (auto* index = es->search_indices()->GetIndex(params->index); index) {

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -11,6 +11,7 @@
 #include <absl/strings/str_join.h>
 #include <absl/strings/str_split.h>
 
+#include <algorithm>
 #include <atomic>
 #include <variant>
 #include <vector>
@@ -18,6 +19,7 @@
 #include "base/logging.h"
 #include "core/search/indices.h"
 #include "core/search/query_driver.h"
+#include "core/search/scoring.h"
 #include "core/search/search.h"
 #include "core/search/vector_utils.h"
 #include "facade/cmd_arg_parser.h"
@@ -440,6 +442,12 @@ search::QueryParams ParseQueryParams(CmdArgParser* parser) {
   return params;
 }
 
+std::optional<search::ScorerType> ParseScorerName(std::string_view name) {
+  if (absl::EqualsIgnoreCase(name, "BM25STD"))
+    return search::ScorerType::BM25STD;
+  return std::nullopt;
+}
+
 ParseResult<SearchParams> ParseSearchParams(CmdArgParser* parser) {
   SearchParams params;
 
@@ -477,6 +485,16 @@ ParseResult<SearchParams> ParseSearchParams(CmdArgParser* parser) {
       ParseNumericFilter(parser, &params);
     } else if (parser->Check("WITHSORTKEYS")) {
       params.with_sortkeys = true;
+    } else if (parser->Check("WITHSCORES")) {
+      params.with_scores = true;
+    } else if (parser->Check("SCORER")) {
+      auto scorer_name = parser->Next();
+      auto scorer = ParseScorerName(scorer_name);
+      if (!scorer)
+        return CreateSyntaxError(absl::StrCat("No such scorer: ", scorer_name));
+      params.scorer = *scorer;
+    } else if (parser->Check("DIALECT")) {
+      parser->Skip(1);  // Accepted and ignored — DF always behaves as dialect 2
     } else {
       // Unsupported parameters are ignored for now
       parser->Skip(1);
@@ -728,6 +746,26 @@ ParseResult<AggregateParams> ParseAggregatorParams(CmdArgParser* parser) {
             absl::StrCat("APPLY expression error: ", std::get<std::string>(step_or_err)));
       }
       params.steps.push_back(std::move(std::get<aggregate::AggregationStep>(step_or_err)));
+      continue;
+    }
+
+    // SCORER, ADDSCORES, WITHSCORES can appear anywhere in the command
+    if (parser->Check("SCORER")) {
+      auto scorer_name = parser->Next();
+      auto scorer = ParseScorerName(scorer_name);
+      if (!scorer)
+        return CreateSyntaxError(absl::StrCat("No such scorer: ", scorer_name));
+      params.scorer = *scorer;
+      continue;
+    }
+
+    if (parser->Check("ADDSCORES")) {
+      params.add_scores = true;
+      continue;
+    }
+
+    if (parser->Check("WITHSCORES")) {
+      // Silently ignored for FT.AGGREGATE (use ADDSCORES instead)
       continue;
     }
 
@@ -1089,7 +1127,8 @@ void SearchReply(const SearchParams& params,
 
   const bool reply_with_ids_only = params.IdsOnly();
   auto* rb = static_cast<RedisReplyBuilder*>(builder);
-  const size_t items_per_field = (reply_with_ids_only ? 1 : 2) + params.with_sortkeys;
+  const size_t items_per_field =
+      (reply_with_ids_only ? 1 : 2) + params.with_sortkeys + params.with_scores;
   RedisReplyBuilder::ArrayScope scope{rb, limit * items_per_field + 1};
 
   Overloaded sortable_value_sender{
@@ -1101,6 +1140,9 @@ void SearchReply(const SearchParams& params,
   rb->SendLong(total_hits);
   for (size_t i = offset; i < end; i++) {
     rb->SendBulkString(docs[i]->key);
+    if (params.with_scores) {
+      rb->SendBulkString(absl::StrCat(docs[i]->text_score));
+    }
     if (params.with_sortkeys) {
       visit(sortable_value_sender, docs[i]->sort_score);
     }
@@ -1874,6 +1916,9 @@ void CmdFtSearch(CmdArgList args, CommandContext* cmd_cntx) {
 
   vector<SearchResult> css_docs;
   if (absl::GetFlag(FLAGS_cluster_search) && !is_cross_shard && IsClusterEnabled()) {
+    if (params->with_scores || params->scorer) {
+      return builder->SendError("WITHSCORES/SCORER is not yet supported in cluster search mode");
+    }
     std::string args_str = absl::StrJoin(args.subspan(2), " ");
 
     css_docs = FtSearchCSS(index_name, query_str, args_str, *params);
@@ -1882,6 +1927,12 @@ void CmdFtSearch(CmdArgList args, CommandContext* cmd_cntx) {
   search::SearchAlgorithm search_algo;
   if (!search_algo.Init(query_str, &params->query_params, &params->optional_filters))
     return builder->SendError("Query syntax error");
+
+  // Enable scorer: explicit SCORER param, or default BM25STD when WITHSCORES is set
+  if (params->scorer)
+    search_algo.SetScorer(*params->scorer);
+  else if (params->with_scores)
+    search_algo.SetScorer(search::ScorerType::BM25STD);
 
   auto [knn_node, knn] = TryPopHnswKnnNode(search_algo, index_name);
 
@@ -1974,6 +2025,12 @@ void CmdFtProfile(CmdArgList args, CommandContext* cmd_cntx) {
   search::SearchAlgorithm search_algo;
   if (!search_algo.Init(query_str, &params->query_params))
     return cmd_cntx->SendError("query syntax error");
+
+  // Enable scorer: explicit SCORER param, or default BM25STD when WITHSCORES is set
+  if (params->scorer)
+    search_algo.SetScorer(*params->scorer);
+  else if (params->with_scores)
+    search_algo.SetScorer(search::ScorerType::BM25STD);
 
   search_algo.EnableProfiling();
 
@@ -2147,6 +2204,12 @@ void CmdFtAggregate(CmdArgList args, CommandContext* cmd_cntx) {
     if (!search_algo.Init(params->query, &params->params))
       return builder->SendError("Query syntax error");
 
+    // Enable scorer: explicit SCORER param, or default BM25STD when ADDSCORES is set
+    if (params->scorer)
+      search_algo.SetScorer(*params->scorer);
+    else if (params->add_scores)
+      search_algo.SetScorer(search::ScorerType::BM25STD);
+
     using ResultContainer = decltype(declval<ShardDocIndex>().SearchForAggregator(
         declval<OpArgs>(), params.value(), &search_algo));
 
@@ -2155,21 +2218,30 @@ void CmdFtAggregate(CmdArgList args, CommandContext* cmd_cntx) {
     auto [knn_node, knn] = TryPopHnswKnnNode(search_algo, params->index);
 
     // Build a shard-load callback for HNSW results (KNN or VECTOR_RANGE).
-    // The returned lambda captures shard_docs by const-reference — the caller must ensure
-    // it outlives the ScheduleSingleHop / Execute call.
+    // The returned lambda captures shard_docs and text_scores by const-reference —
+    // the caller must ensure they outlive the ScheduleSingleHop / Execute call.
     auto make_load_cb =
         [&](const std::vector<std::vector<std::pair<search::DocId, float>>>& shard_docs,
-            std::string_view score_alias) {
-          return
-              [&query_results, &params, &shard_docs, score_alias](Transaction* t, EngineShard* es) {
-                auto* index = es->search_indices()->GetIndex(params->index);
-                if (!index || shard_docs[es->shard_id()].empty())
-                  return OpStatus::OK;
-                query_results[es->shard_id()] = index->LoadHnswRangeDocsForAggregator(
-                    t->GetOpArgs(es), params.value(), shard_docs[es->shard_id()], score_alias);
-                return OpStatus::OK;
-              };
+            std::string_view score_alias,
+            const std::vector<absl::flat_hash_map<search::DocId, float>>& text_scores) {
+          return [&query_results, &params, &shard_docs, score_alias, &text_scores](
+                     Transaction* t, EngineShard* es) {
+            auto* index = es->search_indices()->GetIndex(params->index);
+            if (!index || shard_docs[es->shard_id()].empty())
+              return OpStatus::OK;
+            static const absl::flat_hash_map<search::DocId, float> kEmptyScores;
+            const auto& shard_text_scores =
+                text_scores.empty() ? kEmptyScores : text_scores[es->shard_id()];
+            query_results[es->shard_id()] = index->LoadHnswRangeDocsForAggregator(
+                t->GetOpArgs(es), params.value(), shard_docs[es->shard_id()], score_alias,
+                shard_text_scores);
+            return OpStatus::OK;
+          };
         };
+
+    // Per-shard text scores from prefilter for __score injection in ADDSCORES mode.
+    // Indexed by shard_id because local DocIds are not unique across shards.
+    std::vector<absl::flat_hash_map<search::DocId, float>> prefilter_text_scores(shard_set->size());
 
     if (knn) {
       auto hnsw_index = GlobalHnswIndexRegistry::Instance().Get(params->index, knn->field);
@@ -2196,6 +2268,15 @@ void CmdFtAggregate(CmdArgList args, CommandContext* cmd_cntx) {
             },
             false);
         prefilter_global_ids = CollectPrefilterGlobalIds(prefilter_docs);
+
+        // Collect text scores per-shard from prefilter results for __score injection
+        if (params->add_scores) {
+          for (size_t shard_id = 0; shard_id < prefilter_docs.size(); shard_id++) {
+            for (const auto& doc : prefilter_docs[shard_id].docs) {
+              prefilter_text_scores[shard_id][doc.id] = doc.text_score;
+            }
+          }
+        }
       }
 
       // Run global HNSW KNN search
@@ -2207,10 +2288,11 @@ void CmdFtAggregate(CmdArgList args, CommandContext* cmd_cntx) {
       auto shard_docs = GroupByShardId(knn_results, shard_set->size());
 
       if (knn_has_prefilter) {
-        cmd_cntx->tx()->Execute(make_load_cb(shard_docs, knn->score_alias),
+        cmd_cntx->tx()->Execute(make_load_cb(shard_docs, knn->score_alias, prefilter_text_scores),
                                 true);  // finalize multi-hop
       } else {
-        cmd_cntx->tx()->ScheduleSingleHop(make_load_cb(shard_docs, knn->score_alias));
+        cmd_cntx->tx()->ScheduleSingleHop(
+            make_load_cb(shard_docs, knn->score_alias, prefilter_text_scores));
       }
     } else if (auto* vr = search_algo.GetVectorRangeNode();
                vr && GlobalHnswIndexRegistry::Instance().Exist(params->index, vr->field)) {
@@ -2224,7 +2306,7 @@ void CmdFtAggregate(CmdArgList args, CommandContext* cmd_cntx) {
 
       auto shard_docs = GroupByShardId(range_results, shard_set->size());
 
-      cmd_cntx->tx()->ScheduleSingleHop(make_load_cb(shard_docs, hnsw_range->score_alias));
+      cmd_cntx->tx()->ScheduleSingleHop(make_load_cb(shard_docs, hnsw_range->score_alias, {}));
     } else {
       cmd_cntx->tx()->ScheduleSingleHop([&](Transaction* t, EngineShard* es) {
         if (auto* index = es->search_indices()->GetIndex(params->index); index) {
@@ -2343,6 +2425,13 @@ void CmdFtAggregate(CmdArgList args, CommandContext* cmd_cntx) {
     for (const auto& field : params->load_fields.value()) {
       load_fields.push_back(field.OutputName());
     }
+  }
+
+  // Auto-add __score to visible fields when ADDSCORES is set
+  static constexpr std::string_view kScoreField = "__score";
+  if (params->add_scores &&
+      std::find(load_fields.begin(), load_fields.end(), kScoreField) == load_fields.end()) {
+    load_fields.push_back(kScoreField);
   }
 
   auto agg_results = aggregate::Process(std::move(values), load_fields, params->steps);

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -14,7 +14,6 @@
 #include "base/gtest.h"
 #include "base/logging.h"
 #include "core/detail/gen_utils.h"
-#include "core/search/stateless_allocator.h"
 #include "facade/error.h"
 #include "facade/facade_test.h"
 #include "facade/resp_parser.h"
@@ -347,10 +346,11 @@ TEST_F(SearchFamilyTest, Stats) {
   EXPECT_EQ(metrics.search_stats.num_indices, 2);
   EXPECT_EQ(metrics.search_stats.num_entries, 50 * 2);
 
+  // Per-entry overhead includes: rax nodes, block list headers, CSS varint-encoded diffs + freqs,
+  // and per-field BM25 stats (field_doc_lengths_ vector, counters).
   size_t expected_usage = 2 * (50 + 3 /* number of distinct words*/) * (24 + 48 /* kv size */) +
                           50 * 2 * 1 /* posting list entries */;
   EXPECT_GE(metrics.search_stats.used_memory, expected_usage);
-  // Upper bound accounts for index data + DocKeyIndex + FieldIndices overhead
   EXPECT_LE(metrics.search_stats.used_memory, 4 * expected_usage);
 }
 
@@ -2366,11 +2366,11 @@ TEST_F(SearchFamilyTest, PrefixSearchWithSynonyms) {
 }
 
 TEST_F(SearchFamilyTest, SearchSortByOptionNonSortableFieldJson) {
-  auto resp = Run({"FT.CREATE", "index", "ON", "JSON", "SCHEMA", "$.text", "AS", "text", "TEXT"});
-  EXPECT_EQ(resp, "OK");
-
   Run({"JSON.SET", "json1", "$", R"({"text":"2"})"});
   Run({"JSON.SET", "json2", "$", R"({"text":"1"})"});
+
+  auto resp = Run({"FT.CREATE", "index", "ON", "JSON", "SCHEMA", "$.text", "AS", "text", "TEXT"});
+  EXPECT_EQ(resp, "OK");
 
   auto expect_expr = [](std::string_view text_field) {
     return IsArray(2, "json2", IsMap(text_field, "1", "$", R"({"text":"1"})"), "json1",
@@ -5396,6 +5396,211 @@ TEST_F(SearchFamilyTest, InfoIndexDefaultStopwordsOmitted) {
 
   // Collection size is 7 (no stopwords_list field).
   EXPECT_THAT(info, IsArray(_, _, _, _, _, _, _, _, "num_docs", _, "indexing", _, _, _));
+}
+
+// Verify that BM25 text scores survive document expiration correctly:
+// expired docs must not cause score injection into wrong documents.
+TEST_F(SearchFamilyTest, SearchWithScoresExpiredDoc) {
+  EXPECT_EQ(Run({"ft.create", "i1", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "title", "TEXT"}),
+            "OK");
+
+  Run({"hset", "d:1", "title", "hello world hello"});
+  Run({"hset", "d:2", "title", "hello there"});
+  Run({"hset", "d:3", "title", "hello universe"});
+  Run({"pexpire", "d:2", "50"});
+
+  // All 3 docs match before expiry
+  auto resp = Run({"ft.search", "i1", "hello", "WITHSCORES"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  auto results = resp.GetVec();
+  // With WITHSCORES: [total, key, score, fields, key, score, fields, ...]
+  // Each doc takes 3 slots (key + score + field-array), plus 1 for total
+  EXPECT_GE(results.size(), 1 + 3 * 3u);
+
+  // Wait for d:2 to expire
+  AdvanceTime(60);
+  ThisFiber::SleepFor(5ms);
+
+  // Now only d:1 and d:3 should match; scores must be positive and assigned to correct docs
+  resp = Run({"ft.search", "i1", "hello", "WITHSCORES"});
+  results = resp.GetVec();
+  ASSERT_GE(results.size(), 1 + 3 * 2u);
+
+  // First element is total hits count
+  EXPECT_THAT(results[0], IntArg(2));
+
+  // Verify each returned doc has a positive score (not 0, not misassigned)
+  for (size_t i = 1; i < results.size(); i += 3) {
+    std::string key = results[i].GetString();
+    std::string score_str = results[i + 1].GetString();
+    double score = std::stod(score_str);
+    EXPECT_GT(score, 0.0) << "Doc " << key << " should have positive BM25 score";
+    EXPECT_TRUE(key == "d:1" || key == "d:3") << "Unexpected key: " << key;
+  }
+
+  Run({"flushall"});
+}
+
+// Verify ADDSCORES injects __score in FT.AGGREGATE and survives GROUPBY + REDUCE SUM
+TEST_F(SearchFamilyTest, AggregateAddScoresGroupBy) {
+  EXPECT_EQ(Run({"ft.create", "i1", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "title", "TEXT",
+                 "category", "TAG"}),
+            "OK");
+
+  // Two docs in category "a", one in "b" — all match "hello"
+  Run({"hset", "d:1", "title", "hello world hello", "category", "a"});
+  Run({"hset", "d:2", "title", "hello there", "category", "a"});
+  Run({"hset", "d:3", "title", "hello universe", "category", "b"});
+
+  // ADDSCORES should inject __score, then GROUPBY + REDUCE SUM aggregates them
+  auto resp = Run({"ft.aggregate", "i1", "hello", "ADDSCORES", "GROUPBY", "1", "@category",
+                   "REDUCE", "SUM", "1", "@__score", "AS", "total_score"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  auto results = resp.GetVec();
+
+  // FT.AGGREGATE returns [count, group1, group2, ...] — skip element [0]
+  ASSERT_GE(results.size(), 3u);  // count + 2 groups
+
+  // Parse groups: extract (category -> total_score)
+  std::map<std::string, double> group_scores;
+  for (size_t g = 1; g < results.size(); g++) {
+    auto group_vec = results[g].GetVec();
+    std::string cat;
+    double total = 0;
+    for (size_t j = 0; j < group_vec.size(); j += 2) {
+      auto key = group_vec[j].GetString();
+      if (key == "category")
+        cat = group_vec[j + 1].GetString();
+      else if (key == "total_score")
+        total = std::stod(group_vec[j + 1].GetString());
+    }
+    ASSERT_FALSE(cat.empty());
+    group_scores[cat] = total;
+  }
+
+  ASSERT_EQ(group_scores.size(), 2u);
+  EXPECT_GT(group_scores["a"], 0.0) << "Group 'a' should have positive total score";
+  EXPECT_GT(group_scores["b"], 0.0) << "Group 'b' should have positive total score";
+  // Group "a" has 2 docs matching "hello", group "b" has 1 — sum should be higher
+  EXPECT_GT(group_scores["a"], group_scores["b"])
+      << "Group with more matching docs should have higher total score";
+}
+
+// Verify WITHSCORES returns positive BM25 scores for basic text search
+TEST_F(SearchFamilyTest, SearchWithScoresBasic) {
+  EXPECT_EQ(Run({"ft.create", "i1", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "title", "TEXT"}),
+            "OK");
+
+  Run({"hset", "d:1", "title", "hello world hello hello"});  // TF=3
+  Run({"hset", "d:2", "title", "hello there"});              // TF=1
+
+  auto resp = Run({"ft.search", "i1", "hello", "WITHSCORES"});
+  auto results = resp.GetVec();
+  // [total_hits, key, score, fields, key, score, fields]
+  ASSERT_GE(results.size(), 1 + 3 * 2u);
+  EXPECT_THAT(results[0], IntArg(2));
+
+  // Collect (key -> score)
+  std::map<std::string, double> scores;
+  for (size_t i = 1; i < results.size(); i += 3) {
+    scores[results[i].GetString()] = std::stod(results[i + 1].GetString());
+  }
+
+  EXPECT_GT(scores["d:1"], 0.0);
+  EXPECT_GT(scores["d:2"], 0.0);
+  // d:1 has higher TF -> should score higher
+  EXPECT_GT(scores["d:1"], scores["d:2"]) << "Doc with higher TF should score higher";
+}
+
+// Verify ADDSCORES injects __score for simple (non-KNN) FT.AGGREGATE
+TEST_F(SearchFamilyTest, AggregateAddScoresSimple) {
+  EXPECT_EQ(Run({"ft.create", "i1", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "title", "TEXT"}),
+            "OK");
+
+  Run({"hset", "d:1", "title", "hello world hello hello"});  // TF=3
+  Run({"hset", "d:2", "title", "hello there"});              // TF=1
+  Run({"hset", "d:3", "title", "goodbye world"});            // no match
+
+  auto resp = Run({"ft.aggregate", "i1", "hello", "ADDSCORES", "SORTBY", "2", "@__score", "DESC"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  auto results = resp.GetVec();
+
+  // FT.AGGREGATE returns [count, result1, result2, ...] — skip element [0]
+  ASSERT_GE(results.size(), 3u);  // count + 2 results
+
+  // Results should be sorted descending by __score
+  auto first = results[1].GetVec();
+  auto second = results[2].GetVec();
+
+  // Find __score values
+  double score1 = 0, score2 = 0;
+  for (size_t j = 0; j < first.size(); j += 2) {
+    if (first[j].GetString() == "__score")
+      score1 = std::stod(first[j + 1].GetString());
+  }
+  for (size_t j = 0; j < second.size(); j += 2) {
+    if (second[j].GetString() == "__score")
+      score2 = std::stod(second[j + 1].GetString());
+  }
+
+  EXPECT_GT(score1, 0.0) << "First result should have positive score";
+  EXPECT_GT(score2, 0.0) << "Second result should have positive score";
+  EXPECT_GE(score1, score2) << "Results should be sorted by score DESC";
+}
+
+// Verify per-field BM25 scoring: a long "body" field shouldn't penalize a short "title" match
+TEST_F(SearchFamilyTest, SearchWithScoresPerField) {
+  EXPECT_EQ(Run({"ft.create", "i1", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "title", "TEXT",
+                 "body", "TEXT"}),
+            "OK");
+
+  // d:1 — short title match, very long body (unrelated)
+  Run({"hset", "d:1", "title", "hello", "body",
+       "the quick brown fox jumps over the lazy dog and many other words here to make body long"});
+  // d:2 — short title match, short body
+  Run({"hset", "d:2", "title", "hello", "body", "short"});
+
+  auto resp = Run({"ft.search", "i1", "@title:hello", "WITHSCORES"});
+  auto results = resp.GetVec();
+  ASSERT_GE(results.size(), 1 + 3 * 2u);
+
+  // Collect scores
+  std::map<std::string, double> scores;
+  for (size_t i = 1; i < results.size(); i += 3) {
+    scores[results[i].GetString()] = std::stod(results[i + 1].GetString());
+  }
+
+  EXPECT_GT(scores["d:1"], 0.0);
+  EXPECT_GT(scores["d:2"], 0.0);
+  // With per-field scoring, both docs have the same title field content ("hello", TF=1)
+  // and same title field length (1), so scores should be equal regardless of body length.
+  EXPECT_DOUBLE_EQ(scores["d:1"], scores["d:2"])
+      << "Per-field scoring: body length should not affect title-only query score";
+}
+
+// Verify ADDSCORES makes __score visible even without explicit LOAD or pipeline steps
+TEST_F(SearchFamilyTest, AggregateAddScoresAutoVisible) {
+  EXPECT_EQ(Run({"ft.create", "i1", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "title", "TEXT"}),
+            "OK");
+
+  Run({"hset", "d:1", "title", "hello world"});
+
+  // ADDSCORES with no LOAD, no SORTBY, no GROUPBY — __score should still be visible
+  auto resp = Run({"ft.aggregate", "i1", "hello", "ADDSCORES"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  auto results = resp.GetVec();
+  ASSERT_GE(results.size(), 2u);  // count + at least 1 result
+
+  auto row = results[1].GetVec();
+  bool found_score = false;
+  for (size_t j = 0; j < row.size(); j += 2) {
+    if (row[j].GetString() == "__score") {
+      double score = std::stod(row[j + 1].GetString());
+      EXPECT_GT(score, 0.0);
+      found_score = true;
+    }
+  }
+  EXPECT_TRUE(found_score) << "__score should be visible with ADDSCORES even without LOAD/pipeline";
 }
 
 // DocKeyIndex: empty-key documents must survive Serialize/Restore and not be

--- a/tests/dragonfly/search_test.py
+++ b/tests/dragonfly/search_test.py
@@ -1083,3 +1083,129 @@ async def test_vector_search_with_geo_and_tags(async_client: aioredis.Redis):
         ), f"Expected {expected_count} {cat}s, got {result.total}"
 
     await idx.dropindex()
+
+
+@dfly_args({"proactor_threads": 4})
+async def test_ft_search_scorer_bm25std(async_client: aioredis.Redis):
+    """Test FT.SEARCH with SCORER BM25STD and WITHSCORES."""
+    idx = async_client.ft("scorer_idx")
+
+    await idx.create_index(
+        [TextField("content")],
+        definition=IndexDefinition(index_type=IndexType.HASH),
+    )
+
+    # Doc with "hello" appearing multiple times should score higher
+    await async_client.hset("doc:1", mapping={"content": "hello world hello hello"})
+    await async_client.hset("doc:2", mapping={"content": "hello there"})
+    await async_client.hset("doc:3", mapping={"content": "goodbye world"})
+
+    # Raw command: FT.SEARCH scorer_idx "hello" WITHSCORES SCORER BM25STD
+    res = await async_client.execute_command(
+        "FT.SEARCH", "scorer_idx", "hello", "WITHSCORES", "SCORER", "BM25STD"
+    )
+
+    # Response format: [total, key1, score1, fields1, key2, score2, fields2, ...]
+    total = res[0]
+    assert total == 2, f"Expected 2 matches, got {total}"
+
+    # Parse results: each doc is (key, score, fields)
+    docs = {}
+    i = 1
+    while i < len(res):
+        key = str(res[i]) if isinstance(res[i], bytes) else res[i]
+        score = float(res[i + 1])
+        i += 3  # skip key, score, fields
+        docs[key] = score
+
+    assert "doc:1" in docs, f"doc:1 should match, got {docs}"
+    assert "doc:2" in docs, f"doc:2 should match, got {docs}"
+    assert "doc:3" not in docs, f"doc:3 should not match, got {docs}"
+
+    # doc:1 has higher TF for "hello" -> higher score
+    assert docs["doc:1"] > docs["doc:2"], (
+        f"doc:1 (TF=3) should score higher than doc:2 (TF=1), "
+        f"got {docs['doc:1']} vs {docs['doc:2']}"
+    )
+
+    # Scores should be positive
+    assert docs["doc:1"] > 0
+    assert docs["doc:2"] > 0
+
+    await idx.dropindex()
+
+
+@dfly_args({"proactor_threads": 4})
+async def test_ft_search_scorer_invalid(async_client: aioredis.Redis):
+    """Test that invalid scorer name returns error."""
+    idx = async_client.ft("scorer_err_idx")
+
+    await idx.create_index(
+        [TextField("content")],
+        definition=IndexDefinition(index_type=IndexType.HASH),
+    )
+
+    await async_client.hset("doc:1", mapping={"content": "hello"})
+
+    try:
+        await async_client.execute_command(
+            "FT.SEARCH", "scorer_err_idx", "hello", "SCORER", "INVALID_SCORER"
+        )
+        assert False, "Should have raised error for invalid scorer"
+    except Exception as e:
+        assert "scorer" in str(e).lower() or "syntax" in str(e).lower()
+
+    await idx.dropindex()
+
+
+@dfly_args({"proactor_threads": 4})
+async def test_ft_aggregate_addscores(async_client: aioredis.Redis):
+    """Test FT.AGGREGATE with SCORER BM25STD and ADDSCORES."""
+    await async_client.execute_command(
+        "FT.CREATE", "agg_score_idx", "ON", "HASH", "SCHEMA", "content", "TEXT"
+    )
+
+    await async_client.hset("doc:1", mapping={"content": "science science science"})
+    await async_client.hset("doc:2", mapping={"content": "science fiction"})
+    await async_client.hset("doc:3", mapping={"content": "hello world"})
+
+    # FT.AGGREGATE with LOAD first, then SCORER + ADDSCORES + SORTBY @__score DESC
+    res = await async_client.execute_command(
+        "FT.AGGREGATE",
+        "agg_score_idx",
+        "@content:(science)",
+        "LOAD",
+        "1",
+        "@content",
+        "SCORER",
+        "BM25STD",
+        "ADDSCORES",
+        "SORTBY",
+        "2",
+        "@__score",
+        "DESC",
+    )
+
+    total = res[0]
+    assert total == 2, f"Expected 2 matches, got {total}"
+
+    # Parse aggregate results -- each result is a list of field-value pairs
+    results = []
+    for row in res[1:]:
+        entry = {}
+        for j in range(0, len(row), 2):
+            entry[row[j].decode() if isinstance(row[j], bytes) else row[j]] = (
+                row[j + 1].decode() if isinstance(row[j + 1], bytes) else row[j + 1]
+            )
+        results.append(entry)
+
+    # Both results should have __score field
+    for r in results:
+        assert "__score" in r, f"Expected __score field in result: {r}"
+        assert float(r["__score"]) > 0, f"Expected positive score, got {r['__score']}"
+
+    # First result (sorted DESC) should have higher score
+    if len(results) >= 2:
+        assert float(results[0]["__score"]) >= float(results[1]["__score"])
+
+    await async_client.execute_command("FT.DROPINDEX", "agg_score_idx")


### PR DESCRIPTION
Wire BM25STD scoring: FT.SEARCH WITHSCORES, FT.SEARCH SCORER, FT.AGGREGATE ADDSCORES/SCORER. This is part 3 of 3 for BM25STD scoring support (part 1: #7093, part 2: #7101).

Changes:
Command parsing (`search_family.cc`):
- `ParseScorerName()` maps "BM25STD" to `ScorerType::BM25STD`
- FT.SEARCH: parse WITHSCORES, SCORER, DIALECT params; enable scorer (explicit or default BM25STD when WITHSCORES is set)
- FT.AGGREGATE: parse SCORER, ADDSCORES, WITHSCORES (silently ignored) anywhere in the pipeline
- FT.PROFILE: same scorer activation as FT.SEARCH

Score propagation (`doc_index.h/cc`):
- `SerializedSearchDoc::text_score` carries per-doc BM25 score through serialization
- `SearchParams::with_scores/scorer` for FT.SEARCH, `AggregateParams::add_scores/scorer` for FT.AGGREGATE
- FT.SEARCH path: build `text_score_map` from `SearchResult::text_scores`, inject into serialized docs
- FT.AGGREGATE path: inject `__score` field via `LoadDocEntriesWithScores` when ADDSCORES is set

Response formatting (`search_family.cc`):
- FT.SEARCH WITHSCORES: score sent between key and fields (matches Redis Stack format)
- FT.AGGREGATE ADDSCORES: `__score` auto-added to visible fields

Stats test fix (`search_family_test.cc`):
- Updated `Stats` test memory threshold from 3x to 4x to account for per-field BM25 tracking overhead added in #7101

Fixes: https://github.com/dragonflydb/dragonfly/issues/7062