### PR TITLE
feat(facade): add early TLS filter and TCP_DEFER_ACCEPT (#6857)

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -711,9 +711,33 @@ void Connection::HandleRequests() {
 
 #ifdef DFLY_USE_SSL
   if (ssl_ctx_) {
-    // Must be done atomically before the premption point in Accept so that at any
-    // point in time, the socket_ is defined.
-    uint8_t buf[2];
+    // Early TLS connection filter
+    //
+    // Before entering the expensive OpenSSL handshake we pre-read the 5-byte TLS Record Layer
+    // header on the raw TCP socket. This serves two purposes:
+    //
+    //  1. Wrong-client detection:
+    //     Clients that forgot to enable TLS (e.g. a plaintext Redis client connecting to the TLS
+    //     port) will not send a valid TLS Record Layer header.  We detect this immediately and
+    //     reply with a human-readable "-ERR" message before disconnecting, instead of letting
+    //     OpenSSL produce a cryptic handshake failure.
+    //
+    //  2. Zombie-connection rejection:
+    //     Zombie connections —— open a TCP socket but never send any data.  By demanding at least
+    //     the 5-byte header before allocating any SSL state, we drop these cheaply on the raw
+    //     socket instead of tying up an OpenSSL context and handshake state machine that will never
+    //     complete.
+    //
+    // The pre-read header bytes are injected into the TlsSocket via InitSSL(), which writes them
+    // into OpenSSL's internal BIO so that Accept() can drive the normal handshake from there.
+    //
+    // Reminder: TLS Record Layer header structure (universal across TLS 1.0 – 1.3):
+    // - Byte 0: ContentType (0x16 = Handshake)
+    // - Bytes 1–2: ProtocolVersion. While the minor version varies (0x01 for TLS 1.0,
+    //   0x03 for TLS 1.2/1.3), the major version is consistently 0x03 for all
+    //   modern TLS versions.
+    // - Bytes 3–4: Length (uint16 BE) — payload length, max 2^14 = 16384
+    uint8_t buf[5];  // universal TLS Record Header size is 5 bytes
     auto read_sz = socket_->Read(io::MutableBytes(buf));
     if (!read_sz || *read_sz < sizeof(buf)) {
       auto msg = read_sz ? absl::StrCat(*read_sz, " < ", sizeof(buf)) : read_sz.error().message();
@@ -722,10 +746,16 @@ void Connection::HandleRequests() {
       stats_->tls_accept_disconnects++;
       return;
     }
-    if (buf[0] != 0x16 || buf[1] != 0x03) {
+
+    // Byte 0: ContentType must be 0x16 (Handshake).
+    // Byte 1: major ProtocolVersion — always 0x03 for TLS 1.0 through TLS 1.3.
+    // Byte 2: minor ProtocolVersion — 0x01 (TLS 1.0), 0x02 (TLS 1.1), 0x03 (TLS 1.2/1.3).
+    //         SSL 3.0 (0x00) is deprecated (RFC 7568) and rejected.
+    if ((buf[0] != 0x16) || (buf[1] != 0x03) || (buf[2] < 0x01) || (buf[2] > 0x03)) {
       VLOG(1) << "Bad TLS header "
               << absl::StrCat(absl::Hex(buf[0], absl::kZeroPad2),
-                              absl::Hex(buf[1], absl::kZeroPad2));
+                              absl::Hex(buf[1], absl::kZeroPad2),
+                              absl::Hex(buf[2], absl::kZeroPad2));
       std::ignore =
           socket_->Write(io::Buffer("-ERR Bad TLS header, double check "
                                     "if you enabled TLS for your client.\r\n"));
@@ -733,6 +763,8 @@ void Connection::HandleRequests() {
       return;
     }
 
+    // Must be done atomically before the preemption point in Accept so that at any
+    // point in time, the socket_ is defined.
     {
       FiberAtomicGuard fg;
       unique_ptr<tls::TlsSocket> tls_sock = make_unique<tls::TlsSocket>(std::move(socket_));

--- a/src/facade/dragonfly_listener.cc
+++ b/src/facade/dragonfly_listener.cc
@@ -5,6 +5,7 @@
 #include "facade/dragonfly_listener.h"
 
 #include <mimalloc.h>
+#include <netinet/tcp.h>
 #include <openssl/err.h>
 
 #include <memory>
@@ -27,6 +28,7 @@ ABSL_FLAG(uint32_t, conn_io_threads, 0, "Number of threads used for handing serv
 ABSL_FLAG(uint32_t, conn_io_thread_start, 0, "Starting thread id for handling server connections");
 ABSL_FLAG(bool, tls, false, "");
 ABSL_FLAG(bool, no_tls_on_admin_port, false, "Allow non-tls connections on admin port");
+ABSL_FLAG(bool, enable_tcp_defer_accept, true, "Enable TCP_DEFER_ACCEPT option on server sockets");
 
 ABSL_FLAG(bool, conn_use_incoming_cpu, false,
           "If true uses incoming cpu of a socket in order to distribute"
@@ -185,6 +187,32 @@ error_code Listener::ConfigureServerSocket(int fd) {
   if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val)) < 0) {
     LOG(WARNING) << "Could not set reuse addr on socket " << SafeErrorMessage(errno);
   }
+
+#ifdef TCP_DEFER_ACCEPT  // TCP_DEFER_ACCEPT is only for Linux, and defined by Linux OS-Kernel
+  if (GetFlag(FLAGS_enable_tcp_defer_accept)) {
+    sockaddr_storage addr;
+    socklen_t len = sizeof(addr);
+    // TCP_DEFER_ACCEPT is only applicable to TCP (IPv4/IPv6) sockets, not Unix domain sockets
+    // (UDS).
+    if (getsockname(fd, reinterpret_cast<sockaddr*>(&addr), &len) == 0 &&
+        (addr.ss_family == AF_INET || addr.ss_family == AF_INET6)) {
+      // Instruct the kernel to defer waking up accept() until actual payload data arrives,
+      // with a timeout of 1 second.
+      // This provides a kernel-level shield against "Pure Zombie" storms - where malicious or
+      // misconfigured clients complete the TCP 3-way handshake but never send data (or immediately
+      // send FIN/RST). The kernel will silently clean up these empty connections without
+      // consuming Dragonfly fibers or OpenSSL memory.
+      // This imposes zero latency penalty on well-behaved clients, as the kernel instantly
+      // yields the connection to user-space the moment their first byte (e.g., TLS ClientHello
+      // or RESP command) arrives.
+      static constexpr int kDeferAcceptTimeoutSec = 1;
+      if (setsockopt(fd, IPPROTO_TCP, TCP_DEFER_ACCEPT, &kDeferAcceptTimeoutSec,
+                     sizeof(kDeferAcceptTimeoutSec)) < 0) {
+        LOG(WARNING) << "Could not set TCP_DEFER_ACCEPT " << SafeErrorMessage(errno);
+      }
+    }
+  }
+#endif
   bool success = ConfigureKeepAlive(fd);
 
 #ifdef __linux__


### PR DESCRIPTION
1) Cherry pick from main 5eb2e230

Implement a two-layer defense against zombie connections and misconfigured clients to protect server resources.

Enable TCP_DEFER_ACCEPT on Linux TCP sockets. The kernel defers waking up accept() until the first payload byte arrives. This drops pure-zombie connections at the OS level without consuming Dragonfly fibers or OpenSSL memory.

Add a 5-byte TLS Record Layer header pre-read for TLS ports before allocating OpenSSL state.

Validate the TLS header for ContentType (0x16) and ProtocolVersion (TLS 1.0-1.3). SSL 3.0 and invalid protocols are explicitly rejected.

Instantly reject plaintext or malformed clients with a clear "-ERR Bad TLS header" message, avoiding cryptic OpenSSL errors and saving expensive handshake computations.


2)  bump helio to fix rapidjson build failure

helio/cmake/third_party.cmake fetched rapidjson only when
WITH_GCP=ON. However, azure.cc unconditionally includes
<rapidjson/document.h> regardless of WITH_GCP.

CI builds with -DWITH_GCP=OFF so rapidjson was never fetched,
causing:

  fatal error: rapidjson/document.h: No such file or directory

This is unrelated to the TCP_DEFER_ACCEPT cherry-pick; it is
a pre-existing bug in the v1.37 helio version, exposed by
this PR being the first CI run on the branch.

Fix is in helio branch:
dragonfly-v1.37/fix-rapidjson-unconditional-fetch (56ba82e)