### PR TITLE
fix: OOB in BITCOUNT and some refactoring

### DIFF
--- a/src/core/dragonfly_core.cc
+++ b/src/core/dragonfly_core.cc
@@ -4,10 +4,16 @@
 
 #include <absl/base/macros.h>
 
+#include <ostream>
+
 #include "base/logging.h"
 #include "core/intent_lock.h"
 
 namespace dfly {
+
+std::ostream& operator<<(std::ostream& o, const IntentLock& lock) {
+  return o << "{SHARED: " << lock.cnt_[0] << ", EXCLUSIVE: " << lock.cnt_[1] << "}";
+}
 
 const char* IntentLock::ModeName(Mode m) {
   switch (m) {

--- a/src/core/intent_lock.h
+++ b/src/core/intent_lock.h
@@ -1,11 +1,11 @@
 // Copyright 2022, DragonflyDB authors.  All rights reserved.
 // See LICENSE for licensing terms.
 //
+#pragma once
+
 #include <assert.h>
 
-#include <ostream>
-
-#pragma once
+#include <iosfwd>
 
 namespace dfly {
 
@@ -60,9 +60,7 @@ class IntentLock {
 
   void VerifyDebug();
 
-  friend std::ostream& operator<<(std::ostream& o, const IntentLock& lock) {
-    return o << "{SHARED: " << lock.cnt_[0] << ", EXCLUSIVE: " << lock.cnt_[1] << "}";
-  }
+  friend std::ostream& operator<<(std::ostream& o, const IntentLock& lock);
 
  private:
   unsigned cnt_[2] = {0, 0};

--- a/src/core/search/ast_expr.h
+++ b/src/core/search/ast_expr.h
@@ -5,9 +5,8 @@
 #pragma once
 
 #include <algorithm>
-#include <iostream>
+#include <iosfwd>
 #include <memory>
-#include <ostream>
 #include <variant>
 #include <vector>
 

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -2285,7 +2285,7 @@ void Connection::BreakOnce(uint32_t ev_mask) {
   if (breaker_cb_) {
     DVLOG(1) << "[" << id_ << "] Connection::breaker_cb_ " << ev_mask;
     auto fun = std::move(breaker_cb_);
-    DCHECK(!breaker_cb_);
+    breaker_cb_ = nullptr;
     fun(ev_mask);
   }
 }

--- a/src/facade/facade_test.h
+++ b/src/facade/facade_test.h
@@ -6,7 +6,7 @@
 
 #include <gmock/gmock.h>
 
-#include <ostream>
+#include <iosfwd>
 #include <string>
 #include <string_view>
 

--- a/src/facade/op_status.cc
+++ b/src/facade/op_status.cc
@@ -1,8 +1,18 @@
 #include "facade/op_status.h"
 
+#include <ostream>
+
 #include "base/logging.h"
 #include "facade/error.h"
 #include "facade/resp_expr.h"
+
+namespace std {
+
+std::ostream& operator<<(std::ostream& os, facade::OpStatus op) {
+  return os << static_cast<int>(op);
+}
+
+}  // namespace std
 
 namespace facade {
 

--- a/src/facade/op_status.h
+++ b/src/facade/op_status.h
@@ -5,7 +5,9 @@
 #pragma once
 
 #include <cstdint>
-#include <ostream>
+#include <iosfwd>
+#include <string_view>
+#include <utility>
 
 namespace facade {
 
@@ -127,14 +129,10 @@ std::string_view StatusToMsg(OpStatus status);
 
 namespace std {
 
-template <typename T> std::ostream& operator<<(std::ostream& os, const facade::OpResult<T>& res) {
-  os << res.status();
-  return os;
-}
+std::ostream& operator<<(std::ostream& os, facade::OpStatus op);
 
-inline std::ostream& operator<<(std::ostream& os, const facade::OpStatus op) {
-  os << int(op);
-  return os;
+template <typename T> std::ostream& operator<<(std::ostream& os, const facade::OpResult<T>& res) {
+  return os << res.status();
 }
 
 }  // namespace std

--- a/src/facade/reply_payload.h
+++ b/src/facade/reply_payload.h
@@ -27,7 +27,7 @@ struct BulkString : public std::string {};    // SendBulkString
 using Payload = std::variant<std::monostate, Null, Error, long, double, SimpleString, BulkString,
                              std::unique_ptr<CollectionPayload>>;
 
-#ifdef __linux__
+#if defined(__linux__) && !defined(_LIBCPP_VERSION)
 static_assert(sizeof(Payload) == 40);
 #endif
 

--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -212,7 +212,7 @@ std::size_t CountBitSet(string_view str, int64_t start, int64_t end, bool bits) 
     end = strlen + end;
 
   start = max(start, int64_t(0));
-  end = min(end, strlen - 1);  // inclusive: clamp to last valid index
+  end = max(int64_t(0), min(end, strlen - 1));  // inclusive, clamped to [0, strlen - 1]
 
   if (start > end)
     return 0;

--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -206,13 +206,18 @@ std::size_t CountBitSet(string_view str, int64_t start, int64_t end, bool bits) 
   if (strlen == 0)
     return 0;
 
+  // Both-negative inverted range is empty; without this, clamping pulls both
+  // up to 0 on short strings and counts a spurious byte/bit.
+  if (start < 0 && end < 0 && start > end)
+    return 0;
+
   if (start < 0)
     start = strlen + start;
   if (end < 0)
     end = strlen + end;
 
   start = max(start, int64_t(0));
-  end = max(int64_t(0), min(end, strlen - 1));  // inclusive, clamped to [0, strlen - 1]
+  end = max(int64_t(0), min(end, strlen - 1));
 
   if (start > end)
     return 0;

--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -60,7 +60,7 @@ string GetString(const PrimeValue& pv);
 bool SetBitValue(uint32_t offset, bool bit_value, string* entry);
 std::size_t CountBitSetByByteIndices(string_view at, std::size_t start, std::size_t end);
 std::size_t CountBitSet(string_view str, int64_t start, int64_t end, bool bits);
-std::size_t CountBitSetByBitIndices(string_view at, std::size_t start, std::size_t end);
+std::size_t CountBitSetByBitIndices(string_view at, std::size_t front, std::size_t back);
 string RunBitOperationOnValues(string_view op, const BitsStrVec& values);
 
 // ------------------------------------------------------------------------- //
@@ -169,24 +169,21 @@ std::size_t CountBitSetByByteIndices(string_view at, std::size_t start, std::siz
   return count;
 }
 
-// Count the number of bits that are on, on bits boundaries: i.e. Start and end are the indices for
-// bits locations inside str
-std::size_t CountBitSetByBitIndices(string_view at, std::size_t start, std::size_t end) {
-  auto first_byte_index = GetByteIndex(start);
-  auto last_byte_index = GetByteIndex(end);
-  if (start % OFFSET_FACTOR == 0 && end % OFFSET_FACTOR == 0) {
-    return CountBitSetByByteIndices(at, first_byte_index, last_byte_index);
+// Count the number of bits that are on, in the inclusive bit range [front, back].
+// Caller must guarantee 0 <= front <= back < at.size() * OFFSET_FACTOR.
+std::size_t CountBitSetByBitIndices(string_view at, std::size_t front, std::size_t back) {
+  const size_t front_byte = front / OFFSET_FACTOR;
+  const size_t back_byte = back / OFFSET_FACTOR;
+  const uint8_t front_bit = front % OFFSET_FACTOR;
+  const uint8_t back_bit_end = back % OFFSET_FACTOR + 1;  // exclusive upper
+
+  if (front_byte == back_byte) {
+    return CountBitsRange(static_cast<uint8_t>(at[front_byte]), front_bit, back_bit_end);
   }
-  const auto last_bit_first_byte =
-      first_byte_index != last_byte_index ? OFFSET_FACTOR : GetBitIndex(end);
-  const auto first_byte = GetByteValue(at, start);
-  std::uint32_t count = CountBitsRange(first_byte, GetBitIndex(start), last_bit_first_byte);
-  if (first_byte_index < last_byte_index) {
-    first_byte_index++;
-    const auto last_byte = GetByteValue(at, end);
-    count += CountBitsRange(last_byte, 0, GetBitIndex(end));
-    count += CountBitSetByByteIndices(at, first_byte_index, last_byte_index);
-  }
+  std::size_t count =
+      CountBitsRange(static_cast<uint8_t>(at[front_byte]), front_bit, OFFSET_FACTOR);
+  count += CountBitSetByByteIndices(at, front_byte + 1, back_byte);
+  count += CountBitsRange(static_cast<uint8_t>(at[back_byte]), 0, back_bit_end);
   return count;
 }
 
@@ -206,23 +203,23 @@ int64_t NormalizedOffset(int64_t size, int64_t offset) {
 // Note that when bits is false, it means that we are looking on byte boundaries.
 std::size_t CountBitSet(string_view str, int64_t start, int64_t end, bool bits) {
   const int64_t strlen = bits ? str.size() * OFFSET_FACTOR : str.size();
+  if (strlen == 0)
+    return 0;
 
   if (start < 0)
     start = strlen + start;
   if (end < 0)
     end = strlen + end;
 
-  end = min(end, strlen);
+  start = max(start, int64_t(0));
+  end = min(end, strlen - 1);  // inclusive: clamp to last valid index
 
-  if (strlen == 0 || start > end)
+  if (start > end)
     return 0;
 
-  start = max(start, int64_t(0));
-  end = max(end, int64_t(0));
-
-  ++end;
+  // `end` is passed inclusive to the bit helper, exclusive (end + 1) to the byte helper.
   return bits ? CountBitSetByBitIndices(str, start, end)
-              : CountBitSetByByteIndices(str, start, end);
+              : CountBitSetByByteIndices(str, start, end + 1);
 }
 
 // return true if bit is on

--- a/src/server/bitops_family_test.cc
+++ b/src/server/bitops_family_test.cc
@@ -325,6 +325,10 @@ TEST_F(BitOpsFamilyTest, BitCountByteSubRange) {
   auto a_resp = Run({"set", "A", "A"});
   EXPECT_EQ(a_resp, "OK");
   EXPECT_EQ(2, CheckedInt({"bitcount", "A", "0", "-2"}));
+
+  // Both-negative inverted range on a 1-byte key: must be 0, not a count of
+  // byte 0 after both indices clamp up.
+  EXPECT_EQ(0, CheckedInt({"bitcount", "A", "-1", "-2"}));
 }
 
 TEST_F(BitOpsFamilyTest, BitCountByteBitSubRange) {
@@ -343,6 +347,12 @@ TEST_F(BitOpsFamilyTest, BitCountByteBitSubRange) {
   EXPECT_EQ(4, CheckedInt({"bitcount", "foo", "1", "9", "bit"}));
   EXPECT_EQ(7, CheckedInt({"bitcount", "foo", "2", "19", "bit"}));
   EXPECT_EQ(0, CheckedInt({"bitcount", "foo", "-1", "-2", "bit"}));  // illegal range
+
+  // Both-negative inverted range past the end of a 1-byte key: must be 0,
+  // not a count of bit 0 after both indices clamp up.
+  auto x_resp = Run({"set", "x", std::string(1, '\xff')});
+  EXPECT_EQ(x_resp, "OK");
+  EXPECT_EQ(0, CheckedInt({"bitcount", "x", "-9", "-10", "bit"}));
 }
 
 TEST_F(BitOpsFamilyTest, BitCountBitLastBitRegression) {

--- a/src/server/bitops_family_test.cc
+++ b/src/server/bitops_family_test.cc
@@ -335,6 +335,36 @@ TEST_F(BitOpsFamilyTest, BitCountByteBitSubRange) {
   EXPECT_EQ(0, CheckedInt({"bitcount", "foo", "-1", "-2", "bit"}));  // illegal range
 }
 
+TEST_F(BitOpsFamilyTest, BitCountBitLastBitRegression) {
+  // Regression: `BITCOUNT key s e BIT` used to read one byte past the end of
+  // the value whenever `e` (after converting inclusive->exclusive via ++e) fell
+  // on a byte boundary AND `s` was in an earlier byte. The read was latent UB:
+  // the bogus byte was multiplied by zero inside CountBitsRange, so the
+  // numeric result was correct, but libc++ hardening / ASan trapped on the
+  // out-of-bounds string_view::operator[].
+  // Known trigger: any 1-bit-exclusive range that ends exactly at 8*N-1.
+
+  // Single-byte value: bit 0 = 1, bit 7 = 1, all others 0 → popcount 2.
+  auto resp = Run({"set", "k1", std::string(1, '\x81')});
+  EXPECT_EQ(resp, "OK");
+  EXPECT_EQ(2, CheckedInt({"bitcount", "k1", "0", "7", "BIT"}));    // full-byte, end@byte-boundary
+  EXPECT_EQ(1, CheckedInt({"bitcount", "k1", "1", "7", "BIT"}));    // partial start, end@boundary
+  EXPECT_EQ(2, CheckedInt({"bitcount", "k1", "-8", "-1", "BIT"}));  // negative form of 0..7
+  EXPECT_EQ(2, CheckedInt({"bitcount", "k1", "0", "-1", "BIT"}));
+  EXPECT_EQ(0, CheckedInt({"bitcount", "k1", "8", "8", "BIT"}));  // start past last bit → 0
+
+  // Multi-byte value: "abcdef" has 48 bits; bits 0-47 valid. These ranges all
+  // end at or past the last valid bit — each previously tripped the OOB.
+  resp = Run({"set", "k2", "abcdef"});
+  EXPECT_EQ(resp, "OK");
+  EXPECT_EQ(CheckedInt({"bitcount", "k2", "0", "-1"}),          // reference (byte form)
+            CheckedInt({"bitcount", "k2", "0", "47", "BIT"}));  // end@last bit
+  EXPECT_EQ(CheckedInt({"bitcount", "k2", "5", "5"}),           // last byte only (byte form)
+            CheckedInt({"bitcount", "k2", "40", "47", "BIT"}));
+  EXPECT_EQ(0, CheckedInt({"bitcount", "k2", "48", "48", "BIT"}));    // past the end
+  EXPECT_EQ(0, CheckedInt({"bitcount", "k2", "100", "200", "BIT"}));  // way past
+}
+
 // ------------------------- BITOP tests
 
 const auto EXPECTED_LEN_BITOP =

--- a/src/server/bitops_family_test.cc
+++ b/src/server/bitops_family_test.cc
@@ -315,6 +315,16 @@ TEST_F(BitOpsFamilyTest, BitCountByteSubRange) {
   EXPECT_EQ(13, CheckedInt({"bitcount", "foo", "-5", "-2"}));
   EXPECT_EQ(0, CheckedInt({"bitcount", "foo", "-1", "-2"}));  // illegal range
   EXPECT_EQ(0, CheckedInt({"bitcount", "foo", "1", "0"}));    // illegal range
+
+  // Negative `end` that resolves to < 0 must be clamped to 0 (Redis semantics);
+  EXPECT_EQ(4, CheckedInt({"bitcount", "foo", "0", "-6"}));    // end resolves to 0
+  EXPECT_EQ(4, CheckedInt({"bitcount", "foo", "0", "-100"}));  // end resolves far below 0
+  EXPECT_EQ(4, CheckedInt({"bitcount", "foo", "-100", "-100"}));
+  EXPECT_EQ(4, CheckedInt({"bitcount", "foo", "-100", "-99"}));
+
+  auto a_resp = Run({"set", "A", "A"});
+  EXPECT_EQ(a_resp, "OK");
+  EXPECT_EQ(2, CheckedInt({"bitcount", "A", "0", "-2"}));
 }
 
 TEST_F(BitOpsFamilyTest, BitCountByteBitSubRange) {

--- a/src/server/server_family_test.cc
+++ b/src/server/server_family_test.cc
@@ -41,7 +41,7 @@ TEST_F(ServerFamilyTest, ReadTcpInfo) {
   server_addr.sin_port = 0;  // Let the system choose a free port
 
   // Bind to the port
-  ASSERT_EQ(bind(sockfd, (struct sockaddr*)&server_addr, sizeof(server_addr)), 0)
+  ASSERT_EQ(::bind(sockfd, (struct sockaddr*)&server_addr, sizeof(server_addr)), 0)
       << "Failed to bind socket: " << strerror(errno);
 
   // Start listening
@@ -78,7 +78,7 @@ TEST_F(ServerFamilyTest, GetTcpSocketInfoIPv6) {
   server_addr.sin6_port = 0;  // Let the system choose a free port
 
   // Bind to the port
-  ASSERT_EQ(bind(sockfd, (struct sockaddr*)&server_addr, sizeof(server_addr)), 0)
+  ASSERT_EQ(::bind(sockfd, (struct sockaddr*)&server_addr, sizeof(server_addr)), 0)
       << "Failed to bind IPv6 socket: " << strerror(errno);
 
   // Start listening

--- a/src/server/tiering/common.h
+++ b/src/server/tiering/common.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <iosfwd>
 #include <memory>
 #include <optional>
 #include <variant>
@@ -42,9 +43,7 @@ struct DiskSegment {
 
   size_t offset = 0, length = 0;
 
-  friend std::ostream& operator<<(std::ostream& os, const DiskSegment& ds) {
-    return os << "[" << ds.offset << ", " << ds.length << "]";
-  }
+  friend std::ostream& operator<<(std::ostream& os, const DiskSegment& ds);
 };
 
 using KeyRef = std::pair<uint16_t /* DbIndex */, std::string_view>;

--- a/src/server/tiering/disk_storage.cc
+++ b/src/server/tiering/disk_storage.cc
@@ -4,6 +4,7 @@
 
 #include "server/tiering/disk_storage.h"
 
+#include <ostream>
 #include <system_error>
 
 #include "base/flags.h"
@@ -23,6 +24,10 @@ ABSL_FLAG(uint64_t, registered_buffer_size, 512_KB,
           "Size of registered buffer for IoUring fixed read/writes");
 
 namespace dfly::tiering {
+
+std::ostream& operator<<(std::ostream& os, const DiskSegment& ds) {
+  return os << "[" << ds.offset << ", " << ds.length << "]";
+}
 
 using namespace std;
 using namespace ::util::fb2;


### PR DESCRIPTION
I've run a libc++ hardening build, found a bug in BITCOUNT. Also did some small refactoring to have a correct build.

Fixes an out-of-bounds read in BITCOUNT (BIT mode) discovered under libc++ hardening, and does small refactoring to keep builds correct.

Changes:


- Refactors bit-range counting to use an inclusive end index and avoid reading past the last byte.
- Adds a regression test for ranges that end on the last bit / a byte boundary.
- Moves several operator<< implementations out of headers and replaces <ostream> with <iosfwd> where possible.
- Adjusts a Linux-only static_assert to skip libc++ and qualifies ::bind in socket tests.