### PR TITLE
feat: DEBUG TRAFFIC per-listener recording and memcache replay

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -177,8 +177,10 @@ struct TrafficLogger {
   // Also, makes sure that LogTraffic are executed atomically.
   fb2::Mutex mutex;
   unique_ptr<io::WriteFile> log_file;
-  // Bit mask over Connection::ListenerType values, only matching listeners are logged.
-  uint32_t listener_mask = 0;
+  // Listener type that this thread's file is recording. Only connections with a
+  // matching `listener_type_` produce records; others are skipped on the hot path.
+  // Set once when the file is opened, cleared in ResetLocked().
+  Connection::ListenerType listener_type = Connection::ListenerType::RESP;
 
   void ResetLocked();
   // Returns true if Write succeeded, false if it failed and the recording should be aborted.
@@ -191,7 +193,7 @@ void TrafficLogger::ResetLocked() {
     std::ignore = log_file->Close();
     log_file.reset();
   }
-  listener_mask = 0;
+  listener_type = Connection::ListenerType::RESP;
 }
 
 // Returns true if Write succeeded, false if it failed and the recording should be aborted.
@@ -223,9 +225,10 @@ thread_local uint32 pipeline_wait_batch_usec = absl::GetFlag(FLAGS_pipeline_wait
 
 // Opens the per-thread traffic log file. Distinguishes three outcomes so the caller
 // can report an accurate error to the user (was the logger already running, or did
-// we fail to open a file). `listener_mask` is only committed after the file is
+// we fail to open a file). `listener_type` is only committed after the file is
 // successfully opened so the logger's state stays consistent on failure.
-Connection::StartTrafficResult OpenTrafficLogger(string_view base_path, uint32_t listener_mask) {
+Connection::StartTrafficResult OpenTrafficLogger(string_view base_path,
+                                                 Connection::ListenerType listener_type) {
   using Res = Connection::StartTrafficResult;
   unique_lock lk{tl_traffic_logger.mutex};
   if (tl_traffic_logger.log_file)
@@ -241,24 +244,22 @@ Connection::StartTrafficResult OpenTrafficLogger(string_view base_path, uint32_t
     return Res::kOpenFailed;
   }
   tl_traffic_logger.log_file = unique_ptr<io::WriteFile>{file.value()};
-  tl_traffic_logger.listener_mask = listener_mask;
+  tl_traffic_logger.listener_type = listener_type;
 #else
   LOG(WARNING) << "Traffic logger is only supported on Linux";
   return Res::kOpenFailed;
 #endif
 
-  // File header: version byte.
-  // v3 added per-record listener type packed into the upper bits (8..15) of the former
-  // `has_more` (now `flags`) field. v2 files are forwards-compatible for v3 readers:
-  // the upper bits are zero and get mapped to RESP. v2 readers cannot parse v3 files.
-  uint8_t version[1] = {3};
-  std::ignore = tl_traffic_logger.log_file->Write(version);
+  // File header: version byte (v3), followed by a single byte carrying the listener
+  // type for the whole file. Every record in the file belongs to this listener.
+  uint8_t header[2] = {3, static_cast<uint8_t>(listener_type)};
+  std::ignore = tl_traffic_logger.log_file->Write(header);
   return Res::kStarted;
 }
 
 // Writes a single record. `parts[0]` is the command name, following entries are its arguments.
 void LogTrafficParts(uint32_t id, bool has_more, uint32_t db_index,
-                     Connection::ListenerType listener_type, absl::Span<const string_view> parts) {
+                     absl::Span<const string_view> parts) {
   if (parts.empty())
     return;
 
@@ -271,26 +272,21 @@ void LogTrafficParts(uint32_t id, bool has_more, uint32_t db_index,
   char stack_buf[1024];
   char* next = stack_buf;
 
-  // We write id, timestamp, db_index, flags, num_parts, part_len, part_len, part_len, ...
-  // And then all the part blobs concatenated together.
+  // Record header: id, timestamp, db_index, has_more, num_parts, followed by
+  // part_len, part_len, ... and finally the concatenated part blobs.
+  // The listener type is stored once in the file header; it is not repeated per record.
   auto write_u32 = [&next](uint32_t i) {
     absl::little_endian::Store32(next, i);
     next += 4;
   };
 
-  // id
   write_u32(id);
 
-  // timestamp
   absl::little_endian::Store64(next, absl::GetCurrentTimeNanos());
   next += 8;
 
-  // db_index
   write_u32(db_index);
-
-  // flags: bit 0 = has_more; bits 8..15 = listener_type (v3 file format).
-  uint32_t flags = (has_more ? 1u : 0u) | (static_cast<uint32_t>(listener_type) << 8);
-  write_u32(flags);
+  write_u32(has_more ? 1u : 0u);
   write_u32(uint32_t(parts.size()));
 
   // Grab the lock and check if the file is still open.
@@ -335,12 +331,12 @@ void LogTrafficParts(uint32_t id, bool has_more, uint32_t db_index,
 }
 
 void LogTraffic(uint32_t id, bool has_more, const cmn::BackedArguments& args,
-                ServiceInterface::ContextInfo ci, Connection::ListenerType listener_type) {
+                ServiceInterface::ContextInfo ci) {
   absl::InlinedVector<string_view, 16> parts;
   parts.reserve(args.size());
   for (auto v : args.view())
     parts.push_back(v);
-  LogTrafficParts(id, has_more, ci.db_index, listener_type, absl::MakeSpan(parts));
+  LogTrafficParts(id, has_more, ci.db_index, absl::MakeSpan(parts));
 }
 
 // Variant used by the Memcache protocol path.
@@ -358,7 +354,7 @@ void LogTraffic(uint32_t id, bool has_more, const cmn::BackedArguments& args,
 //               FLUSHALL/STATS/
 //               QUIT/VERSION)      : [cmd, *backed_args]
 void LogMemcacheTraffic(uint32_t id, bool has_more, const MemcacheParser::Command& mc,
-                        ServiceInterface::ContextInfo ci, Connection::ListenerType listener_type) {
+                        ServiceInterface::ContextInfo ci) {
   using MP = MemcacheParser;
   string_view cmd_name = MP::CmdName(mc.type);
   if (cmd_name.empty())
@@ -415,7 +411,7 @@ void LogMemcacheTraffic(uint32_t id, bool has_more, const MemcacheParser::Comman
       break;
   }
 
-  LogTrafficParts(id, has_more, ci.db_index, listener_type, absl::MakeSpan(parts));
+  LogTrafficParts(id, has_more, ci.db_index, absl::MakeSpan(parts));
 }
 
 constexpr size_t kMinReadSize = 256;
@@ -1413,10 +1409,8 @@ Connection::ParserStatus Connection::ParseRedis(unsigned max_busy_cycles, bool e
       request_consumed_bytes_ = 0;
       bool has_more = consumed < read_buffer.size();
 
-      if (tl_traffic_logger.log_file &&
-          (tl_traffic_logger.listener_mask & (1u << static_cast<uint8_t>(listener_type_)))) {
-        LogTraffic(id_, has_more, *parsed_cmd_, service_->GetContextInfo(cc_.get()),
-                   listener_type_);
+      if (tl_traffic_logger.log_file && tl_traffic_logger.listener_type == listener_type_) {
+        LogTraffic(id_, has_more, *parsed_cmd_, service_->GetContextInfo(cc_.get()));
       }
 
       if (enqueue_only) {
@@ -2315,8 +2309,8 @@ void Connection::RequestAsyncMigration(util::fb2::ProactorBase* dest, bool force
 }
 
 Connection::StartTrafficResult Connection::StartTrafficLogging(string_view path,
-                                                               uint32_t listener_mask) {
-  return OpenTrafficLogger(path, listener_mask);
+                                                               ListenerType listener_type) {
+  return OpenTrafficLogger(path, listener_type);
 }
 
 void Connection::StopTrafficLogging() {
@@ -2457,10 +2451,10 @@ bool Connection::ParseMCBatch() {
       return false;
 
     if (result == MemcacheParser::OK && tl_traffic_logger.log_file &&
-        (tl_traffic_logger.listener_mask & (1u << static_cast<uint8_t>(listener_type_)))) {
+        tl_traffic_logger.listener_type == listener_type_) {
       bool has_more = io_buf_.InputLen() > 0;
       LogMemcacheTraffic(id_, has_more, *parsed_cmd_->mc_command(),
-                         service_->GetContextInfo(cc_.get()), listener_type_);
+                         service_->GetContextInfo(cc_.get()));
     }
 
     // We push the command to the parsed queue even in case of parse errors,

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -177,6 +177,8 @@ struct TrafficLogger {
   // Also, makes sure that LogTraffic are executed atomically.
   fb2::Mutex mutex;
   unique_ptr<io::WriteFile> log_file;
+  // Bit mask over Connection::ListenerType values, only matching listeners are logged.
+  uint32_t listener_mask = 0;
 
   void ResetLocked();
   // Returns true if Write succeeded, false if it failed and the recording should be aborted.
@@ -189,6 +191,7 @@ void TrafficLogger::ResetLocked() {
     std::ignore = log_file->Close();
     log_file.reset();
   }
+  listener_mask = 0;
 }
 
 // Returns true if Write succeeded, false if it failed and the recording should be aborted.
@@ -218,10 +221,15 @@ thread_local base::Histogram* io_req_size_hist = nullptr;
 thread_local const size_t reply_size_limit = absl::GetFlag(FLAGS_squashed_reply_size_limit);
 thread_local uint32 pipeline_wait_batch_usec = absl::GetFlag(FLAGS_pipeline_wait_batch_usec);
 
-void OpenTrafficLogger(string_view base_path) {
+// Opens the per-thread traffic log file. Distinguishes three outcomes so the caller
+// can report an accurate error to the user (was the logger already running, or did
+// we fail to open a file). `listener_mask` is only committed after the file is
+// successfully opened so the logger's state stays consistent on failure.
+Connection::StartTrafficResult OpenTrafficLogger(string_view base_path, uint32_t listener_mask) {
+  using Res = Connection::StartTrafficResult;
   unique_lock lk{tl_traffic_logger.mutex};
   if (tl_traffic_logger.log_file)
-    return;
+    return Res::kAlreadyLogging;
 
 #ifdef __linux__
   // Open file with append mode, without it concurrent fiber writes seem to conflict
@@ -230,21 +238,31 @@ void OpenTrafficLogger(string_view base_path) {
   auto file = util::fb2::OpenWrite(path, io::WriteFile::Options{/*.append = */ false});
   if (!file) {
     LOG(ERROR) << "Error opening a file " << path << " for traffic logging: " << file.error();
-    return;
+    return Res::kOpenFailed;
   }
   tl_traffic_logger.log_file = unique_ptr<io::WriteFile>{file.value()};
+  tl_traffic_logger.listener_mask = listener_mask;
 #else
   LOG(WARNING) << "Traffic logger is only supported on Linux";
+  return Res::kOpenFailed;
 #endif
 
-  // Write version, incremental numbering :)
-  uint8_t version[1] = {2};
+  // File header: version byte.
+  // v3 added per-record listener type packed into the upper bits (8..15) of the former
+  // `has_more` (now `flags`) field. v2 files are forwards-compatible for v3 readers:
+  // the upper bits are zero and get mapped to RESP. v2 readers cannot parse v3 files.
+  uint8_t version[1] = {3};
   std::ignore = tl_traffic_logger.log_file->Write(version);
+  return Res::kStarted;
 }
 
-void LogTraffic(uint32_t id, bool has_more, const cmn::BackedArguments& args,
-                ServiceInterface::ContextInfo ci) {
-  string_view cmd = args.Front();
+// Writes a single record. `parts[0]` is the command name, following entries are its arguments.
+void LogTrafficParts(uint32_t id, bool has_more, uint32_t db_index,
+                     Connection::ListenerType listener_type, absl::Span<const string_view> parts) {
+  if (parts.empty())
+    return;
+
+  string_view cmd = parts.front();
   if (absl::EqualsIgnoreCase(cmd, "debug"sv))
     return;
 
@@ -253,7 +271,7 @@ void LogTraffic(uint32_t id, bool has_more, const cmn::BackedArguments& args,
   char stack_buf[1024];
   char* next = stack_buf;
 
-  // We write id, timestamp, db_index, has_more, num_parts, part_len, part_len, part_len, ...
+  // We write id, timestamp, db_index, flags, num_parts, part_len, part_len, part_len, ...
   // And then all the part blobs concatenated together.
   auto write_u32 = [&next](uint32_t i) {
     absl::little_endian::Store32(next, i);
@@ -268,11 +286,12 @@ void LogTraffic(uint32_t id, bool has_more, const cmn::BackedArguments& args,
   next += 8;
 
   // db_index
-  write_u32(ci.db_index);
+  write_u32(db_index);
 
-  // has_more, num_parts
-  write_u32(has_more ? 1 : 0);
-  write_u32(uint32_t(args.size()));
+  // flags: bit 0 = has_more; bits 8..15 = listener_type (v3 file format).
+  uint32_t flags = (has_more ? 1u : 0u) | (static_cast<uint32_t>(listener_type) << 8);
+  write_u32(flags);
+  write_u32(uint32_t(parts.size()));
 
   // Grab the lock and check if the file is still open.
   lock_guard lk{tl_traffic_logger.mutex};
@@ -280,7 +299,7 @@ void LogTraffic(uint32_t id, bool has_more, const cmn::BackedArguments& args,
     return;
 
   // part_len, ...
-  for (auto part : args.view()) {
+  for (string_view part : parts) {
     if (size_t(next - stack_buf + 4) > sizeof(stack_buf)) {
       if (!tl_traffic_logger.Write(string_view{stack_buf, size_t(next - stack_buf)})) {
         return;
@@ -297,7 +316,7 @@ void LogTraffic(uint32_t id, bool has_more, const cmn::BackedArguments& args,
     blobs[index++] = iovec{.iov_base = stack_buf, .iov_len = size_t(next - stack_buf)};
   }
 
-  for (auto part : args.view()) {
+  for (string_view part : parts) {
     if (auto blob_len = part.size(); blob_len > 0) {
       blobs[index++] = iovec{.iov_base = const_cast<char*>(part.data()), .iov_len = blob_len};
 
@@ -313,6 +332,90 @@ void LogTraffic(uint32_t id, bool has_more, const cmn::BackedArguments& args,
   if (index) {
     tl_traffic_logger.Write(blobs.data(), index);
   }
+}
+
+void LogTraffic(uint32_t id, bool has_more, const cmn::BackedArguments& args,
+                ServiceInterface::ContextInfo ci, Connection::ListenerType listener_type) {
+  absl::InlinedVector<string_view, 16> parts;
+  parts.reserve(args.size());
+  for (auto v : args.view())
+    parts.push_back(v);
+  LogTrafficParts(id, has_more, ci.db_index, listener_type, absl::MakeSpan(parts));
+}
+
+// Variant used by the Memcache protocol path.
+//
+// The memcache parser keeps fields that are NOT arguments in scalar Command members
+// (flags, expire_ts, delta, cas_unique) rather than in `backed_args`. We serialize
+// them into the record so that tools/replay has enough context to reproduce the
+// command faithfully. Record layout per command type:
+//
+//   SET/ADD/REPLACE/APPEND/PREPEND : [cmd, key, value, flags, expire_ts]
+//   CAS                            : [cas, key, value, flags, expire_ts, cas_unique]
+//   INCR/DECR                      : [cmd, key, delta]
+//   GAT/GATS                       : [cmd, expire_ts, key+]  (expire BEFORE keys, matches wire)
+//   all others (GET/GETS/DELETE/
+//               FLUSHALL/STATS/
+//               QUIT/VERSION)      : [cmd, *backed_args]
+void LogMemcacheTraffic(uint32_t id, bool has_more, const MemcacheParser::Command& mc,
+                        ServiceInterface::ContextInfo ci, Connection::ListenerType listener_type) {
+  using MP = MemcacheParser;
+  string_view cmd_name = MP::CmdName(mc.type);
+  if (cmd_name.empty())
+    return;
+
+  // owned backs stringified numeric fields. We use a fixed-size std::array
+  // rather than a resizable vector so that string_views inserted into `parts`
+  // remain stable even if more fields are appended in the future: std::array
+  // never reallocates. kMaxOwned must be >= the largest per-type push count
+  // (currently 3, for CAS: flags + expire_ts + cas_unique).
+  constexpr size_t kMaxOwned = 4;
+  std::array<string, kMaxOwned> owned;
+  size_t owned_n = 0;
+
+  absl::InlinedVector<string_view, 16> parts;
+  parts.reserve(mc.backed_args->size() + kMaxOwned + 1);
+  parts.push_back(cmd_name);
+
+  auto push_num = [&](uint64_t n) {
+    DCHECK_LT(owned_n, kMaxOwned);
+    owned[owned_n] = absl::StrCat(n);
+    parts.push_back(owned[owned_n]);
+    ++owned_n;
+  };
+
+  // For GAT/GATS we want expire_ts to precede the key list because the parser can
+  // push multiple keys into backed_args; placing expire at the end would make the
+  // expire index depend on the number of keys.
+  if (mc.type == MP::GAT || mc.type == MP::GATS)
+    push_num(mc.raw_expire_ts);
+
+  for (string_view a : mc.backed_args->view())
+    parts.push_back(a);
+
+  switch (mc.type) {
+    case MP::SET:
+    case MP::ADD:
+    case MP::REPLACE:
+    case MP::APPEND:
+    case MP::PREPEND:
+      push_num(mc.flags);
+      push_num(mc.raw_expire_ts);
+      break;
+    case MP::CAS:
+      push_num(mc.flags);
+      push_num(mc.raw_expire_ts);
+      push_num(mc.cas_unique);
+      break;
+    case MP::INCR:
+    case MP::DECR:
+      push_num(mc.delta);
+      break;
+    default:
+      break;
+  }
+
+  LogTrafficParts(id, has_more, ci.db_index, listener_type, absl::MakeSpan(parts));
 }
 
 constexpr size_t kMinReadSize = 256;
@@ -722,6 +825,14 @@ void Connection::OnConnectionStart() {
   // is null in unit-tests.
   if (const Listener* lsnr = static_cast<Listener*>(listener()); lsnr) {
     is_main_ = lsnr->IsMainInterface();
+    if (lsnr->IsPrivilegedInterface()) {
+      listener_type_ = ListenerType::ADMIN;
+    } else if (protocol_ == Protocol::MEMCACHE) {
+      listener_type_ = ListenerType::MEMCACHE;
+    } else {
+      // RESP covers TCP main listener as well as unix-socket RESP listeners.
+      listener_type_ = ListenerType::RESP;
+    }
   }
 
   if (GetFlag(FLAGS_tcp_nodelay) && !socket_->IsUDS()) {
@@ -1302,8 +1413,10 @@ Connection::ParserStatus Connection::ParseRedis(unsigned max_busy_cycles, bool e
       request_consumed_bytes_ = 0;
       bool has_more = consumed < read_buffer.size();
 
-      if (tl_traffic_logger.log_file && IsMain() /* log only on the main interface */) {
-        LogTraffic(id_, has_more, *parsed_cmd_, service_->GetContextInfo(cc_.get()));
+      if (tl_traffic_logger.log_file &&
+          (tl_traffic_logger.listener_mask & (1u << static_cast<uint8_t>(listener_type_)))) {
+        LogTraffic(id_, has_more, *parsed_cmd_, service_->GetContextInfo(cc_.get()),
+                   listener_type_);
       }
 
       if (enqueue_only) {
@@ -2201,8 +2314,9 @@ void Connection::RequestAsyncMigration(util::fb2::ProactorBase* dest, bool force
   }
 }
 
-void Connection::StartTrafficLogging(string_view path) {
-  OpenTrafficLogger(path);
+Connection::StartTrafficResult Connection::StartTrafficLogging(string_view path,
+                                                               uint32_t listener_mask) {
+  return OpenTrafficLogger(path, listener_mask);
 }
 
 void Connection::StopTrafficLogging() {
@@ -2341,6 +2455,13 @@ bool Connection::ParseMCBatch() {
              << unsigned(parsed_cmd_->mc_command()->type);
     if (result == MemcacheParser::INPUT_PENDING)
       return false;
+
+    if (result == MemcacheParser::OK && tl_traffic_logger.log_file &&
+        (tl_traffic_logger.listener_mask & (1u << static_cast<uint8_t>(listener_type_)))) {
+      bool has_more = io_buf_.InputLen() > 0;
+      LogMemcacheTraffic(id_, has_more, *parsed_cmd_->mc_command(),
+                         service_->GetContextInfo(cc_.get()), listener_type_);
+    }
 
     // We push the command to the parsed queue even in case of parse errors,
     // so that we can reply in order.

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -180,7 +180,7 @@ struct TrafficLogger {
   // Listener type that this thread's file is recording. Only connections with a
   // matching `listener_type_` produce records; others are skipped on the hot path.
   // Set once when the file is opened, cleared in ResetLocked().
-  Connection::ListenerType listener_type = Connection::ListenerType::RESP;
+  Connection::ListenerType listener_type = Connection::ListenerType::MAIN_RESP;
 
   void ResetLocked();
   // Returns true if Write succeeded, false if it failed and the recording should be aborted.
@@ -193,7 +193,7 @@ void TrafficLogger::ResetLocked() {
     std::ignore = log_file->Close();
     log_file.reset();
   }
-  listener_type = Connection::ListenerType::RESP;
+  listener_type = Connection::ListenerType::MAIN_RESP;
 }
 
 // Returns true if Write succeeded, false if it failed and the recording should be aborted.
@@ -258,10 +258,11 @@ Connection::StartTrafficResult OpenTrafficLogger(string_view base_path,
 }
 
 // Writes a single record. `parts[0]` is the command name, following entries are its arguments.
+// Callers must guarantee a non-empty span (both LogTraffic and LogMemcacheTraffic push
+// the command name as the first element before invoking this function).
 void LogTrafficParts(uint32_t id, bool has_more, uint32_t db_index,
                      absl::Span<const string_view> parts) {
-  if (parts.empty())
-    return;
+  DCHECK(!parts.empty());
 
   string_view cmd = parts.front();
   if (absl::EqualsIgnoreCase(cmd, "debug"sv))
@@ -822,12 +823,12 @@ void Connection::OnConnectionStart() {
   if (const Listener* lsnr = static_cast<Listener*>(listener()); lsnr) {
     is_main_ = lsnr->IsMainInterface();
     if (lsnr->IsPrivilegedInterface()) {
-      listener_type_ = ListenerType::ADMIN;
+      listener_type_ = ListenerType::ADMIN_RESP;
     } else if (protocol_ == Protocol::MEMCACHE) {
       listener_type_ = ListenerType::MEMCACHE;
     } else {
-      // RESP covers TCP main listener as well as unix-socket RESP listeners.
-      listener_type_ = ListenerType::RESP;
+      // MAIN_RESP covers TCP main listener as well as unix-socket RESP listeners.
+      listener_type_ = ListenerType::MAIN_RESP;
     }
   }
 

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -231,13 +231,6 @@ class Connection : public util::Connection {
   // and only when the flag --migrate_connections is true.
   void RequestAsyncMigration(util::fb2::ProactorBase* dest, bool force);
 
-  // Bit mask over ListenerType values indicating which listeners are being recorded.
-  // Bit N (1 << static_cast<uint8_t>(ListenerType::X)) is set if listener X is logged.
-  static constexpr uint32_t kAllListenersMask =
-      (1u << static_cast<uint8_t>(ListenerType::RESP)) |
-      (1u << static_cast<uint8_t>(ListenerType::MEMCACHE)) |
-      (1u << static_cast<uint8_t>(ListenerType::ADMIN));
-
   // Outcome of a StartTrafficLogging call on a single thread.
   enum class StartTrafficResult : uint8_t {
     kStarted,         // new recording started successfully on this thread
@@ -246,11 +239,11 @@ class Connection : public util::Connection {
   };
 
   // Starts traffic logging in the calling thread. Must be a proactor thread.
-  // Each thread creates its own log file combining requests from all the connections in
-  // that thread whose listener matches `listener_mask`. See StartTrafficResult for the
-  // possible outcomes; callers must distinguish AlreadyLogging (expected when the user
-  // forgot to STOP) from OpenFailed (unrelated I/O error).
-  static StartTrafficResult StartTrafficLogging(std::string_view base_path, uint32_t listener_mask);
+  // Each thread creates its own log file containing requests from connections on
+  // that thread whose listener type equals `listener_type`. Exactly one listener
+  // kind per recording — mixing protocols in a single file is not supported.
+  static StartTrafficResult StartTrafficLogging(std::string_view base_path,
+                                                ListenerType listener_type);
 
   // Stops traffic logging in this thread. A noop if the thread is not logging.
   static void StopTrafficLogging();

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -191,6 +191,19 @@ class Connection : public util::Connection {
   // This method returns true for customer facing listeners.
   bool IsMainOrMemcache() const;
 
+  // Classification of the listener this connection belongs to, used as a filter for the
+  // traffic logger (DEBUG TRAFFIC) and persisted in the recorded file format.
+  // The numeric values are part of the on-disk format, do not change them.
+  enum class ListenerType : uint8_t {
+    RESP = 1,      // main RESP listener (TCP and unix-socket)
+    MEMCACHE = 2,  // memcached protocol listener
+    ADMIN = 3,     // privileged / admin listener
+  };
+
+  ListenerType GetListenerType() const {
+    return listener_type_;
+  }
+
   void SetName(std::string name);
 
   void SetLibName(std::string name);
@@ -218,10 +231,26 @@ class Connection : public util::Connection {
   // and only when the flag --migrate_connections is true.
   void RequestAsyncMigration(util::fb2::ProactorBase* dest, bool force);
 
+  // Bit mask over ListenerType values indicating which listeners are being recorded.
+  // Bit N (1 << static_cast<uint8_t>(ListenerType::X)) is set if listener X is logged.
+  static constexpr uint32_t kAllListenersMask =
+      (1u << static_cast<uint8_t>(ListenerType::RESP)) |
+      (1u << static_cast<uint8_t>(ListenerType::MEMCACHE)) |
+      (1u << static_cast<uint8_t>(ListenerType::ADMIN));
+
+  // Outcome of a StartTrafficLogging call on a single thread.
+  enum class StartTrafficResult : uint8_t {
+    kStarted,         // new recording started successfully on this thread
+    kAlreadyLogging,  // this thread already had an active recording (noop)
+    kOpenFailed,      // failed to open the log file (or unsupported platform)
+  };
+
   // Starts traffic logging in the calling thread. Must be a proactor thread.
   // Each thread creates its own log file combining requests from all the connections in
-  // that thread. A noop if the thread is already logging.
-  static void StartTrafficLogging(std::string_view base_path);
+  // that thread whose listener matches `listener_mask`. See StartTrafficResult for the
+  // possible outcomes; callers must distinguish AlreadyLogging (expected when the user
+  // forgot to STOP) from OpenFailed (unrelated I/O error).
+  static StartTrafficResult StartTrafficLogging(std::string_view base_path, uint32_t listener_mask);
 
   // Stops traffic logging in this thread. A noop if the thread is not logging.
   static void StopTrafficLogging();
@@ -531,6 +560,8 @@ class Connection : public util::Connection {
       bool pending_input_ : 1;
     };
   };
+
+  ListenerType listener_type_ = ListenerType::RESP;
 
   bool request_shutdown_ = false;
 };

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -194,10 +194,12 @@ class Connection : public util::Connection {
   // Classification of the listener this connection belongs to, used as a filter for the
   // traffic logger (DEBUG TRAFFIC) and persisted in the recorded file format.
   // The numeric values are part of the on-disk format, do not change them.
+  // MAIN_RESP and ADMIN_RESP share the RESP protocol but live on different ports
+  // (main TCP/unix-socket vs. privileged admin port).
   enum class ListenerType : uint8_t {
-    RESP = 1,      // main RESP listener (TCP and unix-socket)
-    MEMCACHE = 2,  // memcached protocol listener
-    ADMIN = 3,     // privileged / admin listener
+    MAIN_RESP = 1,   // main RESP listener (TCP and unix-socket)
+    MEMCACHE = 2,    // memcached protocol listener
+    ADMIN_RESP = 3,  // privileged / admin listener (RESP protocol on admin port)
   };
 
   ListenerType GetListenerType() const {
@@ -554,7 +556,7 @@ class Connection : public util::Connection {
     };
   };
 
-  ListenerType listener_type_ = ListenerType::RESP;
+  ListenerType listener_type_ = ListenerType::MAIN_RESP;
 
   bool request_shutdown_ = false;
 };

--- a/src/facade/memcache_parser.cc
+++ b/src/facade/memcache_parser.cc
@@ -94,6 +94,7 @@ MP::Result ParseStore(ArgSlice tokens, int64_t now, MP::Command* res, uint32_t m
     return MP::PARSE_ERROR;
   }
 
+  res->raw_expire_ts = expire_ts;
   res->expire_ts = ToAbsolute(expire_ts, now);
 
   if (res->type == MP::CAS && !absl::SimpleAtoi(tokens[4], &res->cas_unique)) {
@@ -126,6 +127,7 @@ MP::Result ParseValueless(ArgSlice tokens, int64_t now, MP::Command* res) {
     if (!absl::SimpleAtoi(tokens[0], &expire_ts)) {
       return MP::BAD_INT;
     }
+    res->raw_expire_ts = expire_ts;
     res->expire_ts = ToAbsolute(expire_ts, now);
     ++key_pos;
   }
@@ -277,6 +279,7 @@ MP::Result ParseMeta(ArgSlice tokens, int64_t now, MP::Command* res, uint32_t ma
       case 'T':
         if (!absl::SimpleAtoi(token.substr(1), &expire_ts))
           return MP::BAD_INT;
+        res->raw_expire_ts = expire_ts;
         res->expire_ts = ToAbsolute(expire_ts, now);
         if (res->type == MP::GET)
           res->type = MP::GAT;
@@ -471,6 +474,62 @@ auto MP::ConsumeValue(std::string_view str, uint32_t* consumed, Command* dest) -
   } while (val_len_to_read_ && !str.empty());
 
   return val_len_to_read_ > 0 ? MP::INPUT_PENDING : MP::OK;
+}
+
+// Inverse of the token map in From(): enum -> wire token. Only used by the
+// traffic logger, which is off most of the time, so a switch is plenty.
+string_view MP::CmdName(CmdType type) {
+  switch (type) {
+    case MP::SET:
+      return "set"sv;
+    case MP::ADD:
+      return "add"sv;
+    case MP::REPLACE:
+      return "replace"sv;
+    case MP::APPEND:
+      return "append"sv;
+    case MP::PREPEND:
+      return "prepend"sv;
+    case MP::CAS:
+      return "cas"sv;
+    case MP::GET:
+      return "get"sv;
+    case MP::GETS:
+      return "gets"sv;
+    case MP::GAT:
+      return "gat"sv;
+    case MP::GATS:
+      return "gats"sv;
+    case MP::STATS:
+      return "stats"sv;
+    case MP::INCR:
+      return "incr"sv;
+    case MP::DECR:
+      return "decr"sv;
+    case MP::DELETE:
+      return "delete"sv;
+    case MP::FLUSHALL:
+      return "flush_all"sv;
+    case MP::QUIT:
+      return "quit"sv;
+    case MP::VERSION:
+      return "version"sv;
+    case MP::META_NOOP:
+      return "mn"sv;
+    case MP::META_SET:
+      return "ms"sv;
+    case MP::META_DEL:
+      return "md"sv;
+    case MP::META_ARITHM:
+      return "ma"sv;
+    case MP::META_GET:
+      return "mg"sv;
+    case MP::META_DEBUG:
+      return "me"sv;
+    case MP::INVALID:
+      return ""sv;
+  }
+  return ""sv;
 }
 
 }  // namespace facade

--- a/src/facade/memcache_parser.h
+++ b/src/facade/memcache_parser.h
@@ -90,6 +90,12 @@ class MemcacheParser {
 
     int64_t expire_ts = 0;  // unix time (expire_ts > month) in seconds
 
+    // Original, pre-ToAbsolute exptime token as sent by the client. Kept so that
+    // tools/replay can reproduce the exact wire command: relative exptimes stay
+    // relative on replay (re-resolved against the replayer's "now"), absolute
+    // exptimes stay absolute. `expire_ts` above is always the absolutised form.
+    uint32_t raw_expire_ts = 0;
+
     // flags for STORE commands
     uint32_t flags = 0;
 
@@ -99,7 +105,7 @@ class MemcacheParser {
     cmn::BackedArguments* backed_args = nullptr;
   };
 
-  static_assert(sizeof(Command) == 40);
+  static_assert(sizeof(Command) == 48);
 
   enum Result : uint8_t {
     OK,
@@ -113,6 +119,11 @@ class MemcacheParser {
   static bool IsStoreCmd(CmdType type) {
     return type >= SET && type <= CAS;
   }
+
+  // Returns the wire-protocol token for `type` (e.g. "set", "mg"), or an empty
+  // string_view for INVALID / unrecognized values. Used by the traffic logger
+  // so that the memcache command name does not need to be duplicated in callers.
+  static std::string_view CmdName(CmdType type);
 
   size_t UsedMemory() const {
     return tmp_buf_.capacity();

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -668,7 +668,7 @@ void DebugCmd::Run(CmdArgList args, CommandContext* cmd_cntx) {
         "    calling VALUES OFF command.",
         "TX",
         "    Performs transaction analysis per shard.",
-        "TRAFFIC START <path>/<file_prefix> LISTENER <resp|memcache|admin>",
+        "TRAFFIC START <path>/<file_prefix> LISTENER <main|memcache|admin>",
         "    Start traffic logging for a single listener type to files with the given",
         "    path/prefix. LISTENER is required; mixing listeners in one recording is",
         "    intentionally not supported - start separate recordings per listener.",
@@ -1062,52 +1062,36 @@ void DebugCmd::LogTraffic(CmdArgList args, CommandContext* cmd_cntx) {
 
   // Syntax:
   //   DEBUG TRAFFIC STOP
-  //   DEBUG TRAFFIC START <path> LISTENER <resp|memcache|admin>
+  //   DEBUG TRAFFIC START <path> LISTENER <main|memcache|admin>
   // A recording captures exactly one listener type; mixing protocols in one file is
   // intentionally not supported.
-  if (args.empty()) {
-    return cmd_cntx->SendError(facade::kSyntaxErr);
-  }
-
-  string first = absl::AsciiStrToUpper(ArgS(args, 0));
-
-  if (first == "STOP" && args.size() == 1) {
+  CmdArgParser parser(args);
+  if (parser.Check("STOP")) {
+    if (!parser.Finalize())
+      return cmd_cntx->SendError(parser.TakeError().MakeReply());
     LOG(INFO) << "Traffic logging stopped";
     shard_set->pool()->AwaitFiberOnAll([](auto*) { Connection::StopTrafficLogging(); });
     return rb->SendOk();
   }
 
-  if (first != "START" || args.size() != 4) {
-    return cmd_cntx->SendError(facade::kSyntaxErr);
-  }
+  parser.ExpectTag("START");
+  auto path = parser.Next<string_view>();
+  parser.ExpectTag("LISTENER");
+  auto listener_type = parser.MapNext("main", Connection::ListenerType::MAIN_RESP, "memcache",
+                                      Connection::ListenerType::MEMCACHE, "admin",
+                                      Connection::ListenerType::ADMIN_RESP);
+  if (!parser.Finalize())
+    return cmd_cntx->SendError(parser.TakeError().MakeReply());
 
-  string path(ArgS(args, 1));
-  string keyword = absl::AsciiStrToUpper(ArgS(args, 2));
-  if (keyword != "LISTENER") {
-    return cmd_cntx->SendError(facade::kSyntaxErr);
-  }
-
-  Connection::ListenerType listener_type;
-  string name = absl::AsciiStrToLower(ArgS(args, 3));
-  if (name == "resp") {
-    listener_type = Connection::ListenerType::RESP;
-  } else if (name == "memcache") {
-    listener_type = Connection::ListenerType::MEMCACHE;
-  } else if (name == "admin") {
-    listener_type = Connection::ListenerType::ADMIN;
-  } else {
-    return cmd_cntx->SendError(
-        absl::StrCat("Unknown listener '", name, "'. Expected one of: resp, memcache, admin"));
-  }
-
-  LOG(INFO) << "Logging traffic to " << path << "*.bin, listener=" << name;
+  LOG(INFO) << "Logging traffic to " << path << "*.bin, listener=" << unsigned(listener_type);
 
   std::atomic<unsigned> started_new{0};
   std::atomic<unsigned> already_logging{0};
   std::atomic<unsigned> open_failed{0};
+  std::string path_str(path);
   shard_set->pool()->AwaitFiberOnAll(
-      [path, listener_type, &started_new, &already_logging, &open_failed](auto*) {
-        switch (Connection::StartTrafficLogging(path, listener_type)) {
+      [path_str, listener_type, &started_new, &already_logging, &open_failed](auto*) {
+        switch (Connection::StartTrafficLogging(path_str, listener_type)) {
           case Connection::StartTrafficResult::kStarted:
             started_new.fetch_add(1, std::memory_order_relaxed);
             break;
@@ -1124,31 +1108,29 @@ void DebugCmd::LogTraffic(CmdArgList args, CommandContext* cmd_cntx) {
   unsigned refused = already_logging.load(std::memory_order_relaxed);
   unsigned failed = open_failed.load(std::memory_order_relaxed);
 
-  // Failures are always terminal: if any thread failed to open its file the recording
-  // would be incomplete. Roll back any thread that did start so we end up fully stopped.
-  if (failed > 0) {
+  // Any failure rolls back any thread that started, then reports a specific error.
+  // The only success path is when every thread reports kStarted.
+  if (failed > 0 || refused > 0) {
     if (started > 0)
       shard_set->pool()->AwaitFiberOnAll([](auto*) { Connection::StopTrafficLogging(); });
-    return cmd_cntx->SendError(
-        "Failed to open traffic log file on one or more threads; "
-        "no recording is active. Check server logs for details.");
-  }
 
-  if (refused > 0 && started > 0) {
-    // Partial state: some threads started a new recording, others refused because they
-    // were already logging. The previously-active recording is already corrupt (half its
-    // threads are now writing to the new file) and cannot be restored, so stop everything
-    // to reach a clean non-logging state before reporting the error.
-    shard_set->pool()->AwaitFiberOnAll([](auto*) { Connection::StopTrafficLogging(); });
-    return cmd_cntx->SendError(
-        "Traffic logging was in an inconsistent state; all recording has been stopped. "
-        "Retry DEBUG TRAFFIC START.");
-  }
-  if (refused > 0) {
-    // Every thread was already logging - leave that recording alone and just report the
-    // conflict to the caller.
-    return cmd_cntx->SendError(
-        "Traffic logging is already in progress. Call DEBUG TRAFFIC STOP first.");
+    const char* msg;
+    if (failed > 0) {
+      msg =
+          "Failed to open traffic log file on one or more threads; "
+          "no recording is active. Check server logs for details.";
+    } else if (started > 0) {
+      // Partial state: some threads started a new recording while others refused
+      // (they were already logging). The previously-active recording is now split
+      // across two files and cannot be restored, so we stop everything.
+      msg =
+          "Traffic logging was in an inconsistent state; all recording has been stopped. "
+          "Retry DEBUG TRAFFIC START.";
+    } else {
+      // Every thread was already logging — the original recording is untouched.
+      msg = "Traffic logging is already in progress. Call DEBUG TRAFFIC STOP first.";
+    }
+    return cmd_cntx->SendError(msg);
   }
   rb->SendOk();
 }

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -668,10 +668,12 @@ void DebugCmd::Run(CmdArgList args, CommandContext* cmd_cntx) {
         "    calling VALUES OFF command.",
         "TX",
         "    Performs transaction analysis per shard.",
-        "TRAFFIC <path>/<file_prefix> | [STOP]",
-        "    Use <path>/<file_prefix> to start traffic logging to the specified path.",
-        "    All recorded files will have the specified prefix.",
-        "    Use 'STOP' or do not specify any arguments to stop traffic logging.",
+        "TRAFFIC START <path>/<file_prefix> [LISTENER <resp|memcache|admin|all> ...]",
+        "    Start traffic logging to files with the given path/prefix.",
+        "    Optional LISTENER clause restricts recording to one or more listener kinds.",
+        "    Without LISTENER, every listener is recorded.",
+        "TRAFFIC STOP",
+        "    Stop traffic logging started by a previous TRAFFIC START.",
         "RECVSIZE [<tid> | ENABLE | DISABLE]",
         "    Prints the histogram of the received request sizes on the given thread",
         "COMPRESSION [IMPORT <bintable> | EXPORT | SET <bintable>] [type]",
@@ -1051,25 +1053,110 @@ void DebugCmd::Exec(CommandContext* cmd_cntx) {
 }
 
 void DebugCmd::LogTraffic(CmdArgList args, CommandContext* cmd_cntx) {
-  optional<string> path;
+  using facade::Connection;
+
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (ProactorBase::me()->GetKind() != ProactorBase::IOURING) {
     return cmd_cntx->SendError("Traffic recording supported only on iouring");
   }
 
-  if (args.size() == 1 && absl::AsciiStrToUpper(facade::ToSV(args.front())) != "STOP"sv) {
-    path = ArgS(args, 0);
-    LOG(INFO) << "Logging to traffic to " << *path << "*.bin";
-  } else {
-    LOG(INFO) << "Traffic logging stopped";
+  // Syntax:
+  //   DEBUG TRAFFIC STOP
+  //   DEBUG TRAFFIC START <path> [LISTENER <resp|memcache|admin|all> ...]
+  if (args.empty()) {
+    return cmd_cntx->SendError(facade::kSyntaxErr);
   }
 
-  shard_set->pool()->AwaitFiberOnAll([path](auto*) {
-    if (path)
-      facade::Connection::StartTrafficLogging(*path);
-    else
-      facade::Connection::StopTrafficLogging();
-  });
+  string first = absl::AsciiStrToUpper(ArgS(args, 0));
+
+  if (first == "STOP" && args.size() == 1) {
+    LOG(INFO) << "Traffic logging stopped";
+    shard_set->pool()->AwaitFiberOnAll([](auto*) { Connection::StopTrafficLogging(); });
+    return rb->SendOk();
+  }
+
+  if (first != "START" || args.size() < 2) {
+    return cmd_cntx->SendError(facade::kSyntaxErr);
+  }
+
+  string path(ArgS(args, 1));
+  uint32_t mask = 0;
+
+  if (args.size() == 2) {
+    // No LISTENER clause => record all listener types.
+    mask = Connection::kAllListenersMask;
+  } else {
+    string keyword = absl::AsciiStrToUpper(ArgS(args, 2));
+    if (keyword != "LISTENER" || args.size() < 4) {
+      return cmd_cntx->SendError(facade::kSyntaxErr);
+    }
+    for (size_t i = 3; i < args.size(); ++i) {
+      string name = absl::AsciiStrToLower(ArgS(args, i));
+      if (name == "all") {
+        mask = Connection::kAllListenersMask;
+      } else if (name == "resp") {
+        mask |= 1u << static_cast<uint8_t>(Connection::ListenerType::RESP);
+      } else if (name == "memcache") {
+        mask |= 1u << static_cast<uint8_t>(Connection::ListenerType::MEMCACHE);
+      } else if (name == "admin") {
+        mask |= 1u << static_cast<uint8_t>(Connection::ListenerType::ADMIN);
+      } else {
+        return cmd_cntx->SendError(absl::StrCat("Unknown listener name '", name,
+                                                "'. Expected one of: resp, memcache, admin, all"));
+      }
+    }
+  }
+
+  LOG(INFO) << "Logging traffic to " << path << "*.bin, listener_mask=0x" << std::hex << mask;
+
+  std::atomic<unsigned> started_new{0};
+  std::atomic<unsigned> already_logging{0};
+  std::atomic<unsigned> open_failed{0};
+  shard_set->pool()->AwaitFiberOnAll(
+      [path, mask, &started_new, &already_logging, &open_failed](auto*) {
+        switch (Connection::StartTrafficLogging(path, mask)) {
+          case Connection::StartTrafficResult::kStarted:
+            started_new.fetch_add(1, std::memory_order_relaxed);
+            break;
+          case Connection::StartTrafficResult::kAlreadyLogging:
+            already_logging.fetch_add(1, std::memory_order_relaxed);
+            break;
+          case Connection::StartTrafficResult::kOpenFailed:
+            open_failed.fetch_add(1, std::memory_order_relaxed);
+            break;
+        }
+      });
+
+  unsigned started = started_new.load(std::memory_order_relaxed);
+  unsigned refused = already_logging.load(std::memory_order_relaxed);
+  unsigned failed = open_failed.load(std::memory_order_relaxed);
+
+  // Failures are always terminal: if any thread failed to open its file the recording
+  // would be incomplete. Roll back any thread that did start so we end up fully stopped.
+  if (failed > 0) {
+    if (started > 0)
+      shard_set->pool()->AwaitFiberOnAll([](auto*) { Connection::StopTrafficLogging(); });
+    return cmd_cntx->SendError(
+        "Failed to open traffic log file on one or more threads; "
+        "no recording is active. Check server logs for details.");
+  }
+
+  if (refused > 0 && started > 0) {
+    // Partial state: some threads started a new recording, others refused because they
+    // were already logging. The previously-active recording is already corrupt (half its
+    // threads are now writing to the new file) and cannot be restored, so stop everything
+    // to reach a clean non-logging state before reporting the error.
+    shard_set->pool()->AwaitFiberOnAll([](auto*) { Connection::StopTrafficLogging(); });
+    return cmd_cntx->SendError(
+        "Traffic logging was in an inconsistent state; all recording has been stopped. "
+        "Retry DEBUG TRAFFIC START.");
+  }
+  if (refused > 0) {
+    // Every thread was already logging - leave that recording alone and just report the
+    // conflict to the caller.
+    return cmd_cntx->SendError(
+        "Traffic logging is already in progress. Call DEBUG TRAFFIC STOP first.");
+  }
   rb->SendOk();
 }
 

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -668,10 +668,10 @@ void DebugCmd::Run(CmdArgList args, CommandContext* cmd_cntx) {
         "    calling VALUES OFF command.",
         "TX",
         "    Performs transaction analysis per shard.",
-        "TRAFFIC START <path>/<file_prefix> [LISTENER <resp|memcache|admin|all> ...]",
-        "    Start traffic logging to files with the given path/prefix.",
-        "    Optional LISTENER clause restricts recording to one or more listener kinds.",
-        "    Without LISTENER, every listener is recorded.",
+        "TRAFFIC START <path>/<file_prefix> LISTENER <resp|memcache|admin>",
+        "    Start traffic logging for a single listener type to files with the given",
+        "    path/prefix. LISTENER is required; mixing listeners in one recording is",
+        "    intentionally not supported - start separate recordings per listener.",
         "TRAFFIC STOP",
         "    Stop traffic logging started by a previous TRAFFIC START.",
         "RECVSIZE [<tid> | ENABLE | DISABLE]",
@@ -1062,7 +1062,9 @@ void DebugCmd::LogTraffic(CmdArgList args, CommandContext* cmd_cntx) {
 
   // Syntax:
   //   DEBUG TRAFFIC STOP
-  //   DEBUG TRAFFIC START <path> [LISTENER <resp|memcache|admin|all> ...]
+  //   DEBUG TRAFFIC START <path> LISTENER <resp|memcache|admin>
+  // A recording captures exactly one listener type; mixing protocols in one file is
+  // intentionally not supported.
   if (args.empty()) {
     return cmd_cntx->SendError(facade::kSyntaxErr);
   }
@@ -1075,46 +1077,37 @@ void DebugCmd::LogTraffic(CmdArgList args, CommandContext* cmd_cntx) {
     return rb->SendOk();
   }
 
-  if (first != "START" || args.size() < 2) {
+  if (first != "START" || args.size() != 4) {
     return cmd_cntx->SendError(facade::kSyntaxErr);
   }
 
   string path(ArgS(args, 1));
-  uint32_t mask = 0;
-
-  if (args.size() == 2) {
-    // No LISTENER clause => record all listener types.
-    mask = Connection::kAllListenersMask;
-  } else {
-    string keyword = absl::AsciiStrToUpper(ArgS(args, 2));
-    if (keyword != "LISTENER" || args.size() < 4) {
-      return cmd_cntx->SendError(facade::kSyntaxErr);
-    }
-    for (size_t i = 3; i < args.size(); ++i) {
-      string name = absl::AsciiStrToLower(ArgS(args, i));
-      if (name == "all") {
-        mask = Connection::kAllListenersMask;
-      } else if (name == "resp") {
-        mask |= 1u << static_cast<uint8_t>(Connection::ListenerType::RESP);
-      } else if (name == "memcache") {
-        mask |= 1u << static_cast<uint8_t>(Connection::ListenerType::MEMCACHE);
-      } else if (name == "admin") {
-        mask |= 1u << static_cast<uint8_t>(Connection::ListenerType::ADMIN);
-      } else {
-        return cmd_cntx->SendError(absl::StrCat("Unknown listener name '", name,
-                                                "'. Expected one of: resp, memcache, admin, all"));
-      }
-    }
+  string keyword = absl::AsciiStrToUpper(ArgS(args, 2));
+  if (keyword != "LISTENER") {
+    return cmd_cntx->SendError(facade::kSyntaxErr);
   }
 
-  LOG(INFO) << "Logging traffic to " << path << "*.bin, listener_mask=0x" << std::hex << mask;
+  Connection::ListenerType listener_type;
+  string name = absl::AsciiStrToLower(ArgS(args, 3));
+  if (name == "resp") {
+    listener_type = Connection::ListenerType::RESP;
+  } else if (name == "memcache") {
+    listener_type = Connection::ListenerType::MEMCACHE;
+  } else if (name == "admin") {
+    listener_type = Connection::ListenerType::ADMIN;
+  } else {
+    return cmd_cntx->SendError(
+        absl::StrCat("Unknown listener '", name, "'. Expected one of: resp, memcache, admin"));
+  }
+
+  LOG(INFO) << "Logging traffic to " << path << "*.bin, listener=" << name;
 
   std::atomic<unsigned> started_new{0};
   std::atomic<unsigned> already_logging{0};
   std::atomic<unsigned> open_failed{0};
   shard_set->pool()->AwaitFiberOnAll(
-      [path, mask, &started_new, &already_logging, &open_failed](auto*) {
-        switch (Connection::StartTrafficLogging(path, mask)) {
+      [path, listener_type, &started_new, &already_logging, &open_failed](auto*) {
+        switch (Connection::StartTrafficLogging(path, listener_type)) {
           case Connection::StartTrafficResult::kStarted:
             started_new.fetch_add(1, std::memory_order_relaxed);
             break;

--- a/tools/replay/main.go
+++ b/tools/replay/main.go
@@ -13,8 +13,10 @@ import (
 	"github.com/pterm/pterm"
 )
 
-var fHost = flag.String("host", "127.0.0.1:6379", "Redis host")
-var fCompareHost = flag.String("compare-host", "", "Redis host to compare with")
+var fHost = flag.String("host", "127.0.0.1:6379", "RESP host for main-listener replay")
+var fAdminHost = flag.String("admin-host", "", "RESP host for admin-listener replay; defaults to -host if empty")
+var fMCHost = flag.String("mc-host", "127.0.0.1:11211", "Memcached host for memcache-listener replay")
+var fCompareHost = flag.String("compare-host", "", "RESP host to compare with")
 var fClientBuffer = flag.Int("buffer", 100, "How many records to buffer per client")
 var fPace = flag.Bool("pace", true, "whether to pace the traffic according to the original timings.false - to pace as fast as possible")
 var fSkip = flag.Uint("skip", 0, "skip N records")
@@ -194,7 +196,7 @@ func Analyze(files []string) {
 
 		parseRecords(file, func(r Record) bool {
 			total += 1
-			if r.HasMore > 0 {
+			if r.HasMore() {
 				chained += 1
 			}
 

--- a/tools/replay/main.go
+++ b/tools/replay/main.go
@@ -147,7 +147,7 @@ func Print(files []string) {
 	for i, file := range files {
 		tops[i].ch = make(chan Record, 100)
 		go func(ch chan Record, file string) {
-			parseRecords(file, func(r Record) bool {
+			parseRecords(file, nil, func(r Record) bool {
 				ch <- r
 				return true
 			}, *fIgnoreParseErrors)
@@ -194,7 +194,7 @@ func Analyze(files []string) {
 	for _, file := range files {
 		fileClients := make(map[uint32]bool)
 
-		parseRecords(file, func(r Record) bool {
+		parseRecords(file, nil, func(r Record) bool {
 			total += 1
 			if r.HasMore() {
 				chained += 1
@@ -246,6 +246,8 @@ func main() {
 
 		fmt.Fprintln(os.Stderr, "\nExamples:")
 		fmt.Fprintf(os.Stderr, "   %s -host 192.168.1.10:6379 -buffer 50 run *.bin\n", binaryName)
+		fmt.Fprintf(os.Stderr, "   %s -mc-host 192.168.1.10:11211 run *.bin\n", binaryName)
+		fmt.Fprintf(os.Stderr, "   %s -host 192.168.1.10:6379 -admin-host 192.168.1.10:6380 run *.bin\n", binaryName)
 		fmt.Fprintf(os.Stderr, "   %s -skip-time-sec 30 run *.bin\n", binaryName)
 		fmt.Fprintf(os.Stderr, "   %s -time-limit 60 run *.bin\n", binaryName)
 		fmt.Fprintf(os.Stderr, "   %s print *.bin\n", binaryName)

--- a/tools/replay/main.go
+++ b/tools/replay/main.go
@@ -14,11 +14,9 @@ import (
 )
 
 var fHost = flag.String("host", "127.0.0.1:6379",
-	"host:port of the replay target. By default interpreted as RESP (both main and admin listener "+
-		"records go here); pass -memcache to interpret it as a memcached server")
-var fMemcache = flag.Bool("memcache", false,
-	"if true, -host is a memcached server and only memcache-listener files are replayed. "+
-		"If false (default), only RESP-listener files (main + admin) are replayed")
+	"host:port of the replay target. The client protocol is chosen per file from its "+
+		"header (MAIN_RESP/ADMIN_RESP use RESP, MEMCACHE uses the memcache text protocol); "+
+		"-host must speak the protocol of the files being replayed")
 var fCompareHost = flag.String("compare-host", "", "RESP host to compare with (main listener only)")
 var fClientBuffer = flag.Int("buffer", 100, "How many records to buffer per client")
 var fPace = flag.Bool("pace", true, "whether to pace the traffic according to the original timings.false - to pace as fast as possible")
@@ -248,8 +246,8 @@ func main() {
 		fmt.Fprintln(os.Stderr, "  analyze - analyzes the traffic")
 
 		fmt.Fprintln(os.Stderr, "\nExamples:")
-		fmt.Fprintf(os.Stderr, "   %s -host 192.168.1.10:6379 -buffer 50 run *.bin\n", binaryName)
-		fmt.Fprintf(os.Stderr, "   %s -host 192.168.1.10:11211 -memcache run *.bin\n", binaryName)
+		fmt.Fprintf(os.Stderr, "   %s -host 192.168.1.10:6379 -buffer 50 run *.bin        # RESP files\n", binaryName)
+		fmt.Fprintf(os.Stderr, "   %s -host 192.168.1.10:11211 run *.bin                  # memcache files\n", binaryName)
 		fmt.Fprintf(os.Stderr, "   %s -skip-time-sec 30 run *.bin\n", binaryName)
 		fmt.Fprintf(os.Stderr, "   %s -time-limit 60 run *.bin\n", binaryName)
 		fmt.Fprintf(os.Stderr, "   %s print *.bin\n", binaryName)

--- a/tools/replay/main.go
+++ b/tools/replay/main.go
@@ -13,10 +13,13 @@ import (
 	"github.com/pterm/pterm"
 )
 
-var fHost = flag.String("host", "127.0.0.1:6379", "RESP host for main-listener replay")
-var fAdminHost = flag.String("admin-host", "", "RESP host for admin-listener replay; defaults to -host if empty")
-var fMCHost = flag.String("mc-host", "127.0.0.1:11211", "Memcached host for memcache-listener replay")
-var fCompareHost = flag.String("compare-host", "", "RESP host to compare with")
+var fHost = flag.String("host", "127.0.0.1:6379",
+	"host:port of the replay target. By default interpreted as RESP (both main and admin listener "+
+		"records go here); pass -memcache to interpret it as a memcached server")
+var fMemcache = flag.Bool("memcache", false,
+	"if true, -host is a memcached server and only memcache-listener files are replayed. "+
+		"If false (default), only RESP-listener files (main + admin) are replayed")
+var fCompareHost = flag.String("compare-host", "", "RESP host to compare with (main listener only)")
 var fClientBuffer = flag.Int("buffer", 100, "How many records to buffer per client")
 var fPace = flag.Bool("pace", true, "whether to pace the traffic according to the original timings.false - to pace as fast as possible")
 var fSkip = flag.Uint("skip", 0, "skip N records")
@@ -246,8 +249,7 @@ func main() {
 
 		fmt.Fprintln(os.Stderr, "\nExamples:")
 		fmt.Fprintf(os.Stderr, "   %s -host 192.168.1.10:6379 -buffer 50 run *.bin\n", binaryName)
-		fmt.Fprintf(os.Stderr, "   %s -mc-host 192.168.1.10:11211 run *.bin\n", binaryName)
-		fmt.Fprintf(os.Stderr, "   %s -host 192.168.1.10:6379 -admin-host 192.168.1.10:6380 run *.bin\n", binaryName)
+		fmt.Fprintf(os.Stderr, "   %s -host 192.168.1.10:11211 -memcache run *.bin\n", binaryName)
 		fmt.Fprintf(os.Stderr, "   %s -skip-time-sec 30 run *.bin\n", binaryName)
 		fmt.Fprintf(os.Stderr, "   %s -time-limit 60 run *.bin\n", binaryName)
 		fmt.Fprintf(os.Stderr, "   %s print *.bin\n", binaryName)

--- a/tools/replay/memcache.go
+++ b/tools/replay/memcache.go
@@ -17,8 +17,8 @@ import (
 
 // mcClient is a synchronous text-protocol memcache client. Each command is
 // written in full and its reply is consumed before returning, so replay is
-// sequential per connection (matches gomemcache's model and the realities of
-// ASCII memcache, which has no pipelining).
+// sequential per connection — matching the memcache ASCII protocol, which has
+// no request multiplexing.
 type mcClient struct {
 	addr string
 	conn net.Conn
@@ -125,9 +125,9 @@ func (c *mcClient) Cas(key string, flags uint32, exp int64, casUnique uint64, va
 	c.send(hdr, value)
 }
 
-// Retrieve issues `<cmd> <key>...\r\n` where cmd is get|gets|gat|gats.
-// For gat/gats, the caller must include <exp> as the first key field via
-// passing a custom header builder (see dispatchMC).
+// Retrieve issues `<cmd> <key>...\r\n` where cmd is get|gets. For gat/gats use
+// RetrieveGat — those commands need an <exp> token between the command and the
+// key list so they get their own helper.
 func (c *mcClient) Retrieve(cmd string, keys []string) {
 	var b bytes.Buffer
 	b.WriteString(cmd)

--- a/tools/replay/memcache.go
+++ b/tools/replay/memcache.go
@@ -1,0 +1,174 @@
+// Package main: minimal raw-TCP memcache ASCII protocol client used by the
+// traffic replayer. Exists because we need to reproduce *exactly* the wire
+// commands that were recorded (including CAS tokens, GAT one-shot semantics,
+// multi-key requests, flags/expire, etc.) — high-level libraries like
+// gomemcache hide those details.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"strconv"
+)
+
+// mcClient is a synchronous text-protocol memcache client. Each command is
+// written in full and its reply is consumed before returning, so replay is
+// sequential per connection (matches gomemcache's model and the realities of
+// ASCII memcache, which has no pipelining).
+type mcClient struct {
+	addr string
+	conn net.Conn
+	r    *bufio.Reader
+	w    *bufio.Writer
+}
+
+func newMCClient(addr string) *mcClient {
+	c := &mcClient{addr: addr}
+	c.dial()
+	return c
+}
+
+func (c *mcClient) dial() {
+	conn, err := net.Dial("tcp", c.addr)
+	if err != nil {
+		log.Fatalf("memcache dial %s: %v", c.addr, err)
+	}
+	c.conn = conn
+	c.r = bufio.NewReader(conn)
+	c.w = bufio.NewWriter(conn)
+}
+
+// writeAll writes the prepared command buffer (including any value block and
+// terminating \r\n), flushes and reads the server reply.
+func (c *mcClient) writeAll(cmd []byte) {
+	if _, err := c.w.Write(cmd); err != nil {
+		log.Printf("memcache write to %s failed: %v", c.addr, err)
+		return
+	}
+	if err := c.w.Flush(); err != nil {
+		log.Printf("memcache flush to %s failed: %v", c.addr, err)
+		return
+	}
+	c.drainReply()
+}
+
+// drainReply consumes one server reply. For retrieval commands this means
+// reading VALUE lines + data blocks until END; for everything else a single
+// line. Non-fatal: errors are logged and the reader is left positioned
+// wherever possible so replay can continue.
+func (c *mcClient) drainReply() {
+	for {
+		line, err := c.r.ReadBytes('\n')
+		if err != nil {
+			if err != io.EOF {
+				log.Printf("memcache read from %s failed: %v", c.addr, err)
+			}
+			return
+		}
+		switch {
+		case bytes.HasPrefix(line, []byte("VALUE ")):
+			// VALUE <key> <flags> <bytes> [<cas>]\r\n  -- followed by <bytes> + "\r\n"
+			fields := bytes.Fields(line)
+			if len(fields) < 4 {
+				return
+			}
+			n, err := strconv.Atoi(string(fields[3]))
+			if err != nil {
+				return
+			}
+			// Read exactly n bytes + trailing \r\n.
+			if _, err := io.CopyN(io.Discard, c.r, int64(n)+2); err != nil {
+				return
+			}
+			// Loop — next line is either another VALUE or END.
+		case bytes.HasPrefix(line, []byte("STAT ")):
+			// STATS reply is a sequence of STAT lines terminated by END.
+			// Keep reading.
+		default:
+			// All other terminal responses are single-line: STORED, NOT_STORED,
+			// EXISTS, NOT_FOUND, DELETED, END, OK, VERSION..., <decimal>,
+			// ERROR, CLIENT_ERROR..., SERVER_ERROR...
+			return
+		}
+	}
+}
+
+// send formats `<header>\r\n[value\r\n]` and issues it.
+// value may be nil for non-store commands.
+func (c *mcClient) send(header string, value []byte) {
+	// Preallocate: header + \r\n + value + \r\n
+	buf := make([]byte, 0, len(header)+4+len(value))
+	buf = append(buf, header...)
+	buf = append(buf, '\r', '\n')
+	if value != nil {
+		buf = append(buf, value...)
+		buf = append(buf, '\r', '\n')
+	}
+	c.writeAll(buf)
+}
+
+// Store replays SET/ADD/REPLACE/APPEND/PREPEND.
+func (c *mcClient) Store(cmd, key string, flags uint32, exp int64, value []byte) {
+	hdr := fmt.Sprintf("%s %s %d %d %d", cmd, key, flags, exp, len(value))
+	c.send(hdr, value)
+}
+
+// Cas replays `cas <key> <flags> <exp> <bytes> <cas_unique>\r\n<value>\r\n`.
+// The server will reply STORED or EXISTS — the same response the original
+// client saw, preserving the CAS-miss behaviour.
+func (c *mcClient) Cas(key string, flags uint32, exp int64, casUnique uint64, value []byte) {
+	hdr := fmt.Sprintf("cas %s %d %d %d %d", key, flags, exp, len(value), casUnique)
+	c.send(hdr, value)
+}
+
+// Retrieve issues `<cmd> <key>...\r\n` where cmd is get|gets|gat|gats.
+// For gat/gats, the caller must include <exp> as the first key field via
+// passing a custom header builder (see dispatchMC).
+func (c *mcClient) Retrieve(cmd string, keys []string) {
+	var b bytes.Buffer
+	b.WriteString(cmd)
+	for _, k := range keys {
+		b.WriteByte(' ')
+		b.WriteString(k)
+	}
+	c.send(b.String(), nil)
+}
+
+// RetrieveGat issues `gat|gats <exp> <key>...\r\n`.
+func (c *mcClient) RetrieveGat(cmd string, exp int64, keys []string) {
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "%s %d", cmd, exp)
+	for _, k := range keys {
+		b.WriteByte(' ')
+		b.WriteString(k)
+	}
+	c.send(b.String(), nil)
+}
+
+// Delete replays `delete <key> [extras...]\r\n`. Memcache's deprecated delayed
+// delete (`delete <key> <time>`) parses into backed_args as extra tokens —
+// forward them verbatim so behaviour matches the original request.
+func (c *mcClient) Delete(key string, extras []string) {
+	var b bytes.Buffer
+	b.WriteString("delete ")
+	b.WriteString(key)
+	for _, e := range extras {
+		b.WriteByte(' ')
+		b.WriteString(e)
+	}
+	c.send(b.String(), nil)
+}
+
+// IncrDecr replays `incr|decr <key> <delta>\r\n`.
+func (c *mcClient) IncrDecr(cmd, key string, delta uint64) {
+	c.send(fmt.Sprintf("%s %s %d", cmd, key, delta), nil)
+}
+
+// FlushAll replays `flush_all\r\n`.
+func (c *mcClient) FlushAll() {
+	c.send("flush_all", nil)
+}

--- a/tools/replay/parsing.go
+++ b/tools/replay/parsing.go
@@ -51,8 +51,11 @@ func parseRecords(filename string, cb func(Record) bool, ignoreErrors bool) erro
 
 	var version uint8
 	binary.Read(reader, binary.LittleEndian, &version)
-	if version != 2 {
-		panic("Requires version two replayer, roll back in commits!")
+	// v2: legacy main-listener-only recordings.
+	// v3: per-record listener type packed into the upper bits of the Flags field
+	//     (bits 8..15). Layout is otherwise identical to v2.
+	if version != 2 && version != 3 {
+		log.Fatalf("Unsupported traffic log version %d (supported: 2, 3)", version)
 	}
 
 	recordNum := 0

--- a/tools/replay/parsing.go
+++ b/tools/replay/parsing.go
@@ -65,7 +65,7 @@ func parseRecords(filename string, onHeader func(listenerType uint8),
 	var listenerType uint8
 	switch version {
 	case 2:
-		listenerType = ListenerRESP
+		listenerType = ListenerMainRESP
 	case 3:
 		if err := binary.Read(reader, binary.LittleEndian, &listenerType); err != nil {
 			return err

--- a/tools/replay/parsing.go
+++ b/tools/replay/parsing.go
@@ -40,7 +40,15 @@ func parseStrings(file io.Reader) (out []interface{}, err error) {
 	return
 }
 
-func parseRecords(filename string, cb func(Record) bool, ignoreErrors bool) error {
+// parseRecords reads a traffic log file. The file header (version + listener
+// type) is delivered via onHeader before any record callback runs, so callers
+// can configure per-listener behaviour up-front. onHeader may be nil.
+//
+// File format v2: one byte version = 2, then records. Legacy main-listener
+// only, treated as RESP on read.
+// File format v3: one byte version = 3, one byte listener_type, then records.
+func parseRecords(filename string, onHeader func(listenerType uint8),
+	cb func(Record) bool, ignoreErrors bool) error {
 	file, err := os.Open(filename)
 	if err != nil {
 		return err
@@ -50,12 +58,23 @@ func parseRecords(filename string, cb func(Record) bool, ignoreErrors bool) erro
 	reader := bufio.NewReader(file)
 
 	var version uint8
-	binary.Read(reader, binary.LittleEndian, &version)
-	// v2: legacy main-listener-only recordings.
-	// v3: per-record listener type packed into the upper bits of the Flags field
-	//     (bits 8..15). Layout is otherwise identical to v2.
-	if version != 2 && version != 3 {
+	if err := binary.Read(reader, binary.LittleEndian, &version); err != nil {
+		return err
+	}
+
+	var listenerType uint8
+	switch version {
+	case 2:
+		listenerType = ListenerRESP
+	case 3:
+		if err := binary.Read(reader, binary.LittleEndian, &listenerType); err != nil {
+			return err
+		}
+	default:
 		log.Fatalf("Unsupported traffic log version %d (supported: 2, 3)", version)
+	}
+	if onHeader != nil {
+		onHeader(listenerType)
 	}
 
 	recordNum := 0

--- a/tools/replay/workers.go
+++ b/tools/replay/workers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -14,11 +15,35 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
+// Listener type identifiers as stored in traffic log v3 (must match
+// facade::Connection::ListenerType in the C++ code).
+const (
+	ListenerRESP     uint8 = 1
+	ListenerMemcache uint8 = 2
+	ListenerAdmin    uint8 = 3
+)
+
+// Flags field layout:
+//
+//	bit 0        : 1 if the next record belongs to the same batch as this one (HasMore)
+//	bits 8..15   : listener type (v3 only; 0 in v2 files -> treat as RESP)
 type RecordHeader struct {
 	Client  uint32
 	Time    uint64
 	DbIndex uint32
-	HasMore uint32
+	Flags   uint32
+}
+
+func (h RecordHeader) HasMore() bool {
+	return h.Flags&1 != 0
+}
+
+func (h RecordHeader) ListenerType() uint8 {
+	lt := uint8(h.Flags >> 8)
+	if lt == 0 {
+		return ListenerRESP
+	}
+	return lt
 }
 
 type Record struct {
@@ -42,12 +67,18 @@ func DetermineBaseTime(files []string) time.Time {
 
 // Handles a single connection/client
 type ClientWorker struct {
-	redis     *redis.Client
+	// RESP path (used for resp and admin listeners).
+	redis       *redis.Client
 	compare     *redis.Client
+	pipe        redis.Pipeliner
+	comparePipe redis.Pipeliner
+
+	// Memcache path (used for memcache listener).
+	mc           *mcClient
+	listenerType uint8
+
 	incoming  chan Record
 	processed uint
-	pipe      redis.Pipeliner
-	comparePipe redis.Pipeliner
 }
 
 // Pipeline length ranges for summary
@@ -63,13 +94,13 @@ var pipelineRanges = []struct {
 }
 
 var compareIgnoreCmds = []string{
-    "HELLO",
-    "AUTH",
-    "SELECT",
-    "INFO",
-    "TIME",
-    "CLIENT",
-    "CONFIG",
+	"HELLO",
+	"AUTH",
+	"SELECT",
+	"INFO",
+	"TIME",
+	"CLIENT",
+	"CONFIG",
 }
 
 // Handles a single file and distributes messages to clients
@@ -113,81 +144,90 @@ func trackLatency(worker *FileWorker, batchLatency float64, size int) {
 }
 
 func ignoreCompareCmd(c redis.Cmder) bool {
-    args := c.Args()
-    if len(args) == 0 {
-        return true
-    }
-    name := strings.ToUpper(fmt.Sprint(args[0]))
-    for _, ign := range compareIgnoreCmds {
-        if name == ign {
-            return true
-        }
-    }
-    return false
+	args := c.Args()
+	if len(args) == 0 {
+		return true
+	}
+	name := strings.ToUpper(fmt.Sprint(args[0]))
+	for _, ign := range compareIgnoreCmds {
+		if name == ign {
+			return true
+		}
+	}
+	return false
 }
 
 func cmdAsString(c redis.Cmder) string {
-    args := c.Args()
-    if len(args) == 0 {
-        return "<no-args>"
-    }
+	args := c.Args()
+	if len(args) == 0 {
+		return "<no-args>"
+	}
 
-    name := strings.ToUpper(fmt.Sprint(args[0]))
-    if len(args) == 1 {
-        return name
-    }
+	name := strings.ToUpper(fmt.Sprint(args[0]))
+	if len(args) == 1 {
+		return name
+	}
 
-    parts := make([]string, 0, len(args) - 1)
-    for _, a := range args[1:] {
-        s := fmt.Sprint(a)
-        parts = append(parts, s)
-    }
-    return name + " " + strings.Join(parts, " ")
+	parts := make([]string, 0, len(args)-1)
+	for _, a := range args[1:] {
+		s := fmt.Sprint(a)
+		parts = append(parts, s)
+	}
+	return name + " " + strings.Join(parts, " ")
 }
 
 func cmdResultString(cm redis.Cmder) string {
-    if err := cm.Err(); err != nil {
-        if err == redis.Nil {
-            return "(nil)"
-        }
-        return "ERR: " + err.Error()
-    }
+	if err := cm.Err(); err != nil {
+		if err == redis.Nil {
+			return "(nil)"
+		}
+		return "ERR: " + err.Error()
+	}
 
-    if cmd, ok := cm.(*redis.Cmd); ok {
-        v := cmd.Val()
-        s := fmt.Sprintf("%v", v)
-        return s
-    }
+	if cmd, ok := cm.(*redis.Cmd); ok {
+		v := cmd.Val()
+		s := fmt.Sprintf("%v", v)
+		return s
+	}
 
-    return fmt.Sprintf("<unknown Cmder %T>", cm)
+	return fmt.Sprintf("<unknown Cmder %T>", cm)
 }
 
 func compareCmdResults(a, b []redis.Cmder, lastMsg Record) {
-    if len(a) != len(b) {
-        log.Fatalf("[COMPARE] mismatch count: primary=%d compare=%d (last client=%d time=%d)", len(a), len(b), lastMsg.Client, lastMsg.Time)
-        return
-    }
+	if len(a) != len(b) {
+		log.Fatalf("[COMPARE] mismatch count: primary=%d compare=%d (last client=%d time=%d)", len(a), len(b), lastMsg.Client, lastMsg.Time)
+		return
+	}
 
-    for i := range a {
-		if (ignoreCompareCmd(a[i])) {
+	for i := range a {
+		if ignoreCompareCmd(a[i]) {
 			continue
 		}
 		pa := cmdResultString(a[i])
-        pb := cmdResultString(b[i])
-        if pa != pb {
+		pb := cmdResultString(b[i])
+		if pa != pb {
 			log.Fatalf("[COMPARE] mismatch at idx %d cmd=%s\n  primary=%s\n  compare=%s\n  (client=%d time=%d)", i, cmdAsString(a[i]), pa, pb, lastMsg.Client, lastMsg.Time)
 		}
-    }
+	}
 }
 
 func (c *ClientWorker) Run(pace bool, worker *FileWorker) {
+	if c.listenerType == ListenerMemcache {
+		c.runMC(pace, worker)
+	} else {
+		c.runRedis(pace, worker)
+	}
+	worker.clientGroup.Done()
+}
+
+func (c *ClientWorker) runRedis(pace bool, worker *FileWorker) {
 	for msg := range c.incoming {
 		if c.processed == 0 && msg.DbIndex != 0 {
 			// There is no easy way to switch, we rely on connection pool consisting only of one connection
 			c.redis.Do(context.Background(), []interface{}{"SELECT", fmt.Sprint(msg.DbIndex)})
 			if c.compare != nil {
-        		c.compare.Do(context.Background(), []interface{}{"SELECT", fmt.Sprint(msg.DbIndex)})
-    		}
+				c.compare.Do(context.Background(), []interface{}{"SELECT", fmt.Sprint(msg.DbIndex)})
+			}
 		}
 
 		lag := time.Until(worker.HappensAt(time.Unix(0, int64(msg.Time))))
@@ -201,12 +241,12 @@ func (c *ClientWorker) Run(pace bool, worker *FileWorker) {
 
 		c.pipe.Do(context.Background(), msg.values...).Result()
 		if c.comparePipe != nil {
-    		c.comparePipe.Do(context.Background(), msg.values...).Result()
+			c.comparePipe.Do(context.Background(), msg.values...).Result()
 		}
 
 		atomic.AddUint64(&worker.processed, 1)
 
-		if msg.HasMore == 0 {
+		if !msg.HasMore() {
 			size := c.pipe.Len()
 			start := time.Now()
 			cmds, _ := c.pipe.Exec(context.Background())
@@ -214,35 +254,167 @@ func (c *ClientWorker) Run(pace bool, worker *FileWorker) {
 			trackLatency(worker, batchLatency, size)
 			c.processed += uint(size)
 
-    		if c.comparePipe != nil {
-        		ccmds, _ := c.comparePipe.Exec(context.Background())
-        		compareCmdResults(cmds, ccmds, msg)
-    		}
+			if c.comparePipe != nil {
+				ccmds, _ := c.comparePipe.Exec(context.Background())
+				compareCmdResults(cmds, ccmds, msg)
+			}
 		}
 	}
 
-	if size := c.pipe.Len(); size >= 0 {
+	// Final flush: only run Exec if there is something pending (the input channel
+	// closed mid-batch). Also drain the compare pipeline so its connection does not
+	// keep commands buffered; we don't have a last-message context to attribute a
+	// mismatch to, so we only compare when both pipelines have the same length.
+	if size := c.pipe.Len(); size > 0 {
 		start := time.Now()
-		c.pipe.Exec(context.Background())
+		cmds, _ := c.pipe.Exec(context.Background())
 		batchLatency := float64(time.Since(start).Microseconds())
 		trackLatency(worker, batchLatency, size)
 		c.processed += uint(size)
-	}
 
-	worker.clientGroup.Done()
+		if c.comparePipe != nil && c.comparePipe.Len() == size {
+			ccmds, _ := c.comparePipe.Exec(context.Background())
+			compareCmdResults(cmds, ccmds, Record{})
+		} else if c.comparePipe != nil {
+			// Lengths diverged — still drain so the comparePipe doesn't leak commands.
+			c.comparePipe.Exec(context.Background())
+		}
+	}
 }
 
-func NewClient(w *FileWorker, pace bool) *ClientWorker {
-	client := &ClientWorker{
-		redis:    redis.NewClient(&redis.Options{Addr: *fHost, PoolSize: 1, DisableIndentity: true}),
-		incoming: make(chan Record, *fClientBuffer),
-	}
-	client.pipe = client.redis.Pipeline()
+// runMC replays memcache-listener records via the memcache text protocol.
+// gomemcache has no pipelining, so each command is issued synchronously and the
+// pipeline-range latency digest uses batch size = 1.
+func (c *ClientWorker) runMC(pace bool, worker *FileWorker) {
+	for msg := range c.incoming {
+		lag := time.Until(worker.HappensAt(time.Unix(0, int64(msg.Time))))
+		if lag < 0 {
+			atomic.AddUint64(&worker.delayed, 1)
+		}
+		if pace {
+			time.Sleep(lag)
+		}
 
-	if *fCompareHost != "" {
-        client.compare = redis.NewClient(&redis.Options{Addr: *fCompareHost, PoolSize: 1, DisableIndentity: true})
-        client.comparePipe = client.compare.Pipeline()
-    }
+		start := time.Now()
+		dispatchMC(c.mc, msg.values)
+		trackLatency(worker, float64(time.Since(start).Microseconds()), 1)
+		atomic.AddUint64(&worker.processed, 1)
+		c.processed++
+	}
+}
+
+// dispatchMC maps a recorded memcache command to the raw wire commands sent
+// by the original client. See memcache.go for the underlying TCP client.
+//
+// Record layout written by facade::LogMemcacheTraffic:
+//
+//	SET/ADD/REPLACE/APPEND/PREPEND : [cmd, key, value, flags, expire_ts]
+//	CAS                            : [cas, key, value, flags, expire_ts, cas_unique]
+//	INCR/DECR                      : [cmd, key, delta]
+//	GAT/GATS                       : [cmd, expire_ts, key+]
+//	GET/GETS/DELETE/FLUSHALL/...   : [cmd, *args]
+//
+// Unknown commands are dropped silently.
+func dispatchMC(mc *mcClient, values []interface{}) {
+	if len(values) == 0 {
+		return
+	}
+	name, ok := values[0].(string)
+	if !ok {
+		return
+	}
+	arg := func(i int) string {
+		if i >= len(values) {
+			return ""
+		}
+		s, _ := values[i].(string)
+		return s
+	}
+	argU64 := func(i int) uint64 {
+		v, _ := strconv.ParseUint(arg(i), 10, 64)
+		return v
+	}
+	argI64 := func(i int) int64 {
+		v, _ := strconv.ParseInt(arg(i), 10, 64)
+		return v
+	}
+	argU32 := func(i int) uint32 {
+		return uint32(argU64(i))
+	}
+
+	lc := strings.ToLower(name)
+	switch lc {
+	case "set", "add", "replace", "append", "prepend":
+		mc.Store(lc, arg(1), argU32(3), argI64(4), []byte(arg(2)))
+	case "cas":
+		mc.Cas(arg(1), argU32(3), argI64(4), argU64(5), []byte(arg(2)))
+	case "get", "gets":
+		keys := stringArgs(values, 1)
+		if len(keys) > 0 {
+			mc.Retrieve(lc, keys)
+		}
+	case "gat", "gats":
+		keys := stringArgs(values, 2)
+		if len(keys) > 0 {
+			mc.RetrieveGat(lc, argI64(1), keys)
+		}
+	case "delete":
+		if k := arg(1); k != "" {
+			mc.Delete(k, stringArgs(values, 2))
+		}
+	case "incr", "decr":
+		mc.IncrDecr(lc, arg(1), argU64(2))
+	case "flush_all":
+		mc.FlushAll()
+	case "quit", "version", "stats", "mn":
+		// No-op: control / meta-NOOP commands, not useful for replay.
+	default:
+		// Defensive: parser normalises meta commands (ms/md/ma/mg/me) to their
+		// regular counterparts before logging, so only unknown/corrupted records
+		// can land here. Surface them so replay isn't silently skipping data.
+		log.Printf("replay: unknown memcache command %q skipped", name)
+	}
+}
+
+// stringArgs returns values[start:] coerced to []string (non-string entries
+// are skipped).
+func stringArgs(values []interface{}, start int) []string {
+	out := make([]string, 0, len(values)-start)
+	for i := start; i < len(values); i++ {
+		if s, ok := values[i].(string); ok && s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func NewClient(w *FileWorker, pace bool, listenerType uint8) *ClientWorker {
+	client := &ClientWorker{
+		listenerType: listenerType,
+		incoming:     make(chan Record, *fClientBuffer),
+	}
+
+	switch listenerType {
+	case ListenerMemcache:
+		client.mc = newMCClient(*fMCHost)
+	case ListenerAdmin:
+		// Route admin-listener records to the admin host. Fall back to -host if
+		// -admin-host was not explicitly set (useful when the user replays against
+		// a server that exposes only a single RESP port).
+		addr := *fAdminHost
+		if addr == "" {
+			addr = *fHost
+		}
+		client.redis = redis.NewClient(&redis.Options{Addr: addr, PoolSize: 1, DisableIndentity: true})
+		client.pipe = client.redis.Pipeline()
+	default: // ListenerRESP or unknown
+		client.redis = redis.NewClient(&redis.Options{Addr: *fHost, PoolSize: 1, DisableIndentity: true})
+		client.pipe = client.redis.Pipeline()
+		if *fCompareHost != "" {
+			client.compare = redis.NewClient(&redis.Options{Addr: *fCompareHost, PoolSize: 1, DisableIndentity: true})
+			client.comparePipe = client.compare.Pipeline()
+		}
+	}
 
 	atomic.AddUint64(&w.clients, 1)
 	w.clientGroup.Add(1)
@@ -261,7 +433,7 @@ func (w *FileWorker) Run(file string, wg *sync.WaitGroup) {
 	err := parseRecords(file, func(r Record) bool {
 		client, ok := clients[r.Client]
 		if !ok {
-			client = NewClient(w, *fPace)
+			client = NewClient(w, *fPace, r.ListenerType())
 			clients[r.Client] = client
 		}
 		cmdName := strings.ToLower(r.values[0].(string))

--- a/tools/replay/workers.go
+++ b/tools/replay/workers.go
@@ -25,8 +25,10 @@ const (
 
 // Flags field layout:
 //
-//	bit 0        : 1 if the next record belongs to the same batch as this one (HasMore)
-//	bits 8..15   : listener type (v3 only; 0 in v2 files -> treat as RESP)
+//	bit 0     : 1 if the next record belongs to the same batch as this one (HasMore)
+//	bits 1-31 : reserved, must be zero
+//
+// The listener type is stored once in the file header (see parsing.go), not per record.
 type RecordHeader struct {
 	Client  uint32
 	Time    uint64
@@ -38,14 +40,6 @@ func (h RecordHeader) HasMore() bool {
 	return h.Flags&1 != 0
 }
 
-func (h RecordHeader) ListenerType() uint8 {
-	lt := uint8(h.Flags >> 8)
-	if lt == 0 {
-		return ListenerRESP
-	}
-	return lt
-}
-
 type Record struct {
 	RecordHeader
 	values []interface{} // instead of []string to unwrap into variadic
@@ -55,12 +49,12 @@ type Record struct {
 func DetermineBaseTime(files []string) time.Time {
 	var minTime uint64 = math.MaxUint64
 	for _, file := range files {
-		parseRecords(file, func(r Record) bool {
+		parseRecords(file, nil, func(r Record) bool {
 			if r.Time < minTime {
 				minTime = r.Time
 			}
 			return false
-		}, *fIgnoreParseErrors)
+		}, *fIgnoreParseErrors) //nolint:errcheck
 	}
 	return time.Unix(0, int64(minTime))
 }
@@ -283,7 +277,8 @@ func (c *ClientWorker) runRedis(pace bool, worker *FileWorker) {
 }
 
 // runMC replays memcache-listener records via the memcache text protocol.
-// gomemcache has no pipelining, so each command is issued synchronously and the
+// The ASCII protocol has no multiplexing, so each command is issued synchronously
+// on the per-client connection (see mcClient in memcache.go) and the
 // pipeline-range latency digest uses batch size = 1.
 func (c *ClientWorker) runMC(pace bool, worker *FileWorker) {
 	for msg := range c.incoming {
@@ -430,10 +425,15 @@ func (w *FileWorker) Run(file string, wg *sync.WaitGroup) {
 	}
 	clients := make(map[uint32]*ClientWorker, 0)
 	recordId := uint64(0)
-	err := parseRecords(file, func(r Record) bool {
+	var listenerType uint8
+	err := parseRecords(file, func(lt uint8) {
+		listenerType = lt
+	}, func(r Record) bool {
 		client, ok := clients[r.Client]
 		if !ok {
-			client = NewClient(w, *fPace, r.ListenerType())
+			// Listener type is uniform for the whole file (file-header), so every
+			// client spawned for this FileWorker targets the same backend.
+			client = NewClient(w, *fPace, listenerType)
 			clients[r.Client] = client
 		}
 		cmdName := strings.ToLower(r.values[0].(string))

--- a/tools/replay/workers.go
+++ b/tools/replay/workers.go
@@ -390,16 +390,17 @@ func NewClient(w *FileWorker, pace bool, listenerType uint8) *ClientWorker {
 		incoming:     make(chan Record, *fClientBuffer),
 	}
 
-	// One invocation of the tool targets one backend (RESP or memcached). The
-	// -memcache boolean on the CLI picks the mode; the file-level filter in
-	// FileWorker.Run guarantees we only reach this function with a listener type
-	// that matches the mode.
-	if *fMemcache {
+	// Protocol is decided per file from its header (see FileWorker.Run), so the
+	// same -host can be reused across invocations that target different backends
+	// of the same Dragonfly instance (main RESP port for RESP records, memcache
+	// port for memcache records). Mixing file types in one invocation is the
+	// caller's responsibility — the tool connects as the file says.
+	if listenerType == ListenerMemcache {
 		client.mc = newMCClient(*fHost)
 	} else {
-		// MAIN_RESP and ADMIN_RESP both speak RESP — they share -host. The replay
-		// target is expected to accept admin-class commands on the main port, or
-		// the user points -host at an admin-capable endpoint.
+		// MAIN_RESP and ADMIN_RESP both speak RESP — they share -host. Replaying
+		// admin-listener traffic against a non-admin port may lose privileged
+		// commands; the caller is expected to point -host at the appropriate port.
 		client.redis = redis.NewClient(&redis.Options{Addr: *fHost, PoolSize: 1, DisableIndentity: true})
 		client.pipe = client.redis.Pipeline()
 		// -compare-host only makes sense for the main-listener path.
@@ -424,22 +425,9 @@ func (w *FileWorker) Run(file string, wg *sync.WaitGroup) {
 	clients := make(map[uint32]*ClientWorker, 0)
 	recordId := uint64(0)
 	var listenerType uint8
-	// Files whose listener type does not match the CLI mode (-memcache) are
-	// skipped entirely: a single invocation targets one backend. This keeps the
-	// tool simple to drive against heterogeneous glob expansions like `*.bin`.
-	skipFile := false
 	err := parseRecords(file, func(lt uint8) {
 		listenerType = lt
-		isMC := lt == ListenerMemcache
-		if isMC != *fMemcache {
-			skipFile = true
-			log.Printf("replay: skipping %s (listener_type=%d does not match -memcache=%v)",
-				file, lt, *fMemcache)
-		}
 	}, func(r Record) bool {
-		if skipFile {
-			return false
-		}
 		client, ok := clients[r.Client]
 		if !ok {
 			// Listener type is uniform for the whole file (file-header), so every

--- a/tools/replay/workers.go
+++ b/tools/replay/workers.go
@@ -16,11 +16,12 @@ import (
 )
 
 // Listener type identifiers as stored in traffic log v3 (must match
-// facade::Connection::ListenerType in the C++ code).
+// facade::Connection::ListenerType in the C++ code). MAIN_RESP and ADMIN_RESP
+// both speak RESP but live on different ports on the source server.
 const (
-	ListenerRESP     uint8 = 1
-	ListenerMemcache uint8 = 2
-	ListenerAdmin    uint8 = 3
+	ListenerMainRESP  uint8 = 1
+	ListenerMemcache  uint8 = 2
+	ListenerAdminRESP uint8 = 3
 )
 
 // Flags field layout:
@@ -389,23 +390,20 @@ func NewClient(w *FileWorker, pace bool, listenerType uint8) *ClientWorker {
 		incoming:     make(chan Record, *fClientBuffer),
 	}
 
-	switch listenerType {
-	case ListenerMemcache:
-		client.mc = newMCClient(*fMCHost)
-	case ListenerAdmin:
-		// Route admin-listener records to the admin host. Fall back to -host if
-		// -admin-host was not explicitly set (useful when the user replays against
-		// a server that exposes only a single RESP port).
-		addr := *fAdminHost
-		if addr == "" {
-			addr = *fHost
-		}
-		client.redis = redis.NewClient(&redis.Options{Addr: addr, PoolSize: 1, DisableIndentity: true})
-		client.pipe = client.redis.Pipeline()
-	default: // ListenerRESP or unknown
+	// One invocation of the tool targets one backend (RESP or memcached). The
+	// -memcache boolean on the CLI picks the mode; the file-level filter in
+	// FileWorker.Run guarantees we only reach this function with a listener type
+	// that matches the mode.
+	if *fMemcache {
+		client.mc = newMCClient(*fHost)
+	} else {
+		// MAIN_RESP and ADMIN_RESP both speak RESP — they share -host. The replay
+		// target is expected to accept admin-class commands on the main port, or
+		// the user points -host at an admin-capable endpoint.
 		client.redis = redis.NewClient(&redis.Options{Addr: *fHost, PoolSize: 1, DisableIndentity: true})
 		client.pipe = client.redis.Pipeline()
-		if *fCompareHost != "" {
+		// -compare-host only makes sense for the main-listener path.
+		if listenerType == ListenerMainRESP && *fCompareHost != "" {
 			client.compare = redis.NewClient(&redis.Options{Addr: *fCompareHost, PoolSize: 1, DisableIndentity: true})
 			client.comparePipe = client.compare.Pipeline()
 		}
@@ -426,9 +424,22 @@ func (w *FileWorker) Run(file string, wg *sync.WaitGroup) {
 	clients := make(map[uint32]*ClientWorker, 0)
 	recordId := uint64(0)
 	var listenerType uint8
+	// Files whose listener type does not match the CLI mode (-memcache) are
+	// skipped entirely: a single invocation targets one backend. This keeps the
+	// tool simple to drive against heterogeneous glob expansions like `*.bin`.
+	skipFile := false
 	err := parseRecords(file, func(lt uint8) {
 		listenerType = lt
+		isMC := lt == ListenerMemcache
+		if isMC != *fMemcache {
+			skipFile = true
+			log.Printf("replay: skipping %s (listener_type=%d does not match -memcache=%v)",
+				file, lt, *fMemcache)
+		}
 	}, func(r Record) bool {
+		if skipFile {
+			return false
+		}
 		client, ok := clients[r.Client]
 		if !ok {
 			// Listener type is uniform for the whole file (file-header), so every


### PR DESCRIPTION
Extend `DEBUG TRAFFIC` to record any combination of RESP, memcache, and admin listeners (previously only the main RESP interface) and make `tools/replay` faithfully reproduce memcache traffic via raw wire commands.

Changes:
- New command syntax:
  - `DEBUG TRAFFIC START <path> [LISTENER <resp|memcache|admin|all> ...]`
  - `DEBUG TRAFFIC STOP`
  Replaces `DEBUG TRAFFIC <path>|STOP`. No backwards-compat shim.
- `Connection::ListenerType { RESP=1, MEMCACHE=2, ADMIN=3 }`, set once in `OnConnectionStart` from the listener role + protocol.
- `TrafficLogger` gains a listener bitmask; the hot-path gate in `ParseRedis` no longer hard-codes `IsMain()`.
- Memcache parse path now records commands. `LogMemcacheTraffic` serializes `backed_args` plus the scalar `Command` members that live outside them (`flags`, `expire_ts`, `delta`, `cas_unique`, GAT expire) so the replayer has enough context to reproduce the exact wire command.
- `MemcacheParser::CmdName(CmdType)` exposes the inverse of the parser's command map.
- A second `START` while logging is active now returns an error; the active recording is left untouched (previously it was silently aborted).

File format v3:
- Version byte 2 -> 3.
- Per-record `listener_type` packed into bits 8..15 of the former `has_more` field. Binary layout is unchanged; v2 files remain readable by v3 readers (treated as RESP-only).

tools/replay:
- Parser accepts both v2 and v3 files.
- Per-record dispatch selects the backend by listener type:
  - `-host` for RESP records
  - `-mc-host` for memcache records
  - `-admin-host` (falls back to `-host`) for admin-listener records