### PR TITLE
chore: add logs to detect OOM during replication restart process

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -5,6 +5,7 @@
 #include "server/db_slice.h"
 
 #include "core/dense_set.h"
+#include "strings/human_readable.h"
 
 extern "C" {
 #include "redis/hyperloglog.h"
@@ -963,10 +964,17 @@ util::fb2::Fiber DbSlice::FlushDbIndexes(const std::vector<DbIndex>& indexes) {
   LOG_IF(DFATAL, !fetched_items_.empty())
       << "Some operation might bumped up items outside of a transaction";
 
-  auto cb = [flush_db_arr = std::move(flush_db_arr)]() mutable {
+  ShardId shard_id = owner_->shard_id();
+  auto cb = [flush_db_arr = std::move(flush_db_arr), shard_id]() mutable {
+    LOG(INFO) << "Drakarys shard " << shard_id << " cb entered (pre-destructors)"
+              << " rss="
+              << strings::HumanReadableNumBytes(rss_mem_current.load(std::memory_order_relaxed));
     flush_db_arr.clear();
     ServerState::tlocal()->DecommitMemory(ServerState::kDataHeap | ServerState::kBackingHeap |
                                           ServerState::kGlibcmalloc);
+    LOG(INFO) << "Drakarys shard " << shard_id << " finished decommit"
+              << " rss="
+              << strings::HumanReadableNumBytes(rss_mem_current.load(std::memory_order_relaxed));
   };
 
   return {"flush_dbs", std::move(cb)};

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -5,8 +5,10 @@
 #include "server/rdb_load.h"
 
 #include "absl/strings/escaping.h"
+#include "server/common.h"
 #include "server/search/global_hnsw_index.h"
 #include "server/tiered_storage.h"
+#include "strings/human_readable.h"
 
 extern "C" {
 #include "redis/intset.h"
@@ -2155,7 +2157,8 @@ error_code RdbLoader::Load(io::Source* src) {
     }
 
     if (type == RDB_OPCODE_FULLSYNC_END) {
-      VLOG(1) << "Read RDB_OPCODE_FULLSYNC_END";
+      LOG(INFO) << "Read RDB_OPCODE_FULLSYNC_END rss="
+                << strings::HumanReadableNumBytes(rss_mem_current.load(std::memory_order_relaxed));
       RETURN_ON_ERR(EnsureRead(8));
       mem_buf_->ConsumeInput(8);  // ignore 8 bytes
 

--- a/src/server/rdb_load_context.cc
+++ b/src/server/rdb_load_context.cc
@@ -13,6 +13,7 @@
 #include "base/logging.h"
 #include "facade/redis_parser.h"
 #include "facade/reply_capture.h"
+#include "server/common.h"
 #include "server/conn_context.h"
 #include "server/engine_shard_set.h"
 #include "server/main_service.h"
@@ -20,6 +21,7 @@
 #include "server/search/doc_index.h"
 #include "server/search/global_hnsw_index.h"
 #include "server/sharding.h"
+#include "strings/human_readable.h"
 
 namespace dfly {
 
@@ -378,11 +380,16 @@ void RdbLoadContext::PerformPostLoad(Service* service, bool is_error) {
   // RestoreKeyIndex (above) and RebuildAllIndices (below) run in separate sequential
   // AwaitRunningOnShardQueue calls, so there is no parallel index build that could interfere
   // with the doc_ids assigned during key mapping restoration.
+  LOG(INFO) << "PostLoad: rebuilding search indices across shards has_hnsw_restore="
+            << has_hnsw_restore << " rss="
+            << strings::HumanReadableNumBytes(rss_mem_current.load(std::memory_order_relaxed));
   shard_set->AwaitRunningOnShardQueue([has_hnsw_restore](EngineShard* es) {
     OpArgs op_args{es, nullptr,
                    DbContext{&namespaces->GetDefaultNamespace(), 0, GetCurrentTimeMs()}};
     es->search_indices()->RebuildAllIndices(op_args, has_hnsw_restore);
   });
+  LOG(INFO) << "PostLoad: search index rebuild phase returned rss="
+            << strings::HumanReadableNumBytes(rss_mem_current.load(std::memory_order_relaxed));
 
   // Now execute all pending synonym commands after indices are rebuilt
   for (auto& syn_cmd : synonym_cmds) {

--- a/src/server/rdb_load_context.cc
+++ b/src/server/rdb_load_context.cc
@@ -388,8 +388,6 @@ void RdbLoadContext::PerformPostLoad(Service* service, bool is_error) {
                    DbContext{&namespaces->GetDefaultNamespace(), 0, GetCurrentTimeMs()}};
     es->search_indices()->RebuildAllIndices(op_args, has_hnsw_restore);
   });
-  LOG(INFO) << "PostLoad: search index rebuild phase returned rss="
-            << strings::HumanReadableNumBytes(rss_mem_current.load(std::memory_order_relaxed));
 
   // Now execute all pending synonym commands after indices are rebuilt
   for (auto& syn_cmd : synonym_cmds) {
@@ -397,8 +395,11 @@ void RdbLoadContext::PerformPostLoad(Service* service, bool is_error) {
   }
 
   // Wait until index building ends (all shards' vector data populated).
-  shard_set->RunBlockingInParallel(
-      [](EngineShard* es) { es->search_indices()->BlockUntilConstructionEnd(); });
+  shard_set->RunBlockingInParallel([](EngineShard* es) {
+    es->search_indices()->BlockUntilConstructionEnd();
+    LOG(INFO) << "PostLoad: search index rebuild phase returned rss="
+              << strings::HumanReadableNumBytes(rss_mem_current.load(std::memory_order_relaxed));
+  });
 
   // All shards completed restoration — drain pending ops.
   // DrainPendingVectorUpdates sets kBuilding which allows Add calls.

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2449,7 +2449,8 @@ bool ServerFamily::TEST_IsSaving() const {
 }
 
 void ServerFamily::Drakarys(Transaction* transaction, DbIndex db_ind, bool wait) {
-  VLOG(1) << "Drakarys";
+  LOG(INFO) << "Drakarys start db=" << db_ind << " wait=" << wait
+            << " rss=" << HumanReadableNumBytes(rss_mem_current.load(std::memory_order_relaxed));
 
   vector<fb2::Fiber> fibers(shard_set->size());
   transaction->Execute(
@@ -2462,6 +2463,11 @@ void ServerFamily::Drakarys(Transaction* transaction, DbIndex db_ind, bool wait)
   auto action = wait ? &fb2::Fiber::JoinIfNeeded : &fb2::Fiber::Detach;
   for (auto& f : fibers)
     (f.*action)();
+
+  LOG(INFO) << (wait ? "Drakarys main done (shards joined)"
+                     : "Drakarys main dispatched (shards detached; per-shard 'finished decommit' "
+                       "logs mark real completion)")
+            << " rss=" << HumanReadableNumBytes(rss_mem_current.load(std::memory_order_relaxed));
 }
 
 SaveInfoData ServerFamily::GetLastSaveInfo() const {


### PR DESCRIPTION
Summary: Adds INFO-level RSS logging around the replication restart/flush (“Drakarys”) flow to help diagnose OOM conditions.
Changes: Logs RSS at RDB FULLSYNC end, before/after per-shard decommit, and around post-load search index rebuild dispatch.