### PR TITLE
feat(search): add TFIDF and TFIDF.DOCNORM scorers

### DIFF
--- a/src/core/search/scoring.cc
+++ b/src/core/search/scoring.cc
@@ -14,6 +14,14 @@ double ScoreDocument(ScorerType scorer, const ScoringContext& ctx,
       for (const auto& term : terms)
         score += BM25Std(ctx, term);
       break;
+    case ScorerType::TFIDF:
+      for (const auto& term : terms)
+        score += TfIdf(ctx, term);
+      break;
+    case ScorerType::TFIDF_DOCNORM:
+      for (const auto& term : terms)
+        score += TfIdfDocNorm(ctx, term);
+      break;
   }
   return score;
 }

--- a/src/core/search/scoring.cc
+++ b/src/core/search/scoring.cc
@@ -8,21 +8,21 @@ namespace dfly::search {
 
 double ScoreDocument(ScorerType scorer, const ScoringContext& ctx,
                      const std::vector<ScoringTermInfo>& terms) {
+  auto sc_func = [scorer]() {
+    switch (scorer) {
+      case ScorerType::BM25STD:
+        return &BM25Std;
+      case ScorerType::TFIDF:
+        return &TfIdf;
+      case ScorerType::TFIDF_DOCNORM:
+        return &TfIdfDocNorm;
+    }
+    return static_cast<decltype(&BM25Std)>(nullptr);  // unreachable
+  }();
+
   double score = 0.0;
-  switch (scorer) {
-    case ScorerType::BM25STD:
-      for (const auto& term : terms)
-        score += BM25Std(ctx, term);
-      break;
-    case ScorerType::TFIDF:
-      for (const auto& term : terms)
-        score += TfIdf(ctx, term);
-      break;
-    case ScorerType::TFIDF_DOCNORM:
-      for (const auto& term : terms)
-        score += TfIdfDocNorm(ctx, term);
-      break;
-  }
+  for (const auto& term : terms)
+    score += sc_func(ctx, term);
   return score;
 }
 

--- a/src/core/search/scoring.cc
+++ b/src/core/search/scoring.cc
@@ -6,23 +6,11 @@
 
 namespace dfly::search {
 
-double ScoreDocument(ScorerType scorer, const ScoringContext& ctx,
+double ScoreDocument(ScorerFn scorer, const ScoringContext& ctx,
                      const std::vector<ScoringTermInfo>& terms) {
-  auto sc_func = [scorer]() {
-    switch (scorer) {
-      case ScorerType::BM25STD:
-        return &BM25Std;
-      case ScorerType::TFIDF:
-        return &TfIdf;
-      case ScorerType::TFIDF_DOCNORM:
-        return &TfIdfDocNorm;
-    }
-    return static_cast<decltype(&BM25Std)>(nullptr);  // unreachable
-  }();
-
   double score = 0.0;
   for (const auto& term : terms)
-    score += sc_func(ctx, term);
+    score += scorer(ctx, term);
   return score;
 }
 

--- a/src/core/search/scoring.h
+++ b/src/core/search/scoring.h
@@ -18,7 +18,7 @@ class FieldIndices;
 struct TextIndex;
 
 // Supported scorer types
-enum class ScorerType : int {
+enum class ScorerType : uint8_t {
   BM25STD,        // Standard Okapi BM25 (default)
   TFIDF,          // Classic TF * IDF (no document length normalization)
   TFIDF_DOCNORM,  // TFIDF with document length normalization
@@ -73,26 +73,20 @@ inline double BM25Std(const ScoringContext& ctx, const ScoringTermInfo& term) {
 // Note: returns 0 when a term appears in every document (N == n, no discriminating power).
 // This differs from BM25STD, which adds a "+1" inside the log to keep the score positive.
 inline double TfIdf(const ScoringContext& ctx, const ScoringTermInfo& term) {
-  double f = term.term_freq;
-  if (f == 0 || term.term_docs == 0)
+  if (term.term_docs == 0)
     return 0.0;
 
-  double N = ctx.num_docs;
-  double n = term.term_docs;
   // Clamp N >= n to avoid negative IDF during transient states
-  N = std::max(N, n);
-  double idf = std::log(N / n);
-  return f * idf;
+  double N = std::max(ctx.num_docs, term.term_docs);
+  return std::log(N / term.term_docs) * term.term_freq;
 }
 
 // Compute TFIDF with document length normalization for a single term.
 //
 // Formula: (f * IDF) / fieldDocLen
 inline double TfIdfDocNorm(const ScoringContext& ctx, const ScoringTermInfo& term) {
-  double score = TfIdf(ctx, term);
-  if (score == 0.0 || term.field_doc_len == 0)
-    return score;
-  return score / term.field_doc_len;
+  auto d_len = term.field_doc_len == 0 ? 1 : term.field_doc_len;
+  return TfIdf(ctx, term) / d_len;
 }
 
 // Compute score for a document matched against multiple terms.

--- a/src/core/search/scoring.h
+++ b/src/core/search/scoring.h
@@ -19,7 +19,9 @@ struct TextIndex;
 
 // Supported scorer types
 enum class ScorerType : int {
-  BM25STD,  // Standard Okapi BM25 (default)
+  BM25STD,        // Standard Okapi BM25 (default)
+  TFIDF,          // Classic TF * IDF (no document length normalization)
+  TFIDF_DOCNORM,  // TFIDF with document length normalization
 };
 
 // Per-term information needed for scoring a single document
@@ -63,8 +65,38 @@ inline double BM25Std(const ScoringContext& ctx, const ScoringTermInfo& term) {
   return idf * tf;
 }
 
-// Compute BM25STD score for a document matched against multiple terms.
-// Returns sum of per-term BM25 scores.
+// Compute TFIDF score for a single term in a document.
+//
+// Formula: f * IDF
+// where IDF = ln(N / n), clamped to be non-negative.
+//
+// Note: returns 0 when a term appears in every document (N == n, no discriminating power).
+// This differs from BM25STD, which adds a "+1" inside the log to keep the score positive.
+inline double TfIdf(const ScoringContext& ctx, const ScoringTermInfo& term) {
+  double f = term.term_freq;
+  if (f == 0 || term.term_docs == 0)
+    return 0.0;
+
+  double N = ctx.num_docs;
+  double n = term.term_docs;
+  // Clamp N >= n to avoid negative IDF during transient states
+  N = std::max(N, n);
+  double idf = std::log(N / n);
+  return f * idf;
+}
+
+// Compute TFIDF with document length normalization for a single term.
+//
+// Formula: (f * IDF) / fieldDocLen
+inline double TfIdfDocNorm(const ScoringContext& ctx, const ScoringTermInfo& term) {
+  double score = TfIdf(ctx, term);
+  if (score == 0.0 || term.field_doc_len == 0)
+    return score;
+  return score / term.field_doc_len;
+}
+
+// Compute score for a document matched against multiple terms.
+// Returns sum of per-term scores.
 double ScoreDocument(ScorerType scorer, const ScoringContext& ctx,
                      const std::vector<ScoringTermInfo>& terms);
 

--- a/src/core/search/scoring.h
+++ b/src/core/search/scoring.h
@@ -17,13 +17,6 @@ namespace dfly::search {
 class FieldIndices;
 struct TextIndex;
 
-// Supported scorer types
-enum class ScorerType : uint8_t {
-  BM25STD,        // Standard Okapi BM25 (default)
-  TFIDF,          // Classic TF * IDF (no document length normalization)
-  TFIDF_DOCNORM,  // TFIDF with document length normalization
-};
-
 // Per-term information needed for scoring a single document
 struct ScoringTermInfo {
   uint32_t term_freq = 0;        // How many times this term appears in the document
@@ -36,6 +29,11 @@ struct ScoringTermInfo {
 struct ScoringContext {
   size_t num_docs = 0;  // Total documents in index
 };
+
+// Scorer function signature: computes the score for a single (term, document) pair.
+// Register new scorers by adding a function with this signature and exposing it via
+// ParseScorer in the command layer.
+using ScorerFn = double (*)(const ScoringContext&, const ScoringTermInfo&);
 
 // Compute BM25STD score for a single term in a document.
 //
@@ -90,8 +88,8 @@ inline double TfIdfDocNorm(const ScoringContext& ctx, const ScoringTermInfo& ter
 }
 
 // Compute score for a document matched against multiple terms.
-// Returns sum of per-term scores.
-double ScoreDocument(ScorerType scorer, const ScoringContext& ctx,
+// Returns sum of per-term scores produced by the given scorer function.
+double ScoreDocument(ScorerFn scorer, const ScoringContext& ctx,
                      const std::vector<ScoringTermInfo>& terms);
 
 }  // namespace dfly::search

--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -115,8 +115,8 @@ struct ProfileBuilder {
 struct BasicSearch {
   using LogicOp = AstLogicalNode::LogicOp;
 
-  BasicSearch(const FieldIndices* indices, std::optional<ScorerType> scorer = std::nullopt)
-      : indices_{indices}, scorer_type_{scorer} {
+  BasicSearch(const FieldIndices* indices, ScorerFn scorer = nullptr)
+      : indices_{indices}, scorer_{scorer} {
   }
 
   void EnableProfiling() {
@@ -234,7 +234,7 @@ struct BasicSearch {
 
     // Track matched terms for scoring (prefix/suffix/infix expand to multiple terms).
     // Synonym shadow entries (freq=0) are resolved to their group_id for correct scoring.
-    if (scorer_type_) {
+    if (scorer_) {
       for (auto* index : indices) {
         auto term_cb = [this, index](string_view term, const auto*) {
           std::string resolved{term};
@@ -280,7 +280,7 @@ struct BasicSearch {
 
     if (!active_field.empty()) {
       if (auto* index = GetIndex<TextIndex>(active_field); index) {
-        if (scorer_type_)
+        if (scorer_)
           AddMatchedTerm(index, term);
         return IndexResult{index->Matching(term, strip_whitespace)};
       }
@@ -290,7 +290,7 @@ struct BasicSearch {
     vector<TextIndex*> selected_indices = indices_->GetAllTextIndices();
 
     // Track terms for scoring
-    if (scorer_type_) {
+    if (scorer_) {
       for (auto* index : selected_indices)
         AddMatchedTerm(index, term);
     }
@@ -505,7 +505,7 @@ struct BasicSearch {
     optional<AlgorithmProfile> profile =
         profile_builder_ ? make_optional(profile_builder_->Take()) : nullopt;
 
-    if (scorer_type_ && !matched_text_terms_.empty()) {
+    if (scorer_ && !matched_text_terms_.empty()) {
       // Score ALL matched docs and return top-K by score (not arbitrary cutoff).
       auto [out, total_size, text_scores] = TakeScoredTopK(std::move(result), cuttoff_limit);
       return SearchResult{
@@ -573,7 +573,7 @@ struct BasicSearch {
           term_infos[t].field_avg_doc_len = cursors[t].index->GetFieldAvgDocLen();
         }
       }
-      scored.emplace_back(static_cast<float>(ScoreDocument(*scorer_type_, ctx, term_infos)), doc);
+      scored.emplace_back(static_cast<float>(ScoreDocument(scorer_, ctx, term_infos)), doc);
     }
 
     // Top-K by score (skip sort when no actual cutoff, e.g. FT.AGGREGATE)
@@ -602,7 +602,7 @@ struct BasicSearch {
   }
 
   const FieldIndices* indices_;
-  std::optional<ScorerType> scorer_type_;
+  ScorerFn scorer_ = nullptr;
 
   string error_;
   optional<ProfileBuilder> profile_builder_ = ProfileBuilder{};
@@ -866,7 +866,7 @@ bool SearchAlgorithm::Init(string_view query, const QueryParams* params,
 SearchResult SearchAlgorithm::Search(const FieldIndices* index, size_t cuttoff_limit) const {
   DCHECK(query_);
 
-  auto bs = BasicSearch{index, scorer_type_};
+  auto bs = BasicSearch{index, scorer_};
   if (profiling_enabled_)
     bs.EnableProfiling();
   return bs.Search(*query_, cuttoff_limit);
@@ -915,8 +915,8 @@ void SearchAlgorithm::EnableProfiling() {
   profiling_enabled_ = true;
 }
 
-void SearchAlgorithm::SetScorer(ScorerType type) {
-  scorer_type_ = type;
+void SearchAlgorithm::SetScorer(ScorerFn scorer) {
+  scorer_ = scorer;
 }
 
 const AstVectorRangeNode* SearchAlgorithm::GetVectorRangeNode() const {

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -209,7 +209,7 @@ struct KnnScoreSortOption {
   size_t limit = std::numeric_limits<size_t>::max();
 };
 
-enum class ScorerType : int;
+enum class ScorerType : uint8_t;
 
 // SearchAlgorithm allows searching field indices with a query
 class SearchAlgorithm {

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -15,6 +15,7 @@
 #include "base/pmr/memory_resource.h"
 #include "core/search/base.h"
 #include "core/search/range_tree.h"
+#include "core/search/scoring.h"
 #include "core/search/synonyms.h"
 
 namespace dfly::search {
@@ -209,8 +210,6 @@ struct KnnScoreSortOption {
   size_t limit = std::numeric_limits<size_t>::max();
 };
 
-enum class ScorerType : uint8_t;
-
 // SearchAlgorithm allows searching field indices with a query
 class SearchAlgorithm {
  public:
@@ -237,11 +236,11 @@ class SearchAlgorithm {
 
   void EnableProfiling();
 
-  void SetScorer(ScorerType type);
+  void SetScorer(ScorerFn scorer);
 
  private:
   bool profiling_enabled_ = false;
-  std::optional<ScorerType> scorer_type_;
+  ScorerFn scorer_ = nullptr;
   std::unique_ptr<AstNode> query_;
   std::optional<KnnScoreSortOption> knn_hnsw_score_sort_option_;
 };

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -2844,6 +2844,59 @@ TEST_F(ScoringTest, BM25StdMultiTerm) {
   EXPECT_DOUBLE_EQ(multi, sum);
 }
 
+TEST_F(ScoringTest, TfIdfFormula) {
+  // f=2, N=10, n=3
+  // IDF = ln(10/3) ~ 1.2039
+  // score = 2 * 1.2039 ~ 2.4079
+  ScoringContext ctx{.num_docs = 10};
+  ScoringTermInfo term{.term_freq = 2, .term_docs = 3};
+
+  EXPECT_NEAR(TfIdf(ctx, term), 2.4079, 0.01);
+}
+
+TEST_F(ScoringTest, TfIdfZeroFreq) {
+  ScoringContext ctx{.num_docs = 10};
+  ScoringTermInfo term{.term_freq = 0, .term_docs = 3};
+
+  EXPECT_EQ(TfIdf(ctx, term), 0.0);
+}
+
+TEST_F(ScoringTest, TfIdfRareTermHigherScore) {
+  // Same TF, but rare term (small n) should score higher than common term (large n)
+  ScoringContext ctx{.num_docs = 100};
+  ScoringTermInfo rare{.term_freq = 1, .term_docs = 2};
+  ScoringTermInfo common{.term_freq = 1, .term_docs = 50};
+
+  EXPECT_GT(TfIdf(ctx, rare), TfIdf(ctx, common));
+}
+
+TEST_F(ScoringTest, TfIdfDocNormShorterDocScoresHigher) {
+  // Same TF/IDF, but shorter doc should score higher after length normalization
+  ScoringContext ctx{.num_docs = 10};
+  ScoringTermInfo short_doc{.term_freq = 1, .term_docs = 3, .field_doc_len = 5};
+  ScoringTermInfo long_doc{.term_freq = 1, .term_docs = 3, .field_doc_len = 50};
+
+  EXPECT_GT(TfIdfDocNorm(ctx, short_doc), TfIdfDocNorm(ctx, long_doc));
+}
+
+TEST_F(ScoringTest, TfIdfDocNormZeroDocLen) {
+  // field_doc_len = 0 should not cause division by zero — falls back to unnormalized score
+  ScoringContext ctx{.num_docs = 10};
+  ScoringTermInfo term{.term_freq = 1, .term_docs = 3, .field_doc_len = 0};
+
+  EXPECT_EQ(TfIdfDocNorm(ctx, term), TfIdf(ctx, term));
+}
+
+TEST_F(ScoringTest, ScoreDocumentDispatchesByScorerType) {
+  ScoringContext ctx{.num_docs = 10};
+  ScoringTermInfo term{
+      .term_freq = 2, .term_docs = 3, .field_doc_len = 5, .field_avg_doc_len = 5.0};
+
+  EXPECT_DOUBLE_EQ(ScoreDocument(ScorerType::BM25STD, ctx, {term}), BM25Std(ctx, term));
+  EXPECT_DOUBLE_EQ(ScoreDocument(ScorerType::TFIDF, ctx, {term}), TfIdf(ctx, term));
+  EXPECT_DOUBLE_EQ(ScoreDocument(ScorerType::TFIDF_DOCNORM, ctx, {term}), TfIdfDocNorm(ctx, term));
+}
+
 TEST_F(ScoringTest, SearchWithScorer) {
   // Integration test: build index, search with scorer, verify scores are non-zero
   Schema schema = MakeSimpleSchema({{"field", SchemaField::TEXT}});

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -2838,7 +2838,7 @@ TEST_F(ScoringTest, BM25StdMultiTerm) {
   ScoringTermInfo t2{
       .term_freq = 1, .term_docs = 20, .field_doc_len = 10, .field_avg_doc_len = 10.0};
 
-  double multi = ScoreDocument(ScorerType::BM25STD, ctx, {t1, t2});
+  double multi = ScoreDocument(&BM25Std, ctx, {t1, t2});
   double sum = BM25Std(ctx, t1) + BM25Std(ctx, t2);
 
   EXPECT_DOUBLE_EQ(multi, sum);
@@ -2892,9 +2892,9 @@ TEST_F(ScoringTest, ScoreDocumentDispatchesByScorerType) {
   ScoringTermInfo term{
       .term_freq = 2, .term_docs = 3, .field_doc_len = 5, .field_avg_doc_len = 5.0};
 
-  EXPECT_DOUBLE_EQ(ScoreDocument(ScorerType::BM25STD, ctx, {term}), BM25Std(ctx, term));
-  EXPECT_DOUBLE_EQ(ScoreDocument(ScorerType::TFIDF, ctx, {term}), TfIdf(ctx, term));
-  EXPECT_DOUBLE_EQ(ScoreDocument(ScorerType::TFIDF_DOCNORM, ctx, {term}), TfIdfDocNorm(ctx, term));
+  EXPECT_DOUBLE_EQ(ScoreDocument(&BM25Std, ctx, {term}), BM25Std(ctx, term));
+  EXPECT_DOUBLE_EQ(ScoreDocument(&TfIdf, ctx, {term}), TfIdf(ctx, term));
+  EXPECT_DOUBLE_EQ(ScoreDocument(&TfIdfDocNorm, ctx, {term}), TfIdfDocNorm(ctx, term));
 }
 
 TEST_F(ScoringTest, SearchWithScorer) {
@@ -2914,7 +2914,7 @@ TEST_F(ScoringTest, SearchWithScorer) {
   QueryParams params;
   SearchAlgorithm algo;
   ASSERT_TRUE(algo.Init("hello", &params));
-  algo.SetScorer(ScorerType::BM25STD);
+  algo.SetScorer(&BM25Std);
 
   auto result = algo.Search(&index);
 
@@ -2954,7 +2954,7 @@ TEST_F(ScoringTest, SearchPrefixWithScorer) {
   QueryParams params;
   SearchAlgorithm algo;
   ASSERT_TRUE(algo.Init("hel*", &params));
-  algo.SetScorer(ScorerType::BM25STD);
+  algo.SetScorer(&BM25Std);
 
   auto result = algo.Search(&index);
 
@@ -3061,7 +3061,7 @@ TEST_F(ScoringTest, BM25StdAfterDocRemoval) {
   QueryParams params;
   SearchAlgorithm algo;
   ASSERT_TRUE(algo.Init("hello", &params));
-  algo.SetScorer(ScorerType::BM25STD);
+  algo.SetScorer(&BM25Std);
 
   auto result_before = algo.Search(&index);
   ASSERT_EQ(result_before.ids.size(), 3u);
@@ -3073,7 +3073,7 @@ TEST_F(ScoringTest, BM25StdAfterDocRemoval) {
   // Re-search
   SearchAlgorithm algo2;
   ASSERT_TRUE(algo2.Init("hello", &params));
-  algo2.SetScorer(ScorerType::BM25STD);
+  algo2.SetScorer(&BM25Std);
 
   auto result_after = algo2.Search(&index);
   ASSERT_EQ(result_after.ids.size(), 2u);
@@ -3108,7 +3108,7 @@ TEST_F(ScoringTest, ScorerTopKCutoff) {
   QueryParams params;
   SearchAlgorithm algo;
   ASSERT_TRUE(algo.Init("hello", &params));
-  algo.SetScorer(ScorerType::BM25STD);
+  algo.SetScorer(&BM25Std);
 
   // Request only top 3 - should return docs 9, 8, 7 (highest TF)
   auto result = algo.Search(&index, 3);

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -130,8 +130,8 @@ struct SearchParams {
 
   search::QueryParams query_params;
 
-  bool with_scores = false;                  // WITHSCORES flag
-  std::optional<search::ScorerType> scorer;  // SCORER parameter
+  bool with_scores = false;           // WITHSCORES flag
+  search::ScorerFn scorer = nullptr;  // SCORER parameter (null = not set)
 
   bool ShouldReturnAllFields() const {
     return !return_fields.has_value();
@@ -196,8 +196,8 @@ struct AggregateParams {
   std::optional<std::vector<FieldReference>> load_fields;
   std::vector<aggregate::AggregationStep> steps;
 
-  bool add_scores = false;                   // ADDSCORES flag
-  std::optional<search::ScorerType> scorer;  // SCORER parameter
+  bool add_scores = false;            // ADDSCORES flag
+  search::ScorerFn scorer = nullptr;  // SCORER parameter (null = not set)
 };
 
 // Stores basic info about a document index.

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -442,10 +442,10 @@ search::QueryParams ParseQueryParams(CmdArgParser* parser) {
   return params;
 }
 
-std::optional<search::ScorerType> ParseScorer(CmdArgParser* parser) {
-  return parser->TryMapNext("BM25STD", search::ScorerType::BM25STD, "TFIDF",
-                            search::ScorerType::TFIDF, "TFIDF.DOCNORM",
-                            search::ScorerType::TFIDF_DOCNORM);
+std::optional<search::ScorerFn> ParseScorer(CmdArgParser* parser) {
+  return parser->TryMapNext("BM25STD", &search::BM25Std,  //
+                            "TFIDF", &search::TfIdf,      //
+                            "TFIDF.DOCNORM", &search::TfIdfDocNorm);
 }
 
 ParseResult<SearchParams> ParseSearchParams(CmdArgParser* parser) {
@@ -1928,9 +1928,9 @@ void CmdFtSearch(CmdArgList args, CommandContext* cmd_cntx) {
 
   // Enable scorer: explicit SCORER param, or default BM25STD when WITHSCORES is set
   if (params->scorer)
-    search_algo.SetScorer(*params->scorer);
+    search_algo.SetScorer(params->scorer);
   else if (params->with_scores)
-    search_algo.SetScorer(search::ScorerType::BM25STD);
+    search_algo.SetScorer(&search::BM25Std);
 
   auto [knn_node, knn] = TryPopHnswKnnNode(search_algo, index_name);
 
@@ -2026,9 +2026,9 @@ void CmdFtProfile(CmdArgList args, CommandContext* cmd_cntx) {
 
   // Enable scorer: explicit SCORER param, or default BM25STD when WITHSCORES is set
   if (params->scorer)
-    search_algo.SetScorer(*params->scorer);
+    search_algo.SetScorer(params->scorer);
   else if (params->with_scores)
-    search_algo.SetScorer(search::ScorerType::BM25STD);
+    search_algo.SetScorer(&search::BM25Std);
 
   search_algo.EnableProfiling();
 
@@ -2204,9 +2204,9 @@ void CmdFtAggregate(CmdArgList args, CommandContext* cmd_cntx) {
 
     // Enable scorer: explicit SCORER param, or default BM25STD when ADDSCORES is set
     if (params->scorer)
-      search_algo.SetScorer(*params->scorer);
+      search_algo.SetScorer(params->scorer);
     else if (params->add_scores)
-      search_algo.SetScorer(search::ScorerType::BM25STD);
+      search_algo.SetScorer(&search::BM25Std);
 
     using ResultContainer = decltype(declval<ShardDocIndex>().SearchForAggregator(
         declval<OpArgs>(), params.value(), &search_algo));

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -445,6 +445,10 @@ search::QueryParams ParseQueryParams(CmdArgParser* parser) {
 std::optional<search::ScorerType> ParseScorerName(std::string_view name) {
   if (absl::EqualsIgnoreCase(name, "BM25STD"))
     return search::ScorerType::BM25STD;
+  if (absl::EqualsIgnoreCase(name, "TFIDF"))
+    return search::ScorerType::TFIDF;
+  if (absl::EqualsIgnoreCase(name, "TFIDF.DOCNORM"))
+    return search::ScorerType::TFIDF_DOCNORM;
   return std::nullopt;
 }
 

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -442,14 +442,10 @@ search::QueryParams ParseQueryParams(CmdArgParser* parser) {
   return params;
 }
 
-std::optional<search::ScorerType> ParseScorerName(std::string_view name) {
-  if (absl::EqualsIgnoreCase(name, "BM25STD"))
-    return search::ScorerType::BM25STD;
-  if (absl::EqualsIgnoreCase(name, "TFIDF"))
-    return search::ScorerType::TFIDF;
-  if (absl::EqualsIgnoreCase(name, "TFIDF.DOCNORM"))
-    return search::ScorerType::TFIDF_DOCNORM;
-  return std::nullopt;
+std::optional<search::ScorerType> ParseScorer(CmdArgParser* parser) {
+  return parser->TryMapNext("BM25STD", search::ScorerType::BM25STD, "TFIDF",
+                            search::ScorerType::TFIDF, "TFIDF.DOCNORM",
+                            search::ScorerType::TFIDF_DOCNORM);
 }
 
 ParseResult<SearchParams> ParseSearchParams(CmdArgParser* parser) {
@@ -492,10 +488,9 @@ ParseResult<SearchParams> ParseSearchParams(CmdArgParser* parser) {
     } else if (parser->Check("WITHSCORES")) {
       params.with_scores = true;
     } else if (parser->Check("SCORER")) {
-      auto scorer_name = parser->Next();
-      auto scorer = ParseScorerName(scorer_name);
+      auto scorer = ParseScorer(parser);
       if (!scorer)
-        return CreateSyntaxError(absl::StrCat("No such scorer: ", scorer_name));
+        return CreateSyntaxError(absl::StrCat("No such scorer: ", parser->Peek()));
       params.scorer = *scorer;
     } else if (parser->Check("DIALECT")) {
       parser->Skip(1);  // Accepted and ignored — DF always behaves as dialect 2
@@ -755,10 +750,9 @@ ParseResult<AggregateParams> ParseAggregatorParams(CmdArgParser* parser) {
 
     // SCORER, ADDSCORES, WITHSCORES can appear anywhere in the command
     if (parser->Check("SCORER")) {
-      auto scorer_name = parser->Next();
-      auto scorer = ParseScorerName(scorer_name);
+      auto scorer = ParseScorer(parser);
       if (!scorer)
-        return CreateSyntaxError(absl::StrCat("No such scorer: ", scorer_name));
+        return CreateSyntaxError(absl::StrCat("No such scorer: ", parser->Peek()));
       params.scorer = *scorer;
       continue;
     }


### PR DESCRIPTION
Add two additional scorers alongside the existing BM25STD: classic TFIDF and TFIDF with document length normalization (TFIDF.DOCNORM). Both fit the existing scoring infrastructure without changes to per-field TF tracking or cursor-based scoring.
