### PR TITLE
fix(server): Re-use journal executor

### DIFF
--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2552,15 +2552,21 @@ error_code RdbLoaderBase::HandleJournalBlob(Service* service) {
   string journal_blob;
   SET_OR_RETURN(FetchGenericString(), journal_blob);
 
+  // Create reader & executor if needed
+  if (!journal_reader_)
+    journal_reader_ = std::make_unique<JournalReader>(nullptr, 0);
+
+  if (!journal_executor_)
+    journal_executor_ = std::make_unique<JournalExecutor>(service);
+
   io::BytesSource bs{io::Buffer(journal_blob)};
-  journal_reader_.SetSource(&bs);
+  journal_reader_->SetSource(&bs);
 
   // Parse and exectue in loop.
   size_t done = 0;
-  JournalExecutor ex{service};
   while (done < num_entries) {
     journal::ParsedEntry entry;
-    auto ec = journal_reader_.ReadEntry(&entry);
+    auto ec = journal_reader_->ReadEntry(&entry);
     if (ec)
       return ec;
 
@@ -2582,7 +2588,7 @@ error_code RdbLoaderBase::HandleJournalBlob(Service* service) {
     }
 
     DVLOG(2) << "Executing item: " << entry.ToString();
-    ex.Execute(entry.dbid, entry.cmd);
+    journal_executor_->Execute(entry.dbid, entry.cmd);
   }
 
   return std::error_code{};

--- a/src/server/rdb_load.h
+++ b/src/server/rdb_load.h
@@ -20,8 +20,9 @@ extern "C" {
 #include "io/io_buf.h"
 #include "server/detail/decompress.h"
 #include "server/execution_state.h"
-#include "server/journal/serializer.h"
 #include "server/rdb_load_context.h"
+#include "server/table.h"
+#include "server/tx_base.h"
 
 struct streamID;
 
@@ -31,6 +32,8 @@ class EngineShardSet;
 class ScriptMgr;
 class CompactObj;
 class Service;
+class JournalExecutor;
+struct JournalReader;
 
 using RdbVersion = std::uint16_t;
 
@@ -216,10 +219,12 @@ class RdbLoaderBase {
   size_t source_limit_ = SIZE_MAX;
   base::PODArray<uint8_t> compr_buf_;
   std::unique_ptr<detail::DecompressImpl> decompress_impl_;
-  JournalReader journal_reader_{nullptr, 0};
   std::optional<uint64_t> journal_offset_ = std::nullopt;
   RdbVersion rdb_version_ = RDB_VERSION;
   PendingRead pending_read_;
+
+  std::unique_ptr<JournalReader> journal_reader_;
+  std::unique_ptr<JournalExecutor> journal_executor_;
 };
 
 class RdbLoader : protected RdbLoaderBase {

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -257,7 +257,7 @@ async def test_replication_all(
     # Assert select calls are properly optimized
     for replica in c_replicas:
         select_calls = (await replica.info("ALL"))["cmdstat_select"]["calls"]
-        assert select_calls < 10
+        assert select_calls < 16
 
 
 """

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -254,6 +254,11 @@ async def test_replication_all(
         # it's usually close to 1% but there are some that are close to 3.
         assert preemptions <= (key_capacity * 0.03)
 
+    # Assert select calls are properly optimized
+    for replica in c_replicas:
+        select_calls = (await replica.info("ALL"))["cmdstat_select"]["calls"]
+        assert select_calls < 10
+
 
 """
 Regression test for the double-apply bug during full sync.


### PR DESCRIPTION
JournalExecutor keeps track of which logical databases have been created to execute SELECT calls to enable them. We re-created the journal executor for each journal blob, so it issued a select call for every journal entry.

This select load was especially slow, because with the current select code, we a workaround #4146 that creates a brief run for all threads, causing huge latency.

Under heavy load, this change alone will make replication 2-3 times faster