### PR TITLE
fix(server): reject negative numkeys in EVAL/EVALSHA to avoid CHECK abort

### DIFF
--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -16,6 +16,7 @@ extern "C" {
 #include "base/flags.h"
 #include "base/gtest.h"
 #include "base/logging.h"
+#include "facade/error.h"
 #include "facade/facade_test.h"
 #include "server/main_service.h"
 #include "server/test_utils.h"
@@ -286,6 +287,11 @@ TEST_F(DflyEngineTest, EvalSha) {
   // Important to keep spaces in order to be compatible with Redis.
   // See https://github.com/dragonflydb/dragonfly/issues/146
   EXPECT_THAT(resp, "c6459b95a0e81df97af6fdd49b1a9e0287a57363");
+}
+
+TEST_F(DflyEngineTest, EvalShaNegativeZeroNumKeys) {
+  EXPECT_THAT(Run({"evalsha", "k1", "-0"}), ErrArg(facade::kInvalidIntErr));
+  EXPECT_THAT(Run({"eval", "return 1", "-0"}), ErrArg(facade::kInvalidIntErr));
 }
 
 TEST_F(DflyEngineTest, ScriptFlush) {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -503,12 +503,12 @@ bool IsSHA(string_view str) {
 
 optional<ErrorReply> EvalValidator(CmdArgList args) {
   string_view num_keys_str = ArgS(args, 1);
-  int32_t num_keys;
+  uint32_t num_keys;
 
-  if (!absl::SimpleAtoi(num_keys_str, &num_keys) || num_keys < 0)
+  if (!absl::SimpleAtoi(num_keys_str, &num_keys))
     return ErrorReply{facade::kInvalidIntErr};
 
-  if (unsigned(num_keys) > args.size() - 2)
+  if (num_keys > args.size() - 2)
     return ErrorReply{"Number of keys can't be greater than number of args", kSyntaxErrType};
 
   return nullopt;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -35,6 +35,7 @@ extern "C" {
 #include "base/flags.h"
 #include "base/logging.h"
 #include "core/search/vector_utils.h"
+#include "facade/cmd_arg_parser.h"
 #include "facade/dragonfly_connection.h"
 #include "facade/dragonfly_listener.h"
 #include "facade/error.h"
@@ -502,13 +503,14 @@ bool IsSHA(string_view str) {
 }
 
 optional<ErrorReply> EvalValidator(CmdArgList args) {
-  string_view num_keys_str = ArgS(args, 1);
-  uint32_t num_keys;
+  facade::CmdArgParser parser{args};
+  parser.Skip(1);  // script body / sha
+  uint32_t num_keys = parser.Next<uint32_t>();
 
-  if (!absl::SimpleAtoi(num_keys_str, &num_keys))
-    return ErrorReply{facade::kInvalidIntErr};
+  if (auto err = parser.TakeError(); err)
+    return err.MakeReply();
 
-  if (num_keys > args.size() - 2)
+  if (num_keys > parser.Tail().size())
     return ErrorReply{"Number of keys can't be greater than number of args", kSyntaxErrType};
 
   return nullopt;


### PR DESCRIPTION
`EVALSHA <sha> -0 ...` aborted the server via `CHECK` in `Service::CallSHA`. `EvalValidator` parsed `numkeys` as `int32_t` (which accepts `"-0"` as `0`), while `CallSHA` re-parsed it as `uint32_t` (which rejects a leading `-`), tripping `CHECK(absl::SimpleAtoi(..., &num_keys))`.

Changes:
- Align `EvalValidator` to parse `numkeys` as `uint32_t`, matching the parsing in `Service::CallSHA`. Removes the now-redundant `num_keys < 0` guard - negatives are rejected by `SimpleAtoi<uint32_t>` directly.
- Add regression test `DflyEngineTest.EvalShaNegativeZeroNumKeys` covering both `EVAL` and `EVALSHA`.

Fixes #7202