### PR TITLE
feat: add Apply method to CmdArgParser

### DIFF
--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -9,13 +9,55 @@
 
 #include <optional>
 #include <string_view>
+#include <tuple>
 #include <utility>
 
 #include "facade/facade_types.h"
 
 namespace facade {
 
-// Helper class for numerical range restriction during parsing
+// CmdArgParser — utility for parsing command option lists.
+//
+// Reading individual args:
+//   CmdArgParser parser(args);
+//   auto key = parser.Next<string_view>();                      // read one arg by type
+//   auto [src, dst] = parser.Next<string_view, string_view>();  // read several at once (tuple)
+//   auto db = parser.Next<FInt<0, 15>>();                       // range-restricted int
+//                                                               // (INVALID_INT if out of range)
+//   auto count = parser.NextOrDefault<size_t>(10);              // read optional with default
+//
+// Tag matching:
+//   parser.ExpectTag("LOAD");                                   // required literal keyword
+//   if (parser.Check("NX")) { ... }                             // consume tag only if matched
+//   auto mode = parser.MapNext("EX", Mode::EX, "PX", Mode::PX); // tag -> enum mapping
+//   auto maybe_mode = parser.TryMapNext("ASC", Dir::ASC,        // like MapNext but returns
+//                                       "DESC", Dir::DESC);     // nullopt (no error) on miss
+//
+// Bulk named options with Apply():
+//   parser.Apply(
+//       Exist("WITHSCORES", &params.with_scores),  // tag present -> sets bool true
+//       Tag("LIMIT", &offset, &limit),             // tag -> reads following args
+//       Tag("COUNT", &optional_count),             // std::optional<T>* is supported
+//       Tag("GET", [&](CmdArgParser* p) {          // lambda handler for custom parsing
+//         patterns.push_back(p->Next<string_view>());
+//       }));
+//
+// Navigating manually:
+//   if (parser.HasNext()) { ... }                               // is there another arg?
+//   if (parser.HasAtLeast(3)) { ... }                           // at least N args remain?
+//   auto peek = parser.Peek();                                  // look at next without consuming
+//                                                               //   (useful for error messages)
+//   parser.Skip(n);                                             // advance n args
+//   CmdArgList rest = parser.Tail();                            // remaining args (e.g. k/v pairs)
+//
+// Apply stops at the first unmatched arg without reporting an error. Use ApplyOrSkip() instead
+// to silently ignore unknown tags, or call Finalize() afterwards to require all args were
+// consumed (reports UNPROCESSED otherwise). Error surfacing:
+//   if (parser.HasError()) { ... }                              // any error so far?
+//   if (!parser.Finalize())                                     // common end-of-parse check
+//     return cmd_cntx->SendError(parser.TakeError().MakeReply());
+
+// Numerical range restriction used with Next<FInt<lo, hi>>().
 template <auto min, auto max> struct FInt {
   decltype(min) value = {};
   operator decltype(min)() {
@@ -31,7 +73,10 @@ template <class T> constexpr bool is_fint = false;
 
 template <auto min, auto max> constexpr bool is_fint<FInt<min, max>> = true;
 
-// Utility class for easily parsing command options from argument lists.
+template <class T> constexpr bool is_optional = false;
+
+template <class U> constexpr bool is_optional<std::optional<U>> = true;
+
 struct CmdArgParser {
   enum ErrorType {
     NO_ERROR,
@@ -59,15 +104,13 @@ struct CmdArgParser {
   CmdArgParser(ArgSlice args) : args_{args} {
   }
 
-  // Debug asserts sure error was consumed
+  // DCHECKs that any error was consumed.
   ~CmdArgParser();
 
-  // Get next value without consuming it
   std::string_view Peek() {
     return SafeSV(cur_i_);
   }
 
-  // Consume next value
   template <class T = std::string_view, class... Ts> auto Next() {
     if (cur_i_ + sizeof...(Ts) >= args_.size()) {
       Report(OUT_OF_BOUNDS, cur_i_);
@@ -85,15 +128,13 @@ struct CmdArgParser {
     }
   }
 
-  // returns next value if exists or default value
   template <class T = std::string_view> auto NextOrDefault(T default_value = {}) {
     return HasNext() ? Next<T>() : default_value;
   }
 
-  // check next value ignoring case and consume it
+  // Consumes the next arg; reports INVALID_NEXT if it doesn't match (case-insensitive).
   void ExpectTag(std::string_view tag);
 
-  // Consume next value
   template <class... Cases> auto MapNext(Cases&&... cases) {
     if (cur_i_ >= args_.size()) {
       Report(OUT_OF_BOUNDS, cur_i_);
@@ -110,7 +151,7 @@ struct CmdArgParser {
     return *res;
   }
 
-  // Consume next value if can map it and return mapped result or return nullopt
+  // Same as MapNext, but returns nullopt (no error) if no case matches.
   template <class... Cases>
   auto TryMapNext(Cases&&... cases)
       -> std::optional<std::tuple_element_t<1, std::tuple<Cases...>>> {
@@ -123,7 +164,7 @@ struct CmdArgParser {
     return res;
   }
 
-  // Check if the next value is equal to a specific tag. If equal, its consumed.
+  // If the next arg matches `tag`, consume it and the following args-into-pointers; else no-op.
   template <class... Args> bool Check(std::string_view tag, Args*... args) {
     if (cur_i_ + sizeof...(Args) >= args_.size())
       return false;
@@ -139,7 +180,22 @@ struct CmdArgParser {
     return true;
   }
 
-  // Skip specified number of arguments
+  // Greedily matches remaining args against the options. See the file header for usage.
+  template <class... Opts> void Apply(Opts... opts) {
+    while (HasNext() && (opts.TryApply(this) || ...)) {
+    }
+  }
+
+  // Like Apply, but silently skips unmatched args (one at a time) instead of stopping. Use when
+  // unknown tags should be ignored rather than reported. Prefer Apply + Finalize when strictness
+  // is desired.
+  template <class... Opts> void ApplyOrSkip(Opts... opts) {
+    while (HasNext()) {
+      if (!(opts.TryApply(this) || ...))
+        Skip(1);
+    }
+  }
+
   CmdArgParser& Skip(size_t n) {
     if (cur_i_ + n > args_.size()) {
       Report(OUT_OF_BOUNDS, cur_i_);
@@ -149,7 +205,7 @@ struct CmdArgParser {
     return *this;
   }
 
-  // Expect no more arguments and return if no error has occured
+  // Requires no leftover args and no prior errors. Reports UNPROCESSED if args remain.
   bool Finalize() {
     if (HasNext()) {
       Report(UNPROCESSED, cur_i_);
@@ -158,12 +214,10 @@ struct CmdArgParser {
     return !HasError();
   }
 
-  // Return remaining arguments
   ArgSlice Tail() const {
     return args_.subspan(cur_i_);
   }
 
-  // Return true if arguments are left and no errors occured
   bool HasNext() {
     return cur_i_ < args_.size() && !error_;
   }
@@ -182,10 +236,8 @@ struct CmdArgParser {
     return cur_i_;
   }
 
-  // Custom error_type should start from CUSTOM_ERROR
+  // Reports a custom error (error_type >= CUSTOM_ERROR) at the previously-consumed index.
   void Report(int error_type) {
-    // we use previous index, because the check was done outside and it's done after element is
-    // processed
     Report(error_type, cur_i_ - 1);
   }
 
@@ -216,10 +268,12 @@ struct CmdArgParser {
   }
 
   template <class T> T Convert(size_t idx) {
-    static_assert(
-        std::is_arithmetic_v<T> || std::is_constructible_v<T, std::string_view> || is_fint<T>,
-        "incorrect type");
-    if constexpr (std::is_arithmetic_v<T>) {
+    static_assert(std::is_arithmetic_v<T> || std::is_constructible_v<T, std::string_view> ||
+                      is_fint<T> || is_optional<T>,
+                  "incorrect type");
+    if constexpr (is_optional<T>) {
+      return T{Convert<typename T::value_type>(idx)};
+    } else if constexpr (std::is_arithmetic_v<T>) {
       return Num<T>(idx);
     } else if constexpr (std::is_constructible_v<T, std::string_view>) {
       return static_cast<T>(SafeSV(idx));
@@ -279,5 +333,59 @@ struct CmdArgParser {
 
   ErrorInfo error_;
 };
+
+// Option types used with CmdArgParser::Apply. See the file header for usage.
+namespace detail {
+
+struct ExistOpt {
+  std::string_view tag;
+  bool* field;
+
+  bool TryApply(CmdArgParser* parser) const {
+    if (parser->Check(tag)) {
+      *field = true;
+      return true;
+    }
+    return false;
+  }
+};
+
+template <class... Args> struct TagOpt {
+  std::string_view tag;
+  std::tuple<Args*...> args;
+
+  bool TryApply(CmdArgParser* parser) const {
+    return std::apply([&](auto*... a) { return parser->Check(tag, a...); }, args);
+  }
+};
+
+template <class Func> struct LambdaOpt {
+  std::string_view tag;
+  Func func;
+
+  bool TryApply(CmdArgParser* parser) const {
+    if (parser->Check(tag)) {
+      func(parser);
+      return true;
+    }
+    return false;
+  }
+};
+
+}  // namespace detail
+
+inline detail::ExistOpt Exist(std::string_view tag, bool* field) {
+  return {tag, field};
+}
+
+template <class... Args> detail::TagOpt<Args...> Tag(std::string_view tag, Args*... args) {
+  return detail::TagOpt<Args...>{tag, std::make_tuple(args...)};
+}
+
+// Overload for custom parsing: the callable receives a CmdArgParser* after the tag matches.
+template <class Func, std::enable_if_t<std::is_invocable_v<Func, CmdArgParser*>, int> = 0>
+detail::LambdaOpt<Func> Tag(std::string_view tag, Func func) {
+  return {tag, std::move(func)};
+}
 
 }  // namespace facade

--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -236,9 +236,10 @@ struct CmdArgParser {
     return cur_i_;
   }
 
-  // Reports a custom error (error_type >= CUSTOM_ERROR) at the previously-consumed index.
+  // Reports a custom error (error_type >= CUSTOM_ERROR) at the previously-consumed index
+  // (or 0 if called before any arg was consumed).
   void Report(int error_type) {
-    Report(error_type, cur_i_ - 1);
+    Report(error_type, cur_i_ > 0 ? cur_i_ - 1 : 0);
   }
 
  private:
@@ -355,7 +356,17 @@ template <class... Args> struct TagOpt {
   std::tuple<Args*...> args;
 
   bool TryApply(CmdArgParser* parser) const {
-    return std::apply([&](auto*... a) { return parser->Check(tag, a...); }, args);
+    // Match the tag first; then read each field via Next<>(). This ensures a matched tag is
+    // always consumed — a missing trailing value surfaces OUT_OF_BOUNDS rather than looking like
+    // "tag didn't match" (which ApplyOrSkip would silently skip past).
+    if (!parser->Check(tag))
+      return false;
+    std::apply(
+        [&](auto*... ptrs) {
+          (((*ptrs) = parser->template Next<std::remove_pointer_t<decltype(ptrs)>>()), ...);
+        },
+        args);
+    return true;
   }
 };
 

--- a/src/facade/cmd_arg_parser_test.cc
+++ b/src/facade/cmd_arg_parser_test.cc
@@ -143,6 +143,141 @@ TEST_F(CmdArgParserTest, IgnoreCase) {
   EXPECT_EQ(absl::implicit_cast<string_view>(parser.Next()), "world"sv);
 }
 
+TEST_F(CmdArgParserTest, Apply) {
+  // All option shapes: Exist sets a bool, Tag-with-one-field, Tag-with-two-fields.
+  {
+    auto parser = Make({"FLAG", "COUNT", "5", "LIMIT", "10", "20"});
+
+    bool flag = false;
+    uint32_t count = 0;
+    uint32_t offset = 0;
+    uint32_t limit = 0;
+
+    parser.Apply(Exist("FLAG", &flag), Tag("COUNT", &count), Tag("LIMIT", &offset, &limit));
+
+    EXPECT_TRUE(flag);
+    EXPECT_EQ(count, 5u);
+    EXPECT_EQ(offset, 10u);
+    EXPECT_EQ(limit, 20u);
+    EXPECT_FALSE(parser.HasError());
+  }
+
+  // Unknown option is left unconsumed (no error). The caller decides what to do next.
+  {
+    auto parser = Make({"COUNT", "5", "BOGUS"});
+
+    uint32_t count = 0;
+    parser.Apply(Tag("COUNT", &count));
+
+    EXPECT_EQ(count, 5u);
+    EXPECT_FALSE(parser.HasError());
+    EXPECT_TRUE(parser.HasNext());
+    EXPECT_EQ(parser.Peek(), "BOGUS");
+  }
+
+  // Case-insensitive matching (consistent with Check).
+  {
+    auto parser = Make({"count", "7"});
+
+    uint32_t count = 0;
+    parser.Apply(Tag("COUNT", &count));
+
+    EXPECT_EQ(count, 7u);
+    EXPECT_FALSE(parser.HasError());
+  }
+
+  // Invalid integer in a Tag arg propagates the error.
+  {
+    auto parser = Make({"COUNT", "NAN"});
+
+    uint32_t count = 0;
+    parser.Apply(Tag("COUNT", &count));
+
+    auto err = parser.TakeError();
+    EXPECT_TRUE(err);
+    EXPECT_EQ(err.type, CmdArgParser::INVALID_INT);
+  }
+}
+
+TEST_F(CmdArgParserTest, ApplyOrSkip) {
+  // ApplyOrSkip silently skips any unknown arg (1 at a time) and keeps going.
+  {
+    auto parser = Make({"BOGUS", "COUNT", "5", "MORE_BOGUS", "STUFF"});
+
+    uint32_t count = 0;
+    parser.ApplyOrSkip(Tag("COUNT", &count));
+
+    EXPECT_EQ(count, 5u);
+    EXPECT_FALSE(parser.HasError());
+    EXPECT_FALSE(parser.HasNext());  // everything consumed
+  }
+  // Empty input — no error, no work.
+  {
+    auto parser = Make({});
+    uint32_t count = 0;
+    parser.ApplyOrSkip(Tag("COUNT", &count));
+    EXPECT_FALSE(parser.HasError());
+    EXPECT_FALSE(parser.HasNext());
+  }
+  // Trailing unknown at end-of-args: the skip must not trip OUT_OF_BOUNDS.
+  {
+    auto parser = Make({"BOGUS"});
+    uint32_t count = 0;
+    parser.ApplyOrSkip(Tag("COUNT", &count));
+    EXPECT_FALSE(parser.HasError());
+    EXPECT_FALSE(parser.HasNext());
+  }
+}
+
+TEST_F(CmdArgParserTest, ApplyLambda) {
+  // Tag() with a lambda lets callers run custom parsing on match. Useful for side-effectful cases
+  // like push_back or toggling a bool to false.
+  auto parser = Make({"GET", "p1", "ASC", "GET", "p2"});
+
+  std::vector<std::string_view> patterns;
+  bool reversed = true;
+
+  parser.Apply(
+      Tag("ASC", [&](CmdArgParser*) { reversed = false; }),
+      Tag("GET", [&](CmdArgParser* p) { patterns.push_back(p->Next<std::string_view>()); }));
+
+  EXPECT_FALSE(reversed);
+  ASSERT_EQ(patterns.size(), 2u);
+  EXPECT_EQ(patterns[0], "p1");
+  EXPECT_EQ(patterns[1], "p2");
+  EXPECT_FALSE(parser.HasError());
+}
+
+TEST_F(CmdArgParserTest, ApplyOptional) {
+  // Tag present -> optional engaged.
+  {
+    auto parser = Make({"COUNT", "5"});
+    std::optional<uint32_t> count;
+    parser.Apply(Tag("COUNT", &count));
+    ASSERT_TRUE(count.has_value());
+    EXPECT_EQ(*count, 5u);
+    EXPECT_FALSE(parser.HasError());
+  }
+  // Tag absent -> optional stays empty.
+  {
+    auto parser = Make({});
+    std::optional<uint32_t> count;
+    parser.Apply(Tag("COUNT", &count));
+    EXPECT_FALSE(count.has_value());
+    EXPECT_FALSE(parser.HasError());
+  }
+  // Invalid value -> INVALID_INT reported. The optional's state on error is undefined; callers
+  // must check for the parse error first.
+  {
+    auto parser = Make({"COUNT", "NAN"});
+    std::optional<uint32_t> count;
+    parser.Apply(Tag("COUNT", &count));
+    auto err = parser.TakeError();
+    EXPECT_TRUE(err);
+    EXPECT_EQ(err.type, CmdArgParser::INVALID_INT);
+  }
+}
+
 TEST_F(CmdArgParserTest, FixedRangeInt) {
   {
     auto parser = Make({"10", "-10", "12"});

--- a/src/facade/cmd_arg_parser_test.cc
+++ b/src/facade/cmd_arg_parser_test.cc
@@ -229,6 +229,48 @@ TEST_F(CmdArgParserTest, ApplyOrSkip) {
   }
 }
 
+TEST_F(CmdArgParserTest, ApplyTagMissingValue) {
+  // A matched tag with missing trailing value(s) must surface an error, not be silently skipped.
+  // This guards against a subtle interaction with ApplyOrSkip: if TagOpt treated "tag matches,
+  // values missing" as "no match", the skip path would swallow the malformed option.
+  {
+    auto parser = Make({"COUNT"});  // tag matches, value missing
+    uint32_t count = 0;
+    parser.Apply(Tag("COUNT", &count));
+    auto err = parser.TakeError();
+    EXPECT_TRUE(err);
+    EXPECT_EQ(err.type, CmdArgParser::OUT_OF_BOUNDS);
+  }
+  {
+    auto parser = Make({"COUNT"});
+    uint32_t count = 0;
+    parser.ApplyOrSkip(Tag("COUNT", &count));
+    // Tag must have been consumed (not left for Skip to swallow silently).
+    EXPECT_FALSE(parser.HasNext());
+    auto err = parser.TakeError();
+    EXPECT_TRUE(err);
+    EXPECT_EQ(err.type, CmdArgParser::OUT_OF_BOUNDS);
+  }
+  // Also guard the two-field case: LIMIT with only one trailing value.
+  {
+    auto parser = Make({"LIMIT", "10"});  // needs offset + limit
+    uint32_t offset = 0, limit = 0;
+    parser.Apply(Tag("LIMIT", &offset, &limit));
+    auto err = parser.TakeError();
+    EXPECT_TRUE(err);
+    EXPECT_EQ(err.type, CmdArgParser::OUT_OF_BOUNDS);
+  }
+}
+
+TEST_F(CmdArgParserTest, ReportBeforeAnyNext) {
+  // Report(code) at cur_i_ == 0 must clamp the error index to 0 rather than underflow to SIZE_MAX.
+  auto parser = Make({"x"});
+  parser.Report(CmdArgParser::CUSTOM_ERROR);
+  auto err = parser.TakeError();
+  EXPECT_TRUE(err);
+  EXPECT_EQ(err.index, 0u);
+}
+
 TEST_F(CmdArgParserTest, ApplyLambda) {
   // Tag() with a lambda lets callers run custom parsing on match. Useful for side-effectful cases
   // like push_back or toggling a bool to false.

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -1323,11 +1323,11 @@ void CmdLPos(CmdArgList args, CommandContext* cmd_cntx) {
 
   parser.ApplyOrSkip(Tag("RANK", &rank), Tag("COUNT", &count), Tag("MAXLEN", &max_len));
 
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
+
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (rank == 0)
     return rb->SendError(kInvalidIntErr);
-
-  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   auto cb = [&, &key = key, &elem = elem](Transaction* t, EngineShard* shard) {
     return OpPos(t->GetOpArgs(shard), key, elem, rank, count.value_or(1), max_len);

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -1163,8 +1163,7 @@ void CmdLMPop(CmdArgList args, CommandContext* cmd_cntx) {
 
   ListDir dir = parser.MapNext("LEFT", ListDir::LEFT, "RIGHT", ListDir::RIGHT);
   size_t pop_count = 1;
-  if (parser.Check("COUNT"))
-    pop_count = parser.Next<size_t>();
+  parser.Check("COUNT", &pop_count);
 
   if (!parser.Finalize())
     return cmd_cntx->SendError(parser.TakeError().MakeReply());
@@ -1252,8 +1251,7 @@ void CmdBLMPop(CmdArgList args, CommandContext* cmd_cntx) {
   ListDir dir = parser.MapNext("LEFT", ListDir::LEFT, "RIGHT", ListDir::RIGHT);
 
   size_t pop_count = 1;
-  if (parser.Check("COUNT"))
-    pop_count = parser.Next<size_t>();
+  parser.Check("COUNT", &pop_count);
 
   if (!parser.Finalize())
     return cmd_cntx->SendError(parser.TakeError().MakeReply());
@@ -1320,29 +1318,10 @@ void CmdLPos(CmdArgList args, CommandContext* cmd_cntx) {
   auto [key, elem] = parser.Next<string_view, string_view>();
 
   int rank = 1;
-  uint32_t count = 1;
+  std::optional<uint32_t> count;
   uint32_t max_len = 0;
-  bool skip_count = true;
 
-  while (parser.HasNext()) {
-    if (parser.Check("RANK")) {
-      rank = parser.Next<int>();
-      continue;
-    }
-
-    if (parser.Check("COUNT")) {
-      count = parser.Next<uint32_t>();
-      skip_count = false;
-      continue;
-    }
-
-    if (parser.Check("MAXLEN")) {
-      max_len = parser.Next<uint32_t>();
-      continue;
-    }
-
-    parser.Skip(1);
-  }
+  parser.ApplyOrSkip(Tag("RANK", &rank), Tag("COUNT", &count), Tag("MAXLEN", &max_len));
 
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (rank == 0)
@@ -1351,7 +1330,7 @@ void CmdLPos(CmdArgList args, CommandContext* cmd_cntx) {
   RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   auto cb = [&, &key = key, &elem = elem](Transaction* t, EngineShard* shard) {
-    return OpPos(t->GetOpArgs(shard), key, elem, rank, count, max_len);
+    return OpPos(t->GetOpArgs(shard), key, elem, rank, count.value_or(1), max_len);
   };
 
   Transaction* trans = cmd_cntx->tx();
@@ -1363,7 +1342,7 @@ void CmdLPos(CmdArgList args, CommandContext* cmd_cntx) {
     return rb->SendError(result.status());
   }
 
-  if (skip_count) {
+  if (!count.has_value()) {
     if (result->empty()) {
       rb->SendNull();
     } else {


### PR DESCRIPTION
Summary: This PR extends facade::CmdArgParser with a bulk option-parsing API to simplify command argument handling.

Changes:

- Added CmdArgParser::Apply() and ApplyOrSkip() for greedy option matching over remaining args.
- Introduced helper option builders Exist() and Tag() (including a lambda handler form) to express common parsing patterns.
- Extended Convert() to support parsing into std::optional<T>.
- Added unit tests covering Apply/ApplyOrSkip, lambda handlers, and optional parsing.
- Refactored list commands to use the new APIs (e.g. COUNT parsing in LMPOP/BLMPOP and option handling in LPOS).

Technical Notes: Apply stops on the first unmatched token (caller may Finalize() for strictness), while ApplyOrSkip consumes unknown tokens to allow permissive parsing.