### PR TITLE
feat: add memory consumption for HNSW

### DIFF
--- a/src/core/search/hnsw_alg.h
+++ b/src/core/search/hnsw_alg.h
@@ -716,11 +716,15 @@ template <typename dist_t> class HierarchicalNSW : public hnswlib::AlgorithmInte
   // Recomputes memory_size_ from the current allocation-defining fields.
   // Must be called whenever max_elements_ changes.
   void updateMemorySize() {
-    size_t per_element = size_data_per_element_ + sizeof(char*) + sizeof(int);
+    // Per-element costs: level-0 block, linkLists_ pointer slot, element_levels_ entry,
+    // link_list_locks_ mutex; plus the copied-vector block when enabled.
+    size_t per_element = size_data_per_element_ + sizeof(char*) + sizeof(int) + sizeof(std::mutex);
     if (copy_vector_) {
       per_element += data_size_;
     }
-    memory_size_.store(max_elements_ * per_element, std::memory_order_relaxed);
+    // label_op_locks_ is a fixed-size shard of mutexes independent of max_elements_.
+    size_t fixed = MAX_LABEL_OPERATION_LOCKS * sizeof(std::mutex);
+    memory_size_.store(fixed + max_elements_ * per_element, std::memory_order_relaxed);
   }
 
   size_t indexFileSize() const {

--- a/src/core/search/hnsw_alg.h
+++ b/src/core/search/hnsw_alg.h
@@ -78,6 +78,10 @@ template <typename dist_t> class HierarchicalNSW : public hnswlib::AlgorithmInte
 
   bool copy_vector_ = true;
 
+  // Cached in-memory footprint (bytes) — maintained by the constructor and resizeIndex;
+  // read lock-free by metrics. See memorySize() for what is / isn't counted.
+  std::atomic<size_t> memory_size_{0};
+
   bool allow_replace_deleted_ =
       false;  // flag to replace deleted elements (marked as deleted) during insertions
 
@@ -155,6 +159,7 @@ template <typename dist_t> class HierarchicalNSW : public hnswlib::AlgorithmInte
     size_links_per_element_ = maxM_ * sizeof(tableint) + sizeof(linklistsizeint);
     mult_ = 1 / log(1.0 * M_);
     revSize_ = 1.0 / mult_;
+    updateMemorySize();
   }
 
   ~HierarchicalNSW() {
@@ -689,6 +694,33 @@ template <typename dist_t> class HierarchicalNSW : public hnswlib::AlgorithmInte
     linkLists_ = linkLists_new;
 
     max_elements_ = new_max_elements;
+    updateMemorySize();
+  }
+
+  // Approximate in-memory footprint in bytes. Lock-free: reads the cached
+  // capacity-based total plus rough estimates of the two dynamic containers
+  // (label_lookup_, deleted_elements) from their already-atomic counters.
+  // Per-element upper-layer link lists remain uncounted (< 5% of the total).
+  size_t memorySize() const {
+    // Rough std::unordered_map<labeltype, tableint> entry: node (key+value+hash+
+    // next-ptr) plus amortized bucket-slot overhead.
+    constexpr size_t kLabelLookupEntryBytes = sizeof(labeltype) + sizeof(tableint) + 32;
+    // std::unordered_set<tableint> entry, populated only in allow_replace_deleted mode.
+    constexpr size_t kDeletedEntryBytes = sizeof(tableint) + 24;
+    size_t total = memory_size_.load(std::memory_order_relaxed);
+    total += cur_element_count.load(std::memory_order_relaxed) * kLabelLookupEntryBytes;
+    total += num_deleted_.load(std::memory_order_relaxed) * kDeletedEntryBytes;
+    return total;
+  }
+
+  // Recomputes memory_size_ from the current allocation-defining fields.
+  // Must be called whenever max_elements_ changes.
+  void updateMemorySize() {
+    size_t per_element = size_data_per_element_ + sizeof(char*) + sizeof(int);
+    if (copy_vector_) {
+      per_element += data_size_;
+    }
+    memory_size_.store(max_elements_ * per_element, std::memory_order_relaxed);
   }
 
   size_t indexFileSize() const {

--- a/src/core/search/hnsw_index.cc
+++ b/src/core/search/hnsw_index.cc
@@ -424,6 +424,10 @@ struct HnswlibAdapter {
     return MRMWMutexLock(&mrmw_mutex_, MRMWMutex::LockMode::kReadLock);
   }
 
+  size_t GetMemoryUsage() const {
+    return world_.memorySize();
+  }
+
  private:
   HnswSpace space_;
   HierarchicalNSW<float> world_;
@@ -540,6 +544,10 @@ bool HnswVectorIndex::UpdateVectorData(GlobalDocId id, const DocumentAccessor& d
 
 MRMWMutexLock HnswVectorIndex::GetReadLock() const {
   return adapter_->GetReadLock();
+}
+
+size_t HnswVectorIndex::GetMemoryUsage() const {
+  return adapter_->GetMemoryUsage();
 }
 
 }  // namespace dfly::search

--- a/src/core/search/hnsw_index.h
+++ b/src/core/search/hnsw_index.h
@@ -98,6 +98,9 @@ class HnswVectorIndex {
   // Use this during serialization to block concurrent Add/Remove (write) operations.
   MRMWMutexLock GetReadLock() const;
 
+  // Approximate in-memory footprint of this HNSW graph, in bytes.
+  size_t GetMemoryUsage() const;
+
  private:
   bool copy_vector_;
   size_t dim_;

--- a/src/server/search/global_hnsw_index.cc
+++ b/src/server/search/global_hnsw_index.cc
@@ -82,6 +82,15 @@ void GlobalHnswIndexRegistry::Reset() {
   indices_.clear();
 }
 
+size_t GlobalHnswIndexRegistry::GetTotalMemoryUsage() const {
+  std::shared_lock<std::shared_mutex> lock(registry_mutex_);
+  size_t total = 0;
+  for (const auto& [_, index] : indices_) {
+    total += index->GetMemoryUsage();
+  }
+  return total;
+}
+
 absl::flat_hash_set<std::string> GlobalHnswIndexRegistry::GetIndexNames() const {
   std::shared_lock<std::shared_mutex> lock(registry_mutex_);
   absl::flat_hash_set<std::string> index_names;

--- a/src/server/search/global_hnsw_index.h
+++ b/src/server/search/global_hnsw_index.h
@@ -41,6 +41,9 @@ class GlobalHnswIndexRegistry {
   // Returns unique index names from all registered HNSW indices
   absl::flat_hash_set<std::string> GetIndexNames() const;
 
+  // Aggregate in-memory footprint of all registered HNSW indices, in bytes.
+  size_t GetTotalMemoryUsage() const;
+
   void Reset();
 
  private:

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -415,6 +415,9 @@ TEST_F(SearchFamilyTest, MemoryTrackingHnsw) {
             "OK");
 
   auto metrics = GetMetrics();
+  // Guard against unsigned underflow if a gauge somehow ticks down between snapshots.
+  ASSERT_GE(metrics.search_stats.used_memory, search_mem_before);
+  ASSERT_GE(metrics.heap_used_bytes, heap_mem_before);
   size_t search_delta = metrics.search_stats.used_memory - search_mem_before;
   size_t heap_delta = metrics.heap_used_bytes - heap_mem_before;
 
@@ -424,10 +427,11 @@ TEST_F(SearchFamilyTest, MemoryTrackingHnsw) {
   constexpr size_t kMinLevel0Bytes = kCapacity * 100;
   EXPECT_GE(search_delta, kMinLevel0Bytes) << "HNSW index creation must bump search_used memory";
   EXPECT_GE(heap_delta, kMinLevel0Bytes) << "HNSW index creation must bump heap_used_bytes";
-  // The HNSW contribution is added once (not per-shard), so both gauges must
-  // move by the same amount.
-  EXPECT_EQ(search_delta, heap_delta)
-      << "HNSW memory should be accounted once, producing identical deltas";
+  // The HNSW contribution is added to both gauges. heap_used_bytes also rolls up
+  // other shard-local state (ShardDocIndices::GetUsedMemory, mimalloc heap, etc.),
+  // so it can grow strictly more than search_used; exact equality is too strict.
+  EXPECT_GE(heap_delta, search_delta)
+      << "heap_used_bytes must include the HNSW contribution counted in search_used";
 }
 
 // Test how asynchronous indexing indexes documents and reports its progress

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -399,6 +399,37 @@ TEST_F(SearchFamilyTest, MemoryTrackingDocKeyIndex) {
       << "Remaining half should still be tracked";
 }
 
+// Verify that HNSW index memory is accounted for in both search_stats.used_memory
+// (surfaced as search_used class of dragonfly_memory_by_class_bytes) and in
+// heap_used_bytes (surfaced as dragonfly_memory_used_bytes). See issue #7110.
+TEST_F(SearchFamilyTest, MemoryTrackingHnsw) {
+  constexpr size_t kDim = 16;
+  constexpr size_t kCapacity = 1024;
+
+  size_t search_mem_before = GetMetrics().search_stats.used_memory;
+  size_t heap_mem_before = GetMetrics().heap_used_bytes;
+
+  EXPECT_EQ(Run({"FT.CREATE", "hnsw_idx", "ON", "HASH", "SCHEMA", "v", "VECTOR", "HNSW", "8",
+                 "TYPE", "FLOAT32", "DIM", absl::StrCat(kDim), "DISTANCE_METRIC", "L2",
+                 "INITIAL_CAP", absl::StrCat(kCapacity)}),
+            "OK");
+
+  auto metrics = GetMetrics();
+  size_t search_delta = metrics.search_stats.used_memory - search_mem_before;
+  size_t heap_delta = metrics.heap_used_bytes - heap_mem_before;
+
+  // The level-0 block alone allocates capacity * size_data_per_element_ bytes.
+  // With M=16 (default), maxM0_ = 32, size_data_per_element_ >= 32*4 + 8 = 136 bytes,
+  // so 1024 * 100 is a safe lower bound.
+  constexpr size_t kMinLevel0Bytes = kCapacity * 100;
+  EXPECT_GE(search_delta, kMinLevel0Bytes) << "HNSW index creation must bump search_used memory";
+  EXPECT_GE(heap_delta, kMinLevel0Bytes) << "HNSW index creation must bump heap_used_bytes";
+  // The HNSW contribution is added once (not per-shard), so both gauges must
+  // move by the same amount.
+  EXPECT_EQ(search_delta, heap_delta)
+      << "HNSW memory should be accounted once, producing identical deltas";
+}
+
 // Test how asynchronous indexing indexes documents and reports its progress
 TEST_F(SearchFamilyTest, Indexing) {
   // Create documents

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -68,6 +68,7 @@ extern "C" {
 #include "server/rdb_save.h"
 #include "server/replica.h"
 #include "server/script_mgr.h"
+#include "server/search/global_hnsw_index.h"
 #include "server/search/search_family.h"
 #include "server/server_state.h"
 #include "server/snapshot.h"
@@ -3088,6 +3089,14 @@ Metrics ServerFamily::GetMetrics(Namespace* ns) const {
   };  // cb
 
   service_.proactor_pool().AwaitFiberOnAll(std::move(cb));
+
+  // HNSW indices live in a single global registry shared across shards, so their
+  // footprint must be added once — not per-shard. Track it in both the search_used
+  // breakdown (memory_by_class_bytes{class="search_used"}) and the overall heap
+  // gauge (memory_used_bytes). See issue #7110.
+  size_t hnsw_memory = GlobalHnswIndexRegistry::Instance().GetTotalMemoryUsage();
+  result.search_stats.used_memory += hnsw_memory;
+  result.heap_used_bytes += hnsw_memory;
 
   uint64_t after_cb = absl::GetCurrentTimeNanos();
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -68,7 +68,9 @@ extern "C" {
 #include "server/rdb_save.h"
 #include "server/replica.h"
 #include "server/script_mgr.h"
+#ifdef WITH_SEARCH
 #include "server/search/global_hnsw_index.h"
+#endif
 #include "server/search/search_family.h"
 #include "server/server_state.h"
 #include "server/snapshot.h"
@@ -3090,6 +3092,7 @@ Metrics ServerFamily::GetMetrics(Namespace* ns) const {
 
   service_.proactor_pool().AwaitFiberOnAll(std::move(cb));
 
+#ifdef WITH_SEARCH
   // HNSW indices live in a single global registry shared across shards, so their
   // footprint must be added once — not per-shard. Track it in both the search_used
   // breakdown (memory_by_class_bytes{class="search_used"}) and the overall heap
@@ -3097,6 +3100,7 @@ Metrics ServerFamily::GetMetrics(Namespace* ns) const {
   size_t hnsw_memory = GlobalHnswIndexRegistry::Instance().GetTotalMemoryUsage();
   result.search_stats.used_memory += hnsw_memory;
   result.heap_used_bytes += hnsw_memory;
+#endif
 
   uint64_t after_cb = absl::GetCurrentTimeNanos();
 


### PR DESCRIPTION
fixes: #7110

Summary: This PR adds approximate memory accounting for HNSW vector indices so their footprint is reflected in Dragonfly’s memory metrics.

Changes:

- Adds a cached, lock-free memory_size_ counter and memorySize() accessor in HierarchicalNSW, updated on construction and resizeIndex()
- Exposes per-index usage via HnswVectorIndex::GetMemoryUsage()
- Aggregates all registered HNSW index memory via GlobalHnswIndexRegistry::GetTotalMemoryUsage()
- Plumbs the aggregate into ServerFamily::GetMetrics() (behind WITH_SEARCH) for both search_used and overall heap gauges
- Adds a unit test (MemoryTrackingHnsw) to validate HNSW creation increases both metrics and that heap usage is at least the search usage delta

Technical Notes: The accounting is intentionally approximate and uses relaxed atomics to avoid locking in metrics paths.