### PR TITLE
feat: new methods in CmdArgParser

### DIFF
--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -35,27 +35,33 @@ namespace facade {
 //
 // Bulk named options with Apply():
 //   parser.Apply(
-//       Exist("WITHSCORES", &params.with_scores),  // tag present -> sets bool true
+//       Exist("WITHSCORES", &with_scores),         // tag present -> sets bool true
 //       Tag("LIMIT", &offset, &limit),             // tag -> reads following args
-//       Tag("COUNT", &optional_count),             // std::optional<T>* is supported
-//       Tag("GET", [&](CmdArgParser* p) {          // lambda handler for custom parsing
+//       Tag("COUNT", &optional_count),             // std::optional<T>* supported directly
+//       Tag("GET", [&](CmdArgParser* p) {          // lambda: custom parsing on tag match
 //         patterns.push_back(p->Next<string_view>());
-//       }));
+//       }),
+//       Map(&dir, "ASC", Dir::ASC, "DESC", Dir::DESC),   // tag -> fixed value mapping
+//       Tag("ATTR", Map(&mask, "v", Mask::Volatile,      // nested: outer tag + inner Map
+//                       "p", Mask::Permanent)),          //   (inner keyword required on match)
+//       OneOf(Exist("NX", &nx), Exist("XX", &xx)),       // mutex — at most one may match
+//       If(!read_only, Tag("STORE", &store_key)));    // runtime-gated option
+//
+// Strict vs lenient dispatch:
+//   parser.Apply(...)        — stops at first unmatched arg; pair with Finalize() to error
+//   parser.ApplyOrSkip(...)  — silently skips unknown tags one-by-one
 //
 // Navigating manually:
 //   if (parser.HasNext()) { ... }                               // is there another arg?
 //   if (parser.HasAtLeast(3)) { ... }                           // at least N args remain?
 //   auto peek = parser.Peek();                                  // look at next without consuming
-//                                                               //   (useful for error messages)
 //   parser.Skip(n);                                             // advance n args
 //   CmdArgList rest = parser.Tail();                            // remaining args (e.g. k/v pairs)
 //
-// Apply stops at the first unmatched arg without reporting an error. Use ApplyOrSkip() instead
-// to silently ignore unknown tags, or call Finalize() afterwards to require all args were
-// consumed (reports UNPROCESSED otherwise). Error surfacing:
-//   if (parser.HasError()) { ... }                              // any error so far?
-//   if (!parser.Finalize())                                     // common end-of-parse check
-//     return cmd_cntx->SendError(parser.TakeError().MakeReply());
+// Error surfacing (at the end of parse):
+//   if (!parser.Finalize())                                     // also reports UNPROCESSED on
+//     return cmd_cntx->SendError(parser.TakeError().MakeReply()); // trailing args
+//   // or: if (parser.HasError()) ...
 
 // Numerical range restriction used with Next<FInt<lo, hi>>().
 template <auto min, auto max> struct FInt {
@@ -335,7 +341,6 @@ struct CmdArgParser {
   ErrorInfo error_;
 };
 
-// Option types used with CmdArgParser::Apply. See the file header for usage.
 namespace detail {
 
 struct ExistOpt {
@@ -356,9 +361,8 @@ template <class... Args> struct TagOpt {
   std::tuple<Args*...> args;
 
   bool TryApply(CmdArgParser* parser) const {
-    // Match the tag first; then read each field via Next<>(). This ensures a matched tag is
-    // always consumed — a missing trailing value surfaces OUT_OF_BOUNDS rather than looking like
-    // "tag didn't match" (which ApplyOrSkip would silently skip past).
+    // Match the tag first, then read fields via Next<>() — so a missing value surfaces
+    // OUT_OF_BOUNDS instead of being swallowed by ApplyOrSkip as "no match".
     if (!parser->Check(tag))
       return false;
     std::apply(
@@ -383,6 +387,74 @@ template <class Func> struct LambdaOpt {
   }
 };
 
+template <class T, class... Cases> struct MapOpt {
+  static_assert(sizeof...(Cases) % 2 == 0, "Map expects alternating tag/value pairs");
+
+  T* field;
+  std::tuple<Cases...> cases;
+
+  bool TryApply(CmdArgParser* parser) const {
+    return TryMatch<0>(parser);
+  }
+
+ private:
+  template <size_t I> bool TryMatch(CmdArgParser* parser) const {
+    if constexpr (I >= sizeof...(Cases)) {
+      return false;
+    } else if (parser->Check(std::get<I>(cases))) {
+      *field = std::get<I + 1>(cases);
+      return true;
+    } else {
+      return TryMatch<I + 2>(parser);
+    }
+  }
+};
+
+template <class Inner> struct IfOpt {
+  bool cond;
+  Inner inner;
+
+  bool TryApply(CmdArgParser* parser) const {
+    return cond && inner.TryApply(parser);
+  }
+};
+
+template <class... Opts> struct OneOfOpt {
+  std::tuple<Opts...> opts;
+  mutable bool matched = false;
+
+  bool TryApply(CmdArgParser* parser) const {
+    bool any = std::apply([&](auto&... os) { return (os.TryApply(parser) || ...); }, opts);
+    if (!any)
+      return false;
+    if (matched)
+      parser->Report(CmdArgParser::INVALID_CASES);
+    matched = true;
+    return true;
+  }
+};
+
+// Nested: outer tag consumes one arg, then inner option runs against the next arg. If the inner
+// doesn't match, reports INVALID_CASES (the inner keyword is required once the outer matched).
+template <class Inner> struct TagNestedOpt {
+  std::string_view tag;
+  Inner inner;
+
+  bool TryApply(CmdArgParser* parser) const {
+    if (!parser->Check(tag))
+      return false;
+    if (!inner.TryApply(parser))
+      parser->Report(CmdArgParser::INVALID_CASES);
+    return true;
+  }
+};
+
+// Concept matching any of the Apply options (has a TryApply(CmdArgParser*) method).
+template <class T>
+concept ParseOption = requires(const T& t, CmdArgParser* p) {
+  { t.TryApply(p) } -> std::same_as<bool>;
+};
+
 }  // namespace detail
 
 inline detail::ExistOpt Exist(std::string_view tag, bool* field) {
@@ -393,10 +465,29 @@ template <class... Args> detail::TagOpt<Args...> Tag(std::string_view tag, Args*
   return detail::TagOpt<Args...>{tag, std::make_tuple(args...)};
 }
 
-// Overload for custom parsing: the callable receives a CmdArgParser* after the tag matches.
-template <class Func, std::enable_if_t<std::is_invocable_v<Func, CmdArgParser*>, int> = 0>
-detail::LambdaOpt<Func> Tag(std::string_view tag, Func func) {
+template <class Func>
+requires std::is_invocable_v<Func, CmdArgParser*> detail::LambdaOpt<Func> Tag(std::string_view tag,
+                                                                              Func func) {
   return {tag, std::move(func)};
+}
+
+// Nested option: outer tag + inner sub-option (e.g. Map). After outer matches, inner must match
+// the following arg or INVALID_CASES is reported.
+template <detail::ParseOption Inner>
+detail::TagNestedOpt<Inner> Tag(std::string_view tag, Inner inner) {
+  return {tag, std::move(inner)};
+}
+
+template <class T, class... Cases> detail::MapOpt<T, Cases...> Map(T* field, Cases... cases) {
+  return {field, std::make_tuple(std::move(cases)...)};
+}
+
+template <class Inner> detail::IfOpt<Inner> If(bool cond, Inner inner) {
+  return {cond, std::move(inner)};
+}
+
+template <class... Opts> detail::OneOfOpt<Opts...> OneOf(Opts... opts) {
+  return {{std::move(opts)...}, false};
 }
 
 }  // namespace facade

--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -7,9 +7,11 @@
 #include <absl/strings/match.h>
 #include <absl/strings/numbers.h>
 
+#include <concepts>
 #include <optional>
 #include <string_view>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 
 #include "facade/facade_types.h"

--- a/src/facade/cmd_arg_parser_test.cc
+++ b/src/facade/cmd_arg_parser_test.cc
@@ -315,6 +315,22 @@ TEST_F(CmdArgParserTest, ApplyMap) {
     EXPECT_FALSE(reversed);
     EXPECT_TRUE(parser.HasNext());
   }
+  // Standalone Map allows repeated matches — last wins, no error. This matches Redis SORT
+  // semantics where "ASC DESC" is equivalent to "DESC".
+  {
+    auto parser = Make({"DESC", "ASC"});
+    bool reversed = true;
+    parser.Apply(Map(&reversed, "DESC", true, "ASC", false));
+    EXPECT_FALSE(reversed);  // ASC came last
+    EXPECT_FALSE(parser.HasError());
+  }
+  {
+    auto parser = Make({"ASC", "DESC"});
+    bool reversed = false;
+    parser.Apply(Map(&reversed, "DESC", true, "ASC", false));
+    EXPECT_TRUE(reversed);  // DESC came last
+    EXPECT_FALSE(parser.HasError());
+  }
   // OneOf + Map — DESC followed by ASC is a mutex violation.
   {
     auto parser = Make({"DESC", "ASC"});

--- a/src/facade/cmd_arg_parser_test.cc
+++ b/src/facade/cmd_arg_parser_test.cc
@@ -290,6 +290,165 @@ TEST_F(CmdArgParserTest, ApplyLambda) {
   EXPECT_FALSE(parser.HasError());
 }
 
+TEST_F(CmdArgParserTest, ApplyMap) {
+  // Map(&field, tag, value, ...) — matches any tag and writes the corresponding value.
+  // Standalone Map allows repeated matches (last wins); wrap in OneOf to require at most one.
+  {
+    auto parser = Make({"DESC"});
+    bool reversed = false;
+    parser.Apply(Map(&reversed, "DESC", true, "ASC", false));
+    EXPECT_TRUE(reversed);
+    EXPECT_FALSE(parser.HasError());
+  }
+  {
+    auto parser = Make({"ASC"});
+    bool reversed = true;
+    parser.Apply(Map(&reversed, "DESC", true, "ASC", false));
+    EXPECT_FALSE(reversed);
+    EXPECT_FALSE(parser.HasError());
+  }
+  // Unrelated tag leaves field untouched and stops Apply.
+  {
+    auto parser = Make({"OTHER"});
+    bool reversed = false;
+    parser.Apply(Map(&reversed, "DESC", true, "ASC", false));
+    EXPECT_FALSE(reversed);
+    EXPECT_TRUE(parser.HasNext());
+  }
+  // OneOf + Map — DESC followed by ASC is a mutex violation.
+  {
+    auto parser = Make({"DESC", "ASC"});
+    bool reversed = false;
+    parser.Apply(OneOf(Map(&reversed, "DESC", true, "ASC", false)));
+    auto err = parser.TakeError();
+    EXPECT_TRUE(err);
+    EXPECT_EQ(err.type, CmdArgParser::INVALID_CASES);
+  }
+}
+
+TEST_F(CmdArgParserTest, ApplyTagNested) {
+  // Tag(tag, inner_opt) — outer tag matches, then inner option runs against the next arg.
+  // If the inner doesn't match, INVALID_CASES is reported (the inner keyword is required).
+  enum class Mode { A, B, C };
+  {
+    auto parser = Make({"MODE", "B"});
+    Mode mode = Mode::A;
+    parser.Apply(Tag("MODE", Map(&mode, "A", Mode::A, "B", Mode::B, "C", Mode::C)));
+    EXPECT_EQ(mode, Mode::B);
+    EXPECT_FALSE(parser.HasError());
+  }
+  // Unknown inner tag -> INVALID_CASES.
+  {
+    auto parser = Make({"MODE", "BOGUS"});
+    Mode mode = Mode::A;
+    parser.Apply(Tag("MODE", Map(&mode, "A", Mode::A, "B", Mode::B)));
+    auto err = parser.TakeError();
+    EXPECT_TRUE(err);
+    EXPECT_EQ(err.type, CmdArgParser::INVALID_CASES);
+  }
+  // Outer tag absent -> no effect, no error.
+  {
+    auto parser = Make({});
+    Mode mode = Mode::A;
+    parser.Apply(Tag("MODE", Map(&mode, "A", Mode::A, "B", Mode::B)));
+    EXPECT_EQ(mode, Mode::A);
+    EXPECT_FALSE(parser.HasError());
+  }
+}
+
+TEST_F(CmdArgParserTest, ApplyTagIf) {
+  // If(cond, opt) behaves like `opt` when cond is true, and never matches when false.
+  // Use to gate an option on a runtime flag (e.g. is_read_only).
+
+  // cond=true -> delegate to inner (matches and sets field).
+  {
+    auto parser = Make({"STORE", "dest"});
+    std::string_view store;
+    parser.Apply(If(true, Tag("STORE", &store)));
+    EXPECT_EQ(store, "dest");
+    EXPECT_FALSE(parser.HasError());
+  }
+
+  // cond=false -> inner is skipped. Apply stops at the (now unmatched) arg; Finalize reports
+  // UNPROCESSED so the caller can surface a syntax error.
+  {
+    auto parser = Make({"STORE", "dest"});
+    std::string_view store;
+    parser.Apply(If(false, Tag("STORE", &store)));
+    EXPECT_EQ(store, "");
+    EXPECT_FALSE(parser.HasError());
+    EXPECT_TRUE(parser.HasNext());
+    EXPECT_FALSE(parser.Finalize());
+    auto err = parser.TakeError();
+    EXPECT_TRUE(err);
+    EXPECT_EQ(err.type, CmdArgParser::UNPROCESSED);
+  }
+
+  // Composes: cond=false + Exist - does not toggle the bool even when the tag is present.
+  {
+    auto parser = Make({"FLAG"});
+    bool flag = false;
+    parser.Apply(If(false, Exist("FLAG", &flag)));
+    EXPECT_FALSE(flag);
+  }
+}
+
+TEST_F(CmdArgParserTest, ApplyOneOf) {
+  // OneOf groups mutually-exclusive options. Zero or one may match across the Apply loop.
+  // A second match reports an error instead of being quietly accepted.
+
+  // Zero matches — fine.
+  {
+    auto parser = Make({});
+    bool nx = false, xx = false;
+    parser.Apply(OneOf(Exist("NX", &nx), Exist("XX", &xx)));
+    EXPECT_FALSE(nx);
+    EXPECT_FALSE(xx);
+    EXPECT_FALSE(parser.HasError());
+  }
+
+  // Single match — fine.
+  {
+    auto parser = Make({"NX"});
+    bool nx = false, xx = false;
+    parser.Apply(OneOf(Exist("NX", &nx), Exist("XX", &xx)));
+    EXPECT_TRUE(nx);
+    EXPECT_FALSE(xx);
+    EXPECT_FALSE(parser.HasError());
+  }
+
+  // Two different members of the group match -> error.
+  {
+    auto parser = Make({"NX", "XX"});
+    bool nx = false, xx = false;
+    parser.Apply(OneOf(Exist("NX", &nx), Exist("XX", &xx)));
+    auto err = parser.TakeError();
+    EXPECT_TRUE(err);
+    EXPECT_EQ(err.type, CmdArgParser::INVALID_CASES);
+  }
+
+  // Same member twice also counts as a second match -> error.
+  {
+    auto parser = Make({"NX", "NX"});
+    bool nx = false, xx = false;
+    parser.Apply(OneOf(Exist("NX", &nx), Exist("XX", &xx)));
+    auto err = parser.TakeError();
+    EXPECT_TRUE(err);
+    EXPECT_EQ(err.type, CmdArgParser::INVALID_CASES);
+  }
+
+  // OneOf composes with other Apply options. Unrelated tags are not affected.
+  {
+    auto parser = Make({"NX", "COUNT", "5"});
+    bool nx = false, xx = false;
+    uint32_t count = 0;
+    parser.Apply(OneOf(Exist("NX", &nx), Exist("XX", &xx)), Tag("COUNT", &count));
+    EXPECT_TRUE(nx);
+    EXPECT_EQ(count, 5u);
+    EXPECT_FALSE(parser.HasError());
+  }
+}
+
 TEST_F(CmdArgParserTest, ApplyOptional) {
   // Tag present -> optional engaged.
   {

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -7,6 +7,7 @@
 #include <absl/strings/ascii.h>
 #include <absl/strings/str_cat.h>
 
+#include <limits>
 #include <optional>
 
 #include "facade/cmd_arg_parser.h"
@@ -267,52 +268,29 @@ OpResult<DbSlice::ItAndUpdater> RdbRestoreValue::Add(string_view key, string_vie
 // args[3] .. args[n]: optional arguments that can be [REPLACE] [ABSTTL] [IDLETIME seconds]
 //            [FREQ frequency], in any order
 OpResult<RestoreArgs> RestoreArgs::TryFrom(const CmdArgList& args) {
+  using namespace facade;
   RestoreArgs out_args;
-  string cur_arg{ArgS(args, 1)};  // extract ttl
-  if (!absl::SimpleAtoi(cur_arg, &out_args.expiration_) || (out_args.expiration_ < 0)) {
+  CmdArgParser parser(args);
+
+  // args[0] = key (skip); args[1] = ttl; args[2] = serialized value (skip).
+  parser.Skip(1);
+  out_args.expiration_ = parser.Next<int64_t>();
+  if (parser.TakeError() || out_args.expiration_ < 0)
     return OpStatus::INVALID_INT;
+  parser.Skip(1);
+
+  // IDLETIME and FREQ are parsed (for compat with Redis) but not used currently. Both are
+  // range-checked at parse time via FInt — out-of-range values surface as INVALID_INT.
+  FInt<int64_t{0}, std::numeric_limits<int64_t>::max()> idle_time{};
+  FInt<0, 255> freq{};
+  parser.Apply(Exist("REPLACE", &out_args.replace_), Exist("ABSTTL", &out_args.abs_time_),
+               Exist("STICK", &out_args.sticky_), Tag("IDLETIME", &idle_time), Tag("FREQ", &freq));
+
+  if (!parser.Finalize()) {
+    auto err = parser.TakeError();
+    return err.type == CmdArgParser::INVALID_INT ? OpStatus::INVALID_INT : OpStatus::SYNTAX_ERR;
   }
 
-  // the 3rd arg is the serialized value, so we are starting from one pass it
-  // Note that all these are actually optional
-  // note about the redis doc for this command: https://redis.io/commands/restore/
-  // the IDLETIME and FREQ are not required, but to make this the same as in redis
-  // we would parse them and ensure that they are correct, maybe later they will be used
-  int64_t idle_time = 0;
-
-  for (size_t i = 3; i < args.size(); ++i) {
-    cur_arg = absl::AsciiStrToUpper(ArgS(args, i));
-    bool additional = args.size() - i - 1 >= 1;
-    if (cur_arg == "REPLACE") {
-      out_args.replace_ = true;
-    } else if (cur_arg == "ABSTTL") {
-      out_args.abs_time_ = true;
-    } else if (cur_arg == "STICK") {
-      out_args.sticky_ = true;
-    } else if (cur_arg == "IDLETIME" && additional) {
-      ++i;
-      cur_arg = ArgS(args, i);
-      if (!absl::SimpleAtoi(cur_arg, &idle_time)) {
-        return OpStatus::INVALID_INT;
-      }
-      if (idle_time < 0) {
-        return OpStatus::SYNTAX_ERR;
-      }
-    } else if (cur_arg == "FREQ" && additional) {
-      ++i;
-      cur_arg = ArgS(args, i);
-      int freq = 0;
-      if (!absl::SimpleAtoi(cur_arg, &freq)) {
-        return OpStatus::INVALID_INT;
-      }
-      if (freq < 0 || freq > 255) {
-        return OpStatus::OUT_OF_RANGE;  // need to translate in this case
-      }
-    } else {
-      LOG(WARNING) << "Got unknown command line option for restore '" << cur_arg << "'";
-      return OpStatus::SYNTAX_ERR;
-    }
-  }
   return out_args;
 }
 
@@ -1373,12 +1351,10 @@ void GenericFamily::Persist(CmdArgList args, CommandContext* cmd_cntx) {
 }
 
 void GenericFamily::Expire(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  string_view sec = ArgS(args, 1);
-  int64_t int_arg;
-
-  if (!absl::SimpleAtoi(sec, &int_arg)) {
-    return cmd_cntx->SendError(kInvalidIntErr);
+  facade::CmdArgParser parser{args};
+  auto [key, int_arg] = parser.Next<string_view, int64_t>();
+  if (auto err = parser.TakeError(); err) {
+    return cmd_cntx->SendError(err.MakeReply());
   }
 
   int_arg = std::max<int64_t>(int_arg, -1);
@@ -1403,12 +1379,10 @@ void GenericFamily::Expire(CmdArgList args, CommandContext* cmd_cntx) {
 }
 
 void GenericFamily::ExpireAt(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  string_view sec = ArgS(args, 1);
-  int64_t int_arg;
-
-  if (!absl::SimpleAtoi(sec, &int_arg)) {
-    return cmd_cntx->SendError(kInvalidIntErr);
+  facade::CmdArgParser parser{args};
+  auto [key, int_arg] = parser.Next<string_view, int64_t>();
+  if (auto err = parser.TakeError(); err) {
+    return cmd_cntx->SendError(err.MakeReply());
   }
 
   int_arg = std::max<int64_t>(int_arg, 0L);
@@ -1454,12 +1428,10 @@ void GenericFamily::Keys(CmdArgList args, CommandContext* cmd_cntx) {
 }
 
 void GenericFamily::PexpireAt(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  string_view msec = ArgS(args, 1);
-  int64_t int_arg;
-
-  if (!absl::SimpleAtoi(msec, &int_arg)) {
-    return cmd_cntx->SendError(kInvalidIntErr);
+  facade::CmdArgParser parser{args};
+  auto [key, int_arg] = parser.Next<string_view, int64_t>();
+  if (auto err = parser.TakeError(); err) {
+    return cmd_cntx->SendError(err.MakeReply());
   }
 
   int_arg = std::max<int64_t>(int_arg, 0L);
@@ -1485,12 +1457,10 @@ void GenericFamily::PexpireAt(CmdArgList args, CommandContext* cmd_cntx) {
 }
 
 void GenericFamily::Pexpire(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  string_view msec = ArgS(args, 1);
-  int64_t int_arg;
-
-  if (!absl::SimpleAtoi(msec, &int_arg)) {
-    return cmd_cntx->SendError(kInvalidIntErr);
+  facade::CmdArgParser parser{args};
+  auto [key, int_arg] = parser.Next<string_view, int64_t>();
+  if (auto err = parser.TakeError(); err) {
+    return cmd_cntx->SendError(err.MakeReply());
   }
   int_arg = std::max<int64_t>(int_arg, -1);
 
@@ -2026,28 +1996,17 @@ void SortGeneric(CmdArgList args, CommandContext* cmd_cntx, bool is_read_only) {
   SortParams params;
   params.is_read_only = is_read_only;
 
-  while (parser.HasNext()) {
-    if (parser.Check("ALPHA")) {
-      params.alpha = true;
-    } else if (parser.Check("DESC")) {
-      params.reversed = true;
-    } else if (parser.Check("ASC")) {
-      params.reversed = false;
-    } else if (parser.Check("LIMIT")) {
-      uint32_t offset = parser.Next<uint32_t>();
-      uint32_t limit = parser.Next<uint32_t>();
-      params.bounds = {offset, limit};
-    } else if (!is_read_only && parser.Check("STORE", &params.store_key)) {
-    } else if (parser.Check("BY", &params.by_pattern)) {
-    } else if (parser.Check("GET")) {
-      params.get_patterns.push_back(parser.Next());
-    } else {
-      LOG_EVERY_T(ERROR, 1) << "Unsupported option " << parser.Peek();
-      return cmd_cntx->SendError(kSyntaxErr);
-    }
-  }
+  parser.Apply(
+      Exist("ALPHA", &params.alpha), OneOf(Map(&params.reversed, "DESC", true, "ASC", false)),
+      Tag("LIMIT",
+          [&](CmdArgParser* p) {
+            auto [offset, limit] = p->Next<uint32_t, uint32_t>();
+            params.bounds = std::pair{offset, limit};
+          }),
+      If(!is_read_only, Tag("STORE", &params.store_key)), Tag("BY", &params.by_pattern),
+      Tag("GET", [&](CmdArgParser* p) { params.get_patterns.push_back(p->Next<string_view>()); }));
 
-  if (parser.HasError()) {
+  if (!parser.Finalize()) {
     return cmd_cntx->SendError(parser.TakeError().MakeReply());
   }
 
@@ -2296,10 +2255,9 @@ void GenericFamily::Restore(CmdArgList args, CommandContext* cmd_cntx) {
 void GenericFamily::FieldExpire(CmdArgList args, CommandContext* cmd_cntx) {
   CmdArgParser parser{args};
   string_view key = parser.Next();
-  string_view ttl_str = parser.Next();
-  uint32_t ttl_sec;
-  if (!absl::SimpleAtoi(ttl_str, &ttl_sec) || ttl_sec == 0 || ttl_sec > kMaxTtl) {
-    return cmd_cntx->SendError(kInvalidIntErr);
+  uint32_t ttl_sec = parser.Next<FInt<1u, kMaxTtl>>();
+  if (auto err = parser.TakeError(); err) {
+    return cmd_cntx->SendError(err.MakeReply());
   }
   CmdArgList fields = parser.Tail();
 
@@ -2338,11 +2296,10 @@ void GenericFamily::FieldTtl(CmdArgList args, CommandContext* cmd_cntx) {
 }
 
 void GenericFamily::Move(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  string_view target_db_sv = ArgS(args, 1);
-  int32_t target_db;
-  if (!absl::SimpleAtoi(target_db_sv, &target_db)) {
-    return cmd_cntx->SendError(kInvalidIntErr);
+  facade::CmdArgParser parser{args};
+  auto [key, target_db] = parser.Next<string_view, int32_t>();
+  if (auto err = parser.TakeError(); err) {
+    return cmd_cntx->SendError(err.MakeReply());
   }
 
   if (target_db < 0 || uint32_t(target_db) >= absl::GetFlag(FLAGS_dbnum)) {
@@ -2355,6 +2312,8 @@ void GenericFamily::Move(CmdArgList args, CommandContext* cmd_cntx) {
 
   OpStatus res = OpStatus::SKIPPED;
   ShardId target_shard = Shard(key, shard_set->size());
+  // Holds the serialized target_db for the journal record (ArgSlice cannot own storage).
+  string target_db_str = absl::StrCat(target_db);
   auto cb = [&](Transaction* t, EngineShard* shard) {
     // MOVE runs as a global transaction and is therefore scheduled on every shard.
     if (target_shard == shard->shard_id()) {
@@ -2363,7 +2322,7 @@ void GenericFamily::Move(CmdArgList args, CommandContext* cmd_cntx) {
       // MOVE runs as global command but we want to write the
       // command to only one journal.
       if (op_args.shard->journal()) {
-        RecordJournal(op_args, "MOVE"sv, ArgSlice{key, target_db_sv});
+        RecordJournal(op_args, "MOVE"sv, ArgSlice{key, target_db_str});
       }
     }
     return OpStatus::OK;
@@ -2444,9 +2403,9 @@ void GenericFamily::Pttl(CmdArgList args, CommandContext* cmd_cntx) {
 }
 
 void GenericFamily::Select(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  int64_t index;
-  if (!absl::SimpleAtoi(key, &index)) {
+  facade::CmdArgParser parser{args};
+  int64_t index = parser.Next<int64_t>();
+  if (parser.TakeError()) {
     return cmd_cntx->SendError(kInvalidDbIndErr);
   }
   if (IsClusterEnabled() && index != 0) {

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1997,7 +1997,7 @@ void SortGeneric(CmdArgList args, CommandContext* cmd_cntx, bool is_read_only) {
   params.is_read_only = is_read_only;
 
   parser.Apply(
-      Exist("ALPHA", &params.alpha), OneOf(Map(&params.reversed, "DESC", true, "ASC", false)),
+      Exist("ALPHA", &params.alpha), Map(&params.reversed, "DESC", true, "ASC", false),
       Tag("LIMIT",
           [&](CmdArgParser* p) {
             auto [offset, limit] = p->Next<uint32_t, uint32_t>();

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -723,6 +723,11 @@ TEST_F(GenericFamilyTest, Sort) {
   // desc strig
   ASSERT_THAT(Run({"sort", "list-1", "DESC", "ALPHA"}).GetVec(),
               ElementsAre("3.5", "200", "2.20", "10.1", "1.2"));
+  // ASC/DESC are not mutually exclusive — last one wins (matches Redis behavior).
+  ASSERT_THAT(Run({"sort", "list-1", "DESC", "ASC"}).GetVec(),
+              ElementsAre("1.2", "2.20", "3.5", "10.1", "200"));
+  ASSERT_THAT(Run({"sort", "list-1", "ASC", "DESC"}).GetVec(),
+              ElementsAre("200", "10.1", "3.5", "2.20", "1.2"));
   // limits
   ASSERT_THAT(Run({"sort", "list-1", "LIMIT", "0", "5"}).GetVec(),
               ElementsAre("1.2", "2.20", "3.5", "10.1", "200"));


### PR DESCRIPTION
This PR extends facade::CmdArgParser with additional option-parsing combinators and migrates several command handlers to use the new APIs for more declarative argument parsing.

Changes:

- Added new CmdArgParser::Apply option helpers: Map, If, OneOf, and nested Tag(...) parsing support.
- Refactored multiple commands in generic_family.cc to parse arguments via CmdArgParser (including SORT, RESTORE option parsing, and several TTL-related commands).
- Added unit tests covering the new parsing helpers and their interactions.