### PR TITLE
feat: add stricter cluster config validation

### DIFF
--- a/src/server/cluster/cluster_config.cc
+++ b/src/server/cluster/cluster_config.cc
@@ -53,6 +53,11 @@ bool IsConfigValid(const ClusterShardInfos& new_config) {
     return false;
   }
 
+  absl::flat_hash_set<string_view> master_ids;
+  for (const auto& shard : new_config) {
+    master_ids.insert(shard.master.id);
+  }
+
   for (const auto& shard : new_config) {
     for (const auto& slot_range : shard.slot_ranges) {
       if (slot_range.start > slot_range.end) {
@@ -75,6 +80,42 @@ bool IsConfigValid(const ClusterShardInfos& new_config) {
         }
 
         slots_found[slot] = true;
+      }
+    }
+
+    vector<SlotRange> seen_migration_ranges;
+    for (const auto& migration : shard.migrations) {
+      if (migration.node_info.id == shard.master.id) {
+        LOG(ERROR) << "Invalid cluster config: migration target equals source master="
+                   << shard.master.id;
+        return false;
+      }
+      if (!master_ids.contains(migration.node_info.id)) {
+        LOG(ERROR) << "Invalid cluster config: migration target " << migration.node_info.id
+                   << " is not a shard master in the config";
+        return false;
+      }
+
+      for (const auto& slot_range : migration.slot_ranges) {
+        if (!slot_range.IsValid()) {
+          LOG(ERROR) << "Invalid cluster config: bad migration slot range "
+                     << slot_range.ToString();
+          return false;
+        }
+        if (!shard.slot_ranges.Contains(slot_range)) {
+          LOG(ERROR) << "Invalid cluster config: migration range " << slot_range.ToString()
+                     << " is not owned by shard master=" << shard.master.id;
+          return false;
+        }
+        for (const auto& prev : seen_migration_ranges) {
+          if (slot_range.Overlaps(prev)) {
+            LOG(ERROR) << "Invalid cluster config: overlapping migration ranges "
+                       << slot_range.ToString() << " and " << prev.ToString()
+                       << " in shard master=" << shard.master.id;
+            return false;
+          }
+        }
+        seen_migration_ranges.push_back(slot_range);
       }
     }
   }

--- a/src/server/cluster/cluster_config.cc
+++ b/src/server/cluster/cluster_config.cc
@@ -84,6 +84,7 @@ bool IsConfigValid(const ClusterShardInfos& new_config) {
     }
 
     vector<SlotRange> seen_migration_ranges;
+    absl::flat_hash_set<string_view> seen_migration_targets;
     for (const auto& migration : shard.migrations) {
       if (migration.node_info.id == shard.master.id) {
         LOG(ERROR) << "Invalid cluster config: migration target equals source master="
@@ -93,6 +94,18 @@ bool IsConfigValid(const ClusterShardInfos& new_config) {
       if (!master_ids.contains(migration.node_info.id)) {
         LOG(ERROR) << "Invalid cluster config: migration target " << migration.node_info.id
                    << " is not a shard master in the config";
+        return false;
+      }
+      if (!seen_migration_targets.insert(migration.node_info.id).second) {
+        // Runtime matches outgoing migrations by target id alone, so duplicates would
+        // make cancellation ambiguous.
+        LOG(ERROR) << "Invalid cluster config: duplicate migration target "
+                   << migration.node_info.id << " in shard master=" << shard.master.id;
+        return false;
+      }
+      if (migration.slot_ranges.Empty()) {
+        LOG(ERROR) << "Invalid cluster config: empty migration slot_ranges to target "
+                   << migration.node_info.id << " in shard master=" << shard.master.id;
         return false;
       }
 

--- a/src/server/cluster/cluster_config_test.cc
+++ b/src/server/cluster/cluster_config_test.cc
@@ -574,6 +574,96 @@ TEST_F(ClusterConfigTest, InvalidConfigMigrationsWithoutIP) {
   EXPECT_EQ(config, nullptr);
 }
 
+struct MigrationValidationCase {
+  std::string name;
+  SlotRanges shard_slots;
+  std::vector<MigrationInfo> migrations;
+  bool expected_valid;
+};
+
+class MigrationValidationTest : public ClusterConfigTest,
+                                public testing::WithParamInterface<MigrationValidationCase> {};
+
+TEST_P(MigrationValidationTest, Validate) {
+  const auto& tc = GetParam();
+  // Build a two-shard config where the first shard holds tc.shard_slots (+ migrations)
+  // and the second shard owns the rest, so the full 16384 slot space is always covered.
+  SlotRanges rest = SlotSet(true).GetRemovedSlots(SlotSet(tc.shard_slots)).ToSlotRanges();
+  auto config = ClusterConfig::CreateFromConfig(
+      kMyId, ClusterShardInfos(
+                 {{.slot_ranges = tc.shard_slots,
+                   .master = {{.id = "id0", .ip = "127.0.0.1", .port = 3000}, NodeHealth::ONLINE},
+                   .replicas = {},
+                   .migrations = tc.migrations},
+                  {.slot_ranges = rest,
+                   .master = {{.id = "id1", .ip = "127.0.0.1", .port = 3001}, NodeHealth::ONLINE},
+                   .replicas = {},
+                   .migrations = {}}}));
+  EXPECT_EQ(config == nullptr, !tc.expected_valid);
+}
+
+static MigrationInfo Mig(SlotRanges ranges, std::string target = "id1") {
+  return {.slot_ranges = std::move(ranges),
+          .node_info = {.id = std::move(target), .ip = "127.0.0.1", .port = 9001}};
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    MigrationValidation, MigrationValidationTest,
+    testing::Values(
+        MigrationValidationCase{
+            "Subset", SlotRanges({{0, 8000}}), {Mig(SlotRanges({{7000, 8000}}))}, true},
+        MigrationValidationCase{
+            "ExactMatch", SlotRanges({{0, 8000}}), {Mig(SlotRanges({{0, 8000}}))}, true},
+        MigrationValidationCase{"MultipleMigrationRanges",
+                                SlotRanges({{0, 8000}}),
+                                {Mig(SlotRanges({{100, 200}, {7000, 8000}}))},
+                                true},
+        MigrationValidationCase{"MultiRangeShardSubsetOfOne",
+                                SlotRanges({{0, 500}, {1000, 8000}}),
+                                {Mig(SlotRanges({{2000, 3000}}))},
+                                true},
+        MigrationValidationCase{"MultipleMigrations",
+                                SlotRanges({{0, 8000}}),
+                                {Mig(SlotRanges({{100, 200}})), Mig(SlotRanges({{7000, 8000}}))},
+                                true},
+        MigrationValidationCase{
+            "FullyOutsideShard", SlotRanges({{0, 8000}}), {Mig(SlotRanges({{8500, 8600}}))}, false},
+        MigrationValidationCase{"PartiallyOutsideShard",
+                                SlotRanges({{0, 8000}}),
+                                {Mig(SlotRanges({{7500, 8500}}))},
+                                false},
+        MigrationValidationCase{"StartGreaterThanEnd",
+                                SlotRanges({{0, 8000}}),
+                                {Mig(SlotRanges({{8000, 7000}}))},
+                                false},
+        MigrationValidationCase{
+            "EndOutOfBounds", SlotRanges({{0, 8000}}), {Mig(SlotRanges({{100, 17000}}))}, false},
+        MigrationValidationCase{"InShardGap",
+                                SlotRanges({{0, 500}, {1000, 8000}}),
+                                {Mig(SlotRanges({{700, 800}}))},
+                                false},
+        MigrationValidationCase{"SpansAdjacentShardRanges",
+                                SlotRanges({{0, 100}, {101, 8000}}),
+                                {Mig(SlotRanges({{50, 150}}))},
+                                false},
+        MigrationValidationCase{"UnknownTarget",
+                                SlotRanges({{0, 8000}}),
+                                {Mig(SlotRanges({{100, 200}}), "nonexistent")},
+                                false},
+        MigrationValidationCase{"SelfMigration",
+                                SlotRanges({{0, 8000}}),
+                                {Mig(SlotRanges({{100, 200}}), "id0")},
+                                false},
+        MigrationValidationCase{"OverlappingMigrations",
+                                SlotRanges({{0, 8000}}),
+                                {Mig(SlotRanges({{100, 500}})), Mig(SlotRanges({{400, 800}}))},
+                                false},
+        MigrationValidationCase{"OverlappingRangesInOneMigration",
+                                SlotRanges({{0, 8000}}),
+                                {Mig(SlotRanges({{100, 500}, {300, 700}}))},
+                                false}),
+    [](const auto& info) { return info.param.name; });
+
 TEST_F(ClusterConfigTest, SlotSetAPI) {
   {
     SlotSet ss(false);
@@ -649,9 +739,7 @@ TEST_F(ClusterConfigTest, ConfigComparison) {
     {
       "slot_ranges": [ { "start": 0, "end": 16383 } ],
       "master": { "id": "id0", "ip": "localhost", "port": 3000 },
-      "replicas": [],
-      "migrations": [{ "slot_ranges": [ { "start": 7000, "end": 8000 } ]
-                     , "ip": "127.0.0.1", "port" : 9001, "node_id": "id1" }]
+      "replicas": []
     }
   ])json");
   EXPECT_NE(config1->GetConfig(), config2->GetConfig());
@@ -686,8 +774,13 @@ TEST_F(ClusterConfigTest, ConfigComparison) {
                      , "ip": "127.0.0.1", "port" : 9001, "node_id": "id2" }]
     },
     {
-      "slot_ranges": [ { "start": 8001, "end": 16383 } ],
+      "slot_ranges": [ { "start": 8001, "end": 12000 } ],
       "master": { "id": "id1", "ip": "localhost", "port": 3001 },
+      "replicas": []
+    },
+    {
+      "slot_ranges": [ { "start": 12001, "end": 16383 } ],
+      "master": { "id": "id2", "ip": "localhost", "port": 3002 },
       "replicas": []
     }
   ])json");
@@ -726,9 +819,7 @@ TEST_F(ClusterConfigTest, NodesHealth) {
       "slot_ranges": [ { "start": 0, "end": 16383 } ],
       "master": { "id": "id0", "ip": "localhost", "port": 3000, "health" : "online" },
       "replicas": [{ "id": "id1", "ip": "localhost", "port": 3001, "health" : "loading" },
-                   { "id": "id2", "ip": "localhost", "port": 3002, "health" : "fail" }],
-      "migrations": [{ "slot_ranges": [ { "start": 7000, "end": 8000 } ]
-                     , "ip": "127.0.0.1", "port" : 9001, "node_id": "id1" }]
+                   { "id": "id2", "ip": "localhost", "port": 3002, "health" : "fail" }]
     }
 
   ])json");

--- a/src/server/cluster/cluster_config_test.cc
+++ b/src/server/cluster/cluster_config_test.cc
@@ -622,10 +622,6 @@ INSTANTIATE_TEST_SUITE_P(
                                 SlotRanges({{0, 500}, {1000, 8000}}),
                                 {Mig(SlotRanges({{2000, 3000}}))},
                                 true},
-        MigrationValidationCase{"MultipleMigrations",
-                                SlotRanges({{0, 8000}}),
-                                {Mig(SlotRanges({{100, 200}})), Mig(SlotRanges({{7000, 8000}}))},
-                                true},
         MigrationValidationCase{
             "FullyOutsideShard", SlotRanges({{0, 8000}}), {Mig(SlotRanges({{8500, 8600}}))}, false},
         MigrationValidationCase{"PartiallyOutsideShard",
@@ -661,7 +657,14 @@ INSTANTIATE_TEST_SUITE_P(
         MigrationValidationCase{"OverlappingRangesInOneMigration",
                                 SlotRanges({{0, 8000}}),
                                 {Mig(SlotRanges({{100, 500}, {300, 700}}))},
-                                false}),
+                                false},
+        MigrationValidationCase{
+            "EmptyMigrationSlotRanges", SlotRanges({{0, 8000}}), {Mig(SlotRanges())}, false},
+        MigrationValidationCase{
+            "DuplicateTargetIds",
+            SlotRanges({{0, 8000}}),
+            {Mig(SlotRanges({{100, 200}}), "id1"), Mig(SlotRanges({{7000, 8000}}), "id1")},
+            false}),
     [](const auto& info) { return info.param.name; });
 
 TEST_F(ClusterConfigTest, SlotSetAPI) {

--- a/src/server/cluster/cluster_defs.h
+++ b/src/server/cluster/cluster_defs.h
@@ -34,6 +34,10 @@ struct SlotRange {
     return id >= start && id <= end;
   }
 
+  bool Overlaps(SlotRange other) const noexcept {
+    return start <= other.end && other.start <= end;
+  }
+
   std::string ToString() const;
 };
 
@@ -45,6 +49,15 @@ class SlotRanges {
   bool Contains(SlotId id) const noexcept {
     for (const auto& sr : ranges_) {
       if (sr.Contains(id))
+        return true;
+    }
+    return false;
+  }
+
+  // True iff `r` lies entirely within a single range of *this. Expects r.IsValid().
+  bool Contains(SlotRange r) const noexcept {
+    for (const auto& sr : ranges_) {
+      if (sr.start <= r.start && r.end <= sr.end)
         return true;
     }
     return false;

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -1985,6 +1985,7 @@ async def test_keys_expiration_during_migration(df_factory: DflyInstanceFactory)
     await seeder_task
 
     logging.debug("finish migration")
+    nodes[0].migrations = []
     nodes[0].slots = []
     nodes[1].slots = [(0, 16383)]
     await push_config(json.dumps(generate_config(nodes)), [node.admin_client for node in nodes])
@@ -2257,6 +2258,7 @@ async def test_cluster_migration_while_seeding(
     logging.debug("Migration finished")
 
     logging.debug("Finalizing migration")
+    nodes[0].migrations = []
     nodes[0].slots = []
     nodes[1].slots = [(0, 16383)]
     await push_config(json.dumps(generate_config(nodes)), [node.admin_client for node in nodes])


### PR DESCRIPTION
fixes: #7195

Summary: This PR tightens cluster configuration validation, focusing on slot-migration entries, to reject malformed or inconsistent configs earlier.

Changes:

- Collects all shard master IDs during IsConfigValid and validates migrations against them.
- Rejects migrations that target the source master (self-migration) or a node ID that is not a shard master in the provided config.
- Validates each migration slot range is in-bounds/ordered (IsValid()) and is fully contained within the source shard’s owned slot ranges.
- Rejects overlapping migration slot ranges within a shard (across and within migration entries).
- Adds helpers: SlotRange::Overlaps and SlotRanges::Contains(SlotRange) to support the new checks.
- Adds a parameterized test suite covering valid/invalid migration configurations and updates existing config-comparison/health tests to conform to the stricter rules.

Technical Notes: Validation now enforces stronger invariants on migration metadata (target identity and range correctness), preventing invalid configs from being accepted and later failing during migration execution.