### PR TITLE
fix(server): Don't use item queue for inlined load

### DIFF
--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -3007,12 +3007,20 @@ error_code RdbLoader::LoadKeyValPair(int type, ObjSettings* settings) {
 io::Result<bool> RdbLoader::ReadAndDispatchObject(int object_type, std::string& key,
                                                   const ObjSettings& obj_settings,
                                                   DbIndex db_index) {
-  Item* item = item_queue_.Pop();
-  if (item == nullptr) {
-    item = new Item;
+  const ShardId sid = Shard(key, shard_set->size());
+  bool run_inlined = EngineShard::tlocal() && EngineShard::tlocal()->shard_id() == sid;
+  Item local_item, *item = &local_item;
+
+  // If we run non-inlined, take an item from the queue
+  if (!run_inlined) {
+    if (item = item_queue_.Pop(); item == nullptr)
+      item = new Item;
   }
 
-  auto cleanup = absl::Cleanup([item] { delete item; });
+  auto cleanup = absl::Cleanup([item, run_inlined] {
+    if (!run_inlined)
+      delete item;
+  });
 
   // The caller restores pending_read_ for continuation chunks.
   // If it is already non-empty, this call appends to an existing partially built object.
@@ -3058,12 +3066,9 @@ io::Result<bool> RdbLoader::ReadAndDispatchObject(int object_type, std::string& 
 
   std::move(cleanup).Cancel();
 
-  const ShardId sid = Shard(item->key, shard_set->size());
-
-  if (const EngineShard* es = EngineShard::tlocal(); es && es->shard_id() == sid) {
+  if (run_inlined) {
     const DbContext db_cntx{&namespaces->GetDefaultNamespace(), db_index, GetCurrentTimeMs()};
     CreateObjectOnShard(db_cntx, item, &db_cntx.GetDbSlice(sid));
-    item_queue_.Push(item);
   } else {
     auto& out_buf = shard_buf_[sid];
     out_buf.emplace_back(item);


### PR DESCRIPTION
The item queue showed up on the profile because it uses atomic which can become "cache dirty" if do have some inter-thread intercaction. Avoid atomics at all for inlined execution by using a local item struct