### PR TITLE
perf(facade): defer V2 ReplyBatch flush to reduce syscalls

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -2619,7 +2619,18 @@ bool Connection::ReplyBatch() {
   }
 
   reply_builder_->SetBatchMode(false);
-  reply_builder_->Flush();
+
+  // V1: handles its pipeline batching inside AsyncFiber, so it flushes unconditionally here.
+  //
+  // V2: operates as a single-fiber event loop where reading, parsing, and executing happen
+  // sequentially. Because ParseLoop processes pipelines in chunks, flushing here would trigger a
+  // sendmsg syscall for every single chunk. Instead, V2 delegates flushing to IoLoopV2, which
+  // safely flushes the coalesced buffer right before the fiber yields (await) or when memory limits
+  // are reached.
+  if (!ioloop_v2_) {
+    reply_builder_->Flush();
+  }
+
   return !reply_builder_->GetError();
 }
 
@@ -2953,6 +2964,13 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
     if (io_buf_.InputLen() == 0) {
       phase_ = READ_SOCKET;
 
+      // Flush replies deferred by ReplyBatch before sleeping - ensures the client
+      // gets its response even when no more data arrives (single commands, end of pipeline).
+      reply_builder_->Flush();
+      if (auto err = reply_builder_->GetError(); err) {
+        return err;
+      }
+
       io_event_.await([this, &is_ready_to_migrate]() {
         // TODO: optimize CanReply with looking up waiter key
         // io_buf_.InputLen() > 0 is still needed for multishot flow.
@@ -2990,10 +3008,9 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
         std::visit(AsyncOperations{reply_builder_.get(), this}, msg.handle);
       }
 
-      // TODO: Possibly don't flush unconditionally - optimize it
-      reply_builder_->Flush();
-      if (auto ec = reply_builder_->GetError(); ec)
-        return ec;
+      // Note: No flush needed here: the `continue` below re-enters the loop, which either
+      // hits the data path (ParseLoop flushes via ReplyBatch) or the idle-await block
+      // (Flush 1), which always flushes before sleeping.
 
       // TODO: Properly handle backpressure
       GetQueueBackpressure().pubsub_ec.notifyAll();
@@ -3062,6 +3079,12 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
         // us "deaf" to future memory relief.
         auto sub_key = qbp.v2_pipeline_backpressure_ec.subscribe_persistent(&backpressure_waiter);
 
+        // Client needs replies to free its send buffer and relieve backpressure.
+        reply_builder_->Flush();
+        if (auto err = reply_builder_->GetError(); err) {
+          return err;
+        }
+
         io_event_.await([this, &is_ready_to_migrate]() {
           bool cmd_ready = parsed_head_ && parsed_head_->CanReply();
           bool under_limit = !GetQueueBackpressure().IsPipelineBufferOverLimit(
@@ -3085,6 +3108,10 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
     // Check io_ec_ after parsing and flushing replies, so that half-closed
     // connections get their responses before we close.
     if (io_ec_) {
+      reply_builder_->Flush();
+      if (auto err = reply_builder_->GetError(); err) {
+        return err;
+      }
       LOG_IF(WARNING, cntx()->replica_conn) << "async io error: " << io_ec_;
       return std::exchange(io_ec_, {});
     }
@@ -3095,6 +3122,12 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
 
     // Migration requested and actionable: skip buffer bookkeeping, jump to HandleMigrateRequest().
     if (is_ready_to_migrate()) {
+      // Flush before migrating: handing off unflushed thread-local buffers to a
+      // new thread will cause data corruption or a hard crash.
+      reply_builder_->Flush();
+      if (auto err = reply_builder_->GetError(); err) {
+        return err;  // Connection is dead, no point migrating it cross-thread.
+      }
       continue;
     }
 

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -134,6 +134,10 @@ void SinkReplyBuilder::WriteRef(std::string_view str) {
 }
 
 void SinkReplyBuilder::Flush(size_t expected_buffer_cap) {
+  // Fast path: nothing buffered and no buffer resize requested.
+  if (vecs_.empty() && (expected_buffer_cap == 0))
+    return;
+
   if (!vecs_.empty())
     Send();
 


### PR DESCRIPTION
The Problem:
Under heavy pipeline saturation (50 clients, pipeline=500), V2 was
issuing ~92,600 sendmsg syscalls vs V1's ~7,500 for the same
workload — over 12x more kernel transitions for identical traffic.

Root Cause:
ParseLoop() processes pipelines in chunks bounded by
max_busy_cycles. The old ReplyBatch() called Flush() after
every chunk unconditionally. Since the parser outruns the socket,
this triggered a kernel sendmsg on every parse iteration instead
of coalescing replies across the full pipeline.

The Fix:
Remove the unconditional flush from ReplyBatch() for V2 and
defer it to four explicit points in IoLoopV2:

- Idle await (no input): flush before sleeping — handles single
  commands and end-of-pipeline.
- Backpressure await: flush so the client can drain its recv
  buffer and relieve memory pressure.
- Half-close (io_ec_): flush before returning the read error —
  ensures pipelined replies reach the client before teardown.
- Migration: flush before cross-thread handoff to avoid data
  corruption or crash on the new thread.

SinkReplyBuilder::Flush() now returns immediately when nothing
is buffered and no resize is requested, avoiding a redundant
state-reset on no-op flushes.

Memory Safety:
No OOM risk is introduced because:
- SinkReplyBuilder auto-flushes its iovec when full (~64KB).
- The backpressure guard in IoLoopV2 forces a flush when the
  pipeline queue grows too large.

Results (throughput mode, pipeline=500, 5-run median, local bench):
  V1 baseline : 583,118 RPS | 41.76ms lat | 7,506 syscalls
  V2 before : 513,640 RPS | 47.88ms lat | 92,696 syscalls
  V2 after : 589,165 RPS | 43.05ms lat | 5,721 syscalls
                                             (~94% syscall reduction)

V2 now slightly outperforms V1 at pipeline=500. The primary goal
of this patch is CPU efficiency via syscall reduction, not raw RPS.

Architectural Note on Fragmentation:
The over-flushing also affected fragmented workloads. At
pipeline=500 fragmentation mode, the old V2 issued up to ~27x
more syscalls than V1 (e.g. 1,847 vs 68 in a single run;
median 1,848 vs 72). This patch reduces that to ~5.7x
(427 vs 75, 5-run median).

The remaining gap is inherent to the single-fiber io_uring
design: V1 uses a 50ms busy-spin (max_busy_read_usec) to
artificially batch fragments, while V2 flushes as soon as the
kernel delivers data. V2 will never reach V1 flush parity in
fragmented workloads, and that is an acceptable tradeoff.