### PR TITLE
feat: DEBUG TRAFFIC REPLICA - record replication stream on replicas

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -2329,6 +2329,26 @@ void Connection::StopTrafficLogging() {
   tl_traffic_logger.ResetLocked();
 }
 
+void Connection::LogReplicaCommand(const cmn::BackedArguments& args, uint32_t db_index) {
+  // Contract: LSN/PING opcodes are filtered before ExecuteTx, and
+  // COMMAND/EXPIRED journal entries always carry at least a command name.
+  DCHECK(!args.empty());
+  // Fast-path gate: cheap thread-local reads without the mutex. If the logger
+  // was swapped out concurrently, LogTrafficParts re-checks `log_file` inside
+  // the lock so at worst we do a bit of wasted work (building `parts`).
+  // id=0 is a synthetic client id — replication has no connection/client of its
+  // own, and callers on the same fiber serialise naturally.
+  if (!tl_traffic_logger.log_file ||
+      tl_traffic_logger.listener_type != ListenerType::REPLICA_RESP) {
+    return;
+  }
+  absl::InlinedVector<string_view, 16> parts;
+  parts.reserve(args.size());
+  for (auto v : args.view())
+    parts.push_back(v);
+  LogTrafficParts(/*id=*/0, /*has_more=*/false, db_index, absl::MakeSpan(parts));
+}
+
 bool Connection::IsHttp() const {
   return is_http_;
 }

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -191,15 +191,18 @@ class Connection : public util::Connection {
   // This method returns true for customer facing listeners.
   bool IsMainOrMemcache() const;
 
-  // Classification of the listener this connection belongs to, used as a filter for the
-  // traffic logger (DEBUG TRAFFIC) and persisted in the recorded file format.
-  // The numeric values are part of the on-disk format, do not change them.
-  // MAIN_RESP and ADMIN_RESP share the RESP protocol but live on different ports
-  // (main TCP/unix-socket vs. privileged admin port).
+  // Classification of the traffic source for the DEBUG TRAFFIC recorder.
+  // Persisted as the second byte of the file header in the on-disk format;
+  // the numeric values are part of that format — do not change them.
+  // MAIN_RESP / ADMIN_RESP / REPLICA_RESP all carry RESP-format commands;
+  // MAIN vs ADMIN differ by the port they were accepted on, while REPLICA
+  // covers commands that arrived on a replica via the replication stream
+  // (not from a client-facing listener).
   enum class ListenerType : uint8_t {
-    MAIN_RESP = 1,   // main RESP listener (TCP and unix-socket)
-    MEMCACHE = 2,    // memcached protocol listener
-    ADMIN_RESP = 3,  // privileged / admin listener (RESP protocol on admin port)
+    MAIN_RESP = 1,     // main RESP listener (TCP and unix-socket)
+    MEMCACHE = 2,      // memcached protocol listener
+    ADMIN_RESP = 3,    // privileged / admin listener (RESP protocol on admin port)
+    REPLICA_RESP = 4,  // commands arriving on a replica from its master
   };
 
   ListenerType GetListenerType() const {
@@ -249,6 +252,15 @@ class Connection : public util::Connection {
 
   // Stops traffic logging in this thread. A noop if the thread is not logging.
   static void StopTrafficLogging();
+
+  // Writes a single command to the per-thread traffic log if (and only if) the
+  // logger on this thread is currently recording the REPLICA_RESP source.
+  // Used by the replication read path on replicas to capture commands that
+  // arrived from the master — they do not travel through a Connection, so the
+  // regular per-connection hot path does not see them.
+  // `db_index` is the database the command should be applied to; it is stored
+  // in the record so replay tools can issue SELECT before dispatch.
+  static void LogReplicaCommand(const cmn::BackedArguments& args, uint32_t db_index);
 
   // Get quick debug info for logs
   std::string DebugInfo() const;

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -672,6 +672,9 @@ void DebugCmd::Run(CmdArgList args, CommandContext* cmd_cntx) {
         "    Start traffic logging for a single listener type to files with the given",
         "    path/prefix. LISTENER is required; mixing listeners in one recording is",
         "    intentionally not supported - start separate recordings per listener.",
+        "TRAFFIC START <path>/<file_prefix> REPLICA",
+        "    On a replica, capture commands received from the master via the replication",
+        "    stream. Fails with an error on a master/standalone server.",
         "TRAFFIC STOP",
         "    Stop traffic logging started by a previous TRAFFIC START.",
         "RECVSIZE [<tid> | ENABLE | DISABLE]",
@@ -1063,8 +1066,10 @@ void DebugCmd::LogTraffic(CmdArgList args, CommandContext* cmd_cntx) {
   // Syntax:
   //   DEBUG TRAFFIC STOP
   //   DEBUG TRAFFIC START <path> LISTENER <main|memcache|admin>
-  // A recording captures exactly one listener type; mixing protocols in one file is
-  // intentionally not supported.
+  //   DEBUG TRAFFIC START <path> REPLICA
+  // A recording captures exactly one source; LISTENER and REPLICA are mutually
+  // exclusive. REPLICA captures commands received from a master via the
+  // replication stream (only meaningful while this server is a replica).
   CmdArgParser parser(args);
   if (parser.Check("STOP")) {
     if (!parser.Finalize())
@@ -1076,10 +1081,26 @@ void DebugCmd::LogTraffic(CmdArgList args, CommandContext* cmd_cntx) {
 
   parser.ExpectTag("START");
   auto path = parser.Next<string_view>();
-  parser.ExpectTag("LISTENER");
-  auto listener_type = parser.MapNext("main", Connection::ListenerType::MAIN_RESP, "memcache",
-                                      Connection::ListenerType::MEMCACHE, "admin",
-                                      Connection::ListenerType::ADMIN_RESP);
+
+  Connection::ListenerType listener_type;
+  if (parser.Check("REPLICA")) {
+    // Replication stream is only incoming on a replica; there is no stream to
+    // capture on a master/standalone server. Fail fast so the caller gets a
+    // clear diagnosis instead of an empty log. We intentionally skip Finalize()
+    // here: the role error is more actionable than "extra arg after REPLICA",
+    // and calling Finalize would leave an unchecked UNPROCESSED error that
+    // trips CmdArgParser's destructor DCHECK.
+    if (ServerState::tlocal()->is_master) {
+      return cmd_cntx->SendError(
+          "REPLICA option requires this server to be a replica (current role is master)");
+    }
+    listener_type = Connection::ListenerType::REPLICA_RESP;
+  } else {
+    parser.ExpectTag("LISTENER");
+    listener_type = parser.MapNext("main", Connection::ListenerType::MAIN_RESP, "memcache",
+                                   Connection::ListenerType::MEMCACHE, "admin",
+                                   Connection::ListenerType::ADMIN_RESP);
+  }
   if (!parser.Finalize())
     return cmd_cntx->SendError(parser.TakeError().MakeReply());
 

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -25,6 +25,7 @@ extern "C" {
 
 #include "base/flags.h"
 #include "base/logging.h"
+#include "facade/dragonfly_connection.h"
 #include "facade/redis_parser.h"
 #include "facade/reply_capture.h"
 #include "facade/socket_utils.h"
@@ -1140,6 +1141,10 @@ bool DflyShardReplica::ExecuteTx(TransactionData&& tx_data, ExecutionState* cntx
 
   if (!tx_data.IsGlobalCmd()) {
     VLOG(3) << "Execute cmd without sync between shards. txid: " << tx_data.txid;
+    // Traffic logger hook: gate is inside LogReplicaCommand, so the no-op path
+    // (logger disabled) is cheap. Log before Execute so a crash during execute
+    // still leaves the record on disk for post-mortem replay.
+    facade::Connection::LogReplicaCommand(tx_data.command, tx_data.dbid);
     return executor_->Execute(tx_data.dbid, tx_data.command) == facade::DispatchResult::OK;
   }
 
@@ -1168,6 +1173,9 @@ bool DflyShardReplica::ExecuteTx(TransactionData&& tx_data, ExecutionState* cntx
   // replica.
   bool execution_res = true;
   if (inserted_by_me) {
+    // Global command — log exactly once (only the inserter flow runs Execute,
+    // so this guard naturally dedups across per-shard flows).
+    facade::Connection::LogReplicaCommand(tx_data.command, tx_data.dbid);
     execution_res = executor_->Execute(tx_data.dbid, tx_data.command) == facade::DispatchResult::OK;
   }
   // Wait until exection is done, to make sure we done execute next commands while the global is

--- a/tools/replay/workers.go
+++ b/tools/replay/workers.go
@@ -16,12 +16,14 @@ import (
 )
 
 // Listener type identifiers as stored in traffic log v3 (must match
-// facade::Connection::ListenerType in the C++ code). MAIN_RESP and ADMIN_RESP
-// both speak RESP but live on different ports on the source server.
+// facade::Connection::ListenerType in the C++ code). MAIN_RESP, ADMIN_RESP and
+// REPLICA_RESP all carry RESP-format commands and are replayed via the same
+// RESP client; only MEMCACHE needs a different client.
 const (
-	ListenerMainRESP  uint8 = 1
-	ListenerMemcache  uint8 = 2
-	ListenerAdminRESP uint8 = 3
+	ListenerMainRESP    uint8 = 1
+	ListenerMemcache    uint8 = 2
+	ListenerAdminRESP   uint8 = 3
+	ListenerReplicaRESP uint8 = 4
 )
 
 // Flags field layout:


### PR DESCRIPTION
Extends `DEBUG TRAFFIC` to record commands that arrive on a replica via the replication stream. Follow-up to #7192. Use cases: reproduce production bugs locally, audit replicated writes, replay prod traffic onto staging.

Changes:
- New CLI: `DEBUG TRAFFIC START <path> REPLICA` (mutually exclusive with `LISTENER`). Fails with a clear error on a master/standalone server.
- New `ListenerType::REPLICA_RESP = 4` (persisted in the file header - same v3 format, no new bump).
- New static `facade::Connection::LogReplicaCommand(args, db_index)` - the replication path has no per-client `Connection`, so a static entry point routes straight into the existing per-thread traffic logger.
- Hook in `DflyShardReplica::ExecuteTx` before both `executor_->Execute` sites (non-global + global-with `inserted_by_me`, which naturally dedups global commands across per-shard flows).
- Go replay: `ListenerReplicaRESP` falls through the RESP client path - `run` / `print` / `analyze` all work against the existing backend.