### PR TITLE
fix(server): use LOG_EVERY_T for OOM error logging

### DIFF
--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -703,7 +703,7 @@ void Transaction::RunCallback(EngineShard* shard) {
       }
     }
   } catch (std::bad_alloc&) {
-    LOG_FIRST_N(ERROR, 16) << " out of memory";  // TODO: to log at most once per sec.
+    LOG_EVERY_T(ERROR, 1) << " out of memory";
     absl::base_internal::SpinLockHolder lk{&local_result_mu_};
     local_result_ = OpStatus::OUT_OF_MEMORY;
   } catch (std::exception& e) {


### PR DESCRIPTION
Replace LOG_FIRST_N with LOG_EVERY_T to limit OOM log frequency to at most once per second, as intended by the TODO.

## Changes
- Replace LOG_FIRST_N(ERROR, 16) with LOG_EVERY_T(ERROR, 1)
- Remove resolved TODO comment

## Test plan
- [x] ninja dragonfly compiles successfully
- [x] pre-commit hooks pass
