### PR TITLE
fix(search): propagate FLAT VECTOR_RANGE score alias to FT.SEARCH reply

### DIFF
--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -873,8 +873,13 @@ SearchResult ShardDocIndex::Search(const OpArgs& op_args, const SearchParams& pa
   bool skip_sort = false;
   if (auto ko = search_algo->GetKnnScoreSortOption(); ko) {
     skip_sort = !params.sort_option || params.sort_option->IsSame(*ko);
-    if (!skip_sort)
+    if (skip_sort) {
+      // Caller (SearchReply) will globally reorder by knn_score. Don't cut at the
+      // shard level — otherwise multi-shard top-K-by-distance can drop true winners.
+      limit = numeric_limits<size_t>::max();
+    } else {
       limit = max(limit, ko->limit);
+    }
   }
 
   // We don't apply limit if this is prefilter HNSW KNN search

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -1083,7 +1083,8 @@ void PartialSort(absl::Span<SerializedSearchDoc*> docs, size_t limit, SortOrder 
 
 void SearchReply(const SearchParams& params,
                  std::optional<search::KnnScoreSortOption> knn_sort_option,
-                 absl::Span<SearchResult> results, SinkReplyBuilder* builder, bool is_css) {
+                 std::string_view inject_score_alias, absl::Span<SearchResult> results,
+                 SinkReplyBuilder* builder, bool is_css) {
   size_t total_hits = 0;
   absl::InlinedVector<SerializedSearchDoc*, 5> docs;
   docs.reserve(results.size());
@@ -1105,6 +1106,10 @@ void SearchReply(const SearchParams& params,
     ignore_sort = !params.sort_option || params.sort_option->IsSame(*knn_sort_option);
     if (params.ShouldReturnField(knn_sort_option->score_field_alias))
       knn_score_ret_field = knn_sort_option->score_field_alias;
+  } else if (!inject_score_alias.empty() && params.ShouldReturnField(inject_score_alias)) {
+    // FLAT VECTOR_RANGE without distance-based SORTBY: expose the alias without
+    // forcing a global reorder. Matches Redis Stack default ordering.
+    knn_score_ret_field = string{inject_score_alias};
   }
 
   // Apply LIMIT
@@ -1994,11 +1999,28 @@ void CmdFtSearch(CmdArgList args, CommandContext* cmd_cntx) {
                                       *cmd_cntx);
   }
 
+  // FLAT VECTOR_RANGE alias: HNSW is handled above. For FLAT, the per-shard Search()
+  // populates SerializedSearchDoc::knn_score but doesn't expose the alias name.
+  // If the user is sorting by the alias, route through knn_sort_option to get distance
+  // ordering; otherwise expose the alias without forcing a global reorder.
+  std::string_view inject_score_alias;
+  if (!knn && !hnsw_range && !knn_sort_option) {
+    if (auto* vr = search_algo.GetVectorRangeNode(); vr && !vr->score_alias.empty()) {
+      search::KnnScoreSortOption opt{vr->score_alias, std::numeric_limits<size_t>::max()};
+      if (params->sort_option && params->sort_option->IsSame(opt)) {
+        knn_sort_option = opt;
+      } else {
+        inject_score_alias = vr->score_alias;
+      }
+    }
+  }
+
   // TODO add merging of CSS results with local results (SORT, LIMIT, etc)
   docs.insert(docs.end(), std::make_move_iterator(css_docs.begin()),
               std::make_move_iterator(css_docs.end()));
 
-  SearchReply(*params, knn_sort_option, absl::MakeSpan(docs), builder, is_cross_shard);
+  SearchReply(*params, knn_sort_option, inject_score_alias, absl::MakeSpan(docs), builder,
+              is_cross_shard);
 }
 
 void CmdFtProfile(CmdArgList args, CommandContext* cmd_cntx) {
@@ -2079,8 +2101,8 @@ void CmdFtProfile(CmdArgList args, CommandContext* cmd_cntx) {
 
   // Result of the search command
   if (!result_is_empty) {
-    SearchReply(*params, search_algo.GetKnnScoreSortOption(), absl::MakeSpan(search_results), rb,
-                false);
+    SearchReply(*params, search_algo.GetKnnScoreSortOption(), {}, absl::MakeSpan(search_results),
+                rb, false);
   } else {
     rb->StartArray(1);
     rb->SendLong(0);

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -4475,6 +4475,52 @@ TEST_F(SearchFamilyTest, HnswVectorRangeWithoutYieldDistanceAs) {
   EXPECT_THAT(resp, AreDocIds("k4", "k5", "k6"));
 }
 
+// Regression: FLAT VECTOR_RANGE must inject the YIELD_DISTANCE_AS alias into FT.SEARCH
+// replies. Default order is unchanged (no implicit reorder by distance — matches Redis
+// Stack); SORTBY <alias> opts in to distance ordering.
+TEST_F(SearchFamilyTest, FlatVectorRangeYieldDistanceAs) {
+  auto F = [](float f) { return string(reinterpret_cast<const char*>(&f), sizeof(float)); };
+
+  Run({"FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "pos", "VECTOR", "FLAT", "6", "TYPE", "FLOAT32",
+       "DIM", "1", "DISTANCE_METRIC", "L2"});
+  for (int i = 0; i < 10; i++)
+    Run({"HSET", absl::StrFormat("k%d", i), "pos", F(static_cast<float>(i))});
+
+  string vec = F(5.0f);
+
+  auto extract = [](const RespExpr& resp) {
+    std::map<string, double> out;
+    auto& arr = resp.GetVec();
+    for (size_t i = 1; i + 1 < arr.size(); i += 2) {
+      auto& flds = arr[i + 1].GetVec();
+      for (size_t j = 0; j + 1 < flds.size(); j += 2) {
+        if (flds[j].GetString() == "dist")
+          out[arr[i].GetString()] = std::stod(flds[j + 1].GetString());
+      }
+    }
+    return out;
+  };
+
+  // Default RETURN: alias must be present alongside the indexed field.
+  auto resp = Run({"FT.SEARCH", "idx", "@pos:[VECTOR_RANGE 1.5 $v]=>{$YIELD_DISTANCE_AS: dist}",
+                   "PARAMS", "2", "v", vec});
+  ASSERT_EQ(resp.GetVec()[0].GetInt(), 3);
+  auto d = extract(resp);
+  EXPECT_DOUBLE_EQ(d["k4"], 1.0);
+  EXPECT_DOUBLE_EQ(d["k5"], 0.0);
+  EXPECT_DOUBLE_EQ(d["k6"], 1.0);
+
+  // Explicit RETURN of the alias.
+  resp = Run({"FT.SEARCH", "idx", "@pos:[VECTOR_RANGE 1.5 $v]=>{$YIELD_DISTANCE_AS: dist}",
+              "PARAMS", "2", "v", vec, "RETURN", "1", "dist"});
+  EXPECT_EQ(extract(resp).size(), 3u);
+
+  // SORTBY on the alias yields distance ASC (k5 closest).
+  resp = Run({"FT.SEARCH", "idx", "@pos:[VECTOR_RANGE 1.5 $v]=>{$YIELD_DISTANCE_AS: dist}",
+              "PARAMS", "2", "v", vec, "SORTBY", "dist", "ASC", "RETURN", "1", "dist"});
+  EXPECT_EQ(resp.GetVec()[1].GetString(), "k5");
+}
+
 TEST_F(SearchFamilyTest, VectorRangeAggregate) {
   auto FloatToBytes = [](float f) -> string {
     return string(reinterpret_cast<const char*>(&f), sizeof(float));


### PR DESCRIPTION
FT.SEARCH with `@field:[VECTOR_RANGE r $v]=>{$YIELD_DISTANCE_AS: alias}` on a FLAT vector index dropped the alias from the reply. This broke langchain-redis `RedisSemanticCache` (and any redisvl `VectorRangeQuery` on a FLAT index): `CacheHit` validation failed because the distance field was missing.

Changes:
- `SearchReply` takes a new `inject_score_alias`. When set (and no `knn_sort_option`), the alias is exposed in the reply without forcing a global reorder - preserving Redis Stack's default order.
- `CmdFtSearch` for FLAT VECTOR_RANGE: if `SORTBY` targets the alias, route through `knn_sort_option` (distance ASC); otherwise pass the alias via `inject_score_alias`.
- `ShardDocIndex::Search`: when the caller will globally reorder by `knn_score`, raise the per-shard limit to `max()` so multi-shard top-K-by-distance doesn't drop true winners (mirrors the existing `is_knn_prefilter` pattern).

Verified against Redis Stack: identical results for `SORTBY dist ASC`. LangChain `RedisSemanticCache.lookup()` now succeeds on Dragonfly. New regression test covers default RETURN, explicit RETURN of the alias, and SORTBY on the alias.

Repro before fix:
```
  FT.CREATE idx ON HASH SCHEMA pos VECTOR FLAT 6 TYPE FLOAT32 DIM 1 DISTANCE_METRIC L2
  HSET k5 pos <f32 5.0>
  FT.SEARCH idx "@pos:[VECTOR_RANGE 1.5 $v]=>{$YIELD_DISTANCE_AS: dist}" RETURN 1 dist PARAMS 2 v <f32 5.0> DIALECT 2
```
Redis Stack returns dist=0; Dragonfly returned empty fields.