### PR TITLE
fix: avoid O(n) scans in NotifyWatchQueue

### DIFF
--- a/src/server/blocking_controller.cc
+++ b/src/server/blocking_controller.cc
@@ -9,6 +9,7 @@
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 
 #include "base/logging.h"
+#include "server/db_slice.h"
 #include "server/engine_shard_set.h"
 #include "server/namespaces.h"
 #include "server/transaction.h"
@@ -227,13 +228,20 @@ void BlockingController::NotifyWatchQueue(std::string_view key, WatchQueue* wq,
   auto& queue = wq->items;
   ShardId sid = owner_->shard_id();
 
+  // Fast path: if the key doesn't exist, no checker will pass (all start with FindReadOnly).
+  // We can't use key_ready_checker here because checkers can be per-transaction (e.g. XREAD BLOCK
+  // checks stream-specific conditions beyond key existence), so the front item's checker returning
+  // false doesn't mean later items won't pass. A raw existence check is the safe common gate.
+  if (queue.empty() || !IsValid(context.GetDbSlice(owner_->shard_id()).FindReadOnly(context, key)))
+    return;
+
   // In the most cases we shouldn't have skipped elements at all
   absl::InlinedVector<dfly::WatchItem, 4> skipped;
   while (!queue.empty()) {
     auto& wi = queue.front();
     Transaction* head = wi.get();
     // We check may the transaction be notified otherwise move it to the end of the queue
-    if (wi.key_ready_checker(owner_, context, head, key)) {
+    if (wi.key_ready_checker(owner_, context, key)) {
       DVLOG(2) << "WQ-Pop " << head->DebugId() << " from key " << key << " committed txid "
                << owner_->committed_txid();
       if (head->NotifySuspended(sid, key)) {

--- a/src/server/blocking_controller.cc
+++ b/src/server/blocking_controller.cc
@@ -9,7 +9,6 @@
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 
 #include "base/logging.h"
-#include "server/db_slice.h"
 #include "server/engine_shard_set.h"
 #include "server/namespaces.h"
 #include "server/transaction.h"
@@ -141,6 +140,8 @@ void BlockingController::RemovedWatched(Keys keys, Transaction* tx) {
   if (wt.queue_map.empty()) {
     watched_dbs_.erase(dbit);
   }
+  // TODO: awakened_keys.insert in UnwatchTx already guards on !wq->items.empty(), so we could
+  // skip awakened_indices_.emplace when no key was re-queued, avoiding a spurious NotifyPending.
   awakened_indices_.emplace(tx->GetDbIndex());
 }
 
@@ -228,20 +229,16 @@ void BlockingController::NotifyWatchQueue(std::string_view key, WatchQueue* wq,
   auto& queue = wq->items;
   ShardId sid = owner_->shard_id();
 
-  // Fast path: if the key doesn't exist, no checker will pass (all start with FindReadOnly).
-  // We can't use key_ready_checker here because checkers can be per-transaction (e.g. XREAD BLOCK
-  // checks stream-specific conditions beyond key existence), so the front item's checker returning
-  // false doesn't mean later items won't pass. A raw existence check is the safe common gate.
-  if (queue.empty() || !IsValid(context.GetDbSlice(owner_->shard_id()).FindReadOnly(context, key)))
-    return;
-
   // In the most cases we shouldn't have skipped elements at all
   absl::InlinedVector<dfly::WatchItem, 4> skipped;
   while (!queue.empty()) {
     auto& wi = queue.front();
     Transaction* head = wi.get();
-    // We check may the transaction be notified otherwise move it to the end of the queue
-    if (wi.key_ready_checker(owner_, context, key)) {
+    KeyReadyResult result = wi.key_ready_checker(owner_, context, key);
+    if (result == KeyReadyResult::kKeyNotFound) {
+      // Key is gone - no tx in this queue can be woken, abort the scan entirely.
+      break;
+    } else if (result == KeyReadyResult::kReady) {
       DVLOG(2) << "WQ-Pop " << head->DebugId() << " from key " << key << " committed txid "
                << owner_->committed_txid();
       if (head->NotifySuspended(sid, key)) {
@@ -251,7 +248,7 @@ void BlockingController::NotifyWatchQueue(std::string_view key, WatchQueue* wq,
         awakened_transactions_.insert(head);
         break;
       }
-    } else {
+    } else {  // kNotReady - key exists but per-tx conditions not met, try next
       skipped.push_back(std::move(wi));
     }
 

--- a/src/server/blocking_controller_test.cc
+++ b/src/server/blocking_controller_test.cc
@@ -86,7 +86,7 @@ TEST_F(BlockingControllerTest, Basic) {
     BlockingController bc(shard, &namespaces->GetDefaultNamespace());
     auto keys = t->GetShardArgs(shard->shard_id());
     bc.AddWatched(
-        keys, [](auto...) { return true; }, t);
+        keys, [](auto...) { return KeyReadyResult::kReady; }, t);
     EXPECT_EQ(1, bc.NumWatched(0));
 
     bc.RemovedWatched(keys, t);
@@ -119,7 +119,7 @@ TEST_F(BlockingControllerTest, NotifyWatchQueueFastPathOnAbsentKey) {
 
     auto checker = [&checker_calls](EngineShard*, const DbContext&, std::string_view) {
       ++checker_calls;
-      return false;
+      return KeyReadyResult::kKeyNotFound;
     };
 
     for (auto& t : txs) {
@@ -131,7 +131,9 @@ TEST_F(BlockingControllerTest, NotifyWatchQueueFastPathOnAbsentKey) {
     bc.NotifyPending();
   });
 
-  EXPECT_EQ(0u, checker_calls) << "fast path did not short-circuit";
+  // With the enum-based fast path, the first item's checker is called once and returns
+  // kKeyNotFound, aborting the scan without visiting the remaining kWaiters-1 items.
+  EXPECT_EQ(1u, checker_calls) << "fast path did not short-circuit";
 }
 
 TEST_F(BlockingControllerTest, Timeout) {
@@ -140,7 +142,8 @@ TEST_F(BlockingControllerTest, Timeout) {
   bool paused;
 
   facade::OpStatus status = trans_->WaitOnWatch(
-      tp, Transaction::kShardArgs, [](auto...) { return true; }, &blocked, &paused);
+      tp, Transaction::kShardArgs, [](auto...) { return KeyReadyResult::kReady; }, &blocked,
+      &paused);
 
   EXPECT_EQ(status, facade::OpStatus::TIMED_OUT);
   unsigned num_watched = shard_set->Await(

--- a/src/server/blocking_controller_test.cc
+++ b/src/server/blocking_controller_test.cc
@@ -95,6 +95,45 @@ TEST_F(BlockingControllerTest, Basic) {
   });
 }
 
+// Regression for https://github.com/dragonflydb/dragonfly/pull/7225:
+// NotifyWatchQueue used to walk every queued waiter (O(N) per notify) when
+// the key was absent. The fast path now short-circuits via FindReadOnly. We
+// assert the per-waiter checker is never invoked.
+TEST_F(BlockingControllerTest, NotifyWatchQueueFastPathOnAbsentKey) {
+  constexpr size_t kWaiters = 64;
+  const std::string_view key = str_vec_[0];  // "x", hashes to shard 0 (verified in SetUp)
+
+  std::vector<boost::intrusive_ptr<Transaction>> txs;
+  txs.reserve(kWaiters);
+  for (size_t i = 0; i < kWaiters; ++i) {
+    auto t = boost::intrusive_ptr<Transaction>(new Transaction{&cid_});
+    t->InitByArgs(&namespaces->GetDefaultNamespace(), 0, {arg_vec_.data(), arg_vec_.size()});
+    txs.push_back(std::move(t));
+  }
+
+  size_t checker_calls = 0;
+
+  shard_set->Await(0, [&] {
+    EngineShard* shard = EngineShard::tlocal();
+    BlockingController bc(shard, &namespaces->GetDefaultNamespace());
+
+    auto checker = [&checker_calls](EngineShard*, const DbContext&, std::string_view) {
+      ++checker_calls;
+      return false;
+    };
+
+    for (auto& t : txs) {
+      bc.AddWatched(t->GetShardArgs(shard->shard_id()), checker, t.get());
+    }
+    ASSERT_EQ(1u, bc.NumWatched(0));  // 1 watched key, kWaiters items in its queue
+
+    bc.Awaken(0, key);
+    bc.NotifyPending();
+  });
+
+  EXPECT_EQ(0u, checker_calls) << "fast path did not short-circuit";
+}
+
 TEST_F(BlockingControllerTest, Timeout) {
   time_point tp = steady_clock::now() + chrono::milliseconds(10);
   bool blocked;

--- a/src/server/container_utils.cc
+++ b/src/server/container_utils.cc
@@ -369,9 +369,12 @@ OpResult<string> RunCbOnFirstNonEmptyBlocking(Transaction* trans, int req_obj_ty
   auto* ns = &trans->GetNamespace();
   const auto key_checker = [req_obj_type, ns](EngineShard* owner, const DbContext& context,
                                               std::string_view key) -> KeyReadyResult {
-    return ns->GetDbSlice(owner->shard_id()).FindReadOnly(context, key, req_obj_type).ok()
-               ? KeyReadyResult::kReady
-               : KeyReadyResult::kKeyNotFound;
+    auto res = ns->GetDbSlice(owner->shard_id()).FindReadOnly(context, key, req_obj_type);
+    if (res.ok())
+      return KeyReadyResult::kReady;
+    if (res.status() == OpStatus::WRONG_TYPE)
+      return KeyReadyResult::kNotReady;
+    return KeyReadyResult::kKeyNotFound;
   };
 
   auto status =

--- a/src/server/container_utils.cc
+++ b/src/server/container_utils.cc
@@ -368,7 +368,7 @@ OpResult<string> RunCbOnFirstNonEmptyBlocking(Transaction* trans, int req_obj_ty
 
   auto* ns = &trans->GetNamespace();
   const auto key_checker = [req_obj_type, ns](EngineShard* owner, const DbContext& context,
-                                              Transaction*, std::string_view key) -> bool {
+                                              std::string_view key) -> bool {
     return ns->GetDbSlice(owner->shard_id()).FindReadOnly(context, key, req_obj_type).ok();
   };
 

--- a/src/server/container_utils.cc
+++ b/src/server/container_utils.cc
@@ -368,8 +368,10 @@ OpResult<string> RunCbOnFirstNonEmptyBlocking(Transaction* trans, int req_obj_ty
 
   auto* ns = &trans->GetNamespace();
   const auto key_checker = [req_obj_type, ns](EngineShard* owner, const DbContext& context,
-                                              std::string_view key) -> bool {
-    return ns->GetDbSlice(owner->shard_id()).FindReadOnly(context, key, req_obj_type).ok();
+                                              std::string_view key) -> KeyReadyResult {
+    return ns->GetDbSlice(owner->shard_id()).FindReadOnly(context, key, req_obj_type).ok()
+               ? KeyReadyResult::kReady
+               : KeyReadyResult::kKeyNotFound;
   };
 
   auto status =

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -945,6 +945,15 @@ void BLMove(CmdArgList args, CommandContext* cmd_cntx) {
   }
 }
 
+KeyReadyResult ListKeyChecker(EngineShard* owner, const DbContext& context, std::string_view key) {
+  auto res = context.GetDbSlice(owner->shard_id()).FindReadOnly(context, key, OBJ_LIST);
+  if (res.ok())
+    return KeyReadyResult::kReady;
+  if (res.status() == OpStatus::WRONG_TYPE)
+    return KeyReadyResult::kNotReady;
+  return KeyReadyResult::kKeyNotFound;
+}
+
 BPopPusher::BPopPusher(string_view pop_key, string_view push_key, ListDir popdir, ListDir pushdir)
     : pop_key_(pop_key), push_key_(push_key), popdir_(popdir), pushdir_(pushdir) {
 }
@@ -986,18 +995,8 @@ OpResult<string> BPopPusher::RunSingle(time_point tp, Transaction* tx, Connectio
     return op_res;
   }
 
-  const auto key_checker = [](EngineShard* owner, const DbContext& context,
-                              std::string_view key) -> KeyReadyResult {
-    auto res = context.GetDbSlice(owner->shard_id()).FindReadOnly(context, key, OBJ_LIST);
-    if (res.ok())
-      return KeyReadyResult::kReady;
-    if (res.status() == OpStatus::WRONG_TYPE)
-      return KeyReadyResult::kNotReady;
-    return KeyReadyResult::kKeyNotFound;
-  };
-
   // Block
-  auto status = tx->WaitOnWatch(tp, pop_key_, key_checker, &(cntx->blocked), &(cntx->paused));
+  auto status = tx->WaitOnWatch(tp, pop_key_, ListKeyChecker, &(cntx->blocked), &(cntx->paused));
   if (status != OpStatus::OK)
     return status;
 
@@ -1017,21 +1016,11 @@ OpResult<string> BPopPusher::RunPair(time_point tp, Transaction* tx, ConnectionC
     return op_res;
   }
 
-  const auto key_checker = [](EngineShard* owner, const DbContext& context,
-                              std::string_view key) -> KeyReadyResult {
-    auto res = context.GetDbSlice(owner->shard_id()).FindReadOnly(context, key, OBJ_LIST);
-    if (res.ok())
-      return KeyReadyResult::kReady;
-    if (res.status() == OpStatus::WRONG_TYPE)
-      return KeyReadyResult::kNotReady;
-    return KeyReadyResult::kKeyNotFound;
-  };
-
   // a hack: we watch in both shards for pop_key but only in the source shard it's relevant.
   // Therefore we follow the regular flow of watching the key but for the destination shard it
   // will never be triggerred.
   // This allows us to run Transaction::Execute on watched transactions in both shards.
-  if (auto status = tx->WaitOnWatch(tp, pop_key_, key_checker, &cntx->blocked, &cntx->paused);
+  if (auto status = tx->WaitOnWatch(tp, pop_key_, ListKeyChecker, &cntx->blocked, &cntx->paused);
       status != OpStatus::OK)
     return status;
 

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -986,7 +986,7 @@ OpResult<string> BPopPusher::RunSingle(time_point tp, Transaction* tx, Connectio
     return op_res;
   }
 
-  const auto key_checker = [](EngineShard* owner, const DbContext& context, Transaction*,
+  const auto key_checker = [](EngineShard* owner, const DbContext& context,
                               std::string_view key) -> bool {
     return context.GetDbSlice(owner->shard_id()).FindReadOnly(context, key, OBJ_LIST).ok();
   };
@@ -1012,7 +1012,7 @@ OpResult<string> BPopPusher::RunPair(time_point tp, Transaction* tx, ConnectionC
     return op_res;
   }
 
-  const auto key_checker = [](EngineShard* owner, const DbContext& context, Transaction*,
+  const auto key_checker = [](EngineShard* owner, const DbContext& context,
                               std::string_view key) -> bool {
     return context.GetDbSlice(owner->shard_id()).FindReadOnly(context, key, OBJ_LIST).ok();
   };

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -988,9 +988,12 @@ OpResult<string> BPopPusher::RunSingle(time_point tp, Transaction* tx, Connectio
 
   const auto key_checker = [](EngineShard* owner, const DbContext& context,
                               std::string_view key) -> KeyReadyResult {
-    return context.GetDbSlice(owner->shard_id()).FindReadOnly(context, key, OBJ_LIST).ok()
-               ? KeyReadyResult::kReady
-               : KeyReadyResult::kKeyNotFound;
+    auto res = context.GetDbSlice(owner->shard_id()).FindReadOnly(context, key, OBJ_LIST);
+    if (res.ok())
+      return KeyReadyResult::kReady;
+    if (res.status() == OpStatus::WRONG_TYPE)
+      return KeyReadyResult::kNotReady;
+    return KeyReadyResult::kKeyNotFound;
   };
 
   // Block
@@ -1016,9 +1019,12 @@ OpResult<string> BPopPusher::RunPair(time_point tp, Transaction* tx, ConnectionC
 
   const auto key_checker = [](EngineShard* owner, const DbContext& context,
                               std::string_view key) -> KeyReadyResult {
-    return context.GetDbSlice(owner->shard_id()).FindReadOnly(context, key, OBJ_LIST).ok()
-               ? KeyReadyResult::kReady
-               : KeyReadyResult::kKeyNotFound;
+    auto res = context.GetDbSlice(owner->shard_id()).FindReadOnly(context, key, OBJ_LIST);
+    if (res.ok())
+      return KeyReadyResult::kReady;
+    if (res.status() == OpStatus::WRONG_TYPE)
+      return KeyReadyResult::kNotReady;
+    return KeyReadyResult::kKeyNotFound;
   };
 
   // a hack: we watch in both shards for pop_key but only in the source shard it's relevant.

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -987,8 +987,10 @@ OpResult<string> BPopPusher::RunSingle(time_point tp, Transaction* tx, Connectio
   }
 
   const auto key_checker = [](EngineShard* owner, const DbContext& context,
-                              std::string_view key) -> bool {
-    return context.GetDbSlice(owner->shard_id()).FindReadOnly(context, key, OBJ_LIST).ok();
+                              std::string_view key) -> KeyReadyResult {
+    return context.GetDbSlice(owner->shard_id()).FindReadOnly(context, key, OBJ_LIST).ok()
+               ? KeyReadyResult::kReady
+               : KeyReadyResult::kKeyNotFound;
   };
 
   // Block
@@ -1013,8 +1015,10 @@ OpResult<string> BPopPusher::RunPair(time_point tp, Transaction* tx, ConnectionC
   }
 
   const auto key_checker = [](EngineShard* owner, const DbContext& context,
-                              std::string_view key) -> bool {
-    return context.GetDbSlice(owner->shard_id()).FindReadOnly(context, key, OBJ_LIST).ok();
+                              std::string_view key) -> KeyReadyResult {
+    return context.GetDbSlice(owner->shard_id()).FindReadOnly(context, key, OBJ_LIST).ok()
+               ? KeyReadyResult::kReady
+               : KeyReadyResult::kKeyNotFound;
   };
 
   // a hack: we watch in both shards for pop_key but only in the source shard it's relevant.

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -3011,7 +3011,8 @@ void XReadBlock(ReadOpts* opts, Transaction* tx, SinkReplyBuilder* builder,
     auto& db_slice = context.GetDbSlice(owner->shard_id());
     auto res_it = db_slice.FindReadOnly(context, key, OBJ_STREAM);
     if (!res_it.ok())
-      return KeyReadyResult::kKeyNotFound;
+      return res_it.status() == OpStatus::WRONG_TYPE ? KeyReadyResult::kNotReady
+                                                     : KeyReadyResult::kKeyNotFound;
 
     StreamIDsItem& sitem = opts->stream_ids.at(key);
     if (sitem.id.val.ms != UINT64_MAX && sitem.id.val.seq != UINT64_MAX)

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -3006,7 +3006,7 @@ void XReadBlock(ReadOpts* opts, Transaction* tx, SinkReplyBuilder* builder,
   auto tp = (opts->timeout) ? chrono::steady_clock::now() + chrono::milliseconds(opts->timeout)
                             : Transaction::time_point::max();
 
-  const auto key_checker = [opts](EngineShard* owner, const DbContext& context, Transaction* tx,
+  const auto key_checker = [opts](EngineShard* owner, const DbContext& context,
                                   std::string_view key) -> bool {
     auto& db_slice = context.GetDbSlice(owner->shard_id());
     auto res_it = db_slice.FindReadOnly(context, key, OBJ_STREAM);

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -3007,15 +3007,15 @@ void XReadBlock(ReadOpts* opts, Transaction* tx, SinkReplyBuilder* builder,
                             : Transaction::time_point::max();
 
   const auto key_checker = [opts](EngineShard* owner, const DbContext& context,
-                                  std::string_view key) -> bool {
+                                  std::string_view key) -> KeyReadyResult {
     auto& db_slice = context.GetDbSlice(owner->shard_id());
     auto res_it = db_slice.FindReadOnly(context, key, OBJ_STREAM);
     if (!res_it.ok())
-      return false;
+      return KeyReadyResult::kKeyNotFound;
 
     StreamIDsItem& sitem = opts->stream_ids.at(key);
     if (sitem.id.val.ms != UINT64_MAX && sitem.id.val.seq != UINT64_MAX)
-      return true;
+      return KeyReadyResult::kReady;
 
     const CompactObj& cobj = (*res_it)->second;
     stream* s = GetReadOnlyStream(cobj);
@@ -3028,10 +3028,11 @@ void XReadBlock(ReadOpts* opts, Transaction* tx, SinkReplyBuilder* builder,
     if (opts->read_group) {
       sitem.group = StreamLookupCG(s, WrapSds(opts->group_name));
       if (!sitem.group)
-        return true;  // abort
+        return KeyReadyResult::kReady;  // abort
     }
 
-    return streamCompareID(&last_id, &sitem.group->last_id) > 0;
+    return streamCompareID(&last_id, &sitem.group->last_id) > 0 ? KeyReadyResult::kReady
+                                                                : KeyReadyResult::kNotReady;
   };
 
   if (auto status =

--- a/src/server/tx_base.h
+++ b/src/server/tx_base.h
@@ -109,7 +109,7 @@ class LockTag {
 
 // Checks whether the touched key is valid for a blocking transaction watching it.
 using KeyReadyChecker =
-    std::function<bool(EngineShard*, const DbContext& context, Transaction* tx, std::string_view)>;
+    std::function<bool(EngineShard*, const DbContext& context, std::string_view)>;
 
 // References arguments in another array.
 using IndexSlice = std::pair<uint32_t, uint32_t>;  // [begin, end)

--- a/src/server/tx_base.h
+++ b/src/server/tx_base.h
@@ -107,9 +107,15 @@ class LockTag {
   }
 };
 
+enum class KeyReadyResult {
+  kKeyNotFound,  // key doesn't exist - abort the entire watch queue
+  kNotReady,     // key exists but per-tx conditions not met - skip this tx, try next
+  kReady,        // wake this tx
+};
+
 // Checks whether the touched key is valid for a blocking transaction watching it.
 using KeyReadyChecker =
-    std::function<bool(EngineShard*, const DbContext& context, std::string_view)>;
+    std::function<KeyReadyResult(EngineShard*, const DbContext& context, std::string_view)>;
 
 // References arguments in another array.
 using IndexSlice = std::pair<uint32_t, uint32_t>;  // [begin, end)

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -2657,8 +2657,10 @@ void ZMPopGeneric(CmdArgList args, CommandContext* cmd_cntx, bool is_blocking) {
       limit_tp = steady_clock::now() + milliseconds(limit_ms);
     }
     const auto key_checker = [ns](EngineShard* owner, const DbContext& context,
-                                  std::string_view key) -> bool {
-      return ns->GetDbSlice(owner->shard_id()).FindReadOnly(context, key, OBJ_ZSET).ok();
+                                  std::string_view key) -> KeyReadyResult {
+      return ns->GetDbSlice(owner->shard_id()).FindReadOnly(context, key, OBJ_ZSET).ok()
+                 ? KeyReadyResult::kReady
+                 : KeyReadyResult::kKeyNotFound;
     };
 
     DCHECK(trans->IsScheduled());  // Checking if the transaction is scheduled before calling

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -2658,9 +2658,12 @@ void ZMPopGeneric(CmdArgList args, CommandContext* cmd_cntx, bool is_blocking) {
     }
     const auto key_checker = [ns](EngineShard* owner, const DbContext& context,
                                   std::string_view key) -> KeyReadyResult {
-      return ns->GetDbSlice(owner->shard_id()).FindReadOnly(context, key, OBJ_ZSET).ok()
-                 ? KeyReadyResult::kReady
-                 : KeyReadyResult::kKeyNotFound;
+      auto res = ns->GetDbSlice(owner->shard_id()).FindReadOnly(context, key, OBJ_ZSET);
+      if (res.ok())
+        return KeyReadyResult::kReady;
+      if (res.status() == OpStatus::WRONG_TYPE)
+        return KeyReadyResult::kNotReady;
+      return KeyReadyResult::kKeyNotFound;
     };
 
     DCHECK(trans->IsScheduled());  // Checking if the transaction is scheduled before calling

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -2656,7 +2656,7 @@ void ZMPopGeneric(CmdArgList args, CommandContext* cmd_cntx, bool is_blocking) {
       using namespace std::chrono;
       limit_tp = steady_clock::now() + milliseconds(limit_ms);
     }
-    const auto key_checker = [ns](EngineShard* owner, const DbContext& context, Transaction*,
+    const auto key_checker = [ns](EngineShard* owner, const DbContext& context,
                                   std::string_view key) -> bool {
       return ns->GetDbSlice(owner->shard_id()).FindReadOnly(context, key, OBJ_ZSET).ok();
     };


### PR DESCRIPTION
Each queue maps to a single key. If the first iteration of `IsValid()` is false, then there is no reason to iterate over the rest of the O(n-1) items of the queue.

This avalanches under heavy load for sidekiq workloads as these heavily rely on blocking pop's from multiple connections (thousands).