### PR TITLE
feat: support ~ optional match operator in query language

### DIFF
--- a/src/core/search/ast_expr.cc
+++ b/src/core/search/ast_expr.cc
@@ -24,6 +24,9 @@ AstGeoNode::AstGeoNode(double lon, double lat, double radius, std::string unit)
     : lon(lon), lat(lat), radius(radius), unit(std::move(unit)) {
 }
 
+AstOptionalNode::AstOptionalNode(AstNode&& node) : node{make_unique<AstNode>(std::move(node))} {
+}
+
 AstNegateNode::AstNegateNode(AstNode&& node) : node{make_unique<AstNode>(std::move(node))} {
 }
 

--- a/src/core/search/ast_expr.h
+++ b/src/core/search/ast_expr.h
@@ -51,9 +51,22 @@ struct AstGeoNode {
   std::string unit;
 };
 
+// ~subquery: returns all docs, boosts score of those matched by subquery
+struct AstOptionalNode {
+  explicit AstOptionalNode(AstNode&& node);
+
+  AstOptionalNode(const AstOptionalNode&) = delete;
+  AstOptionalNode& operator=(const AstOptionalNode&) = delete;
+
+  AstOptionalNode(AstOptionalNode&&) noexcept = default;
+  AstOptionalNode& operator=(AstOptionalNode&&) noexcept = default;
+
+  std::unique_ptr<AstNode> node;
+};
+
 // Negates subtree
 struct AstNegateNode {
-  AstNegateNode(AstNode&& node);
+  explicit AstNegateNode(AstNode&& node);
 
   AstNegateNode(const AstNegateNode&) = delete;
   AstNegateNode& operator=(const AstNegateNode&) = delete;
@@ -107,7 +120,7 @@ struct AstTagsNode {
     }
   };
 
-  AstTagsNode(TagValue);
+  explicit AstTagsNode(TagValue);
   AstTagsNode(AstNode&& l, TagValue);
 
   std::vector<TagValue> tags;
@@ -162,10 +175,10 @@ struct AstVectorRangeNode {
   std::string score_alias;
 };
 
-using NodeVariants =
-    std::variant<std::monostate, AstStarNode, AstStarFieldNode, AstTermNode, AstPrefixNode,
-                 AstSuffixNode, AstInfixNode, AstRangeNode, AstNegateNode, AstLogicalNode,
-                 AstFieldNode, AstTagsNode, AstKnnNode, AstGeoNode, AstVectorRangeNode>;
+using NodeVariants = std::variant<std::monostate, AstStarNode, AstStarFieldNode, AstTermNode,
+                                  AstPrefixNode, AstSuffixNode, AstInfixNode, AstRangeNode,
+                                  AstNegateNode, AstOptionalNode, AstLogicalNode, AstFieldNode,
+                                  AstTagsNode, AstKnnNode, AstGeoNode, AstVectorRangeNode>;
 
 struct AstNode : public NodeVariants {
   using variant::variant;

--- a/src/core/search/lexer.lex
+++ b/src/core/search/lexer.lex
@@ -30,6 +30,8 @@
 
   Parser::symbol_type make_StringLit(string_view src, const Parser::location_type& loc);
   Parser::symbol_type make_Tag(string_view src, TagType type, const Parser::location_type& loc);
+  // Strip backslashes from \X sequences in a term.
+  string UnescapeTerm(string_view src);
 %}
 
 dq         \"
@@ -37,6 +39,12 @@ sq         \'
 esc_chars  ['"\?\\abfnrtv]
 esc_seq    \\{esc_chars}
 term_ch    \w
+/* term_part: word char OR any backslash-escaped char.
+ * This deliberately overlaps with tag_val_ch — both can match the same input
+ * inside `{...}`. The grammar treats TERM and TAG_VAL interchangeably as
+ * `tag_list_element`, so identical-length matches resolve to TERM (rule order)
+ * and the unescaped text is the same. UnescapeTerm produces the literal text. */
+term_part  (\w|\\.)
 tag_val_base_ch [^,.<>{}\[\]\\\"\?':;!@#$%^&*()\-+=~\/| ]|\\.
 tag_val_ch {tag_val_base_ch}+(:+{tag_val_base_ch}*)*
 astrsk_ch  \*
@@ -58,6 +66,7 @@ astrsk_ch  \*
 ")"                  return Parser::make_RPAREN (loc());
 "*"                  return Parser::make_STAR (loc());
 "-"                  return Parser::make_NOT_OP (loc());
+"~"                  return Parser::make_TILDE (loc());
 ":"                  return Parser::make_COLON (loc());
 "=>"                 return Parser::make_ARROW (loc());
 "["                  return Parser::make_LBRACKET (loc());
@@ -80,11 +89,11 @@ astrsk_ch  \*
 
 "$"{term_ch}+                       return ParseParam(str(), loc());
 "@"{term_ch}+                       return Parser::make_FIELD(str(), loc());
-{astrsk_ch}{term_ch}+{astrsk_ch}    return Parser::make_INFIX(string{matched_view(1, 1)}, loc());
-{term_ch}+{astrsk_ch}               return Parser::make_PREFIX(string{matched_view(0, 1)}, loc());
-{astrsk_ch}{term_ch}+               return Parser::make_SUFFIX(string{matched_view(1, 0)}, loc());
+{astrsk_ch}{term_part}+{astrsk_ch}    return Parser::make_INFIX(UnescapeTerm(matched_view(1, 1)), loc());
+{term_part}+{astrsk_ch}               return Parser::make_PREFIX(UnescapeTerm(matched_view(0, 1)), loc());
+{astrsk_ch}{term_part}+               return Parser::make_SUFFIX(UnescapeTerm(matched_view(1, 0)), loc());
 
-{term_ch}+                          return Parser::make_TERM(str(), loc());
+{term_part}+                          return Parser::make_TERM(UnescapeTerm(str()), loc());
 {tag_val_ch}+{astrsk_ch}            return make_Tag(str(), TagType::PREFIX, loc());
 {astrsk_ch}{tag_val_ch}+            return make_Tag(str(), TagType::SUFFIX, loc());
 {astrsk_ch}{tag_val_ch}+{astrsk_ch} return make_Tag(str(), TagType::INFIX, loc());
@@ -99,6 +108,26 @@ Parser::symbol_type make_StringLit(string_view src, const Parser::location_type&
     throw Parser::syntax_error (loc, "bad escaped string: " + string(src));
 
   return Parser::make_TERM(res, loc);
+}
+
+string UnescapeTerm(string_view src) {
+  string res;
+  res.reserve(src.size());
+  bool escaped = false;
+  for (char c : src) {
+    if (escaped) {
+      res.push_back(c);
+      escaped = false;
+    } else if (c == '\\') {
+      escaped = true;
+    } else {
+      res.push_back(c);
+    }
+  }
+  // The {term_part}+ pattern always pairs `\\` with a following char, so a
+  // trailing lone backslash is unreachable.
+  DCHECK(!escaped);
+  return res;
 }
 
 Parser::symbol_type make_Tag(string_view src, TagType type, const Parser::location_type& loc) {

--- a/src/core/search/parser.y
+++ b/src/core/search/parser.y
@@ -59,6 +59,7 @@ double toDouble(string_view src);
   RCURLBR     "}"
   OR_OP       "|"
   COMMA       ","
+  TILDE       "~"
   KNN         "KNN"
   AS          "AS"
   EF_RUNTIME  "EF_RUNTIME"
@@ -75,7 +76,7 @@ double toDouble(string_view src);
 %precedence TERM TAG_VAL
 %left OR_OP
 %left AND_OP
-%right NOT_OP
+%right NOT_OP TILDE
 %precedence LPAREN RPAREN
 
 %token <std::string> DOUBLE "double"
@@ -188,13 +189,14 @@ search_or_expr:
   | search_expr OR_OP search_unary_expr            { $$ = AstLogicalNode(std::move($1), std::move($3), AstLogicalNode::OR); }
 
 search_unary_expr:
-  LPAREN search_expr RPAREN           { $$ = std::move($2);                }
-  | NOT_OP search_unary_expr          { $$ = AstNegateNode(std::move($2)); }
-  | TERM                              { $$ = AstTermNode(std::move($1));   }
-  | PREFIX                            { $$ = AstPrefixNode(std::move($1)); }
-  | SUFFIX                            { $$ = AstSuffixNode(std::move($1)); }
-  | INFIX                             { $$ = AstInfixNode(std::move($1));  }
-  | UINT32                            { $$ = AstTermNode(std::move($1));   }
+  LPAREN search_expr RPAREN           { $$ = std::move($2);                  }
+  | NOT_OP search_unary_expr          { $$ = AstNegateNode(std::move($2));   }
+  | TILDE search_unary_expr           { $$ = AstOptionalNode(std::move($2)); }
+  | TERM                              { $$ = AstTermNode(std::move($1));     }
+  | PREFIX                            { $$ = AstPrefixNode(std::move($1));   }
+  | SUFFIX                            { $$ = AstSuffixNode(std::move($1));   }
+  | INFIX                             { $$ = AstInfixNode(std::move($1));    }
+  | UINT32                            { $$ = AstTermNode(std::move($1));     }
   | FIELD COLON field_cond            { $$ = AstFieldNode(std::move($1), std::move($3)); }
 
 field_cond:
@@ -202,6 +204,7 @@ field_cond:
   | UINT32                                              { $$ = AstTermNode(std::move($1));   }
   | STAR                                                { $$ = AstStarFieldNode();           }
   | NOT_OP field_cond                                   { $$ = AstNegateNode(std::move($2)); }
+  | TILDE field_cond                                    { $$ = AstOptionalNode(std::move($2)); }
   | LPAREN field_cond_expr RPAREN                       { $$ = std::move($2); }
   | LBRACKET bracket_filter_expr RBRACKET               { $$ = std::move($2); }
   | LCURLBR tag_list RCURLBR                            { $$ = std::move($2); }
@@ -273,10 +276,11 @@ field_or_expr:
   | field_cond_expr OR_OP field_and_expr          { $$ = AstLogicalNode(std::move($1), std::move($3), AstLogicalNode::OR); }
 
 field_unary_expr:
-  LPAREN field_cond_expr RPAREN { $$ = std::move($2);                }
-  | NOT_OP field_unary_expr     { $$ = AstNegateNode(std::move($2)); }
-  | TERM                        { $$ = AstTermNode(std::move($1));   }
-  | UINT32                      { $$ = AstTermNode(std::move($1));   }
+  LPAREN field_cond_expr RPAREN { $$ = std::move($2);                  }
+  | NOT_OP field_unary_expr     { $$ = AstNegateNode(std::move($2));   }
+  | TILDE field_unary_expr      { $$ = AstOptionalNode(std::move($2)); }
+  | TERM                        { $$ = AstTermNode(std::move($1));     }
+  | UINT32                      { $$ = AstTermNode(std::move($1));     }
 
 tag_list:
   tag_list_element                       { $$ = AstTagsNode(std::move($1));                }

--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -76,6 +76,7 @@ struct ProfileBuilder {
         [](const AstFieldNode& n) { return absl::StrCat("Field{", n.field, "}"); },
         [](const AstKnnNode& n) { return absl::StrCat("KNN{l=", n.limit, "}"); },
         [](const AstNegateNode& n) { return absl::StrCat("Negate{}"); },
+        [](const AstOptionalNode& n) { return absl::StrCat("Optional{}"); },
         [](const AstStarNode& n) { return absl::StrCat("Star{}"); },
         [](const AstStarFieldNode& n) { return absl::StrCat("StarField{}"); },
         [](const AstGeoNode& n) {
@@ -322,6 +323,9 @@ struct BasicSearch {
   // negate -(*subquery*): explicitly compute result complement. Needs further optimizations
   IndexResult Search(const AstNegateNode& node, string_view active_field) {
     auto matched = SearchGeneric(*node.node, active_field).Take().first;
+    if (!error_.empty())
+      return IndexResult{};
+
     vector<DocId> all = indices_->GetAllDocs();
 
     // To negate a result, we have to find the complement of matched to all documents,
@@ -331,6 +335,20 @@ struct BasicSearch {
     };
     all.erase(remove_if(all.begin(), all.end(), pred), all.end());
     return IndexResult{std::move(all)};
+  }
+
+  IndexResult Search(const AstOptionalNode& node, string_view active_field) {
+    // ~ tolerates inner failures: it's a soft scoring boost, not a filter.
+    // E.g. @noindex_field:~hello can't actually populate matched_text_terms_
+    // (no index to query) — but the operator should still return all docs.
+    // Save/restore error_ so a transient inner failure doesn't poison the
+    // outer query.
+    string saved_error = std::move(error_);
+    SearchGeneric(*node.node, active_field);
+    error_ = std::move(saved_error);
+    // ~ never filters: return the full doc set, including docs that lack the
+    // active field. Mirrors AstNegateNode which also operates on global all-docs.
+    return IndexResult{&indices_->GetAllDocs()};
   }
 
   // logical query: unify all sub results
@@ -508,6 +526,23 @@ struct BasicSearch {
     if (scorer_ && !matched_text_terms_.empty()) {
       // Score ALL matched docs and return top-K by score (not arbitrary cutoff).
       auto [out, total_size, text_scores] = TakeScoredTopK(std::move(result), cuttoff_limit);
+
+      // KNN populated knn_scores_ in distance order; TakeScoredTopK reordered
+      // `out` by text score, so realign knn_scores_ to the new id order.
+      // Consumers (e.g. search_family.cc) index ids and knn_scores by position.
+      if (!knn_scores_.empty()) {
+        absl::flat_hash_map<DocId, float> knn_by_id;
+        knn_by_id.reserve(knn_scores_.size());
+        for (auto& [doc, dist] : knn_scores_)
+          knn_by_id.emplace(doc, dist);
+        knn_scores_.clear();
+        knn_scores_.reserve(out.size());
+        for (DocId doc : out) {
+          if (auto it = knn_by_id.find(doc); it != knn_by_id.end())
+            knn_scores_.emplace_back(doc, it->second);
+        }
+      }
+
       return SearchResult{
           total_size,         std::move(out),   std::move(knn_scores_), std::move(text_scores),
           std::move(profile), std::move(error_)};

--- a/src/core/search/search_parser_test.cc
+++ b/src/core/search/search_parser_test.cc
@@ -97,60 +97,65 @@ TEST_F(SearchParserTest, Scanner) {
   NEXT_EQ(TOK_TERM, string, "tag");
   NEXT_TOK(TOK_RCURLBR);
 
+  // After the term lexer learned to handle backslash-escapes (\X anywhere in a
+  // term), `{blue\,1\\\$\+}` and similar inputs are matched by the TERM rule
+  // (same length as TAG_VAL on these inputs, term rule comes first). The
+  // grammar accepts both TERM and TAG_VAL as `tag_list_element`, so the only
+  // observable difference is the token type — the unescaped string is identical.
   SetInput("@color:{blue\\,1\\\\\\$\\+}");
   NEXT_EQ(TOK_FIELD, string, "@color");
   NEXT_TOK(TOK_COLON);
   NEXT_TOK(TOK_LCURLBR);
-  NEXT_EQ(TOK_TAG_VAL, string, R"(blue,1\$+)");
+  NEXT_EQ(TOK_TERM, string, R"(blue,1\$+)");
   NEXT_TOK(TOK_RCURLBR);
 
   SetInput("@color:{blue\\.1\\\"\\%\\=}");
   NEXT_EQ(TOK_FIELD, string, "@color");
   NEXT_TOK(TOK_COLON);
   NEXT_TOK(TOK_LCURLBR);
-  NEXT_EQ(TOK_TAG_VAL, string, "blue.1\"%=");
+  NEXT_EQ(TOK_TERM, string, "blue.1\"%=");
   NEXT_TOK(TOK_RCURLBR);
 
   SetInput("@color:{blue\\<1\\'\\^\\~}");
   NEXT_EQ(TOK_FIELD, string, "@color");
   NEXT_TOK(TOK_COLON);
   NEXT_TOK(TOK_LCURLBR);
-  NEXT_EQ(TOK_TAG_VAL, string, "blue<1'^~");
+  NEXT_EQ(TOK_TERM, string, "blue<1'^~");
   NEXT_TOK(TOK_RCURLBR);
 
   SetInput("@color:{blue\\>1\\:\\&\\/}");
   NEXT_EQ(TOK_FIELD, string, "@color");
   NEXT_TOK(TOK_COLON);
   NEXT_TOK(TOK_LCURLBR);
-  NEXT_EQ(TOK_TAG_VAL, string, "blue>1:&/");
+  NEXT_EQ(TOK_TERM, string, "blue>1:&/");
   NEXT_TOK(TOK_RCURLBR);
 
   SetInput("@color:{blue\\{1\\;\\*\\ }");
   NEXT_EQ(TOK_FIELD, string, "@color");
   NEXT_TOK(TOK_COLON);
   NEXT_TOK(TOK_LCURLBR);
-  NEXT_EQ(TOK_TAG_VAL, string, "blue{1;* ");
+  NEXT_EQ(TOK_TERM, string, "blue{1;* ");
   NEXT_TOK(TOK_RCURLBR);
 
   SetInput("@color:{blue\\}1\\!\\(}");
   NEXT_EQ(TOK_FIELD, string, "@color");
   NEXT_TOK(TOK_COLON);
   NEXT_TOK(TOK_LCURLBR);
-  NEXT_EQ(TOK_TAG_VAL, string, "blue}1!(");
+  NEXT_EQ(TOK_TERM, string, "blue}1!(");
   NEXT_TOK(TOK_RCURLBR);
 
   SetInput("@color:{blue\\[1\\@\\)}");
   NEXT_EQ(TOK_FIELD, string, "@color");
   NEXT_TOK(TOK_COLON);
   NEXT_TOK(TOK_LCURLBR);
-  NEXT_EQ(TOK_TAG_VAL, string, "blue[1@)");
+  NEXT_EQ(TOK_TERM, string, "blue[1@)");
   NEXT_TOK(TOK_RCURLBR);
 
   SetInput("@color:{blue\\]1\\#\\-}");
   NEXT_EQ(TOK_FIELD, string, "@color");
   NEXT_TOK(TOK_COLON);
   NEXT_TOK(TOK_LCURLBR);
-  NEXT_EQ(TOK_TAG_VAL, string, "blue]1#-");
+  NEXT_EQ(TOK_TERM, string, "blue]1#-");
   NEXT_TOK(TOK_RCURLBR);
 
   // Colon in tag value (unescaped)
@@ -227,6 +232,109 @@ TEST_F(SearchParserTest, EscapedTagPrefixes) {
   NEXT_TOK(TOK_LCURLBR);
   NEXT_EQ(TOK_PREFIX, string, "complex-escape+with.many*chars");
   NEXT_TOK(TOK_RCURLBR);
+}
+
+TEST_F(SearchParserTest, TildeScanner) {
+  SetInput("~hello");
+  NEXT_TOK(TOK_TILDE);
+  NEXT_EQ(TOK_TERM, string, "hello");
+  NEXT_TOK(TOK_YYEOF);
+
+  SetInput("hello ~world");
+  NEXT_EQ(TOK_TERM, string, "hello");
+  NEXT_TOK(TOK_TILDE);
+  NEXT_EQ(TOK_TERM, string, "world");
+  NEXT_TOK(TOK_YYEOF);
+}
+
+TEST_F(SearchParserTest, EscapedTilde) {
+  // \~hello must produce a literal-text TERM "~hello", not a TILDE+TERM pair.
+  SetInput("\\~hello");
+  NEXT_EQ(TOK_TERM, string, "~hello");
+  NEXT_TOK(TOK_YYEOF);
+
+  // foo\~bar — escape in middle of a term yields one TERM "foo~bar".
+  SetInput("foo\\~bar");
+  NEXT_EQ(TOK_TERM, string, "foo~bar");
+  NEXT_TOK(TOK_YYEOF);
+
+  // Escape other special chars too (\- and \|).
+  SetInput("foo\\-bar");
+  NEXT_EQ(TOK_TERM, string, "foo-bar");
+  NEXT_TOK(TOK_YYEOF);
+
+  SetInput("foo\\|bar");
+  NEXT_EQ(TOK_TERM, string, "foo|bar");
+  NEXT_TOK(TOK_YYEOF);
+
+  // Tag-specific chars are now also escapable in term context.
+  SetInput("foo\\,bar");
+  NEXT_EQ(TOK_TERM, string, "foo,bar");
+  NEXT_TOK(TOK_YYEOF);
+
+  SetInput("foo\\$bar");
+  NEXT_EQ(TOK_TERM, string, "foo$bar");
+  NEXT_TOK(TOK_YYEOF);
+
+  // Literal backslash via \\ — UnescapeTerm strips the leading \ producing a
+  // single \ character. Also verifies UnescapeTerm doesn't trip its DCHECK.
+  SetInput("foo\\\\bar");
+  NEXT_EQ(TOK_TERM, string, "foo\\bar");
+  NEXT_TOK(TOK_YYEOF);
+
+  SetInput("\\\\");
+  NEXT_EQ(TOK_TERM, string, "\\");
+  NEXT_TOK(TOK_YYEOF);
+
+  // Escape inside prefix/suffix/infix.
+  SetInput("foo\\~*");
+  NEXT_EQ(TOK_PREFIX, string, "foo~");
+  NEXT_TOK(TOK_YYEOF);
+
+  SetInput("*foo\\~");
+  NEXT_EQ(TOK_SUFFIX, string, "foo~");
+  NEXT_TOK(TOK_YYEOF);
+
+  SetInput("*foo\\~bar*");
+  NEXT_EQ(TOK_INFIX, string, "foo~bar");
+  NEXT_TOK(TOK_YYEOF);
+}
+
+TEST_F(SearchParserTest, TildeParse) {
+  // Simple optional term
+  EXPECT_EQ(0, Parse("~hello"));
+  // AND with optional
+  EXPECT_EQ(0, Parse("hello ~world"));
+  // Double optional
+  EXPECT_EQ(0, Parse("~hello ~world"));
+  // Optional with grouping
+  EXPECT_EQ(0, Parse("~(hello world)"));
+  // Optional prefix
+  EXPECT_EQ(0, Parse("~hel*"));
+  // Nested with NOT
+  EXPECT_EQ(0, Parse("~-hello"));
+  // Field-qualified optional — with and without parentheses
+  EXPECT_EQ(0, Parse("@field:(~hello)"));
+  EXPECT_EQ(0, Parse("@field:~hello"));
+  EXPECT_EQ(0, Parse("@title:~hel*"));
+  EXPECT_EQ(0, Parse("@title:~(hello world)"));
+}
+
+TEST_F(SearchParserTest, TildeInvalidGrammar) {
+  // ~ cannot precede top-level KNN or vector-range constructs (they live at
+  // final_query level, not search_unary_expr). Must be a clean syntax error.
+  EXPECT_EQ(1, Parse("~*=>[KNN 3 @v vec]"));
+  EXPECT_EQ(1, Parse("~@v:[VECTOR_RANGE 1 vec]"));
+
+  // ~ followed by closing paren or empty group — syntax errors.
+  EXPECT_EQ(1, Parse("~)"));
+  EXPECT_EQ(1, Parse("~()"));
+
+  // Bare ~ at end of input — syntax error.
+  EXPECT_EQ(1, Parse("hello ~"));
+
+  // ~ inside a tag list is NOT supported (per issue #7223).
+  EXPECT_EQ(1, Parse("@tag:{~value}"));
 }
 
 TEST_F(SearchParserTest, Parse) {

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -3130,5 +3130,254 @@ TEST_F(ScoringTest, ScorerTopKCutoff) {
   }
 }
 
+TEST_F(SearchTest, MatchOptional) {
+  // ~term returns ALL documents, not just matching ones
+  PrepareQuery("~hello");
+
+  ExpectAll("hello world", "no match here", "something else");
+
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+TEST_F(SearchTest, MatchOptionalWithRequired) {
+  // "foo ~bar" means: must match "foo", optionally match "bar"
+  PrepareQuery("foo ~bar");
+
+  ExpectAll("foo", "foo bar", "foo and something");
+  ExpectNone("bar only", "nothing");
+
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+TEST_F(SearchTest, MatchOptionalScoreBoost) {
+  // ~hello: all docs returned, but docs with "hello" get higher score
+  Schema schema = MakeSimpleSchema({{"field", SchemaField::TEXT}});
+  FieldIndices index{schema, kEmptyOptions, PMR_NS::get_default_resource(), nullptr};
+
+  MockedDocument doc_with("hello world");
+  MockedDocument doc_without("goodbye world");
+
+  index.Add(0, doc_with);
+  index.Add(1, doc_without);
+  index.FinalizeInitialization();
+
+  QueryParams params;
+  SearchAlgorithm algo;
+  ASSERT_TRUE(algo.Init("~hello", &params));
+  algo.SetScorer(&BM25Std);
+
+  auto result = algo.Search(&index);
+
+  // Both docs are returned (optional never filters)
+  ASSERT_EQ(result.ids.size(), 2u);
+
+  // Use optional<float> so an absent score is distinguishable from 0.
+  std::optional<float> score_with, score_without;
+  for (auto& [doc, score] : result.text_scores) {
+    if (doc == 0)
+      score_with = score;
+    if (doc == 1)
+      score_without = score;
+  }
+  ASSERT_TRUE(score_with.has_value()) << "doc:0 must have a score entry";
+  ASSERT_TRUE(score_without.has_value()) << "doc:1 must have a score entry";
+  EXPECT_GT(*score_with, 0.0f) << "Doc matching the optional term should score > 0";
+  EXPECT_GT(*score_with, *score_without) << "Matching doc must score higher than non-matching";
+}
+
+TEST_F(SearchTest, MatchDoubleOptional) {
+  // ~foo ~bar: all docs returned
+  PrepareQuery("~foo ~bar");
+
+  ExpectAll("foo bar", "only foo", "only bar", "neither one");
+
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+TEST_F(SearchTest, MatchOptionalNonExistentTerm) {
+  // ~xyznonexistent: term never matches anything, but all docs still returned
+  PrepareQuery("~xyznonexistent");
+
+  ExpectAll("anything goes", "another doc", "third one");
+
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+TEST_F(SearchTest, MatchNestedOptional) {
+  // ~~hello: double optional should still return all docs
+  PrepareQuery("~~hello");
+
+  ExpectAll("hello world", "no match here", "third doc");
+
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+TEST_F(SearchTest, MatchOptionalWithOr) {
+  // ~hello | world: '~hello' is all docs; OR with anything is still all docs
+  PrepareQuery("~hello | world");
+
+  ExpectAll("hello there", "world peace", "neither term", "both hello world");
+
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+TEST_F(SearchTest, MatchFieldOptionalUnparen) {
+  // @field:~hello (no parens) — was a parser fix, ensure it executes correctly
+  PrepareQuery("@field:~hello");
+
+  ExpectAll("hello there", "no match", "another");
+
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+TEST_F(SearchTest, MatchOptionalSwallowsInnerErrors) {
+  // ~@invalid_field:hello: ~ is a soft boost, not a filter. Inner errors
+  // (missing/NOINDEX field) must NOT poison the outer query — return all docs
+  // without error, matching Redis's silent no-op semantics.
+  Schema schema = MakeSimpleSchema({{"text", SchemaField::TEXT}});
+  FieldIndices index{schema, kEmptyOptions, PMR_NS::get_default_resource(), nullptr};
+  MockedDocument doc{Map{{"text", "anything"}}};
+  index.Add(0, doc);
+  index.FinalizeInitialization();
+
+  SearchAlgorithm algo;
+  QueryParams params;
+  ASSERT_TRUE(algo.Init("~@invalid_field:hello", &params));
+  auto result = algo.Search(&index);
+  EXPECT_TRUE(result.error.empty()) << "~ should swallow inner errors, got: " << result.error;
+  EXPECT_EQ(result.ids.size(), 1u) << "~ should still return all docs";
+}
+
+TEST_F(SearchTest, MatchEscapedTermLiteral) {
+  // \X escape: lexer must produce a TERM with the literal char, not a separate
+  // operator token. The actual tokenizer typically strips punctuation when
+  // building the index, so these searches usually return 0 docs — the point of
+  // this test is the *parse + search* path doesn't error or return the wrong
+  // docs through misinterpreting `\~` as TILDE.
+  Schema schema = MakeSimpleSchema({{"field", SchemaField::TEXT}});
+  FieldIndices index{schema, kEmptyOptions, PMR_NS::get_default_resource(), nullptr};
+  MockedDocument plain("hello world");
+  index.Add(0, plain);
+  index.FinalizeInitialization();
+
+  for (auto* query : {"\\~hello", "foo\\~bar", "\\-test", "\\|word", "\\(group\\)"}) {
+    SearchAlgorithm algo;
+    QueryParams params;
+    ASSERT_TRUE(algo.Init(query, &params)) << "should parse: " << query;
+    auto result = algo.Search(&index);
+    EXPECT_TRUE(result.error.empty()) << "no error for escaped query: " << query;
+  }
+}
+
+TEST_F(SearchTest, MatchNestedOptionalNoDoubleScore) {
+  // ~~hello: nested optionals should not double-count "hello" in scoring.
+  // matched_text_terms_ uses a set keyed by (index, term) so the second
+  // OPT(hello) shouldn't add an extra cursor; doc with one "hello" must score
+  // the same as a plain ~hello.
+  Schema schema = MakeSimpleSchema({{"field", SchemaField::TEXT}});
+  FieldIndices index{schema, kEmptyOptions, PMR_NS::get_default_resource(), nullptr};
+  MockedDocument doc_hello("hello world");
+  index.Add(0, doc_hello);
+  index.FinalizeInitialization();
+
+  auto run = [&](const char* query) {
+    SearchAlgorithm algo;
+    QueryParams params;
+    EXPECT_TRUE(algo.Init(query, &params));
+    algo.SetScorer(&BM25Std);
+    return algo.Search(&index);
+  };
+
+  auto single = run("~hello");
+  auto nested = run("~~hello");
+
+  ASSERT_EQ(single.text_scores.size(), 1u);
+  ASSERT_EQ(nested.text_scores.size(), 1u);
+  EXPECT_NEAR(single.text_scores[0].second, nested.text_scores[0].second, 1e-6)
+      << "Nested optionals must not inflate the score";
+}
+
+TEST_F(SearchTest, MatchNegateErrorPropagation) {
+  // -@invalid_field:hello: pre-existing AstNegateNode pattern, error must propagate
+  Schema schema = MakeSimpleSchema({{"text", SchemaField::TEXT}});
+  FieldIndices index{schema, kEmptyOptions, PMR_NS::get_default_resource(), nullptr};
+  index.FinalizeInitialization();
+
+  SearchAlgorithm algo;
+  QueryParams params;
+  ASSERT_TRUE(algo.Init("-@invalid_field:hello", &params));
+  auto result = algo.Search(&index);
+  EXPECT_FALSE(result.error.empty()) << "error from negated subtree must propagate";
+}
+
+TEST_F(SearchTest, MatchOptionalFieldScopedReturnsAllDocs) {
+  Schema schema = MakeSimpleSchema({{"text", SchemaField::TEXT}, {"other", SchemaField::TEXT}});
+  FieldIndices index{schema, kEmptyOptions, PMR_NS::get_default_resource(), nullptr};
+
+  MockedDocument with_text{Map{{"text", "hello"}}};
+  MockedDocument without_text{Map{{"other", "world"}}};  // no "text" field
+  index.Add(0, with_text);
+  index.Add(1, without_text);
+  index.FinalizeInitialization();
+
+  SearchAlgorithm algo;
+  QueryParams params;
+  ASSERT_TRUE(algo.Init("@text:~hello", &params));
+  auto result = algo.Search(&index);
+
+  EXPECT_TRUE(result.error.empty()) << result.error;
+  EXPECT_EQ(result.ids.size(), 2u)
+      << "@field:~term must return all docs, including ones without the field";
+}
+
+TEST_F(SearchTest, MatchOptionalFieldScopedSortableNoIndex) {
+  InitTLSearchMR(PMR_NS::get_default_resource());
+  absl::Cleanup mr_cleanup{[] { InitTLSearchMR(nullptr); }};
+
+  Schema schema = MakeSimpleSchema({{"txt", SchemaField::TEXT}});
+  schema.fields["txt"].flags = SchemaField::SORTABLE | SchemaField::NOINDEX;
+  FieldIndices index{schema, kEmptyOptions, PMR_NS::get_default_resource(), nullptr};
+  MockedDocument doc{Map{{"txt", "hello"}}};
+  index.Add(0, doc);
+  index.FinalizeInitialization();
+
+  SearchAlgorithm algo;
+  QueryParams params;
+  ASSERT_TRUE(algo.Init("@txt:~hello", &params));
+  auto result = algo.Search(&index);
+
+  EXPECT_TRUE(result.error.empty()) << "SORTABLE+NOINDEX field must not error: " << result.error;
+}
+
+TEST_F(SearchTest, MatchOptionalKnnIdsScoresAligned) {
+  auto schema = MakeSimpleSchema({{"text", SchemaField::TEXT}, {"vec", SchemaField::VECTOR}});
+  schema.fields["vec"].special_params = SchemaField::VectorParams{false, 1};
+  FieldIndices index{schema, kEmptyOptions, PMR_NS::get_default_resource(), nullptr};
+
+  // 4 docs with different text and 1-D vector positions.
+  for (size_t i = 0; i < 4; ++i) {
+    MockedDocument doc{Map{{"text", i == 0 || i == 3 ? "hello world" : "other"},
+                           {"vec", ToBytes({float(i + 1)})}}};
+    index.Add(i, doc);
+  }
+  index.FinalizeInitialization();
+
+  SearchAlgorithm algo;
+  QueryParams params;
+  params["v"] = ToBytes({2.5f});  // closest is doc:1 (pos=2) and doc:2 (pos=3)
+  ASSERT_TRUE(algo.Init("~hello => [KNN 4 @vec $v]", &params));
+  algo.SetScorer(&BM25Std);
+  auto result = algo.Search(&index);
+
+  ASSERT_TRUE(result.error.empty()) << result.error;
+  ASSERT_EQ(result.ids.size(), result.knn_scores.size())
+      << "ids and knn_scores must have matching size";
+  for (size_t i = 0; i < result.ids.size(); ++i) {
+    EXPECT_EQ(result.ids[i], result.knn_scores[i].first)
+        << "ids[" << i << "] (" << result.ids[i] << ") must align with knn_scores[" << i
+        << "].first (" << result.knn_scores[i].first << ")";
+  }
+}
+
 }  // namespace search
 }  // namespace dfly


### PR DESCRIPTION
Adds support for the `~` (optional/soft match) operator in the FT.SEARCH / FT.AGGREGATE query language. `~term` returns all documents but boosts the score of those matching the term - required by redisvl ≥ 0.8.2's `AggregateHybridQuery` and other hybrid text+vector use cases.

Fixes #7223