### PR TITLE
feat: add lacked functionality for OAHSet

### DIFF
--- a/src/core/oah_entry.cc
+++ b/src/core/oah_entry.cc
@@ -6,6 +6,7 @@
 
 #include "base/hash.h"
 #include "base/logging.h"
+#include "core/page_usage/page_usage_stats.h"
 
 namespace dfly {
 
@@ -76,6 +77,55 @@ void OAHEntry::ExpireIfNeeded(uint32_t time_now, uint32_t* set_size, size_t* all
     Clear();
     --*set_size;
   }
+}
+
+ssize_t OAHEntry::ReallocIfNeeded(PageUsage* page_usage, bool* realloced) {
+  *realloced = false;
+  if (!data_)
+    return 0;
+
+  ssize_t obj_alloc_delta = 0;
+
+  if (IsVector()) {
+    // Recurse into each inner entry first — every element's own buffer must be checked.
+    auto& vec = AsVector();
+    for (size_t i = 0, n = vec.Size(); i < n; ++i) {
+      if (vec[i]) {
+        bool inner_moved = false;
+        obj_alloc_delta += vec[i].ReallocIfNeeded(page_usage, &inner_moved);
+        if (inner_moved)
+          *realloced = true;
+      }
+    }
+    // Then defrag the vector's array buffer if its page is underutilized. ResizeLog
+    // with the same log_size allocates a fresh buffer, move-constructs each element
+    // (OAHEntry's move-ctor swaps data_, leaving sources empty), and frees the old
+    // buffer via Clear(). The vector's logical AllocSize is unchanged, so no delta
+    // is reported for ptr_vectors_alloc_used_.
+    if (page_usage->IsPageForObjectUnderUtilized(Raw())) {
+      vec.ResizeLog(vec.LogSize());
+      *realloced = true;
+    }
+    return obj_alloc_delta;
+  }
+
+  if (!page_usage->IsPageForObjectUnderUtilized(Raw()))
+    return 0;
+
+  // Single-entry realloc via ctor + move-assignment: build a fresh OAHEntry from this
+  // one's key/expiry/ext_hash; move-assign to swap data_, then the temporary's
+  // destructor frees the old buffer.
+  const size_t old_alloc = AllocSize();
+  const uint64_t saved_hash = GetHash();
+  const uint32_t expiry = HasExpiry() ? GetExpiry() : UINT32_MAX;
+  {
+    OAHEntry replacement(Key(), expiry);
+    if (saved_hash)
+      replacement.SetExtHash(saved_hash);
+    *this = std::move(replacement);
+  }
+  *realloced = true;
+  return static_cast<ssize_t>(AllocSize()) - static_cast<ssize_t>(old_alloc);
 }
 
 // TODO refactor, because it's inefficient

--- a/src/core/oah_entry.h
+++ b/src/core/oah_entry.h
@@ -16,6 +16,8 @@ extern "C" {
 
 namespace dfly {
 
+class PageUsage;
+
 #define PREFETCH_READ(x) __builtin_prefetch(x, 0, 1)
 #define FORCE_INLINE __attribute__((always_inline))
 
@@ -242,6 +244,13 @@ class OAHEntry {
   void SetExpiry(uint32_t at_sec);
 
   void ExpireIfNeeded(uint32_t time_now, uint32_t* set_size, size_t* alloc_used);
+
+  // Reallocates fragmented buffers under this entry. For a single entry, that's its own
+  // string buffer. For a vector entry, recurses into every inner entry AND the vector's
+  // own array buffer. Returns the cumulative change in zmalloc_usable_size across inner
+  // entry buffers (the vector array buffer is realloc'd to the same logical size so its
+  // AllocSize is unchanged). *realloced is set to true iff any buffer was moved.
+  ssize_t ReallocIfNeeded(PageUsage* page_usage, bool* realloced);
 
   // TODO refactor, because it's inefficient
   // Returns additional allocation size of ptrVector

--- a/src/core/oah_set.h
+++ b/src/core/oah_set.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <absl/numeric/bits.h>
+#include <absl/random/random.h>
 #include <absl/types/span.h>
 
 #include <concepts>
@@ -38,6 +39,7 @@ class OAHSet {  // Open Addressing Hash Set
       owner_->obj_alloc_used_ -= entry.AllocSize();
       owner_->entries_[bucket_][pos_].SetExpiry(owner_->EntryTTL(ttl_sec));
       owner_->obj_alloc_used_ += entry.AllocSize();
+      owner_->expiration_used_ = true;
     }
 
     iterator& operator++() {
@@ -82,6 +84,25 @@ class OAHSet {  // Open Addressing Hash Set
       return owner_;
     }
 
+    // Reallocates fragmented buffers in this entry's bucket. For vector buckets, the
+    // inner entries and the array buffer are all checked. Returns true iff anything
+    // moved. Idempotent: repeated calls within a defrag pass hit fresh pages and no-op.
+    bool ReallocIfNeeded(PageUsage* page_usage) {
+      auto& bucket = owner_->entries_[bucket_];
+      bool realloced = false;
+      ssize_t delta = bucket.ReallocIfNeeded(page_usage, &realloced);
+      // delta can be negative if a realloc lands in a smaller mimalloc usable-size
+      // bucket; route the signed update through ssize_t to avoid size_t underflow.
+      if (delta >= 0) {
+        owner_->obj_alloc_used_ += static_cast<size_t>(delta);
+      } else {
+        const size_t shrink = static_cast<size_t>(-delta);
+        assert(shrink <= owner_->obj_alloc_used_);
+        owner_->obj_alloc_used_ -= shrink;
+      }
+      return realloced;
+    }
+
     // find valid entry_ iterator starting from buckets_it_ and set it
     void SetEntryIt() {
       if (!owner_)
@@ -113,6 +134,8 @@ class OAHSet {  // Open Addressing Hash Set
     return iterator(nullptr, 0, 0);
   }
 
+  static constexpr uint32_t kMaxBatchLen = 32;
+
   explicit OAHSet() = default;
 
   bool Add(std::string_view str, uint32_t ttl_sec = UINT32_MAX) {
@@ -136,6 +159,8 @@ class OAHSet {  // Open Addressing Hash Set
       return false;
     }
 
+    if (ttl_sec != UINT32_MAX)
+      expiration_used_ = true;
     obj_alloc_used_ += entry.AllocSize();
     AddUnique(std::move(entry), bucket_id, ttl_sec);
     return true;
@@ -179,6 +204,39 @@ class OAHSet {  // Open Addressing Hash Set
     size_ = 0;
     obj_alloc_used_ = 0;
     ptr_vectors_alloc_used_ = 0;
+    expiration_used_ = false;
+  }
+
+  // Incrementally clears entries in [start, start+count). Returns the next bucket index;
+  // when the returned value equals Capacity() (i.e. entries_.size()), the table is empty.
+  // Mirrors DenseSet::ClearStep, used by AsyncDeleter for cooperative deletion.
+  uint32_t ClearStep(uint32_t start, uint32_t count) {
+    const uint32_t total = entries_.size();
+    const uint32_t end = std::min(total, start + count);
+    for (uint32_t i = start; i < end; ++i) {
+      auto& bucket = entries_[i];
+      if (bucket.Empty())
+        continue;
+
+      if (bucket.IsVector()) {
+        auto& vec = bucket.AsVector();
+        for (auto& entry : vec) {
+          if (entry) {
+            obj_alloc_used_ -= entry.AllocSize();
+            --size_;
+          }
+        }
+        ptr_vectors_alloc_used_ -= vec.AllocSize();
+      } else {
+        obj_alloc_used_ -= bucket.AllocSize();
+        --size_;
+      }
+      bucket = OAHEntry();
+    }
+    // Match Clear() semantics: once incrementally cleared empty, the TTL flag is stale.
+    if (size_ == 0)
+      expiration_used_ = false;
+    return end;
   }
 
   // TODO should be removed, inefficient
@@ -201,12 +259,20 @@ class OAHSet {  // Open Addressing Hash Set
     ptr_vectors_alloc_used_ += entries_[bid].Insert(std::move(e));
   }
 
-  unsigned AddMany(absl::Span<std::string_view> span, uint32_t ttl_sec = UINT32_MAX) {
+  // keepttl=true: existing entries are left alone (current/legacy behavior).
+  // keepttl=false: when ttl_sec is set, existing entries' expiry is updated to ttl_sec.
+  unsigned AddMany(absl::Span<std::string_view> span, uint32_t ttl_sec = UINT32_MAX,
+                   bool keepttl = true) {
     Reserve(span.size());
     unsigned res = 0;
+    const bool has_ttl = ttl_sec != UINT32_MAX;
     for (auto& s : span) {
-      if (Add(s, ttl_sec) != end()) {
-        res++;
+      if (Add(s, ttl_sec)) {
+        ++res;
+      } else if (has_ttl && !keepttl) {
+        auto it = Find(s);
+        if (it != end())
+          it.SetExpiryTime(ttl_sec);
       }
     }
     return res;
@@ -332,6 +398,49 @@ class OAHSet {  // Open Addressing Hash Set
     return Find(member) != end();
   }
 
+  // Returns iterator to a uniformly random non-empty entry, or end() if the set is empty.
+  // Mirrors StringSet::GetRandomMember (used by SPOP/SRANDMEMBER).
+  iterator GetRandomMember() {
+    if (entries_.empty() || size_ == 0)
+      return end();
+
+    static thread_local absl::InsecureBitGen rng;
+    const uint32_t num_buckets = entries_.size();
+    uint32_t start_bucket = absl::Uniform<uint32_t>(rng, 0u, num_buckets);
+
+    for (uint32_t n = 0; n < num_buckets; ++n) {
+      uint32_t bucket_id = start_bucket + n;
+      if (bucket_id >= num_buckets)
+        bucket_id -= num_buckets;
+      auto& bucket = entries_[bucket_id];
+      if (bucket.Empty())
+        continue;
+
+      if (!bucket.IsVector()) {
+        bucket.ExpireIfNeeded(time_now_, &size_, &obj_alloc_used_);
+        if (!bucket.Empty())
+          return iterator{this, bucket_id, 0};
+        continue;
+      }
+
+      auto& vec = bucket.AsVector();
+      const uint32_t vec_size = vec.Size();
+      uint32_t start_pos = absl::Uniform<uint32_t>(rng, 0u, vec_size);
+      for (uint32_t p = 0; p < vec_size; ++p) {
+        uint32_t pos = start_pos + p;
+        if (pos >= vec_size)
+          pos -= vec_size;
+        auto& entry = vec[pos];
+        if (!entry)
+          continue;
+        entry.ExpireIfNeeded(time_now_, &size_, &obj_alloc_used_);
+        if (entry)
+          return iterator{this, bucket_id, pos};
+      }
+    }
+    return end();
+  }
+
   // Returns the number of elements in the map. Note that it might be that some of these elements
   // have expired and can't be accessed.
   size_t UpperBoundSize() const {
@@ -368,9 +477,7 @@ class OAHSet {  // Open Addressing Hash Set
   }
 
   bool ExpirationUsed() const {
-    // TODO
-    assert(false);
-    return true;
+    return expiration_used_;
   }
 
   size_t SizeSlow() {
@@ -651,6 +758,7 @@ class OAHSet {  // Open Addressing Hash Set
   std::uint32_t capacity_log_ = 0;
   std::uint32_t size_ = 0;  // number of elements in the set.
   std::uint32_t time_now_ = 0;
+  bool expiration_used_ = false;
   Buckets entries_;
 };
 

--- a/src/core/oah_set_test.cc
+++ b/src/core/oah_set_test.cc
@@ -14,6 +14,7 @@
 
 #include "base/gtest.h"
 #include "core/mi_memory_resource.h"
+#include "core/page_usage/page_usage_stats.h"
 #include "glog/logging.h"
 
 extern "C" {
@@ -554,6 +555,290 @@ TEST_F(OAHSetTest, Fill) {
   for (const auto& s : *ss_) {
     EXPECT_TRUE(s2.Contains(s.Key()));
   }
+}
+
+TEST_F(OAHSetTest, ExpirationUsedTracking) {
+  EXPECT_FALSE(ss_->ExpirationUsed());
+
+  EXPECT_TRUE(ss_->Add("no_ttl"sv));
+  EXPECT_FALSE(ss_->ExpirationUsed());
+
+  EXPECT_TRUE(ss_->Add("with_ttl"sv, 100));
+  EXPECT_TRUE(ss_->ExpirationUsed());
+
+  ss_->Clear();
+  EXPECT_FALSE(ss_->ExpirationUsed());
+}
+
+TEST_F(OAHSetTest, AddManyKeepTtl) {
+  // keepttl=true: existing entries keep their original TTL (or none).
+  EXPECT_TRUE(ss_->Add("k1"sv, 100));
+  EXPECT_TRUE(ss_->Add("k2"sv));  // no TTL
+
+  string_view members[] = {"k1"sv, "k2"sv, "k3"sv};
+  unsigned added = ss_->AddMany(absl::MakeSpan(members), 200, /*keepttl=*/true);
+  EXPECT_EQ(added, 1u);  // only k3 is new
+
+  EXPECT_EQ(ss_->Find("k1"sv).ExpiryTime(), 100u);  // unchanged
+  EXPECT_FALSE(ss_->Find("k2"sv).HasExpiry());      // unchanged
+  EXPECT_EQ(ss_->Find("k3"sv).ExpiryTime(), 200u);  // newly added with TTL
+}
+
+TEST_F(OAHSetTest, AddManyOverwriteTtl) {
+  // keepttl=false with TTL: existing entries' expiry is updated to ttl_sec.
+  EXPECT_TRUE(ss_->Add("k1"sv, 100));
+  EXPECT_TRUE(ss_->Add("k2"sv));  // no TTL initially
+
+  string_view members[] = {"k1"sv, "k2"sv, "k3"sv};
+  unsigned added = ss_->AddMany(absl::MakeSpan(members), 200, /*keepttl=*/false);
+  EXPECT_EQ(added, 1u);  // only k3 is new
+
+  EXPECT_EQ(ss_->Find("k1"sv).ExpiryTime(), 200u);  // updated
+  EXPECT_TRUE(ss_->Find("k2"sv).HasExpiry());       // got TTL
+  EXPECT_EQ(ss_->Find("k2"sv).ExpiryTime(), 200u);
+  EXPECT_EQ(ss_->Find("k3"sv).ExpiryTime(), 200u);
+}
+
+TEST_F(OAHSetTest, AddManyNoTtlIgnoresKeepttl) {
+  // ttl_sec == UINT32_MAX: keepttl is irrelevant — existing entries are not touched.
+  EXPECT_TRUE(ss_->Add("k1"sv, 100));
+
+  string_view members[] = {"k1"sv};
+  unsigned added = ss_->AddMany(absl::MakeSpan(members), UINT32_MAX, /*keepttl=*/false);
+  EXPECT_EQ(added, 0u);
+  EXPECT_EQ(ss_->Find("k1"sv).ExpiryTime(), 100u);  // unchanged — no TTL provided
+}
+
+TEST_F(OAHSetTest, ReallocIfNeededForceReallocates) {
+  // With ForceReallocate, every entry's buffer is moved; content (key + TTL) must survive.
+  for (size_t i = 0; i < 50; ++i) {
+    EXPECT_TRUE(ss_->Add(absl::StrCat("key_", i, "_xxxxxxxx"), 100 + i));
+  }
+  size_t alloc_before = ss_->ObjAllocUsed();
+  EXPECT_GT(alloc_before, 0u);
+
+  PageUsage page_usage{CollectPageStats::NO, 0.9};
+  page_usage.SetForceReallocate(true);
+
+  size_t realloced = 0;
+  for (auto it = ss_->begin(); it != ss_->end(); ++it) {
+    if (it.ReallocIfNeeded(&page_usage))
+      ++realloced;
+  }
+  EXPECT_EQ(realloced, 50u);
+
+  // Every member is still present with its TTL intact.
+  for (size_t i = 0; i < 50; ++i) {
+    auto it = ss_->Find(absl::StrCat("key_", i, "_xxxxxxxx"));
+    ASSERT_NE(it, ss_->end());
+    EXPECT_EQ(it.ExpiryTime(), 100u + i);
+  }
+  // ObjAllocUsed remains roughly consistent (mimalloc usable size for same logical size).
+  EXPECT_GT(ss_->ObjAllocUsed(), 0u);
+}
+
+TEST_F(OAHSetTest, ReallocIfNeededVectorEntry) {
+  // Construct a vector OAHEntry directly via Insert — same shape as a colliding bucket.
+  OAHEntry e("first_entry_payload");
+  (void)e.Insert(OAHEntry("second_entry_payload"));
+  (void)e.Insert(OAHEntry("third_entry_payload"));
+  ASSERT_TRUE(e.IsVector());
+
+  // Snapshot inner-entry buffer pointers so we can assert each one moved.
+  std::vector<char*> old_inner_ptrs;
+  for (uint32_t i = 0; i < e.AsVector().Size(); ++i)
+    if (e.AsVector()[i])
+      old_inner_ptrs.push_back(e.AsVector()[i].Raw());
+  char* old_vec_buf = e.Raw();
+
+  PageUsage page_usage{CollectPageStats::NO, 0.9};
+  page_usage.SetForceReallocate(true);
+
+  bool realloced = false;
+  e.ReallocIfNeeded(&page_usage, &realloced);
+  EXPECT_TRUE(realloced);
+  ASSERT_TRUE(e.IsVector());
+
+  // The vector container buffer was moved.
+  EXPECT_NE(e.Raw(), old_vec_buf);
+
+  // Each inner entry's buffer was also moved (recursion into elements happened) and
+  // their content is intact.
+  std::set<std::string> seen;
+  std::vector<char*> new_inner_ptrs;
+  auto& vec = e.AsVector();
+  for (uint32_t i = 0; i < vec.Size(); ++i) {
+    if (vec[i]) {
+      seen.insert(std::string(vec[i].Key()));
+      new_inner_ptrs.push_back(vec[i].Raw());
+    }
+  }
+  EXPECT_EQ(seen.count("first_entry_payload"), 1u);
+  EXPECT_EQ(seen.count("second_entry_payload"), 1u);
+  EXPECT_EQ(seen.count("third_entry_payload"), 1u);
+
+  // No new inner pointer should match any old inner pointer (every inner buffer moved).
+  ASSERT_EQ(new_inner_ptrs.size(), old_inner_ptrs.size());
+  for (char* old_p : old_inner_ptrs) {
+    for (char* new_p : new_inner_ptrs) {
+      EXPECT_NE(old_p, new_p) << "inner entry buffer not reallocated";
+    }
+  }
+}
+
+TEST_F(OAHSetTest, ReallocIfNeededVectorBucketViaIterator) {
+  // Force collisions by overflowing the displacement window: add many entries until
+  // at least one bucket becomes a vector, then force-realloc and verify consistency.
+  ss_->Reserve(4);  // tiny start
+  constexpr size_t num = 100;
+  for (size_t i = 0; i < num; ++i)
+    ss_->Add(absl::StrCat("vec_member_", i));
+
+  PageUsage page_usage{CollectPageStats::NO, 0.9};
+  page_usage.SetForceReallocate(true);
+
+  for (auto it = ss_->begin(); it != ss_->end(); ++it)
+    it.ReallocIfNeeded(&page_usage);
+
+  // All members survive the defrag, including any that were inside vector buckets.
+  for (size_t i = 0; i < num; ++i)
+    EXPECT_TRUE(ss_->Contains(absl::StrCat("vec_member_", i))) << i;
+  EXPECT_EQ(ss_->UpperBoundSize(), num);
+}
+
+TEST_F(OAHSetTest, ReallocIfNeededNoUnderutilized) {
+  // No force flag, no fragmented pages — reallocation should not occur.
+  for (size_t i = 0; i < 10; ++i)
+    ss_->Add(absl::StrCat("k", i));
+
+  PageUsage page_usage{CollectPageStats::NO, 0.9};
+  for (auto it = ss_->begin(); it != ss_->end(); ++it) {
+    it.ReallocIfNeeded(&page_usage);
+  }
+  // It's possible (rare) the heap is underutilized for some entries. Don't assert exactly 0,
+  // but verify the set is still consistent.
+  for (size_t i = 0; i < 10; ++i)
+    EXPECT_TRUE(ss_->Contains(absl::StrCat("k", i)));
+}
+
+TEST_F(OAHSetTest, ClearStepEmpty) {
+  EXPECT_EQ(ss_->ClearStep(0, 100), 0u);  // nothing to clear, end = entries_.size() = 0
+}
+
+TEST_F(OAHSetTest, ClearStepIncremental) {
+  // Populate enough to span multiple buckets, then clear in chunks.
+  constexpr size_t num = 1000;
+  for (size_t i = 0; i < num; ++i)
+    ss_->Add(absl::StrCat("k", i), 100);
+  EXPECT_GT(ss_->UpperBoundSize(), 0u);
+  EXPECT_TRUE(ss_->ExpirationUsed());
+
+  const uint32_t total = ss_->Capacity();
+  uint32_t cursor = 0;
+  size_t steps = 0;
+  while (cursor < total) {
+    cursor = ss_->ClearStep(cursor, 64);
+    ++steps;
+    ASSERT_LT(steps, total) << "ClearStep not making progress";
+  }
+  EXPECT_EQ(cursor, total);
+  EXPECT_EQ(ss_->UpperBoundSize(), 0u);
+  EXPECT_EQ(ss_->ObjAllocUsed(), 0u);
+}
+
+TEST_F(OAHSetTest, ClearStepFullBucketCount) {
+  for (size_t i = 0; i < 100; ++i)
+    ss_->Add(absl::StrCat("k", i));
+  // One mega-step covering everything.
+  uint32_t end = ss_->ClearStep(0, ss_->Capacity());
+  EXPECT_EQ(end, ss_->Capacity());
+  EXPECT_EQ(ss_->UpperBoundSize(), 0u);
+  EXPECT_EQ(ss_->ObjAllocUsed(), 0u);
+}
+
+TEST_F(OAHSetTest, GetRandomMemberEmpty) {
+  EXPECT_EQ(ss_->GetRandomMember(), ss_->end());
+}
+
+TEST_F(OAHSetTest, GetRandomMemberSingle) {
+  EXPECT_TRUE(ss_->Add("only"sv));
+  auto it = ss_->GetRandomMember();
+  ASSERT_NE(it, ss_->end());
+  EXPECT_EQ(it->Key(), "only"sv);
+}
+
+TEST_F(OAHSetTest, GetRandomMemberSkipsExpired) {
+  EXPECT_TRUE(ss_->Add("alive"sv, 100));
+  EXPECT_TRUE(ss_->Add("dead"sv, 1));
+
+  ss_->set_time(50);  // dead has expired (expiry=1), alive (expiry=100) survives.
+
+  for (size_t i = 0; i < 200; ++i) {
+    auto it = ss_->GetRandomMember();
+    if (it == ss_->end())
+      continue;
+    EXPECT_EQ(it->Key(), "alive"sv);
+  }
+}
+
+TEST_F(OAHSetTest, AddManyKeepTtlFalseSetsExpirationUsed) {
+  // Regression: adding TTL to an existing member via AddMany(keepttl=false) must mark
+  // expiration_used_ true — otherwise RDB save will skip TTL serialization for the entry.
+  EXPECT_TRUE(ss_->Add("k1"sv));  // no TTL
+  EXPECT_FALSE(ss_->ExpirationUsed());
+
+  string_view members[] = {"k1"sv};
+  ss_->AddMany(absl::MakeSpan(members), 100, /*keepttl=*/false);
+
+  EXPECT_TRUE(ss_->Find("k1"sv).HasExpiry());
+  EXPECT_TRUE(ss_->ExpirationUsed()) << "TTL was added to existing member but flag wasn't set";
+}
+
+TEST_F(OAHSetTest, ClearStepResetsExpirationUsed) {
+  // Regression: ClearStep that fully empties the set must also reset expiration_used_,
+  // matching Clear() semantics.
+  for (size_t i = 0; i < 50; ++i)
+    ss_->Add(absl::StrCat("k", i), 100);
+  EXPECT_TRUE(ss_->ExpirationUsed());
+
+  uint32_t cursor = 0;
+  while (cursor < ss_->Capacity())
+    cursor = ss_->ClearStep(cursor, 16);
+
+  EXPECT_EQ(ss_->UpperBoundSize(), 0u);
+  EXPECT_FALSE(ss_->ExpirationUsed())
+      << "ExpirationUsed must be false after ClearStep fully empties the set";
+}
+
+TEST_F(OAHSetTest, ReallocIfNeededObjAllocUsedConsistent) {
+  // Sanity: after force-realloc, obj_alloc_used_ remains the sum of all entries'
+  // current AllocSize. Guards against signed-delta arithmetic going wrong on the counter.
+  for (size_t i = 0; i < 100; ++i)
+    ss_->Add(absl::StrCat("member_", i), 100 + i);
+
+  PageUsage page_usage{CollectPageStats::NO, 0.9};
+  page_usage.SetForceReallocate(true);
+  for (auto it = ss_->begin(); it != ss_->end(); ++it)
+    it.ReallocIfNeeded(&page_usage);
+
+  size_t expected = 0;
+  for (auto it = ss_->begin(); it != ss_->end(); ++it)
+    expected += (*it).AllocSize();
+  EXPECT_EQ(ss_->ObjAllocUsed(), expected);
+}
+
+TEST_F(OAHSetTest, ClearResetsObjAllocUsed) {
+  for (size_t i = 0; i < 100; ++i) {
+    ss_->Add(random_string(generator_, 10));
+  }
+
+  EXPECT_GT(ss_->ObjAllocUsed(), 0u);
+  EXPECT_GT(ss_->UpperBoundSize(), 0u);
+
+  ss_->Clear();
+
+  EXPECT_EQ(ss_->ObjAllocUsed(), 0u);
+  EXPECT_EQ(ss_->UpperBoundSize(), 0u);
 }
 
 TEST_F(OAHSetTest, IterateEmpty) {


### PR DESCRIPTION
Summary: Adds missing maintenance functionality to OAHSet/OAHEntry to support defragmentation, TTL bookkeeping, incremental deletion, and random member selection.

Changes:

- Introduces OAHEntry::ReallocIfNeeded and an iterator helper to relocate fragmented entry/vector buffers using PageUsage.
- Adds expiration_used_ tracking and makes ExpirationUsed() functional; updates the flag on TTL add/update and resets it on Clear()/ClearStep().
- Extends AddMany with a keepttl parameter to optionally overwrite TTLs for existing members.
- Adds ClearStep for cooperative/incremental clearing (e.g., AsyncDeleter-style deletion).
- Adds GetRandomMember for SPOP/SRANDMEMBER-style selection while lazily expiring entries.
- Expands unit tests for TTL tracking, AddMany semantics, defrag behavior, ClearStep, and GetRandomMember.