### PR TITLE
fix: memory track before preemption in OpAdd

### DIFF
--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -1212,6 +1212,11 @@ OpResult<streamID> OpAdd(const OpArgs& op_args, string_view key, const AddOpts& 
             << " during the XADD command";
   }
 
+  // Must update before RecordJournal, which can preempt and cause evictions that change
+  // zmalloc_used_memory_tl, corrupting the diff computed by UpdateStreamSize.
+  mem_tracker.UpdateStreamSize(it->second);
+  std::move(on_exit).Cancel();
+
   if (op_args.shard->journal()) {
     std::string result_id_as_string = StreamsIdToString(result_id);
     const bool stream_is_empty = stream_inst->length == 0;

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -1178,7 +1178,6 @@ OpResult<streamID> OpAdd(const OpArgs& op_args, string_view key, const AddOpts& 
   auto& it = add_res.it;
 
   StreamMemTracker mem_tracker;
-  absl::Cleanup on_exit([it, &mem_tracker]() mutable { mem_tracker.UpdateStreamSize(it->second); });
 
   if (add_res.is_new) {
     stream* s = streamNew();
@@ -1195,8 +1194,9 @@ OpResult<streamID> OpAdd(const OpArgs& op_args, string_view key, const AddOpts& 
 
   if (res != 0) {
     if (add_res.is_new) {
-      std::move(on_exit).Cancel();
       db_slice.DelMutable(op_args.db_cntx, std::move(add_res));
+    } else {
+      mem_tracker.UpdateStreamSize(it->second);
     }
     if (res == ERANGE)
       return OpStatus::OUT_OF_RANGE;
@@ -1215,7 +1215,6 @@ OpResult<streamID> OpAdd(const OpArgs& op_args, string_view key, const AddOpts& 
   // Must update before RecordJournal, which can preempt and cause evictions that change
   // zmalloc_used_memory_tl, corrupting the diff computed by UpdateStreamSize.
   mem_tracker.UpdateStreamSize(it->second);
-  std::move(on_exit).Cancel();
 
   if (op_args.shard->journal()) {
     std::string result_id_as_string = StreamsIdToString(result_id);


### PR DESCRIPTION
`OpAdd` rewrites to the journal directly via `RecordJournal` which can preempt. On preemption, the heap size might change leading to an improper update to memory tracker after the preemption. 

The fix is simple, run the memory tracker update before the write to the journal.

Fixes  #7232