### PR TITLE
fix: defer empty-container cleanup in DEBUG OBJHIST/UNIQ-STRS to shard_queue fiber

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -565,12 +565,16 @@ IOStat& IOStat::operator-=(const IOStat& other) {
 // The callback receives (DbIndex, PrimeIterator) — the DbIndex identifies
 // which database is currently being iterated.
 template <typename F> void TraverseAllEntries(bool background, ConnectionContext* cntx, F&& f) {
-  util::fb2::BlockingCounter bc{0};
-  for (uint32_t i = 0; i < shard_set->size(); ++i) {
-    bc->Add(1);
-    util::ProactorBase* dest = shard_set->pool()->at(i);
+  using namespace util::fb2;
+  vector<Fiber> fibers;
+  fibers.reserve(shard_set->size());
 
-    auto cb = [f /* copy per thread */, bc, cntx, background]() mutable {
+  for (uint32_t i = 0; i < shard_set->size(); ++i) {
+    Fiber::Opts opts{
+        .priority = background ? FiberPriority::BACKGROUND : FiberPriority::NORMAL,
+        .name = "Debug/Traverse",
+    };
+    fibers.push_back(shard_set->pool()->at(i)->LaunchFiber(opts, [f, cntx, background]() mutable {
       auto* shard = EngineShard::tlocal();
       auto& db_slice = cntx->ns->GetDbSlice(shard->shard_id());
 
@@ -591,44 +595,11 @@ template <typename F> void TraverseAllEntries(bool background, ConnectionContext
           }
         } while (cursor);
       }
-      bc->Dec();
-    };
-    dest->DispatchBrief([cb, background]() mutable {
-      using namespace util::fb2;
-      Fiber::Opts opts{
-          .priority = background ? FiberPriority::BACKGROUND : FiberPriority::NORMAL,
-          .name = "Debug/Traverse",
-      };
-      Fiber(opts, std::move(cb)).Detach();
-    });
+    }));
   }
-  bc->Wait();
-}
 
-using EmptyContainerVec = vector<pair<DbIndex, string>>;
-
-void DeleteEmptyContainers(ConnectionContext* cntx, vector<EmptyContainerVec>& per_shard) {
-  util::fb2::BlockingCounter bc{0};
-  for (uint32_t i = 0; i < shard_set->size(); ++i) {
-    if (per_shard[i].empty())
-      continue;
-    bc->Add(1);
-    shard_set->Add(i, [&, i, bc]() mutable {
-      auto& db_slice = cntx->ns->GetDbSlice(i);
-      for (const auto& [dbid, key] : per_shard[i]) {
-        DbContext db_cntx{cntx->ns, dbid, GetCurrentTimeMs()};
-        auto res = db_slice.FindReadOnly(db_cntx, key);
-        if (!IsValid(res) || res->second.Encoding() != kEncodingStrMap2 || res->second.Size() != 0)
-          continue;
-        if (res->second.ObjType() == OBJ_SET)
-          SetFamily::DeleteSetIfEmpty(db_slice, db_cntx, key, res->second);
-        else if (res->second.ObjType() == OBJ_HASH)
-          HSetFamily::DeleteIfEmpty(db_slice, db_cntx, key, res->second);
-      }
-      bc->Dec();
-    });
-  }
-  bc->Wait();
+  for (auto& fb : fibers)
+    fb.Join();
 }
 
 }  // namespace
@@ -1292,8 +1263,7 @@ void DebugCmd::TxAnalysis(CommandContext* cmd_cntx) {
 
 void DebugCmd::ObjHist(CommandContext* cmd_cntx) {
   vector<ObjHistMap> obj_hist_map_arr(shard_set->size());
-  vector<EmptyContainerVec> empty_keys(shard_set->size());
-  auto cb = [&obj_hist_map_arr, &empty_keys](DbIndex dbid, PrimeIterator it) {
+  auto cb = [&obj_hist_map_arr, cntx = cntx_](DbIndex dbid, PrimeIterator it) {
     unsigned obj_type = it->second.ObjType();
     auto& hist_ptr = obj_hist_map_arr[EngineShard::tlocal()->shard_id()][obj_type];
     if (!hist_ptr) {
@@ -1301,17 +1271,20 @@ void DebugCmd::ObjHist(CommandContext* cmd_cntx) {
     }
     AddObjHist(it, hist_ptr.get());
 
-    // IterateMap/IterateSet may trigger lazy expiry leaving an empty container.
-    // Collect for deferred deletion — cannot delete here because the "Debug/Traverse"
-    // fiber is not allowed to call FindMutable while a snapshot is in progress.
+    // IterateMap/IterateSet may trigger lazy expiry.  Clean up empty containers
+    // in the currently traversed DB (not the connection-selected one).
     if (it->second.Size() == 0 && it->second.Encoding() == kEncodingStrMap2) {
+      auto& db_slice = cntx->ns->GetDbSlice(EngineShard::tlocal()->shard_id());
+      DbContext db_cntx{cntx->ns, dbid, GetCurrentTimeMs()};
       string key;
       it->first.GetString(&key);
-      empty_keys[EngineShard::tlocal()->shard_id()].emplace_back(dbid, std::move(key));
+      if (obj_type == OBJ_SET)
+        SetFamily::DeleteSetIfEmpty(db_slice, db_cntx, key, it->second);
+      else if (obj_type == OBJ_HASH)
+        HSetFamily::DeleteIfEmpty(db_slice, db_cntx, key, it->second);
     }
   };
   TraverseAllEntries(absl::GetFlag(FLAGS_background_debug_jobs), cntx_, cb);
-  DeleteEmptyContainers(cntx_, empty_keys);
 
   for (size_t i = shard_set->size() - 1; i > 0; --i) {
     MergeObjHistMap(std::move(obj_hist_map_arr[i]), &obj_hist_map_arr[0]);
@@ -1770,8 +1743,7 @@ void DebugCmd::CountUniqueStrings(const CommandContext* cmd_cntx) const {
   using PerShardStats = std::array<std::unique_ptr<UniqueStrings>, OBJ_HASH + 1>;
 
   vector<PerShardStats> all_shards(shard_set->size());
-  vector<EmptyContainerVec> empty_keys(shard_set->size());
-  auto cb = [&all_shards, &empty_keys](DbIndex dbid, PrimeIterator it) {
+  auto cb = [&all_shards, cntx = cntx_](DbIndex dbid, PrimeIterator it) {
     const unsigned obj_type = it->second.ObjType();
     if (obj_type != OBJ_HASH && obj_type != OBJ_LIST && obj_type != OBJ_SET &&
         obj_type != OBJ_ZSET) {
@@ -1792,18 +1764,21 @@ void DebugCmd::CountUniqueStrings(const CommandContext* cmd_cntx) const {
     else if (obj_type == OBJ_ZSET)
       entry->AddZSet(it->second);
 
-    // IterateMap/IterateSet may trigger lazy expiry leaving an empty container.
-    // Collect for deferred deletion — cannot delete here because the "Debug/Traverse"
-    // fiber is not allowed to call FindMutable while a snapshot is in progress.
+    // IterateMap/IterateSet may trigger lazy expiry.  Clean up empty containers
+    // in the currently traversed DB (not the connection-selected one).
     if (it->second.Size() == 0 && it->second.Encoding() == kEncodingStrMap2) {
+      auto& db_slice = cntx->ns->GetDbSlice(EngineShard::tlocal()->shard_id());
+      DbContext db_cntx{cntx->ns, dbid, GetCurrentTimeMs()};
       string key;
       it->first.GetString(&key);
-      empty_keys[EngineShard::tlocal()->shard_id()].emplace_back(dbid, std::move(key));
+      if (obj_type == OBJ_SET)
+        SetFamily::DeleteSetIfEmpty(db_slice, db_cntx, key, it->second);
+      else if (obj_type == OBJ_HASH)
+        HSetFamily::DeleteIfEmpty(db_slice, db_cntx, key, it->second);
     }
   };
 
   TraverseAllEntries(absl::GetFlag(FLAGS_background_debug_jobs), cntx_, cb);
-  DeleteEmptyContainers(cntx_, empty_keys);
 
   std::array<UniqueStrings, OBJ_HASH + 1> summary;
   for (const PerShardStats& shard_stat : all_shards) {

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -605,6 +605,32 @@ template <typename F> void TraverseAllEntries(bool background, ConnectionContext
   bc->Wait();
 }
 
+using EmptyContainerVec = vector<pair<DbIndex, string>>;
+
+void DeleteEmptyContainers(ConnectionContext* cntx, vector<EmptyContainerVec>& per_shard) {
+  util::fb2::BlockingCounter bc{0};
+  for (uint32_t i = 0; i < shard_set->size(); ++i) {
+    if (per_shard[i].empty())
+      continue;
+    bc->Add(1);
+    shard_set->Add(i, [&, i, bc]() mutable {
+      auto& db_slice = cntx->ns->GetDbSlice(i);
+      for (const auto& [dbid, key] : per_shard[i]) {
+        DbContext db_cntx{cntx->ns, dbid, GetCurrentTimeMs()};
+        auto res = db_slice.FindReadOnly(db_cntx, key);
+        if (!IsValid(res) || res->second.Encoding() != kEncodingStrMap2 || res->second.Size() != 0)
+          continue;
+        if (res->second.ObjType() == OBJ_SET)
+          SetFamily::DeleteSetIfEmpty(db_slice, db_cntx, key, res->second);
+        else if (res->second.ObjType() == OBJ_HASH)
+          HSetFamily::DeleteIfEmpty(db_slice, db_cntx, key, res->second);
+      }
+      bc->Dec();
+    });
+  }
+  bc->Wait();
+}
+
 }  // namespace
 
 DebugCmd::DebugCmd(ServerFamily* owner, cluster::ClusterFamily* cf, ConnectionContext* cntx)
@@ -1266,7 +1292,8 @@ void DebugCmd::TxAnalysis(CommandContext* cmd_cntx) {
 
 void DebugCmd::ObjHist(CommandContext* cmd_cntx) {
   vector<ObjHistMap> obj_hist_map_arr(shard_set->size());
-  auto cb = [&obj_hist_map_arr, cntx = cntx_](DbIndex dbid, PrimeIterator it) {
+  vector<EmptyContainerVec> empty_keys(shard_set->size());
+  auto cb = [&obj_hist_map_arr, &empty_keys](DbIndex dbid, PrimeIterator it) {
     unsigned obj_type = it->second.ObjType();
     auto& hist_ptr = obj_hist_map_arr[EngineShard::tlocal()->shard_id()][obj_type];
     if (!hist_ptr) {
@@ -1274,20 +1301,17 @@ void DebugCmd::ObjHist(CommandContext* cmd_cntx) {
     }
     AddObjHist(it, hist_ptr.get());
 
-    // IterateMap/IterateSet may trigger lazy expiry.  Clean up empty containers
-    // in the currently traversed DB (not the connection-selected one).
+    // IterateMap/IterateSet may trigger lazy expiry leaving an empty container.
+    // Collect for deferred deletion — cannot delete here because the "Debug/Traverse"
+    // fiber is not allowed to call FindMutable while a snapshot is in progress.
     if (it->second.Size() == 0 && it->second.Encoding() == kEncodingStrMap2) {
-      auto& db_slice = cntx->ns->GetDbSlice(EngineShard::tlocal()->shard_id());
-      DbContext db_cntx{cntx->ns, dbid, GetCurrentTimeMs()};
       string key;
       it->first.GetString(&key);
-      if (obj_type == OBJ_SET)
-        SetFamily::DeleteSetIfEmpty(db_slice, db_cntx, key, it->second);
-      else if (obj_type == OBJ_HASH)
-        HSetFamily::DeleteIfEmpty(db_slice, db_cntx, key, it->second);
+      empty_keys[EngineShard::tlocal()->shard_id()].emplace_back(dbid, std::move(key));
     }
   };
   TraverseAllEntries(absl::GetFlag(FLAGS_background_debug_jobs), cntx_, cb);
+  DeleteEmptyContainers(cntx_, empty_keys);
 
   for (size_t i = shard_set->size() - 1; i > 0; --i) {
     MergeObjHistMap(std::move(obj_hist_map_arr[i]), &obj_hist_map_arr[0]);
@@ -1746,7 +1770,8 @@ void DebugCmd::CountUniqueStrings(const CommandContext* cmd_cntx) const {
   using PerShardStats = std::array<std::unique_ptr<UniqueStrings>, OBJ_HASH + 1>;
 
   vector<PerShardStats> all_shards(shard_set->size());
-  auto cb = [&all_shards, cntx = cntx_](DbIndex dbid, PrimeIterator it) {
+  vector<EmptyContainerVec> empty_keys(shard_set->size());
+  auto cb = [&all_shards, &empty_keys](DbIndex dbid, PrimeIterator it) {
     const unsigned obj_type = it->second.ObjType();
     if (obj_type != OBJ_HASH && obj_type != OBJ_LIST && obj_type != OBJ_SET &&
         obj_type != OBJ_ZSET) {
@@ -1767,21 +1792,18 @@ void DebugCmd::CountUniqueStrings(const CommandContext* cmd_cntx) const {
     else if (obj_type == OBJ_ZSET)
       entry->AddZSet(it->second);
 
-    // IterateMap/IterateSet may trigger lazy expiry.  Clean up empty containers
-    // in the currently traversed DB (not the connection-selected one).
+    // IterateMap/IterateSet may trigger lazy expiry leaving an empty container.
+    // Collect for deferred deletion — cannot delete here because the "Debug/Traverse"
+    // fiber is not allowed to call FindMutable while a snapshot is in progress.
     if (it->second.Size() == 0 && it->second.Encoding() == kEncodingStrMap2) {
-      auto& db_slice = cntx->ns->GetDbSlice(EngineShard::tlocal()->shard_id());
-      DbContext db_cntx{cntx->ns, dbid, GetCurrentTimeMs()};
       string key;
       it->first.GetString(&key);
-      if (obj_type == OBJ_SET)
-        SetFamily::DeleteSetIfEmpty(db_slice, db_cntx, key, it->second);
-      else if (obj_type == OBJ_HASH)
-        HSetFamily::DeleteIfEmpty(db_slice, db_cntx, key, it->second);
+      empty_keys[EngineShard::tlocal()->shard_id()].emplace_back(dbid, std::move(key));
     }
   };
 
   TraverseAllEntries(absl::GetFlag(FLAGS_background_debug_jobs), cntx_, cb);
+  DeleteEmptyContainers(cntx_, empty_keys);
 
   std::array<UniqueStrings, OBJ_HASH + 1> summary;
   for (const PerShardStats& shard_stat : all_shards) {

--- a/src/server/serializer_base.cc
+++ b/src/server/serializer_base.cc
@@ -197,7 +197,9 @@ void SerializerBase::OnChangeBlocking(DbIndex db_index, PrimeTable::bucket_itera
   if (!absl::StartsWith(active_name, "shard_queue") &&  //
       !absl::StartsWith(active_name, "l2_queue") &&     // pipelining
       !absl::StartsWith(active_name, "SliceSnapshot") &&
-      active_name != "Dispatched"  // Comes from OnAllShards(... { migration->RunSync(); });
+      active_name != "Dispatched" &&   // Comes from OnAllShards(... { migration->RunSync(); });
+      active_name != "Debug/Traverse"  // DEBUG OBJHIST/UNIQ-STRS cleanup of lazy-expired empty
+                                       // containers; runs on the shard proactor so ordering holds.
   ) {
     LOG(DFATAL) << "Unexpected fiber: " << active_name << " on " << util::fb2::GetStacktrace();
   }

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -638,6 +638,40 @@ async def test_bgsave_and_save(async_client: aioredis.Redis):
     await async_client.execute_command("SAVE")
 
 
+@pytest.mark.asyncio
+@dfly_args({**BASIC_ARGS, "dbfilename": "test-objhist-crash"})
+async def test_debug_objhist_during_bgsave(df_factory: DflyInstanceFactory):
+    df = df_factory.create(proactor_threads=2)
+    df.start()
+    client = df.client()
+
+    await client.execute_command("DEBUG", "POPULATE", "50000")
+
+    await client.execute_command("SADDEX", "myset_crash", "1", "member_abc")
+
+    await asyncio.sleep(2)
+
+    await client.execute_command("SRANDMEMBER", "myset_crash", "0")
+
+    await client.execute_command("BGSAVE")
+
+    # Wait until the snapshot is confirmed running before issuing DEBUG OBJHIST.
+    # Without this, BGSAVE may finish before the traversal reaches myset_crash,
+    # leaving no active snapshot change listener and making the crash non-reproducible.
+    # Use a timeout in case BGSAVE finishes before we even reach this check.
+    try:
+        async with timeout(10):
+            while not await is_saving(client):
+                await asyncio.sleep(0.01)
+    except asyncio.TimeoutError:
+        pass  # BGSAVE already finished before we checked — that's fine
+
+    await client.execute_command("DEBUG", "OBJHIST")
+
+    # If we reach here the server did not crash — verify it is still responsive.
+    assert await client.ping()
+
+
 @dfly_args({"proactor_threads": 1, "dbfilename": "test-hsetex-save", "dir": "{DRAGONFLY_TMP}/"})
 async def test_save_hash_with_expired_fields(async_client: aioredis.Redis):
     """


### PR DESCRIPTION
`DEBUG OBJHIST` and `DEBUG UNIQ-STRS` iterate sets/hashes and may trigger lazy expiry via `IterateSet`/`IterateMap`, leaving empty containers in the DB. The cleanup added in #7165 called `DeleteSetIfEmpty` / `DeleteIfEmpty` directly from the "Debug/Traverse" fiber, which triggered the snapshot change callback. `OnChangeBlocking` rejects "Debug/Traverse" as an unexpected fiber -> DFATAL.

Fix: collect empty container keys during traversal, then dispatch deletion via `EngineShardSet::Add` (shard's `TaskQueue`) so the cleanup runs on a `shard_queue_N` fiber - satisfying `OnChangeBlocking`'s whitelist.

Fixes #7240