### PR TITLE
fix: handle incompressible data in HuffmanCheckTask

### DIFF
--- a/src/core/compact_object_test.cc
+++ b/src/core/compact_object_test.cc
@@ -894,10 +894,11 @@ static void BuildEncoderAB(HuffmanEncoder* encoder) {
 TEST_F(CompactObjectTest, Huffman) {
   HuffmanEncoder encoder;
   BuildEncoderAB(&encoder);
-  string bindata = encoder.Export();
+  auto bindata = encoder.Export();
+  ASSERT_TRUE(bindata.has_value());
 
   for (CompactObj::HuffmanDomain domain : {CompactObj::HUFF_KEYS, CompactObj::HUFF_STRING_VALUES}) {
-    ASSERT_TRUE(CompactObj::InitHuffmanThreadLocal(domain, bindata));
+    ASSERT_TRUE(CompactObj::InitHuffmanThreadLocal(domain, *bindata));
     for (unsigned i = 30; i < 2048; i += 10) {
       string data(i, 'a');
 

--- a/src/core/dfly_core_test.cc
+++ b/src/core/dfly_core_test.cc
@@ -355,8 +355,9 @@ TEST_F(HuffCoderTest, Decode) {
   EXPECT_EQ(2, encoder_.GetNBits('a'));
   EXPECT_EQ(3, encoder_.GetNBits('b'));
 
-  string bindata = encoder_.Export();
-  ASSERT_TRUE(decoder_.Load(bindata, &error_msg_)) << error_msg_;
+  auto bindata = encoder_.Export();
+  ASSERT_TRUE(bindata.has_value());
+  ASSERT_TRUE(decoder_.Load(*bindata, &error_msg_)) << error_msg_;
 
   const char* src_ptr = reinterpret_cast<const char*>(encoded.data());
   array<char, 100> decode_dest{0};
@@ -415,9 +416,22 @@ TEST_F(HuffCoderTest, HugeHistogram) {
   LOG(INFO) << "Total sum: " << sum << " reduced sum: " << sum / 4;
   ASSERT_TRUE(encoder_.Build(hist.data(), hist.size() - 1, &error_msg_)) << error_msg_;
 
-  string bindata = encoder_.Export();
+  auto bindata = encoder_.Export();
+  ASSERT_TRUE(bindata.has_value());
   encoder_.Reset();
-  ASSERT_TRUE(encoder_.Load(bindata, &error_msg_)) << error_msg_;
+  ASSERT_TRUE(encoder_.Load(*bindata, &error_msg_)) << error_msg_;
+}
+
+// Regression test: uniform histogram produces a degenerate Huffman table with num_bits=0.
+// HUF_writeCTable_wksp fails for such tables, which previously triggered a CHECK crash.
+TEST_F(HuffCoderTest, IncompressibleUniformHistogram) {
+  array<unsigned, 256> hist;
+  hist.fill(100);
+  ASSERT_TRUE(encoder_.Build(hist.data(), hist.size() - 1, &error_msg_)) << error_msg_;
+
+  // Uniform distribution is incompressible - Export() should return nullopt instead of crashing.
+  auto bindata = encoder_.Export();
+  EXPECT_FALSE(bindata.has_value());
 }
 
 using benchmark::DoNotOptimize;

--- a/src/core/huff_coder.cc
+++ b/src/core/huff_coder.cc
@@ -92,7 +92,7 @@ size_t HuffmanEncoder::EstimateCompressedSize(const unsigned hist[], unsigned ma
   return res;
 }
 
-string HuffmanEncoder::Export() const {
+optional<string> HuffmanEncoder::Export() const {
   DCHECK(huf_ctable_);
 
   // Reverse engineered: (maxSymbolValue + 1) / 2 + 1.
@@ -105,7 +105,10 @@ string HuffmanEncoder::Export() const {
   // Seems we can reuse the same workspace, its capacity is enough.
   size_t size = HUF_writeCTable_wksp(res.data(), res.size(), huf_ctable_.get(), table_max_symbol_,
                                      num_bits_, wrkspace.get(), kWspSize);
-  CHECK(!HUF_isError(size));
+  if (HUF_isError(size)) {
+    LOG(WARNING) << "Failed to export Huffman table: " << HUF_getErrorName(size);
+    return nullopt;
+  }
   res.resize(size);
   return res;
 }

--- a/src/core/huff_coder.h
+++ b/src/core/huff_coder.h
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string_view>
 
 namespace dfly {
@@ -25,7 +26,8 @@ class HuffmanEncoder {
   bool Load(std::string_view binary_data, std::string* error_msg);
 
   // Exports a binary representation of the table, that can be loaded using Load().
-  std::string Export() const;
+  // Returns nullopt if the table cannot be serialized (e.g. incompressible data).
+  std::optional<std::string> Export() const;
 
   uint8_t num_bits() const {
     return num_bits_;

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -1645,7 +1645,8 @@ void DebugCmd::Compression(CmdArgList args, CommandContext* cmd_cntx) {
     compressed_size = huff_enc.EstimateCompressedSize(hist.hist.data(), HufHist::kMaxSymbol);
 
     if (print_bintable) {
-      bintable = huff_enc.Export();
+      auto exported = huff_enc.Export();
+      bintable = exported.value_or(string{});
     } else {
       bintable.clear();
     }

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -190,11 +190,15 @@ int32_t HuffmanCheckTask::Run(DbSlice* db_slice) {
   string error_msg;
   if (huff_enc.Build(hist_.data(), kMaxSymbol, &error_msg)) {
     size_t compressed_size = huff_enc.EstimateCompressedSize(hist_.data(), kMaxSymbol);
+    double ratio = double(compressed_size) / total_freq;
     LOG(INFO) << "Huffman table built, reducing character count from " << total_freq << " to "
-              << compressed_size << ", compression ratio " << double(compressed_size) / total_freq;
-    string bintable = huff_enc.Export();
-    LOG(INFO) << "Huffman binary table: " << absl::Base64Escape(bintable);
-    db_slice->shard_owner()->stats().huffman_tables_built++;
+              << compressed_size << ", compression ratio " << ratio;
+    if (ratio < 1.0) {
+      if (auto bintable = huff_enc.Export()) {
+        LOG(INFO) << "Huffman binary table: " << absl::Base64Escape(*bintable);
+        db_slice->shard_owner()->stats().huffman_tables_built++;
+      }
+    }
   } else {
     LOG(WARNING) << "Huffman build failed: " << error_msg;
   }


### PR DESCRIPTION
HuffmanCheckTask crashes the process with SIGABRT when key data is incompressible (e.g. random hashes, UUIDs, encrypted blobs):

  F huff_coder.cc:108] Check failed: !HUF_isError(size)

The task runs as an idle task on shard 0 once key memory exceeds 50 MB. It builds a Huffman frequency table from sampled key data, then unconditionally calls HuffmanEncoder::Export() to serialize the table for logging. When the data is high-entropy (compression ratio = 1.0), HUF_writeCTable_wksp returns an error for the degenerate table and the CHECK kills the process. Since the task re-triggers on every restart after snapshot recovery, this results in a crash loop.

Note: --compression_mode does not prevent this. That flag controls snapshot serialization compression (LZ4/ZSTD), not the background HuffmanCheckTask.

Fix:
- Export() returns std::optional<std::string> instead of crashing via CHECK. Logs a warning on failure.
- HuffmanCheckTask::Run() skips Export() when compression ratio >= 1.0, since there is no useful table to log.
- All callers (debugcmd.cc, tests) updated to handle the optional.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
