### PR TITLE
fix: single-field hash should use listpack even with large values

### DIFF
--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -46,7 +46,28 @@ using IncrByParam = std::variant<double, int64_t>;
 using OptStr = std::optional<std::string>;
 enum GetAllMode : uint8_t { FIELDS = 1, VALUES = 2 };
 
+// TODO: replace all the listpack code with our detail::Listpack wrapper.
 bool IsGoodForListpack(CmdArgList args, const uint8_t* lp) {
+  DCHECK_GE(args.size(), 2u);
+
+  // For a single field-value pair on an empty or single-entry listpack, approve automatically
+  // even with large values. A one-field hash is efficient to look-up or mutate.
+  if (args.size() == 2 && args.front().size() < 4096) {
+    if (lpLength((uint8_t*)lp) == 0)
+      return true;
+
+    // if we override the same field of a singleton hashmap, we allow listpack as well.
+    if (lpLength((uint8_t*)lp) == 2) {
+      uint8_t* first = lpFirst((uint8_t*)lp);
+      unsigned slen = 0;
+      long long lval;
+      uint8_t* vstr = lpGetValue(first, &slen, &lval);
+      if (vstr && args.front().size() == slen && memcmp(vstr, args.front().data(), slen) == 0) {
+        return true;
+      }
+    }
+  }
+
   size_t sum = 0;
   for (auto s : args) {
     if (s.size() > server.max_map_field_len)

--- a/src/server/hset_family_test.cc
+++ b/src/server/hset_family_test.cc
@@ -572,6 +572,28 @@ TEST_F(HSetFamilyTest, TriggerConvertToStrMap) {
   EXPECT_THAT(Run({"HLEN", "hk"}), IntArg(kElements));
 }
 
+// A single-field hash must remain listpack even when the value exceeds max_map_field_len
+// (default 64 bytes). With multiple fields the large value still triggers dense_set. (#7249)
+TEST_F(HSetFamilyTest, SingleFieldLargeValueRemainsListpack) {
+  const string large_value(2000, 'x');
+
+  EXPECT_EQ(1, CheckedInt({"HSET", "hmap", "field", large_value}));
+  auto resp = Run({"DEBUG", "OBJECT", "hmap"});
+  EXPECT_THAT(resp.GetString(), HasSubstr("encoding:listpack"));
+  EXPECT_EQ(Run({"HGET", "hmap", "field"}), large_value);
+
+  EXPECT_EQ(0, CheckedInt({"HSET", "hmap", "field", string(2000, 'y')}));
+  resp = Run({"DEBUG", "OBJECT", "hmap"});
+  EXPECT_THAT(resp.GetString(), HasSubstr("encoding:listpack"));
+
+  // Two fields: falls through to the regular size check, which rejects the large value.
+  EXPECT_EQ(2, CheckedInt({"HSET", "hmap", "field1", large_value, "field2", "val"}));
+  resp = Run({"DEBUG", "OBJECT", "hmap"});
+  EXPECT_THAT(resp.GetString(), HasSubstr("encoding:dense_set"));
+  EXPECT_EQ(Run({"HGET", "hmap", "field1"}), large_value);
+  EXPECT_EQ(Run({"HGET", "hmap", "field2"}), "val");
+}
+
 TEST_F(HSetFamilyTest, Issue1140) {
   Run({"HSET", "CaseKey", "Foo", "Bar"});
 


### PR DESCRIPTION
Single-field hashes now stay as listpack even when the value exceeds
`max_map_field_len`, fixing issue #7249.

Previously `IsGoodForListpack` rejected any field or value larger than
`max_map_field_len` (64 bytes), causing a one-field hash to be
immediately promoted to a dense_set on creation. A single field is
always efficient to look up or mutate in a contiguous listpack blob.

The bypass is limited to listpacks that currently have 0 or 1
field-value pair (`lpLength <= 2`) so that the normal size-based
promotion still fires when fields are added one at a time to a
growing hash.

## Changes
- `IsGoodForListpack`: return `true` for a single field-value pair
  (`args.size() == 2`, field name < 4 KiB) when the listpack holds at
  most one existing entry
- `HSetFamilyTest.SingleFieldLargeValueRemainsListpack`: verifies that
  a one-field hash with a 200-byte value stays as `listpack`, and that
  a two-field hash with the same large value converts to `dense_set`

Fixes #7249