### PR TITLE
fix(server): Reconcile bucket set

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -683,12 +683,15 @@ OpResult<DbSlice::ItAndUpdater> DbSlice::AddOrFindInternal(const Context& cntx, 
   auto status = res.status();
   CHECK(status == OpStatus::KEY_NOTFOUND || status == OpStatus::OUT_OF_MEMORY) << status;
 
+  // Call change callbacks on the computed set of buckets that can be affected by the insert
   if (!change_cb_.empty()) {
-    auto bucket_set = db.prime.CVCUponInsert(key);
-    CallChangeCallbacks(cntx.db_index, bucket_set);
+    for (bool consistent = false; !consistent;) {
+      auto bucket_set = db.prime.CVCUponInsert(key);
+      CallChangeCallbacks(cntx.db_index, bucket_set);
 
-    // Set of possible insertion buckets must be the same after possibly blocking call
-    DCHECK(bucket_set == db.prime.CVCUponInsert(key));
+      // Repeat the change callbacks if the target set changed
+      consistent = (bucket_set == db.prime.CVCUponInsert(key));
+    }
   }
 
   ssize_t memory_offset = -key.size();

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -690,6 +690,7 @@ OpResult<DbSlice::ItAndUpdater> DbSlice::AddOrFindInternal(const Context& cntx, 
       CallChangeCallbacks(cntx.db_index, bucket_set);
 
       // Repeat the change callbacks if the target set changed
+      // The operation is finite as eventually all target buckets will be visited
       consistent = (bucket_set == db.prime.CVCUponInsert(key));
     }
   }


### PR DESCRIPTION
Fixes #7245 

Repeat on change callbacks if the insertion bucket set changed while calling them. 

This can happen because we don't acquire the mutex ahead now and re-acquire it for every bucket, meaning that CallOnChangeCallbacks now can have _multiple suspension points_ during which various stuff can happen (like buckets filling up, etc.)