### PR TITLE
feat(tools): add Copilot backend, per-commit cache, and async refactor to release notes generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ clang-*
 third_party
 genfiles/*
 *.sublime-*
+.release_notes_cache/
 *.orig
 .tags
 !third_party/include/*

--- a/tools/release_notes_generator.py
+++ b/tools/release_notes_generator.py
@@ -15,17 +15,25 @@ The per-commit analyses are then aggregated into themed release notes
 
 Usage
 -----
+    # Anthropic backend (requires ANTHROPIC_API_KEY):
     export ANTHROPIC_API_KEY=...
     pip install -r tools/requirements.txt
     python tools/release_notes_generator.py v1.37.0..v1.38.0
     python tools/release_notes_generator.py v1.37.0..v1.38.0 --output-dir /tmp
     python tools/release_notes_generator.py HEAD~50..HEAD --max-parallel 4
+
+    # GitHub Copilot backend (uses Copilot CLI auth, no API key needed):
+    pip install github-copilot-sdk
+    python tools/release_notes_generator.py v1.37.0..v1.38.0 --backend copilot
 """
 
 from __future__ import annotations
 
 import argparse
-import concurrent.futures
+import asyncio
+import hashlib
+import json
+import logging
 import os
 import re
 import subprocess
@@ -46,26 +54,82 @@ except ImportError:  # allow --dry-run without the SDK installed
         return None
 
 
-MODEL = "claude-sonnet-4-6"
+try:
+    from copilot import CopilotClient as _CopilotClient
+    from copilot.generated.session_events import (
+        AssistantMessageData as _CopilotAssistantMessageData,
+    )
+    from copilot.generated.session_events import (
+        AssistantStreamingDeltaData as _CopilotAssistantStreamingDeltaData,
+    )
+    from copilot.generated.session_events import AssistantUsageData as _CopilotAssistantUsageData
+    from copilot.session import PermissionHandler as _CopilotPermissionHandler
+
+    copilot_sdk_available = True
+except ImportError:
+    _CopilotClient = None  # type: ignore[assignment,misc]
+    _CopilotAssistantMessageData = None  # type: ignore[assignment]
+    _CopilotAssistantStreamingDeltaData = None  # type: ignore[assignment]
+    _CopilotAssistantUsageData = None  # type: ignore[assignment]
+    _CopilotPermissionHandler = None  # type: ignore[assignment]
+    copilot_sdk_available = False
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Model identifiers differ between backends:
+# - Anthropic SDK uses the raw model slug.
+# - GitHub Copilot SDK uses its own model aliases.
+ANTHROPIC_MODEL = "claude-sonnet-4-6"
+ANTHROPIC_CACHE_CONTROL = {"type": "ephemeral"}
+
+# Copilot model alias -- use the ID from `CopilotClient.list_models()`.
+# Available models as of 2026-05 (billing multiplier vs GPT-4.1 baseline):
+#   claude-sonnet-4.6   -- Claude Sonnet 4.6   200K ctx  1.0×  (recommended)
+#   claude-opus-4.6     -- Claude Opus 4.6     200K ctx  3.0×  (highest quality)
+#   gpt-5.3-codex       -- GPT-5.3-Codex       400K ctx  1.0×
+COPILOT_MODEL = "claude-sonnet-4.6"
 
 # Bound the size of diff context per commit. Massive diffs (vendored deps,
 # generated files, large refactors) would otherwise dominate the context window
-# without adding signal. We keep enough to characterize the change.
+# without adding signal.
 MAX_DIFF_BYTES_PER_COMMIT = 40_000
-MAX_DIFF_LINES_PER_FILE = 200
+MAX_DIFF_LINES_PER_FILE = 400
 MAX_FILES_LISTED = 50
 
 DEFAULT_PARALLEL = 8
 
 # Built-in SDK retries with exponential backoff for 429 / 529 / 5xx / network errors.
-# The SDK respects the `retry-after` header on rate limits, so most rate-limit
-# bursts are absorbed transparently.
 SDK_MAX_RETRIES = 8
 
-# Outer retry rounds for commits that still fail after SDK-level retries are
-# exhausted. Each round halves concurrency and waits longer before retrying.
+# Outer retry rounds for commits that still fail after SDK-level retries are exhausted.
 DEFAULT_RETRY_ROUNDS = 3
 
+# Per-commit analysis token budgets.
+# Anthropic's constrained structured-output decode converges faster, so 600 is enough.
+# JSON-in-text backends (Copilot etc.) need more headroom for the JSON envelope.
+ANALYZE_MAX_TOKENS_STRUCTURED = 600
+ANALYZE_MAX_TOKENS_JSON = 1000
+
+COMPOSE_MAX_TOKENS = 16_000
+COMPOSE_HEARTBEAT_S = 15
+COMPOSE_TOKEN_PROGRESS_INTERVAL = 250
+
+# How many consecutive all-failed commits before aborting a round early.
+FAIL_FAST_THRESHOLD = 5
+
+CACHE_SUBDIR = ".release_notes_cache"
+PROMOTE_THEME_MIN_SIZE = 3
+
+logger = logging.getLogger(__name__)
+PR_RE = re.compile(r"\(#(\d+)\)\s*$")
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
 
 Category = Literal[
     "commands",
@@ -86,8 +150,13 @@ Category = Literal[
 
 class CommitAnalysis(BaseModel):
     category: Category = Field(
-        description="Single best-fitting category. Use 'internal' for refactors, "
-        "'ci' for build/test infrastructure, 'docs' for documentation-only changes."
+        description="Single best-fitting category. IMPORTANT: any commit that "
+        "primarily fixes a crash, use-after-free, memory corruption, data loss, "
+        "race condition, or other stability/correctness defect MUST be 'bugfix', "
+        "regardless of the subsystem it touches. Domain categories (search, "
+        "replication, cluster, tiering, …) are ONLY for new features, enhancements, "
+        "or improvements — not for fixes. Use 'internal' for refactors, 'ci' for "
+        "build/test infrastructure, 'docs' for documentation-only changes."
     )
     user_facing: bool = Field(
         description="True only if a Dragonfly operator/user can observe this "
@@ -95,8 +164,8 @@ class CommitAnalysis(BaseModel):
         "Bug fixes that change observable behavior ARE user-facing."
     )
     summary: str = Field(
-        description="One short sentence describing the user-visible change. "
-        "Empty string if not user-facing. Do not repeat the commit subject verbatim."
+        description="Up-to 5 sentences describing the user-visible change. "
+        "Single sentence if not user-facing. Do not repeat the commit subject verbatim."
     )
     impact: str = Field(
         default="",
@@ -120,6 +189,62 @@ class CommitAnalysis(BaseModel):
     )
 
 
+@dataclass
+class Commit:
+    sha: str
+    short_sha: str
+    subject: str
+    body: str
+    author: str
+    date: str
+    files_changed: list[str]
+    diff: str  # possibly truncated
+
+
+@dataclass
+class AnalyzedCommit:
+    commit: Commit
+    analysis: CommitAnalysis
+    pr_number: Optional[str]
+    from_cache: bool = False
+
+
+@dataclass
+class AnalysisStats:
+    total: int
+    succeeded_per_round: list[int]
+    failed: list[tuple[Commit, Exception]]
+    elapsed_s: float
+
+    @property
+    def total_succeeded(self) -> int:
+        return sum(self.succeeded_per_round)
+
+    @property
+    def all_processed(self) -> bool:
+        return not self.failed and self.total_succeeded == self.total
+
+
+@dataclass
+class _ComposeStats:
+    """Live streaming statistics exposed to the heartbeat loop via AnthropicBackend."""
+
+    output_tokens: Optional[int] = None
+    input_tokens: Optional[int] = None
+    reasoning_tokens: Optional[int] = None
+    text_chars: int = 0
+    text_chunks: int = 0
+    cache_read_input_tokens: Optional[int] = None
+    cache_creation_input_tokens: Optional[int] = None
+    cache_read_tokens: Optional[int] = None
+    cache_write_tokens: Optional[int] = None
+    response_bytes: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Prompts
+# ---------------------------------------------------------------------------
+
 ANALYZE_SYSTEM_PROMPT = """\
 You are analyzing a single commit from the Dragonfly database project for inclusion
 in user-facing release notes. Dragonfly is a Redis/Memcached-compatible in-memory
@@ -130,19 +255,27 @@ truncated) unified diff. Use the diff as the source of truth -- commit messages
 sometimes overstate or understate what actually changed.
 
 Categories:
-- commands     : new/changed Redis or Memcached commands, options, or behavior
-- performance  : measurable performance/memory/latency improvements
-- replication  : replication, journal, snapshot/saving, RDB
-- search       : full-text/vector search module
-- cluster      : cluster mode
-- protocol     : RESP2/RESP3/Memcached protocol changes
-- security     : ACL, TLS, authentication
-- cloud        : AWS/GCP/S3 integration
-- tiering      : disk-backed/tiered storage
-- bugfix       : user-visible bug fix not fitting a category above
+- commands     : new/changed Redis or Memcached commands, options, or behavior (features only)
+- performance  : measurable performance/memory/latency improvements (features only)
+- replication  : replication, journal, snapshot/saving, RDB (features only)
+- search       : full-text/vector search module (features only)
+- cluster      : cluster mode (features only)
+- protocol     : RESP2/RESP3/Memcached protocol changes (features only)
+- security     : ACL, TLS, authentication (features only)
+- cloud        : AWS/GCP/S3 integration (features only)
+- tiering      : disk-backed/tiered storage (features only)
+- bugfix       : ANY user-visible bug fix -- crashes, use-after-free, data corruption,
+                 race conditions, memory safety issues, wrong results, starvation,
+                 or other stability/correctness defects IN ANY SUBSYSTEM.
+                 When in doubt between a domain category and bugfix, pick bugfix.
 - internal     : refactor, cleanup, dep bump, code-style -- NOT user-facing
 - ci           : CI/build/test infra -- NOT user-facing
 - docs         : documentation-only -- NOT user-facing
+
+CRITICAL RULE: If the primary purpose of the commit is to fix something that was
+broken (crash, wrong behavior, memory error, data loss, race), use 'bugfix'.
+Domain categories (commands, search, replication, …) are reserved for commits
+whose primary purpose is to ADD or IMPROVE functionality.
 
 Be conservative about user_facing. If the diff only touches tests/, .github/,
 docs/, *.md, build files, or is a pure refactor with no behavior change,
@@ -155,6 +288,18 @@ theme='memory tracking' if it's part of a broader memory-tracking effort.
 Use the diff to identify shared subsystems. If nothing distinctive, leave empty.
 """
 
+_ANALYZE_JSON_SUFFIX = """\
+Respond with a JSON object only (no other text), matching this exact shape:
+{
+  "category": "<one of the category values listed above>",
+  "user_facing": <true|false>,
+  "summary": "<up to five sentences, or single sentence if not user-facing>",
+  "impact": "<quantified impact if explicitly mentioned, else empty string>",
+  "theme": "<short cross-cutting product theme noun phrase, or empty string>"
+}"""
+
+# Used by non-Anthropic backends that cannot do constrained structured-output decoding.
+ANALYZE_SYSTEM_PROMPT_JSON = ANALYZE_SYSTEM_PROMPT + _ANALYZE_JSON_SUFFIX
 
 COMPOSE_SYSTEM_PROMPT = """\
 You are a senior technical writer producing release notes for Dragonfly,
@@ -163,12 +308,15 @@ and operators upgrading their Dragonfly deployment.
 
 Output rules:
 
-OPENING -- write a substantive 3-5 sentence headline paragraph (or a short
-paragraph + 2-3 lead bullets) characterizing the release. Mention the dominant
-themes, the most notable improvements, and any major user-facing additions.
-This is the tl;dr -- a reader who only reads the opening should walk away
-knowing what changed and whether the upgrade matters to them. Don't just list
-section names; tell a short story.
+TITLE -- The very first line must be a Markdown H1 title derived from the commit
+range, if possible.
+
+OPENING -- immediately after the title, write a substantive 3-5 sentence headline
+paragraph (or a short paragraph + 2-3 lead bullets) characterizing the release.
+Mention the dominant themes, the most notable improvements, and any major
+user-facing additions. This is the tl;dr -- a reader who only reads the opening
+should walk away knowing what changed and whether the upgrade matters to them.
+Don't just list section names; tell a short story.
 
 SECTIONS -- Group changes under these BASE section headers (omit any section
 that has no commits):
@@ -193,6 +341,9 @@ cross-cutting themes that span 3+ commits. For each promoted theme:
   major theme).
 - Each commit listed under a promoted theme MUST appear ONLY in its themed
   section, NOT also in its base-category section. Do not duplicate.
+- NEVER move commits whose category is `bugfix` into themed sections. All
+    `[bugfix]` commits MUST remain under `## Bug Fixes` even if they have a
+    non-empty theme.
 
 BULLETS -- Within each section: one short sentence + the PR/commit reference in
 parentheses, e.g. "Improved snapshot loading throughput (#7070)". Quantified
@@ -208,42 +359,443 @@ INVARIANTS:
 """
 
 
-@dataclass
-class Commit:
-    sha: str
-    short_sha: str
-    subject: str
-    body: str
-    author: str
-    date: str
-    files_changed: list[str]
-    diff: str  # possibly truncated
+# ---------------------------------------------------------------------------
+# JSON parsing utility (used by non-Anthropic backends)
+# ---------------------------------------------------------------------------
 
 
-@dataclass
-class AnalyzedCommit:
-    commit: Commit
-    analysis: CommitAnalysis
-    pr_number: Optional[str]
+def _parse_commit_analysis_json(text: str) -> CommitAnalysis:
+    """Parse a CommitAnalysis from a JSON string produced by a text-only backend."""
+    text = text.strip()
+    text = re.sub(r"^```(?:json)?\s*", "", text)
+    text = re.sub(r"\s*```$", "", text)
+    match = re.search(r"\{.*\}", text, re.DOTALL)
+    if not match:
+        raise ValueError(f"No JSON object found in LLM response: {text[:300]}")
+    data = json.loads(match.group())
+    return CommitAnalysis(
+        category=data["category"],
+        user_facing=bool(data["user_facing"]),
+        summary=data.get("summary", ""),
+        impact=data.get("impact", ""),
+        theme=data.get("theme", ""),
+    )
 
 
-@dataclass
-class AnalysisStats:
-    total: int  # total commits in range
-    succeeded_per_round: list[int]  # how many landed in each round
-    failed: list[tuple[Commit, Exception]]  # final unrecoverable failures
-    elapsed_s: float
+def _dedupe_highlights_section(notes: str) -> str:
+    """Keep only the first '## Highlights' section.
 
-    @property
-    def total_succeeded(self) -> int:
-        return sum(self.succeeded_per_round)
+    Copilot occasionally emits a second placeholder Highlights section. Drop later
+    duplicates to keep the output stable.
+    """
+    lines = notes.splitlines()
+    out: list[str] = []
+    seen_highlights = False
+    skip_duplicate = False
 
-    @property
-    def all_processed(self) -> bool:
-        return not self.failed and self.total_succeeded == self.total
+    for line in lines:
+        if line == "## Highlights":
+            if seen_highlights:
+                skip_duplicate = True
+                continue
+            seen_highlights = True
+        elif skip_duplicate and line.startswith("## "):
+            skip_duplicate = False
+
+        if not skip_duplicate:
+            out.append(line)
+
+    return "\n".join(out).rstrip() + "\n"
 
 
-PR_RE = re.compile(r"\(#(\d+)\)\s*$")
+def _strip_leading_preamble(notes: str) -> str:
+    """Drop any non-Markdown preamble that appears before the first H1 title.
+
+    Some backends occasionally prepend confirmations like "Here are the release
+    notes:" despite the prompt asking for Markdown-only output. If an H1 exists,
+    keep the document starting from that title.
+    """
+    match = re.search(r"(?m)^# ", notes)
+    if not match:
+        return notes
+    return notes[match.start() :].lstrip()
+
+
+# ---------------------------------------------------------------------------
+# LLM backends
+# ---------------------------------------------------------------------------
+
+
+class LLMBackend:
+    """Minimal async LLM interface. Subclasses implement analyze_commit and call."""
+
+    name: str = "base"
+    model: str
+    analyze_system_prompt: str
+    analyze_max_tokens: int
+
+    async def analyze_commit(self, user: str) -> CommitAnalysis:
+        raise NotImplementedError
+
+    async def call(self, system: str, user: str, max_tokens: int) -> str:
+        raise NotImplementedError
+
+    async def compose(self, system: str, user: str, max_tokens: int) -> str:
+        """Compose release notes. Backends may override for streaming / progress reporting."""
+        return await self.call(system, user, max_tokens)
+
+    def compose_progress_status(self) -> str:
+        """Return a comma-prefixed status string for the heartbeat line, or ''."""
+        return ""
+
+    def post_process_notes(self, notes: str) -> str:
+        """Apply any backend-specific fixes to the composed release notes."""
+        return notes
+
+    def notes_filename(self, safe_range: str) -> str:
+        raise NotImplementedError
+
+
+class AnthropicBackend(LLMBackend):
+    """Thin async wrapper around the synchronous Anthropic SDK."""
+
+    name = "anthropic"
+    model = ANTHROPIC_MODEL
+    analyze_system_prompt = ANALYZE_SYSTEM_PROMPT
+    analyze_max_tokens = ANALYZE_MAX_TOKENS_STRUCTURED
+
+    def __init__(self, client: "anthropic.Anthropic") -> None:
+        self._client = client
+        self._compose_stats = _ComposeStats()
+
+    @staticmethod
+    def _opt_int(obj, attr: str) -> Optional[int]:
+        val = getattr(obj, attr, None)
+        return int(val) if val is not None else None
+
+    @staticmethod
+    def _extract_text_blocks(response) -> str:
+        parts = [b.text for b in response.content if b.type == "text"]
+        if not parts:
+            raise RuntimeError(
+                f"response contained no text blocks "
+                f"(stop_reason={response.stop_reason}, "
+                f"block_types={[b.type for b in response.content]})"
+            )
+        return "\n".join(parts)
+
+    async def analyze_commit(self, user: str) -> CommitAnalysis:
+        response = await asyncio.to_thread(
+            self._client.messages.parse,
+            model=self.model,
+            max_tokens=self.analyze_max_tokens,
+            system=self.analyze_system_prompt,
+            messages=[{"role": "user", "content": user}],
+            output_format=CommitAnalysis,
+        )
+        return response.parsed_output
+
+    async def call(self, system: str, user: str, max_tokens: int) -> str:
+        response = await asyncio.to_thread(
+            self._client.messages.create,
+            model=self.model,
+            max_tokens=max_tokens,
+            cache_control=ANTHROPIC_CACHE_CONTROL,
+            system=system,
+            messages=[{"role": "user", "content": user}],
+        )
+        logger.info(
+            "anthropic_cache context=call cache_read=%s cache_creation=%s input=%s output=%s",
+            self._opt_int(response.usage, "cache_read_input_tokens"),
+            self._opt_int(response.usage, "cache_creation_input_tokens"),
+            self._opt_int(response.usage, "input_tokens"),
+            self._opt_int(response.usage, "output_tokens"),
+        )
+        return self._extract_text_blocks(response)
+
+    def _sync_stream(self, system: str, user: str, max_tokens: int) -> str:
+        """Synchronous streaming compose; updates self._compose_stats as tokens arrive."""
+        stats = _ComposeStats()
+        self._compose_stats = stats  # exposed to compose_progress_status (read by heartbeat)
+        last_progress_logged = -1
+
+        with self._client.messages.stream(
+            model=self.model,
+            max_tokens=max_tokens,
+            cache_control=ANTHROPIC_CACHE_CONTROL,
+            system=system,
+            messages=[{"role": "user", "content": user}],
+        ) as stream:
+            for event in stream:
+                snapshot_usage = getattr(stream.current_message_snapshot, "usage", None)
+                if snapshot_usage is not None:
+                    if (v := self._opt_int(snapshot_usage, "output_tokens")) is not None:
+                        stats.output_tokens = v
+                    if (v := self._opt_int(snapshot_usage, "cache_read_input_tokens")) is not None:
+                        stats.cache_read_input_tokens = v
+                    if (
+                        v := self._opt_int(snapshot_usage, "cache_creation_input_tokens")
+                    ) is not None:
+                        stats.cache_creation_input_tokens = v
+
+                if (
+                    event.type == "content_block_delta"
+                    and getattr(event.delta, "type", None) == "text_delta"
+                ):
+                    stats.text_chars += len(getattr(event.delta, "text", ""))
+                    stats.text_chunks += 1
+
+                if event.type == "message_delta":
+                    out_tok = self._opt_int(getattr(event, "usage", None), "output_tokens")
+                    if (
+                        out_tok is not None
+                        and out_tok >= last_progress_logged + COMPOSE_TOKEN_PROGRESS_INTERVAL
+                    ):
+                        logger.info(
+                            "compose_progress backend=%s output_tokens=%s/%s",
+                            self.name,
+                            out_tok,
+                            max_tokens,
+                        )
+                        last_progress_logged = out_tok
+
+            final = stream.get_final_message()
+
+        if (v := self._opt_int(final.usage, "output_tokens")) is not None:
+            stats.output_tokens = v
+        stats.cache_read_input_tokens = self._opt_int(final.usage, "cache_read_input_tokens")
+        stats.cache_creation_input_tokens = self._opt_int(
+            final.usage, "cache_creation_input_tokens"
+        )
+        logger.info(
+            "anthropic_cache context=compose cache_read=%s cache_creation=%s input=%s output=%s",
+            stats.cache_read_input_tokens,
+            stats.cache_creation_input_tokens,
+            self._opt_int(final.usage, "input_tokens"),
+            stats.output_tokens,
+        )
+        return self._extract_text_blocks(final)
+
+    async def compose(self, system: str, user: str, max_tokens: int) -> str:
+        return await asyncio.to_thread(self._sync_stream, system, user, max_tokens)
+
+    def compose_progress_status(self) -> str:
+        s = self._compose_stats
+        parts = []
+        if s.output_tokens is not None:
+            parts.append(f"output_tokens={s.output_tokens}")
+        if s.text_chars > 0:
+            parts.append(f"text_chars={s.text_chars}")
+            parts.append(f"text_chunks={s.text_chunks}")
+        if s.cache_read_input_tokens not in (None, 0):
+            parts.append(f"cache_read_input_tokens={s.cache_read_input_tokens}")
+        if s.cache_creation_input_tokens not in (None, 0):
+            parts.append(f"cache_creation_input_tokens={s.cache_creation_input_tokens}")
+        return (", " + ", ".join(parts)) if parts else ""
+
+    def notes_filename(self, safe_range: str) -> str:
+        return f"release_notes_{safe_range}.md"
+
+
+class CopilotBackend(LLMBackend):
+    """Backend that routes requests through the GitHub Copilot SDK.
+
+    Authentication is handled by the GitHub Copilot CLI -- no API key required.
+    """
+
+    name = "copilot"
+    model = COPILOT_MODEL
+    analyze_system_prompt = ANALYZE_SYSTEM_PROMPT_JSON
+    analyze_max_tokens = ANALYZE_MAX_TOKENS_JSON
+
+    def __init__(self) -> None:
+        self._compose_stats = _ComposeStats()
+
+    @staticmethod
+    def _opt_int(value: object) -> Optional[int]:
+        return int(value) if value is not None else None
+
+    async def _call_with_stats(
+        self,
+        system: str,
+        user: str,
+        max_tokens: int,
+        *,
+        context: str,
+        track_progress: bool,
+    ) -> str:
+        # Budget ~120 ms per output token, with a 120 s floor for small calls.
+        timeout_s = max(120.0, max_tokens * 0.12)
+        usage_event = None
+        stats = _ComposeStats()
+        if track_progress:
+            self._compose_stats = stats
+
+        def on_event(event) -> None:
+            nonlocal usage_event
+            data = event.data
+            if _CopilotAssistantStreamingDeltaData is not None and isinstance(
+                data, _CopilotAssistantStreamingDeltaData
+            ):
+                if track_progress:
+                    stats.response_bytes = int(data.total_response_size_bytes)
+                return
+
+            if _CopilotAssistantUsageData is not None and isinstance(
+                data, _CopilotAssistantUsageData
+            ):
+                usage_event = data
+                if track_progress:
+                    stats.input_tokens = self._opt_int(data.input_tokens)
+                    stats.output_tokens = self._opt_int(data.output_tokens)
+                    stats.reasoning_tokens = self._opt_int(data.reasoning_tokens)
+                    stats.cache_read_tokens = self._opt_int(data.cache_read_tokens)
+                    stats.cache_write_tokens = self._opt_int(data.cache_write_tokens)
+                return
+
+            if (
+                track_progress
+                and _CopilotAssistantMessageData is not None
+                and isinstance(data, _CopilotAssistantMessageData)
+            ):
+                if data.content:
+                    stats.text_chars = len(data.content)
+                if data.output_tokens is not None:
+                    stats.output_tokens = int(data.output_tokens)
+
+        async with _CopilotClient() as client:
+            async with await client.create_session(
+                on_permission_request=_CopilotPermissionHandler.approve_all,
+                model=self.model,
+                system_message={"content": system},
+                infinite_sessions={"enabled": False},
+                on_event=on_event,
+                streaming=track_progress,
+            ) as session:
+                response = await session.send_and_wait(user, timeout=timeout_s)
+
+        if response is None or response.data is None:
+            raise RuntimeError("Empty response from Copilot backend")
+        text = response.data.content
+        if not text:
+            raise RuntimeError("Copilot backend returned empty text content")
+
+        if track_progress:
+            stats.text_chars = len(text)
+            stats.text_chunks = max(stats.text_chunks, 1 if text else 0)
+
+        if usage_event is not None:
+            logger.info(
+                "copilot_usage context=%s model=%s input_tokens=%s output_tokens=%s "
+                "reasoning_tokens=%s cache_read_tokens=%s cache_write_tokens=%s duration=%s",
+                context,
+                usage_event.model,
+                self._opt_int(usage_event.input_tokens),
+                self._opt_int(usage_event.output_tokens),
+                self._opt_int(usage_event.reasoning_tokens),
+                self._opt_int(usage_event.cache_read_tokens),
+                self._opt_int(usage_event.cache_write_tokens),
+                usage_event.duration,
+            )
+        else:
+            logger.info("copilot_usage context=%s unavailable=true", context)
+
+        return text
+
+    async def analyze_commit(self, user: str) -> CommitAnalysis:
+        text = await self._call_with_stats(
+            self.analyze_system_prompt,
+            user,
+            self.analyze_max_tokens,
+            context="analyze",
+            track_progress=False,
+        )
+        return _parse_commit_analysis_json(text)
+
+    async def call(self, system: str, user: str, max_tokens: int) -> str:
+        return await self._call_with_stats(
+            system,
+            user,
+            max_tokens,
+            context="call",
+            track_progress=False,
+        )
+
+    async def compose(self, system: str, user: str, max_tokens: int) -> str:
+        return await self._call_with_stats(
+            system,
+            user,
+            max_tokens,
+            context="compose",
+            track_progress=True,
+        )
+
+    def compose_progress_status(self) -> str:
+        s = self._compose_stats
+        parts = []
+        if s.output_tokens is not None:
+            parts.append(f"output_tokens={s.output_tokens}")
+        if s.input_tokens is not None:
+            parts.append(f"input_tokens={s.input_tokens}")
+        if s.reasoning_tokens not in (None, 0):
+            parts.append(f"reasoning_tokens={s.reasoning_tokens}")
+        if s.response_bytes > 0:
+            parts.append(f"response_bytes={s.response_bytes}")
+        if s.text_chars > 0:
+            parts.append(f"text_chars={s.text_chars}")
+        if s.cache_read_tokens not in (None, 0):
+            parts.append(f"cache_read_tokens={s.cache_read_tokens}")
+        if s.cache_write_tokens not in (None, 0):
+            parts.append(f"cache_write_tokens={s.cache_write_tokens}")
+        return (", " + ", ".join(parts)) if parts else ""
+
+    def post_process_notes(self, notes: str) -> str:
+        return _dedupe_highlights_section(_strip_leading_preamble(notes))
+
+    def notes_filename(self, safe_range: str) -> str:
+        return f"release_notes_copilot_{safe_range}.md"
+
+
+# ---------------------------------------------------------------------------
+# Disk cache for per-commit analysis results
+# ---------------------------------------------------------------------------
+
+
+def _make_cache_key(backend: LLMBackend, sha: str) -> str:
+    """Stable SHA-256 fingerprint covering all inputs that affect the result."""
+    h = hashlib.sha256()
+    for part in (
+        backend.name,
+        backend.model,
+        str(backend.analyze_max_tokens),
+        backend.analyze_system_prompt,
+        sha,
+    ):
+        h.update(part.encode())
+    return h.hexdigest()
+
+
+def _cache_load(cache_dir: Path, key: str) -> Optional[CommitAnalysis]:
+    path = cache_dir / f"{key}.json"
+    if not path.exists():
+        return None
+    try:
+        return CommitAnalysis(**json.loads(path.read_text(encoding="utf-8")))
+    except Exception:
+        return None  # treat corrupt entries as a miss
+
+
+def _cache_save(cache_dir: Path, key: str, analysis: CommitAnalysis) -> None:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    (cache_dir / f"{key}.json").write_text(
+        json.dumps(analysis.model_dump(), indent=2),
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Git / commit parsing
+# ---------------------------------------------------------------------------
 
 
 def run_git(args: list[str], cwd: Path) -> str:
@@ -255,48 +807,7 @@ def run_git(args: list[str], cwd: Path) -> str:
     ).stdout
 
 
-def parse_commits(commit_range: str, repo: Path) -> list[Commit]:
-    # \x1f = unit separator between fields, \x1e = record separator between commits.
-    # Safer than newlines because commit bodies contain newlines.
-    fmt = "%H%x1f%h%x1f%s%x1f%an%x1f%aI%x1f%b%x1e"
-    raw = run_git(
-        ["log", f"--format={fmt}", "--no-merges", commit_range],
-        repo,
-    )
-    commits: list[Commit] = []
-    for entry in raw.split("\x1e"):
-        entry = entry.strip("\n").strip()
-        if not entry:
-            continue
-        parts = entry.split("\x1f")
-        if len(parts) < 6:
-            continue
-        sha, short_sha, subject, author, date, body = parts[:6]
-
-        files_changed = (
-            run_git(["show", "--name-only", "--format=", sha], repo).strip().splitlines()
-        )
-
-        diff = _truncate_diff(run_git(["show", "--format=", "--no-color", sha], repo))
-
-        commits.append(
-            Commit(
-                sha=sha,
-                short_sha=short_sha,
-                subject=subject,
-                body=body.strip(),
-                author=author,
-                date=date,
-                files_changed=files_changed,
-                diff=diff,
-            )
-        )
-    return commits
-
-
 def _truncate_diff(diff: str) -> str:
-    # Split on per-file headers. The first chunk before any "diff --git" is
-    # usually empty.
     chunks = re.split(r"^diff --git ", diff, flags=re.MULTILINE)
     out: list[str] = []
     total = 0
@@ -321,40 +832,50 @@ def _truncate_diff(diff: str) -> str:
     return "\n".join(out)
 
 
+def parse_commits(commit_range: str, repo: Path) -> list[Commit]:
+    # \x1f = unit separator between fields, \x1e = record separator between commits.
+    fmt = "%H%x1f%h%x1f%s%x1f%an%x1f%aI%x1f%b%x1e"
+    raw = run_git(["log", f"--format={fmt}", "--no-merges", commit_range], repo)
+    commits: list[Commit] = []
+    for entry in raw.split("\x1e"):
+        entry = entry.strip("\n").strip()
+        if not entry:
+            continue
+        parts = entry.split("\x1f")
+        if len(parts) < 6:
+            continue
+        sha, short_sha, subject, author, date, body = parts[:6]
+        files_changed = (
+            run_git(["show", "--name-only", "--format=", sha], repo).strip().splitlines()
+        )
+        diff = _truncate_diff(run_git(["show", "--format=", "--no-color", sha], repo))
+        commits.append(
+            Commit(
+                sha=sha,
+                short_sha=short_sha,
+                subject=subject,
+                body=body.strip(),
+                author=author,
+                date=date,
+                files_changed=files_changed,
+                diff=diff,
+            )
+        )
+    return commits
+
+
 def extract_pr_number(subject: str) -> Optional[str]:
     m = PR_RE.search(subject)
     return m.group(1) if m else None
 
 
-def analyze_commit(client: anthropic.Anthropic, commit: Commit) -> AnalyzedCommit:
-    files_block = "\n".join(f"  {f}" for f in commit.files_changed[:MAX_FILES_LISTED])
-    if len(commit.files_changed) > MAX_FILES_LISTED:
-        files_block += f"\n  ... +{len(commit.files_changed) - MAX_FILES_LISTED} more"
-
-    user_content = (
-        f"Commit subject: {commit.subject}\n"
-        f"Commit body:\n{commit.body or '(none)'}\n\n"
-        f"Files changed:\n{files_block}\n\n"
-        f"Diff (possibly truncated):\n{commit.diff}"
-    )
-
-    response = client.messages.parse(
-        model=MODEL,
-        max_tokens=600,
-        system=ANALYZE_SYSTEM_PROMPT,
-        messages=[{"role": "user", "content": user_content}],
-        output_format=CommitAnalysis,
-    )
-    return AnalyzedCommit(
-        commit=commit,
-        analysis=response.parsed_output,
-        pr_number=extract_pr_number(commit.subject),
-    )
+# ---------------------------------------------------------------------------
+# Error helpers
+# ---------------------------------------------------------------------------
 
 
 def _short_error(e: Exception) -> str:
-    """Compact one-liner for an exception. Keeps logs scannable when the SDK
-    surfaces a multi-line JSON error body (typical for 429s)."""
+    """Compact one-liner for an exception. Keeps logs scannable for multi-line SDK errors."""
     name = type(e).__name__
     if anthropic is not None and isinstance(e, anthropic.RateLimitError):
         return (
@@ -366,52 +887,157 @@ def _short_error(e: Exception) -> str:
     return f"{name}: {msg}"
 
 
-def _analyze_round(
-    client: "anthropic.Anthropic",
+def _is_fatal_error(e: Exception) -> bool:
+    """True for errors that won't resolve with retries (auth / model-not-available)."""
+    msg = str(e)
+    if "not available" in msg or "JSON-RPC Error" in msg:
+        return True
+    if "authentication" in msg.lower() or "unauthorized" in msg.lower():
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Per-commit analysis
+# ---------------------------------------------------------------------------
+
+
+def _build_commit_user_content(commit: Commit) -> str:
+    files_block = "\n".join(f"  {f}" for f in commit.files_changed[:MAX_FILES_LISTED])
+    if len(commit.files_changed) > MAX_FILES_LISTED:
+        files_block += f"\n  ... +{len(commit.files_changed) - MAX_FILES_LISTED} more"
+    return (
+        f"Commit subject: {commit.subject}\n"
+        f"Commit body:\n{commit.body or '(none)'}\n\n"
+        f"Files changed:\n{files_block}\n\n"
+        f"Diff (possibly truncated):\n{commit.diff}"
+    )
+
+
+async def _analyze_commit_async(
+    backend: LLMBackend, commit: Commit, cache_dir: Optional[Path] = None
+) -> AnalyzedCommit:
+    """Analyze a single commit via backend, with optional disk caching.
+
+    The cache key covers backend name, model, analyze_max_tokens, system prompt,
+    and commit SHA -- so any change to prompts or model busts the cache.
+    """
+    cache_key = _make_cache_key(backend, commit.sha) if cache_dir is not None else None
+
+    if cache_key is not None:
+        cached = _cache_load(cache_dir, cache_key)
+        if cached is not None:
+            logger.info(
+                "commit_analysis cache_hit backend=%s sha=%s subject=%s analysis=%s",
+                backend.name,
+                commit.short_sha,
+                json.dumps(commit.subject),
+                cached.model_dump_json(),
+            )
+            return AnalyzedCommit(
+                commit=commit,
+                analysis=cached,
+                pr_number=extract_pr_number(commit.subject),
+                from_cache=True,
+            )
+
+    analysis = await backend.analyze_commit(_build_commit_user_content(commit))
+
+    logger.info(
+        "commit_analysis backend=%s sha=%s subject=%s analysis=%s",
+        backend.name,
+        commit.short_sha,
+        json.dumps(commit.subject),
+        analysis.model_dump_json(),
+    )
+
+    if cache_key is not None:
+        _cache_save(cache_dir, cache_key, analysis)
+
+    return AnalyzedCommit(
+        commit=commit,
+        analysis=analysis,
+        pr_number=extract_pr_number(commit.subject),
+        from_cache=False,
+    )
+
+
+async def _analyze_round(
+    backend: LLMBackend,
     commits: list[Commit],
     parallel: int,
     round_idx: int,
     is_last_round: bool,
+    cache_dir: Optional[Path] = None,
 ) -> tuple[list[AnalyzedCommit], list[tuple[Commit, Exception]]]:
-    """Run one parallel pass over `commits`.
+    """Run one async parallel pass over commits.
 
     Status legend in the per-commit log:
       OK         -- succeeded on first round
       RECOVERED  -- succeeded on a retry round (round_idx > 0)
-      FAIL       -- failed; will be retried in the next round (or permanent if last round)
+      FAIL       -- failed; will be retried next round (or permanent if last round)
     """
     succeeded: list[AnalyzedCommit] = []
     failed: list[tuple[Commit, Exception]] = []
     label = f"r{round_idx + 1}"
     ok_tag = "OK       " if round_idx == 0 else "RECOVERED"
     fail_tag = "FAIL (PERMANENT)" if is_last_round else "FAIL (will retry)"
+    completed = 0
+    abort_event = asyncio.Event()
+    lock = asyncio.Lock()
+    semaphore = asyncio.Semaphore(parallel)
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=parallel) as pool:
-        futures = {pool.submit(analyze_commit, client, c): c for c in commits}
-        for i, fut in enumerate(concurrent.futures.as_completed(futures), 1):
-            commit = futures[fut]
+    async def analyze_one(commit: Commit) -> None:
+        nonlocal completed
+        if abort_event.is_set():
+            return  # fast path: skip without consuming the semaphore slot
+        async with semaphore:
+            if abort_event.is_set():
+                return
             try:
-                succeeded.append(fut.result())
-                print(
-                    f"  {label} [{i}/{len(commits)}] {ok_tag} {commit.short_sha} {commit.subject}"
-                )
+                result = await _analyze_commit_async(backend, commit, cache_dir)
+                async with lock:
+                    completed += 1
+                    succeeded.append(result)
+                    print(
+                        f"  {label} [{completed}/{len(commits)}] {ok_tag} "
+                        f"{commit.short_sha} {commit.subject}"
+                    )
             except Exception as e:
-                failed.append((commit, e))
-                print(
-                    f"  {label} [{i}/{len(commits)}] {fail_tag} {commit.short_sha} "
-                    f"{commit.subject}\n      -> {_short_error(e)}",
-                    file=sys.stderr,
-                )
+                async with lock:
+                    completed += 1
+                    failed.append((commit, e))
+                    print(
+                        f"  {label} [{completed}/{len(commits)}] {fail_tag} "
+                        f"{commit.short_sha} {commit.subject}\n      -> {_short_error(e)}",
+                        file=sys.stderr,
+                    )
+                    if (
+                        not abort_event.is_set()
+                        and len(succeeded) == 0
+                        and len(failed) >= FAIL_FAST_THRESHOLD
+                        and all(_is_fatal_error(err) for _, err in failed)
+                    ):
+                        print(
+                            f"\nFATAL: first {len(failed)} commits all failed with a "
+                            f"non-retriable error -- aborting round early.\n"
+                            f"  Last error: {_short_error(e)}",
+                            file=sys.stderr,
+                        )
+                        abort_event.set()
+
+    await asyncio.gather(*[analyze_one(c) for c in commits])
     return succeeded, failed
 
 
-def analyze_with_retries(
-    client: "anthropic.Anthropic",
+async def analyze_with_retries(
+    backend: LLMBackend,
     commits: list[Commit],
     initial_parallel: int,
     retry_rounds: int,
+    cache_dir: Optional[Path] = None,
 ) -> tuple[list[AnalyzedCommit], AnalysisStats]:
-    """Run analysis with retry rounds for commits that fail SDK-level retries.
+    """Run analysis with retry rounds for commits that fail backend-level retries.
 
     Each retry round halves concurrency (to ease rate limits) and waits longer
     before kicking off, giving the API time to recover from sustained pressure.
@@ -423,12 +1049,13 @@ def analyze_with_retries(
     parallel = initial_parallel
     last_failures: list[tuple[Commit, Exception]] = []
     total_rounds = retry_rounds + 1
+
     for round_idx in range(total_rounds):
         is_last = round_idx == total_rounds - 1
         if round_idx == 0:
             print(
                 f"\n=== Round 1/{total_rounds}: analyzing {len(remaining)} commits "
-                f"(parallel={parallel}) ==="
+                f"(parallel={parallel}, backend={backend.name}) ==="
             )
         else:
             wait_s = 30 * round_idx
@@ -438,24 +1065,25 @@ def analyze_with_retries(
                 f"waiting {wait_s}s first) ===",
                 file=sys.stderr,
             )
-            time.sleep(wait_s)
+            await asyncio.sleep(wait_s)
 
-        succeeded, failed = _analyze_round(
-            client, remaining, parallel, round_idx, is_last_round=is_last
+        succeeded, failed = await _analyze_round(
+            backend, remaining, parallel, round_idx, is_last_round=is_last, cache_dir=cache_dir
         )
         all_succeeded.extend(succeeded)
         succeeded_per_round.append(len(succeeded))
 
-        # Round-end summary so the user sees the result of each pass at a glance.
         if round_idx == 0:
+            retry_note = " (will retry)" if failed and not is_last else ""
             print(
                 f"\n  Round 1 done: {len(succeeded)}/{len(remaining)} succeeded, "
-                f"{len(failed)} failed" + (" (will retry)" if failed and not is_last else "")
+                f"{len(failed)} failed{retry_note}"
             )
         else:
+            retry_note = " (will retry)" if failed and not is_last else ""
             print(
                 f"\n  Round {round_idx + 1} done: {len(succeeded)} RECOVERED, "
-                f"{len(failed)} still failing" + (" (will retry)" if failed and not is_last else "")
+                f"{len(failed)} still failing{retry_note}"
             )
 
         if not failed:
@@ -475,11 +1103,7 @@ def analyze_with_retries(
 
 
 def print_analysis_stats(stats: AnalysisStats, analyzed: list[AnalyzedCommit]) -> None:
-    """Print a clear summary of the analysis run.
-
-    Always called -- both on success (before composition) and on failure
-    (right before aborting). On failure the analyzed list may be partial.
-    """
+    """Print a clear summary of the analysis run."""
     print("\n" + "=" * 60)
     print("Analysis summary")
     print("=" * 60)
@@ -496,19 +1120,20 @@ def print_analysis_stats(stats: AnalysisStats, analyzed: list[AnalyzedCommit]) -
         for i, n in enumerate(stats.succeeded_per_round, 1):
             tag = "first try" if i == 1 else "RECOVERED via retry"
             print(f"    round {i}: {n:>4d} succeeded  ({tag})")
-
         recovered = sum(stats.succeeded_per_round[1:])
         if recovered > 0:
             print(f"\n  Retry rescued {recovered} commit(s) that failed initially.")
 
     if analyzed:
         by_category: dict[str, int] = {}
-        user_facing = 0
+        user_facing = cache_hits = 0
         for a in analyzed:
             by_category[a.analysis.category] = by_category.get(a.analysis.category, 0) + 1
-            if a.analysis.user_facing:
-                user_facing += 1
+            user_facing += a.analysis.user_facing
+            cache_hits += a.from_cache
         print(f"  User-facing commits:       {user_facing}/{len(analyzed)}")
+        print(f"  Cache hits:                {cache_hits}/{len(analyzed)}")
+        print(f"  Fresh backend calls:       {len(analyzed) - cache_hits}/{len(analyzed)}")
         print("  By category:")
         for cat in sorted(by_category, key=lambda c: -by_category[c]):
             print(f"    {cat:14s} {by_category[cat]}")
@@ -520,10 +1145,11 @@ def print_analysis_stats(stats: AnalysisStats, analyzed: list[AnalyzedCommit]) -
     print("=" * 60)
 
 
-PROMOTE_THEME_MIN_SIZE = 3
+# ---------------------------------------------------------------------------
+# Theme detection & release notes composition
+# ---------------------------------------------------------------------------
 
-# Predefined categories that already have their own section -- themes that
-# duplicate them shouldn't be promoted.
+# Predefined categories that already have their own section.
 _BASE_CATEGORY_NAMES = {
     "commands",
     "performance",
@@ -537,13 +1163,8 @@ _BASE_CATEGORY_NAMES = {
     "bugfix",
 }
 
-# Infrastructure themes that should NEVER be promoted to a release-notes
-# section -- readers want to know what they get in the product, not how it
-# was built. Even if the LLM tags a commit with one of these (or if a few
-# user-facing bug fixes legitimately share an infra theme), we keep them
-# inside the regular category sections instead.
+# Infrastructure themes that should never be promoted to a release-notes section.
 _INFRA_THEME_BLOCKLIST = {
-    # testing & fuzzing
     "fuzzing",
     "fuzz",
     "fuzz testing",
@@ -555,18 +1176,15 @@ _INFRA_THEME_BLOCKLIST = {
     "integration tests",
     "unit tests",
     "e2e tests",
-    # ci & build
     "ci",
     "ci/cd",
     "build",
     "build system",
     "packaging",
     "release",
-    # docs
     "docs",
     "documentation",
     "readme",
-    # cleanup & tooling
     "refactor",
     "refactoring",
     "cleanup",
@@ -585,7 +1203,7 @@ _INFRA_THEME_BLOCKLIST = {
     "dev tools",
     "developer tooling",
     "logging",
-    "log cleanup",  # internal logging -- not a user-visible feature
+    "log cleanup",
 }
 
 
@@ -593,27 +1211,82 @@ def detect_promoted_themes(
     user_facing: list[AnalyzedCommit],
     min_size: int = PROMOTE_THEME_MIN_SIZE,
 ) -> dict[str, list[AnalyzedCommit]]:
-    """Group user-facing commits by `theme` and return clusters with >= min_size.
-
-    Filtered out:
-    - empty themes
-    - themes that just duplicate a predefined category name (already have a section)
-    - infrastructure themes (fuzzing/testing/ci/docs/refactor/...) -- those don't
-      represent product value to readers of release notes
-    """
+    """Group user-facing non-bugfix commits by theme; return clusters with >= min_size."""
     buckets: dict[str, list[AnalyzedCommit]] = {}
     for a in user_facing:
+        if a.analysis.category == "bugfix":
+            continue  # bugfix commits must stay in Bug Fixes, never in theme sections
         theme = a.analysis.theme.strip().lower()
-        if not theme:
-            continue
-        if theme in _BASE_CATEGORY_NAMES or theme in _INFRA_THEME_BLOCKLIST:
+        if not theme or theme in _BASE_CATEGORY_NAMES or theme in _INFRA_THEME_BLOCKLIST:
             continue
         buckets.setdefault(theme, []).append(a)
     return {t: cs for t, cs in buckets.items() if len(cs) >= min_size}
 
 
-def compose_release_notes(
-    client: anthropic.Anthropic,
+def _build_composition_payload(
+    commit_range: str,
+    analyzed: list[AnalyzedCommit],
+    user_facing: list[AnalyzedCommit],
+    promoted: dict[str, list[AnalyzedCommit]],
+) -> str:
+    promoted_shas = {a.commit.sha for cs in promoted.values() for a in cs}
+
+    bullets: list[str] = []
+    for a in user_facing:
+        ref = f"#{a.pr_number}" if a.pr_number else a.commit.short_sha
+        impact = f" [{a.analysis.impact}]" if a.analysis.impact else ""
+        theme_tag = (
+            f" {{theme: {a.analysis.theme.strip().lower()}}}"
+            if a.commit.sha in promoted_shas
+            else ""
+        )
+        bullets.append(f"- [{a.analysis.category}]{impact} {a.analysis.summary} ({ref}){theme_tag}")
+
+    full_changelog = [f"- {a.commit.subject}" for a in analyzed]
+
+    promoted_block = ""
+    if promoted:
+        lines = ["", "Promoted themes (3+ commits each -- render as standalone sections):"]
+        for theme, cs in promoted.items():
+            refs = ", ".join(f"#{a.pr_number}" if a.pr_number else a.commit.short_sha for a in cs)
+            lines.append(f"  - {theme} ({len(cs)} commits): {refs}")
+        promoted_block = "\n".join(lines) + "\n"
+
+    return (
+        f"Range: {commit_range}\n"
+        f"Total commits: {len(analyzed)}\n"
+        f"User-facing commits: {len(user_facing)}\n"
+        f"{promoted_block}\n"
+        "Per-commit summaries (use these as the source of truth):\n"
+        + "\n".join(bullets)
+        + "\n\nFull commit list (for the appended What's Changed section):\n"
+        + "\n".join(full_changelog)
+    )
+
+
+async def _heartbeat_compose(
+    backend: LLMBackend,
+    compose_task: "asyncio.Task[str]",
+    user_facing_count: int,
+) -> str:
+    """Drive the compose task and print periodic progress lines until it finishes."""
+    started_at = time.monotonic()
+    while not compose_task.done():
+        elapsed_s = int(time.monotonic() - started_at)
+        status = backend.compose_progress_status()
+        print(
+            f"  Compose in progress: backend={backend.name}, elapsed={elapsed_s}s, "
+            f"user-facing commits={user_facing_count}{status} ..."
+        )
+        try:
+            await asyncio.wait_for(asyncio.shield(compose_task), timeout=COMPOSE_HEARTBEAT_S)
+        except TimeoutError:
+            continue
+    return await compose_task
+
+
+async def compose_release_notes(
+    backend: LLMBackend,
     analyzed: list[AnalyzedCommit],
     commit_range: str,
 ) -> str:
@@ -625,89 +1298,39 @@ def compose_release_notes(
         )
 
     promoted = detect_promoted_themes(user_facing)
-    promoted_shas = {a.commit.sha for cs in promoted.values() for a in cs}
-
     if promoted:
         print(
             f"  Promoted themes (>={PROMOTE_THEME_MIN_SIZE} commits each): "
             + ", ".join(f"{t}({len(cs)})" for t, cs in promoted.items())
         )
 
-    bullets: list[str] = []
-    for a in user_facing:
-        ref = f"#{a.pr_number}" if a.pr_number else a.commit.short_sha
-        impact = f" [{a.analysis.impact}]" if a.analysis.impact else ""
-        # Mark themed commits so the LLM places them only in the theme section.
-        # Use the SAME normalized form (lowercased + stripped) that
-        # detect_promoted_themes() bucketed by, so the per-commit tag and the
-        # "Promoted themes" header agree byte-for-byte and the LLM doesn't see
-        # them as distinct themes.
-        if a.commit.sha in promoted_shas:
-            theme_key = a.analysis.theme.strip().lower()
-            theme_tag = f" {{theme: {theme_key}}}"
-        else:
-            theme_tag = ""
-        bullets.append(f"- [{a.analysis.category}]{impact} {a.analysis.summary} ({ref}){theme_tag}")
-
-    full_changelog = [f"- {a.commit.subject}" for a in analyzed]
-
-    promoted_block = ""
-    if promoted:
-        lines = ["", "Promoted themes (3+ commits each -- render as standalone sections):"]
-        for theme, cs in promoted.items():
-            # `theme` is already the normalized key from detect_promoted_themes().
-            refs = ", ".join(f"#{a.pr_number}" if a.pr_number else a.commit.short_sha for a in cs)
-            lines.append(f"  - {theme} ({len(cs)} commits): {refs}")
-        promoted_block = "\n".join(lines) + "\n"
-
-    payload = (
-        f"Range: {commit_range}\n"
-        f"Total commits: {len(analyzed)}\n"
-        f"User-facing commits: {len(user_facing)}\n"
-        f"{promoted_block}\n"
-        "Per-commit summaries (use these as the source of truth):\n" + "\n".join(bullets) + "\n\n"
-        "Full commit list (for the appended What's Changed section):\n" + "\n".join(full_changelog)
+    payload = _build_composition_payload(commit_range, analyzed, user_facing, promoted)
+    user_message = (
+        f"Produce release notes for Dragonfly {commit_range}.\n\n"
+        f"{payload}\n\n"
+        "After all themed sections, append a final section:\n"
+        "## What's Changed\n"
+        "with the full commit list verbatim (one bullet per commit subject)."
     )
 
-    response = client.messages.create(
-        model=MODEL,
-        max_tokens=8000,
-        system=COMPOSE_SYSTEM_PROMPT,
-        messages=[
-            {
-                "role": "user",
-                "content": (
-                    f"Produce release notes for Dragonfly {commit_range}.\n\n"
-                    f"{payload}\n\n"
-                    "After all themed sections, append a final section:\n"
-                    "## What's Changed\n"
-                    "with the full commit list verbatim (one bullet per commit subject)."
-                ),
-            }
-        ],
+    compose_task = asyncio.create_task(
+        backend.compose(COMPOSE_SYSTEM_PROMPT, user_message, max_tokens=COMPOSE_MAX_TOKENS)
     )
-    # Concatenate ALL text blocks. The model usually returns a single block,
-    # but multi-block responses are valid and silently dropping the tail would
-    # truncate the release notes. Raise if there are zero text blocks so we
-    # never silently write an empty file.
-    text_parts = [b.text for b in response.content if b.type == "text"]
-    if not text_parts:
-        raise RuntimeError(
-            f"composition response contained no text blocks "
-            f"(stop_reason={response.stop_reason}, "
-            f"block_types={[b.type for b in response.content]})"
-        )
-    return "\n".join(text_parts)
+    notes = await _heartbeat_compose(backend, compose_task, len(user_facing))
+    return backend.post_process_notes(notes)
+
+
+# ---------------------------------------------------------------------------
+# CLI helpers
+# ---------------------------------------------------------------------------
 
 
 def sanitize_for_filename(s: str) -> str:
-    # v1.38.1..v1.38.2 -> v1.38.1_to_v1.38.2 for a cleaner filename
     s = s.replace("...", "_to_").replace("..", "_to_")
     return re.sub(r"[^A-Za-z0-9._-]+", "_", s).strip("_")
 
 
 def _positive_int(s: str) -> int:
-    """argparse type=: accept only integers >= 1."""
     try:
         v = int(s)
     except ValueError:
@@ -718,7 +1341,6 @@ def _positive_int(s: str) -> int:
 
 
 def _non_negative_int(s: str) -> int:
-    """argparse type=: accept only integers >= 0."""
     try:
         v = int(s)
     except ValueError:
@@ -728,7 +1350,7 @@ def _non_negative_int(s: str) -> int:
     return v
 
 
-def main() -> int:
+def _build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -751,43 +1373,147 @@ def main() -> int:
         "--max-parallel",
         type=_positive_int,
         default=DEFAULT_PARALLEL,
-        help=f"Concurrent per-commit analyses, integer >= 1 " f"(default: {DEFAULT_PARALLEL})",
+        help=f"Concurrent per-commit analyses, integer >= 1 (default: {DEFAULT_PARALLEL})",
     )
     parser.add_argument(
         "--retry-rounds",
         type=_non_negative_int,
         default=DEFAULT_RETRY_ROUNDS,
-        help=f"Outer retry rounds for commits that fail SDK retries, integer "
-        f">= 0 (default: {DEFAULT_RETRY_ROUNDS}). Each round halves concurrency "
-        f"and waits longer.",
+        help=(
+            f"Outer retry rounds for commits that fail SDK retries, integer "
+            f">= 0 (default: {DEFAULT_RETRY_ROUNDS}). Each round halves concurrency "
+            f"and waits longer."
+        ),
     )
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Collect commits and print stats, but skip Claude API calls",
+        help="Collect commits and print stats, but skip API calls",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--backend",
+        choices=["anthropic", "copilot"],
+        default="anthropic",
+        help=(
+            "LLM backend to use: 'anthropic' (default, requires ANTHROPIC_API_KEY) "
+            "or 'copilot' (uses GitHub Copilot CLI auth, no API key needed -- "
+            "requires the github-copilot-sdk package and an authenticated Copilot CLI)."
+        ),
+    )
+    parser.add_argument(
+        "--cache-dir",
+        default=None,
+        help=(
+            f"Directory for per-commit analysis cache (default: <repo>/{CACHE_SUBDIR}). "
+            f"Cached results are keyed by commit SHA, backend, model, and prompts, "
+            f"so any meaningful change automatically invalidates stale entries."
+        ),
+    )
+    parser.add_argument(
+        "--no-cache",
+        action="store_true",
+        help="Disable the per-commit disk cache entirely.",
+    )
+    return parser
+
+
+def _check_prerequisites(backend_name: str) -> Optional[str]:
+    """Return an error message string if prerequisites are missing, else None."""
+    if backend_name == "copilot":
+        if not copilot_sdk_available:
+            return (
+                "error: the 'copilot' package is not installed. Install with:\n"
+                "       pip install github-copilot-sdk\n"
+                "(or pass --backend anthropic to use the Anthropic SDK directly)"
+            )
+    else:
+        if anthropic is None:
+            return (
+                "error: the 'anthropic' package is not installed. Install with:\n"
+                "       pip install -r tools/requirements.txt\n"
+                "(or pass --dry-run to validate the commit range without API calls)"
+            )
+        if not os.environ.get("ANTHROPIC_API_KEY"):
+            return (
+                "error: ANTHROPIC_API_KEY env var is required for the anthropic backend\n"
+                "(or pass --backend copilot to use GitHub Copilot CLI auth)"
+            )
+    return None
+
+
+def _build_backend(backend_name: str) -> LLMBackend:
+    if backend_name == "copilot":
+        return CopilotBackend()
+    return AnthropicBackend(anthropic.Anthropic(max_retries=SDK_MAX_RETRIES))
+
+
+def _resolve_cache_dir(no_cache: bool, cache_dir_arg: Optional[str], repo: Path) -> Optional[Path]:
+    if no_cache:
+        return None
+    cache_dir = Path(cache_dir_arg).resolve() if cache_dir_arg else repo / CACHE_SUBDIR
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    print(f"  Cache dir: {cache_dir}")
+    return cache_dir
+
+
+class _AnalysisIncompleteError(RuntimeError):
+    pass
+
+
+async def _run_async(
+    backend: LLMBackend,
+    commits: list[Commit],
+    commit_range: str,
+    max_parallel: int,
+    retry_rounds: int,
+    cache_dir: Optional[Path],
+    output_dir: Path,
+) -> None:
+    analyzed, stats = await analyze_with_retries(
+        backend,
+        commits,
+        initial_parallel=max_parallel,
+        retry_rounds=retry_rounds,
+        cache_dir=cache_dir,
+    )
+    print_analysis_stats(stats, analyzed)
+
+    if not stats.all_processed:
+        raise _AnalysisIncompleteError(
+            f"only {stats.total_succeeded}/{stats.total} commits analyzed successfully "
+            f"after {retry_rounds + 1} round(s). Aborting -- refusing to write incomplete notes."
+        )
+
+    # Restore git-log order (newest first, like `git log` itself).
+    order = {c.sha: i for i, c in enumerate(commits)}
+    analyzed.sort(key=lambda a: order.get(a.commit.sha, 0))
+
+    print("\nAll commits analyzed. Composing release notes ...")
+    notes = await compose_release_notes(backend, analyzed, commit_range)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    out_path = output_dir / backend.notes_filename(sanitize_for_filename(commit_range))
+    out_path.write_text(notes, encoding="utf-8")
+    print(f"\nWrote {out_path}")
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        force=True,
+    )
+    args = _build_arg_parser().parse_args()
 
     repo = Path(args.repo).resolve()
     if not (repo / ".git").exists():
         print(f"error: {repo} is not a git repository", file=sys.stderr)
         return 1
 
-    if not args.dry_run and anthropic is None:
-        print(
-            "error: the 'anthropic' package is not installed. Install with:\n"
-            "       pip install -r tools/requirements.txt\n"
-            "(or pass --dry-run to validate the commit range without API calls)",
-            file=sys.stderr,
-        )
-        return 1
-
-    if not args.dry_run and not os.environ.get("ANTHROPIC_API_KEY"):
-        print(
-            "error: ANTHROPIC_API_KEY env var is required (or pass --dry-run)",
-            file=sys.stderr,
-        )
-        return 1
+    if not args.dry_run:
+        if err := _check_prerequisites(args.backend):
+            print(err, file=sys.stderr)
+            return 1
 
     print(f"Fetching commits in {args.commit_range} from {repo} ...")
     t0 = time.time()
@@ -804,55 +1530,32 @@ def main() -> int:
             print(f"  ... +{len(commits) - 20} more")
         return 0
 
-    # max_retries lifts the SDK's built-in exponential-backoff retry on
-    # 429 / 529 / 5xx / connection errors, so most rate-limit pressure is
-    # absorbed transparently inside each call.
-    client = anthropic.Anthropic(max_retries=SDK_MAX_RETRIES)
+    backend = _build_backend(args.backend)
+    cache_dir = _resolve_cache_dir(args.no_cache, args.cache_dir, repo)
 
-    analyzed, stats = analyze_with_retries(
-        client,
-        commits,
-        initial_parallel=args.max_parallel,
-        retry_rounds=args.retry_rounds,
-    )
-
-    # Stats are always shown -- both before composition (success path) and
-    # before aborting (failure path). User wants explicit visibility either way.
-    print_analysis_stats(stats, analyzed)
-
-    if not stats.all_processed:
-        print(
-            f"\nERROR: only {stats.total_succeeded}/{stats.total} commits were "
-            f"analyzed successfully after {args.retry_rounds + 1} round(s). "
-            f"Aborting before composition -- refusing to write incomplete release notes.",
-            file=sys.stderr,
+    try:
+        asyncio.run(
+            _run_async(
+                backend,
+                commits,
+                args.commit_range,
+                args.max_parallel,
+                args.retry_rounds,
+                cache_dir,
+                Path(args.output_dir).resolve(),
+            )
         )
+    except _AnalysisIncompleteError as e:
+        print(f"\nERROR: {e}", file=sys.stderr)
         print(
             "Hint: re-run with a higher --retry-rounds, lower --max-parallel, "
             "or wait for rate limits to recover.",
             file=sys.stderr,
         )
         return 2
-
-    # Restore git-log order (newest first, like `git log` itself).
-    order = {c.sha: i for i, c in enumerate(commits)}
-    analyzed.sort(key=lambda a: order.get(a.commit.sha, 0))
-
-    print("\nAll commits analyzed. Composing release notes ...")
-    try:
-        notes = compose_release_notes(client, analyzed, args.commit_range)
     except Exception as e:
-        # Composition is one shot; the SDK's max_retries already covered
-        # transient errors. If we land here, something durable broke.
         print(f"\nERROR: composition failed ({type(e).__name__}: {e})", file=sys.stderr)
         return 3
-
-    out_dir = Path(args.output_dir).resolve()
-    out_dir.mkdir(parents=True, exist_ok=True)
-    fname = f"release_notes_{sanitize_for_filename(args.commit_range)}.md"
-    out_path = out_dir / fname
-    out_path.write_text(notes, encoding="utf-8")
-    print(f"\nWrote {out_path}")
     return 0
 
 

--- a/tools/release_notes_generator.py
+++ b/tools/release_notes_generator.py
@@ -45,9 +45,12 @@ from typing import Literal, Optional
 
 try:
     import anthropic
-    from pydantic import BaseModel, Field
-except ImportError:  # allow --dry-run without the SDK installed
+except ImportError:
     anthropic = None  # type: ignore[assignment]
+
+try:
+    from pydantic import BaseModel, Field
+except ImportError:  # allow --dry-run without pydantic installed
     BaseModel = object  # type: ignore[assignment,misc]
 
     def Field(*args, **kwargs):  # type: ignore[no-redef]
@@ -369,10 +372,13 @@ def _parse_commit_analysis_json(text: str) -> CommitAnalysis:
     text = text.strip()
     text = re.sub(r"^```(?:json)?\s*", "", text)
     text = re.sub(r"\s*```$", "", text)
-    match = re.search(r"\{.*\}", text, re.DOTALL)
-    if not match:
+    start = text.find("{")
+    if start == -1:
         raise ValueError(f"No JSON object found in LLM response: {text[:300]}")
-    data = json.loads(match.group())
+    try:
+        data, _ = json.JSONDecoder().raw_decode(text, start)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Failed to parse JSON from LLM response: {exc}\nText: {text[:300]}")
     return CommitAnalysis(
         category=data["category"],
         user_facing=bool(data["user_facing"]),
@@ -771,7 +777,9 @@ def _make_cache_key(backend: LLMBackend, sha: str) -> str:
         backend.analyze_system_prompt,
         sha,
     ):
-        h.update(part.encode())
+        encoded = part.encode()
+        h.update(len(encoded).to_bytes(4, "little"))
+        h.update(encoded)
     return h.hexdigest()
 
 
@@ -1027,6 +1035,15 @@ async def _analyze_round(
                         abort_event.set()
 
     await asyncio.gather(*[analyze_one(c) for c in commits])
+
+    # Any commit not in succeeded or failed was silently skipped due to abort.
+    # Add them to failed so the caller can retry them in the next round.
+    if abort_event.is_set():
+        processed = {a.commit.sha for a in succeeded} | {c.sha for c, _ in failed}
+        for commit in commits:
+            if commit.sha not in processed:
+                failed.append((commit, RuntimeError("skipped due to fatal backend error")))
+
     return succeeded, failed
 
 

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -9,3 +9,5 @@ aiocsv==1.2.3
 aiofiles==22.1.0
 numpy==2.1.3
 anthropic>=0.40.0,<1.0
+# Optional: install for --backend copilot support
+# github-copilot-sdk


### PR DESCRIPTION
## Summary

- Adds a GitHub Copilot backend (`--backend copilot`) as an alternative to the Anthropic backend; routes requests through the Copilot CLI — no `ANTHROPIC_API_KEY` required
- Adds per-commit analysis disk cache (default `<repo>/.release_notes_cache/`); cache key covers backend name, model, token budget, system prompt, and commit SHA — any prompt or model change auto-invalidates
- Migrates the analysis pipeline from `concurrent.futures.ThreadPoolExecutor` to native `asyncio`; `compose_release_notes` streams output with a 15 s heartbeat and live token counters
- Tightens commit categorisation: category descriptions and `CRITICAL RULE` block now strongly enforce that any fix (crash, data corruption, race, wrong result) lands in `bugfix` regardless of subsystem; domain categories are reserved for new features
- Output filename gains a backend tag for Copilot runs (`release_notes_copilot_<range>.md`) to distinguish from Anthropic runs

Refactoring (no behaviour change to existing Anthropic path):
- `LLMBackend` interface extended with `analyze_commit`, `compose_progress_status`, `post_process_notes`, `notes_filename` — all backend-specific decisions live in the backend, not in callers
- `AnthropicBackend._sync_stream` replaces the 75-line nested `_run` closure; `_ComposeStats` dataclass replaces five loose instance variables
- `_model` renamed to public `model`; `_make_cache_key(backend, sha)` replaces the old 5-argument function
- `main()` decomposed: `_build_arg_parser`, `_check_prerequisites`, `_build_backend`, `_resolve_cache_dir`, `_run_async` (single `asyncio.run` call)
- `_is_fatal_error`, `FAIL_FAST_THRESHOLD`, and all token/heartbeat/threshold constants promoted to module level

## Release notes comparison (v1.37.0..v1.38.0)

Three outputs were generated from the same commit range to compare quality:

| | Gold (pre-PR, Anthropic) | New Anthropic | Copilot |
|---|---|---|---|
| **File** | `release_notes_v1.37.0_to_v1.38.0.gold.md` | `release_notes_v1.37.0_to_v1.38.0.md` | `release_notes_copilot_v1.37.0_to_v1.38.0.md` |
| **Lines** | 309 | 307 | 307 |
| **H1 title** | ✅ | ✅ | ✅ |
| **Preamble artefact** | — | — | ⚠️ model emitted "Now I have full context…" before the markdown |
| **Highlights** | ZSTD compression, TTL embed, TOPK+CMS | TTL embed, Top-K+CMS, HNSW range search | TTL embed, ZSTD compression, TOPK+CMS |
| **Structured sections** | 8 sections | 8 sections | 9 sections (adds Docker) |

**Anthropic new vs gold** — structurally identical; new output groups HNSW improvements more tightly in Highlights and surfaces the 30+ bug-fix count explicitly in the opening.

**Copilot vs gold** — equivalent quality and coverage; the Copilot model occasionally violates the "no preamble" system-prompt constraint (the spurious leading line above), which `post_process_notes` does not yet strip.

<details>
<summary>release_notes_v1.37.0_to_v1.38.0.gold.md (pre-PR baseline)</summary>

```markdown
# Dragonfly v1.38.0 Release Notes

This release delivers major memory efficiency improvements, expanded probabilistic data structure support, and significant search engine enhancements. The standout change is a ~26% reduction in memory for workloads with expiring keys by embedding TTL directly into keys and eliminating the separate expire table — a meaningful win for any deployment using key expiry at scale. New probabilistic data structures (TOPK and CMS command families) join the existing HyperLogLog and Bloom filter support, and vector search gains HNSW range queries, improved hybrid search accuracy, and correct replication across shard count mismatches. Operators will also find improved observability through new Prometheus metrics for TLS, pipelines, streams, and defragmentation.

## Highlights

- [~26% memory reduction for workloads with expiring keys] TTL is now embedded directly in each key, eliminating the separate per-shard expire table and saving roughly 26–35 bytes per key with expiry (#6923, #6933).
- Adds the TOPK command family (TOPK.RESERVE, TOPK.ADD, TOPK.INCRBY, TOPK.QUERY, TOPK.COUNT, TOPK.LIST, TOPK.INFO) and the CMS (Count-Min Sketch) command family (CMS.INITBYDIM, CMS.INITBYPROB, CMS.INCRBY, CMS.QUERY, CMS.INFO, CMS.MERGE), both with RDB persistence (#6950, #6896).
- [Up to 75x less memory for repetitive list data; 3–10x for real-world workloads] Introduces ZSTD dictionary-based compression for Redis lists via the new `list_experimental_zstd_dict_threshold` flag (#6967).
```
</details>

<details>
<summary>release_notes_v1.37.0_to_v1.38.0.md (new Anthropic backend)</summary>

```markdown
# Dragonfly v1.38.0 Release Notes

This release delivers major advances across memory efficiency, vector search, probabilistic data structures, and operational observability. The standout improvement is a **~26% reduction in memory for TTL-heavy workloads** by eliminating the per-shard expire table and embedding TTL directly in keys. Vector search gains HNSW range search, improved hybrid search accuracy, deferred write operations during serialization, and better FT.AGGREGATE integration. Two new probabilistic data structure families — **Top-K (HeavyKeeper)** and **Count-Min Sketch** — are now fully implemented with RDB persistence. Operators gain richer Prometheus metrics for TLS, pipelines, defragmentation, stream access patterns, and pipeline latency. The release also includes over 30 bug fixes spanning search crashes, replication correctness, tiering races, and stream handling.

## Highlights

- **Eliminated the per-shard expire table**, embedding TTL directly in keys for [~26% memory reduction (900 MB → 665 MB)] on workloads with many expiring keys (#6923, #6933).
- **Full Top-K and Count-Min Sketch command families** added with RDB persistence, ACL integration, and Redis Stack compatibility (#6950, #6896, #6932).
- **HNSW vector search significantly expanded**: range search in FT.SEARCH, KNN + APPLY in FT.AGGREGATE, filtered brute-force for small candidate sets, and deferred writes during serialization (#6898, #7066, #6730, #6746).
```
</details>

<details>
<summary>release_notes_copilot_v1.37.0_to_v1.38.0.md (new Copilot backend)</summary>

```markdown
# Dragonfly v1.38.0 Release Notes

Dragonfly v1.38.0 delivers substantial memory efficiency gains, expanded probabilistic data structure support, and richer vector search capabilities. The headline change is elimination of the per-shard ExpireTable — embedding TTL directly into keys saves ~26% memory for expiry-heavy workloads (900 MB → 665 MB for 10M keys with TTL). New TOPK and Count-Min Sketch command families join the existing probabilistic primitives with full RDB persistence and RedisBloom compatibility, while ZSTD dictionary-based list compression achieves up to 75× memory reduction in benchmarks. Vector search gains HNSW range queries in both FT.SEARCH and FT.AGGREGATE, improved hybrid search accuracy, and correct index restoration across shard-count-mismatched replicas. Operators also get a distroless Docker image, early TLS/TCP validation, new Prometheus metrics for TLS handshakes and pipeline latency, and 4× higher tiered storage write depth.

## Highlights

- [~26% memory reduction for workloads with expiring keys (900 MB → 665 MB for 10M keys with TTL)] Eliminated the per-shard ExpireTable by embedding TTL directly into each key's CompactKey encoding, removing 26–35 bytes of overhead per expiring key (#6923, #6933).
- [Up to 75× memory reduction in synthetic benchmarks (2.56 GiB → 32.84 MiB); 3–10× expected in real-world workloads] Introduced ZSTD dictionary-based list compression via a shared thread-local dictionary across all QList instances, controlled by the new `list_experimental_zstd_dict_threshold` flag (#6967).
- Added TOPK and Count-Min Sketch (CMS) command families with full RDB persistence, compatible with RedisBloom (#6950, #6896).
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)