### PR TITLE
test(connection): add regression tests for MULTI/EXEC tx-queue stall

### DIFF
--- a/src/facade/conn_context.h
+++ b/src/facade/conn_context.h
@@ -46,6 +46,8 @@ class ConnectionContext {
   virtual void Unsubscribe(std::string_view channel) {
   }
 
+  virtual void OnSocketError(uint32_t epoll_mask){};
+
   // connection state / properties.
   bool conn_closing : 1;
   bool req_auth : 1;

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -362,7 +362,7 @@ void LogTraffic(uint32_t id, bool has_more, const cmn::BackedArguments& args,
 //               FLUSHALL/STATS/
 //               QUIT/VERSION)      : [cmd, *backed_args]
 void LogMemcacheTraffic(uint32_t id, bool has_more, const MemcacheParser::Command& mc,
-                        ServiceInterface::ContextInfo ci) {
+                        unsigned db_index) {
   using MP = MemcacheParser;
   string_view cmd_name = MP::CmdName(mc.type);
   if (cmd_name.empty())
@@ -419,7 +419,7 @@ void LogMemcacheTraffic(uint32_t id, bool has_more, const MemcacheParser::Comman
       break;
   }
 
-  LogTrafficParts(id, has_more, ci.db_index, absl::MakeSpan(parts));
+  LogTrafficParts(id, has_more, db_index, absl::MakeSpan(parts));
 }
 
 constexpr size_t kMinReadSize = 256;
@@ -799,7 +799,7 @@ void Connection::OnPostMigrateThread() {
   DVLOG(1) << "[" << id_ << "] OnPostMigrateThread";
 
   // Once we migrated, we should rearm OnBreakCb callback.
-  if (breaker_cb_ && socket()->IsOpen()) {
+  if (socket()->IsOpen()) {
     socket_->RegisterOnErrorCb([this](int32_t mask) { this->OnBreakCb(mask); });
   }
 
@@ -968,9 +968,7 @@ void Connection::HandleRequests() {
       ioloop_v2_ =
           GetFlag(FLAGS_experimental_io_loop_v2) && !is_tls_ && protocol_ == Protocol::MEMCACHE;
 
-      if (breaker_cb_) {
-        socket_->RegisterOnErrorCb([this](int32_t mask) { this->OnBreakCb(mask); });
-      }
+      socket_->RegisterOnErrorCb([this](int32_t mask) { this->OnBreakCb(mask); });
       switch (protocol_) {
         case Protocol::REDIS:
           reply_builder_.reset(new RedisReplyBuilder(socket_.get()));
@@ -1001,10 +999,6 @@ unsigned Connection::GetSendWaitTimeSec() const {
   }
 
   return 0;
-}
-
-void Connection::RegisterBreakHook(BreakerCb breaker_cb) {
-  breaker_cb_ = std::move(breaker_cb);
 }
 
 void Connection::FlushReplies() {  // NOLINT must not be const due to flush side effect
@@ -1071,12 +1065,14 @@ pair<string, string> Connection::GetClientInfoBeforeAfterTid() const {
                   " tot-dispatches=", local_stats_.dispatch_entries_added);
 
   if (cc_) {
-    string cc_info = service_->GetContextInfo(cc_.get()).Format();
+    auto ctx_info = service_->GetContextInfo(cc_.get());
 
     // reply_builder_ may be null if the connection is in the setup phase, for example.
     if (reply_builder_ && reply_builder_->IsSendActive())
       phase_name = "send";
-    absl::StrAppend(&after, " ", cc_info);
+    else if (ctx_info.is_scheduled)
+      phase_name = "scheduled";
+    absl::StrAppend(&after, " ", ctx_info.Format());
   }
   absl::StrAppend(&after, " phase=", phase_name);
 
@@ -1501,9 +1497,9 @@ void Connection::OnBreakCb(int32_t mask) {
     return;
   }
 
-  DCHECK(reply_builder_) << "[" << id_ << "] " << phase_ << " " << migration_in_process_;
+  DCHECK(reply_builder_) << "[" << id_ << "] " << unsigned(phase_) << " " << migration_in_process_;
 
-  VLOG(1) << "[" << id_ << "] Got event " << mask << " " << phase_ << " "
+  VLOG(1) << "[" << id_ << "] Got event " << mask << " " << unsigned(phase_) << " "
           << reply_builder_->IsSendActive() << " " << reply_builder_->GetError();
 
   cc_->conn_closing = true;
@@ -2421,11 +2417,8 @@ void Connection::DecreaseConnStats() {
 }
 
 void Connection::BreakOnce(uint32_t ev_mask) {
-  if (breaker_cb_) {
-    DVLOG(1) << "[" << id_ << "] Connection::breaker_cb_ " << ev_mask;
-    auto fun = std::move(breaker_cb_);
-    breaker_cb_ = nullptr;
-    fun(ev_mask);
+  if (cc_) {
+    cc_->OnSocketError(ev_mask);
   }
 }
 
@@ -2484,8 +2477,8 @@ bool Connection::ParseMCBatch(base::IoBuf& io_buf) {
     if (result == MemcacheParser::OK && tl_traffic_logger.log_file &&
         tl_traffic_logger.listener_type == listener_type_) {
       bool has_more = io_buf_.InputLen() > 0;
-      LogMemcacheTraffic(id_, has_more, *parsed_cmd_->mc_command(),
-                         service_->GetContextInfo(cc_.get()));
+      unsigned db_index = service_->GetContextInfo(cc_.get()).db_index;
+      LogMemcacheTraffic(id_, has_more, *parsed_cmd_->mc_command(), db_index);
     }
 
     // We push the command to the parsed queue even in case of parse errors,

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -69,7 +69,6 @@ class Connection : public util::Connection {
   // HandleRequests will run.
   void OnConnectionStart();
 
-  using BreakerCb = std::function<void(uint32_t)>;
   using ShutdownCb = std::function<void()>;
 
   // PubSub message, either incoming message for active subscription or reply for new subscription.
@@ -153,9 +152,6 @@ class Connection : public util::Connection {
 
   // Add InvalidationMessage to dispatch queue.
   virtual void SendInvalidationMessageAsync(InvalidationMessage);
-
-  // Register hook that is executen when the connection breaks.
-  void RegisterBreakHook(BreakerCb breaker_cb);
 
   void FlushReplies();
 
@@ -536,8 +532,6 @@ class Connection : public util::Connection {
   std::string lib_ver_;
 
   unsigned parser_error_ = 0;
-
-  BreakerCb breaker_cb_;
 
   // Used to keep track of borrowed references. Does not really own itself
   std::shared_ptr<Connection> self_;

--- a/src/facade/service_interface.cc
+++ b/src/facade/service_interface.cc
@@ -22,10 +22,10 @@ std::string ServiceInterface::ContextInfo::Format() const {
   if (conn_closing)
     buf[index++] = 't';
 
-  if (subscribers)
+  if (has_subscribers)
     buf[index++] = 'P';
 
-  if (blocked)
+  if (is_blocked)
     buf[index++] = 'b';
 
   if (index)

--- a/src/facade/service_interface.h
+++ b/src/facade/service_interface.h
@@ -71,7 +71,8 @@ class ServiceInterface {
     std::string Format() const;
 
     unsigned db_index;
-    bool async_dispatch, conn_closing, subscribers, blocked;
+    bool async_dispatch, conn_closing, has_subscribers, is_blocked;
+    bool is_scheduled;  // coordinator fiber is waiting on scheduled transaction.
   };
 
   virtual ContextInfo GetContextInfo(ConnectionContext* cntx) const {

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -203,6 +203,11 @@ size_t ConnectionContext::UsedMemory() const {
          HeapSize(pub_sub.globs);
 }
 
+void ConnectionContext::OnSocketError(uint32_t /* epoll_mask */) {
+  if (transaction)
+    transaction->CancelBlocking(nullptr);
+}
+
 void ConnectionContext::Unsubscribe(std::string_view channel) {
   auto* sinfo = conn_state.subscribe_info.get();
   DCHECK(sinfo);

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -318,7 +318,8 @@ class ConnectionContext : public facade::ConnectionContext {
 
   size_t UsedMemory() const override;
 
-  virtual void Unsubscribe(std::string_view channel) override;
+  void Unsubscribe(std::string_view channel) override;
+  void OnSocketError(uint32_t epoll_mask) override;
 
   // Whether this connection is a connection from a replica to its master.
   // This flag is true only on replica side, where we need to setup a special ConnectionContext

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1824,13 +1824,6 @@ facade::ConnectionContext* Service::CreateContext(facade::Connection* owner) {
     }
   }
 
-  // a bit of a hack. I set up breaker callback here for the owner.
-  // Should work though it's confusing to have it here.
-  owner->RegisterBreakHook([res](uint32_t) {
-    if (res->transaction)
-      res->transaction->CancelBlocking(nullptr);
-  });
-
   return res;
 }
 
@@ -2908,11 +2901,15 @@ void Service::RegisterTieringFlags() {
 
 Service::ContextInfo Service::GetContextInfo(facade::ConnectionContext* cntx) const {
   ConnectionContext* server_cntx = static_cast<ConnectionContext*>(cntx);
+  bool is_scheduled = server_cntx->transaction && server_cntx->transaction->IsScheduled() &&
+                      !server_cntx->transaction->Blocker()->IsCompleted();
+
   return {.db_index = server_cntx->db_index(),
           .async_dispatch = server_cntx->async_dispatch,
           .conn_closing = server_cntx->conn_closing,
-          .subscribers = bool(server_cntx->conn_state.subscribe_info),
-          .blocked = server_cntx->blocked};
+          .has_subscribers = bool(server_cntx->conn_state.subscribe_info),
+          .is_blocked = server_cntx->blocked,
+          .is_scheduled = is_scheduled};
 }
 
 #define HFUNC(x) SetHandler(&Service::x)

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -2160,6 +2160,114 @@ async def test_pubsub_pipeline_starvation(df_server: DflyInstance):
         await writer.wait_closed()
 
 
+@dfly_args({"proactor_threads": 1})
+async def test_multi_exec_phantom_connections(df_server: DflyInstance):
+    """Reproduce the addr=0.0.0.0 phantom connections from issue #7272.
+
+    Clogger floods MULTI/GET <1 MB key>/EXEC without reading, blocking Send() mid-EXEC
+    while holding the shard lock.  Ghost connections send MULTI/SET/EXEC one command at a
+    time (sync-dispatch mode) then RST-close.  The main connection fiber is stuck in
+    run_barrier_.Wait() inside Transaction::Execute(), so the io_uring RST event goes
+    unprocessed: the kernel moves the socket to TCP_CLOSE (addr=0.0.0.0) while phase
+    shows "scheduled" (coordinator fiber waiting for shard callback to complete).
+    """
+    import struct
+
+    control_client = df_server.client()
+    await control_client.set("key", "v" * 1024 * 1024)
+
+    # Clogger: floods MULTI/GET/EXEC without reading — fills the TCP send buffer,
+    # blocking Send() mid-EXEC while the shard lock on "key" is still held.
+    reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
+    linger_rst = struct.pack("ii", 1, 0)
+    writer.get_extra_info("socket").setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, linger_rst)
+    writer.write(b"CLIENT SETNAME clogger\r\n")
+    await writer.drain()
+    await reader.readline()  # +OK
+
+    # Stop asyncio from draining incoming data — to simulate server replies getting stuck.
+    writer.transport.pause_reading()
+
+    # A few commands are enough: each EXEC reply is ~1 MB; the OS receive buffer
+    # (~4 MB) fills after 4 replies, TCP window drops to 0, and the server's
+    # Send() blocks mid-EXEC while still holding the shard lock.
+    cmd = b"MULTI\r\nGET key\r\nEXEC\r\n"
+    for _ in range(10):
+        writer.write(cmd)
+    await writer.drain()
+
+    @assert_eventually
+    async def wait_clogger_stuck():
+        clients = await control_client.client_list()
+        v = next((c for c in clients if c.get("name") == "clogger"), None)
+        assert v is not None and v["phase"] == "send"
+
+    await wait_clogger_stuck()
+
+    # Ghost connections: preamble commands sent+ack'd one-by-one (sync-dispatch,
+    # tot-dispatches stays 0), then EXEC fired without reading.  EXEC blocks in
+    # ScheduleSingleHop on the shard lock held by the clogger.
+    def recv_line(s):
+        buf = b""
+        while not buf.endswith(b"\r\n"):
+            buf += s.recv(256)
+        return buf
+
+    ghosts = []
+    for i in range(3):
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, linger_rst)
+        s.connect(("127.0.0.1", df_server.port))
+        s.sendall(f"CLIENT SETNAME ghost{i}\r\n".encode())
+        recv_line(s)  # +OK
+        s.sendall(b"MULTI\r\n")
+        recv_line(s)  # +OK
+        s.sendall(b"SET key v\r\n")
+        recv_line(s)  # +QUEUED
+        s.sendall(b"EXEC\r\n")  # after this call, this connection is blocked on stuck tx queue.
+        ghosts.append(s)
+
+    await asyncio.sleep(0.2)  # let EXEC bytes reach server's receive buffer
+
+    # RST-close: kernel moves server-side sockets to TCP_CLOSE.
+    # getpeername() → ENOTCONN → addr=0.0.0.0 in CLIENT LIST.
+    for s in ghosts:
+        s.close()
+
+    @assert_eventually(times=50)
+    async def check_phantoms():
+        clients = await control_client.client_list()
+        phantoms = [
+            c
+            for c in clients
+            if c.get("addr", "").startswith("0.0.0.0") and c.get("phase") == "scheduled"
+        ]
+        logging.info("phantoms: %s", [(c["name"], c["addr"], c["phase"]) for c in phantoms])
+        assert len(phantoms) >= 3, f"got {[(c['addr'], c['phase']) for c in clients]}"
+
+    await check_phantoms()
+
+    # # A competing MULTI/SET confirms the shard lock is still held while we observe.
+    # other = df_server.client()
+    # pipe = other.pipeline(transaction=True)
+    # pipe.set("key", "new")
+    # compete = asyncio.create_task(pipe.execute())
+
+    # await asyncio.sleep(0.5)
+    # assert not compete.done(), "Competing MULTI/EXEC should be stuck waiting for the shard lock"
+
+    # logging.info("Holding stuck state — inspect with: redis-cli -p %d client list", df_server.port)
+    # await asyncio.sleep(300)
+
+    # RST-close the clogger: Write() fails, fiber resumes, UnlockMulti() is called,
+    # the competing transaction unblocks, and phantom connections clean up.
+    writer.transport.abort()
+
+    # result = await asyncio.wait_for(compete, timeout=5.0)
+    # assert result == [True]
+    assert await control_client.ping()
+
+
 async def test_blocking_command_close_eof(df_server: DflyInstance):
     """Server must drop a connection that is parked on a blocking command
     when the client closes its socket.
@@ -2177,16 +2285,16 @@ async def test_blocking_command_close_eof(df_server: DflyInstance):
     client = df_server.client()
     baseline = int((await client.info("clients"))["connected_clients"])
 
-    workers = 8
-    conns_per_cycle = 25
-    cycles = 4
+    WORKERS = 8
+    CONN_PER_CYCLE = 25
+    CYCLES = 4
     blpop_cmd = b"*3\r\n$5\r\nBLPOP\r\n$10\r\n__no_queue\r\n$1\r\n0\r\n"
 
     def churn():
-        for _ in range(cycles):
+        for _ in range(CYCLES):
             socks = []
             try:
-                for _ in range(conns_per_cycle):
+                for _ in range(CONN_PER_CYCLE):
                     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                     s.connect(("127.0.0.1", df_server.port))
                     s.sendall(blpop_cmd)
@@ -2199,7 +2307,7 @@ async def test_blocking_command_close_eof(df_server: DflyInstance):
                     except OSError:
                         pass
 
-    threads = [Thread(target=churn) for _ in range(workers)]
+    threads = [Thread(target=churn) for _ in range(WORKERS)]
     for t in threads:
         t.start()
     await asyncio.to_thread(lambda: [t.join() for t in threads])


### PR DESCRIPTION
## Summary

- Refactor: replace \`Connection::RegisterBreakHook\`/\`breaker_cb_\` with a virtual
  \`ConnectionContext::OnSocketError\` — cleaner polymorphic dispatch, no ad-hoc
  callback registered in \`Service::CreateContext()\`
- Introspection: add \`phase=scheduled\` to \`CLIENT LIST\` to surface connections
  whose coordinator fiber is stuck waiting for a shard callback inside
  \`Transaction::Execute()\`
- Test: \`test_multi_exec_phantom_connections\` reproduces the scenario from issue
  #7272, where ghost connections appear with \`addr=0.0.0.0\` and \`phase=scheduled\`
  in \`CLIENT LIST\` while their transactions are queued behind a lock-holding connection

## Changes

- \`src/facade/conn_context.h\` — add \`virtual OnSocketError(uint32_t)\` to base \`ConnectionContext\`
- \`src/server/conn_context.h/.cc\` — implement \`OnSocketError\` override: calls \`transaction->CancelBlocking(nullptr)\`
- \`src/facade/dragonfly_connection.h/.cc\` — remove \`BreakerCb\`, \`RegisterBreakHook()\`,
  \`breaker_cb_\`; register error callback unconditionally; \`BreakOnce()\` delegates to \`cc_->OnSocketError()\`
- \`src/server/main_service.cc\` — remove \`RegisterBreakHook\` lambda from \`CreateContext()\`;
  add \`is_scheduled\` computation in \`GetContextInfo()\`
- \`src/facade/service_interface.h/.cc\` — rename \`subscribers\`→\`has_subscribers\`,
  \`blocked\`→\`is_blocked\`; add \`is_scheduled\` field to \`ContextInfo\`
- \`tests/dragonfly/connection_test.py\` — add \`test_multi_exec_phantom_connections\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)