### PR TITLE
fix: accept optional `SCHEDULE` subcommand in BGSAVE

### DIFF
--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -1279,6 +1279,37 @@ TEST_F(GenericFamilyTest, Info) {
   EXPECT_EQ(2, get_rdb_changes_since_last_save(resp.GetString()));
 }
 
+TEST_F(GenericFamilyTest, BgSaveSchedule) {
+  InitWithDbFilename();
+
+  auto changes_since_save = [](const string& info) -> int {
+    const string m = "rdb_changes_since_last_success_save:";
+    auto pos = info.find(m);
+    if (pos == string::npos)
+      return -1;
+    pos += m.size();
+    auto end = info.find('\r', pos);
+    return atoi(info.substr(pos, end - pos).c_str());
+  };
+
+  auto bgsave_and_wait = [&](const std::vector<std::string_view>& cmd) {
+    EXPECT_EQ(Run({"set", "k", "1"}), "OK");
+    EXPECT_EQ(Run(cmd), "OK");
+    EXPECT_TRUE(WaitUntilCondition(
+        [&] {
+          return changes_since_save(Run({"info", "persistence"}).GetString()) == 0;
+        },
+        500ms));
+  };
+
+  bgsave_and_wait({"bgsave", "SCHEDULE"});
+  bgsave_and_wait({"bgsave", "schedule"});
+  bgsave_and_wait({"bgsave", "SCHEDULE", "DF"});
+
+  // SAVE must still reject the subcommand.
+  EXPECT_THAT(Run({"save", "SCHEDULE"}), ErrArg("Unknown subcommand"));
+}
+
 TEST_F(GenericFamilyTest, FieldTtl) {
   TEST_current_time_ms = kMemberExpiryBase * 1000;  // to reset to test time.
   EXPECT_THAT(Run({"saddex", "key", "1", "val1"}), IntArg(1));

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2942,9 +2942,14 @@ std::optional<SaveCmdOptions> ServerFamily::GetSaveCmdOpts(CmdArgList args,
   return save_cmd_opts;
 }
 
-// SAVE [DF|RDB] [CLOUD_URI] [BASENAME]
-// TODO add missing [SCHEDULE]
+// BGSAVE [SCHEDULE] [DF|RDB] [CLOUD_URI] [BASENAME]
 void ServerFamily::BgSave(CmdArgList args, CommandContext* cmd_cntx) {
+  // SCHEDULE is parsed for client compatibility but is a no-op: concurrent
+  // saves are still rejected by DoSaveCheckAndStart; we do not queue.
+  if (!args.empty() && absl::EqualsIgnoreCase(ArgS(args, 0), "SCHEDULE")) {
+    args.remove_prefix(1);
+  }
+
   auto maybe_res = GetSaveCmdOpts(args, cmd_cntx);
   if (!maybe_res) {
     return;


### PR DESCRIPTION
`BGSAVE SCHEDULE` was rejected with `Unknown subcommand or wrong number of arguments for 'SCHEDULE'`. Since `redis-py >= 5.0` sends `SCHEDULE` by default whenever a client calls `bgsave()`, this broke clients that rely on the standard async-save path - notably `llama_index.vector_stores.redis.RedisVectorStore.persist(in_background=True)`.

The `SCHEDULE` flag in upstream semantics queues the request when another BGSAVE/AOF rewrite is in progress. Dragonfly's snapshot never blocks another save, so the subcommand is accepted as a no-op. `SAVE` still rejects `SCHEDULE`, matching upstream.

Fixes #2701