### PR TITLE
ci: skip flaky BullMQ QueueEvents.run() race test

### DIFF
--- a/.github/bullmq-skipped-tests.txt
+++ b/.github/bullmq-skipped-tests.txt
@@ -38,3 +38,8 @@ should repeat 7:th day every month at 9:25
 # Worker pause/resume race: worker.resume() is not awaited, rapid 10ms pause/resume
 # cycles can exhaust the 8000ms timeout under CI load.
 should pause and resume worker without error
+
+# QueueEvents.run() race: close() sets this.closing and calls disconnect(), but the
+# XREAD BLOCK error sometimes arrives before checkConnectionError sees this.closing,
+# causing run() to reject instead of resolve.
+when run method is called when queueEvent is running


### PR DESCRIPTION
The test "when run method is called when queueEvent is running -> throws error" intermittently fails with:
```
  AssertionError: expected promise to be fulfilled, but it was rejected  with 'Error: Connection is closed.'
```

Root cause: `QueueEvents.close()` sets `this.closing` and calls `disconnect()`, but the XREAD BLOCK error from ioredis can arrive before `checkConnectionError` observes `this.closing`, causing `run()` to reject instead of resolving cleanly.

https://github.com/dragonflydb/dragonfly/actions/runs/25721228388/job/75522636658