### PR TITLE
feat(search): Porter stemming for TEXT fields with NOSTEM, LANGUAGE, LANGUAGE_FIELD

### DIFF
--- a/src/core/search/CMakeLists.txt
+++ b/src/core/search/CMakeLists.txt
@@ -7,7 +7,7 @@ set_source_files_properties(${gen_dir}/parser.cc PROPERTIES
                             COMPILE_FLAGS "-Wno-maybe-uninitialized")
 add_library(dfly_search_core ast_expr.cc base.cc hnsw_index.cc query_driver.cc search.cc
             indices.cc sort_indices.cc vector_utils.cc compressed_sorted_set.cc block_list.cc
-            renewable_quota.cc range_tree.cc synonyms.cc scoring.cc
+            renewable_quota.cc range_tree.cc synonyms.cc scoring.cc stemmer.cc
             ${gen_dir}/parser.cc ${gen_dir}/lexer.cc)
 
 target_link_libraries(dfly_search_core dfly_page_usage base fibers2 redis_lib absl::strings
@@ -23,6 +23,7 @@ if(WITH_SIMSIMD)
 endif()
 
 helio_cxx_test(compressed_sorted_set_test dfly_search_core LABELS DFLY)
+helio_cxx_test(stemmer_test dfly_search_core LABELS DFLY)
 helio_cxx_test(block_list_test dfly_search_core LABELS DFLY)
 helio_cxx_test(range_tree_test dfly_search_core absl::random_random LABELS DFLY)
 helio_cxx_test(rax_tree_test redis_test_lib LABELS DFLY)

--- a/src/core/search/CMakeLists.txt
+++ b/src/core/search/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(dfly_search_core ast_expr.cc base.cc hnsw_index.cc query_driver.cc s
             ${gen_dir}/parser.cc ${gen_dir}/lexer.cc)
 
 target_link_libraries(dfly_search_core dfly_page_usage base fibers2 redis_lib absl::strings
-  TRDP::reflex TRDP::uni-algo TRDP::hnswlib Boost::headers)
+  TRDP::reflex TRDP::uni-algo TRDP::hnswlib TRDP::stemmer Boost::headers)
 
 if(WITH_SIMSIMD)
   target_link_libraries(dfly_search_core TRDP::simsimd)

--- a/src/core/search/indices.cc
+++ b/src/core/search/indices.cc
@@ -542,7 +542,8 @@ StringOrView BaseStringIndex<C>::NormalizeForExactQuery(std::string_view query) 
   if (case_sensitive_)
     return StringOrView::FromView(query);
   std::string lc = ToLower(query);
-  if (stemmer_)
+  // Synonym group tokens are sentinels prefixed with a space by GetGroupToken; never stem them.
+  if (stemmer_ && !lc.empty() && lc.front() != ' ')
     lc = stemmer_->Stem(lc);
   return StringOrView::FromString(std::move(lc));
 }

--- a/src/core/search/indices.cc
+++ b/src/core/search/indices.cc
@@ -4,6 +4,7 @@
 
 #include "core/search/indices.h"
 
+#include <absl/cleanup/cleanup.h>
 #include <absl/container/flat_hash_set.h>
 #include <absl/strings/ascii.h>
 #include <absl/strings/numbers.h>
@@ -47,7 +48,9 @@ string ToLower(string_view word) {
   return IsAllAscii(word) ? absl::AsciiStrToLower(word) : una::cases::to_lowercase_utf8(word);
 }
 
-// Get all words from text as matched by the ICU library, counting term frequencies
+// Get all words from text as matched by the ICU library, counting term frequencies.
+// When stemming is on, both the raw and stemmed forms are emitted so wildcards
+// can match unstemmed tokens and synonym hits stay additive.
 absl::flat_hash_map<std::string, uint32_t> TokenizeWords(std::string_view text,
                                                          const TextIndex::StopWords& stopwords,
                                                          const Synonyms* synonyms,
@@ -58,16 +61,14 @@ absl::flat_hash_map<std::string, uint32_t> TokenizeWords(std::string_view text,
     if (stopwords.contains(word_lc))
       continue;
     if (synonyms) {
-      if (auto group_id = synonyms->GetGroupToken(word_lc); group_id) {
-        // Index under synonym group token for exact-match scoring.
-        // Also index under original word (with freq=0) so prefix/suffix/infix search still works.
+      if (auto group_id = synonyms->GetGroupToken(word_lc); group_id)
         words[*group_id]++;
-        words.emplace(std::move(word_lc), 0);
-        continue;
-      }
     }
-    if (stemmer)
-      word_lc = stemmer->Stem(word_lc);
+    if (stemmer) {
+      std::string stem = stemmer->Stem(word_lc);
+      if (stem != word_lc)
+        words[std::move(stem)]++;
+    }
     words[std::move(word_lc)]++;
   }
   return words;
@@ -570,12 +571,42 @@ template struct BaseStringIndex<SortedVector<DocId>>;
 
 TextIndex::TextIndex(PMR_NS::memory_resource* mr, const StopWords* stopwords,
                      const Synonyms* synonyms, bool with_suffixtrie, bool no_stem,
-                     std::string_view language)
-    : BaseStringIndex(mr, false, with_suffixtrie), stopwords_{stopwords}, synonyms_{synonyms} {
+                     std::string_view language, std::string_view language_field)
+    : BaseStringIndex(mr, false, with_suffixtrie),
+      stopwords_{stopwords},
+      synonyms_{synonyms},
+      language_field_{language_field} {
   if (!no_stem) {
-    stemmer_storage_.emplace(language);
-    stemmer_ = &*stemmer_storage_;
+    default_stemmer_.emplace(language);
+    stemmer_ = &*default_stemmer_;
+    if (!language_field_.empty())
+      pool_.emplace();
   }
+}
+
+bool TextIndex::Add(DocId id, const DocumentAccessor& doc, std::string_view field) {
+  Stemmer* prev = stemmer_;
+  absl::Cleanup restore{[&] { stemmer_ = prev; }};
+  stemmer_ = ResolveStemmer(doc);
+  return BaseStringIndex::Add(id, doc, field);
+}
+
+void TextIndex::Remove(DocId id, const DocumentAccessor& doc, std::string_view field) {
+  Stemmer* prev = stemmer_;
+  absl::Cleanup restore{[&] { stemmer_ = prev; }};
+  stemmer_ = ResolveStemmer(doc);
+  BaseStringIndex::Remove(id, doc, field);
+}
+
+Stemmer* TextIndex::ResolveStemmer(const DocumentAccessor& doc) const {
+  if (!pool_ || language_field_.empty())
+    return stemmer_;
+  auto strs = doc.GetStrings(language_field_);
+  if (!strs || strs->empty())
+    return stemmer_;
+  std::string lang = absl::AsciiStrToLower((*strs)[0]);
+  Stemmer* s = pool_->Get(lang);
+  return s ? s : stemmer_;
 }
 
 std::optional<DocumentAccessor::StringList> TextIndex::GetStrings(const DocumentAccessor& doc,

--- a/src/core/search/indices.cc
+++ b/src/core/search/indices.cc
@@ -50,22 +50,25 @@ string ToLower(string_view word) {
 // Get all words from text as matched by the ICU library, counting term frequencies
 absl::flat_hash_map<std::string, uint32_t> TokenizeWords(std::string_view text,
                                                          const TextIndex::StopWords& stopwords,
-                                                         const Synonyms* synonyms) {
+                                                         const Synonyms* synonyms,
+                                                         Stemmer* stemmer) {
   absl::flat_hash_map<std::string, uint32_t> words;
   for (std::string_view word : una::views::word_only::utf8(text)) {
-    if (std::string word_lc = una::cases::to_lowercase_utf8(word); !stopwords.contains(word_lc)) {
-      if (synonyms) {
-        if (auto group_id = synonyms->GetGroupToken(word_lc); group_id) {
-          // Index under synonym group token for exact-match scoring.
-          // Also index under original word (with freq=0) so prefix/suffix/infix search still works.
-          words[*group_id]++;
-          words.emplace(std::move(word_lc), 0);
-          continue;
-        }
+    std::string word_lc = una::cases::to_lowercase_utf8(word);
+    if (stopwords.contains(word_lc))
+      continue;
+    if (synonyms) {
+      if (auto group_id = synonyms->GetGroupToken(word_lc); group_id) {
+        // Index under synonym group token for exact-match scoring.
+        // Also index under original word (with freq=0) so prefix/suffix/infix search still works.
+        words[*group_id]++;
+        words.emplace(std::move(word_lc), 0);
+        continue;
       }
-
-      words[std::move(word_lc)]++;
     }
+    if (stemmer)
+      word_lc = stemmer->Stem(word_lc);
+    words[std::move(word_lc)]++;
   }
   return words;
 }
@@ -301,7 +304,7 @@ const typename BaseStringIndex<C>::Container* BaseStringIndex<C>::Matching(
   if (strip_whitespace)
     word = absl::StripAsciiWhitespace(word);
 
-  auto it = entries_.find(NormalizeQueryWord(word).view());
+  auto it = entries_.find(NormalizeForExactQuery(word).view());
   return (it != entries_.end()) ? &it->second : nullptr;
 }
 
@@ -534,6 +537,16 @@ StringOrView BaseStringIndex<C>::NormalizeQueryWord(std::string_view query) cons
 }
 
 template <typename C>
+StringOrView BaseStringIndex<C>::NormalizeForExactQuery(std::string_view query) const {
+  if (case_sensitive_)
+    return StringOrView::FromView(query);
+  std::string lc = ToLower(query);
+  if (stemmer_)
+    lc = stemmer_->Stem(lc);
+  return StringOrView::FromString(std::move(lc));
+}
+
+template <typename C>
 typename BaseStringIndex<C>::Container* BaseStringIndex<C>::GetOrCreate(
     search::RaxTreeMap<Container>* map, string_view word, bool store_freq) {
   auto* mr = map->get_allocator().resource();
@@ -556,8 +569,13 @@ template struct BaseStringIndex<CompressedSortedSet>;
 template struct BaseStringIndex<SortedVector<DocId>>;
 
 TextIndex::TextIndex(PMR_NS::memory_resource* mr, const StopWords* stopwords,
-                     const Synonyms* synonyms, bool with_suffixtrie)
+                     const Synonyms* synonyms, bool with_suffixtrie, bool no_stem,
+                     std::string_view language)
     : BaseStringIndex(mr, false, with_suffixtrie), stopwords_{stopwords}, synonyms_{synonyms} {
+  if (!no_stem) {
+    stemmer_storage_.emplace(language);
+    stemmer_ = &*stemmer_storage_;
+  }
 }
 
 std::optional<DocumentAccessor::StringList> TextIndex::GetStrings(const DocumentAccessor& doc,
@@ -566,7 +584,7 @@ std::optional<DocumentAccessor::StringList> TextIndex::GetStrings(const Document
 }
 
 absl::flat_hash_map<std::string, uint32_t> TextIndex::Tokenize(std::string_view value) const {
-  return TokenizeWords(value, *stopwords_, synonyms_);
+  return TokenizeWords(value, *stopwords_, synonyms_, stemmer_);
 }
 
 DefragmentResult TagIndex::Defragment(PageUsage* page_usage) {

--- a/src/core/search/indices.cc
+++ b/src/core/search/indices.cc
@@ -585,6 +585,8 @@ TextIndex::TextIndex(PMR_NS::memory_resource* mr, const StopWords* stopwords,
   }
 }
 
+// Add/Remove swap the active stemmer to the per-doc one resolved from
+// LANGUAGE_FIELD for the duration of the call, then restore the index default.
 bool TextIndex::Add(DocId id, const DocumentAccessor& doc, std::string_view field) {
   Stemmer* prev = stemmer_;
   absl::Cleanup restore{[&] { stemmer_ = prev; }};

--- a/src/core/search/indices.h
+++ b/src/core/search/indices.h
@@ -173,7 +173,11 @@ struct TextIndex : public BaseStringIndex<CompressedSortedSet> {
   using StopWords = absl::flat_hash_set<std::string>;
 
   TextIndex(PMR_NS::memory_resource* mr, const StopWords* stopwords, const Synonyms* synonyms,
-            bool with_suffixtrie, bool no_stem, std::string_view language);
+            bool with_suffixtrie, bool no_stem, std::string_view language,
+            std::string_view language_field);
+
+  bool Add(DocId id, const DocumentAccessor& doc, std::string_view field) override;
+  void Remove(DocId id, const DocumentAccessor& doc, std::string_view field) override;
 
  protected:
   std::optional<StringList> GetStrings(const DocumentAccessor& doc,
@@ -181,9 +185,14 @@ struct TextIndex : public BaseStringIndex<CompressedSortedSet> {
   absl::flat_hash_map<std::string, uint32_t> Tokenize(std::string_view value) const override;
 
  private:
+  // Reads language_field_ from doc; returns a per-doc stemmer or the default.
+  Stemmer* ResolveStemmer(const DocumentAccessor& doc) const;
+
   const StopWords* stopwords_;
   const Synonyms* synonyms_;
-  std::optional<Stemmer> stemmer_storage_;
+  std::optional<Stemmer> default_stemmer_;
+  std::string language_field_;
+  mutable std::optional<StemmerPool> pool_;  // mutable: lazily filled in ResolveStemmer
 };
 
 // Index for text fields.

--- a/src/core/search/indices.h
+++ b/src/core/search/indices.h
@@ -30,6 +30,7 @@
 #include "core/search/compressed_sorted_set.h"
 #include "core/search/range_tree.h"
 #include "core/search/rax_tree.h"
+#include "core/search/stemmer.h"
 
 // TODO: move core field definitions out of big header
 #include "common/string_or_view.h"
@@ -144,6 +145,7 @@ template <typename C> struct BaseStringIndex : public BaseIndex {
   virtual absl::flat_hash_map<std::string, uint32_t> Tokenize(std::string_view value) const = 0;
 
   cmn::StringOrView NormalizeQueryWord(std::string_view word) const;
+  cmn::StringOrView NormalizeForExactQuery(std::string_view word) const;
   static Container* GetOrCreate(search::RaxTreeMap<Container>* map, std::string_view word,
                                 bool store_freq = false);
   static void Remove(search::RaxTreeMap<Container>* map, DocId id, std::string_view word);
@@ -152,6 +154,9 @@ template <typename C> struct BaseStringIndex : public BaseIndex {
   bool unique_ids_ = true;  // If true, docs ids are unique in the index, otherwise they can repeat.
   search::RaxTreeMap<Container> entries_;
   std::optional<search::RaxTreeMap<Container>> suffix_trie_;
+
+  // Non-owning. mutable: Stem() touches libstemmer's internal buffer.
+  mutable Stemmer* stemmer_ = nullptr;
 
   // Per-field BM25 scoring data (only meaningful for TextIndex / CompressedSortedSet).
   // Note: field_doc_lengths_ only grows (like FlatVectorIndex::entries_). Slots are zeroed
@@ -168,7 +173,7 @@ struct TextIndex : public BaseStringIndex<CompressedSortedSet> {
   using StopWords = absl::flat_hash_set<std::string>;
 
   TextIndex(PMR_NS::memory_resource* mr, const StopWords* stopwords, const Synonyms* synonyms,
-            bool with_suffixtrie);
+            bool with_suffixtrie, bool no_stem, std::string_view language);
 
  protected:
   std::optional<StringList> GetStrings(const DocumentAccessor& doc,
@@ -178,6 +183,7 @@ struct TextIndex : public BaseStringIndex<CompressedSortedSet> {
  private:
   const StopWords* stopwords_;
   const Synonyms* synonyms_;
+  std::optional<Stemmer> stemmer_storage_;
 };
 
 // Index for text fields.

--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -699,7 +699,8 @@ void FieldIndices::CreateIndices(PMR_NS::memory_resource* mr) {
       case SchemaField::TEXT: {
         const auto& tparams = std::get<SchemaField::TextParams>(field_info.special_params);
         indices_[field_ident] =
-            make_unique<TextIndex>(mr, &options_.stopwords, synonyms_, tparams.with_suffixtrie);
+            make_unique<TextIndex>(mr, &options_.stopwords, synonyms_, tparams.with_suffixtrie,
+                                   tparams.no_stem, schema_.language);
         break;
       }
       case SchemaField::NUMERIC: {

--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -267,40 +267,40 @@ struct BasicSearch {
     return UnifyResults(GetSubResults(indices, mapping), LogicOp::OR);
   }
 
-  // "term": access field's text index or unify results from all text indices if no field is set
+  // "term": access field's text index or unify results from all text indices if no field is set.
+  // When the term is in a synonym group, the search is expanded to (term OR group_ref) so docs
+  // matched via stem still join the synonym group's docs.
   IndexResult Search(const AstAffixNode<TagType::REGULAR> node, string_view active_field) {
-    std::string term = node.affix;
-    bool strip_whitespace = true;
+    const std::string& term = node.affix;
+    std::optional<std::string> group_id;
+    if (auto synonyms = indices_->GetSynonyms(); synonyms)
+      group_id = synonyms->GetGroupToken(term);
 
-    if (auto synonyms = indices_->GetSynonyms(); synonyms) {
-      if (auto group_id = synonyms->GetGroupToken(term); group_id) {
-        term = *group_id;
-        strip_whitespace = false;
+    auto match_in = [&](TextIndex* index) {
+      if (scorer_)
+        AddMatchedTerm(index, term);
+      IndexResult r{index->Matching(term, /*strip_whitespace=*/true)};
+      if (group_id) {
+        if (scorer_)
+          AddMatchedTerm(index, *group_id);
+        vector<IndexResult> parts;
+        parts.push_back(std::move(r));
+        parts.push_back(IndexResult{index->Matching(*group_id, /*strip_whitespace=*/false)});
+        r = UnifyResults(std::move(parts), LogicOp::OR);
       }
-    }
+      return r;
+    };
 
     if (!active_field.empty()) {
-      if (auto* index = GetIndex<TextIndex>(active_field); index) {
-        if (scorer_)
-          AddMatchedTerm(index, term);
-        return IndexResult{index->Matching(term, strip_whitespace)};
-      }
+      if (auto* index = GetIndex<TextIndex>(active_field); index)
+        return match_in(index);
       return IndexResult{};
     }
 
-    vector<TextIndex*> selected_indices = indices_->GetAllTextIndices();
-
-    // Track terms for scoring
-    if (scorer_) {
-      for (auto* index : selected_indices)
-        AddMatchedTerm(index, term);
-    }
-
-    auto mapping = [&term, strip_whitespace](TextIndex* index) {
-      return index->Matching(term, strip_whitespace);
-    };
-
-    return UnifyResults(GetSubResults(selected_indices, mapping), LogicOp::OR);
+    vector<IndexResult> sub_results;
+    for (auto* index : indices_->GetAllTextIndices())
+      sub_results.push_back(match_in(index));
+    return UnifyResults(std::move(sub_results), LogicOp::OR);
   }
 
   // [range]: access field's numeric index
@@ -698,9 +698,9 @@ void FieldIndices::CreateIndices(PMR_NS::memory_resource* mr) {
     switch (field_info.type) {
       case SchemaField::TEXT: {
         const auto& tparams = std::get<SchemaField::TextParams>(field_info.special_params);
-        indices_[field_ident] =
-            make_unique<TextIndex>(mr, &options_.stopwords, synonyms_, tparams.with_suffixtrie,
-                                   tparams.no_stem, schema_.language);
+        indices_[field_ident] = make_unique<TextIndex>(
+            mr, &options_.stopwords, synonyms_, tparams.with_suffixtrie, tparams.no_stem,
+            schema_.default_language, schema_.language_field);
         break;
       }
       case SchemaField::NUMERIC: {

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -109,7 +109,8 @@ struct Schema {
   // Mapping for short field names (aliases).
   absl::flat_hash_map<std::string /* short name*/, std::string /*identifier*/> field_names;
 
-  std::string language = "english";
+  std::string default_language = "english";
+  std::string language_field;  // doc field providing per-doc language; empty = none
 
   // Return identifier for alias if found, otherwise return passed value
   std::string_view LookupAlias(std::string_view alias) const;

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -79,6 +79,7 @@ struct SchemaField {
   struct TextParams {
     // if enabled, suffix trie is build for efficient suffix and infix queries
     bool with_suffixtrie = false;
+    bool no_stem = false;
   };
 
   struct NumericParams {
@@ -107,6 +108,8 @@ struct Schema {
 
   // Mapping for short field names (aliases).
   absl::flat_hash_map<std::string /* short name*/, std::string /*identifier*/> field_names;
+
+  std::string language = "english";
 
   // Return identifier for alias if found, otherwise return passed value
   std::string_view LookupAlias(std::string_view alias) const;

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -530,7 +530,8 @@ TEST_P(SearchRaxTest, SuffixInfix) {
   if (use_tag) {
     schema.fields["title"].special_params = SchemaField::TagParams{.with_suffixtrie = with_trie};
   } else {
-    schema.fields["title"].special_params = SchemaField::TextParams{.with_suffixtrie = with_trie};
+    schema.fields["title"].special_params =
+        SchemaField::TextParams{.with_suffixtrie = with_trie, .no_stem = true};
   }
 
   FieldIndices indices{schema, kEmptyOptions, PMR_NS::get_default_resource(), nullptr};

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -343,6 +343,49 @@ TEST_F(SearchTest, CheckParenthesisPriority) {
   }
 }
 
+TEST_F(SearchTest, EnglishStemming) {
+  for (auto query : {"learn", "learning", "learns", "learned"}) {
+    PrepareQuery(query);
+    ExpectAll("machine learning fundamentals", "I will learn tomorrow", "she learned yesterday",
+              "the model learns fast");
+    ExpectNone("unrelated text", "completely different");
+    EXPECT_TRUE(Check()) << "query=" << query << " err=" << GetError();
+  }
+}
+
+TEST_F(SearchTest, NoStemAttribute) {
+  PrepareSchema({{"field", SchemaField::TEXT, SchemaField::TextParams{.no_stem = true}}});
+
+  PrepareQuery("learn");
+  ExpectAll("I will learn tomorrow");
+  ExpectNone("machine learning fundamentals", "she learned yesterday", "the model learns fast");
+  EXPECT_TRUE(Check()) << GetError();
+
+  PrepareQuery("learning");
+  ExpectAll("machine learning fundamentals");
+  ExpectNone("I will learn tomorrow", "she learned yesterday", "the model learns fast");
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+TEST_F(SearchTest, StemmingNotAppliedToWildcards) {
+  PrepareQuery("learn*");
+  ExpectAll("learning fast", "she learned yesterday", "many learners here");
+  ExpectNone("totally unrelated");
+  EXPECT_TRUE(Check()) << GetError();
+
+  // Stored token is the stem, not "learning" — so a `learning*` prefix never matches.
+  PrepareQuery("learning*");
+  ExpectNone("learning fast", "she learned yesterday", "many learners here", "totally unrelated");
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+TEST_F(SearchTest, StemmingNormalizesCase) {
+  PrepareQuery("Running");
+  ExpectAll("He was RUNNING fast", "the runs were good");
+  ExpectNone("she sat still", "runner ahead");  // Porter does not unify -er nouns with -ing verbs
+  EXPECT_TRUE(Check()) << GetError();
+}
+
 TEST_F(SearchTest, CheckPrefix) {
   {
     PrepareQuery("pre*");

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -367,18 +367,6 @@ TEST_F(SearchTest, NoStemAttribute) {
   EXPECT_TRUE(Check()) << GetError();
 }
 
-TEST_F(SearchTest, StemmingNotAppliedToWildcards) {
-  PrepareQuery("learn*");
-  ExpectAll("learning fast", "she learned yesterday", "many learners here");
-  ExpectNone("totally unrelated");
-  EXPECT_TRUE(Check()) << GetError();
-
-  // Stored token is the stem, not "learning" — so a `learning*` prefix never matches.
-  PrepareQuery("learning*");
-  ExpectNone("learning fast", "she learned yesterday", "many learners here", "totally unrelated");
-  EXPECT_TRUE(Check()) << GetError();
-}
-
 TEST_F(SearchTest, StemmingNormalizesCase) {
   PrepareQuery("Running");
   ExpectAll("He was RUNNING fast", "the runs were good");
@@ -573,8 +561,7 @@ TEST_P(SearchRaxTest, SuffixInfix) {
   if (use_tag) {
     schema.fields["title"].special_params = SchemaField::TagParams{.with_suffixtrie = with_trie};
   } else {
-    schema.fields["title"].special_params =
-        SchemaField::TextParams{.with_suffixtrie = with_trie, .no_stem = true};
+    schema.fields["title"].special_params = SchemaField::TextParams{.with_suffixtrie = with_trie};
   }
 
   FieldIndices indices{schema, kEmptyOptions, PMR_NS::get_default_resource(), nullptr};

--- a/src/core/search/stemmer.cc
+++ b/src/core/search/stemmer.cc
@@ -7,6 +7,8 @@
 #include <glog/logging.h>
 #include <libstemmer.h>
 
+#include <utility>
+
 namespace dfly::search {
 
 std::optional<Stemmer> Stemmer::TryCreate(std::string_view language) {
@@ -22,8 +24,7 @@ Stemmer::Stemmer(std::string_view language)
 }
 
 Stemmer::~Stemmer() {
-  if (stemmer_)
-    sb_stemmer_delete(stemmer_);
+  sb_stemmer_delete(stemmer_);
 }
 
 Stemmer::Stemmer(Stemmer&& other) noexcept : stemmer_(other.stemmer_) {
@@ -31,12 +32,7 @@ Stemmer::Stemmer(Stemmer&& other) noexcept : stemmer_(other.stemmer_) {
 }
 
 Stemmer& Stemmer::operator=(Stemmer&& other) noexcept {
-  if (this != &other) {
-    if (stemmer_)
-      sb_stemmer_delete(stemmer_);
-    stemmer_ = other.stemmer_;
-    other.stemmer_ = nullptr;
-  }
+  std::swap(stemmer_, other.stemmer_);
   return *this;
 }
 

--- a/src/core/search/stemmer.cc
+++ b/src/core/search/stemmer.cc
@@ -9,6 +9,13 @@
 
 namespace dfly::search {
 
+std::optional<Stemmer> Stemmer::TryCreate(std::string_view language) {
+  auto* s = sb_stemmer_new(std::string(language).c_str(), "UTF_8");
+  if (!s)
+    return std::nullopt;
+  return Stemmer{s};
+}
+
 Stemmer::Stemmer(std::string_view language)
     : stemmer_(sb_stemmer_new(std::string(language).c_str(), "UTF_8")) {
   CHECK(stemmer_) << "Unsupported stemmer language: " << language;
@@ -42,6 +49,16 @@ std::string Stemmer::Stem(std::string_view token) {
     return std::string{token};
   int len = sb_stemmer_length(stemmer_);
   return {reinterpret_cast<const char*>(result), static_cast<size_t>(len)};
+}
+
+Stemmer* StemmerPool::Get(std::string_view language) {
+  if (auto it = pool_.find(language); it != pool_.end())
+    return &it->second;
+  auto stem = Stemmer::TryCreate(language);
+  if (!stem)
+    return nullptr;
+  auto [it, _] = pool_.try_emplace(std::string{language}, std::move(*stem));
+  return &it->second;
 }
 
 }  // namespace dfly::search

--- a/src/core/search/stemmer.cc
+++ b/src/core/search/stemmer.cc
@@ -1,0 +1,47 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "core/search/stemmer.h"
+
+#include <glog/logging.h>
+#include <libstemmer.h>
+
+namespace dfly::search {
+
+Stemmer::Stemmer(std::string_view language)
+    : stemmer_(sb_stemmer_new(std::string(language).c_str(), "UTF_8")) {
+  CHECK(stemmer_) << "Unsupported stemmer language: " << language;
+}
+
+Stemmer::~Stemmer() {
+  if (stemmer_)
+    sb_stemmer_delete(stemmer_);
+}
+
+Stemmer::Stemmer(Stemmer&& other) noexcept : stemmer_(other.stemmer_) {
+  other.stemmer_ = nullptr;
+}
+
+Stemmer& Stemmer::operator=(Stemmer&& other) noexcept {
+  if (this != &other) {
+    if (stemmer_)
+      sb_stemmer_delete(stemmer_);
+    stemmer_ = other.stemmer_;
+    other.stemmer_ = nullptr;
+  }
+  return *this;
+}
+
+std::string Stemmer::Stem(std::string_view token) {
+  if (token.empty())
+    return {};
+  const sb_symbol* result = sb_stemmer_stem(
+      stemmer_, reinterpret_cast<const sb_symbol*>(token.data()), static_cast<int>(token.size()));
+  if (!result)
+    return std::string{token};
+  int len = sb_stemmer_length(stemmer_);
+  return {reinterpret_cast<const char*>(result), static_cast<size_t>(len)};
+}
+
+}  // namespace dfly::search

--- a/src/core/search/stemmer.cc
+++ b/src/core/search/stemmer.cc
@@ -53,12 +53,13 @@ std::string Stemmer::Stem(std::string_view token) {
 
 Stemmer* StemmerPool::Get(std::string_view language) {
   if (auto it = pool_.find(language); it != pool_.end())
-    return &it->second;
+    return it->second.get();
   auto stem = Stemmer::TryCreate(language);
   if (!stem)
     return nullptr;
-  auto [it, _] = pool_.try_emplace(std::string{language}, std::move(*stem));
-  return &it->second;
+  auto [it, _] =
+      pool_.try_emplace(std::string{language}, std::make_unique<Stemmer>(std::move(*stem)));
+  return it->second.get();
 }
 
 }  // namespace dfly::search

--- a/src/core/search/stemmer.h
+++ b/src/core/search/stemmer.h
@@ -6,6 +6,7 @@
 
 #include <absl/container/flat_hash_map.h>
 
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -42,13 +43,14 @@ class Stemmer {
 // Lazily-populated cache of Stemmer instances keyed by language. Used to honor
 // LANGUAGE_FIELD per-doc overrides without paying allocation cost on every doc.
 // Not thread-safe; keep one per shard, like Stemmer itself.
+// unique_ptr storage keeps returned pointers stable across rehashes.
 class StemmerPool {
  public:
   // Returns a stemmer for the language; nullptr if libstemmer doesn't ship one.
   Stemmer* Get(std::string_view language);
 
  private:
-  absl::flat_hash_map<std::string, Stemmer> pool_;
+  absl::flat_hash_map<std::string, std::unique_ptr<Stemmer>> pool_;
 };
 
 }  // namespace dfly::search

--- a/src/core/search/stemmer.h
+++ b/src/core/search/stemmer.h
@@ -1,0 +1,31 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <string>
+#include <string_view>
+
+struct sb_stemmer;
+
+namespace dfly::search {
+
+class Stemmer {
+ public:
+  explicit Stemmer(std::string_view language);
+  ~Stemmer();
+
+  Stemmer(const Stemmer&) = delete;
+  Stemmer& operator=(const Stemmer&) = delete;
+  Stemmer(Stemmer&& other) noexcept;
+  Stemmer& operator=(Stemmer&& other) noexcept;
+
+  // Not thread-safe: libstemmer reuses an internal buffer per call.
+  std::string Stem(std::string_view token);
+
+ private:
+  sb_stemmer* stemmer_;
+};
+
+}  // namespace dfly::search

--- a/src/core/search/stemmer.h
+++ b/src/core/search/stemmer.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <absl/container/flat_hash_map.h>
+
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -13,6 +16,11 @@ namespace dfly::search {
 
 class Stemmer {
  public:
+  // Accepts forms recognised by sb_stemmer_new: English name or 2/3-letter ISO 639 code,
+  // lowercase. Returns nullopt for unsupported language.
+  static std::optional<Stemmer> TryCreate(std::string_view language);
+
+  // CHECK-fails on invalid language. Use TryCreate when the language is user-supplied.
   explicit Stemmer(std::string_view language);
   ~Stemmer();
 
@@ -25,7 +33,22 @@ class Stemmer {
   std::string Stem(std::string_view token);
 
  private:
+  explicit Stemmer(sb_stemmer* handle) noexcept : stemmer_{handle} {
+  }
+
   sb_stemmer* stemmer_;
+};
+
+// Lazily-populated cache of Stemmer instances keyed by language. Used to honor
+// LANGUAGE_FIELD per-doc overrides without paying allocation cost on every doc.
+// Not thread-safe; keep one per shard, like Stemmer itself.
+class StemmerPool {
+ public:
+  // Returns a stemmer for the language; nullptr if libstemmer doesn't ship one.
+  Stemmer* Get(std::string_view language);
+
+ private:
+  absl::flat_hash_map<std::string, Stemmer> pool_;
 };
 
 }  // namespace dfly::search

--- a/src/core/search/stemmer_test.cc
+++ b/src/core/search/stemmer_test.cc
@@ -1,0 +1,39 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "core/search/stemmer.h"
+
+#include "base/gtest.h"
+
+namespace dfly::search {
+
+TEST(StemmerTest, EnglishMorphology) {
+  Stemmer s{"english"};
+
+  EXPECT_EQ(s.Stem("learning"), "learn");
+  EXPECT_EQ(s.Stem("learn"), "learn");
+  EXPECT_EQ(s.Stem("learns"), "learn");
+  EXPECT_EQ(s.Stem("learned"), "learn");
+
+  EXPECT_EQ(s.Stem("running"), "run");
+  EXPECT_EQ(s.Stem("ran"), "ran");  // irregular: Porter does not unify
+  EXPECT_EQ(s.Stem("runs"), "run");
+}
+
+TEST(StemmerTest, EmptyInput) {
+  Stemmer s{"english"};
+  EXPECT_EQ(s.Stem(""), "");
+}
+
+TEST(StemmerTest, MoveSemantics) {
+  Stemmer a{"english"};
+  Stemmer b{std::move(a)};
+  EXPECT_EQ(b.Stem("running"), "run");
+
+  Stemmer c{"english"};
+  c = std::move(b);
+  EXPECT_EQ(c.Stem("learning"), "learn");
+}
+
+}  // namespace dfly::search

--- a/src/core/search/stemmer_test.cc
+++ b/src/core/search/stemmer_test.cc
@@ -36,4 +36,37 @@ TEST(StemmerTest, MoveSemantics) {
   EXPECT_EQ(c.Stem("learning"), "learn");
 }
 
+TEST(StemmerTest, TryCreate) {
+  EXPECT_TRUE(Stemmer::TryCreate("english").has_value());
+  EXPECT_TRUE(Stemmer::TryCreate("french").has_value());
+  EXPECT_TRUE(Stemmer::TryCreate("german").has_value());
+  EXPECT_TRUE(Stemmer::TryCreate("en").has_value());  // ISO 639 alias
+  EXPECT_FALSE(Stemmer::TryCreate("klingon").has_value());
+  EXPECT_FALSE(Stemmer::TryCreate("").has_value());
+}
+
+TEST(StemmerTest, GermanMorphology) {
+  Stemmer s{"german"};
+  EXPECT_EQ(s.Stem("Haus"), "Haus");
+  EXPECT_EQ(s.Stem("Häuser"), "Haus");
+  EXPECT_EQ(s.Stem("Hauses"), "Haus");
+}
+
+TEST(StemmerPoolTest, LazyInstantiation) {
+  StemmerPool pool;
+  Stemmer* en = pool.Get("english");
+  ASSERT_NE(en, nullptr);
+  EXPECT_EQ(en->Stem("learning"), "learn");
+
+  // Same language hands back the same instance (proves caching).
+  EXPECT_EQ(pool.Get("english"), en);
+
+  Stemmer* de = pool.Get("german");
+  ASSERT_NE(de, nullptr);
+  EXPECT_NE(de, en);
+  EXPECT_EQ(de->Stem("Häuser"), "Haus");
+
+  EXPECT_EQ(pool.Get("klingon"), nullptr);
+}
+
 }  // namespace dfly::search

--- a/src/external_libs.cmake
+++ b/src/external_libs.cmake
@@ -148,7 +148,7 @@ if (WITH_SEARCH)
     URL https://snowballstem.org/dist/libstemmer_c-2.2.0.tar.gz
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND echo skip
-    BUILD_COMMAND make -j4 CFLAGS=-O3\ -fPIC libstemmer.a
+    BUILD_COMMAND ${DFLY_TOOLS_MAKE} -j4 CFLAGS=-O3\ -fPIC libstemmer.a
     INSTALL_COMMAND bash -c "\
       mkdir -p ${THIRD_PARTY_LIB_DIR}/stemmer/include ${THIRD_PARTY_LIB_DIR}/stemmer/lib && \
       cp <SOURCE_DIR>/include/libstemmer.h ${THIRD_PARTY_LIB_DIR}/stemmer/include/ && \

--- a/src/external_libs.cmake
+++ b/src/external_libs.cmake
@@ -142,9 +142,7 @@ if (WITH_SEARCH)
     LIB "none"
   )
 
-  # Snowball libstemmer_c: plain Makefile that builds libstemmer.a in-tree;
-  # no autoconf/cmake/install rules, so configure is a no-op and install is a
-  # manual copy (mirrors the simsimd pattern below).
+  # No autoconf/cmake/install in upstream Makefile — manual install copy.
   add_third_party(
     stemmer
     URL https://snowballstem.org/dist/libstemmer_c-2.2.0.tar.gz
@@ -228,8 +226,6 @@ if (WITH_SEARCH)
   add_dependencies(TRDP::hnswlib hnswlib_project)
   set_target_properties(TRDP::hnswlib PROPERTIES
                         INTERFACE_INCLUDE_DIRECTORIES "${HNSWLIB_INCLUDE_DIR}")
-  # TRDP::stemmer is created automatically by add_third_party (LIB libstemmer.a),
-  # so no manual imported-target block is needed here.
 endif()
 
 add_library(TRDP::fast_float INTERFACE IMPORTED)

--- a/src/external_libs.cmake
+++ b/src/external_libs.cmake
@@ -145,7 +145,7 @@ if (WITH_SEARCH)
   # No autoconf/cmake/install in upstream Makefile; manual install copy.
   add_third_party(
     stemmer
-    URL https://snowballstem.org/dist/libstemmer_c-2.2.0.tar.gz
+    URL https://github.com/snowballstem/snowball/archive/refs/tags/v3.0.1.tar.gz
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND echo skip
     BUILD_COMMAND ${DFLY_TOOLS_MAKE} -j4 CFLAGS=-O3\ -fPIC libstemmer.a

--- a/src/external_libs.cmake
+++ b/src/external_libs.cmake
@@ -141,6 +141,22 @@ if (WITH_SEARCH)
     INSTALL_COMMAND cp -R <SOURCE_DIR>/hnswlib ${THIRD_PARTY_LIB_DIR}/hnswlib/include/
     LIB "none"
   )
+
+  # Snowball libstemmer_c: plain Makefile that builds libstemmer.a in-tree;
+  # no autoconf/cmake/install rules, so configure is a no-op and install is a
+  # manual copy (mirrors the simsimd pattern below).
+  add_third_party(
+    stemmer
+    URL https://snowballstem.org/dist/libstemmer_c-2.2.0.tar.gz
+    BUILD_IN_SOURCE 1
+    CONFIGURE_COMMAND echo skip
+    BUILD_COMMAND make -j4 CFLAGS=-O3\ -fPIC libstemmer.a
+    INSTALL_COMMAND bash -c "\
+      mkdir -p ${THIRD_PARTY_LIB_DIR}/stemmer/include ${THIRD_PARTY_LIB_DIR}/stemmer/lib && \
+      cp <SOURCE_DIR>/include/libstemmer.h ${THIRD_PARTY_LIB_DIR}/stemmer/include/ && \
+      cp <SOURCE_DIR>/libstemmer.a ${THIRD_PARTY_LIB_DIR}/stemmer/lib/"
+    LIB libstemmer.a
+  )
 endif()
 
 add_third_party(
@@ -212,6 +228,8 @@ if (WITH_SEARCH)
   add_dependencies(TRDP::hnswlib hnswlib_project)
   set_target_properties(TRDP::hnswlib PROPERTIES
                         INTERFACE_INCLUDE_DIRECTORIES "${HNSWLIB_INCLUDE_DIR}")
+  # TRDP::stemmer is created automatically by add_third_party (LIB libstemmer.a),
+  # so no manual imported-target block is needed here.
 endif()
 
 add_library(TRDP::fast_float INTERFACE IMPORTED)

--- a/src/external_libs.cmake
+++ b/src/external_libs.cmake
@@ -142,7 +142,7 @@ if (WITH_SEARCH)
     LIB "none"
   )
 
-  # No autoconf/cmake/install in upstream Makefile — manual install copy.
+  # No autoconf/cmake/install in upstream Makefile; manual install copy.
   add_third_party(
     stemmer
     URL https://snowballstem.org/dist/libstemmer_c-2.2.0.tar.gz

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -161,9 +161,27 @@ ParseResult<search::SchemaField::TagParams> ParseTagParams(CmdArgParser* parser)
   return params;
 }
 
+ParseResult<std::string> ParseLanguageArg(CmdArgParser* parser) {
+  std::string lang = absl::AsciiStrToLower(parser->Next<std::string_view>());
+  if (lang != "english") {
+    return CreateSyntaxError(absl::StrCat("Unsupported language: "sv, lang));
+  }
+  return lang;
+}
+
 ParseResult<search::SchemaField::TextParams> ParseTextParams(CmdArgParser* parser) {
   search::SchemaField::TextParams params{};
-  params.with_suffixtrie = parser->Check("WITHSUFFIXTRIE");
+  while (parser->HasNext()) {
+    if (parser->Check("WITHSUFFIXTRIE")) {
+      params.with_suffixtrie = true;
+      continue;
+    }
+    if (parser->Check("NOSTEM")) {
+      params.no_stem = true;
+      continue;
+    }
+    break;
+  }
   return params;
 }
 
@@ -260,6 +278,20 @@ ParseResult<bool> ParsePrefix(CmdArgParser* parser, DocIndex* index) {
   return true;
 }
 
+ParseResult<bool> ParseIndexLanguage(CmdArgParser* parser, DocIndex* index) {
+  auto lang = ParseLanguageArg(parser);
+  if (!lang)
+    return make_unexpected(lang.error());
+  index->schema.language = std::move(lang).value();
+  return true;
+}
+
+ParseResult<bool> ParseIndexLanguageField(CmdArgParser* parser, DocIndex* /*index*/) {
+  auto attr = parser->Next<std::string_view>();
+  LOG(WARNING) << "Ignoring LANGUAGE_FIELD " << attr << " (not yet supported)";
+  return true;
+}
+
 // STOPWORDS count [words...]
 ParseResult<bool> ParseStopwords(CmdArgParser* parser, DocIndex* index) {
   index->options.stopwords.clear();
@@ -275,8 +307,8 @@ ParseResult<bool> ParseStopwords(CmdArgParser* parser, DocIndex* index) {
   return true;
 }
 
-constexpr std::array<const std::string_view, 4> kIgnoredOptions = {
-    "UNF"sv, "NOSTEM"sv, "INDEXMISSING"sv, "INDEXEMPTY"sv};
+constexpr std::array<const std::string_view, 3> kIgnoredOptions = {"UNF"sv, "INDEXMISSING"sv,
+                                                                   "INDEXEMPTY"sv};
 constexpr std::array<const std::string_view, 3> kIgnoredOptionsWithArg = {"WEIGHT"sv, "PHONETIC"sv};
 
 // SCHEMA field [AS alias] type [flags...]
@@ -327,6 +359,11 @@ ParseResult<bool> ParseSchema(CmdArgParser* parser, DocIndex* index) {
                                      search::SchemaField::SORTABLE);
       if (!flag) {
         std::string_view option = parser->Peek();
+        if (field_type == search::SchemaField::TEXT && option == "NOSTEM"sv) {
+          std::get<search::SchemaField::TextParams>(params).no_stem = true;
+          parser->Skip(1);
+          continue;
+        }
         if (rng::find(kIgnoredOptions, option) != kIgnoredOptions.end()) {
           LOG_IF(WARNING, option != "INDEXMISSING"sv && option != "INDEXEMPTY"sv)
               << "Ignoring unsupported field option in FT.CREATE: " << option;
@@ -364,7 +401,8 @@ ParseResult<DocIndex> CreateDocIndex(std::string_view name, CmdArgParser* parser
   while (parser->HasNext()) {
     auto option_parser =
         parser->TryMapNext("ON"sv, &ParseOnOption, "PREFIX"sv, &ParsePrefix, "STOPWORDS"sv,
-                           &ParseStopwords, "SCHEMA"sv, &ParseSchema);
+                           &ParseStopwords, "LANGUAGE"sv, &ParseIndexLanguage, "LANGUAGE_FIELD"sv,
+                           &ParseIndexLanguageField, "SCHEMA"sv, &ParseSchema);
 
     if (!option_parser) {
       // Unsupported parameters are ignored for now

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -163,7 +163,7 @@ ParseResult<search::SchemaField::TagParams> ParseTagParams(CmdArgParser* parser)
 
 ParseResult<std::string> ParseLanguageArg(CmdArgParser* parser) {
   std::string lang = absl::AsciiStrToLower(parser->Next<std::string_view>());
-  if (lang != "english") {
+  if (!search::Stemmer::TryCreate(lang)) {
     return CreateSyntaxError(absl::StrCat("Unsupported language: "sv, lang));
   }
   return lang;
@@ -282,13 +282,12 @@ ParseResult<bool> ParseIndexLanguage(CmdArgParser* parser, DocIndex* index) {
   auto lang = ParseLanguageArg(parser);
   if (!lang)
     return make_unexpected(lang.error());
-  index->schema.language = std::move(lang).value();
+  index->schema.default_language = std::move(lang).value();
   return true;
 }
 
-ParseResult<bool> ParseIndexLanguageField(CmdArgParser* parser, DocIndex* /*index*/) {
-  auto attr = parser->Next<std::string_view>();
-  LOG(WARNING) << "Ignoring LANGUAGE_FIELD " << attr << " (not yet supported)";
+ParseResult<bool> ParseIndexLanguageField(CmdArgParser* parser, DocIndex* index) {
+  index->schema.language_field = std::string{parser->Next<std::string_view>()};
   return true;
 }
 
@@ -1779,7 +1778,8 @@ void CmdFtInfo(CmdArgList args, CommandContext* cmd_cntx) {
 
   rb->SendSimpleString("index_definition");
   {
-    rb->StartCollection(4, CollectionType::MAP);
+    const bool has_lang_field = !schema.language_field.empty();
+    rb->StartCollection(has_lang_field ? 5 : 4, CollectionType::MAP);
     rb->SendSimpleString("key_type");
     rb->SendSimpleString(info.base_index.type == DocIndex::JSON ? "JSON" : "HASH");
     rb->SendSimpleString("prefixes");
@@ -1787,8 +1787,12 @@ void CmdFtInfo(CmdArgList args, CommandContext* cmd_cntx) {
     for (const auto& prefix : info.base_index.prefixes) {
       rb->SendBulkString(prefix);
     }
-    rb->SendSimpleString("language");
-    rb->SendSimpleString(schema.language);
+    rb->SendSimpleString("default_language");
+    rb->SendSimpleString(schema.default_language);
+    if (has_lang_field) {
+      rb->SendSimpleString("language_field");
+      rb->SendSimpleString(schema.language_field);
+    }
     rb->SendSimpleString("default_score");
     rb->SendLong(1);
   }

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -1779,7 +1779,7 @@ void CmdFtInfo(CmdArgList args, CommandContext* cmd_cntx) {
 
   rb->SendSimpleString("index_definition");
   {
-    rb->StartCollection(3, CollectionType::MAP);
+    rb->StartCollection(4, CollectionType::MAP);
     rb->SendSimpleString("key_type");
     rb->SendSimpleString(info.base_index.type == DocIndex::JSON ? "JSON" : "HASH");
     rb->SendSimpleString("prefixes");
@@ -1787,6 +1787,8 @@ void CmdFtInfo(CmdArgList args, CommandContext* cmd_cntx) {
     for (const auto& prefix : info.base_index.prefixes) {
       rb->SendBulkString(prefix);
     }
+    rb->SendSimpleString("language");
+    rb->SendSimpleString(schema.language);
     rb->SendSimpleString("default_score");
     rb->SendLong(1);
   }
@@ -1841,6 +1843,8 @@ void CmdFtInfo(CmdArgList args, CommandContext* cmd_cntx) {
       auto& tparams = std::get<search::SchemaField::TextParams>(field_info.special_params);
       if (tparams.with_suffixtrie)
         info.emplace_back("WITHSUFFIXTRIE");
+      if (tparams.no_stem)
+        info.emplace_back("NOSTEM");
     } else if (field_info.type == search::SchemaField::NUMERIC) {
       auto& numeric_params =
           std::get<search::SchemaField::NumericParams>(field_info.special_params);

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -296,7 +296,7 @@ TEST_F(SearchFamilyTest, AlterIndex) {
 }
 
 TEST_F(SearchFamilyTest, SuffixPrefixSearch) {
-  Run({"ft.create", "idx", "SCHEMA", "name", "TEXT", "NOSTEM"});
+  Run({"ft.create", "idx", "SCHEMA", "name", "TEXT"});
   Run({"hset", "d:1", "name", "apple"});
   Run({"hset", "d:2", "name", "carrot"});
 
@@ -319,8 +319,8 @@ TEST_F(SearchFamilyTest, InfoIndex) {
 
   auto info = Run({"ft.info", "idx-1"});
 
-  auto descriptor_matcher = IsArray("key_type", "HASH", "prefixes", IsArray("doc-"), "language",
-                                    "english", "default_score", 1);
+  auto descriptor_matcher = IsArray("key_type", "HASH", "prefixes", IsArray("doc-"),
+                                    "default_language", "english", "default_score", 1);
   auto schema_matcher = IsArray(IsArray("identifier", "name", "attribute", "name", "type", "TEXT"));
 
   EXPECT_THAT(info, IsArray(_, _, _, descriptor_matcher, "index_options", RespArray(IsEmpty()),
@@ -1070,7 +1070,7 @@ TEST_F(SearchFamilyTest, UnicodeWords) {
 }
 
 TEST_F(SearchFamilyTest, PrefixSuffixInfixTrie) {
-  Run({"ft.create", "i1", "schema", "title", "text", "withsuffixtrie", "nostem"});
+  Run({"ft.create", "i1", "schema", "title", "text", "withsuffixtrie"});
 
   Run({"hset", "d:1", "title", "CaspIAn SeA"});
   Run({"hset", "d:2", "title", "GreAt LakEs"});
@@ -1080,7 +1080,8 @@ TEST_F(SearchFamilyTest, PrefixSuffixInfixTrie) {
   EXPECT_THAT(Run({"ft.search", "i1", "*ea*"}), AreDocIds("d:1", "d:2"));
   EXPECT_THAT(Run({"ft.search", "i1", "*ia*"}), AreDocIds("d:1", "d:3"));
   EXPECT_THAT(Run({"ft.search", "i1", "lake*"}), AreDocIds("d:2", "d:3", "d:4"));
-  EXPECT_THAT(Run({"ft.search", "i1", "*lake"}), AreDocIds("d:3", "d:4"));
+  // d:2 ("LakEs") matches via the stem "lake" stored alongside the raw "lakes".
+  EXPECT_THAT(Run({"ft.search", "i1", "*lake"}), AreDocIds("d:2", "d:3", "d:4"));
 }
 
 struct SortTest : SearchFamilyTest, public testing::WithParamInterface<bool /* sortable */> {};
@@ -4629,8 +4630,8 @@ TEST_F(SearchFamilyTest, HnswVectorRangeAggregate) {
 
 TEST_F(SearchFamilyTest, GeoIndexFieldValidation) {
   // Test 1: Correct geo field definition and usage with HASH
-  auto resp = Run(
-      {"FT.CREATE", "idx_hash", "ON", "HASH", "SCHEMA", "name", "TEXT", "NOSTEM", "coords", "GEO"});
+  auto resp =
+      Run({"FT.CREATE", "idx_hash", "ON", "HASH", "SCHEMA", "name", "TEXT", "coords", "GEO"});
   EXPECT_EQ(resp, "OK");
 
   // Documents with correct geo fields
@@ -4677,7 +4678,7 @@ TEST_F(SearchFamilyTest, GeoIndexFieldValidation) {
 
   // Test 4: Correct geo field definition with JSON
   resp = Run({"FT.CREATE", "idx_json", "ON", "JSON", "SCHEMA", "$.name", "AS", "name", "TEXT",
-              "NOSTEM", "$.location", "AS", "location", "GEO"});
+              "$.location", "AS", "location", "GEO"});
   EXPECT_EQ(resp, "OK");
 
   // JSON documents with correct geo fields
@@ -5477,6 +5478,117 @@ TEST_F(SearchFamilyTest, InfoIndexDefaultStopwordsOmitted) {
 
   // Collection size is 7 (no stopwords_list field).
   EXPECT_THAT(info, IsArray(_, _, _, _, _, _, _, _, "num_docs", _, "indexing", _, _, _));
+}
+
+// TEXT fields stem by default; any morphological form matches the full set.
+TEST_F(SearchFamilyTest, StemmingDefault) {
+  Run({"FT.CREATE", "idx", "SCHEMA", "text", "TEXT"});
+  Run({"HSET", "t:n0", "text", "machine learning fundamentals"});
+  Run({"HSET", "t:n1", "text", "deep learning advanced"});
+  Run({"HSET", "t:n2", "text", "I will learn tomorrow"});
+  Run({"HSET", "t:n3", "text", "she learned yesterday"});
+
+  for (auto q : {"learn", "learning", "learns", "learned", "LEARNING"}) {
+    EXPECT_THAT(Run({"FT.SEARCH", "idx", absl::StrCat("@text:(", q, ")")}),
+                AreDocIds("t:n0", "t:n1", "t:n2", "t:n3"))
+        << "query: " << q;
+  }
+}
+
+// NOSTEM disables stemming for the field; queries match literal tokens only.
+TEST_F(SearchFamilyTest, StemmingNoStemAttribute) {
+  Run({"FT.CREATE", "idx", "SCHEMA", "text", "TEXT", "NOSTEM"});
+  Run({"HSET", "d:1", "text", "machine learning"});
+  Run({"HSET", "d:2", "text", "I will learn"});
+  Run({"HSET", "d:3", "text", "she learned yesterday"});
+
+  EXPECT_THAT(Run({"FT.SEARCH", "idx", "@text:(learn)"}), AreDocIds("d:2"));
+  EXPECT_THAT(Run({"FT.SEARCH", "idx", "@text:(learning)"}), AreDocIds("d:1"));
+  EXPECT_THAT(Run({"FT.SEARCH", "idx", "@text:(learned)"}), AreDocIds("d:3"));
+}
+
+// FT.AGGREGATE reuses the FT.SEARCH query path, so the initial filter stems.
+TEST_F(SearchFamilyTest, StemmingAggregateQueryFilter) {
+  Run({"FT.CREATE", "agg_idx", "SCHEMA", "text", "TEXT"});
+  Run({"HSET", "a:0", "text", "machine learning fundamentals"});
+  Run({"HSET", "a:1", "text", "deep learning advanced"});
+  Run({"HSET", "a:2", "text", "I will learn tomorrow"});
+  Run({"HSET", "a:3", "text", "she learned yesterday"});
+  Run({"HSET", "a:4", "text", "totally unrelated"});
+
+  auto resp = Run({"FT.AGGREGATE", "agg_idx", "@text:(learning)", "GROUPBY", "0", "REDUCE", "COUNT",
+                   "0", "AS", "cnt"});
+  EXPECT_THAT(resp, IsUnordArrayWithSize(IsMap("cnt", "4")));
+}
+
+// GROUPBY operates on raw field values; morphological variants stay distinct.
+TEST_F(SearchFamilyTest, StemmingAggregateGroupbyKeepsRaw) {
+  Run({"FT.CREATE", "agg_grp_idx", "SCHEMA", "tag", "TAG", "text", "TEXT"});
+  Run({"HSET", "g:1", "tag", "learning", "text", "irrelevant"});
+  Run({"HSET", "g:2", "tag", "learn", "text", "irrelevant"});
+  Run({"HSET", "g:3", "tag", "learned", "text", "irrelevant"});
+
+  auto resp = Run({"FT.AGGREGATE", "agg_grp_idx", "*", "GROUPBY", "1", "@tag", "REDUCE", "COUNT",
+                   "0", "AS", "n"});
+  EXPECT_THAT(resp, IsUnordArrayWithSize(IsMap("tag", "learning", "n", "1"),
+                                         IsMap("tag", "learn", "n", "1"),
+                                         IsMap("tag", "learned", "n", "1")));
+}
+
+// FT.INFO surfaces NOSTEM per-attribute and language in index_definition.
+TEST_F(SearchFamilyTest, StemmingInfoSurface) {
+  Run({"FT.CREATE", "info_idx", "ON", "HASH", "PREFIX", "1", "doc:", "SCHEMA", "title", "TEXT",
+       "body", "TEXT", "NOSTEM"});
+
+  auto info = Run({"FT.INFO", "info_idx"});
+  auto title_matcher = IsArray("identifier", "title", "attribute", "title", "type", "TEXT");
+  auto body_matcher = IsArray("identifier", "body", "attribute", "body", "type", "TEXT", "NOSTEM");
+  auto definition = IsArray("key_type", "HASH", "prefixes", IsArray("doc:"), "default_language",
+                            "english", "default_score", 1);
+  EXPECT_THAT(info, IsArray(_, _, _, definition, _, _, "attributes",
+                            IsUnordArray(title_matcher, body_matcher), _, _, _, _, _, _));
+}
+
+// LANGUAGE selects the algorithm; German Porter unifies Haus / Häuser / Hauses.
+TEST_F(SearchFamilyTest, StemmingMultilang) {
+  Run({"FT.CREATE", "de_idx", "LANGUAGE", "german", "SCHEMA", "body", "TEXT"});
+  Run({"HSET", "d:1", "body", "viele Häuser hier"});
+  Run({"HSET", "d:2", "body", "ein altes Haus"});
+  Run({"HSET", "d:3", "body", "des Hauses Wert"});
+  Run({"HSET", "d:4", "body", "etwas anderes"});
+
+  for (auto q : {"Haus", "Häuser", "Hauses"}) {
+    EXPECT_THAT(Run({"FT.SEARCH", "de_idx", absl::StrCat("@body:(", q, ")")}),
+                AreDocIds("d:1", "d:2", "d:3"))
+        << "query: " << q;
+  }
+
+  // Unsupported language is rejected at FT.CREATE.
+  EXPECT_THAT(Run({"FT.CREATE", "bad", "LANGUAGE", "klingon", "SCHEMA", "t", "TEXT"}),
+              ErrArg("Unsupported language"));
+}
+
+// LANGUAGE_FIELD selects the stemmer per-doc from a hash attribute.
+TEST_F(SearchFamilyTest, StemmingLanguageFieldPerDoc) {
+  Run({"FT.CREATE", "lf_idx", "LANGUAGE", "english", "LANGUAGE_FIELD", "lang", "SCHEMA", "body",
+       "TEXT", "lang", "TEXT", "NOSTEM"});
+
+  Run({"HSET", "d:en", "body", "machine learning", "lang", "english"});
+  Run({"HSET", "d:de", "body", "viele Häuser", "lang", "german"});
+  Run({"HSET", "d:fallback", "body", "she learned"});  // no lang -> schema default
+
+  // English Porter stems "learning" and "learned" to "learn".
+  EXPECT_THAT(Run({"FT.SEARCH", "lf_idx", "@body:(learn)"}), AreDocIds("d:en", "d:fallback"));
+
+  // German Porter stems "Häuser" to "Haus" for d:de.
+  EXPECT_THAT(Run({"FT.SEARCH", "lf_idx", "@body:(Haus)"}), AreDocIds("d:de"));
+
+  // FT.INFO exposes language_field.
+  auto info = Run({"FT.INFO", "lf_idx"});
+  auto definition =
+      IsArray("key_type", "HASH", "prefixes", RespArray(IsEmpty()), "default_language", "english",
+              "language_field", "lang", "default_score", 1);
+  EXPECT_THAT(info, IsArray(_, _, _, definition, _, _, _, _, _, _, _, _, _, _));
 }
 
 // Verify that BM25 text scores survive document expiration correctly:

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -319,8 +319,8 @@ TEST_F(SearchFamilyTest, InfoIndex) {
 
   auto info = Run({"ft.info", "idx-1"});
 
-  auto descriptor_matcher =
-      IsArray("key_type", "HASH", "prefixes", IsArray("doc-"), "default_score", 1);
+  auto descriptor_matcher = IsArray("key_type", "HASH", "prefixes", IsArray("doc-"), "language",
+                                    "english", "default_score", 1);
   auto schema_matcher = IsArray(IsArray("identifier", "name", "attribute", "name", "type", "TEXT"));
 
   EXPECT_THAT(info, IsArray(_, _, _, descriptor_matcher, "index_options", RespArray(IsEmpty()),

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -296,7 +296,7 @@ TEST_F(SearchFamilyTest, AlterIndex) {
 }
 
 TEST_F(SearchFamilyTest, SuffixPrefixSearch) {
-  Run({"ft.create", "idx", "SCHEMA", "name", "TEXT"});
+  Run({"ft.create", "idx", "SCHEMA", "name", "TEXT", "NOSTEM"});
   Run({"hset", "d:1", "name", "apple"});
   Run({"hset", "d:2", "name", "carrot"});
 
@@ -1070,7 +1070,7 @@ TEST_F(SearchFamilyTest, UnicodeWords) {
 }
 
 TEST_F(SearchFamilyTest, PrefixSuffixInfixTrie) {
-  Run({"ft.create", "i1", "schema", "title", "text", "withsuffixtrie"});
+  Run({"ft.create", "i1", "schema", "title", "text", "withsuffixtrie", "nostem"});
 
   Run({"hset", "d:1", "title", "CaspIAn SeA"});
   Run({"hset", "d:2", "title", "GreAt LakEs"});
@@ -4629,8 +4629,8 @@ TEST_F(SearchFamilyTest, HnswVectorRangeAggregate) {
 
 TEST_F(SearchFamilyTest, GeoIndexFieldValidation) {
   // Test 1: Correct geo field definition and usage with HASH
-  auto resp =
-      Run({"FT.CREATE", "idx_hash", "ON", "HASH", "SCHEMA", "name", "TEXT", "coords", "GEO"});
+  auto resp = Run(
+      {"FT.CREATE", "idx_hash", "ON", "HASH", "SCHEMA", "name", "TEXT", "NOSTEM", "coords", "GEO"});
   EXPECT_EQ(resp, "OK");
 
   // Documents with correct geo fields
@@ -4677,7 +4677,7 @@ TEST_F(SearchFamilyTest, GeoIndexFieldValidation) {
 
   // Test 4: Correct geo field definition with JSON
   resp = Run({"FT.CREATE", "idx_json", "ON", "JSON", "SCHEMA", "$.name", "AS", "name", "TEXT",
-              "$.location", "AS", "location", "GEO"});
+              "NOSTEM", "$.location", "AS", "location", "GEO"});
   EXPECT_EQ(resp, "OK");
 
   // JSON documents with correct geo fields

--- a/tests/dragonfly/search_test.py
+++ b/tests/dragonfly/search_test.py
@@ -139,6 +139,8 @@ async def test_management(async_client: aioredis.Redis):
         "HASH",
         "prefixes",
         ["p1"],
+        "default_language",
+        "english",
         "default_score",
         1,
     ]
@@ -164,6 +166,8 @@ async def test_management(async_client: aioredis.Redis):
         "HASH",
         "prefixes",
         ["p2"],
+        "default_language",
+        "english",
         "default_score",
         1,
     ]
@@ -1295,159 +1299,3 @@ async def test_ft_aggregate_addscores(async_client: aioredis.Redis):
         assert float(results[0]["__score"]) >= float(results[1]["__score"])
 
     await async_client.execute_command("FT.DROPINDEX", "agg_score_idx")
-
-
-@dfly_args({"proactor_threads": 4})
-async def test_ft_search_stemming_default(async_client: aioredis.Redis):
-    """Issue #7284: TEXT fields stem by default; query for any morphological form
-    matches all variants."""
-    await async_client.execute_command("FT.CREATE", "stem_idx", "SCHEMA", "text", "TEXT")
-    await async_client.hset("t:n0", mapping={"text": "machine learning fundamentals"})
-    await async_client.hset("t:n1", mapping={"text": "deep learning advanced"})
-    await async_client.hset("t:n2", mapping={"text": "I will learn tomorrow"})
-    await async_client.hset("t:n3", mapping={"text": "she learned yesterday"})
-
-    for query in ("learn", "learning", "learns", "learned"):
-        res = await async_client.execute_command(
-            "FT.SEARCH", "stem_idx", f"@text:({query})", "NOCONTENT"
-        )
-        assert res[0] == 4, f"query {query!r} expected 4 docs, got {res[0]}: {res}"
-
-    await async_client.execute_command("FT.DROPINDEX", "stem_idx")
-
-
-@dfly_args({"proactor_threads": 4})
-async def test_ft_search_nostem(async_client: aioredis.Redis):
-    """NOSTEM disables stemming for the field; queries match literal tokens only."""
-    await async_client.execute_command(
-        "FT.CREATE", "nostem_idx", "SCHEMA", "text", "TEXT", "NOSTEM"
-    )
-    await async_client.hset("d:1", mapping={"text": "machine learning"})
-    await async_client.hset("d:2", mapping={"text": "I will learn"})
-    await async_client.hset("d:3", mapping={"text": "she learned yesterday"})
-
-    res = await async_client.execute_command(
-        "FT.SEARCH", "nostem_idx", "@text:(learn)", "NOCONTENT"
-    )
-    assert res[0] == 1, f"expected only literal 'learn' match, got {res}"
-
-    res = await async_client.execute_command(
-        "FT.SEARCH", "nostem_idx", "@text:(learning)", "NOCONTENT"
-    )
-    assert res[0] == 1, f"expected only literal 'learning' match, got {res}"
-
-    await async_client.execute_command("FT.DROPINDEX", "nostem_idx")
-
-
-@dfly_args({"proactor_threads": 4})
-async def test_ft_search_wildcards_do_not_stem(async_client: aioredis.Redis):
-    """Wildcard queries operate on stored stems, not the unstemmed input
-    (Redis Stack parity). `learn*` matches; `learning*` does not."""
-    await async_client.execute_command("FT.CREATE", "wc_idx", "SCHEMA", "text", "TEXT")
-    await async_client.hset("d:1", mapping={"text": "machine learning"})
-    await async_client.hset("d:2", mapping={"text": "she learned"})
-    await async_client.hset("d:3", mapping={"text": "unrelated content"})
-
-    res = await async_client.execute_command("FT.SEARCH", "wc_idx", "learn*", "NOCONTENT")
-    assert res[0] == 2
-
-    res = await async_client.execute_command("FT.SEARCH", "wc_idx", "learning*", "NOCONTENT")
-    assert res[0] == 0
-
-    await async_client.execute_command("FT.DROPINDEX", "wc_idx")
-
-
-@dfly_args({"proactor_threads": 4})
-async def test_ft_aggregate_query_filter_stems(async_client: aioredis.Redis):
-    """FT.AGGREGATE reuses the FT.SEARCH query path, so the initial filter stems."""
-    await async_client.execute_command("FT.CREATE", "agg_idx", "SCHEMA", "text", "TEXT")
-    await async_client.hset("a:0", mapping={"text": "machine learning fundamentals"})
-    await async_client.hset("a:1", mapping={"text": "deep learning advanced"})
-    await async_client.hset("a:2", mapping={"text": "I will learn tomorrow"})
-    await async_client.hset("a:3", mapping={"text": "she learned yesterday"})
-    await async_client.hset("a:4", mapping={"text": "totally unrelated"})
-
-    def _decode(v):
-        return v.decode() if isinstance(v, bytes) else v
-
-    res = await async_client.execute_command(
-        "FT.AGGREGATE",
-        "agg_idx",
-        "@text:(learning)",
-        "GROUPBY",
-        "0",
-        "REDUCE",
-        "COUNT",
-        "0",
-        "AS",
-        "cnt",
-    )
-    assert res[0] == 1, f"expected one group row, got {res}"
-    row = {_decode(res[1][i]): _decode(res[1][i + 1]) for i in range(0, len(res[1]), 2)}
-    assert int(row["cnt"]) == 4, f"expected cnt=4 (stem expansion), got {row}"
-
-    await async_client.execute_command("FT.DROPINDEX", "agg_idx")
-
-
-@dfly_args({"proactor_threads": 4})
-async def test_ft_aggregate_groupby_does_not_stem(async_client: aioredis.Redis):
-    """GROUPBY operates on raw field values — stemming must NOT collapse
-    morphological variants into a single bucket."""
-    await async_client.execute_command(
-        "FT.CREATE", "agg_grp_idx", "SCHEMA", "tag", "TAG", "text", "TEXT"
-    )
-    await async_client.hset("g:1", mapping={"tag": "learning", "text": "irrelevant"})
-    await async_client.hset("g:2", mapping={"tag": "learn", "text": "irrelevant"})
-    await async_client.hset("g:3", mapping={"tag": "learned", "text": "irrelevant"})
-
-    # Group on TAG (raw value). All three should form distinct groups.
-    res = await async_client.execute_command(
-        "FT.AGGREGATE",
-        "agg_grp_idx",
-        "*",
-        "GROUPBY",
-        "1",
-        "@tag",
-        "REDUCE",
-        "COUNT",
-        "0",
-        "AS",
-        "n",
-    )
-    assert res[0] == 3, f"expected 3 distinct groups (learn/learning/learned), got {res[0]}: {res}"
-
-    await async_client.execute_command("FT.DROPINDEX", "agg_grp_idx")
-
-
-@dfly_args({"proactor_threads": 4})
-async def test_ft_info_surfaces_stemming(async_client: aioredis.Redis):
-    """FT.INFO surfaces NOSTEM per-attribute and `language` in index_definition."""
-    await async_client.execute_command(
-        "FT.CREATE", "info_idx", "SCHEMA", "title", "TEXT", "body", "TEXT", "NOSTEM"
-    )
-    info = await async_client.execute_command("FT.INFO", "info_idx")
-
-    def decode(v):
-        return v.decode() if isinstance(v, bytes) else v
-
-    flat = []
-    for v in info:
-        if isinstance(v, list):
-            flat.append([decode(x) if not isinstance(x, list) else x for x in v])
-        else:
-            flat.append(decode(v))
-
-    # index_definition is a flat key/value list at index 3
-    definition = {flat[3][i]: flat[3][i + 1] for i in range(0, len(flat[3]), 2)}
-    assert decode(definition["language"]) == "english", f"got {definition}"
-
-    # attributes: list of per-field attr arrays
-    attrs_idx = flat.index("attributes")
-    attrs = flat[attrs_idx + 1]
-    decoded_attrs = [[decode(x) for x in a] for a in attrs]
-    title_attr = next(a for a in decoded_attrs if "title" in a)
-    body_attr = next(a for a in decoded_attrs if "body" in a)
-    assert "NOSTEM" not in title_attr, f"title should not be NOSTEM: {title_attr}"
-    assert "NOSTEM" in body_attr, f"body should be NOSTEM: {body_attr}"
-
-    await async_client.execute_command("FT.DROPINDEX", "info_idx")

--- a/tests/dragonfly/search_test.py
+++ b/tests/dragonfly/search_test.py
@@ -1295,3 +1295,159 @@ async def test_ft_aggregate_addscores(async_client: aioredis.Redis):
         assert float(results[0]["__score"]) >= float(results[1]["__score"])
 
     await async_client.execute_command("FT.DROPINDEX", "agg_score_idx")
+
+
+@dfly_args({"proactor_threads": 4})
+async def test_ft_search_stemming_default(async_client: aioredis.Redis):
+    """Issue #7284: TEXT fields stem by default; query for any morphological form
+    matches all variants."""
+    await async_client.execute_command("FT.CREATE", "stem_idx", "SCHEMA", "text", "TEXT")
+    await async_client.hset("t:n0", mapping={"text": "machine learning fundamentals"})
+    await async_client.hset("t:n1", mapping={"text": "deep learning advanced"})
+    await async_client.hset("t:n2", mapping={"text": "I will learn tomorrow"})
+    await async_client.hset("t:n3", mapping={"text": "she learned yesterday"})
+
+    for query in ("learn", "learning", "learns", "learned"):
+        res = await async_client.execute_command(
+            "FT.SEARCH", "stem_idx", f"@text:({query})", "NOCONTENT"
+        )
+        assert res[0] == 4, f"query {query!r} expected 4 docs, got {res[0]}: {res}"
+
+    await async_client.execute_command("FT.DROPINDEX", "stem_idx")
+
+
+@dfly_args({"proactor_threads": 4})
+async def test_ft_search_nostem(async_client: aioredis.Redis):
+    """NOSTEM disables stemming for the field; queries match literal tokens only."""
+    await async_client.execute_command(
+        "FT.CREATE", "nostem_idx", "SCHEMA", "text", "TEXT", "NOSTEM"
+    )
+    await async_client.hset("d:1", mapping={"text": "machine learning"})
+    await async_client.hset("d:2", mapping={"text": "I will learn"})
+    await async_client.hset("d:3", mapping={"text": "she learned yesterday"})
+
+    res = await async_client.execute_command(
+        "FT.SEARCH", "nostem_idx", "@text:(learn)", "NOCONTENT"
+    )
+    assert res[0] == 1, f"expected only literal 'learn' match, got {res}"
+
+    res = await async_client.execute_command(
+        "FT.SEARCH", "nostem_idx", "@text:(learning)", "NOCONTENT"
+    )
+    assert res[0] == 1, f"expected only literal 'learning' match, got {res}"
+
+    await async_client.execute_command("FT.DROPINDEX", "nostem_idx")
+
+
+@dfly_args({"proactor_threads": 4})
+async def test_ft_search_wildcards_do_not_stem(async_client: aioredis.Redis):
+    """Wildcard queries operate on stored stems, not the unstemmed input
+    (Redis Stack parity). `learn*` matches; `learning*` does not."""
+    await async_client.execute_command("FT.CREATE", "wc_idx", "SCHEMA", "text", "TEXT")
+    await async_client.hset("d:1", mapping={"text": "machine learning"})
+    await async_client.hset("d:2", mapping={"text": "she learned"})
+    await async_client.hset("d:3", mapping={"text": "unrelated content"})
+
+    res = await async_client.execute_command("FT.SEARCH", "wc_idx", "learn*", "NOCONTENT")
+    assert res[0] == 2
+
+    res = await async_client.execute_command("FT.SEARCH", "wc_idx", "learning*", "NOCONTENT")
+    assert res[0] == 0
+
+    await async_client.execute_command("FT.DROPINDEX", "wc_idx")
+
+
+@dfly_args({"proactor_threads": 4})
+async def test_ft_aggregate_query_filter_stems(async_client: aioredis.Redis):
+    """FT.AGGREGATE reuses the FT.SEARCH query path, so the initial filter stems."""
+    await async_client.execute_command("FT.CREATE", "agg_idx", "SCHEMA", "text", "TEXT")
+    await async_client.hset("a:0", mapping={"text": "machine learning fundamentals"})
+    await async_client.hset("a:1", mapping={"text": "deep learning advanced"})
+    await async_client.hset("a:2", mapping={"text": "I will learn tomorrow"})
+    await async_client.hset("a:3", mapping={"text": "she learned yesterday"})
+    await async_client.hset("a:4", mapping={"text": "totally unrelated"})
+
+    def _decode(v):
+        return v.decode() if isinstance(v, bytes) else v
+
+    res = await async_client.execute_command(
+        "FT.AGGREGATE",
+        "agg_idx",
+        "@text:(learning)",
+        "GROUPBY",
+        "0",
+        "REDUCE",
+        "COUNT",
+        "0",
+        "AS",
+        "cnt",
+    )
+    assert res[0] == 1, f"expected one group row, got {res}"
+    row = {_decode(res[1][i]): _decode(res[1][i + 1]) for i in range(0, len(res[1]), 2)}
+    assert int(row["cnt"]) == 4, f"expected cnt=4 (stem expansion), got {row}"
+
+    await async_client.execute_command("FT.DROPINDEX", "agg_idx")
+
+
+@dfly_args({"proactor_threads": 4})
+async def test_ft_aggregate_groupby_does_not_stem(async_client: aioredis.Redis):
+    """GROUPBY operates on raw field values — stemming must NOT collapse
+    morphological variants into a single bucket."""
+    await async_client.execute_command(
+        "FT.CREATE", "agg_grp_idx", "SCHEMA", "tag", "TAG", "text", "TEXT"
+    )
+    await async_client.hset("g:1", mapping={"tag": "learning", "text": "irrelevant"})
+    await async_client.hset("g:2", mapping={"tag": "learn", "text": "irrelevant"})
+    await async_client.hset("g:3", mapping={"tag": "learned", "text": "irrelevant"})
+
+    # Group on TAG (raw value). All three should form distinct groups.
+    res = await async_client.execute_command(
+        "FT.AGGREGATE",
+        "agg_grp_idx",
+        "*",
+        "GROUPBY",
+        "1",
+        "@tag",
+        "REDUCE",
+        "COUNT",
+        "0",
+        "AS",
+        "n",
+    )
+    assert res[0] == 3, f"expected 3 distinct groups (learn/learning/learned), got {res[0]}: {res}"
+
+    await async_client.execute_command("FT.DROPINDEX", "agg_grp_idx")
+
+
+@dfly_args({"proactor_threads": 4})
+async def test_ft_info_surfaces_stemming(async_client: aioredis.Redis):
+    """FT.INFO surfaces NOSTEM per-attribute and `language` in index_definition."""
+    await async_client.execute_command(
+        "FT.CREATE", "info_idx", "SCHEMA", "title", "TEXT", "body", "TEXT", "NOSTEM"
+    )
+    info = await async_client.execute_command("FT.INFO", "info_idx")
+
+    def decode(v):
+        return v.decode() if isinstance(v, bytes) else v
+
+    flat = []
+    for v in info:
+        if isinstance(v, list):
+            flat.append([decode(x) if not isinstance(x, list) else x for x in v])
+        else:
+            flat.append(decode(v))
+
+    # index_definition is a flat key/value list at index 3
+    definition = {flat[3][i]: flat[3][i + 1] for i in range(0, len(flat[3]), 2)}
+    assert decode(definition["language"]) == "english", f"got {definition}"
+
+    # attributes: list of per-field attr arrays
+    attrs_idx = flat.index("attributes")
+    attrs = flat[attrs_idx + 1]
+    decoded_attrs = [[decode(x) for x in a] for a in attrs]
+    title_attr = next(a for a in decoded_attrs if "title" in a)
+    body_attr = next(a for a in decoded_attrs if "body" in a)
+    assert "NOSTEM" not in title_attr, f"title should not be NOSTEM: {title_attr}"
+    assert "NOSTEM" in body_attr, f"body should be NOSTEM: {body_attr}"
+
+    await async_client.execute_command("FT.DROPINDEX", "info_idx")


### PR DESCRIPTION
`@text:(learn)` now also returns documents containing `learning / learns / learned`, restoring recall parity for RAG pipelines that rely on `text_match` filters.

Behavior:
| Surface | After |
|---|---|
| TEXT field default | Snowball stem applied on index + query |
| `TEXT NOSTEM` | honored, disables stemming for that field |
| `LANGUAGE <lang>` | accepts any libstemmer algorithm (English, German, French, Russian, Spanish, Italian, ...; ISO-639 codes too) |
| `LANGUAGE_FIELD <attr>` | per-doc stemmer chosen from a hash attribute, falls back to schema default |
| `FT.INFO` | `index_definition.default_language`, optional `language_field`; per-attribute `NOSTEM` |
| `FT.AGGREGATE` query filter | inherits stemming via the shared `FT.SEARCH` path |
| Wildcards | match against both raw and stemmed forms stored side-by-side |

Architecture:

`TokenizeWords` emits the lowercased raw form, the Snowball stem (when it differs), and a synonym group reference when applicable. Storing raw + stem lets wildcards find unstemmed surface forms while exact-match queries hit the stem.

`Stemmer` is an RAII wrapper over `sb_stemmer`. Each `TextIndex` owns a default-language stemmer plus a lazily-populated `StemmerPool` keyed by language for `LANGUAGE_FIELD` documents. The existing share-nothing per-shard model gives instances their own thread for free - `sb_stemmer` is not thread-safe.

Synonyms remain language-agnostic on the storage side (so `SYNDUMP` output is unchanged). The query side ORs the original term with the group reference, so stem-equivalent terms still expand through synonyms.

Closes #7284