### PR TITLE
fix(search): guard RebuildForGroup against freed DocIds on lazy key expiry

### DIFF
--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -456,6 +456,8 @@ void ShardDocIndex::RebuildForGroup(const OpArgs& op_args, const std::string_vie
 
   auto update_indices = [&](bool remove) {
     for (DocId doc_id : docs_to_rebuild) {
+      if (!key_index_.IsValid(doc_id))
+        continue;
       std::string_view key = key_index_.Get(doc_id);
       auto it = db_slice.FindReadOnly(op_args.db_cntx, key, base_->GetObjCode());
 

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -5864,4 +5864,18 @@ TEST_F(SearchFamilyTest, SearchDeletesEmptyHash) {
   }
 }
 
+TEST_F(SearchFamilyTest, SynUpdateExpiredDocCrash) {
+  Run({"FT.CREATE", "idx", "ON", "HASH", "PREFIX", "1", "doc:", "SCHEMA", "title", "TEXT"});
+  Run({"HSET", "doc:1", "title", "cat"});
+
+  // Set a short TTL. The key remains in the prime table until lazily expired.
+  Run({"EXPIRE", "doc:1", "1"});
+  AdvanceTime(2000);  // TTL is now past; lazy expiry will fire on next lookup.
+
+  // Without the fix, RebuildForGroup's second update_indices pass calls
+  // key_index_.Get(DocId=0) after the first pass's FindReadOnly already triggered
+  // ExpireIfNeeded which freed DocId=0 — crashing on the DCHECK.
+  EXPECT_EQ(Run({"FT.SYNUPDATE", "idx", "group1", "cat"}), "OK");
+}
+
 }  // namespace dfly


### PR DESCRIPTION
`FT.SYNUPDATE` crashes with SIGABRT when an indexed key has an expired TTL that hasn't been lazily cleaned up yet. `FindReadOnly` inside `update_indices` fires `ExpireIfNeeded` -> `doc_del_cb_` -> `key_index_.Remove(id)`, moving the DocId to `free_ids_`. The second `update_indices` pass then calls `key_index_.Get(id)` on a freed DocId, tripping the DCHECK in `DocKeyIndex::Get`.

Fixes #7312