### PR TITLE
fix(tests): Transient 502 network errors crash test suite due to missing retries in urllib (#7238)

### DIFF
--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -25,7 +25,13 @@ from redis import asyncio as aioredis
 
 from . import PortPicker
 from .instance import DflyInstance, DflyParams, DflyInstanceFactory, RedisServer
-from .utility import DflySeederFactory, gen_ca_cert, gen_certificate, skip_if_not_in_github
+from .utility import (
+    DflySeederFactory,
+    gen_ca_cert,
+    gen_certificate,
+    skip_if_not_in_github,
+    download_with_retries,
+)
 
 logging.getLogger("asyncio").setLevel(logging.WARNING)
 # Suppress "Unclosed ClusterNode" warnings from redis-py topology refreshes (not actionable)
@@ -44,7 +50,6 @@ def _download_minio_binary(dest: Path):
     leaving a corrupt binary on interrupted downloads.
     """
     import platform
-    import urllib.request
 
     system = platform.system().lower()
     arch = platform.machine()
@@ -54,7 +59,7 @@ def _download_minio_binary(dest: Path):
     logging.info(f"Downloading MinIO binary from {url}")
     tmp_dest = dest.with_suffix(".tmp")
     try:
-        urllib.request.urlretrieve(url, tmp_dest)
+        download_with_retries(url, tmp_dest)
         tmp_dest.chmod(0o755)
         tmp_dest.rename(dest)
     except Exception:

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -6,7 +6,6 @@ import signal
 import struct
 import tarfile
 import time
-import urllib.request
 from itertools import chain, repeat
 
 import async_timeout
@@ -2662,7 +2661,7 @@ def download_dragonfly_release(version):
     logging.debug(f"Downloading Dragonfly release into {gzfile}...")
 
     # Download
-    urllib.request.urlretrieve(
+    download_with_retries(
         f"https://github.com/dragonflydb/dragonfly/releases/download/{version}/dragonfly-x86_64.tar.gz",
         gzfile,
     )

--- a/tests/dragonfly/requirements.txt
+++ b/tests/dragonfly/requirements.txt
@@ -31,4 +31,6 @@ hiredis==2.4.0
 PyYAML>=6.0.3
 valkey>=6.0.2
 celery>=5.3.0
+requests>=2.28.0
+urllib3>=1.26.0
 # bullmq>=2.0.0

--- a/tests/dragonfly/utility.py
+++ b/tests/dragonfly/utility.py
@@ -18,6 +18,10 @@ import fakeredis
 from typing import Iterable, Union
 from enum import Enum
 import re
+from shutil import copyfileobj
+from requests import Session
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 
 def tmp_file_name():
@@ -37,6 +41,25 @@ def chunked(n, iterable):
 def eprint(*args, **kwargs):
     """Print to stderr"""
     print(*args, file=sys.stderr, **kwargs)
+
+
+def download_with_retries(url, dest, max_retries: int = 5) -> None:
+    """Download a file from url to dest with exponential backoff retries."""
+    adapter = HTTPAdapter(
+        max_retries=Retry(
+            total=max_retries,
+            backoff_factor=1,
+            status_forcelist=[500, 502, 503, 504],
+            raise_on_status=True,
+        )
+    )
+    with Session() as session:
+        session.mount("https://", adapter)
+        with session.get(url, stream=True) as r:
+            r.raise_for_status()
+            r.raw.decode_content = True
+            with open(dest, "wb") as f:
+                copyfileobj(r.raw, f)
 
 
 def gen_test_data(n, start=0, seed=None):


### PR DESCRIPTION
Fixes a test suite flake where transient 502 Bad Gateway errors caused urllib downloads to fail immediately instead of retrying with exponential back-off.

Changes:
- Replaces urllib.request.urlretrieve with requests.Session and urllib3.Retry to handle transient 5xx errors and network failures with exponential backoff.

Closes #7238