### PR TITLE
fix(ci): install libheif codec plugins for HEIC/AV1 support in Mastodon tests

### DIFF
--- a/.github/workflows/mastodon-ruby-tests.yml
+++ b/.github/workflows/mastodon-ruby-tests.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install pre-requisites
         run: |
           sudo apt update
-          sudo apt install -y libicu-dev libidn11-dev libvips42 ffmpeg imagemagick libpam-dev
+          sudo apt install -y libicu-dev libidn11-dev libvips42 libheif-plugin-libde265 libheif-plugin-dav1d ffmpeg imagemagick libpam-dev
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/mastodon-ruby-tests.yml
+++ b/.github/workflows/mastodon-ruby-tests.yml
@@ -56,6 +56,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: mastodon/mastodon
+          ref: 8bbde181db0d6d79018fb1754a8296e753d47415
       - name: Install pre-requisites
         run: |
           sudo apt update


### PR DESCRIPTION
The Mastodon ruby test suite was failing daily with `heif: Unsupported feature: Unsupported codec (4.3000)` when processing a HEIC fixture file that uses AV1 encoding. On Ubuntu 24.04, libheif uses a plugin architecture - codec support is loaded dynamically from separate packages that are not automatically pulled in via `libvips42`.

https://github.com/dragonflydb/dragonfly/actions/runs/25984156368/job/76378291227
https://github.com/dragonflydb/dragonfly/actions/runs/25986392914/job/76384405378