### PR TITLE
fix(server): Fix iterator invalidation

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1378,7 +1378,10 @@ void DbSlice::FlushChangeToEarlierCallbacks(DbIndex db_ind, Iterator it, uint64_
     // does not change during the serialization, therefore we allow at most one serializer
     // reading the bucket at the same time.
     if (bucket_version <= cb_version) {
-      ccb->second(db_ind, ChangeReq{it.GetInnerIt()});
+      // Key might have been deleted because another FlushChangeToEarlierCallbacks finished
+      // and allowed a mutation to pass while this one was suspended
+      if (auto inner_it = it.GetInnerIt(); !inner_it.is_done())
+        ccb->second(db_ind, ChangeReq{inner_it});
     }
     ++ccb;
   }


### PR DESCRIPTION
Fixes #7282 

Since recently multiple "Flush change to earlier callback" calls can be running at the same time

https://github.com/dragonflydb/dragonfly/blob/82178599f330e9d470fd6c92a79412502865f30b/src/server/serializer_base.cc#L174-L177

It can happen that one such call finishes earlier than the others, unblocking some kind of write that caused it and allowing the write to delete the key. The other "flush" call proceeds with an invalid iterator