### PR TITLE
feat(search): exact phrase queries with slop and BM25 scoring

### DIFF
--- a/src/core/search/ast_expr.h
+++ b/src/core/search/ast_expr.h
@@ -38,8 +38,9 @@ using AstSuffixNode = AstAffixNode<TagType::SUFFIX>;
 using AstInfixNode = AstAffixNode<TagType::INFIX>;
 
 // Quoted multi-word phrase. `raw` is the unsplit content between quotes;
-// the executor lowercases, splits on whitespace, drops stopwords (without
-// advancing positions), then matches against raw posting-list positions.
+// the executor tokenizes via ICU word boundaries (same as indexing), lowercases,
+// drops stopwords (without advancing positions), then matches against raw
+// posting-list positions.
 // `slop` = max number of intervening tokens allowed between consecutive phrase
 // terms (in order). slop=0 = exact adjacency (the default for `"..."`); slop>0
 // comes from `"..."~N` syntax.

--- a/src/core/search/ast_expr.h
+++ b/src/core/search/ast_expr.h
@@ -37,6 +37,20 @@ using AstPrefixNode = AstAffixNode<TagType::PREFIX>;
 using AstSuffixNode = AstAffixNode<TagType::SUFFIX>;
 using AstInfixNode = AstAffixNode<TagType::INFIX>;
 
+// Quoted multi-word phrase. `raw` is the unsplit content between quotes;
+// the executor lowercases, splits on whitespace, drops stopwords (without
+// advancing positions), then matches against raw posting-list positions.
+// `slop` = max number of intervening tokens allowed between consecutive phrase
+// terms (in order). slop=0 = exact adjacency (the default for `"..."`); slop>0
+// comes from `"..."~N` syntax.
+struct AstPhraseNode {
+  explicit AstPhraseNode(std::string raw, uint32_t slop = 0) : raw{std::move(raw)}, slop{slop} {
+  }
+
+  std::string raw;
+  uint32_t slop = 0;
+};
+
 // Matches numeric range
 struct AstRangeNode {
   AstRangeNode(double lo, bool lo_excl, double hi, bool hi_excl);
@@ -175,10 +189,11 @@ struct AstVectorRangeNode {
   std::string score_alias;
 };
 
-using NodeVariants = std::variant<std::monostate, AstStarNode, AstStarFieldNode, AstTermNode,
-                                  AstPrefixNode, AstSuffixNode, AstInfixNode, AstRangeNode,
-                                  AstNegateNode, AstOptionalNode, AstLogicalNode, AstFieldNode,
-                                  AstTagsNode, AstKnnNode, AstGeoNode, AstVectorRangeNode>;
+using NodeVariants =
+    std::variant<std::monostate, AstStarNode, AstStarFieldNode, AstTermNode, AstPrefixNode,
+                 AstSuffixNode, AstInfixNode, AstPhraseNode, AstRangeNode, AstNegateNode,
+                 AstOptionalNode, AstLogicalNode, AstFieldNode, AstTagsNode, AstKnnNode, AstGeoNode,
+                 AstVectorRangeNode>;
 
 struct AstNode : public NodeVariants {
   using variant::variant;

--- a/src/core/search/block_list.cc
+++ b/src/core/search/block_list.cc
@@ -104,10 +104,11 @@ SplitResult Split(BlockList<SortedVector<std::pair<DocId, double>>>&& block_list
 namespace {
 
 // Helper to create a new block with the right constructor args.
-// CompressedSortedSet takes (mr, store_freq); other containers take (mr).
-template <typename Container> Container MakeBlock(PMR_NS::memory_resource* mr, bool store_freq) {
+// CompressedSortedSet takes (mr, store_freq, store_positions); other containers take (mr).
+template <typename Container>
+Container MakeBlock(PMR_NS::memory_resource* mr, bool store_freq, bool store_positions) {
   if constexpr (std::is_same_v<Container, CompressedSortedSet>) {
-    return Container{mr, store_freq};
+    return Container{mr, store_freq, store_positions};
   } else {
     return Container{mr};
   }
@@ -115,13 +116,14 @@ template <typename Container> Container MakeBlock(PMR_NS::memory_resource* mr, b
 
 }  // namespace
 
-template <typename C> bool BlockList<C>::Insert(ElementType t, uint32_t freq) {
+template <typename C>
+bool BlockList<C>::Insert(ElementType t, uint32_t freq, absl::Span<const uint32_t> positions) {
   auto block = FindBlock(t);
   if (block == blocks_.end())
-    block = blocks_.insert(blocks_.end(),
-                           MakeBlock<C>(blocks_.get_allocator().resource(), store_freq_));
+    block = blocks_.insert(blocks_.end(), MakeBlock<C>(blocks_.get_allocator().resource(),
+                                                       store_freq_, store_positions_));
 
-  if (!block->Insert(std::move(t), freq))
+  if (!block->Insert(std::move(t), freq, positions))
     return false;
 
   size_++;
@@ -129,14 +131,16 @@ template <typename C> bool BlockList<C>::Insert(ElementType t, uint32_t freq) {
   return true;
 }
 
-template <typename C> bool BlockList<C>::PushBack(ElementType t, uint32_t freq) {
+template <typename C>
+bool BlockList<C>::PushBack(ElementType t, uint32_t freq, absl::Span<const uint32_t> positions) {
   // If the last block is full, after insert we will need to split it
   // So we can prevent split by creating a new block and inserting there
   if (blocks_.empty() || ShouldSplit(blocks_.back().Size() + 1)) {
-    blocks_.insert(blocks_.end(), MakeBlock<C>(blocks_.get_allocator().resource(), store_freq_));
+    blocks_.insert(blocks_.end(),
+                   MakeBlock<C>(blocks_.get_allocator().resource(), store_freq_, store_positions_));
   }
 
-  if (!blocks_.back().Insert(std::move(t), freq))
+  if (!blocks_.back().Insert(std::move(t), freq, positions))
     return false;
 
   size_++;

--- a/src/core/search/block_list.h
+++ b/src/core/search/block_list.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <absl/types/span.h>
+
 #include <algorithm>
 #include <cstdint>
 #include <iterator>
@@ -35,15 +37,22 @@ template <typename Container /* underlying container */> class BlockList {
   using ElementType = typename Container::ElementType;
 
  public:
-  // store_freq: forwarded to CompressedSortedSet blocks (ignored for other container types).
-  BlockList(PMR_NS::memory_resource* mr, size_t block_size = 1000, bool store_freq = false)
-      : block_size_{block_size}, store_freq_{store_freq}, blocks_(mr) {
+  // store_freq / store_positions: forwarded to CompressedSortedSet blocks (ignored for other
+  // container types). store_positions implies store_freq.
+  BlockList(PMR_NS::memory_resource* mr, size_t block_size = 1000, bool store_freq = false,
+            bool store_positions = false)
+      : block_size_{block_size},
+        store_freq_{store_freq || store_positions},
+        store_positions_{store_positions},
+        blocks_(mr) {
   }
 
   BlockList(const BlockList& other) = default;
 
   BlockList(BlockList&& other) noexcept
-      : block_size_{other.block_size_}, store_freq_{other.store_freq_} {
+      : block_size_{other.block_size_},
+        store_freq_{other.store_freq_},
+        store_positions_{other.store_positions_} {
     // Consider not to do move if block_size_ is different
     // DCHECK(block_size_ == other.block_size_);
     // It seams there is bugs in BaseStringIndex
@@ -60,9 +69,9 @@ template <typename Container /* underlying container */> class BlockList {
   ~BlockList() = default;
 
   // Insert element, returns true if inserted, false if already present.
-  // freq parameter is forwarded to underlying container (used by CompressedSortedSet for TF).
-  bool Insert(ElementType t, uint32_t freq = 1);
-  bool PushBack(ElementType t, uint32_t freq = 1);
+  // freq and positions are forwarded to the underlying container (CompressedSortedSet).
+  bool Insert(ElementType t, uint32_t freq = 1, absl::Span<const uint32_t> positions = {});
+  bool PushBack(ElementType t, uint32_t freq = 1, absl::Span<const uint32_t> positions = {});
 
   // Remove element, returns true if removed, false if not found.
   bool Remove(ElementType t);
@@ -103,6 +112,16 @@ template <typename Container /* underlying container */> class BlockList {
         return block_it.Freq();
       } else {
         return 1;
+      }
+    }
+
+    // Sorted positions for the current term in the current document.
+    // Only valid (non-empty) for BlockList<CompressedSortedSet> with store_positions=true.
+    absl::Span<const uint32_t> Positions() const {
+      if constexpr (requires { block_it.Positions(); }) {
+        return block_it.Positions();
+      } else {
+        return {};
       }
     }
 
@@ -156,7 +175,8 @@ template <typename Container /* underlying container */> class BlockList {
 
  private:
   const size_t block_size_ = 1000;
-  bool store_freq_ = false;  // Forwarded to CompressedSortedSet blocks
+  bool store_freq_ = false;       // Forwarded to CompressedSortedSet blocks
+  bool store_positions_ = false;  // Forwarded to CompressedSortedSet blocks
   size_t size_ = 0;
   PMR_NS::vector<Container> blocks_;
 };
@@ -171,8 +191,8 @@ template <typename T> class SortedVector {
   }
 
   bool Insert(T t);
-  // TODO: store freq when SortedVector-based indices need TF scoring.
-  bool Insert(T t, uint32_t /*freq*/) {
+  // TODO: store freq/positions when SortedVector-based indices need TF scoring or phrase queries.
+  bool Insert(T t, uint32_t /*freq*/, absl::Span<const uint32_t> /*positions*/ = {}) {
     return Insert(std::move(t));
   }
   bool Remove(T t);

--- a/src/core/search/compressed_sorted_set.cc
+++ b/src/core/search/compressed_sorted_set.cc
@@ -240,30 +240,13 @@ bool CompressedSortedSet::Insert(IntType value, uint32_t freq,
                         diff2_span.size() + freq2_span.size() + bound_pos_span.size();
   DCHECK_LE(bound.entry_span.size(), required_len);  // It can't shrink for sure
 
-  // bound_pos_span points into diffs_; capture its offset before any insert() invalidates it.
-  ptrdiff_t bound_pos_offset = store_positions_ ? bound_pos_span.data() - diffs_.data() : 0;
-  size_t bound_pos_size = bound_pos_span.size();
-
+  // Insert padding zeros at entry_offset. This shifts bound's existing positions block right by
+  // exactly the right amount: its new location coincides with entry 2's positions slot in the
+  // final layout, so we don't need to move those bytes explicitly.
   diffs_.insert(diffs_.begin() + entry_offset, required_len - bound.entry_span.size(), 0u);
 
-  // The original positions bytes shifted right by `shift` after the insert above.
-  size_t shift = required_len - bound.entry_span.size();
-  // Move bound's positions block to its final destination (entry 2's tail) before
-  // overwriting earlier bytes that would clobber it.
-  if (store_positions_ && bound_pos_size > 0) {
-    size_t old_pos_pos = bound_pos_offset + shift;
-    size_t new_pos_pos = entry_offset + diff1_span.size() + freq1_span.size() +
-                         new_pos_bytes.size() + diff2_span.size() + freq2_span.size();
-    // Memmove-style: regions may overlap but we always move right-to-left here since
-    // new entries are written from entry_offset onward; preserve bytes by copying first.
-    if (new_pos_pos != old_pos_pos) {
-      std::vector<uint8_t> scratch(diffs_.begin() + old_pos_pos,
-                                   diffs_.begin() + old_pos_pos + bound_pos_size);
-      std::copy(scratch.begin(), scratch.end(), diffs_.begin() + new_pos_pos);
-    }
-  }
-
-  // Now overwrite old entry with the two new entries (heads only; positions already placed).
+  // Overwrite old entry's prefix with the two new entries (heads + new entry's positions only;
+  // bound's original positions sit untouched at entry_offset + (left half size)).
   auto out = diffs_.begin() + entry_offset;
   out = copy(diff1_span.begin(), diff1_span.end(), out);
   out = copy(freq1_span.begin(), freq1_span.end(), out);

--- a/src/core/search/compressed_sorted_set.cc
+++ b/src/core/search/compressed_sorted_set.cc
@@ -17,12 +17,16 @@ using VarintBuffer = array<uint8_t, sizeof(CompressedSortedSet::IntType) * 3>;
 
 }  // namespace
 
-CompressedSortedSet::CompressedSortedSet(PMR_NS::memory_resource* mr, bool store_freq)
-    : store_freq_{store_freq}, diffs_{mr} {
+CompressedSortedSet::CompressedSortedSet(PMR_NS::memory_resource* mr, bool store_freq,
+                                         bool store_positions)
+    : store_freq_{store_freq || store_positions}, store_positions_{store_positions}, diffs_{mr} {
 }
 
 CompressedSortedSet::ConstIterator::ConstIterator(const CompressedSortedSet& list)
-    : stash_{}, store_freq_{list.store_freq_}, diffs_{list.diffs_} {
+    : stash_{},
+      store_freq_{list.store_freq_},
+      store_positions_{list.store_positions_},
+      diffs_{list.diffs_} {
   ReadNext();
 }
 
@@ -34,6 +38,11 @@ CompressedSortedSet::IntType CompressedSortedSet::ConstIterator::operator*() con
 uint32_t CompressedSortedSet::ConstIterator::Freq() const {
   DCHECK(stash_);
   return freq_stash_;
+}
+
+absl::Span<const uint32_t> CompressedSortedSet::ConstIterator::Positions() const {
+  DCHECK(stash_);
+  return {positions_stash_.data(), positions_stash_.size()};
 }
 
 CompressedSortedSet::ConstIterator& CompressedSortedSet::ConstIterator::operator++() {
@@ -51,8 +60,12 @@ bool operator!=(const CompressedSortedSet::ConstIterator& l,
   return !(l == r);
 }
 
-// Each entry is encoded as: [diff_varint] or [diff_varint][freq_varint] when store_freq_ is set.
+// Entry layout per ctor flags:
+//   none:       [diff_varint]
+//   freq:       [diff_varint][freq_varint]
+//   +positions: [diff_varint][freq_varint][pos0_varint][pos1_delta_varint]...[pos(freq-1)_delta]
 void CompressedSortedSet::ConstIterator::ReadNext() {
+  positions_stash_.clear();
   if (diffs_.empty()) {
     stash_ = nullopt;
     freq_stash_ = 0;
@@ -68,11 +81,24 @@ void CompressedSortedSet::ConstIterator::ReadNext() {
   stash_ = base + diff;
 
   if (store_freq_) {
-    auto [freq, freq_read] = CompressedSortedSet::ReadVarLen(diffs_.subspan(diff_read));
+    auto [freq, freq_read] = CompressedSortedSet::ReadVarLen(diffs_.subspan(total_read));
     freq_stash_ = freq;
     total_read += freq_read;
   } else {
     freq_stash_ = 1;
+  }
+
+  if (store_positions_) {
+    positions_stash_.reserve(freq_stash_);
+    uint32_t prev = 0;
+    for (uint32_t i = 0; i < freq_stash_; ++i) {
+      auto [pos_delta, pos_read] = CompressedSortedSet::ReadVarLen(diffs_.subspan(total_read));
+      uint32_t pos =
+          (i == 0) ? static_cast<uint32_t>(pos_delta) : prev + static_cast<uint32_t>(pos_delta);
+      positions_stash_.push_back(pos);
+      prev = pos;
+      total_read += pos_read;
+    }
   }
 
   last_read_ = diffs_.subspan(0, total_read);
@@ -87,8 +113,9 @@ CompressedSortedSet::ConstIterator CompressedSortedSet::end() const {
   return ConstIterator{};
 }
 
-// Encode difference (and optionally freq) and add to end of diffs array
-void CompressedSortedSet::PushBackDiff(IntType diff, uint32_t freq) {
+// Encode difference (and optionally freq + positions) and add to end of diffs array
+void CompressedSortedSet::PushBackDiff(IntType diff, uint32_t freq,
+                                       absl::Span<const uint32_t> positions) {
   size_++;
 
   VarintBuffer buf;
@@ -98,6 +125,17 @@ void CompressedSortedSet::PushBackDiff(IntType diff, uint32_t freq) {
   if (store_freq_) {
     auto freq_span = WriteVarLen(freq, absl::MakeSpan(buf));
     diffs_.insert(diffs_.end(), freq_span.begin(), freq_span.end());
+  }
+
+  if (store_positions_) {
+    DCHECK_EQ(positions.size(), freq);
+    uint32_t prev = 0;
+    for (size_t i = 0; i < positions.size(); ++i) {
+      uint32_t to_write = (i == 0) ? positions[i] : positions[i] - prev;
+      auto pos_span = WriteVarLen(to_write, absl::MakeSpan(buf));
+      diffs_.insert(diffs_.end(), pos_span.begin(), pos_span.end());
+      prev = positions[i];
+    }
   }
 }
 
@@ -118,16 +156,28 @@ CompressedSortedSet::EntryLocation CompressedSortedSet::LowerBound(IntType value
                        .entry_span = it.last_read_};
 }
 
+size_t CompressedSortedSet::HeadSize(absl::Span<const uint8_t> entry_span, bool store_freq) {
+  auto [_diff, d_read] = ReadVarLen(entry_span);
+  if (!store_freq)
+    return d_read;
+  auto [_freq, f_read] = ReadVarLen(entry_span.subspan(d_read));
+  return d_read + f_read;
+}
+
 // Insert has linear complexity. It tries to find between which two entries A and B the new value V
 // needs to be inserted. Then it computes the differences dif1 = V - A and diff2 = B - V that need
 // to be stored where diff0 = B - A was previously stored, possibly extending the vector.
-// Each entry is [diff_varint] or [diff_varint][freq_varint] when store_freq_ is set.
-bool CompressedSortedSet::Insert(IntType value, uint32_t freq) {
+// When store_positions_ is set, the bound's original positions block is preserved verbatim and
+// becomes the right half of the replacement; the new entry contributes positions for V.
+bool CompressedSortedSet::Insert(IntType value, uint32_t freq,
+                                 absl::Span<const uint32_t> positions) {
+  DCHECK(!store_positions_ || positions.size() == freq);
+
   if (tail_value_ && *tail_value_ == value)
     return false;
 
   if (tail_value_ && value > *tail_value_) {
-    PushBackDiff(value - *tail_value_, freq);
+    PushBackDiff(value - *tail_value_, freq, positions);
     tail_value_ = value;
     return true;
   }
@@ -142,7 +192,7 @@ bool CompressedSortedSet::Insert(IntType value, uint32_t freq) {
 
   // Value is bigger than any other (or list is empty): append required diff at the end
   if (value > bound.value || bound.entry_span.empty()) {
-    PushBackDiff(value - bound.value, freq);
+    PushBackDiff(value - bound.value, freq, positions);
     tail_value_ = value;
     return true;
   }
@@ -164,17 +214,60 @@ bool CompressedSortedSet::Insert(IntType value, uint32_t freq) {
     freq2_span = WriteVarLen(bound.freq, absl::MakeSpan(buf4));
   }
 
-  // Extend the location where the old entry is stored with optional zeros before overwriting it
+  // Bound's original positions block is preserved as the right half (entry for B).
+  absl::Span<const uint8_t> bound_pos_span;
+  if (store_positions_) {
+    size_t head = CompressedSortedSet::HeadSize(bound.entry_span, store_freq_);
+    bound_pos_span = bound.entry_span.subspan(head);
+  }
+
+  // New entry's positions block (for V), encoded into a small scratch buffer.
+  absl::InlinedVector<uint8_t, 16> new_pos_bytes;
+  if (store_positions_) {
+    uint32_t prev = 0;
+    VarintBuffer pbuf;
+    for (size_t i = 0; i < positions.size(); ++i) {
+      uint32_t to_write = (i == 0) ? positions[i] : positions[i] - prev;
+      auto sp = WriteVarLen(to_write, absl::MakeSpan(pbuf));
+      new_pos_bytes.insert(new_pos_bytes.end(), sp.begin(), sp.end());
+      prev = positions[i];
+    }
+  }
+
+  // Extend storage to fit both new entries; old entry will be overwritten in place.
   ptrdiff_t entry_offset = bound.entry_span.data() - diffs_.data();
-  size_t required_len =
-      diff1_span.size() + freq1_span.size() + diff2_span.size() + freq2_span.size();
+  size_t required_len = diff1_span.size() + freq1_span.size() + new_pos_bytes.size() +
+                        diff2_span.size() + freq2_span.size() + bound_pos_span.size();
   DCHECK_LE(bound.entry_span.size(), required_len);  // It can't shrink for sure
+
+  // bound_pos_span points into diffs_; capture its offset before any insert() invalidates it.
+  ptrdiff_t bound_pos_offset = store_positions_ ? bound_pos_span.data() - diffs_.data() : 0;
+  size_t bound_pos_size = bound_pos_span.size();
+
   diffs_.insert(diffs_.begin() + entry_offset, required_len - bound.entry_span.size(), 0u);
 
-  // Now overwrite old entry with the two new entries
+  // The original positions bytes shifted right by `shift` after the insert above.
+  size_t shift = required_len - bound.entry_span.size();
+  // Move bound's positions block to its final destination (entry 2's tail) before
+  // overwriting earlier bytes that would clobber it.
+  if (store_positions_ && bound_pos_size > 0) {
+    size_t old_pos_pos = bound_pos_offset + shift;
+    size_t new_pos_pos = entry_offset + diff1_span.size() + freq1_span.size() +
+                         new_pos_bytes.size() + diff2_span.size() + freq2_span.size();
+    // Memmove-style: regions may overlap but we always move right-to-left here since
+    // new entries are written from entry_offset onward; preserve bytes by copying first.
+    if (new_pos_pos != old_pos_pos) {
+      std::vector<uint8_t> scratch(diffs_.begin() + old_pos_pos,
+                                   diffs_.begin() + old_pos_pos + bound_pos_size);
+      std::copy(scratch.begin(), scratch.end(), diffs_.begin() + new_pos_pos);
+    }
+  }
+
+  // Now overwrite old entry with the two new entries (heads only; positions already placed).
   auto out = diffs_.begin() + entry_offset;
   out = copy(diff1_span.begin(), diff1_span.end(), out);
   out = copy(freq1_span.begin(), freq1_span.end(), out);
+  out = copy(new_pos_bytes.begin(), new_pos_bytes.end(), out);
   out = copy(diff2_span.begin(), diff2_span.end(), out);
   copy(freq2_span.begin(), freq2_span.end(), out);
 
@@ -244,16 +337,17 @@ bool CompressedSortedSet::Remove(IntType value) {
 
 void CompressedSortedSet::Merge(CompressedSortedSet&& other) {
   DCHECK_EQ(store_freq_, other.store_freq_);
+  DCHECK_EQ(store_positions_, other.store_positions_);
   // Quadratic compexity in theory, but in practice used only to merge with larger values.
   // Tail insert optimization makes it linear
   for (auto it = other.begin(); it != other.end(); ++it)
-    Insert(*it, it.Freq());
+    Insert(*it, it.Freq(), it.Positions());
 }
 
 std::pair<CompressedSortedSet, CompressedSortedSet> CompressedSortedSet::Split() && {
   DCHECK_GT(Size(), 5u);
 
-  CompressedSortedSet second(diffs_.get_allocator().resource(), store_freq_);
+  CompressedSortedSet second(diffs_.get_allocator().resource(), store_freq_, store_positions_);
 
   // Move iterator to middle position and save size of diffs tail
   auto it = begin();
@@ -267,7 +361,7 @@ std::pair<CompressedSortedSet, CompressedSortedSet> CompressedSortedSet::Split()
 
   // Copy second half into second set
   for (; it != end(); ++it)
-    second.Insert(*it, it.Freq());
+    second.Insert(*it, it.Freq(), it.Positions());
 
   // Erase diffs tail
   diffs_.resize(keep_bytes);

--- a/src/core/search/compressed_sorted_set.h
+++ b/src/core/search/compressed_sorted_set.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <absl/container/inlined_vector.h>
 #include <absl/types/span.h>
 
 #include <cstdint>
@@ -52,7 +51,7 @@ class CompressedSortedSet {
 
     std::optional<IntType> stash_{};
     uint32_t freq_stash_{0};
-    absl::InlinedVector<uint32_t, 4> positions_stash_;
+    std::vector<uint32_t> positions_stash_;
     bool store_freq_{false};
     bool store_positions_{false};
     absl::Span<const uint8_t> last_read_{};

--- a/src/core/search/compressed_sorted_set.h
+++ b/src/core/search/compressed_sorted_set.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <absl/container/inlined_vector.h>
 #include <absl/types/span.h>
 
 #include <cstdint>
@@ -34,6 +35,8 @@ class CompressedSortedSet {
 
     IntType operator*() const;
     uint32_t Freq() const;
+    // Sorted ascending. Empty when the owning set is store_positions_=false.
+    absl::Span<const uint32_t> Positions() const;
     ConstIterator& operator++();
 
     friend class CompressedSortedSet;
@@ -49,7 +52,9 @@ class CompressedSortedSet {
 
     std::optional<IntType> stash_{};
     uint32_t freq_stash_{0};
+    absl::InlinedVector<uint32_t, 4> positions_stash_;
     bool store_freq_{false};
+    bool store_positions_{false};
     absl::Span<const uint8_t> last_read_{};
     absl::Span<const uint8_t> diffs_{};
   };
@@ -57,15 +62,22 @@ class CompressedSortedSet {
   using iterator = ConstIterator;
 
  public:
-  // When store_freq is true, each entry encodes [diff_varint][freq_varint].
-  // When false (default), only [diff_varint] is stored — saves 1 byte per entry.
-  explicit CompressedSortedSet(PMR_NS::memory_resource* mr, bool store_freq = false);
+  // Entry layout depends on flags:
+  //   neither:       [diff_varint]
+  //   store_freq:    [diff_varint][freq_varint]
+  //   +positions:    [diff_varint][freq_varint][pos0_varint][pos1_delta_varint]...
+  //
+  // store_positions implies store_freq (freq tells the reader how many positions follow).
+  explicit CompressedSortedSet(PMR_NS::memory_resource* mr, bool store_freq = false,
+                               bool store_positions = false);
 
   ConstIterator begin() const;
   ConstIterator end() const;
 
-  // Insert element with term frequency. Returns true if new, false if already present.
-  bool Insert(IntType value, uint32_t freq = 1);
+  // Insert with term frequency. Returns true if new, false if already present.
+  // `positions` must be sorted ascending and have size == freq when store_positions_;
+  // it is ignored when store_positions_ is false.
+  bool Insert(IntType value, uint32_t freq = 1, absl::Span<const uint32_t> positions = {});
   bool Remove(IntType value);  // Remove arbitrary element, needs to scan whole list
 
   size_t Size() const {
@@ -88,6 +100,10 @@ class CompressedSortedSet {
 
   bool StoresFreq() const {
     return store_freq_;
+  }
+
+  bool StoresPositions() const {
+    return store_positions_;
   }
 
   // Add all values from other
@@ -117,8 +133,9 @@ class CompressedSortedSet {
   // Find EntryLocation of first entry that is not less than value (std::lower_bound)
   EntryLocation LowerBound(IntType value) const;
 
-  // Push back difference + freq without any decoding. Used for efficient construction
-  void PushBackDiff(IntType diff, uint32_t freq);
+  // Push back difference + freq + positions without any decoding. Used for efficient construction.
+  // `positions` is consulted only when store_positions_; expected to have size == freq.
+  void PushBackDiff(IntType diff, uint32_t freq, absl::Span<const uint32_t> positions = {});
 
   // Encode integer with variable length encoding into buf and return written subspan
   static absl::Span<uint8_t> WriteVarLen(IntType value, absl::Span<uint8_t> buf);
@@ -126,9 +143,13 @@ class CompressedSortedSet {
   // Decode integer with variable length encoding from source
   static std::pair<IntType /*value*/, size_t /*read*/> ReadVarLen(absl::Span<const uint8_t> source);
 
+  // Bytes consumed by an entry's diff+freq prefix (everything before the optional positions block).
+  static size_t HeadSize(absl::Span<const uint8_t> entry_span, bool store_freq);
+
  private:
   uint32_t size_{0};
-  bool store_freq_;  // Whether to encode/decode freq alongside diffs
+  bool store_freq_;       // Whether to encode/decode freq alongside diffs
+  bool store_positions_;  // Whether to encode/decode positions; implies store_freq_
 
   std::optional<IntType> tail_value_{};
   std::vector<uint8_t, PMR_NS::polymorphic_allocator<uint8_t>> diffs_;

--- a/src/core/search/compressed_sorted_set_test.cc
+++ b/src/core/search/compressed_sorted_set_test.cc
@@ -5,6 +5,7 @@
 #include "core/search/compressed_sorted_set.h"
 
 #include <absl/container/btree_set.h>
+#include <gmock/gmock.h>
 
 #include <algorithm>
 
@@ -390,6 +391,188 @@ TEST_F(CompressedSortedSetTest, FreqZeroHandling) {
   ++it;
   EXPECT_EQ(*it, 30u);
   EXPECT_EQ(it.Freq(), 0u);
+}
+
+TEST_F(CompressedSortedSetTest, PositionsBasic) {
+  CompressedSortedSet list{PMR_NS::get_default_resource(), /*store_freq=*/true,
+                           /*store_positions=*/true};
+  EXPECT_TRUE(list.StoresFreq());
+  EXPECT_TRUE(list.StoresPositions());
+
+  std::vector<uint32_t> p1{0, 3, 17};
+  std::vector<uint32_t> p2{5};
+  std::vector<uint32_t> p3{2, 4, 6, 8};
+  list.Insert(10, p1.size(), p1);
+  list.Insert(20, p2.size(), p2);
+  list.Insert(30, p3.size(), p3);
+
+  auto it = list.begin();
+  EXPECT_EQ(*it, 10u);
+  EXPECT_EQ(it.Freq(), 3u);
+  EXPECT_THAT(std::vector<uint32_t>(it.Positions().begin(), it.Positions().end()),
+              ::testing::ElementsAreArray(p1));
+  ++it;
+  EXPECT_EQ(*it, 20u);
+  EXPECT_THAT(std::vector<uint32_t>(it.Positions().begin(), it.Positions().end()),
+              ::testing::ElementsAreArray(p2));
+  ++it;
+  EXPECT_EQ(*it, 30u);
+  EXPECT_THAT(std::vector<uint32_t>(it.Positions().begin(), it.Positions().end()),
+              ::testing::ElementsAreArray(p3));
+}
+
+TEST_F(CompressedSortedSetTest, PositionsInsertMiddle) {
+  CompressedSortedSet list{PMR_NS::get_default_resource(), true, true};
+
+  std::vector<uint32_t> p10{1, 5};
+  std::vector<uint32_t> p30{2, 4, 7};
+  std::vector<uint32_t> p20{0, 10};
+  list.Insert(10, p10.size(), p10);
+  list.Insert(30, p30.size(), p30);
+  // Triggers the middle-insert path: bound is 30, prev is 10.
+  list.Insert(20, p20.size(), p20);
+
+  auto it = list.begin();
+  EXPECT_EQ(*it, 10u);
+  EXPECT_THAT(std::vector<uint32_t>(it.Positions().begin(), it.Positions().end()),
+              ::testing::ElementsAreArray(p10));
+  ++it;
+  EXPECT_EQ(*it, 20u);
+  EXPECT_THAT(std::vector<uint32_t>(it.Positions().begin(), it.Positions().end()),
+              ::testing::ElementsAreArray(p20));
+  ++it;
+  EXPECT_EQ(*it, 30u);
+  // Crucial: 30's positions must survive the middle-insert.
+  EXPECT_THAT(std::vector<uint32_t>(it.Positions().begin(), it.Positions().end()),
+              ::testing::ElementsAreArray(p30));
+}
+
+TEST_F(CompressedSortedSetTest, PositionsRemove) {
+  CompressedSortedSet list{PMR_NS::get_default_resource(), true, true};
+
+  std::vector<uint32_t> p10{0, 4};
+  std::vector<uint32_t> p20{3};
+  std::vector<uint32_t> p30{1, 9, 15};
+  list.Insert(10, p10.size(), p10);
+  list.Insert(20, p20.size(), p20);
+  list.Insert(30, p30.size(), p30);
+
+  EXPECT_TRUE(list.Remove(20));
+  EXPECT_EQ(list.Size(), 2u);
+
+  auto it = list.begin();
+  EXPECT_EQ(*it, 10u);
+  EXPECT_THAT(std::vector<uint32_t>(it.Positions().begin(), it.Positions().end()),
+              ::testing::ElementsAreArray(p10));
+  ++it;
+  EXPECT_EQ(*it, 30u);
+  // Crucial: removing middle entry must preserve 30's positions verbatim.
+  EXPECT_THAT(std::vector<uint32_t>(it.Positions().begin(), it.Positions().end()),
+              ::testing::ElementsAreArray(p30));
+}
+
+TEST_F(CompressedSortedSetTest, PositionsRemoveTail) {
+  CompressedSortedSet list{PMR_NS::get_default_resource(), true, true};
+  std::vector<uint32_t> p10{0, 5};
+  std::vector<uint32_t> p20{2, 8};
+  list.Insert(10, p10.size(), p10);
+  list.Insert(20, p20.size(), p20);
+
+  EXPECT_TRUE(list.Remove(20));
+  auto it = list.begin();
+  EXPECT_EQ(*it, 10u);
+  EXPECT_THAT(std::vector<uint32_t>(it.Positions().begin(), it.Positions().end()),
+              ::testing::ElementsAreArray(p10));
+  ++it;
+  EXPECT_EQ(it, list.end());
+}
+
+TEST_F(CompressedSortedSetTest, PositionsMerge) {
+  CompressedSortedSet a{PMR_NS::get_default_resource(), true, true};
+  CompressedSortedSet b{PMR_NS::get_default_resource(), true, true};
+
+  std::vector<uint32_t> p10{1, 3};
+  std::vector<uint32_t> p30{0};
+  std::vector<uint32_t> p20{5, 7};
+  std::vector<uint32_t> p40{2};
+  a.Insert(10, p10.size(), p10);
+  a.Insert(30, p30.size(), p30);
+  b.Insert(20, p20.size(), p20);
+  b.Insert(40, p40.size(), p40);
+
+  a.Merge(std::move(b));
+
+  auto it = a.begin();
+  EXPECT_EQ(*it, 10u);
+  EXPECT_THAT(std::vector<uint32_t>(it.Positions().begin(), it.Positions().end()),
+              ::testing::ElementsAreArray(p10));
+  ++it;
+  EXPECT_EQ(*it, 20u);
+  EXPECT_THAT(std::vector<uint32_t>(it.Positions().begin(), it.Positions().end()),
+              ::testing::ElementsAreArray(p20));
+  ++it;
+  EXPECT_EQ(*it, 30u);
+  EXPECT_THAT(std::vector<uint32_t>(it.Positions().begin(), it.Positions().end()),
+              ::testing::ElementsAreArray(p30));
+  ++it;
+  EXPECT_EQ(*it, 40u);
+  EXPECT_THAT(std::vector<uint32_t>(it.Positions().begin(), it.Positions().end()),
+              ::testing::ElementsAreArray(p40));
+}
+
+TEST_F(CompressedSortedSetTest, PositionsSplit) {
+  CompressedSortedSet list{PMR_NS::get_default_resource(), true, true};
+  std::vector<std::vector<uint32_t>> all_pos;
+  for (uint32_t i = 0; i < 10; ++i) {
+    std::vector<uint32_t> p{i, i + 100, i + 200};
+    all_pos.push_back(p);
+    list.Insert(i * 10, p.size(), p);
+  }
+
+  auto [first, second] = std::move(list).Split();
+  EXPECT_GT(first.Size(), 0u);
+  EXPECT_GT(second.Size(), 0u);
+  EXPECT_EQ(first.Size() + second.Size(), 10u);
+  EXPECT_TRUE(first.StoresPositions());
+  EXPECT_TRUE(second.StoresPositions());
+
+  // Confirm each docid still has its original positions in whichever half it landed.
+  for (const auto& set : {&first, &second}) {
+    for (auto it = set->begin(); it != set->end(); ++it) {
+      uint32_t docid = *it;
+      ASSERT_EQ(docid % 10u, 0u);
+      const auto& expected = all_pos[docid / 10];
+      EXPECT_THAT(std::vector<uint32_t>(it.Positions().begin(), it.Positions().end()),
+                  ::testing::ElementsAreArray(expected))
+          << "docid=" << docid;
+    }
+  }
+}
+
+TEST_F(CompressedSortedSetTest, PositionsLargeValues) {
+  CompressedSortedSet list{PMR_NS::get_default_resource(), true, true};
+
+  std::vector<uint32_t> p1{0, 127, 128, 16383, 16384, 1u << 28};
+  std::vector<uint32_t> p2{500};
+  list.Insert(1000, p1.size(), p1);
+  list.Insert(2000, p2.size(), p2);
+
+  auto it = list.begin();
+  EXPECT_EQ(*it, 1000u);
+  EXPECT_THAT(std::vector<uint32_t>(it.Positions().begin(), it.Positions().end()),
+              ::testing::ElementsAreArray(p1));
+  ++it;
+  EXPECT_EQ(*it, 2000u);
+  EXPECT_THAT(std::vector<uint32_t>(it.Positions().begin(), it.Positions().end()),
+              ::testing::ElementsAreArray(p2));
+}
+
+TEST_F(CompressedSortedSetTest, PositionsImpliesFreq) {
+  // store_positions=true must imply store_freq=true regardless of the freq flag passed.
+  CompressedSortedSet list{PMR_NS::get_default_resource(), /*store_freq=*/false,
+                           /*store_positions=*/true};
+  EXPECT_TRUE(list.StoresFreq());
+  EXPECT_TRUE(list.StoresPositions());
 }
 
 }  // namespace dfly::search

--- a/src/core/search/indices.cc
+++ b/src/core/search/indices.cc
@@ -636,9 +636,10 @@ void TextIndex::Tokenize(std::string_view value, uint32_t* pos_counter,
 
 std::vector<std::string> TextIndex::TokenizePhraseQuery(std::string_view phrase) const {
   std::vector<std::string> out;
+  const StopWords* sw = stopwords_;
   for (std::string_view word : una::views::word_only::utf8(phrase)) {
     std::string lc = una::cases::to_lowercase_utf8(word);
-    if (stopwords_ && stopwords_->contains(lc))
+    if (sw && sw->contains(lc))
       continue;
     out.push_back(std::move(lc));
   }

--- a/src/core/search/indices.cc
+++ b/src/core/search/indices.cc
@@ -48,43 +48,46 @@ string ToLower(string_view word) {
   return IsAllAscii(word) ? absl::AsciiStrToLower(word) : una::cases::to_lowercase_utf8(word);
 }
 
-// Get all words from text as matched by the ICU library, counting term frequencies.
-// When stemming is on, both the raw and stemmed forms are emitted so wildcards
-// can match unstemmed tokens and synonym hits stay additive.
-absl::flat_hash_map<std::string, uint32_t> TokenizeWords(std::string_view text,
-                                                         const TextIndex::StopWords& stopwords,
-                                                         const Synonyms* synonyms,
-                                                         Stemmer* stemmer) {
-  absl::flat_hash_map<std::string, uint32_t> words;
+// Tokenize text into `out`, advancing *pos_counter per non-stopword token. Raw + stem +
+// synonym entries share the same position. Stopwords don't advance the counter.
+void TokenizeWords(std::string_view text, const TextIndex::StopWords& stopwords,
+                   const Synonyms* synonyms, Stemmer* stemmer, uint32_t* pos_counter,
+                   absl::flat_hash_map<std::string, TermInfo>* out) {
+  auto emit = [&](std::string key, uint32_t pos) {
+    auto& info = (*out)[std::move(key)];
+    info.freq++;
+    info.positions.push_back(pos);
+  };
   for (std::string_view word : una::views::word_only::utf8(text)) {
     std::string word_lc = una::cases::to_lowercase_utf8(word);
     if (stopwords.contains(word_lc))
       continue;
+    uint32_t pos = ++(*pos_counter);
     if (synonyms) {
       if (auto group_id = synonyms->GetGroupToken(word_lc); group_id)
-        words[*group_id]++;
+        emit(*group_id, pos);
     }
     if (stemmer) {
       std::string stem = stemmer->Stem(word_lc);
       if (stem != word_lc)
-        words[std::move(stem)]++;
+        emit(std::move(stem), pos);
     }
-    words[std::move(word_lc)]++;
+    emit(std::move(word_lc), pos);
   }
-  return words;
 }
 
-// Split taglist, remove duplicates and convert all to lowercase. Freq is always 1 for tags.
-absl::flat_hash_map<string, uint32_t> NormalizeTags(string_view taglist, bool case_sensitive,
-                                                    char separator) {
+// Split taglist, remove duplicates and convert all to lowercase. Freq is always 1 for tags;
+// positions are not tracked (phrase queries don't apply to tag fields).
+void NormalizeTags(string_view taglist, bool case_sensitive, char separator,
+                   absl::flat_hash_map<std::string, TermInfo>* out) {
   // Splitting utf8 by ascii character is safe
-  absl::flat_hash_map<string, uint32_t> tags;
   for (string_view tag : absl::StrSplit(taglist, separator, absl::SkipEmpty())) {
     string_view str = absl::StripAsciiWhitespace(tag);
     std::string s = case_sensitive ? string{str} : ToLower(str);
-    tags.emplace(std::move(s), 1);
+    auto& info = (*out)[std::move(s)];
+    if (info.freq == 0)
+      info.freq = 1;  // dedup: tag presence is binary
   }
-  return tags;
 }
 
 // Iterate over all suffixes of all words
@@ -293,8 +296,8 @@ vector<DocId> NumericIndex::GetAllDocsWithNonNullValues() const {
 
 template <typename C>
 BaseStringIndex<C>::BaseStringIndex(PMR_NS::memory_resource* mr, bool case_sensitive,
-                                    bool with_suffix)
-    : case_sensitive_{case_sensitive}, entries_{mr} {
+                                    bool with_suffix, bool with_offsets)
+    : case_sensitive_{case_sensitive}, with_offsets_{with_offsets}, entries_{mr} {
   if (with_suffix)
     suffix_trie_.emplace(mr);
 }
@@ -306,6 +309,13 @@ const typename BaseStringIndex<C>::Container* BaseStringIndex<C>::Matching(
     word = absl::StripAsciiWhitespace(word);
 
   auto it = entries_.find(NormalizeForExactQuery(word).view());
+  return (it != entries_.end()) ? &it->second : nullptr;
+}
+
+template <typename C>
+const typename BaseStringIndex<C>::Container* BaseStringIndex<C>::MatchingNoStem(
+    string_view word) const {
+  auto it = entries_.find(NormalizeQueryWord(word).view());
   return (it != entries_.end()) ? &it->second : nullptr;
 }
 
@@ -424,17 +434,17 @@ bool BaseStringIndex<C>::Add(DocId id, const DocumentAccessor& doc, string_view 
     return false;
   }
 
-  absl::flat_hash_map<std::string, uint32_t> tokens;
+  absl::flat_hash_map<std::string, TermInfo> tokens;
+  uint32_t pos_counter = 0;
   for (string_view str : strings_list.value()) {
-    for (auto& [token, freq] : Tokenize(str))
-      tokens[std::move(token)] += freq;
+    Tokenize(str, &pos_counter, &tokens);
   }
 
   // Track per-field document length for BM25 scoring.
   if constexpr (kIsScored) {
     uint32_t doc_tf_sum = 0;
-    for (const auto& [_, freq] : tokens)
-      doc_tf_sum += freq;
+    for (const auto& [_, info] : tokens)
+      doc_tf_sum += info.freq;
     if (doc_tf_sum > 0) {
       if (id >= field_doc_lengths_.size())
         field_doc_lengths_.resize(id + 1, 0);
@@ -447,8 +457,9 @@ bool BaseStringIndex<C>::Add(DocId id, const DocumentAccessor& doc, string_view 
 
   if (tokens.size() > 1)
     unique_ids_ = false;
-  for (const auto& [token, freq] : tokens)
-    GetOrCreate(&entries_, token, kIsScored)->Insert(id, freq);
+  for (const auto& [token, info] : tokens)
+    GetOrCreate(&entries_, token, kIsScored, with_offsets_)
+        ->Insert(id, info.freq, absl::MakeConstSpan(info.positions.data(), info.positions.size()));
 
   if (suffix_trie_) {
     absl::flat_hash_set<std::string> token_keys;
@@ -474,10 +485,10 @@ void BaseStringIndex<C>::Remove(DocId id, const DocumentAccessor& doc, string_vi
 
   auto strings_list = GetStrings(doc, field).value();
 
-  absl::flat_hash_map<std::string, uint32_t> tokens;
+  absl::flat_hash_map<std::string, TermInfo> tokens;
+  uint32_t pos_counter = 0;
   for (string_view str : strings_list) {
-    for (auto& [token, freq] : Tokenize(str))
-      tokens[std::move(token)] += freq;
+    Tokenize(str, &pos_counter, &tokens);
   }
 
   for (const auto& [token, _] : tokens)
@@ -550,9 +561,10 @@ StringOrView BaseStringIndex<C>::NormalizeForExactQuery(std::string_view query) 
 
 template <typename C>
 typename BaseStringIndex<C>::Container* BaseStringIndex<C>::GetOrCreate(
-    search::RaxTreeMap<Container>* map, string_view word, bool store_freq) {
+    search::RaxTreeMap<Container>* map, string_view word, bool store_freq, bool store_positions) {
   auto* mr = map->get_allocator().resource();
-  return &map->try_emplace(PMR_NS::string{word, mr}, mr, 1000 /* block size */, store_freq)
+  return &map->try_emplace(PMR_NS::string{word, mr}, mr, 1000 /* block size */, store_freq,
+                           store_positions)
               .first->second;
 }
 
@@ -572,8 +584,8 @@ template struct BaseStringIndex<SortedVector<DocId>>;
 
 TextIndex::TextIndex(PMR_NS::memory_resource* mr, const StopWords* stopwords,
                      const Synonyms* synonyms, bool with_suffixtrie, bool no_stem,
-                     std::string_view language, std::string_view language_field)
-    : BaseStringIndex(mr, false, with_suffixtrie),
+                     std::string_view language, std::string_view language_field, bool with_offsets)
+    : BaseStringIndex(mr, false, with_suffixtrie, with_offsets),
       stopwords_{stopwords},
       synonyms_{synonyms},
       language_field_{language_field} {
@@ -617,8 +629,20 @@ std::optional<DocumentAccessor::StringList> TextIndex::GetStrings(const Document
   return doc.GetStrings(field);
 }
 
-absl::flat_hash_map<std::string, uint32_t> TextIndex::Tokenize(std::string_view value) const {
-  return TokenizeWords(value, *stopwords_, synonyms_, stemmer_);
+void TextIndex::Tokenize(std::string_view value, uint32_t* pos_counter,
+                         absl::flat_hash_map<std::string, TermInfo>* out) const {
+  TokenizeWords(value, *stopwords_, synonyms_, stemmer_, pos_counter, out);
+}
+
+std::vector<std::string> TextIndex::TokenizePhraseQuery(std::string_view phrase) const {
+  std::vector<std::string> out;
+  for (std::string_view word : una::views::word_only::utf8(phrase)) {
+    std::string lc = una::cases::to_lowercase_utf8(word);
+    if (stopwords_ && stopwords_->contains(lc))
+      continue;
+    out.push_back(std::move(lc));
+  }
+  return out;
 }
 
 DefragmentResult TagIndex::Defragment(PageUsage* page_usage) {
@@ -641,8 +665,9 @@ std::optional<DocumentAccessor::StringList> TagIndex::GetStrings(const DocumentA
   return doc.GetTags(field);
 }
 
-absl::flat_hash_map<std::string, uint32_t> TagIndex::Tokenize(std::string_view value) const {
-  return NormalizeTags(value, case_sensitive_, separator_);
+void TagIndex::Tokenize(std::string_view value, uint32_t* /*pos_counter*/,
+                        absl::flat_hash_map<std::string, TermInfo>* out) const {
+  NormalizeTags(value, case_sensitive_, separator_, out);
 }
 
 BaseVectorIndex::BaseVectorIndex(size_t dim, VectorSimilarity sim) : dim_{dim}, sim_{sim} {

--- a/src/core/search/indices.h
+++ b/src/core/search/indices.h
@@ -38,7 +38,7 @@
 
 namespace dfly::search {
 
-// Per-token indexing payload. `positions` is sorted ascending (0-based per field value,
+// Per-token indexing payload. `positions` is sorted ascending (1-based per field value,
 // continuous across multi-value fields). Empty when the owning index doesn't store positions.
 struct TermInfo {
   uint32_t freq = 0;

--- a/src/core/search/indices.h
+++ b/src/core/search/indices.h
@@ -38,6 +38,13 @@
 
 namespace dfly::search {
 
+// Per-token indexing payload. `positions` is sorted ascending (0-based per field value,
+// continuous across multi-value fields). Empty when the owning index doesn't store positions.
+struct TermInfo {
+  uint32_t freq = 0;
+  absl::InlinedVector<uint32_t, 4> positions;
+};
+
 // Index for integer fields.
 // Range bounds are queried in logarithmic time, iteration is constant.
 struct NumericIndex : public BaseIndex {
@@ -84,13 +91,18 @@ template <typename C> struct BaseStringIndex : public BaseIndex {
   // TextIndex (CompressedSortedSet) supports TF storage and BM25 scoring; TagIndex does not.
   static constexpr bool kIsScored = std::is_same_v<C, CompressedSortedSet>;
 
-  BaseStringIndex(PMR_NS::memory_resource* mr, bool case_sensitive, bool with_suffixtrie);
+  BaseStringIndex(PMR_NS::memory_resource* mr, bool case_sensitive, bool with_suffixtrie,
+                  bool with_offsets = false);
 
   bool Add(DocId id, const DocumentAccessor& doc, std::string_view field) override;
   void Remove(DocId id, const DocumentAccessor& doc, std::string_view field) override;
 
   // Pointer is valid as long as index is not mutated. Nullptr if not found
   const Container* Matching(std::string_view str, bool strip_whitespace = true) const;
+
+  // Like Matching, but never stems the query word — used by phrase queries which must hit
+  // the raw token form (stems live at the same positions but under a separate trie key).
+  const Container* MatchingNoStem(std::string_view str) const;
 
   // Iterate over all nodes matching on prefix.
   void MatchPrefix(std::string_view prefix, absl::FunctionRef<void(const Container*)> cb) const;
@@ -141,17 +153,21 @@ template <typename C> struct BaseStringIndex : public BaseIndex {
   virtual std::optional<StringList> GetStrings(const DocumentAccessor& doc,
                                                std::string_view field) const = 0;
 
-  // Used by Add & Remove to tokenize text value. Returns token -> frequency map.
-  virtual absl::flat_hash_map<std::string, uint32_t> Tokenize(std::string_view value) const = 0;
+  // Used by Add & Remove to tokenize a single field value. Merges results into `out`,
+  // advancing `pos_counter` per non-stopword token so positions are continuous across
+  // multiple values of the same field. Tag indices ignore positions.
+  virtual void Tokenize(std::string_view value, uint32_t* pos_counter,
+                        absl::flat_hash_map<std::string, TermInfo>* out) const = 0;
 
   cmn::StringOrView NormalizeQueryWord(std::string_view word) const;
   cmn::StringOrView NormalizeForExactQuery(std::string_view word) const;
   static Container* GetOrCreate(search::RaxTreeMap<Container>* map, std::string_view word,
-                                bool store_freq = false);
+                                bool store_freq = false, bool store_positions = false);
   static void Remove(search::RaxTreeMap<Container>* map, DocId id, std::string_view word);
 
   bool case_sensitive_ = false;
   bool unique_ids_ = true;  // If true, docs ids are unique in the index, otherwise they can repeat.
+  bool with_offsets_ = false;  // Whether posting lists store token positions (TextIndex only).
   search::RaxTreeMap<Container> entries_;
   std::optional<search::RaxTreeMap<Container>> suffix_trie_;
 
@@ -174,15 +190,24 @@ struct TextIndex : public BaseStringIndex<CompressedSortedSet> {
 
   TextIndex(PMR_NS::memory_resource* mr, const StopWords* stopwords, const Synonyms* synonyms,
             bool with_suffixtrie, bool no_stem, std::string_view language,
-            std::string_view language_field);
+            std::string_view language_field, bool with_offsets = true);
 
   bool Add(DocId id, const DocumentAccessor& doc, std::string_view field) override;
   void Remove(DocId id, const DocumentAccessor& doc, std::string_view field) override;
 
+  bool StoresPositions() const {
+    return with_offsets_;
+  }
+
+  // Tokenize a quoted phrase query: split on whitespace, lowercase, drop stopwords.
+  // Stems are NOT applied — phrase queries match raw token positions only.
+  std::vector<std::string> TokenizePhraseQuery(std::string_view phrase) const;
+
  protected:
   std::optional<StringList> GetStrings(const DocumentAccessor& doc,
                                        std::string_view field) const override;
-  absl::flat_hash_map<std::string, uint32_t> Tokenize(std::string_view value) const override;
+  void Tokenize(std::string_view value, uint32_t* pos_counter,
+                absl::flat_hash_map<std::string, TermInfo>* out) const override;
 
  private:
   // Reads language_field_ from doc; returns a per-doc stemmer or the default.
@@ -208,7 +233,8 @@ struct TagIndex : public BaseStringIndex<SortedVector<DocId>> {
  protected:
   std::optional<StringList> GetStrings(const DocumentAccessor& doc,
                                        std::string_view field) const override;
-  absl::flat_hash_map<std::string, uint32_t> Tokenize(std::string_view value) const override;
+  void Tokenize(std::string_view value, uint32_t* pos_counter,
+                absl::flat_hash_map<std::string, TermInfo>* out) const override;
 
  private:
   char separator_;

--- a/src/core/search/lexer.lex
+++ b/src/core/search/lexer.lex
@@ -28,7 +28,7 @@
   using namespace std;
   using dfly::search::TagType;
 
-  Parser::symbol_type make_StringLit(string_view src, const Parser::location_type& loc);
+  Parser::symbol_type make_PhraseTok(string_view src, const Parser::location_type& loc);
   Parser::symbol_type make_Tag(string_view src, TagType type, const Parser::location_type& loc);
   // Strip backslashes from \X sequences in a term.
   string UnescapeTerm(string_view src);
@@ -84,8 +84,8 @@ astrsk_ch  \*
 [0-9]{1,9}                          return Parser::make_UINT32(str(), loc());
 [+-]?(([0-9]*[.])?[0-9]+|inf)       return Parser::make_DOUBLE(str(), loc());
 
-{dq}([^"]|{esc_seq})*{dq}           return make_StringLit(matched_view(1, 1), loc());
-{sq}([^']|{esc_seq})*{sq}           return make_StringLit(matched_view(1, 1), loc());
+{dq}([^"]|{esc_seq})*{dq}(~[0-9]+)?   return make_PhraseTok(str(), loc());
+{sq}([^']|{esc_seq})*{sq}(~[0-9]+)?   return make_PhraseTok(str(), loc());
 
 "$"{term_ch}+                       return ParseParam(str(), loc());
 "@"{term_ch}+                       return Parser::make_FIELD(str(), loc());
@@ -102,12 +102,25 @@ astrsk_ch  \*
 <<EOF>> return Parser::make_YYEOF(loc());
 %%
 
-Parser::symbol_type make_StringLit(string_view src, const Parser::location_type& loc) {
+Parser::symbol_type make_PhraseTok(string_view src, const Parser::location_type& loc) {
+  // src is the full match: opening quote, content, closing quote, optionally `~N`.
+  uint32_t slop = 0;
+  char quote = src.front();
+  // Locate closing quote (last char matching the opener, skipping escaped pairs).
+  size_t close_idx = src.size() - 1;
+  while (close_idx > 0 && src[close_idx] != quote)
+    --close_idx;
+  string_view inner = src.substr(1, close_idx - 1);
+  string_view after = src.substr(close_idx + 1);
+  if (!after.empty() && after.front() == '~') {
+    if (!absl::SimpleAtoi(after.substr(1), &slop))
+      throw Parser::syntax_error(loc, "bad phrase slop: " + string(after));
+  }
   string res;
-  if (!absl::CUnescape(src, &res))
-    throw Parser::syntax_error (loc, "bad escaped string: " + string(src));
+  if (!absl::CUnescape(inner, &res))
+    throw Parser::syntax_error(loc, "bad escaped string: " + string(inner));
 
-  return Parser::make_TERM(res, loc);
+  return Parser::make_PHRASE(dfly::search::PhraseTok{std::move(res), slop}, loc);
 }
 
 string UnescapeTerm(string_view src) {

--- a/src/core/search/lexer.lex
+++ b/src/core/search/lexer.lex
@@ -84,6 +84,8 @@ astrsk_ch  \*
 [0-9]{1,9}                          return Parser::make_UINT32(str(), loc());
 [+-]?(([0-9]*[.])?[0-9]+|inf)       return Parser::make_DOUBLE(str(), loc());
 
+  /* Quoted phrase, optionally followed by `~N` slop (no whitespace before `~`). With whitespace
+     before `~`, the tilde tokenizes separately as the optional-term operator. */
 {dq}([^"]|{esc_seq})*{dq}(~[0-9]+)?   return make_PhraseTok(str(), loc());
 {sq}([^']|{esc_seq})*{sq}(~[0-9]+)?   return make_PhraseTok(str(), loc());
 

--- a/src/core/search/parser.y
+++ b/src/core/search/parser.y
@@ -299,7 +299,13 @@ tag_list:
 
 tag_list_element:
   TERM        { $$ = AstTermNode(std::move($1));   }
-  | PHRASE { $$ = AstTermNode(std::move($1.raw));  }  /* Inside {..}, quoted strings are literals, not phrases. */
+  | PHRASE {
+      /* Inside {..}, quoted strings are literal tag values. ~N slop is only meaningful for
+         phrases, so reject it here rather than silently dropping it. */
+      if ($1.slop != 0)
+        throw Parser::syntax_error(@$, "slop is not allowed in tag values");
+      $$ = AstTermNode(std::move($1.raw));
+    }
   | PREFIX    { $$ = AstPrefixNode(std::move($1)); }
   | SUFFIX    { $$ = AstSuffixNode(std::move($1)); }
   | INFIX     { $$ = AstInfixNode(std::move($1));  }

--- a/src/core/search/parser.y
+++ b/src/core/search/parser.y
@@ -19,6 +19,14 @@
   namespace dfly {
   namespace search {
     class QueryDriver;
+    // Token value for quoted phrases: raw text plus optional ~N slop. `slop`=0 = exact adjacency.
+    struct PhraseTok {
+      std::string raw;
+      uint32_t slop = 0;
+    };
+    inline std::ostream& operator<<(std::ostream& os, const PhraseTok&) {
+      return os;  // bison debug trace requires this; content not material to traces.
+    }
   }
   }
 }
@@ -72,6 +80,7 @@ double toDouble(string_view src);
 // Needed 0 at the end to satisfy bison 3.5.1
 %token YYEOF 0
 %token <std::string> TERM "term" TAG_VAL "tag_val" PARAM "param" FIELD "field" PREFIX "prefix" SUFFIX "suffix" INFIX "infix"
+%token <PhraseTok> PHRASE "phrase"
 
 %precedence TERM TAG_VAL
 %left OR_OP
@@ -193,6 +202,7 @@ search_unary_expr:
   | NOT_OP search_unary_expr          { $$ = AstNegateNode(std::move($2));   }
   | TILDE search_unary_expr           { $$ = AstOptionalNode(std::move($2)); }
   | TERM                              { $$ = AstTermNode(std::move($1));     }
+  | PHRASE                            { $$ = AstPhraseNode(std::move($1.raw), $1.slop); }
   | PREFIX                            { $$ = AstPrefixNode(std::move($1));   }
   | SUFFIX                            { $$ = AstSuffixNode(std::move($1));   }
   | INFIX                             { $$ = AstInfixNode(std::move($1));    }
@@ -201,6 +211,7 @@ search_unary_expr:
 
 field_cond:
   TERM                                                  { $$ = AstTermNode(std::move($1));   }
+  | PHRASE                                              { $$ = AstPhraseNode(std::move($1.raw), $1.slop); }
   | UINT32                                              { $$ = AstTermNode(std::move($1));   }
   | STAR                                                { $$ = AstStarFieldNode();           }
   | NOT_OP field_cond                                   { $$ = AstNegateNode(std::move($2)); }
@@ -288,6 +299,7 @@ tag_list:
 
 tag_list_element:
   TERM        { $$ = AstTermNode(std::move($1));   }
+  | PHRASE { $$ = AstTermNode(std::move($1.raw));  }  /* Inside {..}, quoted strings are literals, not phrases. */
   | PREFIX    { $$ = AstPrefixNode(std::move($1)); }
   | SUFFIX    { $$ = AstSuffixNode(std::move($1)); }
   | INFIX     { $$ = AstInfixNode(std::move($1));  }

--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -338,92 +338,112 @@ struct BasicSearch {
     return false;
   }
 
-  // Quoted phrase: AND-intersect posting lists of raw tokens, then verify adjacency by positions.
-  // Stems are not consulted — phrase semantics require the exact surface form. Stopwords inside
-  // the phrase are dropped (matching the index-side tokenizer, which doesn't advance pos for them).
-  IndexResult Search(const AstPhraseNode& node, string_view active_field) {
-    auto eval_in = [&](TextIndex* text_index) -> IndexResult {
-      if (!text_index->StoresPositions()) {
-        error_ = "phrase queries require offsets; index was created with NOOFFSETS";
-        return IndexResult{};
+  // Tokenizes a phrase query, registers its terms with the scorer (so BM25 picks up
+  // phrase-matched docs), and fetches one posting list per term — raw form only, no stem
+  // expansion. Returns the lists in phrase-order, or an empty vector if the phrase can't
+  // possibly match (empty phrase, all-stopword phrase, or any term missing from the index).
+  vector<const TextIndex::Container*> FetchPhrasePostingLists(TextIndex* text_index,
+                                                              std::string_view raw_phrase) {
+    vector<const TextIndex::Container*> lists;
+
+    vector<string> terms = text_index->TokenizePhraseQuery(raw_phrase);
+    if (terms.empty())
+      return lists;
+
+    if (scorer_) {
+      for (const auto& t : terms)
+        AddMatchedTerm(text_index, t);
+    }
+
+    lists.reserve(terms.size());
+    for (const auto& t : terms) {
+      const auto* c = text_index->MatchingNoStem(t);
+      if (!c || c->Empty()) {
+        lists.clear();
+        return lists;
       }
+      lists.push_back(c);
+    }
+    return lists;
+  }
 
-      vector<string> terms = text_index->TokenizePhraseQuery(node.raw);
-      if (terms.empty())
-        return IndexResult{};
+  // Zig-zag intersection over `lists` by docId, with positional adjacency (within `slop`)
+  // verified per common doc via `HasPhraseRun`. Returns matched docIds in sorted order.
+  // Pre: lists.size() >= 2 and each list is non-empty.
+  vector<DocId> IntersectAdjacentDocs(const vector<const TextIndex::Container*>& lists,
+                                      uint32_t slop) {
+    vector<PhraseIt> iters;
+    iters.reserve(lists.size());
+    for (const auto* l : lists)
+      iters.push_back(l->begin());
 
-      // Register each phrase term with the scorer so BM25 picks them up as virtual matches.
-      // Phrase-matched docs then score the same as if `term1 term2 ...` were AND-ed.
-      if (scorer_) {
-        for (const auto& t : terms)
-          AddMatchedTerm(text_index, t);
-      }
-
-      // Fetch posting lists (raw form only, no stem expansion). Any miss → empty result.
-      vector<const TextIndex::Container*> lists;
-      lists.reserve(terms.size());
-      for (const auto& t : terms) {
-        const auto* c = text_index->MatchingNoStem(t);
-        if (!c || c->Empty())
-          return IndexResult{};
-        lists.push_back(c);
-      }
-
-      // Single-token phrase short-circuit: posting list IS the answer (no adjacency to check).
-      if (lists.size() == 1)
-        return IndexResult{lists[0]};
-
-      // Intersect doc ids across all lists; for each common doc, check adjacency.
-      vector<PhraseIt> iters;
-      iters.reserve(lists.size());
-      for (const auto* l : lists)
-        iters.push_back(l->begin());
-
-      auto any_at_end = [&]() {
-        for (size_t i = 0; i < iters.size(); ++i)
-          if (iters[i] == lists[i]->end())
-            return true;
-        return false;
-      };
-
-      vector<DocId> matches;
-      while (!any_at_end()) {
-        DocId max_id = *iters[0];
-        for (size_t i = 1; i < iters.size(); ++i)
-          if (*iters[i] > max_id)
-            max_id = *iters[i];
-        for (auto& it : iters)
-          it.SeekGE(max_id);
-        if (any_at_end())
-          break;
-        bool aligned = true;
-        DocId d = *iters[0];
-        for (size_t i = 1; i < iters.size(); ++i) {
-          if (*iters[i] != d) {
-            aligned = false;
-            break;
-          }
-        }
-        if (aligned) {
-          if (HasPhraseRun(iters, node.slop))
-            matches.push_back(d);
-          // Advance every iterator past this doc to find the next candidate.
-          for (auto& it : iters)
-            ++it;
-        }
-      }
-      return IndexResult{std::move(matches)};
+    auto any_at_end = [&]() {
+      for (size_t i = 0; i < iters.size(); ++i)
+        if (iters[i] == lists[i]->end())
+          return true;
+      return false;
     };
 
-    if (!active_field.empty()) {
-      if (auto* index = GetIndex<TextIndex>(active_field); index)
-        return eval_in(index);
+    vector<DocId> matches;
+    while (!any_at_end()) {
+      DocId max_id = *iters[0];
+      for (size_t i = 1; i < iters.size(); ++i)
+        max_id = std::max(max_id, *iters[i]);
+      for (auto& it : iters)
+        it.SeekGE(max_id);
+      if (any_at_end())
+        break;
+      bool aligned = true;
+      DocId d = *iters[0];
+      for (size_t i = 1; i < iters.size(); ++i) {
+        if (*iters[i] != d) {
+          aligned = false;
+          break;
+        }
+      }
+      if (aligned) {
+        if (HasPhraseRun(iters, slop))
+          matches.push_back(d);
+        // Advance every iterator past this doc to find the next candidate.
+        for (auto& it : iters)
+          ++it;
+      }
+    }
+    return matches;
+  }
+
+  // Phrase match on a single TEXT index. Sets error_ and returns empty if the index was
+  // created with NOOFFSETS. Stems are never consulted — phrase semantics require the exact
+  // surface form. Stopwords inside the phrase drop without advancing positions, matching the
+  // index-side tokenizer.
+  IndexResult MatchPhraseInIndex(TextIndex* text_index, const AstPhraseNode& node) {
+    if (!text_index->StoresPositions()) {
+      error_ = "phrase queries require offsets; index was created with NOOFFSETS";
       return IndexResult{};
+    }
+
+    auto lists = FetchPhrasePostingLists(text_index, node.raw);
+    if (lists.empty())
+      return IndexResult{};
+
+    // Single-token phrase: posting list IS the answer (no adjacency to check).
+    if (lists.size() == 1)
+      return IndexResult{lists[0]};
+
+    return IndexResult{IntersectAdjacentDocs(lists, node.slop)};
+  }
+
+  // Quoted phrase: dispatches per scoping. `@field:"..."` runs against one index; bare `"..."`
+  // ORs results across all TEXT indices, matching the term-lookup pattern.
+  IndexResult Search(const AstPhraseNode& node, string_view active_field) {
+    if (!active_field.empty()) {
+      auto* index = GetIndex<TextIndex>(active_field);
+      return index ? MatchPhraseInIndex(index, node) : IndexResult{};
     }
 
     vector<IndexResult> sub_results;
     for (auto* index : indices_->GetAllTextIndices())
-      sub_results.push_back(eval_in(index));
+      sub_results.push_back(MatchPhraseInIndex(index, node));
     return UnifyResults(std::move(sub_results), LogicOp::OR);
   }
 

--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -65,6 +65,7 @@ struct ProfileBuilder {
         [](const AstPrefixNode& n) { return absl::StrCat("Prefix{", n.affix, "}"); },
         [](const AstSuffixNode& n) { return absl::StrCat("Suffix{", n.affix, "}"); },
         [](const AstInfixNode& n) { return absl::StrCat("Infix{", n.affix, "}"); },
+        [](const AstPhraseNode& n) { return absl::StrCat("Phrase{", n.raw, "}"); },
         [](const AstRangeNode& n) { return absl::StrCat("Range{", n.lo, "<>", n.hi, "}"); },
         [](const AstLogicalNode& n) {
           auto op = n.op == AstLogicalNode::AND ? "and" : "or";
@@ -300,6 +301,129 @@ struct BasicSearch {
     vector<IndexResult> sub_results;
     for (auto* index : indices_->GetAllTextIndices())
       sub_results.push_back(match_in(index));
+    return UnifyResults(std::move(sub_results), LogicOp::OR);
+  }
+
+  // Recursive backtracking: can we extend a phrase starting at `cur` through positions[i..]?
+  // `cur` is the previously chosen position; we need next position q in positions[i] with
+  // q > cur and q - cur - 1 <= slop. Greedy isn't always optimal — must try all candidates
+  // in the window. positions per term per doc are typically small, so this is fine.
+  static bool CanExtendPhrase(const vector<absl::Span<const uint32_t>>& positions, size_t i,
+                              uint32_t cur, uint32_t slop) {
+    if (i >= positions.size())
+      return true;
+    const auto& p = positions[i];
+    uint32_t upper = cur + slop + 1;
+    auto lo = std::upper_bound(p.begin(), p.end(), cur);
+    for (auto it = lo; it != p.end() && *it <= upper; ++it) {
+      if (CanExtendPhrase(positions, i + 1, *it, slop))
+        return true;
+    }
+    return false;
+  }
+
+  // Check whether there exists a sequence p_0 < p_1 < ... < p_{N-1}, with p_i ∈
+  // iters[i].Positions() and p_{i+1} - p_i - 1 <= slop (i.e., at most `slop` intervening tokens).
+  // slop=0 = adjacency.
+  using PhraseIt = TextIndex::Container::BlockListIterator;
+  static bool HasPhraseRun(const vector<PhraseIt>& iters, uint32_t slop) {
+    vector<absl::Span<const uint32_t>> positions;
+    positions.reserve(iters.size());
+    for (const auto& it : iters)
+      positions.push_back(it.Positions());
+    for (uint32_t start : positions[0]) {
+      if (CanExtendPhrase(positions, 1, start, slop))
+        return true;
+    }
+    return false;
+  }
+
+  // Quoted phrase: AND-intersect posting lists of raw tokens, then verify adjacency by positions.
+  // Stems are not consulted — phrase semantics require the exact surface form. Stopwords inside
+  // the phrase are dropped (matching the index-side tokenizer, which doesn't advance pos for them).
+  IndexResult Search(const AstPhraseNode& node, string_view active_field) {
+    auto eval_in = [&](TextIndex* text_index) -> IndexResult {
+      if (!text_index->StoresPositions()) {
+        error_ = "phrase queries require offsets; index was created with NOOFFSETS";
+        return IndexResult{};
+      }
+
+      vector<string> terms = text_index->TokenizePhraseQuery(node.raw);
+      if (terms.empty())
+        return IndexResult{};
+
+      // Register each phrase term with the scorer so BM25 picks them up as virtual matches.
+      // Phrase-matched docs then score the same as if `term1 term2 ...` were AND-ed.
+      if (scorer_) {
+        for (const auto& t : terms)
+          AddMatchedTerm(text_index, t);
+      }
+
+      // Fetch posting lists (raw form only, no stem expansion). Any miss → empty result.
+      vector<const TextIndex::Container*> lists;
+      lists.reserve(terms.size());
+      for (const auto& t : terms) {
+        const auto* c = text_index->MatchingNoStem(t);
+        if (!c || c->Empty())
+          return IndexResult{};
+        lists.push_back(c);
+      }
+
+      // Single-token phrase short-circuit: posting list IS the answer (no adjacency to check).
+      if (lists.size() == 1)
+        return IndexResult{lists[0]};
+
+      // Intersect doc ids across all lists; for each common doc, check adjacency.
+      vector<PhraseIt> iters;
+      iters.reserve(lists.size());
+      for (const auto* l : lists)
+        iters.push_back(l->begin());
+
+      auto any_at_end = [&]() {
+        for (size_t i = 0; i < iters.size(); ++i)
+          if (iters[i] == lists[i]->end())
+            return true;
+        return false;
+      };
+
+      vector<DocId> matches;
+      while (!any_at_end()) {
+        DocId max_id = *iters[0];
+        for (size_t i = 1; i < iters.size(); ++i)
+          if (*iters[i] > max_id)
+            max_id = *iters[i];
+        for (auto& it : iters)
+          it.SeekGE(max_id);
+        if (any_at_end())
+          break;
+        bool aligned = true;
+        DocId d = *iters[0];
+        for (size_t i = 1; i < iters.size(); ++i) {
+          if (*iters[i] != d) {
+            aligned = false;
+            break;
+          }
+        }
+        if (aligned) {
+          if (HasPhraseRun(iters, node.slop))
+            matches.push_back(d);
+          // Advance every iterator past this doc to find the next candidate.
+          for (auto& it : iters)
+            ++it;
+        }
+      }
+      return IndexResult{std::move(matches)};
+    };
+
+    if (!active_field.empty()) {
+      if (auto* index = GetIndex<TextIndex>(active_field); index)
+        return eval_in(index);
+      return IndexResult{};
+    }
+
+    vector<IndexResult> sub_results;
+    for (auto* index : indices_->GetAllTextIndices())
+      sub_results.push_back(eval_in(index));
     return UnifyResults(std::move(sub_results), LogicOp::OR);
   }
 
@@ -700,7 +824,7 @@ void FieldIndices::CreateIndices(PMR_NS::memory_resource* mr) {
         const auto& tparams = std::get<SchemaField::TextParams>(field_info.special_params);
         indices_[field_ident] = make_unique<TextIndex>(
             mr, &options_.stopwords, synonyms_, tparams.with_suffixtrie, tparams.no_stem,
-            schema_.default_language, schema_.language_field);
+            schema_.default_language, schema_.language_field, !options_.no_offsets);
         break;
       }
       case SchemaField::NUMERIC: {

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -127,6 +127,9 @@ struct IndicesOptions {
 
   absl::flat_hash_set<std::string> stopwords;
   bool custom_stopwords = false;  // true when STOPWORDS was explicitly set in FT.CREATE
+  // When true, TEXT posting lists do not store token positions. Saves memory but
+  // disables phrase queries. Set via NOOFFSETS in FT.CREATE.
+  bool no_offsets = false;
 };
 
 // BM25 scoring statistics are now tracked per-field inside each TextIndex.

--- a/src/core/search/search_parser_test.cc
+++ b/src/core/search/search_parser_test.cc
@@ -53,6 +53,15 @@ class SearchParserTest : public ::testing::Test {
     auto tok = Lex();                                   \
     ASSERT_EQ(tok.type_get(), Parser::token::tok_enum); \
   }
+
+#define NEXT_PHRASE(raw_val, slop_val)                    \
+  {                                                       \
+    auto tok = Lex();                                     \
+    ASSERT_EQ(tok.type_get(), Parser::token::TOK_PHRASE); \
+    const auto& pt = tok.value.as<PhraseTok>();           \
+    EXPECT_EQ(pt.raw, raw_val);                           \
+    EXPECT_EQ(pt.slop, static_cast<uint32_t>(slop_val));  \
+  }
 #define NEXT_ERROR()                          \
   {                                           \
     bool caught = false;                      \
@@ -83,7 +92,7 @@ TEST_F(SearchParserTest, Scanner) {
   NEXT_TOK(TOK_RPAREN);
 
   SetInput(R"( "hello\"world" )");
-  NEXT_EQ(TOK_TERM, string, R"(hello"world)");
+  NEXT_PHRASE(R"(hello"world)", 0);
 
   SetInput("@field:hello");
   NEXT_EQ(TOK_FIELD, string, "@field");
@@ -188,7 +197,8 @@ TEST_F(SearchParserTest, Scanner) {
   NEXT_EQ(TOK_FIELD, string, "@color");
   NEXT_TOK(TOK_COLON);
   NEXT_TOK(TOK_LCURLBR);
-  NEXT_EQ(TOK_TERM, string, "prefix*");
+  // Lexer always emits PHRASE for quoted strings; the tag grammar treats it as a literal term.
+  NEXT_PHRASE("prefix*", 0);
   NEXT_TOK(TOK_RCURLBR);
 
   // Prefix spaced with star
@@ -389,18 +399,21 @@ TEST_F(SearchParserTest, ParseParams) {
 }
 
 TEST_F(SearchParserTest, Quotes) {
+  // Quoted strings tokenize to PHRASE (distinct from TERM) so the grammar can route them
+  // into AstPhraseNode for exact phrase queries. See PHRASE_QUERIES_PLAN.md.
   SetInput(" \"fir  st\"  'sec@o@nd' \":third:\" 'four\\\"th' ");
-  NEXT_EQ(TOK_TERM, string, "fir  st");
-  NEXT_EQ(TOK_TERM, string, "sec@o@nd");
-  NEXT_EQ(TOK_TERM, string, ":third:");
-  NEXT_EQ(TOK_TERM, string, "four\"th");
+  NEXT_PHRASE("fir  st", 0);
+  NEXT_PHRASE("sec@o@nd", 0);
+  NEXT_PHRASE(":third:", 0);
+  NEXT_PHRASE("four\"th", 0);
 }
 
 TEST_F(SearchParserTest, Numeric) {
   SetInput("11 123123123123 '22'");
   NEXT_EQ(TOK_UINT32, string, "11");
   NEXT_EQ(TOK_DOUBLE, string, "123123123123");
-  NEXT_EQ(TOK_TERM, string, "22");
+  // '22' is a quoted single-token phrase — still a phrase lit, executor will treat it as 1-token.
+  NEXT_PHRASE("22", 0);
 }
 
 TEST_F(SearchParserTest, VectorRange) {
@@ -448,6 +461,76 @@ TEST_F(SearchParserTest, KNNfull) {
   NEXT_EQ(TOK_TERM, string, "vec_sort");
 
   NEXT_TOK(TOK_RBRACKET);
+}
+
+TEST_F(SearchParserTest, PhraseSlopLex) {
+  // `"..."~N` (no whitespace before ~) → PHRASE token with slop=N.
+  SetInput("\"foo bar\"~3");
+  NEXT_PHRASE("foo bar", 3);
+
+  // Whitespace between `"..."` and `~` blocks slop attachment: ~ is the unary optional operator.
+  SetInput("\"foo bar\" ~3");
+  NEXT_PHRASE("foo bar", 0);
+  NEXT_TOK(TOK_TILDE);
+  NEXT_EQ(TOK_UINT32, string, "3");
+
+  // Slop digits must be unsigned; multi-digit works.
+  SetInput("\"a b\"~123");
+  NEXT_PHRASE("a b", 123);
+}
+
+TEST_F(SearchParserTest, PhraseSlopParse) {
+  ASSERT_EQ(0, Parse("\"machine learning\"~2"));
+  AstExpr root = query_driver_.Take();
+  ASSERT_TRUE(std::holds_alternative<AstPhraseNode>(root));
+  const auto& p = std::get<AstPhraseNode>(root);
+  EXPECT_EQ(p.raw, "machine learning");
+  EXPECT_EQ(p.slop, 2u);
+
+  // Field-scoped slop.
+  ASSERT_EQ(0, Parse("@title:\"machine learning\"~5"));
+  AstExpr field = query_driver_.Take();
+  ASSERT_TRUE(std::holds_alternative<AstFieldNode>(field));
+  const auto& fnode = std::get<AstFieldNode>(field);
+  ASSERT_TRUE(std::holds_alternative<AstPhraseNode>(*fnode.node));
+  EXPECT_EQ(std::get<AstPhraseNode>(*fnode.node).slop, 5u);
+}
+
+TEST_F(SearchParserTest, PhraseParse) {
+  // Top-level phrase.
+  ASSERT_EQ(0, Parse("\"machine learning\""));
+  AstExpr root = query_driver_.Take();
+  ASSERT_TRUE(std::holds_alternative<AstPhraseNode>(root));
+  EXPECT_EQ(std::get<AstPhraseNode>(root).raw, "machine learning");
+
+  // Phrase inside @field:"..."
+  ASSERT_EQ(0, Parse("@title:\"fully convolutional network\""));
+  AstExpr field = query_driver_.Take();
+  ASSERT_TRUE(std::holds_alternative<AstFieldNode>(field));
+  const auto& fnode = std::get<AstFieldNode>(field);
+  EXPECT_EQ(fnode.field, "title");
+  ASSERT_TRUE(std::holds_alternative<AstPhraseNode>(*fnode.node));
+  EXPECT_EQ(std::get<AstPhraseNode>(*fnode.node).raw, "fully convolutional network");
+
+  // Single-quoted single token still becomes a phrase (executor handles 1-token case).
+  ASSERT_EQ(0, Parse("'foo'"));
+  AstExpr single = query_driver_.Take();
+  ASSERT_TRUE(std::holds_alternative<AstPhraseNode>(single));
+
+  // Phrase combined with AND of free terms — RAG-style "...AND \"...\"" queries.
+  ASSERT_EQ(0, Parse("machine \"deep learning\""));
+  AstExpr and_root = query_driver_.Take();
+  ASSERT_TRUE(std::holds_alternative<AstLogicalNode>(and_root));
+  const auto& log = std::get<AstLogicalNode>(and_root);
+  EXPECT_EQ(log.op, AstLogicalNode::AND);
+  bool found_phrase = false;
+  for (const auto& child : log.nodes) {
+    if (std::holds_alternative<AstPhraseNode>(child)) {
+      found_phrase = true;
+      EXPECT_EQ(std::get<AstPhraseNode>(child).raw, "deep learning");
+    }
+  }
+  EXPECT_TRUE(found_phrase);
 }
 
 }  // namespace dfly::search

--- a/src/core/search/search_parser_test.cc
+++ b/src/core/search/search_parser_test.cc
@@ -496,6 +496,17 @@ TEST_F(SearchParserTest, PhraseSlopParse) {
   EXPECT_EQ(std::get<AstPhraseNode>(*fnode.node).slop, 5u);
 }
 
+// Slop inside a tag value (@tag:{"foo"~N}) is meaningless and must be rejected, not silently
+// dropped. Bare quoted tag values are still allowed and become literal AstTermNode.
+TEST_F(SearchParserTest, PhraseSlopRejectedInTagContext) {
+  // Bare quoted tag parses successfully.
+  EXPECT_EQ(0, Parse("@t:{\"foo bar\"}"));
+
+  // Slop in tag context — parser action throws Parser::syntax_error which bison converts to a
+  // non-zero parse result code.
+  EXPECT_NE(0, Parse("@t:{\"foo\"~2}"));
+}
+
 TEST_F(SearchParserTest, PhraseParse) {
   // Top-level phrase.
   ASSERT_EQ(0, Parse("\"machine learning\""));

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -3487,5 +3487,262 @@ TEST_F(SearchTest, MatchOptionalKnnIdsScoresAligned) {
   }
 }
 
+// Positions end-to-end via TextIndex: verifies that TokenizeWords -> BaseStringIndex::Add ->
+// BlockList -> CompressedSortedSet plumbing preserves per-token positions, that stopwords
+// don't advance positions, and that stem and raw tokens share the same position.
+class PositionsTest : public SearchTest {
+ protected:
+  std::vector<uint32_t> Positions(TextIndex* idx, std::string_view term, DocId doc) {
+    const auto* container = idx->Matching(term);
+    if (!container)
+      return {};
+    for (auto it = container->begin(); it != container->end(); ++it) {
+      if (*it == doc) {
+        auto p = it.Positions();
+        return std::vector<uint32_t>(p.begin(), p.end());
+      }
+    }
+    return {};
+  }
+};
+
+TEST_F(PositionsTest, BasicAdjacent) {
+  Schema schema = MakeSimpleSchema({{"field", SchemaField::TEXT}});
+  FieldIndices index{schema, kEmptyOptions, PMR_NS::get_default_resource(), nullptr};
+
+  MockedDocument doc("machine learning algorithm");
+  index.Add(0, doc);
+
+  auto text_indices = index.GetAllTextIndices();
+  ASSERT_EQ(text_indices.size(), 1u);
+  auto* ti = text_indices[0];
+
+  // Tokens "machine", "learning", "algorithm" should land at sequential positions.
+  auto m = Positions(ti, "machine", 0);
+  auto l = Positions(ti, "learning", 0);
+  auto a = Positions(ti, "algorithm", 0);
+  ASSERT_EQ(m.size(), 1u);
+  ASSERT_EQ(l.size(), 1u);
+  ASSERT_EQ(a.size(), 1u);
+  EXPECT_EQ(l[0], m[0] + 1) << "learning must be adjacent to machine";
+  EXPECT_EQ(a[0], l[0] + 1) << "algorithm must follow learning";
+}
+
+TEST_F(PositionsTest, RepeatedTermAccumulates) {
+  Schema schema = MakeSimpleSchema({{"field", SchemaField::TEXT}});
+  FieldIndices index{schema, kEmptyOptions, PMR_NS::get_default_resource(), nullptr};
+
+  MockedDocument doc("foo bar foo baz foo");
+  index.Add(0, doc);
+  auto* ti = index.GetAllTextIndices()[0];
+
+  auto foo = Positions(ti, "foo", 0);
+  EXPECT_EQ(foo.size(), 3u);
+  ASSERT_TRUE(std::is_sorted(foo.begin(), foo.end()));
+  // bar and baz fall between the foos at positions foo[0]+1 and foo[1]+1.
+  auto bar = Positions(ti, "bar", 0);
+  auto baz = Positions(ti, "baz", 0);
+  ASSERT_EQ(bar.size(), 1u);
+  ASSERT_EQ(baz.size(), 1u);
+  EXPECT_EQ(bar[0], foo[0] + 1);
+  EXPECT_EQ(baz[0], foo[1] + 1);
+}
+
+TEST_F(PositionsTest, StopwordsDoNotAdvance) {
+  Schema schema = MakeSimpleSchema({{"field", SchemaField::TEXT}});
+  // "a", "the", "of" are typical English stopwords used by default.
+  IndicesOptions opts{};
+  FieldIndices index{schema, opts, PMR_NS::get_default_resource(), nullptr};
+
+  MockedDocument doc("a machine the learning of");
+  index.Add(0, doc);
+  auto* ti = index.GetAllTextIndices()[0];
+
+  auto m = Positions(ti, "machine", 0);
+  auto l = Positions(ti, "learning", 0);
+  ASSERT_EQ(m.size(), 1u);
+  ASSERT_EQ(l.size(), 1u);
+  EXPECT_EQ(l[0], m[0] + 1)
+      << "Stopwords (a/the/of) must not advance positions; machine and learning should be adjacent";
+}
+
+// Exact phrase queries — issue #7294 reproduction and edge cases.
+class PhraseTest : public SearchTest {};
+
+TEST_F(PhraseTest, BasicReproductionFromIssue7294) {
+  PrepareQuery("\"machine learning\"");
+  ExpectAll("machine learning algorithm",  // adjacent, in order
+            "machine learning",            // adjacent, exact
+            "preface machine learning epilogue");
+  ExpectNone("learning machine works",  // reversed order
+             "machine deep learning",   // not adjacent
+             "only machine", "no learning here");
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+TEST_F(PhraseTest, SingleTokenPhraseEqualsTerm) {
+  PrepareQuery("\"foo\"");
+  ExpectAll("foo", "foo bar", "bar foo baz");
+  ExpectNone("food", "afoo", "bar");
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+TEST_F(PhraseTest, StopwordsInPhraseDoNotAdvancePositions) {
+  // Both indexing and phrase-tokenize drop stopwords without advancing positions, so
+  // "a machine the learning" indexes as machine@1, learning@2 and the phrase
+  // "the machine learning" tokenizes to [machine, learning] — adjacency holds.
+  auto schema = MakeSimpleSchema({{"field", SchemaField::TEXT}});
+  IndicesOptions options{{"a", "the", "of"}};
+  FieldIndices indices{schema, options, PMR_NS::get_default_resource(), nullptr};
+
+  vector<string> documents = {"a machine the learning algorithm",  // pos: machine@1, learning@2
+                              "machine learning works",            // pos: machine@1, learning@2
+                              "learning machine"};                 // pos: learning@1, machine@2
+  for (size_t i = 0; i < documents.size(); i++) {
+    MockedDocument doc{{{"field", documents[i]}}};
+    indices.Add(i, doc);
+  }
+
+  SearchAlgorithm algo{};
+  QueryParams params;
+  ASSERT_TRUE(algo.Init("\"the machine learning\"", &params));
+  EXPECT_THAT(algo.Search(&indices).ids, testing::UnorderedElementsAre(0u, 1u));
+}
+
+TEST_F(PhraseTest, ThreeWordAdjacency) {
+  PrepareQuery("\"fully convolutional network\"");
+  ExpectAll("the fully convolutional network is great", "fully convolutional network");
+  ExpectNone("fully network convolutional",       // wrong order
+             "fully deep convolutional network",  // not adjacent
+             "convolutional network only");
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+TEST_F(PhraseTest, RepeatedTermInPhrase) {
+  // "the the" → after stopword filter is empty → matches nothing.
+  // But repeated content terms like "foo foo" must find adjacent foo,foo.
+  PrepareQuery("\"foo foo\"");
+  ExpectAll("foo foo bar",
+            "bar foo foo baz",  // adjacent pair in middle
+            "foo foo foo");     // three foos contain adjacent pair
+  ExpectNone("foo bar foo",     // separated
+             "foo");            // single
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+TEST_F(PhraseTest, FieldScopedPhrase) {
+  PrepareSchema({{"title", SchemaField::TEXT}, {"body", SchemaField::TEXT}});
+  PrepareQuery("@title:\"machine learning\"");
+  ExpectAll(Map{{"title", "machine learning algorithm"}, {"body", "anything"}});
+  ExpectNone(Map{{"title", "learning machine"}, {"body", "machine learning"}});  // wrong field
+  ExpectNone(Map{{"title", "deep learning"}, {"body", "machine learning"}});
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+TEST_F(PhraseTest, PhraseAndedWithTerm) {
+  PrepareQuery("algorithm \"machine learning\"");
+  ExpectAll("machine learning algorithm", "algorithm runs machine learning");
+  ExpectNone("machine learning",             // missing 'algorithm'
+             "algorithm works",              // missing phrase
+             "learning machine algorithm");  // phrase order wrong
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+TEST_F(PhraseTest, SlopAllowsGap) {
+  PrepareQuery("\"machine learning\"~1");
+  ExpectAll("machine learning",             // gap=0
+            "machine deep learning",        // gap=1
+            "machine learning algorithm");  // contains gap=0 run
+  ExpectNone("machine very deep learning",  // gap=2 (over budget)
+             "learning machine",            // wrong order
+             "machine only");
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+TEST_F(PhraseTest, SlopThreeWordPhrase) {
+  PrepareQuery("\"a b c\"~1");
+  // slop=1: at most 1 intervening word between consecutive phrase terms.
+  ExpectAll("a b c",       // 0,1,2
+            "a x b c",     // 0,2,3 → gap 1 then 0
+            "a b x c",     // 0,1,3 → gap 0 then 1
+            "a x b y c");  // 0,2,4 → gap 1 each
+  ExpectNone("a x y b c",  // gap=2 between a and b
+             "b a c",      // wrong order
+             "a b");       // missing c
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+TEST_F(PhraseTest, SlopRequiresOrder) {
+  // slop > 0 still requires terms in order.
+  PrepareQuery("\"machine learning\"~10");
+  ExpectAll("machine and learning");
+  ExpectNone("learning the machine");
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+TEST_F(PhraseTest, SlopBacktrackingFindsLaterCandidate) {
+  // Greedy "smallest first" fails when an earlier candidate dead-ends: text "a x a y b" with
+  // "a b"~1 should pick a@2 → b@4 (gap=1), not give up at a@0 where no b is within slop range.
+  PrepareQuery("\"a b\"~1");
+  ExpectAll("a x a y b");
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+TEST_F(PhraseTest, OnlyStopwordsInPhraseMatchesNothing) {
+  // Phrase that tokenizes to zero terms (all stopwords) must match no docs.
+  auto schema = MakeSimpleSchema({{"field", SchemaField::TEXT}});
+  IndicesOptions options{{"a", "the", "of"}};
+  FieldIndices indices{schema, options, PMR_NS::get_default_resource(), nullptr};
+
+  vector<string> documents = {"a the of", "machine learning", "anything else"};
+  for (size_t i = 0; i < documents.size(); i++) {
+    MockedDocument doc{{{"field", documents[i]}}};
+    indices.Add(i, doc);
+  }
+
+  SearchAlgorithm algo{};
+  QueryParams params;
+  ASSERT_TRUE(algo.Init("\"a the of\"", &params));
+  EXPECT_THAT(algo.Search(&indices).ids, testing::UnorderedElementsAre());
+}
+
+TEST_F(PhraseTest, PhraseMatchedDocsAreScored) {
+  // Phrase matches must populate text_scores via BM25 — i.e. constituent terms are registered
+  // as matched. Without this, top-K ranking would treat phrase-matched docs as score=0.
+  auto schema = MakeSimpleSchema({{"field", SchemaField::TEXT}});
+  FieldIndices index{schema, kEmptyOptions, PMR_NS::get_default_resource(), nullptr};
+
+  // doc 0 contains the phrase with extra repetition (higher TF → higher BM25).
+  MockedDocument doc0("machine learning machine learning algorithm");
+  MockedDocument doc1("machine learning works");
+  MockedDocument doc2("unrelated content");
+  index.Add(0, doc0);
+  index.Add(1, doc1);
+  index.Add(2, doc2);
+  index.FinalizeInitialization();
+
+  QueryParams params;
+  SearchAlgorithm algo;
+  ASSERT_TRUE(algo.Init("\"machine learning\"", &params));
+  algo.SetScorer(&BM25Std);
+
+  auto result = algo.Search(&index);
+  ASSERT_EQ(result.ids.size(), 2u);
+  EXPECT_EQ(result.text_scores.size(), 2u);
+  for (auto& [doc, score] : result.text_scores)
+    EXPECT_GT(score, 0.0f) << "Phrase-matched doc " << doc << " must have positive score";
+
+  // doc 0 has higher term frequency → must rank higher than doc 1.
+  std::optional<float> s0, s1;
+  for (auto& [doc, score] : result.text_scores) {
+    if (doc == 0)
+      s0 = score;
+    if (doc == 1)
+      s1 = score;
+  }
+  ASSERT_TRUE(s0 && s1);
+  EXPECT_GT(*s0, *s1) << "Higher TF must score higher";
+}
+
 }  // namespace search
 }  // namespace dfly

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -3744,5 +3744,78 @@ TEST_F(PhraseTest, PhraseMatchedDocsAreScored) {
   EXPECT_GT(*s0, *s1) << "Higher TF must score higher";
 }
 
+// UTF-8 phrase eval — adjacency works across Unicode word boundaries (Cyrillic).
+// Corpus drawn from a small Ukrainian poem; verifies Cyrillic lowercase + adjacency
+// through the full eval pipeline:
+//   Кіт заліз у холодильник —
+//   Шукав там ковбасу.
+//   Знайшов лише каструлю борщу
+//   І втратив віру в красу.
+TEST_F(PhraseTest, UnicodePhraseAdjacency) {
+  PrepareQuery("\"втратив віру\"");
+  ExpectAll("І втратив віру в красу",         // adjacent, in order (line 4)
+            "він втратив віру назавжди");     // adjacent, embedded
+  ExpectNone("віру втратив швидко",           // reversed
+             "втратив надію а потім віру",    // not adjacent
+             "Кіт заліз у холодильник",       // unrelated line
+             "Знайшов лише каструлю борщу");  // unrelated line
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+// Phrase of 5+ tokens (exceeds positions_stash_ inline capacity of 4).
+TEST_F(PhraseTest, LongPhraseFiveTokens) {
+  PrepareQuery("\"the quick brown fox jumps\"");
+  ExpectAll("the quick brown fox jumps over", "before the quick brown fox jumps after");
+  ExpectNone("the quick brown fox runs",
+             "quick brown fox jumps over",  // missing 'the'
+             "the brown fox jumps over");   // missing 'quick'
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+// Document with many occurrences of a phrase term — exercises position-decoding loop
+// past the InlinedVector<uint32_t, 4> inline capacity.
+TEST_F(PhraseTest, ManyPositionsPerTerm) {
+  auto schema = MakeSimpleSchema({{"field", SchemaField::TEXT}});
+  FieldIndices indices{schema, kEmptyOptions, PMR_NS::get_default_resource(), nullptr};
+
+  // 'foo' appears 10x, 'bar' 1x adjacent to one of the foos. Forces the position list
+  // for 'foo' to spill to the heap inside positions_stash_.
+  std::string text;
+  for (int i = 0; i < 9; ++i)
+    text += "foo zzz ";
+  text += "foo bar";  // adjacency at the 10th foo
+  MockedDocument doc({{"field", text}});
+  indices.Add(0, doc);
+
+  SearchAlgorithm algo;
+  QueryParams params;
+  ASSERT_TRUE(algo.Init("\"foo bar\"", &params));
+  EXPECT_THAT(algo.Search(&indices).ids, testing::UnorderedElementsAre(0u));
+}
+
+// Empty phrase "" must safely match nothing — neither crash nor match-all.
+TEST_F(PhraseTest, EmptyPhrase) {
+  PrepareQuery("\"\"");
+  ExpectNone("foo", "anything", "literally any document");
+  EXPECT_TRUE(Check()) << GetError();
+}
+
+// NOOFFSETS index surfaces a typed error to FT.SEARCH callers, not silently empty.
+TEST_F(PhraseTest, NoOffsetsErrorIsExplicit) {
+  auto schema = MakeSimpleSchema({{"field", SchemaField::TEXT}});
+  IndicesOptions options{{}};
+  options.no_offsets = true;
+  FieldIndices indices{schema, options, PMR_NS::get_default_resource(), nullptr};
+
+  MockedDocument doc("machine learning algorithm");
+  indices.Add(0, doc);
+
+  SearchAlgorithm algo;
+  QueryParams params;
+  ASSERT_TRUE(algo.Init("\"machine learning\"", &params));
+  auto result = algo.Search(&indices);
+  EXPECT_THAT(result.error, testing::HasSubstr("phrase queries require offsets"));
+}
+
 }  // namespace search
 }  // namespace dfly

--- a/src/core/search/stemmer.cc
+++ b/src/core/search/stemmer.cc
@@ -4,10 +4,11 @@
 
 #include "core/search/stemmer.h"
 
-#include <glog/logging.h>
 #include <libstemmer.h>
 
 #include <utility>
+
+#include "base/logging.h"
 
 namespace dfly::search {
 

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -291,6 +291,13 @@ ParseResult<bool> ParseIndexLanguageField(CmdArgParser* parser, DocIndex* index)
   return true;
 }
 
+// NOOFFSETS (index-level): disable storing token positions in TEXT posting lists.
+// Saves memory but breaks phrase queries.
+ParseResult<bool> ParseNoOffsets(CmdArgParser* /*parser*/, DocIndex* index) {
+  index->options.no_offsets = true;
+  return true;
+}
+
 // STOPWORDS count [words...]
 ParseResult<bool> ParseStopwords(CmdArgParser* parser, DocIndex* index) {
   index->options.stopwords.clear();
@@ -398,10 +405,10 @@ ParseResult<DocIndex> CreateDocIndex(std::string_view name, CmdArgParser* parser
   index.name = name;
 
   while (parser->HasNext()) {
-    auto option_parser =
-        parser->TryMapNext("ON"sv, &ParseOnOption, "PREFIX"sv, &ParsePrefix, "STOPWORDS"sv,
-                           &ParseStopwords, "LANGUAGE"sv, &ParseIndexLanguage, "LANGUAGE_FIELD"sv,
-                           &ParseIndexLanguageField, "SCHEMA"sv, &ParseSchema);
+    auto option_parser = parser->TryMapNext(
+        "ON"sv, &ParseOnOption, "PREFIX"sv, &ParsePrefix, "STOPWORDS"sv, &ParseStopwords,
+        "LANGUAGE"sv, &ParseIndexLanguage, "LANGUAGE_FIELD"sv, &ParseIndexLanguageField,
+        "NOOFFSETS"sv, &ParseNoOffsets, "SCHEMA"sv, &ParseSchema);
 
     if (!option_parser) {
       // Unsupported parameters are ignored for now
@@ -1798,7 +1805,14 @@ void CmdFtInfo(CmdArgList args, CommandContext* cmd_cntx) {
   }
 
   rb->SendSimpleString("index_options");
-  rb->SendEmptyArray();
+  {
+    std::vector<std::string_view> opts;
+    if (info.base_index.options.no_offsets)
+      opts.emplace_back("NOOFFSETS");
+    rb->StartArray(opts.size());
+    for (auto opt : opts)
+      rb->SendSimpleString(opt);
+  }
 
   rb->SendSimpleString("attributes");
   rb->StartArray(schema.fields.size());

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -5535,6 +5535,52 @@ TEST_F(SearchFamilyTest, StemmingAggregateGroupbyKeepsRaw) {
                                          IsMap("tag", "learned", "n", "1")));
 }
 
+// End-to-end reproduction of issue #7294: FT.SEARCH with a quoted phrase enforces adjacency.
+TEST_F(SearchFamilyTest, PhraseQueryIssue7294) {
+  Run({"FT.CREATE", "idx_phrase", "SCHEMA", "t", "TEXT", "NOSTEM"});
+
+  Run({"HSET", "p:1", "t", "machine learning algorithm"});  // adjacent, in order
+  Run({"HSET", "p:2", "t", "learning machine works"});      // reversed order
+  Run({"HSET", "p:3", "t", "machine learning"});            // adjacent, exact
+
+  // Bare terms: AND-match, all three docs.
+  EXPECT_THAT(Run({"FT.SEARCH", "idx_phrase", "machine learning"}), AreDocIds("p:1", "p:2", "p:3"));
+
+  // Quoted phrase: only adjacent, in-order matches.
+  EXPECT_THAT(Run({"FT.SEARCH", "idx_phrase", "\"machine learning\""}), AreDocIds("p:1", "p:3"));
+}
+
+// Phrase queries against a NOOFFSETS index surface an error (positions aren't stored).
+TEST_F(SearchFamilyTest, PhraseOnNoOffsetsErrors) {
+  Run({"FT.CREATE", "idx_no_off", "NOOFFSETS", "SCHEMA", "t", "TEXT"});
+  Run({"HSET", "p:1", "t", "machine learning"});
+
+  EXPECT_THAT(Run({"FT.SEARCH", "idx_no_off", "\"machine learning\""}),
+              ErrArg("phrase queries require offsets"));
+}
+
+// NOOFFSETS index-level flag is accepted by FT.CREATE and round-trips through FT.INFO.
+TEST_F(SearchFamilyTest, NoOffsetsFlagSurface) {
+  Run({"FT.CREATE", "no_off_idx", "NOOFFSETS", "SCHEMA", "body", "TEXT"});
+
+  auto info = Run({"FT.INFO", "no_off_idx"});
+  EXPECT_THAT(info,
+              IsArray(_, _, _, _, "index_options", IsArray("NOOFFSETS"), _, _, _, _, _, _, _, _));
+
+  // Ordinary AND queries don't need offsets and must still work.
+  Run({"HSET", "h:1", "body", "machine learning algorithm"});
+  Run({"HSET", "h:2", "body", "learning machine works"});
+  EXPECT_THAT(Run({"FT.SEARCH", "no_off_idx", "machine learning"}), AreDocIds("h:1", "h:2"));
+}
+
+// Default index (no NOOFFSETS) has an empty index_options array.
+TEST_F(SearchFamilyTest, NoOffsetsAbsentByDefault) {
+  Run({"FT.CREATE", "default_idx", "SCHEMA", "body", "TEXT"});
+  auto info = Run({"FT.INFO", "default_idx"});
+  EXPECT_THAT(info,
+              IsArray(_, _, _, _, "index_options", RespArray(IsEmpty()), _, _, _, _, _, _, _, _));
+}
+
 // FT.INFO surfaces NOSTEM per-attribute and language in index_definition.
 TEST_F(SearchFamilyTest, StemmingInfoSurface) {
   Run({"FT.CREATE", "info_idx", "ON", "HASH", "PREFIX", "1", "doc:", "SCHEMA", "title", "TEXT",


### PR DESCRIPTION
Quoted multi-word terms in `FT.SEARCH` now match documents where the constituent tokens appear at adjacent positions (in order) within the same field - restoring parity for RAG / IR workflows that combine free-text AND with phrase-pinned subspans.

```
> FT.CREATE idx SCHEMA t TEXT NOSTEM
> HSET p:1 t "machine learning algorithm"
> HSET p:2 t "learning machine works"
> HSET p:3 t "machine learning"

> FT.SEARCH idx "machine learning"        # bare terms (AND)
1) 3) p:1, p:2, p:3

> FT.SEARCH idx "\"machine learning\""    # quoted phrase (adjacency)
1) 2) p:1, p:3
```

Behavior:
| Surface | After |
|---|---|
| `"a b"` | matches docs where `a` and `b` are adjacent in order in the same field |
| `"a b c"~N` | up to `N` intervening tokens between consecutive phrase terms (in order); `~0` ≡ adjacency |
| `@field:"a b"` | phrase restricted to a single TEXT field |
| Phrase combined with AND/OR/NOT | works as a regular sub-expression |
| Stemming (`TEXT` default) | bare terms still stem-expand; phrases match raw forms only |
| Stopwords inside the phrase | dropped at tokenize-time without advancing position |
| Single-token phrase `"foo"` | equivalent to bare `foo` but without stem expansion |
| Tag content `@tag:{"foo bar"}` | unchanged - quoted strings in `{...}` are literal tags |
| BM25 scoring | phrase-matched docs score as if constituent terms had matched independently |
| `FT.CREATE idx NOOFFSETS ...` | opt-out: skips position storage (saves memory, breaks phrase) |
| `FT.INFO`'s `index_options` | reports `NOOFFSETS` when set |

Closes #7294
