### PR TITLE
fix(test): Disable cooling for pytest with tiering and cluster

### DIFF
--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -3717,6 +3717,7 @@ async def test_cluster_migration_with_tiering(df_factory):
             proactor_threads=2,
             tiered_prefix="/tmp/tiered/cluster_node",
             tiered_offload_threshold="0.2",
+            tiered_experimental_cooling="False",
             maxmemory="512MB",
         ),
         df_factory.create(
@@ -3733,6 +3734,10 @@ async def test_cluster_migration_with_tiering(df_factory):
 
     keys = 1000000
     await nodes[0].client.execute_command(f"DEBUG POPULATE {keys} size 440")
+
+    # Expect that number of added keys is 1000000
+    info = await nodes[0].client.info("keyspace")
+    assert info["db0"]["keys"] == keys
 
     await asyncio.sleep(5)  # wait for tiering to offload data
 
@@ -3781,6 +3786,7 @@ async def test_cluster_migration_with_tiering_and_deletes(df_factory: DflyInstan
             proactor_threads=2,
             tiered_prefix="/tmp/tiered/cluster_node",
             tiered_offload_threshold="0.2",
+            tiered_experimental_cooling="False",
             maxmemory="512MB",
         ),
         df_factory.create(


### PR DESCRIPTION
On some runs in CI we can see that test can fail because we couldn't add more keys. Disable tiering cooling layer to offload all keys to disk instead of keeping some of them in memory.

Closes #7318

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
