### PR TITLE
fix: strip CRLF from Lua error_reply and status_reply

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -407,15 +407,23 @@ class EvalSerializer : public ObjectExplorer {
   }
 
   void OnStatus(string_view str) {
+    if (str.find_first_of("\r\n") == string_view::npos) {
+      rb_->SendSimpleString(str);
+      return;
+    }
     rb_->SendSimpleString(StripCRLF(str));
   }
 
   void OnError(string_view str) {
-    std::string s = StripCRLF(str);
-    if (!s.empty() && s.front() != '-') {
-      rb_->SendError(absl::StrCat("-", s));
+    std::string buf;
+    if (str.find_first_of("\r\n") != string_view::npos) {
+      buf = StripCRLF(str);
+      str = buf;
+    }
+    if (!str.empty() && str.front() == '-') {
+      rb_->SendError(str);
     } else {
-      rb_->SendError(s);
+      rb_->SendError(absl::StrCat("-", str));
     }
   }
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -407,18 +407,28 @@ class EvalSerializer : public ObjectExplorer {
   }
 
   void OnStatus(string_view str) {
-    rb_->SendSimpleString(str);
+    rb_->SendSimpleString(StripCRLF(str));
   }
 
   void OnError(string_view str) {
-    if (!str.empty() && str.front() != '-') {
-      rb_->SendError(absl::StrCat("-", str));
+    std::string s = StripCRLF(str);
+    if (!s.empty() && s.front() != '-') {
+      rb_->SendError(absl::StrCat("-", s));
     } else {
-      rb_->SendError(str);
+      rb_->SendError(s);
     }
   }
 
  private:
+  static std::string StripCRLF(string_view str) {
+    std::string out;
+    out.reserve(str.size());
+    for (char c : str)
+      if (c != '\r' && c != '\n')
+        out += c;
+    return out;
+  }
+
   RedisReplyBuilder* rb_;
   bool float_as_int_;
 };

--- a/tests/dragonfly/eval_test.py
+++ b/tests/dragonfly/eval_test.py
@@ -414,6 +414,21 @@ async def test_StackOverflowByHincrbyfloat(df_server: DflyInstance):
     assert "2.5" == await client.execute_command("HGET myhash field")
 
 
+@dfly_args({"proactor_threads": 1})
+async def test_eval_no_resp_injection(async_client: aioredis.Redis):
+    """Verify redis.error_reply() and redis.status_reply() strip embedded CRLF (RESP injection)."""
+    for script in [
+        'return redis.error_reply("ERR msg\\r\\n+INJECTED\\r\\n")',
+        'return redis.status_reply("OK\\r\\n+INJECTED\\r\\n")',
+    ]:
+        pipe = async_client.pipeline(transaction=False)
+        pipe.eval(script, 0)
+        pipe.ping()
+        results = await pipe.execute(raise_on_error=False)
+        # If CRLF is not stripped, "+INJECTED\r\n" is consumed as PING's response instead of "+PONG"
+        assert results[1] is True, f"RESP injection detected for: {script}"
+
+
 @dfly_args({"proactor_threads": 4})
 async def test_eval_commandstats_nested_call(async_client: aioredis.Redis):
     def calls(stats, name: str) -> int:


### PR DESCRIPTION
`EvalSerializer::OnError` and `OnStatus` passed Lua-controlled strings directly to `SendError`/`SendSimpleString` without sanitizing embedded `\r\n`. Since CRLF is the RESP frame delimiter, a string like `redis.error_reply("ERR\r\n+INJECTED\r\n")` would split into multiple RESP messages on the wire, allowing response desynchronization in connection-pool clients.

Strip `\r` and `\n` from both paths before writing to the reply builder.

Fixes #7328