### PR TITLE
fix: migration restart flush race

### DIFF
--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -593,7 +593,8 @@ void ClusterFamily::DflyClusterConfig(CmdArgList args, CommandContext* cmd_cntx)
 
     new_config = new_config->CloneWithChanges(enable_slots, disable_slots);
 
-    StartNewSlotMigrations(*new_config);
+    // Capture prev config before SetCurrent so StartNewSlotMigrations can diff correctly.
+    auto prev_config = ClusterConfig::Current();
 
     SlotSet before =
         ClusterConfig::Current() ? ClusterConfig::Current()->GetOwnedSlots() : SlotSet(true);
@@ -632,6 +633,10 @@ void ClusterFamily::DflyClusterConfig(CmdArgList args, CommandContext* cmd_cntx)
           << "Flushing newly unowned slots: " << deleted_slots.ToString();
       WriteFlushSlotsToJournal(deleted_slots);
     }
+
+    // Start new migrations only after stale data is flushed. This ensures DFLYMIGRATE FLOW
+    // cannot write data that is immediately wiped by DeleteSlots above.
+    StartNewSlotMigrations(*new_config, prev_config);
   }
 
   return cmd_cntx->SendOk();
@@ -744,10 +749,11 @@ void ClusterFamily::DflyClusterFlushSlots(CmdArgList args, CommandContext* cmd_c
   return cmd_cntx->SendOk();
 }
 
-void ClusterFamily::StartNewSlotMigrations(const ClusterConfig& new_config) {
+void ClusterFamily::StartNewSlotMigrations(const ClusterConfig& new_config,
+                                           const std::shared_ptr<ClusterConfig>& prev_config) {
   // TODO Add validating and error processing
-  auto out_migrations = new_config.GetNewOutgoingMigrations(ClusterConfig::Current());
-  auto in_migrations = new_config.GetNewIncomingMigrations(ClusterConfig::Current());
+  auto out_migrations = new_config.GetNewOutgoingMigrations(prev_config);
+  auto in_migrations = new_config.GetNewIncomingMigrations(prev_config);
 
   util::fb2::LockGuard lk(migration_mu_);
 

--- a/src/server/cluster/cluster_family.h
+++ b/src/server/cluster/cluster_family.h
@@ -99,7 +99,8 @@ class ClusterFamily {
   std::shared_ptr<IncomingSlotMigration> GetIncomingMigration(std::string_view source_id)
       ABSL_LOCKS_EXCLUDED(migration_mu_);
 
-  void StartNewSlotMigrations(const ClusterConfig& new_config);
+  void StartNewSlotMigrations(const ClusterConfig& new_config,
+                              const std::shared_ptr<ClusterConfig>& prev_config);
 
   // must be destroyed excluded set_config_mu and migration_mu_ locks
   struct PreparedToRemoveOutgoingMigrations {


### PR DESCRIPTION
### The bug

When a new cluster config is sent a stale migration that is already in-flight will be cancelled.  To avoid stale data for cancelled migrations we `flush` the removed slot range `before` any of the new migration (given in the new cluster config) kick in. 

The `before` part however was `racy` and it allowed the following sequence of execution: 

1. the previous migration (call it `A`) is cancelled 
2. the new migrations (call it `B`) is setup
3. data for new migration `B` is moving in
4. flushed newly send data

This could also been seen in the LOGS where we flushed `after` the `connection for the new migration passes the Init stage` (which means it is already streaming data)

Should resolve #7188
