### PR TITLE
refactor: add method CompactObject::SetMemberTime

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -867,6 +867,32 @@ void CompactObj::InitRobj(CompactObjType type, unsigned encoding, void* obj) {
   u_.r_obj.Init(type, encoding, obj);
 }
 
+namespace {
+// Returns the underlying DenseSet if this CompactObj wraps a StringSet/StringMap
+// (kEncodingStrMap2), otherwise nullptr. Encoding() is a safe accessor that
+// returns kEncodingStrMap2 only when taglen_ == ROBJ_TAG.
+DenseSet* AsDenseSetOrNull(const CompactObj& obj) {
+  if (obj.Encoding() != kEncodingStrMap2)
+    return nullptr;
+  return static_cast<DenseSet*>(obj.RObjPtr());
+}
+}  // namespace
+
+void CompactObj::SetMemberTime(uint32_t seconds) const {
+  if (DenseSet* ds = AsDenseSetOrNull(*this))
+    ds->set_time(seconds);
+}
+
+uint32_t CompactObj::MemberTime() const {
+  DenseSet* ds = AsDenseSetOrNull(*this);
+  return ds ? ds->time_now() : 0;
+}
+
+bool CompactObj::HasMemberExpiration() const {
+  DenseSet* ds = AsDenseSetOrNull(*this);
+  return ds && ds->ExpirationUsed();
+}
+
 void CompactObj::SetInt(int64_t val) {
   DCHECK(!IsExternal());
 

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -265,6 +265,19 @@ class CompactObj {
   // type should not be OBJ_STRING.
   void InitRobj(CompactObjType type, unsigned encoding, void* obj_inner);
 
+  // Sets the abstract time used by per-member lazy expiry on StringSet/StringMap.
+  // The value should typically be obtained via MemberTimeSeconds(now_ms).
+  // Safe to call unconditionally — no-op if the underlying encoding is not kEncodingStrMap2.
+  void SetMemberTime(uint32_t seconds) const;
+
+  // Returns the abstract time previously set via SetMemberTime, or 0 if encoding
+  // is not kEncodingStrMap2.
+  uint32_t MemberTime() const;
+
+  // Returns true if any member of the underlying StringSet/StringMap has expiration.
+  // Returns false if encoding is not kEncodingStrMap2.
+  bool HasMemberExpiration() const;
+
   // For STR object.
   void SetInt(int64_t val);
   std::optional<int64_t> TryGetInt() const;

--- a/src/core/compact_object_test.cc
+++ b/src/core/compact_object_test.cc
@@ -801,6 +801,49 @@ TEST_F(CompactObjectTest, DefragSet) {
   ASSERT_FALSE(cobj_.DefragIfNeeded(&page_usage));
 }
 
+TEST_F(CompactObjectTest, MemberTimeSet) {
+  StringSet* s = CompactObj::AllocateMR<StringSet>();
+  cobj_.InitRobj(OBJ_SET, kEncodingStrMap2, s);
+
+  cobj_.SetMemberTime(0);
+  EXPECT_EQ(cobj_.MemberTime(), 0u);
+  EXPECT_FALSE(cobj_.HasMemberExpiration());
+
+  cobj_.SetMemberTime(1234);
+  EXPECT_EQ(cobj_.MemberTime(), 1234u);
+  EXPECT_EQ(s->time_now(), 1234u);
+
+  s->Add("a", 60);  // adding TTL'd entry marks expiration as used
+  EXPECT_TRUE(cobj_.HasMemberExpiration());
+}
+
+TEST_F(CompactObjectTest, MemberTimeHash) {
+  StringMap* m = CompactObj::AllocateMR<StringMap>();
+  cobj_.InitRobj(OBJ_HASH, kEncodingStrMap2, m);
+
+  cobj_.SetMemberTime(100);
+  EXPECT_EQ(cobj_.MemberTime(), 100u);
+  EXPECT_EQ(m->time_now(), 100u);
+  EXPECT_FALSE(cobj_.HasMemberExpiration());
+
+  m->AddOrUpdate("k", "v", 60);
+  EXPECT_TRUE(cobj_.HasMemberExpiration());
+}
+
+TEST_F(CompactObjectTest, MemberTimeSafeOnNonDense) {
+  // Methods must be safe to call on objects that don't use kEncodingStrMap2.
+  cobj_.SetString("hello");
+  cobj_.SetMemberTime(42);  // no-op
+  EXPECT_EQ(cobj_.MemberTime(), 0u);
+  EXPECT_FALSE(cobj_.HasMemberExpiration());
+
+  intset* is = intsetNew();
+  cobj_.InitRobj(OBJ_SET, kEncodingIntSet, is);
+  cobj_.SetMemberTime(42);  // no-op
+  EXPECT_EQ(cobj_.MemberTime(), 0u);
+  EXPECT_FALSE(cobj_.HasMemberExpiration());
+}
+
 TEST_F(CompactObjectTest, StrEncodingAndMaterialize) {
   for (bool ascii : {true, false}) {
     for (size_t len : {64, 128, 256, 512, 1024}) {

--- a/src/server/container_utils.cc
+++ b/src/server/container_utils.cc
@@ -305,10 +305,8 @@ bool IterateMap(const PrimeValue& pv, const IterateKVFunc& func) {
 
 StringMap* GetStringMap(const PrimeValue& pv, const DbContext& db_context) {
   DCHECK_EQ(pv.Encoding(), kEncodingStrMap2);
-  StringMap* res = static_cast<StringMap*>(pv.RObjPtr());
-  uint32_t map_time = MemberTimeSeconds(db_context.time_now_ms);
-  res->set_time(map_time);
-  return res;
+  pv.SetMemberTime(MemberTimeSeconds(db_context.time_now_ms));
+  return static_cast<StringMap*>(pv.RObjPtr());
 }
 
 OpResult<string> RunCbOnFirstNonEmptyBlocking(Transaction* trans, int req_obj_type,

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1667,10 +1667,7 @@ OpResult<pair<vector<string>, CompactObjType>> OpFetchContainerElements(const Op
   // Enable lazy per-member expiry before iterating dense sets.  Without this,
   // IterateSet would skip expiry entirely and empty-set cleanup below would
   // depend on a prior command having set time_now_.
-  if (obj_type == OBJ_SET && it->second.Encoding() == kEncodingStrMap2) {
-    static_cast<StringSet*>(it->second.RObjPtr())
-        ->set_time(MemberTimeSeconds(op_args.db_cntx.time_now_ms));
-  }
+  it->second.SetMemberTime(MemberTimeSeconds(op_args.db_cntx.time_now_ms));
 
   Iterate(it->second, [&elements](const ContainerEntry& entry) {
     elements.emplace_back(entry.ToString());

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -1329,8 +1329,8 @@ int32_t HSetFamily::FieldExpireTime(const DbContext& db_context, const PrimeValu
     detail::ListpackWrap lw{static_cast<uint8_t*>(pv.RObjPtr())};
     return lw.Find(field) == lw.end() ? -3 : -1;
   } else {
+    pv.SetMemberTime(MemberTimeSeconds(db_context.time_now_ms));
     StringMap* string_map = (StringMap*)pv.RObjPtr();
-    string_map->set_time(MemberTimeSeconds(db_context.time_now_ms));
     auto it = string_map->Find(field);
     if (it == string_map->end())
       return -3;

--- a/src/server/journal/cmd_serializer.cc
+++ b/src/server/journal/cmd_serializer.cc
@@ -162,13 +162,8 @@ void CmdSerializer::SerializeExpireIfNeeded(string_view key, uint64_t expire_ms)
 size_t CmdSerializer::SerializeSet(string_view key, const PrimeValue& pv) {
   // Disable lazy expiry during serialization (same as rdb_save.cc).
   // We are called under bucket lock so DeleteIfEmpty is not possible.
-  StringSet* ss = nullptr;
-  uint32_t prev_time = 0;
-  if (pv.Encoding() == kEncodingStrMap2) {
-    ss = static_cast<StringSet*>(pv.RObjPtr());
-    prev_time = ss->time_now();
-    ss->set_time(0);
-  }
+  const uint32_t prev_time = pv.MemberTime();
+  pv.SetMemberTime(0);
 
   CommandAggregator aggregator(
       key, [&](absl::Span<const string_view> args) { SerializeCommand("SADD", args); },
@@ -181,8 +176,7 @@ size_t CmdSerializer::SerializeSet(string_view key, const PrimeValue& pv) {
   });
 
   // Restore previous time so subsequent operations can trigger lazy expiry.
-  if (ss)
-    ss->set_time(prev_time);
+  pv.SetMemberTime(prev_time);
 
   return commands;
 }
@@ -206,13 +200,8 @@ size_t CmdSerializer::SerializeZSet(string_view key, const PrimeValue& pv) {
 
 size_t CmdSerializer::SerializeHash(string_view key, const PrimeValue& pv) {
   // Disable lazy expiry during serialization (same as rdb_save.cc).
-  StringMap* sm = nullptr;
-  uint32_t prev_time = 0;
-  if (pv.Encoding() == kEncodingStrMap2) {
-    sm = static_cast<StringMap*>(pv.RObjPtr());
-    prev_time = sm->time_now();
-    sm->set_time(0);
-  }
+  const uint32_t prev_time = pv.MemberTime();
+  pv.SetMemberTime(0);
 
   CommandAggregator aggregator(
       key, [&](absl::Span<const string_view> args) { SerializeCommand("HSET", args); },
@@ -227,8 +216,7 @@ size_t CmdSerializer::SerializeHash(string_view key, const PrimeValue& pv) {
       });
 
   // Restore previous time so subsequent operations can trigger lazy expiry.
-  if (sm)
-    sm->set_time(prev_time);
+  pv.SetMemberTime(prev_time);
 
   return commands;
 }

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -177,7 +177,7 @@ uint8_t RdbObjectType(const CompactObj& pv) {
       if (compact_enc == kEncodingIntSet)
         return RDB_TYPE_SET_INTSET;
       else if (compact_enc == kEncodingStrMap2) {
-        if (((StringSet*)pv.RObjPtr())->ExpirationUsed())
+        if (pv.HasMemberExpiration())
           return RDB_TYPE_SET_WITH_EXPIRY;
         else
           return RDB_TYPE_SET;
@@ -193,7 +193,7 @@ uint8_t RdbObjectType(const CompactObj& pv) {
       if (compact_enc == kEncodingListPack)
         return RDB_TYPE_HASH_LISTPACK;
       else if (compact_enc == kEncodingStrMap2) {
-        if (((StringMap*)pv.RObjPtr())->ExpirationUsed())
+        if (pv.HasMemberExpiration())
           return RDB_TYPE_HASH_WITH_EXPIRY;  // Incompatible with Redis
         else
           return RDB_TYPE_HASH;
@@ -437,16 +437,17 @@ error_code RdbSerializer::SaveListObject(const PrimeValue& pv) {
 
 error_code RdbSerializer::SaveSetObject(const PrimeValue& obj) {
   if (obj.Encoding() == kEncodingStrMap2) {
-    StringSet* set = (StringSet*)obj.RObjPtr();
-
     // We don't expire any data during serialization
-    set->set_time(0);
+    obj.SetMemberTime(0);
+
+    StringSet* set = (StringSet*)obj.RObjPtr();
+    const bool has_expiry = obj.HasMemberExpiration();
 
     // due to we avoid expiring we can use UpperBoundSize() instead of SlowSize()
     RETURN_ON_ERR(SaveLen(set->UpperBoundSize()));
     for (auto it = set->begin(); it != set->end();) {
       RETURN_ON_ERR(SaveString(string_view{*it, sdslen(*it)}));
-      if (set->ExpirationUsed()) {
+      if (has_expiry) {
         int64_t expiry = -1;
         if (it.HasExpiry())
           expiry = it.ExpiryTime();
@@ -458,7 +459,7 @@ error_code RdbSerializer::SaveSetObject(const PrimeValue& obj) {
         flush_state = FlushState::kFlushEndEntry;
       PushToConsumerIfNeeded(flush_state);
     }
-    set->set_time(MemberTimeSeconds(GetCurrentTimeMs()));
+    obj.SetMemberTime(MemberTimeSeconds(GetCurrentTimeMs()));
   } else {
     CHECK_EQ(obj.Encoding(), kEncodingIntSet);
     intset* is = (intset*)obj.RObjPtr();
@@ -474,10 +475,11 @@ error_code RdbSerializer::SaveHSetObject(const PrimeValue& pv) {
   DCHECK_EQ(OBJ_HASH, pv.ObjType());
 
   if (pv.Encoding() == kEncodingStrMap2) {
-    StringMap* string_map = (StringMap*)pv.RObjPtr();
-
     // We don't expire any data during serialization
-    string_map->set_time(0);
+    pv.SetMemberTime(0);
+
+    StringMap* string_map = (StringMap*)pv.RObjPtr();
+    const bool has_expiry = pv.HasMemberExpiration();
 
     // due to we avoid expiring we can use UpperBoundSize() instead of SlowSize()
     RETURN_ON_ERR(SaveLen(string_map->UpperBoundSize()));
@@ -486,7 +488,7 @@ error_code RdbSerializer::SaveHSetObject(const PrimeValue& pv) {
       const auto& [k, v] = *it;
       RETURN_ON_ERR(SaveString(string_view{k, sdslen(k)}));
       RETURN_ON_ERR(SaveString(string_view{v, sdslen(v)}));
-      if (string_map->ExpirationUsed()) {
+      if (has_expiry) {
         int64_t expiry = -1;
         if (it.HasExpiry())
           expiry = it.ExpiryTime();
@@ -499,7 +501,7 @@ error_code RdbSerializer::SaveHSetObject(const PrimeValue& pv) {
       PushToConsumerIfNeeded(flush_state);
     }
 
-    string_map->set_time(MemberTimeSeconds(GetCurrentTimeMs()));
+    pv.SetMemberTime(MemberTimeSeconds(GetCurrentTimeMs()));
   } else {
     CHECK_EQ(kEncodingListPack, pv.Encoding());
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2838,8 +2838,8 @@ void ServerFamily::Shrink(CmdArgList args, CommandContext* cmd_cntx) {
         return OpStatus::WRONG_TYPE;
       }
 
+      pv.SetMemberTime(MemberTimeSeconds(t->GetDbContext().time_now_ms));
       DenseSet* ds = static_cast<DenseSet*>(pv.RObjPtr());
-      ds->set_time(MemberTimeSeconds(t->GetDbContext().time_now_ms));
       size_t current_size = ds->UpperBoundSize();
       size_t bucket_count = ds->BucketCount();
 
@@ -2862,8 +2862,8 @@ void ServerFamily::Shrink(CmdArgList args, CommandContext* cmd_cntx) {
     }
 
     PrimeValue& pv = it_res.it->second;
+    pv.SetMemberTime(MemberTimeSeconds(t->GetDbContext().time_now_ms));
     DenseSet* ds = static_cast<DenseSet*>(pv.RObjPtr());
-    ds->set_time(MemberTimeSeconds(t->GetDbContext().time_now_ms));
 
     size_t bucket_bytes_before = ds->BucketCount() * sizeof(void*);
     size_t optimal_size = std::max(size_t(8), absl::bit_ceil(ds->UpperBoundSize()));

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -736,10 +736,7 @@ OpResult<StringVec> OpUnion(const OpArgs& op_args, ShardArgs::Iterator start,
     auto find_res = db_slice.FindReadOnly(op_args.db_cntx, *start, OBJ_SET);
     if (find_res) {
       const PrimeValue& pv = find_res.value()->second;
-      if (IsDenseEncoding(pv)) {
-        StringSet* ss = (StringSet*)pv.RObjPtr();
-        ss->set_time(MemberTimeSeconds(op_args.db_cntx.time_now_ms));
-      }
+      pv.SetMemberTime(MemberTimeSeconds(op_args.db_cntx.time_now_ms));
       container_utils::IterateSet(pv, [&uniques](container_utils::ContainerEntry ce) {
         uniques.emplace(ce.ToString());
         return true;
@@ -770,10 +767,7 @@ OpResult<StringVec> OpDiff(const OpArgs& op_args, ShardArgs::Iterator start,
 
   absl::flat_hash_set<string> uniques;
   const PrimeValue& pv = find_res.value()->second;
-  if (IsDenseEncoding(pv)) {
-    StringSet* ss = (StringSet*)pv.RObjPtr();
-    ss->set_time(MemberTimeSeconds(op_args.db_cntx.time_now_ms));
-  }
+  pv.SetMemberTime(MemberTimeSeconds(op_args.db_cntx.time_now_ms));
 
   container_utils::IterateSet(pv, [&uniques](container_utils::ContainerEntry ce) {
     uniques.emplace(ce.ToString());
@@ -833,10 +827,7 @@ OpResult<StringVec> OpInter(const Transaction* t, EngineShard* es, bool remove_f
       return find_res.status();
 
     const PrimeValue& pv = find_res.value()->second;
-    if (IsDenseEncoding(pv)) {
-      StringSet* ss = (StringSet*)pv.RObjPtr();
-      ss->set_time(MemberTimeSeconds(t->GetDbContext().time_now_ms));
-    }
+    pv.SetMemberTime(MemberTimeSeconds(t->GetDbContext().time_now_ms));
 
     result.reserve(pv.Size());
     container_utils::IterateSet(find_res.value()->second,
@@ -961,10 +952,7 @@ OpResult<StringVec> OpPop(const OpArgs& op_args, string_view key, unsigned count
    * The number of requested elements is greater than or equal to
    * the number of elements inside the set: simply return the whole set. */
   if (count >= size) {
-    if (IsDenseEncoding(co)) {
-      StringSet* ss = (StringSet*)co.RObjPtr();
-      ss->set_time(MemberTimeSeconds(op_args.db_cntx.time_now_ms));
-    }
+    co.SetMemberTime(MemberTimeSeconds(op_args.db_cntx.time_now_ms));
 
     StringVec result;
     result.reserve(picks_count);
@@ -1742,9 +1730,8 @@ vector<long> SetFamily::SetFieldsExpireTime(const OpArgs& op_args, uint32_t ttl_
     pv->InitRobj(OBJ_SET, kEncodingStrMap2, ss);
   }
 
-  auto ss = static_cast<StringSet*>(pv->RObjPtr());
-  ss->set_time(MemberTimeSeconds(op_args.db_cntx.time_now_ms));
-  return ExpireElements(ss, values, ttl_sec);
+  pv->SetMemberTime(MemberTimeSeconds(op_args.db_cntx.time_now_ms));
+  return ExpireElements(static_cast<StringSet*>(pv->RObjPtr()), values, ttl_sec);
 }
 
 }  // namespace dfly

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -740,9 +740,7 @@ ScoredMap FromObject(const PrimeValue& co, double weight) {
 ScoredMap ScoreMapFromSet(const PrimeValue& pv, double weight, const DbContext& db_cntx) {
   // Enable lazy member expiry before iterating dense sets so expired members
   // do not pollute the result (and so the caller can detect an emptied set).
-  if (pv.Encoding() == kEncodingStrMap2) {
-    static_cast<StringSet*>(pv.RObjPtr())->set_time(MemberTimeSeconds(db_cntx.time_now_ms));
-  }
+  pv.SetMemberTime(MemberTimeSeconds(db_cntx.time_now_ms));
 
   ScoredMap result;
   container_utils::IterateSet(pv, [&result, weight](container_utils::ContainerEntry ce) {


### PR DESCRIPTION
Summary: Refactors per-member lazy expiry time handling for DenseSet-backed containers by adding dedicated helpers on CompactObj.

Changes:

- Added CompactObj::SetMemberTime(), MemberTime(), and HasMemberExpiration() with an internal DenseSet accessor.
- Updated server call sites (set/hash iteration, shrink, expiry queries) to use the new methods instead of casting to StringSet/StringMap.
- Simplified journal command serialization by saving/restoring member-time through MemberTime()/SetMemberTime().
- Adjusted RDB save logic to use HasMemberExpiration() and to disable lazy expiry via SetMemberTime(0) during serialization.
- Added unit tests covering set/map member-time behavior and ensuring calls are safe on non-kEncodingStrMap2 objects.

Technical Notes: The new APIs are safe to call unconditionally (no-op unless encoding is kEncodingStrMap2), which reduces repetition and centralizes the DenseSet/time semantics.