### PR TITLE
fix: prevent PII leaks in FailedCommandToString error logs

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -629,16 +629,51 @@ string ConnectionLogContext(const facade::Connection* conn) {
 
 string FailedCommandToString(std::string_view command, facade::CmdArgList args,
                              std::string_view reason) {
+  constexpr size_t kMaxArgCount = 31;
+  constexpr size_t kMaxArgLength = 128;
+  constexpr size_t kMaxReasonLength = 256;
+
   string result;
   absl::StrAppend(&result, " ", command);
 
-  if (command != "AUTH" && command != "ACL SETUSER") {
-    for (auto arg : args) {
+  auto AppendArg = [&](string_view arg) {
+    if (arg.size() > kMaxArgLength) {
+      absl::StrAppend(&result, " ", absl::CHexEscape(arg.substr(0, kMaxArgLength)), "... (",
+                      arg.size() - kMaxArgLength, " more bytes)");
+    } else {
       absl::StrAppend(&result, " ", absl::CHexEscape(arg));
+    }
+  };
+
+  const bool is_eval =
+      command == "EVAL" || command == "EVALSHA" || command == "EVAL_RO" || command == "EVALSHA_RO";
+
+  if (command == "AUTH" || command == "ACL SETUSER") {
+    // skip all args to protect passwords
+  } else if (is_eval) {
+    // log only script/SHA and numkeys, skip KEYS and ARGV to avoid PII leaks
+    for (size_t i = 0; i < std::min(args.size(), size_t{2}); ++i) {
+      AppendArg(facade::ArgS(args, i));
+    }
+  } else {
+    size_t num_args = std::min(args.size(), kMaxArgCount);
+    for (size_t i = 0; i < num_args; ++i) {
+      AppendArg(facade::ArgS(args, i));
+    }
+    if (args.size() > kMaxArgCount) {
+      absl::StrAppend(&result, " ... (", args.size() - kMaxArgCount, " more arguments)");
     }
   }
 
-  absl::StrAppend(&result, " failed with reason: ", reason);
+  // Lua error messages for EVAL can contain user-supplied data (PII).
+  // "Error running script (call to <sha>): <lua_error>" — strip everything after "): ".
+  string_view safe_reason = reason.substr(0, kMaxReasonLength);
+  if (is_eval && absl::StartsWith(reason, "Error running script (call to ")) {
+    auto sep = reason.find("): ");
+    if (sep != string_view::npos)
+      safe_reason = reason.substr(0, sep + 1);
+  }
+  absl::StrAppend(&result, " failed with reason: ", safe_reason);
 
   return result;
 }

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -645,10 +645,9 @@ string FailedCommandToString(std::string_view command, facade::CmdArgList args,
     }
   };
 
-  const bool is_eval =
-      command == "EVAL" || command == "EVALSHA" || command == "EVAL_RO" || command == "EVALSHA_RO";
+  const bool is_eval = absl::StartsWith(command, "EVAL");
 
-  if (command == "AUTH" || command == "ACL SETUSER") {
+  if (command == "AUTH" || absl::StartsWith(command, "ACL")) {
     // skip all args to protect passwords
   } else if (is_eval) {
     // log only script/SHA and numkeys, skip KEYS and ARGV to avoid PII leaks


### PR DESCRIPTION
When a command fails (e.g. due to OOM), `FailedCommandToString` logged all arguments and the full error reason without any size limits. This caused sensitive customer data to be written to plain-text logs, as confirmed in before where EVAL scripts with large BullMQ payloads dumped PII (IP addresses, user data) into Loki on OOM events.

Changes:
- Truncate arguments to 31 max and 128 bytes each for all commands (mirrors slowlog behavior)
- For EVAL/EVALSHA/EVAL_RO/EVALSHA_RO: log only script/SHA and numkeys, drop KEYS and ARGV entirely to prevent user payload exposure
- For EVAL error reasons: strip the Lua error part from "Error running script (call to <sha>): <lua_error>", keeping only the structured prefix; fall back to 256-byte truncation for non-standard formats
- AUTH and ACL SETUSER retain existing behavior (no args logged)