### PR TITLE
server: Handle errors in memory cmd parse

### DIFF
--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -282,6 +282,8 @@ void MemoryCmd::Run(CmdArgList args) {
     static const float default_threshold =
         absl::GetFlag(FLAGS_mem_defrag_page_utilization_threshold);
     const float threshold = parser.NextOrDefault(default_threshold);
+    if (const auto err = parser.TakeError(); err)
+      return cmd_cntx_->SendError(err.MakeReply());
 
     std::vector<CollectedPageStats> results(shard_set->size());
     shard_set->pool()->AwaitFiberOnAll([threshold, &results](util::ProactorBase*) {
@@ -299,7 +301,7 @@ void MemoryCmd::Run(CmdArgList args) {
     return rb->SendVerbatimString(merged.ToString());
   }
 
-  string err = UnknownSubCmd(parser.Next(), "MEMORY");
+  const string err = UnknownSubCmd(parser.Next(), "MEMORY");
   return cmd_cntx_->SendError(err, kSyntaxErrType);
 }
 

--- a/src/server/server_family_test.cc
+++ b/src/server/server_family_test.cc
@@ -743,4 +743,8 @@ TEST_F(ServerFamilyTest, MemoryArenaSummary) {
   EXPECT_THAT(resp.GetString(), HasSubstr("Count"));
 }
 
+TEST_F(ServerFamilyTest, MemoryParserErrorHandling) {
+  EXPECT_THAT(Run({"MEMORY", "DEFRAGMENT", "not-a-float"}), ErrArg("not a valid float"));
+}
+
 }  // namespace dfly


### PR DESCRIPTION
FIXES https://github.com/dragonflydb/dragonfly/issues/7267

handles errors in memory cmd parsing, no change in behavior

* handle error when parsing threshold (float) for defragment)
* test