### PR TITLE
feat: info replication is lock free

### DIFF
--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -70,6 +70,9 @@ const char kIdNotFound[] = "syncid not found";
 const char kInvalidSyncId[] = "bad sync id";
 const char kInvalidState[] = "invalid state";
 
+// Per-proactor view of replica_infos_. Published by UpdateReplicaInfoState.
+thread_local std::shared_ptr<const DflyCmd::ReplicaInfoMap> tl_replica_infos;
+
 bool ToSyncId(string_view str, uint32_t* num) {
   if (!absl::StartsWith(str, "SYNC"))
     return false;
@@ -117,14 +120,14 @@ bool WaitReplicaFlowToCatchup(absl::Time end_time, const DflyCmd::ReplicaInfo* r
 
 void DflyCmd::ReplicaInfo::Cancel() {
   util::fb2::LockGuard lk{shared_mu_};
-  if (replica_state_ == SyncState::CANCELLED) {
+  if (replica_state_.load(std::memory_order_relaxed) == SyncState::CANCELLED) {
     return;
   }
 
   LOG(INFO) << "Disconnecting from replica " << address_ << ":" << listening_port_;
 
   // Update state and cancel context.
-  replica_state_ = SyncState::CANCELLED;
+  replica_state_.store(SyncState::CANCELLED, std::memory_order_relaxed);
   exec_st_.ReportCancelError();
   // Wait for tasks to finish.
   shard_set->RunBlockingInParallel([this](EngineShard* shard) {
@@ -782,6 +785,7 @@ auto DflyCmd::CreateSyncSession(ConnectionState* state) -> std::pair<uint32_t, u
   auto [it, inserted] = replica_infos_.emplace(sync_id, std::move(replica_ptr));
   CHECK(inserted);
 
+  UpdateReplicaInfoState();
   return {it->first, flow_count};
 }
 
@@ -814,6 +818,7 @@ void DflyCmd::StopReplication(uint32_t sync_id) {
 
   util::fb2::LockGuard lk(mu_);
   replica_infos_.erase(sync_id);
+  UpdateReplicaInfoState();
 }
 
 // Because we need to annotate unique_lock
@@ -852,6 +857,9 @@ void DflyCmd::BreakStalledFlowsInShard() {
 
   for (auto sync_id : deleted)
     replica_infos_.erase(sync_id);
+
+  if (!deleted.empty())
+    UpdateReplicaInfoState();
 }
 
 shared_ptr<DflyCmd::ReplicaInfo> DflyCmd::GetReplicaInfo(uint32_t sync_id) {
@@ -865,27 +873,17 @@ shared_ptr<DflyCmd::ReplicaInfo> DflyCmd::GetReplicaInfo(uint32_t sync_id) {
 
 std::vector<ReplicaRoleInfo> DflyCmd::GetReplicasRoleInfo() const {
   std::vector<ReplicaRoleInfo> vec;
-  util::fb2::LockGuard lk(mu_);
+  auto replica_infos = tl_replica_infos;
+  if (!replica_infos)
+    return vec;
 
-  vec.reserve(replica_infos_.size());
-  map replication_lags = ReplicationLagsLocked();
+  vec.reserve(replica_infos->size());
+  std::map<uint32_t, LSN> replication_lags = ReplicationLags(*replica_infos);
 
-  for (const auto& [id, info] : replica_infos_) {
-    LSN lag = replication_lags[id];
-    SyncState state = SyncState::PREPARATION;
-
-    // If the replica state being updated, its lag is undefined,
-    // the same applies of course if its state is not STABLE_SYNC.
-    shared_lock lk(info->GetMutex(), try_to_lock);
-    if (lk.owns_lock()) {
-      state = info->GetReplicaState();
-      // If the replica is not in stable sync, its lag is undefined, so we set it to 0.
-      if (state != SyncState::STABLE_SYNC) {
-        lag = 0;
-      }
-    } else {
-      lag = 0;
-    }
+  for (const auto& [id, info] : *replica_infos) {
+    SyncState state = info->GetReplicaState();
+    // Lag is undefined unless the replica is in stable sync.
+    LSN lag = (state == SyncState::STABLE_SYNC) ? replication_lags[id] : 0;
     vec.push_back(ReplicaRoleInfo{std::string{info->GetId()}, info->GetAddress(),
                                   info->GetListeningPort(), SyncStateName(state), lag});
   }
@@ -894,27 +892,32 @@ std::vector<ReplicaRoleInfo> DflyCmd::GetReplicasRoleInfo() const {
 
 void DflyCmd::GetReplicationMemoryStats(ReplicationMemoryStats* stats) const {
   atomic<size_t> streamer_bytes{0}, full_sync_bytes{0};
+  auto replica_infos = tl_replica_infos;
+  if (!replica_infos)
+    return;
 
-  {
-    util::fb2::LockGuard lk{mu_};  // prevent state changes
-    auto cb = [&](EngineShard* shard) ABSL_NO_THREAD_SAFETY_ANALYSIS {
-      for (const auto& [_, info] : replica_infos_) {
-        dfly::SharedLock repl_lk{info->GetMutex()};
+  // Lock-free read: tl_replica_infos keeps each ReplicaInfo alive, and the cb
+  // runs on each flow's owner shard — the only thread that ever sets or resets
+  // these unique_ptrs. RunBriefInParallel enforces the non-yielding contract.
+  shard_set->RunBriefInParallel([&](EngineShard* shard) {
+    for (const auto& [_, info] : *replica_infos) {
+      DCHECK_GT(info->GetFlowCount(), 0u);
+      if (info->GetFlowCount() == 0)
+        continue;
 
-        // flows should not be empty.
-        DCHECK_GT(info->GetFlowCount(), 0u);
-        if (info->GetFlowCount() == 0)
-          continue;
-
-        const auto& flow = info->GetFlow(shard->shard_id());
-        if (flow.streamer)
-          streamer_bytes.fetch_add(flow.streamer->UsedBytes(), memory_order_relaxed);
-        if (flow.saver)
-          full_sync_bytes.fetch_add(flow.saver->GetTotalBuffersSize(), memory_order_relaxed);
+      const auto& flow = info->GetFlow(shard->shard_id());
+      if (flow.streamer)
+        streamer_bytes.fetch_add(flow.streamer->UsedBytes(), memory_order_relaxed);
+      if (flow.saver) {
+        // Replication-flow savers must be single-shard, otherwise the saver's
+        // GetTotalBuffersSize would internally call RunBriefInParallel and nest.
+        DCHECK(flow.saver->Mode() == SaveMode::SINGLE_SHARD ||
+               flow.saver->Mode() == SaveMode::SINGLE_SHARD_WITH_SUMMARY);
+        full_sync_bytes.fetch_add(flow.saver->GetTotalBuffersSize(), memory_order_relaxed);
       }
-    };
-    shard_set->RunBlockingInParallel(cb);
-  }
+    }
+  });
+
   stats->streamer_buf_capacity_bytes += streamer_bytes.load(memory_order_relaxed);
   stats->full_sync_buf_bytes += full_sync_bytes.load(memory_order_relaxed);
 }
@@ -937,21 +940,27 @@ pair<uint32_t, shared_ptr<DflyCmd::ReplicaInfo>> DflyCmd::GetReplicaInfoOrReply(
   return {sync_id, sync_it->second};
 }
 
-std::map<uint32_t, LSN> DflyCmd::ReplicationLagsLocked() const {
-  DCHECK(!mu_.try_lock());  // expects to be under global lock
-  if (replica_infos_.empty())
+std::map<uint32_t, LSN> DflyCmd::ReplicationLags(const ReplicaInfoMap& replicas) const {
+  if (replicas.empty())
     return {};
 
   // In each shard we calculate a map of replica id to replication lag in the shard.
+  // Only compute lag for replicas currently in STABLE_SYNC — for any other state the
+  // lag is undefined (e.g. last_acked_lsn is still 0 mid-full-sync). Replicas that
+  // transition out of (or into) STABLE_SYNC between this scan and the outer reader
+  // are naturally handled: missing entries default to lag=0, and the outer reader
+  // re-checks state before emitting the lag.
   std::vector<std::map<uint32_t, LSN>> shard_lags(shard_set->size());
-  shard_set->RunBriefInParallel([&shard_lags, this](EngineShard* shard) {
+  shard_set->RunBriefInParallel([&shard_lags, &replicas](EngineShard* shard) {
+    if (!shard->journal())
+      return;
     auto& lags = shard_lags[shard->shard_id()];
-    for (const auto& info : ABSL_TS_UNCHECKED_READ(replica_infos_)) {
+    const LSN cur_lsn = journal::GetLsn();
+    for (const auto& info : replicas) {
       const ReplicaInfo* replica = info.second.get();
-      if (shard->journal()) {
-        int64_t lag = journal::GetLsn() - replica->GetFlow(shard->shard_id()).last_acked_lsn;
-        lags[info.first] = lag;
-      }
+      if (replica->GetReplicaState() != SyncState::STABLE_SYNC)
+        continue;
+      lags[info.first] = cur_lsn - replica->GetFlow(shard->shard_id()).last_acked_lsn;
     }
   });
 
@@ -963,6 +972,12 @@ std::map<uint32_t, LSN> DflyCmd::ReplicationLagsLocked() const {
     }
   }
   return rv;
+}
+
+void DflyCmd::UpdateReplicaInfoState() {
+  auto replica_infos = std::make_shared<const ReplicaInfoMap>(replica_infos_);
+  shard_set->pool()->AwaitFiberOnAll(
+      [&replica_infos](unsigned, ProactorBase*) { tl_replica_infos = replica_infos; });
 }
 
 void DflyCmd::SetDflyClientVersion(ConnectionState* state, DflyVersion version) {
@@ -997,6 +1012,7 @@ void DflyCmd::CancelReplicas() {
   {
     util::fb2::LockGuard lk(mu_);
     pending = std::move(replica_infos_);
+    UpdateReplicaInfoState();
   }
 
   for (auto& [_, replica_ptr] : pending) {

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -70,7 +70,9 @@ const char kIdNotFound[] = "syncid not found";
 const char kInvalidSyncId[] = "bad sync id";
 const char kInvalidState[] = "invalid state";
 
-// Per-proactor view of replica_infos_. Published by UpdateReplicaInfoState.
+// Per-proactor cached view of replica_infos_.
+// Every mutation of centralized `replica_infos_` warrants subsequent call to
+// UpdateReplicaInfoCacheLocked.
 thread_local std::shared_ptr<const DflyCmd::ReplicaInfoMap> tl_replica_infos;
 
 bool ToSyncId(string_view str, uint32_t* num) {
@@ -785,7 +787,7 @@ auto DflyCmd::CreateSyncSession(ConnectionState* state) -> std::pair<uint32_t, u
   auto [it, inserted] = replica_infos_.emplace(sync_id, std::move(replica_ptr));
   CHECK(inserted);
 
-  UpdateReplicaInfoState();
+  UpdateReplicaInfoCacheLocked();
   return {it->first, flow_count};
 }
 
@@ -818,7 +820,7 @@ void DflyCmd::StopReplication(uint32_t sync_id) {
 
   util::fb2::LockGuard lk(mu_);
   replica_infos_.erase(sync_id);
-  UpdateReplicaInfoState();
+  UpdateReplicaInfoCacheLocked();
 }
 
 // Because we need to annotate unique_lock
@@ -859,7 +861,7 @@ void DflyCmd::BreakStalledFlowsInShard() {
     replica_infos_.erase(sync_id);
 
   if (!deleted.empty())
-    UpdateReplicaInfoState();
+    UpdateReplicaInfoCacheLocked();
 }
 
 shared_ptr<DflyCmd::ReplicaInfo> DflyCmd::GetReplicaInfo(uint32_t sync_id) {
@@ -882,8 +884,9 @@ std::vector<ReplicaRoleInfo> DflyCmd::GetReplicasRoleInfo() const {
 
   for (const auto& [id, info] : *replica_infos) {
     SyncState state = info->GetReplicaState();
-    // Lag is undefined unless the replica is in stable sync.
-    LSN lag = (state == SyncState::STABLE_SYNC) ? replication_lags[id] : 0;
+    // ReplicationLags only populates entries for STABLE_SYNC replicas, so a missing
+    // entry defaults to lag=0 — exactly what we want for any other state.
+    LSN lag = replication_lags[id];
     vec.push_back(ReplicaRoleInfo{std::string{info->GetId()}, info->GetAddress(),
                                   info->GetListeningPort(), SyncStateName(state), lag});
   }
@@ -940,8 +943,8 @@ pair<uint32_t, shared_ptr<DflyCmd::ReplicaInfo>> DflyCmd::GetReplicaInfoOrReply(
   return {sync_id, sync_it->second};
 }
 
-std::map<uint32_t, LSN> DflyCmd::ReplicationLags(const ReplicaInfoMap& replicas) const {
-  if (replicas.empty())
+std::map<uint32_t, LSN> DflyCmd::ReplicationLags(const ReplicaInfoMap& replicas_local_cache) const {
+  if (replicas_local_cache.empty())
     return {};
 
   // In each shard we calculate a map of replica id to replication lag in the shard.
@@ -950,13 +953,15 @@ std::map<uint32_t, LSN> DflyCmd::ReplicationLags(const ReplicaInfoMap& replicas)
   // transition out of (or into) STABLE_SYNC between this scan and the outer reader
   // are naturally handled: missing entries default to lag=0, and the outer reader
   // re-checks state before emitting the lag.
+  // We fan out via RunBriefInParallel only because journal::GetLsn() is per-shard
+  // thread-local state that must be read on each shard's own proactor.
   std::vector<std::map<uint32_t, LSN>> shard_lags(shard_set->size());
-  shard_set->RunBriefInParallel([&shard_lags, &replicas](EngineShard* shard) {
+  shard_set->RunBriefInParallel([&shard_lags, &replicas_local_cache](EngineShard* shard) {
     if (!shard->journal())
       return;
     auto& lags = shard_lags[shard->shard_id()];
     const LSN cur_lsn = journal::GetLsn();
-    for (const auto& info : replicas) {
+    for (const auto& info : replicas_local_cache) {
       const ReplicaInfo* replica = info.second.get();
       if (replica->GetReplicaState() != SyncState::STABLE_SYNC)
         continue;
@@ -974,10 +979,14 @@ std::map<uint32_t, LSN> DflyCmd::ReplicationLags(const ReplicaInfoMap& replicas)
   return rv;
 }
 
-void DflyCmd::UpdateReplicaInfoState() {
+void DflyCmd::UpdateReplicaInfoCacheLocked() {
   auto replica_infos = std::make_shared<const ReplicaInfoMap>(replica_infos_);
-  shard_set->pool()->AwaitFiberOnAll(
-      [&replica_infos](unsigned, ProactorBase*) { tl_replica_infos = replica_infos; });
+  // Dispatching under mu_ keeps
+  // the per-proactor caches consistent — concurrent callers enqueue their updates in a
+  // serialized order, so all proactors observe the same final snapshot. The shared_ptr is
+  // captured by value because the local goes out of scope before the lambda runs.
+  shard_set->pool()->DispatchBrief(
+      [replica_infos](unsigned, ProactorBase*) { tl_replica_infos = replica_infos; });
 }
 
 void DflyCmd::SetDflyClientVersion(ConnectionState* state, DflyVersion version) {
@@ -1012,7 +1021,7 @@ void DflyCmd::CancelReplicas() {
   {
     util::fb2::LockGuard lk(mu_);
     pending = std::move(replica_infos_);
-    UpdateReplicaInfoState();
+    UpdateReplicaInfoCacheLocked();
   }
 
   for (auto& [_, replica_ptr] : pending) {

--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -76,7 +76,7 @@ struct FlowInfo {
 //    access.
 //  3. Lock-free snapshot.
 //    A copy of `replica_infos_` is published to a thread-local on every proactor via
-//    `UpdateReplicaInfoState()` (which must be called from each mutator of replica_infos_).
+//    `UpdateReplicaInfoCacheLocked()` (which must be called from each mutator of replica_infos_).
 //    Readers (INFO REPLICATION, metrics) load this snapshot and access ReplicaInfo state via
 //    its atomic getters (GetReplicaState, etc.) without taking any lock.
 //
@@ -328,11 +328,11 @@ class DflyCmd {
 
   // Return a map between replication ID to lag. lag is defined as the maximum of difference
   // between the master's LSN and the last acknowledged LSN in over all shards.
-  std::map<uint32_t, LSN> ReplicationLags(const ReplicaInfoMap& replicas) const;
+  std::map<uint32_t, LSN> ReplicationLags(const ReplicaInfoMap& replicas_local_cache) const;
 
   // Publishes a fresh copy of replica_infos_ to a thread-local on every proactor.
   // Caller must hold mu_. Readers (INFO/metrics) load this view lock-free.
-  void UpdateReplicaInfoState() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+  void UpdateReplicaInfoCacheLocked() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   ServerFamily* sf_;  // Not owned
   uint32_t next_sync_id_ = 1;

--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -42,6 +42,8 @@ struct FlowInfo {
 
   facade::Connection* conn = nullptr;
 
+  // Owned by the shard that this flow corresponds to; only that shard's proactor
+  // ever reads or writes these pointers, so no synchronization is needed.
   std::unique_ptr<RdbSaver> saver;            // Saver for full sync phase.
   std::unique_ptr<JournalStreamer> streamer;  // Streamer for stable sync phase
   std::string eof_token;
@@ -49,6 +51,7 @@ struct FlowInfo {
   DflyVersion version = DflyVersion::VER1;
 
   std::optional<LSN> start_partial_sync_at;
+  // Written by REPLCONF ACK on the owner-shard proactor; all readers also run there.
   uint64_t last_acked_lsn = 0;
 
   std::function<void()> cleanup;  // Optional cleanup for cancellation.
@@ -63,7 +66,7 @@ struct FlowInfo {
 // sync_id. Each per-thread connection is called a Flow and is represented by the FlowInfo
 // instance, accessible by its index.
 //
-// An important aspect is synchronization and efficient locking. Two levels of locking are used:
+// An important aspect is synchronization and efficient locking. Three patterns are used:
 //  1. Global locking.
 //    Member  mutex `mu_` is used for synchronizing operations connected with internal data
 //    structures.
@@ -71,6 +74,11 @@ struct FlowInfo {
 //    ReplicaInfo contains a separate mutex that is used for replica-only routines. It is held
 //    during state transitions (start full sync, start stable state sync), cancellation and member
 //    access.
+//  3. Lock-free snapshot.
+//    A copy of `replica_infos_` is published to a thread-local on every proactor via
+//    `UpdateReplicaInfoState()` (which must be called from each mutator of replica_infos_).
+//    Readers (INFO REPLICATION, metrics) load this snapshot and access ReplicaInfo state via
+//    its atomic getters (GetReplicaState, etc.) without taking any lock.
 //
 // Upon first connection from the replica, a new ReplicaInfo is created.
 // It transitions through the following phases:
@@ -151,13 +159,14 @@ class DflyCmd {
       version_.store(v, std::memory_order_relaxed);
     }
 
-    // State machine field. Caller must hold GetMutex() exclusively for the setter
-    // and at least in shared mode for the getter.
+    // State machine field. Setter must hold GetMutex() exclusively — the value is
+    // only written under the lock so transitions remain serialized. Readers do not
+    // need any lock; the atomic load lets INFO/metrics observe state lock-free.
     SyncState GetReplicaState() const {
-      return replica_state_;
+      return replica_state_.load(std::memory_order_relaxed);
     }
     void SetReplicaState(SyncState s) {
-      replica_state_ = s;
+      replica_state_.store(s, std::memory_order_relaxed);
     }
 
     // Per-shard fibers receive &GetExecState() and pass it into StartFullSyncInThread
@@ -169,8 +178,12 @@ class DflyCmd {
       return exec_st_;
     }
 
-    // Per-shard flow access; idx is the master shard index.
-    // Caller must hold GetMutex() for any read or write.
+    // Per-shard flow access; idx is the master shard index. The flows_ vector
+    // is sized once at construction so addresses are stable for the ReplicaInfo's
+    // lifetime. Default contract: caller must hold GetMutex(). Exception: the
+    // saver/streamer/last_acked_lsn fields are touched only by the owner-shard
+    // proactor (idx == that proactor's shard_id) and may be accessed lock-free
+    // from that proactor — see the FlowInfo field comments.
     FlowInfo& GetFlow(size_t idx) {
       return flows_[idx];
     }
@@ -199,7 +212,8 @@ class DflyCmd {
     void Cancel();
 
    private:
-    SyncState replica_state_;  // always guarded by shared_mu_
+    // Transitions still serialized under shared_mu_; atomic so readers can load lock-free.
+    std::atomic<SyncState> replica_state_;
     ExecutionState exec_st_;
 
     std::string id_;
@@ -241,6 +255,8 @@ class DflyCmd {
 
   // Tries to break those flows that stuck on socket write for too long time.
   void BreakStalledFlowsInShard() ABSL_NO_THREAD_SAFETY_ANALYSIS;
+
+  using ReplicaInfoMap = absl::btree_map<uint32_t, std::shared_ptr<ReplicaInfo>>;
 
  private:
   // JOURNAL [START/STOP]
@@ -312,12 +328,15 @@ class DflyCmd {
 
   // Return a map between replication ID to lag. lag is defined as the maximum of difference
   // between the master's LSN and the last acknowledged LSN in over all shards.
-  std::map<uint32_t, LSN> ReplicationLagsLocked() const ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+  std::map<uint32_t, LSN> ReplicationLags(const ReplicaInfoMap& replicas) const;
+
+  // Publishes a fresh copy of replica_infos_ to a thread-local on every proactor.
+  // Caller must hold mu_. Readers (INFO/metrics) load this view lock-free.
+  void UpdateReplicaInfoState() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   ServerFamily* sf_;  // Not owned
   uint32_t next_sync_id_ = 1;
 
-  using ReplicaInfoMap = absl::btree_map<uint32_t, std::shared_ptr<ReplicaInfo>>;
   ReplicaInfoMap replica_infos_ ABSL_GUARDED_BY(mu_);
 
   mutable util::fb2::Mutex mu_;  // Guard global operations. See header top for locking levels.


### PR DESCRIPTION
fixes: #7320

The main idea of the changes is that we read/write all the data only in the threads the data belongs to, in such a way we avoid mutex lock

### Changes
- Add a per-proactor thread-local snapshot of `replica_infos_` (`tl_replica_infos`) for lock-free reads.
- Add `UpdateReplicaInfoCacheLocked()`: copies `replica_infos_` into a fresh `shared_ptr` and publishes it to every proactor via `DispatchBrief` (caller holds  `mu_`). Called from every mutator — `CreateSyncSession`, `StopReplication`,  `BreakStalledFlowsInShard`, `CancelReplicas`.
- Make `replica_state_` a `std::atomic<SyncState>` so readers load lock-free while  writers still serialize under `shared_mu_`.
- `GetReplicasRoleInfo()` drops `mu_` and the per-replica try-lock, reading the snapshot.
- `GetReplicationMemoryStats()` switches from `RunBlockingInParallel` under `mu_` to  lock-free `RunBriefInParallel` over the snapshot.
- Rename `ReplicationLagsLocked()` → `ReplicationLags(snapshot)`;

Write paths keep their `mu_`/`shared_mu_` discipline; `last_acked_lsn`/`saver`/`streamer` stay non-atomic, safe via the same-shard owner invariant.
