### PR TITLE
facade: Downgrade bad input parse failure to warning

### DIFF
--- a/src/facade/resp_srv_parser.cc
+++ b/src/facade/resp_srv_parser.cc
@@ -205,9 +205,10 @@ auto RespSrvParser::ParseLen(Buffer str, int64_t* res) -> ResultConsumed {
     return ResultConsumed{OK, consumed};
   }
 
-  LOG(ERROR) << "Failed to parse len " << absl::CHexEscape(len_token) << " "
-             << absl::CHexEscape(string_view{reinterpret_cast<const char*>(str.data()), str.size()})
-             << " " << consumed << " " << int(s == small_buf_.data());
+  LOG_EVERY_T(WARNING, 1) << "Failed to parse len " << absl::CHexEscape(len_token) << " "
+                          << absl::CHexEscape(
+                                 string_view{reinterpret_cast<const char*>(str.data()), str.size()})
+                          << " " << consumed << " " << static_cast<int>(s == small_buf_.data());
   return ResultConsumed{BAD_ARRAYLEN, consumed};
 }
 


### PR DESCRIPTION
Sometimes bad input from client is not parsed (as expected). The log level `WARNING` seems more appropriate for something caused by the client and not representing an error in itself.

This avoids tripping any systems set up to trigger on `ERROR` messages.