### PR TITLE
core: split LargeString out of RobjWrapper

### DIFF
--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -408,9 +408,6 @@ size_t RobjWrapper::MallocUsed(bool slow) const {
     return 0;
 
   switch (type_) {
-    case OBJ_STRING:
-      CHECK_EQ(OBJ_ENCODING_RAW, encoding_);
-      return InnerObjMallocUsed();
     case OBJ_LIST:
       if (encoding_ == kEncodingListPack) {
         return zmalloc_usable_size(inner_obj_);
@@ -434,9 +431,6 @@ size_t RobjWrapper::MallocUsed(bool slow) const {
 
 size_t RobjWrapper::Size() const {
   switch (type_) {
-    case OBJ_STRING:
-      DCHECK_EQ(OBJ_ENCODING_RAW, encoding_);
-      return sz_;
     case OBJ_LIST:
       if (encoding_ == kEncodingListPack) {
         return lpLength((uint8_t*)inner_obj_);
@@ -495,11 +489,6 @@ void RobjWrapper::Free(MemoryResource* mr) {
   DVLOG(1) << "RobjWrapper::Free " << inner_obj_;
 
   switch (type_) {
-    case OBJ_STRING:
-      DVLOG(2) << "Freeing string object";
-      DCHECK_EQ(OBJ_ENCODING_RAW, encoding_);
-      mr->deallocate(inner_obj_, 0, 8);  // we do not keep the allocated size.
-      break;
     case OBJ_LIST:
       FreeList(encoding_, inner_obj_, mr);
       break;
@@ -525,69 +514,6 @@ void RobjWrapper::Free(MemoryResource* mr) {
   Set(nullptr, 0);
 }
 
-uint64_t RobjWrapper::HashCode() const {
-  switch (type_) {
-    case OBJ_STRING:
-      DCHECK_EQ(OBJ_ENCODING_RAW, encoding());
-      {
-        auto str = AsView();
-        return XXH3_64bits_withSeed(str.data(), str.size(), kHashSeed);
-      }
-      break;
-    default:
-      LOG(FATAL) << "Unsupported type for hashcode " << type_;
-  }
-  return 0;
-}
-
-bool RobjWrapper::Equal(const RobjWrapper& ow) const {
-  if (ow.type_ != type_ || ow.encoding_ != encoding_)
-    return false;
-
-  if (type_ == OBJ_STRING) {
-    DCHECK_EQ(OBJ_ENCODING_RAW, encoding());
-    return AsView() == ow.AsView();
-  }
-  LOG(FATAL) << "Unsupported type " << type_;
-  return false;
-}
-
-bool RobjWrapper::Equal(string_view sv) const {
-  if (type() != OBJ_STRING)
-    return false;
-
-  DCHECK_EQ(OBJ_ENCODING_RAW, encoding());
-  return AsView() == sv;
-}
-
-void RobjWrapper::SetString(string_view s, MemoryResource* mr) {
-  type_ = OBJ_STRING;
-  encoding_ = OBJ_ENCODING_RAW;
-
-  if (s.size() > sz_) {
-    size_t cur_cap = InnerObjMallocUsed();
-    if (s.size() > cur_cap) {
-      MakeInnerRoom(cur_cap, s.size(), mr);
-    }
-    memcpy(inner_obj_, s.data(), s.size());
-    sz_ = s.size();
-  }
-}
-
-void RobjWrapper::ReserveString(size_t size, MemoryResource* mr) {
-  CHECK_EQ(inner_obj_, nullptr);
-  type_ = OBJ_STRING;
-  encoding_ = OBJ_ENCODING_RAW;
-  MakeInnerRoom(0, size, mr);
-}
-
-void RobjWrapper::AppendString(string_view s, MemoryResource* mr) {
-  size_t cur_cap = InnerObjMallocUsed();
-  CHECK(cur_cap >= sz_ + s.size()) << cur_cap << " " << sz_ << " " << s.size();
-  memcpy(reinterpret_cast<uint8_t*>(inner_obj_) + sz_, s.data(), s.size());
-  sz_ += s.size();
-}
-
 void RobjWrapper::SetSize(uint64_t size) {
   sz_ = size;
 }
@@ -599,12 +525,7 @@ bool RobjWrapper::DefragIfNeeded(PageUsage* page_usage) {
     return realloced;
   };
 
-  if (type() == OBJ_STRING) {
-    if (page_usage->IsPageForObjectUnderUtilized(inner_obj())) {
-      ReallocateString(tl.local_mr);
-      return true;
-    }
-  } else if (type() == OBJ_HASH) {
+  if (type() == OBJ_HASH) {
     return do_defrag(DefragHash);
   } else if (type() == OBJ_SET) {
     return do_defrag(DefragSet);
@@ -618,41 +539,68 @@ bool RobjWrapper::DefragIfNeeded(PageUsage* page_usage) {
   return false;
 }
 
-void RobjWrapper::ReallocateString(MemoryResource* mr) {
-  DCHECK_EQ(type(), OBJ_STRING);
-  void* old_ptr = inner_obj_;
-  inner_obj_ = mr->allocate(sz_, kAlignSize);
-  memcpy(inner_obj_, old_ptr, sz_);
-  mr->deallocate(old_ptr, 0, kAlignSize);
-}
-
 void RobjWrapper::Init(unsigned type, unsigned encoding, void* inner) {
   type_ = type;
   encoding_ = encoding;
   Set(inner, 0);
 }
 
-inline size_t RobjWrapper::InnerObjMallocUsed() const {
-  return zmalloc_size(inner_obj_);
+size_t LargeString::MallocUsed() const {
+  return zmalloc_size(ptr);
 }
 
-void RobjWrapper::MakeInnerRoom(size_t current_cap, size_t desired, MemoryResource* mr) {
-  if (current_cap * 2 > desired) {
-    if (desired < SDS_MAX_PREALLOC)
-      desired *= 2;
-    else
-      desired += SDS_MAX_PREALLOC;
-  }
+uint64_t LargeString::HashCode() const {
+  auto str = AsView();
+  return XXH3_64bits_withSeed(str.data(), str.size(), kHashSeed);
+}
 
-  void* newp = mr->allocate(desired, kAlignSize);
-  if (sz_) {
-    memcpy(newp, inner_obj_, sz_);
+void LargeString::SetString(string_view s, MemoryResource* mr) {
+  if (s.size() > zmalloc_size(ptr)) {
+    if (ptr) {
+      mr->deallocate(ptr, 0, kAlignSize);
+    }
+    ptr = mr->allocate(s.size(), kAlignSize);
   }
+  if (!s.empty()) {
+    memcpy(ptr, s.data(), s.size());
+  }
+  sz = s.size();
+}
 
-  if (current_cap) {
-    mr->deallocate(inner_obj_, current_cap, kAlignSize);
+void LargeString::ReserveString(size_t size, MemoryResource* mr) {
+  CHECK_EQ(ptr, nullptr);
+  ptr = mr->allocate(size, kAlignSize);
+}
+
+void LargeString::AppendString(string_view s, MemoryResource* mr) {
+  size_t cur_cap = zmalloc_size(ptr);
+  CHECK(cur_cap >= sz + s.size()) << cur_cap << " " << sz << " " << s.size();
+  memcpy(reinterpret_cast<uint8_t*>(ptr) + sz, s.data(), s.size());
+  sz += s.size();
+}
+
+void LargeString::Free(MemoryResource* mr) {
+  if (!ptr)
+    return;
+
+  mr->deallocate(ptr, 0, 8);  // we do not keep the allocated size.
+  ptr = nullptr;
+  sz = 0;
+}
+
+bool LargeString::DefragIfNeeded(PageUsage* page_usage) {
+  if (page_usage->IsPageForObjectUnderUtilized(ptr)) {
+    ReallocateString(tl.local_mr);
+    return true;
   }
-  inner_obj_ = newp;
+  return false;
+}
+
+void LargeString::ReallocateString(MemoryResource* mr) {
+  void* old_ptr = ptr;
+  ptr = mr->allocate(sz, kAlignSize);
+  memcpy(ptr, old_ptr, sz);
+  mr->deallocate(old_ptr, 0, kAlignSize);
 }
 
 }  // namespace detail
@@ -746,10 +694,9 @@ size_t CompactObj::Size() const {
       else
         return u_.ext_ptr.serialized_size;
     case ROBJ_TAG:
-      if (size_t size = u_.r_obj.Size(); u_.r_obj.type() != OBJ_STRING)
-        return size;
-      else
-        return decoded_str_size(size, *(uint8_t*)u_.r_obj.inner_obj());
+      return u_.r_obj.Size();
+    case LARGE_STR_TAG:
+      return decoded_str_size(u_.large_str.Size(), *(uint8_t*)u_.large_str.ptr);
     case INT_TAG:
       return absl::AlphaNum(u_.ival).size();
     case SDS_TTL_TAG:
@@ -782,8 +729,8 @@ uint64_t CompactObj::HashCode() const {
     switch (taglen_) {
       case SMALL_TAG:
         return u_.small_str.HashCode();
-      case ROBJ_TAG:
-        return u_.r_obj.HashCode();
+      case LARGE_STR_TAG:
+        return u_.large_str.HashCode();
       case INT_TAG: {
         absl::AlphaNum an(u_.ival);
         return XXH3_64bits_withSeed(an.data(), an.size(), kHashSeed);
@@ -813,7 +760,8 @@ uint64_t CompactObj::HashCode(string_view str) {
 }
 
 CompactObjType CompactObj::ObjType() const {
-  if (IsInline() || taglen_ == INT_TAG || taglen_ == SMALL_TAG || taglen_ == SDS_TTL_TAG)
+  if (IsInline() || taglen_ == INT_TAG || taglen_ == SMALL_TAG || taglen_ == SDS_TTL_TAG ||
+      taglen_ == LARGE_STR_TAG)
     return OBJ_STRING;
 
   if (taglen_ == EXTERNAL_TAG) {
@@ -856,6 +804,8 @@ unsigned CompactObj::Encoding() const {
       return u_.r_obj.encoding();
     case INT_TAG:
       return OBJ_ENCODING_INT;
+    case LARGE_STR_TAG:
+      return OBJ_ENCODING_RAW;
     default:
       return OBJ_ENCODING_RAW;
   }
@@ -1048,13 +998,14 @@ void CompactObj::SetString(std::string_view str) {
 
 void CompactObj::ReserveString(size_t size) {
   encoding_ = NONE_ENC;
-  SetMeta(ROBJ_TAG, mask_);
+  SetMeta(LARGE_STR_TAG, mask_);
 
-  u_.r_obj.ReserveString(size, tl.local_mr);
+  u_.large_str.ReserveString(size, tl.local_mr);
 }
 
 void CompactObj::AppendString(std::string_view str) {
-  u_.r_obj.AppendString(str, tl.local_mr);
+  DCHECK_EQ(taglen_, LARGE_STR_TAG);
+  u_.large_str.AppendString(str, tl.local_mr);
 }
 
 string_view CompactObj::GetSlice(string* scratch) const {
@@ -1077,10 +1028,8 @@ string_view CompactObj::GetSlice(string* scratch) const {
   }
 
   // no encoding.
-  if (taglen_ == ROBJ_TAG) {
-    CHECK_EQ(OBJ_STRING, u_.r_obj.type());
-    DCHECK_EQ(OBJ_ENCODING_RAW, u_.r_obj.encoding());
-    return u_.r_obj.AsView();
+  if (taglen_ == LARGE_STR_TAG) {
+    return u_.large_str.AsView();
   }
 
   if (taglen_ == SMALL_TAG) {
@@ -1111,6 +1060,11 @@ bool CompactObj::DefragIfNeeded(PageUsage* page_usage) {
       // currently only these object types are supported for this operation
       if (u_.r_obj.inner_obj() != nullptr) {
         return u_.r_obj.DefragIfNeeded(page_usage);
+      }
+      return false;
+    case LARGE_STR_TAG:
+      if (u_.large_str.ptr != nullptr) {
+        return u_.large_str.DefragIfNeeded(page_usage);
       }
       return false;
     case SMALL_TAG:
@@ -1145,11 +1099,13 @@ bool CompactObj::DefragIfNeeded(PageUsage* page_usage) {
 
 bool CompactObj::HasAllocated() const {
   if (taglen_ == INT_TAG || IsInline() || taglen_ == EXTERNAL_TAG ||
-      (taglen_ == ROBJ_TAG && u_.r_obj.inner_obj() == nullptr))
+      (taglen_ == ROBJ_TAG && u_.r_obj.inner_obj() == nullptr) ||
+      (taglen_ == LARGE_STR_TAG && u_.large_str.ptr == nullptr))
     return false;
 
-  DCHECK(taglen_ == ROBJ_TAG || taglen_ == SMALL_TAG || taglen_ == JSON_TAG || taglen_ == SBF_TAG ||
-         taglen_ == CMS_TAG || taglen_ == SDS_TTL_TAG || taglen_ == TOPK_TAG);
+  DCHECK(taglen_ == ROBJ_TAG || taglen_ == LARGE_STR_TAG || taglen_ == SMALL_TAG ||
+         taglen_ == JSON_TAG || taglen_ == SBF_TAG || taglen_ == CMS_TAG ||
+         taglen_ == SDS_TTL_TAG || taglen_ == TOPK_TAG);
   return true;
 }
 
@@ -1187,10 +1143,8 @@ void CompactObj::GetString(char* dest) const {
   }
 
   // no encoding.
-  if (taglen_ == ROBJ_TAG) {
-    CHECK_EQ(OBJ_STRING, u_.r_obj.type());
-    DCHECK_EQ(OBJ_ENCODING_RAW, u_.r_obj.encoding());
-    memcpy(dest, u_.r_obj.inner_obj(), u_.r_obj.Size());
+  if (taglen_ == LARGE_STR_TAG) {
+    memcpy(dest, u_.large_str.ptr, u_.large_str.Size());
     return;
   }
 
@@ -1261,10 +1215,8 @@ std::pair<size_t, size_t> CompactObj::GetExternalSlice() const {
 }
 
 string_view CompactObj::GetEncodedBlob(StrEncoding str_encoding, char* opt_dest) const {
-  if (taglen_ == ROBJ_TAG) {
-    CHECK_EQ(OBJ_STRING, u_.r_obj.type());
-    DCHECK_EQ(OBJ_ENCODING_RAW, u_.r_obj.encoding());
-    return u_.r_obj.AsView();
+  if (taglen_ == LARGE_STR_TAG) {
+    return u_.large_str.AsView();
   } else if (IsInline()) {
     return {u_.inline_str, taglen_};
   } else if (taglen_ == SDS_TTL_TAG) {
@@ -1296,8 +1248,8 @@ void CompactObj::Materialize(std::string_view blob, bool is_raw) {
       SetMeta(SMALL_TAG, mask_);
       tl.small_str_bytes += u_.small_str.Assign(blob);
     } else {
-      SetMeta(ROBJ_TAG, mask_);
-      u_.r_obj.SetString(blob, tl.local_mr);
+      SetMeta(LARGE_STR_TAG, mask_);
+      u_.large_str.SetString(blob, tl.local_mr);
     }
   } else {
     encoding_ = NONE_ENC;  // reset encoding
@@ -1321,10 +1273,8 @@ uint8_t CompactObj::GetFirstByte() const {
     return u_.inline_str[0];
   }
 
-  if (taglen_ == ROBJ_TAG) {
-    CHECK_EQ(OBJ_STRING, u_.r_obj.type());
-    DCHECK_EQ(OBJ_ENCODING_RAW, u_.r_obj.encoding());
-    return *(uint8_t*)u_.r_obj.inner_obj();
+  if (taglen_ == LARGE_STR_TAG) {
+    return *(uint8_t*)u_.large_str.ptr;
   }
 
   if (taglen_ == SMALL_TAG) {
@@ -1399,24 +1349,21 @@ std::pair<bool, bool> CompactObj::SetByteAtIndex(size_t idx, uint8_t val) {
     return {true, true};
   }
 
-  // ROBJ_TAG raw string without encoding: modify the underlying buffer directly.
-  if (taglen_ == ROBJ_TAG && !encoding_) {
-    CHECK_EQ(OBJ_STRING, u_.r_obj.type());
-    DCHECK_EQ(OBJ_ENCODING_RAW, u_.r_obj.encoding());
-    if (idx >= u_.r_obj.Size()) {
-      VLOG(1) << "Offset out of bounds for raw string: " << idx << " >= " << u_.r_obj.Size();
+  // LARGE_STR_TAG raw string without encoding: modify the underlying buffer directly.
+  if (taglen_ == LARGE_STR_TAG && !encoding_) {
+    if (idx >= u_.large_str.Size()) {
+      VLOG(1) << "Offset out of bounds for raw string: " << idx << " >= " << u_.large_str.Size();
       return {false, false};
     }
-    reinterpret_cast<char*>(u_.r_obj.inner_obj())[idx] = val;
+    reinterpret_cast<char*>(u_.large_str.ptr)[idx] = val;
     return {true, true};
   }
 
-  // For ASCII encoded ROBJ strings we can modify the underlying buffer directly.
-  if (encoding_ && (encoding_ == ASCII1_ENC || encoding_ == ASCII2_ENC) && taglen_ == ROBJ_TAG &&
-      absl::ascii_isascii(val)) {
-    DCHECK_EQ(OBJ_ENCODING_RAW, u_.r_obj.encoding());
-    auto* buf = reinterpret_cast<uint8_t*>(u_.r_obj.inner_obj());
-    size_t decoded_len = GetStrEncoding().DecodedSize(u_.r_obj.Size(), buf[0]);
+  // For ASCII encoded large strings we can modify the underlying buffer directly.
+  if (encoding_ && (encoding_ == ASCII1_ENC || encoding_ == ASCII2_ENC) &&
+      taglen_ == LARGE_STR_TAG && absl::ascii_isascii(val)) {
+    auto* buf = reinterpret_cast<uint8_t*>(u_.large_str.ptr);
+    size_t decoded_len = GetStrEncoding().DecodedSize(u_.large_str.Size(), buf[0]);
     if (idx >= decoded_len) {
       VLOG(1) << "Offset out of bounds for ASCII encoded string: " << idx << " >= " << decoded_len;
       return {false, false};
@@ -1443,6 +1390,8 @@ void CompactObj::Free() {
 
   if (taglen_ == ROBJ_TAG) {
     u_.r_obj.Free(tl.local_mr);
+  } else if (taglen_ == LARGE_STR_TAG) {
+    u_.large_str.Free(tl.local_mr);
   } else if (taglen_ == SMALL_TAG) {
     tl.small_str_bytes -= u_.small_str.MallocUsed();
     u_.small_str.Free();
@@ -1474,6 +1423,10 @@ size_t CompactObj::MallocUsed(bool slow) const {
 
   if (taglen_ == ROBJ_TAG) {
     return u_.r_obj.MallocUsed(slow);
+  }
+
+  if (taglen_ == LARGE_STR_TAG) {
+    return u_.large_str.MallocUsed();
   }
 
   if (taglen_ == JSON_TAG) {
@@ -1515,8 +1468,8 @@ bool CompactObj::CmpNonInline(std::string_view sv) const {
   switch (taglen_) {
     case INT_TAG:
       return absl::AlphaNum(u_.ival).Piece() == sv;
-    case ROBJ_TAG:
-      return u_.r_obj.Equal(sv);
+    case LARGE_STR_TAG:
+      return u_.large_str.Equal(sv);
     case SMALL_TAG:
       return u_.small_str.Equal(sv);
     case SDS_TTL_TAG:
@@ -1562,17 +1515,14 @@ bool CompactObj::CmpEncoded(string_view sv) const {
     return sv == string_view(buf, sv.size());
   }
 
-  if (taglen_ == ROBJ_TAG) {
-    if (u_.r_obj.type() != OBJ_STRING)
-      return false;
-
-    if (u_.r_obj.Size() != encode_len)
+  if (taglen_ == LARGE_STR_TAG) {
+    if (u_.large_str.Size() != encode_len)
       return false;
 
     if (!detail::validate_ascii_fast(sv.data(), sv.size()))
       return false;
 
-    return detail::compare_packed(to_byte(u_.r_obj.inner_obj()), sv.data(), sv.size());
+    return detail::compare_packed(to_byte(u_.large_str.ptr), sv.data(), sv.size());
   }
 
   if (taglen_ == SDS_TTL_TAG) {
@@ -1726,17 +1676,15 @@ void CompactObj::EncodeString(string_view str) {
     return;
   }
 
-  SetMeta(ROBJ_TAG, mask_);
-  u_.r_obj.SetString(encoded, tl.local_mr);
+  SetMeta(LARGE_STR_TAG, mask_);
+  u_.large_str.SetString(encoded, tl.local_mr);
 }
 
 std::array<std::string_view, 2> CompactObj::GetRawString() const {
   DCHECK(!IsExternal());
 
-  if (taglen_ == ROBJ_TAG) {
-    CHECK_EQ(OBJ_STRING, u_.r_obj.type());
-    DCHECK_EQ(OBJ_ENCODING_RAW, u_.r_obj.encoding());
-    return {u_.r_obj.AsView(), {}};
+  if (taglen_ == LARGE_STR_TAG) {
+    return {u_.large_str.AsView(), {}};
   }
 
   if (taglen_ == SMALL_TAG) {
@@ -1848,11 +1796,10 @@ void CompactKey::SetExpireTime(uint64_t abs_ms) {
     u_.small_str.Get(new_sds);
     tl.small_str_bytes -= u_.small_str.MallocUsed();
     u_.small_str.Free();
-  } else if (taglen_ == ROBJ_TAG) {
-    CHECK_EQ(OBJ_STRING, u_.r_obj.type());
-    auto view = u_.r_obj.AsView();
+  } else if (taglen_ == LARGE_STR_TAG) {
+    auto view = u_.large_str.AsView();
     new_sds = sdsnewlen(view.data(), view.size());
-    u_.r_obj.Free(tl.local_mr);
+    u_.large_str.Free(tl.local_mr);
   } else {
     LOG(FATAL) << "Unexpected tag for SetExpireTime: " << int(taglen_);
   }

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -48,16 +48,10 @@ class RobjWrapper {
 
   size_t MallocUsed(bool slow) const;
 
-  uint64_t HashCode() const;
-  bool Equal(const RobjWrapper& ow) const;
-  bool Equal(std::string_view sv) const;
   size_t Size() const;
   void Free(MemoryResource* mr);
 
-  void SetString(std::string_view s, MemoryResource* mr);
-  void ReserveString(size_t size, MemoryResource* mr);
-  void AppendString(std::string_view s, MemoryResource* mr);
-  // Used when sz_ is used to denote memory usage
+  // Used when sz_ is used to denote memory usage (e.g. OBJ_STREAM).
   void SetSize(uint64_t size);
   void Init(unsigned type, unsigned encoding, void* inner);
 
@@ -75,20 +69,11 @@ class RobjWrapper {
     inner_obj_ = ptr;
   }
 
-  std::string_view AsView() const {
-    return std::string_view{reinterpret_cast<char*>(inner_obj_), sz_};
-  }
-
   // Try reducing memory fragmentation by re-allocating values from underutilized pages.
   // Returns true if re-allocated.
   bool DefragIfNeeded(PageUsage* page_usage);
 
  private:
-  void ReallocateString(MemoryResource* mr);
-
-  size_t InnerObjMallocUsed() const;
-  void MakeInnerRoom(size_t current_cap, size_t desired, MemoryResource* mr);
-
   void Set(void* p, size_t s) {
     inner_obj_ = p;
     sz_ = s;
@@ -96,7 +81,7 @@ class RobjWrapper {
 
   void* inner_obj_ = nullptr;
 
-  // semantics depend on the type. For OBJ_STRING it's string length.
+  // semantics depend on the type; for OBJ_STREAM it tracks bytes used.
   uint64_t sz_ : 56;
 
   uint64_t type_ : 4;
@@ -104,6 +89,52 @@ class RobjWrapper {
 } __attribute__((packed));
 
 static_assert(sizeof(RobjWrapper) == 16);
+
+// Raw, large (non-inline) string storage. Used when a string value does not
+// fit in CompactObj's inline buffer and is not better represented as INT/SMALL/EXTERNAL.
+struct LargeString {
+  using MemoryResource = PMR_NS::memory_resource;
+
+  void* ptr;
+  uint64_t sz : 56;
+  uint64_t reserved : 8;
+
+  size_t Size() const {
+    return sz;
+  }
+
+  size_t MallocUsed() const;
+
+  std::string_view AsView() const {
+    return std::string_view{reinterpret_cast<char*>(ptr), sz};
+  }
+
+  uint64_t HashCode() const;
+
+  bool Equal(std::string_view sv) const {
+    return AsView() == sv;
+  }
+
+  // Replace contents with s, growing the underlying allocation if needed.
+  void SetString(std::string_view s, MemoryResource* mr);
+
+  // Allocate room for `size` bytes; ptr must be null.
+  void ReserveString(size_t size, MemoryResource* mr);
+
+  // Append s. Precondition: existing capacity >= sz + s.size().
+  void AppendString(std::string_view s, MemoryResource* mr);
+
+  // Free underlying allocation; resets to {nullptr, 0}.
+  void Free(MemoryResource* mr);
+
+  // Re-allocate the backing buffer if its memory page is under-utilized.
+  bool DefragIfNeeded(PageUsage* page_usage);
+
+ private:
+  void ReallocateString(MemoryResource* mr);
+} __attribute__((packed));
+
+static_assert(sizeof(LargeString) == 16);
 
 }  // namespace detail
 
@@ -131,6 +162,7 @@ class CompactObj {
     CMS_TAG = 23,
     SDS_TTL_TAG = 24,
     TOPK_TAG = 25,
+    LARGE_STR_TAG = 26,  // detail::LargeString — raw, large non-inline string
   };
 
   // String encoding types.
@@ -523,6 +555,7 @@ class CompactObj {
 
     SmallString small_str;
     detail::RobjWrapper r_obj;
+    detail::LargeString large_str;
 
     // using 'packed' to reduce alignment of U to 1.
     JsonWrapper json_obj __attribute__((packed));

--- a/src/core/compact_object_test.cc
+++ b/src/core/compact_object_test.cc
@@ -876,6 +876,43 @@ TEST_F(CompactObjectTest, StrEncodingAndMaterialize) {
   }
 }
 
+TEST_F(CompactObjectTest, LargeStringSetReplacesContents) {
+  // SetString must fully replace contents, including when the new string is
+  // shorter than or equal in length to the current one. See LargeString::SetString.
+  detail::LargeString ls{};
+  auto* mr = CompactObj::memory_resource();
+
+  // 1. Initial set with a long value.
+  string long_str(128, 'a');
+  ls.SetString(long_str, mr);
+  EXPECT_EQ(ls.Size(), long_str.size());
+  EXPECT_EQ(ls.AsView(), long_str);
+
+  // 2. Replace with a shorter value of a different content.
+  string short_str(40, 'b');
+  ls.SetString(short_str, mr);
+  EXPECT_EQ(ls.Size(), short_str.size());
+  EXPECT_EQ(ls.AsView(), short_str);
+
+  // 3. Replace with an equal-length but different value.
+  string equal_len_str(40, 'c');
+  ls.SetString(equal_len_str, mr);
+  EXPECT_EQ(ls.Size(), equal_len_str.size());
+  EXPECT_EQ(ls.AsView(), equal_len_str);
+
+  // 4. Replace with a longer value (the growth path).
+  string longer_str(200, 'd');
+  ls.SetString(longer_str, mr);
+  EXPECT_EQ(ls.Size(), longer_str.size());
+  EXPECT_EQ(ls.AsView(), longer_str);
+
+  // 5. Replace with an empty string.
+  ls.SetString("", mr);
+  EXPECT_EQ(ls.Size(), 0u);
+
+  ls.Free(mr);
+}
+
 TEST_F(CompactObjectTest, ExternalRepresentation) {
   {
     CompactValue obj;


### PR DESCRIPTION
## Summary

First step of decoupling `CompactObj` from the monolithic `detail::RobjWrapper`. The raw large-string case (formerly `OBJ_STRING` stored inside `RobjWrapper`) moves into a dedicated `detail::LargeString` type with its own `LARGE_STR_TAG`.

All churn is internal to `src/core/compact_object.{h,cc}` — verified that no external caller (`src/server/*_family.cc`, `rdb_*`, `container_utils`, `src/server/tiering/*`, `src/server/search/*`) ever used `RObjPtr`/`InitRobj` for `OBJ_STRING`. The `InitRobj`/`RObjPtr`/`SetRObjPtr` external API is unchanged.

## Changes

- **New `detail::LargeString`** — `{ void* ptr; uint64_t sz:56; uint64_t reserved:8 }` (16 bytes, packed). Inline `Size`, `AsView`, and `Equal` in the header; out-of-line `MallocUsed`, `HashCode`, `SetString`, `ReserveString`, `AppendString`, `Free`, `DefragIfNeeded`; private `ReallocateString`.
- **New `LARGE_STR_TAG` (= 26)** in `TagEnum` and a `large_str` member in `CompactObj::U`.
- **`CompactObj` rerouted** — `Size`, `HashCode`, `ObjType`, `Encoding`, `ReserveString`, `AppendString`, `GetSlice`, `GetString`, `GetEncodedBlob`, `GetFirstByte`, `SetByteAtIndex` (raw + ASCII-encoded), `Free`, `MallocUsed`, `DefragIfNeeded`, `HasAllocated`, `CmpNonInline`, `CmpEncoded`, `EncodeString`, `Materialize`, `GetRawString`, `SetExpireTime`.
- **`RobjWrapper` slimmed** — removed `OBJ_STRING` branches in `Free`/`Size`/`MallocUsed`/`DefragIfNeeded`; removed `HashCode` and both `Equal` overloads (string-only with `LOG(FATAL)` otherwise); removed `SetString`/`ReserveString`/`AppendString`/`AsView`/`ReallocateString`/`MakeInnerRoom`/`InnerObjMallocUsed` helpers. `RobjWrapper` now covers only collection types.
- **`LargeString::SetString` fully replaces contents on every call.** The original `RobjWrapper::SetString` guarded the entire body with `if (s.size() > sz_)`, so shorter/equal-length replacements silently no-op'd. Not currently reachable (every caller goes through `SetMeta` first which zeroes the union), but the contract was fragile. The carved-out version drops the guard. Added `LargeStringSetReplacesContents` regression test covering shorter / equal-length / longer / empty replacements.
- **No doubling/preallocation logic carried over.** Every current caller hits `SetString`/`ReserveString` with `cur_cap == 0` and `sz == 0`, so `MakeInnerRoom`'s growth heuristic and old-content preservation were dead code. Re-adding the doubling later, if a `SetString`-on-populated-buffer caller appears, is trivial.

## Why

- Eliminates dead branches: `RobjWrapper::HashCode` and both `Equal` overloads were string-only with `LOG(FATAL)` otherwise — string-only methods masquerading as polymorphic.
- The 4-bit `encoding_` field in `RobjWrapper` was dead weight for `OBJ_STRING` (always `OBJ_ENCODING_RAW`; `CompactObj::encoding_` already owns ASCII/Huffman encoding).
- Sets up a follow-up PR that replaces `ROBJ_TAG` with per-collection tags (`LIST_TAG`/`SET_TAG`/`HASH_TAG`/`ZSET_TAG`/`STREAM_TAG`) and drops the `type_` field from `RobjWrapper` — much cleaner once strings are out of the way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)