### PR TITLE
test: fix flaky cluster migration tiering test

### DIFF
--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -3795,7 +3795,7 @@ async def test_cluster_migration_with_tiering_and_deletes(df_factory: DflyInstan
             tiered_prefix="/tmp/tiered/cluster_node",
             tiered_offload_threshold="0.2",
             tiered_experimental_cooling="False",
-            maxmemory="512MB",
+            maxmemory="800MB",
         ),
         df_factory.create(
             port=next(next_port), admin_port=next(next_port), proactor_threads=2, maxmemory="1024MB"
@@ -3813,7 +3813,8 @@ async def test_cluster_migration_with_tiering_and_deletes(df_factory: DflyInstan
     await nodes[0].client.execute_command(f"DEBUG POPULATE {keys} key 440")
 
     # Expect that number of added keys is 1000000
-    info = await nodes[0].client.info("keyspace")
+    info = await nodes[0].client.info()
+    assert info["oom_rejections"] == 0
     assert info["db0"]["keys"] == keys
 
     # Wait for some data to be offloaded to tiered storage


### PR DESCRIPTION
## Summary
- Raise `maxmemory` from 512 MB to 800 MB on the source node in `test_cluster_migration_with_tiering_and_deletes` so `DEBUG POPULATE` (1M keys × 440 B) doesn't race against tiering and silently drop keys via OOM rejections
- Add `assert info["oom_rejections"] == 0` (fetched in the same `INFO` call, checked before the key count) so future failures immediately say whether the cause is memory pressure or a migration bug

Fixes #6683