### PR TITLE
fix(lua): Add input size validation to dragonfly.randstr()

### DIFF
--- a/src/core/interpreter.cc
+++ b/src/core/interpreter.cc
@@ -466,8 +466,30 @@ int DragonflyHashCommand(lua_State* lua) {
 
 int DragonflyRandstrCommand(lua_State* state) {
   int argc = lua_gettop(state);
-  lua_Integer dsize = lua_tonumber(state, 1);
+
+  if ((argc < 1 || argc > 2) || lua_type(state, 1) != LUA_TNUMBER) {
+    PushError(state, "randstr: expected randstr(size) or randstr(size, count)");
+    return RaiseErrorAndAbort(state);
+  }
+
+  lua_Integer dsize = lua_tointeger(state, 1);
   lua_remove(state, 1);
+
+  constexpr lua_Integer kMaxRandstrSize = 16 << 20;  // 16 MiB per string
+  if (dsize < 1 || dsize > kMaxRandstrSize) {
+    PushError(state, absl::StrCat("randstr: size must be between 1 and ", kMaxRandstrSize));
+    return RaiseErrorAndAbort(state);
+  }
+
+  lua_Integer count = 1;
+  if (argc == 2) {
+    count = lua_tointeger(state, 1);
+    constexpr lua_Integer kMaxRandstrCount = 32 << 10;  // 32k strings
+    if (count < 1 || count > kMaxRandstrCount) {
+      PushError(state, absl::StrCat("randstr: count must be between 1 and ", kMaxRandstrCount));
+      return RaiseErrorAndAbort(state);
+    }
+  }
 
   std::string buf(dsize, ' ');
 
@@ -496,9 +518,8 @@ int DragonflyRandstrCommand(lua_State* state) {
   if (argc == 1) {
     push_str();
   } else {
-    lua_Integer num = lua_tonumber(state, 1);
-    lua_createtable(state, num, 0);
-    for (int i = 1; i <= num; i++) {
+    lua_createtable(state, count, 0);
+    for (int i = 1; i <= count; i++) {
       push_str();
       lua_rawseti(state, -2, i);
     }

--- a/src/core/interpreter_test.cc
+++ b/src/core/interpreter_test.cc
@@ -638,4 +638,49 @@ TEST_F(InterpreterTest, GcAccountingAfterReturn) {
   im.Return(interpreter);
 }
 
+TEST_F(InterpreterTest, RandstrValidation) {
+  // Single string: valid size
+  ASSERT_TRUE(Execute("return string.len(dragonfly.randstr(1024))"));
+  EXPECT_EQ("i(1024)", ser_.res);
+
+  // Multiple strings: valid size and count
+  ASSERT_TRUE(Execute("return #dragonfly.randstr(16, 4)"));
+  EXPECT_EQ("i(4)", ser_.res);
+
+  // Invalid: wrong argument type
+  ASSERT_FALSE(Execute("return dragonfly.randstr('bad')"));
+  EXPECT_THAT(error_, testing::HasSubstr("randstr:"));
+
+  // Invalid: too few arguments
+  ASSERT_FALSE(Execute("return dragonfly.randstr()"));
+  EXPECT_THAT(error_, testing::HasSubstr("randstr:"));
+
+  // Invalid: too many arguments
+  ASSERT_FALSE(Execute("return dragonfly.randstr(1, 2, 3)"));
+  EXPECT_THAT(error_, testing::HasSubstr("randstr:"));
+
+  constexpr int kMaxRandstrSize = 16 << 20;
+  constexpr int kMaxRandstrCount = 32 << 10;
+
+  // Invalid: size = 0
+  ASSERT_FALSE(Execute("return dragonfly.randstr(0)"));
+  EXPECT_THAT(error_, testing::HasSubstr("randstr: size must be between 1 and"));
+
+  // Invalid: negative size
+  ASSERT_FALSE(Execute("return dragonfly.randstr(-1)"));
+  EXPECT_THAT(error_, testing::HasSubstr("randstr: size must be between 1 and"));
+
+  // Invalid: size exceeds max
+  ASSERT_FALSE(Execute(absl::StrCat("return dragonfly.randstr(", kMaxRandstrSize + 1, ")")));
+  EXPECT_THAT(error_, testing::HasSubstr("randstr: size must be between 1 and"));
+
+  // Invalid: count = 0
+  ASSERT_FALSE(Execute("return dragonfly.randstr(16, 0)"));
+  EXPECT_THAT(error_, testing::HasSubstr("randstr: count must be between 1 and"));
+
+  // Invalid: count exceeds max
+  ASSERT_FALSE(Execute(absl::StrCat("return dragonfly.randstr(1, ", kMaxRandstrCount + 1, ")")));
+  EXPECT_THAT(error_, testing::HasSubstr("randstr: count must be between 1 and"));
+}
+
 }  // namespace dfly


### PR DESCRIPTION
Validate argument count (1 or 2), type, size (1–16 MiB) and count (1–32k)
to prevent excessive allocations.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
