### PR TITLE
fix(lua): Harden sandbox by protecting rawset, setmetatable, and getmetatable

### DIFF
--- a/src/core/interpreter.cc
+++ b/src/core/interpreter.cc
@@ -348,6 +348,75 @@ void LoadLibrary(lua_State* lua, const char* libname, lua_CFunction luafunc) {
   lua_call(lua, 1, 0);
 }
 
+// Returns true if the table at stack index idx is _G, its metatable, or any global table value.
+bool IsGlobalTableOrMetatable(lua_State* lua, int idx) {
+  lua_pushglobaltable(lua);
+
+  // Check if idx is _G itself.
+  if (lua_rawequal(lua, idx, -1)) {
+    lua_pop(lua, 1);
+    return true;
+  }
+
+  // Check if metatable of _G.
+  bool has_mt = lua_getmetatable(lua, -1);
+  if (has_mt) {
+    lua_remove(lua, -2);
+    bool eq = lua_rawequal(lua, idx, -1);
+    lua_pop(lua, 1);
+    if (eq) {
+      return true;
+    }
+  } else {
+    lua_pop(lua, 1);
+  }
+
+  // Check if idx is any table stored directly as a global value.
+  lua_pushglobaltable(lua);
+  lua_pushnil(lua);
+  while (lua_next(lua, -2) != 0) {
+    if (lua_type(lua, -1) == LUA_TTABLE && lua_rawequal(lua, idx, -1)) {
+      lua_pop(lua, 3);
+      return true;
+    }
+    lua_pop(lua, 1);
+  }
+
+  lua_pop(lua, 1);
+
+  return false;
+}
+
+// Protected replacement for rawset: blocks writes to _G or its metatable.
+int ProtectedRawset(lua_State* lua) {
+  int argc = lua_gettop(lua);
+  if (argc != 3 || lua_type(lua, 1) != LUA_TTABLE) {
+    lua_pushstring(lua, "rawset requires a table and two arguments");
+    return lua_error(lua);
+  }
+  if (IsGlobalTableOrMetatable(lua, 1)) {
+    lua_pushstring(lua, "Script attempted to access rawset with global environment");
+    return lua_error(lua);
+  }
+  lua_rawset(lua, 1);
+  return 1;
+}
+
+// Protected replacement for setmetatable: blocks replacing metatable of _G or its metatable.
+int ProtectedSetmetatable(lua_State* lua) {
+  int argc = lua_gettop(lua);
+  if (argc != 2 || lua_type(lua, 1) != LUA_TTABLE) {
+    lua_pushstring(lua, "setmetatable requires a table and one argument");
+    return lua_error(lua);
+  }
+  if (IsGlobalTableOrMetatable(lua, 1)) {
+    lua_pushstring(lua, "Script attempted to set metatable of global environment");
+    return lua_error(lua);
+  }
+  lua_setmetatable(lua, 1);
+  return 1;
+}
+
 void InitLua(lua_State* lua) {
   Require(lua, "", luaopen_base);
   Require(lua, LUA_TABLIBNAME, luaopen_table);
@@ -385,7 +454,7 @@ void InitLua(lua_State* lua) {
     const char code[] = R"(
 local dbg=debug
 local mt = {}
-
+local _orig_rawset=rawset
 setmetatable(_G, mt)
 mt.__newindex = function (t, n, v)
   if dbg.getinfo(2) then
@@ -394,7 +463,7 @@ mt.__newindex = function (t, n, v)
       error("Script attempted to create global variable '"..tostring(n).."'", 2)
     end
   end
-  rawset(t, n, v)
+  _orig_rawset(t, n, v)
 end
 mt.__index = function (t, n)
   if dbg.getinfo(2) and dbg.getinfo(2, "S").what ~= "C" then
@@ -402,10 +471,38 @@ mt.__index = function (t, n)
   end
   return rawget(t, n)
 end
+local _orig_getmetatable = getmetatable
+-- Prevent access to _G's metatable.
+getmetatable = function(t)
+  if t == _G then
+    error("Script attempted to access metatable of global environment", 2)
+  end
+  return _orig_getmetatable(t)
+end
 debug = nil
+-- Lock all global tables so scripts cannot replace their metatables.
+local global_guard = {}
+global_guard.__metatable = "Script attempted to access metatable of global table"
+for _, v in pairs(_G) do
+  if type(v) == "table" and v ~= _G then
+    setmetatable(v, global_guard)
+  end
+end
 )";
     RunSafe(lua, code, "@enable_strict_lua");
   }
+
+  // Protected replacements for built-in functions.
+  const luaL_Reg protected_funcs[] = {
+      // Blocks direct writes to _G or its metatable.
+      {"rawset", ProtectedRawset},
+      // Blocks replacing the metatable of _G or its metatable.
+      {"setmetatable", ProtectedSetmetatable},
+      {nullptr, nullptr},
+  };
+  lua_pushglobaltable(lua);
+  luaL_setfuncs(lua, protected_funcs, 0);
+  lua_pop(lua, 1);
 
   lua_pushnil(lua);
   lua_setglobal(lua, "loadfile");

--- a/src/core/interpreter_test.cc
+++ b/src/core/interpreter_test.cc
@@ -503,6 +503,93 @@ TEST_F(InterpreterTest, Log) {
   EXPECT_THAT(error_, testing::HasSubstr("requires two arguments or more"));
 }
 
+TEST_F(InterpreterTest, ProtectedRawset) {
+  // rawset on a plain table is allowed
+  EXPECT_TRUE(Execute("local t = {}; rawset(t, 'k', 'v'); return t['k']"));
+  EXPECT_EQ("str(v)", ser_.res);
+
+  // rawset directly on _G is blocked
+  EXPECT_FALSE(Execute("rawset(_G, 'key', 'value')"));
+  EXPECT_THAT(error_,
+              testing::HasSubstr("Script attempted to access rawset with global environment"));
+
+  // getmetatable(_G) now errors, so rawset never runs
+  EXPECT_FALSE(Execute("rawset(getmetatable(_G), 'key', 'value')"));
+  EXPECT_THAT(error_,
+              testing::HasSubstr("Script attempted to access metatable of global environment"));
+}
+
+TEST_F(InterpreterTest, ProtectedSetmetatable) {
+  // setmetatable on a plain table is allowed
+  EXPECT_TRUE(Execute("local t = {}; setmetatable(t, {}); return 'ok'"));
+
+  // setmetatable on _G is blocked
+  EXPECT_FALSE(Execute("setmetatable(_G, {})"));
+  EXPECT_THAT(error_,
+              testing::HasSubstr("Script attempted to set metatable of global environment"));
+
+  // getmetatable(_G) now errors — mt is unreachable.
+  EXPECT_FALSE(Execute("return type(getmetatable(_G))"));
+  EXPECT_THAT(error_,
+              testing::HasSubstr("Script attempted to access metatable of global environment"));
+
+  // setmetatable on global tables (stdlib) is blocked — prevents cross-script contamination.
+  EXPECT_FALSE(Execute("setmetatable(string, {})"));
+  EXPECT_THAT(error_,
+              testing::HasSubstr("Script attempted to set metatable of global environment"));
+  EXPECT_FALSE(Execute("setmetatable(table, {})"));
+  EXPECT_THAT(error_,
+              testing::HasSubstr("Script attempted to set metatable of global environment"));
+  EXPECT_FALSE(Execute("setmetatable(math, {})"));
+  EXPECT_THAT(error_,
+              testing::HasSubstr("Script attempted to set metatable of global environment"));
+}
+
+TEST_F(InterpreterTest, ProtectedRawsetGlobalTables) {
+  // rawset on global stdlib tables is blocked — same contamination risk as setmetatable.
+  EXPECT_FALSE(Execute("rawset(string, 'format', function() end)"));
+  EXPECT_THAT(error_,
+              testing::HasSubstr("Script attempted to access rawset with global environment"));
+  EXPECT_FALSE(Execute("rawset(table, 'sort', function() end)"));
+  EXPECT_THAT(error_,
+              testing::HasSubstr("Script attempted to access rawset with global environment"));
+}
+
+TEST_F(InterpreterTest, ProtectedGetmetatable) {
+  // getmetatable on a plain table is allowed
+  EXPECT_TRUE(Execute("local t = {}; return type(getmetatable(t))"));
+  EXPECT_EQ("str(nil)", ser_.res);
+
+  // getmetatable on _G is blocked from Lua functions
+  EXPECT_FALSE(Execute("local function f() return getmetatable(_G) end; f()"));
+  EXPECT_THAT(error_,
+              testing::HasSubstr("Script attempted to access metatable of global environment"));
+
+  // top-level script call is also blocked — scripts run as Lua functions, not main chunks
+  EXPECT_FALSE(Execute("return type(getmetatable(_G))"));
+  EXPECT_THAT(error_,
+              testing::HasSubstr("Script attempted to access metatable of global environment"));
+  ;
+
+  // global_guard __metatable on stdlib tables is still respected
+  EXPECT_TRUE(Execute("return type(getmetatable(string))"));
+  EXPECT_EQ("str(string)", ser_.res);
+}
+
+TEST_F(InterpreterTest, ProtectedGlobalAssignment) {
+  // direct global assignment from a function is blocked
+  EXPECT_FALSE(Execute("local function f() x = 1 end; f()"));
+  EXPECT_THAT(error_, testing::HasSubstr("Script attempted to create global variable 'x'"));
+
+  // direct field assignment on _G is blocked
+  EXPECT_FALSE(Execute("_G.newkey = 1"));
+  EXPECT_THAT(error_, testing::HasSubstr("Script attempted to create global variable 'newkey'"));
+
+  // top-level script assignment is also blocked — scripts run as functions, not main chunk
+  EXPECT_FALSE(Execute("x = 1; return x"));
+  EXPECT_THAT(error_, testing::HasSubstr("Script attempted to create global variable 'x'"));
+}
+
 TEST_F(InterpreterTest, Robust) {
   EXPECT_FALSE(Execute(R"(eval "local a = {}
       setmetatable(a,{__index=function() foo() end})


### PR DESCRIPTION
Override rawset, setmetatable, and getmetatable to block access to _G and
all protected global tables (string, table, math, etc.). Attach guard
metatables to all global library tables, preventing scripts from accessing
or replacing their metatables.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
