### PR TITLE
fix(lua): Restrict load() to text-only mode

### DIFF
--- a/src/core/interpreter.cc
+++ b/src/core/interpreter.cc
@@ -471,14 +471,20 @@ mt.__index = function (t, n)
   end
   return rawget(t, n)
 end
-local _orig_getmetatable = getmetatable
+-- Restrict load() to text-only mode; binary chunks are not supported.
+local _orig_load = load
+load = function(chunk, chunkname, mode, env)
+  return _orig_load(chunk, chunkname, "t", env)
+end
 -- Prevent access to _G's metatable.
+local _orig_getmetatable = getmetatable
 getmetatable = function(t)
   if t == _G then
     error("Script attempted to access metatable of global environment", 2)
   end
   return _orig_getmetatable(t)
 end
+-- Remove debug library
 debug = nil
 -- Lock all global tables so scripts cannot replace their metatables.
 local global_guard = {}

--- a/src/core/interpreter_test.cc
+++ b/src/core/interpreter_test.cc
@@ -597,6 +597,35 @@ TEST_F(InterpreterTest, Robust) {
   EXPECT_EQ("", ser_.res);
 }
 
+TEST_F(InterpreterTest, LoadBytecodeBlocked) {
+  // Bytecode passed as string must be rejected.
+  EXPECT_TRUE(Execute(R"(
+    local bc = string.dump(function() return 1 end)
+    local f, err = load(bc, "test", "b")
+    return f == nil
+  )"));
+  EXPECT_EQ("bool(1)", ser_.res);
+
+  // Bytecode delivered via a reader function must also be rejected.
+  EXPECT_TRUE(Execute(R"(
+    local bc = string.dump(function() return 1 end)
+    local i = 0
+    local f, err = load(function()
+      i = i + 1
+      return bc:sub(i, i) ~= "" and bc:sub(i, i) or nil
+    end)
+    return f == nil
+  )"));
+  EXPECT_EQ("bool(1)", ser_.res);
+
+  // Source code must still load and execute normally.
+  EXPECT_TRUE(Execute(R"(
+    local f = load("return 42")
+    return f()
+  )"));
+  EXPECT_EQ("i(42)", ser_.res);
+}
+
 TEST_F(InterpreterTest, Unpack) {
   auto cb = [](Interpreter::CallArgs ca) {
     auto* reply = ca.translator;


### PR DESCRIPTION
Wrap load() during sandbox initialization to enforce mode "t", returning nil for any 
binary input regardless of the caller-supplied mode.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
