### PR TITLE
chore: do not unwrap parsed expression in tests

### DIFF
--- a/src/facade/resp_expr_test_utils.h
+++ b/src/facade/resp_expr_test_utils.h
@@ -17,14 +17,6 @@ class RespExprBuilder {
  public:
   RespExpr BuildExpr(const RESPObj& obj);
 
-  void Clear() {
-    owned_arrays_.clear();
-    // Note: owned_strings_ is NOT cleared here because test code may still hold
-    // string_view/Buffer references to data from prior ParseResponse calls
-    // (e.g., SHA values, DUMP payloads). This mirrors the old behavior where
-    // tmp_str_vec_ accumulated across calls within a test.
-  }
-
  private:
   void SetStringPayload(const RESPObj& obj, RespExpr* expr);
 

--- a/src/server/acl/acl_family_test.cc
+++ b/src/server/acl/acl_family_test.cc
@@ -162,7 +162,7 @@ TEST_F(AclFamilyTest, AclDelUser) {
   EXPECT_THAT(resp, IntArg(0));
 
   resp = Run({"ACL", "LIST"});
-  EXPECT_THAT(resp.GetString(), "user default on nopass ~* &* +@all $all");
+  EXPECT_THAT(resp, RespElementsAre("user default on nopass ~* &* +@all $all"));
 
   Run({"ACL", "SETUSER", "michael", "ON"});
   Run({"ACL", "SETUSER", "kobe", "ON"});

--- a/src/server/bitops_family_test.cc
+++ b/src/server/bitops_family_test.cc
@@ -707,89 +707,95 @@ TEST_F(BitOpsFamilyTest, BitFieldParsing) {
 
 TEST_F(BitOpsFamilyTest, BitFieldCreate) {
   // check that SET, INCR create the key when it does not exist
-  ASSERT_THAT(Run({"bitfield", "foo", "set", "u1", "0", "1"}), IntArg(0));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "0"}), IntArg(1));
-  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "u1", "1", "1"}), IntArg(1));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "1"}), IntArg(1));
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u1", "0", "1"}), RespElementsAre(IntArg(0)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "0"}), RespElementsAre(IntArg(1)));
+  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "u1", "1", "1"}), RespElementsAre(IntArg(1)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "1"}), RespElementsAre(IntArg(1)));
 }
 
 TEST_F(BitOpsFamilyTest, BitFieldOverflowUnderflow) {
   Run({"bitfield", "foo", "set", "u2", "0", "2"});
 
   // unsigned 1bit
-  ASSERT_THAT(Run({"bitfield", "foo", "set", "u1", "0", "2"}), IntArg(1));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "0"}), IntArg(0));
-  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "u1", "1", "2"}), IntArg(0));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "1"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u1", "0", "2"}), RespElementsAre(IntArg(1)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "0"}), RespElementsAre(IntArg(0)));
+  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "u1", "1", "2"}), RespElementsAre(IntArg(0)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "1"}), RespElementsAre(IntArg(0)));
 
   // unsigned 63bit
   int64_t max = std::numeric_limits<int64_t>::max();
   Run({"bitfield", "foo", "set", "i64", "0", StrCat(max)});
-  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i64", "0", "1"}), IntArg(-max - 1));
+  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i64", "0", "1"}),
+              RespElementsAre(IntArg(-max - 1)));
 
   // signed 1 bit
   Run({"bitfield", "foo", "set", "i1", "0", "-2"});
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "i1", "0"}), IntArg(0));
-  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i1", "0", "-1"}), IntArg(-1));
-  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i1", "0", "-1"}), IntArg(0));
-  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i1", "0", "-3"}), IntArg(-1));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i1", "0"}), RespElementsAre(IntArg(0)));
+  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i1", "0", "-1"}), RespElementsAre(IntArg(-1)));
+  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i1", "0", "-1"}), RespElementsAre(IntArg(0)));
+  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i1", "0", "-3"}), RespElementsAre(IntArg(-1)));
 
   int64_t min = std::numeric_limits<int64_t>::min();
   Run({"bitfield", "foo", "set", "i8", "0", StrCat(min)});
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "0"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "0"}), RespElementsAre(IntArg(0)));
 
   // signed 64 bit
   Run({"bitfield", "foo", "set", "i64", "0", StrCat(min)});
-  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i64", "0", "-1"}), IntArg(max));
+  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i64", "0", "-1"}), RespElementsAre(IntArg(max)));
 
   // overflow sat
   // unsigned 8 bit
   Run({"bitfield", "foo", "set", "u1", "0", "0"});
-  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "incrby", "u8", "0", "300"}), IntArg(255));
-  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "incrby", "u8", "0", "10"}), IntArg(255));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "0"}), IntArg(255));
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "incrby", "u8", "0", "300"}),
+              RespElementsAre(IntArg(255)));
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "incrby", "u8", "0", "10"}),
+              RespElementsAre(IntArg(255)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "0"}), RespElementsAre(IntArg(255)));
 
   // unsigned 63 bit
   Run({"bitfield", "foo", "set", "u63", "0", "0"});
   ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "set", "u63", "0", StrCat(max)}),
-              IntArg(0));
-  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "incrby", "u63", "0", "10"}), IntArg(max));
+              RespElementsAre(IntArg(0)));
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "incrby", "u63", "0", "10"}),
+              RespElementsAre(IntArg(max)));
 
   // signed 8 bit
   Run({"bitfield", "foo", "set", "u8", "0", "0"});
-  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "set", "i8", "0", "300"}), IntArg(0));
-  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "incrby", "i8", "0", "-127"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "set", "i8", "0", "300"}),
+              RespElementsAre(IntArg(0)));
+  ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "incrby", "i8", "0", "-127"}),
+              RespElementsAre(IntArg(0)));
   ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "incrby", "i8", "0", "-255"}),
-              IntArg(-128));
+              RespElementsAre(IntArg(-128)));
 
   // signed 64 bit
   Run({"bitfield", "foo", "set", "i64", "0", "0"});
   ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "set", "i64", "0", StrCat(max)}),
-              IntArg(0));
+              RespElementsAre(IntArg(0)));
   ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "incrby", "i64", "0", "100"}),
-              IntArg(max));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "i64", "0"}), IntArg(max));
+              RespElementsAre(IntArg(max)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i64", "0"}), RespElementsAre(IntArg(max)));
   ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "set", "i64", "0", StrCat(min)}),
-              IntArg(max));
+              RespElementsAre(IntArg(max)));
   ASSERT_THAT(Run({"bitfield", "foo", "overflow", "sat", "incrby", "i64", "0", "-100"}),
-              IntArg(min));
+              RespElementsAre(IntArg(min)));
 
   // overflow fail
   // unsigned
   ASSERT_THAT(Run({"bitfield", "foo", "overflow", "fail", "set", "u8", "0", "300"}),
-              ArgType(RespExpr::Type::NIL));
+              RespElementsAre(ArgType(RespExpr::Type::NIL)));
   ASSERT_THAT(Run({"bitfield", "foo", "overflow", "fail", "incrby", "u1", "0", "10"}),
-              ArgType(RespExpr::Type::NIL));
+              RespElementsAre(ArgType(RespExpr::Type::NIL)));
   ASSERT_THAT(Run({"bitfield", "foo", "overflow", "fail", "incrby", "u1", "0", "-10"}),
-              ArgType(RespExpr::Type::NIL));
+              RespElementsAre(ArgType(RespExpr::Type::NIL)));
 
   // signed
   ASSERT_THAT(Run({"bitfield", "foo", "overflow", "fail", "incrby", "i8", "0", "300"}),
-              ArgType(RespExpr::Type::NIL));
+              RespElementsAre(ArgType(RespExpr::Type::NIL)));
   ASSERT_THAT(Run({"bitfield", "foo", "overflow", "fail", "incrby", "i1", "0", "10"}),
-              ArgType(RespExpr::Type::NIL));
+              RespElementsAre(ArgType(RespExpr::Type::NIL)));
   ASSERT_THAT(Run({"bitfield", "foo", "overflow", "fail", "incrby", "i1", "0", "-10"}),
-              ArgType(RespExpr::Type::NIL));
+              RespElementsAre(ArgType(RespExpr::Type::NIL)));
 
   // stickiness of overflow among operations in a chain
   ASSERT_THAT(Run({"bitfield", "foo", "overflow", "fail", "set", "u8", "0", "300", "set", "u1", "0",
@@ -801,84 +807,85 @@ TEST_F(BitOpsFamilyTest, BitFieldOperations) {
   // alligned offset reads/writes unsigned
   Run({"bitfield", "foo", "set", "u32", "0", "0"});
   // Set the bit battern 01111000 00000001 00000001 00001010
-  ASSERT_THAT(Run({"bitfield", "foo", "set", "u8", "0", "120"}), IntArg(0));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "0"}), IntArg(120));
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u8", "0", "120"}), RespElementsAre(IntArg(0)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "0"}), RespElementsAre(IntArg(120)));
 
-  ASSERT_THAT(Run({"bitfield", "foo", "set", "u8", "8", "1"}), IntArg(0));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "8"}), IntArg(1));
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u8", "8", "1"}), RespElementsAre(IntArg(0)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "8"}), RespElementsAre(IntArg(1)));
 
-  ASSERT_THAT(Run({"bitfield", "foo", "set", "u8", "16", "1"}), IntArg(0));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "16"}), IntArg(1));
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u8", "16", "1"}), RespElementsAre(IntArg(0)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "16"}), RespElementsAre(IntArg(1)));
 
-  ASSERT_THAT(Run({"bitfield", "foo", "set", "u8", "24", "10"}), IntArg(0));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "24"}), IntArg(10));
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u8", "24", "10"}), RespElementsAre(IntArg(0)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "24"}), RespElementsAre(IntArg(10)));
 
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u32", "0"}), IntArg(2013331722));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u32", "0"}), RespElementsAre(IntArg(2013331722)));
 
-  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "u8", "0", "120"}), IntArg(240));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "0"}), IntArg(240));
+  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "u8", "0", "120"}), RespElementsAre(IntArg(240)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "0"}), RespElementsAre(IntArg(240)));
 
-  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "u16", "0", "120"}), IntArg(61561));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u16", "0"}), IntArg(61561));
+  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "u16", "0", "120"}),
+              RespElementsAre(IntArg(61561)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u16", "0"}), RespElementsAre(IntArg(61561)));
 
   // alligned offset reads/writes signed
   Run({"bitfield", "foo", "set", "u32", "0", "0"});
   // Set the bit battern 10001000 11111111 11111111 11110110
-  ASSERT_THAT(Run({"bitfield", "foo", "set", "i8", "0", "-120"}), IntArg(0));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "0"}), IntArg(-120));
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "i8", "0", "-120"}), RespElementsAre(IntArg(0)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "0"}), RespElementsAre(IntArg(-120)));
 
-  ASSERT_THAT(Run({"bitfield", "foo", "set", "i8", "8", "-1"}), IntArg(0));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "8"}), IntArg(-1));
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "i8", "8", "-1"}), RespElementsAre(IntArg(0)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "8"}), RespElementsAre(IntArg(-1)));
 
-  ASSERT_THAT(Run({"bitfield", "foo", "set", "i8", "16", "-1"}), IntArg(0));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "16"}), IntArg(-1));
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "i8", "16", "-1"}), RespElementsAre(IntArg(0)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "16"}), RespElementsAre(IntArg(-1)));
 
-  ASSERT_THAT(Run({"bitfield", "foo", "set", "i8", "24", "-10"}), IntArg(0));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "24"}), IntArg(-10));
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "i8", "24", "-10"}), RespElementsAre(IntArg(0)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "24"}), RespElementsAre(IntArg(-10)));
 
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "i32", "0"}), IntArg(-1996488714));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i32", "0"}), RespElementsAre(IntArg(-1996488714)));
 
-  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i8", "0", "-8"}), IntArg(-128));
+  ASSERT_THAT(Run({"bitfield", "foo", "incrby", "i8", "0", "-8"}), RespElementsAre(IntArg(-128)));
 
   // nonalligned offset reads/writes unsigned
   Run({"bitfield", "foo", "set", "i64", "0", "0"});
   // Set the bit battern 00000000 10000000 10000000 10000000 10000000
-  ASSERT_THAT(Run({"bitfield", "foo", "set", "u8", "1", "1"}), IntArg(0));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "1"}), IntArg(1));
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u8", "1", "1"}), RespElementsAre(IntArg(0)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "1"}), RespElementsAre(IntArg(1)));
 
-  ASSERT_THAT(Run({"bitfield", "foo", "set", "u8", "9", "1"}), IntArg(0));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "9"}), IntArg(1));
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u8", "9", "1"}), RespElementsAre(IntArg(0)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "9"}), RespElementsAre(IntArg(1)));
 
-  ASSERT_THAT(Run({"bitfield", "foo", "set", "u8", "17", "1"}), IntArg(0));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "17"}), IntArg(1));
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u8", "17", "1"}), RespElementsAre(IntArg(0)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "17"}), RespElementsAre(IntArg(1)));
 
-  ASSERT_THAT(Run({"bitfield", "foo", "set", "u8", "25", "1"}), IntArg(0));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "25"}), IntArg(1));
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "u8", "25", "1"}), RespElementsAre(IntArg(0)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "25"}), RespElementsAre(IntArg(1)));
 
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "0"}), IntArg(0));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "8"}), IntArg(1));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "16"}), IntArg(1));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "24"}), IntArg(1));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "32"}), IntArg(1));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "0"}), RespElementsAre(IntArg(0)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "8"}), RespElementsAre(IntArg(1)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "16"}), RespElementsAre(IntArg(1)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "24"}), RespElementsAre(IntArg(1)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "32"}), RespElementsAre(IntArg(1)));
 
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u33", "0"}), IntArg(16843009));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u33", "0"}), RespElementsAre(IntArg(16843009)));
 
   // nonalligned offset reads/writes signed
   Run({"bitfield", "foo", "set", "i64", "0", "0"});
   // Set the bit battern 1111111 11111111 0000000 000000001
-  ASSERT_THAT(Run({"bitfield", "foo", "set", "i8", "1", "-1"}), IntArg(0));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "1"}), IntArg(-1));
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "i8", "1", "-1"}), RespElementsAre(IntArg(0)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "1"}), RespElementsAre(IntArg(-1)));
 
-  ASSERT_THAT(Run({"bitfield", "foo", "set", "i8", "9", "-1"}), IntArg(0));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "9"}), IntArg(-1));
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "i8", "9", "-1"}), RespElementsAre(IntArg(0)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "9"}), RespElementsAre(IntArg(-1)));
 
-  ASSERT_THAT(Run({"bitfield", "foo", "set", "i8", "17", "0"}), IntArg(0));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "17"}), IntArg(0));
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "i8", "17", "0"}), RespElementsAre(IntArg(0)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "17"}), RespElementsAre(IntArg(0)));
 
-  ASSERT_THAT(Run({"bitfield", "foo", "set", "i8", "25", "1"}), IntArg(0));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "25"}), IntArg(1));
+  ASSERT_THAT(Run({"bitfield", "foo", "set", "i8", "25", "1"}), RespElementsAre(IntArg(0)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i8", "25"}), RespElementsAre(IntArg(1)));
 
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "i32", "1"}), IntArg(-65535));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "i32", "1"}), RespElementsAre(IntArg(-65535)));
 
   // chaining
   Run({
@@ -887,7 +894,7 @@ TEST_F(BitOpsFamilyTest, BitFieldOperations) {
       "5",        "1",   "set", "u1", "6", "1", "set", "u1", "7", "1",
   });
 
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "0"}), IntArg(255));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u8", "0"}), RespElementsAre(IntArg(255)));
 
   ASSERT_THAT(Run({
                   "bitfield",
@@ -909,8 +916,8 @@ TEST_F(BitOpsFamilyTest, BitFieldOperations) {
   // check for positional offsets
   Run({"bitfield", "foo", "set", "u8", "#0", "1", "set", "u8", "#1", "1", "set", "u8", "#2", "1"});
 
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "7"}), IntArg(1));
-  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "15"}), IntArg(1));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "7"}), RespElementsAre(IntArg(1)));
+  ASSERT_THAT(Run({"bitfield", "foo", "get", "u1", "15"}), RespElementsAre(IntArg(1)));
 }
 
 TEST_F(BitOpsFamilyTest, BitFieldLargeOffset) {
@@ -927,7 +934,7 @@ TEST_F(BitOpsFamilyTest, BitFieldLargeOffset) {
   EXPECT_THAT(ToSV(resp.GetBuf()), Eq(std::string_view("bar\0", 4)));
 
   resp = Run({"bitfield", "foo", "get", "u32", "4294967295"});
-  EXPECT_THAT(resp, 0);
+  EXPECT_THAT(resp, RespElementsAre(IntArg(0)));
 }
 
 TEST_F(BitOpsFamilyTest, BitFieldIssue5237_SetOverflowSat) {

--- a/src/server/cluster/cluster_family_test.cc
+++ b/src/server/cluster/cluster_family_test.cc
@@ -168,30 +168,31 @@ TEST_F(ClusterFamilyTest, ClusterConfigNoReplicas) {
   EXPECT_THAT(cluster_info, HasSubstr("cluster_known_nodes:1"));
   EXPECT_THAT(cluster_info, HasSubstr("cluster_size:1"));
 
-  EXPECT_THAT(Run({"cluster", "shards"}),
-              RespArray(ElementsAre("slots",                                            //
-                                    RespArray(ElementsAre(IntArg(0), IntArg(16'383))),  //
-                                    "nodes",                                            //
-                                    RespArray(ElementsAre(                              //
-                                        RespArray(ElementsAre(                          //
-                                            "id", "abcd1234",                           //
-                                            "endpoint", "10.0.0.1",                     //
-                                            "ip", "10.0.0.1",                           //
-                                            "port", IntArg(7000),                       //
-                                            "role", "master",                           //
-                                            "replication-offset", IntArg(0),            //
-                                            "health", "online")))))));
+  EXPECT_THAT(
+      Run({"cluster", "shards"}),
+      RespElementsAre(RespArray(ElementsAre("slots",                                            //
+                                            RespArray(ElementsAre(IntArg(0), IntArg(16'383))),  //
+                                            "nodes",                                            //
+                                            RespArray(ElementsAre(                              //
+                                                RespArray(ElementsAre(                          //
+                                                    "id", "abcd1234",                           //
+                                                    "endpoint", "10.0.0.1",                     //
+                                                    "ip", "10.0.0.1",                           //
+                                                    "port", IntArg(7000),                       //
+                                                    "role", "master",                           //
+                                                    "replication-offset", IntArg(0),            //
+                                                    "health", "online"))))))));
 
   EXPECT_THAT(Run({"get", "x"}).GetString(),
               testing::MatchesRegex(R"(MOVED [0-9]+ 10.0.0.1:7000)"));
 
   EXPECT_THAT(Run({"cluster", "slots"}),
-              RespArray(ElementsAre(IntArg(0),              //
-                                    IntArg(16'383),         //
-                                    RespArray(ElementsAre(  //
-                                        "10.0.0.1",         //
-                                        IntArg(7'000),      //
-                                        "abcd1234")))));
+              RespElementsAre(RespArray(ElementsAre(IntArg(0),              //
+                                                    IntArg(16'383),         //
+                                                    RespArray(ElementsAre(  //
+                                                        "10.0.0.1",         //
+                                                        IntArg(7'000),      //
+                                                        "abcd1234"))))));
 
   EXPECT_EQ(Run({"cluster", "nodes"}),
             "abcd1234 10.0.0.1:7000@7000 master - 0 0 0 connected 0-16383\n");
@@ -232,39 +233,40 @@ TEST_F(ClusterFamilyTest, ClusterConfigFull) {
   EXPECT_THAT(cluster_info, HasSubstr("cluster_known_nodes:2"));
   EXPECT_THAT(cluster_info, HasSubstr("cluster_size:1"));
 
-  EXPECT_THAT(Run({"cluster", "shards"}),
-              RespArray(ElementsAre("slots",                                            //
-                                    RespArray(ElementsAre(IntArg(0), IntArg(16'383))),  //
-                                    "nodes",                                            //
-                                    RespArray(ElementsAre(                              //
-                                        RespArray(ElementsAre(                          //
-                                            "id", "abcd1234",                           //
-                                            "endpoint", "10.0.0.1",                     //
-                                            "ip", "10.0.0.1",                           //
-                                            "port", IntArg(7000),                       //
-                                            "role", "master",                           //
-                                            "replication-offset", IntArg(0),            //
-                                            "health", "online")),                       //
-                                        RespArray(ElementsAre(                          //
-                                            "id", "wxyz",                               //
-                                            "endpoint", "10.0.0.10",                    //
-                                            "ip", "10.0.0.10",                          //
-                                            "port", IntArg(8000),                       //
-                                            "role", "replica",                          //
-                                            "replication-offset", IntArg(0),            //
-                                            "health", "online")))))));
+  EXPECT_THAT(
+      Run({"cluster", "shards"}),
+      RespElementsAre(RespArray(ElementsAre("slots",                                            //
+                                            RespArray(ElementsAre(IntArg(0), IntArg(16'383))),  //
+                                            "nodes",                                            //
+                                            RespArray(ElementsAre(                              //
+                                                RespArray(ElementsAre(                          //
+                                                    "id", "abcd1234",                           //
+                                                    "endpoint", "10.0.0.1",                     //
+                                                    "ip", "10.0.0.1",                           //
+                                                    "port", IntArg(7000),                       //
+                                                    "role", "master",                           //
+                                                    "replication-offset", IntArg(0),            //
+                                                    "health", "online")),                       //
+                                                RespArray(ElementsAre(                          //
+                                                    "id", "wxyz",                               //
+                                                    "endpoint", "10.0.0.10",                    //
+                                                    "ip", "10.0.0.10",                          //
+                                                    "port", IntArg(8000),                       //
+                                                    "role", "replica",                          //
+                                                    "replication-offset", IntArg(0),            //
+                                                    "health", "online"))))))));
 
   EXPECT_THAT(Run({"cluster", "slots"}),
-              RespArray(ElementsAre(IntArg(0),              //
-                                    IntArg(16'383),         //
-                                    RespArray(ElementsAre(  //
-                                        "10.0.0.1",         //
-                                        IntArg(7'000),      //
-                                        "abcd1234")),       //
-                                    RespArray(ElementsAre(  //
-                                        "10.0.0.10",        //
-                                        IntArg(8'000),      //
-                                        "wxyz")))));
+              RespElementsAre(RespArray(ElementsAre(IntArg(0),              //
+                                                    IntArg(16'383),         //
+                                                    RespArray(ElementsAre(  //
+                                                        "10.0.0.1",         //
+                                                        IntArg(7'000),      //
+                                                        "abcd1234")),       //
+                                                    RespArray(ElementsAre(  //
+                                                        "10.0.0.10",        //
+                                                        IntArg(8'000),      //
+                                                        "wxyz"))))));
 
   EXPECT_EQ(Run({"cluster", "nodes"}),
             "abcd1234 10.0.0.1:7000@7000 master - 0 0 0 connected 0-16383\n"
@@ -563,12 +565,14 @@ TEST_F(ClusterFamilyTest, ClusterSlotsPopulate) {
 
   for (int i = 0; i <= 1'000; ++i) {
     EXPECT_THAT(RunPrivileged({"dflycluster", "getslotinfo", "slots", absl::StrCat(i)}),
-                RespArray(ElementsAre(IntArg(i), "key_count", Not(IntArg(0)), _, _, _, _, _, _)));
+                RespElementsAre(RespArray(
+                    ElementsAre(IntArg(i), "key_count", Not(IntArg(0)), _, _, _, _, _, _))));
   }
 
   for (int i = 1'001; i <= 16'383; ++i) {
     EXPECT_THAT(RunPrivileged({"dflycluster", "getslotinfo", "slots", absl::StrCat(i)}),
-                RespArray(ElementsAre(IntArg(i), "key_count", IntArg(0), _, _, _, _, _, _)));
+                RespElementsAre(
+                    RespArray(ElementsAre(IntArg(i), "key_count", IntArg(0), _, _, _, _, _, _))));
   }
 }
 
@@ -837,9 +841,10 @@ TEST_F(ClusterFamilyTest, FlushSlotsAndImmediatelySetValue) {
     EXPECT_THAT(Run({"cluster", "keyslot", "key:0"}), IntArg(2592));
     EXPECT_THAT(Run({"dbsize"}), IntArg(count));
     auto slot_size_response = Run({"dflycluster", "getslotinfo", "slots", "2592"});
-    EXPECT_THAT(slot_size_response, RespArray(ElementsAre(_, "key_count", _, "total_reads", _,
-                                                          "total_writes", _, "memory_bytes", _)));
-    auto slot_size = slot_size_response.GetVec()[2].GetInt();
+    EXPECT_THAT(slot_size_response,
+                RespElementsAre(RespArray(ElementsAre(_, "key_count", _, "total_reads", _,
+                                                      "total_writes", _, "memory_bytes", _))));
+    auto slot_size = slot_size_response.GetVec()[0].GetVec()[2].GetInt();
     EXPECT_TRUE(slot_size.has_value());
 
     EXPECT_EQ(Run({"dflycluster", "flushslots", "2592", "2592"}), "OK");
@@ -919,7 +924,7 @@ TEST_F(ClusterFamilyTest, ClusterCrossSlot) {
   EXPECT_EQ(Run({"GET", "key"}), "value");
 
   EXPECT_EQ(Run({"MSET", "key", "value2"}), "OK");
-  EXPECT_EQ(Run({"MGET", "key"}), "value2");
+  EXPECT_THAT(Run({"MGET", "key"}), RespElementsAre("value2"));
 
   EXPECT_THAT(Run({"MSET", "key", "value", "key2", "value2"}), ErrArg("CROSSSLOT"));
   EXPECT_THAT(Run({"MGET", "key", "key2"}), ErrArg("CROSSSLOT"));
@@ -947,29 +952,30 @@ TEST_F(ClusterFamilyEmulatedTest, ClusterInfo) {
 }
 
 TEST_F(ClusterFamilyEmulatedTest, ClusterShardInfos) {
-  EXPECT_THAT(Run({"cluster", "shards"}),
-              RespArray(ElementsAre("slots",                                           //
-                                    RespArray(ElementsAre(IntArg(0), IntArg(16383))),  //
-                                    "nodes",                                           //
-                                    RespArray(ElementsAre(                             //
-                                        RespArray(ElementsAre(                         //
-                                            "id", GetMyId(),                           //
-                                            "endpoint", "fake-host",                   //
-                                            "ip", "fake-host",                         //
-                                            "port", IntArg(6379),                      //
-                                            "role", "master",                          //
-                                            "replication-offset", IntArg(0),           //
-                                            "health", "online")))))));
+  EXPECT_THAT(
+      Run({"cluster", "shards"}),
+      RespElementsAre(RespArray(ElementsAre("slots",                                           //
+                                            RespArray(ElementsAre(IntArg(0), IntArg(16383))),  //
+                                            "nodes",                                           //
+                                            RespArray(ElementsAre(                             //
+                                                RespArray(ElementsAre(                         //
+                                                    "id", GetMyId(),                           //
+                                                    "endpoint", "fake-host",                   //
+                                                    "ip", "fake-host",                         //
+                                                    "port", IntArg(6379),                      //
+                                                    "role", "master",                          //
+                                                    "replication-offset", IntArg(0),           //
+                                                    "health", "online"))))))));
 }
 
 TEST_F(ClusterFamilyEmulatedTest, ClusterSlots) {
   EXPECT_THAT(Run({"cluster", "slots"}),
-              RespArray(ElementsAre(IntArg(0),              //
-                                    IntArg(16383),          //
-                                    RespArray(ElementsAre(  //
-                                        "fake-host",        //
-                                        IntArg(6379),       //
-                                        GetMyId())))));
+              RespElementsAre(RespArray(ElementsAre(IntArg(0),              //
+                                                    IntArg(16383),          //
+                                                    RespArray(ElementsAre(  //
+                                                        "fake-host",        //
+                                                        IntArg(6379),       //
+                                                        GetMyId()))))));
 }
 
 TEST_F(ClusterFamilyEmulatedTest, ClusterNodes) {

--- a/src/server/cms_family_test.cc
+++ b/src/server/cms_family_test.cc
@@ -45,7 +45,7 @@ TEST_F(CmsFamilyTest, IncrBy) {
   Run("cms.initbydim cms 100 5");
 
   auto resp = Run("cms.incrby cms foo 3");
-  EXPECT_THAT(resp, IntArg(3));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(3)));
 
   resp = Run("cms.incrby cms foo 4 bar 1");
   EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(7), IntArg(1))));
@@ -64,13 +64,13 @@ TEST_F(CmsFamilyTest, Query) {
   Run("cms.incrby cms foo 5 bar 3");
 
   auto resp = Run("cms.query cms foo");
-  EXPECT_THAT(resp, IntArg(5));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(5)));
 
   resp = Run("cms.query cms foo bar");
   EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(5), IntArg(3))));
 
   resp = Run("cms.query cms noexist");
-  EXPECT_THAT(resp, IntArg(0));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(0)));
 
   resp = Run("cms.query noexist foo");
   EXPECT_THAT(resp, ErrArg("CMS: key does not exist"));

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -301,11 +301,11 @@ TEST_F(DflyEngineTest, ScriptFlush) {
   resp = Run({"evalsha", sha, "0"});
   EXPECT_THAT(5, resp.GetInt());
   resp = Run({"script", "exists", sha});
-  EXPECT_THAT(1, resp.GetInt());
+  EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
 
   resp = Run({"script", "flush"});
   resp = Run({"script", "exists", sha});
-  EXPECT_THAT(0, resp.GetInt());
+  EXPECT_THAT(resp, RespElementsAre(IntArg(0)));
   EXPECT_THAT(Run({"evalsha", sha, "0"}), ErrArg("NOSCRIPT No matching script. Please use EVAL."));
 
   resp = Run({"script", "load", "return 5"});
@@ -314,7 +314,7 @@ TEST_F(DflyEngineTest, ScriptFlush) {
   resp = Run({"evalsha", sha, "0"});
   EXPECT_THAT(5, resp.GetInt());
   resp = Run({"script", "exists", sha});
-  EXPECT_THAT(1, resp.GetInt());
+  EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
 }
 
 TEST_F(DflyEngineTestWithRegistry, Hello) {
@@ -693,7 +693,7 @@ TEST_F(DflyEngineTest, Bug468) {
   ASSERT_EQ(resp, "QUEUED");
 
   resp = Run({"exec"});
-  ASSERT_THAT(resp, ErrArg("not an integer"));
+  ASSERT_THAT(resp, RespElementsAre(ErrArg("not an integer")));
 
   ASSERT_FALSE(IsLocked(0, "foo"));
 
@@ -1110,7 +1110,7 @@ TEST_F(DflyCommandAliasTest, Aliasing) {
   // test stats within multi-exec
   EXPECT_EQ(Run({"multi"}), "OK");
   EXPECT_EQ(Run({"___set", "a", "x"}), "QUEUED");
-  EXPECT_EQ(Run({"exec"}), "OK");
+  EXPECT_THAT(Run({"exec"}), RespElementsAre("OK"));
 
   metrics = GetMetrics();
   EXPECT_THAT(metrics.cmd_stats_map, Contains(Pair("___set", Key(2))));

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -653,7 +653,7 @@ TEST_F(GenericFamilyTest, Scan) {
   resp = Run({"keys", "*"});
   EXPECT_THAT(resp, RespArray(ElementsAre("bar", "")));
   resp = Run({"keys", ""});
-  EXPECT_EQ(resp, "");
+  EXPECT_THAT(resp, RespElementsAre(""));
 }
 
 TEST_F(GenericFamilyTest, ScanWithAttr) {
@@ -734,15 +734,15 @@ TEST_F(GenericFamilyTest, Sort) {
   ASSERT_THAT(Run({"sort", "list-1", "LIMIT", "0", "10"}).GetVec(),
               ElementsAre("1.2", "2.20", "3.5", "10.1", "200"));
   ASSERT_THAT(Run({"sort", "list-1", "LIMIT", "2", "2"}).GetVec(), ElementsAre("3.5", "10.1"));
-  ASSERT_THAT(Run({"sort", "list-1", "LIMIT", "1", "1"}), "2.20");
-  ASSERT_THAT(Run({"sort", "list-1", "LIMIT", "4", "2"}), "200");
+  ASSERT_THAT(Run({"sort", "list-1", "LIMIT", "1", "1"}), RespElementsAre("2.20"));
+  ASSERT_THAT(Run({"sort", "list-1", "LIMIT", "4", "2"}), RespElementsAre("200"));
   ASSERT_THAT(Run({"sort", "list-1", "LIMIT", "5", "2"}), ArrLen(0));
   // limits desc
   ASSERT_THAT(Run({"sort", "list-1", "DESC", "LIMIT", "0", "5"}).GetVec(),
               ElementsAre("200", "10.1", "3.5", "2.20", "1.2"));
   ASSERT_THAT(Run({"sort", "list-1", "DESC", "LIMIT", "2", "2"}).GetVec(),
               ElementsAre("3.5", "2.20"));
-  ASSERT_THAT(Run({"sort", "list-1", "DESC", "LIMIT", "1", "1"}), "10.1");
+  ASSERT_THAT(Run({"sort", "list-1", "DESC", "LIMIT", "1", "1"}), RespElementsAre("10.1"));
   ASSERT_THAT(Run({"sort", "list-1", "DESC", "LIMIT", "5", "2"}), ArrLen(0));
 
   // Test set sort
@@ -781,7 +781,7 @@ TEST_F(GenericFamilyTest, Sort) {
   ASSERT_THAT(Run({"sort", "foo"}), ErrArg("WRONGTYPE "));
 
   Run({"rpush", "list-3", ""});
-  ASSERT_THAT(Run({"sort", "list-3"}), "");
+  ASSERT_THAT(Run({"sort", "list-3"}), RespElementsAre(""));
 
   Run({"rpush", "list-3", "2", "0", "", "-0.14", "0.12", "-0", "-123123", "7654"});
   ASSERT_THAT(Run({"sort", "list-3"}).GetVec(),
@@ -844,10 +844,10 @@ TEST_F(GenericFamilyTest, SortStore) {
   ASSERT_THAT(Run({"lrange", "list-2", "0", "-1"}).GetVec(), ElementsAre("3.5", "10.1"));
   resp = Run({"sort", "list-1", "LIMIT", "1", "1", "store", "list-2"});
   EXPECT_EQ(1, resp.GetInt());
-  ASSERT_THAT(Run({"lrange", "list-2", "0", "-1"}), "2.20");
+  ASSERT_THAT(Run({"lrange", "list-2", "0", "-1"}), RespElementsAre("2.20"));
   resp = Run({"sort", "list-1", "LIMIT", "4", "2", "store", "list-2"});
   EXPECT_EQ(1, resp.GetInt());
-  ASSERT_THAT(Run({"lrange", "list-2", "0", "-1"}), "200");
+  ASSERT_THAT(Run({"lrange", "list-2", "0", "-1"}), RespElementsAre("200"));
   resp = Run({"sort", "list-1", "LIMIT", "5", "2", "store", "list-2"});
   EXPECT_EQ(0, resp.GetInt());
   ASSERT_THAT(Run({"lrange", "list-2", "0", "-1"}), ArrLen(0));
@@ -953,15 +953,15 @@ TEST_F(GenericFamilyTest, Sort_RO) {
   ASSERT_THAT(Run({"sort_ro", "list-1", "LIMIT", "0", "10"}).GetVec(),
               ElementsAre("1.2", "2.20", "3.5", "10.1", "200"));
   ASSERT_THAT(Run({"sort_ro", "list-1", "LIMIT", "2", "2"}).GetVec(), ElementsAre("3.5", "10.1"));
-  ASSERT_THAT(Run({"sort_ro", "list-1", "LIMIT", "1", "1"}), "2.20");
-  ASSERT_THAT(Run({"sort_ro", "list-1", "LIMIT", "4", "2"}), "200");
+  ASSERT_THAT(Run({"sort_ro", "list-1", "LIMIT", "1", "1"}), RespElementsAre("2.20"));
+  ASSERT_THAT(Run({"sort_ro", "list-1", "LIMIT", "4", "2"}), RespElementsAre("200"));
   ASSERT_THAT(Run({"sort_ro", "list-1", "LIMIT", "5", "2"}), ArrLen(0));
   // limits desc
   ASSERT_THAT(Run({"sort_ro", "list-1", "DESC", "LIMIT", "0", "5"}).GetVec(),
               ElementsAre("200", "10.1", "3.5", "2.20", "1.2"));
   ASSERT_THAT(Run({"sort_ro", "list-1", "DESC", "LIMIT", "2", "2"}).GetVec(),
               ElementsAre("3.5", "2.20"));
-  ASSERT_THAT(Run({"sort_ro", "list-1", "DESC", "LIMIT", "1", "1"}), "10.1");
+  ASSERT_THAT(Run({"sort_ro", "list-1", "DESC", "LIMIT", "1", "1"}), RespElementsAre("10.1"));
   ASSERT_THAT(Run({"sort_ro", "list-1", "DESC", "LIMIT", "5", "2"}), ArrLen(0));
 
   // Test set sort
@@ -1003,7 +1003,7 @@ TEST_F(GenericFamilyTest, Sort_RO) {
   ASSERT_THAT(Run({"sort_ro", "foo"}), ErrArg("WRONGTYPE "));
 
   Run({"rpush", "list-3", ""});
-  ASSERT_THAT(Run({"sort_ro", "list-3"}), "");
+  ASSERT_THAT(Run({"sort_ro", "list-3"}), RespElementsAre(""));
 
   Run({"rpush", "list-3", "2", "0", "", "-0.14", "0.12", "-0", "-123123", "7654"});
   ASSERT_THAT(Run({"sort_ro", "list-3"}).GetVec(),
@@ -1221,7 +1221,7 @@ TEST_F(GenericFamilyTest, Restore) {
   resp = Run({"restore", "my-zset", "0", ToSV(ZSET_LISTPACK_DUMP)});
   EXPECT_EQ(resp.GetString(), "OK");
   resp = Run({"zrange", "my-zset", "0", "-1"});
-  EXPECT_EQ("elon", resp.GetString());
+  EXPECT_THAT(resp, RespElementsAre("elon"));
 
   // corrupt the dump file but keep the crc correct.
   ZSET_LISTPACK_DUMP[0] = 0x12;

--- a/src/server/geo_family_test.cc
+++ b/src/server/geo_family_test.cc
@@ -56,12 +56,14 @@ TEST_F(GeoFamilyTest, GeoAddOptions) {
   // update 1 + CH + XX
   EXPECT_EQ(1, CheckedInt({"geoadd", "Sicily", "CH", "XX", "10.361389", "38.115556", "Palermo"}));
   resp = Run({"geopos", "Sicily", "Palermo"});
-  EXPECT_THAT(resp, RespArray(ElementsAre(DoubleArg(10.361389), DoubleArg(38.115556))));
+  EXPECT_THAT(resp,
+              RespElementsAre(RespArray(ElementsAre(DoubleArg(10.361389), DoubleArg(38.115556)))));
 
   // add 1 + CH + NX
   EXPECT_EQ(1, CheckedInt({"geoadd", "Sicily", "CH", "NX", "14.25", "37.066667", "Gela"}));
   resp = Run({"geopos", "Sicily", "Gela"});
-  EXPECT_THAT(resp, RespArray(ElementsAre(DoubleArg(14.25), DoubleArg(37.066667))));
+  EXPECT_THAT(resp,
+              RespElementsAre(RespArray(ElementsAre(DoubleArg(14.25), DoubleArg(37.066667)))));
 
   // add 1 + XX + NX
   resp = Run({"geoadd", "Sicily", "XX", "NX", "14.75", "36.933333", "Ragusa"});
@@ -350,7 +352,7 @@ TEST_F(GeoFamilyTest, GeoRadius) {
   EXPECT_THAT(resp, ErrArg("ERR COUNT must be > 0"));
 
   resp = Run("GEORADIUS Sicily 15 37 200 km COUNT 1");
-  EXPECT_THAT(resp, "Agrigento");
+  EXPECT_THAT(resp, RespElementsAre("Agrigento"));
 
   auto err =
       "ERR STORE option in GEORADIUS is not compatible with WITHDIST, WITHHASH and WITHCOORDS options"sv;
@@ -393,9 +395,9 @@ TEST_F(GeoFamilyTest, GeoRadiusByMemberUb) {
   auto resp = Run({"GEORADIUSBYMEMBER", "geo", "971", "200", "mi", "WITHCOORD", "WITHDIST", "COUNT",
                    "40", "ASC"});
   // Use DoubleArg(0) to tolerate tiny floating-point residuals (e.g. 5e-15) on AVX/FMA builds.
-  EXPECT_THAT(resp, RespArray(ElementsAre(
+  EXPECT_THAT(resp, RespElementsAre(RespArray(ElementsAre(
                         "971", DoubleArg(0),
-                        RespArray(ElementsAre("-122.41940170526505", "37.77490001056578")))));
+                        RespArray(ElementsAre("-122.41940170526505", "37.77490001056578"))))));
 }
 
 }  // namespace dfly

--- a/src/server/hset_family_test.cc
+++ b/src/server/hset_family_test.cc
@@ -623,18 +623,26 @@ TEST_F(HSetFamilyTest, HExpire) {
   EXPECT_EQ(CheckedInt({"HSET", "key3", "k0", "v0", "k1", "v1", "k2", "v2", "k3", "v3", "k4", "v4",
                         "k5", "v5"}),
             6);
-  EXPECT_THAT(Run({"HEXPIRE", "key3", "10", "XX", "FIELDS", "1", "k0"}), IntArg(0));
-  EXPECT_THAT(Run({"HEXPIRE", "key3", "10", "NX", "FIELDS", "1", "k0"}), IntArg(1));
-  EXPECT_THAT(Run({"HEXPIRE", "key3", "10", "NX", "FIELDS", "1", "k0"}), IntArg(0));
-  EXPECT_THAT(Run({"HEXPIRE", "key3", "10", "XX", "FIELDS", "1", "k0"}), IntArg(1));
+  EXPECT_THAT(Run({"HEXPIRE", "key3", "10", "XX", "FIELDS", "1", "k0"}),
+              RespElementsAre(IntArg(0)));
+  EXPECT_THAT(Run({"HEXPIRE", "key3", "10", "NX", "FIELDS", "1", "k0"}),
+              RespElementsAre(IntArg(1)));
+  EXPECT_THAT(Run({"HEXPIRE", "key3", "10", "NX", "FIELDS", "1", "k0"}),
+              RespElementsAre(IntArg(0)));
+  EXPECT_THAT(Run({"HEXPIRE", "key3", "10", "XX", "FIELDS", "1", "k0"}),
+              RespElementsAre(IntArg(1)));
   EXPECT_THAT(Run({"HEXPIRE", "key3", "10", "NX", "FIELDS", "3", "k1", "k2", "k3"}),
               RespArray(ElementsAre(IntArg(1), IntArg(1), IntArg(1))));
-  EXPECT_THAT(Run({"HEXPIRE", "key3", "8", "GT", "FIELDS", "1", "k2"}), IntArg(0));
-  EXPECT_THAT(Run({"HEXPIRE", "key3", "12", "GT", "FIELDS", "1", "k2"}), IntArg(1));
-  EXPECT_THAT(Run({"HEXPIRE", "key3", "8", "LT", "FIELDS", "1", "k3"}), IntArg(1));
-  EXPECT_THAT(Run({"HEXPIRE", "key3", "12", "LT", "FIELDS", "1", "k3"}), IntArg(0));
-  EXPECT_THAT(Run({"HEXPIRE", "key3", "10", "GT", "FIELDS", "1", "k4"}), IntArg(0));
-  EXPECT_THAT(Run({"HEXPIRE", "key3", "10", "LT", "FIELDS", "1", "k5"}), IntArg(1));
+  EXPECT_THAT(Run({"HEXPIRE", "key3", "8", "GT", "FIELDS", "1", "k2"}), RespElementsAre(IntArg(0)));
+  EXPECT_THAT(Run({"HEXPIRE", "key3", "12", "GT", "FIELDS", "1", "k2"}),
+              RespElementsAre(IntArg(1)));
+  EXPECT_THAT(Run({"HEXPIRE", "key3", "8", "LT", "FIELDS", "1", "k3"}), RespElementsAre(IntArg(1)));
+  EXPECT_THAT(Run({"HEXPIRE", "key3", "12", "LT", "FIELDS", "1", "k3"}),
+              RespElementsAre(IntArg(0)));
+  EXPECT_THAT(Run({"HEXPIRE", "key3", "10", "GT", "FIELDS", "1", "k4"}),
+              RespElementsAre(IntArg(0)));
+  EXPECT_THAT(Run({"HEXPIRE", "key3", "10", "LT", "FIELDS", "1", "k5"}),
+              RespElementsAre(IntArg(1)));
   AdvanceTime(8'000);
   EXPECT_THAT(
       Run({"HGETALL", "key3"}),
@@ -644,8 +652,8 @@ TEST_F(HSetFamilyTest, HExpire) {
   AdvanceTime(2'000);
   EXPECT_THAT(Run({"HGETALL", "key3"}), RespArray(ElementsAre("k4", "v4")));
 
-  EXPECT_THAT(Run({"HEXPIRE", "key3", "10", "FIELDS", "1", "k4"}), IntArg(1));
-  EXPECT_THAT(Run({"HEXPIRE", "key3", "0", "XX", "FIELDS", "1", "k4"}), IntArg(2));
+  EXPECT_THAT(Run({"HEXPIRE", "key3", "10", "FIELDS", "1", "k4"}), RespElementsAre(IntArg(1)));
+  EXPECT_THAT(Run({"HEXPIRE", "key3", "0", "XX", "FIELDS", "1", "k4"}), RespElementsAre(IntArg(2)));
   EXPECT_THAT(Run({"HGETALL", "key3"}), RespArray(ElementsAre()));
 
   EXPECT_EQ(
@@ -655,11 +663,12 @@ TEST_F(HSetFamilyTest, HExpire) {
   EXPECT_THAT(Run({"HEXPIRE", "key4", "0", "LT", "FIELDS", "2", "k2", "k3"}),
               RespElementsAre(IntArg(2), IntArg(2)));
 
-  EXPECT_THAT(Run({"HEXPIRE", "key4", "0", "XX", "FIELDS", "1", "k4"}), IntArg(0));
-  EXPECT_THAT(Run({"HEXPIRE", "key4", "10", "NX", "FIELDS", "1", "k4"}), IntArg(1));
-  EXPECT_THAT(Run({"HEXPIRE", "key4", "0", "NX", "FIELDS", "1", "k4"}), IntArg(0));
-  EXPECT_THAT(Run({"HEXPIRE", "key4", "0", "GT", "FIELDS", "1", "k4"}), IntArg(0));
-  EXPECT_THAT(Run({"HEXPIRE", "key4", "0", "FIELDS", "1", "k4"}), IntArg(2));
+  EXPECT_THAT(Run({"HEXPIRE", "key4", "0", "XX", "FIELDS", "1", "k4"}), RespElementsAre(IntArg(0)));
+  EXPECT_THAT(Run({"HEXPIRE", "key4", "10", "NX", "FIELDS", "1", "k4"}),
+              RespElementsAre(IntArg(1)));
+  EXPECT_THAT(Run({"HEXPIRE", "key4", "0", "NX", "FIELDS", "1", "k4"}), RespElementsAre(IntArg(0)));
+  EXPECT_THAT(Run({"HEXPIRE", "key4", "0", "GT", "FIELDS", "1", "k4"}), RespElementsAre(IntArg(0)));
+  EXPECT_THAT(Run({"HEXPIRE", "key4", "0", "FIELDS", "1", "k4"}), RespElementsAre(IntArg(2)));
   EXPECT_THAT(Run({"HGETALL", "key4"}), RespArray(ElementsAre()));
 }
 
@@ -707,13 +716,13 @@ TEST_F(HSetFamilyTest, HTtl) {
               RespArray(ElementsAre(IntArg(-1), IntArg(-1), IntArg(-2))));
 
   // Set expiry and verify TTL
-  EXPECT_THAT(Run({"HEXPIRE", "key", "10", "FIELDS", "1", "k0"}), IntArg(1));
+  EXPECT_THAT(Run({"HEXPIRE", "key", "10", "FIELDS", "1", "k0"}), RespElementsAre(IntArg(1)));
   EXPECT_THAT(Run({"HTTL", "key", "FIELDS", "2", "k0", "k1"}),
               RespArray(ElementsAre(IntArg(10), IntArg(-1))));
 
   // Advance time and verify TTL decreases
   AdvanceTime(3000);
-  EXPECT_THAT(Run({"HTTL", "key", "FIELDS", "1", "k0"}), IntArg(7));
+  EXPECT_THAT(Run({"HTTL", "key", "FIELDS", "1", "k0"}), RespElementsAre(IntArg(7)));
 
   // Wrong type
   Run({"SET", "strkey", "val"});
@@ -777,7 +786,7 @@ TEST_F(HSetFamilyTest, EmptyHashBug) {
 
 TEST_F(HSetFamilyTest, ScanAfterExpireSet) {
   EXPECT_THAT(Run({"HSET", "aset", "afield", "avalue"}), IntArg(1));
-  EXPECT_THAT(Run({"HEXPIRE", "aset", "1", "FIELDS", "1", "afield"}), IntArg(1));
+  EXPECT_THAT(Run({"HEXPIRE", "aset", "1", "FIELDS", "1", "afield"}), RespElementsAre(IntArg(1)));
 
   const auto resp = Run({"HSCAN", "aset", "0", "count", "100"});
   EXPECT_THAT(resp, ArrLen(2));
@@ -792,7 +801,7 @@ TEST_F(HSetFamilyTest, ScanAfterExpireSet) {
 TEST_F(HSetFamilyTest, KeyRemovedWhenEmpty) {
   auto test_cmd = [&](const std::function<void()>& f, const std::string_view tag) {
     EXPECT_THAT(Run({"HSET", "a", "afield", "avalue"}), IntArg(1));
-    EXPECT_THAT(Run({"HEXPIRE", "a", "1", "FIELDS", "1", "afield"}), IntArg(1));
+    EXPECT_THAT(Run({"HEXPIRE", "a", "1", "FIELDS", "1", "afield"}), RespElementsAre(IntArg(1)));
     AdvanceTime(1000);
 
     EXPECT_THAT(Run({"EXISTS", "a"}), IntArg(1));
@@ -804,7 +813,11 @@ TEST_F(HSetFamilyTest, KeyRemovedWhenEmpty) {
   test_cmd([&] { EXPECT_THAT(Run({"HGETALL", "a"}), RespArray(ElementsAre())); }, "HGETALL");
   test_cmd([&] { EXPECT_THAT(Run({"HDEL", "a", "afield"}), IntArg(0)); }, "HDEL");
   test_cmd([&] { EXPECT_THAT(Run({"HSCAN", "a", "0"}).GetVec()[0], "0"); }, "HSCAN");
-  test_cmd([&] { EXPECT_THAT(Run({"HMGET", "a", "afield"}), ArgType(RespExpr::NIL)); }, "HMGET");
+  test_cmd(
+      [&] {
+        EXPECT_THAT(Run({"HMGET", "a", "afield"}), RespElementsAre(ArgType(RespExpr::NIL)));
+      },
+      "HMGET");
   test_cmd([&] { EXPECT_THAT(Run({"HEXISTS", "a", "afield"}), IntArg(0)); }, "HEXISTS");
   test_cmd([&] { EXPECT_THAT(Run({"HSTRLEN", "a", "afield"}), IntArg(0)); }, "HSTRLEN");
 }
@@ -860,7 +873,7 @@ TEST_F(HSetFamilyTest, HExpireZeroTTL_DeletesKey) {
   auto cleanup = absl::MakeCleanup([kRdbFile] { std::ignore = remove(kRdbFile); });
   Run({"HSET", "zombie", "f", "v"});
   auto resp = Run({"HEXPIRE", "zombie", "0", "FIELDS", "1", "f"});
-  EXPECT_THAT(resp, IntArg(2));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(2)));
   EXPECT_EQ(0, CheckedInt({"EXISTS", "zombie"}));
   EXPECT_EQ(Run({"SAVE", "RDB", kRdbFile}), "OK");
 }

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -398,16 +398,16 @@ TEST_F(JsonFamilyTest, StrLen) {
   /* Test simple response from only one value */
 
   resp = Run({"JSON.STRLEN", "json", "$.a.a"});
-  EXPECT_THAT(resp, IntArg(1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
 
   resp = Run({"JSON.STRLEN", "json", "$.a"});
-  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
+  EXPECT_THAT(resp, RespElementsAre(ArgType(RespExpr::NIL)));
 
   resp = Run({"JSON.STRLEN", "json", "$.a.*"});
-  EXPECT_THAT(resp, IntArg(1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
 
   resp = Run({"JSON.STRLEN", "json", "$.c.b"});
-  EXPECT_THAT(resp, IntArg(2));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(2)));
 
   resp = Run({"JSON.STRLEN", "non_existent_key", "$.c.b"});
   EXPECT_THAT(resp, ErrArg("no such key"));
@@ -481,22 +481,22 @@ TEST_F(JsonFamilyTest, ObjLen) {
   /* Test simple response from only one value */
 
   resp = Run({"JSON.OBJLEN", "json", "$.a"});
-  EXPECT_THAT(resp, IntArg(0));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(0)));
 
   resp = Run({"JSON.OBJLEN", "json", "$.a.*"});
   EXPECT_THAT(resp.GetVec(), IsEmpty());
 
   resp = Run({"JSON.OBJLEN", "json", "$.b"});
-  EXPECT_THAT(resp, IntArg(1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
 
   resp = Run({"JSON.OBJLEN", "json", "$.b.*"});
-  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
+  EXPECT_THAT(resp, RespElementsAre(ArgType(RespExpr::NIL)));
 
   resp = Run({"JSON.OBJLEN", "json", "$.c"});
-  EXPECT_THAT(resp, IntArg(2));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(2)));
 
   resp = Run({"JSON.OBJLEN", "json", "$.d"});
-  EXPECT_THAT(resp, IntArg(3));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(3)));
 
   resp = Run({"JSON.OBJLEN", "non_existent_key", "$.a"});
   EXPECT_THAT(resp, ErrArg("no such key"));
@@ -1216,7 +1216,7 @@ TEST_F(JsonFamilyTest, NumericOperationsResp2Resp3) {
   EXPECT_EQ(resp, "[2]");  // Currently returns string "[2]"
 
   resp = Run({"JSON.TYPE", "a", "$"});
-  EXPECT_EQ(resp, "integer");
+  EXPECT_THAT(resp, RespElementsAre("integer"));
 
   resp = Run({"JSON.TYPE", "a", "."});
   EXPECT_EQ(resp, "integer");
@@ -1233,17 +1233,17 @@ TEST_F(JsonFamilyTest, NumericOperationsResp2Resp3) {
 
   resp = Run({"JSON.NUMINCRBY", "a", "$", "1"});
   // In RESP3, this should return a proper array with integer: 1) (integer) 2
-  EXPECT_THAT(resp, IntArg(2));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(2)));
 
   resp = Run({"JSON.TYPE", "a", "$"});
-  EXPECT_THAT(resp, RespArray(ElementsAre("integer")));
+  EXPECT_THAT(resp, RespElementsAre(RespArray(ElementsAre("integer"))));
 
   resp = Run({"JSON.TYPE", "a", "."});
-  EXPECT_EQ(resp, "integer");
+  EXPECT_THAT(resp, RespElementsAre("integer"));
 
   resp = Run({"JSON.NUMMULTBY", "a", "$", "2"});
   // In RESP3, this should return a proper array with integer: 1) (integer) 4
-  EXPECT_THAT(resp, IntArg(4));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(4)));
 }
 
 TEST_F(JsonFamilyTest, Del) {
@@ -1431,13 +1431,13 @@ TEST_F(JsonFamilyTest, ObjKeys) {
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.OBJKEYS", "json", "$"});
-  EXPECT_THAT(resp.GetVec(), ElementsAre("a", "b", "c", "d", "e"));
+  EXPECT_THAT(resp, RespElementsAre(RespArray(ElementsAre("a", "b", "c", "d", "e"))));
 
   resp = Run({"JSON.OBJKEYS", "json", "$.a"});
-  EXPECT_THAT(resp.GetVec(), IsEmpty());
+  EXPECT_THAT(resp, RespElementsAre(RespArray(IsEmpty())));
 
   resp = Run({"JSON.OBJKEYS", "json", "$.b"});
-  EXPECT_THAT(resp.GetVec(), ElementsAre("a"));
+  EXPECT_THAT(resp, RespElementsAre(RespArray(ElementsAre("a"))));
 
   resp = Run({"JSON.OBJKEYS", "json", "$.*"});
   EXPECT_THAT(resp, ElementsAreArrays(IsEmpty(), ElementsAre("a"), ElementsAre("a", "b"),
@@ -1486,7 +1486,7 @@ TEST_F(JsonFamilyTest, ObjKeysLegacy) {
   EXPECT_THAT(resp.GetVec(), IsEmpty());
 
   resp = Run({"JSON.OBJKEYS", "json", ".b"});
-  EXPECT_THAT(resp, "a");
+  EXPECT_THAT(resp, RespElementsAre("a"));
 
   resp = Run({"JSON.OBJKEYS", "json", ".*"});
   EXPECT_THAT(resp.GetVec(), IsEmpty());
@@ -1526,7 +1526,7 @@ TEST_F(JsonFamilyTest, StrAppend) {
   /* Test simple response from only one value */
 
   resp = Run({"JSON.STRAPPEND", "json", "$.a.a", "\"ab\""});
-  EXPECT_THAT(resp, IntArg(3));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(3)));
 
   resp = Run({"JSON.GET", "json"});
   EXPECT_EQ(
@@ -1536,7 +1536,7 @@ TEST_F(JsonFamilyTest, StrAppend) {
   const char kVal[] = "\"a\"";
 
   resp = Run({"JSON.STRAPPEND", "json", "$.a.*", kVal});
-  EXPECT_THAT(resp, IntArg(4));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(4)));
 
   resp = Run({"JSON.GET", "json"});
   EXPECT_EQ(
@@ -1544,7 +1544,7 @@ TEST_F(JsonFamilyTest, StrAppend) {
       R"({"a":{"a":"aaba"},"b":{"a":"a","b":1},"c":{"a":"a","b":"bb"},"d":{"a":1,"b":"b","c":3}})");
 
   resp = Run({"JSON.STRAPPEND", "json", "$.c.b", kVal});
-  EXPECT_THAT(resp, IntArg(3));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(3)));
 
   resp = Run({"JSON.GET", "json"});
   EXPECT_EQ(
@@ -2011,13 +2011,13 @@ TEST_F(JsonFamilyTest, ArrPopOutOfRange) {
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.ARRPOP", "arr", "$", "-55"});
-  EXPECT_EQ(resp, "0");
+  EXPECT_THAT(resp, RespElementsAre("0"));
 
   resp = Run({"JSON.SET", "arr", "$", json});
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.ARRPOP", "arr", "$", "55"});
-  EXPECT_EQ(resp, "5");
+  EXPECT_THAT(resp, RespElementsAre("5"));
 
   // Test legacy mode
   resp = Run({"JSON.SET", "arr", ".", json});
@@ -2084,7 +2084,7 @@ TEST_F(JsonFamilyTest, ArrTrim) {
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.ARRTRIM", "json", "$", "2", "3"});
-  EXPECT_THAT(resp, IntArg(2));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(2)));
 
   resp = Run({"JSON.GET", "json"});
   EXPECT_EQ(resp, R"([3,4])");
@@ -2163,42 +2163,42 @@ TEST_F(JsonFamilyTest, ArrTrimOutOfRange) {
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.ARRTRIM", "arr", "$", "-1", "3"});
-  EXPECT_THAT(resp, IntArg(0));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(0)));
   EXPECT_EQ(Run({"JSON.GET", "arr"}), "[]");
 
   resp = Run({"JSON.SET", "arr", "$", arr});
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.ARRTRIM", "arr", "$", "54", "55"});
-  EXPECT_THAT(resp, IntArg(0));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(0)));
   EXPECT_EQ(Run({"JSON.GET", "arr"}), "[]");
 
   resp = Run({"JSON.SET", "arr", "$", arr});
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.ARRTRIM", "arr", "$", "56", "55"});
-  EXPECT_THAT(resp, IntArg(0));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(0)));
   EXPECT_EQ(Run({"JSON.GET", "arr"}), "[]");
 
   resp = Run({"JSON.SET", "arr", "$", arr});
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.ARRTRIM", "arr", "$", "-55", "-55"});
-  EXPECT_THAT(resp, IntArg(1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
   EXPECT_EQ(Run({"JSON.GET", "arr"}), "[0]");
 
   resp = Run({"JSON.SET", "arr", "$", arr});
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.ARRTRIM", "arr", "$", "-2", "-1"});
-  EXPECT_THAT(resp, IntArg(2));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(2)));
   EXPECT_EQ(Run({"JSON.GET", "arr"}), "[3,4]");
 
   resp = Run({"JSON.SET", "arr", "$", arr});
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.ARRTRIM", "arr", "$", "-1", "-2"});
-  EXPECT_THAT(resp, IntArg(0));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(0)));
   EXPECT_EQ(Run({"JSON.GET", "arr"}), "[]");
 }
 
@@ -2239,7 +2239,7 @@ TEST_F(JsonFamilyTest, ArrInsert) {
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.ARRINSERT", "json", "$.a", "0", R"("c")"});
-  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
+  EXPECT_THAT(resp, RespElementsAre(ArgType(RespExpr::NIL)));
 }
 
 TEST_F(JsonFamilyTest, ArrInsertLegacy) {
@@ -2300,7 +2300,7 @@ TEST_F(JsonFamilyTest, ArrInsertOutOfRange) {
   EXPECT_THAT(resp, ErrArg("index out of range"));
 
   resp = Run({"JSON.ARRINSERT", "arr", "$", "0", "2"});
-  EXPECT_THAT(resp, IntArg(1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
 
   resp = Run({"JSON.GET", "arr"});
   EXPECT_EQ(resp, "[2]");
@@ -2402,10 +2402,10 @@ TEST_F(JsonFamilyTest, ArrIndex) {
       {"JSON.SET", "json", ".", R"({"key" : ["Alice", "Bob", "Carol", "David", "Eve", "Frank"]})"});
   ASSERT_EQ(resp, "OK");
   resp = Run({"JSON.ARRINDEX", "json", "$.key", R"("Bob")"});
-  EXPECT_THAT(resp, IntArg(1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
 
   resp = Run({"JSON.ARRINDEX", "json", "$.key", R"("Bob")", "1", "2"});
-  EXPECT_THAT(resp, IntArg(1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
 }
 
 TEST_F(JsonFamilyTest, ArrIndexLegacy) {
@@ -2445,10 +2445,10 @@ TEST_F(JsonFamilyTest, ArrIndexWithNumericValues) {
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.ARRINDEX", "json", "$", "3"});
-  EXPECT_THAT(resp, IntArg(2));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(2)));
 
   resp = Run({"JSON.ARRINDEX", "json", "$", "3.0"});
-  EXPECT_THAT(resp, IntArg(1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
 
   json = R"(
     [[1, 2, 3], [1.0, 2.0, 3.0], 2.0, [1,2,3]]
@@ -2458,10 +2458,10 @@ TEST_F(JsonFamilyTest, ArrIndexWithNumericValues) {
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.ARRINDEX", "json", "$", "[1,2,3]"});
-  EXPECT_THAT(resp, IntArg(0));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(0)));
 
   resp = Run({"JSON.ARRINDEX", "json", "$", "[1.0,2.0,3.0]"});
-  EXPECT_THAT(resp, IntArg(1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
 
   json = R"(
     [{"a":2},{"a":2.0},2.0]
@@ -2471,10 +2471,10 @@ TEST_F(JsonFamilyTest, ArrIndexWithNumericValues) {
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.ARRINDEX", "json", "$", R"({"a":2})"});
-  EXPECT_THAT(resp, IntArg(0));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(0)));
 
   resp = Run({"JSON.ARRINDEX", "json", "$", R"({"a":2.0})"});
-  EXPECT_THAT(resp, IntArg(1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
 
   json = R"(
     [{"arr":[1,2,3],"number":2},{"arr":[1.0,2.0,3.0],"number":2.0},2]
@@ -2484,16 +2484,16 @@ TEST_F(JsonFamilyTest, ArrIndexWithNumericValues) {
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.ARRINDEX", "json", "$", R"({"arr":[1,2,3],"number":2})"});
-  EXPECT_THAT(resp, IntArg(0));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(0)));
 
   resp = Run({"JSON.ARRINDEX", "json", "$", R"({"arr":[1.0,2.0,3.0],"number":2.0})"});
-  EXPECT_THAT(resp, IntArg(1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
 
   resp = Run({"JSON.ARRINDEX", "json", "$", R"({"arr":[1,2,3],"number":2.0})"});
-  EXPECT_THAT(resp, IntArg(-1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(-1)));
 
   resp = Run({"JSON.ARRINDEX", "json", "$", R"({"arr":[1.0,2.0,3.0],"number":2})"});
-  EXPECT_THAT(resp, IntArg(-1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(-1)));
 }
 
 TEST_F(JsonFamilyTest, ArrIndexWithNumericValuesLegacy) {
@@ -2535,31 +2535,31 @@ TEST_F(JsonFamilyTest, ArrIndexOutOfRange) {
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.ARRINDEX", "arr", "$", "1", "-55", "-55"});
-  EXPECT_THAT(resp, IntArg(-1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(-1)));
 
   resp = Run({"JSON.ARRINDEX", "arr", "$", "1", "-55", "-56"});
-  EXPECT_THAT(resp, IntArg(-1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(-1)));
 
   resp = Run({"JSON.ARRINDEX", "arr", "$", "1", "-55", "-54"});
-  EXPECT_THAT(resp, IntArg(-1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(-1)));
 
   resp = Run({"JSON.ARRINDEX", "arr", "$", "1", "-2"});
-  EXPECT_THAT(resp, IntArg(3));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(3)));
 
   resp = Run({"JSON.ARRINDEX", "arr", "$", "1", "-2", "-1"});
-  EXPECT_THAT(resp, IntArg(3));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(3)));
 
   resp = Run({"JSON.ARRINDEX", "arr", "$", "1", "-2", "-3"});
-  EXPECT_THAT(resp, IntArg(-1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(-1)));
 
   resp = Run({"JSON.ARRINDEX", "arr", "$", "1", "55", "56"});
-  EXPECT_THAT(resp, IntArg(4));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(4)));
 
   resp = Run({"JSON.ARRINDEX", "arr", "$", "1", "55", "54"});
-  EXPECT_THAT(resp, IntArg(4));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(4)));
 
   resp = Run({"JSON.ARRINDEX", "arr", "$", "1", "5", "4"});
-  EXPECT_THAT(resp, IntArg(-1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(-1)));
 }
 
 TEST_F(JsonFamilyTest, MGet) {
@@ -2670,7 +2670,7 @@ TEST_F(JsonFamilyTest, DebugFields) {
                                          IntArg(0), IntArg(0), IntArg(2), IntArg(3)));
 
   resp = Run({"JSON.DEBUG", "fields", "json1", "$"});
-  EXPECT_THAT(resp, IntArg(14));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(14)));
 
   json = R"(
     [[1,2,3, [4,5,6,[6,7,8]]], {"a": {"b": {"c": 1337}}}]
@@ -2684,7 +2684,7 @@ TEST_F(JsonFamilyTest, DebugFields) {
   EXPECT_THAT(resp.GetVec(), ElementsAre(IntArg(11), IntArg(3)));
 
   resp = Run({"JSON.DEBUG", "fields", "json1", "$"});
-  EXPECT_THAT(resp, IntArg(16));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(16)));
 
   json = R"({"a":1, "b":2, "c":{"k1":1,"k2":2}})";
 
@@ -2692,10 +2692,10 @@ TEST_F(JsonFamilyTest, DebugFields) {
   ASSERT_THAT(resp, "OK");
 
   resp = Run({"JSON.DEBUG", "FIELDS", "obj_doc", "$.a"});
-  EXPECT_THAT(resp, IntArg(1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
 
   resp = Run({"JSON.DEBUG", "fields", "obj_doc", "$.a"});
-  EXPECT_THAT(resp, IntArg(1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
 }
 
 TEST_F(JsonFamilyTest, DebugFieldsLegacy) {
@@ -2759,20 +2759,20 @@ TEST_F(JsonFamilyTest, DebugMemory) {
   EXPECT_GT(resp.GetVec()[8].GetInt(), 0);
 
   resp = Run({"JSON.DEBUG", "memory", "json1", "$"});
-  EXPECT_GT(resp.GetInt(), 0);
+  EXPECT_GT(resp.GetVec()[0].GetInt().value_or(0), 0);
 
   resp = Run({"JSON.SET", "bigstr", "$",
               R"({"text":"This is a longer string that should definitely exceed SSO buffer"})"});
   EXPECT_EQ(resp, "OK");
   resp = Run({"JSON.DEBUG", "memory", "bigstr", "$.text"});
-  EXPECT_GT(resp.GetInt(), 0);
+  EXPECT_GT(resp.GetVec()[0].GetInt().value_or(0), 0);
 
   resp = Run({"JSON.SET", "obj_doc", "$", R"({"num":42, "obj":{"k1":1,"k2":2}})"});
   EXPECT_EQ(resp, "OK");
   resp = Run({"JSON.DEBUG", "MEMORY", "obj_doc", "$.num"});
-  EXPECT_EQ(resp.GetInt(), 0);
+  EXPECT_EQ(resp.GetVec()[0].GetInt().value_or(-1), 0);
   resp = Run({"JSON.DEBUG", "memory", "obj_doc", "$.obj"});
-  EXPECT_GT(resp.GetInt(), 0);
+  EXPECT_GT(resp.GetVec()[0].GetInt().value_or(0), 0);
 }
 
 TEST_F(JsonFamilyTest, DebugMemoryLegacy) {
@@ -2826,13 +2826,13 @@ TEST_F(JsonFamilyTest, Resp) {
   EXPECT_THAT(resp.GetVec(), ElementsAre("New York", "NY", "21 2nd Street", "10021-3100"));
 
   resp = Run({"JSON.RESP", "json", "$.isAlive"});
-  EXPECT_THAT(resp, "true");
+  EXPECT_THAT(resp, RespElementsAre("true"));
 
   resp = Run({"JSON.RESP", "json", "$.age"});
-  EXPECT_THAT(resp, IntArg(27));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(27)));
 
   resp = Run({"JSON.RESP", "json", "$.weight"});
-  EXPECT_THAT(resp, "135.25");
+  EXPECT_THAT(resp, RespElementsAre("135.25"));
 }
 
 TEST_F(JsonFamilyTest, RespLegacy) {

--- a/src/server/list_family_test.cc
+++ b/src/server/list_family_test.cc
@@ -282,7 +282,7 @@ TEST_F(ListFamilyTest, BLPopTimeout) {
   Run({"blpop", kKey1, "0"});
   resp = Run({"exec"});
 
-  EXPECT_THAT(resp, ArgType(RespExpr::NIL_ARRAY));
+  EXPECT_THAT(resp, RespElementsAre(ArgType(RespExpr::NIL_ARRAY)));
   ASSERT_FALSE(IsLocked(0, kKey1));
   ASSERT_EQ(0, NumWatched());
 }
@@ -482,7 +482,7 @@ TEST_F(ListFamilyTest, LRem) {
   ASSERT_THAT(Run({"lpush", kKey3, "bar", "bar", "foo"}), IntArg(3));
   ASSERT_THAT(Run({"lrem", kKey3, "-2", "bar"}), IntArg(2));
   resp = Run({"lrange", kKey3, "0", "-1"});
-  ASSERT_EQ(resp, "foo");
+  ASSERT_THAT(resp, RespElementsAre("foo"));
 }
 
 TEST_F(ListFamilyTest, DumpRestorePlain) {
@@ -491,7 +491,7 @@ TEST_F(ListFamilyTest, DumpRestorePlain) {
   auto buffer = Run({"DUMP", kKey1}).GetBuf();
   EXPECT_EQ(Run({"RESTORE", kKey2, "0", ToSV(buffer)}), "OK");
   EXPECT_EQ(CheckedInt({"LLEN", kKey2}), 1);
-  EXPECT_EQ(Run({"LRANGE", kKey2, "0", "1"}), kValue);
+  EXPECT_THAT(Run({"LRANGE", kKey2, "0", "1"}), RespElementsAre(kValue));
 }
 
 TEST_F(ListFamilyTest, LTrim) {
@@ -501,7 +501,7 @@ TEST_F(ListFamilyTest, LTrim) {
   ASSERT_THAT(resp, ArrLen(2));
   ASSERT_THAT(resp.GetVec(), ElementsAre("c", "d"));
   ASSERT_EQ(Run({"ltrim", kKey1, "0", "0"}), "OK");
-  ASSERT_EQ(Run({"lrange", kKey1, "0", "1"}), "c");
+  ASSERT_THAT(Run({"lrange", kKey1, "0", "1"}), RespElementsAre("c"));
   Run({"set", "foo", "bar"});
   ASSERT_THAT(Run({"ltrim", "foo", "0", "1"}), ErrArg("WRONGTYPE"));
   ASSERT_EQ(Run({"ltrim", "nexists", "0", "1"}), "OK");
@@ -659,7 +659,7 @@ TEST_F(ListFamilyTest, LMove) {
   ASSERT_THAT(resp, "4");
 
   resp = Run({"lrange", kKey1, "0", "-1"});
-  ASSERT_EQ(resp, "3");
+  ASSERT_THAT(resp, RespElementsAre("3"));
 
   resp = Run({"lrange", kKey2, "0", "-1"});
   ASSERT_THAT(resp, ArrLen(4));
@@ -778,7 +778,7 @@ TEST_F(ListFamilyTest, BRPopLPushSingleShard) {
   Run({"multi"});
   Run({"brpoplpush", "y", "x", "0"});
   RespExpr resp = Run({"exec"});
-  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
+  EXPECT_THAT(resp, RespElementsAre(ArgType(RespExpr::NIL)));
   ASSERT_FALSE(IsLocked(0, "x"));
   ASSERT_FALSE(IsLocked(0, "y"));
   ASSERT_EQ(0, NumWatched());
@@ -873,7 +873,7 @@ TEST_F(ListFamilyTest, BRPopLPushTwoShards) {
   Run({"lpush", "x", "val"});
   EXPECT_EQ(Run({"brpoplpush", "x", "z", "0"}), "val");
   resp = Run({"lrange", "z", "0", "-1"});
-  ASSERT_EQ(resp, "val");
+  ASSERT_THAT(resp, RespElementsAre("val"));
   Run({"del", "z"});
   ASSERT_EQ(0, NumWatched());
 
@@ -967,7 +967,7 @@ TEST_F(ListFamilyTest, BLMoveRings) {
 
   for (int i = 1; i < 10; i++)
     EXPECT_THAT(Run({"llen", to_string(i)}), IntArg(0));
-  EXPECT_EQ(Run({"lrange", "0", "0", "-1"}), "v1");
+  EXPECT_THAT(Run({"lrange", "0", "0", "-1"}), RespElementsAre("v1"));
 }
 
 // Move in waves where each wave layer has a fixed set of "vertices" through which all values travel
@@ -1056,7 +1056,7 @@ TEST_F(ListFamilyTest, LPushX) {
   EXPECT_THAT(Run({"llen", kKey1}), IntArg(0));
 
   EXPECT_THAT(Run({"lpush", kKey1, "val1"}), IntArg(1));
-  EXPECT_THAT(Run({"lrange", kKey1, "0", "-1"}), "val1");
+  EXPECT_THAT(Run({"lrange", kKey1, "0", "-1"}), RespElementsAre("val1"));
 
   EXPECT_THAT(Run({"lpushx", kKey1, "val2"}), IntArg(2));
   EXPECT_THAT(Run({"lrange", kKey1, "0", "-1"}).GetVec(), ElementsAre("val2", "val1"));
@@ -1068,7 +1068,7 @@ TEST_F(ListFamilyTest, RPushX) {
   EXPECT_THAT(Run({"llen", kKey1}), IntArg(0));
 
   EXPECT_THAT(Run({"rpush", kKey1, "val1"}), IntArg(1));
-  EXPECT_THAT(Run({"lrange", kKey1, "0", "-1"}), "val1");
+  EXPECT_THAT(Run({"lrange", kKey1, "0", "-1"}), RespElementsAre("val1"));
 
   EXPECT_THAT(Run({"rpushx", kKey1, "val2"}), IntArg(2));
   EXPECT_THAT(Run({"lrange", kKey1, "0", "-1"}).GetVec(), ElementsAre("val1", "val2"));

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -96,7 +96,7 @@ TEST_F(MultiTest, MultiWithError) {
 
   EXPECT_THAT(Run({"multi"}), "OK");
   EXPECT_THAT(Run({"set", "z", "y"}), "QUEUED");
-  EXPECT_THAT(Run({"exec"}), "OK");
+  EXPECT_THAT(Run({"exec"}), RespElementsAre("OK"));
 
   EXPECT_THAT(Run({"get", "x"}), ArgType(RespExpr::NIL));
   EXPECT_THAT(Run({"get", "z"}), "y");
@@ -247,12 +247,12 @@ TEST_F(MultiTest, MultiEmpty) {
   Run({"multi"});
   ASSERT_EQ(Run({"ping", "foo"}), "QUEUED");
   resp = Run({"exec"});
-  EXPECT_EQ(resp, "foo");
+  EXPECT_THAT(resp, RespElementsAre("foo"));
 
   Run({"multi"});
   Run({"set", "a", ""});
   resp = Run({"exec"});
-  EXPECT_EQ(resp, "OK");
+  EXPECT_THAT(resp, RespElementsAre("OK"));
 
   resp = Run({"get", "a"});
   EXPECT_EQ(resp, "");
@@ -432,7 +432,7 @@ TEST_F(MultiTest, MultiRename) {
   resp = Run({"rename", kKey4, kKey2});
   ASSERT_EQ(resp, "QUEUED");
   resp = Run({"exec"});
-  EXPECT_EQ(resp, "OK");
+  EXPECT_THAT(resp, RespElementsAre("OK"));
 
   EXPECT_FALSE(IsLocked(0, kKey1));
   EXPECT_FALSE(IsLocked(0, kKey2));
@@ -445,7 +445,7 @@ TEST_F(MultiTest, MultiWithoutTx) {
   Run({"multi"});
   Run({"ping"});
   auto resp = Run({"exec"});
-  EXPECT_EQ(resp, "PONG");
+  EXPECT_THAT(resp, RespElementsAre("PONG"));
 
   // EVAL without keys and default script flags should be non-transactional
   Run({"multi"});
@@ -480,7 +480,7 @@ TEST_F(MultiTest, MultiCommandsWithBonusKeys) {
   Run({"multi"});
   Run({"zinterstore", "ze", "2", "za", "zb", "z one extra"});
   resp = Run({"exec"});
-  EXPECT_THAT(resp, ErrArg("syntax error"));
+  EXPECT_THAT(resp, RespElementsAre(ErrArg("syntax error")));
 }
 
 TEST_F(MultiTest, MultiHop) {
@@ -590,7 +590,7 @@ TEST_F(MultiTest, Eval) {
   EXPECT_EQ(resp, "OK");
 
   resp = Run({"hvals", "hmap"});
-  EXPECT_EQ(resp, "2222");
+  EXPECT_THAT(resp, RespElementsAre("2222"));
 
   Run({"sadd", "s1", "a", "b"});
   Run({"sadd", "s2", "a", "c"});
@@ -998,7 +998,7 @@ TEST_F(MultiTest, UndeclaredKeyFlag) {
 
   // Clear all Lua scripts so we can configure the cache
   EXPECT_THAT(Run({"script", "flush"}), "OK");
-  EXPECT_THAT(Run({"script", "exists", sha}), IntArg(0));
+  EXPECT_THAT(Run({"script", "exists", sha}), RespElementsAre(IntArg(0)));
 
   EXPECT_THAT(
       Run({"config", "set", "lua_undeclared_keys_shas", absl::StrCat(sha, ",NON-EXISTING-HASH")}),
@@ -1459,7 +1459,7 @@ TEST_F(MultiEvalTest, MultiAndEval) {
   Run({"multi"});
   Run({"eval", "return 'OK';", "0"});
   auto resp = Run({"exec"});
-  EXPECT_EQ(resp, "OK");
+  EXPECT_THAT(resp, RespElementsAre("OK"));
 
   // We had a bug running script load inside multi
   Run({"multi"});

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -194,9 +194,10 @@ TEST_F(RdbTest, Stream) {
                               "1655444851523-1", "entries-read", kMatchNil, "lag", kMatchNil));
 
   resp = Run({"xinfo", "groups", "key:1"});  // test dereferences array of size 1
-  EXPECT_THAT(resp, RespElementsAre("name", "g2", "consumers", IntArg(0), "pending", IntArg(0),
-                                    "last-delivered-id", "1655444851523-1", "entries-read",
-                                    kMatchNil, "lag", kMatchNil));
+  EXPECT_THAT(resp,
+              RespElementsAre(RespElementsAre("name", "g2", "consumers", IntArg(0), "pending",
+                                              IntArg(0), "last-delivered-id", "1655444851523-1",
+                                              "entries-read", kMatchNil, "lag", kMatchNil)));
 
   resp = Run({"xinfo", "groups", "key:2"});
   EXPECT_THAT(resp, ArrLen(0));
@@ -1195,8 +1196,7 @@ TEST_F(RdbTest, TopkSerializationEmptyEdgeCase) {
   // After loading an empty TOPK, adding items must work correctly.
   Run({"TOPK.INCRBY", "topk_empty", "new_item", "100"});
   resp = Run({"TOPK.LIST", "topk_empty"});
-  // Run() unwraps single-element arrays to a scalar string
-  EXPECT_EQ(resp, "new_item");
+  EXPECT_THAT(resp, RespElementsAre("new_item"));
 }
 
 // Tests that the decay parameter (double) is correctly serialized using SaveBinaryDouble/

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -57,7 +57,7 @@ class SearchFamilyTest : public BaseFamilyTest {
  protected:
 };
 
-const auto kNoResults = IntArg(0);  // tests auto destruct single element arrays
+const auto kNoResults = RespElementsAre(IntArg(0));
 
 /* Asserts that response is array of two arrays. Used to test FT.PROFILE response */
 ::testing::AssertionResult AssertArrayOfTwoArrays(const RespExpr& resp) {
@@ -81,20 +81,21 @@ const auto kNoResults = IntArg(0);  // tests auto destruct single element arrays
 #define ASSERT_ARRAY_OF_TWO_ARRAYS(resp) ASSERT_PRED1(AssertArrayOfTwoArrays, resp)
 
 MATCHER_P2(DocIds, total, arg_ids, "") {
-  if (arg_ids.empty()) {
-    if (auto res = arg.GetInt(); !res || *res != 0) {
-      *result_listener << "Expected single zero";
-      return false;
-    }
-    return true;
-  }
-
   if (arg.type != RespExpr::ARRAY) {
     *result_listener << "Wrong response type: " << int(arg.type);
     return false;
   }
 
   auto results = arg.GetVec();
+
+  if (arg_ids.empty()) {
+    if (results.size() != 1 || !results[0].GetInt() || *results[0].GetInt() != 0) {
+      *result_listener << "Expected single zero";
+      return false;
+    }
+    return true;
+  }
+
   if (results.size() != arg_ids.size() * 2 + 1) {
     *result_listener << "Wrong resp vec size: " << results.size();
     return false;
@@ -246,7 +247,7 @@ TEST_F(SearchFamilyTest, CreateDropListIndex) {
   EXPECT_THAT(Run({"ft.dropindex", "idx-100"}), ErrArg("Index with name 'idx-100' not found"));
 
   EXPECT_EQ(Run({"ft.dropindex", "idx-1"}), "OK");
-  EXPECT_EQ(Run({"ft._list"}), "idx-3");
+  EXPECT_THAT(Run({"ft._list"}), RespElementsAre("idx-3"));
 }
 
 TEST_F(SearchFamilyTest, CreateDropDifferentDatabases) {
@@ -270,7 +271,7 @@ TEST_F(SearchFamilyTest, CreateDropDifferentDatabases) {
 
   // Search from db 1 should return 0 results (only db 0 is indexed)
   resp = Run({"ft.search", "idx-1", "*"});
-  EXPECT_THAT(resp, IntArg(0));
+  EXPECT_THAT(resp, kNoResults);
 
   // ft.dropindex must work from another database
   EXPECT_EQ(Run({"ft.dropindex", "idx-1"}), "OK");
@@ -505,11 +506,11 @@ TEST_F(SearchFamilyTest, Indexing) {
   EXPECT_GT(iterations, 0u);  // ensure we observed indexing-in-progress state at least once
 
   auto resp = Run({"ft.search", "i1", "@v1:[10 20]", "LIMIT", "0", "0"});
-  EXPECT_THAT(resp, IntArg(110));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(110)));
 
   // check added with alter field v2 is fully indexed
   resp = Run({"ft.search", "i1", "@v2:[0 10000]", "LIMIT", "0", "0"});
-  EXPECT_THAT(resp, IntArg(kNumDocs));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(kNumDocs)));
 }
 
 TEST_F(SearchFamilyTest, Simple) {
@@ -848,7 +849,7 @@ TEST_F(SearchFamilyTest, TestLimit) {
   EXPECT_THAT(resp, ArrLen(10 * 2 + 1));
 
   resp = Run({"ft.search", "i1", "all", "limit", "0", "0"});
-  EXPECT_THAT(resp, IntArg(20));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(20)));
 
   resp = Run({"ft.search", "i1", "all", "limit", "0", "5"});
   EXPECT_THAT(resp, ArrLen(5 * 2 + 1));
@@ -2047,7 +2048,7 @@ TEST_F(SearchFamilyTest, KnnSearchOptions) {
   // KNN 11929939, LIMIT 4 2
   resp = Run({"FT.SEARCH", "my_index", "*=>[KNN 11929939 @vector $query_vector]", "PARAMS", "2",
               "query_vector", query_vector, "LIMIT", "4", "2"});
-  EXPECT_THAT(resp, IntArg(3));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(3)));
 
   // KNN 11929939, LIMIT 0 10
   resp = Run({"FT.SEARCH", "my_index", "*=>[KNN 11929939 @vector $query_vector]", "PARAMS", "2",
@@ -3248,7 +3249,7 @@ TEST_F(SearchFamilyTest, AggregateWithLoadFromNoMatches) {
       Run({"ft.aggregate", "idx1", "*", "LOAD", "4", "idx1.num1", "idx1.str1", "idx2.num2",
            "idx2.str2", "LOAD_FROM", "idx2", "2", "idx2.num2=idx1.num1", "idx2.str2=idx1.str1"});
 
-  EXPECT_THAT(resp, IntArg(0));  // No matches, so result should be empty
+  EXPECT_THAT(resp, RespElementsAre(IntArg(0)));  // No matches, so result should be empty
 }
 
 TEST_F(SearchFamilyTest, AggregateWithLoadFromQueries) {
@@ -3322,7 +3323,7 @@ TEST_F(SearchFamilyTest, AggregateWithLoadFromSyntaxErrors) {
   // Test when index does not exist
   EXPECT_THAT(Run({"ft.aggregate", "idx1", "*", "LOAD", "2", "idx1.num1", "idx1.str1", "LOAD_FROM",
                    "idx4", "1", "idx4.num2=idx1.num1"}),
-              IntArg(0));
+              RespElementsAre(IntArg(0)));
 
   // Test when index exists but no LOAD_FROM is specified
   EXPECT_THAT(Run({"ft.aggregate", "idx1", "*", "LOAD", "2", "idx1.num1", "idx1.str1", "LOAD_FROM",
@@ -3345,15 +3346,15 @@ TEST_F(SearchFamilyTest, AggregateWithLoadFromSyntaxErrors) {
   // Test when field of index does not exist
   EXPECT_THAT(Run({"ft.aggregate", "idx1", "*", "LOAD", "2", "idx1.num1", "idx1.str1", "LOAD_FROM",
                    "idx2", "1", "idx2.num2=idx1.nonexistent_field"}),
-              IntArg(0));
+              RespElementsAre(IntArg(0)));
   EXPECT_THAT(Run({"ft.aggregate", "idx1", "*", "LOAD", "2", "idx1.num1", "idx1.str1", "LOAD_FROM",
                    "idx2", "1", "idx2.nonexistent_field=idx1.num1"}),
-              IntArg(0));
+              RespElementsAre(IntArg(0)));
 
   // Test when field in QUERY does not exist in index
   EXPECT_THAT(Run({"ft.aggregate", "idx1", "*", "LOAD", "2", "idx1.num1", "idx1.str1", "LOAD_FROM",
                    "idx2", "1", "idx2.num2=idx1.num1", "QUERY", "@nonexistent_tag:{tag1|tag2}"}),
-              IntArg(0));
+              RespElementsAre(IntArg(0)));
 
   // Test when field in LOAD does not exist in index
   EXPECT_THAT(Run({"ft.aggregate", "idx1", "*", "LOAD", "2", "idx1.num1", "idx1.non_existent_field",
@@ -3552,8 +3553,9 @@ TEST_F(SearchFamilyTest, MAXSEARCHRESULTS) {
   EXPECT_THAT(resp, IsArray("MAXSEARCHRESULTS", "1"));
 
   resp = Run({"FT.CONFIG", "HELP", "MAXSEARCHRESULTS"});
-  EXPECT_THAT(resp, IsArray("MAXSEARCHRESULTS", "Description",
-                            "Maximum number of results from ft.search command", "Value", "1"));
+  EXPECT_THAT(resp, RespElementsAre(IsArray("MAXSEARCHRESULTS", "Description",
+                                            "Maximum number of results from ft.search command",
+                                            "Value", "1")));
 
   resp = Run({"FT.CONFIG", "GET", "*"});
   // Should contain MAXSEARCHRESULTS among other search config parameters
@@ -3728,7 +3730,7 @@ TEST_F(SearchFamilyTest, HsetOnDifferentDatabasesCrash) {
 
   // Search on database 1 should return no results (only db 0 is indexed)
   auto resp = Run({"FT.SEARCH", "idx", "another_value"});
-  EXPECT_THAT(resp, IntArg(0));
+  EXPECT_THAT(resp, kNoResults);
 
   // Switch back to database 0
   EXPECT_THAT(Run({"SELECT", "0"}), "OK");
@@ -3809,12 +3811,12 @@ TEST_F(SearchFamilyTest, KnnHnsw) {
 
   resp = Run({"FT.SEARCH", "knn_idx", "@even:{maybe} => [KNN 3 @pos $vec]", "PARAMS", "2", "vec",
               query_vec});
-  EXPECT_THAT(resp, IntArg(0));
+  EXPECT_THAT(resp, kNoResults);
 
   // Verify that empty prefilter return zero results
   resp = Run({"FT.SEARCH", "knn_idx", "@even:{non_existing} => [KNN 3 @pos $vec]", "PARAMS", "2",
               "vec", query_vec});
-  EXPECT_THAT(resp, IntArg(0));
+  EXPECT_THAT(resp, kNoResults);
 }
 
 TEST_F(SearchFamilyTest, KnnHnswCosineDistanceCalculation) {
@@ -4573,7 +4575,7 @@ TEST_F(SearchFamilyTest, VectorRangeAggregate) {
   resp = Run({"FT.AGGREGATE", "idx", "@vec:[VECTOR_RANGE 0.1 $vec]=>{$YIELD_DISTANCE_AS: dist}",
               "PARAMS", "2", "vec", far_vec, "GROUPBY", "1", "@route", "REDUCE", "COUNT", "0", "AS",
               "cnt"});
-  EXPECT_THAT(resp, IntArg(0));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(0)));
 }
 
 TEST_F(SearchFamilyTest, HnswVectorRangeAggregate) {
@@ -4625,7 +4627,7 @@ TEST_F(SearchFamilyTest, HnswVectorRangeAggregate) {
   resp = Run({"FT.AGGREGATE", "idx", "@pos:[VECTOR_RANGE 0.1 $vec]=>{$YIELD_DISTANCE_AS: dist}",
               "PARAMS", "2", "vec", far_vec, "GROUPBY", "1", "@route", "REDUCE", "COUNT", "0", "AS",
               "cnt"});
-  EXPECT_THAT(resp, IntArg(0));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(0)));
 }
 
 TEST_F(SearchFamilyTest, GeoIndexFieldValidation) {
@@ -4970,7 +4972,7 @@ TEST_F(SearchFamilyTest, FtAggregateFilterEmptyResult) {
                    "FILTER", "@total > 100"});
   // clang-format on
   // When all rows are filtered out, FT.AGGREGATE returns integer 0
-  EXPECT_THAT(resp, IntArg(0));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(0)));
 }
 
 TEST_F(SearchFamilyTest, FtAggregateFilterPipelineOrder) {

--- a/src/server/set_family_test.cc
+++ b/src/server/set_family_test.cc
@@ -187,8 +187,7 @@ TEST_F(SetFamilyTest, SPop) {
 
   Run({"sadd", "y", "a", "b", "c"});
   resp = Run({"spop", "y", "1"});
-  EXPECT_THAT(resp, ArgType(RespExpr::STRING));
-  EXPECT_THAT(resp, testing::AnyOf("a", "b", "c"));
+  EXPECT_THAT(resp, RespElementsAre(testing::AnyOf("a", "b", "c")));
 
   resp = Run({"smembers", "y"});
   ASSERT_THAT(resp, ArrLen(2));
@@ -220,8 +219,7 @@ TEST_F(SetFamilyTest, SRandMember) {
   EXPECT_THAT(resp, AnyOf("1", "2", "3"));
 
   resp = Run({"SRandMember", "x", "1"});
-  ASSERT_THAT(resp, ArgType(RespExpr::STRING));
-  EXPECT_THAT(resp, AnyOf("1", "2", "3"));
+  EXPECT_THAT(resp, RespElementsAre(AnyOf("1", "2", "3")));
 
   resp = Run({"SRandMember", "x", "2"});
   ASSERT_THAT(resp, ArrLen(2));
@@ -238,8 +236,7 @@ TEST_F(SetFamilyTest, SRandMember) {
 
   // Test if count < 0 (IntSet)
   resp = Run({"SRandMember", "x", "-1"});
-  ASSERT_THAT(resp, ArgType(RespExpr::STRING));
-  EXPECT_THAT(resp, AnyOf("1", "2", "3"));
+  EXPECT_THAT(resp, RespElementsAre(AnyOf("1", "2", "3")));
 
   resp = Run({"SRandMember", "x", "-2"});
   ASSERT_THAT(resp, ArrLen(2));
@@ -263,8 +260,7 @@ TEST_F(SetFamilyTest, SRandMember) {
   EXPECT_THAT(resp, AnyOf("a", "b", "c"));
 
   resp = Run({"SRandMember", "y", "1"});
-  ASSERT_THAT(resp, ArgType(RespExpr::STRING));
-  EXPECT_THAT(resp, AnyOf("a", "b", "c"));
+  EXPECT_THAT(resp, RespElementsAre(AnyOf("a", "b", "c")));
 
   resp = Run({"SRandMember", "y", "2"});
   ASSERT_THAT(resp, ArrLen(2));
@@ -281,8 +277,7 @@ TEST_F(SetFamilyTest, SRandMember) {
 
   // Test if count < 0 (StrSet)
   resp = Run({"SRandMember", "y", "-1"});
-  ASSERT_THAT(resp, ArgType(RespExpr::STRING));
-  EXPECT_THAT(resp, AnyOf("a", "b", "c"));
+  EXPECT_THAT(resp, RespElementsAre(AnyOf("a", "b", "c")));
 
   resp = Run({"SRandMember", "y", "-2"});
   ASSERT_THAT(resp, ArrLen(2));
@@ -336,10 +331,10 @@ TEST_F(SetFamilyTest, SMIsMember) {
   EXPECT_THAT(resp, RespArray(ElementsAre(IntArg(0), IntArg(0))));
 
   resp = Run({"smismember", "foo", "b"});
-  EXPECT_THAT(resp, IntArg(1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
 
   resp = Run({"smismember", "foo", "x"});
-  EXPECT_THAT(resp, IntArg(0));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(0)));
 }
 
 TEST_F(SetFamilyTest, Empty) {
@@ -770,7 +765,7 @@ TEST_F(SetFamilyTest, FieldExpireDeletesEmptySet) {
   // FIELDEXPIRE on an already-expired member should clean up the empty set.
   auto resp = Run({"fieldexpire", "key", "100", "a"});
   // -2 means the field was not found (expired).
-  EXPECT_THAT(resp, IntArg(-2));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(-2)));
   EXPECT_THAT(Run({"exists", "key"}), IntArg(0));
 }
 

--- a/src/server/stream_family_test.cc
+++ b/src/server/stream_family_test.cc
@@ -32,8 +32,8 @@ TEST_F(StreamFamilyTest, Add) {
   EXPECT_THAT(resp, ArrLen(0));
 
   resp = Run({"xrange", "key", "-", "+"});
-  EXPECT_THAT(resp, ArrLen(2));
-  auto sub_arr = resp.GetVec();
+  EXPECT_THAT(resp, ArrLen(1));
+  auto sub_arr = resp.GetVec()[0].GetVec();
   EXPECT_THAT(sub_arr, ElementsAre(id, ArrLen(2)));
 
   resp = Run({"xlen", "key"});
@@ -53,8 +53,8 @@ TEST_F(StreamFamilyTest, AddExtended) {
   auto resp0 = Run({"xadd", "key", "5", "f1", "v1", "f2", "v2"});
   EXPECT_EQ(resp0, "5-0");
   resp0 = Run({"xrange", "key", "5-0", "5-0"});
-  EXPECT_THAT(resp0, ArrLen(2));
-  auto sub_arr = resp0.GetVec();
+  EXPECT_THAT(resp0, ArrLen(1));
+  auto sub_arr = resp0.GetVec()[0].GetVec();
   EXPECT_THAT(sub_arr, ElementsAre("5-0", ArrLen(4)));
   sub_arr = sub_arr[1].GetVec();
   EXPECT_THAT(sub_arr, ElementsAre("f1", "v1", "f2", "v2"));
@@ -147,7 +147,7 @@ TEST_F(StreamFamilyTest, XRead) {
 
   // Receive all records from a single stream, in a single hop
   auto resp = Run({"xread", "streams", "foo", "0"});
-  EXPECT_THAT(resp.GetVec(), ElementsAre("foo", ArrLen(3)));
+  EXPECT_THAT(resp.GetVec()[0].GetVec(), ElementsAre("foo", ArrLen(3)));
   EXPECT_EQ(GetMetrics().shard_stats.tx_optimistic_total, 5u);
 
   // Receive all records from both streams.
@@ -172,14 +172,12 @@ TEST_F(StreamFamilyTest, XRead) {
 
   // Read from ID.
   resp = Run({"xread", "count", "10", "streams", "foo", "bar", "1-1", "2-0"});
-  // Note when the response has length 1, Run returns the first element.
-  EXPECT_THAT(resp.GetVec(), ElementsAre("foo", ArrLen(1)));
-  EXPECT_THAT(resp.GetVec()[1].GetVec()[0].GetVec(), ElementsAre("1-2", ArrLen(2)));
+  EXPECT_THAT(resp.GetVec()[0].GetVec(), ElementsAre("foo", ArrLen(1)));
+  EXPECT_THAT(resp.GetVec()[0].GetVec()[1].GetVec()[0].GetVec(), ElementsAre("1-2", ArrLen(2)));
 
   // Stream not found.
   resp = Run({"xread", "streams", "foo", "notfound", "0", "0"});
-  // Note when the response has length 1, Run returns the first element.
-  EXPECT_THAT(resp.GetVec(), ElementsAre("foo", ArrLen(3)));
+  EXPECT_THAT(resp.GetVec()[0].GetVec(), ElementsAre("foo", ArrLen(3)));
 
   // Not found.
   resp = Run({"xread", "streams", "notfound", "0"});
@@ -213,12 +211,12 @@ TEST_F(StreamFamilyTest, XReadGroup) {
 
   // consumer PEL is empty, so resp should have empty list
   auto resp = Run({"xreadgroup", "group", "group", "alice", "streams", "foo", "0"});
-  EXPECT_THAT(resp, RespArray(ElementsAre("foo", ArrLen(0))));
+  EXPECT_THAT(resp, RespElementsAre(RespArray(ElementsAre("foo", ArrLen(0)))));
 
   // should return unread entries with key "foo"
   resp = Run({"xreadgroup", "group", "group", "alice", "streams", "foo", ">"});
   // only "foo" key entries are read
-  EXPECT_THAT(resp, RespArray(ElementsAre("foo", ArrLen(3))));
+  EXPECT_THAT(resp, RespElementsAre(RespArray(ElementsAre("foo", ArrLen(3)))));
 
   Run({"xadd", "foo", "1-*", "k5", "v5"});
   resp = Run({"xreadgroup", "group", "group", "alice", "streams", "bar", "foo", ">", ">"});
@@ -229,7 +227,7 @@ TEST_F(StreamFamilyTest, XReadGroup) {
 
   // now we can specify id for "foo" and it fetches from alice's consumer PEL
   resp = Run({"xreadgroup", "group", "group", "alice", "streams", "foo", "0"});
-  EXPECT_THAT(resp.GetVec()[1], ArrLen(4));
+  EXPECT_THAT(resp.GetVec()[0].GetVec()[1], ArrLen(4));
 
   // now ">" gives nil
   resp = Run({"xreadgroup", "group", "group", "alice", "streams", "foo", ">"});
@@ -244,23 +242,26 @@ TEST_F(StreamFamilyTest, XReadGroup) {
 
   // bob will not get entries of alice
   resp = Run({"xreadgroup", "group", "group", "bob", "streams", "foo", "0"});
-  EXPECT_THAT(resp, RespArray(ElementsAre("foo", ArrLen(0))));
+  EXPECT_THAT(resp, RespElementsAre(RespArray(ElementsAre("foo", ArrLen(0)))));
 
   resp = Run({"xinfo", "groups", "foo"});
-  // 2 consumers created
-  EXPECT_THAT(resp.GetVec()[3], IntArg(2));
-  // check last_delivery_id
-  EXPECT_THAT(resp.GetVec()[7], "1-3");
+  {
+    auto group_info = resp.GetVec()[0].GetVec();
+    // 2 consumers created
+    EXPECT_THAT(group_info[3], IntArg(2));
+    // check last_delivery_id
+    EXPECT_THAT(group_info[7], "1-3");
+  }
 
   // Noack
   Run({"xadd", "foo", "1-*", "k6", "v6"});
   resp = Run({"xreadgroup", "group", "group", "bob", "noack", "streams", "foo", ">"});
   // check basic results
-  EXPECT_THAT(resp, ArrLen(2));
-  EXPECT_THAT(resp.GetVec(), ElementsAre("foo", ArrLen(1)));
+  EXPECT_THAT(resp, ArrLen(1));
+  EXPECT_THAT(resp.GetVec()[0].GetVec(), ElementsAre("foo", ArrLen(1)));
   // Entry is not inserted in Bob's consumer PEL.
   resp = Run({"xreadgroup", "group", "group", "bob", "streams", "foo", "0"});
-  EXPECT_THAT(resp, RespArray(ElementsAre("foo", ArrLen(0))));
+  EXPECT_THAT(resp, RespElementsAre(RespArray(ElementsAre("foo", ArrLen(0)))));
 
   // No Group
   resp = Run({"xreadgroup", "group", "nogroup", "alice", "streams", "foo", "0"});
@@ -334,10 +335,8 @@ TEST_F(StreamFamilyTest, XReadBlock) {
   fb1.Join();
 
   // Both xread calls should have been unblocked.
-  //
-  // Note when the response has length 1, Run returns the first element.
-  EXPECT_THAT(resp0.GetVec(), ElementsAre("foo", ArrLen(1)));
-  EXPECT_THAT(resp1.GetVec(), ElementsAre("foo", ArrLen(1)));
+  EXPECT_THAT(resp0.GetVec()[0].GetVec(), ElementsAre("foo", ArrLen(1)));
+  EXPECT_THAT(resp1.GetVec()[0].GetVec(), ElementsAre("foo", ArrLen(1)));
 }
 
 TEST_F(StreamFamilyTest, XReadGroupBlockwithoutBlock) {
@@ -389,12 +388,12 @@ TEST_F(StreamFamilyTest, XReadGroupBlock) {
   fb0.Join();
   fb1.Join();
 
-  if (resp0.GetVec()[0].GetString() == "foo") {
-    EXPECT_THAT(resp0.GetVec(), ElementsAre("foo", ArrLen(1)));
-    EXPECT_THAT(resp1.GetVec(), ElementsAre("bar", ArrLen(1)));
+  if (resp0.GetVec()[0].GetVec()[0].GetString() == "foo") {
+    EXPECT_THAT(resp0.GetVec()[0].GetVec(), ElementsAre("foo", ArrLen(1)));
+    EXPECT_THAT(resp1.GetVec()[0].GetVec(), ElementsAre("bar", ArrLen(1)));
   } else {
-    EXPECT_THAT(resp1.GetVec(), ElementsAre("foo", ArrLen(1)));
-    EXPECT_THAT(resp0.GetVec(), ElementsAre("bar", ArrLen(1)));
+    EXPECT_THAT(resp1.GetVec()[0].GetVec(), ElementsAre("foo", ArrLen(1)));
+    EXPECT_THAT(resp0.GetVec()[0].GetVec(), ElementsAre("bar", ArrLen(1)));
   }
 
   // Call XGROUP DESTROY while blocking
@@ -424,7 +423,7 @@ TEST_F(StreamFamilyTest, XReadGroupBlockDelconsumer) {
   pp_->at(1)->Await([&] { return Run("xadd", {"XADD", "foo", "1-0", "k1", "v1"}); });
   fb0.Join();
 
-  EXPECT_THAT(resp0.GetVec(), ElementsAre("foo", ArrLen(1)));
+  EXPECT_THAT(resp0.GetVec()[0].GetVec(), ElementsAre("foo", ArrLen(1)));
   EXPECT_THAT(resp_del_consumer, IntArg(0));
 }
 
@@ -500,7 +499,7 @@ TEST_F(StreamFamilyTest, XReadGroupEmpty) {
   Run({"XADD", "stream", "*", "foo", "bar"});
   Run({"XGROUP", "CREATE", "stream", "group", "0"});
   auto resp = Run({"XREADGROUP", "GROUP", "group", "consumer1", "STREAMS", "stream", "0"});
-  EXPECT_THAT(resp, ArrLen(2));
+  EXPECT_THAT(resp, RespElementsAre(RespArray(ElementsAre("stream", ArrLen(0)))));
 }
 
 TEST_F(StreamFamilyTest, Issue854) {
@@ -517,10 +516,10 @@ TEST_F(StreamFamilyTest, XGroupConsumer) {
   EXPECT_THAT(resp, IntArg(1));
   Run({"xgroup", "createconsumer", "foo", "group", "alice"});
   resp = Run({"xinfo", "groups", "foo"});
-  EXPECT_THAT(resp.GetVec()[3], IntArg(2));
+  EXPECT_THAT(resp.GetVec()[0].GetVec()[3], IntArg(2));
   Run({"xgroup", "delconsumer", "foo", "group", "alice"});
   resp = Run({"xinfo", "groups", "foo"});
-  EXPECT_THAT(resp.GetVec()[3], IntArg(1));
+  EXPECT_THAT(resp.GetVec()[0].GetVec()[3], IntArg(1));
 
   resp = Run({"xgroup", "createconsumer", "foo", "group", "alice"});
   EXPECT_THAT(resp, IntArg(1));
@@ -553,29 +552,29 @@ TEST_F(StreamFamilyTest, Xclaim) {
 
   // bob really have these claimed entries
   resp = Run({"xreadgroup", "group", "group", "bob", "streams", "foo", "0"});
-  EXPECT_THAT(resp,
-              RespArray(ElementsAre(
-                  "foo", RespArray(ElementsAre(
-                             RespArray(ElementsAre("1-2", RespArray(ElementsAre("k3", "v3")))),
-                             RespArray(ElementsAre("1-3", RespArray(ElementsAre("k4", "v4")))))))));
+  EXPECT_THAT(
+      resp, RespElementsAre(RespArray(ElementsAre(
+                "foo", RespArray(ElementsAre(
+                           RespArray(ElementsAre("1-2", RespArray(ElementsAre("k3", "v3")))),
+                           RespArray(ElementsAre("1-3", RespArray(ElementsAre("k4", "v4"))))))))));
 
   // alice no longer have those entries
   resp = Run({"xreadgroup", "group", "group", "alice", "streams", "foo", "0"});
-  EXPECT_THAT(resp,
-              RespArray(ElementsAre(
-                  "foo", RespArray(ElementsAre(
-                             RespArray(ElementsAre("1-0", RespArray(ElementsAre("k1", "v1")))),
-                             RespArray(ElementsAre("1-1", RespArray(ElementsAre("k2", "v2")))))))));
+  EXPECT_THAT(
+      resp, RespElementsAre(RespArray(ElementsAre(
+                "foo", RespArray(ElementsAre(
+                           RespArray(ElementsAre("1-0", RespArray(ElementsAre("k1", "v1")))),
+                           RespArray(ElementsAre("1-1", RespArray(ElementsAre("k2", "v2"))))))))));
 
   // xclaim ensures that entries before the min-idle-time are not claimed by bob
   resp = Run({"xclaim", "foo", "group", "bob", "3600000", "1-0"});
   EXPECT_THAT(resp, ArrLen(0));
   resp = Run({"xreadgroup", "group", "group", "alice", "streams", "foo", "0"});
-  EXPECT_THAT(resp,
-              RespArray(ElementsAre(
-                  "foo", RespArray(ElementsAre(
-                             RespArray(ElementsAre("1-0", RespArray(ElementsAre("k1", "v1")))),
-                             RespArray(ElementsAre("1-1", RespArray(ElementsAre("k2", "v2")))))))));
+  EXPECT_THAT(
+      resp, RespElementsAre(RespArray(ElementsAre(
+                "foo", RespArray(ElementsAre(
+                           RespArray(ElementsAre("1-0", RespArray(ElementsAre("k1", "v1")))),
+                           RespArray(ElementsAre("1-1", RespArray(ElementsAre("k2", "v2"))))))))));
 
   Run({"xadd", "foo", "1-4", "k5", "v5"});
   Run({"xreadgroup", "group", "group", "alice", "streams", "foo", ">"});
@@ -586,39 +585,40 @@ TEST_F(StreamFamilyTest, Xclaim) {
   Run({"xadd", "foo", "1-5", "k6", "v6"});
   // bob should claim the id forcefully even if it is not yet present in group pel
   resp = Run({"xclaim", "foo", "group", "bob", "0", "1-5", "force", "justid"});
-  EXPECT_THAT(resp.GetString(), "1-5");
+  EXPECT_THAT(resp, RespElementsAre("1-5"));
   resp = Run({"xreadgroup", "group", "group", "bob", "streams", "foo", "0"});
-  EXPECT_THAT(resp.GetVec()[1].GetVec()[4].GetVec(),
+  EXPECT_THAT(resp.GetVec()[0].GetVec()[1].GetVec()[4].GetVec(),
               ElementsAre("1-5", RespArray(ElementsAre("k6", "v6"))));
 
   TEST_current_time_ms += 2000;
   resp = Run({"xclaim", "foo", "group", "alice", "0", "1-4", "TIME",
               absl::StrCat(TEST_current_time_ms - 500), "justid"});
-  EXPECT_THAT(resp.GetString(), "1-4");
+  EXPECT_THAT(resp, RespElementsAre("1-4"));
 
   // min idle time is exceeded for this entry
   resp = Run({"xclaim", "foo", "group", "bob", "600", "1-4"});
   ASSERT_THAT(resp, ArrLen(0));
 
   resp = Run({"xclaim", "foo", "group", "bob", "400", "1-4", "justid"});
-  EXPECT_THAT(resp.GetString(), "1-4");
+  EXPECT_THAT(resp, RespElementsAre("1-4"));
 
   //  test RETRYCOUNT
   Run({"xadd", "foo", "1-6", "k7", "v7"});
   resp = Run({"xclaim", "foo", "group", "bob", "0", "1-6", "force", "justid", "retrycount", "5"});
-  EXPECT_THAT(resp.GetString(), "1-6");
+  EXPECT_THAT(resp, RespElementsAre("1-6"));
   resp = Run({"xpending", "foo", "group", "1-6", "1-6", "1"});
-  EXPECT_THAT(resp.GetVec(), ElementsAre("1-6", "bob", ArgType(RespExpr::INT64), IntArg(5)));
+  EXPECT_THAT(resp.GetVec()[0].GetVec(),
+              ElementsAre("1-6", "bob", ArgType(RespExpr::INT64), IntArg(5)));
 
   // test LASTID
   Run({"xreadgroup", "group", "group", "bob", "count", "2", "streams", "foo", ">"});
   Run({"xclaim", "foo", "group", "alice", "0", "1-6", "LASTID", "1-4"});
   resp = Run({"xinfo", "groups", "foo"});
-  EXPECT_EQ(resp.GetVec()[7], "1-6");
+  EXPECT_EQ(resp.GetVec()[0].GetVec()[7], "1-6");
 
   Run({"xclaim", "foo", "group", "bob", "0", "1-6", "LASTID", "1-9"});
   resp = Run({"xinfo", "groups", "foo"});
-  EXPECT_EQ(resp.GetVec()[7], "1-9");
+  EXPECT_EQ(resp.GetVec()[0].GetVec()[7], "1-9");
 }
 
 TEST_F(StreamFamilyTest, XTrim) {
@@ -737,14 +737,16 @@ TEST_F(StreamFamilyTest, XPending) {
 
   // only return a single entry
   resp = Run({"xpending", "foo", "group", "-", "+", "1"});
-  EXPECT_THAT(resp.GetVec(), ElementsAre("1-0", "alice", ArgType(RespExpr::INT64), IntArg(1)));
+  EXPECT_THAT(resp.GetVec()[0].GetVec(),
+              ElementsAre("1-0", "alice", ArgType(RespExpr::INT64), IntArg(1)));
 
   // Bob read a new entry
   Run({"xadd", "foo", "1-3", "k4", "v4"});
   Run({"xreadgroup", "group", "group", "bob", "streams", "foo", ">"});
   // Bob now has` an entry in his pending list
   resp = Run({"xpending", "foo", "group", "-", "+", "10", "bob"});
-  EXPECT_THAT(resp.GetVec(), ElementsAre("1-3", "bob", ArgType(RespExpr::INT64), IntArg(1)));
+  EXPECT_THAT(resp.GetVec()[0].GetVec(),
+              ElementsAre("1-3", "bob", ArgType(RespExpr::INT64), IntArg(1)));
 
   Run({"xadd", "foo", "1-4", "k5", "v5"});
   TEST_current_time_ms = 100;
@@ -820,12 +822,12 @@ TEST_F(StreamFamilyTest, XAck) {
 
   // Verifies message id 1-0 gets removed from PEL.
   resp = Run({"xreadgroup", "group", "cgroup", "consumer", "streams", "foo", "0"});
-  EXPECT_THAT(resp,
-              RespArray(ElementsAre(
-                  "foo", RespArray(ElementsAre(
-                             RespArray(ElementsAre("1-1", RespArray(ElementsAre("k1", "v1")))),
-                             RespArray(ElementsAre("1-2", RespArray(ElementsAre("k2", "v2")))),
-                             RespArray(ElementsAre("1-3", RespArray(ElementsAre("k3", "v3")))))))));
+  EXPECT_THAT(
+      resp, RespElementsAre(RespArray(ElementsAre(
+                "foo", RespArray(ElementsAre(
+                           RespArray(ElementsAre("1-1", RespArray(ElementsAre("k1", "v1")))),
+                           RespArray(ElementsAre("1-2", RespArray(ElementsAre("k2", "v2")))),
+                           RespArray(ElementsAre("1-3", RespArray(ElementsAre("k3", "v3"))))))))));
 
   // acknowledge a message that doesn't exist
   resp = Run({"xack", "foo", "cgroup", "1-9"});
@@ -833,12 +835,12 @@ TEST_F(StreamFamilyTest, XAck) {
 
   // Verifies no message gets removed from PEL.
   resp = Run({"xreadgroup", "group", "cgroup", "consumer", "streams", "foo", "0"});
-  EXPECT_THAT(resp,
-              RespArray(ElementsAre(
-                  "foo", RespArray(ElementsAre(
-                             RespArray(ElementsAre("1-1", RespArray(ElementsAre("k1", "v1")))),
-                             RespArray(ElementsAre("1-2", RespArray(ElementsAre("k2", "v2")))),
-                             RespArray(ElementsAre("1-3", RespArray(ElementsAre("k3", "v3")))))))));
+  EXPECT_THAT(
+      resp, RespElementsAre(RespArray(ElementsAre(
+                "foo", RespArray(ElementsAre(
+                           RespArray(ElementsAre("1-1", RespArray(ElementsAre("k1", "v1")))),
+                           RespArray(ElementsAre("1-2", RespArray(ElementsAre("k2", "v2")))),
+                           RespArray(ElementsAre("1-3", RespArray(ElementsAre("k3", "v3"))))))))));
 
   // acknowledge another message that exists and one non-existing message.
   resp = Run({"xack", "foo", "cgroup", "1-3", "1-9"});
@@ -846,11 +848,11 @@ TEST_F(StreamFamilyTest, XAck) {
 
   // Verifies only "1-3" gets removed from PEL.
   resp = Run({"xreadgroup", "group", "cgroup", "consumer", "streams", "foo", "0"});
-  EXPECT_THAT(resp,
-              RespArray(ElementsAre(
-                  "foo", RespArray(ElementsAre(
-                             RespArray(ElementsAre("1-1", RespArray(ElementsAre("k1", "v1")))),
-                             RespArray(ElementsAre("1-2", RespArray(ElementsAre("k2", "v2")))))))));
+  EXPECT_THAT(
+      resp, RespElementsAre(RespArray(ElementsAre(
+                "foo", RespArray(ElementsAre(
+                           RespArray(ElementsAre("1-1", RespArray(ElementsAre("k1", "v1")))),
+                           RespArray(ElementsAre("1-2", RespArray(ElementsAre("k2", "v2"))))))))));
 
   // acknowledge all the existing messages left.
   resp = Run({"xack", "foo", "cgroup", "1-1", "1-2"});
@@ -858,7 +860,7 @@ TEST_F(StreamFamilyTest, XAck) {
 
   // Verifies that PEL is empty.
   resp = Run({"xreadgroup", "group", "cgroup", "consumer", "streams", "foo", "0"});
-  EXPECT_THAT(resp, RespArray(ElementsAre("foo", ArrLen(0))));
+  EXPECT_THAT(resp, RespElementsAre(RespArray(ElementsAre("foo", ArrLen(0)))));
 }
 
 TEST_F(StreamFamilyTest, XInfoGroups) {
@@ -871,8 +873,8 @@ TEST_F(StreamFamilyTest, XInfoGroups) {
 
   // group with no consumers
   resp = Run({"xinfo", "groups", "mystream"});
-  EXPECT_THAT(resp, ArrLen(12));
-  EXPECT_THAT(resp.GetVec(),
+  ASSERT_THAT(resp, ArrLen(1));
+  EXPECT_THAT(resp.GetVec()[0].GetVec(),
               ElementsAre("name", "mygroup", "consumers", IntArg(0), "pending", IntArg(0),
                           "last-delivered-id", "0-0", "entries-read", kMatchNil, "lag", IntArg(0)));
 
@@ -880,20 +882,20 @@ TEST_F(StreamFamilyTest, XInfoGroups) {
   Run({"xgroup", "createconsumer", "mystream", "mygroup", "consumer1"});
   Run({"xgroup", "createconsumer", "mystream", "mygroup", "consumer2"});
   resp = Run({"xinfo", "groups", "mystream"});
-  EXPECT_THAT(resp, ArrLen(12));
-  EXPECT_THAT(resp.GetVec()[3], IntArg(2));
+  ASSERT_THAT(resp, ArrLen(1));
+  EXPECT_THAT(resp.GetVec()[0].GetVec()[3], IntArg(2));
 
   // group with lag
   Run({"xadd", "mystream", "1-0", "test-field-1", "test-value-1"});
   Run({"xadd", "mystream", "2-0", "test-field-2", "test-value-2"});
   resp = Run({"xinfo", "groups", "mystream"});
-  EXPECT_THAT(resp.GetVec()[11], IntArg(2));
-  EXPECT_THAT(resp.GetVec()[7], "0-0");
+  EXPECT_THAT(resp.GetVec()[0].GetVec()[11], IntArg(2));
+  EXPECT_THAT(resp.GetVec()[0].GetVec()[7], "0-0");
 
   // group with no lag, before ack
   Run({"xreadgroup", "group", "mygroup", "consumer1", "STREAMS", "mystream", ">"});
   resp = Run({"xinfo", "groups", "mystream"});
-  EXPECT_THAT(resp.GetVec(),
+  EXPECT_THAT(resp.GetVec()[0].GetVec(),
               ElementsAre("name", "mygroup", "consumers", IntArg(2), "pending", IntArg(2),
                           "last-delivered-id", "2-0", "entries-read", IntArg(2), "lag", IntArg(0)));
 
@@ -901,7 +903,7 @@ TEST_F(StreamFamilyTest, XInfoGroups) {
   Run({"xack", "mystream", "mygroup", "1-0"});
   Run({"xack", "mystream", "mygroup", "2-0"});
   resp = Run({"xinfo", "groups", "mystream"});
-  EXPECT_THAT(resp.GetVec(),
+  EXPECT_THAT(resp.GetVec()[0].GetVec(),
               ElementsAre("name", "mygroup", "consumers", IntArg(2), "pending", IntArg(0),
                           "last-delivered-id", "2-0", "entries-read", IntArg(2), "lag", IntArg(0)));
 }
@@ -964,19 +966,19 @@ TEST_F(StreamFamilyTest, XAutoClaim) {
 
   // bob really has these claimed entries
   resp = Run({"xreadgroup", "group", "group", "bob", "streams", "foo", "0"});
-  EXPECT_THAT(resp,
-              RespArray(ElementsAre(
-                  "foo", RespArray(ElementsAre(
-                             RespArray(ElementsAre("1-2", RespArray(ElementsAre("k3", "v3")))),
-                             RespArray(ElementsAre("1-3", RespArray(ElementsAre("k4", "v4")))))))));
+  EXPECT_THAT(
+      resp, RespElementsAre(RespArray(ElementsAre(
+                "foo", RespArray(ElementsAre(
+                           RespArray(ElementsAre("1-2", RespArray(ElementsAre("k3", "v3")))),
+                           RespArray(ElementsAre("1-3", RespArray(ElementsAre("k4", "v4"))))))))));
 
   // alice no longer have those entries
   resp = Run({"xreadgroup", "group", "group", "alice", "streams", "foo", "0"});
-  EXPECT_THAT(resp,
-              RespArray(ElementsAre(
-                  "foo", RespArray(ElementsAre(
-                             RespArray(ElementsAre("1-0", RespArray(ElementsAre("k1", "v1")))),
-                             RespArray(ElementsAre("1-1", RespArray(ElementsAre("k2", "v2")))))))));
+  EXPECT_THAT(
+      resp, RespElementsAre(RespArray(ElementsAre(
+                "foo", RespArray(ElementsAre(
+                           RespArray(ElementsAre("1-0", RespArray(ElementsAre("k1", "v1")))),
+                           RespArray(ElementsAre("1-1", RespArray(ElementsAre("k2", "v2"))))))))));
 
   // xautoclaim ensures that entries before the min-idle-time are not claimed by bob
   resp = Run({"xautoclaim", "foo", "group", "bob", "3600000", "0-0"});
@@ -1162,7 +1164,8 @@ TEST_F(StreamFamilyTest, AutoClaimPelItemsFromAnotherConsumer) {
       {"XREADGROUP", "GROUP", "mygroup", "consumer1", "COUNT", "1", "STREAMS", "mystream", ">"});
 
   auto match_a1 = RespElementsAre("a", "1");
-  ASSERT_THAT(resp, RespElementsAre("mystream", RespElementsAre(RespElementsAre(id1, match_a1))));
+  ASSERT_THAT(resp, RespElementsAre(RespElementsAre(
+                        "mystream", RespElementsAre(RespElementsAre(id1, match_a1)))));
 
   AdvanceTime(200);  // Advance time to greater time than the idle time in the autoclaim (10)
   resp = Run({"XAUTOCLAIM", "mystream", "mygroup", "consumer2", "10", "-", "COUNT", "1"});
@@ -1210,7 +1213,7 @@ TEST_F(StreamFamilyTest, AutoClaimDelCount) {
   auto m1 = RespElementsAre("1-0", _);
   auto m2 = RespElementsAre("2-0", _);
   auto m3 = RespElementsAre("3-0", _);
-  EXPECT_THAT(resp, RespElementsAre("x", RespElementsAre(m1, m2, m3)));
+  EXPECT_THAT(resp, RespElementsAre(RespElementsAre("x", RespElementsAre(m1, m2, m3))));
 
   EXPECT_THAT(Run({"XDEL", "x", "1-0"}), IntArg(1));
   EXPECT_THAT(Run({"XDEL", "x", "2-0"}), IntArg(1));
@@ -1267,16 +1270,16 @@ TEST_F(StreamFamilyTest, SeenActiveTime) {
   Run({"XREADGROUP", "GROUP", "mygroup", "Alice", "COUNT", "1", "STREAMS", "mystream", ">"});
   AdvanceTime(100);
   auto resp = Run({"xinfo", "consumers", "mystream", "mygroup"});
-  EXPECT_THAT(resp, RespElementsAre("name", "Alice", "pending", IntArg(0), "idle", IntArg(100),
-                                    "inactive", IntArg(-1)));
+  EXPECT_THAT(resp, RespElementsAre(RespElementsAre("name", "Alice", "pending", IntArg(0), "idle",
+                                                    IntArg(100), "inactive", IntArg(-1))));
 
   Run({"XADD", "mystream", "*", "f", "v"});
   Run({"XREADGROUP", "GROUP", "mygroup", "Alice", "COUNT", "1", "STREAMS", "mystream", ">"});
   AdvanceTime(50);
 
   resp = Run({"xinfo", "consumers", "mystream", "mygroup"});
-  EXPECT_THAT(resp, RespElementsAre("name", "Alice", "pending", IntArg(1), "idle", IntArg(50),
-                                    "inactive", IntArg(50)));
+  EXPECT_THAT(resp, RespElementsAre(RespElementsAre("name", "Alice", "pending", IntArg(1), "idle",
+                                                    IntArg(50), "inactive", IntArg(50))));
   AdvanceTime(100);
   resp = Run({"XREADGROUP", "GROUP", "mygroup", "Alice", "COUNT", "1", "STREAMS", "mystream", ">"});
   EXPECT_THAT(resp, ArgType(RespExpr::NIL_ARRAY));
@@ -1285,8 +1288,8 @@ TEST_F(StreamFamilyTest, SeenActiveTime) {
 
   // Idle is 0 because XREADGROUP just run, but inactive continues clocking because nothing was
   // read.
-  EXPECT_THAT(resp, RespElementsAre("name", "Alice", "pending", IntArg(1), "idle", IntArg(0),
-                                    "inactive", IntArg(150)));
+  EXPECT_THAT(resp, RespElementsAre(RespElementsAre("name", "Alice", "pending", IntArg(1), "idle",
+                                                    IntArg(0), "inactive", IntArg(150))));
 
   // Serialize/deserialize.
   resp = Run({"XINFO", "STREAM", "mystream", "FULL"});
@@ -1557,15 +1560,17 @@ TEST_F(StreamFamilyTest, XGroupSetIdEntriesRead) {
   Run("XGROUP SETID mystream mygroup 2000-0 ENTRIESREAD 100");
 
   auto resp = Run("XINFO GROUPS mystream");
-  EXPECT_THAT(resp.GetVec(), ElementsAre("name", "mygroup", "consumers", IntArg(0), "pending",
-                                         IntArg(0), "last-delivered-id", "2000-0", "entries-read",
-                                         IntArg(100), "lag", IntArg(-99)));
+  EXPECT_THAT(
+      resp.GetVec()[0].GetVec(),
+      ElementsAre("name", "mygroup", "consumers", IntArg(0), "pending", IntArg(0),
+                  "last-delivered-id", "2000-0", "entries-read", IntArg(100), "lag", IntArg(-99)));
 
   Run("XGROUP SETID mystream mygroup 2000-0 ENTRIESREAD -1");
   resp = Run("XINFO GROUPS mystream");
-  EXPECT_THAT(resp.GetVec(), ElementsAre("name", "mygroup", "consumers", IntArg(0), "pending",
-                                         IntArg(0), "last-delivered-id", "2000-0", "entries-read",
-                                         kMatchNil, "lag", IntArg(0)));
+  EXPECT_THAT(
+      resp.GetVec()[0].GetVec(),
+      ElementsAre("name", "mygroup", "consumers", IntArg(0), "pending", IntArg(0),
+                  "last-delivered-id", "2000-0", "entries-read", kMatchNil, "lag", IntArg(0)));
 }
 
 TEST_F(StreamFamilyTest, XInfoConsumersArityCrash) {

--- a/src/server/string_family_test.cc
+++ b/src/server/string_family_test.cc
@@ -222,7 +222,7 @@ TEST_F(StringFamilyTest, MSetLong) {
 TEST_F(StringFamilyTest, MGetSet) {
   Run({"mset", "z", "0"});         // single key
   auto resp = Run({"mget", "z"});  // single key
-  EXPECT_THAT(resp, "0");
+  EXPECT_THAT(resp, RespElementsAre("0"));
 
   Run({"mset", "x", "0", "b", "0"});
 

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -120,7 +120,7 @@ class BaseFamilyTest::TestConnWrapper {
 
   CmdArgVec Args(ArgSlice list);
 
-  RespVec ParseResponse(bool fully_consumed);
+  RespExpr ParseResponse(bool fully_consumed);
 
   // returns: type(pmessage), pattern, channel, message.
   const facade::Connection::PubMessage& GetPubMessage(size_t index) const;
@@ -139,7 +139,6 @@ class BaseFamilyTest::TestConnWrapper {
 
   void ClearSink() {
     sink_.Clear();
-    expr_builder_.Clear();
   }
 
   TestConnection* conn() {
@@ -180,8 +179,6 @@ BaseFamilyTest::BaseFamilyTest() {
 }
 
 BaseFamilyTest::~BaseFamilyTest() {
-  for (auto* v : resp_vec_)
-    delete v;
 }
 
 void BaseFamilyTest::SetUpTestSuite() {
@@ -480,16 +477,7 @@ RespExpr BaseFamilyTest::Run(std::string_view id, ArgSlice slice) {
   unique_lock lk(mu_);
   last_cmd_dbg_info_ = context->last_command_debug;
 
-  RespVec vec = conn_wrapper->ParseResponse(single_response_);
-  if (vec.size() == 1)
-    return vec.front();
-  RespVec* new_vec = new RespVec(vec);
-  resp_vec_.push_back(new_vec);
-  RespExpr e;
-  e.type = RespExpr::ARRAY;
-  e.u = new_vec;
-
-  return e;
+  return conn_wrapper->ParseResponse(single_response_);
 }
 
 void BaseFamilyTest::RunMany(const std::vector<std::vector<std::string>>& cmds) {
@@ -627,7 +615,7 @@ CmdArgVec BaseFamilyTest::TestConnWrapper::Args(ArgSlice list) {
   return res;
 }
 
-RespVec BaseFamilyTest::TestConnWrapper::ParseResponse(bool fully_consumed) {
+RespExpr BaseFamilyTest::TestConnWrapper::ParseResponse(bool fully_consumed) {
   tmp_str_vec_.emplace_back(new string{sink_.str()});
   auto& s = *tmp_str_vec_.back();
 
@@ -647,29 +635,11 @@ RespVec BaseFamilyTest::TestConnWrapper::ParseResponse(bool fully_consumed) {
   // freeing it, since BuildExpr copies string data into owned_strings_.
   auto& parsed = *obj;
 
-  // The old RedisParser unwraps top-level arrays: elements go directly into res.
-  // We match that behavior here for compatibility with existing tests.
-  RespVec res;
-  auto type = parsed.GetType();
-  if (type == RESPObj::Type::ARRAY || type == RESPObj::Type::MAP || type == RESPObj::Type::SET) {
-    auto arr = parsed.As<RESPArray>();
-    if (arr.has_value() && arr->Size() != SIZE_MAX) {
-      for (size_t i = 0; i < arr->Size(); ++i) {
-        res.push_back(expr_builder_.BuildExpr((*arr)[i]));
-      }
-    } else {
-      // Null aggregate (e.g. *-1\r\n) — produce a NIL_ARRAY entry.
-      res.push_back(expr_builder_.BuildExpr(parsed));
-    }
-  } else {
-    res.push_back(expr_builder_.BuildExpr(parsed));
-  }
-
+  // BuildExpr handles scalars and arrays recursively, preserving array cardinality.
   // parsed (RESPObj) goes out of scope here, freeing zmalloc-allocated hiredis
   // reply data on this thread. All needed string data has been copied into
   // expr_builder_.owned_strings_.
-
-  return res;
+  return expr_builder_.BuildExpr(parsed);
 }
 
 const facade::Connection::PubMessage& BaseFamilyTest::TestConnWrapper::GetPubMessage(

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -189,7 +189,6 @@ class BaseFamilyTest : public ::testing::Test {
   util::fb2::Mutex mu_;
   ConnectionContext::DebugInfo last_cmd_dbg_info_;
 
-  std::vector<RespVec*> resp_vec_;
   bool single_response_ = true;
   util::fb2::Fiber watchdog_fiber_;
   util::fb2::Done watchdog_done_;

--- a/src/server/topk_family_test.cc
+++ b/src/server/topk_family_test.cc
@@ -7,6 +7,8 @@
 
 namespace dfly {
 
+using facade::RespArray;
+using facade::RespElementsAre;
 using testing::ElementsAre;
 using testing::HasSubstr;
 
@@ -235,7 +237,7 @@ TEST_F(TopkFamilyTest, ReserveDimensionsExceedCaps) {
 TEST_F(TopkFamilyTest, AddSingleItem) {
   ReserveDefault("tk", 5);
   auto resp = AddItem("tk", "foo");
-  EXPECT_EQ(resp.type, RespExpr::NIL);
+  EXPECT_THAT(resp, RespElementsAre(ArgType(RespExpr::NIL)));
 }
 
 // Tests adding multiple items in a single TOPK.ADD call.
@@ -256,10 +258,10 @@ TEST_F(TopkFamilyTest, AddDuplicateItem) {
   AddItem("tk", "foo");
 
   auto resp = Run({"topk.count", "tk", "foo"});
-  EXPECT_GE(resp.GetInt(), 1);
+  EXPECT_GE(resp.GetVec()[0].GetInt().value_or(0), 1);
 
   resp = Run({"topk.query", "tk", "foo"});
-  EXPECT_THAT(resp, IntArg(1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
 }
 
 // Tests that TOPK.ADD fails when called with no items (only key).
@@ -280,19 +282,19 @@ TEST_F(TopkFamilyTest, AddEviction) {
 
   // Adding a weak item should return NIL (no eviction, because it can't beat the min)
   auto resp = AddItem("tk", "weak");
-  EXPECT_EQ(resp.type, RespExpr::NIL);
+  EXPECT_THAT(resp, RespElementsAre(ArgType(RespExpr::NIL)));
 
   auto list = Run({"topk.list", "tk"});
   EXPECT_EQ(list.GetVec().size(), 2u);
 
   // The two heavy items should still be in the top-k
-  EXPECT_THAT(Run({"topk.query", "tk", "heavy1"}), IntArg(1));
-  EXPECT_THAT(Run({"topk.query", "tk", "heavy2"}), IntArg(1));
+  EXPECT_THAT(Run({"topk.query", "tk", "heavy1"}), RespElementsAre(IntArg(1)));
+  EXPECT_THAT(Run({"topk.query", "tk", "heavy2"}), RespElementsAre(IntArg(1)));
 
   // Now add a very strong item that should evict the weakest (heavy2)
   resp = IncrByItem("tk", "newcomer", 100000);
   // The return value should be a string (the evicted item), not NIL
-  EXPECT_EQ(resp.type, RespExpr::STRING);
+  EXPECT_EQ(resp.GetVec()[0].type, RespExpr::STRING);
 }
 
 // Tests adding items with special characters (spaces, emoji-like, binary-safe).
@@ -303,7 +305,7 @@ TEST_F(TopkFamilyTest, AddSpecialCharacters) {
   AddItem("tk", "");  // Empty string
 
   auto resp = Run({"topk.query", "tk", "hello world"});
-  EXPECT_THAT(resp, IntArg(1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
 }
 
 // Tests adding a large number of items exceeding k to verify batch behavior.
@@ -327,10 +329,10 @@ TEST_F(TopkFamilyTest, AddLargeBatch) {
 TEST_F(TopkFamilyTest, IncrBySingleItem) {
   ReserveDefault("tk", 5);
   auto resp = IncrByItem("tk", "foo", 10);
-  EXPECT_EQ(resp.type, RespExpr::NIL);
+  EXPECT_THAT(resp, RespElementsAre(ArgType(RespExpr::NIL)));
 
   resp = Run({"topk.count", "tk", "foo"});
-  EXPECT_GE(resp.GetInt(), 1);
+  EXPECT_GE(resp.GetVec()[0].GetInt().value_or(0), 1);
 }
 
 // Tests incrementing multiple items in a single TOPK.INCRBY call.
@@ -349,21 +351,21 @@ TEST_F(TopkFamilyTest, IncrByAccumulates) {
 
   auto resp = Run({"topk.count", "tk", "foo"});
   // Probabilistic, but should be at least 1
-  EXPECT_GE(resp.GetInt(), 1);
+  EXPECT_GE(resp.GetVec()[0].GetInt().value_or(0), 1);
 }
 
 // Tests TOPK.INCRBY with increment=1 (minimum valid increment).
 TEST_F(TopkFamilyTest, IncrByMinIncrement) {
   ReserveDefault("tk", 5);
   auto resp = IncrByItem("tk", "foo", 1);
-  EXPECT_EQ(resp.type, RespExpr::NIL);
+  EXPECT_THAT(resp, RespElementsAre(ArgType(RespExpr::NIL)));
 }
 
 // Tests TOPK.INCRBY with increment=100000 (maximum valid increment per Redis docs).
 TEST_F(TopkFamilyTest, IncrByMaxIncrement) {
   ReserveDefault("tk", 5);
   auto resp = IncrByItem("tk", "foo", 100000);
-  EXPECT_EQ(resp.type, RespExpr::NIL);
+  EXPECT_THAT(resp, RespElementsAre(ArgType(RespExpr::NIL)));
 }
 
 // Tests that TOPK.INCRBY with increment=0 returns an error.
@@ -411,13 +413,13 @@ TEST_F(TopkFamilyTest, IncrByNoItems) {
 TEST_F(TopkFamilyTest, QueryPresentItem) {
   ReserveDefault("tk", 5);
   AddItem("tk", "foo");
-  EXPECT_THAT(Run({"topk.query", "tk", "foo"}), IntArg(1));
+  EXPECT_THAT(Run({"topk.query", "tk", "foo"}), RespElementsAre(IntArg(1)));
 }
 
 // Tests TOPK.QUERY for an item that has never been added.
 TEST_F(TopkFamilyTest, QueryAbsentItem) {
   ReserveDefault("tk", 5);
-  EXPECT_THAT(Run({"topk.query", "tk", "neveradded"}), IntArg(0));
+  EXPECT_THAT(Run({"topk.query", "tk", "neveradded"}), RespElementsAre(IntArg(0)));
 }
 
 // Tests TOPK.QUERY with multiple items, mixing present and absent.
@@ -432,7 +434,7 @@ TEST_F(TopkFamilyTest, QueryMultipleMixed) {
 // Tests TOPK.QUERY on a just-reserved (empty) top-k.
 TEST_F(TopkFamilyTest, QueryEmptyTopk) {
   ReserveDefault("tk", 5);
-  EXPECT_THAT(Run({"topk.query", "tk", "anything"}), IntArg(0));
+  EXPECT_THAT(Run({"topk.query", "tk", "anything"}), RespElementsAre(IntArg(0)));
 }
 
 // Tests that TOPK.QUERY with no items returns an error.
@@ -451,13 +453,13 @@ TEST_F(TopkFamilyTest, CountSingleItem) {
   ReserveDefault("tk", 5);
   IncrByItem("tk", "foo", 10);
   auto resp = Run({"topk.count", "tk", "foo"});
-  EXPECT_GE(resp.GetInt(), 1);
+  EXPECT_GE(resp.GetVec()[0].GetInt().value_or(0), 1);
 }
 
 // Tests that TOPK.COUNT for a never-added item returns 0.
 TEST_F(TopkFamilyTest, CountAbsentItem) {
   ReserveDefault("tk", 5);
-  EXPECT_THAT(Run({"topk.count", "tk", "neveradded"}), IntArg(0));
+  EXPECT_THAT(Run({"topk.count", "tk", "neveradded"}), RespElementsAre(IntArg(0)));
 }
 
 // Tests TOPK.COUNT with multiple items and verifies relative ordering.
@@ -475,7 +477,7 @@ TEST_F(TopkFamilyTest, CountMultipleRelativeOrder) {
 // Tests TOPK.COUNT on an empty top-k for any item.
 TEST_F(TopkFamilyTest, CountEmptyTopk) {
   ReserveDefault("tk", 5);
-  EXPECT_THAT(Run({"topk.count", "tk", "anything"}), IntArg(0));
+  EXPECT_THAT(Run({"topk.count", "tk", "anything"}), RespElementsAre(IntArg(0)));
 }
 
 // Tests that TOPK.COUNT returns the estimated frequency from the sketch
@@ -488,14 +490,14 @@ TEST_F(TopkFamilyTest, CountItemOutsideOfHeap) {
   IncrByItem("tk", "heavy", 1000);
   IncrByItem("tk", "victim", 5);
 
-  EXPECT_THAT(Run({"topk.query", "tk", "victim"}), IntArg(0));
+  EXPECT_THAT(Run({"topk.query", "tk", "victim"}), RespElementsAre(IntArg(0)));
 
   // Use EXPECT_GE because Count-Min Sketch guarantees count >= actual,
   // but hash collisions can technically cause overestimation.
   auto count_victim = Run({"topk.count", "tk", "victim"});
-  EXPECT_GE(count_victim.GetInt().value_or(0), 5);
+  EXPECT_GE(count_victim.GetVec()[0].GetInt().value_or(0), 5);
   auto count_heavy = Run({"topk.count", "tk", "heavy"});
-  EXPECT_GE(count_heavy.GetInt().value_or(0), 1000);
+  EXPECT_GE(count_heavy.GetVec()[0].GetInt().value_or(0), 1000);
 }
 
 // Tests that TOPK.COUNT with no items returns an error.
@@ -658,11 +660,11 @@ TEST_F(TopkFamilyTest, FrequencyAccuracy) {
 
   // The top-3 should still contain our heavy items
   auto resp = Run({"topk.query", "tk", "alpha"});
-  EXPECT_THAT(resp, IntArg(1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
   resp = Run({"topk.query", "tk", "beta"});
-  EXPECT_THAT(resp, IntArg(1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
   resp = Run({"topk.query", "tk", "gamma"});
-  EXPECT_THAT(resp, IntArg(1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
 }
 
 // Tests that multiple independent TOPK keys do not interfere with each other.
@@ -673,11 +675,11 @@ TEST_F(TopkFamilyTest, MultipleKeysIsolation) {
   AddItem("tk1", "onlyin1");
   AddItem("tk2", "onlyin2");
 
-  EXPECT_THAT(Run({"topk.query", "tk1", "onlyin1"}), IntArg(1));
-  EXPECT_THAT(Run({"topk.query", "tk1", "onlyin2"}), IntArg(0));
+  EXPECT_THAT(Run({"topk.query", "tk1", "onlyin1"}), RespElementsAre(IntArg(1)));
+  EXPECT_THAT(Run({"topk.query", "tk1", "onlyin2"}), RespElementsAre(IntArg(0)));
 
-  EXPECT_THAT(Run({"topk.query", "tk2", "onlyin2"}), IntArg(1));
-  EXPECT_THAT(Run({"topk.query", "tk2", "onlyin1"}), IntArg(0));
+  EXPECT_THAT(Run({"topk.query", "tk2", "onlyin2"}), RespElementsAre(IntArg(1)));
+  EXPECT_THAT(Run({"topk.query", "tk2", "onlyin1"}), RespElementsAre(IntArg(0)));
 
   // Verify INFO returns correct per-key parameters
   auto info1 = Run({"topk.info", "tk1"});
@@ -697,18 +699,18 @@ TEST_F(TopkFamilyTest, AddAndIncrByInteraction) {
   // Add item via ADD (count +1)
   AddItem("tk", "foo");
   auto resp = Run({"topk.query", "tk", "foo"});
-  EXPECT_THAT(resp, IntArg(1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
 
   // Increment same item via INCRBY — item should still be in top-k
   IncrByItem("tk", "foo", 100);
   resp = Run({"topk.query", "tk", "foo"});
-  EXPECT_THAT(resp, IntArg(1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
 
   // Add a different item via ADD, then boost via INCRBY
   AddItem("tk", "bar");
   IncrByItem("tk", "bar", 50);
   resp = Run({"topk.query", "tk", "bar"});
-  EXPECT_THAT(resp, IntArg(1));
+  EXPECT_THAT(resp, RespElementsAre(IntArg(1)));
 }
 
 // Tests behavior under high contention: many distinct items with the same count

--- a/src/server/zset_family_test.cc
+++ b/src/server/zset_family_test.cc
@@ -189,8 +189,8 @@ TEST_F(ZSetFamilyTest, ZRem) {
 
   resp = Run({"zcard", "x"});
   EXPECT_THAT(resp, IntArg(1));
-  EXPECT_THAT(Run({"zrange", "x", "0", "3", "byscore"}), "a");
-  EXPECT_THAT(Run({"zrange", "x", "(-inf", "(+inf", "byscore"}), "a");
+  EXPECT_THAT(Run({"zrange", "x", "0", "3", "byscore"}), RespElementsAre("a"));
+  EXPECT_THAT(Run({"zrange", "x", "(-inf", "(+inf", "byscore"}), RespElementsAre("a"));
 }
 
 TEST_F(ZSetFamilyTest, ZRandMember) {
@@ -199,12 +199,11 @@ TEST_F(ZSetFamilyTest, ZRandMember) {
 
   // Test if count > 0
   resp = Run({"ZRandMember", "x"});
-  ASSERT_THAT(resp, ArgType(RespExpr::STRING));
-  EXPECT_THAT(resp, AnyOf("a", "b", "c"));
+  // ZRandMember always uses SendScoredArray which wraps in an array even without count arg.
+  EXPECT_THAT(resp, RespElementsAre(AnyOf("a", "b", "c")));
 
   resp = Run({"ZRandMember", "x", "1"});
-  ASSERT_THAT(resp, ArgType(RespExpr::STRING));
-  EXPECT_THAT(resp, AnyOf("a", "b", "c"));
+  EXPECT_THAT(resp, RespElementsAre(AnyOf("a", "b", "c")));
 
   resp = Run({"ZRandMember", "x", "2"});
   ASSERT_THAT(resp, ArrLen(2));
@@ -216,8 +215,7 @@ TEST_F(ZSetFamilyTest, ZRandMember) {
 
   // Test if count < 0
   resp = Run({"ZRandMember", "x", "-1"});
-  ASSERT_THAT(resp, ArgType(RespExpr::STRING));
-  EXPECT_THAT(resp, AnyOf("a", "b", "c"));
+  EXPECT_THAT(resp, RespElementsAre(AnyOf("a", "b", "c")));
 
   resp = Run({"ZRandMember", "x", "-2"});
   ASSERT_THAT(resp, ArrLen(2));
@@ -298,7 +296,7 @@ TEST_F(ZSetFamilyTest, ZMScore) {
 TEST_F(ZSetFamilyTest, ZMScoreNonExistentKeys) {
   // Case 1: Single member with non-existent key (ZMSCORE abc x)
   auto resp = Run({"zmscore", "abc", "x"});
-  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
+  EXPECT_THAT(resp, RespElementsAre(ArgType(RespExpr::NIL)));
 
   // Case 2: Multiple members with non-existent key (ZMSCORE abc x y z)
   resp = Run({"zmscore", "abc", "x", "y", "z"});
@@ -309,7 +307,7 @@ TEST_F(ZSetFamilyTest, ZMScoreNonExistentKeys) {
 TEST_F(ZSetFamilyTest, ByScore) {
   Run({"zadd", "x", "1.1", "a", "2.1", "b"});
   EXPECT_THAT(Run({"zrangebyscore", "x", "0", "(1.1"}), ArrLen(0));
-  EXPECT_THAT(Run({"zrangebyscore", "x", "-inf", "1.1", "limit", "0", "10"}), "a");
+  EXPECT_THAT(Run({"zrangebyscore", "x", "-inf", "1.1", "limit", "0", "10"}), RespElementsAre("a"));
 
   auto resp = Run({"zrangebyscore", "x", "-inf", "1.1", "limit", "0", "10", "WITHSCORES"});
   ASSERT_THAT(resp, ArrLen(2));
@@ -386,7 +384,7 @@ TEST_F(ZSetFamilyTest, ZRemRangeRank) {
   Run({"zadd", "x", "1.1", "a", "2.1", "b"});
   EXPECT_THAT(Run({"ZREMRANGEBYRANK", "y", "0", "1"}), IntArg(0));
   EXPECT_THAT(Run({"ZREMRANGEBYRANK", "x", "0", "0"}), IntArg(1));
-  EXPECT_EQ(Run({"zrange", "x", "0", "5"}), "b");
+  EXPECT_THAT(Run({"zrange", "x", "0", "5"}), RespElementsAre("b"));
   EXPECT_THAT(Run({"ZREMRANGEBYRANK", "x", "0", "1"}), IntArg(1));
   EXPECT_EQ(Run({"type", "x"}), "none");
 }
@@ -395,7 +393,7 @@ TEST_F(ZSetFamilyTest, ZRemRangeScore) {
   Run({"zadd", "x", "1.1", "a", "2.1", "b"});
   EXPECT_THAT(Run({"ZREMRANGEBYSCORE", "y", "0", "1"}), IntArg(0));
   EXPECT_THAT(Run({"ZREMRANGEBYSCORE", "x", "-inf", "1.1"}), IntArg(1));
-  EXPECT_EQ(Run({"zrange", "x", "0", "5"}), "b");
+  EXPECT_THAT(Run({"zrange", "x", "0", "5"}), RespElementsAre("b"));
   EXPECT_THAT(Run({"ZREMRANGEBYSCORE", "x", "(2.0", "+inf"}), IntArg(1));
   EXPECT_EQ(Run({"type", "x"}), "none");
   EXPECT_THAT(Run({"zremrangebyscore", "x", "1", "NaN"}), ErrArg("min or max is not a float"));
@@ -434,7 +432,7 @@ TEST_F(ZSetFamilyTest, ByLex) {
   ASSERT_THAT(resp.GetVec(), ElementsAre("cool", "down", "elephant"));
 
   resp = Run({"zrangebylex", "key", "-", "+", "LIMIT", "5", "1"});
-  ASSERT_THAT(resp, "foo");
+  ASSERT_THAT(resp, RespElementsAre("foo"));
 }
 
 TEST_F(ZSetFamilyTest, ZRevRangeByLex) {


### PR DESCRIPTION
Remove `RespVec` wrapper and return `RespExpr` directly. 

The old parser would unwrap top level arrays and the calling code would unwrap single element arrays to scalar. None of this needed and we return `RespExpr` directly.