### PR TITLE
feat(server): Implement COMMAND LIST (#5466)

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -5,7 +5,7 @@
 #include "server/main_service.h"
 
 #include "absl/strings/str_split.h"
-#include "facade/resp_expr.h"
+#include "core/glob_matcher.h"
 #include "util/fibers/detail/fiber_interface.h"
 #include "util/fibers/proactor_base.h"
 #include "util/fibers/synchronization.h"
@@ -28,7 +28,7 @@ extern "C" {
 #include <xxhash.h>
 
 #include <csignal>
-#include <filesystem>
+#include <optional>
 
 #include "base/cycle_clock.h"
 #include "base/flag_utils.h"
@@ -2729,38 +2729,117 @@ void Service::Command(CmdArgList args, CommandContext* cmd_cntx) {
     return rb->SendLong(cmd_cnt);
   }
 
-  bool sufficient_args = (args.size() == 2);
+  // INFO [command-name [command-name ...]]
+  if (subcmd == "INFO") {
+    const auto total_cmds = static_cast<uint32_t>(args.size() - 1);
+    rb->StartArray(total_cmds);
 
-  // INFO [cmd]
-  if (subcmd == "INFO" && sufficient_args) {
-    string cmd = absl::AsciiStrToUpper(ArgS(args, 1));
+    std::string cmd_name_buf;
+    for (size_t i = 1; i < args.size(); ++i) {
+      std::string_view raw_arg = ArgS(args, i);
 
-    if (const auto* cid = registry_.Find(cmd); cid) {
-      rb->StartArray(1);
-      serialize_command(cmd, *cid);
-    } else {
-      rb->SendNull();
+      // Resize/clear the buffer without necessarily deallocating capacity
+      cmd_name_buf.assign(raw_arg);
+      absl::AsciiStrToUpper(&cmd_name_buf);
+
+      if (const auto* cid = registry_.Find(cmd_name_buf)) {
+        serialize_command(cid->name(), *cid);
+      } else {
+        rb->SendNull();
+      }
     }
-
     return;
   }
 
-  sufficient_args = (args.size() == 1);
-  if (subcmd == "DOCS" && sufficient_args) {
+  // LIST [FILTERBY <MODULE module-name | ACLCAT category | PATTERN pattern>]
+  if (subcmd == "LIST") {
+    if (args.size() != 1 && args.size() != 4)
+      return rb->SendError(kSyntaxErr, kSyntaxErrType);
+
+    string_view filter_type, filter_value;
+    uint32_t cat_bit = 0;
+    bool is_pattern = false;
+
+    // Parse filters and return early for non-traversal cases (syntax error, MODULE, invalid ACL)
+    if (args.size() == 4) {
+      if (!absl::EqualsIgnoreCase(ArgS(args, 1), "FILTERBY"))
+        return rb->SendError(kSyntaxErr, kSyntaxErrType);
+      filter_type = ArgS(args, 2);
+      filter_value = ArgS(args, 3);
+
+      if (absl::EqualsIgnoreCase(filter_type, "MODULE"))
+        return rb->SendEmptyArray();
+
+      if (absl::EqualsIgnoreCase(filter_type, "ACLCAT")) {
+        if (filter_value.empty())
+          return rb->SendEmptyArray();
+
+        const string_view cat = absl::StripPrefix(filter_value, "@");
+        const auto& rev_table = acl_family_.GetRevTable();
+        auto it = std::find_if(rev_table.begin(), rev_table.end(), [cat](string_view rev_cat) {
+          return absl::EqualsIgnoreCase(rev_cat, cat);
+        });
+
+        auto dist = std::distance(rev_table.begin(), it);
+        if (it == rev_table.end() || dist >= 32)
+          return rb->SendEmptyArray();
+        cat_bit = dist;
+      } else {
+        is_pattern = absl::EqualsIgnoreCase(filter_type, "PATTERN");
+        if (!is_pattern)
+          return rb->SendError(kSyntaxErr, kSyntaxErrType);
+      }
+    }
+
+    // Lazy-construct GlobMatcher only for PATTERN filter
+    std::optional<GlobMatcher> pattern_matcher;
+    if (is_pattern)
+      pattern_matcher.emplace(filter_value, false);
+
+    std::vector<string_view> matching_cmds;
+    registry_.Traverse([&](string_view name, const CommandId& cid) {
+      if (cid.opt_mask() & CO::HIDDEN)
+        return;
+
+      bool keep;
+      if (pattern_matcher)
+        keep = pattern_matcher->Matches(name);
+      else if (args.size() == 1)
+        keep = true;
+      else
+        keep = cid.acl_categories() & (1u << cat_bit);
+
+      if (keep)
+        matching_cmds.emplace_back(name);
+    });
+
+    rb->StartArray(matching_cmds.size());
+    for (string_view cmd_name : matching_cmds)
+      rb->SendBulkString(cmd_name);
+    return;
+  }
+
+  const bool no_args = (args.size() == 1);
+
+  // DOCS
+  if (subcmd == "DOCS" && no_args) {
     // Returning an error here forces the interactive CLI client to fall back to static hints and
     // tab completion
     return rb->SendError("COMMAND DOCS Not Implemented");
   }
 
-  if (subcmd == "HELP" && sufficient_args) {
+  // HELP
+  if (subcmd == "HELP" && no_args) {
     // Return help information for supported COMMAND subcommands
     constexpr string_view help[] = {
         "(no subcommand)",
         "    Return details about all commands.",
-        "INFO command-name",
-        "    Return details about specified command.",
         "COUNT",
         "    Return the total number of commands in this server.",
+        "INFO [<command-name> ...]",
+        "    Return details about one or more commands.",
+        "LIST [FILTERBY <MODULE module-name | ACLCAT category | PATTERN pattern>]",
+        "    Return a list of command names, optionally filtered.",
     };
     return rb->SendSimpleStrArr(help);
   }

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2711,14 +2711,19 @@ void Service::Command(CmdArgList args, CommandContext* cmd_cntx) {
     }
   };
 
-  // If no arguments are specified, reply with all commands
-  if (args.empty()) {
+  // Helper to return all non-hidden commands
+  auto send_all_commands = [rb, &serialize_command, &cmd_cnt, this]() {
     rb->StartArray(cmd_cnt);
-    registry_.Traverse([&](string_view name, const CommandId& cid) {
+    registry_.Traverse([&](const string_view name, const CommandId& cid) {
       if (cid.opt_mask() & CO::HIDDEN)
         return;
       serialize_command(name, cid);
     });
+  };
+
+  // If no arguments are specified, reply with all commands
+  if (args.empty()) {
+    send_all_commands();
     return;
   }
 
@@ -2731,6 +2736,12 @@ void Service::Command(CmdArgList args, CommandContext* cmd_cntx) {
 
   // INFO [command-name [command-name ...]]
   if (subcmd == "INFO") {
+    // Returning all available commands when COMMAND INFO with no args called
+    if (args.size() == 1) {
+      send_all_commands();
+      return;
+    }
+
     const auto total_cmds = static_cast<uint32_t>(args.size() - 1);
     rb->StartArray(total_cmds);
 
@@ -2781,7 +2792,8 @@ void Service::Command(CmdArgList args, CommandContext* cmd_cntx) {
         });
 
         auto dist = std::distance(rev_table.begin(), it);
-        if (it == rev_table.end() || dist >= 32)
+        // Enforce 32-bit width of the acl_categories bitmask.
+        if (it == rev_table.end() || std::cmp_greater_equal(dist, sizeof(acl::AclCat) * CHAR_BIT))
           return rb->SendEmptyArray();
         cat_bit = dist;
       } else {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -5,7 +5,7 @@
 #include "server/main_service.h"
 
 #include "absl/strings/str_split.h"
-#include "facade/resp_expr.h"
+#include "core/glob_matcher.h"
 #include "util/fibers/detail/fiber_interface.h"
 #include "util/fibers/fibers.h"
 #include "util/fibers/proactor_base.h"
@@ -2917,6 +2917,120 @@ void Service::Command(CmdArgParser parser, CommandContext* cmd_cntx) {
     return;
   }
 
+  // LIST [FILTERBY <MODULE module-name | ACLCAT category | PATTERN pattern>]
+  if (subcmd == "LIST") {
+    // COMMAND LIST
+    if (!parser.HasNext()) {
+      vector<string_view> matching_cmds;
+
+      registry_.Traverse([&](string_view name, const CommandId& cid) {
+        if (cid.opt_mask() & CO::HIDDEN)
+          return;
+
+        matching_cmds.emplace_back(name);
+      });
+
+      rb->StartArray(matching_cmds.size());
+      for (string_view cmd_name : matching_cmds)
+        rb->SendBulkString(cmd_name);
+
+      return;
+    }
+
+    // LIST must be followed by FILTERBY.
+    parser.ExpectTag("FILTERBY");
+    if (parser.HasError()) {
+      parser.TakeError();
+      return rb->SendError(kSyntaxErr, kSyntaxErrType);
+    }
+
+    if (!parser.HasNext())
+      return rb->SendError(kSyntaxErr, kSyntaxErrType);
+
+    string filter_type = absl::AsciiStrToUpper(parser.Next());
+
+    if (!parser.HasNext())
+      return rb->SendError(kSyntaxErr, kSyntaxErrType);
+
+    string_view filter_value = parser.Next();
+
+    // MODULE commands are not supported by Dragonfly.
+    if (filter_type == "MODULE") {
+      if (parser.HasNext())
+        return rb->SendError(kSyntaxErr, kSyntaxErrType);
+
+      return rb->SendEmptyArray();
+    }
+
+    uint32_t cat_bit = 0;
+    bool is_pattern = false;
+
+    if (filter_type == "ACLCAT") {
+      if (filter_value.empty()) {
+        if (parser.HasNext())
+          return rb->SendError(kSyntaxErr, kSyntaxErrType);
+
+        return rb->SendEmptyArray();
+      }
+
+      if (parser.HasNext())
+        return rb->SendError(kSyntaxErr, kSyntaxErrType);
+
+      const string_view cat = absl::StripPrefix(filter_value, "@");
+      const auto& rev_table = acl_family_.GetRevTable();
+
+      auto it = std::find_if(rev_table.begin(), rev_table.end(), [cat](string_view rev_cat) {
+        return absl::EqualsIgnoreCase(rev_cat, cat);
+      });
+
+      auto dist = std::distance(rev_table.begin(), it);
+
+      // Enforce 32-bit width of the ACL category bitmask.
+      if (it == rev_table.end() || std::cmp_greater_equal(dist, sizeof(acl::AclCat) * CHAR_BIT)) {
+        return rb->SendEmptyArray();
+      }
+
+      cat_bit = dist;
+    } else if (filter_type == "PATTERN") {
+      if (parser.HasNext())
+        return rb->SendError(kSyntaxErr, kSyntaxErrType);
+
+      is_pattern = true;
+    } else {
+      return rb->SendError(kSyntaxErr, kSyntaxErrType);
+    }
+
+    // Lazy-construct GlobMatcher only for PATTERN filter.
+    std::optional<GlobMatcher> pattern_matcher;
+    if (is_pattern)
+      pattern_matcher.emplace(filter_value, false);
+
+    vector<string_view> matching_cmds;
+
+    registry_.Traverse([&](string_view name, const CommandId& cid) {
+      if (cid.opt_mask() & CO::HIDDEN)
+        return;
+
+      bool keep = false;
+
+      if (pattern_matcher) {
+        keep = pattern_matcher->Matches(name);
+      } else {
+        keep = cid.acl_categories() & (1u << cat_bit);
+      }
+
+      if (keep)
+        matching_cmds.emplace_back(name);
+    });
+
+    rb->StartArray(matching_cmds.size());
+
+    for (string_view cmd_name : matching_cmds)
+      rb->SendBulkString(cmd_name);
+
+    return;
+  }
+
   if (subcmd == "DOCS" && !parser.HasNext()) {
     // Returning an error here forces the interactive CLI client to fall back to static hints and
     // tab completion
@@ -2928,10 +3042,12 @@ void Service::Command(CmdArgParser parser, CommandContext* cmd_cntx) {
     constexpr string_view help[] = {
         "(no subcommand)",
         "    Return details about all commands.",
-        "INFO command-name",
-        "    Return details about specified command.",
         "COUNT",
         "    Return the total number of commands in this server.",
+        "INFO [<command-name> ...]",
+        "    Return details about one or more commands.",
+        "LIST [FILTERBY <MODULE module-name | ACLCAT category | PATTERN pattern>]",
+        "    Return a list of command names, optionally filtered.",
     };
     return rb->SendSimpleStrArr(help);
   }

--- a/src/server/server_family_test.cc
+++ b/src/server/server_family_test.cc
@@ -9,7 +9,7 @@
 #include "absl/strings/str_cat.h"
 #include "base/flags.h"
 #include "base/gtest.h"
-#include "base/logging.h"
+#include "facade/error.h"
 #include "facade/facade_test.h"
 #include "facade/socket_utils.h"
 #include "server/test_utils.h"
@@ -791,6 +791,134 @@ TEST_F(ServerFamilyTest, InfoReplicationMemoryOnlyInMemorySection) {
   EXPECT_THAT(Run({"INFO", "MEMORY"}).GetString(), HasSubstr("replication_streaming_buffer_bytes"));
   EXPECT_THAT(Run({"INFO"}).GetString(), HasSubstr("replication_streaming_buffer_bytes"));
   EXPECT_THAT(Run({"INFO", "ALL"}).GetString(), HasSubstr("replication_streaming_buffer_bytes"));
+}
+
+TEST_F(ServerFamilyTest, CommandInfo) {
+  // CASE: Single valid command
+  auto resp = Run({"command", "info", "get"});
+  // Validating size as 7 instead of 1 because Run() flattens a single top-level response array.
+  ASSERT_EQ(resp.GetVec().size(), 1);
+
+  // CASE: Multiple valid commands
+  resp = Run({"command", "info", "get", "set"});
+  ASSERT_EQ(resp.GetVec().size(), 2);
+  ASSERT_EQ(resp.GetVec()[0].type, RespExpr::ARRAY);
+  ASSERT_EQ(resp.GetVec()[0].GetVec().size(), 7);
+  ASSERT_EQ(resp.GetVec()[1].type, RespExpr::ARRAY);
+  ASSERT_EQ(resp.GetVec()[1].GetVec().size(), 7);
+
+  // CASE: Unknown command
+  resp = Run({"command", "info", "nonExistentCommand"});
+  ASSERT_EQ(resp.GetVec().size(), 1);
+  EXPECT_EQ(resp.GetVec()[0].type, RespExpr::NIL);
+
+  // CASE: Multiple unknown commands
+  resp = Run({"command", "info", "nonExistentCommand", "anotherUnknown"});
+  ASSERT_EQ(resp.GetVec().size(), 2);
+  EXPECT_EQ(resp.GetVec()[0].type, RespExpr::NIL);
+  EXPECT_EQ(resp.GetVec()[1].type, RespExpr::NIL);
+
+  // CASE: Mixed valid + unknown commands
+  resp = Run({"command", "info", "get", "nonexistent"});
+  ASSERT_EQ(resp.GetVec().size(), 2);
+  EXPECT_EQ(resp.GetVec()[0].type, RespExpr::ARRAY);
+  EXPECT_EQ(resp.GetVec()[0].GetVec().size(), 7);
+  EXPECT_EQ(resp.GetVec()[1].type, RespExpr::NIL);
+
+  // CASE: Duplicate args
+  resp = Run({"command", "info", "get", "GET"});
+  EXPECT_EQ(resp.GetVec().size(), 2);
+  EXPECT_EQ(resp.GetVec()[0].type, RespExpr::ARRAY);
+  EXPECT_EQ(resp.GetVec()[1].type, RespExpr::ARRAY);
+
+  // CASE: No args
+  resp = Run({"command", "info"});
+  EXPECT_EQ(resp.GetVec().size(), 0);
+}
+
+TEST_F(ServerFamilyTest, CommandList) {
+  // CASE: No filter
+  auto resp = Run({"command", "list"});
+  const size_t total = resp.GetVec().size();
+  EXPECT_EQ(total, CheckedInt({"command", "count"}));
+
+  // Also validating all entries are strings
+  for (const auto& entry : resp.GetVec())
+    EXPECT_EQ(entry.type, RespExpr::STRING);
+
+  // CASE: PATTERN — known match
+  resp = Run({"command", "list", "filterby", "pattern", "gEt*"});
+  ASSERT_GT(resp.GetVec().size(), 0);
+  for (const auto& entry : resp.GetVec()) {
+    const string name = absl::AsciiStrToLower(entry.GetString());
+    EXPECT_TRUE(absl::StartsWith(name, "get"));
+  }
+
+  // CASE: PATTERN — no match
+  resp = Run({"command", "list", "filterby", "pattern", "zzznomatch*"});
+  EXPECT_EQ(resp.GetVec().size(), 0);
+
+  // CASE: PATTERN exact match (no wildcards)
+  resp = Run({"command", "list", "filterby", "pattern", "GET"});
+  ASSERT_EQ(resp.GetVec().size(), 1);
+  EXPECT_EQ(absl::AsciiStrToUpper(resp.GetVec()[0].GetString()), "GET");
+
+  // CASE: PATTERN wildcard-only matches everything
+  resp = Run({"command", "list", "filterby", "pattern", "*"});
+  EXPECT_EQ(resp.GetVec().size(), total);
+
+  // CASE: PATTERN with ? single-char wildcard
+  resp = Run({"command", "list", "filterby", "pattern", "G?T"});
+  ASSERT_GT(resp.GetVec().size(), 0);
+  for (const auto& entry : resp.GetVec())
+    EXPECT_EQ(absl::AsciiStrToUpper(entry.GetString()).size(), 3);
+
+  // CASE: PATTERN with character class
+  resp = Run({"command", "list", "filterby", "pattern", "[gs]et"});
+  ASSERT_GE(resp.GetVec().size(), 1);
+  for (const auto& entry : resp.GetVec()) {
+    const string name = absl::AsciiStrToLower(entry.GetString());
+    EXPECT_TRUE(name == "get" || name == "set");
+  }
+
+  // CASE: PATTERN empty string
+  resp = Run({"command", "list", "filterby", "pattern", ""});
+  EXPECT_EQ(resp.GetVec().size(), 0);
+
+  // CASE: FILTERBY is case-insensitive
+  resp = Run({"command", "list", "FilterBy", "pattern", "gEt*"});
+  EXPECT_GT(resp.GetVec().size(), 0);
+
+  // CASE: ACLCAT — verify response entries are strings (like bare LIST)
+  resp = Run({"command", "list", "filterby", "aclcat", "string"});
+  ASSERT_GT(resp.GetVec().size(), 0);
+  for (const auto& entry : resp.GetVec())
+    EXPECT_EQ(entry.type, RespExpr::STRING);
+
+  // CASE: ACLCAT with @ prefix (same results as without)
+  auto resp2 = Run({"command", "list", "filterby", "aclcat", "@string"});
+  EXPECT_EQ(resp.GetVec().size(), resp2.GetVec().size());
+
+  // CASE: ACLCAT unknown category
+  resp = Run({"command", "list", "filterby", "aclcat", "nonexistent"});
+  EXPECT_EQ(resp.GetVec().size(), 0);
+
+  // CASE: ACLCAT empty category
+  resp = Run({"command", "list", "filterby", "aclcat", ""});
+  EXPECT_EQ(resp.GetVec().size(), 0);
+
+  // CASE: MODULE
+  resp = Run({"command", "list", "filterby", "module", "anything"});
+  EXPECT_EQ(resp.GetVec().size(), 0);
+
+  // CASE: Validating syntax errors
+  EXPECT_THAT(Run({"command", "list", "extraarg"}), ErrArg(kSyntaxErr));
+  EXPECT_THAT(Run({"command", "list", "filterby"}), ErrArg(kSyntaxErr));
+  EXPECT_THAT(Run({"command", "list", "filterby", "pattern"}), ErrArg(kSyntaxErr));
+  EXPECT_THAT(Run({"command", "list", "notfilterby", "pattern", "g*"}), ErrArg(kSyntaxErr));
+
+  // CASE: Unknown filter type
+  EXPECT_THAT(Run({"command", "list", "filterby", "unknown", "x"}), ErrArg(kSyntaxErr));
 }
 
 }  // namespace dfly

--- a/src/server/server_family_test.cc
+++ b/src/server/server_family_test.cc
@@ -833,7 +833,7 @@ TEST_F(ServerFamilyTest, CommandInfo) {
 
   // CASE: No args
   resp = Run({"command", "info"});
-  EXPECT_EQ(resp.GetVec().size(), 0);
+  EXPECT_EQ(resp.GetVec().size(), CheckedInt({"command", "count"}));
 }
 
 TEST_F(ServerFamilyTest, CommandList) {

--- a/src/server/server_family_test.cc
+++ b/src/server/server_family_test.cc
@@ -9,7 +9,7 @@
 #include "absl/strings/str_cat.h"
 #include "base/flags.h"
 #include "base/gtest.h"
-#include "base/logging.h"
+#include "facade/error.h"
 #include "facade/facade_test.h"
 #include "facade/socket_utils.h"
 #include "server/test_utils.h"
@@ -904,6 +904,91 @@ TEST_F(ServerFamilyTest, InfoCommandStatsAggregation) {
 
 TEST_F(ServerFamilyTest, InfoClusterMigrationErrors) {
   EXPECT_THAT(Run({"INFO", "CLUSTER"}).GetString(), HasSubstr("migration_errors_total:0"));
+}
+
+TEST_F(ServerFamilyTest, CommandList) {
+  // CASE: No filter
+  auto resp = Run({"command", "list"});
+  const size_t total = resp.GetVec().size();
+  EXPECT_EQ(total, CheckedInt({"command", "count"}));
+
+  // Also validating all entries are strings
+  for (const auto& entry : resp.GetVec())
+    EXPECT_EQ(entry.type, RespExpr::STRING);
+
+  // CASE: PATTERN — known match
+  resp = Run({"command", "list", "filterby", "pattern", "gEt*"});
+  ASSERT_GT(resp.GetVec().size(), 0);
+  for (const auto& entry : resp.GetVec()) {
+    const string name = absl::AsciiStrToLower(entry.GetString());
+    EXPECT_TRUE(absl::StartsWith(name, "get"));
+  }
+
+  // CASE: PATTERN — no match
+  resp = Run({"command", "list", "filterby", "pattern", "zzznomatch*"});
+  EXPECT_EQ(resp.GetVec().size(), 0);
+
+  // CASE: PATTERN exact match (no wildcards)
+  resp = Run({"command", "list", "filterby", "pattern", "GET"});
+  ASSERT_EQ(resp.GetVec().size(), 1);
+  EXPECT_EQ(absl::AsciiStrToUpper(resp.GetVec()[0].GetString()), "GET");
+
+  // CASE: PATTERN wildcard-only matches everything
+  resp = Run({"command", "list", "filterby", "pattern", "*"});
+  EXPECT_EQ(resp.GetVec().size(), total);
+
+  // CASE: PATTERN with ? single-char wildcard
+  resp = Run({"command", "list", "filterby", "pattern", "G?T"});
+  ASSERT_GT(resp.GetVec().size(), 0);
+  for (const auto& entry : resp.GetVec())
+    EXPECT_EQ(absl::AsciiStrToUpper(entry.GetString()).size(), 3);
+
+  // CASE: PATTERN with character class
+  resp = Run({"command", "list", "filterby", "pattern", "[gs]et"});
+  ASSERT_GE(resp.GetVec().size(), 1);
+  for (const auto& entry : resp.GetVec()) {
+    const string name = absl::AsciiStrToLower(entry.GetString());
+    EXPECT_TRUE(name == "get" || name == "set");
+  }
+
+  // CASE: PATTERN empty string
+  resp = Run({"command", "list", "filterby", "pattern", ""});
+  EXPECT_EQ(resp.GetVec().size(), 0);
+
+  // CASE: FILTERBY is case-insensitive
+  resp = Run({"command", "list", "FilterBy", "pattern", "gEt*"});
+  EXPECT_GT(resp.GetVec().size(), 0);
+
+  // CASE: ACLCAT — verify response entries are strings (like bare LIST)
+  resp = Run({"command", "list", "filterby", "aclcat", "string"});
+  ASSERT_GT(resp.GetVec().size(), 0);
+  for (const auto& entry : resp.GetVec())
+    EXPECT_EQ(entry.type, RespExpr::STRING);
+
+  // CASE: ACLCAT with @ prefix (same results as without)
+  auto resp2 = Run({"command", "list", "filterby", "aclcat", "@string"});
+  EXPECT_EQ(resp.GetVec().size(), resp2.GetVec().size());
+
+  // CASE: ACLCAT unknown category
+  resp = Run({"command", "list", "filterby", "aclcat", "nonexistent"});
+  EXPECT_EQ(resp.GetVec().size(), 0);
+
+  // CASE: ACLCAT empty category
+  resp = Run({"command", "list", "filterby", "aclcat", ""});
+  EXPECT_EQ(resp.GetVec().size(), 0);
+
+  // CASE: MODULE
+  resp = Run({"command", "list", "filterby", "module", "anything"});
+  EXPECT_EQ(resp.GetVec().size(), 0);
+
+  // CASE: Validating syntax errors
+  EXPECT_THAT(Run({"command", "list", "extraarg"}), ErrArg(kSyntaxErr));
+  EXPECT_THAT(Run({"command", "list", "filterby"}), ErrArg(kSyntaxErr));
+  EXPECT_THAT(Run({"command", "list", "filterby", "pattern"}), ErrArg(kSyntaxErr));
+  EXPECT_THAT(Run({"command", "list", "notfilterby", "pattern", "g*"}), ErrArg(kSyntaxErr));
+
+  // CASE: Unknown filter type
+  EXPECT_THAT(Run({"command", "list", "filterby", "unknown", "x"}), ErrArg(kSyntaxErr));
 }
 
 }  // namespace dfly


### PR DESCRIPTION
- Implements COMMAND LIST with FILTERBY MODULE (empty array, no module system), FILTERBY ACLCAT (case-insensitive, strips leading @), and FILTERBY PATTERN (GlobMatcher, case-insensitive). Unknown filter types return kSyntaxErr.
- Adds tests for LIST subcommand in server_family_test.cc.
- Updates COMMAND HELP strings to reflect new subcommand signatures.
