### PR TITLE
facade: Trim parsed args if capacity much higher than size

### DIFF
--- a/src/common/backed_args.h
+++ b/src/common/backed_args.h
@@ -16,6 +16,8 @@ class BackedArguments {
   constexpr static size_t kLenCap = 5;
   constexpr static size_t kStorageCap = 88;
 
+  constexpr static size_t kShrinkFloor = 64 << 10;  // 256 KiB
+
  public:
   using value_type = std::string_view;
 
@@ -93,6 +95,13 @@ class BackedArguments {
     // Clear the contents without deallocating memory. clear() deallocates inlined_vector.
     offsets_.resize(0);
     storage_.resize(0);
+  }
+
+  void MaybeShrink() {
+    if (storage_.capacity() > kShrinkFloor && storage_.size() < storage_.capacity() / 2) {
+      storage_.shrink_to_fit();
+      offsets_.shrink_to_fit();
+    }
   }
 
   std::string_view back() const {

--- a/src/facade/parsed_command.cc
+++ b/src/facade/parsed_command.cc
@@ -52,10 +52,11 @@ void ParsedCommand::ResetForReuse() {
   is_deferred_reply_ = false;
   reply_ = std::monostate{};
 
-  offsets_.clear();
+  offsets_.resize(0);
+  offsets_.shrink_to_fit();
   if (HeapMemory() > 1024) {
-    storage_.clear();  // also deallocates the heap.
-    offsets_.shrink_to_fit();
+    storage_.resize(0);
+    storage_.shrink_to_fit();
   }
   ReuseInternal();
 }

--- a/src/facade/resp_srv_parser.cc
+++ b/src/facade/resp_srv_parser.cc
@@ -90,6 +90,7 @@ auto RespSrvParser::Parse(Buffer str, uint32_t* consumed, cmn::BackedArguments* 
     return resultc.first;
   }
 
+  args->MaybeShrink();
   return resultc.first;
 }
 

--- a/src/facade/resp_srv_parser_test.cc
+++ b/src/facade/resp_srv_parser_test.cc
@@ -211,4 +211,28 @@ TEST_F(RespSrvParserTest, InlineReset) {
   EXPECT_EQ(13, consumed_);
 }
 
+static string SetCmd(size_t val_size) {
+  const string val(val_size, 'x');
+  return absl::StrCat("*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$", val_size, "\r\n", val, "\r\n");
+}
+
+TEST_F(RespSrvParserTest, ResetForParseChecksFloor) {
+  ASSERT_EQ(RespSrvParser::OK, Parse(SetCmd(10 * 1024)));
+  const size_t grown = args_.HeapMemory();
+  EXPECT_GE(grown, 10 * 1024);
+
+  ASSERT_EQ(RespSrvParser::OK, Parse("*1\r\n$4\r\nPING\r\n"));
+  ASSERT_EQ(RespSrvParser::OK, Parse("*1\r\n$4\r\nPING\r\n"));
+  // not reclaimed if below floor
+  EXPECT_EQ(grown, args_.HeapMemory());
+}
+
+TEST_F(RespSrvParserTest, ResetForParseShrinksAfterSingleCommand) {
+  ASSERT_EQ(RespSrvParser::OK, Parse(SetCmd(512 * 1024)));
+  EXPECT_GE(args_.HeapMemory(), 512u * 1024);
+
+  ASSERT_EQ(RespSrvParser::OK, Parse("*1\r\n$4\r\nPING\r\n"));
+  EXPECT_EQ(0u, args_.HeapMemory());
+}
+
 }  // namespace facade


### PR DESCRIPTION
backport of https://github.com/dragonflydb/dragonfly/pull/7378