### PR TITLE
perf(server): reduce ProactorBase::GetMonotonicTimeNs callers

### DIFF
--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -511,12 +511,12 @@ static void RunFPeriodically(std::function<void()> f, std::chrono::milliseconds 
       return;
     }
 
-    int64_t now_ms = fb2::ProactorBase::GetMonotonicTimeNs() / 1000000;
+    int64_t now_ms = absl::GetCurrentTimeNanos() / 1000000;
     if (now_ms - 5 * period_ms.count() > last_heartbeat_ms) {
       VLOG(1) << "This " << error_msg << " step took " << now_ms - last_heartbeat_ms << "ms";
     }
     f();
-    last_heartbeat_ms = fb2::ProactorBase::GetMonotonicTimeNs() / 1000000;
+    last_heartbeat_ms = absl::GetCurrentTimeNanos() / 1000000;
   }
 }
 
@@ -1022,10 +1022,6 @@ size_t EngineShard::CalculateEvictionBytes() {
 }
 
 void EngineShard::CacheStats() {
-  uint64_t now = fb2::ProactorBase::GetMonotonicTimeNs();
-  if (last_mem_params_.updated_at + 1000000 > now)  // 1ms
-    return;
-
   size_t used_mem = UsedMemory();
   DbSlice& db_slice = namespaces->GetDefaultNamespace().GetDbSlice(shard_id());
 
@@ -1047,7 +1043,7 @@ void EngineShard::CacheStats() {
   }
 
   db_slice.UpdateMemoryParams(free_mem / shard_set->size(), bytes_per_obj);
-  last_mem_params_ = {now, used_mem};
+  last_mem_params_ = {used_mem};
 }
 
 size_t EngineShard::UsedMemory() const {

--- a/src/server/engine_shard.h
+++ b/src/server/engine_shard.h
@@ -301,7 +301,6 @@ class EngineShard {
   MiMemoryResource mi_resource_;
 
   struct {
-    uint64_t updated_at = 0;  // from GetMonotonicTimeNs
     size_t used_mem = 0;
   } last_mem_params_;
 

--- a/src/server/protocol_client.cc
+++ b/src/server/protocol_client.cc
@@ -454,7 +454,7 @@ uint64_t ProtocolClient::LastIoTime() const {
 }
 
 void ProtocolClient::TouchIoTime() {
-  last_io_time_.store(Proactor()->GetMonotonicTimeNs(), std::memory_order_relaxed);
+  last_io_time_.store(TimeSec(), std::memory_order_relaxed);
 }
 
 }  // namespace dfly

--- a/src/server/protocol_client.h
+++ b/src/server/protocol_client.h
@@ -4,7 +4,9 @@
 #pragma once
 
 #include <absl/strings/escaping.h>
+#include <time.h>
 
+#include <cstdint>
 #include <queue>
 #include <variant>
 
@@ -153,10 +155,15 @@ class ProtocolClient {
   util::fb2::Mutex sock_mu_;
 
  protected:
+  static uint64_t TimeSec() {
+    return time(nullptr);
+  }
+
   std::string last_cmd_;
   std::string last_resp_;
 
-  std::atomic<uint64_t> last_io_time_ = 0;  // in ns, monotonic clock.
+  // Seconds (CLOCK_MONOTONIC_COARSE) — consumed only by master_last_io_sec.
+  std::atomic<uint64_t> last_io_time_ = 0;
 
 #ifdef DFLY_USE_SSL
 

--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -1022,7 +1022,7 @@ void DflyShardReplica::StableSyncDflyReadFb(ExecutionState* cntx) {
   while (tx_reader.NextTxData(&reader, cntx, &tx_data)) {
     DVLOG(3) << "Lsn: " << tx_data.lsn;
 
-    last_io_time_ = Proactor()->GetMonotonicTimeNs();
+    last_io_time_ = TimeSec();
     if (tx_data.opcode == journal::Op::LSN) {
       //  Do nothing
     } else if (tx_data.opcode == journal::Op::PING) {
@@ -1293,14 +1293,14 @@ auto Replica::GetSummary() const -> Summary {
     res.full_sync_in_progress = (state_mask_ & R_SYNCING);
     res.full_sync_done = (state_mask_ & R_SYNC_OK);
 
-    uint64_t current_time = ProactorBase::GetMonotonicTimeNs();
+    uint64_t current_time_sec = TimeSec();
     // last_io_time is derived above by reading last_io_time_ from all the flows,
     // by accessing them from a foreign thread, see the loop above. As a result some
     // threads may have last_io_time_ bigger than our current time, so we fix it here.
-    if (last_io_time > current_time) {
+    if (last_io_time > current_time_sec) {
       res.master_last_io_sec = 0;
     } else {
-      res.master_last_io_sec = (current_time - last_io_time) / 1000000000UL;
+      res.master_last_io_sec = current_time_sec - last_io_time;
     }
 
     res.master_id = master_context_.master_repl_id;

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -124,8 +124,7 @@ struct Metrics {
   size_t lsn_buffer_size = 0;
   size_t lsn_buffer_bytes = 0;
 
-  // monotonic timestamp (ProactorBase::GetMonotonicTimeNs) of the connection stuck on send
-  // for longest time.
+  // CPU cycles timestamp (CycleClock) of the connection stuck on send for longest time.
   uint64_t oldest_pending_send_ts = uint64_t(-1);
 
   InterpreterManager::Stats lua_stats;


### PR DESCRIPTION
Step toward deprecating `ProactorBase::GetMonotonicTimeNs` by removing its callers across the replica/server paths.

- **`ProtocolClient::last_io_time_`** — only consumed by `master_last_io_sec` (seconds resolution), so switch to `time(nullptr)` via a protected static `TimeSec()` helper. Storage drops from nanoseconds to seconds and `Summary` loses the `/ 1e9` divide.
- **`engine_shard::RunFPeriodically`** — use `absl::GetCurrentTimeNanos()` for the heartbeat watchdog timing.
- **`EngineShard::CacheStats`** — drop the 1ms throttle (and `last_mem_params_.updated_at` field) that was the only reason to read the monotonic clock here; `CacheStats` is already invoked from a periodic task.
- **`server_family.h`** — refresh stale comment to reference `CycleClock`.