### PR TITLE
perf(facade): use CycleClock for ReplyBuilder send timing

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -994,8 +994,9 @@ void Connection::HandleRequests() {
 
 unsigned Connection::GetSendWaitTimeSec() const {
   if (reply_builder_ && reply_builder_->IsSendActive()) {
-    return (util::fb2::ProactorBase::GetMonotonicTimeNs() - reply_builder_->GetLastSendTimeNs()) /
-           1'000'000'000;
+    return base::CycleClock::ToUsec(base::CycleClock::Now() -
+                                    reply_builder_->GetLastSendTimeCycles()) /
+           1'000'000;
   }
 
   return 0;

--- a/src/facade/facade_stats.h
+++ b/src/facade/facade_stats.h
@@ -69,6 +69,7 @@ struct ConnectionStats {
 struct ReplyStats {
   struct SendStats {
     int64_t count = 0;
+    // In CycleClock cycles. Convert via base::CycleClock::ToUsec at the reporting boundary.
     int64_t total_duration = 0;
 
     SendStats& operator+=(const SendStats& other) {

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -13,6 +13,7 @@
 
 #include "absl/strings/escaping.h"
 #include "absl/types/span.h"
+#include "base/cycle_clock.h"
 #include "base/logging.h"
 #include "facade/error.h"
 #include "util/fibers/proactor_base.h"
@@ -156,8 +157,8 @@ void SinkReplyBuilder::Flush(size_t expected_buffer_cap) {
     buffer_.Reserve(expected_buffer_cap);
 }
 
-uint64_t SinkReplyBuilder::GetLastSendTimeNs() const {
-  return send_time_ns_;
+uint64_t SinkReplyBuilder::GetLastSendTimeCycles() const {
+  return send_time_cycles_;
 }
 
 void SinkReplyBuilder::Send() {
@@ -165,8 +166,8 @@ void SinkReplyBuilder::Send() {
   DCHECK(!vecs_.empty());
   auto& reply_stats = tl_facade_stats->reply_stats;
 
-  send_time_ns_ = util::fb2::ProactorBase::GetMonotonicTimeNs();
-  PendingPin pin(send_time_ns_);
+  send_time_cycles_ = base::CycleClock::Now();
+  PendingPin pin(send_time_cycles_);
 
   pending_list.push_back(pin);
 
@@ -179,11 +180,11 @@ void SinkReplyBuilder::Send() {
   auto it = PendingList::s_iterator_to(pin);
   pending_list.erase(it);
 
-  send_time_ns_ = 0;
+  send_time_cycles_ = 0;
 
-  uint64_t after_ns = util::fb2::ProactorBase::GetMonotonicTimeNs();
+  uint64_t after_cycles = base::CycleClock::Now();
   reply_stats.send_stats.count++;
-  reply_stats.send_stats.total_duration += (after_ns - pin.timestamp_ns);
+  reply_stats.send_stats.total_duration += (after_cycles - pin.timestamp_cycles);
   DVLOG(2) << "Finished writing " << total_size_ << " bytes";
 }
 

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -31,9 +31,9 @@ class SinkReplyBuilder {
 
   struct PendingPin : public boost::intrusive::list_base_hook<
                           ::boost::intrusive::link_mode<::boost::intrusive::normal_link>> {
-    uint64_t timestamp_ns;
+    uint64_t timestamp_cycles;  // base::CycleClock::Now() value
 
-    PendingPin(uint64_t v = 0) : timestamp_ns(v) {
+    PendingPin(uint64_t v = 0) : timestamp_cycles(v) {
     }
   };
 
@@ -83,7 +83,7 @@ class SinkReplyBuilder {
   }
 
   bool IsSendActive() const {
-    return send_time_ns_ > 0;
+    return send_time_cycles_ > 0;
   }
 
   void SetBatchMode(bool b) {
@@ -115,7 +115,7 @@ class SinkReplyBuilder {
     return std::exchange(last_error_, {});
   }
 
-  uint64_t GetLastSendTimeNs() const;
+  uint64_t GetLastSendTimeCycles() const;
 
  protected:
   template <typename... Ts>
@@ -142,8 +142,8 @@ class SinkReplyBuilder {
   // external data (WriteRef). Validity is ensured by FinishScope that either flushes before ref
   // lifetime ends or copies refs to the buffer.
   absl::InlinedVector<iovec, 16> vecs_;
-  size_t guaranteed_pieces_ = 0;  // length of prefix of vecs_ that are guaranteed to be pieces
-  uint64_t send_time_ns_ = 0;
+  size_t guaranteed_pieces_ = 0;   // length of prefix of vecs_ that are guaranteed to be pieces
+  uint64_t send_time_cycles_ = 0;  // base::CycleClock::Now() at Send() entry, 0 when idle
 };
 
 class MCReplyBuilder : public SinkReplyBuilder {

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -36,6 +36,7 @@ extern "C" {
 #include "redis/redis_aux.h"
 }
 
+#include "base/cycle_clock.h"
 #include "base/flags.h"
 #include "base/histogram.h"
 #include "base/logging.h"
@@ -761,13 +762,10 @@ nonstd::expected<ReplicaOfArgs, ErrorReply> ReplicaOfArgs::FromCmdArgs(CmdArgLis
   return replicaof_args;
 }
 
-uint64_t GetDelayMs(uint64_t ts) {
-  uint64_t now_ns = fb2::ProactorBase::GetMonotonicTimeNs();
-  uint64_t delay_ns = 0;
-  if (ts < now_ns - 1000000) {  // if more than 1ms has passed between ts and now_ns
-    delay_ns = (now_ns - ts) / 1000000;
-  }
-  return delay_ns;
+uint64_t GetDelayMs(uint64_t cycles_ts) {
+  if (cycles_ts == UINT64_MAX)  // sentinel: no pending sends on any thread
+    return 0;
+  return base::CycleClock::ToUsec(base::CycleClock::Now() - cycles_ts) / 1'000;
 }
 
 bool ReadProcStats(io::StatusData* sdata) {
@@ -1799,9 +1797,10 @@ void PrintPrometheusMetrics(uint64_t uptime, const Metrics& m, DflyCmd* dfly_cmd
   AppendMetricWithoutLabels("net_output_bytes_total", "", m.facade_stats.reply_stats.io_write_bytes,
                             MetricType::COUNTER, &resp->body());
   {
-    AppendMetricWithoutLabels("reply_duration_seconds", "",
-                              m.facade_stats.reply_stats.send_stats.total_duration * 1e-9,
-                              MetricType::COUNTER, &resp->body());
+    AppendMetricWithoutLabels(
+        "reply_duration_seconds", "",
+        base::CycleClock::ToUsec(m.facade_stats.reply_stats.send_stats.total_duration) * 1e-6,
+        MetricType::COUNTER, &resp->body());
     AppendMetricWithoutLabels("reply_total", "", m.facade_stats.reply_stats.send_stats.count,
                               MetricType::COUNTER, &resp->body());
   }
@@ -3084,12 +3083,12 @@ Metrics ServerFamily::GetMetrics(Namespace* ns) const {
     if (!send_list.empty()) {
       DCHECK(std::is_sorted(send_list.begin(), send_list.end(),
                             [](const auto& left, const auto& right) {
-                              return left.timestamp_ns < right.timestamp_ns;
+                              return left.timestamp_cycles < right.timestamp_cycles;
                             }));
 
       auto& oldest_member = send_list.front();
       result.oldest_pending_send_ts =
-          min<uint64_t>(result.oldest_pending_send_ts, oldest_member.timestamp_ns);
+          min<uint64_t>(result.oldest_pending_send_ts, oldest_member.timestamp_cycles);
     }
     service_.mutable_registry()->MergeCallStats(index, cmd_stat_cb);
     result.interned_string_stats += GetInternedStringStats();


### PR DESCRIPTION
Step toward deprecating `ProactorBase::GetMonotonicTimeNs` by removing its callers. `SinkReplyBuilder::Send` brackets `writev` with two `GetMonotonicTimeNs` reads per flush — at pipelined load that's a `__vdso_clock_gettime` per Send. `CycleClock::Now` is a single `mrs cntvct_el0` / `rdtsc`, no vdso, and the values are only compared/subtracted within the process.

- `send_time_ns_` → `send_time_cycles_`, `PendingPin::timestamp_ns` → `timestamp_cycles`, `GetLastSendTimeNs` → `GetLastSendTimeCycles`.
- `SendStats::total_duration` accumulates cycles; `reply_duration_seconds` and `send_delay_ms` convert via `CycleClock::ToUsec` at the reporting boundary, preserving external semantics.
- Removes 4 `GetMonotonicTimeNs` call sites (2 in `Send`, plus `GetSendWaitTimeSec` and `GetDelayMs`).