### PR TITLE
feat(server): Yield fiber periodically during long container iterations

### DIFF
--- a/src/server/container_utils.cc
+++ b/src/server/container_utils.cc
@@ -230,7 +230,6 @@ bool IterateSet(const PrimeValue& pv, const IterateFunc& func, bool allow_yield)
           success = false;
           break;
         }
-   
       }
     });
   }

--- a/src/server/container_utils.cc
+++ b/src/server/container_utils.cc
@@ -24,6 +24,10 @@ extern "C" {
 #include "redis/util.h"
 }
 
+ABSL_FLAG(uint32_t, container_iteration_yield_interval_usec, 500,
+          "Yield the fiber every N microseconds during container iteration. "
+          "0 disables yielding.");
+
 namespace rng = std::ranges;
 
 namespace dfly::container_utils {
@@ -141,11 +145,21 @@ OpResult<ShardFFResult> FindFirstNonEmpty(Transaction* trans, int req_obj_type) 
   return ShardFFResult{std::get<0>(res), std::get<2>(res)};
 }
 
+void YieldLongIteration(bool allow_yield) {
+  static const uint32_t interval_usec =
+      absl::GetFlag(FLAGS_container_iteration_yield_interval_usec);
+  if (allow_yield && interval_usec > 0 &&
+      base::CycleClock::ToUsec(util::ThisFiber::GetRunningTimeCycles()) > interval_usec) {
+    util::ThisFiber::Yield();
+  }
+}
+
 }  // namespace
 
 using namespace std;
 
-bool IterateList(const PrimeValue& pv, const IterateFunc& func, size_t start, size_t end) {
+bool IterateList(const PrimeValue& pv, const IterateFunc& func, size_t start, size_t end,
+                 bool allow_yield) {
   DCHECK_LE(start, end);
   bool success = true;
   size_t len = pv.Size();
@@ -188,6 +202,7 @@ bool IterateList(const PrimeValue& pv, const IterateFunc& func, size_t start, si
 
   ql->Iterate(
       [&](const CollectionEntry& entry) {
+        YieldLongIteration(allow_yield);
         success = func(entry);
         return success;
       },
@@ -195,7 +210,7 @@ bool IterateList(const PrimeValue& pv, const IterateFunc& func, size_t start, si
   return success;
 }
 
-bool IterateSet(const PrimeValue& pv, const IterateFunc& func) {
+bool IterateSet(const PrimeValue& pv, const IterateFunc& func, bool allow_yield) {
   bool success = true;
   if (pv.Encoding() == kEncodingIntSet) {
     intset* is = static_cast<intset*>(pv.RObjPtr());
@@ -203,16 +218,19 @@ bool IterateSet(const PrimeValue& pv, const IterateFunc& func) {
     int ii = 0;
 
     while (success && intsetGet(is, ii++, &ival)) {
+      YieldLongIteration(allow_yield);
       success = func(ContainerEntry{ival});
     }
   } else {
     VisitSet(pv.RObjPtr(), [&](auto* set) {
       for (auto it = set->begin(); it != set->end(); ++it) {
+        YieldLongIteration(allow_yield);
         std::string_view key = Key(it);
         if (!func(ContainerEntry{key.data(), key.size()})) {
           success = false;
           break;
         }
+   
       }
     });
   }
@@ -221,7 +239,7 @@ bool IterateSet(const PrimeValue& pv, const IterateFunc& func) {
 }
 
 bool IterateSortedSet(const PrimeValue& pv, const IterateSortedFunc& func, size_t start, size_t end,
-                      bool reverse, bool use_score) {
+                      bool reverse, bool use_score, bool allow_yield) {
   size_t llen = pv.Size();
   if (llen == 0)
     return true;
@@ -277,13 +295,14 @@ bool IterateSortedSet(const PrimeValue& pv, const IterateSortedFunc& func, size_
     CHECK_EQ(pv.Encoding(), OBJ_ENCODING_SKIPLIST);
     auto* smap = static_cast<detail::SortedMap*>(pv.RObjPtr());
     return smap->Iterate(start, rangelen, reverse, [&](sds ele, double score) {
+      YieldLongIteration(allow_yield);
       return func(ContainerEntry{ele, sdslen(ele)}, score);
     });
   }
   return false;
 }
 
-bool IterateMap(const PrimeValue& pv, const IterateKVFunc& func) {
+bool IterateMap(const PrimeValue& pv, const IterateKVFunc& func, bool allow_yield) {
   bool finished = true;
 
   if (pv.Encoding() == kEncodingListPack) {
@@ -297,6 +316,7 @@ bool IterateMap(const PrimeValue& pv, const IterateKVFunc& func) {
   } else {
     StringMap* sm = static_cast<StringMap*>(pv.RObjPtr());
     for (const auto& k_v : *sm) {
+      YieldLongIteration(allow_yield);
       if (!func(ContainerEntry{k_v.first, sdslen(k_v.first)},
                 ContainerEntry{k_v.second, sdslen(k_v.second)})) {
         finished = false;

--- a/src/server/container_utils.h
+++ b/src/server/container_utils.h
@@ -38,20 +38,21 @@ using IterateKVFunc = std::function<bool(ContainerEntry, ContainerEntry)>;
 // as func return false. Returns true if it successfully processed all elements
 // without breaking.
 bool IterateList(const PrimeValue& pv, const IterateFunc& func, size_t start = 0,
-                 size_t end = SIZE_MAX);
+                 size_t end = SIZE_MAX, bool allow_yield = true);
 
 // Iterate over all values and call func(val). Iteration stops as soon
 // as func return false. Returns true if it successfully processed all elements
 // without stopping.
-bool IterateSet(const PrimeValue& pv, const IterateFunc& func);
+bool IterateSet(const PrimeValue& pv, const IterateFunc& func, bool allow_yield = true);
 
 // Iterate over all values and call func(val). Iteration stops as soon
 // as func return false. Returns true if it successfully processed all elements
 // without stopping.
 bool IterateSortedSet(const PrimeValue& pv, const IterateSortedFunc& func, size_t start = 0,
-                      size_t end = SIZE_MAX, bool reverse = false, bool use_score = false);
+                      size_t end = SIZE_MAX, bool reverse = false, bool use_score = false,
+                      bool allow_yield = true);
 
-bool IterateMap(const PrimeValue& pv, const IterateKVFunc& func);
+bool IterateMap(const PrimeValue& pv, const IterateKVFunc& func, bool allow_yield = true);
 
 // Get StringMap pointer from primetable value. Sets expire time from db_context
 StringMap* GetStringMap(const PrimeValue& pv, const DbContext& db_context);

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -13,11 +13,13 @@ extern "C" {
 #include "base/logging.h"
 #include "facade/facade_test.h"
 #include "server/conn_context.h"
+#include "server/container_utils.h"
 #include "server/engine_shard_set.h"
 #include "server/test_utils.h"
 #include "server/transaction.h"
 
 ABSL_DECLARE_FLAG(bool, multi_exec_squash);
+ABSL_DECLARE_FLAG(uint32_t, container_iteration_yield_interval_usec);
 
 using namespace testing;
 using namespace std;
@@ -2001,6 +2003,41 @@ TEST_F(GenericFamilyTest, RmDeletesMatchingKeys) {
   EXPECT_EQ(Run({"exists", "foo0"}), 0);
   EXPECT_EQ(Run({"exists", "bar0"}), 1);
   EXPECT_EQ(Run({"dbsize"}), 5);
+}
+
+// Verifies that long-running container iteration is yielding.
+// This test uses a sorted set iteration path, but the same yielding
+// behavior is expected for other containers (SET, HASH, LIST) with non
+// listpack encodings.
+TEST_F(GenericFamilyTest, ContainerIterationYields) {
+  // Build a large sorted set that will be encoded as SKIPLIST.
+  constexpr int N = 500'000;
+  for (int start = 0; start < N; start += 1'000) {
+    std::vector<std::string> args = {"zadd", "zs"};
+    for (int i = start; i < start + 1000; i++) {
+      args.push_back(StrCat(i));
+      args.push_back(StrCat("m:", i));
+    }
+    Run(absl::Span<const std::string>(args));
+  }
+
+  // Run IterateSortedSet directly on the shard and verify that the
+  // long-running iteration path triggers fiber preemption.
+  uint64_t delta = 0;
+  ShardId sid = Shard("zs", shard_set->size());
+  shard_set->Await(sid, [&delta] {
+    auto& db = namespaces->GetDefaultNamespace().GetDbSlice(EngineShard::tlocal()->shard_id());
+    auto* table = db.GetDBTable(0);
+    auto it = table->prime.Find(string_view{"zs"});
+    ASSERT_EQ(it->second.Encoding(), OBJ_ENCODING_SKIPLIST);
+    uint64_t before = ThisFiber::GetPreemptCount();
+    container_utils::IterateSortedSet(it->second,
+                                      [](container_utils::ContainerEntry, double) { return true; });
+    delta = ThisFiber::GetPreemptCount() - before;
+  });
+
+  // Iteration should yield at least once during long-running execution.
+  EXPECT_GT(delta, 0);
 }
 
 // Regression test for SORT BY nosort STORE inside MULTI/EXEC does a

--- a/src/server/journal/cmd_serializer.cc
+++ b/src/server/journal/cmd_serializer.cc
@@ -170,10 +170,13 @@ size_t CmdSerializer::SerializeSet(string_view key, const PrimeValue& pv) {
       max_serialization_buffer_size_);
 
   size_t commands = 0;
-  container_utils::IterateSet(pv, [&](container_utils::ContainerEntry ce) {
-    commands += aggregator.AddArg(ce.ToString());
-    return true;
-  });
+  container_utils::IterateSet(
+      pv,
+      [&](container_utils::ContainerEntry ce) {
+        commands += aggregator.AddArg(ce.ToString());
+        return true;
+      },
+      /*allow_yield=*/false);
 
   // Restore previous time so subsequent operations can trigger lazy expiry.
   pv.SetMemberTime(prev_time);
@@ -194,7 +197,7 @@ size_t CmdSerializer::SerializeZSet(string_view key, const PrimeValue& pv) {
         commands += aggregator.AddArg(ce.ToString());
         return true;
       },
-      /*start=*/0, /*end=*/SIZE_MAX, /*reverse=*/false, /*use_score=*/true);
+      /*start=*/0, /*end=*/SIZE_MAX, /*reverse=*/false, /*use_score=*/true, /*allow_yield=*/false);
   return commands;
 }
 
@@ -209,11 +212,13 @@ size_t CmdSerializer::SerializeHash(string_view key, const PrimeValue& pv) {
 
   size_t commands = 0;
   container_utils::IterateMap(
-      pv, [&](container_utils::ContainerEntry k, container_utils::ContainerEntry v) {
+      pv,
+      [&](container_utils::ContainerEntry k, container_utils::ContainerEntry v) {
         aggregator.AddArg(k.ToString(), CommandAggregator::CommitMode::kNoCommit);
         commands += aggregator.AddArg(v.ToString());
         return true;
-      });
+      },
+      /*allow_yield=*/false);
 
   // Restore previous time so subsequent operations can trigger lazy expiry.
   pv.SetMemberTime(prev_time);
@@ -227,10 +232,13 @@ size_t CmdSerializer::SerializeList(string_view key, const PrimeValue& pv) {
       max_serialization_buffer_size_);
 
   size_t commands = 0;
-  container_utils::IterateList(pv, [&](container_utils::ContainerEntry ce) {
-    commands += aggregator.AddArg(ce.ToString());
-    return true;
-  });
+  container_utils::IterateList(
+      pv,
+      [&](container_utils::ContainerEntry ce) {
+        commands += aggregator.AddArg(ce.ToString());
+        return true;
+      },
+      /*start=*/0, /*end=*/SIZE_MAX, /*allow_yield=*/false);
   return commands;
 }
 

--- a/tests/dragonfly/generic_test.py
+++ b/tests/dragonfly/generic_test.py
@@ -1,12 +1,11 @@
 import logging
-import threading
 import pytest
 import redis
 import asyncio
 from redis import asyncio as aioredis
 
 from . import dfly_multi_test_args, dfly_args
-from .instance import DflyInstance, DflyInstanceFactory, DflyStartException
+from .instance import DflyInstance, DflyStartException
 from .utility import batch_fill_data, gen_test_data, EnvironCntx
 from .seeder import DebugPopulateSeeder
 
@@ -343,121 +342,6 @@ async def test_key_bump_ups(df_factory):
         new_slot_id = int(dict(map(lambda s: s.split(":"), debug_key_info.split()))["slot"])
         assert new_slot_id + 1 == slot_id
         break
-
-
-@pytest.mark.large
-@pytest.mark.opt_only
-@pytest.mark.asyncio
-async def test_long_container_iteration_yields(df_factory: DflyInstanceFactory):
-    """
-    Verifies that long container iteration yields keep the shard responsive to
-    concurrent commands.
-
-    When a command iterates a large container the shard fiber can monopolize the thread
-    for the entire command duration.
-    container_iteration_yield_interval_usec instructs the shard fiber to yield
-    periodically, letting the fiber scheduler service queued commands in between.
-
-    Two Dragonfly instances are started: one with yields disabled (interval=0) and one
-    with yields enabled (interval=500µs). Both run the same workload concurrently —
-    ZRANGESTORE keeps the shard busy while a tight GET loop on the same shard counts
-    how many GETs complete in the measurement window. The GET counts from each instance
-    are then compared:
-      Instance 1 : yields disabled: ZRANGESTORE holds the shard fiber for the full scan;
-        GETs can only run between complete ZRANGESTORE calls, so GET throughput is low.
-      Instance 2 : yields enabled: the fiber scheduler services queued GETs within each
-        yield window; GET throughput is significantly higher.
-    """
-
-    N = 500_000
-    YIELD_INTERVAL_USEC = 500
-    NUM_ZRANGESTORE = 3
-    DURATION_SEC = 30
-    ZSET_KEY = "zs{s0}"
-    GET_KEY = "x{s0}"
-
-    async def setup(server: DflyInstance):
-        c = server.client()
-        pipe = c.pipeline(transaction=False)
-        for i in range(N):
-            pipe.zadd(ZSET_KEY, {f"m{i}": float(i)})
-        await pipe.execute()
-        await c.set(GET_KEY, 1)
-        await c.aclose()
-
-    def zrangestore_worker(port: int, stop: threading.Event):
-        """
-        Runs NUM_ZRANGESTORE concurrent ZRANGESTORE commands in a loop until stop is set.
-        Destination keys use the {s0} hashtag so they land on shard 0.
-        """
-
-        async def _inner():
-            clients = [aioredis.Redis(host="127.0.0.1", port=port) for _ in range(NUM_ZRANGESTORE)]
-            await asyncio.gather(*[c.ping() for c in clients])
-            while not stop.is_set():
-                # Each worker writes to its own dst key to avoid key conflicts.
-                await asyncio.gather(
-                    *[
-                        c.execute_command("ZRANGESTORE", f"dst{i}{{s0}}", ZSET_KEY, "0", "-1")
-                        for i, c in enumerate(clients)
-                    ]
-                )
-            await asyncio.gather(*[c.aclose() for c in clients])
-
-        asyncio.run(_inner())
-
-    async def measure(server: DflyInstance) -> int:
-        await setup(server)
-
-        thread_stop = threading.Event()
-        t = threading.Thread(
-            target=zrangestore_worker, args=(server.port, thread_stop), daemon=True
-        )
-        t.start()
-        await asyncio.sleep(1)  # let workers connect and queue up ZRANGESTOREs
-
-        get_count = 0
-        async_stop = asyncio.Event()
-
-        async def get_loop():
-            nonlocal get_count
-            c = server.client()
-            await c.ping()
-            while not async_stop.is_set():
-                await c.get(GET_KEY)
-                get_count += 1
-            await c.aclose()
-
-        get_task = asyncio.create_task(get_loop())
-        await asyncio.sleep(DURATION_SEC)
-        async_stop.set()
-        await get_task
-
-        thread_stop.set()
-        t.join(timeout=10)
-        return get_count
-
-    disabled_yield_instance = df_factory.create(
-        proactor_threads=2, num_shards=1, container_iteration_yield_interval_usec=0
-    )
-    enabled_yield_instance = df_factory.create(
-        proactor_threads=2,
-        num_shards=1,
-        container_iteration_yield_interval_usec=YIELD_INTERVAL_USEC,
-    )
-
-    disabled_yield_instance.start()
-    get_commands_in_disabled_yield = await measure(disabled_yield_instance)
-    disabled_yield_instance.stop()
-
-    enabled_yield_instance.start()
-    get_commands_in_enabled_yield = await measure(enabled_yield_instance)
-    enabled_yield_instance.stop()
-
-    assert get_commands_in_enabled_yield > get_commands_in_disabled_yield * 5, (
-        f"Expected at least 5x more GETs with yielding enabled, "
-        f"got {get_commands_in_enabled_yield} vs {get_commands_in_disabled_yield}"
-    )
 
 
 @pytest.mark.debug_only

--- a/tests/dragonfly/generic_test.py
+++ b/tests/dragonfly/generic_test.py
@@ -1,11 +1,12 @@
 import logging
+import threading
 import pytest
 import redis
 import asyncio
 from redis import asyncio as aioredis
 
 from . import dfly_multi_test_args, dfly_args
-from .instance import DflyInstance, DflyStartException
+from .instance import DflyInstance, DflyInstanceFactory, DflyStartException
 from .utility import batch_fill_data, gen_test_data, EnvironCntx
 from .seeder import DebugPopulateSeeder
 
@@ -342,6 +343,121 @@ async def test_key_bump_ups(df_factory):
         new_slot_id = int(dict(map(lambda s: s.split(":"), debug_key_info.split()))["slot"])
         assert new_slot_id + 1 == slot_id
         break
+
+
+@pytest.mark.large
+@pytest.mark.opt_only
+@pytest.mark.asyncio
+async def test_long_container_iteration_yields(df_factory: DflyInstanceFactory):
+    """
+    Verifies that long container iteration yields keep the shard responsive to
+    concurrent commands.
+
+    When a command iterates a large container the shard fiber can monopolize the thread
+    for the entire command duration.
+    container_iteration_yield_interval_usec instructs the shard fiber to yield
+    periodically, letting the fiber scheduler service queued commands in between.
+
+    Two Dragonfly instances are started: one with yields disabled (interval=0) and one
+    with yields enabled (interval=500µs). Both run the same workload concurrently —
+    ZRANGESTORE keeps the shard busy while a tight GET loop on the same shard counts
+    how many GETs complete in the measurement window. The GET counts from each instance
+    are then compared:
+      Instance 1 : yields disabled: ZRANGESTORE holds the shard fiber for the full scan;
+        GETs can only run between complete ZRANGESTORE calls, so GET throughput is low.
+      Instance 2 : yields enabled: the fiber scheduler services queued GETs within each
+        yield window; GET throughput is significantly higher.
+    """
+
+    N = 500_000
+    YIELD_INTERVAL_USEC = 500
+    NUM_ZRANGESTORE = 3
+    DURATION_SEC = 30
+    ZSET_KEY = "zs{s0}"
+    GET_KEY = "x{s0}"
+
+    async def setup(server: DflyInstance):
+        c = server.client()
+        pipe = c.pipeline(transaction=False)
+        for i in range(N):
+            pipe.zadd(ZSET_KEY, {f"m{i}": float(i)})
+        await pipe.execute()
+        await c.set(GET_KEY, 1)
+        await c.aclose()
+
+    def zrangestore_worker(port: int, stop: threading.Event):
+        """
+        Runs NUM_ZRANGESTORE concurrent ZRANGESTORE commands in a loop until stop is set.
+        Destination keys use the {s0} hashtag so they land on shard 0.
+        """
+
+        async def _inner():
+            clients = [aioredis.Redis(host="127.0.0.1", port=port) for _ in range(NUM_ZRANGESTORE)]
+            await asyncio.gather(*[c.ping() for c in clients])
+            while not stop.is_set():
+                # Each worker writes to its own dst key to avoid key conflicts.
+                await asyncio.gather(
+                    *[
+                        c.execute_command("ZRANGESTORE", f"dst{i}{{s0}}", ZSET_KEY, "0", "-1")
+                        for i, c in enumerate(clients)
+                    ]
+                )
+            await asyncio.gather(*[c.aclose() for c in clients])
+
+        asyncio.run(_inner())
+
+    async def measure(server: DflyInstance) -> int:
+        await setup(server)
+
+        thread_stop = threading.Event()
+        t = threading.Thread(
+            target=zrangestore_worker, args=(server.port, thread_stop), daemon=True
+        )
+        t.start()
+        await asyncio.sleep(1)  # let workers connect and queue up ZRANGESTOREs
+
+        get_count = 0
+        async_stop = asyncio.Event()
+
+        async def get_loop():
+            nonlocal get_count
+            c = server.client()
+            await c.ping()
+            while not async_stop.is_set():
+                await c.get(GET_KEY)
+                get_count += 1
+            await c.aclose()
+
+        get_task = asyncio.create_task(get_loop())
+        await asyncio.sleep(DURATION_SEC)
+        async_stop.set()
+        await get_task
+
+        thread_stop.set()
+        t.join(timeout=10)
+        return get_count
+
+    disabled_yield_instance = df_factory.create(
+        proactor_threads=2, num_shards=1, container_iteration_yield_interval_usec=0
+    )
+    enabled_yield_instance = df_factory.create(
+        proactor_threads=2,
+        num_shards=1,
+        container_iteration_yield_interval_usec=YIELD_INTERVAL_USEC,
+    )
+
+    disabled_yield_instance.start()
+    get_commands_in_disabled_yield = await measure(disabled_yield_instance)
+    disabled_yield_instance.stop()
+
+    enabled_yield_instance.start()
+    get_commands_in_enabled_yield = await measure(enabled_yield_instance)
+    enabled_yield_instance.stop()
+
+    assert get_commands_in_enabled_yield > get_commands_in_disabled_yield * 5, (
+        f"Expected at least 5x more GETs with yielding enabled, "
+        f"got {get_commands_in_enabled_yield} vs {get_commands_in_disabled_yield}"
+    )
 
 
 @pytest.mark.debug_only


### PR DESCRIPTION
Add a configurable yield mechanism to container iteration loops so that
long-running commands do  not monopolize the shard fiber for their entire duration.

A new flag `container_iteration_yield_interval_usec` (default: 500µs) controls
the yield interval. When  the running time of the current fiber exceeds the
threshold, `YieldLongIteration()` yields to the scheduler, allowing queued 
commands to be serviced before the scan resumes. Setting the 
flag to 0 disables yielding entirely.

We disable yielding during serialization to not preempt and we don't
yield if encoding is ListPack.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
