### PR TITLE
fix(string_map): mark DenseSet expiration_used in SetExpiryTime

### DIFF
--- a/src/core/dense_set.cc
+++ b/src/core/dense_set.cc
@@ -53,6 +53,9 @@ DenseSet::IteratorBase::IteratorBase(const DenseSet* owner, bool is_end)
 void DenseSet::IteratorBase::SetExpiryTime(uint32_t ttl_sec) {
   DensePtr* ptr = curr_entry_->IsLink() ? curr_entry_->AsLink() : curr_entry_;
   void* src = ptr->GetObject();
+  // Self-heal: pre-existing TTL entries may have been created before this
+  // flag was tracked here.
+  owner_->expiration_used_ = true;
   if (!HasExpiry()) {
     const size_t old_size = owner_->ObjectAllocSize(ptr->Raw());
     void* new_obj = owner_->ObjectClone(src, false, true);
@@ -62,7 +65,6 @@ void DenseSet::IteratorBase::SetExpiryTime(uint32_t ttl_sec) {
 
     // Important: we set the ttl bit on the wrapping pointer.
     curr_entry_->SetTtl(true);
-    owner_->expiration_used_ = true;
     owner_->ObjDelete(src);
     src = new_obj;
 

--- a/src/core/dense_set.cc
+++ b/src/core/dense_set.cc
@@ -62,6 +62,7 @@ void DenseSet::IteratorBase::SetExpiryTime(uint32_t ttl_sec) {
 
     // Important: we set the ttl bit on the wrapping pointer.
     curr_entry_->SetTtl(true);
+    owner_->expiration_used_ = true;
     owner_->ObjDelete(src);
     src = new_obj;
 

--- a/src/core/string_map_test.cc
+++ b/src/core/string_map_test.cc
@@ -341,6 +341,26 @@ TEST_F(StringMapTest, AddOrExchangeWithTtl) {
   EXPECT_EQ(it.ExpiryTime(), 200u);
 }
 
+TEST_F(StringMapTest, RandomPairsUniqueAfterSetExpiryTime) {
+  sm_->Reserve(1024);
+  for (unsigned i = 0; i < 20; i++) {
+    EXPECT_TRUE(sm_->AddOrUpdate(to_string(i), "v"));
+  }
+  EXPECT_FALSE(sm_->ExpirationUsed());
+
+  for (unsigned i = 0; i < 10; i++) {
+    auto it = sm_->Find(to_string(i));
+    ASSERT_FALSE(it.HasExpiry());
+    it.SetExpiryTime(1);
+  }
+
+  sm_->set_time(2);
+
+  vector<sds> keys, vals;
+  sm_->RandomPairsUnique(20, keys, vals, false);
+  EXPECT_EQ(keys.size(), 10u);
+}
+
 TEST_F(StringMapTest, ExtractMultiple) {
   for (unsigned i = 0; i < 20; i++) {
     sm_->AddOrUpdate(to_string(i), "val" + to_string(i));

--- a/src/core/string_map_test.cc
+++ b/src/core/string_map_test.cc
@@ -353,6 +353,9 @@ TEST_F(StringMapTest, RandomPairsUniqueAfterSetExpiryTime) {
     ASSERT_FALSE(it.HasExpiry());
     it.SetExpiryTime(1);
   }
+  // Validate the regression in all build types: DCHECK below is a no-op in
+  // release, so RandomPairsUnique could still return 10 keys by chance.
+  EXPECT_TRUE(sm_->ExpirationUsed());
 
   sm_->set_time(2);
 


### PR DESCRIPTION
`DenseSet::IteratorBase::SetExpiryTime` (the path used by `HEXPIRE`) sets the TTL bit on an entry but never updated `expiration_used_`. As a result, `SizeSlow()` skipped `CollectExpired()` and returned a stale count that included already-expired entries, while the iterator in `RandomPairsUnique` still expired them on the fly - tripping `DCHECK(keys.size() == count)` in `HRANDFIELD`.

Fixes #7390