### PR TITLE
fix(dense_set): avoid use-after-free in expiry chain walks

### DIFF
--- a/src/core/dense_set.cc
+++ b/src/core/dense_set.cc
@@ -678,7 +678,11 @@ auto DenseSet::Find2(const void* ptr, uint32_t bid, uint32_t cookie)
   DensePtr* prev = &entries_[bid];
   curr = prev->Next();
   while (curr != nullptr) {
-    ExpireIfNeeded(prev, curr);
+    if (ExpireIfNeeded(prev, curr)) {
+      // Chain compacted: prev's LinkKey was freed and curr now dangles.
+      if (!prev->IsLink())
+        break;
+    }
 
     if (Equal(*curr, ptr, cookie)) {
       return {bid, prev, curr};
@@ -928,9 +932,16 @@ bool DenseSet::ExpireIfNeededInternal(DensePtr* prev, DensePtr* node) const {
       break;
     }
 
+    // Delete on a tail Object with non-null prev frees prev's LinkKey,
+    // which dangles `node` (= &prev->AsLink()->next).
+    const bool node_in_prev_link = prev != nullptr && node->IsObject();
+
     // updates the *node to next item if relevant or resets it to empty.
     const_cast<DenseSet*>(this)->Delete(prev, node);
     deleted = true;
+
+    if (node_in_prev_link)
+      break;
   } while (node->HasTtl());
 
   return deleted;

--- a/src/core/string_map_test.cc
+++ b/src/core/string_map_test.cc
@@ -341,6 +341,48 @@ TEST_F(StringMapTest, AddOrExchangeWithTtl) {
   EXPECT_EQ(it.ExpiryTime(), 200u);
 }
 
+TEST_F(StringMapTest, ExpireCollectChainUaf) {
+  // Iterating after SetExpiryTime'd chain-tail entries expire reads through
+  // a LinkKey freed by Delete in ExpireIfNeededInternal's loop. Reproduces
+  // probabilistically without ASAN; the 32-trial loop raises crash rate.
+  for (unsigned trial = 0; trial < 32; trial++) {
+    StringMap sm(&mi_alloc_);
+    for (unsigned i = 0; i < 20; i++) {
+      ASSERT_TRUE(sm.AddOrUpdate(absl::StrCat("t", trial, "_", i), "v"));
+    }
+    for (unsigned i = 0; i < 10; i++) {
+      sm.Find(absl::StrCat("t", trial, "_", i)).SetExpiryTime(1);
+    }
+    sm.set_time(2);
+
+    unsigned alive = 0;
+    for (auto it = sm.begin(); it != sm.end(); ++it) {
+      ++alive;
+    }
+    EXPECT_EQ(alive, 10u);
+  }
+}
+
+TEST_F(StringMapTest, FindAfterExpiredTailUaf) {
+  // Find() on a missing key walks the chain to the tail. If the tail Object
+  // has expired, ExpireIfNeeded inside Find2 frees prev's LinkKey, leaving
+  // `curr` dangling for the subsequent Equal / curr->Next() reads.
+  for (unsigned trial = 0; trial < 32; trial++) {
+    StringMap sm(&mi_alloc_);
+    for (unsigned i = 0; i < 20; i++) {
+      ASSERT_TRUE(sm.AddOrUpdate(absl::StrCat("t", trial, "_", i), "v"));
+    }
+    for (unsigned i = 0; i < 10; i++) {
+      sm.Find(absl::StrCat("t", trial, "_", i)).SetExpiryTime(1);
+    }
+    sm.set_time(2);
+
+    for (unsigned i = 0; i < 50; i++) {
+      sm.Find(absl::StrCat("missing", trial, "_", i));
+    }
+  }
+}
+
 TEST_F(StringMapTest, ExtractMultiple) {
   for (unsigned i = 0; i < 20; i++) {
     sm_->AddOrUpdate(to_string(i), "val" + to_string(i));


### PR DESCRIPTION
When ExpireIfNeeded() deletes a tail Object inside `prev`'s LinkKey, Delete() frees that LinkKey. Two call paths then dereference the now dangling node/curr pointer:
- `ExpireIfNeededInternal`'s do-while loop reads `node->HasTtl()`.
- `Find2`'s chain walk reads `*curr` (Equal) and `curr->Next()`.

Both reads usually return the zero written by `ptr->Reset()` before FreeLink, so the bug is silent without ASAN - but with non-zero garbage in the freed block, ObjExpireTime/sdslen SIGSEGV.

Changes:
- ExpireIfNeededInternal: break after Delete in the tail-Object case.
- Find2: same guard as Grow (`if (prev && !prev->IsLink()) break;`) after ExpireIfNeeded.
- Add ExpireCollectChainUaf - exercises the iterator path.
- Add FindAfterExpiredTailUaf - exercises the Find2 path. Lookups for missing keys deterministically reproduce the crash before the fix.