### PR TITLE
perf(server): use CycleClock for streamer/disk-storage timing

### DIFF
--- a/src/server/journal/streamer.cc
+++ b/src/server/journal/streamer.cc
@@ -12,6 +12,7 @@
 #include <netinet/tcp.h>
 #endif
 
+#include "base/cycle_clock.h"
 #include "base/flags.h"
 #include "base/logging.h"
 #include "server/db_slice.h"
@@ -114,7 +115,7 @@ JournalStreamer::JournalStreamer(ExecutionState* cntx, JournalStreamer::Config c
   replication_stream_output_limit_cached = absl::GetFlag(FLAGS_replication_stream_output_limit);
   migration_buckets_sleep_usec_cached = absl::GetFlag(FLAGS_migration_buckets_sleep_usec);
   replication_dispatch_threshold = absl::GetFlag(FLAGS_replication_dispatch_threshold);
-  last_async_write_time_ = fb2::ProactorBase::GetMonotonicTimeNs() / 1000000;
+  last_async_write_time_ = base::CycleClock::Now();
 }
 
 JournalStreamer::~JournalStreamer() {
@@ -173,11 +174,13 @@ size_t JournalStreamer::UsedBytes() const {
 }
 
 std::string JournalStreamer::FormatInternalState() const {
+  uint64_t last_async_ms_ago =
+      base::CycleClock::ToUsec(base::CycleClock::Now() - last_async_write_time_) / 1000;
   return absl::StrCat(
       "pending_buf_size:", pending_buf_.Size(), " in_flight_bytes:", in_flight_bytes_,
       " total_sent:", total_sent_, " throttle_count:", throttle_count_,
       " total_throttle_wait_usec:", total_throttle_wait_usec_,
-      " throttle_waiters:", throttle_waiters_, " last_async_write_time_ms:", last_async_write_time_,
+      " throttle_waiters:", throttle_waiters_, " last_async_time_ms_ago:", last_async_ms_ago,
       " last_lsn_time_s:", last_lsn_time_, " last_lsn_writen_:", last_lsn_writen_);
 }
 
@@ -258,9 +261,9 @@ void JournalStreamer::StalledDataWriterFiber(std::chrono::milliseconds period_ms
 
     // We don't want to force async write to replicate if last data
     // was written recent. Data needs to be stalled for period_ms duration.
+    const uint64_t period_cycles = base::CycleClock::FromUsec(period_ms.count() * 1000);
     if (!pending_buf_.Size() || in_flight_bytes_ > 0 ||
-        ((last_async_write_time_ + period_ms.count()) >
-         (fb2::ProactorBase::GetMonotonicTimeNs() / 1000000))) {
+        ((last_async_write_time_ + period_cycles) > base::CycleClock::Now())) {
       continue;
     }
 
@@ -286,7 +289,7 @@ void JournalStreamer::AsyncWrite(bool force_send) {
 
   in_flight_bytes_ = cur_buf.mem_size;
   total_sent_ += in_flight_bytes_;
-  last_async_write_time_ = fb2::ProactorBase::GetMonotonicTimeNs() / 1000000;
+  last_async_write_time_ = base::CycleClock::Now();
 
   const auto v_size = cur_buf.buf.size();
   absl::InlinedVector<iovec, 8> v(v_size);

--- a/src/server/journal/streamer.h
+++ b/src/server/journal/streamer.h
@@ -96,7 +96,8 @@ class JournalStreamer : public journal::JournalConsumerInterface {
   const Config config_;
   // If we are replication in stable sync we can aggregate data before sending
   size_t in_flight_bytes_ = 0, total_sent_ = 0;
-  // Last time that send data in milliseconds
+
+  // Last time we sent async data, as base::CycleClock::Now() cycles.
   uint64_t last_async_write_time_ = 0;
   time_t last_lsn_time_ = 0;
   LSN last_lsn_writen_ = 0;

--- a/src/server/tiering/disk_storage.cc
+++ b/src/server/tiering/disk_storage.cc
@@ -7,6 +7,7 @@
 #include <ostream>
 #include <system_error>
 
+#include "base/cycle_clock.h"
 #include "base/flags.h"
 #include "base/logging.h"
 #include "io/io_buf.h"
@@ -221,8 +222,8 @@ error_code DiskStorage::RequestGrow(off_t grow_size) {
     return make_error_code(errc::file_too_large);
 
   // Don't try again immediately, most likely it won't succeed ever.
-  const uint64_t kCooldownTime = 100'000'000;  // 100ms
-  if (grow_.last_err && (ProactorBase::GetMonotonicTimeNs() - grow_.timestamp_ns) < kCooldownTime)
+  const uint64_t kCooldownCycles = base::CycleClock::FromUsec(100'000);  // 100ms
+  if (grow_.last_err && (base::CycleClock::Now() - grow_.timestamp_cycles) < kCooldownCycles)
     return make_error_code(errc::operation_canceled);
 
   if (std::exchange(grow_.pending, true)) {
@@ -235,7 +236,7 @@ error_code DiskStorage::RequestGrow(off_t grow_size) {
     auto ec = (res < 0) ? std::error_code{-res, std::system_category()} : std::error_code{};
     grow_.pending = false;
     grow_.last_err = ec;
-    grow_.timestamp_ns = ProactorBase::GetMonotonicTimeNs();
+    grow_.timestamp_cycles = base::CycleClock::Now();
     if (!ec)
       alloc_.AddStorage(end, grow_size);
   });

--- a/src/server/tiering/disk_storage.h
+++ b/src/server/tiering/disk_storage.h
@@ -73,8 +73,8 @@ class DiskStorage {
   struct {
     bool pending = false;  // currently in progress
     std::error_code last_err;
-    uint64_t timestamp_ns;  // last grow finished
-  } grow_;                  // status of last RequestGrow() operation
+    uint64_t timestamp_cycles;  // last grow finished, base::CycleClock::Now() cycles
+  } grow_;                      // status of last RequestGrow() operation
 
   std::string backing_file_path_;
   std::unique_ptr<util::fb2::LinuxFile> backing_file_;


### PR DESCRIPTION
Continues #7387 — replace remaining `ProactorBase::GetMonotonicTimeNs` callers in the journal streamer and tiered disk storage.

- **`JournalStreamer::last_async_write_time_`** — store `base::CycleClock` cycles (constructor + `AsyncWrite`). The `StalledDataWriterFiber` comparison converts `period_ms` once via `CycleClock::FromUsec`.
- **`DiskStorage` grow cooldown** — switch `grow_.timestamp` to `CycleClock` cycles, rename the field to `timestamp_cycles`, and convert `kCooldownTime` via `CycleClock::FromUsec`.