### PR TITLE
ci: build with LEGACY_GLOG=OFF

### DIFF
--- a/.github/actions/builder/action.yml
+++ b/.github/actions/builder/action.yml
@@ -85,6 +85,7 @@ runs:
           -DWITH_GPERF=OFF
           -DWITH_ASAN="${ASAN}"
           -DWITH_USAN="${USAN}"
+          -DLEGACY_GLOG=OFF
         )
 
         # Execute CMake


### PR DESCRIPTION
## Summary
- Pass `-DLEGACY_GLOG=OFF` in the shared builder action so Dragonfly CI builds with absl-based logging instead of glog.
- Helio already supports this via `USE_ABSL_LOG` and uses the same option in its own CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)