### PR TITLE
fix(facade): Cancel commands on connection disconnect (loopv2)

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -13,6 +13,7 @@
 #include <absl/time/time.h>
 
 #include <algorithm>
+#include <boost/intrusive/list.hpp>
 #include <numeric>
 #include <variant>
 
@@ -548,6 +549,47 @@ class PipelineCacheSizeTracker {
 };
 
 thread_local PipelineCacheSizeTracker tl_pipe_cache_sz_tracker;
+
+// An orphaned command is a command whose execution was aborted due to a client disconnect,
+// but which cannot be safely cancelled (due to transactional framework limitations),
+// so we wait for its execution to finish and keep it in a separate list.
+// TODO: Explore more safe ways to cancel a scheduled transaction atomically
+struct OrphanedCommand : public boost::intrusive::list_base_hook<
+                             boost::intrusive::link_mode<boost::intrusive::auto_unlink>> {
+  explicit OrphanedCommand(ParsedCommand* c)
+      : cmd(c),
+        callback(std::bind_front(&OrphanedCommand::OnFinish, this)),
+        waiter(util::fb2::detail::Waiter::Callback(callback)),
+        sub_key(cmd->Blocker()->OnCompletion(&waiter)) {
+  }
+
+  void OnFinish() {
+    sub_key->Drop();
+    sub_key.reset();
+    unlink();
+    delete this;
+  }
+
+  // Takes ownership of cmd: registers a self-deleting waiter, or deletes immediately if done.
+  static void Adopt(ParsedCommand* cmd);
+
+  std::unique_ptr<ParsedCommand> cmd;  // owned by this struct
+
+  std::function<void()> callback;
+  util::fb2::detail::Waiter waiter;
+  std::optional<util::fb2::EventCount::SubKey> sub_key;
+};
+
+using OrphanedList =
+    boost::intrusive::list<OrphanedCommand, boost::intrusive::constant_time_size<false>>;
+thread_local OrphanedList tl_orphaned_commands;
+
+void OrphanedCommand::Adopt(ParsedCommand* cmd) {
+  if (auto* orphan = new OrphanedCommand(cmd); orphan->sub_key)
+    tl_orphaned_commands.push_back(*orphan);
+  else
+    delete orphan;  // already completed
+}
 
 size_t Connection::MessageHandle::UsedMemory() const {
   struct MessageSize {
@@ -1810,8 +1852,20 @@ void Connection::ClearPipelinedMessages() {
     auto* curr{parsed_head_};
     parsed_head_ = parsed_head_->next;
 
-    // Wait for the in-flight async commands processing by consumer to finish before recycling.
+    // For in-flight async commands that haven't completed yet:
     if (curr->IsDeferredReply() && !curr->CanReply()) {
+      if (ioloop_v2_) {
+        // Multi-shard commands are atomic — orphan instead of blocking.
+        size_t used_mem = curr->UsedMemory();
+        curr->next = nullptr;
+        VLOG(1) << "Orphaning in-flight command from closed connection " << id_;
+        OrphanedCommand::Adopt(curr);
+        parsed_cmd_q_len_--;
+        parsed_cmd_q_bytes_ -= used_mem;
+        tl_facade_stats->conn_stats.pipeline_queue_entries--;
+        tl_facade_stats->conn_stats.pipeline_queue_bytes -= used_mem;
+        continue;
+      }
       curr->Blocker()->Wait();
     }
 
@@ -2157,6 +2211,17 @@ Connection::WeakRef Connection::Borrow() {
 
 void Connection::ShutdownThreadLocal() {
   pipeline_req_pool_.clear();
+
+  // Wait at most 10ms for orphaned commands to finish
+  for (size_t i = 0; i < 10 && !tl_orphaned_commands.empty(); i++)
+    util::ThisFiber::SleepFor(1ms);
+
+  // Force delete orphaned commands then
+  if (!tl_orphaned_commands.empty()) {
+    size_t cmds = std::distance(tl_orphaned_commands.begin(), tl_orphaned_commands.end());
+    LOG(WARNING) << "Shutting down with " << cmds << " orphaned commands still pending";
+    tl_orphaned_commands.clear_and_dispose([](OrphanedCommand* o) { delete o; });
+  }
 }
 
 bool Connection::IsCurrentlyDispatching() const {

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -565,7 +565,6 @@ struct OrphanedCommand : public boost::intrusive::list_base_hook<
 
   void OnFinish() {
     sub_key->Drop();
-    sub_key.reset();
     unlink();
     delete this;
   }

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1854,16 +1854,11 @@ void Connection::ClearPipelinedMessages() {
 
     // For in-flight async commands that haven't completed yet:
     if (curr->IsDeferredReply() && !curr->CanReply()) {
+      // For V2 loop we can disown the commands instead of waiting for them
       if (ioloop_v2_) {
-        // Multi-shard commands are atomic — orphan instead of blocking.
-        size_t used_mem = curr->UsedMemory();
+        UnaccountParsedCommand(curr);
         curr->next = nullptr;
-        VLOG(1) << "Orphaning in-flight command from closed connection " << id_;
         OrphanedCommand::Adopt(curr);
-        parsed_cmd_q_len_--;
-        parsed_cmd_q_bytes_ -= used_mem;
-        tl_facade_stats->conn_stats.pipeline_queue_entries--;
-        tl_facade_stats->conn_stats.pipeline_queue_bytes -= used_mem;
         continue;
       }
       curr->Blocker()->Wait();
@@ -2780,18 +2775,8 @@ void Connection::EnqueueParsedCommand(ParsedCommand* cmd) {
 }
 
 void Connection::ReleaseParsedCommand(ParsedCommand* cmd, bool is_pipelined) {
-  size_t used_mem = cmd->UsedMemory();
   auto& conn_stats = tl_facade_stats->conn_stats;
-
-  DCHECK_GT(parsed_cmd_q_len_, 0u);
-  DCHECK_GE(parsed_cmd_q_bytes_, used_mem);
-  DCHECK_GT(conn_stats.pipeline_queue_entries, 0u);
-  DCHECK_GE(conn_stats.pipeline_queue_bytes, used_mem);
-  parsed_cmd_q_len_--;
-  parsed_cmd_q_bytes_ -= used_mem;
-
-  conn_stats.pipeline_queue_entries--;
-  conn_stats.pipeline_queue_bytes -= used_mem;
+  UnaccountParsedCommand(cmd);
 
   if (is_pipelined) {
     conn_stats.pipelined_cmd_cnt++;
@@ -2821,6 +2806,20 @@ void Connection::ReleaseParsedCommand(ParsedCommand* cmd, bool is_pipelined) {
       delete cmd;
     }
   }
+}
+
+void Connection::UnaccountParsedCommand(ParsedCommand* cmd) {
+  size_t used_mem = cmd->UsedMemory();
+  auto& conn_stats = tl_facade_stats->conn_stats;
+
+  DCHECK_GT(parsed_cmd_q_len_, 0u);
+  DCHECK_GE(parsed_cmd_q_bytes_, used_mem);
+  DCHECK_GT(conn_stats.pipeline_queue_entries, 0u);
+  DCHECK_GE(conn_stats.pipeline_queue_bytes, used_mem);
+  parsed_cmd_q_len_--;
+  parsed_cmd_q_bytes_ -= used_mem;
+  conn_stats.pipeline_queue_entries--;
+  conn_stats.pipeline_queue_bytes -= used_mem;
 }
 
 void Connection::DestroyParsedQueue() {

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1854,14 +1854,17 @@ void Connection::ClearPipelinedMessages() {
 
     // For in-flight async commands that haven't completed yet:
     if (curr->IsDeferredReply() && !curr->CanReply()) {
-      // For V2 loop we can disown the commands instead of waiting for them
-      if (ioloop_v2_) {
+      if (!ioloop_v2_) {
+        curr->Blocker()->Wait();
+        continue;
+      }
+
+      // Try cancelling the command, if not - let it finish and add it to the orphan list
+      if (!curr->TryCancel()) {
         UnaccountParsedCommand(curr);
         curr->next = nullptr;
         OrphanedCommand::Adopt(curr);
-        continue;
       }
-      curr->Blocker()->Wait();
     }
 
     ReleaseParsedCommand(curr, false);

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -557,21 +557,23 @@ thread_local PipelineCacheSizeTracker tl_pipe_cache_sz_tracker;
 struct OrphanedCommand : public boost::intrusive::list_base_hook<
                              boost::intrusive::link_mode<boost::intrusive::auto_unlink>> {
   explicit OrphanedCommand(ParsedCommand* c)
-      : cmd(c),
+      : owner(fb2::ProactorBase::me()),
+        cmd(c),
         callback(std::bind_front(&OrphanedCommand::OnFinish, this)),
         waiter(util::fb2::detail::Waiter::Callback(callback)),
         sub_key(cmd->Blocker()->OnCompletion(&waiter)) {
   }
 
   void OnFinish() {
-    sub_key->Drop();
-    unlink();
-    delete this;
+    // Completion could've happened from any thread, so dispatch to owner thread
+    owner->DispatchBrief([this] {
+      sub_key->Drop();
+      unlink();
+      delete this;
+    });
   }
 
-  // Takes ownership of cmd: registers a self-deleting waiter, or deletes immediately if done.
-  static void Adopt(ParsedCommand* cmd);
-
+  fb2::ProactorBase* owner;            // original proactor of command
   std::unique_ptr<ParsedCommand> cmd;  // owned by this struct
 
   std::function<void()> callback;
@@ -582,13 +584,6 @@ struct OrphanedCommand : public boost::intrusive::list_base_hook<
 using OrphanedList =
     boost::intrusive::list<OrphanedCommand, boost::intrusive::constant_time_size<false>>;
 thread_local OrphanedList tl_orphaned_commands;
-
-void OrphanedCommand::Adopt(ParsedCommand* cmd) {
-  if (auto* orphan = new OrphanedCommand(cmd); orphan->sub_key)
-    tl_orphaned_commands.push_back(*orphan);
-  else
-    delete orphan;  // already completed
-}
 
 size_t Connection::MessageHandle::UsedMemory() const {
   struct MessageSize {
@@ -1853,17 +1848,22 @@ void Connection::ClearPipelinedMessages() {
 
     // For in-flight async commands that haven't completed yet:
     if (curr->IsDeferredReply() && !curr->CanReply()) {
-      if (!ioloop_v2_) {
-        curr->Blocker()->Wait();
-        continue;
-      }
-
-      // Try cancelling the command, if not - let it finish and add it to the orphan list
-      if (!curr->TryCancel()) {
+      // With v2, try cancelling the command, if not - let it finish and add it to the orphan list
+      if (ioloop_v2_ && !curr->TryCancel()) {
         UnaccountParsedCommand(curr);
         curr->next = nullptr;
-        OrphanedCommand::Adopt(curr);
+        if (auto* orphan = new OrphanedCommand(curr); orphan->sub_key) {
+          tl_orphaned_commands.push_back(*orphan);
+        } else {
+          DCHECK(curr->Blocker()->IsCompleted());
+          delete orphan;  // already completed
+        }
+
+        continue;  // Skip ReleaseParsedCommand below
       }
+
+      // Otherwise wait for its completion
+      curr->Blocker()->Wait();
     }
 
     ReleaseParsedCommand(curr, false);

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -475,6 +475,9 @@ class Connection : public util::Connection {
   // not be counted in stats.
   void ReleaseParsedCommand(ParsedCommand* cmd, bool is_pipelined);
 
+  // Decrease connection stats when removing this parsed command from the queue
+  void UnaccountParsedCommand(ParsedCommand*);
+
   void DestroyParsedQueue();
 
   // Dispatch Queue - Queue for the Control Path.

--- a/src/facade/parsed_command.h
+++ b/src/facade/parsed_command.h
@@ -66,6 +66,11 @@ class ParsedCommand : public cmn::BackedArguments {
     return sizeof(ParsedCommand);
   }
 
+  // Try cancelling the current command execution. Returns true if successful
+  virtual bool TryCancel() {
+    return false;
+  }
+
   // time when the message was parsed as reported by CycleClock::Now()
   // Also serves as the enqueue timestamp for calculating pipeline wait latency.
   uint64_t parsed_cycle = 0;

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -301,6 +301,10 @@ bool ConnectionState::ClientTracking::ShouldTrackKeys() const {
   return option_ == OPTIN ? match : !match;
 }
 
+bool CommandContext::TryCancel() {
+  return tx_->CancelScheduledTx();
+}
+
 void CommandContext::ReuseInternal() {
   cid_ = nullptr;
   tx_ = nullptr;

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -302,7 +302,7 @@ bool ConnectionState::ClientTracking::ShouldTrackKeys() const {
 }
 
 bool CommandContext::TryCancel() {
-  return tx_->CancelScheduledTx();
+  return tx_ && tx_->CancelScheduledTx();
 }
 
 void CommandContext::ReuseInternal() {

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -392,6 +392,8 @@ class CommandContext : public facade::ParsedCommand {
     return sizeof(CommandContext);
   }
 
+  bool TryCancel() override;
+
   ConnectionContext* server_conn_cntx() const {
     return static_cast<ConnectionContext*>(conn_cntx_);
   }

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -2165,19 +2165,18 @@ async def test_pubsub_pipeline_starvation(df_server: DflyInstance):
         await writer.wait_closed()
 
 
-@dfly_args({"proactor_threads": 1})
+@dfly_args({"proactor_threads": 1, "memcached_port": 11311, "experimental_io_loop_v2": "true"})
 async def test_multi_exec_phantom_connections(df_server: DflyInstance):
-    """Reproduce the addr=0.0.0.0 phantom connections from issue #7272.
+    """With ioloopv2, commands from RST-closed connections must not be dropped.
 
-    Clogger floods MULTI/GET <1 MB key>/EXEC without reading, blocking Send() mid-EXEC
-    while holding the shard lock.  Ghost connections send MULTI/SET/EXEC one command at a
-    time (sync-dispatch mode) then RST-close.  The main connection fiber is stuck in
-    run_barrier_.Wait() inside Transaction::Execute(), so the io_uring RST event goes
-    unprocessed: the kernel moves the socket to TCP_CLOSE (addr=0.0.0.0) while phase
-    shows "scheduled" (coordinator fiber waiting for shard callback to complete).
+    Clogger floods MULTI/GET <1 MB key>/EXEC on the Redis port without reading,
+    blocking Send() mid-EXEC while holding the shard lock.  Ghost connections on
+    the memcache port (ioloopv2) send SET on the same key and RST-close while
+    blocked.  The orphan mechanism keeps commands alive until they complete.
     """
     import struct
 
+    mc_port = 11311
     control_client = df_server.client()
     await control_client.set("key", "v" * 1024 * 1024)
 
@@ -2190,12 +2189,8 @@ async def test_multi_exec_phantom_connections(df_server: DflyInstance):
     await writer.drain()
     await reader.readline()  # +OK
 
-    # Stop asyncio from draining incoming data — to simulate server replies getting stuck.
     writer.transport.pause_reading()
 
-    # A few commands are enough: each EXEC reply is ~1 MB; the OS receive buffer
-    # (~4 MB) fills after 4 replies, TCP window drops to 0, and the server's
-    # Send() blocks mid-EXEC while still holding the shard lock.
     cmd = b"MULTI\r\nGET key\r\nEXEC\r\n"
     for _ in range(10):
         writer.write(cmd)
@@ -2209,67 +2204,39 @@ async def test_multi_exec_phantom_connections(df_server: DflyInstance):
 
     await wait_clogger_stuck()
 
-    # Ghost connections: preamble commands sent+ack'd one-by-one (sync-dispatch,
-    # tot-dispatches stays 0), then EXEC fired without reading.  EXEC blocks in
-    # ScheduleSingleHop on the shard lock held by the clogger.
-    def recv_line(s):
-        buf = b""
-        while not buf.endswith(b"\r\n"):
-            buf += s.recv(256)
-        return buf
-
+    # Ghost connections via memcache port (ioloopv2).
+    # Each sends SET on the SAME key locked by clogger's EXEC.
     ghosts = []
-    for i in range(3):
+    num_ghosts = 5
+    for i in range(num_ghosts):
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, linger_rst)
-        s.connect(("127.0.0.1", df_server.port))
-        s.sendall(f"CLIENT SETNAME ghost{i}\r\n".encode())
-        recv_line(s)  # +OK
-        s.sendall(b"MULTI\r\n")
-        recv_line(s)  # +OK
-        s.sendall(b"SET key v\r\n")
-        recv_line(s)  # +QUEUED
-        s.sendall(b"EXEC\r\n")  # after this call, this connection is blocked on stuck tx queue.
+        s.connect(("127.0.0.1", mc_port))
+        val = f"ghost_val_{i}"
+        mc_set = f"set key 0 0 {len(val)}\r\n{val}\r\n"
+        s.sendall(mc_set.encode())
         ghosts.append(s)
 
-    await asyncio.sleep(0.2)  # let EXEC bytes reach server's receive buffer
+    await asyncio.sleep(0.3)  # let SET bytes reach server and block on shard
 
-    # RST-close: kernel moves server-side sockets to TCP_CLOSE.
-    # getpeername() → ENOTCONN → addr=0.0.0.0 in CLIENT LIST.
+    # RST-close all ghost connections while their SET is in-flight.
     for s in ghosts:
         s.close()
 
-    @assert_eventually(times=50)
-    async def check_phantoms():
-        clients = await control_client.client_list()
-        phantoms = [
-            c
-            for c in clients
-            if c.get("addr", "").startswith("0.0.0.0") and c.get("phase") == "scheduled"
-        ]
-        logging.info("phantoms: %s", [(c["name"], c["addr"], c["phase"]) for c in phantoms])
-        assert len(phantoms) >= 3, f"got {[(c['addr'], c['phase']) for c in clients]}"
+    await asyncio.sleep(0.2)  # let RST propagate
 
-    await check_phantoms()
-
-    # # A competing MULTI/SET confirms the shard lock is still held while we observe.
-    # other = df_server.client()
-    # pipe = other.pipeline(transaction=True)
-    # pipe.set("key", "new")
-    # compete = asyncio.create_task(pipe.execute())
-
-    # await asyncio.sleep(0.5)
-    # assert not compete.done(), "Competing MULTI/EXEC should be stuck waiting for the shard lock"
-
-    # logging.info("Holding stuck state — inspect with: redis-cli -p %d client list", df_server.port)
-    # await asyncio.sleep(300)
-
-    # RST-close the clogger: Write() fails, fiber resumes, UnlockMulti() is called,
-    # the competing transaction unblocks, and phantom connections clean up.
+    # Unblock the clogger — server detects write failure, releases shard lock,
+    # orphaned SET commands complete.
     writer.transport.abort()
 
-    # result = await asyncio.wait_for(compete, timeout=5.0)
-    # assert result == [True]
+    # Verify the orphaned SET commands were applied (not dropped).
+    @assert_eventually
+    async def verify_sets_applied():
+        val = await control_client.get("key")
+        expected_vals = {f"ghost_val_{i}" for i in range(num_ghosts)}
+        assert val in expected_vals, f"key was not set by any ghost, got {val}"
+
+    await verify_sets_applied()
     assert await control_client.ping()
 
 

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -2176,7 +2176,7 @@ async def test_multi_exec_phantom_connections(df_server: DflyInstance):
     """
     import struct
 
-    mc_port = 11311
+    mc_port = int(df_server["memcached_port"])
     control_client = df_server.client()
     await control_client.set("key", "v" * 1024 * 1024)
 

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -2165,7 +2165,14 @@ async def test_pubsub_pipeline_starvation(df_server: DflyInstance):
         await writer.wait_closed()
 
 
-@dfly_args({"proactor_threads": 1, "memcached_port": 11311, "experimental_io_loop_v2": "true"})
+@dfly_args(
+    {
+        "proactor_threads": 1,
+        "memcached_port": 11311,
+        "enable_memcache_io_loop_v2": "true",
+        "enable_resp_io_loop_v2": "true",
+    }
+)
 async def test_multi_exec_phantom_connections(df_server: DflyInstance):
     """With ioloopv2, commands from RST-closed connections must not be dropped.
 


### PR DESCRIPTION
With ioloopv2, all "in flight" commands are coroutines that suspended on the `tx->Blocker()` (aka `run_barrier`). When a connection disconnects, we can:
1. Try to cancel all such commands as they pass the conditions of #7399 
2. If it is not possible to cancel them, add them to the orphan list and wait for their completion while letting the connection forget about them and progress further with shutdown