### PR TITLE
fix(server): Cancel transactions

### DIFF
--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -149,6 +149,63 @@ TEST_F(MultiTxTest, MultiUnlock) {
     EXPECT_FALSE(IsLocked(0, key));
 }
 
+// Test that CancelScheduledTx successfully cancels a multi-shard transaction
+// that has been scheduled and armed but not yet executed on any shard.
+TEST_F(MultiTxTest, CancelScheduledTx) {
+  // Set initial values on keys spanning multiple shards.
+  Run({"mset", kKeySid0, "v0", kKeySid1, "v1", kKeySid2, "v2"});
+
+  // Suspend all shards with a global transaction. This prevents any other transaction
+  // from executing, ensuring the MSET stays armed but unexecuted.
+  TransactionSuspension suspension;
+  pp_->at(0)->Await([&] { suspension.Start(); });
+
+  // Launch MSET on a fiber. It will schedule and arm but block in run_barrier_.Wait()
+  // because the global suspension transaction holds all shards.
+  auto mset_fb = pp_->at(0)->LaunchFiber([&] {
+    Run("mset_client", {"MSET", kKeySid0, "new0", kKeySid1, "new1", kKeySid2, "new2"});
+  });
+
+  // Wait for the MSET transaction to be scheduled.
+  Transaction* mset_tx = nullptr;
+  ExpectConditionWithinTimeout([&] {
+    bool ready = false;
+    pp_->at(0)->Await([&] {
+      mset_tx = GetTransaction("mset_client");
+      ready = mset_tx != nullptr && mset_tx->IsScheduled();
+    });
+    return ready;
+  });
+
+  // Cancel the MSET transaction from proactor 0.
+  bool cancelled = false;
+  pp_->at(0)->Await([&] { cancelled = mset_tx->CancelScheduledTx(); });
+  EXPECT_TRUE(cancelled);
+
+  // Release the suspension so everything can proceed.
+  pp_->at(0)->Await([&] { suspension.Terminate(); });
+
+  mset_fb.Join();
+
+  // Verify the MSET's values did NOT take effect.
+  EXPECT_EQ(Run({"get", kKeySid0}), "v0");
+  EXPECT_EQ(Run({"get", kKeySid1}), "v1");
+  EXPECT_EQ(Run({"get", kKeySid2}), "v2");
+
+  // Verify no locks are held.
+  EXPECT_FALSE(IsLocked(0, kKeySid0));
+  EXPECT_FALSE(IsLocked(0, kKeySid1));
+  EXPECT_FALSE(IsLocked(0, kKeySid2));
+
+  // Verify tx queues are empty.
+  atomic_bool tx_empty{true};
+  shard_set->RunBriefInParallel([&](EngineShard* shard) {
+    if (!shard->txq()->Empty())
+      tx_empty.store(false);
+  });
+  EXPECT_TRUE(tx_empty);
+}
+
 TEST_F(MultiTest, MultiGlobalCommands) {
   ASSERT_THAT(Run({"set", "key", "val"}), "OK");
 

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -747,9 +747,9 @@ auto BaseFamilyTest::AddFindConn(Protocol proto, std::string_view id) -> TestCon
   return it->second.get();
 }
 
-Transaction* BaseFamilyTest::GetTransaction(string_view id) {
+Transaction* BaseFamilyTest::GetTransaction(string_view conn_id) {
   unique_lock lk(mu_);
-  auto it = connections_.find(id);
+  auto it = connections_.find(conn_id);
   if (it == connections_.end())
     return nullptr;
   return it->second->cmd_cntx()->transaction;

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -747,6 +747,14 @@ auto BaseFamilyTest::AddFindConn(Protocol proto, std::string_view id) -> TestCon
   return it->second.get();
 }
 
+Transaction* BaseFamilyTest::GetTransaction(string_view id) {
+  unique_lock lk(mu_);
+  auto it = connections_.find(id);
+  if (it == connections_.end())
+    return nullptr;
+  return it->second->cmd_cntx()->transaction;
+}
+
 vector<string> BaseFamilyTest::StrArray(const RespExpr& expr) {
   CHECK(expr.type == RespExpr::ARRAY || expr.type == RespExpr::NIL_ARRAY);
   if (expr.type == RespExpr::NIL_ARRAY)

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -136,6 +136,7 @@ class BaseFamilyTest : public ::testing::Test {
   }
 
   TestConnWrapper* AddFindConn(Protocol proto, std::string_view id);
+  Transaction* GetTransaction(std::string_view id);
   static std::vector<std::string> StrArray(const RespExpr& expr);
 
   Metrics GetMetrics() const {

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -136,7 +136,7 @@ class BaseFamilyTest : public ::testing::Test {
   }
 
   TestConnWrapper* AddFindConn(Protocol proto, std::string_view id);
-  Transaction* GetTransaction(std::string_view id);
+  Transaction* GetTransaction(std::string_view conn_id);
   static std::vector<std::string> StrArray(const RespExpr& expr);
 
   Metrics GetMetrics() const {

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1040,56 +1040,37 @@ void Transaction::Conclude() {
 
 bool Transaction::CancelScheduledTx() {
   DCHECK(coordinator_state_ & COORD_SCHED);
-
   bool is_readonly = cid_->IsReadOnly();
 
-  // Phase 1: Try to disarm all active shards atomically.
-  // We iterate shards and attempt to clear is_armed. If a shard was already disarmed
-  // (consumed by PollExecution/RunInShard), it means the callback already ran there.
-  unsigned disarmed_cnt = 0;
-  unsigned active_cnt = 0;
-
-  // Track which shards we successfully disarmed so we can re-arm them on failure.
-  // Using a bitset since shard_data_ is bounded at 1024.
+  // First, try to clear all is_armed flags
   std::bitset<1024> disarmed_shards;
-
   IterateActiveShards([&](auto& sd, ShardId i) {
-    active_cnt++;
-    if (sd.is_armed.exchange(false, memory_order_acquire)) {
+    if (sd.is_armed.exchange(false, memory_order_acquire))
       disarmed_shards.set(i);
-      disarmed_cnt++;
-    }
   });
 
-  // If we disarmed all shards, the callback never ran anywhere - safe to cancel.
-  // For readonly transactions, we can cancel even if some shards already ran
-  // (partial reads are harmless since they don't mutate state).
-  if (disarmed_cnt == active_cnt || is_readonly) {
-    // Remove the transaction from shard queues and release locks BEFORE unblocking
-    // the coordinator barrier. This prevents a race where the coordinator fiber wakes,
-    // the transaction is destroyed, and shard threads still reference it.
+  // For mutable transctions we can cancel only if all shards can be stopped.
+  // Reads do not cause any inconsistencies if stopped mid-read, so any condition is ok
+  unsigned disarmed_cnt = disarmed_shards.count();
+  if (disarmed_cnt == unique_shard_cnt_ || is_readonly) {
+    // Cancel the transaction
     auto is_active = [this](uint32_t i) { return IsActive(i); };
     shard_set->RunBriefInParallel([this](EngineShard* shard) { CancelShardCb(shard); }, is_active);
-
-    coordinator_state_ |= COORD_CANCELLED;
-    coordinator_state_ &= ~COORD_SCHED;
+    coordinator_state_ = (coordinator_state_ & ~COORD_SCHED) | COORD_CANCELLED;
     cb_ptr_.reset();
 
     // Signal the run_barrier_ for all shards we disarmed so the coordinator unblocks.
-    for (unsigned i = 0; i < disarmed_cnt; i++) {
+    for (unsigned i = 0; i < disarmed_cnt; i++)
       run_barrier_.Dec();
-    }
 
     // If readonly and some shards already ran, wait for them to finish naturally.
-    if (disarmed_cnt < active_cnt) {
+    if (disarmed_cnt < unique_shard_cnt_)
       run_barrier_.Wait();
-    }
 
     return true;
   }
 
-  // Phase 2: A mutable transaction already ran on at least one shard.
-  // We must re-arm the shards we disarmed so the transaction completes on all shards.
+  // A mutable transaction already ran on at least one shard. Re-arm to let it complete.
   std::atomic_thread_fence(memory_order_release);
   IterateActiveShards([&](auto& sd, ShardId i) {
     if (disarmed_shards.test(i)) {

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1038,6 +1038,79 @@ void Transaction::Conclude() {
   Execute(std::move(cb), true);
 }
 
+bool Transaction::CancelScheduledTx() {
+  DCHECK(coordinator_state_ & COORD_SCHED);
+
+  bool is_readonly = cid_->IsReadOnly();
+
+  // Phase 1: Try to disarm all active shards atomically.
+  // We iterate shards and attempt to clear is_armed. If a shard was already disarmed
+  // (consumed by PollExecution/RunInShard), it means the callback already ran there.
+  unsigned disarmed_cnt = 0;
+  unsigned active_cnt = 0;
+
+  // Track which shards we successfully disarmed so we can re-arm them on failure.
+  // Using a bitset since shard_data_ is bounded at 1024.
+  std::bitset<1024> disarmed_shards;
+
+  IterateActiveShards([&](auto& sd, ShardId i) {
+    active_cnt++;
+    if (sd.is_armed.exchange(false, memory_order_acquire)) {
+      disarmed_shards.set(i);
+      disarmed_cnt++;
+    }
+  });
+
+  // If we disarmed all shards, the callback never ran anywhere - safe to cancel.
+  // For readonly transactions, we can cancel even if some shards already ran
+  // (partial reads are harmless since they don't mutate state).
+  if (disarmed_cnt == active_cnt || is_readonly) {
+    // Remove the transaction from shard queues and release locks BEFORE unblocking
+    // the coordinator barrier. This prevents a race where the coordinator fiber wakes,
+    // the transaction is destroyed, and shard threads still reference it.
+    auto is_active = [this](uint32_t i) { return IsActive(i); };
+    shard_set->RunBriefInParallel([this](EngineShard* shard) { CancelShardCb(shard); }, is_active);
+
+    coordinator_state_ |= COORD_CANCELLED;
+    coordinator_state_ &= ~COORD_SCHED;
+    cb_ptr_.reset();
+
+    // Signal the run_barrier_ for all shards we disarmed so the coordinator unblocks.
+    for (unsigned i = 0; i < disarmed_cnt; i++) {
+      run_barrier_.Dec();
+    }
+
+    // If readonly and some shards already ran, wait for them to finish naturally.
+    if (disarmed_cnt < active_cnt) {
+      run_barrier_.Wait();
+    }
+
+    return true;
+  }
+
+  // Phase 2: A mutable transaction already ran on at least one shard.
+  // We must re-arm the shards we disarmed so the transaction completes on all shards.
+  std::atomic_thread_fence(memory_order_release);
+  IterateActiveShards([&](auto& sd, ShardId i) {
+    if (disarmed_shards.test(i)) {
+      sd.is_armed.store(true, memory_order_relaxed);
+    }
+  });
+
+  // Submit poll tasks for re-armed shards so they get picked up.
+  IterateActiveShards([&](auto& sd, ShardId i) {
+    if (disarmed_shards.test(i)) {
+      use_count_.fetch_add(1, memory_order_relaxed);
+      shard_set->Add(i, [this] {
+        EngineShard::tlocal()->PollExecution("cancel_rearm", this);
+        intrusive_ptr_release(this);
+      });
+    }
+  });
+
+  return false;
+}
+
 void Transaction::Refurbish() {
   txid_ = 0;
   coordinator_state_ = 0;

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1049,6 +1049,19 @@ bool Transaction::CancelScheduledTx() {
       disarmed_shards.set(i);
   });
 
+  // Issue PollExecutions to shards that were disarmed
+  auto poll_disarmed = [this, &disarmed_shards](const char* context) {
+    IterateActiveShards([&](auto& sd, ShardId i) {
+      if (disarmed_shards.test(i)) {
+        use_count_.fetch_add(1, memory_order_relaxed);
+        shard_set->Add(i, [this, context] {
+          EngineShard::tlocal()->PollExecution(context, this);
+          intrusive_ptr_release(this);
+        });
+      }
+    });
+  };
+
   // For mutable transctions we can cancel only if all shards can be stopped.
   // Reads do not cause any inconsistencies if stopped mid-read, so any condition is ok
   unsigned disarmed_cnt = disarmed_shards.count();
@@ -1057,39 +1070,32 @@ bool Transaction::CancelScheduledTx() {
     auto is_active = [this](uint32_t i) { return IsActive(i); };
     shard_set->RunBriefInParallel([this](EngineShard* shard) { CancelShardCb(shard); }, is_active);
     coordinator_state_ = (coordinator_state_ & ~COORD_SCHED) | COORD_CANCELLED;
-    cb_ptr_.reset();
 
     // Signal the run_barrier_ for all shards we disarmed so the coordinator unblocks.
     for (unsigned i = 0; i < disarmed_cnt; i++)
       run_barrier_.Dec();
+
+    // Issue polls after cancels (like in schedule)
+    poll_disarmed("cancel_cancel");
 
     // If readonly and some shards already ran, wait for them to finish naturally.
     if (disarmed_cnt < unique_shard_cnt_)
       run_barrier_.Wait();
 
     return true;
+  } else {
+    // Rearm to ensure atomicity of execution on all shards
+    std::atomic_thread_fence(memory_order_release);
+    IterateActiveShards([&](auto& sd, ShardId i) {
+      if (disarmed_shards.test(i)) {
+        sd.is_armed.store(true, memory_order_relaxed);
+      }
+    });
+
+    // Submit poll tasks for re-armed shards so they get picked up.
+    poll_disarmed("cancel_rearm");
+    return false;
   }
-
-  // A mutable transaction already ran on at least one shard. Re-arm to let it complete.
-  std::atomic_thread_fence(memory_order_release);
-  IterateActiveShards([&](auto& sd, ShardId i) {
-    if (disarmed_shards.test(i)) {
-      sd.is_armed.store(true, memory_order_relaxed);
-    }
-  });
-
-  // Submit poll tasks for re-armed shards so they get picked up.
-  IterateActiveShards([&](auto& sd, ShardId i) {
-    if (disarmed_shards.test(i)) {
-      use_count_.fetch_add(1, memory_order_relaxed);
-      shard_set->Add(i, [this] {
-        EngineShard::tlocal()->PollExecution("cancel_rearm", this);
-        intrusive_ptr_release(this);
-      });
-    }
-  });
-
-  return false;
 }
 
 void Transaction::Refurbish() {

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1039,8 +1039,12 @@ void Transaction::Conclude() {
 }
 
 bool Transaction::CancelScheduledTx() {
+  // For safety reasons we don't cancel those - requires more investigation
+  if (IsGlobal())
+    return false;
+
   DCHECK(coordinator_state_ & COORD_SCHED);
-  bool is_readonly = cid_->IsReadOnly();
+  bool is_safe = cid_->IsReadOnly();
 
   // First, try to clear all is_armed flags
   std::bitset<1024> disarmed_shards;
@@ -1065,7 +1069,7 @@ bool Transaction::CancelScheduledTx() {
   // For mutable transctions we can cancel only if all shards can be stopped.
   // Reads do not cause any inconsistencies if stopped mid-read, so any condition is ok
   unsigned disarmed_cnt = disarmed_shards.count();
-  if (disarmed_cnt == unique_shard_cnt_ || is_readonly) {
+  if (disarmed_cnt == unique_shard_cnt_ || is_safe) {
     // Cancel the transaction
     auto is_active = [this](uint32_t i) { return IsActive(i); };
     shard_set->RunBriefInParallel([this](EngineShard* shard) { CancelShardCb(shard); }, is_active);

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -227,6 +227,15 @@ class Transaction {
   // Must be called from coordinator thread.
   void CancelBlocking(const std::function<OpStatus(ArgSlice)>&);
 
+  // Attempt to cancel a scheduled transaction that has been armed (hop dispatched).
+  // Tries to atomically disarm all active shards. If all shards are successfully disarmed,
+  // the transaction is cancelled and removed from shard queues. If any shard already executed
+  // (couldn't be disarmed), re-arms the previously disarmed shards so the transaction
+  // completes normally.
+  // Returns true if the transaction was successfully cancelled.
+  // Must be called from the coordinator thread after DispatchHop() but before run_barrier_.Wait().
+  bool CancelScheduledTx();
+
   // Prepare a squashed hop on given shards.
   // Only compatible with multi modes that acquire all locks ahead - global and lock_ahead.
   void PrepareSquashedMultiHop(const CommandId* cid, absl::FunctionRef<bool(ShardId)> enabled);


### PR DESCRIPTION
Try to cancel scheduled + armed transactions safely. We can do this for readonly commands and mutable commands that haven't yet started executing on any shard (otherwise they already touched the data and we can't interrupt them). 