### PR TITLE
fix(server): run RANDOMKEY scan on regular fiber to allow preempt

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -2604,29 +2604,31 @@ void GenericFamily::RandomKey(CmdArgList args, CommandContext* cmd_cntx) {
   scan_opts.limit = 3;  // number of entries per shard
   std::vector<StringVec> candidates_collection(shard_set->size());
 
-  shard_set->RunBriefInParallel(
-      [&](EngineShard* shard) {
-        auto* prime_table = cntx->ns->GetDbSlice(shard->shard_id()).GetTables(db_cntx.db_index);
-        if (prime_table->size() == 0) {
-          return;
-        }
+  // OpScan can preempt (WaitForUnblockedJournalWrites suspends on CondVar during BGSAVE),
+  // so we must run on a regular fiber rather than the dispatcher (RunBriefInParallel).
+  shard_set->RunBlockingInParallel([&](EngineShard* shard) {
+    auto* prime_table = cntx->ns->GetDbSlice(shard->shard_id()).GetTables(db_cntx.db_index);
+    if (prime_table->size() == 0) {
+      return;
+    }
 
-        StringVec* candidates = &candidates_collection[shard->shard_id()];
+    StringVec* candidates = &candidates_collection[shard->shard_id()];
 
-        for (size_t i = 0; i <= kMaxAttempts; ++i) {
-          if (!candidates->empty()) {
-            break;
-          }
-          uint64_t cursor = 0;  // scans from the start of the shard after reaching kMaxAttemps
-          if (i < kMaxAttempts) {
-            cursor = prime_table->GetRandomCursor(&bitgen).token();
-          }
-          OpScan({shard, 0u, db_cntx}, scan_opts, &cursor, candidates);
-        }
+    // Per-shard RNG; absl::BitGen is not thread-safe.
+    absl::BitGen local_gen;
+    for (size_t i = 0; i <= kMaxAttempts; ++i) {
+      if (!candidates->empty()) {
+        break;
+      }
+      uint64_t cursor = 0;  // scans from the start of the shard after reaching kMaxAttemps
+      if (i < kMaxAttempts) {
+        cursor = prime_table->GetRandomCursor(&local_gen).token();
+      }
+      OpScan({shard, 0u, db_cntx}, scan_opts, &cursor, candidates);
+    }
 
-        candidates_counter.fetch_add(candidates->size(), memory_order_relaxed);
-      },
-      [&](ShardId) { return true; });
+    candidates_counter.fetch_add(candidates->size(), memory_order_relaxed);
+  });
 
   auto candidates_count = candidates_counter.load(memory_order_relaxed);
 

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -672,6 +672,53 @@ async def test_debug_objhist_during_bgsave(df_factory: DflyInstanceFactory):
     assert await client.ping()
 
 
+@pytest.mark.asyncio
+@dfly_args({**BASIC_ARGS})
+async def test_randomkey_during_bgsave(df_factory: DflyInstanceFactory):
+    """
+    Regression test for #7404. Before the fix, RANDOMKEY dispatched its per-shard
+    scan via RunBriefInParallel (dispatcher fiber, no preempt). The callback ran
+    OpScan -> DbSlice::WaitForUnblockedJournalWrites, which suspends on a CondVar
+    while a BGSAVE snapshot has buckets mid-serialization — tripping
+    "Should not preempt dispatcher" and aborting the process.
+    """
+    df = df_factory.create(
+        proactor_threads=4,
+        serialization_max_chunk_size=4096,
+        dbfilename=f"dump_{tmp_file_name()}",
+    )
+    df.start()
+    client = df.client()
+
+    # Big values + small chunk size force the snapshot serializer to yield mid-bucket,
+    # leaving deps_ non-empty so RANDOMKEY's scan callback hits WaitEmpty.
+    await client.execute_command("DEBUG", "POPULATE", "20000", "k", "8192", "RAND")
+
+    async def hammer_random(stop_evt):
+        c = df.client()
+        while not stop_evt.is_set():
+            try:
+                await c.execute_command("RANDOMKEY")
+            except Exception:
+                pass
+
+    stop = asyncio.Event()
+    workers = [asyncio.create_task(hammer_random(stop)) for _ in range(8)]
+
+    try:
+        async with timeout(60):
+            for _ in range(5):
+                await client.execute_command("BGSAVE")
+                while await is_saving(client):
+                    await asyncio.sleep(0.01)
+    finally:
+        stop.set()
+        await asyncio.gather(*workers, return_exceptions=True)
+
+    # If we get here the server did not crash — verify it is still responsive.
+    assert await client.ping()
+
+
 @dfly_args({"proactor_threads": 1, "dbfilename": "test-hsetex-save", "dir": "{DRAGONFLY_TMP}/"})
 async def test_save_hash_with_expired_fields(async_client: aioredis.Redis):
     """


### PR DESCRIPTION
`RANDOMKEY` dispatched its per-shard scan via `RunBriefInParallel`, which runs the callback on the dispatcher fiber where preemption is forbidden. The callback eventually calls `OpScan` -> `DbSlice::WaitForUnblockedJournalWrites` -> `BucketDependencies::WaitEmpty`, which suspends on a `CondVar` whenever a snapshot serializer has a bucket mid-serialization (e.g., during `BGSAVE`). Suspending the dispatcher trips `Scheduler::Preempt`'s `Should not preempt dispatcher` check and aborts the process.

Switch to `RunBlockingInParallel`, so the scan runs on a regular fiber, matching the model used by `SCAN` (`ess->Await`).

Fixes #7404