### PR TITLE
refactor: ReplicaInfo into class

### DIFF
--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -96,12 +96,12 @@ bool WaitReplicaFlowToCatchup(absl::Time end_time, const DflyCmd::ReplicaInfo* r
   while (flow->last_acked_lsn < journal::GetLsn()) {
     if (absl::Now() > end_time) {
       LOG(WARNING) << "Couldn't synchronize with replica for takeover in time: "
-                   << replica->Address() << ":" << replica->ListeningPort()
+                   << replica->GetAddress() << ":" << replica->GetListeningPort()
                    << ", last acked: " << flow->last_acked_lsn << ", expecting "
                    << journal::GetLsn();
       return false;
     }
-    if (!replica->ExecState().IsRunning()) {
+    if (!replica->GetExecState().IsRunning()) {
       return false;
     }
     LOG_EVERY_T(INFO, 1) << "Replica lsn:" << flow->last_acked_lsn
@@ -282,7 +282,7 @@ void DflyCmd::Flow(CmdArgList args, CommandContext* cmd_cntx) {
   {
     util::fb2::LockGuard lk{replica_ptr->GetMutex()};
 
-    if (replica_ptr->ReplicaState() != SyncState::PREPARATION) {
+    if (replica_ptr->GetReplicaState() != SyncState::PREPARATION) {
       return cmd_cntx->SendError(kInvalidState);
     }
 
@@ -300,7 +300,7 @@ void DflyCmd::Flow(CmdArgList args, CommandContext* cmd_cntx) {
     conn_cntx->master_repl_flow = &flow;
     flow.conn = cmd_cntx->conn();
     flow.eof_token = eof_token;
-    flow.version = replica_ptr->Version();
+    flow.version = replica_ptr->GetVersion();
 
     if (!conn_cntx->conn()->Migrate(shard_set->pool()->at(flow_id))) {
       // Listener::PreShutdown() triggered
@@ -366,7 +366,7 @@ void DflyCmd::Sync(CmdArgList args, CommandContext* cmd_cntx) {
     // Use explicit assignment for replica_ptr, because capturing structured bindings is C++20.
     auto cb = [this, &status, replica_ptr = replica_ptr](EngineShard* shard) {
       status = StartFullSyncInThread(&replica_ptr->GetFlow(shard->shard_id()),
-                                     &replica_ptr->ExecState(), shard);
+                                     &replica_ptr->GetExecState(), shard);
     };
     shard_set->RunBlockingInParallel(std::move(cb));
 
@@ -375,8 +375,8 @@ void DflyCmd::Sync(CmdArgList args, CommandContext* cmd_cntx) {
       return cmd_cntx->SendError(kInvalidState);
   }
 
-  LOG(INFO) << "Started sync with replica " << replica_ptr->Address() << ":"
-            << replica_ptr->ListeningPort();
+  LOG(INFO) << "Started sync with replica " << replica_ptr->GetAddress() << ":"
+            << replica_ptr->GetListeningPort();
 
   // protected by lk above.
   replica_ptr->SetReplicaState(SyncState::FULL_SYNC);
@@ -394,7 +394,7 @@ void DflyCmd::StartStable(CmdArgList args, CommandContext* cmd_cntx) {
     return;
 
   util::fb2::LockGuard lk{replica_ptr->GetMutex()};
-  auto repl_state = replica_ptr->ReplicaState();
+  auto repl_state = replica_ptr->GetReplicaState();
   if (repl_state != SyncState::FULL_SYNC && repl_state != SyncState::PREPARATION) {
     cmd_cntx->SendError(kInvalidState);
     return;
@@ -416,13 +416,13 @@ void DflyCmd::StartStable(CmdArgList args, CommandContext* cmd_cntx) {
       // We are doing partial sync. We never started FullSync so we don't need to stop it.
       bool is_partial = flow->start_partial_sync_at.has_value();
       if (!is_partial) {
-        status = StopFullSyncInThread(flow, &replica_ptr->ExecState(), shard);
+        status = StopFullSyncInThread(flow, &replica_ptr->GetExecState(), shard);
         if (*status != OpStatus::OK) {
           return;
         }
       }
 
-      StartStableSyncInThread(flow, &replica_ptr->ExecState(), shard);
+      StartStableSyncInThread(flow, &replica_ptr->GetExecState(), shard);
     };
     shard_set->RunBlockingInParallel(std::move(cb));
 
@@ -430,8 +430,8 @@ void DflyCmd::StartStable(CmdArgList args, CommandContext* cmd_cntx) {
       return cmd_cntx->SendError(kInvalidState);
   }
 
-  LOG(INFO) << "Transitioned into stable sync with replica " << replica_ptr->Address() << ":"
-            << replica_ptr->ListeningPort();
+  LOG(INFO) << "Transitioned into stable sync with replica " << replica_ptr->GetAddress() << ":"
+            << replica_ptr->GetListeningPort();
 
   replica_ptr->SetReplicaState(SyncState::STABLE_SYNC);
   return cmd_cntx->SendOk();
@@ -622,7 +622,7 @@ void DflyCmd::TakeOver(CmdArgList args, CommandContext* cmd_cntx) {
     LOG(INFO) << "ReconcileMasterSlots() early exit. Config already updated";
     return;
   }
-  sf_->service().cluster_family().ReconcileMasterSlots(replica_ptr->Id());
+  sf_->service().cluster_family().ReconcileMasterSlots(replica_ptr->GetId());
 }
 
 void DflyCmd::Expire(CmdArgList args, CommandContext* cmd_cntx) {
@@ -878,7 +878,7 @@ std::vector<ReplicaRoleInfo> DflyCmd::GetReplicasRoleInfo() const {
     // the same applies of course if its state is not STABLE_SYNC.
     shared_lock lk(info->GetMutex(), try_to_lock);
     if (lk.owns_lock()) {
-      state = info->ReplicaState();
+      state = info->GetReplicaState();
       // If the replica is not in stable sync, its lag is undefined, so we set it to 0.
       if (state != SyncState::STABLE_SYNC) {
         lag = 0;
@@ -886,8 +886,8 @@ std::vector<ReplicaRoleInfo> DflyCmd::GetReplicasRoleInfo() const {
     } else {
       lag = 0;
     }
-    vec.push_back(ReplicaRoleInfo{std::string{info->Id()}, info->Address(), info->ListeningPort(),
-                                  SyncStateName(state), lag});
+    vec.push_back(ReplicaRoleInfo{std::string{info->GetId()}, info->GetAddress(),
+                                  info->GetListeningPort(), SyncStateName(state), lag});
   }
   return vec;
 }
@@ -902,8 +902,8 @@ void DflyCmd::GetReplicationMemoryStats(ReplicationMemoryStats* stats) const {
         dfly::SharedLock repl_lk{info->GetMutex()};
 
         // flows should not be empty.
-        DCHECK_GT(info->FlowCount(), 0u);
-        if (info->FlowCount() == 0)
+        DCHECK_GT(info->GetFlowCount(), 0u);
+        if (info->GetFlowCount() == 0)
           continue;
 
         const auto& flow = info->GetFlow(shard->shard_id());
@@ -978,7 +978,7 @@ void DflyCmd::SetDflyClientVersion(ConnectionState* state, DflyVersion version) 
 // block, leading to high contention in some case. Split it and avoid replying under a lock.
 bool DflyCmd::CheckReplicaStateOrReply(const ReplicaInfo& repl_info, SyncState expected,
                                        CommandContext* cmd_cntx) {
-  if (repl_info.ReplicaState() != expected) {
+  if (repl_info.GetReplicaState() != expected) {
     cmd_cntx->SendError(kInvalidState);
     return false;
   }

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -91,16 +91,17 @@ bool WaitReplicaFlowToCatchup(absl::Time end_time, const DflyCmd::ReplicaInfo* r
     journal::RecordEntry(0, journal::Op::PING, 0, nullopt, {});
   }
 
-  const FlowInfo* flow = &replica->flows[shard->shard_id()];
+  const FlowInfo* flow = &replica->GetFlow(shard->shard_id());
 
   while (flow->last_acked_lsn < journal::GetLsn()) {
     if (absl::Now() > end_time) {
-      LOG(WARNING) << "Couldn't synchronize with replica for takeover in time: " << replica->address
-                   << ":" << replica->listening_port << ", last acked: " << flow->last_acked_lsn
-                   << ", expecting " << journal::GetLsn();
+      LOG(WARNING) << "Couldn't synchronize with replica for takeover in time: "
+                   << replica->Address() << ":" << replica->ListeningPort()
+                   << ", last acked: " << flow->last_acked_lsn << ", expecting "
+                   << journal::GetLsn();
       return false;
     }
-    if (!replica->exec_st.IsRunning()) {
+    if (!replica->ExecState().IsRunning()) {
       return false;
     }
     LOG_EVERY_T(INFO, 1) << "Replica lsn:" << flow->last_acked_lsn
@@ -115,21 +116,21 @@ bool WaitReplicaFlowToCatchup(absl::Time end_time, const DflyCmd::ReplicaInfo* r
 }  // namespace
 
 void DflyCmd::ReplicaInfo::Cancel() {
-  util::fb2::LockGuard lk{shared_mu};
-  if (replica_state == SyncState::CANCELLED) {
+  util::fb2::LockGuard lk{shared_mu_};
+  if (replica_state_ == SyncState::CANCELLED) {
     return;
   }
 
-  LOG(INFO) << "Disconnecting from replica " << address << ":" << listening_port;
+  LOG(INFO) << "Disconnecting from replica " << address_ << ":" << listening_port_;
 
   // Update state and cancel context.
-  replica_state = SyncState::CANCELLED;
-  exec_st.ReportCancelError();
+  replica_state_ = SyncState::CANCELLED;
+  exec_st_.ReportCancelError();
   // Wait for tasks to finish.
   shard_set->RunBlockingInParallel([this](EngineShard* shard) {
     VLOG(2) << "Disconnecting flow " << shard->shard_id();
 
-    FlowInfo* flow = &flows[shard->shard_id()];
+    FlowInfo* flow = &flows_[shard->shard_id()];
     if (flow->cleanup) {
       flow->cleanup();
     }
@@ -137,8 +138,8 @@ void DflyCmd::ReplicaInfo::Cancel() {
     flow->conn = nullptr;
   });
   // Wait for error handler to quit.
-  exec_st.JoinErrorHandler();
-  VLOG(1) << "Disconnecting replica " << address << ":" << listening_port;
+  exec_st_.JoinErrorHandler();
+  VLOG(1) << "Disconnecting replica " << address_ << ":" << listening_port_;
 }
 
 DflyCmd::DflyCmd(ServerFamily* server_family) : sf_(server_family) {
@@ -279,9 +280,9 @@ void DflyCmd::Flow(CmdArgList args, CommandContext* cmd_cntx) {
   string eof_token;
   std::string sync_type{"FULL"};
   {
-    util::fb2::LockGuard lk{replica_ptr->shared_mu};
+    util::fb2::LockGuard lk{replica_ptr->GetMutex()};
 
-    if (replica_ptr->replica_state != SyncState::PREPARATION) {
+    if (replica_ptr->ReplicaState() != SyncState::PREPARATION) {
       return cmd_cntx->SendError(kInvalidState);
     }
 
@@ -295,11 +296,11 @@ void DflyCmd::Flow(CmdArgList args, CommandContext* cmd_cntx) {
     absl::InsecureBitGen gen;
     eof_token = GetRandomHex(gen, 40);
 
-    auto& flow = replica_ptr->flows[flow_id];
+    auto& flow = replica_ptr->GetFlow(flow_id);
     conn_cntx->master_repl_flow = &flow;
     flow.conn = cmd_cntx->conn();
     flow.eof_token = eof_token;
-    flow.version = replica_ptr->version;
+    flow.version = replica_ptr->Version();
 
     if (!conn_cntx->conn()->Migrate(shard_set->pool()->at(flow_id))) {
       // Listener::PreShutdown() triggered
@@ -353,7 +354,7 @@ void DflyCmd::Sync(CmdArgList args, CommandContext* cmd_cntx) {
   if (!sync_id)
     return;
 
-  util::fb2::LockGuard lk{replica_ptr->shared_mu};
+  util::fb2::LockGuard lk{replica_ptr->GetMutex()};
   if (!CheckReplicaStateOrReply(*replica_ptr, SyncState::PREPARATION, cmd_cntx))
     return;
 
@@ -364,8 +365,8 @@ void DflyCmd::Sync(CmdArgList args, CommandContext* cmd_cntx) {
 
     // Use explicit assignment for replica_ptr, because capturing structured bindings is C++20.
     auto cb = [this, &status, replica_ptr = replica_ptr](EngineShard* shard) {
-      status = StartFullSyncInThread(&replica_ptr->flows[shard->shard_id()], &replica_ptr->exec_st,
-                                     shard);
+      status = StartFullSyncInThread(&replica_ptr->GetFlow(shard->shard_id()),
+                                     &replica_ptr->ExecState(), shard);
     };
     shard_set->RunBlockingInParallel(std::move(cb));
 
@@ -374,11 +375,11 @@ void DflyCmd::Sync(CmdArgList args, CommandContext* cmd_cntx) {
       return cmd_cntx->SendError(kInvalidState);
   }
 
-  LOG(INFO) << "Started sync with replica " << replica_ptr->address << ":"
-            << replica_ptr->listening_port;
+  LOG(INFO) << "Started sync with replica " << replica_ptr->Address() << ":"
+            << replica_ptr->ListeningPort();
 
   // protected by lk above.
-  replica_ptr->replica_state = SyncState::FULL_SYNC;
+  replica_ptr->SetReplicaState(SyncState::FULL_SYNC);
 
   return cmd_cntx->SendOk();
 }
@@ -392,20 +393,17 @@ void DflyCmd::StartStable(CmdArgList args, CommandContext* cmd_cntx) {
   if (!sync_id)
     return;
 
-  util::fb2::LockGuard lk{replica_ptr->shared_mu};
-  auto repl_state = replica_ptr->replica_state;
+  util::fb2::LockGuard lk{replica_ptr->GetMutex()};
+  auto repl_state = replica_ptr->ReplicaState();
   if (repl_state != SyncState::FULL_SYNC && repl_state != SyncState::PREPARATION) {
     cmd_cntx->SendError(kInvalidState);
     return;
   }
 
-  // Check all flows are connected.
   // This might happen if a flow abruptly disconnected before sending the SYNC request.
-  for (const FlowInfo& flow : replica_ptr->flows) {
-    if (!flow.conn) {
-      cmd_cntx->SendError(kInvalidState);
-      return;
-    }
+  if (!replica_ptr->AllFlowsConnected()) {
+    cmd_cntx->SendError(kInvalidState);
+    return;
   }
 
   {
@@ -413,18 +411,18 @@ void DflyCmd::StartStable(CmdArgList args, CommandContext* cmd_cntx) {
     AggregateStatus status;
 
     auto cb = [this, &status, replica_ptr = replica_ptr](EngineShard* shard) {
-      FlowInfo* flow = &replica_ptr->flows[shard->shard_id()];
+      FlowInfo* flow = &replica_ptr->GetFlow(shard->shard_id());
 
       // We are doing partial sync. We never started FullSync so we don't need to stop it.
       bool is_partial = flow->start_partial_sync_at.has_value();
       if (!is_partial) {
-        status = StopFullSyncInThread(flow, &replica_ptr->exec_st, shard);
+        status = StopFullSyncInThread(flow, &replica_ptr->ExecState(), shard);
         if (*status != OpStatus::OK) {
           return;
         }
       }
 
-      StartStableSyncInThread(flow, &replica_ptr->exec_st, shard);
+      StartStableSyncInThread(flow, &replica_ptr->ExecState(), shard);
     };
     shard_set->RunBlockingInParallel(std::move(cb));
 
@@ -432,10 +430,10 @@ void DflyCmd::StartStable(CmdArgList args, CommandContext* cmd_cntx) {
       return cmd_cntx->SendError(kInvalidState);
   }
 
-  LOG(INFO) << "Transitioned into stable sync with replica " << replica_ptr->address << ":"
-            << replica_ptr->listening_port;
+  LOG(INFO) << "Transitioned into stable sync with replica " << replica_ptr->Address() << ":"
+            << replica_ptr->ListeningPort();
 
-  replica_ptr->replica_state = SyncState::STABLE_SYNC;
+  replica_ptr->SetReplicaState(SyncState::STABLE_SYNC);
   return cmd_cntx->SendOk();
 }
 
@@ -508,7 +506,7 @@ void DflyCmd::TakeOver(CmdArgList args, CommandContext* cmd_cntx) {
     return;
 
   {
-    dfly::SharedLock lk{replica_ptr->shared_mu};
+    dfly::SharedLock lk{replica_ptr->GetMutex()};
     if (!CheckReplicaStateOrReply(*replica_ptr, SyncState::STABLE_SYNC, cmd_cntx))
       return;
 
@@ -559,7 +557,7 @@ void DflyCmd::TakeOver(CmdArgList args, CommandContext* cmd_cntx) {
 
   atomic_bool catchup_success = true;
   if (*status == OpStatus::OK) {
-    dfly::SharedLock lk{replica_ptr->shared_mu};
+    dfly::SharedLock lk{replica_ptr->GetMutex()};
     auto cb = [replica_ptr = replica_ptr, end_time, &catchup_success](EngineShard* shard) {
       // PING to force the replica to send the last acked lsn.
       if (!WaitReplicaFlowToCatchup(end_time, replica_ptr.get(), shard, true)) {
@@ -624,7 +622,7 @@ void DflyCmd::TakeOver(CmdArgList args, CommandContext* cmd_cntx) {
     LOG(INFO) << "ReconcileMasterSlots() early exit. Config already updated";
     return;
   }
-  sf_->service().cluster_family().ReconcileMasterSlots(replica_ptr->id);
+  sf_->service().cluster_family().ReconcileMasterSlots(replica_ptr->Id());
 }
 
 void DflyCmd::Expire(CmdArgList args, CommandContext* cmd_cntx) {
@@ -832,13 +830,13 @@ void DflyCmd::BreakStalledFlowsInShard() {
   vector<uint32_t> deleted;
 
   for (auto [sync_id, replica_ptr] : replica_infos_) {
-    dfly::SharedLock replica_lock{replica_ptr->shared_mu};
+    dfly::SharedLock replica_lock{replica_ptr->GetMutex()};
 
-    if (!replica_ptr->flows[sid].saver)
+    if (!replica_ptr->GetFlow(sid).saver)
       continue;
 
     // If saver is present - we are currently using it for full sync.
-    int64_t last_write_ns = replica_ptr->flows[sid].saver->GetLastWriteTime();
+    int64_t last_write_ns = replica_ptr->GetFlow(sid).saver->GetLastWriteTime();
     int64_t timeout_ns = int64_t(absl::GetFlag(FLAGS_replication_timeout)) * 1'000'000LL;
     int64_t now = absl::GetCurrentTimeNanos();
     if (last_write_ns > 0 && last_write_ns + timeout_ns < now) {
@@ -878,9 +876,9 @@ std::vector<ReplicaRoleInfo> DflyCmd::GetReplicasRoleInfo() const {
 
     // If the replica state being updated, its lag is undefined,
     // the same applies of course if its state is not STABLE_SYNC.
-    shared_lock lk(info->shared_mu, try_to_lock);
+    shared_lock lk(info->GetMutex(), try_to_lock);
     if (lk.owns_lock()) {
-      state = info->replica_state;
+      state = info->ReplicaState();
       // If the replica is not in stable sync, its lag is undefined, so we set it to 0.
       if (state != SyncState::STABLE_SYNC) {
         lag = 0;
@@ -888,8 +886,8 @@ std::vector<ReplicaRoleInfo> DflyCmd::GetReplicasRoleInfo() const {
     } else {
       lag = 0;
     }
-    vec.push_back(
-        ReplicaRoleInfo{info->id, info->address, info->listening_port, SyncStateName(state), lag});
+    vec.push_back(ReplicaRoleInfo{std::string{info->Id()}, info->Address(), info->ListeningPort(),
+                                  SyncStateName(state), lag});
   }
   return vec;
 }
@@ -901,14 +899,14 @@ void DflyCmd::GetReplicationMemoryStats(ReplicationMemoryStats* stats) const {
     util::fb2::LockGuard lk{mu_};  // prevent state changes
     auto cb = [&](EngineShard* shard) ABSL_NO_THREAD_SAFETY_ANALYSIS {
       for (const auto& [_, info] : replica_infos_) {
-        dfly::SharedLock repl_lk{info->shared_mu};
+        dfly::SharedLock repl_lk{info->GetMutex()};
 
         // flows should not be empty.
-        DCHECK(!info->flows.empty());
-        if (info->flows.empty())
+        DCHECK_GT(info->FlowCount(), 0u);
+        if (info->FlowCount() == 0)
           continue;
 
-        const auto& flow = info->flows[shard->shard_id()];
+        const auto& flow = info->GetFlow(shard->shard_id());
         if (flow.streamer)
           streamer_bytes.fetch_add(flow.streamer->UsedBytes(), memory_order_relaxed);
         if (flow.saver)
@@ -951,7 +949,7 @@ std::map<uint32_t, LSN> DflyCmd::ReplicationLagsLocked() const {
     for (const auto& info : ABSL_TS_UNCHECKED_READ(replica_infos_)) {
       const ReplicaInfo* replica = info.second.get();
       if (shard->journal()) {
-        int64_t lag = journal::GetLsn() - replica->flows[shard->shard_id()].last_acked_lsn;
+        int64_t lag = journal::GetLsn() - replica->GetFlow(shard->shard_id()).last_acked_lsn;
         lags[info.first] = lag;
       }
     }
@@ -972,7 +970,7 @@ void DflyCmd::SetDflyClientVersion(ConnectionState* state, DflyVersion version) 
   VLOG(1) << "Client version for session_id=" << state->replication_info.repl_session_id << " is "
           << int(version);
 
-  replica_ptr->version = version;
+  replica_ptr->SetVersion(version);
 }
 
 // Must run under locked replica_info.mu.
@@ -980,18 +978,15 @@ void DflyCmd::SetDflyClientVersion(ConnectionState* state, DflyVersion version) 
 // block, leading to high contention in some case. Split it and avoid replying under a lock.
 bool DflyCmd::CheckReplicaStateOrReply(const ReplicaInfo& repl_info, SyncState expected,
                                        CommandContext* cmd_cntx) {
-  if (repl_info.replica_state != expected) {
+  if (repl_info.ReplicaState() != expected) {
     cmd_cntx->SendError(kInvalidState);
     return false;
   }
 
-  // Check all flows are connected.
   // This might happen if a flow abruptly disconnected before sending the SYNC request.
-  for (const FlowInfo& flow : repl_info.flows) {
-    if (!flow.conn) {
-      cmd_cntx->SendError(kInvalidState);
-      return false;
-    }
+  if (!repl_info.AllFlowsConnected()) {
+    cmd_cntx->SendError(kInvalidState);
+    return false;
   }
 
   return true;

--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -116,18 +116,18 @@ class DflyCmd {
     }
 
     // Immutable after construction; safe to read without locking.
-    const std::string& Address() const {
+    const std::string& GetAddress() const {
       return address_;
     }
-    uint32_t ListeningPort() const {
+    uint32_t GetListeningPort() const {
       return listening_port_;
     }
 
     // Returns the replica ID, or an empty view if SetId has not been called.
     // Thread-safe: id is written at most once via SetId, with release/acquire
     // ordering enforced by id_set_.
-    std::string_view Id() const {
-      if (id_set_.load(std::memory_order_acquire)) {
+    std::string_view GetId() const {
+      if (id_set_.load(std::memory_order_relaxed)) {
         return id_;
       }
       return {};
@@ -137,14 +137,14 @@ class DflyCmd {
     void SetId(std::string_view id) {
       DCHECK(!id_set_.load(std::memory_order_relaxed)) << "SetId called more than once";
       id_.assign(id);
-      id_set_.store(true, std::memory_order_release);
+      id_set_.store(true, std::memory_order_relaxed);
     }
 
     // Atomic to allow cross-thread access: SetDflyClientVersion writes from the
     // REPLCONF CLIENT-VERSION handler without locking, while Flow() reads under
-    // an exclusive lock on GetMutex(). Relaxed ordering: version is independent
-    // of other state.
-    DflyVersion Version() const {
+    // an exclusive lock on mutex(). Relaxed ordering: version is independent of
+    // other state.
+    DflyVersion GetVersion() const {
       return version_.load(std::memory_order_relaxed);
     }
     void SetVersion(DflyVersion v) {
@@ -153,19 +153,19 @@ class DflyCmd {
 
     // State machine field. Caller must hold GetMutex() exclusively for the setter
     // and at least in shared mode for the getter.
-    SyncState ReplicaState() const {
+    SyncState GetReplicaState() const {
       return replica_state_;
     }
     void SetReplicaState(SyncState s) {
       replica_state_ = s;
     }
 
-    // Per-shard fibers receive &ExecState() and pass it into StartFullSyncInThread
+    // Per-shard fibers receive &GetExecState() and pass it into StartFullSyncInThread
     // and friends. ExecutionState has its own internal synchronization.
-    ExecutionState& ExecState() {
+    ExecutionState& GetExecState() {
       return exec_st_;
     }
-    const ExecutionState& ExecState() const {
+    const ExecutionState& GetExecState() const {
       return exec_st_;
     }
 
@@ -177,7 +177,7 @@ class DflyCmd {
     const FlowInfo& GetFlow(size_t idx) const {
       return flows_[idx];
     }
-    size_t FlowCount() const {
+    size_t GetFlowCount() const {
       return flows_.size();
     }
 

--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -6,11 +6,13 @@
 
 #include <absl/container/btree_map.h>
 
+#include <algorithm>
 #include <atomic>
 #include <memory>
 
 #include "server/conn_context.h"
 #include "server/execution_state.h"
+#include "server/synchronization.h"
 #include "util/fibers/synchronization.h"
 
 namespace facade {
@@ -102,32 +104,115 @@ class DflyCmd {
   enum class SyncState { PREPARATION, FULL_SYNC, STABLE_SYNC, CANCELLED };
 
   // Stores information related to a single replica.
-  struct ABSL_LOCKABLE ReplicaInfo {
+  class ABSL_LOCKABLE ReplicaInfo {
+   public:
     ReplicaInfo(unsigned flow_count, std::string address, uint32_t listening_port,
                 ExecutionState::ErrHandler err_handler)
-        : replica_state{SyncState::PREPARATION},
-          exec_st{std::move(err_handler)},
-          address{std::move(address)},
-          listening_port(listening_port),
-          flows{flow_count} {
+        : replica_state_{SyncState::PREPARATION},
+          exec_st_{std::move(err_handler)},
+          address_{std::move(address)},
+          listening_port_(listening_port),
+          flows_{flow_count} {
+    }
+
+    // Immutable after construction; safe to read without locking.
+    const std::string& Address() const {
+      return address_;
+    }
+    uint32_t ListeningPort() const {
+      return listening_port_;
+    }
+
+    // Returns the replica ID, or an empty view if SetId has not been called.
+    // Thread-safe: id is written at most once via SetId, with release/acquire
+    // ordering enforced by id_set_.
+    std::string_view Id() const {
+      if (id_set_.load(std::memory_order_acquire)) {
+        return id_;
+      }
+      return {};
+    }
+    // Sets the replica ID. Expected to be called at most once per ReplicaInfo
+    // lifetime (from the REPLCONF CLIENT-ID handler on the owner thread).
+    void SetId(std::string_view id) {
+      DCHECK(!id_set_.load(std::memory_order_relaxed)) << "SetId called more than once";
+      id_.assign(id);
+      id_set_.store(true, std::memory_order_release);
+    }
+
+    // Atomic to allow cross-thread access: SetDflyClientVersion writes from the
+    // REPLCONF CLIENT-VERSION handler without locking, while Flow() reads under
+    // an exclusive lock on GetMutex(). Relaxed ordering: version is independent
+    // of other state.
+    DflyVersion Version() const {
+      return version_.load(std::memory_order_relaxed);
+    }
+    void SetVersion(DflyVersion v) {
+      version_.store(v, std::memory_order_relaxed);
+    }
+
+    // State machine field. Caller must hold GetMutex() exclusively for the setter
+    // and at least in shared mode for the getter.
+    SyncState ReplicaState() const {
+      return replica_state_;
+    }
+    void SetReplicaState(SyncState s) {
+      replica_state_ = s;
+    }
+
+    // Per-shard fibers receive &ExecState() and pass it into StartFullSyncInThread
+    // and friends. ExecutionState has its own internal synchronization.
+    ExecutionState& ExecState() {
+      return exec_st_;
+    }
+    const ExecutionState& ExecState() const {
+      return exec_st_;
+    }
+
+    // Per-shard flow access; idx is the master shard index.
+    // Caller must hold GetMutex() for any read or write.
+    FlowInfo& GetFlow(size_t idx) {
+      return flows_[idx];
+    }
+    const FlowInfo& GetFlow(size_t idx) const {
+      return flows_[idx];
+    }
+    size_t FlowCount() const {
+      return flows_.size();
+    }
+
+    // Returns true if every flow has a live connection. Caller must hold a lock.
+    bool AllFlowsConnected() const {
+      return std::ranges::all_of(flows_, [](const FlowInfo& flow) { return flow.conn != nullptr; });
+    }
+
+    // Returns the per-replica mutex. Callers acquire it via util::fb2::LockGuard
+    // (exclusive), dfly::SharedLock (shared), or std::shared_lock(..., std::try_to_lock)
+    // (try-shared). Returned by reference rather than a factory-returned scoped lock
+    // because clang's -Wthread-safety-analysis cannot track ownership transfer
+    // through a factory function's return value.
+    util::fb2::SharedMutex& GetMutex() {
+      return shared_mu_;
     }
 
     // Transition into cancelled state, run cleanup.
     void Cancel();
 
-    SyncState replica_state;  // always guarded by shared_mu
-    ExecutionState exec_st;
+   private:
+    SyncState replica_state_;  // always guarded by shared_mu_
+    ExecutionState exec_st_;
 
-    std::string id;
-    std::string address;
-    uint32_t listening_port;
-    DflyVersion version = DflyVersion::VER1;
+    std::string id_;
+    // Publication guard for id_: SetId writes id_ then sets this flag with
+    // release; id() acquires this flag and reads id_ on true.
+    std::atomic<bool> id_set_{false};
+    std::string address_;
+    uint32_t listening_port_;
+    std::atomic<DflyVersion> version_{DflyVersion::VER1};
 
-    // Flows describe the state of shard-local flow.
-    // They are always indexed by the shard index on the master.
-    std::vector<FlowInfo> flows;
+    std::vector<FlowInfo> flows_;
 
-    util::fb2::SharedMutex shared_mu;  // See top of header for locking levels.
+    util::fb2::SharedMutex shared_mu_;
   };
 
  public:

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -4216,7 +4216,7 @@ void ServerFamily::ReplConf(CmdArgList args, CommandContext* cmd_cntx) {
       auto info = dfly_cmd_->GetReplicaInfoFromConnection(&cntx->conn_state);
       DCHECK(info != nullptr);
       if (info) {
-        info->id = arg;
+        info->SetId(arg);
       }
     } else if (cmd == "CLIENT-VERSION" && args.size() == 2) {
       unsigned version;


### PR DESCRIPTION
related to: #7348

• Convert ReplicaInfo from struct to class with encapsulation
• Replace direct member access with getter/setter methods
• Add thread-safe atomic access for version and id fields