### PR TITLE
feat(server): tagged chunk write path

### DIFF
--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -584,11 +584,9 @@ void RdbLoaderBase::OpaqueObjLoader::CreateHMap(const LoadTrace* ltrace) {
 void RdbLoaderBase::OpaqueObjLoader::CreateList(const LoadTrace* ltrace) {
   QList* qlv2 = nullptr;
   if (config_.append) {
-    if (pv_->ObjType() != OBJ_LIST) {
-      ec_ = RdbError(errc::invalid_rdb_type);
+    if (!EnsureObjEncoding(OBJ_LIST, kEncodingQL2))
       return;
-    }
-    DCHECK_EQ(pv_->Encoding(), kEncodingQL2);
+
     qlv2 = static_cast<QList*>(pv_->RObjPtr());
   } else {
     qlv2 = CompactObj::AllocateMR<QList>(GetFlag(FLAGS_list_max_listpack_size),
@@ -664,10 +662,13 @@ void RdbLoaderBase::OpaqueObjLoader::CreateList(const LoadTrace* ltrace) {
   std::move(cleanup).Cancel();
 
   if (!config_.append) {
-    // Try to convert to listpack if it's a single-node quicklist
-    if (uint8_t* lp = qlv2->TryExtractListpack()) {
+    // Try to convert to listpack if it's a single-node quicklist, but only if there is no more data
+    // to come. In case of a chunked list, there can be a single node with more to come in future
+    // chunks.
+    // chunked=true and append=false is the first chunk (append is updated after reading object)
+    if (const auto list_ptr = config_.chunked ? nullptr : qlv2->TryExtractListpack()) {
       CompactObj::DeleteMR<QList>(qlv2);
-      pv_->InitRobj(OBJ_LIST, kEncodingListPack, lp);
+      pv_->InitRobj(OBJ_LIST, kEncodingListPack, list_ptr);
     } else {
       pv_->InitRobj(OBJ_LIST, kEncodingQL2, qlv2);
     }

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -1882,6 +1882,11 @@ void RdbSerializer::PushToConsumerIfNeeded(FlushState flush_state) {
 void MemBufController::StartEntry() {
   DCHECK_EQ(entry_buffer_owner_, 0u);
   DCHECK_EQ(entry_buffer_.InputLen(), 0u);
+
+  // Roll over to 1, id=0 is a special case
+  if (next_id_ == std::numeric_limits<EntryId>::max())
+    next_id_ = 1;
+
   active_id_ = next_id_++;
   entry_buffer_owner_ = active_id_;
   current_buffer_ = &entry_buffer_;
@@ -1950,10 +1955,19 @@ void MemBufController::RestoreStateAfterConsume(EntryId id) {
 }
 
 std::string MemBufController::BuildBlob(Bytes current_bytes) {
+  // default buffer always lies behind current bytes (entry buffer) in temporal sense, so it is
+  // built as prefix. We can never reach here where default buffer content was written _after_ entry
+  // buffer due to FinishEntry semantics.
   const bool has_prefix = current_buffer_ != &default_buffer_ && default_buffer_.InputLen() > 0;
   const auto prefix = has_prefix ? default_buffer_.InputBuffer() : Bytes{};
-  const bool should_tag = send_tagged_entries_ && active_id_ != 0 &&
-                          split_entries_.contains(active_id_) && !current_bytes.empty();
+
+  bool should_tag = send_tagged_entries_;
+
+  // tag only data entries (active id > 0) which were split at some point
+  should_tag &= active_id_ != 0 && split_entries_.contains(active_id_);
+
+  // do not tag empty bytes, it will send a useless header
+  should_tag &= !current_bytes.empty();
 
   std::string out;
   out.reserve(prefix.size() + (should_tag ? kHeaderSize : 0) + current_bytes.size());

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -215,7 +215,6 @@ uint8_t RdbObjectType(const CompactObj& pv) {
 RdbSerializer::RdbSerializer(CompressionMode compression_mode, ConsumeFun consume_fun,
                              size_t flush_threshold)
     : compression_mode_(compression_mode),
-      mem_buf_{4_KB},
       tmp_buf_(nullptr),
       consume_fun_(std::move(consume_fun)),
       flush_threshold_(flush_threshold) {
@@ -279,6 +278,9 @@ io::Result<uint8_t> RdbSerializer::SaveEntry(const PrimeKey& pk, const PrimeValu
   if (ec) {
     return make_unexpected(ec);
   }
+
+  mem_buf_controller_.StartEntry();
+  absl::Cleanup cleanup = [&] { mem_buf_controller_.FinishEntry(); };
 
   /* Save the expire time */
   if (expire_ms > 0) {
@@ -930,7 +932,7 @@ std::error_code RdbSerializer::WriteOpcode(uint8_t opcode) {
 }
 
 size_t RdbSerializer::GetBufferCapacity() const {
-  return mem_buf_.Capacity();
+  return mem_buf_controller_.GetTotalBufferCapacity();
 }
 
 size_t RdbSerializer::GetTempBufferSize() const {
@@ -938,27 +940,55 @@ size_t RdbSerializer::GetTempBufferSize() const {
 }
 
 error_code RdbSerializer::WriteRaw(const io::Bytes& buf) {
-  mem_buf_.Reserve(mem_buf_.InputLen() + buf.size());
-  IoBuf::Bytes dest = mem_buf_.AppendBuffer();
+  auto* mem_buf = mem_buf_controller_.CurrentBuffer();
+  mem_buf->Reserve(mem_buf->InputLen() + buf.size());
+  IoBuf::Bytes dest = mem_buf->AppendBuffer();
   memcpy(dest.data(), buf.data(), buf.size());
-  mem_buf_.CommitWrite(buf.size());
+  mem_buf->CommitWrite(buf.size());
   return error_code{};
 }
 
+io::Bytes RdbSerializer::PrepareFlush(FlushState flush_state) {
+  using enum CompressionMode;
+  auto* mem_buf = mem_buf_controller_.CurrentBuffer();
+  if (mem_buf_controller_.TagEntriesEnabled())
+    return mem_buf->InputBuffer();
+
+  const bool is_last_chunk = flush_state == FlushState::kFlushEndEntry;
+  const bool has_current_bytes = mem_buf->InputLen() != 0;
+  const bool is_compression_enabled =
+      compression_mode_ == MULTI_ENTRY_ZSTD || compression_mode_ == MULTI_ENTRY_LZ4;
+  VLOG(2) << "PrepareFlush: is_last_chunk" << is_last_chunk << " split=" << entry_was_split_;
+
+  // Legacy compressed blobs must contain a complete top-level RDB sequence, so only compress
+  // the current buffer when this is the only flush of an entry that never split. Otherwise, the
+  // latter half of an object might end up in its own compressed packet. The loader main loop will
+  // not be able to handle such values which begin from the middle.
+  if (is_last_chunk && !entry_was_split_ && is_compression_enabled && has_current_bytes)
+    CompressBlob();
+
+  entry_was_split_ = !is_last_chunk;
+
+  return mem_buf->InputBuffer();
+}
+
 string RdbSerializer::Flush(FlushState flush_state) {
-  auto bytes = PrepareFlush(flush_state);
-  if (bytes.empty())
+  const auto bytes = PrepareFlush(flush_state);
+  string result = mem_buf_controller_.BuildBlob(bytes);
+  if (result.empty())
     return {};
 
-  if (bytes.size() > serialization_peak_bytes_) {
-    serialization_peak_bytes_ = bytes.size();
-  }
+  // For tagged entry, compress the entire blob as a whole. Since tagged entries contain envelope
+  // with an id, the loader loop can assemble values from saved context by id, so it is possible to
+  // split a large entry across multiple chunks
+  if (mem_buf_controller_.TagEntriesEnabled())
+    if (auto res = CompressBlob(result); res)
+      result = std::move(*res);
 
-  DVLOG(2) << "FlushToSink " << bytes.size() << " bytes";
+  if (result.size() > serialization_peak_bytes_)
+    serialization_peak_bytes_ = result.size();
 
-  string result(io::View(bytes));
-
-  mem_buf_.ConsumeInput(bytes.size());
+  DVLOG(2) << "FlushToSink " << result.size() << " bytes";
 
   // After every flush we should write the DB index again because the blobs in the channel are
   // interleaved and multiple savers can correspond to a single writer (in case of single file rdb
@@ -1031,29 +1061,6 @@ string RdbSerializer::DumpValue(RdbSerializer* serializer, const PrimeValue& obj
 string RdbSerializer::DumpValue(const PrimeValue& obj, bool ignore_crc) {
   RdbSerializer serializer(GetDefaultCompressionMode());
   return DumpValue(&serializer, obj, ignore_crc);
-}
-
-size_t RdbSerializer::SerializedLen() const {
-  return mem_buf_.InputLen();
-}
-
-io::Bytes RdbSerializer::PrepareFlush(FlushState flush_state) {
-  size_t sz = mem_buf_.InputLen();
-  if (sz == 0)
-    return {};
-
-  bool is_last_chunk = flush_state == FlushState::kFlushEndEntry;
-  VLOG(2) << "PrepareFlush:" << is_last_chunk << " " << number_of_chunks_;
-  if (is_last_chunk && number_of_chunks_ == 0) {
-    if (compression_mode_ == CompressionMode::MULTI_ENTRY_ZSTD ||
-        compression_mode_ == CompressionMode::MULTI_ENTRY_LZ4) {
-      CompressBlob();
-    }
-  }
-
-  number_of_chunks_ = is_last_chunk ? 0 : (number_of_chunks_ + 1);
-
-  return mem_buf_.InputBuffer();
 }
 
 error_code RdbSerializer::WriteJournalEntry(std::string_view serialized_entry) {
@@ -1793,71 +1800,83 @@ void RdbSerializer::AllocateCompressorOnce() {
   }
 }
 
-void RdbSerializer::CompressBlob() {
-  if (!compression_stats_) {
+std::optional<std::string> RdbSerializer::CompressBlob(std::string_view input) {
+  if (compression_mode_ != CompressionMode::MULTI_ENTRY_ZSTD &&
+      compression_mode_ != CompressionMode::MULTI_ENTRY_LZ4)
+    return std::nullopt;
+
+  if (!compression_stats_)
     compression_stats_.emplace(CompressionStats{});
-  }
-  Bytes blob_to_compress = mem_buf_.InputBuffer();
-  VLOG(2) << "CompressBlob size " << blob_to_compress.size();
-  size_t blob_size = blob_to_compress.size();
+
+  VLOG(2) << "CompressBlob size " << input.size();
+  size_t blob_size = input.size();
 
   if (blob_size < kMinStrSizeToCompress || blob_size > kMaxStrSizeToCompress) {
     ++compression_stats_->size_skip_count;
-    return;
+    return std::nullopt;
   }
 
   AllocateCompressorOnce();
 
-  // Compress the data. We copy compressed data once into the internal buffer of compressor_impl_
-  // and then we copy it again into the mem_buf_.
-  //
-  // TODO: it is possible to avoid double copying here by changing the compressor interface,
-  // so that the compressor will accept the output buffer and return the final size. This requires
-  // exposing the additional compress bound interface as well.
-  io::Result<io::Bytes> res = compressor_impl_->Compress(blob_to_compress);
+  io::Result<io::Bytes> res = compressor_impl_->Compress(
+      Bytes{reinterpret_cast<const unsigned char*>(input.data()), input.size()});
   if (!res) {
     ++compression_stats_->compression_failed;
-    return;
+    return std::nullopt;
   }
 
   Bytes compressed_blob = *res;
   if (compressed_blob.length() > blob_size * kMinCompressionReductionPrecentage) {
     ++compression_stats_->compression_no_effective;
-    return;
+    return std::nullopt;
   }
 
-  // Clear membuf and write the compressed blob to it
-  mem_buf_.ConsumeInput(blob_size);
-  mem_buf_.Reserve(compressed_blob.length() + 1 + 9);  // reserve space for blob + opcode + len
+  const uint8_t opcode = compression_mode_ == CompressionMode::MULTI_ENTRY_ZSTD
+                             ? RDB_OPCODE_COMPRESSED_ZSTD_BLOB_START
+                             : RDB_OPCODE_COMPRESSED_LZ4_BLOB_START;
+  uint8_t len_buf[16];
+  const unsigned encoded_size = WritePackedUInt(compressed_blob.size(), len_buf);
 
-  // First write opcode for compressed string
-  auto dest = mem_buf_.AppendBuffer();
-  uint8_t opcode = compression_mode_ == CompressionMode::MULTI_ENTRY_ZSTD
-                       ? RDB_OPCODE_COMPRESSED_ZSTD_BLOB_START
-                       : RDB_OPCODE_COMPRESSED_LZ4_BLOB_START;
-  dest[0] = opcode;
-  mem_buf_.CommitWrite(1);
+  std::string out;
+  out.reserve(1 + encoded_size + compressed_blob.size());
+  out.push_back(static_cast<char>(opcode));
+  out.append(reinterpret_cast<const char*>(len_buf), encoded_size);
+  out.append(reinterpret_cast<const char*>(compressed_blob.data()), compressed_blob.size());
 
-  // Write encoded compressed blob len
-  dest = mem_buf_.AppendBuffer();
-  unsigned enclen = WritePackedUInt(compressed_blob.length(), dest);
-  mem_buf_.CommitWrite(enclen);
-
-  // Write compressed blob
-  dest = mem_buf_.AppendBuffer();
-  memcpy(dest.data(), compressed_blob.data(), compressed_blob.length());
-  mem_buf_.CommitWrite(compressed_blob.length());
   ++compression_stats_->compressed_blobs;
-  auto& stats = ServerState::tlocal()->stats;
-  ++stats.compressed_blobs;
+  ++ServerState::tlocal()->stats.compressed_blobs;
+  return out;
+}
+
+void RdbSerializer::CompressBlob() {
+  auto* mem_buf = mem_buf_controller_.CurrentBuffer();
+  Bytes blob = mem_buf->InputBuffer();
+  std::string_view input{reinterpret_cast<const char*>(blob.data()), blob.size()};
+  auto compressed = CompressBlob(input);
+  if (!compressed)
+    return;
+
+  mem_buf->ConsumeInput(blob.size());
+  mem_buf->Reserve(compressed->size());
+  auto dest = mem_buf->AppendBuffer();
+  memcpy(dest.data(), compressed->data(), compressed->size());
+  mem_buf->CommitWrite(compressed->size());
 }
 
 void RdbSerializer::PushToConsumerIfNeeded(FlushState flush_state) {
-  if (consume_fun_ && SerializedLen() > flush_threshold_) {
-    string blob = Flush(flush_state);
-    DCHECK(!blob.empty());  // SerializedLen() > 0.
-    consume_fun_(std::move(blob));
-  }
+  if (!consume_fun_ || SerializedLen() <= flush_threshold_)
+    return;
+
+  if (flush_state == FlushState::kFlushMidEntry)
+    mem_buf_controller_.MarkEntrySplit();
+
+  string blob = Flush(flush_state);
+  DCHECK(!blob.empty());
+
+  // save and restore id around preempt point consume_fun_
+  const auto id = mem_buf_controller_.SaveStateBeforeConsume();
+  consume_fun_(std::move(blob));
+  mem_buf_controller_.RestoreStateAfterConsume(id);
 }
 
 void MemBufController::StartEntry() {

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -129,13 +129,21 @@ class MemBufController {
   // 1. Prepends any data in the default buffer (from previously finished entries) as a prefix.
   // 2. If the active entry was split, a tag header is inserted before current_bytes.
   // 3. current_bytes is added.
-  // 3. Consumes all buffers used.
+  // 4. Consumes all buffers used.
   // current_bytes is typically CurrentBuffer()->InputBuffer(), passed explicitly because it works
   // on data returned by PrepareFlush.
   [[nodiscard]] std::string BuildBlob(io::Bytes current_bytes);
 
   void SetTagEntries(bool tag_entries) {
     send_tagged_entries_ = tag_entries;
+  }
+
+  bool TagEntriesEnabled() const {
+    return send_tagged_entries_;
+  }
+
+  size_t GetTotalBufferCapacity() const {
+    return default_buffer_.Capacity() + entry_buffer_.Capacity();
   }
 
  private:
@@ -258,7 +266,9 @@ class RdbSerializer {
                                bool ignore_crc = false);
 
   // Internal buffer size. Might shrink after flush due to compression.
-  size_t SerializedLen() const;
+  size_t SerializedLen() const {
+    return mem_buf_controller_.FlushableSize();
+  }
 
   // Flush internal buffer and return serialized blob.
   std::string Flush(FlushState flush_state);
@@ -313,13 +323,20 @@ class RdbSerializer {
 
   std::error_code SendEofAndChecksum();
 
+  // When enabled, entries that get flushed mid-serialization are wrapped in tagged chunk
+  // envelopes so that the loader can reassemble them.
+  void SetTagEntries(bool tag_entries) {
+    mem_buf_controller_.SetTagEntries(tag_entries);
+  }
+
  private:
   // Prepare internal buffer for flush. Compress it.
   io::Bytes PrepareFlush(FlushState flush_state);
 
-  // If membuf data is compressable use compression impl to compress the data and write it to membuf
   void CompressBlob();
   void AllocateCompressorOnce();
+
+  std::optional<std::string> CompressBlob(std::string_view input);
 
   std::error_code SaveLzfBlob(const ::io::Bytes& src, size_t uncompressed_len);
 
@@ -355,18 +372,23 @@ class RdbSerializer {
   };
 
   CompressionMode compression_mode_;
-  io::IoBuf mem_buf_;
   std::unique_ptr<detail::CompressorImpl> compressor_impl_;
   std::optional<CompressionStats> compression_stats_;
   base::PODArray<uint8_t> tmp_buf_;
   std::unique_ptr<LZF_HSLOT[]> lzf_;
-  size_t number_of_chunks_ = 0;
+
+  // Whether current entry has ever been flushed mid-serialization. Only read on legacy non tagged
+  // code path.
+  bool entry_was_split_ = false;
+
   uint64_t serialization_peak_bytes_ = 0;
 
   std::string tmp_str_;
   DbIndex last_entry_db_index_ = kInvalidDbId;
   ConsumeFun consume_fun_;
   size_t flush_threshold_ = 0;
+
+  MemBufController mem_buf_controller_;
 };
 
 }  // namespace dfly

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -153,6 +153,7 @@ class MemBufController {
   bool send_tagged_entries_ = false;
 
   EntryId next_id_ = 1;
+  // id for current entry: non zero for data entries. 0 for non data entries, eg journal items
   EntryId active_id_ = 0;
 
   io::IoBuf default_buffer_{4096};

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -1466,7 +1466,8 @@ struct InterleaveHarness {
 
   // Each invocation appends the supplied blob to the body, then injects a SaveEntry for the next
   // queued key (sandwiched between a journal offset and a journal entry) to force interleaved
-  // tagged chunks.
+  // tagged chunks. Passed to serializer as consume_fun_, so the blob is the flushed data
+  // accumulated in serializer.
   void operator()(std::string blob) {
     body += blob;
     if (next >= queued.size())
@@ -1477,6 +1478,11 @@ struct InterleaveHarness {
     ASSERT_FALSE(serializer->SendJournalOffset(offset));
 
     const auto& entry = queued[next++];
+    // SaveEntry calls get preempted (not by fiber but call stack) every time consume_fun_ is
+    // called. So the call stack looks like: SaveEntry(A) -> consume_fun_ -> SaveEntry(B) ->
+    // consume_fun_ -> ... The last entry in queue (next == queued size) does not add anything, it
+    // simply returns until the entry is completed. From that point on all entries simply flush
+    // repeatedly until completed, moving down the stack.
     ASSERT_TRUE(serializer->SaveEntry(PrimeKey{entry.key}, *entry.value, 0, 0, 0).has_value());
 
     io::StringSink sink;
@@ -1491,28 +1497,6 @@ struct InterleaveHarness {
 // The following are tests that directly feed byte data to loader to exercise chunk loading.
 // Some of these will become redundant once the saver starts sending chunked data, so instead of
 // hand-crafting data we will be able to load from the db directly.
-
-TEST_F(RdbTest, LoadTwoChunks) {
-  std::string first;
-  first.push_back(RDB_TYPE_HASH);
-  AppendString(&first, "h");
-  AppendLen(&first, 2);
-  AddKV(&first, "f1", "v1");
-
-  std::string second;
-  AddKV(&second, "f2", "v2");
-
-  std::string body;
-  // hash is split across two tagged chunks
-  body += MakeTaggedChunk(1, first);
-  body += MakeTaggedChunk(1, second);
-
-  const auto ec = pp_->at(0)->Await([&] { return LoadRdbData(service_.get(), WrapInRdb(body)); });
-  ASSERT_FALSE(ec) << ec.message();
-
-  EXPECT_EQ(Run({"HGET", "h", "f1"}), "v1");
-  EXPECT_EQ(Run({"HGET", "h", "f2"}), "v2");
-}
 
 TEST_F(RdbTest, InterleavedLoad) {
   // must have >1 shards for non inlined path check. find a key that lands in shard 1 by hashing, to
@@ -1565,34 +1549,6 @@ TEST_F(RdbTest, InterleavedLoad) {
   EXPECT_EQ(Run({"SELECT", "1"}), "OK");
   EXPECT_THAT(Run({"EXISTS", key}), IntArg(0));
   EXPECT_EQ(Run({"SELECT", "0"}), "OK");
-}
-
-TEST_F(RdbTest, ChunksAroundJournalOffset) {
-  std::string a1;
-  a1.push_back(RDB_TYPE_HASH);
-  AppendString(&a1, "a");
-  AppendLen(&a1, 2);
-  AddKV(&a1, "f1", "v1");
-
-  std::string a2;
-  AddKV(&a2, "f2", "v2");
-
-  std::string body;
-  body += MakeTaggedChunk(1, a1);
-
-  // put the journal offset in the middle
-  body.push_back(static_cast<char>(RDB_OPCODE_JOURNAL_OFFSET));
-  uint8_t offset_bytes[8];
-  absl::little_endian::Store64(offset_bytes, 1234);
-  body.append(reinterpret_cast<const char*>(offset_bytes), sizeof(offset_bytes));
-
-  body += MakeTaggedChunk(1, a2);
-
-  auto ec = pp_->at(0)->Await([&] { return LoadRdbData(service_.get(), WrapInRdb(body), 1234); });
-  ASSERT_FALSE(ec) << ec.message();
-
-  EXPECT_EQ(Run({"HGET", "a", "f1"}), "v1");
-  EXPECT_EQ(Run({"HGET", "a", "f2"}), "v2");
 }
 
 TEST_F(RdbTest, SplitSBF) {
@@ -1699,26 +1655,27 @@ TEST_F(RdbTest, TaggedInterleavedRoundTrip) {
   SetTestFlag("serialization_tagged_chunks", "true");
   ResetService();
 
+  // create hset named key, then fill it with count fields each with 128 char long string
   auto fill_hash = [&](std::string_view key, int count, char ch) {
     for (int i = 0; i < count; ++i) {
-      EXPECT_THAT(Run({"HSET", std::string{key}, StrCat("field:", i), std::string(128, ch)}),
-                  IntArg(1));
+      auto res = Run({"HSET", key, StrCat("field:", i), std::string(128, ch)});
+      EXPECT_THAT(res, IntArg(1));
     }
   };
 
-  // Larger keys force a mid-entry flush; smaller keys finish in a single chunk. Mixing both
-  // shapes ensures the harness sees both split and unsplit entries.
-  auto get_key_size = [](std::string s) {
+  // Some hashes have many more fields to make them flush mid-entry during serialization
+  auto num_fields_in_hash_set = [](std::string s) {
     if ((s[0] - 'A') % 3 == 2)
       return 4;
     return 200;
   };
 
+  // note: going to Z causes stack size issues because of the recursive nature of the harness
   constexpr auto from = 'A';
   constexpr auto to = 'F';
   for (auto ch = from; ch <= to; ++ch) {
     std::string s{ch};
-    fill_hash(s, get_key_size(s), ch);
+    fill_hash(s, num_fields_in_hash_set(s), ch);
   }
 
   std::string body;
@@ -1768,7 +1725,7 @@ TEST_F(RdbTest, TaggedInterleavedRoundTrip) {
 
   for (auto ch = from; ch <= to; ++ch) {
     std::string s{ch};
-    verify_hash(s, get_key_size(s), ch);
+    verify_hash(s, num_fields_in_hash_set(s), ch);
   }
 }
 

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -19,6 +19,8 @@ extern "C" {
 #include "facade/facade_test.h"  // needed to find operator== for RespExpr.
 #include "io/file.h"
 #include "server/engine_shard_set.h"
+#include "server/journal/serializer.h"
+#include "server/journal/types.h"
 #include "server/rdb_extensions.h"
 #include "server/rdb_load.h"
 #include "server/rdb_save.h"
@@ -1441,6 +1443,49 @@ void AppendBinaryDouble(std::string* out, double val) {
   out->append(reinterpret_cast<const char*>(buf), sizeof(buf));
 }
 
+// Drives interleaving SaveEntry calls from the serializer's consume callback to exercise
+// tagged-chunk framing when a serialization is preempted mid-entry.
+struct InterleaveHarness {
+  struct Pending {
+    std::string key;
+    const PrimeValue* value;
+  };
+
+  std::vector<Pending> queued;
+  size_t next = 0;
+  std::string body;
+  RdbSerializer* serializer = nullptr;
+  std::optional<uint64_t> last_journal_offset;
+
+  void AddKey(std::string_view key, DbContext& ctx) {
+    auto& db = ctx.GetDbSlice(0);
+    auto it = db.FindReadOnly(ctx, key, OBJ_HASH);
+    ASSERT_TRUE(it.ok());
+    queued.push_back(Pending{std::string{key}, &it.value()->second});
+  }
+
+  // Each invocation appends the supplied blob to the body, then injects a SaveEntry for the next
+  // queued key (sandwiched between a journal offset and a journal entry) to force interleaved
+  // tagged chunks.
+  void operator()(std::string blob) {
+    body += blob;
+    if (next >= queued.size())
+      return;
+
+    uint64_t offset = last_journal_offset.value_or(0) + 100;
+    last_journal_offset = offset;
+    ASSERT_FALSE(serializer->SendJournalOffset(offset));
+
+    const auto& entry = queued[next++];
+    ASSERT_TRUE(serializer->SaveEntry(PrimeKey{entry.key}, *entry.value, 0, 0, 0).has_value());
+
+    io::StringSink sink;
+    JournalWriter writer(&sink);
+    writer.Write(journal::Entry{journal::Op::PING, 0, std::nullopt});
+    ASSERT_FALSE(serializer->WriteJournalEntry(std::move(sink).str()));
+  }
+};
+
 }  // namespace
 
 // The following are tests that directly feed byte data to loader to exercise chunk loading.
@@ -1644,6 +1689,86 @@ TEST_F(RdbTest, SplitSBF) {
 
   for (size_t i = 0; i < 50; ++i) {
     EXPECT_THAT(Run({"BF.EXISTS", "bf_loaded", StrCat("item", i)}), IntArg(1));
+  }
+}
+
+TEST_F(RdbTest, TaggedInterleavedRoundTrip) {
+  absl::FlagSaver fs;
+  SetTestFlag("cache_mode", "false");
+  SetTestFlag("num_shards", "1");
+  SetTestFlag("serialization_tagged_chunks", "true");
+  ResetService();
+
+  auto fill_hash = [&](std::string_view key, int count, char ch) {
+    for (int i = 0; i < count; ++i) {
+      EXPECT_THAT(Run({"HSET", std::string{key}, StrCat("field:", i), std::string(128, ch)}),
+                  IntArg(1));
+    }
+  };
+
+  // Larger keys force a mid-entry flush; smaller keys finish in a single chunk. Mixing both
+  // shapes ensures the harness sees both split and unsplit entries.
+  auto get_key_size = [](std::string s) {
+    if ((s[0] - 'A') % 3 == 2)
+      return 4;
+    return 200;
+  };
+
+  constexpr auto from = 'A';
+  constexpr auto to = 'F';
+  for (auto ch = from; ch <= to; ++ch) {
+    std::string s{ch};
+    fill_hash(s, get_key_size(s), ch);
+  }
+
+  std::string body;
+  std::optional<uint64_t> last_journal_offset;
+
+  pp_->at(0)->Await([&] {
+    DbContext ctx{&namespaces->GetDefaultNamespace(), 0, GetCurrentTimeMs()};
+
+    InterleaveHarness harness;
+    // Queue up B..F to be injected when A yields mid-SaveEntry through PushToConsumerIfNeeded.
+    for (auto ch = 'B'; ch <= to; ++ch) {
+      std::string s{ch};
+      harness.AddKey(s, ctx);
+    }
+
+    RdbSerializer serializer(
+        CompressionMode::NONE, [&](std::string blob) { harness(std::move(blob)); }, 256);
+
+    harness.serializer = &serializer;
+    serializer.SetTagEntries(true);
+
+    auto& db = ctx.GetDbSlice(0);
+    auto it = db.FindReadOnly(ctx, "A", OBJ_HASH);
+    ASSERT_TRUE(it.ok());
+
+    ASSERT_TRUE(serializer.SaveEntry(PrimeKey{"A"}, it.value()->second, 0, 0, 0).has_value());
+
+    if (auto tail = serializer.Flush(RdbSerializer::FlushState::kFlushEndEntry); !tail.empty())
+      harness.body += tail;
+
+    body = std::move(harness.body);
+    last_journal_offset = harness.last_journal_offset;
+  });
+
+  EXPECT_EQ(Run({"FLUSHALL"}), "OK");
+
+  auto ec = pp_->at(0)->Await(
+      [&] { return LoadRdbData(service_.get(), WrapInRdb(body), last_journal_offset); });
+  ASSERT_FALSE(ec) << ec.message();
+
+  auto verify_hash = [&](std::string_view key, int count, char ch) {
+    EXPECT_EQ(CheckedInt({"HLEN", std::string{key}}), count);
+    for (int i = 0; i < count; ++i) {
+      EXPECT_EQ(Run({"HGET", std::string{key}, StrCat("field:", i)}), std::string(128, ch));
+    }
+  };
+
+  for (auto ch = from; ch <= to; ++ch) {
+    std::string s{ch};
+    verify_hash(s, get_key_size(s), ch);
   }
 }
 

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -22,11 +22,12 @@
 #include "server/search/serialization_utils.h"
 #include "server/server_state.h"
 #include "server/tiered_storage.h"
-#include "util/fibers/stacktrace.h"
 #include "util/fibers/synchronization.h"
 
 ABSL_FLAG(bool, background_snapshotting, false, "Whether to run snapshot as a background fiber");
 ABSL_FLAG(bool, serialize_hnsw_index, false, "Serialize HNSW vector index graph structure");
+ABSL_FLAG(bool, serialization_tagged_chunks, false,
+          "Allow serializer output to be split into tagged chunks and reassembled by receiver");
 
 namespace dfly {
 
@@ -101,6 +102,10 @@ void SliceSnapshot::Start(bool stream_journal, SnapshotFlush allow_flush) {
                          replica_dfly_version_ >= DflyVersion::VER6;
 
   serializer_ = std::make_unique<RdbSerializer>(compression_mode_, consume_fun, flush_threshold);
+
+  if (allow_flush == SnapshotFlush::kAllow) {
+    serializer_->SetTagEntries(absl::GetFlag(FLAGS_serialization_tagged_chunks));
+  }
 
   VLOG(1) << "DbSaver::Start - saving entries with version less than " << snapshot_version_;
 

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -1,20 +1,20 @@
 import dataclasses
+import logging
 import os
+import random
+import re
+import signal
+import subprocess
 import threading
 import time
-import subprocess
-import random
-import aiohttp
-import logging
 from dataclasses import dataclass
 from typing import Dict, Optional, List, Union
-import re
+
+import aiohttp
 import psutil
-import itertools
 from prometheus_client.parser import text_string_to_metric_families
 from redis.asyncio import Redis as RedisClient
 from redis.asyncio import RedisCluster as RedisCluster
-import signal
 
 START_DELAY = 0.8
 START_GDB_DELAY = 5.0
@@ -443,6 +443,10 @@ class DflyInstanceFactory:
 
         if version >= 1.21 and "serialization_max_chunk_size" not in args:
             args.setdefault("serialization_max_chunk_size", 300000)
+
+        # TODO (abhijat) fix version once feature released
+        if version == 100 and "serialization_tagged_chunks" not in args:
+            args.setdefault("serialization_tagged_chunks", True)
 
         if version > 1.36:
             args.setdefault("serialize_hnsw_index", "true")

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -1,24 +1,30 @@
-import pytest
+import asyncio
+import glob
 import logging
 import os
-import glob
-import asyncio
-from async_timeout import timeout
-import redis
-from redis import asyncio as aioredis
 from pathlib import Path
+
+import async_timeout
 import boto3
+import pytest
+import redis
+from async_timeout import timeout
 from azure.storage.blob import BlobServiceClient
-from .instance import DflyInstanceFactory, RedisServer
-from random import randint as rand
-import string
-import random
 from pymemcache.client.base import Client as MCClient
+from redis import asyncio as aioredis
 
 from . import dfly_args
-from .utility import assert_eventually, wait_available_async, is_saving, tmp_file_name
-
-from .seeder import DebugPopulateSeeder
+from .instance import DflyInstanceFactory, RedisServer
+from .replication_test import compare_datasets
+from .seeder import DebugPopulateSeeder, Seeder
+from .utility import (
+    assert_eventually,
+    wait_available_async,
+    is_saving,
+    tmp_file_name,
+    wait_for_replicas_state,
+    check_all_replicas_finished,
+)
 
 BASIC_ARGS = {"dir": "{DRAGONFLY_TMP}/", "proactor_threads": 4}
 FILE_FORMATS = ["RDB", "DF"]
@@ -1021,3 +1027,68 @@ async def test_mc_flags_saving(memcached_client: MCClient, async_client: aioredi
 
     await check_flag("key1", 2)
     await check_flag("key2", 123456)
+
+
+@pytest.mark.parametrize("compression_mode", ["NONE", "MULTI_ENTRY_LZ4", "MULTI_ENTRY_ZSTD"])
+async def test_tagged_chunk_reload(df_factory, compression_mode: str):
+    instance = df_factory.create(
+        dbfilename=f"dump_{tmp_file_name()}",
+        serialization_tagged_chunks=True,
+        compression_mode=compression_mode,
+        proactor_threads=4,
+        serialization_max_chunk_size=4096,
+    )
+    instance.start()
+    cl = instance.client()
+
+    await DebugPopulateSeeder(key_target=5000, data_size=2000, variance=20, samples=20).run(cl)
+    start_capture = await DebugPopulateSeeder.capture(cl)
+    await cl.execute_command("DEBUG", "RELOAD")
+    preempts = (await cl.info())["big_value_preemptions"]
+    assert preempts > 10
+    res = await DebugPopulateSeeder.capture(cl)
+    assert res == start_capture
+
+
+@pytest.mark.parametrize("compression_mode", ["NONE", "MULTI_ENTRY_LZ4", "MULTI_ENTRY_ZSTD"])
+async def test_tagged_chunk_replication(df_factory, compression_mode: str):
+    master = df_factory.create(
+        proactor_threads=4,
+        serialization_tagged_chunks=True,
+        compression_mode=compression_mode,
+        serialization_max_chunk_size=4096,
+    )
+
+    replica = df_factory.create(proactor_threads=2)
+    df_factory.start_all([master, replica])
+
+    cm = master.client()
+    cr = replica.client()
+
+    seeder = Seeder(
+        key_target=3000,
+        data_size=200,
+        huge_value_size=20000,
+        huge_value_target=50,
+    )
+
+    await seeder.run(cm, target_deviation=0.1)
+
+    stream_task = asyncio.create_task(seeder.run(cm))
+    await asyncio.sleep(0.0)
+
+    await cr.execute_command(f"REPLICAOF localhost {master.port}")
+    async with async_timeout.timeout(120):
+        await wait_for_replicas_state(cr)
+
+    await seeder.stop(cm)
+    await stream_task
+
+    preempts = (await cm.info())["big_value_preemptions"]
+    assert preempts > 0
+
+    await check_all_replicas_finished([cr], cm)
+    hashes = await asyncio.gather(Seeder.capture(cm), Seeder.capture(cr))
+    if hashes[0] != hashes[1]:
+        await compare_datasets(cm, cr)
+        assert False, "replica does not match master after full sync"


### PR DESCRIPTION
Enables tagged-chunk writes in serializer, so that `SaveEntry` calls can be freely mixed and yield together mid entry etc with journal writes and other types of writes interleaved, by using mem buffer controller to safely store data. 

  - Adds tagged-chunk emission to `RdbSerializer` using the recently introduced `MemBufController`.
  - Splits serializer buffering into a default buffer and an entry buffer. An "entry" is the top-level payload written by `SaveEntry`, for example a key, its metadata, and value data.
  - Preserves existing non-tagged behavior when `serialization_tagged_chunks` is disabled (default behavior).
  - Enables tagged chunks in Python tests by default to exercise the new path more broadly.
  - Adds integration coverage for reload and replication with tagged chunks and different compression modes.

  Buffering Model:

  `MemBufController` manages which buffer the serializer writes to:

  - Non-entry data is written to the default buffer.
  - Entry data is written to the entry buffer.
  - If an entry finishes without being flushed, remaining entry-buffer bytes are drained back into the default buffer.
  - On flush, default-buffer data is always emitted before entry-buffer data, which preserves serialization order.
  - If an entry was split across flushes, entry-buffer bytes are wrapped in a tagged envelope. Un-split entries are emitted without tagging.
  - After a flush, emitted input bytes are consumed from both buffers.

  This lets a large entry be split safely while still preserving the stream order needed by the loader.

  Preemption / Interleaving:

  `consume_fun_` is a preemption point: another snapshot fiber may run before the current fiber resumes. Before calling it, the serializer saves the active entry state. It restores that state on returning.

  A resumed fiber never has to merge with stale entry-buffer data. Any other fiber that ran meanwhile either flushed and consumed its buffers, or completed entries and drained their entry data into the default buffer. Therefore restoring only needs to restore the active entry id used for the next tagged envelope.

  Compression:

  In non-tagged mode, existing behavior is preserved: only an entry emitted as a single, unsplit chunk may be compressed. This avoids producing compressed blobs that start in the middle of a top-level RDB object, which the legacy loader loop cannot handle.

  In tagged mode, chunks can be compressed more freely. The loader can preserve state between tagged chunks, so a key-value entry may be split across multiple chunks and still be reconstructed correctly.

  A new `CompressBlob(std::string_view)` helper compresses input bytes instead of only the serializer’s current buffer. `Flush()` first builds the combined `MemBufController` output and then compresses using the new helper.