### PR TITLE
fix(ci): correct docker health check condition

### DIFF
--- a/.github/actions/test-docker/action.yml
+++ b/.github/actions/test-docker/action.yml
@@ -20,6 +20,6 @@ runs:
 
         # docker run with port-forwarding
         docker run  --name test -d -p 6379:6379 ${{inputs.image_id}}
-        until [ "`docker inspect -f {{.State.Health.Status}} test`"=="healthy" ]; do
+        until [ "$(docker inspect -f '{{.State.Health.Status}}' test)" = "healthy" ]; do
           sleep 0.1;
         done;


### PR DESCRIPTION
## Summary
- fix the Docker test action's health-check loop so it actually waits for `healthy`

## Why
The shell test in `.github/actions/test-docker/action.yml` was malformed, so the loop succeeded immediately instead of comparing the container health status.

## Validation
- `bash -lc 'status=starting; if [ "$status"=="healthy" ]; then echo malformed:true; else echo malformed:false; fi; if [ "$status" = "healthy" ]; then echo fixed:true; else echo fixed:false; fi'`
- `pre-commit run --files .github/actions/test-docker/action.yml`
