### PR TITLE
feat(facade): add per-protocol IoLoopV2 flags for Memcache and RESP

### DIFF
--- a/docs/pub-sub.md
+++ b/docs/pub-sub.md
@@ -248,7 +248,7 @@ I/O loop implementations, selected at connection setup time:
 | Loop | Flag / Condition | Protocols | Architecture |
 |------|-----------------|-----------|--------------|
 | **v1** (`IoLoop` + `AsyncFiber`) | Default for Redis, TLS | Redis (RESP), TLS connections | Two-fiber: blocking recv loop (producer) + `AsyncFiber` (consumer) |
-| **v2** (`IoLoopV2`) | `--experimental_io_loop_v2` (default: true), non-TLS Memcache only | Memcache | Single-fiber: event-driven via `RegisterOnRecv`, dispatch queue drained inline |
+| **v2** (`IoLoopV2`) | `--enable_memcache_io_loop_v2` (default: true) for Memcache; `--enable_resp_io_loop_v2` (default: false) for RESP | Memcache (and optionally RESP) | Single-fiber: event-driven via `RegisterOnRecv`, dispatch queue drained inline |
 
 ### v1: `IoLoop` + `AsyncFiber` (Redis connections)
 
@@ -276,7 +276,7 @@ starving the Data Path: after processing `async_dispatch_quota` dispatch queue i
 interleaving pipeline work, the fiber yields to let `IoLoop` parse pending socket data, then
 switches to pipeline processing.
 
-### v2: `IoLoopV2` (Memcache connections)
+### v2: `IoLoopV2` (Memcache and optional RESP connections)
 
 `IoLoopV2` is an event-driven, single-fiber loop that uses `socket->RegisterOnRecv()`
 instead of blocking on `recv()`. There is no separate `AsyncFiber` — the dispatch queue is
@@ -285,9 +285,9 @@ the same `AsyncOperations` handler as v1. Key differences: no `async_dispatch_qu
 interleaving, no pipeline squashing, and backpressure uses `notifyAll()` instead of
 per-publisher `notify()`.
 
-> **Note**: `IoLoopV2` is currently enabled only for non-TLS Memcache connections
-> (`--experimental_io_loop_v2`, default: true). Since Pub/Sub is a Redis-only feature,
-> **all Pub/Sub traffic flows through the v1 `AsyncFiber` path**.
+> **Note**: By default, Pub/Sub traffic flows through the v1 `AsyncFiber` path because
+> `--enable_resp_io_loop_v2` defaults to `false`. When `--enable_resp_io_loop_v2` is
+> enabled, non-TLS RESP connections (including Pub/Sub subscribers) use `IoLoopV2` instead.
 
 ### PubMessage Processing (shared by v1 and v2)
 

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -126,7 +126,10 @@ ABSL_FLAG(uint32_t, pipeline_wait_batch_usec, 0,
           "If non-zero, waits for this time for more I/O "
           " events to come for the connection in case there is only one command in the pipeline. ");
 
-ABSL_FLAG(bool, experimental_io_loop_v2, true, "new io loop");
+ABSL_FLAG(bool, enable_memcache_io_loop_v2, true,
+          "Enable the event-driven IoLoopV2 for non-TLS Memcache connections.");
+ABSL_FLAG(bool, enable_resp_io_loop_v2, false,
+          "Enable the event-driven IoLoopV2 for non-TLS RESP connections.");
 
 using namespace util;
 using namespace std;
@@ -964,9 +967,10 @@ void Connection::HandleRequests() {
       // this connection.
       http_conn.ReleaseSocket();
     } else {  // non-http
-      // ioloop_v2 not supported for TLS & redis connections yet.
       ioloop_v2_ =
-          GetFlag(FLAGS_experimental_io_loop_v2) && !is_tls_ && protocol_ == Protocol::MEMCACHE;
+          !is_tls_ &&
+          ((protocol_ == Protocol::MEMCACHE && GetFlag(FLAGS_enable_memcache_io_loop_v2)) ||
+           (protocol_ == Protocol::REDIS && GetFlag(FLAGS_enable_resp_io_loop_v2)));
 
       socket_->RegisterOnErrorCb([this](int32_t mask) { this->OnBreakCb(mask); });
       switch (protocol_) {

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -24,16 +24,16 @@ from .utility import tick_timer, assert_eventually
 BASE_PORT = 1111
 
 
-def is_io_loop_v2(server: DflyInstance) -> bool:
-    """Check if the server is running with experimental_io_loop_v2 enabled.
+def is_resp_io_loop_v2(server: DflyInstance) -> bool:
+    """Check if the server is running with enable_resp_io_loop_v2 enabled.
 
-    When the flag is passed as a bare flag (--experimental_io_loop_v2), the test runner
+    When the flag is passed as a bare flag (--enable_resp_io_loop_v2), the test runner
     stores its value as None instead of "true". This function checks both has_arg() and
     != "false" to correctly detect V2 while safely defaulting to V1 otherwise.
     """
     return (
-        server.has_arg("experimental_io_loop_v2")
-        and server.args.get("experimental_io_loop_v2") != "false"
+        server.has_arg("enable_resp_io_loop_v2")
+        and server.args.get("enable_resp_io_loop_v2") != "false"
     )
 
 
@@ -663,8 +663,8 @@ async def test_keyspace_events_config_set(async_client: aioredis.Redis):
 
 
 @dfly_multi_test_args(
-    {"max_busy_read_usec": 50000, "experimental_io_loop_v2": "false"},
-    {"max_busy_read_usec": 50000, "experimental_io_loop_v2": "true"},
+    {"max_busy_read_usec": 50000, "enable_resp_io_loop_v2": "false"},
+    {"max_busy_read_usec": 50000, "enable_resp_io_loop_v2": "true"},
 )
 async def test_reply_count(df_server: DflyInstance):
     """Make sure reply aggregations reduce reply counts for common cases"""
@@ -708,7 +708,7 @@ async def test_reply_count(df_server: DflyInstance):
     # MULTI-OK + the EXEC array.
     # V1 (dual-fiber) is aggressive (<=2).
     # V2 (single-fiber): MULTI/OK may flush separately before the EXEC batch (<=3).
-    is_v2 = is_io_loop_v2(df_server)
+    is_v2 = is_resp_io_loop_v2(df_server)
     multi_limit = 3 if is_v2 else 2
     assert await measure(e.execute()) <= multi_limit
 
@@ -736,7 +736,7 @@ async def test_reply_count(df_server: DflyInstance):
     assert await measure(async_client.ft("i1").search("*")) <= 2
 
 
-@dfly_args({"experimental_io_loop_v2": "true"})
+@dfly_args({"enable_resp_io_loop_v2": "true"})
 async def test_v2_conditional_flush_no_stall(df_server: DflyInstance):
     """Verify that V2 conditional flushing never stalls client replies.
 
@@ -907,8 +907,8 @@ async def test_parser_while_script_running(async_client: aioredis.Redis, df_serv
 
 
 @dfly_multi_test_args(
-    {"proactor_threads": "4", "pipeline_squash": 0, "experimental_io_loop_v2": "false"},
-    {"proactor_threads": "4", "pipeline_squash": 0, "experimental_io_loop_v2": "true"},
+    {"proactor_threads": "4", "pipeline_squash": 0, "enable_resp_io_loop_v2": "false"},
+    {"proactor_threads": "4", "pipeline_squash": 0, "enable_resp_io_loop_v2": "true"},
 )
 async def test_pipeline_batching_while_migrating(
     async_client: aioredis.Redis, df_server: DflyInstance
@@ -1342,14 +1342,14 @@ async def test_send_timeout(df_server, async_client: aioredis.Redis):
         "proactor_threads": 1,
         "pipeline_squash": 9,
         "max_busy_read_usec": 50000,
-        "experimental_io_loop_v2": "false",
+        "enable_resp_io_loop_v2": "false",
     }
 )
 async def test_pipeline_cache_only_async_squashed_dispatches(df_factory):
     server = df_factory.create()
     server.start()
 
-    if is_io_loop_v2(server):
+    if is_resp_io_loop_v2(server):
         pytest.skip("V2 does not use SquashPipeline; cache lifecycle differs")
 
     client = server.client()
@@ -1431,13 +1431,13 @@ async def test_pipeline_cache_size(df_server: DflyInstance):
         "proactor_threads": 4,
         "pipeline_queue_limit": 10,
         "pipeline_buffer_limit": "1024",
-        "experimental_io_loop_v2": "false",
+        "enable_resp_io_loop_v2": "false",
     },
     {
         "proactor_threads": 4,
         "pipeline_queue_limit": 10,
         "pipeline_buffer_limit": "1024",
-        "experimental_io_loop_v2": "true",
+        "enable_resp_io_loop_v2": "true",
     },
 )
 async def test_pipeline_overlimit(df_factory: DflyInstanceFactory):
@@ -1479,7 +1479,7 @@ async def test_pipeline_overlimit(df_factory: DflyInstanceFactory):
     # V2's self-regulating ParseLoop (parse→execute→reply) drains the queue each iteration,
     # so the throttle counter may not fire even though backpressure is applied internally.
     info = await client.info("stats")
-    is_v2 = server.args.get("experimental_io_loop_v2") == "true"
+    is_v2 = server.args.get("enable_resp_io_loop_v2") == "true"
     if not is_v2:
         assert int(info["pipeline_throttle_total"]) > 0, "Expected pipeline_throttle_total > 0"
 
@@ -1496,7 +1496,7 @@ async def test_pipeline_overlimit(df_factory: DflyInstanceFactory):
         "proactor_threads": 4,
         "pipeline_queue_limit": 10,
         "pipeline_buffer_limit": "1024",
-        "experimental_io_loop_v2": "true",
+        "enable_resp_io_loop_v2": "true",
     }
 )
 async def test_pipeline_backpressure_v2_correctness(df_server: DflyInstance):
@@ -1530,13 +1530,13 @@ async def test_pipeline_backpressure_v2_correctness(df_server: DflyInstance):
         "proactor_threads": 4,
         "pipeline_queue_limit": 10,
         "pipeline_buffer_limit": "1024",
-        "experimental_io_loop_v2": "false",
+        "enable_resp_io_loop_v2": "false",
     },
     {
         "proactor_threads": 4,
         "pipeline_queue_limit": 10,
         "pipeline_buffer_limit": "1024",
-        "experimental_io_loop_v2": "true",
+        "enable_resp_io_loop_v2": "true",
     },
 )
 async def test_pipeline_backpressure_disconnect(df_factory: DflyInstanceFactory):
@@ -1576,7 +1576,7 @@ async def test_pipeline_backpressure_disconnect(df_factory: DflyInstanceFactory)
     # V1 increments pipeline_throttle_total reliably because DispatchSingle parks the fiber.
     # V2's self-regulating ParseLoop drains the queue each iteration, so the counter may not fire.
     info = await client.info("stats")
-    is_v2 = server.args.get("experimental_io_loop_v2") == "true"
+    is_v2 = server.args.get("enable_resp_io_loop_v2") == "true"
     if not is_v2:
         assert int(info["pipeline_throttle_total"]) > 0, "Expected pipeline_throttle_total > 0"
 
@@ -1700,8 +1700,8 @@ async def test_tls_client_kill_preemption(
 
 
 @dfly_multi_test_args(
-    {"proactor_threads": 4, "experimental_io_loop_v2": "false"},
-    {"proactor_threads": 4, "experimental_io_loop_v2": "true"},
+    {"proactor_threads": 4, "enable_resp_io_loop_v2": "false"},
+    {"proactor_threads": 4, "enable_resp_io_loop_v2": "true"},
 )
 async def test_client_migrate(df_server: DflyInstance):
     """
@@ -1724,8 +1724,8 @@ async def test_client_migrate(df_server: DflyInstance):
 
 
 @dfly_multi_test_args(
-    {"proactor_threads": 4, "experimental_io_loop_v2": "false"},
-    {"proactor_threads": 4, "experimental_io_loop_v2": "true"},
+    {"proactor_threads": 4, "enable_resp_io_loop_v2": "false"},
+    {"proactor_threads": 4, "enable_resp_io_loop_v2": "true"},
 )
 async def test_client_migrate_no_conn_leak(df_server: DflyInstance):
     admin = df_server.client()
@@ -1774,13 +1774,13 @@ async def test_client_migrate_no_conn_leak(df_server: DflyInstance):
         "proactor_threads": 4,
         "pipeline_queue_limit": 10,
         "pipeline_buffer_limit": "1024",
-        "experimental_io_loop_v2": "false",
+        "enable_resp_io_loop_v2": "false",
     },
     {
         "proactor_threads": 4,
         "pipeline_queue_limit": 10,
         "pipeline_buffer_limit": "1024",
-        "experimental_io_loop_v2": "true",
+        "enable_resp_io_loop_v2": "true",
     },
 )
 @pytest.mark.timeout(30)
@@ -1832,7 +1832,7 @@ async def test_migration_during_backpressure(df_server: DflyInstance):
     # V1 increments pipeline_throttle_total reliably because DispatchSingle parks the fiber.
     # V2's self-regulating ParseLoop drains the queue each iteration, so the counter may not fire.
     info = await admin.info("stats")
-    is_v2 = df_server.args.get("experimental_io_loop_v2") == "true"
+    is_v2 = df_server.args.get("enable_resp_io_loop_v2") == "true"
     if not is_v2:
         assert int(info["pipeline_throttle_total"]) > 0, "Expected pipeline_throttle_total > 0"
 
@@ -1872,13 +1872,13 @@ async def test_migration_during_backpressure(df_server: DflyInstance):
         "proactor_threads": 4,
         "pipeline_buffer_limit": "1024",
         "pipeline_queue_limit": 10,
-        "experimental_io_loop_v2": "false",
+        "enable_resp_io_loop_v2": "false",
     },
     {
         "proactor_threads": 4,
         "pipeline_buffer_limit": "1024",
         "pipeline_queue_limit": 10,
-        "experimental_io_loop_v2": "true",
+        "enable_resp_io_loop_v2": "true",
     },
 )
 @pytest.mark.timeout(30)
@@ -1917,7 +1917,7 @@ async def test_pipeline_global_memory_relief(df_server: DflyInstance):
     # V1 increments pipeline_throttle_total reliably because DispatchSingle parks the fiber.
     # V2's self-regulating ParseLoop drains the queue each iteration, so the counter may not fire.
     info = await client.info("stats")
-    is_v2 = df_server.args.get("experimental_io_loop_v2") == "true"
+    is_v2 = df_server.args.get("enable_resp_io_loop_v2") == "true"
     if not is_v2:
         assert int(info["pipeline_throttle_total"]) > 0, "Expected pipeline_throttle_total > 0"
 
@@ -2148,8 +2148,8 @@ async def test_blocking_command_pipeline_flush(df_server: DflyInstance):
 
 
 @dfly_multi_test_args(
-    {"proactor_threads": 2, "async_dispatch_quota": 50, "experimental_io_loop_v2": "false"},
-    {"proactor_threads": 2, "async_dispatch_quota": 50, "experimental_io_loop_v2": "true"},
+    {"proactor_threads": 2, "async_dispatch_quota": 50, "enable_resp_io_loop_v2": "false"},
+    {"proactor_threads": 2, "async_dispatch_quota": 50, "enable_resp_io_loop_v2": "true"},
 )
 async def test_pubsub_pipeline_starvation(df_server: DflyInstance):
     reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -479,8 +479,9 @@ class DflyInstanceFactory:
         if path is not None:
             params = dataclasses.replace(self.params, path=path)
 
-        if version < 1.35:
-            params.args.pop("experimental_io_loop_v2", None)
+        if version < 1.39:
+            args.pop("enable_memcache_io_loop_v2", None)
+            args.pop("enable_resp_io_loop_v2", None)
 
         instance = DflyInstance(params, args)
         self.instances.append(instance)


### PR DESCRIPTION
Replace `experimental_io_loop_v2` with two protocol-specific flags:
- `enable_memcache_io_loop_v2` (default: true) — non-TLS Memcache
- `enable_resp_io_loop_v2` (default: false) — non-TLS RESP

Update `ioloop_v2_` assignment in `HandleRequests()` to check the protocol and select the appropriate flag.

Rename Python helper `is_io_loop_v2` → `is_resp_io_loop_v2` and update all call sites and test parameter dicts in connection_test.py.

Bump the version guard in instance.py from < 1.35 to < 1.39 to strip both new flags from older binaries that don't support them.

Update docs/pub-sub.md to reflect the new flag names and that RESP connections can optionally use IoLoopV2.

