### PR TITLE
fix(test): Remove stale keyspace assertion in _run_tiering_migration

### DIFF
--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -3792,9 +3792,6 @@ async def _run_tiering_migration(
         with breaker:
             assert info["tiered_entries"] == 0
 
-    info = await nodes[0].client.info("keyspace")
-    assert info["db0"]["keys"] == 0
-
     info = await nodes[1].client.info("keyspace")
     assert info["db0"]["keys"] == keys - delete_succeded
 


### PR DESCRIPTION
After a full slot migration, originating node may still have a non-zero key count. 
Remove the assertion and keep only the meaningful check on destination node.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
