### PR TITLE
chore: remove test_tls_when_read_write_is_interleaved

### DIFF
--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -1191,57 +1191,6 @@ async def test_multiple_blocking_commands_client_pause(async_client: aioredis.Re
     await all
 
 
-async def test_tls_when_read_write_is_interleaved(
-    with_ca_tls_server_args, with_ca_tls_client_args, df_factory
-):
-    """
-    This test covers a deadlock bug in helio and TlsSocket when a client connection renegotiated a
-    handshake without reading its pending data from the socket.
-    This is a weak test case and from our local experiments it deadlocked 30% of the test runs
-    """
-    server: DflyInstance = df_factory.create(
-        port=1211, **with_ca_tls_server_args, proactor_threads=1
-    )
-
-    server.start()
-
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-
-    ssl_key = with_ca_tls_client_args["ssl_keyfile"]
-    ssl_cert = with_ca_tls_client_args["ssl_certfile"]
-    ssl_ca_cert = with_ca_tls_client_args["ssl_ca_certs"]
-
-    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-    context.load_verify_locations(ssl_ca_cert)
-    context.load_cert_chain(certfile=ssl_cert, keyfile=ssl_key)
-    context.verify_mode = ssl.CERT_REQUIRED
-    context.maximum_version = ssl.TLSVersion.TLSv1_2
-
-    ssl_sock = context.wrap_socket(s, server_hostname="localhost")
-    ssl_sock.connect(("127.0.0.1", server.port))
-    ssl_sock.settimeout(0.1)
-
-    tmp = "f" * 1000
-    message = f"SET foo {tmp}\r\n".encode()
-    ssl_sock.send(message)
-
-    try:
-        for i in range(0, 100_000):
-            res = random.randint(1, 4)
-            message = b""
-            for j in range(0, res):
-                message = message + b"GET foo\r\n"
-            ssl_sock.send(message)
-            ssl_sock.do_handshake()
-    except:
-        # We might have filled the socket buffer, causing further sending will fail
-        pass
-
-    # This deadlocks
-    client = aioredis.Redis(port=server.port, **with_ca_tls_client_args)
-    await client.execute_command("GET foo")
-
-
 async def test_lib_name_ver(async_client: aioredis.Redis):
     await async_client.execute_command("client setinfo lib-name dragonfly")
     await async_client.execute_command("client setinfo lib-ver 1.2.3.4")


### PR DESCRIPTION
This test was not good as it actually failed *very* rarely. With `tls_socket_test` in helio, it is now possible to reproduce such test cases conveniently. I remove this test from here and added a similar one to https://github.com/romange/helio/pull/593 that reliably reproduces the "should not happen" flow.
