### PR TITLE
fix(search): preserve empty TAG/TEXT values in FT.SEARCH RETURN

### DIFF
--- a/src/server/search/doc_accessors.cc
+++ b/src/server/search/doc_accessors.cc
@@ -45,18 +45,17 @@ string_view SdsToSafeSv(sds str) {
 using FieldValue = std::optional<search::SortableValue>;
 
 FieldValue ToSortableValue(search::SchemaField::FieldType type, string_view value) {
-  if (value.empty()) {
-    return std::nullopt;
-  }
-
   if (type == search::SchemaField::NUMERIC) {
     auto value_as_double = search::ParseNumericField(value);
-    if (!value_as_double) {  // temporary convert to double
+    if (!value_as_double) {
       return std::nullopt;
     }
     return value_as_double.value();
   }
   if (type == search::SchemaField::VECTOR) {
+    if (value.empty()) {
+      return std::nullopt;
+    }
     auto opt_vector = search::BytesToFtVectorSafe(value);
     if (!opt_vector) {
       return std::nullopt;
@@ -108,8 +107,11 @@ SearchDocData BaseAccessor::Serialize(const search::Schema& schema,
   SearchDocData out{};
   for (const auto& field : fields) {
     string_view fident = field.Identifier(schema, false);
-    auto field_value =
-        ExtractSortableValue(schema, fident, absl::StrJoin(GetStrings(fident).value(), ","));
+    auto strings = GetStrings(fident);
+    if (!strings || strings->empty()) {
+      continue;
+    }
+    auto field_value = ExtractSortableValue(schema, fident, absl::StrJoin(*strings, ","));
     if (field_value) {
       out[field.OutputName()] = std::move(field_value).value();
     }

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -782,6 +782,28 @@ TEST_F(SearchFamilyTest, TagNumbers) {
   EXPECT_THAT(Run({"ft.search", "i1", "@number:{1|hello|2}"}), AreDocIds("d:1", "d:2"));
 }
 
+TEST_F(SearchFamilyTest, ReturnEmptyFieldValue) {
+  EXPECT_EQ(Run({"ft.create", "probe", "ON", "JSON", "PREFIX", "1", "probe:", "SCHEMA", "$.parent",
+                 "AS", "parent", "TAG", "$.body", "AS", "body", "TEXT"}),
+            "OK");
+  EXPECT_EQ(Run({"json.set", "probe:1", "$", R"({"parent":"","body":""})"}), "OK");
+  EXPECT_EQ(Run({"json.set", "probe:2", "$", R"({"parent":"a","body":"hello"})"}), "OK");
+
+  auto resp = Run({"ft.search", "probe", "*", "RETURN", "2", "parent", "body", "SORTBY", "parent"});
+  EXPECT_THAT(resp, IsMapWithSize("probe:1", IsMap("parent", "", "body", ""), "probe:2",
+                                  IsMap("parent", "a", "body", "hello")));
+
+  EXPECT_EQ(Run({"ft.create", "hprobe", "ON", "HASH", "PREFIX", "1", "h:", "SCHEMA", "parent",
+                 "TAG", "body", "TEXT"}),
+            "OK");
+  Run({"hset", "h:1", "parent", "", "body", ""});
+  Run({"hset", "h:2", "parent", "a", "body", "hello"});
+
+  resp = Run({"ft.search", "hprobe", "*", "RETURN", "2", "parent", "body", "SORTBY", "parent"});
+  EXPECT_THAT(resp, IsMapWithSize("h:1", IsMap("parent", "", "body", ""), "h:2",
+                                  IsMap("parent", "a", "body", "hello")));
+}
+
 TEST_F(SearchFamilyTest, TagEscapeCharacters) {
   EXPECT_EQ(Run({"ft.create", "item_idx", "ON", "JSON", "PREFIX", "1", "p", "SCHEMA", "$.name",
                  "AS", "name", "TAG"}),


### PR DESCRIPTION
FT.SEARCH RETURN was dropping TAG/TEXT fields whose value was an empty string, so docs like `{"parent":""}` came back without the requested field. Now, empty strings are emitted as `[name, ""]` while genuinely absent fields stay absent.

Fixes: #7430