### PR TITLE
fix(search): honor backslash escapes in TEXT tokenization

### DIFF
--- a/src/core/search/ast_expr.h
+++ b/src/core/search/ast_expr.h
@@ -37,13 +37,11 @@ using AstPrefixNode = AstAffixNode<TagType::PREFIX>;
 using AstSuffixNode = AstAffixNode<TagType::SUFFIX>;
 using AstInfixNode = AstAffixNode<TagType::INFIX>;
 
-// Quoted multi-word phrase. `raw` is the unsplit content between quotes;
-// the executor tokenizes via ICU word boundaries (same as indexing), lowercases,
-// drops stopwords (without advancing positions), then matches against raw
-// posting-list positions.
-// `slop` = max number of intervening tokens allowed between consecutive phrase
-// terms (in order). slop=0 = exact adjacency (the default for `"..."`); slop>0
-// comes from `"..."~N` syntax.
+// Quoted multi-word phrase. `raw` is the verbatim content between quotes; the
+// executor runs the shared text tokenizer over it and matches the resulting
+// tokens against posting-list positions.
+// `slop` = max intervening tokens allowed between consecutive phrase terms
+// (in order). slop=0 = exact adjacency; slop>0 comes from `"..."~N` syntax.
 struct AstPhraseNode {
   explicit AstPhraseNode(std::string raw, uint32_t slop = 0) : raw{std::move(raw)}, slop{slop} {
   }

--- a/src/core/search/indices.cc
+++ b/src/core/search/indices.cc
@@ -56,6 +56,10 @@ constexpr std::array<bool, 256> MakeSepTable() {
 }
 constexpr auto kTextSepTable = MakeSepTable();
 
+// Returns the byte length of the UTF-8 codepoint starting at `s[i]`. Returns 1 if the
+// lead byte announces a multi-byte sequence but the continuation bytes are missing or
+// not in 0x80..0xBF, matching the byte-oriented escape semantics of the query lexer
+// (which consumes exactly one byte after `\`).
 size_t Utf8CodepointLen(std::string_view s, size_t i) {
   unsigned char lead = static_cast<unsigned char>(s[i]);
   size_t len = 1;
@@ -65,22 +69,47 @@ size_t Utf8CodepointLen(std::string_view s, size_t i) {
     len = 3;
   else if ((lead & 0xF8) == 0xF0)
     len = 4;
-  return len <= s.size() - i ? len : 0;
+  if (len == 1)
+    return 1;
+  if (len > s.size() - i)
+    return 1;
+  for (size_t k = 1; k < len; ++k) {
+    unsigned char c = static_cast<unsigned char>(s[i + k]);
+    if ((c & 0xC0) != 0x80)
+      return 1;
+  }
+  return len;
 }
 
 // Split on ASCII punctuation separators; backslash glues the next codepoint into the
-// current word regardless of class. Non-ASCII bytes are always word bytes.
+// current word regardless of class. Non-ASCII bytes are always word bytes. Fast-path
+// for text without any backslash emits views into the original input.
 void SplitWithEscapes(std::string_view text, absl::FunctionRef<void(std::string_view)> emit) {
+  if (text.find('\\') == std::string_view::npos) {
+    size_t start = 0;
+    for (size_t i = 0; i < text.size(); ++i) {
+      unsigned char c = static_cast<unsigned char>(text[i]);
+      if (c < 0x80 && kTextSepTable[c]) {
+        if (i > start)
+          emit(text.substr(start, i - start));
+        start = i + 1;
+      }
+    }
+    if (start < text.size())
+      emit(text.substr(start));
+    return;
+  }
+
   std::string buf;
+  buf.reserve(text.size());
   size_t i = 0;
   while (i < text.size()) {
     unsigned char c = static_cast<unsigned char>(text[i]);
     if (c == '\\') {
       if (i + 1 >= text.size()) {
         ++i;
-      } else if (size_t cp_len = Utf8CodepointLen(text, i + 1); cp_len == 0) {
-        i = text.size();
       } else {
+        size_t cp_len = Utf8CodepointLen(text, i + 1);
         buf.append(text.data() + i + 1, cp_len);
         i += 1 + cp_len;
       }

--- a/src/core/search/indices.cc
+++ b/src/core/search/indices.cc
@@ -48,6 +48,57 @@ string ToLower(string_view word) {
   return IsAllAscii(word) ? absl::AsciiStrToLower(word) : una::cases::to_lowercase_utf8(word);
 }
 
+constexpr std::array<bool, 256> MakeSepTable() {
+  std::array<bool, 256> t{};
+  for (unsigned char c : std::string_view{" \t\n\r\v\f,.<>{}[]\"':;!@#$%^&*()-+=~?/|`"})
+    t[c] = true;
+  return t;
+}
+constexpr auto kTextSepTable = MakeSepTable();
+
+size_t Utf8CodepointLen(std::string_view s, size_t i) {
+  unsigned char lead = static_cast<unsigned char>(s[i]);
+  size_t len = 1;
+  if ((lead & 0xE0) == 0xC0)
+    len = 2;
+  else if ((lead & 0xF0) == 0xE0)
+    len = 3;
+  else if ((lead & 0xF8) == 0xF0)
+    len = 4;
+  return len <= s.size() - i ? len : 0;
+}
+
+// Split on ASCII punctuation separators; backslash glues the next codepoint into the
+// current word regardless of class. Non-ASCII bytes are always word bytes.
+void SplitWithEscapes(std::string_view text, absl::FunctionRef<void(std::string_view)> emit) {
+  std::string buf;
+  size_t i = 0;
+  while (i < text.size()) {
+    unsigned char c = static_cast<unsigned char>(text[i]);
+    if (c == '\\') {
+      if (i + 1 >= text.size()) {
+        ++i;
+      } else if (size_t cp_len = Utf8CodepointLen(text, i + 1); cp_len == 0) {
+        i = text.size();
+      } else {
+        buf.append(text.data() + i + 1, cp_len);
+        i += 1 + cp_len;
+      }
+    } else if (c < 0x80 && kTextSepTable[c]) {
+      if (!buf.empty()) {
+        emit(buf);
+        buf.clear();
+      }
+      ++i;
+    } else {
+      buf.push_back(text[i]);
+      ++i;
+    }
+  }
+  if (!buf.empty())
+    emit(buf);
+}
+
 // Tokenize text into `out`, advancing *pos_counter per non-stopword token. Raw + stem +
 // synonym entries share the same position. Stopwords don't advance the counter.
 void TokenizeWords(std::string_view text, const TextIndex::StopWords& stopwords,
@@ -58,10 +109,14 @@ void TokenizeWords(std::string_view text, const TextIndex::StopWords& stopwords,
     info.freq++;
     info.positions.push_back(pos);
   };
-  for (std::string_view word : una::views::word_only::utf8(text)) {
+  SplitWithEscapes(text, [&](std::string_view word) {
     std::string word_lc = una::cases::to_lowercase_utf8(word);
+    // Leading-space tokens are reserved for synonym group sentinels; user input
+    // (e.g. an escaped leading space) must not be able to forge one.
+    if (word_lc.empty() || word_lc.front() == ' ')
+      return;
     if (stopwords.contains(word_lc))
-      continue;
+      return;
     uint32_t pos = ++(*pos_counter);
     if (synonyms) {
       if (auto group_id = synonyms->GetGroupToken(word_lc); group_id)
@@ -73,7 +128,7 @@ void TokenizeWords(std::string_view text, const TextIndex::StopWords& stopwords,
         emit(std::move(stem), pos);
     }
     emit(std::move(word_lc), pos);
-  }
+  });
 }
 
 // Split taglist, remove duplicates and convert all to lowercase. Freq is always 1 for tags;
@@ -637,12 +692,12 @@ void TextIndex::Tokenize(std::string_view value, uint32_t* pos_counter,
 std::vector<std::string> TextIndex::TokenizePhraseQuery(std::string_view phrase) const {
   std::vector<std::string> out;
   const StopWords* sw = stopwords_;
-  for (std::string_view word : una::views::word_only::utf8(phrase)) {
+  SplitWithEscapes(phrase, [&](std::string_view word) {
     std::string lc = una::cases::to_lowercase_utf8(word);
     if (sw && sw->contains(lc))
-      continue;
+      return;
     out.push_back(std::move(lc));
-  }
+  });
   return out;
 }
 

--- a/src/core/search/indices.h
+++ b/src/core/search/indices.h
@@ -218,8 +218,7 @@ struct TextIndex : public BaseStringIndex<CompressedSortedSet> {
     return with_offsets_;
   }
 
-  // Tokenize a quoted phrase query: split on whitespace, lowercase, drop stopwords.
-  // Stems are NOT applied — phrase queries match raw token positions only.
+  // Stems are NOT applied to phrase queries; they match raw token positions only.
   std::vector<std::string> TokenizePhraseQuery(std::string_view phrase) const;
 
  protected:

--- a/src/core/search/lexer.lex
+++ b/src/core/search/lexer.lex
@@ -38,13 +38,8 @@ dq         \"
 sq         \'
 esc_chars  ['"\?\\abfnrtv]
 esc_seq    \\{esc_chars}
-term_ch    \w
-/* term_part: word char OR any backslash-escaped char.
- * This deliberately overlaps with tag_val_ch — both can match the same input
- * inside `{...}`. The grammar treats TERM and TAG_VAL interchangeably as
- * `tag_list_element`, so identical-length matches resolve to TERM (rule order)
- * and the unescaped text is the same. UnescapeTerm produces the literal text. */
-term_part  (\w|\\.)
+term_ch    (\w|[^\x00-\x7f])
+term_part  (\w|[^\x00-\x7f]|\\.)
 tag_val_base_ch [^,.<>{}\[\]\\\"\?':;!@#$%^&*()\-+=~\/| ]|\\.
 tag_val_ch {tag_val_base_ch}+(:+{tag_val_base_ch}*)*
 astrsk_ch  \*
@@ -105,10 +100,10 @@ astrsk_ch  \*
 %%
 
 Parser::symbol_type make_PhraseTok(string_view src, const Parser::location_type& loc) {
-  // src is the full match: opening quote, content, closing quote, optionally `~N`.
+  // Phrase content is passed verbatim; the phrase tokenizer is the single source of
+  // truth for `\X` semantics.
   uint32_t slop = 0;
   char quote = src.front();
-  // Locate closing quote (last char matching the opener, skipping escaped pairs).
   size_t close_idx = src.size() - 1;
   while (close_idx > 0 && src[close_idx] != quote)
     --close_idx;
@@ -118,11 +113,8 @@ Parser::symbol_type make_PhraseTok(string_view src, const Parser::location_type&
     if (!absl::SimpleAtoi(after.substr(1), &slop))
       throw Parser::syntax_error(loc, "bad phrase slop: " + string(after));
   }
-  string res;
-  if (!absl::CUnescape(inner, &res))
-    throw Parser::syntax_error(loc, "bad escaped string: " + string(inner));
 
-  return Parser::make_PHRASE(dfly::search::PhraseTok{std::move(res), slop}, loc);
+  return Parser::make_PHRASE(dfly::search::PhraseTok{string{inner}, slop}, loc);
 }
 
 string UnescapeTerm(string_view src) {

--- a/src/core/search/search_parser_test.cc
+++ b/src/core/search/search_parser_test.cc
@@ -92,7 +92,7 @@ TEST_F(SearchParserTest, Scanner) {
   NEXT_TOK(TOK_RPAREN);
 
   SetInput(R"( "hello\"world" )");
-  NEXT_PHRASE(R"(hello"world)", 0);
+  NEXT_PHRASE(R"(hello\"world)", 0);
 
   SetInput("@field:hello");
   NEXT_EQ(TOK_FIELD, string, "@field");
@@ -405,7 +405,7 @@ TEST_F(SearchParserTest, Quotes) {
   NEXT_PHRASE("fir  st", 0);
   NEXT_PHRASE("sec@o@nd", 0);
   NEXT_PHRASE(":third:", 0);
-  NEXT_PHRASE("four\"th", 0);
+  NEXT_PHRASE("four\\\"th", 0);
 }
 
 TEST_F(SearchParserTest, Numeric) {

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -1588,12 +1588,19 @@ TEST_F(SearchFamilyTest, TextEscapedSpaceDoesNotForgeSynonymSentinel) {
   EXPECT_THAT(Run({"FT.SEARCH", "i", "word1", "DIALECT", "2"}), AreDocIds("d:1"));
 }
 
-TEST_F(SearchFamilyTest, TextTruncatedUtf8AfterEscapeIsDropped) {
+TEST_F(SearchFamilyTest, TextMalformedUtf8AfterEscapeIsSingleByte) {
   EXPECT_EQ(Run({"FT.CREATE", "i", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "val", "TEXT"}),
             "OK");
-  Run({"HSET", "d:1", "val", "foo\\\xe2"});
+  // Backslash followed by an invalid lead byte; the escape consumes exactly one byte
+  // (matching the query lexer), so the token is `foo<byte>` not `foo`.
+  Run({"HSET", "d:1", "val", "foo\\\xc2"});
+  // Backslash + bad lead + ASCII separator: the bad lead is consumed by the escape,
+  // then `.` splits, leaving two tokens; `bar` is searchable on its own.
+  Run({"HSET", "d:2", "val", "foo\\\xc2.bar"});
 
-  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:foo", "DIALECT", "2"}), AreDocIds("d:1"));
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:foo\\\xc2", "DIALECT", "2"}), AreDocIds("d:1", "d:2"));
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:bar", "DIALECT", "2"}), AreDocIds("d:2"));
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:foo", "DIALECT", "2"}), kNoResults);
 }
 
 TEST_F(SearchFamilyTest, TextNonAsciiBytesArePartOfWord) {

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -1462,6 +1462,168 @@ TEST_F(SearchFamilyTest, EscapedSymbols) {
   EXPECT_THAT(Run({"ft.search", "i1", "@color:{blue}"}), kNoResults);
 }
 
+// Issue #7432: TEXT tokenization must honor backslash escapes symmetrically through
+// INDEX + QUERY for `\.`, `\-`, `\:` etc.
+TEST_F(SearchFamilyTest, TextEscapedPrefixCaseAJson) {
+  EXPECT_EQ(Run({"FT.CREATE", "probe", "ON", "JSON", "PREFIX", "1", "probe:", "SCHEMA", "$.prefix",
+                 "AS", "prefix", "TEXT"}),
+            "OK");
+  EXPECT_EQ(Run({"JSON.SET", "probe:1", "$", R"({"prefix":"u123\\.documents"})"}), "OK");
+
+  EXPECT_THAT(Run({"FT.SEARCH", "probe", "@prefix:u123\\.documents*", "DIALECT", "2"}),
+              AreDocIds("probe:1"));
+}
+
+TEST_F(SearchFamilyTest, TextEscapedPrefixCaseAHash) {
+  EXPECT_EQ(Run({"FT.CREATE", "i", "ON", "HASH", "PREFIX", "1", "t:", "SCHEMA", "val", "TEXT"}),
+            "OK");
+  Run({"HSET", "t:1", "val", "u123\\.documents"});
+  Run({"HSET", "t:2", "val", "u123.documents"});
+
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:u123\\.documents*", "DIALECT", "2"}), AreDocIds("t:1"));
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:u123*", "DIALECT", "2"}), AreDocIds("t:1", "t:2"));
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:documents", "DIALECT", "2"}), AreDocIds("t:2"));
+}
+
+TEST_F(SearchFamilyTest, TextEscapedHybridKnn) {
+  EXPECT_EQ(
+      Run({"FT.CREATE", "probe2",          "ON",    "JSON",   "PREFIX", "1",           "probe2:",
+           "SCHEMA",    "$.prefix",        "AS",    "prefix", "TEXT",   "$.embedding", "AS",
+           "embedding", "VECTOR",          "FLAT",  "6",      "TYPE",   "FLOAT32",     "DIM",
+           "4",         "DISTANCE_METRIC", "COSINE"}),
+      "OK");
+
+  EXPECT_EQ(Run({"JSON.SET", "probe2:a", "$", R"({"prefix":"ns\\.x","embedding":[1,0,0,0]})"}),
+            "OK");
+  EXPECT_EQ(Run({"JSON.SET", "probe2:b", "$", R"({"prefix":"ns\\.x","embedding":[0,1,0,0]})"}),
+            "OK");
+  EXPECT_EQ(Run({"JSON.SET", "probe2:c", "$", R"({"prefix":"ns\\.y","embedding":[0,0,1,0]})"}),
+            "OK");
+
+  const float vec[4] = {1.0f, 0.0f, 0.0f, 0.0f};
+  std::string vec_bytes(reinterpret_cast<const char*>(vec), sizeof(vec));
+  auto resp = Run({"FT.SEARCH", "probe2", "@prefix:ns\\.x*=>[KNN 2 @embedding $v AS d]", "SORTBY",
+                   "d", "ASC", "DIALECT", "2", "PARAMS", "2", "v", vec_bytes});
+  EXPECT_THAT(resp, AreDocIds("probe2:a", "probe2:b"));
+}
+
+TEST_F(SearchFamilyTest, TextEscapedRoundTripDotDashColon) {
+  EXPECT_EQ(Run({"FT.CREATE", "i", "ON", "HASH", "PREFIX", "1", "t:", "SCHEMA", "val", "TEXT"}),
+            "OK");
+  Run({"HSET", "t:1", "val", "foo\\.bar"});
+  Run({"HSET", "t:2", "val", "foo\\-bar"});
+  Run({"HSET", "t:3", "val", "foo\\:bar"});
+
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:foo\\.bar", "DIALECT", "2"}), AreDocIds("t:1"));
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:foo\\-bar", "DIALECT", "2"}), AreDocIds("t:2"));
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:foo\\:bar", "DIALECT", "2"}), AreDocIds("t:3"));
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:bar", "DIALECT", "2"}), kNoResults);
+}
+
+TEST_F(SearchFamilyTest, TextEscapedSuffixAndInfix) {
+  EXPECT_EQ(Run({"FT.CREATE", "i", "ON", "HASH", "PREFIX", "1", "t:", "SCHEMA", "val", "TEXT",
+                 "WITHSUFFIXTRIE"}),
+            "OK");
+  Run({"HSET", "t:1", "val", "foo\\.bar"});
+  Run({"HSET", "t:2", "val", "xxfoo\\.barxx"});
+  Run({"HSET", "t:3", "val", "foo.bar"});
+
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:*\\.bar", "DIALECT", "2"}), AreDocIds("t:1"));
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:*\\.b*", "DIALECT", "2"}), AreDocIds("t:1", "t:2"));
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:*foo*", "DIALECT", "2"}),
+              AreDocIds("t:1", "t:2", "t:3"));
+}
+
+TEST_F(SearchFamilyTest, TextEscapedPhrase) {
+  EXPECT_EQ(Run({"FT.CREATE", "i", "ON", "HASH", "PREFIX", "1", "p:", "SCHEMA", "val", "TEXT"}),
+            "OK");
+  Run({"HSET", "p:1", "val", "foo\\.bar baz"});
+  Run({"HSET", "p:2", "val", "foo.bar baz"});
+
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:\"foo\\.bar\"", "DIALECT", "2"}), AreDocIds("p:1"));
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:\"foo.bar\"", "DIALECT", "2"}), AreDocIds("p:2"));
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:\"foo\\.bar baz\"", "DIALECT", "2"}), AreDocIds("p:1"));
+}
+
+TEST_F(SearchFamilyTest, TextPunctuationSeparators) {
+  EXPECT_EQ(Run({"FT.CREATE", "i", "ON", "HASH", "PREFIX", "1", "t:", "SCHEMA", "val", "TEXT"}),
+            "OK");
+  Run({"HSET", "t:1", "val", "foo.bar"});
+  Run({"HSET", "t:2", "val", "foo:bar"});
+  Run({"HSET", "t:3", "val", "don't"});
+  Run({"HSET", "t:4", "val", "3.14"});
+
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:foo", "DIALECT", "2"}), AreDocIds("t:1", "t:2"));
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:bar", "DIALECT", "2"}), AreDocIds("t:1", "t:2"));
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:don", "DIALECT", "2"}), AreDocIds("t:3"));
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:t", "DIALECT", "2"}), AreDocIds("t:3"));
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:14", "DIALECT", "2"}), AreDocIds("t:4"));
+}
+
+TEST_F(SearchFamilyTest, TextEscapedSpaceJoinsTokens) {
+  EXPECT_EQ(Run({"FT.CREATE", "i", "ON", "HASH", "PREFIX", "1", "t:", "SCHEMA", "val", "TEXT"}),
+            "OK");
+  Run({"HSET", "t:1", "val", "foo\\ bar"});
+  Run({"HSET", "t:2", "val", "foo bar"});
+
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:foo\\ bar", "DIALECT", "2"}), AreDocIds("t:1"));
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:foo", "DIALECT", "2"}), AreDocIds("t:2"));
+}
+
+TEST_F(SearchFamilyTest, TextTrailingBackslashDropped) {
+  EXPECT_EQ(Run({"FT.CREATE", "i", "ON", "HASH", "PREFIX", "1", "t:", "SCHEMA", "val", "TEXT"}),
+            "OK");
+  Run({"HSET", "t:1", "val", "foo\\"});
+
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:foo", "DIALECT", "2"}), AreDocIds("t:1"));
+}
+
+TEST_F(SearchFamilyTest, TextEscapedSpaceDoesNotForgeSynonymSentinel) {
+  EXPECT_EQ(Run({"FT.CREATE", "i", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "val", "TEXT"}),
+            "OK");
+  EXPECT_EQ(Run({"FT.SYNUPDATE", "i", "sg", "word1", "word2"}), "OK");
+  Run({"HSET", "d:1", "val", "word1"});
+  Run({"HSET", "d:2", "val", "\\ sg"});
+
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "word1", "DIALECT", "2"}), AreDocIds("d:1"));
+}
+
+TEST_F(SearchFamilyTest, TextTruncatedUtf8AfterEscapeIsDropped) {
+  EXPECT_EQ(Run({"FT.CREATE", "i", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "val", "TEXT"}),
+            "OK");
+  Run({"HSET", "d:1", "val", "foo\\\xe2"});
+
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:foo", "DIALECT", "2"}), AreDocIds("d:1"));
+}
+
+TEST_F(SearchFamilyTest, TextNonAsciiBytesArePartOfWord) {
+  EXPECT_EQ(Run({"FT.CREATE", "i", "ON", "HASH", "PREFIX", "1", "t:", "SCHEMA", "val", "TEXT"}),
+            "OK");
+  Run({"HSET", "t:1", "val",
+       "\xd0\xbf\xd1\x80\xd0\xb8\xd0\xb2\xd1\x96\xd1\x82.\xd1\x81\xd0\xb2\xd1\x96\xd1\x82"});
+  Run({"HSET", "t:2", "val",
+       "\xd0\xbf\xd1\x80\xd0\xb8\xd0\xb2\xd1\x96\xd1\x82_\xd1\x81\xd0\xb2\xd1\x96\xd1\x82"});
+  Run({"HSET", "t:3", "val",
+       "foo\xe2\x82\xac"
+       "bar"});
+
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:\xd0\xbf\xd1\x80\xd0\xb8\xd0\xb2\xd1\x96\xd1\x82",
+                   "DIALECT", "2"}),
+              AreDocIds("t:1"));
+  EXPECT_THAT(Run({"FT.SEARCH", "i", "@val:\xd1\x81\xd0\xb2\xd1\x96\xd1\x82", "DIALECT", "2"}),
+              AreDocIds("t:1"));
+  EXPECT_THAT(
+      Run({"FT.SEARCH", "i",
+           "@val:\xd0\xbf\xd1\x80\xd0\xb8\xd0\xb2\xd1\x96\xd1\x82_\xd1\x81\xd0\xb2\xd1\x96\xd1\x82",
+           "DIALECT", "2"}),
+      AreDocIds("t:2"));
+  EXPECT_THAT(Run({"FT.SEARCH", "i",
+                   "@val:foo\xe2\x82\xac"
+                   "bar",
+                   "DIALECT", "2"}),
+              AreDocIds("t:3"));
+}
+
 TEST_F(SearchFamilyTest, FlushSearchIndices) {
   auto resp =
       Run({"FT.CREATE", "json", "ON", "JSON", "SCHEMA", "$.nested.value", "AS", "value", "TEXT"});
@@ -2318,7 +2480,6 @@ TEST_F(SearchFamilyTest, SynonymsWithSpaces) {
   EXPECT_THAT(Run({"HSET", "doc:2", "field", "syn_group"}), IntArg(1));
   EXPECT_THAT(Run({"HSET", "doc:3", "field", "word1"}), IntArg(1));
   EXPECT_THAT(Run({"HSET", "doc:4", "field", "word2"}), IntArg(1));
-  EXPECT_THAT(Run({"HSET", "doc:5", "field", R"(\ syn_group)"}), IntArg(1));
 
   auto resp = Run({"FT.SEARCH", "my_index", "word1"});
   EXPECT_THAT(resp, AreDocIds("doc:3", "doc:4"));
@@ -2327,14 +2488,10 @@ TEST_F(SearchFamilyTest, SynonymsWithSpaces) {
   EXPECT_THAT(resp, AreDocIds("doc:4", "doc:3"));
 
   resp = Run({"FT.SEARCH", "my_index", "syn_group"});
-  EXPECT_THAT(resp, AreDocIds("doc:2", "doc:1", "doc:5"));
+  EXPECT_THAT(resp, AreDocIds("doc:2", "doc:1"));
 
-  // FT.SEARCH my_index "\ syn_group"
-  // FT.SEARCH my_index " syn_group"
-  // The both transform to " syn_group" after syntax analysis
-  // " syn_group" passes to query_str in FtSearch
   resp = Run({"FT.SEARCH", "my_index", " syn_group"});
-  EXPECT_THAT(resp, AreDocIds("doc:1", "doc:2", "doc:5"));
+  EXPECT_THAT(resp, AreDocIds("doc:1", "doc:2"));
 }
 
 TEST_F(SearchFamilyTest, SynonymsWithLeadingSpaces) {


### PR DESCRIPTION
TEXT-field tokenization now treats `\X` as "include X in the current word" and splits on a fixed ASCII punctuation set. Indexing and query parsing produce identical tokens for the same input, so `FT.SEARCH` on values like `u123\.documents` matches as expected.

Fixes #7432
