### PR TITLE
ci: parallelize ctest runs with -j$(nproc)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,10 +119,10 @@ jobs:
       - name: C++ Unit Tests - IoUring
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          echo Run ctest -V -L DFLY
+          echo Run ctest -V -L DFLY -j$(nproc)
 
           GLOG_alsologtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1,op_manager=1,op_manager_test=1 \
-          FLAGS_fiber_safety_margin=4096 timeout 20m ctest -V -L DFLY -E allocation_tracker_test
+          FLAGS_fiber_safety_margin=4096 timeout 20m ctest -V -L DFLY -j$(nproc) -E allocation_tracker_test
 
           # Run allocation tracker test separately without alsologtostderr because it generates a TON of logs.
           FLAGS_fiber_safety_margin=4096 timeout 5m ./allocation_tracker_test
@@ -148,19 +148,19 @@ jobs:
 
           gdb -ix ./init.gdb --batch -ex r --args ./dragonfly_test --force_epoll
           GLOG_alsologtostderr=1 FLAGS_fiber_safety_margin=4096 FLAGS_force_epoll=true GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 \
-          timeout 20m ctest -V -L DFLY -E allocation_tracker_test
+          timeout 20m ctest -V -L DFLY -j$(nproc) -E allocation_tracker_test
 
           FLAGS_fiber_safety_margin=4096 FLAGS_force_epoll=true timeout 5m ./allocation_tracker_test
 
       - name: C++ Unit Tests - IoUring with cluster mode
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          FLAGS_fiber_safety_margin=4096 FLAGS_cluster_mode=emulated timeout 20m ctest -V -L DFLY
+          FLAGS_fiber_safety_margin=4096 FLAGS_cluster_mode=emulated timeout 20m ctest -V -L DFLY -j$(nproc)
 
       - name: C++ Unit Tests - IoUring with cluster mode and FLAGS_lock_on_hashtags
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          FLAGS_fiber_safety_margin=4096 FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true timeout 20m ctest -V -L DFLY
+          FLAGS_fiber_safety_margin=4096 FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true timeout 20m ctest -V -L DFLY -j$(nproc)
 
       - name: Upload unit logs on failure
         if: failure()

--- a/.github/workflows/cov.yml
+++ b/.github/workflows/cov.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Run C++ Unit Tests
         run: |
           cd $GITHUB_WORKSPACE/build
-          ctest -V -L DFLY
+          ctest -V -L DFLY -j$(nproc)
 
       - name: Run Python Integration Tests
         run: |

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Test
         run: |
             cd $GITHUB_WORKSPACE/build
-            ctest -V -L DFLY
+            ctest -V -L DFLY -j$(nproc)
 
       - name: Send notification on failure
         if: failure() && github.ref == 'refs/heads/main'
@@ -129,7 +129,7 @@ jobs:
       - name: Test
         run: |
             cd $GITHUB_WORKSPACE/build
-            ctest -V -L DFLY
+            ctest -V -L DFLY -j$(sysctl -n hw.ncpu)
 
       - name: Send notification on failure
         if: failure() && github.ref == 'refs/heads/main'

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -738,7 +738,7 @@ TEST_F(SearchFamilyTest, FtSearchWaitsForInitialIndexing) {
   }
 
   Run({"ft.create", "i1", "on", "json", "schema", "$.name", "as", "name", "text"});
-  WaitForIndexReady("i1");
+  WaitForIndexReady("i1", absl::Seconds(60));
 
   auto resp = Run({"ft.search", "i1", "*", "LIMIT", "0", "0"});
   EXPECT_THAT(resp, RespElementsAre(IntArg(kDocs)));

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -16,6 +16,7 @@ extern "C" {
 #include <absl/strings/match.h>
 #include <absl/strings/str_split.h>
 #include <mimalloc.h>
+#include <unistd.h>
 
 #include "base/flags.h"
 #include "base/logging.h"
@@ -349,7 +350,9 @@ void BaseFamilyTest::ShutdownService() {
 void BaseFamilyTest::InitWithDbFilename() {
   ShutdownService();
 
-  absl::SetFlag(&FLAGS_dbfilename, "rdbtestdump");
+  // Include PID so parallel ctest runs (different test binaries sharing the
+  // build dir) don't unlink each other's snapshot files via CleanupSnapshots.
+  absl::SetFlag(&FLAGS_dbfilename, absl::StrCat("rdbtestdump_", getpid()));
   CleanupSnapshots();
   ResetService();
 }


### PR DESCRIPTION
Run `ctest -V -L DFLY` in parallel using all available cores across GitHub Actions workflows. Previously tests ran sequentially, leaving CI runners mostly idle.
