### PR TITLE
chore: dfly version clean ups

### DIFF
--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -164,7 +164,6 @@ struct ConnectionState {
     uint32_t repl_flow_id = UINT32_MAX;
     std::string repl_ip_address;
     uint32_t repl_listening_port = 0;
-    DflyVersion repl_version = DflyVersion::VER1;
   };
 
   struct SquashingInfo {

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -300,7 +300,6 @@ void DflyCmd::Flow(CmdArgList args, CommandContext* cmd_cntx) {
     conn_cntx->master_repl_flow = &flow;
     flow.conn = cmd_cntx->conn();
     flow.eof_token = eof_token;
-    flow.version = replica_ptr->GetVersion();
 
     if (!conn_cntx->conn()->Migrate(shard_set->pool()->at(flow_id))) {
       // Listener::PreShutdown() triggered
@@ -365,8 +364,9 @@ void DflyCmd::Sync(CmdArgList args, CommandContext* cmd_cntx) {
 
     // Use explicit assignment for replica_ptr, because capturing structured bindings is C++20.
     auto cb = [this, &status, replica_ptr = replica_ptr](EngineShard* shard) {
-      status = StartFullSyncInThread(&replica_ptr->GetFlow(shard->shard_id()),
-                                     &replica_ptr->GetExecState(), shard);
+      status =
+          StartFullSyncInThread(replica_ptr->GetVersion(), &replica_ptr->GetFlow(shard->shard_id()),
+                                &replica_ptr->GetExecState(), shard);
     };
     shard_set->RunBlockingInParallel(std::move(cb));
 
@@ -675,8 +675,8 @@ void DflyCmd::Load(CmdArgList args, CommandContext* cmd_cntx) {
   cmd_cntx->SendOk();
 }
 
-OpStatus DflyCmd::StartFullSyncInThread(FlowInfo* flow, ExecutionState* exec_st,
-                                        EngineShard* shard) {
+OpStatus DflyCmd::StartFullSyncInThread(DflyVersion version, FlowInfo* flow,
+                                        ExecutionState* exec_st, EngineShard* shard) {
   DCHECK(shard);
   DCHECK(flow->conn);
 
@@ -684,8 +684,7 @@ OpStatus DflyCmd::StartFullSyncInThread(FlowInfo* flow, ExecutionState* exec_st,
   // of the flows also contain them.
   SaveMode save_mode =
       shard->shard_id() == 0 ? SaveMode::SINGLE_SHARD_WITH_SUMMARY : SaveMode::SINGLE_SHARD;
-  flow->saver =
-      std::make_unique<RdbSaver>(flow->conn->socket(), save_mode, false, "", flow->version);
+  flow->saver = std::make_unique<RdbSaver>(flow->conn->socket(), save_mode, false, "", version);
 
   flow->cleanup = [flow, shard]() {
     // socket shutdown is needed before calling saver->Cancel(). Because

--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -46,8 +46,6 @@ struct FlowInfo {
   std::unique_ptr<JournalStreamer> streamer;  // Streamer for stable sync phase
   std::string eof_token;
 
-  DflyVersion version = DflyVersion::VER1;
-
   std::optional<LSN> start_partial_sync_at;
   uint64_t last_acked_lsn = 0;
 
@@ -208,6 +206,9 @@ class DflyCmd {
     std::atomic<bool> id_set_{false};
     std::string address_;
     uint32_t listening_port_;
+
+    // We expect to update version_ during handshaking, for now we set it to
+    // the oldest version to be safe.
     std::atomic<DflyVersion> version_{DflyVersion::VER1};
 
     std::vector<FlowInfo> flows_;
@@ -280,7 +281,8 @@ class DflyCmd {
   void Load(CmdArgList args, CommandContext* cmd_cntx);
 
   // Start full sync in thread. Start FullSyncFb. Called for each flow.
-  facade::OpStatus StartFullSyncInThread(FlowInfo* flow, ExecutionState* cntx, EngineShard* shard);
+  facade::OpStatus StartFullSyncInThread(DflyVersion version, FlowInfo* flow, ExecutionState* cntx,
+                                         EngineShard* shard);
 
   // Stop full sync in thread. Run state switch cleanup.
   facade::OpStatus StopFullSyncInThread(FlowInfo* flow, ExecutionState* cntx, EngineShard* shard);


### PR DESCRIPTION
## Summary
Cleans up replication version handling by removing per-connection/per-flow stored Dragonfly version fields.

## Changes
- Pass the replica's negotiated `DflyVersion` explicitly into full-sync/RDB save paths.
- Centralize version state on `ReplicaInfo` instead of storing it in `FlowInfo`/connection replication state.
- Keep full-sync shards using a single captured version value for consistent snapshot output.
