### PR TITLE
tests: Fix test_denyoom_commands by removing RSS factor

### DIFF
--- a/tests/dragonfly/generic_test.py
+++ b/tests/dragonfly/generic_test.py
@@ -232,7 +232,9 @@ async def test_reply_guard_oom(df_factory, df_seeder_factory):
 
 @pytest.mark.asyncio
 async def test_denyoom_commands(df_factory):
-    df_server = df_factory.create(proactor_threads=1, maxmemory="256mb", oom_deny_commands="get")
+    df_server = df_factory.create(
+        proactor_threads=1, maxmemory="256mb", oom_deny_commands="get", rss_oom_deny_ratio=-1
+    )
     df_server.start()
     client = df_server.client()
     await client.execute_command("DEBUG POPULATE 7000 size 44000")


### PR DESCRIPTION
Currently this test does the following:

* set up max memory
* use debug populate to trigger fill
* assert used mem > max mem
* proceed with firing off cmds to see them get denied

This second step is broken. debug populate issues commands to fill the data set, and RSS climbs such that rss / used > 1.25 at which point the RSS leg of the deny clause kicks in. In short

`used < 256m < 256m * 1.25 < rss`

which causes deny to kick in.

Then the debug populate partially blocked, and the test thinks it did not produce enough data (used < max). Since this test does not intend to test rss limits, it should keep that limit off and only test the used mem leg of the deny condition.

FIXES https://github.com/dragonflydb/dragonfly/issues/7279