### PR TITLE
docs: rewrite transaction.md to align with current codebase

### DIFF
--- a/docs/transaction.md
+++ b/docs/transaction.md
@@ -1,41 +1,44 @@
-# Life of a transaction
+# Dragonfly Transaction Model
 
-This document describes how Dragonfly transactions provide atomicity and serializability for its multi-key and multi-command operations.
+This document describes how Dragonfly provides atomicity and strict serializability for its multi-key and multi-command operations. The transaction algorithm is based on the [Very Lightweight Locking (VLL) paper](https://www.cs.umd.edu/~abadi/papers/vldbj-vll.pdf), adapted for Dragonfly's shared-nothing, fiber-based architecture.
 
-## Definitions
+## Table of Contents
 
-### Serializability
+1. [Background: Consistency Guarantees](#background-consistency-guarantees)
+2. [Architecture Overview](#architecture-overview)
+3. [Core Concepts](#core-concepts)
+4. [Scheduling a Transaction](#scheduling-a-transaction)
+5. [Executing a Transaction](#executing-a-transaction)
+6. [Optimizations](#optimizations)
+7. [Multi-op Transactions (MULTI/EXEC, Lua)](#multi-op-transactions-multiexec-lua)
+8. [Command Squashing](#command-squashing)
+9. [Blocking Commands (BLPOP)](#blocking-commands-blpop)
+10. [Further Reading](#further-reading)
 
-Serializability is an isolation level for database transactions. Serializability describes multiple transactions, where a transaction is usually composed of multiple operations on multiple objects.
+---
 
-Databases can execute transactions in parallel (and the operations in parallel). Serializability guarantees the result is the same with, as if the transactions were executed one by one. i.e. to behave like executed in a serial order.
+## Background: Consistency Guarantees
 
-Serializability doesn’t guarantee the resulting serial order respects recency. I.e. the serial order can be different from the order in which transactions were actually executed. E.g. Tx1 begins earlier than Tx2, but the result behaves as if Tx2 executed before Tx1. That is also to say, to satisfy the same Serializability, there can be more than one possible execution schedulings.
+**Serializability** guarantees that the result of executing transactions in parallel is equivalent to *some* serial order of those transactions. It does not require that the serial order matches real-time ordering: transaction T1 can start before T2 but appear after T2 in the equivalent serial schedule.
 
-### Strict Serializability
+**Strict serializability** (serializability + linearizability) additionally requires that the equivalent serial order respects real-time precedence: if T1 completes before T2 begins, T1 must appear before T2 in the serial order. It also implies atomicity: a transaction's sub-operations never interleave with those of another transaction.
 
-Strict serializability means that operations appear to have occurred in some order, consistent with the real-time ordering of those operations; e.g. if operation A completes before operation B begins, then A should appear to precede B in the serialization order.
+Single-key operations in Dragonfly are trivially strictly serializable because in the shared-nothing architecture each shard thread processes its keys sequentially. The challenge is providing strict serializability for operations that span multiple keys across different shards.
 
-Strict serializability implies atomicity meaning, a transaction’s sub-operations do not appear to interleave with sub-operations from other transactions. It also implies serializability
-by definition (appear in some order...).
+---
 
-Note that simple, single-key operations in Dragonfly are already strictly serializable because in a shared-nothing architecture each shard-thread performs operations on its keys sequentially.
-The complexity rises when we need to provide strict-serializability (aka serializability and linearizability) for operations spawning multiple keys.
+## Architecture Overview
 
-## Transactions high level overview
-Transactions in Dragonfly are orchestrated by an abstract entity, called coordination layer.
-In reality, a client connection instance takes on itself the role of a coordinator: it coordinates a transaction every time it drives a redis or memcached command to completion. The algorithm behind Dragonfly transactions is based on the [VLL paper](https://www.cs.umd.edu/~abadi/papers/vldbj-vll.pdf).
-
-Every step within a coordinator is done sequentially. Therefore, it's easier to describe the flow using a sequence diagram. Below is a sequence diagram of a generic transaction consisting of multiple execution steps. In this diagram, the operation it executes touches keys in two different shards: `Shard1` and `Shard2`.
+In Dragonfly, a client connection fiber acts as the **coordinator** for each command it executes. The coordinator does not access shard data directly. Instead, it sends asynchronous messages to the relevant shard threads and waits for their responses. We call each such round-trip a **hop**.
 
 ```mermaid
 %%{init: {'theme':'base'}}%%
 sequenceDiagram
     participant C as Coordinator
-    participant S1 as Data Shard 1
-    participant S2 as Data Shard 2
+    participant S1 as Shard 1
+    participant S2 as Shard 2
 
-    par hop1
+    par Schedule
     C->>+S1: Schedule
     and
     C->>+S2: Schedule
@@ -43,214 +46,320 @@ sequenceDiagram
     S2--)C: Ack
     end
 
-    par hop2
-    C->>S1: Exec1
+    par Execute (hop 1)
+    C->>S1: Run callback
     and
-    C->>S2: Exec1
+    C->>S2: Run callback
     S1--)C: Ack
     S2--)C: Ack
     end
-    par hop N+1
-    C->>S1: Exec N+Fin
+
+    par Execute (final hop)
+    C->>S1: Run callback + Conclude
     and
-    C->>S2: Exec N+Fin
+    C->>S2: Run callback + Conclude
     S1--)-C: Ack
     S2--)-C: Ack
     end
 ```
 
-The shared-nothing architecture of Dragonfly does not allow accessing each shard data directly from a coordinator fiber. Instead, the coordinator sends messages to the shards and instructs them what to do at each step. Every time, the coordinator sends a message, it blocks until it gets an answer. We call such interaction a *message hop* or a *hop* in short.
+A transaction proceeds in two phases:
 
-The flow consists of two different phases: *scheduling* a transaction, and *executing* it. The execution phase may consist of one or more hops, depending on the complexity of the operation we model.
+1. **Scheduling** - The coordinator reserves a slot for the transaction in each shard's transaction queue (tx-queue) and acquires intent locks on the relevant keys.
+2. **Execution** - The coordinator dispatches one or more hop callbacks. Each hop runs in parallel across the involved shards. On the final hop, shards release locks and remove the transaction from the tx-queue.
 
-*Note, that only the coordinator fiber is blocked. Its thread can still execute other fibers - like processing requests on other connections or handling operations for the shard it owns. This is the advantage of adopting fibers - they allow us to separate the execution context from OS threads.*
+Only the coordinator *fiber* blocks while waiting for shard responses. Its underlying OS thread continues running other fibers (other client connections, shard operations), so a blocked coordinator does not stall the system.
 
-## Scheduling a transaction
+---
 
-The transaction initiates with a scheduling hop, during which the coordinator sends to each shard the keys that shards handle. The coordinator sends messages to multiple shards asynchronously but it waits until all shards ack and confirm that the scheduling succeeded before it proceeds to the next steps.
+## Core Concepts
 
-When the scheduling message is processed by a data shard, it adds the transaction to its local transaction queue (tx-queue). In order to provide serializability, i.e. to make sure that all shards order their scheduled transactions in the same order, Dragonfly maintains a global sequence counter that is used to induce a total order for all its transactions.
+### Global Sequence Counter (TxId)
 
-This global counter is shared by all coordinator entities and is represented by an atomic integer. *This counter may be a source of contention - it breaks the shared nothing model, after all. However, in practice, we have not observed a significant impact on Dragonfly performance due to other optimizations we added. These will be detailed in the [Optimization](#optimizations) section below.
+Dragonfly maintains a global atomic counter (`op_seq`) that can assign each transaction a monotonically increasing ID (`TxId`). This TxId establishes a **total order** across transactions that need it: every shard orders its tx-queue by TxId, so all shards agree on the same logical execution order.
 
-Transactions in tx-queue in each shard are arranged by their sequence counter.
+However, **the majority of transactions never allocate a TxId**. Most Redis workloads consist of single-key or single-shard commands. When such a transaction runs on an uncontended key, it takes the optimistic fast path: the callback executes inline during scheduling, locks are acquired and released immediately, and the transaction never enters the tx-queue. Since there is no queue insertion, there is no need for a TxId. The global counter is only incremented when a transaction actually needs ordering — multi-shard transactions, or single-shard transactions that encounter contention and must be enqueued. This keeps the atomic counter, which is a point of contention in an otherwise shared-nothing architecture, off the critical path for the common case.
 
-As shown in the snippet below, a shard thread may receive transactions in a different sequence, so a transaction with a smaller id can be added to the tx-queue after a transaction with a larger id. If the scheduling algorithm running on the data shard, can not reorder the last added transaction, it fails the scheduling request. In that case, the coordinator reverts the scheduling operation by removing the tx from the shards, and retries the whole hop again by allocating a new sequence number. In reality the fail-rate of a scheduling attempt is low and the retries are rare (subject to contention on the keys). Note, inconsistent reordering happens when two coordinators try to schedule multi-shard transactions concurrently:
+### Transaction Queue (tx-queue)
+
+Each shard maintains a `TxQueue`, a circular doubly-linked list ordered by TxId. The tx-queue determines the execution order on that shard: transactions run in TxId order. A transaction is inserted into the tx-queue during scheduling and removed after its final execution hop.
+
+### Intent Locks
+
+Each shard maintains a `LockTable` that maps key fingerprints (`LockFp`) to `IntentLock` counters. An `IntentLock` has two counters: one for SHARED intent and one for EXCLUSIVE intent. When a transaction is scheduled on a shard, it increments the appropriate counter for each of its keys.
+
+Intent locks do **not** block the scheduling flow. They record how many pending transactions intend to read or write a key. For example, if `lock[fp(key)]` has an exclusive count of 2, two transactions in the tx-queue plan to modify that key.
+
+Intent locks serve two purposes:
+- **Out-of-order optimization**: A transaction can safely execute ahead of its queue position if it holds the lock and the lock is uncontended.
+- **Contention detection**: `IntentLock::IsContended()` reports whether a key has conflicting intent (multiple exclusive, or mixed shared/exclusive), which determines whether out-of-order execution is safe.
+
+### Key Fingerprints
+
+Keys are hashed to `LockFp` (64-bit fingerprints) for lock table lookups. Fingerprints are computed from `LockTag` values, which determine lock granularity.
+
+Fingerprint collisions do not affect correctness. If two unrelated keys happen to hash to the same `LockFp`, the lock table treats them as contended, which disables out-of-order execution for those transactions. The result is a fallback to the slower ordered-queue path — a performance penalty, not a correctness violation. With 64-bit fingerprints, such collisions are exceedingly rare in practice.
+
+---
+
+## Scheduling a Transaction
+
+Scheduling acquires intent locks on the transaction's keys and, when ordering is needed, inserts the transaction into each shard's tx-queue. On the common fast path (single-shard, uncontended), the transaction completes during scheduling without ever entering the tx-queue.
+
+### Single-shard uncontended path (the common case)
+
+Most transactions target a single shard and operate on uncontended keys. These take a fast path that avoids the global counter and the tx-queue entirely:
+
+1. The coordinator dispatches a scheduling message to the single target shard (via a per-shard MPSC queue for batching).
+2. On the shard, `ScheduleInShard()` acquires intent locks on the transaction's keys.
+3. If the keys are uncontended and the transaction is concluding (single hop), the callback executes **inline during scheduling** — the `OPTIMISTIC_EXECUTION` flag is set, locks are released immediately, and the function returns. No TxId is allocated, no tx-queue insertion occurs.
+4. The coordinator is unblocked and the transaction is complete.
+
+This is the dominant path. It requires no global synchronization, no queue management, and no cross-thread coordination beyond the single dispatch message.
+
+### Multi-shard path
+
+When a transaction spans multiple shards, it must be ordered relative to other multi-shard transactions:
+
+1. The coordinator allocates a `TxId` from the global sequence counter.
+2. It dispatches a scheduling message to each relevant shard.
+3. On each shard, `ScheduleInShard()`:
+   - Acquires intent locks on the transaction's keys via `DbSlice::Acquire()`.
+   - Checks ordering: if the tx-queue is non-empty and the new TxId is smaller than the tail (a late arrival), the shard attempts to insert it in order. If the transaction's keys are contended with a conflicting later transaction, scheduling fails.
+   - On success, inserts the transaction into the tx-queue and records its position.
+4. The coordinator waits for all shards to acknowledge.
+5. If any shard fails scheduling (ordering conflict), the coordinator reverts all shards and retries with a new TxId.
+
+### Single-shard contended path
+
+When a single-shard transaction encounters contention (keys are locked by another transaction), the optimistic execution cannot proceed. In this case, the transaction falls back to the multi-shard-like path: it allocates a TxId (deferred until this point), inserts into the tx-queue, and waits for its turn.
+
+### Scheduling failures and retries
+
+The failure/retry scenario arises from message ordering non-determinism in multi-shard scheduling:
 
 ```
-C1: enqueue msg to Shard1 to schedule T1
-C2: enqueue msg to Shard1 to schedule T2  # enqueued earlier than C1
-
-C1: enqueue msg to Shard2 to schedule T1
-C2: enqueue msg to Shard2 to schedule T2 # enqueued later than C1
-
-shard1: pull T2, add it to TxQueue, pull T1, add it to TxQueue
-shard2: pull T1, add it to TxQueue, pull T2, add it to TxQueue
-
-TxQueue1: T2, T1  # wrong order
-TxQueue2: T1, T2
+Coordinator C1 schedules T1 (TxId=5), C2 schedules T2 (TxId=6).
+Messages arrive:
+  Shard 1: T2 first, then T1   -> queue: [T1, T2] (reordered by TxId, OK if uncontended)
+  Shard 2: T1 first, then T2   -> queue: [T1, T2]
 ```
 
+If T1 and T2 contend on the same keys, the late-arriving T1 on Shard 1 cannot be safely inserted before an already-positioned T2. In that case, scheduling fails and is retried with a fresh TxId. In practice, retries are rare because most transactions touch disjoint keys.
 
-Once the transaction is added to the tx-queue, the shard also marks the tx-keys using the *intent* locks. Those locks do not block the flow of the underlying operation but merely express the intent to touch or modify the key. In reality, they are represented by a map: `lock:str->counter`. If `lock[key] == 2` it means the tx-queue has 2 pending transactions that plan to modify `key`. These intent locks are used for optimizations detailed below and are not required to implement the naive version of VLL algorithm.
+### Lock modes
 
-Once the scheduling hops converges, it means that the transaction entered the execution phase, in which it never rollbacks, or retries. Once it's been scheduled, VLL guarantees the progress of subsequent execution operations while providing strict-serializability guarantees.
+A transaction's lock mode is determined by its command:
+- **SHARED** for read-only commands (GET, MGET, EXISTS, etc.)
+- **EXCLUSIVE** for write commands (SET, DEL, etc.)
 
-It's important to note that a scheduled transaction does not hold exclusivity on its keys. There could be other transactions that still mutate the keys it touches - these transactions were scheduled earlier and have not finished running yet, or even have not even started running.
+Multiple SHARED locks can coexist. EXCLUSIVE locks conflict with any other lock.
 
-## Executing a transaction
+---
 
-Once the transaction is scheduled, the coordinator starts sending the execution messages. We break each command to one or more micro-ops and each operation corresponds to a single message hop.
+## Executing a Transaction
 
-For example, "MSET" corresponds to a single micro-op "mset" that has the same semantics, but runs in parallel on all the involved shards.
+Once scheduled, a transaction never rolls back or retries. VLL guarantees forward progress: the transaction will eventually reach the head of the tx-queue on every shard, at which point it can execute.
 
-However, "RENAME" requires two micro-ops: fetching the data from two keys, and then the second hop - deleting/writing a key (depending whether the key is a source or a destination).
+### Hop execution
 
-Once a coordinator sends the micro-op request to all the shards, it waits for an answer. Only when all shards executed the micro-op and return the result, the coordinator is unblocked and it can proceed to the next hop. The coordinator is allowed to process the intermediary responses from the previous hops in order to define the next execution request.
+For each hop, the coordinator:
 
-When a coordinator sends an execution request to data shards, it also specifies whether
-this execution is the last hop for that command. This is necessary, so that shards could do clean-up operations when running the last execution request: unlocking the keys and removing the transaction from the tx-queue.
+1. Arms all active shards by setting `PerShardData::is_armed = true`.
+2. Submits a `PollExecution` callback to each shard.
+3. Waits on `run_barrier_` (a blocking counter) until all shards complete.
 
-The shards always execute transactions at the head of the tx-queue. When the last execution hop for that transaction is executed the transaction is removed from the queue and the next one can be executed. This way we maintain the ordering guarantees specified by the scheduling order of the transactions and we maintain
-the serializability of operations across multiple shards.
+On each shard, `PollExecution` checks whether the transaction is at the head of the tx-queue (or can run out of order). If so, it calls `RunInShard()`, which:
 
-## Multi-op transactions (Redis transactions)
+1. Executes the hop callback (`cb_ptr_`).
+2. If this is the final hop (the coordinator set COORD_CONCLUDING):
+   - Releases intent locks via `DbSlice::Release()`.
+   - Removes the transaction from the tx-queue.
+3. Decrements `run_barrier_` to signal completion.
 
-Redis transactions (MULTI/EXEC sequences) and commands produced by Lua scripts are modelled as consecutive commands within a Dragonfly transaction. In order to avoid ambiguity with terms, we call a Redis transaction - a multi-transaction in Dragonfly.
+### Examples
 
-The multi feature of the transactional framework allows running consecutive commands without rescheduling the transaction for each command as if they are part of one single transaction. This feature is transparent to the commands itself, so no changes are required for them to be used in a multi-transaction.
+**MSET key1 val1 key2 val2** (keys on different shards): One scheduling hop + one execution hop. The execution callback writes each key on its respective shard in parallel.
 
-There are three modes called "multi modes" in which a multi transaction can be executed, each with its own benefits and drawbacks.
+**RENAME src dst** (keys potentially on different shards): One scheduling hop + two execution hops. Hop 1 reads `src` and `dst` from their shards. The coordinator processes intermediate results. Hop 2 deletes `src` and writes `dst`.
 
-__1. Global mode__
-
-The transaction is equivalent to a global transaction with multiple hops. It is scheduled globally and the commands are executed as a series of consecutive hops. This mode is required for global commands (like MOVE) and for accessing undeclared keys in Lua scripts. Otherwise, it should be avoided, because it prevents Dragonfly from running concurrently and thus greatly decreases throughput.
-
-__2. Lock ahead mode__
-
-The transaction is equivalent to a regular transaction with multiple hops. It is scheduled on all keys used by the commands in the transaction block, or Lua script, and the commands are executed as a series of consecutive hops.
-
-__3. Non atomic mode__
-
-All commands are executed as separate transactions making the multi-transaction not atomic. It vastly improves the throughput with contended keys, as locks are acquired only for single commands. This mode is useful for Lua scripts without atomicity requirements.
-
-## Multi-op command squashing
-
-There are two fundamental problems to executing a series of consecutive commands on Dragonfly:
-* each command invocation requires an expensive hop
-* executing commands sequentially makes no use of our multi-threaded architecture
-
-Luckily we can make one important observation about command sequences. Given a sequence of commands _where each command needs to access only a single shard_, we can conclude that as long as they are part of one atomic transaction:
-* each command needs to preserve its order only relative to other commands accessing the same shard
-* commands accessing different shards can run in parallel
-
-The basic idea behind command squashing is identifying consecutive series of single-shard commands and separating them by shards, while maintaing their relative order whitin each shard. Once the commands are separated, we can execute a single hop on all relevant shards. Within each shard the hop callback will execute one by one only those commands, that assigned to its respective shard. Because all commands are already placed on their relevant threads, no further hops are required and all command callbacks are executed inline.
-
-Reviewing our initial problems, command squashing:
-* Allows executing many commands with only one hop
-* Allows executing commands in parallel
+---
 
 ## Optimizations
-Out of order transactions - TBD
 
-## Blocking commands (BLPOP)
+### Single-shard fast path
 
-Redis has a rich api with around 200 commands. Few of those commands provide blocking semantics, which allow using Redis as publisher/subscriber broker.
+As described in [Scheduling a Transaction](#scheduling-a-transaction), single-shard transactions on uncontended keys bypass the global sequence counter, the tx-queue, and the separate execution phase entirely. The callback runs inline during scheduling. This is the most important optimization in the system: it means the vast majority of real-world commands execute with minimal overhead — a single message to the target shard, an inline callback, and done.
 
-Redis (when running as a single node) is famously single threaded, and all its operations are strictly serializable. In order to build a multi-threaded memory store with the equivalent semantics as Redis, we had to design an algorithm that can parallelize potentially blocking operations and still provide strict serializability guarantees. This section focuses mainly on how to solve this challenge for BLPOP (BRPOP) command since it involves coordinating multiple keys and is considered the more complicated case. Other blocking commands can benefit from the same principles.
+Additionally, single-shard scheduling messages are buffered in per-shard MPSC queues. `ScheduleBatchInShard()` drains multiple transactions in a single shard callback, amortizing the per-message dispatch cost.
 
+### Out-of-order execution
 
-### BLPOP spec
+The basic VLL algorithm processes transactions strictly in tx-queue order. The VLL paper addresses this limitation with Selective Contention Analysis (SCA), which scans the queue for blocked transactions whose locks have become available and unblocks them ahead of turn.
 
-BLPOP key1 key2 key3 0
+Dragonfly implements a similar idea using intent locks: a transaction can execute **out of order** (ahead of earlier transactions in the queue) if its keys are uncontended. Specifically, during scheduling, if the shard lock is free and all key locks are acquired without conflict, the `OUT_OF_ORDER` flag is set. This allows the transaction to run immediately without waiting for all preceding transactions to complete.
 
-*BLPOP is a blocking list pop primitive. It is the blocking version of LPOP because it blocks the client connection when there are no elements to pop from any of the given lists. An element is popped from the head of the first list that is non-empty, with the given keys being checked in the order that they are given.*
+Out-of-order execution is safe because it only happens when there is no conflict with any other pending transaction on the same keys. If a key's `IntentLock` is contended (another transaction holds a conflicting intent), the transaction must wait for its turn at the head of the queue.
 
-### Non-blocking behavior of BLPOP
-When BLPOP is called, if at least one of the specified keys contains a non-empty list, an element is popped from the head of the list and returned to the caller together with the key it was popped from. Keys are checked in the order that they are given. Let's say that the key1 doesn't exist and key2 and key3 hold non-empty lists. Therefore, in the example above, BLPOP returns the element from list2.
+### Inline execution
 
-### Blocking behavior
-If none of the specified keys exist, BLPOP blocks the connection until another client performs a LPUSH or RPUSH operation against one of the keys. Once new data is present on one of the lists, the client returns with the name of the key unblocking it and the popped value.
+When a coordinator fiber happens to run on the same thread as its target shard, Dragonfly can skip the message dispatch entirely and call `ScheduleInShard()` and `PollExecution()` directly on the coordinator fiber. This is called **inline execution** (`CanRunInlined()`). It avoids the overhead of posting to the shard's message queue, which is significant for high-throughput single-shard workloads.
 
-### Ordering semantics
-If a client tries to wait on multiple keys, but at least one key contains elements, the returned key / element pair is the first key from left to right that has one or more elements. In this case the client will not be blocked. So for instance, BLPOP key1 key2 key3 key4 0, assuming that both key2 and key4 are non-empty, will always return an element from key2.
+However, inline execution introduces a subtle correctness constraint. Normally, all shard callbacks run on the shard's dedicated queue fiber, which processes them sequentially. This provides a natural guarantee: a transaction callback that is running has exclusive access to the shard until it yields. With inlining, a callback runs on the *coordinator* fiber instead. If that callback preempts (e.g., by performing I/O or calling a suspendable operation), the shard queue fiber can pick up another transaction and start executing on the same keys in parallel — violating atomicity.
 
-If multiple clients are blocked for the same key, the first client to be served is the one that was waiting longer (the first that was blocked for the key). Once a client is unblocked it does not retain any priority, when it blocks again with the next call to BLPOP, it will be served according to the queue order of clients already waiting for the same key.
+The core issue is that intent locks only track *intent*, not actual execution. When an inlined transaction suspends mid-callback, the shard queue fiber has no way to know that a callback is already in progress — it only sees that the locks are acquired, and since the inlined transaction may hold the `OUT_OF_ORDER` flag, another transaction on uncontended keys could proceed, or the queue could advance.
 
-When a client is blocking on multiple keys at the same time, and elements are becoming available at the same time in multiple keys (because of a transaction), the client will be unblocked with the first key on the left that received data via push operation (assuming it has enough elements to serve our client, as there could be earlier clients waiting for this key as well).
+For this reason, `CanRunInlined()` is gated on the absence of suspension points:
 
-### BLPOP and transactions
-If multiple elements are pushed either via a transaction or via variadic arguments of LPUSH command then BLPOP is waked after that transaction or command completely finished. Specifically, when a client performs
-`LPUSH listkey a b c`, then `BLPOP listkey 0` will pop `c`, because `lpush` pushes first `a`, then `b` and then `c` which will be the first one on the left.
+- **Journal callbacks disabled**: When replication is active, journal callbacks (`JournalSlice::AddLogRecord`) iterate over registered listeners and may preempt. `AllowInlineScheduling()` returns false if `journal::HasRegisteredCallbacks()` is true.
+- **No DbSlice change callbacks**: `DbSlice::HasRegisteredCallbacks()` must be false, as these callbacks can also preempt.
+- **Not during LOADING state**: During full sync, `RdbLoader` is not transaction-aware, so inlined transactions could interleave with it.
+- **Not global**: Global transactions change the inlining rules themselves, so they always run on the shard queue fiber.
 
-If a client executes a transaction that first pushes into a list and then pops from it atomically, then another client blocked on `BLPOP` won’t pop anything, because it waits for the transaction to finish. When BLPOP itself is run in a transaction its blocking behavior is disabled and it returns the “timed-out” response if there is no element to pop.
+> [!NOTE]
+> This has been a recurring source of design bugs: the assumption that shard callbacks are atomic holds for the normal queue-fiber path, but breaks when an inlined callback preempts. Any new feature that adds preemption points to shard callbacks must either disable inlining or ensure the callback remains non-suspendable.
 
-### Complexity of implementing BLPOP in Dragonfly
-The ordering semantics of BLPOP assume total order of the underlying operations. BLPOP must “observe” multiple keys simultaneously in order to determine which one is non-empty in left-to-right order. If there are no keys with items, BLPOP blocks, waits, and “observes” which key is being filled first.
+### Global transactions
 
-For the single-threaded Redis the order is determined by following the natural execution of operations inside the main execution thread.  However, for a multi-threaded, shared-nothing execution, there is no concept of total order or a global synchronized timeline. For non-blockign scenario, "observing" keys is atomic because we lock the keys when executing a command in Dragonfly.
+Commands that must access all shards (FLUSHDB, FLUSHALL, MOVE, SAVE, etc.) run as **global transactions**. A global transaction acquires the shard-level lock (not individual key locks) on every shard, preventing any other transaction from executing until it completes. Global transactions should be avoided in hot paths because they serialize all shard activity.
 
-However with blocking scenario for BLPOP, we do not have a built-in mechanism to determine which key was filled earlier - since, as stated, the concept of total order does not exist for multiple shards.
+---
 
-### Interesting examples to consider:
+## Multi-op Transactions (MULTI/EXEC, Lua)
 
-**Ex1:**
+Redis transactions (MULTI/EXEC sequences) and Lua scripts execute as a series of commands within a single Dragonfly transaction. We call these **multi-transactions**.
+
+A multi-transaction schedules once and then runs multiple commands as consecutive hops, without rescheduling for each command. Individual commands within the transaction are unaware that they are part of a multi-transaction - the framework handles it transparently.
+
+The flow is:
 ```
-client1: blpop X, Y  // blocks
-client2: lpush X A
-client3: exist X Y
-```
-
-Client3 should always return 0.
-
-**Ex2:**
-
-```
-client1: BLPOP X Y Z
-client2: RPUSH X A
-client3: RPUSH X B;  RPUSH Y B
+trans->StartMulti_<Mode>()
+for each (cmd, args):
+    trans->MultiSwitchCmd(cmd)   // set new command
+    trans->InitByArgs(args)      // re-initialize for new arguments
+    cmd->Invoke(trans)           // execute
+trans->UnlockMulti()
 ```
 
-**Ex3:**
+### Multi modes
+
+**1. Global mode** - Acquires the shard-level lock on all shards. Required for global commands (MOVE, FLUSHDB) and Lua scripts that access undeclared keys. Blocks all concurrent transactions across all shards, so it should be avoided when possible.
+
+**2. Lock-ahead mode** - Pre-locks all keys declared by the transaction (e.g., keys from MULTI/EXEC or declared Lua script keys). Commands run as consecutive hops with locks held throughout. Other transactions touching different keys can still run concurrently.
+
+**3. Non-atomic mode** - Each command schedules and executes independently, as if pipelined. No atomicity guarantee across commands. Useful for Lua scripts that explicitly opt out of atomicity, since it avoids holding locks across the entire sequence.
+
+---
+
+## Command Squashing
+
+Executing commands one-by-one in a multi-transaction has two problems:
+- Each command requires an expensive cross-thread hop.
+- Sequential execution underutilizes the multi-threaded architecture.
+
+**Command squashing** addresses both. Given a consecutive sequence of single-shard commands within an atomic multi-transaction, the framework partitions them by target shard, preserving per-shard order, and executes all shards in a single parallel hop.
+
+Consider a MULTI/EXEC block with six single-shard commands. Without squashing, each runs as a separate hop — six sequential round-trips. With squashing, they are grouped by shard and dispatched in one hop:
 
 ```
-client1: BLPOP X Y Z
-client2: RPUSH Z C
-client3: RPUSH X A
-client4: RPUSH X B; RPUSH Y B
+   MULTI/EXEC block (6 commands)          Squashed execution (1 hop)
+  ─────────────────────────────          ────────────────────────────
+
+  1. SET  user:1  Alice  → Shard 1       ┌─── Shard 1 (stub tx) ───┐
+  2. SET  user:2  Bob    → Shard 2       │ 1. SET user:1 Alice      │
+  3. INCR counter:1      → Shard 1       │ 3. INCR counter:1        │
+  4. SET  user:3  Carol  → Shard 3       │ 6. GET user:1            │
+  5. INCR counter:2      → Shard 2       └────────────────────────  ┘
+  6. GET  user:1         → Shard 1
+                                         ┌─── Shard 2 (stub tx) ───┐
+  Without squashing:                     │ 2. SET user:2 Bob        │
+  6 sequential hops                      │ 5. INCR counter:2        │
+                                         └──────────────────────────┘
+  With squashing:
+  1 parallel hop                         ┌─── Shard 3 (stub tx) ───┐
+                                         │ 4. SET user:3 Carol      │
+                                         └──────────────────────────┘
+
+                                         All three shards run in parallel.
+                                         Per-shard order is preserved.
 ```
 
-### BLPOP Ramblings
-There are two cases of how a key can appear and wake a blocking `BLPOP`:
+Each shard receives a "stub" transaction (`SQUASHED_STUB` role) that provides the standard transaction interface to individual commands without performing real scheduling. The parent transaction (`SQUASHER` role) coordinates the single hop across all shards. Within each shard, the hop callback executes that shard's commands inline, one by one.
 
-a. with lpush/rpush/rename commands.
-b. via multi-transaction.
+---
 
-`(a)` is actually easy to reason about, because those commands operate on a single key and single key operations are strictly serializable in shared-nothing architecture.
+## Blocking Commands (BLPOP)
 
-With `(b)` we need to consider the case where we have "BLPOP X Y 0" and then a multi-transaction fills both `y` and `x` using multiple "lpush" commands. Luckily, a multi-transaction in Dragonfly introduces a global barrier across all its shards, and it does not allow any other transactions to run as long as it does not finish. So the blocking "blpop" won't be awaken until the multi-transaction finishes its run. By that time the state of the keys will be well defined and "blpop" will be able to choose the first non empty key to pop from.
+Commands like BLPOP, BRPOP, and BLMOVE block the client connection until data becomes available. These are the most complex transaction type because they must "observe" multiple keys across shards simultaneously while maintaining strict serializability.
 
+### How blocking works
 
-## Background reading:
+The following diagram shows `BLPOP X Y 0` where key X is on Shard 1 and key Y is on Shard 2, and a second client later pushes to Y:
 
-### Strict Serializability
-Here is a [very nice diagram](https://jepsen.io/consistency) showing how various consistency models relate.
+```mermaid
+%%{init: {'theme':'base'}}%%
+sequenceDiagram
+    participant C1 as BLPOP Coordinator
+    participant S1 as Shard 1 (key X)
+    participant S2 as Shard 2 (key Y)
+    participant C2 as LPUSH Coordinator
 
-Single node Redis is strictly serializable because all its operation are executed sequentially
-and atomically in a single thread.
+    Note over C1: Schedule + check keys
+    par
+    C1->>+S1: Schedule & check X
+    and
+    C1->>+S2: Schedule & check Y
+    S1--)C1: X is empty
+    S2--)C1: Y is empty
+    end
 
-More formally: following the definition from https://jepsen.io/consistency/models/strict-serializable - due to the single threaded design of Redis, its transactions are executed in a global order, which is consistent with the main thread clock, hence it’s strictly serializable.
+    Note over C1: All empty → suspend
+    par Register watches (concluding hop)
+    C1->>S1: WatchInShard(X)
+    and
+    C1->>S2: WatchInShard(Y)
+    Note over S1: Remove from tx-queue,<br/>keep locks
+    Note over S2: Remove from tx-queue,<br/>keep locks
+    S1--)C1: Ack
+    S2--)C1: Ack
+    end
+    Note over C1: Not in any tx-queue.<br/>Locks held, fiber blocks<br/>on BatonBarrier.
 
-Serializability is a global property that given a transaction log, there is an order with which transactions are consistent (the log order is not relevant).
+    Note over C2: Another client: LPUSH Y val
+    C2->>S2: Execute LPUSH Y
 
-Example of serializable but not linearizable transaction: https://gist.github.com/pbailis/8279494
+    S2->>C1: NotifySuspended(Y)<br/>claims BatonBarrier
+    Note over C1: Wakes up, wake_key = Y
 
-More material to read:
-* [Fauna Serializability vs Linearizability](https://fauna.com/blog/serializability-vs-strict-serializability-the-dirty-secret-of-database-isolation-levels)
-* [Jepsen consistency diagrams](https://jepsen.io/consistency)
-* [Strict Serializability definition](https://jepsen.io/consistency/models/strict-serializable)
-* [Example of serializable but not linearizable schedule](https://gist.github.com/pbailis/8279494)
-* [Atomic clocks and distributed databases](https://www.cockroachlabs.com/blog/living-without-atomic-clocks/)
-* [Another cockroach article about consistency](https://www.cockroachlabs.com/blog/consistency-model/)
-* [Abadi blog](http://dbmsmusings.blogspot.com/)
-* [Peter Beilis blog](http://www.bailis.org/blog) (both wrote lots of material on the subject)
+    par Pop from wake key (AWAKED_Q, bypasses tx-queue)
+    C1->>S1: Release locks
+    and
+    C1->>S2: Pop Y, release locks
+    S1--)-C1: Ack
+    S2--)-C1: Ack
+    end
+    Note over C1: Return "Y", "val"
+```
+
+Step by step:
+
+1. BLPOP schedules normally and checks its keys across shards. If any key is non-empty, it pops and returns immediately (not shown above).
+2. If all keys are empty, the transaction executes a concluding hop to register watches on its keys via `BlockingController`. This hop removes the transaction from the tx-queue, but **keeps locks held** (the `became_suspended` path in `RunInShard`). The coordinator fiber then blocks on a `BatonBarrier`. At this point the transaction is not in any tx-queue — it only holds intent locks on its keys.
+3. When a mutating command (LPUSH, RPUSH, etc.) modifies a watched key, the shard calls `NotifySuspended()`. The first notification to successfully claim the `BatonBarrier` wins, recording the wake key.
+4. The coordinator wakes up and re-executes its callback to pop from the wake key. Awakened transactions run with the `AWAKED_Q` flag, which gives them highest priority in `PollExecution` — they bypass the tx-queue entirely. Locks are released on this final hop.
+5. If the timeout expires before any notification, `ExpireBlocking()` cleans up instead: releases locks and unregisters watches from `BlockingController`.
+
+### Key design constraints
+
+- The suspended transaction holds its locks throughout the blocking period, preventing interleaving with other transactions on the same keys.
+- BLPOP within a MULTI/EXEC block disables blocking behavior and returns immediately (with a timeout response if no data is available).
+- When a multi-transaction pushes to multiple keys atomically, BLPOP is only woken after the entire multi-transaction completes.
+
+---
+
+## Further Reading
+
+- [VLL: a lock manager redesign for main memory database systems](https://www.cs.umd.edu/~abadi/papers/vldbj-vll.pdf) - The paper Dragonfly's transaction model is based on.
+- [Jepsen consistency models](https://jepsen.io/consistency) - Diagram of consistency model relationships.
+- [Strict Serializability](https://jepsen.io/consistency/models/strict-serializable) - Formal definition.
+- [Serializability vs Strict Serializability](https://fauna.com/blog/serializability-vs-strict-serializability-the-dirty-secret-of-database-isolation-levels)


### PR DESCRIPTION
## Summary

- Restructure docs/transaction.md into modular sections with table of contents
- Align with actual code: IntentLock counters, LockFp fingerprints, BatonBarrier, optimistic execution
- Document that most transactions never allocate a TxId (single-shard uncontended fast path)
- Fill in previously TBD "Optimizations" section (out-of-order execution, batch scheduling)
- Add ASCII diagram for command squashing and mermaid sequence diagram for BLPOP blocking flow
- Trim verbose definitions, BLPOP spec dump, and stale "ramblings" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

I find it easier to look at the rendered file than on the diff:

https://github.com/dragonflydb/dragonfly/blob/8e196cee567991d31faa38aa8d2a3d4eee3a1a65/docs/transaction.md