### PR TITLE
chore(core): Re-enable container iterations yielding

### DIFF
--- a/src/server/container_utils.cc
+++ b/src/server/container_utils.cc
@@ -24,7 +24,7 @@ extern "C" {
 #include "redis/util.h"
 }
 
-ABSL_FLAG(uint32_t, container_iteration_yield_interval_usec, 0,
+ABSL_FLAG(uint32_t, container_iteration_yield_interval_usec, 500,
           "Yield the fiber every N microseconds during container iteration. "
           "0 disables yielding.");
 

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -2053,8 +2053,6 @@ TEST_F(GenericFamilyTest, RmDeletesMatchingKeys) {
 // behavior is expected for other containers (SET, HASH, LIST) with non
 // listpack encodings.
 TEST_F(GenericFamilyTest, ContainerIterationYields) {
-  GTEST_SKIP() << "Until --container_iteration_yield_interval_usec is re-enabled";
-
   // Build a large sorted set that will be encoded as SKIPLIST.
   constexpr int N = 500'000;
   for (int start = 0; start < N; start += 1'000) {
@@ -2083,6 +2081,60 @@ TEST_F(GenericFamilyTest, ContainerIterationYields) {
 
   // Iteration should yield at least once during long-running execution.
   EXPECT_GT(delta, 0);
+}
+
+// Verifies that a yielding container iteration observes a consistent view.
+// While LRANGE iterates over a large list and yields, a concurrent fiber
+// performs RPUSH operations. The returned result must remain consistent with
+// the list state at the start of LRANGE.
+TEST_F(GenericFamilyTest, ConcurrentWritesDuringContainerYield) {
+  constexpr int kListSize = 50'000;
+  constexpr int kIterations = 25;
+  const char* key = "list1";
+  constexpr int kBatch = 1'000;
+
+  vector<string> batch_args = {"RPUSH", key};
+  batch_args.insert(batch_args.end(), kBatch, "A");
+  for (int start = 0; start < kListSize; start += kBatch) {
+    Run(absl::Span<const string>(batch_args));
+  }
+
+  atomic_bool done{false};
+  uint64_t total_yields = 0;
+
+  // LLEN is executed immediately before LRANGE, so it reflects the list size
+  // seen by LRANGE at start. Even if LRANGE yields during iteration, the
+  // returned result should remain consistent.
+  auto reader = pp_->at(0)->LaunchFiber([&] {
+    for (int i = 0; i < kIterations; i++) {
+      size_t expected_size = *Run("reader", {"LLEN", key}).GetInt();
+      uint64_t preempt_before = ThisFiber::GetPreemptCount();
+      auto resp = Run("reader", {"LRANGE", key, "0", "-1"});
+      total_yields += ThisFiber::GetPreemptCount() - preempt_before;
+      EXPECT_EQ(StrArray(resp).size(), expected_size);
+    }
+    done.store(true);
+  });
+
+  // Writer in same shard.
+  auto writer_same_shard = pp_->at(0)->LaunchFiber([&] {
+    while (!done.load()) {
+      Run("writer_same_shard", {"RPUSH", key, "B"});
+    }
+  });
+
+  // Writer from differnt shard.
+  auto writer_different_shard = pp_->at(1)->LaunchFiber([&] {
+    while (!done.load()) {
+      Run("writer_different_shard", {"RPUSH", key, "C"});
+    }
+  });
+
+  reader.Join();
+  writer_same_shard.Join();
+  writer_different_shard.Join();
+
+  EXPECT_GT(total_yields, 0);
 }
 
 // Regression test for SORT BY nosort STORE inside MULTI/EXEC does a


### PR DESCRIPTION
Re-enable `container_iteration_yield_interval_usec` and set back to 500us.

Verify that a container iteration command returns a consistent result even
when it yields and concurrent writes are issued at the same time.

The test runs LRANGE on a large list while other fibers continuously perform
RPUSH operations and verifies that each LRANGE result matches the list state
observed when the command started.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
