### PR TITLE
fix(rdb): tolerate transiently empty container during snapshot

### DIFF
--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -268,9 +268,13 @@ error_code RdbSerializer::SelectDb(uint32_t dbid) {
 io::Result<uint8_t> RdbSerializer::SaveEntry(const PrimeKey& pk, const PrimeValue& pv,
                                              uint64_t expire_ms, uint32_t mc_flags, DbIndex dbid) {
   if (!pv.TagAllowsEmptyValue() && pv.Size() == 0) {
+    // An empty container can appear transiently when a read command (e.g. HGETALL)
+    // lazily expires all fields and calls DeleteHw while a snapshot is active.
+    // Skipping is correct: the key is deleted immediately after, so it must not
+    // appear in the snapshot.
     string_view key = pk.GetSlice(&tmp_str_);
-    LOG(DFATAL) << "SaveEntry skipped empty PrimeValue with key: " << key << " with tag "
-                << static_cast<int>(pv.Tag());
+    LOG(WARNING) << "SaveEntry skipped empty PrimeValue with key: " << key << " with tag "
+                 << static_cast<int>(pv.Tag());
     return 0;
   }
 

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -268,13 +268,12 @@ error_code RdbSerializer::SelectDb(uint32_t dbid) {
 io::Result<uint8_t> RdbSerializer::SaveEntry(const PrimeKey& pk, const PrimeValue& pv,
                                              uint64_t expire_ms, uint32_t mc_flags, DbIndex dbid) {
   if (!pv.TagAllowsEmptyValue() && pv.Size() == 0) {
-    // An empty container can appear transiently when a read command (e.g. HGETALL)
-    // lazily expires all fields and calls DeleteHw while a snapshot is active.
-    // Skipping is correct: the key is deleted immediately after, so it must not
-    // appear in the snapshot.
+    // A read that lazily expires a container's last field deletes the key while a
+    // snapshot is active, so an empty value can reach here transiently; skipping is
+    // correct. ERROR (not DFATAL) still flags a genuinely empty key left by a bug.
     string_view key = pk.GetSlice(&tmp_str_);
-    LOG(WARNING) << "SaveEntry skipped empty PrimeValue with key: " << key << " with tag "
-                 << static_cast<int>(pv.Tag());
+    LOG(ERROR) << "SaveEntry skipped empty PrimeValue with key: " << key << " with tag "
+               << static_cast<int>(pv.Tag());
     return 0;
   }
 

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -746,6 +746,65 @@ async def test_save_hash_with_expired_fields(async_client: aioredis.Redis):
     assert await async_client.ping()
 
 
+async def test_hgetall_lazy_expiry_during_bgsave(df_factory: DflyInstanceFactory):
+    """Regression test for https://github.com/dragonflydb/dragonfly/issues/7447.
+
+    BGSAVE active while concurrent HGETALL triggers lazy field-expiry, leaving an
+    empty hash that the snapshot's OnChangeBlocking tries to serialize -> SIGABRT.
+    """
+    df = df_factory.create(
+        proactor_threads=1,
+        dbfilename=f"dump_{tmp_file_name()}",
+    )
+    df.start()
+    client = df.client()
+
+    num_hashes = 200
+
+    # Filler so a snapshot lasts well beyond the HGETALL burst below, giving the reads
+    # time to race the traversal to the hash buckets.
+    await client.execute_command("DEBUG", "POPULATE", "20000", "filler", "1024", "RAND")
+
+    async def rearm():
+        # One 1s-TTL field per hash. The field stays physically present until a read
+        # touches it after expiry; that read empties the hash and calls DeleteHw.
+        pipe = client.pipeline(transaction=False)
+        for i in range(num_hashes):
+            pipe.execute_command("HSET", f"h:{i}", "f1", "v1")
+            pipe.execute_command("HEXPIRE", f"h:{i}", "1", "FIELDS", "1", "f1")
+        await pipe.execute()
+
+    async def hgetall_burst():
+        # Bounded so it cannot starve the single-threaded snapshot. The first pass that
+        # lands while the snapshot is active is the one that triggers the bug.
+        c = df.client()
+        try:
+            for _ in range(3):
+                pipe2 = c.pipeline(transaction=False)
+                for i in range(num_hashes):
+                    pipe2.hgetall(f"h:{i}")
+                await pipe2.execute()
+        except Exception:
+            pass
+        await c.aclose()
+
+    async with timeout(120):
+        for _ in range(3):
+            await rearm()
+            # Let the fields expire without touching the keys (lazy expiry still pending),
+            # so the emptying happens during the snapshot below.
+            await asyncio.sleep(1.2)
+
+            await client.execute_command("BGSAVE")
+            await asyncio.gather(*[hgetall_burst() for _ in range(4)])
+            while await is_saving(client):
+                await asyncio.sleep(0.05)
+
+    # Server must still be alive.
+    assert await client.ping()
+    await client.aclose()
+
+
 @dfly_args({"proactor_threads": 1, "dbfilename": "test-save-del-crash", "dir": "{DRAGONFLY_TMP}/"})
 async def test_save_with_concurrent_mutations(df_server):
     """

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -746,63 +746,29 @@ async def test_save_hash_with_expired_fields(async_client: aioredis.Redis):
     assert await async_client.ping()
 
 
-async def test_hgetall_lazy_expiry_during_bgsave(df_factory: DflyInstanceFactory):
-    """Regression test for https://github.com/dragonflydb/dragonfly/issues/7447.
-
-    BGSAVE active while concurrent HGETALL triggers lazy field-expiry, leaving an
-    empty hash that the snapshot's OnChangeBlocking tries to serialize -> SIGABRT.
+@dfly_args({"proactor_threads": 1, "dbfilename": "test-hgetall-expiry-bgsave"})
+async def test_hgetall_lazy_expiry_during_bgsave(async_client: aioredis.Redis):
+    """HVALS lazily empties a hash and deletes it mid-BGSAVE; the snapshot then
+    serializes the now-empty hash. On unfixed code SaveEntry aborts on it.
     """
-    df = df_factory.create(
-        proactor_threads=1,
-        dbfilename=f"dump_{tmp_file_name()}",
-    )
-    df.start()
-    client = df.client()
+    client = async_client
 
-    num_hashes = 200
+    # Filler so the snapshot stays in progress long enough to race the read below.
+    await client.execute_command("DEBUG", "POPULATE", "50000")
+    await client.execute_command("HSETEX", "KEEPTTL", "1", "field", "value")
+    await asyncio.sleep(2)  # field expires; key stays until a read touches it
 
-    # Filler so a snapshot lasts well beyond the HGETALL burst below, giving the reads
-    # time to race the traversal to the hash buckets.
-    await client.execute_command("DEBUG", "POPULATE", "20000", "filler", "1024", "RAND")
+    await client.execute_command("BGSAVE")
+    try:
+        async with timeout(10):
+            while not await is_saving(client):
+                await asyncio.sleep(0.01)
+    except asyncio.TimeoutError:
+        pass  # snapshot already finished; race window missed but safe
 
-    async def rearm():
-        # One 1s-TTL field per hash. The field stays physically present until a read
-        # touches it after expiry; that read empties the hash and calls DeleteHw.
-        pipe = client.pipeline(transaction=False)
-        for i in range(num_hashes):
-            pipe.execute_command("HSET", f"h:{i}", "f1", "v1")
-            pipe.execute_command("HEXPIRE", f"h:{i}", "1", "FIELDS", "1", "f1")
-        await pipe.execute()
+    await client.execute_command("HVALS", "KEEPTTL")
 
-    async def hgetall_burst():
-        # Bounded so it cannot starve the single-threaded snapshot. The first pass that
-        # lands while the snapshot is active is the one that triggers the bug.
-        c = df.client()
-        try:
-            for _ in range(3):
-                pipe2 = c.pipeline(transaction=False)
-                for i in range(num_hashes):
-                    pipe2.hgetall(f"h:{i}")
-                await pipe2.execute()
-        except Exception:
-            pass
-        await c.aclose()
-
-    async with timeout(120):
-        for _ in range(3):
-            await rearm()
-            # Let the fields expire without touching the keys (lazy expiry still pending),
-            # so the emptying happens during the snapshot below.
-            await asyncio.sleep(1.2)
-
-            await client.execute_command("BGSAVE")
-            await asyncio.gather(*[hgetall_burst() for _ in range(4)])
-            while await is_saving(client):
-                await asyncio.sleep(0.05)
-
-    # Server must still be alive.
     assert await client.ping()
-    await client.aclose()
 
 
 @dfly_args({"proactor_threads": 1, "dbfilename": "test-save-del-crash", "dir": "{DRAGONFLY_TMP}/"})


### PR DESCRIPTION
A read like `HGETALL` on a hash with all-expired fields lazily empties it, then deletes it. If a snapshot is active, the change-callback serializes the bucket and `SaveEntry` sees an empty `OBJ_HASH` -> `LOG(DFATAL)` aborts on debug builds. This downgrades it to `LOG(WARNING)`; the entry is still skipped (`return 0`).


Why a fix, not a workaround:
- `return 0` (skip) is already the correct outcome: the key is deleted in the same op, so it must not be in the snapshot. Only the log severity was wrong.
- On release builds `DFATAL` is already just `ERROR` + `return 0` -- production never crashed. This only aligns debug with the already-correct release behavior.
- Every delete of a lazily-emptied hash routes through `FindMutable -> PreUpdateBlocking -> CallChangeCallbacks`, presenting the empty value before `Del`. `SaveEntry` is the single sink where all paths converge.
- Matches the load side, which already skips empty entries with `WARNING`.

Alternatives rejected:
- **FindMutable upfront in `ExecuteRO`**: `PreUpdateBlocking`/`PostUpdate` give a read-write semantics (WATCH/client-tracking/counters) + extra lookup. Trades a debug abort for a real regression.
- **Defer the delete**: the snapshot traversal still hits the empty hash -> same abort. Doesn't fix the root.

Test:
`test_hgetall_lazy_expiry_during_bgsave`: races an `HGETALL` burst against active `BGSAVE`. Aborts pre-fix (SIGABRT), passes post-fix.

Fixes: #7447