### PR TITLE
fix: HNSW index building bug on replica

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1319,7 +1319,7 @@ std::optional<ErrorReply> Service::VerifyCommandState(const CommandId& cid, CmdA
   const GlobalState gstate = etl.gstate();
   switch (gstate) {
     case GlobalState::LOADING:
-      allowed_by_state = dfly_cntx.journal_emulated || (cid.opt_mask() & CO::LOADING);
+      allowed_by_state = dfly_cntx.is_replicating || (cid.opt_mask() & CO::LOADING);
       break;
     case GlobalState::SHUTTING_DOWN:
       allowed_by_state = false;

--- a/src/server/rdb_load_context.cc
+++ b/src/server/rdb_load_context.cc
@@ -179,7 +179,6 @@ void LoadSearchCommandFromAux(Service* service, std::string&& def, std::string_v
 
   ConnectionContext cntx{nullptr, acl::UserCredentials{}};
   cntx.is_replicating = true;
-  cntx.journal_emulated = true;
   cntx.skip_acl_validation = true;
   cntx.ns = &namespaces->GetDefaultNamespace();
 

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -1226,15 +1226,20 @@ ShardDocIndex* ShardDocIndices::GetIndex(string_view name) {
 }
 
 void ShardDocIndices::InitIndex(const OpArgs& op_args, std::string_view name,
-                                shared_ptr<const DocIndex> index_ptr) {
+                                shared_ptr<const DocIndex> index_ptr, bool is_journal) {
   auto shard_index = make_unique<ShardDocIndex>(std::move(index_ptr));
   auto [it, _] = indices_.emplace(name, std::move(shard_index));
 
   it->second->InitHnswShardIndices();
 
-  // Don't build while loading, shutting down, etc.
-  // After loading, indices are rebuilt separately
-  if (ServerState::tlocal()->gstate() == GlobalState::ACTIVE)
+  // Build now when ACTIVE, or for a journaled FT.CREATE/FT.ALTER replayed
+  // during a replica's full sync (gstate==LOADING) so AddDoc has an
+  // initialized indices_ to write into. RDB-aux load defers to
+  // PerformPostLoad's RebuildAllIndices, which also re-runs for the journal
+  // case and covers any docs not yet present when this Rebuild started. Other
+  // states (SHUTTING_DOWN, TAKEN_OVER) don't build.
+  const GlobalState gstate = ServerState::tlocal()->gstate();
+  if (gstate == GlobalState::ACTIVE || (gstate == GlobalState::LOADING && is_journal))
     it->second->Rebuild(op_args, &local_mr_);
 
   op_args.GetDbSlice().SetDocDeletionCallback(

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -543,9 +543,8 @@ class ShardDocIndices {
   ShardDocIndex* GetIndex(std::string_view name);
 
   // Init index: create shard local state for given index with given name.
-  // Build if instance is in active state.
   void InitIndex(const OpArgs& op_args, std::string_view name,
-                 std::shared_ptr<const DocIndex> index);
+                 std::shared_ptr<const DocIndex> index, bool is_journal = false);
 
   // Drop index, return the dropped index if it existed or nullptr otherwise
   std::unique_ptr<ShardDocIndex> DropIndex(std::string_view name);

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -1611,9 +1611,10 @@ void CmdFtCreate(CmdArgList args, CommandContext* cmd_cntx) {
   }
 
   auto idx_ptr = make_shared<DocIndex>(std::move(parsed_index).value());
+  const bool is_journal = cmd_cntx->server_conn_cntx()->journal_emulated;
   cmd_cntx->tx()->Execute(
-      [idx_name, idx_ptr](auto* tx, auto* es) {
-        es->search_indices()->InitIndex(tx->GetOpArgs(es), idx_name, idx_ptr);
+      [idx_name, idx_ptr, is_journal](auto* tx, auto* es) {
+        es->search_indices()->InitIndex(tx->GetOpArgs(es), idx_name, idx_ptr, is_journal);
         return OpStatus::OK;
       },
       true);
@@ -1669,9 +1670,10 @@ void CmdFtAlter(CmdArgList args, CommandContext* cmd_cntx) {
 
   // Rebuild index
   // TODO: Introduce partial rebuild
-  auto upd_cb = [idx_name, index_info](Transaction* tx, EngineShard* es) {
+  const bool is_journal = cmd_cntx->server_conn_cntx()->journal_emulated;
+  auto upd_cb = [idx_name, index_info, is_journal](Transaction* tx, EngineShard* es) {
     (void)es->search_indices()->DropIndex(idx_name);
-    es->search_indices()->InitIndex(tx->GetOpArgs(es), idx_name, index_info);
+    es->search_indices()->InitIndex(tx->GetOpArgs(es), idx_name, index_info, is_journal);
     return OpStatus::OK;
   };
   cmd_cntx->tx()->Execute(upd_cb, true);

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -4685,6 +4685,130 @@ async def test_hnsw_external_vector_replication_crash(df_factory: DflyInstanceFa
     await check_all_replicas_finished([c_replica], c_master, timeout=60)
 
 
+async def _ft_num_docs(client, index_name: str) -> int:
+    info = await client.execute_command("FT.INFO", index_name)
+    info_map = dict(zip(info[::2], info[1::2]))
+    return int(info_map["num_docs"])
+
+
+@dfly_args({"proactor_threads": 4})
+@pytest.mark.parametrize(
+    "docs_keep",
+    [
+        pytest.param(2000, id="small"),
+        pytest.param(100_000, id="100k", marks=HNSW_LARGE_MARKS),
+    ],
+)
+async def test_hnsw_multi_replica_with_concurrent_index_ops(
+    df_factory: DflyInstanceFactory, docs_keep: int
+):
+    """
+    Fan-out HNSW replication with a pre-existing index dropped and a new index
+    created shortly after the replicas connect. Verifies doc-count parity and
+    KNN coverage across master and every replica.
+
+    Covers next:
+      - Multiple replicas (3 fan-out)
+      - FT.DROPINDEX of a pre-existing index, 0.5-5s after replicas connect
+      - FT.CREATE of a new index, 0.5-5s after replicas connect
+      - Document-count parity master/replica per surviving index
+      - 100k-document HNSW main index (large variant)
+    """
+    master = df_factory.create()
+    replicas = [df_factory.create(proactor_threads=2) for _ in range(3)]
+    df_factory.start_all([master] + replicas)
+
+    c_master = master.client()
+    c_replicas = [r.client() for r in replicas]
+
+    seeder_keep = HnswSearchSeeder(
+        num_initial_docs=docs_keep, num_dims=8, index_name="idx_keep", prefix="keep:"
+    )
+    seeder_drop = HnswSearchSeeder(
+        num_initial_docs=1000, num_dims=8, index_name="idx_drop", prefix="drop:"
+    )
+    seeder_new = HnswSearchSeeder(
+        num_initial_docs=500, num_dims=8, index_name="idx_new", prefix="new:"
+    )
+
+    await seeder_keep.create_index(c_master)
+    await seeder_keep.seed_initial_docs(c_master)
+    await seeder_drop.create_index(c_master)
+    await seeder_drop.seed_initial_docs(c_master)
+
+    traffic_task = asyncio.create_task(seeder_keep.run_traffic(c_master))
+    sync_timeout = _hnsw_sync_timeout(docs_keep)
+
+    try:
+        await asyncio.gather(
+            *(c.execute_command(f"REPLICAOF localhost {master.port}") for c in c_replicas)
+        )
+
+        # Drop the pre-existing index and create the new one, each at an
+        # independent random offset in the (0.5, 5)s window after REPLICAOF.
+        # The randomness is intentional: it spreads the ops across the replica's
+        # full-sync window to exercise the indexing race. Log the offsets so a
+        # failure is reproducible.
+        drop_delay = random.uniform(0.5, 5)
+        create_delay = random.uniform(0.5, 5)
+        logging.info(f"drop_delay={drop_delay:.2f}s create_delay={create_delay:.2f}s")
+
+        async def drop_after_delay():
+            await asyncio.sleep(drop_delay)
+            await c_master.execute_command("FT.DROPINDEX", "idx_drop")
+
+        async def create_after_delay():
+            await asyncio.sleep(create_delay)
+            await seeder_new.create_index(c_master)
+            await seeder_new.seed_initial_docs(c_master)
+
+        await asyncio.gather(drop_after_delay(), create_after_delay())
+
+        master_indices = set(await c_master.execute_command("FT._LIST"))
+        assert master_indices == {
+            "idx_keep",
+            "idx_new",
+        }, f"Master indices unexpected: {master_indices}"
+
+        await wait_available_async(c_replicas, timeout=sync_timeout)
+        seeder_keep.stop()
+        await traffic_task
+        await check_all_replicas_finished(c_replicas, c_master, timeout=sync_timeout)
+
+        for c in c_replicas:
+            idx_list = set(await c.execute_command("FT._LIST"))
+            assert idx_list == {"idx_keep", "idx_new"}, f"Unexpected indices: {idx_list}"
+
+        # HNSW background indexing on the replica can lag the journal LSN, so
+        # poll until num_docs converges. Fan out across all (replica × index) pairs.
+        @assert_eventually(timeout=sync_timeout)
+        async def _converged(client, index_name: str, expected: int):
+            actual = await _ft_num_docs(client, index_name)
+            assert actual == expected, f"{index_name}: replica={actual} master={expected}"
+
+        index_to_expected = {
+            name: await _ft_num_docs(c_master, name) for name in ("idx_keep", "idx_new")
+        }
+        await asyncio.gather(
+            *(
+                _converged(c, name, expected)
+                for c in c_replicas
+                for name, expected in index_to_expected.items()
+            )
+        )
+
+        await asyncio.gather(*(seeder_keep.verify(c_master, c) for c in c_replicas))
+        await asyncio.gather(*(seeder_new.verify(c_master, c) for c in c_replicas))
+
+    finally:
+        seeder_keep.stop()
+        traffic_task.cancel()
+        try:
+            await traffic_task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
 async def test_snapshot_load_replication(df_factory: DflyInstanceFactory):
     dbfilename = f"dump_{tmp_file_name()}"
 


### PR DESCRIPTION
fixes: #7244

When `FT.CREATE` was journaled to a replica during the LOADING window of a full sync (i.e. between the snapshot cut and the replica reaching ACTIVE state), the new index was registered but never built: `ShardDocIndices::InitIndex` skipped `Rebuild` whenever `gstate != ACTIVE`, the existing `PerformPostLoad`/`RebuildAllIndices` pass had already run, and there was no later trigger. Subsequent `HSET`s replayed for that index returned `nullopt` in `AddDoc` because `indices_` stayed uninitialized — so the keys existed on the replica, but every `FT.SEARCH` returned zero hits. Silent wrong KNN results until the replica was restarted.

## Fix

`journal_emulated` was previously set by both RDB-aux replay and journal replay, so it couldn't distinguish them. De-conflate:

- `LoadSearchCommandFromAux` no longer sets `journal_emulated`. The LOADING state admission bypass in `main_service.cc` is shifted to `is_replicating`,   which every internal-dispatch path already sets — no behavior change for existing callers.
- `journal_emulated` now means exactly what its name says: the command came from `JournalExecutor` or `Replica::ConsumeRedisStream`.
- `ShardDocIndices::InitIndex` gains a `bool is_journal` parameter. The gate becomes `gstate == ACTIVE || is_journal`: direct dispatch rebuilds, journal replayed `FT.CREATE`/`FT.ALTER` rebuilds (bug fixed), RDB-aux replay defers as before.

## Test

`test_hnsw_multi_replica_with_concurrent_index_ops` (small + 100k variants):

1. On master, create `idx_keep` (HNSW, with traffic) and `idx_drop` (HNSW,  ≥1000 docs) before any replica connects.
2. Connect 3 replicas via `REPLICAOF`.
3. In parallel, 0.5–5 s after the replicas connect: drop `idx_drop`, and create+seed a new HNSW `idx_new` (≥500 docs). Both happen while replicas are still inside the LOADING window.
4. Wait for stable sync.
5. Assert every replica converges to `{idx_keep, idx_new}` with the exact same `num_docs` per index as the master.