### PR TITLE
feat(search): support w'...' glob wildcards on text and tag fields

### DIFF
--- a/src/core/search/ast_expr.h
+++ b/src/core/search/ast_expr.h
@@ -37,6 +37,10 @@ using AstPrefixNode = AstAffixNode<TagType::PREFIX>;
 using AstSuffixNode = AstAffixNode<TagType::SUFFIX>;
 using AstInfixNode = AstAffixNode<TagType::INFIX>;
 
+// Glob pattern from `w'...'` syntax. `affix` holds the verbatim pattern: `*` matches any run of
+// characters, `?` matches exactly one, `\` escapes the next character to a literal.
+using AstWildcardNode = AstAffixNode<TagType::WILDCARD>;
+
 // Quoted multi-word phrase. `raw` is the verbatim content between quotes; the
 // executor runs the shared text tokenizer over it and matches the resulting
 // tokens against posting-list positions.
@@ -123,7 +127,8 @@ struct AstFieldNode {
 
 // Stores a list of tags for a tag query
 struct AstTagsNode {
-  using TagValue = std::variant<AstTermNode, AstPrefixNode, AstSuffixNode, AstInfixNode>;
+  using TagValue =
+      std::variant<AstTermNode, AstPrefixNode, AstSuffixNode, AstInfixNode, AstWildcardNode>;
 
   struct TagValueProxy
       : public AstTagsNode::TagValue {  // bison needs it to be default constructible
@@ -190,9 +195,9 @@ struct AstVectorRangeNode {
 
 using NodeVariants =
     std::variant<std::monostate, AstStarNode, AstStarFieldNode, AstTermNode, AstPrefixNode,
-                 AstSuffixNode, AstInfixNode, AstPhraseNode, AstRangeNode, AstNegateNode,
-                 AstOptionalNode, AstLogicalNode, AstFieldNode, AstTagsNode, AstKnnNode, AstGeoNode,
-                 AstVectorRangeNode>;
+                 AstSuffixNode, AstInfixNode, AstWildcardNode, AstPhraseNode, AstRangeNode,
+                 AstNegateNode, AstOptionalNode, AstLogicalNode, AstFieldNode, AstTagsNode,
+                 AstKnnNode, AstGeoNode, AstVectorRangeNode>;
 
 struct AstNode : public NodeVariants {
   using variant::variant;

--- a/src/core/search/indices.cc
+++ b/src/core/search/indices.cc
@@ -184,6 +184,85 @@ void IterateAllSuffixes(const absl::flat_hash_set<string>& words,
   }
 }
 
+// Literal characters of `pat` up to the first unescaped `*` or `?`. Any term matching `pat` must
+// start with this, so it bounds the dictionary range that has to be scanned.
+string GlobLiteralPrefix(string_view pat) {
+  string prefix;
+  for (size_t i = 0; i < pat.size(); ++i) {
+    char c = pat[i];
+    if (c == '*' || c == '?')
+      break;
+    if (c == '\\' && i + 1 < pat.size())
+      c = pat[++i];
+    prefix.push_back(c);
+  }
+  return prefix;
+}
+
+// Longest run of literal characters in `pat` (bounded by unescaped `*`/`?`), with `\` escapes
+// resolved. Every term matching `pat` must contain this run as a contiguous substring, which the
+// suffix trie can test for a cheap early-exit.
+string GlobLongestLiteralSegment(string_view pat) {
+  string best, cur;
+  auto flush = [&] {
+    if (cur.size() > best.size())
+      best = cur;
+    cur.clear();
+  };
+  for (size_t i = 0; i < pat.size(); ++i) {
+    char c = pat[i];
+    if (c == '*' || c == '?') {
+      flush();
+      continue;
+    }
+    if (c == '\\' && i + 1 < pat.size())
+      c = pat[++i];
+    cur.push_back(c);
+  }
+  flush();
+  return best;
+}
+
+// Matches `text` against glob `pat`: `*` = any run (incl. empty), `?` = exactly one character,
+// `\` escapes the next character to a literal. Two-pointer scan with backtracking to the last `*`.
+// `?` and `*` advance over whole UTF-8 codepoints so single-character matching works on multibyte
+// text; literal bytes in the pattern still match the text byte-for-byte.
+bool GlobMatch(string_view text, string_view pat) {
+  size_t t = 0, p = 0;
+  size_t star_p = string_view::npos;  // pattern index just past the last `*`
+  size_t star_t = 0;                  // text index that `*` is currently matched up to
+  while (t < text.size()) {
+    if (p < pat.size()) {
+      char pc = pat[p];
+      if (pc == '*') {
+        star_p = ++p;
+        star_t = t;
+        continue;
+      }
+      if (pc == '?') {
+        ++p;
+        t += Utf8CodepointLen(text, t);
+        continue;
+      }
+      char lit = (pc == '\\' && p + 1 < pat.size()) ? pat[p + 1] : pc;
+      if (lit == text[t]) {
+        p += (pc == '\\' && p + 1 < pat.size()) ? 2 : 1;
+        ++t;
+        continue;
+      }
+    }
+    if (star_p == string_view::npos)
+      return false;
+    // Extend the last `*` by one codepoint so backtracking stays on character boundaries.
+    p = star_p;
+    star_t += Utf8CodepointLen(text, star_t);
+    t = star_t;
+  }
+  while (p < pat.size() && pat[p] == '*')
+    ++p;
+  return p == pat.size();
+}
+
 // Haversine with earth radius in meters. Used to calculate distance.
 boost::geometry::strategy::distance::haversine haversine_(6372797.560856);
 
@@ -509,6 +588,39 @@ void BaseStringIndex<C>::MatchInfixWithTerm(
     if (entry.first.find(infix) != string::npos)
       cb(entry.first, &entry.second);
   }
+}
+
+template <typename C>
+void BaseStringIndex<C>::MatchWildcardWithTerm(
+    std::string_view pattern,
+    absl::FunctionRef<void(std::string_view term, const Container*)> cb) const {
+  StringOrView pattern_norm{NormalizeQueryWord(pattern)};
+  pattern = pattern_norm.view();
+
+  // Early-exit via the suffix trie: every matching term must contain the pattern's longest literal
+  // segment as a substring, so if no term does, skip the dictionary scan. Mirrors
+  // MatchInfixWithTerm.
+  if (suffix_trie_) {
+    string segment = GlobLongestLiteralSegment(pattern);
+    if (!segment.empty()) {
+      auto it = suffix_trie_->lower_bound(segment);
+      if (it == suffix_trie_->end() || !(*it).first.starts_with(segment))
+        return;
+    }
+  }
+
+  string prefix = GlobLiteralPrefix(pattern);
+  for (auto it = entries_.lower_bound(prefix);
+       it != entries_.end() && (*it).first.starts_with(prefix); ++it) {
+    if (GlobMatch((*it).first, pattern))
+      cb((*it).first, &(*it).second);
+  }
+}
+
+template <typename C>
+void BaseStringIndex<C>::MatchWildcard(std::string_view pattern,
+                                       absl::FunctionRef<void(const Container*)> cb) const {
+  MatchWildcardWithTerm(pattern, [&cb](string_view, const Container* c) { cb(c); });
 }
 
 template <typename C>

--- a/src/core/search/indices.h
+++ b/src/core/search/indices.h
@@ -124,6 +124,14 @@ template <typename C> struct BaseStringIndex : public BaseIndex {
       std::string_view infix,
       absl::FunctionRef<void(std::string_view term, const Container*)> cb) const;
 
+  // Iterate over all nodes whose term matches the glob pattern (`*` = any run of characters,
+  // `?` = exactly one, `\` escapes the next character). Scans entries_, narrowing the range by
+  // the pattern's literal prefix when present.
+  void MatchWildcard(std::string_view pattern, absl::FunctionRef<void(const Container*)> cb) const;
+  void MatchWildcardWithTerm(
+      std::string_view pattern,
+      absl::FunctionRef<void(std::string_view term, const Container*)> cb) const;
+
   // Returns all the terms that appear as keys in the reverse index.
   std::vector<std::string> GetTerms() const;
 

--- a/src/core/search/lexer.lex
+++ b/src/core/search/lexer.lex
@@ -29,6 +29,7 @@
   using dfly::search::TagType;
 
   Parser::symbol_type make_PhraseTok(string_view src, const Parser::location_type& loc);
+  Parser::symbol_type make_Wildcard(string_view src, const Parser::location_type& loc);
   Parser::symbol_type make_Tag(string_view src, TagType type, const Parser::location_type& loc);
   // Strip backslashes from \X sequences in a term.
   string UnescapeTerm(string_view src);
@@ -79,6 +80,15 @@ astrsk_ch  \*
 [0-9]{1,9}                          return Parser::make_UINT32(str(), loc());
 [+-]?(([0-9]*[.])?[0-9]+|inf)       return Parser::make_DOUBLE(str(), loc());
 
+  /* w'...' / w"..." glob wildcard, where `*`/`?` inside are glob metacharacters interpreted at
+     query time. Only a lowercase `w` marks a wildcard; the lexer is case-insensitive, so an
+     uppercase `W` is rewound to a plain term and the quoted part re-scans as a phrase. Longest
+     match wins over the bare `w` term plus a following phrase. */
+w{sq}([^']|{esc_seq})*{sq}            { if (str()[0] != 'w') { matcher().less(1); return Parser::make_TERM(UnescapeTerm(str()), loc()); }
+                                        return make_Wildcard(str(), loc()); }
+w{dq}([^"]|{esc_seq})*{dq}            { if (str()[0] != 'w') { matcher().less(1); return Parser::make_TERM(UnescapeTerm(str()), loc()); }
+                                        return make_Wildcard(str(), loc()); }
+
   /* Quoted phrase, optionally followed by `~N` slop (no whitespace before `~`). With whitespace
      before `~`, the tilde tokenizes separately as the optional-term operator. */
 {dq}([^"]|{esc_seq})*{dq}(~[0-9]+)?   return make_PhraseTok(str(), loc());
@@ -115,6 +125,14 @@ Parser::symbol_type make_PhraseTok(string_view src, const Parser::location_type&
   }
 
   return Parser::make_PHRASE(dfly::search::PhraseTok{string{inner}, slop}, loc);
+}
+
+Parser::symbol_type make_Wildcard(string_view src, const Parser::location_type& loc) {
+  // src is `w'...'` or `w"..."`. Drop the marker and the surrounding quotes, then strip one layer
+  // of `\` escapes (as terms do). The glob matcher interprets any remaining `\`, so `w'a\*'` keeps
+  // `*` a metacharacter while `w'a\\*'` matches a literal `*`.
+  string_view inner = src.substr(2, src.size() - 3);
+  return Parser::make_WILDCARD(UnescapeTerm(inner), loc);
 }
 
 string UnescapeTerm(string_view src) {

--- a/src/core/search/parser.y
+++ b/src/core/search/parser.y
@@ -79,7 +79,7 @@ double toDouble(string_view src);
 
 // Needed 0 at the end to satisfy bison 3.5.1
 %token YYEOF 0
-%token <std::string> TERM "term" TAG_VAL "tag_val" PARAM "param" FIELD "field" PREFIX "prefix" SUFFIX "suffix" INFIX "infix"
+%token <std::string> TERM "term" TAG_VAL "tag_val" PARAM "param" FIELD "field" PREFIX "prefix" SUFFIX "suffix" INFIX "infix" WILDCARD "wildcard"
 %token <PhraseTok> PHRASE "phrase"
 
 %precedence TERM TAG_VAL
@@ -206,6 +206,7 @@ search_unary_expr:
   | PREFIX                            { $$ = AstPrefixNode(std::move($1));   }
   | SUFFIX                            { $$ = AstSuffixNode(std::move($1));   }
   | INFIX                             { $$ = AstInfixNode(std::move($1));    }
+  | WILDCARD                          { $$ = AstWildcardNode(std::move($1)); }
   | UINT32                            { $$ = AstTermNode(std::move($1));     }
   | FIELD COLON field_cond            { $$ = AstFieldNode(std::move($1), std::move($3)); }
 
@@ -222,6 +223,7 @@ field_cond:
   | PREFIX                                              { $$ = AstPrefixNode(std::move($1)); }
   | SUFFIX                                              { $$ = AstSuffixNode(std::move($1)); }
   | INFIX                                               { $$ = AstInfixNode(std::move($1));  }
+  | WILDCARD                                            { $$ = AstWildcardNode(std::move($1)); }
 
 bracket_filter_expr:
   /* Numeric filter has form [(] UINT32|DOUBLE [COMMA] [(] UINT32|DOUBLE */
@@ -291,6 +293,7 @@ field_unary_expr:
   | NOT_OP field_unary_expr     { $$ = AstNegateNode(std::move($2));   }
   | TILDE field_unary_expr      { $$ = AstOptionalNode(std::move($2)); }
   | TERM                        { $$ = AstTermNode(std::move($1));     }
+  | WILDCARD                    { $$ = AstWildcardNode(std::move($1)); }
   | UINT32                      { $$ = AstTermNode(std::move($1));     }
 
 tag_list:
@@ -310,6 +313,7 @@ tag_list_element:
   | PREFIX    { $$ = AstPrefixNode(std::move($1)); }
   | SUFFIX    { $$ = AstSuffixNode(std::move($1)); }
   | INFIX     { $$ = AstInfixNode(std::move($1));  }
+  | WILDCARD  { $$ = AstWildcardNode(std::move($1)); }
   | UINT32    { $$ = AstTermNode(std::move($1));   }
   | DOUBLE    { $$ = AstTermNode(std::move($1));   }
   | TAG_VAL   { $$ = AstTermNode(std::move($1));   }

--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -65,6 +65,7 @@ struct ProfileBuilder {
         [](const AstPrefixNode& n) { return absl::StrCat("Prefix{", n.affix, "}"); },
         [](const AstSuffixNode& n) { return absl::StrCat("Suffix{", n.affix, "}"); },
         [](const AstInfixNode& n) { return absl::StrCat("Infix{", n.affix, "}"); },
+        [](const AstWildcardNode& n) { return absl::StrCat("Wildcard{", n.affix, "}"); },
         [](const AstPhraseNode& n) { return absl::StrCat("Phrase{", n.raw, "}"); },
         [](const AstRangeNode& n) { return absl::StrCat("Range{", n.lo, "<>", n.hi, "}"); },
         [](const AstLogicalNode& n) {
@@ -259,6 +260,8 @@ struct BasicSearch {
         index->MatchSuffixWithTerm(node.affix, term_cb);
       else if constexpr (T == TagType::INFIX)
         index->MatchInfixWithTerm(node.affix, term_cb);
+      else if constexpr (T == TagType::WILDCARD)
+        index->MatchWildcardWithTerm(node.affix, term_cb);
       sub_results.push_back(std::move(per_index));
     }
 
@@ -522,6 +525,9 @@ struct BasicSearch {
                   },
                   [tag_index, this](const AstInfixNode& infix) {
                     return CollectMatches(tag_index, infix.affix, &TagIndex::MatchInfix);
+                  },
+                  [tag_index, this](const AstWildcardNode& wildcard) {
+                    return CollectMatches(tag_index, wildcard.affix, &TagIndex::MatchWildcard);
                   }};
     auto mapping = [ov](const auto& tag) { return visit(ov, tag); };
     return UnifyResults(GetSubResults(node.tags, mapping), LogicOp::OR);
@@ -878,6 +884,8 @@ struct StatsCollector {
         idx->MatchSuffixWithTerm(node.affix, cb);
       else if constexpr (T == TagType::INFIX)
         idx->MatchInfixWithTerm(node.affix, cb);
+      else if constexpr (T == TagType::WILDCARD)
+        idx->MatchWildcardWithTerm(node.affix, cb);
     }
   }
 

--- a/src/core/search/search_parser_test.cc
+++ b/src/core/search/search_parser_test.cc
@@ -544,4 +544,52 @@ TEST_F(SearchParserTest, PhraseParse) {
   EXPECT_TRUE(found_phrase);
 }
 
+TEST_F(SearchParserTest, WildcardLex) {
+  // Lowercase `w` marks a glob; one layer of `\` escapes is stripped at lex time.
+  SetInput("w'hel*'");
+  NEXT_EQ(TOK_WILDCARD, string, "hel*");
+  NEXT_TOK(TOK_YYEOF);
+
+  SetInput(R"(w'hel\*')");
+  NEXT_EQ(TOK_WILDCARD, string, "hel*");
+  NEXT_TOK(TOK_YYEOF);
+
+  SetInput(R"(w'hel\\*')");
+  NEXT_EQ(TOK_WILDCARD, string, R"(hel\*)");
+  NEXT_TOK(TOK_YYEOF);
+
+  SetInput("w\"h?o\"");
+  NEXT_EQ(TOK_WILDCARD, string, "h?o");
+  NEXT_TOK(TOK_YYEOF);
+
+  // Uppercase `W` is not a wildcard: it rewinds to a term followed by a phrase.
+  SetInput("W'HEL*'");
+  NEXT_EQ(TOK_TERM, string, "W");
+  NEXT_PHRASE("HEL*", 0);
+}
+
+TEST_F(SearchParserTest, WildcardParse) {
+  ASSERT_EQ(0, Parse("w'hel*'"));
+  AstExpr root = query_driver_.Take();
+  ASSERT_TRUE(std::holds_alternative<AstWildcardNode>(root));
+  EXPECT_EQ(std::get<AstWildcardNode>(root).affix, "hel*");
+
+  // After a field colon, both bare and parenthesized.
+  ASSERT_EQ(0, Parse("@title:w'h?llo'"));
+  AstExpr field = query_driver_.Take();
+  ASSERT_TRUE(std::holds_alternative<AstFieldNode>(field));
+  ASSERT_TRUE(std::holds_alternative<AstWildcardNode>(*std::get<AstFieldNode>(field).node));
+  ASSERT_EQ(0, Parse("@title:(w'h?llo')"));
+
+  // As a tag value.
+  ASSERT_EQ(0, Parse("@tag:{w'hel*'}"));
+  AstExpr tag_field = query_driver_.Take();
+  ASSERT_TRUE(std::holds_alternative<AstFieldNode>(tag_field));
+  const AstNode& tags = *std::get<AstFieldNode>(tag_field).node;
+  ASSERT_TRUE(std::holds_alternative<AstTagsNode>(tags));
+  const auto& tn = std::get<AstTagsNode>(tags);
+  ASSERT_EQ(tn.tags.size(), 1u);
+  EXPECT_TRUE(std::holds_alternative<AstWildcardNode>(tn.tags[0]));
+}
+
 }  // namespace dfly::search

--- a/src/core/search/tag_types.h
+++ b/src/core/search/tag_types.h
@@ -7,7 +7,7 @@
 namespace dfly {
 namespace search {
 
-enum class TagType { PREFIX, SUFFIX, INFIX, REGULAR };
+enum class TagType { PREFIX, SUFFIX, INFIX, REGULAR, WILDCARD };
 
 }  // namespace search
 }  // namespace dfly

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -5777,6 +5777,53 @@ TEST_F(SearchFamilyTest, PhraseQueryIssue7294) {
   EXPECT_THAT(Run({"FT.SEARCH", "idx_phrase", "\"machine learning\""}), AreDocIds("p:1", "p:3"));
 }
 
+// Glob wildcards via `w'...'`: `*` matches any run of characters, `?` exactly one. Supported on
+// TEXT fields, globally, and inside tag braces.
+TEST_F(SearchFamilyTest, WildcardQuery) {
+  Run({"FT.CREATE", "wq", "SCHEMA", "t", "TEXT", "NOSTEM", "tag", "TAG"});
+  Run({"HSET", "t:1", "t", "hello", "tag", "hello"});
+  Run({"HSET", "t:2", "t", "help", "tag", "help"});
+  Run({"HSET", "t:3", "t", "hero", "tag", "hero"});
+  Run({"HSET", "t:4", "t", "shell", "tag", "shell"});
+
+  EXPECT_THAT(Run({"FT.SEARCH", "wq", "w'hel*'"}), AreDocIds("t:1", "t:2"));
+  EXPECT_THAT(Run({"FT.SEARCH", "wq", "w'*llo'"}), AreDocIds("t:1"));
+  EXPECT_THAT(Run({"FT.SEARCH", "wq", "w'*ell*'"}), AreDocIds("t:1", "t:4"));
+  EXPECT_THAT(Run({"FT.SEARCH", "wq", "w'h?llo'"}), AreDocIds("t:1"));
+  // he?? is two single-char wildcards; raw string keeps it literal without a ??' trigraph.
+  EXPECT_THAT(Run({"FT.SEARCH", "wq", R"(@t:w'he??')"}), AreDocIds("t:2", "t:3"));
+
+  // The pattern is case-insensitive; the marker is not -- an uppercase W is a plain term.
+  EXPECT_THAT(Run({"FT.SEARCH", "wq", "w'HEL*'"}), AreDocIds("t:1", "t:2"));
+  EXPECT_THAT(Run({"FT.SEARCH", "wq", "W'hel*'"}), kNoResults);
+
+  EXPECT_THAT(Run({"FT.SEARCH", "wq", "@tag:{w'hel*'}"}), AreDocIds("t:1", "t:2"));
+  EXPECT_THAT(Run({"FT.SEARCH", "wq", "@tag:{w'*ell*'}"}), AreDocIds("t:1", "t:4"));
+}
+
+// `?` matches a whole UTF-8 codepoint (not a single byte), and results are identical with a suffix
+// trie present (which adds an early-exit path to wildcard matching).
+TEST_F(SearchFamilyTest, WildcardUnicode) {
+  Run({"FT.CREATE", "wu", "SCHEMA", "t", "TEXT", "NOSTEM", "WITHSUFFIXTRIE", "tag", "TAG",
+       "WITHSUFFIXTRIE"});
+  Run({"HSET", "u:1", "t", "кіт", "tag", "кіт"});  // 3 codepoints, 6 bytes
+  Run({"HSET", "u:2", "t", "кит", "tag", "кит"});  // differs in the middle codepoint
+  Run({"HSET", "u:3", "t", "café", "tag", "café"});
+
+  // `?` spans one codepoint: к?т matches both к_т words, ?іт only the one ending in іт.
+  EXPECT_THAT(Run({"FT.SEARCH", "wu", "w'к?т'"}), AreDocIds("u:1", "u:2"));
+  EXPECT_THAT(Run({"FT.SEARCH", "wu", "w'?іт'"}), AreDocIds("u:1"));
+  EXPECT_THAT(Run({"FT.SEARCH", "wu", "w'caf?'"}), AreDocIds("u:3"));
+  EXPECT_THAT(Run({"FT.SEARCH", "wu", "w'кіт'"}), AreDocIds("u:1"));
+
+  // `*` runs and the tag-brace form behave the same with the suffix trie.
+  EXPECT_THAT(Run({"FT.SEARCH", "wu", "w'к*т'"}), AreDocIds("u:1", "u:2"));
+  EXPECT_THAT(Run({"FT.SEARCH", "wu", "@tag:{w'к?т'}"}), AreDocIds("u:1", "u:2"));
+
+  // Early-exit: a literal segment absent from every term yields no match.
+  EXPECT_THAT(Run({"FT.SEARCH", "wu", "w'*xyz*'"}), kNoResults);
+}
+
 // Phrase queries against a NOOFFSETS index surface an error (positions aren't stored).
 TEST_F(SearchFamilyTest, PhraseOnNoOffsetsErrors) {
   Run({"FT.CREATE", "idx_no_off", "NOOFFSETS", "SCHEMA", "t", "TEXT"});


### PR DESCRIPTION
Adds glob wildcard queries via the `w'...'` syntax in `FT.SEARCH` — on TEXT fields, globally, and inside tag braces (`@tag:{w'...'}`). In the pattern `*` matches any run of characters, `?` matches exactly one, and `\` escapes a metacharacter to a literal.

Examples:
```
w'hel*'            prefix
w'*llo'            suffix
w'*ell*'           infix
w'h?llo'           single-character wildcard
@title:w'mach*'    field-scoped
@tag:{w'doc?'}     inside a tag list
```

Details:
- **Lexer**: a lowercase `w` immediately before a quote starts a wildcard token; an uppercase `W` stays a plain term (the quoted part re-scans as a phrase). One layer of `\` escapes is stripped at lex time, so `w'a\*'` keeps `*` a metacharacter while `w'a\\*'` matches a literal `*`.
- **Grammar**: `WILDCARD` is accepted everywhere an affix (prefix/suffix/infix) is — top level, after `@field:`, inside parentheses, and in tag lists. No new shift/reduce or reduce/reduce conflicts.
- **Matching**: two-pointer glob matcher with single-`*` backtracking (`O(text x pattern)`, no catastrophic blowup). `?` and `*` advance over whole UTF-8 codepoints, so single-character matching works on multibyte text. The dictionary scan is bounded by the pattern's literal prefix and short-circuited through the suffix trie when present (same strategy as infix/suffix matching).
- Works for both TEXT (scored) and TAG fields; accepted under any DIALECT.
