### PR TITLE
perf(tx): track running transactions per-shard and enable inline scheduling during replication

### DIFF
--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -614,6 +614,16 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
   ShardId sid = shard_id();
   stats_.poll_execution_total++;
 
+  // If another transaction is currently running on this shard (e.g. an inlined tx preempted
+  // on the connection fiber), we must not run any callbacks to avoid interleaving.
+  if (running_tx_) {
+    // The transaction (if any) if armed, must be in the txq so a future PollExecution picks it up.
+    DCHECK(trans == nullptr || !trans->DEBUG_IsArmedInShard(sid) ||
+           trans->DEBUG_GetTxqPosInShard(sid) != TxQueue::kEnd)
+        << context << " " << trans->DebugId();
+    return;
+  }
+
   // If any of the following flags are present, we are guaranteed to run in this function:
   // 1. AWAKED_Q -> Blocking transactions are executed immediately after waking up, they don't
   // occupy a place in txq and have highest priority

--- a/src/server/engine_shard.h
+++ b/src/server/engine_shard.h
@@ -161,6 +161,14 @@ class EngineShard {
     return continuation_trans_;
   }
 
+  Transaction* running_tx() const {
+    return running_tx_;
+  }
+
+  void set_running_tx(Transaction* tx) {
+    running_tx_ = tx;
+  }
+
   void StopPeriodicFiber();
 
   struct TxQueueItem {
@@ -301,6 +309,7 @@ class EngineShard {
   // Logical ts used to order distributed transactions.
   TxId committed_txid_ = 0;
   Transaction* continuation_trans_ = nullptr;
+  Transaction* running_tx_ = nullptr;
   std::string continuation_debug_id_;
   unsigned poll_concurrent_factor_ = 0;
 

--- a/src/server/serializer_base.cc
+++ b/src/server/serializer_base.cc
@@ -199,22 +199,14 @@ void SerializerBase::WaitForNoBucketBlocked() const {
 }
 
 void SerializerBase::OnChange(DbIndex db_index, const ChangeReq& req) {
-  std::string_view active_name = util::fb2::detail::FiberActive()->name();
-  if (!absl::StartsWith(active_name, "shard_queue") &&  //
-      !absl::StartsWith(active_name, "l2_queue") &&     // pipelining
-      !absl::StartsWith(active_name, "SliceSnapshot") &&
-      !absl::StartsWith(active_name, "DflyConn_") &&  // TOCTOU: connection checks
-                                                      // has_registered_callbacks before save
-                                                      // registers them, schedules inline, then
-                                                      // triggers OnChange on the DflyConn_ fiber
-      active_name != "Dispatched" &&  // Comes from OnAllShards(... { migration->RunSync(); });
-      active_name !=
-          "Debug/Traverse" &&  // DEBUG OBJHIST/UNIQ-STRS cleanup of lazy-expired empty
-                               // containers; runs on the shard proactor so ordering holds.
-      !absl::StartsWith(active_name, "shard_stable_sync_read")  // races with BGSAVE on replica
-  ) {
-    LOG(DFATAL) << "Unexpected fiber: " << active_name << " on " << util::fb2::GetStacktrace();
-  }
+  // OnChangeBlocking can be reached almost from any fiber.
+  // Specifically, they can be called from the following fibers:
+  // 1. shard_queue, SliceSnapshot - trivial.
+  // 2. DflyConn/AsyncFiber - connection fiber that runs an inline transaction.
+  // 3. l2_queue via pipelining.
+  // 4."Debug/Traverse" - DEBUG OBJHIST/UNIQ-STRS delete lazy-expired empty collections.
+  // 5. "Dispatched" -  OnAllShards(... { migration->RunSync(); });
+  // 6. "shard_stable_sync_read" - on replica
 
   // We call Process even for up-to-date buckets to ensure all operations (delayed) are finished.
   for (auto it : req.buckets())

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -189,14 +189,6 @@ bool ServerState::AllowInlineScheduling() const {
   if (gstate_ == GlobalState::LOADING)
     return false;
 
-  // Journal callbacks can preempt; This means we have to disallow inline scheduling
-  // because then we might interleave the callbacks loop from an inlined-scheduled command
-  // and a normally-scheduled command.
-  // The problematic loop is in JournalSlice::AddLogRecord, going over all the callbacks.
-
-  if (journal::HasRegisteredCallbacks())
-    return false;
-
   return true;
 }
 

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -644,6 +644,8 @@ bool Transaction::RunInShard(EngineShard* shard, bool allow_q_removal) {
 
 void Transaction::RunCallback(EngineShard* shard) {
   DCHECK_EQ(shard, EngineShard::tlocal());
+  DCHECK(shard->running_tx() == nullptr);
+  shard->set_running_tx(this);
 
   RunnableResult result;
   try {
@@ -686,6 +688,8 @@ void Transaction::RunCallback(EngineShard* shard) {
     LogAutoJournalOnShard(shard, result);
     MaybeInvokeTrackingCb();
   }
+
+  shard->set_running_tx(nullptr);
 }
 
 // TODO: For multi-transactions we should be able to deduce mode() at run-time based
@@ -727,6 +731,9 @@ void Transaction::ScheduleInternal() {
       // single shard schedule operation can't fail
       CHECK(ScheduleInShard(EngineShard::tlocal(), optimistic_exec));
       run_barrier_.Dec();
+
+      // Drain any work that was deferred while this inlined tx held running_tx_.
+      EngineShard::tlocal()->PollExecution("after_inline", nullptr);
       break;
     }
 
@@ -1005,12 +1012,13 @@ bool Transaction::CancelScheduledTx() {
   });
 
   // Issue PollExecutions to shards that were disarmed
-  auto poll_disarmed = [this, &disarmed_shards](const char* context) {
+  auto poll_disarmed = [this, &disarmed_shards](bool rearm) {
     IterateActiveShards([&](auto& sd, ShardId i) {
       if (disarmed_shards.test(i)) {
         use_count_.fetch_add(1, memory_order_relaxed);
-        shard_set->Add(i, [this, context] {
-          EngineShard::tlocal()->PollExecution(context, this);
+        shard_set->Add(i, [this, rearm] {
+          EngineShard::tlocal()->PollExecution(rearm ? "cancel_rearm" : "cancel_cancel",
+                                               rearm ? this : nullptr);
           intrusive_ptr_release(this);
         });
       }
@@ -1231,8 +1239,12 @@ bool Transaction::ScheduleInShard(EngineShard* shard, bool execute_optimistic) {
 
     DVLOG(3) << "Lock granted " << lock_granted << " for trans " << DebugId();
 
-    // Check if we can run immediately
-    if (lock_granted && execute_optimistic) {
+    // Check if we can run immediately. Skip if another transaction is already running on this shard
+    // (e.g., an inlined tx preempted). While lock_granted ensures no contention on keys, we must
+    // maintain the "running_tx == nullptr" invariant,
+    // since we only track one active transaction per shard.
+    bool immediate_run = execute_optimistic && lock_granted && shard->running_tx() == nullptr;
+    if (immediate_run) {
       sd.local_mask |= OPTIMISTIC_EXECUTION;
       shard->stats().tx_optimistic_total++;
 
@@ -1430,11 +1442,23 @@ OpStatus Transaction::RunSquashedMultiCb(RunnableType cb) {
   auto* shard = EngineShard::tlocal();
   auto& db_slice = GetDbSlice(shard->shard_id());
 
+  // In NON_ATOMIC mode SquashedHopCb is invoked directly, without a wrapping RunCallback,
+  // so this stub owns the running_tx_ slot. In atomic modes (LOCK_AHEAD / GLOBAL) the
+  // parent transaction's RunCallback has already set running_tx_ to itself.
+  bool owns_running_tx = multi_->mode == NON_ATOMIC;
+  if (owns_running_tx) {
+    DCHECK(shard->running_tx() == nullptr);
+    shard->set_running_tx(this);
+  }
+
   auto result = cb(this, shard);
   db_slice.OnCbFinishBlocking();
 
   LogAutoJournalOnShard(shard, result);
   MaybeInvokeTrackingCb();
+
+  if (owns_running_tx)
+    shard->set_running_tx(nullptr);
 
   DCHECK_EQ(result.flags, 0);  // if it's sophisticated, we shouldn't squash it
   return result;
@@ -1601,10 +1625,12 @@ bool Transaction::CanRunInlined() const {
 
   // Global transactions like SAVE can change the inlining rules, so run them non-inlined.
   // This guarantees that their PollExecution batch executes on the shard-queue fiber
-  // when the conditions update
+  // when the conditions update.
+  // We also refuse to inline when another transaction is already running on this shard:
+  // journal/db-slice callbacks invoked from RunCallback can preempt, and a nested inlined
+  // transaction would interleave its own callback loop with the outer one.
   if (unique_shard_cnt_ == 1 && unique_shard_id_ == ss->thread_index() &&
-      ss->AllowInlineScheduling() && !GetDbSlice(es->shard_id()).HasRegisteredCallbacks() &&
-      !IsGlobal()) {
+      ss->AllowInlineScheduling() && !IsGlobal() && es->running_tx() == nullptr) {
     ss->stats.tx_inline_runs++;
     return true;
   }


### PR DESCRIPTION
## Summary

Replace the broad bans on inline scheduling (any registered journal callback, any registered db_slice change callback) with a precise check: inline a transaction only when no other transaction is currently running on this shard.

## Why

The old guards in `ServerState::AllowInlineScheduling` and `Transaction::CanRunInlined` existed because `RunCallback` can preempt inside `LogAutoJournalOnShard` / journal `CallOnChange` and inside db_slice change callbacks. If a second transaction were scheduled inline on the same shard during that suspension, the two callback iterations would interleave and consumers could observe out-of-order updates.

Tracking the running transaction directly lets us keep inline scheduling enabled in the common case (no in-flight callback on this shard) and disable it only while it is actually unsafe — including during replication, where the old `journal::HasRegisteredCallbacks()` check disabled inlining for every command on the master.

## Changes

- `EngineShard` gains `running_tx_` with `running_tx()` / `set_running_tx()`.
- `Transaction::RunCallback` sets/clears `running_tx_` around the callback body.
- `Transaction::RunSquashedMultiCb` sets/clears `running_tx_` **only in `NON_ATOMIC` mode**. In atomic squashing (`LOCK_AHEAD`/`GLOBAL`) the parent transaction runs `SquashedHopCb` via `ScheduleSingleHop` → `RunCallback` and has already set `running_tx_` to itself; the stub must not overwrite it. In `NON_ATOMIC` mode `SquashedHopCb` is invoked directly without a wrapping `RunCallback`, so the stub owns the slot.
- `Transaction::CanRunInlined` now rejects when `es->running_tx() != nullptr` — this is the actual interleaving prevention.
- `ServerState::AllowInlineScheduling` no longer checks `journal::HasRegisteredCallbacks`; `CanRunInlined` no longer checks `DbSlice::HasRegisteredCallbacks` — both are subsumed by the `running_tx_` gate.

Fixes #7457