### PR TITLE
fix(serializer): allow inline-scheduled tx on DflyConn fibers

### DIFF
--- a/src/server/engine_shard.h
+++ b/src/server/engine_shard.h
@@ -167,6 +167,14 @@ class EngineShard {
     return continuation_trans_;
   }
 
+  Transaction* running_tx() const {
+    return running_tx_;
+  }
+
+  void set_running_tx(Transaction* tx) {
+    running_tx_ = tx;
+  }
+
   void StopPeriodicFiber();
 
   struct TxQueueItem {
@@ -307,6 +315,7 @@ class EngineShard {
   // Logical ts used to order distributed transactions.
   TxId committed_txid_ = 0;
   Transaction* continuation_trans_ = nullptr;
+  Transaction* running_tx_ = nullptr;
   std::string continuation_debug_id_;
   unsigned poll_concurrent_factor_ = 0;
 

--- a/src/server/serializer_base.cc
+++ b/src/server/serializer_base.cc
@@ -211,6 +211,7 @@ void SerializerBase::OnChangeBlocking(DbIndex db_index, PrimeTable::bucket_itera
   if (!absl::StartsWith(active_name, "shard_queue") &&  //
       !absl::StartsWith(active_name, "l2_queue") &&     // pipelining
       !absl::StartsWith(active_name, "SliceSnapshot") &&
+      !absl::StartsWith(active_name, "DflyConn") &&  // inline-scheduled tx on connection fiber
       active_name != "Dispatched" &&   // Comes from OnAllShards(... { migration->RunSync(); });
       active_name != "Debug/Traverse"  // DEBUG OBJHIST/UNIQ-STRS cleanup of lazy-expired empty
                                        // containers; runs on the shard proactor so ordering holds.

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -189,14 +189,6 @@ bool ServerState::AllowInlineScheduling() const {
   if (gstate_ == GlobalState::LOADING)
     return false;
 
-  // Journal callbacks can preempt; This means we have to disallow inline scheduling
-  // because then we might interleave the callbacks loop from an inlined-scheduled command
-  // and a normally-scheduled command.
-  // The problematic loop is in JournalSlice::AddLogRecord, going over all the callbacks.
-
-  if (journal::HasRegisteredCallbacks())
-    return false;
-
   return true;
 }
 

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -685,6 +685,8 @@ bool Transaction::RunInShard(EngineShard* shard, bool allow_q_removal) {
 
 void Transaction::RunCallback(EngineShard* shard) {
   DCHECK_EQ(shard, EngineShard::tlocal());
+  DCHECK(shard->running_tx() == nullptr);
+  shard->set_running_tx(this);
 
   RunnableResult result;
   try {
@@ -727,6 +729,8 @@ void Transaction::RunCallback(EngineShard* shard) {
     LogAutoJournalOnShard(shard, result);
     MaybeInvokeTrackingCb();
   }
+
+  shard->set_running_tx(nullptr);
 }
 
 // TODO: For multi-transactions we should be able to deduce mode() at run-time based
@@ -1518,11 +1522,23 @@ OpStatus Transaction::RunSquashedMultiCb(RunnableType cb) {
   auto* shard = EngineShard::tlocal();
   auto& db_slice = GetDbSlice(shard->shard_id());
 
+  // In NON_ATOMIC mode SquashedHopCb is invoked directly, without a wrapping RunCallback,
+  // so this stub owns the running_tx_ slot. In atomic modes (LOCK_AHEAD / GLOBAL) the
+  // parent transaction's RunCallback has already set running_tx_ to itself.
+  bool owns_running_tx = multi_->mode == NON_ATOMIC;
+  if (owns_running_tx) {
+    DCHECK(shard->running_tx() == nullptr);
+    shard->set_running_tx(this);
+  }
+
   auto result = cb(this, shard);
   db_slice.OnCbFinishBlocking();
 
   LogAutoJournalOnShard(shard, result);
   MaybeInvokeTrackingCb();
+
+  if (owns_running_tx)
+    shard->set_running_tx(nullptr);
 
   DCHECK_EQ(result.flags, 0);  // if it's sophisticated, we shouldn't squash it
   return result;
@@ -1689,10 +1705,12 @@ bool Transaction::CanRunInlined() const {
 
   // Global transactions like SAVE can change the inlining rules, so run them non-inlined.
   // This guarantees that their PollExecution batch executes on the shard-queue fiber
-  // when the conditions update
+  // when the conditions update.
+  // We also refuse to inline when another transaction is already running on this shard:
+  // journal/db-slice callbacks invoked from RunCallback can preempt, and a nested inlined
+  // transaction would interleave its own callback loop with the outer one.
   if (unique_shard_cnt_ == 1 && unique_shard_id_ == ss->thread_index() &&
-      ss->AllowInlineScheduling() && !GetDbSlice(es->shard_id()).HasRegisteredCallbacks() &&
-      !IsGlobal()) {
+      ss->AllowInlineScheduling() && !IsGlobal() && es->running_tx() == nullptr) {
     ss->stats.tx_inline_runs++;
     return true;
   }


### PR DESCRIPTION
Fixes the serializer_base_test failure in #7459.

With inline scheduling enabled during replication, connection fibers (DflyConn_*) can now trigger OnChangeBlocking directly. Adds the DflyConn prefix to the fiber name allowlist. Safe because the running_tx_ gate prevents concurrent callback interleaving.

Signed-off-by: Dragon Claw <dragonclaw@dragonflydb.io>