### PR TITLE
fix(serializer): allow inline-scheduled tx on DflyConn fibers

### DIFF
--- a/src/server/serializer_base.cc
+++ b/src/server/serializer_base.cc
@@ -211,6 +211,7 @@ void SerializerBase::OnChangeBlocking(DbIndex db_index, PrimeTable::bucket_itera
   if (!absl::StartsWith(active_name, "shard_queue") &&  //
       !absl::StartsWith(active_name, "l2_queue") &&     // pipelining
       !absl::StartsWith(active_name, "SliceSnapshot") &&
+      !absl::StartsWith(active_name, "DflyConn") &&  // inline-scheduled tx on connection fiber
       active_name != "Dispatched" &&   // Comes from OnAllShards(... { migration->RunSync(); });
       active_name != "Debug/Traverse"  // DEBUG OBJHIST/UNIQ-STRS cleanup of lazy-expired empty
                                        // containers; runs on the shard proactor so ordering holds.


### PR DESCRIPTION
Fixes serializer_base_test failure in #7459.

Adds DflyConn prefix to fiber name allowlist in OnChangeBlocking. Safe because running_tx_ gate prevents concurrent callback interleaving.

Signed-off-by: Dragon Claw <dragonclaw@dragonflydb.io>