### PR TITLE
chore: disable default settings that cause regression in CI

### DIFF
--- a/.github/actions/builder/action.yml
+++ b/.github/actions/builder/action.yml
@@ -85,7 +85,7 @@ runs:
           -DWITH_GPERF=OFF
           -DWITH_ASAN="${ASAN}"
           -DWITH_USAN="${USAN}"
-          -DLEGACY_GLOG=OFF
+          -DLEGACY_GLOG=ON
         )
 
         # Execute CMake

--- a/src/server/container_utils.cc
+++ b/src/server/container_utils.cc
@@ -24,7 +24,7 @@ extern "C" {
 #include "redis/util.h"
 }
 
-ABSL_FLAG(uint32_t, container_iteration_yield_interval_usec, 500,
+ABSL_FLAG(uint32_t, container_iteration_yield_interval_usec, 0,
           "Yield the fiber every N microseconds during container iteration. "
           "0 disables yielding.");
 

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -2010,6 +2010,8 @@ TEST_F(GenericFamilyTest, RmDeletesMatchingKeys) {
 // behavior is expected for other containers (SET, HASH, LIST) with non
 // listpack encodings.
 TEST_F(GenericFamilyTest, ContainerIterationYields) {
+  GTEST_SKIP() << "Until --container_iteration_yield_interval_usec is re-enabled";
+
   // Build a large sorted set that will be encoded as SKIPLIST.
   constexpr int N = 500'000;
   for (int start = 0; start < N; start += 1'000) {

--- a/src/server/memory_cmd.cc
+++ b/src/server/memory_cmd.cc
@@ -251,7 +251,11 @@ void MemoryCmd::Run(CmdArgList args) {
   }
 
   if (parser.Check("DECOMMIT")) {
-    if (parser.Check("COOL")) {
+    bool cool = parser.Check("COOL");
+    if (parser.HasNext()) {
+      return cmd_cntx_->SendError(kSyntaxErr);
+    }
+    if (cool) {
       shard_set->RunBriefInParallel([](EngineShard* shard) {
         if (auto* ts = shard->tiered_storage(); ts) {
           ts->ReclaimMemory(SIZE_MAX);


### PR DESCRIPTION
1. Bring back LEGACY_GLOG=ON
2. set container_iteration_yield_interval_usec=0 to avoid yielding during operations.
3. Fix `MEMORY DECOMMIT` to return syntax error on unexpected arguments (e.g. `MEMORY DECOMMIT foo`).

Both settings will be investigated further post 1.39 release.