### PR TITLE
refactor: simplify ExpireParams by removing TimeUnit field

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1130,24 +1130,17 @@ OpResult<DbSlice::ItAndUpdater> DbSlice::AddNew(const Context& cntx, string_view
   return DbSlice::ItAndUpdater{.it = res.it, .post_updater = std::move(res.post_updater)};
 }
 
-int64_t DbSlice::ExpireParams::Cap(int64_t value, TimeUnit unit) {
-  return unit == TimeUnit::SEC ? min(value, kMaxExpireDeadlineSec)
-                               : min(value, kMaxExpireDeadlineMs);
+int64_t DbSlice::ExpireParams::Cap(int64_t value) {
+  return min(value, kMaxExpireDeadlineMs);
 }
 
 pair<int64_t, int64_t> DbSlice::ExpireParams::Calculate(uint64_t now_ms, bool cap) const {
   if (persist)
     return {0, 0};
 
-  // return a negative absolute time if we overflow.
-  if (unit == TimeUnit::SEC && value > INT64_MAX / 1000) {
-    return {0, -1};
-  }
-
-  int64_t msec = (unit == TimeUnit::SEC) ? value * 1000 : value;
-  int64_t rel_msec = absolute ? msec - now_ms : msec;
+  int64_t rel_msec = absolute ? msec_val - now_ms : msec_val;
   if (cap)
-    rel_msec = Cap(rel_msec, TimeUnit::MSEC);
+    rel_msec = Cap(rel_msec);
   return make_pair(rel_msec, now_ms + rel_msec);
 }
 

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1134,6 +1134,14 @@ int64_t DbSlice::ExpireParams::Cap(int64_t value) {
   return min(value, kMaxExpireDeadlineMs);
 }
 
+bool DbSlice::ExpireParams::SafeSecToMs(int64_t sec, int64_t* out_ms) {
+  if (sec > kMaxExpireDeadlineSec || sec < 0) {
+    return false;
+  }
+  *out_ms = sec * 1000;
+  return true;
+}
+
 pair<int64_t, int64_t> DbSlice::ExpireParams::Calculate(uint64_t now_ms, bool cap) const {
   if (persist)
     return {0, 0};

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -222,10 +222,10 @@ class DbSlice {
 
   struct ExpireParams {
     bool IsDefined() const {
-      return persist || value > INT64_MIN;
+      return persist || msec_val > INT64_MIN;
     }
 
-    static int64_t Cap(int64_t value, TimeUnit unit);
+    static int64_t Cap(int64_t value);
 
     // Calculate relative and absolue timepoints.
     std::pair<int64_t, int64_t> Calculate(uint64_t now_msec, bool cap) const;
@@ -236,12 +236,10 @@ class DbSlice {
     }
 
    public:
-    int64_t value = INT64_MIN;  // undefined
-    TimeUnit unit = TimeUnit::SEC;
-
-    bool absolute = false;
-    bool persist = false;        // persist means remove all expiry
-    int32_t expire_options = 0;  // ExpireFlags
+    int64_t msec_val = INT64_MIN;  // always in milliseconds
+    bool absolute = false;         // true = absolute timestamp, false = relative
+    bool persist = false;          // persist means remove all expiry
+    int32_t expire_options = 0;    // ExpireFlags
   };
 
   DbSlice(uint32_t index, bool cache_mode, EngineShard* owner);

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -227,6 +227,9 @@ class DbSlice {
 
     static int64_t Cap(int64_t value);
 
+    // Safely convert seconds to milliseconds. Returns false on overflow.
+    static bool SafeSecToMs(int64_t sec, int64_t* out_ms);
+
     // Calculate relative and absolue timepoints.
     std::pair<int64_t, int64_t> Calculate(uint64_t now_msec, bool cap) const;
 

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1368,7 +1368,8 @@ void GenericFamily::Expire(CmdArgList args, CommandContext* cmd_cntx) {
   if (!expire_options) {
     return cmd_cntx->SendError(expire_options.error());
   }
-  DbSlice::ExpireParams params{.value = int_arg, .expire_options = expire_options.value()};
+  DbSlice::ExpireParams params{.msec_val = int_arg * 1000,
+                               .expire_options = expire_options.value()};
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpExpire(t->GetOpArgs(shard), key, params);
@@ -1391,7 +1392,7 @@ void GenericFamily::ExpireAt(CmdArgList args, CommandContext* cmd_cntx) {
     return cmd_cntx->SendError(expire_options.error());
   }
   DbSlice::ExpireParams params{
-      .value = int_arg, .absolute = true, .expire_options = expire_options.value()};
+      .msec_val = int_arg * 1000, .absolute = true, .expire_options = expire_options.value()};
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpExpire(t->GetOpArgs(shard), key, params);
@@ -1439,8 +1440,7 @@ void GenericFamily::PexpireAt(CmdArgList args, CommandContext* cmd_cntx) {
   if (!expire_options) {
     return cmd_cntx->SendError(expire_options.error());
   }
-  DbSlice::ExpireParams params{.value = int_arg,
-                               .unit = TimeUnit::MSEC,
+  DbSlice::ExpireParams params{.msec_val = int_arg,
                                .absolute = true,
                                .expire_options = expire_options.value()};
 
@@ -1474,7 +1474,7 @@ void GenericFamily::Pexpire(CmdArgList args, CommandContext* cmd_cntx) {
     return cmd_cntx->SendError(expire_options.error());
   }
   DbSlice::ExpireParams params{
-      .value = int_arg, .unit = TimeUnit::MSEC, .expire_options = expire_options.value()};
+      .msec_val = int_arg, .expire_options = expire_options.value()};
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpExpire(t->GetOpArgs(shard), key, params);

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1368,7 +1368,11 @@ void GenericFamily::Expire(CmdArgList args, CommandContext* cmd_cntx) {
   if (!expire_options) {
     return cmd_cntx->SendError(expire_options.error());
   }
-  DbSlice::ExpireParams params{.msec_val = int_arg * 1000,
+  int64_t msec_val;
+  if (!DbSlice::ExpireParams::SafeSecToMs(int_arg, &msec_val)) {
+    return cmd_cntx->SendError(kExpiryOutOfRange);
+  }
+  DbSlice::ExpireParams params{.msec_val = msec_val,
                                .expire_options = expire_options.value()};
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
@@ -1387,12 +1391,16 @@ void GenericFamily::ExpireAt(CmdArgList args, CommandContext* cmd_cntx) {
   }
 
   int_arg = std::max<int64_t>(int_arg, 0L);
+  int64_t msec_val;
+  if (!DbSlice::ExpireParams::SafeSecToMs(int_arg, &msec_val)) {
+    return cmd_cntx->SendError(kExpiryOutOfRange);
+  }
   auto expire_options = ParseExpireOptionsOrReply(args.subspan(2));
   if (!expire_options) {
     return cmd_cntx->SendError(expire_options.error());
   }
   DbSlice::ExpireParams params{
-      .msec_val = int_arg * 1000, .absolute = true, .expire_options = expire_options.value()};
+      .msec_val = msec_val, .absolute = true, .expire_options = expire_options.value()};
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpExpire(t->GetOpArgs(shard), key, params);

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -1012,8 +1012,12 @@ std::variant<SetCmd::SetParams, facade::ErrorReply, NegativeExpire> ParseSetPara
         return facade::ErrorReply{InvalidExpireTime("set")};
 
       bool is_ms = *exp_type == ExpT::PX || *exp_type == ExpT::PXAT;
+      int64_t msec_val;
+      if (!is_ms && !DbSlice::ExpireParams::SafeSecToMs(int_arg, &msec_val)) {
+        return facade::ErrorReply{InvalidExpireTime("set")};
+      }
       DbSlice::ExpireParams expiry{
-          .msec_val = is_ms ? int_arg : int_arg * 1000,
+          .msec_val = is_ms ? int_arg : msec_val,
           .absolute = *exp_type == ExpT::EXAT || *exp_type == ExpT::PXAT,
       };
 
@@ -1138,8 +1142,12 @@ cmd::CmdR CmdSetExGeneric(CmdArgList args, CommandContext* cmd_cntx) {
     co_return facade::ErrorReply{InvalidExpireTime(cmd_name)};
 
   bool is_ms = cmd_name.front() == 'P';
+  int64_t msec_val;
+  if (!is_ms && !DbSlice::ExpireParams::SafeSecToMs(exp_int, &msec_val)) {
+    co_return facade::ErrorReply{InvalidExpireTime(cmd_name)};
+  }
   DbSlice::ExpireParams expiry{
-      .msec_val = is_ms ? exp_int : exp_int * 1000,
+      .msec_val = is_ms ? exp_int : msec_val,
       .absolute = false,
   };
 
@@ -1307,7 +1315,10 @@ cmd::CmdR CmdGetEx(CmdArgList args, CommandContext* cmd_cntx) {
 
       exp_params.absolute = *exp_type == ExpT::EXAT || *exp_type == ExpT::PXAT;
       bool is_ms = *exp_type == ExpT::PX || *exp_type == ExpT::PXAT;
-      exp_params.msec_val = is_ms ? int_arg : int_arg * 1000;
+      if (!is_ms && !DbSlice::ExpireParams::SafeSecToMs(int_arg, &exp_params.msec_val)) {
+        co_return facade::ErrorReply{InvalidExpireTime("getex")};
+      }
+      if (is_ms) exp_params.msec_val = int_arg;
       defined = true;
     } else if (parser.Check("PERSIST")) {
       exp_params.persist = true;
@@ -1513,8 +1524,12 @@ cmd::CmdR CmdGAT(CmdArgList args, CommandContext* cmd_cntx) {
     return cmd::kAborted;
   }
   int64_t expire_ts = cmd_cntx->mc_command()->expire_ts;
+  int64_t msec_val;
+  if (!DbSlice::ExpireParams::SafeSecToMs(expire_ts, &msec_val)) {
+    msec_val = 0;  // persist if overflow
+  }
   DbSlice::ExpireParams expire_params{
-      .msec_val = expire_ts * 1000, .absolute = true, .persist = expire_ts == 0};
+      .msec_val = msec_val, .absolute = true, .persist = expire_ts == 0};
   return MGetGeneric(cmd_cntx, args, expire_params);
 }
 

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -1011,9 +1011,9 @@ std::variant<SetCmd::SetParams, facade::ErrorReply, NegativeExpire> ParseSetPara
       if (int_arg <= 0)
         return facade::ErrorReply{InvalidExpireTime("set")};
 
+      bool is_ms = *exp_type == ExpT::PX || *exp_type == ExpT::PXAT;
       DbSlice::ExpireParams expiry{
-          .value = int_arg,
-          .unit = *exp_type == ExpT::PX || *exp_type == ExpT::PXAT ? TimeUnit::MSEC : TimeUnit::SEC,
+          .msec_val = is_ms ? int_arg : int_arg * 1000,
           .absolute = *exp_type == ExpT::EXAT || *exp_type == ExpT::PXAT,
       };
 
@@ -1137,9 +1137,9 @@ cmd::CmdR CmdSetExGeneric(CmdArgList args, CommandContext* cmd_cntx) {
   if (exp_int < 1)
     co_return facade::ErrorReply{InvalidExpireTime(cmd_name)};
 
+  bool is_ms = cmd_name.front() == 'P';
   DbSlice::ExpireParams expiry{
-      .value = exp_int,
-      .unit = cmd_name.front() == 'P' ? TimeUnit::MSEC : TimeUnit::SEC,
+      .msec_val = is_ms ? exp_int : exp_int * 1000,
       .absolute = false,
   };
 
@@ -1306,9 +1306,8 @@ cmd::CmdR CmdGetEx(CmdArgList args, CommandContext* cmd_cntx) {
       }
 
       exp_params.absolute = *exp_type == ExpT::EXAT || *exp_type == ExpT::PXAT;
-      exp_params.value = int_arg;
-      exp_params.unit =
-          *exp_type == ExpT::PX || *exp_type == ExpT::PXAT ? TimeUnit::MSEC : TimeUnit::SEC;
+      bool is_ms = *exp_type == ExpT::PX || *exp_type == ExpT::PXAT;
+      exp_params.msec_val = is_ms ? int_arg : int_arg * 1000;
       defined = true;
     } else if (parser.Check("PERSIST")) {
       exp_params.persist = true;
@@ -1515,7 +1514,7 @@ cmd::CmdR CmdGAT(CmdArgList args, CommandContext* cmd_cntx) {
   }
   int64_t expire_ts = cmd_cntx->mc_command()->expire_ts;
   DbSlice::ExpireParams expire_params{
-      .value = expire_ts, .absolute = true, .persist = expire_ts == 0};
+      .msec_val = expire_ts * 1000, .absolute = true, .persist = expire_ts == 0};
   return MGetGeneric(cmd_cntx, args, expire_params);
 }
 


### PR DESCRIPTION
## Summary
Removes the `TimeUnit` enum from `ExpireParams` and renames `value` to `msec_val` (always in milliseconds).

## Problem
`ExpireParams` had three interrelated fields (`value`, `unit`, `absolute`) where `value` could represent either seconds or milliseconds depending on `unit`. This ambiguity made the API error-prone.

## Solution
- `value` (int64_t, ambiguous unit) → `msec_val` (int64_t, always milliseconds)
- `unit` (TimeUnit enum) → REMOVED
- `absolute` (bool) → KEPT (callers do not have `now_ms` at construction time)

## Changes
| File | Changes |
|------|---------|
| `db_slice.h` | Updated struct definition, IsDefined(), Cap() signature |
| `db_slice.cc` | Simplified Calculate() and Cap() — no more unit conversion |
| `generic_family.cc` | Updated 4 call sites to pre-convert seconds to ms |
| `string_family.cc` | Updated 4 call sites to pre-convert seconds to ms |

Fixes #3634