### PR TITLE
fix: enable rdb_sbf_chunked by default and fix sbf serialization bug

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@
    `ninja <unit_test> && ./unit_test`
 4. ✅ **Format Code** - `pre-commit run --files <files>`
 5. ✅ **Follow Architecture** - See [Architecture Patterns](#architecture-patterns) below
+6. ✅ **Never Push to Main** - Always create a feature branch and open a PR. Never run `git push origin main`.
 
 ### Pull Request Guidelines
 

--- a/src/server/bloom_family_test.cc
+++ b/src/server/bloom_family_test.cc
@@ -145,4 +145,16 @@ TEST_F(BloomFamilyTest, LoadChunkErrors) {
   EXPECT_THAT(Run({"bf.loadchunk", "b1", "-1", "data"}), ErrArg("not an integer"));
 }
 
+// COPY of an SBF must survive the chunked serialize/deserialize round-trip.
+TEST_F(BloomFamilyTest, CopyChunkedRoundTrip) {
+  Run({"bf.reserve", "b1", "0.01", "1000"});
+  for (int i = 0; i < 100; ++i)
+    Run({"bf.add", "b1", absl::StrCat("item", i)});
+
+  EXPECT_THAT(Run({"copy", "b1", "b2"}), IntArg(1));
+
+  for (int i = 0; i < 100; ++i)
+    EXPECT_THAT(Run({"bf.exists", "b2", absl::StrCat("item", i)}), IntArg(1));
+}
+
 }  // namespace dfly

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -53,8 +53,7 @@ ABSL_FLAG(dfly::CompressionMode, compression_mode, dfly::CompressionMode::MULTI_
           "set 2 for multi entry zstd compression on df snapshot and single entry on rdb snapshot,"
           "set 3 for multi entry lz4 compression on df snapshot and single entry on rdb snapshot");
 
-// Flip this value to 'true' in March 2026.
-ABSL_FLAG(bool, rdb_sbf_chunked, false, "Enable new save format for saving SBFs in chunks.");
+ABSL_FLAG(bool, rdb_sbf_chunked, true, "Enable new save format for saving SBFs in chunks.");
 
 namespace dfly {
 

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -686,7 +686,11 @@ std::error_code RdbSerializer::SaveSBFObject(const PrimeValue& pv) {
       RETURN_ON_ERR(SaveLen(blob.size()));
       for (size_t offset = 0; offset < blob.size(); offset += kFilterChunkSize) {
         size_t chunk_len = std::min(kFilterChunkSize, blob.size() - offset);
-        RETURN_ON_ERR(SaveString(blob.substr(offset, chunk_len)));
+        string_view chunk = blob.substr(offset, chunk_len);
+        // Verbatim length prefix + raw bytes: the loader reads chunks with LoadLen + FetchBuf.
+        RETURN_ON_ERR(SaveLen(chunk.size()));
+        RETURN_ON_ERR(
+            WriteRaw(io::Bytes{reinterpret_cast<const uint8_t*>(chunk.data()), chunk_len}));
         const bool is_last_chunk = (offset + chunk_len >= blob.size());
         PushToConsumerIfNeeded(is_last_chunk ? flush_state : FlushState::kFlushMidEntry);
       }

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -716,7 +716,6 @@ TEST_F(RdbTest, SBF) {
 }
 
 TEST_F(RdbTest, SBFLargeFilterChunking) {
-  absl::SetFlag(&FLAGS_rdb_sbf_chunked, true);
   max_memory_limit = 200000000;
 
   // Using this set of parameters for the BF.RESERVE command resulted in a

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -4239,7 +4239,6 @@ async def test_sbf_chunked_replication(df_factory: DflyInstanceFactory):
     master = df_factory.create(
         proactor_threads=1,
         maxmemory="6G",
-        rdb_sbf_chunked="true",
     )
     replica = df_factory.create(
         proactor_threads=1,
@@ -4270,7 +4269,6 @@ async def test_sbf_chunked_replication_chunk_size(df_factory: DflyInstanceFactor
     master = df_factory.create(
         proactor_threads=1,
         maxmemory="4G",
-        rdb_sbf_chunked="true",
     )
     replica = df_factory.create(
         proactor_threads=1,


### PR DESCRIPTION
## Summary
- Flip `rdb_sbf_chunked` flag default from `false` to `true` — the chunked SBF save format has been validated.
- Remove explicit flag overrides in `rdb_test.cc` and `replication_test.py` that are no longer needed.

#The bug

the chunked SBF path saved each filter chunk via SaveString, which integer-encodes short strings and LZF-compresses long ones in SINGLE_ENTRY mode. The loader reads chunks with a plain LoadLen + FetchBuf and can't decode that. A fresh filter is mostly zeros and compresses well, so COPY/DUMP/RESTORE (SINGLE_ENTRY) produced payloads the loader rejected, crashing in Renamer::FinalizeRename with deserialize_status=INVALID_VALUE. The on-disk RDB save (also SINGLE_ENTRY) had the same latent issue.

No, we don't break compatibility, and an old replica can still load SBF from a new master:

The fix only touches the save side. The loader is unchanged and always expected verbatim length-prefixed chunks.
Replication/snapshot run in MULTI_ENTRY mode, where SaveString already wrote chunks verbatim (LZF only triggers in SINGLE_ENTRY; whole-blob compression is separate and transparent to the loader). So the bytes on the wire for SBF2 chunks are identical before and after this change.
The only outputs that change are the SINGLE_ENTRY paths (DUMP/COPY/RESTORE, on-disk RDB), which previously produced payloads no version could load. There's no valid prior format to break there.
The flag still selects RDB_TYPE_SBF vs RDB_TYPE_SBF2; this only fixes the chunk encoding inside SBF2.