### PR TITLE
perf(facade): batch V2 control-path replies in ProcessControlMessages

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1574,6 +1574,12 @@ bool Connection::ProcessControlMessages(uint32_t quota) {
   // PubSub replies flush immediately via FinishScope() only when batched_ is false.
   // ReplyBatch() and ExecuteBatch() both reset it via absl::Cleanup guards on all return paths.
   DCHECK(!reply_builder_->IsBatchMode());
+
+  // Batch control-message replies when multiple are queued,
+  // avoiding per-message sendmsg syscalls while preserving latency for single-message wakeups.
+  reply_builder_->SetBatchMode(dispatch_q_.size() > 1);
+  absl::Cleanup batch_guard = [this] { reply_builder_->SetBatchMode(false); };
+
   uint32_t dispatched = 0;
 
   while (!dispatch_q_.empty()) {


### PR DESCRIPTION
When ProcessControlMessages wakes with multiple messages queued, each std::visit call triggers FinishScope() -> Flush(), producing one sendmsg syscall per message (PubSub, Monitor, Invalidation).

Enable batch mode when dispatch_q_ holds more than one message, so all replies in the drain pass accumulate in the send buffer and flush together at the main loop's idle-await point.

Single-message wakeups are unaffected: SetBatchMode(false) leaves FinishScope() flushing immediately, preserving p=1 latency.

Cross-machine benchmark (10 subscribers, 4 threads):

| Pipeline | RPS Δ | Syscalls Δ |
|----------|-------|------------|
| 1        | +3%   | -24%       |
| 10       | +12%  | -68%       |
| 100      | -1.4% | -69%       |
| 500      | -2%   | -70%       |

The syscall reduction is the real gain here.
