### PR TITLE
server: Block for shards to finish before applying journal blob

### DIFF
--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2274,7 +2274,7 @@ error_code RdbLoader::Load(io::Source* src) {
       RETURN_ON_ERR(ConsumeInput(8));  // ignore 8 bytes
 
       if (full_sync_cut_cb) {
-        FlushAllShards();  // Flush as the handler awakes post load handlers
+        FlushAllShards();  // Drain queued loads before waking post-load handlers.
         full_sync_cut_cb();
       }
       continue;
@@ -2359,7 +2359,7 @@ error_code RdbLoader::Load(io::Source* src) {
     }
 
     if (type == RDB_OPCODE_JOURNAL_BLOB) {
-      FlushAllShards();  // Always flush before applying incremental on top
+      FlushAllShards();  // Always drain before applying incremental on top.
       RETURN_ON_ERR(HandleJournalBlob(service_));
       continue;
     }
@@ -2442,15 +2442,7 @@ error_code RdbLoader::Load(io::Source* src) {
 }
 
 void RdbLoader::FinishLoad(absl::Time start_time, size_t* keys_loaded) {
-  BlockingCounter bc(shard_set->size());
-  for (unsigned i = 0; i < shard_set->size(); ++i) {
-    // Flush the remaining items.
-    FlushShardAsync(i);
-
-    // Send sentinel callbacks to ensure that all previous messages have been processed.
-    shard_set->Add(i, [bc]() mutable { bc->Dec(); });
-  }
-  bc->Wait();  // wait for sentinels to report.
+  FlushAllShards();
   // Decrement local one if it exists
   if (EngineShard* es = EngineShard::tlocal(); es) {
     GetCurrentDbSlice().DecrLoadInProgress();
@@ -2826,8 +2818,14 @@ void RdbLoader::FlushShardAsync(ShardId sid) {
 }
 
 void RdbLoader::FlushAllShards() {
-  for (ShardId i = 0; i < shard_set->size(); i++)
+  BlockingCounter bc(shard_set->size());
+  for (ShardId i = 0; i < shard_set->size(); i++) {
     FlushShardAsync(i);
+
+    // Send sentinel callbacks to ensure that all previous messages have been processed.
+    shard_set->Add(i, [bc]() mutable { bc->Dec(); });
+  }
+  bc->Wait();  // wait for sentinels to report.
 }
 
 std::error_code RdbLoaderBase::FromOpaque(const OpaqueObj& opaque, LoadConfig config,

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -12,6 +12,9 @@ extern "C" {
 #include <absl/flags/reflection.h>
 #include <mimalloc.h>
 
+#include <atomic>
+#include <chrono>
+
 #include "base/flags.h"
 #include "base/gtest.h"
 #include "base/logging.h"
@@ -1434,6 +1437,12 @@ std::string MakeTaggedChunk(uint32_t id, std::string_view payload) {
   return out;
 }
 
+std::string MakeFullSyncCut() {
+  RdbSerializer serializer(CompressionMode::NONE);
+  CHECK(!serializer.SendFullSyncCut());
+  return serializer.Flush(RdbSerializer::FlushState::kFlushEndEntry);
+}
+
 void AppendBinaryDouble(std::string* out, double val) {
   uint64_t bits;
   memcpy(&bits, &val, sizeof(bits));
@@ -1549,6 +1558,84 @@ TEST_F(RdbTest, InterleavedLoad) {
   EXPECT_EQ(Run({"SELECT", "1"}), "OK");
   EXPECT_THAT(Run({"EXISTS", key}), IntArg(0));
   EXPECT_EQ(Run({"SELECT", "0"}), "OK");
+}
+
+// https://github.com/dragonflydb/dragonfly/issues/7476
+// unlike the linked issue we test full sync cut vs flush, because it is easier to test with
+// callback which full sync cut works with rather than deletes. in the test we block the target
+// shard queue, and that may end up blocking the DEL command too
+TEST_F(RdbTest, FullSyncCutWaitsForTaggedShardLoads) {
+  ASSERT_GT(shard_set->size(), 1u);
+
+  std::string key;
+  // The issue is only seen on buffer queue on non-coordinator shards
+  for (unsigned i = 0; i < 1000; ++i) {
+    key = StrCat("full-sync-barrier-", i);
+    if (Shard(key, shard_set->size()) != 0)
+      break;
+  }
+  ASSERT_NE(Shard(key, shard_set->size()), 0u);
+  const ShardId sid = Shard(key, shard_set->size());
+
+  std::string entry;
+  entry.push_back(RDB_TYPE_STRING);
+  AppendString(&entry, key);
+  AppendString(&entry, "baseline");
+
+  std::string body;
+  // single tagged chunk and then full sync cut
+  body += MakeTaggedChunk(1, entry);
+  body += MakeFullSyncCut();
+
+  EXPECT_EQ(Run({"FLUSHALL"}), "OK");
+
+  std::atomic_bool release_shard_queue{false};
+  bool visible_at_cut = false;
+
+  // block the task queue until releaser returns from its sleep (task queue for shard != 0)
+  // would cause test to fail if shard 0 could send full sync cut while sid was still blocked here
+  // this is enqueued before the key operations to test that key operations are performed before
+  // full sync cut
+  shard_set->Add(sid, [&] {
+    while (!release_shard_queue.load(std::memory_order_relaxed)) {
+      ThisFiber::SleepFor(chrono::milliseconds(1));
+    }
+  });
+
+  auto ec = pp_->at(0)->Await([&] {
+    Fiber releaser([&] {
+      ThisFiber::SleepFor(chrono::milliseconds(50));
+      // unblock the sid task queue
+      release_shard_queue.store(true, std::memory_order_relaxed);
+    });
+
+    auto full_sync_cut_cb = [&] {
+      // set to true if key is present in the db. full sync cut is called after FlushAllShards() so
+      // key must be visible after flush
+      visible_at_cut = pp_->at(sid)->Await([&] {
+        const DbContext ctx{&namespaces->GetDefaultNamespace(), 0, GetCurrentTimeMs()};
+        const auto& db = ctx.GetDbSlice(sid);
+        return db.FindReadOnly(ctx, key, OBJ_STRING).ok();
+      });
+    };
+
+    const std::string rdb = WrapInRdb(body);
+    io::BytesSource src{io::Buffer(rdb)};
+    RdbLoadContext load_context;
+    RdbLoader loader(service_.get(), &load_context);
+    loader.SetFullSyncCutCb(full_sync_cut_cb);
+
+    const auto ec_ = loader.Load(&src);
+    EXPECT_EQ(loader.journal_offset(), std::nullopt);
+    releaser.Join();
+    shard_set->Await(sid, [] {});
+    return ec_;
+  });
+
+  ASSERT_FALSE(ec) << ec.message();
+
+  EXPECT_TRUE(visible_at_cut);
+  EXPECT_EQ(Run({"GET", key}), "baseline");
 }
 
 TEST_F(RdbTest, SplitSBF) {


### PR DESCRIPTION
In rdb load when handling journal blob RDB_OPCODE_JOURNAL_BLOB the expectation is that we flush all shards before consuming and applying journal change. 

The baseline (pending objects) must be created before applying a journal command for those objects, so that for example we do not end up with situation:

* Journal: DELETE key X, and then
* Baseline: Create key X

the above ordering resurrects the key X. 

Due to the way that the flush is issued, the above ordering is possible when the object is not on the shard running the loader.

There is a queue for these other shards which holds pending items to create in case of cross shard creation path (ReadAndDispatchObject). 

**But because the flush method does not wait for work to complete**, it only enqueues and continues, the journal can end up being applied first while the shard is still processing buffer items, the exact ordering issue that journal before baseline causes.

To fix this, a blocking counter is added similar to the FinishLoad method of the rdb loader, so that the work actually finishes before the journal blob is applied.

Note that this has performance implications, as now all shards must process their buffer items before executing every single journal command, which is the correct option.

FIXES https://github.com/dragonflydb/dragonfly/issues/7476

A new unit test is added, which fails without change and passes with it
