### PR TITLE
fix(server): Propagate error on bigvalue cancel

### DIFF
--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -327,7 +327,8 @@ io::Result<uint8_t> RdbSerializer::SaveEntry(const PrimeKey& pk, const PrimeValu
   // We flush here because if the next element in the bucket we are serializing is a container,
   // it will first serialize the first entry and then flush the internal buffer, even if
   // crossed the limit.
-  PushToConsumerIfNeeded(FlushState::kFlushEndEntry);
+  if (auto ec = PushToConsumerIfNeeded(FlushState::kFlushEndEntry); ec)
+    return make_unexpected(ec);
   return rdb_type;
 }
 
@@ -387,7 +388,7 @@ error_code RdbSerializer::SaveListObject(const PrimeValue& pv) {
     size_t lp_bytes = lpBytes(lp);
     RETURN_ON_ERR(SaveString(lp, lp_bytes));
 
-    PushToConsumerIfNeeded(FlushState::kFlushEndEntry);
+    RETURN_ON_ERR(PushToConsumerIfNeeded(FlushState::kFlushEndEntry));
     return error_code{};
   }
 
@@ -419,7 +420,7 @@ error_code RdbSerializer::SaveListObject(const PrimeValue& pv) {
       FlushState flush_state = FlushState::kFlushMidEntry;
       if (node->next == nullptr)
         flush_state = FlushState::kFlushEndEntry;
-      PushToConsumerIfNeeded(flush_state);
+      RETURN_ON_ERR(PushToConsumerIfNeeded(flush_state));
     } else if (node->IsCompressed()) {
       void* data;
       size_t compress_len = node->GetLZF(&data);
@@ -429,7 +430,7 @@ error_code RdbSerializer::SaveListObject(const PrimeValue& pv) {
       FlushState flush_state = FlushState::kFlushMidEntry;
       if (node->next == nullptr)
         flush_state = FlushState::kFlushEndEntry;
-      PushToConsumerIfNeeded(flush_state);
+      RETURN_ON_ERR(PushToConsumerIfNeeded(flush_state));
     }
     node = node->next;
   }
@@ -456,7 +457,7 @@ error_code RdbSerializer::SaveSetObject(const PrimeValue& obj) {
         ++it;
         FlushState flush_state =
             it == set->end() ? FlushState::kFlushEndEntry : FlushState::kFlushMidEntry;
-        PushToConsumerIfNeeded(flush_state);
+        RETURN_ON_ERR(PushToConsumerIfNeeded(flush_state));
       }
       return error_code{};
     };
@@ -500,13 +501,12 @@ error_code RdbSerializer::SaveHSetObject(const PrimeValue& pv) {
       FlushState flush_state = FlushState::kFlushMidEntry;
       if (it == string_map->end())
         flush_state = FlushState::kFlushEndEntry;
-      PushToConsumerIfNeeded(flush_state);
+      RETURN_ON_ERR(PushToConsumerIfNeeded(flush_state));
     }
 
     pv.SetMemberTime(MemberTimeSeconds(GetCurrentTimeMs()));
   } else {
     CHECK_EQ(kEncodingListPack, pv.Encoding());
-
     uint8_t* lp = (uint8_t*)pv.RObjPtr();
     size_t lp_bytes = lpBytes(lp);
     RETURN_ON_ERR(SaveString((uint8_t*)lp, lp_bytes));
@@ -541,7 +541,9 @@ error_code RdbSerializer::SaveZSetObject(const PrimeValue& pv) {
       if (count == total)
         flush_state = FlushState::kFlushEndEntry;
 
-      PushToConsumerIfNeeded(flush_state);
+      ec = PushToConsumerIfNeeded(flush_state);
+      if (ec)
+        return false;
       return true;
     });
   } else {
@@ -583,7 +585,7 @@ error_code RdbSerializer::SaveStreamObject(const PrimeValue& pv) {
     // but the stream metadata tail is expected to stay bundled with the last listpack chunk, not
     // in its own separate chunk.
     if (i + 1 < rax_size)
-      PushToConsumerIfNeeded(FlushState::kFlushMidEntry);
+      RETURN_ON_ERR(PushToConsumerIfNeeded(FlushState::kFlushMidEntry));
   }
 
   std::move(stop_listpacks_rax).Invoke();
@@ -652,7 +654,7 @@ error_code RdbSerializer::SaveStreamObject(const PrimeValue& pv) {
     }
   }
 
-  PushToConsumerIfNeeded(FlushState::kFlushEndEntry);
+  RETURN_ON_ERR(PushToConsumerIfNeeded(FlushState::kFlushEndEntry));
 
   return error_code{};
 }
@@ -689,11 +691,12 @@ std::error_code RdbSerializer::SaveSBFObject(const PrimeValue& pv) {
         size_t chunk_len = std::min(kFilterChunkSize, blob.size() - offset);
         RETURN_ON_ERR(SaveString(blob.substr(offset, chunk_len)));
         const bool is_last_chunk = (offset + chunk_len >= blob.size());
-        PushToConsumerIfNeeded(is_last_chunk ? flush_state : FlushState::kFlushMidEntry);
+        RETURN_ON_ERR(
+            PushToConsumerIfNeeded(is_last_chunk ? flush_state : FlushState::kFlushMidEntry));
       }
     } else {
       RETURN_ON_ERR(SaveString(blob));
-      PushToConsumerIfNeeded(flush_state);
+      RETURN_ON_ERR(PushToConsumerIfNeeded(flush_state));
     }
   }
 
@@ -1866,9 +1869,9 @@ void RdbSerializer::CompressBlob() {
   mem_buf->CommitWrite(compressed->size());
 }
 
-void RdbSerializer::PushToConsumerIfNeeded(FlushState flush_state) {
+std::error_code RdbSerializer::PushToConsumerIfNeeded(FlushState flush_state) {
   if (!consume_fun_ || SerializedLen() <= flush_threshold_)
-    return;
+    return {};
 
   if (flush_state == FlushState::kFlushMidEntry)
     mem_buf_controller_.MarkEntrySplit();
@@ -1878,8 +1881,9 @@ void RdbSerializer::PushToConsumerIfNeeded(FlushState flush_state) {
 
   // save and restore id around preempt point consume_fun_
   const auto id = mem_buf_controller_.SaveStateBeforeConsume();
-  consume_fun_(std::move(blob));
+  std::error_code ec = consume_fun_(std::move(blob));
   mem_buf_controller_.RestoreStateAfterConsume(id);
+  return ec;
 }
 
 void MemBufController::StartEntry() {

--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -546,6 +546,7 @@ error_code RdbSerializer::SaveZSetObject(const PrimeValue& pv) {
         return false;
       return true;
     });
+    return ec;
   } else {
     CHECK_EQ(pv.Encoding(), unsigned(OBJ_ENCODING_LISTPACK));
     uint8_t* lp = (uint8_t*)pv.RObjPtr();

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -253,8 +253,9 @@ class RdbSerializer {
   enum class FlushState : uint8_t { kFlushMidEntry, kFlushEndEntry };
 
   // ConsumeFun is called when internal buffer exceeds flush_threshold.
-  // The callback receives the extracted data.
-  using ConsumeFun = std::function<void(std::string)>;
+  // The callback receives the extracted data and returns an error_code to signal
+  // the serializer to stop early (e.g. on cancellation).
+  using ConsumeFun = std::function<std::error_code(std::string)>;
 
   explicit RdbSerializer(CompressionMode compression_mode, ConsumeFun consume_fun = {},
                          size_t flush_threshold = 0);
@@ -359,7 +360,7 @@ class RdbSerializer {
   std::error_code SaveStreamConsumers(bool save_active, streamCG* cg);
 
   // Might preempt
-  void PushToConsumerIfNeeded(FlushState flush_state);
+  std::error_code PushToConsumerIfNeeded(FlushState flush_state);
 
   static constexpr size_t kFilterChunkSize = 1ULL << 26;
   static constexpr size_t kMinStrSizeToCompress = 256;

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -1468,14 +1468,14 @@ struct InterleaveHarness {
   // queued key (sandwiched between a journal offset and a journal entry) to force interleaved
   // tagged chunks. Passed to serializer as consume_fun_, so the blob is the flushed data
   // accumulated in serializer.
-  void operator()(std::string blob) {
+  std::error_code operator()(std::string blob) {
     body += blob;
     if (next >= queued.size())
-      return;
+      return {};
 
     uint64_t offset = last_journal_offset.value_or(0) + 100;
     last_journal_offset = offset;
-    ASSERT_FALSE(serializer->SendJournalOffset(offset));
+    EXPECT_FALSE(serializer->SendJournalOffset(offset));
 
     const auto& entry = queued[next++];
     // SaveEntry calls get preempted (not by fiber but call stack) every time consume_fun_ is
@@ -1483,12 +1483,13 @@ struct InterleaveHarness {
     // consume_fun_ -> ... The last entry in queue (next == queued size) does not add anything, it
     // simply returns until the entry is completed. From that point on all entries simply flush
     // repeatedly until completed, moving down the stack.
-    ASSERT_TRUE(serializer->SaveEntry(PrimeKey{entry.key}, *entry.value, 0, 0, 0).has_value());
+    EXPECT_TRUE(serializer->SaveEntry(PrimeKey{entry.key}, *entry.value, 0, 0, 0).has_value());
 
     io::StringSink sink;
     JournalWriter writer(&sink);
     writer.Write(journal::Entry{journal::Op::PING, 0, std::nullopt});
-    ASSERT_FALSE(serializer->WriteJournalEntry(std::move(sink).str()));
+    EXPECT_FALSE(serializer->WriteJournalEntry(std::move(sink).str()));
+    return {};
   }
 };
 
@@ -1692,7 +1693,12 @@ TEST_F(RdbTest, TaggedInterleavedRoundTrip) {
     }
 
     RdbSerializer serializer(
-        CompressionMode::NONE, [&](std::string blob) { harness(std::move(blob)); }, 256);
+        CompressionMode::NONE,
+        [&](std::string blob) -> std::error_code {
+          harness(std::move(blob));
+          return {};
+        },
+        256);
 
     harness.serializer = &serializer;
     serializer.SetTagEntries(true);

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -318,14 +318,16 @@ void SliceSnapshot::HandleFlushData(std::string data) {
   VLOG(2) << "Pushed with Serialize() " << serialized;
 }
 
-void SliceSnapshot::ConsumeBigValueChunk(std::string data) {
-  if (!cntx_->IsRunning()) {
-    ThisFiber::Yield();
-    return;  // Short circuit flush on cancel or error to finish faster
-  }
+std::error_code SliceSnapshot::ConsumeBigValueChunk(std::string data) {
+  if (cntx_->IsError())
+    return cntx_->GetError();
+
+  if (cntx_->IsCancelled())
+    return std::make_error_code(std::errc::operation_canceled);
 
   HandleFlushData(std::move(data));
   ++ServerState::tlocal()->stats.big_value_preemptions;
+  return {};
 }
 
 size_t SliceSnapshot::FlushSerialized() {

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -247,8 +247,7 @@ unsigned SliceSnapshot::SerializeBucketLocked(DbIndex db_index, PrimeTable::buck
 
 void SliceSnapshot::SerializeFetchedEntry(const TieredDelayedEntry& tde, const PrimeValue& pv) {
   std::lock_guard lk{stream_mu_};
-  auto res = serializer_->SaveEntry(tde.key, pv, tde.expire, tde.mc_flags, tde.dbid);
-  CHECK(res);
+  serializer_->SaveEntry(tde.key, pv, tde.expire, tde.mc_flags, tde.dbid);
 }
 
 void SliceSnapshot::SerializeEntry(BucketIdentity bucket, DbIndex db_indx, const PrimeKey& pk,
@@ -265,9 +264,10 @@ void SliceSnapshot::SerializeEntry(BucketIdentity bucket, DbIndex db_indx, const
     ++type_freq_map_[RDB_TYPE_STRING];
   } else {
     std::lock_guard lk{stream_mu_};
-    io::Result<uint8_t> res = serializer_->SaveEntry(pk, pv, expire_time, mc_flags, db_indx);
-    CHECK(res);
-    ++type_freq_map_[*res];
+    if (auto res = serializer_->SaveEntry(pk, pv, expire_time, mc_flags, db_indx); res)
+      ++type_freq_map_[*res];
+    else
+      LOG(ERROR) << "Serialization error: " << res.error();
   }
 }
 

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -247,7 +247,8 @@ unsigned SliceSnapshot::SerializeBucketLocked(DbIndex db_index, PrimeTable::buck
 
 void SliceSnapshot::SerializeFetchedEntry(const TieredDelayedEntry& tde, const PrimeValue& pv) {
   std::lock_guard lk{stream_mu_};
-  serializer_->SaveEntry(tde.key, pv, tde.expire, tde.mc_flags, tde.dbid);
+  auto res = serializer_->SaveEntry(tde.key, pv, tde.expire, tde.mc_flags, tde.dbid);
+  LOG_IF(ERROR, !res.has_value()) << "Serialization error: " << res.error();
 }
 
 void SliceSnapshot::SerializeEntry(BucketIdentity bucket, DbIndex db_indx, const PrimeKey& pk,

--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -129,7 +129,7 @@ class SliceSnapshot : public SerializerBase, public journal::JournalConsumerInte
   void HandleFlushData(std::string data);
 
   // Callback of RdbSerializer to push big value chunks
-  void ConsumeBigValueChunk(std::string data);
+  std::error_code ConsumeBigValueChunk(std::string data);
 
   // Used for explicit flushes at safe points (e.g. between entries). Can block.
   size_t FlushSerialized();


### PR DESCRIPTION
Better way to fix #7187 by actually returning an error from the FlushCallback to then propagate this error further in the serializer to abort big value streaming on an error