### PR TITLE
feat(search): accept bare identifiers in FT.CREATE schema on JSON

### DIFF
--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -327,12 +327,20 @@ ParseResult<bool> ParseSchema(CmdArgParser* parser, DocIndex* index) {
   }
 
   while (parser->HasNext()) {
-    string_view field = parser->Next();
-    string_view field_alias = field;
+    string_view field_token = parser->Next();
+    string field_path_storage;
+    string_view field_path = field_token;
+    string_view field_alias = field_token;
 
-    // Verify json path is correct
-    if (index->type == DocIndex::JSON && !IsValidJsonPath(field)) {
-      return CreateSyntaxError(absl::StrCat("Bad json path: "sv, field));
+    // On JSON indexes, a bare identifier (no leading $) expands to $.identifier,
+    // matching the Valkey-search relaxation of the JSONPath requirement.
+    if (index->type == DocIndex::JSON && !field_token.empty() && field_token[0] != '$') {
+      field_path_storage = absl::StrCat("$.", field_token);
+      field_path = field_path_storage;
+    }
+
+    if (index->type == DocIndex::JSON && !IsValidJsonPath(field_path)) {
+      return CreateSyntaxError(absl::StrCat("Bad json path: "sv, field_path));
     }
 
     // AS [alias]
@@ -340,6 +348,12 @@ ParseResult<bool> ParseSchema(CmdArgParser* parser, DocIndex* index) {
 
     if (schema.field_names.contains(field_alias)) {
       return CreateSyntaxError(absl::StrCat("Duplicate field in schema - "sv, field_alias));
+    }
+    // Same identifier may appear twice on HASH (e.g. one TAG spec + one TEXT spec with
+    // different aliases). On JSON, a bare identifier expands to $.<id> and would silently
+    // shadow an earlier $.<id> spec; reject that collision instead of last-write-wins.
+    if (index->type == DocIndex::JSON && schema.fields.contains(field_path)) {
+      return CreateSyntaxError(absl::StrCat("Duplicate field in schema - "sv, field_path));
     }
 
     // Determine type
@@ -390,8 +404,8 @@ ParseResult<bool> ParseSchema(CmdArgParser* parser, DocIndex* index) {
       flags |= *flag;
     }
 
-    schema.fields[field] = {field_type, flags, string{field_alias}, params};
-    schema.field_names[field_alias] = field;
+    schema.fields[field_path] = {field_type, flags, string{field_alias}, params};
+    schema.field_names[field_alias] = field_path;
   }
 
   return false;

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -2387,6 +2387,80 @@ TEST_F(SearchFamilyTest, ReturnMixedAliasedAndBare) {
   EXPECT_THAT(resp, IsArray(IntArg(1), "j1", IsUnordArray("aliased_a", "alpha", "$.b", "beta")));
 }
 
+TEST_F(SearchFamilyTest, BareIdentifierOnJsonExpandsToJsonPath) {
+  EXPECT_EQ(Run({"FT.CREATE",       "bx",     "ON",     "JSON",    "PREFIX", "1",   "bx:",
+                 "SCHEMA",          "vector", "VECTOR", "HNSW",    "6",      "DIM", "8",
+                 "DISTANCE_METRIC", "COSINE", "TYPE",   "FLOAT32", "cat",    "TAG"}),
+            "OK");
+  Run({"JSON.SET", "bx:1", "$", R"({"vector":[0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1],"cat":"tech"})"});
+
+  std::string qv(32, '\0');
+  for (int i = 0; i < 8; ++i) {
+    float v = 0.1f;
+    memcpy(qv.data() + i * 4, &v, 4);
+  }
+
+  auto resp = Run({"FT.SEARCH", "bx", "*=>[KNN 3 @vector $qv]", "RETURN", "3", "$.cat", "AS",
+                   "catalias", "PARAMS", "2", "qv", qv, "DIALECT", "2"});
+  EXPECT_THAT(resp, IsArray(IntArg(1), "bx:1", IsArray("catalias", "tech")));
+
+  resp = Run({"FT.SEARCH", "bx", "@cat:{tech}", "RETURN", "1", "$.cat"});
+  EXPECT_THAT(resp, IsArray(IntArg(1), "bx:1", IsArray("$.cat", "tech")));
+}
+
+TEST_F(SearchFamilyTest, BareIdentifierWithExplicitAlias) {
+  EXPECT_EQ(Run({"FT.CREATE", "bx", "ON", "JSON", "PREFIX", "1", "bx:", "SCHEMA", "name", "AS",
+                 "person_name", "TEXT"}),
+            "OK");
+  Run({"JSON.SET", "bx:1", "$", R"({"name":"alpha"})"});
+  EXPECT_THAT(Run({"FT.SEARCH", "bx", "@person_name:alpha"}),
+              IsArray(IntArg(1), "bx:1", IsArray("$", R"({"name":"alpha"})")));
+}
+
+TEST_F(SearchFamilyTest, BareIdentifierCollisionRejected) {
+  EXPECT_THAT(Run({"FT.CREATE", "bx",   "ON",      "JSON",        "PREFIX",
+                   "1",         "bx:",  "SCHEMA",  "vector",      "VECTOR",
+                   "HNSW",      "6",    "DIM",     "4",           "DISTANCE_METRIC",
+                   "COSINE",    "TYPE", "FLOAT32", "$.something", "AS",
+                   "vector",    "TAG"}),
+              ErrArg("Duplicate field in schema"));
+}
+
+TEST_F(SearchFamilyTest, DuplicateIdentifierRejected) {
+  EXPECT_THAT(Run({"FT.CREATE", "bx",   "ON",      "JSON",     "PREFIX",
+                   "1",         "bx:",  "SCHEMA",  "vector",   "VECTOR",
+                   "HNSW",      "6",    "DIM",     "4",        "DISTANCE_METRIC",
+                   "COSINE",    "TYPE", "FLOAT32", "$.vector", "AS",
+                   "other",     "TAG"}),
+              ErrArg("Duplicate field in schema"));
+
+  EXPECT_THAT(
+      Run({"FT.CREATE",       "by",     "ON",    "JSON",    "PREFIX", "1",  "by:",    "SCHEMA",
+           "$.vec",           "AS",     "first", "VECTOR",  "HNSW",   "6",  "DIM",    "4",
+           "DISTANCE_METRIC", "COSINE", "TYPE",  "FLOAT32", "$.vec",  "AS", "second", "TAG"}),
+      ErrArg("Duplicate field in schema"));
+}
+
+TEST_F(SearchFamilyTest, BareIdentifierOnHashUnchanged) {
+  EXPECT_EQ(Run({"FT.CREATE", "hx", "ON", "HASH", "PREFIX", "1", "hx:", "SCHEMA", "title", "TEXT"}),
+            "OK");
+  Run({"HSET", "hx:1", "title", "alpha"});
+  EXPECT_THAT(Run({"FT.SEARCH", "hx", "@title:alpha"}),
+              IsArray(IntArg(1), "hx:1", IsArray("title", "alpha")));
+}
+
+TEST_F(SearchFamilyTest, HashAllowsSameIdentifierWithDifferentAliases) {
+  // redis-om's HashModel emits this shape for fields marked full_text_search=True:
+  //   description TAG SEPARATOR | description AS description_fts TEXT
+  // Same identifier, two aliases — must be accepted on HASH indexes.
+  EXPECT_EQ(Run({"FT.CREATE", "hx", "ON", "HASH", "PREFIX", "1", "hx:", "SCHEMA", "description",
+                 "TAG", "SEPARATOR", "|", "description", "AS", "description_fts", "TEXT"}),
+            "OK");
+  Run({"HSET", "hx:1", "description", "very fast and elegant"});
+  EXPECT_THAT(Run({"FT.SEARCH", "hx", "@description_fts:fast"}),
+              IsArray(IntArg(1), "hx:1", IsArray("description", "very fast and elegant")));
+}
+
 TEST_F(SearchFamilyTest, ReturnTrailingAsRejected) {
   Run({"FT.CREATE", "idx", "ON", "JSON", "SCHEMA", "$.a", "AS", "a", "TEXT"});
   Run({"JSON.SET", "j1", ".", R"({"a":"alpha"})"});


### PR DESCRIPTION
On JSON indexes, `FT.CREATE` schema attributes had to start with `$` or the command would reject them with `Bad json path`. This change relaxes the rule: a bare identifier (e.g. `vector VECTOR HNSW ...`) is treated as the JSONPath `$.identifier` with the bare token as the implicit alias. Behavior matches Valkey-search's schema syntax and unblocks clients that emit this form, including the `valkey-haystack` document store integration.

Changes:
- `src/server/search/search_family.cc`: in `ParseSchema`, expand a bare identifier on JSON to `$.<identifier>` before JSONPath validation. HASH indexes are unchanged.
- `src/server/search/search_family_test.cc`: four new tests covering bare identifier with KNN, bare with explicit `AS`, alias collision detection, and HASH-parity (no behavior change for HASH).

Notes:
- Pure additive: the bare-identifier form previously errored, so no existing index can rely on the old behavior. Canonical `$.path AS alias TYPE` syntax is untouched.
- Alias collision (e.g. `vector VECTOR ... $.other AS vector ...`) is caught by the existing duplicate-field check.