### PR TITLE
chore: drop extra drakarys logs

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1015,15 +1015,15 @@ util::fb2::Fiber DbSlice::FlushDbIndexes(const std::vector<DbIndex>& indexes) {
 
   ShardId shard_id = owner_->shard_id();
   auto cb = [flush_db_arr = std::move(flush_db_arr), shard_id]() mutable {
-    LOG(INFO) << "Drakarys shard " << shard_id << " cb entered (pre-destructors)"
-              << " rss="
-              << strings::HumanReadableNumBytes(rss_mem_current.load(std::memory_order_relaxed));
+    VLOG(1) << "Drakarys shard " << shard_id << " cb entered (pre-destructors)"
+            << " rss="
+            << strings::HumanReadableNumBytes(rss_mem_current.load(std::memory_order_relaxed));
     flush_db_arr.clear();
     ServerState::tlocal()->DecommitMemory(ServerState::kDataHeap | ServerState::kBackingHeap |
                                           ServerState::kGlibcmalloc);
-    LOG(INFO) << "Drakarys shard " << shard_id << " finished decommit"
-              << " rss="
-              << strings::HumanReadableNumBytes(rss_mem_current.load(std::memory_order_relaxed));
+    VLOG(1) << "Drakarys shard " << shard_id << " finished decommit"
+            << " rss="
+            << strings::HumanReadableNumBytes(rss_mem_current.load(std::memory_order_relaxed));
   };
 
   return {"flush_dbs", std::move(cb)};

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2567,8 +2567,8 @@ bool ServerFamily::TEST_IsSaving() const {
 }
 
 void ServerFamily::Drakarys(Transaction* transaction, DbIndex db_ind, bool wait) {
-  LOG(INFO) << "Drakarys start db=" << db_ind << " wait=" << wait
-            << " rss=" << HumanReadableNumBytes(rss_mem_current.load(std::memory_order_relaxed));
+  VLOG(1) << "Drakarys start db=" << db_ind << " wait=" << wait
+          << " rss=" << HumanReadableNumBytes(rss_mem_current.load(std::memory_order_relaxed));
 
   vector<fb2::Fiber> fibers(shard_set->size());
   transaction->Execute(
@@ -2582,10 +2582,9 @@ void ServerFamily::Drakarys(Transaction* transaction, DbIndex db_ind, bool wait)
   for (auto& f : fibers)
     (f.*action)();
 
-  LOG(INFO) << (wait ? "Drakarys main done (shards joined)"
-                     : "Drakarys main dispatched (shards detached; per-shard 'finished decommit' "
-                       "logs mark real completion)")
-            << " rss=" << HumanReadableNumBytes(rss_mem_current.load(std::memory_order_relaxed));
+  VLOG(1) << (wait ? "Drakarys main done (shards joined)"
+                   : "Drakarys main dispatched (shards detached)")
+          << " rss=" << HumanReadableNumBytes(rss_mem_current.load(std::memory_order_relaxed));
 }
 
 SaveInfoData ServerFamily::GetLastSaveInfo() const {


### PR DESCRIPTION
Summary: Lowers Drakarys-related logging from INFO to VLOG(1) to reduce default log noise.
Changes: Downgrades per-shard callback/decommit progress logs and simplifies the detached-mode completion message.