### PR TITLE
fix(json): surface JSON.DEBUG arg parse errors instead of aborting

### DIFF
--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -1825,6 +1825,9 @@ void CmdDebug(CmdArgList args, CommandContext* cmd_cntx) {
     string_view key = parser.Next();
     string_view path = parser.NextOrDefault();
 
+    if (auto err = parser.TakeError(); err)
+      return builder->SendError(err.MakeReply());
+
     WrappedJsonPath json_path = GET_OR_SEND_UNEXPECTED(ParseJsonPath(path));
 
     ShardId sid = Shard(key, shard_set->size());
@@ -1845,6 +1848,9 @@ void CmdDebug(CmdArgList args, CommandContext* cmd_cntx) {
     // JSON.DEBUG FIELDS
     string_view key = parser.Next();
     string_view path = parser.NextOrDefault();
+
+    if (auto err = parser.TakeError(); err)
+      return builder->SendError(err.MakeReply());
 
     WrappedJsonPath json_path = GET_OR_SEND_UNEXPECTED(ParseJsonPath(path));
 

--- a/src/server/json_family_test.cc
+++ b/src/server/json_family_test.cc
@@ -2656,6 +2656,16 @@ TEST_F(JsonFamilyTest, DebugHelp) {
   EXPECT_THAT(resp.GetVec()[2].GetString(), HasSubstr("HELP"));
 }
 
+TEST_F(JsonFamilyTest, DebugMissingKey) {
+  // Missing key: the default root path parses fine, so the unchecked parser error must
+  // still be surfaced rather than left to abort the parser destructor.
+  auto resp = Run({"JSON.DEBUG", "FIELDS"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
+
+  resp = Run({"JSON.DEBUG", "MEMORY"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
+}
+
 TEST_F(JsonFamilyTest, DebugFields) {
   string json = R"(
     [1, 2.3, "foo", true, null, {}, [], {"a":1, "b":2}, [1,2,3]]


### PR DESCRIPTION
`JSON.DEBUG FIELDS` / `JSON.DEBUG MEMORY` without a key argument aborted the server: the missing-arg parser error was never checked, and the default root path masked it, so the `CmdArgParser` destructor hit `DCHECK(!error_)`.

Fixes #7492