### PR TITLE
ci: run C++ unit tests serially (drop ctest -j)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,10 +119,10 @@ jobs:
       - name: C++ Unit Tests - IoUring
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          echo Run ctest -V -L DFLY -j$(nproc)
+          echo Run ctest -V -L DFLY
 
           GLOG_alsologtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1,op_manager=1,op_manager_test=1 \
-          FLAGS_fiber_safety_margin=4096 timeout 20m ctest -V -L DFLY -j$(nproc) -E allocation_tracker_test
+          FLAGS_fiber_safety_margin=4096 timeout 20m ctest -V -L DFLY -E allocation_tracker_test
 
           # Run allocation tracker test separately without alsologtostderr because it generates a TON of logs.
           FLAGS_fiber_safety_margin=4096 timeout 5m ./allocation_tracker_test
@@ -148,19 +148,19 @@ jobs:
 
           gdb -ix ./init.gdb --batch -ex r --args ./dragonfly_test --force_epoll
           GLOG_alsologtostderr=1 FLAGS_fiber_safety_margin=4096 FLAGS_force_epoll=true GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 \
-          timeout 20m ctest -V -L DFLY -j$(nproc) -E allocation_tracker_test
+          timeout 20m ctest -V -L DFLY -E allocation_tracker_test
 
           FLAGS_fiber_safety_margin=4096 FLAGS_force_epoll=true timeout 5m ./allocation_tracker_test
 
       - name: C++ Unit Tests - IoUring with cluster mode
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          FLAGS_fiber_safety_margin=4096 FLAGS_cluster_mode=emulated timeout 20m ctest -V -L DFLY -j$(nproc)
+          FLAGS_fiber_safety_margin=4096 FLAGS_cluster_mode=emulated timeout 20m ctest -V -L DFLY
 
       - name: C++ Unit Tests - IoUring with cluster mode and FLAGS_lock_on_hashtags
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          FLAGS_fiber_safety_margin=4096 FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true timeout 20m ctest -V -L DFLY -j$(nproc)
+          FLAGS_fiber_safety_margin=4096 FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true timeout 20m ctest -V -L DFLY
 
       - name: Upload unit logs on failure
         if: failure()

--- a/.github/workflows/cov.yml
+++ b/.github/workflows/cov.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Run C++ Unit Tests
         run: |
           cd $GITHUB_WORKSPACE/build
-          ctest -V -L DFLY -j$(nproc)
+          ctest -V -L DFLY
 
       - name: Run Python Integration Tests
         run: |

--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Test
         run: |
             cd $GITHUB_WORKSPACE/build
-            ctest -V -L DFLY -j$(nproc)
+            ctest -V -L DFLY
 
       - name: Send notification on failure
         if: failure() && github.ref == 'refs/heads/main'
@@ -129,7 +129,7 @@ jobs:
       - name: Test
         run: |
             cd $GITHUB_WORKSPACE/build
-            ctest -V -L DFLY -j$(sysctl -n hw.ncpu)
+            ctest -V -L DFLY
 
       - name: Send notification on failure
         if: failure() && github.ref == 'refs/heads/main'


### PR DESCRIPTION
Remove parallel execution (`-j$(nproc)` / `-j$(sysctl -n hw.ncpu)`) from all `ctest -L DFLY` invocations in CI so C++ unit tests run serially.
