### PR TITLE
rdb: test that fails on out of order execution on load

### DIFF
--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -81,6 +81,11 @@ using namespace tiering::literals;
 
 namespace {
 
+bool ReproOrderKey(std::string_view key) {
+  return absl::StartsWith(key, "journal-del-barrier-") ||
+         absl::StartsWith(key, "journal-del-prime-");
+}
+
 int64_t LpGetIntegerIfValid(unsigned char* ele, int* valid) {
   int64_t v = 0;
   *valid = lpGetInteger(ele, &v);
@@ -2690,7 +2695,19 @@ error_code RdbLoaderBase::HandleJournalBlob(Service* service) {
     }
 
     DVLOG(2) << "Executing item: " << entry.ToString();
+    std::string repro_del_key;
+    if (entry.cmd.size() > 1 && absl::EqualsIgnoreCase(entry.cmd[0], "DEL") &&
+        ReproOrderKey(entry.cmd[1])) {
+      repro_del_key = entry.cmd[1];
+    }
+    const bool repro_del = !repro_del_key.empty();
+    if (repro_del) {
+      LOG(INFO) << "REPRO_ORDER journal_execute_begin cmd=DEL key=" << repro_del_key;
+    }
     journal_executor_->Execute(entry.dbid, entry.cmd);
+    if (repro_del) {
+      LOG(INFO) << "REPRO_ORDER journal_execute_end cmd=DEL key=" << repro_del_key;
+    }
   }
 
   return std::error_code{};
@@ -2810,7 +2827,26 @@ void RdbLoader::FlushShardAsync(ShardId sid) {
   if (out_buf.empty())
     return;
 
-  auto cb = [this, ib = std::move(out_buf)] {
+  std::string repro_key;
+  for (const auto* item : out_buf) {
+    if (ReproOrderKey(item->key)) {
+      repro_key = item->key;
+      break;
+    }
+  }
+  size_t item_count = out_buf.size();
+
+  if (!repro_key.empty()) {
+    LOG(INFO) << "REPRO_ORDER rdb_flush_enqueue_begin sid=" << sid << " key=" << repro_key
+              << " items=" << item_count;
+  }
+
+  auto cb = [this, ib = std::move(out_buf), sid, repro_key, item_count] {
+    if (!repro_key.empty()) {
+      LOG(INFO) << "REPRO_ORDER rdb_flush_cb_begin sid=" << sid << " key=" << repro_key
+                << " items=" << item_count;
+    }
+
     auto& db_slice = GetCurrentDbSlice();
 
     // Before we start loading, increment LoadInProgress.
@@ -2819,9 +2855,18 @@ void RdbLoader::FlushShardAsync(ShardId sid) {
     db_slice.IncrLoadInProgress();
     this->LoadItemsBuffer(ib);
     db_slice.DecrLoadInProgress();
+
+    if (!repro_key.empty()) {
+      LOG(INFO) << "REPRO_ORDER rdb_flush_cb_end sid=" << sid << " key=" << repro_key
+                << " items=" << item_count;
+    }
   };
 
   bool preempted = shard_set->Add(sid, std::move(cb));
+  if (!repro_key.empty()) {
+    LOG(INFO) << "REPRO_ORDER rdb_flush_enqueue_end sid=" << sid << " key=" << repro_key
+              << " items=" << item_count << " preempted=" << preempted;
+  }
   VLOG_IF(2, preempted) << "FlushShardAsync was throttled";
 }
 
@@ -2932,12 +2977,22 @@ void RdbLoader::CreateObjectOnShard(const DbContext& db_cntx, const Item* item, 
     return;
   }
 
+  if (ReproOrderKey(item->key)) {
+    LOG(INFO) << "REPRO_ORDER rdb_create_begin sid=" << EngineShard::tlocal()->shard_id()
+              << " key=" << item->key;
+  }
+
   auto op_res = db_slice->AddOrUpdate(db_cntx, item->key, std::move(pv), item->expire_ms);
   if (!op_res) {
     LOG(ERROR) << "OOM failed to add key '" << item->key << "' in DB " << db_ind;
     ec_ = RdbError(errc::out_of_memory);
     stop_early_ = true;
     return;
+  }
+
+  if (ReproOrderKey(item->key)) {
+    LOG(INFO) << "REPRO_ORDER rdb_create_end sid=" << EngineShard::tlocal()->shard_id()
+              << " key=" << item->key;
   }
 
   DbSlice::ItAndUpdater& updater = *op_res;

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -1729,4 +1729,96 @@ TEST_F(RdbTest, TaggedInterleavedRoundTrip) {
   }
 }
 
+std::string MakeJournalDel(std::string_view key) {
+  io::StringSink sink;
+  JournalWriter writer(&sink);
+  writer.Write(journal::Entry{1, journal::Op::COMMAND, 0, std::nullopt,
+                              journal::Entry::Payload("DEL", ArgSlice{key})});
+
+  RdbSerializer serializer(CompressionMode::NONE);
+  CHECK(!serializer.WriteJournalEntry(std::move(sink).str()));
+  return serializer.Flush(RdbSerializer::FlushState::kFlushEndEntry);
+}
+
+TEST_F(RdbTest, JournalDelWaitsForShardLoads) {
+  ASSERT_GT(shard_set->size(), 1u);
+
+  std::string key;
+  for (unsigned i = 0; i < 1000; ++i) {
+    key = StrCat("journal-del-barrier-", i);
+    if (Shard(key, shard_set->size()) != 0)
+      break;
+  }
+  ASSERT_NE(Shard(key, shard_set->size()), 0u);
+  const ShardId sid = Shard(key, shard_set->size());
+
+  // priming key on same shard as key so that it primes the schedule_queues[sid] first
+  std::string priming_key;
+  for (unsigned i = 0; i < 1000; ++i) {
+    priming_key = StrCat("journal-del-prime-", i);
+    if (Shard(priming_key, shard_set->size()) == sid)
+      break;
+  }
+  ASSERT_EQ(Shard(priming_key, shard_set->size()), sid);
+
+  EXPECT_EQ(Run({"FLUSHALL"}), "OK");
+
+  std::atomic_bool release_shard_queue{false};
+
+  // block sid task queue for 50ms. releaser will unlock this after 50ms
+  shard_set->Add(sid, [&] {
+    while (!release_shard_queue.load(std::memory_order_relaxed)) {
+      ThisFiber::SleepFor(chrono::milliseconds(1));
+    }
+  });
+
+  const auto ec = pp_->at(0)->Await([&] {
+    Fiber releaser([&] {
+      ThisFiber::SleepFor(chrono::milliseconds(50));
+      release_shard_queue.store(true, std::memory_order_relaxed);
+    });
+
+    // run priming key so that schedule_queues is already primed and in the shard set task queue by
+    // the time delete runs
+    Fiber scheduler_primer([&] { EXPECT_EQ(Run({"SET", priming_key, "1"}), "OK"); });
+    ThisFiber::SleepFor(chrono::milliseconds(10));
+
+    std::string entry;
+    entry.push_back(RDB_TYPE_STRING);
+    AppendString(&entry, key);
+    AppendString(&entry, "baseline");
+
+    // create artificial rdb
+    // one entry key -> baseline
+    // one delete journal entry for same key
+    std::string body;
+
+    // this entry will be added to task set after the blocked entry from
+    // src/server/rdb_load.cc:2824
+    body += entry;
+    // this entry will be executed directly in the already running batch without going to task queue
+    // task queue will look like this for sid
+    // 1. 50ms blocker
+    // 2. schedule batch in shard (which will run SET priming_key and then DEL key in same batch)
+    // 3. then finally loader callback which creates the key
+    body += MakeJournalDel(key);
+
+    const std::string rdb = WrapInRdb(body);
+    io::BytesSource src{io::Buffer(rdb)};
+    RdbLoadContext load_context;
+    RdbLoader loader(service_.get(), &load_context);
+
+    const auto ec_ = loader.Load(&src);
+    EXPECT_EQ(loader.journal_offset(), std::nullopt);
+    scheduler_primer.Join();
+    releaser.Join();
+    shard_set->Await(sid, [] {});
+    return ec_;
+  });
+
+  ASSERT_FALSE(ec) << ec.message();
+
+  EXPECT_THAT(Run({"GET", key}), ArgType(RespExpr::NIL));
+}
+
 }  // namespace dfly

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -83,6 +83,11 @@ uint16_t trans_id(const Transaction* ptr) {
   return (intptr_t(ptr) >> 8) & 0xFFFF;
 }
 
+bool ReproOrderTx(const Transaction* tx) {
+  std::string_view name = tx->Name();
+  return name == "SET" || name == "DEL";
+}
+
 struct ScheduleContext {
   Transaction* trans;
   bool optimistic_execution = false;
@@ -772,14 +777,30 @@ void Transaction::ScheduleInternal() {
     }
 
     ScheduleContext schedule_ctx{this, optimistic_exec};
+    const std::string_view repro_key =
+        full_args_.empty() ? std::string_view{} : facade::ToSV(full_args_.front());
 
     if (unique_shard_cnt_ == 1) {
       // Single shard optimization. Note: we could apply the same optimization
       // to multi-shard transactions as well by creating a vector of ScheduleContext.
       schedule_queues[unique_shard_id_].queue.Push(&schedule_ctx);
+      if (ReproOrderTx(this)) {
+        LOG(INFO) << "REPRO_ORDER tx_schedule_push cmd=" << Name() << " sid=" << unique_shard_id_
+                  << " key=" << repro_key << " optimistic=" << optimistic_exec;
+      }
       bool current_val = false;
-      if (schedule_queues[unique_shard_id_].armed.compare_exchange_strong(current_val, true,
-                                                                          memory_order_acq_rel)) {
+      const bool added_batch = schedule_queues[unique_shard_id_].armed.compare_exchange_strong(
+          current_val, true, memory_order_acq_rel);
+      if (ReproOrderTx(this)) {
+        LOG(INFO) << "REPRO_ORDER tx_schedule_arm cmd=" << Name() << " sid=" << unique_shard_id_
+                  << " key=" << repro_key << " added_batch=" << added_batch
+                  << " observed_armed=" << current_val;
+      }
+      if (added_batch) {
+        if (ReproOrderTx(this)) {
+          LOG(INFO) << "REPRO_ORDER tx_schedule_add_batch cmd=" << Name()
+                    << " sid=" << unique_shard_id_ << " key=" << repro_key;
+        }
         shard_set->Add(unique_shard_id_, &Transaction::ScheduleBatchInShard);
       }
     } else {
@@ -1285,7 +1306,15 @@ bool Transaction::ScheduleInShard(EngineShard* shard, bool execute_optimistic) {
       sd.local_mask |= OPTIMISTIC_EXECUTION;
       shard->stats().tx_optimistic_total++;
 
+      if (ReproOrderTx(this)) {
+        LOG(INFO) << "REPRO_ORDER tx_run_optimistic_begin cmd=" << Name()
+                  << " sid=" << shard->shard_id() << " key=" << facade::ToSV(full_args_.front());
+      }
       RunCallback(shard);
+      if (ReproOrderTx(this)) {
+        LOG(INFO) << "REPRO_ORDER tx_run_optimistic_end cmd=" << Name()
+                  << " sid=" << shard->shard_id() << " key=" << facade::ToSV(full_args_.front());
+      }
 
       // Check state again, it could've been updated if the callback returned AVOID_CONCLUDING flag.
       // Only possible for single shard.
@@ -1337,6 +1366,8 @@ void Transaction::ScheduleBatchInShard() {
   ShardId sid = shard->shard_id();
   auto& sq = schedule_queues[sid];
 
+  LOG(INFO) << "REPRO_ORDER tx_batch_start sid=" << sid;
+
   for (unsigned j = 0;; ++j) {
     // We pull the items from the queue in a loop until we reach the stop condition.
     // TODO: we may have fairness problem here, where transactions being added up all the time
@@ -1348,8 +1379,22 @@ void Transaction::ScheduleBatchInShard() {
       if (!item)
         break;
 
+      if (ReproOrderTx(item->trans)) {
+        const std::string_view repro_key = item->trans->full_args_.empty()
+                                               ? std::string_view{}
+                                               : facade::ToSV(item->trans->full_args_.front());
+        LOG(INFO) << "REPRO_ORDER tx_batch_pop cmd=" << item->trans->Name() << " sid=" << sid
+                  << " key=" << repro_key << " optimistic=" << item->optimistic_execution;
+      }
       if (!item->trans->ScheduleInShard(shard, item->optimistic_execution)) {
         item->fail_cnt.fetch_add(1, memory_order_relaxed);
+      }
+      if (ReproOrderTx(item->trans)) {
+        const std::string_view repro_key = item->trans->full_args_.empty()
+                                               ? std::string_view{}
+                                               : facade::ToSV(item->trans->full_args_.front());
+        LOG(INFO) << "REPRO_ORDER tx_batch_scheduled cmd=" << item->trans->Name() << " sid=" << sid
+                  << " key=" << repro_key;
       }
       item->trans->FinishHop();
       stats.tx_batch_scheduled_items_total++;
@@ -1366,6 +1411,8 @@ void Transaction::ScheduleBatchInShard() {
     // adding the callback that fetches the transaction.
     sq.armed.exchange(false, memory_order_acq_rel);
   }
+
+  LOG(INFO) << "REPRO_ORDER tx_batch_end sid=" << sid;
 }
 
 bool Transaction::CancelShardCb(EngineShard* shard) {


### PR DESCRIPTION
test sends two commands to rdb loader:

* create key
* delete same key

at the end the key is still present and the test fails

* tagged chunks are not in play
* the key is created on shard != 0 ie where the loader is not running
* before creating the key, a priming key is created which runs schedule batch in shard, that priming key pulls in the new delete command into its own batch without going through `shard_set->Add`
* the SET command for creating the key has to go via the shard set task queue
* end result is out of order 

# Test failure mechanism

On shard which is not where rdb load is running, say rdb load is on shard 0, then on shard 1

* some operation happens, which is on that single shard, it adds `Transaction::ScheduleBatchInShard` to the task queue for shard
* then later we enqueue the key creation on the same shard after the schedule back operation, in the task queue (but we do not wait for the operation to finish)
* the DEL command is executed via journal executor, it is not scheduled but just added to the `schedule_queues[sid]` and will run in batch from step 1
* before batch finishes it runs DEL also
* then the task from step 2 (key creation) happens

test fails with added log

```
I0603 16:09:07.336596  612979 test_utils.cc:269] Starting JournalDelWaitsForShardLoads
--> priming key schedules batch in shard, adds to task queue on shard
I0603 16:09:07.337102  612980 transaction.cc:788] REPRO_ORDER tx_schedule_push cmd=SET sid=1 key=journal-del-prime-1 optimistic=true
I0603 16:09:07.337122  612980 transaction.cc:796] REPRO_ORDER tx_schedule_arm cmd=SET sid=1 key=journal-del-prime-1 added_batch=true observed_armed=false
--> batch is created 
I0603 16:09:07.337129  612980 transaction.cc:802] REPRO_ORDER tx_schedule_add_batch cmd=SET sid=1 key=journal-del-prime-1

--> creation is added to the item buffer during rdb load in task queue after the prime key batch
I0603 16:09:07.347167  612980 rdb_load.cc:2840] REPRO_ORDER rdb_flush_enqueue_begin sid=1 key=journal-del-barrier-0 items=1
I0603 16:09:07.347189  612980 rdb_load.cc:2867] REPRO_ORDER rdb_flush_enqueue_end sid=1 key=journal-del-barrier-0 items=1 preempted=false

--> journal cmd executed
I0603 16:09:07.347214  612980 rdb_load.cc:2705] REPRO_ORDER journal_execute_begin cmd=DEL key=journal-del-barrier-0
I0603 16:09:07.347259  612980 transaction.cc:788] REPRO_ORDER tx_schedule_push cmd=DEL sid=1 key=journal-del-barrier-0 optimistic=true

--> directly added to schedule queue but no batch enqueued, as queue is already armed
I0603 16:09:07.347266  612980 transaction.cc:796] REPRO_ORDER tx_schedule_arm cmd=DEL sid=1 key=journal-del-barrier-0 added_batch=false observed_armed=true

--> batch starts
I0603 16:09:07.387269  612981 transaction.cc:1370] REPRO_ORDER tx_batch_start sid=1
I0603 16:09:07.387303  612981 transaction.cc:1387] REPRO_ORDER tx_batch_pop cmd=SET sid=1 key=journal-del-prime-1 optimistic=true
I0603 16:09:07.387322  612981 transaction.cc:1311] REPRO_ORDER tx_run_optimistic_begin cmd=SET sid=1 key=journal-del-prime-1
I0603 16:09:07.387366  612981 transaction.cc:1316] REPRO_ORDER tx_run_optimistic_end cmd=SET sid=1 key=journal-del-prime-1
I0603 16:09:07.387374  612981 transaction.cc:1397] REPRO_ORDER tx_batch_scheduled cmd=SET sid=1 key=journal-del-prime-1

--> del command is run in batch
I0603 16:09:07.387383  612981 transaction.cc:1387] REPRO_ORDER tx_batch_pop cmd=DEL sid=1 key=journal-del-barrier-0 optimistic=true
I0603 16:09:07.387389  612981 transaction.cc:1311] REPRO_ORDER tx_run_optimistic_begin cmd=DEL sid=1 key=journal-del-barrier-0
I0603 16:09:07.387397  612981 transaction.cc:1316] REPRO_ORDER tx_run_optimistic_end cmd=DEL sid=1 key=journal-del-barrier-0
I0603 16:09:07.387403  612981 transaction.cc:1397] REPRO_ORDER tx_batch_scheduled cmd=DEL sid=1 key=journal-del-barrier-0
I0603 16:09:07.387408  612981 transaction.cc:1416] REPRO_ORDER tx_batch_end sid=1

--> key is created now from load item buffer since we reach it in task queue
I0603 16:09:07.387412  612981 rdb_load.cc:2846] REPRO_ORDER rdb_flush_cb_begin sid=1 key=journal-del-barrier-0 items=1
I0603 16:09:07.387421  612981 rdb_load.cc:2981] REPRO_ORDER rdb_create_begin sid=1 key=journal-del-barrier-0
I0603 16:09:07.387430  612981 rdb_load.cc:2994] REPRO_ORDER rdb_create_end sid=1 key=journal-del-barrier-0
I0603 16:09:07.387436  612981 rdb_load.cc:2860] REPRO_ORDER rdb_flush_cb_end sid=1 key=journal-del-barrier-0 items=1
I0603 16:09:07.387509  612980 rdb_load.cc:2709] REPRO_ORDER journal_execute_end cmd=DEL key=journal-del-barrier-0
I0603 16:09:07.387726  612981 transaction.cc:1370] REPRO_ORDER tx_batch_start sid=1
I0603 16:09:07.387751  612981 transaction.cc:1416] REPRO_ORDER tx_batch_end sid=1
/home/abhijat/dev/cc/dragonfly/src/server/rdb_test.cc:1821: Failure
Value of: Run({"GET", key})
Expected: is nil
  Actual: 'baseline' (of type facade::RespExpr),
Wrong type: string

I0603 16:09:07.399086  612979 test_utils.cc:233] Finishing JournalDelWaitsForShardLoads
[  FAILED  ] RdbTest.JournalDelWaitsForShardLoads (66 ms)
[----------] 1 test from RdbTest (66 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (66 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] RdbTest.JournalDelWaitsForShardLoads

 1 FAILED TEST
```