### PR TITLE
refactor: drop extra dispatch for info replica section

### DIFF
--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -892,7 +892,7 @@ std::vector<ReplicaRoleInfo> DflyCmd::GetReplicasRoleInfo() const {
   return vec;
 }
 
-ReplicationMemoryStats DflyCmd::GetReplicationMemoryStats(EngineShard* shard) const {
+ReplicationMemoryStats DflyCmd::GetReplicationMemoryStats(EngineShard* shard) {
   // Must run on the shard's own proactor: it reads thread-local tl_replica_infos
   // and the shard's flow saver/streamer, which only this thread mutates — so the
   // read is lock-free and a wrong-thread call would report 0/stale stats.

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -892,36 +892,34 @@ std::vector<ReplicaRoleInfo> DflyCmd::GetReplicasRoleInfo() const {
   return vec;
 }
 
-void DflyCmd::GetReplicationMemoryStats(ReplicationMemoryStats* stats) const {
-  atomic<size_t> streamer_bytes{0}, full_sync_bytes{0};
+ReplicationMemoryStats DflyCmd::GetReplicationMemoryStats(EngineShard* shard) const {
+  // Must run on the shard's own proactor: it reads thread-local tl_replica_infos
+  // and the shard's flow saver/streamer, which only this thread mutates — so the
+  // read is lock-free and a wrong-thread call would report 0/stale stats.
+  DCHECK(shard && shard->IsMyThread());
+
+  ReplicationMemoryStats stats;
   auto replica_infos = tl_replica_infos;
   if (!replica_infos)
-    return;
+    return stats;
 
-  // Lock-free read: tl_replica_infos keeps each ReplicaInfo alive, and the cb
-  // runs on each flow's owner shard — the only thread that ever sets or resets
-  // these unique_ptrs. RunBriefInParallel enforces the non-yielding contract.
-  shard_set->RunBriefInParallel([&](EngineShard* shard) {
-    for (const auto& [_, info] : *replica_infos) {
-      DCHECK_GT(info->GetFlowCount(), 0u);
-      if (info->GetFlowCount() == 0)
-        continue;
+  for (const auto& [_, info] : *replica_infos) {
+    DCHECK_GT(info->GetFlowCount(), 0u);
+    if (info->GetFlowCount() == 0)
+      continue;
 
-      const auto& flow = info->GetFlow(shard->shard_id());
-      if (flow.streamer)
-        streamer_bytes.fetch_add(flow.streamer->UsedBytes(), memory_order_relaxed);
-      if (flow.saver) {
-        // Replication-flow savers must be single-shard, otherwise the saver's
-        // GetTotalBuffersSize would internally call RunBriefInParallel and nest.
-        DCHECK(flow.saver->Mode() == SaveMode::SINGLE_SHARD ||
-               flow.saver->Mode() == SaveMode::SINGLE_SHARD_WITH_SUMMARY);
-        full_sync_bytes.fetch_add(flow.saver->GetTotalBuffersSize(), memory_order_relaxed);
-      }
+    const auto& flow = info->GetFlow(shard->shard_id());
+    if (flow.streamer)
+      stats.streamer_buf_capacity_bytes += flow.streamer->UsedBytes();
+    if (flow.saver) {
+      // Replication-flow savers must be single-shard, otherwise the saver's
+      // GetTotalBuffersSize would internally call RunBriefInParallel and nest.
+      DCHECK(flow.saver->Mode() == SaveMode::SINGLE_SHARD ||
+             flow.saver->Mode() == SaveMode::SINGLE_SHARD_WITH_SUMMARY);
+      stats.full_sync_buf_bytes += flow.saver->GetTotalBuffersSize();
     }
-  });
-
-  stats->streamer_buf_capacity_bytes += streamer_bytes.load(memory_order_relaxed);
-  stats->full_sync_buf_bytes += full_sync_bytes.load(memory_order_relaxed);
+  }
+  return stats;
 }
 
 pair<uint32_t, shared_ptr<DflyCmd::ReplicaInfo>> DflyCmd::GetReplicaInfoOrReply(

--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -252,8 +252,7 @@ class DflyCmd {
 
   // Must be called on the given shard's thread (e.g. from the GetMetrics
   // fan-out). Lock-free: reads thread-local replica infos.
-  ReplicationMemoryStats GetReplicationMemoryStats(EngineShard* shard) const
-      ABSL_NO_THREAD_SAFETY_ANALYSIS;
+  static ReplicationMemoryStats GetReplicationMemoryStats(EngineShard* shard);
 
   // Sets metadata.
   void SetDflyClientVersion(ConnectionState* state, DflyVersion version);

--- a/src/server/dflycmd.h
+++ b/src/server/dflycmd.h
@@ -25,6 +25,7 @@ class ListenerInterface;
 
 namespace dfly {
 
+class EngineShard;
 class EngineShardSet;
 class ServerFamily;
 class RdbSaver;
@@ -249,7 +250,10 @@ class DflyCmd {
   // Master-side command. Provides Replica info.
   std::vector<ReplicaRoleInfo> GetReplicasRoleInfo() const ABSL_LOCKS_EXCLUDED(mu_);
 
-  void GetReplicationMemoryStats(ReplicationMemoryStats* out) const ABSL_NO_THREAD_SAFETY_ANALYSIS;
+  // Must be called on the given shard's thread (e.g. from the GetMetrics
+  // fan-out). Lock-free: reads thread-local replica infos.
+  ReplicationMemoryStats GetReplicationMemoryStats(EngineShard* shard) const
+      ABSL_NO_THREAD_SAFETY_ANALYSIS;
 
   // Sets metadata.
   void SetDflyClientVersion(ConnectionState* state, DflyVersion version);

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2048,18 +2048,17 @@ void PrintPrometheusMetrics(uint64_t uptime, const Metrics& m, DflyCmd* dfly_cmd
   } else {  // Master side
     string replication_lag_metrics;
     vector<ReplicaRoleInfo> replicas_info = dfly_cmd->GetReplicasRoleInfo();
-    ReplicationMemoryStats repl_mem;
-    dfly_cmd->GetReplicationMemoryStats(&repl_mem);
     if (legacy) {
       AppendMetricWithoutLabels(
           "replication_streaming_bytes", "Stable sync replication memory usage",
-          repl_mem.streamer_buf_capacity_bytes, MetricType::GAUGE, &resp->body());
+          m.replication_stats.streamer_buf_capacity_bytes, MetricType::GAUGE, &resp->body());
       AppendMetricWithoutLabels("replication_full_sync_bytes", "Full sync memory usage",
-                                repl_mem.full_sync_buf_bytes, MetricType::GAUGE, &resp->body());
+                                m.replication_stats.full_sync_buf_bytes, MetricType::GAUGE,
+                                &resp->body());
     }
-    AppendMetricValue("memory_by_class_bytes", repl_mem.streamer_buf_capacity_bytes, {"class"},
-                      {"replication_streaming"}, &memory_by_class_bytes);
-    AppendMetricValue("memory_by_class_bytes", repl_mem.full_sync_buf_bytes, {"class"},
+    AppendMetricValue("memory_by_class_bytes", m.replication_stats.streamer_buf_capacity_bytes,
+                      {"class"}, {"replication_streaming"}, &memory_by_class_bytes);
+    AppendMetricValue("memory_by_class_bytes", m.replication_stats.full_sync_buf_bytes, {"class"},
                       {"replication_full_sync"}, &memory_by_class_bytes);
 
     AppendMetricWithoutLabels("replication_psync_count", "Pync count",
@@ -3151,7 +3150,7 @@ void ServerFamily::ResetStat(Namespace* ns) {
       });
 }
 
-Metrics ServerFamily::GetMetrics(Namespace* ns) const {
+Metrics ServerFamily::GetMetrics(Namespace* ns, bool collect_replication_memory) const {
   Metrics result;
   util::fb2::Mutex mu;
 
@@ -3207,6 +3206,11 @@ Metrics ServerFamily::GetMetrics(Namespace* ns) const {
         result.lsn_buffer_size += journal::LsnBufferSize();
         result.lsn_buffer_bytes += journal::LsnBufferBytes();
       }
+
+      // Fold the per-shard replication-memory collection into this fan-out
+      // instead of a dedicated RunBriefInParallel in DflyCmd.
+      if (collect_replication_memory)
+        result.replication_stats += dfly_cmd_->GetReplicationMemoryStats(shard);
     }  // if (shard)
 
     result.tls_bytes += Listener::TLSUsedMemoryThreadLocal();
@@ -3435,10 +3439,8 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
 
     // master
     if (!m.replica_side_info) {
-      ReplicationMemoryStats repl_mem;
-      dfly_cmd_->GetReplicationMemoryStats(&repl_mem);
-      append("replication_streaming_buffer_bytes", repl_mem.streamer_buf_capacity_bytes);
-      append("replication_full_sync_buffer_bytes", repl_mem.full_sync_buf_bytes);
+      append("replication_streaming_buffer_bytes", m.replication_stats.streamer_buf_capacity_bytes);
+      append("replication_full_sync_buffer_bytes", m.replication_stats.full_sync_buf_bytes);
     }
 
     if (auto controller_copy = GetSaveController()) {
@@ -3822,6 +3824,7 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
 void ServerFamily::Info(CmdArgList args, CommandContext* cmd_cntx) {
   std::vector<std::string> sections;
   bool need_metrics{false};  // Save time - do not fetch metrics if we don't need them.
+  bool need_repl_mem{false};
   Metrics metrics;
 
   sections.reserve(args.size());
@@ -3831,10 +3834,15 @@ void ServerFamily::Info(CmdArgList args, CommandContext* cmd_cntx) {
     if (!need_metrics && (section != "SERVER") && (section != "REPLICATION")) {
       need_metrics = true;
     }
+    // Mirror should_enter()'s MEMORY gate: the section is rendered for an exact
+    // match or for "ALL" (the empty/no-args case is handled below).
+    if (section == "MEMORY" || section == "ALL") {
+      need_repl_mem = true;
+    }
   }
 
   if (need_metrics || sections.empty()) {
-    metrics = GetMetrics(cmd_cntx->server_conn_cntx()->ns);
+    metrics = GetMetrics(cmd_cntx->server_conn_cntx()->ns, need_repl_mem || sections.empty());
   } else if (!IsMaster()) {
     metrics.replica_side_info = GetReplicaSummary();
   }

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -64,6 +64,12 @@ struct ReplicaRoleInfo {
 struct ReplicationMemoryStats {
   size_t streamer_buf_capacity_bytes = 0;  // total capacities of streamer buffers
   size_t full_sync_buf_bytes = 0;          // total bytes used for full sync buffers
+
+  ReplicationMemoryStats& operator+=(const ReplicationMemoryStats& o) {
+    streamer_buf_capacity_bytes += o.streamer_buf_capacity_bytes;
+    full_sync_buf_bytes += o.full_sync_buf_bytes;
+    return *this;
+  }
 };
 
 struct LoadingStats {
@@ -123,6 +129,9 @@ struct Metrics {
 
   size_t lsn_buffer_size = 0;
   size_t lsn_buffer_bytes = 0;
+
+  // Meaningful only on a master (zero on replicas / no replicas).
+  ReplicationMemoryStats replication_stats;
 
   // CPU cycles timestamp (CycleClock) of the connection stuck on send for longest time.
   uint64_t oldest_pending_send_ts = uint64_t(-1);
@@ -240,7 +249,9 @@ class ServerFamily {
 
   void ResetStat(Namespace* ns);
 
-  Metrics GetMetrics(Namespace* ns) const;
+  // Pass collect_replication_memory=false to skip the per-shard replication
+  // collection when no consumer (INFO MEMORY / metrics) needs it.
+  Metrics GetMetrics(Namespace* ns, bool collect_replication_memory = true) const;
 
   std::string FormatInfoMetrics(const Metrics& metrics, std::string_view section,
                                 bool priveleged) const;

--- a/src/server/server_family_test.cc
+++ b/src/server/server_family_test.cc
@@ -778,4 +778,19 @@ TEST_F(ServerFamilyTest, MemoryParserErrorHandling) {
   EXPECT_THAT(Run({"MEMORY", "DEFRAGMENT", "not-a-float"}), ErrArg("not a valid float"));
 }
 
+TEST_F(ServerFamilyTest, InfoReplicationMemoryNoReplicas) {
+  auto resp = Run({"INFO", "MEMORY"});
+  auto info = resp.GetString();
+  EXPECT_THAT(info, HasSubstr("replication_streaming_buffer_bytes:0"));
+  EXPECT_THAT(info, HasSubstr("replication_full_sync_buffer_bytes:0"));
+}
+
+TEST_F(ServerFamilyTest, InfoReplicationMemoryOnlyInMemorySection) {
+  EXPECT_THAT(Run({"INFO", "REPLICATION"}).GetString(),
+              Not(HasSubstr("replication_streaming_buffer_bytes")));
+  EXPECT_THAT(Run({"INFO", "MEMORY"}).GetString(), HasSubstr("replication_streaming_buffer_bytes"));
+  EXPECT_THAT(Run({"INFO"}).GetString(), HasSubstr("replication_streaming_buffer_bytes"));
+  EXPECT_THAT(Run({"INFO", "ALL"}).GetString(), HasSubstr("replication_streaming_buffer_bytes"));
+}
+
 }  // namespace dfly


### PR DESCRIPTION
part of: #7414
Summary: Refactors master-side replication memory metrics collection to avoid an extra shard fan-out dispatch.

Changes:

- Changes DflyCmd::GetReplicationMemoryStats to return per-shard stats (called on the shard thread) instead of internally running RunBriefInParallel.
- Folds replication-memory collection into ServerFamily::GetMetrics fan-out and stores totals in Metrics::replication_stats.
- Updates Prometheus metrics and INFO MEMORY output to use the pre-collected replication_stats.
- Adds an opt-out flag (collect_replication_memory) to skip replication-memory collection when not needed.
- Adds unit tests to ensure replication memory appears only in INFO MEMORY/ALL (and defaults to 0 with no replicas).

Technical Notes: The new replication-memory path is lock-free w.r.t. replica-info snapshots and assumes a non-yielding, shard-thread execution context during metrics fan-out.