### PR TITLE
fix(server): Disable single shard batch optimization

### DIFF
--- a/docs/transaction.md
+++ b/docs/transaction.md
@@ -191,8 +191,6 @@ On each shard, `PollExecution` checks whether the transaction is at the head of 
 
 As described in [Scheduling a Transaction](#scheduling-a-transaction), single-shard transactions on uncontended keys bypass the global sequence counter, the tx-queue, and the separate execution phase entirely. The callback runs inline during scheduling. This is the most important optimization in the system: it means the vast majority of real-world commands execute with minimal overhead — a single message to the target shard, an inline callback, and done.
 
-Additionally, single-shard scheduling messages are buffered in per-shard MPSC queues. `ScheduleBatchInShard()` drains multiple transactions in a single shard callback, amortizing the per-message dispatch cost.
-
 ### Out-of-order execution
 
 The basic VLL algorithm processes transactions strictly in tx-queue order. The VLL paper addresses this limitation with Selective Contention Analysis (SCA), which scans the queue for blocked transactions whose locks have become available and unblocks them ahead of turn.

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -231,7 +231,7 @@ string EngineShard::TxQueueInfo::Format() const {
 }
 
 EngineShard::Stats& EngineShard::Stats::operator+=(const Stats& o) {
-  static_assert(sizeof(Stats) == 152);
+  static_assert(sizeof(Stats) == 136);
 
 #define ADD(x) x += o.x
 
@@ -244,8 +244,6 @@ EngineShard::Stats& EngineShard::Stats::operator+=(const Stats& o) {
   ADD(poll_execution_total);
   ADD(tx_ooo_total);
   ADD(tx_optimistic_total);
-  ADD(tx_batch_schedule_calls_total);
-  ADD(tx_batch_scheduled_items_total);
   ADD(total_heartbeat_expired_keys);
   ADD(total_heartbeat_expired_bytes);
   ADD(total_heartbeat_expired_calls);

--- a/src/server/engine_shard.h
+++ b/src/server/engine_shard.h
@@ -37,12 +37,6 @@ class EngineShard {
     uint64_t tx_optimistic_total = 0;
     uint64_t tx_ooo_total = 0;
 
-    // Number of ScheduleBatchInShard calls.
-    uint64_t tx_batch_schedule_calls_total = 0;
-
-    // Number of transactions scheduled via ScheduleBatchInShard.
-    uint64_t tx_batch_scheduled_items_total = 0;
-
     uint64_t total_heartbeat_expired_keys = 0;
     uint64_t total_heartbeat_expired_bytes = 0;
     uint64_t total_heartbeat_expired_calls = 0;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1088,7 +1088,6 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
   // InitThreadLocals might block
   pp_.AwaitFiberOnAll(
       [&](uint32_t index, ProactorBase* pb) { sharding::InitThreadLocals(shard_set->size()); });
-  Transaction::Init(shard_num);
 
   shard_set->pool()->AwaitBrief([](unsigned, auto*) {
     facade::Connection::UpdateFromFlags();
@@ -1131,8 +1130,6 @@ void Service::Shutdown() {
 
   delete channel_store;
   channel_store = nullptr;
-
-  Transaction::Shutdown();
 
   pp_.AwaitFiberOnAll([](ProactorBase* pb) {
 #if defined(DFLY_USE_SSL)

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -1728,4 +1728,96 @@ TEST_F(RdbTest, TaggedInterleavedRoundTrip) {
   }
 }
 
+std::string MakeJournalDel(std::string_view key) {
+  io::StringSink sink;
+  JournalWriter writer(&sink);
+  writer.Write(journal::Entry{1, journal::Op::COMMAND, 0, std::nullopt,
+                              journal::Entry::Payload("DEL", ArgSlice{key})});
+
+  RdbSerializer serializer(CompressionMode::NONE);
+  CHECK(!serializer.WriteJournalEntry(std::move(sink).str()));
+  return serializer.Flush(RdbSerializer::FlushState::kFlushEndEntry);
+}
+
+TEST_F(RdbTest, JournalDelWaitsForShardLoads) {
+  ASSERT_GT(shard_set->size(), 1u);
+
+  std::string key;
+  for (unsigned i = 0; i < 1000; ++i) {
+    key = StrCat("journal-del-barrier-", i);
+    if (Shard(key, shard_set->size()) != 0)
+      break;
+  }
+  ASSERT_NE(Shard(key, shard_set->size()), 0u);
+  const ShardId sid = Shard(key, shard_set->size());
+
+  // Priming key on same shard as key so that it can schedule before the RDB load callback.
+  std::string priming_key;
+  for (unsigned i = 0; i < 1000; ++i) {
+    priming_key = StrCat("journal-del-prime-", i);
+    if (Shard(priming_key, shard_set->size()) == sid)
+      break;
+  }
+  ASSERT_EQ(Shard(priming_key, shard_set->size()), sid);
+
+  EXPECT_EQ(Run({"FLUSHALL"}), "OK");
+
+  std::atomic_bool release_shard_queue{false};
+
+  // block sid task queue for 50ms. releaser will unlock this after 50ms
+  shard_set->Add(sid, [&] {
+    while (!release_shard_queue.load(std::memory_order_relaxed)) {
+      ThisFiber::SleepFor(chrono::milliseconds(1));
+    }
+  });
+
+  const auto ec = pp_->at(0)->Await([&] {
+    Fiber releaser([&] {
+      ThisFiber::SleepFor(chrono::milliseconds(50));
+      release_shard_queue.store(true, std::memory_order_relaxed);
+    });
+
+    // Run priming key so that transaction scheduling is already in the shard set task queue by the
+    // time delete runs.
+    Fiber scheduler_primer([&] { EXPECT_EQ(Run({"SET", priming_key, "1"}), "OK"); });
+    ThisFiber::SleepFor(chrono::milliseconds(10));
+
+    std::string entry;
+    entry.push_back(RDB_TYPE_STRING);
+    AppendString(&entry, key);
+    AppendString(&entry, "baseline");
+
+    // create artificial rdb
+    // one entry key -> baseline
+    // one delete journal entry for same key
+    std::string body;
+
+    // this entry will be added to task set after the blocked entry from
+    // src/server/rdb_load.cc:2824
+    body += entry;
+    // this entry will be executed directly in the already running batch without going to task queue
+    // task queue will look like this for sid
+    // 1. 50ms blocker
+    // 2. schedule batch in shard (which will run SET priming_key and then DEL key in same batch)
+    // 3. then finally loader callback which creates the key
+    body += MakeJournalDel(key);
+
+    const std::string rdb = WrapInRdb(body);
+    io::BytesSource src{io::Buffer(rdb)};
+    RdbLoadContext load_context;
+    RdbLoader loader(service_.get(), &load_context);
+
+    const auto ec_ = loader.Load(&src);
+    EXPECT_EQ(loader.journal_offset(), std::nullopt);
+    scheduler_primer.Join();
+    releaser.Join();
+    shard_set->Await(sid, [] {});
+    return ec_;
+  });
+
+  ASSERT_FALSE(ec) << ec.message();
+
+  EXPECT_THAT(Run({"GET", key}), ArgType(RespExpr::NIL));
+}
+
 }  // namespace dfly

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -3600,8 +3600,6 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
     append("tx_normal_total", m.coordinator_stats.tx_normal_cnt);
     append("tx_inline_runs_total", m.coordinator_stats.tx_inline_runs);
     append("tx_schedule_cancel_total", m.coordinator_stats.tx_schedule_cancel_cnt);
-    append("tx_batch_scheduled_items_total", m.shard_stats.tx_batch_scheduled_items_total);
-    append("tx_batch_schedule_calls_total", m.shard_stats.tx_batch_schedule_calls_total);
     append("tx_with_freq", absl::StrJoin(m.coordinator_stats.tx_width_freq_arr, ","));
     append("squash_with_freq", absl::StrJoin(m.coordinator_stats.squash_width_freq_arr, ","));
     append("tx_queue_len", m.tx_queue_len);

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -7,7 +7,6 @@
 #include <absl/strings/match.h>
 
 #include <memory>
-#include <new>
 
 #include "base/flags.h"
 #include "base/logging.h"
@@ -87,30 +86,11 @@ struct ScheduleContext {
   Transaction* trans;
   bool optimistic_execution = false;
 
-  std::atomic<ScheduleContext*> next{nullptr};
-
   std::atomic_uint32_t fail_cnt{0};
 
   ScheduleContext(Transaction* t, bool optimistic) : trans(t), optimistic_execution(optimistic) {
   }
 };
-
-constexpr size_t kAvoidFalseSharingSize = 64;
-struct ScheduleQ {
-  alignas(kAvoidFalseSharingSize) base::MPSCIntrusiveQueue<ScheduleContext> queue;
-  alignas(kAvoidFalseSharingSize) atomic_bool armed{false};
-};
-
-void MPSC_intrusive_store_next(ScheduleContext* dest, ScheduleContext* next_node) {
-  dest->next.store(next_node, std::memory_order_relaxed);
-}
-
-ScheduleContext* MPSC_intrusive_load_next(const ScheduleContext& src) {
-  return src.next.load(std::memory_order_acquire);
-}
-
-// of shard_num arity.
-ScheduleQ* schedule_queues = nullptr;
 
 }  // namespace
 
@@ -165,17 +145,6 @@ Transaction::Guard::~Guard() {
   };
   tx->Execute(cb, true);
   tx->Refurbish();
-}
-
-void Transaction::Init(unsigned num_shards) {
-  DCHECK(schedule_queues == nullptr);
-  schedule_queues = new ScheduleQ[num_shards];
-}
-
-void Transaction::Shutdown() {
-  DCHECK(schedule_queues);
-  delete[] schedule_queues;
-  schedule_queues = nullptr;
 }
 
 Transaction::Transaction(const CommandId* cid) : cid_{cid} {
@@ -773,24 +742,17 @@ void Transaction::ScheduleInternal() {
 
     ScheduleContext schedule_ctx{this, optimistic_exec};
 
-    if (unique_shard_cnt_ == 1) {
-      // Single shard optimization. Note: we could apply the same optimization
-      // to multi-shard transactions as well by creating a vector of ScheduleContext.
-      schedule_queues[unique_shard_id_].queue.Push(&schedule_ctx);
-      bool current_val = false;
-      if (schedule_queues[unique_shard_id_].armed.compare_exchange_strong(current_val, true,
-                                                                          memory_order_acq_rel)) {
-        shard_set->Add(unique_shard_id_, &Transaction::ScheduleBatchInShard);
+    auto cb = [&schedule_ctx] {
+      if (!schedule_ctx.trans->ScheduleInShard(EngineShard::tlocal(),
+                                               schedule_ctx.optimistic_execution)) {
+        schedule_ctx.fail_cnt.fetch_add(1, memory_order_relaxed);
       }
-    } else {
-      auto cb = [&schedule_ctx] {
-        if (!schedule_ctx.trans->ScheduleInShard(EngineShard::tlocal(),
-                                                 schedule_ctx.optimistic_execution)) {
-          schedule_ctx.fail_cnt.fetch_add(1, memory_order_relaxed);
-        }
-        schedule_ctx.trans->FinishHop();
-      };
+      schedule_ctx.trans->FinishHop();
+    };
 
+    if (unique_shard_cnt_ == 1) {
+      shard_set->Add(unique_shard_id_, cb);
+    } else {
       IterateActiveShards([cb](const auto& sd, ShardId i) { shard_set->Add(i, cb); });
 
       // Add this debugging function to print more information when we experience deadlock
@@ -1327,45 +1289,6 @@ bool Transaction::ScheduleInShard(EngineShard* shard, bool execute_optimistic) {
   DVLOG(1) << "Insert into tx-queue, sid(" << sid << ") " << DebugId() << ", qlen " << txq->size();
 
   return true;
-}
-
-void Transaction::ScheduleBatchInShard() {
-  EngineShard* shard = EngineShard::tlocal();
-  auto& stats = shard->stats();
-  stats.tx_batch_schedule_calls_total++;
-
-  ShardId sid = shard->shard_id();
-  auto& sq = schedule_queues[sid];
-
-  for (unsigned j = 0;; ++j) {
-    // We pull the items from the queue in a loop until we reach the stop condition.
-    // TODO: we may have fairness problem here, where transactions being added up all the time
-    // and we never break from the loop. It is possible to break early but it's not trivial
-    // because we must ensure that there is another ScheduleBatchInShard callback in the queue.
-    // Can be checked with testing sq.armed is true when j == 1.
-    while (true) {
-      ScheduleContext* item = sq.queue.Pop();
-      if (!item)
-        break;
-
-      if (!item->trans->ScheduleInShard(shard, item->optimistic_execution)) {
-        item->fail_cnt.fetch_add(1, memory_order_relaxed);
-      }
-      item->trans->FinishHop();
-      stats.tx_batch_scheduled_items_total++;
-    };
-
-    // j==1 means we already signalled that we're done with the current batch.
-    if (j == 1)
-      break;
-
-    // We signal that we're done with the current batch but then we check if there are more
-    // transactions to fetch in the next iteration.
-    // We do this to avoid the situation where we have a data race, where
-    // a transaction is added to the queue, we've checked that sq.armed is true and skipped
-    // adding the callback that fetches the transaction.
-    sq.armed.exchange(false, memory_order_acq_rel);
-  }
 }
 
 bool Transaction::CancelShardCb(EngineShard* shard) {

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -176,9 +176,6 @@ class Transaction {
     Transaction* tx;
   };
 
-  static void Init(unsigned num_shards);
-  static void Shutdown();
-
   explicit Transaction(const CommandId* cid);
 
   // Initialize transaction for squashing placed on a specific shard with a given parent tx
@@ -519,9 +516,6 @@ class Transaction {
   // if execute_optimistic is true - means we can try executing during the scheduling,
   // subject to uncontended keys.
   bool ScheduleInShard(EngineShard* shard, bool execute_optimistic);
-
-  // Optimized extension of ScheduleInShard. Pulls several transactions queued for scheduling.
-  static void ScheduleBatchInShard();
 
   // Set ARMED flags, start run barrier and submit poll tasks. Doesn't wait for the run barrier
   void DispatchHop();


### PR DESCRIPTION
It was recently seen that there is a correctness issue with batch scheduling for single shard tx, which is seen in the unit test added here as below as well as in https://github.com/dragonflydb/dragonfly/issues/7476

test sends two commands to rdb loader:

- create key
- delete same key

at the end the key is still present and the test fails. the following preconditions are necessary

- the key is created on shard != 0 ie where the loader is not running
- before creating the key, a priming key is created which runs schedule batch in shard, that priming key pulls in the new delete command into its own batch without going through shard_set->Add
- the SET command for creating the key has to go via the shard set task queue
- end result is out of order

The root cause is because we have the following sequence

expected shard task queue order FIFO

A = create priming key
B = create actual key  (wrapped in CreateObjectOnShard etc)
C = DEL key

```
tx A -> task B -> tx C
```

what happens is the below

```
tx A -> task B
[tx C]
```

tx C gets latched on to the batch triggered by tx A as it skips shard set add altogether. whereas task B goes on to task set add via rdb load without any such short cuts

The batching is removed altogether to remove this correctness bug, the schedule queue and associated code and metrics are also removed.

FIXES https://github.com/dragonflydb/dragonfly/issues/7476

several past PRs are involved here, adding them as cross reference

https://github.com/dragonflydb/dragonfly/pull/3794
https://github.com/dragonflydb/dragonfly/pull/3819
https://github.com/dragonflydb/dragonfly/pull/4647
https://github.com/dragonflydb/dragonfly/pull/4925