### PR TITLE
CI/build: switch from glog to absl

### DIFF
--- a/.github/actions/builder/action.yml
+++ b/.github/actions/builder/action.yml
@@ -85,7 +85,7 @@ runs:
           -DWITH_GPERF=OFF
           -DWITH_ASAN="${ASAN}"
           -DWITH_USAN="${USAN}"
-          -DLEGACY_GLOG=ON
+          -DLEGACY_GLOG=OFF
         )
 
         # Execute CMake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,8 @@ if (HAS_SPLIT_DWARF_C)
   add_compile_options($<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:C>>:-gsplit-dwarf>)
 endif()
 
+set(LEGACY_GLOG OFF CACHE BOOL "Use absl instead of glog")
+
 include(third_party)
 include(internal)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ if (HAS_SPLIT_DWARF_C)
   add_compile_options($<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:C>>:-gsplit-dwarf>)
 endif()
 
-set(LEGACY_GLOG OFF CACHE BOOL "Use absl instead of glog")
+set(LEGACY_GLOG OFF CACHE BOOL "Use legacy glog instead of absl")
 
 include(third_party)
 include(internal)


### PR DESCRIPTION
Recently we switched from glog -> absl and the test in https://github.com/dragonflydb/dragonfly/pull/7446 started failing. We briefly switched absl -> glog again. 

After investigation https://github.com/dragonflydb/dragonfly/issues/7471 it is seen that absl does use marginal, constant higher memory around 2 MiB. 

The test has been fixed separately in the linked PR, here we switch back to absl since a small constant overhead is acceptable.