### PR TITLE
fix: batched backpressure

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2938,23 +2938,6 @@ void Service::OnConnectionClose(facade::ConnectionContext* cntx) {
   conn_state.tracking_info_.SetClientTracking(false);
 }
 
-void Service::RegisterTieringFlags() {
-#ifdef WITH_TIERING
-  // TODO(vlad): Introduce templatable flag cache
-  auto update_tiered_storage = [](auto) {
-    shard_set->pool()->AwaitBrief([](unsigned, auto*) {
-      if (auto* es = EngineShard::tlocal(); es && es->tiered_storage()) {
-        es->tiered_storage()->UpdateFromFlags();
-      }
-    });
-  };
-  config_registry.RegisterSetter<bool>("tiered_experimental_cooling", update_tiered_storage);
-  config_registry.RegisterSetter<unsigned>("tiered_storage_write_depth", update_tiered_storage);
-  config_registry.RegisterSetter<float>("tiered_offload_threshold", update_tiered_storage);
-  config_registry.RegisterSetter<float>("tiered_upload_threshold", update_tiered_storage);
-#endif
-}
-
 Service::ContextInfo Service::GetContextInfo(facade::ConnectionContext* cntx) const {
   ConnectionContext* server_cntx = static_cast<ConnectionContext*>(cntx);
   bool is_scheduled = server_cntx->transaction && server_cntx->transaction->IsScheduled() &&

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -3528,6 +3528,7 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
 
     append("tiered_pending_read_cnt", m.tiered_stats.pending_read_cnt);
     append("tiered_pending_stash_cnt", m.tiered_stats.pending_stash_cnt);
+    append("tiered_pending_stash_bytes", m.tiered_stats.pending_stash_bytes);
 
     append("tiered_small_bins_cnt", m.tiered_stats.small_bins_cnt);
     append("tiered_small_bins_entries_cnt", m.tiered_stats.small_bins_entries_cnt);

--- a/src/server/stats.cc
+++ b/src/server/stats.cc
@@ -11,7 +11,7 @@ namespace dfly {
 #define ADD(x) (x) += o.x
 
 TieredStats& TieredStats::operator+=(const TieredStats& o) {
-  static_assert(sizeof(TieredStats) == 168);
+  static_assert(sizeof(TieredStats) == 176);
 
   ADD(total_stashes);
   ADD(total_fetches);
@@ -35,6 +35,7 @@ TieredStats& TieredStats::operator+=(const TieredStats& o) {
 
   ADD(total_stash_overflows);
   ADD(cold_storage_bytes);
+  ADD(pending_stash_bytes);
   ADD(total_offloading_steps);
   ADD(total_offloading_stashes);
 

--- a/src/server/stats.h
+++ b/src/server/stats.h
@@ -73,6 +73,9 @@ struct TieredStats {
   // Memory used by the cooling layer (recently stashed values held before full eviction).
   size_t cold_storage_bytes = 0;
 
+  // Bytes currently in-flight to disk (submitted stash IOs not yet completed).
+  size_t pending_stash_bytes = 0;
+
   // Current number of throttled clients.
   uint64_t clients_throttled = 0;
 

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -661,11 +661,11 @@ void TieredStorage::RunOffloading(DbIndex dbid) {
   // Loop over entry with time and max stash budget.
   uint64_t cycles = 0;
   do {
-    offloading_cursor_ = table.TraverseBySegmentOrder(offloading_cursor_, cb);
-
     // We hit backpressure limit, so stop
     if (op_manager_->GetStats().disk_stats.pending_stash_bytes >= config_.max_pending_stash_bytes)
       break;
+
+    offloading_cursor_ = table.TraverseBySegmentOrder(offloading_cursor_, cb);
 
     // TODO: yield as background fiber to perform more work on idle
     // Limit allowed cpu-timeslice
@@ -731,12 +731,10 @@ auto TieredStorage::ShouldStash(const tiering::FragmentRef& fragment_ref) const
   if (fragment_ref.ObjType() == OBJ_LIST && !OccupiesWholePages(estimated_size))
     return nullopt;
 
-  // Don't oversaturate disk with too many writes (backpressure should try to avoid this branch)
+  // Track if we oversature disk (backpressure fails to stop clients, possibly many new)
   const auto& disk_stats = op_manager_->GetStats().disk_stats;
-  if (disk_stats.pending_stash_bytes >= config_.max_pending_stash_bytes) {
+  if (disk_stats.pending_stash_bytes >= 2 * config_.max_pending_stash_bytes)
     ++stats_.stash_overflow_cnt;
-    return nullopt;
-  }
 
   if (disk_stats.allocated_bytes + tiering::kPageSize + estimated_size < disk_stats.max_file_size) {
     return blobs;

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -49,7 +49,8 @@ ABSL_RETIRED_FLAG(unsigned, tiered_storage_write_depth, 200,
                   "Maximum number of concurrent stash requests issued by background offload. "
                   "Deprecated: prefer tiered_max_pending_stash_bytes.");
 
-ABSL_FLAG(strings::MemoryBytesFlag, tiered_max_pending_stash_bytes, 16_MB,
+// 1MB is a realistic upper limit for moden NVMe drives: in-flight = avg latency * throughput/s
+ABSL_FLAG(strings::MemoryBytesFlag, tiered_max_pending_stash_bytes, 1_MB,
           "Maximum bytes in-flight to disk before rejecting new stashes or applying client "
           "backpressure. Allows batching writes to saturate disk I/O even with few clients");
 

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -29,6 +29,7 @@
 #include "server/tiering/decoders.h"
 #include "server/tiering/op_manager.h"
 #include "server/tiering/small_bins.h"
+#include "strings/human_readable.h"
 
 extern "C" {
 #include "redis/listpack.h"
@@ -44,8 +45,13 @@ ABSL_FLAG(bool, tiered_experimental_cooling, true,
           "If true, uses intermediate cooling layer "
           "when offloading values to storage");
 
-ABSL_FLAG(unsigned, tiered_storage_write_depth, 200,
-          "Maximum number of concurrent stash requests issued by background offload");
+ABSL_RETIRED_FLAG(unsigned, tiered_storage_write_depth, 200,
+                  "Maximum number of concurrent stash requests issued by background offload. "
+                  "Deprecated: prefer tiered_max_pending_stash_bytes.");
+
+ABSL_FLAG(strings::MemoryBytesFlag, tiered_max_pending_stash_bytes, 16_MB,
+          "Maximum bytes in-flight to disk before rejecting new stashes or applying client "
+          "backpressure. Allows batching writes to saturate disk I/O even with few clients");
 
 ABSL_FLAG(float, tiered_offload_threshold, 0.5,
           "Ratio of free memory (free/max memory) below which offloading starts");
@@ -508,8 +514,8 @@ void TieredStorage::StashPrimeValue(DbIndex dbid, string_view key, const StashDe
     return;
   }
 
-  // If we are in the active offloading phase, throttle stashes by providing backpressure future
-  if (backpressure && ShouldOffload()) {
+  // Throttle if we're low on memory and reached the offloading limit
+  if (backpressure && ShouldOffload() && WriteDepthUsage() >= 1.0f) {
     stats_.total_clients_throttled++;
     *backpressure = stash_backpressure_[{dbid, string{key}}];
   }
@@ -561,6 +567,7 @@ TieredStats TieredStorage::GetStats() const {
     stats.pending_stash_cnt = op_stats.pending_stash_cnt;
     stats.allocated_bytes = op_stats.disk_stats.allocated_bytes;
     stats.capacity_bytes = op_stats.disk_stats.capacity_bytes;
+    stats.pending_stash_bytes = op_stats.disk_stats.pending_stash_bytes;
     stats.total_heap_buf_allocs = op_stats.disk_stats.heap_buf_alloc_count;
     stats.total_registered_buf_allocs = op_stats.disk_stats.registered_buf_alloc_count;
   }
@@ -585,14 +592,15 @@ TieredStats TieredStorage::GetStats() const {
 }
 
 float TieredStorage::WriteDepthUsage() const {
-  return 1.0f * op_manager_->GetStats().pending_stash_cnt / config_.write_depth_limit;
+  auto disk_stats = op_manager_->GetStats().disk_stats;
+  return 1.0f * float(disk_stats.pending_stash_bytes) / float(config_.max_pending_stash_bytes);
 }
 
 void TieredStorage::UpdateFromFlags() {
   config_ = {
       .min_value_size = absl::GetFlag(FLAGS_tiered_min_value_size),
       .experimental_cooling = absl::GetFlag(FLAGS_tiered_experimental_cooling),
-      .write_depth_limit = absl::GetFlag(FLAGS_tiered_storage_write_depth),
+      .max_pending_stash_bytes = absl::GetFlag(FLAGS_tiered_max_pending_stash_bytes),
       .offload_threshold = absl::GetFlag(FLAGS_tiered_offload_threshold),
       .upload_threshold = absl::GetFlag(FLAGS_tiered_upload_threshold),
       .experimental_hash_offload = absl::GetFlag(FLAGS_tiered_experimental_hash_support),
@@ -602,7 +610,7 @@ void TieredStorage::UpdateFromFlags() {
 
 std::vector<std::string> TieredStorage::GetMutableFlagNames() {
   return base::GetFlagNames(FLAGS_tiered_min_value_size, FLAGS_tiered_experimental_cooling,
-                            FLAGS_tiered_storage_write_depth, FLAGS_tiered_offload_threshold,
+                            FLAGS_tiered_max_pending_stash_bytes, FLAGS_tiered_offload_threshold,
                             FLAGS_tiered_upload_threshold, FLAGS_tiered_experimental_hash_support,
                             FLAGS_tiered_experimental_list_support);
 }
@@ -654,10 +662,12 @@ void TieredStorage::RunOffloading(DbIndex dbid) {
   do {
     offloading_cursor_ = table.TraverseBySegmentOrder(offloading_cursor_, cb);
 
-    if (op_manager_->GetStats().pending_stash_cnt >= config_.write_depth_limit)
+    // We hit backpressure limit, so stop
+    if (op_manager_->GetStats().disk_stats.pending_stash_bytes >= config_.max_pending_stash_bytes)
       break;
 
     // TODO: yield as background fiber to perform more work on idle
+    // Limit allowed cpu-timeslice
     cycles = base::CycleClock::Now() - start_cycles;
     if (base::CycleClock::ToUsec(cycles) >= 100)
       break;
@@ -720,13 +730,13 @@ auto TieredStorage::ShouldStash(const tiering::FragmentRef& fragment_ref) const
   if (fragment_ref.ObjType() == OBJ_LIST && !OccupiesWholePages(estimated_size))
     return nullopt;
 
-  // Limit write depth. TODO: Provide backpressure?
-  if (op_manager_->GetStats().pending_stash_cnt >= config_.write_depth_limit) {
+  // Don't oversaturate disk with too many writes (backpressure should try to avoid this branch)
+  const auto& disk_stats = op_manager_->GetStats().disk_stats;
+  if (disk_stats.pending_stash_bytes >= config_.max_pending_stash_bytes) {
     ++stats_.stash_overflow_cnt;
-    return {};
+    return nullopt;
   }
 
-  const auto& disk_stats = op_manager_->GetStats().disk_stats;
   if (disk_stats.allocated_bytes + tiering::kPageSize + estimated_size < disk_stats.max_file_size) {
     return blobs;
   }

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -49,8 +49,8 @@ ABSL_RETIRED_FLAG(unsigned, tiered_storage_write_depth, 200,
                   "Maximum number of concurrent stash requests issued by background offload. "
                   "Deprecated: prefer tiered_max_pending_stash_bytes.");
 
-// 1MB is a realistic upper limit for moden NVMe drives: in-flight = avg latency * throughput/s
-ABSL_FLAG(strings::MemoryBytesFlag, tiered_max_pending_stash_bytes, 1_MB,
+// 256kb is a realistic limit for moden NVMe drives: in-flight = avg latency * throughput/s
+ABSL_FLAG(strings::MemoryBytesFlag, tiered_max_pending_stash_bytes, 256_KB,
           "Maximum bytes in-flight to disk before rejecting new stashes or applying client "
           "backpressure. Allows batching writes to saturate disk I/O even with few clients");
 

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -150,7 +150,7 @@ class TieredStorage : public TieredStorageBase {
   struct {
     size_t min_value_size;
     bool experimental_cooling;
-    unsigned write_depth_limit;
+    size_t max_pending_stash_bytes;
     float offload_threshold;
     float upload_threshold;
     bool experimental_hash_offload;

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -26,6 +26,7 @@ ABSL_DECLARE_FLAG(string, tiered_prefix);
 ABSL_DECLARE_FLAG(float, tiered_offload_threshold);
 ABSL_DECLARE_FLAG(float, tiered_upload_threshold);
 ABSL_DECLARE_FLAG(unsigned, tiered_storage_write_depth);
+ABSL_DECLARE_FLAG(size_t, tiered_max_pending_stash_bytes);
 ABSL_DECLARE_FLAG(bool, tiered_experimental_cooling);
 ABSL_DECLARE_FLAG(uint64_t, registered_buffer_size);
 ABSL_DECLARE_FLAG(bool, tiered_experimental_hash_support);
@@ -498,6 +499,8 @@ TEST_F(TieredStorageTest, FlushPending) {
 TEST_F(PureDiskTSTest, ThrottleClients) {
   absl::FlagSaver saver;
   absl::SetFlag(&FLAGS_tiered_upload_threshold, 0.0);
+  // Set low pending bytes limit so throttling kicks in quickly
+  absl::SetFlag(&FLAGS_tiered_max_pending_stash_bytes, 32_MB);
   UpdateFromFlags();
 
   // issue client pause to accumualte SETs

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -8,8 +8,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <string>
-
 #include "absl/flags/internal/flag.h"
 #include "absl/flags/reflection.h"
 #include "base/flags.h"
@@ -501,8 +499,8 @@ TEST_F(TieredStorageTest, FlushPending) {
 TEST_F(PureDiskTSTest, ThrottleClients) {
   absl::FlagSaver saver;
   absl::SetFlag(&FLAGS_tiered_upload_threshold, 0.0);
-  // Set low pending bytes limit so throttling kicks in quickly
-  absl::SetFlag(&FLAGS_tiered_max_pending_stash_bytes, 100);
+  // Set low limit so all clients are throttled
+  absl::SetFlag(&FLAGS_tiered_max_pending_stash_bytes, 1);
   UpdateFromFlags();
 
   // issue client pause to accumualte SETs

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -8,6 +8,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <string>
+
 #include "absl/flags/internal/flag.h"
 #include "absl/flags/reflection.h"
 #include "base/flags.h"
@@ -15,6 +17,7 @@
 #include "facade/facade_test.h"
 #include "server/engine_shard_set.h"
 #include "server/test_utils.h"
+#include "strings/human_readable.h"
 #include "util/fibers/fibers.h"
 
 using namespace std;
@@ -25,8 +28,7 @@ ABSL_DECLARE_FLAG(bool, force_epoll);
 ABSL_DECLARE_FLAG(string, tiered_prefix);
 ABSL_DECLARE_FLAG(float, tiered_offload_threshold);
 ABSL_DECLARE_FLAG(float, tiered_upload_threshold);
-ABSL_DECLARE_FLAG(unsigned, tiered_storage_write_depth);
-ABSL_DECLARE_FLAG(size_t, tiered_max_pending_stash_bytes);
+ABSL_DECLARE_FLAG(strings::MemoryBytesFlag, tiered_max_pending_stash_bytes);
 ABSL_DECLARE_FLAG(bool, tiered_experimental_cooling);
 ABSL_DECLARE_FLAG(uint64_t, registered_buffer_size);
 ABSL_DECLARE_FLAG(bool, tiered_experimental_hash_support);
@@ -61,7 +63,7 @@ class TieredStorageTest : public BaseFamilyTest {
       SetFlag(&FLAGS_registered_buffer_size, 0);
     }
 
-    SetFlag(&FLAGS_tiered_storage_write_depth, 15000);
+    SetFlag(&FLAGS_tiered_max_pending_stash_bytes, 32_MB);
     if (GetFlag(FLAGS_tiered_prefix).empty()) {
       SetFlag(&FLAGS_tiered_prefix, "/tmp/tiered_storage_test");
     }
@@ -500,7 +502,7 @@ TEST_F(PureDiskTSTest, ThrottleClients) {
   absl::FlagSaver saver;
   absl::SetFlag(&FLAGS_tiered_upload_threshold, 0.0);
   // Set low pending bytes limit so throttling kicks in quickly
-  absl::SetFlag(&FLAGS_tiered_max_pending_stash_bytes, 32_MB);
+  absl::SetFlag(&FLAGS_tiered_max_pending_stash_bytes, 100);
   UpdateFromFlags();
 
   // issue client pause to accumualte SETs

--- a/src/server/tiering/disk_storage.cc
+++ b/src/server/tiering/disk_storage.cc
@@ -181,8 +181,7 @@ io::Result<std::pair<size_t, RegisteredSlice>> DiskStorage::PrepareStash(size_t 
 }
 
 void DiskStorage::Stash(DiskSegment segment, RegisteredSlice buf, StashCb cb) {
-  size_t stash_len = segment.length;
-  auto io_cb = [this, cb = std::move(cb), buf, segment, stash_len](int io_res) {
+  auto io_cb = [this, cb = std::move(cb), buf, segment](int io_res) {
     if (io_res < 0) {
       MarkAsFree(segment);
       cb(error_code{-io_res, std::system_category()});
@@ -191,11 +190,11 @@ void DiskStorage::Stash(DiskSegment segment, RegisteredSlice buf, StashCb cb) {
     }
     ReturnBuf(buf);
     pending_ops_--;
-    pending_stash_bytes_ -= stash_len;
+    pending_stash_bytes_ -= segment.length;
   };
 
   pending_ops_++;
-  pending_stash_bytes_ += stash_len;
+  pending_stash_bytes_ += segment.length;
   size_t offset = segment.offset;
   if (buf.buf_idx != kHeapSliceId)
     backing_file_->WriteFixedAsync(buf.bytes, offset, buf.buf_idx, std::move(io_cb));

--- a/src/server/tiering/disk_storage.cc
+++ b/src/server/tiering/disk_storage.cc
@@ -181,7 +181,8 @@ io::Result<std::pair<size_t, RegisteredSlice>> DiskStorage::PrepareStash(size_t 
 }
 
 void DiskStorage::Stash(DiskSegment segment, RegisteredSlice buf, StashCb cb) {
-  auto io_cb = [this, cb = std::move(cb), buf, segment](int io_res) {
+  size_t stash_len = segment.length;
+  auto io_cb = [this, cb = std::move(cb), buf, segment, stash_len](int io_res) {
     if (io_res < 0) {
       MarkAsFree(segment);
       cb(error_code{-io_res, std::system_category()});
@@ -190,9 +191,11 @@ void DiskStorage::Stash(DiskSegment segment, RegisteredSlice buf, StashCb cb) {
     }
     ReturnBuf(buf);
     pending_ops_--;
+    pending_stash_bytes_ -= stash_len;
   };
 
   pending_ops_++;
+  pending_stash_bytes_ += stash_len;
   size_t offset = segment.offset;
   if (buf.buf_idx != kHeapSliceId)
     backing_file_->WriteFixedAsync(buf.bytes, offset, buf.buf_idx, std::move(io_cb));
@@ -211,7 +214,7 @@ void DiskStorage::Stash(DiskSegment segment, RegisteredSlice buf, StashCb cb) {
 DiskStorage::Stats DiskStorage::GetStats() const {
   return {
       alloc_.allocated_bytes(),       alloc_.capacity(), heap_buf_alloc_cnt_, reg_buf_alloc_cnt_,
-      static_cast<size_t>(max_size_), pending_ops_};
+      static_cast<size_t>(max_size_), pending_ops_,      pending_stash_bytes_};
 }
 
 error_code DiskStorage::RequestGrow(off_t grow_size) {

--- a/src/server/tiering/disk_storage.h
+++ b/src/server/tiering/disk_storage.h
@@ -29,6 +29,7 @@ class DiskStorage {
     uint64_t registered_buf_alloc_count = 0;
     size_t max_file_size = 0;
     size_t pending_ops = 0;
+    size_t pending_stash_bytes = 0;
   };
 
   using ReadCb = std::function<void(io::Result<std::string_view>)>;
@@ -65,7 +66,8 @@ class DiskStorage {
   util::fb2::RegisteredSlice PrepareBuf(size_t len);
 
   off_t max_size_;
-  size_t pending_ops_ = 0;  // number of ongoing ops for safe shutdown
+  size_t pending_ops_ = 0;          // number of ongoing ops for safe shutdown
+  size_t pending_stash_bytes_ = 0;  // bytes currently in-flight to disk
 
   // how many times we allocate registered/heap buffers.
   uint64_t heap_buf_alloc_cnt_ = 0, reg_buf_alloc_cnt_ = 0;

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -3577,6 +3577,7 @@ async def _run_tiering_migration(
             tiered_offload_threshold="0.2",
             tiered_experimental_cooling="False",
             maxmemory=maxmemory,
+            tiered_max_pending_stash_bytes="128KB",
         ),
         df_factory.create(
             port=next(next_port), admin_port=next(next_port), proactor_threads=2, maxmemory="1024MB"

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -885,7 +885,7 @@ async def test_tiered_entries(async_client: aioredis.Redis):
         "dbfilename": "tiered-entries",
         "tiered_prefix": "/tmp/tiered/backing",
         "tiered_offload_threshold": "0.5",  # ask to keep below 0.5 * 2G
-        "tiered_storage_write_depth": 1000,
+        "tiered_max_pending_stash_bytes": "16MB",
         "tiered_experimental_cooling": "false",
     }
 )
@@ -962,7 +962,7 @@ async def test_rdb_load_with_tiering_6823(df_factory: DflyInstanceFactory):
         tiered_prefix="/tmp/tiered/rdb_load_test",
         tiered_offload_threshold="0.9",
         tiered_experimental_cooling="false",
-        tiered_storage_write_depth=10,
+        tiered_max_pending_stash_bytes="100KB",
     )
     tiered.start()
     tiered_client = tiered.client()

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -8,6 +8,7 @@ import async_timeout
 import boto3
 import pytest
 import redis
+import random
 from async_timeout import timeout
 from azure.storage.blob import BlobServiceClient
 from pymemcache.client.base import Client as MCClient
@@ -980,10 +981,13 @@ async def test_rdb_load_with_tiering_6823(df_factory: DflyInstanceFactory):
     info = await tiered_client.info("memory")
     used_mem = info["used_memory"]
     obj_mem = info["object_used_memory"]
-    assert used_mem > 20_000_000 and used_mem < 300_000_000
-    assert obj_mem > 20_000_000 and obj_mem < 300_000_000
+    assert used_mem < 50_000_000
+    assert obj_mem < 10_000_000
 
     assert info["num_entries"] == num_keys
+    keys = await tiered_client.keys()
+    for key in random.sample(keys, k=10):
+        assert (len(await tiered_client.get(key))) == 8192
 
 
 @dfly_args({"serialization_max_chunk_size": 4096, "proactor_threads": 1})

--- a/tests/dragonfly/tiering_test.py
+++ b/tests/dragonfly/tiering_test.py
@@ -21,7 +21,7 @@ BASIC_ARGS = {
     "proactor_threads": 4,
     "tiered_prefix": "/tmp/tiered/backing",
     "tiered_offload_threshold": "1.0",  # offload immediately
-    "tiered_storage_write_depth": 1000,
+    "tiered_max_pending_stash_bytes": "16MB",
     "maxmemory": "1G",
 }
 
@@ -118,7 +118,7 @@ async def test_tiered_replication_strings_with_append(df_factory: DflyInstanceFa
         tiered_prefix="/tmp/tiered/backing_master",
         tiered_offload_threshold="0.6",
         tiered_upload_threshold="0.2",
-        tiered_storage_write_depth=1500,
+        tiered_max_pending_stash_bytes="16MB",
         **args,
     )
     master.start()
@@ -134,7 +134,7 @@ async def test_tiered_replication_strings_with_append(df_factory: DflyInstanceFa
         maxmemory="512MB",
         tiered_prefix="/tmp/tiered/backing_replica",
         tiered_offload_threshold="0.5",
-        tiered_storage_write_depth=1500,
+        tiered_max_pending_stash_bytes="16MB",
     )
     replica.start()
     replica_client = replica.client()
@@ -258,7 +258,7 @@ async def test_tiered_replication_with_lists(df_factory: DflyInstanceFactory):
         maxmemory="512MB",
         tiered_prefix="/tmp/tiered/backing_master_list",
         tiered_offload_threshold="1.0",
-        tiered_storage_write_depth=1500,
+        tiered_max_pending_stash_bytes="16MB",
         tiered_experimental_cooling="false",
         list_max_listpack_size=1,
         list_tiering_threshold=2,


### PR DESCRIPTION
1. Instead of "number of writes" count "memory bandwith ot writes"
2. Apply backpressure only if bandwith is full - otherwise under offloading a single client is throttled on every single write and no paralllel writes can occur -> low disk utilization


Relevant to #7506  (consumer side)