### PR TITLE
fix: slave_repl_offset should be non zero for valkey master

### DIFF
--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -1311,9 +1311,15 @@ auto Replica::GetSummary() const -> Summary {
 
     res.master_id = master_context_.master_repl_id;
     res.reconnect_count = reconnect_count_;
-    res.repl_offset_sum = 0;
-    for (uint64_t offs : GetReplicaOffset()) {
-      res.repl_offset_sum += offs;
+    if (HasDflyMaster()) {
+      res.repl_offset_sum = 0;
+      for (uint64_t offs : GetReplicaOffset()) {
+        res.repl_offset_sum += offs;
+      }
+    } else {
+      // For Redis→Dragonfly replication, repl_offs_ tracks the byte offset
+      // in the Redis replication stream (sent via REPLCONF ACK to the master).
+      res.repl_offset_sum = repl_offs_;
     }
     res.psync_successes = psync_successes_;
     res.psync_attempts = psync_attempts_;

--- a/tests/dragonfly/redis_replication_test.py
+++ b/tests/dragonfly/redis_replication_test.py
@@ -378,19 +378,25 @@ async def test_redis_replication_info_offset(df_factory, redis_server, port_pick
     # Give the ACK fiber time to fire (interval is 1000ms).
     await asyncio.sleep(2)
 
-    master_info = await c_master.info("replication")
     replica_info = await c_replica.info("replication")
-
-    slave_entry = next(
-        (v for k, v in master_info.items() if k.startswith("slave") and isinstance(v, dict)),
-        None,
-    )
-    assert slave_entry is not None, "Master sees no slaves"
-
-    master_offset = slave_entry["offset"]
     replica_offset = replica_info.get("slave_repl_offset", 0)
-
     assert replica_offset > 0, f"slave_repl_offset={replica_offset}, expected non-zero"
-    assert (
-        replica_offset == master_offset
-    ), f"slave_repl_offset mismatch: replica={replica_offset} master={master_offset}"
+
+    @assert_eventually(timeout=30)
+    async def offsets_converge():
+        m_info = await c_master.info("replication")
+        r_info = await c_replica.info("replication")
+
+        slave_entry = next(
+            (v for k, v in m_info.items() if k.startswith("slave") and isinstance(v, dict)),
+            None,
+        )
+        assert slave_entry is not None, "Master sees no slaves"
+
+        master_offset = slave_entry["offset"]
+        replica_offset = r_info.get("slave_repl_offset", 0)
+        assert (
+            replica_offset == master_offset
+        ), f"slave_repl_offset mismatch: replica={replica_offset} master={master_offset}"
+
+    await offsets_converge()

--- a/tests/dragonfly/redis_replication_test.py
+++ b/tests/dragonfly/redis_replication_test.py
@@ -366,7 +366,8 @@ async def test_redis_replication_info_offset(df_factory, redis_server, port_pick
     master = redis_server
     c_master = aioredis.Redis(port=master.port)
 
-    await c_master.execute_command("DEBUG", "POPULATE", 100)
+    for i in range(100):
+        await c_master.set(f"key:{i}", f"value:{i}")
 
     replica = df_factory.create(port=port_picker.get_available_port(), proactor_threads=2)
     replica.start()

--- a/tests/dragonfly/redis_replication_test.py
+++ b/tests/dragonfly/redis_replication_test.py
@@ -355,3 +355,42 @@ async def test_disconnect_master(
     await check_data(seeder, replicas, c_replicas)
 
     await proxy.close(proxy_task)
+
+
+@pytest.mark.asyncio
+async def test_redis_replication_info_offset(df_factory, redis_server, port_picker):
+    """
+    Dragonfly replica of a Redis master must report a non-zero slave_repl_offset
+    in INFO REPLICATION that matches the offset the master tracks for that slave.
+    """
+    master = redis_server
+    c_master = aioredis.Redis(port=master.port)
+
+    await c_master.execute_command("DEBUG", "POPULATE", 100)
+
+    replica = df_factory.create(port=port_picker.get_available_port(), proactor_threads=2)
+    replica.start()
+    c_replica = replica.client()
+
+    await run_replication(c_replica, master.port)
+    await await_synced(c_master, c_replica)
+
+    # Give the ACK fiber time to fire (interval is 1000ms).
+    await asyncio.sleep(2)
+
+    master_info = await c_master.info("replication")
+    replica_info = await c_replica.info("replication")
+
+    slave_entry = next(
+        (v for k, v in master_info.items() if k.startswith("slave") and isinstance(v, dict)),
+        None,
+    )
+    assert slave_entry is not None, "Master sees no slaves"
+
+    master_offset = slave_entry["offset"]
+    replica_offset = replica_info.get("slave_repl_offset", 0)
+
+    assert replica_offset > 0, f"slave_repl_offset={replica_offset}, expected non-zero"
+    assert (
+        replica_offset == master_offset
+    ), f"slave_repl_offset mismatch: replica={replica_offset} master={master_offset}"


### PR DESCRIPTION
`slave_repl_offset` was improperly set to `0` when dragonfly replicated a redis/valkey instance. The correct value is the aggregate of bytes read from ConsumeRedisStream

* add test
* fix the metric to be non zero for redis/valkey master