### PR TITLE
fix: increase timeout for test_randomkey_during_bgsave

### DIFF
--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -713,7 +713,7 @@ async def test_randomkey_during_bgsave(df_factory: DflyInstanceFactory):
     workers = [asyncio.create_task(hammer_random(stop)) for _ in range(8)]
 
     try:
-        async with timeout(60):
+        async with timeout(100):
             for _ in range(5):
                 await client.execute_command("BGSAVE")
                 while await is_saving(client):


### PR DESCRIPTION
logs show an iteration takes roughy 13 seconds so the test naturally times out. 

This happens only on coverage builds where instrumentation effect pushes the test to timeout.

I would have not opened an issue had I know it was a single line fix. resolves #7518