### PR TITLE
fix(facade): skip idle flush with queued commands

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -3049,9 +3049,13 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
 
         // Flush replies deferred by ReplyBatch before sleeping - ensures the client
         // gets its response even when no more data arrives (single commands, end of pipeline).
-        reply_builder_->Flush();
-        if (auto err = reply_builder_->GetError(); err) {
-          return err;
+        // Skip the flush when there are still commands in the queue - they will produce
+        // more replies shortly and we want to batch them all into a single sendmsg.
+        if (parsed_cmd_q_len_ == 0) {
+          reply_builder_->Flush();
+          if (auto err = reply_builder_->GetError(); err) {
+            return err;
+          }
         }
 
         io_event_.await(should_wake);


### PR DESCRIPTION
In IoLoopV2(), the idle block flushes pending replies before the fiber sleeps. However, flushing while commands are still queued sends a partial response, then another sendmsg when the remaining commands complete - wasting syscalls and hurting throughput.

Guard the flush with `parsed_cmd_q_len_ == 0` so that in-flight commands can accumulate all their replies before a single flush is issued at the end of the pipeline.
