### PR TITLE
refactor: reduce threads contention for INFO cmd

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -3283,7 +3283,10 @@ Metrics ServerFamily::GetMetrics(Namespace* ns, bool collect_replication_memory)
     result.interned_string_stats = GetInternedStringStats();
   };  // cb
 
-  service_.proactor_pool().AwaitFiberOnAll(std::move(cb));
+  // AwaitBrief (not AwaitFiberOnAll): the callback only reads thread-local/atomic state into
+  // its own partials slot and never yields, so it can run directly in each IO loop, avoiding
+  // a per-proactor fiber spawn on every INFO call.
+  service_.proactor_pool().AwaitBrief(std::move(cb));
 
   // Fold per-thread partials into the aggregate result on this thread.
   for (const Metrics& partial : partials)

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -3120,15 +3120,59 @@ void ServerFamily::Save(CmdArgList args, CommandContext* cmd_cntx) {
   }
 }
 
-static void MergeDbSliceStats(const DbSlice::Stats& src, Metrics* dest) {
+// Folds a per-proactor partial Metrics (filled lock-free in the fan-out callback)
+// into the aggregate `dest`. Mirrors the combine semantics used while collecting:
+// almost everything sums, tx_queue_len takes the max and oldest_pending_send_ts the min.
+static void MergeShardMetrics(const Metrics& src, Metrics* dest) {
+  // Per-db stats / events / small_string_bytes are merged element-wise.
   if (src.db_stats.size() > dest->db_stats.size())
     dest->db_stats.resize(src.db_stats.size());
-
   for (size_t i = 0; i < src.db_stats.size(); ++i)
     dest->db_stats[i] += src.db_stats[i];
-
   dest->events += src.events;
   dest->small_string_bytes += src.small_string_bytes;
+
+  // Aggregate sub-structs.
+  dest->shard_stats += src.shard_stats;
+  dest->facade_stats += src.facade_stats;
+  dest->tiered_stats += src.tiered_stats;
+  dest->search_stats += src.search_stats;
+  dest->coordinator_stats.Add(src.coordinator_stats);
+  dest->qlist_stats += src.qlist_stats;
+  dest->replication_stats += src.replication_stats;
+  dest->lua_stats += src.lua_stats;
+  dest->interned_string_stats += src.interned_string_stats;
+
+  // Scalar sums.
+  dest->qps += src.qps;
+  dest->heap_used_bytes += src.heap_used_bytes;
+  dest->serialization_bytes += src.serialization_bytes;
+  dest->traverse_ttl_per_sec += src.traverse_ttl_per_sec;
+  dest->delete_ttl_per_sec += src.delete_ttl_per_sec;
+  dest->fiber_switch_cnt += src.fiber_switch_cnt;
+  dest->fiber_switch_delay_usec += src.fiber_switch_delay_usec;
+  dest->fiber_longrun_cnt += src.fiber_longrun_cnt;
+  dest->fiber_longrun_usec += src.fiber_longrun_usec;
+  dest->worker_fiber_stack_size += src.worker_fiber_stack_size;
+  dest->worker_fiber_count += src.worker_fiber_count;
+  dest->blocked_tasks += src.blocked_tasks;
+  dest->tls_bytes += src.tls_bytes;
+  dest->refused_conn_max_clients_reached_count += src.refused_conn_max_clients_reached_count;
+  dest->lsn_buffer_size += src.lsn_buffer_size;
+  dest->lsn_buffer_bytes += src.lsn_buffer_bytes;
+
+  // Non-sum reductions.
+  dest->tx_queue_len = std::max(dest->tx_queue_len, src.tx_queue_len);
+  dest->oldest_pending_send_ts = std::min(dest->oldest_pending_send_ts, src.oldest_pending_send_ts);
+
+  // Map merges.
+  for (const auto& [k, v] : src.connections_lib_name_ver_map)
+    dest->connections_lib_name_ver_map[k] += v;
+  for (const auto& [name, stat] : src.cmd_stats_map) {
+    auto& [calls, sum] = dest->cmd_stats_map[name];
+    calls += stat.first;
+    sum += stat.second;
+  }
 }
 
 void ServerFamily::ResetStat(Namespace* ns) {
@@ -3151,76 +3195,81 @@ void ServerFamily::ResetStat(Namespace* ns) {
 
 Metrics ServerFamily::GetMetrics(Namespace* ns, bool collect_replication_memory) const {
   Metrics result;
-  util::fb2::Mutex mu;
 
   uint64_t start = absl::GetCurrentTimeNanos();
 
-  auto cmd_stat_cb = [&dest = result.cmd_stats_map](string_view name, const CmdCallStats& stat) {
-    auto& [calls, sum] = dest[absl::AsciiStrToLower(name)];
-    calls += stat.first;
-    sum += stat.second;
-  };
+  // Each proactor accumulates into its own slot (indexed by proactor id), so the
+  // fan-out callback runs fully in parallel with no shared-state locking. The
+  // per-thread partials are folded into `result` on this thread afterwards.
+  std::vector<Metrics> partials(service_.proactor_pool().size());
 
   auto cb = [&](unsigned index, ProactorBase* pb) {
     EngineShard* shard = EngineShard::tlocal();
     ServerState* ss = ServerState::tlocal();
+    // Each proactor writes its own freshly-zeroed slot exactly once, so plain assignment
+    // is enough — cross-thread accumulation happens later in MergeShardMetrics. Named
+    // `result` (shadowing the outer aggregate) to keep this body close to the original.
+    Metrics& result = partials[index];
 
-    lock_guard lk(mu);
+    auto cmd_stat_cb = [&dest = result.cmd_stats_map](string_view name, const CmdCallStats& stat) {
+      auto& [calls, sum] = dest[absl::AsciiStrToLower(name)];
+      calls += stat.first;
+      sum += stat.second;
+    };
 
-    result.fiber_switch_cnt += fb2::FiberSwitchEpoch();
-    result.fiber_switch_delay_usec += fb2::FiberSwitchDelayUsec();
-    result.fiber_longrun_cnt += fb2::FiberLongRunCnt();
-    result.fiber_longrun_usec += fb2::FiberLongRunSumUsec();
-    result.worker_fiber_stack_size += fb2::WorkerFibersStackSize();
-    result.worker_fiber_count += fb2::WorkerFibersCount();
-    result.blocked_tasks += TaskQueue::blocked_submitters();
+    result.fiber_switch_cnt = fb2::FiberSwitchEpoch();
+    result.fiber_switch_delay_usec = fb2::FiberSwitchDelayUsec();
+    result.fiber_longrun_cnt = fb2::FiberLongRunCnt();
+    result.fiber_longrun_usec = fb2::FiberLongRunSumUsec();
+    result.worker_fiber_stack_size = fb2::WorkerFibersStackSize();
+    result.worker_fiber_count = fb2::WorkerFibersCount();
+    result.blocked_tasks = TaskQueue::blocked_submitters();
 
-    result.coordinator_stats.Add(ss->stats);
+    result.coordinator_stats.Add(ss->stats);  // ServerState::Stats is not copy-assignable
 
-    result.qps += uint64_t(ss->MovingSum6());
-    result.facade_stats += *tl_facade_stats;
-    result.serialization_bytes += SliceSnapshot::GetThreadLocalMemoryUsage();
+    result.qps = uint64_t(ss->MovingSum6());
+    result.facade_stats = *tl_facade_stats;
+    result.serialization_bytes = SliceSnapshot::GetThreadLocalMemoryUsage();
 
     if (shard) {
-      result.heap_used_bytes += shard->UsedMemory();
-      MergeDbSliceStats(ns->GetDbSlice(shard->shard_id()).GetStats(), &result);
-      result.shard_stats += shard->stats();
+      result.heap_used_bytes = shard->UsedMemory();
+      const DbSlice::Stats slice_stats = ns->GetDbSlice(shard->shard_id()).GetStats();
+      result.db_stats = slice_stats.db_stats;
+      result.events = slice_stats.events;
+      result.small_string_bytes = slice_stats.small_string_bytes;
+      result.shard_stats = shard->stats();
 
       if (shard->tiered_storage()) {
-        result.tiered_stats += shard->tiered_storage()->GetStats();
+        result.tiered_stats = shard->tiered_storage()->GetStats();
       }
 
       if (shard->search_indices()) {
-        result.search_stats += shard->search_indices()->GetStats();
+        result.search_stats = shard->search_indices()->GetStats();
       }
 
-      result.qlist_stats += QList::stats;
+      result.qlist_stats = QList::stats;
 
-      result.traverse_ttl_per_sec += shard->GetMovingSum6(EngineShard::TTL_TRAVERSE);
-      result.delete_ttl_per_sec += shard->GetMovingSum6(EngineShard::TTL_DELETE);
-      if (result.tx_queue_len < shard->txq()->size())
-        result.tx_queue_len = shard->txq()->size();
+      result.traverse_ttl_per_sec = shard->GetMovingSum6(EngineShard::TTL_TRAVERSE);
+      result.delete_ttl_per_sec = shard->GetMovingSum6(EngineShard::TTL_DELETE);
+      result.tx_queue_len = shard->txq()->size();
 
       if (shard->journal()) {
-        result.lsn_buffer_size += journal::LsnBufferSize();
-        result.lsn_buffer_bytes += journal::LsnBufferBytes();
+        result.lsn_buffer_size = journal::LsnBufferSize();
+        result.lsn_buffer_bytes = journal::LsnBufferBytes();
       }
 
       // Fold the per-shard replication-memory collection into this fan-out
       // instead of a dedicated RunBriefInParallel in DflyCmd.
       if (collect_replication_memory)
-        result.replication_stats += dfly_cmd_->GetReplicationMemoryStats(shard);
+        result.replication_stats = dfly_cmd_->GetReplicationMemoryStats(shard);
     }  // if (shard)
 
-    result.tls_bytes += Listener::TLSUsedMemoryThreadLocal();
-    result.refused_conn_max_clients_reached_count += Listener::RefusedConnectionMaxClientsCount();
+    result.tls_bytes = Listener::TLSUsedMemoryThreadLocal();
+    result.refused_conn_max_clients_reached_count = Listener::RefusedConnectionMaxClientsCount();
 
-    result.lua_stats += InterpreterManager::tl_stats();
+    result.lua_stats = InterpreterManager::tl_stats();
 
-    auto connections_lib_name_ver_map = facade::Connection::GetLibStatsTL();
-    for (auto& [k, v] : connections_lib_name_ver_map) {
-      result.connections_lib_name_ver_map[k] += v;
-    }
+    result.connections_lib_name_ver_map = facade::Connection::GetLibStatsTL();
 
     auto& send_list = facade::SinkReplyBuilder::pending_list;
     if (!send_list.empty()) {
@@ -3228,16 +3277,17 @@ Metrics ServerFamily::GetMetrics(Namespace* ns, bool collect_replication_memory)
                             [](const auto& left, const auto& right) {
                               return left.timestamp_cycles < right.timestamp_cycles;
                             }));
-
-      auto& oldest_member = send_list.front();
-      result.oldest_pending_send_ts =
-          min<uint64_t>(result.oldest_pending_send_ts, oldest_member.timestamp_cycles);
+      result.oldest_pending_send_ts = send_list.front().timestamp_cycles;
     }
     service_.mutable_registry()->MergeCallStats(index, cmd_stat_cb);
-    result.interned_string_stats += GetInternedStringStats();
+    result.interned_string_stats = GetInternedStringStats();
   };  // cb
 
   service_.proactor_pool().AwaitFiberOnAll(std::move(cb));
+
+  // Fold per-thread partials into the aggregate result on this thread.
+  for (const Metrics& partial : partials)
+    MergeShardMetrics(partial, &result);
 
 #ifdef WITH_SEARCH
   // HNSW indices live in a single global registry shared across shards, so their

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -3120,56 +3120,70 @@ void ServerFamily::Save(CmdArgList args, CommandContext* cmd_cntx) {
   }
 }
 
-// Folds a per-proactor partial Metrics (filled lock-free in the fan-out callback)
-// into the aggregate `dest`. Mirrors the combine semantics used while collecting:
-// almost everything sums, tx_queue_len takes the max and oldest_pending_send_ts the min.
-static void MergeShardMetrics(const Metrics& src, Metrics* dest) {
+void Metrics::Merge(const Metrics& src) {
+  // Sum of all member sizes plus alignment padding (4 bytes after blocked_tasks).
+  // Expressed via sizeof so it adapts to different STL/Abseil implementations.
+  // If this fires, a field was added/removed — update Merge() and InitFromThread().
+  static_assert(
+      sizeof(Metrics) == sizeof(SliceEvents) + sizeof(std::vector<DbStats>) +
+                             sizeof(EngineShard::Stats) + sizeof(facade::FacadeStats) +
+                             sizeof(TieredStats) + sizeof(SearchStats) +
+                             sizeof(ServerState::Stats) + sizeof(PeakStats) + sizeof(QList::Stats) +
+                             sizeof(ReplicationMemoryStats) + sizeof(InterpreterManager::Stats) +
+                             sizeof(std::map<std::string, std::pair<uint64_t, uint64_t>>) +
+                             sizeof(absl::flat_hash_map<std::string, uint64_t>) +
+                             sizeof(std::optional<Metrics::ReplicaInfo>) + sizeof(LoadingStats) +
+                             sizeof(absl::flat_hash_map<std::string, hdr_histogram*>) +
+                             sizeof(InternedStringStats) + sizeof(acl::UserRegistry::AclStats) +
+                             176,  // scalar fields (19 fields) + 4-byte alignment padding
+      "Metrics size changed — update Merge() and InitFromThread()");
+
   // Per-db stats / events / small_string_bytes are merged element-wise.
-  if (src.db_stats.size() > dest->db_stats.size())
-    dest->db_stats.resize(src.db_stats.size());
+  if (src.db_stats.size() > db_stats.size())
+    db_stats.resize(src.db_stats.size());
   for (size_t i = 0; i < src.db_stats.size(); ++i)
-    dest->db_stats[i] += src.db_stats[i];
-  dest->events += src.events;
-  dest->small_string_bytes += src.small_string_bytes;
+    db_stats[i] += src.db_stats[i];
+  events += src.events;
+  small_string_bytes += src.small_string_bytes;
 
   // Aggregate sub-structs.
-  dest->shard_stats += src.shard_stats;
-  dest->facade_stats += src.facade_stats;
-  dest->tiered_stats += src.tiered_stats;
-  dest->search_stats += src.search_stats;
-  dest->coordinator_stats.Add(src.coordinator_stats);
-  dest->qlist_stats += src.qlist_stats;
-  dest->replication_stats += src.replication_stats;
-  dest->lua_stats += src.lua_stats;
-  dest->interned_string_stats += src.interned_string_stats;
+  shard_stats += src.shard_stats;
+  facade_stats += src.facade_stats;
+  tiered_stats += src.tiered_stats;
+  search_stats += src.search_stats;
+  coordinator_stats.Add(src.coordinator_stats);
+  qlist_stats += src.qlist_stats;
+  replication_stats += src.replication_stats;
+  lua_stats += src.lua_stats;
+  interned_string_stats += src.interned_string_stats;
 
   // Scalar sums.
-  dest->qps += src.qps;
-  dest->heap_used_bytes += src.heap_used_bytes;
-  dest->serialization_bytes += src.serialization_bytes;
-  dest->traverse_ttl_per_sec += src.traverse_ttl_per_sec;
-  dest->delete_ttl_per_sec += src.delete_ttl_per_sec;
-  dest->fiber_switch_cnt += src.fiber_switch_cnt;
-  dest->fiber_switch_delay_usec += src.fiber_switch_delay_usec;
-  dest->fiber_longrun_cnt += src.fiber_longrun_cnt;
-  dest->fiber_longrun_usec += src.fiber_longrun_usec;
-  dest->worker_fiber_stack_size += src.worker_fiber_stack_size;
-  dest->worker_fiber_count += src.worker_fiber_count;
-  dest->blocked_tasks += src.blocked_tasks;
-  dest->tls_bytes += src.tls_bytes;
-  dest->refused_conn_max_clients_reached_count += src.refused_conn_max_clients_reached_count;
-  dest->lsn_buffer_size += src.lsn_buffer_size;
-  dest->lsn_buffer_bytes += src.lsn_buffer_bytes;
+  qps += src.qps;
+  heap_used_bytes += src.heap_used_bytes;
+  serialization_bytes += src.serialization_bytes;
+  traverse_ttl_per_sec += src.traverse_ttl_per_sec;
+  delete_ttl_per_sec += src.delete_ttl_per_sec;
+  fiber_switch_cnt += src.fiber_switch_cnt;
+  fiber_switch_delay_usec += src.fiber_switch_delay_usec;
+  fiber_longrun_cnt += src.fiber_longrun_cnt;
+  fiber_longrun_usec += src.fiber_longrun_usec;
+  worker_fiber_stack_size += src.worker_fiber_stack_size;
+  worker_fiber_count += src.worker_fiber_count;
+  blocked_tasks += src.blocked_tasks;
+  tls_bytes += src.tls_bytes;
+  refused_conn_max_clients_reached_count += src.refused_conn_max_clients_reached_count;
+  lsn_buffer_size += src.lsn_buffer_size;
+  lsn_buffer_bytes += src.lsn_buffer_bytes;
 
   // Non-sum reductions.
-  dest->tx_queue_len = std::max(dest->tx_queue_len, src.tx_queue_len);
-  dest->oldest_pending_send_ts = std::min(dest->oldest_pending_send_ts, src.oldest_pending_send_ts);
+  tx_queue_len = std::max(tx_queue_len, src.tx_queue_len);
+  oldest_pending_send_ts = std::min(oldest_pending_send_ts, src.oldest_pending_send_ts);
 
   // Map merges.
   for (const auto& [k, v] : src.connections_lib_name_ver_map)
-    dest->connections_lib_name_ver_map[k] += v;
+    connections_lib_name_ver_map[k] += v;
   for (const auto& [name, stat] : src.cmd_stats_map) {
-    auto& [calls, sum] = dest->cmd_stats_map[name];
+    auto& [calls, sum] = cmd_stats_map[name];
     calls += stat.first;
     sum += stat.second;
   }
@@ -3193,6 +3207,95 @@ void ServerFamily::ResetStat(Namespace* ns) {
       });
 }
 
+void Metrics::InitFromThread(Namespace* ns, CommandRegistry* registry, unsigned proactor_index,
+                             bool collect_replication_memory, DflyCmd* dfly_cmd) {
+  static_assert(
+      sizeof(Metrics) == sizeof(SliceEvents) + sizeof(std::vector<DbStats>) +
+                             sizeof(EngineShard::Stats) + sizeof(facade::FacadeStats) +
+                             sizeof(TieredStats) + sizeof(SearchStats) +
+                             sizeof(ServerState::Stats) + sizeof(PeakStats) + sizeof(QList::Stats) +
+                             sizeof(ReplicationMemoryStats) + sizeof(InterpreterManager::Stats) +
+                             sizeof(std::map<std::string, std::pair<uint64_t, uint64_t>>) +
+                             sizeof(absl::flat_hash_map<std::string, uint64_t>) +
+                             sizeof(std::optional<Metrics::ReplicaInfo>) + sizeof(LoadingStats) +
+                             sizeof(absl::flat_hash_map<std::string, hdr_histogram*>) +
+                             sizeof(InternedStringStats) + sizeof(acl::UserRegistry::AclStats) +
+                             176,  // scalar fields (19 fields) + 4-byte alignment padding
+      "Metrics size changed — update Merge() and InitFromThread()");
+  EngineShard* shard = EngineShard::tlocal();
+  ServerState* ss = ServerState::tlocal();
+
+  fiber_switch_cnt = fb2::FiberSwitchEpoch();
+  fiber_switch_delay_usec = fb2::FiberSwitchDelayUsec();
+  fiber_longrun_cnt = fb2::FiberLongRunCnt();
+  fiber_longrun_usec = fb2::FiberLongRunSumUsec();
+  worker_fiber_stack_size = fb2::WorkerFibersStackSize();
+  worker_fiber_count = fb2::WorkerFibersCount();
+  blocked_tasks = TaskQueue::blocked_submitters();
+
+  coordinator_stats.Add(ss->stats);
+
+  qps = uint64_t(ss->MovingSum6());
+  facade_stats = *tl_facade_stats;
+  serialization_bytes = SliceSnapshot::GetThreadLocalMemoryUsage();
+
+  if (shard) {
+    heap_used_bytes = shard->UsedMemory();
+    const DbSlice::Stats slice_stats = ns->GetDbSlice(shard->shard_id()).GetStats();
+    db_stats = slice_stats.db_stats;
+    events = slice_stats.events;
+    small_string_bytes = slice_stats.small_string_bytes;
+    shard_stats = shard->stats();
+
+    if (shard->tiered_storage()) {
+      tiered_stats = shard->tiered_storage()->GetStats();
+    }
+
+    if (shard->search_indices()) {
+      search_stats = shard->search_indices()->GetStats();
+    }
+
+    qlist_stats = QList::stats;
+
+    traverse_ttl_per_sec = shard->GetMovingSum6(EngineShard::TTL_TRAVERSE);
+    delete_ttl_per_sec = shard->GetMovingSum6(EngineShard::TTL_DELETE);
+    tx_queue_len = shard->txq()->size();
+
+    if (shard->journal()) {
+      lsn_buffer_size = journal::LsnBufferSize();
+      lsn_buffer_bytes = journal::LsnBufferBytes();
+    }
+
+    if (collect_replication_memory)
+      replication_stats = dfly_cmd->GetReplicationMemoryStats(shard);
+  }
+
+  tls_bytes = Listener::TLSUsedMemoryThreadLocal();
+  refused_conn_max_clients_reached_count = Listener::RefusedConnectionMaxClientsCount();
+
+  lua_stats = InterpreterManager::tl_stats();
+
+  connections_lib_name_ver_map = facade::Connection::GetLibStatsTL();
+
+  auto& send_list = facade::SinkReplyBuilder::pending_list;
+  if (!send_list.empty()) {
+    DCHECK(
+        std::is_sorted(send_list.begin(), send_list.end(), [](const auto& left, const auto& right) {
+          return left.timestamp_cycles < right.timestamp_cycles;
+        }));
+    oldest_pending_send_ts = send_list.front().timestamp_cycles;
+  }
+
+  auto cmd_stat_cb = [this](string_view name, const CmdCallStats& stat) {
+    auto& [calls, sum] = cmd_stats_map[absl::AsciiStrToLower(name)];
+    calls += stat.first;
+    sum += stat.second;
+  };
+  registry->MergeCallStats(proactor_index, cmd_stat_cb);
+
+  interned_string_stats = GetInternedStringStats();
+}
+
 Metrics ServerFamily::GetMetrics(Namespace* ns, bool collect_replication_memory) const {
   Metrics result;
 
@@ -3203,85 +3306,10 @@ Metrics ServerFamily::GetMetrics(Namespace* ns, bool collect_replication_memory)
   // per-thread partials are folded into `result` on this thread afterwards.
   std::vector<Metrics> partials(service_.proactor_pool().size());
 
-  auto cb = [&](unsigned index, ProactorBase* pb) {
-    EngineShard* shard = EngineShard::tlocal();
-    ServerState* ss = ServerState::tlocal();
-    // Each proactor writes its own freshly-zeroed slot exactly once, so plain assignment
-    // is enough — cross-thread accumulation happens later in MergeShardMetrics. Named
-    // `result` (shadowing the outer aggregate) to keep this body close to the original.
-    Metrics& result = partials[index];
-
-    auto cmd_stat_cb = [&dest = result.cmd_stats_map](string_view name, const CmdCallStats& stat) {
-      auto& [calls, sum] = dest[absl::AsciiStrToLower(name)];
-      calls += stat.first;
-      sum += stat.second;
-    };
-
-    result.fiber_switch_cnt = fb2::FiberSwitchEpoch();
-    result.fiber_switch_delay_usec = fb2::FiberSwitchDelayUsec();
-    result.fiber_longrun_cnt = fb2::FiberLongRunCnt();
-    result.fiber_longrun_usec = fb2::FiberLongRunSumUsec();
-    result.worker_fiber_stack_size = fb2::WorkerFibersStackSize();
-    result.worker_fiber_count = fb2::WorkerFibersCount();
-    result.blocked_tasks = TaskQueue::blocked_submitters();
-
-    result.coordinator_stats.Add(ss->stats);  // ServerState::Stats is not copy-assignable
-
-    result.qps = uint64_t(ss->MovingSum6());
-    result.facade_stats = *tl_facade_stats;
-    result.serialization_bytes = SliceSnapshot::GetThreadLocalMemoryUsage();
-
-    if (shard) {
-      result.heap_used_bytes = shard->UsedMemory();
-      const DbSlice::Stats slice_stats = ns->GetDbSlice(shard->shard_id()).GetStats();
-      result.db_stats = slice_stats.db_stats;
-      result.events = slice_stats.events;
-      result.small_string_bytes = slice_stats.small_string_bytes;
-      result.shard_stats = shard->stats();
-
-      if (shard->tiered_storage()) {
-        result.tiered_stats = shard->tiered_storage()->GetStats();
-      }
-
-      if (shard->search_indices()) {
-        result.search_stats = shard->search_indices()->GetStats();
-      }
-
-      result.qlist_stats = QList::stats;
-
-      result.traverse_ttl_per_sec = shard->GetMovingSum6(EngineShard::TTL_TRAVERSE);
-      result.delete_ttl_per_sec = shard->GetMovingSum6(EngineShard::TTL_DELETE);
-      result.tx_queue_len = shard->txq()->size();
-
-      if (shard->journal()) {
-        result.lsn_buffer_size = journal::LsnBufferSize();
-        result.lsn_buffer_bytes = journal::LsnBufferBytes();
-      }
-
-      // Fold the per-shard replication-memory collection into this fan-out
-      // instead of a dedicated RunBriefInParallel in DflyCmd.
-      if (collect_replication_memory)
-        result.replication_stats = dfly_cmd_->GetReplicationMemoryStats(shard);
-    }  // if (shard)
-
-    result.tls_bytes = Listener::TLSUsedMemoryThreadLocal();
-    result.refused_conn_max_clients_reached_count = Listener::RefusedConnectionMaxClientsCount();
-
-    result.lua_stats = InterpreterManager::tl_stats();
-
-    result.connections_lib_name_ver_map = facade::Connection::GetLibStatsTL();
-
-    auto& send_list = facade::SinkReplyBuilder::pending_list;
-    if (!send_list.empty()) {
-      DCHECK(std::is_sorted(send_list.begin(), send_list.end(),
-                            [](const auto& left, const auto& right) {
-                              return left.timestamp_cycles < right.timestamp_cycles;
-                            }));
-      result.oldest_pending_send_ts = send_list.front().timestamp_cycles;
-    }
-    service_.mutable_registry()->MergeCallStats(index, cmd_stat_cb);
-    result.interned_string_stats = GetInternedStringStats();
-  };  // cb
+  auto cb = [&partials, ns, registry = service_.mutable_registry(), collect_replication_memory,
+             dfly_cmd = dfly_cmd_.get()](unsigned index, ProactorBase* pb) {
+    partials[index].InitFromThread(ns, registry, index, collect_replication_memory, dfly_cmd);
+  };
 
   // AwaitBrief (not AwaitFiberOnAll): the callback only reads thread-local/atomic state into
   // its own partials slot and never yields, so it can run directly in each IO loop, avoiding
@@ -3290,7 +3318,7 @@ Metrics ServerFamily::GetMetrics(Namespace* ns, bool collect_replication_memory)
 
   // Fold per-thread partials into the aggregate result on this thread.
   for (const Metrics& partial : partials)
-    MergeShardMetrics(partial, &result);
+    result.Merge(partial);
 
 #ifdef WITH_SEARCH
   // HNSW indices live in a single global registry shared across shards, so their

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -88,6 +88,7 @@ struct PeakStats {
 };
 
 // Aggregated metrics over multiple sources on all shards
+// TODO: move into metrics.h/cc.
 struct Metrics {
   SliceEvents events;              // general keyspace stats
   std::vector<DbStats> db_stats;   // dbsize stats
@@ -162,6 +163,14 @@ struct Metrics {
   InternedStringStats interned_string_stats;
 
   acl::UserRegistry::AclStats acl_stats;
+
+  // Collects all thread-local / per-shard stats on the current proactor thread.
+  void InitFromThread(Namespace* ns, CommandRegistry* registry, unsigned proactor_index,
+                      bool collect_replication_memory, DflyCmd* dfly_cmd);
+
+  // Folds `src` into *this. Almost everything sums; tx_queue_len takes the max
+  // and oldest_pending_send_ts the min.
+  void Merge(const Metrics& src);
 };
 
 // Contains the state of the last save operation.


### PR DESCRIPTION
related to: #7414
## Reduce thread contention for INFO

`ServerFamily::GetMetrics()` fanned every proactor's stats collection into a single
shared `Metrics result` guarded by a mutex. Because the lock was taken at the start
of the callback, all per-thread work (`GetStats`, `MergeCallStats`, etc.) ran
serialized — defeating the parallel fan-out.

### Change
- Drop the mutex. Each proactor writes its own slot in a `std::vector<Metrics>`
  (indexed by proactor id), fully in parallel and lock-free.
- Fold the per-thread partials into the aggregate on the calling thread via a new
  `MergeShardMetrics()` helper (sums, plus `max` for `tx_queue_len` and `min` for
  `oldest_pending_send_ts`).
- Uses AwaitBrief instead of AwaitFiberOnAll

# INFO command benchmark — main vs current

Measures the cost of the `INFO` command (full / all sections), which fans out across
every proactor to collect metrics, comparing **main** (mutex-guarded shared accumulator +
`AwaitFiberOnAll`) against the **current** branch (per-proactor partial-`Metrics` vector +
`AwaitBrief`).

## Setup

- **Build:** release (`-O3 -DNDEBUG`), the canonical `blaze.sh -release` configuration.
- **Hardware pinning** (cores isolated via `taskset`, distinct physical cores):
  - Dragonfly: 4 proactor threads on cores **0–3**.
  - Background traffic: cores **4–6**.
  - Single INFO client: core **7**.
- **Dataset:** 50,000 keys across 6 types (string/hash/list/set/zset/string-with-TTL).
- **Background load (the "other" commands):** full-tilt `redis-benchmark` GET (`-c 40`) and
  SET (`-c 20`) over the 50k keyspace; CPU is *not* capped — it settles at ~90%.
- **INFO measurement:** one closed-loop client issues `INFO` for a 6 s window
  (one outstanding call at a time), recording client-side round-trip latency.
- **Metrics:**
  - *INFO executions / rate* — count of INFO calls completed in the window.
  - *INFO p50/p90/p99* — client-side round-trip latency (includes loopback network).
  - *INFO server µs/call* — Dragonfly's own `cmdstat_info:usec_per_call` (server-side
    processing time only, excludes network).
  - *GET/SET throughput* — from Dragonfly's `cmdstat` counters over the window.
  - *CPU* — Dragonfly process `utime+stime` as a percentage of the 4 allocated cores.
- 3 interleaved rounds per build; values below are the averages.
- Harness: `tests/dragonfly/info_benchmark_test.py` (and `/tmp/info_pinned_bench.py` for
  the pinned/under-load variant).

## Results

| metric | main | current | Δ |
|---|---:|---:|---:|
| INFO executions (6 s window) | 35,555 | 41,528 | **+16.8%** |
| INFO rate | 5,926/s | 6,921/s | **+16.8%** |
| INFO p50 | 163 µs | 137 µs | −15.8% |
| INFO p90 | 181 µs | 159 µs | −12.3% |
| INFO p99 | 255 µs | 229 µs | −10.1% |
| INFO server µs/call (cmdstat) | 73.6 | 45.3 | **−38.4%** |
| GET+SET throughput | ~602k/s | ~592k/s | ~flat (noise) |
| CPU | 90% | 87% | −3 pts |

Per-round INFO server µs/call — main: `73.0 / 73.6 / 74.3`; current: `44.2 / 42.6 / 49.1`
(clean separation, no overlap).