### PR TITLE
chore: introduce CmdRef and generator-based MultiCommandSquasher

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -2574,9 +2574,6 @@ bool Connection::ExecuteBatch() {
     return parsed_head_;
   };
 
-  auto dispatch = protocol_ == Protocol::MEMCACHE ? &ServiceInterface::DispatchMC
-                                                  : &ServiceInterface::DispatchCommandSimple;
-
   // Execute sequentially all parsed commands.
   for (auto& cmd = parsed_to_execute_; cmd != nullptr;) {
     if (reply_builder_->GetError())
@@ -2605,7 +2602,7 @@ bool Connection::ExecuteBatch() {
     // sendmsg syscalls to a minimum. IoLoopV2's idle-await block handles the final flush.
     reply_builder_->SetBatchMode(ioloop_v2_ && is_head && (cmd->next != nullptr));
 
-    auto dispatch_res = (service_->*dispatch)(cmd, mode);
+    auto dispatch_res = service_->DispatchCommandSimple(cmd, mode);
 
     // Enforce the pipeline reply-ordering invariant: replies must reach the socket in parse order.
     // V1 (ONLY_SYNC): all commands run serially, so parsed_to_execute_ always equals parsed_head_
@@ -2619,8 +2616,7 @@ bool Connection::ExecuteBatch() {
     bool is_deferred = cmd->IsDeferredReply();
     DCHECK(is_head || (is_deferred == (dispatch_res != DispatchResult::WOULD_BLOCK)))
         << "Pipeline contract breach! Invalid state for non-head command. "
-        << "DispatchResult: " << static_cast<int>(dispatch_res) << ", IsDeferred: " << is_deferred
-        << ", Command Type: " << cmd->mc_command()->type;
+        << "DispatchResult: " << static_cast<int>(dispatch_res) << ", IsDeferred: " << is_deferred;
 
     if (dispatch_res == DispatchResult::WOULD_BLOCK)
       break;  // Sync command. Wait for current async commands to finish

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1738,21 +1738,12 @@ void Connection::SquashPipeline() {
 
   uint64_t start = CycleClock::Now();
 
-  // Define a "Feeder" Lambda
-  // This lambda advances a temporary pointer exec_cmd_ptr to feed the execution engine.
-  // We do not modify parsed_to_execute_ yet, in case execution throws/fails.
-  auto exec_cmd_ptr{parsed_to_execute_};
-  auto get_next_fn = [&exec_cmd_ptr]() mutable -> ParsedArgs {
-    DCHECK(exec_cmd_ptr);
-    return ParsedArgs{*std::exchange(exec_cmd_ptr, exec_cmd_ptr->next)};
-  };
-
   // async_dispatch is a guard to prevent concurrent writes into reply_builder_, hence
   // it must guard the Flush() as well.
   cc_->async_dispatch = true;
 
-  DispatchManyResult result =
-      service_->DispatchManyCommands(get_next_fn, pipeline_count, reply_builder_.get(), cc_.get());
+  DispatchManyResult result = service_->DispatchManyCommands(parsed_to_execute_, pipeline_count,
+                                                             reply_builder_.get(), cc_.get());
 
   local_stats_.cmds += result.processed;
   last_interaction_ = time(nullptr);
@@ -2705,7 +2696,7 @@ void Connection::EnqueueParsedCommand(ParsedCommand* cmd) {
   cmd->next = nullptr;
   auto& conn_stats = tl_facade_stats->conn_stats;
 
-  cmd->parsed_cycle = base::CycleClock::Now();
+  cmd->FinalizeParsing();
 
   if (parsed_head_ == nullptr) {
     parsed_head_ = cmd;
@@ -2719,7 +2710,7 @@ void Connection::EnqueueParsedCommand(ParsedCommand* cmd) {
   }
   parsed_tail_ = cmd;
 
-  size_t used_mem = cmd->UsedMemory();
+  size_t used_mem = cmd->EnqueuedBytes();
   parsed_cmd_q_len_++;
   parsed_cmd_q_bytes_ += used_mem;
   local_stats_.dispatch_entries_added++;
@@ -2734,7 +2725,7 @@ void Connection::EnqueueParsedCommand(ParsedCommand* cmd) {
 }
 
 void Connection::ReleaseParsedCommand(ParsedCommand* cmd, bool is_pipelined) {
-  size_t used_mem = cmd->UsedMemory();
+  size_t used_mem = cmd->EnqueuedBytes();
   auto& conn_stats = tl_facade_stats->conn_stats;
 
   DCHECK_GT(parsed_cmd_q_len_, 0u);

--- a/src/facade/ok_main.cc
+++ b/src/facade/ok_main.cc
@@ -50,11 +50,6 @@ class OkService : public ServiceInterface {
     return result;
   }
 
-  DispatchResult DispatchMC(ParsedCommand* cmd, AsyncPreference) final {
-    cmd->rb()->SendError("");
-    return DispatchResult::OK;
-  }
-
   ConnectionContext* CreateContext(Connection* owner) final {
     return new ConnectionContext{owner};
   }

--- a/src/facade/ok_main.cc
+++ b/src/facade/ok_main.cc
@@ -33,16 +33,15 @@ class OkService : public ServiceInterface {
     return DispatchResult::OK;
   }
 
-  DispatchManyResult DispatchManyCommands(std::function<ParsedArgs()> arg_gen, unsigned count,
+  DispatchManyResult DispatchManyCommands(ParsedCommand* head, unsigned count,
                                           SinkReplyBuilder* builder,
                                           ConnectionContext* cntx) final {
     for (unsigned i = 0; i < count; i++) {
-      ParsedArgs args = arg_gen();
-      ParsedCommand* cmd = AllocateParsedCommand();
+      ParsedCommand* cmd = head;
+      head = head->next;
       cmd->Init(builder, cntx);
-
+      ParsedArgs args{*cmd};
       DispatchCommand(args, cmd, AsyncPreference::ONLY_SYNC);
-      delete cmd;
     }
     DispatchManyResult result{
         .processed = static_cast<uint32_t>(count),

--- a/src/facade/parsed_command.h
+++ b/src/facade/parsed_command.h
@@ -7,6 +7,7 @@
 #include <coroutine>
 #include <variant>
 
+#include "base/cycle_clock.h"
 #include "base/function2.hpp"
 #include "common/backed_args.h"
 #include "facade/memcache_parser.h"
@@ -105,6 +106,15 @@ class ParsedCommand : public cmn::BackedArguments {
     return sz;
   }
 
+  size_t EnqueuedBytes() const {
+    return enqueued_bytes_;
+  }
+
+  void FinalizeParsing() {
+    parsed_cycle = base::CycleClock::Now();
+    enqueued_bytes_ = UsedMemory();
+  }
+
   // Marks this command as having reply stored in its payload instead of being sent directly.
   void SetDeferredReply() {
     is_deferred_reply_ = true;
@@ -187,11 +197,13 @@ class ParsedCommand : public cmn::BackedArguments {
   // otherwise, moved asynchronously into reply_payload_
   bool is_deferred_reply_ = false;
 
+  size_t enqueued_bytes_ = 0;
+
   std::variant<payload::Payload, SuspendedCommand> reply_;
 };
 
 #ifdef __linux__
-static_assert(sizeof(ParsedCommand) == 232);
+static_assert(sizeof(ParsedCommand) == 240);
 #endif
 
 }  // namespace facade

--- a/src/facade/service_interface.h
+++ b/src/facade/service_interface.h
@@ -51,8 +51,8 @@ class ServiceInterface {
   virtual DispatchResult DispatchCommand(ParsedArgs args, ParsedCommand* cmd, AsyncPreference) = 0;
   DispatchResult DispatchCommandSimple(ParsedCommand* cmd, AsyncPreference mode);
 
-  virtual DispatchManyResult DispatchManyCommands(std::function<ParsedArgs()> arg_gen,
-                                                  unsigned count, SinkReplyBuilder* builder,
+  virtual DispatchManyResult DispatchManyCommands(ParsedCommand* head, unsigned count,
+                                                  SinkReplyBuilder* builder,
                                                   ConnectionContext* cntx) = 0;
 
   virtual DispatchResult DispatchMC(ParsedCommand* cmd, AsyncPreference) = 0;

--- a/src/facade/service_interface.h
+++ b/src/facade/service_interface.h
@@ -19,7 +19,6 @@ namespace facade {
 class ConnectionContext;
 class Connection;
 class SinkReplyBuilder;
-class MCReplyBuilder;
 
 // Controls asynchronicity of command dispatch
 enum class AsyncPreference : uint8_t {
@@ -54,8 +53,6 @@ class ServiceInterface {
   virtual DispatchManyResult DispatchManyCommands(ParsedCommand* head, unsigned count,
                                                   SinkReplyBuilder* builder,
                                                   ConnectionContext* cntx) = 0;
-
-  virtual DispatchResult DispatchMC(ParsedCommand* cmd, AsyncPreference) = 0;
 
   virtual ConnectionContext* CreateContext(Connection* owner) = 0;
 

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -65,6 +65,16 @@ StoredCmd::StoredCmd(const CommandId* cid, facade::ArgSlice args, facade::ReplyM
   args_ = facade::ParsedArgs{*backed_};
 }
 
+StoredCmd::StoredCmd(const CommandId* cid, cmn::BackedArguments* src, uint8_t tail_index,
+                     facade::ReplyMode mode)
+    : cid_{cid}, reply_mode_{mode} {
+  backed_ = std::make_unique<cmn::BackedArguments>();
+  src->SwapArgs(*backed_);
+  args_ = facade::ParsedArgs{*backed_};
+  for (uint8_t i = 0; i < tail_index; ++i)
+    args_ = args_.Tail();
+}
+
 CmdArgList StoredCmd::Slice(CmdArgVec* scratch) const {
   return args_.ToSlice(scratch);
 }
@@ -74,6 +84,10 @@ std::string StoredCmd::FirstArg() const {
     return {};
   }
   return string{args_.Front()};
+}
+
+CmdRef StoredCmd::Ref() const {
+  return CmdRef{cid_, args_, reply_mode_};
 }
 
 ConnectionContext::ConnectionContext(facade::Connection* owner, acl::UserCredentials cred)
@@ -170,12 +184,6 @@ void ConnectionContext::PUnsubscribeAll(bool to_reply, facade::RedisReplyBuilder
 
 size_t ConnectionState::ExecInfo::UsedMemory() const {
   return HeapSize(body) + HeapSize(watched_keys);
-}
-
-void ConnectionState::ExecInfo::AddStoredCmd(const CommandId* cid, ArgSlice args) {
-  body.emplace_back(cid, args);
-  stored_cmd_bytes += body.back().UsedMemory();
-  is_write |= cid->IsJournaled();
 }
 
 size_t ConnectionState::ExecInfo::ClearStoredCmds() {

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -21,6 +21,22 @@ class ChannelStore;
 class Interpreter;
 struct FlowInfo;
 
+// Non-owning view of a command for the squasher. Can be constructed from StoredCmd or
+// CommandContext.
+struct CmdRef {
+  const CommandId* cid = nullptr;
+  facade::ParsedArgs args;
+  facade::ReplyMode reply_mode = facade::ReplyMode::FULL;
+
+  bool IsValid() const {
+    return cid != nullptr;
+  }
+
+  facade::ArgSlice Slice(CmdArgVec* scratch) const {
+    return args.ToSlice(scratch);
+  }
+};
+
 // Stores command id and arguments for delayed invocation.
 // Used for storing MULTI/EXEC commands.
 class StoredCmd {
@@ -28,10 +44,10 @@ class StoredCmd {
   // Deep copy of args, creates backing storage internally.
   StoredCmd(const CommandId* cid, ArgSlice args, facade::ReplyMode mode = facade::ReplyMode::FULL);
 
-  // Shallow copy of args.
-  StoredCmd(const CommandId* cid, facade::ParsedArgs args)
-      : cid_{cid}, args_{args}, reply_mode_(facade::ReplyMode::FULL) {
-  }
+  // Moves args from src via swap. src's BackedArguments will be empty after this.
+  // tail_index specifies how many leading args to skip (e.g., 1 to skip the command name).
+  StoredCmd(const CommandId* cid, cmn::BackedArguments* src, uint8_t tail_index,
+            facade::ReplyMode mode = facade::ReplyMode::FULL);
 
   size_t NumArgs() const {
     return args_.size();
@@ -51,6 +67,8 @@ class StoredCmd {
   facade::ReplyMode ReplyMode() const {
     return reply_mode_;
   }
+
+  CmdRef Ref() const;
 
  private:
   const CommandId* cid_;     // underlying command
@@ -86,9 +104,6 @@ struct ConnectionState {
     void ClearWatched();
 
     size_t UsedMemory() const;
-
-    // Deep copies arguments and updates the stored_cmd_bytes.
-    void AddStoredCmd(const CommandId* cid, ArgSlice args);
 
     // Empties the body vector and resets stored_cmd_bytes to 0. Returns the size before data was
     // cleared.

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -907,6 +907,38 @@ bool ShouldLogError(const CommandId& cid, string_view reason, CmdArgList tail_ar
   return tail_args.empty() || !absl::EqualsIgnoreCase(tail_args.front(), "maint_notifications");
 }
 
+string_view McTypeToCmdName(MemcacheParser::CmdType type) {
+  using MP = MemcacheParser;
+  switch (type) {
+    case MP::SET:
+    case MP::ADD:
+    case MP::REPLACE:
+      return "SET";
+    case MP::DELETE:
+      return "DEL";
+    case MP::INCR:
+      return "INCR";
+    case MP::DECR:
+      return "DECR";
+    case MP::APPEND:
+      return "APPEND";
+    case MP::PREPEND:
+      return "PREPEND";
+    case MP::GET:
+    case MP::GETS:
+      return "MGET";
+    case MP::GAT:
+    case MP::GATS:
+      return "GAT";
+    case MP::FLUSHALL:
+      return "FLUSHDB";
+    case MP::QUIT:
+      return "QUIT";
+    default:
+      return {};
+  }
+}
+
 }  // namespace
 
 Service::Service(ProactorPool* pp)
@@ -1422,19 +1454,44 @@ std::optional<ErrorReply> Service::VerifyCommandState(const CommandId& cid, CmdA
 
 DispatchResult Service::DispatchCommand(facade::ParsedArgs args, facade::ParsedCommand* parsed_cmd,
                                         facade::AsyncPreference async_pref) {
-  DCHECK(!args.empty());
   DCHECK_NE(0u, shard_set->size()) << "Init was not called";
 
-  // We must resolve the command ID (cid) before the guard block.
-  // The following switch statement relies on the command's metadata
-  // (e.g., SupportsAsync()) to evaluate execution preferences,
-  // making this lookup a hard dependency for the logic below.
-  const auto [cid, args_no_cmd] = registry_.FindExtended(args);
+  const CommandId* cid = nullptr;
+  ParsedArgs args_no_cmd;
+
+  if (auto* mc = parsed_cmd->mc_command()) {
+    // Handle MC commands that don't map to registered Redis commands.
+    if (mc->type == MemcacheParser::STATS || mc->type == MemcacheParser::VERSION) {
+      if (async_pref == AsyncPreference::ONLY_ASYNC)
+        return DispatchResult::WOULD_BLOCK;
+      auto* cmd_ctx = static_cast<CommandContext*>(parsed_cmd);
+      if (mc->type == MemcacheParser::STATS) {
+        server_family_.StatsMC(mc->key(), cmd_ctx);
+      } else {
+        cmd_ctx->SendSimpleString("VERSION 1.6.0 DF");
+      }
+      return DispatchResult::OK;
+    }
+
+    // Map MC command type to Redis command name.
+    string_view cmd_name = McTypeToCmdName(mc->type);
+    if (!cmd_name.empty())
+      cid = registry_.Find(cmd_name);
+    args_no_cmd = args;  // MC args have no command name prefix
+  } else {
+    DCHECK(!args.empty());
+    std::tie(cid, args_no_cmd) = registry_.FindExtended(args);
+  }
+
   if (cid == nullptr) {
     if (async_pref != AsyncPreference::ONLY_SYNC) {
       parsed_cmd->SetDeferredReply();
     }
-    parsed_cmd->SendError(ReportUnknownCmd(absl::AsciiStrToUpper(args.Front())));
+    if (parsed_cmd->mc_command()) {
+      parsed_cmd->SendSimpleString("CLIENT_ERROR bad command line format");
+    } else {
+      parsed_cmd->SendError(ReportUnknownCmd(absl::AsciiStrToUpper(args.Front())));
+    }
     return DispatchResult::ERROR;
   }
 
@@ -1754,106 +1811,6 @@ DispatchManyResult Service::DispatchManyCommands(facade::ParsedCommand* head, un
     ss->stats.squash_stats_ignored++;
   }
   return {.processed = dispatched, .account_in_stats = account_in_stats};
-}
-
-DispatchResult Service::DispatchMC(facade::ParsedCommand* parsed_cmd,
-                                   facade::AsyncPreference apref) {
-  CommandContext* cmd_ctx = static_cast<CommandContext*>(parsed_cmd);
-  const auto& cmd = *parsed_cmd->mc_command();
-
-  auto* cntx = cmd_ctx->server_conn_cntx();
-  DCHECK(cntx->transaction == nullptr);
-
-  string_view cmd_name, cmd_opt;
-  char buffer[absl::numbers_internal::kFastToBufferSize];
-
-  switch (cmd.type) {
-    case MemcacheParser::REPLACE:
-      cmd_name = "SET";
-      cmd_opt = "XX";
-      break;
-    case MemcacheParser::SET:
-      cmd_name = "SET";
-      break;
-    case MemcacheParser::ADD:
-      cmd_name = "SET";
-      cmd_opt = "NX";
-      break;
-    case MemcacheParser::DELETE:
-      cmd_name = "DEL";
-      break;
-    case MemcacheParser::INCR:
-      cmd_name = "INCRBY";
-      absl::numbers_internal::FastIntToBuffer(cmd.delta, buffer);
-      cmd_opt = buffer;
-      break;
-    case MemcacheParser::DECR:
-      cmd_name = "DECRBY";
-      absl::numbers_internal::FastIntToBuffer(cmd.delta, buffer);
-      cmd_opt = buffer;
-      break;
-    case MemcacheParser::APPEND:
-      cmd_name = "APPEND";
-      break;
-    case MemcacheParser::PREPEND:
-      cmd_name = "PREPEND";
-      break;
-    case MemcacheParser::GAT:
-    case MemcacheParser::GATS:
-      cmd_name = "GAT";
-      break;
-    case MemcacheParser::GET:
-    case MemcacheParser::GETS:
-      cmd_name = "MGET";
-      break;
-    case MemcacheParser::FLUSHALL:
-      cmd_name = "FLUSHDB";
-      break;
-    case MemcacheParser::QUIT:
-      cmd_name = "QUIT";
-      break;
-    case MemcacheParser::STATS:
-      if (apref == AsyncPreference::ONLY_ASYNC)
-        return DispatchResult::WOULD_BLOCK;
-      server_family_.StatsMC(cmd.key(), cmd_ctx);
-      return DispatchResult::OK;
-    case MemcacheParser::VERSION:
-      if (apref == AsyncPreference::ONLY_ASYNC)
-        return DispatchResult::WOULD_BLOCK;
-      cmd_ctx->SendSimpleString("VERSION 1.6.0 DF");
-      return DispatchResult::OK;
-    default:
-      if (apref != AsyncPreference::ONLY_SYNC) {
-        parsed_cmd->SetDeferredReply();
-      }
-      cmd_ctx->SendSimpleString("CLIENT_ERROR bad command line format");
-      return DispatchResult::ERROR;
-  }
-
-  absl::InlinedVector<string_view, 8> args = {cmd_name};
-
-  bool is_store = MemcacheParser::IsStoreCmd(cmd.type);
-  bool is_read = !is_store && cmd.type < MemcacheParser::QUIT;
-  if (!is_read) {
-    if (!cmd.backed_args->empty())
-      args.emplace_back(cmd.key());
-
-    if (is_store)
-      args.emplace_back(cmd.value());
-    if (!cmd_opt.empty())
-      args.emplace_back(cmd_opt);
-
-    if (cmd.expire_ts && cmd_name == "SET") {
-      args.emplace_back("EXAT");
-      absl::numbers_internal::FastIntToBuffer(cmd.expire_ts, buffer);
-      args.emplace_back(buffer);
-    }
-  } else {  // is_read
-    auto view = cmd.backed_args->view();
-    args.insert(args.end(), view.begin(), view.end());
-  }
-
-  return DispatchCommand(ParsedArgs{args}, parsed_cmd, apref);
 }
 
 ErrorReply Service::ReportUnknownCmd(string_view cmd_name) {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -885,11 +885,16 @@ pair<intrusive_ptr<Transaction>, OpStatus> PrepareTransaction(const CommandId* c
   return {std::move(res), OpStatus::OK};
 }
 
-void StoreInMultiBlock(ConnectionContext* dfly_cntx, const CommandId* cid, ArgSlice tail_args) {
+void StoreInMultiBlock(ConnectionContext* dfly_cntx, const CommandId* cid,
+                       facade::ParsedCommand* parsed_cmd, uint8_t tail_index) {
   // TODO: protect against aggregating huge transactions.
   auto& exec_info = dfly_cntx->conn_state.exec_info;
   const size_t old_size = exec_info.GetStoredCmdBytes();
-  exec_info.AddStoredCmd(cid, tail_args);  // Deep copy of args.
+
+  // Moves arguments from parsed_cmd to body.
+  exec_info.body.emplace_back(cid, parsed_cmd, tail_index);
+  exec_info.stored_cmd_bytes += exec_info.body.back().UsedMemory();
+  exec_info.is_write |= cid->IsJournaled();
   ServerState::tlocal()->stats.stored_cmd_bytes += exec_info.GetStoredCmdBytes() - old_size;
 }
 
@@ -1508,7 +1513,8 @@ DispatchResult Service::DispatchCommand(facade::ParsedArgs args, facade::ParsedC
   // If inside MULTI block, store command
   bool is_trans_cmd = cid->MultiControlKind() == CO::MultiControlKind::EXEC;
   if (dfly_cntx->conn_state.exec_info.IsCollecting() && !is_trans_cmd) {
-    StoreInMultiBlock(dfly_cntx, cid, tail_args);
+    uint8_t tail_index = args.size() - args_no_cmd.size();
+    StoreInMultiBlock(dfly_cntx, cid, parsed_cmd, tail_index);
     cmd_cntx->SendSimpleString("QUEUED");
     return DispatchResult::OK;
   }
@@ -1642,8 +1648,8 @@ DispatchResult Service::InvokeCmd(CmdArgList tail_args, CommandContext* cmd_cntx
   return res;
 }
 
-DispatchManyResult Service::DispatchManyCommands(std::function<facade::ParsedArgs()> arg_gen,
-                                                 unsigned count, SinkReplyBuilder* builder,
+DispatchManyResult Service::DispatchManyCommands(facade::ParsedCommand* head, unsigned count,
+                                                 SinkReplyBuilder* builder,
                                                  facade::ConnectionContext* cntx) {
   ConnectionContext* dfly_cntx = static_cast<ConnectionContext*>(cntx);
   DCHECK(!dfly_cntx->conn_state.exec_info.IsRunning());
@@ -1655,17 +1661,15 @@ DispatchManyResult Service::DispatchManyCommands(std::function<facade::ParsedArg
   if (ss->IsPaused())
     return {.processed = 0, .account_in_stats = false};
 
-  vector<StoredCmd> stored_cmds;
+  vector<CmdRef> cmd_refs;
   intrusive_ptr<Transaction> dist_trans;
   uint32_t dispatched = 0;
   MultiCommandSquasher::Stats stats;
 
   uint64_t start_cycles = base::CycleClock::Now();
-  CommandContext dummy_cmd_cntx;
-  dummy_cmd_cntx.Init(builder, dfly_cntx);
 
   auto perform_squash = [&] {
-    if (stored_cmds.empty())
+    if (cmd_refs.empty())
       return;
 
     if (!dist_trans) {
@@ -1681,17 +1685,24 @@ DispatchManyResult Service::DispatchManyCommands(std::function<facade::ParsedArg
     opts.verify_commands = true;
     opts.max_squash_size = ss->max_squash_cmd_num;
 
-    stats += MultiCommandSquasher::Execute(absl::MakeSpan(stored_cmds),
-                                           static_cast<RedisReplyBuilder*>(builder), dfly_cntx,
-                                           this, opts);
+    auto cmd_gen = [it = cmd_refs.begin(), end = cmd_refs.end()]() mutable -> CmdRef {
+      return (it == end) ? CmdRef{} : *it++;
+    };
+    stats += MultiCommandSquasher::Execute(
+        std::move(cmd_gen), static_cast<RedisReplyBuilder*>(builder), dfly_cntx, this, opts);
     dfly_cntx->transaction = nullptr;
 
-    dispatched += stored_cmds.size();
-    stored_cmds.clear();
+    dispatched += cmd_refs.size();
+    cmd_refs.clear();
   };
 
   for (unsigned i = 0; i < count; i++) {
-    ParsedArgs args = arg_gen();
+    ParsedCommand* parsed_cmd = head;
+    head = head->next;
+    CommandContext* cmd_cntx = static_cast<CommandContext*>(parsed_cmd);
+    cmd_cntx->Init(builder, dfly_cntx);
+
+    ParsedArgs args{*parsed_cmd};
     const auto [cid, tail_args] = registry_.FindExtended(args);
 
     // MULTI...EXEC commands need to be collected into a single context, so squashing is not
@@ -1708,8 +1719,8 @@ DispatchManyResult Service::DispatchManyCommands(std::function<facade::ParsedArg
     const bool is_blocking = cid != nullptr && cid->IsBlocking();
 
     if (!is_multi && !is_eval && !is_blocking && cid != nullptr) {
-      stored_cmds.reserve(count);
-      stored_cmds.emplace_back(cid, tail_args);  // Shallow copy
+      cmd_refs.reserve(count);
+      cmd_refs.push_back(CmdRef{cid, tail_args});
       continue;
     }
 
@@ -1720,8 +1731,9 @@ DispatchManyResult Service::DispatchManyCommands(std::function<facade::ParsedArg
     if (ss->IsPaused())
       break;
 
-    // Dispatch non squashed command only after all squshed commands were executed and replied
-    DispatchCommand(args, &dummy_cmd_cntx, AsyncPreference::ONLY_SYNC);
+    // Dispatch non squashed command only after all squashed commands were executed and replied
+    cmd_cntx->UpdateCid(cid);
+    DispatchCommand(args, cmd_cntx, AsyncPreference::ONLY_SYNC);
     dispatched++;
   }
 
@@ -1991,7 +2003,10 @@ optional<CapturingReplyBuilder::Payload> Service::FlushEvalAsyncCmds(ConnectionC
   opts.verify_commands = true;
   opts.error_abort = true;
   opts.max_squash_size = ServerState::tlocal()->max_squash_cmd_num;
-  MultiCommandSquasher::Execute(absl::MakeSpan(info->async_cmds), &crb, cntx, this, opts);
+  auto cmd_gen = [it = info->async_cmds.begin(), end = info->async_cmds.end()]() mutable -> CmdRef {
+    return (it == end) ? CmdRef{} : (it++)->Ref();
+  };
+  MultiCommandSquasher::Execute(std::move(cmd_gen), &crb, cntx, this, opts);
 
   info->async_cmds_heap_mem = 0;
   info->async_cmds.clear();
@@ -2516,9 +2531,12 @@ void Service::Exec(CmdArgList args, CommandContext* cmd_cntx) {
 
     if (GetFlag(FLAGS_multi_exec_squash) && state != ExecScriptUse::SCRIPT_RUN &&
         !cntx->conn_state.tracking_info_.IsTrackingOn()) {
+      auto cmd_gen = [it = exec_info.body.begin(), end = exec_info.body.end()]() mutable -> CmdRef {
+        return (it == end) ? CmdRef{} : (it++)->Ref();
+      };
       MultiCommandSquasher::Opts opts;
       opts.max_squash_size = ServerState::tlocal()->max_squash_cmd_num;
-      MultiCommandSquasher::Execute(absl::MakeSpan(exec_info.body), rb, cntx, this, opts);
+      MultiCommandSquasher::Execute(std::move(cmd_gen), rb, cntx, this, opts);
     } else {
       CmdArgVec arg_vec;
       DCHECK_EQ(cmd_cntx->cid(), exec_cid_);

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -42,8 +42,8 @@ class Service : public facade::ServiceInterface {
                                          facade::AsyncPreference apref) final;
 
   // Execute multiple consecutive commands, possibly in parallel by squashing
-  facade::DispatchManyResult DispatchManyCommands(std::function<facade::ParsedArgs()> arg_gen,
-                                                  unsigned count, facade::SinkReplyBuilder* builder,
+  facade::DispatchManyResult DispatchManyCommands(facade::ParsedCommand* head, unsigned count,
+                                                  facade::SinkReplyBuilder* builder,
                                                   facade::ConnectionContext* cntx) final;
 
   // Check OOM and invoke command with args

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -55,9 +55,6 @@ class Service : public facade::ServiceInterface {
   std::optional<facade::ErrorReply> VerifyCommandState(const CommandId& cid, ArgSlice tail_args,
                                                        const ConnectionContext& cntx);
 
-  facade::DispatchResult DispatchMC(facade::ParsedCommand* parsed_cmd,
-                                    facade::AsyncPreference apref) final;
-
   facade::ConnectionContext* CreateContext(facade::Connection* owner) final;
   facade::ParsedCommand* AllocateParsedCommand() final;
 

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -71,9 +71,13 @@ MultiCommandSquasher::Stats& MultiCommandSquasher::Stats::operator+=(const Stats
   return *this;
 }
 
-MultiCommandSquasher::MultiCommandSquasher(absl::Span<StoredCmd> cmds, ConnectionContext* cntx,
+MultiCommandSquasher::MultiCommandSquasher(CmdGenerator cmd_gen, ConnectionContext* cntx,
                                            Service* service, const Opts& opts)
-    : cmds_{cmds}, cntx_{cntx}, service_{service}, base_cid_{nullptr}, opts_{opts} {
+    : cmd_gen_{std::move(cmd_gen)},
+      cntx_{cntx},
+      service_{service},
+      base_cid_{nullptr},
+      opts_{opts} {
   auto mode = cntx->transaction->GetMultiMode();
   base_cid_ = cntx->transaction->GetCId();
   atomic_ = mode != Transaction::NON_ATOMIC;
@@ -103,10 +107,10 @@ MultiCommandSquasher::ShardExecInfo& MultiCommandSquasher::PrepareShardInfo(Shar
   return sinfo;
 }
 
-MultiCommandSquasher::SquashResult MultiCommandSquasher::TrySquash(const StoredCmd* cmd) {
-  DCHECK(cmd->Cid());
+MultiCommandSquasher::SquashResult MultiCommandSquasher::TrySquash(CmdRef cmd) {
+  DCHECK(cmd.cid);
 
-  const CommandId& cid = *cmd->Cid();
+  const CommandId& cid = *cmd.cid;
   if (!cid.IsTransactional() || (cid.opt_mask() & CO::BLOCKING) ||
       (cid.opt_mask() & CO::GLOBAL_TRANS))
     return SquashResult::NOT_SQUASHED;
@@ -115,7 +119,7 @@ MultiCommandSquasher::SquashResult MultiCommandSquasher::TrySquash(const StoredC
     return SquashResult::NOT_SQUASHED;
   }
 
-  auto args = cmd->Slice(&tmp_keylist_);
+  auto args = cmd.Slice(&tmp_keylist_);
   if (args.empty())
     return SquashResult::NOT_SQUASHED;
 
@@ -154,21 +158,21 @@ MultiCommandSquasher::SquashResult MultiCommandSquasher::TrySquash(const StoredC
   return need_flush ? SquashResult::SQUASHED_FULL : SquashResult::SQUASHED;
 }
 
-bool MultiCommandSquasher::ExecuteStandalone(RedisReplyBuilder* rb, const StoredCmd* cmd) {
+bool MultiCommandSquasher::ExecuteStandalone(RedisReplyBuilder* rb, CmdRef cmd) {
   DCHECK(order_.empty());  // check no squashed chain is interrupted
 
-  auto args = cmd->Slice(&tmp_keylist_);
+  auto args = cmd.Slice(&tmp_keylist_);
 
   if (opts_.verify_commands) {
-    if (auto err = service_->VerifyCommandState(*cmd->Cid(), args, *cntx_); err) {
+    if (auto err = service_->VerifyCommandState(*cmd.cid, args, *cntx_); err) {
       rb->SendError(std::move(*err));
       return !opts_.error_abort;
     }
   }
 
   auto* tx = cntx_->transaction;
-  if (cmd->Cid()->IsTransactional()) {
-    tx->MultiSwitchCmd(cmd->Cid());
+  if (cmd.cid->IsTransactional()) {
+    tx->MultiSwitchCmd(cmd.cid);
     auto status = tx->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, args);
     if (status != OpStatus::OK) {
       rb->SendError(status);
@@ -176,7 +180,7 @@ bool MultiCommandSquasher::ExecuteStandalone(RedisReplyBuilder* rb, const Stored
     }
   }
   CommandContext cmd_cntx{rb, cntx_};
-  cmd_cntx.SetupTx(cmd->Cid(), tx);
+  cmd_cntx.SetupTx(cmd.cid, tx);
   service_->InvokeCmd(args, &cmd_cntx);
   return true;
 }
@@ -200,24 +204,24 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
   };
 
   for (auto& dispatched : sinfo.dispatched) {
-    auto args = dispatched.cmd->Slice(&arg_vec);
+    auto args = dispatched.cmd.Slice(&arg_vec);
     if (opts_.verify_commands) {
       // The shared context is used for state verification, the local one is only for replies
-      if (auto err = service_->VerifyCommandState(*dispatched.cmd->Cid(), args, *cntx_); err) {
+      if (auto err = service_->VerifyCommandState(*dispatched.cmd.cid, args, *cntx_); err) {
         crb.SendError(std::move(*err));
         move_reply(crb.Take(), &dispatched.reply);
         continue;
       }
     }
 
-    crb.SetReplyMode(dispatched.cmd->ReplyMode());
+    crb.SetReplyMode(dispatched.cmd.reply_mode);
 
-    local_tx->MultiSwitchCmd(dispatched.cmd->Cid());
+    local_tx->MultiSwitchCmd(dispatched.cmd.cid);
     auto status = local_tx->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, args);
     if (status != OpStatus::OK) {
       crb.SendError(status);
     } else {
-      cmd_cntx.UpdateCid(dispatched.cmd->Cid());
+      cmd_cntx.UpdateCid(dispatched.cmd.cid);
       service_->InvokeCmd(args, &cmd_cntx);
     }
     move_reply(crb.Take(), &dispatched.reply);
@@ -359,11 +363,11 @@ bool MultiCommandSquasher::ExecuteSquashed(facade::RedisReplyBuilder* rb) {
 }
 
 void MultiCommandSquasher::Run(RedisReplyBuilder* rb) {
-  DVLOG(1) << "Trying to squash " << cmds_.size() << " commands for transaction "
-           << cntx_->transaction->DebugId();
+  DVLOG(1) << "Trying to squash commands for transaction " << cntx_->transaction->DebugId();
 
-  for (auto& cmd : cmds_) {
-    auto res = TrySquash(&cmd);
+  for (CmdRef cmd = cmd_gen_(); cmd.IsValid(); cmd = cmd_gen_()) {
+    num_commands_++;
+    auto res = TrySquash(cmd);
 
     if (res == SquashResult::NOT_SQUASHED || res == SquashResult::SQUASHED_FULL) {
       if (!ExecuteSquashed(rb))
@@ -371,7 +375,7 @@ void MultiCommandSquasher::Run(RedisReplyBuilder* rb) {
 
       // if the last command was not added - we squash it separately.
       if (res == SquashResult::NOT_SQUASHED) {
-        if (!ExecuteStandalone(rb, &cmd))
+        if (!ExecuteStandalone(rb, cmd))
           break;
       }
     }
@@ -391,7 +395,7 @@ void MultiCommandSquasher::Run(RedisReplyBuilder* rb) {
     }
   }
 
-  VLOG(1) << "Handled " << cmds_.size() << " commands, max fanout: " << num_shards_
+  VLOG(1) << "Handled " << num_commands_ << " commands, max fanout: " << num_shards_
           << ", atomic: " << atomic_;
 }
 

--- a/src/server/multi_command_squasher.h
+++ b/src/server/multi_command_squasher.h
@@ -37,10 +37,12 @@ class MultiCommandSquasher {
     Stats& operator+=(const Stats& o);
   };
 
-  // Returns number of processed commands.
-  static Stats Execute(absl::Span<StoredCmd> cmds, facade::RedisReplyBuilder* rb,
-                       ConnectionContext* cntx, Service* service, const Opts& opts) {
-    MultiCommandSquasher sq{cmds, cntx, service, opts};
+  // cmd_gen returns CmdRef one at a time; an invalid CmdRef (cid==nullptr) signals the end.
+  using CmdGenerator = std::function<CmdRef()>;
+
+  static Stats Execute(CmdGenerator cmd_gen, facade::RedisReplyBuilder* rb, ConnectionContext* cntx,
+                       Service* service, const Opts& opts) {
+    MultiCommandSquasher sq{std::move(cmd_gen), cntx, service, opts};
     sq.Run(rb);
     return sq.stats_;
   }
@@ -55,7 +57,7 @@ class MultiCommandSquasher {
     }
 
     struct Command {
-      const StoredCmd* cmd;
+      CmdRef cmd;
       facade::CapturingReplyBuilder::Payload reply;
     };
     std::vector<Command> dispatched;  // Dispatched commands
@@ -68,17 +70,17 @@ class MultiCommandSquasher {
 
   enum class SquashResult : uint8_t { SQUASHED, SQUASHED_FULL, NOT_SQUASHED };
 
-  MultiCommandSquasher(absl::Span<StoredCmd> cmds, ConnectionContext* cntx, Service* Service,
+  MultiCommandSquasher(CmdGenerator cmd_gen, ConnectionContext* cntx, Service* Service,
                        const Opts& opts);
 
   // Lazy initialize shard info.
   ShardExecInfo& PrepareShardInfo(ShardId sid);
 
   // Retrun squash flags
-  SquashResult TrySquash(const StoredCmd* cmd);
+  SquashResult TrySquash(CmdRef cmd);
 
   // Execute separate non-squashed cmd. Return false if aborting on error.
-  bool ExecuteStandalone(facade::RedisReplyBuilder* rb, const StoredCmd* cmd);
+  bool ExecuteStandalone(facade::RedisReplyBuilder* rb, CmdRef cmd);
 
   // Callback that runs on shards during squashed hop.
   facade::OpStatus SquashedHopCb(EngineShard* es, facade::RespVersion resp_v);
@@ -90,8 +92,8 @@ class MultiCommandSquasher {
 
   bool IsAtomic() const;
 
-  absl::Span<StoredCmd> cmds_;  // Input range of stored commands
-  ConnectionContext* cntx_;     // Underlying context
+  CmdGenerator cmd_gen_;     // Pulls commands one at a time
+  ConnectionContext* cntx_;  // Underlying context
   Service* service_;
 
   bool atomic_;                // Whether working in any of the atomic modes
@@ -103,6 +105,7 @@ class MultiCommandSquasher {
   std::vector<ShardId> order_;  // reply order for squashed cmds
 
   size_t num_shards_ = 0;
+  size_t num_commands_ = 0;  // Total commands processed
 
   std::vector<MutableSlice> tmp_keylist_;
   Stats stats_;

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -1040,6 +1040,26 @@ std::variant<SetCmd::SetParams, facade::ErrorReply, NegativeExpire> ParseSetPara
   if (auto err = parser.TakeError(); err)
     return err.MakeReply();
 
+  if (auto* mc = cmd_cntx->mc_command()) {
+    using MP = facade::MemcacheParser;
+    if (mc->type == MP::ADD)
+      sparams.flags |= SetCmd::SET_IF_NOTEXIST;
+    else if (mc->type == MP::REPLACE)
+      sparams.flags |= SetCmd::SET_IF_EXISTS;
+
+    if (mc->expire_ts > 0) {
+      sparams.flags |= SetCmd::SET_EXPIRE_AFTER_MS;
+      DbSlice::ExpireParams expiry{.value = mc->expire_ts, .unit = TimeUnit::SEC, .absolute = true};
+      int64_t now_ms = GetCurrentTimeMs();
+      auto [rel_ms, abs_ms] = expiry.Calculate(now_ms, false);
+      if (abs_ms < 0)
+        return facade::ErrorReply{InvalidExpireTime("set")};
+      if (rel_ms < 0)
+        return NegativeExpire{};
+      tie(sparams.expire_after_ms, ignore) = expiry.Calculate(now_ms, true);
+    }
+  }
+
   auto has_mask = [&](uint16_t m) { return (sparams.flags & m) == m; };
   if (has_mask(SetCmd::SET_IF_EXISTS | SetCmd::SET_IF_NOTEXIST) ||
       has_mask(SetCmd::SET_KEEP_EXPIRE | SetCmd::SET_EXPIRE_AFTER_MS)) {
@@ -1352,7 +1372,8 @@ cmd::CmdR CmdGetEx(CmdArgList args, CommandContext* cmd_cntx) {
 
 cmd::CmdR CmdIncr(CmdArgList args, CommandContext* cmd_cntx) {
   string_view key = ArgS(args, 0);
-  return IncrByGeneric(cmd_cntx, key, 1);
+  int64_t delta = cmd_cntx->mc_command() ? int64_t(cmd_cntx->mc_command()->delta) : 1;
+  return IncrByGeneric(cmd_cntx, key, delta);
 }
 
 cmd::CmdR CmdIncrBy(CmdArgList args, CommandContext* cmd_cntx) {
@@ -1392,7 +1413,8 @@ cmd::CmdR CmdIncrByFloat(CmdArgList args, CommandContext* cmd_cntx) {
 
 cmd::CmdR CmdDecr(CmdArgList args, CommandContext* cmd_cntx) {
   string_view key = ArgS(args, 0);
-  return IncrByGeneric(cmd_cntx, key, -1);
+  int64_t delta = cmd_cntx->mc_command() ? int64_t(cmd_cntx->mc_command()->delta) : 1;
+  return IncrByGeneric(cmd_cntx, key, -delta);
 }
 
 cmd::CmdR CmdDecrBy(CmdArgList args, CommandContext* cmd_cntx) {

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -493,16 +493,13 @@ void BaseFamilyTest::RunMany(const std::vector<std::vector<std::string>>& cmds) 
   TestConnWrapper* conn_wrapper = AddFindConn(Protocol::REDIS, GetId());
   auto* context = conn_wrapper->cmd_cntx();
   context->ns = &namespaces->GetDefaultNamespace();
-  vector<cmn::BackedArguments> backed_args_vec(cmds.size());
+  vector<CommandContext> cmd_cntxs(cmds.size());
   for (size_t i = 0; i < cmds.size(); ++i) {
-    backed_args_vec[i] = cmn::BackedArguments(cmds[i].begin(), cmds[i].end(), cmds[i].size());
+    cmd_cntxs[i].Assign(cmds[i].begin(), cmds[i].end(), cmds[i].size());
+    if (i + 1 < cmds.size())
+      cmd_cntxs[i].next = &cmd_cntxs[i + 1];
   }
-  auto next_fn = [it = backed_args_vec.begin()]() mutable {
-    ParsedArgs args(*it);
-    ++it;
-    return args;
-  };
-  service_->DispatchManyCommands(next_fn, cmds.size(), conn_wrapper->builder(), context);
+  service_->DispatchManyCommands(&cmd_cntxs[0], cmds.size(), conn_wrapper->builder(), context);
   DCHECK(context->transaction == nullptr);
 }
 

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -530,7 +530,7 @@ auto BaseFamilyTest::RunMC(MP::CmdType cmd_type, string_view key, MCArgs args) -
 
   DCHECK(context->transaction == nullptr);
 
-  service_->DispatchMC(&cmd_cntx, AsyncPreference::ONLY_SYNC);
+  service_->DispatchCommandSimple(&cmd_cntx, AsyncPreference::ONLY_SYNC);
 
   DCHECK(context->transaction == nullptr);
 
@@ -566,7 +566,7 @@ auto BaseFamilyTest::GetMC(MP::CmdType cmd_type, std::initializer_list<std::stri
   }
 
   cmd_cntx.Assign(src, list.end(), list.end() - src);
-  service_->DispatchMC(&cmd_cntx, AsyncPreference::ONLY_SYNC);
+  service_->DispatchCommandSimple(&cmd_cntx, AsyncPreference::ONLY_SYNC);
 
   return conn->SplitLines();
 }

--- a/tests/dragonfly/memory_test.py
+++ b/tests/dragonfly/memory_test.py
@@ -9,7 +9,7 @@ import redis
 
 from . import dfly_args
 from .instance import DflyInstanceFactory
-from .utility import tmp_file_name
+from .utility import assert_eventually, tmp_file_name
 
 
 @pytest.mark.large
@@ -113,18 +113,22 @@ async def test_rss_oom_ratio(df_factory: DflyInstanceFactory, admin_port):
     df_server.start()
 
     client = df_server.client()
-    await client.execute_command("DEBUG POPULATE 10000 key 40000 RAND")
+    await client.execute_command("DEBUG POPULATE 10100 key 40000 RAND")
 
     await asyncio.sleep(1)  # Wait for another RSS heartbeat update in Dragonfly
 
     new_client = df_server.admin_client() if admin_port else df_server.client()
-    await new_client.ping()
-
-    info = await new_client.info("memory")
-    logging.debug(f'Used memory {info["used_memory"]}, rss {info["used_memory_rss"]}')
-
     reject_limit = 256 * 1024 * 1024  # 256mb
-    assert info["used_memory_rss"] > reject_limit
+
+    @assert_eventually(timeout=5)
+    async def rss_compare(gt: bool):
+        info = await new_client.info("memory")
+        rss = info["used_memory_rss"]
+        used = info["used_memory"]
+        logging.info(f"Used memory {used}, rss {rss}")
+        assert (rss > reject_limit) if gt else (rss < reject_limit)
+
+    await rss_compare(True)
 
     # get command from existing connection should not be rejected
     await client.execute_command("get x")
@@ -142,11 +146,8 @@ async def test_rss_oom_ratio(df_factory: DflyInstanceFactory, admin_port):
     # flush to free memory
     await new_client.flushall()
 
-    await asyncio.sleep(2)  # Wait for another RSS heartbeat update in Dragonfly
-
-    info = await new_client.info("memory")
-    logging.debug(f'Used memory {info["used_memory"]}, rss {info["used_memory_rss"]}')
-    assert info["used_memory_rss"] < reject_limit
+    await rss_compare(False)
+    await asyncio.sleep(0.5)  # Wait for another RSS heartbeat update in Dragonfly
 
     # new client create shoud not fail after memory usage decrease
     client = df_server.client()


### PR DESCRIPTION
## Summary

Avoid deep-copy of multi/exec arguments and remove reliance of MultiCommandSquasher on StoredCmd.

- Introduce `CmdRef` — a lightweight non-owning view (`{cid, ParsedArgs, ReplyMode}`) that both `StoredCmd` and `CommandContext` can produce
- Change `MultiCommandSquasher` from `Span<StoredCmd>` to a generator function (`std::function<CmdRef()>`) with invalid-CmdRef sentinel, eliminating intermediate vector materialization at EXEC and Lua call sites
- Add swap-based `StoredCmd` constructor for the EXEC path — moves args from `ParsedCommand` via `BackedArguments::SwapArgs` instead of deep-copying
- Change `DispatchManyCommands` generator to return `ParsedCommand*`, allowing direct use of `CommandContext` without a dummy instance

## Test plan
- [x] `multi_test` — 58 passed, 2 skipped
- [x] `generic_family_test` — 76 passed, 1 skipped
- [x] `string_family_test` — 39 passed