### PR TITLE
fix(tiering): Don't overstaturate when Offloading not requried

### DIFF
--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -731,10 +731,14 @@ auto TieredStorage::ShouldStash(const tiering::FragmentRef& fragment_ref) const
   if (fragment_ref.ObjType() == OBJ_LIST && !OccupiesWholePages(estimated_size))
     return nullopt;
 
-  // Track if we oversature disk (backpressure fails to stop clients, possibly many new)
+  // Track if we oversature disk (backpressure fails to stop clients, possibly many new).
   const auto& disk_stats = op_manager_->GetStats().disk_stats;
-  if (disk_stats.pending_stash_bytes >= 2 * config_.max_pending_stash_bytes)
+  if (disk_stats.pending_stash_bytes >= 2 * config_.max_pending_stash_bytes) {
     ++stats_.stash_overflow_cnt;
+    // Discard the write if we don't require offloading to not oversaturate the disk
+    if (!ShouldOffload())
+      return std::nullopt;
+  }
 
   if (disk_stats.allocated_bytes + tiering::kPageSize + estimated_size < disk_stats.max_file_size) {
     return blobs;


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Tiered storage: skip stashing when disk is saturated and offload isn&#x27;t needed
<code>🐞 Bug fix</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

Don't write to disk if we oversatured in-flight-bytes and offloading is not required

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Skip stashing to disk when pending stash bytes exceed the overflow threshold and offloading isn’t
  needed.
• Keep tracking stash overflow events for observability.
• Prevent optional disk writes from worsening disk saturation under heavy load.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["Write path"] --> B["TieredStorage::ShouldStash"] --> C{"Pending stash bytes\n> 2x limit?"}
  C -- "no" --> E["Allow stashing"] --> F["OpManager: stash to disk"]
  C -- "yes" --> D{"ShouldOffload?"}
  D -- "no" --> G["Return nullopt\n(skip disk write)"]
  D -- "yes" --> E

  subgraph Legend
    direction LR
    _svc["Process/Function"] ~~~ _dec{"Decision"}
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Priority-based stashing under saturation</b></summary>

- ➕ Preserves some stashing even when saturated by prioritizing critical/offload-driven items
- ➕ Can reduce tail-latency impact by selecting smaller/cheaper stashes first
- ➖ More complexity (needs prioritization signals, queue changes, and tuning)
- ➖ Harder to reason about fairness and worst-case behavior

</details>

<details>
<summary><b>2. Stronger backpressure enforcement instead of dropping optional stashes</b></summary>

- ➕ Avoids silent reduction in disk persistence/offload activity
- ➕ Keeps behavior consistent while protecting disk
- ➖ May throttle clients more aggressively, impacting throughput/latency
- ➖ Backpressure paths can be tricky and risk deadlocks/starvation if mis-tuned

</details>

**Recommendation:** Current approach is a good targeted fix: when the disk queue is far beyond the configured limit, only proceed with disk writes if memory pressure actually requires offloading. Consider priority-based stashing only if you later observe that dropping optional stashes harms eviction/offload effectiveness during sustained bursts.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>tiered_storage.cc</strong> <code>Skip stashing on overflow unless offloading is required</code> <code>+6/-2</code></summary>

<br/>

>Skip stashing on overflow unless offloading is required
>
><pre>
>• Updates TieredStorage::ShouldStash to return nullopt when pending stash bytes exceed 2x the configured limit and offloading is not required. Continues incrementing the overflow counter while preventing optional disk writes from further saturating the disk queue.
></pre>
>
><a href='https://github.com/dragonflydb/dragonfly/pull/7531/files#diff-9c9e8538f09f858442817af779ace9b941c8f861454050e4f9beb8b8a0e65dcd'>src/server/tiered_storage.cc</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>