### PR TITLE
fix(search): support parenthesized and filtered VECTOR_RANGE queries

### DIFF
--- a/src/core/search/parser.y
+++ b/src/core/search/parser.y
@@ -88,6 +88,12 @@ double toDouble(string_view src);
 %right NOT_OP TILDE
 %precedence LPAREN RPAREN
 
+// Dangling-else for the optional VECTOR_RANGE YIELD: at `]` with `=>` ahead, ARROW outranks the
+// no-yield rule (tagged %prec NO_YIELD), so bison shifts into the YIELD clause instead of reducing
+// and treating `=>` as a top-level KNN arrow.
+%precedence NO_YIELD
+%precedence ARROW
+
 %token <std::string> DOUBLE "double"
 %token <std::string> UINT32 "uint32"
 %nterm <AstExpr> final_query filter star_expr search_expr search_unary_expr search_or_expr search_and_expr bracket_filter_expr
@@ -111,8 +117,6 @@ final_query:
       { driver->Set(std::move($1)); }
   | filter ARROW knn_query
       { driver->Set(AstKnnNode(std::move($1), std::move($3))); }
-  | vector_range_query
-      { driver->Set(std::move($1)); }
 
 knn_query:
   LBRACKET KNN UINT32 FIELD TERM opt_ef_runtime opt_knn_alias RBRACKET
@@ -157,7 +161,7 @@ vector_range_query:
                                 std::move(alias));
       }
     }
-  | FIELD COLON LBRACKET VECTOR_RANGE vec_range_radius TERM RBRACKET
+  | FIELD COLON LBRACKET VECTOR_RANGE vec_range_radius TERM RBRACKET %prec NO_YIELD
     {
       double radius = $5;
       auto field = std::move($1);
@@ -215,6 +219,7 @@ search_unary_expr:
   | TILDE search_unary_expr           { $$ = AstOptionalNode(std::move($2)); }
   | term_atom                         { $$ = std::move($1);                  }
   | FIELD COLON field_cond            { $$ = AstFieldNode(std::move($1), std::move($3)); }
+  | vector_range_query                { $$ = std::move($1);                  }
 
 field_cond:
   term_atom                                             { $$ = std::move($1);                }

--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -564,7 +564,8 @@ struct BasicSearch {
     knn_distances_.resize(prefix_size);
   }
 
-  void SearchVectorRangeFlat(FlatVectorIndex* vec_index, const AstVectorRangeNode& node) {
+  void SearchVectorRangeFlat(FlatVectorIndex* vec_index, const AstVectorRangeNode& node,
+                             vector<DocId>* out) {
     const auto& all_docs = indices_->GetAllDocs();
     auto [dim, sim] = vec_index->Info();
     for (DocId doc : all_docs) {
@@ -573,7 +574,8 @@ struct BasicSearch {
         continue;
       float dist = VectorDistance(node.vec.first.get(), vec, dim, sim);
       if (dist <= static_cast<float>(node.radius)) {
-        knn_scores_.emplace_back(doc, dist);
+        knn_scores_[doc] = dist;
+        out->push_back(doc);
       }
     }
   }
@@ -606,12 +608,9 @@ struct BasicSearch {
     // HNSW fields are not stored in FieldIndices::indices_, so GetIndex<BaseVectorIndex> above
     // returns nullptr for HNSW before we reach this point.
     // HNSW range search support is planned separately (see hnsw_index.h).
+    vector<DocId> out;
     if (auto* flat_index = dynamic_cast<FlatVectorIndex*>(vec_index); flat_index)
-      SearchVectorRangeFlat(flat_index, node);
-
-    vector<DocId> out(knn_scores_.size());
-    for (size_t i = 0; i < knn_scores_.size(); i++)
-      out[i] = knn_scores_[i].first;
+      SearchVectorRangeFlat(flat_index, node, &out);
     return IndexResult{std::move(out)};
   }
 
@@ -643,8 +642,9 @@ struct BasicSearch {
     vector<DocId> out(knn_distances_.size());
     knn_scores_.reserve(knn_distances_.size());
 
+    // `out` carries KNN distance order; knn_scores_ is a by-id distance lookup.
     for (size_t i = 0; i < knn_distances_.size(); i++) {
-      knn_scores_.emplace_back(knn_distances_[i].second, knn_distances_[i].first);
+      knn_scores_[knn_distances_[i].second] = knn_distances_[i].first;
       out[i] = knn_distances_[i].second;
     }
 
@@ -684,23 +684,6 @@ struct BasicSearch {
     if (scorer_ && !matched_text_terms_.empty()) {
       // Score ALL matched docs and return top-K by score (not arbitrary cutoff).
       auto [out, total_size, text_scores] = TakeScoredTopK(std::move(result), cuttoff_limit);
-
-      // KNN populated knn_scores_ in distance order; TakeScoredTopK reordered
-      // `out` by text score, so realign knn_scores_ to the new id order.
-      // Consumers (e.g. search_family.cc) index ids and knn_scores by position.
-      if (!knn_scores_.empty()) {
-        absl::flat_hash_map<DocId, float> knn_by_id;
-        knn_by_id.reserve(knn_scores_.size());
-        for (auto& [doc, dist] : knn_scores_)
-          knn_by_id.emplace(doc, dist);
-        knn_scores_.clear();
-        knn_scores_.reserve(out.size());
-        for (DocId doc : out) {
-          if (auto it = knn_by_id.find(doc); it != knn_by_id.end())
-            knn_scores_.emplace_back(doc, it->second);
-        }
-      }
-
       return SearchResult{
           total_size,         std::move(out),   std::move(knn_scores_), std::move(text_scores),
           std::move(profile), std::move(error_)};
@@ -731,12 +714,12 @@ struct BasicSearch {
 
   // Score all matched docs via cursor-based posting list traversal and return top-K by score.
   // Total work: O(sum of posting_list_sizes) for cursors + O(N log K) for partial sort.
-  std::tuple<vector<DocId>, size_t, vector<pair<DocId, float>>> TakeScoredTopK(IndexResult&& result,
-                                                                               size_t limit) {
+  std::tuple<vector<DocId>, size_t, absl::flat_hash_map<DocId, float>> TakeScoredTopK(
+      IndexResult&& result, size_t limit) {
     auto [all_docs, total_size] = result.Take();  // all matched docs
 
     if (all_docs.empty())
-      return std::make_tuple(vector<DocId>{}, total_size, vector<pair<DocId, float>>{});
+      return std::make_tuple(vector<DocId>{}, total_size, absl::flat_hash_map<DocId, float>{});
 
     // Ensure sorted for cursor-based scoring
     sort(all_docs.begin(), all_docs.end());
@@ -782,14 +765,14 @@ struct BasicSearch {
       scored.resize(k);
     }
 
-    // Build output: docs in score order, paired scores
+    // `out` carries score order; text_scores is a by-id score lookup.
     vector<DocId> out;
-    vector<pair<DocId, float>> text_scores;
+    absl::flat_hash_map<DocId, float> text_scores;
     out.reserve(k);
     text_scores.reserve(k);
     for (auto& [score, doc] : scored) {
       out.push_back(doc);
-      text_scores.emplace_back(doc, score);
+      text_scores[doc] = score;
     }
 
     return std::make_tuple(std::move(out), total_size, std::move(text_scores));
@@ -807,7 +790,7 @@ struct BasicSearch {
   string error_;
   optional<ProfileBuilder> profile_builder_ = ProfileBuilder{};
 
-  std::vector<pair<DocId, float>> knn_scores_;
+  absl::flat_hash_map<DocId, float> knn_scores_;
   vector<pair<float, DocId>> knn_distances_;
 
   // Tracked text terms for scoring: (TextIndex*, normalized_term)
@@ -1247,8 +1230,66 @@ void SearchAlgorithm::SetScorer(ScorerFn scorer) {
   scorer_ = scorer;
 }
 
+// Visits `node` and recurses into its sub-expressions, invoking `cb` on every node in DFS order.
+template <typename F> void WalkAst(const AstNode& node, const F& cb) {
+  cb(node);
+  visit(Overloaded{
+            [&](const AstLogicalNode& n) {
+              for (const auto& child : n.nodes)
+                WalkAst(child, cb);
+            },
+            [&](const AstKnnNode& n) { WalkAst(*n.filter, cb); },
+            // Negate/Optional/Field all wrap a single child `node`; leaves have none (no-op).
+            [&](const auto& n) {
+              if constexpr (requires { n.node; })
+                WalkAst(*n.node, cb);
+            },
+        },
+        node.Variant());
+}
+
+vector<const AstVectorRangeNode*> SearchAlgorithm::CollectVectorRangeNodes() const {
+  vector<const AstVectorRangeNode*> out;
+  if (query_) {
+    WalkAst(*query_, [&out](const AstNode& node) {
+      if (auto* r = get_if<AstVectorRangeNode>(&node))
+        out.push_back(r);
+    });
+  }
+  return out;
+}
+
 const AstVectorRangeNode* SearchAlgorithm::GetVectorRangeNode() const {
-  return get_if<AstVectorRangeNode>(query_.get());
+  auto all = CollectVectorRangeNodes();
+  return all.empty() ? nullptr : all.front();
+}
+
+bool SearchAlgorithm::IsBareVectorRange() const {
+  DCHECK(query_);
+  return holds_alternative<AstVectorRangeNode>(*query_);
+}
+
+bool SearchAlgorithm::IsAndedVectorRange() const {
+  DCHECK(query_);
+  auto* logical = get_if<AstLogicalNode>(query_.get());
+  if (!logical || logical->op != AstLogicalNode::AND)
+    return false;
+  return any_of(logical->nodes.begin(), logical->nodes.end(),
+                [](const AstNode& n) { return holds_alternative<AstVectorRangeNode>(n); });
+}
+
+std::unique_ptr<AstNode> SearchAlgorithm::ExtractVectorRangeAsPrefilter() {
+  auto* logical = get_if<AstLogicalNode>(query_.get());
+  DCHECK(logical && logical->op == AstLogicalNode::AND);
+  for (auto& child : logical->nodes) {
+    if (holds_alternative<AstVectorRangeNode>(child)) {
+      auto extracted = make_unique<AstNode>(std::move(child));
+      child = AstStarNode{};  // match-all in its place, leaving query_ as the pure pre-filter
+      return extracted;
+    }
+  }
+  LOG(DFATAL) << "ExtractVectorRangeAsPrefilter called without an AND-ed VECTOR_RANGE";
+  return nullptr;
 }
 
 }  // namespace dfly::search

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -200,14 +200,14 @@ struct AlgorithmProfile {
 struct SearchResult {
   size_t total;  // how many documents were matched in total
 
-  // The ids of the matched documents
+  // The ids of the matched documents, in result order
   std::vector<DocId> ids;
 
-  // Contains final scores if an aggregation was present
-  std::vector<std::pair<DocId, float>> knn_scores;
+  // Vector distances keyed by DocId (order is carried by `ids`). Populated for KNN/VECTOR_RANGE.
+  absl::flat_hash_map<DocId, float> knn_scores;
 
-  // Text relevance scores (DocId -> score). Populated when a scorer is active.
-  std::vector<std::pair<DocId, float>> text_scores;
+  // Text relevance scores keyed by DocId. Populated when a scorer is active.
+  absl::flat_hash_map<DocId, float> text_scores;
 
   // If profiling was enabled
   std::optional<AlgorithmProfile> profile;
@@ -250,6 +250,18 @@ class SearchAlgorithm {
   std::unique_ptr<AstNode> PopKnnNode();
 
   const AstVectorRangeNode* GetVectorRangeNode() const;
+
+  // All VECTOR_RANGE leaves in the query tree, in DFS order.
+  std::vector<const AstVectorRangeNode*> CollectVectorRangeNodes() const;
+
+  bool IsBareVectorRange() const;
+
+  // True when the query is `AND[VECTOR_RANGE, filters...]`.
+  bool IsAndedVectorRange() const;
+
+  // Detaches the range from the top-level AND (replacing it with match-all) and returns it,
+  // leaving query_ as the runnable pre-filter. Requires IsAndedVectorRange().
+  std::unique_ptr<AstNode> ExtractVectorRangeAsPrefilter();
 
   void EnableProfiling();
 

--- a/src/core/search/search_parser_test.cc
+++ b/src/core/search/search_parser_test.cc
@@ -331,10 +331,9 @@ TEST_F(SearchParserTest, TildeParse) {
 }
 
 TEST_F(SearchParserTest, TildeInvalidGrammar) {
-  // ~ cannot precede top-level KNN or vector-range constructs (they live at
-  // final_query level, not search_unary_expr). Must be a clean syntax error.
+  // ~ cannot precede a top-level KNN construct (it lives at final_query level, not
+  // search_unary_expr). Must be a clean syntax error.
   EXPECT_EQ(1, Parse("~*=>[KNN 3 @v vec]"));
-  EXPECT_EQ(1, Parse("~@v:[VECTOR_RANGE 1 vec]"));
 
   // ~ followed by closing paren or empty group — syntax errors.
   EXPECT_EQ(1, Parse("~)"));
@@ -434,6 +433,31 @@ TEST_F(SearchParserTest, VectorRangeParse) {
 
   // Basic syntax parses without error
   EXPECT_EQ(0, Parse("@f:[VECTOR_RANGE $radius $vec]=>{$YIELD_DISTANCE_AS: dist}"));
+}
+
+TEST_F(SearchParserTest, VectorRangeCombinations) {
+  QueryParams params;
+  params["radius"] = "1";
+  // 4 bytes = one float dimension
+  params["vec"] = std::string(4, '\0');
+  SetParams(&params);
+
+  // VECTOR_RANGE is a regular predicate: parenthesized, AND-ed in any order, without parens,
+  // OR-ed, negated and nested must all parse.
+  EXPECT_EQ(0, Parse("(@f:[VECTOR_RANGE $radius $vec]=>{$YIELD_DISTANCE_AS: dist})"));
+  EXPECT_EQ(0, Parse("(@f:[VECTOR_RANGE $radius $vec])"));
+  EXPECT_EQ(0, Parse("(@f:[VECTOR_RANGE $radius $vec]=>{$YIELD_DISTANCE_AS: dist} @name:(idxA))"));
+  EXPECT_EQ(0, Parse("(@name:(idxA) @f:[VECTOR_RANGE $radius $vec]=>{$YIELD_DISTANCE_AS: dist})"));
+  EXPECT_EQ(0, Parse("@f:[VECTOR_RANGE $radius $vec]=>{$YIELD_DISTANCE_AS: dist} @name:(idxA)"));
+  EXPECT_EQ(0, Parse("@f:[VECTOR_RANGE $radius $vec]=>{$YIELD_DISTANCE_AS: dist} | @name:(idxA)"));
+  EXPECT_EQ(0, Parse("-@f:[VECTOR_RANGE $radius $vec]"));
+  EXPECT_EQ(0, Parse("~@f:[VECTOR_RANGE $radius $vec]"));
+  EXPECT_EQ(0, Parse("((@f:[VECTOR_RANGE $radius $vec]=>{$YIELD_DISTANCE_AS: dist}))"));
+
+  // A lone (parenthesized) range still reduces to the range node itself.
+  EXPECT_EQ(0, Parse("(@f:[VECTOR_RANGE $radius $vec])"));
+  auto ast = query_driver_.Take();
+  EXPECT_TRUE(std::holds_alternative<AstVectorRangeNode>(ast.Variant()));
 }
 
 TEST_F(SearchParserTest, KNN) {

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -833,6 +833,32 @@ TEST_F(VectorRangeTest, FlatRangeDistancesStoredInScores) {
   EXPECT_EQ(result.knn_scores.size(), 3u);
 }
 
+TEST_F(VectorRangeTest, RangeOrFilterScoresByDoc) {
+  // OR-ing a range with a filter makes the result larger than the range-match set. knn_scores is
+  // keyed by DocId: only in-range docs carry a distance, filter-only docs are simply absent.
+  auto schema = MakeSimpleSchema({{"pos", SchemaField::VECTOR}, {"route", SchemaField::TAG}});
+  schema.fields["pos"].special_params = SchemaField::VectorParams{false, 1};
+  FieldIndices indices{schema, kEmptyOptions, PMR_NS::get_default_resource(), nullptr};
+  for (size_t i = 0; i < 10; i++) {
+    MockedDocument doc{Map{{"pos", ToBytes({float(i)})}, {"route", (i % 2 == 0) ? "a" : "b"}}};
+    indices.Add(i, doc);
+  }
+
+  SearchAlgorithm algo{};
+  QueryParams params;
+  params["vec"] = ToBytes({5.0f});
+
+  // range (pos 4,5,6 -> docs 4,5,6) OR route "a" (docs 0,2,4,6,8) = union {0,2,4,5,6,8}.
+  ASSERT_TRUE(
+      algo.Init("@pos:[VECTOR_RANGE 1.5 $vec]=>{$YIELD_DISTANCE_AS: dist} | @route:{a}", &params));
+  auto result = algo.Search(&indices);
+  EXPECT_THAT(result.ids, testing::UnorderedElementsAre(0, 2, 4, 5, 6, 8));
+  // Distances exist only for the in-range docs; filter-only docs (0, 2, 8) are absent.
+  EXPECT_THAT(result.knn_scores,
+              testing::UnorderedElementsAre(testing::Key(4u), testing::Key(5u), testing::Key(6u)));
+  EXPECT_FLOAT_EQ(result.knn_scores.at(5), 0.0f);
+}
+
 TEST_F(VectorRangeTest, FlatStarQueryZeroVectorIsValid) {
   // Regression: @field:* on a FLAT vector index uses GetAllDocsWithNonNullValues(), which
   // incorrectly skips zero vectors. The zero vector [0.0,...,0.0] is a valid embedding.
@@ -3271,9 +3297,9 @@ TEST_F(ScoringTest, ScorerTopKCutoff) {
   EXPECT_TRUE(returned.count(8)) << "Doc8 (TF=9) should be in top-3";
   EXPECT_TRUE(returned.count(7)) << "Doc7 (TF=8) should be in top-3";
 
-  // Verify scores are in descending order
-  for (size_t i = 1; i < result.text_scores.size(); i++) {
-    EXPECT_GE(result.text_scores[i - 1].second, result.text_scores[i].second)
+  // Verify scores are in descending order along result.ids, which carries the ranking.
+  for (size_t i = 1; i < result.ids.size(); i++) {
+    EXPECT_GE(result.text_scores.at(result.ids[i - 1]), result.text_scores.at(result.ids[i]))
         << "Scores should be in descending order";
   }
 }
@@ -3441,7 +3467,7 @@ TEST_F(SearchTest, MatchNestedOptionalNoDoubleScore) {
 
   ASSERT_EQ(single.text_scores.size(), 1u);
   ASSERT_EQ(nested.text_scores.size(), 1u);
-  EXPECT_NEAR(single.text_scores[0].second, nested.text_scores[0].second, 1e-6)
+  EXPECT_NEAR(single.text_scores.at(0), nested.text_scores.at(0), 1e-6)
       << "Nested optionals must not inflate the score";
 }
 
@@ -3519,11 +3545,9 @@ TEST_F(SearchTest, MatchOptionalKnnIdsScoresAligned) {
 
   ASSERT_TRUE(result.error.empty()) << result.error;
   ASSERT_EQ(result.ids.size(), result.knn_scores.size())
-      << "ids and knn_scores must have matching size";
-  for (size_t i = 0; i < result.ids.size(); ++i) {
-    EXPECT_EQ(result.ids[i], result.knn_scores[i].first)
-        << "ids[" << i << "] (" << result.ids[i] << ") must align with knn_scores[" << i
-        << "].first (" << result.knn_scores[i].first << ")";
+      << "every KNN result must carry a distance";
+  for (DocId id : result.ids) {
+    EXPECT_TRUE(result.knn_scores.contains(id)) << "id " << id << " must have a knn_score entry";
   }
 }
 

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -911,13 +911,6 @@ SearchResult ShardDocIndex::Search(const OpArgs& op_args, const SearchParams& pa
       if (params.ShouldReturnAllFields())
         return_fields.push_back(so.field);
     }
-
-    // If we sorted with knn_scores present, rearrange them
-    if (!sort_scores.empty() && !result.knn_scores.empty()) {
-      unordered_map<DocId, float> score_lookup(result.knn_scores.begin(), result.knn_scores.end());
-      for (size_t i = 0; i < min(limit, result.ids.size()); i++)
-        result.knn_scores[i] = {result.ids[i], score_lookup[result.ids[i]]};
-    }
   }
 
   // Re-rank by (score, key) so per-shard top-K matches what a global merge
@@ -943,34 +936,32 @@ SearchResult ShardDocIndex::Search(const OpArgs& op_args, const SearchParams& pa
                         return a.key < b.key;
                       });
 
-    // Trim text_scores to the surviving top-K so the score map below stays small.
+    // Keep only the surviving top-K, both in result order (ids) and in the by-id score map.
     result.ids.clear();
     result.ids.reserve(take);
-    result.text_scores.clear();
-    result.text_scores.reserve(take);
+    absl::flat_hash_map<search::DocId, float> top_scores;
+    top_scores.reserve(take);
     for (size_t i = 0; i < take; i++) {
       result.ids.push_back(entries[i].doc);
-      result.text_scores.emplace_back(entries[i].doc, entries[i].score);
+      top_scores[entries[i].doc] = entries[i].score;
     }
+    result.text_scores = std::move(top_scores);
   }
 
   // Cut off unnecessary items
   result.ids.resize(min(result.ids.size(), limit));
 
-  // Build text score lookup (DocId -> score) if available
-  absl::flat_hash_map<search::DocId, float> text_score_map;
-  for (const auto& [doc, score] : result.text_scores)
-    text_score_map[doc] = score;
-
-  // Serialize documents
+  // Serialize documents. knn_scores/text_scores are keyed by DocId (looked up per result id).
   vector<SerializedSearchDoc> out;
   out.reserve(min(limit, result.ids.size()));
 
   size_t expired_count = 0;
   for (size_t i = 0; i < result.ids.size(); i++) {
-    float knn_score = result.knn_scores.empty() ? 0 : result.knn_scores[i].second;
+    float knn_score = 0;
+    if (auto it = result.knn_scores.find(result.ids[i]); it != result.knn_scores.end())
+      knn_score = it->second;
     float text_score = 0;
-    if (auto it = text_score_map.find(result.ids[i]); it != text_score_map.end())
+    if (auto it = result.text_scores.find(result.ids[i]); it != result.text_scores.end())
       text_score = it->second;
     auto sort_score = sort_scores.empty() ? std::monostate{} : std::move(sort_scores[i]);
 
@@ -1017,24 +1008,19 @@ vector<SearchDocData> ShardDocIndex::SearchForAggregator(
   if (!search_results.error.empty())
     return {};
 
-  // Build distance lookup for FLAT VECTOR_RANGE so the YIELD_DISTANCE_AS alias is
-  // available in the aggregation pipeline. HNSW VECTOR_RANGE uses LoadHnswRangeDocsForAggregator.
+  // Distance lookup for FLAT VECTOR_RANGE so the YIELD_DISTANCE_AS alias is available in the
+  // aggregation pipeline. HNSW VECTOR_RANGE uses LoadHnswRangeDocsForAggregator. Both score maps
+  // are already keyed by DocId, so move them through directly when requested.
   absl::flat_hash_map<DocId, float> knn_score_map;
   std::string score_alias;
   if (auto* vr = search_algo->GetVectorRangeNode(); vr && !vr->score_alias.empty()) {
     score_alias = vr->score_alias;
-    knn_score_map.reserve(search_results.knn_scores.size());
-    for (auto& [doc_id, dist] : search_results.knn_scores)
-      knn_score_map[doc_id] = dist;
+    knn_score_map = std::move(search_results.knn_scores);
   }
 
-  // Build text score lookup for ADDSCORES injection (keyed by DocId, safe across expired docs)
   absl::flat_hash_map<DocId, float> text_score_map;
-  if (params.add_scores && !search_results.text_scores.empty()) {
-    text_score_map.reserve(search_results.text_scores.size());
-    for (auto& [doc_id, score] : search_results.text_scores)
-      text_score_map[doc_id] = score;
-  }
+  if (params.add_scores)
+    text_score_map = std::move(search_results.text_scores);
 
   return LoadDocEntriesWithScores(op_args, params, search_results.ids, score_alias, knn_score_map,
                                   text_score_map);

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -1495,6 +1495,42 @@ vector<SearchResult> SearchGlobalHnswIndexRange(
   return results;
 }
 
+// Runs RangeQuery and keeps results that also appear in `sharded_prefilter_docs` (the filter
+// matches, already loaded), reusing the loaded docs without an extra transaction hop. Exact for
+// a range query, unlike top-k KNN where dropping out-of-set docs after the scan loses results.
+vector<SearchResult> SearchGlobalHnswIndexRangePrefiltered(
+    const search::AstVectorRangeNode* range, const shared_ptr<search::HnswVectorIndex>& index,
+    std::vector<SearchResult>& sharded_prefilter_docs) {
+  // Sort each shard's prefilter docs by local id so a range hit can be matched with binary search.
+  for (auto& shard : sharded_prefilter_docs)
+    std::sort(
+        shard.docs.begin(), shard.docs.end(),
+        [](const SerializedSearchDoc& a, const SerializedSearchDoc& b) { return a.id < b.id; });
+
+  auto range_results = index->RangeQuery(range->vec.first.get(), static_cast<float>(range->radius));
+
+  std::vector<SerializedSearchDoc> out;
+  out.reserve(range_results.size());
+  for (const auto& [dist, global_doc_id] : range_results) {
+    auto [shard_id, local_id] = search::DecomposeGlobalDocId(global_doc_id);
+    if (shard_id >= sharded_prefilter_docs.size())
+      continue;
+    auto& docs = sharded_prefilter_docs[shard_id].docs;
+    auto it =
+        std::lower_bound(docs.begin(), docs.end(), local_id,
+                         [](const SerializedSearchDoc& d, search::DocId id) { return d.id < id; });
+    if (it != docs.end() && it->id == local_id) {
+      out.emplace_back(std::move(*it));
+      out.back().knn_score = dist;
+    }
+  }
+
+  std::vector<SearchResult> results(1);
+  results[0].total_hits = out.size();
+  results[0].docs = std::move(out);
+  return results;
+}
+
 // Try creating global hnsw indices for given fields and return true on success
 bool CreateHnswIndices(std::string_view idx_name, const DocIndex& index) {
   std::vector<std::string> created_vector_indices;
@@ -2785,14 +2821,35 @@ void CmdFtSearch(CmdArgList args, CommandContext* cmd_cntx) {
 
   auto [knn_node, knn] = TryPopHnswKnnNode(search_algo, index_name);
 
-  // Check for HNSW vector range query (mutually exclusive with KNN)
+  // HNSW range (mutually exclusive with KNN): bare -> RangeQuery directly; AND-ed with a filter
+  // -> pre-filter then intersect; OR/NOT -> no execution path.
   const search::AstVectorRangeNode* hnsw_range = nullptr;
+  std::unique_ptr<search::AstNode> hnsw_range_holder;
+  const search::AstVectorRangeNode* hnsw_range_prefilter = nullptr;
   if (!knn) {
+    auto ranges = search_algo.CollectVectorRangeNodes();
+    if (ranges.size() > 1 &&
+        std::any_of(ranges.begin(), ranges.end(), [&](const search::AstVectorRangeNode* r) {
+          return GlobalHnswIndexRegistry::Instance().Exist(index_name, r->field);
+        })) {
+      return builder->SendError(
+          "Combining multiple VECTOR_RANGE clauses with an HNSW index is not supported");
+    }
     if (auto* vr = search_algo.GetVectorRangeNode(); vr != nullptr) {
-      if (GlobalHnswIndexRegistry::Instance().Exist(index_name, vr->field))
-        hnsw_range = vr;
+      if (GlobalHnswIndexRegistry::Instance().Exist(index_name, vr->field)) {
+        if (search_algo.IsBareVectorRange()) {
+          hnsw_range = vr;
+        } else if (search_algo.IsAndedVectorRange()) {
+          hnsw_range_holder = search_algo.ExtractVectorRangeAsPrefilter();
+          hnsw_range_prefilter = &std::get<search::AstVectorRangeNode>(*hnsw_range_holder);
+        } else {
+          return builder->SendError(
+              "Combining VECTOR_RANGE with OR/NOT is not supported on HNSW indexes");
+        }
+      }
     }
   }
+  const bool hnsw_range_has_prefilter = hnsw_range_prefilter != nullptr;
 
   // Because our coordinator thread may not have a shard, we can't check ahead if the index exists.
   atomic<bool> index_not_found{false};
@@ -2802,7 +2859,7 @@ void CmdFtSearch(CmdArgList args, CommandContext* cmd_cntx) {
   bool empty_prefilter_result = true;
 
   // Phase 1 collects per-shard counts; phase 2 scores with the global aggregate.
-  // Skipped for KNN/HNSW and single-shard.
+  // Skipped for bare KNN/HNSW range and single-shard; the prefilter search still scores its filter.
   const bool scoring_active =
       (params->scorer || params->with_scores) && (!knn || knn_has_prefilter) && !hnsw_range;
   const bool needs_global_stats = scoring_active && shard_set->size() > 1;
@@ -2836,8 +2893,9 @@ void CmdFtSearch(CmdArgList args, CommandContext* cmd_cntx) {
   if ((!knn || knn_has_prefilter) && !hnsw_range) {
     auto search_cb = [&](Transaction* t, EngineShard* es) {
       if (auto* index = es->search_indices()->GetIndex(index_name); index)
-        docs[es->shard_id()] = index->Search(t->GetOpArgs(es), *params, &search_algo,
-                                             knn_has_prefilter, global_stats_ptr);
+        docs[es->shard_id()] =
+            index->Search(t->GetOpArgs(es), *params, &search_algo,
+                          knn_has_prefilter || hnsw_range_has_prefilter, global_stats_ptr);
       else
         index_not_found.store(true, memory_order_relaxed);
       return OpStatus::OK;
@@ -2877,6 +2935,18 @@ void CmdFtSearch(CmdArgList args, CommandContext* cmd_cntx) {
           search::KnnScoreSortOption{hnsw_range->score_alias, std::numeric_limits<size_t>::max()};
     docs = SearchGlobalHnswIndexRange(hnsw_range, hnsw_index, index_name, knn_sort_option, *params,
                                       *cmd_cntx);
+  }
+
+  // `docs` holds the pre-filter matches from the per-shard search above; intersect RangeQuery
+  // with them. Empty pre-filter -> empty result, so `docs` is left as-is.
+  if (hnsw_range_prefilter && !empty_prefilter_result) {
+    auto hnsw_index = GetValidatedHnswRangeIndex(index_name, hnsw_range_prefilter, builder);
+    if (!hnsw_index)
+      return;
+    if (!hnsw_range_prefilter->score_alias.empty())
+      knn_sort_option = search::KnnScoreSortOption{hnsw_range_prefilter->score_alias,
+                                                   std::numeric_limits<size_t>::max()};
+    docs = SearchGlobalHnswIndexRangePrefiltered(hnsw_range_prefilter, hnsw_index, docs);
   }
 
   // FLAT VECTOR_RANGE alias: HNSW is handled above. For FLAT, the per-shard Search()
@@ -3101,6 +3171,166 @@ void CmdFtTagVals(CmdArgList args, CommandContext* cmd_cntx) {
   rb->SendBulkStrArr(vec, CollectionType::SET);
 }
 
+// Runs the ids-only prefilter search (a non-finalizing tx hop) and returns the matched global ids.
+// When ADDSCORES is on, also records per-shard text scores for later __score injection.
+static std::vector<search::GlobalDocId> RunAggregatePrefilter(
+    CommandContext* cmd_cntx, const AggregateParams& params, search::SearchAlgorithm& search_algo,
+    std::vector<absl::flat_hash_map<search::DocId, float>>& text_scores) {
+  std::vector<SearchResult> prefilter_docs(shard_set->size());
+  cmd_cntx->tx()->Execute(
+      [&](Transaction* t, EngineShard* es) {
+        if (auto* index = es->search_indices()->GetIndex(params.index); index) {
+          SearchParams sp;
+          sp.limit_total = std::numeric_limits<size_t>::max();
+          sp.return_fields.emplace();  // ids-only, skip field serialization
+          prefilter_docs[es->shard_id()] = index->Search(t->GetOpArgs(es), sp, &search_algo,
+                                                         /*is_knn_prefilter=*/true, nullptr);
+        }
+        return OpStatus::OK;
+      },
+      false);
+
+  if (params.add_scores) {
+    for (size_t shard_id = 0; shard_id < prefilter_docs.size(); shard_id++)
+      for (const auto& doc : prefilter_docs[shard_id].docs)
+        text_scores[shard_id][doc.id] = doc.text_score;
+  }
+  return CollectPrefilterGlobalIds(prefilter_docs);
+}
+
+// Loads HNSW result docs (KNN or VECTOR_RANGE) into query_results. Finalizes the multi-hop tx when
+// `finalize` is set (a prefilter hop already ran), otherwise schedules a single hop.
+static void RunHnswAggregateLoad(
+    CommandContext* cmd_cntx, const AggregateParams& params,
+    std::vector<std::vector<SearchDocData>>& query_results,
+    const std::vector<std::vector<std::pair<search::DocId, float>>>& shard_docs,
+    std::string_view score_alias,
+    const std::vector<absl::flat_hash_map<search::DocId, float>>& text_scores, bool finalize) {
+  auto cb = [&query_results, &params, &shard_docs, score_alias, &text_scores](Transaction* t,
+                                                                              EngineShard* es) {
+    auto* index = es->search_indices()->GetIndex(params.index);
+    if (!index || shard_docs[es->shard_id()].empty())
+      return OpStatus::OK;
+    DCHECK_LT(es->shard_id(), text_scores.size());
+    query_results[es->shard_id()] =
+        index->LoadHnswRangeDocsForAggregator(t->GetOpArgs(es), params, shard_docs[es->shard_id()],
+                                              score_alias, text_scores[es->shard_id()]);
+    return OpStatus::OK;
+  };
+  if (finalize)
+    cmd_cntx->tx()->Execute(std::move(cb), true);
+  else
+    cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));
+}
+
+// FT.AGGREGATE over a global HNSW KNN query. Returns false if an error was already sent.
+static bool AggregateHnswKnn(CommandContext* cmd_cntx, AggregateParams& params,
+                             search::SearchAlgorithm& search_algo, const search::AstKnnNode* knn,
+                             std::vector<std::vector<SearchDocData>>& query_results) {
+  auto hnsw_index = GlobalHnswIndexRegistry::Instance().Get(params.index, knn->field);
+  if (!hnsw_index) {
+    cmd_cntx->rb()->SendError(string{params.index} + ": no such global hnsw index");
+    return false;
+  }
+
+  const bool has_prefilter = knn->HasPreFilter();
+  std::vector<absl::flat_hash_map<search::DocId, float>> text_scores(shard_set->size());
+  std::optional<std::vector<search::GlobalDocId>> prefilter_ids;
+  if (has_prefilter)
+    prefilter_ids = RunAggregatePrefilter(cmd_cntx, params, search_algo, text_scores);
+
+  auto knn_results =
+      prefilter_ids
+          ? hnsw_index->Knn(knn->vec.first.get(), knn->limit, knn->ef_runtime, *prefilter_ids)
+          : hnsw_index->Knn(knn->vec.first.get(), knn->limit, knn->ef_runtime);
+  auto shard_docs = GroupByShardId(knn_results, shard_set->size());
+  RunHnswAggregateLoad(cmd_cntx, params, query_results, shard_docs, knn->score_alias, text_scores,
+                       has_prefilter);
+  return true;
+}
+
+// FT.AGGREGATE over a global HNSW VECTOR_RANGE query. Bare range -> RangeQuery directly; AND-ed
+// with a filter -> pre-filter then intersect; OR/NOT -> unsupported. Returns false on error.
+static bool AggregateHnswRange(CommandContext* cmd_cntx, AggregateParams& params,
+                               search::SearchAlgorithm& search_algo,
+                               const search::AstVectorRangeNode* vr,
+                               std::vector<std::vector<SearchDocData>>& query_results) {
+  auto* builder = cmd_cntx->rb();
+  std::unique_ptr<search::AstNode> range_holder;
+  const search::AstVectorRangeNode* hnsw_range = vr;
+  bool has_prefilter = false;
+  if (!search_algo.IsBareVectorRange()) {
+    if (!search_algo.IsAndedVectorRange()) {
+      builder->SendError("Combining VECTOR_RANGE with OR/NOT is not supported on HNSW indexes");
+      return false;
+    }
+    range_holder = search_algo.ExtractVectorRangeAsPrefilter();
+    hnsw_range = &std::get<search::AstVectorRangeNode>(*range_holder);
+    has_prefilter = true;
+  }
+
+  auto hnsw_index = GetValidatedHnswRangeIndex(params.index, hnsw_range, builder);
+  if (!hnsw_index)
+    return false;
+
+  std::vector<absl::flat_hash_map<search::DocId, float>> text_scores(shard_set->size());
+  std::optional<std::vector<search::GlobalDocId>> prefilter_ids;
+  if (has_prefilter) {
+    auto ids = RunAggregatePrefilter(cmd_cntx, params, search_algo, text_scores);
+    std::sort(ids.begin(), ids.end());  // sorted for the binary_search intersection below
+    prefilter_ids = std::move(ids);
+  }
+
+  // Intersect the range hits with the filter matches: keep only range results whose global id is
+  // in the sorted prefilter id set. Memory is O(filter matches) of ids plus O(range hits).
+  auto range_results =
+      hnsw_index->RangeQuery(hnsw_range->vec.first.get(), static_cast<float>(hnsw_range->radius));
+  if (prefilter_ids) {
+    erase_if(range_results, [&](const auto& r) {
+      return !std::binary_search(prefilter_ids->begin(), prefilter_ids->end(), r.second);
+    });
+  }
+  auto shard_docs = GroupByShardId(range_results, shard_set->size());
+  RunHnswAggregateLoad(cmd_cntx, params, query_results, shard_docs, hnsw_range->score_alias,
+                       text_scores, has_prefilter);
+  return true;
+}
+
+// FT.AGGREGATE over a non-vector query: optional global-stats phase, then per-shard search.
+static void AggregateGeneric(CommandContext* cmd_cntx, AggregateParams& params,
+                             search::SearchAlgorithm& search_algo,
+                             std::vector<std::vector<SearchDocData>>& query_results) {
+  // Same global-stats phase as FT.SEARCH so SORTBY @__score is stable across shard counts.
+  const bool scoring_active = params.scorer || params.add_scores;
+  const bool needs_global_stats = scoring_active && shard_set->size() > 1;
+  search::GlobalScoringStats global_stats;
+
+  if (needs_global_stats) {
+    std::vector<search::ShardScoringStats> shard_stats(shard_set->size());
+    cmd_cntx->tx()->Execute(
+        [&](Transaction* t, EngineShard* es) {
+          if (auto* index = es->search_indices()->GetIndex(params.index); index)
+            shard_stats[es->shard_id()] = index->CollectScoringStats(&search_algo);
+          return OpStatus::OK;
+        },
+        false);
+    for (auto& s : shard_stats)
+      global_stats.Merge(s);
+    params.global_scoring_stats = &global_stats;
+  }
+
+  auto search_cb = [&](Transaction* t, EngineShard* es) {
+    if (auto* index = es->search_indices()->GetIndex(params.index); index)
+      query_results[es->shard_id()] =
+          index->SearchForAggregator(t->GetOpArgs(es), params, &search_algo);
+    return OpStatus::OK;
+  };
+  if (needs_global_stats)
+    cmd_cntx->tx()->Execute(std::move(search_cb), true);
+  else
+    cmd_cntx->tx()->ScheduleSingleHop(std::move(search_cb));
+}
+
 void CmdFtAggregate(CmdArgList args, CommandContext* cmd_cntx) {
   CmdArgParser parser{args};
   auto* builder = cmd_cntx->rb();
@@ -3129,136 +3359,30 @@ void CmdFtAggregate(CmdArgList args, CommandContext* cmd_cntx) {
     else if (params->add_scores)
       search_algo.SetScorer(&search::BM25Std);
 
-    using ResultContainer = decltype(declval<ShardDocIndex>().SearchForAggregator(
-        declval<OpArgs>(), params.value(), &search_algo));
-
-    vector<ResultContainer> query_results(shard_set->size());
+    std::vector<std::vector<SearchDocData>> query_results(shard_set->size());
 
     auto [knn_node, knn] = TryPopHnswKnnNode(search_algo, params->index);
 
-    // Per-shard text scores from prefilter for __score injection in ADDSCORES mode.
-    // Indexed by shard_id because local DocIds are not unique across shards.
-    // Always allocated to shard_set->size() so the callback can index unconditionally.
-    std::vector<absl::flat_hash_map<search::DocId, float>> prefilter_text_scores(shard_set->size());
-
-    // Build a shard-load callback for HNSW results (KNN or VECTOR_RANGE).
-    // The returned lambda captures shard_docs and text_scores by const-reference —
-    // the caller must ensure they outlive the ScheduleSingleHop / Execute call.
-    auto make_load_cb =
-        [&](const std::vector<std::vector<std::pair<search::DocId, float>>>& shard_docs,
-            std::string_view score_alias,
-            const std::vector<absl::flat_hash_map<search::DocId, float>>& text_scores) {
-          return [&query_results, &params, &shard_docs, score_alias, &text_scores](
-                     Transaction* t, EngineShard* es) {
-            auto* index = es->search_indices()->GetIndex(params->index);
-            if (!index || shard_docs[es->shard_id()].empty())
-              return OpStatus::OK;
-            DCHECK_LT(es->shard_id(), text_scores.size());
-            query_results[es->shard_id()] = index->LoadHnswRangeDocsForAggregator(
-                t->GetOpArgs(es), params.value(), shard_docs[es->shard_id()], score_alias,
-                text_scores[es->shard_id()]);
-            return OpStatus::OK;
-          };
-        };
+    if (!knn) {
+      auto ranges = search_algo.CollectVectorRangeNodes();
+      if (ranges.size() > 1 &&
+          std::any_of(ranges.begin(), ranges.end(), [&](const search::AstVectorRangeNode* r) {
+            return GlobalHnswIndexRegistry::Instance().Exist(params->index, r->field);
+          })) {
+        return builder->SendError(
+            "Combining multiple VECTOR_RANGE clauses with an HNSW index is not supported");
+      }
+    }
 
     if (knn) {
-      auto hnsw_index = GlobalHnswIndexRegistry::Instance().Get(params->index, knn->field);
-      if (!hnsw_index) {
-        return builder->SendError(string{params->index} + ": no such global hnsw index");
-      }
-
-      // Run per-shard prefilter and collect GlobalDocIds if KNN has a filter expression
-      const bool knn_has_prefilter = knn->HasPreFilter();
-      std::optional<std::vector<search::GlobalDocId>> prefilter_global_ids;
-
-      if (knn_has_prefilter) {
-        vector<SearchResult> prefilter_docs(shard_set->size());
-        cmd_cntx->tx()->Execute(
-            [&](Transaction* t, EngineShard* es) {
-              if (auto* index = es->search_indices()->GetIndex(params->index); index) {
-                SearchParams sp;
-                sp.limit_total = std::numeric_limits<size_t>::max();
-                sp.return_fields.emplace();  // ids-only, skip field serialization
-                prefilter_docs[es->shard_id()] =
-                    index->Search(t->GetOpArgs(es), sp, &search_algo, /*is_knn_prefilter=*/true,
-                                  /*global_stats=*/nullptr);
-              }
-              return OpStatus::OK;
-            },
-            false);
-        prefilter_global_ids = CollectPrefilterGlobalIds(prefilter_docs);
-
-        // Collect text scores per-shard from prefilter results for __score injection
-        if (params->add_scores) {
-          for (size_t shard_id = 0; shard_id < prefilter_docs.size(); shard_id++) {
-            for (const auto& doc : prefilter_docs[shard_id].docs) {
-              prefilter_text_scores[shard_id][doc.id] = doc.text_score;
-            }
-          }
-        }
-      }
-
-      // Run global HNSW KNN search
-      auto knn_results = prefilter_global_ids
-                             ? hnsw_index->Knn(knn->vec.first.get(), knn->limit, knn->ef_runtime,
-                                               *prefilter_global_ids)
-                             : hnsw_index->Knn(knn->vec.first.get(), knn->limit, knn->ef_runtime);
-
-      auto shard_docs = GroupByShardId(knn_results, shard_set->size());
-
-      if (knn_has_prefilter) {
-        cmd_cntx->tx()->Execute(make_load_cb(shard_docs, knn->score_alias, prefilter_text_scores),
-                                true);  // finalize multi-hop
-      } else {
-        cmd_cntx->tx()->ScheduleSingleHop(
-            make_load_cb(shard_docs, knn->score_alias, prefilter_text_scores));
-      }
+      if (!AggregateHnswKnn(cmd_cntx, params.value(), search_algo, knn, query_results))
+        return;
     } else if (auto* vr = search_algo.GetVectorRangeNode();
                vr && GlobalHnswIndexRegistry::Instance().Exist(params->index, vr->field)) {
-      const search::AstVectorRangeNode* hnsw_range = vr;
-      auto hnsw_index = GetValidatedHnswRangeIndex(params->index, hnsw_range, builder);
-      if (!hnsw_index)
+      if (!AggregateHnswRange(cmd_cntx, params.value(), search_algo, vr, query_results))
         return;
-
-      auto range_results = hnsw_index->RangeQuery(hnsw_range->vec.first.get(),
-                                                  static_cast<float>(hnsw_range->radius));
-
-      auto shard_docs = GroupByShardId(range_results, shard_set->size());
-
-      cmd_cntx->tx()->ScheduleSingleHop(
-          make_load_cb(shard_docs, hnsw_range->score_alias, prefilter_text_scores));
     } else {
-      // Same global-stats phase as FT.SEARCH so SORTBY @__score is stable
-      // across shard counts.
-      const bool agg_scoring_active = params->scorer || params->add_scores;
-      const bool agg_needs_global_stats = agg_scoring_active && shard_set->size() > 1;
-      search::GlobalScoringStats agg_global_stats;
-
-      if (agg_needs_global_stats) {
-        std::vector<search::ShardScoringStats> shard_stats(shard_set->size());
-        cmd_cntx->tx()->Execute(
-            [&](Transaction* t, EngineShard* es) {
-              if (auto* index = es->search_indices()->GetIndex(params->index); index)
-                shard_stats[es->shard_id()] = index->CollectScoringStats(&search_algo);
-              return OpStatus::OK;
-            },
-            false);
-        for (auto& s : shard_stats)
-          agg_global_stats.Merge(s);
-        params->global_scoring_stats = &agg_global_stats;
-      }
-
-      auto agg_search_cb = [&](Transaction* t, EngineShard* es) {
-        if (auto* index = es->search_indices()->GetIndex(params->index); index) {
-          query_results[es->shard_id()] =
-              index->SearchForAggregator(t->GetOpArgs(es), params.value(), &search_algo);
-        }
-        return OpStatus::OK;
-      };
-      if (agg_needs_global_stats)
-        cmd_cntx->tx()->Execute(std::move(agg_search_cb), true);
-      else
-        cmd_cntx->tx()->ScheduleSingleHop(std::move(agg_search_cb));
+      AggregateGeneric(cmd_cntx, params.value(), search_algo, query_results);
     }
 
     // ResultContainer is absl::flat_hash_map<std::string, search::SortableValue>

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -5004,6 +5004,154 @@ TEST_F(SearchFamilyTest, FlatVectorRangeYieldDistanceAs) {
   EXPECT_EQ(resp.GetVec()[1].GetString(), "k5");
 }
 
+TEST_F(SearchFamilyTest, FlatVectorRangeWithFilter) {
+  auto F = [](float f) { return string(reinterpret_cast<const char*>(&f), sizeof(float)); };
+
+  Run({"FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "pos", "VECTOR", "FLAT", "6", "TYPE", "FLOAT32",
+       "DIM", "1", "DISTANCE_METRIC", "L2", "route", "TAG"});
+  for (int i = 0; i < 10; i++)
+    Run({"HSET", absl::StrFormat("k%d", i), "pos", F(static_cast<float>(i)), "route",
+         (i % 2 == 0) ? "a" : "b"});
+
+  string vec = F(5.0f);
+
+  auto extract = [](const RespExpr& resp) {
+    std::map<string, double> out;
+    auto& arr = resp.GetVec();
+    for (size_t i = 1; i + 1 < arr.size(); i += 2) {
+      auto& flds = arr[i + 1].GetVec();
+      for (size_t j = 0; j + 1 < flds.size(); j += 2) {
+        if (flds[j].GetString() == "dist")
+          out[arr[i].GetString()] = std::stod(flds[j + 1].GetString());
+      }
+    }
+    return out;
+  };
+
+  // Parenthesized VECTOR_RANGE AND-ed with a filter: pos 4,5,6 within radius 1.5 of 5.0,
+  // route "a" keeps k4 and k6 (dist 1).
+  auto resp = Run({"FT.SEARCH", "idx",
+                   "(@pos:[VECTOR_RANGE 1.5 $v]=>{$YIELD_DISTANCE_AS: dist} @route:{a})", "PARAMS",
+                   "2", "v", vec, "SORTBY", "dist", "ASC", "RETURN", "1", "dist"});
+  ASSERT_EQ(resp.GetVec()[0].GetInt(), 2);
+  auto d = extract(resp);
+  EXPECT_EQ(d.size(), 2u);
+  EXPECT_DOUBLE_EQ(d["k4"], 1.0);
+  EXPECT_DOUBLE_EQ(d["k6"], 1.0);
+
+  // Parens without a filter == bare range: all of k4,k5,k6.
+  resp = Run({"FT.SEARCH", "idx", "(@pos:[VECTOR_RANGE 1.5 $v]=>{$YIELD_DISTANCE_AS: dist})",
+              "PARAMS", "2", "v", vec, "RETURN", "1", "dist"});
+  EXPECT_EQ(resp.GetVec()[0].GetInt(), 3);
+
+  // Only k5 (pos 5, route "b") is within radius 0.4; filtering route "a" excludes it -> empty.
+  resp = Run({"FT.SEARCH", "idx",
+              "(@pos:[VECTOR_RANGE 0.4 $v]=>{$YIELD_DISTANCE_AS: dist} @route:{a})", "PARAMS", "2",
+              "v", vec});
+  EXPECT_EQ(resp.GetVec()[0].GetInt(), 0);
+
+  // Same result (k4, k6) regardless of order or parentheses.
+  for (const char* q : {
+           "(@route:{a} @pos:[VECTOR_RANGE 1.5 $v]=>{$YIELD_DISTANCE_AS: dist})",  // filter first
+           "@pos:[VECTOR_RANGE 1.5 $v]=>{$YIELD_DISTANCE_AS: dist} @route:{a}",    // no parens
+       }) {
+    resp = Run({"FT.SEARCH", "idx", q, "PARAMS", "2", "v", vec, "RETURN", "1", "dist"});
+    ASSERT_EQ(resp.GetVec()[0].GetInt(), 2) << q;
+    d = extract(resp);
+    EXPECT_DOUBLE_EQ(d["k4"], 1.0) << q;
+    EXPECT_DOUBLE_EQ(d["k6"], 1.0) << q;
+  }
+
+  // Multiple VECTOR_RANGE clauses are allowed on FLAT (intersected natively): radius 1.5 ->
+  // k4,k5,k6 AND radius 2.5 -> k3..k7 = k4,k5,k6.
+  resp = Run({"FT.SEARCH", "idx", "@pos:[VECTOR_RANGE 1.5 $v] @pos:[VECTOR_RANGE 2.5 $v]", "PARAMS",
+              "2", "v", vec, "NOCONTENT"});
+  EXPECT_EQ(resp.GetVec()[0].GetInt(), 3);
+}
+
+TEST_F(SearchFamilyTest, HnswVectorRangeWithFilter) {
+  auto F = [](float f) { return string(reinterpret_cast<const char*>(&f), sizeof(float)); };
+
+  Run({"FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "pos", "VECTOR", "HNSW", "6", "TYPE", "FLOAT32",
+       "DIM", "1", "DISTANCE_METRIC", "L2", "route", "TAG"});
+  for (int i = 0; i < 10; i++)
+    Run({"HSET", absl::StrFormat("k%d", i), "pos", F(static_cast<float>(i)), "route",
+         (i % 2 == 0) ? "a" : "b"});
+
+  string vec = F(5.0f);
+
+  auto extract = [](const RespExpr& resp) {
+    std::map<string, double> out;
+    auto& arr = resp.GetVec();
+    for (size_t i = 1; i + 1 < arr.size(); i += 2) {
+      auto& flds = arr[i + 1].GetVec();
+      for (size_t j = 0; j + 1 < flds.size(); j += 2) {
+        if (flds[j].GetString() == "dist")
+          out[arr[i].GetString()] = std::stod(flds[j + 1].GetString());
+      }
+    }
+    return out;
+  };
+
+  // Bare range on HNSW still works (k4, k5, k6 within radius 1.5).
+  auto resp = Run({"FT.SEARCH", "idx", "@pos:[VECTOR_RANGE 1.5 $v]=>{$YIELD_DISTANCE_AS: dist}",
+                   "PARAMS", "2", "v", vec});
+  EXPECT_EQ(resp.GetVec()[0].GetInt(), 3);
+
+  // Range AND-ed with a filter: RangeQuery results intersected with route "a" keep k4, k6.
+  resp = Run({"FT.SEARCH", "idx",
+              "(@pos:[VECTOR_RANGE 1.5 $v]=>{$YIELD_DISTANCE_AS: dist} @route:{a})", "PARAMS", "2",
+              "v", vec, "SORTBY", "dist", "ASC", "RETURN", "1", "dist"});
+  ASSERT_EQ(resp.GetVec()[0].GetInt(), 2);
+  auto d = extract(resp);
+  EXPECT_DOUBLE_EQ(d["k4"], 1.0);
+  EXPECT_DOUBLE_EQ(d["k6"], 1.0);
+
+  // In-range docs all excluded by the filter -> empty.
+  resp = Run({"FT.SEARCH", "idx",
+              "(@pos:[VECTOR_RANGE 0.4 $v]=>{$YIELD_DISTANCE_AS: dist} @route:{a})", "PARAMS", "2",
+              "v", vec});
+  EXPECT_EQ(resp.GetVec()[0].GetInt(), 0);
+
+  // Pre-filter matches nothing -> empty.
+  resp = Run({"FT.SEARCH", "idx",
+              "(@pos:[VECTOR_RANGE 1.5 $v]=>{$YIELD_DISTANCE_AS: dist} @route:{zzz})", "PARAMS",
+              "2", "v", vec});
+  EXPECT_EQ(resp.GetVec()[0].GetInt(), 0);
+
+  // OR with range -> unsupported on HNSW.
+  resp = Run({"FT.SEARCH", "idx",
+              "@pos:[VECTOR_RANGE 1.5 $v]=>{$YIELD_DISTANCE_AS: dist} | @route:{a}", "PARAMS", "2",
+              "v", vec});
+  EXPECT_THAT(resp, ErrArg("not supported"));
+
+  // Multiple VECTOR_RANGE clauses on HNSW -> rejected (would otherwise be silently mishandled).
+  resp = Run({"FT.SEARCH", "idx", "@pos:[VECTOR_RANGE 1.5 $v] @pos:[VECTOR_RANGE 2.5 $v]", "PARAMS",
+              "2", "v", vec});
+  EXPECT_THAT(resp, ErrArg("not supported"));
+}
+
+TEST_F(SearchFamilyTest, HnswVectorRangeWithFilterScores) {
+  auto F = [](float f) { return string(reinterpret_cast<const char*>(&f), sizeof(float)); };
+
+  Run({"FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "pos", "VECTOR", "HNSW", "6", "TYPE", "FLOAT32",
+       "DIM", "1", "DISTANCE_METRIC", "L2", "title", "TEXT"});
+  for (int i = 1; i <= 3; i++)
+    Run({"HSET", absl::StrFormat("d%d", i), "pos", F(static_cast<float>(i)), "title",
+         "hello world"});
+
+  string v = F(2.0f);
+
+  // WITHSCORES on a range AND-ed with a text filter must return BM25 scores from the prefilter
+  // search, like the KNN-with-prefilter path. Format: [total, key, score, fields, ...].
+  auto resp = Run({"FT.SEARCH", "idx", "@title:hello @pos:[VECTOR_RANGE 1.5 $v]", "PARAMS", "2",
+                   "v", v, "WITHSCORES"});
+  auto arr = resp.GetVec();
+  ASSERT_EQ(arr[0].GetInt(), 3);
+  for (size_t i = 1; i + 1 < arr.size(); i += 3)
+    EXPECT_GT(std::stod(arr[i + 1].GetString()), 0.0) << arr[i].GetString();
+}
+
 TEST_F(SearchFamilyTest, VectorRangeAggregate) {
   auto FloatToBytes = [](float f) -> string {
     return string(reinterpret_cast<const char*>(&f), sizeof(float));
@@ -5108,6 +5256,76 @@ TEST_F(SearchFamilyTest, HnswVectorRangeAggregate) {
               "PARAMS", "2", "vec", far_vec, "GROUPBY", "1", "@route", "REDUCE", "COUNT", "0", "AS",
               "cnt"});
   EXPECT_THAT(resp, RespElementsAre(IntArg(0)));
+}
+
+TEST_F(SearchFamilyTest, HnswVectorRangeAggregateWithFilter) {
+  auto F = [](float f) { return string(reinterpret_cast<const char*>(&f), sizeof(float)); };
+
+  Run({"FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "pos", "VECTOR", "HNSW", "6", "TYPE", "FLOAT32",
+       "DIM", "1", "DISTANCE_METRIC", "L2", "route", "TAG"});
+  // Both routes share positions, so the filter narrows the range result.
+  for (int i : {1, 2, 3})
+    Run({"HSET", absl::StrFormat("t%d", i), "pos", F(static_cast<float>(i)), "route", "tech"});
+  for (int i : {1, 2, 3})
+    Run({"HSET", absl::StrFormat("s%d", i), "pos", F(static_cast<float>(i)), "route", "sports"});
+
+  string q = F(2.0f);
+
+  // radius 1.5 from 2.0 -> pos 1,2,3 -> t1..t3,s1..s3; pre-filter route tech keeps 3.
+  auto resp =
+      Run({"FT.AGGREGATE", "idx",
+           "(@pos:[VECTOR_RANGE 1.5 $v]=>{$YIELD_DISTANCE_AS: dist} @route:{tech})", "PARAMS", "2",
+           "v", q, "GROUPBY", "1", "@route", "REDUCE", "COUNT", "0", "AS", "cnt"});
+  EXPECT_THAT(resp, IsUnordArrayWithSize(IsMap("route", "tech", "cnt", "3")));
+
+  // Pre-filter matches nothing -> empty.
+  resp = Run({"FT.AGGREGATE", "idx",
+              "(@pos:[VECTOR_RANGE 1.5 $v]=>{$YIELD_DISTANCE_AS: dist} @route:{none})", "PARAMS",
+              "2", "v", q, "GROUPBY", "1", "@route", "REDUCE", "COUNT", "0", "AS", "cnt"});
+  EXPECT_THAT(resp, RespElementsAre(IntArg(0)));
+
+  // OR with range has no HNSW execution path -> explicit error.
+  resp = Run({"FT.AGGREGATE", "idx",
+              "@pos:[VECTOR_RANGE 1.5 $v]=>{$YIELD_DISTANCE_AS: dist} | @route:{tech}", "PARAMS",
+              "2", "v", q, "GROUPBY", "1", "@route", "REDUCE", "COUNT", "0", "AS", "cnt"});
+  EXPECT_THAT(resp, ErrArg("not supported"));
+
+  // Multiple VECTOR_RANGE clauses on HNSW -> rejected.
+  resp =
+      Run({"FT.AGGREGATE", "idx", "@pos:[VECTOR_RANGE 1.5 $v] @pos:[VECTOR_RANGE 2.5 $v]", "PARAMS",
+           "2", "v", q, "GROUPBY", "1", "@route", "REDUCE", "COUNT", "0", "AS", "cnt"});
+  EXPECT_THAT(resp, ErrArg("not supported"));
+}
+
+TEST_F(SearchFamilyTest, HnswVectorRangeAggregateAddScores) {
+  auto F = [](float f) { return string(reinterpret_cast<const char*>(&f), sizeof(float)); };
+
+  Run({"FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "pos", "VECTOR", "HNSW", "6", "TYPE", "FLOAT32",
+       "DIM", "1", "DISTANCE_METRIC", "L2", "title", "TEXT"});
+  for (int i = 1; i <= 3; i++)
+    Run({"HSET", absl::StrFormat("d%d", i), "pos", F(static_cast<float>(i)), "title",
+         "hello world"});
+
+  string v = F(2.0f);
+
+  // ADDSCORES on a range AND-ed with a text filter must inject __score (the filter's text score),
+  // not silently drop it.
+  auto resp = Run({"FT.AGGREGATE", "idx", "(@title:hello @pos:[VECTOR_RANGE 1.5 $v])", "PARAMS",
+                   "2", "v", v, "ADDSCORES"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  auto rows = resp.GetVec();
+  ASSERT_GE(rows.size(), 2u);
+  bool found = false;
+  for (size_t r = 1; r < rows.size(); r++) {
+    auto row = rows[r].GetVec();
+    for (size_t j = 0; j + 1 < row.size(); j += 2) {
+      if (row[j].GetString() == "__score") {
+        found = true;
+        EXPECT_GT(std::stod(row[j + 1].GetString()), 0.0);
+      }
+    }
+  }
+  EXPECT_TRUE(found) << "__score should be injected for ADDSCORES range+filter aggregate";
 }
 
 TEST_F(SearchFamilyTest, GeoIndexFieldValidation) {


### PR DESCRIPTION
`FT.SEARCH` and `FT.AGGREGATE` rejected parenthesized and filtered `VECTOR_RANGE` queries with "Query syntax error" - exactly the shape langchain-redis / redisvl emit for `distance_threshold` and filtered range search. This makes `VECTOR_RANGE` a first-class query predicate that composes with filters on both FLAT and HNSW indexes.

Changes:
- Grammar: `VECTOR_RANGE` is now a regular query leaf, so it parses inside parentheses, AND-ed with a filter in any order, without parentheses, and when nested.
- FLAT: filtered ranges run natively; `knn_scores` is kept positionally aligned with the result ids (fixes an out-of-bounds read when a range is combined with a filter).
- HNSW: a bare range runs directly; a range AND-ed with a filter pre-filters and then intersects the range results (FT.SEARCH reuses loaded docs, FT.AGGREGATE loads only the survivors).
- HNSW guards: combining `VECTOR_RANGE` with OR/NOT, or using more than one `VECTOR_RANGE` clause, returns an explicit error instead of silently wrong results.
- Tests: parser combinations, a score-alignment regression, and FLAT/HNSW filtered-range and multi-range coverage for both FT.SEARCH and FT.AGGREGATE.

Fixes: #7521