### PR TITLE
feat: use more SIMD ops in OAHSet

### DIFF
--- a/src/core/oah_entry.cc
+++ b/src/core/oah_entry.cc
@@ -98,13 +98,10 @@ ssize_t OAHEntry::ReallocIfNeeded(PageUsage* page_usage, bool* realloced) {
           *realloced = true;
       }
     }
-    // Then defrag the vector's array buffer if its page is underutilized. ResizeLog
-    // with the same log_size allocates a fresh buffer, move-constructs each element
-    // (OAHEntry's move-ctor swaps data_, leaving sources empty), and frees the old
-    // buffer via Clear(). The vector's logical AllocSize is unchanged, so no delta
-    // is reported for ptr_vectors_alloc_used_.
+    // Then defrag the array buffer if its page is underutilized. Realloc() moves into a
+    // fresh same-size buffer; logical AllocSize is unchanged, so no delta is reported.
     if (page_usage->IsPageForObjectUnderUtilized(Raw())) {
-      vec.ResizeLog(vec.LogSize());
+      vec.Realloc();
       *realloced = true;
     }
     return obj_alloc_delta;
@@ -113,9 +110,8 @@ ssize_t OAHEntry::ReallocIfNeeded(PageUsage* page_usage, bool* realloced) {
   if (!page_usage->IsPageForObjectUnderUtilized(Raw()))
     return 0;
 
-  // Single-entry realloc via ctor + move-assignment: build a fresh OAHEntry from this
-  // one's key/expiry/ext_hash; move-assign to swap data_, then the temporary's
-  // destructor frees the old buffer.
+  // Single-entry realloc: build a fresh OAHEntry from this one's key/expiry/ext_hash,
+  // move-assign to swap data_, and let the temporary free the old buffer.
   const size_t old_alloc = AllocSize();
   const uint64_t saved_hash = GetHash();
   const uint32_t expiry = HasExpiry() ? GetExpiry() : UINT32_MAX;
@@ -131,16 +127,15 @@ ssize_t OAHEntry::ReallocIfNeeded(PageUsage* page_usage, bool* realloced) {
 
 // TODO refactor, because it's inefficient
 //
-// Vector capacity is always a power of 2 with a minimum of 2 (the initial
-// promotion from single-entry uses FromLogSize(1) below; ResizeLog doubles).
-// OAHSet::ProbeExtensionVector relies on this invariant to drive a 2-lane
-// SIMD probe over vector contents without ever reading past the allocation.
+// Vector capacity starts at 2 and grows by 2 (doubles past kLinearMax), so it stays
+// an even count >= 2 — OAHSet::ProbeExtensionVector relies on this for a tail-free
+// 2-lane probe.
 size_t OAHEntry::Insert(OAHEntry&& e) {
   if (Empty()) {
     *this = std::move(e);
     return 0;
   } else if (!IsVector()) {
-    OAHEntry tmp(PtrVector<OAHEntry>::FromLogSize(1));
+    OAHEntry tmp(PtrVector<OAHEntry>::FromSize(2));
     auto& arr = tmp.AsVector();
     arr[0] = std::move(*this);
     arr[1] = std::move(e);
@@ -158,7 +153,7 @@ size_t OAHEntry::Insert(OAHEntry&& e) {
     }
     size_t prev_alloc_size = arr.AllocSize();
     auto new_pos = arr.Size();
-    arr.ResizeLog(arr.LogSize() + 1);
+    arr.Grow();
     arr[new_pos] = (std::move(e));
     return arr.AllocSize() - prev_alloc_size;
   }
@@ -199,18 +194,6 @@ OAHEntry OAHEntry::Remove(uint32_t pos) {
     assert(pos < arr.Size());
     return std::move(arr[pos]);
   }
-}
-
-OAHEntry OAHEntry::Pop() {
-  if (IsVector()) {
-    auto& arr = AsVector();
-    for (auto& e : arr) {
-      if (e)
-        return std::move(e);
-    }
-    return {};
-  }
-  return std::move(*this);
 }
 
 void OAHEntry::Clear() {

--- a/src/core/oah_entry.h
+++ b/src/core/oah_entry.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <bit>
 #include <cassert>
 #include <cstring>
 #include <string_view>
@@ -22,17 +23,25 @@ class PageUsage;
 #define FORCE_INLINE __attribute__((always_inline))
 
 // TODO add allocator support
+//
+// Capacity grows by 2 below kLinearMax (sizes stay even, keeping the 2-lane SIMD
+// probe tail-free), then doubles at/above it. The 11-bit tag field holds either a
+// literal count or, with kLogModeBit set, its base-2 log (power-of-2 sizes).
 template <class T> class PtrVector {
   static constexpr size_t kVectorBit = 1ULL << 0;          // first 3 bits aren't used by pointer
   static constexpr size_t kTagMask = (4095ULL << 52) | 7;  // we reserve 12 high bits and 3 low bits
 
-  static constexpr size_t kLogSizeShift = 56;
-  static constexpr size_t kLogSizeMask = 0xFFULL;
-  static constexpr size_t kLogSizeShiftedMask = kLogSizeMask << kLogSizeShift;
+  static constexpr size_t kSizeShift = 52;
+  static constexpr size_t kSizeMask = 0x7FFULL;  // 11-bit field: count, or log2 in log mode
+  static constexpr size_t kLogModeBit = 1ULL << 63;
+  static constexpr size_t kSizeFieldMask = (kSizeMask << kSizeShift) | kLogModeBit;
+
+  static constexpr size_t kLinearMax = 128;
 
  public:
-  static PtrVector FromLogSize(uint64_t log_size) {
-    return PtrVector(log_size);
+  // Allocates exactly `count` elements (used for the initial small vector).
+  static PtrVector FromSize(size_t count) {
+    return PtrVector(count);
   }
 
   T* begin() const {
@@ -52,12 +61,11 @@ template <class T> class PtrVector {
     Clear();
   }
 
-  size_t LogSize() const {
-    return (uptr_ >> kLogSizeShift) & kLogSizeMask;
-  }
-
+  // Number of elements. Normal mode stores the count directly; log mode stores
+  // its base-2 log.
   size_t Size() const {
-    return 1 << LogSize();
+    const uint64_t field = (uptr_ >> kSizeShift) & kSizeMask;
+    return (uptr_ & kLogModeBit) ? (size_t(1) << field) : size_t(field);
   }
 
   uint64_t Release() {
@@ -77,19 +85,16 @@ template <class T> class PtrVector {
     return true;
   }
 
-  void ResizeLog(uint64_t new_log_size) {
-    auto new_ptr = reinterpret_cast<T*>(zmalloc(sizeof(T) << new_log_size));
-    size_t new_size = 1 << new_log_size;
-    const size_t size = std::min(Size(), new_size);
-    for (size_t i = 0; i < size; ++i) {
-      new (new_ptr + i) T(std::move(Raw()[i]));
-    }
-    for (size_t i = size; i < new_size; ++i) {
-      new (new_ptr + i) T();
-    }
-    Clear();
-    uptr_ = reinterpret_cast<uint64_t>(new_ptr);
-    SetLogSize(new_log_size);
+  // Grows per policy: +2 elements below kLinearMax, doubling at/above it. Starting
+  // from an even size (2), this keeps Size() even (a multiple of the 2-lane probe).
+  void Grow() {
+    const size_t cur = Size();
+    Reallocate(cur < kLinearMax ? cur + 2 : cur * 2);
+  }
+
+  // Reallocates to the same size (defrag), preserving contents.
+  void Realloc() {
+    Reallocate(Size());
   }
 
   T& operator[](size_t idx) {
@@ -122,19 +127,39 @@ template <class T> class PtrVector {
     zfree(Raw());
     uptr_ = 0;
   }
-  // because of log_size I prefer to hide it
-  PtrVector(uint64_t log_size) {
-    assert(log_size <= 32);
-    uptr_ = reinterpret_cast<uint64_t>(zmalloc(sizeof(T) << log_size));
-    const uint64_t size = 1 << log_size;
-    for (uint64_t i = 0; i < size; ++i) {
-      new (reinterpret_cast<T*>(uptr_) + i) T();
+
+  // Allocates `new_count` slots, moves existing elements over, frees the old
+  // buffer, and records the new size.
+  void Reallocate(size_t new_count) {
+    auto* new_ptr = reinterpret_cast<T*>(zmalloc(sizeof(T) * new_count));
+    const size_t keep = std::min(Size(), new_count);
+    for (size_t i = 0; i < keep; ++i) {
+      new (new_ptr + i) T(std::move(Raw()[i]));
     }
-    SetLogSize(log_size);
+    for (size_t i = keep; i < new_count; ++i) {
+      new (new_ptr + i) T();
+    }
+    Clear();
+    uptr_ = reinterpret_cast<uint64_t>(new_ptr);
+    SetSize(new_count);
   }
 
-  void SetLogSize(uint64_t log_size) {
-    uptr_ = (uptr_ & ~kLogSizeShiftedMask) | kVectorBit | (uint64_t(log_size) << kLogSizeShift);
+  explicit PtrVector(size_t count) {
+    uptr_ = reinterpret_cast<uint64_t>(zmalloc(sizeof(T) * count));
+    for (size_t i = 0; i < count; ++i) {
+      new (reinterpret_cast<T*>(uptr_) + i) T();
+    }
+    SetSize(count);
+  }
+
+  // Encodes the element count: a literal count below kLinearMax, or its base-2
+  // log at/above it (countr_zero == log2 since such sizes are powers of two).
+  void SetSize(size_t count) {
+    const bool log_mode = count >= kLinearMax;
+    const uint64_t field = log_mode ? std::countr_zero(count) : count;
+    assert(field <= kSizeMask);
+    uptr_ = (uptr_ & ~kSizeFieldMask) | kVectorBit | (field << kSizeShift) |
+            (log_mode ? kLogModeBit : 0);
   }
 
   uint64_t uptr_ = 0;
@@ -245,11 +270,9 @@ class OAHEntry {
 
   void ExpireIfNeeded(uint32_t time_now, uint32_t* set_size, size_t* alloc_used);
 
-  // Reallocates fragmented buffers under this entry. For a single entry, that's its own
-  // string buffer. For a vector entry, recurses into every inner entry AND the vector's
-  // own array buffer. Returns the cumulative change in zmalloc_usable_size across inner
-  // entry buffers (the vector array buffer is realloc'd to the same logical size so its
-  // AllocSize is unchanged). *realloced is set to true iff any buffer was moved.
+  // Reallocates fragmented buffers under this entry: its string buffer, or for a vector
+  // every inner entry plus the array buffer. Returns the cumulative zmalloc_usable_size
+  // delta across inner buffers (the array buffer keeps its size). *realloced = any moved.
   ssize_t ReallocIfNeeded(PageUsage* page_usage, bool* realloced);
 
   // TODO refactor, because it's inefficient
@@ -262,8 +285,6 @@ class OAHEntry {
   OAHEntry& operator[](uint32_t pos);
 
   OAHEntry Remove(uint32_t pos);
-
-  OAHEntry Pop();
 
   char* Raw() const {
     return (char*)(data_ & ~kTagMask);

--- a/src/core/oah_set.cc
+++ b/src/core/oah_set.cc
@@ -10,10 +10,9 @@
 
 namespace dfly {
 
-// Several definitions below are `inline FORCE_INLINE`: the inline keyword makes
-// them COMDAT (non-interposable), which is what lets always_inline apply to an
-// out-of-line member, so they fold into their in-TU callers (notably AddImpl into
-// AddMany's bulk-insert loop, and FindMatch into both AddImpl and FindInternal).
+// Definitions below are `inline FORCE_INLINE`: inline makes them COMDAT
+// (non-interposable), which lets always_inline apply to an out-of-line member so
+// they fold into their in-TU callers.
 
 template <typename Wide>
 inline FORCE_INLINE OAHSet::LaneMasks OAHSet::ProbeLanes(const OAHEntry* base,
@@ -26,20 +25,34 @@ inline FORCE_INLINE OAHSet::LaneMasks OAHSet::ProbeLanes(const OAHEntry* base,
   return {candidate.GetMSBs(), is_empty.GetMSBs()};
 }
 
+// Window may exceed one SIMD register: sweep in EntryWide strides, packing each
+// stride's masks (lane i of stride `off` -> bit off+i). uint32_t masks => <= 32 lanes.
+inline FORCE_INLINE OAHSet::LaneMasks OAHSet::ProbeWindow(const OAHEntry* base,
+                                                          uint64_t ext_hash) noexcept {
+  LaneMasks w{0, 0};
+  for (uint32_t off = 0; off < kDisplacementSize; off += EntryWide::kLanes) {
+    const LaneMasks m = ProbeLanes<EntryWide>(base + off, ext_hash);
+    w.candidates |= m.candidates << off;
+    w.empties |= m.empties << off;
+  }
+  return w;
+}
+
 inline FORCE_INLINE void OAHSet::RefreshStaleCandidate(OAHEntry& e, uint64_t ext_hash) {
   if (e.GetHash() != ext_hash)
     e.SetExtHash(CalcExtHash(Hash(e.Key()), capacity_log_));
   e.ExpireIfNeeded(time_now_, &size_, &obj_alloc_used_);
 }
 
-// 2-lane SIMD strides; the vector's size is a power of 2, >= 2.
+// 2-lane SIMD strides. Vector sizes are always even (PtrVector grows by 2), so the
+// stride covers the array with no tail.
 inline FORCE_INLINE OAHEntry* OAHSet::ProbeExtensionVector(uint32_t ext_bid, std::string_view str,
                                                            uint64_t ext_hash) {
   auto& vec = entries_[ext_bid].AsVector();
   auto* raw_arr = vec.Raw();
   const size_t size = vec.Size();
   DCHECK_GE(size, size_t(kVectorLaneStep));
-  DCHECK(std::has_single_bit(size));
+  DCHECK_EQ(size % kVectorLaneStep, 0u);
 
   for (size_t base = 0; base < size; base += kVectorLaneStep) {
     auto cand_bits = ProbeLanes<VectorWide>(&raw_arr[base], ext_hash).candidates;
@@ -58,9 +71,7 @@ inline FORCE_INLINE OAHEntry* OAHSet::ProbeExtensionVector(uint32_t ext_bid, std
   return nullptr;
 }
 
-// Scans the displacement window then the extension vector for `str`. entries_
-// spans (1 << capacity_log_) + kDisplacementSize - 1 with bid < (1 << capacity_log_),
-// so the window read stays in bounds.
+// Window read stays in bounds: entries_ has kDisplacementSize-1 slack past BucketCount.
 inline FORCE_INLINE OAHSet::MatchResult OAHSet::FindMatch(uint32_t bid, uint32_t ext_bid,
                                                           uint32_t cand_bits, std::string_view str,
                                                           uint64_t ext_hash) {
@@ -86,7 +97,8 @@ inline FORCE_INLINE OAHSet::MatchResult OAHSet::FindMatch(uint32_t bid, uint32_t
 }
 
 inline FORCE_INLINE bool OAHSet::AddImpl(std::string_view str, uint32_t ttl_sec) {
-  if (size_ >= entries_.size()) [[unlikely]] {
+  // Grow at load factor 2; until then overflow lands in the window / extension vectors.
+  if (size_ >= entries_.size() * 2) [[unlikely]] {
     Reserve(BucketCount() * 2);
   }
   DCHECK_GE(Capacity(), kDisplacementSize);
@@ -107,15 +119,14 @@ inline FORCE_INLINE bool OAHSet::AddImpl(std::string_view str, uint32_t ttl_sec)
   const uint64_t ext_hash = CalcExtHash(hash, capacity_log_);
   entry.SetExtHash(ext_hash);
 
-  const LaneMasks masks = ProbeLanes<EntryWide>(&entries_[bucket_id], ext_hash);
+  const LaneMasks masks = ProbeWindow(&entries_[bucket_id], ext_hash);
   const MatchResult m = FindMatch(bucket_id, ext_bid, masks.candidates, str, ext_hash);
   if (m.matched && !m.matched->Empty())
     return false;
 
   obj_alloc_used_ += entry_alloc_size;
   ++size_;
-  // Place it: reuse an expired duplicate's slot, else a free window lane, else
-  // spill into the extension vector.
+  // Reuse an expired duplicate's slot, else a free window lane, else spill to the vector.
   if (m.matched) {
     *m.matched = std::move(entry);
   } else if (masks.empties) {
@@ -149,7 +160,7 @@ unsigned OAHSet::AddMany(absl::Span<std::string_view> span, uint32_t ttl_sec, bo
 inline FORCE_INLINE OAHSet::iterator OAHSet::FindInternal(uint32_t bid, std::string_view str,
                                                           uint64_t hash) {
   const uint64_t ext_hash = CalcExtHash(hash, capacity_log_);
-  const uint32_t cand_bits = ProbeLanes<EntryWide>(&entries_[bid], ext_hash).candidates;
+  const uint32_t cand_bits = ProbeWindow(&entries_[bid], ext_hash).candidates;
   const MatchResult m = FindMatch(bid, GetExtensionPoint(bid), cand_bits, str, ext_hash);
   if (m.matched && !m.matched->Empty())  // empty => matched but just expired, i.e. gone
     return iterator{this, m.bucket_id, m.pos_in_vec};
@@ -179,6 +190,129 @@ bool OAHSet::Erase(std::string_view str) {
     entries_[erase_bucket] = OAHEntry();
   }
   return true;
+}
+
+inline FORCE_INLINE OAHSet::iterator OAHSet::PickFromBucket(uint32_t b) {
+  OAHEntry& bucket = entries_[b];
+  if (!bucket.IsVector()) {
+    bucket.ExpireIfNeeded(time_now_, &size_, &obj_alloc_used_);
+    return bucket.Empty() ? end() : iterator{this, b, 0};
+  }
+  auto& vec = bucket.AsVector();
+  for (uint32_t pos = 0, vec_size = vec.Size(); pos < vec_size; ++pos) {
+    auto& entry = vec[pos];
+    if (!entry)
+      continue;
+    entry.ExpireIfNeeded(time_now_, &size_, &obj_alloc_used_);
+    if (entry)
+      return iterator{this, b, pos};
+  }
+  return end();
+}
+
+OAHSet::iterator OAHSet::ScanRange(uint32_t lo, uint32_t hi) {
+  for (; lo + EntryWide::kLanes <= hi; lo += EntryWide::kLanes) {
+    const EntryWide data = EntryWide::Load(reinterpret_cast<const uint64_t*>(&entries_[lo]));
+    uint32_t used = (~(data == uint64_t(0))).GetMSBs();
+    while (used) {
+      const uint32_t b = lo + std::countr_zero(used);
+      used &= used - 1;
+      if (auto it = PickFromBucket(b); it != end())
+        return it;
+    }
+  }
+  for (; lo < hi; ++lo) {
+    if (entries_[lo].Empty())
+      continue;
+    if (auto it = PickFromBucket(lo); it != end())
+      return it;
+  }
+  return end();
+}
+
+OAHSet::iterator OAHSet::GetRandomMember() {
+  if (entries_.empty() || size_ == 0)
+    return end();
+
+  static thread_local absl::InsecureBitGen rng;
+  const uint32_t n = entries_.size();
+  const uint32_t start = absl::Uniform<uint32_t>(rng, 0u, n);
+
+  // Random-start wrap-around. The first range covers `n - start` buckets out of `n`,
+  // so for a non-trivially populated set finding a live entry there is the common
+  // case; the wrap-around call to [0, start) is the rare cold path.
+  if (auto it = ScanRange(start, n); it != end())
+    return it;
+  return ScanRange(0, start);
+}
+
+inline FORCE_INLINE uint32_t OAHSet::FindEmptyAround(uint32_t bid) {
+  // Strides scanned in order, so the first empty found is the lowest-index one. In
+  // bounds thanks to entries_' kDisplacementSize-1 slack past BucketCount.
+  for (uint32_t off = 0; off < kDisplacementSize; off += EntryWide::kLanes) {
+    const EntryWide data = EntryWide::Load(reinterpret_cast<const uint64_t*>(&entries_[bid + off]));
+    if (uint32_t empties = (data == uint64_t(0)).GetMSBs())
+      return bid + off + std::countr_zero(empties);
+  }
+  // TODO add expiration logic
+  const uint32_t ext = GetExtensionPoint(bid);
+  DCHECK_LT(ext, entries_.size());
+  return ext;
+}
+
+void OAHSet::Rehash(uint32_t prev_capacity_log, uint32_t prev_size) {
+  if (prev_size == 0) {
+    return;
+  }
+  // we should prevent moving elements before current possition to avoid double processing
+  constexpr size_t mix_size = (2 << kShiftLog) - 1;
+  std::array<OAHEntry, mix_size> old_buckets{};
+  for (size_t i = 0; i < mix_size; ++i) {
+    old_buckets[i] = std::move(entries_[i]);
+  }
+
+  for (size_t bucket_id = prev_size - 1; bucket_id >= mix_size; --bucket_id) {
+    auto bucket = std::move(entries_[bucket_id]);
+    for (uint32_t pos = 0, size = bucket.ElementsNum(); pos < size; ++pos) {
+      if (bucket[pos]) {
+        auto new_bucket_id = RehashEntry(bucket[pos], bucket_id, prev_capacity_log);
+        new_bucket_id = FindEmptyAround(new_bucket_id);
+        ptr_vectors_alloc_used_ += entries_[new_bucket_id].Insert(std::move(bucket[pos]));
+      }
+    }
+    if (bucket.IsVector())
+      ptr_vectors_alloc_used_ -= bucket.AsVector().AllocSize();
+  }
+
+  for (size_t bucket_id = 0; bucket_id < mix_size; ++bucket_id) {
+    auto& bucket = old_buckets[bucket_id];
+    for (uint32_t pos = 0, size = bucket.ElementsNum(); pos < size; ++pos) {
+      if (bucket[pos]) {
+        auto new_bucket_id = RehashEntry(bucket[pos], bucket_id, prev_capacity_log);
+        new_bucket_id = FindEmptyAround(new_bucket_id);
+        ptr_vectors_alloc_used_ += entries_[new_bucket_id].Insert(std::move(bucket[pos]));
+      }
+    }
+    if (bucket.IsVector())
+      ptr_vectors_alloc_used_ -= bucket.AsVector().AllocSize();
+  }
+}
+
+void OAHSet::Shrink(size_t new_size) {
+  assert(absl::has_single_bit(new_size));
+  assert(new_size >= (1u << kMinCapacityLog));
+  assert(new_size < entries_.size());
+
+  size_t prev_size = entries_.size();
+  capacity_log_ = absl::bit_width(new_size) - 1;
+
+  // Process from low to high (opposite of Grow/Rehash).
+  for (size_t i = 0; i < prev_size; ++i) {
+    ShrinkBucket(i);
+  }
+
+  entries_.resize(Capacity());
+  entries_.shrink_to_fit();
 }
 
 }  // namespace dfly

--- a/src/core/oah_set.h
+++ b/src/core/oah_set.h
@@ -25,7 +25,7 @@ class OAHSet {  // Open Addressing Hash Set
   using Buckets = std::vector<OAHEntry, OAHEntryAllocator>;
 
  public:
-  static constexpr std::uint32_t kShiftLog = 2;                         // TODO make template
+  static constexpr std::uint32_t kShiftLog = 5;                         // TODO make template
   static constexpr std::uint32_t kMinCapacityLog = kShiftLog;           // should be >= ShiftLog
   static constexpr std::uint32_t kDisplacementSize = (1 << kShiftLog);  // TODO check
 
@@ -91,9 +91,8 @@ class OAHSet {  // Open Addressing Hash Set
       return owner_;
     }
 
-    // Reallocates fragmented buffers in this entry's bucket. For vector buckets, the
-    // inner entries and the array buffer are all checked. Returns true iff anything
-    // moved. Idempotent: repeated calls within a defrag pass hit fresh pages and no-op.
+    // Reallocates fragmented buffers in this bucket (inner entries + array buffer for
+    // vectors). Returns true iff anything moved. Idempotent within a defrag pass.
     bool ReallocIfNeeded(PageUsage* page_usage) {
       auto& bucket = owner_->entries_[bucket_];
       bool realloced = false;
@@ -151,23 +150,24 @@ class OAHSet {  // Open Addressing Hash Set
 
   static constexpr uint32_t kMaxBatchLen = 32;
 
-  // SIMD wide of kDisplacementSize uint64 lanes; one lane per consecutive bucket.
-  // OAHEntry is a single uint64_t under the hood, so 4 entries are 32 contiguous
-  // bytes — perfect for an AVX2 256-bit register on x86_64.
+  // OAHEntry is one uint64_t, so 4 entries fill a 32-byte AVX2 register. The window is
+  // probed in kEntryLaneStep-lane strides, so kDisplacementSize must be a multiple of
+  // the stride and <= 32 (masks fit a uint32_t).
   static_assert(sizeof(OAHEntry) == sizeof(uint64_t));
   static_assert(alignof(OAHEntry) == alignof(uint64_t));
-  using EntryWide = SimdOp<uint64_t, kDisplacementSize>;
+  static constexpr std::uint32_t kEntryLaneStep = 4;
+  using EntryWide = SimdOp<uint64_t, kEntryLaneStep>;
+  static_assert(kDisplacementSize % kEntryLaneStep == 0 && kDisplacementSize <= 32);
 
-  // 2-lane SIMD for iterating the extension-point vector. Vectors are
-  // guaranteed power-of-2 capacity with minimum 2 (see OAHEntry::Insert), so a
-  // 2-lane (16-byte SSE) load is always within the heap allocation.
+  // 2-lane SIMD for iterating the extension-point vector. Vector sizes are always
+  // even with a minimum of 2 (see OAHEntry::Insert / PtrVector::Grow), so a 2-lane
+  // (16-byte SSE) load always stays within the heap allocation.
   static constexpr std::uint32_t kVectorLaneStep = 2;
   using VectorWide = SimdOp<uint64_t, kVectorLaneStep>;
 
   explicit OAHSet() = default;
 
-  // Inserts `str` (optional TTL); returns false if already present. Thin
-  // out-of-line entry point over the FORCE_INLINE AddImpl.
+  // Inserts `str` (optional TTL); returns false if already present.
   bool Add(std::string_view str, uint32_t ttl_sec = UINT32_MAX);
 
   void Reserve(size_t sz) {
@@ -182,25 +182,10 @@ class OAHSet {  // Open Addressing Hash Set
     assert(entries_.size() >= kDisplacementSize);
   }
 
-  // Shrinks the table to the specified size. The new_size must be a power of 2,
-  // >= kMinCapacity (which is 1 << kMinCapacityLog), and >= current number of elements.
-  // This method should be called explicitly when memory reclamation is needed.
-  void Shrink(size_t new_size) {
-    assert(absl::has_single_bit(new_size));
-    assert(new_size >= (1u << kMinCapacityLog));
-    assert(new_size < entries_.size());
-
-    size_t prev_size = entries_.size();
-    capacity_log_ = absl::bit_width(new_size) - 1;
-
-    // Process from low to high (opposite of Grow/Rehash).
-    for (size_t i = 0; i < prev_size; ++i) {
-      ShrinkBucket(i);
-    }
-
-    entries_.resize(Capacity());
-    entries_.shrink_to_fit();
-  }
+  // TODO rewrite using extended hash approach
+  //
+  // Shrinks the table to new_size (power of 2, >= 1 << kMinCapacityLog and >= element count).
+  void Shrink(size_t new_size);
 
   void Clear() {
     capacity_log_ = 0;
@@ -211,9 +196,8 @@ class OAHSet {  // Open Addressing Hash Set
     expiration_used_ = false;
   }
 
-  // Incrementally clears entries in [start, start+count). Returns the next bucket index;
-  // when the returned value equals Capacity() (i.e. entries_.size()), the table is empty.
-  // Mirrors DenseSet::ClearStep, used by AsyncDeleter for cooperative deletion.
+  // Incrementally clears [start, start+count). Returns the next bucket index; equals
+  // Capacity() when the table is empty. Mirrors DenseSet::ClearStep (AsyncDeleter).
   uint32_t ClearStep(uint32_t start, uint32_t count) {
     const uint32_t total = entries_.size();
     const uint32_t end = std::min(total, start + count);
@@ -299,24 +283,6 @@ class OAHSet {  // Open Addressing Hash Set
     return bucket_id << (32 - capacity_log_);
   }
 
-  OAHEntry Pop() {
-    for (auto& bucket : entries_) {
-      if (auto res = bucket.Pop(); !res.Empty()) {
-        assert(!res.IsVector());
-        --size_;
-        obj_alloc_used_ -= res.AllocSize();
-        if (bucket.IsVector()) {
-          if (bucket.AsVector().Empty()) {
-            ptr_vectors_alloc_used_ -= bucket.AsVector().AllocSize();
-            bucket = OAHEntry();
-          }
-        }
-        return res;
-      }
-    }
-    return {};
-  }
-
   bool Erase(std::string_view str);
 
   iterator Find(std::string_view member);
@@ -325,48 +291,8 @@ class OAHSet {  // Open Addressing Hash Set
     return Find(member) != end();
   }
 
-  // Returns iterator to a uniformly random non-empty entry, or end() if the set is empty.
-  // Mirrors StringSet::GetRandomMember (used by SPOP/SRANDMEMBER).
-  iterator GetRandomMember() {
-    if (entries_.empty() || size_ == 0)
-      return end();
-
-    static thread_local absl::InsecureBitGen rng;
-    const uint32_t num_buckets = entries_.size();
-    uint32_t start_bucket = absl::Uniform<uint32_t>(rng, 0u, num_buckets);
-
-    for (uint32_t n = 0; n < num_buckets; ++n) {
-      uint32_t bucket_id = start_bucket + n;
-      if (bucket_id >= num_buckets)
-        bucket_id -= num_buckets;
-      auto& bucket = entries_[bucket_id];
-      if (bucket.Empty())
-        continue;
-
-      if (!bucket.IsVector()) {
-        bucket.ExpireIfNeeded(time_now_, &size_, &obj_alloc_used_);
-        if (!bucket.Empty())
-          return iterator{this, bucket_id, 0};
-        continue;
-      }
-
-      auto& vec = bucket.AsVector();
-      const uint32_t vec_size = vec.Size();
-      uint32_t start_pos = absl::Uniform<uint32_t>(rng, 0u, vec_size);
-      for (uint32_t p = 0; p < vec_size; ++p) {
-        uint32_t pos = start_pos + p;
-        if (pos >= vec_size)
-          pos -= vec_size;
-        auto& entry = vec[pos];
-        if (!entry)
-          continue;
-        entry.ExpireIfNeeded(time_now_, &size_, &obj_alloc_used_);
-        if (entry)
-          return iterator{this, bucket_id, pos};
-      }
-    }
-    return end();
-  }
+  // Iterator to a uniformly random non-empty entry, or end() if empty (SPOP/SRANDMEMBER).
+  iterator GetRandomMember();
 
   // Returns the number of elements in the map. Note that it might be that some of these elements
   // have expired and can't be accessed.
@@ -424,43 +350,7 @@ class OAHSet {  // Open Addressing Hash Set
     return hash >> (64 - capacity_log);
   }
   // was Grow in StringSet
-  void Rehash(uint32_t prev_capacity_log, uint32_t prev_size) {
-    if (prev_size == 0) {
-      return;
-    }
-    // we should prevent moving elements before current possition to avoid double processing
-    constexpr size_t mix_size = (2 << kShiftLog) - 1;
-    std::array<OAHEntry, mix_size> old_buckets{};
-    for (size_t i = 0; i < mix_size; ++i) {
-      old_buckets[i] = std::move(entries_[i]);
-    }
-
-    for (size_t bucket_id = prev_size - 1; bucket_id >= mix_size; --bucket_id) {
-      auto bucket = std::move(entries_[bucket_id]);
-      for (uint32_t pos = 0, size = bucket.ElementsNum(); pos < size; ++pos) {
-        if (bucket[pos]) {
-          auto new_bucket_id = RehashEntry(bucket[pos], bucket_id, prev_capacity_log);
-          new_bucket_id = FindEmptyAround(new_bucket_id);
-          ptr_vectors_alloc_used_ += entries_[new_bucket_id].Insert(std::move(bucket[pos]));
-        }
-      }
-      if (bucket.IsVector())
-        ptr_vectors_alloc_used_ -= bucket.AsVector().AllocSize();
-    }
-
-    for (size_t bucket_id = 0; bucket_id < mix_size; ++bucket_id) {
-      auto& bucket = old_buckets[bucket_id];
-      for (uint32_t pos = 0, size = bucket.ElementsNum(); pos < size; ++pos) {
-        if (bucket[pos]) {
-          auto new_bucket_id = RehashEntry(bucket[pos], bucket_id, prev_capacity_log);
-          new_bucket_id = FindEmptyAround(new_bucket_id);
-          ptr_vectors_alloc_used_ += entries_[new_bucket_id].Insert(std::move(bucket[pos]));
-        }
-      }
-      if (bucket.IsVector())
-        ptr_vectors_alloc_used_ -= bucket.AsVector().AllocSize();
-    }
-  }
+  void Rehash(uint32_t prev_capacity_log, uint32_t prev_size);
 
   // it is inefficient for now,
   // TODO predict new position by current position and extended hash
@@ -491,7 +381,7 @@ class OAHSet {  // Open Addressing Hash Set
     }
   }
 
-  uint32_t GetExtensionPoint(const uint32_t bid) const {
+  static uint32_t GetExtensionPoint(uint32_t bid) {
     constexpr uint32_t extension_point_shift = kDisplacementSize - 1;
     return bid | extension_point_shift;
   }
@@ -523,46 +413,46 @@ class OAHSet {  // Open Addressing Hash Set
     return ttl_sec == UINT32_MAX ? ttl_sec : time_now_ + ttl_sec;
   }
 
-  uint32_t FindEmptyAround(uint32_t bid) {
-    for (uint32_t i = 0; i < kDisplacementSize; i++) {
-      const uint32_t bucket_id = bid + i;
-      if (entries_[bucket_id].Empty())
-        return bucket_id;
-      // TODO add expiration logic
-    }
+  // First empty slot in the window [bid, bid+kDisplacementSize), or the extension
+  // point if full. SIMD over EntryWide strides.
+  uint32_t FindEmptyAround(uint32_t bid);
 
-    bid = GetExtensionPoint(bid);
-    assert(bid < entries_.size());
-    return bid;
-  }
+  // Returns an iterator to a live entry in bucket `b` (skipping just-expired ones for
+  // single entries and walking vector entries in order), or end() if none remain.
+  // FORCE_INLINE: it sits inside ScanRange's hot SIMD inner loop.
+  iterator PickFromBucket(uint32_t b);
+
+  // Linear [lo, hi) scan returning the first live entry or end(). SIMD strides over
+  // EntryWide::kLanes plus a scalar tail for the < kLanes trailing buckets. Kept
+  // out-of-line so GetRandomMember can call it twice (hot range + rare wrap) without
+  // duplicating the body in the cold path.
+  iterator ScanRange(uint32_t lo, uint32_t hi);
 
   // The body of Add, FORCE_INLINE so it folds into Add and AddMany.
   bool AddImpl(std::string_view str, uint32_t ttl_sec);
 
   // Result of a SIMD probe over a run of OAHEntry lanes.
   struct LaneMasks {
-    // Non-empty lanes whose stored ext-hash matches or is lazily zero: key-compare
-    // candidates the caller confirms by key.
-    uint32_t candidates;
-    uint32_t empties;  // empty lanes (data_ == 0); Add uses these to pick a slot.
+    uint32_t candidates;  // non-empty lanes whose ext-hash matches or is lazily zero
+    uint32_t empties;     // empty lanes (data_ == 0); Add picks a slot from these
   };
 
-  // Vectorized hash probe over Wide::kLanes consecutive OAHEntry lanes from
-  // `base`. Backs the displacement-window (EntryWide) and extension-vector
-  // (VectorWide) scans. Defined in oah_set.cc.
+  // Vectorized hash probe over Wide::kLanes consecutive lanes from `base`. Backs
+  // the window (EntryWide) and extension-vector (VectorWide) scans.
   template <typename Wide>
   static LaneMasks ProbeLanes(const OAHEntry* base, uint64_t ext_hash) noexcept;
+
+  // Combined candidate/empty masks over the whole window (lane i -> bit i).
+  LaneMasks ProbeWindow(const OAHEntry* base, uint64_t ext_hash) noexcept;
 
   // Searches the extension-point vector for `str`. Returns the matched slot
   // (possibly now-empty after expiry, which the caller reuses) or nullptr.
   OAHEntry* ProbeExtensionVector(uint32_t ext_bid, std::string_view str, uint64_t ext_hash);
 
-  // Outcome of a key probe. A raw slot (not an iterator) so the caller can
-  // inspect/overwrite a matched-but-just-expired entry: it is Empty(), and
-  // dereferencing an iterator to it would hit OAHEntry::operator[]'s !Empty() assert.
+  // Outcome of a key probe. A raw slot (not an iterator) so the caller can reuse a
+  // matched-but-just-expired entry, which is Empty() and would trip operator[]'s assert.
   struct MatchResult {
-    OAHEntry* matched;    // matched entry, or null if the key is absent;
-                          // may be Empty() (just expired) — the caller reuses it
+    OAHEntry* matched;    // matched entry, or null if absent; may be Empty() (just expired)
     uint32_t bucket_id;   // location of `matched`, for building an iterator
     uint32_t pos_in_vec;  // position within a vector bucket (0 for single entries)
   };
@@ -655,18 +545,14 @@ class OAHSet {  // Open Addressing Hash Set
 // Snapshot of --use_oah_set captured once at startup.
 inline bool g_use_oah_set = false;
 
-// Dispatches a generic lambda over the runtime-selected dense-set type backing
-// kEncodingStrMap2 SETs. Both StringSet and OAHSet expose the same surface
-// (set_time, Empty, BucketCount, Reserve, ObjMallocUsed, ...) so the lambda
-// can be written once and visit either concrete type.
+// Dispatches a generic lambda over the runtime-selected set type (StringSet or
+// OAHSet) backing kEncodingStrMap2 SETs; both expose the same surface.
 template <typename Fn> auto VisitSet(void* ptr, Fn&& fn) {
   return g_use_oah_set ? fn(static_cast<OAHSet*>(ptr)) : fn(static_cast<StringSet*>(ptr));
 }
 
-// Extracts the current member as a string_view from either a StringSet or an
-// OAHSet iterator. Free functions so generic code (e.g. inside VisitSet
-// lambdas) can write `Key(it)` without a member-method asymmetry between the
-// two iterator types.
+// Current member as a string_view from either iterator type. Free functions so
+// generic code (e.g. VisitSet lambdas) can write `Key(it)` uniformly.
 inline std::string_view Key(StringSet::iterator it) {
   sds s = *it;
   return {s, sdslen(s)};

--- a/src/core/oah_set_test.cc
+++ b/src/core/oah_set_test.cc
@@ -64,26 +64,29 @@ static string random_string(mt19937& rand, unsigned len) {
   return ret;
 }
 
-TEST_F(OAHSetTest, PtrVectorTest) {
-  PtrVector<int> vp(PtrVector<int>::FromLogSize(3));
-  EXPECT_EQ(vp.Size(), 8);
-  EXPECT_EQ(vp.LogSize(), 3);
-  size_t i = 0;
-  for (; i < vp.Size(); ++i) {
-    EXPECT_EQ(vp[i], 0);
-    vp[i] = i + 1;
-  }
-  vp.ResizeLog(4);
+TEST_F(OAHSetTest, PtrVectorLinearThenDouble) {
+  auto vp = PtrVector<int>::FromSize(2);
+  EXPECT_EQ(vp.Size(), 2u);
+  vp[0] = 1;
+  vp[1] = 2;
 
-  for (; i < vp.Size(); ++i) {
-    EXPECT_EQ(vp[i], 0);
-    vp[i] = i + 1;
+  // Linear growth (+2 elements) up to and including kLinearMax (128); sizes stay even.
+  for (size_t expected = 4; expected <= 128; expected += 2) {
+    const size_t prev = vp.Size();
+    vp.Grow();
+    EXPECT_EQ(vp.Size(), expected);
+    EXPECT_EQ(vp[0], 1);     // existing elements preserved across reallocation
+    EXPECT_EQ(vp[prev], 0);  // newly added slots are default-constructed
   }
-  EXPECT_EQ(vp.Size(), 16);
-  EXPECT_EQ(vp.LogSize(), 4);
-  for (size_t i = 0; i < vp.Size(); ++i) {
-    EXPECT_EQ(vp[i], i + 1);
-  }
+  EXPECT_EQ(vp.Size(), 128u);
+
+  // At/above kLinearMax the vector switches to doubling (log-mode encoding).
+  vp.Grow();
+  EXPECT_EQ(vp.Size(), 256u);
+  vp.Grow();
+  EXPECT_EQ(vp.Size(), 512u);
+  EXPECT_EQ(vp[0], 1);
+  EXPECT_EQ(vp[1], 2);
 }
 
 TEST_F(OAHSetTest, OAHEntryTest) {
@@ -94,15 +97,15 @@ TEST_F(OAHSetTest, OAHEntryTest) {
 
   OAHEntry first("123456789");
 
-  EXPECT_EQ(test.Insert(std::move(first)), 16);
+  EXPECT_EQ(test.Insert(std::move(first)), 16);  // promote to a 2-element vector (2 * 8 bytes)
 
-  EXPECT_EQ(test.Insert(OAHEntry("23456789")), 16);
+  EXPECT_EQ(test.Insert(OAHEntry("23456789")), 16);  // linear grow 2 -> 4 (two more 8-byte slots)
 
   EXPECT_TRUE(test.Remove(0));
   EXPECT_FALSE(test.Remove(0));
 
   EXPECT_EQ(test.Remove(2).Key(), "23456789");
-  EXPECT_EQ(test.Pop().Key(), "123456789");
+  EXPECT_EQ(test.Remove(1).Key(), "123456789");
 }
 
 TEST_F(OAHSetTest, OAHSetAddFindTest) {
@@ -122,7 +125,8 @@ TEST_F(OAHSetTest, OAHSetAddFindTest) {
     EXPECT_EQ(e->Key(), s);
   }
 
-  EXPECT_EQ(ss.BucketCount(), 16384);
+  // ~10000 elements at load factor 2 (grow only when size_ >= 2 * table size).
+  EXPECT_EQ(ss.BucketCount(), 8192);
 }
 
 TEST_F(OAHSetTest, Basic) {
@@ -519,34 +523,6 @@ TEST_F(OAHSetTest, XtremeScanGrow) {
   }
 
   EXPECT_EQ(seen.size(), to_see.size());
-}
-
-TEST_F(OAHSetTest, Pop) {
-  constexpr size_t num_items = 8;
-  unordered_set<string> to_insert;
-
-  while (to_insert.size() != num_items) {
-    auto str = random_string(generator_, 10);
-    if (to_insert.count(str)) {
-      continue;
-    }
-
-    to_insert.insert(str);
-    EXPECT_TRUE(ss_->Add(str));
-  }
-
-  while (!ss_->Empty()) {
-    size_t size = ss_->UpperBoundSize();
-    auto str = ss_->Pop();
-    DCHECK(ss_->UpperBoundSize() == to_insert.size() - 1);
-    DCHECK(str);
-    DCHECK(to_insert.count(std::string(str.Key())));
-    DCHECK_EQ(ss_->UpperBoundSize(), size - 1);
-    to_insert.erase(std::string(str.Key()));
-  }
-
-  DCHECK(ss_->Empty());
-  DCHECK(to_insert.empty());
 }
 
 TEST_F(OAHSetTest, Iteration) {


### PR DESCRIPTION
Summary: This PR increases SIMD usage and adjusts growth policies in OAHSet/OAHEntry to improve probe efficiency.

Changes:

Refactors displacement-window probing to sweep the window in SIMD strides and pack candidate/empty masks via a new ProbeWindow helper.

- Changes kShiftLog (and thus kDisplacementSize) to a larger window and adds compile-time checks that the window fits in a 32-bit mask.
- Updates extension-vector probing assumptions from “power-of-two capacity” to “even capacity”, and changes PtrVector growth to +2 elements up to a linear threshold, then doubling.
- Replaces vector “defrag” via ResizeLog with a same-size Realloc path.
- Adjusts AddImpl growth trigger to a higher load threshold and updates related unit test expectations.
- Refactors GetRandomMember into SIMD-assisted scanning helpers (ScanRange/PickFromBucket) and removes Pop APIs from OAHEntry/OAHSet.
- Moves Rehash and Shrink definitions out-of-line into oah_set.cc and updates tests for the new behavior.