### PR TITLE
fix: build with WITH_COLLECTION_CMDS=OFF

### DIFF
--- a/src/server/collection_family_fallback.cc
+++ b/src/server/collection_family_fallback.cc
@@ -9,6 +9,7 @@
 #include "server/set_family.h"
 #include "server/stream_family.h"
 #include "server/zset_family.h"
+
 namespace dfly {
 
 using namespace std;
@@ -38,6 +39,18 @@ void* SetFamily::ConvertToStrSet(const intset* is, size_t expected_len) {
 uint32_t SetFamily::MaxIntsetEntries() {
   Fail();
   return 0;
+}
+
+bool SetFamily::DeleteSetIfEmpty(DbSlice& db_slice, const DbContext& db_cntx, std::string_view key,
+                                 const PrimeValue& pv) {
+  Fail();
+  return false;
+}
+
+bool HSetFamily::DeleteIfEmpty(DbSlice& db_slice, const DbContext& db_cntx, std::string_view key,
+                               const PrimeValue& pv) {
+  Fail();
+  return false;
 }
 
 LoadBlobResult SetFamily::LoadLPSetBlob(std::string_view blob, bool deep, PrimeValue* pv) {

--- a/src/server/dfly_main.cc
+++ b/src/server/dfly_main.cc
@@ -84,7 +84,7 @@ ABSL_DECLARE_FLAG(std::string, admin_bind);
 ABSL_DECLARE_FLAG(strings::MemoryBytesFlag, maxmemory);
 ABSL_DECLARE_FLAG(uint32_t, proactor_threads);
 ABSL_DECLARE_FLAG(std::string, dbfilename);
-ABSL_DECLARE_FLAG(bool, use_oah_set);
+ABSL_FLAG(bool, use_oah_set, false, "If true, store SET values in OAHSet instead of StringSet.");
 
 namespace dfly {
 extern bool g_use_oah_set;  // defined in core/oah_set.h

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -13,7 +13,7 @@ extern "C" {
 #include "redis/zmalloc.h"
 }
 
-#include "absl/flags/flag.h"
+#include "absl/flags/declare.h"
 #include "base/logging.h"
 #include "core/detail/listpack_wrap.h"
 #include "core/overloaded.h"
@@ -33,10 +33,8 @@ extern "C" {
 #include "server/transaction.h"
 #include "server/tx_base.h"
 
-ABSL_FLAG(size_t, listpack_max_field_len, 64,
-          "Maximum length of a hash field or value to be stored in listpack encoding");
-ABSL_FLAG(size_t, listpack_max_bytes, 1024,
-          "Maximum total bytes of a hash in listpack encoding before converting to a hash table");
+ABSL_DECLARE_FLAG(size_t, listpack_max_field_len);
+ABSL_DECLARE_FLAG(size_t, listpack_max_bytes);
 
 using namespace std;
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -91,8 +91,10 @@ ABSL_FLAG(bool, lua_resp2_legacy_float, false,
 ABSL_FLAG(uint32_t, multi_eval_squash_buffer, 4096, "Max buffer for squashed commands per script");
 
 ABSL_DECLARE_FLAG(bool, primary_port_http_enabled);
-ABSL_DECLARE_FLAG(size_t, listpack_max_field_len);
-ABSL_DECLARE_FLAG(size_t, listpack_max_bytes);
+ABSL_FLAG(size_t, listpack_max_field_len, 64,
+          "Maximum length of a hash field or value to be stored in listpack encoding");
+ABSL_FLAG(size_t, listpack_max_bytes, 1024,
+          "Maximum total bytes of a hash in listpack encoding before converting to a hash table");
 ABSL_FLAG(bool, admin_nopass, false,
           "If set, would enable open admin access to console on the assigned port, without "
           "authorization needed.");

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -12,8 +12,6 @@ extern "C" {
 #include "redis/util.h"  // for string2ll
 }
 
-#include <base/flags.h>
-
 #include "base/cycle_clock.h"
 #include "base/logging.h"
 #include "base/stl_util.h"
@@ -30,8 +28,6 @@ extern "C" {
 #include "server/error.h"
 #include "server/journal/journal.h"
 #include "server/transaction.h"
-
-ABSL_FLAG(bool, use_oah_set, false, "If true, store SET values in OAHSet instead of StringSet.");
 
 namespace rng = std::ranges;
 

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -33,7 +33,7 @@ using namespace std;
 ABSL_DECLARE_FLAG(string, dbfilename);
 ABSL_DECLARE_FLAG(double, rss_oom_deny_ratio);
 ABSL_DECLARE_FLAG(uint32_t, num_shards);
-ABSL_DECLARE_FLAG(bool, use_oah_set);
+ABSL_FLAG(bool, use_oah_set, false, "If true, store SET values in OAHSet instead of StringSet.");
 ABSL_FLAG(bool, force_epoll, false, "If true, uses epoll api instead iouring to run tests");
 ABSL_DECLARE_FLAG(uint32_t, acllog_max_len);
 ABSL_DECLARE_FLAG(bool, enable_heartbeat_rss_eviction);


### PR DESCRIPTION
fixes: #7525
Makes Dragonfly build cleanly with WITH_COLLECTION_CMDS=OFF by supplying missing fallback symbols.
