### PR TITLE
chore: disable failing tests

### DIFF
--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -3645,6 +3645,7 @@ async def _run_tiering_migration(
     assert info["db0"]["keys"] == keys - delete_succeded
 
 
+@pytest.mark.skip("Fails constantly on CI")
 @pytest.mark.large
 @pytest.mark.exclude_epoll
 @pytest.mark.opt_only

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -662,6 +662,7 @@ async def test_keyspace_events_config_set(async_client: aioredis.Redis):
             await collect_expiring_events(pclient, keys)
 
 
+@pytest.mark.skip("Fails constantly on CI")
 @dfly_multi_test_args(
     {"max_busy_read_usec": 50000, "enable_resp_io_loop_v2": "false"},
     {"max_busy_read_usec": 50000, "enable_resp_io_loop_v2": "true"},


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Disable two flaky CI tests via pytest skip markers
<code>🧪 Tests</code> <code>🕐 Less than 5 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

disable failing tests:

* test_reply_cunt
* test_cluster_migration_with_tiering failed

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Skip two consistently failing tests to stabilize CI signal.
• Annotate skips with explicit CI-failure rationale for future re-enable work.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  CI["CI Test Run"] --> Pytest["pytest"] --> CT["cluster_test.py"] --> Skip1["Skipped test"]
  Pytest --> ConnT["connection_test.py"] --> Skip2["Skipped test"]

  subgraph Legend
    direction LR
    _runner["Runner/Tool"] ~~~ _file["Test file"] ~~~ _outcome["Outcome"]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Quarantine via flaky/xfail marker (with tracking)</b></summary>

- ➕ Keeps visibility that the test is expected to fail (vs silently skipped)
- ➕ Can be conditioned on CI environment and/or linked to an issue
- ➕ Encourages eventual remediation and re-enable
- ➖ Still allows failures (as expected) which may be undesirable for strict CI gates
- ➖ Requires agreement on policy and tooling (markers, reporting)

</details>

<details>
<summary><b>2. Stabilize tests by tightening setup/teardown and timing</b></summary>

- ➕ Preserves coverage and confidence for the affected behavior
- ➕ Avoids long-term test debt from skipped coverage
- ➖ Potentially non-trivial investigation and time cost
- ➖ May require product/infra changes if flakiness stems from environment

</details>

<details>
<summary><b>3. Run these tests in a separate non-blocking CI lane</b></summary>

- ➕ Maintains signal without blocking merges
- ➕ Helps measure flakiness rate over time
- ➖ More CI complexity and longer overall pipeline time
- ➖ Still leaves mainline coverage gaps for merge gating

</details>

**Recommendation:** Given the stated goal (stop constant CI failures), skipping is acceptable as an immediate containment step. To avoid long-term coverage loss, consider switching to a quarantined xfail/flaky marker with an issue link and/or moving the tests to a non-blocking lane, then prioritize stabilizing and re-enabling.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Tests</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>cluster_test.py</strong> <code>Skip a flaky cluster migration test in CI</code> <code>+1/-0</code></summary>

<br/>

>Skip a flaky cluster migration test in CI
>
><pre>
>• Adds a pytest skip marker to a large cluster-related test that fails consistently on CI, preventing it from running during test collection/execution.
></pre>
>
><a href='https://github.com/dragonflydb/dragonfly/pull/7541/files#diff-84f62368c6e1619d79a05fda3fd46406c8cee4cd215f6469eb00ebfa091a6c9d'>tests/dragonfly/cluster_test.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>connection_test.py</strong> <code>Skip a flaky connection/IO multi-arg test in CI</code> <code>+1/-0</code></summary>

<br/>

>Skip a flaky connection/IO multi-arg test in CI
>
><pre>
>• Adds a pytest skip marker to a parameterized/multi-configuration connection test that fails consistently on CI, reducing CI instability.
></pre>
>
><a href='https://github.com/dragonflydb/dragonfly/pull/7541/files#diff-f34b45a2abc1d0c0c0b507feeaebd49c3f0f3832da4101a2b7f4d17bdbd0efe0'>tests/dragonfly/connection_test.py</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>