### PR TITLE
chore: retire v1 and experimental_replicaof_v2 flag

### DIFF
--- a/src/server/replica.cc
+++ b/src/server/replica.cc
@@ -68,8 +68,8 @@ ABSL_DECLARE_FLAG(uint16_t, announce_port);
 ABSL_FLAG(
     int, replica_priority, 100,
     "Published by info command for sentinel to pick replica based on score during a failover");
-ABSL_FLAG(bool, experimental_replicaof_v2, true,
-          "Use ReplicaOfV2 algorithm for initiating replication");
+ABSL_RETIRED_FLAG(bool, experimental_replicaof_v2, true,
+                  "Deprecated: ReplicaOfV2 is now the only replication algorithm");
 
 namespace dfly {
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -171,7 +171,6 @@ ABSL_DECLARE_FLAG(string, tls_ca_cert_file);
 ABSL_DECLARE_FLAG(string, tls_ca_cert_dir);
 ABSL_DECLARE_FLAG(int, replica_priority);
 ABSL_DECLARE_FLAG(double, rss_oom_deny_ratio);
-ABSL_DECLARE_FLAG(bool, experimental_replicaof_v2);
 
 bool AbslParseFlag(std::string_view in, ReplicaOfFlag* flag, std::string* err) {
 #define RETURN_ON_ERROR(cond, m)                                           \
@@ -3995,113 +3994,6 @@ void ServerFamily::AddReplicaOf(CmdArgList args, CommandContext* cmd_cntx) {
   rb->SendOk();
 }
 
-void ServerFamily::ReplicaOfInternal(CmdArgList args, CommandContext* cmd_cntx,
-                                     ActionOnConnectionFail on_err) {
-  std::shared_ptr<Replica> new_replica;
-  std::optional<Replica::LastMasterSyncData> last_master_data;
-  {
-    util::fb2::LockGuard lk(replicaof_mu_);  // Only one REPLICAOF command can run at a time
-
-    // We should not execute replica of command while loading from snapshot.
-    ServerState* ss = ServerState::tlocal();
-    if (ss->is_master && ss->gstate() == GlobalState::LOADING) {
-      cmd_cntx->SendError(kLoadingErr);
-      return;
-    }
-
-    auto replicaof_args = ReplicaOfArgs::FromCmdArgs(args);
-    if (!replicaof_args.has_value()) {
-      cmd_cntx->SendError(replicaof_args.error());
-      return;
-    }
-
-    LOG(INFO) << "Replicating " << *replicaof_args;
-
-    // If NO ONE was supplied, just stop the current replica (if it exists)
-    if (replicaof_args->IsReplicaOfNoOne()) {
-      if (!ss->is_master) {
-        CHECK(replica_);
-
-        SetMasterFlagOnAllThreads(true);  // Flip flag before clearing replica
-        // No partial sync for NO ONE flow
-        replica_->Stop();
-        replica_.reset();
-
-        StopAllClusterReplicas();
-      }
-
-      // May not switch to ACTIVE if the process is, for example, shutting down at the same time.
-      service_.SwitchState(GlobalState::LOADING, GlobalState::ACTIVE);
-
-      return cmd_cntx->rb()->SendOk();
-    }
-
-    // If any replication is in progress, stop it, cancellation should kick in immediately
-
-    if (replica_)
-      last_master_data = replica_->Stop();
-    StopAllClusterReplicas();
-
-    const GlobalState gstate = ServerState::tlocal()->gstate();
-    if (gstate == GlobalState::TAKEN_OVER) {
-      service_.SwitchState(GlobalState::TAKEN_OVER, GlobalState::LOADING);
-    } else if (auto prev_state = service_.SwitchState(GlobalState::ACTIVE, GlobalState::LOADING);
-               prev_state != GlobalState::ACTIVE) {
-      LOG(WARNING) << prev_state << " in progress, ignored";
-      cmd_cntx->SendError("Invalid state");
-      return;
-    }
-
-    // Create a new replica and assign it
-    new_replica = make_shared<Replica>(replicaof_args->host, replicaof_args->port, &service_,
-                                       master_replid(), replicaof_args->slot_range);
-
-    replica_ = new_replica;
-
-    // TODO: disconnect pending blocked clients (pubsub, blocking commands)
-    SetMasterFlagOnAllThreads(false);  // Flip flag after assiging replica
-
-  }  // release the lock, lk.unlock()
-  // We proceed connecting below without the lock to allow interrupting the replica immediately.
-  // From this point and onward, it should be highly responsive.
-
-  GenericError ec{};
-  switch (on_err) {
-    case ActionOnConnectionFail::kReturnOnError:
-      ec = new_replica->Start();
-      break;
-    case ActionOnConnectionFail::kContinueReplication:
-      new_replica->EnableReplication();
-      break;
-  };
-
-  // If the replication attempt failed, clean up global state. The replica should have stopped
-  // internally.
-  util::fb2::LockGuard lk(replicaof_mu_);  // Only one REPLICAOF command can run at a time
-
-  // If there was an error above during Start we must not start the main replication fiber.
-  // However, it could be the case that Start() above connected succefully and by the time
-  // we acquire the lock, the context got cancelled because another ReplicaOf command
-  // executed and acquired the replicaof_mu_ before us.
-  const bool cancelled = new_replica->IsContextCancelled();
-  if (ec || cancelled) {
-    if (replica_ == new_replica) {
-      service_.SwitchState(GlobalState::LOADING, GlobalState::ACTIVE);
-      SetMasterFlagOnAllThreads(true);
-      replica_.reset();
-    }
-    cmd_cntx->SendError(ec ? ec.Format() : "replication cancelled");
-    return;
-  }
-  // Successfully connected now we flush
-  // If we are called by "Replicate", tx will be null but we do not need
-  // to flush anything.
-  if (on_err == ActionOnConnectionFail::kReturnOnError) {
-    new_replica->StartMainReplicationFiber(last_master_data);
-  }
-  cmd_cntx->rb()->SendOk();
-}
-
 void ServerFamily::StopAllClusterReplicas() {
   // Stop all cluster replication.
   for (auto& replica : cluster_replicas_) {
@@ -4112,11 +4004,6 @@ void ServerFamily::StopAllClusterReplicas() {
 }
 
 void ServerFamily::ReplicaOf(CmdArgList args, CommandContext* cmd_cntx) {
-  const bool use_replica_of_v2 = absl::GetFlag(FLAGS_experimental_replicaof_v2);
-  if (use_replica_of_v2) {
-    ReplicaOfInternalV2(args, cmd_cntx, ActionOnConnectionFail::kReturnOnError);
-    return;
-  }
   ReplicaOfInternal(args, cmd_cntx, ActionOnConnectionFail::kReturnOnError);
 }
 
@@ -4130,12 +4017,7 @@ void ServerFamily::Replicate(string_view host, string_view port) {
   CmdArgList args_list = absl::MakeSpan(args_vec);
   io::NullSink sink;
   facade::RedisReplyBuilder rb(&sink);
-  const bool use_replica_of_v2 = absl::GetFlag(FLAGS_experimental_replicaof_v2);
   CommandContext cmd_cntx{&rb, nullptr};
-  if (use_replica_of_v2) {
-    ReplicaOfInternalV2(args_list, &cmd_cntx, ActionOnConnectionFail::kContinueReplication);
-    return;
-  }
   ReplicaOfInternal(args_list, &cmd_cntx, ActionOnConnectionFail::kContinueReplication);
 }
 
@@ -4174,8 +4056,8 @@ void ServerFamily::ReplicaOfNoOne(SinkReplyBuilder* builder) {
   return builder->SendOk();
 }
 
-void ServerFamily::ReplicaOfInternalV2(CmdArgList args, CommandContext* cmd_cntx,
-                                       ActionOnConnectionFail on_error)
+void ServerFamily::ReplicaOfInternal(CmdArgList args, CommandContext* cmd_cntx,
+                                     ActionOnConnectionFail on_error)
     ABSL_LOCKS_EXCLUDED(replicaof_mu_) {
   auto replicaof_args = ReplicaOfArgs::FromCmdArgs(args);
   if (!replicaof_args.has_value()) {

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -388,17 +388,12 @@ class ServerFamily {
                            // failure
   };
 
-  // REPLICAOF implementation. See arguments above
   void ReplicaOfInternal(CmdArgList args, CommandContext* cmnd_cntx,
                          ActionOnConnectionFail on_error) ABSL_LOCKS_EXCLUDED(replicaof_mu_);
 
   void StartJournalInShardThreads(Replica* repl_ptr);
 
   void ReplicaOfNoOne(SinkReplyBuilder* builder) ABSL_LOCKS_EXCLUDED(replicaof_mu_);
-
-  // REPLICAOF implementation without two phase locking.
-  void ReplicaOfInternalV2(CmdArgList args, CommandContext* cmnd_cntx,
-                           ActionOnConnectionFail on_error) ABSL_LOCKS_EXCLUDED(replicaof_mu_);
 
   struct LoadOptions {
     std::string snapshot_id;


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Retire legacy REPLICAOF v1 path and deprecate experimental_replicaof_v2 flag
<code>⚙️ Configuration changes</code> <code>✨ Enhancement</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Retire the experimental_replicaof_v2 flag and make v2 replication the only path.
• Remove the legacy REPLICAOF implementation and its runtime switch.
• Consolidate REPLICAOF internal logic to a single implementation entrypoint.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["Client / Admin"] --> B["REPLICAOF cmd"] --> C["ServerFamily::ReplicaOf"] --> D["ReplicaOfInternal (v2-only)"] --> E["Replica"] --> F["Replication fibers"]
  subgraph Legend
    direction LR
    _user["Caller"] ~~~ _cmd["Command handler"] ~~~ _mod["Server module"] ~~~ _obj["Runtime object"]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Keep the flag but default it on (soft deprecation)</b></summary>

- ➕ Fast rollback lever if unforeseen issues appear in the field
- ➕ Allows staged migrations across deployments
- ➖ Continues supporting two production paths, increasing maintenance and test surface
- ➖ Encourages dependency on a flag that is intended to be removed

</details>

<details>
<summary><b>2. Compile-time switch (build option) instead of runtime flag</b></summary>

- ➕ Eliminates runtime branching while allowing emergency builds with legacy behavior
- ➕ Reduces risk of accidentally toggling behavior in production
- ➖ Operationally heavier rollback (requires rebuild/redeploy)
- ➖ Still preserves legacy code that the PR aims to delete

</details>

<details>
<summary><b>3. Remove v1 but keep a compatibility shim function name</b></summary>

- ➕ Minimizes churn for internal call sites and reduces rename-related confusion
- ➕ Keeps public/internal naming stable while consolidating implementation
- ➖ Can obscure that behavior has fully moved to the v2 algorithm
- ➖ Still requires careful documentation to avoid assumptions about old semantics

</details>

**Recommendation:** The PR’s approach (delete the legacy implementation and retire the experiment flag) is the cleanest long-term option because it removes a bifurcated control flow and reduces the number of replication behaviors to reason about. If rollback risk is a concern, consider the compile-time switch alternative; otherwise, fully retiring the runtime flag and v1 path is preferable for maintainability.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Refactor</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>server_family.cc</strong> <code>Remove v1 REPLICAOF implementation and flag-based routing</code> <code>+2/-120</code></summary>

<br/>

>Remove v1 REPLICAOF implementation and flag-based routing
>
><pre>
>• Deletes the legacy ReplicaOfInternal implementation and removes all runtime branching on experimental_replicaof_v2. Renames the former ReplicaOfInternalV2 implementation to ReplicaOfInternal so all call sites use the consolidated path.
></pre>
>
><a href='https://github.com/dragonflydb/dragonfly/pull/7542/files#diff-04447876005188a028fe0e46ee54f437b03f9d2dfb8b456be2fa6fa539a56499'>src/server/server_family.cc</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>server_family.h</strong> <code>Drop ReplicaOfInternalV2 declaration and keep single internal API</code> <code>+0/-5</code></summary>

<br/>

>Drop ReplicaOfInternalV2 declaration and keep single internal API
>
><pre>
>• Removes the separate ReplicaOfInternalV2 method declaration and associated comments. Leaves a single ReplicaOfInternal declaration matching the consolidated implementation in server_family.cc.
></pre>
>
><a href='https://github.com/dragonflydb/dragonfly/pull/7542/files#diff-0e93c9531b091521c21707f9c1008edd53ce929db8cda1733be8526c2302e63c'>src/server/server_family.h</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>replica.cc</strong> <code>Retire experimental_replicaof_v2 flag</code> <code>+2/-2</code></summary>

<br/>

>Retire experimental_replicaof_v2 flag
>
><pre>
>• Converts experimental_replicaof_v2 from an active flag to a retired flag. Updates the help text to reflect that the v2 algorithm is now the only supported replication initiation path.
></pre>
>
><a href='https://github.com/dragonflydb/dragonfly/pull/7542/files#diff-8174e8eae32841a10b583a676b1b8ec068e7b3f2aa3cf61d2e952553ab343875'>src/server/replica.cc</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>