### PR TITLE
fix(tiering): Avoid defrag spikes + fix negative memory budget bug

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -3520,6 +3520,7 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
     append("tiered_total_cancels", m.tiered_stats.total_cancels);
     append("tiered_total_deletes", m.tiered_stats.total_deletes);
     append("tiered_total_uploads", m.tiered_stats.total_uploads);
+    append("tiered_total_defrags", m.tiered_stats.total_defrags);
     append("tiered_total_stash_overflows", m.tiered_stats.total_stash_overflows);
     append("tiered_heap_buf_allocations", m.tiered_stats.total_heap_buf_allocs);
     append("tiered_registered_buf_allocations", m.tiered_stats.total_registered_buf_allocs);

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -3521,6 +3521,7 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
     append("tiered_total_deletes", m.tiered_stats.total_deletes);
     append("tiered_total_uploads", m.tiered_stats.total_uploads);
     append("tiered_total_defrags", m.tiered_stats.total_defrags);
+    append("tiered_delayed_defrag_queue_size", m.tiered_stats.delayed_defrag_queue_size);
     append("tiered_total_stash_overflows", m.tiered_stats.total_stash_overflows);
     append("tiered_heap_buf_allocations", m.tiered_stats.total_heap_buf_allocs);
     append("tiered_registered_buf_allocations", m.tiered_stats.total_registered_buf_allocs);

--- a/src/server/stats.cc
+++ b/src/server/stats.cc
@@ -11,13 +11,14 @@ namespace dfly {
 #define ADD(x) (x) += o.x
 
 TieredStats& TieredStats::operator+=(const TieredStats& o) {
-  static_assert(sizeof(TieredStats) == 176);
+  static_assert(sizeof(TieredStats) == 184);
 
   ADD(total_stashes);
   ADD(total_fetches);
   ADD(total_cancels);
   ADD(total_deletes);
   ADD(total_defrags);
+  ADD(delayed_defrag_queue_size);
   ADD(total_uploads);
   ADD(total_heap_buf_allocs);
   ADD(total_registered_buf_allocs);

--- a/src/server/stats.h
+++ b/src/server/stats.h
@@ -25,6 +25,9 @@ struct TieredStats {
   // Defragmentation operations (small bins read and consolidated back to memory).
   uint64_t total_defrags = 0;
 
+  // Number of segments waiting in the delayed defragmentation queue.
+  size_t delayed_defrag_queue_size = 0;
+
   // Values restored from disk to memory (e.g. after modification).
   uint64_t total_uploads = 0;
 

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -648,9 +648,9 @@ std::vector<std::string> TieredStorage::GetMutableFlagNames() {
 bool TieredStorage::ShouldOffload() const {
   // Cool values can be dropped, so count as free as well
   int64_t actual_free = op_manager_->db_slice_.memory_budget() + int64_t(CoolMemoryUsage());
-  int64_t expected_free = double(config_.offload_threshold) *
-                          max_memory_limit.load(memory_order_relaxed) / shard_set->size();
-  return actual_free < expected_free;
+  int64_t target_free = double(config_.offload_threshold) *
+                        max_memory_limit.load(memory_order_relaxed) / shard_set->size();
+  return actual_free < target_free;
 }
 
 int64_t TieredStorage::UploadBudget() const {

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -441,11 +441,16 @@ bool TieredStorage::ShardOpManager::NotifyDelete(tiering::DiskSegment segment) {
 }
 
 void TieredStorage::ShardOpManager::EnqueueForDefrag(tiering::DiskSegment segment) {
-  // Trigger read to signal need for defragmentation. NotifyFetched will handle it.
+  // Trigger read to signal need for defragmentation. NotifyFetched will handle it on success.
   DVLOG(2) << "Enqueueing bin defragmentation for: " << segment.offset;
   stats_.pending_defrags++;
   Enqueue(
-      kFragmentedBin, segment, tiering::BareDecoder{}, [](auto) {}, true);
+      kFragmentedBin, segment, tiering::BareDecoder{},
+      [this](io::Result<tiering::Decoder*> res) {
+        if (!res)
+          stats_.pending_defrags--;
+      },
+      true);
 }
 
 void TieredStorage::ShardOpManager::RetireColdEntries(size_t additional_memory) {

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -318,7 +318,7 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
   } stats_;
 
   // When we don't have memory to upload a page for defragmentation, we save it here to do it later
-  std::deque<uint32_t /* offset */> delayed_defrag_queue_;
+  std::deque<uint32_t /* page index (kPageSize) */> delayed_defrag_queue_;
 
   TieredStorage* ts_;
   DbSlice& db_slice_;
@@ -366,7 +366,6 @@ bool TieredStorage::ShardOpManager::NotifyFetched(const OwnedEntryId& id,
     if (*i == kFragmentedBin) {  // Generally we read whole bins only for defrag
       auto* bdecoder = static_cast<tiering::BareDecoder*>(decoder);
       Defragment(segment, bdecoder->slice);
-      stats_.pending_defrags--;
       return true;  // delete
     }
   }
@@ -433,7 +432,8 @@ bool TieredStorage::ShardOpManager::NotifyDelete(tiering::DiskSegment segment) {
     if (stats_.pending_defrags < kMaxPendingDefrags && ts_->UploadBudget() > 0) {
       EnqueueForDefrag(bin.segment);
     } else if (delayed_defrag_queue_.size() * sizeof(uint32_t) < kMaxDelayedMem) {
-      delayed_defrag_queue_.push_back(bin.segment.offset);
+      uint32_t page_index = bin.segment.offset / tiering::kPageSize;
+      delayed_defrag_queue_.push_back(page_index);
     }
   }
 
@@ -446,11 +446,7 @@ void TieredStorage::ShardOpManager::EnqueueForDefrag(tiering::DiskSegment segmen
   stats_.pending_defrags++;
   Enqueue(
       kFragmentedBin, segment, tiering::BareDecoder{},
-      [this](io::Result<tiering::Decoder*> res) {
-        if (!res)
-          stats_.pending_defrags--;
-      },
-      true);
+      [this](io::Result<tiering::Decoder*> res) { stats_.pending_defrags--; }, true);
 }
 
 void TieredStorage::ShardOpManager::RetireColdEntries(size_t additional_memory) {
@@ -718,7 +714,7 @@ void TieredStorage::ProcessDelayedDeframents() {
     return;
 
   while (op_manager_->stats_.pending_defrags < kMaxPendingDefrags && !dd_queue.empty()) {
-    uint32_t offset = dd_queue.front();
+    size_t offset = dd_queue.front() * tiering::kPageSize;
     dd_queue.pop_front();
 
     if (!bins_->IsFragmented(offset))

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -647,7 +647,7 @@ std::vector<std::string> TieredStorage::GetMutableFlagNames() {
 
 bool TieredStorage::ShouldOffload() const {
   // Cool values can be dropped, so count as free as well
-  int64_t actual_free = op_manager_->db_slice_.memory_budget() + CoolMemoryUsage();
+  int64_t actual_free = op_manager_->db_slice_.memory_budget() + int64_t(CoolMemoryUsage());
   int64_t expected_free = double(config_.offload_threshold) *
                           max_memory_limit.load(memory_order_relaxed) / shard_set->size();
   return actual_free < expected_free;

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -220,6 +220,8 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
 
   bool NotifyDelete(tiering::DiskSegment segment) override;
 
+  void EnqueueForDefrag(tiering::DiskSegment segment);
+
   // If we are low on memory, remove entries from the ColdQueue,
   // and promote their PrimeValues to be fully external.
   void RetireColdEntries(size_t additional_memory);
@@ -309,6 +311,9 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
     uint64_t total_defrags = 0;
     uint64_t total_uploads = 0;
   } stats_;
+
+  // When we don't have memory to upload a page for defragmentation, we save it here to do it later
+  std::deque<uint32_t /* offset */> delayed_defrag_queue_;
 
   TieredStorage* ts_;
   DbSlice& db_slice_;
@@ -415,14 +420,25 @@ bool TieredStorage::ShardOpManager::NotifyDelete(tiering::DiskSegment segment) {
     return true;
   }
 
+  // If we have memory, upload the page for defrag. It will be reshuffled and offloaded more packed.
+  // Otherwise, enqueue the bin to be defragmented later when memory is available
   if (bin.fragmented) {
-    // Trigger read to signal need for defragmentation. NotifyFetched will handle it.
-    DVLOG(2) << "Enqueueing bin defragmentation for: " << bin.segment.offset;
-    Enqueue(
-        kFragmentedBin, bin.segment, tiering::BareDecoder{}, [](auto res) {}, true);
+    const size_t kMaxDelayedMem = 1_MB;
+    if (ts_->UploadBudget() > 0) {
+      EnqueueForDefrag(bin.segment);
+    } else if (delayed_defrag_queue_.size() * sizeof(uint32_t) < kMaxDelayedMem) {
+      delayed_defrag_queue_.push_back(bin.segment.offset);
+    }
   }
 
   return false;
+}
+
+void TieredStorage::ShardOpManager::EnqueueForDefrag(tiering::DiskSegment segment) {
+  // Trigger read to signal need for defragmentation. NotifyFetched will handle it.
+  DVLOG(2) << "Enqueueing bin defragmentation for: " << segment.offset;
+  Enqueue(
+      kFragmentedBin, segment, tiering::BareDecoder{}, [](...) {}, true);
 }
 
 void TieredStorage::ShardOpManager::RetireColdEntries(size_t additional_memory) {
@@ -607,6 +623,10 @@ void TieredStorage::UpdateFromFlags() {
       .experimental_hash_offload = absl::GetFlag(FLAGS_tiered_experimental_hash_support),
       .experimental_list_offload = absl::GetFlag(FLAGS_tiered_experimental_list_support),
   };
+
+  LOG_IF(WARNING, config_.upload_threshold > config_.offload_threshold)
+      << "tiered_upload_threshold should be less than tiered_offload_threshold to maximize cache "
+         "and defragmentation effectiveness";
 }
 
 std::vector<std::string> TieredStorage::GetMutableFlagNames() {
@@ -617,16 +637,17 @@ std::vector<std::string> TieredStorage::GetMutableFlagNames() {
 }
 
 bool TieredStorage::ShouldOffload() const {
-  size_t free_memory = op_manager_->db_slice_.memory_budget();
-  size_t per_shard = max_memory_limit.load(memory_order_relaxed) / shard_set->size();
-  // Cool values are already offloadeded, so don't count them as used memory
-  return (free_memory + CoolMemoryUsage()) < config_.offload_threshold * per_shard;
+  // Cool values can be dropped, so count as free as well
+  int64_t actual_free = op_manager_->db_slice_.memory_budget() + CoolMemoryUsage();
+  int64_t expected_free = double(config_.offload_threshold) *
+                          max_memory_limit.load(memory_order_relaxed) / shard_set->size();
+  return actual_free < expected_free;
 }
 
 int64_t TieredStorage::UploadBudget() const {
-  size_t free_memory = op_manager_->db_slice_.memory_budget();
-  size_t per_shard = max_memory_limit.load(memory_order_relaxed) / shard_set->size();
-  return int64_t(free_memory) - int64_t(config_.upload_threshold * per_shard);
+  int64_t free_memory = op_manager_->db_slice_.memory_budget();
+  int64_t per_shard = max_memory_limit.load(memory_order_relaxed) / shard_set->size();
+  return free_memory - double(config_.upload_threshold) * per_shard;
 }
 
 void TieredStorage::RunOffloading(DbIndex dbid) {
@@ -635,6 +656,9 @@ void TieredStorage::RunOffloading(DbIndex dbid) {
     return;
 
   const auto start_cycles = base::CycleClock::Now();
+
+  // Takes up a small fixed amount of time and is best done before offloading (to be picked up)
+  ProcessDelayedDeframents();
 
   // Don't run offloading if there's only very little space left
   auto disk_stats = op_manager_->GetStats().disk_stats;
@@ -673,6 +697,24 @@ void TieredStorage::RunOffloading(DbIndex dbid) {
     if (base::CycleClock::ToUsec(cycles) >= 100)
       break;
   } while (offloading_cursor_);
+}
+
+void TieredStorage::ProcessDelayedDeframents() {
+  const size_t kMaxEntries = 100;
+
+  auto& dd_queue = op_manager_->delayed_defrag_queue_;
+  if (dd_queue.empty() || UploadBudget() <= 0)
+    return;
+
+  size_t processed = 0;
+  while (processed < kMaxEntries && !dd_queue.empty()) {
+    uint32_t offset = dd_queue.front();
+    dd_queue.pop_front();
+
+    if (!bins_->IsFragmented(offset))
+      continue;
+    op_manager_->EnqueueForDefrag({offset, tiering::kPageSize});
+  }
 }
 
 size_t TieredStorage::ReclaimMemory(size_t goal) {

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -576,6 +576,7 @@ TieredStats TieredStorage::GetStats() const {
     stats.total_cancels = shard_stats.total_cancels;
     stats.total_defrags = shard_stats.total_defrags;
     stats.total_uploads = shard_stats.total_uploads;
+    stats.delayed_defrag_queue_size = op_manager_->delayed_defrag_queue_.size();
   }
 
   {  // OpManager stats

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -81,6 +81,10 @@ bool OccupiesWholePages(size_t size) {
 // Stashed bins no longer have bin ids, so this sentinel is used to differentiate from regular reads
 constexpr auto kFragmentedBin = tiering::SmallBins::kInvalidBin - 1;
 
+// Memory budget (UploadBudget) does not account for buffers allocated for in-flight defrag reads,
+// so we cap the number of concurrent defragmentation operations to avoid unbounded memory growth.
+constexpr uint32_t kMaxPendingDefrags = 100;
+
 // Called after setting new value in place of previous segment
 void RecordDeleted(const FragmentRef& fragment_ref, size_t tiered_len, DbTableStats* stats) {
   stats->AddTypeMemoryUsage(fragment_ref.ObjType(), fragment_ref.MallocUsed());
@@ -310,6 +314,7 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
     uint64_t total_stashes = 0, total_cancels = 0, total_fetches = 0;
     uint64_t total_defrags = 0;
     uint64_t total_uploads = 0;
+    uint32_t pending_defrags = 0;
   } stats_;
 
   // When we don't have memory to upload a page for defragmentation, we save it here to do it later
@@ -361,6 +366,7 @@ bool TieredStorage::ShardOpManager::NotifyFetched(const OwnedEntryId& id,
     if (*i == kFragmentedBin) {  // Generally we read whole bins only for defrag
       auto* bdecoder = static_cast<tiering::BareDecoder*>(decoder);
       Defragment(segment, bdecoder->slice);
+      stats_.pending_defrags--;
       return true;  // delete
     }
   }
@@ -423,8 +429,8 @@ bool TieredStorage::ShardOpManager::NotifyDelete(tiering::DiskSegment segment) {
   // If we have memory, upload the page for defrag. It will be reshuffled and offloaded more packed.
   // Otherwise, enqueue the bin to be defragmented later when memory is available
   if (bin.fragmented) {
-    const size_t kMaxDelayedMem = 1_MB;
-    if (ts_->UploadBudget() > 0) {
+    constexpr size_t kMaxDelayedMem = 1_MB;
+    if (stats_.pending_defrags < kMaxPendingDefrags && ts_->UploadBudget() > 0) {
       EnqueueForDefrag(bin.segment);
     } else if (delayed_defrag_queue_.size() * sizeof(uint32_t) < kMaxDelayedMem) {
       delayed_defrag_queue_.push_back(bin.segment.offset);
@@ -437,8 +443,9 @@ bool TieredStorage::ShardOpManager::NotifyDelete(tiering::DiskSegment segment) {
 void TieredStorage::ShardOpManager::EnqueueForDefrag(tiering::DiskSegment segment) {
   // Trigger read to signal need for defragmentation. NotifyFetched will handle it.
   DVLOG(2) << "Enqueueing bin defragmentation for: " << segment.offset;
+  stats_.pending_defrags++;
   Enqueue(
-      kFragmentedBin, segment, tiering::BareDecoder{}, [](...) {}, true);
+      kFragmentedBin, segment, tiering::BareDecoder{}, [](auto) {}, true);
 }
 
 void TieredStorage::ShardOpManager::RetireColdEntries(size_t additional_memory) {
@@ -701,14 +708,11 @@ void TieredStorage::RunOffloading(DbIndex dbid) {
 }
 
 void TieredStorage::ProcessDelayedDeframents() {
-  const size_t kMaxEntries = 100;
-
   auto& dd_queue = op_manager_->delayed_defrag_queue_;
   if (dd_queue.empty() || UploadBudget() <= 0)
     return;
 
-  size_t processed = 0;
-  while (processed < kMaxEntries && !dd_queue.empty()) {
+  while (op_manager_->stats_.pending_defrags < kMaxPendingDefrags && !dd_queue.empty()) {
     uint32_t offset = dd_queue.front();
     dd_queue.pop_front();
 

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -131,6 +131,8 @@ class TieredStorage : public TieredStorageBase {
   void CoolDown(DbIndex db_ind, std::string_view str, const tiering::DiskSegment& segment,
                 CompactObj::ExternalRep rep, PrimeValue* pv);
 
+  void ProcessDelayedDeframents();
+
   PrimeValue DeleteCool(tiering::TieredCoolRecord* record);
   tiering::TieredCoolRecord* PopCool();
 

--- a/src/server/tiering/small_bins.cc
+++ b/src/server/tiering/small_bins.cc
@@ -158,7 +158,7 @@ SmallBins::BinInfo SmallBins::Delete(DiskSegment segment) {
   return {segment};
 }
 
-bool SmallBins::IsFragmented(uint32_t offset) {
+bool SmallBins::IsFragmented(size_t offset) {
   if (auto it = stashed_bins_.find(offset); it != stashed_bins_.end())
     return it->second.bytes < kPageSize / 2;
   return false;

--- a/src/server/tiering/small_bins.cc
+++ b/src/server/tiering/small_bins.cc
@@ -158,6 +158,12 @@ SmallBins::BinInfo SmallBins::Delete(DiskSegment segment) {
   return {segment};
 }
 
+bool SmallBins::IsFragmented(uint32_t offset) {
+  if (auto it = stashed_bins_.find(offset); it != stashed_bins_.end())
+    return it->second.bytes < kPageSize / 2;
+  return false;
+}
+
 SmallBins::Stats SmallBins::GetStats() const {
   return Stats{.stashed_bins_cnt = stashed_bins_.size(),
                .stashed_entries_cnt = stats_.stashed_entries_cnt,

--- a/src/server/tiering/small_bins.h
+++ b/src/server/tiering/small_bins.h
@@ -78,7 +78,7 @@ class SmallBins {
   BinInfo Delete(DiskSegment segment);
 
   // Returns true if the page exists and is fragmented
-  bool IsFragmented(uint32_t offset);
+  bool IsFragmented(size_t offset);
 
   // Delete stashed bin. Returns list of recovered item key hashes and db indices.
   // Mainly used for defragmentation

--- a/src/server/tiering/small_bins.h
+++ b/src/server/tiering/small_bins.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "server/tiering/common.h"
 #include "server/tiering/disk_storage.h"
 #include "server/tiering/entry_map.h"
 
@@ -75,6 +76,9 @@ class SmallBins {
   // Delete a stored segment. Returns information about the current bin, which might indicate
   // the need for external actions like deleting empty segments or triggering defragmentation
   BinInfo Delete(DiskSegment segment);
+
+  // Returns true if the page exists and is fragmented
+  bool IsFragmented(uint32_t offset);
 
   // Delete stashed bin. Returns list of recovered item key hashes and db indices.
   // Mainly used for defragmentation

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -4,13 +4,11 @@ import logging
 import os
 from pathlib import Path
 
-import async_timeout
+from async_timeout import timeout
 import boto3
 import pytest
 import redis
 import random
-from async_timeout import timeout
-from azure.storage.blob import BlobServiceClient
 from pymemcache.client.base import Client as MCClient
 from redis import asyncio as aioredis
 
@@ -496,6 +494,8 @@ def _missing_azure_test_env():
 
 
 def delete_azure_objects(container, prefix):
+    from azure.storage.blob import BlobServiceClient
+
     conn_str = os.environ["AZURE_STORAGE_CONNECTION_STRING"]
     blob_service = BlobServiceClient.from_connection_string(conn_str)
     container_client = blob_service.get_container_client(container)
@@ -1108,7 +1108,7 @@ async def test_tagged_chunk_replication(df_factory, compression_mode: str):
     await asyncio.sleep(0.0)
 
     await cr.execute_command(f"REPLICAOF localhost {master.port}")
-    async with async_timeout.timeout(120):
+    async with timeout(120):
         await wait_for_replicas_state(cr)
 
     await seeder.stop(cm)

--- a/tests/dragonfly/snapshot_test.py
+++ b/tests/dragonfly/snapshot_test.py
@@ -287,7 +287,7 @@ async def test_parallel_snapshot(async_client):
         try:
             await async_client.execute_command("save", "rdb", "dump")
             return True
-        except Exception as e:
+        except Exception:
             return False
 
     save_successes = sum(await asyncio.gather(*(save() for _ in range(2))), 0)


### PR DESCRIPTION
1. Fix calculation bug where `db_size_->memory_budget()` returned **s**size_t, but it was cast to size_t and caused an overflow, stopping all offloading
2. When non-owned slots are flushed, a huge amount of DELs is issued which lead to a huge amount of fragmented bins, all of which are enqueued immediately for defragmentation, causing a memory spike. Limit defragmentation to a positive upload budget and at most 100 concurrent defrag operations. Otherwise, the offset is added to a delayed_defrag queue, which is processed later during offloading