### PR TITLE
fix(regtets): Increase test_big_huge_streaming_restart timeout

### DIFF
--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -3320,7 +3320,7 @@ async def test_big_huge_streaming_restart(df_factory: DflyInstanceFactory):
         await asyncio.sleep(random.random() + 0.5)
 
     # Wait for it to finish finally
-    async with async_timeout.timeout(60):
+    async with async_timeout.timeout(70):
         await wait_for_replicas_state(c_replica)
 
     # Check that everything is in sync


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Increase timeout for big streaming replication restart regression test
<code>🧪 Tests</code> <code>🐞 Bug fix</code> <code>🕐 Less than 5 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Increase timeout in flaky replication restart regression test.
• Reduce false negatives when replicas converge slower under load/CI variability.
</pre>
</details>

<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Condition-based wait with bounded retries</b></summary>

- ➕ Reduces reliance on fixed wall-clock timeouts
- ➕ Typically more stable across CI/load variance
- ➖ Requires updating helper(s) to expose progress/termination conditions
- ➖ More code than a simple timeout bump

</details>

<details>
<summary><b>2. Test-level performance isolation</b></summary>

- ➕ Keeps timeouts tight while reducing runtime variance (e.g., dedicated resources, reduced parallelism)
- ➕ Improves signal for genuine regressions
- ➖ CI configuration complexity and potential increased cost
- ➖ May not be feasible for all environments

</details>

**Recommendation:** The +10s timeout increase is a reasonable minimal fix for CI variability and should be accepted if it addresses observed flakes. If flakes persist, prefer moving toward condition-based waiting (bounded retries/backoff) so the test completes quickly when healthy but still tolerates slower convergence.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>replication_test.py</strong> <code>Bump timeout for big streaming restart test</code> <code>+1/-1</code></summary>

<br/>

>Bump timeout for big streaming restart test
>
><pre>
>• Increases the async timeout guarding replica state convergence from 60s to 70s in &#x27;test_big_huge_streaming_restart&#x27;, improving robustness against slower CI runs.
></pre>
>
><a href='https://github.com/dragonflydb/dragonfly/pull/7547/files#diff-f41a28e79426b76916ad0fb750e102f83955a92be0f24dda7ae4fda79d74ca8c'>tests/dragonfly/replication_test.py</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>