### PR TITLE
server: Simplify Flush - PrepareFlush interaction

### DIFF
--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -958,33 +958,29 @@ error_code RdbSerializer::WriteRaw(const io::Bytes& buf) {
   return error_code{};
 }
 
-io::Bytes RdbSerializer::PrepareFlush(FlushState flush_state) {
-  using enum CompressionMode;
-  auto* mem_buf = mem_buf_controller_.CurrentBuffer();
-  if (mem_buf_controller_.TagEntriesEnabled())
-    return mem_buf->InputBuffer();
-
-  const bool is_last_chunk = flush_state == FlushState::kFlushEndEntry;
-  const bool has_current_bytes = mem_buf->InputLen() != 0;
-  const bool is_compression_enabled =
-      compression_mode_ == MULTI_ENTRY_ZSTD || compression_mode_ == MULTI_ENTRY_LZ4;
-  VLOG(2) << "PrepareFlush: is_last_chunk" << is_last_chunk << " split=" << entry_was_split_;
-
-  // Legacy compressed blobs must contain a complete top-level RDB sequence, so only compress
-  // the current buffer when this is the only flush of an entry that never split. Otherwise, the
-  // latter half of an object might end up in its own compressed packet. The loader main loop will
-  // not be able to handle such values which begin from the middle.
-  if (is_last_chunk && !entry_was_split_ && is_compression_enabled && has_current_bytes)
-    CompressBlob();
-
-  entry_was_split_ = !is_last_chunk;
-
-  return mem_buf->InputBuffer();
-}
-
 string RdbSerializer::Flush(FlushState flush_state) {
-  const auto bytes = PrepareFlush(flush_state);
-  string result = mem_buf_controller_.BuildBlob(bytes);
+  using enum CompressionMode;
+  const IoBuf* mem_buf = mem_buf_controller_.CurrentBuffer();
+
+  if (!mem_buf_controller_.TagEntriesEnabled()) {
+    const bool is_last_chunk = flush_state == FlushState::kFlushEndEntry;
+    const bool has_current_bytes = mem_buf->InputLen() != 0;
+    const bool is_compression_enabled =
+        compression_mode_ == MULTI_ENTRY_ZSTD || compression_mode_ == MULTI_ENTRY_LZ4;
+    VLOG(2) << "Flush: is_last_chunk" << is_last_chunk << " split=" << entry_was_split_;
+
+    // Legacy compressed blobs must contain a complete top-level RDB sequence, so only compress
+    // the current buffer when this is the only flush of an entry that never split. Otherwise, the
+    // latter half of an object might end up in its own compressed packet. The loader main loop will
+    // not be able to handle such values which begin from the middle.
+    if (is_last_chunk && !entry_was_split_ && is_compression_enabled && has_current_bytes)
+      // replaces the current buffer with compressed content
+      CompressBlob();
+
+    entry_was_split_ = !is_last_chunk;
+  }
+
+  string result = mem_buf_controller_.BuildBlob();
   if (result.empty())
     return {};
 
@@ -1965,12 +1961,13 @@ void MemBufController::RestoreStateAfterConsume(EntryId id) {
   current_buffer_ = &entry_buffer_;
 }
 
-std::string MemBufController::BuildBlob(Bytes current_bytes) {
+std::string MemBufController::BuildBlob() {
   // default buffer always lies behind current bytes (entry buffer) in temporal sense, so it is
   // built as prefix. We can never reach here where default buffer content was written _after_ entry
   // buffer due to FinishEntry semantics.
+  const Bytes current_bytes = current_buffer_->InputBuffer();
   const bool has_prefix = current_buffer_ != &default_buffer_ && default_buffer_.InputLen() > 0;
-  const auto prefix = has_prefix ? default_buffer_.InputBuffer() : Bytes{};
+  const Bytes prefix = has_prefix ? default_buffer_.InputBuffer() : Bytes{};
 
   bool should_tag = send_tagged_entries_;
 

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -125,14 +125,12 @@ class MemBufController {
   // buffer to entry_buffer_.
   void RestoreStateAfterConsume(EntryId id);
 
-  // Assembles a flush blob in the following steps:
+  // Assembles a flush blob from the current buffer in the following steps:
   // 1. Prepends any data in the default buffer (from previously finished entries) as a prefix.
-  // 2. If the active entry was split, a tag header is inserted before current_bytes.
-  // 3. current_bytes is added.
+  // 2. If the active entry was split, a tag header is inserted before the current bytes.
+  // 3. Current bytes are added.
   // 4. Consumes all buffers used.
-  // current_bytes is typically CurrentBuffer()->InputBuffer(), passed explicitly because it works
-  // on data returned by PrepareFlush.
-  [[nodiscard]] std::string BuildBlob(io::Bytes current_bytes);
+  [[nodiscard]] std::string BuildBlob();
 
   void SetTagEntries(bool tag_entries) {
     send_tagged_entries_ = tag_entries;
@@ -332,9 +330,6 @@ class RdbSerializer {
   }
 
  private:
-  // Prepare internal buffer for flush. Compress it.
-  io::Bytes PrepareFlush(FlushState flush_state);
-
   void CompressBlob();
   void AllocateCompressorOnce();
 

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -1244,8 +1244,7 @@ class MemBufControllerTest : public Test {
   }
 
   std::string Flush() {
-    auto current = controller_.CurrentBuffer()->InputBuffer();
-    const auto blob = controller_.BuildBlob(current);
+    const auto blob = controller_.BuildBlob();
     EXPECT_EQ(controller_.FlushableSize(), 0);
     return blob;
   }


### PR DESCRIPTION
After recent changes for tagged chunk the interaction between PrepareFlush and Flush became a little convoluted, basically the two handled different levels of compression (tagged vs untagged). The code is simplified so that Flush handles compression differently based on the tagged chunk setting.

No functional changes.