### PR TITLE
server: Adds metric for connection memory bytes

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -179,6 +179,18 @@ struct ReadBufTracker {
   size_t last_capacity_;
 };
 
+struct ConnectionMemoryTracker {
+  explicit ConnectionMemoryTracker(Connection* conn) : conn_(conn) {
+  }
+
+  ~ConnectionMemoryTracker() {
+    conn_->RefreshConnectionMemoryUsage();
+  }
+
+ private:
+  Connection* conn_;
+};
+
 size_t UsedMemoryInternal(const ParsedCommand& msg) {
   return msg.GetSize() + msg.HeapMemory();
 }
@@ -1430,6 +1442,7 @@ Connection::ParserStatus Connection::ParseRedis(base::IoBuf& io_buf, uint32_t ma
   // TODO(kostas): follow up on this
   size_t total_consumed = 0;
   do {
+    bool stop_parsing = false;
     DCHECK(parsed_cmd_);
     result = redis_parser_->Parse(read_buffer, &consumed, parsed_cmd_);
     request_consumed_bytes_ += consumed;
@@ -1455,7 +1468,7 @@ Connection::ParserStatus Connection::ParseRedis(base::IoBuf& io_buf, uint32_t ma
         if (GetQueueBackpressure().IsPipelineBufferOverLimit(
                 GetLocalConnStats().pipeline_queue_bytes, parsed_cmd_q_len_)) {
           DVLOG(2) << "Pipeline buffer over limit, breaking from parsing loop.";
-          break;
+          stop_parsing = true;
         }
       } else {
         DispatchSingle(has_more, dispatch_sync, dispatch_async);
@@ -1464,8 +1477,13 @@ Connection::ParserStatus Connection::ParseRedis(base::IoBuf& io_buf, uint32_t ma
     if (result != RespSrvParser::OK && result != RespSrvParser::INPUT_PENDING) {
       // We do not expect that a replica sends an invalid command so we log if it happens.
       LOG_IF(WARNING, cntx()->replica_conn)
-          << "Redis parser error: " << result << " during parse: " << io::View(read_buffer);
+          << "Redis parser error: " << static_cast<unsigned int>(result)
+          << " during parse: " << io::View(read_buffer);
     }
+    RefreshConnectionMemoryUsage();
+    if (stop_parsing)
+      break;
+
     read_buffer.remove_prefix(consumed);
 
     // We must yield from time to time to allow other fibers to run.
@@ -1475,7 +1493,7 @@ Connection::ParserStatus Connection::ParseRedis(base::IoBuf& io_buf, uint32_t ma
       GetLocalConnStats().num_read_yields++;
       ThisFiber::Yield();
     }
-  } while (RespSrvParser::OK == result && read_buffer.size() > 0 && !reply_builder_->GetError());
+  } while (RespSrvParser::OK == result && !read_buffer.empty() && !reply_builder_->GetError());
 
   io_buf.ConsumeInput(total_consumed);
 
@@ -2431,8 +2449,36 @@ size_t Connection::GetMemoryUsage() const {
   return mem;
 }
 
+void Connection::RefreshConnectionMemoryUsage() {
+  if (!conn_stats_registered_)
+    return;
+
+  size_t current = account_connection_memory_ ? GetMemoryUsage() : 0;
+  auto& conn_stats = tl_facade_stats->conn_stats;
+
+  if (current >= accounted_connection_memory_bytes_) {
+    conn_stats.connection_memory_bytes += current - accounted_connection_memory_bytes_;
+  } else {
+    const size_t delta = accounted_connection_memory_bytes_ - current;
+    DCHECK_GE(conn_stats.connection_memory_bytes, delta);
+    conn_stats.connection_memory_bytes -= delta;
+  }
+
+  accounted_connection_memory_bytes_ = current;
+}
+
+void Connection::SetConnectionMemoryAccounting(bool enabled) {
+  if (account_connection_memory_ == enabled)
+    return;
+
+  account_connection_memory_ = enabled;
+  // reduce memory to 0 and tl stat contribution to 0 on enabled=false
+  RefreshConnectionMemoryUsage();
+}
+
 void Connection::IncreaseConnStats() {
   DCHECK(tl_facade_stats);
+  DCHECK(!conn_stats_registered_);
   auto& conn_stats = tl_facade_stats->conn_stats;
   if (IsMainOrMemcache())
     ++conn_stats.num_conns_main;
@@ -2449,11 +2495,22 @@ void Connection::IncreaseConnStats() {
     conn_stats.dispatch_queue_subscriber_bytes += dispatch_q_subscriber_bytes_;
     qbp.subscriber_bytes.fetch_add(dispatch_q_subscriber_bytes_, std::memory_order_relaxed);
   }
+
+  conn_stats_registered_ = true;
+  accounted_connection_memory_bytes_ = account_connection_memory_ ? GetMemoryUsage() : 0;
+  conn_stats.connection_memory_bytes += accounted_connection_memory_bytes_;
 }
 
 void Connection::DecreaseConnStats() {
   DCHECK(tl_facade_stats);
+  DCHECK(conn_stats_registered_);
   auto& conn_stats = tl_facade_stats->conn_stats;
+  RefreshConnectionMemoryUsage();
+  DCHECK_GE(conn_stats.connection_memory_bytes, accounted_connection_memory_bytes_);
+  conn_stats.connection_memory_bytes -= accounted_connection_memory_bytes_;
+  accounted_connection_memory_bytes_ = 0;
+  conn_stats_registered_ = false;
+
   if (IsMainOrMemcache()) {
     DCHECK_GT(conn_stats.num_conns_main, 0u);
     --conn_stats.num_conns_main;
@@ -2532,8 +2589,10 @@ Connection::ParserStatus Connection::ParseMCBatch(base::IoBuf& io_buf) {
 
     DVLOG(2) << "mc_result " << unsigned(result) << " consumed: " << consumed << " type "
              << unsigned(parsed_cmd_->mc_command()->type);
-    if (result == MemcacheParser::INPUT_PENDING)
+    if (result == MemcacheParser::INPUT_PENDING) {
+      RefreshConnectionMemoryUsage();
       return NEED_MORE;
+    }
 
     if (result == MemcacheParser::OK && tl_traffic_logger.log_file &&
         tl_traffic_logger.listener_type == listener_type_) {
@@ -2570,6 +2629,7 @@ Connection::ParserStatus Connection::ParseMCBatch(base::IoBuf& io_buf) {
           break;
       }
     }
+    RefreshConnectionMemoryUsage();
   } while (parsed_cmd_q_len_ < 128 && io_buf.InputLen() > 0);
   // Memcache parse errors are turned into deferred replies above, so we never return ERROR here.
   return OK;
@@ -2609,6 +2669,7 @@ bool Connection::ExecuteBatch() {
   // dispatch; it advances as commands are dispatched, and parsed_head_ advances with it whenever a
   // command retires (executes synchronously or replies immediately).
   while (parsed_to_execute_ != nullptr) {
+    ConnectionMemoryTracker memory_tracker(this);
     if (reply_builder_->GetError())
       return false;
 
@@ -2759,6 +2820,7 @@ void Connection::EnqueueParsedCommand(ParsedCommand* cmd) {
 }
 
 void Connection::ReleasePipelinedCommand(ParsedCommand* cmd) {
+  ConnectionMemoryTracker memory_tracker(this);
   auto& conn_stats = tl_facade_stats->conn_stats;
   conn_stats.pipelined_cmd_cnt++;
   uint64_t latency_usec = CycleClock::ToUsec(CycleClock::Now() - cmd->parsed_cycle);
@@ -2806,6 +2868,7 @@ void Connection::ReleaseParsedCommand(ParsedCommand* cmd) {
 }
 
 void Connection::DestroyParsedQueue() {
+  ConnectionMemoryTracker memory_tracker(this);
   while (parsed_head_ != nullptr) {
     auto* cmd = parsed_head_;
     parsed_head_ = cmd->next;

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -183,6 +183,9 @@ struct ConnectionMemoryTracker {
   explicit ConnectionMemoryTracker(Connection* conn) : conn_(conn) {
   }
 
+  ConnectionMemoryTracker(const ConnectionMemoryTracker&) = delete;
+  ConnectionMemoryTracker& operator=(const ConnectionMemoryTracker&) = delete;
+
   ~ConnectionMemoryTracker() {
     conn_->RefreshConnectionMemoryUsage();
   }
@@ -1763,6 +1766,7 @@ bool Connection::ShouldEndAsyncFiber(const MessageHandle& msg) {
 void Connection::SquashPipeline() {
   DCHECK_EQ(GetPendingMessageCount(), parsed_cmd_q_len_);
   DCHECK_EQ(reply_builder_->GetProtocol(), Protocol::REDIS);  // Only Redis is supported.
+  ConnectionMemoryTracker memory_tracker(this);
   unsigned pipeline_count = std::min<uint32_t>(parsed_cmd_q_len_, pipeline_squash_limit_cached);
   auto& conn_stats = tl_facade_stats->conn_stats;
 
@@ -1935,6 +1939,7 @@ bool Connection::ProcessAdminMessage(MessageHandle* msg, AsyncOperations* async_
 
 void Connection::ProcessPipelineCommandV1() {
   DCHECK(parsed_head_ && parsed_to_execute_) << DebugInfo();
+  ConnectionMemoryTracker memory_tracker(this);
   auto* cmd = parsed_to_execute_;
   AdvanceParsedHead(AdvanceToExecute());
 
@@ -2453,6 +2458,9 @@ void Connection::RefreshConnectionMemoryUsage() {
   if (!conn_stats_registered_)
     return;
 
+  DCHECK(socket());
+  DCHECK_EQ(socket()->proactor(), ProactorBase::me());
+
   size_t current = account_connection_memory_ ? GetMemoryUsage() : 0;
   ConnectionStats& conn_stats = GetLocalConnStats();
 
@@ -2460,8 +2468,13 @@ void Connection::RefreshConnectionMemoryUsage() {
     conn_stats.connection_memory_bytes += current - accounted_connection_memory_bytes_;
   } else {
     const size_t delta = accounted_connection_memory_bytes_ - current;
-    DCHECK_GE(conn_stats.connection_memory_bytes, delta);
-    conn_stats.connection_memory_bytes -= delta;
+    if (ABSL_PREDICT_FALSE(delta > conn_stats.connection_memory_bytes)) {
+      LOG(DFATAL) << "Connection memory accounting underflow: total="
+                  << conn_stats.connection_memory_bytes << " delta=" << delta;
+      conn_stats.connection_memory_bytes = 0;
+    } else {
+      conn_stats.connection_memory_bytes -= delta;
+    }
   }
 
   accounted_connection_memory_bytes_ = current;
@@ -2479,6 +2492,8 @@ void Connection::SetConnectionMemoryAccounting(bool enabled) {
 void Connection::IncreaseConnStats() {
   DCHECK(tl_facade_stats);
   DCHECK(!conn_stats_registered_);
+  DCHECK(socket());
+  DCHECK_EQ(socket()->proactor(), ProactorBase::me());
   auto& conn_stats = tl_facade_stats->conn_stats;
   if (IsMainOrMemcache())
     ++conn_stats.num_conns_main;
@@ -2506,8 +2521,14 @@ void Connection::DecreaseConnStats() {
   DCHECK(conn_stats_registered_);
   auto& conn_stats = tl_facade_stats->conn_stats;
   RefreshConnectionMemoryUsage();
-  DCHECK_GE(conn_stats.connection_memory_bytes, accounted_connection_memory_bytes_);
-  conn_stats.connection_memory_bytes -= accounted_connection_memory_bytes_;
+  if (ABSL_PREDICT_FALSE(accounted_connection_memory_bytes_ > conn_stats.connection_memory_bytes)) {
+    LOG(DFATAL) << "Connection memory accounting underflow on unregister: total="
+                << conn_stats.connection_memory_bytes
+                << " delta=" << accounted_connection_memory_bytes_;
+    conn_stats.connection_memory_bytes = 0;
+  } else {
+    conn_stats.connection_memory_bytes -= accounted_connection_memory_bytes_;
+  }
   accounted_connection_memory_bytes_ = 0;
   conn_stats_registered_ = false;
 
@@ -2644,6 +2665,7 @@ bool Connection::ExecuteBatch() {
     return true;  // no errors.
   }
 
+  ConnectionMemoryTracker memory_tracker(this);
   absl::Cleanup batch_guard = [this] { reply_builder_->SetBatchMode(false); };
   auto& conn_stats = tl_facade_stats->conn_stats;
 
@@ -2669,7 +2691,6 @@ bool Connection::ExecuteBatch() {
   // dispatch; it advances as commands are dispatched, and parsed_head_ advances with it whenever a
   // command retires (executes synchronously or replies immediately).
   while (parsed_to_execute_ != nullptr) {
-    ConnectionMemoryTracker memory_tracker(this);
     if (reply_builder_->GetError())
       return false;
 
@@ -2743,6 +2764,7 @@ bool Connection::ReplyBatch() {
   if (!HasInFlightCommands())
     return true;
 
+  ConnectionMemoryTracker memory_tracker(this);
   reply_builder_->SetBatchMode(true);
   absl::Cleanup batch_guard = [this] { reply_builder_->SetBatchMode(false); };
   while (parsed_head_->CanReply()) {
@@ -2820,7 +2842,6 @@ void Connection::EnqueueParsedCommand(ParsedCommand* cmd) {
 }
 
 void Connection::ReleasePipelinedCommand(ParsedCommand* cmd) {
-  ConnectionMemoryTracker memory_tracker(this);
   auto& conn_stats = tl_facade_stats->conn_stats;
   conn_stats.pipelined_cmd_cnt++;
   uint64_t latency_usec = CycleClock::ToUsec(CycleClock::Now() - cmd->parsed_cycle);

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -2454,7 +2454,7 @@ void Connection::RefreshConnectionMemoryUsage() {
     return;
 
   size_t current = account_connection_memory_ ? GetMemoryUsage() : 0;
-  auto& conn_stats = tl_facade_stats->conn_stats;
+  ConnectionStats& conn_stats = GetLocalConnStats();
 
   if (current >= accounted_connection_memory_bytes_) {
     conn_stats.connection_memory_bytes += current - accounted_connection_memory_bytes_;

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -264,6 +264,13 @@ class Connection : public util::Connection {
 
   ConnectionContext* cntx();
 
+  // For non replication connections refresh memory usage field as well as update tl stats if conn.
+  // is still live.
+  void RefreshConnectionMemoryUsage();
+
+  // Sets to false on switching to replication to remove accounting for direct bytes
+  void SetConnectionMemoryAccounting(bool enabled);
+
   // Requests that at some point, this connection will be migrated to `dest` thread.
   // If force is false, the connection will migrate at most once,
   // and only when the flag --migrate_connections is true.
@@ -605,6 +612,13 @@ class Connection : public util::Connection {
   uint32_t id_;
   Protocol protocol_;
   Phase phase_ = SETUP;
+  // memory is not accounted before this flag is set in IncreaseConnStats
+  // to prevent duplicate increment etc before migration
+  bool conn_stats_registered_ = false;
+  // should conn. memory be counted at all, replication conn. is counted separately so this is set
+  // to false
+  bool account_connection_memory_ = true;
+  size_t accounted_connection_memory_bytes_ = 0;
 
   struct {
     size_t read_cnt = 0;                // total number of read calls

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -612,12 +612,18 @@ class Connection : public util::Connection {
   uint32_t id_;
   Protocol protocol_;
   Phase phase_ = SETUP;
-  // memory is not accounted before this flag is set in IncreaseConnStats
-  // to prevent duplicate increment etc before migration
+
+  // True after IncreaseConnStats registers this connection in the current thread's stats.
+  // False before registration and after DecreaseConnStats unregisters it during close/migration.
   bool conn_stats_registered_ = false;
-  // should conn. memory be counted at all, replication conn. is counted separately so this is set
-  // to false
+
+  // True while this connection contributes to connection_memory_bytes. Set false for
+  // replication-flow connections, whose direct memory is excluded from the client connection
+  // metric.
   bool account_connection_memory_ = true;
+
+  // Last value this connection contributed to connection_memory_bytes. Refreshes compare the
+  // current memory usage with this baseline and apply only the delta to the thread-local total.
   size_t accounted_connection_memory_bytes_ = 0;
 
   struct {

--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -23,9 +23,10 @@ using namespace std;
 constexpr size_t kSizeConnStats = sizeof(ConnectionStats);
 
 ConnectionStats& ConnectionStats::operator+=(const ConnectionStats& o) {
-  static_assert(kSizeConnStats == 272);
+  static_assert(kSizeConnStats == 280);
 
   ADD(read_buf_capacity);
+  ADD(connection_memory_bytes);
   ADD(dispatch_queue_entries);
   ADD(dispatch_queue_bytes);
   ADD(pipeline_queue_entries);

--- a/src/facade/facade_stats.h
+++ b/src/facade/facade_stats.h
@@ -14,6 +14,7 @@ namespace facade {
 
 struct ConnectionStats {
   size_t read_buf_capacity = 0;  // total capacity of input buffers
+  size_t connection_memory_bytes = 0;
   // Count of pending messages in dispatch queue
   uint64_t dispatch_queue_entries = 0;
   // Memory used by pending messages in dispatch queue

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -303,6 +303,7 @@ void DflyCmd::Flow(CmdArgList args, CommandContext* cmd_cntx) {
 
     auto& flow = replica_ptr->GetFlow(flow_id);
     conn_cntx->master_repl_flow = &flow;
+    conn_cntx->conn()->SetConnectionMemoryAccounting(false);
     flow.conn = cmd_cntx->conn();
     flow.eof_token = eof_token;
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1792,6 +1792,9 @@ void PrintPrometheusMetrics(uint64_t uptime, const Metrics& m, DflyCmd* dfly_cmd
                             &resp->body());
   AppendMetricWithoutLabels("memory_used_peak_bytes", "", m.used_mem_peak, MetricType::GAUGE,
                             &resp->body());
+  AppendMetricWithoutLabels("connection_memory_bytes",
+                            "Memory used directly by active client connections",
+                            conn_stats.connection_memory_bytes, MetricType::GAUGE, &resp->body());
   AppendMetricWithoutLabels("fibers_count", "", m.worker_fiber_count, MetricType::GAUGE,
                             &resp->body());
   AppendMetricWithoutLabels("blocked_tasks", "", m.blocked_tasks, MetricType::GAUGE, &resp->body());
@@ -1981,6 +1984,9 @@ void PrintPrometheusMetrics(uint64_t uptime, const Metrics& m, DflyCmd* dfly_cmd
 
   AppendMetricValue("memory_by_class_bytes", conn_stats.read_buf_capacity, {"class"},
                     {"client_read_buffer"}, &memory_by_class_bytes);
+
+  AppendMetricValue("memory_by_class_bytes", conn_stats.connection_memory_bytes, {"class"},
+                    {"connection"}, &memory_by_class_bytes);
 
   AppendMetricValue("memory_by_class_bytes", total.table_mem_usage, {"class"}, {"table_used"},
                     &memory_by_class_bytes);

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1792,9 +1792,11 @@ void PrintPrometheusMetrics(uint64_t uptime, const Metrics& m, DflyCmd* dfly_cmd
                             &resp->body());
   AppendMetricWithoutLabels("memory_used_peak_bytes", "", m.used_mem_peak, MetricType::GAUGE,
                             &resp->body());
-  AppendMetricWithoutLabels("connection_memory_bytes",
-                            "Memory used directly by active client connections",
-                            conn_stats.connection_memory_bytes, MetricType::GAUGE, &resp->body());
+  AppendMetricWithoutLabels(
+      "connection_memory_bytes",
+      "Approximate direct memory used by active non-replication-flow connections, excluding "
+      "separately tracked read buffers and queues.",
+      conn_stats.connection_memory_bytes, MetricType::GAUGE, &resp->body());
   AppendMetricWithoutLabels("fibers_count", "", m.worker_fiber_count, MetricType::GAUGE,
                             &resp->body());
   AppendMetricWithoutLabels("blocked_tasks", "", m.blocked_tasks, MetricType::GAUGE, &resp->body());

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -995,6 +995,14 @@ async def test_parser_memory_stats(df_server, async_client: aioredis.Redis):
         stats = await async_client.execute_command("memory stats")
         assert stats["connections.direct_bytes"] > 130000
 
+        metrics = await df_server.metrics()
+        connection_memory_bytes = metrics["dragonfly_connection_memory_bytes"].samples[0].value
+        assert connection_memory_bytes > 130000
+        assert any(
+            sample.labels["class"] == "connection" and sample.value == connection_memory_bytes
+            for sample in metrics["dragonfly_memory_by_class_bytes"].samples
+        )
+
     await check_stats()
 
 


### PR DESCRIPTION
Adds new metric connection_memory_bytes
Exposed as dragonfly_connection_memory_bytes

The metric is sourced from new thread local field `ConnectionStats::connection_memory_bytes`
Each connection is responsible for updating the tl field at appropriate points. Currently we update the metric on the following spots

* ParseRedis
* ParseMCBatch
* ExecuteBatch
* ReleaseParsedCommand
* DestroyParsedQueue

Some are updated via a new RAII helper and some explicitly.
Connection memory is only added after `IncreaseConnStats` call and before `DecreaseConnStats`
If a connection is used for replication (ie `conn_cntx->master_repl_flow != nullptr`) then it is not tracked in this metric and its current contributions are deducted. There is a separate metric for replication bytes