### PR TITLE
chore: add check-ast and pyflakes pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,12 +19,19 @@ repos:
         entry: contrib/scripts/signed-commit
         language: script
         stages: [commit-msg]
+      - id: pyflakes
+        name: pyflakes
+        entry: pyflakes
+        language: python
+        additional_dependencies: [pyflakes==3.4.0]
+        types: [python]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+      - id: check-ast
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v14.0.6


### PR DESCRIPTION
- Add `check-ast` to the gate that changed Python files' parse (catches SyntaxError that black does not guarantee to surface)
- Add a local `pyflakes` hook (pinned 3.4.0) to catch undefined names and unused imports in changed Python files

Why:
CI runs only black and clang-format; there is no explicit check that changed .py files parse or are statically sound. These hooks run on changed files in CI via the existing pre-commit job.

Notes:
- check-ast reuses the already-pinned pre-commit/pre-commit-hooks v4.3.0 repo
- pyflakes is a local hook because PyCQA/pyflakes ships no pre-commit manifest
- pyflakes runs per changed file, so existing findings in tools/*.py surface only when those files are next edited