### PR TITLE
fix(search): drop stopwords from query terms in FT.SEARCH

### DIFF
--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -8,6 +8,7 @@
 #include <absl/container/flat_hash_set.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_join.h>
+#include <uni_algo/case.h>
 
 #include <chrono>
 #include <type_traits>
@@ -497,8 +498,18 @@ struct BasicSearch {
 
   // logical query: unify all sub results
   IndexResult Search(const AstLogicalNode& node, string_view active_field) {
-    auto mapping = [&](auto& node) { return SearchGeneric(node, active_field); };
-    return UnifyResults(GetSubResults(node.nodes, mapping), node.op);
+    // Stopwords are never indexed, so a bare stopword operand matches nothing: as an AND term it
+    // would zero the whole result (e.g. `@title:(foo) and bar`), as an OR term it adds nothing.
+    // Drop such operands so the surrounding query still matches.
+    vector<IndexResult> sub_results;
+    sub_results.reserve(node.nodes.size());
+    for (const auto& sub : node.nodes) {
+      if (const auto* term = get_if<AstTermNode>(&sub.Variant());
+          term && indices_->IsStopWord(term->affix))
+        continue;
+      sub_results.push_back(SearchGeneric(sub, active_field));
+    }
+    return UnifyResults(std::move(sub_results), node.op);
   }
 
   // @field: set active field for sub tree
@@ -849,6 +860,11 @@ struct StatsCollector {
   }
 
   void Visit(const AstTermNode& node, string_view active_field) {
+    // Stopwords are dropped from queries (see BasicSearch), so they never contribute matches and
+    // must not be recorded as scoring terms either.
+    if (indices_->IsStopWord(node.affix))
+      return;
+
     string term = node.affix;
     bool strip_whitespace = true;
     if (auto* syn = indices_->GetSynonyms(); syn) {
@@ -1136,6 +1152,12 @@ DefragmentResult FieldIndices::Defragment(PageUsage* page_usage) {
 
 const Synonyms* FieldIndices::GetSynonyms() const {
   return synonyms_;
+}
+
+bool FieldIndices::IsStopWord(std::string_view term) const {
+  if (options_.stopwords.empty())
+    return false;
+  return options_.stopwords.contains(una::cases::to_lowercase_utf8(term));
 }
 
 SearchAlgorithm::SearchAlgorithm() = default;

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -155,6 +155,10 @@ class FieldIndices {
 
   const Synonyms* GetSynonyms() const;
 
+  // True if `term` (case-folded) is a stopword for this index. Mirrors the index-time stopword
+  // check so query terms that are stopwords can be dropped instead of matching nothing.
+  bool IsStopWord(std::string_view term) const;
+
   SortableValue GetSortIndexValue(DocId doc, std::string_view field_identifier) const;
 
   void FinalizeInitialization();

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -550,6 +550,46 @@ TEST_F(SearchTest, StopWords) {
   EXPECT_THAT(algo.Search(&indices).ids, testing::UnorderedElementsAre(1, 3));
 }
 
+// A stopword among query terms must be dropped, not kept as a required term. Otherwise the
+// implicit-AND query reduces to an empty result because stopwords are never indexed.
+TEST_F(SearchTest, StopWordsDroppedFromQuery) {
+  auto schema = MakeSimpleSchema({{"title", SchemaField::TEXT}});
+  IndicesOptions options{{"some", "words", "are", "left", "out"}};
+
+  FieldIndices indices{schema, options, PMR_NS::get_default_resource(), nullptr};
+  SearchAlgorithm algo{};
+  QueryParams params;
+
+  vector<string> documents = {"some words left out",      //
+                              "some can be found",        //
+                              "words are never matched",  //
+                              "explicitly found!"};
+  for (size_t i = 0; i < documents.size(); i++) {
+    MockedDocument doc{{{"title", documents[i]}}};
+    indices.Add(i, doc);
+  }
+
+  // Trailing stopword is dropped -> query behaves like "found".
+  algo.Init("found some", &params);
+  EXPECT_THAT(algo.Search(&indices).ids, testing::UnorderedElementsAre(1, 3));
+
+  // Stopword between two real terms is dropped -> "explicitly found".
+  algo.Init("explicitly are found", &params);
+  EXPECT_THAT(algo.Search(&indices).ids, testing::UnorderedElementsAre(3));
+
+  // Stopword as an OR operand contributes nothing; the real operand still matches.
+  algo.Init("found | some", &params);
+  EXPECT_THAT(algo.Search(&indices).ids, testing::UnorderedElementsAre(1, 3));
+
+  // Field-scoped group with a trailing stopword still matches.
+  algo.Init("@title:(found are)", &params);
+  EXPECT_THAT(algo.Search(&indices).ids, testing::UnorderedElementsAre(1, 3));
+
+  // A non-stopword term still constrains the result as usual.
+  algo.Init("found matched", &params);
+  EXPECT_THAT(algo.Search(&indices).ids, testing::UnorderedElementsAre());
+}
+
 class SearchRaxTest
     : public SearchTest,
       public testing::WithParamInterface<pair<bool /* build suffix trie */, bool /* tag index */>> {

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -1133,6 +1133,35 @@ TEST_F(SearchFamilyTest, TestStopWords) {
   EXPECT_THAT(Run({"ft.search", "i1", "whale"}), AreDocIds("d:3"));
 }
 
+// A default stopword (the, and, or, ...) appearing in a query must be dropped rather than kept
+// as a required term, otherwise the implicit-AND query silently returns no results. This unblocks
+// query builders that join clauses with the literal word " AND " (relying on it being a stopword).
+TEST_F(SearchFamilyTest, StopWordsInQueryAreDropped) {
+  Run({"ft.create", "idx", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "content", "TEXT",
+       "user_id", "TAG"});
+
+  Run({"hset", "d:1", "content", "python", "user_id", "u1"});
+  Run({"hset", "d:2", "content", "rust", "user_id", "u2"});
+
+  // Trailing default stopword must be dropped (issue #7556 reproduction).
+  EXPECT_THAT(Run({"ft.search", "idx", "@content:(python) and"}), AreDocIds("d:1"));
+
+  // Case-insensitive: an uppercased stopword is recognized too.
+  EXPECT_THAT(Run({"ft.search", "idx", "@content:(python) AND"}), AreDocIds("d:1"));
+
+  // Query-builder style join: text clause AND tag filter glued by the literal " AND ".
+  EXPECT_THAT(Run({"ft.search", "idx", "@content:(python) AND @user_id:{u1}"}), AreDocIds("d:1"));
+  EXPECT_THAT(Run({"ft.search", "idx", "@content:(python) AND @user_id:{u2}"}), kNoResults);
+
+  // A non-stopword tail still constrains and yields no match.
+  EXPECT_THAT(Run({"ft.search", "idx", "@content:(python) xyzzy"}), kNoResults);
+
+  // STOPWORDS 0 disables the default list, so the same term is required again and matches nothing.
+  Run({"ft.create", "idx0", "ON", "HASH", "PREFIX", "1", "d:", "STOPWORDS", "0", "SCHEMA",
+       "content", "TEXT"});
+  EXPECT_THAT(Run({"ft.search", "idx0", "@content:(python) and"}), kNoResults);
+}
+
 TEST_F(SearchFamilyTest, SimpleUpdates) {
   EXPECT_EQ(Run({"ft.create", "i1", "schema", "title", "text", "visits", "numeric"}), "OK");
 


### PR DESCRIPTION
Stopwords were applied at index time but never to query terms, so a stopword like `and` or `the` was kept as a required term. Since stopwords are never indexed, the implicit-AND query matched nothing and silently returned 0 results (e.g. `@content:(python) and` -> empty). This filters query stopwords against the index's stopword set, so they are dropped instead of being required.

Changes:
- Add `FieldIndices::IsStopWord` (case-folded, mirrors the index-time check).
- Drop stopword operands in the logical (AND/OR) executor and skip them when collecting scoring stats.
- Works for both the default and `FT.CREATE STOPWORDS` lists; `STOPWORDS 0` leaves the set empty, so no query-side filtering is applied.
- Add C++ unit and end-to-end regression tests.

Fixes: #7556