### PR TITLE
test: re-enable test_reply_count for V1

### DIFF
--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -662,11 +662,8 @@ async def test_keyspace_events_config_set(async_client: aioredis.Redis):
             await collect_expiring_events(pclient, keys)
 
 
-@pytest.mark.skip("Fails constantly on CI")
-@dfly_multi_test_args(
-    {"max_busy_read_usec": 50000, "enable_resp_io_loop_v2": "false"},
-    {"max_busy_read_usec": 50000, "enable_resp_io_loop_v2": "true"},
-)
+# TODO(#7505): add enable_resp_io_loop_v2=true once V2 flush density improves.
+@dfly_args({"max_busy_read_usec": 50000, "enable_resp_io_loop_v2": "false"})
 async def test_reply_count(df_server: DflyInstance):
     """Make sure reply aggregations reduce reply counts for common cases"""
 
@@ -709,6 +706,7 @@ async def test_reply_count(df_server: DflyInstance):
     # MULTI-OK + the EXEC array.
     # V1 (dual-fiber) is aggressive (<=2).
     # V2 (single-fiber): MULTI/OK may flush separately before the EXEC batch (<=3).
+    # TODO(#7505): tighten multi_limit for V2 once flush density improves.
     is_v2 = is_resp_io_loop_v2(df_server)
     multi_limit = 3 if is_v2 else 2
     assert await measure(e.execute()) <= multi_limit
@@ -719,11 +717,9 @@ async def test_reply_count(df_server: DflyInstance):
         p.incr("num-1")
 
     # V1: aggressive squashing across dual fibers (<=2).
-    # V2: conditional flushing defers flush when pending_input_ or io_buf_ has data,
-    # but fast synchronous commands (INCR) don't yield, so io_uring completions aren't processed
-    # mid-batch. Task 2 (Epoch Yield) will fix this by yielding before flush. Until then, V2
-    # flushes based on TCP segment boundaries (<=12).
-    pipe_limit = 12 if is_v2 else 2
+    # V2: flush density is poor and under active development; see #7505.
+    # TODO(#7505): tighten this limit once V2 flush aggregation improves.
+    pipe_limit = 20 if is_v2 else 2
     pipe_flushes = await measure(p.execute())
     assert pipe_flushes <= pipe_limit
 


### PR DESCRIPTION
The test was previously skipped entirely. It is now re-enabled for V1, which correctly aggregates replies (<=2 flushes for 100 INCRs).

V2 remains skipped - flush density for V2 is not a current focus and will be addressed separately. See #7505.
