### PR TITLE
chore: introduce CmdRef and generator-based MultiCommandSquasher

### DIFF
--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -65,6 +65,14 @@ StoredCmd::StoredCmd(const CommandId* cid, facade::ArgSlice args, facade::ReplyM
   args_ = facade::ParsedArgs{*backed_};
 }
 
+StoredCmd::StoredCmd(const CommandId* cid, cmn::BackedArguments* src, uint8_t tail_index,
+                     facade::ReplyMode mode)
+    : cid_{cid}, reply_mode_{mode} {
+  backed_ = std::make_unique<cmn::BackedArguments>();
+  backed_->SwapArgs(*src);
+  args_ = facade::ParsedArgs{*backed_, tail_index};
+}
+
 CmdArgList StoredCmd::Slice(CmdArgVec* scratch) const {
   return args_.ToSlice(scratch);
 }
@@ -74,6 +82,10 @@ std::string StoredCmd::FirstArg() const {
     return {};
   }
   return string{args_.Front()};
+}
+
+CmdRef StoredCmd::Ref() const {
+  return CmdRef{cid_, args_, reply_mode_};
 }
 
 ConnectionContext::ConnectionContext(facade::Connection* owner, acl::UserCredentials cred)
@@ -170,12 +182,6 @@ void ConnectionContext::PUnsubscribeAll(bool to_reply, facade::RedisReplyBuilder
 
 size_t ConnectionState::ExecInfo::UsedMemory() const {
   return HeapSize(body) + HeapSize(watched_keys);
-}
-
-void ConnectionState::ExecInfo::AddStoredCmd(const CommandId* cid, ArgSlice args) {
-  body.emplace_back(cid, args);
-  stored_cmd_bytes += body.back().UsedMemory();
-  is_write |= cid->IsJournaled();
 }
 
 size_t ConnectionState::ExecInfo::ClearStoredCmds() {

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -21,6 +21,22 @@ class ChannelStore;
 class Interpreter;
 struct FlowInfo;
 
+// Non-owning view of a command for the squasher. Can be constructed from StoredCmd or
+// CommandContext.
+struct CmdRef {
+  const CommandId* cid = nullptr;
+  facade::ParsedArgs args;
+  facade::ReplyMode reply_mode = facade::ReplyMode::FULL;
+
+  bool IsValid() const {
+    return cid != nullptr;
+  }
+
+  facade::ArgSlice Slice(CmdArgVec* scratch) const {
+    return args.ToSlice(scratch);
+  }
+};
+
 // Stores command id and arguments for delayed invocation.
 // Used for storing MULTI/EXEC commands.
 class StoredCmd {
@@ -28,10 +44,10 @@ class StoredCmd {
   // Deep copy of args, creates backing storage internally.
   StoredCmd(const CommandId* cid, ArgSlice args, facade::ReplyMode mode = facade::ReplyMode::FULL);
 
-  // Shallow copy of args.
-  StoredCmd(const CommandId* cid, facade::ParsedArgs args)
-      : cid_{cid}, args_{args}, reply_mode_(facade::ReplyMode::FULL) {
-  }
+  // Moves args from src via swap. src's BackedArguments will be empty after this.
+  // tail_index specifies how many leading args to skip (e.g., 1 to skip the command name).
+  StoredCmd(const CommandId* cid, cmn::BackedArguments* src, uint8_t tail_index,
+            facade::ReplyMode mode = facade::ReplyMode::FULL);
 
   size_t NumArgs() const {
     return args_.size();
@@ -54,6 +70,8 @@ class StoredCmd {
   facade::ReplyMode ReplyMode() const {
     return reply_mode_;
   }
+
+  CmdRef Ref() const;
 
  private:
   const CommandId* cid_;     // underlying command
@@ -89,9 +107,6 @@ struct ConnectionState {
     void ClearWatched();
 
     size_t UsedMemory() const;
-
-    // Deep copies arguments and updates the stored_cmd_bytes.
-    void AddStoredCmd(const CommandId* cid, ArgSlice args);
 
     // Empties the body vector and resets stored_cmd_bytes to 0. Returns the size before data was
     // cleared.

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -880,11 +880,16 @@ pair<intrusive_ptr<Transaction>, OpStatus> PrepareTransaction(const CommandId* c
   return {std::move(res), OpStatus::OK};
 }
 
-void StoreInMultiBlock(ConnectionContext* dfly_cntx, const CommandId* cid, ArgSlice tail_args) {
+void StoreInMultiBlock(ConnectionContext* dfly_cntx, const CommandId* cid,
+                       facade::ParsedCommand* parsed_cmd, uint8_t tail_index) {
   // TODO: protect against aggregating huge transactions.
   auto& exec_info = dfly_cntx->conn_state.exec_info;
   const size_t old_size = exec_info.GetStoredCmdBytes();
-  exec_info.AddStoredCmd(cid, tail_args);  // Deep copy of args.
+
+  // Moves arguments from parsed_cmd to body.
+  exec_info.body.emplace_back(cid, parsed_cmd, tail_index);
+  exec_info.stored_cmd_bytes += exec_info.body.back().UsedMemory();
+  exec_info.is_write |= cid->IsJournaled();
   ServerState::tlocal()->stats.stored_cmd_bytes += exec_info.GetStoredCmdBytes() - old_size;
 }
 
@@ -1550,7 +1555,8 @@ DispatchResult Service::DispatchCommand(facade::ParsedArgs args, facade::ParsedC
   // If inside MULTI block, store command
   bool is_trans_cmd = cid->MultiControlKind() == CO::MultiControlKind::EXEC;
   if (dfly_cntx->conn_state.exec_info.IsCollecting() && !is_trans_cmd) {
-    StoreInMultiBlock(dfly_cntx, cid, tail_args);
+    uint8_t tail_index = args.size() - args_no_cmd.size();
+    StoreInMultiBlock(dfly_cntx, cid, parsed_cmd, tail_index);
     cmd_cntx->SendSimpleString("QUEUED");
     return DispatchResult::OK;
   }
@@ -1722,7 +1728,7 @@ DispatchManyResult Service::DispatchManyCommands(facade::ParsedCommand* head, un
   if (ss->IsPaused())
     return {.processed = 0, .account_in_stats = false};
 
-  vector<StoredCmd> stored_cmds;
+  vector<CmdRef> cmd_refs;
   intrusive_ptr<Transaction> dist_trans;
   uint32_t dispatched = 0;
   MultiCommandSquasher::Stats stats;
@@ -1730,7 +1736,7 @@ DispatchManyResult Service::DispatchManyCommands(facade::ParsedCommand* head, un
   uint64_t start_cycles = base::CycleClock::Now();
 
   auto perform_squash = [&] {
-    if (stored_cmds.empty())
+    if (cmd_refs.empty())
       return;
 
     if (!dist_trans) {
@@ -1746,13 +1752,15 @@ DispatchManyResult Service::DispatchManyCommands(facade::ParsedCommand* head, un
     opts.verify_commands = true;
     opts.max_squash_size = ss->max_squash_cmd_num;
 
-    stats += MultiCommandSquasher::Execute(absl::MakeSpan(stored_cmds),
-                                           static_cast<RedisReplyBuilder*>(builder), dfly_cntx,
-                                           this, opts);
+    auto cmd_gen = [it = cmd_refs.begin(), end = cmd_refs.end()]() mutable -> CmdRef {
+      return (it == end) ? CmdRef{} : *it++;
+    };
+    stats += MultiCommandSquasher::Execute(
+        std::move(cmd_gen), static_cast<RedisReplyBuilder*>(builder), dfly_cntx, this, opts);
     dfly_cntx->transaction = nullptr;
 
-    dispatched += stored_cmds.size();
-    stored_cmds.clear();
+    dispatched += cmd_refs.size();
+    cmd_refs.clear();
   };
 
   for (unsigned i = 0; i < count; i++) {
@@ -1778,8 +1786,8 @@ DispatchManyResult Service::DispatchManyCommands(facade::ParsedCommand* head, un
     const bool is_blocking = cid != nullptr && cid->IsBlocking();
 
     if (!is_multi && !is_eval && !is_blocking && cid != nullptr) {
-      stored_cmds.reserve(count);
-      stored_cmds.emplace_back(cid, tail_args);  // Shallow copy
+      cmd_refs.reserve(count);
+      cmd_refs.push_back(CmdRef{cid, tail_args});
       continue;
     }
 
@@ -1962,7 +1970,10 @@ optional<CapturingReplyBuilder::Payload> Service::FlushEvalAsyncCmds(ConnectionC
   opts.verify_commands = true;
   opts.error_abort = true;
   opts.max_squash_size = ServerState::tlocal()->max_squash_cmd_num;
-  MultiCommandSquasher::Execute(absl::MakeSpan(info->async_cmds), &crb, cntx, this, opts);
+  auto cmd_gen = [it = info->async_cmds.begin(), end = info->async_cmds.end()]() mutable -> CmdRef {
+    return (it == end) ? CmdRef{} : (it++)->Ref();
+  };
+  MultiCommandSquasher::Execute(std::move(cmd_gen), &crb, cntx, this, opts);
 
   info->async_cmds_heap_mem = 0;
   info->async_cmds.clear();
@@ -2487,9 +2498,12 @@ void Service::Exec(CmdArgList args, CommandContext* cmd_cntx) {
 
     if (GetFlag(FLAGS_multi_exec_squash) && state != ExecScriptUse::SCRIPT_RUN &&
         !cntx->conn_state.tracking_info_.IsTrackingOn()) {
+      auto cmd_gen = [it = exec_info.body.begin(), end = exec_info.body.end()]() mutable -> CmdRef {
+        return (it == end) ? CmdRef{} : (it++)->Ref();
+      };
       MultiCommandSquasher::Opts opts;
       opts.max_squash_size = ServerState::tlocal()->max_squash_cmd_num;
-      MultiCommandSquasher::Execute(absl::MakeSpan(exec_info.body), rb, cntx, this, opts);
+      MultiCommandSquasher::Execute(std::move(cmd_gen), rb, cntx, this, opts);
     } else {
       CmdArgVec arg_vec;
       DCHECK_EQ(cmd_cntx->cid(), exec_cid_);

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -71,9 +71,13 @@ MultiCommandSquasher::Stats& MultiCommandSquasher::Stats::operator+=(const Stats
   return *this;
 }
 
-MultiCommandSquasher::MultiCommandSquasher(absl::Span<StoredCmd> cmds, ConnectionContext* cntx,
+MultiCommandSquasher::MultiCommandSquasher(CmdGenerator cmd_gen, ConnectionContext* cntx,
                                            Service* service, const Opts& opts)
-    : cmds_{cmds}, cntx_{cntx}, service_{service}, base_cid_{nullptr}, opts_{opts} {
+    : cmd_gen_{std::move(cmd_gen)},
+      cntx_{cntx},
+      service_{service},
+      base_cid_{nullptr},
+      opts_{opts} {
   auto mode = cntx->transaction->GetMultiMode();
   base_cid_ = cntx->transaction->GetCId();
   atomic_ = mode != Transaction::NON_ATOMIC;
@@ -103,10 +107,10 @@ MultiCommandSquasher::ShardExecInfo& MultiCommandSquasher::PrepareShardInfo(Shar
   return sinfo;
 }
 
-MultiCommandSquasher::SquashResult MultiCommandSquasher::TrySquash(const StoredCmd* cmd) {
-  DCHECK(cmd->Cid());
+MultiCommandSquasher::SquashResult MultiCommandSquasher::TrySquash(CmdRef cmd) {
+  DCHECK(cmd.cid);
 
-  const CommandId& cid = *cmd->Cid();
+  const CommandId& cid = *cmd.cid;
   if (!cid.IsTransactional() || (cid.opt_mask() & CO::BLOCKING) ||
       (cid.opt_mask() & CO::GLOBAL_TRANS))
     return SquashResult::NOT_SQUASHED;
@@ -115,7 +119,7 @@ MultiCommandSquasher::SquashResult MultiCommandSquasher::TrySquash(const StoredC
     return SquashResult::NOT_SQUASHED;
   }
 
-  auto args = cmd->Slice(&tmp_keylist_);
+  auto args = cmd.Slice(&tmp_keylist_);
   if (args.empty())
     return SquashResult::NOT_SQUASHED;
 
@@ -154,21 +158,21 @@ MultiCommandSquasher::SquashResult MultiCommandSquasher::TrySquash(const StoredC
   return need_flush ? SquashResult::SQUASHED_FULL : SquashResult::SQUASHED;
 }
 
-bool MultiCommandSquasher::ExecuteStandalone(RedisReplyBuilder* rb, const StoredCmd* cmd) {
+bool MultiCommandSquasher::ExecuteStandalone(RedisReplyBuilder* rb, CmdRef cmd) {
   DCHECK(order_.empty());  // check no squashed chain is interrupted
 
-  auto args = cmd->Slice(&tmp_keylist_);
+  auto args = cmd.Slice(&tmp_keylist_);
 
   if (opts_.verify_commands) {
-    if (auto err = service_->VerifyCommandState(*cmd->Cid(), args, *cntx_); err) {
+    if (auto err = service_->VerifyCommandState(*cmd.cid, args, *cntx_); err) {
       rb->SendError(std::move(*err));
       return !opts_.error_abort;
     }
   }
 
   auto* tx = cntx_->transaction;
-  if (cmd->Cid()->IsTransactional()) {
-    tx->MultiSwitchCmd(cmd->Cid());
+  if (cmd.cid->IsTransactional()) {
+    tx->MultiSwitchCmd(cmd.cid);
     auto status = tx->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, args);
     if (status != OpStatus::OK) {
       rb->SendError(status);
@@ -176,8 +180,8 @@ bool MultiCommandSquasher::ExecuteStandalone(RedisReplyBuilder* rb, const Stored
     }
   }
   CommandContext cmd_cntx{rb, cntx_};
-  cmd_cntx.SetupTx(cmd->Cid(), tx);
-  cmd_cntx.SetTailArgs(cmd->Args());
+  cmd_cntx.SetupTx(cmd.cid, tx);
+  cmd_cntx.SetTailArgs(cmd.args);
   service_->InvokeCmd(args, &cmd_cntx);
   return true;
 }
@@ -201,25 +205,25 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
   };
 
   for (auto& dispatched : sinfo.dispatched) {
-    auto args = dispatched.cmd->Slice(&arg_vec);
+    auto args = dispatched.cmd.Slice(&arg_vec);
     if (opts_.verify_commands) {
       // The shared context is used for state verification, the local one is only for replies
-      if (auto err = service_->VerifyCommandState(*dispatched.cmd->Cid(), args, *cntx_); err) {
+      if (auto err = service_->VerifyCommandState(*dispatched.cmd.cid, args, *cntx_); err) {
         crb.SendError(std::move(*err));
         move_reply(crb.Take(), &dispatched.reply);
         continue;
       }
     }
 
-    crb.SetReplyMode(dispatched.cmd->ReplyMode());
+    crb.SetReplyMode(dispatched.cmd.reply_mode);
 
-    local_tx->MultiSwitchCmd(dispatched.cmd->Cid());
+    local_tx->MultiSwitchCmd(dispatched.cmd.cid);
     auto status = local_tx->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, args);
     if (status != OpStatus::OK) {
       crb.SendError(status);
     } else {
-      cmd_cntx.UpdateCid(dispatched.cmd->Cid());
-      cmd_cntx.SetTailArgs(dispatched.cmd->Args());
+      cmd_cntx.UpdateCid(dispatched.cmd.cid);
+      cmd_cntx.SetTailArgs(dispatched.cmd.args);
       service_->InvokeCmd(args, &cmd_cntx);
     }
     move_reply(crb.Take(), &dispatched.reply);
@@ -361,11 +365,11 @@ bool MultiCommandSquasher::ExecuteSquashed(facade::RedisReplyBuilder* rb) {
 }
 
 void MultiCommandSquasher::Run(RedisReplyBuilder* rb) {
-  DVLOG(1) << "Trying to squash " << cmds_.size() << " commands for transaction "
-           << cntx_->transaction->DebugId();
+  DVLOG(1) << "Trying to squash commands for transaction " << cntx_->transaction->DebugId();
 
-  for (auto& cmd : cmds_) {
-    auto res = TrySquash(&cmd);
+  for (CmdRef cmd = cmd_gen_(); cmd.IsValid(); cmd = cmd_gen_()) {
+    num_commands_++;
+    auto res = TrySquash(cmd);
 
     if (res == SquashResult::NOT_SQUASHED || res == SquashResult::SQUASHED_FULL) {
       if (!ExecuteSquashed(rb))
@@ -373,7 +377,7 @@ void MultiCommandSquasher::Run(RedisReplyBuilder* rb) {
 
       // if the last command was not added - we squash it separately.
       if (res == SquashResult::NOT_SQUASHED) {
-        if (!ExecuteStandalone(rb, &cmd))
+        if (!ExecuteStandalone(rb, cmd))
           break;
       }
     }
@@ -393,7 +397,7 @@ void MultiCommandSquasher::Run(RedisReplyBuilder* rb) {
     }
   }
 
-  VLOG(1) << "Handled " << cmds_.size() << " commands, max fanout: " << num_shards_
+  VLOG(1) << "Handled " << num_commands_ << " commands, max fanout: " << num_shards_
           << ", atomic: " << atomic_;
 }
 

--- a/src/server/multi_command_squasher.h
+++ b/src/server/multi_command_squasher.h
@@ -37,10 +37,12 @@ class MultiCommandSquasher {
     Stats& operator+=(const Stats& o);
   };
 
-  // Returns number of processed commands.
-  static Stats Execute(absl::Span<StoredCmd> cmds, facade::RedisReplyBuilder* rb,
-                       ConnectionContext* cntx, Service* service, const Opts& opts) {
-    MultiCommandSquasher sq{cmds, cntx, service, opts};
+  // cmd_gen returns CmdRef one at a time; an invalid CmdRef (cid==nullptr) signals the end.
+  using CmdGenerator = std::function<CmdRef()>;
+
+  static Stats Execute(CmdGenerator cmd_gen, facade::RedisReplyBuilder* rb, ConnectionContext* cntx,
+                       Service* service, const Opts& opts) {
+    MultiCommandSquasher sq{std::move(cmd_gen), cntx, service, opts};
     sq.Run(rb);
     return sq.stats_;
   }
@@ -55,7 +57,7 @@ class MultiCommandSquasher {
     }
 
     struct Command {
-      const StoredCmd* cmd;
+      CmdRef cmd;
       facade::CapturingReplyBuilder::Payload reply;
     };
     std::vector<Command> dispatched;  // Dispatched commands
@@ -68,17 +70,17 @@ class MultiCommandSquasher {
 
   enum class SquashResult : uint8_t { SQUASHED, SQUASHED_FULL, NOT_SQUASHED };
 
-  MultiCommandSquasher(absl::Span<StoredCmd> cmds, ConnectionContext* cntx, Service* Service,
+  MultiCommandSquasher(CmdGenerator cmd_gen, ConnectionContext* cntx, Service* Service,
                        const Opts& opts);
 
   // Lazy initialize shard info.
   ShardExecInfo& PrepareShardInfo(ShardId sid);
 
   // Retrun squash flags
-  SquashResult TrySquash(const StoredCmd* cmd);
+  SquashResult TrySquash(CmdRef cmd);
 
   // Execute separate non-squashed cmd. Return false if aborting on error.
-  bool ExecuteStandalone(facade::RedisReplyBuilder* rb, const StoredCmd* cmd);
+  bool ExecuteStandalone(facade::RedisReplyBuilder* rb, CmdRef cmd);
 
   // Callback that runs on shards during squashed hop.
   facade::OpStatus SquashedHopCb(EngineShard* es, facade::RespVersion resp_v);
@@ -90,8 +92,8 @@ class MultiCommandSquasher {
 
   bool IsAtomic() const;
 
-  absl::Span<StoredCmd> cmds_;  // Input range of stored commands
-  ConnectionContext* cntx_;     // Underlying context
+  CmdGenerator cmd_gen_;     // Pulls commands one at a time
+  ConnectionContext* cntx_;  // Underlying context
   Service* service_;
 
   bool atomic_;                // Whether working in any of the atomic modes
@@ -103,6 +105,7 @@ class MultiCommandSquasher {
   std::vector<ShardId> order_;  // reply order for squashed cmds
 
   size_t num_shards_ = 0;
+  size_t num_commands_ = 0;  // Total commands processed
 
   std::vector<MutableSlice> tmp_keylist_;
   Stats stats_;


### PR DESCRIPTION
- Add CmdRef struct as non-owning view of command for the squasher
- Change MultiCommandSquasher from Span<StoredCmd> to CmdGenerator
- Add swap-based StoredCmd constructor to avoid deep-copying EXEC args
- Add StoredCmd::Ref() to produce CmdRef from stored commands
- Add ParsedArgs offset constructor for tail_index support
- Remove AddStoredCmd, inline logic in StoreInMultiBlock

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
