### PR TITLE
chore: make CmdArgParser work directly with BackedArguments

### DIFF
--- a/src/facade/cmd_arg_parser.cc
+++ b/src/facade/cmd_arg_parser.cc
@@ -18,7 +18,7 @@ void CmdArgParser::ExpectTag(std::string_view tag) {
   }
 
   auto idx = cur_i_++;
-  auto val = ToSV(args_[idx]);
+  auto val = args_[idx];
   if (!absl::EqualsIgnoreCase(val, tag)) {
     Report(INVALID_NEXT, idx);
   }
@@ -31,7 +31,7 @@ void CmdArgParser::ExpectTag(std::string_view tag, std::string error_msg) {
   }
 
   auto idx = cur_i_++;
-  if (!absl::EqualsIgnoreCase(ToSV(args_[idx]), tag))
+  if (!absl::EqualsIgnoreCase(args_[idx], tag))
     Report(CUSTOM_ERROR, idx, std::move(error_msg));
 }
 
@@ -42,7 +42,7 @@ std::string_view CmdArgParser::ExpectStartsWith(std::string_view prefix, std::st
   }
 
   auto idx = cur_i_++;
-  auto val = ToSV(args_[idx]);
+  auto val = args_[idx];
   if (!absl::StartsWith(val, prefix)) {
     Report(CUSTOM_ERROR, idx, std::move(error_msg));
     return {};

--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -58,7 +58,7 @@ namespace facade {
 //   if (parser.HasAtLeast(3)) { ... }                           // at least N args remain?
 //   auto peek = parser.Peek();                                  // look at next without consuming
 //   parser.Skip(n);                                             // advance n args
-//   CmdArgList rest = parser.Tail();                            // remaining args (e.g. k/v pairs)
+//   size_t start = parser.UnparsedStart();                       // index of first unparsed arg
 //
 // Error surfacing (at the end of parse):
 //   if (!parser.Finalize())                                     // also reports UNPROCESSED on
@@ -253,8 +253,8 @@ struct CmdArgParser {
     return !HasError();
   }
 
-  ArgSlice Tail() const {
-    return args_.subspan(cur_i_);
+  size_t UnparsedStart() const {
+    return cur_i_;
   }
 
   bool HasNext() {
@@ -269,10 +269,6 @@ struct CmdArgParser {
 
   bool HasAtLeast(size_t i) const {
     return !error_ && i <= args_.size() - cur_i_;
-  }
-
-  size_t GetCurrentIndex() const {
-    return cur_i_;
   }
 
   // Reports a custom error (error_type >= CUSTOM_ERROR) at the previously-consumed index

--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -113,6 +113,9 @@ struct CmdArgParser {
   CmdArgParser(ArgSlice args) : args_{args} {
   }
 
+  CmdArgParser(const cmn::BackedArguments& bargs, uint32_t offset = 0) : args_{bargs, offset} {
+  }
+
   // DCHECKs that any error was consumed.
   ~CmdArgParser();
 
@@ -337,7 +340,7 @@ struct CmdArgParser {
     using namespace std::literals::string_view_literals;
     if (i >= args_.size())
       return ""sv;
-    return args_[i].empty() ? ""sv : ToSV(args_[i]);
+    return args_[i].empty() ? ""sv : args_[i];
   }
 
   template <typename T> T Num(size_t idx) {
@@ -371,7 +374,7 @@ struct CmdArgParser {
 
  private:
   size_t cur_i_ = 0;
-  ArgSlice args_;
+  ParsedArgs args_;
 
   ErrorInfo error_;
 };

--- a/src/facade/cmd_arg_parser_test.cc
+++ b/src/facade/cmd_arg_parser_test.cc
@@ -520,4 +520,33 @@ TEST_F(CmdArgParserTest, FixedRangeInt) {
   }
 }
 
+TEST_F(CmdArgParserTest, BackedArguments) {
+  cmn::BackedArguments bargs;
+  string_view args[] = {"SET", "mykey", "42", "EX", "100"};
+  bargs.Assign(std::begin(args), std::end(args), 5);
+
+  // Full range
+  {
+    CmdArgParser parser(bargs);
+    EXPECT_EQ(parser.Next(), "SET");
+    EXPECT_EQ(parser.Next(), "mykey");
+    EXPECT_EQ(parser.Next<int>(), 42);
+    EXPECT_TRUE(parser.Check("EX"));
+    EXPECT_EQ(parser.Next<int>(), 100);
+    EXPECT_TRUE(parser.Finalize());
+  }
+
+  // With offset (skip command name)
+  {
+    CmdArgParser parser(bargs, 1);
+    EXPECT_EQ(parser.Next(), "mykey");
+    EXPECT_EQ(parser.Next<int>(), 42);
+    EXPECT_EQ(parser.UnparsedStart(), 2u);
+    EXPECT_TRUE(parser.HasAtLeast(2));
+    EXPECT_FALSE(parser.HasAtLeast(3));
+    parser.Skip(2);
+    EXPECT_TRUE(parser.Finalize());
+  }
+}
+
 }  // namespace facade

--- a/src/facade/facade_types.h
+++ b/src/facade/facade_types.h
@@ -46,8 +46,8 @@ class ParsedArgs {
   ParsedArgs() = default;
 
   // References backed arguments. The object must outlive this ParsedArgs.
-  ParsedArgs(const cmn::BackedArguments& bargs)  // NOLINT google-explicit-constructor
-      : args_(&bargs) {
+  ParsedArgs(const cmn::BackedArguments& bargs, uint32_t offset = 0)  // NOLINT
+      : args_(WrapperBacked{&bargs, offset}) {
   }
 
   ParsedArgs(ArgSlice slice)  // NOLINT google-explicit-constructor
@@ -73,6 +73,10 @@ class ParsedArgs {
     return std::visit([](const auto& args) { return args.front(); }, args_);
   }
 
+  std::string_view operator[](size_t i) const {
+    return std::visit([i](const auto& args) { return args.at(i); }, args_);
+  }
+
   ArgSlice ToSlice(CmdArgVec* scratch) const {
     return std::visit([scratch](const auto& args) { return args.ToSlice(scratch); }, args_);
   }
@@ -83,7 +87,8 @@ class ParsedArgs {
 
  private:
   struct WrapperBacked {
-    WrapperBacked(const cmn::BackedArguments* args) : args_(args) {  // NOLINT
+    WrapperBacked(const cmn::BackedArguments* args, uint32_t index = 0)  // NOLINT
+        : args_(args), index_(index) {
     }
 
     const cmn::BackedArguments* args_;
@@ -104,6 +109,10 @@ class ParsedArgs {
       return args_->at(index_);
     }
 
+    std::string_view at(size_t i) const {
+      return args_->at(index_ + i);
+    }
+
     ArgSlice ToSlice(CmdArgVec* scratch) const {
       ToVec(scratch);
       return *scratch;
@@ -120,6 +129,10 @@ class ParsedArgs {
   struct Slice : public ArgSlice {
     using ArgSlice::ArgSlice;
     Slice(ArgSlice other) : ArgSlice(other) {  // NOLINT
+    }
+
+    std::string_view at(size_t i) const {
+      return ArgSlice::operator[](i);
     }
 
     ParsedArgs Tail() const {

--- a/src/server/cms_family.cc
+++ b/src/server/cms_family.cc
@@ -303,7 +303,7 @@ bool ParseMergeArgs(CmdArgList args, RedisReplyBuilder* rb, CmsMergeArgs* out) {
     return false;
   }
 
-  if (parser.Tail().size() < num_keys) {
+  if (!parser.HasAtLeast(num_keys)) {
     rb->SendError(kSyntaxErr);
     return false;
   }

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -2257,7 +2257,7 @@ void GenericFamily::FieldExpire(CmdArgList args, CommandContext* cmd_cntx) {
   if (auto err = parser.TakeError(); err) {
     return cmd_cntx->SendError(err.MakeReply());
   }
-  CmdArgList fields = parser.Tail();
+  CmdArgList fields = args.subspan(parser.UnparsedStart());
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpFieldExpire(t->GetOpArgs(shard), key, ttl_sec, fields);

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -723,7 +723,7 @@ struct HSetExParams {
 // mandatory FIELDS keyword, the Dragonfly format a bare numeric ttl_sec. NX (per-field skip) and
 // the collective FNX/FXX condition are mutually exclusive; FNX/FXX behave identically in both
 // syntaxes (set all-or-nothing). Only the reported value differs (see OpSetParams::Format).
-HSetExParams ParseHSetEx(CmdArgParser* parser, string_view cmd_name) {
+HSetExParams ParseHSetEx(CmdArgParser* parser, CmdArgList args, string_view cmd_name) {
   using Mode = OpSetParams::Mode;
   using Format = OpSetParams::Format;
   constexpr int kMaxTtl = 1 << 26;
@@ -765,7 +765,7 @@ HSetExParams ParseHSetEx(CmdArgParser* parser, string_view cmd_name) {
     if (op_sp.mode == Mode::kNX || (op_sp.keepttl && has_exp))
       parser->Report(CmdArgParser::CUSTOM_ERROR);  // NX is Dragonfly-only; one expiry option max
 
-    res.fields = parser->Tail();
+    res.fields = args.subspan(parser->UnparsedStart());
     if (numfields == 0 || res.fields.size() != size_t(numfields) * 2)
       parser->ReportCustom("The `numfields` parameter must match the number of arguments");
   } else if (has_exp) {
@@ -775,7 +775,7 @@ HSetExParams ParseHSetEx(CmdArgParser* parser, string_view cmd_name) {
     op_sp.format = Format::kDragonfly;
     op_sp.ttl = parser->Next<FInt<1, kMaxTtl>>();
 
-    res.fields = parser->Tail();
+    res.fields = args.subspan(parser->UnparsedStart());
     if (res.fields.empty() || res.fields.size() % 2 != 0)
       parser->ReportCustom(WrongNumArgsError(cmd_name));
   }
@@ -785,7 +785,7 @@ HSetExParams ParseHSetEx(CmdArgParser* parser, string_view cmd_name) {
 void HSetEx(CmdArgList args, CommandContext* cmd_cntx) {
   CmdArgParser parser{args};
   string_view key = parser.Next();
-  HSetExParams parsed = ParseHSetEx(&parser, cmd_cntx->cid()->name());
+  HSetExParams parsed = ParseHSetEx(&parser, args, cmd_cntx->cid()->name());
   RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   // Evaluate the FNX/FXX condition (if any), then let OpSet set the fields and report the
@@ -862,7 +862,7 @@ void CmdHExpire(CmdArgList args, CommandContext* cmd_cntx) {
 
   uint32_t numFields = parser.Next<uint32_t>();
 
-  CmdArgList fields = parser.Tail();
+  CmdArgList fields = args.subspan(parser.UnparsedStart());
   if (fields.size() != numFields) {
     return rb->SendError("The `numfields` parameter must match the number of arguments",
                          kSyntaxErrType);
@@ -929,7 +929,7 @@ void CmdHTtl(CmdArgList args, CommandContext* cmd_cntx) {
 
   uint32_t numFields = parser.Next<uint32_t>();
 
-  CmdArgList fields = parser.Tail();
+  CmdArgList fields = args.subspan(parser.UnparsedStart());
   if (fields.size() != numFields) {
     return rb->SendError("The `numfields` parameter must match the number of arguments",
                          kSyntaxErrType);

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -532,7 +532,7 @@ optional<ErrorReply> EvalValidator(CmdArgList args) {
   if (auto err = parser.TakeError(); err)
     return err.MakeReply();
 
-  if (num_keys > parser.Tail().size())
+  if (!parser.HasAtLeast(num_keys))
     return ErrorReply{"Number of keys can't be greater than number of args", kSyntaxErrType};
 
   return nullopt;

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -640,6 +640,8 @@ ParseResult<AggregateParams::JoinParams> ParseAggregatorJoinParams(
   known_indexes->insert(join_params.index_alias);
 
   size_t num_fields = parser->Next<size_t>();
+  if (!parser->HasAtLeast(num_fields))
+    return CreateSyntaxError("bad arguments for LOAD_FROM: not enough arguments"sv);
   join_params.conditions.reserve(num_fields);
   // Conditions are in the form index.field=foreign_index.field or foreign_index.field=index.field
   while (parser->HasNext() && num_fields > 0) {
@@ -718,7 +720,8 @@ ParseResult<AggregateParams> ParseAggregatorParams(CmdArgParser* parser) {
       size_t num_fields = parser->Next<size_t>();
 
       std::vector<std::string> fields;
-      fields.reserve(num_fields);
+      if (parser->HasAtLeast(num_fields))
+        fields.reserve(num_fields);
       while (parser->HasNext() && num_fields > 0) {
         auto parsed_field = ParseFieldWithAtSign(parser);
         if (!parsed_field) {

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -640,7 +640,7 @@ ParseResult<AggregateParams::JoinParams> ParseAggregatorJoinParams(
   known_indexes->insert(join_params.index_alias);
 
   size_t num_fields = parser->Next<size_t>();
-  join_params.conditions.reserve(std::min(num_fields, parser->Tail().size()));
+  join_params.conditions.reserve(num_fields);
   // Conditions are in the form index.field=foreign_index.field or foreign_index.field=index.field
   while (parser->HasNext() && num_fields > 0) {
     auto [left, right] = Split(parser->Next(), '=');
@@ -718,7 +718,7 @@ ParseResult<AggregateParams> ParseAggregatorParams(CmdArgParser* parser) {
       size_t num_fields = parser->Next<size_t>();
 
       std::vector<std::string> fields;
-      fields.reserve(std::min(num_fields, parser->Tail().size()));
+      fields.reserve(num_fields);
       while (parser->HasNext() && num_fields > 0) {
         auto parsed_field = ParseFieldWithAtSign(parser);
         if (!parsed_field) {

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -1597,7 +1597,7 @@ void CmdSAddEx(CmdArgList args, CommandContext* cmd_cntx) {
     return cmd_cntx->SendError(kInvalidIntErr);
   }
 
-  CmdArgList vals = parser.Tail();
+  CmdArgList vals = args.subspan(parser.UnparsedStart());
   if (vals.empty()) {
     return cmd_cntx->SendError(WrongNumArgsError("SADDEX"));
   }

--- a/src/server/stream_family.cc
+++ b/src/server/stream_family.cc
@@ -3276,7 +3276,7 @@ void XReadGeneric2(CmdArgList args, bool read_group, CommandContext* cmd_cntx) {
 }
 
 void HelpSubCmd(facade::CmdArgParser* parser, CommandContext* cmd_cntx) {
-  XGroupHelp(parser->Tail(), cmd_cntx);
+  XGroupHelp({}, cmd_cntx);
 }
 
 bool ParseXpendingOptions(CmdArgList& args, PendingOpts& opts, SinkReplyBuilder* builder) {
@@ -3355,12 +3355,12 @@ void CmdXAdd(CmdArgList args, CommandContext* cmd_cntx) {
 
   // Save the index of the stream ID in the arguments list.
   // We need this during journaling
-  // It is (parser.GetCurrentIndex() - 1) because the stream id is the last parsed argument in the
+  // It is (parser.UnparsedStart() - 1) because the stream id is the last parsed argument in the
   // ParseAddOpts
-  const size_t stream_id_index_in_args = parser.GetCurrentIndex() - 1;
+  const size_t stream_id_index_in_args = parser.UnparsedStart() - 1;
   AddArgsJournaler journaler{{args.begin(), args.end()}, stream_id_index_in_args};
 
-  CmdArgList fields = parser.Tail();
+  CmdArgList fields = args.subspan(parser.UnparsedStart());
   if (fields.empty() || fields.size() % 2 != 0) {
     return rb->SendError(WrongNumArgsError("XADD"), kSyntaxErrType);
   }


### PR DESCRIPTION
## Summary
- Replace `CmdArgParser::Tail()` with `UnparsedStart()` (returns index of first unparsed arg)
- Remove redundant `GetCurrentIndex()` method
- Change `CmdArgParser` internal storage from `ArgSlice` to `ParsedArgs`
- Add `BackedArguments` constructor: `CmdArgParser(const BackedArguments& bargs, uint32_t offset = 0)`
- Add `operator[]` and `at()` to `ParsedArgs` and its inner types
- Remove redundant `ToSV()` calls (noop on `string_view`)
- Guard `reserve()` against unbounded client-provided `num_fields` in search aggregation parsing

All existing callers are unchanged. New test covers the `BackedArguments` path.

Part of #7566 (Phase 0 + Phase 1).

## Test plan
- [x] `cmd_arg_parser_test` passes (21/21, including new `BackedArguments` test)
- [x] `dragonfly` binary builds cleanly
- [x] Pre-commit checks pass