### PR TITLE
chore: pass CmdArgParser to async command handlers via SetAsyncHandler

### DIFF
--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -116,6 +116,9 @@ struct CmdArgParser {
   CmdArgParser(const cmn::BackedArguments& bargs, uint32_t offset = 0) : args_{bargs, offset} {
   }
 
+  CmdArgParser(ParsedArgs args) : args_{args} {
+  }
+
   // DCHECKs that any error was consumed.
   ~CmdArgParser();
 

--- a/src/facade/facade_types.h
+++ b/src/facade/facade_types.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <optional>
 #include <ranges>
 #include <string>
@@ -89,6 +90,7 @@ class ParsedArgs {
   struct WrapperBacked {
     WrapperBacked(const cmn::BackedArguments* args, uint32_t index = 0)  // NOLINT
         : args_(args), index_(index) {
+      assert(index <= args->size());
     }
 
     const cmn::BackedArguments* args_;

--- a/src/server/cmd_support.h
+++ b/src/server/cmd_support.h
@@ -10,6 +10,7 @@
 #include <coroutine>
 #include <variant>
 
+#include "facade/cmd_arg_parser.h"
 #include "facade/error.h"
 #include "facade/op_status.h"
 #include "server/conn_context.h"
@@ -82,11 +83,11 @@ constexpr CmdR kAborted = {};
 // Underlying driver (promise) of coroutine that defines its context
 struct CmdR::Coro {
   // Coroutine created of a top level command
-  Coro(facade::CmdArgList arg, CommandContext* cmd_cntx) : cmd_cntx{cmd_cntx} {
+  Coro(facade::CmdArgParser, CommandContext* cmd) : cmd_cntx{cmd} {
   }
 
   // Coroutine created of a internal function with arguments
-  template <typename... Ts> Coro(CommandContext* cmd_cntx, const Ts&... ts) : cmd_cntx{cmd_cntx} {
+  template <typename... Ts> explicit Coro(CommandContext* cmd, const Ts&... ts) : cmd_cntx{cmd} {
   }
 
   // Use it waiter directly cases when it needs to stay in scope to keep the transaction alive

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -19,6 +19,7 @@
 #include "facade/dragonfly_connection.h"
 #include "facade/error.h"
 #include "server/acl/acl_commands_def.h"
+#include "server/conn_context.h"
 
 using namespace std;
 ABSL_FLAG(vector<string>, rename_command, {},
@@ -39,6 +40,10 @@ ABSL_FLAG(bool, latency_tracking, false, "If true, track latency for commands");
 namespace dfly {
 
 using namespace facade;
+
+CmdArgParser MakeParserFromContext(CommandContext* cntx) {
+  return CmdArgParser{cntx->tail_args()};
+}
 
 using absl::AsciiStrToUpper;
 using absl::GetFlag;

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -12,6 +12,7 @@
 #include <optional>
 
 #include "base/function2.hpp"
+#include "facade/cmd_arg_parser.h"
 #include "facade/command_id.h"
 #include "facade/facade_types.h"
 
@@ -66,6 +67,8 @@ using CmdCallStats = std::pair<uint64_t, uint64_t>;
 
 class CommandId;
 class CommandContext;
+
+facade::CmdArgParser MakeParserFromContext(CommandContext* cntx);
 
 // TODO: move it to helio
 // Makes sure that the POD T that is passed to the constructor is reset to default state
@@ -151,9 +154,10 @@ class CommandId : public facade::CommandId {
     return interleave_step_;
   }
 
-  template <typename RT> CommandId&& SetAsyncHandler(RT f(CmdArgList, CommandContext*)) && {
+  template <typename RT>
+  CommandId&& SetAsyncHandler(RT f(facade::CmdArgParser, CommandContext*)) && {
     support_async_ = true;
-    handler_ = [f](CmdArgList args, CommandContext* cntx) { f(args, cntx); };
+    handler_ = [f](CmdArgList args, CommandContext* cntx) { f(MakeParserFromContext(cntx), cntx); };
     return std::move(*this);
   }
 

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -304,6 +304,7 @@ bool ConnectionState::ClientTracking::ShouldTrackKeys() const {
 void CommandContext::ReuseInternal() {
   cid_ = nullptr;
   tx_ = nullptr;
+  tail_args_ = {};
   arg_slice_backing.clear();
   start_time_ns = 0;
 }

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -42,6 +42,9 @@ class StoredCmd {
   }
 
   facade::ArgSlice Slice(CmdArgVec* scratch) const;
+  const facade::ParsedArgs& Args() const {
+    return args_;
+  }
   std::string FirstArg() const;
 
   const CommandId* Cid() const {
@@ -414,6 +417,14 @@ class CommandContext : public facade::ParsedCommand {
     return cid_;
   }
 
+  void SetTailArgs(facade::ParsedArgs args) {
+    tail_args_ = args;
+  }
+
+  const facade::ParsedArgs& tail_args() const {
+    return tail_args_;
+  }
+
   uint64_t start_time_ns = 0;
 
   // Stores backing array for tail args slice
@@ -421,6 +432,11 @@ class CommandContext : public facade::ParsedCommand {
 
  protected:
   void ReuseInternal() final;
+
+  // Command arguments without the command name. Replaces arg_slice_backing as the
+  // canonical arg source once all handlers are migrated. Points into BackedArguments
+  // owned by this CommandContext (or StoredCmd for EXEC), so it survives async execution.
+  facade::ParsedArgs tail_args_;
 
   Transaction* tx_ = nullptr;
   const CommandId* cid_ = nullptr;

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -1856,6 +1856,7 @@ void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBat
       crb.SetReplyMode(ReplyMode::NONE);
       stub_tx->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, args_span);
       cmd_cntx.UpdateCid(cid);
+      cmd_cntx.SetTailArgs(facade::ArgSlice{args_span});
       sf_.service().InvokeCmd(args_span, &cmd_cntx);
     }
 
@@ -1877,6 +1878,7 @@ void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBat
       stub_tx->MultiSwitchCmd(cid);
       stub_tx->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, args_span);
       cmd_cntx.UpdateCid(cid);
+      cmd_cntx.SetTailArgs(facade::ArgSlice{args_span});
       sf_.service().InvokeCmd(args_span, &cmd_cntx);
     }
   }

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1165,7 +1165,7 @@ OpResult<uint32_t> GenericFamily::OpDel(const OpArgs& op_args, const ShardArgs& 
   return res;
 }
 
-static cmd::CmdR CmdDel(CmdArgList args, CommandContext* cmd_cntx) {
+static cmd::CmdR CmdDel(CmdArgParser parser, CommandContext* cmd_cntx) {
   bool async_unlink =
       cmd_cntx->cid()->name() == "UNLINK" && absl::GetFlag(FLAGS_unlink_experimental_async);
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1500,6 +1500,8 @@ DispatchResult Service::DispatchCommand(facade::ParsedArgs args, facade::ParsedC
     cmd_cntx->conn()->FlushReplies();
   }
 
+  cmd_cntx->SetTailArgs(args_no_cmd);
+
   ArgSlice tail_args;
   if (cmd_cntx->IsDeferredReply()) {
     args_no_cmd.ToVec(&cmd_cntx->arg_slice_backing);  // Ensure lifetime
@@ -2512,6 +2514,7 @@ void Service::Exec(CmdArgList args, CommandContext* cmd_cntx) {
         // TODO: we will have to create a CommandContext per command if we want to support async
         // execution inside exec.
         cmd_cntx->UpdateCid(scmd.Cid());
+        cmd_cntx->SetTailArgs(scmd.Args());
         auto invoke_res = InvokeCmd(args, cmd_cntx);
         if ((invoke_res != DispatchResult::OK) ||
             rb->GetError())  // checks for i/o error, not logical error.

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -177,6 +177,7 @@ bool MultiCommandSquasher::ExecuteStandalone(RedisReplyBuilder* rb, const Stored
   }
   CommandContext cmd_cntx{rb, cntx_};
   cmd_cntx.SetupTx(cmd->Cid(), tx);
+  cmd_cntx.SetTailArgs(cmd->Args());
   service_->InvokeCmd(args, &cmd_cntx);
   return true;
 }
@@ -218,6 +219,7 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
       crb.SendError(status);
     } else {
       cmd_cntx.UpdateCid(dispatched.cmd->Cid());
+      cmd_cntx.SetTailArgs(dispatched.cmd->Args());
       service_->InvokeCmd(args, &cmd_cntx);
     }
     move_reply(crb.Take(), &dispatched.reply);

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -739,9 +739,8 @@ struct GetReplies {
   RedisReplyBuilder* rb;
 };
 
-cmd::CmdR ExtendGeneric(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  string_view value = ArgS(args, 1);
+cmd::CmdR ExtendGeneric(CmdArgParser parser, CommandContext* cmd_cntx) {
+  auto [key, value] = parser.Next<string_view, string_view>();
   bool prepend = cmd_cntx->cid()->name().starts_with('P');
 
   VLOG(2) << "ExtendGeneric(" << key << ", " << value << ")";
@@ -1119,9 +1118,7 @@ std::variant<SetCmd::SetParams, facade::ErrorReply, NegativeExpire> ParseSetPara
   return sparams;
 }
 
-cmd::CmdR CmdSet(CmdArgList args, CommandContext* cmd_cntx) {
-  facade::CmdArgParser parser{args};
-
+cmd::CmdR CmdSet(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto [key, value] = parser.Next<string_view, string_view>();
   auto params_result = ParseSetParams(parser, cmd_cntx);
 
@@ -1195,10 +1192,8 @@ cmd::CmdR CmdSet(CmdArgList args, CommandContext* cmd_cntx) {
 }
 
 /// (P)SETEX key seconds (milliseconds) value
-cmd::CmdR CmdSetExGeneric(CmdArgList args, CommandContext* cmd_cntx) {
+cmd::CmdR CmdSetExGeneric(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view cmd_name = cmd_cntx->cid()->name();
-
-  CmdArgParser parser{args};
   auto [key, exp_int, value] = parser.Next<string_view, int64_t, string_view>();
 
   if (auto err = parser.TakeError(); err)
@@ -1232,9 +1227,8 @@ cmd::CmdR CmdSetExGeneric(CmdArgList args, CommandContext* cmd_cntx) {
   co_return std::nullopt;
 }
 
-cmd::CmdR CmdSetNx(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  string_view value = ArgS(args, 1);
+cmd::CmdR CmdSetNx(CmdArgParser parser, CommandContext* cmd_cntx) {
+  auto [key, value] = parser.Next<string_view, string_view>();
 
   SetCmd::SetParams sparams;
   sparams.flags |= SetCmd::SET_IF_NOTEXIST;
@@ -1263,8 +1257,8 @@ cmd::CmdR CmdSetNx(CmdArgList args, CommandContext* cmd_cntx) {
   co_return std::nullopt;
 }
 
-cmd::CmdR CmdGet(CmdArgList args, CommandContext* cmd_cntx) {
-  auto cb = [key = ArgS(args, 0)](Transaction* tx, EngineShard* es) -> OpResult<StringResult> {
+cmd::CmdR CmdGet(CmdArgParser parser, CommandContext* cmd_cntx) {
+  auto cb = [key = parser.Next()](Transaction* tx, EngineShard* es) -> OpResult<StringResult> {
     auto it_res = tx->GetDbSlice(es->shard_id()).FindReadOnly(tx->GetDbContext(), key, OBJ_STRING);
     if (!it_res.ok())
       return it_res.status();
@@ -1276,8 +1270,8 @@ cmd::CmdR CmdGet(CmdArgList args, CommandContext* cmd_cntx) {
   co_return std::nullopt;
 }
 
-cmd::CmdR CmdGetDel(CmdArgList args, CommandContext* cmd_cntx) {
-  auto cb = [key = ArgS(args, 0)](Transaction* tx, EngineShard* es) -> OpResult<StringResult> {
+cmd::CmdR CmdGetDel(CmdArgParser parser, CommandContext* cmd_cntx) {
+  auto cb = [key = parser.Next()](Transaction* tx, EngineShard* es) -> OpResult<StringResult> {
     auto& db_slice = tx->GetDbSlice(es->shard_id());
     auto it_res = db_slice.FindMutable(tx->GetDbContext(), key, OBJ_STRING);
     if (!it_res.ok())
@@ -1332,9 +1326,8 @@ void CmdDigest(CmdArgList args, CommandContext* cmd_cntx) {
   }
 }
 
-cmd::CmdR CmdGetSet(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  string_view value = ArgS(args, 1);
+cmd::CmdR CmdGetSet(CmdArgParser parser, CommandContext* cmd_cntx) {
+  auto [key, value] = parser.Next<string_view, string_view>();
 
   optional<StringResult> prev;
   SetCmd::SetParams sparams{.prev_val = &prev};
@@ -1353,8 +1346,7 @@ cmd::CmdR CmdGetSet(CmdArgList args, CommandContext* cmd_cntx) {
   co_return std::nullopt;
 }
 
-cmd::CmdR CmdGetEx(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{args};
+cmd::CmdR CmdGetEx(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
 
   DbSlice::ExpireParams exp_params;
@@ -1420,8 +1412,8 @@ cmd::CmdR CmdGetEx(CmdArgList args, CommandContext* cmd_cntx) {
   co_return std::nullopt;
 }
 
-cmd::CmdR CmdIncr(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
+cmd::CmdR CmdIncr(CmdArgParser parser, CommandContext* cmd_cntx) {
+  string_view key = parser.Next();
   int64_t delta = 1;
   if (auto* mc = cmd_cntx->mc_command()) {
     if (mc->delta > static_cast<uint64_t>(INT64_MAX)) {
@@ -1433,9 +1425,8 @@ cmd::CmdR CmdIncr(CmdArgList args, CommandContext* cmd_cntx) {
   return IncrByGeneric(cmd_cntx, key, delta);
 }
 
-cmd::CmdR CmdIncrBy(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  string_view sval = ArgS(args, 1);
+cmd::CmdR CmdIncrBy(CmdArgParser parser, CommandContext* cmd_cntx) {
+  auto [key, sval] = parser.Next<string_view, string_view>();
   int64_t val;
 
   if (!absl::SimpleAtoi(sval, &val)) {
@@ -1445,9 +1436,8 @@ cmd::CmdR CmdIncrBy(CmdArgList args, CommandContext* cmd_cntx) {
   return IncrByGeneric(cmd_cntx, key, val);
 }
 
-cmd::CmdR CmdIncrByFloat(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  string_view sval = ArgS(args, 1);
+cmd::CmdR CmdIncrByFloat(CmdArgParser parser, CommandContext* cmd_cntx) {
+  auto [key, sval] = parser.Next<string_view, string_view>();
   double val;
 
   if (!absl::SimpleAtod(sval, &val)) {
@@ -1468,8 +1458,8 @@ cmd::CmdR CmdIncrByFloat(CmdArgList args, CommandContext* cmd_cntx) {
   co_return std::nullopt;
 }
 
-cmd::CmdR CmdDecr(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
+cmd::CmdR CmdDecr(CmdArgParser parser, CommandContext* cmd_cntx) {
+  string_view key = parser.Next();
   int64_t delta = 1;
   if (auto* mc = cmd_cntx->mc_command()) {
     if (mc->delta > static_cast<uint64_t>(INT64_MAX)) {
@@ -1481,9 +1471,8 @@ cmd::CmdR CmdDecr(CmdArgList args, CommandContext* cmd_cntx) {
   return IncrByGeneric(cmd_cntx, key, -delta);
 }
 
-cmd::CmdR CmdDecrBy(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  string_view sval = ArgS(args, 1);
+cmd::CmdR CmdDecrBy(CmdArgParser parser, CommandContext* cmd_cntx) {
+  auto [key, sval] = parser.Next<string_view, string_view>();
   int64_t val;
 
   if (!absl::SimpleAtoi(sval, &val)) {
@@ -1519,9 +1508,9 @@ void ReorderShardResults(absl::Span<MGetResponse> mget_resp, const Transaction* 
   }
 }
 
-cmd::CmdR MGetGeneric(CommandContext* cmd_cntx, CmdArgList args,
-                      std::optional<DbSlice::ExpireParams> gat_params) {
-  DCHECK_GE(args.size(), 1U);
+cmd::CmdR MGetGeneric(CommandContext* cmd_cntx, std::optional<DbSlice::ExpireParams> gat_params) {
+  const auto& tail_args = cmd_cntx->tail_args();
+  DCHECK_GE(tail_args.size(), 1U);
 
   MemcacheCmdFlags cmd_flags;
 
@@ -1552,7 +1541,7 @@ cmd::CmdR MGetGeneric(CommandContext* cmd_cntx, CmdArgList args,
     co_return std::nullopt;
   }
 
-  size_t arg_len = args.size();
+  size_t arg_len = tail_args.size();
 
   unique_ptr<optional<GetResp>[]> mget_results(new optional<GetResp>[arg_len]);
   ReorderShardResults(absl::MakeSpan(mget_resp.get(), shard_set->size()), cmd_cntx->tx(),
@@ -1587,14 +1576,14 @@ cmd::CmdR MGetGeneric(CommandContext* cmd_cntx, CmdArgList args,
   co_return std::nullopt;
 }
 
-cmd::CmdR CmdMGet(CmdArgList args, CommandContext* cmd_cntx) {
-  return MGetGeneric(cmd_cntx, args, std::nullopt);
+cmd::CmdR CmdMGet(CmdArgParser parser, CommandContext* cmd_cntx) {
+  return MGetGeneric(cmd_cntx, std::nullopt);
 }
 
 // Implements the memcache GAT command. The expected input is
 // GAT key [keys...]
 // The expiry argument is stored in mc_command()->expire_ts
-cmd::CmdR CmdGAT(CmdArgList args, CommandContext* cmd_cntx) {
+cmd::CmdR CmdGAT(CmdArgParser parser, CommandContext* cmd_cntx) {
   if (!cmd_cntx->mc_command()) {
     cmd_cntx->SendError("GAT is a memcache-only command");
     return cmd::kAborted;
@@ -1602,7 +1591,7 @@ cmd::CmdR CmdGAT(CmdArgList args, CommandContext* cmd_cntx) {
   int64_t expire_ts = cmd_cntx->mc_command()->expire_ts;
   DbSlice::ExpireParams expire_params{
       .value = expire_ts, .absolute = true, .persist = expire_ts == 0};
-  return MGetGeneric(cmd_cntx, args, expire_params);
+  return MGetGeneric(cmd_cntx, expire_params);
 }
 
 void CmdMSet(CmdArgList args, CommandContext* cmd_cntx) {
@@ -1669,16 +1658,15 @@ void CmdMSetNx(CmdArgList args, CommandContext* cmd_cntx) {
   cmd_cntx->SendLong(to_skip || (*result != OpStatus::OK) ? 0 : 1);
 }
 
-cmd::CmdR CmdStrLen(CmdArgList args, CommandContext* cmd_cntx) {
-  auto cb = [key = ArgS(args, 0)](Transaction* t, EngineShard* shard) {
+cmd::CmdR CmdStrLen(CmdArgParser parser, CommandContext* cmd_cntx) {
+  auto cb = [key = parser.Next()](Transaction* t, EngineShard* shard) {
     return OpStrLen(t->GetOpArgs(shard), key);
   };
   GetReplies{cmd_cntx->rb()}.Send(co_await cmd::SingleHopT(cb));
   co_return std::nullopt;
 }
 
-cmd::CmdR CmdGetRange(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser(args);
+cmd::CmdR CmdGetRange(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto [key, start, end] = parser.Next<string_view, int32_t, int32_t>();
 
   if (auto err = parser.TakeError(); err)
@@ -1692,8 +1680,7 @@ cmd::CmdR CmdGetRange(CmdArgList args, CommandContext* cmd_cntx) {
   co_return std::nullopt;
 }
 
-cmd::CmdR CmdSetRange(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser(args);
+cmd::CmdR CmdSetRange(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto [key, start, value] = parser.Next<string_view, int32_t, string_view>();
 
   if (auto err = parser.TakeError(); err)


### PR DESCRIPTION
## Summary
- Change `SetAsyncHandler` to accept `(CmdArgParser, CommandContext*)` instead of `(CmdArgList, CommandContext*)`
- The wrapper lambda constructs `CmdArgParser` from `tail_args()`, removing the need for handlers to access `tail_args` or create their own parser
- Migrate all async handlers in `string_family.cc` and `generic_family.cc` to use the passed-in parser directly
- Add `MakeParserFromContext()` helper to avoid incomplete-type issue in `command_registry.h`