### PR TITLE
chore: use BackedArguments in DEBUG POPULATE

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -152,11 +152,7 @@ const CommandId* GeneratePopulateCommand(string_view type, std::string key, size
     }
   }
 
-  absl::InlinedVector<string_view, 5> views;
-  for (const auto& arg : args) {
-    views.push_back(arg);
-  }
-  out->Assign(views.begin(), views.end(), views.size());
+  out->Assign(args.begin(), args.end(), args.size());
   return cid;
 }
 

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -99,9 +99,10 @@ std::string GenerateValue(size_t val_size, bool random_value, absl::InsecureBitG
   }
 }
 
-tuple<const CommandId*, absl::InlinedVector<string, 5>> GeneratePopulateCommand(
-    string_view type, std::string key, size_t val_size, bool random_value, uint32_t elements,
-    const CommandRegistry& registry, absl::InsecureBitGen* gen) {
+const CommandId* GeneratePopulateCommand(string_view type, std::string key, size_t val_size,
+                                         bool random_value, uint32_t elements,
+                                         const CommandRegistry& registry, absl::InsecureBitGen* gen,
+                                         cmn::BackedArguments* out) {
   absl::InlinedVector<string, 5> args;
   args.push_back(std::move(key));
 
@@ -151,7 +152,12 @@ tuple<const CommandId*, absl::InlinedVector<string, 5>> GeneratePopulateCommand(
     }
   }
 
-  return {cid, args};
+  absl::InlinedVector<string_view, 5> views;
+  for (const auto& arg : args) {
+    views.push_back(arg);
+  }
+  out->Assign(views.begin(), views.end(), views.size());
+  return cid;
 }
 
 struct ObjHist {
@@ -1820,11 +1826,25 @@ void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBat
   boost::intrusive_ptr<Transaction> stub_tx =
       new Transaction{local_tx.get(), EngineShard::tlocal()->shard_id(), nullopt};
 
-  absl::InlinedVector<string_view, 5> args_view;
+  cmn::BackedArguments backed_args;
+  CmdArgVec arg_vec;
   facade::CapturingReplyBuilder crb;
   absl::InsecureBitGen gen;
   CommandContext cmd_cntx{&crb, cntx_};
   cmd_cntx.SetupTx(exec_cid, stub_tx.get());
+
+  auto invoke = [&](const CommandId* cid) {
+    arg_vec.clear();
+    for (auto sv : backed_args.view())
+      arg_vec.push_back(sv);
+    auto args_span = absl::MakeSpan(arg_vec);
+    stub_tx->MultiSwitchCmd(cid);
+    crb.SetReplyMode(ReplyMode::NONE);
+    stub_tx->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, args_span);
+    cmd_cntx.UpdateCid(cid);
+    cmd_cntx.SetTailArgs(facade::ParsedArgs{backed_args});
+    sf_.service().InvokeCmd(args_span, &cmd_cntx);
+  };
 
   for (unsigned i = 0; i < batch.sz; ++i) {
     string key = StrCat(options.prefix, ":", batch.index[i]);
@@ -1841,25 +1861,14 @@ void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBat
         populate_elements -= (populate_elements % 4);
       }
       elements_left -= populate_elements;
-      auto [cid, args] = GeneratePopulateCommand(options.type, key, options.val_size,
-                                                 options.populate_random_values, populate_elements,
-                                                 *sf_.service().mutable_registry(), &gen);
+      auto* cid = GeneratePopulateCommand(options.type, key, options.val_size,
+                                          options.populate_random_values, populate_elements,
+                                          *sf_.service().mutable_registry(), &gen, &backed_args);
       if (!cid) {
         LOG_EVERY_N(WARNING, 10'000) << "Unable to find command, was it renamed?";
         break;
       }
-
-      args_view.clear();
-      for (auto& arg : args) {
-        args_view.push_back(arg);
-      }
-      auto args_span = absl::MakeSpan(args_view);
-      stub_tx->MultiSwitchCmd(cid);
-      crb.SetReplyMode(ReplyMode::NONE);
-      stub_tx->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, args_span);
-      cmd_cntx.UpdateCid(cid);
-      cmd_cntx.SetTailArgs(facade::ArgSlice{args_span});
-      sf_.service().InvokeCmd(args_span, &cmd_cntx);
+      invoke(cid);
     }
 
     if (options.expire_ttl_range.has_value()) {
@@ -1867,21 +1876,11 @@ void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBat
       uint32_t end = options.expire_ttl_range->second;
       uint32_t expire_ttl = rand() % (end - start) + start;
       VLOG(1) << "set key " << key << " expire ttl as " << expire_ttl;
-      auto cid = sf_.service().mutable_registry()->Find("EXPIRE");
-      absl::InlinedVector<string, 5> args;
-      args.push_back(std::move(key));
-      args.push_back(to_string(expire_ttl));
-      args_view.clear();
-      for (auto& arg : args) {
-        args_view.push_back(arg);
-      }
-      auto args_span = absl::MakeSpan(args_view);
-      crb.SetReplyMode(ReplyMode::NONE);
-      stub_tx->MultiSwitchCmd(cid);
-      stub_tx->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, args_span);
-      cmd_cntx.UpdateCid(cid);
-      cmd_cntx.SetTailArgs(facade::ArgSlice{args_span});
-      sf_.service().InvokeCmd(args_span, &cmd_cntx);
+      auto* cid = sf_.service().mutable_registry()->Find("EXPIRE");
+      auto ttl_str = to_string(expire_ttl);
+      string_view expire_args[] = {key, ttl_str};
+      backed_args.Assign(std::begin(expire_args), std::end(expire_args), 2);
+      invoke(cid);
     }
   }
 


### PR DESCRIPTION
## Summary
- Refactor `GeneratePopulateCommand` to populate a `BackedArguments` output parameter instead of returning `InlinedVector<string, 5>`
- Extract `invoke()` helper in `DoPopulateBatch` to reduce duplication between the main command and expire paths
- Eliminates the intermediate `args_view` copy loop

Prep work for #7566 — moves DEBUG POPULATE off the `InlinedVector<string> → string_view[]` pattern and onto `BackedArguments`.

## Test plan
- [x] All 76 `generic_family_test` pass (covers DEBUG POPULATE)
- [x] All 45 `string_family_test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)