### PR TITLE
chore: pass BackedArguments through Lua redis.call path

### DIFF
--- a/src/core/interpreter.cc
+++ b/src/core/interpreter.cc
@@ -5,7 +5,6 @@
 #include "core/interpreter.h"
 
 #include <absl/base/casts.h>
-#include <absl/container/fixed_array.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_split.h>
 #include <absl/time/clock.h>
@@ -1177,85 +1176,52 @@ void Interpreter::UpdateGCParameters() {
              gc);
 }
 
-std::optional<absl::FixedArray<std::string_view, 4>> Interpreter::PrepareArgs() {
+bool Interpreter::PrepareArgs() {
   int argc = lua_gettop(lua_);
+  backed_args_.clear();
+
   if (argc == 0)
-    return {{}};
+    return true;
 
-  size_t blob_len = 0;
-  char tmpbuf[64];
-
-  // Determine size required for backing storage for all args.
-  // Skip command name (idx=1), as its stored in a separate buffer.
+  // Validate argument types (skip command name at idx=1).
   for (int idx = 2; idx <= argc; idx++) {
-    switch (lua_type(lua_, idx)) {
-      case LUA_TNUMBER:
-        if (lua_isinteger(lua_, idx)) {
-          blob_len += absl::AlphaNum(lua_tointeger(lua_, idx)).size();
-        } else {
-          int fmt_len = absl::SNPrintF(tmpbuf, sizeof(tmpbuf), "%.17g", lua_tonumber(lua_, idx));
-          CHECK_GT(fmt_len, 0);
-          blob_len += fmt_len;
-        }
-        continue;
-      case LUA_TSTRING:
-        blob_len += lua_rawlen(lua_, idx) + 1;
-        continue;
-      default:
-        PushError(lua_, "Lua redis() command arguments must be strings or integers");
-        return std::nullopt;
+    int t = lua_type(lua_, idx);
+    if (t != LUA_TNUMBER && t != LUA_TSTRING) {
+      PushError(lua_, "Lua redis() command arguments must be strings or integers");
+      return false;
     }
   }
 
-  absl::FixedArray<string_view, 4> args(argc);
+  // Copy command name.
+  backed_args_.PushArg(string_view{lua_tostring(lua_, 1), lua_rawlen(lua_, 1)});
 
-  // Copy command name to name_buffer and set it as first arg.
-  unsigned name_len = lua_rawlen(lua_, 1);
-  if (name_len >= sizeof(name_buffer_)) {
-    PushError(lua_, "Lua redis() command name too long");
-    return std::nullopt;
-  }
-
-  memcpy(name_buffer_, lua_tostring(lua_, 1), name_len);
-  args[0] = {name_buffer_, name_len};
-  buffer_.resize(blob_len + 4, '\0');  // backing storage for args
-
-  char* cur = buffer_.data();
-  char* end = cur + blob_len;
+  // Copy remaining arguments directly into backed_args_.
+  char tmpbuf[64];
   for (int idx = 2; idx <= argc; idx++) {
-    size_t len = 0;
     switch (lua_type(lua_, idx)) {
       case LUA_TNUMBER:
         if (lua_isinteger(lua_, idx)) {
-          char* next = absl::numbers_internal::FastIntToBuffer(lua_tointeger(lua_, idx), cur);
-          len = next - cur;
+          char* next = absl::numbers_internal::FastIntToBuffer(lua_tointeger(lua_, idx), tmpbuf);
+          backed_args_.PushArg(string_view{tmpbuf, size_t(next - tmpbuf)});
         } else if (lua_isnumber(lua_, idx)) {
-          // we pass `end - cur + 1` because we do not want to skip the last character
-          // if it's the last argument.
-          int fmt_len = absl::SNPrintF(cur, end - cur + 1, "%.17g", lua_tonumber(lua_, idx));
+          int fmt_len = absl::SNPrintF(tmpbuf, sizeof(tmpbuf), "%.17g", lua_tonumber(lua_, idx));
           CHECK_GT(fmt_len, 0);
-          len = fmt_len;
+          backed_args_.PushArg(string_view{tmpbuf, size_t(fmt_len)});
         }
         break;
       case LUA_TSTRING:
-        len = lua_rawlen(lua_, idx);
-        memcpy(cur, lua_tostring(lua_, idx), len + 1);  // + 1 for null terminator
-    };
-
-    args[idx - 1] = {cur, len};
-    cur += len;
+        backed_args_.PushArg(string_view{lua_tostring(lua_, idx), lua_rawlen(lua_, idx)});
+        break;
+    }
   }
 
-  /* Pop all arguments from the stack, we do not need them anymore
-   * and this way we guaranty we will have room on the stack for the result. */
   lua_pop(lua_, argc);
-  return args;
+  return true;
 }
 
 // Calls redis function
 // Returns false if error needs to be raised.
-bool Interpreter::CallRedisFunction(CallArgs::Type call_type, ObjectExplorer* explorer,
-                                    SliceSpan args) {
+bool Interpreter::CallRedisFunction(CallArgs::Type call_type, ObjectExplorer* explorer) {
   bool raise_error = (call_type & CallArgs::PCALL) == 0;
   bool async = call_type & CallArgs::ACALL;
   bool tx = call_type & (CallArgs::LOCK | CallArgs::UNLOCK);
@@ -1269,15 +1235,12 @@ bool Interpreter::CallRedisFunction(CallArgs::Type call_type, ObjectExplorer* ex
     translator.emplace(lua_);
     explorer = &*translator;
   }
+
   cmd_depth_++;
-  redis_func_(CallArgs{args, &buffer_, explorer, call_type, &raise_error});
+  redis_func_(CallArgs{&backed_args_, explorer, call_type, &raise_error});
   cmd_depth_--;
 
-  // Shrink reusable buffer if it's too big.
-  if (buffer_.capacity() > 128) {
-    buffer_.clear();
-    buffer_.shrink_to_fit();
-  }
+  backed_args_.MaybeShrink();
 
   if (!translator)
     return true;
@@ -1320,20 +1283,12 @@ int Interpreter::RedisGenericCommand(CallArgs::Type call_type, ObjectExplorer* e
     return 1;
   }
 
-  // IMPORTANT! all allocations within this funciton must be freed
-  // BEFORE calling RaiseErrorAndAbort in case of script error. RaiseErrorAndAbort
-  // uses longjmp which bypasses stack unwinding and skips the destruction of objects.
-  {
-    std::optional<absl::FixedArray<std::string_view, 4>> args = PrepareArgs();
-
-    // Verify argument are non-empty for all calls but unlock
-    if (args->empty() && (call_type & CallArgs::UNLOCK) == 0) {
+  // RaiseErrorAndAbort uses longjmp, which skips destructors. Avoid local allocations below.
+  if (PrepareArgs()) {
+    if (backed_args_.empty() && (call_type & CallArgs::UNLOCK) == 0) {
       PushError(lua_, "Please specify at least one argument for this call");
-      args = nullopt;
-    }
-
-    if (args.has_value()) {
-      raise_error = !CallRedisFunction(call_type, explorer, SliceSpan{*args});
+    } else {
+      raise_error = !CallRedisFunction(call_type, explorer);
     }
   }
   if (!raise_error) {

--- a/src/core/interpreter.h
+++ b/src/core/interpreter.h
@@ -4,13 +4,13 @@
 
 #pragma once
 
-#include <absl/container/fixed_array.h>
 #include <absl/types/span.h>
 
 #include <functional>
 #include <optional>
 #include <string_view>
 
+#include "common/backed_args.h"
 #include "util/fibers/synchronization.h"
 
 typedef struct lua_State lua_State;
@@ -46,12 +46,8 @@ class Interpreter {
 
   // Arguments received from redis.call
   struct CallArgs {
-    // Full arguments, including cmd name.
-    SliceSpan args;
-
-    // Pointer to backing storage for args (excluding cmd name).
-    // Moving can invalidate arg slice pointers. Moved by async to re-use buffer.
-    std::string* buffer;
+    // Full arguments, including cmd name. Owned by Interpreter::backed_args_.
+    const cmn::BackedArguments* args;
 
     ObjectExplorer* translator;
 
@@ -150,15 +146,14 @@ class Interpreter {
   bool AddInternal(const char* f_id, std::string_view body, std::string* error);
   bool IsTableSafe() const;
 
-  std::optional<absl::FixedArray<std::string_view, 4>> PrepareArgs();
-  bool CallRedisFunction(CallArgs::Type call_type, ObjectExplorer* explorer, SliceSpan args);
+  bool PrepareArgs();
+  bool CallRedisFunction(CallArgs::Type call_type, ObjectExplorer* explorer);
 
   lua_State* lua_;
   unsigned cmd_depth_ = 0;
   RedisFunc redis_func_;
-  std::string buffer_;
+  cmn::BackedArguments backed_args_;
   int64_t used_bytes_ = 0;
-  char name_buffer_[32];  // backing storage for cmd name
 };
 
 // Manages an internal interpreter pool. This allows multiple connections residing on the same

--- a/src/core/interpreter_test.cc
+++ b/src/core/interpreter_test.cc
@@ -288,9 +288,9 @@ TEST_F(InterpreterTest, Execute) {
 TEST_F(InterpreterTest, Call) {
   auto cb = [](auto ca) {
     auto* reply = ca.translator;
-    auto span = ca.args;
-    CHECK_GE(span.size(), 1u);
-    string_view cmd{span[0].data(), span[0].size()};
+    auto* span = ca.args;
+    CHECK_GE(span->size(), 1u);
+    string_view cmd = span->at(0);
     if (cmd == "string") {
       reply->OnString("foo");
     } else if (cmd == "double") {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1289,8 +1289,6 @@ optional<ErrorReply> CheckKeysDeclared(const ConnectionState::ScriptInfo& eval_i
   if (!key_index_res)
     return ErrorReply{key_index_res.status()};
 
-  // TODO: Switch to transaction internal locked keys once single hop multi transactions are merged
-  // const auto& locked_keys = trans->GetMultiKeys();
   const auto& locked_tags = eval_info.lock_tags;
   for (string_view key : key_index_res->Range(args)) {
     if (!locked_tags.contains(LockTag{key})) {
@@ -1965,14 +1963,14 @@ void Service::TryEnqueueEvalAsyncCmd(const Interpreter::CallArgs& ca, CommandCon
 
   // Full command verification happens during squashed execution
   if (async_call) {
-    if (auto [cid, tail] = registry_.FindExtended(ca.args); cid != nullptr) {
+    ParsedArgs parsed_args{*ca.args};
+    if (auto [cid, tail] = registry_.FindExtended(parsed_args); cid != nullptr) {
       auto reply_mode = abort_on_error ? ReplyMode::ONLY_ERR : ReplyMode::NONE;
-      auto tail_slice = ca.args.subspan(ca.args.size() - tail.size());
-
-      info->async_cmds.emplace_back(cid, tail_slice, reply_mode);
+      CmdArgVec scratch;
+      info->async_cmds.emplace_back(cid, tail.ToSlice(&scratch), reply_mode);
       info->async_cmds_heap_mem += info->async_cmds.back().UsedMemory();
     } else if (abort_on_error) {  // If we don't abort on errors, we can ignore it completely
-      early_async_error = ReportUnknownCmd(ca.args[0]);
+      early_async_error = ReportUnknownCmd(ca.args->at(0));
     }
   }
 
@@ -2015,22 +2013,34 @@ void Service::CallFromScript(Interpreter::CallArgs& ca, CommandContext* cmd_cntx
       if (tx->GetMultiMode() != Transaction::NON_ATOMIC)
         return;
 
-      info->key_backing.resize(ca.args.size());
-      for (size_t i = 0; i < ca.args.size(); i++) {
-        info->key_backing[i] = ca.args[i];  // copy key
+      info->key_backing.resize(ca.args->size());
+      for (size_t i = 0; i < ca.args->size(); i++) {
+        info->key_backing[i] = ca.args->at(i);  // copy key
         info->lock_tags.insert(LockTag(info->key_backing[i]));
       }
 
-      tx->MultiSwitchCmd(registry_.Find("EVAL"));  // change cid + refurbish
-      tx->StartMultiLockedAhead(cntx->ns, cntx->db_index(), ca.args, false);
+      {
+        CmdArgVec keys(info->key_backing.begin(), info->key_backing.end());
+        tx->MultiSwitchCmd(registry_.Find("EVAL"));
+        tx->StartMultiLockedAhead(cntx->ns, cntx->db_index(), keys, false);
+      }
       return;
     case CT::ACALL:
     case CT::APCALL:  // was handled above
       return;
-    default:  // regular call
+    default: {
+      // Save EVAL's state that DispatchCommand overwrites.
+      auto saved_tail = cmd_cntx->tail_args();
+      CmdArgVec saved_backing;
+      saved_backing.swap(cmd_cntx->arg_slice_backing);
+
       auto* prev = cmd_cntx->SwapReplier(&replier);
-      DispatchCommand(ParsedArgs{ca.args}, cmd_cntx, AsyncPreference::ONLY_SYNC);
+      DispatchCommand(ParsedArgs{*ca.args}, cmd_cntx, AsyncPreference::ONLY_SYNC);
       cmd_cntx->SwapReplier(prev);
+
+      saved_backing.swap(cmd_cntx->arg_slice_backing);
+      cmd_cntx->SetTailArgs(saved_tail);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Store Lua command arguments in `Interpreter::backed_args_` instead of passing `SliceSpan` through `CallArgs`
- Update `CallFromScript` in `main_service.cc` to use pointer-based `BackedArguments` access

Part of the incremental migration away from `arg_slice_backing`. After this + #7571 (DEBUG POPULATE), the `Slice` variant in `ParsedArgs` can be removed.