### PR TITLE
fix(search): reply to FT.INFO with a flat array under RESP3

### DIFF
--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -2606,7 +2606,8 @@ void CmdFtInfo(CmdArgList args, CommandContext* cmd_cntx) {
   const auto& schema = info.base_index.schema;
 
   bool has_custom_stopwords = info.base_index.options.custom_stopwords;
-  rb->StartCollection(has_custom_stopwords ? 8 : 7, CollectionType::MAP);
+  // Reply with a flat array under RESP3 too, not a map.
+  rb->StartArray((has_custom_stopwords ? 8 : 7) * 2);
 
   rb->SendSimpleString("index_name");
   rb->SendSimpleString(idx_name);
@@ -2614,7 +2615,7 @@ void CmdFtInfo(CmdArgList args, CommandContext* cmd_cntx) {
   rb->SendSimpleString("index_definition");
   {
     const bool has_lang_field = !schema.language_field.empty();
-    rb->StartCollection(has_lang_field ? 5 : 4, CollectionType::MAP);
+    rb->StartArray((has_lang_field ? 5 : 4) * 2);
     rb->SendSimpleString("key_type");
     rb->SendSimpleString(info.base_index.type == DocIndex::JSON ? "JSON" : "HASH");
     rb->SendSimpleString("prefixes");

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -6349,6 +6349,25 @@ TEST_F(SearchFamilyTest, NoOffsetsAbsentByDefault) {
               IsArray(_, _, _, _, "index_options", RespArray(IsEmpty()), _, _, _, _, _, _, _, _));
 }
 
+// FT.INFO replies with a flat array under both RESP2 and RESP3.
+TEST_F(SearchFamilyTest, FtInfoResp2AndResp3) {
+  Run({"FT.CREATE", "idx", "ON", "JSON", "PREFIX", "1", "d:", "SCHEMA", "$.id", "AS", "id", "TAG"});
+
+  auto definition = IsArray("key_type", "JSON", "prefixes", IsArray("d:"), "default_language",
+                            "english", "default_score", 1);
+  auto attributes =
+      IsArray(IsArray("identifier", "$.id", "attribute", "id", "type", "TAG", "SEPARATOR", ","));
+
+  for (string_view proto : {"2", "3"}) {
+    Run({"HELLO", proto});
+    EXPECT_THAT(Run({"FT.INFO", "idx"}),
+                IsArray("index_name", "idx", "index_definition", definition, "index_options",
+                        RespArray(IsEmpty()), "attributes", attributes, "num_docs", _, "indexing",
+                        _, "percent_indexed", _))
+        << "RESP" << proto;
+  }
+}
+
 // FT.INFO surfaces NOSTEM per-attribute and language in index_definition.
 TEST_F(SearchFamilyTest, StemmingInfoSurface) {
   Run({"FT.CREATE", "info_idx", "ON", "HASH", "PREFIX", "1", "doc:", "SCHEMA", "title", "TEXT",


### PR DESCRIPTION
Under RESP3, `FT.INFO` was encoded as a map, while RESP2 returns a flat array. The map form breaks the valkey-glide client (RESP3-only), which hard-codes the flat-array reply and raises `Response couldn't be converted for FT.INFO - TypeError: (response was "Map")`. This makes the RESP3 reply a flat array too, so the shape is protocol-independent and matches valkey-search.

Changes:
- `CmdFtInfo`: emit the top-level reply and the nested `index_definition` as flat arrays instead of RESP3 maps. RESP2 output is byte-identical (a map already serializes as a flat `2N` array under RESP2).
- Add `FtInfoResp2AndResp3` test: `FT.INFO` returns the expected flat array under both `HELLO 2` and `HELLO 3`.

Verification:
- valkey-glide `ft.info()` now succeeds against Dragonfly (previously raised the Map TypeError) - identical to valkey-search.
- redisvl on RESP2 (its default) is unaffected: `info()` and `from_existing()` still reconstruct the index schema.

Note:
Clients that explicitly negotiate RESP3 and rely on a map for `FT.INFO` (e.g. redis-py with `protocol=3`) now receive a flat array - consistent with how Dragonfly already replies to `FT.SEARCH`/`FT.AGGREGATE` under RESP3.

Fixes: #7570