### PR TITLE
chore(server): use CycleClock for latency and move OOM check into ServerState

### DIFF
--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -306,15 +306,15 @@ void CommandContext::ReuseInternal() {
   tx_ = nullptr;
   tail_args_ = {};
   arg_slice_backing.clear();
-  start_time_ns = 0;
+  start_time_usec = 0;
 }
 
 void CommandContext::RecordLatency(facade::ArgSlice tail_args) const {
-  DCHECK_GT(start_time_ns, 0u);
-  int64_t after = absl::GetCurrentTimeNanos();
+  DCHECK_GT(start_time_usec, 0u);
+  int64_t after = base::CycleClock::ToUsec(base::CycleClock::Now());
 
   ServerState* ss = ServerState::SafeTLocal();  // Might have migrated thread, read after invocation
-  int64_t execution_time_usec = (after - start_time_ns) / 1000;
+  int64_t execution_time_usec = after - start_time_usec;
 
   cid_->RecordLatency(ss->thread_index(), execution_time_usec);
   DCHECK(conn_cntx_ != nullptr);
@@ -325,8 +325,9 @@ void CommandContext::RecordLatency(facade::ArgSlice tail_args) const {
     return;
 
   if (!ss->ShouldLogSlowCmd(execution_time_usec))  // It was not a slow command
-    return;
+    return;                                        // fast path - no logging is required
 
+  // Slow path - logging is required.
   auto* cntx = static_cast<dfly::ConnectionContext*>(conn_cntx());
 
   // Log nested commands of scripts that made it into slowlog

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -425,7 +425,7 @@ class CommandContext : public facade::ParsedCommand {
     return tail_args_;
   }
 
-  uint64_t start_time_ns = 0;
+  uint64_t start_time_usec = 0;
 
   // Stores backing array for tail args slice
   CmdArgVec arg_slice_backing;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1307,24 +1307,6 @@ static optional<ErrorReply> VerifyConnectionAclStatus(const CommandId* cid,
   return nullopt;
 }
 
-bool ShouldDenyOnOOM(const CommandContext& cmd_cntx) {
-  DCHECK_NE(cmd_cntx.start_time_ns, 0u);
-  ServerState& etl = *ServerState::tlocal();
-  if ((cmd_cntx.cid()->opt_mask() & CO::DENYOOM) && etl.is_master) {
-    auto memory_stats = etl.GetMemoryUsage(cmd_cntx.start_time_ns);
-
-    size_t limit = max_memory_limit.load(memory_order_relaxed);
-    if (memory_stats.used_mem > limit ||
-        (etl.rss_oom_deny_ratio > 0 && memory_stats.rss_mem > (limit * etl.rss_oom_deny_ratio))) {
-      DLOG(WARNING) << "Out of memory, used " << memory_stats.used_mem << " ,rss "
-                    << memory_stats.rss_mem << " ,limit " << limit;
-      etl.stats.oom_error_cmd_cnt++;
-      return true;
-    }
-  }
-  return false;
-}
-
 std::optional<ErrorReply> Service::VerifyCommandState(const CommandId& cid, CmdArgList tail_args,
                                                       const ConnectionContext& dfly_cntx) {
   ServerState& etl = *ServerState::tlocal();
@@ -1635,75 +1617,79 @@ DispatchResult Service::InvokeCmd(CmdArgList tail_args, CommandContext* cmd_cntx
   DCHECK(cid);
   DCHECK(!cid->Validate(tail_args));
 
-  cmd_cntx->start_time_ns = absl::GetCurrentTimeNanos();
+  cmd_cntx->start_time_usec = base::CycleClock::ToUsec(base::CycleClock::Now());
 
   ConnectionContext* cntx = cmd_cntx->server_conn_cntx();
   auto* builder = cmd_cntx->rb();
   DCHECK(builder);
   DCHECK(cntx);
 
-  if (ShouldDenyOnOOM(*cmd_cntx)) {
+  ServerState& ss = *ServerState::tlocal();
+
+  if ((cid->opt_mask() & CO::DENYOOM) && ss.ShouldDenyOnOOM(cmd_cntx->start_time_usec)) {
     cmd_cntx->SendError(ErrorReply{OpStatus::OUT_OF_MEMORY});
     return DispatchResult::OOM;
   }
 
-  bool has_monitors = !ServerState::tlocal()->Monitors().Empty();
-  if (cid->CanBeMonitored() && has_monitors) {
+  bool has_monitors = !ss.Monitors().Empty();
+  if (has_monitors && cid->CanBeMonitored()) {
     DispatchMonitor(cntx, cid, tail_args);
   }
 
-  ServerState::tlocal()->RecordCmd(cntx->has_main_or_memcache_listener);
+  ss.RecordCmd(cntx->has_main_or_memcache_listener);
   TrackIfNeeded(cmd_cntx);
   auto* tx = cmd_cntx->tx();
-
-  // For EVAL[] and EXEC/DISCARD, clean up state.
-  // We don't do it directly in commands to allow some introspection after execution (slowlog).
-  absl::Cleanup mck_cleanup = [cntx, cid, mck = cid->MultiControlKind()]() {
-    if (mck && *mck == CO::MultiControlKind::EXEC && cid->name() != "MULTI")
-      MultiCleanup(cntx);
-    else if (mck && *mck == CO::MultiControlKind::EVAL)
-      cntx->conn_state.script_info.reset();
-  };
 
 #ifndef NDEBUG
   // Verifies that we reply to the client when needed.
   ReplyGuard reply_guard(*cmd_cntx);
 #endif
   builder->ConsumeLastError();  // throw away last error
+  DispatchResult res = DispatchResult::OK;
   try {
     cid->Invoke(tail_args, cmd_cntx);
   } catch (std::exception& e) {
     LOG(ERROR) << "Internal error, system probably unstable " << e.what();
-    return DispatchResult::ERROR;
+    res = DispatchResult::ERROR;
   }
 
-  DispatchResult res = DispatchResult::OK;
-  if (std::string reason = builder->ConsumeLastError(); !reason.empty()) {
-    // Set flag if OOM reported
-    if (reason == kOutOfMemory) {
-      res = DispatchResult::OOM;
+  if (res == DispatchResult::OK) {
+    if (std::string reason = builder->ConsumeLastError(); !reason.empty()) {
+      // Set flag if OOM reported
+      if (reason == kOutOfMemory) {
+        res = DispatchResult::OOM;
+      }
+      VLOG(2) << FailedCommandToString(cid->name(), tail_args, reason);
+      if (ShouldLogError(*cid, reason, tail_args)) {
+        LOG_EVERY_T(WARNING, 1) << FailedCommandToString(cid->name(), tail_args, reason);
+      }
     }
-    VLOG(2) << FailedCommandToString(cid->name(), tail_args, reason);
-    if (ShouldLogError(*cid, reason, tail_args)) {
-      LOG_EVERY_T(WARNING, 1) << FailedCommandToString(cid->name(), tail_args, reason);
+
+    if (cntx->conn_state.tracking_info_.IsTrackingOn()) {
+      if ((!tx && cid->name() != "MULTI") || (tx && !tx->IsMulti())) {
+        // Each time we execute a command we need to increase the sequence number in
+        // order to properly track clients when OPTIN is used.
+        // We don't do this for `multi/exec` because it would break the
+        // semantics, i.e, CACHING should stick for all commands following
+        // the CLIENT CACHING ON within a multi/exec block
+        cntx->conn_state.tracking_info_.IncrementSequenceNumber();
+      }
+    }
+
+    cmd_cntx->RecordLatency(tail_args);
+
+    if (tx && !cntx->conn_state.exec_info.IsRunning() && cntx->conn_state.script_info == nullptr) {
+      cntx->last_command_debug.clock = tx->txid();
     }
   }
 
-  if (cntx->conn_state.tracking_info_.IsTrackingOn()) {
-    if ((!tx && cid->name() != "MULTI") || (tx && !tx->IsMulti())) {
-      // Each time we execute a command we need to increase the sequence number in
-      // order to properly track clients when OPTIN is used.
-      // We don't do this for `multi/exec` because it would break the
-      // semantics, i.e, CACHING should stick for all commands following
-      // the CLIENT CACHING ON within a multi/exec block
-      cntx->conn_state.tracking_info_.IncrementSequenceNumber();
-    }
-  }
-
-  cmd_cntx->RecordLatency(tail_args);
-
-  if (tx && !cntx->conn_state.exec_info.IsRunning() && cntx->conn_state.script_info == nullptr) {
-    cntx->last_command_debug.clock = tx->txid();
+  // For EVAL[] and EXEC/DISCARD, clean up state.
+  // We don't do it directly in commands to allow some introspection after execution (slowlog).
+  if (auto mck = cid->MultiControlKind(); mck) {
+    if (*mck == CO::MultiControlKind::EXEC && cid->name() != "MULTI")
+      MultiCleanup(cntx);
+    else if (*mck == CO::MultiControlKind::EVAL)
+      cntx->conn_state.script_info.reset();
   }
 
   return res;

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -172,14 +172,30 @@ void ServerState::EnterLameDuck() {
   watcher_cv_.notify_all();
 }
 
-ServerState::MemoryUsageStats ServerState::GetMemoryUsage(uint64_t now_ns) {
-  static constexpr uint64_t kCacheEveryNs = 1000;
-  if (now_ns > used_mem_last_update_ + kCacheEveryNs) {
-    used_mem_last_update_ = now_ns;
+ServerState::MemoryUsageStats ServerState::GetMemoryUsage(uint64_t now_usec) const {
+  if (now_usec != used_mem_last_read_usec_) {
+    used_mem_last_read_usec_ = now_usec;
     memory_stats_cached_.used_mem = used_mem_current.load(std::memory_order_relaxed);
     memory_stats_cached_.rss_mem = rss_mem_current.load(std::memory_order_relaxed);
   }
   return memory_stats_cached_;
+}
+
+bool ServerState::ShouldDenyOnOOM(uint64_t now_usec) {
+  DCHECK_NE(now_usec, 0u);
+  if (is_master) {
+    auto memory_stats = GetMemoryUsage(now_usec);
+
+    size_t limit = max_memory_limit.load(memory_order_relaxed);
+    if (memory_stats.used_mem > limit ||
+        (rss_oom_deny_ratio > 0 && memory_stats.rss_mem > (limit * rss_oom_deny_ratio))) {
+      DLOG(WARNING) << "Out of memory, used " << memory_stats.used_mem << " ,rss "
+                    << memory_stats.rss_mem << " ,limit " << limit;
+      stats.oom_error_cmd_cnt++;
+      return true;
+    }
+  }
+  return false;
 }
 
 bool ServerState::AllowInlineScheduling() const {

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -190,7 +190,8 @@ class ServerState {  // public struct - to allow initialization.
     uint64_t rss_mem = 0;
   };
 
-  MemoryUsageStats GetMemoryUsage(uint64_t now_ns);
+  MemoryUsageStats GetMemoryUsage(uint64_t now_usec) const;
+  bool ShouldDenyOnOOM(uint64_t now_usec);
 
   bool AllowInlineScheduling() const;
 
@@ -326,8 +327,9 @@ class ServerState {  // public struct - to allow initialization.
   absl::flat_hash_map<std::string, base::Histogram> call_latency_histos_;
   uint32_t thread_index_ = 0;
 
-  uint64_t used_mem_last_update_ = 0;
-  MemoryUsageStats memory_stats_cached_;  // thread local cache of used and rss memory current
+  mutable uint64_t used_mem_last_read_usec_ = 0;
+  mutable MemoryUsageStats
+      memory_stats_cached_;  // thread local cache of used and rss memory current
 
   static __thread ServerState* state_;
 };


### PR DESCRIPTION
## Summary
- Switch command timing from `absl::GetCurrentTimeNanos` to `base::CycleClock` (cheaper rdtsc vs vdso call)
- Move `ShouldDenyOnOOM` from a free function in `main_service.cc` into `ServerState` where it naturally belongs
- Skip post-invocation bookkeeping (latency recording, tracking sequence increment) when command throws an exception
- Remove `absl::Cleanup` for multi-control cleanup in favor of explicit conditional at function end