### PR TITLE
chore: reduce log level

### DIFF
--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2270,8 +2270,8 @@ error_code RdbLoader::Load(io::Source* src) {
     }
 
     if (type == RDB_OPCODE_FULLSYNC_END) {
-      LOG(INFO) << "Read RDB_OPCODE_FULLSYNC_END rss="
-                << strings::HumanReadableNumBytes(rss_mem_current.load(std::memory_order_relaxed));
+      VLOG(2) << "Read RDB_OPCODE_FULLSYNC_END rss="
+              << strings::HumanReadableNumBytes(rss_mem_current.load(std::memory_order_relaxed));
       RETURN_ON_ERR(EnsureRead(8));
       RETURN_ON_ERR(ConsumeInput(8));  // ignore 8 bytes
 

--- a/src/server/rdb_load_context.cc
+++ b/src/server/rdb_load_context.cc
@@ -356,8 +356,8 @@ void RdbLoadContext::PerformPostLoad(Service* service, bool is_error) {
   // with the doc_ids assigned during key mapping restoration.
   // RebuildAllIndices decides per-index whether to use the restore path or rebuild from
   // scratch, based on the index's actual graph + key_index state.
-  LOG(INFO) << "PostLoad: rebuilding search indices across shards rss="
-            << strings::HumanReadableNumBytes(rss_mem_current.load(std::memory_order_relaxed));
+  VLOG(2) << "PostLoad: rebuilding search indices across shards rss="
+          << strings::HumanReadableNumBytes(rss_mem_current.load(std::memory_order_relaxed));
   shard_set->AwaitRunningOnShardQueue([](EngineShard* es) {
     OpArgs op_args{es, nullptr,
                    DbContext{&namespaces->GetDefaultNamespace(), 0, GetCurrentTimeMs()}};
@@ -372,8 +372,8 @@ void RdbLoadContext::PerformPostLoad(Service* service, bool is_error) {
   // Wait until index building ends (all shards' vector data populated).
   shard_set->RunBlockingInParallel([](EngineShard* es) {
     es->search_indices()->BlockUntilConstructionEnd();
-    LOG(INFO) << "PostLoad: search index rebuild phase returned rss="
-              << strings::HumanReadableNumBytes(rss_mem_current.load(std::memory_order_relaxed));
+    VLOG(2) << "PostLoad: search index rebuild phase returned rss="
+            << strings::HumanReadableNumBytes(rss_mem_current.load(std::memory_order_relaxed));
   });
 
   // Transition every search index out of kRestoring/kSerializing into kBuilding and


### PR DESCRIPTION
Summary: This PR reduces default log noise during RDB load/post-load phases by moving a few RSS/progress messages from LOG(INFO) to VLOG(2).
Why: Keeps INFO logs cleaner while preserving the diagnostics behind verbose logging (e.g., --v=2).