### PR TITLE
fix(search): return stored VECTOR fields verbatim in FT.SEARCH

### DIFF
--- a/src/server/search/doc_accessors.cc
+++ b/src/server/search/doc_accessors.cc
@@ -52,16 +52,9 @@ FieldValue ToSortableValue(search::SchemaField::FieldType type, string_view valu
     }
     return value_as_double.value();
   }
-  if (type == search::SchemaField::VECTOR) {
-    if (value.empty()) {
-      return std::nullopt;
-    }
-    auto opt_vector = search::BytesToFtVectorSafe(value);
-    if (!opt_vector) {
-      return std::nullopt;
-    }
-    auto& [ptr, size] = opt_vector.value();
-    return absl::StrCat("[", absl::StrJoin(absl::Span<const float>{ptr.get(), size}, ","), "]");
+  // An empty vector field is dropped rather than returned as an empty value.
+  if (type == search::SchemaField::VECTOR && value.empty()) {
+    return std::nullopt;
   }
   return string{value};
 }

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -1033,7 +1033,7 @@ TEST_F(SearchFamilyTest, ReturnOption) {
   // Check all fields are returned
   auto resp = Run({"ft.search", "i1", "@justA:0"});
   EXPECT_THAT(resp, MatchEntry("k0", "longA", "0", "longB", "1", "longC", "2", "secret", "3",
-                               "vector", "[0]"));
+                               "vector", FloatVec1(0.0f)));
 
   // Check no fields are returned
   resp = Run({"ft.search", "i1", "@justA:0", "return", "0"});
@@ -1115,6 +1115,50 @@ TEST_F(SearchFamilyTest, ReturnOptionJson) {
   // RETURN with SORTBY doesn't include sortable field
   EXPECT_THAT(Run({"ft.search", "i1", "*", "sortby", "size", "return", "1", "name"}),
               MatchEntry("k1", "name", "dragon"));
+}
+
+// A returned HASH vector field echoes the raw stored binary buffer.
+TEST_F(SearchFamilyTest, VectorReturnRawBytesHash) {
+  Run({"FT.CREATE", "idx", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "v", "VECTOR", "FLAT", "6",
+       "TYPE", "FLOAT32", "DIM", "3", "DISTANCE_METRIC", "L2"});
+  WaitForIndexReady("idx");
+
+  const string vec = Vec3ToBytes(1.0f, 2.0f, 3.0f);  // 12 raw little-endian bytes
+  Run({"HSET", "d:a", "v", vec});
+
+  // Explicit RETURN of the vector field.
+  EXPECT_THAT(Run({"FT.SEARCH", "idx", "*", "RETURN", "1", "v"}), MatchEntry("d:a", "v", vec));
+
+  // Default serialization (no RETURN) echoes the same raw buffer.
+  EXPECT_THAT(Run({"FT.SEARCH", "idx", "*"}), MatchEntry("d:a", "v", vec));
+}
+
+// A JSON vector field is returned as its array text, not omitted.
+TEST_F(SearchFamilyTest, VectorReturnJson) {
+  Run({"FT.CREATE", "idx",     "ON",  "JSON", "PREFIX",          "1",    "d:",
+       "SCHEMA",    "$.v",     "AS",  "v",    "VECTOR",          "FLAT", "6",
+       "TYPE",      "FLOAT32", "DIM", "3",    "DISTANCE_METRIC", "L2"});
+  WaitForIndexReady("idx");
+
+  Run({"JSON.SET", "d:a", "$", R"({"v": [1, 2, 3]})"});
+
+  EXPECT_THAT(Run({"FT.SEARCH", "idx", "*", "RETURN", "1", "v"}),
+              MatchEntry("d:a", "v", "[1,2,3]"));
+}
+
+// A KNN query that also returns the candidate vectors: score numeric, vector raw.
+TEST_F(SearchFamilyTest, VectorReturnWithKnn) {
+  Run({"FT.CREATE", "idx", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "v", "VECTOR", "FLAT", "6",
+       "TYPE", "FLOAT32", "DIM", "3", "DISTANCE_METRIC", "L2"});
+  WaitForIndexReady("idx");
+
+  const string va = Vec3ToBytes(1.0f, 0.0f, 0.0f);
+  Run({"HSET", "d:a", "v", va});
+
+  const string q = Vec3ToBytes(1.0f, 0.0f, 0.0f);
+  EXPECT_THAT(Run({"FT.SEARCH", "idx", "* => [KNN 1 @v $q AS dist]", "RETURN", "2", "v", "dist",
+                   "PARAMS", "2", "q", q, "DIALECT", "2"}),
+              MatchEntry("d:a", "v", va, "dist", "0"));
 }
 
 TEST_F(SearchFamilyTest, TestStopWords) {

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -1123,7 +1123,7 @@ TEST_F(SearchFamilyTest, VectorReturnRawBytesHash) {
        "TYPE", "FLOAT32", "DIM", "3", "DISTANCE_METRIC", "L2"});
   WaitForIndexReady("idx");
 
-  const string vec = Vec3ToBytes(1.0f, 2.0f, 3.0f);  // 12 raw little-endian bytes
+  const string vec = Vec3ToBytes(1.0f, 2.0f, 3.0f);  // 12 raw bytes
   Run({"HSET", "d:a", "v", vec});
 
   // Explicit RETURN of the vector field.

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1,6 +1,9 @@
+import asyncio
+import logging
 import os
 import platform
 import random
+import re
 import shutil
 import signal
 import struct
@@ -10,13 +13,31 @@ from itertools import chain, repeat
 
 import async_timeout
 import pymemcache
+import pytest
+import redis
+from redis import asyncio as aioredis
 
 from . import dfly_args
 from .instance import DflyInstanceFactory, DflyInstance
 from .proxy import Proxy
 from .seeder import DebugPopulateSeeder, HnswSearchSeeder
 from .seeder import Seeder as SeederV2
-from .utility import *
+from .utility import (
+    assert_eventually,
+    batch_fill_data,
+    check_all_replicas_finished,
+    DflySeederFactory,
+    download_with_retries,
+    ExpirySeeder,
+    extract_int_after_prefix,
+    gen_test_data,
+    info_tick_timer,
+    is_saving,
+    parse_client_list,
+    tmp_file_name,
+    wait_available_async,
+    wait_for_replicas_state,
+)
 
 ADMIN_PORT = 1211
 
@@ -790,16 +811,16 @@ async def test_rewrites(df_factory):
         await check("SPOP k-set 2", r"DEL k-set")
 
         # Check SET + {EX/PX/EXAT} + {XX/NX/GET} arguments turns into SET PXAT
-        await check(f"SET k v EX 100 NX GET", r"SET k v PXAT (.*?)")
+        await check("SET k v EX 100 NX GET", r"SET k v PXAT (.*?)")
         await check_expire("k")
-        await check(f"SET k v PX 50000", r"SET k v PXAT (.*?)")
+        await check("SET k v PX 50000", r"SET k v PXAT (.*?)")
         await check_expire("k")
         # Exact expiry is skewed
-        await check(f"SET k v XX EXAT {CLOSE_TIMESTAMP}", rf"SET k v PXAT (.*?)")
+        await check(f"SET k v XX EXAT {CLOSE_TIMESTAMP}", r"SET k v PXAT (.*?)")
         await check_expire("k")
 
         # Check SET + KEEPTTL doesn't loose KEEPTTL
-        await check(f"SET k v KEEPTTL", r"SET k v KEEPTTL")
+        await check("SET k v KEEPTTL", r"SET k v KEEPTTL")
 
         # Check SETEX/PSETEX turn into SET PXAT
         await check("SETEX k 100 v", r"SET k v PXAT (.*?)")
@@ -852,10 +873,10 @@ async def test_rewrites(df_factory):
         # Check BITOP turns into SET
         await check("BITOP OR kdest k1 k2", r"SET kdest 1100")
         # See gh issue #3528
-        await c_master.execute_command(f"HSET foo bar val")
+        await c_master.execute_command("HSET foo bar val")
         await skip_cmd()
         await check("BITOP NOT foo tmp", r"DEL foo")
-        await c_master.execute_command(f"HSET foo bar val")
+        await c_master.execute_command("HSET foo bar val")
         await skip_cmd()
         await c_master.set("k3", "-")
         await skip_cmd()
@@ -1484,7 +1505,7 @@ async def test_readonly_script(df_factory):
 
     await c_replica.eval(READONLY_SCRIPT, 3, "A", "B", "WORKS") == "YES"
 
-    with pytest.raises(aioredis.ResponseError) as roe:
+    with pytest.raises(aioredis.ResponseError):
         await c_replica.eval(WRITE_SCRIPT, 1, "A")
 
 
@@ -1523,7 +1544,7 @@ async def test_take_over_counters(df_factory, master_threads, replica_threads):
         while time.time() - start < 20:
             try:
                 value = await c_master.execute_command(f"INCR {key}")
-            except (redis.exceptions.ConnectionError, redis.exceptions.ResponseError) as e:
+            except (redis.exceptions.ConnectionError, redis.exceptions.ResponseError):
                 break
         else:
             assert False, "The incrementing loop should be exited with a connection error"
@@ -1539,7 +1560,7 @@ async def test_take_over_counters(df_factory, master_threads, replica_threads):
 
     async def delayed_takeover():
         await asyncio.sleep(1)
-        await c1.execute_command(f"REPLTAKEOVER 5")
+        await c1.execute_command("REPLTAKEOVER 5")
 
     _, _, *results = await asyncio.gather(
         delayed_takeover(), block_during_takeover(), *[counter(f"key{i}") for i in range(16)]
@@ -1583,7 +1604,7 @@ async def test_take_over_seeder(
     # Give the seeder a bit of time.
     await asyncio.sleep(3)
     logging.debug("running repltakover")
-    await c_replica.execute_command(f"REPLTAKEOVER 30 SAVE")
+    await c_replica.execute_command("REPLTAKEOVER 30 SAVE")
     logging.debug("after running repltakover")
     seeder.stop()
     await fill_task
@@ -1635,7 +1656,7 @@ async def test_take_over_read_commands(df_factory, master_threads, replica_threa
             assert res == "bar"
 
     promt_task = asyncio.create_task(prompt())
-    await c_replica.execute_command(f"REPLTAKEOVER 5")
+    await c_replica.execute_command("REPLTAKEOVER 5")
 
     assert await c_replica.execute_command("role") == ["master", []]
     await promt_task
@@ -1660,7 +1681,7 @@ async def test_take_over_timeout(df_factory, df_seeder_factory):
     # Give the seeder a bit of time.
     await asyncio.sleep(1)
     try:
-        await c_replica.execute_command(f"REPLTAKEOVER 0")
+        await c_replica.execute_command("REPLTAKEOVER 0")
     except redis.exceptions.ResponseError as e:
         # Should fail with detailed error message
         assert str(e).startswith("Couldn't execute takeover")
@@ -2229,7 +2250,7 @@ async def test_replicaof_reject_on_load(df_factory, df_seeder_factory):
 
     c_replica = replica.client()
 
-    await c_replica.execute_command(f"DEBUG POPULATE 1000 key 500 RAND type set elements 500")
+    await c_replica.execute_command("DEBUG POPULATE 1000 key 500 RAND type set elements 500")
 
     replica.stop()
     replica.start()
@@ -2753,14 +2774,14 @@ async def test_empty_hash_map_replicate_old_master(df_factory):
         assert await old_c_master.execute_command("HGETALL foo") == []
 
     await check_if_empty()
-    assert await old_c_master.execute_command(f"EXISTS foo") == 1
+    assert await old_c_master.execute_command("EXISTS foo") == 1
     await old_c_master.aclose()
 
     async def assert_body(client, result=1, state="online", node_role="slave"):
         async with async_timeout.timeout(10):
             await wait_for_replicas_state(client, state=state, node_role=node_role)
 
-        assert await client.execute_command(f"EXISTS foo") == result
+        assert await client.execute_command("EXISTS foo") == result
         assert await client.execute_command("REPLTAKEOVER 1") == "OK"
 
     index = 0
@@ -2808,7 +2829,7 @@ async def test_empty_hashmap_loading_bug(df_factory: DflyInstanceFactory):
         assert await c_master.execute_command("HGETALL foo") == []
 
     await check_if_empty()
-    assert await c_master.execute_command(f"EXISTS foo") == 1
+    assert await c_master.execute_command("EXISTS foo") == 1
 
     replica = df_factory.create()
     replica.start()
@@ -2816,7 +2837,7 @@ async def test_empty_hashmap_loading_bug(df_factory: DflyInstanceFactory):
 
     await c_replica.execute_command(f"REPLICAOF localhost {master.port}")
     await wait_for_replicas_state(c_replica)
-    assert await c_replica.execute_command(f"dbsize") == 0
+    assert await c_replica.execute_command("dbsize") == 0
 
 
 async def test_replicate_search_index_to_old_replica(df_factory: DflyInstanceFactory):
@@ -2896,10 +2917,18 @@ async def test_replicate_search_index_to_old_replica(df_factory: DflyInstanceFac
     text_result = await master_idx.search("Product 50")
     assert text_result.total >= 1
 
-    # Verify KNN search on master
+    # Verify KNN search on master. NOCONTENT: only the doc keys are checked, and it
+    # avoids returning the raw binary embedding that a decode_responses client cannot decode.
     query_vec = struct.pack("<2f", 50.0, 100.0)
     knn_result = await c_master.execute_command(
-        "FT.SEARCH", "test_idx", "*=>[KNN 2 @embedding $vec]", "PARAMS", "2", "vec", query_vec
+        "FT.SEARCH",
+        "test_idx",
+        "*=>[KNN 2 @embedding $vec]",
+        "NOCONTENT",
+        "PARAMS",
+        "2",
+        "vec",
+        query_vec,
     )
     assert knn_result[0] >= 1
     assert "item:50" in knn_result
@@ -2914,7 +2943,14 @@ async def test_replicate_search_index_to_old_replica(df_factory: DflyInstanceFac
 
     # Verify KNN search works on old replica (index rebuilt from replicated data)
     knn_result = await c_replica.execute_command(
-        "FT.SEARCH", "test_idx", "*=>[KNN 2 @embedding $vec]", "PARAMS", "2", "vec", query_vec
+        "FT.SEARCH",
+        "test_idx",
+        "*=>[KNN 2 @embedding $vec]",
+        "NOCONTENT",
+        "PARAMS",
+        "2",
+        "vec",
+        query_vec,
     )
     assert knn_result[0] >= 1
     assert "item:50" in knn_result
@@ -2972,7 +3008,7 @@ async def test_double_take_over(df_factory, df_seeder_factory):
     await start_replication(c_replica, master.admin_port)
 
     logging.debug("running repltakover")
-    await c_replica.execute_command(f"REPLTAKEOVER 10")
+    await c_replica.execute_command("REPLTAKEOVER 10")
     assert await c_replica.execute_command("role") == ["master", []]
 
     @assert_eventually
@@ -2989,7 +3025,7 @@ async def test_double_take_over(df_factory, df_seeder_factory):
     await start_replication(c_master, replica.admin_port)
 
     logging.debug("running second repltakover")
-    await c_master.execute_command(f"REPLTAKEOVER 10")
+    await c_master.execute_command("REPLTAKEOVER 10")
     assert await c_master.execute_command("role") == ["master", []]
 
     assert await seeder.compare(capture, port=master.port)
@@ -3417,14 +3453,14 @@ async def test_partial_replication_on_same_source_master(df_factory, use_takeove
 
     if use_takeover:
         # Promote first replica to master
-        await c_replica1.execute_command(f"REPLTAKEOVER 5")
+        await c_replica1.execute_command("REPLTAKEOVER 5")
         if backlog_len > 1:
             await c_replica1.execute_command("SET bar foo")
             await c_replica1.execute_command("SET foo bar")
 
     else:
         # Promote first replica to master
-        await c_replica1.execute_command(f"REPLICAOF NO ONE")
+        await c_replica1.execute_command("REPLICAOF NO ONE")
         await c_master.set("x", "y")
         await c_master.set("x", "y")
         await check_all_replicas_finished([c_replica2], c_master)
@@ -3444,7 +3480,7 @@ async def test_partial_replication_on_same_source_master(df_factory, use_takeove
         assert s1 == s2
 
     # Check we can takeover to the second replica
-    await c_replica2.execute_command(f"REPLTAKEOVER 5")
+    await c_replica2.execute_command("REPLTAKEOVER 5")
 
     replica1.stop()
     replica2.stop()
@@ -3481,7 +3517,7 @@ async def test_partial_replication_on_same_source_master_with_replica_lsn_inc(df
     await wait_for_replicas_state(c_s3)
 
     # Promote server 2 to master
-    await c_s2.execute_command(f"REPLTAKEOVER 20")
+    await c_s2.execute_command("REPLTAKEOVER 20")
     # Make server 4 replica of server 2
     await c_s4.execute_command(f"REPLICAOF localhost {server2.port}")
     # Send some write command for lsn inc
@@ -3939,7 +3975,7 @@ async def test_repl_offset(df_factory):
     await check_all_replicas_finished([c_replica1, c_replica2, c_replica3], c_master)
 
     # Promote first replica to master
-    await c_replica1.execute_command(f"REPLTAKEOVER 5")
+    await c_replica1.execute_command("REPLTAKEOVER 5")
 
     # issue 4183
     async def with_timeout_link_down(client):
@@ -3970,7 +4006,7 @@ async def test_repl_offset(df_factory):
     assert info["slave_repl_offset"] > proactors
     assert info["psync_successes"] == 1
 
-    await c_replica1.execute_command(f"REPLTAKEOVER 5")
+    await c_replica1.execute_command("REPLTAKEOVER 5")
     await with_timeout_link_down(c_replica3)
 
 

--- a/tests/dragonfly/seeder/__init__.py
+++ b/tests/dragonfly/seeder/__init__.py
@@ -367,10 +367,13 @@ class HnswSearchSeeder:
 
     async def _search_knn(self, client, query_vec, k=5):
         """Run a KNN search and return (total_count, set_of_doc_ids)."""
+        # NOCONTENT: only keys are needed, and it avoids returning the raw binary
+        # embedding field that a decode_responses client cannot decode.
         r = await client.execute_command(
             "FT.SEARCH",
             self.index_name,
             "*=>[KNN {k} @embedding $vec]".format(k=k),
+            "NOCONTENT",
             "PARAMS",
             "2",
             "vec",
@@ -379,7 +382,7 @@ class HnswSearchSeeder:
             "0",
             str(k),
         )
-        doc_ids = set(r[i] for i in range(1, len(r), 2))
+        doc_ids = set(r[1:])
         return r[0], doc_ids
 
     async def _search_knn_filtered(self, client, query_vec, doc_id, k=5):
@@ -394,6 +397,7 @@ class HnswSearchSeeder:
             "FT.SEARCH",
             self.index_name,
             "@doc_id:{{{id}}}=>[KNN {k} @embedding $vec]".format(id=doc_num, k=k),
+            "NOCONTENT",
             "PARAMS",
             "2",
             "vec",
@@ -490,6 +494,7 @@ class HnswSearchSeeder:
                     "FT.SEARCH",
                     self.index_name,
                     "*=>[KNN 5 @embedding $vec]",
+                    "NOCONTENT",
                     "PARAMS",
                     "2",
                     "vec",


### PR DESCRIPTION
FT.SEARCH/FT.AGGREGATE re-encoded a returned vector field as a printable ASCII array for HASH and dropped it for JSON. Clients that round-trip the buffer via numpy.frombuffer failed with "buffer size must be a multiple of element size".

ToSortableValue now echoes the stored value verbatim: HASH returns the raw little-endian buffer, JSON the array text -- matching the expected, parseable form.

- doc_accessors.cc: VECTOR fields returned as stored (no ASCII re-encode).
- search_family_test.cc: VectorReturnRawBytesHash/Json/WithKnn; ReturnOption updated to expect raw bytes.

Fixes: #7580