### PR TITLE
Add pipeline-reply plumbing to MultiCommandSquasher

### DIFF
--- a/src/facade/parsed_command.cc
+++ b/src/facade/parsed_command.cc
@@ -99,6 +99,12 @@ void ParsedCommand::SendLong(long val) {
   rb_->SendLong(val);
 }
 
+void ParsedCommand::Resolve(payload::Payload&& pl) {
+  DCHECK(is_deferred_reply_);
+  DCHECK_GT(pl.index(), 0u);  // not monostate
+  reply_ = std::move(pl);
+}
+
 bool ParsedCommand::CanReply() const {
   DCHECK(is_deferred_reply_);
   dfly::Overloaded ov{[](const payload::Payload& pl) { return pl.index() > 0 /* not monostate */; },

--- a/src/facade/parsed_command.h
+++ b/src/facade/parsed_command.h
@@ -162,6 +162,9 @@ class ParsedCommand : public cmn::BackedArguments {
     SendError(error);
   }
 
+  // Resolve deferred command with a captured payload.
+  void Resolve(payload::Payload&& pl);
+
   // Suspend the deferred command until `blocker` reaches zero.
   // When that happens, CanReply() returns true and SendReply() will resume `coro`,
   // which is expected to write the reply directly to the reply builder.

--- a/src/facade/reply_builder_test.cc
+++ b/src/facade/reply_builder_test.cc
@@ -913,6 +913,37 @@ TEST_F(RedisReplyBuilderTest, BasicCapture) {
   builder_->SetRespVersion(RespVersion::kResp2);
 }
 
+// Regression: applying a captured payload into a CapturingReplyBuilder that is in the middle
+// of building a collection must append to the open collection, not overwrite the root value.
+// Before the fix, SendDirect() ignored the open collection on the stack and stored the value
+// into current_, so the collection was left unfilled and Take() crashed on CHECK(stack_.empty()).
+// This is the path hit when MULTI/EXEC array replies are re-applied during pipeline squashing.
+TEST_F(RedisReplyBuilderTest, CaptureApplyIntoOpenCollection) {
+  // The expected bytes: an array [1, "two"] built directly on a real builder.
+  builder_->StartArray(2);
+  builder_->SendLong(1);
+  builder_->SendBulkString("two");
+  const string expected = TakePayload();
+
+  // Pre-capture the two element replies as standalone payloads.
+  CapturingReplyBuilder elem{};
+  elem.SendLong(1);
+  auto p1 = elem.Take();
+  elem.SendBulkString("two");
+  auto p2 = elem.Take();
+
+  // Build the same array on a capturing builder, but fill the elements via Apply() — which
+  // routes through SendDirect() because the target is itself a CapturingReplyBuilder.
+  CapturingReplyBuilder outer{};
+  outer.StartArray(2);
+  CapturingReplyBuilder::Apply(std::move(p1), &outer);
+  CapturingReplyBuilder::Apply(std::move(p2), &outer);
+
+  // Would crash here (CHECK stack_.empty()) before the fix.
+  CapturingReplyBuilder::Apply(outer.Take(), builder_.get());
+  EXPECT_EQ(expected, TakePayload());
+}
+
 TEST_F(RedisReplyBuilderTest, FormatDouble) {
   char buf[64];
 

--- a/src/facade/reply_capture.cc
+++ b/src/facade/reply_capture.cc
@@ -82,8 +82,8 @@ void CapturingReplyBuilder::SendDirect(Payload&& val) {
   bool is_err = holds_alternative<Error>(val);
   ReplyMode min_mode = is_err ? ReplyMode::ONLY_ERR : ReplyMode::FULL;
   if (reply_mode_ >= min_mode) {
-    DCHECK_EQ(current_.index(), 0u);
-    current_ = std::move(val);
+    // Capture() appends to an open collection if one exists, otherwise stores into current_.
+    Capture(std::move(val));
   } else {
     current_ = monostate{};
   }

--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -27,6 +27,7 @@ struct CmdRef {
   const CommandId* cid = nullptr;
   facade::ParsedArgs args;
   facade::ReplyMode reply_mode = facade::ReplyMode::FULL;
+  CommandContext* cmd_cntx = nullptr;
 
   bool IsValid() const {
     return cid != nullptr;

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -163,9 +163,26 @@ bool MultiCommandSquasher::ExecuteStandalone(RedisReplyBuilder* rb, CmdRef cmd) 
 
   auto args = cmd.Slice(&tmp_keylist_);
 
+  // In pipeline mode the reply is captured and deferred into the parsed command, preserving
+  // the reply order with squashed commands whose replies are sent later by the connection.
+  optional<CapturingReplyBuilder> crb;
+  if (opts_.pipeline_mode) {
+    DCHECK(cmd.cmd_cntx);
+    cmd.cmd_cntx->SetDeferredReply();
+    DCHECK(cmd.reply_mode == ReplyMode::FULL);
+    crb.emplace(ReplyMode::FULL, rb->GetRespVersion());
+    rb = &*crb;
+  }
+
+  auto resolve = [&] {
+    if (crb)
+      cmd.cmd_cntx->Resolve(crb->Take());
+  };
+
   if (opts_.verify_commands) {
     if (auto err = service_->VerifyCommandState(*cmd.cid, args, *cntx_); err) {
       rb->SendError(std::move(*err));
+      resolve();
       return !opts_.error_abort;
     }
   }
@@ -176,13 +193,17 @@ bool MultiCommandSquasher::ExecuteStandalone(RedisReplyBuilder* rb, CmdRef cmd) 
     auto status = tx->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, args);
     if (status != OpStatus::OK) {
       rb->SendError(status);
+      resolve();
       return !opts_.error_abort;
     }
   }
+
   CommandContext cmd_cntx{rb, cntx_};
   cmd_cntx.SetupTx(cmd.cid, tx);
   cmd_cntx.SetTailArgs(cmd.args);
   service_->InvokeCmd(args, &cmd_cntx);
+  resolve();
+
   return true;
 }
 
@@ -210,7 +231,13 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
       // The shared context is used for state verification, the local one is only for replies
       if (auto err = service_->VerifyCommandState(*dispatched.cmd.cid, args, *cntx_); err) {
         crb.SendError(std::move(*err));
-        move_reply(crb.Take(), &dispatched.reply);
+        auto payload = crb.Take();
+        if (opts_.pipeline_mode) {
+          DCHECK(dispatched.cmd.cmd_cntx);
+          dispatched.cmd.cmd_cntx->Resolve(std::move(payload));
+        } else {
+          move_reply(std::move(payload), &dispatched.reply);
+        }
         continue;
       }
     }
@@ -226,7 +253,13 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
       cmd_cntx.SetTailArgs(dispatched.cmd.args);
       service_->InvokeCmd(args, &cmd_cntx);
     }
-    move_reply(crb.Take(), &dispatched.reply);
+    auto payload = crb.Take();
+    if (opts_.pipeline_mode) {
+      DCHECK(dispatched.cmd.cmd_cntx);
+      dispatched.cmd.cmd_cntx->Resolve(std::move(payload));
+    } else {
+      move_reply(std::move(payload), &dispatched.reply);
+    }
   }
 
   return OpStatus::OK;
@@ -251,6 +284,16 @@ bool MultiCommandSquasher::ExecuteSquashed(facade::RedisReplyBuilder* rb) {
   base::SpinLock lock;
   uint64_t fiber_running_cycles{0}, proactor_running_cycles{0};
   uint32_t max_sched_thread_id{0}, max_sched_seq_num{0};
+
+  // Mark pipeline commands as deferred before dispatching to shards.
+  if (opts_.pipeline_mode) {
+    for (auto& sinfo : sharded_) {
+      for (auto& cmd : sinfo.dispatched) {
+        DCHECK(cmd.cmd.cmd_cntx);
+        cmd.cmd.cmd_cntx->SetDeferredReply();
+      }
+    }
+  }
 
   // Atomic transactions (that have all keys locked) perform hops and run squashed commands via
   // stubs, non-atomic ones just run the commands in parallel.
@@ -314,21 +357,26 @@ bool MultiCommandSquasher::ExecuteSquashed(facade::RedisReplyBuilder* rb) {
   uint64_t after_hop = CycleClock::Now();
   bool aborted = false;
 
-  size_t total_reply_size = 0;
-  for (auto& sinfo : sharded_) {
-    total_reply_size += sinfo.reply_size_delta;
-  }
+  if (!opts_.pipeline_mode) {
+    size_t total_reply_size = 0;
+    for (auto& sinfo : sharded_) {
+      total_reply_size += sinfo.reply_size_delta;
+    }
 
-  for (auto idx : order_) {
-    auto& sinfo = sharded_[idx];
-    DCHECK_LT(sinfo.reply_id, sinfo.dispatched.size());
+    for (auto idx : order_) {
+      auto& sinfo = sharded_[idx];
+      DCHECK_LT(sinfo.reply_id, sinfo.dispatched.size());
 
-    auto& reply = sinfo.dispatched[sinfo.reply_id++].reply;
-    aborted |= opts_.error_abort && CapturingReplyBuilder::TryExtractError(reply);
+      auto& reply = sinfo.dispatched[sinfo.reply_id++].reply;
+      aborted |= opts_.error_abort && CapturingReplyBuilder::TryExtractError(reply);
 
-    CapturingReplyBuilder::Apply(std::move(reply), rb);
-    if (aborted)
-      break;
+      CapturingReplyBuilder::Apply(std::move(reply), rb);
+      if (aborted)
+        break;
+    }
+
+    tl_facade_stats->reply_stats.squashing_current_reply_size.fetch_sub(total_reply_size,
+                                                                        std::memory_order_release);
   }
 
   uint64_t after_reply = CycleClock::Now();
@@ -353,11 +401,12 @@ bool MultiCommandSquasher::ExecuteSquashed(facade::RedisReplyBuilder* rb) {
         << CycleClock::ToUsec(ProactorBase::me()->GetCurrentBusyCycles());
   }
 
-  tl_facade_stats->reply_stats.squashing_current_reply_size.fetch_sub(total_reply_size,
-                                                                      std::memory_order_release);
   for (auto& sinfo : sharded_) {
     sinfo.dispatched.clear();
     sinfo.reply_id = 0;
+    // Reset so a subsequent flush of the same instance does not re-count this batch's
+    // reply size into total_reply_size and underflow squashing_current_reply_size.
+    sinfo.reply_size_delta = 0;
   }
 
   order_.clear();

--- a/src/server/multi_command_squasher.h
+++ b/src/server/multi_command_squasher.h
@@ -25,6 +25,7 @@ class MultiCommandSquasher {
   struct Opts {
     bool verify_commands = false;   // Whether commands need to be verified before execution
     bool error_abort = false;       // Abort upon receiving error
+    bool pipeline_mode = false;     // Whether to expect pipeline command contexts
     unsigned max_squash_size = 32;  // How many commands to squash at once
   };
 

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -1320,6 +1320,24 @@ TEST_F(MultiTest, TestSquashing) {
   Run({"exec"});
 }
 
+// Regression: squashing_current_reply_size must return to zero after a squash that spans
+// multiple flushes. A single MultiCommandSquasher instance flushes once per batch that
+// reaches max_squash_cmd_num; reply_size_delta was not reset between flushes, so
+// total_reply_size double-counted earlier batches and the counter underflowed.
+TEST_F(MultiTest, SquashReplySizeAccounting) {
+  absl::FlagSaver fs;
+  absl::SetFlag(&FLAGS_multi_exec_squash, true);
+
+  // Must exceed max_squashed_cmd_num (default 100) so the squash spans multiple flushes.
+  const int kNumCmds = 300;
+  Run({"multi"});
+  for (int i = 0; i < kNumCmds; ++i)
+    Run({"set", kKey1, "v"});
+  Run({"exec"});
+
+  EXPECT_EQ(GetMetrics().facade_stats.reply_stats.squashing_current_reply_size, 0u);
+}
+
 TEST_F(MultiTest, MultiLeavesTxQueue) {
   // Tests the scenario, where the OOO multi-tx is scheduled into tx queue and there is another
   // tx (mget) after it that runs and tests for atomicity.


### PR DESCRIPTION
First of three incremental PRs for #7585.

Adds the capability for `MultiCommandSquasher` to route a command's reply into its
`ParsedCommand` (deferred reply) instead of replaying via the `order_` vector. This is
pure plumbing — **no behavior change**: the capability is gated by an explicit
`Opts::pipeline_mode` flag that no caller enables on this branch (`DispatchSquashedBatch`
turns it on in PR 2), so every current flow is unchanged.

## Changes
- Add `ParsedCommand::Resolve(payload::Payload&&)` overload (guards against monostate).
- Fix `CapturingReplyBuilder::SendDirect` to `Capture()` into an open collection (strict
  superset; safe for existing callers).
- Add `CmdRef::cmd_cntx` field and an explicit `MultiCommandSquasher::Opts::pipeline_mode`
  flag. In pipeline mode, replies are deferred into each command's `ParsedCommand` and the
  `order_` replay is skipped; `cmd_cntx` is `DCHECK`-guaranteed present.
- Fix a pre-existing reply-size accounting bug: `ShardExecInfo::reply_size_delta` was not
  reset between flushes, so a squash spanning multiple flushes (a batch exceeding
  `max_squashed_cmd_num`) double-counted and underflowed `squashing_current_reply_size`.

## Tests
- `RedisReplyBuilderTest.CaptureApplyIntoOpenCollection` — covers the `SendDirect` fix
  (applying a captured payload into a builder mid-collection).
- `MultiTest.SquashReplySizeAccounting` — covers the multi-flush reply-size accounting fix.

The pipeline-squashing wire-up (PR 2) and `DispatchManyCommands` removal (PR 3) follow.

Part of #7585