### PR TITLE
Squash V1 pipelines via DispatchSquashedBatch

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1740,20 +1740,47 @@ void Connection::SquashPipeline() {
 
   uint64_t start = CycleClock::Now();
 
-  // async_dispatch is a guard to prevent concurrent writes into reply_builder_, hence
-  // it must guard the Flush() as well.
+  // async_dispatch guards the whole batch: it gates sync dispatch and reply_builder_ writes
+  // (incl. Flush), and marks the connection as dispatching for DispatchTracker checkpoints.
+  // It must be set before DispatchSquashedBatch, which can preempt on shard hops.
   cc_->async_dispatch = true;
 
-  uint32_t num_dispatched_cmds = service_->DispatchManyCommands(parsed_to_execute_, pipeline_count,
-                                                                reply_builder_.get(), cc_.get());
+  uint32_t squashed =
+      service_->DispatchSquashedBatch(parsed_to_execute_, pipeline_count, cc_.get());
 
-  local_stats_.cmds += num_dispatched_cmds;
+  // Nothing was squashed (the head command can't join a batch, e.g. MULTI/EXEC, EVAL,
+  // subscribe, blocking, or unknown). Hand it off to regular dispatch without flushing or
+  // resetting batch mode here — doing so would break reply aggregation for the rest of the
+  // pipeline (e.g. a pipelined MULTI/EXEC would flush once per command).
+  if (squashed == 0) {
+    cc_->async_dispatch = false;
+    skip_next_squashing_ = true;
+    return;
+  }
+
+  // Send the deferred replies in linked-list order, then release the commands. SendReply() may
+  // preempt, allowing the producer to append new commands, so re-read the next pointer after it
+  // and advance the list incrementally to keep it consistent at any preemption point.
+  for (unsigned i = 0; i < squashed && parsed_head_; ++i) {
+    auto* current = parsed_head_;
+
+    DCHECK(current->CanReply());
+    current->SendReply();
+
+    conn_stats.pipelined_wait_latency += CycleClock::ToUsec(start - current->parsed_cycle);
+
+    auto* next = current->next;
+    ReleasePipelinedCommand(current);
+    AdvanceParsedHead(next);
+  }
+  parsed_to_execute_ = parsed_head_;
+
+  local_stats_.cmds += squashed;
   last_interaction_ = time(nullptr);
 
-  // TODO: to investigate if always flushing will improve P99 latency because otherwise we
-  // wait for the next batch to finish before fully flushing the current response.
-  if (parsed_cmd_q_len_ == pipeline_count ||
-      always_flush_pipeline_cached) {  // Flush if no new commands appeared
+  // Flush if no new commands appeared while we dispatched. The released commands were already
+  // subtracted from parsed_cmd_q_len_, so add them back for the comparison.
+  if (parsed_cmd_q_len_ + squashed == pipeline_count || always_flush_pipeline_cached) {
     uint64_t flush_start_cycle = CycleClock::Now();
     reply_builder_->Flush();
     conn_stats.pipeline_dispatch_flush_count++;
@@ -1765,20 +1792,10 @@ void Connection::SquashPipeline() {
   cc_->async_dispatch = false;
 
   conn_stats.pipeline_dispatch_calls++;
-  conn_stats.pipeline_dispatch_commands += num_dispatched_cmds;
+  conn_stats.pipeline_dispatch_commands += squashed;
 
-  for (size_t i = 0; (i < num_dispatched_cmds) && parsed_head_; ++i) {
-    auto* next = parsed_head_->next;
-
-    conn_stats.pipelined_wait_latency += CycleClock::ToUsec(start - parsed_head_->parsed_cycle);
-
-    ReleasePipelinedCommand(parsed_head_);
-    AdvanceParsedHead(next);
-  }
-  parsed_to_execute_ = parsed_head_;
-
-  // If interrupted due to pause, fall back to regular dispatch
-  skip_next_squashing_ = (num_dispatched_cmds != pipeline_count);
+  // If interrupted due to pause or a non-squashable command, fall back to regular dispatch.
+  skip_next_squashing_ = (squashed != pipeline_count);
 }
 
 void Connection::ClearPipelinedMessages() {

--- a/src/facade/parsed_command.cc
+++ b/src/facade/parsed_command.cc
@@ -100,8 +100,10 @@ void ParsedCommand::SendLong(long val) {
 }
 
 void ParsedCommand::Resolve(payload::Payload&& pl) {
-  DCHECK(is_deferred_reply_);
+  DCHECK(!is_deferred_reply_);
   DCHECK_GT(pl.index(), 0u);  // not monostate
+
+  is_deferred_reply_ = true;
   reply_ = std::move(pl);
 }
 

--- a/src/facade/service_interface.h
+++ b/src/facade/service_interface.h
@@ -46,6 +46,14 @@ class ServiceInterface {
   virtual uint32_t DispatchManyCommands(ParsedCommand* head, unsigned count,
                                         SinkReplyBuilder* builder, ConnectionContext* cntx) = 0;
 
+  // Dispatches a batch of pipelined commands, squashing consecutive single-shard commands.
+  // Replies are deferred into the parsed commands and are sent by the connection afterwards.
+  // Returns the number of squashed commands.
+  virtual uint32_t DispatchSquashedBatch(ParsedCommand* first, unsigned count,
+                                         ConnectionContext* cntx) {
+    return 0;
+  }
+
   virtual ConnectionContext* CreateContext(Connection* owner) = 0;
 
   virtual ParsedCommand* AllocateParsedCommand() = 0;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1796,6 +1796,97 @@ uint32_t Service::DispatchManyCommands(facade::ParsedCommand* head, unsigned cou
   return dispatched;
 }
 
+uint32_t Service::DispatchSquashedBatch(facade::ParsedCommand* first, unsigned count,
+                                        facade::ConnectionContext* cntx) {
+  auto* dfly_cntx = static_cast<ConnectionContext*>(cntx);
+  DCHECK(!dfly_cntx->conn_state.exec_info.IsRunning());
+
+  auto* rb = static_cast<RedisReplyBuilder*>(first->rb());
+  auto* ss = ServerState::tlocal();
+
+  // Don't even start when paused. We can only continue if DispatchTracker is aware of us running.
+  if (ss->IsPaused())
+    return 0;
+
+  vector<CmdRef> cmd_refs;
+  cmd_refs.reserve(count);
+  intrusive_ptr<Transaction> dist_trans;
+  unsigned dispatched = 0;
+  MultiCommandSquasher::Stats stats;
+
+  auto perform_squash = [&] {
+    if (cmd_refs.empty())
+      return;
+
+    if (!dist_trans) {
+      dist_trans.reset(new Transaction{exec_cid_});
+      dist_trans->StartMultiNonAtomic();
+    } else {
+      // Reset to original command id as it's changed during squashing
+      dist_trans->MultiSwitchCmd(exec_cid_);
+    }
+
+    dfly_cntx->transaction = dist_trans.get();
+    MultiCommandSquasher::Opts opts;
+    opts.verify_commands = true;
+    opts.pipeline_mode = true;
+    opts.max_squash_size = ss->max_squash_cmd_num;
+
+    auto cmd_gen = [it = cmd_refs.begin(), end = cmd_refs.end()]() mutable -> CmdRef {
+      return (it == end) ? CmdRef{} : *it++;
+    };
+    stats += MultiCommandSquasher::Execute(std::move(cmd_gen), rb, dfly_cntx, this, opts);
+    dfly_cntx->transaction = nullptr;
+
+    dispatched += cmd_refs.size();
+    cmd_refs.clear();
+  };
+
+  auto* cmd = first;
+  for (unsigned i = 0; i < count && cmd; i++) {
+    auto* cmd_cntx = static_cast<CommandContext*>(cmd);
+
+    ParsedArgs args{*cmd_cntx};
+    const auto [cid, tail_args] = registry_.FindExtended(args);
+
+    // Only consecutive transactional single-shard commands are squashed. Stop the batch at the
+    // first command that can't join it; the connection's regular dispatch path then handles it
+    // (and the rest of the pipeline) with the real reply builder, after the replies squashed so
+    // far are flushed in order. Commands that stop the batch:
+    //  - unknown commands (cid == nullptr): dispatched standalone to produce their error reply;
+    //  - MULTI/EXEC and the commands queued between them: sequential, stored in ExecInfo;
+    //  - EVAL: scripts may require a stricter multi mode than the non-atomic squashing tx;
+    //  - blocking commands: prior replies must be flushed before the fiber blocks;
+    //  - QUIT: closes the reply builder, dropping any deferred replies not yet sent;
+    //  - subscribe/unsubscribe: emit one reply per channel (multiple top-level replies), which the
+    //    CapturingReplyBuilder backing deferred replies cannot represent.
+    if (cid == nullptr)
+      break;
+
+    const bool is_multi = dfly_cntx->conn_state.exec_info.IsCollecting() ||
+                          cid->MultiControlKind() == CO::MultiControlKind::EXEC;
+    const bool is_eval = cid->MultiControlKind() == CO::MultiControlKind::EVAL;
+    if (is_multi || is_eval || cid->IsBlocking() || string_view{cid->name()} == "QUIT" ||
+        absl::EndsWith(cid->name(), "SUBSCRIBE"))
+      break;
+
+    cmd_refs.push_back(CmdRef{cid, tail_args, ReplyMode::FULL, cmd_cntx});
+    cmd = cmd->next;
+  }
+
+  perform_squash();
+
+  if (dist_trans)
+    dist_trans->UnlockMulti();
+
+  ss->stats.multi_squash_exec_hop_usec += stats.hop_usec;
+  ss->stats.multi_squash_exec_reply_usec += stats.reply_usec;
+  ss->stats.multi_squash_hops += stats.hops;
+  ss->stats.squashed_commands += stats.squashed_commands;
+
+  return dispatched;
+}
+
 ErrorReply Service::ReportUnknownCmd(string_view cmd_name) {
   constexpr uint8_t kMaxUknownCommands = 64;
   constexpr uint8_t kMaxUknownCommandLength = 20;

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -46,6 +46,9 @@ class Service : public facade::ServiceInterface {
                                 facade::SinkReplyBuilder* builder,
                                 facade::ConnectionContext* cntx) final;
 
+  uint32_t DispatchSquashedBatch(facade::ParsedCommand* first, unsigned count,
+                                 facade::ConnectionContext* cntx) final;
+
   // Check OOM and invoke command with args
   facade::DispatchResult InvokeCmd(CmdArgList tail_args, CommandContext* cmd_cntx);
 

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -168,7 +168,6 @@ bool MultiCommandSquasher::ExecuteStandalone(RedisReplyBuilder* rb, CmdRef cmd) 
   optional<CapturingReplyBuilder> crb;
   if (opts_.pipeline_mode) {
     DCHECK(cmd.cmd_cntx);
-    cmd.cmd_cntx->SetDeferredReply();
     DCHECK(cmd.reply_mode == ReplyMode::FULL);
     crb.emplace(ReplyMode::FULL, rb->GetRespVersion());
     rb = &*crb;
@@ -232,8 +231,7 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
       if (auto err = service_->VerifyCommandState(*dispatched.cmd.cid, args, *cntx_); err) {
         crb.SendError(std::move(*err));
         auto payload = crb.Take();
-        if (opts_.pipeline_mode) {
-          DCHECK(dispatched.cmd.cmd_cntx);
+        if (dispatched.cmd.cmd_cntx) {
           dispatched.cmd.cmd_cntx->Resolve(std::move(payload));
         } else {
           move_reply(std::move(payload), &dispatched.reply);
@@ -254,8 +252,7 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
       service_->InvokeCmd(args, &cmd_cntx);
     }
     auto payload = crb.Take();
-    if (opts_.pipeline_mode) {
-      DCHECK(dispatched.cmd.cmd_cntx);
+    if (dispatched.cmd.cmd_cntx) {
       dispatched.cmd.cmd_cntx->Resolve(std::move(payload));
     } else {
       move_reply(std::move(payload), &dispatched.reply);
@@ -284,16 +281,6 @@ bool MultiCommandSquasher::ExecuteSquashed(facade::RedisReplyBuilder* rb) {
   base::SpinLock lock;
   uint64_t fiber_running_cycles{0}, proactor_running_cycles{0};
   uint32_t max_sched_thread_id{0}, max_sched_seq_num{0};
-
-  // Mark pipeline commands as deferred before dispatching to shards.
-  if (opts_.pipeline_mode) {
-    for (auto& sinfo : sharded_) {
-      for (auto& cmd : sinfo.dispatched) {
-        DCHECK(cmd.cmd.cmd_cntx);
-        cmd.cmd.cmd_cntx->SetDeferredReply();
-      }
-    }
-  }
 
   // Atomic transactions (that have all keys locked) perform hops and run squashed commands via
   // stubs, non-atomic ones just run the commands in parallel.

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import random
 import socket
-import ssl
 import string
 import time
 from dataclasses import dataclass
@@ -532,14 +531,14 @@ async def test_subscribers_with_active_publisher(df_server: DflyInstance, max_co
         for i in range(0, 150):
             try:
                 async with async_timeout.timeout(1):
-                    message = await channel.get_message(ignore_subscribe_messages=True)
+                    await channel.get_message(ignore_subscribe_messages=True)
             except asyncio.TimeoutError:
                 break
 
     async def subscribe_worker():
         client = aioredis.Redis(connection_pool=async_pool)
         pubsub = client.pubsub()
-        async with pubsub as p:
+        async with pubsub:
             await pubsub.subscribe("channel")
             await channel_reader(pubsub)
             await pubsub.unsubscribe("channel")
@@ -832,10 +831,9 @@ async def test_send_delay_metric(df_server: DflyInstance):
 
 
 async def test_match_http(df_server: DflyInstance):
-    client = df_server.client()
     reader, writer = await asyncio.open_connection("localhost", df_server.port)
     for i in range(2000):
-        writer.write(f"foo bar ".encode())
+        writer.write("foo bar ".encode())
         await writer.drain()
 
 
@@ -1076,6 +1074,52 @@ async def test_squashed_pipeline_multi(async_client: aioredis.Redis):
     await p.execute()
 
 
+"""
+Regression: subscribe/unsubscribe commands emit one reply per channel (multiple top-level
+replies), which the CapturingReplyBuilder backing deferred replies cannot represent. When such
+a command lands in a squashed pipeline it must be routed to the regular dispatch path, not
+captured — otherwise the server crashes (reply_capture: current_.index() == 0).
+"""
+
+
+@dfly_args({"proactor_threads": "1", "pipeline_squash": 1})
+async def test_squashed_pipeline_pubsub(df_server: DflyInstance):
+    reader, writer = await asyncio.open_connection("localhost", df_server.port)
+
+    def enc(*args):
+        out = f"*{len(args)}\r\n".encode()
+        for a in args:
+            b = str(a).encode()
+            out += f"${len(b)}\r\n".encode() + b + b"\r\n"
+        return out
+
+    # A large pipeline forces SquashPipeline; the multi-channel (s)unsubscribe commands sit
+    # among squashable SETs. A trailing PING marker confirms the whole batch was processed in
+    # order without crashing.
+    req = enc("SET", "k", "v") * 40
+    req += enc("SUNSUBSCRIBE", "chA", "chB")
+    req += enc("UNSUBSCRIBE", "chC", "chD")
+    req += enc("SET", "k", "v") * 40
+    req += enc("PING", "squash_survived")
+    writer.write(req)
+    await writer.drain()
+
+    data = b""
+    async with async_timeout.timeout(5):
+        while b"squash_survived" not in data:
+            chunk = await reader.read(65536)
+            if not chunk:
+                break
+            data += chunk
+
+    assert b"squash_survived" in data, "server did not finish the pipeline (crash?)"
+    # Both unsubscribe commands produced their per-channel replies, in order.
+    assert b"chA" in data and b"chB" in data  # SUNSUBSCRIBE
+    assert b"chC" in data and b"chD" in data  # UNSUBSCRIBE
+    writer.close()
+    await writer.wait_closed()
+
+
 async def test_unix_domain_socket(df_factory, tmp_dir):
     server = df_factory.create(proactor_threads=1, port=BASE_PORT, unixsocket="./df.sock")
     server.start()
@@ -1245,7 +1289,7 @@ async def test_timeout(df_server: DflyInstance, async_client: aioredis.Redis):
 @dfly_args({"send_timeout": 3})
 async def test_send_timeout(df_server, async_client: aioredis.Redis):
     reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
-    writer.write(f"client setname writer_test\n".encode())
+    writer.write("client setname writer_test\n".encode())
     await writer.drain()
     assert "OK" in (await reader.readline()).decode()
     clients = await async_client.client_list()
@@ -1256,7 +1300,7 @@ async def test_send_timeout(df_server, async_client: aioredis.Redis):
 
     async def get_task():
         while True:
-            writer.write(f"GET a\n".encode())
+            writer.write("GET a\n".encode())
             await writer.drain()
             await asyncio.sleep(0.1)
 
@@ -1302,23 +1346,24 @@ async def test_pipeline_cache_only_async_squashed_dispatches(df_factory):
     await client.ping()  # Make sure the connection and the protocol were established
 
     async def push_pipeline(size):
-        p = client.pipeline(transaction=True)
+        # Plain (non-transactional) pipeline: MULTI/EXEC is no longer squash-dispatched
+        # (it falls back to regular dispatch), so use squashable commands to exercise the
+        # SquashPipeline cache lifecycle.
+        p = client.pipeline(transaction=False)
         for i in range(size):
             p.info()
         res = await p.execute()
         return res
 
-    # Dispatch only async command/pipelines and force squashing. pipeline_cache_bytes,
-    # should be zero because:
-    # We always dispatch the items that will be squashed, so when `INFO` gets called
-    # the cache is empty because the pipeline consumed it throughout its execution
+    # Dispatch only async command/pipelines and force squashing. pipeline_cache_bytes
+    # should be zero because the squashed batch consumes the parsed commands and releases
+    # them only after execution, so while `INFO` runs the cache is empty.
     # high max_busy_read_usec ensures that the connection fiber has enough time to push
     # all the commands to reach the squashing limit.
     for i in range(0, 10):
-        # it's actually 11 commands. 8 INFO + 2 from the MULTI/EXEC block that is injected
-        # by the client. The minimum to squash is 9 so it will squash the pipeline
-        # and INFO ALL should return zero for all the squashed commands in the pipeline
-        res = await push_pipeline(8)
+        # 10 INFO commands exceed pipeline_squash=9, so the whole pipeline is squashed and
+        # INFO should report pipeline_cache_bytes == 0 for every command in it.
+        res = await push_pipeline(10)
         for r in res:
             assert r["pipeline_cache_bytes"] == 0
 
@@ -1675,8 +1720,6 @@ async def test_client_migrate(df_server: DflyInstance):
 )
 async def test_client_migrate_no_conn_leak(df_server: DflyInstance):
     admin = df_server.client()
-    resp = await admin.execute_command("DFLY THREAD")
-    num_threads = resp[1]
 
     # Create multiple clients and migrate them all to the same thread.
     # If DecreaseConnStats is called twice per migration (double-decrement bug),
@@ -1902,7 +1945,7 @@ async def test_issue_5931_malformed_protocol_crash(df_server: DflyInstance):
         await writer.drain()
 
         try:
-            response = await asyncio.wait_for(reader.read(1024), timeout=2.0)
+            await asyncio.wait_for(reader.read(1024), timeout=2.0)
             # If we get a response, it should be an error, not a crash
             # The server is still running if we got here
         except asyncio.TimeoutError:
@@ -1947,7 +1990,7 @@ async def test_issue_5949_nil_bulk_string_crash(df_server: DflyInstance):
         await writer.drain()
 
         try:
-            response = await asyncio.wait_for(reader.read(1024), timeout=2.0)
+            await asyncio.wait_for(reader.read(1024), timeout=2.0)
             # If we get a response, it should be an error, not a crash
         except asyncio.TimeoutError:
             # Timeout is acceptable - connection might be closed
@@ -1981,6 +2024,17 @@ async def test_issue_6165_squash_invalid_syntax(async_client):
     res = await pip.execute(raise_on_error=False)
     assert res[0] == True  # SET key1
     assert isinstance(res[1], aioredis.ResponseError)  # INVALID SYNTAX
+
+    # Unknown command (cid == nullptr) takes the inline non-squashable path in
+    # DispatchSquashedBatch; its error must be captured and replies kept in order.
+    pip = async_client.pipeline(transaction=False)
+    pip.set("k", "v")
+    pip.execute_command("FOOBAR", "arg1", "arg2")
+    pip.get("k")
+    res = await pip.execute(raise_on_error=False)
+    assert res[0] == True  # SET
+    assert isinstance(res[1], aioredis.ResponseError)  # unknown command
+    assert res[2] == "v"  # GET after the unknown command, order preserved
 
 
 @dfly_args({"proactor_threads": "2", "pipeline_squash": 1})


### PR DESCRIPTION
Second of three incremental PRs for #7585 (#7587 has merged; this now targets `main`).

Adds `Service::DispatchSquashedBatch` and routes `Connection::SquashPipeline` through it.
Consecutive single-shard pipeline commands are squashed and their replies deferred into each
`ParsedCommand`, then sent by the connection in linked-list order.

## Changes
- `Service::DispatchSquashedBatch` (`main_service.cc`, `main_service.h`, `service_interface.h`):
  accumulate squashable single-shard commands and **stop the batch at the first command that
  can't join it**, letting the connection's regular dispatch path handle it (and the rest of
  the pipeline) with the real reply builder, after the squashed replies are flushed in order.
  Such commands: MULTI/EXEC and the commands queued between them, EVAL, blocking commands,
  QUIT, subscribe/unsubscribe (multiple top-level replies), and unknown commands.
- `Connection::SquashPipeline` (`dragonfly_connection.cc`): send the deferred replies in
  linked-list order; advance the list pointers incrementally to stay consistent across
  `SendReply()` preemption points; fix the post-dispatch flush condition for released commands.
- `ParsedCommand::Resolve(payload)` (`parsed_command.cc`): marks the command deferred itself.
  `MultiCommandSquasher` (`multi_command_squasher.cc`) routes a captured reply to
  `cmd_cntx->Resolve()` when present, otherwise replays it via `order_`.
- `DispatchManyCommands` is left in place (now dead in the connection flow) and removed in the
  follow-up PR (#7589).

## Tests (`connection_test.py`)
- `test_squashed_pipeline_pubsub` — subscribe/unsubscribe in a squashed pipeline.
- `test_issue_6165_squash_invalid_syntax` — added an unknown-command case.
- `test_multi_exec_phantom_connections` — passes again (MULTI/EXEC streams via the real builder).
- `test_pipeline_cache_only_async_squashed_dispatches` — switched to a non-transactional
  pipeline (MULTI/EXEC is no longer squash-dispatched).
- C++ `multi_test`, `dragonfly_test`; full AFL fuzz corpus replay clean.

Part of #7585