### PR TITLE
Consolidate CommandId derived attributes into a kind_mask bitmask

### DIFF
--- a/src/facade/command_id.h
+++ b/src/facade/command_id.h
@@ -94,14 +94,14 @@ class CommandId {
   int8_t first_key_;
   int8_t last_key_;
 
+  // Whether the command can only be used by admin connections.
+  bool restricted_ = false;
+
   // Acl categories
   uint32_t acl_categories_;
   // Acl commands indices
   size_t family_;
   uint64_t bit_index_;
-
-  // Whether the command can only be used by admin connections.
-  bool restricted_ = false;
 };
 
 }  // namespace facade

--- a/src/server/acl/validator.cc
+++ b/src/server/acl/validator.cc
@@ -81,8 +81,8 @@ bool ValidateCommand(const std::vector<uint64_t>& acl_commands, const CommandId&
 
   std::pair<bool, AclLog::Reason> auth_res;
 
-  if (auto pkind = id.PubSubKind(); pkind) {
-    bool is_pattern = *pkind == CO::PubSubKind::PATTERN;
+  if (id.IsPubSub()) {
+    bool is_pattern = id.IsPatternPubSub();
     auth_res =
         IsPubSubCommandAuthorized(is_pattern, cntx.acl_commands, cntx.pub_sub, tail_args, id);
   } else {

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -133,7 +133,8 @@ CommandId::CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first
                      int8_t last_key, std::optional<uint32_t> acl_categories)
     : facade::CommandId(name, ImplicitCategories(mask), arity, first_key, last_key,
                         acl_categories.value_or(ImplicitAclCategories(mask))) {
-  implicit_acl_ = !acl_categories.has_value();
+  if (!acl_categories.has_value())
+    kind_mask_ |= IMPLICIT_ACL;
   bool is_latency_tracked = GetFlag(FLAGS_latency_tracking);
   if (is_latency_tracked) {
     hdr_histogram* hist = nullptr;
@@ -143,17 +144,31 @@ CommandId::CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first
     latency_histogram_ = hist;
   }
 
-  if (name_.rfind("EVAL", 0) == 0)
-    kind_multi_ctr_ = CO::MultiControlKind::EVAL;
-  else if (base::_in(name_, {"EXEC", "MULTI", "DISCARD"}))
-    kind_multi_ctr_ = CO::MultiControlKind::EXEC;
-  else if (base::_in(name_, {"PUBLISH", "SUBSCRIBE", "UNSUBSCRIBE"}))
-    kind_pubsub_ = CO::PubSubKind::REGULAR;
-  else if (base::_in(name_, {"PSUBSCRIBE", "PUNSUBSCRIBE"}))
-    kind_pubsub_ = CO::PubSubKind::PATTERN;
-  else if (base::_in(name_, {"SPUBLISH", "SSUBSCRIBE", "SUNSUBSCRIBE"}))
-    kind_pubsub_ = CO::PubSubKind::SHARDED;
-  can_be_monitored_ = (opt_mask_ & CO::ADMIN) == 0 && name_ != "EXEC";
+  if (name_.rfind("EVAL", 0) == 0) {
+    kind_mask_ |= EVAL_CTRL;
+  } else if (base::_in(name_, {"EXEC", "MULTI", "DISCARD"})) {
+    kind_mask_ |= EXEC_CTRL;
+    if (name_ == "EXEC")
+      kind_mask_ |= EXEC;
+    else if (name_ == "MULTI")
+      kind_mask_ |= MULTI;
+  } else if (base::_in(name_, {"PUBLISH", "SUBSCRIBE", "UNSUBSCRIBE"})) {
+    kind_mask_ |= PUBSUB_REGULAR;
+    if (name_ == "PUBLISH")
+      kind_mask_ |= PUBLISH;
+  } else if (base::_in(name_, {"PSUBSCRIBE", "PUNSUBSCRIBE"})) {
+    kind_mask_ |= PUBSUB_PATTERN;
+  } else if (base::_in(name_, {"SPUBLISH", "SSUBSCRIBE", "SUNSUBSCRIBE"})) {
+    kind_mask_ |= PUBSUB_SHARDED;
+    if (name_ == "SPUBLISH")
+      kind_mask_ |= SPUBLISH;
+  } else if (name_ == "REPLCONF") {
+    kind_mask_ |= REPLCONF;
+  } else if (name_ == "QUIT") {
+    kind_mask_ |= QUIT;
+  }
+  if ((opt_mask_ & CO::ADMIN) == 0 && name_ != "EXEC")
+    kind_mask_ |= CAN_MONITOR;
 
   if (base::_in(name_, {"MSET", "MSETNX"}))
     interleave_step_ = 2;
@@ -163,7 +178,7 @@ CommandId::CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first
 
 CommandId::~CommandId() {
   // Aliases share the same latency histogram, so we only close it if this is not an alias.
-  if (latency_histogram_ && !is_alias_) {
+  if (latency_histogram_ && !IsAlias()) {
     hdr_close(latency_histogram_);
   }
 }
@@ -174,9 +189,12 @@ CommandId CommandId::Clone(const std::string_view name) const {
   cloned.handler_ = handler_;
   cloned.opt_mask_ = opt_mask_ | CO::HIDDEN;
   cloned.acl_categories_ = acl_categories_;
-  cloned.implicit_acl_ = implicit_acl_;
   cloned.interleave_step_ = interleave_step_;
-  cloned.is_alias_ = true;
+  // An alias is semantically the same command, so inherit the source's full derived identity and
+  // attributes (incl. SUPPORT_ASYNC, pub/sub & exec/eval identity, CAN_MONITOR, IMPLICIT_ACL) -
+  // the ctor recomputed these from the alias name, which is not what we want - and mark it as an
+  // alias.
+  cloned.kind_mask_ = kind_mask_ | IS_ALIAS;
 
   // explicit sharing of the object since it's an alias we can do that.
   // I am assuming that the source object lifetime is at least as of the cloned object.
@@ -191,15 +209,12 @@ bool CommandId::IsTransactional() const {
   if (first_key_ > 0 || (opt_mask_ & CO::GLOBAL_TRANS) || (opt_mask_ & CO::NO_KEY_TRANSACTIONAL))
     return true;
 
-  if (name_ == "EVAL" || name_ == "EVALSHA" || name_ == "EVAL_RO" || name_ == "EVALSHA_RO" ||
-      name_ == "EXEC")
-    return true;
-
-  return false;
+  // EVAL family (incl. *_RO) and EXEC (but not MULTI/DISCARD) are transactional.
+  return (kind_mask_ & EVAL_CTRL) || (kind_mask_ & EXEC);
 }
 
 bool CommandId::IsMultiTransactional() const {
-  return kind_multi_ctr_.has_value();
+  return kind_mask_ & (EVAL_CTRL | EXEC_CTRL);
 }
 
 optional<facade::ErrorReply> CommandId::Validate(CmdArgList tail_args) const {

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -51,15 +51,6 @@ enum CommandOpt : uint32_t {
   IDEMPOTENT = 1U << 18,
 };
 
-enum class PubSubKind : uint8_t { REGULAR = 0, PATTERN = 1, SHARDED = 2 };
-
-// Commands controlling any multi command execution.
-// They often need to be handled separately from regular commands in many contexts
-enum class MultiControlKind : uint8_t {
-  EVAL,  // EVAL, EVAL_RO, EVALSHA, EVALSHA_RO
-  EXEC,  // EXEC, MULTI, DISCARD
-};
-
 };  // namespace CO
 
 // Per thread vector of command stats. Each entry is {cmd_calls, cmd_latency_agg in usec}.
@@ -147,7 +138,7 @@ class CommandId : public facade::CommandId {
   // See deduction logic for details. We don't monitor ADMIN commands
   // and log the final `EXEC` command manually at the end.
   bool CanBeMonitored() const {
-    return can_be_monitored_;
+    return kind_mask_ & CAN_MONITOR;
   }
 
   int8_t interleaved_step() const {
@@ -156,13 +147,14 @@ class CommandId : public facade::CommandId {
 
   template <typename RT>
   CommandId&& SetAsyncHandler(RT f(facade::CmdArgParser, CommandContext*)) && {
-    support_async_ = true;
+    kind_mask_ |= SUPPORT_ASYNC;
     handler_ = [f](CmdArgList args, CommandContext* cntx) { f(MakeParserFromContext(cntx), cntx); };
     return std::move(*this);
   }
 
   CommandId&& SetHandler(Handler f, bool async_support = false) && {
-    support_async_ |= async_support;
+    if (async_support)
+      kind_mask_ |= SUPPORT_ASYNC;
     handler_ = std::move(f);
     return std::move(*this);
   }
@@ -183,42 +175,115 @@ class CommandId : public facade::CommandId {
   }
 
   void SetAclCategory(uint32_t mask) {
-    if (implicit_acl_)
+    if (kind_mask_ & IMPLICIT_ACL)
       acl_categories_ |= mask;
   }
 
   bool IsAlias() const {
-    return is_alias_;
+    return kind_mask_ & IS_ALIAS;
   }
 
   hdr_histogram* GetLatencyHist() const {
     return latency_histogram_;
   }
 
-  std::optional<CO::PubSubKind> PubSubKind() const {
-    return kind_pubsub_;
+  // Returns true if this command belongs to the pub/sub family (any variant).
+  bool IsPubSub() const {
+    return kind_mask_ & (PUBSUB_REGULAR | PUBSUB_PATTERN | PUBSUB_SHARDED);
   }
 
-  // Returns value if this command controls multi command execution (EVAL, EXEC & helpers)
-  std::optional<CO::MultiControlKind> MultiControlKind() const {
-    return kind_multi_ctr_;
+  bool IsShardedPubSub() const {
+    return kind_mask_ & PUBSUB_SHARDED;
+  }
+
+  bool IsPatternPubSub() const {
+    return kind_mask_ & PUBSUB_PATTERN;
+  }
+
+  bool IsSPublish() const {
+    return kind_mask_ & SPUBLISH;
+  }
+
+  bool IsPublish() const {
+    return kind_mask_ & PUBLISH;
+  }
+
+  // (UN)SUBSCRIBE and their P*/S* variants - the pub/sub commands that emit one reply per channel
+  // and may not run inside a transaction. Excludes PUBLISH / SPUBLISH.
+  bool IsSubscribeFamily() const {
+    return IsPubSub() && !IsPublish() && !IsSPublish();
+  }
+
+  // EVAL / EVAL_RO / EVALSHA / EVALSHA_RO.
+  bool IsEvalGroup() const {
+    return kind_mask_ & EVAL_CTRL;
+  }
+
+  // EXEC / MULTI / DISCARD.
+  bool IsExecGroup() const {
+    return kind_mask_ & EXEC_CTRL;
+  }
+
+  bool IsExec() const {
+    return kind_mask_ & EXEC;
+  }
+
+  bool IsMulti() const {
+    return kind_mask_ & MULTI;
+  }
+
+  bool IsReplConf() const {
+    return kind_mask_ & REPLCONF;
+  }
+
+  bool IsQuit() const {
+    return kind_mask_ & QUIT;
   }
 
   void RecordLatency(unsigned tid, uint64_t latency_usec) const;
 
   bool SupportsAsync() const {
-    return support_async_;
+    return kind_mask_ & SUPPORT_ASYNC;
   }
 
  private:
-  std::optional<CO::PubSubKind> kind_pubsub_;
-  std::optional<CO::MultiControlKind> kind_multi_ctr_;
+  // Engine-derived command identity and attributes, computed once in the constructor from the
+  // command name and opt_mask, and stored in kind_mask_ so that hot-path queries are single bit
+  // tests instead of string comparisons. This is an internal detail of CommandId, distinct from
+  // CO::CommandOpt which holds author-declared capabilities set at registration time.
+  enum CmdKind : uint16_t {
+    // pub/sub family. The *PUBLISH bits additionally mark the publishing command within a family.
+    PUBSUB_REGULAR = 1U << 0,  // PUBLISH / SUBSCRIBE / UNSUBSCRIBE
+    PUBSUB_PATTERN = 1U << 1,  // PSUBSCRIBE / PUNSUBSCRIBE
+    PUBSUB_SHARDED = 1U << 2,  // SPUBLISH / SSUBSCRIBE / SUNSUBSCRIBE
+    PUBLISH = 1U << 3,         // PUBLISH only
+    SPUBLISH = 1U << 4,        // SPUBLISH only
 
-  // The following fields must copy manually in the move constructor.
-  bool implicit_acl_;
-  bool is_alias_{false};
-  bool can_be_monitored_{true};
-  bool support_async_{false};
+    // multi command control family.
+    EVAL_CTRL = 1U << 5,  // EVAL / EVAL_RO / EVALSHA / EVALSHA_RO
+    EXEC_CTRL = 1U << 6,  // EXEC / MULTI / DISCARD
+    EXEC = 1U << 7,       // EXEC only
+    MULTI = 1U << 8,      // MULTI only
+
+    REPLCONF = 1U << 9,  // REPLCONF only
+    QUIT = 1U << 10,     // QUIT only
+
+    // attributes (formerly standalone bool members).
+
+    // Command shows up in MONITOR output. Set for all non-ADMIN commands except EXEC (the final
+    // EXEC of a transaction is logged manually after its body).
+    CAN_MONITOR = 1U << 11,
+    // ACL categories were derived from opt_mask (no explicit categories given at registration).
+    // Only such commands may have categories augmented later via SetAclCategory().
+    IMPLICIT_ACL = 1U << 12,
+    // This CommandId is an alias of another command, produced by Clone().
+    IS_ALIAS = 1U << 13,
+    // Command has an async handler (set via SetAsyncHandler / SetHandler with async_support).
+    SUPPORT_ASYNC = 1U << 14,
+  };
+
+  // CmdKind bits. Trivially copied by the move ctor.
+  uint16_t kind_mask_ = 0;
   int8_t interleave_step_{0};
 
   struct alignas(64) StatsCell {

--- a/src/server/conn_context.cc
+++ b/src/server/conn_context.cc
@@ -337,23 +337,18 @@ void CommandContext::RecordLatency(facade::ArgSlice tail_args) const {
   auto* cntx = static_cast<dfly::ConnectionContext*>(conn_cntx());
 
   // Log nested commands of scripts that made it into slowlog
-  if (auto sinfo = cntx->conn_state.script_info.get(); !cid_->MultiControlKind() && sinfo)
+  if (auto sinfo = cntx->conn_state.script_info.get(); !cid_->IsMultiTransactional() && sinfo)
     sinfo->stats.slow_commands.fetch_add(1, memory_order_relaxed);
 
   vector<string> aux_params;
   CmdArgVec aux_slice;
 
   // Rewrite arguments for exec/eval with stats
-  if (auto mck = cid_->MultiControlKind(); mck) {
-    switch (*mck) {
-      case CO::MultiControlKind::EXEC:
-        if (cid_->name() == "EXEC")
-          aux_params = FormatExecSlowlog(cntx->conn_state);
-        break;
-      case CO::MultiControlKind::EVAL:
-        aux_params = FormatEvalSlowlog(cntx->conn_state);
-        break;
-    };
+  if (cid_->IsMultiTransactional()) {
+    if (cid_->IsExec())
+      aux_params = FormatExecSlowlog(cntx->conn_state);
+    else if (cid_->IsEvalGroup())
+      aux_params = FormatEvalSlowlog(cntx->conn_state);
     aux_slice = {aux_params.begin(), aux_params.end()};
     if (tail_args.size() > 0) {
       if (!aux_params.empty())

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -543,7 +543,7 @@ enum class ExecScriptUse : uint8_t {
 ExecScriptUse DetermineScriptPresense(const std::vector<StoredCmd>& body) {
   bool script_load = false;
   for (const auto& scmd : body) {
-    if (scmd.Cid()->MultiControlKind() == CO::MultiControlKind::EVAL) {
+    if (scmd.Cid()->IsEvalGroup()) {
       return ExecScriptUse::SCRIPT_RUN;
     }
 
@@ -823,8 +823,9 @@ void CheckPauseState(facade::Connection* conn, ConnectionContext* dfly_cntx, con
   auto& etl = *ServerState::tlocal();
   if (etl.IsPaused() && !conn->IsPrivileged()) {
     bool is_write = cid->IsJournaled();
-    is_write |= cid->name() == "PUBLISH" || cid->name() == "EVAL" || cid->name() == "EVALSHA";
-    is_write |= cid->name() == "EXEC" && dfly_cntx->conn_state.exec_info.is_write;
+    // PUBLISH and writable EVAL/EVALSHA (not the *_RO variants) count as writes here.
+    is_write |= cid->IsPublish() || (cid->IsEvalGroup() && !cid->IsReadOnly());
+    is_write |= cid->IsExec() && dfly_cntx->conn_state.exec_info.is_write;
 
     dfly_cntx->paused = true;
     etl.AwaitPauseState(is_write);
@@ -1181,9 +1182,9 @@ void Service::Shutdown() {
 
 OpResult<KeyIndex> Service::FindKeys(const CommandId* cid, CmdArgList args) {
   // Sharded pub-sub acts as if it's sharded by its channel name (just for checks)
-  if (cid->PubSubKind() == CO::PubSubKind::SHARDED) {
+  if (cid->IsShardedPubSub()) {
     // SPUBLISH has only one key, the rest is data
-    if (cid->name() == "SPUBLISH")
+    if (cid->IsSPublish())
       return KeyIndex(0, 1);
     return {KeyIndex(0, args.size())};  // sub/unsub list of channels
   }
@@ -1198,7 +1199,7 @@ optional<ErrorReply> Service::CheckKeysOwnership(const CommandId& cid, CmdArgLis
     return nullopt;
   }
 
-  if (cid.first_key_pos() == 0 && cid.PubSubKind() != CO::PubSubKind::SHARDED) {
+  if (cid.first_key_pos() == 0 && !cid.IsShardedPubSub()) {
     return nullopt;  // No key command.
   }
 
@@ -1234,7 +1235,7 @@ optional<ErrorReply> Service::CheckKeysOwnership(const CommandId& cid, CmdArgLis
 // TODO(kostas) refactor. Almost 1-1 with CheckKeyOwnership() above.
 std::optional<facade::ErrorReply> Service::TakenOverSlotError(const CommandId& cid, CmdArgList args,
                                                               const ConnectionContext& dfly_cntx) {
-  if (cid.first_key_pos() == 0 && cid.PubSubKind() != CO::PubSubKind::SHARDED) {
+  if (cid.first_key_pos() == 0 && !cid.IsShardedPubSub()) {
     return nullopt;  // No key command.
   }
 
@@ -1367,17 +1368,19 @@ std::optional<ErrorReply> Service::VerifyCommandState(const CommandId& cid, CmdA
   string_view cmd_name{cid.name()};
 
   if (dfly_cntx.req_auth && !dfly_cntx.authenticated) {
-    if (cmd_name != "AUTH" && cmd_name != "QUIT" && cmd_name != "HELLO") {
+    if (cmd_name != "AUTH" && !cid.IsQuit() && cmd_name != "HELLO") {
       return ErrorReply{"-NOAUTH Authentication required.", facade::kNoAuthErrType};
     }
   }
 
-  // only reset and quit are allow if this connection is used for monitoring
-  if (dfly_cntx.monitor && (cmd_name != "RESET" && cmd_name != "QUIT"))
+  // only reset and quit are allow if this connection is used for monitoring.
+  // In Valkey monitor connections are marked as replica connections, so they get this unrelated
+  // error message.
+  if (dfly_cntx.monitor && (cmd_name != "RESET" && !cid.IsQuit()))
     return ErrorReply{"Replica can't interact with the keyspace"};
 
   bool is_write_cmd = cid.IsJournaled();
-  bool is_trans_cmd = cid.MultiControlKind() == CO::MultiControlKind::EXEC;
+  bool is_trans_cmd = cid.IsExecGroup();
   bool under_script = dfly_cntx.conn_state.script_info != nullptr;
   bool multi_active = dfly_cntx.conn_state.exec_info.IsCollecting() && !is_trans_cmd;
 
@@ -1386,7 +1389,7 @@ std::optional<ErrorReply> Service::VerifyCommandState(const CommandId& cid, CmdA
 
   if (multi_active) {
     if (cmd_name == "WATCH" || cmd_name == "FLUSHALL" || cmd_name == "FLUSHDB" ||
-        absl::EndsWith(cmd_name, "SUBSCRIBE"))
+        cid.IsSubscribeFamily())
       return ErrorReply{absl::StrCat("'", cmd_name, "' not allowed inside a transaction")};
   }
 
@@ -1513,7 +1516,7 @@ DispatchResult Service::DispatchCommand(facade::ParsedArgs args, facade::ParsedC
     // Bonus points because this allows to continue replication with ACL users who got
     // their access revoked and reinstated
 
-    if (cid->name() == "REPLCONF") {
+    if (cid->IsReplConf()) {
       DCHECK_GE(args_no_cmd.size(), 1u);
       // We should not reply to REPLCONF ACKS.
       if (absl::EqualsIgnoreCase(args_no_cmd.Front(), "ACK")) {
@@ -1532,7 +1535,7 @@ DispatchResult Service::DispatchCommand(facade::ParsedArgs args, facade::ParsedC
       << ConnectionLogContext(dfly_cntx->conn());
 
   // If inside MULTI block, store command
-  bool is_trans_cmd = cid->MultiControlKind() == CO::MultiControlKind::EXEC;
+  bool is_trans_cmd = cid->IsExecGroup();
   if (dfly_cntx->conn_state.exec_info.IsCollecting() && !is_trans_cmd) {
     uint8_t tail_index = args.size() - args_no_cmd.size();
     StoreInMultiBlock(dfly_cntx, cid, parsed_cmd, tail_index);
@@ -1591,10 +1594,10 @@ class ReplyGuard {
   explicit ReplyGuard(const CommandContext& cmd_cntx) {
     const bool is_script = bool(cmd_cntx.server_conn_cntx()->conn_state.script_info);
     cid_name_ = cmd_cntx.cid()->name();
-    const bool is_one_of = (cid_name_ == "REPLCONF" || cid_name_ == "DFLY");
+    const bool is_one_of = (cmd_cntx.cid()->IsReplConf() || cid_name_ == "DFLY");
     bool is_mcache = cmd_cntx.mc_command() != nullptr;
     const bool is_no_reply_memcache =
-        (is_mcache && cmd_cntx.mc_command()->cmd_flags.no_reply) || cid_name_ == "QUIT";
+        (is_mcache && cmd_cntx.mc_command()->cmd_flags.no_reply) || cmd_cntx.cid()->IsQuit();
     const bool should_dcheck = !is_one_of && !is_script && !is_no_reply_memcache;
     if (should_dcheck) {
       cmd_cntx_ = &cmd_cntx;
@@ -1669,7 +1672,7 @@ DispatchResult Service::InvokeCmd(CmdArgList tail_args, CommandContext* cmd_cntx
     }
 
     if (cntx->conn_state.tracking_info_.IsTrackingOn()) {
-      if ((!tx && cid->name() != "MULTI") || (tx && !tx->IsMulti())) {
+      if ((!tx && !cid->IsMulti()) || (tx && !tx->IsMulti())) {
         // Each time we execute a command we need to increase the sequence number in
         // order to properly track clients when OPTIN is used.
         // We don't do this for `multi/exec` because it would break the
@@ -1688,12 +1691,10 @@ DispatchResult Service::InvokeCmd(CmdArgList tail_args, CommandContext* cmd_cntx
 
   // For EVAL[] and EXEC/DISCARD, clean up state.
   // We don't do it directly in commands to allow some introspection after execution (slowlog).
-  if (auto mck = cid->MultiControlKind(); mck) {
-    if (*mck == CO::MultiControlKind::EXEC && cid->name() != "MULTI")
-      MultiCleanup(cntx);
-    else if (*mck == CO::MultiControlKind::EVAL)
-      cntx->conn_state.script_info.reset();
-  }
+  if (cid->IsExecGroup() && !cid->IsMulti())
+    MultiCleanup(cntx);
+  else if (cid->IsEvalGroup())
+    cntx->conn_state.script_info.reset();
 
   return res;
 }
@@ -1765,11 +1766,9 @@ uint32_t Service::DispatchSquashedBatch(facade::ParsedCommand* first, unsigned c
     if (cid == nullptr)
       break;
 
-    const bool is_multi = dfly_cntx->conn_state.exec_info.IsCollecting() ||
-                          cid->MultiControlKind() == CO::MultiControlKind::EXEC;
-    const bool is_eval = cid->MultiControlKind() == CO::MultiControlKind::EVAL;
-    if (is_multi || is_eval || cid->IsBlocking() || string_view{cid->name()} == "QUIT" ||
-        absl::EndsWith(cid->name(), "SUBSCRIBE"))
+    const bool is_multi = dfly_cntx->conn_state.exec_info.IsCollecting() || cid->IsExecGroup();
+    const bool is_eval = cid->IsEvalGroup();
+    if (is_multi || is_eval || cid->IsBlocking() || cid->IsQuit() || cid->IsSubscribeFamily())
       break;
 
     cmd_refs.push_back(CmdRef{cid, tail_args, ReplyMode::FULL, cmd_cntx});
@@ -2514,7 +2513,7 @@ void Service::Exec(CmdArgList args, CommandContext* cmd_cntx) {
 }
 
 void Service::Publish(CmdArgList args, CommandContext* cmd_cntx) {
-  bool sharded = cmd_cntx->cid()->PubSubKind() == CO::PubSubKind::SHARDED;
+  bool sharded = cmd_cntx->cid()->IsShardedPubSub();
   if (!sharded && IsClusterEnabled())
     return cmd_cntx->SendError("PUBLISH is not supported in cluster mode yet");
 
@@ -2525,7 +2524,7 @@ void Service::Publish(CmdArgList args, CommandContext* cmd_cntx) {
 }
 
 void Service::Subscribe(CmdArgList args, CommandContext* cmd_cntx) {
-  bool sharded = cmd_cntx->cid()->PubSubKind() == CO::PubSubKind::SHARDED;
+  bool sharded = cmd_cntx->cid()->IsShardedPubSub();
   if (!sharded && IsClusterEnabled())
     return cmd_cntx->SendError("SUBSCRIBE is not supported in cluster mode yet");
 
@@ -2535,7 +2534,7 @@ void Service::Subscribe(CmdArgList args, CommandContext* cmd_cntx) {
 }
 
 void Service::Unsubscribe(CmdArgList args, CommandContext* cmd_cntx) {
-  bool sharded = cmd_cntx->cid()->PubSubKind() == CO::PubSubKind::SHARDED;
+  bool sharded = cmd_cntx->cid()->IsShardedPubSub();
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   auto* conn_cntx = cmd_cntx->server_conn_cntx();
   if (!sharded && IsClusterEnabled())


### PR DESCRIPTION
## Summary

`CommandId` stored derived command attributes across several separate fields and re-derived command identity on the dispatch hot path via `cid->name()` string comparisons. This consolidates all of it into a single `uint16_t kind_mask_` of `CmdKind` bits computed once in the constructor, so hot-path queries are single bit tests.

## Changes

- Replace fields `kind_pubsub_`, `kind_multi_ctr_`, `implicit_acl_`, `is_alias_`, `can_be_monitored_`, `support_async_` with one `kind_mask_`.
- Add a private `CommandId::CmdKind` enum; remove the public `CO::PubSubKind` and `CO::MultiControlKind` enums (the enum is an internal detail, not part of the author-facing `CO` flag vocabulary).
- Expose flat predicates — `IsPubSub`/`IsShardedPubSub`/`IsPatternPubSub`/`IsPublish`/`IsSPublish`, `IsEvalGroup`/`IsExecGroup`/`IsExec`/`IsMulti`, `IsReplConf` — and reimplement `CanBeMonitored`/`IsAlias`/`SupportsAsync`/`IsMultiTransactional`/`IsTransactional` on the mask.
- Convert all dispatch-path `name()==...` compares (REPLCONF, MULTI, SPUBLISH) and every `MultiControlKind`/`PubSubKind` enum comparison across `main_service.cc`, `conn_context.cc`, and `acl/validator.cc` to bit tests.

`CheckPauseState` keeps its original semantics by guarding the EVAL group with `!IsReadOnly()`, so the read-only `EVAL_RO`/`EVALSHA_RO` variants are not treated as writes.

## Testing

- `ninja dragonfly` — clean build
- `multi_test` (59 passed, 2 unconditional skips), `acl_family_test` (19), `dragonfly_test` (45, incl. the alias/`Clone` test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)