### PR TITLE
test(fuzz): Add experimental persistent AFL++ nightly fuzzing

### DIFF
--- a/.github/actions/fuzzing/action.yml
+++ b/.github/actions/fuzzing/action.yml
@@ -181,7 +181,7 @@ runs:
           if [ -f "$STATS_FILE" ]; then
             echo ""
             echo "Key Statistics:"
-            grep -E "execs_done|execs_per_sec|paths_total|corpus_count|unique_crashes|unique_hangs|last_crash|last_hang" "$STATS_FILE" || true
+            grep -E "execs_done|execs_per_sec|paths_total|corpus_count|saved_crashes|saved_hangs|unique_crashes|unique_hangs|last_crash|last_hang" "$STATS_FILE" || true
           fi
         fi
 

--- a/.github/workflows/fuzz-experimental-persistent.yml
+++ b/.github/workflows/fuzz-experimental-persistent.yml
@@ -1,0 +1,377 @@
+name: Experimental AFL++ Persistent Fuzzing
+
+on:
+  schedule:
+    # Run two hours before the regular AFL++ long campaign.
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      resp_duration:
+        description: 'RESP fuzzing duration in minutes'
+        required: false
+        default: '90'
+        type: string
+      memcache_duration:
+        description: 'Memcache fuzzing duration in minutes'
+        required: false
+        default: '60'
+        type: string
+      reset_state:
+        description: 'Drop restored AFL state and start from seeds'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  experimental-persistent-fuzz:
+    if: github.repository == 'dragonflydb/dragonfly'
+    runs-on: CI-LARGE-86
+    timeout-minutes: 150
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.target }}
+      cancel-in-progress: false
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: resp
+            duration: '90'
+          - target: memcache
+            duration: '60'
+
+    container:
+      image: ghcr.io/romange/ubuntu-dev:24-afl
+      options: --security-opt seccomp=unconfined --sysctl "net.ipv6.conf.all.disable_ipv6=0"
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    env:
+      TARGET: ${{ matrix.target }}
+      DURATION_MINUTES: ${{ matrix.target == 'resp' && (github.event.inputs.resp_duration || matrix.duration) || (github.event.inputs.memcache_duration || matrix.duration) }}
+      RESET_STATE: ${{ inputs.reset_state && 'true' || 'false' }}
+      OUTPUT_DIR: ${{ github.workspace }}/fuzz/artifacts/experimental-persistent/${{ matrix.target }}
+      CORPUS_DIR: ${{ github.workspace }}/fuzz/corpus/experimental-persistent/${{ matrix.target }}
+      HEALTH_DIR: ${{ github.workspace }}/fuzz/health/experimental-persistent/${{ matrix.target }}
+      CACHE_KEY: experimental-afl-${{ runner.os }}-${{ matrix.target }}-v1-${{ github.run_number }}-${{ github.run_attempt }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Verify AFL++ installation
+        run: |
+          echo "Verifying AFL++ installation..."
+          afl-fuzz -h | head -5 || true
+          which afl-clang-fast
+          which afl-clang-fast++
+          afl-clang-fast --version
+
+      - name: Configure system for fuzzing
+        run: |
+          echo "Configuring system for AFL++ fuzzing..."
+          afl-system-config || true
+          echo core > /proc/sys/kernel/core_pattern || echo "Warning: Could not set core_pattern"
+          echo "System configured"
+
+      - name: Prepare experimental fuzzing paths
+        run: |
+          echo "Experimental persistent fuzzing configuration:"
+          echo "  target: ${TARGET}"
+          echo "  duration: ${DURATION_MINUTES} minutes"
+          echo "  reset_state: ${RESET_STATE}"
+          echo "  output_dir: ${OUTPUT_DIR}"
+          echo "  corpus_dir: ${CORPUS_DIR}"
+          echo "  cache_key: ${CACHE_KEY}"
+          echo "  run_url: ${RUN_URL}"
+
+          if [[ "${RESET_STATE}" == "true" ]]; then
+            echo "Reset requested: removing restored AFL state before run"
+            rm -rf "${OUTPUT_DIR}" "${CORPUS_DIR}"
+          fi
+
+          mkdir -p "${OUTPUT_DIR}" "${CORPUS_DIR}" "${HEALTH_DIR}"
+
+      - name: Restore experimental AFL state
+        id: restore-afl-state
+        if: env.RESET_STATE != 'true'
+        uses: actions/cache/restore@v5
+        continue-on-error: true
+        with:
+          path: |
+            fuzz/artifacts/experimental-persistent/${{ matrix.target }}/default/queue
+            fuzz/artifacts/experimental-persistent/${{ matrix.target }}/default/.state
+            fuzz/artifacts/experimental-persistent/${{ matrix.target }}/default/fuzzer_stats
+            fuzz/artifacts/experimental-persistent/${{ matrix.target }}/default/plot_data
+            fuzz/artifacts/experimental-persistent/${{ matrix.target }}/repro.env
+            fuzz/corpus/experimental-persistent/${{ matrix.target }}
+          key: ${{ env.CACHE_KEY }}
+          restore-keys: |
+            experimental-afl-${{ runner.os }}-${{ matrix.target }}-v1-
+
+      - name: Capture pre-run health snapshot
+        run: |
+          python3 fuzz/fuzz_health.py snapshot \
+            --stats-file "${OUTPUT_DIR}/default/fuzzer_stats" \
+            --queue-dir "${OUTPUT_DIR}/default/queue" \
+            --output "${HEALTH_DIR}/before.json"
+
+      - name: Build Dragonfly with AFL++
+        run: |
+          echo "Building Dragonfly with AFL++ instrumentation..."
+          ./helio/blaze.sh -DUSE_AFL:BOOL=ON
+          cd ./build-dbg
+          ninja dragonfly
+          cd ..
+          echo "Build complete"
+          ls -lh ./build-dbg/dragonfly
+
+      - name: Run experimental AFL++ persistent fuzzing
+        id: run-fuzzer
+        run: |
+          echo "started=true" >> "${GITHUB_OUTPUT}"
+          echo "Starting experimental persistent AFL++ fuzzing..."
+          echo "This mode intentionally keeps AFL byte-level stages enabled."
+          echo "AFL_CUSTOM_MUTATOR_ONLY is unset; AFL_ENABLE_SAVE is unset."
+
+          cd fuzz
+          export BUILD_DIR="${GITHUB_WORKSPACE}/build-dbg"
+          export OUTPUT_DIR="${OUTPUT_DIR}"
+          export CORPUS_DIR="${CORPUS_DIR}"
+
+          export AFL_NO_UI=1
+          export AFL_AUTORESUME=1
+          export AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
+          export AFL_TESTCACHE_SIZE=500
+          export AFL_SKIP_CPUFREQ=1
+          export AFL_FAST_CAL=1
+          unset AFL_CUSTOM_MUTATOR_ONLY
+          unset AFL_ENABLE_SAVE
+
+          set +e
+          timeout "${DURATION_MINUTES}m" ./run_fuzzer.sh "${TARGET}"
+          exit_code=$?
+          set -e
+
+          echo "exit_code=${exit_code}" >> "${GITHUB_OUTPUT}"
+          if [[ "${exit_code}" -eq 124 ]]; then
+            echo "Fuzzing completed: timeout reached"
+          elif [[ "${exit_code}" -eq 0 ]]; then
+            echo "Fuzzing completed normally"
+          elif [[ "${exit_code}" -eq 137 ]]; then
+            echo "::warning::Fuzzer was killed with exit 137; treating it as an experimental resource stop"
+          else
+            echo "::warning::Fuzzer exited with code ${exit_code}; preserving artifacts before failing"
+          fi
+
+      - name: Analyze experimental fuzzing results
+        id: analyze
+        if: always() && steps.run-fuzzer.outputs.started == 'true'
+        run: |
+          CRASHES_DIR="${OUTPUT_DIR}/default/crashes"
+          HANGS_DIR="${OUTPUT_DIR}/default/hangs"
+          QUEUE_DIR="${OUTPUT_DIR}/default/queue"
+          STATS_FILE="${OUTPUT_DIR}/default/fuzzer_stats"
+
+          CRASH_COUNT=0
+          HANG_COUNT=0
+          CORPUS_SIZE=0
+
+          if [[ -d "${CRASHES_DIR}" ]]; then
+            CRASH_COUNT=$(find "${CRASHES_DIR}" -maxdepth 1 -type f -name 'id:*' | wc -l)
+          fi
+
+          if [[ -d "${HANGS_DIR}" ]]; then
+            HANG_COUNT=$(find "${HANGS_DIR}" -maxdepth 1 -type f -name 'id:*' ! -name 'RECORD:*' | wc -l)
+          fi
+
+          if [[ -d "${QUEUE_DIR}" ]]; then
+            CORPUS_SIZE=$(find "${QUEUE_DIR}" -type f ! -path '*/.state/*' | wc -l)
+          fi
+
+          echo "Experimental persistent fuzzing results:"
+          echo "  target: ${TARGET}"
+          echo "  crashes: ${CRASH_COUNT}"
+          echo "  hangs: ${HANG_COUNT}"
+          echo "  queue files: ${CORPUS_SIZE}"
+          echo "  stats file: ${STATS_FILE}"
+
+          if [[ -f "${STATS_FILE}" ]]; then
+            echo "Key AFL statistics:"
+            grep -E "execs_done|execs_per_sec|paths_total|corpus_count|saved_crashes|saved_hangs|unique_crashes|unique_hangs|last_find|last_crash|last_hang|bitmap_cvg|stability|cycles_done|cycles_wo_finds" "${STATS_FILE}" || true
+          else
+            echo "HEALTH WARNING: fuzzer_stats was not found"
+          fi
+
+          echo "crash_count=${CRASH_COUNT}" >> "${GITHUB_OUTPUT}"
+          echo "hang_count=${HANG_COUNT}" >> "${GITHUB_OUTPUT}"
+          echo "corpus_size=${CORPUS_SIZE}" >> "${GITHUB_OUTPUT}"
+
+      - name: Package experimental crash artifacts
+        if: always() && steps.analyze.outputs.crash_count > 0
+        run: |
+          CRASHES_DIR="${OUTPUT_DIR}/default/crashes"
+          mkdir -p fuzz/packaged_experimental
+
+          find "${CRASHES_DIR}" -maxdepth 1 -name 'id:*' ! -name 'RECORD:*' -type f | sort | while read -r file; do
+            CRASH_ID=$(basename "${file}" | sed 's/^id:\([0-9]*\),.*/\1/')
+            echo "Packaging experimental crash ${CRASH_ID}..."
+            if (cd fuzz && ./package_crash.sh "${CRASH_ID}" "${CRASHES_DIR}"); then
+              mv "fuzz/crash-${CRASH_ID}.tar.gz" fuzz/packaged_experimental/ 2>/dev/null || true
+            else
+              echo "Warning: failed to package crash ${CRASH_ID}, continuing..."
+            fi
+          done
+
+          ls -lh fuzz/packaged_experimental/ 2>/dev/null || true
+
+      - name: Package experimental hang artifacts
+        if: always() && steps.analyze.outputs.hang_count > 0
+        run: |
+          HANGS_DIR="${OUTPUT_DIR}/default/hangs"
+          mkdir -p fuzz/packaged_experimental_hangs
+          tar -czf "fuzz/packaged_experimental_hangs/hangs-${TARGET}.tar.gz" \
+            -C "$(dirname "${HANGS_DIR}")" hangs/
+          ls -lh fuzz/packaged_experimental_hangs/
+
+      - name: Write experimental health report
+        if: always() && steps.run-fuzzer.outputs.started == 'true'
+        env:
+          CACHE_RESTORED: ${{ steps.restore-afl-state.outputs.cache-hit == 'true' || steps.restore-afl-state.outputs.cache-matched-key != '' }}
+        run: |
+          python3 fuzz/fuzz_health.py report \
+            --target "${TARGET}" \
+            --stats-file "${OUTPUT_DIR}/default/fuzzer_stats" \
+            --queue-dir "${OUTPUT_DIR}/default/queue" \
+            --before "${HEALTH_DIR}/before.json" \
+            --output-json "${HEALTH_DIR}/health.json" \
+            --output-md "${HEALTH_DIR}/health.md" \
+            --duration-minutes "${DURATION_MINUTES}" \
+            --reset-state "${RESET_STATE}" \
+            --cache-hit "${CACHE_RESTORED}" \
+            --commit "${GITHUB_SHA}" \
+            --run-url "${RUN_URL}"
+
+          cat "${HEALTH_DIR}/health.md" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload experimental health artifacts
+        if: always() && steps.run-fuzzer.outputs.started == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: fuzz-experimental-persistent-${{ matrix.target }}-health-${{ github.run_number }}
+          path: |
+            fuzz/health/experimental-persistent/${{ matrix.target }}/health.json
+            fuzz/health/experimental-persistent/${{ matrix.target }}/health.md
+            fuzz/artifacts/experimental-persistent/${{ matrix.target }}/default/fuzzer_stats
+            fuzz/artifacts/experimental-persistent/${{ matrix.target }}/default/plot_data
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Upload experimental crash artifacts
+        if: always() && steps.analyze.outputs.crash_count > 0
+        uses: actions/upload-artifact@v7
+        with:
+          name: fuzz-experimental-persistent-${{ matrix.target }}-crashes-${{ github.run_number }}
+          path: |
+            fuzz/packaged_experimental/*.tar.gz
+            fuzz/artifacts/experimental-persistent/${{ matrix.target }}/default/crashes/**
+            fuzz/artifacts/experimental-persistent/${{ matrix.target }}/default/fuzzer_stats
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Upload experimental hang artifacts
+        if: always() && steps.analyze.outputs.hang_count > 0
+        uses: actions/upload-artifact@v7
+        with:
+          name: fuzz-experimental-persistent-${{ matrix.target }}-hangs-${{ github.run_number }}
+          path: |
+            fuzz/packaged_experimental_hangs/*.tar.gz
+            fuzz/artifacts/experimental-persistent/${{ matrix.target }}/default/hangs/**
+            fuzz/artifacts/experimental-persistent/${{ matrix.target }}/default/fuzzer_stats
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Drop crashes and hangs before saving AFL state
+        if: always() && steps.run-fuzzer.outputs.started == 'true'
+        run: |
+          rm -rf "${OUTPUT_DIR}/default/crashes" "${OUTPUT_DIR}/default/hangs"
+          echo "Removed crash/hang directories before cache save. Queue state is preserved and may rediscover known findings."
+
+      - name: Check experimental AFL cache size
+        id: cache-size
+        if: always() && steps.run-fuzzer.outputs.started == 'true'
+        env:
+          MAX_CACHE_BYTES: 2147483648
+        run: |
+          cache_bytes=0
+          for path in \
+            "${OUTPUT_DIR}/default/queue" \
+            "${OUTPUT_DIR}/default/.state" \
+            "${OUTPUT_DIR}/default/fuzzer_stats" \
+            "${OUTPUT_DIR}/default/plot_data" \
+            "${OUTPUT_DIR}/repro.env" \
+            "${CORPUS_DIR}"; do
+            if [[ -e "${path}" ]]; then
+              bytes=$(du -sb "${path}" | cut -f1)
+              cache_bytes=$((cache_bytes + bytes))
+              echo "Cache candidate: ${path} (${bytes} bytes)"
+            fi
+          done
+
+          echo "cache_bytes=${cache_bytes}" >> "${GITHUB_OUTPUT}"
+          echo "max_cache_bytes=${MAX_CACHE_BYTES}" >> "${GITHUB_OUTPUT}"
+
+          if (( cache_bytes > MAX_CACHE_BYTES )); then
+            echo "save_cache=false" >> "${GITHUB_OUTPUT}"
+            echo "::warning::Experimental AFL state is ${cache_bytes} bytes, above ${MAX_CACHE_BYTES}; skipping cache save"
+          else
+            echo "save_cache=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Save experimental AFL state
+        if: always() && steps.run-fuzzer.outputs.started == 'true' && steps.cache-size.outputs.save_cache == 'true'
+        uses: actions/cache/save@v5
+        continue-on-error: true
+        with:
+          path: |
+            fuzz/artifacts/experimental-persistent/${{ matrix.target }}/default/queue
+            fuzz/artifacts/experimental-persistent/${{ matrix.target }}/default/.state
+            fuzz/artifacts/experimental-persistent/${{ matrix.target }}/default/fuzzer_stats
+            fuzz/artifacts/experimental-persistent/${{ matrix.target }}/default/plot_data
+            fuzz/artifacts/experimental-persistent/${{ matrix.target }}/repro.env
+            fuzz/corpus/experimental-persistent/${{ matrix.target }}
+          key: ${{ env.CACHE_KEY }}
+
+      - name: Fail on experimental fuzzing findings
+        if: always() && steps.run-fuzzer.outputs.started == 'true'
+        run: |
+          EXIT_CODE="${{ steps.run-fuzzer.outputs.exit_code || '0' }}"
+          CRASH_COUNT="${{ steps.analyze.outputs.crash_count || '0' }}"
+          HANG_COUNT="${{ steps.analyze.outputs.hang_count || '0' }}"
+
+          if [[ "${EXIT_CODE}" == "137" ]]; then
+            echo "::warning::Experimental fuzzer stopped with exit 137; not failing without crash/hang artifacts"
+          elif [[ "${EXIT_CODE}" != "0" && "${EXIT_CODE}" != "124" ]]; then
+            echo "::error::Experimental fuzzer failed with exit code ${EXIT_CODE}"
+            exit 1
+          fi
+
+          if [[ "${CRASH_COUNT}" -gt 0 ]]; then
+            echo "::error::Experimental fuzzing found ${CRASH_COUNT} crash(es)"
+            exit 1
+          fi
+
+          if [[ "${HANG_COUNT}" -gt 0 ]]; then
+            echo "::error::Experimental fuzzing found ${HANG_COUNT} hang(s)"
+            exit 1
+          fi
+
+          echo "Experimental persistent fuzzing completed without crashes or hangs."

--- a/fuzz/FUZZING.md
+++ b/fuzz/FUZZING.md
@@ -8,7 +8,7 @@ AFL++ must be built from source with `AFL_PERSISTENT_RECORD` enabled for crash r
 sudo apt update
 sudo apt install llvm-18-dev clang-18 lld-18 gcc-13-plugin-dev
 
-git clone --depth=1 --branch v4.34c https://github.com/AFLplusplus/AFLplusplus.git
+git clone --depth=1 --branch v5.00c https://github.com/AFLplusplus/AFLplusplus.git
 cd AFLplusplus
 
 # Enable AFL_PERSISTENT_RECORD (required for stateful crash replay)
@@ -84,6 +84,39 @@ mutator runs — AFL++'s byte-level stages and the dictionary are disabled. Reas
 
 Locally you can drop `AFL_CUSTOM_MUTATOR_ONLY` to also run the byte-level stages
 and the dictionary (`dict/*.dict`) for ad-hoc parser-edge-case exploration.
+
+## Experimental Persistent Nightly
+
+`.github/workflows/fuzz-experimental-persistent.yml` runs an experimental nightly
+campaign at 00:00 UTC, two hours before the regular long fuzzing campaign. It is
+separate from the PR and long fuzzing workflows and intentionally keeps its state
+between runs.
+
+Differences from the regular long campaign:
+
+- SAVE/BGSAVE testing is disabled (`AFL_ENABLE_SAVE` is not set).
+- `AFL_CUSTOM_MUTATOR_ONLY` is not set, so AFL++ byte-level stages and dictionaries
+  run together with the protocol mutators.
+- AFL output and corpus state are stored under
+  `fuzz/artifacts/experimental-persistent/<target>` and
+  `fuzz/corpus/experimental-persistent/<target>`.
+- The workflow restores the previous AFL state from cache and saves the updated
+  state after each run when it stays under the cache size guard.
+- Manual dispatch has a `reset_state` input that drops the restored state and starts
+  again from the seed corpus.
+- Exit 137 is treated as an experimental resource stop, not a Dragonfly failure,
+  unless crash or hang artifacts were produced.
+- Health statistics and warnings are written to the job log, the GitHub step
+  summary, and `fuzz-experimental-persistent-<target>-health-*` artifacts.
+
+The experimental layout keeps AFL's usual `default/crashes` structure, so existing
+crash packaging and replay scripts still work by passing the experimental crashes
+directory explicitly.
+
+Before saving restored state for the next run, the workflow removes transient
+`default/crashes` and `default/hangs` directories but keeps the AFL queue and
+resume metadata. A known issue can therefore be rediscovered until the queue is
+manually reset or curated.
 
 ## Crash Replay
 

--- a/fuzz/fuzz_health.py
+++ b/fuzz/fuzz_health.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Collect health metrics for AFL++ fuzzing runs.
+
+The experimental persistent workflow uses this helper in two phases:
+  1. snapshot: capture the restored AFL state before the run starts.
+  2. report: compare the final state with the snapshot and write JSON/Markdown reports.
+
+The script is intentionally best-effort. Missing AFL stats should produce warnings, not hide
+crashes or fail an experimental fuzzing run.
+"""
+
+import argparse
+import json
+import os
+import time
+from pathlib import Path
+
+STALE_FIND_SECONDS = 3 * 24 * 60 * 60
+
+
+def _parse_number(value):
+    value = value.strip()
+    if value.endswith("%"):
+        value = value[:-1]
+    try:
+        if any(ch in value for ch in (".", "e", "E")):
+            return float(value)
+        return int(value)
+    except ValueError:
+        return value
+
+
+def read_stats(path):
+    stats = {}
+    stats_path = Path(path)
+    if not stats_path.is_file():
+        return stats
+
+    with stats_path.open(encoding="utf-8", errors="replace") as file:
+        for line in file:
+            if ":" not in line:
+                continue
+            key, value = line.split(":", 1)
+            stats[key.strip()] = _parse_number(value)
+    return stats
+
+
+def queue_metrics(queue_dir):
+    root = Path(queue_dir)
+    count = 0
+    size_bytes = 0
+    if not root.is_dir():
+        return {"queue_files": 0, "queue_size_bytes": 0}
+
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if ".state" in path.parts:
+            continue
+        count += 1
+        try:
+            size_bytes += path.stat().st_size
+        except OSError:
+            pass
+
+    return {"queue_files": count, "queue_size_bytes": size_bytes}
+
+
+def collect_state(stats_file, queue_dir):
+    stats = read_stats(stats_file)
+    state = {
+        "captured_at": int(time.time()),
+        "stats_file": str(stats_file),
+        "queue_dir": str(queue_dir),
+        "stats": stats,
+    }
+    state.update(queue_metrics(queue_dir))
+    return state
+
+
+def _num(stats, key, default=0):
+    value = stats.get(key, default)
+    return value if isinstance(value, (int, float)) else default
+
+
+def _first_num(stats, *keys, default=0):
+    for key in keys:
+        value = stats.get(key)
+        if isinstance(value, (int, float)):
+            return value
+    return default
+
+
+def _delta(after, before, key):
+    return _num(after, key) - _num(before, key)
+
+
+def _load_before_state(path):
+    if not path:
+        return {"stats": {}}, []
+
+    before_path = Path(path)
+    if not before_path.is_file():
+        return {"stats": {}}, []
+
+    try:
+        with before_path.open(encoding="utf-8") as file:
+            data = json.load(file)
+    except (OSError, json.JSONDecodeError, TypeError) as exc:
+        return {"stats": {}}, [f"Could not read pre-run health snapshot: {exc}"]
+
+    if not isinstance(data, dict):
+        return {"stats": {}}, ["Pre-run health snapshot did not contain a JSON object"]
+
+    if not isinstance(data.get("stats", {}), dict):
+        data["stats"] = {}
+    return data, []
+
+
+def _format_seconds(seconds):
+    if seconds is None:
+        return "unknown"
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86400:
+        return f"{seconds // 3600}h"
+    return f"{seconds // 86400}d"
+
+
+def build_report(args):
+    before, warnings = _load_before_state(args.before)
+
+    after = collect_state(args.stats_file, args.queue_dir)
+    before_stats = before.get("stats", {})
+    after_stats = after["stats"]
+    now = int(time.time())
+
+    last_find = _num(after_stats, "last_find", 0)
+    last_find_age = None if last_find <= 0 else max(0, now - int(last_find))
+    execs_done = _num(after_stats, "execs_done")
+    corpus_count = _first_num(after_stats, "corpus_count", "paths_total")
+    before_corpus_count = _first_num(before_stats, "corpus_count", "paths_total")
+    saved_crashes = _first_num(after_stats, "saved_crashes", "unique_crashes")
+    saved_hangs = _first_num(after_stats, "saved_hangs", "unique_hangs")
+    unique_crashes = _first_num(after_stats, "unique_crashes", "saved_crashes")
+    unique_hangs = _first_num(after_stats, "unique_hangs", "saved_hangs")
+    execs_per_sec = _num(after_stats, "execs_per_sec")
+
+    metrics = {
+        "target": args.target,
+        "duration_minutes": args.duration_minutes,
+        "reset_state": args.reset_state,
+        "cache_hit": args.cache_hit,
+        "commit": args.commit,
+        "run_url": args.run_url,
+        "captured_at": now,
+        "stats_file": str(args.stats_file),
+        "queue_dir": str(args.queue_dir),
+        "execs_done": execs_done,
+        "execs_done_delta": _delta(after_stats, before_stats, "execs_done"),
+        "execs_per_sec": execs_per_sec,
+        "corpus_count": corpus_count,
+        "corpus_count_delta": corpus_count - before_corpus_count,
+        "paths_total": _first_num(after_stats, "paths_total", "corpus_count"),
+        "saved_crashes": saved_crashes,
+        "saved_hangs": saved_hangs,
+        "unique_crashes": unique_crashes,
+        "unique_hangs": unique_hangs,
+        "last_find": last_find,
+        "last_find_age_seconds": last_find_age,
+        "bitmap_cvg": after_stats.get("bitmap_cvg", ""),
+        "stability": after_stats.get("stability", ""),
+        "cycles_done": _num(after_stats, "cycles_done"),
+        "cycles_wo_finds": _num(after_stats, "cycles_wo_finds"),
+        "queue_files": after["queue_files"],
+        "queue_files_delta": after["queue_files"] - int(before.get("queue_files", 0)),
+        "queue_size_bytes": after["queue_size_bytes"],
+        "queue_size_bytes_delta": after["queue_size_bytes"]
+        - int(before.get("queue_size_bytes", 0)),
+    }
+
+    if not after_stats:
+        warnings.append("AFL fuzzer_stats was not found or was empty")
+    if metrics["execs_done"] <= 0:
+        warnings.append("No AFL executions were recorded")
+    if metrics["queue_files"] <= 0:
+        warnings.append("AFL queue is empty")
+    if "execs_per_sec" in after_stats and metrics["execs_per_sec"] < 1:
+        warnings.append("AFL execs_per_sec is below 1")
+    if last_find_age is not None and last_find_age > STALE_FIND_SECONDS:
+        warnings.append(f"No new path was found for {_format_seconds(last_find_age)}")
+
+    stability = metrics["stability"]
+    if isinstance(stability, (int, float)) and stability < 80:
+        warnings.append(f"AFL stability is low: {metrics['stability']}")
+
+    if metrics["saved_crashes"] > 0:
+        warnings.append(f"AFL reported {metrics['saved_crashes']} saved crash(es)")
+    if metrics["saved_hangs"] > 0:
+        warnings.append(f"AFL reported {metrics['saved_hangs']} saved hang(s)")
+
+    metrics["warnings"] = warnings
+    return metrics
+
+
+def write_json(path, data):
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", encoding="utf-8") as file:
+        json.dump(data, file, indent=2, sort_keys=True)
+        file.write("\n")
+
+
+def write_markdown(path, data):
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    rows = [
+        ("target", data["target"]),
+        ("duration_minutes", data["duration_minutes"]),
+        ("reset_state", data["reset_state"]),
+        ("cache_hit", data["cache_hit"]),
+        ("execs_done", data["execs_done"]),
+        ("execs_done_delta", data["execs_done_delta"]),
+        ("execs_per_sec", data["execs_per_sec"]),
+        ("corpus_count", data["corpus_count"]),
+        ("corpus_count_delta", data["corpus_count_delta"]),
+        ("queue_files", data["queue_files"]),
+        ("queue_files_delta", data["queue_files_delta"]),
+        ("last_find_age", _format_seconds(data["last_find_age_seconds"])),
+        ("bitmap_cvg", data["bitmap_cvg"]),
+        ("stability", data["stability"]),
+        ("saved_crashes", data["saved_crashes"]),
+        ("saved_hangs", data["saved_hangs"]),
+        ("unique_crashes", data["unique_crashes"]),
+        ("unique_hangs", data["unique_hangs"]),
+        ("queue_size_bytes", data["queue_size_bytes"]),
+    ]
+
+    with output.open("w", encoding="utf-8") as file:
+        file.write(f"### Experimental persistent fuzzing health ({data['target']})\n\n")
+        file.write(f"- Commit: `{data['commit']}`\n")
+        file.write(f"- Run: {data['run_url']}\n")
+        file.write("\n| Metric | Value |\n| --- | --- |\n")
+        for key, value in rows:
+            file.write(f"| `{key}` | `{value}` |\n")
+
+        file.write("\n#### Health warnings\n\n")
+        if data["warnings"]:
+            for warning in data["warnings"]:
+                file.write(f"- {warning}\n")
+        else:
+            file.write("- None\n")
+
+
+def print_report(data):
+    print("Experimental persistent fuzzing health")
+    for key in (
+        "target",
+        "duration_minutes",
+        "reset_state",
+        "cache_hit",
+        "execs_done",
+        "execs_done_delta",
+        "execs_per_sec",
+        "corpus_count",
+        "corpus_count_delta",
+        "queue_files",
+        "queue_files_delta",
+        "last_find_age_seconds",
+        "bitmap_cvg",
+        "stability",
+        "saved_crashes",
+        "saved_hangs",
+        "unique_crashes",
+        "unique_hangs",
+    ):
+        print(f"  {key}: {data[key]}")
+
+    if data["warnings"]:
+        for warning in data["warnings"]:
+            print(f"HEALTH WARNING: {warning}")
+            if os.environ.get("GITHUB_ACTIONS"):
+                print(f"::warning::{warning}")
+    else:
+        print("HEALTH WARNING: none")
+
+
+def snapshot_cmd(args):
+    write_json(args.output, collect_state(args.stats_file, args.queue_dir))
+
+
+def report_cmd(args):
+    report = build_report(args)
+    write_json(args.output_json, report)
+    write_markdown(args.output_md, report)
+    print_report(report)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Collect AFL++ fuzzing health metrics")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    snapshot = subparsers.add_parser("snapshot", help="Capture current AFL state")
+    snapshot.add_argument("--stats-file", required=True)
+    snapshot.add_argument("--queue-dir", required=True)
+    snapshot.add_argument("--output", required=True)
+    snapshot.set_defaults(func=snapshot_cmd)
+
+    report = subparsers.add_parser("report", help="Write health report after a run")
+    report.add_argument("--target", required=True)
+    report.add_argument("--stats-file", required=True)
+    report.add_argument("--queue-dir", required=True)
+    report.add_argument("--before", required=True)
+    report.add_argument("--output-json", required=True)
+    report.add_argument("--output-md", required=True)
+    report.add_argument("--duration-minutes", required=True)
+    report.add_argument("--reset-state", required=True)
+    report.add_argument("--cache-hit", required=True)
+    report.add_argument("--commit", required=True)
+    report.add_argument("--run-url", required=True)
+    report.set_defaults(func=report_cmd)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add a separate experimental nightly AFL++ persistent fuzzing workflow that keeps AFL queue and corpus state between runs while leaving the existing PR and long fuzzing workflows unchanged.
