### PR TITLE
feat(search): add NOHL option to FT.CREATE

### DIFF
--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -130,6 +130,9 @@ struct IndicesOptions {
   // When true, TEXT posting lists do not store token positions. Saves memory but
   // disables phrase queries. Set via NOOFFSETS in FT.CREATE.
   bool no_offsets = false;
+
+  // When true, disables highlighting support. Saves memory. Set via NOHL in FT.CREATE.
+  bool no_hl = false;
 };
 
 // BM25 scoring statistics are now tracked per-field inside each TextIndex.

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -299,6 +299,12 @@ ParseResult<bool> ParseNoOffsets(CmdArgParser* /*parser*/, DocIndex* index) {
   return true;
 }
 
+// NOHL: placeholder for future HIGHLIGHT disable support.
+ParseResult<bool> ParseNoHl(CmdArgParser* /*parser*/, DocIndex* index) {
+  index->options.no_hl = true;
+  return true;
+}
+
 // STOPWORDS count [words...]
 ParseResult<bool> ParseStopwords(CmdArgParser* parser, DocIndex* index) {
   index->options.stopwords.clear();
@@ -423,7 +429,7 @@ ParseResult<DocIndex> CreateDocIndex(std::string_view name, CmdArgParser* parser
     auto option_parser = parser->TryMapNext(
         "ON"sv, &ParseOnOption, "PREFIX"sv, &ParsePrefix, "STOPWORDS"sv, &ParseStopwords,
         "LANGUAGE"sv, &ParseIndexLanguage, "LANGUAGE_FIELD"sv, &ParseIndexLanguageField,
-        "NOOFFSETS"sv, &ParseNoOffsets, "SCHEMA"sv, &ParseSchema);
+        "NOOFFSETS"sv, &ParseNoOffsets, "NOHL"sv, &ParseNoHl, "SCHEMA"sv, &ParseSchema);
 
     if (!option_parser) {
       // Unsupported parameters are ignored for now
@@ -2638,6 +2644,8 @@ void CmdFtInfo(CmdArgList args, CommandContext* cmd_cntx) {
     std::vector<std::string_view> opts;
     if (info.base_index.options.no_offsets)
       opts.emplace_back("NOOFFSETS");
+    if (info.base_index.options.no_hl)
+      opts.emplace_back("NOHL");
     rb->StartArray(opts.size());
     for (auto opt : opts)
       rb->SendSimpleString(opt);

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -3468,6 +3468,38 @@ TEST_F(SearchFamilyTest, SortStoreDoesNotUpdateIndexesBug) {
   EXPECT_THAT(resp, AreDocIds("k1"));
 }
 
+TEST_F(SearchFamilyTest, FtCreateNoHl) {
+  // Test NOHL option appears in FT.INFO when specified
+  auto resp = Run({"FT.CREATE", "idx1", "NOHL", "SCHEMA", "title", "TEXT"});
+  EXPECT_EQ(resp, "OK");
+
+  auto info = Run({"FT.INFO", "idx1"});
+  EXPECT_THAT(info, IsArray(_, _, _, _, "index_options", RespArray(ElementsAre("NOHL")), _, _, _, _,
+                            _, _, _, _));
+
+  Run({"FT.DROPINDEX", "idx1"});
+
+  // Test NOHL does not appear when only NOOFFSETS is specified
+  resp = Run({"FT.CREATE", "idx2", "NOOFFSETS", "SCHEMA", "title", "TEXT"});
+  EXPECT_EQ(resp, "OK");
+
+  info = Run({"FT.INFO", "idx2"});
+  EXPECT_THAT(info, IsArray(_, _, _, _, "index_options", RespArray(ElementsAre("NOOFFSETS")), _, _,
+                            _, _, _, _, _, _));
+
+  Run({"FT.DROPINDEX", "idx2"});
+
+  // Test NOHL and NOOFFSETS can coexist
+  resp = Run({"FT.CREATE", "idx3", "NOHL", "NOOFFSETS", "SCHEMA", "title", "TEXT"});
+  EXPECT_EQ(resp, "OK");
+
+  info = Run({"FT.INFO", "idx3"});
+  EXPECT_THAT(info,
+              IsArray(_, _, _, _, "index_options",
+                      RespArray(UnorderedElementsAre("NOHL", "NOOFFSETS")),  // Both should appear
+                      _, _, _, _, _, _, _, _));
+}
+
 TEST_F(SearchFamilyTest, BlockSizeOptionFtCreate) {
   // Create an index with a block size option
   auto resp = Run({"FT.CREATE", "index", "ON", "HASH", "SCHEMA", "number1", "NUMERIC", "BLOCKSIZE",


### PR DESCRIPTION
## Description

This PR implements the NOHL option for FT.CREATE command.

### Changes

- Added `no_hl` field to `IndicesOptions` in `search.h`
- Added `ParseNoHl` parser function in `search_family.cc`
- Registered NOHL option in `CreateDocIndex`
- Updated `FtInfo` to output NOHL in index_options
- Added test cases for NOHL option

### Compatibility Notes

The NOHL option is implemented as a compatibility feature. Currently, Dragonfly does not implement the HIGHLIGHT functionality, so this option is primarily for Redis API compatibility. When HIGHLIGHT is implemented in the future, the `no_hl` flag can be used to disable it.

### Testing

- Added unit tests in `search_family_test.cc` covering:
  - NOHL appears in FT.INFO when specified
  - NOHL does not appear when not specified
  - NOHL and NOOFFSETS can coexist
