### PR TITLE
feat(server): Concurrent squashing

### DIFF
--- a/src/facade/parsed_command.h
+++ b/src/facade/parsed_command.h
@@ -144,17 +144,17 @@ class ParsedCommand : public cmn::BackedArguments {
     func(static_cast<RbType>(rb_));
   }
 
-  // Below are main commands for the async api and all assume that the command defers replies
-
-  // Whether SendReply() can be called. If not, it must be waited via Blocker()
+  // Whether SendReply() can be called. Only valid in deferred mode.
+  // If the reply is not ready yet, it is guaranteed to be tracked by non-null Blocker()
   bool CanReply() const;
 
-  // Reaching zero on blocker means CanReply() turns true
+  // Reaching zero on blocker means CanReply() will turn true.
+  // Waits for underlying awaitable (usually transaction)
   util::fb2::EmbeddedBlockingCounter* Blocker() const {
     return std::get<SuspendedCommand>(reply_).blocker;
   }
 
-  // Assumes CanReply() is true. Sends reply
+  // Requires CanReply(). Either sends stored reply or wakes up coroutine to send reply
   void SendReply();
 
   // Resolve deferred command immediately with an error reply.
@@ -165,9 +165,7 @@ class ParsedCommand : public cmn::BackedArguments {
   // Resolve deferred command with a captured payload.
   void Resolve(payload::Payload&& pl);
 
-  // Suspend the deferred command until `blocker` reaches zero.
-  // When that happens, CanReply() returns true and SendReply() will resume `coro`,
-  // which is expected to write the reply directly to the reply builder.
+  // Resolve deferred command with coroutine + blocker. See CanReply(), Blocker() and SendReply()
   void Resolve(util::fb2::EmbeddedBlockingCounter* blocker, std::coroutine_handle<> coro) {
     reply_ = SuspendedCommand{blocker, coro};
   }

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -6,6 +6,8 @@
 
 #include <absl/container/inlined_vector.h>
 
+#include <boost/smart_ptr/intrusive_ptr.hpp>
+
 #include "base/cycle_clock.h"
 #include "base/flag_utils.h"
 #include "base/flags.h"
@@ -151,7 +153,7 @@ MultiCommandSquasher::SquashResult MultiCommandSquasher::TrySquash(CmdRef cmd) {
 
   auto& sinfo = PrepareShardInfo(last_sid);
 
-  sinfo.dispatched.push_back({.cmd = cmd, .reply = {}});
+  sinfo.dispatched.push_back({cmd, {}});
   order_.push_back(last_sid);
 
   bool need_flush = sinfo.dispatched.size() >= opts_.max_squash_size;
@@ -210,53 +212,80 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
   auto& sinfo = sharded_[es->shard_id()];
   DCHECK(!sinfo.dispatched.empty());
 
-  auto* local_tx = sinfo.local_tx.get();
   CapturingReplyBuilder crb(ReplyMode::FULL, resp_v);
   CmdArgVec arg_vec;
-  CommandContext cmd_cntx{&crb, cntx_};
-  cmd_cntx.SetupTx(nullptr, local_tx);
+  CommandContext local_cntx{&crb, cntx_};
+  local_cntx.SetupTx(nullptr, sinfo.local_tx.get());
 
-  auto move_reply = [&sinfo](CapturingReplyBuilder::Payload&& src,
-                             CapturingReplyBuilder::Payload* dst) {
-    *dst = std::move(src);
-    size_t sz = Size(*dst);
+  auto move_reply = [&sinfo, &crb](ShardExecInfo::Command* cmd) {
+    if (cmd->cmd_cntx)
+      return cmd->cmd_cntx->Resolve(crb.Take());
+
+    cmd->reply = crb.Take();
+    size_t sz = Size(cmd->reply);
     sinfo.reply_size_delta += sz;
     sinfo.reply_size_total_ptr->fetch_add(sz, std::memory_order_relaxed);
   };
 
+  // Command dispatched asynchronously
+  struct AsyncDispatched {
+    ShardExecInfo::Command* cmd;
+    boost::intrusive_ptr<Transaction> trans;
+    CmdArgVec local_vec;
+  };
+  std::vector<AsyncDispatched> async_commands;
+
   for (auto& dispatched : sinfo.dispatched) {
-    auto args = dispatched.cmd.Slice(&arg_vec);
+    auto* ctx = &local_cntx;
+    auto args = dispatched.Slice(&arg_vec);
     if (opts_.verify_commands) {
       // The shared context is used for state verification, the local one is only for replies
-      if (auto err = service_->VerifyCommandState(*dispatched.cmd.cid, args, *cntx_); err) {
+      if (auto err = service_->VerifyCommandState(*dispatched.cid, args, *cntx_); err) {
         crb.SendError(std::move(*err));
-        auto payload = crb.Take();
-        if (dispatched.cmd.cmd_cntx) {
-          dispatched.cmd.cmd_cntx->Resolve(std::move(payload));
-        } else {
-          move_reply(std::move(payload), &dispatched.reply);
-        }
+        move_reply(&dispatched);
         continue;
       }
     }
 
-    crb.SetReplyMode(dispatched.cmd.reply_mode);
+    crb.SetReplyMode(dispatched.reply_mode);
 
-    local_tx->MultiSwitchCmd(dispatched.cmd.cid);
-    auto status = local_tx->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, args);
+    // With tiered storage enabled, it makes sense to dispatch async commands concurrently
+    // to allow concurrent disk operations. Tiered futures are only blocked on during replies
+    bool do_async = es->tiered_storage() && !IsAtomic() && dispatched.cid->SupportsAsync();
+    if (do_async) {
+      // Create new transaction for the command (high overhead, but worth for disk hits)
+      boost::intrusive_ptr<Transaction> stx = new Transaction{dispatched.cid};
+      dispatched.cmd_cntx->SetupTx(dispatched.cid, stx.get());
+
+      // Create entry to keep transaction and arguemnt backing, enable new contex + async mode
+      async_commands.push_back({&dispatched, stx, std::move(arg_vec)});
+      ctx = dispatched.cmd_cntx;
+      ctx->SetDeferredReply();
+    } else {
+      ctx->tx()->MultiSwitchCmd(dispatched.cid);
+    }
+
+    auto status = ctx->tx()->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, args);
     if (status != OpStatus::OK) {
       crb.SendError(status);
     } else {
-      cmd_cntx.UpdateCid(dispatched.cmd.cid);
-      cmd_cntx.SetTailArgs(dispatched.cmd.args);
-      service_->InvokeCmd(args, &cmd_cntx);
+      ctx->UpdateCid(dispatched.cid);
+      ctx->SetTailArgs(dispatched.args);
+      service_->InvokeCmd(args, ctx);
     }
-    auto payload = crb.Take();
-    if (dispatched.cmd.cmd_cntx) {
-      dispatched.cmd.cmd_cntx->Resolve(std::move(payload));
-    } else {
-      move_reply(std::move(payload), &dispatched.reply);
-    }
+
+    if (!do_async)
+      move_reply(&dispatched);
+  }
+
+  // Collect replies from async commands
+  for (auto& de : async_commands) {
+    auto* ctx = de.cmd->cmd_cntx;
+    if (!ctx->CanReply())
+      ctx->Blocker()->Wait();
+
+    ctx->SendReply();
+    move_reply(de.cmd);
   }
 
   return OpStatus::OK;

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -6,8 +6,6 @@
 
 #include <absl/container/inlined_vector.h>
 
-#include <boost/smart_ptr/intrusive_ptr.hpp>
-
 #include "base/cycle_clock.h"
 #include "base/flag_utils.h"
 #include "base/flags.h"
@@ -227,14 +225,6 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
     sinfo.reply_size_total_ptr->fetch_add(sz, std::memory_order_relaxed);
   };
 
-  // Command dispatched asynchronously
-  struct AsyncDispatched {
-    ShardExecInfo::Command* cmd;
-    boost::intrusive_ptr<Transaction> trans;
-    CmdArgVec local_vec;
-  };
-  std::vector<AsyncDispatched> async_commands;
-
   for (auto& dispatched : sinfo.dispatched) {
     auto* ctx = &local_cntx;
     auto args = dispatched.Slice(&arg_vec);
@@ -254,17 +244,12 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
     bool do_async = es->tiered_storage() && !IsAtomic() && opts_.pipeline_mode &&
                     dispatched.cid->SupportsAsync();
     if (do_async) {
-      // Create new transaction for the command (high overhead, but worth for disk hits)
-      boost::intrusive_ptr<Transaction> stx = new Transaction{dispatched.cid};
-      dispatched.cmd_cntx->SetupTx(dispatched.cid, stx.get());
-
-      // Create entry to keep transaction and arguemnt backing, enable new contex + async mode
-      async_commands.push_back({&dispatched, stx, std::move(arg_vec)});
       ctx = dispatched.cmd_cntx;
       ctx->SetDeferredReply();
-    } else {
-      ctx->tx()->MultiSwitchCmd(dispatched.cid);
     }
+
+    ctx->SetupTx(dispatched.cid, local_cntx.tx());
+    ctx->tx()->MultiSwitchCmd(dispatched.cid);
 
     auto status = ctx->tx()->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, args);
     if (status != OpStatus::OK) {
@@ -277,13 +262,8 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
 
     if (!do_async)
       move_reply(&dispatched);
-  }
-
-  // Collect replies from async commands
-  for (auto& de : async_commands) {
-    auto* ctx = de.cmd->cmd_cntx;
-    if (!ctx->CanReply())
-      ctx->Blocker()->Wait();
+    else if (!ctx->CanReply())
+      ctx->Blocker()->Wait();  // Might have been blocked on a key
   }
 
   return OpStatus::OK;

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -260,10 +260,11 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
       service_->InvokeCmd(args, ctx);
     }
 
-    if (!do_async)
-      move_reply(&dispatched);
-    else if (!ctx->CanReply())
-      ctx->Blocker()->Wait();  // Might have been blocked on a key
+    if (!do_async) {
+      move_reply(&dispatched);  // Async commands resolve the context directly
+    } else if (!ctx->CanReply()) {
+      ctx->Blocker()->Wait();  // Transaction didn't finish inline (likely locked key), wait for it
+    }
   }
 
   return OpStatus::OK;

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -251,7 +251,8 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
 
     // With tiered storage enabled, it makes sense to dispatch async commands concurrently
     // to allow concurrent disk operations. Tiered futures are only blocked on during replies
-    bool do_async = es->tiered_storage() && !IsAtomic() && dispatched.cid->SupportsAsync();
+    bool do_async = es->tiered_storage() && !IsAtomic() && opts_.pipeline_mode &&
+                    dispatched.cid->SupportsAsync();
     if (do_async) {
       // Create new transaction for the command (high overhead, but worth for disk hits)
       boost::intrusive_ptr<Transaction> stx = new Transaction{dispatched.cid};
@@ -267,7 +268,7 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
 
     auto status = ctx->tx()->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, args);
     if (status != OpStatus::OK) {
-      crb.SendError(status);
+      ctx->SendError(status);  // Calls Resolve() in async, routes to crb in non async
     } else {
       ctx->UpdateCid(dispatched.cid);
       ctx->SetTailArgs(dispatched.args);
@@ -283,9 +284,6 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
     auto* ctx = de.cmd->cmd_cntx;
     if (!ctx->CanReply())
       ctx->Blocker()->Wait();
-
-    ctx->SendReply();
-    move_reply(de.cmd);
   }
 
   return OpStatus::OK;

--- a/src/server/multi_command_squasher.h
+++ b/src/server/multi_command_squasher.h
@@ -57,8 +57,7 @@ class MultiCommandSquasher {
     ShardExecInfo() : local_tx{nullptr} {
     }
 
-    struct Command {
-      CmdRef cmd;
+    struct Command : public CmdRef {
       facade::CapturingReplyBuilder::Payload reply;
     };
     std::vector<Command> dispatched;  // Dispatched commands

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -851,17 +851,15 @@ OpStatus Transaction::ScheduleSingleHop(RunnableType cb) {
 }
 
 void Transaction::SingleHopAsync(RunnableType cb) {
-  CHECK(!multi_);
+  CHECK(!IsAtomicMulti());
   CHECK_EQ(coordinator_state_, 0u);
 
   coordinator_state_ |= COORD_CONCLUDING;
   cb_ptr_ = cb;
 
   if (unique_shard_cnt_ == 1) {
-    CHECK_EQ(shard_data_.size(), 1u);
-
     // Arm immediately
-    shard_data_.front().is_armed.store(true, memory_order_relaxed);
+    shard_data_[SidToId(unique_shard_id_)].is_armed.store(true, memory_order_relaxed);
 
     // Keep alive till end and set barrier
     run_barrier_.Add(1);
@@ -871,7 +869,8 @@ void Transaction::SingleHopAsync(RunnableType cb) {
       bool success = ScheduleInShard(EngineShard::tlocal(), true);
       CHECK(success);  // single shard scheduling can't fail
 
-      if (shard_data_.front().local_mask & OPTIMISTIC_EXECUTION) {  // executed during schedule
+      auto mask = shard_data_[SidToId(unique_shard_id_)].local_mask;
+      if (mask & OPTIMISTIC_EXECUTION) {  // executed during schedule
         run_barrier_.Dec();
         intrusive_ptr_release(this);
       } else {

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -858,9 +858,6 @@ void Transaction::SingleHopAsync(RunnableType cb) {
   cb_ptr_ = cb;
 
   if (unique_shard_cnt_ == 1) {
-    // Arm immediately
-    shard_data_[SidToId(unique_shard_id_)].is_armed.store(true, memory_order_relaxed);
-
     // Keep alive till end and set barrier
     run_barrier_.Add(1);
     use_count_.fetch_add(1, memory_order_relaxed);
@@ -869,11 +866,12 @@ void Transaction::SingleHopAsync(RunnableType cb) {
       bool success = ScheduleInShard(EngineShard::tlocal(), true);
       CHECK(success);  // single shard scheduling can't fail
 
-      auto mask = shard_data_[SidToId(unique_shard_id_)].local_mask;
-      if (mask & OPTIMISTIC_EXECUTION) {  // executed during schedule
+      auto& sd = shard_data_[SidToId(unique_shard_id_)];
+      if (sd.local_mask & OPTIMISTIC_EXECUTION) {  // executed during schedule
         run_barrier_.Dec();
         intrusive_ptr_release(this);
       } else {
+        sd.is_armed.store(true, memory_order_relaxed);
         // do we really need to submit a shard callback?
         // an armed transaction will be driven by the next previous txq entry
 


### PR DESCRIPTION
Implement the option to run commands concurrently in non-atomic squashing to allow parallel disk reads and writes. The blocking point is moved from the command handler to the reply phase by using the new async cmds infrastructure

So far this applies only to **single shard mget**

Pipeline load before:

<img width="2083" height="770" alt="Image" src="https://github.com/user-attachments/assets/0586db14-e269-415a-ad3e-417a385f266e" />

Pipeline load after:

<img width="2083" height="770" alt="image" src="https://github.com/user-attachments/assets/535eb879-37e1-41dd-9176-8a38cc71f037" />

One more update in the PR

<img width="2084" height="770" alt="image" src="https://github.com/user-attachments/assets/9a19723a-9d5b-4c83-91ef-0ed213be3f9e" />

-> parallelization shows that it is now less important how many keys are in an MGET request to reach higher load.

This optimization is only enabled when tiered storage is enabled (otherwise it doesn't make any sense). It is visible that it has noticable overhead (creating new transaction, preparing the coro, etc)