### PR TITLE
refactor(server): record last-command stats at top-level dispatch

### DIFF
--- a/src/server/conn_context.h
+++ b/src/server/conn_context.h
@@ -308,12 +308,16 @@ class ConnectionContext : public facade::ConnectionContext {
  public:
   ConnectionContext(facade::Connection* owner, dfly::acl::UserCredentials cred);
 
-  struct DebugInfo {
-    uint32_t shards_count = 0;
-    TxClock clock = 0;
+  // Per-client introspection about the most recent command executed on this
+  // connection (akin to the info Redis exposes via CLIENT INFO). Captured live
+  // during command execution because the underlying Transaction is per-command
+  // and freed once dispatch returns.
+  struct LastCommandStats {
+    uint32_t shards_count = 0;  // unique shards touched by the command's transaction
+    TxClock clock = 0;          // transaction id (txid) of the command
   };
 
-  DebugInfo last_command_debug;
+  LastCommandStats last_cmd_stats;
 
   // TODO: to introduce proper accessors.
   Namespace* ns = nullptr;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -871,7 +871,7 @@ pair<intrusive_ptr<Transaction>, OpStatus> PrepareTransaction(const CommandId* c
     }
 
     if (res)  // new transaction
-      dfly_cntx->last_command_debug.shards_count = cmd_ctx->tx()->GetUniqueShardCnt();
+      dfly_cntx->last_cmd_stats.shards_count = cmd_ctx->tx()->GetUniqueShardCnt();
   }
 
   return {std::move(res), OpStatus::OK};
@@ -1550,6 +1550,11 @@ DispatchResult Service::DispatchCommand(facade::ParsedArgs args, facade::ParsedC
   DispatchResult res = InvokeCmd(tail_args, cmd_cntx);
   if (dispatched_tx) {
     DCHECK(dfly_cntx->transaction == dispatched_tx.get());
+    // A new top-level transaction is created here only for top-level commands. Nested commands
+    // (EXEC body, script CALLs, squashed sub-commands) reuse an existing transaction or run on a
+    // different dispatch path, so recording last-command stats here naturally excludes them and
+    // avoids racing on the shared ConnectionContext from squashing shard threads.
+    dfly_cntx->last_cmd_stats.clock = dispatched_tx->txid();
     dfly_cntx->transaction = nullptr;
   }
 
@@ -1680,10 +1685,6 @@ DispatchResult Service::InvokeCmd(CmdArgList tail_args, CommandContext* cmd_cntx
     }
 
     cmd_cntx->RecordLatency(tail_args);
-
-    if (tx && !cntx->conn_state.exec_info.IsRunning() && cntx->conn_state.script_info == nullptr) {
-      cntx->last_command_debug.clock = tx->txid();
-    }
   }
 
   // For EVAL[] and EXEC/DISCARD, clean up state.

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -422,7 +422,7 @@ void MultiCommandSquasher::Run(RedisReplyBuilder* rb) {
   ExecuteSquashed(rb);  // Flush leftover
 
   // Set last txid.
-  cntx_->last_command_debug.clock = cntx_->transaction->txid();
+  cntx_->last_cmd_stats.clock = cntx_->transaction->txid();
 
   // UnlockMulti is a no-op for non-atomic multi transactions,
   // still called for correctness and future changes

--- a/src/server/test_utils.cc
+++ b/src/server/test_utils.cc
@@ -481,7 +481,7 @@ RespExpr BaseFamilyTest::Run(std::string_view id, ArgSlice slice) {
   }
 
   unique_lock lk(mu_);
-  last_cmd_dbg_info_ = context->last_command_debug;
+  last_cmd_dbg_info_ = context->last_cmd_stats;
 
   return conn_wrapper->ParseResponse(single_response_);
 }
@@ -705,11 +705,11 @@ const facade::Connection::InvalidationMessage& BaseFamilyTest::GetInvalidationMe
   return it->second->GetInvalidationMessage(index);
 }
 
-ConnectionContext::DebugInfo BaseFamilyTest::GetDebugInfo(const std::string& id) const {
+ConnectionContext::LastCommandStats BaseFamilyTest::GetDebugInfo(const std::string& id) const {
   auto it = connections_.find(id);
   CHECK(it != connections_.end());
 
-  return it->second->cmd_cntx()->last_command_debug;
+  return it->second->cmd_cntx()->last_cmd_stats;
 }
 
 auto BaseFamilyTest::AddFindConn(Protocol proto, std::string_view id) -> TestConnWrapper* {

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -129,9 +129,9 @@ class BaseFamilyTest : public ::testing::Test {
   void CleanupSnapshots();
 
   bool IsLocked(DbIndex db_index, std::string_view key) const;
-  ConnectionContext::DebugInfo GetDebugInfo(const std::string& id) const;
+  ConnectionContext::LastCommandStats GetDebugInfo(const std::string& id) const;
 
-  ConnectionContext::DebugInfo GetDebugInfo() const {
+  ConnectionContext::LastCommandStats GetDebugInfo() const {
     return GetDebugInfo("IO0");
   }
 
@@ -188,7 +188,7 @@ class BaseFamilyTest : public ::testing::Test {
 
   absl::flat_hash_map<std::string, std::unique_ptr<TestConnWrapper>> connections_;
   util::fb2::Mutex mu_;
-  ConnectionContext::DebugInfo last_cmd_dbg_info_;
+  ConnectionContext::LastCommandStats last_cmd_dbg_info_;
 
   bool single_response_ = true;
   util::fb2::Fiber watchdog_fiber_;


### PR DESCRIPTION
## Summary
- Renames `ConnectionContext::DebugInfo` → `LastCommandStats` to reflect that it's per-client introspection about the most recent command (akin to Redis `CLIENT INFO`), not test-only scaffolding.
- Moves the `clock` (txid) write out of `InvokeCmd` and into `DispatchCommand`, gated on `dispatched_tx` (the newly-created top-level transaction).

## Why
`InvokeCmd` runs on squashing **shard threads**, where it wrote `last_cmd_stats.clock` into the *shared* `ConnectionContext`. That was a data race across threads and the source of reported cache-line contention (false sharing against concurrent `owner_`/`ns`/`db_index` reads on the same line).

Recording at the top-level dispatch site instead is provably equivalent: `dispatched_tx` is non-null **exactly** for top-level commands. Nested paths are excluded for free — script CALLs reuse the script transaction (`dispatched_tx` is null), while EXEC body and squashed sub-commands never reach `DispatchCommand`. This also lets us delete the old three-part guard (`tx && !exec_info.IsRunning() && script_info == nullptr`); `InvokeCmd` no longer touches shared connection state at all.

## Changes
- `conn_context.h`: rename struct/member, add documenting comments.
- `main_service.cc`: write `last_cmd_stats.clock` in `DispatchCommand`; remove the guarded write from `InvokeCmd`.
- `multi_command_squasher.cc`, `test_utils.{h,cc}`: rename follow-through.

## Test
- `multi_test` (59), `list_family_test` (51), `string_family_test` (45) pass — these cover the `clock` and `shards_count` assertions.