### PR TITLE
fix(facade): retire experimental_io_loop_v2 flag

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -130,6 +130,7 @@ ABSL_FLAG(bool, enable_memcache_io_loop_v2, true,
           "Enable the event-driven IoLoopV2 for non-TLS Memcache connections.");
 ABSL_FLAG(bool, enable_resp_io_loop_v2, false,
           "Enable the event-driven IoLoopV2 for non-TLS RESP connections.");
+ABSL_RETIRED_FLAG(bool, experimental_io_loop_v2, true, "retired.");
 
 using namespace util;
 using namespace std;


### PR DESCRIPTION
The `experimental_io_loop_v2` flag was accidentally dropped. Using ABSL_RETIRED_FLAG instead of simply removing it preserves backward compatibility for deployments that reference it in configs or scripts.