### PR TITLE
perf(facade): Drain socket in recv callback

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -809,6 +809,7 @@ void Connection::OnPostMigrateThread() {
     MaybeEnableRecvMultishot();
     socket_->RegisterOnRecv([this](const FiberSocketBase::RecvNotification& n) {
       NotifyOnRecv(n);
+      ReadPendingInput();
       io_event_.notify();
     });
   }
@@ -2902,6 +2903,8 @@ void Connection::NotifyOnRecv(const util::FiberSocketBase::RecvNotification& n) 
 }
 
 void Connection::ReadPendingInput() {
+  if (!pending_input_)
+    return;
   // Drain available socket data into io_buf_.
   io::MutableBytes buf = io_buf_.AppendBuffer();
   // A recv call can return fewer bytes than requested even if the
@@ -3059,6 +3062,10 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
   peer->RegisterOnRecv([this](const FiberSocketBase::RecvNotification& n) {
     DVLOG(2) << "Calling DoReadOnRecv iobuf_len: " << io_buf_.InputLen();
     NotifyOnRecv(n);
+    // Eagerly drain the kernel TCP receive buffer while the connection fiber might be is
+    // blocked/busy. This prevents rbuf starvation (V2's single fiber can't read while executing).
+    // Safe: callback only fires when the fiber has yielded - no concurrent access to io_buf_.
+    ReadPendingInput();
     io_event_.notify();
   });
 
@@ -3088,9 +3095,7 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
       current_wait_.emplace(parsed_head_, &cmd_completion_waiter);
     }
 
-    if (pending_input_) {
-      ReadPendingInput();
-    }
+    ReadPendingInput();
 
     // Idle park: flush and sleep when there is nothing to do (ShouldWakeIdle is false only when
     // the read buffer is also empty).


### PR DESCRIPTION
V2's single fiber cannot read from the socket while executing
commands. When the fiber is suspended at a cross-shard barrier
or idle-await, the kernel TCP receive buffer accumulates data.
If the buffer fills, the kernel drops packets or advertises a
zero-window, causing client retransmits and latency spikes.

ReadPendingInput() is now called directly in the RegisterOnRecv
callback. The callback fires while the fiber is suspended,
draining the kernel buffer before the fiber resumes and reaches
the top of its loop.

ReadPendingInput() is made self-guarding: it returns immediately
if pending_input_ is false, so callers need no external guard.
This also replaces the guarded call at the IoLoopV2 top-of-loop
with an unconditional one.

Safe: cooperative scheduling guarantees the callback and the
connection fiber never execute concurrently - no locks needed.

Benchmarks (AWS Graviton, 4 proactors, cross-machine, SET 2KB,
50 connections, 3 runs, memtier_benchmark):

  pipeline=1: 150k -> 164k ops/s (+9.2%)
  pipeline=10: 402k -> 422k ops/s (+5.0%)
  pipeline=50: 461k -> 480k ops/s (+4.0%)
  pipeline=100: 433k -> 444k ops/s (+2.5%)

Largest gains at low pipeline depths where the callback fires
frequently during shard-hop suspensions. No regressions in
single-conn, pubsub, or high-pipeline runs.

The RPS improvement comes from having data pre-loaded in io_buf_
when the fiber resumes, shortening the read-to-execute round-
trip rather than reducing TCP retransmits.
