### PR TITLE
fix(facade): propagate parse status from batch parsers

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1496,18 +1496,25 @@ auto Connection::ParseLoop() -> ParserStatus {
   auto parse_func =
       protocol_ == Protocol::MEMCACHE ? &Connection::ParseMCBatch : &Connection::ParseRedisBatch;
 
-  bool commands_parsed = false;
+  ParserStatus parse_status = NEED_MORE;
   do {
-    commands_parsed = (this->*parse_func)(io_buf_);
+    parse_status = (this->*parse_func)(io_buf_);
 
+    // Execute/reply the commands parsed so far first, so a trailing protocol error still flushes
+    // earlier replies in order before we report it.
     if (!ExecuteBatch())
       return ERROR;
 
     if (!ReplyBatch())
       return ERROR;
-  } while (commands_parsed && io_buf_.InputLen() > 0);
 
-  return commands_parsed ? OK : NEED_MORE;
+    // Surface a protocol error to the caller (HandleRequests/IoLoopV2) so it can send the
+    // protocol error reply (using parser_error_) and close the connection.
+    if (parse_status == ERROR)
+      return ERROR;
+  } while (parse_status == OK && io_buf_.InputLen() > 0);
+
+  return parse_status;  // OK or NEED_MORE
 }
 
 void Connection::OnBreakCb(int32_t mask) {
@@ -2492,7 +2499,7 @@ bool Connection::IsReplySizeOverLimit() const {
   return over_limit;
 }
 
-bool Connection::ParseRedisBatch(base::IoBuf& buf) {
+Connection::ParserStatus Connection::ParseRedisBatch(base::IoBuf& buf) {
   QueueBackpressure& qbp = GetQueueBackpressure();
 
   // Only throttle parsing if this connection is actively contributing to the queue.
@@ -2500,15 +2507,17 @@ bool Connection::ParseRedisBatch(base::IoBuf& buf) {
   // administrative commands (CONFIG SET, etc.) can execute and relieve backpressure.
   if ((parsed_cmd_q_len_ > 0) &&
       qbp.IsPipelineBufferOverLimit(GetLocalConnStats().pipeline_queue_bytes, parsed_cmd_q_len_)) {
-    // Signal ParseLoop to stop. IoLoopV2 will drain before resuming.
+    // Signal ParseLoop to stop (NEED_MORE, not an error). IoLoopV2 will drain before resuming.
     DVLOG(2) << "Pipeline buffer over limit. Avoid parsing Redis batch.";
     GetLocalConnStats().pipeline_throttle_count++;
-    return false;
+    return NEED_MORE;
   }
-  return ParseRedis(buf, max_busy_read_cycles_cached, true) == ParserStatus::OK;
+  // Forward ParseRedis's status verbatim (OK / NEED_MORE / ERROR) so a protocol error
+  // propagates to ParseLoop instead of being flattened into "no commands parsed".
+  return ParseRedis(buf, max_busy_read_cycles_cached, true);
 }
 
-bool Connection::ParseMCBatch(base::IoBuf& io_buf) {
+Connection::ParserStatus Connection::ParseMCBatch(base::IoBuf& io_buf) {
   CHECK(io_buf.InputLen() > 0);
 
   do {
@@ -2526,7 +2535,7 @@ bool Connection::ParseMCBatch(base::IoBuf& io_buf) {
     DVLOG(2) << "mc_result " << unsigned(result) << " consumed: " << consumed << " type "
              << unsigned(parsed_cmd_->mc_command()->type);
     if (result == MemcacheParser::INPUT_PENDING)
-      return false;
+      return NEED_MORE;
 
     if (result == MemcacheParser::OK && tl_traffic_logger.log_file &&
         tl_traffic_logger.listener_type == listener_type_) {
@@ -2564,7 +2573,8 @@ bool Connection::ParseMCBatch(base::IoBuf& io_buf) {
       }
     }
   } while (parsed_cmd_q_len_ < 128 && io_buf.InputLen() > 0);
-  return true;
+  // Memcache parse errors are turned into deferred replies above, so we never return ERROR here.
+  return OK;
 }
 
 bool Connection::ExecuteBatch() {

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -435,12 +435,17 @@ class Connection : public util::Connection {
 
   bool IsReplySizeOverLimit() const;
 
-  // Returns true if one or more commands were parsed from the read buffer,
-  // and false if no complete commands could be parsed (for example, when
-  // parsing is pending more input).
-  bool ParseMCBatch(base::IoBuf& buf);
+  // Parse a batch of commands from the read buffer, enqueueing each complete command.
+  // Returns:
+  //   OK        - parsing stopped at a clean command boundary; more may follow (keep going).
+  //   NEED_MORE - the buffer ends mid-command (or parsing was throttled by backpressure);
+  //               any complete commands seen so far are still enqueued.
+  //   ERROR     - a protocol error was hit; the caller must report it and close.
+  // Note: a non-OK result does NOT mean "no commands were parsed" - complete commands ahead
+  // of the boundary/error are enqueued regardless.
+  ParserStatus ParseMCBatch(base::IoBuf& buf);
 
-  bool ParseRedisBatch(base::IoBuf& buf);
+  ParserStatus ParseRedisBatch(base::IoBuf& buf);
 
   // Call the appropriate ParseMCBatch or ParseRedisBatch based on the protocol.
   // Only CPU-bound work; must not perform I/O or fiber suspension.

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -771,6 +771,37 @@ async def test_v2_conditional_flush_no_stall(df_server: DflyInstance):
     await writer.wait_closed()
 
 
+@dfly_args({"enable_resp_io_loop_v2": "true"})
+async def test_v2_protocol_error_closes_connection(df_server: DflyInstance):
+    """A RESP protocol error on the event-driven (V2) loop must reply and close.
+
+    Regression test: ParseRedisBatch used to collapse ParseRedis's 3-valued status into a
+    bool, so a protocol error became indistinguishable from "need more input". ParseLoop
+    then never returned ERROR and the malformed command was silently treated as a partial
+    one - the client got no error and the connection hung instead of being closed.
+    """
+    reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
+
+    # A valid command first confirms the connection is healthy on the V2 path.
+    writer.write(b"PING\r\n")
+    await writer.drain()
+    assert await asyncio.wait_for(reader.readline(), timeout=2.0) == b"+PONG\r\n"
+
+    # Malformed multibulk header (length is not a number) -> protocol error.
+    writer.write(b"*x\r\n")
+    await writer.drain()
+
+    err = await asyncio.wait_for(reader.readline(), timeout=2.0)
+    assert err.startswith(b"-ERR Protocol error"), f"expected protocol error, got {err!r}"
+
+    # The server must close the connection after a protocol error (read() returns b"" at EOF).
+    eof = await asyncio.wait_for(reader.read(), timeout=2.0)
+    assert eof == b"", f"expected connection close after protocol error, got {eof!r}"
+
+    writer.close()
+    await writer.wait_closed()
+
+
 async def test_big_command(df_server, size=8 * 1024):
     reader, writer = await asyncio.open_connection("127.0.0.1", df_server.port)
 


### PR DESCRIPTION
## Summary

`ParseRedisBatch` / `ParseMCBatch` returned a `bool` that collapsed four distinct outcomes — clean command boundary (`OK`), needs more input (`NEED_MORE`), backpressure throttle, and protocol error (`ERROR`) — into `true`/`false`. Two problems followed:

- **Swallowed RESP protocol errors.** `ParseLoop` ended with `return commands_parsed ? OK : NEED_MORE` and never produced `ERROR`. In the event-driven loop (`enable_resp_io_loop_v2`, default **off** — so this is latent), a malformed RESP command was therefore treated as "need more data": the connection never sent a protocol-error reply and never closed. Unlike Memcache, the RESP `enqueue_only` path does not bake errors into a deferred reply, so the error had nowhere to go. (The default RESP path calls `ParseRedis` directly and was unaffected.)
- **Misleading semantics.** `true` meant "the parser stopped at a clean boundary," not "a command was parsed." A buffer ending in a partial command yields `NEED_MORE` → `false` even though complete commands ahead of it were parsed and enqueued.

## Fix

- Both batch parsers now return the 3-valued `ParserStatus`:
  - `ParseRedisBatch` forwards `ParseRedis`'s status verbatim; backpressure throttle → `NEED_MORE`.
  - `ParseMCBatch` returns `OK` (it converts parse errors into deferred replies) and `NEED_MORE` on `INPUT_PENDING`.
- `ParseLoop` executes/replies the commands parsed so far (preserving in-order replies), then returns `ERROR` on a protocol error so `HandleRequests`/`IoLoopV2` send the protocol-error reply (via `parser_error_`) and close.

## Verification

- `dragonfly` builds.
- Pipeline + Memcache error/pipeline integration tests pass (`connection_test::test_pipeline_support`, `pymemcached_test::TestMemcached::{test_error_in_pipeline,test_noreply_pipeline}`).
- Manual raw-socket test with `--enable_resp_io_loop_v2=true`: a valid `PING` returns `+PONG`, and a malformed `*x\r\n` now returns `-ERR Protocol error: ...` and closes the connection (previously it hung waiting for more input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)