### PR TITLE
fix(search): ensure index-level options persist across restart

### DIFF
--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -204,6 +204,18 @@ string DocIndexInfo::BuildRestoreCommand() const {
       absl::StrAppend(&out, " ", sw);
   }
 
+  if (base_index.options.no_offsets) {
+    absl::StrAppend(&out, " NOOFFSETS");
+  }
+
+  if (base_index.schema.default_language != "english") {
+    absl::StrAppend(&out, " LANGUAGE ", base_index.schema.default_language);
+  }
+
+  if (!base_index.schema.language_field.empty()) {
+    absl::StrAppend(&out, " LANGUAGE_FIELD ", base_index.schema.language_field);
+  }
+
   absl::StrAppend(&out, " SCHEMA");
   for (const auto& [fident, finfo] : base_index.schema.fields) {
     // Store field name, alias and type
@@ -234,6 +246,8 @@ string DocIndexInfo::BuildRestoreCommand() const {
         [out = &out](const search::SchemaField::TextParams& params) {
           if (params.with_suffixtrie)
             absl::StrAppend(out, " ", "WITHSUFFIXTRIE");
+          if (params.no_stem)
+            absl::StrAppend(out, " ", "NOSTEM");
         },
         [out = &out](const search::SchemaField::NumericParams& params) {
           absl::StrAppend(out, " ", "BLOCKSIZE", " ", std::to_string(params.block_size));

--- a/tests/dragonfly/search_test.py
+++ b/tests/dragonfly/search_test.py
@@ -532,6 +532,68 @@ async def test_knn_score_return(async_client: aioredis.Redis):
     await i1.dropindex()
 
 
+@dfly_args({"proactor_threads": 4, "dbfilename": "search-options-persistence"})
+async def test_index_level_options_persist_after_restart(df_server):
+    """Test that index-level options (LANGUAGE, LANGUAGE_FIELD, NOOFFSETS, NOSTEM) persist after server restart."""
+    client = df_server.client()
+    await client.execute_command(
+        "FT.CREATE idx "
+        "ON HASH "
+        "PREFIX 1 test: "
+        "LANGUAGE spanish "
+        "LANGUAGE_FIELD lang "
+        "NOOFFSETS "
+        "SCHEMA "
+        "title TEXT NOSTEM "
+    )
+
+    def verify_index_options(info, is_after_restart=False):
+        msg = "after restart" if is_after_restart else "before restart"
+
+        index_options_idx = info.index("index_options") + 1
+        assert "NOOFFSETS" in info[index_options_idx], f"NOOFFSETS option lost {msg}"
+
+        def_idx = info.index("index_definition") + 1
+        index_def = info[def_idx]
+
+        lang_pos = index_def.index("default_language") + 1
+        assert index_def[lang_pos] == "spanish", f"LANGUAGE lost {msg}"
+
+        lang_field_pos = index_def.index("language_field") + 1
+
+        assert index_def[lang_field_pos] == "lang", f"LANGUAGE_FIELD lost {msg}"
+
+        attributes_idx = info.index("attributes") + 1
+        attributes = info[attributes_idx]
+
+        title_field = None
+        for field in attributes:
+            for i, val in enumerate(field):
+                if val == "attribute" and i + 1 < len(field) and field[i + 1] == "title":
+                    title_field = field
+                    break
+            if title_field:
+                break
+        assert title_field is not None, "title field not found in attributes"
+        assert "NOSTEM" in title_field, f"NOSTEM option lost {msg}"
+
+    info_before = await client.execute_command("FT.INFO idx")
+    verify_index_options(info_before, False)
+
+    await client.execute_command("SAVE")
+    df_server.stop()
+    df_server.start()
+    async with df_server.client() as client:
+        await wait_available_async(client)
+
+    new_client = df_server.client()
+    info_after = await new_client.execute_command("FT.INFO idx")
+
+    verify_index_options(info_after, is_after_restart=True)
+
+    await new_client.execute_command("FT.DROPINDEX idx")
+
+
 @dfly_args({"proactor_threads": 4, "dbfilename": "search-data"})
 async def test_index_persistence(df_server):
     client = aioredis.Redis(port=df_server.port)


### PR DESCRIPTION
Update DocIndexInfo::BuildRestoreCommand() to include:
- NOOFFSETS option
- LANGUAGE option
- LANGUAGE_FIELD option
- NOSTEM option for text fields

This fixes the issue where index configuration was lost after server restart or during replication, because these options were not serialized in the restore command.

Add test_index_level_options_persist_after_restart to verify the fix.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
