### PR TITLE
refactor(facade): extract IoLoopV2 data-path into drain/parse helpers

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -3016,12 +3016,13 @@ bool Connection::ShouldWakeIdle() const {
 }
 
 bool Connection::DrainControlPath(uint32_t quota) {
+  DCHECK(!dispatch_q_.empty());
+
+  // TODO: ProcessControlMessages should be fused into here.
+
   // Bounded quota prevents the control path from starving the data path: under a PubSub flood
   // dispatch_q_ can accumulate thousands of messages, and without a quota the fiber would drain
   // them all before parsing any socket data. Mirrors V1's async_dispatch_quota mechanism.
-  if (dispatch_q_.empty())
-    return false;
-
   bool quota_reached = ProcessControlMessages(quota);
   GetQueueBackpressure().pubsub_ec.notifyAll();
 
@@ -3038,6 +3039,57 @@ Connection::ParserStatus Connection::RunParsePath() {
   ParserStatus parse_status = ParseLoop();
   NotifyIfMemReleased(mem_before);
   return parse_status;
+}
+
+void Connection::DrainQueuedCommands() {
+  // No new input to parse (or parsing is held off by backpressure). Drain already-queued commands
+  // - execute ready ones and send completed replies - to free pipeline memory without growing the
+  // queue.
+  size_t mem_before = GetLocalConnStats().pipeline_queue_bytes;
+
+  if (parsed_head_) {
+    if (HasCommandToExecute())
+      ExecuteBatch();
+    ReplyBatch();
+  }
+
+  NotifyIfMemReleased(mem_before);
+}
+
+void Connection::ParkOnBackpressure(util::fb2::detail::Waiter* bp_waiter) {
+  // Draining (by the caller) may have freed enough memory; only park if still over the limit, to
+  // prevent a busy-spin.
+  if (!IsOverPipelineLimit())
+    return;
+
+  auto& conn_stats = GetLocalConnStats();
+  conn_stats.pipeline_throttle_count++;
+  LOG_EVERY_T(WARNING, 10) << "Pipeline buffer over limit (V2)."
+                           << ", Thread pipeline_queue_bytes: " << conn_stats.pipeline_queue_bytes
+                           << ", Thread pipeline_queue_entries: "
+                           << conn_stats.pipeline_queue_entries
+                           << ", Connection parsed_cmd_q_bytes_: " << parsed_cmd_q_bytes_
+                           << ", Connection parsed commands queue size: " << parsed_cmd_q_len_
+                           << ", consider increasing pipeline_buffer_limit/pipeline_queue_limit";
+
+  // Subscribe persistently to the global backpressure EventCount so that when another connection
+  // frees memory (or CONFIG SET raises limits), our waiter callback fires io_event_.notify(),
+  // waking this fiber. Must be persistent because io_event_.await()'s internal loop may re-sleep
+  // if the predicate is still false after the first notification. A one-shot subscription would be
+  // consumed on the first wake, leaving us "deaf" to future memory relief.
+  auto sub_key = GetQueueBackpressure().v2_pipeline_backpressure_ec.subscribe_persistent(bp_waiter);
+
+  // Exit on error, the caller will propagate the reply_builder error further.
+  if (auto ec = FlushReplies(); ec)
+    return;
+
+  io_event_.await([this]() {
+    // Leave the backpressure wait once our own pipeline pressure clears, or on any control event
+    // (the latter lets a terminating/migrating connection escape the park).
+    bool under_limit = !GetQueueBackpressure().IsPipelineBufferOverLimit(
+        GetLocalConnStats().pipeline_queue_bytes, parsed_cmd_q_len_);
+    return under_limit || HasControlEvent();
+  });
 }
 
 variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
@@ -3092,13 +3144,11 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
       ReadPendingInput();
     }
 
-    // Idle park: flush and sleep when there is nothing to do (ShouldWakeIdle is false only when
-    // the read buffer is also empty).
+    // Idle park: flush and sleep only when the fiber is truly idle (ShouldWakeIdle() is false).
+    // When synchronous commands (e.g. PUBLISH) are pipelined, ExecuteBatch processes them
+    // and loops back here with HasCommandToExecute() == true; skipping the flush then lets the
+    // whole pipeline execute in-memory before a single sendmsg at the end.
     if (!ShouldWakeIdle()) {
-      // Only flush and park if the fiber is truly idle. When synchronous commands (e.g. PUBLISH)
-      // are pipelined, ExecuteBatch processes one at a time and loops back here with
-      // HasCommandToExecute() == true. Skipping the flush lets the entire pipeline execute
-      // in-memory before a single sendmsg at the end.
       phase_ = READ_SOCKET;
 
       // Flush replies deferred by ReplyBatch before sleeping - ensures the client gets its response
@@ -3113,74 +3163,27 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
     phase_ = PROCESS;
     bool reached_capacity = io_buf_.AppendLen() == 0;
 
-    // Control path: drain dispatch_q_. Restart the loop (so fresh socket data is read first) unless
-    // we hit the quota, in which case fall through to the data path to avoid starving it.
-    if (DrainControlPath(async_dispatch_quota)) {
+    // Control path: drain dispatch_q_. Restart the loop (so fresh socket data is read first)
+    // unless we hit the quota, in which case fall through to the data path to avoid starving it.
+    if (!dispatch_q_.empty() && DrainControlPath(async_dispatch_quota)) {
       continue;
     }
 
-    // Only parse data if we are under the memory limit (backpressure).
-    // Exception: If the queue is empty, we always parse to allow admin commands
-    // (like CONFIG SET) to run so they can fix the memory limits if needed.
-    if ((io_buf_.InputLen() > 0) && !IsOverPipelineLimit()) {
-      parse_status = RunParsePath();
-    } else {
-      // Data Backpressure Path: either no input (io_buf_ empty) or over memory limit.
-      // Do NOT parse - that would grow the queue further. Instead, drain already-queued
-      // commands (execute + reply) to free memory, then park until pressure is relieved.
+    bool over_limit = IsOverPipelineLimit();
+    if (io_buf_.InputLen() == 0 || over_limit) {
+      // Drain-only path: either there is no new input to parse, or we are over the pipeline memory
+      // limit (parsing would only grow the queue further). Either way, drain queued commands to
+      // free memory instead of parsing. When over the limit, also park until another connection
+      // relieves the pressure. (Empty queues are never over the limit, so admin commands can still
+      // parse.)
+      DrainQueuedCommands();
+      if (over_limit)
+        ParkOnBackpressure(&backpressure_waiter);
       parse_status = NEED_MORE;
-
-      // Handle Parsed Commands Queue (Data Path)
-      auto& conn_stats = GetLocalConnStats();
-
-      size_t mem_before = conn_stats.pipeline_queue_bytes;
-
-      if (parsed_head_) {
-        if (HasCommandToExecute())
-          ExecuteBatch();
-        ReplyBatch();
-      }
-
-      NotifyIfMemReleased(mem_before);
-
-      // await block (backpressure)
-      // Re-check if pipeline buffer over limit after draining - ExecuteBatch/ReplyBatch may have
-      // freed memory. If still over limit, sleep to prevent busy-spin.
-      // Only park if this connection is actively contributing (parsed_cmd_q_len_ > 0).
-      // Connections with an empty queue must stay in the read loop.
-      if (IsOverPipelineLimit()) {
-        conn_stats.pipeline_throttle_count++;
-        LOG_EVERY_T(WARNING, 10)
-            << "Pipeline buffer over limit (V2)."
-            << ", Thread pipeline_queue_bytes: " << conn_stats.pipeline_queue_bytes
-            << ", Thread pipeline_queue_entries: " << conn_stats.pipeline_queue_entries
-            << ", Connection parsed_cmd_q_bytes_: " << parsed_cmd_q_bytes_
-            << ", Connection parsed commands queue size: " << parsed_cmd_q_len_
-            << ", consider increasing pipeline_buffer_limit/pipeline_queue_limit";
-
-        // Subscribe persistently to the global backpressure EventCount so that when another
-        // connection frees memory (or CONFIG SET raises limits), our backpressure_waiter callback
-        // fires io_event_.notify(), waking this fiber. Must be persistent because
-        // io_event_.await()'s internal loop may re-sleep if the predicate is still false after the
-        // first notification. A one-shot subscription would be consumed on the first wake, leaving
-        // us "deaf" to future memory relief.
-        auto sub_key = GetQueueBackpressure().v2_pipeline_backpressure_ec.subscribe_persistent(
-            &backpressure_waiter);
-
-        // Client needs replies to free its send buffer and relieve backpressure.
-        if (auto ec = FlushReplies(); ec) {
-          return ec;
-        }
-
-        io_event_.await([this]() {
-          // Leave the backpressure wait once our own pipeline pressure clears, or on any control
-          // event (the latter lets a terminating/migrating connection escape the park).
-          bool under_limit = !GetQueueBackpressure().IsPipelineBufferOverLimit(
-              GetLocalConnStats().pipeline_queue_bytes, parsed_cmd_q_len_);
-          return under_limit || HasControlEvent();
-        });
-      }
-    }  // else Execute and reply
+    } else {
+      // Input available and under budget: parse, execute, reply.
+      parse_status = RunParsePath();
+    }
 
     if (reply_builder_->GetError()) {
       return reply_builder_->GetError();

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -3056,7 +3056,7 @@ void Connection::DrainQueuedCommands() {
   NotifyIfMemReleased(mem_before);
 }
 
-void Connection::ParkOnBackpressure(util::fb2::detail::Waiter* bp_waiter) {
+void Connection::ParkOnBackpressure(util::fb2::detail::Waiter* backpressure_waiter) {
   // Draining (by the caller) may have freed enough memory; only park if still over the limit, to
   // prevent a busy-spin.
   if (!IsOverPipelineLimit())
@@ -3077,7 +3077,8 @@ void Connection::ParkOnBackpressure(util::fb2::detail::Waiter* bp_waiter) {
   // waking this fiber. Must be persistent because io_event_.await()'s internal loop may re-sleep
   // if the predicate is still false after the first notification. A one-shot subscription would be
   // consumed on the first wake, leaving us "deaf" to future memory relief.
-  auto sub_key = GetQueueBackpressure().v2_pipeline_backpressure_ec.subscribe_persistent(bp_waiter);
+  auto sub_key =
+      GetQueueBackpressure().v2_pipeline_backpressure_ec.subscribe_persistent(backpressure_waiter);
 
   // Exit on error, the caller will propagate the reply_builder error further.
   if (auto ec = FlushReplies(); ec)

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -485,8 +485,8 @@ class Connection : public util::Connection {
   bool ShouldWakeIdle() const;
 
   // IoLoopV2 control path: drains dispatch_q_, processing up to `quota` control messages.
-  // Expects dispatch_q_ to be non-empty. Returns true if dispatch_q_ was depleted, false if the
-  // quota was reached first.
+  // Expects dispatch_q_ to be non-empty. Returns true if dispatch_q_ was depleted or it had to
+  // stop draining, false if the quota was reached.
   bool DrainControlPath(uint32_t quota);
 
   // IoLoopV2 data path when input is available and we are under the pipeline limit: parse, execute

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -484,14 +484,22 @@ class Connection : public util::Connection {
   // ready to run.
   bool ShouldWakeIdle() const;
 
-  // IoLoopV2 control path: drains dispatch_q_ up to `quota`. Returns true if the caller should
-  // restart the loop (so freshly arrived socket data is read before the data path runs), false to
-  // fall through to the data path.
+  // IoLoopV2 control path: drains dispatch_q_, processing up to `quota` control messages.
+  // Expects dispatch_q_ to be non-empty. Returns true if dispatch_q_ was depleted, false if the
+  // quota was reached first.
   bool DrainControlPath(uint32_t quota);
 
   // IoLoopV2 data path when input is available and we are under the pipeline limit: parse, execute
   // and reply. Returns the parser status.
   ParserStatus RunParsePath();
+
+  // IoLoopV2 data path with no new input to parse: execute ready commands and send completed
+  // replies, freeing pipeline memory without growing the queue.
+  void DrainQueuedCommands();
+
+  // IoLoopV2 backpressure park: if still over the pipeline limit (draining may have relieved it),
+  // subscribe to global memory-relief notifications, flush, and park until pressure clears.
+  void ParkOnBackpressure(util::fb2::detail::Waiter* backpressure_waiter);
 
   // Guard of the current subscription to a parsed commands async task blocker
   struct WaitEvent {


### PR DESCRIPTION
## Summary
Pull the inline data-path blocks of `Connection::IoLoopV2` into two helpers and collapse the parse/backpressure logic into two clear branches. No behavior change.

Stacked on #7623 (`refactor/ioloopv2-extract-methods`) — that PR should merge first.

## New helpers
| Helper | Contract |
|---|---|
| `DrainQueuedCommands()` | execute ready commands + reply to free pipeline memory without growing the queue (no new input, or backpressure) |
| `ParkOnBackpressure()` | park while still over the pipeline memory limit, subscribing to global memory-relief notifications |

The base (#7623) already provides `ShouldWakeIdle()`, `DrainControlPath()`, and `RunParsePath()`.

## Data path — two branches
- **No input or over limit** → `DrainQueuedCommands()`, then `ParkOnBackpressure()` only when over the limit
- **Input, under budget** → `RunParsePath()`

Gating the park on `over_limit` makes the empty-input case explicit. It stays equivalent to the old code, where `ParkOnBackpressure()` early-returns when under the limit.

## Read socket ASAP
After the idle park wakes on a recv notification (`pending_input_` set but data not yet in `io_buf_`), the loop restarts so `ReadPendingInput()` pulls the data before the data path runs on an empty buffer. Guarded by an empty `io_buf_` so buffered input is never skipped and a full buffer never busy-spins.

## Testing
- `dragonfly_test`: 45 passed, 1 skipped
- `connection_test.py --df enable_resp_io_loop_v2=true`: pipelining, pubsub control path, squashing, migration, and `test_pipeline_overlimit` / `test_pipeline_backpressure_v2_correctness` all pass
- clang-format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
