### PR TITLE
fix(server): exclude admin commands from pipeline squashing

### DIFF
--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1763,13 +1763,16 @@ uint32_t Service::DispatchSquashedBatch(facade::ParsedCommand* first, unsigned c
     //  - blocking commands: prior replies must be flushed before the fiber blocks;
     //  - QUIT: closes the reply builder, dropping any deferred replies not yet sent;
     //  - subscribe/unsubscribe: emit one reply per channel (multiple top-level replies), which the
-    //    CapturingReplyBuilder backing deferred replies cannot represent.
+    //    CapturingReplyBuilder backing deferred replies cannot represent;
+    //  - admin commands (e.g. REPLCONF, DFLY): control commands that may produce no top-level
+    //    reply (e.g. REPLCONF ACK), which a deferred (captured) reply cannot represent.
     if (cid == nullptr)
       break;
 
     const bool is_multi = dfly_cntx->conn_state.exec_info.IsCollecting() || cid->IsExecGroup();
     const bool is_eval = cid->IsEvalGroup();
-    if (is_multi || is_eval || cid->IsBlocking() || cid->IsQuit() || cid->IsSubscribeFamily())
+    if (is_multi || is_eval || cid->IsBlocking() || (cid->opt_mask() & CO::ADMIN) ||
+        cid->IsQuit() || cid->IsSubscribeFamily())
       break;
 
     cmd_refs.push_back(CmdRef{cid, tail_args, ReplyMode::FULL, cmd_cntx});

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -1106,15 +1106,21 @@ async def test_squashed_pipeline_multi(async_client: aioredis.Redis):
 
 
 """
-Regression: subscribe/unsubscribe commands emit one reply per channel (multiple top-level
-replies), which the CapturingReplyBuilder backing deferred replies cannot represent. When such
-a command lands in a squashed pipeline it must be routed to the regular dispatch path, not
-captured — otherwise the server crashes (reply_capture: current_.index() == 0).
+Regression: some commands cannot be represented by the CapturingReplyBuilder that backs deferred
+replies, so when they land in a squashed pipeline they must be routed to the regular dispatch
+path rather than captured. This test pipelines such commands among squashable SETs (a large
+pipeline forces SquashPipeline) and confirms the whole batch is processed in order without the
+server crashing. The two command classes exercised:
+
+  - subscribe/unsubscribe emit one reply per channel (multiple top-level replies), which a single
+    captured payload cannot hold -> previously crashed in reply_capture (current_.index() == 0);
+  - admin commands may produce no top-level reply at all (e.g. REPLCONF ACK), leaving an empty
+    captured payload -> previously crashed resolving it (parsed_command.cc DCHECK pl.index() > 0).
 """
 
 
 @dfly_args({"proactor_threads": "1", "pipeline_squash": 1})
-async def test_squashed_pipeline_pubsub(df_server: DflyInstance):
+async def test_squashed_pipeline_control_commands(df_server: DflyInstance):
     reader, writer = await asyncio.open_connection("localhost", df_server.port)
 
     def enc(*args):
@@ -1124,12 +1130,12 @@ async def test_squashed_pipeline_pubsub(df_server: DflyInstance):
             out += f"${len(b)}\r\n".encode() + b + b"\r\n"
         return out
 
-    # A large pipeline forces SquashPipeline; the multi-channel (s)unsubscribe commands sit
-    # among squashable SETs. A trailing PING marker confirms the whole batch was processed in
-    # order without crashing.
+    # The control commands sit between two blocks of squashable SETs; a trailing PING marker
+    # confirms the whole batch was processed in order without crashing.
     req = enc("SET", "k", "v") * 40
-    req += enc("SUNSUBSCRIBE", "chA", "chB")
-    req += enc("UNSUBSCRIBE", "chC", "chD")
+    req += enc("SUNSUBSCRIBE", "chA", "chB")  # multi-reply (one per channel)
+    req += enc("UNSUBSCRIBE", "chC", "chD")  # multi-reply (one per channel)
+    req += enc("REPLCONF", "ACK", "1")  # no reply at all
     req += enc("SET", "k", "v") * 40
     req += enc("PING", "squash_survived")
     writer.write(req)


### PR DESCRIPTION
Fixes https://github.com/dragonflydb/dragonfly/issues/7612

## Summary
- Pipelined admin control commands that produce no top-level reply (e.g. `REPLCONF ACK`, `DFLY`) crash the server in the pipeline-squashing path.
- The squash path defers every batched command's reply via `ParsedCommand::Resolve`, which asserts a non-empty payload — so an empty (no-reply) command trips `parsed_command.cc:104] Check failed: pl.index() > 0u`.

This is the same crash hitting the intermittent CI failures, including the flaky `test_memory_on_big_string_loading` replication test (identical stack: `ParsedCommand::Resolve` ← `MultiCommandSquasher::ExecuteStandalone`). On the master side the replica connection sends `REPLCONF`/`DFLY`, which get squashed and abort the server. This PR fixes it.

## Changes
- `DispatchSquashedBatch` now rejects `CO::ADMIN` commands from the squash batch (alongside the existing QUIT/subscribe/blocking/multi/eval cases), routing them through regular dispatch where no-reply is fully supported. Using the `CO::ADMIN` flag covers both `REPLCONF` and `DFLY` plus any future admin command, without name enumeration.
- Extended `test_squashed_pipeline_control_commands` (merged from the former `test_squashed_pipeline_pubsub`) to also pipeline a no-reply `REPLCONF ACK` among squashable `SET`s and assert the batch completes without crashing.

## Test
- The added `REPLCONF ACK` case fails on the current code (server aborts on the DCHECK) and passes with this fix.
- `test_reply_count`, `test_pipeline_support` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)