### PR TITLE
feat(tiering): Skip offloading keys with TTL below minimum threshold

### DIFF
--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -619,7 +619,7 @@ OpResult<CbVariant<uint32_t>> OpSet(const OpArgs& op_args, string_view key, CmdA
   op_args.shard->search_indices()->AddDoc(key, op_args.db_cntx, &pv);
 
   if (auto* ts = op_args.shard->tiered_storage(); ts) {
-    StashPrimeValue(op_args.db_cntx.db_index, key, &pv, ts, op_sp.backpressure);
+    StashPrimeValue(op_args.db_cntx.db_index, key, &it->first, &pv, ts, op_sp.backpressure);
   }
 
   return CbVariant<uint32_t>{SetReply(op_sp, created)};

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -619,7 +619,7 @@ OpResult<CbVariant<uint32_t>> OpSet(const OpArgs& op_args, string_view key, CmdA
   op_args.shard->search_indices()->AddDoc(key, op_args.db_cntx, &pv);
 
   if (auto* ts = op_args.shard->tiered_storage(); ts) {
-    StashPrimeValue(op_args.db_cntx.db_index, key, &it->first, &pv, ts, op_sp.backpressure);
+    StashPrimeValue(op_args.db_cntx.db_index, key, it->first, &pv, ts, op_sp.backpressure);
   }
 
   return CbVariant<uint32_t>{SetReply(op_sp, created)};

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2961,7 +2961,7 @@ void RdbLoader::CreateObjectOnShard(const DbContext& db_cntx, const Item* item, 
     // bogus negative memory delta and crash in AccountObjectMemory.
     auto it = updater.it;
     updater.post_updater.Run();
-    StashPrimeValue(db_cntx.db_index, item->key, &it->first, &it->second, ts, nullptr);
+    StashPrimeValue(db_cntx.db_index, item->key, it->first, &it->second, ts, nullptr);
 
     // Block, if tiered storage is active, but can't keep up
     while (db_slice->shard_owner()->ShouldThrottleForTiering())

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2961,7 +2961,7 @@ void RdbLoader::CreateObjectOnShard(const DbContext& db_cntx, const Item* item, 
     // bogus negative memory delta and crash in AccountObjectMemory.
     auto it = updater.it;
     updater.post_updater.Run();
-    StashPrimeValue(db_cntx.db_index, item->key, &it->second, ts, nullptr);
+    StashPrimeValue(db_cntx.db_index, item->key, &it->first, &it->second, ts, nullptr);
 
     // Block, if tiered storage is active, but can't keep up
     while (db_slice->shard_owner()->ShouldThrottleForTiering())

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -130,7 +130,7 @@ class SetCmd {
               std::string_view value);
 
   // Called at the end of AddNew of SetExisting
-  void PostEdit(const SetParams& params, std::string_view key, std::string_view value,
+  void PostEdit(const SetParams& params, std::string_view key, std::string_view value, PrimeKey* pk,
                 PrimeValue* pv);
 
   void RecordJournal(const SetParams& params, std::string_view key, std::string_view value);
@@ -951,7 +951,7 @@ OpStatus SetCmd::SetExisting(const SetParams& params, string_view value,
 
   DCHECK_EQ(has_expire, key.HasExpire());
 
-  PostEdit(params, it_upd->it.key(), value, &prime_value);
+  PostEdit(params, it_upd->it.key(), value, &key, &prime_value);
   return OpStatus::OK;
 }
 
@@ -974,18 +974,18 @@ void SetCmd::AddNew(const SetParams& params, const DbSlice::Iterator& it, std::s
     it->first.SetSticky(true);
   }
 
-  PostEdit(params, key, value, &it->second);
+  PostEdit(params, key, value, &it->first, &it->second);
 }
 
 void SetCmd::PostEdit(const SetParams& params, std::string_view key, std::string_view value,
-                      PrimeValue* pv) {
+                      PrimeKey* pk, PrimeValue* pv) {
   EngineShard* shard = op_args_.shard;
 
   // Currently we always try to offload, but Stash may ignore it, if disk I/O is overloaded.
   // If we are beyond the offloading threshold, StashPrimeValue may populate a backpressure future
   // via the provided out-parameter.
   if (auto* ts = shard->tiered_storage(); ts) {
-    StashPrimeValue(op_args_.db_cntx.db_index, key, pv, ts, params.backpressure);
+    StashPrimeValue(op_args_.db_cntx.db_index, key, pk, pv, ts, params.backpressure);
   }
 
   if (explicit_journal_ && op_args_.shard->journal()) {

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -985,7 +985,7 @@ void SetCmd::PostEdit(const SetParams& params, std::string_view key, std::string
   // If we are beyond the offloading threshold, StashPrimeValue may populate a backpressure future
   // via the provided out-parameter.
   if (auto* ts = shard->tiered_storage(); ts) {
-    StashPrimeValue(op_args_.db_cntx.db_index, key, pk, pv, ts, params.backpressure);
+    StashPrimeValue(op_args_.db_cntx.db_index, key, *pk, pv, ts, params.backpressure);
   }
 
   if (explicit_journal_ && op_args_.shard->journal()) {

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -64,6 +64,9 @@ ABSL_FLAG(bool, tiered_experimental_hash_support, false, "Experimental hash data
 
 ABSL_FLAG(bool, tiered_experimental_list_support, false, "Experimental list node offloading");
 
+ABSL_FLAG(uint32, tiered_min_ttl_to_offload_ms, 5000,
+          "Min remaining TTL in ms for a value to be eligible for offloading");
+
 namespace dfly {
 
 using namespace std;
@@ -631,6 +634,7 @@ void TieredStorage::UpdateFromFlags() {
       .upload_threshold = absl::GetFlag(FLAGS_tiered_upload_threshold),
       .experimental_hash_offload = absl::GetFlag(FLAGS_tiered_experimental_hash_support),
       .experimental_list_offload = absl::GetFlag(FLAGS_tiered_experimental_list_support),
+      .min_ttl_to_offload_ms = absl::GetFlag(FLAGS_tiered_min_ttl_to_offload_ms),
   };
 
   LOG_IF(WARNING, config_.upload_threshold > config_.offload_threshold)
@@ -642,7 +646,8 @@ std::vector<std::string> TieredStorage::GetMutableFlagNames() {
   return base::GetFlagNames(FLAGS_tiered_min_value_size, FLAGS_tiered_experimental_cooling,
                             FLAGS_tiered_max_pending_stash_bytes, FLAGS_tiered_offload_threshold,
                             FLAGS_tiered_upload_threshold, FLAGS_tiered_experimental_hash_support,
-                            FLAGS_tiered_experimental_list_support);
+                            FLAGS_tiered_experimental_list_support,
+                            FLAGS_tiered_min_ttl_to_offload_ms);
 }
 
 bool TieredStorage::ShouldOffload() const {
@@ -677,7 +682,7 @@ void TieredStorage::RunOffloading(DbIndex dbid) {
   string tmp;
   auto cb = [this, dbid, &tmp](PrimeIterator it) mutable {
     stats_.offloading_steps++;
-    auto blobs = ShouldStash(it->second);
+    auto blobs = ShouldStash(it->second, StashContext{.key_expire_ms = it->first.GetExpireTime()});
     if (blobs) {
       if (it->second.WasTouched()) {
         it->second.SetTouched(false);
@@ -755,11 +760,17 @@ size_t TieredStorage::ReclaimMemory(size_t goal) {
   return gained;
 }
 
-auto TieredStorage::ShouldStash(const tiering::FragmentRef& fragment_ref) const
+auto TieredStorage::ShouldStash(const tiering::FragmentRef& fragment_ref,
+                                const StashContext& stash_ctx) const
     -> std::optional<StashDescriptor> {
   // Check value state
   if (fragment_ref.IsOffloaded() || fragment_ref.HasStashPending())
     return nullopt;
+
+  if (stash_ctx.key_expire_ms > 0 && config_.min_ttl_to_offload_ms > 0) {
+    if (stash_ctx.key_expire_ms <= GetCurrentTimeMs() + config_.min_ttl_to_offload_ms)
+      return nullopt;
+  }
 
   // For now, hash offloading is conditional
   if (fragment_ref.ObjType() == OBJ_HASH && !config_.experimental_hash_offload)
@@ -838,9 +849,11 @@ TieredCoolRecord* TieredStorage::PopCool() {
   return &res;
 }
 
-void StashPrimeValue(DbIndex dbid, std::string_view key, PrimeValue* pv, TieredStorage* ts,
-                     BackPressureFuture* backpressure) {
-  if (auto blobs = ts->ShouldStash(*pv); blobs) {
+void StashPrimeValue(DbIndex dbid, std::string_view key, PrimeKey* pk, PrimeValue* pv,
+                     TieredStorage* ts, BackPressureFuture* backpressure) {
+  if (auto blobs =
+          ts->ShouldStash(*pv, TieredStorage::StashContext{.key_expire_ms = pk->GetExpireTime()});
+      blobs) {
     pv->SetStashPending(true);
     ts->StashPrimeValue(dbid, key, *blobs, backpressure);
   }
@@ -848,7 +861,7 @@ void StashPrimeValue(DbIndex dbid, std::string_view key, PrimeValue* pv, TieredS
 
 bool StashListNode(DbIndex dbid, QList* ql, QList::Node* node, TieredStorage* ts,
                    BackPressureFuture* backpressure) {
-  if (auto blobs = ts->ShouldStash(*node); blobs) {
+  if (auto blobs = ts->ShouldStash(*node, {}); blobs) {
     // Increment before stashing; decremented on failure in `ClearStashPending`
     ql->AdjustOffloadNodeCount(1);
     node->io_pending = 1;

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -852,10 +852,10 @@ TieredCoolRecord* TieredStorage::PopCool() {
   return &res;
 }
 
-void StashPrimeValue(DbIndex dbid, std::string_view key, PrimeKey* pk, PrimeValue* pv,
+void StashPrimeValue(DbIndex dbid, std::string_view key, const PrimeKey& pk, PrimeValue* pv,
                      TieredStorage* ts, BackPressureFuture* backpressure) {
   if (auto blobs =
-          ts->ShouldStash(*pv, TieredStorage::StashContext{.key_expire_ms = pk->GetExpireTime()});
+          ts->ShouldStash(*pv, TieredStorage::StashContext{.key_expire_ms = pk.GetExpireTime()});
       blobs) {
     pv->SetStashPending(true);
     ts->StashPrimeValue(dbid, key, *blobs, backpressure);

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -767,9 +767,12 @@ auto TieredStorage::ShouldStash(const tiering::FragmentRef& fragment_ref,
   if (fragment_ref.IsOffloaded() || fragment_ref.HasStashPending())
     return nullopt;
 
-  if (stash_ctx.key_expire_ms > 0 && config_.min_ttl_to_offload_ms > 0) {
-    if (stash_ctx.key_expire_ms <= GetCurrentTimeMs() + config_.min_ttl_to_offload_ms)
+  const bool should_offload = ShouldOffload();
+
+  if (!should_offload && stash_ctx.key_expire_ms > 0 && config_.min_ttl_to_offload_ms > 0) {
+    if (stash_ctx.key_expire_ms <= GetCurrentTimeMs() + config_.min_ttl_to_offload_ms) {
       return nullopt;
+    }
   }
 
   // For now, hash offloading is conditional
@@ -795,7 +798,7 @@ auto TieredStorage::ShouldStash(const tiering::FragmentRef& fragment_ref,
   if (disk_stats.pending_stash_bytes >= 2 * config_.max_pending_stash_bytes) {
     ++stats_.stash_overflow_cnt;
     // Discard the write if we don't require offloading to not oversaturate the disk
-    if (!ShouldOffload())
+    if (!should_offload)
       return std::nullopt;
   }
 

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -212,7 +212,7 @@ TieredStorage::TResult<T> ModifyTiered(DbIndex dbid, std::string_view key, const
 
 // Stash prime value if it meets criteria. If the value was stashed and `backpressure` is not
 // nullptr, assign/set the backpressure future to `*backpressure`.
-void StashPrimeValue(DbIndex dbid, std::string_view key, PrimeKey* pk, PrimeValue* pv,
+void StashPrimeValue(DbIndex dbid, std::string_view key, const PrimeKey& pk, PrimeValue* pv,
                      TieredStorage* ts, BackPressureFuture* backpressure);
 
 // Stash list node if it meets criteria.
@@ -345,7 +345,7 @@ TieredStorage::TResult<T> ModifyTiered(DbIndex dbid, std::string_view key, const
   return {};
 }
 
-inline void StashPrimeValue(DbIndex dbid, std::string_view key, PrimeKey* pk, PrimeValue* pv,
+inline void StashPrimeValue(DbIndex dbid, std::string_view key, const PrimeKey& pk, PrimeValue* pv,
                             TieredStorage* ts, BackPressureFuture* backpressure) {
 }
 

--- a/src/server/tiered_storage.h
+++ b/src/server/tiered_storage.h
@@ -41,6 +41,10 @@ struct TieredStorageBase {
     size_t Serialize(io::MutableBytes buffer) const;
   };
 
+  struct StashContext {
+    uint64_t key_expire_ms = 0;  // 0 means no expiry
+  };
+
   template <typename T> using TResult = util::fb2::Future<io::Result<T>>;
 };
 
@@ -75,7 +79,8 @@ class TieredStorage : public TieredStorageBase {
   }
 
   // Returns StashDescriptor if a value should be stashed.
-  std::optional<StashDescriptor> ShouldStash(const tiering::FragmentRef& fragment_ref) const;
+  std::optional<StashDescriptor> ShouldStash(const tiering::FragmentRef& fragment_ref,
+                                             const StashContext& stash_ctx) const;
 
   // Stash value identified by (dbid, key), returns optional future for backpressure is not null.
   // if `provide_bp` is set and conditions are met.
@@ -157,6 +162,7 @@ class TieredStorage : public TieredStorageBase {
     float upload_threshold;
     bool experimental_hash_offload;
     bool experimental_list_offload;
+    uint32_t min_ttl_to_offload_ms;
   } config_;
 
   mutable struct {
@@ -206,8 +212,8 @@ TieredStorage::TResult<T> ModifyTiered(DbIndex dbid, std::string_view key, const
 
 // Stash prime value if it meets criteria. If the value was stashed and `backpressure` is not
 // nullptr, assign/set the backpressure future to `*backpressure`.
-void StashPrimeValue(DbIndex dbid, std::string_view key, PrimeValue* pv, TieredStorage* ts,
-                     BackPressureFuture* backpressure);
+void StashPrimeValue(DbIndex dbid, std::string_view key, PrimeKey* pk, PrimeValue* pv,
+                     TieredStorage* ts, BackPressureFuture* backpressure);
 
 // Stash list node if it meets criteria.
 // Returns true if stash was initiated, false otherwise.
@@ -249,7 +255,8 @@ class TieredStorage : public TieredStorageBase {
     return {};
   }
 
-  std::optional<StashDescriptor> ShouldStash(const tiering::FragmentRef& fragment) const {
+  std::optional<StashDescriptor> ShouldStash(const tiering::FragmentRef& fragment,
+                                             const StashContext& stash_ctx) const {
     return {};
   }
 
@@ -338,8 +345,8 @@ TieredStorage::TResult<T> ModifyTiered(DbIndex dbid, std::string_view key, const
   return {};
 }
 
-inline void StashPrimeValue(DbIndex dbid, std::string_view key, PrimeValue* pv, TieredStorage* ts,
-                            BackPressureFuture* backpressure) {
+inline void StashPrimeValue(DbIndex dbid, std::string_view key, PrimeKey* pk, PrimeValue* pv,
+                            TieredStorage* ts, BackPressureFuture* backpressure) {
 }
 
 inline bool StashListNode(DbIndex dbid, QList* ql, QList::Node* node, TieredStorage* ts,

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -541,9 +541,10 @@ TEST_F(TieredStorageTest, Expiry) {
   EXPECT_EQ(resp, val);
 }
 
-TEST_F(TieredStorageTest, DontStashShortTTL) {
+TEST_F(TieredStorageTest, ShortTtlOffloadUnderMemoryPressure) {
   absl::FlagSaver saver;
-  SetFlag(&FLAGS_tiered_offload_threshold, 1.0f);
+  // Without memory pressure, short-lived keys are not worth offloading.
+  SetFlag(&FLAGS_tiered_offload_threshold, 0.1f);
   UpdateFromFlags();
 
   const string value = BuildString(3000);
@@ -552,16 +553,30 @@ TEST_F(TieredStorageTest, DontStashShortTTL) {
   Run({"SET", "k2", value, "EX", "2"});
   Run({"SET", "k3", value});
 
-  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 2; });
-  EXPECT_EQ(GetMetrics().tiered_stats.total_stashes, 2);
-  EXPECT_EQ(GetMetrics().db_stats[0].tiered_entries, 2);
+  auto IsOffloaded = [&](string_view key) {
+    bool result = false;
+    pp_->at(0)->AwaitBrief([&] {
+      EngineShard* shard = EngineShard::tlocal();
+      if (!shard)
+        return;
+      auto& db = namespaces->GetDefaultNamespace().GetDbSlice(shard->shard_id());
+      auto it = db.GetDBTable(0)->prime.Find(key);
+      result = IsValid(it) && it->second.IsExternal();
+    });
+    return result;
+  };
 
-  AdvanceTime(1000);
-  Run({"EXPIRE", "k2", "100"});
+  // k1 has enough TTL and k3 has none, while k2 expires too soon.
+  ExpectConditionWithinTimeout([&] { return IsOffloaded("k1") && IsOffloaded("k3"); });
+  EXPECT_FALSE(IsOffloaded("k2"));
 
-  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 3; });
+  // Simulate low memory so offloading protects the system despite short TTL.
+  SetFlag(&FLAGS_tiered_offload_threshold, 1.0f);
+  UpdateFromFlags();
 
-  EXPECT_EQ(GetMetrics().db_stats[0].tiered_entries, 3);
+  // k4 has the same short TTL as k2, but low memory should still offload it.
+  Run({"SET", "k4", value, "EX", "2"});
+  ExpectConditionWithinTimeout([&] { return IsOffloaded("k4"); });
 }
 
 TEST_F(PureDiskTSTest, SetExistingExpire) {

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -541,6 +541,29 @@ TEST_F(TieredStorageTest, Expiry) {
   EXPECT_EQ(resp, val);
 }
 
+TEST_F(TieredStorageTest, DontStashShortTTL) {
+  absl::FlagSaver saver;
+  SetFlag(&FLAGS_tiered_offload_threshold, 1.0f);
+  UpdateFromFlags();
+
+  const string value = BuildString(3000);
+
+  Run({"SET", "k1", value, "EX", "60"});
+  Run({"SET", "k2", value, "EX", "2"});
+  Run({"SET", "k3", value});
+
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 2; });
+  EXPECT_EQ(GetMetrics().tiered_stats.total_stashes, 2);
+  EXPECT_EQ(GetMetrics().db_stats[0].tiered_entries, 2);
+
+  AdvanceTime(1000);
+  Run({"EXPIRE", "k2", "100"});
+
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 3; });
+
+  EXPECT_EQ(GetMetrics().db_stats[0].tiered_entries, 3);
+}
+
 TEST_F(PureDiskTSTest, SetExistingExpire) {
   const int kNum = 20;
   for (size_t i = 0; i < kNum; i++) {


### PR DESCRIPTION
Avoid wasting disk I/O by offloading keys that are about to expire soon. Introduces
a new flag `tiered_min_ttl_to_offload_ms` (default 5000ms) that sets the minimum
remaining TTL a key must have to be eligible for tiered storage offloading.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
