### PR TITLE
Track dispatch_waiting_count_ and rename ok_backend metrics

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1782,6 +1782,8 @@ void Connection::SquashPipeline() {
     ReleasePipelinedCommand(current);
     AdvanceParsedHead(next);
   }
+  DCHECK_GE(dispatch_waiting_count_, squashed);
+  dispatch_waiting_count_ -= squashed;  // the squashed run was waiting; it is now fully handled
   parsed_to_execute_ = parsed_head_;
 
   local_stats_.cmds += squashed;
@@ -1840,6 +1842,7 @@ void Connection::ClearPipelinedMessages() {
   DCHECK_EQ(parsed_cmd_q_bytes_, 0u);
   parsed_tail_ = nullptr;
   parsed_to_execute_ = nullptr;
+  dispatch_waiting_count_ = 0;
 
   QueueBackpressure& qbp = GetQueueBackpressure();
   qbp.NotifyPipelineWaiters();
@@ -1914,8 +1917,7 @@ bool Connection::ProcessAdminMessage(MessageHandle* msg, AsyncOperations* async_
 void Connection::ProcessPipelineCommandV1() {
   DCHECK(parsed_head_ && parsed_to_execute_) << DebugInfo();
   auto* cmd = parsed_to_execute_;
-  parsed_to_execute_ = cmd->next;
-  AdvanceParsedHead(parsed_to_execute_);
+  AdvanceParsedHead(AdvanceToExecute());
 
   tl_facade_stats->conn_stats.pipelined_wait_latency +=
       CycleClock::ToUsec(CycleClock::Now() - cmd->parsed_cycle);
@@ -2586,29 +2588,39 @@ bool Connection::ExecuteBatch() {
 
   bool is_true_pipeline = (parsed_to_execute_->next) != nullptr;
 
-  auto advance_head = [&] {
-    auto* cmd = parsed_head_;
-    AdvanceParsedHead(parsed_head_->next);
-    if (is_true_pipeline)  // pipeline mode as we have
+  // Retires the head command once its reply has been handled: removes it from the queue and
+  // releases it. Only reached when the head is also the command we just processed
+  // (parsed_head_ == parsed_to_execute_), so both pointers advance together to head->next.
+  auto retire_head = [&] {
+    DCHECK_EQ(parsed_head_, parsed_to_execute_);
+    ParsedCommand* cmd = parsed_head_;
+    // Advance both pointers to cmd->next in lockstep: AdvanceToExecute() moves parsed_to_execute_
+    // (keeping dispatch_waiting_count_ in sync) and returns the new value for parsed_head_.
+    AdvanceParsedHead(AdvanceToExecute());
+    DCHECK_EQ(parsed_head_, parsed_to_execute_);
+    if (is_true_pipeline)
       ReleasePipelinedCommand(cmd);
     else
       ReleaseParsedCommand(cmd);
-    return parsed_head_;
   };
 
-  // Execute sequentially all parsed commands.
-  for (auto& cmd = parsed_to_execute_; cmd != nullptr;) {
+  // Execute sequentially all parsed commands. parsed_to_execute_ points to the next command to
+  // dispatch; it advances as commands are dispatched, and parsed_head_ advances with it whenever a
+  // command retires (executes synchronously or replies immediately).
+  while (parsed_to_execute_ != nullptr) {
     if (reply_builder_->GetError())
       return false;
+
+    ParsedCommand* cmd = parsed_to_execute_;
     bool is_head = cmd == parsed_head_;
 
     // parser errors are stored as deferred replies
     if (cmd->IsDeferredReply() && cmd->CanReply()) {
       if (is_head) {
         cmd->SendReply();
-        cmd = advance_head();
+        retire_head();
       } else {
-        cmd = cmd->next;
+        AdvanceToExecute();
       }
       continue;
     }
@@ -2624,6 +2636,7 @@ bool Connection::ExecuteBatch() {
     // sendmsg syscalls to a minimum. IoLoopV2's idle-await block handles the final flush.
     reply_builder_->SetBatchMode(ioloop_v2_ && is_head && (cmd->next != nullptr));
 
+    uint64_t dispatch_start = CycleClock::Now();
     auto dispatch_res = service_->DispatchCommandSimple(cmd, mode);
 
     // Enforce the pipeline reply-ordering invariant: replies must reach the socket in parse order.
@@ -2643,19 +2656,20 @@ bool Connection::ExecuteBatch() {
     if (dispatch_res == DispatchResult::WOULD_BLOCK)
       break;  // Sync command. Wait for current async commands to finish
 
+    conn_stats.pipelined_wait_latency += CycleClock::ToUsec(dispatch_start - cmd->parsed_cycle);
     conn_stats.pipeline_dispatch_commands++;
     if (is_head)
       conn_stats.pipeline_dispatch_calls++;
 
     if (cmd->IsDeferredReply()) {
-      cmd = cmd->next;
+      AdvanceToExecute();
     } else {
-      DCHECK(is_head);       // only head can execute sync
-      cmd = advance_head();  // advance it
+      DCHECK(is_head);  // only head can execute sync
+      retire_head();
     }
   }
 
-  // Since we are done executing a batch, and advance_head might be called which release commands,
+  // Since we are done executing a batch, and retire_head might be called which releases commands,
   // notify waiters that backpressure might be relieved.
   if (ioloop_v2_) {
     io_event_.notify();
@@ -2730,6 +2744,7 @@ void Connection::EnqueueParsedCommand(ParsedCommand* cmd) {
 
   size_t used_mem = cmd->EnqueuedBytes();
   parsed_cmd_q_len_++;
+  dispatch_waiting_count_++;  // the newly appended tail command is not yet dispatched
   parsed_cmd_q_bytes_ += used_mem;
   local_stats_.dispatch_entries_added++;
   conn_stats.pipeline_queue_entries++;
@@ -2802,6 +2817,8 @@ void Connection::DestroyParsedQueue() {
   }
 
   parsed_tail_ = nullptr;
+  parsed_to_execute_ = nullptr;
+  dispatch_waiting_count_ = 0;
   CHECK_EQ(parsed_cmd_q_len_, 0u);
   CHECK_EQ(parsed_cmd_q_bytes_, 0u);
   delete parsed_cmd_;
@@ -3196,7 +3213,7 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
       return std::exchange(io_ec_, {});
     }
 
-    if ((parse_status != OK) && (parse_status != NEED_MORE)) {
+    if (parse_status == ERROR) {
       break;
     }
 

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -2825,6 +2825,15 @@ void Connection::DestroyParsedQueue() {
   parsed_cmd_ = nullptr;
 }
 
+ParsedCommand* Connection::AdvanceToExecute() {
+  DCHECK(parsed_to_execute_ != nullptr);
+  DCHECK_GT(dispatch_waiting_count_, 0u);
+
+  --dispatch_waiting_count_;
+  parsed_to_execute_ = parsed_to_execute_->next;
+  return parsed_to_execute_;
+}
+
 void Connection::UpdateFromFlags() {
   unsigned tid = fb2::ProactorBase::me()->GetPoolIndex();
   thread_queue_backpressure[tid].pipeline_queue_max_len = GetFlag(FLAGS_pipeline_queue_limit);

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -521,6 +521,14 @@ class Connection : public util::Connection {
     }
   }
 
+  // Advance parsed_to_execute_ past the command it currently points at (now dispatched), keeping
+  // dispatch_waiting_count_ in sync. Returns the new parsed_to_execute_.
+  ParsedCommand* AdvanceToExecute() {
+    --dispatch_waiting_count_;
+    parsed_to_execute_ = parsed_to_execute_->next;
+    return parsed_to_execute_;
+  }
+
   // Dispatch Queue - Queue for the Control Path.
   // Handles asynchronous administrative tasks, events, and high-priority control
   // messages (e.g., PubSub, Monitor, Migration requests, Checkpoints) processed
@@ -568,6 +576,12 @@ class Connection : public util::Connection {
 
   // Total number of commands in parsed command queue
   size_t parsed_cmd_q_len_ = 0;
+
+  // Number of parsed commands not yet dispatched: the run [parsed_to_execute_, ..., parsed_tail_].
+  // Maintained incrementally (incremented on enqueue, decremented as parsed_to_execute_ advances)
+  // so the V2 squasher can pass an exact count starting at parsed_to_execute_ even when earlier
+  // commands are still in flight. Always <= parsed_cmd_q_len_.
+  size_t dispatch_waiting_count_ = 0;
 
   // Total bytes used by commands in parsed command queue
   size_t parsed_cmd_q_bytes_ = 0;

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -523,11 +523,7 @@ class Connection : public util::Connection {
 
   // Advance parsed_to_execute_ past the command it currently points at (now dispatched), keeping
   // dispatch_waiting_count_ in sync. Returns the new parsed_to_execute_.
-  ParsedCommand* AdvanceToExecute() {
-    --dispatch_waiting_count_;
-    parsed_to_execute_ = parsed_to_execute_->next;
-    return parsed_to_execute_;
-  }
+  ParsedCommand* AdvanceToExecute();
 
   // Dispatch Queue - Queue for the Control Path.
   // Handles asynchronous administrative tasks, events, and high-priority control

--- a/src/facade/ok_main.cc
+++ b/src/facade/ok_main.cc
@@ -425,92 +425,96 @@ void HandleMetrics(ProactorPool* pool, const util::http::QueryArgs&, util::HttpC
 #define APPEND_BODY(...) absl::StrAppend(&body, __VA_ARGS__)
 
   // Connection metrics
-  APPEND_BODY("# HELP connections_received_total Total connections received\n");
-  APPEND_BODY("# TYPE connections_received_total counter\n");
-  APPEND_BODY("connections_received_total ", conn.conn_received_cnt, "\n");
+  APPEND_BODY("# HELP dragonfly_connections_received_total Total connections received\n");
+  APPEND_BODY("# TYPE dragonfly_connections_received_total counter\n");
+  APPEND_BODY("dragonfly_connections_received_total ", conn.conn_received_cnt, "\n");
 
-  APPEND_BODY("# HELP connected_clients Number of connected clients\n");
-  APPEND_BODY("# TYPE connected_clients gauge\n");
-  APPEND_BODY("connected_clients ", conn.num_conns_main, "\n");
+  APPEND_BODY("# HELP dragonfly_connected_clients Number of connected clients\n");
+  APPEND_BODY("# TYPE dragonfly_connected_clients gauge\n");
+  APPEND_BODY("dragonfly_connected_clients ", conn.num_conns_main, "\n");
 
-  APPEND_BODY("# HELP blocked_clients Number of blocked clients\n");
-  APPEND_BODY("# TYPE blocked_clients gauge\n");
-  APPEND_BODY("blocked_clients ", conn.num_blocked_clients, "\n");
+  APPEND_BODY("# HELP dragonfly_blocked_clients Number of blocked clients\n");
+  APPEND_BODY("# TYPE dragonfly_blocked_clients gauge\n");
+  APPEND_BODY("dragonfly_blocked_clients ", conn.num_blocked_clients, "\n");
 
-  APPEND_BODY("# HELP num_migrations Connection migrations between threads\n");
-  APPEND_BODY("# TYPE num_migrations counter\n");
-  APPEND_BODY("num_migrations ", conn.num_migrations, "\n");
+  APPEND_BODY("# HELP dragonfly_num_migrations Connection migrations between threads\n");
+  APPEND_BODY("# TYPE dragonfly_num_migrations counter\n");
+  APPEND_BODY("dragonfly_num_migrations ", conn.num_migrations, "\n");
 
   // Command metrics
-  APPEND_BODY("# HELP commands_processed_total Total commands processed\n");
-  APPEND_BODY("# TYPE commands_processed_total counter\n");
-  APPEND_BODY("commands_processed_total ", conn.command_cnt_main, "\n");
+  APPEND_BODY("# HELP dragonfly_commands_processed_total Total commands processed\n");
+  APPEND_BODY("# TYPE dragonfly_commands_processed_total counter\n");
+  APPEND_BODY("dragonfly_commands_processed_total ", conn.command_cnt_main, "\n");
 
   // Pipeline metrics
-  APPEND_BODY("# HELP pipelined_commands_total Total pipelined commands\n");
-  APPEND_BODY("# TYPE pipelined_commands_total counter\n");
-  APPEND_BODY("pipelined_commands_total ", conn.pipelined_cmd_cnt, "\n");
+  APPEND_BODY("# HELP dragonfly_pipelined_commands_total Total pipelined commands\n");
+  APPEND_BODY("# TYPE dragonfly_pipelined_commands_total counter\n");
+  APPEND_BODY("dragonfly_pipelined_commands_total ", conn.pipelined_cmd_cnt, "\n");
 
-  APPEND_BODY("# HELP pipelined_commands_duration_seconds Total pipelined cmd latency\n");
-  APPEND_BODY("# TYPE pipelined_commands_duration_seconds counter\n");
-  APPEND_BODY("pipelined_commands_duration_seconds ", conn.pipelined_cmd_latency * 1e-6, "\n");
+  APPEND_BODY("# HELP dragonfly_pipelined_commands_duration_seconds Total pipelined cmd latency\n");
+  APPEND_BODY("# TYPE dragonfly_pipelined_commands_duration_seconds counter\n");
+  APPEND_BODY("dragonfly_pipelined_commands_duration_seconds ", conn.pipelined_cmd_latency * 1e-6,
+              "\n");
 
-  APPEND_BODY("# HELP pipelined_wait_duration_seconds Pipeline queue wait latency\n");
-  APPEND_BODY("# TYPE pipelined_wait_duration_seconds counter\n");
-  APPEND_BODY("pipelined_wait_duration_seconds ", conn.pipelined_wait_latency * 1e-6, "\n");
+  APPEND_BODY("# HELP dragonfly_pipelined_wait_duration_seconds Pipeline queue wait latency\n");
+  APPEND_BODY("# TYPE dragonfly_pipelined_wait_duration_seconds counter\n");
+  APPEND_BODY("dragonfly_pipelined_wait_duration_seconds ", conn.pipelined_wait_latency * 1e-6,
+              "\n");
 
-  APPEND_BODY("# HELP pipeline_queue_length Pending commands in pipeline queue\n");
-  APPEND_BODY("# TYPE pipeline_queue_length gauge\n");
-  APPEND_BODY("pipeline_queue_length ", conn.pipeline_queue_entries, "\n");
+  APPEND_BODY("# HELP dragonfly_pipeline_queue_length Pending commands in pipeline queue\n");
+  APPEND_BODY("# TYPE dragonfly_pipeline_queue_length gauge\n");
+  APPEND_BODY("dragonfly_pipeline_queue_length ", conn.pipeline_queue_entries, "\n");
 
-  APPEND_BODY("# HELP pipeline_throttle_total Pipeline throttle events\n");
-  APPEND_BODY("# TYPE pipeline_throttle_total counter\n");
-  APPEND_BODY("pipeline_throttle_total ", conn.pipeline_throttle_count, "\n");
+  APPEND_BODY("# HELP dragonfly_pipeline_throttle_total Pipeline throttle events\n");
+  APPEND_BODY("# TYPE dragonfly_pipeline_throttle_total counter\n");
+  APPEND_BODY("dragonfly_pipeline_throttle_total ", conn.pipeline_throttle_count, "\n");
 
-  APPEND_BODY("# HELP pipeline_dispatch_calls_total Pipeline batch dispatch calls\n");
-  APPEND_BODY("# TYPE pipeline_dispatch_calls_total counter\n");
-  APPEND_BODY("pipeline_dispatch_calls_total ", conn.pipeline_dispatch_calls, "\n");
+  APPEND_BODY("# HELP dragonfly_pipeline_dispatch_calls_total Pipeline batch dispatch calls\n");
+  APPEND_BODY("# TYPE dragonfly_pipeline_dispatch_calls_total counter\n");
+  APPEND_BODY("dragonfly_pipeline_dispatch_calls_total ", conn.pipeline_dispatch_calls, "\n");
 
-  APPEND_BODY("# HELP pipeline_dispatch_commands_total Commands via pipeline dispatch\n");
-  APPEND_BODY("# TYPE pipeline_dispatch_commands_total counter\n");
-  APPEND_BODY("pipeline_dispatch_commands_total ", conn.pipeline_dispatch_commands, "\n");
+  APPEND_BODY("# HELP dragonfly_pipeline_dispatch_commands_total Commands via pipeline dispatch\n");
+  APPEND_BODY("# TYPE dragonfly_pipeline_dispatch_commands_total counter\n");
+  APPEND_BODY("dragonfly_pipeline_dispatch_commands_total ", conn.pipeline_dispatch_commands, "\n");
 
-  APPEND_BODY("# HELP pipeline_dispatch_flush_seconds Pipeline dispatch flush duration\n");
-  APPEND_BODY("# TYPE pipeline_dispatch_flush_seconds counter\n");
-  APPEND_BODY("pipeline_dispatch_flush_seconds ", conn.pipeline_dispatch_flush_usec * 1e-6, "\n");
+  APPEND_BODY(
+      "# HELP dragonfly_pipeline_dispatch_flush_seconds Pipeline dispatch flush duration\n");
+  APPEND_BODY("# TYPE dragonfly_pipeline_dispatch_flush_seconds counter\n");
+  APPEND_BODY("dragonfly_pipeline_dispatch_flush_seconds ",
+              conn.pipeline_dispatch_flush_usec * 1e-6, "\n");
 
-  APPEND_BODY("# TYPE pipeline_dispatch_flush_total counter\n");
-  APPEND_BODY("pipeline_dispatch_flush_total ", conn.pipeline_dispatch_flush_count, "\n");
+  APPEND_BODY("# TYPE dragonfly_pipeline_dispatch_flush_total counter\n");
+  APPEND_BODY("dragonfly_pipeline_dispatch_flush_total ", conn.pipeline_dispatch_flush_count, "\n");
 
   // Network I/O metrics
-  APPEND_BODY("# HELP net_input_bytes_total Total bytes read from network\n");
-  APPEND_BODY("# TYPE net_input_bytes_total counter\n");
-  APPEND_BODY("net_input_bytes_total ", conn.io_read_bytes, "\n");
+  APPEND_BODY("# HELP dragonfly_net_input_bytes_total Total bytes read from network\n");
+  APPEND_BODY("# TYPE dragonfly_net_input_bytes_total counter\n");
+  APPEND_BODY("dragonfly_net_input_bytes_total ", conn.io_read_bytes, "\n");
 
-  APPEND_BODY("# HELP net_output_bytes_total Total bytes written to network\n");
-  APPEND_BODY("# TYPE net_output_bytes_total counter\n");
-  APPEND_BODY("net_output_bytes_total ", reply.io_write_bytes, "\n");
+  APPEND_BODY("# HELP dragonfly_net_output_bytes_total Total bytes written to network\n");
+  APPEND_BODY("# TYPE dragonfly_net_output_bytes_total counter\n");
+  APPEND_BODY("dragonfly_net_output_bytes_total ", reply.io_write_bytes, "\n");
 
-  APPEND_BODY("# HELP net_input_recv_total Total read syscalls\n");
-  APPEND_BODY("# TYPE net_input_recv_total counter\n");
-  APPEND_BODY("net_input_recv_total ", conn.io_read_cnt, "\n");
+  APPEND_BODY("# HELP dragonfly_net_input_recv_total Total read syscalls\n");
+  APPEND_BODY("# TYPE dragonfly_net_input_recv_total counter\n");
+  APPEND_BODY("dragonfly_net_input_recv_total ", conn.io_read_cnt, "\n");
 
-  APPEND_BODY("# HELP net_output_send_total Total write syscalls\n");
-  APPEND_BODY("# TYPE net_output_send_total counter\n");
-  APPEND_BODY("net_output_send_total ", reply.io_write_cnt, "\n");
+  APPEND_BODY("# HELP dragonfly_net_output_send_total Total write syscalls\n");
+  APPEND_BODY("# TYPE dragonfly_net_output_send_total counter\n");
+  APPEND_BODY("dragonfly_net_output_send_total ", reply.io_write_cnt, "\n");
 
-  APPEND_BODY("# HELP net_read_yields_total Read yields due to busy limit\n");
-  APPEND_BODY("# TYPE net_read_yields_total counter\n");
-  APPEND_BODY("net_read_yields_total ", conn.num_read_yields, "\n");
+  APPEND_BODY("# HELP dragonfly_net_read_yields_total Read yields due to busy limit\n");
+  APPEND_BODY("# TYPE dragonfly_net_read_yields_total counter\n");
+  APPEND_BODY("dragonfly_net_read_yields_total ", conn.num_read_yields, "\n");
 
   // Reply metrics
-  APPEND_BODY("# HELP reply_total Total reply send calls\n");
-  APPEND_BODY("# TYPE reply_total counter\n");
-  APPEND_BODY("reply_total ", reply.send_stats.count, "\n");
+  APPEND_BODY("# HELP dragonfly_reply_total Total reply send calls\n");
+  APPEND_BODY("# TYPE dragonfly_reply_total counter\n");
+  APPEND_BODY("dragonfly_reply_total ", reply.send_stats.count, "\n");
 
-  APPEND_BODY("# HELP reply_duration_seconds Total reply send duration\n");
-  APPEND_BODY("# TYPE reply_duration_seconds counter\n");
-  APPEND_BODY("reply_duration_seconds ",
+  APPEND_BODY("# HELP dragonfly_reply_duration_seconds Total reply send duration\n");
+  APPEND_BODY("# TYPE dragonfly_reply_duration_seconds counter\n");
+  APPEND_BODY("dragonfly_reply_duration_seconds ",
               base::CycleClock::ToUsec(reply.send_stats.total_duration) * 1e-6, "\n");
 
   util::http::StringResponse resp = util::http::MakeStringResponse(h2::status::ok);


### PR DESCRIPTION
## Summary
Groundwork for V2 pipeline dispatch, with no behavioral squashing change.

## Changes
- **Connection**: add `dispatch_waiting_count_` — the number of parsed-but-not-yet-dispatched commands in the run `[parsed_to_execute_, parsed_tail_]`, maintained incrementally (incremented on enqueue, decremented as `parsed_to_execute_` advances). Add the `AdvanceToExecute()` helper and route `parsed_to_execute_` advances through it.
- **Connection**: track `pipelined_wait_latency` (the parse→dispatch wait) per command on the V2 path.
- **ok_backend**: rename the exported Prometheus metrics with a `dragonfly_` prefix to be compatible with the local monitoring stack.

## Testing
`dragonfly` and `ok_backend` build clean; clang-format passes.