### PR TITLE
feat: Add ReplyScope to SquashPipeline

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1796,21 +1796,22 @@ void Connection::SquashPipeline() {
     return;
   }
 
-  // Send the deferred replies in linked-list order, then release the commands.
-  // Wrap all replies under a single ReplyScope so the reply builder can use vectorized IO
-  // (writev) with zero intermediate copies — string refs stay valid until we release commands.
+  // Send all replies under a ReplyScope before releasing the commands.
+  // This allows the reply builder to flush without copies
   {
     SinkReplyBuilder::ReplyScope scope(reply_builder_.get());
     auto* cmd = parsed_head_;
-    for (unsigned i = 0; i < squashed && cmd; ++i) {
+    for (unsigned i = 0; i < squashed && cmd; i++, cmd = cmd->next) {
       DCHECK(cmd->CanReply());
+      // TODO: Coroutine replies don't preserve lifetimes after running, so pause the scope
+      std::optional<SinkReplyBuilder::ScopePause> pause;
+      if (cmd->IsSuspendedReply())
+        pause.emplace(reply_builder_.get());
       cmd->SendReply();
       conn_stats.pipelined_wait_latency += CycleClock::ToUsec(start - cmd->parsed_cycle);
-      cmd = cmd->next;
     }
   }
 
-  // Release all commands after the scope has flushed — refs into payloads are no longer needed.
   for (unsigned i = 0; i < squashed && parsed_head_; ++i) {
     auto* current = parsed_head_;
     auto* next = current->next;

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -1796,17 +1796,23 @@ void Connection::SquashPipeline() {
     return;
   }
 
-  // Send the deferred replies in linked-list order, then release the commands. SendReply() may
-  // preempt, allowing the producer to append new commands, so re-read the next pointer after it
-  // and advance the list incrementally to keep it consistent at any preemption point.
+  // Send the deferred replies in linked-list order, then release the commands.
+  // Wrap all replies under a single ReplyScope so the reply builder can use vectorized IO
+  // (writev) with zero intermediate copies — string refs stay valid until we release commands.
+  {
+    SinkReplyBuilder::ReplyScope scope(reply_builder_.get());
+    auto* cmd = parsed_head_;
+    for (unsigned i = 0; i < squashed && cmd; ++i) {
+      DCHECK(cmd->CanReply());
+      cmd->SendReply();
+      conn_stats.pipelined_wait_latency += CycleClock::ToUsec(start - cmd->parsed_cycle);
+      cmd = cmd->next;
+    }
+  }
+
+  // Release all commands after the scope has flushed — refs into payloads are no longer needed.
   for (unsigned i = 0; i < squashed && parsed_head_; ++i) {
     auto* current = parsed_head_;
-
-    DCHECK(current->CanReply());
-    current->SendReply();
-
-    conn_stats.pipelined_wait_latency += CycleClock::ToUsec(start - current->parsed_cycle);
-
     auto* next = current->next;
     ReleasePipelinedCommand(current);
     AdvanceParsedHead(next);

--- a/src/facade/parsed_command.cc
+++ b/src/facade/parsed_command.cc
@@ -115,8 +115,8 @@ bool ParsedCommand::CanReply() const {
 }
 
 void ParsedCommand::SendReply() {
-  auto payload_handler = [this](payload::Payload& pl) {
-    CapturingReplyBuilder::Apply(std::move(pl), rb_);
+  auto payload_handler = [this](const payload::Payload& pl) {
+    CapturingReplyBuilder::Apply(pl, rb_);
   };
   auto task_handler = [](SuspendedCommand& task) {
     DCHECK(task.coro);

--- a/src/facade/parsed_command.h
+++ b/src/facade/parsed_command.h
@@ -154,6 +154,11 @@ class ParsedCommand : public cmn::BackedArguments {
     return std::get<SuspendedCommand>(reply_).blocker;
   }
 
+  // Whether this command will resume a coroutine on SendReply().
+  bool IsSuspendedReply() const {
+    return std::holds_alternative<SuspendedCommand>(reply_);
+  }
+
   // Requires CanReply(). Either sends stored reply or wakes up coroutine to send reply
   void SendReply();
 

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -15,6 +15,7 @@
 #include "absl/types/span.h"
 #include "base/cycle_clock.h"
 #include "base/logging.h"
+#include "common/borrowed_string.h"
 #include "facade/error.h"
 #include "util/fibers/proactor_base.h"
 
@@ -344,7 +345,7 @@ void RedisReplyBuilderBase::SendBulkString(std::string_view str) {
   WritePieces(kCRLF);
 }
 
-void RedisReplyBuilderBase::SendBulkStringBorrowed(cmn::BorrowedString bs) {
+void RedisReplyBuilderBase::SendBulkStringBorrowed(const cmn::BorrowedString& bs) {
   ReplyScope scope(this);
   tl_facade_stats->reply_stats.borrowed_string_sent_cnt++;
 
@@ -359,29 +360,10 @@ void RedisReplyBuilderBase::SendBulkStringBorrowed(cmn::BorrowedString bs) {
     WriteRef(bs.view());
   }
   WritePieces(kCRLF);
-
-  // Drain all iovecs (including any WriteRef into bs.view()) before this
-  // function returns. ~BorrowedString releases the pin afterward — by then
-  // the source bytes are already in the kernel.
-  Flush();
 }
 
-void RedisReplyBuilderBase::SendBulkStringBorrowedRef(const cmn::BorrowedString& bs) {
-  ReplyScope scope(this);
-  tl_facade_stats->reply_stats.borrowed_string_sent_cnt++;
-
-  auto* ops = cmn::BorrowedStringOps::Get();
-  size_t total = ops->DecodedSize(bs);
-
-  DVLOG(1) << "SendBulkBorrowedRef " << total << " enc=" << unsigned(bs.encoding());
-  WritePieces(kLengthPrefix, total, kCRLF);
-  if (bs.IsEncoded()) {
-    WriteDecodedAscii(bs);
-  } else {
-    WriteRef(bs.view());
-  }
-  WritePieces(kCRLF);
-  // No flush — caller guarantees bs outlives any enqueued refs.
+void RedisReplyBuilderBase::SendBulkStringBorrowed(cmn::BorrowedString&& bs) {
+  SendBulkStringBorrowed(static_cast<const cmn::BorrowedString&>(bs));
 }
 
 void RedisReplyBuilderBase::SendLong(long val) {

--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -366,6 +366,24 @@ void RedisReplyBuilderBase::SendBulkStringBorrowed(cmn::BorrowedString bs) {
   Flush();
 }
 
+void RedisReplyBuilderBase::SendBulkStringBorrowedRef(const cmn::BorrowedString& bs) {
+  ReplyScope scope(this);
+  tl_facade_stats->reply_stats.borrowed_string_sent_cnt++;
+
+  auto* ops = cmn::BorrowedStringOps::Get();
+  size_t total = ops->DecodedSize(bs);
+
+  DVLOG(1) << "SendBulkBorrowedRef " << total << " enc=" << unsigned(bs.encoding());
+  WritePieces(kLengthPrefix, total, kCRLF);
+  if (bs.IsEncoded()) {
+    WriteDecodedAscii(bs);
+  } else {
+    WriteRef(bs.view());
+  }
+  WritePieces(kCRLF);
+  // No flush — caller guarantees bs outlives any enqueued refs.
+}
+
 void RedisReplyBuilderBase::SendLong(long val) {
   ReplyScope scope(this);
   WritePieces(kLongPref, val, kCRLF);

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -207,6 +207,10 @@ class RedisReplyBuilderBase : public SinkReplyBuilder {
   // through replay.
   virtual void SendBulkStringBorrowed(cmn::BorrowedString bs);
 
+  // Like SendBulkStringBorrowed, but does not take ownership and does not flush.
+  // Caller must guarantee the BorrowedString outlives any enqueued refs (e.g. via ReplyScope).
+  void SendBulkStringBorrowedRef(const cmn::BorrowedString& bs);
+
   void SendLong(long val) override;
   virtual void SendDouble(double val);  // RESP: Number
 

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -218,7 +218,7 @@ class RedisReplyBuilderBase : public SinkReplyBuilder {
   void SendBulkStringBorrowed(const cmn::BorrowedString& bs);
 
   // The interface exposes only the rvalue function to allow squashing to "steal" the value,
-  // the real builder implmenetation forwards it to the constref version
+  // the real builder implementation forwards it to the constref version
   virtual void SendBulkStringBorrowed(cmn::BorrowedString&& bs);
 
   void SendLong(long val) override;

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -14,12 +14,19 @@
 #include "facade/facade_types.h"
 #include "io/io.h"
 
+namespace cmn {
+class BorrowedString;
+}  // namespace cmn
+
 namespace facade {
 
 enum class RespVersion { kResp2, kResp3 };
 
 // Base class for all reply builders. Offer a simple high level interface for controlling output
 // modes and sending basic response types.
+// By default, pointer validity for reference types (string_view, const BorrowedString&) is only
+// assumed for the Send...() function call. Use ReplyScope if the lifetime is longer to avoid copies
+// and enable zero-copy vectorized IO.
 class SinkReplyBuilder {
   struct GuardBase {
     bool prev;
@@ -57,6 +64,17 @@ class SinkReplyBuilder {
     }
 
     ~ReplyScope();
+  };
+
+  // Temporarily pauses an active ReplyScope. While paused, Send calls copy data as usual
+  // (no zero-copy refs). Restores the previous scoped_ state on destruction.
+  struct ScopePause : GuardBase {
+    explicit ScopePause(SinkReplyBuilder* rb) : GuardBase{std::exchange(rb->scoped_, false), rb} {
+    }
+
+    ~ScopePause() {
+      rb->scoped_ = prev;
+    }
   };
 
   // Aggregator reduces the number of raw send calls by copying data in an intermediate buffer.
@@ -197,19 +215,8 @@ class RedisReplyBuilderBase : public SinkReplyBuilder {
   void SendSimpleString(std::string_view str) override;
   virtual void SendBulkString(std::string_view str);  // RESP: Blob String
 
-  // Like SendBulkString, but takes ownership of a move-only cmn::BorrowedString
-  // whose bytes are borrowed from a stable in-memory source (e.g. a CompactObj
-  // LargeString under the read-only invariant). The default impl handles both
-  // raw (iovec ref) and packed (chunked decode into scratch) encodings and
-  // Flushes before returning, so ~BorrowedString releases the pin only after
-  // the source bytes are in the kernel. CapturingReplyBuilder overrides this
-  // to move `bs` into the captured payload, extending the pin's lifetime
-  // through replay.
-  virtual void SendBulkStringBorrowed(cmn::BorrowedString bs);
-
-  // Like SendBulkStringBorrowed, but does not take ownership and does not flush.
-  // Caller must guarantee the BorrowedString outlives any enqueued refs (e.g. via ReplyScope).
-  void SendBulkStringBorrowedRef(const cmn::BorrowedString& bs);
+  void SendBulkStringBorrowed(const cmn::BorrowedString& bs);
+  virtual void SendBulkStringBorrowed(cmn::BorrowedString&& bs);
 
   void SendLong(long val) override;
   virtual void SendDouble(double val);  // RESP: Number

--- a/src/facade/reply_builder.h
+++ b/src/facade/reply_builder.h
@@ -216,6 +216,9 @@ class RedisReplyBuilderBase : public SinkReplyBuilder {
   virtual void SendBulkString(std::string_view str);  // RESP: Blob String
 
   void SendBulkStringBorrowed(const cmn::BorrowedString& bs);
+
+  // The interface exposes only the rvalue function to allow squashing to "steal" the value,
+  // the real builder implmenetation forwards it to the constref version
   virtual void SendBulkStringBorrowed(cmn::BorrowedString&& bs);
 
   void SendLong(long val) override;

--- a/src/facade/reply_capture.cc
+++ b/src/facade/reply_capture.cc
@@ -160,6 +160,58 @@ struct CaptureVisitor {
   SinkReplyBuilder* rb;
 };
 
+// Const-ref visitor: replays a payload without consuming it. String views into the payload
+// remain valid after the visit, which is required for batched ReplyScope use.
+struct ConstCaptureVisitor {
+  void operator()(monostate) {
+  }
+
+  void operator()(long v) {
+    rb->SendLong(v);
+  }
+
+  void operator()(double v) {
+    static_cast<RedisReplyBuilder*>(rb)->SendDouble(v);
+  }
+
+  void operator()(const payload::SimpleString& ss) {
+    rb->SendSimpleString(ss);
+  }
+
+  void operator()(const payload::BulkString& bs) {
+    static_cast<RedisReplyBuilder*>(rb)->SendBulkString(bs);
+  }
+
+  void operator()(const cmn::BorrowedString& bs) {
+    static_cast<RedisReplyBuilderBase*>(rb)->SendBulkStringBorrowedRef(bs);
+  }
+
+  void operator()(payload::Null) {
+    static_cast<RedisReplyBuilder*>(rb)->SendNull();
+  }
+
+  void operator()(const payload::Error& err) {
+    rb->SendError(err->first, err->second);
+  }
+
+  void operator()(const unique_ptr<payload::CollectionPayload>& cp) {
+    auto* builder = static_cast<RedisReplyBuilder*>(rb);
+    if (!cp) {
+      builder->SendNullArray();
+      return;
+    }
+    if (cp->len == 0 && cp->type == CollectionType::ARRAY) {
+      builder->SendEmptyArray();
+      return;
+    }
+    builder->StartCollection(cp->len, cp->type);
+    for (const auto& pl : cp->arr)
+      visit(*this, pl);
+  }
+
+  SinkReplyBuilder* rb;
+};
+
 void CapturingReplyBuilder::Apply(Payload&& pl, SinkReplyBuilder* rb) {
   if (auto* crb = dynamic_cast<CapturingReplyBuilder*>(rb); crb != nullptr) {
     crb->SendDirect(std::move(pl));
@@ -168,6 +220,11 @@ void CapturingReplyBuilder::Apply(Payload&& pl, SinkReplyBuilder* rb) {
 
   CaptureVisitor cv{rb};
   visit(cv, std::move(pl));
+}
+
+void CapturingReplyBuilder::Apply(const Payload& pl, SinkReplyBuilder* rb) {
+  ConstCaptureVisitor cv{rb};
+  visit(cv, pl);
 }
 
 void CapturingReplyBuilder::SetReplyMode(ReplyMode mode) {

--- a/src/facade/reply_capture.cc
+++ b/src/facade/reply_capture.cc
@@ -56,7 +56,7 @@ void CapturingReplyBuilder::SendBulkString(std::string_view str) {
 
 // Capture the borrow into the payload, extending the pin's lifetime until
 // replay moves it into the real sink where it is parked across the writev.
-void CapturingReplyBuilder::SendBulkStringBorrowed(cmn::BorrowedString bs) {
+void CapturingReplyBuilder::SendBulkStringBorrowed(cmn::BorrowedString&& bs) {
   SKIP_LESS(ReplyMode::FULL);
   Capture(std::move(bs));
 }
@@ -130,8 +130,8 @@ struct CaptureVisitor {
     static_cast<RedisReplyBuilder*>(rb)->SendBulkString(bs);
   }
 
-  void operator()(cmn::BorrowedString bs) {
-    static_cast<RedisReplyBuilder*>(rb)->SendBulkStringBorrowed(std::move(bs));
+  void operator()(const cmn::BorrowedString& bs) {
+    static_cast<RedisReplyBuilder*>(rb)->SendBulkStringBorrowed(bs);
   }
 
   void operator()(payload::Null) {
@@ -160,70 +160,17 @@ struct CaptureVisitor {
   SinkReplyBuilder* rb;
 };
 
-// Const-ref visitor: replays a payload without consuming it. String views into the payload
-// remain valid after the visit, which is required for batched ReplyScope use.
-struct ConstCaptureVisitor {
-  void operator()(monostate) {
-  }
-
-  void operator()(long v) {
-    rb->SendLong(v);
-  }
-
-  void operator()(double v) {
-    static_cast<RedisReplyBuilder*>(rb)->SendDouble(v);
-  }
-
-  void operator()(const payload::SimpleString& ss) {
-    rb->SendSimpleString(ss);
-  }
-
-  void operator()(const payload::BulkString& bs) {
-    static_cast<RedisReplyBuilder*>(rb)->SendBulkString(bs);
-  }
-
-  void operator()(const cmn::BorrowedString& bs) {
-    static_cast<RedisReplyBuilderBase*>(rb)->SendBulkStringBorrowedRef(bs);
-  }
-
-  void operator()(payload::Null) {
-    static_cast<RedisReplyBuilder*>(rb)->SendNull();
-  }
-
-  void operator()(const payload::Error& err) {
-    rb->SendError(err->first, err->second);
-  }
-
-  void operator()(const unique_ptr<payload::CollectionPayload>& cp) {
-    auto* builder = static_cast<RedisReplyBuilder*>(rb);
-    if (!cp) {
-      builder->SendNullArray();
-      return;
-    }
-    if (cp->len == 0 && cp->type == CollectionType::ARRAY) {
-      builder->SendEmptyArray();
-      return;
-    }
-    builder->StartCollection(cp->len, cp->type);
-    for (const auto& pl : cp->arr)
-      visit(*this, pl);
-  }
-
-  SinkReplyBuilder* rb;
-};
-
 void CapturingReplyBuilder::Apply(Payload&& pl, SinkReplyBuilder* rb) {
   if (auto* crb = dynamic_cast<CapturingReplyBuilder*>(rb); crb != nullptr) {
     crb->SendDirect(std::move(pl));
     return;
   }
 
-  CaptureVisitor cv{rb};
-  visit(cv, std::move(pl));
+  Apply(static_cast<const Payload&>(pl), rb);
 }
 
 void CapturingReplyBuilder::Apply(const Payload& pl, SinkReplyBuilder* rb) {
-  ConstCaptureVisitor cv{rb};
+  CaptureVisitor cv{rb};
   visit(cv, pl);
 }
 

--- a/src/facade/reply_capture.h
+++ b/src/facade/reply_capture.h
@@ -31,7 +31,8 @@ class CapturingReplyBuilder : public RedisReplyBuilder {
   void SendDouble(double val) override;
   void SendSimpleString(std::string_view str) override;
   void SendBulkString(std::string_view str) override;
-  void SendBulkStringBorrowed(cmn::BorrowedString bs) override;
+
+  void SendBulkStringBorrowed(cmn::BorrowedString&& bs) override;
 
   void StartCollection(unsigned len, CollectionType type) override;
   void SendNullArray() override;

--- a/src/facade/reply_capture.h
+++ b/src/facade/reply_capture.h
@@ -56,6 +56,10 @@ class CapturingReplyBuilder : public RedisReplyBuilder {
   // Send payload to builder.
   static void Apply(Payload&& pl, SinkReplyBuilder* builder);
 
+  // Send payload to builder without consuming it. String refs into the payload remain valid,
+  // making this safe to use under a ReplyScope when the payload outlives the scope.
+  static void Apply(const Payload& pl, SinkReplyBuilder* builder);
+
   // If an error is stored inside payload, get a reference to it.
   static std::optional<ErrorRef> TryExtractError(const Payload& pl);
 

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -732,6 +732,37 @@ async def test_reply_count(df_server: DflyInstance):
     assert await measure(async_client.ft("i1").search("*")) <= 2
 
 
+@dfly_args({"proactor_threads": "1", "pipeline_squash": 1})
+async def test_squashed_reply_count(async_client: aioredis.Redis):
+    """Akin to test_reply_count but with pipelines"""
+
+    await async_client.ping()
+
+    # Create some keys to read
+    await async_client.set("long-str", "a" * 256)
+    await async_client.lpush("long-list", *(f"{i}" for i in range(100)))
+
+    pre = int((await async_client.info("stats"))["total_writes_processed"])
+    before = int((await async_client.info("stats"))["total_writes_processed"])
+    info_diff = before - pre
+
+    # Send a large pipeline of simple commands that will be squashed together.
+    p = async_client.pipeline(transaction=False)
+    for _ in range(10):
+        p.set("some-keys", "some-values")
+    for _ in range(50):
+        p.get("long-str")
+    for _ in range(50):
+        p.lrange("long-list", 0, -1)
+    await p.execute()
+
+    after = int((await async_client.info("stats"))["total_writes_processed"])
+    writes = after - before
+
+    # 90% of the commands don't cause writes. The replies should have been squashed
+    assert writes - info_diff < 11
+
+
 @dfly_args({"enable_resp_io_loop_v2": "true"})
 async def test_v2_conditional_flush_no_stall(df_server: DflyInstance):
     """Verify that V2 conditional flushing never stalls client replies.


### PR DESCRIPTION
Send replies from `SquashPipeline` under a ReplyScope to avoid copies and use the zero-copy vectorized IO features of the sink reply builder. Deallocate commands only after all replies were sent

Performance comparision against the main branch for GET benchmark. With 10+ connections and long pipelines (50) the difference in throughput becomes 15% and more

<img width="1800" height="750" alt="image" src="https://github.com/user-attachments/assets/3d9b426e-3ffe-4c6f-8d58-36c27106343f" />

<img width="1800" height="750" alt="image" src="https://github.com/user-attachments/assets/2d3a5dd9-e75f-41d3-8640-05a044f73791" />
