### PR TITLE
feat(facade): wire V2 dispatch loop into pipeline squashing

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -2686,8 +2686,6 @@ bool Connection::SquashPipelineV2() {
     AdvanceToExecute();
   }
 
-  reply_builder_->Flush();
-
   conn_stats.pipeline_dispatch_calls++;
   conn_stats.pipeline_dispatch_commands += squashed;
   return true;
@@ -3087,8 +3085,16 @@ void Connection::ReadPendingInput() {
 
     DVLOG(1) << "Read " << *res << " bytes from socket";
 
+    auto& conn_stats = tl_facade_stats->conn_stats;
+    size_t commit_sz = *res;
+    conn_stats.io_read_bytes += commit_sz;
+    local_stats_.net_bytes_in += commit_sz;
+
+    ++conn_stats.io_read_cnt;
+    ++local_stats_.read_cnt;
+
     last_interaction_ = time(nullptr);
-    io_buf_.CommitWrite(*res);
+    io_buf_.CommitWrite(commit_sz);
     buf = io_buf_.AppendBuffer();
   }
 }

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -130,6 +130,9 @@ ABSL_FLAG(bool, enable_memcache_io_loop_v2, true,
           "Enable the event-driven IoLoopV2 for non-TLS Memcache connections.");
 ABSL_FLAG(bool, enable_resp_io_loop_v2, false,
           "Enable the event-driven IoLoopV2 for non-TLS RESP connections.");
+ABSL_FLAG(bool, enable_pipeline_squashing_v2, true,
+          "Enable vectorized pipeline squashing for the V2 dispatch loop. Groups consecutive "
+          "single-shard pipeline commands by shard and executes them in parallel.");
 ABSL_RETIRED_FLAG(bool, experimental_io_loop_v2, true, "retired.");
 
 using namespace util;
@@ -986,6 +989,8 @@ void Connection::HandleRequests() {
           !is_tls_ &&
           ((protocol_ == Protocol::MEMCACHE && GetFlag(FLAGS_enable_memcache_io_loop_v2)) ||
            (protocol_ == Protocol::REDIS && GetFlag(FLAGS_enable_resp_io_loop_v2)));
+      pipeline_squashing_v2_ =
+          ioloop_v2_ && GetFlag(FLAGS_enable_pipeline_squashing_v2) && protocol_ == Protocol::REDIS;
 
       socket_->RegisterOnErrorCb([this](int32_t mask) { this->OnBreakCb(mask); });
       switch (protocol_) {
@@ -1520,7 +1525,9 @@ auto Connection::ParseLoop() -> ParserStatus {
       protocol_ == Protocol::MEMCACHE ? &Connection::ParseMCBatch : &Connection::ParseRedisBatch;
 
   ParserStatus parse_status = NEED_MORE;
+
   do {
+    DCHECK_GT(io_buf_.InputLen(), 0u);
     parse_status = (this->*parse_func)(io_buf_);
 
     // Execute/reply the commands parsed so far first, so a trailing protocol error still flushes
@@ -1652,6 +1659,8 @@ io::Result<size_t> Connection::HandleRecvSocket() {
   // In case the socket was closed orderly, we get 0 bytes read.
   if (recv_sz && *recv_sz) {
     size_t commit_sz = *recv_sz;
+    DVLOG(2) << "Received " << commit_sz << " bytes from socket";
+
     io_buf_.CommitWrite(commit_sz);
 
     conn_stats.io_read_bytes += commit_sz;
@@ -2656,6 +2665,33 @@ Connection::ParserStatus Connection::ParseMCBatch(base::IoBuf& io_buf) {
   return OK;
 }
 
+bool Connection::SquashPipelineV2() {
+  // vectorized squash phase: pack multiple commands and dispatch at once.
+  // dispatch_waiting_count_ is the exact length of the run starting at parsed_to_execute_, so the
+  // squash works even when earlier commands are still in flight.
+  auto& conn_stats = tl_facade_stats->conn_stats;
+
+  uint64_t dispatch_start = CycleClock::Now();
+  unsigned squashed =
+      service_->DispatchSquashedBatch(parsed_to_execute_, dispatch_waiting_count_, cc_.get());
+
+  // Like V1's SquashPipeline, sample once before the blocking squash and attribute it to every
+  // squashed command's parse->dispatch wait.
+  for (unsigned i = 0; i < squashed; i++) {
+    auto usec = CycleClock::ToUsec(dispatch_start - parsed_to_execute_->parsed_cycle);
+    conn_stats.pipelined_wait_latency += usec;
+    AdvanceToExecute();
+  }
+  if (squashed == 0)
+    return false;
+
+  reply_builder_->Flush();
+
+  conn_stats.pipeline_dispatch_calls++;
+  conn_stats.pipeline_dispatch_commands += squashed;
+  return true;
+}
+
 bool Connection::ExecuteBatch() {
   // Invariant: batched_ must be false on entry.
   // Both ReplyBatch() and ExecuteBatch() reset it via absl::Cleanup guards on all return paths.
@@ -2690,9 +2726,27 @@ bool Connection::ExecuteBatch() {
   // Execute sequentially all parsed commands. parsed_to_execute_ points to the next command to
   // dispatch; it advances as commands are dispatched, and parsed_head_ advances with it whenever a
   // command retires (executes synchronously or replies immediately).
+  DVLOG(2) << "ExecuteBatch: " << dispatch_waiting_count_ << " commands ";
+
   while (parsed_to_execute_ != nullptr) {
     if (reply_builder_->GetError())
       return false;
+
+    if (pipeline_squashing_v2_ && dispatch_waiting_count_ > 1) {
+      // if we squashed any commands, continue the loop to check if there are
+      // non-squashable commands commands to process.
+      DVLOG(2) << "Squashing pipeline " << dispatch_waiting_count_ << " commands " << pending_input_
+               << " " << io_buf_.InputLen();
+
+      if (SquashPipelineV2()) {
+        // This helps with throughput. Explanation:
+        // when we suspend the thread calls io-callbacks that fill up the input buffer.
+        // By breaking now we give the io-loop a chance to add more commands to the pipeline.
+        if (pending_input_ || io_buf_.InputLen() > 0)
+          break;
+        continue;
+      }
+    }
 
     ParsedCommand* cmd = parsed_to_execute_;
     bool is_head = cmd == parsed_head_;
@@ -3029,6 +3083,8 @@ void Connection::ReadPendingInput() {
       break;
     }
 
+    DVLOG(1) << "Read " << *res << " bytes from socket";
+
     last_interaction_ = time(nullptr);
     io_buf_.CommitWrite(*res);
     buf = io_buf_.AppendBuffer();
@@ -3215,6 +3271,8 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
       }
 
       io_event_.await([this] { return ShouldWakeIdle(); });
+      if (pending_input_)
+        continue;
     }
 
     phase_ = PROCESS;

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -2675,6 +2675,9 @@ bool Connection::SquashPipelineV2() {
   unsigned squashed =
       service_->DispatchSquashedBatch(parsed_to_execute_, dispatch_waiting_count_, cc_.get());
 
+  if (squashed == 0)
+    return false;
+
   // Like V1's SquashPipeline, sample once before the blocking squash and attribute it to every
   // squashed command's parse->dispatch wait.
   for (unsigned i = 0; i < squashed; i++) {
@@ -2682,8 +2685,6 @@ bool Connection::SquashPipelineV2() {
     conn_stats.pipelined_wait_latency += usec;
     AdvanceToExecute();
   }
-  if (squashed == 0)
-    return false;
 
   reply_builder_->Flush();
 
@@ -2734,7 +2735,7 @@ bool Connection::ExecuteBatch() {
 
     if (pipeline_squashing_v2_ && dispatch_waiting_count_ > 1) {
       // if we squashed any commands, continue the loop to check if there are
-      // non-squashable commands commands to process.
+      // non-squashable commands to process.
       DVLOG(2) << "Squashing pipeline " << dispatch_waiting_count_ << " commands " << pending_input_
                << " " << io_buf_.InputLen();
 
@@ -3061,6 +3062,7 @@ void Connection::NotifyOnRecv(const util::FiberSocketBase::RecvNotification& n) 
 void Connection::ReadPendingInput() {
   if (!pending_input_)
     return;
+
   // Drain available socket data into io_buf_.
   io::MutableBytes buf = io_buf_.AppendBuffer();
   // A recv call can return fewer bytes than requested even if the
@@ -3271,8 +3273,6 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
       }
 
       io_event_.await([this] { return ShouldWakeIdle(); });
-      if (pending_input_)
-        continue;
     }
 
     phase_ = PROCESS;

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -467,6 +467,11 @@ class Connection : public util::Connection {
   // Returns true on successful execution, false on reply builder error.
   bool ExecuteBatch();
 
+  // V2 vectorized squash phase: dispatch the run starting at parsed_to_execute_ through
+  // DispatchSquashedBatch when squashing is enabled. Returns true if a squashed batch was
+  // dispatched (and parsed_to_execute_ advanced).
+  bool SquashPipelineV2();
+
   // Loop over finished async commands and let them reply.
   // Returns true on successful execution, false on reply builder error.
   bool ReplyBatch();
@@ -672,7 +677,8 @@ class Connection : public util::Connection {
       // if the flag is set.
       bool is_tls_ : 1;
       bool is_main_ : 1;
-      bool ioloop_v2_ : 1;  // whether this connection is running on ioloop v2
+      bool ioloop_v2_ : 1;              // whether this connection is running on ioloop v2
+      bool pipeline_squashing_v2_ : 1;  // whether V2 pipeline squashing is enabled
 
       // If post migration is allowed to call RegisterRecv
       bool migration_allowed_to_register_ : 1;

--- a/src/facade/ok_main.cc
+++ b/src/facade/ok_main.cc
@@ -377,6 +377,7 @@ DispatchResult OkService::DispatchCommand([[maybe_unused]] ParsedArgs args, Pars
 uint32_t OkService::DispatchSquashedBatch(ParsedCommand* first, unsigned count,
                                           [[maybe_unused]] ConnectionContext* cntx) {
   const unsigned num_shards = pool_->size();
+  VLOG(1) << "DispatchSquashedBatch: " << count << " commands";
 
   // Grouping scratch, private to this call: the squasher can preempt in FiberQueue::Add() when a
   // shard queue is full, so a shared buffer could be corrupted by a re-entrant call on this thread.
@@ -465,60 +466,46 @@ void HandleMetrics(ProactorPool* pool, const util::http::QueryArgs&, util::HttpC
 #define APPEND_BODY(...) absl::StrAppend(&body, __VA_ARGS__)
 
   // Connection metrics
-  APPEND_BODY("# HELP dragonfly_connections_received_total Total connections received\n");
   APPEND_BODY("# TYPE dragonfly_connections_received_total counter\n");
   APPEND_BODY("dragonfly_connections_received_total ", conn.conn_received_cnt, "\n");
 
-  APPEND_BODY("# HELP dragonfly_connected_clients Number of connected clients\n");
   APPEND_BODY("# TYPE dragonfly_connected_clients gauge\n");
   APPEND_BODY("dragonfly_connected_clients ", conn.num_conns_main, "\n");
 
-  APPEND_BODY("# HELP dragonfly_blocked_clients Number of blocked clients\n");
   APPEND_BODY("# TYPE dragonfly_blocked_clients gauge\n");
   APPEND_BODY("dragonfly_blocked_clients ", conn.num_blocked_clients, "\n");
 
-  APPEND_BODY("# HELP dragonfly_num_migrations Connection migrations between threads\n");
   APPEND_BODY("# TYPE dragonfly_num_migrations counter\n");
   APPEND_BODY("dragonfly_num_migrations ", conn.num_migrations, "\n");
 
   // Command metrics
-  APPEND_BODY("# HELP dragonfly_commands_processed_total Total commands processed\n");
   APPEND_BODY("# TYPE dragonfly_commands_processed_total counter\n");
   APPEND_BODY("dragonfly_commands_processed_total ", conn.command_cnt_main, "\n");
 
   // Pipeline metrics
-  APPEND_BODY("# HELP dragonfly_pipelined_commands_total Total pipelined commands\n");
   APPEND_BODY("# TYPE dragonfly_pipelined_commands_total counter\n");
   APPEND_BODY("dragonfly_pipelined_commands_total ", conn.pipelined_cmd_cnt, "\n");
 
-  APPEND_BODY("# HELP dragonfly_pipelined_commands_duration_seconds Total pipelined cmd latency\n");
   APPEND_BODY("# TYPE dragonfly_pipelined_commands_duration_seconds counter\n");
   APPEND_BODY("dragonfly_pipelined_commands_duration_seconds ", conn.pipelined_cmd_latency * 1e-6,
               "\n");
 
-  APPEND_BODY("# HELP dragonfly_pipelined_wait_duration_seconds Pipeline queue wait latency\n");
   APPEND_BODY("# TYPE dragonfly_pipelined_wait_duration_seconds counter\n");
   APPEND_BODY("dragonfly_pipelined_wait_duration_seconds ", conn.pipelined_wait_latency * 1e-6,
               "\n");
 
-  APPEND_BODY("# HELP dragonfly_pipeline_queue_length Pending commands in pipeline queue\n");
   APPEND_BODY("# TYPE dragonfly_pipeline_queue_length gauge\n");
   APPEND_BODY("dragonfly_pipeline_queue_length ", conn.pipeline_queue_entries, "\n");
 
-  APPEND_BODY("# HELP dragonfly_pipeline_throttle_total Pipeline throttle events\n");
   APPEND_BODY("# TYPE dragonfly_pipeline_throttle_total counter\n");
   APPEND_BODY("dragonfly_pipeline_throttle_total ", conn.pipeline_throttle_count, "\n");
 
-  APPEND_BODY("# HELP dragonfly_pipeline_dispatch_calls_total Pipeline batch dispatch calls\n");
   APPEND_BODY("# TYPE dragonfly_pipeline_dispatch_calls_total counter\n");
   APPEND_BODY("dragonfly_pipeline_dispatch_calls_total ", conn.pipeline_dispatch_calls, "\n");
 
-  APPEND_BODY("# HELP dragonfly_pipeline_dispatch_commands_total Commands via pipeline dispatch\n");
   APPEND_BODY("# TYPE dragonfly_pipeline_dispatch_commands_total counter\n");
   APPEND_BODY("dragonfly_pipeline_dispatch_commands_total ", conn.pipeline_dispatch_commands, "\n");
 
-  APPEND_BODY(
-      "# HELP dragonfly_pipeline_dispatch_flush_seconds Pipeline dispatch flush duration\n");
   APPEND_BODY("# TYPE dragonfly_pipeline_dispatch_flush_seconds counter\n");
   APPEND_BODY("dragonfly_pipeline_dispatch_flush_seconds ",
               conn.pipeline_dispatch_flush_usec * 1e-6, "\n");
@@ -527,32 +514,25 @@ void HandleMetrics(ProactorPool* pool, const util::http::QueryArgs&, util::HttpC
   APPEND_BODY("dragonfly_pipeline_dispatch_flush_total ", conn.pipeline_dispatch_flush_count, "\n");
 
   // Network I/O metrics
-  APPEND_BODY("# HELP dragonfly_net_input_bytes_total Total bytes read from network\n");
   APPEND_BODY("# TYPE dragonfly_net_input_bytes_total counter\n");
   APPEND_BODY("dragonfly_net_input_bytes_total ", conn.io_read_bytes, "\n");
 
-  APPEND_BODY("# HELP dragonfly_net_output_bytes_total Total bytes written to network\n");
   APPEND_BODY("# TYPE dragonfly_net_output_bytes_total counter\n");
   APPEND_BODY("dragonfly_net_output_bytes_total ", reply.io_write_bytes, "\n");
 
-  APPEND_BODY("# HELP dragonfly_net_input_recv_total Total read syscalls\n");
   APPEND_BODY("# TYPE dragonfly_net_input_recv_total counter\n");
   APPEND_BODY("dragonfly_net_input_recv_total ", conn.io_read_cnt, "\n");
 
-  APPEND_BODY("# HELP dragonfly_net_output_send_total Total write syscalls\n");
   APPEND_BODY("# TYPE dragonfly_net_output_send_total counter\n");
   APPEND_BODY("dragonfly_net_output_send_total ", reply.io_write_cnt, "\n");
 
-  APPEND_BODY("# HELP dragonfly_net_read_yields_total Read yields due to busy limit\n");
   APPEND_BODY("# TYPE dragonfly_net_read_yields_total counter\n");
   APPEND_BODY("dragonfly_net_read_yields_total ", conn.num_read_yields, "\n");
 
   // Reply metrics
-  APPEND_BODY("# HELP dragonfly_reply_total Total reply send calls\n");
   APPEND_BODY("# TYPE dragonfly_reply_total counter\n");
   APPEND_BODY("dragonfly_reply_total ", reply.send_stats.count, "\n");
 
-  APPEND_BODY("# HELP dragonfly_reply_duration_seconds Total reply send duration\n");
   APPEND_BODY("# TYPE dragonfly_reply_duration_seconds counter\n");
   APPEND_BODY("dragonfly_reply_duration_seconds ",
               base::CycleClock::ToUsec(reply.send_stats.total_duration) * 1e-6, "\n");


### PR DESCRIPTION
## Summary
On top of the squasher groundwork: drive the V2 dispatch path through `DispatchSquashedBatch` behind `--enable_pipeline_squashing_v2`, using `dispatch_waiting_count_` as the exact run length. The squash phase is factored into `Connection::SquashPipelineV2()`.

Fixes #7526 when run with `--enable_pipeline_squashing_v2=true`.

## Changes
- Add `--enable_pipeline_squashing_v2` flag (default on) and the `pipeline_squashing_v2_` connection bit (set when running on ioloop v2 and the flag is enabled).
- Factor the V2 vectorized squash phase into `Connection::SquashPipelineV2()`: dispatch the run starting at `parsed_to_execute_` through `DispatchSquashedBatch` and advance `dispatch_waiting_count_` accordingly.
- Invoke it from `ExecuteBatch`'s loop when `dispatch_waiting_count_ > 1`, so squashable runs are batched while non-squashable commands fall through to sequential dispatch.

## Testing
- `ninja dragonfly` builds clean.
- clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
