### PR TITLE
feat(search): add SCORE option to FT.CREATE

### DIFF
--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -746,6 +746,8 @@ struct BasicSearch {
     scored.reserve(all_docs.size());
     vector<ScoringTermInfo> term_infos(cursors.size());
 
+    float default_score = indices_->GetSchema().score;
+
     for (DocId doc : all_docs) {
       for (size_t t = 0; t < cursors.size(); t++) {
         term_infos[t].term_docs = cursors[t].term_docs;
@@ -755,7 +757,8 @@ struct BasicSearch {
           term_infos[t].field_avg_doc_len = cursors[t].field_avg_doc_len;
         }
       }
-      scored.emplace_back(static_cast<float>(ScoreDocument(scorer_, ctx, term_infos)), doc);
+      scored.emplace_back(
+          static_cast<float>((ScoreDocument(scorer_, ctx, term_infos)) * default_score), doc);
     }
 
     // Top-K by score (skip sort when no actual cutoff, e.g. FT.AGGREGATE)

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -112,6 +112,8 @@ struct Schema {
   std::string default_language = "english";
   std::string language_field;  // doc field providing per-doc language; empty = none
 
+  float score = 1.0f;  // Default relevance score multiplier for the index
+
   // Return identifier for alias if found, otherwise return passed value
   std::string_view LookupAlias(std::string_view alias) const;
 

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -212,6 +212,8 @@ string DocIndexInfo::BuildRestoreCommand() const {
   if (!base_index.schema.language_field.empty())
     absl::StrAppend(&out, " LANGUAGE_FIELD ", base_index.schema.language_field);
 
+  absl::StrAppend(&out, " SCORE ", absl::StrFormat("%.9g", base_index.schema.score));
+
   absl::StrAppend(&out, " SCHEMA");
   for (const auto& [fident, finfo] : base_index.schema.fields) {
     // Store field name, alias and type

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -291,6 +291,14 @@ ParseResult<bool> ParseIndexLanguageField(CmdArgParser* parser, DocIndex* index)
   return true;
 }
 
+ParseResult<bool> ParseScore(CmdArgParser* parser, DocIndex* index) {
+  index->schema.score = parser->Next<float>();
+  if (!std::isfinite(index->schema.score)) {
+    return CreateSyntaxError(std::string_view("SCORE must be a finite number"));
+  }
+  return true;
+}
+
 // NOOFFSETS (index-level): disable storing token positions in TEXT posting lists.
 // Saves memory but breaks phrase queries.
 ParseResult<bool> ParseNoOffsets(CmdArgParser* /*parser*/, DocIndex* index) {
@@ -422,7 +430,7 @@ ParseResult<DocIndex> CreateDocIndex(std::string_view name, CmdArgParser* parser
     auto option_parser = parser->TryMapNext(
         "ON"sv, &ParseOnOption, "PREFIX"sv, &ParsePrefix, "STOPWORDS"sv, &ParseStopwords,
         "LANGUAGE"sv, &ParseIndexLanguage, "LANGUAGE_FIELD"sv, &ParseIndexLanguageField,
-        "NOOFFSETS"sv, &ParseNoOffsets, "SCHEMA"sv, &ParseSchema);
+        "NOOFFSETS"sv, &ParseNoOffsets, "SCHEMA"sv, &ParseSchema, "SCORE"sv, &ParseScore);
 
     if (!option_parser) {
       // Unsupported parameters are ignored for now
@@ -2628,7 +2636,13 @@ void CmdFtInfo(CmdArgList args, CommandContext* cmd_cntx) {
       rb->SendSimpleString(schema.language_field);
     }
     rb->SendSimpleString("default_score");
-    rb->SendLong(1);
+    float default_score = schema.score;
+    if (default_score >= LONG_MIN && default_score <= LONG_MAX &&
+        std::floor(default_score) == default_score) {
+      rb->SendLong(static_cast<long>(default_score));
+    } else {
+      rb->SendDouble(static_cast<double>(default_score));
+    }
   }
 
   rb->SendSimpleString("index_options");

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -382,6 +382,127 @@ TEST_F(SearchFamilyTest, CreateDropListIndex) {
   EXPECT_THAT(Run({"ft._list"}), RespElementsAre("idx-3"));
 }
 
+// Test SCORE parameter parsing: FT.INFO should return correct default_score
+TEST_F(SearchFamilyTest, CreateIndexWithDefaultScore) {
+  // Custom SCORE = 1.5
+
+  EXPECT_EQ(Run({"ft.create", "idx-default-score", "ON", "HASH", "PREFIX", "1", "s:", "SCORE",
+                 "1.5", "SCHEMA", "title", "TEXT"}),
+            "OK");
+
+  auto info = Run({"ft.info", "idx-default-score"});
+
+  auto descriptor_matcher = IsArray("key_type", "HASH", "prefixes", IsArray("s:"),
+                                    "default_language", "english", "default_score", DoubleArg(1.5));
+  auto schema_matcher =
+      IsArray(IsArray("identifier", "title", "attribute", "title", "type", "TEXT"));
+
+  EXPECT_THAT(info, IsArray(_, _, _, descriptor_matcher, "index_options", RespArray(IsEmpty()),
+                            "attributes", schema_matcher, "num_docs", IntArg(0), "indexing",
+                            IntArg(0), "percent_indexed", "1"));
+
+  // Default SCORE = 1 (when not specified)
+  EXPECT_EQ(Run({"ft.create", "idx-default", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "title",
+                 "TEXT"}),
+            "OK");
+
+  auto info2 = Run({"ft.info", "idx-default"});
+
+  auto descriptor_matcher2 = IsArray("key_type", "HASH", "prefixes", IsArray("d:"),
+                                     "default_language", "english", "default_score", IntArg(1));
+  EXPECT_THAT(info2, IsArray(_, _, _, descriptor_matcher2, "index_options", RespArray(IsEmpty()),
+                             "attributes", schema_matcher, "num_docs", IntArg(0), "indexing",
+                             IntArg(0), "percent_indexed", "1"));
+}
+
+// Test SCORE parameter affects scores: Final score = BM25 score × SCORE
+TEST_F(SearchFamilyTest, DefaultScoreMultipliesTextScore) {
+  EXPECT_EQ(
+      Run({"ft.create", "idx-test", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "title", "TEXT"}),
+      "OK");
+  WaitForIndexReady("idx-test");
+
+  Run({"hset", "d:1", "title", "hello world hello hello"});
+  Run({"hset", "d:2", "title", "hello there"});
+
+  auto resp_default = Run({"ft.search", "idx-test", "hello", "WITHSCORES"}).GetVec();
+  std::map<std::string, double> scores;
+  for (size_t i = 1; i + 1 < resp_default.size(); i += 3) {
+    scores[resp_default[i].GetString()] = std::stod(resp_default[i + 1].GetString());
+  }
+  ASSERT_EQ(scores.size(), 2u);
+
+  EXPECT_EQ(Run({"ft.dropindex", "idx-test"}), "OK");
+  EXPECT_EQ(Run({"ft.create", "idx-test", "ON", "HASH", "PREFIX", "1", "d:", "SCORE", "2.0",
+                 "SCHEMA", "title", "TEXT"}),
+            "OK");
+  WaitForIndexReady("idx-test");
+
+  Run({"hset", "d:1", "title", "hello world hello hello"});
+  Run({"hset", "d:2", "title", "hello there"});
+
+  auto resp_score2 = Run({"ft.search", "idx-test", "hello", "WITHSCORES"}).GetVec();
+  std::map<std::string, double> score2_scores;
+  for (size_t i = 1; i + 1 < resp_score2.size(); i += 3) {
+    score2_scores[resp_score2[i].GetString()] = std::stod(resp_score2[i + 1].GetString());
+  }
+  ASSERT_EQ(score2_scores.size(), 2u);
+
+  for (const auto& [k, s1] : scores) {
+    auto it = score2_scores.find(k);
+    ASSERT_NE(it, score2_scores.end()) << "Key " << k << " not found in SCORE=2.0 results";
+    EXPECT_NEAR(it->second / s1, 2.0, 1e-3)
+        << "SCORE=2.0 should multiply text score by 2 (key=" << k << ")";
+  }
+
+  EXPECT_GT(scores["d:1"], scores["d:2"]);
+  EXPECT_GT(score2_scores["d:1"], score2_scores["d:2"]);
+}
+
+// Test SCORE=0 produces zero scores for all documents
+TEST_F(SearchFamilyTest, DefaultScoreZeroProducesZeroScores) {
+  EXPECT_EQ(Run({"ft.create", "idx0", "ON", "HASH", "PREFIX", "1", "z:", "SCORE", "0", "SCHEMA",
+                 "title", "TEXT"}),
+            "OK");
+  WaitForIndexReady("idx0");
+
+  Run({"hset", "z:1", "title", "hello world hello hello"});
+  Run({"hset", "z:2", "title", "hello there"});
+  Run({"hset", "z:3", "title", "world hello"});
+
+  auto resp = Run({"ft.search", "idx0", "hello", "WITHSCORES"}).GetVec();
+  ASSERT_GE(resp.size(), 1 + 3u);
+
+  for (size_t i = 1; i + 1 < resp.size(); i += 3) {
+    double score = std::stod(resp[i + 1].GetString());
+    EXPECT_NEAR(score, 0.0, 1e-6) << "SCORE=0 should make all scores 0 (key=" << resp[i].GetString()
+                                  << ")";
+  }
+}
+
+// Test SCORE parameter affects scores: Final score = BM25 score × SCORE
+TEST_F(SearchFamilyTest, DefaultScoreNegative) {
+  EXPECT_EQ(Run({"ft.create", "idx-neg", "ON", "HASH", "PREFIX", "1", "n:", "SCORE", "-1", "SCHEMA",
+                 "title", "TEXT"}),
+            "OK");
+  WaitForIndexReady("idx-neg");
+
+  Run({"hset", "n:1", "title", "hello world"});
+
+  EXPECT_EQ(
+      Run({"ft.create", "idx-pos", "ON", "HASH", "PREFIX", "1", "p:", "SCHEMA", "title", "TEXT"}),
+      "OK");
+  WaitForIndexReady("idx-pos");
+  Run({"hset", "p:1", "title", "hello world"});
+  auto resp_pos = Run({"ft.search", "idx-pos", "hello", "WITHSCORES"}).GetVec();
+  double pos_score = std::stod(resp_pos[2].GetString());
+
+  auto resp_neg = Run({"ft.search", "idx-neg", "hello", "WITHSCORES"}).GetVec();
+  double neg_score = std::stod(resp_neg[2].GetString());
+
+  EXPECT_NEAR(neg_score, -pos_score, 1e-6);
+}
+
 TEST_F(SearchFamilyTest, CreateDropDifferentDatabases) {
   // Create index on db 0
   auto resp =
@@ -6567,6 +6688,31 @@ TEST(BuildRestoreCommandTest, IndexOptionsPreserved) {
   EXPECT_THAT(cmd, HasSubstr("NOOFFSETS"));
   EXPECT_THAT(cmd, HasSubstr("LANGUAGE german"));
   EXPECT_THAT(cmd, HasSubstr("LANGUAGE_FIELD lang"));
+}
+
+// Verify that BuildRestoreCommand preserves SCORE parameter.
+TEST(BuildRestoreCommandTest, DefaultScorePreserved) {
+  using dfly::DocIndex;
+  using dfly::DocIndexInfo;
+  using dfly::search::IndicesOptions;
+  using dfly::search::SchemaField;
+
+  SchemaField field;
+  field.type = SchemaField::TEXT;
+  field.flags = 0;
+  field.short_name = "title";
+
+  DocIndex base;
+  base.type = DocIndex::HASH;
+  base.options = IndicesOptions(absl::flat_hash_set<std::string>{});
+  base.schema.score = 2.5f;
+  base.schema.fields["title"] = std::move(field);
+
+  DocIndexInfo info;
+  info.base_index = std::move(base);
+
+  std::string cmd = info.BuildRestoreCommand();
+  EXPECT_THAT(cmd, HasSubstr("SCORE 2.5"));
 }
 
 // Verify that FT.INFO returns all VECTOR field parameters.


### PR DESCRIPTION
Implement the DEFAULT_SCORE parameter for FT.CREATE to allow setting a global multiplier for text relevance scores.

- Parse and store default_score in Schema during FT.CREATE
- Include default_score in BuildRestoreCommand() for persistence
- Display default_score in FT.INFO response
- Apply default_score as a multiplier in ShardDocIndex::Search
- Add unit tests for default_score parsing, zero value, negative value, score multiplication, and persistence after restart

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
