### PR TITLE
chore(facade): remove no-op io_event_ notifies in ioloop v2

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -2670,11 +2670,6 @@ bool Connection::ExecuteBatch() {
     }
   }
 
-  // Since we are done executing a batch, and retire_head might be called which releases commands,
-  // notify waiters that backpressure might be relieved.
-  if (ioloop_v2_) {
-    io_event_.notify();
-  }
   return true;
 }
 
@@ -2700,17 +2695,14 @@ bool Connection::ReplyBatch() {
       break;
   }
 
+  // V1: handles its pipeline batching inside AsyncFiber, so it flushes unconditionally here.
+  //
   // V2: operates as a single-fiber event loop where reading, parsing, and executing happen
   // sequentially. Because ParseLoop processes pipelines in chunks, flushing here would trigger a
   // sendmsg syscall for every single chunk. Instead, V2 delegates flushing to IoLoopV2, which
   // safely flushes the coalesced buffer right before the fiber yields (await) or when memory limits
   // are reached.
-  if (ioloop_v2_) {
-    // Since we are done replying a batch, and ReleaseParsedCommand might be called which release
-    // commands, notify waiters that backpressure might be relieved.
-    io_event_.notify();
-  } else {
-    // V1: handles its pipeline batching inside AsyncFiber, so it flushes unconditionally here.
+  if (!ioloop_v2_) {
     reply_builder_->Flush();
   }
 


### PR DESCRIPTION
Remove io_event_.notify() calls from ExecuteBatch() and ReplyBatch(). These are no-ops because both functions run synchronously on the same V2 fiber that is the sole waiter of io_event_. A notify issued before the fiber reaches await() is consumed by prepareWait()'s epoch snapshot and has no effect.

Cross-connection backpressure relief is handled separately by NotifyPipelineWaiters() in IoLoopV2() after ParseLoop() returns, so removing these does not affect backpressure signaling.

