### PR TITLE
fix(tiering): Fix QList node cleanup after clearing offloaded state

### DIFF
--- a/src/core/qlist.cc
+++ b/src/core/qlist.cc
@@ -1220,7 +1220,8 @@ void QList::DelNode(Node* node) {
     }
   }
 
-  if (!node->offloaded) {
+  if (!node->offloaded && node->entry) {
+    DCHECK(node->entry != nullptr);
     zfree(node->entry);
   }
 

--- a/src/core/tiering_types.cc
+++ b/src/core/tiering_types.cc
@@ -20,7 +20,10 @@ bool FragmentRef::IsOffloaded() const {
 
 void FragmentRef::ClearOffloaded() {
   std::visit(Overloaded{[](CompactValue* pv) { pv->RemoveExternal(); },
-                        [](QList::Node* node) { node->offloaded = 0; }},
+                        [](QList::Node* node) {
+                          node->offloaded = 0;
+                          node->entry = nullptr;
+                        }},
              val_);
 }
 


### PR DESCRIPTION
Clear the node entry pointer when restoring an offloaded QList node, and guard 
node deletion so cleanup does not free a null or stale entry.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
