### PR TITLE
fix: stale search index entries after MOVE

### DIFF
--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -950,6 +950,7 @@ OpStatus OpMove(const OpArgs& op_args, string_view key, DbIndex target_db) {
   bool sticky = from_res.it->first.IsSticky();
   uint64_t exp_ts = from_res.it->first.GetExpireTime();
   from_res.post_updater.Run();
+  RemoveKeyFromIndexesIfNeeded(key, op_args.db_cntx, from_res.it->second, op_args.shard);
   PrimeValue from_obj = std::move(from_res.it->second);
 
   db_slice.Del(op_args.db_cntx, from_res.it);
@@ -957,6 +958,7 @@ OpStatus OpMove(const OpArgs& op_args, string_view key, DbIndex target_db) {
   RETURN_ON_BAD_STATUS(op_result);
   auto& add_res = *op_result;
   add_res.it->first.SetSticky(sticky);
+  AddKeyToIndexesIfNeeded(key, target_cntx, add_res.it->second, op_args.shard);
 
   // When tiering is enabled, update tiered-storage metadata for partial moved values.
   if (EngineShard::tlocal()->tiered_storage()) {

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -949,11 +949,11 @@ OpStatus OpMove(const OpArgs& op_args, string_view key, DbIndex target_db) {
 
   bool sticky = from_res.it->first.IsSticky();
   uint64_t exp_ts = from_res.it->first.GetExpireTime();
-  from_res.post_updater.Run();
   RemoveKeyFromIndexesIfNeeded(key, op_args.db_cntx, from_res.it->second, op_args.shard);
+  from_res.post_updater.ReduceHeapUsage();
   PrimeValue from_obj = std::move(from_res.it->second);
 
-  db_slice.Del(op_args.db_cntx, from_res.it);
+  db_slice.DelMutable(op_args.db_cntx, std::move(from_res));
   auto op_result = db_slice.AddNew(target_cntx, key, std::move(from_obj), exp_ts);
   RETURN_ON_BAD_STATUS(op_result);
   auto& add_res = *op_result;

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -622,6 +622,20 @@ TEST_F(GenericFamilyTest, Move) {
   fb_blpop.Join();
 }
 
+TEST_F(GenericFamilyTest, MoveUpdatesMemoryAccounting) {
+  EXPECT_EQ(1, CheckedInt({"lpush", "list", "elem"}));
+
+  Metrics metrics = GetMetrics();
+  size_t list_usage = metrics.db_stats[0].memory_usage_by_type[OBJ_LIST];
+  ASSERT_GT(list_usage, 0);
+
+  EXPECT_THAT(Run({"move", "list", "1"}), IntArg(1));
+
+  metrics = GetMetrics();
+  EXPECT_EQ(metrics.db_stats[0].memory_usage_by_type[OBJ_LIST], 0u);
+  EXPECT_EQ(metrics.db_stats[1].memory_usage_by_type[OBJ_LIST], list_usage);
+}
+
 using testing::AnyOf;
 using testing::Each;
 using testing::StartsWith;

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -7245,6 +7245,46 @@ TEST_F(SearchFamilyTest, SynUpdateExpiredDocCrash) {
 
 // --- FT.HYBRID tests ---------------------------------------------------------
 
+TEST_F(SearchFamilyTest, FtHybridStaleDocIdAfterMoveAndHashRewrite) {
+  const string vec = FloatVec(1.0f, 1.0f);
+
+  EXPECT_EQ(Run({"FT.CREATE", "vidx", "ON", "HASH", "SCHEMA", "t", "TEXT", "v", "VECTOR", "FLAT",
+                 "6", "DIM", "2", "DISTANCE_METRIC", "L2", "TYPE", "FLOAT32"}),
+            "OK");
+  EXPECT_EQ(Run({"HSET", "1", "t", "hello", "v", vec}), 2);
+  EXPECT_EQ(Run({"MOVE", "1", "1"}), 1);
+  EXPECT_EQ(Run({"HMSET", "1", "100", "RIGHT", "src", "v", "hello", ""}), "OK");
+  EXPECT_EQ(Run({"DEL", "1", "v", "BYSCORE", "FIELDS", "WITHVALUES", "*0\r\n"}), 1);
+
+  auto resp = Run({"FT.HYBRID", "vidx", "SEARCH", "hello", "VSIM", "@v", "$b", "KNN", "5", "PARAMS",
+                   "2", "b", vec});
+  ASSERT_HYBRID_RESP(resp);
+  EXPECT_EQ(HybridTotal(resp), 0);
+}
+
+TEST_F(SearchFamilyTest, MoveFromIndexedDbRemovesSearchDocument) {
+  EXPECT_EQ(Run({"FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "field", "TEXT"}), "OK");
+  EXPECT_EQ(Run({"HSET", "doc", "field", "value"}), 1);
+  EXPECT_THAT(Run({"FT.SEARCH", "idx", "value"}), AreDocIds("doc"));
+
+  EXPECT_EQ(Run({"MOVE", "doc", "1"}), 1);
+  EXPECT_THAT(Run({"FT.SEARCH", "idx", "value"}), kNoResults);
+
+  EXPECT_EQ(Run({"SELECT", "1"}), "OK");
+  EXPECT_EQ(Run({"EXISTS", "doc"}), 1);
+  EXPECT_EQ(Run({"SELECT", "0"}), "OK");
+}
+
+TEST_F(SearchFamilyTest, MoveIntoIndexedDbAddsSearchDocument) {
+  EXPECT_EQ(Run({"FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "field", "TEXT"}), "OK");
+  EXPECT_EQ(Run({"SELECT", "1"}), "OK");
+  EXPECT_EQ(Run({"HSET", "doc", "field", "value"}), 1);
+
+  EXPECT_EQ(Run({"MOVE", "doc", "0"}), 1);
+  EXPECT_EQ(Run({"SELECT", "0"}), "OK");
+  EXPECT_THAT(Run({"FT.SEARCH", "idx", "value"}), AreDocIds("doc"));
+}
+
 TEST_F(SearchFamilyTest, FtHybridUnknownIndex) {
   auto resp =
       Run({"FT.HYBRID", "no_such_idx", "SEARCH", "hello",  "VSIM", "@vec", "$v",


### PR DESCRIPTION
Fixes a crash in `FT.HYBRID` caused by stale search index entries after `MOVE`.

`MOVE` was moving the source `PrimeValue` before deleting the source key, so the search deletion callback could observe a moved-from hash value and fail to remove old text index postings. This could leave a freed `DocId` in the text index, later crashing in `DocKeyIndex::Get()` during hybrid search.

This change updates `MOVE` to:
- remove the source key from search indexes before moving its value
- add the destination key to search indexes after the value is inserted into the target DB
- cover the issue with a minimized `FT.HYBRID` regression test
- add regression coverage for moving indexed hash documents out of and into DB 0

Fixes: #7611