### PR TITLE
fix(tiering): Keep tiered list endpoints materialized

### DIFF
--- a/src/core/qlist.cc
+++ b/src/core/qlist.cc
@@ -1209,9 +1209,11 @@ void QList::DelNode(Node* node) {
    * now have compressed nodes needing to be decompressed. */
   CompressByDepth(NULL);
 
-  // Head and tail must always be uncompressed. A deletion may promote a
-  // ZSTD-compressed interior node to head or tail.
+  // Head and tail must always be materialized and uncompressed. A deletion may promote an
+  // offloaded, pending, or ZSTD-compressed interior node to head or tail.
   if (head_) {
+    Materialize(head_);
+    Materialize(head_->prev);
     if (head_->IsCompressed()) {
       malloc_size_ += TryDecompressInternal(false, head_);
     }

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -1021,6 +1021,26 @@ TEST_F(ListNodeTieringTest, RPopStashedNodes) {
   EXPECT_THAT(Run({"EXISTS", "mylist"}), IntArg(0));
 }
 
+TEST_F(ListNodeTieringTest, PushAfterOffloadedNodePromotedToTail) {
+  // Allow appending into an existing tail listpack after it is promoted by LTRIM.
+  SetFlag(&FLAGS_list_max_listpack_size, -2);
+
+  const int kItems = 10;
+  for (int i = 0; i < kItems; i++) {
+    Run({"RPUSH", "mylist", BuildString(3000, static_cast<char>('A' + i))});
+  }
+
+  ExpectConditionWithinTimeout([this] { return GetMetrics().tiered_stats.total_stashes >= 1; });
+
+  const int kTrimmedItems = 6;
+  EXPECT_EQ(Run({"LTRIM", "mylist", "0", "5"}), "OK");
+
+  string appended = BuildString(64, 'z');
+  EXPECT_THAT(Run({"RPUSH", "mylist", appended}), IntArg(kTrimmedItems + 1));
+  EXPECT_EQ(Run({"RPOP", "mylist"}), appended);
+  EXPECT_THAT(Run({"LLEN", "mylist"}), IntArg(kTrimmedItems));
+}
+
 // Test MEMORY DECOMMIT COOL command flushes the cool queue
 TEST_P(LatentCoolingTSTest, MemoryDecommitCool) {
   absl::FlagSaver saver;


### PR DESCRIPTION
QList endpoint operations assume head and tail nodes are in memory and access
their listpack entries directly. Deleting a node can promote an offloaded or
pending interior node to head or tail, breaking that invariant.

Materialize the current head and tail after node deletion and add a regression
for RPUSH after LTRIM promotes an offloaded node to the tail.
