### PR TITLE
fix(list_family): Fix QList insert-before at head

### DIFF
--- a/src/core/qlist.cc
+++ b/src/core/qlist.cc
@@ -779,7 +779,7 @@ void QList::Insert(Iterator it, std::string_view elem, InsertOpt insert_opt) {
 
   if (!after && (it.offset_ == 0 || it.offset_ == -(node->count))) {
     at_head = 1;
-    if (NodeAllowInsert(node->prev, fill_, sz)) {
+    if (node != head_ && NodeAllowInsert(node->prev, fill_, sz)) {
       avail_prev = 1;
     }
   }

--- a/src/core/qlist_test.cc
+++ b/src/core/qlist_test.cc
@@ -257,6 +257,20 @@ TEST_F(QListTest, InsertDelete) {
   EXPECT_EQ(0, ql_.Size());
 }
 
+TEST_F(QListTest, InsertBeforeHeadPreservesOrder) {
+  // Each qlist node can hold up to 2 entries.
+  ql_ = QList(2, QUICKLIST_NOCOMPRESS);
+
+  ql_.Push("v0", QList::TAIL);
+  ql_.Push("v1", QList::TAIL);
+  ql_.Push("v2", QList::TAIL);
+  ASSERT_EQ(2u, ql_.node_count());
+
+  EXPECT_TRUE(ql_.Insert("v0", "x", QList::BEFORE));
+
+  EXPECT_THAT(ToItems(), ElementsAre("x", "v0", "v1", "v2"));
+}
+
 TEST_F(QListTest, EraseLastElementInNodeAdvancesToNextNode) {
   // Regression test for iterator semantics: when erasing the last element
   // within a multi-entry node and another node follows, the iterator should


### PR DESCRIPTION
When inserting before the first element of a full head node, QList could treat 
head_->prev as an available previous node. Since head_->prev points to the tail, 
the new element could be appended at the end instead of inserted before the pivot.

Skip the previous-node fast path for the head node and create new head node.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
