### PR TITLE
fix: experimental fuzz workflow validation and run title

### DIFF
--- a/.github/workflows/fuzz-experimental-persistent.yml
+++ b/.github/workflows/fuzz-experimental-persistent.yml
@@ -58,7 +58,7 @@ jobs:
       OUTPUT_DIR: ${{ github.workspace }}/fuzz/artifacts/experimental-persistent/${{ matrix.target }}
       CORPUS_DIR: ${{ github.workspace }}/fuzz/corpus/experimental-persistent/${{ matrix.target }}
       HEALTH_DIR: ${{ github.workspace }}/fuzz/health/experimental-persistent/${{ matrix.target }}
-      CACHE_KEY: experimental-afl-${{ runner.os }}-${{ matrix.target }}-v1-${{ github.run_number }}-${{ github.run_attempt }}
+      CACHE_KEY: experimental-afl-Linux-${{ matrix.target }}-v1-${{ github.run_number }}-${{ github.run_attempt }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
     steps:

--- a/.github/workflows/fuzz-experimental-persistent.yml
+++ b/.github/workflows/fuzz-experimental-persistent.yml
@@ -1,4 +1,5 @@
 name: Experimental AFL++ Persistent Fuzzing
+run-name: Experimental persistent AFL++ fuzzing - ${{ github.event_name }} - ${{ github.ref_name }}
 
 on:
   schedule:


### PR DESCRIPTION
Fixes the experimental persistent AFL++ fuzzing workflow so GitHub Actions can validate it correctly.

Changes:
- Replace job-level ${{ runner.os }} usage with Linux in the AFL cache key, since runner is not available in job-level env.
- Add run-name so workflow runs appear with a readable title instead of the workflow file path.

Validation:
- Ran actionlint successfully, ignoring only the local warning for the custom CI-LARGE-86 runner label.