### PR TITLE
feat: add /benchmark Claude Code skill

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: benchmark
+description: >
+  Benchmark Dragonfly (and compare against Valkey/Redis) on local or remote
+  cloud instances, then produce a performance + memory report with charts and a
+  raw-data appendix. Use this whenever the user runs /benchmark, or asks to
+  benchmark / load-test / measure throughput, QPS, latency, or memory efficiency
+  of Dragonfly or another Redis-compatible server, to compare Dragonfly vs
+  Valkey or Redis, or to generate a benchmark report. Trigger it even when the
+  user just describes the goal ("see how fast Dragonfly is on this box",
+  "compare memory per key vs Valkey") without saying the word "benchmark".
+argument-hint: (optional) free-form spec, e.g. "server=10.0.0.1 client=10.0.0.2 strings vs-valkey"
+allowed-tools: Bash, Read, Write, Edit, AskUserQuestion
+---
+
+# Benchmark Dragonfly
+
+Drive a benchmark of Dragonfly (optionally side-by-side with Valkey or Redis) on
+local or remote instances, collect throughput / latency / memory numbers, and
+assemble a report that mirrors the team's published format: a narrative TLDR,
+per-instance metric tables, charts, and an appendix with the exact commands and
+raw output so anyone can reproduce it.
+
+The whole point of the report is **trust**: a reader should be able to see the
+headline numbers, understand the conditions they were measured under, and
+re-run the exact commands themselves. Everything below serves that goal.
+
+## When you start
+
+If the user passed a free-form spec in `$ARGUMENTS`, parse what you can from it
+(IPs, use-cases, comparison targets) and only ask about what's missing. The work
+splits into clear phases — walk through them in order, but stay flexible: the
+user may already have servers running, or may only want the report half (handed
+raw output to format). Read what they're actually asking for.
+
+Phases: (1) gather spec → (2) prepare instances → (3) network tuning →
+(4) start monitoring → (5) run workloads → (6) extract metrics, charts, report.
+
+The two reference files carry the operational detail — read them before acting,
+not from memory:
+
+- `references/running-benchmarks.md` — how to prep instances, start servers,
+  drive `dfly_bench` and `memtier_benchmark`, run Valkey/Redis for comparison,
+  apply network tuning, and measure memory. **Read this before Phase 2.**
+- `references/report-template.md` — the exact report structure, with an example.
+  **Read this before Phase 5.**
+
+Bundled `scripts/` (reuse these instead of re-improvising the same loops — they
+encode the safety discipline learned the hard way):
+
+- `bench_server.sh start|stop|status <ssh> <binary> [maxmem] [port]` — launch a
+  server tracking its PID; **stop kills by PID and verifies the process is gone +
+  port free** (tmux kill-session does not reap it).
+- `monitor_fill.sh <server_ssh> <client_ssh> [session] [abort_pct]` — the live
+  RSS guard: polls `used_memory_rss`, prints a line per sample, aborts the write
+  if RSS crosses the threshold (default 92%). Its output is also the input to
+  `plot_fill.py`.
+- `capture_result.sh <server_ssh> <client_ssh> <log> <outdir> [label]` — saves
+  the run summary + INFO memory + **OS-level `free` snapshot** (`host_memory.txt`)
+  and exits non-zero if there were any eviction errors (enforces the zero-error
+  rule). The OS snapshot matters: `used_memory_rss` and host free can diverge
+  significantly — e.g. with `MIMALLOC_ALLOW_LARGE_OS_PAGES=1` (default), mimalloc
+  holds large-page arenas that the OS counts as used but INFO doesn't fully reflect,
+  making the machine appear near-OOM while RSS looks fine.
+- `collect_metrics.py` / `make_charts.py` — metrics + charts from dfly_bench
+  JSON (GET/SET workloads).
+- `plot_fill.py` — memory-fill chart from `monitor_fill.sh` output, for
+  `--command` workloads (e.g. SETEX) that produce no JSON time series.
+
+Every benchmark output directory must include a `commands_audit.log`
+artifact with the exact command lines used for setup, server launch, writes,
+reads, captures, diagnostics, and chart/report generation. Raw data without the
+commands that produced it is not reproducible.
+
+**Run-control scripts are mandatory for benchmark phases.** For Phase 5 runs,
+use the bundled scripts as the default API:
+
+- start/stop/status servers with `scripts/bench_server.sh`;
+- monitor long write fills with `scripts/monitor_fill.sh`;
+- capture write results and enforce the zero-error rule with
+  `scripts/capture_result.sh`;
+- generate metrics/charts with `scripts/collect_metrics.py`,
+  `scripts/make_charts.py`, and `scripts/plot_fill.py`.
+
+Inline SSH is fine for inspection, package setup, one-off diagnostics, and
+bounded foreground probes, but not as a replacement for the run-control scripts
+in the main benchmark path. If a script is not usable for a run, document the
+reason in `commands_audit.log` and in the report appendix before using a manual
+equivalent.
+
+## Phase 1 — Gather the benchmark spec (interactive)
+
+Use `AskUserQuestion` to pin down anything not already given. You need:
+
+1. **Where it runs.** Local, or remote instances? For remote, get the **server**
+   host/IP and the **client** host/IP (the load generator should run on a
+   separate machine from the server — co-locating them steals CPU and corrupts
+   the numbers). Get the SSH user / key if not obvious. On cloud instances,
+   **always use the private/internal IP** (VPC-internal) for both SSH and as the
+   load generator's `-h` target — the public IP routes through the internet
+   gateway, adding latency and egress cost, and the result measures the gateway
+   rather than the server.
+2. **Use-cases.** Default menu: simple strings (SETEX writes + GET reads),
+   pipelined / peak-throughput, memory efficiency. Always also ask whether there
+   is a **specific focus** (a particular command, data type, key distribution,
+   value size, or scenario) — the canned use-cases are a starting point, not a
+   cage.
+3. **Comparison targets.** Dragonfly only, or also Valkey / Redis? Which
+   versions?
+4. **Instance specs** (for the report's conditions section): instance type, CPU
+   count, OS/kernel. Read these directly from the box at the start of Phase 2
+   rather than asking the user.
+5. **Load parameters** if the user has opinions: value size (`-d`), key space
+   (`--key_maximum`), connections (`-c`), pipeline depth, test duration. Pick
+   sensible defaults (see the reference) and tell the user what you chose.
+   **Sizing the key count is the consequential decision** — see the reference's
+   "Sizing the load" section. The dataset must fill a large fraction of instance
+   RAM (benchmarking a near-empty instance is wrong) but stay clear of OOM
+   (~60–75% of RAM, headroom to spare). `--key_maximum` bounds the footprint, so
+   compute it from instance RAM ÷ estimated bytes-per-entry, calibrating with a
+   short pilot write if unsure.
+
+Summarize the resolved spec back to the user in a short block before running
+anything, so a wrong assumption gets caught before machines spin.
+
+## Phase 2 — Prepare the instances
+
+- Record instance specs (`nproc`, `uname -r`, cloud metadata) — these go in the
+  report's conditions section. Use the **private IP** when connecting between
+  instances (see Phase 1).
+- A remote instance usually already has `~/projects/dragonfly`. If not, clone it
+  there. Build a **release** binary (`build-opt/dragonfly`, `build-opt/dfly_bench`)
+  unless the user wants a published release downloaded instead — follow their
+  instruction on build-vs-download.
+- For comparison targets, pull the Valkey/Redis docker image on the server box.
+- Verify everything launches and is reachable from the client box (a quick
+  `redis-cli -h <server-private-ip> ping`) before committing to a long run.
+
+Run each step individually over SSH — do not chain launch, polling, capture, and
+the next phase into one command. If a tool call is interrupted, remote work keeps
+running but goes uncaptured. Start the server; start the write; monitor it;
+capture; start reads — one bounded step at a time.
+
+## Phase 3 — Network tuning (optional, remote only)
+
+High-throughput numbers on cloud hardware depend heavily on IRQ/SMP affinity
+tuning. If the user wants maximal numbers, apply the tuning described in the
+reference and **record exactly what you did** — it belongs in the appendix and
+materially affects the results. If skipped, say so in the report; untuned and
+tuned numbers are not comparable.
+
+## Phase 4 — Start the monitoring stack (server machine)
+
+Start the local Prometheus + Grafana stack on the **server** machine so you get
+continuous, fine-grained time-series (server CPU, memory, command rates, host
+metrics) spanning the whole benchmark — richer than the load generator's own
+output and the source of the most convincing report charts.
+
+```bash
+ssh <server> 'cd ~/projects/dragonfly/tools/local/monitoring && docker compose up -d'
+# when benchmarking Valkey/Redis, also bring up the redis exporter:
+ssh <server> 'cd ~/projects/dragonfly/tools/local/monitoring && docker compose --profile redis up -d'
+```
+
+Prometheus scrapes at 1s. **Always run servers on port 6380** (Dragonfly,
+Valkey, and Redis alike). The bundled `prometheus.yml` ships pointing at `6379`,
+so before bringing the stack up, fix the scrape targets:
+
+```bash
+sed -i 's/:6379/:6380/g' tools/local/monitoring/prometheus/prometheus.yml
+```
+
+(This is a workaround for a misconfigured default — if you have repo write
+access, commit the corrected file once so future runs start clean.)
+
+Restart Prometheus if it was already running, then verify targets are `UP` at
+`http://<server>:9090/targets` before starting the load — a silently-down scrape
+job means no data for that window.
+
+Start monitoring **before** the workloads and leave it running across all runs,
+so a single continuous window covers everything. See the reference's monitoring
+section for what to read from Grafana (dashboards are pre-provisioned) and how to
+pull panels into the report. Record the benchmark start/end timestamps — they
+let you crop the Grafana window to exactly the run.
+
+## Phase 5 — Run the workloads
+
+For each (use-case × datastore) combination, see the reference for the precise
+commands. The shape is always: **write → memory snapshot → read**. Use the
+private IP as the load generator's `-h` target.
+
+Pass `--json_out_file` to `dfly_bench` (and `--json-out-file` to memtier) when
+the workload supports it — charts and headline numbers come from these files.
+`dfly_bench --command` workloads (e.g. `SETEX __key__ 10000 __data__`) do not
+produce JSON; save full stdout and chart the `monitor_fill.sh` output instead.
+
+Drive the run with the bundled scripts: `bench_server.sh start`, write in a
+client tmux session, `monitor_fill.sh` alongside (live RSS guard), then
+`capture_result.sh` to save results. `capture_result.sh` enforces the
+**zero-error rule** — any eviction/OOM error response makes the run invalid;
+discard it, cut `--key_maximum` ~10–15%, and re-run. See the preamble and the
+reference's "Sizing the load" section for the full rule.
+
+**Prefill writes must use `--pipeline 30`.** Without pipelining, the client
+stalls waiting for each reply and becomes the bottleneck before the server is
+saturated — especially at high key counts. Use `--pipeline 30` for all write
+(fill) phases. Drop to `--pipeline 1` (or omit it) only for latency-honest
+read benchmarks where you want honest per-request numbers.
+
+Initialize `commands_audit.log` at the start and append each command as it runs
+(see the preamble for the requirement).
+
+## Phase 6 — Extract metrics, build charts, assemble the report
+
+1. **Headline metrics + memory.** Run the bundled extractor over the JSON files
+   to pull QPS / P99 and compute bytes-per-entry (both `used_memory`- and
+   `used_memory_rss`-based, per the user's choice to report both):
+
+   ```bash
+   python3 .claude/skills/benchmark/scripts/collect_metrics.py \
+       --bench-json <run.json> [--bench-json <run2.json> ...] \
+       --info <info_memory.txt> --dbsize <N> \
+       --label "Dragonfly m7g.2xlarge"
+   ```
+
+   It prints a metrics block (and JSON) you can drop straight into the tables.
+
+2. **Charts.** Generate QPS-over-time PNGs from the time series (this is what
+   visually shows Dragonfly's smooth throughput vs a competitor's degradation):
+
+   ```bash
+   python3 .claude/skills/benchmark/scripts/make_charts.py \
+       --series "Dragonfly=df_write.json" --series "Valkey=valkey_write.json" \
+       --metric qps --title "Write throughput, m7g.2xlarge" \
+       --out charts/write_m7g2xl.png
+   ```
+
+   Embed the PNGs in the report with relative paths. **For `--command` workloads
+   (e.g. SETEX) there is no dfly_bench JSON** — use `plot_fill.py` instead to chart
+   memory-fill over time from the `monitor_fill.sh` output:
+
+   ```bash
+   python3 .claude/skills/benchmark/scripts/plot_fill.py \
+       --series "prebuilt=prebuilt/poll.txt" --series "release=release/poll.txt" \
+       --interval 10 --ram-gib 30 --out charts/memory_fill.png
+   ```
+
+3. **Report.** Follow `references/report-template.md` exactly. Write a TLDR with
+   the 3–5 genuinely important takeaways (scaling behavior, memory efficiency,
+   any hardware surprise), then per-instance tables, then the appendix. The TLDR
+   is interpretation, not a restatement of the tables — say what the numbers
+   *mean*. Only claim what the data supports.
+
+Save the report where the user asks (default: `benchmark-<YYYY>-<MM>.md` in the
+repo root) and tell them the path plus a one-line summary of the headline
+result.
+
+## Cleanup
+
+If you started servers, the monitoring stack, or comparison containers on remote
+instances, offer to stop them (`docker compose down` in the monitoring dir).
+If you applied network tuning that changes machine state, tell the user what
+would need reverting. Don't tear anything down without asking — they may want to
+inspect or re-run.

--- a/.claude/skills/benchmark/evals/evals.json
+++ b/.claude/skills/benchmark/evals/evals.json
@@ -1,0 +1,39 @@
+{
+  "skill_name": "benchmark",
+  "evals": [
+    {
+      "id": 0,
+      "name": "full-report-vs-valkey",
+      "prompt":
+          "I just finished a benchmark run comparing Dragonfly against Valkey 9.0 on AWS. The raw artifacts are in the directory I'm pointing you at: dfly_bench JSON output (write and read phases) and INFO memory dumps for both datastores on m7g.2xlarge and m7g.4xlarge, plus a RUN_NOTES.txt with the hardware, exact commands, and DBSIZE after each write phase. Generate the benchmark report from this data, with charts and a raw-data appendix.",
+      "expected_output":
+          "A markdown report mirroring the team format: conditions section, a Simple Strings use-case section with a TLDR, per-instance (m7g.2xlarge, m7g.4xlarge) QPS/memory and latency tables, embedded QPS-over-time charts, and an appendix with exact commands, environment, and raw output. QPS/P99 must match the data; bytes-per-entry reported both logical (~127 DF / ~149-150 Valkey) and RSS.",
+      "files": [
+        "fixtures/"
+      ]
+    },
+    {
+      "id": 1,
+      "name": "memory-focus-single-datastore",
+      "prompt":
+          "Here's raw output from a Dragonfly-only run on m7g.4xlarge (dfly_bench write/read JSON + INFO memory dump + run notes with DBSIZE). I care mostly about memory efficiency. Write me a short benchmark report focused on memory usage per entry, plus the throughput numbers.",
+      "expected_output":
+          "A report covering only Dragonfly (no fabricated Valkey/Redis comparison column), reporting both logical (used_memory/DBSIZE ~127) and RSS bytes-per-entry, plus write/read QPS and P99. Honest about it being single-datastore.",
+      "files": [
+        "fixtures/df_4xl_write.json",
+        "fixtures/df_4xl_read.json",
+        "fixtures/df_4xl_info_memory.txt",
+        "fixtures/RUN_NOTES.txt"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "kickoff-planning-interactive",
+      "prompt":
+          "I've got two m7g.4xlarge boxes in AWS. Benchmark Dragonfly against Valkey on a simple strings workload.",
+      "expected_output":
+          "The skill should engage its interactive front-end: ask which box is the server vs the client (load generator must be separate), confirm SSH access, plan to run servers on port 6380, plan to start the monitoring stack (and fix the prometheus scrape port to 6380), and lay out the write/read workload plan. It must NOT invent benchmark numbers it hasn't measured.",
+      "files": []
+    }
+  ]
+}

--- a/.claude/skills/benchmark/evals/fixtures/RUN_NOTES.txt
+++ b/.claude/skills/benchmark/evals/fixtures/RUN_NOTES.txt
@@ -1,0 +1,24 @@
+Benchmark run notes (raw artifacts in this directory)
+
+Hardware:
+  Server: m7g.2xlarge (8 vCPU) and m7g.4xlarge (16 vCPU), Ubuntu 24.04.2, kernel 6.8.0
+  Client: c7gn.4xlarge (16 vCPU) running dfly_bench
+  Network tuning: IRQ SMP affinity spread across CPUs (applied)
+
+Servers launched on port 6380:
+  Dragonfly: ./dragonfly --conn_use_incoming_cpu --dbfilename= --logtostderr --port 6380
+  Valkey 9.0: docker run --network=host --rm valkey/valkey:9.0 --save "" --appendonly no --io-threads 8 --protected-mode no --port 6380
+
+Workload: simple strings, 64-byte values.
+  Write: ./dfly_bench -p 6380 --qps=0 -d 64 --key_maximum=$KMAX -c 50 --ratio 1:0 --json_out_file <f>
+  Read:  ./dfly_bench -p 6380 --qps=0 -d 64 --key_maximum=$KMAX -c 50 --ratio 0:1 --json_out_file <f>
+
+DBSIZE captured after the write phase:
+  m7g.2xlarge: Dragonfly 50,000,000 keys ; Valkey 50,000,000 keys
+  m7g.4xlarge: Dragonfly 80,000,000 keys ; Valkey 80,000,000 keys
+
+Files:
+  df_2xl_write.json df_2xl_read.json valkey_2xl_write.json valkey_2xl_read.json
+  df_2xl_info_memory.txt valkey_2xl_info_memory.txt
+  df_4xl_write.json df_4xl_read.json valkey_4xl_write.json valkey_4xl_read.json
+  df_4xl_info_memory.txt valkey_4xl_info_memory.txt

--- a/.claude/skills/benchmark/evals/fixtures/df_2xl_info_memory.txt
+++ b/.claude/skills/benchmark/evals/fixtures/df_2xl_info_memory.txt
@@ -1,0 +1,10 @@
+# Memory
+used_memory:6350000000
+used_memory_human:6.35G
+used_memory_rss:6900000000
+used_memory_rss_human:6.90G
+used_memory_peak:6477000000
+maxmemory:0
+maxmemory_policy:noeviction
+mem_fragmentation_ratio:1.09
+mem_allocator:mimalloc

--- a/.claude/skills/benchmark/evals/fixtures/df_2xl_read.json
+++ b/.claude/skills/benchmark/evals/fixtures/df_2xl_read.json
@@ -1,0 +1,203 @@
+{
+  "configuration": {
+    "server": "10.0.0.10",
+    "port": 6380,
+    "clients": 400,
+    "threads": 8,
+    "pipeline": 1,
+    "ratio": "0:1"
+  },
+  "ALL STATS": {
+    "Runtime": {
+      "Total duration": 30000
+    },
+    "Gets": {
+      "Count": 25435791,
+      "Average Latency": 267.0,
+      "Percentile 50.00": 356,
+      "Percentile 99.00": 923,
+      "Time-Serie": {
+        "0": {
+          "Count": 854758,
+          "Average Latency": 267.0,
+          "Percentile 50.00": 356,
+          "Percentile 99.00": 890
+        },
+        "1": {
+          "Count": 844647,
+          "Average Latency": 275.1,
+          "Percentile 50.00": 367,
+          "Percentile 99.00": 917
+        },
+        "2": {
+          "Count": 851515,
+          "Average Latency": 273.6,
+          "Percentile 50.00": 365,
+          "Percentile 99.00": 912
+        },
+        "3": {
+          "Count": 849698,
+          "Average Latency": 274.8,
+          "Percentile 50.00": 366,
+          "Percentile 99.00": 916
+        },
+        "4": {
+          "Count": 849438,
+          "Average Latency": 260.7,
+          "Percentile 50.00": 348,
+          "Percentile 99.00": 869
+        },
+        "5": {
+          "Count": 847211,
+          "Average Latency": 264.0,
+          "Percentile 50.00": 352,
+          "Percentile 99.00": 880
+        },
+        "6": {
+          "Count": 854119,
+          "Average Latency": 262.5,
+          "Percentile 50.00": 350,
+          "Percentile 99.00": 875
+        },
+        "7": {
+          "Count": 856004,
+          "Average Latency": 275.1,
+          "Percentile 50.00": 367,
+          "Percentile 99.00": 917
+        },
+        "8": {
+          "Count": 847533,
+          "Average Latency": 276.9,
+          "Percentile 50.00": 369,
+          "Percentile 99.00": 923
+        },
+        "9": {
+          "Count": 850954,
+          "Average Latency": 257.7,
+          "Percentile 50.00": 344,
+          "Percentile 99.00": 859
+        },
+        "10": {
+          "Count": 840092,
+          "Average Latency": 258.3,
+          "Percentile 50.00": 344,
+          "Percentile 99.00": 861
+        },
+        "11": {
+          "Count": 851626,
+          "Average Latency": 259.5,
+          "Percentile 50.00": 346,
+          "Percentile 99.00": 865
+        },
+        "12": {
+          "Count": 850648,
+          "Average Latency": 259.5,
+          "Percentile 50.00": 346,
+          "Percentile 99.00": 865
+        },
+        "13": {
+          "Count": 856875,
+          "Average Latency": 265.5,
+          "Percentile 50.00": 354,
+          "Percentile 99.00": 885
+        },
+        "14": {
+          "Count": 853794,
+          "Average Latency": 268.2,
+          "Percentile 50.00": 358,
+          "Percentile 99.00": 894
+        },
+        "15": {
+          "Count": 844122,
+          "Average Latency": 260.4,
+          "Percentile 50.00": 347,
+          "Percentile 99.00": 868
+        },
+        "16": {
+          "Count": 845944,
+          "Average Latency": 254.1,
+          "Percentile 50.00": 339,
+          "Percentile 99.00": 847
+        },
+        "17": {
+          "Count": 851035,
+          "Average Latency": 264.0,
+          "Percentile 50.00": 352,
+          "Percentile 99.00": 880
+        },
+        "18": {
+          "Count": 839406,
+          "Average Latency": 262.8,
+          "Percentile 50.00": 350,
+          "Percentile 99.00": 876
+        },
+        "19": {
+          "Count": 847310,
+          "Average Latency": 267.6,
+          "Percentile 50.00": 357,
+          "Percentile 99.00": 892
+        },
+        "20": {
+          "Count": 842024,
+          "Average Latency": 276.9,
+          "Percentile 50.00": 369,
+          "Percentile 99.00": 923
+        },
+        "21": {
+          "Count": 841107,
+          "Average Latency": 270.6,
+          "Percentile 50.00": 361,
+          "Percentile 99.00": 902
+        },
+        "22": {
+          "Count": 840061,
+          "Average Latency": 266.4,
+          "Percentile 50.00": 355,
+          "Percentile 99.00": 888
+        },
+        "23": {
+          "Count": 852828,
+          "Average Latency": 268.8,
+          "Percentile 50.00": 358,
+          "Percentile 99.00": 896
+        },
+        "24": {
+          "Count": 841328,
+          "Average Latency": 270.3,
+          "Percentile 50.00": 360,
+          "Percentile 99.00": 901
+        },
+        "25": {
+          "Count": 843457,
+          "Average Latency": 255.3,
+          "Percentile 50.00": 340,
+          "Percentile 99.00": 851
+        },
+        "26": {
+          "Count": 846037,
+          "Average Latency": 275.4,
+          "Percentile 50.00": 367,
+          "Percentile 99.00": 918
+        },
+        "27": {
+          "Count": 854685,
+          "Average Latency": 272.7,
+          "Percentile 50.00": 364,
+          "Percentile 99.00": 909
+        },
+        "28": {
+          "Count": 840450,
+          "Average Latency": 274.8,
+          "Percentile 50.00": 366,
+          "Percentile 99.00": 916
+        },
+        "29": {
+          "Count": 847085,
+          "Average Latency": 273.0,
+          "Percentile 50.00": 364,
+          "Percentile 99.00": 910
+        }
+      }
+    }
+  }
+}

--- a/.claude/skills/benchmark/evals/fixtures/df_2xl_write.json
+++ b/.claude/skills/benchmark/evals/fixtures/df_2xl_write.json
@@ -1,0 +1,203 @@
+{
+  "configuration": {
+    "server": "10.0.0.10",
+    "port": 6380,
+    "clients": 400,
+    "threads": 8,
+    "pipeline": 1,
+    "ratio": "1:0"
+  },
+  "ALL STATS": {
+    "Runtime": {
+      "Total duration": 30000
+    },
+    "Sets": {
+      "Count": 24428207,
+      "Average Latency": 235.4,
+      "Percentile 50.00": 314,
+      "Percentile 99.00": 817,
+      "Time-Serie": {
+        "0": {
+          "Count": 813181,
+          "Average Latency": 239.4,
+          "Percentile 50.00": 319,
+          "Percentile 99.00": 798
+        },
+        "1": {
+          "Count": 810413,
+          "Average Latency": 232.8,
+          "Percentile 50.00": 310,
+          "Percentile 99.00": 776
+        },
+        "2": {
+          "Count": 818414,
+          "Average Latency": 237.0,
+          "Percentile 50.00": 316,
+          "Percentile 99.00": 790
+        },
+        "3": {
+          "Count": 809158,
+          "Average Latency": 225.6,
+          "Percentile 50.00": 301,
+          "Percentile 99.00": 752
+        },
+        "4": {
+          "Count": 816574,
+          "Average Latency": 225.3,
+          "Percentile 50.00": 300,
+          "Percentile 99.00": 751
+        },
+        "5": {
+          "Count": 813851,
+          "Average Latency": 228.9,
+          "Percentile 50.00": 305,
+          "Percentile 99.00": 763
+        },
+        "6": {
+          "Count": 808927,
+          "Average Latency": 240.3,
+          "Percentile 50.00": 320,
+          "Percentile 99.00": 801
+        },
+        "7": {
+          "Count": 816118,
+          "Average Latency": 234.3,
+          "Percentile 50.00": 312,
+          "Percentile 99.00": 781
+        },
+        "8": {
+          "Count": 808599,
+          "Average Latency": 231.6,
+          "Percentile 50.00": 309,
+          "Percentile 99.00": 772
+        },
+        "9": {
+          "Count": 814938,
+          "Average Latency": 237.9,
+          "Percentile 50.00": 317,
+          "Percentile 99.00": 793
+        },
+        "10": {
+          "Count": 809117,
+          "Average Latency": 234.9,
+          "Percentile 50.00": 313,
+          "Percentile 99.00": 783
+        },
+        "11": {
+          "Count": 809451,
+          "Average Latency": 231.0,
+          "Percentile 50.00": 308,
+          "Percentile 99.00": 770
+        },
+        "12": {
+          "Count": 814792,
+          "Average Latency": 243.0,
+          "Percentile 50.00": 324,
+          "Percentile 99.00": 810
+        },
+        "13": {
+          "Count": 821229,
+          "Average Latency": 240.6,
+          "Percentile 50.00": 321,
+          "Percentile 99.00": 802
+        },
+        "14": {
+          "Count": 809980,
+          "Average Latency": 229.8,
+          "Percentile 50.00": 306,
+          "Percentile 99.00": 766
+        },
+        "15": {
+          "Count": 811571,
+          "Average Latency": 237.6,
+          "Percentile 50.00": 317,
+          "Percentile 99.00": 792
+        },
+        "16": {
+          "Count": 818038,
+          "Average Latency": 236.7,
+          "Percentile 50.00": 316,
+          "Percentile 99.00": 789
+        },
+        "17": {
+          "Count": 823163,
+          "Average Latency": 245.1,
+          "Percentile 50.00": 327,
+          "Percentile 99.00": 817
+        },
+        "18": {
+          "Count": 817233,
+          "Average Latency": 241.5,
+          "Percentile 50.00": 322,
+          "Percentile 99.00": 805
+        },
+        "19": {
+          "Count": 814346,
+          "Average Latency": 231.0,
+          "Percentile 50.00": 308,
+          "Percentile 99.00": 770
+        },
+        "20": {
+          "Count": 823620,
+          "Average Latency": 247.5,
+          "Percentile 50.00": 330,
+          "Percentile 99.00": 825
+        },
+        "21": {
+          "Count": 808745,
+          "Average Latency": 226.8,
+          "Percentile 50.00": 302,
+          "Percentile 99.00": 756
+        },
+        "22": {
+          "Count": 821735,
+          "Average Latency": 234.0,
+          "Percentile 50.00": 312,
+          "Percentile 99.00": 780
+        },
+        "23": {
+          "Count": 812633,
+          "Average Latency": 242.1,
+          "Percentile 50.00": 323,
+          "Percentile 99.00": 807
+        },
+        "24": {
+          "Count": 810308,
+          "Average Latency": 227.7,
+          "Percentile 50.00": 304,
+          "Percentile 99.00": 759
+        },
+        "25": {
+          "Count": 809884,
+          "Average Latency": 235.8,
+          "Percentile 50.00": 314,
+          "Percentile 99.00": 786
+        },
+        "26": {
+          "Count": 812935,
+          "Average Latency": 225.0,
+          "Percentile 50.00": 300,
+          "Percentile 99.00": 750
+        },
+        "27": {
+          "Count": 821058,
+          "Average Latency": 240.0,
+          "Percentile 50.00": 320,
+          "Percentile 99.00": 800
+        },
+        "28": {
+          "Count": 810891,
+          "Average Latency": 242.4,
+          "Percentile 50.00": 323,
+          "Percentile 99.00": 808
+        },
+        "29": {
+          "Count": 817305,
+          "Average Latency": 237.6,
+          "Percentile 50.00": 317,
+          "Percentile 99.00": 792
+        }
+      }
+    }
+  }
+}

--- a/.claude/skills/benchmark/evals/fixtures/df_4xl_info_memory.txt
+++ b/.claude/skills/benchmark/evals/fixtures/df_4xl_info_memory.txt
@@ -1,0 +1,10 @@
+# Memory
+used_memory:10160000000
+used_memory_human:10.16G
+used_memory_rss:11120000000
+used_memory_rss_human:11.12G
+used_memory_peak:10363200000
+maxmemory:0
+maxmemory_policy:noeviction
+mem_fragmentation_ratio:1.09
+mem_allocator:mimalloc

--- a/.claude/skills/benchmark/evals/fixtures/df_4xl_read.json
+++ b/.claude/skills/benchmark/evals/fixtures/df_4xl_read.json
@@ -1,0 +1,203 @@
+{
+  "configuration": {
+    "server": "10.0.0.10",
+    "port": 6380,
+    "clients": 400,
+    "threads": 8,
+    "pipeline": 1,
+    "ratio": "0:1"
+  },
+  "ALL STATS": {
+    "Runtime": {
+      "Total duration": 30000
+    },
+    "Gets": {
+      "Count": 47442701,
+      "Average Latency": 234.6,
+      "Percentile 50.00": 313,
+      "Percentile 99.00": 809,
+      "Time-Serie": {
+        "0": {
+          "Count": 1569942,
+          "Average Latency": 228.0,
+          "Percentile 50.00": 304,
+          "Percentile 99.00": 760
+        },
+        "1": {
+          "Count": 1587915,
+          "Average Latency": 230.7,
+          "Percentile 50.00": 308,
+          "Percentile 99.00": 769
+        },
+        "2": {
+          "Count": 1586128,
+          "Average Latency": 226.8,
+          "Percentile 50.00": 302,
+          "Percentile 99.00": 756
+        },
+        "3": {
+          "Count": 1569575,
+          "Average Latency": 240.0,
+          "Percentile 50.00": 320,
+          "Percentile 99.00": 800
+        },
+        "4": {
+          "Count": 1593250,
+          "Average Latency": 231.0,
+          "Percentile 50.00": 308,
+          "Percentile 99.00": 770
+        },
+        "5": {
+          "Count": 1595961,
+          "Average Latency": 228.3,
+          "Percentile 50.00": 304,
+          "Percentile 99.00": 761
+        },
+        "6": {
+          "Count": 1572026,
+          "Average Latency": 233.7,
+          "Percentile 50.00": 312,
+          "Percentile 99.00": 779
+        },
+        "7": {
+          "Count": 1595480,
+          "Average Latency": 242.4,
+          "Percentile 50.00": 323,
+          "Percentile 99.00": 808
+        },
+        "8": {
+          "Count": 1577744,
+          "Average Latency": 240.9,
+          "Percentile 50.00": 321,
+          "Percentile 99.00": 803
+        },
+        "9": {
+          "Count": 1580592,
+          "Average Latency": 230.7,
+          "Percentile 50.00": 308,
+          "Percentile 99.00": 769
+        },
+        "10": {
+          "Count": 1596675,
+          "Average Latency": 228.6,
+          "Percentile 50.00": 305,
+          "Percentile 99.00": 762
+        },
+        "11": {
+          "Count": 1591638,
+          "Average Latency": 242.7,
+          "Percentile 50.00": 324,
+          "Percentile 99.00": 809
+        },
+        "12": {
+          "Count": 1570166,
+          "Average Latency": 236.4,
+          "Percentile 50.00": 315,
+          "Percentile 99.00": 788
+        },
+        "13": {
+          "Count": 1578808,
+          "Average Latency": 238.8,
+          "Percentile 50.00": 318,
+          "Percentile 99.00": 796
+        },
+        "14": {
+          "Count": 1581499,
+          "Average Latency": 227.7,
+          "Percentile 50.00": 304,
+          "Percentile 99.00": 759
+        },
+        "15": {
+          "Count": 1575851,
+          "Average Latency": 227.1,
+          "Percentile 50.00": 303,
+          "Percentile 99.00": 757
+        },
+        "16": {
+          "Count": 1571263,
+          "Average Latency": 238.5,
+          "Percentile 50.00": 318,
+          "Percentile 99.00": 795
+        },
+        "17": {
+          "Count": 1575192,
+          "Average Latency": 233.7,
+          "Percentile 50.00": 312,
+          "Percentile 99.00": 779
+        },
+        "18": {
+          "Count": 1588108,
+          "Average Latency": 227.4,
+          "Percentile 50.00": 303,
+          "Percentile 99.00": 758
+        },
+        "19": {
+          "Count": 1565623,
+          "Average Latency": 243.0,
+          "Percentile 50.00": 324,
+          "Percentile 99.00": 810
+        },
+        "20": {
+          "Count": 1582729,
+          "Average Latency": 237.6,
+          "Percentile 50.00": 317,
+          "Percentile 99.00": 792
+        },
+        "21": {
+          "Count": 1579094,
+          "Average Latency": 240.6,
+          "Percentile 50.00": 321,
+          "Percentile 99.00": 802
+        },
+        "22": {
+          "Count": 1565578,
+          "Average Latency": 227.7,
+          "Percentile 50.00": 304,
+          "Percentile 99.00": 759
+        },
+        "23": {
+          "Count": 1575607,
+          "Average Latency": 241.5,
+          "Percentile 50.00": 322,
+          "Percentile 99.00": 805
+        },
+        "24": {
+          "Count": 1584965,
+          "Average Latency": 227.1,
+          "Percentile 50.00": 303,
+          "Percentile 99.00": 757
+        },
+        "25": {
+          "Count": 1581392,
+          "Average Latency": 241.5,
+          "Percentile 50.00": 322,
+          "Percentile 99.00": 805
+        },
+        "26": {
+          "Count": 1567057,
+          "Average Latency": 234.3,
+          "Percentile 50.00": 312,
+          "Percentile 99.00": 781
+        },
+        "27": {
+          "Count": 1596522,
+          "Average Latency": 232.2,
+          "Percentile 50.00": 310,
+          "Percentile 99.00": 774
+        },
+        "28": {
+          "Count": 1590227,
+          "Average Latency": 236.1,
+          "Percentile 50.00": 315,
+          "Percentile 99.00": 787
+        },
+        "29": {
+          "Count": 1596094,
+          "Average Latency": 242.7,
+          "Percentile 50.00": 324,
+          "Percentile 99.00": 809
+        }
+      }
+    }
+  }
+}

--- a/.claude/skills/benchmark/evals/fixtures/df_4xl_write.json
+++ b/.claude/skills/benchmark/evals/fixtures/df_4xl_write.json
@@ -1,0 +1,203 @@
+{
+  "configuration": {
+    "server": "10.0.0.10",
+    "port": 6380,
+    "clients": 400,
+    "threads": 8,
+    "pipeline": 1,
+    "ratio": "1:0"
+  },
+  "ALL STATS": {
+    "Runtime": {
+      "Total duration": 30000
+    },
+    "Sets": {
+      "Count": 46849868,
+      "Average Latency": 183.9,
+      "Percentile 50.00": 245,
+      "Percentile 99.00": 635,
+      "Time-Serie": {
+        "0": {
+          "Count": 1555780,
+          "Average Latency": 187.5,
+          "Percentile 50.00": 250,
+          "Percentile 99.00": 625
+        },
+        "1": {
+          "Count": 1560570,
+          "Average Latency": 182.7,
+          "Percentile 50.00": 244,
+          "Percentile 99.00": 609
+        },
+        "2": {
+          "Count": 1551932,
+          "Average Latency": 183.6,
+          "Percentile 50.00": 245,
+          "Percentile 99.00": 612
+        },
+        "3": {
+          "Count": 1575300,
+          "Average Latency": 187.2,
+          "Percentile 50.00": 250,
+          "Percentile 99.00": 624
+        },
+        "4": {
+          "Count": 1558613,
+          "Average Latency": 189.9,
+          "Percentile 50.00": 253,
+          "Percentile 99.00": 633
+        },
+        "5": {
+          "Count": 1561744,
+          "Average Latency": 181.5,
+          "Percentile 50.00": 242,
+          "Percentile 99.00": 605
+        },
+        "6": {
+          "Count": 1565500,
+          "Average Latency": 184.5,
+          "Percentile 50.00": 246,
+          "Percentile 99.00": 615
+        },
+        "7": {
+          "Count": 1575128,
+          "Average Latency": 182.7,
+          "Percentile 50.00": 244,
+          "Percentile 99.00": 609
+        },
+        "8": {
+          "Count": 1560618,
+          "Average Latency": 182.7,
+          "Percentile 50.00": 244,
+          "Percentile 99.00": 609
+        },
+        "9": {
+          "Count": 1575531,
+          "Average Latency": 186.0,
+          "Percentile 50.00": 248,
+          "Percentile 99.00": 620
+        },
+        "10": {
+          "Count": 1563049,
+          "Average Latency": 181.8,
+          "Percentile 50.00": 242,
+          "Percentile 99.00": 606
+        },
+        "11": {
+          "Count": 1563954,
+          "Average Latency": 183.0,
+          "Percentile 50.00": 244,
+          "Percentile 99.00": 610
+        },
+        "12": {
+          "Count": 1563705,
+          "Average Latency": 182.1,
+          "Percentile 50.00": 243,
+          "Percentile 99.00": 607
+        },
+        "13": {
+          "Count": 1548561,
+          "Average Latency": 190.5,
+          "Percentile 50.00": 254,
+          "Percentile 99.00": 635
+        },
+        "14": {
+          "Count": 1561203,
+          "Average Latency": 186.0,
+          "Percentile 50.00": 248,
+          "Percentile 99.00": 620
+        },
+        "15": {
+          "Count": 1553493,
+          "Average Latency": 189.3,
+          "Percentile 50.00": 252,
+          "Percentile 99.00": 631
+        },
+        "16": {
+          "Count": 1548117,
+          "Average Latency": 190.5,
+          "Percentile 50.00": 254,
+          "Percentile 99.00": 635
+        },
+        "17": {
+          "Count": 1571975,
+          "Average Latency": 178.2,
+          "Percentile 50.00": 238,
+          "Percentile 99.00": 594
+        },
+        "18": {
+          "Count": 1553170,
+          "Average Latency": 183.6,
+          "Percentile 50.00": 245,
+          "Percentile 99.00": 612
+        },
+        "19": {
+          "Count": 1562204,
+          "Average Latency": 190.5,
+          "Percentile 50.00": 254,
+          "Percentile 99.00": 635
+        },
+        "20": {
+          "Count": 1569755,
+          "Average Latency": 188.7,
+          "Percentile 50.00": 252,
+          "Percentile 99.00": 629
+        },
+        "21": {
+          "Count": 1564694,
+          "Average Latency": 176.1,
+          "Percentile 50.00": 235,
+          "Percentile 99.00": 587
+        },
+        "22": {
+          "Count": 1557779,
+          "Average Latency": 175.8,
+          "Percentile 50.00": 234,
+          "Percentile 99.00": 586
+        },
+        "23": {
+          "Count": 1563550,
+          "Average Latency": 181.5,
+          "Percentile 50.00": 242,
+          "Percentile 99.00": 605
+        },
+        "24": {
+          "Count": 1564663,
+          "Average Latency": 174.9,
+          "Percentile 50.00": 233,
+          "Percentile 99.00": 583
+        },
+        "25": {
+          "Count": 1571528,
+          "Average Latency": 177.9,
+          "Percentile 50.00": 237,
+          "Percentile 99.00": 593
+        },
+        "26": {
+          "Count": 1551183,
+          "Average Latency": 174.9,
+          "Percentile 50.00": 233,
+          "Percentile 99.00": 583
+        },
+        "27": {
+          "Count": 1564808,
+          "Average Latency": 185.7,
+          "Percentile 50.00": 248,
+          "Percentile 99.00": 619
+        },
+        "28": {
+          "Count": 1555454,
+          "Average Latency": 187.8,
+          "Percentile 50.00": 250,
+          "Percentile 99.00": 626
+        },
+        "29": {
+          "Count": 1556307,
+          "Average Latency": 189.6,
+          "Percentile 50.00": 253,
+          "Percentile 99.00": 632
+        }
+      }
+    }
+  }
+}

--- a/.claude/skills/benchmark/evals/fixtures/valkey_2xl_info_memory.txt
+++ b/.claude/skills/benchmark/evals/fixtures/valkey_2xl_info_memory.txt
@@ -1,0 +1,10 @@
+# Memory
+used_memory:7450000000
+used_memory_human:7.45G
+used_memory_rss:8100000000
+used_memory_rss_human:8.10G
+used_memory_peak:7599000000
+maxmemory:0
+maxmemory_policy:noeviction
+mem_fragmentation_ratio:1.09
+mem_allocator:mimalloc

--- a/.claude/skills/benchmark/evals/fixtures/valkey_2xl_read.json
+++ b/.claude/skills/benchmark/evals/fixtures/valkey_2xl_read.json
@@ -1,0 +1,203 @@
+{
+  "configuration": {
+    "server": "10.0.0.10",
+    "port": 6380,
+    "clients": 400,
+    "threads": 8,
+    "pipeline": 1,
+    "ratio": "0:1"
+  },
+  "ALL STATS": {
+    "Runtime": {
+      "Total duration": 30000
+    },
+    "Gets": {
+      "Count": 24384570,
+      "Average Latency": 286.4,
+      "Percentile 50.00": 382,
+      "Percentile 99.00": 1007,
+      "Time-Serie": {
+        "0": {
+          "Count": 796838,
+          "Average Latency": 302.1,
+          "Percentile 50.00": 403,
+          "Percentile 99.00": 1007
+        },
+        "1": {
+          "Count": 804382,
+          "Average Latency": 281.4,
+          "Percentile 50.00": 375,
+          "Percentile 99.00": 938
+        },
+        "2": {
+          "Count": 803775,
+          "Average Latency": 281.7,
+          "Percentile 50.00": 376,
+          "Percentile 99.00": 939
+        },
+        "3": {
+          "Count": 816775,
+          "Average Latency": 301.2,
+          "Percentile 50.00": 402,
+          "Percentile 99.00": 1004
+        },
+        "4": {
+          "Count": 824695,
+          "Average Latency": 293.1,
+          "Percentile 50.00": 391,
+          "Percentile 99.00": 977
+        },
+        "5": {
+          "Count": 809416,
+          "Average Latency": 273.3,
+          "Percentile 50.00": 364,
+          "Percentile 99.00": 911
+        },
+        "6": {
+          "Count": 824110,
+          "Average Latency": 271.8,
+          "Percentile 50.00": 362,
+          "Percentile 99.00": 906
+        },
+        "7": {
+          "Count": 825641,
+          "Average Latency": 272.7,
+          "Percentile 50.00": 364,
+          "Percentile 99.00": 909
+        },
+        "8": {
+          "Count": 824650,
+          "Average Latency": 299.7,
+          "Percentile 50.00": 400,
+          "Percentile 99.00": 999
+        },
+        "9": {
+          "Count": 806939,
+          "Average Latency": 296.1,
+          "Percentile 50.00": 395,
+          "Percentile 99.00": 987
+        },
+        "10": {
+          "Count": 802613,
+          "Average Latency": 272.4,
+          "Percentile 50.00": 363,
+          "Percentile 99.00": 908
+        },
+        "11": {
+          "Count": 802805,
+          "Average Latency": 297.0,
+          "Percentile 50.00": 396,
+          "Percentile 99.00": 990
+        },
+        "12": {
+          "Count": 801901,
+          "Average Latency": 302.4,
+          "Percentile 50.00": 403,
+          "Percentile 99.00": 1008
+        },
+        "13": {
+          "Count": 802131,
+          "Average Latency": 290.7,
+          "Percentile 50.00": 388,
+          "Percentile 99.00": 969
+        },
+        "14": {
+          "Count": 814721,
+          "Average Latency": 279.9,
+          "Percentile 50.00": 373,
+          "Percentile 99.00": 933
+        },
+        "15": {
+          "Count": 823009,
+          "Average Latency": 286.8,
+          "Percentile 50.00": 382,
+          "Percentile 99.00": 956
+        },
+        "16": {
+          "Count": 821213,
+          "Average Latency": 271.8,
+          "Percentile 50.00": 362,
+          "Percentile 99.00": 906
+        },
+        "17": {
+          "Count": 810384,
+          "Average Latency": 267.6,
+          "Percentile 50.00": 357,
+          "Percentile 99.00": 892
+        },
+        "18": {
+          "Count": 815589,
+          "Average Latency": 302.1,
+          "Percentile 50.00": 403,
+          "Percentile 99.00": 1007
+        },
+        "19": {
+          "Count": 819989,
+          "Average Latency": 290.4,
+          "Percentile 50.00": 387,
+          "Percentile 99.00": 968
+        },
+        "20": {
+          "Count": 798543,
+          "Average Latency": 286.2,
+          "Percentile 50.00": 382,
+          "Percentile 99.00": 954
+        },
+        "21": {
+          "Count": 815817,
+          "Average Latency": 300.9,
+          "Percentile 50.00": 401,
+          "Percentile 99.00": 1003
+        },
+        "22": {
+          "Count": 823293,
+          "Average Latency": 282.9,
+          "Percentile 50.00": 377,
+          "Percentile 99.00": 943
+        },
+        "23": {
+          "Count": 819469,
+          "Average Latency": 298.5,
+          "Percentile 50.00": 398,
+          "Percentile 99.00": 995
+        },
+        "24": {
+          "Count": 818504,
+          "Average Latency": 297.0,
+          "Percentile 50.00": 396,
+          "Percentile 99.00": 990
+        },
+        "25": {
+          "Count": 810340,
+          "Average Latency": 274.8,
+          "Percentile 50.00": 366,
+          "Percentile 99.00": 916
+        },
+        "26": {
+          "Count": 801355,
+          "Average Latency": 276.3,
+          "Percentile 50.00": 368,
+          "Percentile 99.00": 921
+        },
+        "27": {
+          "Count": 819674,
+          "Average Latency": 277.8,
+          "Percentile 50.00": 370,
+          "Percentile 99.00": 926
+        },
+        "28": {
+          "Count": 805975,
+          "Average Latency": 275.7,
+          "Percentile 50.00": 368,
+          "Percentile 99.00": 919
+        },
+        "29": {
+          "Count": 820024,
+          "Average Latency": 288.3,
+          "Percentile 50.00": 384,
+          "Percentile 99.00": 961
+        }
+      }
+    }
+  }
+}

--- a/.claude/skills/benchmark/evals/fixtures/valkey_2xl_write.json
+++ b/.claude/skills/benchmark/evals/fixtures/valkey_2xl_write.json
@@ -1,0 +1,203 @@
+{
+  "configuration": {
+    "server": "10.0.0.10",
+    "port": 6380,
+    "clients": 400,
+    "threads": 8,
+    "pipeline": 1,
+    "ratio": "1:0"
+  },
+  "ALL STATS": {
+    "Runtime": {
+      "Total duration": 30000
+    },
+    "Sets": {
+      "Count": 16365001,
+      "Average Latency": 978.2,
+      "Percentile 50.00": 1304,
+      "Percentile 99.00": 3600,
+      "Time-Serie": {
+        "0": {
+          "Count": 597417,
+          "Average Latency": 909.3,
+          "Percentile 50.00": 1212,
+          "Percentile 99.00": 3031
+        },
+        "1": {
+          "Count": 594127,
+          "Average Latency": 836.4,
+          "Percentile 50.00": 1115,
+          "Percentile 99.00": 2788
+        },
+        "2": {
+          "Count": 583588,
+          "Average Latency": 827.1,
+          "Percentile 50.00": 1103,
+          "Percentile 99.00": 2757
+        },
+        "3": {
+          "Count": 592878,
+          "Average Latency": 945.6,
+          "Percentile 50.00": 1261,
+          "Percentile 99.00": 3152
+        },
+        "4": {
+          "Count": 575700,
+          "Average Latency": 902.1,
+          "Percentile 50.00": 1203,
+          "Percentile 99.00": 3007
+        },
+        "5": {
+          "Count": 572374,
+          "Average Latency": 863.7,
+          "Percentile 50.00": 1152,
+          "Percentile 99.00": 2879
+        },
+        "6": {
+          "Count": 572320,
+          "Average Latency": 918.6,
+          "Percentile 50.00": 1225,
+          "Percentile 99.00": 3062
+        },
+        "7": {
+          "Count": 567757,
+          "Average Latency": 863.7,
+          "Percentile 50.00": 1152,
+          "Percentile 99.00": 2879
+        },
+        "8": {
+          "Count": 568575,
+          "Average Latency": 931.2,
+          "Percentile 50.00": 1242,
+          "Percentile 99.00": 3104
+        },
+        "9": {
+          "Count": 558227,
+          "Average Latency": 992.4,
+          "Percentile 50.00": 1323,
+          "Percentile 99.00": 3308
+        },
+        "10": {
+          "Count": 553522,
+          "Average Latency": 985.8,
+          "Percentile 50.00": 1314,
+          "Percentile 99.00": 3286
+        },
+        "11": {
+          "Count": 553699,
+          "Average Latency": 972.9,
+          "Percentile 50.00": 1297,
+          "Percentile 99.00": 3243
+        },
+        "12": {
+          "Count": 549055,
+          "Average Latency": 928.2,
+          "Percentile 50.00": 1238,
+          "Percentile 99.00": 3094
+        },
+        "13": {
+          "Count": 551899,
+          "Average Latency": 948.0,
+          "Percentile 50.00": 1264,
+          "Percentile 99.00": 3160
+        },
+        "14": {
+          "Count": 540336,
+          "Average Latency": 931.2,
+          "Percentile 50.00": 1242,
+          "Percentile 99.00": 3104
+        },
+        "15": {
+          "Count": 557259,
+          "Average Latency": 1011.0,
+          "Percentile 50.00": 1348,
+          "Percentile 99.00": 3370
+        },
+        "16": {
+          "Count": 547565,
+          "Average Latency": 989.7,
+          "Percentile 50.00": 1320,
+          "Percentile 99.00": 3299
+        },
+        "17": {
+          "Count": 532944,
+          "Average Latency": 1026.3,
+          "Percentile 50.00": 1368,
+          "Percentile 99.00": 3421
+        },
+        "18": {
+          "Count": 531985,
+          "Average Latency": 979.8,
+          "Percentile 50.00": 1306,
+          "Percentile 99.00": 3266
+        },
+        "19": {
+          "Count": 530820,
+          "Average Latency": 974.1,
+          "Percentile 50.00": 1299,
+          "Percentile 99.00": 3247
+        },
+        "20": {
+          "Count": 527774,
+          "Average Latency": 1052.1,
+          "Percentile 50.00": 1403,
+          "Percentile 99.00": 3507
+        },
+        "21": {
+          "Count": 518534,
+          "Average Latency": 1080.0,
+          "Percentile 50.00": 1440,
+          "Percentile 99.00": 3600
+        },
+        "22": {
+          "Count": 532512,
+          "Average Latency": 1071.6,
+          "Percentile 50.00": 1429,
+          "Percentile 99.00": 3572
+        },
+        "23": {
+          "Count": 532524,
+          "Average Latency": 1073.1,
+          "Percentile 50.00": 1431,
+          "Percentile 99.00": 3577
+        },
+        "24": {
+          "Count": 516425,
+          "Average Latency": 1081.8,
+          "Percentile 50.00": 1442,
+          "Percentile 99.00": 3606
+        },
+        "25": {
+          "Count": 513405,
+          "Average Latency": 1079.7,
+          "Percentile 50.00": 1440,
+          "Percentile 99.00": 3599
+        },
+        "26": {
+          "Count": 500406,
+          "Average Latency": 1025.4,
+          "Percentile 50.00": 1367,
+          "Percentile 99.00": 3418
+        },
+        "27": {
+          "Count": 497349,
+          "Average Latency": 1067.4,
+          "Percentile 50.00": 1423,
+          "Percentile 99.00": 3558
+        },
+        "28": {
+          "Count": 499671,
+          "Average Latency": 1055.4,
+          "Percentile 50.00": 1407,
+          "Percentile 99.00": 3518
+        },
+        "29": {
+          "Count": 494354,
+          "Average Latency": 1023.3,
+          "Percentile 50.00": 1364,
+          "Percentile 99.00": 3411
+        }
+      }
+    }
+  }
+}

--- a/.claude/skills/benchmark/evals/fixtures/valkey_4xl_info_memory.txt
+++ b/.claude/skills/benchmark/evals/fixtures/valkey_4xl_info_memory.txt
@@ -1,0 +1,10 @@
+# Memory
+used_memory:12000000000
+used_memory_human:12.00G
+used_memory_rss:13120000000
+used_memory_rss_human:13.12G
+used_memory_peak:12240000000
+maxmemory:0
+maxmemory_policy:noeviction
+mem_fragmentation_ratio:1.09
+mem_allocator:mimalloc

--- a/.claude/skills/benchmark/evals/fixtures/valkey_4xl_read.json
+++ b/.claude/skills/benchmark/evals/fixtures/valkey_4xl_read.json
@@ -1,0 +1,203 @@
+{
+  "configuration": {
+    "server": "10.0.0.10",
+    "port": 6380,
+    "clients": 400,
+    "threads": 8,
+    "pipeline": 1,
+    "ratio": "0:1"
+  },
+  "ALL STATS": {
+    "Runtime": {
+      "Total duration": 30000
+    },
+    "Gets": {
+      "Count": 25233771,
+      "Average Latency": 348.6,
+      "Percentile 50.00": 465,
+      "Percentile 99.00": 1208,
+      "Time-Serie": {
+        "0": {
+          "Count": 837905,
+          "Average Latency": 362.4,
+          "Percentile 50.00": 483,
+          "Percentile 99.00": 1208
+        },
+        "1": {
+          "Count": 839410,
+          "Average Latency": 351.3,
+          "Percentile 50.00": 468,
+          "Percentile 99.00": 1171
+        },
+        "2": {
+          "Count": 828034,
+          "Average Latency": 355.8,
+          "Percentile 50.00": 474,
+          "Percentile 99.00": 1186
+        },
+        "3": {
+          "Count": 840212,
+          "Average Latency": 359.1,
+          "Percentile 50.00": 479,
+          "Percentile 99.00": 1197
+        },
+        "4": {
+          "Count": 843188,
+          "Average Latency": 330.9,
+          "Percentile 50.00": 441,
+          "Percentile 99.00": 1103
+        },
+        "5": {
+          "Count": 844088,
+          "Average Latency": 347.1,
+          "Percentile 50.00": 463,
+          "Percentile 99.00": 1157
+        },
+        "6": {
+          "Count": 834431,
+          "Average Latency": 346.2,
+          "Percentile 50.00": 462,
+          "Percentile 99.00": 1154
+        },
+        "7": {
+          "Count": 844151,
+          "Average Latency": 360.0,
+          "Percentile 50.00": 480,
+          "Percentile 99.00": 1200
+        },
+        "8": {
+          "Count": 828158,
+          "Average Latency": 358.8,
+          "Percentile 50.00": 478,
+          "Percentile 99.00": 1196
+        },
+        "9": {
+          "Count": 836453,
+          "Average Latency": 359.7,
+          "Percentile 50.00": 480,
+          "Percentile 99.00": 1199
+        },
+        "10": {
+          "Count": 830872,
+          "Average Latency": 349.5,
+          "Percentile 50.00": 466,
+          "Percentile 99.00": 1165
+        },
+        "11": {
+          "Count": 840784,
+          "Average Latency": 362.4,
+          "Percentile 50.00": 483,
+          "Percentile 99.00": 1208
+        },
+        "12": {
+          "Count": 829333,
+          "Average Latency": 353.7,
+          "Percentile 50.00": 472,
+          "Percentile 99.00": 1179
+        },
+        "13": {
+          "Count": 828719,
+          "Average Latency": 354.3,
+          "Percentile 50.00": 472,
+          "Percentile 99.00": 1181
+        },
+        "14": {
+          "Count": 837735,
+          "Average Latency": 334.8,
+          "Percentile 50.00": 446,
+          "Percentile 99.00": 1116
+        },
+        "15": {
+          "Count": 835449,
+          "Average Latency": 326.4,
+          "Percentile 50.00": 435,
+          "Percentile 99.00": 1088
+        },
+        "16": {
+          "Count": 846738,
+          "Average Latency": 330.6,
+          "Percentile 50.00": 441,
+          "Percentile 99.00": 1102
+        },
+        "17": {
+          "Count": 844934,
+          "Average Latency": 340.2,
+          "Percentile 50.00": 454,
+          "Percentile 99.00": 1134
+        },
+        "18": {
+          "Count": 852017,
+          "Average Latency": 329.4,
+          "Percentile 50.00": 439,
+          "Percentile 99.00": 1098
+        },
+        "19": {
+          "Count": 849041,
+          "Average Latency": 360.3,
+          "Percentile 50.00": 480,
+          "Percentile 99.00": 1201
+        },
+        "20": {
+          "Count": 850911,
+          "Average Latency": 348.6,
+          "Percentile 50.00": 465,
+          "Percentile 99.00": 1162
+        },
+        "21": {
+          "Count": 856130,
+          "Average Latency": 351.3,
+          "Percentile 50.00": 468,
+          "Percentile 99.00": 1171
+        },
+        "22": {
+          "Count": 840464,
+          "Average Latency": 351.3,
+          "Percentile 50.00": 468,
+          "Percentile 99.00": 1171
+        },
+        "23": {
+          "Count": 838436,
+          "Average Latency": 353.7,
+          "Percentile 50.00": 472,
+          "Percentile 99.00": 1179
+        },
+        "24": {
+          "Count": 859511,
+          "Average Latency": 345.6,
+          "Percentile 50.00": 461,
+          "Percentile 99.00": 1152
+        },
+        "25": {
+          "Count": 832782,
+          "Average Latency": 325.2,
+          "Percentile 50.00": 434,
+          "Percentile 99.00": 1084
+        },
+        "26": {
+          "Count": 851172,
+          "Average Latency": 358.5,
+          "Percentile 50.00": 478,
+          "Percentile 99.00": 1195
+        },
+        "27": {
+          "Count": 848583,
+          "Average Latency": 356.4,
+          "Percentile 50.00": 475,
+          "Percentile 99.00": 1188
+        },
+        "28": {
+          "Count": 829401,
+          "Average Latency": 346.2,
+          "Percentile 50.00": 462,
+          "Percentile 99.00": 1154
+        },
+        "29": {
+          "Count": 854729,
+          "Average Latency": 347.4,
+          "Percentile 50.00": 463,
+          "Percentile 99.00": 1158
+        }
+      }
+    }
+  }
+}

--- a/.claude/skills/benchmark/evals/fixtures/valkey_4xl_write.json
+++ b/.claude/skills/benchmark/evals/fixtures/valkey_4xl_write.json
@@ -1,0 +1,203 @@
+{
+  "configuration": {
+    "server": "10.0.0.10",
+    "port": 6380,
+    "clients": 400,
+    "threads": 8,
+    "pipeline": 1,
+    "ratio": "1:0"
+  },
+  "ALL STATS": {
+    "Runtime": {
+      "Total duration": 30000
+    },
+    "Sets": {
+      "Count": 17891646,
+      "Average Latency": 1273.1,
+      "Percentile 50.00": 1697,
+      "Percentile 99.00": 4763,
+      "Time-Serie": {
+        "0": {
+          "Count": 633500,
+          "Average Latency": 1197.9,
+          "Percentile 50.00": 1597,
+          "Percentile 99.00": 3993
+        },
+        "1": {
+          "Count": 626859,
+          "Average Latency": 1249.5,
+          "Percentile 50.00": 1666,
+          "Percentile 99.00": 4165
+        },
+        "2": {
+          "Count": 635236,
+          "Average Latency": 1160.7,
+          "Percentile 50.00": 1548,
+          "Percentile 99.00": 3869
+        },
+        "3": {
+          "Count": 624400,
+          "Average Latency": 1241.4,
+          "Percentile 50.00": 1655,
+          "Percentile 99.00": 4138
+        },
+        "4": {
+          "Count": 618030,
+          "Average Latency": 1229.7,
+          "Percentile 50.00": 1640,
+          "Percentile 99.00": 4099
+        },
+        "5": {
+          "Count": 616727,
+          "Average Latency": 1226.4,
+          "Percentile 50.00": 1635,
+          "Percentile 99.00": 4088
+        },
+        "6": {
+          "Count": 610858,
+          "Average Latency": 1199.1,
+          "Percentile 50.00": 1599,
+          "Percentile 99.00": 3997
+        },
+        "7": {
+          "Count": 612339,
+          "Average Latency": 1197.6,
+          "Percentile 50.00": 1597,
+          "Percentile 99.00": 3992
+        },
+        "8": {
+          "Count": 612666,
+          "Average Latency": 1161.0,
+          "Percentile 50.00": 1548,
+          "Percentile 99.00": 3870
+        },
+        "9": {
+          "Count": 609712,
+          "Average Latency": 1179.6,
+          "Percentile 50.00": 1573,
+          "Percentile 99.00": 3932
+        },
+        "10": {
+          "Count": 619679,
+          "Average Latency": 1177.8,
+          "Percentile 50.00": 1570,
+          "Percentile 99.00": 3926
+        },
+        "11": {
+          "Count": 603774,
+          "Average Latency": 1285.5,
+          "Percentile 50.00": 1714,
+          "Percentile 99.00": 4285
+        },
+        "12": {
+          "Count": 606899,
+          "Average Latency": 1220.1,
+          "Percentile 50.00": 1627,
+          "Percentile 99.00": 4067
+        },
+        "13": {
+          "Count": 595119,
+          "Average Latency": 1213.5,
+          "Percentile 50.00": 1618,
+          "Percentile 99.00": 4045
+        },
+        "14": {
+          "Count": 597095,
+          "Average Latency": 1209.0,
+          "Percentile 50.00": 1612,
+          "Percentile 99.00": 4030
+        },
+        "15": {
+          "Count": 585129,
+          "Average Latency": 1329.6,
+          "Percentile 50.00": 1773,
+          "Percentile 99.00": 4432
+        },
+        "16": {
+          "Count": 588874,
+          "Average Latency": 1341.3,
+          "Percentile 50.00": 1788,
+          "Percentile 99.00": 4471
+        },
+        "17": {
+          "Count": 579533,
+          "Average Latency": 1318.5,
+          "Percentile 50.00": 1758,
+          "Percentile 99.00": 4395
+        },
+        "18": {
+          "Count": 596871,
+          "Average Latency": 1267.5,
+          "Percentile 50.00": 1690,
+          "Percentile 99.00": 4225
+        },
+        "19": {
+          "Count": 589015,
+          "Average Latency": 1268.7,
+          "Percentile 50.00": 1692,
+          "Percentile 99.00": 4229
+        },
+        "20": {
+          "Count": 576132,
+          "Average Latency": 1283.7,
+          "Percentile 50.00": 1712,
+          "Percentile 99.00": 4279
+        },
+        "21": {
+          "Count": 581362,
+          "Average Latency": 1315.8,
+          "Percentile 50.00": 1754,
+          "Percentile 99.00": 4386
+        },
+        "22": {
+          "Count": 591480,
+          "Average Latency": 1277.7,
+          "Percentile 50.00": 1704,
+          "Percentile 99.00": 4259
+        },
+        "23": {
+          "Count": 565527,
+          "Average Latency": 1328.4,
+          "Percentile 50.00": 1771,
+          "Percentile 99.00": 4428
+        },
+        "24": {
+          "Count": 582722,
+          "Average Latency": 1308.0,
+          "Percentile 50.00": 1744,
+          "Percentile 99.00": 4360
+        },
+        "25": {
+          "Count": 569135,
+          "Average Latency": 1420.2,
+          "Percentile 50.00": 1894,
+          "Percentile 99.00": 4734
+        },
+        "26": {
+          "Count": 568135,
+          "Average Latency": 1428.9,
+          "Percentile 50.00": 1905,
+          "Percentile 99.00": 4763
+        },
+        "27": {
+          "Count": 574886,
+          "Average Latency": 1372.5,
+          "Percentile 50.00": 1830,
+          "Percentile 99.00": 4575
+        },
+        "28": {
+          "Count": 559765,
+          "Average Latency": 1334.4,
+          "Percentile 50.00": 1779,
+          "Percentile 99.00": 4448
+        },
+        "29": {
+          "Count": 560187,
+          "Average Latency": 1449.6,
+          "Percentile 50.00": 1933,
+          "Percentile 99.00": 4832
+        }
+      }
+    }
+  }
+}

--- a/.claude/skills/benchmark/references/report-template.md
+++ b/.claude/skills/benchmark/references/report-template.md
@@ -36,7 +36,7 @@ OS: <distro + kernel>. Network tuning: <applied / none — one line on what>.
 Write command:
 
     ./dfly_bench -n $N -p 6380 --qps=0 -d 64 --key_maximum=$KMAX -c $CONN \
-        --command "setex __key__ 10000 __data__"
+        --pipeline 30 --command "setex __key__ 10000 __data__"
 
 Read command:
 

--- a/.claude/skills/benchmark/references/report-template.md
+++ b/.claude/skills/benchmark/references/report-template.md
@@ -1,0 +1,127 @@
+# Report template
+
+The report mirrors the team's published benchmark format. Structure matters: a
+reader scans the conditions, jumps to the TLDR for the takeaways, checks the
+per-instance tables for numbers, and uses the appendix to reproduce. Follow this
+shape.
+
+Use Markdown tables. Center-align numeric columns (`:---:`). Bold the winning
+datastore in comparison tables when there's a clear winner.
+
+## Structure
+
+```markdown
+# <Title> — e.g. "Comparing Dragonfly vs Valkey on AWS"
+
+<1–2 sentences: what was compared, on what hardware, what workloads.>
+
+## Conditions
+
+Dragonfly launch command (identical across all configs):
+
+    ./dragonfly --conn_use_incoming_cpu --dbfilename= --logtostderr --port 6380
+
+<Comparison target> launch command:
+
+    docker run --network=host --rm valkey/valkey:9.0 --save "" --appendonly no \
+        --io-threads 8 --protected-mode no --port 6380
+
+Instances: <server types + CPU counts>, client on <client instance type>.
+OS: <distro + kernel>. Network tuning: <applied / none — one line on what>.
+
+## <Use-case name> — e.g. "Simple Strings"
+
+<1–2 sentences describing the workload and why it matters.>
+
+Write command:
+
+    ./dfly_bench -n $N -p 6380 --qps=0 -d 64 --key_maximum=$KMAX -c $CONN \
+        --command "setex __key__ 10000 __data__"
+
+Read command:
+
+    ./dfly_bench -n $N -p 6380 --qps=0 -d 64 --key_maximum=$KMAX -c $CONN --ratio 0:1
+
+### TLDR
+
+* **<Datastore>** <the genuinely important takeaway — scaling, efficiency, a surprise>.
+* <3–5 bullets total. Interpretation, not a restatement of the tables.>
+
+## <Instance type> — e.g. "m7g.2xlarge"
+
+<Optional: one sentence on anything notable, e.g. throughput stability over time.>
+
+![Write throughput over time](charts/write_m7g2xl.png)
+
+### QPS and memory
+
+| Metric | Dragonfly | Valkey |
+| ----- | :---: | :---: |
+| Write QPS (k) | 816 | 548 |
+| Read QPS (k) | 848 | 811 |
+| Memory / entry — logical (bytes) | 127 | 149 |
+| Memory / entry — RSS (bytes) | 138 | 162 |
+
+### Latency
+
+| Backend | Write P99 (us) | Read P99 (us) |
+| :---: | :---: | :---: |
+| **Dragonfly** | 787 | 887 |
+| **Valkey** | 3283 | 951 |
+
+<Repeat the per-instance block for each instance type tested.>
+
+## Appendix — raw data
+
+### Environment
+
+| Property | Server | Client |
+| --- | --- | --- |
+| Instance type | m7g.2xlarge | c7gn.4xlarge |
+| vCPUs | 8 | 16 |
+| OS / kernel | Ubuntu 24.04.2 / 6.8.0 | ... |
+| Dragonfly version | <git hash / release> | — |
+| Network tuning | IRQ SMP affinity spread across CPUs | — |
+
+### Exact commands
+
+<Every command line actually run, per phase and per datastore, verbatim —
+including the launch commands, write/read load commands, and any tuning steps.>
+
+### Raw output
+
+<Per run: the final dfly_bench/memtier summary + latency histogram, and a
+reference to the saved JSON file (df_write.json, etc.). Include INFO memory
+snapshots used for the per-entry figures.>
+```
+
+## Notes on writing the TLDR
+
+The TLDR is the part people actually read. Make each bullet a claim the data
+supports, phrased as a takeaway:
+
+- Good: "Dragonfly scales vertically with cores and sustains up to 10x the
+  throughput of a single Valkey process on large instances."
+- Weak: "Dragonfly had higher QPS." (just restates the table)
+
+Call out hardware surprises honestly — e.g. an instance type that didn't scale
+linearly — because they affect how a reader should interpret the numbers. If a
+run was client-bound or otherwise caveated, say so here rather than burying it.
+
+## Charts
+
+One chart per instance per phase is usually enough: QPS-over-time, with one line
+per datastore. The visual story is throughput *stability* — Dragonfly holding a
+flat line while a competitor degrades as its table grows is more convincing than
+a single aggregate number. Generate with `scripts/make_charts.py` from the load
+generator's time-series JSON, save under a `charts/` dir next to the report, and
+embed with relative paths.
+
+When the monitoring stack ran (Phase 4), the Grafana dashboards add server-side
+panels that the load generator can't show — memory growth over the write phase,
+per-shard CPU, host network saturation. Crop the Grafana time range to the run
+window and pull the relevant panels (rendered PNG or screenshot) into the
+per-instance section. These are especially good for the memory-efficiency story
+and for proving the server (not the client) was the bottleneck. Note in the
+appendix that the data came from the monitoring stack, and which scrape port was
+used.

--- a/.claude/skills/benchmark/references/report-template.md
+++ b/.claude/skills/benchmark/references/report-template.md
@@ -36,7 +36,7 @@ OS: <distro + kernel>. Network tuning: <applied / none — one line on what>.
 Write command:
 
     ./dfly_bench -n $N -p 6380 --qps=0 -d 64 --key_maximum=$KMAX -c $CONN \
-        --pipeline 30 --command "setex __key__ 10000 __data__"
+        --pipeline 30 --ratio 1:0 --json_out_file df_write.json
 
 Read command:
 

--- a/.claude/skills/benchmark/references/running-benchmarks.md
+++ b/.claude/skills/benchmark/references/running-benchmarks.md
@@ -259,14 +259,14 @@ with a memory snapshot in between.
 
 ```bash
 ./dfly_bench -h <server> -p 6380 --qps=0 -d 64 --key_maximum=$KMAX -c $CONN \
-    --pipeline 30 -n $N --json_out_file df_write.json --command "setex __key__ 10000 __data__"
+    --pipeline 30 -n $N --ratio 1:0 --json_out_file df_write.json
 ```
 
-Note: with `--command`, `--json_out_file` is ignored — for the canonical strings
-test use the built-in SET path (`--ratio 1:0`) instead if you need the JSON/time
-series, and reserve `--command "setex ..."` for when TTLs matter. For SETEX,
-save stdout and parse/chart the periodic `RPS(now/agg)` lines or
-`monitor_fill.sh` output.
+The canonical strings test uses the built-in SET path (`--ratio 1:0`) so it
+produces the JSON/time series the charts need. If TTLs matter, swap in
+`--command "setex __key__ 10000 __data__"` — but note `--json_out_file` is then
+ignored, so for SETEX save stdout and parse/chart the periodic `RPS(now/agg)`
+lines or `monitor_fill.sh` output instead.
 
 **Memory snapshot** (immediately after writes — see next section).
 

--- a/.claude/skills/benchmark/references/running-benchmarks.md
+++ b/.claude/skills/benchmark/references/running-benchmarks.md
@@ -1,0 +1,552 @@
+# Running benchmarks — operational reference
+
+How to prepare instances, start servers, drive the load generators, and measure
+memory. Read the section you need; you don't have to read top-to-bottom.
+
+## Table of contents
+
+- [Instance preparation](#instance-preparation)
+- [Starting Dragonfly](#starting-dragonfly)
+- [Starting Valkey / Redis for comparison](#starting-valkey--redis-for-comparison)
+- [dfly_bench (default load generator)](#dfly_bench-default-load-generator)
+- [memtier_benchmark (alternative)](#memtier_benchmark-alternative)
+- [The standard strings workload](#the-standard-strings-workload)
+- [Measuring memory](#measuring-memory)
+- [Monitoring stack (Prometheus + Grafana)](#monitoring-stack-prometheus--grafana)
+- [Network tuning](#network-tuning)
+- [Sizing the load](#sizing-the-load)
+
+---
+
+## Instance preparation
+
+The server and the load generator should live on **separate machines**. A
+client co-located with the server competes for CPU and silently caps the
+numbers — the report is then measuring the client, not the server.
+
+Remote instances usually already have the repo at `~/projects/dragonfly`. Check
+first; clone only if missing:
+
+```bash
+ssh <host> 'test -d ~/projects/dragonfly && echo present || echo missing'
+# if missing:
+ssh <host> 'git clone https://github.com/dragonflydb/dragonfly.git ~/projects/dragonfly'
+```
+
+**Look for prebuilt binaries first.** Before building or downloading, check the
+repo's build output folders — the binary is often already there. Look in
+`build-opt/` and `build-release/` (and `build-dbg/` only as a last resort — debug
+builds give meaningless performance numbers):
+
+```bash
+ssh <host> 'ls -la ~/projects/dragonfly/build-opt/{dragonfly,dragonfly-aarch64,dfly_bench} 2>/dev/null; \
+            ls -la ~/projects/dragonfly/build-release/{dragonfly,dfly_bench} 2>/dev/null'
+```
+
+A folder may hold several binaries — e.g. a locally-built `dragonfly` (dev/HEAD)
+alongside a downloaded release `dragonfly-aarch64`; check `--version` on each to
+know which is which, since "compare the prebuilt vs the release binary" is a
+common request. The load generator (`dfly_bench`) lives in the same folder on the
+client.
+
+**Build vs download** — if no suitable prebuilt binary exists, follow the user's
+instruction. To build a release binary from source on the instance:
+
+```bash
+ssh <host> 'cd ~/projects/dragonfly && ./helio/blaze.sh -release -DWITH_AWS=OFF -DWITH_GCP=OFF'
+ssh <host> 'cd ~/projects/dragonfly/build-opt && ninja dragonfly dfly_bench'
+```
+
+This yields `build-opt/dragonfly` (the server) and `build-opt/dfly_bench` (the
+load generator). Build `dfly_bench` on the **client** box and `dragonfly` on the
+**server** box. Always benchmark release builds — a debug build's numbers are
+meaningless for performance claims.
+
+If the user prefers a published release, download the tarball from GitHub
+releases and extract it instead of building.
+
+Sanity-check reachability from the client before a long run:
+
+```bash
+redis-cli -h <server-ip> -p 6380 ping   # expect PONG
+```
+
+Collect environment facts for the report while you're on the box:
+
+```bash
+ssh <host> 'nproc; uname -r; cat /etc/os-release | head -2'
+# cloud instance type, if on AWS:
+ssh <host> 'curl -s http://169.254.169.254/latest/meta-data/instance-type'
+```
+
+---
+
+## Starting Dragonfly
+
+The published comparisons run Dragonfly with a minimal, persistence-free config
+so the benchmark measures the data path, not disk:
+
+```bash
+./dragonfly --conn_use_incoming_cpu --dbfilename= --logtostderr --port 6380
+```
+
+- `--conn_use_incoming_cpu` — pin each connection's processing to the CPU that
+  received it; improves locality under high connection counts.
+- `--dbfilename=` — disable snapshot loading/saving.
+
+Let Dragonfly use all cores by default (it auto-detects). Record the exact
+launch command for the appendix.
+
+**Start it so you can reliably stop it — capture the PID.** Launching under
+`tmux`/`nohup` is fine, but `tmux kill-session` does **not** reliably reap the
+server, and a stale server is a trap: a "fresh" server silently fails to bind the
+port, your client reconnects to the *old* instance, and you measure stale data
+(and waste the old dataset's RAM). Always record the PID and kill by PID:
+
+```bash
+ssh <server> 'cd ~/projects/dragonfly/build-opt; \
+   nohup ./dragonfly --conn_use_incoming_cpu --dbfilename= --logtostderr --port 6380 \
+       >/tmp/dfly.log 2>&1 & echo $! > /tmp/dfly.pid'
+# ... benchmark ...
+# Stop it and VERIFY it's gone before starting the next binary:
+ssh <server> 'kill -9 $(cat /tmp/dfly.pid); sleep 3; \
+   pgrep -af dragonfly | grep -v "pgrep\|bash -c" || echo "stopped"; \
+   redis-cli -p 6380 ping 2>&1 | head -1   # expect Connection refused'
+```
+
+Between two binaries (e.g. prebuilt vs release), **fully stop and verify the
+first is dead and the port is free before starting the second** — otherwise the
+second never binds and you benchmark the first twice. Note that pattern-based
+`pkill -f` can miss a process whose cmdline is the relative `./dragonfly`; killing
+by the captured PID is the robust path.
+
+---
+
+## Starting Valkey / Redis for comparison
+
+Run via docker on the server box. Valkey does not scale past ~8 io-threads on
+current hardware, so more than that rarely helps — note the thread count you
+used.
+
+```bash
+docker run --network=host --rm valkey/valkey:9.0 \
+    --save "" --appendonly no --io-threads 8 --protected-mode no --port 6380
+```
+
+For Redis, substitute the `redis` image and equivalent flags. Run the comparison
+target on the **same instance type** as Dragonfly, one at a time (not
+simultaneously — they'd contend), so the comparison is apples-to-apples.
+
+---
+
+## dfly_bench (default load generator)
+
+Source: `src/server/dfly_bench.cc`. Key flags:
+
+| Flag | Meaning | Typical |
+| --- | --- | --- |
+| `-h` | server host | client→server IP |
+| `-p` | server port | `6380` |
+| `-c` | connections **per thread** | ~10; ≤25 max; 1–5 when pipelining |
+| `-n` | requests per connection | sizes the run (omit if `--test_time`) |
+| `--test_time` | run duration in seconds | e.g. `120` |
+| `--qps` | target QPS per connection; `0` = unthrottled | `0` for peak |
+| `-d` | value size in bytes | `64` for strings tests |
+| `--key_maximum` | size of key space | tune to fill memory |
+| `--key_dist` | `U` uniform, `N` normal, `Z` zipfian, `S` sequential | `U` default |
+| `--ratio` | set:get ratio | `1:0` writes, `0:1` reads |
+| `--command` | custom command template (`__key__`, `__data__`) | for non-string workloads |
+| `--pipeline` | pending requests per connection | `>1` for peak throughput |
+| `-P` | `memcache_text` for memcached protocol | empty for RESP |
+| `--json_out_file` | **memtier-compatible JSON with per-second time series** | always set it |
+
+`--json_out_file` only works with the built-in GET/SET workload (not with
+`--command`, `--noreply`, or `--connect_only`). For custom-command workloads you
+scrape the console summary instead.
+
+**Console output.** Periodic lines look like:
+
+```
+12s: 40.0% done, RPS(now/agg): 815000/812340, errs: 0, hitrate: 99.8%, clients: 200
+```
+
+and the final summary:
+
+```
+Total time: 30s. Overall number of requests: 24370200, QPS: 812340, P99 lat: 787us
+Latency summary, all times are in usec:
+<histogram>
+```
+
+Save the full stdout — the histogram and final QPS go in the appendix; the
+`collect_metrics.py` script prefers the JSON but can fall back to this.
+
+Also save the command lines themselves under the run output directory, e.g.
+`commands_audit.log`. Record setup, server launch, write/read load,
+capture, diagnostics, and chart/report commands as they are run; stdout alone is
+not raw data because it cannot reproduce the run. Initialize this file before
+the first workload so planned script invocations are visible up front, then
+append commands as they execute.
+
+**Use the skill scripts for the main run path.** The main benchmark phases should
+use:
+
+```bash
+.claude/skills/benchmark/scripts/bench_server.sh start|start-docker|stop|stop-docker|status ...
+.claude/skills/benchmark/scripts/monitor_fill.sh ...
+.claude/skills/benchmark/scripts/capture_result.sh ...
+.claude/skills/benchmark/scripts/collect_metrics.py ...
+.claude/skills/benchmark/scripts/make_charts.py ...
+.claude/skills/benchmark/scripts/plot_fill.py ...
+```
+
+Inline SSH is acceptable for discovery, package/setup checks, bounded
+foreground probes, and diagnostics. If you bypass a run-control script for a
+main benchmark phase, record the reason in `commands_audit.log` and the appendix before
+running the manual equivalent.
+
+**Keep orchestration phase-separated.** Do not run a single local shell command
+that starts a remote tmux benchmark, polls until completion, captures results,
+and starts the next phase. If the local command is interrupted, the remote tmux
+process can finish while the local capture logic is gone, leaving the run idle
+and uncaptured. Prefer bounded foreground `dfly_bench` commands for known-length
+runs. If you need tmux/nohup for a long fill, use separate steps: launch it,
+monitor it, verify it has exited, then run the capture/read commands separately.
+
+**JSON structure** (`--json_out_file`):
+
+```json
+{
+  "configuration": { "server": "...", "port": 6380, "clients": 200,
+                      "threads": 8, "pipeline": 1, "ratio": "1:0" },
+  "ALL STATS": {
+    "Runtime": { "Total duration": 30000 },
+    "Sets": { "Count": ..., "Average Latency": ..., "Percentile ...": ...,
+              "Time-Serie": { "0": {...}, "1": {...}, ... } },
+    "Gets": { ... }
+  }
+}
+```
+
+The per-second `Time-Serie` buckets are what the charts plot.
+
+---
+
+## memtier_benchmark (alternative)
+
+Industry-standard, available as a docker image (`redislabs/memtier_benchmark`).
+Use it when the user wants cross-validation against a tool Dragonfly doesn't
+ship, or for the pipelined peak-throughput use-case. Example (from the repo's
+k8s job):
+
+```bash
+memtier_benchmark -s <server> -p 6380 \
+    --pipeline=30 --key-maximum=100000 -c 10 -t 2 --test-time=120 \
+    --distinct-client-seed --hide-histogram --json-out-file memtier_out.json
+```
+
+`--json-out-file` produces the same shape `collect_metrics.py` and
+`make_charts.py` read.
+
+---
+
+## The standard strings workload
+
+This reproduces the published "Simple Strings" comparison. Run write then read,
+with a memory snapshot in between.
+
+**Write phase** (load the keyspace):
+
+```bash
+./dfly_bench -h <server> -p 6380 --qps=0 -d 64 --key_maximum=$KMAX -c $CONN \
+    --pipeline 30 -n $N --json_out_file df_write.json --command "setex __key__ 10000 __data__"
+```
+
+Note: with `--command`, `--json_out_file` is ignored — for the canonical strings
+test use the built-in SET path (`--ratio 1:0`) instead if you need the JSON/time
+series, and reserve `--command "setex ..."` for when TTLs matter. For SETEX,
+save stdout and parse/chart the periodic `RPS(now/agg)` lines or
+`monitor_fill.sh` output.
+
+**Memory snapshot** (immediately after writes — see next section).
+
+**Read phase**:
+
+```bash
+./dfly_bench -h <server> -p 6380 --qps=0 -d 64 --key_maximum=$KMAX -c $CONN \
+    -n $N --ratio 0:1 --json_out_file df_read.json
+```
+
+Choose `KMAX`, `N`, and `CONN` to (a) saturate the server and (b) load enough
+data that instance memory is well utilized — see [Sizing the load](#sizing-the-load).
+
+---
+
+## Measuring memory
+
+"Bytes per entry" is the memory metric in the report. Capture it right after the
+write phase, before reads:
+
+```bash
+redis-cli -h <server> -p 6380 INFO memory > info_memory.txt
+redis-cli -h <server> -p 6380 DBSIZE
+```
+
+From `INFO memory` you need `used_memory` (logical) and `used_memory_rss`
+(physical resident set). Report **both** per-entry figures:
+
+- `used_memory / DBSIZE` — logical bytes per entry (matches the published
+  "Memory Per Entry").
+- `used_memory_rss / DBSIZE` — physical bytes per entry, the real footprint
+  including allocator overhead and fragmentation.
+
+`collect_metrics.py` computes both when given `--info` and `--dbsize`.
+
+For Valkey/Redis the same `INFO memory` fields exist, so the comparison is
+direct. Capture the snapshot at the **same keyspace size** for both, or the
+per-entry comparison is unfair.
+
+---
+
+## Monitoring stack (Prometheus + Grafana)
+
+Lives in `tools/local/monitoring/` and runs on the **server** machine via docker
+compose. It gives continuous, 1-second-resolution time series for the whole
+benchmark window — server-side command rates and memory, plus host CPU/network
+from node-exporter — which is both a sanity check (was the server actually
+saturated? did it swap?) and the source of the report's best charts.
+
+```bash
+cd ~/projects/dragonfly/tools/local/monitoring
+docker compose up -d                      # Prometheus, Grafana, node-exporter
+docker compose --profile redis up -d      # also start redis-exporter for Valkey/Redis
+```
+
+Endpoints (on the server box): Prometheus `:9090`, Grafana `:3000`,
+node-exporter `:9100`, redis-exporter `:9121`.
+
+**What gets scraped:**
+
+- `dragonfly` job — Dragonfly exposes Prometheus metrics directly at
+  `/metrics` on its main port. The bundled `prometheus.yml` targets
+  `host.docker.internal:6379`.
+- `node-exporter` job — host CPU, memory, network.
+- `redis-exporter` job (profile `redis`) — Valkey/Redis stats, also via
+  `host.docker.internal:6379`.
+
+**Port — standardize on 6380.** Always run benchmarked servers (Dragonfly,
+Valkey, Redis) on port `6380`. The shipped `prometheus.yml` targets `6379`, so
+before bringing the stack up, edit the `dragonfly` and `redis-exporter` jobs in
+`tools/local/monitoring/prometheus/prometheus.yml` to point at `:6380`:
+
+```bash
+sed -i 's/:6379/:6380/g' ~/projects/dragonfly/tools/local/monitoring/prometheus/prometheus.yml
+# if Prometheus is already up, pick up the change:
+docker compose restart prometheus
+```
+
+Then confirm targets are `UP` at `http://<server>:9090/targets` before starting
+load — otherwise Prometheus silently collects nothing for the server.
+
+**Dashboards** are pre-provisioned in Grafana (`dragonfly.json`, `redis.json`,
+`node-exporter.json`) — no manual import. For the report, note the benchmark
+start/end timestamps so you can crop the Grafana time range to the exact run,
+then capture the relevant panels (throughput, memory, CPU) — via the provisioned
+`grafana-image-renderer` (the compose file includes a `renderer` service) or a
+screenshot — and embed them. You can also query Prometheus directly over HTTP
+(`/api/v1/query_range`) if you want raw series for `make_charts.py`.
+
+Leave the stack up across all runs so one continuous window covers everything.
+
+## Network tuning
+
+On cloud hardware, peak throughput is gated by how network-interrupt load is
+spread across CPUs. The published runs tuned **SMP affinity for IRQs** so the
+NIC's interrupts fan out across multiple cores instead of saturating one.
+
+This is instance- and NIC-specific. The general approach: identify the NIC's IRQs
+(`/proc/interrupts`), then write CPU masks to `/proc/irq/<N>/smp_affinity` to
+spread them. Many setups use the kernel's `set_irq_affinity.sh` helper shipped
+with the NIC driver. Because the exact steps depend on the instance, confirm the
+approach with the user if they want tuning, and **record the exact commands you
+ran** — tuned and untuned numbers are not comparable, and the appendix must say
+which was used.
+
+If you skip tuning, state that plainly in the report.
+
+---
+
+## Sizing the load
+
+Two independent things to size: **how many keys** (sets the memory footprint)
+and **how long / how many requests** (sets steady-state and how full memory
+gets). Get these wrong in either direction and the benchmark is misleading.
+
+### The memory budget — the most important (and most dangerous) call
+
+A write benchmark must land in the **sweet spot between two failure modes**:
+
+- **Too few keys → wrong-but-safe.** Benchmarking a nearly-empty instance is
+  not representative. A small dataset sits in CPU cache and hides the real cost
+  of a large hash table (cache misses, allocator behavior, fragmentation). The
+  QPS looks great and means nothing. *Using available memory is the whole
+  point.*
+- **Too many keys → OOM or eviction.** Push too far and the run is ruined two
+  different ways (see the two ceilings below). Either way the numbers are
+  garbage.
+
+**There are TWO ceilings, not one. Stay under both.**
+
+1. **Dragonfly's `maxmemory`.** Dragonfly auto-sets `maxmemory` to a fraction of
+   RAM (≈ 78–80% by default). When memory crosses it, Dragonfly **rejects or
+   evicts** writes — the load generator reports *error responses* and the run is
+   contaminated. **Check it before the run** (`redis-cli -p 6380 config get
+   maxmemory`, or the `maxmemory:` line in `INFO memory`).
+
+   **Rejections start with a margin *below* `maxmemory`, not at it.** During a
+   write, dash-table resizes transiently spike memory, so Dragonfly begins
+   rejecting while steady-state `used_memory` is still well under the cap —
+   observed rejections at `used_memory` ≈ 90% of `maxmemory` and even lower at the
+   moment of a big resize. So keep steady-state `used_memory` to **≤ ~80% of
+   `maxmemory`** to leave room for these spikes. If you need to fill more, raise
+   `--maxmemory` explicitly — but then ceiling #2 (host RAM) binds.
+
+   **Zero errors is the pass/fail bar.** *Any* eviction/OOM error contaminates
+   the experiment — it slows the run (rejection stalls inflate P99) and stops the
+   keyspace from growing, so QPS, latency, and bytes-per-entry are all off. After
+   every write, **verify the load generator reported zero errors**
+   (`grep -i error <write.log>`; dfly_bench prints `Got N error responses!`). If
+   N > 0, the run is **invalid** — discard it, cut `--key_maximum` (start with a
+   ~10–15% reduction), and re-run until errors are zero. Don't report a run with
+   any errors, and don't try to "subtract" them out.
+2. **Host physical RAM, measured by RSS.** The accurate measure of real memory
+   pressure is **resident set size — `used_memory_rss`** (equivalently the
+   process RSS). True OOM happens when RSS approaches host RAM. Do **not** panic
+   over `free`'s `used`/`available` columns during a write: a high-rate write
+   inflates **page cache** (clean, reclaimable) and dirty pages, which makes
+   `available` dip alarmingly even though the kernel will reclaim it under
+   pressure. On a 30 GiB box a 195M-key dataset showed `free` available dropping
+   to ~10% while `used_memory_rss` was only ~21 GiB (71% of RAM) — the dataset
+   was nowhere near OOM; the rest was reclaimable cache. **Track RSS, keep it
+   below host RAM with a ≥5% margin**, and ignore page-cache noise.
+
+**So size against RSS.** Target the dataset's RSS up to your fill goal while
+keeping a real margin, and stay under `maxmemory`:
+
+```
+target_rss     = host_RAM * fill_fraction      # e.g. 0.90 for "fill 90%", never > 0.95
+rss_per_entry  = used_memory_rss / DBSIZE        # from calibration (accurate)
+key_for_host   = target_rss / rss_per_entry
+key_for_maxmem = 0.90 * maxmemory / used_memory_per_entry   # avoid eviction
+target_keys    = min(key_for_host, key_for_maxmem)
+--key_maximum  = target_keys
+```
+
+The usual binding constraint is **`maxmemory`**, since its default (~78% of RAM)
+is below a 90% fill target. **To genuinely fill 90% of RAM, raise `--maxmemory`
+explicitly** (e.g. `--maxmemory 28gb` on a 30 GiB box) so Dragonfly doesn't evict
+before RSS reaches the target — then RSS, watched live, is the safety signal.
+Filling memory is the goal; the failure modes to avoid are eviction (used_memory
+> maxmemory) and RSS approaching host RAM.
+
+`*_per_entry` (≈ `value_size + 60–100 B` overhead for small strings; more for
+TTL'd keys and other types) is best **calibrated**, not guessed:
+
+1. Run a short pilot write inserting a known, modest number of distinct keys
+   (e.g. `--key_maximum=5000000 --key_dist S` with enough requests to write them
+   all).
+2. Read `used_memory` / `DBSIZE` → real `bytes_per_entry`. Note this slightly
+   *under*-estimates at scale (fragmentation grows), so keep margin.
+3. Plug into the formula above for the full run.
+
+Calibrate **per datastore** — Dragonfly and Valkey have different per-entry
+overhead, which is exactly what the report measures. Size each so its dataset
+fills the same target fraction; comparing at the same `DBSIZE` keeps the
+bytes-per-entry comparison fair (Dragonfly will simply use less RAM at that
+key count, which is the finding, not a sizing error).
+
+### How distinct keys actually accumulate
+
+With uniform random keys over `--key_maximum`, distinct keys (and therefore
+memory) climb fast at first, then asymptote toward `key_maximum` as repeats
+start landing on existing keys. **Memory plateaus near `key_maximum` distinct
+entries** — writing *longer* past that point just overwrites existing keys and
+does **not** grow memory. That's the key safety property: **`--key_maximum`, not
+run length, bounds the footprint.** Run length controls how *close* to that
+plateau you get and how long you hold steady state.
+
+So to reliably fill to the target without OOM:
+
+- Set `--key_maximum` to the computed `target_keys`.
+- Make the write phase long enough to insert essentially all of them — total
+  requests (`-c` × threads × `-n`, or a `--test_time` that covers it) should be
+  a small multiple of `key_maximum` (~2–3×) so coverage is near-complete.
+- Use `--key_dist S` (sequential) if you want *exactly* `key_maximum` distinct
+  keys with no repeats and a precise fill; uniform is fine when you just need to
+  approach the plateau.
+
+### Watch memory live — guard on RSS
+
+Never run a long write blind. The accurate safety signal is **`used_memory_rss`**
+(resident set), not `free`'s `available` (page cache makes it dip transiently and
+is reclaimable). Poll RSS every few seconds and **abort the write if RSS exceeds
+~90–95% of host RAM**, and separately watch `used_memory` against `maxmemory` to
+catch approaching eviction. Example guard loop:
+
+Run the guard as its own bounded step, not as part of a larger launch/poll/capture
+mega-command. After the guard reports `DONE`, immediately run a separate capture
+step (`DBSIZE`, `INFO memory`, stdout log, and zero-error check), then start the
+read phase.
+
+```bash
+TOTAL=$(ssh <server> 'free -b | awk "/^Mem:/{print \$2}"')
+for i in $(seq 1 60); do
+  sleep 8
+  read DB RSS USED < <(ssh <server> 'redis-cli -p 6380 dbsize | tr -d "\r"; \
+     redis-cli -p 6380 info memory | grep -E "^used_memory_rss:|^used_memory:" | cut -d: -f2 | tr -d "\r"' | paste -sd" ")
+  pct=$(awk "BEGIN{printf \"%.0f\", $RSS/$TOTAL*100}")
+  echo "dbsize=$DB rss=$(awk "BEGIN{printf \"%.1f\",$RSS/2^30}")GiB (${pct}% of RAM)"
+  if [ "$pct" -ge 92 ]; then echo "ABORT: RSS ≥92% of RAM"; \
+     ssh <client> 'tmux kill-session -t bench'; break; fi
+done
+```
+
+Ways to read current memory:
+
+- **`INFO memory` → `used_memory_rss`** — the accurate measure; the guard's
+  input. Also compare `used_memory` to `maxmemory` (eviction warning).
+- **`/metrics` endpoint (Dragonfly only)** — `curl -s
+  http://<server>:6380/metrics | grep -i mem` gives Dragonfly's live RSS/used
+  gauges without a redis client. **Valkey/Redis do not serve `/metrics`** — for
+  those, use `INFO memory` directly or scrape via the redis-exporter (see the
+  monitoring section). `INFO memory` works for all three datastores, so it's the
+  portable choice for the guard.
+- **Monitoring stack** — Prometheus/Grafana plots these over time; the source of
+  the memory-over-time chart. (`free`/node-exporter available is fine for the
+  chart, just not the trigger.)
+
+If RSS approaches the limit faster than expected, **stop the write early** —
+you've already filled enough to measure; a partially-filled run with clean
+numbers beats one that evicted or OOMed.
+
+### The other knobs
+
+- **Connections (`-c` is *per thread*):** keep `-c` modest — **never above 25
+  connections per thread, usually around 10**; for pipelined runs drop it to
+  **1–5 per thread** (each connection already has many requests in flight, so
+  more connections just add contention without more throughput). Scale total
+  load by adding **threads** (and, if needed, a second client box), not by
+  cramming connections onto each thread. Raise the total until QPS stops rising;
+  if it keeps climbing at your max, the client is the bottleneck — add threads or
+  another client machine, not more `-c`.
+- **Duration / steady state:** beyond filling memory, hold at least 30–60s of
+  steady traffic so the reported QPS/P99 reflect steady state, not warm-up.
+  Watch the periodic RPS line stabilize before trusting the number.
+- **Pipeline:** Use `--pipeline 30` for all write/prefill phases — without it
+  the client stalls on each reply and becomes the bottleneck before the server
+  saturates. Use `--pipeline 1` (or omit) only for latency-honest read
+  benchmarks, and label those numbers accordingly.
+
+Always note in the report the key count, value size, resulting memory fill (%
+of instance RAM), and whether the run was client-bound — an under-driven server
+or a barely-filled instance both produce numbers that quietly mislead.

--- a/.claude/skills/benchmark/scripts/bench_server.sh
+++ b/.claude/skills/benchmark/scripts/bench_server.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Start / stop / check a server (Dragonfly binary or Valkey/Redis Docker) on a
+# remote host. Two modes:
+#
+#   binary mode  — launches a local binary, tracks PID in /tmp/bench-server.pid
+#   docker mode  — runs a named Docker container (bench-server); Docker manages
+#                  lifecycle, no PID file needed
+#
+# Reliable shutdown matters: tmux kill-session does NOT reap the server process,
+# and a stale server silently steals the port.
+#
+# Usage:
+#   bench_server.sh start        <ssh> <binary_path> [maxmem] [port] [extra_env]
+#   bench_server.sh start-docker <ssh> <image>       [maxmem] [port]
+#   bench_server.sh stop         <ssh> [port]
+#   bench_server.sh stop-docker  <ssh> [port]
+#   bench_server.sh status       <ssh> [port]
+#
+# Examples:
+#   bench_server.sh start        dev@HOST ~/projects/dragonfly/build-opt/dragonfly 27gb 6380
+#   bench_server.sh start        dev@HOST ~/projects/dragonfly/build-opt/dragonfly 27gb 6380 'MIMALLOC_ALLOW_LARGE_OS_PAGES=0'
+#   bench_server.sh start-docker dev@HOST valkey/valkey:9 27gb 6380
+#   bench_server.sh stop         dev@HOST 6380
+#   bench_server.sh stop-docker  dev@HOST 6380
+set -euo pipefail
+
+cmd=${1:?start|start-docker|stop|stop-docker|status}; tgt=${2:?ssh target}
+SSH="ssh -o BatchMode=yes -o ConnectTimeout=15"
+
+# Shared: build --maxmemory flag (called per-subcommand after args are parsed)
+_mm() { [ -n "${1:-}" ] && echo "--maxmemory $1" || echo ""; }
+
+case "$cmd" in
+  start)
+    bin=${3:?binary path}; maxmem=${4:-}; port=${5:-6380}; env_prefix=${6:-}
+    $SSH "$tgt" "$env_prefix nohup $bin --conn_use_incoming_cpu --dbfilename= $(_mm "$maxmem") \
+        --logtostderr --port $port >/tmp/bench-server.log 2>&1 & echo \$! > /tmp/bench-server.pid; sleep 3; \
+        echo PID=\$(cat /tmp/bench-server.pid); redis-cli -p $port ping; \
+        redis-cli -p $port info server | grep -iE 'dragonfly_version|redis_version' | head -2"
+    ;;
+  start-docker)
+    image=${3:?docker image}; maxmem=${4:-}; port=${5:-6380}
+    # Detect server binary name from image name (valkey → valkey-server, else redis-server)
+    case "$image" in
+      *[Vv]alkey*) srv_bin="valkey-server" ;;
+      *)            srv_bin="redis-server" ;;
+    esac
+    # io-threads: computed on the remote side, capped at 8 (diminishing returns beyond that)
+    $SSH "$tgt" "io_t=\$(n=\$(nproc); echo \$((n < 8 ? n : 8))); \
+        docker rm -f bench-server 2>/dev/null || true; \
+        docker run -d --name bench-server --network host $image \
+          $srv_bin --port $port --save \"\" --loglevel notice $(_mm "$maxmem") --io-threads \$io_t; \
+        sleep 3; docker ps --filter name=bench-server --format 'Status: {{.Status}}'; \
+        redis-cli -p $port ping; \
+        redis-cli -p $port info server | grep -iE 'redis_version|valkey_version' | head -2; \
+        redis-cli -p $port config get io-threads"
+    ;;
+  stop)
+    port=${3:-6380}
+    $SSH "$tgt" "kill -9 \$(cat /tmp/bench-server.pid 2>/dev/null) 2>/dev/null || true; sleep 3; \
+        pgrep -af 'dragonfly|valkey-server|redis-server' | grep -v 'pgrep\|bash -c' || echo 'stopped'; \
+        redis-cli -p $port ping 2>&1 | head -1; free -h | head -2"
+    ;;
+  stop-docker)
+    port=${3:-6380}
+    $SSH "$tgt" "docker stop bench-server 2>/dev/null; docker rm bench-server 2>/dev/null || true; \
+        redis-cli -p $port ping 2>&1 | head -1; free -h | head -2"
+    ;;
+  status)
+    port=${3:-6380}
+    $SSH "$tgt" "pgrep -af 'dragonfly|valkey-server|redis-server' | grep -v 'pgrep\|bash -c' || true; \
+        docker ps --filter name=bench-server --format 'docker: {{.Status}}' 2>/dev/null || true; \
+        redis-cli -p $port ping 2>&1 | head -1; \
+        redis-cli -p $port info memory 2>/dev/null | grep -E '^used_memory:|^used_memory_rss:|^maxmemory:' || true"
+    ;;
+  *) echo "usage: $0 start|start-docker|stop|stop-docker|status <ssh_target> ..." >&2; exit 2;;
+esac

--- a/.claude/skills/benchmark/scripts/bench_server.sh
+++ b/.claude/skills/benchmark/scripts/bench_server.sh
@@ -49,7 +49,7 @@ case "$cmd" in
     $SSH "$tgt" "io_t=\$(n=\$(nproc); echo \$((n < 8 ? n : 8))); \
         docker rm -f bench-server 2>/dev/null || true; \
         docker run -d --name bench-server --network host $image \
-          $srv_bin --port $port --save \"\" --loglevel notice $(_mm "$maxmem") --io-threads \$io_t; \
+          $srv_bin --port $port --save \"\" --loglevel notice --protected-mode no $(_mm "$maxmem") --io-threads \$io_t; \
         sleep 3; docker ps --filter name=bench-server --format 'Status: {{.Status}}'; \
         redis-cli -p $port ping; \
         redis-cli -p $port info server | grep -iE 'redis_version|valkey_version' | head -2; \
@@ -59,18 +59,18 @@ case "$cmd" in
     port=${3:-6380}
     $SSH "$tgt" "kill -9 \$(cat /tmp/bench-server.pid 2>/dev/null) 2>/dev/null || true; sleep 3; \
         pgrep -af 'dragonfly|valkey-server|redis-server' | grep -v 'pgrep\|bash -c' || echo 'stopped'; \
-        redis-cli -p $port ping 2>&1 | head -1; free -h | head -2"
+        redis-cli -p $port ping 2>&1 || true; free -h | head -2"
     ;;
   stop-docker)
     port=${3:-6380}
     $SSH "$tgt" "docker stop bench-server 2>/dev/null; docker rm bench-server 2>/dev/null || true; \
-        redis-cli -p $port ping 2>&1 | head -1; free -h | head -2"
+        redis-cli -p $port ping 2>&1 || true; free -h | head -2"
     ;;
   status)
     port=${3:-6380}
     $SSH "$tgt" "pgrep -af 'dragonfly|valkey-server|redis-server' | grep -v 'pgrep\|bash -c' || true; \
         docker ps --filter name=bench-server --format 'docker: {{.Status}}' 2>/dev/null || true; \
-        redis-cli -p $port ping 2>&1 | head -1; \
+        redis-cli -p $port ping 2>&1 || true; \
         redis-cli -p $port info memory 2>/dev/null | grep -E '^used_memory:|^used_memory_rss:|^maxmemory:' || true"
     ;;
   *) echo "usage: $0 start|start-docker|stop|stop-docker|status <ssh_target> ..." >&2; exit 2;;

--- a/.claude/skills/benchmark/scripts/bench_server.sh
+++ b/.claude/skills/benchmark/scripts/bench_server.sh
@@ -33,9 +33,16 @@ _mm() { [ -n "${1:-}" ] && echo "--maxmemory $1" || echo ""; }
 case "$cmd" in
   start)
     bin=${3:?binary path}; maxmem=${4:-}; port=${5:-6380}; env_prefix=${6:-}
+    # Verify the launched process is alive before pinging: if the port is already
+    # held by a stale server the new binary exits on bind failure, yet redis-cli
+    # ping would still succeed against the old one — a false "started" report.
     $SSH "$tgt" "$env_prefix nohup $bin --conn_use_incoming_cpu --dbfilename= $(_mm "$maxmem") \
-        --logtostderr --port $port >/tmp/bench-server.log 2>&1 & echo \$! > /tmp/bench-server.pid; sleep 3; \
-        echo PID=\$(cat /tmp/bench-server.pid); redis-cli -p $port ping; \
+        --logtostderr --port $port >/tmp/bench-server.log 2>&1 & \
+        pid=\$!; echo \$pid > /tmp/bench-server.pid; sleep 3; \
+        if ! kill -0 \$pid 2>/dev/null; then \
+          echo \"ERROR: server (pid \$pid) died on startup — port $port likely already in use:\"; \
+          tail -5 /tmp/bench-server.log; exit 1; fi; \
+        echo PID=\$pid; redis-cli -p $port ping; \
         redis-cli -p $port info server | grep -iE 'dragonfly_version|redis_version' | head -2"
     ;;
   start-docker)
@@ -50,21 +57,34 @@ case "$cmd" in
         docker rm -f bench-server 2>/dev/null || true; \
         docker run -d --name bench-server --network host $image \
           $srv_bin --port $port --save \"\" --loglevel notice --protected-mode no $(_mm "$maxmem") --io-threads \$io_t; \
-        sleep 3; docker ps --filter name=bench-server --format 'Status: {{.Status}}'; \
+        sleep 3; \
+        if [ -z \"\$(docker ps -q --filter name=bench-server)\" ]; then \
+          echo 'ERROR: bench-server container is not running (bind failure / stale server on port?):'; \
+          docker logs bench-server 2>&1 | tail -5; exit 1; fi; \
+        docker ps --filter name=bench-server --format 'Status: {{.Status}}'; \
         redis-cli -p $port ping; \
         redis-cli -p $port info server | grep -iE 'redis_version|valkey_version' | head -2; \
         redis-cli -p $port config get io-threads"
     ;;
   stop)
     port=${3:-6380}
-    $SSH "$tgt" "kill -9 \$(cat /tmp/bench-server.pid 2>/dev/null) 2>/dev/null || true; sleep 3; \
-        pgrep -af 'dragonfly|valkey-server|redis-server' | grep -v 'pgrep\|bash -c' || echo 'stopped'; \
-        redis-cli -p $port ping 2>&1 || true; free -h | head -2"
+    # Only kill the recorded PID if it still exists AND looks like a server, so a
+    # stale/reused PID file can't take down an unrelated process. Then fail if the
+    # port is still served, so the next run doesn't silently hit a stale server.
+    $SSH "$tgt" "pid=\$(cat /tmp/bench-server.pid 2>/dev/null || true); \
+        if [ -n \"\$pid\" ] && kill -0 \$pid 2>/dev/null; then \
+          if ps -p \$pid -o comm= 2>/dev/null | grep -qE 'dragonfly|valkey|redis'; then kill -9 \$pid 2>/dev/null || true; \
+          else echo \"WARN: pid \$pid (\$(ps -p \$pid -o comm=)) is not a benchmark server — not killing\"; fi; \
+        fi; rm -f /tmp/bench-server.pid; sleep 3; \
+        pgrep -af 'dragonfly|valkey-server|redis-server' | grep -v 'pgrep\|bash -c' || echo 'no server process'; \
+        if redis-cli -p $port ping >/dev/null 2>&1; then echo \"ERROR: port $port still serving after stop\"; free -h | head -2; exit 1; fi; \
+        echo \"stopped, port $port free\"; free -h | head -2"
     ;;
   stop-docker)
     port=${3:-6380}
-    $SSH "$tgt" "docker stop bench-server 2>/dev/null; docker rm bench-server 2>/dev/null || true; \
-        redis-cli -p $port ping 2>&1 || true; free -h | head -2"
+    $SSH "$tgt" "docker stop bench-server 2>/dev/null || true; docker rm bench-server 2>/dev/null || true; sleep 1; \
+        if redis-cli -p $port ping >/dev/null 2>&1; then echo \"ERROR: port $port still serving after stop-docker\"; free -h | head -2; exit 1; fi; \
+        echo \"stopped, port $port free\"; free -h | head -2"
     ;;
   status)
     port=${3:-6380}

--- a/.claude/skills/benchmark/scripts/bench_util.py
+++ b/.claude/skills/benchmark/scripts/bench_util.py
@@ -1,0 +1,78 @@
+"""Shared helpers for benchmark scripts (collect_metrics, make_charts, plot_fill)."""
+
+import os
+import sys
+
+
+def find_first(d, *names):
+    """Return the value of the first key in d whose lowercase form contains any of names."""
+    if not isinstance(d, dict):
+        return None
+    for k, v in d.items():
+        kl = k.lower()
+        for name in names:
+            if name.lower() in kl:
+                return v
+    return None
+
+
+def percentile_latency_us(d, percentile="99"):
+    """Return percentile latency in microseconds across old and new bench JSON schemas."""
+    if not isinstance(d, dict):
+        return None
+
+    def matches(key):
+        lk = key.lower()
+        return percentile in lk and ("percentile" in lk or f"p{percentile}" in lk or "th" in lk)
+
+    # Newer dfly_bench/memtier-compatible JSON nests percentile latencies in milliseconds.
+    nested = find_first(d, "Percentile Latencies")
+    if isinstance(nested, dict):
+        for key, value in nested.items():
+            if matches(key):
+                return value * 1000
+
+    for key, value in d.items():
+        if not matches(key):
+            continue
+        # Older benchmark fixtures use "Percentile 99.00" directly in microseconds.
+        # Newer time-series samples use "p99.00" directly in milliseconds.
+        if key.lower().startswith(f"p{percentile}"):
+            return value * 1000
+        return value
+
+    return None
+
+
+def import_matplotlib():
+    """Import matplotlib with Agg backend; exit with a helpful message if missing."""
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        return plt
+    except ImportError:
+        print("matplotlib required: pip install matplotlib", file=sys.stderr)
+        sys.exit(1)
+
+
+def parse_series_specs(specs):
+    """Yield (label, path) from a list of 'LABEL=path' strings, warning on bad entries."""
+    for spec in specs:
+        if "=" not in spec:
+            print(f"warning: bad --series '{spec}', expected LABEL=path", file=sys.stderr)
+            continue
+        label, path = spec.split("=", 1)
+        yield label, path
+
+
+def save_figure(fig, out_path, dpi=120):
+    """Create output directory if needed, save figure, and print the path."""
+    d = os.path.dirname(out_path)
+    if d:
+        os.makedirs(d, exist_ok=True)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=dpi)
+    print(f"wrote {out_path}")

--- a/.claude/skills/benchmark/scripts/capture_result.sh
+++ b/.claude/skills/benchmark/scripts/capture_result.sh
@@ -10,7 +10,7 @@
 #
 # Example:
 #   capture_result.sh dev@SERVER dev@CLIENT /tmp/prebuilt_write.log /tmp/bench-run/prebuilt prebuilt 6380
-set -uo pipefail
+set -euo pipefail
 srv=${1:?server ssh}; cli=${2:?client ssh}; log=${3:?client log path}; out=${4:?outdir}
 label=${5:-run}; port=${6:-6380}
 SSH="ssh -o BatchMode=yes -o ConnectTimeout=12"
@@ -25,7 +25,7 @@ read -r host_free host_total < <($SSH "$srv" 'free -b | awk "/^Mem:/{print \$4, 
 $SSH "$srv" 'free -h' > "$out/host_memory.txt"
 host_used_pct=$(awk "BEGIN{printf \"%.1f\", ($host_total-$host_free)/$host_total*100}")
 
-summary=$(grep -E 'Total time' "$out/write.log" | tail -1)
+summary=$(grep -E 'Total time' "$out/write.log" | tail -1 || true)
 errline=$(grep -iE 'error responses' "$out/write.log" | tail -1 || true)
 errs=$(echo "$errline" | grep -oE '[0-9]+' | head -1)
 errs=${errs:-0}

--- a/.claude/skills/benchmark/scripts/capture_result.sh
+++ b/.claude/skills/benchmark/scripts/capture_result.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Capture one write run's result and ENFORCE the zero-error rule. Pulls the
+# dfly_bench summary (QPS/P99/errors) from the client log and the server's
+# INFO memory + DBSIZE, saves them under <outdir>, and exits non-zero if the run
+# had ANY eviction/OOM errors — because those contaminate QPS, latency, and
+# bytes-per-entry, so the run must be discarded and re-run at a lower key count.
+#
+# Usage:
+#   capture_result.sh <server_ssh> <client_ssh> <client_log_path> <outdir> [label] [port]
+#
+# Example:
+#   capture_result.sh dev@SERVER dev@CLIENT /tmp/prebuilt_write.log /tmp/bench-run/prebuilt prebuilt 6380
+set -uo pipefail
+srv=${1:?server ssh}; cli=${2:?client ssh}; log=${3:?client log path}; out=${4:?outdir}
+label=${5:-run}; port=${6:-6380}
+SSH="ssh -o BatchMode=yes -o ConnectTimeout=12"
+mkdir -p "$out"
+
+$SSH "$cli" "cat $log" > "$out/write.log"
+$SSH "$srv" "redis-cli -p $port info memory" > "$out/info_memory.txt"
+dbsize=$($SSH "$srv" "redis-cli -p $port dbsize")
+# OS-level host memory — used_memory_rss alone misses allocator arena waste
+# (visible as large discrepancy between INFO rss and OS `free`, e.g. with huge pages).
+read -r host_free host_total < <($SSH "$srv" 'free -b | awk "/^Mem:/{print \$4, \$2}"')
+$SSH "$srv" 'free -h' > "$out/host_memory.txt"
+host_used_pct=$(awk "BEGIN{printf \"%.1f\", ($host_total-$host_free)/$host_total*100}")
+
+summary=$(grep -E 'Total time' "$out/write.log" | tail -1)
+errline=$(grep -iE 'error responses' "$out/write.log" | tail -1 || true)
+errs=$(echo "$errline" | grep -oE '[0-9]+' | head -1)
+errs=${errs:-0}
+
+echo "=== $label ==="
+echo "$summary"
+echo "DBSIZE: $dbsize"
+grep -E '^used_memory:|^used_memory_rss:|^maxmemory:' "$out/info_memory.txt"
+echo "host_free: $(awk "BEGIN{printf \"%.2f\", $host_free/2^30}")GiB  host_used: ${host_used_pct}%  (see $out/host_memory.txt)"
+
+if [ "$errs" -gt 0 ]; then
+  echo "!! INVALID: $errs eviction/OOM error responses — DISCARD this run."
+  echo "   Cut --key_maximum ~10-15% and re-run until errors are zero."
+  exit 4
+fi
+echo "OK: zero errors — run is clean."

--- a/.claude/skills/benchmark/scripts/collect_metrics.py
+++ b/.claude/skills/benchmark/scripts/collect_metrics.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Extract headline benchmark metrics from dfly_bench / memtier JSON output and
+compute memory-per-entry.
+
+The dfly_bench --json_out_file (and memtier --json-out-file) reports carry
+per-operation aggregate stats and a per-second time series. This pulls the
+numbers that go into the report tables (QPS, P99) and, given an INFO memory
+snapshot plus DBSIZE, computes both logical and RSS bytes-per-entry.
+
+Usage:
+    collect_metrics.py --bench-json run.json [--bench-json run2.json ...] \
+        [--info info_memory.txt] [--dbsize N] [--label "Dragonfly m7g.2xlarge"] \
+        [--json]
+
+Each --bench-json is summarized independently (e.g. pass the write run and the
+read run). Memory metrics are computed once from --info/--dbsize and apply to
+the labeled configuration as a whole.
+"""
+
+import argparse
+import json
+import re
+import sys
+
+from bench_util import find_first, percentile_latency_us
+
+
+def summarize_bench(path):
+    """Pull QPS, op count, and P99 per operation from one bench JSON file."""
+    with open(path) as f:
+        data = json.load(f)
+
+    stats = find_first(data, "ALL STATS") or data
+    runtime = find_first(stats, "Runtime") or {}
+    total_ms = find_first(runtime, "Total duration") or 0
+
+    ops = {}
+    for op_name, op in stats.items():
+        if not isinstance(op, dict) or op_name.lower() == "runtime":
+            continue
+        count = find_first(op, "Count")
+        if count is None:
+            continue  # not an operation block
+        if count == 0:
+            continue
+        p99 = percentile_latency_us(op)
+        qps = (count * 1000.0 / total_ms) if total_ms else None
+        ops[op_name] = {
+            "count": count,
+            "qps": round(qps) if qps is not None else None,
+            "qps_k": round(qps / 1000.0, 1) if qps is not None else None,
+            "p99_us": p99,
+        }
+
+    return {
+        "file": path,
+        "total_ms": total_ms,
+        "config": find_first(data, "configuration") or {},
+        "operations": ops,
+    }
+
+
+_INFO_RE = re.compile(r"^([a-zA-Z0-9_]+):(.+)$")
+
+
+def parse_info_memory(path):
+    """Parse a redis-cli INFO memory dump into a dict."""
+    out = {}
+    with open(path) as f:
+        for line in f:
+            m = _INFO_RE.match(line.strip())
+            if m:
+                out[m.group(1)] = m.group(2)
+    return out
+
+
+def memory_metrics(info_path, dbsize):
+    info = parse_info_memory(info_path)
+    used = int(info.get("used_memory", 0))
+    rss = int(info.get("used_memory_rss", 0))
+    result = {
+        "used_memory": used,
+        "used_memory_rss": rss,
+        "dbsize": dbsize,
+    }
+    if dbsize:
+        result["bytes_per_entry_logical"] = round(used / dbsize, 1)
+        result["bytes_per_entry_rss"] = round(rss / dbsize, 1) if rss else None
+    return result
+
+
+def format_latency_us(value):
+    if value is None:
+        return "?"
+    if isinstance(value, float):
+        return f"{value:.1f}us"
+    return f"{value}us"
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "--bench-json",
+        action="append",
+        default=[],
+        help="dfly_bench/memtier JSON report (repeatable)",
+    )
+    ap.add_argument("--info", help="redis-cli INFO memory dump")
+    ap.add_argument("--dbsize", type=int, help="number of keys (DBSIZE)")
+    ap.add_argument("--label", default="", help="configuration label for the report")
+    ap.add_argument("--json", action="store_true", help="emit JSON instead of text")
+    args = ap.parse_args()
+
+    if not args.bench_json and not args.info:
+        ap.error("provide at least one --bench-json or --info")
+
+    result = {"label": args.label, "runs": [], "memory": None}
+    for path in args.bench_json:
+        try:
+            result["runs"].append(summarize_bench(path))
+        except Exception as e:  # keep going; a bad file shouldn't kill the batch
+            print(f"warning: could not parse {path}: {e}", file=sys.stderr)
+    if args.info:
+        result["memory"] = memory_metrics(args.info, args.dbsize or 0)
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+        return
+
+    if args.label:
+        print(f"# {args.label}\n")
+    for run in result["runs"]:
+        print(f"{run['file']}  (duration {run['total_ms']} ms)")
+        for op, m in run["operations"].items():
+            qk = f"{m['qps_k']}k" if m["qps_k"] is not None else "?"
+            p99 = format_latency_us(m["p99_us"])
+            print(f"  {op:<8} QPS {qk:<10} P99 {p99}")
+        print()
+    mem = result["memory"]
+    if mem:
+        print("Memory:")
+        print(f"  used_memory     {mem['used_memory']:,} bytes")
+        if mem.get("used_memory_rss"):
+            print(f"  used_memory_rss {mem['used_memory_rss']:,} bytes")
+        print(f"  DBSIZE          {mem['dbsize']:,} keys")
+        if mem.get("bytes_per_entry_logical") is not None:
+            print(f"  bytes/entry (logical) {mem['bytes_per_entry_logical']}")
+        if mem.get("bytes_per_entry_rss") is not None:
+            print(f"  bytes/entry (rss)     {mem['bytes_per_entry_rss']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/benchmark/scripts/make_charts.py
+++ b/.claude/skills/benchmark/scripts/make_charts.py
@@ -49,10 +49,19 @@ def load_series(path, metric, op_hint):
     if op_hint:
         op_block = find_first(stats, op_hint)
     if op_block is None:
-        for name, blk in stats.items():
-            if isinstance(blk, dict) and find_first(blk, "Time-Serie") is not None:
-                op_block = blk
-                break
+        # dfly_bench emits a Sets block before Gets, but a read-only run leaves Sets
+        # at zero count (and vice versa). Picking the first op would plot the empty
+        # series, so choose the op whose time series actually has traffic.
+        def _activity(blk):
+            ts = find_first(blk, "Time-Serie") or {}
+            return sum(find_first(v, "Count") or 0 for v in ts.values() if isinstance(v, dict))
+
+        candidates = [
+            blk
+            for blk in stats.values()
+            if isinstance(blk, dict) and find_first(blk, "Time-Serie") is not None
+        ]
+        op_block = max(candidates, key=_activity, default=None)
     if op_block is None:
         raise ValueError(f"no time series found in {path}")
 

--- a/.claude/skills/benchmark/scripts/make_charts.py
+++ b/.claude/skills/benchmark/scripts/make_charts.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Generate a QPS/latency-over-time PNG chart from dfly_bench / memtier JSON
+time-series output, overlaying one line per datastore.
+
+The persuasive story in these reports is throughput *stability* over time —
+e.g. Dragonfly holding a flat line while a competitor degrades as its main
+table grows. This plots the per-second time series from each run's JSON.
+
+Usage:
+    make_charts.py --series "Dragonfly=df_write.json" \
+                   --series "Valkey=valkey_write.json" \
+                   --metric qps --title "Write throughput, m7g.2xlarge" \
+                   --out charts/write_m7g2xl.png
+
+--metric: qps (default) or p99.  --op picks the operation block (Sets/Gets);
+default is the first op found.  Requires matplotlib.
+"""
+
+import argparse
+import json
+import sys
+
+from bench_util import (
+    find_first,
+    import_matplotlib,
+    parse_series_specs,
+    percentile_latency_us,
+    save_figure,
+)
+
+
+def _bucket_value(sample, metric):
+    """Pull qps (Count, since buckets are 1s) or p99 from a time bucket."""
+    if not isinstance(sample, dict):
+        return None
+    if metric == "qps":
+        # 1-second buckets, so count per bucket is already a per-second rate.
+        return find_first(sample, "Count")
+    return percentile_latency_us(sample)
+
+
+def load_series(path, metric, op_hint):
+    """Return (seconds[], values[]) for the chosen op from one JSON file."""
+    with open(path) as f:
+        data = json.load(f)
+    stats = find_first(data, "ALL STATS") or data
+
+    op_block = None
+    if op_hint:
+        op_block = find_first(stats, op_hint)
+    if op_block is None:
+        for name, blk in stats.items():
+            if isinstance(blk, dict) and find_first(blk, "Time-Serie") is not None:
+                op_block = blk
+                break
+    if op_block is None:
+        raise ValueError(f"no time series found in {path}")
+
+    ts = find_first(op_block, "Time-Serie") or {}
+    secs = sorted(int(s) for s in ts.keys())
+    xs, ys = [], []
+    for s in secs:
+        val = _bucket_value(ts[str(s)], metric)
+        if val is not None:
+            xs.append(s)
+            ys.append(val)
+    return xs, ys
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "--series",
+        action="append",
+        default=[],
+        required=True,
+        help="LABEL=path.json (repeatable, one line per datastore)",
+    )
+    ap.add_argument("--metric", choices=["qps", "p99"], default="qps")
+    ap.add_argument("--op", default="", help="operation block hint, e.g. Sets or Gets")
+    ap.add_argument("--title", default="")
+    ap.add_argument("--out", required=True, help="output PNG path")
+    args = ap.parse_args()
+
+    plt = import_matplotlib()
+
+    fig, ax = plt.subplots(figsize=(9, 5))
+    plotted = 0
+    for label, path in parse_series_specs(args.series):
+        try:
+            xs, ys = load_series(path, args.metric, args.op)
+        except Exception as e:
+            print(f"warning: {path}: {e}", file=sys.stderr)
+            continue
+        if args.metric == "qps":
+            ys = [y / 1000.0 for y in ys]  # plot in thousands
+        ax.plot(xs, ys, label=label, linewidth=2)
+        plotted += 1
+
+    if not plotted:
+        print("no series plotted", file=sys.stderr)
+        sys.exit(1)
+
+    ax.set_xlabel("Time (s)")
+    ax.set_ylabel("QPS (k)" if args.metric == "qps" else "P99 latency (us)")
+    if args.title:
+        ax.set_title(args.title)
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+    ax.set_ylim(bottom=0)
+
+    save_figure(fig, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/benchmark/scripts/monitor_fill.sh
+++ b/.claude/skills/benchmark/scripts/monitor_fill.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Watch a running write fill memory and ABORT before OOM. Polls the server's
+# used_memory_rss (the accurate signal — not `free` available, which page cache
+# inflates) and the live DBSIZE, prints a line per sample, and kills the client
+# bench tmux session if RSS crosses the abort threshold. Exits when the write
+# finishes (client tmux session gone) or on abort.
+#
+# Usage:
+#   monitor_fill.sh <server_ssh> <client_ssh> [tmux_session] [abort_pct] [interval_s] [max_polls] [port]
+#
+# Example:
+#   monitor_fill.sh dev@SERVER dev@CLIENT bench 92 10 60 6380
+#
+# Emits poll lines like: "poll 7: RUN dbsize=172018929 rss=18.37GiB (60%)"
+# so the output doubles as the data for scripts/plot_fill.py.
+#
+# Done-detection: checks whether dfly_bench or memtier_benchmark is running on
+# the client (pgrep), not just whether the tmux session exists. The tmux session
+# outlives the bench process, so has-session alone gives false "RUN" forever.
+set -uo pipefail
+
+srv=${1:?server ssh target}; cli=${2:?client ssh target}
+sess=${3:-bench}; abort=${4:-92}; iv=${5:-10}; maxp=${6:-60}; port=${7:-6380}
+SSH="ssh -o BatchMode=yes -o ConnectTimeout=10"
+
+total=$($SSH "$srv" 'free -b | awk "/^Mem:/{print \$2}"')
+echo "host total bytes=$total, abort at ${abort}% RSS"
+
+for i in $(seq 1 "$maxp"); do
+  sleep "$iv"
+  state=$($SSH "$cli" "if pgrep -x dfly_bench >/dev/null 2>&1 || \
+      pgrep -f '(^|/)[m]emtier_benchmark([[:space:]]|$)' >/dev/null 2>&1; then \
+      echo RUN; else echo DONE; fi")
+  read -r db rss host_used host_free < <($SSH "$srv" "D=\$(redis-cli -p $port dbsize); \
+      R=\$(redis-cli -p $port info memory | grep '^used_memory_rss:' | cut -d: -f2 | tr -d '\r'); \
+      HU=\$(free -b | awk '/^Mem:/{print \$3}'); HF=\$(free -b | awk '/^Mem:/{print \$4}'); echo \$D \$R \$HU \$HF")
+  pct=$(awk "BEGIN{printf \"%.0f\", $rss/$total*100}")
+  rssg=$(awk "BEGIN{printf \"%.2f\", $rss/2^30}")
+  host_used_g=$(awk "BEGIN{printf \"%.2f\", $host_used/2^30}")
+  host_free_g=$(awk "BEGIN{printf \"%.2f\", $host_free/2^30}")
+  echo "poll $i: $state dbsize=$db rss=${rssg}GiB (${pct}%) host_used=${host_used_g}GiB host_free=${host_free_g}GiB"
+  if [ "$pct" -ge "$abort" ]; then
+    echo "!! ABORT: RSS ${pct}% >= ${abort}% — killing write"
+    $SSH "$cli" "tmux kill-session -t $sess 2>/dev/null" || true
+    exit 3
+  fi
+  [ "$state" = "DONE" ] && { echo "write finished"; exit 0; }
+done
+echo "monitor: max polls reached, write still running"

--- a/.claude/skills/benchmark/scripts/monitor_fill.sh
+++ b/.claude/skills/benchmark/scripts/monitor_fill.sh
@@ -46,4 +46,4 @@ for i in $(seq 1 "$maxp"); do
   fi
   [ "$state" = "DONE" ] && { echo "write finished"; exit 0; }
 done
-echo "monitor: max polls reached, write still running"
+echo "monitor: max polls reached, write still running"; exit 2

--- a/.claude/skills/benchmark/scripts/monitor_fill.sh
+++ b/.claude/skills/benchmark/scripts/monitor_fill.sh
@@ -24,6 +24,7 @@ sess=${3:-bench}; abort=${4:-92}; iv=${5:-10}; maxp=${6:-60}; port=${7:-6380}
 SSH="ssh -o BatchMode=yes -o ConnectTimeout=10"
 
 total=$($SSH "$srv" 'free -b | awk "/^Mem:/{print \$2}"')
+[[ "$total" =~ ^[0-9]+$ ]] || { echo "monitor: could not read host total memory (got '$total') — aborting"; exit 4; }
 echo "host total bytes=$total, abort at ${abort}% RSS"
 
 for i in $(seq 1 "$maxp"); do
@@ -34,6 +35,9 @@ for i in $(seq 1 "$maxp"); do
   read -r db rss host_used host_free < <($SSH "$srv" "D=\$(redis-cli -p $port dbsize); \
       R=\$(redis-cli -p $port info memory | grep '^used_memory_rss:' | cut -d: -f2 | tr -d '\r'); \
       HU=\$(free -b | awk '/^Mem:/{print \$3}'); HF=\$(free -b | awk '/^Mem:/{print \$4}'); echo \$D \$R \$HU \$HF")
+  # Fail closed: a dropped SSH/redis-cli read yields an empty rss, which would
+  # otherwise make the abort comparison silently pass and the fill run unguarded.
+  [[ "$rss" =~ ^[0-9]+$ ]] || { echo "poll $i: could not read used_memory_rss (got '$rss') — aborting"; exit 4; }
   pct=$(awk "BEGIN{printf \"%.0f\", $rss/$total*100}")
   rssg=$(awk "BEGIN{printf \"%.2f\", $rss/2^30}")
   host_used_g=$(awk "BEGIN{printf \"%.2f\", $host_used/2^30}")

--- a/.claude/skills/benchmark/scripts/plot_fill.py
+++ b/.claude/skills/benchmark/scripts/plot_fill.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Plot memory-fill-over-time from monitor_fill.sh output.
+
+For `--command` workloads (e.g. SETEX), dfly_bench writes no JSON time series, so
+make_charts.py can't be used. monitor_fill.sh already emits per-poll lines like:
+
+    poll 7: RUN dbsize=172018929 rss=18.37GiB (60%)
+
+This parses one or more such logs (one per binary/datastore) and produces two
+panels: RSS vs time, and RSS vs keyspace size — the visual for how memory fills
+and where it plateaus.
+
+Usage:
+    plot_fill.py --series "prebuilt=prebuilt/poll.txt" \
+                 --series "release=release/poll.txt" \
+                 --interval 10 --ram-gib 30 --out charts/memory_fill.png
+"""
+import argparse
+import re
+import sys
+
+from bench_util import import_matplotlib, parse_series_specs, save_figure
+
+LINE = re.compile(r"dbsize=(\d+)\s+rss=([\d.]+)GiB")
+
+
+def parse(path, interval):
+    t, db, rss = [], [], []
+    with open(path) as f:
+        for line in f:
+            m = LINE.search(line)
+            if m:
+                t.append(len(t) * interval)
+                db.append(int(m.group(1)) / 1e6)
+                rss.append(float(m.group(2)))
+    return t, db, rss
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--series", action="append", required=True, help="LABEL=poll.txt (repeatable)")
+    ap.add_argument("--interval", type=int, default=10, help="seconds between polls")
+    ap.add_argument(
+        "--ram-gib", type=float, default=0, help="host RAM for the abort-line annotation"
+    )
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    plt = import_matplotlib()
+
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(13, 5))
+    markers = "os^Dv"
+    for i, (label, path) in enumerate(parse_series_specs(args.series)):
+        t, db, rss = parse(path, args.interval)
+        if not t:
+            print(f"warning: no poll lines in {path}", file=sys.stderr)
+            continue
+        m = markers[i % len(markers)]
+        ax1.plot(t, rss, m + "-", label=label, lw=2)
+        ax2.plot(db, rss, m + "-", label=label, lw=2)
+
+    if args.ram_gib:
+        ax1.axhline(args.ram_gib * 0.92, ls="--", color="r", alpha=0.6, label="92% RSS guard")
+        ax1.set_ylim(0, args.ram_gib)
+    ax1.set_xlabel("Time (s)")
+    ax1.set_ylabel("Server RSS (GiB)")
+    ax1.set_title("Memory fill over time")
+    ax1.legend()
+    ax1.grid(alpha=0.3)
+    ax2.set_xlabel("Keys (millions)")
+    ax2.set_ylabel("Server RSS (GiB)")
+    ax2.set_title("RSS vs keyspace size")
+    ax2.legend()
+    ax2.grid(alpha=0.3)
+
+    save_figure(fig, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/benchmark/scripts/plot_fill.py
+++ b/.claude/skills/benchmark/scripts/plot_fill.py
@@ -45,6 +45,12 @@ def main():
     ap.add_argument(
         "--ram-gib", type=float, default=0, help="host RAM for the abort-line annotation"
     )
+    ap.add_argument(
+        "--abort-pct",
+        type=float,
+        default=92,
+        help="RSS abort threshold for the guard line (match monitor_fill.sh)",
+    )
     ap.add_argument("--out", required=True)
     args = ap.parse_args()
 
@@ -62,7 +68,13 @@ def main():
         ax2.plot(db, rss, m + "-", label=label, lw=2)
 
     if args.ram_gib:
-        ax1.axhline(args.ram_gib * 0.92, ls="--", color="r", alpha=0.6, label="92% RSS guard")
+        ax1.axhline(
+            args.ram_gib * args.abort_pct / 100,
+            ls="--",
+            color="r",
+            alpha=0.6,
+            label=f"{args.abort_pct:g}% RSS guard",
+        )
         ax1.set_ylim(0, args.ram_gib)
     ax1.set_xlabel("Time (s)")
     ax1.set_ylabel("Server RSS (GiB)")

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ fuzz/artifacts/
 fuzz/corpus/
 tools/replay/traffic-replay
 .claude/settings.local.json
+.claude/agent-memory/
 # Valkey-search integration tests (synced from external repo)
 tests/dragonfly/valkey_search/integration/
 _codeql_build_dir/

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ fuzz/corpus/
 tools/replay/traffic-replay
 .claude/settings.local.json
 .claude/agent-memory/
+.claude/skills/benchmark-workspace/
 # Valkey-search integration tests (synced from external repo)
 tests/dragonfly/valkey_search/integration/
 _codeql_build_dir/


### PR DESCRIPTION
## Summary

- Adds a `/benchmark` Claude Code skill for driving end-to-end Dragonfly benchmarks against Valkey/Redis on remote cloud instances
- Includes reusable shell scripts (`bench_server.sh`, `monitor_fill.sh`, `capture_result.sh`) and Python scripts (`collect_metrics.py`, `make_charts.py`, `plot_fill.py`, `bench_util.py`)
- Bundled operational reference docs (`running-benchmarks.md`, `report-template.md`) and eval fixtures

## Key operational rules encoded in the skill

- Always use private/VPC-internal IPs for cross-instance traffic
- `--pipeline 30` required for all prefill/write phases (client bottlenecks without it)
- Zero-error enforcement: any eviction/OOM error invalidates the run
- Port 6380 standard for all servers (Dragonfly, Valkey, Redis)
- Valkey/Redis Docker: `--io-threads min(nproc, 8)` always set
- OS-level host memory tracked alongside `used_memory_rss` (they can diverge significantly with mimalloc large pages)