### PR TITLE
Extend dfly_bench JSON output

### DIFF
--- a/src/server/dfly_bench.cc
+++ b/src/server/dfly_bench.cc
@@ -8,6 +8,7 @@ extern "C" {
 
 #include <absl/container/flat_hash_set.h>
 #include <absl/random/random.h>
+#include <absl/strings/ascii.h>
 #include <absl/strings/match.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
@@ -117,9 +118,9 @@ enum DistType : uint8_t { UNIFORM, NORMAL, ZIPFIAN, SEQUENTIAL } dist_type{UNIFO
 constexpr uint16_t kNumSlots = 16384;
 constexpr uint32_t kDnsResolveTimeoutMs = 2000;
 constexpr string_view kMovedErrorKey = "MOVED"sv;
-enum class BenchOp : uint8_t { kSet = 0, kGet = 1, kUnknown = 2 };
+enum class BenchOp : int8_t { kUnknown = -1, kSet = 0, kGet = 1, kCustom = 0 };
 constexpr size_t kTrackedOpCount = 2;
-constexpr std::array<string_view, kTrackedOpCount> kTrackedOpNames = {"Sets", "Gets"};
+constexpr std::array<string_view, kTrackedOpCount> kBuiltInOpNames = {"Sets", "Gets"};
 
 static string GetRandomBlob(size_t len, bool ascii) {
   static bool is_random = GetFlag(FLAGS_random_data);
@@ -235,6 +236,19 @@ optional<pair<uint16_t, tcp::endpoint>> ParseMovedError(string_view error, Proac
 }
 
 }  // namespace
+
+vector<string> GetTrackedOpNames() {
+  const string command = GetFlag(FLAGS_command);
+
+  if (command.empty()) {
+    return {string(kBuiltInOpNames[0]), string(kBuiltInOpNames[1])};
+  }
+
+  vector<string_view> parts = absl::StrSplit(command, ' ', absl::SkipEmpty());
+  CHECK(!parts.empty()) << "--command must not be whitespace only";
+
+  return {absl::AsciiStrToUpper(parts.front())};
+}
 
 struct ShardInfo {
   vector<SlotRange> slots;  // list of [start, end] pairs. inclusive.
@@ -413,6 +427,7 @@ CommandGenerator::CommandGenerator(KeyGenerator* keygen) : keygen_(keygen) {
   }
 
   vector<string_view> parts = absl::StrSplit(command_, ' ', absl::SkipEmpty());
+  CHECK(!parts.empty()) << "--command must not be whitespace only";
   for (string_view p : parts) {
     if (p == "__key__"sv) {
       cmd_parts_.emplace_back(KEY);
@@ -451,6 +466,7 @@ string CommandGenerator::Next(SlotRange range) {
   }
 
   // For custom commands, we select a random slot and then use it for key generation.
+  op_ = BenchOp::kCustom;
   uint16_t slot_id = 0;
 
   if (keygen_->IsClusterEnabled()) {
@@ -529,8 +545,8 @@ struct ClientStats {
   unsigned num_clients = 0;
 
   void AddLatencySample(BenchOp op, uint64_t usec, uint64_t elapsed_ns) {
-    unsigned index = unsigned(op);
-    if (index >= kTrackedOpCount)
+    int index = static_cast<int>(op);
+    if (index < 0 || index >= int(kTrackedOpCount))
       return;
 
     op_stats[index].Add(usec);
@@ -1230,6 +1246,20 @@ void WriteSampleStatsJson(std::ostream& os, const base::Histogram& hist, uint64_
   }
 }
 
+base::Histogram AggregateTimeSeriesSample(const ClientStats& summary, uint64_t sec) {
+  base::Histogram sample;
+
+  auto it = summary.time_series.find(sec);
+  if (it == summary.time_series.end())
+    return sample;
+
+  for (const base::Histogram& hist : it->second) {
+    sample.Merge(hist);
+  }
+
+  return sample;
+}
+
 void WriteTimeSeriesJson(std::ostream& os, const ClientStats& summary, size_t op_index,
                          uint64_t bucket_count, unsigned indent) {
   WriteIndent(os, indent);
@@ -1240,6 +1270,30 @@ void WriteTimeSeriesJson(std::ostream& os, const ClientStats& summary, size_t op
     if (auto it = summary.time_series.find(sec); it != summary.time_series.end()) {
       sample = it->second[op_index];
     }
+
+    WriteIndent(os, indent + 2);
+    os << '"' << sec << "\": {\n";
+    WriteSampleStatsJson(os, sample, 1000, indent + 4, false);
+    os << "\n";
+    WriteIndent(os, indent + 2);
+    os << '}';
+    if (sec + 1 != bucket_count) {
+      os << ',';
+    }
+    os << "\n";
+  }
+
+  WriteIndent(os, indent);
+  os << '}';
+}
+
+void WriteTotalsTimeSeriesJson(std::ostream& os, const ClientStats& summary, uint64_t bucket_count,
+                               unsigned indent) {
+  WriteIndent(os, indent);
+  os << "\"Time-Serie\": {\n";
+
+  for (uint64_t sec = 0; sec < bucket_count; ++sec) {
+    base::Histogram sample = AggregateTimeSeriesSample(summary, sec);
 
     WriteIndent(os, indent + 2);
     os << '"' << sec << "\": {\n";
@@ -1274,11 +1328,28 @@ void WriteOperationJson(std::ostream& os, string_view op_name, const ClientStats
   os << "\n";
 }
 
+void WriteTotalsJson(std::ostream& os, const ClientStats& summary, uint64_t total_ms,
+                     uint64_t bucket_count, unsigned indent, bool trailing_comma) {
+  WriteIndent(os, indent);
+  os << "\"Totals\": {\n";
+  WriteSampleStatsJson(os, summary.total_hist, total_ms, indent + 2, true);
+  os << ",\n";
+  WriteTotalsTimeSeriesJson(os, summary, bucket_count, indent + 2);
+  os << "\n";
+  WriteIndent(os, indent);
+  os << '}';
+  if (trailing_comma) {
+    os << ',';
+  }
+  os << "\n";
+}
+
 void WriteLatencyJsonReport(const ClientStats& summary, absl::Duration duration,
                             size_t thread_count) {
   const string output_path = GetFlag(FLAGS_json_out_file);
   if (output_path.empty())
     return;
+  const vector<string> op_names = GetTrackedOpNames();
 
   const uint64_t total_ms = std::max<uint64_t>(1, absl::ToInt64Milliseconds(duration));
   uint64_t bucket_count = std::max<uint64_t>(1, (total_ms + 999) / 1000);
@@ -1314,8 +1385,11 @@ void WriteLatencyJsonReport(const ClientStats& summary, absl::Duration duration,
   os << "\"Total duration\": " << total_ms << "\n";
   WriteIndent(os, 4);
   os << "},\n";
-  WriteOperationJson(os, kTrackedOpNames[0], summary, 0, total_ms, bucket_count, 4, true);
-  WriteOperationJson(os, kTrackedOpNames[1], summary, 1, total_ms, bucket_count, 4, false);
+  WriteTotalsJson(os, summary, total_ms, bucket_count, 4, !op_names.empty());
+  for (size_t i = 0; i < op_names.size(); ++i) {
+    WriteOperationJson(os, op_names[i], summary, i, total_ms, bucket_count, 4,
+                       i + 1 != op_names.size());
+  }
   WriteIndent(os, 2);
   os << "}\n";
   os << "}\n";
@@ -1503,8 +1577,6 @@ int main(int argc, char* argv[]) {
   string json_out_file = GetFlag(FLAGS_json_out_file);
 
   if (!json_out_file.empty()) {
-    CHECK(GetFlag(FLAGS_command).empty())
-        << "--json_out_file is supported only with the built-in GET/SET workload";
     CHECK(!GetFlag(FLAGS_noreply)) << "--json_out_file is not supported together with --noreply";
     CHECK(!GetFlag(FLAGS_connect_only)) << "--json_out_file requires sending benchmark commands";
   }

--- a/src/server/dfly_bench.cc
+++ b/src/server/dfly_bench.cc
@@ -118,9 +118,23 @@ enum DistType : uint8_t { UNIFORM, NORMAL, ZIPFIAN, SEQUENTIAL } dist_type{UNIFO
 constexpr uint16_t kNumSlots = 16384;
 constexpr uint32_t kDnsResolveTimeoutMs = 2000;
 constexpr string_view kMovedErrorKey = "MOVED"sv;
-enum class BenchOp : int8_t { kUnknown = -1, kSet = 0, kGet = 1, kCustom = 0 };
+enum class BenchOp : uint8_t { kSet, kGet, kCustom, kUnknown };
 constexpr size_t kTrackedOpCount = 2;
 constexpr std::array<string_view, kTrackedOpCount> kBuiltInOpNames = {"Sets", "Gets"};
+
+optional<size_t> TrackedOpIndex(BenchOp op) {
+  switch (op) {
+    case BenchOp::kSet:
+    case BenchOp::kCustom:
+      return 0;
+    case BenchOp::kGet:
+      return 1;
+    case BenchOp::kUnknown:
+      return nullopt;
+  }
+
+  return nullopt;
+}
 
 static string GetRandomBlob(size_t len, bool ascii) {
   static bool is_random = GetFlag(FLAGS_random_data);
@@ -545,12 +559,12 @@ struct ClientStats {
   unsigned num_clients = 0;
 
   void AddLatencySample(BenchOp op, uint64_t usec, uint64_t elapsed_ns) {
-    int index = static_cast<int>(op);
-    if (index < 0 || index >= int(kTrackedOpCount))
+    optional<size_t> index = TrackedOpIndex(op);
+    if (!index || *index >= kTrackedOpCount)
       return;
 
-    op_stats[index].Add(usec);
-    time_series[elapsed_ns / 1'000'000'000ULL][index].Add(usec);
+    op_stats[*index].Add(usec);
+    time_series[elapsed_ns / 1'000'000'000ULL][*index].Add(usec);
   }
 
   ClientStats& operator+=(const ClientStats& o) {

--- a/tools/plot_memtier_latency.py
+++ b/tools/plot_memtier_latency.py
@@ -29,10 +29,8 @@ Note: If plotly is not available, falls back to static SVG charts.
 
 import json
 import matplotlib.pyplot as plt
-import numpy as np
 from pathlib import Path
 import webbrowser
-import tempfile
 import os
 
 # Try to import plotly for interactive charts
@@ -162,13 +160,18 @@ def plot_latency_chart_interactive(data, output_file="latency_chart.html", open_
         specs = [[{"secondary_y": False}] for _ in range(rows)]
         subplot_titles = [f"{op} Latency" for op in operations] + ["Throughput"]
 
+    # Plotly's default subplot title placement gets cramped once we have multiple rows.
+    # Use a taller layout and more inter-row spacing so titles do not overlap the plots below.
+    vertical_spacing = 0.18 if rows == 2 else 0.14
+    figure_height = 360 * rows
+
     # Create subplots
     fig = make_subplots(
         rows=rows,
         cols=cols,
         subplot_titles=subplot_titles,
         specs=specs,
-        vertical_spacing=0.12,
+        vertical_spacing=vertical_spacing,
         horizontal_spacing=0.1,
     )
 
@@ -289,11 +292,15 @@ def plot_latency_chart_interactive(data, output_file="latency_chart.html", open_
     # Update layout
     fig.update_layout(
         title_text="Memtier Benchmark - Latency Analysis (Interactive - Click legend to toggle)",
-        height=300 * rows,
+        height=figure_height,
         hovermode="x unified",
         showlegend=True,
         legend=dict(orientation="v", yanchor="top", y=1, xanchor="left", x=1.02),
+        margin=dict(t=110, b=120, l=80, r=220),
     )
+
+    for annotation in fig.layout.annotations[: len(subplot_titles)]:
+        annotation.update(font=dict(size=13), yshift=12)
 
     # Add annotation with statistics
     stats_lines = ["<b>Overall Statistics (last 3 seconds excluded):</b><br>"]
@@ -482,7 +489,7 @@ def print_summary(data):
     config = data["configuration"]
     runtime = data["ALL STATS"]["Runtime"]
 
-    print(f"\nConfiguration:")
+    print("\nConfiguration:")
     print(f"  Server: {config['server']}:{config['port']}")
     print(f"  Clients: {config['clients']}")
     print(f"  Threads: {config['threads']}")
@@ -534,10 +541,10 @@ def main():
     if not Path(input_file).exists():
         print(f"Error: Input file '{input_file}' not found!")
         print(f"\nUsage: {sys.argv[0]} [input_file.json] [output_file.html|.svg]")
-        print(f"\nTo generate the JSON file, run memtier_benchmark with --json-out-file:")
-        print(f"  memtier_benchmark --server <host> --port <port> \\")
-        print(f"      --json-out-file memtier_out.json \\")
-        print(f"      [other options...]")
+        print("\nTo generate the JSON file, run memtier_benchmark with --json-out-file:")
+        print("  memtier_benchmark --server <host> --port <port> \\")
+        print("      --json-out-file memtier_out.json \\")
+        print("      [other options...]")
         sys.exit(1)
 
     # Load and process data
@@ -548,7 +555,7 @@ def main():
     print_summary(data)
 
     # Generate chart
-    print(f"Generating latency chart...")
+    print("Generating latency chart...")
 
     # Use interactive chart if output is .html, otherwise use matplotlib
     if output_file.endswith(".html"):
@@ -556,9 +563,9 @@ def main():
     else:
         plot_latency_chart(data, output_file)
 
-    print(f"\nDone!")
+    print("\nDone!")
     if PLOTLY_AVAILABLE:
-        print(f"Tip: Use .html extension for interactive charts with toggleable series")
+        print("Tip: Use .html extension for interactive charts with toggleable series")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Add memtier-style Totals output for dfly_bench JSON reports, allow custom commands in json_out_file mode, and improve interactive plot spacing so subplot titles do not overlap.

## Changes
- support json_out_file with custom dfly_bench commands
- add ALL STATS.Totals with aggregated Time-Serie data
- increase Plotly subplot spacing and clean up plot_memtier_latency.py
