### PR TITLE
Add repl backlog memory metric

### DIFF
--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2007,6 +2007,8 @@ void PrintPrometheusMetrics(uint64_t uptime, const Metrics& m, DflyCmd* dfly_cmd
 
   AppendMetricValue("memory_by_class_bytes", m.interned_string_stats.pool_table_bytes, {"class"},
                     {"interned_string_table"}, &memory_by_class_bytes);
+  AppendMetricValue("memory_by_class_bytes", m.lsn_buffer_bytes, {"class"}, {"repl_backlog_buffer"},
+                    &memory_by_class_bytes);
 
   // Interned string stats
   AppendMetricWithoutLabels("interned_string_entries", "Number of unique interned strings",


### PR DESCRIPTION
Summary:
Expose the replication backlog buffer in the Prometheus memory_by_class_bytes metric.

Fixes https://github.com/dragonflydb/dragonfly/issues/7639