### PR TITLE
fix: bound CMS dimensions to prevent heap overflow on INITBYDIM/INITBYPROB

### DIFF
--- a/src/core/cms.cc
+++ b/src/core/cms.cc
@@ -15,6 +15,11 @@
 namespace dfly {
 namespace {
 
+size_t AllocationSize(size_t len) {
+  CHECK_LE(len, std::numeric_limits<size_t>::max() / sizeof(int64_t));
+  return len * sizeof(int64_t);
+}
+
 uint32_t Offset(uint64_t h1, uint64_t h2, uint32_t row, uint32_t width) {
   uint32_t idx = static_cast<uint32_t>((h1 + (row * h2)) % width);
   return row * width + idx;
@@ -25,13 +30,13 @@ uint32_t Offset(uint64_t h1, uint64_t h2, uint32_t row, uint32_t width) {
 CMS::CMS(uint32_t width, uint32_t depth, PMR_NS::memory_resource* mr)
     : width_(width), depth_(depth), mr_(mr) {
   size_t len = NumCounters();
-  counters_ = static_cast<int64_t*>(mr_->allocate(len * sizeof(int64_t), alignof(int64_t)));
+  counters_ = static_cast<int64_t*>(mr_->allocate(AllocationSize(len), alignof(int64_t)));
   std::fill_n(counters_, len, 0);
 }
 
 CMS::~CMS() {
   if (counters_) {
-    mr_->deallocate(counters_, NumCounters() * sizeof(int64_t), alignof(int64_t));
+    mr_->deallocate(counters_, AllocationSize(NumCounters()), alignof(int64_t));
   }
 }
 
@@ -50,7 +55,7 @@ CMS::CMS(CMS&& other) noexcept
 CMS& CMS::operator=(CMS&& other) noexcept {
   if (this != &other) {
     if (counters_) {
-      mr_->deallocate(counters_, NumCounters() * sizeof(int64_t), alignof(int64_t));
+      mr_->deallocate(counters_, AllocationSize(NumCounters()), alignof(int64_t));
     }
     width_ = other.width_;
     depth_ = other.depth_;

--- a/src/server/cms_family.cc
+++ b/src/server/cms_family.cc
@@ -2,6 +2,11 @@
 // See LICENSE for licensing terms.
 //
 
+#include <absl/strings/str_cat.h>
+
+#include <cmath>
+#include <limits>
+
 #include "core/cms.h"
 #include "facade/cmd_arg_parser.h"
 #include "facade/error.h"
@@ -27,6 +32,41 @@ constexpr char kCmsWrongNumKeys[] = "CMS: wrong number of keys";
 constexpr char kCmsWrongNumKeysWeights[] = "CMS: wrong number of keys/weights";
 constexpr char kCmsCannotParseNumber[] = "CMS: Cannot parse number";
 
+constexpr uint32_t kMaxCmsWidth = 1'000'000;
+constexpr uint32_t kMaxCmsDepth = 100;
+
+bool ValidateCmsDimensions(uint32_t width, uint32_t depth, RedisReplyBuilder* rb) {
+  if (width == 0 || depth == 0) {
+    rb->SendError("CMS: width and depth must be greater than 0");
+    return false;
+  }
+
+  if ((width > kMaxCmsWidth) || (depth > kMaxCmsDepth)) {
+    rb->SendError(absl::StrCat("CMS: width must not exceed ", kMaxCmsWidth,
+                               " and depth must not exceed ", kMaxCmsDepth));
+    return false;
+  }
+
+  return true;
+}
+
+bool ComputeCmsDimensions(double error, double probability, RedisReplyBuilder* rb, uint32_t* width,
+                          uint32_t* depth) {
+  double computed_width = std::ceil(M_E / error);
+  double computed_depth = std::ceil(std::log(1.0 / probability));
+
+  if (!std::isfinite(computed_width) || !std::isfinite(computed_depth) || computed_width <= 0 ||
+      computed_depth <= 0 || computed_width > std::numeric_limits<uint32_t>::max() ||
+      computed_depth > std::numeric_limits<uint32_t>::max()) {
+    rb->SendError("CMS: invalid error/probability");
+    return false;
+  }
+
+  *width = static_cast<uint32_t>(computed_width);
+  *depth = static_cast<uint32_t>(computed_depth);
+  return ValidateCmsDimensions(*width, *depth, rb);
+}
+
 OpStatus OpInitByDim(const OpArgs& op_args, string_view key, uint32_t width, uint32_t depth) {
   auto& db_slice = op_args.GetDbSlice();
   auto op_res = db_slice.AddOrFind(op_args.db_cntx, key, OBJ_CMS);
@@ -37,22 +77,6 @@ OpStatus OpInitByDim(const OpArgs& op_args, string_view key, uint32_t width, uin
 
   PrimeValue& pv = op_res->it->second;
   pv.SetCMS(width, depth);
-
-  return OpStatus::OK;
-}
-
-OpStatus OpInitByProb(const OpArgs& op_args, string_view key, double error, double probability) {
-  auto& db_slice = op_args.GetDbSlice();
-  auto op_res = db_slice.AddOrFind(op_args.db_cntx, key, OBJ_CMS);
-  RETURN_ON_BAD_STATUS(op_res);
-
-  if (!op_res->is_new)
-    return OpStatus::KEY_EXISTS;
-
-  PrimeValue& pv = op_res->it->second;
-  CMS* cms = CompactObj::AllocateMR<CMS>(CMS::ErrorRateTag{}, error, probability,
-                                         CompactObj::memory_resource());
-  pv.SetCMS(cms);
 
   return OpStatus::OK;
 }
@@ -117,9 +141,8 @@ void CmdInitByDim(CmdArgList args, CommandContext* cmd_cntx) {
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   RETURN_ON_PARSE_ERROR(parser, rb);
 
-  if (width == 0 || depth == 0) {
-    return rb->SendError("CMS: width and depth must be greater than 0");
-  }
+  if (!ValidateCmsDimensions(width, depth, rb))
+    return;
 
   const auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpInitByDim(t->GetOpArgs(shard), key, width, depth);
@@ -151,8 +174,12 @@ void CmdInitByProb(CmdArgList args, CommandContext* cmd_cntx) {
     return rb->SendError("CMS: probability must be between 0 and 1 exclusive");
   }
 
+  uint32_t width = 0, depth = 0;
+  if (!ComputeCmsDimensions(error, probability, rb, &width, &depth))
+    return;
+
   const auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpInitByProb(t->GetOpArgs(shard), key, error, probability);
+    return OpInitByDim(t->GetOpArgs(shard), key, width, depth);
   };
 
   OpStatus res = cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));

--- a/src/server/cms_family_test.cc
+++ b/src/server/cms_family_test.cc
@@ -27,6 +27,20 @@ TEST_F(CmsFamilyTest, InitByDim) {
   EXPECT_THAT(resp, ErrArg("width and depth must be greater than 0"));
 }
 
+TEST_F(CmsFamilyTest, InitByDimRejectsOversizedDimensionsAndPreservesState) {
+  auto resp = Run({"cms.initbydim", "k", "2147483648", "1073741824"});
+  EXPECT_THAT(resp, ErrArg("width must not exceed"));
+  EXPECT_THAT(Run({"exists", "k"}), IntArg(0));
+
+  resp = Run({"cms.incrby", "k", "a", "1"});
+  EXPECT_THAT(resp, ErrArg("CMS: key does not exist"));
+  EXPECT_THAT(Run({"exists", "k"}), IntArg(0));
+
+  EXPECT_EQ(Run({"cms.initbydim", "safe", "100", "5"}), "OK");
+  EXPECT_THAT(Run({"cms.incrby", "safe", "a", "1"}), RespElementsAre(IntArg(1)));
+  EXPECT_THAT(Run({"cms.query", "safe", "a"}), RespElementsAre(IntArg(1)));
+}
+
 TEST_F(CmsFamilyTest, InitByProb) {
   auto resp = Run("cms.initbyprob cms1 0.01 0.01");
   EXPECT_EQ(resp, "OK");
@@ -39,6 +53,12 @@ TEST_F(CmsFamilyTest, InitByProb) {
 
   resp = Run("cms.initbyprob cms3 0.01 0");
   EXPECT_THAT(resp, ErrArg("probability must be between 0 and 1"));
+}
+
+TEST_F(CmsFamilyTest, InitByProbRejectsOversizedDerivedDimensions) {
+  auto resp = Run({"cms.initbyprob", "cms", "0.000001", "0.01"});
+  EXPECT_THAT(resp, ErrArg("width must not exceed"));
+  EXPECT_THAT(Run({"exists", "cms"}), IntArg(0));
 }
 
 TEST_F(CmsFamilyTest, IncrBy) {

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2040,8 +2040,8 @@ io::Result<RdbLoaderBase::OpaqueObj> RdbLoaderBase::ReadCMS() {
 
   SET_OR_UNEXPECT(LoadLen(nullptr), res.total_incr_count);
 
-  // Safely check for multiplication overflow BEFORE multiplying
-  if (depth > 0 && width > (SIZE_MAX / depth))
+  // Reject dimensions whose counter buffer (num_counters * sizeof(int64_t)) would overflow size_t.
+  if (width > (SIZE_MAX / sizeof(int64_t)) / depth)
     return Unexpected(errc::rdb_file_corrupted);
 
   res.width = static_cast<uint32_t>(width);

--- a/src/server/topk_family.cc
+++ b/src/server/topk_family.cc
@@ -219,11 +219,6 @@ void TopkFamily::Reserve(CmdArgList args, CommandContext* cmd_cntx) {
     return rb->SendError(kSyntaxErr);
   }
 
-  // Guard against overflow: width * depth * sizeof(uint32_t) must fit in size_t.
-  if (width > SIZE_MAX / sizeof(uint32_t) / depth) {
-    return rb->SendError("width * depth is too large");
-  }
-
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpReserve(t->GetOpArgs(shard), key, k, width, depth, decay);
   };


### PR DESCRIPTION
CMS.INITBYDIM accepted unbounded width/depth and CMS.INITBYPROB derived an unbounded width from the error rate. The constructor sized the backing array as width * depth * sizeof(int64_t); a large width/depth wrapped the size_t byte count to a small/zero allocation, so a subsequent CMS.INCRBY wrote out of bounds. Reachable without auth, this is a remote crash plus a controllable heap out-of-bounds write.

Changes:
- Cap CMS width at 1,000,000 and depth at 100 in CmdInitByDim, matching the TOPK limits.
- Compute and validate INITBYPROB dimensions in the handler before scheduling the transaction; guard the double->uint32 conversion against non-finite/out-of-range values.
- Add an AllocationSize() guard in core/cms.cc so every CMS construction path (commands, snapshot load, merge) aborts safely instead of overflowing the byte count.
- Remove a now-unreachable width*depth overflow check in CmdInitByDim and the equivalent dead check in TOPK Reserve (the dimension caps already make overflow impossible).
- Tests: reproduce the reported INITBYDIM proof of concept, cover oversized INITBYPROB dimensions, and verify no key/state is created on rejection.
