### PR TITLE
fix(tiering): Fix tiered list memory accounting on materialized nodes

### DIFF
--- a/src/core/qlist.cc
+++ b/src/core/qlist.cc
@@ -430,7 +430,7 @@ void QList::Node::Upload(QList* ql, std::string_view val) {
   entry = static_cast<unsigned char*>(zmalloc(val.size()));
   memcpy(entry, val.data(), val.size());
   ql->AdjustMallocSize(val.size());
-  ql->AdjustAccountedObjectSize(val.size());
+  ql->AddReportedMemorySizeDelta(val.size());
   ql->AdjustOffloadNodeCount(-1);
   offloaded = 0;
 }

--- a/src/core/qlist.cc
+++ b/src/core/qlist.cc
@@ -430,7 +430,7 @@ void QList::Node::Upload(QList* ql, std::string_view val) {
   entry = static_cast<unsigned char*>(zmalloc(val.size()));
   memcpy(entry, val.data(), val.size());
   ql->AdjustMallocSize(val.size());
-  ql->AddReportedMemorySizeDelta(val.size());
+  ql->AddReportedMemorySizeDelta(static_cast<int32_t>(val.size()));
   ql->AdjustOffloadNodeCount(-1);
   offloaded = 0;
 }

--- a/src/core/qlist.cc
+++ b/src/core/qlist.cc
@@ -430,6 +430,7 @@ void QList::Node::Upload(QList* ql, std::string_view val) {
   entry = static_cast<unsigned char*>(zmalloc(val.size()));
   memcpy(entry, val.data(), val.size());
   ql->AdjustMallocSize(val.size());
+  ql->AdjustAccountedObjectSize(val.size());
   ql->AdjustOffloadNodeCount(-1);
   offloaded = 0;
 }

--- a/src/core/qlist.h
+++ b/src/core/qlist.h
@@ -123,7 +123,7 @@ class QList {
     malloc_size_ += delta;
   }
 
-  void AddReportedMemorySizeDelta(size_t delta) {
+  void AddReportedMemorySizeDelta(int32_t delta) {
     if (tiering_enabled_) {
       tiering_params_->reported_memory_size_delta += delta;
     }

--- a/src/core/qlist.h
+++ b/src/core/qlist.h
@@ -119,13 +119,13 @@ class QList {
   using IterateFunc = absl::FunctionRef<bool(Entry)>;
   enum InsertOpt : uint8_t { BEFORE, AFTER };
 
-  void AdjustMallocSize(size_t delta) {
+  void AdjustMallocSize(ssize_t delta) {
     malloc_size_ += delta;
   }
 
-  void AdjustAccountedObjectSize(size_t delta) {
+  void AddReportedMemorySizeDelta(size_t delta) {
     if (tiering_enabled_) {
-      tiering_params_->accounted_object_size += delta;
+      tiering_params_->reported_memory_size_delta += delta;
     }
   }
 
@@ -143,7 +143,7 @@ class QList {
   struct TieringParams {
     uint32_t num_offloaded_nodes = 0;
     uint32_t node_depth_threshold = 0;
-    int32_t accounted_object_size = 0;
+    int32_t reported_memory_size_delta = 0;
     void (*offload)(QList* ql, Node* node) = nullptr;
     void (*load)(QList* ql, Node* node) = nullptr;
     void (*cleanup)(QList* ql, Node* node) = nullptr;
@@ -289,13 +289,19 @@ class QList {
     tiering_params_ = std::make_unique<TieringParams>(params);
   }
 
-  int32_t ConsumeAccountedObjectSize() {
+  int32_t TakeReportedMemorySizeDelta() {
     if (tiering_enabled_) {
-      int32_t n = tiering_params_->accounted_object_size;
-      tiering_params_->accounted_object_size = 0;
+      int32_t n = tiering_params_->reported_memory_size_delta;
+      tiering_params_->reported_memory_size_delta = 0;
       return n;
     }
     return 0;
+  }
+
+  void ClearReportedMemorySizeDelta() {
+    if (tiering_enabled_) {
+      tiering_params_->reported_memory_size_delta = 0;
+    }
   }
 
   // Updates the db index associated with this list.

--- a/src/core/qlist.h
+++ b/src/core/qlist.h
@@ -119,8 +119,14 @@ class QList {
   using IterateFunc = absl::FunctionRef<bool(Entry)>;
   enum InsertOpt : uint8_t { BEFORE, AFTER };
 
-  void AdjustMallocSize(ssize_t delta) {
+  void AdjustMallocSize(size_t delta) {
     malloc_size_ += delta;
+  }
+
+  void AdjustAccountedObjectSize(size_t delta) {
+    if (tiering_enabled_) {
+      tiering_params_->accounted_object_size += delta;
+    }
   }
 
   // Add to the number of offloaded nodes by one.
@@ -133,9 +139,11 @@ class QList {
   DbIndex GetDbIndex() const {
     return db_id_;
   }
+
   struct TieringParams {
     uint32_t num_offloaded_nodes = 0;
     uint32_t node_depth_threshold = 0;
+    int32_t accounted_object_size = 0;
     void (*offload)(QList* ql, Node* node) = nullptr;
     void (*load)(QList* ql, Node* node) = nullptr;
     void (*cleanup)(QList* ql, Node* node) = nullptr;
@@ -279,6 +287,15 @@ class QList {
   void EnableTiering(const TieringParams& params) {
     tiering_enabled_ = 1;
     tiering_params_ = std::make_unique<TieringParams>(params);
+  }
+
+  int32_t ConsumeAccountedObjectSize() {
+    if (tiering_enabled_) {
+      int32_t n = tiering_params_->accounted_object_size;
+      tiering_params_->accounted_object_size = 0;
+      return n;
+    }
+    return 0;
   }
 
   // Updates the db index associated with this list.

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -532,10 +532,10 @@ void DbSlice::AutoUpdater::Run() {
     AccountObjectMemory(fields_.key, fields_.orig_obj_type,
                         -static_cast<int64_t>(fields_.orig_value_heap_size), table);
     AccountObjectMemory(fields_.key, current_type,
-                        current_size - fields_.already_accounted_object_size, table);
+                        current_size - fields_.manually_reported_memory_size_delta, table);
   } else {
     ssize_t delta = current_size - static_cast<int64_t>(fields_.orig_value_heap_size);
-    delta -= fields_.already_accounted_object_size;
+    delta -= fields_.manually_reported_memory_size_delta;
     AccountObjectMemory(fields_.key, current_type, delta, table);
   }
 

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -531,9 +531,11 @@ void DbSlice::AutoUpdater::Run() {
     // from a counter that never had the original bytes added to it.
     AccountObjectMemory(fields_.key, fields_.orig_obj_type,
                         -static_cast<int64_t>(fields_.orig_value_heap_size), table);
-    AccountObjectMemory(fields_.key, current_type, current_size, table);
+    AccountObjectMemory(fields_.key, current_type,
+                        current_size - fields_.already_accounted_object_size, table);
   } else {
     ssize_t delta = current_size - static_cast<int64_t>(fields_.orig_value_heap_size);
+    delta -= fields_.already_accounted_object_size;
     AccountObjectMemory(fields_.key, current_type, delta, table);
   }
 

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -181,8 +181,8 @@ class DbSlice {
     // Used when the existing object is overridden by a new one.
     void ReduceHeapUsage();
 
-    void SetAccountedObjectSize(int32_t delta) {
-      fields_.already_accounted_object_size += delta;
+    void AddManuallyReportedMemorySizeDelta(int32_t delta) {
+      fields_.manually_reported_memory_size_delta += delta;
     }
 
     void Run();
@@ -202,8 +202,9 @@ class DbSlice {
       size_t orig_value_heap_size = 0;
       CompactObjType orig_obj_type = 0;
 
-      // Field used to account for object memory that is adjusted outside of AutoUpdater.
-      int64_t already_accounted_object_size = 0;
+      // Memory size delta already reported to stats outside of AutoUpdater.
+      // Subtracted from AutoUpdater's own heap diff to avoid double-counting.
+      int32_t manually_reported_memory_size_delta = 0;
     };
 
     AutoUpdater(DbIndex db_ind, std::string_view key, const Iterator& it, DbSlice* db_slice);

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -181,6 +181,10 @@ class DbSlice {
     // Used when the existing object is overridden by a new one.
     void ReduceHeapUsage();
 
+    void SetAccountedObjectSize(int32_t delta) {
+      fields_.already_accounted_object_size += delta;
+    }
+
     void Run();
     void Cancel();
 
@@ -197,6 +201,9 @@ class DbSlice {
       // The following fields are calculated at init time
       size_t orig_value_heap_size = 0;
       CompactObjType orig_obj_type = 0;
+
+      // Field used to account for object memory that is adjusted outside of AutoUpdater.
+      int64_t already_accounted_object_size = 0;
     };
 
     AutoUpdater(DbIndex db_ind, std::string_view key, const Iterator& it, DbSlice* db_slice);

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -268,6 +268,12 @@ class ListWrapper {
     return VisitMut([&](auto& list) { return ReplaceInternal(index, elem, list); });
   }
 
+  int64_t AccountedObjectSize() {
+    return visit(Overload{[](QList* ql) -> int64_t { return ql->ConsumeAccountedObjectSize(); },
+                          [](const LP&) -> int64_t { return 0; }},
+                 impl_);
+  }
+
   void Erase(long start, long count) {
     VisitMut([&](auto& list) { list.Erase(start, count); });
   }
@@ -404,6 +410,8 @@ std::string OpBPop(Transaction* t, EngineShard* shard, std::string_view key, Lis
   lw.Launder(&it->second);
   len = lw.Size();
 
+  it_res->post_updater.SetAccountedObjectSize(lw.AccountedObjectSize());
+
   it_res->post_updater.Run();
 
   OpArgs op_args = t->GetOpArgs(shard);
@@ -451,6 +459,7 @@ OpResult<string> OpMoveSingleShard(const OpArgs& op_args, string_view src, strin
     val = srcql_v2.Pop(ToWhere(src_dir));
     srcql_v2.Push(val, ToWhere(dest_dir));
     srcql_v2.Launder(&src_it->second);
+    src_res->post_updater.SetAccountedObjectSize(srcql_v2.AccountedObjectSize());
     return val;
   }
 
@@ -471,6 +480,9 @@ OpResult<string> OpMoveSingleShard(const OpArgs& op_args, string_view src, strin
 
   dest_lw.Push(val, ToWhere(dest_dir));
   dest_lw.Launder(&dest_res.it->second);
+
+  src_res->post_updater.SetAccountedObjectSize(srcql_v2.AccountedObjectSize());
+  dest_res.post_updater.SetAccountedObjectSize(dest_lw.AccountedObjectSize());
 
   src_res->post_updater.Run();
   dest_res.post_updater.Run();
@@ -527,6 +539,8 @@ OpResult<uint32_t> OpPush(const OpArgs& op_args, std::string_view key, ListDir d
   lw.Launder(&res.it->second);
   len = lw.Size();
 
+  res.post_updater.SetAccountedObjectSize(lw.AccountedObjectSize());
+
   if (journal_rewrite && op_args.shard->journal()) {
     string command = dir == ListDir::LEFT ? "LPUSH" : "RPUSH";
     vector<string_view> mapped(vals.Size() + 1);
@@ -571,6 +585,8 @@ OpResult<StringVec> OpPop(const OpArgs& op_args, string_view key, ListDir dir, u
     }
   }
   lw.Launder(&it->second);
+
+  it_res->post_updater.SetAccountedObjectSize(lw.AccountedObjectSize());
 
   it_res->post_updater.Run();
 
@@ -711,6 +727,8 @@ OpResult<int> OpInsert(const OpArgs& op_args, string_view key, string_view pivot
     res = int(lw.Size());
   }
 
+  it_res->post_updater.SetAccountedObjectSize(lw.AccountedObjectSize());
+
   return res;
 }
 
@@ -731,6 +749,7 @@ OpResult<uint32_t> OpRem(const OpArgs& op_args, string_view key, string_view ele
   unsigned removed = lw.Remove(elem, count, where);
   size_t len = lw.Size();
   lw.Launder(&it_res->it->second);
+  it_res->post_updater.SetAccountedObjectSize(lw.AccountedObjectSize());
   it_res->post_updater.Run();
 
   if (len == 0) {
@@ -752,6 +771,8 @@ OpStatus OpSet(const OpArgs& op_args, string_view key, string_view elem, long in
     lw.Launder(&it_res->it->second);
     status = OpStatus::OK;
   }
+  it_res->post_updater.SetAccountedObjectSize(lw.AccountedObjectSize());
+
   return status;
 }
 
@@ -792,6 +813,8 @@ OpStatus OpTrim(const OpArgs& op_args, string_view key, long start, long end) {
   lw.Erase(0, ltrim);
   lw.Erase(-rtrim, rtrim);
   lw.Launder(&it->second);
+
+  it_res->post_updater.SetAccountedObjectSize(lw.AccountedObjectSize());
 
   it_res->post_updater.Run();
 

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -220,6 +220,9 @@ class ListWrapper {
   // another db so this dbid will be incorrect. Refactor to support moving objects between dbs.
   template <typename T>
   explicit ListWrapper(DbIndex dbid, T t) : db_id_(dbid), impl_(std::forward<T>(t)) {
+    if (auto* ql = std::get_if<QList*>(&impl_)) {
+      (*ql)->ClearReportedMemorySizeDelta();
+    }
   }
 
   size_t Size() const {
@@ -268,8 +271,8 @@ class ListWrapper {
     return VisitMut([&](auto& list) { return ReplaceInternal(index, elem, list); });
   }
 
-  int64_t AccountedObjectSize() {
-    return visit(Overload{[](QList* ql) -> int64_t { return ql->ConsumeAccountedObjectSize(); },
+  int64_t ReportedMemorySizeDelta() {
+    return visit(Overload{[](QList* ql) -> int64_t { return ql->TakeReportedMemorySizeDelta(); },
                           [](const LP&) -> int64_t { return 0; }},
                  impl_);
   }
@@ -410,7 +413,7 @@ std::string OpBPop(Transaction* t, EngineShard* shard, std::string_view key, Lis
   lw.Launder(&it->second);
   len = lw.Size();
 
-  it_res->post_updater.SetAccountedObjectSize(lw.AccountedObjectSize());
+  it_res->post_updater.AddManuallyReportedMemorySizeDelta(lw.ReportedMemorySizeDelta());
 
   it_res->post_updater.Run();
 
@@ -459,7 +462,7 @@ OpResult<string> OpMoveSingleShard(const OpArgs& op_args, string_view src, strin
     val = srcql_v2.Pop(ToWhere(src_dir));
     srcql_v2.Push(val, ToWhere(dest_dir));
     srcql_v2.Launder(&src_it->second);
-    src_res->post_updater.SetAccountedObjectSize(srcql_v2.AccountedObjectSize());
+    src_res->post_updater.AddManuallyReportedMemorySizeDelta(srcql_v2.ReportedMemorySizeDelta());
     return val;
   }
 
@@ -481,8 +484,8 @@ OpResult<string> OpMoveSingleShard(const OpArgs& op_args, string_view src, strin
   dest_lw.Push(val, ToWhere(dest_dir));
   dest_lw.Launder(&dest_res.it->second);
 
-  src_res->post_updater.SetAccountedObjectSize(srcql_v2.AccountedObjectSize());
-  dest_res.post_updater.SetAccountedObjectSize(dest_lw.AccountedObjectSize());
+  src_res->post_updater.AddManuallyReportedMemorySizeDelta(srcql_v2.ReportedMemorySizeDelta());
+  dest_res.post_updater.AddManuallyReportedMemorySizeDelta(dest_lw.ReportedMemorySizeDelta());
 
   src_res->post_updater.Run();
   dest_res.post_updater.Run();
@@ -539,7 +542,7 @@ OpResult<uint32_t> OpPush(const OpArgs& op_args, std::string_view key, ListDir d
   lw.Launder(&res.it->second);
   len = lw.Size();
 
-  res.post_updater.SetAccountedObjectSize(lw.AccountedObjectSize());
+  res.post_updater.AddManuallyReportedMemorySizeDelta(lw.ReportedMemorySizeDelta());
 
   if (journal_rewrite && op_args.shard->journal()) {
     string command = dir == ListDir::LEFT ? "LPUSH" : "RPUSH";
@@ -586,7 +589,7 @@ OpResult<StringVec> OpPop(const OpArgs& op_args, string_view key, ListDir dir, u
   }
   lw.Launder(&it->second);
 
-  it_res->post_updater.SetAccountedObjectSize(lw.AccountedObjectSize());
+  it_res->post_updater.AddManuallyReportedMemorySizeDelta(lw.ReportedMemorySizeDelta());
 
   it_res->post_updater.Run();
 
@@ -727,7 +730,7 @@ OpResult<int> OpInsert(const OpArgs& op_args, string_view key, string_view pivot
     res = int(lw.Size());
   }
 
-  it_res->post_updater.SetAccountedObjectSize(lw.AccountedObjectSize());
+  it_res->post_updater.AddManuallyReportedMemorySizeDelta(lw.ReportedMemorySizeDelta());
 
   return res;
 }
@@ -749,7 +752,7 @@ OpResult<uint32_t> OpRem(const OpArgs& op_args, string_view key, string_view ele
   unsigned removed = lw.Remove(elem, count, where);
   size_t len = lw.Size();
   lw.Launder(&it_res->it->second);
-  it_res->post_updater.SetAccountedObjectSize(lw.AccountedObjectSize());
+  it_res->post_updater.AddManuallyReportedMemorySizeDelta(lw.ReportedMemorySizeDelta());
   it_res->post_updater.Run();
 
   if (len == 0) {
@@ -771,7 +774,7 @@ OpStatus OpSet(const OpArgs& op_args, string_view key, string_view elem, long in
     lw.Launder(&it_res->it->second);
     status = OpStatus::OK;
   }
-  it_res->post_updater.SetAccountedObjectSize(lw.AccountedObjectSize());
+  it_res->post_updater.AddManuallyReportedMemorySizeDelta(lw.ReportedMemorySizeDelta());
 
   return status;
 }
@@ -814,7 +817,7 @@ OpStatus OpTrim(const OpArgs& op_args, string_view key, long start, long end) {
   lw.Erase(-rtrim, rtrim);
   lw.Launder(&it->second);
 
-  it_res->post_updater.SetAccountedObjectSize(lw.AccountedObjectSize());
+  it_res->post_updater.AddManuallyReportedMemorySizeDelta(lw.ReportedMemorySizeDelta());
 
   it_res->post_updater.Run();
 

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -271,9 +271,9 @@ class ListWrapper {
     return VisitMut([&](auto& list) { return ReplaceInternal(index, elem, list); });
   }
 
-  int64_t ReportedMemorySizeDelta() {
-    return visit(Overload{[](QList* ql) -> int64_t { return ql->TakeReportedMemorySizeDelta(); },
-                          [](const LP&) -> int64_t { return 0; }},
+  int32_t ReportedMemorySizeDelta() {
+    return visit(Overload{[](QList* ql) -> int32_t { return ql->TakeReportedMemorySizeDelta(); },
+                          [](const LP&) -> int32_t { return 0; }},
                  impl_);
   }
 

--- a/src/server/tiered_storage.cc
+++ b/src/server/tiered_storage.cc
@@ -299,8 +299,8 @@ class TieredStorage::ShardOpManager : public tiering::OpManager {
 
     // Adjust parent QList node malloc size / number of offloaded nodes.
     ql->AdjustMallocSize(-segment.length);
+    ql->AddReportedMemorySizeDelta(-static_cast<int32_t>(segment.length));
     node->SetExternal(segment.offset, segment.length);
-
     stats->AddTypeMemoryUsage(OBJ_LIST, -segment.length);
   }
 

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -1041,6 +1041,70 @@ TEST_F(ListNodeTieringTest, PushAfterOffloadedNodePromotedToTail) {
   EXPECT_THAT(Run({"LLEN", "mylist"}), IntArg(kTrimmedItems));
 }
 
+// Test memory accounting for tiered lists. Reading and mutating tiered list nodes should keep
+// tracked list memory in sync with the actual in-memory list size.
+TEST_F(ListNodeTieringTest, ListTieringMemoryAccounting) {
+  const int kItems = 8;
+  const size_t kNodeSize = 4096;
+  const string kReadListKey = "read_cmd_on_list";
+  const string kMutableListKey = "mutable_command_on_list";
+
+  // Read the tracked object heap size for a single list key on its owning shard.
+  auto list_malloc_used = [](string_view key) {
+    size_t result = 0;
+    ShardId sid = Shard(key, shard_set->size());
+    shard_set->Await(sid, [key, &result] {
+      auto& db_slice =
+          namespaces->GetDefaultNamespace().GetDbSlice(EngineShard::tlocal()->shard_id());
+      auto* table = db_slice.GetDBTable(0);
+      auto it = table->prime.Find(key);
+      ASSERT_TRUE(IsValid(it));
+      result = it->second.MallocUsed();
+    });
+    return result;
+  };
+
+  // The test uses one list at a time, so OBJ_LIST type memory should match that list exactly.
+  auto expect_list_memory = [this, &list_malloc_used](string_view key) {
+    size_t list_memory = GetMetrics().db_stats[0].memory_usage_by_type[OBJ_LIST];
+    size_t malloc_used = list_malloc_used(key);
+    EXPECT_EQ(list_memory, malloc_used);
+  };
+
+  // Build a list with large one-item nodes and wait for at least one interior node to be offloaded.
+  auto push_list_and_wait = [this, kItems, kNodeSize, &expect_list_memory](string_view key) {
+    size_t stashes_before = GetMetrics().tiered_stats.total_stashes;
+    for (int i = 0; i < kItems; i++) {
+      Run({"RPUSH", string{key}, BuildString(kNodeSize, static_cast<char>('a' + i))});
+    }
+    ExpectConditionWithinTimeout([this, stashes_before] {
+      auto metrics = GetMetrics().tiered_stats;
+      return metrics.total_stashes > stashes_before && metrics.pending_stash_cnt == 0;
+    });
+    // Check that the list memory accounting matches the malloc used for the list key after tiering.
+    expect_list_memory(key);
+  };
+
+  // Read-only materialization.
+  push_list_and_wait(kReadListKey);
+  size_t fetches_before = GetMetrics().tiered_stats.total_fetches;
+  EXPECT_EQ(Run({"LINDEX", kReadListKey, "2"}), BuildString(kNodeSize, 'c'));
+  EXPECT_GT(GetMetrics().tiered_stats.total_fetches, fetches_before);
+  expect_list_memory(kReadListKey);
+  EXPECT_THAT(Run({"DEL", kReadListKey}), IntArg(1));
+
+  // Expect list memory to be zero after deletion
+  EXPECT_EQ(GetMetrics().db_stats[0].memory_usage_by_type[OBJ_LIST], 0u);
+
+  // Mutable materialization.
+  push_list_and_wait(kMutableListKey);
+  fetches_before = GetMetrics().tiered_stats.total_fetches;
+  EXPECT_EQ(Run({"LSET", kMutableListKey, "2", "z"}), "OK");
+  EXPECT_GT(GetMetrics().tiered_stats.total_fetches, fetches_before);
+  EXPECT_EQ(Run({"LINDEX", kMutableListKey, "2"}), "z");
+  expect_list_memory(kMutableListKey);
+}
+
 // Test MEMORY DECOMMIT COOL command flushes the cool queue
 TEST_P(LatentCoolingTSTest, MemoryDecommitCool) {
   absl::FlagSaver saver;

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -1117,7 +1117,6 @@ TEST_F(ListNodeTieringTest, ListTieringMemoryAccounting) {
   EXPECT_GT(GetMetrics().tiered_stats.total_fetches, fetches_before);
   expect_list_memory(kReadWritListeKey);
 
-  fetches_before = GetMetrics().tiered_stats.total_fetches;
   EXPECT_EQ(Run({"LPOP", kReadWritListeKey}), BuildString(kNodeSize, 'a'));
   expect_list_memory(kReadWritListeKey);
 }

--- a/src/server/tiered_storage_test.cc
+++ b/src/server/tiered_storage_test.cc
@@ -1047,7 +1047,8 @@ TEST_F(ListNodeTieringTest, ListTieringMemoryAccounting) {
   const int kItems = 8;
   const size_t kNodeSize = 4096;
   const string kReadListKey = "read_cmd_on_list";
-  const string kMutableListKey = "mutable_command_on_list";
+  const string kWriteListKey = "mutable_command_on_list";
+  const string kReadWritListeKey = "read_then_write_command_on_list";
 
   // Read the tracked object heap size for a single list key on its owning shard.
   auto list_malloc_used = [](string_view key) {
@@ -1085,24 +1086,40 @@ TEST_F(ListNodeTieringTest, ListTieringMemoryAccounting) {
     expect_list_memory(key);
   };
 
-  // Read-only materialization.
+  // 1. Read-only materialization.
   push_list_and_wait(kReadListKey);
   size_t fetches_before = GetMetrics().tiered_stats.total_fetches;
   EXPECT_EQ(Run({"LINDEX", kReadListKey, "2"}), BuildString(kNodeSize, 'c'));
   EXPECT_GT(GetMetrics().tiered_stats.total_fetches, fetches_before);
   expect_list_memory(kReadListKey);
-  EXPECT_THAT(Run({"DEL", kReadListKey}), IntArg(1));
 
   // Expect list memory to be zero after deletion
+  EXPECT_THAT(Run({"DEL", kReadListKey}), IntArg(1));
   EXPECT_EQ(GetMetrics().db_stats[0].memory_usage_by_type[OBJ_LIST], 0u);
 
-  // Mutable materialization.
-  push_list_and_wait(kMutableListKey);
+  // 2. Mutable materialization.
+  push_list_and_wait(kWriteListKey);
   fetches_before = GetMetrics().tiered_stats.total_fetches;
-  EXPECT_EQ(Run({"LSET", kMutableListKey, "2", "z"}), "OK");
+  EXPECT_EQ(Run({"LSET", kWriteListKey, "2", "z"}), "OK");
   EXPECT_GT(GetMetrics().tiered_stats.total_fetches, fetches_before);
-  EXPECT_EQ(Run({"LINDEX", kMutableListKey, "2"}), "z");
-  expect_list_memory(kMutableListKey);
+  EXPECT_EQ(Run({"LINDEX", kWriteListKey, "2"}), "z");
+  expect_list_memory(kWriteListKey);
+
+  // Expect list memory to be zero after deletion
+  EXPECT_THAT(Run({"DEL", kWriteListKey}), IntArg(1));
+  EXPECT_EQ(GetMetrics().db_stats[0].memory_usage_by_type[OBJ_LIST], 0u);
+
+  // 3. Test read-only then mutable operations on same key.
+  push_list_and_wait(kReadWritListeKey);
+
+  fetches_before = GetMetrics().tiered_stats.total_fetches;
+  EXPECT_EQ(Run({"LINDEX", kReadWritListeKey, "3"}), BuildString(kNodeSize, 'd'));
+  EXPECT_GT(GetMetrics().tiered_stats.total_fetches, fetches_before);
+  expect_list_memory(kReadWritListeKey);
+
+  fetches_before = GetMetrics().tiered_stats.total_fetches;
+  EXPECT_EQ(Run({"LPOP", kReadWritListeKey}), BuildString(kNodeSize, 'a'));
+  expect_list_memory(kReadWritListeKey);
 }
 
 // Test MEMORY DECOMMIT COOL command flushes the cool queue


### PR DESCRIPTION
When a QList node is offloaded, uploading it back into memory allocates the node 
payload before DbSlice::AutoUpdater recalculates object memory usage. Both mutable
and non-mutable list commands can materialize nodes through the same tiering load
path, so accounting has to be handled at the tiering/QList layer instead of only in individual 
command handlers.

Track bytes accounted by QList uploads while tiering is enabled, then have list mutation 
paths pass that amount into AutoUpdater so it is subtracted from the final object-memory 
delta. This keeps OBJ_LIST metrics aligned with the list object's actual malloc usage across
read-only fetches and mutating commands that materialize tiered nodes.

Also add a tiered list regression test that compares tracked OBJ_LIST memory against the 
owning list object's MallocUsed value.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
