### PR TITLE
chore: migrate server_family/dflycmd/debug/cluster/search to ParsedArgs

### DIFF
--- a/src/server/cluster/cluster_family.cc
+++ b/src/server/cluster/cluster_family.cc
@@ -643,7 +643,7 @@ void ClusterFamily::DflyClusterConfig(CmdArgList args, CommandContext* cmd_cntx)
 }
 
 void ClusterFamily::DflyClusterGetSlotInfo(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser(args);
+  CmdArgParser parser(cmd_cntx->tail_args().Tail());
   parser.ExpectTag("SLOTS");
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
@@ -734,7 +734,7 @@ void ClusterFamily::DflyClusterFlushSlots(CmdArgList args, CommandContext* cmd_c
 
   std::vector<SlotRange> slot_ranges;
 
-  CmdArgParser parser(args);
+  CmdArgParser parser(cmd_cntx->tail_args().Tail());
   do {
     auto [slot_start, slot_end] = parser.Next<ParsedSlotId, ParsedSlotId>();
     RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
@@ -788,7 +788,7 @@ static string_view StateToStr(MigrationState state) {
 }
 
 void ClusterFamily::DflySlotMigrationStatus(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser(args);
+  CmdArgParser parser(cmd_cntx->tail_args().Tail());
 
   util::fb2::LockGuard lk(migration_mu_);
 
@@ -948,7 +948,7 @@ SlotRanges ClusterFamily::RemoveIncomingMigrations(const std::vector<MigrationIn
 
 void ClusterFamily::InitMigration(CmdArgList args, CommandContext* cmd_cntx) {
   VLOG(1) << "Create incoming migration, args: " << args;
-  CmdArgParser parser{args};
+  CmdArgParser parser{cmd_cntx->tail_args().Tail()};
 
   auto [source_id, flows_num] = parser.Next<string_view, uint32_t>();
 
@@ -1006,7 +1006,7 @@ void ClusterFamily::InitMigration(CmdArgList args, CommandContext* cmd_cntx) {
 }
 
 void ClusterFamily::DflyMigrateFlow(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{args};
+  CmdArgParser parser{cmd_cntx->tail_args().Tail()};
   auto [source_id, shard_id] = parser.Next<std::string_view, uint32_t>();
 
   RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
@@ -1092,7 +1092,7 @@ void ClusterFamily::ApplyMigrationSlotRangeToConfig(std::string_view node_id,
 }
 
 void ClusterFamily::DflyMigrateAck(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{args};
+  CmdArgParser parser{cmd_cntx->tail_args().Tail()};
   auto [source_id, attempt] = parser.Next<std::string_view, long>();
 
   RETURN_ON_PARSE_ERROR(parser, cmd_cntx);

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -884,7 +884,7 @@ enum PopulateFlag { FLAG_RAND, FLAG_TYPE, FLAG_ELEMENTS, FLAG_SLOT, FLAG_EXPIRE,
 // optional: [RAND | TYPE typename | ELEMENTS element num | SLOTS (key value)+ | EXPIRE start end]
 optional<DebugCmd::PopulateOptions> DebugCmd::ParsePopulateArgs(CmdArgList args,
                                                                 CommandContext* cmd_cntx) {
-  CmdArgParser parser(args.subspan(1));
+  CmdArgParser parser(cmd_cntx->tail_args().Tail());
   PopulateOptions options;
 
   options.total_count = parser.Next<uint64_t>();
@@ -1073,7 +1073,7 @@ void DebugCmd::LogTraffic(CmdArgList args, CommandContext* cmd_cntx) {
   // A recording captures exactly one source; LISTENER and REPLICA are mutually
   // exclusive. REPLICA captures commands received from a master via the
   // replication stream (only meaningful while this server is a replica).
-  CmdArgParser parser(args);
+  CmdArgParser parser(cmd_cntx->tail_args().Tail());
   if (parser.Check("STOP")) {
     if (!parser.Finalize())
       return cmd_cntx->SendError(parser.TakeError().MakeReply());
@@ -1570,7 +1570,7 @@ static size_t PostProcessHist(HufHist* dest) {
 
 void DebugCmd::Compression(CmdArgList args, CommandContext* cmd_cntx) {
   CompactObjType type = kInvalidCompactObjType;
-  CmdArgParser parser(args);
+  CmdArgParser parser(cmd_cntx->tail_args().Tail());
   string bintable;
   bool print_bintable = false;
 

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -500,7 +500,7 @@ std::optional<LSN> DflyCmd::ParseLsnVec(std::string_view last_master_lsn,
 // timeout_sec - number of seconds to wait for TAKEOVER to converge.
 // SAVE option is used only by tests.
 void DflyCmd::TakeOver(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{args};
+  CmdArgParser parser{cmd_cntx->tail_args()};
   parser.Next();
   float timeout = std::ceil(parser.Next<float>());
   if (timeout < 0) {
@@ -660,7 +660,7 @@ void DflyCmd::ReplicaOffset(CmdArgList args, CommandContext* cmd_cntx) {
 }
 
 void DflyCmd::Load(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{args};
+  CmdArgParser parser{cmd_cntx->tail_args()};
   parser.ExpectTag("LOAD");
   string filename = parser.Next<string>();
   ServerFamily::LoadExistingKeys existing_keys = ServerFamily::LoadExistingKeys::kFail;

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -2374,7 +2374,7 @@ void CmdFtCreate(CmdArgList args, CommandContext* cmd_cntx) {
     return builder->SendError("Cannot create index on db != 0"sv);
   }
 
-  CmdArgParser parser{args};
+  CmdArgParser parser{cmd_cntx->tail_args()};
   string_view idx_name = parser.Next();
 
   // Parse optional NX (Only create if not exists) parameter for internal usage
@@ -2433,7 +2433,7 @@ void CmdFtCreate(CmdArgList args, CommandContext* cmd_cntx) {
 }
 
 void CmdFtAlter(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{args};
+  CmdArgParser parser{cmd_cntx->tail_args()};
   string_view idx_name = parser.Next();
   parser.ExpectTag("SCHEMA");
   parser.ExpectTag("ADD");
@@ -2783,7 +2783,7 @@ static vector<SearchResult> FtSearchCSS(std::string_view idx, std::string_view q
 }
 
 void CmdFtSearch(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{args};
+  CmdArgParser parser{cmd_cntx->tail_args()};
   string_view index_name = parser.Next();
   string_view query_str = parser.Next();
 
@@ -3021,7 +3021,7 @@ void CmdFtProfileHybrid(string_view index_name, CmdArgParser* parser, CommandCon
 }
 
 void CmdFtProfile(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{args};
+  CmdArgParser parser{cmd_cntx->tail_args()};
 
   string_view index_name = parser.Next();
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
@@ -3335,7 +3335,7 @@ static void AggregateGeneric(CommandContext* cmd_cntx, AggregateParams& params,
 }
 
 void CmdFtAggregate(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{args};
+  CmdArgParser parser{cmd_cntx->tail_args()};
   auto* builder = cmd_cntx->rb();
 
   auto params = ParseAggregatorParams(&parser);
@@ -3679,7 +3679,7 @@ void FtConfigSet(CmdArgParser* parser, CommandContext* cmd_cntx) {
 }
 
 void CmdFtConfig(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{args};
+  CmdArgParser parser{cmd_cntx->tail_args()};
   auto func = parser.MapNext("GET", &FtConfigGet, "SET", &FtConfigSet, "HELP", &FtConfigHelp);
 
   if (auto err = parser.TakeError(); err) {
@@ -3690,7 +3690,7 @@ void CmdFtConfig(CmdArgList args, CommandContext* cmd_cntx) {
 }
 
 void CmdFtSynUpdate(CmdArgList args, CommandContext* cmd_cntx) {
-  facade::CmdArgParser parser{args};
+  facade::CmdArgParser parser{cmd_cntx->tail_args()};
   auto [index_name, group_id] = parser.Next<string_view, string>();
 
   // Redis ignores this parameter. Checked on redis_version:6.2.13
@@ -3740,7 +3740,7 @@ void CmdFtSynUpdate(CmdArgList args, CommandContext* cmd_cntx) {
 void CmdFtDebug(CmdArgList args, CommandContext* cmd_cntx) {
   // FT._DEBUG command stub for test compatibility
   // This command is used by integration tests to control internal behavior
-  CmdArgParser parser{args};
+  CmdArgParser parser{cmd_cntx->tail_args()};
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
   if (args.empty() || parser.Check("HELP")) {
@@ -3768,7 +3768,7 @@ void CmdFtDebug(CmdArgList args, CommandContext* cmd_cntx) {
 }
 
 void CmdFtHybrid(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{args};
+  CmdArgParser parser{cmd_cntx->tail_args()};
   string_view index_name = parser.Next();
 
   auto params = ParseHybridParams(&parser);

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -434,7 +434,7 @@ struct ClientListFilter {
 
 optional<ClientListFilter> ParseClientListFilter(CmdArgList args, CommandContext* cmd_cntx) {
   ClientListFilter filter;
-  CmdArgParser parser{args};
+  CmdArgParser parser{cmd_cntx->tail_args().Tail()};
   if (!parser.HasNext())
     return filter;
 
@@ -549,7 +549,7 @@ void ClientTracking(CmdArgList args, CommandContext* cmd_cntx) {
     return cmd_cntx->SendError(
         "Client tracking is currently not supported for RESP2. Please use RESP3.");
 
-  CmdArgParser parser{args};
+  CmdArgParser parser{cmd_cntx->tail_args().Tail()};
   if (!parser.HasAtLeast(1) || args.size() > 3)
     return cmd_cntx->SendError(kSyntaxErr);
 
@@ -613,7 +613,7 @@ void ClientCaching(CmdArgList args, CommandContext* cmd_cntx) {
   }
 
   using Tracking = ConnectionState::ClientTracking;
-  CmdArgParser parser{args};
+  CmdArgParser parser{cmd_cntx->tail_args().Tail()};
 
   if (parser.Check("YES")) {
     if (!cntx->conn_state.tracking_info_.HasOption(Tracking::OPTIN)) {
@@ -810,7 +810,7 @@ struct ReplicaOfArgs {
   string host;
   uint16_t port;
   std::optional<cluster::SlotRange> slot_range;
-  static nonstd::expected<ReplicaOfArgs, ErrorReply> FromCmdArgs(CmdArgList args);
+  static nonstd::expected<ReplicaOfArgs, ErrorReply> FromCmdArgs(facade::ParsedArgs args);
   bool IsReplicaOfNoOne() const {
     return port == 0;
   }
@@ -827,7 +827,7 @@ struct ReplicaOfArgs {
   }
 };
 
-nonstd::expected<ReplicaOfArgs, ErrorReply> ReplicaOfArgs::FromCmdArgs(CmdArgList args) {
+nonstd::expected<ReplicaOfArgs, ErrorReply> ReplicaOfArgs::FromCmdArgs(facade::ParsedArgs args) {
   ReplicaOfArgs replicaof_args;
   CmdArgParser parser(args);
 
@@ -2662,7 +2662,7 @@ void ServerFamily::FlushDb(CmdArgList args, CommandContext* cmd_cntx) {
   if (args.size() > 1)
     return cmd_cntx->SendError(kSyntaxErr);
 
-  bool sync = CmdArgParser{args}.Check("SYNC");
+  bool sync = CmdArgParser{cmd_cntx->tail_args()}.Check("SYNC");
   string_view cmd_name = cmd_cntx->tx()->GetCId()->name();
   DbIndex index = cmd_name == "FLUSHALL" ? DbSlice::kDbAll : cmd_cntx->tx()->GetDbIndex();
   Drakarys(cmd_cntx->tx(), index, sync);
@@ -4065,7 +4065,7 @@ void ServerFamily::AddReplicaOf(CmdArgList args, CommandContext* cmd_cntx) {
   }
   CHECK(replica_);
 
-  auto replicaof_args = ReplicaOfArgs::FromCmdArgs(args);
+  auto replicaof_args = ReplicaOfArgs::FromCmdArgs(cmd_cntx->tail_args());
   if (!replicaof_args.has_value()) {
     return cmd_cntx->SendError(replicaof_args.error());
   }
@@ -4095,21 +4095,19 @@ void ServerFamily::StopAllClusterReplicas() {
 }
 
 void ServerFamily::ReplicaOf(CmdArgList args, CommandContext* cmd_cntx) {
-  ReplicaOfInternal(args, cmd_cntx, ActionOnConnectionFail::kReturnOnError);
+  ReplicaOfInternal(cmd_cntx->tail_args(), cmd_cntx, ActionOnConnectionFail::kReturnOnError);
 }
 
 void ServerFamily::Replicate(string_view host, string_view port) {
-  StringVec replicaof_params{string(host), string(port)};
+  cmn::BackedArguments bargs;
+  bargs.PushArg(host);
+  bargs.PushArg(port);
 
-  CmdArgVec args_vec;
-  for (auto& s : replicaof_params) {
-    args_vec.emplace_back(MutableSlice{s.data(), s.size()});
-  }
-  CmdArgList args_list = absl::MakeSpan(args_vec);
   io::NullSink sink;
   facade::RedisReplyBuilder rb(&sink);
   CommandContext cmd_cntx{&rb, nullptr};
-  ReplicaOfInternal(args_list, &cmd_cntx, ActionOnConnectionFail::kContinueReplication);
+  ReplicaOfInternal(facade::ParsedArgs{bargs}, &cmd_cntx,
+                    ActionOnConnectionFail::kContinueReplication);
 }
 
 void ServerFamily::StartJournalInShardThreads(Replica* repl_ptr) {
@@ -4147,7 +4145,7 @@ void ServerFamily::ReplicaOfNoOne(SinkReplyBuilder* builder) {
   return builder->SendOk();
 }
 
-void ServerFamily::ReplicaOfInternal(CmdArgList args, CommandContext* cmd_cntx,
+void ServerFamily::ReplicaOfInternal(facade::ParsedArgs args, CommandContext* cmd_cntx,
                                      ActionOnConnectionFail on_error)
     ABSL_LOCKS_EXCLUDED(replicaof_mu_) {
   auto replicaof_args = ReplicaOfArgs::FromCmdArgs(args);
@@ -4225,7 +4223,7 @@ void ServerFamily::ReplicaOfInternal(CmdArgList args, CommandContext* cmd_cntx,
 void ServerFamily::ReplTakeOver(CmdArgList args, CommandContext* cmd_cntx) {
   VLOG(1) << "ReplTakeOver start";
 
-  CmdArgParser parser{args};
+  CmdArgParser parser{cmd_cntx->tail_args()};
 
   int timeout_sec = parser.Next<int>();
   bool save_flag = static_cast<bool>(parser.Check("SAVE"));
@@ -4447,7 +4445,7 @@ void ServerFamily::ShutdownCmd(CmdArgList args, CommandContext* cmd_cntx) {
 
   uint32_t sb = 0;
 
-  CmdArgParser parser(args);
+  CmdArgParser parser(cmd_cntx->tail_args());
   while (parser.HasNext()) {
     // Map SAFE to SAVE directly (fallthrough behavior)
     ShutBits opt = parser.MapNext("SAVE", SB_SAVE, "NOSAVE", SB_NOSAVE, "NOW", SB_NOW, "FORCE",
@@ -4560,7 +4558,7 @@ void ServerFamily::Module(CmdArgList args, CommandContext* cmd_cntx) {
 }
 
 void ServerFamily::ClientPauseCmd(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser(args);
+  CmdArgParser parser(cmd_cntx->tail_args().Tail());
   auto listeners = GetNonPriviligedListeners();
 
   auto timeout = parser.Next<uint64_t>();

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -397,7 +397,7 @@ class ServerFamily {
                            // failure
   };
 
-  void ReplicaOfInternal(CmdArgList args, CommandContext* cmnd_cntx,
+  void ReplicaOfInternal(facade::ParsedArgs args, CommandContext* cmnd_cntx,
                          ActionOnConnectionFail on_error) ABSL_LOCKS_EXCLUDED(replicaof_mu_);
 
   void StartJournalInShardThreads(Replica* repl_ptr);


### PR DESCRIPTION
## Summary

Final batch of the `CmdArgParser` migration away from raw `CmdArgList` args.

## Changes

- `cluster_family`, `debugcmd`, `dflycmd`, `search_family`: replace `CmdArgParser parser(args)` with `cmd_cntx->tail_args()` (or `.Tail()` for sub-dispatched helpers that skip the command name)
- `server_family`: same migration, plus convert `ReplicaOfArgs::FromCmdArgs` and `ReplicaOfInternal` to accept `facade::ParsedArgs` instead of `CmdArgList`
- `Replicate()`: replace manual `StringVec`/`CmdArgVec`/`CmdArgList` construction with `BackedArguments`