### PR TITLE
fix: validate Lua redis.call command name argument

### DIFF
--- a/src/core/interpreter.cc
+++ b/src/core/interpreter.cc
@@ -1183,8 +1183,8 @@ bool Interpreter::PrepareArgs() {
   if (argc == 0)
     return true;
 
-  // Validate argument types (skip command name at idx=1).
-  for (int idx = 2; idx <= argc; idx++) {
+  // Validate argument types, including the command name at idx=1.
+  for (int idx = 1; idx <= argc; idx++) {
     int t = lua_type(lua_, idx);
     if (t != LUA_TNUMBER && t != LUA_TSTRING) {
       PushError(lua_, "Lua redis() command arguments must be strings or integers");

--- a/src/core/interpreter.cc
+++ b/src/core/interpreter.cc
@@ -1192,12 +1192,11 @@ bool Interpreter::PrepareArgs() {
     }
   }
 
-  // Copy command name.
-  backed_args_.PushArg(string_view{lua_tostring(lua_, 1), lua_rawlen(lua_, 1)});
-
-  // Copy remaining arguments directly into backed_args_.
+  // Copy all arguments (including the command name at idx=1) into backed_args_.
+  // Numbers go through deterministic formatting; doing the same for the command name
+  // avoids relying on unspecified evaluation order between lua_tostring and lua_rawlen.
   char tmpbuf[64];
-  for (int idx = 2; idx <= argc; idx++) {
+  for (int idx = 1; idx <= argc; idx++) {
     switch (lua_type(lua_, idx)) {
       case LUA_TNUMBER:
         if (lua_isinteger(lua_, idx)) {

--- a/src/core/interpreter_test.cc
+++ b/src/core/interpreter_test.cc
@@ -323,6 +323,23 @@ TEST_F(InterpreterTest, Call) {
   EXPECT_EQ("[str(table) status(mystatus)]", ser_.res);
 }
 
+TEST_F(InterpreterTest, CallTableFirstArg) {
+  auto cb = [](auto ca) { ca.translator->OnStatus("OK"); };
+
+  intptr_.SetRedisFunc(cb);
+  // The command name (first argument) must be validated like the rest: a non-empty
+  // table used to crash because lua_tostring(.,1) returns null while lua_rawlen(.,1)
+  // returns 3, causing a memcpy from null in BackedArguments::PushArg.
+  EXPECT_FALSE(Execute("return redis.call({1,2,3})"));
+  EXPECT_THAT(error_, testing::HasSubstr("must be strings or integers"));
+
+  // Userdata as the command name is rejected as well.
+  EXPECT_FALSE(Execute("return redis.call(redis)"));
+
+  // A valid string command name still works.
+  EXPECT_TRUE(Execute("return redis.call('ping')")) << error_;
+}
+
 TEST_F(InterpreterTest, CallArray) {
   auto cb = [](auto ca) {
     auto* reply = ca.translator;

--- a/src/core/interpreter_test.cc
+++ b/src/core/interpreter_test.cc
@@ -338,6 +338,17 @@ TEST_F(InterpreterTest, CallTableFirstArg) {
 
   // A valid string command name still works.
   EXPECT_TRUE(Execute("return redis.call('ping')")) << error_;
+
+  // A numeric command name is converted deterministically (not via the
+  // evaluation-order-dependent lua_tostring/lua_rawlen path).
+  string captured;
+  auto capture_cb = [&captured](auto ca) {
+    captured = string{ca.args->at(0)};
+    ca.translator->OnStatus("OK");
+  };
+  intptr_.SetRedisFunc(capture_cb);
+  EXPECT_TRUE(Execute("return redis.call(123)")) << error_;
+  EXPECT_EQ("123", captured);
 }
 
 TEST_F(InterpreterTest, CallArray) {


### PR DESCRIPTION
## Summary
`Interpreter::PrepareArgs()` copied the command name (arg #1) without validating its type, while args 2..N were validated. Passing a table/userdata as the first argument to `redis.call`/`redis.pcall` crashed the server: `lua_tostring(.,1)` returns null while `lua_rawlen(.,1)` is non-zero, leading to a `memcpy` from null in `BackedArguments::PushArg`.

## Changes
- Start the type-validation loop at `idx=1` so the command name is checked like every other argument.
- Add `InterpreterTest.CallTableFirstArg` regression test (crashed before, passes now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)