### PR TITLE
Back Transaction::full_args_ with facade::ParsedArgs

### DIFF
--- a/src/facade/facade.cc
+++ b/src/facade/facade.cc
@@ -168,6 +168,18 @@ ostream& operator<<(ostream& os, facade::CmdArgList ras) {
   return os;
 }
 
+ostream& operator<<(ostream& os, const facade::ParsedArgs& args) {
+  os << "[";
+  for (size_t i = 0; i < args.size(); ++i) {
+    if (i)
+      os << ",";
+    os << absl::CHexEscape(args[i]);
+  }
+  os << "]";
+
+  return os;
+}
+
 ostream& operator<<(ostream& os, const facade::RespExpr& e) {
   using facade::RespExpr;
   using facade::ToSV;

--- a/src/facade/facade_types.h
+++ b/src/facade/facade_types.h
@@ -78,6 +78,55 @@ class ParsedArgs {
     return std::visit([i](const auto& args) { return args.at(i); }, args_);
   }
 
+  // Index-based const iterator, so ParsedArgs can be iterated (e.g. as a journal
+  // Payload alternative) without exposing its underlying span/BackedArguments.
+  class const_iterator {
+   public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = std::string_view;
+    using difference_type = ptrdiff_t;
+    using pointer = const std::string_view*;
+    using reference = std::string_view;
+
+    const_iterator(const ParsedArgs* args, size_t index) : args_(args), index_(index) {
+    }
+
+    std::string_view operator*() const {
+      return (*args_)[index_];
+    }
+
+    const_iterator& operator++() {
+      ++index_;
+      return *this;
+    }
+
+    const_iterator operator++(int) {
+      const_iterator copy = *this;
+      ++index_;
+      return copy;
+    }
+
+    bool operator==(const const_iterator& o) const {
+      return index_ == o.index_;
+    }
+
+    bool operator!=(const const_iterator& o) const {
+      return index_ != o.index_;
+    }
+
+   private:
+    const ParsedArgs* args_;
+    size_t index_;
+  };
+
+  const_iterator begin() const {
+    return const_iterator{this, 0};
+  }
+
+  const_iterator end() const {
+    return const_iterator{this, size()};
+  }
+
   ArgSlice ToSlice(CmdArgVec* scratch) const {
     return std::visit([scratch](const auto& args) { return args.ToSlice(scratch); }, args_);
   }
@@ -234,6 +283,7 @@ constexpr size_t kRecvBufSize = 1500;
 
 namespace std {
 ostream& operator<<(ostream& os, cmn::ArgSlice args);
+ostream& operator<<(ostream& os, const facade::ParsedArgs& args);
 ostream& operator<<(ostream& os, facade::Protocol protocol);
 
 }  // namespace std

--- a/src/server/journal/types.h
+++ b/src/server/journal/types.h
@@ -30,8 +30,9 @@ struct Entry : public EntryBase {
   // Payload represents a non-owning view into a command executed on the shard.
   struct Payload {
     std::string_view cmd;
-    std::variant<ShardArgs,  // Shard parts.
-                 ArgSlice>   // Parts of a full command.
+    std::variant<ShardArgs,           // Shard parts.
+                 ArgSlice,            // Parts of a full command.
+                 facade::ParsedArgs>  // Full command backed by a span or BackedArguments.
         args;
 
     Payload() = default;
@@ -39,6 +40,8 @@ struct Entry : public EntryBase {
     Payload(std::string_view c, const ShardArgs& a) : cmd(c), args(a) {
     }
     Payload(std::string_view c, ArgSlice a) : cmd(c), args(a) {
+    }
+    Payload(std::string_view c, const facade::ParsedArgs& a) : cmd(c), args(a) {
     }
   };
 

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -630,7 +630,7 @@ OpResult<string> MoveTwoShards(Transaction* trans, string_view src, string_view 
         auto blocking_controller = t->GetNamespace().GetBlockingController(shard->shard_id());
         if (blocking_controller) {
           IndexSlice slice(0, 1);
-          ShardArgs sa{absl::MakeSpan(&src, 1), absl::MakeSpan(&slice, 1)};
+          ShardArgs sa{cmn::ArgSlice{&src, 1}, absl::MakeSpan(&slice, 1)};
 
           // hack, again. since we hacked which queue we are waiting on (see RunPair)
           // we must clean-up src key here manually. See RunPair why we do this.

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -202,7 +202,7 @@ void Transaction::BuildShardIndex(const KeyIndex& key_index, std::vector<PerShar
 
   auto& shard_index = *out;
   for (unsigned i : key_index.Range()) {
-    string_view key = ArgS(full_args_, i);
+    string_view key = full_args_[i];
     unique_slot_checker_.Add(key);
     ShardId sid = Shard(key, shard_data_.size());
 
@@ -329,7 +329,7 @@ void Transaction::InitByKeys(const KeyIndex& key_index) {
 
   DCHECK(!multi_ || multi_->mode != LOCK_AHEAD || !multi_->tag_fps.empty());
 
-  DVLOG(1) << "InitByArgs " << DebugId() << facade::ToSV(full_args_.front());
+  DVLOG(1) << "InitByArgs " << DebugId() << full_args_.Front();
 
   // Compress shard data, if we occupy only one shard.
   if (unique_shard_cnt_ == 1) {
@@ -1115,7 +1115,7 @@ void Transaction::ExpireBlocking(WaitKeys wkeys) {
     EngineShard* es = EngineShard::tlocal();
     if (wkeys) {
       IndexSlice is(0, 1);
-      ShardArgs sa(absl::MakeSpan(&wkeys.value(), 1), absl::MakeSpan(&is, 1));
+      ShardArgs sa(cmn::ArgSlice{&wkeys.value(), 1}, absl::MakeSpan(&is, 1));
       ExpireShardCb(sa, es);
     } else {
       ExpireShardCb(GetShardArgs(es->shard_id()), es);
@@ -1351,7 +1351,7 @@ OpStatus Transaction::WaitOnWatch(const time_point& tp, WaitKeys wkeys, KeyReady
   auto cb = [&](Transaction* t, EngineShard* shard) {
     if (wkeys) {  // single string_view.
       IndexSlice is(0, 1);
-      ShardArgs sa(absl::MakeSpan(&wkeys.value(), 1), absl::MakeSpan(&is, 1));
+      ShardArgs sa(cmn::ArgSlice{&wkeys.value(), 1}, absl::MakeSpan(&is, 1));
       t->WatchInShard(&t->GetNamespace(), sa, shard, krc);
     } else {
       t->WatchInShard(&t->GetNamespace(), t->GetShardArgs(shard->shard_id()), shard, krc);
@@ -1535,7 +1535,7 @@ optional<string_view> Transaction::GetWakeKey(ShardId sid) const {
     return nullopt;
 
   CHECK_LT(sd.wake_key_pos, full_args_.size());
-  return ArgS(full_args_, sd.wake_key_pos);
+  return full_args_[sd.wake_key_pos];
 }
 
 void Transaction::LogAutoJournalOnShard(EngineShard* shard, RunnableResult result) {

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -607,8 +607,10 @@ class Transaction {
   // Fingerprints of keys, precomputed once during the transaction initialization.
   absl::InlinedVector<LockFp, 4> kv_fp_;
 
-  // Stores the full undivided command.
-  CmdArgList full_args_;
+  // Stores the full undivided command. Backed either by a caller-owned span (legacy
+  // callers, via implicit ArgSlice conversion) or a caller-owned BackedArguments
+  // (migrated callers). The backing storage must outlive the transaction's hops.
+  facade::ParsedArgs full_args_;
 
   // Set if a NO_AUTOJOURNAL command asked to enable auto journal again
   bool re_enabled_auto_journal_ = false;

--- a/src/server/tx_base.h
+++ b/src/server/tx_base.h
@@ -11,6 +11,7 @@
 
 #include "base/iterator.h"
 #include "common/arg_range.h"
+#include "facade/facade_types.h"
 #include "server/common_types.h"
 
 namespace dfly {
@@ -47,7 +48,8 @@ struct KeyIndex {
     return base::it::Range(*this, KeyIndex{end, end, step, std::nullopt});
   }
 
-  auto Range(const cmn::ArgSlice& args) const {
+  // Accepts any indexable argument container (cmn::ArgSlice, facade::ParsedArgs, ...).
+  template <typename Args> auto Range(const Args& args) const {
     return base::it::Transform([args](unsigned idx) { return args[idx]; }, Range());
   }
 
@@ -128,12 +130,12 @@ using IndexSlice = std::pair<uint32_t, uint32_t>;  // [begin, end)
 // ShardArgs - hold a span to full arguments and a span of sub-ranges
 // referencing those arguments.
 class ShardArgs {
-  using ArgsIndexPair = std::pair<cmn::ArgSlice, absl::Span<const IndexSlice>>;
+  using ArgsIndexPair = std::pair<facade::ParsedArgs, absl::Span<const IndexSlice>>;
   ArgsIndexPair slice_;
 
  public:
   class Iterator {
-    cmn::ArgSlice arglist_;
+    facade::ParsedArgs arglist_;
     absl::Span<const IndexSlice>::const_iterator index_it_;
     uint32_t delta_ = 0;
 
@@ -145,12 +147,13 @@ class ShardArgs {
     using reference = value_type&;
 
     // First version, corresponds to spans over arguments.
-    Iterator(cmn::ArgSlice list, absl::Span<const IndexSlice>::const_iterator it)
+    Iterator(facade::ParsedArgs list, absl::Span<const IndexSlice>::const_iterator it)
         : arglist_(list), index_it_(it) {
     }
 
     bool operator==(const Iterator& o) const {
-      return index_it_ == o.index_it_ && delta_ == o.delta_ && arglist_.data() == o.arglist_.data();
+      // begin()/end() always come from the same ShardArgs, so position identifies them.
+      return index_it_ == o.index_it_ && delta_ == o.delta_;
     }
 
     bool operator!=(const Iterator& o) const {
@@ -183,7 +186,7 @@ class ShardArgs {
 
   using const_iterator = Iterator;
 
-  ShardArgs(cmn::ArgSlice fa, absl::Span<const IndexSlice> s) : slice_(ArgsIndexPair(fa, s)) {
+  ShardArgs(facade::ParsedArgs fa, absl::Span<const IndexSlice> s) : slice_(ArgsIndexPair(fa, s)) {
   }
 
   ShardArgs() : slice_(ArgsIndexPair{}) {


### PR DESCRIPTION
## Summary

Flips `Transaction::full_args_` from `CmdArgList` (a non-owning span of `string_view`) to `facade::ParsedArgs` — the variant that abstracts over both a span (legacy callers) and a `BackedArguments` (migrated callers). All existing callers compile unchanged via the implicit `ArgSlice → ParsedArgs` conversion, so no caller is yet forced to own a `BackedArguments`. This is step 1 toward carrying `BackedArguments`-backed args through the transaction end to end.

## Changes

- `ParsedArgs` gains an index-based `const_iterator` + `begin()`/`end()` and an `operator<<`, so it can be iterated (as a journal `Payload` alternative) and streamed (the `DCHECK << full_args_` site).
- `KeyIndex::Range` is templated over any indexable container.
- `ShardArgs` (and its `Iterator`) now holds `ParsedArgs`; the `arglist_.data()` identity check in `operator==` is dropped since `begin()`/`end()` always come from the same `ShardArgs`.
- `facade::ParsedArgs` added as a third `journal::Entry::Payload` alternative.
- `ShardArgs` sites that passed a mutable `Span` now build an explicit `cmn::ArgSlice` (the previous code relied on a span-to-span conversion that no longer chains implicitly).

## Testing

- `ninja dragonfly` builds clean.
- Pass: `journal_test`, `blocking_controller_test`, `multi_test`, `list_family_test`, `generic_family_test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)