### PR TITLE
server: Tagged chunk single buffer design, reduce copies

### DIFF
--- a/src/server/rdb_save.cc
+++ b/src/server/rdb_save.cc
@@ -282,7 +282,8 @@ io::Result<uint8_t> RdbSerializer::SaveEntry(const PrimeKey& pk, const PrimeValu
   }
 
   mem_buf_controller_.StartEntry();
-  absl::Cleanup cleanup = [&] { mem_buf_controller_.FinishEntry(); };
+  bool save_succeeded = false;
+  absl::Cleanup cleanup = [&] { mem_buf_controller_.FinishEntry(save_succeeded); };
 
   /* Save the expire time */
   if (expire_ms > 0) {
@@ -328,6 +329,7 @@ io::Result<uint8_t> RdbSerializer::SaveEntry(const PrimeKey& pk, const PrimeValu
   // crossed the limit.
   if (auto ec = PushToConsumerIfNeeded(FlushState::kFlushEndEntry); ec)
     return make_unexpected(ec);
+  save_succeeded = true;
   return rdb_type;
 }
 
@@ -942,7 +944,7 @@ std::error_code RdbSerializer::WriteOpcode(uint8_t opcode) {
 }
 
 size_t RdbSerializer::GetBufferCapacity() const {
-  return mem_buf_controller_.GetTotalBufferCapacity();
+  return mem_buf_controller_.BufferCapacity();
 }
 
 size_t RdbSerializer::GetTempBufferSize() const {
@@ -950,7 +952,7 @@ size_t RdbSerializer::GetTempBufferSize() const {
 }
 
 error_code RdbSerializer::WriteRaw(const io::Bytes& buf) {
-  auto* mem_buf = mem_buf_controller_.CurrentBuffer();
+  auto* mem_buf = mem_buf_controller_.Buffer();
   mem_buf->Reserve(mem_buf->InputLen() + buf.size());
   IoBuf::Bytes dest = mem_buf->AppendBuffer();
   memcpy(dest.data(), buf.data(), buf.size());
@@ -960,7 +962,7 @@ error_code RdbSerializer::WriteRaw(const io::Bytes& buf) {
 
 string RdbSerializer::Flush(FlushState flush_state) {
   using enum CompressionMode;
-  const IoBuf* mem_buf = mem_buf_controller_.CurrentBuffer();
+  const IoBuf* mem_buf = mem_buf_controller_.Buffer();
 
   if (!mem_buf_controller_.TagEntriesEnabled()) {
     const bool is_last_chunk = flush_state == FlushState::kFlushEndEntry;
@@ -1855,7 +1857,7 @@ std::optional<std::string> RdbSerializer::CompressBlob(std::string_view input) {
 }
 
 void RdbSerializer::CompressBlob() {
-  auto* mem_buf = mem_buf_controller_.CurrentBuffer();
+  auto* mem_buf = mem_buf_controller_.Buffer();
   Bytes blob = mem_buf->InputBuffer();
   std::string_view input{reinterpret_cast<const char*>(blob.data()), blob.size()};
   auto compressed = CompressBlob(input);
@@ -1887,42 +1889,71 @@ std::error_code RdbSerializer::PushToConsumerIfNeeded(FlushState flush_state) {
 }
 
 void MemBufController::StartEntry() {
-  DCHECK_EQ(entry_buffer_owner_, 0u);
-  DCHECK_EQ(entry_buffer_.InputLen(), 0u);
+  DCHECK_EQ(buffer_owner_, 0u);
 
   // Roll over to 1, id=0 is a special case
   if (next_id_ == std::numeric_limits<EntryId>::max())
     next_id_ = 1;
 
   active_id_ = next_id_++;
-  entry_buffer_owner_ = active_id_;
-  current_buffer_ = &entry_buffer_;
+  buffer_owner_ = active_id_;
+  // these bytes belong to another entry
+  prefix_len_ = buffer_.InputLen();
 }
 
-void MemBufController::FinishEntry() {
-  if (current_buffer_ == &entry_buffer_)
-    TagAndDrainToDefaultBuffer();
+namespace {
 
-  DCHECK_EQ(entry_buffer_.InputLen(), 0u);
-  split_entries_.erase(active_id_);
-  entry_buffer_owner_ = 0;
-  current_buffer_ = &default_buffer_;
-  active_id_ = 0;
+io::IoBuf RollbackBuffer(const io::IoBuf& buffer, const size_t cutoff) {
+  const auto bytes = io::View(buffer.InputBuffer());
+  DCHECK_LE(cutoff, bytes.size()) << "attempt to truncate more than buffer size";
+  IoBuf temp(cutoff);
+  temp.WriteAndCommit(bytes.data(), cutoff);
+  return temp;
 }
 
-void MemBufController::TagAndDrainToDefaultBuffer() {
-  DCHECK_EQ(current_buffer_, &entry_buffer_);
-  if (entry_buffer_.InputLen() == 0)
-    return;
+}  // namespace
 
-  const auto bytes = entry_buffer_.InputBuffer();
-  if (split_entries_.contains(active_id_) && send_tagged_entries_) {
-    const auto header = MakeTagHeader(entry_buffer_.InputLen());
-    default_buffer_.WriteAndCommit(header.data(), header.size());
+void MemBufController::FinishEntry(const bool save_entry_successful) {
+  // remove the data from buffer if we were not able to write cleanly
+  if (!save_entry_successful) {
+    if (prefix_len_ == 0)
+      buffer_.Clear();
+    else
+      buffer_ = RollbackBuffer(buffer_, prefix_len_);
+  } else if (split_entries_.contains(active_id_) && send_tagged_entries_) {
+    MaybeTagEntryTail();
   }
 
-  default_buffer_.WriteAndCommit(bytes.data(), bytes.size());
-  entry_buffer_.ConsumeInput(bytes.size());
+  split_entries_.erase(active_id_);
+  buffer_owner_ = 0;
+  active_id_ = 0;
+  prefix_len_ = 0;
+}
+
+void MemBufController::MaybeTagEntryTail() {
+  if (buffer_.InputLen() == prefix_len_)
+    return;
+
+  std::string dest;
+  dest.reserve(buffer_.InputLen() + kHeaderSize);
+  ConsumePrefix(&dest);
+
+  // TODO store in place, not append later, store directly in `dest`
+  const auto header = MakeTagHeader(buffer_.InputLen());
+  dest.append(reinterpret_cast<const char*>(header.data()), kHeaderSize);
+
+  const auto bytes = io::View(buffer_.InputBuffer());
+  dest.append(bytes.data(), bytes.size());
+
+  buffer_.Clear();
+  buffer_.WriteAndCommit(dest.data(), dest.size());
+}
+
+void MemBufController::ConsumePrefix(std::string* out) {
+  const auto bytes = io::View(buffer_.InputBuffer());
+  out->append(bytes.data(), prefix_len_);
+  buffer_.ConsumeInput(prefix_len_);
+  prefix_len_ = 0;
 }
 
 std::array<uint8_t, 9> MemBufController::MakeTagHeader(size_t size) const {
@@ -1936,62 +1967,52 @@ std::array<uint8_t, 9> MemBufController::MakeTagHeader(size_t size) const {
   return header;
 }
 
-size_t MemBufController::FlushableSize() const {
-  auto size = current_buffer_->InputLen();
-  if (current_buffer_ != &default_buffer_)
-    size += default_buffer_.InputLen();
-  return size;
-}
-
 MemBufController::EntryId MemBufController::SaveStateBeforeConsume() {
-  DCHECK_EQ(entry_buffer_owner_, active_id_);
-  DCHECK_EQ(entry_buffer_.InputLen(), 0u);
+  DCHECK_EQ(buffer_owner_, active_id_);
+  DCHECK_EQ(buffer_.InputLen(), 0u);
   const EntryId id = active_id_;
-  entry_buffer_owner_ = 0;
-  current_buffer_ = &default_buffer_;
+  buffer_owner_ = 0;
   active_id_ = 0;
   return id;
 }
 
 void MemBufController::RestoreStateAfterConsume(EntryId id) {
-  DCHECK_EQ(entry_buffer_owner_, 0u);
-  DCHECK_EQ(entry_buffer_.InputLen(), 0u);
-  entry_buffer_owner_ = id;
+  DCHECK_EQ(buffer_owner_, 0u);
+  buffer_owner_ = id;
   active_id_ = id;
-  current_buffer_ = &entry_buffer_;
+  // prepare to write a new chunk
+  prefix_len_ = buffer_.InputLen();
 }
 
 std::string MemBufController::BuildBlob() {
-  // default buffer always lies behind current bytes (entry buffer) in temporal sense, so it is
-  // built as prefix. We can never reach here where default buffer content was written _after_ entry
-  // buffer due to FinishEntry semantics.
-  const Bytes current_bytes = current_buffer_->InputBuffer();
-  const bool has_prefix = current_buffer_ != &default_buffer_ && default_buffer_.InputLen() > 0;
-  const Bytes prefix = has_prefix ? default_buffer_.InputBuffer() : Bytes{};
-
-  bool should_tag = send_tagged_entries_;
-
-  // tag only data entries (active id > 0) which were split at some point
-  should_tag &= active_id_ != 0 && split_entries_.contains(active_id_);
-
-  // do not tag empty bytes, it will send a useless header
-  should_tag &= !current_bytes.empty();
-
-  std::string out;
-  out.reserve(prefix.size() + (should_tag ? kHeaderSize : 0) + current_bytes.size());
-
-  if (has_prefix) {
-    out.append(io::View(prefix));
-    default_buffer_.ConsumeInput(prefix.size());
+  // In case of tagged chunks disabled, there is no prefix-suffix divide and no header to inject.
+  // The entire buffer should be returned as a whole, it may have been compressed already.
+  if (!send_tagged_entries_) {
+    std::string out{io::View(buffer_.InputBuffer())};
+    buffer_.Clear();
+    prefix_len_ = 0;
+    return out;
   }
 
+  // tag only data entries (active id > 0) which were split at some point
+  bool should_tag = active_id_ != 0 && split_entries_.contains(active_id_);
+
+  // do not tag empty bytes, it will send a useless header
+  const bool has_suffix = buffer_.InputLen() > prefix_len_;
+  should_tag &= has_suffix;
+
+  std::string out;
+  out.reserve(buffer_.InputLen() + (should_tag ? kHeaderSize : 0));
+
+  ConsumePrefix(&out);
+
   if (should_tag) {
-    const auto header = MakeTagHeader(current_bytes.size());
+    const auto header = MakeTagHeader(buffer_.InputLen());
     out.append(reinterpret_cast<const char*>(header.data()), header.size());
   }
 
-  out.append(io::View(current_bytes));
-  current_buffer_->ConsumeInput(current_bytes.size());
+  out.append(io::View(buffer_.InputBuffer()));
+  buffer_.ConsumeInput(buffer_.InputLen());
   return out;
 }
 

--- a/src/server/rdb_save.h
+++ b/src/server/rdb_save.h
@@ -79,10 +79,10 @@ CompressionMode GetDefaultCompressionMode();
 
 using StringVec = std::vector<std::string>;
 
-// Manages per-entry IO buffers for the RDB serializer, enabling tagged chunk framing for
-// interleaved serialization of multiple keys. When tagging is enabled, entries that were split
-// across multiple flushes are prefixed with a [opcode:1][stream_id:4][payload_length:4] header so
-// the loader can reassemble them.
+// Manages IO buffer for the RDB serializer, enabling tagged chunk framing for interleaved
+// serialization of multiple keys. When tagging is enabled, entries that were split across multiple
+// flushes are prefixed with a [opcode:1][stream_id:4][payload_length:4] header so the loader can
+// reassemble them.
 class MemBufController {
   friend class MemBufControllerTest;
 
@@ -91,20 +91,22 @@ class MemBufController {
   // Tagged chunk envelope: [RDB_OPCODE_TAGGED_CHUNK:1][stream_id:4][payload_length:4]
   static constexpr auto kHeaderSize = 9;
 
-  // Makes entry_buffer_ the current write target and assigns a new entry id.
+  // Marks the beginning of the current entry in prefix_len_ and assigns a new entry id.
   // Must be paired with FinishEntry().
   void StartEntry();
 
-  // Finalizes the active entry. Drains any remaining data from entry_buffer_ into the
-  // default buffer (tagging it if the entry was split), then resets to default state.
-  void FinishEntry();
+  // Finalizes the active entry. Replaces data with the tagged version if needed, then resets the
+  // state to default.
+  // save_entry_successful denotes whether the save (which started on StartEntry) was successful. If
+  // it failed, then the data which has been written since StartEntry (everything after prefix_len_)
+  // is removed from the buffer so as not to corrupt the rest of the data stream.
+  void FinishEntry(bool save_entry_successful);
 
-  // Moves data from entry_buffer_ into the default buffer. If the entry was
-  // split and tagging is enabled, a tag header is prepended.
-  void TagAndDrainToDefaultBuffer();
+  // Replaces the tail of an entry in the buffer with tagged data.
+  void MaybeTagEntryTail();
 
-  io::IoBuf* CurrentBuffer() const {
-    return current_buffer_;
+  io::IoBuf* Buffer() {
+    return &buffer_;
   }
 
   // Marks the active entry as having been split across multiple flushes. Once marked,
@@ -113,16 +115,16 @@ class MemBufController {
     split_entries_.insert(active_id_);
   }
 
-  // Total bytes available for flushing: current entry buffer + any previously drained
-  // data sitting in the default buffer.
-  size_t FlushableSize() const;
+  size_t FlushableSize() const {
+    return buffer_.InputLen();
+  }
 
-  // Captures the active entry id and points the current buffer to the default buffer. Called before
-  // the serializer's consume callback, which may preempt and allow other entries to interleave.
+  // Returns the active entry id. Called before the serializer's consume callback, which may preempt
+  // and allow other entries to interleave. The returned id must be saved by caller, and then later
+  // used for restoring the state.
   [[nodiscard]] EntryId SaveStateBeforeConsume();
 
-  // Restores a previously saved entry id after the consume callback returns. Points the current
-  // buffer to entry_buffer_.
+  // Restores a previously saved entry id after the consume callback returns.
   void RestoreStateAfterConsume(EntryId id);
 
   // Assembles a flush blob from the current buffer in the following steps:
@@ -140,11 +142,14 @@ class MemBufController {
     return send_tagged_entries_;
   }
 
-  size_t GetTotalBufferCapacity() const {
-    return default_buffer_.Capacity() + entry_buffer_.Capacity();
+  size_t BufferCapacity() const {
+    return buffer_.Capacity();
   }
 
  private:
+  // Consumes upto the prefix_len_ from the buffer, and appends into the string. Clears prefix_len_.
+  void ConsumePrefix(std::string* out);
+
   // Builds a 9-byte tagged chunk header for the active entry with the given payload size.
   std::array<uint8_t, 9> MakeTagHeader(size_t size) const;
 
@@ -154,13 +159,13 @@ class MemBufController {
   // id for current entry: non zero for data entries. 0 for non data entries, eg journal items
   EntryId active_id_ = 0;
 
-  io::IoBuf default_buffer_{4096};
-  io::IoBuf entry_buffer_{4096};
+  io::IoBuf buffer_{4096};
 
-  // intent lock to check that some entry id does not own the entry buffer before writing to it
-  EntryId entry_buffer_owner_ = 0;
-  io::IoBuf* current_buffer_ = &default_buffer_;
+  // intent lock to check that some other entry id does not own the buffer before writing to it
+  EntryId buffer_owner_ = 0;
   absl::flat_hash_set<EntryId> split_entries_;
+
+  size_t prefix_len_{0};
 };
 
 class RdbSaver {

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -1250,12 +1250,12 @@ class MemBufControllerTest : public Test {
   }
 
   void Write(std::string_view s) {
-    controller_.CurrentBuffer()->WriteAndCommit(s.data(), s.size());
+    controller_.Buffer()->WriteAndCommit(s.data(), s.size());
   }
 
-  void AssertDefaultState() const {
+  void AssertDefaultState() {
     EXPECT_EQ(controller_.active_id_, 0u);
-    EXPECT_EQ(controller_.CurrentBuffer(), &controller_.default_buffer_);
+    EXPECT_EQ(controller_.Buffer(), &controller_.buffer_);
   }
 
   void MarkMidFlush() {
@@ -1280,30 +1280,35 @@ class MemBufControllerTest : public Test {
   void Restore(MemBufController::EntryId id) {
     controller_.RestoreStateAfterConsume(id);
     EXPECT_EQ(controller_.active_id_, id);
-    EXPECT_EQ(controller_.CurrentBuffer(), &controller_.entry_buffer_);
+  }
+
+  void WriteEntry(std::string_view data, bool save_successful = true) {
+    controller_.StartEntry();
+    Write(data);
+    controller_.FinishEntry(save_successful);
   }
 };
 
 TEST_F(MemBufControllerTest, TaggedData) {
   controller_.SetTagEntries(true);
 
-  const std::string_view data = "a_a_a_";
+  constexpr std::string_view data = "a_a_a_";
   const auto saved_id = SplitAndSuspend(data, 1);
   EXPECT_TRUE(HasSplitEntries());
 
   Write("a");
   Restore(saved_id);
-  EXPECT_EQ(controller_.FlushableSize(), 1);
+  ASSERT_EQ(controller_.FlushableSize(), 1);
 
   Write("b");
-  EXPECT_EQ(controller_.FlushableSize(), 2);
-  controller_.FinishEntry();
+  ASSERT_EQ(controller_.FlushableSize(), 2);
+  controller_.FinishEntry(true);
   EXPECT_FALSE(HasSplitEntries());
 
   const std::string blob = Flush();
 
-  EXPECT_EQ(blob.size(), MemBufController::kHeaderSize + 2);
-  EXPECT_EQ(blob[0], 'a');
+  ASSERT_EQ(blob.size(), MemBufController::kHeaderSize + 2);
+  ASSERT_EQ(blob[0], 'a');
   AssertTaggedData(blob.substr(1), "b");
 }
 
@@ -1315,7 +1320,7 @@ TEST_F(MemBufControllerTest, NestedInterleaving) {
 
   controller_.StartEntry();
   Write("ccc");
-  controller_.FinishEntry();
+  controller_.FinishEntry(true);
   AssertDefaultState();
 
   EXPECT_EQ(controller_.FlushableSize(), 3);
@@ -1324,13 +1329,13 @@ TEST_F(MemBufControllerTest, NestedInterleaving) {
 
   Restore(saved_id_b);
   Write("x");
-  controller_.FinishEntry();
+  controller_.FinishEntry(true);
 
   AssertTaggedData(Flush(), "x", 2);
 
   Restore(saved_id_a);
   Write("y");
-  controller_.FinishEntry();
+  controller_.FinishEntry(true);
   EXPECT_FALSE(HasSplitEntries());
 
   AssertTaggedData(Flush(), "y");
@@ -1349,7 +1354,7 @@ TEST_F(MemBufControllerTest, BuildBlobEdgeCases) {
   EXPECT_EQ(blob[0], 'p');
   AssertTaggedData(blob.substr(1), "x");
 
-  controller_.FinishEntry();
+  controller_.FinishEntry(true);
   AssertDefaultState();
 }
 
@@ -1358,7 +1363,7 @@ TEST_F(MemBufControllerTest, UnsplitEntry) {
 
   controller_.StartEntry();
   Write("hello");
-  controller_.FinishEntry();
+  controller_.FinishEntry(true);
   AssertDefaultState();
 
   EXPECT_EQ(controller_.FlushableSize(), 5);
@@ -1376,9 +1381,62 @@ TEST_F(MemBufControllerTest, TaggingDisabled) {
   Restore(saved_id);
 
   Write("def");
-  controller_.FinishEntry();
+  controller_.FinishEntry(true);
 
   EXPECT_EQ(Flush(), "def");
+}
+
+TEST_F(MemBufControllerTest, RollbackPartialEntry) {
+  for (const auto state : {true, false}) {
+    controller_.SetTagEntries(state);
+
+    WriteEntry("hello", true);
+    WriteEntry("world", false);
+
+    EXPECT_EQ(Flush(), "hello");
+
+    // empty buffer case
+    WriteEntry("a", false);
+
+    EXPECT_EQ(controller_.FlushableSize(), 0);
+    EXPECT_EQ(Flush(), "");
+
+    // next write works as expected ie no state corruption
+    WriteEntry("abc", true);
+    EXPECT_EQ(Flush(), "abc");
+  }
+}
+
+TEST_F(MemBufControllerTest, RollbackPartialEntrySplit) {
+  controller_.SetTagEntries(true);
+  auto entry = SplitAndSuspend("abc", 1);
+  EXPECT_TRUE(HasSplitEntries());
+  Restore(entry);
+  Write("bbb");
+
+  controller_.FinishEntry(false);
+  EXPECT_FALSE(HasSplitEntries());
+  EXPECT_EQ(controller_.FlushableSize(), 0);
+  EXPECT_EQ(Flush(), "");
+}
+
+TEST_F(MemBufControllerTest, RollbackOnSuspendedEntry) {
+  controller_.SetTagEntries(true);
+
+  const auto id_a = SplitAndSuspend("aaa", 1);
+
+  // a failed entry written
+  WriteEntry("bbb", false);
+
+  // controller still has aaa in map
+  EXPECT_TRUE(HasSplitEntries());
+
+  Restore(id_a);
+  Write("a_tail");
+  controller_.FinishEntry(true);
+
+  AssertTaggedData(Flush(), "a_tail", 1);
+  EXPECT_FALSE(HasSplitEntries());
 }
 
 namespace {


### PR DESCRIPTION
The motivation is to avoid copying entry data between buffers every time we finish an entry.

Before:
At every finish entry we would copy its data from entry buffer to default buffer. Even if the entry was untagged and small, which can be the majority of entries.

Now (in this PR):
The mem buf controller is moved to single buffer design. Instead of two buffers:

* default
* entry specific

It switches to a single buffer and a prefix length. This enables us to skip copying for small entries which are not tagged, so they stay inside default buffer as it is. Only tagged entries need a copy.

Now when data fails to write cleanly, we need to do a rollback operation because they leave behind partial data in the buffer. That is also part of the PR and tests.

FIXES https://github.com/dragonflydb/dragonfly/issues/7469