### PR TITLE
Migrate command handlers to CmdArgParser

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -752,7 +752,7 @@ void DebugCmd::Run(CmdArgList args, CommandContext* cmd_cntx) {
   }
 
   if (subcmd == "TRAFFIC") {
-    return LogTraffic(args.subspan(1), cmd_cntx);
+    return LogTraffic(CmdArgParser{args.subspan(1)}, cmd_cntx);
   }
 
   if (subcmd == "RECVSIZE" && args.size() == 2) {
@@ -771,7 +771,7 @@ void DebugCmd::Run(CmdArgList args, CommandContext* cmd_cntx) {
     return Values(args.subspan(1), cmd_cntx);
   }
   if (subcmd == "COMPRESSION") {
-    return Compression(args.subspan(1), cmd_cntx);
+    return Compression(CmdArgParser{args.subspan(1)}, cmd_cntx);
   }
 
   if (subcmd == "IOSTATS") {
@@ -882,9 +882,9 @@ enum PopulateFlag { FLAG_RAND, FLAG_TYPE, FLAG_ELEMENTS, FLAG_SLOT, FLAG_EXPIRE,
 // Populate arguments format:
 // required: (total count) (key prefix) (val size)
 // optional: [RAND | TYPE typename | ELEMENTS element num | SLOTS (key value)+ | EXPIRE start end]
-optional<DebugCmd::PopulateOptions> DebugCmd::ParsePopulateArgs(CmdArgList args,
+optional<DebugCmd::PopulateOptions> DebugCmd::ParsePopulateArgs(CmdArgParser parser,
                                                                 CommandContext* cmd_cntx) {
-  CmdArgParser parser(args.subspan(1));
+  parser.Skip(1);
   PopulateOptions options;
 
   options.total_count = parser.Next<uint64_t>();
@@ -919,7 +919,7 @@ optional<DebugCmd::PopulateOptions> DebugCmd::ParsePopulateArgs(CmdArgList args,
         break;
       }
       default:
-        LOG(FATAL) << "Unexpected flag in PopulateArgs. Args: " << args;
+        LOG(FATAL) << "Unexpected flag in PopulateArgs";
         break;
     }
   }
@@ -935,7 +935,7 @@ optional<DebugCmd::PopulateOptions> DebugCmd::ParsePopulateArgs(CmdArgList args,
 }
 
 void DebugCmd::Populate(CmdArgList args, CommandContext* cmd_cntx) {
-  optional<PopulateOptions> options = ParsePopulateArgs(args, cmd_cntx);
+  optional<PopulateOptions> options = ParsePopulateArgs(CmdArgParser{args}, cmd_cntx);
   if (!options.has_value()) {
     return;
   }
@@ -1058,7 +1058,7 @@ void DebugCmd::Exec(CommandContext* cmd_cntx) {
   rb->SendVerbatimString(res);
 }
 
-void DebugCmd::LogTraffic(CmdArgList args, CommandContext* cmd_cntx) {
+void DebugCmd::LogTraffic(CmdArgParser parser, CommandContext* cmd_cntx) {
   using facade::Connection;
 
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
@@ -1073,7 +1073,6 @@ void DebugCmd::LogTraffic(CmdArgList args, CommandContext* cmd_cntx) {
   // A recording captures exactly one source; LISTENER and REPLICA are mutually
   // exclusive. REPLICA captures commands received from a master via the
   // replication stream (only meaningful while this server is a replica).
-  CmdArgParser parser(args);
   if (parser.Check("STOP")) {
     if (!parser.Finalize())
       return cmd_cntx->SendError(parser.TakeError().MakeReply());
@@ -1568,9 +1567,8 @@ static size_t PostProcessHist(HufHist* dest) {
   return total_freq;
 }
 
-void DebugCmd::Compression(CmdArgList args, CommandContext* cmd_cntx) {
+void DebugCmd::Compression(CmdArgParser parser, CommandContext* cmd_cntx) {
   CompactObjType type = kInvalidCompactObjType;
-  CmdArgParser parser(args);
   string bintable;
   bool print_bintable = false;
 

--- a/src/server/debugcmd.h
+++ b/src/server/debugcmd.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "facade/cmd_arg_parser.h"
 #include "server/cluster/cluster_defs.h"
 #include "server/conn_context.h"
 
@@ -39,7 +40,7 @@ class DebugCmd {
 
  private:
   void Populate(CmdArgList args, CommandContext* cmd_cntx);
-  static std::optional<PopulateOptions> ParsePopulateArgs(CmdArgList args,
+  static std::optional<PopulateOptions> ParsePopulateArgs(facade::CmdArgParser parser,
                                                           CommandContext* cmd_cntx);
   void PopulateRangeFiber(uint64_t from, uint64_t count, const PopulateOptions& opts);
 
@@ -54,12 +55,12 @@ class DebugCmd {
   void ObjHist(CommandContext* cmd_cntx);
   void Stacktrace(CommandContext* cmd_cntx);
   void Shards(CommandContext* cmd_cntx);
-  void LogTraffic(CmdArgList, CommandContext* cmd_cntx);
+  void LogTraffic(facade::CmdArgParser parser, CommandContext* cmd_cntx);
   void RecvSize(std::string_view param, CommandContext* cmd_cntx);
   void Topk(CmdArgList args, CommandContext* cmd_cntx);
   void Keys(CmdArgList args, CommandContext* cmd_cntx);
   void Values(CmdArgList args, CommandContext* cmd_cntx);
-  void Compression(CmdArgList args, CommandContext* cmd_cntx);
+  void Compression(facade::CmdArgParser parser, CommandContext* cmd_cntx);
   void IOStats(CmdArgList args, CommandContext* cmd_cntx);
   void Segments(CmdArgList args, CommandContext* cmd_cntx);
   void CompactTable(CmdArgList args, CommandContext* cmd_cntx);

--- a/src/server/dflycmd.cc
+++ b/src/server/dflycmd.cc
@@ -625,10 +625,9 @@ void DflyCmd::TakeOver(CmdArgList args, CommandContext* cmd_cntx) {
   // For non-cluster mode we shutdown
   if (detail::cluster_mode != detail::ClusterMode::kRealCluster) {
     VLOG(1) << "Takeover accepted, shutting down.";
-    std::string save_arg = "NOSAVE";
-    MutableSlice sargs(save_arg);
     CommandContext child_cmd_cntx{cmd_cntx->rb(), nullptr};
-    sf_->ShutdownCmd(CmdArgList(&sargs, 1), &child_cmd_cntx);
+    child_cmd_cntx.PushArg("NOSAVE");
+    sf_->ShutdownCmd(facade::CmdArgParser{child_cmd_cntx, 0}, &child_cmd_cntx);
     return;
   }
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -260,9 +260,16 @@ using http::StringResponse;
 using strings::HumanReadableNumBytes;
 
 using EngineFunc = void (ServerFamily::*)(CmdArgList args, CommandContext*);
+using EngineFuncParser = void (ServerFamily::*)(CmdArgParser, CommandContext*);
 
 inline CommandId::Handler HandlerFunc(ServerFamily* se, EngineFunc f) {
   return [=](CmdArgList args, CommandContext* cntx) { return (se->*f)(args, cntx); };
+}
+
+inline CommandId::Handler HandlerFunc(ServerFamily* se, EngineFuncParser f) {
+  return [=](CmdArgList args, CommandContext* cntx) {
+    return (se->*f)(MakeParserFromContext(cntx), cntx);
+  };
 }
 
 namespace {
@@ -432,9 +439,8 @@ struct ClientListFilter {
   absl::flat_hash_set<uint32_t> ids;
 };
 
-optional<ClientListFilter> ParseClientListFilter(CmdArgList args, CommandContext* cmd_cntx) {
+optional<ClientListFilter> ParseClientListFilter(CmdArgParser parser, CommandContext* cmd_cntx) {
   ClientListFilter filter;
-  CmdArgParser parser{args};
   if (!parser.HasNext())
     return filter;
 
@@ -498,7 +504,7 @@ ClientListType ClassifyConnection(facade::Connection* conn) {
 
 void ClientList(CmdArgList args, absl::Span<facade::Listener*> listeners,
                 ServerFamily* server_family, CommandContext* cmd_cntx) {
-  auto filter = ParseClientListFilter(args, cmd_cntx);
+  auto filter = ParseClientListFilter(CmdArgParser{args}, cmd_cntx);
   if (!filter)
     return;
 
@@ -543,14 +549,13 @@ void ClientList(CmdArgList args, absl::Span<facade::Listener*> listeners,
   return rb->SendVerbatimString(result);
 }
 
-void ClientTracking(CmdArgList args, CommandContext* cmd_cntx) {
+void ClientTracking(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (!rb->IsResp3())
     return cmd_cntx->SendError(
         "Client tracking is currently not supported for RESP2. Please use RESP3.");
 
-  CmdArgParser parser{args};
-  if (!parser.HasAtLeast(1) || args.size() > 3)
+  if (!parser.HasAtLeast(1) || parser.HasAtLeast(4))
     return cmd_cntx->SendError(kSyntaxErr);
 
   bool is_on = false;
@@ -595,13 +600,13 @@ void ClientTracking(CmdArgList args, CommandContext* cmd_cntx) {
   return cmd_cntx->rb()->SendOk();
 }
 
-void ClientCaching(CmdArgList args, CommandContext* cmd_cntx) {
+void ClientCaching(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (!rb->IsResp3())
     return cmd_cntx->SendError(
         "Client caching is currently not supported for RESP2. Please use RESP3.");
 
-  if (args.size() != 1) {
+  if (!parser.HasAtLeast(1) || parser.HasAtLeast(2)) {
     return cmd_cntx->SendError(kSyntaxErr);
   }
 
@@ -613,7 +618,6 @@ void ClientCaching(CmdArgList args, CommandContext* cmd_cntx) {
   }
 
   using Tracking = ConnectionState::ClientTracking;
-  CmdArgParser parser{args};
 
   if (parser.Check("YES")) {
     if (!cntx->conn_state.tracking_info_.HasOption(Tracking::OPTIN)) {
@@ -2596,7 +2600,7 @@ SaveInfoData ServerFamily::GetLastSaveInfo() const {
   return thread_safe_save_info_.Get();
 }
 
-void ServerFamily::DbSize(CmdArgList args, CommandContext* cmd_cntx) {
+void ServerFamily::DbSize(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   atomic_ulong num_keys{0};
 
   auto* cntx = cmd_cntx->server_conn_cntx();
@@ -2658,11 +2662,11 @@ void ServerFamily::SendInvalidationMessages() const {
   }
 }
 
-void ServerFamily::FlushDb(CmdArgList args, CommandContext* cmd_cntx) {
-  if (args.size() > 1)
+void ServerFamily::FlushDb(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
+  if (parser.HasAtLeast(2))
     return cmd_cntx->SendError(kSyntaxErr);
 
-  bool sync = CmdArgParser{args}.Check("SYNC");
+  bool sync = parser.Check("SYNC");
   string_view cmd_name = cmd_cntx->tx()->GetCId()->name();
   DbIndex index = cmd_name == "FLUSHALL" ? DbSlice::kDbAll : cmd_cntx->tx()->GetDbIndex();
   Drakarys(cmd_cntx->tx(), index, sync);
@@ -2699,18 +2703,22 @@ bool ServerFamily::DoAuth(ConnectionContext* cntx, std::string_view username,
   return is_authorized;
 }
 
-void ServerFamily::Auth(CmdArgList args, CommandContext* cmd_cntx) {
-  if (args.size() > 2) {
+void ServerFamily::Auth(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
+  if (parser.HasAtLeast(3)) {
     return cmd_cntx->SendError(kSyntaxErr);
   }
+
+  std::string_view arg0 = parser.Next<string_view>();
+  std::optional<std::string_view> arg1;
+  if (parser.HasNext())
+    arg1 = parser.Next<string_view>();
 
   ConnectionContext* cntx = cmd_cntx->server_conn_cntx();
   // non admin port auth
   if (!cntx->conn()->IsPrivileged()) {
-    const bool one_arg = args.size() == 1;
-    std::string_view username = one_arg ? "default" : facade::ToSV(args[0]);
-    const size_t index = one_arg ? 0 : 1;
-    std::string_view password = facade::ToSV(args[index]);
+    const bool one_arg = !arg1.has_value();
+    std::string_view username = one_arg ? "default" : arg0;
+    std::string_view password = one_arg ? arg0 : *arg1;
     if (DoAuth(cntx, username, password)) {
       return cmd_cntx->rb()->SendOk();
     }
@@ -2726,7 +2734,7 @@ void ServerFamily::Auth(CmdArgList args, CommandContext* cmd_cntx) {
         "admin port. Are you sure your configuration is correct?");
   }
 
-  string_view pass = ArgS(args, 0);
+  string_view pass = arg0;
   if (pass == GetPassword()) {
     cntx->authenticated = true;
     cmd_cntx->rb()->SendOk();
@@ -2808,15 +2816,15 @@ void ServerFamily::Client(CmdArgList args, CommandContext* cmd_cntx) {
   } else if (sub_cmd == "LIST") {
     return ClientList(sub_args, absl::MakeSpan(listeners_), this, cmd_cntx);
   } else if (sub_cmd == "PAUSE") {
-    return ClientPauseCmd(sub_args, cmd_cntx);
+    return ClientPauseCmd(CmdArgParser{sub_args}, cmd_cntx);
   } else if (sub_cmd == "UNPAUSE") {
     return ClientUnPauseCmd(sub_args, cmd_cntx);
   } else if (sub_cmd == "TRACKING") {
-    return ClientTracking(sub_args, cmd_cntx);
+    return ClientTracking(CmdArgParser{sub_args}, cmd_cntx);
   } else if (sub_cmd == "KILL") {
     return ClientKill(sub_args, absl::MakeSpan(listeners_), this, cmd_cntx);
   } else if (sub_cmd == "CACHING") {
-    return ClientCaching(sub_args, cmd_cntx);
+    return ClientCaching(CmdArgParser{sub_args}, cmd_cntx);
   } else if (sub_cmd == "SETINFO") {
     return ClientSetInfo(sub_args, cmd_cntx);
   } else if (sub_cmd == "ID") {
@@ -2830,8 +2838,9 @@ void ServerFamily::Client(CmdArgList args, CommandContext* cmd_cntx) {
   return cmd_cntx->SendError(UnknownSubCmd(sub_cmd, "CLIENT"), kSyntaxErrType);
 }
 
-void ServerFamily::Config(CmdArgList args, CommandContext* cmd_cntx) {
-  string sub_cmd = absl::AsciiStrToUpper(ArgS(args, 0));
+void ServerFamily::Config(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
+  const facade::ParsedArgs& args = cmd_cntx->tail_args();
+  string sub_cmd = absl::AsciiStrToUpper(parser.Next<string_view>());
 
   auto* builder = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (sub_cmd == "HELP") {
@@ -2857,9 +2866,9 @@ void ServerFamily::Config(CmdArgList args, CommandContext* cmd_cntx) {
       return cmd_cntx->SendError(WrongNumArgsError("config|set"), kConfigErrType);
     }
 
-    string param = absl::AsciiStrToLower(ArgS(args, 1));
+    string param = absl::AsciiStrToLower(args[1]);
 
-    ConfigRegistry::SetResult result = config_registry.Set(param, ArgS(args, 2));
+    ConfigRegistry::SetResult result = config_registry.Set(param, args[2]);
 
     const char kErrPrefix[] = "CONFIG SET failed (possibly related to argument '";
     switch (result) {
@@ -2882,7 +2891,7 @@ void ServerFamily::Config(CmdArgList args, CommandContext* cmd_cntx) {
 
   if (sub_cmd == "GET" && args.size() == 2) {
     vector<string> res;
-    string_view param = ArgS(args, 1);
+    string_view param = args[1];
 
     // Support 'databases' for backward compatibility.
     if (param == "databases") {
@@ -2934,8 +2943,8 @@ void ServerFamily::Memory(CmdArgList args, CommandContext* cmd_cntx) {
   return mem_cmd.Run(args);
 }
 
-void ServerFamily::Shrink(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
+void ServerFamily::Shrink(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
+  string_view key = parser.Next<string_view>();
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
   auto cb = [key](Transaction* t, EngineShard* shard) -> OpResult<int64_t> {
@@ -3910,15 +3919,15 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
   return info;
 }
 
-void ServerFamily::Info(CmdArgList args, CommandContext* cmd_cntx) {
+void ServerFamily::Info(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   std::vector<std::string> sections;
   bool need_metrics{false};  // Save time - do not fetch metrics if we don't need them.
   bool need_repl_mem{false};
   Metrics metrics;
 
-  sections.reserve(args.size());
-  for (const auto& arg : args) {
-    sections.emplace_back(absl::AsciiStrToUpper(arg));
+  sections.reserve(cmd_cntx->tail_args().size());
+  while (parser.HasNext()) {
+    sections.emplace_back(absl::AsciiStrToUpper(parser.Next<string_view>()));
     const auto& section = sections.back();
     if (!need_metrics && (section != "SERVER") && (section != "REPLICATION")) {
       need_metrics = true;
@@ -4222,10 +4231,8 @@ void ServerFamily::ReplicaOfInternal(CmdArgList args, CommandContext* cmd_cntx,
 
 // REPLTAKEOVER <seconds> [SAVE]
 // SAVE is used only by tests.
-void ServerFamily::ReplTakeOver(CmdArgList args, CommandContext* cmd_cntx) {
+void ServerFamily::ReplTakeOver(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   VLOG(1) << "ReplTakeOver start";
-
-  CmdArgParser parser{args};
 
   int timeout_sec = parser.Next<int>();
   bool save_flag = static_cast<bool>(parser.Check("SAVE"));
@@ -4370,7 +4377,7 @@ void ServerFamily::ReplConf(CmdArgList args, CommandContext* cmd_cntx) {
   return builder->SendOk();
 }
 
-void ServerFamily::Role(CmdArgList args, CommandContext* cmd_cntx) {
+void ServerFamily::Role(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   util::fb2::LockGuard lk(replicaof_mu_);
   // Thread local var is_master is updated under mutex replicaof_mu_ together with replica_,
@@ -4418,14 +4425,14 @@ void ServerFamily::Script(CmdArgList args, CommandContext* cmd_cntx) {
   script_mgr_->Run(args, cmd_cntx->tx(), cmd_cntx->rb(), cmd_cntx->server_conn_cntx());
 }
 
-void ServerFamily::LastSave(CmdArgList args, CommandContext* cmd_cntx) {
+void ServerFamily::LastSave(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   auto info = thread_safe_save_info_.Get();
   cmd_cntx->rb()->SendLong(info.save_time);
 }
 
-void ServerFamily::Latency(CmdArgList args, CommandContext* cmd_cntx) {
+void ServerFamily::Latency(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
-  string sub_cmd = absl::AsciiStrToUpper(ArgS(args, 0));
+  string sub_cmd = absl::AsciiStrToUpper(parser.Next<string_view>());
 
   if (sub_cmd == "LATEST" || sub_cmd == "HISTOGRAM") {
     return rb->SendEmptyArray();
@@ -4434,7 +4441,7 @@ void ServerFamily::Latency(CmdArgList args, CommandContext* cmd_cntx) {
   return cmd_cntx->SendError(UnknownSubCmd(sub_cmd, "LATENCY"), kSyntaxErrType);
 }
 
-void ServerFamily::ShutdownCmd(CmdArgList args, CommandContext* cmd_cntx) {
+void ServerFamily::ShutdownCmd(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   // Supported options (case-insensitive):
   // SAVE | NOSAVE, NOW, FORCE, ABORT, SAFE (Valkey-specific, the same as SAVE in Dragonfly)
   enum ShutBits : uint32_t {
@@ -4446,8 +4453,6 @@ void ServerFamily::ShutdownCmd(CmdArgList args, CommandContext* cmd_cntx) {
   };
 
   uint32_t sb = 0;
-
-  CmdArgParser parser(args);
   while (parser.HasNext()) {
     // Map SAFE to SAVE directly (fallthrough behavior)
     ShutBits opt = parser.MapNext("SAVE", SB_SAVE, "NOSAVE", SB_NOSAVE, "NOW", SB_NOW, "FORCE",
@@ -4535,8 +4540,8 @@ void ServerFamily::SlowLog(CmdArgList args, CommandContext* cmd_cntx) {
   cmd_cntx->SendError(UnknownSubCmd(sub_cmd, "SLOWLOG"), kSyntaxErrType);
 }
 
-void ServerFamily::Module(CmdArgList args, CommandContext* cmd_cntx) {
-  string sub_cmd = absl::AsciiStrToUpper(ArgS(args, 0));
+void ServerFamily::Module(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
+  string sub_cmd = absl::AsciiStrToUpper(parser.Next<string_view>());
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
   if (sub_cmd != "LIST")
@@ -4559,8 +4564,7 @@ void ServerFamily::Module(CmdArgList args, CommandContext* cmd_cntx) {
   rb->SendLong(21'015);  // we target v2
 }
 
-void ServerFamily::ClientPauseCmd(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser(args);
+void ServerFamily::ClientPauseCmd(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   auto listeners = GetNonPriviligedListeners();
 
   auto timeout = parser.Next<uint64_t>();

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "core/qlist.h"
+#include "facade/cmd_arg_parser.h"
 #include "facade/facade_stats.h"
 #include "facade/facade_types.h"
 #include "server/acl/user_registry.h"
@@ -250,7 +251,7 @@ class ServerFamily {
   void Shutdown() ABSL_LOCKS_EXCLUDED(replicaof_mu_);
 
   // Public because is used by DflyCmd.
-  void ShutdownCmd(CmdArgList args, CommandContext* cmd_cntx);
+  void ShutdownCmd(facade::CmdArgParser parser, CommandContext* cmd_cntx);
 
   Service& service() {
     return service_;
@@ -365,29 +366,32 @@ class ServerFamily {
     return shard_set->size();
   }
 
-  void Auth(CmdArgList args, CommandContext* cmd_cntx);
+  void Auth(facade::CmdArgParser parser, CommandContext* cmd_cntx);
   void Client(CmdArgList args, CommandContext* cmd_cntx);
-  void Config(CmdArgList args, CommandContext* cmd_cntx);
-  void DbSize(CmdArgList args, CommandContext* cmd_cntx);
+  void Config(facade::CmdArgParser parser, CommandContext* cmd_cntx);
+  void DbSize(facade::CmdArgParser parser, CommandContext* cmd_cntx);
   void Debug(CmdArgList args, CommandContext* cmd_cntx);
   void Dfly(CmdArgList args, CommandContext* cmd_cntx);
   void Memory(CmdArgList args, CommandContext* cmd_cntx);
-  void Shrink(CmdArgList args, CommandContext* cmd_cntx);
-  void FlushDb(CmdArgList args, CommandContext* cmd_cntx);
-  void Info(CmdArgList args, CommandContext* cmd_cntx) ABSL_LOCKS_EXCLUDED(replicaof_mu_);
+  void Shrink(facade::CmdArgParser parser, CommandContext* cmd_cntx);
+  void FlushDb(facade::CmdArgParser parser, CommandContext* cmd_cntx);
+  void Info(facade::CmdArgParser parser, CommandContext* cmd_cntx)
+      ABSL_LOCKS_EXCLUDED(replicaof_mu_);
   void Hello(CmdArgList args, CommandContext* cmd_cntx);
-  void LastSave(CmdArgList args, CommandContext* cmd_cntx);
-  void Latency(CmdArgList args, CommandContext* cmd_cntx);
+  void LastSave(facade::CmdArgParser parser, CommandContext* cmd_cntx);
+  void Latency(facade::CmdArgParser parser, CommandContext* cmd_cntx);
   void ReplicaOf(CmdArgList args, CommandContext* cmd_cntx);
   void AddReplicaOf(CmdArgList args, CommandContext* cmd_cntx);
-  void ReplTakeOver(CmdArgList args, CommandContext* cmd_cntx) ABSL_LOCKS_EXCLUDED(replicaof_mu_);
+  void ReplTakeOver(facade::CmdArgParser parser, CommandContext* cmd_cntx)
+      ABSL_LOCKS_EXCLUDED(replicaof_mu_);
   void ReplConf(CmdArgList args, CommandContext* cmd_cntx);
-  void Role(CmdArgList args, CommandContext* cmd_cntx) ABSL_LOCKS_EXCLUDED(replicaof_mu_);
+  void Role(facade::CmdArgParser parser, CommandContext* cmd_cntx)
+      ABSL_LOCKS_EXCLUDED(replicaof_mu_);
   void Save(CmdArgList args, CommandContext* cmd_cntx);
   void BgSave(CmdArgList args, CommandContext* cmd_cntx);
   void Script(CmdArgList args, CommandContext* cmd_cntx);
   void SlowLog(CmdArgList args, CommandContext* cmd_cntx);
-  void Module(CmdArgList args, CommandContext* cmd_cntx);
+  void Module(facade::CmdArgParser parser, CommandContext* cmd_cntx);
 
   void SyncGeneric(std::string_view repl_master_id, uint64_t offs, ConnectionContext* cntx);
 
@@ -438,7 +442,7 @@ class ServerFamily {
 
   static bool DoAuth(ConnectionContext* cntx, std::string_view username, std::string_view password);
 
-  void ClientPauseCmd(CmdArgList args, CommandContext* cmd_cntx);
+  void ClientPauseCmd(facade::CmdArgParser parser, CommandContext* cmd_cntx);
   void ClientUnPauseCmd(CmdArgList args, CommandContext* cmd_cntx);
 
   // Set accepting_connections_ and update listners according to it


### PR DESCRIPTION
## Summary

Continues the `CmdArgParser` handler migration (follow-up to #7664). Converts the cleanly-parseable handlers in `debugcmd` and `server_family` to take `facade::CmdArgParser` by value instead of `CmdArgList`, so parsing happens through the unified parser API.

## Changes

- **server_family.cc**: add a local `EngineFuncParser` typedef and a `HandlerFunc` overload that adapts a `CmdArgParser`-taking member to the registry's `CmdArgList` handler signature; the existing `EngineFunc`/`HandlerFunc` overload is kept for dispatcher/delegator handlers that still take `CmdArgList`.
- **server_family**: migrate `ShutdownCmd`, `ReplTakeOver`, `ClientPauseCmd`, `ClientTracking`, `ClientCaching`, and leaf handlers `Auth`, `Config`, `DbSize`, `Shrink`, `FlushDb`, `Info`, `LastSave`, `Latency`, `Role`, `Module` to accept `CmdArgParser`; also convert the `ParseClientListFilter` helper.
- **debugcmd**: migrate `LogTraffic`, `Compression`, and `ParsePopulateArgs` to accept `CmdArgParser`.
- **dflycmd.cc**: update `DflyCmd::TakeOver` to build its `NOSAVE` argument via `CommandContext::PushArg` and call the new `ShutdownCmd(CmdArgParser)` signature.
- Include `facade/cmd_arg_parser.h` from `debugcmd.h` and `server_family.h`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)