### PR TITLE
server: Skip error on load EOF with pending tagged chunk state

### DIFF
--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -2253,18 +2253,17 @@ error_code RdbLoader::Load(io::Source* src) {
     }
 
     if (type == RDB_OPCODE_EOF) {
-      if (current_chunk_state_) {
-        LOG(ERROR) << "eof seen while a previous chunk is not yet finished, stream id "
-                   << current_chunk_state_->stream_id << ", remaining bytes "
-                   << current_chunk_state_->remaining_payload_bytes
-                   << ", pending stream states: " << stream_states_.size();
-        return RdbError(errc::rdb_chunk_payload_remaining);
-      }
+      if (current_chunk_state_)
+        LOG(WARNING) << "eof seen while a previous chunk is not yet finished, stream id "
+                     << current_chunk_state_->stream_id << ", remaining bytes "
+                     << current_chunk_state_->remaining_payload_bytes
+                     << ", pending stream states: " << stream_states_.size();
 
       if (!stream_states_.empty()) {
-        LOG(ERROR) << "eof seen while pending stream states: " << stream_states_.size();
-        return RdbError(errc::rdb_chunk_payload_remaining);
+        LOG(WARNING) << "eof seen while pending stream states: " << stream_states_.size();
       }
+      current_chunk_state_.reset();
+      stream_states_.clear();
       /* EOF: End of file, exit the main loop. */
       break;
     }

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -1550,6 +1550,31 @@ TEST_F(RdbTest, InterleavedLoad) {
   EXPECT_EQ(Run({"SELECT", "0"}), "OK");
 }
 
+TEST_F(RdbTest, EofWithPendingChunkState) {
+  // will be skipped
+  std::string a1;
+  a1.push_back(RDB_TYPE_HASH);
+  AppendString(&a1, "partial_hash");
+  AppendLen(&a1, 2);
+  AddKV(&a1, "f1", "v1");
+
+  // will survive
+  std::string b;
+  b.push_back(RDB_TYPE_STRING);
+  AppendString(&b, "complete_key");
+  AppendString(&b, "hello");
+
+  std::string body;
+  body += MakeTaggedChunk(1, a1);
+  body += b;
+
+  const auto ec = pp_->at(0)->Await([&] { return LoadRdbData(service_.get(), WrapInRdb(body)); });
+  ASSERT_FALSE(ec) << ec.message();
+
+  EXPECT_THAT(Run({"EXISTS", "partial_hash"}), IntArg(0));
+  EXPECT_EQ(Run({"GET", "complete_key"}), "hello");
+}
+
 TEST_F(RdbTest, SplitSBF) {
   // this test creates two filter SBF, then splits one of the filters. Since in sbf loading there
   // are two layers of possible splits, intra-filter and inter-filter, this test exercises both


### PR DESCRIPTION
The RDB loader loop EOF state previously exited on error if tagged chunk loading state was partial at the end (ie the map contained entries at EOF opcode). This breaks the existing contract with the RDB saver.

Currently the saver, if it sees an error while writing a key-value, does not terminate the save process. It skips that key and continues. So the loader on the other side of the network does not see that key (or the error) but sees a valid RDB stream which skipped that key.

With tagged chunks if a value is split into for example three chunks, and the second chunk write fails, the saver continues with the next key and the loader ends up with a partial state for that key which never touches the DB.

This is all correct, but at the end of the loader loop we previously returned error if there was such partial state. Instead, to keep the contract intact, we now simply log a warning and let the loader finish. The partial state has never touched the db and is discarded.
