### PR TITLE
chore(server): pass CmdArgParser to bitops/json handlers

### DIFF
--- a/src/server/bitops_family.cc
+++ b/src/server/bitops_family.cc
@@ -43,13 +43,13 @@ using BitsStrVec = vector<string>;
 
 // The following is the list of the functions that would handle the
 // commands that handle the bit operations
-void BitPos(CmdArgList args, CommandContext* cmd_cntx);
-void BitCount(CmdArgList args, CommandContext* cmd_cntx);
-void BitField(CmdArgList args, CommandContext* cmd_cntx);
-void BitFieldRo(CmdArgList args, CommandContext* cmd_cntx);
-void BitOp(CmdArgList args, CommandContext* cmd_cntx);
-void GetBit(CmdArgList args, CommandContext* cmd_cntx);
-void SetBit(CmdArgList args, CommandContext* cmd_cntx);
+void BitPos(facade::CmdArgParser parser, CommandContext* cmd_cntx);
+void BitCount(facade::CmdArgParser parser, CommandContext* cmd_cntx);
+void BitField(facade::CmdArgParser parser, CommandContext* cmd_cntx);
+void BitFieldRo(facade::CmdArgParser parser, CommandContext* cmd_cntx);
+void BitOp(facade::CmdArgParser parser, CommandContext* cmd_cntx);
+void GetBit(facade::CmdArgParser parser, CommandContext* cmd_cntx);
+void SetBit(facade::CmdArgParser parser, CommandContext* cmd_cntx);
 
 OpResult<string> ReadValue(const DbContext& context, string_view key, EngineShard* shard);
 OpResult<bool> ReadValueBitsetAt(const OpArgs& op_args, string_view key, uint32_t offset);
@@ -519,48 +519,49 @@ void HandleOpValueResult(const OpResult<T>& result, SinkReplyBuilder* builder) {
 
 // ------------------------------------------------------------------------- //
 //  Impl for the command functions
-void BitPos(CmdArgList args, CommandContext* cmd_cntx) {
+void BitPos(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   // Support for the command BITPOS
   // See details at https://redis.io/commands/bitpos/
   auto* builder = cmd_cntx->rb();
-  if (args.size() < 1 || args.size() > 5) {
-    return builder->SendError(kSyntaxErr);
+
+  auto key = parser.Next<string_view>();
+  auto value = parser.Next<int32_t>();
+
+  if (auto err = parser.TakeError(); err) {
+    return builder->SendError(err.MakeReply());
   }
 
-  string_view key = ArgS(args, 0);
+  if (value != 0 && value != 1) {
+    return builder->SendError("The bit argument must be 1 or 0");
+  }
 
-  int32_t value{0};
   int64_t start = 0;
   int64_t end = std::numeric_limits<int64_t>::max();
   bool as_bit = false;
 
-  if (!absl::SimpleAtoi(ArgS(args, 1), &value)) {
-    return builder->SendError(kInvalidIntErr);
-  } else if (value != 0 && value != 1) {
-    return builder->SendError("The bit argument must be 1 or 0");
-  }
-
-  if (args.size() >= 3) {
-    if (!absl::SimpleAtoi(ArgS(args, 2), &start)) {
-      return builder->SendError(kInvalidIntErr);
+  if (parser.HasNext()) {
+    start = parser.Next<int64_t>();
+    if (auto err = parser.TakeError(); err) {
+      return builder->SendError(err.MakeReply());
     }
 
-    if (args.size() >= 4) {
-      if (!absl::SimpleAtoi(ArgS(args, 3), &end)) {
-        return builder->SendError(kInvalidIntErr);
+    if (parser.HasNext()) {
+      end = parser.Next<int64_t>();
+      if (auto err = parser.TakeError(); err) {
+        return builder->SendError(err.MakeReply());
       }
 
-      if (args.size() >= 5) {
-        string arg = absl::AsciiStrToUpper(ArgS(args, 4));
-        if (arg == "BIT") {
-          as_bit = true;
-        } else if (arg == "BYTE") {
-          as_bit = false;
-        } else {
+      if (parser.HasNext()) {
+        as_bit = parser.MapNext("BIT", true, "BYTE", false);
+        if (auto err = parser.TakeError(); err) {
           return builder->SendError(kSyntaxErr);
         }
       }
     }
+  }
+
+  if (!parser.Finalize()) {
+    return builder->SendError(parser.TakeError().MakeReply());
   }
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
@@ -570,12 +571,11 @@ void BitPos(CmdArgList args, CommandContext* cmd_cntx) {
   HandleOpValueResult(res, builder);
 }
 
-void BitCount(CmdArgList args, CommandContext* cmd_cntx) {
+void BitCount(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   // Support for the command BITCOUNT
   // See details at https://redis.io/commands/bitcount/
   // Please note that if the key don't exists, it would return 0
 
-  CmdArgParser parser(cmd_cntx->tail_args());
   auto key = parser.Next<string_view>();
 
   std::pair<int64_t, int64_t> start_end;
@@ -1055,13 +1055,12 @@ nonstd::expected<CommonAttributes, string> ParseCommonAttr(CmdArgParser* parser,
 // Parses a list of arguments (without key) to a CommandList.
 // Returns the CommandList if the parsing completed succefully or string
 // to indicate an error
-nonstd::expected<CommandList, string> ParseToCommandList(facade::ParsedArgs args, bool read_only) {
+nonstd::expected<CommandList, string> ParseToCommandList(CmdArgParser parser, bool read_only) {
   enum class Cmds { OVERFLOW_OPT, GET_OPT, SET_OPT, INCRBY_OPT };
   CommandList result;
 
   using nonstd::make_unexpected;
 
-  CmdArgParser parser(args);
   while (parser.HasNext()) {
     auto cmd = parser.MapNext("OVERFLOW", Cmds::OVERFLOW_OPT, "GET", Cmds::GET_OPT, "SET",
                               Cmds::SET_OPT, "INCRBY", Cmds::INCRBY_OPT);
@@ -1136,15 +1135,15 @@ void SendResults(const vector<ResultType>& results, SinkReplyBuilder* builder) {
   }
 }
 
-void BitFieldGeneric(facade::ParsedArgs args, bool read_only, Transaction* tx,
+void BitFieldGeneric(CmdArgParser parser, bool read_only, Transaction* tx,
                      SinkReplyBuilder* builder) {
-  if (args.size() == 1) {
+  if (!parser.HasAtLeast(2)) {
     auto* rb = static_cast<RedisReplyBuilder*>(builder);
     rb->SendEmptyArray();
     return;
   }
-  auto key = args[0];
-  auto maybe_ops_list = ParseToCommandList(args.Tail(), read_only);
+  auto key = parser.Next<string_view>();
+  auto maybe_ops_list = ParseToCommandList(parser, read_only);
 
   if (!maybe_ops_list.has_value()) {
     builder->SendError(maybe_ops_list.error());
@@ -1167,27 +1166,37 @@ void BitFieldGeneric(facade::ParsedArgs args, bool read_only, Transaction* tx,
   SendResults(*res, builder);
 }
 
-void BitField(CmdArgList args, CommandContext* cmd_cntx) {
-  BitFieldGeneric(cmd_cntx->tail_args(), false, cmd_cntx->tx(), cmd_cntx->rb());
+void BitField(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
+  BitFieldGeneric(parser, false, cmd_cntx->tx(), cmd_cntx->rb());
 }
 
-void BitFieldRo(CmdArgList args, CommandContext* cmd_cntx) {
-  BitFieldGeneric(cmd_cntx->tail_args(), true, cmd_cntx->tx(), cmd_cntx->rb());
+void BitFieldRo(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
+  BitFieldGeneric(parser, true, cmd_cntx->tx(), cmd_cntx->rb());
 }
 
 #ifndef __clang__
 #pragma GCC diagnostic pop
 #endif
 
-void BitOp(CmdArgList args, CommandContext* cmd_cntx) {
+void BitOp(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   static const std::array<string_view, 4> BITOP_OP_NAMES{OR_OP_NAME, XOR_OP_NAME, AND_OP_NAME,
                                                          NOT_OP_NAME};
-  string op = absl::AsciiStrToUpper(ArgS(args, 0));
-  string_view dest_key = ArgS(args, 1);
+  string op = absl::AsciiStrToUpper(parser.Next<string_view>());
+  string_view dest_key = parser.Next<string_view>();
+
+  if (auto err = parser.TakeError(); err) {
+    return cmd_cntx->rb()->SendError(err.MakeReply());
+  }
+
   bool illegal = rng::none_of(BITOP_OP_NAMES, [&op](auto val) { return op == val; });
 
+  // Count remaining args (src keys); for NOT there must be exactly one src key.
+  // The transaction args include dest_key + src_keys, so src key count = total tail - 2.
+  // We check via cmd_cntx->tail_args() which has all args including op and dest.
+  size_t num_src_keys = cmd_cntx->tail_args().size() - 2;
+
   auto* builder = cmd_cntx->rb();
-  if (illegal || (op == NOT_OP_NAME && args.size() > 3)) {
+  if (illegal || (op == NOT_OP_NAME && num_src_keys > 1)) {
     return builder->SendError(kSyntaxErr);  // too many arguments
   }
 
@@ -1252,15 +1261,14 @@ void BitOp(CmdArgList args, CommandContext* cmd_cntx) {
   }
 }
 
-void GetBit(CmdArgList args, CommandContext* cmd_cntx) {
+void GetBit(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   // Support for the command "GETBIT key offset"
   // see https://redis.io/commands/getbit/
 
-  uint32_t offset{0};
-  string_view key = ArgS(args, 0);
+  auto [key, offset] = parser.Next<string_view, uint32_t>();
 
-  if (!absl::SimpleAtoi(ArgS(args, 1), &offset)) {
-    return cmd_cntx->SendError(kInvalidIntErr);
+  if (auto err = parser.TakeError(); err) {
+    return cmd_cntx->SendError(err.MakeReply());
   }
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return ReadValueBitsetAt(t->GetOpArgs(shard), key, offset);
@@ -1269,11 +1277,10 @@ void GetBit(CmdArgList args, CommandContext* cmd_cntx) {
   HandleOpValueResult(res, cmd_cntx->rb());
 }
 
-void SetBit(CmdArgList args, CommandContext* cmd_cntx) {
+void SetBit(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   // Support for the command "SETBIT key offset new_value"
   // see https://redis.io/commands/setbit/
 
-  CmdArgParser parser(cmd_cntx->tail_args());
   auto [key, offset, value] = parser.Next<string_view, uint32_t, FInt<0, 1>>();
 
   if (auto err = parser.TakeError(); err) {

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -146,11 +146,15 @@ class CommandId : public facade::CommandId {
     return interleave_step_;
   }
 
+  template <typename RT> CommandId&& SetHandler(RT f(facade::CmdArgParser, CommandContext*)) && {
+    handler_ = [f](CmdArgList args, CommandContext* cntx) { f(MakeParserFromContext(cntx), cntx); };
+    return std::move(*this);
+  }
+
   template <typename RT>
   CommandId&& SetAsyncHandler(RT f(facade::CmdArgParser, CommandContext*)) && {
     kind_mask_ |= SUPPORT_ASYNC;
-    handler_ = [f](CmdArgList args, CommandContext* cntx) { f(MakeParserFromContext(cntx), cntx); };
-    return std::move(*this);
+    return std::move(*this).SetHandler(f);
   }
 
   CommandId&& SetHandler(Handler f, bool async_support = false) && {

--- a/src/server/json_family.cc
+++ b/src/server/json_family.cc
@@ -1709,8 +1709,7 @@ OpStatus OpMerge(const OpArgs& op_args, string_view key, string_view path,
   return OpStatus::SYNTAX_ERR;
 }
 
-void CmdSet(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{cmd_cntx->tail_args()};
+void CmdSet(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto [key, path, json_str] = parser.Next<string_view, string_view, string_view>();
   auto* builder = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   WrappedJsonPath json_path = GET_OR_SEND_UNEXPECTED(ParseJsonPath(path));
@@ -1741,11 +1740,9 @@ void CmdSet(CmdArgList args, CommandContext* cmd_cntx) {
 }
 
 // JSON.MSET key path value [key path value ...]
-void CmdMSet(CmdArgList args, CommandContext* cmd_cntx) {
-  DCHECK_GE(args.size(), 3u);
-
+void CmdMSet(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto* builder = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
-  if (args.size() % 3 != 0) {
+  if (cmd_cntx->tail_args().size() % 3 != 0) {
     return builder->SendError(facade::WrongNumArgsError("json.mset"));
   }
 
@@ -1767,8 +1764,7 @@ void CmdMSet(CmdArgList args, CommandContext* cmd_cntx) {
 
 // JSON.MERGE key path value
 // Based on https://datatracker.ietf.org/doc/html/rfc7386 spec
-void CmdMerge(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{cmd_cntx->tail_args()};
+void CmdMerge(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
   string_view path = parser.Next();
   string_view value = parser.Next();
@@ -1786,8 +1782,7 @@ void CmdMerge(CmdArgList args, CommandContext* cmd_cntx) {
   cmd_cntx->SendError(status);
 }
 
-void CmdResp(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{cmd_cntx->tail_args()};
+void CmdResp(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
   string_view path = parser.NextOrDefault();
 
@@ -1802,8 +1797,7 @@ void CmdResp(CmdArgList args, CommandContext* cmd_cntx) {
   reply_generic::Send(result, cmd_cntx);
 }
 
-void CmdDebug(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{cmd_cntx->tail_args()};
+void CmdDebug(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view command = parser.Next();
 
   auto* builder = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
@@ -1871,10 +1865,9 @@ void CmdDebug(CmdArgList args, CommandContext* cmd_cntx) {
   builder->SendError(facade::UnknownSubCmd(command, "JSON.DEBUG"), facade::kSyntaxErrType);
 }
 
-void CmdMGet(CmdArgList args, CommandContext* cmd_cntx) {
-  DCHECK_GE(args.size(), 1U);
-
-  string_view path = ArgS(args, args.size() - 1);
+void CmdMGet(CmdArgParser parser, CommandContext* cmd_cntx) {
+  const facade::ParsedArgs& tail = cmd_cntx->tail_args();
+  string_view path = tail[tail.size() - 1];
 
   auto* builder = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   WrappedJsonPath json_path = GET_OR_SEND_UNEXPECTED(ParseJsonPath(path));
@@ -1891,7 +1884,7 @@ void CmdMGet(CmdArgList args, CommandContext* cmd_cntx) {
   OpStatus result = cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));
   CHECK_EQ(OpStatus::OK, result);
 
-  std::vector<std::optional<std::string>> results(args.size() - 1);
+  std::vector<std::optional<std::string>> results(tail.size() - 1);  // last arg is path
   for (ShardId sid = 0; sid < shard_count; ++sid) {
     if (!cmd_cntx->tx()->IsActive(sid))
       continue;
@@ -1911,8 +1904,7 @@ void CmdMGet(CmdArgList args, CommandContext* cmd_cntx) {
   reply_generic::Send(results.begin(), results.end(), cmd_cntx);
 }
 
-void CmdArrIndex(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{cmd_cntx->tail_args()};
+void CmdArrIndex(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
   string_view path = parser.Next();
 
@@ -1924,7 +1916,7 @@ void CmdArrIndex(CmdArgList args, CommandContext* cmd_cntx) {
   int start_index = 0;
   if (parser.HasNext()) {
     if (!absl::SimpleAtoi(parser.Next(), &start_index)) {
-      VLOG(1) << "Failed to convert the start index to numeric" << ArgS(args, 3);
+      VLOG(1) << "Failed to convert the start index to numeric";
       builder->SendError(kInvalidIntErr);
       return;
     }
@@ -1933,7 +1925,7 @@ void CmdArrIndex(CmdArgList args, CommandContext* cmd_cntx) {
   int end_index = 0;
   if (parser.HasNext()) {
     if (!absl::SimpleAtoi(parser.Next(), &end_index)) {
-      VLOG(1) << "Failed to convert the stop index to numeric" << ArgS(args, 4);
+      VLOG(1) << "Failed to convert the stop index to numeric";
       builder->SendError(kInvalidIntErr);
       return;
     }
@@ -1947,14 +1939,15 @@ void CmdArrIndex(CmdArgList args, CommandContext* cmd_cntx) {
   reply_generic::Send(result, cmd_cntx);
 }
 
-void CmdArrInsert(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  string_view path = ArgS(args, 1);
+void CmdArrInsert(CmdArgParser parser, CommandContext* cmd_cntx) {
+  string_view key = parser.Next();
+  string_view path = parser.Next();
   int index = -1;
 
   auto* builder = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
-  if (!absl::SimpleAtoi(ArgS(args, 2), &index)) {
-    VLOG(1) << "Failed to convert the following value to numeric: " << ArgS(args, 2);
+  string_view index_sv = parser.Next();
+  if (!absl::SimpleAtoi(index_sv, &index)) {
+    VLOG(1) << "Failed to convert the following value to numeric: " << index_sv;
     builder->SendError(kInvalidIntErr);
     return;
   }
@@ -1962,8 +1955,8 @@ void CmdArrInsert(CmdArgList args, CommandContext* cmd_cntx) {
   WrappedJsonPath json_path = GET_OR_SEND_UNEXPECTED(ParseJsonPath(path));
 
   vector<string_view> new_values;
-  for (size_t i = 3; i < args.size(); i++) {
-    new_values.emplace_back(ArgS(args, i));
+  while (parser.HasNext()) {
+    new_values.emplace_back(parser.Next());
   }
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
@@ -1974,16 +1967,16 @@ void CmdArrInsert(CmdArgList args, CommandContext* cmd_cntx) {
   reply_generic::Send(result, cmd_cntx);
 }
 
-void CmdArrAppend(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  string_view path = ArgS(args, 1);
+void CmdArrAppend(CmdArgParser parser, CommandContext* cmd_cntx) {
+  string_view key = parser.Next();
+  string_view path = parser.Next();
 
   auto* builder = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   WrappedJsonPath json_path = GET_OR_SEND_UNEXPECTED(ParseJsonPath(path));
 
   vector<string_view> append_values;
-  for (size_t i = 2; i < args.size(); ++i) {
-    append_values.emplace_back(ArgS(args, i));
+  while (parser.HasNext()) {
+    append_values.emplace_back(parser.Next());
   }
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
@@ -1994,20 +1987,20 @@ void CmdArrAppend(CmdArgList args, CommandContext* cmd_cntx) {
   reply_generic::Send(result, cmd_cntx);
 }
 
-void CmdArrTrim(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  string_view path = ArgS(args, 1);
+void CmdArrTrim(CmdArgParser parser, CommandContext* cmd_cntx) {
+  string_view key = parser.Next();
+  string_view path = parser.Next();
   int start_index;
   int stop_index;
 
   auto* builder = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
-  if (!absl::SimpleAtoi(ArgS(args, 2), &start_index)) {
+  if (!absl::SimpleAtoi(parser.Next(), &start_index)) {
     VLOG(1) << "Failed to parse array start index";
     builder->SendError(kInvalidIntErr);
     return;
   }
 
-  if (!absl::SimpleAtoi(ArgS(args, 3), &stop_index)) {
+  if (!absl::SimpleAtoi(parser.Next(), &stop_index)) {
     VLOG(1) << "Failed to parse array stop index";
     builder->SendError(kInvalidIntErr);
     return;
@@ -2023,8 +2016,7 @@ void CmdArrTrim(CmdArgList args, CommandContext* cmd_cntx) {
   reply_generic::Send(result, cmd_cntx);
 }
 
-void CmdArrPop(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{cmd_cntx->tail_args()};
+void CmdArrPop(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
   string_view path = parser.NextOrDefault();
   int index = parser.NextOrDefault<int>(-1);
@@ -2042,8 +2034,7 @@ void CmdArrPop(CmdArgList args, CommandContext* cmd_cntx) {
   reply_generic::Send(result, cmd_cntx);
 }
 
-void CmdClear(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{cmd_cntx->tail_args()};
+void CmdClear(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
   string_view path = parser.NextOrDefault();
 
@@ -2058,10 +2049,10 @@ void CmdClear(CmdArgList args, CommandContext* cmd_cntx) {
   reply_generic::Send(result, cmd_cntx);
 }
 
-void CmdStrAppend(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  string_view path = ArgS(args, 1);
-  string_view value = ArgS(args, 2);
+void CmdStrAppend(CmdArgParser parser, CommandContext* cmd_cntx) {
+  string_view key = parser.Next();
+  string_view path = parser.Next();
+  string_view value = parser.Next();
 
   auto* builder = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   WrappedJsonPath json_path = GET_OR_SEND_UNEXPECTED(ParseJsonPath(path));
@@ -2081,8 +2072,7 @@ void CmdStrAppend(CmdArgList args, CommandContext* cmd_cntx) {
   reply_generic::Send(result, cmd_cntx);
 }
 
-void CmdObjKeys(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{cmd_cntx->tail_args()};
+void CmdObjKeys(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
   string_view path = parser.NextOrDefault();
 
@@ -2097,8 +2087,7 @@ void CmdObjKeys(CmdArgList args, CommandContext* cmd_cntx) {
   reply_generic::Send(result, cmd_cntx);
 }
 
-void CmdDel(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{cmd_cntx->tail_args()};
+void CmdDel(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
   string_view path = parser.NextOrDefault();
 
@@ -2113,10 +2102,10 @@ void CmdDel(CmdArgList args, CommandContext* cmd_cntx) {
   reply_generic::Send(result, cmd_cntx);
 }
 
-void CmdNumIncrBy(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  string_view path = ArgS(args, 1);
-  string_view num = ArgS(args, 2);
+void CmdNumIncrBy(CmdArgParser parser, CommandContext* cmd_cntx) {
+  string_view key = parser.Next();
+  string_view path = parser.Next();
+  string_view num = parser.Next();
 
   auto* builder = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   WrappedJsonPath json_path = GET_OR_SEND_UNEXPECTED(ParseJsonPath(path));
@@ -2129,10 +2118,10 @@ void CmdNumIncrBy(CmdArgList args, CommandContext* cmd_cntx) {
   reply_generic::SendJsonString(result, cmd_cntx);
 }
 
-void CmdNumMultBy(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  string_view path = ArgS(args, 1);
-  string_view num = ArgS(args, 2);
+void CmdNumMultBy(CmdArgParser parser, CommandContext* cmd_cntx) {
+  string_view key = parser.Next();
+  string_view path = parser.Next();
+  string_view num = parser.Next();
 
   auto* builder = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   WrappedJsonPath json_path = GET_OR_SEND_UNEXPECTED(ParseJsonPath(path));
@@ -2145,8 +2134,7 @@ void CmdNumMultBy(CmdArgList args, CommandContext* cmd_cntx) {
   reply_generic::SendJsonString(result, cmd_cntx);
 }
 
-void CmdToggle(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{cmd_cntx->tail_args()};
+void CmdToggle(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
   string_view path = parser.NextOrDefault();
 
@@ -2160,8 +2148,7 @@ void CmdToggle(CmdArgList args, CommandContext* cmd_cntx) {
   }
 }
 
-void CmdType(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{cmd_cntx->tail_args()};
+void CmdType(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
   string_view path = parser.NextOrDefault();
 
@@ -2176,8 +2163,7 @@ void CmdType(CmdArgList args, CommandContext* cmd_cntx) {
   reply_generic::Send(result, cmd_cntx);
 }
 
-void CmdArrLen(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{cmd_cntx->tail_args()};
+void CmdArrLen(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
   string_view path = parser.NextOrDefault();
 
@@ -2192,8 +2178,7 @@ void CmdArrLen(CmdArgList args, CommandContext* cmd_cntx) {
   reply_generic::Send(result, cmd_cntx);
 }
 
-void CmdObjLen(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{cmd_cntx->tail_args()};
+void CmdObjLen(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
   string_view path = parser.NextOrDefault();
 
@@ -2208,8 +2193,7 @@ void CmdObjLen(CmdArgList args, CommandContext* cmd_cntx) {
   reply_generic::Send(result, cmd_cntx);
 }
 
-void CmdStrLen(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{cmd_cntx->tail_args()};
+void CmdStrLen(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
   string_view path = parser.NextOrDefault();
 
@@ -2224,10 +2208,7 @@ void CmdStrLen(CmdArgList args, CommandContext* cmd_cntx) {
   reply_generic::Send(result, cmd_cntx);
 }
 
-void CmdGet(CmdArgList args, CommandContext* cmd_cntx) {
-  DCHECK_GE(args.size(), 1U);
-
-  facade::CmdArgParser parser{cmd_cntx->tail_args()};
+void CmdGet(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
   auto* builder = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 


### PR DESCRIPTION
## Summary
Adds a parser-based `CommandId::SetHandler` overload and migrates bitops/JSON command
handlers to receive `CmdArgParser` from dispatch.

## Changes
- Add a non-async parser handler overload and make `SetAsyncHandler` reuse it
- Convert bitops and JSON handlers away from local `CmdArgParser` construction
- Keep arity and parsing checks on the shared dispatch parser where needed