### PR TITLE
refactor(server): move VerifyCommandState out of squasher, migrate dispatch path to ParsedArgs

### DIFF
--- a/src/server/acl/validator.cc
+++ b/src/server/acl/validator.cc
@@ -55,11 +55,10 @@ bool ValidateCommand(const std::vector<uint64_t>& acl_commands, const CommandId&
   if (!pub_sub.all_channels) {
     std::string_view name = id.name();
     if (name == "PUBLISH" || name == "SPUBLISH") {
-      auto channel = tail_args[0];
-      allowed &= iterate_globs(facade::ToSV(channel));
+      allowed &= iterate_globs(tail_args[0]);
     } else {
       for (auto channel : tail_args) {
-        allowed &= iterate_globs(facade::ToSV(channel));
+        allowed &= iterate_globs(channel);
       }
     }
   }

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1736,7 +1736,6 @@ uint32_t Service::DispatchSquashedBatch(facade::ParsedCommand* first, unsigned c
 
     dfly_cntx->transaction = dist_trans.get();
     MultiCommandSquasher::Opts opts;
-    opts.verify_commands = true;
     opts.pipeline_mode = true;
     opts.max_squash_size = ss->max_squash_cmd_num;
 
@@ -1778,6 +1777,15 @@ uint32_t Service::DispatchSquashedBatch(facade::ParsedCommand* first, unsigned c
     if (is_multi || is_eval || cid->IsBlocking() || (cid->opt_mask() & CO::ADMIN) ||
         cid->IsQuit() || cid->IsSubscribeFamily())
       break;
+
+    if (auto err = VerifyCommandState(*cid, tail_args, *dfly_cntx); err) {
+      CapturingReplyBuilder crb{ReplyMode::FULL, rb->GetRespVersion()};
+      crb.SendError(std::move(*err));
+      cmd_cntx->Resolve(crb.Take());
+      ++dispatched;
+      cmd = cmd->next;
+      continue;
+    }
 
     cmd_refs.push_back(CmdRef{cid, tail_args, ReplyMode::FULL, cmd_cntx});
     cmd = cmd->next;
@@ -1938,9 +1946,20 @@ optional<CapturingReplyBuilder::Payload> Service::FlushEvalAsyncCmds(ConnectionC
   DCHECK(eval_cid);
   tx->MultiSwitchCmd(eval_cid);
 
+  for (auto& scmd : info->async_cmds) {
+    auto ref = scmd.Ref();
+    if (auto err = VerifyCommandState(*ref.cid, ref.args, *cntx); err) {
+      info->async_cmds_heap_mem = 0;
+      info->async_cmds.clear();
+      CapturingReplyBuilder crb{ReplyMode::ONLY_ERR};
+      crb.SendError(std::move(*err));
+      auto reply = crb.Take();
+      return make_optional(std::move(reply));
+    }
+  }
+
   CapturingReplyBuilder crb{ReplyMode::ONLY_ERR};
   MultiCommandSquasher::Opts opts;
-  opts.verify_commands = true;
   opts.error_abort = true;
   opts.max_squash_size = ServerState::tlocal()->max_squash_cmd_num;
   auto cmd_gen = [it = info->async_cmds.begin(), end = info->async_cmds.end()]() mutable -> CmdRef {

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -178,14 +178,6 @@ bool MultiCommandSquasher::ExecuteStandalone(RedisReplyBuilder* rb, CmdRef cmd) 
       cmd.cmd_cntx->Resolve(crb->Take());
   };
 
-  if (opts_.verify_commands) {
-    if (auto err = service_->VerifyCommandState(*cmd.cid, args, *cntx_); err) {
-      rb->SendError(std::move(*err));
-      resolve();
-      return !opts_.error_abort;
-    }
-  }
-
   auto* tx = cntx_->transaction;
   if (cmd.cid->IsTransactional()) {
     tx->MultiSwitchCmd(cmd.cid);
@@ -228,15 +220,6 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
   for (auto& dispatched : sinfo.dispatched) {
     auto* ctx = &local_cntx;
     auto args = dispatched.Slice(&arg_vec);
-    if (opts_.verify_commands) {
-      // The shared context is used for state verification, the local one is only for replies
-      if (auto err = service_->VerifyCommandState(*dispatched.cid, args, *cntx_); err) {
-        crb.SendError(std::move(*err));
-        move_reply(&dispatched);
-        continue;
-      }
-    }
-
     crb.SetReplyMode(dispatched.reply_mode);
 
     // With tiered storage enabled, it makes sense to dispatch async commands concurrently

--- a/src/server/multi_command_squasher.h
+++ b/src/server/multi_command_squasher.h
@@ -23,7 +23,6 @@ namespace dfly {
 class MultiCommandSquasher {
  public:
   struct Opts {
-    bool verify_commands = false;   // Whether commands need to be verified before execution
     bool error_abort = false;       // Abort upon receiving error
     bool pipeline_mode = false;     // Whether to expect pipeline command contexts
     unsigned max_squash_size = 32;  // How many commands to squash at once

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -1165,6 +1165,31 @@ async def test_squashed_pipeline_control_commands(df_server: DflyInstance):
     await writer.wait_closed()
 
 
+"""
+Regression: verify-failed commands inside a squashed pipeline must still advance the
+reply loop; otherwise already-resolved commands can be left queued and resolved again.
+"""
+
+
+@dfly_args({"proactor_threads": "1", "pipeline_squash": 1, "restricted_commands": "SET"})
+async def test_squashed_pipeline_verify_fail(async_client: aioredis.Redis):
+    p = async_client.pipeline(transaction=False)
+    # N=3 reproduces the double-Resolve; use one extra pair for margin.
+    N = 4
+    for i in range(N):
+        p.get(f"k{i}")  # passes VerifyCommandState
+        p.set(f"k{i}", "v")  # fails VerifyCommandState (restricted command)
+    p.ping()  # liveness marker — never arrives if the server crashed
+
+    results = await p.execute(raise_on_error=False)
+
+    # aioredis returns True for PING in pipelines; a crash would raise ConnectionError instead
+    assert results[-1] is True, f"server crashed or wrong final reply: {results[-1]}"
+    for i in range(N):
+        assert results[i * 2] is None  # GET: key was never written (SET was denied)
+        assert isinstance(results[i * 2 + 1], aioredis.ResponseError)  # SET: denied
+
+
 async def test_unix_domain_socket(df_factory, tmp_dir):
     server = df_factory.create(proactor_threads=1, port=BASE_PORT, unixsocket="./df.sock")
     server.start()


### PR DESCRIPTION
## Summary

- Removes `verify_commands` from `MultiCommandSquasher::Opts` and eliminates `VerifyCommandState` calls from `ExecuteStandalone` and `SquashedHopCb`, simplifying the squasher to a pure execution loop.
- Moves verification to the two call sites that set `verify_commands = true`:
  - `DispatchSquashedBatch`: verifies each command in the pre-squash loop; on failure, captures the error into the command's deferred reply slot and skips it.
  - `FlushEvalAsyncCmds`: verifies all async commands before executing any; on first failure, clears the queue and returns the error.

## ParsedArgs migration

Migrates `VerifyCommandState` and its entire helper chain from `CmdArgList`/`ArgSlice` to `const facade::ParsedArgs&`, following #7656:
- `VerifyCommandState`, `CheckKeysOwnership`, `TakenOverSlotError`, `CheckKeysDeclared`, `VerifyConnectionAclStatus`, `FindKeys`
- `DetermineKeys`, `Transaction::InitByArgs`, `Transaction::InitBase`
- `acl::IsUserAllowedToInvokeCommand`, `IsUserAllowedToInvokeCommandGeneric`, `IsPubSubCommandAuthorized`

`ParsedArgs` has an implicit `ArgSlice` constructor so existing raw-span call sites compile unchanged.

## Testing

- `ninja dragonfly` builds clean.
- `multi_test`: 59 passed, 2 skipped (pre-existing).