### PR TITLE
Migrate command init and dispatch paths to facade::ParsedArgs

### DIFF
--- a/src/server/acl/validator.cc
+++ b/src/server/acl/validator.cc
@@ -34,7 +34,7 @@ bool ValidateCommand(const std::vector<uint64_t>& acl_commands, const CommandId&
 
 [[nodiscard]] std::pair<bool, AclLog::Reason> IsPubSubCommandAuthorized(
     bool literal_match, const std::vector<uint64_t>& acl_commands, const AclPubSub& pub_sub,
-    CmdArgList tail_args, const CommandId& id) {
+    const facade::ParsedArgs& tail_args, const CommandId& id) {
   if (!ValidateCommand(acl_commands, id)) {
     return {false, AclLog::Reason::COMMAND};
   }
@@ -70,7 +70,7 @@ bool ValidateCommand(const std::vector<uint64_t>& acl_commands, const CommandId&
 }  // namespace
 
 [[nodiscard]] bool IsUserAllowedToInvokeCommand(const ConnectionContext& cntx, const CommandId& id,
-                                                ArgSlice tail_args) {
+                                                const facade::ParsedArgs& tail_args) {
   if (cntx.skip_acl_validation) {
     return true;
   }
@@ -100,7 +100,7 @@ bool ValidateCommand(const std::vector<uint64_t>& acl_commands, const CommandId&
 }
 
 [[nodiscard]] std::pair<bool, AclLog::Reason> IsUserAllowedToInvokeCommandGeneric(
-    const ConnectionContext& cntx, const CommandId& id, CmdArgList tail_args) {
+    const ConnectionContext& cntx, const CommandId& id, const facade::ParsedArgs& tail_args) {
   const size_t max = std::numeric_limits<size_t>::max();
   // Once we support ranges this must change
   const bool reject_move_command = cntx.acl_db_idx != max && id.name() == "MOVE";

--- a/src/server/acl/validator.h
+++ b/src/server/acl/validator.h
@@ -15,10 +15,9 @@ namespace dfly::acl {
 struct AclKeys;
 struct AclPubSub;
 
-std::pair<bool, AclLog::Reason> IsUserAllowedToInvokeCommandGeneric(const ConnectionContext& cntx,
-                                                                    const CommandId& id,
-                                                                    facade::CmdArgList tail_args);
+std::pair<bool, AclLog::Reason> IsUserAllowedToInvokeCommandGeneric(
+    const ConnectionContext& cntx, const CommandId& id, const facade::ParsedArgs& tail_args);
 
 bool IsUserAllowedToInvokeCommand(const ConnectionContext& cntx, const CommandId& id,
-                                  facade::CmdArgList tail_args);
+                                  const facade::ParsedArgs& tail_args);
 }  // namespace dfly::acl

--- a/src/server/blocking_controller_test.cc
+++ b/src/server/blocking_controller_test.cc
@@ -64,7 +64,8 @@ void BlockingControllerTest::SetUp() {
     arg_vec_.emplace_back(s);
   }
 
-  trans_->InitByArgs(&namespaces->GetDefaultNamespace(), 0, {arg_vec_.data(), arg_vec_.size()});
+  trans_->InitByArgs(&namespaces->GetDefaultNamespace(), 0,
+                     CmdArgList{arg_vec_.data(), arg_vec_.size()});
   CHECK_EQ(0u, Shard("x", shard_set->size()));
   CHECK_EQ(2u, Shard("z", shard_set->size()));
 
@@ -107,7 +108,8 @@ TEST_F(BlockingControllerTest, NotifyWatchQueueFastPathOnAbsentKey) {
   txs.reserve(kWaiters);
   for (size_t i = 0; i < kWaiters; ++i) {
     auto t = boost::intrusive_ptr<Transaction>(new Transaction{&cid_});
-    t->InitByArgs(&namespaces->GetDefaultNamespace(), 0, {arg_vec_.data(), arg_vec_.size()});
+    t->InitByArgs(&namespaces->GetDefaultNamespace(), 0,
+                  CmdArgList{arg_vec_.data(), arg_vec_.size()});
     txs.push_back(std::move(t));
   }
 

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -1836,7 +1836,7 @@ void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBat
     auto args_span = absl::MakeSpan(arg_vec);
     stub_tx->MultiSwitchCmd(cid);
     crb.SetReplyMode(ReplyMode::NONE);
-    stub_tx->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, args_span);
+    stub_tx->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, facade::ParsedArgs{backed_args});
     cmd_cntx.UpdateCid(cid);
     cmd_cntx.SetTailArgs(facade::ParsedArgs{backed_args});
     sf_.service().InvokeCmd(args_span, &cmd_cntx);

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -293,7 +293,7 @@ auto CmdEntryToMonitorFormat(std::string_view str) -> std::string {
 }
 
 std::string MakeMonitorMessage(const ConnectionContext* cntx, const CommandId* cid,
-                               CmdArgList tail_args) {
+                               const facade::ParsedArgs& tail_args) {
   std::string message = absl::StrCat(CreateMonitorTimestamp(), " [", cntx->conn_state.db_index);
 
   string endpoint;
@@ -312,12 +312,13 @@ std::string MakeMonitorMessage(const ConnectionContext* cntx, const CommandId* c
     return message;
 
   for (auto arg : tail_args)
-    absl::StrAppend(&message, " ", CmdEntryToMonitorFormat(facade::ToSV(arg)));
+    absl::StrAppend(&message, " ", CmdEntryToMonitorFormat(arg));
 
   return message;
 }
 
-void DispatchMonitor(ConnectionContext* cntx, const CommandId* cid, CmdArgList tail_args) {
+void DispatchMonitor(ConnectionContext* cntx, const CommandId* cid,
+                     const facade::ParsedArgs& tail_args) {
   auto cb = [msg = MakeMonitorMessage(cntx, cid, tail_args)](unsigned idx, util::ProactorBase*) {
     const auto& monitors = ServerState::tlocal()->Monitors().monitors();
     if (monitors.empty())
@@ -627,7 +628,7 @@ string ConnectionLogContext(const facade::Connection* conn) {
   return absl::StrCat("(", conn->RemoteEndpointStr(), ")");
 }
 
-string FailedCommandToString(std::string_view command, facade::CmdArgList args,
+string FailedCommandToString(std::string_view command, const facade::ParsedArgs& args,
                              std::string_view reason) {
   constexpr size_t kMaxArgCount = 31;
   constexpr size_t kMaxArgLength = 128;
@@ -652,12 +653,12 @@ string FailedCommandToString(std::string_view command, facade::CmdArgList args,
   } else if (is_eval) {
     // log only script/SHA and numkeys, skip KEYS and ARGV to avoid PII leaks
     for (size_t i = 0; i < std::min(args.size(), size_t{2}); ++i) {
-      AppendArg(facade::ArgS(args, i));
+      AppendArg(args[i]);
     }
   } else {
     size_t num_args = std::min(args.size(), kMaxArgCount);
     for (size_t i = 0; i < num_args; ++i) {
-      AppendArg(facade::ArgS(args, i));
+      AppendArg(args[i]);
     }
     if (args.size() > kMaxArgCount) {
       absl::StrAppend(&result, " ... (", args.size() - kMaxArgCount, " more arguments)");
@@ -839,7 +840,7 @@ void CheckPauseState(facade::Connection* conn, ConnectionContext* dfly_cntx, con
 //   first  - newly created top-level transaction (or nullptr if none).
 //   second - result: overall status of preparation.
 pair<intrusive_ptr<Transaction>, OpStatus> PrepareTransaction(const CommandId* cid,
-                                                              ArgSlice tail_args,
+                                                              const facade::ParsedArgs& tail_args,
                                                               CommandContext* cmd_ctx) {
   auto* dfly_cntx = cmd_ctx->server_conn_cntx();
   bool init = false;
@@ -891,13 +892,13 @@ void StoreInMultiBlock(ConnectionContext* dfly_cntx, const CommandId* cid,
   ServerState::tlocal()->stats.stored_cmd_bytes += exec_info.GetStoredCmdBytes() - old_size;
 }
 
-bool ShouldLogError(const CommandId& cid, string_view reason, CmdArgList tail_args) {
+bool ShouldLogError(const CommandId& cid, string_view reason, const facade::ParsedArgs& tail_args) {
   if (absl::StartsWith(reason, "-BUSYGROUP"))
     return false;
 
   if (cid.name() != "CLIENT")
     return true;
-  return tail_args.empty() || !absl::EqualsIgnoreCase(tail_args.front(), "maint_notifications");
+  return tail_args.empty() || !absl::EqualsIgnoreCase(tail_args.Front(), "maint_notifications");
 }
 
 string_view McTypeToCmdName(MemcacheParser::CmdType type) {
@@ -1180,7 +1181,7 @@ void Service::Shutdown() {
   shutdown_watchdog->Disarm();
 }
 
-OpResult<KeyIndex> Service::FindKeys(const CommandId* cid, CmdArgList args) {
+OpResult<KeyIndex> Service::FindKeys(const CommandId* cid, const facade::ParsedArgs& args) {
   // Sharded pub-sub acts as if it's sharded by its channel name (just for checks)
   if (cid->IsShardedPubSub()) {
     // SPUBLISH has only one key, the rest is data
@@ -1192,7 +1193,8 @@ OpResult<KeyIndex> Service::FindKeys(const CommandId* cid, CmdArgList args) {
   return DetermineKeys(cid, args);
 }
 
-optional<ErrorReply> Service::CheckKeysOwnership(const CommandId& cid, CmdArgList args,
+optional<ErrorReply> Service::CheckKeysOwnership(const CommandId& cid,
+                                                 const facade::ParsedArgs& args,
                                                  const ConnectionContext& dfly_cntx) {
   if (dfly_cntx.is_replicating) {
     // Always allow commands on the replication port, as it might be for future-owned keys.
@@ -1233,7 +1235,8 @@ optional<ErrorReply> Service::CheckKeysOwnership(const CommandId& cid, CmdArgLis
 }
 
 // TODO(kostas) refactor. Almost 1-1 with CheckKeyOwnership() above.
-std::optional<facade::ErrorReply> Service::TakenOverSlotError(const CommandId& cid, CmdArgList args,
+std::optional<facade::ErrorReply> Service::TakenOverSlotError(const CommandId& cid,
+                                                              const facade::ParsedArgs& args,
                                                               const ConnectionContext& dfly_cntx) {
   if (cid.first_key_pos() == 0 && !cid.IsShardedPubSub()) {
     return nullopt;  // No key command.
@@ -1278,7 +1281,7 @@ std::optional<facade::ErrorReply> Service::TakenOverSlotError(const CommandId& c
 // Return OK if all keys are allowed to be accessed: either declared in EVAL or
 // transaction is running in global or non-atomic mode.
 optional<ErrorReply> CheckKeysDeclared(const ConnectionState::ScriptInfo& eval_info,
-                                       const CommandId* cid, CmdArgList args,
+                                       const CommandId* cid, const facade::ParsedArgs& args,
                                        Transaction::MultiMode multi_mode) {
   // We either scheduled on all shards or re-schedule for each operation,
   // so we are not restricted to any keys.
@@ -1301,14 +1304,16 @@ optional<ErrorReply> CheckKeysDeclared(const ConnectionState::ScriptInfo& eval_i
 
 static optional<ErrorReply> VerifyConnectionAclStatus(const CommandId* cid,
                                                       const ConnectionContext* cntx,
-                                                      string_view error_msg, ArgSlice tail_args) {
+                                                      string_view error_msg,
+                                                      const facade::ParsedArgs& tail_args) {
   if (!acl::IsUserAllowedToInvokeCommand(*cntx, *cid, tail_args)) {
     return ErrorReply(absl::StrCat("-NOPERM ", cntx->authed_username, " ", error_msg));
   }
   return nullopt;
 }
 
-std::optional<ErrorReply> Service::VerifyCommandState(const CommandId& cid, CmdArgList tail_args,
+std::optional<ErrorReply> Service::VerifyCommandState(const CommandId& cid,
+                                                      const facade::ParsedArgs& tail_args,
                                                       const ConnectionContext& dfly_cntx) {
   ServerState& etl = *ServerState::tlocal();
 
@@ -1495,7 +1500,8 @@ DispatchResult Service::DispatchCommand(facade::ParsedArgs args, facade::ParsedC
     if (VLOG_IS_ON(2)) {
       bool under_script = bool(dfly_cntx->conn_state.script_info);
       LOG(INFO) << "Got (" << conn->GetClientId() << "): " << (under_script ? "LUA " : "")
-                << cid->name() << " " << tail_args << " in dbid=" << dfly_cntx->conn_state.db_index;
+                << cid->name() << " " << args_no_cmd
+                << " in dbid=" << dfly_cntx->conn_state.db_index;
     }
 
     // Check pause state only if it is a top level transaction.
@@ -1504,7 +1510,7 @@ DispatchResult Service::DispatchCommand(facade::ParsedArgs args, facade::ParsedC
   }
 
   // Verify command state
-  if (auto err = VerifyCommandState(*cid, tail_args, *dfly_cntx); err) {
+  if (auto err = VerifyCommandState(*cid, args_no_cmd, *dfly_cntx); err) {
     LOG_IF(WARNING, dfly_cntx->replica_conn || !dfly_cntx->conn() /* no owner in replica context */)
         << "VerifyCommandState error: " << err->ToSv();
     if (auto& exec_info = dfly_cntx->conn_state.exec_info; exec_info.IsCollecting())
@@ -1541,7 +1547,7 @@ DispatchResult Service::DispatchCommand(facade::ParsedArgs args, facade::ParsedC
     return DispatchResult::OK;
   }
 
-  auto [dispatched_tx, status] = PrepareTransaction(cid, tail_args, cmd_cntx);
+  auto [dispatched_tx, status] = PrepareTransaction(cid, args_no_cmd, cmd_cntx);
   if (status != OpStatus::OK) {
     DCHECK(!dispatched_tx);
     cmd_cntx->SendError(StatusToMsg(status));

--- a/src/server/main_service.h
+++ b/src/server/main_service.h
@@ -51,7 +51,8 @@ class Service : public facade::ServiceInterface {
   // Verify command prepares execution in correct state.
   // It's usually called before command execution. Only for multi/exec transactions it's checked
   // when the command is queued for execution, not before the execution itself.
-  std::optional<facade::ErrorReply> VerifyCommandState(const CommandId& cid, ArgSlice tail_args,
+  std::optional<facade::ErrorReply> VerifyCommandState(const CommandId& cid,
+                                                       const facade::ParsedArgs& tail_args,
                                                        const ConnectionContext& cntx);
 
   facade::ConnectionContext* CreateContext(facade::Connection* owner) final;
@@ -157,12 +158,14 @@ class Service : public facade::ServiceInterface {
   };
 
   // Return error if not all keys are owned by the server when running in cluster mode
-  std::optional<facade::ErrorReply> CheckKeysOwnership(const CommandId& cid, CmdArgList args,
+  std::optional<facade::ErrorReply> CheckKeysOwnership(const CommandId& cid,
+                                                       const facade::ParsedArgs& args,
                                                        const ConnectionContext& dfly_cntx);
 
   // Return moved error if we *own* the slot. This function is used from flows that assume our
   // state is TAKEN_OVER which happens after a replica takeover.
-  std::optional<facade::ErrorReply> TakenOverSlotError(const CommandId& cid, CmdArgList args,
+  std::optional<facade::ErrorReply> TakenOverSlotError(const CommandId& cid,
+                                                       const facade::ParsedArgs& args,
                                                        const ConnectionContext& dfly_cntx);
 
   void EvalInternal(CmdArgList args, const EvalArgs& eval_args, Interpreter* interpreter,
@@ -182,7 +185,7 @@ class Service : public facade::ServiceInterface {
   std::variant<CommandId*, facade::DispatchResult> HandleMemcacheCommand(
       facade::ParsedCommand* parsed_cmd, facade::AsyncPreference async_pref);
 
-  OpResult<KeyIndex> FindKeys(const CommandId* cid, CmdArgList args);
+  OpResult<KeyIndex> FindKeys(const CommandId* cid, const facade::ParsedArgs& args);
 
   void RegisterCommands();
   void Register(CommandRegistry* registry);

--- a/src/server/serializer_base_test.cc
+++ b/src/server/serializer_base_test.cc
@@ -242,7 +242,7 @@ void TestDriver::ConsumeJournalChange(const journal::JournalChangeItem& item) {
   str_vec.erase(str_vec.begin());
 
   // Check all keys were baseline emitted before
-  auto keys = DetermineKeys(cid, str_vec);
+  auto keys = DetermineKeys(cid, CmdArgList{str_vec});
   CHECK(keys);
   for (auto key : keys->Range(str_vec))
     journal_writes_[key]++;

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -173,7 +173,7 @@ Transaction::~Transaction() {
            << " destroyed";
 }
 
-void Transaction::InitBase(Namespace* ns, DbIndex dbid, CmdArgList args) {
+void Transaction::InitBase(Namespace* ns, DbIndex dbid, const facade::ParsedArgs& args) {
   global_ = false;
   db_index_ = dbid;
   full_args_ = args;
@@ -357,7 +357,7 @@ void Transaction::InitByKeys(const KeyIndex& key_index) {
   }
 }
 
-OpStatus Transaction::InitByArgs(Namespace* ns, DbIndex index, CmdArgList args) {
+OpStatus Transaction::InitByArgs(Namespace* ns, DbIndex index, const facade::ParsedArgs& args) {
   InitBase(ns, index, args);
 
   if ((cid_->opt_mask() & CO::GLOBAL_TRANS) > 0) {
@@ -1634,7 +1634,7 @@ bool Transaction::CanRunInlined() const {
   return false;
 }
 
-OpResult<KeyIndex> DetermineKeys(const CommandId* cid, CmdArgList args) {
+OpResult<KeyIndex> DetermineKeys(const CommandId* cid, const facade::ParsedArgs& args) {
   if (cid->opt_mask() & (CO::GLOBAL_TRANS | CO::NO_KEY_TRANSACTIONAL))
     return KeyIndex{};
 
@@ -1655,7 +1655,7 @@ OpResult<KeyIndex> DetermineKeys(const CommandId* cid, CmdArgList args) {
     // Determine based on STREAMS argument position
     if (name == "XREAD" || name == "XREADGROUP") {
       for (size_t i = 0; i < args.size(); ++i) {
-        string_view arg = ArgS(args, i);
+        string_view arg = args[i];
         if (absl::EqualsIgnoreCase(arg, "STREAMS")) {
           size_t left = args.size() - i - 1;
           return KeyIndex(i + 1, i + 1 + (left / 2));
@@ -1673,7 +1673,7 @@ OpResult<KeyIndex> DetermineKeys(const CommandId* cid, CmdArgList args) {
     else
       num_keys_index = bonus ? *bonus + 1 : 0;
 
-    string_view num = ArgS(args, num_keys_index);
+    string_view num = args[num_keys_index];
     if (!absl::SimpleAtoi(num, &num_custom_keys) || num_custom_keys < 0)
       return OpStatus::INVALID_INT;
 
@@ -1708,7 +1708,7 @@ OpResult<KeyIndex> DetermineKeys(const CommandId* cid, CmdArgList args) {
       if ((name == "GEORADIUSBYMEMBER" && args.size() >= 5) ||
           (name == "GEORADIUS" && args.size() >= 6)) {
         // key member radius .. STORE destkey
-        string_view opt = ArgS(args, args.size() - 2);
+        string_view opt = args[args.size() - 2];
         if (absl::EqualsIgnoreCase(opt, "STORE") || absl::EqualsIgnoreCase(opt, "STOREDIST")) {
           bonus = args.size() - 1;
         }
@@ -1717,7 +1717,7 @@ OpResult<KeyIndex> DetermineKeys(const CommandId* cid, CmdArgList args) {
       if (name == "SORT") {
         if (args.size() >= 3) {
           // SORT key ... STORE destkey
-          string_view opt = ArgS(args, args.size() - 2);
+          string_view opt = args[args.size() - 2];
           if (absl::EqualsIgnoreCase(opt, "STORE")) {
             bonus = args.size() - 1;
           }

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -182,7 +182,7 @@ class Transaction {
   explicit Transaction(const Transaction* parent, ShardId shard_id, std::optional<SlotId> slot_id);
 
   // Initialize from command (args) on specific db.
-  OpStatus InitByArgs(Namespace* ns, DbIndex index, CmdArgList args);
+  OpStatus InitByArgs(Namespace* ns, DbIndex index, const facade::ParsedArgs& args);
 
   // Get command arguments for specific shard. Called from shard thread.
   ShardArgs GetShardArgs(ShardId sid) const;
@@ -486,7 +486,7 @@ class Transaction {
   };
 
   // Init basic fields and reset re-usable.
-  void InitBase(Namespace* ns, DbIndex dbid, CmdArgList args);
+  void InitBase(Namespace* ns, DbIndex dbid, const facade::ParsedArgs& args);
 
   // Init as a global transaction.
   void InitGlobal();
@@ -674,6 +674,6 @@ template <typename F> auto Transaction::ScheduleSingleHopT(F&& f) -> decltype(f(
   return res;
 }
 
-OpResult<KeyIndex> DetermineKeys(const CommandId* cid, CmdArgList args);
+OpResult<KeyIndex> DetermineKeys(const CommandId* cid, const facade::ParsedArgs& args);
 
 }  // namespace dfly


### PR DESCRIPTION
Widen the argument type along the transaction init and command dispatch paths from CmdArgList (a non-owning span) to const facade::ParsedArgs&, so BackedArguments-backed args flow through without re-narrowing to a span. Existing callers keep working via the implicit ArgSlice -> ParsedArgs conversion.

Init path:
- Transaction::InitByArgs / InitBase / DetermineKeys take ParsedArgs.
- debugcmd's stub-exec path passes ParsedArgs{backed_args} directly instead of materializing a span.

Dispatch / ACL path:
- PrepareTransaction, VerifyCommandState, FindKeys, CheckKeysOwnership, TakenOverSlotError, CheckKeysDeclared, VerifyConnectionAclStatus and the acl::IsUserAllowedToInvokeCommand* helpers take ParsedArgs.
- DispatchCommand now passes args_no_cmd (ParsedArgs) to these directly.

InvokeCmd and the command handlers still consume a span, so the arg_slice_backing copy is not removed yet; this shrinks the span-consumer surface ahead of that migration.

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
