### PR TITLE
fix(ok_backend): track command_cnt_main in dispatch

### DIFF
--- a/src/facade/ok_main.cc
+++ b/src/facade/ok_main.cc
@@ -374,6 +374,8 @@ class OkService : public ServiceInterface {
 
 DispatchResult OkService::DispatchCommand([[maybe_unused]] ParsedArgs args, ParsedCommand* cmd,
                                           AsyncPreference mode) {
+  ++tl_facade_stats->conn_stats.command_cnt_main;
+
   if (cmd->empty()) {
     cmd->rb()->SendError("ERR empty command");
     return DispatchResult::OK;
@@ -436,6 +438,8 @@ uint32_t OkService::DispatchSquashedBatch(ParsedCommand* first, unsigned count,
   GroupResult group = GroupSquashableRun(first, count, num_shards, &per_shard);
   if (group.processed == 0)
     return 0;
+
+  tl_facade_stats->conn_stats.command_cnt_main += group.processed;
 
   if (absl::GetFlag(FLAGS_coro_squash))
     EmitCoroBatch(group.num_active, per_shard);


### PR DESCRIPTION
in ok_main.cc: neither DispatchCommand nor DispatchSquashedBatch incremented command_cnt_main, so dragonfly_commands_processed_total always reported 0 in /metrics.

- DispatchCommand: increment by 1 for each non-squashable command.
- DispatchSquashedBatch: increment by group.processed to cover the hot squashed-SET/GET path, which bypasses DispatchCommand entirely.

