### PR TITLE
fix(search): serialize only KNN winners for filtered vector search

### DIFF
--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -827,8 +827,13 @@ vector<search::SortableValue> ShardDocIndex::KeepTopKSorted(vector<DocId>* ids, 
   DCHECK_GT(limit, 0u) << "Limit=0 still has O(ids->size()) complexity";
 
   using QPair = std::pair<search::SortableValue, DocId>;
-  // Docs missing the sort field are kept but rank worst (sorted last) in both directions;
-  // returns true when `a` should outrank `b` so q.top() is always the worst kept value.
+  // priority_queue comparator: q.top() is the worst kept entry, evicted first when a better
+  // candidate arrives. better(a, b) is true when a should rank before b. Docs missing the sort
+  // field hold a monostate value and always rank last, in both directions. Cases (a, b -> result):
+  //   present, present -> order by (value, doc id): a < b for ASC, b < a for DESC
+  //   present, missing -> true   (present ranks before missing)
+  //   missing, present -> false  (missing ranks after present)
+  //   missing, missing -> order by (value, doc id); values are equal, so deterministic by doc id
   auto better = [order = sort.order](const QPair& a, const QPair& b) {
     bool a_null = std::holds_alternative<std::monostate>(a.first);
     bool b_null = std::holds_alternative<std::monostate>(b.first);

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -6,6 +6,7 @@
 
 #include <absl/strings/str_join.h>
 
+#include <functional>
 #include <memory>
 #include <queue>
 #include <ranges>
@@ -827,50 +828,50 @@ vector<search::SortableValue> ShardDocIndex::KeepTopKSorted(vector<DocId>* ids, 
   DCHECK_GT(limit, 0u) << "Limit=0 still has O(ids->size()) complexity";
 
   using QPair = std::pair<search::SortableValue, DocId>;
-  // priority_queue comparator: q.top() is the worst kept entry, evicted first when a better
-  // candidate arrives. better(a, b) is true when a should rank before b. Docs missing the sort
-  // field hold a monostate value and always rank last, in both directions. Cases (a, b -> result):
-  //   present, present -> order by (value, doc id): a < b for ASC, b < a for DESC
-  //   present, missing -> true   (present ranks before missing)
-  //   missing, present -> false  (missing ranks after present)
-  //   missing, missing -> order by (value, doc id); values are equal, so deterministic by doc id
-  auto better = [order = sort.order](const QPair& a, const QPair& b) {
-    bool a_null = std::holds_alternative<std::monostate>(a.first);
-    bool b_null = std::holds_alternative<std::monostate>(b.first);
-    if (a_null != b_null)
-      return b_null;
-    return order == SortOrder::ASC ? a < b : b < a;
-  };
-  std::priority_queue<QPair, std::vector<QPair>, decltype(better)> q(better);
 
-  // Iterate over all documents, extract the sortable field (monostate if absent) and update the
-  // queue, keeping the top-k by sort order.
-  for (DocId id : *ids) {
-    auto entry = LoadEntry(id, op_args);
-    if (!entry)
-      continue;
+  // ValueCmp (std::less/std::greater) selects the direction for present values; docs missing the
+  // sort field hold a monostate value and always rank last, independent of direction, so that rule
+  // wraps ValueCmp. ranks_before(a, b) is true when a should rank before b; the priority queue
+  // keeps the max (worst) on top, so it is evicted first when a better candidate arrives.
+  auto select = [&](auto value_cmp) {
+    auto ranks_before = [value_cmp](const QPair& a, const QPair& b) {
+      bool a_missing = std::holds_alternative<std::monostate>(a.first);
+      bool b_missing = std::holds_alternative<std::monostate>(b.first);
+      if (a_missing != b_missing)
+        return !a_missing;  // present ranks before missing
+      return value_cmp(a, b);
+    };
+    std::priority_queue<QPair, std::vector<QPair>, decltype(ranks_before)> q(ranks_before);
 
-    search::SortableValue value = std::monostate{};
-    if (auto result = entry->second->Serialize(base_->schema, {sort.field}); !result.empty())
-      value = std::move(result.begin()->second);
+    for (DocId id : *ids) {
+      auto entry = LoadEntry(id, op_args);
+      if (!entry)
+        continue;
 
-    QPair candidate{std::move(value), id};
-    if (q.size() < limit || better(candidate, q.top())) {
-      if (q.size() >= limit)
-        q.pop();
-      q.push(std::move(candidate));
+      search::SortableValue value = std::monostate{};
+      if (auto result = entry->second->Serialize(base_->schema, {sort.field}); !result.empty())
+        value = std::move(result.begin()->second);
+
+      QPair candidate{std::move(value), id};
+      if (q.size() < limit || ranks_before(candidate, q.top())) {
+        if (q.size() >= limit)
+          q.pop();
+        q.push(std::move(candidate));
+      }
     }
-  }
 
-  // Reorder ids and collect scores
-  vector<search::SortableValue> out(q.size());
-  for (int i = 0; !q.empty(); i++) {
-    auto [v, id] = q.top();
-    (*ids)[i] = id;
-    out[i] = std::move(v);
-    q.pop();
-  }
-  return out;
+    // Reorder ids and collect scores
+    vector<search::SortableValue> out(q.size());
+    for (int i = 0; !q.empty(); i++) {
+      auto [v, id] = q.top();
+      (*ids)[i] = id;
+      out[i] = std::move(v);
+      q.pop();
+    }
+    return out;
+  };
+
+  return sort.order == SortOrder::ASC ? select(std::less<QPair>{}) : select(std::greater<QPair>{});
 }
 
 SearchResult ShardDocIndex::Search(const OpArgs& op_args, const SearchParams& params,

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -826,28 +826,34 @@ vector<search::SortableValue> ShardDocIndex::KeepTopKSorted(vector<DocId>* ids, 
                                                             const OpArgs& op_args) const {
   DCHECK_GT(limit, 0u) << "Limit=0 still has O(ids->size()) complexity";
 
-  auto comp = [order = sort.order](const auto& lhs, const auto& rhs) {
-    return order == SortOrder::ASC ? lhs < rhs : lhs > rhs;
-  };
-  // Priority queue keeps top-k values in reverse order (to compare against top - worst value)
   using QPair = std::pair<search::SortableValue, DocId>;
-  std::priority_queue<QPair, std::vector<QPair>, decltype(comp)> q(comp);
+  // Docs missing the sort field are kept but rank worst (sorted last) in both directions;
+  // returns true when `a` should outrank `b` so q.top() is always the worst kept value.
+  auto better = [order = sort.order](const QPair& a, const QPair& b) {
+    bool a_null = std::holds_alternative<std::monostate>(a.first);
+    bool b_null = std::holds_alternative<std::monostate>(b.first);
+    if (a_null != b_null)
+      return b_null;
+    return order == SortOrder::ASC ? a < b : b < a;
+  };
+  std::priority_queue<QPair, std::vector<QPair>, decltype(better)> q(better);
 
-  // Iterate over all documents, extract sortable field and update the queue
+  // Iterate over all documents, extract the sortable field (monostate if absent) and update the
+  // queue, keeping the top-k by sort order.
   for (DocId id : *ids) {
     auto entry = LoadEntry(id, op_args);
     if (!entry)
       continue;
 
-    auto result = entry->second->Serialize(base_->schema, {sort.field});
-    if (result.empty())
-      continue;
+    search::SortableValue value = std::monostate{};
+    if (auto result = entry->second->Serialize(base_->schema, {sort.field}); !result.empty())
+      value = std::move(result.begin()->second);
 
-    // Check if the extracted value is better than the worst (q.top())
-    if (q.size() < limit || comp(result.begin()->second, q.top().first)) {
+    QPair candidate{std::move(value), id};
+    if (q.size() < limit || better(candidate, q.top())) {
       if (q.size() >= limit)
         q.pop();
-      q.emplace(std::move(result.begin()->second), id);
+      q.push(std::move(candidate));
     }
   }
 
@@ -1003,6 +1009,39 @@ SearchResult ShardDocIndex::Search(const OpArgs& op_args, const SearchParams& pa
   }
 
   return {result.total - expired_count, std::move(out), std::move(result.profile)};
+}
+
+SearchIdResult ShardDocIndex::SearchIds(const OpArgs& op_args, const SearchParams& params,
+                                        search::SearchAlgorithm* search_algo,
+                                        const search::GlobalScoringStats* global_stats) const {
+  auto result = search_algo->Search(&*indices_, numeric_limits<size_t>::max(), global_stats);
+  if (!result.error.empty())
+    return {facade::ErrorReply(std::move(result.error))};
+
+  if (!params.IdsOnly()) {
+    vector<DocId> live_ids;
+    absl::flat_hash_map<DocId, float> live_text_scores;
+    live_ids.reserve(result.ids.size());
+    if (!result.text_scores.empty())
+      live_text_scores.reserve(result.text_scores.size());
+
+    for (DocId id : result.ids) {
+      if (!LoadEntry(id, op_args))
+        continue;
+
+      live_ids.push_back(id);
+      if (auto it = result.text_scores.find(id); it != result.text_scores.end())
+        live_text_scores[id] = it->second;
+    }
+
+    return {live_ids.size(), std::move(live_ids), std::move(live_text_scores),
+            std::move(result.profile)};
+  }
+
+  // NOCONTENT returns ids without a per-id liveness check (ignore-expiration fast path); a winner
+  // deleted before the load hop is dropped there, which can yield <k results — acceptable here.
+  return {result.total, std::move(result.ids), std::move(result.text_scores),
+          std::move(result.profile)};
 }
 
 search::ShardScoringStats ShardDocIndex::CollectScoringStats(

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -60,12 +60,41 @@ struct SearchResult {
   SearchResult(facade::ErrorReply error) : error{std::move(error)} {
   }
 
-  size_t total_hits;
+  size_t total_hits = 0;
   std::vector<SerializedSearchDoc> docs;
   std::optional<search::AlgorithmProfile> profile;
 
   std::optional<facade::ErrorReply> error;
 };
+
+struct SearchIdResult {
+  SearchIdResult() = default;
+
+  SearchIdResult(size_t total_hits, std::vector<search::DocId> ids,
+                 absl::flat_hash_map<search::DocId, float> text_scores,
+                 std::optional<search::AlgorithmProfile> profile);
+
+  SearchIdResult(facade::ErrorReply error);
+
+  size_t total_hits = 0;
+  std::vector<search::DocId> ids;
+  absl::flat_hash_map<search::DocId, float> text_scores;
+  std::optional<search::AlgorithmProfile> profile;
+
+  std::optional<facade::ErrorReply> error;
+};
+
+inline SearchIdResult::SearchIdResult(size_t total_hits, std::vector<search::DocId> ids,
+                                      absl::flat_hash_map<search::DocId, float> text_scores,
+                                      std::optional<search::AlgorithmProfile> profile)
+    : total_hits{total_hits},
+      ids{std::move(ids)},
+      text_scores{std::move(text_scores)},
+      profile{std::move(profile)} {
+}
+
+inline SearchIdResult::SearchIdResult(facade::ErrorReply error) : error{std::move(error)} {
+}
 
 // Field reference with optional alias as parsed from RETURN [field AS alias], LOAD, etc...
 struct FieldReference {
@@ -359,6 +388,12 @@ class ShardDocIndex {
   SearchResult Search(const OpArgs& op_args, const SearchParams& params,
                       search::SearchAlgorithm* search_algo, bool is_knn_prefilter,
                       const search::GlobalScoringStats* global_stats) const;
+
+  // Perform search and return only matched document ids. Used by HNSW prefilters where
+  // serializing every filtered key before KNN would dominate wide-filter queries.
+  SearchIdResult SearchIds(const OpArgs& op_args, const SearchParams& params,
+                           search::SearchAlgorithm* search_algo,
+                           const search::GlobalScoringStats* global_stats) const;
 
   // This shard's contribution to a GlobalScoringStats. search_algo must be
   // Init()-ed.

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -1157,8 +1157,13 @@ void PartialSort(absl::Span<SerializedSearchDoc*> docs, size_t limit, SortOrder 
   partial_sort(docs.begin(), docs.begin() + min(limit, docs.size()), docs.end(), cb);
 }
 
-// SORTBY merge: orders by sort_score, placing docs missing the field (monostate) last in both
-// directions. A plain value comparison would otherwise sort monostate first in ASC.
+// Global SORTBY merge across shards. cb(l, r) is true when l should rank before r. Docs missing the
+// sort field hold a monostate sort_score and always rank last, in both directions (a plain variant
+// comparison would sort monostate first in ASC). Cases (l, r -> result):
+//   present, present -> order by value: l < r for ASC, r < l for DESC
+//   present, missing -> true   (present ranks before missing)
+//   missing, present -> false  (missing ranks after present)
+//   missing, missing -> false  (equal)
 void PartialSortBySortScore(absl::Span<SerializedSearchDoc*> docs, size_t limit, SortOrder order) {
   auto cb = [order](SerializedSearchDoc* l, SerializedSearchDoc* r) {
     bool l_null = std::holds_alternative<std::monostate>(l->sort_score);

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -16,6 +16,7 @@
 #include <atomic>
 #include <cmath>
 #include <exception>
+#include <functional>
 #include <variant>
 #include <vector>
 
@@ -1157,22 +1158,25 @@ void PartialSort(absl::Span<SerializedSearchDoc*> docs, size_t limit, SortOrder 
   partial_sort(docs.begin(), docs.begin() + min(limit, docs.size()), docs.end(), cb);
 }
 
-// Global SORTBY merge across shards. cb(l, r) is true when l should rank before r. Docs missing the
-// sort field hold a monostate sort_score and always rank last, in both directions (a plain variant
-// comparison would sort monostate first in ASC). Cases (l, r -> result):
-//   present, present -> order by value: l < r for ASC, r < l for DESC
-//   present, missing -> true   (present ranks before missing)
-//   missing, present -> false  (missing ranks after present)
-//   missing, missing -> false  (equal)
+// Global SORTBY merge across shards. ValueCmp (std::less/std::greater) selects the direction for
+// present values; docs missing the field hold a monostate sort_score and always rank last,
+// independent of direction, so that rule wraps ValueCmp (a plain variant comparison would sort
+// monostate first in ASC). ranks_before(l, r) is true when l should be ordered before r.
 void PartialSortBySortScore(absl::Span<SerializedSearchDoc*> docs, size_t limit, SortOrder order) {
-  auto cb = [order](SerializedSearchDoc* l, SerializedSearchDoc* r) {
-    bool l_null = std::holds_alternative<std::monostate>(l->sort_score);
-    bool r_null = std::holds_alternative<std::monostate>(r->sort_score);
-    if (l_null != r_null)
-      return r_null;
-    return order == SortOrder::ASC ? l->sort_score < r->sort_score : r->sort_score < l->sort_score;
+  auto run = [&](auto value_cmp) {
+    auto ranks_before = [value_cmp](SerializedSearchDoc* l, SerializedSearchDoc* r) {
+      bool l_missing = std::holds_alternative<std::monostate>(l->sort_score);
+      bool r_missing = std::holds_alternative<std::monostate>(r->sort_score);
+      if (l_missing != r_missing)
+        return !l_missing;  // present ranks before missing
+      return value_cmp(l->sort_score, r->sort_score);
+    };
+    partial_sort(docs.begin(), docs.begin() + min(limit, docs.size()), docs.end(), ranks_before);
   };
-  partial_sort(docs.begin(), docs.begin() + min(limit, docs.size()), docs.end(), cb);
+  if (order == SortOrder::ASC)
+    run(std::less<>{});
+  else
+    run(std::greater<>{});
 }
 
 void SearchReply(const SearchParams& params,

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -4,6 +4,7 @@
 
 #include "server/search/search_family.h"
 
+#include <absl/cleanup/cleanup.h>
 #include <absl/container/flat_hash_map.h>
 #include <absl/flags/flag.h>
 #include <absl/strings/match.h>
@@ -14,6 +15,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cmath>
+#include <exception>
 #include <variant>
 #include <vector>
 
@@ -1155,6 +1157,19 @@ void PartialSort(absl::Span<SerializedSearchDoc*> docs, size_t limit, SortOrder 
   partial_sort(docs.begin(), docs.begin() + min(limit, docs.size()), docs.end(), cb);
 }
 
+// SORTBY merge: orders by sort_score, placing docs missing the field (monostate) last in both
+// directions. A plain value comparison would otherwise sort monostate first in ASC.
+void PartialSortBySortScore(absl::Span<SerializedSearchDoc*> docs, size_t limit, SortOrder order) {
+  auto cb = [order](SerializedSearchDoc* l, SerializedSearchDoc* r) {
+    bool l_null = std::holds_alternative<std::monostate>(l->sort_score);
+    bool r_null = std::holds_alternative<std::monostate>(r->sort_score);
+    if (l_null != r_null)
+      return r_null;
+    return order == SortOrder::ASC ? l->sort_score < r->sort_score : r->sort_score < l->sort_score;
+  };
+  partial_sort(docs.begin(), docs.begin() + min(limit, docs.size()), docs.end(), cb);
+}
+
 void SearchReply(const SearchParams& params,
                  std::optional<search::KnnScoreSortOption> knn_sort_option,
                  std::string_view inject_score_alias, absl::Span<SearchResult> results,
@@ -1214,8 +1229,7 @@ void SearchReply(const SearchParams& params,
 
   // Apply SORTBY if its different from the KNN sort
   if (params.sort_option && !ignore_sort)
-    PartialSort(absl::MakeSpan(docs), end, params.sort_option->order,
-                &SerializedSearchDoc::sort_score);
+    PartialSortBySortScore(absl::MakeSpan(docs), end, params.sort_option->order);
 
   const bool reply_with_ids_only = params.IdsOnly();
   auto* rb = static_cast<RedisReplyBuilder*>(builder);
@@ -1263,6 +1277,7 @@ void WarmupQueryParser() {
 struct HnswLoadOptions {
   bool set_sort_score = false;
   bool remove_sort_field = false;
+  std::string sort_score_field;
   std::optional<std::vector<FieldReference>> return_fields;
 };
 
@@ -1273,10 +1288,15 @@ HnswLoadOptions PrepareHnswLoadOptions(const SearchParams& params,
 
   options.set_sort_score =
       params.sort_option && (!knn_score_option || !params.sort_option->IsSame(*knn_score_option));
-  if (!options.return_fields || !options.set_sort_score)
+  if (!options.set_sort_score)
     return options;
 
   auto sort_field = params.sort_option->field.Name();
+  options.sort_score_field = sort_field;
+
+  if (!options.return_fields)
+    return options;
+
   auto sort_return_field = rng::find_if(
       *options.return_fields,
       [sort_field](const FieldReference& field) { return field.Name() == sort_field; });
@@ -1284,86 +1304,31 @@ HnswLoadOptions PrepareHnswLoadOptions(const SearchParams& params,
   if (sort_return_field == options.return_fields->end()) {
     options.return_fields->push_back(params.sort_option->field);
     options.remove_sort_field = true;
+  } else {
+    options.sort_score_field = sort_return_field->OutputName();
   }
   return options;
 }
 
-vector<SearchResult> SearchGlobalHnswIndex(
-    const search::AstKnnNode* knn, const shared_ptr<search::HnswVectorIndex>& index,
+vector<SearchResult> LoadHnswSearchDocs(
     const std::string_view index_name,
-    const std::optional<search::KnnScoreSortOption>& knn_score_option,
-    const std::vector<SearchResult>& sharded_prefilter_docs, const SearchParams& params,
-    const CommandContext& cmd_cntx) {
+    const std::optional<search::KnnScoreSortOption>& knn_score_option, const SearchParams& params,
+    const CommandContext& cmd_cntx, std::vector<std::vector<SerializedSearchDoc>> shard_docs,
+    bool finalize) {
   std::vector<SearchResult> results(1);
-
-  std::optional<std::vector<search::GlobalDocId>> prefilter_global_docs_ids = std::nullopt;
-
-  // Quick lookup to match global id to serialized doc
-  std::map<search::GlobalDocId, const SerializedSearchDoc*> prefilter_docs_lookup;
-
-  const bool has_prefilter_docs = knn->HasPreFilter();
-  const ShardId shard_size = sharded_prefilter_docs.size();
-
-  // We have pre filter docs so all documents should already be fetched
-  if (has_prefilter_docs) {
-    std::vector<search::GlobalDocId> global_doc_ids;
-    for (size_t shard_id = 0; shard_id < shard_size; shard_id++) {
-      for (auto& doc : sharded_prefilter_docs[shard_id].docs) {
-        auto global_doc_id = search::CreateGlobalDocId(shard_id, doc.id);
-        global_doc_ids.emplace_back(global_doc_id);
-        prefilter_docs_lookup[global_doc_id] = &doc;
-      }
-    }
-    prefilter_global_docs_ids = std::move(global_doc_ids);
-  }
-
-  // Search HNSW index
-  std::vector<std::pair<float, search::GlobalDocId>> knn_results;
-
-  if (prefilter_global_docs_ids) {
-    VLOG(1) << "Searching HNSW index with prefilter size: " << prefilter_global_docs_ids->size();
-    if (prefilter_global_docs_ids->size() < absl::GetFlag(FLAGS_subset_knn_search_threshold)) {
-      knn_results = index->SubsetKnn(knn->vec.first.get(), knn->limit, *prefilter_global_docs_ids);
-    } else {
-      knn_results =
-          index->Knn(knn->vec.first.get(), knn->limit, knn->ef_runtime, *prefilter_global_docs_ids);
-    }
-  } else {
-    knn_results = index->Knn(knn->vec.first.get(), knn->limit, knn->ef_runtime);
-  }
+  const ShardId shard_size = shard_docs.size();
 
   std::vector<SerializedSearchDoc> knn_search_serialized_docs;
-  knn_search_serialized_docs.reserve(knn_results.size());
-
-  // Serialized docs for each shard
-  std::vector<std::vector<SerializedSearchDoc>> shard_docs(shard_size);
-
-  for (const auto& [score, global_doc_id] : knn_results) {
-    if (has_prefilter_docs) {
-      knn_search_serialized_docs.emplace_back(*prefilter_docs_lookup[global_doc_id]);
-      knn_search_serialized_docs.back().knn_score = score;
-    } else {
-      // Create SerializedSearchDoc and fill only knn information
-      auto [shard_id, local_doc_id] = search::DecomposeGlobalDocId(global_doc_id);
-      SerializedSearchDoc doc;
-      doc.id = local_doc_id;
-      doc.knn_score = score;
-      shard_docs[shard_id].emplace_back(doc);
-    }
-  }
-
-  // If we have prefilter docs we don't need to fetch docs so can return early
-  if (has_prefilter_docs) {
-    results[0].total_hits = knn_search_serialized_docs.size();
-    results[0].docs = std::move(knn_search_serialized_docs);
-    return results;
-  }
+  size_t docs_count = 0;
+  for (const auto& shard : shard_docs)
+    docs_count += shard.size();
+  knn_search_serialized_docs.reserve(docs_count);
 
   // Indicator if we serialized document on shard
   std::vector<std::vector<bool>> shard_docs_serialized_indicator(shard_size);
 
   // Fetch all docs from shards
-  cmd_cntx.tx()->ScheduleSingleHop([&](Transaction* t, EngineShard* es) {
+  auto cb = [&](Transaction* t, EngineShard* es) {
     auto* index = es->search_indices()->GetIndex(index_name);
 
     // No index found or no docs on this shard
@@ -1373,12 +1338,24 @@ vector<SearchResult> SearchGlobalHnswIndex(
 
     const auto& schema = index->base().schema;
     auto load_options = PrepareHnswLoadOptions(params, knn_score_option);
+    const bool ids_only_without_sort_load = params.IdsOnly() && !load_options.set_sort_score;
 
     // Resize shard with default `true` value
     shard_docs_serialized_indicator[es->shard_id()].resize(shard_docs[es->shard_id()].size(), true);
 
     for (size_t i = 0; i < shard_docs[es->shard_id()].size(); i++) {
       auto& shard_doc = shard_docs[es->shard_id()][i];
+
+      if (ids_only_without_sort_load) {
+        const auto& keys = index->key_index();
+        if (keys.IsValid(shard_doc.id)) {
+          shard_doc.key = std::string{keys.Get(shard_doc.id)};
+        } else {
+          shard_docs_serialized_indicator[es->shard_id()][i] = false;
+        }
+        continue;
+      }
+
       if (auto doc = index->SerializeDocWithKey(shard_doc.id, t->GetOpArgs(es), schema,
                                                 load_options.return_fields);
           doc) {
@@ -1387,9 +1364,10 @@ vector<SearchResult> SearchGlobalHnswIndex(
         // Handle sort_score and remove field if we don't need it
         search::SortableValue sort_score = std::monostate{};
         if (load_options.set_sort_score) {
-          sort_score = fields[params.sort_option->field.Name()];
+          if (auto it = fields.find(load_options.sort_score_field); it != fields.end())
+            sort_score = it->second;
           if (load_options.remove_sort_field) {
-            fields.erase(params.sort_option->field.Name());
+            fields.erase(load_options.sort_score_field);
           }
         }
         shard_doc.key = std::string{key};
@@ -1401,17 +1379,21 @@ vector<SearchResult> SearchGlobalHnswIndex(
       }
     }
     return OpStatus::OK;
-  });
+  };
+  if (finalize)
+    cmd_cntx.tx()->Execute(std::move(cb), true);
+  else
+    cmd_cntx.tx()->ScheduleSingleHop(std::move(cb));
 
-  // Transform shard results back to
+  // Transform shard results back to a flat list of serialized docs. A shard whose index went
+  // missing during the hop (e.g. dropped between hops) leaves its indicator empty, not resized.
   size_t shard_id = 0;
   std::for_each(shard_docs.begin(), shard_docs.end(),
                 [&](const std::vector<SerializedSearchDoc>& shard) {
+                  const auto& serialized = shard_docs_serialized_indicator[shard_id];
                   for (size_t doc_index = 0; doc_index < shard.size(); ++doc_index) {
-                    // Check if we serialized doc
-                    if (shard_docs_serialized_indicator[shard_id][doc_index]) {
+                    if (doc_index < serialized.size() && serialized[doc_index])
                       knn_search_serialized_docs.push_back(shard[doc_index]);
-                    }
                   }
                   shard_id++;
                 });
@@ -1420,6 +1402,91 @@ vector<SearchResult> SearchGlobalHnswIndex(
   results[0].docs = std::move(knn_search_serialized_docs);
 
   return results;
+}
+
+std::vector<std::pair<float, search::GlobalDocId>> SearchHnswWithPrefilter(
+    const search::AstKnnNode* knn, const shared_ptr<search::HnswVectorIndex>& index,
+    std::optional<std::vector<search::GlobalDocId>> prefilter_global_docs_ids) {
+  if (!prefilter_global_docs_ids)
+    return index->Knn(knn->vec.first.get(), knn->limit, knn->ef_runtime);
+
+  auto& ids = *prefilter_global_docs_ids;
+  VLOG(1) << "Searching HNSW index with prefilter size: " << ids.size();
+
+  if (ids.size() < absl::GetFlag(FLAGS_subset_knn_search_threshold))
+    return index->SubsetKnn(knn->vec.first.get(), knn->limit, ids);
+
+  // HnswVectorIndex::Knn(... allowed) uses binary_search for membership.
+  if (!is_sorted(ids.begin(), ids.end()))
+    sort(ids.begin(), ids.end());
+
+  return index->Knn(knn->vec.first.get(), knn->limit, knn->ef_runtime, ids);
+}
+
+vector<SearchResult> SearchGlobalHnswIndex(
+    const search::AstKnnNode* knn, const shared_ptr<search::HnswVectorIndex>& index,
+    const std::string_view index_name,
+    const std::optional<search::KnnScoreSortOption>& knn_score_option, const SearchParams& params,
+    const CommandContext& cmd_cntx, ShardId shard_size) {
+  auto knn_results = SearchHnswWithPrefilter(knn, index, std::nullopt);
+
+  std::vector<std::vector<SerializedSearchDoc>> shard_docs(shard_size);
+  for (const auto& [score, global_doc_id] : knn_results) {
+    auto [shard_id, local_doc_id] = search::DecomposeGlobalDocId(global_doc_id);
+    SerializedSearchDoc doc;
+    doc.id = local_doc_id;
+    doc.knn_score = score;
+    shard_docs[shard_id].emplace_back(std::move(doc));
+  }
+
+  return LoadHnswSearchDocs(index_name, knn_score_option, params, cmd_cntx, std::move(shard_docs),
+                            false);
+}
+
+vector<SearchResult> SearchGlobalHnswIndex(
+    const search::AstKnnNode* knn, const shared_ptr<search::HnswVectorIndex>& index,
+    const std::string_view index_name,
+    const std::optional<search::KnnScoreSortOption>& knn_score_option,
+    const std::vector<SearchIdResult>& sharded_prefilter_docs, const SearchParams& params,
+    const CommandContext& cmd_cntx) {
+  std::vector<search::GlobalDocId> prefilter_global_docs_ids;
+  absl::flat_hash_map<search::GlobalDocId, float> text_scores;
+  const bool keep_text_scores = params.with_scores || params.scorer;
+
+  for (size_t shard_id = 0; shard_id < sharded_prefilter_docs.size(); shard_id++) {
+    const auto& shard = sharded_prefilter_docs[shard_id];
+    prefilter_global_docs_ids.reserve(prefilter_global_docs_ids.size() + shard.ids.size());
+    if (keep_text_scores)
+      text_scores.reserve(text_scores.size() + shard.text_scores.size());
+
+    for (search::DocId doc_id : shard.ids) {
+      auto global_doc_id = search::CreateGlobalDocId(shard_id, doc_id);
+      prefilter_global_docs_ids.emplace_back(global_doc_id);
+      if (keep_text_scores) {
+        if (auto it = shard.text_scores.find(doc_id); it != shard.text_scores.end())
+          text_scores[global_doc_id] = it->second;
+      }
+    }
+  }
+
+  auto knn_results =
+      SearchHnswWithPrefilter(knn, index, std::make_optional(std::move(prefilter_global_docs_ids)));
+
+  std::vector<std::vector<SerializedSearchDoc>> shard_docs(sharded_prefilter_docs.size());
+  for (const auto& [score, global_doc_id] : knn_results) {
+    auto [shard_id, local_doc_id] = search::DecomposeGlobalDocId(global_doc_id);
+    SerializedSearchDoc doc;
+    doc.id = local_doc_id;
+    doc.knn_score = score;
+    if (keep_text_scores) {
+      if (auto it = text_scores.find(global_doc_id); it != text_scores.end())
+        doc.text_score = it->second;
+    }
+    shard_docs[shard_id].emplace_back(std::move(doc));
+  }
+
+  return LoadHnswSearchDocs(index_name, knn_score_option, params, cmd_cntx, std::move(shard_docs),
+                            true);
 }
 
 // Search HNSW index for all documents within the given radius.
@@ -1442,21 +1509,7 @@ vector<SearchResult> SearchGlobalHnswIndexRange(
     shard_docs[shard_id].emplace_back(doc);
   }
 
-  bool set_sort_score =
-      params.sort_option && (!knn_score_option || !params.sort_option->IsSame(*knn_score_option));
-  bool remove_sort_field = false;
-  std::optional<std::vector<FieldReference>> return_fields = params.return_fields;
-
-  if (set_sort_score && return_fields) {
-    auto sort_field = params.sort_option->field.Name();
-    auto sort_return_field = rng::find_if(
-        *return_fields,
-        [sort_field](const FieldReference& field) { return field.Name() == sort_field; });
-    if (sort_return_field == return_fields->end()) {
-      return_fields->push_back(params.sort_option->field);
-      remove_sort_field = true;
-    }
-  }
+  auto load_options = PrepareHnswLoadOptions(params, knn_score_option);
 
   cmd_cntx.tx()->ScheduleSingleHop([&](Transaction* t, EngineShard* es) {
     auto* idx = es->search_indices()->GetIndex(index_name);
@@ -1464,15 +1517,16 @@ vector<SearchResult> SearchGlobalHnswIndexRange(
       return OpStatus::OK;
     const auto& schema = idx->base().schema;
     for (auto& shard_doc : shard_docs[es->shard_id()]) {
-      if (auto doc =
-              idx->SerializeDocWithKey(shard_doc.id, t->GetOpArgs(es), schema, return_fields);
+      if (auto doc = idx->SerializeDocWithKey(shard_doc.id, t->GetOpArgs(es), schema,
+                                              load_options.return_fields);
           doc) {
         auto& [key, fields] = *doc;
         search::SortableValue sort_score = std::monostate{};
-        if (set_sort_score) {
-          sort_score = fields[params.sort_option->field.Name()];
-          if (remove_sort_field)
-            fields.erase(params.sort_option->field.Name());
+        if (load_options.set_sort_score) {
+          if (auto it = fields.find(load_options.sort_score_field); it != fields.end())
+            sort_score = it->second;
+          if (load_options.remove_sort_field)
+            fields.erase(load_options.sort_score_field);
         }
         shard_doc.key = std::string{key};
         shard_doc.values = std::move(fields);
@@ -2853,9 +2907,18 @@ void CmdFtSearch(CmdArgList args, CommandContext* cmd_cntx) {
   }
   const bool hnsw_range_has_prefilter = hnsw_range_prefilter != nullptr;
 
+  // The KNN-prefilter flow leaves the transaction open between hops; conclude it if an exception
+  // unwinds out of the command, otherwise the scheduled global tx leaks and stalls the shards.
+  const int uncaught_on_entry = std::uncaught_exceptions();
+  absl::Cleanup conclude_on_unwind = [&] {
+    if (std::uncaught_exceptions() > uncaught_on_entry)
+      cmd_cntx->tx()->Conclude();
+  };
+
   // Because our coordinator thread may not have a shard, we can't check ahead if the index exists.
   atomic<bool> index_not_found{false};
   vector<SearchResult> docs(shard_set->size());
+  vector<SearchIdResult> knn_prefilter_docs(shard_set->size());
 
   const bool knn_has_prefilter = knn && knn->HasPreFilter();
   bool empty_prefilter_result = true;
@@ -2895,36 +2958,65 @@ void CmdFtSearch(CmdArgList args, CommandContext* cmd_cntx) {
   if ((!knn || knn_has_prefilter) && !hnsw_range) {
     auto search_cb = [&](Transaction* t, EngineShard* es) {
       if (auto* index = es->search_indices()->GetIndex(index_name); index) {
-        docs[es->shard_id()] =
-            index->Search(t->GetOpArgs(es), *params, &search_algo,
-                          knn_has_prefilter || hnsw_range_has_prefilter, global_stats_ptr);
+        if (knn_has_prefilter) {
+          knn_prefilter_docs[es->shard_id()] =
+              index->SearchIds(t->GetOpArgs(es), *params, &search_algo, global_stats_ptr);
+        } else {
+          docs[es->shard_id()] = index->Search(t->GetOpArgs(es), *params, &search_algo,
+                                               hnsw_range_has_prefilter, global_stats_ptr);
+        }
       } else {
         index_not_found.store(true, memory_order_relaxed);
       }
       return OpStatus::OK;
     };
-    if (needs_global_stats)
+    if (knn_has_prefilter) {
+      cmd_cntx->tx()->Execute(std::move(search_cb), false);
+    } else if (needs_global_stats) {
       cmd_cntx->tx()->Execute(std::move(search_cb), true);
-    else
+    } else {
       cmd_cntx->tx()->ScheduleSingleHop(std::move(search_cb));
+    }
 
-    if (index_not_found.load(memory_order_relaxed))
+    if (index_not_found.load(memory_order_relaxed)) {
+      if (knn_has_prefilter)
+        cmd_cntx->tx()->Conclude();
       return cmd_cntx->SendError(string{index_name} + ": no such index");
+    }
 
-    for (const auto& res : docs) {
-      empty_prefilter_result &= res.docs.empty();
-      if (res.error)
-        return cmd_cntx->SendError(*res.error);
+    if (knn_has_prefilter) {
+      for (const auto& res : knn_prefilter_docs) {
+        empty_prefilter_result &= res.ids.empty();
+        if (res.error) {
+          cmd_cntx->tx()->Conclude();
+          return cmd_cntx->SendError(*res.error);
+        }
+      }
+      if (empty_prefilter_result)
+        cmd_cntx->tx()->Conclude();
+    } else {
+      for (const auto& res : docs) {
+        empty_prefilter_result &= res.docs.empty();
+        if (res.error)
+          return cmd_cntx->SendError(*res.error);
+      }
     }
   }
 
   if (knn_node && (!knn_has_prefilter || !empty_prefilter_result)) {
     auto hnsw_index = GlobalHnswIndexRegistry::Instance().Get(index_name, knn->field);
     if (!hnsw_index) {
+      if (knn_has_prefilter)
+        cmd_cntx->tx()->Conclude();
       return builder->SendError(string{index_name} + ": no such global hnsw index");
     }
-    docs = SearchGlobalHnswIndex(knn, hnsw_index, index_name, search_algo.GetKnnScoreSortOption(),
-                                 docs, *params, *cmd_cntx);
+    if (knn_has_prefilter) {
+      docs = SearchGlobalHnswIndex(knn, hnsw_index, index_name, search_algo.GetKnnScoreSortOption(),
+                                   knn_prefilter_docs, *params, *cmd_cntx);
+    } else {
+      docs = SearchGlobalHnswIndex(knn, hnsw_index, index_name, search_algo.GetKnnScoreSortOption(),
+                                   *params, *cmd_cntx, shard_set->size());
+    }
   }
 
   auto knn_sort_option = search_algo.GetKnnScoreSortOption();
@@ -3020,6 +3112,59 @@ void CmdFtProfileHybrid(string_view index_name, CmdArgParser* parser, CommandCon
   }
 }
 
+void SendFtProfileSearchResponse(const SearchParams& params,
+                                 std::optional<search::KnnScoreSortOption> knn_sort_option,
+                                 std::string_view inject_score_alias,
+                                 absl::Span<SearchResult> search_results,
+                                 absl::Span<SearchResult> profile_results,
+                                 absl::Span<const absl::Duration> shard_durations,
+                                 absl::Duration took, RedisReplyBuilder* rb, bool limited) {
+  bool result_is_empty = false;
+  size_t total_docs = 0;
+  size_t total_serialized = 0;
+  for (const auto& result : search_results) {
+    if (!result.error) {
+      total_docs += result.total_hits;
+      total_serialized += result.docs.size();
+    } else {
+      result_is_empty = true;
+    }
+  }
+
+  // First element -> Result of the search command
+  // Second element -> Profile information
+  rb->StartArray(2);
+
+  // Result of the search command
+  if (!result_is_empty) {
+    SearchReply(params, knn_sort_option, inject_score_alias, search_results, rb, false);
+  } else {
+    rb->StartArray(1);
+    rb->SendLong(0);
+  }
+
+  // Profile information
+  rb->StartArray(profile_results.size() + 1);
+
+  // General stats
+  rb->StartCollection(3, CollectionType::MAP);
+  rb->SendBulkString("took");
+  rb->SendLong(absl::ToInt64Microseconds(took));
+  rb->SendBulkString("hits");
+  rb->SendLong(static_cast<long>(total_docs));
+  rb->SendBulkString("serialized");
+  rb->SendLong(static_cast<long>(total_serialized));
+
+  // Per-shard stats
+  for (size_t shard_id = 0; shard_id < profile_results.size(); shard_id++) {
+    rb->StartCollection(2, CollectionType::MAP);
+    rb->SendBulkString("took");
+    rb->SendLong(absl::ToInt64Microseconds(shard_durations[shard_id]));
+    rb->SendBulkString("tree");
+    RenderShardProfileTree(rb, profile_results[shard_id], limited);
+  }
+}
+
 void CmdFtProfile(CmdArgList args, CommandContext* cmd_cntx) {
   CmdArgParser parser{args};
 
@@ -3049,7 +3194,7 @@ void CmdFtProfile(CmdArgList args, CommandContext* cmd_cntx) {
     return;
 
   search::SearchAlgorithm search_algo;
-  if (!search_algo.Init(query_str, &params->query_params))
+  if (!search_algo.Init(query_str, &params->query_params, &params->optional_filters))
     return cmd_cntx->SendError("query syntax error");
 
   // Enable scorer: explicit SCORER param, or default BM25STD when WITHSCORES is set
@@ -3063,12 +3208,227 @@ void CmdFtProfile(CmdArgList args, CommandContext* cmd_cntx) {
   absl::Time start = absl::Now();
   const size_t shards_count = shard_set->size();
 
+  // Prefilter/range profile flows leave the transaction open between hops; conclude it if an
+  // exception unwinds out of the command so the scheduled global tx cannot leak.
+  const int uncaught_on_entry = std::uncaught_exceptions();
+  absl::Cleanup conclude_on_unwind = [&] {
+    if (std::uncaught_exceptions() > uncaught_on_entry)
+      cmd_cntx->tx()->Conclude();
+  };
+
+  auto [profile_knn_node, profile_knn] = TryPopHnswKnnNode(search_algo, index_name);
+  if (profile_knn) {
+    auto hnsw_index = GlobalHnswIndexRegistry::Instance().Get(index_name, profile_knn->field);
+    if (!hnsw_index)
+      return rb->SendError(std::string{index_name} + ": no such global hnsw index");
+
+    std::vector<SearchResult> search_results(shards_count);
+    std::vector<SearchResult> profile_search_results(shards_count);
+    std::vector<absl::Duration> profile_results(shards_count);
+
+    const bool knn_has_prefilter = profile_knn->HasPreFilter();
+    const bool needs_global_stats =
+        knn_has_prefilter && (params->scorer || params->with_scores) && shards_count > 1;
+    search::GlobalScoringStats global_scoring_stats;
+    const search::GlobalScoringStats* global_stats_ptr = nullptr;
+
+    if (needs_global_stats) {
+      if (!CollectGlobalScoringStats(index_name, search_algo, cmd_cntx->tx(), shards_count,
+                                     global_scoring_stats)) {
+        cmd_cntx->tx()->Conclude();
+        return rb->SendError(std::string{index_name} + ": no such index");
+      }
+      global_stats_ptr = &global_scoring_stats;
+    }
+
+    if (knn_has_prefilter) {
+      std::atomic<bool> index_not_found{false};
+      std::vector<SearchIdResult> knn_prefilter_docs(shards_count);
+
+      cmd_cntx->tx()->Execute(
+          [&](Transaction* t, EngineShard* es) {
+            auto* index = es->search_indices()->GetIndex(index_name);
+            if (!index) {
+              index_not_found.store(true, memory_order_relaxed);
+              return OpStatus::OK;
+            }
+
+            const ShardId shard_id = es->shard_id();
+            auto shard_start = absl::Now();
+            knn_prefilter_docs[shard_id] =
+                index->SearchIds(t->GetOpArgs(es), *params, &search_algo, global_stats_ptr);
+            profile_results[shard_id] = absl::Now() - shard_start;
+            return OpStatus::OK;
+          },
+          false);
+
+      if (index_not_found.load(memory_order_relaxed)) {
+        cmd_cntx->tx()->Conclude();
+        return rb->SendError(std::string{index_name} + ": no such index");
+      }
+
+      bool empty_prefilter_result = true;
+      for (size_t shard_id = 0; shard_id < knn_prefilter_docs.size(); shard_id++) {
+        auto& res = knn_prefilter_docs[shard_id];
+        empty_prefilter_result &= res.ids.empty();
+        if (res.error) {
+          cmd_cntx->tx()->Conclude();
+          return cmd_cntx->SendError(*res.error);
+        }
+        profile_search_results[shard_id].total_hits = res.total_hits;
+        profile_search_results[shard_id].profile = std::move(res.profile);
+      }
+
+      if (empty_prefilter_result) {
+        cmd_cntx->tx()->Conclude();
+      } else {
+        search_results = SearchGlobalHnswIndex(profile_knn, hnsw_index, index_name,
+                                               search_algo.GetKnnScoreSortOption(),
+                                               knn_prefilter_docs, *params, *cmd_cntx);
+      }
+    } else {
+      search_results = SearchGlobalHnswIndex(profile_knn, hnsw_index, index_name,
+                                             search_algo.GetKnnScoreSortOption(), *params,
+                                             *cmd_cntx, shards_count);
+      profile_search_results.clear();
+      profile_results.clear();
+    }
+
+    auto took = absl::Now() - start;
+    SendFtProfileSearchResponse(
+        *params, search_algo.GetKnnScoreSortOption(), {}, absl::MakeSpan(search_results),
+        absl::MakeSpan(profile_search_results), absl::MakeSpan(profile_results), took, rb, limited);
+    return;
+  }
+
+  const search::AstVectorRangeNode* hnsw_range = nullptr;
+  std::unique_ptr<search::AstNode> hnsw_range_holder;
+  const search::AstVectorRangeNode* hnsw_range_prefilter = nullptr;
+  auto ranges = search_algo.CollectVectorRangeNodes();
+  if (ranges.size() > 1 &&
+      std::any_of(ranges.begin(), ranges.end(), [&](const search::AstVectorRangeNode* r) {
+        return GlobalHnswIndexRegistry::Instance().Exist(index_name, r->field);
+      })) {
+    return rb->SendError(
+        "Combining multiple VECTOR_RANGE clauses with an HNSW index is not "
+        "supported");
+  }
+  if (auto* vr = search_algo.GetVectorRangeNode(); vr != nullptr) {
+    if (GlobalHnswIndexRegistry::Instance().Exist(index_name, vr->field)) {
+      if (search_algo.IsBareVectorRange()) {
+        hnsw_range = vr;
+      } else if (search_algo.IsAndedVectorRange()) {
+        hnsw_range_holder = search_algo.ExtractVectorRangeAsPrefilter();
+        hnsw_range_prefilter = &std::get<search::AstVectorRangeNode>(*hnsw_range_holder);
+      } else {
+        return rb->SendError("Combining VECTOR_RANGE with OR/NOT is not supported on HNSW indexes");
+      }
+    }
+  }
+
+  std::optional<search::KnnScoreSortOption> hnsw_range_sort_option;
+  if (hnsw_range || hnsw_range_prefilter) {
+    const auto* range_node = hnsw_range ? hnsw_range : hnsw_range_prefilter;
+    if (!range_node->score_alias.empty())
+      hnsw_range_sort_option =
+          search::KnnScoreSortOption{range_node->score_alias, std::numeric_limits<size_t>::max()};
+  }
+
+  if (hnsw_range) {
+    auto hnsw_index = GetValidatedHnswRangeIndex(index_name, hnsw_range, rb);
+    if (!hnsw_index)
+      return;
+
+    auto search_results = SearchGlobalHnswIndexRange(hnsw_range, hnsw_index, index_name,
+                                                     hnsw_range_sort_option, *params, *cmd_cntx);
+    std::vector<SearchResult> profile_search_results;
+    std::vector<absl::Duration> profile_results;
+    auto took = absl::Now() - start;
+    SendFtProfileSearchResponse(*params, hnsw_range_sort_option, {}, absl::MakeSpan(search_results),
+                                absl::MakeSpan(profile_search_results),
+                                absl::MakeSpan(profile_results), took, rb, limited);
+    return;
+  }
+
+  if (hnsw_range_prefilter) {
+    std::atomic<bool> index_not_found{false};
+    std::vector<SearchResult> prefilter_results(shards_count);
+    std::vector<absl::Duration> profile_results(shards_count);
+
+    const bool needs_global_stats = (params->scorer || params->with_scores) && shards_count > 1;
+    search::GlobalScoringStats global_scoring_stats;
+    const search::GlobalScoringStats* global_stats_ptr = nullptr;
+    if (needs_global_stats) {
+      if (!CollectGlobalScoringStats(index_name, search_algo, cmd_cntx->tx(), shards_count,
+                                     global_scoring_stats)) {
+        cmd_cntx->tx()->Conclude();
+        return rb->SendError(std::string{index_name} + ": no such index");
+      }
+      global_stats_ptr = &global_scoring_stats;
+    }
+
+    cmd_cntx->tx()->Execute(
+        [&](Transaction* t, EngineShard* es) {
+          auto* index = es->search_indices()->GetIndex(index_name);
+          if (!index) {
+            index_not_found.store(true, memory_order_relaxed);
+            return OpStatus::OK;
+          }
+          const ShardId shard_id = es->shard_id();
+          auto shard_start = absl::Now();
+          prefilter_results[shard_id] = index->Search(t->GetOpArgs(es), *params, &search_algo,
+                                                      /*is_knn_prefilter=*/true, global_stats_ptr);
+          profile_results[shard_id] = absl::Now() - shard_start;
+          return OpStatus::OK;
+        },
+        true);
+
+    if (index_not_found.load(memory_order_relaxed))
+      return rb->SendError(std::string{index_name} + ": no such index");
+
+    bool result_is_empty = true;
+    for (const auto& res : prefilter_results) {
+      result_is_empty &= res.docs.empty();
+      if (res.error)
+        return cmd_cntx->SendError(*res.error);
+    }
+
+    std::vector<SearchResult> search_results;
+    if (result_is_empty) {
+      search_results = prefilter_results;
+    } else {
+      auto hnsw_index = GetValidatedHnswRangeIndex(index_name, hnsw_range_prefilter, rb);
+      if (!hnsw_index)
+        return;
+      search_results = SearchGlobalHnswIndexRangePrefiltered(hnsw_range_prefilter, hnsw_index,
+                                                             prefilter_results);
+    }
+
+    auto took = absl::Now() - start;
+    SendFtProfileSearchResponse(*params, hnsw_range_sort_option, {}, absl::MakeSpan(search_results),
+                                absl::MakeSpan(prefilter_results), absl::MakeSpan(profile_results),
+                                took, rb, limited);
+    return;
+  }
+
   // Because our coordinator thread may not have a shard, we can't check ahead if the index exists.
   std::atomic<bool> index_not_found{false};
   std::vector<SearchResult> search_results(shards_count);
   std::vector<absl::Duration> profile_results(shards_count);
 
-  cmd_cntx->tx()->ScheduleSingleHop([&](Transaction* t, EngineShard* es) {
+  const bool needs_global_stats = (params->scorer || params->with_scores) && shards_count > 1;
+  search::GlobalScoringStats global_scoring_stats;
+  const search::GlobalScoringStats* global_stats_ptr = nullptr;
+  if (needs_global_stats) {
+    if (!CollectGlobalScoringStats(index_name, search_algo, cmd_cntx->tx(), shards_count,
+                                   global_scoring_stats)) {
+      cmd_cntx->tx()->Conclude();
+      return rb->SendError(std::string{index_name} + ": no such index");
+    }
+    global_stats_ptr = &global_scoring_stats;
+  }
+
+  auto search_cb = [&](Transaction* t, EngineShard* es) {
     auto* index = es->search_indices()->GetIndex(index_name);
     if (!index) {
       index_not_found.store(true, memory_order_relaxed);
@@ -3079,63 +3439,37 @@ void CmdFtProfile(CmdArgList args, CommandContext* cmd_cntx) {
 
     auto shard_start = absl::Now();
     search_results[shard_id] = index->Search(t->GetOpArgs(es), *params, &search_algo,
-                                             /*is_knn_prefilter=*/false,
-                                             /*global_stats=*/nullptr);
+                                             /*is_knn_prefilter=*/false, global_stats_ptr);
     profile_results[shard_id] = {absl::Now() - shard_start};
 
     return OpStatus::OK;
-  });
+  };
+  if (needs_global_stats)
+    cmd_cntx->tx()->Execute(std::move(search_cb), true);
+  else
+    cmd_cntx->tx()->ScheduleSingleHop(std::move(search_cb));
 
   if (index_not_found.load())
     return rb->SendError(std::string{index_name} + ": no such index");
 
   auto took = absl::Now() - start;
 
-  bool result_is_empty = false;
-  size_t total_docs = 0;
-  size_t total_serialized = 0;
-  for (const auto& result : search_results) {
-    if (!result.error) {
-      total_docs += result.total_hits;
-      total_serialized += result.docs.size();
-    } else {
-      result_is_empty = true;
+  auto knn_sort_option = search_algo.GetKnnScoreSortOption();
+  std::string_view inject_score_alias;
+  if (!knn_sort_option) {
+    if (auto* vr = search_algo.GetVectorRangeNode(); vr && !vr->score_alias.empty()) {
+      search::KnnScoreSortOption opt{vr->score_alias, std::numeric_limits<size_t>::max()};
+      if (params->sort_option && params->sort_option->IsSame(opt)) {
+        knn_sort_option = opt;
+      } else {
+        inject_score_alias = vr->score_alias;
+      }
     }
   }
 
-  // First element -> Result of the search command
-  // Second element -> Profile information
-  rb->StartArray(2);
-
-  // Result of the search command
-  if (!result_is_empty) {
-    auto knn_sort_option = search_algo.GetKnnScoreSortOption();
-    SearchReply(*params, knn_sort_option, {}, absl::MakeSpan(search_results), rb, false);
-  } else {
-    rb->StartArray(1);
-    rb->SendLong(0);
-  }
-
-  // Profile information
-  rb->StartArray(shards_count + 1);
-
-  // General stats
-  rb->StartCollection(3, CollectionType::MAP);
-  rb->SendBulkString("took");
-  rb->SendLong(absl::ToInt64Microseconds(took));
-  rb->SendBulkString("hits");
-  rb->SendLong(static_cast<long>(total_docs));
-  rb->SendBulkString("serialized");
-  rb->SendLong(static_cast<long>(total_serialized));
-
-  // Per-shard stats
-  for (size_t shard_id = 0; shard_id < shards_count; shard_id++) {
-    rb->StartCollection(2, CollectionType::MAP);
-    rb->SendBulkString("took");
-    rb->SendLong(absl::ToInt64Microseconds(profile_results[shard_id]));
-    rb->SendBulkString("tree");
-    RenderShardProfileTree(rb, search_results[shard_id], limited);
-  }
+  SendFtProfileSearchResponse(*params, knn_sort_option, inject_score_alias,
+                              absl::MakeSpan(search_results), absl::MakeSpan(search_results),
+                              absl::MakeSpan(profile_results), took, rb, limited);
 }
 
 void CmdFtTagVals(CmdArgList args, CommandContext* cmd_cntx) {

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -1583,6 +1583,18 @@ TEST_F(SearchFamilyTest, FtProfileInvalidQuery) {
   EXPECT_THAT(resp, ErrArg("query syntax error"));
 }
 
+TEST_F(SearchFamilyTest, FtProfileSearchFilterParam) {
+  Run({"ft.create", "i1", "schema", "title", "text", "n", "numeric"});
+
+  Run({"hset", "doc1", "title", "hello", "n", "1"});
+  Run({"hset", "doc2", "title", "hello", "n", "2"});
+  Run({"hset", "doc3", "title", "hello", "n", "3"});
+
+  auto resp = Run({"ft.profile", "i1", "search", "query", "hello", "FILTER", "n", "2", "3"});
+  ASSERT_ARRAY_OF_TWO_ARRAYS(resp);
+  EXPECT_THAT(resp.GetVec()[0], AreDocIds("doc2", "doc3"));
+}
+
 TEST_F(SearchFamilyTest, FtProfileErrorReply) {
   Run({"ft.create", "i1", "schema", "name", "text"});
 
@@ -4508,6 +4520,190 @@ TEST_F(SearchFamilyTest, KnnHnsw) {
   EXPECT_THAT(resp, kNoResults);
 }
 
+TEST_F(SearchFamilyTest, FilteredKnnHnswSearchLoadsOnlyWinners) {
+  auto resp = Run({"FT.CREATE", "knn_idx", "ON",     "HASH",    "SCHEMA",
+                   "grp",       "TAG",     "rank",   "NUMERIC", "payload",
+                   "TEXT",      "pos",     "VECTOR", "HNSW",    "6",
+                   "TYPE",      "FLOAT32", "DIM",    "1",       "DISTANCE_METRIC",
+                   "L2"});
+  EXPECT_EQ(resp, "OK");
+
+  for (int i = 0; i < 20; i++) {
+    string group = i < 15 ? "yes" : "no";
+    Run({"HSET", absl::StrCat("doc", i), "grp", group, "rank", absl::StrCat(100 - i), "payload",
+         absl::StrCat("value", i), "pos", FloatVec1(static_cast<float>(i))});
+  }
+
+  string query_vec = FloatVec1(8.0f);
+
+  resp = Run({"FT.SEARCH", "knn_idx", "@grp:{yes}=>[KNN 3 @pos $vec AS dist]", "PARAMS", "2", "vec",
+              query_vec, "NOCONTENT", "SORTBY", "dist"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  auto results = resp.GetVec();
+  ASSERT_EQ(results.size(), 4);
+  EXPECT_THAT(results[0], IntArg(3));
+  EXPECT_EQ(results[1].GetString(), "doc8");
+  vector<string> tied_docs{string{results[2].GetString()}, string{results[3].GetString()}};
+  EXPECT_THAT(tied_docs, UnorderedElementsAre("doc7", "doc9"));
+
+  resp = Run({"FT.SEARCH", "knn_idx", "@grp:{yes}=>[KNN 3 @pos $vec AS dist]", "PARAMS", "2", "vec",
+              query_vec, "RETURN", "2", "payload", "dist", "SORTBY", "dist"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  results = resp.GetVec();
+  ASSERT_EQ(results.size(), 7);
+  EXPECT_EQ(results[1].GetString(), "doc8");
+  EXPECT_EQ(map_string("payload", results[2].GetVec()), "value8");
+  EXPECT_LT(map_score("dist", results[2].GetVec()), 0.01);
+
+  resp = Run({"FT.SEARCH", "knn_idx", "@grp:{yes}=>[KNN 3 @pos $vec AS dist]", "PARAMS", "2", "vec",
+              query_vec, "RETURN", "1", "rank", "SORTBY", "rank"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  results = resp.GetVec();
+  ASSERT_EQ(results.size(), 7);
+  vector<string> sorted_docs{string{results[1].GetString()}, string{results[3].GetString()},
+                             string{results[5].GetString()}};
+  EXPECT_THAT(sorted_docs, ElementsAre("doc9", "doc8", "doc7"));
+
+  resp = Run({"FT.SEARCH", "knn_idx", "@grp:{yes}=>[KNN 3 @pos $vec AS dist]", "PARAMS", "2", "vec",
+              query_vec, "RETURN", "3", "rank", "AS", "r", "SORTBY", "rank"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  results = resp.GetVec();
+  ASSERT_EQ(results.size(), 7);
+  sorted_docs = {string{results[1].GetString()}, string{results[3].GetString()},
+                 string{results[5].GetString()}};
+  EXPECT_THAT(sorted_docs, ElementsAre("doc9", "doc8", "doc7"));
+  EXPECT_THAT(map_string("r", results[2].GetVec()), "91");
+}
+
+// A filter-matched doc that is the vector-nearest neighbor must stay a KNN candidate even when it
+// lacks the (non-sortable) SORTBY field; the pre-fix code dropped it from the candidate set.
+TEST_F(SearchFamilyTest, FilteredKnnHnswKeepsDocMissingSortField) {
+  auto resp =
+      Run({"FT.CREATE", "ms_idx", "ON", "HASH", "SCHEMA", "n", "NUMERIC", "s", "NUMERIC", "pos",
+           "VECTOR", "HNSW", "6", "TYPE", "FLOAT32", "DIM", "1", "DISTANCE_METRIC", "L2"});
+  EXPECT_EQ(resp, "OK");
+
+  for (int i = 0; i < 10; i++) {
+    if (i == 5)  // doc5 is the nearest to the query vector but deliberately has no 's'
+      Run({"HSET", "doc5", "n", "50", "pos", FloatVec1(5.0f)});
+    else
+      Run({"HSET", absl::StrCat("doc", i), "n", "50", "s", absl::StrCat(i), "pos",
+           FloatVec1(static_cast<float>(i))});
+  }
+
+  string query_vec = FloatVec1(5.0f);
+  resp = Run({"FT.SEARCH", "ms_idx", "@n:[0 100]=>[KNN 3 @pos $vec AS dist]", "PARAMS", "2", "vec",
+              query_vec, "NOCONTENT", "SORTBY", "s", "ASC"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  auto results = resp.GetVec();
+  ASSERT_EQ(results.size(), 4);
+  EXPECT_THAT(results[0], IntArg(3));
+  // The 3 vector-nearest to 5.0 are doc5 (missing 's'), doc4 and doc6 — doc5 must not be dropped.
+  vector<string> ids{string{results[1].GetString()}, string{results[2].GetString()},
+                     string{results[3].GetString()}};
+  EXPECT_THAT(ids, UnorderedElementsAre("doc4", "doc5", "doc6"));
+}
+
+// WITHSCORES on a filtered KNN must carry the prefilter BM25 text score onto the KNN winners.
+// Exercises the multi-shard global-scoring two-hop path that other KNN tests don't cover.
+TEST_F(SearchFamilyTest, FilteredKnnHnswWithScores) {
+  auto resp = Run({"FT.CREATE", "ws_idx", "ON", "HASH", "SCHEMA", "title", "TEXT", "pos", "VECTOR",
+                   "HNSW", "6", "TYPE", "FLOAT32", "DIM", "1", "DISTANCE_METRIC", "L2"});
+  EXPECT_EQ(resp, "OK");
+
+  // h2 has the highest term frequency for "hello", so it must get the highest BM25 score.
+  Run({"HSET", "h0", "title", "hello", "pos", FloatVec1(0.0f)});
+  Run({"HSET", "h1", "title", "hello world", "pos", FloatVec1(1.0f)});
+  Run({"HSET", "h2", "title", "hello hello hello", "pos", FloatVec1(2.0f)});
+  Run({"HSET", "h3", "title", "hello", "pos", FloatVec1(3.0f)});
+  Run({"HSET", "n0", "title", "goodbye", "pos", FloatVec1(2.0f)});  // does not match the filter
+
+  string query_vec = FloatVec1(2.0f);
+  resp = Run({"FT.SEARCH", "ws_idx", "@title:hello=>[KNN 3 @pos $vec]", "PARAMS", "2", "vec",
+              query_vec, "WITHSCORES", "NOCONTENT", "DIALECT", "2"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  auto results = resp.GetVec();
+  ASSERT_EQ(results.size(), 7);  // count + 3 * (id, score)
+  EXPECT_THAT(results[0], IntArg(3));
+
+  absl::flat_hash_map<string, float> scores;
+  for (size_t i = 1; i + 1 < results.size(); i += 2) {
+    float s = -1.0f;
+    ASSERT_TRUE(absl::SimpleAtof(results[i + 1].GetView(), &s));
+    scores[string{results[i].GetString()}] = s;
+  }
+  // The 3 nearest "hello" docs to pos=2.0 are h2, h1, h3; n0 is filtered out before KNN.
+  ASSERT_EQ(scores.size(), 3);
+  EXPECT_TRUE(scores.contains("h1") && scores.contains("h2") && scores.contains("h3"));
+  for (const auto& [k, s] : scores)
+    EXPECT_GT(s, 0.0f) << "score for " << k;
+  EXPECT_GT(scores["h2"], scores["h1"]);
+  EXPECT_GT(scores["h2"], scores["h3"]);
+}
+
+TEST_F(SearchFamilyTest, FtProfileSearchFilteredKnnHnsw) {
+  auto resp = Run({"FT.CREATE", "knn_idx", "ON", "HASH", "SCHEMA", "grp", "TAG", "pos", "VECTOR",
+                   "HNSW", "6", "TYPE", "FLOAT32", "DIM", "1", "DISTANCE_METRIC", "L2"});
+  EXPECT_EQ(resp, "OK");
+
+  for (int i = 0; i < 20; i++) {
+    string group = i < 15 ? "yes" : "no";
+    Run({"HSET", absl::StrCat("doc", i), "grp", group, "pos", FloatVec1(static_cast<float>(i))});
+  }
+
+  string query_vec = FloatVec1(8.0f);
+  resp = Run({"FT.PROFILE", "knn_idx", "SEARCH", "QUERY", "@grp:{yes}=>[KNN 3 @pos $vec AS dist]",
+              "NOCONTENT", "SORTBY", "dist", "PARAMS", "2", "vec", query_vec});
+  ASSERT_ARRAY_OF_TWO_ARRAYS(resp);
+
+  const auto& search_result = resp.GetVec()[0].GetVec();
+  ASSERT_EQ(search_result.size(), 4);
+  EXPECT_THAT(search_result[0], IntArg(3));
+  EXPECT_EQ(search_result[1].GetString(), "doc8");
+  vector<string> tied_docs{string{search_result[2].GetString()},
+                           string{search_result[3].GetString()}};
+  EXPECT_THAT(tied_docs, UnorderedElementsAre("doc7", "doc9"));
+
+  const auto& stats = resp.GetVec()[1].GetVec()[0].GetVec();
+  EXPECT_THAT(stats, ElementsAre("took", _, "hits", IntArg(3), "serialized", IntArg(3)));
+}
+
+TEST_F(SearchFamilyTest, FtProfileSearchHnswVectorRange) {
+  auto FloatToBytes = [](float f) { return string(reinterpret_cast<const char*>(&f), sizeof(f)); };
+
+  Run({"FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "pos", "VECTOR", "HNSW", "6", "TYPE", "FLOAT32",
+       "DIM", "1", "DISTANCE_METRIC", "L2"});
+
+  for (int i = 0; i < 10; i++)
+    Run({"HSET", absl::StrFormat("k%d", i), "pos", FloatToBytes(static_cast<float>(i))});
+
+  string query_vec = FloatToBytes(5.0f);
+  auto resp = Run({"FT.PROFILE", "idx", "SEARCH", "QUERY",
+                   "@pos:[VECTOR_RANGE 1.5 $vec]=>{$YIELD_DISTANCE_AS: dist}", "PARAMS", "2", "vec",
+                   query_vec, "LIMIT", "0", "10"});
+  ASSERT_ARRAY_OF_TWO_ARRAYS(resp);
+  EXPECT_THAT(resp.GetVec()[0], AreDocIds("k4", "k5", "k6"));
+}
+
+TEST_F(SearchFamilyTest, FtProfileSearchFlatVectorRangeDistanceAlias) {
+  CreateFlatHashIdx();
+  Run({"HSET", "d:1", "title", "a", "vec", FloatVec1(1.0f)});
+  Run({"HSET", "d:2", "title", "a", "vec", FloatVec1(1.2f)});
+  Run({"HSET", "d:3", "title", "a", "vec", FloatVec1(5.0f)});
+
+  string query_vec = FloatVec1(1.0f);
+  auto resp = Run({"FT.PROFILE", "idx", "SEARCH", "QUERY",
+                   "@vec:[VECTOR_RANGE 0.5 $vec]=>{$YIELD_DISTANCE_AS: dist}", "PARAMS", "2", "vec",
+                   query_vec, "RETURN", "1", "dist", "SORTBY", "dist"});
+  ASSERT_ARRAY_OF_TWO_ARRAYS(resp);
+
+  const auto& search_result = resp.GetVec()[0].GetVec();
+  ASSERT_EQ(search_result.size(), 5);
+  EXPECT_THAT(search_result[0], IntArg(2));
+  EXPECT_EQ(search_result[1].GetString(), "d:1");
+  EXPECT_LT(map_score("dist", search_result[2].GetVec()), 0.01);
+}
+
 TEST_F(SearchFamilyTest, KnnHnswCosineDistanceCalculation) {
   // Create index with 3D vectors using COSINE distance metric with HNSW
   auto resp = Run({"FT.CREATE", "cosine_idx", "ON", "HASH", "SCHEMA", "vec", "VECTOR", "HNSW", "6",
@@ -5137,6 +5333,16 @@ TEST_F(SearchFamilyTest, HnswVectorRange) {
   }
   EXPECT_THAT(vals_asc, ElementsAre(40, 50, 60));
 
+  resp = Run({"FT.SEARCH", "idx", "@pos:[VECTOR_RANGE 1.5 $vec]=>{$YIELD_DISTANCE_AS: dist}",
+              "PARAMS", "2", "vec", query_vec, "SORTBY", "val", "ASC", "RETURN", "3", "val", "AS",
+              "v", "LIMIT", "0", "10"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  auto& asc_alias_arr = resp.GetVec();
+  vector<int> vals_asc_alias;
+  for (size_t i = 2; i < asc_alias_arr.size(); i += 2)
+    vals_asc_alias.push_back(stoi(map_string("v", asc_alias_arr[i].GetVec())));
+  EXPECT_THAT(vals_asc_alias, ElementsAre(40, 50, 60));
+
   // SORTBY val DESC
   resp = Run({"FT.SEARCH", "idx", "@pos:[VECTOR_RANGE 1.5 $vec]=>{$YIELD_DISTANCE_AS: dist}",
               "PARAMS", "2", "vec", query_vec, "SORTBY", "val", "DESC", "RETURN", "1", "val",
@@ -5683,9 +5889,9 @@ TEST_F(SearchFamilyTest, VectorFieldWrongSizeDoesNotCrash) {
   EXPECT_THAT(resp, Not(ErrArg("")));
 }
 
-TEST_F(SearchFamilyTest, SortBySkipsDocsWithoutSortField) {
-  // KeepTopKSorted skips docs that don't have the sort field, returning fewer sort scores
-  // than result.ids.size(). The loop then accesses sort_scores[i] out-of-bounds.
+TEST_F(SearchFamilyTest, SortByKeepsDocsWithoutSortFieldLast) {
+  // Docs missing the SORTBY field are kept and ranked last, not dropped. Also guards the historical
+  // out-of-bounds crash: KeepTopKSorted must emit one sort score per kept id.
   Run({"FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "val", "NUMERIC"});
 
   Run({"HSET", "valid:1", "val", "123"});
@@ -5693,19 +5899,54 @@ TEST_F(SearchFamilyTest, SortBySkipsDocsWithoutSortField) {
   Run({"HSET", "valid:3", "val", "789"});
 
   // These docs are indexed (no prefix restriction) but lack the sort field.
-  // They appear in '*' search results but are skipped by KeepTopKSorted.
   for (int i = 0; i < 97; i++)
     Run({"HSET", absl::StrCat("nofield:", i), "txt", "garbage"});
 
-  auto resp = Run({"FT.SEARCH", "idx", "*", "SORTBY", "val", "LIMIT", "0", "100"});
+  auto resp = Run({"FT.SEARCH", "idx", "*", "NOCONTENT", "SORTBY", "val", "LIMIT", "0", "100"});
   auto vec = resp.GetVec();
 
-  // Extract doc keys from the response (indices 1, 3, 5, ...).
+  ASSERT_THAT(vec[0], IntArg(100));
   vector<string> keys;
-  for (size_t i = 1; i < vec.size(); i += 2)
-    keys.push_back(vec[i].GetString());
+  for (size_t i = 1; i < vec.size(); i++)
+    keys.push_back(string{vec[i].GetString()});
+  ASSERT_EQ(keys.size(), 100u);
 
-  EXPECT_THAT(keys, ElementsAre("valid:1", "valid:2", "valid:3"));
+  // Docs with the field sort first by value; the 97 field-less docs follow (in any order).
+  EXPECT_THAT((vector<string>{keys[0], keys[1], keys[2]}),
+              ElementsAre("valid:1", "valid:2", "valid:3"));
+  size_t nofield = 0;
+  for (const auto& k : keys)
+    nofield += (k.rfind("nofield:", 0) == 0);
+  EXPECT_EQ(nofield, 97u);
+}
+
+TEST_F(SearchFamilyTest, SortByNonSortableFieldNullsLast) {
+  // Missing-field docs rank last in both directions and never steal a top-K slot.
+  Run({"FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "n", "NUMERIC", "s", "NUMERIC"});
+  for (int i = 0; i < 5; i++) {
+    if (i == 2)
+      Run({"HSET", "d2", "n", "50"});  // deliberately lacks 's'
+    else
+      Run({"HSET", absl::StrCat("d", i), "n", "50", "s", absl::StrCat(i)});
+  }
+
+  auto ids = [](const RespExpr& r) {
+    vector<string> v;
+    for (size_t i = 1; i < r.GetVec().size(); i++)
+      v.push_back(string{r.GetVec()[i].GetString()});
+    return v;
+  };
+
+  EXPECT_THAT(ids(Run({"FT.SEARCH", "idx", "@n:[0 100]", "NOCONTENT", "SORTBY", "s", "ASC", "LIMIT",
+                       "0", "10"})),
+              ElementsAre("d0", "d1", "d3", "d4", "d2"));
+  EXPECT_THAT(ids(Run({"FT.SEARCH", "idx", "@n:[0 100]", "NOCONTENT", "SORTBY", "s", "DESC",
+                       "LIMIT", "0", "10"})),
+              ElementsAre("d4", "d3", "d1", "d0", "d2"));
+  // The field-less doc must not occupy a top-2 slot.
+  EXPECT_THAT(ids(Run({"FT.SEARCH", "idx", "@n:[0 100]", "NOCONTENT", "SORTBY", "s", "ASC", "LIMIT",
+                       "0", "2"})),
+              ElementsAre("d0", "d1"));
 }
 
 TEST_F(SearchFamilyTest, NumericIndexRejectsNonFiniteValues) {


### PR DESCRIPTION
Filtered KNN queries (`(@filter)=>[KNN k @v $q]`) previously serialized **every** filter-matched document on each shard before running the global HNSW search, so a wide filter (e.g. matching ~50% of the index) paid a huge serialization cost to return only `k` results. This now fetches only matched **ids** for the prefilter, runs KNN, and serializes **only the `k` winners**. Also adds `FT.PROFILE` support for HNSW queries, hardens the new multi-hop transaction flow, and fixes a `SORTBY` result-drop bug found while verifying the change.

Fixes #7632.

Wide filtered KNN (the perf fix):
- New `ShardDocIndex::SearchIds()` / `SearchIdResult`: the prefilter pass returns matched doc ids (+ text scores when scoring) instead of fully serialized docs.
- `FT.SEARCH` KNN-prefilter is now two hops: collect ids -> global HNSW KNN on the coordinator → serialize only the winners (`LoadHnswSearchDocs`, gated by a `finalize` flag; `NOCONTENT` uses a key-index fast path that skips doc loads).
- `SearchHnswWithPrefilter()` sorts the allow-list before the membership-checked `Knn(..., allowed)` path.
- `PrepareHnswLoadOptions()` resolves the sort field through `RETURN ... AS` aliases.

FT.PROFILE for HNSW:
- Adds dedicated branches for KNN prefilter, bare `VECTOR_RANGE`, range prefilter, and FLAT range alias, via a shared `SendFtProfileSearchResponse` helper.

Transaction safety:
- The KNN-prefilter / range-prefilter flows leave the transaction open between hops. Added an `absl::Cleanup` guard in `CmdFtSearch`/`CmdFtProfile` that concludes the transaction if an exception unwinds out of the command (e.g. `bad_alloc` inside the global KNN), preventing a leaked scheduled global tx from stalling the shards. `Conclude()` is idempotent, so normal paths are unaffected.

SORTBY on a missing non-sortable field:
- A `SORTBY` on a non-`SORTABLE` field used to **drop** docs that lack the field from the result while still counting them in `total` (`count` disagreed with the returned rows). Such docs are now kept and ranked **last** in both directions, and never occupy a top-K slot - consistent with the reference engine behavior.
- `KeepTopKSorted` keeps missing values (as null) with null-last selection;
  `PartialSortBySortScore` orders the global merge null-last.

Tests:
- `FilteredKnnHnswWithScores` — `WITHSCORES` on filtered KNN (multi-shard scoring path).
- `FilteredKnnHnswKeepsDocMissingSortField` — field-less nearest doc stays a KNN candidate.
- `SortByKeepsDocsWithoutSortFieldLast` — replaces the old drop-asserting crash test; still guards the original out-of-bounds crash.
- `SortByNonSortableFieldNullsLast` — null-last ordering (ASC/DESC) + top-K exclusion.
