### PR TITLE
fix: SetCMS/SetSBF/SetTOPK/SetCuckooFilter orphan and leak on bad_alloc   

### DIFF
--- a/src/core/bloom.cc
+++ b/src/core/bloom.cc
@@ -165,6 +165,9 @@ inline bool Bloom::Set(size_t bit_idx) {
 ///////////////////////////////////////////////////////////////////////////////
 void SBF::Init(uint64_t initial_capacity, double fp_prob, double grow_factor,
                PMR_NS::memory_resource* mr) {
+  // Called exactly once, right after construction: no previous filters to free.
+  DCHECK(filters_.empty());
+
   double new_fp_prob = fp_prob * kSBFErrorFactor;
 
   // Reserve storage for the new filter before initializing it. Bloom::~Bloom() CHECKs that
@@ -172,17 +175,13 @@ void SBF::Init(uint64_t initial_capacity, double fp_prob, double grow_factor,
   // filters_ — otherwise unwinding would destroy a Bloom that still owns its bit array and
   // abort instead of cleanly propagating bad_alloc. Reserving first guarantees the push_back
   // below cannot reallocate (and Bloom's move ctor is noexcept).
-  decltype(filters_) new_filters(filters_.get_allocator());
-  new_filters.reserve(1);
+  filters_.reserve(1);
 
   Bloom b;
   b.Init(initial_capacity, new_fp_prob, mr);
-  new_filters.push_back(std::move(b));
+  filters_.push_back(std::move(b));
 
   // Nothing below can throw.
-  for (auto& f : filters_)
-    f.Destroy(mr);
-  filters_.swap(new_filters);
   grow_factor_ = grow_factor;
   fp_prob_ = new_fp_prob;
   max_capacity_ = filters_.front().Capacity(fp_prob_);

--- a/src/core/bloom.cc
+++ b/src/core/bloom.cc
@@ -165,17 +165,24 @@ inline bool Bloom::Set(size_t bit_idx) {
 ///////////////////////////////////////////////////////////////////////////////
 void SBF::Init(uint64_t initial_capacity, double fp_prob, double grow_factor,
                PMR_NS::memory_resource* mr) {
-  // Build and initialize the new filter before touching any existing state: if Bloom::Init
-  // throws, *this is left completely unchanged.
   double new_fp_prob = fp_prob * kSBFErrorFactor;
+
+  // Reserve storage for the new filter before initializing it. Bloom::~Bloom() CHECKs that
+  // bf_ is null, so once b.Init() below succeeds, b must never throw on its way into
+  // filters_ — otherwise unwinding would destroy a Bloom that still owns its bit array and
+  // abort instead of cleanly propagating bad_alloc. Reserving first guarantees the push_back
+  // below cannot reallocate (and Bloom's move ctor is noexcept).
+  decltype(filters_) new_filters(filters_.get_allocator());
+  new_filters.reserve(1);
+
   Bloom b;
   b.Init(initial_capacity, new_fp_prob, mr);
+  new_filters.push_back(std::move(b));
 
   // Nothing below can throw.
   for (auto& f : filters_)
     f.Destroy(mr);
-  filters_.clear();
-  filters_.push_back(std::move(b));
+  filters_.swap(new_filters);
   grow_factor_ = grow_factor;
   fp_prob_ = new_fp_prob;
   max_capacity_ = filters_.front().Capacity(fp_prob_);

--- a/src/core/bloom.cc
+++ b/src/core/bloom.cc
@@ -163,10 +163,24 @@ inline bool Bloom::Set(size_t bit_idx) {
 ///////////////////////////////////////////////////////////////////////////////
 // SBF implementation
 ///////////////////////////////////////////////////////////////////////////////
-SBF::SBF(uint64_t initial_capacity, double fp_prob, double grow_factor, PMR_NS::memory_resource* mr)
-    : filters_(1, mr), grow_factor_(grow_factor), fp_prob_(fp_prob * kSBFErrorFactor) {
-  filters_.front().Init(initial_capacity, fp_prob_, mr);
+void SBF::Init(uint64_t initial_capacity, double fp_prob, double grow_factor,
+               PMR_NS::memory_resource* mr) {
+  // Build and initialize the new filter before touching any existing state: if Bloom::Init
+  // throws, *this is left completely unchanged.
+  double new_fp_prob = fp_prob * kSBFErrorFactor;
+  Bloom b;
+  b.Init(initial_capacity, new_fp_prob, mr);
+
+  // Nothing below can throw.
+  for (auto& f : filters_)
+    f.Destroy(mr);
+  filters_.clear();
+  filters_.push_back(std::move(b));
+  grow_factor_ = grow_factor;
+  fp_prob_ = new_fp_prob;
   max_capacity_ = filters_.front().Capacity(fp_prob_);
+  prev_size_ = 0;
+  current_size_ = 0;
 }
 
 SBF::SBF(double grow_factor, double fp_prob, size_t max_capacity, size_t prev_size,
@@ -183,6 +197,15 @@ SBF::~SBF() {
   PMR_NS::memory_resource* mr = filters_.get_allocator().resource();
   for (auto& f : filters_)
     f.Destroy(mr);
+}
+
+SBF::SBF(SBF&& src) noexcept
+    : filters_(std::move(src.filters_)),
+      grow_factor_(src.grow_factor_),
+      fp_prob_(src.fp_prob_),
+      prev_size_(src.prev_size_),
+      current_size_(src.current_size_),
+      max_capacity_(src.max_capacity_) {
 }
 
 SBF& SBF::operator=(SBF&& src) noexcept {

--- a/src/core/bloom.h
+++ b/src/core/bloom.h
@@ -116,8 +116,8 @@ class SBF {
   SBF(SBF&& src) noexcept;
   SBF& operator=(SBF&& src) noexcept;
 
-  // (Re)initializes this SBF, discarding any previous filters. May throw std::bad_alloc; on
-  // failure this object is left unchanged.
+  // Initializes this SBF. Must be called exactly once, right after construction, on an
+  // otherwise-empty SBF. May throw std::bad_alloc; on failure this object is left unchanged.
   void Init(uint64_t initial_capacity, double fp_prob, double grow_factor,
             PMR_NS::memory_resource* mr);
 

--- a/src/core/bloom.h
+++ b/src/core/bloom.h
@@ -100,16 +100,26 @@ class Bloom {
  */
 class SBF {
  public:
-  SBF(uint64_t initial_capacity, double fp_prob, double grow_factor, PMR_NS::memory_resource* mr);
+  // Constructs an empty, uninitialized SBF bound to mr. Never allocates, never throws.
+  // Call Init() before use.
+  explicit SBF(PMR_NS::memory_resource* mr) : filters_(mr) {
+  }
+
   SBF(const SBF&) = delete;
 
-  // C'tor used for loading persisted filters into SBF.
+  // C'tor used for loading persisted filters into SBF. Never allocates, never throws.
   // Should be followed by AllocateFilter.
   SBF(double grow_factor, double fp_prob, size_t max_capacity, size_t prev_size,
       size_t current_size, PMR_NS::memory_resource* mr);
   ~SBF();
 
+  SBF(SBF&& src) noexcept;
   SBF& operator=(SBF&& src) noexcept;
+
+  // (Re)initializes this SBF, discarding any previous filters. May throw std::bad_alloc; on
+  // failure this object is left unchanged.
+  void Init(uint64_t initial_capacity, double fp_prob, double grow_factor,
+            PMR_NS::memory_resource* mr);
 
   uint8_t* AllocateFilter(size_t alloc_size, unsigned hash_cnt);
 
@@ -178,11 +188,11 @@ class SBF {
  private:
   // multiple filters from the smallest to the largest.
   std::vector<Bloom, PMR_NS::polymorphic_allocator<Bloom>> filters_;
-  double grow_factor_;
-  double fp_prob_;
+  double grow_factor_ = 0;
+  double fp_prob_ = 0;
   size_t prev_size_ = 0;
   size_t current_size_ = 0;
-  size_t max_capacity_;
+  size_t max_capacity_ = 0;
 };
 
 // Pair of values returned to a client.

--- a/src/core/bloom_test.cc
+++ b/src/core/bloom_test.cc
@@ -16,6 +16,15 @@ namespace dfly {
 
 using namespace std;
 
+namespace {
+SBF MakeSBF(uint64_t initial_capacity, double fp_prob, double grow_factor,
+            PMR_NS::memory_resource* mr) {
+  SBF sbf(mr);
+  sbf.Init(initial_capacity, fp_prob, grow_factor, mr);
+  return sbf;
+}
+}  // namespace
+
 class BloomTest : public ::testing::Test {
  protected:
   BloomTest() {
@@ -76,7 +85,7 @@ TEST_F(BloomTest, Extreme) {
 }
 
 TEST_F(BloomTest, SBF) {
-  SBF sbf(10, 0.001, 2, PMR_NS::get_default_resource());
+  SBF sbf = MakeSBF(10, 0.001, 2, PMR_NS::get_default_resource());
 
   unsigned collisions = 0;
   constexpr unsigned kNumElems = 2000000;
@@ -93,7 +102,7 @@ TEST_F(BloomTest, SBF) {
 
 TEST_F(BloomTest, DumpAndLoadRoundTrip) {
   auto* mr = PMR_NS::get_default_resource();
-  SBF src(10, 0.001, 2, mr);
+  SBF src = MakeSBF(10, 0.001, 2, mr);
 
   constexpr unsigned kNumElems = 200;
   for (unsigned i = 0; i < kNumElems; ++i)
@@ -139,7 +148,7 @@ TEST_F(BloomTest, DumpAndLoadRoundTrip) {
 }
 
 TEST_F(BloomTest, DumpPastEndCursorReturnsEof) {
-  SBF sbf(10, 0.001, 2, PMR_NS::get_default_resource());
+  SBF sbf = MakeSBF(10, 0.001, 2, PMR_NS::get_default_resource());
   SBFDumpIterator it(sbf, 999999);
   auto [cursor, data] = it.Next();
   EXPECT_EQ(cursor, 0);
@@ -148,7 +157,7 @@ TEST_F(BloomTest, DumpPastEndCursorReturnsEof) {
 
 TEST_F(BloomTest, DumpWithGrowthDuringIteration) {
   auto* mr = PMR_NS::get_default_resource();
-  SBF sbf(10, 0.001, 2, mr);
+  SBF sbf = MakeSBF(10, 0.001, 2, mr);
 
   constexpr unsigned initial = 100;
   for (unsigned i = 0; i < initial; ++i)

--- a/src/core/cms.cc
+++ b/src/core/cms.cc
@@ -27,11 +27,21 @@ uint32_t Offset(uint64_t h1, uint64_t h2, uint32_t row, uint32_t width) {
 
 }  // namespace
 
-CMS::CMS(uint32_t width, uint32_t depth, PMR_NS::memory_resource* mr)
-    : width_(width), depth_(depth), mr_(mr) {
-  size_t len = NumCounters();
-  counters_ = static_cast<int64_t*>(mr_->allocate(AllocationSize(len), alignof(int64_t)));
-  std::fill_n(counters_, len, 0);
+void CMS::Init(uint32_t width, uint32_t depth) {
+  size_t len = static_cast<size_t>(width) * depth;
+  // Allocate the new buffer before touching any existing state: if this throws,
+  // *this is left completely unchanged.
+  int64_t* new_counters =
+      static_cast<int64_t*>(mr_->allocate(AllocationSize(len), alignof(int64_t)));
+  std::fill_n(new_counters, len, 0);
+
+  if (counters_) {
+    mr_->deallocate(counters_, AllocationSize(NumCounters()), alignof(int64_t));
+  }
+  width_ = width;
+  depth_ = depth;
+  counters_ = new_counters;
+  count_ = 0;
 }
 
 CMS::~CMS() {
@@ -70,9 +80,9 @@ CMS& CMS::operator=(CMS&& other) noexcept {
   return *this;
 }
 
-CMS::CMS(ErrorRateTag /*tag*/, double error, double probability, PMR_NS::memory_resource* mr)
-    : CMS(static_cast<uint32_t>(std::ceil(M_E / error)),
-          static_cast<uint32_t>(std::ceil(std::log(1.0 / probability))), mr) {
+void CMS::Init(ErrorRateTag, double error, double probability) {
+  Init(static_cast<uint32_t>(std::ceil(M_E / error)),
+       static_cast<uint32_t>(std::ceil(std::log(1.0 / probability))));
 }
 
 int64_t CMS::IncrBy(std::string_view item, int64_t increment) {

--- a/src/core/cms.cc
+++ b/src/core/cms.cc
@@ -28,6 +28,9 @@ uint32_t Offset(uint64_t h1, uint64_t h2, uint32_t row, uint32_t width) {
 }  // namespace
 
 void CMS::Init(uint32_t width, uint32_t depth) {
+  // Called exactly once, right after construction: no previous counters to free.
+  DCHECK(counters_ == nullptr);
+
   size_t len = static_cast<size_t>(width) * depth;
   // Allocate the new buffer before touching any existing state: if this throws,
   // *this is left completely unchanged.
@@ -35,9 +38,6 @@ void CMS::Init(uint32_t width, uint32_t depth) {
       static_cast<int64_t*>(mr_->allocate(AllocationSize(len), alignof(int64_t)));
   std::fill_n(new_counters, len, 0);
 
-  if (counters_) {
-    mr_->deallocate(counters_, AllocationSize(NumCounters()), alignof(int64_t));
-  }
   width_ = width;
   depth_ = depth;
   counters_ = new_counters;

--- a/src/core/cms.h
+++ b/src/core/cms.h
@@ -14,10 +14,10 @@ namespace dfly {
 /// Count-Min Sketch implementation compatible with Redis CMS commands.
 class CMS {
  public:
-  // Create a CMS with given width and depth dimensions.
-  // width: number of counters per row
-  // depth: number of rows (hash functions)
-  CMS(uint32_t width, uint32_t depth, PMR_NS::memory_resource* mr);
+  // Constructs an empty, uninitialized CMS bound to mr. This is the only constructor;
+  // it never allocates and never throws. Call Init() before use.
+  explicit CMS(PMR_NS::memory_resource* mr) : mr_(mr) {
+  }
 
   CMS(const CMS&) = delete;
   CMS& operator=(const CMS&) = delete;
@@ -27,14 +27,19 @@ class CMS {
 
   ~CMS();
 
+  // (Re)initializes this CMS with the given dimensions. May throw std::bad_alloc; on failure
+  // this object is left unchanged (the old counters, if any, are preserved).
+  void Init(uint32_t width, uint32_t depth);
+
   // Tag type to disambiguate CMS construction by error rate and probability.
   struct ErrorRateTag {};
 
-  // Create a CMS from error rate and probability parameters.
+  // Computes width/depth from error rate and probability and calls Init(). May throw
+  // std::bad_alloc.
   // error: relative error (e.g. 0.01 for 1%), must be in (0, 1).
   // probability: probability of exceeding the error, must be in (0, 1).
   // width = ceil(e / error), depth = ceil(ln(1 / probability)).
-  CMS(ErrorRateTag, double error, double probability, PMR_NS::memory_resource* mr);
+  void Init(ErrorRateTag, double error, double probability);
 
   // Increment the count for an item by the given value.
   // Returns the new estimated count for the item.
@@ -82,8 +87,8 @@ class CMS {
   }
 
  private:
-  uint32_t width_;
-  uint32_t depth_;
+  uint32_t width_ = 0;
+  uint32_t depth_ = 0;
   PMR_NS::memory_resource* mr_ = nullptr;
   int64_t count_ = 0;  // Total count of all IncrBy operations
   int64_t* counters_ = nullptr;

--- a/src/core/cms.h
+++ b/src/core/cms.h
@@ -27,8 +27,9 @@ class CMS {
 
   ~CMS();
 
-  // (Re)initializes this CMS with the given dimensions. May throw std::bad_alloc; on failure
-  // this object is left unchanged (the old counters, if any, are preserved).
+  // Initializes this CMS with the given dimensions. Must be called exactly once, right after
+  // construction, on an otherwise-empty CMS. May throw std::bad_alloc; on failure this object
+  // is left unchanged.
   void Init(uint32_t width, uint32_t depth);
 
   // Tag type to disambiguate CMS construction by error rate and probability.

--- a/src/core/cms_test.cc
+++ b/src/core/cms_test.cc
@@ -14,9 +14,23 @@ namespace dfly {
 
 using namespace std;
 
+namespace {
+CMS MakeCMS(uint32_t width, uint32_t depth, PMR_NS::memory_resource* mr) {
+  CMS cms(mr);
+  cms.Init(width, depth);
+  return cms;
+}
+
+CMS MakeCMS(CMS::ErrorRateTag tag, double error, double probability, PMR_NS::memory_resource* mr) {
+  CMS cms(mr);
+  cms.Init(tag, error, probability);
+  return cms;
+}
+}  // namespace
+
 class CMSTest : public ::testing::Test {
  protected:
-  CMSTest() : cms_(CMS(1000, 5, PMR_NS::get_default_resource())) {
+  CMSTest() : cms_(MakeCMS(1000, 5, PMR_NS::get_default_resource())) {
   }
 
   CMS cms_;
@@ -32,13 +46,13 @@ TEST_F(CMSTest, InitialCountIsZero) {
 // Use width=1 so every item maps to column 0, exercising all counters.
 // This catches initialization bugs (e.g. counters not zeroed).
 TEST(CMSBasic, InitialCountIsZeroSmall) {
-  CMS cms(1, 1, PMR_NS::get_default_resource());
+  CMS cms = MakeCMS(1, 1, PMR_NS::get_default_resource());
   EXPECT_EQ(cms.Query("x"), 0);
   EXPECT_EQ(cms.Query("y"), 0);
 }
 
 TEST(CMSBasic, IncrBySmall) {
-  CMS cms(1, 1, PMR_NS::get_default_resource());
+  CMS cms = MakeCMS(1, 1, PMR_NS::get_default_resource());
   EXPECT_EQ(cms.IncrBy("a", 3), 3);
   // width=1 means all items collide; "b" should also return 3.
   EXPECT_EQ(cms.Query("b"), 3);
@@ -46,7 +60,7 @@ TEST(CMSBasic, IncrBySmall) {
 
 // Inspired by fakeredis test_cms_create: initbyprob computes correct dimensions.
 TEST(CMSBasic, InitByProb) {
-  CMS cms(CMS::ErrorRateTag{}, 0.01, 0.01, PMR_NS::get_default_resource());
+  CMS cms = MakeCMS(CMS::ErrorRateTag{}, 0.01, 0.01, PMR_NS::get_default_resource());
 
   // width = ceil(e / 0.01) = ceil(271.8..) = 272
   EXPECT_EQ(cms.width(), static_cast<uint32_t>(std::ceil(M_E / 0.01)));
@@ -114,7 +128,7 @@ TEST_F(CMSTest, MallocUsed) {
 
 // Inspired by fakeredis test_cms_merge: basic merge of two sketches.
 TEST_F(CMSTest, MergeFrom) {
-  CMS other(1000, 5, PMR_NS::get_default_resource());
+  CMS other = MakeCMS(1000, 5, PMR_NS::get_default_resource());
   cms_.IncrBy("foo", 3);
   other.IncrBy("foo", 4);
   other.IncrBy("bar", 1);
@@ -125,7 +139,7 @@ TEST_F(CMSTest, MergeFrom) {
 }
 
 TEST_F(CMSTest, MergeFromWithWeight) {
-  CMS other(1000, 5, PMR_NS::get_default_resource());
+  CMS other = MakeCMS(1000, 5, PMR_NS::get_default_resource());
   other.IncrBy("x", 5);
 
   cms_.IncrBy("x", 10);
@@ -135,10 +149,10 @@ TEST_F(CMSTest, MergeFromWithWeight) {
 }
 
 TEST_F(CMSTest, MergeDimensionMismatch) {
-  CMS other(500, 5, PMR_NS::get_default_resource());
+  CMS other = MakeCMS(500, 5, PMR_NS::get_default_resource());
   EXPECT_FALSE(cms_.MergeFrom(other));
 
-  CMS other2(1000, 3, PMR_NS::get_default_resource());
+  CMS other2 = MakeCMS(1000, 3, PMR_NS::get_default_resource());
   EXPECT_FALSE(cms_.MergeFrom(other2));
 }
 
@@ -146,9 +160,9 @@ TEST_F(CMSTest, MergeDimensionMismatch) {
 // Mirrors the exact sequence: C=A+B, C+=A*1+B*2, C+=A*2+B*3, then check info.count.
 TEST(CMSBasic, MergeMultipleWithWeights) {
   auto* mr = PMR_NS::get_default_resource();
-  CMS a(1000, 5, mr);
-  CMS b(1000, 5, mr);
-  CMS c(1000, 5, mr);
+  CMS a = MakeCMS(1000, 5, mr);
+  CMS b = MakeCMS(1000, 5, mr);
+  CMS c = MakeCMS(1000, 5, mr);
 
   a.IncrBy("foo", 5);
   a.IncrBy("bar", 3);
@@ -190,7 +204,7 @@ TEST(CMSBasic, MergeMultipleWithWeights) {
 // Inspired by fakeredis test_cms_info: verify count tracks total of all IncrBy operations.
 TEST(CMSBasic, CountTracking) {
   auto* mr = PMR_NS::get_default_resource();
-  CMS a(1000, 5, mr);
+  CMS a = MakeCMS(1000, 5, mr);
 
   EXPECT_EQ(a.total_count(), 0);
 
@@ -204,9 +218,9 @@ TEST(CMSBasic, CountTracking) {
 // Inspired by fakeredis test_cms_info: count is updated by MergeFrom.
 TEST(CMSBasic, CountAfterMerge) {
   auto* mr = PMR_NS::get_default_resource();
-  CMS a(1000, 5, mr);
-  CMS b(1000, 5, mr);
-  CMS c(1000, 5, mr);
+  CMS a = MakeCMS(1000, 5, mr);
+  CMS b = MakeCMS(1000, 5, mr);
+  CMS c = MakeCMS(1000, 5, mr);
 
   a.IncrBy("foo", 5);
   a.IncrBy("bar", 3);
@@ -241,7 +255,7 @@ TEST_F(CMSTest, MoveConstruct) {
 
 TEST_F(CMSTest, MoveAssign) {
   cms_.IncrBy("foo", 42);
-  CMS other(500, 3, PMR_NS::get_default_resource());
+  CMS other = MakeCMS(500, 3, PMR_NS::get_default_resource());
   other = std::move(cms_);
 
   EXPECT_EQ(other.Query("foo"), 42);

--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -20,6 +20,7 @@ extern "C" {
 #include "redis/util.h"
 #include "redis/zmalloc.h"  // for non-string objects.
 }
+#include <absl/cleanup/cleanup.h>
 #include <absl/container/flat_hash_map.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/strip.h>
@@ -1109,12 +1110,19 @@ void CompactObj::SetJson(const uint8_t* buf, size_t len) {
 }
 
 void CompactObj::SetSBF(uint64_t initial_capacity, double fp_prob, double grow_factor) {
-  if (taglen_ != SBF_TAG) {
-    SetMeta(SBF_TAG);
-    u_.sbf = AllocateMR<SBF>(tl.local_mr);  // trivial ctor, never throws
-  }
-  // may throw; u_.sbf is already safely owned either way
-  u_.sbf->Init(initial_capacity, fp_prob, grow_factor, tl.local_mr);
+  // Build and initialize the SBF before committing the tag: if Init() throws, *this must
+  // stay untouched rather than publish a tagged-but-uninitialized SBF that later accesses
+  // (Insert/Exists on the same key) would find in a broken state and crash on (DCHECKs and
+  // raw-pointer derefs in Bloom/CMS/TOPK/CuckooFilter all assume Init() has already run).
+  // absl::Cleanup stores the callback inline (placement-new into its own char buffer), so
+  // this costs no heap allocation -- same as a hand-rolled try/catch, just RAII instead.
+  SBF* sbf = AllocateMR<SBF>(tl.local_mr);  // trivial ctor, never throws
+  absl::Cleanup cleanup = [sbf] { DeleteMR<SBF>(sbf); };
+  sbf->Init(initial_capacity, fp_prob, grow_factor, tl.local_mr);  // may throw
+  std::move(cleanup).Cancel();
+
+  SetMeta(SBF_TAG);
+  u_.sbf = sbf;
 }
 
 SBF* CompactObj::GetSBF() const {
@@ -1123,11 +1131,15 @@ SBF* CompactObj::GetSBF() const {
 }
 
 void CompactObj::SetCMS(uint32_t width, uint32_t depth) {
-  if (taglen_ != CMS_TAG) {
-    SetMeta(CMS_TAG);
-    u_.cms = AllocateMR<CMS>(tl.local_mr);  // trivial ctor, never throws
-  }
-  u_.cms->Init(width, depth);  // may throw; u_.cms is already safely owned either way
+  // Build and initialize the CMS before committing the tag: if Init() throws, *this must
+  // stay untouched rather than publish a tagged-but-uninitialized CMS.
+  CMS* cms = AllocateMR<CMS>(tl.local_mr);  // trivial ctor, never throws
+  absl::Cleanup cleanup = [cms] { DeleteMR<CMS>(cms); };
+  cms->Init(width, depth);  // may throw
+  std::move(cleanup).Cancel();
+
+  SetMeta(CMS_TAG);
+  u_.cms = cms;
 }
 
 CMS* CompactObj::GetCMS() const {
@@ -1136,11 +1148,15 @@ CMS* CompactObj::GetCMS() const {
 }
 
 void CompactObj::SetTOPK(uint32_t k, uint32_t width, uint32_t depth, double decay) {
-  if (taglen_ != TOPK_TAG) {
-    SetMeta(TOPK_TAG);
-    u_.topk = AllocateMR<TOPK>(memory_resource());  // trivial ctor, never throws
-  }
-  u_.topk->Init(k, width, depth, decay);  // may throw; u_.topk is already safely owned either way
+  // Build and initialize the TOPK before committing the tag: if Init() throws, *this must
+  // stay untouched rather than publish a tagged-but-uninitialized TOPK.
+  TOPK* topk = AllocateMR<TOPK>(memory_resource());  // trivial ctor, never throws
+  absl::Cleanup cleanup = [topk] { DeleteMR<TOPK>(topk); };
+  topk->Init(k, width, depth, decay);  // may throw
+  std::move(cleanup).Cancel();
+
+  SetMeta(TOPK_TAG);
+  u_.topk = topk;
 }
 
 TOPK* CompactObj::GetTOPK() const {
@@ -1149,12 +1165,16 @@ TOPK* CompactObj::GetTOPK() const {
 }
 
 void CompactObj::SetCuckooFilter(const CuckooFilterOptions& options) {
-  if (taglen_ != CUCKOO_FILTER_TAG) {
-    SetMeta(CUCKOO_FILTER_TAG);
-    u_.cuckoo_filter = AllocateMR<CuckooFilter>(tl.local_mr);  // trivial ctor, never throws
-  }
-  // may throw; u_.cuckoo_filter is already safely owned either way
-  u_.cuckoo_filter->Init(options);
+  // Build and initialize the CuckooFilter before committing the tag: if Init() throws,
+  // *this must stay untouched rather than publish a tagged-but-uninitialized filter that
+  // later Insert()/Exists() calls on the same key would find in a broken (empty) state.
+  CuckooFilter* cf = AllocateMR<CuckooFilter>(tl.local_mr);  // trivial ctor, never throws
+  absl::Cleanup cleanup = [cf] { DeleteMR<CuckooFilter>(cf); };
+  cf->Init(options);  // may throw
+  std::move(cleanup).Cancel();
+
+  SetMeta(CUCKOO_FILTER_TAG);
+  u_.cuckoo_filter = cf;
 }
 
 CuckooFilter* CompactObj::GetCuckooFilter() const {

--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -1109,11 +1109,12 @@ void CompactObj::SetJson(const uint8_t* buf, size_t len) {
 }
 
 void CompactObj::SetSBF(uint64_t initial_capacity, double fp_prob, double grow_factor) {
-  if (taglen_ == SBF_TAG) {  // already json
+  if (taglen_ == SBF_TAG) {
     *u_.sbf = SBF(initial_capacity, fp_prob, grow_factor, tl.local_mr);
   } else {
+    SBF* sbf = AllocateMR<SBF>(initial_capacity, fp_prob, grow_factor, tl.local_mr);
     SetMeta(SBF_TAG);
-    u_.sbf = AllocateMR<SBF>(initial_capacity, fp_prob, grow_factor, tl.local_mr);
+    u_.sbf = sbf;
   }
 }
 
@@ -1126,8 +1127,9 @@ void CompactObj::SetCMS(uint32_t width, uint32_t depth) {
   if (taglen_ == CMS_TAG) {
     *u_.cms = CMS(width, depth, tl.local_mr);
   } else {
+    CMS* cms = AllocateMR<CMS>(width, depth, tl.local_mr);  // may throw; CompactObj unchanged
     SetMeta(CMS_TAG);
-    u_.cms = AllocateMR<CMS>(width, depth, tl.local_mr);
+    u_.cms = cms;
   }
 }
 
@@ -1140,8 +1142,9 @@ void CompactObj::SetTOPK(uint32_t k, uint32_t width, uint32_t depth, double deca
   if (taglen_ == TOPK_TAG) {
     *u_.topk = TOPK(memory_resource(), k, width, depth, decay);
   } else {
+    TOPK* topk = AllocateMR<TOPK>(memory_resource(), k, width, depth, decay);
     SetMeta(TOPK_TAG);
-    u_.topk = AllocateMR<TOPK>(memory_resource(), k, width, depth, decay);
+    u_.topk = topk;
   }
 }
 

--- a/src/core/compact_object.cc
+++ b/src/core/compact_object.cc
@@ -1109,13 +1109,12 @@ void CompactObj::SetJson(const uint8_t* buf, size_t len) {
 }
 
 void CompactObj::SetSBF(uint64_t initial_capacity, double fp_prob, double grow_factor) {
-  if (taglen_ == SBF_TAG) {
-    *u_.sbf = SBF(initial_capacity, fp_prob, grow_factor, tl.local_mr);
-  } else {
-    SBF* sbf = AllocateMR<SBF>(initial_capacity, fp_prob, grow_factor, tl.local_mr);
+  if (taglen_ != SBF_TAG) {
     SetMeta(SBF_TAG);
-    u_.sbf = sbf;
+    u_.sbf = AllocateMR<SBF>(tl.local_mr);  // trivial ctor, never throws
   }
+  // may throw; u_.sbf is already safely owned either way
+  u_.sbf->Init(initial_capacity, fp_prob, grow_factor, tl.local_mr);
 }
 
 SBF* CompactObj::GetSBF() const {
@@ -1124,13 +1123,11 @@ SBF* CompactObj::GetSBF() const {
 }
 
 void CompactObj::SetCMS(uint32_t width, uint32_t depth) {
-  if (taglen_ == CMS_TAG) {
-    *u_.cms = CMS(width, depth, tl.local_mr);
-  } else {
-    CMS* cms = AllocateMR<CMS>(width, depth, tl.local_mr);  // may throw; CompactObj unchanged
+  if (taglen_ != CMS_TAG) {
     SetMeta(CMS_TAG);
-    u_.cms = cms;
+    u_.cms = AllocateMR<CMS>(tl.local_mr);  // trivial ctor, never throws
   }
+  u_.cms->Init(width, depth);  // may throw; u_.cms is already safely owned either way
 }
 
 CMS* CompactObj::GetCMS() const {
@@ -1139,13 +1136,11 @@ CMS* CompactObj::GetCMS() const {
 }
 
 void CompactObj::SetTOPK(uint32_t k, uint32_t width, uint32_t depth, double decay) {
-  if (taglen_ == TOPK_TAG) {
-    *u_.topk = TOPK(memory_resource(), k, width, depth, decay);
-  } else {
-    TOPK* topk = AllocateMR<TOPK>(memory_resource(), k, width, depth, decay);
+  if (taglen_ != TOPK_TAG) {
     SetMeta(TOPK_TAG);
-    u_.topk = topk;
+    u_.topk = AllocateMR<TOPK>(memory_resource());  // trivial ctor, never throws
   }
+  u_.topk->Init(k, width, depth, decay);  // may throw; u_.topk is already safely owned either way
 }
 
 TOPK* CompactObj::GetTOPK() const {
@@ -1154,11 +1149,12 @@ TOPK* CompactObj::GetTOPK() const {
 }
 
 void CompactObj::SetCuckooFilter(const CuckooFilterOptions& options) {
-  // Allocate before touching taglen_/u_: if constructor throws (e.g. bad_alloc)
-  // this object must stay in its previous, valid state.
-  CuckooFilter* cf = AllocateMR<CuckooFilter>(options, tl.local_mr);
-  SetMeta(CUCKOO_FILTER_TAG);  // frees the previous value, whatever tag it had
-  u_.cuckoo_filter = cf;
+  if (taglen_ != CUCKOO_FILTER_TAG) {
+    SetMeta(CUCKOO_FILTER_TAG);
+    u_.cuckoo_filter = AllocateMR<CuckooFilter>(tl.local_mr);  // trivial ctor, never throws
+  }
+  // may throw; u_.cuckoo_filter is already safely owned either way
+  u_.cuckoo_filter->Init(options);
 }
 
 CuckooFilter* CompactObj::GetCuckooFilter() const {

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -506,15 +506,10 @@ class CompactObj {
 
   template <typename T, typename... Args> static T* AllocateMR(Args&&... args) {
     void* ptr = memory_resource()->allocate(sizeof(T), alignof(T));
-    try {
-      if constexpr (std::is_constructible_v<T, decltype(memory_resource())> && sizeof...(args) == 0)
-        return new (ptr) T{memory_resource()};
-      else
-        return new (ptr) T{std::forward<Args>(args)...};
-    } catch (...) {
-      memory_resource()->deallocate(ptr, sizeof(T), alignof(T));
-      throw;
-    }
+    if constexpr (std::is_constructible_v<T, decltype(memory_resource())> && sizeof...(args) == 0)
+      return new (ptr) T{memory_resource()};
+    else
+      return new (ptr) T{std::forward<Args>(args)...};
   }
 
   template <typename T> static void DeleteMR(void* ptr) {

--- a/src/core/compact_object.h
+++ b/src/core/compact_object.h
@@ -506,10 +506,15 @@ class CompactObj {
 
   template <typename T, typename... Args> static T* AllocateMR(Args&&... args) {
     void* ptr = memory_resource()->allocate(sizeof(T), alignof(T));
-    if constexpr (std::is_constructible_v<T, decltype(memory_resource())> && sizeof...(args) == 0)
-      return new (ptr) T{memory_resource()};
-    else
-      return new (ptr) T{std::forward<Args>(args)...};
+    try {
+      if constexpr (std::is_constructible_v<T, decltype(memory_resource())> && sizeof...(args) == 0)
+        return new (ptr) T{memory_resource()};
+      else
+        return new (ptr) T{std::forward<Args>(args)...};
+    } catch (...) {
+      memory_resource()->deallocate(ptr, sizeof(T), alignof(T));
+      throw;
+    }
   }
 
   template <typename T> static void DeleteMR(void* ptr) {

--- a/src/core/compact_object_test.cc
+++ b/src/core/compact_object_test.cc
@@ -1583,4 +1583,23 @@ static void BM_LpString2Int(benchmark::State& state) {
 }
 BENCHMARK(BM_LpString2Int)->Arg(1)->Arg(2);
 
+TEST_F(CompactObjectTest, CMSHugeAllocLeavesNoOrphan) {
+  constexpr uint32_t kHugeWidth = std::numeric_limits<uint32_t>::max();
+  constexpr uint32_t kHugeDepth = 10000;
+  EXPECT_THROW(cobj_.SetCMS(kHugeWidth, kHugeDepth), std::bad_alloc);
+  EXPECT_NE(cobj_.ObjType(), OBJ_CMS);
+}
+
+TEST_F(CompactObjectTest, CMSHugeAllocLeavesNoLeak) {
+  constexpr uint32_t kHugeWidth = std::numeric_limits<uint32_t>::max();
+  constexpr uint32_t kHugeDepth = 10000;
+
+  auto* mr = static_cast<MiMemoryResource*>(CompactObj::memory_resource());
+  const size_t used_before = mr->used();
+
+  EXPECT_THROW(cobj_.SetCMS(kHugeWidth, kHugeDepth), std::bad_alloc);
+
+  EXPECT_EQ(mr->used(), used_before);
+}
+
 }  // namespace dfly

--- a/src/core/compact_object_test.cc
+++ b/src/core/compact_object_test.cc
@@ -14,6 +14,7 @@
 
 #include "base/gtest.h"
 #include "base/logging.h"
+#include "core/cms.h"
 #include "core/cuckoo.h"
 #include "core/detail/bitpacking.h"
 #include "core/huff_coder.h"
@@ -1583,11 +1584,16 @@ static void BM_LpString2Int(benchmark::State& state) {
 }
 BENCHMARK(BM_LpString2Int)->Arg(1)->Arg(2);
 
-TEST_F(CompactObjectTest, CMSHugeAllocLeavesNoOrphan) {
+// CMS's constructor never allocates (CompactObj::SetCMS adopts a trivially-constructed CMS
+// before calling CMS::Init()), so a huge alloc failure is left as a valid, empty, correctly
+// tagged CMS object rather than an orphaned/corrupted union.
+TEST_F(CompactObjectTest, CMSHugeAllocLeavesValidEmptyObject) {
   constexpr uint32_t kHugeWidth = std::numeric_limits<uint32_t>::max();
   constexpr uint32_t kHugeDepth = 10000;
   EXPECT_THROW(cobj_.SetCMS(kHugeWidth, kHugeDepth), std::bad_alloc);
-  EXPECT_NE(cobj_.ObjType(), OBJ_CMS);
+  EXPECT_EQ(cobj_.ObjType(), OBJ_CMS);
+  EXPECT_EQ(cobj_.GetCMS()->NumCounters(), 0u);
+  EXPECT_NO_THROW(cobj_.MallocUsed());
 }
 
 TEST_F(CompactObjectTest, CMSHugeAllocLeavesNoLeak) {
@@ -1598,6 +1604,7 @@ TEST_F(CompactObjectTest, CMSHugeAllocLeavesNoLeak) {
   const size_t used_before = mr->used();
 
   EXPECT_THROW(cobj_.SetCMS(kHugeWidth, kHugeDepth), std::bad_alloc);
+  cobj_.Reset();
 
   EXPECT_EQ(mr->used(), used_before);
 }

--- a/src/core/compact_object_test.cc
+++ b/src/core/compact_object_test.cc
@@ -1584,15 +1584,15 @@ static void BM_LpString2Int(benchmark::State& state) {
 }
 BENCHMARK(BM_LpString2Int)->Arg(1)->Arg(2);
 
-// CMS's constructor never allocates (CompactObj::SetCMS adopts a trivially-constructed CMS
-// before calling CMS::Init()), so a huge alloc failure is left as a valid, empty, correctly
-// tagged CMS object rather than an orphaned/corrupted union.
+// CompactObj::SetCMS only commits the CMS_TAG once CMS::Init() has succeeded (it builds and
+// initializes a trivially-constructed CMS first, cleaning it up on throw). So a huge alloc
+// failure must leave *this in its prior state instead of publishing a tagged-but-uninitialized
+// CMS that a later GetCMS()/IncrBy() call on the same key would find broken.
 TEST_F(CompactObjectTest, CMSHugeAllocLeavesValidEmptyObject) {
   constexpr uint32_t kHugeWidth = std::numeric_limits<uint32_t>::max();
   constexpr uint32_t kHugeDepth = 10000;
   EXPECT_THROW(cobj_.SetCMS(kHugeWidth, kHugeDepth), std::bad_alloc);
-  EXPECT_EQ(cobj_.ObjType(), OBJ_CMS);
-  EXPECT_EQ(cobj_.GetCMS()->NumCounters(), 0u);
+  EXPECT_NE(cobj_.ObjType(), OBJ_CMS);
   EXPECT_NO_THROW(cobj_.MallocUsed());
 }
 

--- a/src/core/cuckoo.cc
+++ b/src/core/cuckoo.cc
@@ -49,7 +49,10 @@ CuckooFilter::CuckooFilter(std::pmr::memory_resource* mr) : mr_(mr), filters_(mr
 }
 
 void CuckooFilter::Init(const Options& options) {
+  // Called exactly once, right after construction: no previous sub-filters to free.
+  DCHECK(filters_.empty());
   DCHECK_GT(options.slots_per_bucket, 0);
+
   uint16_t new_expansion = options.expansion ? NextPowerOfTwo(options.expansion) : 0;
   uint64_t new_num_buckets =
       options.slots_per_bucket ? NextPowerOfTwo(options.capacity / options.slots_per_bucket) : 1;
@@ -57,12 +60,15 @@ void CuckooFilter::Init(const Options& options) {
     new_num_buckets = 1;
   DCHECK(IsPowerOfTwo(new_num_buckets));
 
-  // Build the first SubFilter before touching any existing state: if this throws,
+  // filters_ starts with 0 capacity, so push_back would otherwise be the operation that can
+  // throw. Reserve first so that risk happens while *this is still guaranteed unchanged.
+  filters_.reserve(1);
+
+  // Build the first SubFilter before committing any state: if this throws,
   // *this is left completely unchanged.
   SubFilter sf(new_num_buckets * options.slots_per_bucket, uint8_t{0}, mr_);
 
   // Nothing below can throw.
-  filters_.clear();
   filters_.push_back(std::move(sf));
   slots_per_bucket_ = options.slots_per_bucket;
   max_iterations_ = options.max_iterations;

--- a/src/core/cuckoo.cc
+++ b/src/core/cuckoo.cc
@@ -44,19 +44,33 @@ uint64_t AltIndex(uint8_t fp, uint64_t index) {
 
 }  // namespace
 
-CuckooFilter::CuckooFilter(const Options& options, std::pmr::memory_resource* mr)
-    : slots_per_bucket_(options.slots_per_bucket),
-      max_iterations_(options.max_iterations),
-      expansion_(options.expansion ? NextPowerOfTwo(options.expansion) : 0),
-      mr_(mr),
-      filters_(mr) {
+CuckooFilter::CuckooFilter(std::pmr::memory_resource* mr) : mr_(mr), filters_(mr) {
   DCHECK(mr);
-  DCHECK_GT(slots_per_bucket_, 0);
-  num_buckets_ = slots_per_bucket_ ? NextPowerOfTwo(options.capacity / slots_per_bucket_) : 1;
-  if (num_buckets_ == 0)
-    num_buckets_ = 1;
-  DCHECK(IsPowerOfTwo(num_buckets_));
-  AddNewSubFilter();
+}
+
+void CuckooFilter::Init(const Options& options) {
+  DCHECK_GT(options.slots_per_bucket, 0);
+  uint16_t new_expansion = options.expansion ? NextPowerOfTwo(options.expansion) : 0;
+  uint64_t new_num_buckets =
+      options.slots_per_bucket ? NextPowerOfTwo(options.capacity / options.slots_per_bucket) : 1;
+  if (new_num_buckets == 0)
+    new_num_buckets = 1;
+  DCHECK(IsPowerOfTwo(new_num_buckets));
+
+  // Build the first SubFilter before touching any existing state: if this throws,
+  // *this is left completely unchanged.
+  SubFilter sf(new_num_buckets * options.slots_per_bucket, uint8_t{0}, mr_);
+
+  // Nothing below can throw.
+  filters_.clear();
+  filters_.push_back(std::move(sf));
+  slots_per_bucket_ = options.slots_per_bucket;
+  max_iterations_ = options.max_iterations;
+  expansion_ = new_expansion;
+  num_buckets_ = new_num_buckets;
+  num_items_ = 0;
+  num_deletes_ = 0;
+  num_ko_inserts_ = 0;
 }
 
 bool CuckooFilter::Insert(uint64_t hash) {

--- a/src/core/cuckoo.h
+++ b/src/core/cuckoo.h
@@ -32,8 +32,9 @@ class CuckooFilter {
   // constructor; it never allocates and never throws. Call Init() before use.
   explicit CuckooFilter(std::pmr::memory_resource* mr);
 
-  // (Re)initializes this filter with the given options, discarding any previous content.
-  // May throw std::bad_alloc; on failure this object is left unchanged.
+  // Initializes this filter with the given options. Must be called exactly once, right after
+  // construction, on an otherwise-empty CuckooFilter. May throw std::bad_alloc; on failure
+  // this object is left unchanged.
   void Init(const Options& options);
 
   // Inserts a pre-computed hash. Returns false only if the filter is full

--- a/src/core/cuckoo.h
+++ b/src/core/cuckoo.h
@@ -28,7 +28,13 @@ class CuckooFilter {
  public:
   using Options = CuckooFilterOptions;
 
-  CuckooFilter(const Options& options, std::pmr::memory_resource* mr);
+  // Constructs an empty, uninitialized CuckooFilter bound to mr. This is the only
+  // constructor; it never allocates and never throws. Call Init() before use.
+  explicit CuckooFilter(std::pmr::memory_resource* mr);
+
+  // (Re)initializes this filter with the given options, discarding any previous content.
+  // May throw std::bad_alloc; on failure this object is left unchanged.
+  void Init(const Options& options);
 
   // Inserts a pre-computed hash. Returns false only if the filter is full
   // and expansion is disabled (expansion_ == 0) or memory allocation fails.
@@ -163,9 +169,9 @@ class CuckooFilter {
   // Returns false if no earlier sub-filter had room
   bool RelocateSlot(size_t filter_idx, uint64_t bucket_idx, uint8_t slot_idx);
 
-  uint8_t slots_per_bucket_;
-  uint16_t max_iterations_;
-  uint16_t expansion_;
+  uint8_t slots_per_bucket_ = 0;
+  uint16_t max_iterations_ = 0;
+  uint16_t expansion_ = 0;
 
   uint64_t num_buckets_ = 0;
   uint64_t num_items_ = 0;

--- a/src/core/cuckoo_filter_test.cc
+++ b/src/core/cuckoo_filter_test.cc
@@ -9,10 +9,19 @@ namespace dfly {
 
 using namespace std;
 
+namespace {
+CuckooFilter MakeCuckooFilter(const CuckooFilter::Options& options,
+                              std::pmr::memory_resource* mr) {
+  CuckooFilter cf(mr);
+  cf.Init(options);
+  return cf;
+}
+}  // namespace
+
 class CuckooFilterTest : public ::testing::Test {
  protected:
   CuckooFilterTest()
-      : cf_(CuckooFilter::Options{.capacity = 128}, std::pmr::get_default_resource()) {
+      : cf_(MakeCuckooFilter({.capacity = 128}, std::pmr::get_default_resource())) {
   }
 
   CuckooFilter cf_;
@@ -74,7 +83,8 @@ TEST_F(CuckooFilterTest, FillBeyondCapacityExpands) {
 
 TEST_F(CuckooFilterTest, NoExpansionRejectWhenFull) {
   // A small filter with expansion=0 must reject inserts once full.
-  CuckooFilter small({.capacity = 4, .expansion = 0}, std::pmr::get_default_resource());
+  CuckooFilter small =
+      MakeCuckooFilter({.capacity = 4, .expansion = 0}, std::pmr::get_default_resource());
 
   size_t inserted = 0;
   for (size_t i = 0; i < 1000; ++i) {

--- a/src/core/cuckoo_filter_test.cc
+++ b/src/core/cuckoo_filter_test.cc
@@ -10,18 +10,17 @@ namespace dfly {
 using namespace std;
 
 namespace {
-CuckooFilter MakeCuckooFilter(const CuckooFilter::Options& options,
-                              std::pmr::memory_resource* mr) {
+CuckooFilter MakeCuckooFilter(const CuckooFilter::Options& options, std::pmr::memory_resource* mr) {
   CuckooFilter cf(mr);
   cf.Init(options);
+
   return cf;
 }
 }  // namespace
 
 class CuckooFilterTest : public ::testing::Test {
  protected:
-  CuckooFilterTest()
-      : cf_(MakeCuckooFilter({.capacity = 128}, std::pmr::get_default_resource())) {
+  CuckooFilterTest() : cf_(MakeCuckooFilter({.capacity = 128}, std::pmr::get_default_resource())) {
   }
 
   CuckooFilter cf_;

--- a/src/core/topk.cc
+++ b/src/core/topk.cc
@@ -41,6 +41,9 @@ TOPK::TOPK(PMR_NS::memory_resource* mr)
 }
 
 void TOPK::Init(uint32_t k, uint32_t width, uint32_t depth, double decay) {
+  // Called exactly once, right after construction: no previous state to preserve.
+  DCHECK(counters_.empty());
+  DCHECK(min_heap_.empty());
   DCHECK_GT(k, 0u);
   DCHECK_GT(width, 0u);
   DCHECK_GT(depth, 0u);

--- a/src/core/topk.cc
+++ b/src/core/topk.cc
@@ -34,32 +34,50 @@ const std::array<double, TOPK::kDecayLookupSize>& GetDefaultDecayTable() {
 
 }  // namespace
 
-TOPK::TOPK(PMR_NS::memory_resource* mr, uint32_t k, uint32_t width, uint32_t depth, double decay)
-    : k_(k),
-      width_(width),
-      depth_(depth),
-      decay_(decay),
-      counters_(static_cast<size_t>(width) * depth, 0, PMR_NS::polymorphic_allocator<uint32_t>(mr)),
+TOPK::TOPK(PMR_NS::memory_resource* mr)
+    : counters_(PMR_NS::polymorphic_allocator<uint32_t>(mr)),
       min_heap_(PMR_NS::polymorphic_allocator<HeapItem>(mr)) {
   DCHECK(mr != nullptr);
-  DCHECK_GT(k_, 0u);
-  DCHECK_GT(width_, 0u);
-  DCHECK_GT(depth_, 0u);
-  DCHECK_GE(decay_, 0.0);
-  DCHECK_LE(decay_, 1.0);
-  min_heap_.reserve(k_);
+}
 
-  if (std::abs(decay_ - TOPK::kDefaultDecay) < TOPK::kDecayEpsilon) {
+void TOPK::Init(uint32_t k, uint32_t width, uint32_t depth, double decay) {
+  DCHECK_GT(k, 0u);
+  DCHECK_GT(width, 0u);
+  DCHECK_GT(depth, 0u);
+  DCHECK_GE(decay, 0.0);
+  DCHECK_LE(decay, 1.0);
+
+  // Build the new state in locals first; only commit once every allocation below has
+  // succeeded, so a failure here leaves *this completely unchanged.
+  std::vector<uint32_t, PMR_NS::polymorphic_allocator<uint32_t>> new_counters(
+      static_cast<size_t>(width) * depth, 0, counters_.get_allocator());
+  std::vector<HeapItem, PMR_NS::polymorphic_allocator<HeapItem>> new_heap(
+      min_heap_.get_allocator());
+  new_heap.reserve(k);
+
+  const std::array<double, kDecayLookupSize>* new_lookup;
+  std::unique_ptr<std::array<double, kDecayLookupSize>> new_custom_table;
+  if (std::abs(decay - TOPK::kDefaultDecay) < TOPK::kDecayEpsilon) {
     // default decay value: use shared static table to save memory and initialization time
-    decay_lookup_ = &GetDefaultDecayTable();
+    new_lookup = &GetDefaultDecayTable();
   } else {
     // custom decay value: build a dedicated table for this instance
-    custom_decay_table_ = std::make_unique<std::array<double, TOPK::kDecayLookupSize>>();
+    new_custom_table = std::make_unique<std::array<double, TOPK::kDecayLookupSize>>();
     for (size_t i = 0; i < TOPK::kDecayLookupSize; ++i) {
-      (*custom_decay_table_)[i] = std::pow(decay_, static_cast<double>(i));
+      (*new_custom_table)[i] = std::pow(decay, static_cast<double>(i));
     }
-    decay_lookup_ = custom_decay_table_.get();
+    new_lookup = new_custom_table.get();
   }
+
+  // Nothing below can throw.
+  k_ = k;
+  width_ = width;
+  depth_ = depth;
+  decay_ = decay;
+  counters_.swap(new_counters);
+  min_heap_.swap(new_heap);
+  custom_decay_table_ = std::move(new_custom_table);
+  decay_lookup_ = custom_decay_table_ ? custom_decay_table_.get() : new_lookup;
 }
 
 TOPK::TOPK(TOPK&& other) noexcept

--- a/src/core/topk.h
+++ b/src/core/topk.h
@@ -69,8 +69,9 @@ class TOPK {
   TOPK& operator=(TOPK&& other) noexcept;
   ~TOPK() = default;
 
-  // (Re)initializes this sketch with the given dimensions. May throw std::bad_alloc; on
-  // failure this object is left unchanged.
+  // Initializes this sketch with the given dimensions. Must be called exactly once, right
+  // after construction, on an otherwise-empty TOPK. May throw std::bad_alloc; on failure this
+  // object is left unchanged.
   void Init(uint32_t k, uint32_t width = kDefaultWidth, uint32_t depth = kDefaultDepth,
             double decay = kDefaultDecay);
 

--- a/src/core/topk.h
+++ b/src/core/topk.h
@@ -59,21 +59,20 @@ class TOPK {
   friend class TOPKTest;
 
  public:
-  // Initializes a Top-K tracking sketch with the specified dimensions.
-  //
-  // mr: Pointer to the memory resource used for allocations (MUST NOT be null).
-  // k: Maximum number of most frequent items to maintain in the min-heap.
-  // width: Number of counter buckets per row in the hash grid (default: 8).
-  // depth: Number of independent hash functions (rows) used (default: 7).
-  // decay: Probability multiplier for exponential decay (must be 0.0 to 1.0, default: 0.9).
-  TOPK(PMR_NS::memory_resource* mr, uint32_t k, uint32_t width = kDefaultWidth,
-       uint32_t depth = kDefaultDepth, double decay = kDefaultDecay);
+  // Constructs an empty, uninitialized TOPK bound to mr. This is the only constructor; it
+  // never allocates and never throws. Call Init() before use.
+  explicit TOPK(PMR_NS::memory_resource* mr);
 
   TOPK(const TOPK&) = delete;
   TOPK& operator=(const TOPK&) = delete;
   TOPK(TOPK&& other) noexcept;
   TOPK& operator=(TOPK&& other) noexcept;
   ~TOPK() = default;
+
+  // (Re)initializes this sketch with the given dimensions. May throw std::bad_alloc; on
+  // failure this object is left unchanged.
+  void Init(uint32_t k, uint32_t width = kDefaultWidth, uint32_t depth = kDefaultDepth,
+            double decay = kDefaultDecay);
 
   static constexpr double kDefaultDecay = 0.9;
   static constexpr uint32_t kDefaultWidth = 8;
@@ -224,10 +223,10 @@ class TOPK {
   void HeapifyUp(size_t index);
   void HeapifyDown(size_t index);
 
-  uint32_t k_;      // Number of top items to track
-  uint32_t width_;  // Hash table width (buckets per row)
-  uint32_t depth_;  // Hash table depth (number of rows)
-  double decay_;    // Decay constant (0.0-1.0, typically 0.9)
+  uint32_t k_ = 0;      // Number of top items to track
+  uint32_t width_ = 0;  // Hash table width (buckets per row)
+  uint32_t depth_ = 0;  // Hash table depth (number of rows)
+  double decay_ = 0.0;  // Decay constant (0.0-1.0, typically 0.9)
 
   // Pointer to the active decay lookup table. For the default decay (0.9), this points to
   // a process-wide shared static table (32KB, allocated once). For custom (non-default) decay

--- a/src/core/topk_test.cc
+++ b/src/core/topk_test.cc
@@ -18,6 +18,15 @@ namespace dfly {
 
 using namespace std;
 
+namespace {
+TOPK MakeTOPK(PMR_NS::memory_resource* mr, uint32_t k, uint32_t width = TOPK::kDefaultWidth,
+              uint32_t depth = TOPK::kDefaultDepth, double decay = TOPK::kDefaultDecay) {
+  TOPK topk(mr);
+  topk.Init(k, width, depth, decay);
+  return topk;
+}
+}  // namespace
+
 class TOPKTest : public ::testing::Test {
  protected:
   // Use decay=0 to disable probabilistic decay, making tests deterministic.
@@ -25,7 +34,7 @@ class TOPKTest : public ::testing::Test {
   // so counters only grow and are never decremented by colliding items.
   // Having a decay != 0 will cause probabilistic flakiness in tests, as items may be randomly
   // evicted due to decay rather than true count comparisons.
-  TOPKTest() : topk_(PMR_NS::get_default_resource(), 5, 100, 5, 0.0) {
+  TOPKTest() : topk_(MakeTOPK(PMR_NS::get_default_resource(), 5, 100, 5, 0.0)) {
   }
 
   double ComputeDecayProbability(TOPK* topk, uint32_t count) const {
@@ -40,7 +49,7 @@ class TOPKTest : public ::testing::Test {
 
 // Verify K(), Width(), Depth(), Decay() return the exact values passed to the constructor.
 TEST(TOPKBasic, ConstructorStoresParameters) {
-  TOPK topk(PMR_NS::get_default_resource(), 10, 200, 7, 0.85);
+  TOPK topk = MakeTOPK(PMR_NS::get_default_resource(), 10, 200, 7, 0.85);
   EXPECT_EQ(topk.K(), 10u);
   EXPECT_EQ(topk.Width(), 200u);
   EXPECT_EQ(topk.Depth(), 7u);
@@ -50,8 +59,8 @@ TEST(TOPKBasic, ConstructorStoresParameters) {
 // Verify that default decay reuses the static process-wide table (saving memory),
 // while a custom decay value allocates its own ~32KB lookup table.
 TEST(TOPKBasic, DecayTableMemoryAllocation) {
-  TOPK default_topk(PMR_NS::get_default_resource(), 5, 100, 5, TOPK::kDefaultDecay);
-  TOPK custom_topk(PMR_NS::get_default_resource(), 5, 100, 5, 0.75);
+  TOPK default_topk = MakeTOPK(PMR_NS::get_default_resource(), 5, 100, 5, TOPK::kDefaultDecay);
+  TOPK custom_topk = MakeTOPK(PMR_NS::get_default_resource(), 5, 100, 5, 0.75);
 
   size_t default_mem = default_topk.MallocUsed();
   size_t custom_mem = custom_topk.MallocUsed();
@@ -81,11 +90,11 @@ TEST_F(TOPKTest, MoveConstructorTransfersOwnership) {
 
 // Move-assign a populated TOPK into another; verify same post-conditions as move constructor.
 TEST(TOPKBasic, MoveAssignmentTransfersOwnership) {
-  TOPK src(PMR_NS::get_default_resource(), 3, 50, 3, 0.0);
+  TOPK src = MakeTOPK(PMR_NS::get_default_resource(), 3, 50, 3, 0.0);
   src.Add("x");
   src.Add("y");
 
-  TOPK dst(PMR_NS::get_default_resource(), 1, 10, 1, 0.0);
+  TOPK dst = MakeTOPK(PMR_NS::get_default_resource(), 1, 10, 1, 0.0);
   dst = std::move(src);
 
   EXPECT_EQ(dst.K(), 3u);
@@ -175,8 +184,8 @@ TEST_F(TOPKTest, IncrByZeroReturnsNullopt) {
 
 // IncrBy(item, 1) should behave the same as Add(item) — both increment by 1.
 TEST(TOPKBasic, IncrByOneBehavesLikeAdd) {
-  TOPK a(PMR_NS::get_default_resource(), 3, 100, 5, 0.0);
-  TOPK b(PMR_NS::get_default_resource(), 3, 100, 5, 0.0);
+  TOPK a = MakeTOPK(PMR_NS::get_default_resource(), 3, 100, 5, 0.0);
+  TOPK b = MakeTOPK(PMR_NS::get_default_resource(), 3, 100, 5, 0.0);
 
   a.Add("x");
   b.IncrBy("x", 1);
@@ -294,7 +303,7 @@ TEST_F(TOPKTest, CountForHeapItemMatchesListCount) {
 
 // List() returns an empty vector on a freshly constructed TOPK.
 TEST(TOPKBasic, ListEmptyOnConstruction) {
-  TOPK fresh(PMR_NS::get_default_resource(), 5, 100, 5, 0.0);
+  TOPK fresh = MakeTOPK(PMR_NS::get_default_resource(), 5, 100, 5, 0.0);
   EXPECT_TRUE(fresh.List().empty());
 }
 
@@ -336,7 +345,7 @@ TEST_F(TOPKTest, ListNeverExceedsKItems) {
 // For count < kDecayLookupSize, ComputeDecayProbability equals std::pow(decay, count).
 TEST_F(TOPKTest, ProbabilityBelowTableSize) {
   double decay_val = 0.85;
-  TOPK topk(PMR_NS::get_default_resource(), 5, 100, 5, decay_val);
+  TOPK topk = MakeTOPK(PMR_NS::get_default_resource(), 5, 100, 5, decay_val);
 
   // ComputeDecayProbability enforces DCHECK_GT(count, 0u), so we start at 1.
   for (uint32_t count = 1; count < TOPK::kDecayLookupSize; ++count) {
@@ -349,7 +358,7 @@ TEST_F(TOPKTest, ProbabilityBelowTableSize) {
 
 // For count >= kDecayLookupSize, the extrapolation path should not crash or produce NaN.
 TEST(TOPKBasic, ProbabilityAboveTableSizeNoCrash) {
-  TOPK topk(PMR_NS::get_default_resource(), 3, 10, 3, 0.999);
+  TOPK topk = MakeTOPK(PMR_NS::get_default_resource(), 3, 10, 3, 0.999);
 
   // Push counter safely above kDecayLookupSize (4097)
   topk.IncrBy("big", 5000);
@@ -369,7 +378,7 @@ TEST(TOPKBasic, ProbabilityAboveTableSizeNoCrash) {
 TEST(TOPKBasic, VeryHighCountApproachesZero) {
   // decay=0.5: 0.5^4096 is astronomically small (< kDecayEpsilon). The extrapolation
   // path should return 0.0, meaning no decay fires for counts above the table range.
-  TOPK topk(PMR_NS::get_default_resource(), 3, 10, 3, 0.5);
+  TOPK topk = MakeTOPK(PMR_NS::get_default_resource(), 3, 10, 3, 0.5);
   topk.IncrBy("stable", 10000);
   auto count_before = topk.Count("stable");
   // Adding more items should not decay "stable"'s counter because the decay
@@ -385,7 +394,7 @@ TEST(TOPKBasic, VeryHighCountApproachesZero) {
 // With decay=0.0, the decay probability is always 0 (0^n = 0 for n>0),
 // so counters should grow monotonically.
 TEST(TOPKBasic, ZeroDecayNeverDecays) {
-  TOPK topk(PMR_NS::get_default_resource(), 3, 50, 3, 0.0);
+  TOPK topk = MakeTOPK(PMR_NS::get_default_resource(), 3, 50, 3, 0.0);
   topk.IncrBy("mono", 100);
   auto count1 = topk.Count("mono");
   topk.IncrBy("mono", 50);
@@ -400,7 +409,7 @@ TEST(TOPKBasic, ZeroDecayNeverDecays) {
 // The counter therefore oscillates: 0 → 1 (add to zero-counter) → 0 (decay fires) → repeat.
 // It is mathematically impossible for the counter to exceed 1.
 TEST(TOPKBasic, DecayOneAlwaysDecays) {
-  TOPK topk(PMR_NS::get_default_resource(), 3, 10, 3, 1.0);
+  TOPK topk = MakeTOPK(PMR_NS::get_default_resource(), 3, 10, 3, 1.0);
 
   for (int i{}; i < 1000; ++i) {
     topk.Add("suppressed");
@@ -417,7 +426,7 @@ TEST(TOPKBasic, DecayOneAlwaysDecays) {
 
 // MallocUsed() after filling the heap should be larger than right after construction.
 TEST(TOPKBasic, MallocUsedIncreaseWithHeapGrowth) {
-  TOPK topk(PMR_NS::get_default_resource(), 5, 100, 5, 0.0);
+  TOPK topk = MakeTOPK(PMR_NS::get_default_resource(), 5, 100, 5, 0.0);
   size_t before = topk.MallocUsed();
   for (int i{}; i < 5; ++i) {
     topk.IncrBy(absl::StrCat("item_with_a_long_name_", i), 100);
@@ -452,7 +461,8 @@ TEST_F(TOPKTest, SerializeRoundTripPreservesConfiguration) {
   topk_.IncrBy("a", 10);
   auto data = ExtractData(topk_);
 
-  TOPK restored(PMR_NS::get_default_resource(), data.k, data.width, data.depth, data.decay);
+  TOPK restored =
+      MakeTOPK(PMR_NS::get_default_resource(), data.k, data.width, data.depth, data.decay);
   restored.Deserialize(data);
 
   EXPECT_EQ(restored.K(), topk_.K());
@@ -468,7 +478,8 @@ TEST_F(TOPKTest, SerializeRoundTripPreservesHeapItems) {
   topk_.IncrBy("gamma", 25);
 
   auto data = ExtractData(topk_);
-  TOPK restored(PMR_NS::get_default_resource(), data.k, data.width, data.depth, data.decay);
+  TOPK restored =
+      MakeTOPK(PMR_NS::get_default_resource(), data.k, data.width, data.depth, data.decay);
   restored.Deserialize(data);
 
   auto orig_list = topk_.List();
@@ -486,7 +497,8 @@ TEST_F(TOPKTest, SerializeRoundTripPreservesCounters) {
   topk_.IncrBy("bar", 77);
 
   auto data = ExtractData(topk_);
-  TOPK restored(PMR_NS::get_default_resource(), data.k, data.width, data.depth, data.decay);
+  TOPK restored =
+      MakeTOPK(PMR_NS::get_default_resource(), data.k, data.width, data.depth, data.decay);
   restored.Deserialize(data);
 
   EXPECT_EQ(topk_.Count("foo"), restored.Count("foo"));
@@ -500,7 +512,8 @@ TEST_F(TOPKTest, DeserializeRebuildsValidHeapProperty) {
   }
 
   auto data = ExtractData(topk_);
-  TOPK restored(PMR_NS::get_default_resource(), data.k, data.width, data.depth, data.decay);
+  TOPK restored =
+      MakeTOPK(PMR_NS::get_default_resource(), data.k, data.width, data.depth, data.decay);
   restored.Deserialize(data);
 
   // The restored heap is full (K items). A heavy new item should evict the minimum.
@@ -511,7 +524,7 @@ TEST_F(TOPKTest, DeserializeRebuildsValidHeapProperty) {
 
 // Serializing a fresh TOPK produces empty heap_items and a zero-filled counters vector.
 TEST(TOPKBasic, SerializeEmptyTOPK) {
-  TOPK topk(PMR_NS::get_default_resource(), 5, 100, 5, 0.0);
+  TOPK topk = MakeTOPK(PMR_NS::get_default_resource(), 5, 100, 5, 0.0);
   auto data = ExtractData(topk);
 
   EXPECT_TRUE(data.heap_items.empty());
@@ -527,7 +540,7 @@ TEST(TOPKBasic, SerializeEmptyTOPK) {
 
 // Explicitly passing get_default_resource() works correctly without crashing.
 TEST(TOPKBasic, PMRExplicitDefaultResourceWorks) {
-  TOPK topk(PMR_NS::get_default_resource(), 5, 100, 5, 0.9);
+  TOPK topk = MakeTOPK(PMR_NS::get_default_resource(), 5, 100, 5, 0.9);
   topk.Add("works");
   EXPECT_EQ(topk.List().size(), 1u);
 }
@@ -550,7 +563,7 @@ TEST(TOPKBasic, PMRExplicitDefaultResourceWorks) {
 // we bypass that math to ensure our "Hot" items are strictly,
 // deterministically larger than the noise.
 TEST(TOPKBasic, TopKItemsIdentifiedUnderHeavyLoad) {
-  TOPK topk(PMR_NS::get_default_resource(), 5, 500, 5, 0.0);
+  TOPK topk = MakeTOPK(PMR_NS::get_default_resource(), 5, 500, 5, 0.0);
   // Hot items get a large, deterministic count via IncrBy.
   for (int h{}; h < 5; ++h) {
     topk.IncrBy(absl::StrCat("hot", h), 1000);
@@ -580,7 +593,7 @@ TEST(TOPKBasic, TopKItemsIdentifiedUnderHeavyLoad) {
 // Uses decay=0.0 and IncrBy so "dominant" has a deterministically high count
 // that minor items (each added once, count=1) can never exceed.
 TEST(TOPKBasic, KEqualsOneTracksOnlyTopItem) {
-  TOPK topk(PMR_NS::get_default_resource(), 1, 500, 5, 0.0);
+  TOPK topk = MakeTOPK(PMR_NS::get_default_resource(), 1, 500, 5, 0.0);
 
   // "dominant" gets a large, fixed count.
   topk.IncrBy("dominant", 1000);
@@ -613,7 +626,7 @@ TEST(TOPKBasic, DeserializeRestoresHeapProperty) {
   data.heap_items.push_back({500, "medium"});
   data.heap_items.push_back({10, "light"});
 
-  TOPK restored(PMR_NS::get_default_resource(), 5, 100, 5, 0.0);
+  TOPK restored = MakeTOPK(PMR_NS::get_default_resource(), 5, 100, 5, 0.0);
   restored.Deserialize(data);
 
   // List() sorts descending — correct only if make_heap built a valid heap.
@@ -656,24 +669,24 @@ TEST_F(TOPKTest, CounterSaturationPreventsOverflow) {
 // ---------------------------------------------------------------------------
 
 #ifndef NDEBUG
-// k=0 violates DCHECK_GT(k_, 0u) in the constructor.
+// k=0 violates DCHECK_GT(k, 0u) in Init().
 TEST(TOPKDeathTest, ZeroKCrashes) {
-  EXPECT_DEBUG_DEATH(TOPK(PMR_NS::get_default_resource(), 0, 100, 5, 0.9), "k_ > 0");
+  EXPECT_DEBUG_DEATH(MakeTOPK(PMR_NS::get_default_resource(), 0, 100, 5, 0.9), "k > 0");
 }
 
-// width=0 violates DCHECK_GT(width_, 0u) in the constructor.
+// width=0 violates DCHECK_GT(width, 0u) in Init().
 TEST(TOPKDeathTest, ZeroWidthCrashes) {
-  EXPECT_DEBUG_DEATH(TOPK(PMR_NS::get_default_resource(), 5, 0, 5, 0.9), "width_ > 0");
+  EXPECT_DEBUG_DEATH(MakeTOPK(PMR_NS::get_default_resource(), 5, 0, 5, 0.9), "width > 0");
 }
 
-// decay=1.5 violates DCHECK_LE(decay_, 1.0) in the constructor.
+// decay=1.5 violates DCHECK_LE(decay, 1.0) in Init().
 TEST(TOPKDeathTest, DecayAboveOneCrashes) {
-  EXPECT_DEBUG_DEATH(TOPK(PMR_NS::get_default_resource(), 5, 100, 5, 1.5), "decay_ <= 1.0");
+  EXPECT_DEBUG_DEATH(MakeTOPK(PMR_NS::get_default_resource(), 5, 100, 5, 1.5), "decay <= 1.0");
 }
 
 // Deserializing data with a mismatched k violates DCHECK_EQ(data.k, k_).
 TEST(TOPKDeathTest, DeserializeDimensionMismatchCrashes) {
-  TOPK topk(PMR_NS::get_default_resource(), 5, 100, 5, 0.9);
+  TOPK topk = MakeTOPK(PMR_NS::get_default_resource(), 5, 100, 5, 0.9);
   TOPK::SerializedData bad;
   bad.k = 10;  // Mismatch: object was constructed with k=5.
   bad.width = 100;
@@ -685,7 +698,7 @@ TEST(TOPKDeathTest, DeserializeDimensionMismatchCrashes) {
 
 // Deserializing data with a mismatched decay violates DCHECK_EQ(data.decay, decay_).
 TEST(TOPKDeathTest, DeserializeDecayMismatchCrashes) {
-  TOPK topk(PMR_NS::get_default_resource(), 5, 100, 5, 0.9);
+  TOPK topk = MakeTOPK(PMR_NS::get_default_resource(), 5, 100, 5, 0.9);
   TOPK::SerializedData bad;
   bad.k = 5;
   bad.width = 100;

--- a/src/server/cms_family.cc
+++ b/src/server/cms_family.cc
@@ -462,7 +462,8 @@ void CmdMerge(CmdArgParser parser, CommandContext* cmd_cntx) {
         continue;
 
       for (const auto& cms_data : result.value()) {
-        CMS temp_cms(cms_data.width, cms_data.depth, CompactObj::memory_resource());
+        CMS temp_cms(CompactObj::memory_resource());
+        temp_cms.Init(cms_data.width, cms_data.depth);
         temp_cms.Load(cms_data.count, cms_data.counters.data());
 
         if (!dest_cms->MergeFrom(temp_cms, merge_args.weights[cms_data.src_index])) {

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -295,24 +295,26 @@ void RdbLoaderBase::OpaqueObjLoader::operator()(const unique_ptr<LoadTrace>& ptr
 }
 
 void RdbLoaderBase::OpaqueObjLoader::operator()(const RdbSBF& src) {
-  SBF* sbf = config_.append ? pv_->GetSBF()
-                            : CompactObj::AllocateMR<SBF>(
-                                  src.grow_factor, src.fp_prob, src.max_capacity, src.prev_size,
-                                  src.current_size, CompactObj::memory_resource());
+  SBF* sbf;
+  if (config_.append) {
+    sbf = pv_->GetSBF();
+  } else {
+    sbf = CompactObj::AllocateMR<SBF>(src.grow_factor, src.fp_prob, src.max_capacity, src.prev_size,
+                                      src.current_size, CompactObj::memory_resource());
+    // Adopt immediately so sbf is safely owned even if AllocateFilter throws below.
+    pv_->SetSBF(sbf);
+  }
   for (unsigned i = 0; i < src.filters.size(); ++i) {
     const auto& blob = src.filters[i].blob;
     auto* ptr = sbf->AllocateFilter(blob.size(), src.filters[i].hash_cnt);
     memcpy(ptr, blob.data(), blob.size());
   }
-
-  // new obj
-  if (!config_.append)
-    pv_->SetSBF(sbf);
 }
 
 void RdbLoaderBase::OpaqueObjLoader::operator()(const RdbTOPK& src) {
-  TOPK* topk = CompactObj::AllocateMR<TOPK>(CompactObj::memory_resource(), src.k, src.width,
-                                            src.depth, src.decay);
+  TOPK* topk = CompactObj::AllocateMR<TOPK>(CompactObj::memory_resource());  // trivial ctor
+  pv_->SetTOPK(topk);  // adopt immediately so topk is safely owned even if Init() throws below
+  topk->Init(src.k, src.width, src.depth, src.decay);
 
   TOPK::SerializedData data;
   data.k = src.k;
@@ -339,14 +341,14 @@ void RdbLoaderBase::OpaqueObjLoader::operator()(const RdbTOPK& src) {
   }
 
   topk->Deserialize(data);
-  pv_->SetTOPK(topk);
 }
 
 void RdbLoaderBase::OpaqueObjLoader::operator()(const RdbCMS& src) {
-  CMS* cms = CompactObj::AllocateMR<CMS>(src.width, src.depth, CompactObj::memory_resource());
+  CMS* cms = CompactObj::AllocateMR<CMS>(CompactObj::memory_resource());  // trivial ctor
+  pv_->SetCMS(cms);  // adopt immediately so cms is safely owned even if Init() throws below
+  cms->Init(src.width, src.depth);
   DCHECK_EQ(src.counters.size(), cms->NumCounters());
   cms->Load(src.total_incr_count, src.counters.data());
-  pv_->SetCMS(cms);
 }
 
 void RdbLoaderBase::OpaqueObjLoader::operator()(const RdbCuckoo& src) {

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -359,8 +359,7 @@ void RdbLoaderBase::OpaqueObjLoader::operator()(const RdbCuckoo& src) {
       cf->AppendFilter(blob);
     return;
   }
-  CuckooFilter* cf =
-      CompactObj::AllocateMR<CuckooFilter>(CuckooFilterOptions{}, CompactObj::memory_resource());
+  CuckooFilter* cf = CompactObj::AllocateMR<CuckooFilter>(CompactObj::memory_resource());
   cf->Deserialize({src.slots_per_bucket, src.max_iterations, src.expansion, src.num_buckets,
                    src.num_items, src.num_deletes, src.filters});
   pv_->SetCuckooFilter(cf);


### PR DESCRIPTION
When vm.overcommit_memory=0, the kernel enforces memory limits and the allocator correctly throws std::bad_alloc. This exposed two bugs in SetCMS, SetSBF, SetTOPK, and SetCuckooFilter:

* Orphan/crash: SetMeta(TAG) was called before AllocateMR, leaving CompactObj with a valid tag but u_.ptr == nullptr. Any subsequent destruction (expiry, FLUSHDB, etc.) would trigger a SIGSEGV.
* Leak: AllocateMR allocated sizeof(T) bytes for the shell object, then placement new threw. The shell allocation was never freed.

Also, `std::bad_alloc` can be thrown by the constructor if an rdb file is injected with improper dim parameters as demonstrated in the test. This is *not* a very realistic scenario.

### The fix

* Make constructors non-throwing
* Add an Init() function that can-throw

fixes https://github.com/dragonflydb/dragonfly/issues/7668