### PR TITLE
chore(server): migrate set/list/hset family handlers to CmdArgParser

### DIFF
--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -625,7 +625,7 @@ OpResult<CbVariant<uint32_t>> OpSet(const OpArgs& op_args, string_view key, CmdA
   return CbVariant<uint32_t>{SetReply(op_sp, created)};
 }
 
-void HGetGeneric(CmdArgList args, uint8_t getall_mask, CommandContext* cmd_cntx) {
+void HGetGeneric(uint8_t getall_mask, CommandContext* cmd_cntx) {
   auto cb = [getall_mask](const HMapWrap& hw) -> OpResult<vector<string>> {
     vector<string> res;
     bool keyval = (getall_mask == (FIELDS | VALUES));
@@ -782,8 +782,12 @@ HSetExParams ParseHSetEx(CmdArgParser* parser, CmdArgList args, string_view cmd_
   return res;
 }
 
-void HSetEx(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{cmd_cntx->tail_args()};
+void HSetEx(CmdArgParser parser, CommandContext* cmd_cntx) {
+  // Materialize the tail args so ParseHSetEx can slice the unparsed fields into a CmdArgList that
+  // outlives the synchronous ScheduleSingleHopT call below.
+  const ParsedArgs& tail = cmd_cntx->tail_args();
+  vector<string_view> args(tail.begin(), tail.end());
+
   string_view key = parser.Next();
   HSetExParams parsed = ParseHSetEx(&parser, args, cmd_cntx->cid()->name());
   RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
@@ -825,9 +829,12 @@ struct HSetReplies {
   CommandContext* cmd_cntx;
 };
 
-void CmdHDel(CmdArgList args, CommandContext* cmd_cntx) {
+void CmdHDel(CmdArgParser parser, CommandContext* cmd_cntx) {
+  parser.Next();  // skip key
   // Collect field names for HNSW data preservation.
-  auto fields_span = args.subspan(1);
+  vector<string_view> fields_span;
+  while (parser.HasNext())
+    fields_span.push_back(parser.Next());
   absl::InlinedVector<std::string_view, 4> field_names;
   for (auto f : fields_span)
     field_names.push_back(f);
@@ -841,8 +848,7 @@ void CmdHDel(CmdArgList args, CommandContext* cmd_cntx) {
   HSetReplies{cmd_cntx}.Send(ExecuteW(cmd_cntx->tx(), std::move(cb), std::move(field_names)));
 }
 
-void CmdHExpire(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{cmd_cntx->tail_args()};
+void CmdHExpire(CmdArgParser parser, CommandContext* cmd_cntx) {
   using MinMaxTtl = FInt<0, (1 << 26)>;
   auto [key, ttl_sec] = parser.Next<string_view, MinMaxTtl>();
 
@@ -862,7 +868,12 @@ void CmdHExpire(CmdArgList args, CommandContext* cmd_cntx) {
 
   uint32_t numFields = parser.Next<uint32_t>();
 
-  CmdArgList fields = args.subspan(parser.UnparsedStart());
+  // Collect the remaining (unparsed) args as the field list. Indexing into tail_args is
+  // independent of the parser's error short-circuit, matching the original args.subspan().
+  const ParsedArgs& tail = cmd_cntx->tail_args();
+  vector<string_view> fields;
+  for (size_t i = parser.UnparsedStart(); i < tail.size(); ++i)
+    fields.push_back(tail[i]);
   if (fields.size() != numFields) {
     return rb->SendError("The `numfields` parameter must match the number of arguments",
                          kSyntaxErrType);
@@ -914,8 +925,7 @@ OpResult<vector<long>> OpHTtl(Transaction* t, EngineShard* shard, string_view ke
   return res;
 }
 
-void CmdHTtl(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{cmd_cntx->tail_args()};
+void CmdHTtl(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
 
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
@@ -929,7 +939,12 @@ void CmdHTtl(CmdArgList args, CommandContext* cmd_cntx) {
 
   uint32_t numFields = parser.Next<uint32_t>();
 
-  CmdArgList fields = args.subspan(parser.UnparsedStart());
+  // Collect the remaining (unparsed) args as the field list. Indexing into tail_args is
+  // independent of the parser's error short-circuit, matching the original args.subspan().
+  const ParsedArgs& tail = cmd_cntx->tail_args();
+  vector<string_view> fields;
+  for (size_t i = parser.UnparsedStart(); i < tail.size(); ++i)
+    fields.push_back(tail[i]);
   if (fields.size() != numFields) {
     return rb->SendError("The `numfields` parameter must match the number of arguments",
                          kSyntaxErrType);
@@ -950,8 +965,9 @@ void CmdHTtl(CmdArgList args, CommandContext* cmd_cntx) {
   };
 }
 
-void CmdHGet(CmdArgList args, CommandContext* cmd_cntx) {
-  auto cb = [field = args[1]](const HMapWrap& hw) -> OpResult<string> {
+void CmdHGet(CmdArgParser parser, CommandContext* cmd_cntx) {
+  parser.Next();  // skip key
+  auto cb = [field = parser.Next()](const HMapWrap& hw) -> OpResult<string> {
     if (auto it = hw.Find(field); it)
       return string{it->second};
     return OpStatus::KEY_NOTFOUND;
@@ -969,9 +985,12 @@ void CmdHGet(CmdArgList args, CommandContext* cmd_cntx) {
   };
 }
 
-void CmdHMGet(CmdArgList args, CommandContext* cmd_cntx) {
-  auto fields = args.subspan(1);
-  auto cb = [fields](const HMapWrap& hw) { return OpHMGet(hw, fields); };
+void CmdHMGet(CmdArgParser parser, CommandContext* cmd_cntx) {
+  parser.Next();  // skip key
+  vector<string_view> fields;
+  while (parser.HasNext())
+    fields.push_back(parser.Next());
+  auto cb = [&fields](const HMapWrap& hw) { return OpHMGet(hw, fields); };
 
   OpResult<vector<OptStr>> result = ExecuteRO(cmd_cntx->tx(), cb);
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
@@ -991,8 +1010,9 @@ void CmdHMGet(CmdArgList args, CommandContext* cmd_cntx) {
   };
 }
 
-void CmdHStrLen(CmdArgList args, CommandContext* cmd_cntx) {
-  auto cb = [field = ArgS(args, 1)](const HMapWrap& hw) -> OpResult<uint32_t> {
+void CmdHStrLen(CmdArgParser parser, CommandContext* cmd_cntx) {
+  parser.Next();  // skip key
+  auto cb = [field = parser.Next()](const HMapWrap& hw) -> OpResult<uint32_t> {
     if (auto it = hw.Find(field); it)
       return it->second.length();
     return OpStatus::KEY_NOTFOUND;
@@ -1000,22 +1020,23 @@ void CmdHStrLen(CmdArgList args, CommandContext* cmd_cntx) {
   HSetReplies{cmd_cntx}.Send(ExecuteRO(cmd_cntx->tx(), cb));
 }
 
-void CmdHLen(CmdArgList args, CommandContext* cmd_cntx) {
+void CmdHLen(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto cb = [](const HMapWrap& hw) -> OpResult<uint32_t> { return hw.Length(); };
   HSetReplies{cmd_cntx}.Send(ExecuteRO(cmd_cntx->tx(), cb));
 }
 
-void CmdHExists(CmdArgList args, CommandContext* cmd_cntx) {
-  auto cb = [field = args[1]](const HMapWrap& hw) -> OpResult<uint32_t> {
+void CmdHExists(CmdArgParser parser, CommandContext* cmd_cntx) {
+  parser.Next();  // skip key
+  auto cb = [field = parser.Next()](const HMapWrap& hw) -> OpResult<uint32_t> {
     return hw.Find(field) ? 1 : 0;
   };
   HSetReplies{cmd_cntx}.Send(ExecuteRO(cmd_cntx->tx(), cb));
 }
 
-void CmdHIncrBy(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  string_view field = ArgS(args, 1);
-  string_view incrs = ArgS(args, 2);
+void CmdHIncrBy(CmdArgParser parser, CommandContext* cmd_cntx) {
+  string_view key = parser.Next();
+  string_view field = parser.Next();
+  string_view incrs = parser.Next();
   int64_t ival = 0;
 
   if (!absl::SimpleAtoi(incrs, &ival)) {
@@ -1047,10 +1068,10 @@ void CmdHIncrBy(CmdArgList args, CommandContext* cmd_cntx) {
   }
 }
 
-void CmdHIncrByFloat(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  string_view field = ArgS(args, 1);
-  string_view incrs = ArgS(args, 2);
+void CmdHIncrByFloat(CmdArgParser parser, CommandContext* cmd_cntx) {
+  string_view key = parser.Next();
+  string_view field = parser.Next();
+  string_view incrs = parser.Next();
   double dval = 0;
 
   if (!absl::SimpleAtod(incrs, &dval)) {
@@ -1084,20 +1105,21 @@ void CmdHIncrByFloat(CmdArgList args, CommandContext* cmd_cntx) {
   }
 }
 
-void CmdHKeys(CmdArgList args, CommandContext* cmd_cntx) {
-  HGetGeneric(args, FIELDS, cmd_cntx);
+void CmdHKeys(CmdArgParser parser, CommandContext* cmd_cntx) {
+  HGetGeneric(FIELDS, cmd_cntx);
 }
 
-void CmdHVals(CmdArgList args, CommandContext* cmd_cntx) {
-  HGetGeneric(args, VALUES, cmd_cntx);
+void CmdHVals(CmdArgParser parser, CommandContext* cmd_cntx) {
+  HGetGeneric(VALUES, cmd_cntx);
 }
 
-void CmdHGetAll(CmdArgList args, CommandContext* cmd_cntx) {
-  HGetGeneric(args, GetAllMode::FIELDS | GetAllMode::VALUES, cmd_cntx);
+void CmdHGetAll(CmdArgParser parser, CommandContext* cmd_cntx) {
+  HGetGeneric(GetAllMode::FIELDS | GetAllMode::VALUES, cmd_cntx);
 }
 
-void CmdHScan(CmdArgList args, CommandContext* cmd_cntx) {
-  std::string_view token = ArgS(args, 1);
+void CmdHScan(CmdArgParser parser, CommandContext* cmd_cntx) {
+  parser.Next();  // skip key
+  std::string_view token = parser.Next();
   uint64_t cursor = 0;
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   if (!absl::SimpleAtoi(token, &cursor)) {
@@ -1105,8 +1127,8 @@ void CmdHScan(CmdArgList args, CommandContext* cmd_cntx) {
   }
 
   // HSCAN key cursor [MATCH pattern] [COUNT count] [NOVALUES]
-  if (args.size() > 7) {
-    DVLOG(1) << "got " << args.size() << " this is more than it should be";
+  if (cmd_cntx->tail_args().size() > 7) {
+    DVLOG(1) << "got " << cmd_cntx->tail_args().size() << " this is more than it should be";
     return rb->SendError(kSyntaxErr);
   }
 
@@ -1135,21 +1157,24 @@ void CmdHScan(CmdArgList args, CommandContext* cmd_cntx) {
   }
 }
 
-void CmdHSet(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-
+void CmdHSet(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view cmd{cmd_cntx->cid()->name()};
   auto* rb = cmd_cntx->rb();
-  if (args.size() % 2 != 1) {
+  // tail_args = key + field/value pairs; a valid command has an odd count.
+  if (cmd_cntx->tail_args().size() % 2 != 1) {
     return rb->SendError(facade::WrongNumArgsError(cmd), kSyntaxErrType);
   }
+
+  string_view key = parser.Next();
 
   optional<util::fb2::Future<bool>> tiered_backpressure;
   OpSetParams params{.backpressure = &tiered_backpressure};
 
-  args.remove_prefix(1);
+  vector<string_view> values;
+  while (parser.HasNext())
+    values.push_back(parser.Next());
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpSet(t->GetOpArgs(shard), key, args, params);
+    return OpSet(t->GetOpArgs(shard), key, values, params);
   };
 
   auto delayed_result = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
@@ -1165,12 +1190,14 @@ void CmdHSet(CmdArgList args, CommandContext* cmd_cntx) {
   }
 }
 
-void CmdHSetNx(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
+void CmdHSetNx(CmdArgParser parser, CommandContext* cmd_cntx) {
+  string_view key = parser.Next();
 
+  vector<string_view> values;
+  while (parser.HasNext())
+    values.push_back(parser.Next());
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpSet(t->GetOpArgs(shard), key, args.subspan(1),
-                 OpSetParams{.mode = OpSetParams::Mode::kNX});
+    return OpSet(t->GetOpArgs(shard), key, values, OpSetParams{.mode = OpSetParams::Mode::kNX});
   };
   HSetReplies{cmd_cntx}.Send(Unwrap(cmd_cntx->tx()->ScheduleSingleHopT(cb)));
 }
@@ -1183,23 +1210,24 @@ void StrVecEmplaceBack(StringVec& str_vec, const listpackEntry& lp) {
   str_vec.emplace_back(absl::StrCat(lp.lval));
 }
 
-void CmdHRandField(CmdArgList args, CommandContext* cmd_cntx) {
+void CmdHRandField(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
-  if (args.size() > 3) {
-    DVLOG(1) << "Wrong number of command arguments: " << args.size();
+  const size_t argc = cmd_cntx->tail_args().size();
+  if (argc > 3) {
+    DVLOG(1) << "Wrong number of command arguments: " << argc;
     return rb->SendError(kSyntaxErr);
   }
 
-  string_view key = ArgS(args, 0);
+  string_view key = parser.Next();
   int32_t count;
   bool with_values = false;
 
-  if ((args.size() > 1) && (!SimpleAtoi(ArgS(args, 1), &count))) {
+  if ((argc > 1) && (!SimpleAtoi(parser.Next(), &count))) {
     return rb->SendError("count value is not an integer", kSyntaxErrType);
   }
 
-  if (args.size() == 3) {
-    string arg = absl::AsciiStrToUpper(ArgS(args, 2));
+  if (argc == 3) {
+    string arg = absl::AsciiStrToUpper(parser.Next());
     if (arg != "WITHVALUES")
       return rb->SendError(kSyntaxErr);
     else
@@ -1220,7 +1248,7 @@ void CmdHRandField(CmdArgList args, CommandContext* cmd_cntx) {
     if (pv.Encoding() == kEncodingStrMap2) {
       StringMap* string_map = GetStringMap(pv, db_context);
 
-      if (args.size() == 1) {
+      if (argc == 1) {
         auto opt_pair = string_map->RandomPair();
         if (opt_pair.has_value()) {
           auto [key, value] = *opt_pair;
@@ -1258,7 +1286,7 @@ void CmdHRandField(CmdArgList args, CommandContext* cmd_cntx) {
       size_t lplen = lpLength(lp);
       CHECK(lplen > 0 && lplen % 2 == 0);
       size_t hlen = lplen / 2;
-      if (args.size() == 1) {
+      if (argc == 1) {
         listpackEntry key;
         lpRandomPair(lp, hlen, &key, NULL);
         StrVecEmplaceBack(str_vec, key);
@@ -1292,7 +1320,7 @@ void CmdHRandField(CmdArgList args, CommandContext* cmd_cntx) {
 
   OpResult<StringVec> result = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
   if (result) {
-    if (result->size() == 1 && args.size() == 1)
+    if (result->size() == 1 && argc == 1)
       rb->SendBulkString(result->front());
     else if (with_values) {
       const auto result_size = result->size();
@@ -1310,7 +1338,7 @@ void CmdHRandField(CmdArgList args, CommandContext* cmd_cntx) {
     } else
       rb->SendBulkStrArr(*result, CollectionType::ARRAY);
   } else if (result.status() == OpStatus::KEY_NOTFOUND) {
-    if (args.size() == 1)
+    if (argc == 1)
       rb->SendNull();
     else
       rb->SendEmptyArray();

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -874,15 +874,14 @@ void MoveGeneric(string_view src, string_view dest, ListDir src_dir, ListDir des
   }
 }
 
-void RPopLPush(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view src = ArgS(args, 0);
-  string_view dest = ArgS(args, 1);
+void RPopLPush(CmdArgParser parser, CommandContext* cmd_cntx) {
+  string_view src = parser.Next();
+  string_view dest = parser.Next();
 
   MoveGeneric(src, dest, ListDir::RIGHT, ListDir::LEFT, cmd_cntx->tx(), cmd_cntx->rb());
 }
 
-void BRPopLPush(CmdArgList args, CommandContext* cmd_cntx) {
-  facade::CmdArgParser parser{cmd_cntx->tail_args()};
+void BRPopLPush(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto [src, dest] = parser.Next<string_view, string_view>();
   float timeout = parser.Next<float>();
   auto* builder = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
@@ -912,8 +911,7 @@ void BRPopLPush(CmdArgList args, CommandContext* cmd_cntx) {
   }
 }
 
-void BLMove(CmdArgList args, CommandContext* cmd_cntx) {
-  facade::CmdArgParser parser{cmd_cntx->tail_args()};
+void BLMove(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto [src, dest] = parser.Next<string_view, string_view>();
   ListDir src_dir = ParseDir(&parser);
   ListDir dest_dir = ParseDir(&parser);
@@ -1042,8 +1040,7 @@ void PushGeneric(ListDir dir, bool skip_notexists, CmdArgList args, CommandConte
   return cmd_cntx->SendError(result.status());
 }
 
-void PopGeneric(ListDir dir, CmdArgList args, CommandContext* cmd_cntx) {
-  facade::CmdArgParser parser{cmd_cntx->tail_args()};
+void PopGeneric(ListDir dir, CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
 
   uint32_t count = 1;
@@ -1154,10 +1151,9 @@ optional<pair<string_view, bool>> GetFirstNonEmptyKeyFound(EngineShard* shard, T
   return result;
 }
 
-void CmdLMPop(CmdArgList args, CommandContext* cmd_cntx) {
+void CmdLMPop(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto* response_builder = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
-  CmdArgParser parser{cmd_cntx->tail_args()};
   parser.Skip(parser.Next<size_t>());  // skip numkeys and keys
 
   ListDir dir = parser.MapNext("LEFT", ListDir::LEFT, "RIGHT", ListDir::RIGHT);
@@ -1235,10 +1231,9 @@ void CmdLMPop(CmdArgList args, CommandContext* cmd_cntx) {
   }
 }
 
-void CmdBLMPop(CmdArgList args, CommandContext* cmd_cntx) {
+void CmdBLMPop(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto* response_builder = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
-  CmdArgParser parser{cmd_cntx->tail_args()};
   float timeout = parser.Next<float>();
   if (auto err = parser.TakeError(); err)
     return cmd_cntx->SendError(err.MakeReply());
@@ -1275,32 +1270,48 @@ void CmdBLMPop(CmdArgList args, CommandContext* cmd_cntx) {
   }
 }
 
-void CmdLPush(CmdArgList args, CommandContext* cmd_cntx) {
+void CmdLPush(CmdArgParser parser, CommandContext* cmd_cntx) {
+  vector<string_view> args;
+  while (parser.HasNext()) {
+    args.push_back(parser.Next());
+  }
   return PushGeneric(ListDir::LEFT, false, args, cmd_cntx);
 }
 
-void CmdLPushX(CmdArgList args, CommandContext* cmd_cntx) {
+void CmdLPushX(CmdArgParser parser, CommandContext* cmd_cntx) {
+  vector<string_view> args;
+  while (parser.HasNext()) {
+    args.push_back(parser.Next());
+  }
   return PushGeneric(ListDir::LEFT, true, args, cmd_cntx);
 }
 
-void CmdLPop(CmdArgList args, CommandContext* cmd_cntx) {
-  return PopGeneric(ListDir::LEFT, args, cmd_cntx);
+void CmdLPop(CmdArgParser parser, CommandContext* cmd_cntx) {
+  return PopGeneric(ListDir::LEFT, std::move(parser), cmd_cntx);
 }
 
-void CmdRPush(CmdArgList args, CommandContext* cmd_cntx) {
+void CmdRPush(CmdArgParser parser, CommandContext* cmd_cntx) {
+  vector<string_view> args;
+  while (parser.HasNext()) {
+    args.push_back(parser.Next());
+  }
   return PushGeneric(ListDir::RIGHT, false, args, cmd_cntx);
 }
 
-void CmdRPushX(CmdArgList args, CommandContext* cmd_cntx) {
+void CmdRPushX(CmdArgParser parser, CommandContext* cmd_cntx) {
+  vector<string_view> args;
+  while (parser.HasNext()) {
+    args.push_back(parser.Next());
+  }
   return PushGeneric(ListDir::RIGHT, true, args, cmd_cntx);
 }
 
-void CmdRPop(CmdArgList args, CommandContext* cmd_cntx) {
-  return PopGeneric(ListDir::RIGHT, args, cmd_cntx);
+void CmdRPop(CmdArgParser parser, CommandContext* cmd_cntx) {
+  return PopGeneric(ListDir::RIGHT, std::move(parser), cmd_cntx);
 }
 
-void CmdLLen(CmdArgList args, CommandContext* cmd_cntx) {
-  auto key = ArgS(args, 0);
+void CmdLLen(CmdArgParser parser, CommandContext* cmd_cntx) {
+  auto key = parser.Next();
   auto cb = [&](Transaction* t, EngineShard* shard) { return OpLen(t->GetOpArgs(shard), key); };
   OpResult<uint32_t> result = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
   if (result) {
@@ -1312,8 +1323,7 @@ void CmdLLen(CmdArgList args, CommandContext* cmd_cntx) {
   }
 }
 
-void CmdLPos(CmdArgList args, CommandContext* cmd_cntx) {
-  facade::CmdArgParser parser{cmd_cntx->tail_args()};
+void CmdLPos(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto [key, elem] = parser.Next<string_view, string_view>();
 
   int rank = 1;
@@ -1352,9 +1362,9 @@ void CmdLPos(CmdArgList args, CommandContext* cmd_cntx) {
   }
 }
 
-void CmdLIndex(CmdArgList args, CommandContext* cmd_cntx) {
-  std::string_view key = ArgS(args, 0);
-  std::string_view index_str = ArgS(args, 1);
+void CmdLIndex(CmdArgParser parser, CommandContext* cmd_cntx) {
+  std::string_view key = parser.Next();
+  std::string_view index_str = parser.Next();
   int32_t index;
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
@@ -1378,8 +1388,7 @@ void CmdLIndex(CmdArgList args, CommandContext* cmd_cntx) {
 }
 
 /* LINSERT <key> (BEFORE|AFTER) <pivot> <element> */
-void CmdLInsert(CmdArgList args, CommandContext* cmd_cntx) {
-  facade::CmdArgParser parser{cmd_cntx->tail_args()};
+void CmdLInsert(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
   QList::InsertOpt ins_opt = parser.MapNext("AFTER", QList::AFTER, "BEFORE", QList::BEFORE);
   auto [pivot, elem] = parser.Next<string_view, string_view>();
@@ -1401,10 +1410,10 @@ void CmdLInsert(CmdArgList args, CommandContext* cmd_cntx) {
   rb->SendError(result.status());
 }
 
-void CmdLTrim(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  string_view s_str = ArgS(args, 1);
-  string_view e_str = ArgS(args, 2);
+void CmdLTrim(CmdArgParser parser, CommandContext* cmd_cntx) {
+  string_view key = parser.Next();
+  string_view s_str = parser.Next();
+  string_view e_str = parser.Next();
   int32_t start, end;
 
   if (!absl::SimpleAtoi(s_str, &start) || !absl::SimpleAtoi(e_str, &end)) {
@@ -1421,10 +1430,10 @@ void CmdLTrim(CmdArgList args, CommandContext* cmd_cntx) {
   cmd_cntx->SendError(st);
 }
 
-void CmdLRange(CmdArgList args, CommandContext* cmd_cntx) {
-  std::string_view key = ArgS(args, 0);
-  std::string_view s_str = ArgS(args, 1);
-  std::string_view e_str = ArgS(args, 2);
+void CmdLRange(CmdArgParser parser, CommandContext* cmd_cntx) {
+  std::string_view key = parser.Next();
+  std::string_view s_str = parser.Next();
+  std::string_view e_str = parser.Next();
   int32_t start, end;
 
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
@@ -1446,10 +1455,10 @@ void CmdLRange(CmdArgList args, CommandContext* cmd_cntx) {
 }
 
 // lrem key 5 foo, will remove foo elements from the list if exists at most 5 times.
-void CmdLRem(CmdArgList args, CommandContext* cmd_cntx) {
-  std::string_view key = ArgS(args, 0);
-  std::string_view index_str = ArgS(args, 1);
-  std::string_view elem = ArgS(args, 2);
+void CmdLRem(CmdArgParser parser, CommandContext* cmd_cntx) {
+  std::string_view key = parser.Next();
+  std::string_view index_str = parser.Next();
+  std::string_view elem = parser.Next();
   int32_t count;
 
   if (!absl::SimpleAtoi(index_str, &count)) {
@@ -1467,10 +1476,10 @@ void CmdLRem(CmdArgList args, CommandContext* cmd_cntx) {
   cmd_cntx->SendError(result.status());
 }
 
-void CmdLSet(CmdArgList args, CommandContext* cmd_cntx) {
-  std::string_view key = ArgS(args, 0);
-  std::string_view index_str = ArgS(args, 1);
-  std::string_view elem = ArgS(args, 2);
+void CmdLSet(CmdArgParser parser, CommandContext* cmd_cntx) {
+  std::string_view key = parser.Next();
+  std::string_view index_str = parser.Next();
+  std::string_view elem = parser.Next();
   int32_t count;
 
   if (!absl::SimpleAtoi(index_str, &count)) {
@@ -1489,16 +1498,23 @@ void CmdLSet(CmdArgList args, CommandContext* cmd_cntx) {
   }
 }
 
-void CmdBLPop(CmdArgList args, CommandContext* cmd_cntx) {
+void CmdBLPop(CmdArgParser parser, CommandContext* cmd_cntx) {
+  vector<string_view> args;
+  while (parser.HasNext()) {
+    args.push_back(parser.Next());
+  }
   BPopGeneric(ListDir::LEFT, args, cmd_cntx);
 }
 
-void CmdBRPop(CmdArgList args, CommandContext* cmd_cntx) {
+void CmdBRPop(CmdArgParser parser, CommandContext* cmd_cntx) {
+  vector<string_view> args;
+  while (parser.HasNext()) {
+    args.push_back(parser.Next());
+  }
   BPopGeneric(ListDir::RIGHT, args, cmd_cntx);
 }
 
-void CmdLMove(CmdArgList args, CommandContext* cmd_cntx) {
-  facade::CmdArgParser parser{cmd_cntx->tail_args()};
+void CmdLMove(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto [src, dest] = parser.Next<string_view, string_view>();
   ListDir src_dir = ParseDir(&parser);
   ListDir dest_dir = ParseDir(&parser);

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -1121,12 +1121,14 @@ struct SetReplies {
   bool script;
 };
 
-void CmdSAdd(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  auto values = args.subspan(1);
+void CmdSAdd(CmdArgParser parser, CommandContext* cmd_cntx) {
+  string_view key = parser.Next();
+  vector<string_view> values;
+  while (parser.HasNext())
+    values.push_back(parser.Next());
 
-  auto cb = [key, values](Transaction* t, EngineShard* shard) {
-    return OpAdd(t->GetOpArgs(shard), key, values, false, false);
+  auto cb = [key, &values](Transaction* t, EngineShard* shard) {
+    return OpAdd(t->GetOpArgs(shard), key, ArgSlice{values}, false, false);
   };
 
   OpResult<uint32_t> result = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
@@ -1137,9 +1139,9 @@ void CmdSAdd(CmdArgList args, CommandContext* cmd_cntx) {
   cmd_cntx->SendError(result.status());
 }
 
-void CmdSIsMember(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  string_view val = ArgS(args, 1);
+void CmdSIsMember(CmdArgParser parser, CommandContext* cmd_cntx) {
+  string_view key = parser.Next();
+  string_view val = parser.Next();
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     auto& db_slice = t->GetDbSlice(shard->shard_id());
@@ -1160,9 +1162,11 @@ void CmdSIsMember(CmdArgList args, CommandContext* cmd_cntx) {
   SendNumeric(result ? OpResult<uint32_t>(1) : result.status(), cmd_cntx);
 }
 
-void CmdSMIsMember(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  auto members = args.subspan(1);
+void CmdSMIsMember(CmdArgParser parser, CommandContext* cmd_cntx) {
+  string_view key = parser.Next();
+  vector<string_view> members;
+  while (parser.HasNext())
+    members.push_back(parser.Next());
 
   vector<int32_t> memberships(members.size());
 
@@ -1174,7 +1178,7 @@ void CmdSMIsMember(CmdArgList args, CommandContext* cmd_cntx) {
       const PrimeValue& pv = (*find_res)->second;
       SetType st{pv.RObjPtr(), pv.Encoding()};
       for (size_t i = 0; i < members.size(); ++i)
-        memberships[i] = IsInSet(db_cntx, st, ToSV(members[i]));
+        memberships[i] = IsInSet(db_cntx, st, members[i]);
       SetFamily::DeleteSetIfEmpty(db_slice, db_cntx, key, pv);
       return OpStatus::OK;
     }
@@ -1194,10 +1198,10 @@ void CmdSMIsMember(CmdArgList args, CommandContext* cmd_cntx) {
   cmd_cntx->ReplyWith(std::move(replier));
 }
 
-void CmdSMove(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view src = ArgS(args, 0);
-  string_view dest = ArgS(args, 1);
-  string_view member = ArgS(args, 2);
+void CmdSMove(CmdArgParser parser, CommandContext* cmd_cntx) {
+  string_view src = parser.Next();
+  string_view dest = parser.Next();
+  string_view member = parser.Next();
 
   Mover mover{src, dest, member, true};
   mover.Find(cmd_cntx->tx());
@@ -1210,20 +1214,22 @@ void CmdSMove(CmdArgList args, CommandContext* cmd_cntx) {
   cmd_cntx->SendLong(result.value());
 }
 
-void CmdSRem(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  auto vals = args.subspan(1);
+void CmdSRem(CmdArgParser parser, CommandContext* cmd_cntx) {
+  string_view key = parser.Next();
+  vector<string_view> vals;
+  while (parser.HasNext())
+    vals.push_back(parser.Next());
 
-  auto cb = [key, vals](Transaction* t, EngineShard* shard) {
-    return OpRem(t->GetOpArgs(shard), key, vals, false);
+  auto cb = [key, &vals](Transaction* t, EngineShard* shard) {
+    return OpRem(t->GetOpArgs(shard), key, ArgSlice{vals}, false);
   };
 
   OpResult<uint32_t> result = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
   SendNumeric(result, cmd_cntx);
 }
 
-void CmdSCard(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
+void CmdSCard(CmdArgParser parser, CommandContext* cmd_cntx) {
+  string_view key = parser.Next();
 
   auto cb = [&](Transaction* t, EngineShard* shard) -> OpResult<uint32_t> {
     auto find_res = t->GetDbSlice(shard->shard_id()).FindReadOnly(t->GetDbContext(), key, OBJ_SET);
@@ -1238,11 +1244,12 @@ void CmdSCard(CmdArgList args, CommandContext* cmd_cntx) {
   SendNumeric(result, cmd_cntx);
 }
 
-void CmdSPop(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
+void CmdSPop(CmdArgParser parser, CommandContext* cmd_cntx) {
+  const size_t args_size = cmd_cntx->tail_args().size();
+  string_view key = parser.Next();
   unsigned count = 1;
-  if (args.size() > 1) {
-    string_view arg = ArgS(args, 1);
+  if (parser.HasNext()) {
+    string_view arg = parser.Next();
     if (!absl::SimpleAtoi(arg, &count)) {
       cmd_cntx->SendError(kInvalidIntErr);
       return;
@@ -1255,7 +1262,7 @@ void CmdSPop(CmdArgList args, CommandContext* cmd_cntx) {
 
   OpResult<StringVec> result = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
   auto replier = [result = std::move(result),
-                  pop_single = (args.size() == 1)](facade::SinkReplyBuilder* builder) {
+                  pop_single = (args_size == 1)](facade::SinkReplyBuilder* builder) {
     auto* rb = static_cast<RedisReplyBuilder*>(builder);
     if (result || result.status() == OpStatus::KEY_NOTFOUND) {
       if (pop_single) {  // SPOP key
@@ -1276,9 +1283,9 @@ void CmdSPop(CmdArgList args, CommandContext* cmd_cntx) {
   cmd_cntx->ReplyWith(std::move(replier));
 }
 
-void CmdSDiff(CmdArgList args, CommandContext* cmd_cntx) {
+void CmdSDiff(CmdArgParser parser, CommandContext* cmd_cntx) {
   ResultStringVec result_set(shard_set->size(), OpStatus::SKIPPED);
-  string_view src_key = ArgS(args, 0);
+  string_view src_key = parser.Next();
   ShardId src_shard = Shard(src_key, result_set.size());
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
@@ -1298,11 +1305,11 @@ void CmdSDiff(CmdArgList args, CommandContext* cmd_cntx) {
   SetReplies{cmd_cntx}.Send(rsv);
 }
 
-void CmdSDiffStore(CmdArgList args, CommandContext* cmd_cntx) {
+void CmdSDiffStore(CmdArgParser parser, CommandContext* cmd_cntx) {
   ResultStringVec result_set(shard_set->size(), OpStatus::SKIPPED);
-  string_view dest_key = ArgS(args, 0);
+  string_view dest_key = parser.Next();
   ShardId dest_shard = Shard(dest_key, result_set.size());
-  string_view src_key = ArgS(args, 1);
+  string_view src_key = parser.Next();
   ShardId src_shard = Shard(src_key, result_set.size());
 
   VLOG(1) << "SDiffStore " << src_key << " " << src_shard;
@@ -1352,7 +1359,7 @@ void CmdSDiffStore(CmdArgList args, CommandContext* cmd_cntx) {
   cmd_cntx->SendLong(result_size);
 }
 
-void CmdSMembers(CmdArgList args, CommandContext* cmd_cntx) {
+void CmdSMembers(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto cb = [](Transaction* t, EngineShard* shard) { return OpInter(t, shard, false); };
 
   OpResult<StringVec> result = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
@@ -1364,8 +1371,7 @@ void CmdSMembers(CmdArgList args, CommandContext* cmd_cntx) {
   }
 }
 
-void CmdSRandMember(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser{cmd_cntx->tail_args()};
+void CmdSRandMember(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
 
   bool is_count = parser.HasNext();
@@ -1400,7 +1406,7 @@ void CmdSRandMember(CmdArgList args, CommandContext* cmd_cntx) {
   cmd_cntx->ReplyWith(std::move(replier));
 }
 
-void CmdSInter(CmdArgList args, CommandContext* cmd_cntx) {
+void CmdSInter(CmdArgParser parser, CommandContext* cmd_cntx) {
   ResultStringVec result_set(shard_set->size(), OpStatus::SKIPPED);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
@@ -1418,9 +1424,9 @@ void CmdSInter(CmdArgList args, CommandContext* cmd_cntx) {
   }
 }
 
-void CmdSInterStore(CmdArgList args, CommandContext* cmd_cntx) {
+void CmdSInterStore(CmdArgParser parser, CommandContext* cmd_cntx) {
   ResultStringVec result_set(shard_set->size(), OpStatus::SKIPPED);
-  string_view dest_key = ArgS(args, 0);
+  string_view dest_key = parser.Next();
   ShardId dest_shard = Shard(dest_key, result_set.size());
   atomic_uint32_t inter_shard_cnt{0};
 
@@ -1457,14 +1463,16 @@ void CmdSInterStore(CmdArgList args, CommandContext* cmd_cntx) {
   cmd_cntx->SendLong(result->size());
 }
 
-void CmdSInterCard(CmdArgList args, CommandContext* cmd_cntx) {
+void CmdSInterCard(CmdArgParser parser, CommandContext* cmd_cntx) {
+  const facade::ParsedArgs& args = cmd_cntx->tail_args();
+
   unsigned num_keys;
-  if (!absl::SimpleAtoi(ArgS(args, 0), &num_keys))
+  if (!absl::SimpleAtoi(parser.Next(), &num_keys))
     return cmd_cntx->SendError(kSyntaxErr);
 
   unsigned limit = 0;
-  if (args.size() == (num_keys + 3) && ArgS(args, 1 + num_keys) == "LIMIT") {
-    if (!absl::SimpleAtoi(ArgS(args, num_keys + 2), &limit))
+  if (args.size() == (num_keys + 3) && args[1 + num_keys] == "LIMIT") {
+    if (!absl::SimpleAtoi(args[num_keys + 2], &limit))
       return cmd_cntx->SendError("limit can't be negative");
   } else if (args.size() > (num_keys + 1))
     return cmd_cntx->SendError(kSyntaxErr);
@@ -1484,7 +1492,7 @@ void CmdSInterCard(CmdArgList args, CommandContext* cmd_cntx) {
   cmd_cntx->SendError(result.status());
 }
 
-void CmdSUnion(CmdArgList args, CommandContext* cmd_cntx) {
+void CmdSUnion(CmdArgParser parser, CommandContext* cmd_cntx) {
   ResultStringVec result_set(shard_set->size());
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
@@ -1499,9 +1507,9 @@ void CmdSUnion(CmdArgList args, CommandContext* cmd_cntx) {
   SetReplies{cmd_cntx}.Send(unionset);
 }
 
-void CmdSUnionStore(CmdArgList args, CommandContext* cmd_cntx) {
+void CmdSUnionStore(CmdArgParser parser, CommandContext* cmd_cntx) {
   ResultStringVec result_set(shard_set->size(), OpStatus::SKIPPED);
-  string_view dest_key = ArgS(args, 0);
+  string_view dest_key = parser.Next();
   ShardId dest_shard = Shard(dest_key, result_set.size());
 
   auto union_cb = [&](Transaction* t, EngineShard* shard) {
@@ -1539,9 +1547,10 @@ void CmdSUnionStore(CmdArgList args, CommandContext* cmd_cntx) {
   cmd_cntx->SendLong(result_size);
 }
 
-void CmdSScan(CmdArgList args, CommandContext* cmd_cntx) {
-  string_view key = ArgS(args, 0);
-  string_view token = ArgS(args, 1);
+void CmdSScan(CmdArgParser parser, CommandContext* cmd_cntx) {
+  const size_t args_size = cmd_cntx->tail_args().size();
+  string_view key = parser.Next();
+  string_view token = parser.Next();
 
   uint64_t cursor = 0;
 
@@ -1550,8 +1559,8 @@ void CmdSScan(CmdArgList args, CommandContext* cmd_cntx) {
   }
 
   // SSCAN key cursor [MATCH pattern] [COUNT count]
-  if (args.size() > 6) {
-    DVLOG(1) << "got " << args.size() << " this is more than it should be";
+  if (args_size > 6) {
+    DVLOG(1) << "got " << args_size << " this is more than it should be";
     return cmd_cntx->SendError(kSyntaxErr);
   }
 
@@ -1582,9 +1591,7 @@ void CmdSScan(CmdArgList args, CommandContext* cmd_cntx) {
 }
 
 // Syntax: saddex key [KEEPTTL] ttl_sec member [member...]
-void CmdSAddEx(CmdArgList args, CommandContext* cmd_cntx) {
-  CmdArgParser parser(cmd_cntx->tail_args());
-
+void CmdSAddEx(CmdArgParser parser, CommandContext* cmd_cntx) {
   const std::string_view key = parser.Next<std::string_view>();
   const bool keepttl = parser.Check("KEEPTTL");
   const uint32_t ttl_sec = parser.Next<uint32_t>();
@@ -1597,13 +1604,15 @@ void CmdSAddEx(CmdArgList args, CommandContext* cmd_cntx) {
     return cmd_cntx->SendError(kInvalidIntErr);
   }
 
-  CmdArgList vals = args.subspan(parser.UnparsedStart());
+  vector<string_view> vals;
+  while (parser.HasNext())
+    vals.push_back(parser.Next());
   if (vals.empty()) {
     return cmd_cntx->SendError(WrongNumArgsError("SADDEX"));
   }
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpAddEx(t->GetOpArgs(shard), key, ttl_sec, vals, keepttl);
+    return OpAddEx(t->GetOpArgs(shard), key, ttl_sec, ArgSlice{vals}, keepttl);
   };
 
   OpResult<uint32_t> result = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));


### PR DESCRIPTION
## Summary
Continues the `CmdArgParser` migration across the larger collection families. Migrates **all registered command handlers** in `set_family`, `list_family`, and `hset_family` from `CmdArgList` to `facade::CmdArgParser`.

## Notes
- Handlers read positional args via the parser. Variadic value/field/member lists are collected into a `vector<string_view>`, which converts to the `CmdArgList` that internal `Op*`/`*Generic` helpers still accept.
- Up-front arity/parity checks (e.g. HSET even field/value count, SINTERCARD/SSCAN size checks) use `cmd_cntx->tail_args().size()` to preserve exact error ordering.
- Internal helpers keep their `CmdArgList` signatures (`PushGeneric`, `BPopGeneric`, `ParseHSetEx`, `Op*`, …). `PopGeneric` and `HGetGeneric` were adjusted since their only callers are migrated handlers.
- `HEXPIRE`/`HTTL` collect their trailing field list by indexing `tail_args()` from `parser.UnparsedStart()` (independent of the parser's error short-circuit, matching the original `args.subspan()`).
- Registration is unchanged — `SetHandler(&Cmd...)` now resolves to the parser-function `SetHandler` template.

## Verification
- `ninja dragonfly` builds clean
- Unit tests: list 51 (+2 pre-existing skips), set 33/33, hset 41/41
- Live smoke tests across all three families, including the trickier paths: `LPOP`/`SPOP` with count, `LMPOP`/`LMOVE`/`LINSERT`/`LPOS`, `SINTERCARD` (with `LIMIT` and the syntax-error path), `SSCAN`, `HMGET`/`HDEL`/`HINCRBY`, `HRANDFIELD ... WITHVALUES`, `HEXPIRE`/`HTTL`, `HSCAN`, and `HSET` odd-args error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)