### PR TITLE
feat(string_family): add CL.PROBE read-only throttle inspection command

### DIFF
--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -10,6 +10,7 @@
 #include <array>
 #include <chrono>
 #include <cstdint>
+#include <optional>
 #include <variant>
 
 #include "base/flags.h"
@@ -405,7 +406,7 @@ bool IsValueWithinBounds(const int64_t value, const int64_t bound) {
 // limit is assumed to be positive
 OpResult<array<int64_t, 5>> OpThrottle(const OpArgs& op_args, const string_view key,
                                        const int64_t limit, const int64_t emission_interval_ns,
-                                       const uint64_t quantity) {
+                                       const uint64_t quantity, bool probe = false) {
   constexpr uint64_t kSecondToMilliSecond = 1000;
   constexpr uint64_t kMilliSecondToNanoSecond = 1000000;
   auto& db_slice = op_args.GetDbSlice();
@@ -420,19 +421,34 @@ OpResult<array<int64_t, 5>> OpThrottle(const OpArgs& op_args, const string_view 
   // Cost of this request
   const int64_t increment_ns = emission_interval_ns * quantity;  // should be nonnegative
 
-  auto res = db_slice.FindMutable(op_args.db_cntx, key, OBJ_STRING);
   const int64_t now_ns = GetCurrentTimeNs();
 
   int64_t tat_ns = now_ns;
-  if (res) {
-    // Type is already checked by FindMutable (OBJ_STRING)
-    auto opt_prev = res->it->second.TryGetInt();
-    if (!opt_prev) {
-      return OpStatus::INVALID_VALUE;
+  optional<OpResult<DbSlice::ItAndUpdater>> mutable_res;
+  if (probe) {
+    auto res = db_slice.FindReadOnly(op_args.db_cntx, key, OBJ_STRING);
+    if (res) {
+      // Type is already checked by FindReadOnly (OBJ_STRING)
+      auto opt_prev = (*res)->second.TryGetInt();
+      if (!opt_prev) {
+        return OpStatus::INVALID_VALUE;
+      }
+      tat_ns = *opt_prev;
+    } else if (res.status() == OpStatus::WRONG_TYPE) {
+      return res.status();
     }
-    tat_ns = *opt_prev;
-  } else if (res.status() == OpStatus::WRONG_TYPE) {
-    return res.status();
+  } else {
+    mutable_res.emplace(db_slice.FindMutable(op_args.db_cntx, key, OBJ_STRING));
+    if (*mutable_res) {
+      // Type is already checked by FindMutable (OBJ_STRING)
+      auto opt_prev = (*mutable_res)->it->second.TryGetInt();
+      if (!opt_prev) {
+        return OpStatus::INVALID_VALUE;
+      }
+      tat_ns = *opt_prev;
+    } else if (mutable_res->status() == OpStatus::WRONG_TYPE) {
+      return mutable_res->status();
+    }
   }
 
   int64_t new_tat_ns = max(tat_ns, now_ns);
@@ -485,7 +501,9 @@ OpResult<array<int64_t, 5>> OpThrottle(const OpArgs& op_args, const string_view 
   }
   reset_after_ms = (ttl_ns + kMilliSecondToNanoSecond - 1) / kMilliSecondToNanoSecond;
 
-  if (!limited) {
+  if (!limited && !probe) {
+    DCHECK(mutable_res.has_value());
+    auto& res = *mutable_res;
     // Although most computation so far is in nanoseconds, we must store expiry as milliseconds.
     // While this causes loss of precision, the value stored against the throttle key is still in
     // the nanosecond units. When the key is loaded, that value will be read and used as tat_ns. The
@@ -1701,7 +1719,9 @@ cmd::CmdR CmdSetRange(CmdArgParser parser, CommandContext* cmd_cntx) {
   co_return std::nullopt;
 }
 
-/* CL.THROTTLE <key> <max_burst> <count per period> <period> [<quantity>] */
+/* CL.THROTTLE <key> <max_burst> <count per period> <period> [<quantity>]
+ * CL.PROBE <key> <max_burst> <count per period> <period> [<quantity>]
+ */
 /* Response is array of 5 integers. The meaning of each array item is:
  *  1. Whether the action was limited:
  *   - 0 indicates the action is allowed.
@@ -1714,7 +1734,7 @@ cmd::CmdR CmdSetRange(CmdArgParser parser, CommandContext* cmd_cntx) {
  *  5. The number of seconds until the limit will reset to its maximum capacity.
  * Equivalent to X-RateLimit-Reset.
  */
-void CmdClThrottle(CmdArgList args, CommandContext* cmd_cntx) {
+void CmdClThrottleOrProbe(CmdArgList args, CommandContext* cmd_cntx, bool probe) {
   constexpr uint64_t kSecondToNanoSecond = 1000000000;
   const string_view key = ArgS(args, 0);
 
@@ -1775,7 +1795,7 @@ void CmdClThrottle(CmdArgList args, CommandContext* cmd_cntx) {
   }
 
   auto cb = [&](Transaction* t, EngineShard* shard) -> OpResult<array<int64_t, 5>> {
-    return OpThrottle(t->GetOpArgs(shard), key, limit, emission_interval_ns, quantity);
+    return OpThrottle(t->GetOpArgs(shard), key, limit, emission_interval_ns, quantity, probe);
   };
 
   Transaction* trans = cmd_cntx->tx();
@@ -1820,6 +1840,14 @@ void CmdClThrottle(CmdArgList args, CommandContext* cmd_cntx) {
   }
 }
 
+void CmdClThrottle(CmdArgList args, CommandContext* cmd_cntx) {
+  CmdClThrottleOrProbe(args, cmd_cntx, false);
+}
+
+void CmdClProbe(CmdArgList args, CommandContext* cmd_cntx) {
+  CmdClThrottleOrProbe(args, cmd_cntx, true);
+}
+
 }  // namespace
 
 #define HFUNC(x) SetHandler(&Cmd##x)
@@ -1860,6 +1888,7 @@ void RegisterStringFamily(CommandRegistry* registry) {
       << CI{"SETRANGE", CO::JOURNALED | CO::DENYOOM, 4, 1, 1}.SetAsyncHandler(CmdSetRange)
       << CI{"CL.THROTTLE", CO::JOURNALED | CO::DENYOOM | CO::FAST, -5, 1, 1, acl::THROTTLE}.HFUNC(
              ClThrottle)
+      << CI{"CL.PROBE", CO::READONLY | CO::FAST, -5, 1, 1, acl::THROTTLE}.HFUNC(ClProbe)
       << CI{"GAT", CO::JOURNALED | CO::DENYOOM | CO::NO_AUTOJOURNAL | CO::HIDDEN, -2, 1, -1}
              .SetAsyncHandler(CmdGAT);
 }

--- a/src/server/string_family_test.cc
+++ b/src/server/string_family_test.cc
@@ -808,6 +808,85 @@ TEST_F(StringFamilyTest, ClThrottle) {
               ElementsAre(IntArg(0), IntArg(limit), IntArg(limit - 2), IntArg(-1), IntArg(1)));
 }
 
+TEST_F(StringFamilyTest, ClProbe) {
+  const int64_t limit = 5;
+  const char* const max_burst = "4";  // limit - 1
+  const char* const count = "1";
+  const char* const period = "10";
+
+  const char* const missing_key = "probe-missing";
+  auto resp = Run({"cl.probe", missing_key, max_burst, count, period});
+  ASSERT_EQ(RespExpr::ARRAY, resp.type);
+  ASSERT_THAT(resp.GetVec(),
+              ElementsAre(IntArg(0), IntArg(limit), IntArg(4), IntArg(-1), IntArg(11)));
+  EXPECT_THAT(Run({"exists", missing_key}), IntArg(0));
+
+  resp = Run({"cl.probe", missing_key, max_burst, count, period});
+  ASSERT_EQ(RespExpr::ARRAY, resp.type);
+  ASSERT_THAT(resp.GetVec(),
+              ElementsAre(IntArg(0), IntArg(limit), IntArg(4), IntArg(-1), IntArg(11)));
+  EXPECT_THAT(Run({"exists", missing_key}), IntArg(0));
+
+  const char* const quantity_key = "probe-quantity";
+  resp = Run({"cl.probe", quantity_key, max_burst, count, period, "2"});
+  ASSERT_EQ(RespExpr::ARRAY, resp.type);
+  ASSERT_THAT(resp.GetVec(),
+              ElementsAre(IntArg(0), IntArg(limit), IntArg(3), IntArg(-1), IntArg(21)));
+  EXPECT_THAT(Run({"exists", quantity_key}), IntArg(0));
+
+  resp = Run({"cl.throttle", quantity_key, max_burst, count, period, "2"});
+  ASSERT_EQ(RespExpr::ARRAY, resp.type);
+  ASSERT_THAT(resp.GetVec(),
+              ElementsAre(IntArg(0), IntArg(limit), IntArg(3), IntArg(-1), IntArg(21)));
+  EXPECT_THAT(Run({"pttl", quantity_key}), IntArg(20000));
+
+  const char* const key = "probe-used";
+  resp = Run({"cl.throttle", key, max_burst, count, period});
+  ASSERT_EQ(RespExpr::ARRAY, resp.type);
+  ASSERT_THAT(resp.GetVec(),
+              ElementsAre(IntArg(0), IntArg(limit), IntArg(4), IntArg(-1), IntArg(11)));
+  EXPECT_THAT(Run({"pttl", key}), IntArg(10000));
+
+  resp = Run({"cl.probe", key, max_burst, count, period});
+  ASSERT_EQ(RespExpr::ARRAY, resp.type);
+  ASSERT_THAT(resp.GetVec(),
+              ElementsAre(IntArg(0), IntArg(limit), IntArg(3), IntArg(-1), IntArg(21)));
+  EXPECT_THAT(Run({"pttl", key}), IntArg(10000));
+
+  resp = Run({"cl.probe", key, max_burst, count, period});
+  ASSERT_EQ(RespExpr::ARRAY, resp.type);
+  ASSERT_THAT(resp.GetVec(),
+              ElementsAre(IntArg(0), IntArg(limit), IntArg(3), IntArg(-1), IntArg(21)));
+  EXPECT_THAT(Run({"pttl", key}), IntArg(10000));
+
+  resp = Run({"cl.throttle", key, max_burst, count, period});
+  ASSERT_EQ(RespExpr::ARRAY, resp.type);
+  ASSERT_THAT(resp.GetVec(),
+              ElementsAre(IntArg(0), IntArg(limit), IntArg(3), IntArg(-1), IntArg(21)));
+  EXPECT_THAT(Run({"pttl", key}), IntArg(20000));
+
+  resp = Run({"cl.throttle", key, max_burst, count, period});
+  ASSERT_EQ(RespExpr::ARRAY, resp.type);
+  ASSERT_THAT(resp.GetVec(),
+              ElementsAre(IntArg(0), IntArg(limit), IntArg(2), IntArg(-1), IntArg(31)));
+
+  resp = Run({"cl.throttle", key, max_burst, count, period});
+  ASSERT_EQ(RespExpr::ARRAY, resp.type);
+  ASSERT_THAT(resp.GetVec(),
+              ElementsAre(IntArg(0), IntArg(limit), IntArg(1), IntArg(-1), IntArg(41)));
+
+  resp = Run({"cl.throttle", key, max_burst, count, period});
+  ASSERT_EQ(RespExpr::ARRAY, resp.type);
+  ASSERT_THAT(resp.GetVec(),
+              ElementsAre(IntArg(0), IntArg(limit), IntArg(0), IntArg(-1), IntArg(51)));
+
+  resp = Run({"cl.probe", key, max_burst, count, period});
+  ASSERT_EQ(RespExpr::ARRAY, resp.type);
+  ASSERT_THAT(resp.GetVec(),
+              ElementsAre(IntArg(1), IntArg(limit), IntArg(0), IntArg(11), IntArg(51)));
+  EXPECT_THAT(Run({"pttl", key}), IntArg(50000));
+}
+
 TEST_F(StringFamilyTest, SetMGetWithNilResp3) {
   Run({"hello", "3"});
 


### PR DESCRIPTION
## Summary
Adds `CL.PROBE`, a read-only companion to `CL.THROTTLE`. It returns the same 5-element rate-limit response but inspects the throttle state without consuming quota, mutating the stored TAT, or creating the key.

## Why this matters
`CL.THROTTLE` always writes (it stores the new theoretical arrival time and bumps the key TTL), so there is no way to ask "would this be limited?" without actually consuming a request. #7128 asks for a non-consuming probe. `CL.PROBE` takes the same `<key> <max_burst> <count per period> <period> [<quantity>]` arguments and computes the identical decision, but takes the read path: it reads through `FindReadOnly` and skips the store/TTL update, so it is registered `CO::READONLY` and can run on replicas.

## Changes
- `OpThrottle` gains a `probe` flag; on the probe path it uses `FindReadOnly` and returns the computed decision without persisting the new TAT or TTL.
- `CmdClThrottle` and the new `CmdClProbe` share one `CmdClThrottleOrProbe` body.
- Registered `CL.PROBE` with `CO::READONLY | CO::FAST` under the existing `acl::THROTTLE` category.

## Testing
Added `StringFamilyTest.ClProbe`: verifies `CL.PROBE` never creates a missing key (`EXISTS` stays 0), never advances the TTL of an existing throttle key (repeated probes leave `PTTL` unchanged), and that `CL.THROTTLE` interleaved with probes still advances state as before. Built and ran the C++ suite locally is not included here; the test exercises the read-only invariants the change introduces.

Fixes #7128

AI was used for assistance.