### PR TITLE
feat(search): support WITHSCORES/SCORER in cluster search (CSS) mode

### DIFF
--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -1148,7 +1148,7 @@ void SendSerializedDoc(const SerializedSearchDoc& doc, SinkReplyBuilder* builder
 
 template <typename T>
 void PartialSort(absl::Span<SerializedSearchDoc*> docs, size_t limit, SortOrder order,
-                 T SerializedSearchDoc::*field) {
+                 T SerializedSearchDoc::* field) {
   auto cb = [order, field](SerializedSearchDoc* l, SerializedSearchDoc* r) {
     return order == SortOrder::ASC ? l->*field < r->*field : r->*field < l->*field;
   };
@@ -2730,50 +2730,93 @@ void CmdFtList(CmdArgList args, CommandContext* cmd_cntx) {
   rb->SendBulkStrArr(names);
 }
 
-static vector<SearchResult> FtSearchCSS(std::string_view idx, std::string_view query,
-                                        std::string_view args_str, const SearchParams& params) {
-  vector<SearchResult> results;
-  const bool sorted = params.sort_option.has_value();
-  const std::string_view with_sortkeys = sorted && !params.with_sortkeys ? " WITHSORTKEYS"sv : ""sv;
-  std::string cmd = absl::StrCat("FT.SEARCH ", idx, " ", query, " CSS ", args_str, with_sortkeys);
+bool ParseFtSearchCSSResponse(const RESPObj& resp_obj, const SearchParams& params,
+                              SearchResult* result) {
+  RESPIterator it{resp_obj};
+  result->total_hits = it.Next<uint64_t>();
 
-  util::fb2::Mutex mu_;
-  auto req_future = cluster::Coordinator::Current().DispatchAll(cmd, [&](const RESPObj& resp_obj) {
-    RESPIterator it{resp_obj};
-    const auto size = it.Next<uint64_t>();
+  const bool read_scores = params.with_scores || params.scorer;
+  const bool read_sortkeys = params.sort_option.has_value() || params.with_sortkeys;
+  while (it.HasNext()) {
+    auto key = it.Next<std::string>();
+    if (it.HasError())
+      break;
 
-    std::lock_guard lock{mu_};
-    auto& res = results.emplace_back();
-    results.back().total_hits = size;
+    auto& search_doc = result->docs.emplace_back();
+    search_doc.key = std::move(key);
 
-    while (it.HasNext()) {
-      auto& search_doc = res.docs.emplace_back();
-      search_doc.key = it.Next<std::string>();
-      if (sorted) {
-        auto sort_score = it.Next<std::string_view>();
-        if (sort_score.empty() || (sort_score[0] != '#' && sort_score[0] != '$')) {
+    if (read_scores) {
+      double text_score = 0;
+      auto score = it.Next<std::string_view>();
+      if (it.HasError() || !ParseDouble(score, &text_score)) {
+        it.SetError();
+        break;
+      }
+      search_doc.text_score = static_cast<float>(text_score);
+    }
+
+    if (read_sortkeys) {
+      auto sort_obj = it.Next<RESPObj>();
+      if (it.HasError())
+        break;
+
+      if (sort_obj.GetType() != RESPObj::Type::NIL) {
+        auto sort_score = sort_obj.As<std::string_view>();
+        if (!sort_score || sort_score->empty() ||
+            ((*sort_score)[0] != '#' && (*sort_score)[0] != '$')) {
           it.SetError();
           break;
         }
-        if (sort_score[0] == '#') {  // It's a double
+
+        if ((*sort_score)[0] == '#') {  // It's a double
           double sort_res = 0;
-          if (ParseDouble(sort_score.substr(1), &sort_res)) {
+          if (ParseDouble(sort_score->substr(1), &sort_res)) {
             search_doc.sort_score = sort_res;
           } else {
             it.SetError();
             break;
           }
         } else {  // It's a string
-          search_doc.sort_score = std::string(sort_score.substr(1));
+          search_doc.sort_score = std::string(sort_score->substr(1));
         }
       }
+    }
 
-      for (auto arr_fields = it.Next<RESPIterator>(); arr_fields.HasNext();) {
+    if (!params.IdsOnly()) {
+      auto arr_fields = it.Next<RESPIterator>();
+      if (it.HasError())
+        break;
+
+      while (arr_fields.HasNext()) {
         auto [key, value] = arr_fields.Next<std::string, std::string>();
         search_doc.values.emplace(std::move(key), std::move(value));
       }
+      if (arr_fields.HasError()) {
+        it.SetError();
+        break;
+      }
     }
-    if (it.HasError()) {
+  }
+
+  return !it.HasError();
+}
+
+static vector<SearchResult> FtSearchCSS(std::string_view idx, std::string_view query,
+                                        std::string_view args_str, const SearchParams& params) {
+  vector<SearchResult> results;
+  const bool sorted = params.sort_option.has_value();
+  // SCORER needs hidden scores for coordinator-side merge ordering, even when the client did not
+  // request WITHSCORES in the final reply.
+  const std::string_view with_scores =
+      params.scorer && !params.with_scores ? " WITHSCORES"sv : ""sv;
+  const std::string_view with_sortkeys = sorted && !params.with_sortkeys ? " WITHSORTKEYS"sv : ""sv;
+  std::string cmd =
+      absl::StrCat("FT.SEARCH ", idx, " ", query, " CSS ", args_str, with_scores, with_sortkeys);
+
+  util::fb2::Mutex mu_;
+  auto req_future = cluster::Coordinator::Current().DispatchAll(cmd, [&](const RESPObj& resp_obj) {
+    std::lock_guard lock{mu_};
+    if (!ParseFtSearchCSSResponse(resp_obj, params, &results.emplace_back())) {
       LOG(ERROR) << "FT.SEARCH CSS reply parsing error: " << resp_obj;
     }
   });
@@ -2803,9 +2846,6 @@ void CmdFtSearch(CmdArgList args, CommandContext* cmd_cntx) {
 
   vector<SearchResult> css_docs;
   if (absl::GetFlag(FLAGS_cluster_search) && !is_cross_shard && IsClusterEnabled()) {
-    if (params->with_scores || params->scorer) {
-      return builder->SendError("WITHSCORES/SCORER is not yet supported in cluster search mode");
-    }
     std::string args_str = absl::StrJoin(args.subspan(2), " ");
 
     css_docs = FtSearchCSS(index_name, query_str, args_str, *params);

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -151,6 +151,9 @@ auto HybridDocFieldNames = [](const RespExpr& resp, size_t doc_idx) -> set<strin
 
 namespace dfly {
 
+bool ParseFtSearchCSSResponse(const facade::RESPObj& resp_obj, const SearchParams& params,
+                              SearchResult* result);
+
 class SearchFamilyTest : public BaseFamilyTest {
  protected:
   void CreateFlatHashIdx() {
@@ -4851,57 +4854,72 @@ TEST_F(SearchFamilyTest, KnnHnswIPDistanceCalculation) {
 }
 
 TEST_F(SearchFamilyTest, ParseCSSResponse) {
-  using Fields = std::map<std::string, std::string>;
-  using Docs = std::map<std::string, Fields>;
-
-  std::string msg1 =
-      "*17\r\n:8\r\n$2\r\ns0\r\n*2\r\n$5\r\ntitle\r\n$6\r\ntest "
-      "0\r\n$2\r\ns3\r\n*2\r\n$5\r\ntitle\r\n$6\r\ntest "
-      "3\r\n$2\r\ns7\r\n*2\r\n$5\r\ntitle\r\n$6\r\ntest "
-      "7\r\n$2\r\ns8\r\n*2\r\n$5\r\ntitle\r\n$6\r\ntest "
-      "8\r\n$2\r\ns4\r\n*2\r\n$5\r\ntitle\r\n$6\r\ntest "
-      "4\r\n$2\r\ns9\r\n*2\r\n$5\r\ntitle\r\n$6\r\ntest 9\r\n";
-
-  std::string msg2 =
-      "$2\r\ns1\r\n*2\r\n$5\r\ntitle\r\n$6\r\ntest "
-      "1\r\n$2\r\ns5\r\n*2\r\n$5\r\ntitle\r\n$6\r\ntest 5\r\n";
+  std::string msg =
+      "*5\r\n:2\r\n$2\r\ns0\r\n*2\r\n$5\r\ntitle\r\n$6\r\ntest "
+      "0\r\n$2\r\ns1\r\n*2\r\n$5\r\ntitle\r\n$6\r\ntest 1\r\n";
 
   RESPParser reader;
-  auto reply = reader.Feed(msg1.c_str(), msg1.size());
-  ASSERT_TRUE(reply->Empty());
-
-  reply = reader.Feed(msg2.c_str(), msg2.size());
+  auto reply = reader.Feed(msg.c_str(), msg.size());
   ASSERT_FALSE(reply->Empty());
 
-  EXPECT_EQ(reply->GetType(), RESPObj::Type::ARRAY);
-  auto array = *reply->As<RESPArray>();
-  EXPECT_GE(array.Size(), 1);
-  EXPECT_EQ(array[0].GetType(), RESPObj::Type::INTEGER);
+  SearchParams params;
+  SearchResult result;
+  ASSERT_TRUE(ParseFtSearchCSSResponse(*reply, params, &result));
 
-  Docs search_results;
-  for (size_t i = 1; i < array.Size(); i += 2) {
-    auto& fields = search_results[*array[i].As<std::string>()];
+  ASSERT_EQ(result.total_hits, 2u);
+  ASSERT_EQ(result.docs.size(), 2u);
+  EXPECT_EQ(result.docs[0].key, "s0");
+  EXPECT_EQ(std::get<std::string>(result.docs[0].values["title"]), "test 0");
+  EXPECT_EQ(result.docs[1].key, "s1");
+  EXPECT_EQ(std::get<std::string>(result.docs[1].values["title"]), "test 1");
+}
 
-    auto field_array = *array[i + 1].As<RESPArray>();
+TEST_F(SearchFamilyTest, ParseCSSResponseWithScores) {
+  std::string msg =
+      "*9\r\n:2\r\n$3\r\nd:a\r\n$3\r\n1.5\r\n$3\r\n#10\r\n*2\r\n$5\r\ntitle\r\n$5\r\nalpha\r\n"
+      "$3\r\nd:b\r\n$3\r\n0.7\r\n$5\r\n$beta\r\n*2\r\n$5\r\ntitle\r\n$4\r\nbeta\r\n";
 
-    for (size_t j = 0; j < field_array.Size(); j += 2) {
-      std::string field_name = *field_array[j].As<std::string>();
-      std::string field_value = *field_array[j + 1].As<std::string>();
+  RESPParser reader;
+  auto reply = reader.Feed(msg.c_str(), msg.size());
+  ASSERT_FALSE(reply->Empty());
 
-      fields[field_name] = field_value;
-    }
-  }
+  SearchParams params;
+  params.with_scores = true;
+  params.sort_option = SearchParams::SortOption{FieldReference{"age"}, SortOrder::ASC};
+  SearchResult result;
+  ASSERT_TRUE(ParseFtSearchCSSResponse(*reply, params, &result));
 
-  EXPECT_EQ(search_results.size(), 8);
+  ASSERT_EQ(result.total_hits, 2u);
+  ASSERT_EQ(result.docs.size(), 2u);
 
-  EXPECT_EQ(search_results["s0"]["title"], "test 0");
-  EXPECT_EQ(search_results["s1"]["title"], "test 1");
-  EXPECT_EQ(search_results["s3"]["title"], "test 3");
-  EXPECT_EQ(search_results["s4"]["title"], "test 4");
-  EXPECT_EQ(search_results["s5"]["title"], "test 5");
-  EXPECT_EQ(search_results["s7"]["title"], "test 7");
-  EXPECT_EQ(search_results["s8"]["title"], "test 8");
-  EXPECT_EQ(search_results["s9"]["title"], "test 9");
+  EXPECT_EQ(result.docs[0].key, "d:a");
+  EXPECT_FLOAT_EQ(result.docs[0].text_score, 1.5f);
+  EXPECT_EQ(std::get<double>(result.docs[0].sort_score), 10);
+  EXPECT_EQ(std::get<std::string>(result.docs[0].values["title"]), "alpha");
+
+  EXPECT_EQ(result.docs[1].key, "d:b");
+  EXPECT_FLOAT_EQ(result.docs[1].text_score, 0.7f);
+  EXPECT_EQ(std::get<std::string>(result.docs[1].sort_score), "beta");
+  EXPECT_EQ(std::get<std::string>(result.docs[1].values["title"]), "beta");
+}
+
+TEST_F(SearchFamilyTest, ParseCSSResponseWithScorerOnly) {
+  std::string msg =
+      "*7\r\n:2\r\n$3\r\nd:a\r\n$3\r\n1.5\r\n*2\r\n$5\r\ntitle\r\n$5\r\nalpha\r\n"
+      "$3\r\nd:b\r\n$3\r\n0.7\r\n*2\r\n$5\r\ntitle\r\n$4\r\nbeta\r\n";
+
+  RESPParser reader;
+  auto reply = reader.Feed(msg.c_str(), msg.size());
+  ASSERT_FALSE(reply->Empty());
+
+  SearchParams params;
+  params.scorer = &search::BM25Std;
+  SearchResult result;
+  ASSERT_TRUE(ParseFtSearchCSSResponse(*reply, params, &result));
+
+  ASSERT_EQ(result.docs.size(), 2u);
+  EXPECT_FLOAT_EQ(result.docs[0].text_score, 1.5f);
+  EXPECT_FLOAT_EQ(result.docs[1].text_score, 0.7f);
 }
 
 TEST_F(SearchFamilyTest, WithSortKeysOption) {

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -3522,6 +3522,73 @@ async def test_SortedSearchRequest(df_factory: DflyInstanceFactory):
     await asyncio.gather(*(search_test() for _ in range(2)))
 
 
+@dfly_args({"proactor_threads": 4, "cluster_mode": "yes", "cluster_search": "yes"})
+async def test_SearchWithScoresRequest(df_factory: DflyInstanceFactory):
+    """
+    Create cluster of 3 nodes.
+    Execute Search request with scores on documents spread across the cluster.
+    """
+
+    _, nodes = await create_cluster(
+        df_factory, 3, vmodule="coordinator=2,search_family=3,protocol_client=3"
+    )
+    nodes[0].slots = [(0, 5259)]
+    nodes[1].slots = [(5260, 10519)]
+    nodes[2].slots = [(10520, 16383)]
+
+    await apply_config(nodes)
+
+    assert (
+        await nodes[0].client.execute_command(
+            "FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "title", "TEXT"
+        )
+        == "OK"
+    )
+
+    for node in nodes:
+        await wait_for_ft_index_creation(node.client, "idx")
+
+    def key_for_node(prefix, node):
+        for i in itertools.count():
+            key = f"{prefix}:{i}"
+            if any(start <= key_slot(key) <= end for start, end in node.slots):
+                return key
+
+    docs = [
+        (nodes[0], key_for_node("score-rich", nodes[0]), "hello hello hello"),
+        (nodes[1], key_for_node("score-mid", nodes[1]), "hello hello"),
+        (nodes[2], key_for_node("score-plain", nodes[2]), "hello"),
+    ]
+
+    for node, key, title in docs:
+        assert await node.client.execute_command("HSET", key, "title", title) == 1
+
+    with_scores = await nodes[0].client.execute_command(
+        "FT.SEARCH", "idx", "hello", "WITHSCORES", "RETURN", "1", "title", "LIMIT", "0", "10"
+    )
+    assert with_scores[0] == len(docs)
+
+    score_by_key = {}
+    keys_by_score = []
+    for i in range(1, len(with_scores), 3):
+        key = with_scores[i]
+        score = float(with_scores[i + 1])
+        fields = dict(zip(with_scores[i + 2][0::2], with_scores[i + 2][1::2]))
+        assert fields["title"] in {title for _, _, title in docs}
+        assert score > 0
+        score_by_key[key] = score
+        keys_by_score.append(key)
+
+    assert set(score_by_key) == {key for _, key, _ in docs}
+    assert keys_by_score == sorted(keys_by_score, key=lambda key: (-score_by_key[key], key))
+
+    scorer_only = await nodes[0].client.execute_command(
+        "FT.SEARCH", "idx", "hello", "SCORER", "BM25STD", "RETURN", "1", "title", "LIMIT", "0", "10"
+    )
+    assert scorer_only[0] == len(docs)
+    assert [scorer_only[i] for i in range(1, len(scorer_only), 2)] == keys_by_score
+
+
 async def verify_keys_match_number_of_index_docs(client, expected_num_keys):
     # Get number of docs in index
     index_info = await client.execute_command("FT.INFO idx")


### PR DESCRIPTION
## Summary
Cluster single-shard search (CSS) errored on `WITHSCORES` / `SCORER`. This parses the score and sortkey fields out of each shard's sub-search response so cluster search returns scores the same way non-cluster search does.

## Changes
Replace the inline CSS response handler with `ParseFtSearchCSSResponse`, which reads `total_hits`, then per-doc reads the key plus (conditionally) the score and sortkey depending on `with_scores`/`scorer`/`sort_option`/`with_sortkeys`.

## Testing
Added cluster-search WITHSCORES coverage in `search_family_test.cc` and `tests/dragonfly/cluster_test.py`.

Fixes #7182

AI was used for assistance.
