### PR TITLE
refactor(facade): add OnRecvNotification helper & suppress spurious wakeups

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -825,11 +825,8 @@ void Connection::OnPostMigrateThread() {
 
   if (ioloop_v2_ && socket_ && socket_->IsOpen() && migration_allowed_to_register_) {
     MaybeEnableRecvMultishot();
-    socket_->RegisterOnRecv([this](const FiberSocketBase::RecvNotification& n) {
-      NotifyOnRecv(n);
-      ReadPendingInput();
-      io_event_.notify();
-    });
+    socket_->RegisterOnRecv(
+        [this](const FiberSocketBase::RecvNotification& n) { OnRecvNotification(n); });
   }
 
   migration_in_process_ = false;
@@ -3031,6 +3028,21 @@ bool ConnectionRef::operator==(const ConnectionRef& other) const {
   return client_id_ == other.client_id_;
 }
 
+void Connection::OnRecvNotification(const util::FiberSocketBase::RecvNotification& n) {
+  DVLOG(2) << "OnRecvNotification iobuf_len: " << io_buf_.InputLen();
+  size_t input_before = io_buf_.InputLen();
+  NotifyOnRecv(n);
+  // Eagerly drain the socket while the fiber is suspended to prevent receive buffer starvation.
+  ReadPendingInput();
+  // Both epoll and io_uring poll can deliver spurious POLLIN completions where the subsequent
+  // recv() returns EAGAIN (no actual data). HasNetworkEvent() filters these out so the spurious
+  // proactor wakeup is not propagated as a spurious fiber wakeup: if nothing changed (no error,
+  // no new bytes, no pending input remaining) waking the fiber is wasteful — it would only
+  // re-evaluate ShouldWakeIdle(), find it false, and immediately re-park.
+  if (HasNetworkEvent(input_before))
+    io_event_.notify();
+}
+
 void Connection::NotifyOnRecv(const util::FiberSocketBase::RecvNotification& n) {
   if (std::holds_alternative<std::error_code>(n.read_result)) {
     io_ec_ = std::get<std::error_code>(n.read_result);
@@ -3286,15 +3298,8 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
 
   MaybeEnableRecvMultishot();
 
-  peer->RegisterOnRecv([this](const FiberSocketBase::RecvNotification& n) {
-    DVLOG(2) << "Calling DoReadOnRecv iobuf_len: " << io_buf_.InputLen();
-    NotifyOnRecv(n);
-    // Eagerly drain the kernel TCP receive buffer while the connection fiber might be is
-    // blocked/busy. This prevents rbuf starvation (V2's single fiber can't read while executing).
-    // Safe: callback only fires when the fiber has yielded - no concurrent access to io_buf_.
-    ReadPendingInput();
-    io_event_.notify();
-  });
+  peer->RegisterOnRecv(
+      [this](const FiberSocketBase::RecvNotification& n) { OnRecvNotification(n); });
 
   ParserStatus parse_status = OK;
 

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -355,6 +355,12 @@ class Connection : public util::Connection {
 
   void NotifyOnRecv(const util::FiberSocketBase::RecvNotification& n);
 
+  // Registered as the proactor OnRecv hook for V2 connections. Processes the notification,
+  // eagerly drains the socket into io_buf_, and wakes the fiber if actionable input arrived.
+  // Suppresses spurious wakeups when no new data was harvested.
+  // Only called from the proactor event loop while the connection fiber is suspended.
+  void OnRecvNotification(const util::FiberSocketBase::RecvNotification& n);
+
   // Enables io_uring multishot receives for the connection if the current thread supports it.
   // This is required during initial setup or after migrating to a new thread/proactor,
   // provided the buffer ring is configured and the connection is not using TLS.
@@ -610,6 +616,13 @@ class Connection : public util::Connection {
   // Returns true if the head command is ready to execute (nothing in-flight ahead of it).
   bool HasCommandToExecute() const {
     return parsed_head_ && !HasInFlightCommands();
+  }
+
+  // Returns true if a network completion produced actionable input: a socket error, pending data,
+  // or newly buffered bytes relative to input_before_len. Used to suppress spurious fiber wakeups
+  // from completions that harvested nothing.
+  bool HasNetworkEvent(size_t input_before_len) const {
+    return io_ec_ || pending_input_ || (io_buf_.InputLen() != input_before_len);
   }
 
   // Returns true if there are any commands pending in the parsed command queue or dispatch queue.


### PR DESCRIPTION
- Merge the two identical RegisterOnRecv lambdas in IoLoopV2 and OnPostMigrateThread by extracting their body into a new private OnRecvNotification() method.

- Adds HasNetworkEvent() to guard io_event_.notify(): the callback now skips the wakeup when the completion harvested nothing (no error, no pending data, no newly buffered bytes), avoiding a spurious wake that would just re-park on ShouldWakeIdle().
