### PR TITLE
fix(facade): count multishot recv in io read stats

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -3052,6 +3052,14 @@ void Connection::NotifyOnRecv(const util::FiberSocketBase::RecvNotification& n) 
       io_buf_.WriteAndCommit(buf.data(), buf.size());
     }
     last_interaction_ = time(nullptr);
+
+    DCHECK(tl_facade_stats);
+    auto& conn_stats = tl_facade_stats->conn_stats;
+    conn_stats.io_read_bytes += buf.size();
+    local_stats_.net_bytes_in += buf.size();
+    ++conn_stats.io_read_cnt;
+    ++local_stats_.read_cnt;
+    ++conn_stats.num_recv_provided_calls;
   } else {
     LOG(FATAL) << "Should not reach here";
   }


### PR DESCRIPTION
The multishot provided-buffer branch of NotifyOnRecv write bytes into io_buf_ but never updated the read counters. This cause net_input_recv_total and net_input_bytes_total to undercount whenever io_uring multishot recv is active (--uring_recv_buffer_cnt > 0).

Also wires num_recv_provided_calls, which was declared and exposed in INFO as connection_recv_provided_calls but always read 0.
