### PR TITLE
CI: generate and upload junit artifacts

### DIFF
--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -98,10 +98,7 @@ runs:
           FILTER="all"
         fi
 
-        SAFE_FILTER=$(printf '%s' "${FILTER}" | tr -c 'A-Za-z0-9._-' '-' | sed -E 's/-+/-/g; s/^-//; s/-$//')
-        if [[ -z "${SAFE_FILTER}" ]]; then
-          SAFE_FILTER="all"
-        fi
+        SAFE_FILTER=$("${GITHUB_WORKSPACE}/.github/scripts/sanitize-token.sh" "${FILTER}" all)
 
         UNIQUE_SUFFIX="$(date +%s%N)-${RANDOM}"
         {

--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -37,7 +37,7 @@ inputs:
     default: us-east-1
     description: "AWS region for S3 JUnit XML uploads"
   s3-bucket:
-    required: true
+    required: false
     type: string
     description: "S3 bucket for Dragonfly snapshot tests; when empty, the S3 snapshot tests are skipped"
   junit-s3-bucket:

--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -27,9 +27,23 @@ inputs:
     required: false
     type: string
     description: "AWS secret access key (optional if using OIDC - credentials set by workflow)"
+  aws-role-to-assume:
+    required: false
+    type: string
+    description: "AWS role ARN to assume before uploading JUnit XML to S3"
+  aws-region:
+    required: false
+    type: string
+    default: us-east-1
+    description: "AWS region for S3 JUnit XML uploads"
   s3-bucket:
     required: true
     type: string
+    description: "S3 bucket for Dragonfly snapshot tests; when empty, the S3 snapshot tests are skipped"
+  junit-s3-bucket:
+    required: false
+    type: string
+    description: "S3 bucket for JUnit XML uploads"
   azure-container:
     required: false
     type: string
@@ -67,6 +81,36 @@ runs:
       shell: bash
       run: ${GITHUB_WORKSPACE}/.github/scripts/install-pytest-requirements.sh
 
+    - name: Prepare regression JUnit environment
+      if: always()
+      shell: bash
+      run: |
+        JUNIT_DIR="${GITHUB_WORKSPACE}/test-results/junit/regression"
+        mkdir -p "${JUNIT_DIR}"
+
+        KIND="iouring"
+        if [[ "${{inputs.epoll}}" == 'epoll' ]]; then
+          KIND="epoll"
+        fi
+
+        FILTER="${{inputs.filter}}"
+        if [[ -z "${FILTER}" ]]; then
+          FILTER="all"
+        fi
+
+        SAFE_FILTER=$(printf '%s' "${FILTER}" | tr -c 'A-Za-z0-9._-' '-' | sed -E 's/-+/-/g; s/^-//; s/-$//')
+        if [[ -z "${SAFE_FILTER}" ]]; then
+          SAFE_FILTER="all"
+        fi
+
+        UNIQUE_SUFFIX="$(date +%s%N)-${RANDOM}"
+        {
+          echo "REGRESSION_JUNIT_DIR=${JUNIT_DIR}"
+          echo "REGRESSION_JUNIT_KIND=${KIND}"
+          echo "REGRESSION_JUNIT_S3_SUFFIX=${RUNNER_OS}-${RUNNER_ARCH}-${KIND}-${FILTER}"
+          echo "REGRESSION_JUNIT_ARTIFACT=junit-regression-${GITHUB_JOB}-${RUNNER_OS}-${RUNNER_ARCH}-${KIND}-${SAFE_FILTER}-${UNIQUE_SUFFIX}"
+        } >> "${GITHUB_ENV}"
+
     - name: Run S3 snapshot tests with MinIO
       if: inputs.s3-bucket != ''
       shell: bash
@@ -91,6 +135,7 @@ runs:
         export ROOT_DIR="${GITHUB_WORKSPACE}/tests/dragonfly/valkey_search"
         export UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 # to crash on errors
         export FILTER="${{inputs.filter}}"
+        JUNIT_DIR="${REGRESSION_JUNIT_DIR}"
 
         # Exclude large tests unless explicitly requested
         if [[ "$FILTER" == "large" ]]; then
@@ -101,13 +146,19 @@ runs:
           FILTER="not large"
         fi
 
-        if [[ "${{inputs.epoll}}" == 'epoll' ]]; then
+        if [[ "${REGRESSION_JUNIT_KIND}" == 'epoll' ]]; then
           FILTER="$FILTER and not exclude_epoll"
           # Run only replication tests with epoll
-          timeout 80m pytest -m "$FILTER" --durations=10 --timeout=300 --color=yes --json-report --json-report-file=report.json dragonfly --df force_epoll=true --log-cli-level=INFO || code=$?
+          timeout 80m pytest -m "$FILTER" --durations=10 --timeout=300 --color=yes \
+            --json-report --json-report-file=report.json \
+            --junitxml="${JUNIT_DIR}/pytest-${REGRESSION_JUNIT_KIND}.xml" \
+            dragonfly --df force_epoll=true --log-cli-level=INFO || code=$?
         else
           # Run only replication tests with iouring
-          timeout 80m pytest -m "$FILTER" --durations=10 --timeout=300 --color=yes --json-report --json-report-file=report.json dragonfly --log-cli-level=INFO || code=$?
+          timeout 80m pytest -m "$FILTER" --durations=10 --timeout=300 --color=yes \
+            --json-report --json-report-file=report.json \
+            --junitxml="${JUNIT_DIR}/pytest-${REGRESSION_JUNIT_KIND}.xml" \
+            dragonfly --log-cli-level=INFO || code=$?
         fi
 
         # timeout returns 124 if we exceeded the timeout duration
@@ -138,6 +189,30 @@ runs:
         # Azure credentials for snapshot tests (optional)
         DRAGONFLY_AZURE_CONTAINER: ${{ inputs.azure-container }}
         AZURE_STORAGE_CONNECTION_STRING: ${{ inputs.azure-storage-connection-string }}
+
+    - name: Upload regression JUnit results
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ env.REGRESSION_JUNIT_ARTIFACT }}
+        path: ${{ github.workspace }}/test-results/junit/regression/**/*.xml
+        if-no-files-found: ignore
+
+    - name: Refresh AWS credentials for regression JUnit upload
+      if: always() && inputs.junit-s3-bucket != '' && inputs.aws-role-to-assume != ''
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: ${{ inputs.aws-role-to-assume }}
+        aws-region: ${{ inputs.aws-region }}
+        unset-current-credentials: true
+
+    - name: Upload regression JUnit results to S3
+      if: always() && inputs.junit-s3-bucket != '' && inputs.aws-role-to-assume != ''
+      shell: bash
+      run: |
+        "${GITHUB_WORKSPACE}/.github/scripts/upload-junit-to-s3.sh" \
+          "${REGRESSION_JUNIT_DIR}" "${{ inputs.junit-s3-bucket }}" "regression" \
+          "${REGRESSION_JUNIT_S3_SUFFIX}" "regression JUnit"
 
     - name: Send notification on failure
       if: failure() && github.ref == 'refs/heads/main'

--- a/.github/scripts/sanitize-token.sh
+++ b/.github/scripts/sanitize-token.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Sanitize a string into a token safe for use in S3 key components and GitHub
+# artifact names: replace every character outside [A-Za-z0-9._-] with '-',
+# collapse repeated '-', and trim leading/trailing '-'. Falls back to $2
+# (default "unknown") when the sanitized result is empty.
+#
+# Usage: sanitize-token.sh <value> [fallback]
+
+set -eu
+
+VALUE=$(printf '%s' "${1:-}" | tr -c 'A-Za-z0-9._-' '-' | sed 's/--*/-/g; s/^-//; s/-$//')
+printf '%s' "${VALUE:-${2:-unknown}}"

--- a/.github/scripts/upload-junit-to-s3.sh
+++ b/.github/scripts/upload-junit-to-s3.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+set -eu
+
+source_dir=${1:?source directory is required}
+bucket=${2:-}
+suite=${3:?JUnit suite name is required}
+suffix=${4:?JUnit upload suffix is required}
+label=${5:-JUnit}
+
+sanitize() {
+  value=$(printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '-' | sed 's/--*/-/g; s/^-//; s/-$//')
+  if [ -n "$value" ]; then
+    printf '%s' "$value"
+  else
+    printf 'unknown'
+  fi
+}
+
+if [ -z "$bucket" ]; then
+  echo "S3 bucket is empty; skipping $label upload"
+  exit 0
+fi
+
+if [ ! -d "$source_dir" ] || ! find "$source_dir" -type f -name '*.xml' -print -quit | grep -q .; then
+  echo "No $label XML files found under $source_dir; skipping S3 upload"
+  exit 0
+fi
+
+if ! command -v aws >/dev/null 2>&1; then
+  pip3 install --break-system-packages awscli
+fi
+
+safe_suite=$(sanitize "$suite")
+safe_workflow=$(sanitize "${GITHUB_WORKFLOW:-unknown-workflow}")
+safe_job=$(sanitize "${GITHUB_JOB:-unknown-job}")
+safe_suffix=$(sanitize "$suffix")
+upload_year=$(date -u +%Y)
+upload_month=$(date -u +%m)
+upload_day=$(date -u +%d)
+prefix="test-results/junit/$safe_suite/year=$upload_year/month=$upload_month/day=$upload_day/$safe_workflow/${GITHUB_RUN_ID:-unknown-run}/${GITHUB_RUN_ATTEMPT:-1}/$safe_job/$safe_suffix"
+dest="s3://$bucket/$prefix/"
+
+echo "Uploading $label XML files from $source_dir to $dest"
+aws s3 sync "$source_dir/" "$dest" --exclude "*" --include "*.xml"

--- a/.github/scripts/upload-junit-to-s3.sh
+++ b/.github/scripts/upload-junit-to-s3.sh
@@ -2,28 +2,25 @@
 
 set -eu
 
-source_dir=${1:?source directory is required}
-bucket=${2:-}
-suite=${3:?JUnit suite name is required}
-suffix=${4:?JUnit upload suffix is required}
-label=${5:-JUnit}
+SOURCE_DIR=${1:?source directory is required}
+BUCKET=${2:-}
+TEST_SUITE=${3:?JUnit TEST_SUITE name is required}
+UPLOAD_SUFFIX=${4:?JUnit upload UPLOAD_SUFFIX is required}
+LABEL=${5:-JUnit}
+
+SCRIPT_DIR=$(dirname "$0")
 
 sanitize() {
-  value=$(printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '-' | sed 's/--*/-/g; s/^-//; s/-$//')
-  if [ -n "$value" ]; then
-    printf '%s' "$value"
-  else
-    printf 'unknown'
-  fi
+  "$SCRIPT_DIR/sanitize-token.sh" "$1"
 }
 
-if [ -z "$bucket" ]; then
-  echo "S3 bucket is empty; skipping $label upload"
+if [ -z "$BUCKET" ]; then
+  echo "S3 BUCKET is empty; skipping $LABEL upload"
   exit 0
 fi
 
-if [ ! -d "$source_dir" ] || ! find "$source_dir" -type f -name '*.xml' -print -quit | grep -q .; then
-  echo "No $label XML files found under $source_dir; skipping S3 upload"
+if [ ! -d "$SOURCE_DIR" ] || ! find "$SOURCE_DIR" -type f -name '*.xml' -print -quit | grep -q .; then
+  echo "No $LABEL XML files found under $SOURCE_DIR; skipping S3 upload"
   exit 0
 fi
 
@@ -31,15 +28,15 @@ if ! command -v aws >/dev/null 2>&1; then
   pip3 install --break-system-packages awscli
 fi
 
-safe_suite=$(sanitize "$suite")
-safe_workflow=$(sanitize "${GITHUB_WORKFLOW:-unknown-workflow}")
-safe_job=$(sanitize "${GITHUB_JOB:-unknown-job}")
-safe_suffix=$(sanitize "$suffix")
-upload_year=$(date -u +%Y)
-upload_month=$(date -u +%m)
-upload_day=$(date -u +%d)
-prefix="test-results/junit/$safe_suite/year=$upload_year/month=$upload_month/day=$upload_day/$safe_workflow/${GITHUB_RUN_ID:-unknown-run}/${GITHUB_RUN_ATTEMPT:-1}/$safe_job/$safe_suffix"
-dest="s3://$bucket/$prefix/"
+SAFE_SUITE=$(sanitize "$TEST_SUITE")
+SAFE_WORKFLOW=$(sanitize "${GITHUB_WORKFLOW:-unknown-workflow}")
+SAFE_JOB=$(sanitize "${GITHUB_JOB:-unknown-job}")
+SAFE_SUFFIX=$(sanitize "$UPLOAD_SUFFIX")
+UPLOAD_YEAR=$(date -u +%Y)
+UPLOAD_MONTH=$(date -u +%m)
+UPLOAD_DAY=$(date -u +%d)
+PREFIX="test-results/junit/$SAFE_SUITE/year=$UPLOAD_YEAR/month=$UPLOAD_MONTH/day=$UPLOAD_DAY/$SAFE_WORKFLOW/${GITHUB_RUN_ID:-unknown-run}/${GITHUB_RUN_ATTEMPT:-1}/$SAFE_JOB/$SAFE_SUFFIX"
+DEST="s3://$BUCKET/$PREFIX/"
 
-echo "Uploading $label XML files from $source_dir to $dest"
-aws s3 sync "$source_dir/" "$dest" --exclude "*" --include "*.xml"
+echo "Uploading $LABEL XML files from $SOURCE_DIR to $DEST"
+aws s3 sync "$SOURCE_DIR/" "$DEST" --exclude "*" --include "*.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,12 +239,13 @@ jobs:
           SAFE_NAME=$("${GITHUB_WORKSPACE}/.github/scripts/sanitize-token.sh" "${NAME}")
           echo "CI_JUNIT_ARTIFACT=${SAFE_NAME}" >> "${GITHUB_ENV}"
 
-      - name: Upload JUnit test results
+      - name: Upload C++ JUnit test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: ${{ env.CI_JUNIT_ARTIFACT }}
-          path: ${{ github.workspace }}/test-results/junit/**/*.xml
+          # Scope to cpp/ only: regression XMLs are uploaded by the regression action itself.
+          path: ${{ github.workspace }}/test-results/junit/cpp/**/*.xml
           if-no-files-found: ignore
 
       - name: Refresh AWS credentials for C++ JUnit upload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
         if: always()
         run: |
           NAME="junit-ci-${{ matrix.container }}-${{ matrix.build-type }}-${{ matrix.compiler.cxx }}-${{ matrix.sanitizers }}"
-          SAFE_NAME=$(printf '%s' "${NAME}" | tr -c 'A-Za-z0-9._-' '-' | sed -E 's/-+/-/g; s/^-//; s/-$//')
+          SAFE_NAME=$("${GITHUB_WORKSPACE}/.github/scripts/sanitize-token.sh" "${NAME}")
           echo "CI_JUNIT_ARTIFACT=${SAFE_NAME}" >> "${GITHUB_ENV}"
 
       - name: Upload JUnit test results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,14 @@ jobs:
             --from-ref ${{ github.event.pull_request.base.sha }}
             --to-ref ${{ github.event.pull_request.head.sha }}
   build:
+    permissions:
+      contents: read
+      id-token: write
+      packages: read
+
+    env:
+      CPP_JUNIT_DIR: ${{ github.workspace }}/test-results/junit/cpp
+
     strategy:
       matrix:
         # Test of these containers
@@ -120,23 +128,40 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/build
           echo Run ctest -V -L DFLY
+          JUNIT_DIR="${CPP_JUNIT_DIR}"
+          CTEST_JUNIT_DIR="${JUNIT_DIR}/ctest"
+          GTEST_IOURING_DIR="${JUNIT_DIR}/gtest/iouring"
+          GTEST_MANUAL_DIR="${JUNIT_DIR}/gtest/iouring-manual"
+          mkdir -p "${CTEST_JUNIT_DIR}" "${GTEST_IOURING_DIR}" "${GTEST_MANUAL_DIR}"
 
+          run_manual_gtest() {
+            GTEST_OUTPUT="xml:${GTEST_MANUAL_DIR}/" timeout 5m "$@"
+          }
+
+          GTEST_OUTPUT="xml:${GTEST_IOURING_DIR}/" \
           GLOG_alsologtostderr=1 GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1,op_manager=1,op_manager_test=1 \
-          FLAGS_fiber_safety_margin=4096 timeout 20m ctest -V -L DFLY -E allocation_tracker_test
+          FLAGS_fiber_safety_margin=4096 timeout 20m ctest -V -L DFLY -E allocation_tracker_test \
+            --output-junit "${CTEST_JUNIT_DIR}/iouring.xml"
 
           # Run allocation tracker test separately without alsologtostderr because it generates a TON of logs.
-          FLAGS_fiber_safety_margin=4096 timeout 5m ./allocation_tracker_test
+          GTEST_OUTPUT="xml:${GTEST_MANUAL_DIR}/" FLAGS_fiber_safety_margin=4096 \
+            timeout 5m ./allocation_tracker_test
 
-          timeout 5m ./dragonfly_test
-          timeout 5m ./json_family_test --jsonpathv2=false
-          timeout 5m ./tiered_storage_test --vmodule=db_slice=2 --logtostderr
-          timeout 5m ./search_test --use_numeric_range_tree=false
-          timeout 5m ./search_family_test --use_numeric_range_tree=false
+          run_manual_gtest ./dragonfly_test
+          run_manual_gtest ./json_family_test --jsonpathv2=false
+          run_manual_gtest ./tiered_storage_test --vmodule=db_slice=2 --logtostderr
+          run_manual_gtest ./search_test --use_numeric_range_tree=false
+          run_manual_gtest ./search_family_test --use_numeric_range_tree=false
 
 
       - name: C++ Unit Tests - Epoll
         run: |
           cd ${GITHUB_WORKSPACE}/build
+          JUNIT_DIR="${CPP_JUNIT_DIR}"
+          CTEST_JUNIT_DIR="${JUNIT_DIR}/ctest"
+          GTEST_EPOLL_DIR="${JUNIT_DIR}/gtest/epoll"
+          GTEST_MANUAL_DIR="${JUNIT_DIR}/gtest/epoll-manual"
+          mkdir -p "${CTEST_JUNIT_DIR}" "${GTEST_EPOLL_DIR}" "${GTEST_MANUAL_DIR}"
 
           # Create a rule that automatically prints stacktrace upon segfault
           cat > ./init.gdb <<EOF
@@ -146,21 +171,37 @@ jobs:
           end
           EOF
 
-          gdb -ix ./init.gdb --batch -ex r --args ./dragonfly_test --force_epoll
+          GTEST_OUTPUT="xml:${GTEST_MANUAL_DIR}/" \
+            gdb -ix ./init.gdb --batch -ex r --args ./dragonfly_test --force_epoll
+          GTEST_OUTPUT="xml:${GTEST_EPOLL_DIR}/" \
           GLOG_alsologtostderr=1 FLAGS_fiber_safety_margin=4096 FLAGS_force_epoll=true GLOG_vmodule=rdb_load=1,rdb_save=1,snapshot=1 \
-          timeout 20m ctest -V -L DFLY -E allocation_tracker_test
+          timeout 20m ctest -V -L DFLY -E allocation_tracker_test \
+            --output-junit "${CTEST_JUNIT_DIR}/epoll.xml"
 
-          FLAGS_fiber_safety_margin=4096 FLAGS_force_epoll=true timeout 5m ./allocation_tracker_test
+          GTEST_OUTPUT="xml:${GTEST_MANUAL_DIR}/" FLAGS_fiber_safety_margin=4096 \
+            FLAGS_force_epoll=true timeout 5m ./allocation_tracker_test
 
       - name: C++ Unit Tests - IoUring with cluster mode
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          FLAGS_fiber_safety_margin=4096 FLAGS_cluster_mode=emulated timeout 20m ctest -V -L DFLY
+          JUNIT_DIR="${CPP_JUNIT_DIR}"
+          CTEST_JUNIT_DIR="${JUNIT_DIR}/ctest"
+          GTEST_CLUSTER_DIR="${JUNIT_DIR}/gtest/cluster"
+          mkdir -p "${CTEST_JUNIT_DIR}" "${GTEST_CLUSTER_DIR}"
+          GTEST_OUTPUT="xml:${GTEST_CLUSTER_DIR}/" FLAGS_fiber_safety_margin=4096 \
+            FLAGS_cluster_mode=emulated timeout 20m ctest -V -L DFLY \
+            --output-junit "${CTEST_JUNIT_DIR}/cluster.xml"
 
       - name: C++ Unit Tests - IoUring with cluster mode and FLAGS_lock_on_hashtags
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          FLAGS_fiber_safety_margin=4096 FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true timeout 20m ctest -V -L DFLY
+          JUNIT_DIR="${CPP_JUNIT_DIR}"
+          CTEST_JUNIT_DIR="${JUNIT_DIR}/ctest"
+          GTEST_CLUSTER_DIR="${JUNIT_DIR}/gtest/cluster-hashtags"
+          mkdir -p "${CTEST_JUNIT_DIR}" "${GTEST_CLUSTER_DIR}"
+          GTEST_OUTPUT="xml:${GTEST_CLUSTER_DIR}/" FLAGS_fiber_safety_margin=4096 \
+            FLAGS_cluster_mode=emulated FLAGS_lock_on_hashtags=true timeout 20m ctest -V -L DFLY \
+            --output-junit "${CTEST_JUNIT_DIR}/cluster-hashtags.xml"
 
       - name: Upload unit logs on failure
         if: failure()
@@ -179,6 +220,8 @@ jobs:
           # Non-release build will not run tests marked as opt_only
           # "not empty" string is needed for release build because pytest command can not get empty string for filter
           filter: ${{ matrix.build-type == 'Release' && 'not debug_only' || 'not opt_only' }}
+          junit-s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}
+          aws-role-to-assume: ${{ secrets.AWS_CI_S3_ROLE_ARN }}
           azure-container: ${{ secrets.AZURE_REGTEST_CONTAINER }}
           azure-storage-connection-string: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}
 
@@ -188,6 +231,40 @@ jobs:
         with:
           name: regression_logs
           path: /tmp/failed/*
+
+      - name: Prepare JUnit artifact name
+        if: always()
+        run: |
+          NAME="junit-ci-${{ matrix.container }}-${{ matrix.build-type }}-${{ matrix.compiler.cxx }}-${{ matrix.sanitizers }}"
+          SAFE_NAME=$(printf '%s' "${NAME}" | tr -c 'A-Za-z0-9._-' '-' | sed -E 's/-+/-/g; s/^-//; s/-$//')
+          echo "CI_JUNIT_ARTIFACT=${SAFE_NAME}" >> "${GITHUB_ENV}"
+
+      - name: Upload JUnit test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.CI_JUNIT_ARTIFACT }}
+          path: ${{ github.workspace }}/test-results/junit/**/*.xml
+          if-no-files-found: ignore
+
+      - name: Refresh AWS credentials for C++ JUnit upload
+        if: always() && github.repository_owner == 'dragonflydb' && github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_CI_S3_ROLE_ARN }}
+          aws-region: us-east-1
+          unset-current-credentials: true
+
+      - name: Upload C++ JUnit results to S3
+        if: always() && github.repository_owner == 'dragonflydb' && github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        env:
+          S3_REGTEST_BUCKET: ${{ secrets.S3_REGTEST_BUCKET }}
+        run: |
+          JUNIT_DIR="${CPP_JUNIT_DIR}"
+          MATRIX_NAME="container-${{ matrix.container }}-build-${{ matrix.build-type }}-compiler-${{ matrix.compiler.cxx }}-sanitizers-${{ matrix.sanitizers }}"
+
+          "${GITHUB_WORKSPACE}/.github/scripts/upload-junit-to-s3.sh" \
+            "${JUNIT_DIR}" "${S3_REGTEST_BUCKET}" "cpp" "${MATRIX_NAME}" "C++ JUnit"
 
       - name: Upload dragonfly binary for cgroup test
         if: matrix.container == 'ubuntu-dev:24' && matrix.build-type == 'Release' && matrix.sanitizers == 'NoSanitizers' && matrix.compiler.cxx == 'g++'
@@ -326,6 +403,8 @@ jobs:
           run-only-on-ubuntu-latest: true
           filter: large
           s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}
+          junit-s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}
+          aws-role-to-assume: ${{ secrets.AWS_CI_S3_ROLE_ARN }}
           azure-container: ${{ secrets.AZURE_REGTEST_CONTAINER }}
           azure-storage-connection-string: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}
 

--- a/.github/workflows/epoll-regression-tests.yml
+++ b/.github/workflows/epoll-regression-tests.yml
@@ -61,6 +61,8 @@ jobs:
           build-folder-name: build
           filter: ${{ matrix.build-type == 'Release' && 'not empty' || 'not opt_only' }}
           s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}
+          junit-s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}
+          aws-role-to-assume: ${{ secrets.AWS_CI_S3_ROLE_ARN }}
           # Chain ternary oprator of the form (which can be nested)
           # (expression == condition && <true expression> || <false expression>)
           epoll: ${{ matrix.proactor == 'Epoll' && 'epoll' || 'iouring' }}

--- a/.github/workflows/heavy-tests.yml
+++ b/.github/workflows/heavy-tests.yml
@@ -62,6 +62,8 @@ jobs:
           build-folder-name: build
           filter: large
           s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}
+          junit-s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}
+          aws-role-to-assume: ${{ secrets.AWS_CI_S3_ROLE_ARN }}
 
       - name: Upload logs on failure
         if: failure()

--- a/.github/workflows/ioloop-v2-regtests.yml
+++ b/.github/workflows/ioloop-v2-regtests.yml
@@ -60,6 +60,8 @@ jobs:
           build-folder-name: build
           filter: ${{ matrix.build-type == 'Release' && 'not debug_only and not tls' || 'not opt_only and not tls' }}
           s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}
+          junit-s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}
+          aws-role-to-assume: ${{ secrets.AWS_CI_S3_ROLE_ARN }}
 
       - name: Upload logs on failure
         if: failure()

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -62,6 +62,8 @@ jobs:
           build-folder-name: build
           filter: ${{ matrix.build-type == 'Release' && 'not debug_only' || 'not opt_only' }}
           s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}
+          junit-s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}
+          aws-role-to-assume: ${{ secrets.AWS_CI_S3_ROLE_ARN }}
 
       - name: Upload logs on failure
         if: failure()


### PR DESCRIPTION
* pytest outputs junit xml along with prev. json
* C++ unit tests output ctest junit xml and googletest xml
* all XML files uploaded to gh artifacts
* also uploaded to `S3_REGTEST_BUCKET` under `test-results/junit/` - which is durable storage
* helper scripts