### PR TITLE
refactor(facade): extract V2 OnRecv hook method

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -825,11 +825,8 @@ void Connection::OnPostMigrateThread() {
 
   if (ioloop_v2_ && socket_ && socket_->IsOpen() && migration_allowed_to_register_) {
     MaybeEnableRecvMultishot();
-    socket_->RegisterOnRecv([this](const FiberSocketBase::RecvNotification& n) {
-      NotifyOnRecv(n);
-      ReadPendingInput();
-      io_event_.notify();
-    });
+    socket_->RegisterOnRecv(
+        [this](const FiberSocketBase::RecvNotification& n) { OnRecvNotification(n); });
   }
 
   migration_in_process_ = false;
@@ -3031,7 +3028,15 @@ bool ConnectionRef::operator==(const ConnectionRef& other) const {
   return client_id_ == other.client_id_;
 }
 
-void Connection::NotifyOnRecv(const util::FiberSocketBase::RecvNotification& n) {
+void Connection::OnRecvNotification(const util::FiberSocketBase::RecvNotification& n) {
+  DVLOG(2) << "OnRecvNotification iobuf_len: " << io_buf_.InputLen();
+  ProcessRecvNotification(n);
+  // Eagerly drain the socket while the fiber is suspended to prevent receive buffer starvation.
+  ReadPendingInput();
+  io_event_.notify();
+}
+
+void Connection::ProcessRecvNotification(const util::FiberSocketBase::RecvNotification& n) {
   if (std::holds_alternative<std::error_code>(n.read_result)) {
     io_ec_ = std::get<std::error_code>(n.read_result);
     return;
@@ -3286,15 +3291,8 @@ variant<error_code, Connection::ParserStatus> Connection::IoLoopV2() {
 
   MaybeEnableRecvMultishot();
 
-  peer->RegisterOnRecv([this](const FiberSocketBase::RecvNotification& n) {
-    DVLOG(2) << "Calling DoReadOnRecv iobuf_len: " << io_buf_.InputLen();
-    NotifyOnRecv(n);
-    // Eagerly drain the kernel TCP receive buffer while the connection fiber might be is
-    // blocked/busy. This prevents rbuf starvation (V2's single fiber can't read while executing).
-    // Safe: callback only fires when the fiber has yielded - no concurrent access to io_buf_.
-    ReadPendingInput();
-    io_event_.notify();
-  });
+  peer->RegisterOnRecv(
+      [this](const FiberSocketBase::RecvNotification& n) { OnRecvNotification(n); });
 
   ParserStatus parse_status = OK;
 

--- a/src/facade/dragonfly_connection.h
+++ b/src/facade/dragonfly_connection.h
@@ -353,7 +353,18 @@ class Connection : public util::Connection {
   // Main loop reading client messages and passing requests to dispatch queue.
   std::variant<std::error_code, ParserStatus> IoLoop();
 
-  void NotifyOnRecv(const util::FiberSocketBase::RecvNotification& n);
+  // Ingests a single proactor recv notification, updating connection I/O state:
+  // - io_ec_ on error/abort, pending_input_ for multishot completions
+  // - io_buf_ for provided buffers.
+  // May return early on error.
+  // The caller (OnRecvNotification) wakes the fiber regardless so the loop can observe io_ec_ and
+  // close.
+  void ProcessRecvNotification(const util::FiberSocketBase::RecvNotification& n);
+
+  // Callback: registered as the proactor OnRecv hook for V2 connections.
+  // Processes the notification, eagerly drains the socket into io_buf_, and wakes the connection
+  // fiber. Only called from the proactor event loop while the connection fiber is suspended.
+  void OnRecvNotification(const util::FiberSocketBase::RecvNotification& n);
 
   // Enables io_uring multishot receives for the connection if the current thread supports it.
   // This is required during initial setup or after migrating to a new thread/proactor,


### PR DESCRIPTION
The two RegisterOnRecv lambdas (in OnPostMigrateThread and IoLoopV2) each duplicated the same three-step sequence:
  NotifyOnRecv(n) -> ReadPendingInput() -> io_event_.notify()

Extract it into Connection::OnRecvNotification, the named proactor hook for V2 connections. Rename the old NotifyOnRecv helper to ProcessRecvNotification to better reflect its role: it ingests the completion and updates I/O state (io_ec_, pending_input_, io_buf_) but does not notify the fiber.

The split is deliberate: ProcessRecvNotification may return early on error/abort paths; keeping io_event_.notify() in the outer method ensures the fiber always wakes to observe io_ec_ and close.

No behavior change.
