### PR TITLE
chore: add cf.info, cf.count and cf.del

### DIFF
--- a/src/core/cuckoo.cc
+++ b/src/core/cuckoo.cc
@@ -115,6 +115,23 @@ bool CuckooFilter::Exists(uint64_t hash) const {
   return false;
 }
 
+size_t CuckooFilter::Count(uint64_t hash) const {
+  const LookupParams p = LookupParamsFromHash(hash);
+
+  size_t count = 0;
+  for (const SubFilter& sf : filters_) {
+    auto [i1, i2] = BucketIndices(sf, p);
+    for (uint64_t idx : {i1, i2}) {
+      const size_t base = idx * slots_per_bucket_;
+      for (uint8_t s = 0; s < slots_per_bucket_; ++s) {
+        if (sf[base + s] == p.fp)
+          ++count;
+      }
+    }
+  }
+  return count;
+}
+
 bool CuckooFilter::Delete(uint64_t hash) {
   DCHECK(!filters_.empty());
   const LookupParams p = LookupParamsFromHash(hash);

--- a/src/core/cuckoo.h
+++ b/src/core/cuckoo.h
@@ -43,6 +43,12 @@ class CuckooFilter {
   // TODO(kostas): SIMD for the inner bucket scan. Establish a baseline bench and then add SIMD.
   bool Exists(uint64_t hash) const;
 
+  // Returns the number of fingerprint matches for hash across both candidate buckets and
+  // all sub-filters. Each successful Insert of the same item occupies its own slot (Insert
+  // never deduplicates), so this reflects how many times the item was added minus how many
+  // times it was deleted. Like Exists, can overcount on fingerprint collisions.
+  size_t Count(uint64_t hash) const;
+
   // Removes one occurrence of hash from the filter. Returns true if found and removed.
   // This is the key advantage over Bloom filters, which do not support deletion.
   bool Delete(uint64_t hash);
@@ -62,6 +68,33 @@ class CuckooFilter {
 
   // Returns approximate heap bytes used by this filter's SubFilter data.
   size_t MallocUsed() const;
+
+  // Base bucket count from construction; never changes as the filter grows (each new
+  // sub-filter scales its own bucket count by expansion_ instead).
+  uint64_t NumBuckets() const {
+    return num_buckets_;
+  }
+
+  size_t NumFilters() const {
+    return filters_.size();
+  }
+
+  uint64_t NumDeletes() const {
+    return num_deletes_;
+  }
+
+  uint8_t SlotsPerBucket() const {
+    return slots_per_bucket_;
+  }
+
+  uint16_t MaxIterations() const {
+    return max_iterations_;
+  }
+
+  // Already rounded up to the next power of two (or 0 if expansion is disabled).
+  uint16_t Expansion() const {
+    return expansion_;
+  }
 
  private:
   using SubFilter = std::pmr::vector<uint8_t>;

--- a/src/core/cuckoo_filter_test.cc
+++ b/src/core/cuckoo_filter_test.cc
@@ -104,4 +104,20 @@ TEST_F(CuckooFilterTest, InsertUniquePreventsduplicates) {
   EXPECT_EQ(cf_.NumItems(), 1u);
 }
 
+TEST_F(CuckooFilterTest, CountTracksDuplicateInsertsAndDeletes) {
+  const uint64_t h = CuckooFilter::Hash("counted");
+  EXPECT_EQ(cf_.Count(h), 0u);
+
+  EXPECT_TRUE(cf_.Insert(h));
+  EXPECT_EQ(cf_.Count(h), 1u);
+
+  // Insert (not InsertUnique) never dedups — a second insert of the same item occupies
+  // its own slot, so Count reflects how many times it was added.
+  EXPECT_TRUE(cf_.Insert(h));
+  EXPECT_EQ(cf_.Count(h), 2u);
+
+  EXPECT_TRUE(cf_.Delete(h));
+  EXPECT_EQ(cf_.Count(h), 1u);
+}
+
 }  // namespace dfly

--- a/src/server/cuckoo_filter_family.cc
+++ b/src/server/cuckoo_filter_family.cc
@@ -21,6 +21,17 @@ namespace {
 
 constexpr uint64_t kDefaultCapacity = 1024;
 
+struct CuckooInfo {
+  size_t size = 0;
+  uint64_t num_buckets = 0;
+  size_t num_filters = 0;
+  size_t num_items = 0;
+  uint64_t num_deletes = 0;
+  uint8_t bucket_size = 0;
+  uint16_t expansion = 0;
+  uint16_t max_iterations = 0;
+};
+
 OpResult<CuckooFilter*> FindOrCreate(const OpArgs& op_args, string_view key) {
   auto& db_slice = op_args.GetDbSlice();
   auto op_res = db_slice.AddOrFind(op_args.db_cntx, key, OBJ_CUCKOOFILTER);
@@ -67,6 +78,38 @@ OpResult<vector<bool>> OpExists(const OpArgs& op_args, string_view key, ParsedAr
     result[i] = cf->Exists(CuckooFilter::Hash(items[i]));
   }
   return result;
+}
+
+OpResult<CuckooInfo> OpInfo(const OpArgs& op_args, string_view key) {
+  auto& db_slice = op_args.GetDbSlice();
+  auto op_res = db_slice.FindReadOnly(op_args.db_cntx, key, OBJ_CUCKOOFILTER);
+  if (!op_res)
+    return op_res.status();
+
+  const CuckooFilter* cf = op_res.value()->second.GetCuckooFilter();
+  return CuckooInfo{cf->MallocUsed(), cf->NumBuckets(),     cf->NumFilters(), cf->NumItems(),
+                    cf->NumDeletes(), cf->SlotsPerBucket(), cf->Expansion(),  cf->MaxIterations()};
+}
+
+OpResult<size_t> OpCount(const OpArgs& op_args, string_view key, string_view item) {
+  auto& db_slice = op_args.GetDbSlice();
+  auto op_res = db_slice.FindReadOnly(op_args.db_cntx, key, OBJ_CUCKOOFILTER);
+  if (!op_res)
+    return op_res.status();
+
+  const CuckooFilter* cf = op_res.value()->second.GetCuckooFilter();
+  return cf->Count(CuckooFilter::Hash(item));
+}
+
+OpResult<bool> OpDel(const OpArgs& op_args, string_view key, string_view item) {
+  auto& db_slice = op_args.GetDbSlice();
+  auto op_res = db_slice.FindMutable(op_args.db_cntx, key, OBJ_CUCKOOFILTER);
+  RETURN_ON_BAD_STATUS(op_res);
+
+  // RedisBloom auto-compacts (merges sub-filters) once deletes exceed 10% of items, to
+  // reclaim space from sparse sub-filters. CuckooFilter has no compaction/merge support;
+  // this is an intentional, known parity gap that doesn't affect Delete's correctness.
+  return op_res->it->second.GetCuckooFilter()->Delete(CuckooFilter::Hash(item));
 }
 
 OpStatus OpReserve(const OpArgs& op_args, string_view key, const CuckooFilterOptions& options) {
@@ -191,6 +234,66 @@ void CmdMExists(CmdArgParser parser, CommandContext* cmd_cntx) {
   }
 }
 
+void CmdInfo(CmdArgParser parser, CommandContext* cmd_cntx) {
+  string_view key = parser.Next();
+  auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
+
+  const auto cb = [&](Transaction* t, EngineShard* shard) {
+    return OpInfo(t->GetOpArgs(shard), key);
+  };
+
+  OpResult<CuckooInfo> res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
+  if (!res)
+    return rb->SendError(res.status());
+
+  SinkReplyBuilder::ReplyScope scope(rb);
+  rb->StartArray(16);
+  rb->SendBulkString("Size");
+  rb->SendLong(static_cast<long>(res->size));
+  rb->SendBulkString("Number of buckets");
+  rb->SendLong(static_cast<long>(res->num_buckets));
+  rb->SendBulkString("Number of filters");
+  rb->SendLong(static_cast<long>(res->num_filters));
+  rb->SendBulkString("Number of items inserted");
+  rb->SendLong(static_cast<long>(res->num_items));
+  rb->SendBulkString("Number of items deleted");
+  rb->SendLong(static_cast<long>(res->num_deletes));
+  rb->SendBulkString("Bucket size");
+  rb->SendLong(res->bucket_size);
+  rb->SendBulkString("Expansion rate");
+  rb->SendLong(res->expansion);
+  rb->SendBulkString("Max iterations");
+  rb->SendLong(res->max_iterations);
+}
+
+void CmdCount(CmdArgParser parser, CommandContext* cmd_cntx) {
+  string_view key = parser.Next();
+  string_view item = parser.Next();
+
+  const auto cb = [&](Transaction* t, EngineShard* shard) {
+    return OpCount(t->GetOpArgs(shard), key, item);
+  };
+
+  OpResult<size_t> res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
+  if (!res && res.status() != OpStatus::KEY_NOTFOUND && res.status() != OpStatus::WRONG_TYPE)
+    return cmd_cntx->SendError(res.status());
+  cmd_cntx->SendLong(res ? static_cast<long>(*res) : 0);
+}
+
+void CmdDel(CmdArgParser parser, CommandContext* cmd_cntx) {
+  string_view key = parser.Next();
+  string_view item = parser.Next();
+
+  const auto cb = [&](Transaction* t, EngineShard* shard) {
+    return OpDel(t->GetOpArgs(shard), key, item);
+  };
+
+  OpResult<bool> res = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
+  if (!res)
+    return cmd_cntx->SendError(res.status());
+  cmd_cntx->SendLong(*res);
+}
+
 }  // namespace
 
 using CI = CommandId;
@@ -204,7 +307,10 @@ void RegisterCuckooFilterFamily(CommandRegistry* registry) {
             << CI{"CF.ADD", CO::JOURNALED | CO::DENYOOM | CO::FAST, 3, 1, 1}.HFUNC(Add)
             << CI{"CF.ADDNX", CO::JOURNALED | CO::DENYOOM | CO::FAST, 3, 1, 1}.HFUNC(AddNx)
             << CI{"CF.EXISTS", CO::READONLY | CO::FAST, 3, 1, 1}.HFUNC(Exists)
-            << CI{"CF.MEXISTS", CO::READONLY | CO::FAST, -3, 1, 1}.HFUNC(MExists);
+            << CI{"CF.MEXISTS", CO::READONLY | CO::FAST, -3, 1, 1}.HFUNC(MExists)
+            << CI{"CF.INFO", CO::READONLY | CO::FAST, 2, 1, 1}.HFUNC(Info)
+            << CI{"CF.COUNT", CO::READONLY | CO::FAST, 3, 1, 1}.HFUNC(Count)
+            << CI{"CF.DEL", CO::JOURNALED | CO::DENYOOM | CO::FAST, 3, 1, 1}.HFUNC(Del);
 }
 
 }  // namespace dfly

--- a/src/server/cuckoo_filter_family_test.cc
+++ b/src/server/cuckoo_filter_family_test.cc
@@ -135,4 +135,55 @@ TEST_F(CuckooFilterFamilyTest, MExistsWrongType) {
   EXPECT_THAT(Run({"cf.mexists", "str1", "foo"}), RespArray(ElementsAre(IntArg(0))));
 }
 
+TEST_F(CuckooFilterFamilyTest, Info) {
+  ASSERT_EQ(Run("cf.reserve cf1 1000 bucketsize 4 maxiterations 10 expansion 2"), "OK");
+  EXPECT_THAT(Run({"cf.add", "cf1", "foo"}), IntArg(1));
+
+  auto resp = Run({"cf.info", "cf1"});
+  EXPECT_THAT(resp, RespArray(ElementsAre(
+                        "Size", testing::_, "Number of buckets", testing::_, "Number of filters",
+                        IntArg(1), "Number of items inserted", IntArg(1), "Number of items deleted",
+                        IntArg(0), "Bucket size", IntArg(4), "Expansion rate", IntArg(2),
+                        "Max iterations", IntArg(10))));
+}
+
+TEST_F(CuckooFilterFamilyTest, InfoMissingKey) {
+  EXPECT_THAT(Run({"cf.info", "nonexist-key"}), ErrArg("no such key"));
+}
+
+TEST_F(CuckooFilterFamilyTest, Count) {
+  EXPECT_THAT(Run({"cf.add", "f1", "foo"}), IntArg(1));
+  EXPECT_THAT(Run({"cf.count", "f1", "foo"}), IntArg(1));
+  EXPECT_THAT(Run({"cf.count", "f1", "bar"}), IntArg(0));
+
+  // Missing key returns 0, not an error.
+  EXPECT_THAT(Run({"cf.count", "nonexist-key", "blah"}), IntArg(0));
+}
+
+TEST_F(CuckooFilterFamilyTest, CountAfterDuplicateAdds) {
+  // CF.ADD never dedups, so repeated adds of the same item should each bump the count.
+  EXPECT_THAT(Run({"cf.add", "f1", "foo"}), IntArg(1));
+  EXPECT_THAT(Run({"cf.add", "f1", "foo"}), IntArg(1));
+  EXPECT_THAT(Run({"cf.add", "f1", "foo"}), IntArg(1));
+  EXPECT_THAT(Run({"cf.count", "f1", "foo"}), IntArg(3));
+
+  EXPECT_THAT(Run({"cf.del", "f1", "foo"}), IntArg(1));
+  EXPECT_THAT(Run({"cf.count", "f1", "foo"}), IntArg(2));
+}
+
+TEST_F(CuckooFilterFamilyTest, Del) {
+  EXPECT_THAT(Run({"cf.add", "f1", "foo"}), IntArg(1));
+  EXPECT_THAT(Run({"cf.del", "f1", "foo"}), IntArg(1));
+  EXPECT_THAT(Run({"cf.exists", "f1", "foo"}), IntArg(0));
+}
+
+TEST_F(CuckooFilterFamilyTest, DelNonExistentItem) {
+  ASSERT_EQ(Run("cf.reserve cf1 1000"), "OK");
+  EXPECT_THAT(Run({"cf.del", "cf1", "nope"}), IntArg(0));
+}
+
+TEST_F(CuckooFilterFamilyTest, DelMissingKey) {
+  EXPECT_THAT(Run({"cf.del", "nonexist-key", "foo"}), ErrArg("no such key"));
+}
+
 }  // namespace dfly


### PR DESCRIPTION
* add cf.info
* add cf.count
* add cf.del
* add tests

There is also `compaction` of the filters after `Del` which I will solve in a follow up PR.

#5446