### PR TITLE
feat: Add BM25STD.NORM and BM25STD.TANH scorers

### DIFF
--- a/src/core/search/scoring.cc
+++ b/src/core/search/scoring.cc
@@ -17,6 +17,7 @@ double ScoreDocument(ScorerFn scorer, const ScoringContext& ctx,
 ScorerFn RawScorer(const ScorerSpec& scorer) {
   switch (scorer.kind) {
     case ScorerKind::BM25STD:
+    case ScorerKind::BM25STD_NORM:
     case ScorerKind::BM25STD_TANH:
       return &BM25Std;
     case ScorerKind::TFIDF:

--- a/src/core/search/scoring.cc
+++ b/src/core/search/scoring.cc
@@ -14,6 +14,27 @@ double ScoreDocument(ScorerFn scorer, const ScoringContext& ctx,
   return score;
 }
 
+ScorerFn RawScorer(const ScorerSpec& scorer) {
+  switch (scorer.kind) {
+    case ScorerKind::BM25STD:
+    case ScorerKind::BM25STD_TANH:
+      return &BM25Std;
+    case ScorerKind::TFIDF:
+      return &TfIdf;
+    case ScorerKind::TFIDF_DOCNORM:
+      return &TfIdfDocNorm;
+  }
+  return &BM25Std;
+}
+
+double ScoreDocument(const ScorerSpec& scorer, const ScoringContext& ctx,
+                     const std::vector<ScoringTermInfo>& terms) {
+  double score = ScoreDocument(RawScorer(scorer), ctx, terms);
+  if (scorer.kind == ScorerKind::BM25STD_TANH)
+    score = std::tanh(score / scorer.bm25std_tanh_factor);
+  return score;
+}
+
 void GlobalScoringStats::Merge(const ShardScoringStats& shard) {
   num_docs += shard.num_docs;
   for (const auto& [field, stats] : shard.field_stats) {

--- a/src/core/search/scoring.h
+++ b/src/core/search/scoring.h
@@ -42,6 +42,7 @@ inline constexpr uint64_t kDefaultBM25StdTanhFactor = 4;
 
 enum class ScorerKind {
   BM25STD,
+  BM25STD_NORM,
   BM25STD_TANH,
   TFIDF,
   TFIDF_DOCNORM,

--- a/src/core/search/scoring.h
+++ b/src/core/search/scoring.h
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -34,9 +35,22 @@ struct ScoringContext {
 };
 
 // Scorer function signature: computes the score for a single (term, document) pair.
-// Register new scorers by adding a function with this signature and exposing it via
-// ParseScorer in the command layer.
+// ScorerSpec below applies optional document-level post processing on top of these raw scorers.
 using ScorerFn = double (*)(const ScoringContext&, const ScoringTermInfo&);
+
+inline constexpr uint64_t kDefaultBM25StdTanhFactor = 4;
+
+enum class ScorerKind {
+  BM25STD,
+  BM25STD_TANH,
+  TFIDF,
+  TFIDF_DOCNORM,
+};
+
+struct ScorerSpec {
+  ScorerKind kind = ScorerKind::BM25STD;
+  uint64_t bm25std_tanh_factor = kDefaultBM25StdTanhFactor;
+};
 
 // Compute BM25STD score for a single term in a document.
 //
@@ -94,6 +108,10 @@ inline double TfIdfDocNorm(const ScoringContext& ctx, const ScoringTermInfo& ter
 // Returns sum of per-term scores produced by the given scorer function.
 double ScoreDocument(ScorerFn scorer, const ScoringContext& ctx,
                      const std::vector<ScoringTermInfo>& terms);
+double ScoreDocument(const ScorerSpec& scorer, const ScoringContext& ctx,
+                     const std::vector<ScoringTermInfo>& terms);
+
+ScorerFn RawScorer(const ScorerSpec& scorer);
 
 // Single-shard slice of the counts a scorer needs. Keys are schema canonical
 // names; terms are post-synonym-resolution.

--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -749,6 +749,9 @@ struct BasicSearch {
     scored.reserve(all_docs.size());
     vector<ScoringTermInfo> term_infos(cursors.size());
 
+    // Track the max score over the full matched set (before top-K trimming) so the command
+    // layer can normalize BM25STD.NORM by the global max. Cheap byproduct of scoring.
+    float max_text_score = 0.0f;
     for (DocId doc : all_docs) {
       for (size_t t = 0; t < cursors.size(); t++) {
         term_infos[t].term_docs = cursors[t].term_docs;
@@ -758,10 +761,10 @@ struct BasicSearch {
           term_infos[t].field_avg_doc_len = cursors[t].field_avg_doc_len;
         }
       }
-      scored.emplace_back(static_cast<float>(ScoreDocument(*scorer_, ctx, term_infos)), doc);
+      float score = static_cast<float>(ScoreDocument(*scorer_, ctx, term_infos));
+      max_text_score = max(max_text_score, score);
+      scored.emplace_back(score, doc);
     }
-    auto max_it = max_element(scored.begin(), scored.end());
-    float max_text_score = max_it == scored.end() ? 0.0f : max_it->first;
 
     // Top-K by score (skip sort when no actual cutoff, e.g. FT.AGGREGATE)
     size_t k = min(limit, scored.size());
@@ -1233,17 +1236,6 @@ void SearchAlgorithm::EnableProfiling() {
 
 void SearchAlgorithm::SetScorer(ScorerSpec scorer) {
   scorer_ = scorer;
-}
-
-void SearchAlgorithm::SetScorer(ScorerFn scorer) {
-  if (scorer == &BM25Std)
-    scorer_ = ScorerSpec{ScorerKind::BM25STD};
-  else if (scorer == &TfIdf)
-    scorer_ = ScorerSpec{ScorerKind::TFIDF};
-  else if (scorer == &TfIdfDocNorm)
-    scorer_ = ScorerSpec{ScorerKind::TFIDF_DOCNORM};
-  else
-    scorer_ = nullopt;
 }
 
 // Visits `node` and recurses into its sub-expressions, invoking `cb` on every node in DFS order.

--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -119,7 +119,8 @@ struct ProfileBuilder {
 struct BasicSearch {
   using LogicOp = AstLogicalNode::LogicOp;
 
-  BasicSearch(const FieldIndices* indices, ScorerFn scorer, const GlobalScoringStats* global_stats)
+  BasicSearch(const FieldIndices* indices, optional<ScorerSpec> scorer,
+              const GlobalScoringStats* global_stats)
       : indices_{indices}, scorer_{scorer}, global_stats_{global_stats} {
   }
 
@@ -755,7 +756,7 @@ struct BasicSearch {
           term_infos[t].field_avg_doc_len = cursors[t].field_avg_doc_len;
         }
       }
-      scored.emplace_back(static_cast<float>(ScoreDocument(scorer_, ctx, term_infos)), doc);
+      scored.emplace_back(static_cast<float>(ScoreDocument(*scorer_, ctx, term_infos)), doc);
     }
 
     // Top-K by score (skip sort when no actual cutoff, e.g. FT.AGGREGATE)
@@ -784,7 +785,7 @@ struct BasicSearch {
   }
 
   const FieldIndices* indices_;
-  ScorerFn scorer_ = nullptr;
+  optional<ScorerSpec> scorer_;
   const GlobalScoringStats* global_stats_ = nullptr;
 
   string error_;
@@ -1226,8 +1227,19 @@ void SearchAlgorithm::EnableProfiling() {
   profiling_enabled_ = true;
 }
 
-void SearchAlgorithm::SetScorer(ScorerFn scorer) {
+void SearchAlgorithm::SetScorer(ScorerSpec scorer) {
   scorer_ = scorer;
+}
+
+void SearchAlgorithm::SetScorer(ScorerFn scorer) {
+  if (scorer == &BM25Std)
+    scorer_ = ScorerSpec{ScorerKind::BM25STD};
+  else if (scorer == &TfIdf)
+    scorer_ = ScorerSpec{ScorerKind::TFIDF};
+  else if (scorer == &TfIdfDocNorm)
+    scorer_ = ScorerSpec{ScorerKind::TFIDF_DOCNORM};
+  else
+    scorer_ = nullopt;
 }
 
 // Visits `node` and recurses into its sub-expressions, invoking `cb` on every node in DFS order.

--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -684,15 +684,16 @@ struct BasicSearch {
 
     if (scorer_ && !matched_text_terms_.empty()) {
       // Score ALL matched docs and return top-K by score (not arbitrary cutoff).
-      auto [out, total_size, text_scores] = TakeScoredTopK(std::move(result), cuttoff_limit);
+      auto [out, total_size, text_scores, max_text_score] =
+          TakeScoredTopK(std::move(result), cuttoff_limit);
       return SearchResult{
-          total_size,         std::move(out),   std::move(knn_scores_), std::move(text_scores),
-          std::move(profile), std::move(error_)};
+          total_size,     std::move(out),     std::move(knn_scores_), std::move(text_scores),
+          max_text_score, std::move(profile), std::move(error_)};
     }
 
     auto [out, total_size] = result.Take(cuttoff_limit);
-    return SearchResult{total_size, std::move(out),     std::move(knn_scores_),
-                        {},         std::move(profile), std::move(error_)};
+    return SearchResult{total_size, std::move(out),     std::move(knn_scores_), {},
+                        0.0f,       std::move(profile), std::move(error_)};
   }
 
  private:
@@ -715,12 +716,13 @@ struct BasicSearch {
 
   // Score all matched docs via cursor-based posting list traversal and return top-K by score.
   // Total work: O(sum of posting_list_sizes) for cursors + O(N log K) for partial sort.
-  std::tuple<vector<DocId>, size_t, absl::flat_hash_map<DocId, float>> TakeScoredTopK(
+  std::tuple<vector<DocId>, size_t, absl::flat_hash_map<DocId, float>, float> TakeScoredTopK(
       IndexResult&& result, size_t limit) {
     auto [all_docs, total_size] = result.Take();  // all matched docs
 
     if (all_docs.empty())
-      return std::make_tuple(vector<DocId>{}, total_size, absl::flat_hash_map<DocId, float>{});
+      return std::make_tuple(vector<DocId>{}, total_size, absl::flat_hash_map<DocId, float>{},
+                             0.0f);
 
     // Ensure sorted for cursor-based scoring
     sort(all_docs.begin(), all_docs.end());
@@ -758,6 +760,8 @@ struct BasicSearch {
       }
       scored.emplace_back(static_cast<float>(ScoreDocument(*scorer_, ctx, term_infos)), doc);
     }
+    auto max_it = max_element(scored.begin(), scored.end());
+    float max_text_score = max_it == scored.end() ? 0.0f : max_it->first;
 
     // Top-K by score (skip sort when no actual cutoff, e.g. FT.AGGREGATE)
     size_t k = min(limit, scored.size());
@@ -776,7 +780,7 @@ struct BasicSearch {
       text_scores[doc] = score;
     }
 
-    return std::make_tuple(std::move(out), total_size, std::move(text_scores));
+    return std::make_tuple(std::move(out), total_size, std::move(text_scores), max_text_score);
   }
 
   void AddMatchedTerm(TextIndex* index, string term) {

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -208,6 +208,7 @@ struct SearchResult {
 
   // Text relevance scores keyed by DocId. Populated when a scorer is active.
   absl::flat_hash_map<DocId, float> text_scores;
+  float max_text_score = 0;
 
   // If profiling was enabled
   std::optional<AlgorithmProfile> profile;

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -267,7 +267,6 @@ class SearchAlgorithm {
   void EnableProfiling();
 
   void SetScorer(ScorerSpec scorer);
-  void SetScorer(ScorerFn scorer);
 
  private:
   bool profiling_enabled_ = false;

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -265,11 +265,12 @@ class SearchAlgorithm {
 
   void EnableProfiling();
 
+  void SetScorer(ScorerSpec scorer);
   void SetScorer(ScorerFn scorer);
 
  private:
   bool profiling_enabled_ = false;
-  ScorerFn scorer_ = nullptr;
+  std::optional<ScorerSpec> scorer_;
   std::unique_ptr<AstNode> query_;
   std::optional<KnnScoreSortOption> knn_hnsw_score_sort_option_;
 };

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -3067,6 +3067,8 @@ TEST_F(ScoringTest, ScoreDocumentDispatchesByScorerType) {
       .term_freq = 2, .term_docs = 3, .field_doc_len = 5, .field_avg_doc_len = 5.0};
 
   EXPECT_DOUBLE_EQ(ScoreDocument(&BM25Std, ctx, {term}), BM25Std(ctx, term));
+  EXPECT_DOUBLE_EQ(ScoreDocument(ScorerSpec{ScorerKind::BM25STD_NORM}, ctx, {term}),
+                   BM25Std(ctx, term));
   EXPECT_DOUBLE_EQ(ScoreDocument(&TfIdf, ctx, {term}), TfIdf(ctx, term));
   EXPECT_DOUBLE_EQ(ScoreDocument(&TfIdfDocNorm, ctx, {term}), TfIdfDocNorm(ctx, term));
 }

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -3113,7 +3113,7 @@ TEST_F(ScoringTest, SearchWithScorer) {
   QueryParams params;
   SearchAlgorithm algo;
   ASSERT_TRUE(algo.Init("hello", &params));
-  algo.SetScorer(&BM25Std);
+  algo.SetScorer(ScorerSpec{});
 
   auto result = algo.Search(&index);
 
@@ -3153,7 +3153,7 @@ TEST_F(ScoringTest, SearchPrefixWithScorer) {
   QueryParams params;
   SearchAlgorithm algo;
   ASSERT_TRUE(algo.Init("hel*", &params));
-  algo.SetScorer(&BM25Std);
+  algo.SetScorer(ScorerSpec{});
 
   auto result = algo.Search(&index);
 
@@ -3260,7 +3260,7 @@ TEST_F(ScoringTest, BM25StdAfterDocRemoval) {
   QueryParams params;
   SearchAlgorithm algo;
   ASSERT_TRUE(algo.Init("hello", &params));
-  algo.SetScorer(&BM25Std);
+  algo.SetScorer(ScorerSpec{});
 
   auto result_before = algo.Search(&index);
   ASSERT_EQ(result_before.ids.size(), 3u);
@@ -3272,7 +3272,7 @@ TEST_F(ScoringTest, BM25StdAfterDocRemoval) {
   // Re-search
   SearchAlgorithm algo2;
   ASSERT_TRUE(algo2.Init("hello", &params));
-  algo2.SetScorer(&BM25Std);
+  algo2.SetScorer(ScorerSpec{});
 
   auto result_after = algo2.Search(&index);
   ASSERT_EQ(result_after.ids.size(), 2u);
@@ -3307,7 +3307,7 @@ TEST_F(ScoringTest, ScorerTopKCutoff) {
   QueryParams params;
   SearchAlgorithm algo;
   ASSERT_TRUE(algo.Init("hello", &params));
-  algo.SetScorer(&BM25Std);
+  algo.SetScorer(ScorerSpec{});
 
   // Request only top 3 - should return docs 9, 8, 7 (highest TF)
   auto result = algo.Search(&index, 3);
@@ -3363,7 +3363,7 @@ TEST_F(SearchTest, MatchOptionalScoreBoost) {
   QueryParams params;
   SearchAlgorithm algo;
   ASSERT_TRUE(algo.Init("~hello", &params));
-  algo.SetScorer(&BM25Std);
+  algo.SetScorer(ScorerSpec{});
 
   auto result = algo.Search(&index);
 
@@ -3483,7 +3483,7 @@ TEST_F(SearchTest, MatchNestedOptionalNoDoubleScore) {
     SearchAlgorithm algo;
     QueryParams params;
     EXPECT_TRUE(algo.Init(query, &params));
-    algo.SetScorer(&BM25Std);
+    algo.SetScorer(ScorerSpec{});
     return algo.Search(&index);
   };
 
@@ -3565,7 +3565,7 @@ TEST_F(SearchTest, MatchOptionalKnnIdsScoresAligned) {
   QueryParams params;
   params["v"] = ToBytes({2.5f});  // closest is doc:1 (pos=2) and doc:2 (pos=3)
   ASSERT_TRUE(algo.Init("~hello => [KNN 4 @vec $v]", &params));
-  algo.SetScorer(&BM25Std);
+  algo.SetScorer(ScorerSpec{});
   auto result = algo.Search(&index);
 
   ASSERT_TRUE(result.error.empty()) << result.error;
@@ -3813,7 +3813,7 @@ TEST_F(PhraseTest, PhraseMatchedDocsAreScored) {
   QueryParams params;
   SearchAlgorithm algo;
   ASSERT_TRUE(algo.Init("\"machine learning\"", &params));
-  algo.SetScorer(&BM25Std);
+  algo.SetScorer(ScorerSpec{});
 
   auto result = algo.Search(&index);
   ASSERT_EQ(result.ids.size(), 2u);

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -3071,6 +3071,29 @@ TEST_F(ScoringTest, ScoreDocumentDispatchesByScorerType) {
   EXPECT_DOUBLE_EQ(ScoreDocument(&TfIdfDocNorm, ctx, {term}), TfIdfDocNorm(ctx, term));
 }
 
+TEST_F(ScoringTest, BM25StdTanhAppliesDefaultFactor) {
+  ScoringContext ctx{.num_docs = 10};
+  ScoringTermInfo term{
+      .term_freq = 2, .term_docs = 3, .field_doc_len = 5, .field_avg_doc_len = 5.0};
+
+  ScorerSpec scorer{ScorerKind::BM25STD_TANH};
+  double raw = ScoreDocument(ScorerSpec{ScorerKind::BM25STD}, ctx, {term});
+
+  EXPECT_NEAR(ScoreDocument(scorer, ctx, {term}), std::tanh(raw / kDefaultBM25StdTanhFactor),
+              1e-12);
+}
+
+TEST_F(ScoringTest, BM25StdTanhAppliesCustomFactor) {
+  ScoringContext ctx{.num_docs = 10};
+  ScoringTermInfo term{
+      .term_freq = 2, .term_docs = 3, .field_doc_len = 5, .field_avg_doc_len = 5.0};
+
+  ScorerSpec scorer{.kind = ScorerKind::BM25STD_TANH, .bm25std_tanh_factor = 20};
+  double raw = ScoreDocument(ScorerSpec{ScorerKind::BM25STD}, ctx, {term});
+
+  EXPECT_NEAR(ScoreDocument(scorer, ctx, {term}), std::tanh(raw / 20), 1e-12);
+}
+
 TEST_F(ScoringTest, SearchWithScorer) {
   // Integration test: build index, search with scorer, verify scores are non-zero
   Schema schema = MakeSimpleSchema({{"field", SchemaField::TEXT}});

--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -26,8 +26,8 @@ namespace facade {
 //   auto [src, dst] = parser.Next<string_view, string_view>();  // read several at once (tuple)
 //   auto db = parser.Next<FInt<0, 15>>();                       // range-restricted int
 //                                                               // (INVALID_INT if out of range)
-//   auto f  = parser.NextBounded<uint32_t>(1, 99, "bad f");     // range-restricted int with a
-//                                                               // custom out-of-range message
+//   auto f  = parser.Next<FInt<1, 99>>("bad f");                // FInt with a custom out-of-range
+//                                                               // / non-integer error message
 //   auto count = parser.NextOrDefault<size_t>(10);              // read optional with default
 //
 // Tag matching:
@@ -149,6 +149,19 @@ struct CmdArgParser {
     }
   }
 
+  // Like Next<T>(), but on a failed read (non-numeric, out-of-range FInt, or missing arg) replaces
+  // the generic error with a caller-supplied CUSTOM_ERROR message. Pair with FInt<lo,hi> to attach
+  // a custom out-of-range / non-integer message: parser.Next<FInt<1u, 99u>>("bad f").
+  template <class T = std::string_view> T Next(std::string_view err_msg) {
+    bool prior = bool(error_);
+    T val = Next<T>();
+    if (!prior && error_ && !err_msg.empty()) {
+      error_.type = CUSTOM_ERROR;
+      error_.custom_msg = std::string{err_msg};
+    }
+    return val;
+  }
+
   template <class T = std::string_view> auto NextOrDefault(T default_value = {}) {
     return HasNext() ? Next<T>() : default_value;
   }
@@ -181,25 +194,6 @@ struct CmdArgParser {
     T out{};
     if (!absl::SimpleAtoi(val, &out)) {
       Report(INVALID_INT, idx);
-      return {};
-    }
-    return out;
-  }
-
-  // Consumes the next arg as an integer of type T constrained to [min, max]. Unlike
-  // Next<FInt<lo,hi>>(), an out-of-range or non-integer value reports a caller-supplied
-  // CUSTOM_ERROR message (surfaced verbatim) instead of the generic INVALID_INT text. A missing
-  // arg reports OUT_OF_BOUNDS.
-  template <class T> T NextBounded(T min, T max, std::string_view err_msg) {
-    static_assert(std::is_integral_v<T>);
-    if (cur_i_ >= args_.size()) {
-      Report(OUT_OF_BOUNDS, cur_i_);
-      return {};
-    }
-    size_t idx = cur_i_++;
-    T out{};
-    if (!absl::SimpleAtoi(SafeSV(idx), &out) || out < min || out > max) {
-      Report(CUSTOM_ERROR, idx, std::string{err_msg});
       return {};
     }
     return out;

--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -26,6 +26,8 @@ namespace facade {
 //   auto [src, dst] = parser.Next<string_view, string_view>();  // read several at once (tuple)
 //   auto db = parser.Next<FInt<0, 15>>();                       // range-restricted int
 //                                                               // (INVALID_INT if out of range)
+//   auto f  = parser.NextBounded<uint32_t>(1, 99, "bad f");     // range-restricted int with a
+//                                                               // custom out-of-range message
 //   auto count = parser.NextOrDefault<size_t>(10);              // read optional with default
 //
 // Tag matching:
@@ -179,6 +181,25 @@ struct CmdArgParser {
     T out{};
     if (!absl::SimpleAtoi(val, &out)) {
       Report(INVALID_INT, idx);
+      return {};
+    }
+    return out;
+  }
+
+  // Consumes the next arg as an integer of type T constrained to [min, max]. Unlike
+  // Next<FInt<lo,hi>>(), an out-of-range or non-integer value reports a caller-supplied
+  // CUSTOM_ERROR message (surfaced verbatim) instead of the generic INVALID_INT text. A missing
+  // arg reports OUT_OF_BOUNDS.
+  template <class T> T NextBounded(T min, T max, std::string_view err_msg) {
+    static_assert(std::is_integral_v<T>);
+    if (cur_i_ >= args_.size()) {
+      Report(OUT_OF_BOUNDS, cur_i_);
+      return {};
+    }
+    size_t idx = cur_i_++;
+    T out{};
+    if (!absl::SimpleAtoi(SafeSV(idx), &out) || out < min || out > max) {
+      Report(CUSTOM_ERROR, idx, std::string{err_msg});
       return {};
     }
     return out;

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -1017,11 +1017,9 @@ SearchResult ShardDocIndex::Search(const OpArgs& op_args, const SearchParams& pa
   // Recompute the max over docs that survived loading. Expired/missing docs were dropped above,
   // so the pre-filter result.max_text_score could otherwise normalize BM25STD.NORM by a document
   // that is not returned, pushing the best returned document below 1.0.
-  float max_text_score = 0.0f;
-  if (!out.empty())
-    max_text_score = std::max_element(out.begin(), out.end(), [](const auto& a, const auto& b) {
-                       return a.text_score < b.text_score;
-                     })->text_score;
+  auto max_it = std::ranges::max_element(
+      out, [](const auto& a, const auto& b) { return a.text_score < b.text_score; });
+  float max_text_score = max_it == out.end() ? 0.0f : max_it->text_score;
 
   return {result.total - expired_count, std::move(out), std::move(result.profile), max_text_score};
 }
@@ -1051,12 +1049,9 @@ SearchIdResult ShardDocIndex::SearchIds(const OpArgs& op_args, const SearchParam
 
     // Recompute the max over live docs only, mirroring ShardDocIndex::Search: a dropped
     // top-scoring doc must not inflate the BM25STD.NORM denominator.
-    float max_text_score = 0.0f;
-    if (!live_text_scores.empty())
-      max_text_score =
-          std::max_element(live_text_scores.begin(), live_text_scores.end(),
-                           [](const auto& a, const auto& b) { return a.second < b.second; })
-              ->second;
+    auto max_it = std::ranges::max_element(
+        live_text_scores, [](const auto& a, const auto& b) { return a.second < b.second; });
+    float max_text_score = max_it == live_text_scores.end() ? 0.0f : max_it->second;
 
     return {live_ids.size(), std::move(live_ids), std::move(live_text_scores),
             std::move(result.profile), max_text_score};

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -1132,9 +1132,11 @@ vector<SearchDocData> ShardDocIndex::LoadDocEntriesWithScores(
         out.back()[string{score_alias}] = static_cast<double>(it->second);
     }
 
-    if (!text_score_map.empty()) {
+    if (params.add_scores) {
+      double text_score = 0;
       if (auto it = text_score_map.find(doc); it != text_score_map.end())
-        out.back()["__score"] = static_cast<double>(it->second);
+        text_score = it->second;
+      out.back()["__score"] = text_score;
       // Hidden tie-breaker for SORTBY @__score; not added to fields_to_print.
       out.back()["__key"] = string{key};
     }

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -1014,8 +1014,14 @@ SearchResult ShardDocIndex::Search(const OpArgs& op_args, const SearchParams& pa
         {result.ids[i], string{key}, std::move(fields), knn_score, text_score, sort_score});
   }
 
-  return {result.total - expired_count, std::move(out), std::move(result.profile),
-          result.max_text_score};
+  // Recompute the max over docs that survived loading. Expired/missing docs were dropped above,
+  // so the pre-filter result.max_text_score could otherwise normalize BM25STD.NORM by a document
+  // that is not returned, pushing the best returned document below 1.0.
+  float max_text_score = 0.0f;
+  for (const auto& doc : out)
+    max_text_score = std::max(max_text_score, doc.text_score);
+
+  return {result.total - expired_count, std::move(out), std::move(result.profile), max_text_score};
 }
 
 SearchIdResult ShardDocIndex::SearchIds(const OpArgs& op_args, const SearchParams& params,
@@ -1041,8 +1047,14 @@ SearchIdResult ShardDocIndex::SearchIds(const OpArgs& op_args, const SearchParam
         live_text_scores[id] = it->second;
     }
 
+    // Recompute the max over live docs only, mirroring ShardDocIndex::Search: a dropped
+    // top-scoring doc must not inflate the BM25STD.NORM denominator.
+    float max_text_score = 0.0f;
+    for (const auto& [id, score] : live_text_scores)
+      max_text_score = std::max(max_text_score, score);
+
     return {live_ids.size(), std::move(live_ids), std::move(live_text_scores),
-            std::move(result.profile), result.max_text_score};
+            std::move(result.profile), max_text_score};
   }
 
   // NOCONTENT returns ids without a per-id liveness check (ignore-expiration fast path); a winner

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -1014,7 +1014,8 @@ SearchResult ShardDocIndex::Search(const OpArgs& op_args, const SearchParams& pa
         {result.ids[i], string{key}, std::move(fields), knn_score, text_score, sort_score});
   }
 
-  return {result.total - expired_count, std::move(out), std::move(result.profile)};
+  return {result.total - expired_count, std::move(out), std::move(result.profile),
+          result.max_text_score};
 }
 
 SearchIdResult ShardDocIndex::SearchIds(const OpArgs& op_args, const SearchParams& params,
@@ -1041,13 +1042,13 @@ SearchIdResult ShardDocIndex::SearchIds(const OpArgs& op_args, const SearchParam
     }
 
     return {live_ids.size(), std::move(live_ids), std::move(live_text_scores),
-            std::move(result.profile)};
+            std::move(result.profile), result.max_text_score};
   }
 
   // NOCONTENT returns ids without a per-id liveness check (ignore-expiration fast path); a winner
   // deleted before the load hop is dropped there, which can yield <k results — acceptable here.
   return {result.total, std::move(result.ids), std::move(result.text_scores),
-          std::move(result.profile)};
+          std::move(result.profile), result.max_text_score};
 }
 
 search::ShardScoringStats ShardDocIndex::CollectScoringStats(

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -1018,8 +1018,10 @@ SearchResult ShardDocIndex::Search(const OpArgs& op_args, const SearchParams& pa
   // so the pre-filter result.max_text_score could otherwise normalize BM25STD.NORM by a document
   // that is not returned, pushing the best returned document below 1.0.
   float max_text_score = 0.0f;
-  for (const auto& doc : out)
-    max_text_score = std::max(max_text_score, doc.text_score);
+  if (!out.empty())
+    max_text_score = std::max_element(out.begin(), out.end(), [](const auto& a, const auto& b) {
+                       return a.text_score < b.text_score;
+                     })->text_score;
 
   return {result.total - expired_count, std::move(out), std::move(result.profile), max_text_score};
 }
@@ -1050,8 +1052,11 @@ SearchIdResult ShardDocIndex::SearchIds(const OpArgs& op_args, const SearchParam
     // Recompute the max over live docs only, mirroring ShardDocIndex::Search: a dropped
     // top-scoring doc must not inflate the BM25STD.NORM denominator.
     float max_text_score = 0.0f;
-    for (const auto& [id, score] : live_text_scores)
-      max_text_score = std::max(max_text_score, score);
+    if (!live_text_scores.empty())
+      max_text_score =
+          std::max_element(live_text_scores.begin(), live_text_scores.end(),
+                           [](const auto& a, const auto& b) { return a.second < b.second; })
+              ->second;
 
     return {live_ids.size(), std::move(live_ids), std::move(live_text_scores),
             std::move(result.profile), max_text_score};
@@ -1145,10 +1150,8 @@ vector<SearchDocData> ShardDocIndex::LoadDocEntriesWithScores(
     }
 
     if (params.add_scores) {
-      double text_score = 0;
-      if (auto it = text_score_map.find(doc); it != text_score_map.end())
-        text_score = it->second;
-      out.back()["__score"] = text_score;
+      auto it = text_score_map.find(doc);
+      out.back()["__score"] = it != text_score_map.end() ? static_cast<double>(it->second) : 0.0;
       // Hidden tie-breaker for SORTBY @__score; not added to fields_to_print.
       out.back()["__key"] = string{key};
     }

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -168,8 +168,8 @@ struct SearchParams {
   search::QueryParams query_params;
 
   bool with_scores = false;                  // WITHSCORES flag
-  std::optional<search::ScorerSpec> scorer;  // SCORER parameter (null = not set)
-  uint64_t bm25std_tanh_factor = search::kDefaultBM25StdTanhFactor;
+  std::optional<search::ScorerSpec> scorer;  // SCORER parameter (null = not set); carries the
+                                             // BM25STD.TANH factor when applicable
 
   bool ShouldReturnAllFields() const {
     return !return_fields.has_value();
@@ -235,8 +235,8 @@ struct AggregateParams {
   std::vector<aggregate::AggregationStep> steps;
 
   bool add_scores = false;                   // ADDSCORES flag
-  std::optional<search::ScorerSpec> scorer;  // SCORER parameter (null = not set)
-  uint64_t bm25std_tanh_factor = search::kDefaultBM25StdTanhFactor;
+  std::optional<search::ScorerSpec> scorer;  // SCORER parameter (null = not set); carries the
+                                             // BM25STD.TANH factor when applicable
 
   // Set only for multi-shard scoring queries; not owned.
   const search::GlobalScoringStats* global_scoring_stats = nullptr;

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -54,8 +54,11 @@ struct SearchResult {
   SearchResult() = default;
 
   SearchResult(size_t total_hits, std::vector<SerializedSearchDoc> docs,
-               std::optional<search::AlgorithmProfile> profile)
-      : total_hits{total_hits}, docs{std::move(docs)}, profile{std::move(profile)} {
+               std::optional<search::AlgorithmProfile> profile, float max_text_score = 0)
+      : total_hits{total_hits},
+        docs{std::move(docs)},
+        max_text_score{max_text_score},
+        profile{std::move(profile)} {
   }
 
   SearchResult(facade::ErrorReply error) : error{std::move(error)} {
@@ -63,6 +66,7 @@ struct SearchResult {
 
   size_t total_hits = 0;
   std::vector<SerializedSearchDoc> docs;
+  float max_text_score = 0;
   std::optional<search::AlgorithmProfile> profile;
 
   std::optional<facade::ErrorReply> error;
@@ -73,13 +77,14 @@ struct SearchIdResult {
 
   SearchIdResult(size_t total_hits, std::vector<search::DocId> ids,
                  absl::flat_hash_map<search::DocId, float> text_scores,
-                 std::optional<search::AlgorithmProfile> profile);
+                 std::optional<search::AlgorithmProfile> profile, float max_text_score = 0);
 
   SearchIdResult(facade::ErrorReply error);
 
   size_t total_hits = 0;
   std::vector<search::DocId> ids;
   absl::flat_hash_map<search::DocId, float> text_scores;
+  float max_text_score = 0;
   std::optional<search::AlgorithmProfile> profile;
 
   std::optional<facade::ErrorReply> error;
@@ -87,10 +92,12 @@ struct SearchIdResult {
 
 inline SearchIdResult::SearchIdResult(size_t total_hits, std::vector<search::DocId> ids,
                                       absl::flat_hash_map<search::DocId, float> text_scores,
-                                      std::optional<search::AlgorithmProfile> profile)
+                                      std::optional<search::AlgorithmProfile> profile,
+                                      float max_text_score)
     : total_hits{total_hits},
       ids{std::move(ids)},
       text_scores{std::move(text_scores)},
+      max_text_score{max_text_score},
       profile{std::move(profile)} {
 }
 

--- a/src/server/search/doc_index.h
+++ b/src/server/search/doc_index.h
@@ -7,6 +7,7 @@
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -159,8 +160,9 @@ struct SearchParams {
 
   search::QueryParams query_params;
 
-  bool with_scores = false;           // WITHSCORES flag
-  search::ScorerFn scorer = nullptr;  // SCORER parameter (null = not set)
+  bool with_scores = false;                  // WITHSCORES flag
+  std::optional<search::ScorerSpec> scorer;  // SCORER parameter (null = not set)
+  uint64_t bm25std_tanh_factor = search::kDefaultBM25StdTanhFactor;
 
   bool ShouldReturnAllFields() const {
     return !return_fields.has_value();
@@ -225,8 +227,9 @@ struct AggregateParams {
   std::optional<std::vector<FieldReference>> load_fields;
   std::vector<aggregate::AggregationStep> steps;
 
-  bool add_scores = false;            // ADDSCORES flag
-  search::ScorerFn scorer = nullptr;  // SCORER parameter (null = not set)
+  bool add_scores = false;                   // ADDSCORES flag
+  std::optional<search::ScorerSpec> scorer;  // SCORER parameter (null = not set)
+  uint64_t bm25std_tanh_factor = search::kDefaultBM25StdTanhFactor;
 
   // Set only for multi-shard scoring queries; not owned.
   const search::GlobalScoringStats* global_scoring_stats = nullptr;

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -528,8 +528,8 @@ constexpr string_view kBM25StdTanhFactorErr = "BM25STD_TANH_FACTOR must be a pos
 // Parses a BM25STD_TANH_FACTOR value: an integer >= 1 (no upper bound). On a missing or invalid
 // value the parser reports kBM25StdTanhFactorErr, surfaced by the caller's error handling.
 uint64_t ParseBM25StdTanhFactor(CmdArgParser* parser) {
-  return parser->NextBounded<uint64_t>(1, std::numeric_limits<uint64_t>::max(),
-                                       kBM25StdTanhFactorErr);
+  using TanhFactorInt = facade::FInt<uint64_t{1}, std::numeric_limits<uint64_t>::max()>;
+  return parser->Next<TanhFactorInt>(kBM25StdTanhFactorErr);
 }
 
 ParseResult<SearchParams> ParseSearchParams(CmdArgParser* parser) {
@@ -1215,12 +1215,9 @@ bool IsBM25StdNorm(const std::optional<search::ScorerSpec>& scorer) {
 // Global max raw text score across per-shard results, used to normalize BM25STD.NORM by the
 // max over the full matched set. Returns 0 when there are no scored docs.
 float GlobalMaxTextScore(absl::Span<const SearchResult> results) {
-  if (results.empty())
-    return 0.0f;
-  return std::max_element(
-             results.begin(), results.end(),
-             [](const auto& a, const auto& b) { return a.max_text_score < b.max_text_score; })
-      ->max_text_score;
+  auto max_it = std::ranges::max_element(
+      results, [](const auto& a, const auto& b) { return a.max_text_score < b.max_text_score; });
+  return max_it == results.end() ? 0.0f : max_it->max_text_score;
 }
 
 void SearchReply(const SearchParams& params,
@@ -2158,10 +2155,10 @@ void NormalizeHybridTextScores(absl::Span<SearchResult> text_docs) {
   if (max_text_score == 0)
     return;
 
-  std::ranges::for_each(text_docs, [max_text_score](SearchResult& shard) {
-    std::ranges::for_each(shard.docs,
-                          [max_text_score](auto& doc) { doc.text_score /= max_text_score; });
-  });
+  for (auto& shard : text_docs) {
+    for (auto& doc : shard.docs)
+      doc.text_score /= max_text_score;
+  }
 }
 
 void NormalizeAggregateScores(absl::Span<aggregate::DocValues> values) {
@@ -2177,17 +2174,15 @@ void NormalizeAggregateScores(absl::Span<aggregate::DocValues> values) {
   if (values.empty())
     return;
 
-  double max_score = get_score(*std::max_element(
-      values.begin(), values.end(),
-      [&get_score](const auto& a, const auto& b) { return get_score(a) < get_score(b); }));
+  double max_score = std::ranges::max(values | std::views::transform(get_score));
   if (max_score == 0)
     return;
 
-  std::ranges::for_each(values, [max_score](aggregate::DocValues& row) {
+  for (auto& row : values) {
     if (auto it = row.find(kScoreField); it != row.end())
       if (auto* score = std::get_if<double>(&it->second))
         *score /= max_score;
-  });
+  }
 }
 
 struct HybridExecResult {

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -512,22 +512,11 @@ search::QueryParams ParseQueryParams(CmdArgParser* parser) {
   return params;
 }
 
-std::optional<search::ScorerSpec> ParseScorer(CmdArgParser* parser, bool allow_bm25std_tanh = true,
-                                              bool allow_bm25std_norm = false) {
-  auto kind = allow_bm25std_tanh
-                  ? (allow_bm25std_norm
-                         ? parser->TryMapNext("BM25STD", search::ScorerKind::BM25STD,
-                                              "BM25STD.NORM", search::ScorerKind::BM25STD_NORM,
-                                              "BM25STD.TANH", search::ScorerKind::BM25STD_TANH,
-                                              "TFIDF", search::ScorerKind::TFIDF, "TFIDF.DOCNORM",
-                                              search::ScorerKind::TFIDF_DOCNORM)
-                         : parser->TryMapNext("BM25STD", search::ScorerKind::BM25STD,
-                                              "BM25STD.TANH", search::ScorerKind::BM25STD_TANH,
-                                              "TFIDF", search::ScorerKind::TFIDF, "TFIDF.DOCNORM",
-                                              search::ScorerKind::TFIDF_DOCNORM))
-                  : parser->TryMapNext("BM25STD", search::ScorerKind::BM25STD,  //
-                                       "TFIDF", search::ScorerKind::TFIDF,      //
-                                       "TFIDF.DOCNORM", search::ScorerKind::TFIDF_DOCNORM);
+std::optional<search::ScorerSpec> ParseScorer(CmdArgParser* parser) {
+  auto kind = parser->TryMapNext(
+      "BM25STD", search::ScorerKind::BM25STD, "BM25STD.NORM", search::ScorerKind::BM25STD_NORM,
+      "BM25STD.TANH", search::ScorerKind::BM25STD_TANH, "TFIDF", search::ScorerKind::TFIDF,
+      "TFIDF.DOCNORM", search::ScorerKind::TFIDF_DOCNORM);
   if (!kind)
     return nullopt;
   return search::ScorerSpec{*kind};
@@ -593,7 +582,7 @@ ParseResult<SearchParams> ParseSearchParams(CmdArgParser* parser) {
     } else if (parser->Check("WITHSCORES")) {
       params.with_scores = true;
     } else if (parser->Check("SCORER")) {
-      auto scorer = ParseScorer(parser, /*allow_bm25std_tanh=*/true, /*allow_bm25std_norm=*/true);
+      auto scorer = ParseScorer(parser);
       if (!scorer)
         return CreateSyntaxError(absl::StrCat("No such scorer: ", parser->Peek()));
       params.scorer = *scorer;
@@ -1810,7 +1799,7 @@ ParseResult<HybridSearchParams> ParseHybridParams(CmdArgParser* parser) {
       sub->Next();
       return;
     }
-    auto scorer_fn = ParseScorer(sub, /*allow_bm25std_tanh=*/true, /*allow_bm25std_norm=*/true);
+    auto scorer_fn = ParseScorer(sub);
     if (!scorer_fn)
       sub->ReportCustom(absl::StrCat("No such scorer: ", sub->Peek()));
     else
@@ -2188,6 +2177,29 @@ void NormalizeHybridTextScores(absl::Span<SearchResult> text_docs) {
   for (auto& shard : text_docs) {
     for (auto& doc : shard.docs)
       doc.text_score /= max_text_score;
+  }
+}
+
+void NormalizeAggregateScores(absl::Span<aggregate::DocValues> values) {
+  static constexpr std::string_view kScoreField = "__score";
+
+  double max_score = 0;
+  for (const auto& row : values) {
+    auto it = row.find(kScoreField);
+    if (it == row.end())
+      continue;
+    if (const auto* score = std::get_if<double>(&it->second))
+      max_score = std::max(max_score, *score);
+  }
+  if (max_score == 0)
+    return;
+
+  for (auto& row : values) {
+    auto it = row.find(kScoreField);
+    if (it == row.end())
+      continue;
+    if (auto* score = std::get_if<double>(&it->second))
+      *score /= max_score;
   }
 }
 
@@ -3913,6 +3925,9 @@ void CmdFtAggregate(CmdArgList args, CommandContext* cmd_cntx) {
     values =
         MergeJoinedKeysWithData(*params, *data_for_join, joined_entries, shard_keys_data_per_index);
   }
+
+  if (params->add_scores && IsBM25StdNorm(params->scorer))
+    NormalizeAggregateScores(absl::MakeSpan(values));
 
   std::vector<std::string_view> load_fields;
   if (params->load_fields) {

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -18,6 +18,7 @@
 #include <cmath>
 #include <exception>
 #include <functional>
+#include <ranges>
 #include <variant>
 #include <vector>
 
@@ -522,24 +523,13 @@ std::optional<search::ScorerSpec> ParseScorer(CmdArgParser* parser) {
   return search::ScorerSpec{*kind};
 }
 
-constexpr string_view kBM25StdTanhFactorErr =
-    "BM25STD_TANH_FACTOR must be between 1 and 10000 inclusive";
+constexpr string_view kBM25StdTanhFactorErr = "BM25STD_TANH_FACTOR must be a positive integer";
 
-std::optional<uint64_t> TryParseBM25StdTanhFactor(CmdArgParser* parser) {
-  if (!parser->HasNext())
-    return nullopt;
-
-  uint64_t factor = 0;
-  if (!absl::SimpleAtoi(parser->Next(), &factor) || factor == 0)
-    return nullopt;
-  return factor;
-}
-
-ParseResult<uint64_t> ParseBM25StdTanhFactor(CmdArgParser* parser) {
-  auto factor = TryParseBM25StdTanhFactor(parser);
-  if (!factor)
-    return CreateSyntaxError(kBM25StdTanhFactorErr);
-  return *factor;
+// Parses a BM25STD_TANH_FACTOR value: an integer >= 1 (no upper bound). On a missing or invalid
+// value the parser reports kBM25StdTanhFactorErr, surfaced by the caller's error handling.
+uint64_t ParseBM25StdTanhFactor(CmdArgParser* parser) {
+  return parser->NextBounded<uint64_t>(1, std::numeric_limits<uint64_t>::max(),
+                                       kBM25StdTanhFactorErr);
 }
 
 ParseResult<SearchParams> ParseSearchParams(CmdArgParser* parser) {
@@ -588,10 +578,7 @@ ParseResult<SearchParams> ParseSearchParams(CmdArgParser* parser) {
         return CreateSyntaxError(absl::StrCat("No such scorer: ", parser->Peek()));
       params.scorer = *scorer;
     } else if (parser->Check("BM25STD_TANH_FACTOR")) {
-      auto factor = ParseBM25StdTanhFactor(parser);
-      if (!factor)
-        return make_unexpected(factor.error());
-      tanh_factor = *factor;
+      tanh_factor = ParseBM25StdTanhFactor(parser);
     } else if (parser->Check("DIALECT")) {
       parser->Skip(1);  // Accepted and ignored — DF always behaves as dialect 2
     } else {
@@ -847,10 +834,7 @@ ParseResult<AggregateParams> ParseAggregatorParams(CmdArgParser* parser) {
     }
 
     if (parser->Check("BM25STD_TANH_FACTOR")) {
-      auto factor = ParseBM25StdTanhFactor(parser);
-      if (!factor)
-        return make_unexpected(factor.error());
-      tanh_factor = *factor;
+      tanh_factor = ParseBM25StdTanhFactor(parser);
       continue;
     }
 
@@ -1231,10 +1215,12 @@ bool IsBM25StdNorm(const std::optional<search::ScorerSpec>& scorer) {
 // Global max raw text score across per-shard results, used to normalize BM25STD.NORM by the
 // max over the full matched set. Returns 0 when there are no scored docs.
 float GlobalMaxTextScore(absl::Span<const SearchResult> results) {
-  float max_text_score = 0.0f;
-  for (const auto& shard : results)
-    max_text_score = std::max(max_text_score, shard.max_text_score);
-  return max_text_score;
+  if (results.empty())
+    return 0.0f;
+  return std::max_element(
+             results.begin(), results.end(),
+             [](const auto& a, const auto& b) { return a.max_text_score < b.max_text_score; })
+      ->max_text_score;
 }
 
 void SearchReply(const SearchParams& params,
@@ -1813,13 +1799,7 @@ ParseResult<HybridSearchParams> ParseHybridParams(CmdArgParser* parser) {
     else
       p.scorer = *scorer_fn;
   };
-  auto parse_tanh_factor = [&](CmdArgParser* sub) {
-    auto factor = TryParseBM25StdTanhFactor(sub);
-    if (!factor)
-      sub->ReportCustom(std::string{kBM25StdTanhFactorErr});
-    else
-      tanh_factor = *factor;
-  };
+  auto parse_tanh_factor = [&](CmdArgParser* sub) { tanh_factor = ParseBM25StdTanhFactor(sub); };
 
   parser->ExpectTag("SEARCH", "expected SEARCH keyword");
   p.text_query = parser->Next<string>();
@@ -1908,9 +1888,7 @@ void ComputeLinearCombined(float alpha, float beta, search::VectorSimilarity vsi
                            absl::flat_hash_map<string, HybridDocEntry>& docs) {
   for (auto& [_, e] : docs) {
     float text_score = e.has_text ? e.text_score : 0.f;
-    float knn_score = 0.f;
-    if (e.has_knn)
-      knn_score = search::DistanceToSimilarity(e.knn_dist, vsim_metric);
+    float knn_score = e.has_knn ? search::DistanceToSimilarity(e.knn_dist, vsim_metric) : 0.f;
     e.combined = alpha * text_score + beta * knn_score;  // ALPHA=text, BETA=vector
   }
 }
@@ -2180,33 +2158,36 @@ void NormalizeHybridTextScores(absl::Span<SearchResult> text_docs) {
   if (max_text_score == 0)
     return;
 
-  for (auto& shard : text_docs) {
-    for (auto& doc : shard.docs)
-      doc.text_score /= max_text_score;
-  }
+  std::ranges::for_each(text_docs, [max_text_score](SearchResult& shard) {
+    std::ranges::for_each(shard.docs,
+                          [max_text_score](auto& doc) { doc.text_score /= max_text_score; });
+  });
 }
 
 void NormalizeAggregateScores(absl::Span<aggregate::DocValues> values) {
   static constexpr std::string_view kScoreField = "__score";
 
-  double max_score = 0;
-  for (const auto& row : values) {
-    auto it = row.find(kScoreField);
-    if (it == row.end())
-      continue;
-    if (const auto* score = std::get_if<double>(&it->second))
-      max_score = std::max(max_score, *score);
-  }
+  auto get_score = [](const aggregate::DocValues& row) -> double {
+    if (auto it = row.find(kScoreField); it != row.end())
+      if (const auto* score = std::get_if<double>(&it->second))
+        return *score;
+    return 0.0;
+  };
+
+  if (values.empty())
+    return;
+
+  double max_score = get_score(*std::max_element(
+      values.begin(), values.end(),
+      [&get_score](const auto& a, const auto& b) { return get_score(a) < get_score(b); }));
   if (max_score == 0)
     return;
 
-  for (auto& row : values) {
-    auto it = row.find(kScoreField);
-    if (it == row.end())
-      continue;
-    if (auto* score = std::get_if<double>(&it->second))
-      *score /= max_score;
-  }
+  std::ranges::for_each(values, [max_score](aggregate::DocValues& row) {
+    if (auto it = row.find(kScoreField); it != row.end())
+      if (auto* score = std::get_if<double>(&it->second))
+        *score /= max_score;
+  });
 }
 
 struct HybridExecResult {

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -512,13 +512,19 @@ search::QueryParams ParseQueryParams(CmdArgParser* parser) {
   return params;
 }
 
-std::optional<search::ScorerSpec> ParseScorer(CmdArgParser* parser,
-                                              bool allow_bm25std_tanh = true) {
+std::optional<search::ScorerSpec> ParseScorer(CmdArgParser* parser, bool allow_bm25std_tanh = true,
+                                              bool allow_bm25std_norm = false) {
   auto kind = allow_bm25std_tanh
-                  ? parser->TryMapNext("BM25STD", search::ScorerKind::BM25STD,            //
-                                       "BM25STD.TANH", search::ScorerKind::BM25STD_TANH,  //
-                                       "TFIDF", search::ScorerKind::TFIDF,                //
-                                       "TFIDF.DOCNORM", search::ScorerKind::TFIDF_DOCNORM)
+                  ? (allow_bm25std_norm
+                         ? parser->TryMapNext("BM25STD", search::ScorerKind::BM25STD,
+                                              "BM25STD.NORM", search::ScorerKind::BM25STD_NORM,
+                                              "BM25STD.TANH", search::ScorerKind::BM25STD_TANH,
+                                              "TFIDF", search::ScorerKind::TFIDF, "TFIDF.DOCNORM",
+                                              search::ScorerKind::TFIDF_DOCNORM)
+                         : parser->TryMapNext("BM25STD", search::ScorerKind::BM25STD,
+                                              "BM25STD.TANH", search::ScorerKind::BM25STD_TANH,
+                                              "TFIDF", search::ScorerKind::TFIDF, "TFIDF.DOCNORM",
+                                              search::ScorerKind::TFIDF_DOCNORM))
                   : parser->TryMapNext("BM25STD", search::ScorerKind::BM25STD,  //
                                        "TFIDF", search::ScorerKind::TFIDF,      //
                                        "TFIDF.DOCNORM", search::ScorerKind::TFIDF_DOCNORM);
@@ -587,7 +593,7 @@ ParseResult<SearchParams> ParseSearchParams(CmdArgParser* parser) {
     } else if (parser->Check("WITHSCORES")) {
       params.with_scores = true;
     } else if (parser->Check("SCORER")) {
-      auto scorer = ParseScorer(parser);
+      auto scorer = ParseScorer(parser, /*allow_bm25std_tanh=*/true, /*allow_bm25std_norm=*/true);
       if (!scorer)
         return CreateSyntaxError(absl::StrCat("No such scorer: ", parser->Peek()));
       params.scorer = *scorer;
@@ -1227,6 +1233,10 @@ void PartialSortBySortScore(absl::Span<SerializedSearchDoc*> docs, size_t limit,
     run(std::greater<>{});
 }
 
+bool IsBM25StdNorm(const std::optional<search::ScorerSpec>& scorer) {
+  return scorer && scorer->kind == search::ScorerKind::BM25STD_NORM;
+}
+
 void SearchReply(const SearchParams& params,
                  std::optional<search::KnnScoreSortOption> knn_sort_option,
                  std::string_view inject_score_alias, absl::Span<SearchResult> results,
@@ -1238,6 +1248,16 @@ void SearchReply(const SearchParams& params,
     total_hits += shard_results.total_hits;
     for (auto& doc : shard_results.docs) {
       docs.push_back(&doc);
+    }
+  }
+
+  if (IsBM25StdNorm(params.scorer)) {
+    float max_text_score = 0.0f;
+    for (const auto& shard_results : results)
+      max_text_score = std::max(max_text_score, shard_results.max_text_score);
+    if (max_text_score > 0) {
+      for (auto* doc : docs)
+        doc->text_score /= max_text_score;
     }
   }
 
@@ -1456,6 +1476,8 @@ vector<SearchResult> LoadHnswSearchDocs(
                 });
 
   results[0].total_hits = knn_search_serialized_docs.size();
+  for (const auto& doc : knn_search_serialized_docs)
+    results[0].max_text_score = std::max(results[0].max_text_score, doc.text_score);
   results[0].docs = std::move(knn_search_serialized_docs);
 
   return results;

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -8,6 +8,7 @@
 #include <absl/container/flat_hash_map.h>
 #include <absl/flags/flag.h>
 #include <absl/strings/match.h>
+#include <absl/strings/numbers.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_join.h>
 #include <absl/strings/str_split.h>
@@ -511,10 +512,30 @@ search::QueryParams ParseQueryParams(CmdArgParser* parser) {
   return params;
 }
 
-std::optional<search::ScorerFn> ParseScorer(CmdArgParser* parser) {
-  return parser->TryMapNext("BM25STD", &search::BM25Std,  //
-                            "TFIDF", &search::TfIdf,      //
-                            "TFIDF.DOCNORM", &search::TfIdfDocNorm);
+std::optional<search::ScorerSpec> ParseScorer(CmdArgParser* parser,
+                                              bool allow_bm25std_tanh = true) {
+  auto kind = allow_bm25std_tanh
+                  ? parser->TryMapNext("BM25STD", search::ScorerKind::BM25STD,            //
+                                       "BM25STD.TANH", search::ScorerKind::BM25STD_TANH,  //
+                                       "TFIDF", search::ScorerKind::TFIDF,                //
+                                       "TFIDF.DOCNORM", search::ScorerKind::TFIDF_DOCNORM)
+                  : parser->TryMapNext("BM25STD", search::ScorerKind::BM25STD,  //
+                                       "TFIDF", search::ScorerKind::TFIDF,      //
+                                       "TFIDF.DOCNORM", search::ScorerKind::TFIDF_DOCNORM);
+  if (!kind)
+    return nullopt;
+  return search::ScorerSpec{*kind};
+}
+
+ParseResult<uint64_t> ParseBM25StdTanhFactor(CmdArgParser* parser) {
+  constexpr string_view kErr = "BM25STD_TANH_FACTOR must be between 1 and 10000 inclusive";
+  if (!parser->HasNext())
+    return CreateSyntaxError(kErr);
+
+  uint64_t factor = 0;
+  if (!absl::SimpleAtoi(parser->Next(), &factor) || factor == 0)
+    return CreateSyntaxError(kErr);
+  return factor;
 }
 
 ParseResult<SearchParams> ParseSearchParams(CmdArgParser* parser) {
@@ -561,6 +582,11 @@ ParseResult<SearchParams> ParseSearchParams(CmdArgParser* parser) {
       if (!scorer)
         return CreateSyntaxError(absl::StrCat("No such scorer: ", parser->Peek()));
       params.scorer = *scorer;
+    } else if (parser->Check("BM25STD_TANH_FACTOR")) {
+      auto factor = ParseBM25StdTanhFactor(parser);
+      if (!factor)
+        return make_unexpected(factor.error());
+      params.bm25std_tanh_factor = *factor;
     } else if (parser->Check("DIALECT")) {
       parser->Skip(1);  // Accepted and ignored — DF always behaves as dialect 2
     } else {
@@ -570,6 +596,8 @@ ParseResult<SearchParams> ParseSearchParams(CmdArgParser* parser) {
   }
 
   params.limit_total = std::min(params.limit_total, max_results);
+  if (params.scorer)
+    params.scorer->bm25std_tanh_factor = params.bm25std_tanh_factor;
 
   return params;
 }
@@ -812,6 +840,14 @@ ParseResult<AggregateParams> ParseAggregatorParams(CmdArgParser* parser) {
       continue;
     }
 
+    if (parser->Check("BM25STD_TANH_FACTOR")) {
+      auto factor = ParseBM25StdTanhFactor(parser);
+      if (!factor)
+        return make_unexpected(factor.error());
+      params.bm25std_tanh_factor = *factor;
+      continue;
+    }
+
     // DIALECT (accepted and ignored — DF always behaves as dialect 2)
     if (parser->Check("DIALECT")) {
       parser->Skip(1);
@@ -854,6 +890,9 @@ ParseResult<AggregateParams> ParseAggregatorParams(CmdArgParser* parser) {
 
     return CreateSyntaxError(absl::StrCat("Unknown clause: ", parser->Peek()));
   }
+
+  if (params.scorer)
+    params.scorer->bm25std_tanh_factor = params.bm25std_tanh_factor;
 
   return params;
 }
@@ -1687,7 +1726,7 @@ struct HybridSearchParams {
 
   string text_query;
   string yield_text_score_as;
-  search::ScorerFn scorer = nullptr;
+  std::optional<search::ScorerSpec> scorer;
 
   string vsim_field;
   string vsim_param;
@@ -1739,7 +1778,7 @@ ParseResult<HybridSearchParams> ParseHybridParams(CmdArgParser* parser) {
       sub->Next();
       return;
     }
-    auto scorer_fn = ParseScorer(sub);
+    auto scorer_fn = ParseScorer(sub, /*allow_bm25std_tanh=*/false);
     if (!scorer_fn)
       sub->ReportCustom(absl::StrCat("No such scorer: ", sub->Peek()));
     else
@@ -2140,7 +2179,7 @@ bool RunHybridSearch(string_view index_name, HybridSearchParams* params, Command
     rb->SendError("Query syntax error in SEARCH clause");
     return false;
   }
-  text_algo.SetScorer(params->scorer ? params->scorer : &search::BM25Std);
+  text_algo.SetScorer(params->scorer ? *params->scorer : search::ScorerSpec{});
   if (enable_profile)
     text_algo.EnableProfiling();
 
@@ -2880,9 +2919,9 @@ void CmdFtSearch(CmdArgList args, CommandContext* cmd_cntx) {
 
   // Enable scorer: explicit SCORER param, or default BM25STD when WITHSCORES is set
   if (params->scorer)
-    search_algo.SetScorer(params->scorer);
+    search_algo.SetScorer(*params->scorer);
   else if (params->with_scores)
-    search_algo.SetScorer(&search::BM25Std);
+    search_algo.SetScorer(search::ScorerSpec{});
 
   auto [knn_node, knn] = TryPopHnswKnnNode(search_algo, index_name);
 
@@ -3208,9 +3247,9 @@ void CmdFtProfile(CmdArgList args, CommandContext* cmd_cntx) {
 
   // Enable scorer: explicit SCORER param, or default BM25STD when WITHSCORES is set
   if (params->scorer)
-    search_algo.SetScorer(params->scorer);
+    search_algo.SetScorer(*params->scorer);
   else if (params->with_scores)
-    search_algo.SetScorer(&search::BM25Std);
+    search_algo.SetScorer(search::ScorerSpec{});
 
   search_algo.EnableProfiling();
 
@@ -3701,9 +3740,9 @@ void CmdFtAggregate(CmdArgList args, CommandContext* cmd_cntx) {
 
     // Enable scorer: explicit SCORER param, or default BM25STD when ADDSCORES is set
     if (params->scorer)
-      search_algo.SetScorer(params->scorer);
+      search_algo.SetScorer(*params->scorer);
     else if (params->add_scores)
-      search_algo.SetScorer(&search::BM25Std);
+      search_algo.SetScorer(search::ScorerSpec{});
 
     std::vector<std::vector<SearchDocData>> query_results(shard_set->size());
 

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -1810,7 +1810,7 @@ ParseResult<HybridSearchParams> ParseHybridParams(CmdArgParser* parser) {
       sub->Next();
       return;
     }
-    auto scorer_fn = ParseScorer(sub);
+    auto scorer_fn = ParseScorer(sub, /*allow_bm25std_tanh=*/true, /*allow_bm25std_norm=*/true);
     if (!scorer_fn)
       sub->ReportCustom(absl::StrCat("No such scorer: ", sub->Peek()));
     else
@@ -2178,6 +2178,19 @@ HybridDocMap MergeHybridResults(const vector<SearchResult>& text_docs,
   return doc_map;
 }
 
+void NormalizeHybridTextScores(absl::Span<SearchResult> text_docs) {
+  float max_text_score = 0.0f;
+  for (const auto& shard : text_docs)
+    max_text_score = std::max(max_text_score, shard.max_text_score);
+  if (max_text_score == 0)
+    return;
+
+  for (auto& shard : text_docs) {
+    for (auto& doc : shard.docs)
+      doc.text_score /= max_text_score;
+  }
+}
+
 struct HybridExecResult {
   HybridDocMap doc_map;
   search::VectorSimilarity vsim_metric = search::VectorSimilarity::L2;
@@ -2417,6 +2430,8 @@ bool RunHybridSearch(string_view index_name, HybridSearchParams* params, Command
   }
 
   const absl::Time t_combine = absl::Now();
+  if (IsBM25StdNorm(params->scorer))
+    NormalizeHybridTextScores(absl::MakeSpan(text_docs));
   auto doc_map = MergeHybridResults(text_docs, hnsw_shard_docs, flat_knn_docs, use_hnsw);
   if (params->combine_method == HybridSearchParams::CombineMethod::LINEAR)
     ComputeLinearCombined(params->alpha, params->beta, captured_metric, doc_map);

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -527,15 +527,24 @@ std::optional<search::ScorerSpec> ParseScorer(CmdArgParser* parser,
   return search::ScorerSpec{*kind};
 }
 
-ParseResult<uint64_t> ParseBM25StdTanhFactor(CmdArgParser* parser) {
-  constexpr string_view kErr = "BM25STD_TANH_FACTOR must be between 1 and 10000 inclusive";
+constexpr string_view kBM25StdTanhFactorErr =
+    "BM25STD_TANH_FACTOR must be between 1 and 10000 inclusive";
+
+std::optional<uint64_t> TryParseBM25StdTanhFactor(CmdArgParser* parser) {
   if (!parser->HasNext())
-    return CreateSyntaxError(kErr);
+    return nullopt;
 
   uint64_t factor = 0;
   if (!absl::SimpleAtoi(parser->Next(), &factor) || factor == 0)
-    return CreateSyntaxError(kErr);
+    return nullopt;
   return factor;
+}
+
+ParseResult<uint64_t> ParseBM25StdTanhFactor(CmdArgParser* parser) {
+  auto factor = TryParseBM25StdTanhFactor(parser);
+  if (!factor)
+    return CreateSyntaxError(kBM25StdTanhFactorErr);
+  return *factor;
 }
 
 ParseResult<SearchParams> ParseSearchParams(CmdArgParser* parser) {
@@ -1727,6 +1736,7 @@ struct HybridSearchParams {
   string text_query;
   string yield_text_score_as;
   std::optional<search::ScorerSpec> scorer;
+  uint64_t bm25std_tanh_factor = search::kDefaultBM25StdTanhFactor;
 
   string vsim_field;
   string vsim_param;
@@ -1778,16 +1788,26 @@ ParseResult<HybridSearchParams> ParseHybridParams(CmdArgParser* parser) {
       sub->Next();
       return;
     }
-    auto scorer_fn = ParseScorer(sub, /*allow_bm25std_tanh=*/false);
+    auto scorer_fn = ParseScorer(sub);
     if (!scorer_fn)
       sub->ReportCustom(absl::StrCat("No such scorer: ", sub->Peek()));
     else
       p.scorer = *scorer_fn;
   };
+  auto parse_tanh_factor = [&](CmdArgParser* sub) {
+    auto factor = TryParseBM25StdTanhFactor(sub);
+    if (!factor)
+      sub->ReportCustom(std::string{kBM25StdTanhFactorErr});
+    else
+      p.bm25std_tanh_factor = *factor;
+  };
 
   parser->ExpectTag("SEARCH", "expected SEARCH keyword");
   p.text_query = parser->Next<string>();
-  parser->Apply(Tag("SCORER", parse_scorer), Tag("YIELD_SCORE_AS", &p.yield_text_score_as));
+  parser->Apply(Tag("SCORER", parse_scorer), Tag("BM25STD_TANH_FACTOR", parse_tanh_factor),
+                Tag("YIELD_SCORE_AS", &p.yield_text_score_as));
+  if (p.scorer)
+    p.scorer->bm25std_tanh_factor = p.bm25std_tanh_factor;
 
   parser->ExpectTag("VSIM", "expected VSIM keyword");
   p.vsim_field = string{parser->ExpectStartsWith("@", "VSIM field must start with @")};
@@ -1865,29 +1885,14 @@ ParseResult<HybridSearchParams> ParseHybridParams(CmdArgParser* parser) {
   return p;
 }
 
-void ComputeLinearCombined(float alpha, float beta,
+void ComputeLinearCombined(float alpha, float beta, search::VectorSimilarity vsim_metric,
                            absl::flat_hash_map<string, HybridDocEntry>& docs) {
-  float max_text = 0.0f;
-  float min_dist = std::numeric_limits<float>::max();
-  float max_dist = 0.0f;
-
-  for (const auto& [_, e] : docs) {
-    if (e.has_text)
-      max_text = std::max(max_text, e.text_score);
-    if (e.has_knn) {
-      min_dist = std::min(min_dist, e.knn_dist);
-      max_dist = std::max(max_dist, e.knn_dist);
-    }
-  }
-
-  const float dist_range = (max_dist > min_dist) ? max_dist - min_dist : 0.0f;
-
   for (auto& [_, e] : docs) {
-    float norm_text = (e.has_text && max_text > 0.f) ? e.text_score / max_text : 0.f;
-    float norm_knn = 0.f;
+    float text_score = e.has_text ? e.text_score : 0.f;
+    float knn_score = 0.f;
     if (e.has_knn)
-      norm_knn = (dist_range > 0.f) ? 1.f - (e.knn_dist - min_dist) / dist_range : 1.f;
-    e.combined = alpha * norm_text + beta * norm_knn;  // ALPHA=text, BETA=vector
+      knn_score = search::DistanceToSimilarity(e.knn_dist, vsim_metric);
+    e.combined = alpha * text_score + beta * knn_score;  // ALPHA=text, BETA=vector
   }
 }
 
@@ -2392,7 +2397,7 @@ bool RunHybridSearch(string_view index_name, HybridSearchParams* params, Command
   const absl::Time t_combine = absl::Now();
   auto doc_map = MergeHybridResults(text_docs, hnsw_shard_docs, flat_knn_docs, use_hnsw);
   if (params->combine_method == HybridSearchParams::CombineMethod::LINEAR)
-    ComputeLinearCombined(params->alpha, params->beta, doc_map);
+    ComputeLinearCombined(params->alpha, params->beta, captured_metric, doc_map);
   else
     ComputeRrfCombined(params->rrf_constant, doc_map);
   const absl::Duration combine_took = absl::Now() - t_combine;

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -544,6 +544,7 @@ ParseResult<uint64_t> ParseBM25StdTanhFactor(CmdArgParser* parser) {
 
 ParseResult<SearchParams> ParseSearchParams(CmdArgParser* parser) {
   SearchParams params;
+  uint64_t tanh_factor = search::kDefaultBM25StdTanhFactor;
 
   const size_t max_results = absl::GetFlag(FLAGS_MAXSEARCHRESULTS);
 
@@ -590,7 +591,7 @@ ParseResult<SearchParams> ParseSearchParams(CmdArgParser* parser) {
       auto factor = ParseBM25StdTanhFactor(parser);
       if (!factor)
         return make_unexpected(factor.error());
-      params.bm25std_tanh_factor = *factor;
+      tanh_factor = *factor;
     } else if (parser->Check("DIALECT")) {
       parser->Skip(1);  // Accepted and ignored — DF always behaves as dialect 2
     } else {
@@ -601,7 +602,7 @@ ParseResult<SearchParams> ParseSearchParams(CmdArgParser* parser) {
 
   params.limit_total = std::min(params.limit_total, max_results);
   if (params.scorer)
-    params.scorer->bm25std_tanh_factor = params.bm25std_tanh_factor;
+    params.scorer->bm25std_tanh_factor = tanh_factor;
 
   return params;
 }
@@ -714,6 +715,7 @@ ParseResult<AggregateParams::JoinParams> ParseAggregatorJoinParams(
 
 ParseResult<AggregateParams> ParseAggregatorParams(CmdArgParser* parser) {
   AggregateParams params;
+  uint64_t tanh_factor = search::kDefaultBM25StdTanhFactor;
   tie(params.index, params.query) = parser->Next<string_view, string_view>();
 
   // Used for join params
@@ -848,7 +850,7 @@ ParseResult<AggregateParams> ParseAggregatorParams(CmdArgParser* parser) {
       auto factor = ParseBM25StdTanhFactor(parser);
       if (!factor)
         return make_unexpected(factor.error());
-      params.bm25std_tanh_factor = *factor;
+      tanh_factor = *factor;
       continue;
     }
 
@@ -896,7 +898,7 @@ ParseResult<AggregateParams> ParseAggregatorParams(CmdArgParser* parser) {
   }
 
   if (params.scorer)
-    params.scorer->bm25std_tanh_factor = params.bm25std_tanh_factor;
+    params.scorer->bm25std_tanh_factor = tanh_factor;
 
   return params;
 }
@@ -1226,6 +1228,15 @@ bool IsBM25StdNorm(const std::optional<search::ScorerSpec>& scorer) {
   return scorer && scorer->kind == search::ScorerKind::BM25STD_NORM;
 }
 
+// Global max raw text score across per-shard results, used to normalize BM25STD.NORM by the
+// max over the full matched set. Returns 0 when there are no scored docs.
+float GlobalMaxTextScore(absl::Span<const SearchResult> results) {
+  float max_text_score = 0.0f;
+  for (const auto& shard : results)
+    max_text_score = std::max(max_text_score, shard.max_text_score);
+  return max_text_score;
+}
+
 void SearchReply(const SearchParams& params,
                  std::optional<search::KnnScoreSortOption> knn_sort_option,
                  std::string_view inject_score_alias, absl::Span<SearchResult> results,
@@ -1241,10 +1252,7 @@ void SearchReply(const SearchParams& params,
   }
 
   if (IsBM25StdNorm(params.scorer)) {
-    float max_text_score = 0.0f;
-    for (const auto& shard_results : results)
-      max_text_score = std::max(max_text_score, shard_results.max_text_score);
-    if (max_text_score > 0) {
+    if (float max_text_score = GlobalMaxTextScore(results); max_text_score > 0) {
       for (auto* doc : docs)
         doc->text_score /= max_text_score;
     }
@@ -1746,8 +1754,7 @@ struct HybridSearchParams {
 
   string text_query;
   string yield_text_score_as;
-  std::optional<search::ScorerSpec> scorer;
-  uint64_t bm25std_tanh_factor = search::kDefaultBM25StdTanhFactor;
+  std::optional<search::ScorerSpec> scorer;  // carries the BM25STD.TANH factor when applicable
 
   string vsim_field;
   string vsim_param;
@@ -1793,6 +1800,7 @@ ParseResult<HybridSearchParams> ParseHybridParams(CmdArgParser* parser) {
   using facade::Tag;
 
   HybridSearchParams p;
+  uint64_t tanh_factor = search::kDefaultBM25StdTanhFactor;
 
   auto parse_scorer = [&](CmdArgParser* sub) {
     if (p.scorer) {
@@ -1810,7 +1818,7 @@ ParseResult<HybridSearchParams> ParseHybridParams(CmdArgParser* parser) {
     if (!factor)
       sub->ReportCustom(std::string{kBM25StdTanhFactorErr});
     else
-      p.bm25std_tanh_factor = *factor;
+      tanh_factor = *factor;
   };
 
   parser->ExpectTag("SEARCH", "expected SEARCH keyword");
@@ -1818,7 +1826,7 @@ ParseResult<HybridSearchParams> ParseHybridParams(CmdArgParser* parser) {
   parser->Apply(Tag("SCORER", parse_scorer), Tag("BM25STD_TANH_FACTOR", parse_tanh_factor),
                 Tag("YIELD_SCORE_AS", &p.yield_text_score_as));
   if (p.scorer)
-    p.scorer->bm25std_tanh_factor = p.bm25std_tanh_factor;
+    p.scorer->bm25std_tanh_factor = tanh_factor;
 
   parser->ExpectTag("VSIM", "expected VSIM keyword");
   p.vsim_field = string{parser->ExpectStartsWith("@", "VSIM field must start with @")};
@@ -2168,9 +2176,7 @@ HybridDocMap MergeHybridResults(const vector<SearchResult>& text_docs,
 }
 
 void NormalizeHybridTextScores(absl::Span<SearchResult> text_docs) {
-  float max_text_score = 0.0f;
-  for (const auto& shard : text_docs)
-    max_text_score = std::max(max_text_score, shard.max_text_score);
+  float max_text_score = GlobalMaxTextScore(text_docs);
   if (max_text_score == 0)
     return;
 

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -7331,6 +7331,63 @@ TEST_F(SearchFamilyTest, FtSearchScorerBM25StdTanh) {
   EXPECT_GT(tanh_default["d:1"], tanh_default["d:2"]);
 }
 
+TEST_F(SearchFamilyTest, FtSearchScorerBM25StdNorm) {
+  EXPECT_EQ(
+      Run({"ft.create", "idx", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "content", "TEXT"}),
+      "OK");
+  Run({"hset", "d:1", "content", "hello world hello hello"});
+  Run({"hset", "d:2", "content", "hello there"});
+
+  auto search_scores = [&](std::initializer_list<std::string_view> extra_args) {
+    std::vector<std::string> cmd{"ft.search", "idx", "hello", "NOCONTENT", "WITHSCORES"};
+    for (std::string_view arg : extra_args)
+      cmd.emplace_back(arg);
+
+    auto resp = Run(absl::Span<const std::string>(cmd));
+    EXPECT_THAT(resp, ArgType(RespExpr::ARRAY));
+
+    std::map<std::string, double> scores;
+    const auto& vals = resp.GetVec();
+    for (size_t i = 1; i + 1 < vals.size(); i += 2)
+      scores[vals[i].GetString()] = std::stod(vals[i + 1].GetString());
+    return scores;
+  };
+
+  auto raw = search_scores({"SCORER", "BM25STD"});
+  auto norm = search_scores({"SCORER", "BM25STD.NORM"});
+
+  ASSERT_EQ(raw.size(), 2u);
+  ASSERT_EQ(norm.size(), raw.size());
+  double max_raw = std::max_element(raw.begin(), raw.end(), [](const auto& a, const auto& b) {
+                     return a.second < b.second;
+                   })->second;
+  for (const auto& [key, score] : raw)
+    EXPECT_NEAR(norm[key], score / max_raw, 1e-5);
+  EXPECT_DOUBLE_EQ(norm["d:1"], 1.0);
+  EXPECT_GT(norm["d:2"], 0.0);
+}
+
+TEST_F(SearchFamilyTest, FtSearchBM25StdNormLimitStable) {
+  EXPECT_EQ(
+      Run({"ft.create", "idx", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "content", "TEXT"}),
+      "OK");
+  Run({"hset", "d:1", "content", "hello world hello hello"});
+  Run({"hset", "d:2", "content", "hello there"});
+
+  auto full =
+      Run({"ft.search", "idx", "hello", "NOCONTENT", "WITHSCORES", "SCORER", "BM25STD.NORM"});
+  auto limited = Run({"ft.search", "idx", "hello", "NOCONTENT", "WITHSCORES", "SCORER",
+                      "BM25STD.NORM", "LIMIT", "0", "1"});
+  ASSERT_THAT(full, ArgType(RespExpr::ARRAY));
+  ASSERT_THAT(limited, ArgType(RespExpr::ARRAY));
+  ASSERT_GE(full.GetVec().size(), 3u);
+  ASSERT_GE(limited.GetVec().size(), 3u);
+
+  EXPECT_EQ(full.GetVec()[1].GetString(), limited.GetVec()[1].GetString());
+  EXPECT_DOUBLE_EQ(std::stod(full.GetVec()[2].GetString()),
+                   std::stod(limited.GetVec()[2].GetString()));
+}
+
 TEST_F(SearchFamilyTest, FtSearchBM25StdTanhFactorValidation) {
   EXPECT_EQ(Run({"ft.create", "idx", "ON", "HASH", "SCHEMA", "content", "TEXT"}), "OK");
   Run({"hset", "d:1", "content", "hello"});

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cmath>
 #include <string_view>
 
 #include "base/flags.h"
@@ -7292,6 +7293,77 @@ TEST_F(SearchFamilyTest, AggregateAddScoresSimple) {
   EXPECT_GT(score1, 0.0) << "First result should have positive score";
   EXPECT_GT(score2, 0.0) << "Second result should have positive score";
   EXPECT_GE(score1, score2) << "Results should be sorted by score DESC";
+}
+
+TEST_F(SearchFamilyTest, FtSearchScorerBM25StdTanh) {
+  EXPECT_EQ(
+      Run({"ft.create", "idx", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "content", "TEXT"}),
+      "OK");
+  Run({"hset", "d:1", "content", "hello world hello hello"});
+  Run({"hset", "d:2", "content", "hello there"});
+
+  auto search_scores = [&](std::initializer_list<std::string_view> extra_args) {
+    std::vector<std::string> cmd{"ft.search", "idx", "hello", "NOCONTENT", "WITHSCORES"};
+    for (std::string_view arg : extra_args)
+      cmd.emplace_back(arg);
+
+    auto resp = Run(absl::Span<const std::string>(cmd));
+    EXPECT_THAT(resp, ArgType(RespExpr::ARRAY));
+
+    std::map<std::string, double> scores;
+    const auto& vals = resp.GetVec();
+    for (size_t i = 1; i + 1 < vals.size(); i += 2)
+      scores[vals[i].GetString()] = std::stod(vals[i + 1].GetString());
+    return scores;
+  };
+
+  auto raw = search_scores({"SCORER", "BM25STD"});
+  auto tanh_default = search_scores({"SCORER", "BM25STD.TANH"});
+  auto tanh_custom = search_scores({"SCORER", "BM25STD.TANH", "BM25STD_TANH_FACTOR", "20"});
+  auto factor_ignored = search_scores({"SCORER", "BM25STD", "BM25STD_TANH_FACTOR", "20"});
+
+  ASSERT_EQ(raw.size(), 2u);
+  EXPECT_EQ(raw, factor_ignored);
+  for (const auto& [key, score] : raw) {
+    EXPECT_NEAR(tanh_default[key], std::tanh(score / 4), 1e-6);
+    EXPECT_NEAR(tanh_custom[key], std::tanh(score / 20), 1e-6);
+  }
+  EXPECT_GT(tanh_default["d:1"], tanh_default["d:2"]);
+}
+
+TEST_F(SearchFamilyTest, FtSearchBM25StdTanhFactorValidation) {
+  EXPECT_EQ(Run({"ft.create", "idx", "ON", "HASH", "SCHEMA", "content", "TEXT"}), "OK");
+  Run({"hset", "d:1", "content", "hello"});
+
+  auto resp = Run({"ft.search", "idx", "hello", "WITHSCORES", "SCORER", "BM25STD.TANH",
+                   "BM25STD_TANH_FACTOR", "0"});
+  ASSERT_EQ(resp.type, RespExpr::ERROR);
+  EXPECT_THAT(string{resp.GetString()},
+              HasSubstr("BM25STD_TANH_FACTOR must be between 1 and 10000 inclusive"));
+
+  resp = Run({"ft.search", "idx", "hello", "WITHSCORES", "SCORER", "BM25STD.TANH",
+              "BM25STD_TANH_FACTOR", "10001"});
+  EXPECT_NE(resp.type, RespExpr::ERROR);
+}
+
+TEST_F(SearchFamilyTest, FtAggregateBM25StdTanhAddScores) {
+  EXPECT_EQ(
+      Run({"ft.create", "idx", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "content", "TEXT"}),
+      "OK");
+  Run({"hset", "d:1", "content", "hello world hello hello"});
+  Run({"hset", "d:2", "content", "hello there"});
+
+  auto resp = Run({"ft.aggregate", "idx", "hello", "ADDSCORES", "SCORER", "BM25STD.TANH",
+                   "BM25STD_TANH_FACTOR", "20", "SORTBY", "2", "@__score", "DESC"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+
+  const auto& results = resp.GetVec();
+  ASSERT_GE(results.size(), 3u);
+  double first_score = map_score("__score", results[1].GetVec());
+  double second_score = map_score("__score", results[2].GetVec());
+  EXPECT_GT(first_score, 0.0);
+  EXPECT_GT(second_score, 0.0);
+  EXPECT_GT(first_score, second_score);
 }
 
 // Verify per-field BM25 scoring: a long "body" field shouldn't penalize a short "title" match

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -7906,6 +7906,29 @@ TEST_F(SearchFamilyTest, FtHybridLinearNoTextRescale) {
   EXPECT_NEAR(HybridScore(hybrid, 1), map_score("__score", agg.GetVec()[2].GetVec()), 1e-6);
 }
 
+TEST_F(SearchFamilyTest, FtHybridScorerBM25StdNorm) {
+  CreateFlatHashIdx();
+  Run({"HSET", "d:1", "title", "apple apple apple", "vec", FloatVec1(1.0f)});
+  Run({"HSET", "d:2", "title", "apple", "vec", FloatVec1(2.0f)});
+
+  auto search = Run({"FT.SEARCH", "idx", "apple", "NOCONTENT", "WITHSCORES", "SCORER",
+                     "BM25STD.NORM", "LIMIT", "0", "2"});
+  ASSERT_THAT(search, ArgType(RespExpr::ARRAY));
+  ASSERT_GE(search.GetVec().size(), 5u);
+
+  auto hybrid = Run({"FT.HYBRID", "idx",    "SEARCH", "apple",   "SCORER",       "BM25STD.NORM",
+                     "VSIM",      "@vec",   "$v",     "COMBINE", "LINEAR",       "4",
+                     "ALPHA",     "1.0",    "BETA",   "0.0",     "LIMIT",        "0",
+                     "2",         "PARAMS", "2",      "v",       FloatVec1(1.0f)});
+  ASSERT_HYBRID_RESP(hybrid);
+  ASSERT_EQ(HybridKeys(hybrid).size(), 2u);
+
+  EXPECT_EQ(HybridKeys(hybrid)[0], search.GetVec()[1].GetString());
+  EXPECT_EQ(HybridKeys(hybrid)[1], search.GetVec()[3].GetString());
+  EXPECT_NEAR(HybridScore(hybrid, 0), std::stod(search.GetVec()[2].GetString()), 1e-6);
+  EXPECT_NEAR(HybridScore(hybrid, 1), std::stod(search.GetVec()[4].GetString()), 1e-6);
+}
+
 TEST_F(SearchFamilyTest, FtHybridScorerBM25StdTanh) {
   CreateFlatHashIdx();
   Run({"HSET", "d:1", "title", "apple apple apple", "vec", FloatVec1(1.0f)});

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -7403,6 +7403,133 @@ TEST_F(SearchFamilyTest, FtSearchBM25StdTanhFactorValidation) {
   EXPECT_NE(resp.type, RespExpr::ERROR);
 }
 
+// Runs with the default multi-shard fixture (num_shards == 2). BM25STD.NORM must use ONE
+// global max across shards: only the single global best document gets 1.0. A per-shard
+// normalization bug would make one document per shard reach 1.0.
+TEST_F(SearchFamilyTest, FtSearchBM25StdNormMultiShard) {
+  EXPECT_EQ(
+      Run({"ft.create", "idx", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "content", "TEXT"}),
+      "OK");
+  // Distinct "hello" frequencies -> distinct scores; several keys spread across shards.
+  Run({"hset", "d:1", "content", "hello"});
+  Run({"hset", "d:2", "content", "hello hello"});
+  Run({"hset", "d:3", "content", "hello hello hello"});
+  Run({"hset", "d:4", "content", "hello hello hello hello"});
+  Run({"hset", "d:5", "content", "hello hello hello hello hello"});
+  Run({"hset", "d:6", "content", "hello hello hello hello hello hello"});
+
+  auto scores = [&](std::string_view scorer) {
+    std::vector<std::string> cmd{"ft.search", "idx",          "hello", "NOCONTENT", "WITHSCORES",
+                                 "SCORER",    string{scorer}, "LIMIT", "0",         "100"};
+    auto resp = Run(absl::Span<const std::string>(cmd));
+    EXPECT_THAT(resp, ArgType(RespExpr::ARRAY));
+    std::map<std::string, double> out;
+    const auto& vals = resp.GetVec();
+    for (size_t i = 1; i + 1 < vals.size(); i += 2)
+      out[string{vals[i].GetString()}] = std::stod(string{vals[i + 1].GetString()});
+    return out;
+  };
+
+  auto raw = scores("BM25STD");
+  auto norm = scores("BM25STD.NORM");
+  ASSERT_EQ(raw.size(), 6u);
+  ASSERT_EQ(norm.size(), 6u);
+
+  double max_raw = 0;
+  for (const auto& [key, score] : raw)
+    max_raw = std::max(max_raw, score);
+
+  int winners = 0;
+  for (const auto& [key, score] : norm) {
+    EXPECT_NEAR(score, raw[key] / max_raw, 1e-5) << "key=" << key;
+    EXPECT_LE(score, 1.0 + 1e-9);
+    if (std::abs(score - 1.0) < 1e-9)
+      winners++;
+  }
+  EXPECT_EQ(winners, 1) << "exactly one global winner should reach 1.0";
+}
+
+// FT.PROFILE SEARCH must not change score semantics: BM25STD.NORM through profile yields the
+// same normalized scores as a plain FT.SEARCH.
+TEST_F(SearchFamilyTest, FtProfileSearchBM25StdNorm) {
+  EXPECT_EQ(
+      Run({"ft.create", "idx", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "content", "TEXT"}),
+      "OK");
+  Run({"hset", "d:1", "content", "hello world hello hello"});
+  Run({"hset", "d:2", "content", "hello there"});
+
+  auto parse_scores = [](const RespExpr::Vec& vals) {
+    std::map<std::string, double> out;
+    for (size_t i = 1; i + 1 < vals.size(); i += 2)
+      out[string{vals[i].GetString()}] = std::stod(string{vals[i + 1].GetString()});
+    return out;
+  };
+
+  auto search =
+      Run({"ft.search", "idx", "hello", "NOCONTENT", "WITHSCORES", "SCORER", "BM25STD.NORM"});
+  ASSERT_THAT(search, ArgType(RespExpr::ARRAY));
+  auto search_scores = parse_scores(search.GetVec());
+
+  auto profile = Run({"ft.profile", "idx", "SEARCH", "QUERY", "hello", "NOCONTENT", "WITHSCORES",
+                      "SCORER", "BM25STD.NORM"});
+  ASSERT_ARRAY_OF_TWO_ARRAYS(profile);
+  auto profile_scores = parse_scores(profile.GetVec()[0].GetVec());
+
+  ASSERT_EQ(search_scores.size(), 2u);
+  EXPECT_EQ(profile_scores.size(), search_scores.size());
+  EXPECT_DOUBLE_EQ(search_scores["d:1"], 1.0);
+  for (const auto& [key, score] : search_scores)
+    EXPECT_NEAR(profile_scores[key], score, 1e-6) << "key=" << key;
+}
+
+// FT.SEARCH with a KNN vector query + text prefilter: BM25STD.NORM normalizes the per-doc
+// text prefilter score (returned via WITHSCORES) by the max over the KNN-selected docs.
+TEST_F(SearchFamilyTest, FtSearchKnnPrefilterBM25StdNorm) {
+  CreateFlatHashIdx();  // title TEXT + vec FLAT DIM 1 L2, prefix "d:"
+  Run({"HSET", "d:1", "title", "apple apple apple", "vec", FloatVec1(1.0f)});
+  Run({"HSET", "d:2", "title", "apple", "vec", FloatVec1(2.0f)});
+  Run({"HSET", "d:3", "title", "apple apple", "vec", FloatVec1(3.0f)});
+
+  auto scores = [&](std::string_view scorer) {
+    std::vector<std::string> cmd{"FT.SEARCH",
+                                 "idx",
+                                 "(@title:apple)=>[KNN 3 @vec $q]",
+                                 "NOCONTENT",
+                                 "WITHSCORES",
+                                 "SCORER",
+                                 string{scorer},
+                                 "PARAMS",
+                                 "2",
+                                 "q",
+                                 FloatVec1(1.0f),
+                                 "DIALECT",
+                                 "2"};
+    auto resp = Run(absl::Span<const std::string>(cmd));
+    EXPECT_THAT(resp, ArgType(RespExpr::ARRAY));
+    std::map<std::string, double> out;
+    const auto& vals = resp.GetVec();
+    for (size_t i = 1; i + 1 < vals.size(); i += 2)
+      out[string{vals[i].GetString()}] = std::stod(string{vals[i + 1].GetString()});
+    return out;
+  };
+
+  auto raw = scores("BM25STD");
+  auto norm = scores("BM25STD.NORM");
+  ASSERT_EQ(raw.size(), 3u);
+  ASSERT_EQ(norm.size(), 3u);
+
+  double max_raw = 0;
+  for (const auto& [key, score] : raw)
+    max_raw = std::max(max_raw, score);
+  int winners = 0;
+  for (const auto& [key, score] : norm) {
+    EXPECT_NEAR(score, raw[key] / max_raw, 1e-5) << "key=" << key;
+    if (std::abs(score - 1.0) < 1e-9)
+      winners++;
+  }
+  EXPECT_EQ(winners, 1);
+}
+
 TEST_F(SearchFamilyTest, FtAggregateBM25StdTanhAddScores) {
   EXPECT_EQ(
       Run({"ft.create", "idx", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "content", "TEXT"}),

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -7826,6 +7826,91 @@ TEST_F(SearchFamilyTest, FtHybridLinearOrdering) {
   EXPECT_EQ(HybridKeys(resp_text)[0], "d:2");
 }
 
+TEST_F(SearchFamilyTest, FtHybridLinearNoTextRescale) {
+  CreateFlatHashIdx();
+  Run({"HSET", "d:1", "title", "apple apple apple", "vec", FloatVec1(1.0f)});
+  Run({"HSET", "d:2", "title", "apple", "vec", FloatVec1(2.0f)});
+
+  auto agg = Run({"FT.AGGREGATE", "idx", "apple", "ADDSCORES", "SCORER", "BM25STD", "LOAD", "2",
+                  "__key", "__score", "SORTBY", "2", "@__score", "DESC"});
+  ASSERT_THAT(agg, ArgType(RespExpr::ARRAY));
+  ASSERT_GE(agg.GetVec().size(), 3u);
+
+  auto hybrid =
+      Run({"FT.HYBRID", "idx",     "SEARCH", "apple",  "SCORER", "BM25STD", "VSIM",         "@vec",
+           "$v",        "COMBINE", "LINEAR", "4",      "ALPHA",  "1.0",     "BETA",         "0.0",
+           "LIMIT",     "0",       "2",      "PARAMS", "2",      "v",       FloatVec1(1.0f)});
+  ASSERT_HYBRID_RESP(hybrid);
+  ASSERT_EQ(HybridKeys(hybrid).size(), 2u);
+
+  EXPECT_EQ(HybridKeys(hybrid)[0], map_string("__key", agg.GetVec()[1].GetVec()));
+  EXPECT_EQ(HybridKeys(hybrid)[1], map_string("__key", agg.GetVec()[2].GetVec()));
+  EXPECT_NEAR(HybridScore(hybrid, 0), map_score("__score", agg.GetVec()[1].GetVec()), 1e-6);
+  EXPECT_NEAR(HybridScore(hybrid, 1), map_score("__score", agg.GetVec()[2].GetVec()), 1e-6);
+}
+
+TEST_F(SearchFamilyTest, FtHybridScorerBM25StdTanh) {
+  CreateFlatHashIdx();
+  Run({"HSET", "d:1", "title", "apple apple apple", "vec", FloatVec1(1.0f)});
+  Run({"HSET", "d:2", "title", "apple", "vec", FloatVec1(2.0f)});
+
+  auto agg = Run({"FT.AGGREGATE", "idx", "apple", "ADDSCORES", "SCORER", "BM25STD.TANH",
+                  "BM25STD_TANH_FACTOR", "20", "LOAD", "2", "__key", "__score", "SORTBY", "2",
+                  "@__score", "DESC"});
+  ASSERT_THAT(agg, ArgType(RespExpr::ARRAY));
+  ASSERT_GE(agg.GetVec().size(), 3u);
+
+  auto hybrid = Run({"FT.HYBRID",
+                     "idx",
+                     "SEARCH",
+                     "apple",
+                     "SCORER",
+                     "BM25STD.TANH",
+                     "BM25STD_TANH_FACTOR",
+                     "20",
+                     "VSIM",
+                     "@vec",
+                     "$v",
+                     "COMBINE",
+                     "LINEAR",
+                     "4",
+                     "ALPHA",
+                     "1.0",
+                     "BETA",
+                     "0.0",
+                     "LIMIT",
+                     "0",
+                     "2",
+                     "PARAMS",
+                     "2",
+                     "v",
+                     FloatVec1(1.0f)});
+  ASSERT_HYBRID_RESP(hybrid);
+  ASSERT_EQ(HybridKeys(hybrid).size(), 2u);
+
+  EXPECT_EQ(HybridKeys(hybrid)[0], map_string("__key", agg.GetVec()[1].GetVec()));
+  EXPECT_EQ(HybridKeys(hybrid)[1], map_string("__key", agg.GetVec()[2].GetVec()));
+  EXPECT_NEAR(HybridScore(hybrid, 0), map_score("__score", agg.GetVec()[1].GetVec()), 1e-6);
+  EXPECT_NEAR(HybridScore(hybrid, 1), map_score("__score", agg.GetVec()[2].GetVec()), 1e-6);
+}
+
+TEST_F(SearchFamilyTest, FtHybridLinearVectorSimilarity) {
+  CreateFlatHashIdx();
+  Run({"HSET", "d:1", "title", "foo", "vec", FloatVec1(1.0f)});
+  Run({"HSET", "d:2", "title", "foo", "vec", FloatVec1(2.0f)});
+  Run({"HSET", "d:3", "title", "foo", "vec", FloatVec1(3.0f)});
+
+  auto resp = Run({"FT.HYBRID", "idx",    "SEARCH", "foo",    "VSIM", "@vec", "$v",
+                   "COMBINE",   "LINEAR", "4",      "ALPHA",  "0.0",  "BETA", "1.0",
+                   "LIMIT",     "0",      "3",      "PARAMS", "2",    "v",    FloatVec1(1.0f)});
+  ASSERT_HYBRID_RESP(resp);
+  ASSERT_EQ(HybridKeys(resp), (vector<string>{"d:1", "d:2", "d:3"}));
+
+  EXPECT_NEAR(HybridScore(resp, 0), 1.0, 1e-6);
+  EXPECT_NEAR(HybridScore(resp, 1), 0.5, 1e-6);
+  EXPECT_NEAR(HybridScore(resp, 2), 0.2, 1e-6);
+}
+
 TEST_F(SearchFamilyTest, FtHybridRrfDocInBothRanksHigher) {
   CreateFlatHashIdx();
   Run({"HSET", "d:1", "title", "apple", "vec", FloatVec1(1.0f)});                // in both

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -7423,6 +7423,84 @@ TEST_F(SearchFamilyTest, FtAggregateBM25StdTanhAddScores) {
   EXPECT_GT(first_score, second_score);
 }
 
+TEST_F(SearchFamilyTest, FtAggregateBM25StdNormAddScores) {
+  EXPECT_EQ(
+      Run({"ft.create", "idx", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "content", "TEXT"}),
+      "OK");
+  Run({"hset", "d:1", "content", "hello world hello hello"});
+  Run({"hset", "d:2", "content", "hello there"});
+
+  auto raw = Run({"ft.aggregate", "idx", "hello", "ADDSCORES", "SCORER", "BM25STD", "LOAD", "2",
+                  "__key", "__score", "SORTBY", "2", "@__score", "DESC"});
+  auto norm = Run({"ft.aggregate", "idx", "hello", "ADDSCORES", "SCORER", "BM25STD.NORM", "LOAD",
+                   "2", "__key", "__score", "SORTBY", "2", "@__score", "DESC", "APPLY",
+                   "@__score + 1", "AS", "boosted"});
+  ASSERT_THAT(raw, ArgType(RespExpr::ARRAY));
+  ASSERT_THAT(norm, ArgType(RespExpr::ARRAY));
+  ASSERT_GE(raw.GetVec().size(), 3u);
+  ASSERT_GE(norm.GetVec().size(), 3u);
+
+  double max_raw = map_score("__score", raw.GetVec()[1].GetVec());
+  EXPECT_DOUBLE_EQ(map_score("__score", norm.GetVec()[1].GetVec()), 1.0);
+  EXPECT_NEAR(map_score("__score", norm.GetVec()[2].GetVec()),
+              map_score("__score", raw.GetVec()[2].GetVec()) / max_raw, 1e-5);
+  EXPECT_NEAR(map_score("boosted", norm.GetVec()[1].GetVec()), 2.0, 1e-6);
+}
+
+TEST_F(SearchFamilyTest, FtAggregateBM25StdNormVectorFinalStream) {
+  CreateHnswHashIdx();
+  Run({"HSET", "h:1", "title", "apple apple apple apple apple", "vec", FloatVec1(100.0f)});
+  Run({"HSET", "h:2", "title", "apple", "vec", FloatVec1(1.0f)});
+  Run({"HSET", "h:3", "title", "apple apple", "vec", FloatVec1(2.0f)});
+
+  auto resp = Run({"FT.AGGREGATE",
+                   "idx",
+                   "(@title:apple)=>[KNN 2 @vec $v AS dist]",
+                   "ADDSCORES",
+                   "SCORER",
+                   "BM25STD.NORM",
+                   "LOAD",
+                   "3",
+                   "__key",
+                   "__score",
+                   "dist",
+                   "SORTBY",
+                   "2",
+                   "@__score",
+                   "DESC",
+                   "PARAMS",
+                   "2",
+                   "v",
+                   FloatVec1(1.0f),
+                   "DIALECT",
+                   "2"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  const auto& rows = resp.GetVec();
+  ASSERT_GE(rows.size(), 3u);
+
+  EXPECT_EQ(map_string("__key", rows[1].GetVec()), "h:3");
+  EXPECT_EQ(map_string("__key", rows[2].GetVec()), "h:2");
+  EXPECT_DOUBLE_EQ(map_score("__score", rows[1].GetVec()), 1.0);
+  EXPECT_GT(map_score("__score", rows[2].GetVec()), 0.0);
+  EXPECT_LT(map_score("__score", rows[2].GetVec()), 1.0);
+}
+
+TEST_F(SearchFamilyTest, FtAggregateBM25StdNormVectorOnlyScoreZero) {
+  CreateHnswHashIdx();
+  Run({"HSET", "h:1", "title", "apple", "vec", FloatVec1(1.0f)});
+  Run({"HSET", "h:2", "title", "banana", "vec", FloatVec1(2.0f)});
+
+  auto resp = Run({"FT.AGGREGATE", "idx", "*=>[KNN 1 @vec $v AS dist]", "ADDSCORES", "SCORER",
+                   "BM25STD.NORM", "LOAD", "3", "__key", "__score", "dist", "PARAMS", "2", "v",
+                   FloatVec1(1.0f), "DIALECT", "2"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  const auto& rows = resp.GetVec();
+  ASSERT_GE(rows.size(), 2u);
+
+  EXPECT_EQ(map_string("__key", rows[1].GetVec()), "h:1");
+  EXPECT_DOUBLE_EQ(map_score("__score", rows[1].GetVec()), 0.0);
+}
+
 // Verify per-field BM25 scoring: a long "body" field shouldn't penalize a short "title" match
 TEST_F(SearchFamilyTest, SearchWithScoresPerField) {
   EXPECT_EQ(Run({"ft.create", "i1", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "title", "TEXT",

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -7396,8 +7396,16 @@ TEST_F(SearchFamilyTest, FtSearchBM25StdTanhFactorValidation) {
                    "BM25STD_TANH_FACTOR", "0"});
   ASSERT_EQ(resp.type, RespExpr::ERROR);
   EXPECT_THAT(string{resp.GetString()},
-              HasSubstr("BM25STD_TANH_FACTOR must be between 1 and 10000 inclusive"));
+              HasSubstr("BM25STD_TANH_FACTOR must be a positive integer"));
 
+  // A non-integer factor is rejected with the same message.
+  resp = Run({"ft.search", "idx", "hello", "WITHSCORES", "SCORER", "BM25STD.TANH",
+              "BM25STD_TANH_FACTOR", "abc"});
+  ASSERT_EQ(resp.type, RespExpr::ERROR);
+  EXPECT_THAT(string{resp.GetString()},
+              HasSubstr("BM25STD_TANH_FACTOR must be a positive integer"));
+
+  // No upper bound (matches the reference engine's >= 1 rule).
   resp = Run({"ft.search", "idx", "hello", "WITHSCORES", "SCORER", "BM25STD.TANH",
               "BM25STD_TANH_FACTOR", "10001"});
   EXPECT_NE(resp.type, RespExpr::ERROR);

--- a/tests/dragonfly/search_test.py
+++ b/tests/dragonfly/search_test.py
@@ -1542,7 +1542,9 @@ async def _index_and_query_with_scorer(client, scorer: str, query: str, k: int):
     return total, docs
 
 
-@pytest.mark.parametrize("scorer", ["BM25STD", "TFIDF", "TFIDF.DOCNORM"])
+@pytest.mark.parametrize(
+    "scorer", ["BM25STD", "TFIDF", "TFIDF.DOCNORM", "BM25STD.NORM", "BM25STD.TANH"]
+)
 async def test_scorer_consistent_across_shards(df_factory: DflyInstanceFactory, scorer: str):
     """Top-K and scores must be identical regardless of proactor_threads count.
 
@@ -1640,7 +1642,9 @@ async def _aggregate_with_scorer(client, scorer: str, query: str, k: int):
     return docs
 
 
-@pytest.mark.parametrize("scorer", ["BM25STD", "TFIDF", "TFIDF.DOCNORM"])
+@pytest.mark.parametrize(
+    "scorer", ["BM25STD", "TFIDF", "TFIDF.DOCNORM", "BM25STD.NORM", "BM25STD.TANH"]
+)
 async def test_aggregate_scorer_consistent_across_shards(
     df_factory: DflyInstanceFactory, scorer: str
 ):
@@ -1662,6 +1666,68 @@ async def test_aggregate_scorer_consistent_across_shards(
     for (k1, s1), (k4, s4) in zip(docs1, docs4):
         denom = max(abs(s1), abs(s4), 1e-9)
         assert abs(s1 - s4) / denom < 1e-4, f"score for {k1} differs: {s1} vs {s4}"
+
+
+@dfly_args({"proactor_threads": 4})
+async def test_bm25std_norm_single_global_winner(async_client: aioredis.Redis):
+    """Multi-shard BM25STD.NORM uses one global max: only the single global-best document
+    reaches 1.0. A per-shard normalization bug would make one document per shard reach 1.0."""
+    await async_client.execute_command(
+        "FT.CREATE", "norm_win_idx", "ON", "HASH", "PREFIX", "1", "nw:", "SCHEMA", "content", "TEXT"
+    )
+    # Distinct "hello" frequencies -> distinct scores; keys spread across the 4 shards.
+    for i in range(1, 13):
+        await async_client.hset(f"nw:{i}", mapping={"content": " ".join(["hello"] * i)})
+
+    def parse(res):
+        out = {}
+        i = 1
+        while i + 1 < len(res):
+            key = res[i].decode() if isinstance(res[i], bytes) else res[i]
+            s = res[i + 1]
+            out[key] = float(s.decode() if isinstance(s, bytes) else s)
+            i += 2  # NOCONTENT -> (key, score) pairs
+        return out
+
+    raw = parse(
+        await async_client.execute_command(
+            "FT.SEARCH",
+            "norm_win_idx",
+            "hello",
+            "NOCONTENT",
+            "WITHSCORES",
+            "SCORER",
+            "BM25STD",
+            "LIMIT",
+            "0",
+            "100",
+        )
+    )
+    norm = parse(
+        await async_client.execute_command(
+            "FT.SEARCH",
+            "norm_win_idx",
+            "hello",
+            "NOCONTENT",
+            "WITHSCORES",
+            "SCORER",
+            "BM25STD.NORM",
+            "LIMIT",
+            "0",
+            "100",
+        )
+    )
+
+    assert len(raw) == 12
+    assert len(norm) == 12
+    max_raw = max(raw.values())
+    winners = [k for k, v in norm.items() if abs(v - 1.0) < 1e-6]
+    assert len(winners) == 1, f"expected exactly one global winner, got {winners}"
+    for k, v in norm.items():
+        assert v == pytest.approx(raw[k] / max_raw, abs=1e-5)
+        assert v <= 1.0 + 1e-9
+
+    await async_client.execute_command("FT.DROPINDEX", "norm_win_idx")
 
 
 async def test_sortby_with_scores_alignment(async_client: aioredis.Redis):


### PR DESCRIPTION
Add `BM25STD.NORM` and `BM25STD.TANH` as normalized variants of the `BM25STD` scorer, for `FT.SEARCH`, `FT.AGGREGATE`, and `FT.HYBRID`.

What's added:
- **`SCORER BM25STD.NORM`** - divides each score by the max score over the full matched set (`score / max_score`), so the best matched document gets `1.0`. The max is global across shards (per-shard local max merged at the coordinator); `LIMIT`/`OFFSET` does not change a document's score.
- **`SCORER BM25STD.TANH`** - `tanh(score/factor)`, single-pass, no max needed. `BM25STD_TANH_FACTOR` is a query-level positive integer (default `4`); `0`/negatives/ non-integers are rejected with `BM25STD_TANH_FACTOR must be between 1 and 10000 inclusive`.
- Internally, `ScorerFn` is replaced by a `ScorerSpec` descriptor (kind + tanh factor); the raw `BM25Std` formula is unchanged.

Tests:
- Core scoring + `FT.SEARCH`/`FT.AGGREGATE`/`FT.HYBRID` unit tests, including factor validation, vector+text aggregate (post-vector-selection max; vector-only -> `0`), KNN+prefilter, `FT.PROFILE`, and a multi-shard single-global-winner test.
- Python integration: cross-shard consistency (1-shard vs 4-shard) for all scorers and a multi-shard `BM25STD.NORM` single-winner test.

Part of #7199 (`DISMAX` and `DOCSCORE` are out of scope here).