### PR TITLE
tests: ensure that proxy chooses random port and closes on teardown

### DIFF
--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -19,7 +19,6 @@ from redis.exceptions import MovedError
 
 from . import dfly_args
 from .instance import DflyInstanceFactory, DflyInstance
-from .proxy import Proxy
 from .replication_test import check_all_replicas_finished
 from .seeder import DebugPopulateSeeder
 from .utility import (
@@ -1544,7 +1543,7 @@ async def test_migration_with_key_ttl(df_factory):
 
 
 @dfly_args({"proactor_threads": 4, "cluster_mode": "yes", "migration_finalization_timeout_ms": 50})
-async def test_network_disconnect_during_migration(df_factory):
+async def test_network_disconnect_during_migration(df_factory, proxy_factory):
     instances, nodes = await create_cluster(
         df_factory,
         2,
@@ -1558,37 +1557,33 @@ async def test_network_disconnect_during_migration(df_factory):
     await DebugPopulateSeeder(key_target=100000).run(nodes[0].client)
     start_capture = await DebugPopulateSeeder.capture(nodes[0].client)
 
-    async with Proxy(
-        "127.0.0.1", next(next_port), "127.0.0.1", nodes[1].instance.admin_port
-    ) as proxy:
-        nodes[0].migrations.append(
-            MigrationInfo("127.0.0.1", proxy.port, [(0, 16383)], nodes[1].id)
+    proxy = await proxy_factory(nodes[1].instance.admin_port)
+    nodes[0].migrations.append(MigrationInfo("127.0.0.1", proxy.port, [(0, 16383)], nodes[1].id))
+    logging.debug("Start migration")
+    await apply_config(nodes)
+
+    for _ in range(10):
+        await asyncio.sleep(random.randint(0, 50) / 100)
+        info = await nodes[0].admin_client.info("CLUSTER")
+        logging.debug("drop connection: %s", info)
+        proxy.drop_connection()
+        logging.debug(
+            await nodes[0].admin_client.execute_command("DFLYCLUSTER", "SLOT-MIGRATION-STATUS")
         )
-        logging.debug("Start migration")
-        await apply_config(nodes)
 
-        for _ in range(10):
-            await asyncio.sleep(random.randint(0, 50) / 100)
-            info = await nodes[0].admin_client.info("CLUSTER")
-            logging.debug("drop connection: %s", info)
-            proxy.drop_connection()
-            logging.debug(
-                await nodes[0].admin_client.execute_command("DFLYCLUSTER", "SLOT-MIGRATION-STATUS")
-            )
+    await wait_for_status(nodes[0].admin_client, nodes[1].id, "SYNC", 20)
 
-        await wait_for_status(nodes[0].admin_client, nodes[1].id, "SYNC", 20)
+    await proxy.close()
+    await proxy.start_serving()
 
-        await proxy.close()
-        await proxy.start_serving()
+    await wait_for_status(nodes[0].admin_client, nodes[1].id, "FINISHED", 300)
+    nodes[0].migrations = []
+    nodes[0].slots = []
+    nodes[1].slots = [(0, 16383)]
+    logging.debug("remove finished migrations")
+    await apply_config(nodes)
 
-        await wait_for_status(nodes[0].admin_client, nodes[1].id, "FINISHED", 300)
-        nodes[0].migrations = []
-        nodes[0].slots = []
-        nodes[1].slots = [(0, 16383)]
-        logging.debug("remove finished migrations")
-        await apply_config(nodes)
-
-        assert (await DebugPopulateSeeder.capture(nodes[1].client)) == start_capture
+    assert (await DebugPopulateSeeder.capture(nodes[1].client)) == start_capture
 
 
 @pytest.mark.parametrize(
@@ -2393,7 +2388,9 @@ async def await_stable_sync(m_client: aioredis.Redis, replica_port, timeout=10):
 
 
 @dfly_args({"proactor_threads": 4})
-async def test_replicate_disconnect_cluster(df_factory: DflyInstanceFactory, df_seeder_factory):
+async def test_replicate_disconnect_cluster(
+    df_factory: DflyInstanceFactory, df_seeder_factory, proxy_factory
+):
     """
     Create dragonfly cluster of 2 nodes and additional dragonfly server in emulated mode.
     Populate the cluster with data
@@ -2442,49 +2439,50 @@ async def test_replicate_disconnect_cluster(df_factory: DflyInstanceFactory, df_
 
     fill_task = asyncio.create_task(seeder.run())
 
-    async with Proxy("127.0.0.1", next(next_port), "127.0.0.1", cluster_nodes[0].port) as proxy:
-        # Start replication
-        await c_replica.execute_command("REPLICAOF localhost " + str(proxy.port) + " 0 5259")
-        await c_replica.execute_command(
-            "ADDREPLICAOF localhost " + str(cluster_nodes[1].port) + " 5260 16383"
-        )
+    proxy = await proxy_factory(cluster_nodes[0].port)
 
-        # wait for replication to reach stable state on all nodes
-        await asyncio.gather(
-            *(asyncio.create_task(await_stable_sync(c, replica.port)) for c in c_nodes)
-        )
+    # Start replication
+    await c_replica.execute_command("REPLICAOF localhost " + str(proxy.port) + " 0 5259")
+    await c_replica.execute_command(
+        "ADDREPLICAOF localhost " + str(cluster_nodes[1].port) + " 5260 16383"
+    )
 
-        # break connection between first node and replica
-        await proxy.close()
-        await asyncio.sleep(3)
+    # wait for replication to reach stable state on all nodes
+    await asyncio.gather(
+        *(asyncio.create_task(await_stable_sync(c, replica.port)) for c in c_nodes)
+    )
 
-        async def is_first_master_conn_down(conn):
-            info = await conn.execute_command("INFO REPLICATION")
-            print(info)
-            statuses = re.findall("master_link_status:(down|up)\r\n", info)
-            assert len(statuses) == 2
-            assert statuses[0] == "down"
-            assert statuses[1] == "up"
+    # break connection between first node and replica
+    await proxy.close()
+    await asyncio.sleep(3)
 
-        await is_first_master_conn_down(c_replica)
+    async def is_first_master_conn_down(conn):
+        info = await conn.execute_command("INFO REPLICATION")
+        print(info)
+        statuses = re.findall("master_link_status:(down|up)\r\n", info)
+        assert len(statuses) == 2
+        assert statuses[0] == "down"
+        assert statuses[1] == "up"
 
-        # start connection again
-        await proxy.start_serving()
+    await is_first_master_conn_down(c_replica)
 
-        seeder.stop()
-        await fill_task
+    # start connection again
+    await proxy.start_serving()
 
-        # wait for stable sync on first master
-        await await_stable_sync(c_nodes[0], replica.port)
-        # wait for no lag on all cluster nodes
-        await asyncio.gather(*(asyncio.create_task(await_no_lag(c)) for c in c_nodes))
+    seeder.stop()
+    await fill_task
 
-        # promote replica to master and compare data
-        await c_replica.execute_command("REPLICAOF NO ONE")
-        capture = await seeder.capture()
-        assert await seeder.compare(capture, replica.port)
-        fake_capture = await seeder.capture_fake_redis()
-        assert await seeder.compare(fake_capture, replica.port)
+    # wait for stable sync on first master
+    await await_stable_sync(c_nodes[0], replica.port)
+    # wait for no lag on all cluster nodes
+    await asyncio.gather(*(asyncio.create_task(await_no_lag(c)) for c in c_nodes))
+
+    # promote replica to master and compare data
+    await c_replica.execute_command("REPLICAOF NO ONE")
+    capture = await seeder.capture()
+    assert await seeder.compare(capture, replica.port)
+    fake_capture = await seeder.capture_fake_redis()
+    assert await seeder.compare(fake_capture, replica.port)
 
 
 def is_offset_eq_master_repl_offset(replication_info: str):
@@ -2563,7 +2561,9 @@ async def test_replicate_redis_cluster(redis_cluster, df_factory, df_seeder_fact
 
 
 @dfly_args({"proactor_threads": 4, "pause_wait_timeout": 10})
-async def test_replicate_disconnect_redis_cluster(redis_cluster, df_factory, df_seeder_factory):
+async def test_replicate_disconnect_redis_cluster(
+    redis_cluster, df_factory, df_seeder_factory, proxy_factory
+):
     """
     Create redis cluster of 3 nodes.
     Create dragonfly server in emulated mode.
@@ -2593,62 +2593,59 @@ async def test_replicate_disconnect_redis_cluster(redis_cluster, df_factory, df_
 
     fill_task = asyncio.create_task(seeder.run())
 
-    async with Proxy(
-        "127.0.0.1", next(next_port), "127.0.0.1", redis_cluster_nodes[1].port
-    ) as proxy:
-        # Start replication
-        await c_replica.execute_command(
-            "REPLICAOF localhost " + str(redis_cluster_nodes[0].port) + " 0 5460"
-        )
-        await c_replica.execute_command("ADDREPLICAOF localhost " + str(proxy.port) + " 5461 10922")
-        await c_replica.execute_command(
-            "ADDREPLICAOF localhost " + str(redis_cluster_nodes[2].port) + " 10923 16383"
-        )
+    proxy = await proxy_factory(redis_cluster_nodes[1].port)
 
-        # give seeder time to run.
-        await asyncio.sleep(1)
+    # Start replication
+    await c_replica.execute_command(
+        "REPLICAOF localhost " + str(redis_cluster_nodes[0].port) + " 0 5460"
+    )
+    await c_replica.execute_command("ADDREPLICAOF localhost " + str(proxy.port) + " 5461 10922")
+    await c_replica.execute_command(
+        "ADDREPLICAOF localhost " + str(redis_cluster_nodes[2].port) + " 10923 16383"
+    )
 
-        # break connection between second node and replica
-        await proxy.close()
-        await asyncio.sleep(3)
+    # give seeder time to run.
+    await asyncio.sleep(1)
 
-        # check second node connection is down
-        info = await c_replica.execute_command("INFO REPLICATION")
-        statuses = re.findall("master_link_status:(down|up)\r\n", info)
-        assert len(statuses) == 3
-        assert statuses[0] == "up"
-        assert statuses[1] == "down"
-        assert statuses[2] == "up"
+    # break connection between second node and replica
+    await proxy.close()
+    await asyncio.sleep(3)
 
-        # start connection again
-        await proxy.start_serving()
+    # check second node connection is down
+    info = await c_replica.execute_command("INFO REPLICATION")
+    statuses = re.findall("master_link_status:(down|up)\r\n", info)
+    assert len(statuses) == 3
+    assert statuses[0] == "up"
+    assert statuses[1] == "down"
+    assert statuses[2] == "up"
 
-        # give seeder more time to run
-        await asyncio.sleep(1)
+    # start connection again
+    await proxy.start_serving()
 
-        # check second node connection is up
-        info = await c_replica.execute_command("INFO REPLICATION")
-        statuses = re.findall("master_link_status:(down|up)\r\n", info)
-        assert len(statuses) == 3
-        assert statuses[0] == "up"
-        assert statuses[1] == "up"
-        assert statuses[2] == "up"
+    # give seeder more time to run
+    await asyncio.sleep(1)
 
-        # give seeder time to run.
-        await asyncio.sleep(1)
+    # check second node connection is up
+    info = await c_replica.execute_command("INFO REPLICATION")
+    statuses = re.findall("master_link_status:(down|up)\r\n", info)
+    assert len(statuses) == 3
+    assert statuses[0] == "up"
+    assert statuses[1] == "up"
+    assert statuses[2] == "up"
 
-        # Stop seeder
-        seeder.stop()
-        await fill_task
+    # give seeder time to run.
+    await asyncio.sleep(1)
 
-        # wait for replication to finish
-        await asyncio.gather(
-            *(asyncio.create_task(await_eq_offset(client)) for client in node_clients)
-        )
+    # Stop seeder
+    seeder.stop()
+    await fill_task
 
-        await c_replica.execute_command("REPLICAOF NO ONE")
-        capture = await seeder.capture()
-        assert await seeder.compare(capture, replica.port)
+    # wait for replication to finish
+    await asyncio.gather(*(asyncio.create_task(await_eq_offset(client)) for client in node_clients))
+
+    await c_replica.execute_command("REPLICAOF NO ONE")
+    capture = await seeder.capture()
+    assert await seeder.compare(capture, replica.port)
 
 
 @pytest.mark.large

--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -1558,12 +1558,12 @@ async def test_network_disconnect_during_migration(df_factory):
     await DebugPopulateSeeder(key_target=100000).run(nodes[0].client)
     start_capture = await DebugPopulateSeeder.capture(nodes[0].client)
 
-    proxy = Proxy("127.0.0.1", next(next_port), "127.0.0.1", nodes[1].instance.admin_port)
-    await proxy.start()
-    task = asyncio.create_task(proxy.serve())
-
-    nodes[0].migrations.append(MigrationInfo("127.0.0.1", proxy.port, [(0, 16383)], nodes[1].id))
-    try:
+    async with Proxy(
+        "127.0.0.1", next(next_port), "127.0.0.1", nodes[1].instance.admin_port
+    ) as proxy:
+        nodes[0].migrations.append(
+            MigrationInfo("127.0.0.1", proxy.port, [(0, 16383)], nodes[1].id)
+        )
         logging.debug("Start migration")
         await apply_config(nodes)
 
@@ -1577,12 +1577,10 @@ async def test_network_disconnect_during_migration(df_factory):
             )
 
         await wait_for_status(nodes[0].admin_client, nodes[1].id, "SYNC", 20)
-    finally:
-        await proxy.close(task)
 
-    await proxy.start()
-    task = asyncio.create_task(proxy.serve())
-    try:
+        await proxy.close()
+        await proxy.start_serving()
+
         await wait_for_status(nodes[0].admin_client, nodes[1].id, "FINISHED", 300)
         nodes[0].migrations = []
         nodes[0].slots = []
@@ -1591,8 +1589,6 @@ async def test_network_disconnect_during_migration(df_factory):
         await apply_config(nodes)
 
         assert (await DebugPopulateSeeder.capture(nodes[1].client)) == start_capture
-    finally:
-        await proxy.close(task)
 
 
 @pytest.mark.parametrize(
@@ -2446,55 +2442,49 @@ async def test_replicate_disconnect_cluster(df_factory: DflyInstanceFactory, df_
 
     fill_task = asyncio.create_task(seeder.run())
 
-    proxy = Proxy("127.0.0.1", next(next_port), "127.0.0.1", cluster_nodes[0].port)
-    await proxy.start()
-    proxy_task = asyncio.create_task(proxy.serve())
+    async with Proxy("127.0.0.1", next(next_port), "127.0.0.1", cluster_nodes[0].port) as proxy:
+        # Start replication
+        await c_replica.execute_command("REPLICAOF localhost " + str(proxy.port) + " 0 5259")
+        await c_replica.execute_command(
+            "ADDREPLICAOF localhost " + str(cluster_nodes[1].port) + " 5260 16383"
+        )
 
-    # Start replication
-    await c_replica.execute_command("REPLICAOF localhost " + str(proxy.port) + " 0 5259")
-    await c_replica.execute_command(
-        "ADDREPLICAOF localhost " + str(cluster_nodes[1].port) + " 5260 16383"
-    )
+        # wait for replication to reach stable state on all nodes
+        await asyncio.gather(
+            *(asyncio.create_task(await_stable_sync(c, replica.port)) for c in c_nodes)
+        )
 
-    # wait for replication to reach stable state on all nodes
-    await asyncio.gather(
-        *(asyncio.create_task(await_stable_sync(c, replica.port)) for c in c_nodes)
-    )
+        # break connection between first node and replica
+        await proxy.close()
+        await asyncio.sleep(3)
 
-    # break connection between first node and replica
-    await proxy.close(proxy_task)
-    await asyncio.sleep(3)
+        async def is_first_master_conn_down(conn):
+            info = await conn.execute_command("INFO REPLICATION")
+            print(info)
+            statuses = re.findall("master_link_status:(down|up)\r\n", info)
+            assert len(statuses) == 2
+            assert statuses[0] == "down"
+            assert statuses[1] == "up"
 
-    async def is_first_master_conn_down(conn):
-        info = await conn.execute_command("INFO REPLICATION")
-        print(info)
-        statuses = re.findall("master_link_status:(down|up)\r\n", info)
-        assert len(statuses) == 2
-        assert statuses[0] == "down"
-        assert statuses[1] == "up"
+        await is_first_master_conn_down(c_replica)
 
-    await is_first_master_conn_down(c_replica)
+        # start connection again
+        await proxy.start_serving()
 
-    # start connection again
-    await proxy.start()
-    proxy_task = asyncio.create_task(proxy.serve())
+        seeder.stop()
+        await fill_task
 
-    seeder.stop()
-    await fill_task
+        # wait for stable sync on first master
+        await await_stable_sync(c_nodes[0], replica.port)
+        # wait for no lag on all cluster nodes
+        await asyncio.gather(*(asyncio.create_task(await_no_lag(c)) for c in c_nodes))
 
-    # wait for stable sync on first master
-    await await_stable_sync(c_nodes[0], replica.port)
-    # wait for no lag on all cluster nodes
-    await asyncio.gather(*(asyncio.create_task(await_no_lag(c)) for c in c_nodes))
-
-    # promote replica to master and compare data
-    await c_replica.execute_command("REPLICAOF NO ONE")
-    capture = await seeder.capture()
-    assert await seeder.compare(capture, replica.port)
-    fake_capture = await seeder.capture_fake_redis()
-    assert await seeder.compare(fake_capture, replica.port)
-
-    await proxy.close(proxy_task)
+        # promote replica to master and compare data
+        await c_replica.execute_command("REPLICAOF NO ONE")
+        capture = await seeder.capture()
+        assert await seeder.compare(capture, replica.port)
+        fake_capture = await seeder.capture_fake_redis()
+        assert await seeder.compare(fake_capture, replica.port)
 
 
 def is_offset_eq_master_repl_offset(replication_info: str):
@@ -2603,63 +2593,62 @@ async def test_replicate_disconnect_redis_cluster(redis_cluster, df_factory, df_
 
     fill_task = asyncio.create_task(seeder.run())
 
-    proxy = Proxy("127.0.0.1", next(next_port), "127.0.0.1", redis_cluster_nodes[1].port)
-    await proxy.start()
-    proxy_task = asyncio.create_task(proxy.serve())
+    async with Proxy(
+        "127.0.0.1", next(next_port), "127.0.0.1", redis_cluster_nodes[1].port
+    ) as proxy:
+        # Start replication
+        await c_replica.execute_command(
+            "REPLICAOF localhost " + str(redis_cluster_nodes[0].port) + " 0 5460"
+        )
+        await c_replica.execute_command("ADDREPLICAOF localhost " + str(proxy.port) + " 5461 10922")
+        await c_replica.execute_command(
+            "ADDREPLICAOF localhost " + str(redis_cluster_nodes[2].port) + " 10923 16383"
+        )
 
-    # Start replication
-    await c_replica.execute_command(
-        "REPLICAOF localhost " + str(redis_cluster_nodes[0].port) + " 0 5460"
-    )
-    await c_replica.execute_command("ADDREPLICAOF localhost " + str(proxy.port) + " 5461 10922")
-    await c_replica.execute_command(
-        "ADDREPLICAOF localhost " + str(redis_cluster_nodes[2].port) + " 10923 16383"
-    )
+        # give seeder time to run.
+        await asyncio.sleep(1)
 
-    # give seeder time to run.
-    await asyncio.sleep(1)
+        # break connection between second node and replica
+        await proxy.close()
+        await asyncio.sleep(3)
 
-    # break connection between second node and replica
-    await proxy.close(proxy_task)
-    await asyncio.sleep(3)
+        # check second node connection is down
+        info = await c_replica.execute_command("INFO REPLICATION")
+        statuses = re.findall("master_link_status:(down|up)\r\n", info)
+        assert len(statuses) == 3
+        assert statuses[0] == "up"
+        assert statuses[1] == "down"
+        assert statuses[2] == "up"
 
-    # check second node connection is down
-    info = await c_replica.execute_command("INFO REPLICATION")
-    statuses = re.findall("master_link_status:(down|up)\r\n", info)
-    assert len(statuses) == 3
-    assert statuses[0] == "up"
-    assert statuses[1] == "down"
-    assert statuses[2] == "up"
+        # start connection again
+        await proxy.start_serving()
 
-    # start connection again
-    await proxy.start()
-    proxy_task = asyncio.create_task(proxy.serve())
+        # give seeder more time to run
+        await asyncio.sleep(1)
 
-    # give seeder more time to run
-    await asyncio.sleep(1)
+        # check second node connection is up
+        info = await c_replica.execute_command("INFO REPLICATION")
+        statuses = re.findall("master_link_status:(down|up)\r\n", info)
+        assert len(statuses) == 3
+        assert statuses[0] == "up"
+        assert statuses[1] == "up"
+        assert statuses[2] == "up"
 
-    # check second node connection is up
-    info = await c_replica.execute_command("INFO REPLICATION")
-    statuses = re.findall("master_link_status:(down|up)\r\n", info)
-    assert len(statuses) == 3
-    assert statuses[0] == "up"
-    assert statuses[1] == "up"
-    assert statuses[2] == "up"
+        # give seeder time to run.
+        await asyncio.sleep(1)
 
-    # give seeder time to run.
-    await asyncio.sleep(1)
+        # Stop seeder
+        seeder.stop()
+        await fill_task
 
-    # Stop seeder
-    seeder.stop()
-    await fill_task
+        # wait for replication to finish
+        await asyncio.gather(
+            *(asyncio.create_task(await_eq_offset(client)) for client in node_clients)
+        )
 
-    # wait for replication to finish
-    await asyncio.gather(*(asyncio.create_task(await_eq_offset(client)) for client in node_clients))
-
-    await c_replica.execute_command("REPLICAOF NO ONE")
-    capture = await seeder.capture()
-    assert await seeder.compare(capture, replica.port)
-    await proxy.close(proxy_task)
+        await c_replica.execute_command("REPLICAOF NO ONE")
+        capture = await seeder.capture()
+        assert await seeder.compare(capture, replica.port)
 
 
 @pytest.mark.large

--- a/tests/dragonfly/conftest.py
+++ b/tests/dragonfly/conftest.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import time
 import typing
+from contextlib import AsyncExitStack
 from copy import deepcopy
 from pathlib import Path
 from tempfile import gettempdir, mkdtemp
@@ -25,6 +26,7 @@ from redis import asyncio as aioredis
 
 from . import PortPicker
 from .instance import DflyInstance, DflyParams, DflyInstanceFactory, RedisServer
+from .proxy import Proxy
 from .utility import (
     DflySeederFactory,
     gen_ca_cert,
@@ -241,6 +243,20 @@ def df_seeder_factory(request) -> DflySeederFactory:
     logging.debug(f"Random seed: {seed}, check: {random.randrange(100)}")
 
     return DflySeederFactory(request.config.getoption("--log-seeder"))
+
+
+@pytest_asyncio.fixture
+async def proxy_factory():
+    async with AsyncExitStack() as stack:
+
+        async def create_proxy(
+            remote_port, remote_host="127.0.0.1", *, host="127.0.0.1", local_port=0
+        ):
+            return await stack.enter_async_context(
+                Proxy(host, local_port, remote_host, remote_port)
+            )
+
+        yield create_proxy
 
 
 def parse_args(args: List[str]) -> Dict[str, Union[str, None]]:
@@ -584,7 +600,7 @@ def redis_server(port_picker, df_log_dir) -> RedisServer:
     s = RedisServer(port_picker.get_available_port(), log_dir=df_log_dir)
     try:
         s.start()
-    except FileNotFoundError as e:
+    except FileNotFoundError:
         skip_if_not_in_github()
         raise
     time.sleep(1)

--- a/tests/dragonfly/proxy.py
+++ b/tests/dragonfly/proxy.py
@@ -11,6 +11,7 @@ class Proxy:
         self.stop_connections = []
         self.server = None
         self._handler_tasks = set()
+        self._serve_task = None
 
     async def handle(self, reader, writer):
         task = asyncio.current_task()
@@ -65,9 +66,23 @@ class Proxy:
             _, port = self.server.sockets[0].getsockname()[:2]
             self.port = port
 
-    async def serve(self):
-        async with self.server:
-            await self.server.serve_forever()
+    async def start_serving(self):
+        await self.start()
+        self._serve_task = asyncio.create_task(self.serve(self.server))
+
+    async def serve(self, server=None):
+        server = server or self.server
+        if server is None:
+            return
+        async with server:
+            await server.serve_forever()
+
+    async def __aenter__(self):
+        await self.start_serving()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.close()
 
     def drop_connection(self):
         """
@@ -79,6 +94,11 @@ class Proxy:
             cb()
 
     async def close(self, task=None):
+        if task is None:
+            task = self._serve_task
+        if task is self._serve_task:
+            self._serve_task = None
+
         if self.server is not None:
             self.server.close()
             self.server = None

--- a/tests/dragonfly/redis_replication_test.py
+++ b/tests/dragonfly/redis_replication_test.py
@@ -330,60 +330,53 @@ async def test_disconnect_master(
     c_master = aioredis.Redis(port=master.port)
     assert await c_master.ping()
 
-    proxy = Proxy("127.0.0.1", 0, "127.0.0.1", master.port)
-    await proxy.start()
-    proxy_task = asyncio.create_task(proxy.serve())
     stream_task = None
     seeder = None
 
-    try:
-        replicas = [
-            df_factory.create(port=port_picker.get_available_port(), proactor_threads=t)
-            for i, t in enumerate(t_replicas)
-        ]
-
-        # Fill master with test data
-        seeder = df_seeder_factory.create(port=master.port, **seeder_config)
-        await seeder.run(target_deviation=0.1)
-
-        # Start replicas
-        df_factory.start_all(replicas)
-
-        c_replicas = [replica.client() for replica in replicas]
-
-        # Start data stream
-        stream_task = asyncio.create_task(seeder.run())
-        await asyncio.sleep(0.5)
-
-        await replicate_all(c_replicas, proxy.port)
-
-        # Break the connection between master and replica
-        await proxy.close(proxy_task)
-        proxy_task = None
-        await asyncio.sleep(2)
-        await proxy.start()
-        proxy_task = asyncio.create_task(proxy.serve())
-
-        # finish streaming data
-        await asyncio.sleep(1)
-        seeder.stop()
-        await stream_task
-        stream_task = None
-
-        # Check data after stable state stream
-        await wait_available_async(c_replicas)
-        await await_synced_all(c_master, c_replicas)
-        await check_data(seeder, replicas, c_replicas)
-        seeder = None
-
-    finally:
+    async with Proxy("127.0.0.1", 0, "127.0.0.1", master.port) as proxy:
         try:
+            replicas = [
+                df_factory.create(port=port_picker.get_available_port(), proactor_threads=t)
+                for i, t in enumerate(t_replicas)
+            ]
+
+            # Fill master with test data
+            seeder = df_seeder_factory.create(port=master.port, **seeder_config)
+            await seeder.run(target_deviation=0.1)
+
+            # Start replicas
+            df_factory.start_all(replicas)
+
+            c_replicas = [replica.client() for replica in replicas]
+
+            # Start data stream
+            stream_task = asyncio.create_task(seeder.run())
+            await asyncio.sleep(0.5)
+
+            await replicate_all(c_replicas, proxy.port)
+
+            # Break the connection between master and replica
+            await proxy.close()
+            await asyncio.sleep(2)
+            await proxy.start_serving()
+
+            # finish streaming data
+            await asyncio.sleep(1)
+            seeder.stop()
+            await stream_task
+            stream_task = None
+
+            # Check data after stable state stream
+            await wait_available_async(c_replicas)
+            await await_synced_all(c_master, c_replicas)
+            await check_data(seeder, replicas, c_replicas)
+            seeder = None
+
+        finally:
             if seeder is not None:
                 seeder.stop()
             if stream_task is not None:
                 await asyncio.gather(stream_task, return_exceptions=True)
-        finally:
-            await proxy.close(proxy_task)
 
 
 @pytest.mark.asyncio

--- a/tests/dragonfly/redis_replication_test.py
+++ b/tests/dragonfly/redis_replication_test.py
@@ -201,6 +201,7 @@ async def test_redis_replication_all(
     c_replicas = [replica.client() for replica in replicas]
 
     progress = asyncio.create_task(_log_progress(c_master, c_replicas))
+    stream_task = None
     try:
         # Start data stream
         stream_task = asyncio.create_task(seeder.run())
@@ -214,6 +215,7 @@ async def test_redis_replication_all(
         ), "Weak testcase. Increase number of streamed iterations to surpass full sync"
         seeder.stop()
         await stream_task
+        stream_task = None
 
         # Check data after full sync
         await await_synced_all(c_master, c_replicas, timeout=60)
@@ -226,11 +228,16 @@ async def test_redis_replication_all(
         await await_synced_all(c_master, c_replicas, timeout=60)
         await check_data(seeder, replicas, c_replicas)
     finally:
-        progress.cancel()
         try:
-            await progress
-        except asyncio.CancelledError:
-            pass
+            if stream_task is not None:
+                seeder.stop()
+                await asyncio.gather(stream_task, return_exceptions=True)
+        finally:
+            progress.cancel()
+            try:
+                await progress
+            except asyncio.CancelledError:
+                pass
 
 
 master_disconnect_cases = [
@@ -269,29 +276,35 @@ async def test_redis_master_restart(
 
     # Start data stream
     stream_task = asyncio.create_task(seeder.run())
-    await asyncio.sleep(0.0)
+    try:
+        await asyncio.sleep(0.0)
 
-    await replicate_all(c_replicas, master.port)
+        await replicate_all(c_replicas, master.port)
 
-    # Wait for streaming to finish
-    assert (
-        not stream_task.done()
-    ), "Weak testcase. Increase number of streamed iterations to surpass full sync"
-    seeder.stop()
-    await stream_task
+        # Wait for streaming to finish
+        assert (
+            not stream_task.done()
+        ), "Weak testcase. Increase number of streamed iterations to surpass full sync"
+        seeder.stop()
+        await stream_task
+        stream_task = None
 
-    for _ in range(t_disconnect):
-        master.stop()
-        await asyncio.sleep(1)
-        master.start()
-        await asyncio.sleep(1)
-        # fill master with data
-        await seeder.run(target_deviation=0.1)
+        for _ in range(t_disconnect):
+            master.stop()
+            await asyncio.sleep(1)
+            master.start()
+            await asyncio.sleep(1)
+            # fill master with data
+            await seeder.run(target_deviation=0.1)
 
-    # Check data after stable state stream
-    await wait_available_async(c_replicas)
-    await await_synced_all(c_master, c_replicas)
-    await check_data(seeder, replicas, c_replicas)
+        # Check data after stable state stream
+        await wait_available_async(c_replicas)
+        await await_synced_all(c_master, c_replicas)
+        await check_data(seeder, replicas, c_replicas)
+    finally:
+        if stream_task is not None:
+            seeder.stop()
+            await asyncio.gather(stream_task, return_exceptions=True)
 
 
 master_disconnect_cases = [
@@ -320,6 +333,8 @@ async def test_disconnect_master(
     proxy = Proxy("127.0.0.1", 0, "127.0.0.1", master.port)
     await proxy.start()
     proxy_task = asyncio.create_task(proxy.serve())
+    stream_task = None
+    seeder = None
 
     try:
         replicas = [

--- a/tests/dragonfly/redis_replication_test.py
+++ b/tests/dragonfly/redis_replication_test.py
@@ -7,7 +7,6 @@ import pytest
 import redis.asyncio as aioredis
 
 from .instance import DflyInstanceFactory
-from .proxy import Proxy
 from .utility import ValueType, wait_available_async, assert_eventually
 
 
@@ -325,6 +324,7 @@ async def test_disconnect_master(
     t_replicas,
     seeder_config,
     port_picker,
+    proxy_factory,
 ):
     master = redis_server
     c_master = aioredis.Redis(port=master.port)
@@ -333,50 +333,50 @@ async def test_disconnect_master(
     stream_task = None
     seeder = None
 
-    async with Proxy("127.0.0.1", 0, "127.0.0.1", master.port) as proxy:
-        try:
-            replicas = [
-                df_factory.create(port=port_picker.get_available_port(), proactor_threads=t)
-                for i, t in enumerate(t_replicas)
-            ]
+    proxy = await proxy_factory(master.port)
+    try:
+        replicas = [
+            df_factory.create(port=port_picker.get_available_port(), proactor_threads=t)
+            for i, t in enumerate(t_replicas)
+        ]
 
-            # Fill master with test data
-            seeder = df_seeder_factory.create(port=master.port, **seeder_config)
-            await seeder.run(target_deviation=0.1)
+        # Fill master with test data
+        seeder = df_seeder_factory.create(port=master.port, **seeder_config)
+        await seeder.run(target_deviation=0.1)
 
-            # Start replicas
-            df_factory.start_all(replicas)
+        # Start replicas
+        df_factory.start_all(replicas)
 
-            c_replicas = [replica.client() for replica in replicas]
+        c_replicas = [replica.client() for replica in replicas]
 
-            # Start data stream
-            stream_task = asyncio.create_task(seeder.run())
-            await asyncio.sleep(0.5)
+        # Start data stream
+        stream_task = asyncio.create_task(seeder.run())
+        await asyncio.sleep(0.5)
 
-            await replicate_all(c_replicas, proxy.port)
+        await replicate_all(c_replicas, proxy.port)
 
-            # Break the connection between master and replica
-            await proxy.close()
-            await asyncio.sleep(2)
-            await proxy.start_serving()
+        # Break the connection between master and replica
+        await proxy.close()
+        await asyncio.sleep(2)
+        await proxy.start_serving()
 
-            # finish streaming data
-            await asyncio.sleep(1)
+        # finish streaming data
+        await asyncio.sleep(1)
+        seeder.stop()
+        await stream_task
+        stream_task = None
+
+        # Check data after stable state stream
+        await wait_available_async(c_replicas)
+        await await_synced_all(c_master, c_replicas)
+        await check_data(seeder, replicas, c_replicas)
+        seeder = None
+
+    finally:
+        if seeder is not None:
             seeder.stop()
-            await stream_task
-            stream_task = None
-
-            # Check data after stable state stream
-            await wait_available_async(c_replicas)
-            await await_synced_all(c_master, c_replicas)
-            await check_data(seeder, replicas, c_replicas)
-            seeder = None
-
-        finally:
-            if seeder is not None:
-                seeder.stop()
-            if stream_task is not None:
-                await asyncio.gather(stream_task, return_exceptions=True)
+        if stream_task is not None:
+            await asyncio.gather(stream_task, return_exceptions=True)
 
 
 @pytest.mark.asyncio

--- a/tests/dragonfly/redis_replication_test.py
+++ b/tests/dragonfly/redis_replication_test.py
@@ -1,11 +1,14 @@
-import time
-import pytest
 import asyncio
-from redis import asyncio as aioredis
-import subprocess
-from .utility import *
+import logging
+import random
+import string
+
+import pytest
+import redis.asyncio as aioredis
+
 from .instance import DflyInstanceFactory
 from .proxy import Proxy
+from .utility import ValueType, wait_available_async, assert_eventually
 
 
 async def _bounded(awaitable, timeout=5):
@@ -314,47 +317,58 @@ async def test_disconnect_master(
     c_master = aioredis.Redis(port=master.port)
     assert await c_master.ping()
 
-    proxy = Proxy("127.0.0.1", 1114, "127.0.0.1", master.port)
+    proxy = Proxy("127.0.0.1", 0, "127.0.0.1", master.port)
     await proxy.start()
     proxy_task = asyncio.create_task(proxy.serve())
 
-    replicas = [
-        df_factory.create(port=port_picker.get_available_port(), proactor_threads=t)
-        for i, t in enumerate(t_replicas)
-    ]
+    try:
+        replicas = [
+            df_factory.create(port=port_picker.get_available_port(), proactor_threads=t)
+            for i, t in enumerate(t_replicas)
+        ]
 
-    # Fill master with test data
-    seeder = df_seeder_factory.create(port=master.port, **seeder_config)
-    await seeder.run(target_deviation=0.1)
+        # Fill master with test data
+        seeder = df_seeder_factory.create(port=master.port, **seeder_config)
+        await seeder.run(target_deviation=0.1)
 
-    # Start replicas
-    df_factory.start_all(replicas)
+        # Start replicas
+        df_factory.start_all(replicas)
 
-    c_replicas = [replica.client() for replica in replicas]
+        c_replicas = [replica.client() for replica in replicas]
 
-    # Start data stream
-    stream_task = asyncio.create_task(seeder.run())
-    await asyncio.sleep(0.5)
+        # Start data stream
+        stream_task = asyncio.create_task(seeder.run())
+        await asyncio.sleep(0.5)
 
-    await replicate_all(c_replicas, proxy.port)
+        await replicate_all(c_replicas, proxy.port)
 
-    # Break the connection between master and replica
-    await proxy.close(proxy_task)
-    await asyncio.sleep(2)
-    await proxy.start()
-    proxy_task = asyncio.create_task(proxy.serve())
+        # Break the connection between master and replica
+        await proxy.close(proxy_task)
+        proxy_task = None
+        await asyncio.sleep(2)
+        await proxy.start()
+        proxy_task = asyncio.create_task(proxy.serve())
 
-    # finish streaming data
-    await asyncio.sleep(1)
-    seeder.stop()
-    await stream_task
+        # finish streaming data
+        await asyncio.sleep(1)
+        seeder.stop()
+        await stream_task
+        stream_task = None
 
-    # Check data after stable state stream
-    await wait_available_async(c_replicas)
-    await await_synced_all(c_master, c_replicas)
-    await check_data(seeder, replicas, c_replicas)
+        # Check data after stable state stream
+        await wait_available_async(c_replicas)
+        await await_synced_all(c_master, c_replicas)
+        await check_data(seeder, replicas, c_replicas)
+        seeder = None
 
-    await proxy.close(proxy_task)
+    finally:
+        try:
+            if seeder is not None:
+                seeder.stop()
+            if stream_task is not None:
+                await asyncio.gather(stream_task, return_exceptions=True)
+        finally:
+            await proxy.close(proxy_task)
 
 
 @pytest.mark.asyncio

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -1779,44 +1779,38 @@ async def test_tls_replication(
     db_size = await c_master.execute_command("DBSIZE")
     assert 100 == db_size
 
-    proxy = Proxy(
-        "127.0.0.1", 1114, "127.0.0.1", master.port if not test_admin_port else master.admin_port
-    )
-    await proxy.start()
-    proxy_task = asyncio.create_task(proxy.serve())
+    async with Proxy(
+        "127.0.0.1", 0, "127.0.0.1", master.port if not test_admin_port else master.admin_port
+    ) as proxy:
+        # 2. Spin up a replica and initiate a REPLICAOF
+        replica = df_factory.create(
+            tls_replication="true",
+            **with_ca_tls_server_args,
+            proactor_threads=t_replica,
+        )
+        replica.start()
+        c_replica = replica.client(**with_ca_tls_client_args)
+        res = await c_replica.execute_command("REPLICAOF localhost " + str(proxy.port))
+        assert "OK" == res
+        await check_all_replicas_finished([c_replica], c_master)
 
-    # 2. Spin up a replica and initiate a REPLICAOF
-    replica = df_factory.create(
-        tls_replication="true",
-        **with_ca_tls_server_args,
-        proactor_threads=t_replica,
-    )
-    replica.start()
-    c_replica = replica.client(**with_ca_tls_client_args)
-    res = await c_replica.execute_command("REPLICAOF localhost " + str(proxy.port))
-    assert "OK" == res
-    await check_all_replicas_finished([c_replica], c_master)
+        # 3. Verify that replica dbsize == debug populate key size -- replication works
+        db_size = await c_replica.execute_command("DBSIZE")
+        assert 100 == db_size
 
-    # 3. Verify that replica dbsize == debug populate key size -- replication works
-    db_size = await c_replica.execute_command("DBSIZE")
-    assert 100 == db_size
+        # 4. Break the connection between master and replica
+        await proxy.close()
+        await asyncio.sleep(3)
+        await proxy.start_serving()
 
-    # 4. Break the connection between master and replica
-    await proxy.close(proxy_task)
-    await asyncio.sleep(3)
-    await proxy.start()
-    proxy_task = asyncio.create_task(proxy.serve())
+        # Check replica gets new keys
+        await c_master.execute_command("SET MY_KEY 1")
+        db_size = await c_master.execute_command("DBSIZE")
+        assert 101 == db_size
 
-    # Check replica gets new keys
-    await c_master.execute_command("SET MY_KEY 1")
-    db_size = await c_master.execute_command("DBSIZE")
-    assert 101 == db_size
-
-    await check_all_replicas_finished([c_replica], c_master)
-    db_size = await c_replica.execute_command("DBSIZE")
-    assert 101 == db_size
-
-    await proxy.close(proxy_task)
+        await check_all_replicas_finished([c_replica], c_master)
+        db_size = await c_replica.execute_command("DBSIZE")
+        assert 101 == db_size
 
 
 @dfly_args({"proactor_threads": 2})
@@ -2026,10 +2020,7 @@ async def test_network_disconnect(
     async with replica.client() as c_replica, master.client() as c_master:
         await seeder.run(target_deviation=0.1)
 
-        proxy = Proxy("127.0.0.1", 0, "127.0.0.1", master.port)
-        await proxy.start()
-        task = asyncio.create_task(proxy.serve())
-        try:
+        async with Proxy("127.0.0.1", 0, "127.0.0.1", master.port) as proxy:
             await c_replica.execute_command(f"REPLICAOF localhost {proxy.port}")
 
             if check_stale_log:
@@ -2060,8 +2051,6 @@ async def test_network_disconnect(
 
             capture = await seeder.capture()
             assert await seeder.compare(capture, replica.port)
-        finally:
-            await proxy.close(task)
 
     if check_stale_log:
         master.stop()
@@ -2079,10 +2068,7 @@ async def test_replica_reconnections_after_network_disconnect(df_factory, df_see
     async with replica.client() as c_replica:
         await seeder.run(target_deviation=0.1)
 
-        proxy = Proxy("127.0.0.1", 1115, "127.0.0.1", master.port)
-        await proxy.start()
-        task = asyncio.create_task(proxy.serve())
-        try:
+        async with Proxy("127.0.0.1", 0, "127.0.0.1", master.port) as proxy:
             await c_replica.execute_command(f"REPLICAOF localhost {proxy.port}")
 
             # Wait replica to be up and synchronized with master
@@ -2091,15 +2077,14 @@ async def test_replica_reconnections_after_network_disconnect(df_factory, df_see
             initial_reconnects_count = await get_replica_reconnects_count(replica)
 
             # Fully drop the server
-            await proxy.close(task)
+            await proxy.close()
 
             # After dropping the connection replica should try to reconnect
             await wait_for_replica_status(c_replica, status="down")
             await asyncio.sleep(2)
 
             # Restart the proxy
-            await proxy.start()
-            task = asyncio.create_task(proxy.serve())
+            await proxy.start_serving()
 
             # Wait replica to be reconnected and synchronized with master
             await wait_available_async(c_replica)
@@ -2109,9 +2094,6 @@ async def test_replica_reconnections_after_network_disconnect(df_factory, df_see
 
             # Assert replica reconnects metrics increased
             await assert_replica_reconnections(replica, initial_reconnects_count)
-
-        finally:
-            await proxy.close(task)
 
 
 async def test_search(df_factory):
@@ -3631,11 +3613,7 @@ async def test_partial_sync(df_factory, proactors, backlog_len):
         seeder = SeederV2(key_target=keys)
         await seeder.run(c_master, target_deviation=0.01)
 
-        proxy = Proxy("127.0.0.1", 1113, "127.0.0.1", master.port)
-        await proxy.start()
-        task = asyncio.create_task(proxy.serve())
-
-        try:
+        async with Proxy("127.0.0.1", 0, "127.0.0.1", master.port) as proxy:
             await c_replica.execute_command(f"REPLICAOF localhost {proxy.port}")
             # Reach stable sync
             await wait_for_replicas_state(c_replica)
@@ -3655,7 +3633,7 @@ async def test_partial_sync(df_factory, proactors, backlog_len):
             await proxy.close()
             # Whoops we moved too much, no partial sync here
             await stream(c_master, backlog_len + 10)
-            await proxy.start()
+            await proxy.start_serving()
             await asyncio.sleep(1.0)
 
             await check_all_replicas_finished([c_replica], c_master)
@@ -3664,8 +3642,6 @@ async def test_partial_sync(df_factory, proactors, backlog_len):
                 *(SeederV2.capture(c) for c in (c_master, c_replica))
             )
             assert hash1 == hash2
-        finally:
-            await proxy.close(task)
 
     master.stop()
     replica.stop()
@@ -4425,48 +4401,44 @@ async def test_hnsw_search_replication_with_network_disruptions(
     await seeder.create_index(c_master)
     await seeder.seed_initial_docs(c_master)
 
-    proxy = Proxy("127.0.0.1", 0, "127.0.0.1", master.port)
-    await proxy.start()
-    proxy_task = asyncio.create_task(proxy.serve())
+    async with Proxy("127.0.0.1", 0, "127.0.0.1", master.port) as proxy:
+        traffic_task = asyncio.create_task(seeder.run_traffic(c_master))
+        search_task = asyncio.create_task(seeder.run_search_queries(c_master))
+        await c_replica.execute_command(f"REPLICAOF localhost {proxy.port}")
 
-    traffic_task = asyncio.create_task(seeder.run_traffic(c_master))
-    search_task = asyncio.create_task(seeder.run_search_queries(c_master))
-    await c_replica.execute_command(f"REPLICAOF localhost {proxy.port}")
+        sync_timeout = _hnsw_sync_timeout(num_docs)
 
-    sync_timeout = _hnsw_sync_timeout(num_docs)
-
-    # Wait for initial sync before running search queries on replica.
-    # During HNSW graph restoration with external vectors, nodes have
-    # uninitialized data pointers — search queries could dereference them.
-    await wait_available_async(c_replica, timeout=sync_timeout)
-    replica_search_task = asyncio.create_task(seeder.run_search_queries(c_replica))
-
-    try:
-        await asyncio.sleep(random.uniform(0, 10))
-        proxy.drop_connection()
-
-        # Give time to detect dropped connection and reconnect
-        await asyncio.sleep(1.0)
-
+        # Wait for initial sync before running search queries on replica.
+        # During HNSW graph restoration with external vectors, nodes have
+        # uninitialized data pointers — search queries could dereference them.
         await wait_available_async(c_replica, timeout=sync_timeout)
-        seeder.stop()
-        await traffic_task
-        await search_task
-        await replica_search_task
+        replica_search_task = asyncio.create_task(seeder.run_search_queries(c_replica))
 
-        # Log replica FT.INFO for debugging if assertion fails later
-        info = await c_replica.execute_command("FT.INFO", seeder.index_name)
-        logging.info(f"Replica FT.INFO: {info}")
+        try:
+            await asyncio.sleep(random.uniform(0, 10))
+            proxy.drop_connection()
 
-        await check_all_replicas_finished([c_replica], c_master, timeout=sync_timeout)
-        await seeder.verify(c_master, c_replica)
+            # Give time to detect dropped connection and reconnect
+            await asyncio.sleep(1.0)
 
-    finally:
-        seeder.stop()
-        traffic_task.cancel()
-        search_task.cancel()
-        replica_search_task.cancel()
-        await proxy.close(proxy_task)
+            await wait_available_async(c_replica, timeout=sync_timeout)
+            seeder.stop()
+            await traffic_task
+            await search_task
+            await replica_search_task
+
+            # Log replica FT.INFO for debugging if assertion fails later
+            info = await c_replica.execute_command("FT.INFO", seeder.index_name)
+            logging.info(f"Replica FT.INFO: {info}")
+
+            await check_all_replicas_finished([c_replica], c_master, timeout=sync_timeout)
+            await seeder.verify(c_master, c_replica)
+
+        finally:
+            seeder.stop()
+            traffic_task.cancel()
+            search_task.cancel()
+            replica_search_task.cancel()
 
 
 @pytest.mark.parametrize(

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -19,7 +19,6 @@ from redis import asyncio as aioredis
 
 from . import dfly_args
 from .instance import DflyInstanceFactory, DflyInstance
-from .proxy import Proxy
 from .seeder import DebugPopulateSeeder, HnswSearchSeeder
 from .seeder import Seeder as SeederV2
 from .utility import (
@@ -1764,6 +1763,7 @@ async def test_tls_replication(
     test_admin_port,
     with_ca_tls_server_args,
     with_ca_tls_client_args,
+    proxy_factory,
 ):
     # 1. Spin up dragonfly tls enabled, debug populate
     master = df_factory.create(
@@ -1779,38 +1779,37 @@ async def test_tls_replication(
     db_size = await c_master.execute_command("DBSIZE")
     assert 100 == db_size
 
-    async with Proxy(
-        "127.0.0.1", 0, "127.0.0.1", master.port if not test_admin_port else master.admin_port
-    ) as proxy:
-        # 2. Spin up a replica and initiate a REPLICAOF
-        replica = df_factory.create(
-            tls_replication="true",
-            **with_ca_tls_server_args,
-            proactor_threads=t_replica,
-        )
-        replica.start()
-        c_replica = replica.client(**with_ca_tls_client_args)
-        res = await c_replica.execute_command("REPLICAOF localhost " + str(proxy.port))
-        assert "OK" == res
-        await check_all_replicas_finished([c_replica], c_master)
+    proxy = await proxy_factory(master.port if not test_admin_port else master.admin_port)
 
-        # 3. Verify that replica dbsize == debug populate key size -- replication works
-        db_size = await c_replica.execute_command("DBSIZE")
-        assert 100 == db_size
+    # 2. Spin up a replica and initiate a REPLICAOF
+    replica = df_factory.create(
+        tls_replication="true",
+        **with_ca_tls_server_args,
+        proactor_threads=t_replica,
+    )
+    replica.start()
+    c_replica = replica.client(**with_ca_tls_client_args)
+    res = await c_replica.execute_command("REPLICAOF localhost " + str(proxy.port))
+    assert "OK" == res
+    await check_all_replicas_finished([c_replica], c_master)
 
-        # 4. Break the connection between master and replica
-        await proxy.close()
-        await asyncio.sleep(3)
-        await proxy.start_serving()
+    # 3. Verify that replica dbsize == debug populate key size -- replication works
+    db_size = await c_replica.execute_command("DBSIZE")
+    assert 100 == db_size
 
-        # Check replica gets new keys
-        await c_master.execute_command("SET MY_KEY 1")
-        db_size = await c_master.execute_command("DBSIZE")
-        assert 101 == db_size
+    # 4. Break the connection between master and replica
+    await proxy.close()
+    await asyncio.sleep(3)
+    await proxy.start_serving()
 
-        await check_all_replicas_finished([c_replica], c_master)
-        db_size = await c_replica.execute_command("DBSIZE")
-        assert 101 == db_size
+    # Check replica gets new keys
+    await c_master.execute_command("SET MY_KEY 1")
+    db_size = await c_master.execute_command("DBSIZE")
+    assert 101 == db_size
+
+    await check_all_replicas_finished([c_replica], c_master)
+    db_size = await c_replica.execute_command("DBSIZE")
+    assert 101 == db_size
 
 
 @dfly_args({"proactor_threads": 2})
@@ -2007,6 +2006,7 @@ async def test_network_disconnect(
     num_drops,
     sleep_range,
     check_stale_log,
+    proxy_factory,
 ):
     master_kwargs = dict(proactor_threads=master_threads)
     if backlog_len is not None:
@@ -2020,37 +2020,37 @@ async def test_network_disconnect(
     async with replica.client() as c_replica, master.client() as c_master:
         await seeder.run(target_deviation=0.1)
 
-        async with Proxy("127.0.0.1", 0, "127.0.0.1", master.port) as proxy:
-            await c_replica.execute_command(f"REPLICAOF localhost {proxy.port}")
+        proxy = await proxy_factory(master.port)
+        await c_replica.execute_command(f"REPLICAOF localhost {proxy.port}")
 
-            if check_stale_log:
-                # Wait for the two nodes to be in sync (stable state replication) before seeding
-                await wait_available_async(c_replica)
-
-            fill_task = None
-            if stream_during:
-                if stream_target_ops is not None:
-                    fill_task = asyncio.create_task(seeder.run(target_ops=stream_target_ops))
-                else:
-                    fill_task = asyncio.create_task(seeder.run())
-
-            for _ in range(num_drops):
-                await asyncio.sleep(random.randint(*sleep_range) / 10)
-                proxy.drop_connection()
-
-            if fill_task is not None:
-                seeder.stop()
-                await fill_task
-
-            # Give time to detect dropped connection and reconnect
-            await asyncio.sleep(1.0)
+        if check_stale_log:
+            # Wait for the two nodes to be in sync (stable state replication) before seeding
             await wait_available_async(c_replica)
 
-            logging.debug(await c_replica.execute_command("INFO REPLICATION"))
-            logging.debug(await c_master.execute_command("INFO REPLICATION"))
+        fill_task = None
+        if stream_during:
+            if stream_target_ops is not None:
+                fill_task = asyncio.create_task(seeder.run(target_ops=stream_target_ops))
+            else:
+                fill_task = asyncio.create_task(seeder.run())
 
-            capture = await seeder.capture()
-            assert await seeder.compare(capture, replica.port)
+        for _ in range(num_drops):
+            await asyncio.sleep(random.randint(*sleep_range) / 10)
+            proxy.drop_connection()
+
+        if fill_task is not None:
+            seeder.stop()
+            await fill_task
+
+        # Give time to detect dropped connection and reconnect
+        await asyncio.sleep(1.0)
+        await wait_available_async(c_replica)
+
+        logging.debug(await c_replica.execute_command("INFO REPLICATION"))
+        logging.debug(await c_master.execute_command("INFO REPLICATION"))
+
+        capture = await seeder.capture()
+        assert await seeder.compare(capture, replica.port)
 
     if check_stale_log:
         master.stop()
@@ -2058,7 +2058,9 @@ async def test_network_disconnect(
         assert len(lines) > 0
 
 
-async def test_replica_reconnections_after_network_disconnect(df_factory, df_seeder_factory):
+async def test_replica_reconnections_after_network_disconnect(
+    df_factory, df_seeder_factory, proxy_factory
+):
     master = df_factory.create(proactor_threads=6)
     replica = df_factory.create(proactor_threads=4)
 
@@ -2068,32 +2070,32 @@ async def test_replica_reconnections_after_network_disconnect(df_factory, df_see
     async with replica.client() as c_replica:
         await seeder.run(target_deviation=0.1)
 
-        async with Proxy("127.0.0.1", 0, "127.0.0.1", master.port) as proxy:
-            await c_replica.execute_command(f"REPLICAOF localhost {proxy.port}")
+        proxy = await proxy_factory(master.port)
+        await c_replica.execute_command(f"REPLICAOF localhost {proxy.port}")
 
-            # Wait replica to be up and synchronized with master
-            await wait_available_async(c_replica)
+        # Wait replica to be up and synchronized with master
+        await wait_available_async(c_replica)
 
-            initial_reconnects_count = await get_replica_reconnects_count(replica)
+        initial_reconnects_count = await get_replica_reconnects_count(replica)
 
-            # Fully drop the server
-            await proxy.close()
+        # Fully drop the server
+        await proxy.close()
 
-            # After dropping the connection replica should try to reconnect
-            await wait_for_replica_status(c_replica, status="down")
-            await asyncio.sleep(2)
+        # After dropping the connection replica should try to reconnect
+        await wait_for_replica_status(c_replica, status="down")
+        await asyncio.sleep(2)
 
-            # Restart the proxy
-            await proxy.start_serving()
+        # Restart the proxy
+        await proxy.start_serving()
 
-            # Wait replica to be reconnected and synchronized with master
-            await wait_available_async(c_replica)
+        # Wait replica to be reconnected and synchronized with master
+        await wait_available_async(c_replica)
 
-            capture = await seeder.capture()
-            assert await seeder.compare(capture, replica.port)
+        capture = await seeder.capture()
+        assert await seeder.compare(capture, replica.port)
 
-            # Assert replica reconnects metrics increased
-            await assert_replica_reconnections(replica, initial_reconnects_count)
+        # Assert replica reconnects metrics increased
+        await assert_replica_reconnections(replica, initial_reconnects_count)
 
 
 async def test_search(df_factory):
@@ -3589,7 +3591,7 @@ async def test_bug_5221(df_factory):
 
 @pytest.mark.parametrize("proactors", [1, 4, 6])
 @pytest.mark.parametrize("backlog_len", [1, 256, 1024, 1300])
-async def test_partial_sync(df_factory, proactors, backlog_len):
+async def test_partial_sync(df_factory, proactors, backlog_len, proxy_factory):
     keys = 5_000
     if proactors > 1:
         keys = 10_000
@@ -3613,35 +3615,31 @@ async def test_partial_sync(df_factory, proactors, backlog_len):
         seeder = SeederV2(key_target=keys)
         await seeder.run(c_master, target_deviation=0.01)
 
-        async with Proxy("127.0.0.1", 0, "127.0.0.1", master.port) as proxy:
-            await c_replica.execute_command(f"REPLICAOF localhost {proxy.port}")
-            # Reach stable sync
-            await wait_for_replicas_state(c_replica)
-            # Stream some elements
-            await stream(c_master, backlog_len)
+        proxy = await proxy_factory(master.port)
+        await c_replica.execute_command(f"REPLICAOF localhost {proxy.port}")
+        # Reach stable sync
+        await wait_for_replicas_state(c_replica)
+        # Stream some elements
+        await stream(c_master, backlog_len)
 
-            proxy.drop_connection()
-            # Give time to detect dropped connection and reconnect
-            await asyncio.sleep(1.0)
-            # Partial synced here
-            await check_all_replicas_finished([c_replica], c_master)
-            hash1, hash2 = await asyncio.gather(
-                *(SeederV2.capture(c) for c in (c_master, c_replica))
-            )
-            assert hash1 == hash2
+        proxy.drop_connection()
+        # Give time to detect dropped connection and reconnect
+        await asyncio.sleep(1.0)
+        # Partial synced here
+        await check_all_replicas_finished([c_replica], c_master)
+        hash1, hash2 = await asyncio.gather(*(SeederV2.capture(c) for c in (c_master, c_replica)))
+        assert hash1 == hash2
 
-            await proxy.close()
-            # Whoops we moved too much, no partial sync here
-            await stream(c_master, backlog_len + 10)
-            await proxy.start_serving()
-            await asyncio.sleep(1.0)
+        await proxy.close()
+        # Whoops we moved too much, no partial sync here
+        await stream(c_master, backlog_len + 10)
+        await proxy.start_serving()
+        await asyncio.sleep(1.0)
 
-            await check_all_replicas_finished([c_replica], c_master)
+        await check_all_replicas_finished([c_replica], c_master)
 
-            hash1, hash2 = await asyncio.gather(
-                *(SeederV2.capture(c) for c in (c_master, c_replica))
-            )
-            assert hash1 == hash2
+        hash1, hash2 = await asyncio.gather(*(SeederV2.capture(c) for c in (c_master, c_replica)))
+        assert hash1 == hash2
 
     master.stop()
     replica.stop()
@@ -4379,6 +4377,7 @@ async def test_hnsw_search_replication_with_network_disruptions(
     replica_threads: int,
     num_dims: int,
     num_docs: int,
+    proxy_factory,
 ):
     """
     Test HNSW search index replication under continuous traffic and a network disruption.
@@ -4401,44 +4400,44 @@ async def test_hnsw_search_replication_with_network_disruptions(
     await seeder.create_index(c_master)
     await seeder.seed_initial_docs(c_master)
 
-    async with Proxy("127.0.0.1", 0, "127.0.0.1", master.port) as proxy:
-        traffic_task = asyncio.create_task(seeder.run_traffic(c_master))
-        search_task = asyncio.create_task(seeder.run_search_queries(c_master))
-        await c_replica.execute_command(f"REPLICAOF localhost {proxy.port}")
+    proxy = await proxy_factory(master.port)
+    traffic_task = asyncio.create_task(seeder.run_traffic(c_master))
+    search_task = asyncio.create_task(seeder.run_search_queries(c_master))
+    await c_replica.execute_command(f"REPLICAOF localhost {proxy.port}")
 
-        sync_timeout = _hnsw_sync_timeout(num_docs)
+    sync_timeout = _hnsw_sync_timeout(num_docs)
 
-        # Wait for initial sync before running search queries on replica.
-        # During HNSW graph restoration with external vectors, nodes have
-        # uninitialized data pointers — search queries could dereference them.
+    # Wait for initial sync before running search queries on replica.
+    # During HNSW graph restoration with external vectors, nodes have
+    # uninitialized data pointers — search queries could dereference them.
+    await wait_available_async(c_replica, timeout=sync_timeout)
+    replica_search_task = asyncio.create_task(seeder.run_search_queries(c_replica))
+
+    try:
+        await asyncio.sleep(random.uniform(0, 10))
+        proxy.drop_connection()
+
+        # Give time to detect dropped connection and reconnect
+        await asyncio.sleep(1.0)
+
         await wait_available_async(c_replica, timeout=sync_timeout)
-        replica_search_task = asyncio.create_task(seeder.run_search_queries(c_replica))
+        seeder.stop()
+        await traffic_task
+        await search_task
+        await replica_search_task
 
-        try:
-            await asyncio.sleep(random.uniform(0, 10))
-            proxy.drop_connection()
+        # Log replica FT.INFO for debugging if assertion fails later
+        info = await c_replica.execute_command("FT.INFO", seeder.index_name)
+        logging.info(f"Replica FT.INFO: {info}")
 
-            # Give time to detect dropped connection and reconnect
-            await asyncio.sleep(1.0)
+        await check_all_replicas_finished([c_replica], c_master, timeout=sync_timeout)
+        await seeder.verify(c_master, c_replica)
 
-            await wait_available_async(c_replica, timeout=sync_timeout)
-            seeder.stop()
-            await traffic_task
-            await search_task
-            await replica_search_task
-
-            # Log replica FT.INFO for debugging if assertion fails later
-            info = await c_replica.execute_command("FT.INFO", seeder.index_name)
-            logging.info(f"Replica FT.INFO: {info}")
-
-            await check_all_replicas_finished([c_replica], c_master, timeout=sync_timeout)
-            await seeder.verify(c_master, c_replica)
-
-        finally:
-            seeder.stop()
-            traffic_task.cancel()
-            search_task.cancel()
-            replica_search_task.cancel()
+    finally:
+        seeder.stop()
+        traffic_task.cancel()
+        search_task.cancel()
+        replica_search_task.cancel()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
previously proxy chose fixed port did not close on failing path.
this causes cascading errors on CI sometimes:

* test 1 fails, does not stop proxy cleanly
* test 2 cannot use same port, fails
* test 3 cannot reuse same port, fails
* ...

The test 1 still has to be fixed, but we should not leak processes and also try to use non-fixed ports to avoid such cascades. proxy already supports random port with `port=0` so we choose that.