### PR TITLE
fix: GETEX command replication

### DIFF
--- a/src/server/common_types.h
+++ b/src/server/common_types.h
@@ -33,6 +33,13 @@ enum class GlobalState : uint8_t {
 
 enum class TimeUnit : uint8_t { SEC, MSEC };
 
+enum class ExpT : uint8_t {
+  EX,    // relative seconds
+  PX,    // relative milliseconds
+  EXAT,  // absolute seconds
+  PXAT   // absolute milliseconds
+};
+
 enum class LoadBlobResult : uint8_t {
   kSuccess,
   kCorrupted,

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -1126,25 +1126,48 @@ OpResult<DbSlice::ItAndUpdater> DbSlice::AddNew(const Context& cntx, string_view
   return DbSlice::ItAndUpdater{.it = res.it, .post_updater = std::move(res.post_updater)};
 }
 
-int64_t DbSlice::ExpireParams::Cap(int64_t value, TimeUnit unit) {
-  return unit == TimeUnit::SEC ? min(value, kMaxExpireDeadlineSec)
-                               : min(value, kMaxExpireDeadlineMs);
+DbSlice::ExpireParams::ExpireParams(ExpT type, int64_t value, uint64_t now_ms, bool cap) {
+  const TimeUnit unit = (type == ExpT::PX || type == ExpT::PXAT) ? TimeUnit::MSEC : TimeUnit::SEC;
+  const bool is_absolute = type == ExpT::EXAT || type == ExpT::PXAT;
+  *this = is_absolute ? ExpireParams{unit, value} : ExpireParams{unit, value, now_ms, cap};
+}
+
+DbSlice::ExpireParams::ExpireParams(TimeUnit unit, int64_t svalue, uint64_t now_ms, bool cap) {
+  if (svalue <= 0) {
+    ms_timestamp = 0;  // expire immediately
+    return;
+  }
+
+  int64_t ms_value = svalue;
+  if (unit == TimeUnit::SEC) {
+    ms_value = (svalue <= kOverflow / 1000) ? svalue * 1000 : kOverflow;
+  }
+
+  if (cap && now_ms > 0 && ms_value > kMaxExpireDeadlineMs) {
+    ms_value = kMaxExpireDeadlineMs;
+  }
+
+  if ((kOverflow - static_cast<int64_t>(now_ms)) < static_cast<int64_t>(ms_value)) {
+    ms_timestamp = kOverflow;
+    return;
+  }
+
+  ms_timestamp = ms_value + now_ms;
 }
 
 pair<int64_t, int64_t> DbSlice::ExpireParams::Calculate(uint64_t now_ms, bool cap) const {
   if (persist)
     return {0, 0};
-
-  // return a negative absolute time if we overflow.
-  if (unit == TimeUnit::SEC && value > INT64_MAX / 1000) {
+  if (ms_timestamp == kOverflow)
     return {0, -1};
+
+  int64_t rel_ms = ms_timestamp - now_ms;
+  if (cap) {
+    rel_ms = min(rel_ms, kMaxExpireDeadlineMs);
+    return {rel_ms, rel_ms + now_ms};
   }
 
-  int64_t msec = (unit == TimeUnit::SEC) ? value * 1000 : value;
-  int64_t rel_msec = absolute ? msec - now_ms : msec;
-  if (cap)
-    rel_msec = Cap(rel_msec, TimeUnit::MSEC);
-  return make_pair(rel_msec, now_ms + rel_msec);
+  return {rel_ms, ms_timestamp};
 }
 
 OpResult<int64_t> DbSlice::UpdateExpire(const Context& cntx, Iterator prime_it,

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -8,6 +8,7 @@
 #include <absl/container/flat_hash_set.h>
 
 #include <atomic>
+#include <limits>
 
 #include "common/string_or_view.h"
 #include "core/mi_memory_resource.h"
@@ -221,26 +222,32 @@ class DbSlice {
   using DocDeletionCallback = std::function<void(std::string_view, const Context&, PrimeValue& pv)>;
 
   struct ExpireParams {
+    ExpireParams() = default;
+
+    // if now_ms = 0 the value is absolute; cap applies to relative dispatch only;
+    // cap=true silently clamps to kMaxExpireDeadlineMs;
+    ExpireParams(TimeUnit unit, int64_t value, uint64_t now_ms = 0, bool cap = false);
+
+    // if now_ms = 0 the value is absolute; cap applies to relative dispatch only;
+    // cap=true silently clamps to kMaxExpireDeadlineMs;
+    ExpireParams(ExpT type, int64_t value, uint64_t now_ms = 0, bool cap = false);
+
     bool IsDefined() const {
-      return persist || value > INT64_MIN;
+      return persist || ms_timestamp >= 0;
     }
 
-    static int64_t Cap(int64_t value, TimeUnit unit);
+    bool IsExpired(int64_t now_msec) const {
+      return ms_timestamp >= 0 && ms_timestamp < now_msec;
+    }
 
-    // Calculate relative and absolue timepoints.
+    // Returns (relative_ms, absolute_ms). On overflow returns {0, -1}.
     std::pair<int64_t, int64_t> Calculate(uint64_t now_msec, bool cap) const;
 
-    // Return true if relative expiration is in the past
-    bool IsExpired(uint64_t now_msec) const {
-      return Calculate(now_msec, false).first < 0;
-    }
+    // INT64_MAX is the year 292M AD — never a real expiration.
+    static constexpr int64_t kOverflow = std::numeric_limits<int64_t>::max();
 
-   public:
-    int64_t value = INT64_MIN;  // undefined
-    TimeUnit unit = TimeUnit::SEC;
-
-    bool absolute = false;
-    bool persist = false;        // persist means remove all expiry
+    int64_t ms_timestamp = -1;  // -1 = undefined; 0 = expire now; kOverflow = overflow.
+    bool persist = false;
     int32_t expire_options = 0;  // ExpireFlags
   };
 

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -227,17 +227,10 @@ class DbSlice {
     // if now_ms = 0 the value is absolute; cap applies to relative dispatch only;
     // cap=true silently clamps to kMaxExpireDeadlineMs;
     ExpireParams(TimeUnit unit, int64_t value, uint64_t now_ms = 0, bool cap = false);
-
-    // if now_ms = 0 the value is absolute; cap applies to relative dispatch only;
-    // cap=true silently clamps to kMaxExpireDeadlineMs;
     ExpireParams(ExpT type, int64_t value, uint64_t now_ms = 0, bool cap = false);
 
     bool IsDefined() const {
       return persist || ms_timestamp >= 0;
-    }
-
-    bool IsExpired(int64_t now_msec) const {
-      return ms_timestamp >= 0 && ms_timestamp < now_msec;
     }
 
     // Returns (relative_ms, absolute_ms). On overflow returns {0, -1}.

--- a/src/server/generic_family.cc
+++ b/src/server/generic_family.cc
@@ -1404,21 +1404,17 @@ void GenericFamily::Expire(facade::CmdArgParser parser, CommandContext* cmd_cntx
     return cmd_cntx->SendError(err.MakeReply());
   }
 
-  int_arg = std::max<int64_t>(int_arg, -1);
-
-  // silently cap the expire time to kMaxExpireDeadlineSec which is more than 8 years.
-  if (int_arg > kMaxExpireDeadlineSec) {
-    int_arg = kMaxExpireDeadlineSec;
-  }
-
   auto expire_options = ParseExpireOptionsOrReply(cmd_cntx->tail_args().Tail(2));
   if (!expire_options) {
     return cmd_cntx->SendError(expire_options.error());
   }
-  DbSlice::ExpireParams params{.value = int_arg, .expire_options = expire_options.value()};
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpExpire(t->GetOpArgs(shard), key, params);
+    auto op_args = t->GetOpArgs(shard);
+    DbSlice::ExpireParams params{TimeUnit::SEC, int_arg, op_args.db_cntx.time_now_ms,
+                                 /*cap=*/true};
+    params.expire_options = expire_options.value();
+    return OpExpire(op_args, key, params);
   };
 
   OpStatus status = cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));
@@ -1431,13 +1427,13 @@ void GenericFamily::ExpireAt(facade::CmdArgParser parser, CommandContext* cmd_cn
     return cmd_cntx->SendError(err.MakeReply());
   }
 
-  int_arg = std::max<int64_t>(int_arg, 0L);
   auto expire_options = ParseExpireOptionsOrReply(cmd_cntx->tail_args().Tail(2));
   if (!expire_options) {
     return cmd_cntx->SendError(expire_options.error());
   }
-  DbSlice::ExpireParams params{
-      .value = int_arg, .absolute = true, .expire_options = expire_options.value()};
+  // ExpireParams normalizes 0/negative inputs internally.
+  DbSlice::ExpireParams params{TimeUnit::SEC, int_arg};
+  params.expire_options = expire_options.value();
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpExpire(t->GetOpArgs(shard), key, params);
@@ -1479,15 +1475,13 @@ void GenericFamily::PexpireAt(facade::CmdArgParser parser, CommandContext* cmd_c
     return cmd_cntx->SendError(err.MakeReply());
   }
 
-  int_arg = std::max<int64_t>(int_arg, 0L);
   auto expire_options = ParseExpireOptionsOrReply(cmd_cntx->tail_args().Tail(2));
   if (!expire_options) {
     return cmd_cntx->SendError(expire_options.error());
   }
-  DbSlice::ExpireParams params{.value = int_arg,
-                               .unit = TimeUnit::MSEC,
-                               .absolute = true,
-                               .expire_options = expire_options.value()};
+  // ExpireParams normalizes 0/negative inputs internally.
+  DbSlice::ExpireParams params{TimeUnit::MSEC, int_arg};
+  params.expire_options = expire_options.value();
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpExpire(t->GetOpArgs(shard), key, params);
@@ -1506,22 +1500,18 @@ void GenericFamily::Pexpire(facade::CmdArgParser parser, CommandContext* cmd_cnt
   if (auto err = parser.TakeError(); err) {
     return cmd_cntx->SendError(err.MakeReply());
   }
-  int_arg = std::max<int64_t>(int_arg, -1);
-
-  // to be more compatible with redis, we silently cap the expire time to kMaxExpireDeadlineSec
-  if (int_arg > kMaxExpireDeadlineMs) {
-    int_arg = kMaxExpireDeadlineMs;
-  }
 
   auto expire_options = ParseExpireOptionsOrReply(cmd_cntx->tail_args().Tail(2));
   if (!expire_options) {
     return cmd_cntx->SendError(expire_options.error());
   }
-  DbSlice::ExpireParams params{
-      .value = int_arg, .unit = TimeUnit::MSEC, .expire_options = expire_options.value()};
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
-    return OpExpire(t->GetOpArgs(shard), key, params);
+    auto op_args = t->GetOpArgs(shard);
+    DbSlice::ExpireParams params{TimeUnit::MSEC, int_arg, op_args.db_cntx.time_now_ms,
+                                 /*cap=*/true};
+    params.expire_options = expire_options.value();
+    return OpExpire(op_args, key, params);
   };
   OpStatus status = cmd_cntx->tx()->ScheduleSingleHop(std::move(cb));
 

--- a/src/server/generic_family_test.cc
+++ b/src/server/generic_family_test.cc
@@ -79,6 +79,69 @@ TEST_F(GenericFamilyTest, Expire) {
   EXPECT_THAT(resp, ArgType(RespExpr::NIL));
 }
 
+TEST_F(GenericFamilyTest, ExpireCornerCases) {
+  // EXPIRE / PEXPIRE with non-positive TTL deletes the key immediately and reports success.
+  Run({"set", "key", "val"});
+  EXPECT_THAT(Run({"expire", "key", "-1"}), IntArg(1));
+  EXPECT_THAT(Run({"exists", "key"}), IntArg(0));
+
+  Run({"set", "key", "val"});
+  EXPECT_THAT(Run({"expire", "key", "0"}), IntArg(1));
+  EXPECT_THAT(Run({"exists", "key"}), IntArg(0));
+
+  Run({"set", "key", "val"});
+  EXPECT_THAT(Run({"expire", "key", "-100"}), IntArg(1));
+  EXPECT_THAT(Run({"exists", "key"}), IntArg(0));
+
+  Run({"set", "key", "val"});
+  EXPECT_THAT(Run({"pexpire", "key", "-1"}), IntArg(1));
+  EXPECT_THAT(Run({"exists", "key"}), IntArg(0));
+
+  Run({"set", "key", "val"});
+  EXPECT_THAT(Run({"pexpire", "key", "0"}), IntArg(1));
+  EXPECT_THAT(Run({"exists", "key"}), IntArg(0));
+
+  // EXPIREAT / PEXPIREAT with a past absolute timestamp (including 0 and negatives) deletes
+  // the key.
+  Run({"set", "key", "val"});
+  EXPECT_THAT(Run({"expireat", "key", "0"}), IntArg(1));
+  EXPECT_THAT(Run({"exists", "key"}), IntArg(0));
+
+  Run({"set", "key", "val"});
+  EXPECT_THAT(Run({"expireat", "key", "-100"}), IntArg(1));
+  EXPECT_THAT(Run({"exists", "key"}), IntArg(0));
+
+  Run({"set", "key", "val"});
+  EXPECT_THAT(Run({"pexpireat", "key", "0"}), IntArg(1));
+  EXPECT_THAT(Run({"exists", "key"}), IntArg(0));
+
+  Run({"set", "key", "val"});
+  EXPECT_THAT(Run({"pexpireat", "key", "-1"}), IntArg(1));
+  EXPECT_THAT(Run({"exists", "key"}), IntArg(0));
+
+  // Huge absolute timestamps overflow the kMaxExpireDeadlineMs cap and surface OUT_OF_RANGE.
+  Run({"set", "key", "val"});
+  EXPECT_THAT(Run({"expireat", "key", absl::StrCat(INT64_MAX)}), ErrArg("expiry is out of range"));
+  EXPECT_THAT(Run({"exists", "key"}), IntArg(1));
+
+  EXPECT_THAT(Run({"pexpireat", "key", absl::StrCat(INT64_MAX)}), ErrArg("expiry is out of range"));
+  EXPECT_THAT(Run({"exists", "key"}), IntArg(1));
+
+  // Huge relative TTLs are silently capped to kMaxExpireDeadlineSec (~8.5 years).
+  EXPECT_THAT(Run({"expire", "key", "99999999999"}), IntArg(1));
+  EXPECT_EQ(CheckedInt({"ttl", "key"}), kMaxExpireDeadlineSec);
+
+  EXPECT_THAT(Run({"pexpire", "key", absl::StrCat(int64_t{kMaxExpireDeadlineMs} * 10)}), IntArg(1));
+  EXPECT_EQ(CheckedInt({"pttl", "key"}), kMaxExpireDeadlineMs);
+
+  // Expire commands on a missing key return 0 regardless of the TTL value.
+  EXPECT_THAT(Run({"del", "missing"}), IntArg(0));
+  EXPECT_THAT(Run({"expire", "missing", "5"}), IntArg(0));
+  EXPECT_THAT(Run({"expire", "missing", "-1"}), IntArg(0));
+  EXPECT_THAT(Run({"expireat", "missing", "0"}), IntArg(0));
+  EXPECT_THAT(Run({"pexpireat", "missing", "0"}), IntArg(0));
+}
+
 TEST_F(GenericFamilyTest, ExpireOptions) {
   // NX and XX are mutually exclusive
   Run({"set", "key", "val"});

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -56,8 +56,6 @@ using namespace util;
 
 using CI = CommandId;
 
-enum class ExpT { EX, PX, EXAT, PXAT };
-
 // Either immediately available value or tiering future + result
 template <typename T> using TResultOrT = variant<T, TieredStorage::TResult<T>>;
 
@@ -1060,13 +1058,9 @@ std::variant<SetCmd::SetParams, facade::ErrorReply, NegativeExpire> ParseSetPara
       if (int_arg <= 0)
         return facade::ErrorReply{InvalidExpireTime("set")};
 
-      DbSlice::ExpireParams expiry{
-          .value = int_arg,
-          .unit = *exp_type == ExpT::PX || *exp_type == ExpT::PXAT ? TimeUnit::MSEC : TimeUnit::SEC,
-          .absolute = *exp_type == ExpT::EXAT || *exp_type == ExpT::PXAT,
-      };
+      const uint64_t now_ms = GetCurrentTimeMs();
+      DbSlice::ExpireParams expiry{*exp_type, int_arg, now_ms};
 
-      int64_t now_ms = GetCurrentTimeMs();
       auto [rel_ms, abs_ms] = expiry.Calculate(now_ms, false);
       if (abs_ms < 0)
         return facade::ErrorReply{InvalidExpireTime("set")};
@@ -1098,7 +1092,7 @@ std::variant<SetCmd::SetParams, facade::ErrorReply, NegativeExpire> ParseSetPara
 
     if (mc->expire_ts > 0) {
       sparams.flags |= SetCmd::SET_EXPIRE_AFTER_MS;
-      DbSlice::ExpireParams expiry{.value = mc->expire_ts, .unit = TimeUnit::SEC, .absolute = true};
+      DbSlice::ExpireParams expiry{TimeUnit::SEC, mc->expire_ts};
       int64_t now_ms = GetCurrentTimeMs();
       auto [rel_ms, abs_ms] = expiry.Calculate(now_ms, false);
       if (abs_ms < 0)
@@ -1202,13 +1196,10 @@ cmd::CmdR CmdSetExGeneric(CmdArgParser parser, CommandContext* cmd_cntx) {
   if (exp_int < 1)
     co_return facade::ErrorReply{InvalidExpireTime(cmd_name)};
 
-  DbSlice::ExpireParams expiry{
-      .value = exp_int,
-      .unit = cmd_name.front() == 'P' ? TimeUnit::MSEC : TimeUnit::SEC,
-      .absolute = false,
-  };
+  const ExpT type = cmd_name.front() == 'P' ? ExpT::PX : ExpT::EX;
+  const uint64_t now_ms = GetCurrentTimeMs();
+  DbSlice::ExpireParams expiry{type, exp_int, now_ms};
 
-  int64_t now_ms = GetCurrentTimeMs();
   auto [_, abs_ms] = expiry.Calculate(now_ms, false);
   if (abs_ms < 0)
     co_return facade::ErrorReply{InvalidExpireTime("set")};
@@ -1349,38 +1340,36 @@ cmd::CmdR CmdGetSet(CmdArgParser parser, CommandContext* cmd_cntx) {
 cmd::CmdR CmdGetEx(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
 
-  DbSlice::ExpireParams exp_params;
+  ExpT exp_type_value = ExpT::EX;
+  int64_t int_arg = 0;
+  bool persist = false;
   bool defined = false;
-  while (parser.HasNext()) {
-    if (auto exp_type = parser.TryMapNext("EX", ExpT::EX, "PX", ExpT::PX, "EXAT", ExpT::EXAT,
-                                          "PXAT", ExpT::PXAT);
-        exp_type) {
-      auto int_arg = parser.Next<int64_t>();
-      if (auto err = parser.TakeError(); err)
-        co_return err.MakeReply();
 
-      if (defined) {
-        co_return facade::ErrorReply{kSyntaxErr, kSyntaxErrType};
-      }
-
-      if (int_arg <= 0) {
-        co_return facade::ErrorReply{InvalidExpireTime("getex")};
-      }
-
-      exp_params.absolute = *exp_type == ExpT::EXAT || *exp_type == ExpT::PXAT;
-      exp_params.value = int_arg;
-      exp_params.unit =
-          *exp_type == ExpT::PX || *exp_type == ExpT::PXAT ? TimeUnit::MSEC : TimeUnit::SEC;
+  auto expiry = [&](ExpT type) {
+    return [&, type](CmdArgParser* p) {
+      exp_type_value = type;
+      int_arg = p->Next<int64_t>();
       defined = true;
-    } else if (parser.Check("PERSIST")) {
-      exp_params.persist = true;
-    } else {
-      co_return facade::ErrorReply{kSyntaxErr};
-    }
+    };
+  };
+  parser.Apply(OneOf(Tag("EX", expiry(ExpT::EX)), Tag("PX", expiry(ExpT::PX)),
+                     Tag("EXAT", expiry(ExpT::EXAT)), Tag("PXAT", expiry(ExpT::PXAT)),
+                     Exist("PERSIST", &persist)));
+  if (!parser.Finalize()) {
+    co_return parser.TakeError().MakeReply();
+  }
+  if (defined && int_arg <= 0) {
+    co_return facade::ErrorReply{InvalidExpireTime("getex")};
   }
 
   auto cb = [&](Transaction* t, EngineShard* shard) -> OpResult<StringResult> {
     auto op_args = t->GetOpArgs(shard);
+
+    DbSlice::ExpireParams exp_params;
+    if (defined) {
+      exp_params = DbSlice::ExpireParams{exp_type_value, int_arg, op_args.db_cntx.time_now_ms};
+    }
+    exp_params.persist = persist;
 
     auto it_res = op_args.GetDbSlice().FindMutable(op_args.db_cntx, key, OBJ_STRING);
     if (!it_res)
@@ -1395,7 +1384,7 @@ cmd::CmdR CmdGetEx(CmdArgParser parser, CommandContext* cmd_cntx) {
     }
 
     // Replicate GETEX as PEXPIREAT or PERSIST
-    if (shard->journal()) {
+    if (shard->journal() && exp_params.IsDefined()) {
       if (exp_params.persist) {
         RecordJournal(op_args, "PERSIST", {key});
       } else {
@@ -1589,8 +1578,8 @@ cmd::CmdR CmdGAT(CmdArgParser parser, CommandContext* cmd_cntx) {
     return cmd::kAborted;
   }
   int64_t expire_ts = cmd_cntx->mc_command()->expire_ts;
-  DbSlice::ExpireParams expire_params{
-      .value = expire_ts, .absolute = true, .persist = expire_ts == 0};
+  DbSlice::ExpireParams expire_params{TimeUnit::SEC, expire_ts};
+  expire_params.persist = expire_ts == 0;
   return MGetGeneric(cmd_cntx, expire_params);
 }
 

--- a/src/server/string_family_test.cc
+++ b/src/server/string_family_test.cc
@@ -626,6 +626,16 @@ TEST_F(StringFamilyTest, GetEx) {
   resp = Run({"getex", "foo", "PERSIST", "1"});
   EXPECT_THAT(resp, ErrArg("syntax error"));
 
+  // PERSIST and EX/PX/EXAT/PXAT are mutually exclusive in either order.
+  resp = Run({"getex", "foo", "PERSIST", "EX", "1"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
+  resp = Run({"getex", "foo", "EX", "1", "PERSIST"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
+  resp = Run({"getex", "foo", "PXAT", absl::StrCat(TEST_current_time_ms + 1000), "PERSIST"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
+  resp = Run({"getex", "foo", "PERSIST", "PERSIST"});
+  EXPECT_THAT(resp, ErrArg("syntax error"));
+
   resp = Run({"getex", "foo", "PXAT"});
   EXPECT_THAT(resp, ErrArg("syntax error"));
 

--- a/tests/dragonfly/replication_test.py
+++ b/tests/dragonfly/replication_test.py
@@ -832,6 +832,11 @@ async def test_rewrites(df_factory):
         await check("GETEX k EX 100", r"PEXPIREAT k (.*?)")
         await check_expire("k")
 
+        # Bare GETEX (no EX/PX/EXAT/PXAT/PERSIST) is read-only and must not journal.
+        # If it did, the next SET would not be the next replicated command.
+        await c_master.execute_command("GETEX k")
+        await check("SET marker after-bare-getex", r"SET marker after-bare-getex")
+
         # Check SDIFFSTORE turns into DEL and SADD
         await c_master.sadd("set1", "v1", "v2", "v3")
         await c_master.sadd("set2", "v1", "v2")


### PR DESCRIPTION
Problem: Incorrect replication if expiry/persist isn't specified

fix: Makes bare GETEX read-only by skipping journaling unless expiry/persist is actually specified.

Refactor part:
closes: https://github.com/dragonflydb/dragonfly/issues/3634

Refactors how expiry arguments are represented and normalized across commands by centralizing expiration math in DbSlice::ExpireParams.

Changes:

- Introduces ExpT (EX/PX/EXAT/PXAT) in common_types.h for shared parsing/dispatch.
- Reworks DbSlice::ExpireParams to store a normalized millisecond timestamp (ms_timestamp) instead of (value, unit, absolute) triples.
- Adds constructors that convert relative TTLs to absolute deadlines using now_ms, with optional silent clamping for EXPIRE/PEXPIRE.
- Simplifies Calculate() to return (relative_ms, absolute_ms) and a sentinel overflow result.
- Updates EXPIRE/PEXPIRE/EXPIREAT/PEXPIREAT handlers to use the new API and keep Redis-compatible capping behavior where intended.
- Updates SET / (P)SETEX parsing to use ExpT-based expiry construction and overflow checks.
- Adds unit and integration tests covering non-positive TTLs, past timestamps, overflow/out-of-range behavior, and journaling semantics.