### PR TITLE
fix: race condition in restore streamer

### DIFF
--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -920,7 +920,8 @@ void DbSlice::FlushSlotsFb(const cluster::SlotSet& slot_ids, uint64_t next_versi
   } while (cursor && etl.gstate() != GlobalState::SHUTTING_DOWN);
 
   VLOG(1) << "FlushSlotsFb del count is: " << del_count;
-  CHECK(UnregisterOnChange(consumer));
+  if (!UnregisterOnChange(consumer))
+    LOG(DFATAL) << "UnregisterOnChange failed";
 
   if (absl::GetFlag(FLAGS_cluster_flush_decommit_memory)) {
     int64_t start = absl::GetCurrentTimeNanos();

--- a/src/server/db_slice.cc
+++ b/src/server/db_slice.cc
@@ -920,7 +920,7 @@ void DbSlice::FlushSlotsFb(const cluster::SlotSet& slot_ids, uint64_t next_versi
   } while (cursor && etl.gstate() != GlobalState::SHUTTING_DOWN);
 
   VLOG(1) << "FlushSlotsFb del count is: " << del_count;
-  UnregisterOnChange(consumer);
+  CHECK(UnregisterOnChange(consumer));
 
   if (absl::GetFlag(FLAGS_cluster_flush_decommit_memory)) {
     int64_t start = absl::GetCurrentTimeNanos();
@@ -1435,12 +1435,14 @@ void DbSlice::RegisterOnChange(ChangeConsumerInterface* consumer) {
   change_cb_.emplace_back(consumer);
 }
 
-void DbSlice::UnregisterOnChange(ChangeConsumerInterface* consumer) {
+bool DbSlice::UnregisterOnChange(ChangeConsumerInterface* consumer) {
   change_cb_latch_.Wait();
   auto it = std::find(change_cb_.begin(), change_cb_.end(), consumer);
-  CHECK(it != change_cb_.end());
+  if (it == change_cb_.end())
+    return false;  // not registered (or already unregistered by a racing fiber)
   change_cb_.erase(it);
   consumer->snapshot_version_ = 0;
+  return true;
 }
 
 bool DbSlice::WillBlockOnJournalWrite() const {

--- a/src/server/db_slice.h
+++ b/src/server/db_slice.h
@@ -416,8 +416,10 @@ class DbSlice {
 
   void RegisterOnChange(ChangeConsumerInterface* consumer);
 
-  // Not allowed to be called from the consumer callback
-  void UnregisterOnChange(ChangeConsumerInterface* consumer);
+  // Not allowed to be called from the consumer callback. Idempotent: returns true only for the
+  // caller that actually removed the consumer, false if it was not registered. This makes it safe
+  // for racing fibers to unregister the same consumer without double-erasing.
+  bool UnregisterOnChange(ChangeConsumerInterface* consumer);
 
   bool HasRegisteredCallbacks() const {
     return !change_cb_.empty();

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -712,7 +712,7 @@ TEST_F(DflyEngineTest, Bug496) {
       EXPECT_EQ(cb_hits, 3);
     }
 
-    db.UnregisterOnChange(&consumer);
+    EXPECT_TRUE(db.UnregisterOnChange(&consumer));
   });
 }
 

--- a/src/server/journal/streamer.cc
+++ b/src/server/journal/streamer.cc
@@ -440,6 +440,12 @@ void RestoreStreamer::Start(util::FiberSocketBase* dest) {
 void RestoreStreamer::Run() {
   VLOG(1) << "RestoreStreamer run";
 
+  // If the context was cancelled before Start() ran, RegisterChangeListener was skipped and
+  // db_array_ is empty (see RestoreStreamer::Start). Guard the db_array_.front() access below;
+  // mid-traversal cancellation is handled by the cntx_->IsRunning() check inside the loop.
+  if (db_array_.empty())
+    return;
+
   PrimeTable::Cursor cursor;
   uint64_t last_yield = 0;
 
@@ -534,10 +540,18 @@ RestoreStreamer::~RestoreStreamer() {
 }
 
 bool RestoreStreamer::Cancel() {
-  if (snapshot_version_ == 0)
+  // Cancel the execution context unconditionally, even if the streamer was not started yet. A
+  // concurrent Start() may run after Cancel() on the same shard (e.g. OutgoingMigration::Finish()
+  // cancels the flow while it is between ChangeState(C_SYNC) and PrepareSync()). Start() bails out
+  // early when the context is cancelled, which prevents the streamer from being registered (and
+  // leaked) after cancellation.
+  cntx_->Cancel();
+
+  // UnregisterOnChange is idempotent and returns true only for the caller that actually removed the
+  // listener, so racing Cancel() calls (e.g. Finish() vs ~SliceSlotMigration) can't double-erase.
+  if (!db_slice_->UnregisterOnChange(this))
     return false;
 
-  db_slice_->UnregisterOnChange(this);
   JournalStreamer::Cancel();
   return true;
 }

--- a/src/server/serializer_base.cc
+++ b/src/server/serializer_base.cc
@@ -170,7 +170,8 @@ void SerializerBase::RegisterChangeListener(bool replication) {
 void SerializerBase::UnregisterChangeListener() {
   DCHECK(!IsAnyBucketBlocked());
   if (snapshot_version_ > 0)
-    CHECK(db_slice_->UnregisterOnChange(this));
+    if (!db_slice_->UnregisterOnChange(this))
+      LOG(DFATAL) << "UnregisterOnChange failed for snapshot_version_ " << snapshot_version_;
 }
 
 bool SerializerBase::ProcessBucket(DbIndex db_index, PrimeTable::bucket_iterator it,

--- a/src/server/serializer_base.cc
+++ b/src/server/serializer_base.cc
@@ -170,7 +170,7 @@ void SerializerBase::RegisterChangeListener(bool replication) {
 void SerializerBase::UnregisterChangeListener() {
   DCHECK(!IsAnyBucketBlocked());
   if (snapshot_version_ > 0)
-    db_slice_->UnregisterOnChange(this);
+    CHECK(db_slice_->UnregisterOnChange(this));
 }
 
 bool SerializerBase::ProcessBucket(DbIndex db_index, PrimeTable::bucket_iterator it,


### PR DESCRIPTION
fixes: #7703
<h3>PR Summary by Qodo</h3>

Fix RestoreStreamer cancellation race with idempotent UnregisterOnChange
<code>🐞 Bug fix</code> <code>🧪 Tests</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<details open>
<summary>Description</summary>

<dl>
<dd>
<br/>

><pre>
>• Make DbSlice change-listener unregistration idempotent to avoid double-erase races.
>• Ensure RestoreStreamer cancellation always cancels the context and safely unregisters listeners.
>• Strengthen call sites and tests to assert successful unregistration when expected.
></pre>

</dd>
</dl>

</details>

<details>
<summary>Diagram</summary>

<dl>
<dd>

<br/>

```mermaid
graph TD
  A["Migration flow"] --> B["RestoreStreamer"] --> C["DbSlice change callbacks"]
  B --> D(("ExecutionContext")) --> B
  B --> E["Cancel()"] --> D
  E --> C
  B --> F["Run()"] --> G["db_array_ guard"]
```

</dd>
</dl>

</details>




<details>
<summary>High-Level Assessment</summary>

<dl>
<dd>

<br/>

>The following are alternative approaches to this PR:

<details>
<summary><b>1. RAII registration token (scoped listener handle)</b></summary>

<dl>
<dd>

- ➕ Makes registration/unregistration pairing explicit and harder to misuse
- ➕ Can centralize idempotency and lifetime semantics in one abstraction
- ➖ More invasive change across all listener users
- ➖ May require additional storage/ownership rules (tokens per shard, move-only, etc.)

</dd>
</dl>

</details>

<details>
<summary><b>2. Serialize Start/Cancel with explicit state machine + mutex</b></summary>

<dl>
<dd>

- ➕ Clear ordering guarantees between Start(), Run(), Cancel(), destructor
- ➕ Avoids relying on idempotent container operations
- ➖ Adds locking and complexity in a fiber-heavy hot path
- ➖ Higher risk of deadlocks/latency regressions if not designed carefully

</dd>
</dl>

</details>

<details>
<summary><b>3. Keep CHECK-on-missing but prevent double-unregister via atomic flag in consumer</b></summary>

<dl>
<dd>

- ➕ Minimal API churn (DbSlice signature can remain void)
- ➕ Localizes race-handling to RestoreStreamer/consumers
- ➖ Each consumer must re-implement the same correctness pattern
- ➖ Still leaves DbSlice vulnerable to other unintentional double-unregister call sites

</dd>
</dl>

</details>

>**Recommendation:** The PR’s approach (idempotent DbSlice::UnregisterOnChange returning bool, with call sites asserting when they expect removal) is a good balance of safety and scope. It fixes the concrete race where Cancel() and teardown can both attempt to unregister, and it prevents future crashes from similar patterns. A scoped registration handle could be a future improvement if listener lifecycle continues to be a common source of concurrency bugs.

</dd>
</dl>

</details>

<details>
<summary> Files changed (5) <code> +27 / -9 </code> </summary>

<dl>
<dd>

<br/>

<details>
<summary>Bug fix (3) <code> +22 / -6 </code></summary>

<dl>
<dd>

<details>
<summary>db_slice.cc<code>Make UnregisterOnChange idempotent and return success</code> <code>+5/-3</code></summary>

<br/>

>Make UnregisterOnChange idempotent and return success
>
><pre>
>• Changes DbSlice::UnregisterOnChange to return bool instead of CHECKing on missing consumers, allowing safe concurrent/unordered unregister attempts. Updates FlushSlotsFb to CHECK the return value to preserve the expectation that the consumer must be registered in that path.
></pre>
>
><a href='https://github.com/dragonflydb/dragonfly/pull/7707/files#diff-883d71d37722157c22061e0b592d4784172d9e6f50a8cbf0c76f349e483418e6'>src/server/db_slice.cc</a>

</details>

<details>
<summary>streamer.cc<code>Fix RestoreStreamer Start/Cancel race and guard empty db_array_</code> <code>+16/-2</code></summary>

<br/>

>Fix RestoreStreamer Start/Cancel race and guard empty db_array_
>
><pre>
>• Adds an early return in Run() if db_array_ is empty (when cancellation happened before Start() performed listener registration). Updates Cancel() to always cancel the execution context and to rely on idempotent UnregisterOnChange to avoid double-unregister races between concurrent cancellation/teardown paths.
></pre>
>
><a href='https://github.com/dragonflydb/dragonfly/pull/7707/files#diff-74d77d4ffb9439bb5043974a39404847ef8c0b596acae317d72f56b6d3400280'>src/server/journal/streamer.cc</a>

</details>

<details>
<summary>serializer_base.cc<code>Harden change-listener unregistration with CHECK on success</code> <code>+1/-1</code></summary>

<br/>

>Harden change-listener unregistration with CHECK on success
>
><pre>
>• Updates SerializerBase::UnregisterChangeListener to CHECK that UnregisterOnChange succeeds when snapshot_version_ indicates a listener should be registered, preserving invariant checking under the new boolean-return API.
></pre>
>
><a href='https://github.com/dragonflydb/dragonfly/pull/7707/files#diff-ea7828208c3c5406d35312a840ea38db3c7db26123e27fbf3fe406e349bd9d5e'>src/server/serializer_base.cc</a>

</details>

</dd>
</dl>

</details>

<details>
<summary>Refactor (1) <code> +4 / -2 </code></summary>

<dl>
<dd>

<details>
<summary>db_slice.h<code>Update UnregisterOnChange API contract and documentation</code> <code>+4/-2</code></summary>

<br/>

>Update UnregisterOnChange API contract and documentation
>
><pre>
>• Updates the DbSlice header to reflect the new bool return value and documents the idempotent semantics (true only for the caller that actually removed the consumer). Clarifies that this supports racing fibers without double-erasing.
></pre>
>
><a href='https://github.com/dragonflydb/dragonfly/pull/7707/files#diff-9d5b93b5dd834f42483b54b13d83a1cdde96330ba12d833fda806a3b409bd311'>src/server/db_slice.h</a>

</details>

</dd>
</dl>

</details>

<details>
<summary>Tests (1) <code> +1 / -1 </code></summary>

<dl>
<dd>

<details>
<summary>dragonfly_test.cc<code>Assert successful listener removal in Bug496 test</code> <code>+1/-1</code></summary>

<br/>

>Assert successful listener removal in Bug496 test
>
><pre>
>• Updates the test to EXPECT_TRUE on UnregisterOnChange to match the new API and ensure the listener was actually removed in the tested scenario.
></pre>
>
><a href='https://github.com/dragonflydb/dragonfly/pull/7707/files#diff-7743010a9439d8dc900a2c46820efcd7908d25b255f863f0f793667cdb984e1d'>src/server/dragonfly_test.cc</a>

</details>

</dd>
</dl>

</details>

</dd>
</dl>

</details>