### PR TITLE
tests: Stop seeder before checking replica finished

### DIFF
--- a/tests/dragonfly/cluster_test.py
+++ b/tests/dragonfly/cluster_test.py
@@ -1919,10 +1919,11 @@ async def test_start_replication_during_migration(
         json.dumps(generate_config(master_nodes)), [node.admin_client for node in nodes]
     )
 
-    await check_all_replicas_finished([r1_node.client], m1_node.client)
-
     seeder.stop()
     await seed
+
+    await check_all_replicas_finished([r1_node.client], m1_node.client)
+
     fake_capture = await seeder.capture_fake_redis()
     assert await seeder.compare(fake_capture, r1_node.instance.port)
 


### PR DESCRIPTION
Previously seeder stopped after replica check finished, which can create a situation where replica races to keep up with master. This is not necessary for the test, so we stop seeder before checking, this also makes the test faster as the replica catches up quickly.

FIXES https://github.com/dragonflydb/dragonfly/issues/7713