### PR TITLE
refactor: OAHSet - split OAHEntry on 3 classes

### DIFF
--- a/src/core/oah_entry.cc
+++ b/src/core/oah_entry.cc
@@ -4,209 +4,89 @@
 
 #include "core/oah_entry.h"
 
-#include "base/hash.h"
-#include "base/logging.h"
 #include "core/page_usage/page_usage_stats.h"
 
 namespace dfly {
 
-OAHEntry::OAHEntry(std::string_view key, uint32_t expiry) {
+OAHEntry::TaggedPtr OAHEntry::Create(std::string_view key, uint32_t expiry) {
   uint32_t key_size = key.size();
-
   uint32_t expiry_size = (expiry != UINT32_MAX) * sizeof(expiry);
-
   uint32_t key_len_field_size = key_size <= std::numeric_limits<uint8_t>::max() ? 1 : 4;
 
-  auto size = key_len_field_size + key_size + expiry_size;
+  auto* blob = (char*)zmalloc(key_len_field_size + key_size + expiry_size);
 
-  auto* expiry_pos = (char*)zmalloc(size);
-
-  data_ = reinterpret_cast<uint64_t>(expiry_pos);
+  TaggedPtr tagged_ptr = reinterpret_cast<TaggedPtr>(blob);
+  OAHEntry entry(tagged_ptr);  // accessor over the local control word being built
   if (expiry_size) {
-    SetExpiryBit(true);
-    std::memcpy(expiry_pos, &expiry, sizeof(expiry));
+    entry.SetExpiryBit(true);
+    std::memcpy(blob, &expiry, sizeof(expiry));
   }
 
-  auto* key_size_pos = expiry_pos + expiry_size;
+  auto* key_size_pos = blob + expiry_size;
   if (key_len_field_size == 1) {
-    SetSsoBit();
+    entry.SetSsoBit();
     uint8_t sso_key_size = key_size;
     std::memcpy(key_size_pos, &sso_key_size, key_len_field_size);
   } else {
     std::memcpy(key_size_pos, &key_size, key_len_field_size);
   }
-
-  auto* key_pos = key_size_pos + key_len_field_size;
-  std::memcpy(key_pos, key.data(), key_size);
+  std::memcpy(key_size_pos + key_len_field_size, key.data(), key_size);
+  return tagged_ptr;
 }
 
-// returns the expiry time of the current entry or UINT32_MAX if no expiry is set.
+void OAHEntry::Destroy(TaggedPtr tagged_ptr) {
+  if (tagged_ptr == 0)
+    return;
+  zfree(reinterpret_cast<void*>(tagged_ptr & ~kTagMask));
+}
+
 uint32_t OAHEntry::GetExpiry() const {
   std::uint32_t res = UINT32_MAX;
-  if (HasExpiry()) {
-    assert(!IsVector());
+  if (HasExpiry())
     std::memcpy(&res, Raw(), sizeof(res));
-  }
   return res;
 }
 
-bool OAHEntry::CheckNoCollisions(const uint64_t ext_hash) {
-  auto stored_hash = GetHash();
-  return ((stored_hash != ext_hash) & (stored_hash != 0)) | (Empty());
+void OAHEntry::SetExtHash(uint64_t ext_hash) {
+  assert(GetTaggedPtr());
+  SetTaggedPtr((GetTaggedPtr() & ~kExtHashShiftedMask) | (ext_hash << kExtHashShift));
 }
 
-void OAHEntry::SetExtHash(uint64_t ext_hash) {
-  assert(data_);
-  assert(!IsVector());
-  data_ = (data_ & ~kExtHashShiftedMask) | (ext_hash << kExtHashShift);
+void OAHEntry::Rebuild(uint32_t expiry) {
+  const uint64_t saved_hash = GetHash();
+  TaggedPtr rebuilt = Create(Key(), expiry);
+  OAHEntry(rebuilt).SetExtHash(saved_hash);
+  Destroy(Release());
+  SetTaggedPtr(rebuilt);
 }
 
 void OAHEntry::SetExpiry(uint32_t at_sec) {
-  assert(!IsVector());
   if (HasExpiry()) {
-    auto* expiry_pos = Raw();
-    std::memcpy(expiry_pos, &at_sec, sizeof(at_sec));
+    std::memcpy(Raw(), &at_sec, sizeof(at_sec));
   } else {
-    *this = OAHEntry(Key(), at_sec);
+    Rebuild(at_sec);  // no expiry field yet: rebuild the blob with room for one
   }
 }
 
 void OAHEntry::ExpireIfNeeded(uint32_t time_now, uint32_t* set_size, size_t* alloc_used) {
-  assert(!IsVector());
   if (GetExpiry() <= time_now) {
     *alloc_used -= AllocSize();
-    Clear();
+    Destroy(Release());
     --*set_size;
   }
 }
 
 ssize_t OAHEntry::ReallocIfNeeded(PageUsage* page_usage, bool* realloced) {
   *realloced = false;
-  if (!data_)
+  if (Empty())
     return 0;
-
-  ssize_t obj_alloc_delta = 0;
-
-  if (IsVector()) {
-    // Recurse into each inner entry first — every element's own buffer must be checked.
-    auto& vec = AsVector();
-    for (size_t i = 0, n = vec.Size(); i < n; ++i) {
-      if (vec[i]) {
-        bool inner_moved = false;
-        obj_alloc_delta += vec[i].ReallocIfNeeded(page_usage, &inner_moved);
-        if (inner_moved)
-          *realloced = true;
-      }
-    }
-    // Then defrag the array buffer if its page is underutilized. Realloc() moves into a
-    // fresh same-size buffer; logical AllocSize is unchanged, so no delta is reported.
-    if (page_usage->IsPageForObjectUnderUtilized(Raw())) {
-      vec.Realloc();
-      *realloced = true;
-    }
-    return obj_alloc_delta;
-  }
-
   if (!page_usage->IsPageForObjectUnderUtilized(Raw()))
     return 0;
 
-  // Single-entry realloc: build a fresh OAHEntry from this one's key/expiry/ext_hash,
-  // move-assign to swap data_, and let the temporary free the old buffer.
   const size_t old_alloc = AllocSize();
-  const uint64_t saved_hash = GetHash();
-  const uint32_t expiry = HasExpiry() ? GetExpiry() : UINT32_MAX;
-  {
-    OAHEntry replacement(Key(), expiry);
-    if (saved_hash)
-      replacement.SetExtHash(saved_hash);
-    *this = std::move(replacement);
-  }
+  Rebuild(HasExpiry() ? GetExpiry() : UINT32_MAX);
   *realloced = true;
   return static_cast<ssize_t>(AllocSize()) - static_cast<ssize_t>(old_alloc);
-}
-
-// TODO refactor, because it's inefficient
-//
-// Vector capacity starts at 2 and grows by 2 (doubles past kLinearMax), so it stays
-// an even count >= 2 — OAHSet::ProbeExtensionVector relies on this for a tail-free
-// 2-lane probe.
-size_t OAHEntry::Insert(OAHEntry&& e) {
-  if (Empty()) {
-    *this = std::move(e);
-    return 0;
-  } else if (!IsVector()) {
-    OAHEntry tmp(PtrVector<OAHEntry>::FromSize(2));
-    auto& arr = tmp.AsVector();
-    arr[0] = std::move(*this);
-    arr[1] = std::move(e);
-    auto res = arr.AllocSize();
-    *this = std::move(tmp);
-    return res;
-  } else {
-    auto& arr = AsVector();
-    size_t i = 0;
-    for (; i < arr.Size(); ++i) {
-      if (!arr[i]) {
-        arr[i] = std::move(e);
-        return 0;
-      }
-    }
-    size_t prev_alloc_size = arr.AllocSize();
-    auto new_pos = arr.Size();
-    arr.Grow();
-    arr[new_pos] = (std::move(e));
-    return arr.AllocSize() - prev_alloc_size;
-  }
-}
-
-uint32_t OAHEntry::ElementsNum() {
-  if (Empty()) {
-    return 0;
-  } else if (!IsVector()) {
-    return 1;
-  }
-  return AsVector().Size();
-}
-
-// TODO remove, it is inefficient
-OAHEntry& OAHEntry::operator[](uint32_t pos) {
-  assert(!Empty());
-  if (!IsVector()) {
-    assert(pos == 0);
-    return *this;
-  } else {
-    auto& arr = AsVector();
-    assert(pos < arr.Size());
-    return arr[pos];
-  }
-}
-
-OAHEntry OAHEntry::Remove(uint32_t pos) {
-  if (Empty()) {
-    // I'm not sure that this scenario should be check at all
-    assert(pos == 0);
-    return OAHEntry();
-  } else if (!IsVector()) {
-    assert(pos == 0);
-    return std::move(*this);
-  } else {
-    auto& arr = AsVector();
-    assert(pos < arr.Size());
-    return std::move(arr[pos]);
-  }
-}
-
-void OAHEntry::Clear() {
-  // TODO add optimization to avoid destructor calls during vector allocator
-  if (!data_)
-    return;
-
-  if (IsVector()) {
-    AsVector().~PtrVector<OAHEntry>();
-  } else {
-    zfree(Raw());
-  }
-  data_ = 0;
 }
 
 uint32_t OAHEntry::GetKeySize() const {
@@ -222,15 +102,9 @@ uint32_t OAHEntry::GetKeySize() const {
 
 void OAHEntry::SetExpiryBit(bool b) {
   if (b)
-    data_ |= kExpiryBit;
+    SetTaggedPtr(GetTaggedPtr() | kExpiryBit);
   else
-    data_ &= ~kExpiryBit;
-}
-
-size_t OAHEntry::Size() {
-  size_t key_field_size = HasSso() ? 1 : 4;
-  size_t expiry_field_size = HasExpiry() ? 4 : 0;
-  return expiry_field_size + key_field_size + GetKeySize();
+    SetTaggedPtr(GetTaggedPtr() & ~kExpiryBit);
 }
 
 }  // namespace dfly

--- a/src/core/oah_entry.h
+++ b/src/core/oah_entry.h
@@ -4,12 +4,13 @@
 
 #pragma once
 
-#include <bit>
-#include <cassert>
-#include <cstring>
-#include <string_view>
+#include <sys/types.h>
 
-#include "base/hash.h"
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <string_view>
 
 extern "C" {
 #include "redis/zmalloc.h"
@@ -22,306 +23,113 @@ class PageUsage;
 #define PREFETCH_READ(x) __builtin_prefetch(x, 0, 1)
 #define FORCE_INLINE __attribute__((always_inline))
 
-// TODO add allocator support
+// oah_entry.h - a single set member: a string key plus its expiry and cached hash.
 //
-// Capacity grows by 2 below kLinearMax (sizes stay even, keeping the 2-lane SIMD
-// probe tail-free), then doubles at/above it. The 11-bit tag field holds either a
-// literal count or, with kLogModeBit set, its base-2 log (power-of-2 sizes).
-template <class T> class PtrVector {
-  static constexpr size_t kVectorBit = 1ULL << 0;          // first 3 bits aren't used by pointer
-  static constexpr size_t kTagMask = (4095ULL << 52) | 7;  // we reserve 12 high bits and 3 low bits
-
-  static constexpr size_t kSizeShift = 52;
-  static constexpr size_t kSizeMask = 0x7FFULL;  // 11-bit field: count, or log2 in log mode
-  static constexpr size_t kLogModeBit = 1ULL << 63;
-  static constexpr size_t kSizeFieldMask = (kSizeMask << kSizeShift) | kLogModeBit;
-
-  static constexpr size_t kLinearMax = 128;
-
- public:
-  // Allocates exactly `count` elements (used for the initial small vector).
-  static PtrVector FromSize(size_t count) {
-    return PtrVector(count);
-  }
-
-  T* begin() const {
-    return &Raw()[0];
-  }
-
-  T* end() const {
-    return &Raw()[Size()];
-  }
-
-  PtrVector(PtrVector&& other) {
-    uptr_ = other.uptr_;
-    other.uptr_ = 0;
-  }
-
-  ~PtrVector() {
-    Clear();
-  }
-
-  // Number of elements. Normal mode stores the count directly; log mode stores
-  // its base-2 log.
-  size_t Size() const {
-    const uint64_t field = (uptr_ >> kSizeShift) & kSizeMask;
-    return (uptr_ & kLogModeBit) ? (size_t(1) << field) : size_t(field);
-  }
-
-  uint64_t Release() {
-    uint64_t res = uptr_;
-    uptr_ = 0;
-    return res;
-  }
-
-  bool Empty() const {
-    if (uptr_ == 0)
-      return true;
-
-    for (auto& el : *this) {
-      if (el)
-        return false;
-    }
-    return true;
-  }
-
-  // Grows per policy: +2 elements below kLinearMax, doubling at/above it. Starting
-  // from an even size (2), this keeps Size() even (a multiple of the 2-lane probe).
-  void Grow() {
-    const size_t cur = Size();
-    Reallocate(cur < kLinearMax ? cur + 2 : cur * 2);
-  }
-
-  // Reallocates to the same size (defrag), preserving contents.
-  void Realloc() {
-    Reallocate(Size());
-  }
-
-  T& operator[](size_t idx) {
-    return Raw()[idx];
-  }
-
-  const T& operator[](size_t idx) const {
-    return Raw()[idx];
-  }
-
-  T* Raw() const {
-    return (T*)(uptr_ & ~kTagMask);
-  }
-
-  size_t AllocSize() const {
-    return Size() * sizeof(T);
-  }
-
- private:
-  void Clear() {
-    const size_t size = Size();
-    T* raw = Raw();
-    if (!raw)
-      return;
-    for (size_t i = 0; i < size; ++i) {
-      if (raw[i])
-        raw[i].~T();
-    }
-
-    zfree(Raw());
-    uptr_ = 0;
-  }
-
-  // Allocates `new_count` slots, moves existing elements over, frees the old
-  // buffer, and records the new size.
-  void Reallocate(size_t new_count) {
-    auto* new_ptr = reinterpret_cast<T*>(zmalloc(sizeof(T) * new_count));
-    const size_t keep = std::min(Size(), new_count);
-    for (size_t i = 0; i < keep; ++i) {
-      new (new_ptr + i) T(std::move(Raw()[i]));
-    }
-    for (size_t i = keep; i < new_count; ++i) {
-      new (new_ptr + i) T();
-    }
-    Clear();
-    uptr_ = reinterpret_cast<uint64_t>(new_ptr);
-    SetSize(new_count);
-  }
-
-  explicit PtrVector(size_t count) {
-    uptr_ = reinterpret_cast<uint64_t>(zmalloc(sizeof(T) * count));
-    for (size_t i = 0; i < count; ++i) {
-      new (reinterpret_cast<T*>(uptr_) + i) T();
-    }
-    SetSize(count);
-  }
-
-  // Encodes the element count: a literal count below kLinearMax, or its base-2
-  // log at/above it (countr_zero == log2 since such sizes are powers of two).
-  void SetSize(size_t count) {
-    const bool log_mode = count >= kLinearMax;
-    const uint64_t field = log_mode ? std::countr_zero(count) : count;
-    assert(field <= kSizeMask);
-    uptr_ = (uptr_ & ~kSizeFieldMask) | kVectorBit | (field << kSizeShift) |
-            (log_mode ? kLogModeBit : 0);
-  }
-
-  uint64_t uptr_ = 0;
-};
-
-// doesn't possess memory, it should be created and release manually
+// OAHEntry is a non-owning accessor over a TaggedPtr that points at a [expiry, key_size, key] heap
+// blob. It manages that string: the static Create()/Destroy() allocate and free the blob, and
+// SetExpiry/SetExtHash/ReallocIfNeeded update it in place. The top 12 and bottom 3 bits of a heap
+// pointer are always free (user addresses are <= 52 bits), so flags live there: bit 0 stays clear
+// for OAHPtr's entry/vector tag, OAHEntry uses bits 1-2 (expiry/sso) and 52-63 (cached hash).
 class OAHEntry {
  public:
-  // we can assume that high 12 bits of user address space
-  // can be used for tagging. At most 52 bits of address are reserved for
-  // some configurations, and usually it's 48 bits.
-  // https://docs.kernel.org/arch/arm64/memory.html
-  // first 3 bits aren't used by pointer
-  static constexpr size_t kVectorBit = 1ULL << 0;
-  static constexpr size_t kExpiryBit = 1ULL << 1;
-  // if bit is set the string length field is 1 byte instead of 4
-  static constexpr size_t kSsoBit = 1ULL << 2;
+  // A uint64_t packing the heap pointer together with tag/flag bits in its free low/high bits.
+  using TaggedPtr = uint64_t;
 
-  // extended hash allows us to reduce keys comparisons
+  static constexpr size_t kExpiryBit = 1ULL << 1;
+  static constexpr size_t kSsoBit = 1ULL << 2;  // 1-byte (vs 4) key-length field
+
   static constexpr size_t kExtHashShift = 52;
   static constexpr uint32_t kExtHashSize = 12;
   static constexpr size_t kExtHashMask = 0xFFFULL;
   static constexpr size_t kExtHashShiftedMask = kExtHashMask << kExtHashShift;
 
-  static constexpr size_t kTagMask = (4095ULL << 52) | 7;  // we reserve 12 high bits and 3 low.
+  static constexpr size_t kTagMask = (4095ULL << 52) | 7;  // 12 high + 3 low tag bits
 
-  OAHEntry() = default;
+  static TaggedPtr Create(std::string_view key, uint32_t expiry = UINT32_MAX);
+  static void Destroy(TaggedPtr tagged_ptr);
 
-  OAHEntry(std::string_view key, uint32_t expiry = UINT32_MAX);
-
-  // TODO add initializer list constructor
-  OAHEntry(PtrVector<OAHEntry>&& vec) {
-    data_ = vec.Release() | kVectorBit;
+  explicit OAHEntry(TaggedPtr& slot) : slot_(&slot) {
   }
-
-  OAHEntry(const OAHEntry& e) = delete;
-  OAHEntry(OAHEntry&& e) {
-    data_ = e.data_;
-    e.data_ = 0;
-  }
-
-  // consider manual removing, we waste a lot of time to check nullptr
-  ~OAHEntry() {
-    Clear();
-  }
-
-  OAHEntry& operator=(const OAHEntry& e) = delete;
-  OAHEntry& operator=(OAHEntry&& e) {
-    std::swap(data_, e.data_);
-    return *this;
-  }
+  OAHEntry(const OAHEntry&) = default;
+  OAHEntry& operator=(const OAHEntry&) = default;
 
   bool Empty() const {
-    return data_ == 0;
+    return GetTaggedPtr() == 0;
   }
-
   operator bool() const {
     return !Empty();
-  }
-
-  bool IsVector() const {
-    return (data_ & kVectorBit) != 0;
-  }
-
-  bool IsEntry() const {
-    return (data_ != 0) & !(data_ & kVectorBit);
   }
 
   size_t AllocSize() const {
     return zmalloc_usable_size(Raw());
   }
 
-  PtrVector<OAHEntry>& AsVector() {
-    static_assert(sizeof(PtrVector<OAHEntry>) == sizeof(uint64_t));
-    return *reinterpret_cast<PtrVector<OAHEntry>*>(&data_);
-  }
-
   std::string_view Key() const {
-    assert(!IsVector());
     return {GetKeyData(), GetKeySize()};
   }
 
   bool HasExpiry() const {
-    return (data_ & kExpiryBit) != 0;
+    return (GetTaggedPtr() & kExpiryBit) != 0;
+  }
+  uint32_t GetExpiry() const;
+  void SetExpiry(uint32_t at_sec);
+  void ExpireIfNeeded(uint32_t time_now, uint32_t* set_size, size_t* alloc_used);
+
+  uint64_t GetHash() const {
+    return (GetTaggedPtr() & kExtHashShiftedMask) >> kExtHashShift;
+  }
+  void SetExtHash(uint64_t ext_hash);
+
+  // Reallocates the key blob if its page is underutilized; returns the usable-size delta and sets
+  // *realloced when the buffer moved.
+  ssize_t ReallocIfNeeded(PageUsage* page_usage, bool* realloced);
+
+  char* Raw() const {
+    return (char*)(GetTaggedPtr() & ~kTagMask);
   }
 
-  // returns the expiry time of the current entry or UINT32_MAX if no expiry is set.
-  uint32_t GetExpiry() const;
+  // Returns the control word and zeroes the slot, transferring ownership to the caller.
+  TaggedPtr Release() {
+    TaggedPtr res = GetTaggedPtr();
+    SetTaggedPtr(0);
+    return res;
+  }
 
-  // TODO consider another option to implement iterator
+  // Lets the iterator drill down (it->Key()).
   OAHEntry* operator->() {
     return this;
   }
 
-  uint64_t GetHash() const {
-    return (data_ & kExtHashShiftedMask) >> kExtHashShift;
-  }
-
-  bool CheckNoCollisions(const uint64_t ext_hash);
-
-  void SetExtHash(uint64_t ext_hash);
-
-  void ClearHash() {
-    data_ &= ~kExtHashShiftedMask;
-  }
-
-  void SetExpiry(uint32_t at_sec);
-
-  void ExpireIfNeeded(uint32_t time_now, uint32_t* set_size, size_t* alloc_used);
-
-  // Reallocates fragmented buffers under this entry: its string buffer, or for a vector
-  // every inner entry plus the array buffer. Returns the cumulative zmalloc_usable_size
-  // delta across inner buffers (the array buffer keeps its size). *realloced = any moved.
-  ssize_t ReallocIfNeeded(PageUsage* page_usage, bool* realloced);
-
-  // TODO refactor, because it's inefficient
-  // Returns additional allocation size of ptrVector
-  [[nodiscard]] size_t Insert(OAHEntry&& e);
-
-  uint32_t ElementsNum();
-
-  // TODO remove, it is inefficient
-  OAHEntry& operator[](uint32_t pos);
-
-  OAHEntry Remove(uint32_t pos);
-
-  char* Raw() const {
-    return (char*)(data_ & ~kTagMask);
-  }
-
  protected:
-  void Clear();
-
   const char* GetKeyData() const {
     uint32_t key_field_size = HasSso() ? 1 : 4;
     return Raw() + GetExpirySize() + key_field_size;
   }
-
   uint32_t GetKeySize() const;
 
   void SetExpiryBit(bool b);
 
-  void SetVectorBit() {
-    data_ |= kVectorBit;
-  }
+  // Reallocates the key blob with `expiry`, preserving the key and stored ext-hash.
+  void Rebuild(uint32_t expiry);
 
   void SetSsoBit() {
-    data_ |= kSsoBit;
+    SetTaggedPtr(GetTaggedPtr() | kSsoBit);
   }
-
   bool HasSso() const {
-    return (data_ & kSsoBit) != 0;
+    return (GetTaggedPtr() & kSsoBit) != 0;
   }
-
-  size_t Size();
-
   std::uint32_t GetExpirySize() const {
     return HasExpiry() ? sizeof(std::uint32_t) : 0;
   }
 
-  // memory daya layout [Expiry, key_size, key]
-  uint64_t data_ = 0;
+  TaggedPtr GetTaggedPtr() const {
+    return *slot_;
+  }
+  void SetTaggedPtr(TaggedPtr tagged_ptr) {
+    *slot_ = tagged_ptr;
+  }
+
+  TaggedPtr* slot_;
 };
 
 }  // namespace dfly

--- a/src/core/oah_ptr.h
+++ b/src/core/oah_ptr.h
@@ -1,0 +1,167 @@
+// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include "core/oah_entry.h"
+#include "core/page_usage/page_usage_stats.h"
+#include "core/ptr_vector.h"
+
+namespace dfly {
+
+// oah_ptr.h - the bucket-slot manager that ties OAHEntry and PtrVector together.
+//
+// OAHPtr is a non-owning accessor over one bucket TaggedPtr that holds EITHER a single OAHEntry or
+// a PtrVector collision chain. Bit 0 (kVectorBit) discriminates them: a vector sets it, an entry
+// never does. OAHPtr is the only type aware of both representations and owns the lifetime logic
+// (promote-to-vector, grow, clear) via the OAHEntry and PtrVector Create()/Destroy() factories.
+class OAHPtr {
+  using Entry = OAHEntry;
+  using Vector = PtrVector<TaggedPtr>;
+
+ public:
+  static constexpr TaggedPtr kVectorBit = 1ULL << 0;
+
+  explicit OAHPtr(TaggedPtr& slot) : slot_(&slot) {
+  }
+
+  bool Empty() const {
+    return *slot_ == 0;
+  }
+  operator bool() const {
+    return !Empty();
+  }
+  bool IsVector() const {
+    return (*slot_ & kVectorBit) != 0;
+  }
+
+  Vector AsVector() {
+    return Vector(*slot_);
+  }
+
+  // The entry at `pos`: the bucket slot itself for a single entry (pos == 0), else a vector cell.
+  Entry operator[](uint32_t pos) {
+    if (!IsVector()) {
+      assert(pos == 0);
+      return Entry(*slot_);
+    }
+    assert(pos < AsVector().Size());
+    return Entry(AsVector()[pos]);
+  }
+
+  // 0 if empty, 1 for a single entry, else the vector capacity.
+  uint32_t ElementsNum() {
+    if (Empty())
+      return 0;
+    if (!IsVector())
+      return 1;
+    return AsVector().Size();
+  }
+
+  // Inserts entry `tagged_ptr` (ownership transferred), promoting a single entry to a 2-element
+  // vector on the first collision and growing it afterwards. Returns the added vector allocation
+  // size.
+  [[nodiscard]] size_t Insert(TaggedPtr tagged_ptr) {
+    if (Empty()) {
+      *slot_ = tagged_ptr;
+      return 0;
+    }
+    if (!IsVector()) {
+      TaggedPtr arr_tagged_ptr = Vector::Create(2);
+      Vector arr(arr_tagged_ptr);
+      arr[0] = *slot_;      // the existing single entry
+      arr[1] = tagged_ptr;  // the new one
+      *slot_ = arr_tagged_ptr;
+      return arr.AllocSize();
+    }
+    Vector arr = AsVector();
+    for (size_t i = 0; i < arr.Size(); ++i) {
+      if (arr[i] == 0) {
+        arr[i] = tagged_ptr;
+        return 0;
+      }
+    }
+    size_t prev_alloc = arr.AllocSize();
+    size_t pos = arr.Size();
+    arr.Grow();
+    arr[pos] = tagged_ptr;
+    return arr.AllocSize() - prev_alloc;
+  }
+
+  // Moves out and returns the entry's TaggedPtr at `pos`, leaving the cell empty.
+  TaggedPtr Remove(uint32_t pos) {
+    if (Empty()) {
+      assert(pos == 0);
+      return 0;
+    }
+    if (!IsVector()) {
+      assert(pos == 0);
+      TaggedPtr tagged_ptr = *slot_;
+      *slot_ = 0;
+      return tagged_ptr;
+    }
+    Vector arr = AsVector();
+    assert(pos < arr.Size());
+    TaggedPtr tagged_ptr = arr[pos];
+    arr[pos] = 0;
+    return tagged_ptr;
+  }
+
+  // Defragments fragmented buffers under this slot: the entry's string, or for a vector every inner
+  // entry plus the array. Returns the cumulative usable-size delta; *realloced is set if anything
+  // moved.
+  ssize_t ReallocIfNeeded(PageUsage* page_usage, bool* realloced) {
+    *realloced = false;
+    if (Empty())
+      return 0;
+    if (!IsVector())
+      return Entry(*slot_).ReallocIfNeeded(page_usage, realloced);
+
+    ssize_t obj_alloc_delta = 0;
+    Vector vec = AsVector();
+    for (TaggedPtr& cell : vec) {
+      Entry entry(cell);
+      if (entry) {
+        bool inner_moved = false;
+        obj_alloc_delta += entry.ReallocIfNeeded(page_usage, &inner_moved);
+        *realloced |= inner_moved;
+      }
+    }
+    if (page_usage->IsPageForObjectUnderUtilized(Raw())) {
+      vec.Realloc();
+      *realloced = true;
+    }
+    return obj_alloc_delta;
+  }
+
+  char* Raw() const {
+    return reinterpret_cast<char*>(*slot_ & ~OAHEntry::kTagMask);
+  }
+
+  // Replaces the slot's contents with the single entry `tagged_ptr`, freeing the old contents.
+  void Assign(TaggedPtr tagged_ptr) {
+    Clear();
+    *slot_ = tagged_ptr;
+  }
+
+  // Frees the entry blob or collision vector and zeroes the slot.
+  void Clear() {
+    if (!*slot_)
+      return;
+    if (IsVector()) {
+      Vector vec = AsVector();
+      for (TaggedPtr cell : vec)
+        Entry::Destroy(cell);
+      Vector::Destroy(vec.Release());
+    } else {
+      Entry::Destroy(*slot_);
+      *slot_ = 0;
+    }
+  }
+
+ private:
+  TaggedPtr* slot_;
+};
+
+}  // namespace dfly

--- a/src/core/oah_set.cc
+++ b/src/core/oah_set.cc
@@ -15,19 +15,19 @@ namespace dfly {
 // they fold into their in-TU callers.
 
 template <typename Wide>
-inline FORCE_INLINE OAHSet::LaneMasks OAHSet::ProbeLanes(const OAHEntry* base,
+inline FORCE_INLINE OAHSet::LaneMasks OAHSet::ProbeLanes(const TaggedPtr* base,
                                                          uint64_t ext_hash) noexcept {
-  auto data_v = Wide::Load(reinterpret_cast<const uint64_t*>(base));
+  auto data_v = Wide::Load(base);
   auto hash_v = (data_v & Wide::Fill(OAHEntry::kExtHashShiftedMask)) >> OAHEntry::kExtHashShift;
-  // ~is_empty stops an empty lane's zero hash from aliasing a hash/lazy-zero match.
+  // ~is_empty excludes empty lanes, whose zero hash would otherwise match a zero query hash.
   auto is_empty = data_v == uint64_t(0);
-  auto candidate = ((hash_v == ext_hash) | (hash_v == uint64_t(0))) & ~is_empty;
+  auto candidate = (hash_v == ext_hash) & ~is_empty;
   return {candidate.GetMSBs(), is_empty.GetMSBs()};
 }
 
 // Window may exceed one SIMD register: sweep in EntryWide strides, packing each
 // stride's masks (lane i of stride `off` -> bit off+i). uint32_t masks => <= 32 lanes.
-inline FORCE_INLINE OAHSet::LaneMasks OAHSet::ProbeWindow(const OAHEntry* base,
+inline FORCE_INLINE OAHSet::LaneMasks OAHSet::ProbeWindow(const TaggedPtr* base,
                                                           uint64_t ext_hash) noexcept {
   LaneMasks w{0, 0};
   for (uint32_t off = 0; off < kDisplacementSize; off += EntryWide::kLanes) {
@@ -38,34 +38,28 @@ inline FORCE_INLINE OAHSet::LaneMasks OAHSet::ProbeWindow(const OAHEntry* base,
   return w;
 }
 
-inline FORCE_INLINE void OAHSet::RefreshStaleCandidate(OAHEntry& e, uint64_t ext_hash) {
-  if (e.GetHash() != ext_hash)
-    e.SetExtHash(CalcExtHash(Hash(e.Key()), capacity_log_));
-  e.ExpireIfNeeded(time_now_, &size_, &obj_alloc_used_);
-}
-
 // 2-lane SIMD strides. Vector sizes are always even (PtrVector grows by 2), so the
 // stride covers the array with no tail.
-inline FORCE_INLINE OAHEntry* OAHSet::ProbeExtensionVector(uint32_t ext_bid, std::string_view str,
-                                                           uint64_t ext_hash) {
-  auto& vec = entries_[ext_bid].AsVector();
-  auto* raw_arr = vec.Raw();
+inline FORCE_INLINE TaggedPtr* OAHSet::ProbeExtensionVector(uint32_t ext_bid, std::string_view str,
+                                                            uint64_t ext_hash) {
+  auto vec = At(ext_bid).AsVector();
+  TaggedPtr* raw_arr = vec.Raw();
   const size_t size = vec.Size();
   DCHECK_GE(size, size_t(kVectorLaneStep));
   DCHECK_EQ(size % kVectorLaneStep, 0u);
 
   for (size_t base = 0; base < size; base += kVectorLaneStep) {
-    auto cand_bits = ProbeLanes<VectorWide>(&raw_arr[base], ext_hash).candidates;
+    auto cand_bits =
+        ProbeLanes<VectorWide>(reinterpret_cast<const uint64_t*>(&raw_arr[base]), ext_hash)
+            .candidates;
     while (cand_bits) {
       const uint32_t j = std::countr_zero(cand_bits);
       cand_bits &= cand_bits - 1;
-      OAHEntry& re = raw_arr[base + j];
-      if (re.Key() != str) {
-        RefreshStaleCandidate(re, ext_hash);
-        continue;
-      }
+      OAHEntry re(raw_arr[base + j]);
+      const bool match = re.Key() == str;
       re.ExpireIfNeeded(time_now_, &size_, &obj_alloc_used_);
-      return &re;
+      if (match)
+        return &raw_arr[base + j];
     }
   }
   return nullptr;
@@ -79,19 +73,18 @@ inline FORCE_INLINE OAHSet::MatchResult OAHSet::FindMatch(uint32_t bid, uint32_t
     const uint32_t i = std::countr_zero(cand_bits);
     cand_bits &= cand_bits - 1;
     const uint32_t bucket_id = bid + i;
-    OAHEntry& e = entries_[bucket_id];
-    if (e.IsVector())  // vectors live only at the extension point
+    OAHPtr p = At(bucket_id);
+    if (p.IsVector())  // vectors live only at the extension point
       continue;
-    if (e.Key() != str) {
-      RefreshStaleCandidate(e, ext_hash);
-      continue;
-    }
+    OAHEntry e = p[0];
+    const bool match = e.Key() == str;
     e.ExpireIfNeeded(time_now_, &size_, &obj_alloc_used_);
-    return {&e, bucket_id, 0};
+    if (match)
+      return {&entries_[bucket_id], bucket_id, 0};
   }
-  if (entries_[ext_bid].IsVector()) {
-    if (OAHEntry* hit = ProbeExtensionVector(ext_bid, str, ext_hash))
-      return {hit, ext_bid, static_cast<uint32_t>(hit - entries_[ext_bid].AsVector().Raw())};
+  if (At(ext_bid).IsVector()) {
+    if (TaggedPtr* hit = ProbeExtensionVector(ext_bid, str, ext_hash))
+      return {hit, ext_bid, static_cast<uint32_t>(hit - At(ext_bid).AsVector().Raw())};
   }
   return {nullptr, 0, 0};
 }
@@ -108,31 +101,34 @@ inline FORCE_INLINE bool OAHSet::AddImpl(std::string_view str, uint32_t ttl_sec)
   PREFETCH_READ(entries_.data() + bucket_id);
 
   const ssize_t mem_before = zmalloc_used_memory_tl;
-  OAHEntry entry(str, EntryTTL(ttl_sec));
+  TaggedPtr entry_tagged_ptr = OAHEntry::Create(str, EntryTTL(ttl_sec));
   if (ttl_sec != UINT32_MAX)
     expiration_used_ = true;
   const size_t entry_alloc_size = zmalloc_used_memory_tl - mem_before;
 
   const uint32_t ext_bid = GetExtensionPoint(bucket_id);
-  PREFETCH_READ(entries_[ext_bid].Raw());
+  PREFETCH_READ(At(ext_bid).Raw());
 
   const uint64_t ext_hash = CalcExtHash(hash, capacity_log_);
-  entry.SetExtHash(ext_hash);
+  OAHEntry new_entry(entry_tagged_ptr);
+  new_entry.SetExtHash(ext_hash);
 
   const LaneMasks masks = ProbeWindow(&entries_[bucket_id], ext_hash);
   const MatchResult m = FindMatch(bucket_id, ext_bid, masks.candidates, str, ext_hash);
-  if (m.matched && !m.matched->Empty())
+  if (m.matched && *m.matched != 0) {
+    OAHEntry::Destroy(entry_tagged_ptr);  // duplicate already present: discard the new blob
     return false;
+  }
 
   obj_alloc_used_ += entry_alloc_size;
   ++size_;
   // Reuse an expired duplicate's slot, else a free window lane, else spill to the vector.
   if (m.matched) {
-    *m.matched = std::move(entry);
+    *m.matched = entry_tagged_ptr;
   } else if (masks.empties) {
-    entries_[bucket_id + std::countr_zero(masks.empties)] = std::move(entry);
+    At(bucket_id + std::countr_zero(masks.empties)).Assign(entry_tagged_ptr);
   } else {
-    ptr_vectors_alloc_used_ += entries_[ext_bid].Insert(std::move(entry));
+    ptr_vectors_alloc_used_ += At(ext_bid).Insert(entry_tagged_ptr);
   }
   return true;
 }
@@ -162,7 +158,7 @@ inline FORCE_INLINE OAHSet::iterator OAHSet::FindInternal(uint32_t bid, std::str
   const uint64_t ext_hash = CalcExtHash(hash, capacity_log_);
   const uint32_t cand_bits = ProbeWindow(&entries_[bid], ext_hash).candidates;
   const MatchResult m = FindMatch(bid, GetExtensionPoint(bid), cand_bits, str, ext_hash);
-  if (m.matched && !m.matched->Empty())  // empty => matched but just expired, i.e. gone
+  if (m.matched && *m.matched != 0)  // empty => matched but just expired, i.e. gone
     return iterator{this, m.bucket_id, m.pos_in_vec};
   return end();
 }
@@ -182,25 +178,28 @@ bool OAHSet::Erase(std::string_view str) {
   if (item == end())
     return false;
   --size_;
-  obj_alloc_used_ -= item->AllocSize();
-  *item = OAHEntry();
-  uint32_t erase_bucket = item.bucket_id();
-  if (entries_[erase_bucket].IsVector() && entries_[erase_bucket].AsVector().Empty()) {
-    ptr_vectors_alloc_used_ -= entries_[erase_bucket].AsVector().AllocSize();
-    entries_[erase_bucket] = OAHEntry();
+  OAHEntry victim = *item;
+  obj_alloc_used_ -= victim.AllocSize();
+  OAHEntry::Destroy(victim.Release());
+
+  OAHPtr bucket = At(item.bucket_id());
+  if (bucket.IsVector() && bucket.AsVector().Empty()) {
+    ptr_vectors_alloc_used_ -= bucket.AsVector().AllocSize();
+    bucket.Clear();
   }
   return true;
 }
 
 inline FORCE_INLINE OAHSet::iterator OAHSet::PickFromBucket(uint32_t b) {
-  OAHEntry& bucket = entries_[b];
+  OAHPtr bucket = At(b);
   if (!bucket.IsVector()) {
-    bucket.ExpireIfNeeded(time_now_, &size_, &obj_alloc_used_);
-    return bucket.Empty() ? end() : iterator{this, b, 0};
+    OAHEntry e = bucket[0];
+    e.ExpireIfNeeded(time_now_, &size_, &obj_alloc_used_);
+    return e.Empty() ? end() : iterator{this, b, 0};
   }
-  auto& vec = bucket.AsVector();
+  auto vec = bucket.AsVector();
   for (uint32_t pos = 0, vec_size = vec.Size(); pos < vec_size; ++pos) {
-    auto& entry = vec[pos];
+    OAHEntry entry(vec[pos]);
     if (!entry)
       continue;
     entry.ExpireIfNeeded(time_now_, &size_, &obj_alloc_used_);
@@ -212,7 +211,7 @@ inline FORCE_INLINE OAHSet::iterator OAHSet::PickFromBucket(uint32_t b) {
 
 OAHSet::iterator OAHSet::ScanRange(uint32_t lo, uint32_t hi) {
   for (; lo + EntryWide::kLanes <= hi; lo += EntryWide::kLanes) {
-    const EntryWide data = EntryWide::Load(reinterpret_cast<const uint64_t*>(&entries_[lo]));
+    const EntryWide data = EntryWide::Load(&entries_[lo]);
     uint32_t used = (~(data == uint64_t(0))).GetMSBs();
     while (used) {
       const uint32_t b = lo + std::countr_zero(used);
@@ -222,7 +221,7 @@ OAHSet::iterator OAHSet::ScanRange(uint32_t lo, uint32_t hi) {
     }
   }
   for (; lo < hi; ++lo) {
-    if (entries_[lo].Empty())
+    if (entries_[lo] == 0)
       continue;
     if (auto it = PickFromBucket(lo); it != end())
       return it;
@@ -250,7 +249,7 @@ inline FORCE_INLINE uint32_t OAHSet::FindEmptyAround(uint32_t bid) {
   // Strides scanned in order, so the first empty found is the lowest-index one. In
   // bounds thanks to entries_' kDisplacementSize-1 slack past BucketCount.
   for (uint32_t off = 0; off < kDisplacementSize; off += EntryWide::kLanes) {
-    const EntryWide data = EntryWide::Load(reinterpret_cast<const uint64_t*>(&entries_[bid + off]));
+    const EntryWide data = EntryWide::Load(&entries_[bid + off]);
     if (uint32_t empties = (data == uint64_t(0)).GetMSBs())
       return bid + off + std::countr_zero(empties);
   }
@@ -260,42 +259,41 @@ inline FORCE_INLINE uint32_t OAHSet::FindEmptyAround(uint32_t bid) {
   return ext;
 }
 
-void OAHSet::Rehash(uint32_t prev_capacity_log, uint32_t prev_size) {
+void OAHSet::Rehash(uint32_t prev_size) {
   if (prev_size == 0) {
     return;
   }
-  // we should prevent moving elements before current possition to avoid double processing
+  // we should prevent moving elements before current possition to avoid double processing.
+  // Detach the first mix_size slots into locals; each `bucket` view is freed explicitly
+  // after its entries are redistributed into entries_ (a TaggedPtr slot has no dtor).
   constexpr size_t mix_size = (2 << kShiftLog) - 1;
-  std::array<OAHEntry, mix_size> old_buckets{};
+  std::array<TaggedPtr, mix_size> old_buckets{};
   for (size_t i = 0; i < mix_size; ++i) {
-    old_buckets[i] = std::move(entries_[i]);
+    old_buckets[i] = entries_[i];
+    entries_[i] = 0;
   }
 
   for (size_t bucket_id = prev_size - 1; bucket_id >= mix_size; --bucket_id) {
-    auto bucket = std::move(entries_[bucket_id]);
-    for (uint32_t pos = 0, size = bucket.ElementsNum(); pos < size; ++pos) {
-      if (bucket[pos]) {
-        auto new_bucket_id = RehashEntry(bucket[pos], bucket_id, prev_capacity_log);
-        new_bucket_id = FindEmptyAround(new_bucket_id);
-        ptr_vectors_alloc_used_ += entries_[new_bucket_id].Insert(std::move(bucket[pos]));
-      }
-    }
-    if (bucket.IsVector())
-      ptr_vectors_alloc_used_ -= bucket.AsVector().AllocSize();
+    TaggedPtr slot = entries_[bucket_id];
+    entries_[bucket_id] = 0;
+    RedistributeBucket(slot);
   }
 
-  for (size_t bucket_id = 0; bucket_id < mix_size; ++bucket_id) {
-    auto& bucket = old_buckets[bucket_id];
-    for (uint32_t pos = 0, size = bucket.ElementsNum(); pos < size; ++pos) {
-      if (bucket[pos]) {
-        auto new_bucket_id = RehashEntry(bucket[pos], bucket_id, prev_capacity_log);
-        new_bucket_id = FindEmptyAround(new_bucket_id);
-        ptr_vectors_alloc_used_ += entries_[new_bucket_id].Insert(std::move(bucket[pos]));
-      }
+  for (size_t bucket_id = 0; bucket_id < mix_size; ++bucket_id)
+    RedistributeBucket(old_buckets[bucket_id]);
+}
+
+void OAHSet::RedistributeBucket(TaggedPtr& slot) {
+  OAHPtr bucket(slot);
+  for (uint32_t pos = 0, size = bucket.ElementsNum(); pos < size; ++pos) {
+    if (bucket[pos]) {
+      uint32_t new_bucket_id = FindEmptyAround(RehashEntry(bucket[pos]));
+      ptr_vectors_alloc_used_ += At(new_bucket_id).Insert(bucket.Remove(pos));
     }
-    if (bucket.IsVector())
-      ptr_vectors_alloc_used_ -= bucket.AsVector().AllocSize();
   }
+  if (bucket.IsVector())
+    ptr_vectors_alloc_used_ -= bucket.AsVector().AllocSize();
+  bucket.Clear();
 }
 
 void OAHSet::Shrink(size_t new_size) {

--- a/src/core/oah_set.h
+++ b/src/core/oah_set.h
@@ -12,17 +12,24 @@
 #include <concepts>
 #include <vector>
 
+#include "common/rapidhash.h"
 #include "core/detail/stateless_allocator.h"
+#include "core/oah_ptr.h"
 #include "core/simd_op.h"
 #include "core/string_set.h"
-#include "oah_entry.h"
 
 namespace dfly {
 
+// oah_set.h - an open-addressing hash set of string members (the OAHSet container).
+//
+// OAHSet stores members in a flat array of TaggedPtr buckets. Each bucket is wrapped by a
+// non-owning OAHPtr holding either a single OAHEntry or a PtrVector collision chain. Lookups probe
+// a small SIMD window around the home bucket and spill overflow into an extension-point vector.
+// Buckets own their blobs/vectors and are freed explicitly (a TaggedPtr has no destructor).
+//
 // TODO add template parameter instead of OAHEntry
 class OAHSet {  // Open Addressing Hash Set
-  using OAHEntryAllocator = StatelessAllocator<OAHEntry>;
-  using Buckets = std::vector<OAHEntry, OAHEntryAllocator>;
+  using Buckets = std::vector<TaggedPtr, StatelessAllocator<TaggedPtr>>;
 
  public:
   static constexpr std::uint32_t kShiftLog = 5;                         // TODO make template
@@ -34,17 +41,17 @@ class OAHSet {  // Open Addressing Hash Set
     using iterator_category = std::forward_iterator_tag;
     using difference_type = std::ptrdiff_t;
     using value_type = OAHEntry;
-    using pointer = OAHEntry*;
-    using reference = OAHEntry&;
+    using pointer = OAHEntry;
+    using reference = OAHEntry;
 
     iterator(OAHSet* owner, uint32_t bucket_id, uint32_t pos_in_bucket)
         : owner_(owner), bucket_(bucket_id), pos_(pos_in_bucket) {
     }
 
     void SetExpiryTime(uint32_t ttl_sec) {
-      auto& entry = owner_->entries_[bucket_][pos_];
+      auto entry = owner_->At(bucket_)[pos_];
       owner_->obj_alloc_used_ -= entry.AllocSize();
-      owner_->entries_[bucket_][pos_].SetExpiry(owner_->EntryTTL(ttl_sec));
+      owner_->At(bucket_)[pos_].SetExpiry(owner_->EntryTTL(ttl_sec));
       owner_->obj_alloc_used_ += entry.AllocSize();
       owner_->expiration_used_ = true;
     }
@@ -68,19 +75,19 @@ class OAHSet {  // Open Addressing Hash Set
     }
 
     reference operator*() {
-      return owner_->entries_[bucket_][pos_];
+      return owner_->At(bucket_)[pos_];
     }
 
     reference operator->() {
-      return owner_->entries_[bucket_][pos_];
+      return owner_->At(bucket_)[pos_];
     }
 
     bool HasExpiry() {
-      return owner_->entries_[bucket_][pos_].HasExpiry();
+      return owner_->At(bucket_)[pos_].HasExpiry();
     }
 
     uint32_t ExpiryTime() {
-      return owner_->entries_[bucket_][pos_].GetExpiry();
+      return owner_->At(bucket_)[pos_].GetExpiry();
     }
 
     uint32_t bucket_id() const {
@@ -94,7 +101,7 @@ class OAHSet {  // Open Addressing Hash Set
     // Reallocates fragmented buffers in this bucket (inner entries + array buffer for
     // vectors). Returns true iff anything moved. Idempotent within a defrag pass.
     bool ReallocIfNeeded(PageUsage* page_usage) {
-      auto& bucket = owner_->entries_[bucket_];
+      auto bucket = owner_->At(bucket_);
       bool realloced = false;
       ssize_t delta = bucket.ReallocIfNeeded(page_usage, &realloced);
       // delta can be negative if a realloc lands in a smaller mimalloc usable-size
@@ -116,9 +123,9 @@ class OAHSet {  // Open Addressing Hash Set
       // time_now_ == 0 disables expiry (callers set it to 0 around serialization).
       const uint32_t now = owner_->time_now_;
       for (auto num_entries = owner_->entries_.size(); bucket_ < num_entries; ++bucket_) {
-        auto& bucket = owner_->entries_[bucket_];
+        auto bucket = owner_->At(bucket_);
         for (uint32_t bucket_size = bucket.ElementsNum(); pos_ < bucket_size; ++pos_) {
-          auto& entry = bucket[pos_];
+          auto entry = bucket[pos_];
           if (!entry)
             continue;
           if (now != 0 && entry.HasExpiry() && entry.GetExpiry() <= now) {
@@ -150,11 +157,12 @@ class OAHSet {  // Open Addressing Hash Set
 
   static constexpr uint32_t kMaxBatchLen = 32;
 
-  // OAHEntry is one uint64_t, so 4 entries fill a 32-byte AVX2 register. The window is
-  // probed in kEntryLaneStep-lane strides, so kDisplacementSize must be a multiple of
-  // the stride and <= 32 (masks fit a uint32_t).
-  static_assert(sizeof(OAHEntry) == sizeof(uint64_t));
-  static_assert(alignof(OAHEntry) == alignof(uint64_t));
+  // Buckets hold one TaggedPtr control word per lane, so 4 fill a 32-byte AVX2 register.
+  // The window is probed in kEntryLaneStep-lane strides, so kDisplacementSize must be a
+  // multiple of the stride and <= 32 (masks fit a uint32_t). OAHEntry stays a thin
+  // word-sized accessor over such a slot.
+  static_assert(sizeof(OAHEntry) == sizeof(TaggedPtr));
+  static_assert(alignof(OAHEntry) == alignof(TaggedPtr));
   static constexpr std::uint32_t kEntryLaneStep = 4;
   using EntryWide = SimdOp<uint64_t, kEntryLaneStep>;
   static_assert(kDisplacementSize % kEntryLaneStep == 0 && kDisplacementSize <= 32);
@@ -167,17 +175,25 @@ class OAHSet {  // Open Addressing Hash Set
 
   explicit OAHSet() = default;
 
+  // Buckets are TaggedPtr control words that own their blobs/vectors (freed by
+  // ~OAHSet), so a shallow copy would double-free. Non-copyable, matching DenseSet.
+  OAHSet(const OAHSet&) = delete;
+  OAHSet& operator=(const OAHSet&) = delete;
+
+  ~OAHSet() {
+    FreeAllSlots();
+  }
+
   // Inserts `str` (optional TTL); returns false if already present.
   bool Add(std::string_view str, uint32_t ttl_sec = UINT32_MAX);
 
   void Reserve(size_t sz) {
     sz = absl::bit_ceil(sz);
     if (sz > entries_.size()) {
-      auto prev_capacity_log = capacity_log_;
       capacity_log_ = std::max(kMinCapacityLog, uint32_t(absl::bit_width(sz) - 1));
       size_t prev_size = entries_.size();
       entries_.resize(Capacity());
-      Rehash(prev_capacity_log, prev_size);
+      Rehash(prev_size);
     }
     assert(entries_.size() >= kDisplacementSize);
   }
@@ -188,6 +204,7 @@ class OAHSet {  // Open Addressing Hash Set
   void Shrink(size_t new_size);
 
   void Clear() {
+    FreeAllSlots();
     capacity_log_ = 0;
     entries_.resize(0);
     size_ = 0;
@@ -202,13 +219,14 @@ class OAHSet {  // Open Addressing Hash Set
     const uint32_t total = entries_.size();
     const uint32_t end = std::min(total, start + count);
     for (uint32_t i = start; i < end; ++i) {
-      auto& bucket = entries_[i];
+      auto bucket = At(i);
       if (bucket.Empty())
         continue;
 
       if (bucket.IsVector()) {
-        auto& vec = bucket.AsVector();
-        for (auto& entry : vec) {
+        auto vec = bucket.AsVector();
+        for (TaggedPtr& cell : vec) {
+          OAHEntry entry(cell);
           if (entry) {
             obj_alloc_used_ -= entry.AllocSize();
             --size_;
@@ -216,10 +234,10 @@ class OAHSet {  // Open Addressing Hash Set
         }
         ptr_vectors_alloc_used_ -= vec.AllocSize();
       } else {
-        obj_alloc_used_ -= bucket.AllocSize();
+        obj_alloc_used_ -= bucket[0].AllocSize();
         --size_;
       }
-      bucket = OAHEntry();
+      bucket.Clear();
     }
     // Match Clear() semantics: once incrementally cleared empty, the TTL flag is stale.
     if (size_ == 0)
@@ -270,7 +288,7 @@ class OAHSet {  // Open Addressing Hash Set
       bool res = false;
       for (uint32_t i = 0; i < kDisplacementSize; i++) {
         const uint32_t shifted_bid = bucket_id + i;
-        res |= ScanBucket(entries_[shifted_bid], cb, bucket_id);
+        res |= ScanBucket(At(shifted_bid), cb, bucket_id);
       }
       if (res)
         break;
@@ -326,7 +344,7 @@ class OAHSet {  // Open Addressing Hash Set
   }
 
   size_t SetMallocUsed() const {
-    return entries_.capacity() * sizeof(OAHEntry) + ptr_vectors_alloc_used_;
+    return entries_.capacity() * sizeof(TaggedPtr) + ptr_vectors_alloc_used_;
   }
 
   bool ExpirationUsed() const {
@@ -342,20 +360,41 @@ class OAHSet {  // Open Addressing Hash Set
 
  private:
   static uint64_t Hash(std::string_view str) {
-    constexpr XXH64_hash_t kHashSeed = 24061983;
-    return XXH3_64bits_withSeed(str.data(), str.size(), kHashSeed);
+    constexpr uint64_t kHashSeed = 24061983;
+    return rapidhashMicro_withSeed(str.data(), str.size(), kHashSeed);
   }
 
   static uint32_t BucketId(uint64_t hash, uint32_t capacity_log) {
     return hash >> (64 - capacity_log);
   }
+
+  // A non-owning OAHPtr over bucket slot `i`.
+  OAHPtr At(uint32_t i) {
+    return OAHPtr(entries_[i]);
+  }
+
+  // Frees the blob/vector of every non-empty bucket. Used by ~OAHSet and Clear().
+  void FreeAllSlots() {
+    for (size_t i = 0, n = entries_.size(); i < n; ++i) {
+      if (entries_[i])
+        At(i).Clear();
+    }
+  }
+
   // was Grow in StringSet
-  void Rehash(uint32_t prev_capacity_log, uint32_t prev_size);
+  void Rehash(uint32_t prev_size);
+
+  // Rehashes and re-inserts every entry of `slot`'s bucket into entries_, then frees it.
+  void RedistributeBucket(TaggedPtr& slot);
 
   // it is inefficient for now,
   // TODO predict new position by current position and extended hash
   void ShrinkBucket(uint32_t bucket_id) {
-    auto bucket = std::move(entries_[bucket_id]);
+    // Detach the slot bits into a local; `bucket` views the local and is freed
+    // explicitly below (At(new_bucket_id) writes into entries_, never this local).
+    TaggedPtr slot = entries_[bucket_id];
+    entries_[bucket_id] = 0;
+    OAHPtr bucket(slot);
     if (bucket.Empty())
       return;
 
@@ -368,17 +407,16 @@ class OAHSet {  // Open Addressing Hash Set
           continue;
         }
 
-        auto hash = Hash(bucket[pos].Key());
-        auto new_bucket_id = BucketId(hash, capacity_log_);
-        SetEntryHash(bucket[pos], hash);
-        new_bucket_id = FindEmptyAround(new_bucket_id);
-        ptr_vectors_alloc_used_ += entries_[new_bucket_id].Insert(std::move(bucket[pos]));
+        uint32_t new_bucket_id = FindEmptyAround(RehashEntry(bucket[pos]));
+        ptr_vectors_alloc_used_ += At(new_bucket_id).Insert(bucket.Remove(pos));
       }
     }
 
     if (bucket.IsVector()) {
       ptr_vectors_alloc_used_ -= bucket.AsVector().AllocSize();
     }
+    // Frees the (now drained) collision array and any expired entries left behind.
+    bucket.Clear();
   }
 
   static uint32_t GetExtensionPoint(uint32_t bid) {
@@ -387,17 +425,19 @@ class OAHSet {  // Open Addressing Hash Set
   }
 
   template <std::invocable<std::string_view> T>
-  bool ScanBucket(OAHEntry& entry, const T& cb, uint32_t bucket_id) {
+  bool ScanBucket(OAHPtr entry, const T& cb, uint32_t bucket_id) {
     if (!entry.IsVector()) {
-      entry.ExpireIfNeeded(time_now_, &size_, &obj_alloc_used_);
-      if (CheckBucketAffiliation(entry, bucket_id)) {
-        cb(entry.Key());
+      OAHEntry e = entry[0];
+      e.ExpireIfNeeded(time_now_, &size_, &obj_alloc_used_);
+      if (CheckBucketAffiliation(e, bucket_id)) {
+        cb(e.Key());
         return true;
       }
     } else {
-      auto& arr = entry.AsVector();
+      auto arr = entry.AsVector();
       bool result = false;
-      for (auto& el : arr) {
+      for (TaggedPtr& cell : arr) {
+        OAHEntry el(cell);
         el.ExpireIfNeeded(time_now_, &size_, &obj_alloc_used_);
         if (CheckBucketAffiliation(el, bucket_id)) {
           cb(el.Key());
@@ -433,26 +473,26 @@ class OAHSet {  // Open Addressing Hash Set
 
   // Result of a SIMD probe over a run of OAHEntry lanes.
   struct LaneMasks {
-    uint32_t candidates;  // non-empty lanes whose ext-hash matches or is lazily zero
+    uint32_t candidates;  // non-empty lanes whose stored ext-hash equals the query ext-hash
     uint32_t empties;     // empty lanes (data_ == 0); Add picks a slot from these
   };
 
   // Vectorized hash probe over Wide::kLanes consecutive lanes from `base`. Backs
   // the window (EntryWide) and extension-vector (VectorWide) scans.
   template <typename Wide>
-  static LaneMasks ProbeLanes(const OAHEntry* base, uint64_t ext_hash) noexcept;
+  static LaneMasks ProbeLanes(const TaggedPtr* base, uint64_t ext_hash) noexcept;
 
   // Combined candidate/empty masks over the whole window (lane i -> bit i).
-  LaneMasks ProbeWindow(const OAHEntry* base, uint64_t ext_hash) noexcept;
+  LaneMasks ProbeWindow(const TaggedPtr* base, uint64_t ext_hash) noexcept;
 
   // Searches the extension-point vector for `str`. Returns the matched slot
   // (possibly now-empty after expiry, which the caller reuses) or nullptr.
-  OAHEntry* ProbeExtensionVector(uint32_t ext_bid, std::string_view str, uint64_t ext_hash);
+  TaggedPtr* ProbeExtensionVector(uint32_t ext_bid, std::string_view str, uint64_t ext_hash);
 
   // Outcome of a key probe. A raw slot (not an iterator) so the caller can reuse a
   // matched-but-just-expired entry, which is Empty() and would trip operator[]'s assert.
   struct MatchResult {
-    OAHEntry* matched;    // matched entry, or null if absent; may be Empty() (just expired)
+    TaggedPtr* matched;   // ptr to matched cell, or null if absent; may be 0 (just expired)
     uint32_t bucket_id;   // location of `matched`, for building an iterator
     uint32_t pos_in_vec;  // position within a vector bucket (0 for single entries)
   };
@@ -472,64 +512,21 @@ class OAHSet {  // Open Addressing Hash Set
     return (hash >> ext_hash_shift) & OAHEntry::kExtHashMask;
   }
 
-  uint64_t SetEntryHash(OAHEntry& entry, uint64_t hash) {
-    uint64_t ext_hash = CalcExtHash(hash, capacity_log_);
-    entry.SetExtHash(ext_hash);
-    return ext_hash;
-  }
-
-  // Probe candidate whose key didn't match: refresh its stale/lazy-zero ext-hash
-  // cache so later probes skip it, then apply pending expiry.
-  void RefreshStaleCandidate(OAHEntry& e, uint64_t ext_hash);
-
-  bool CheckBucketAffiliation(OAHEntry& entry, uint32_t bucket_id) {
-    assert(!entry.IsVector());
+  bool CheckBucketAffiliation(OAHEntry entry, uint32_t bucket_id) {
     if (entry.Empty())
       return false;
     uint32_t bucket_id_hash_part = capacity_log_ > kShiftLog ? kShiftLog : capacity_log_;
     uint32_t bucket_mask = (1 << bucket_id_hash_part) - 1;
     bucket_id &= bucket_mask;
-    auto stored_hash = entry.GetHash();
-    if (!stored_hash) {
-      stored_hash = SetEntryHash(entry, Hash(entry.Key()));
-    }
-    uint32_t stored_bucket_id = stored_hash >> (OAHEntry::kExtHashSize - bucket_id_hash_part);
+    uint32_t stored_bucket_id = entry.GetHash() >> (OAHEntry::kExtHashSize - bucket_id_hash_part);
     return bucket_id == stored_bucket_id;
   }
 
-  // return new bucket_id
-  uint32_t RehashEntry(OAHEntry& entry, uint32_t current_bucket_id, uint32_t prev_capacity_log) {
-    assert(!entry.IsVector());
-    auto stored_hash = entry.GetHash();
-
-    const uint32_t logs_diff = capacity_log_ - prev_capacity_log;
-    const uint32_t prev_significant_bits =
-        prev_capacity_log > kShiftLog ? kShiftLog : prev_capacity_log;
-    const uint32_t needed_hash_bits = prev_significant_bits + logs_diff;
-
-    if (!stored_hash || needed_hash_bits > OAHEntry::kExtHashSize) {
-      auto hash = Hash(entry.Key());
-      SetEntryHash(entry, hash);
-      return BucketId(hash, capacity_log_);
-    }
-
-    const uint32_t real_bucket_end =
-        stored_hash >> (OAHEntry::kExtHashSize - prev_significant_bits);
-    const uint32_t prev_shift_mask = (1 << prev_significant_bits) - 1;
-    const uint32_t curr_shift = (current_bucket_id - real_bucket_end) & prev_shift_mask;
-    const uint32_t prev_bucket_mask = (1 << prev_capacity_log) - 1;
-    const uint32_t base_bucket_id = (current_bucket_id - curr_shift) & prev_bucket_mask;
-
-    const uint32_t last_bits_mask = (1 << logs_diff) - 1;
-    const uint32_t stored_hash_shift = OAHEntry::kExtHashSize - needed_hash_bits;
-    const uint32_t last_bits = (stored_hash >> stored_hash_shift) & last_bits_mask;
-    const uint32_t new_bucket_id = (base_bucket_id << logs_diff) | last_bits;
-
-    entry.ClearHash();  // the cache is invalid after rehash operation
-
-    assert(BucketId(Hash(entry.Key()), capacity_log_) == new_bucket_id);
-
-    return new_bucket_id;
+  // Recomputes the entry's hash, refreshes its stored ext-hash, and returns its new bucket.
+  uint32_t RehashEntry(OAHEntry entry) {
+    uint64_t hash = Hash(entry.Key());
+    entry.SetExtHash(CalcExtHash(hash, capacity_log_));
+    return BucketId(hash, capacity_log_);
   }
 
   mutable size_t obj_alloc_used_ = 0;

--- a/src/core/oah_set_test.cc
+++ b/src/core/oah_set_test.cc
@@ -65,7 +65,8 @@ static string random_string(mt19937& rand, unsigned len) {
 }
 
 TEST_F(OAHSetTest, PtrVectorLinearThenDouble) {
-  auto vp = PtrVector<int>::FromSize(2);
+  uint64_t slot = PtrVector<int>::Create(2);
+  PtrVector<int> vp(slot);
   EXPECT_EQ(vp.Size(), 2u);
   vp[0] = 1;
   vp[1] = 2;
@@ -87,25 +88,88 @@ TEST_F(OAHSetTest, PtrVectorLinearThenDouble) {
   EXPECT_EQ(vp.Size(), 512u);
   EXPECT_EQ(vp[0], 1);
   EXPECT_EQ(vp[1], 2);
+
+  PtrVector<int>::Destroy(vp.Release());
+}
+
+// Counts live instances so a test can assert that every slot's destructor runs.
+struct LiveCounter {
+  static inline int live = 0;
+  uint64_t v = 0;
+
+  LiveCounter() {
+    ++live;
+  }
+  LiveCounter(LiveCounter&& o) noexcept : v(o.v) {
+    o.v = 0;
+    ++live;
+  }
+  LiveCounter& operator=(LiveCounter&& o) noexcept {
+    v = o.v;
+    o.v = 0;
+    return *this;
+  }
+  ~LiveCounter() {
+    --live;
+  }
+  explicit operator bool() const {
+    return v != 0;
+  }
+};
+
+TEST_F(OAHSetTest, PtrVectorDestroysAllElements) {
+  // Regression: Destroy() must run ~T() on every placement-new'd slot, not just the
+  // occupied (truthy) ones. Otherwise non-trivially-destructible elements -- including
+  // moved-from ones -- are leaked when the backing storage is freed.
+  LiveCounter::live = 0;
+  uint64_t slot = PtrVector<LiveCounter>::Create(4);
+  PtrVector<LiveCounter> vec(slot);
+  ASSERT_EQ(LiveCounter::live, 4);  // all four slots are default-constructed
+
+  vec[0].v = 7;                     // occupy one slot; the other three stay "empty"
+  vec.Grow();                       // reallocates: moves survivors, frees the old buffer
+  ASSERT_EQ(LiveCounter::live, 6);  // linear grow 4 -> 6, old buffer fully destroyed
+
+  PtrVector<LiveCounter>::Destroy(vec.Release());
+  EXPECT_EQ(LiveCounter::live, 0);  // every slot, empty or moved-from, was destroyed
 }
 
 TEST_F(OAHSetTest, OAHEntryTest) {
-  OAHEntry test("0123456789", 2);
+  uint64_t bits = OAHEntry::Create("0123456789", 2);
+  OAHEntry test(bits);
 
   EXPECT_EQ(test.Key(), "0123456789"sv);
   EXPECT_EQ(test.GetExpiry(), 2);
 
-  OAHEntry first("123456789");
+  OAHEntry::Destroy(test.Release());
+}
 
-  EXPECT_EQ(test.Insert(std::move(first)), 16);  // promote to a 2-element vector (2 * 8 bytes)
+TEST_F(OAHSetTest, OAHPtrInsertRemove) {
+  // OAHPtr is a non-owning view over a uint64_t slot; the test owns the slot and frees
+  // the leftover collision array explicitly at the end.
+  uint64_t slot = 0;
+  OAHPtr test{slot};
+  test.Assign(OAHEntry::Create("0123456789", 2));
 
-  EXPECT_EQ(test.Insert(OAHEntry("23456789")), 16);  // linear grow 2 -> 4 (two more 8-byte slots)
+  EXPECT_EQ(test[0].Key(), "0123456789"sv);
+  EXPECT_EQ(test[0].GetExpiry(), 2);
 
-  EXPECT_TRUE(test.Remove(0));
-  EXPECT_FALSE(test.Remove(0));
+  EXPECT_EQ(test.Insert(OAHEntry::Create("123456789")), 16);  // promote to a 2-element vector
+  EXPECT_EQ(test.Insert(OAHEntry::Create("23456789")), 16);   // linear grow 2 -> 4
 
-  EXPECT_EQ(test.Remove(2).Key(), "23456789");
-  EXPECT_EQ(test.Remove(1).Key(), "123456789");
+  uint64_t removed0 = test.Remove(0);
+  EXPECT_TRUE(removed0);
+  OAHEntry::Destroy(removed0);
+  EXPECT_FALSE(test.Remove(0));  // cell already empty -> 0 bits
+
+  uint64_t removed2 = test.Remove(2);
+  uint64_t removed1 = test.Remove(1);
+  EXPECT_EQ(OAHEntry(removed2).Key(), "23456789");
+  EXPECT_EQ(OAHEntry(removed1).Key(), "123456789");
+  OAHEntry::Destroy(removed2);
+  OAHEntry::Destroy(removed1);
+
+  test.Clear();  // free the now-empty collision array
 }
 
 TEST_F(OAHSetTest, OAHSetAddFindTest) {
@@ -142,10 +206,9 @@ TEST_F(OAHSetTest, Basic) {
 }
 
 // Regression: re-adding existing keys must never store a duplicate, even
-// across multiple rehashes (ClearHash → h_zero lazy path) and after entries
-// have overflowed into a vector at ext_bid. UpperBoundSize alone is
-// insufficient: a buggy AddUnique would still increment size_ exactly once. We
-// iterate and assert each key appears exactly once.
+// across multiple rehashes and after entries have overflowed into a vector at
+// ext_bid. UpperBoundSize alone is insufficient: a buggy AddUnique would still
+// increment size_ exactly once. We iterate and assert each key appears exactly once.
 TEST_F(OAHSetTest, NoDuplicateInsertion) {
   constexpr int kNumKeys = 2000;  // enough for several Reserve→Rehash cycles
   std::vector<std::string> keys;
@@ -731,17 +794,20 @@ TEST_F(OAHSetTest, ReallocIfNeededForceReallocates) {
 }
 
 TEST_F(OAHSetTest, ReallocIfNeededVectorEntry) {
-  // Construct a vector OAHEntry directly via Insert — same shape as a colliding bucket.
-  OAHEntry e("first_entry_payload");
-  (void)e.Insert(OAHEntry("second_entry_payload"));
-  (void)e.Insert(OAHEntry("third_entry_payload"));
+  // Construct a vector slot directly via Insert — same shape as a colliding bucket.
+  // OAHPtr is a non-owning view; the test owns `slot` and frees it at the end.
+  uint64_t slot = 0;
+  OAHPtr e{slot};
+  e.Assign(OAHEntry::Create("first_entry_payload"));
+  (void)e.Insert(OAHEntry::Create("second_entry_payload"));
+  (void)e.Insert(OAHEntry::Create("third_entry_payload"));
   ASSERT_TRUE(e.IsVector());
 
   // Snapshot inner-entry buffer pointers so we can assert each one moved.
   std::vector<char*> old_inner_ptrs;
   for (uint32_t i = 0; i < e.AsVector().Size(); ++i)
-    if (e.AsVector()[i])
-      old_inner_ptrs.push_back(e.AsVector()[i].Raw());
+    if (OAHEntry(e.AsVector()[i]))
+      old_inner_ptrs.push_back(OAHEntry(e.AsVector()[i]).Raw());
   char* old_vec_buf = e.Raw();
 
   PageUsage page_usage{CollectPageStats::NO, 0.9};
@@ -759,11 +825,12 @@ TEST_F(OAHSetTest, ReallocIfNeededVectorEntry) {
   // their content is intact.
   std::set<std::string> seen;
   std::vector<char*> new_inner_ptrs;
-  auto& vec = e.AsVector();
+  auto vec = e.AsVector();
   for (uint32_t i = 0; i < vec.Size(); ++i) {
-    if (vec[i]) {
-      seen.insert(std::string(vec[i].Key()));
-      new_inner_ptrs.push_back(vec[i].Raw());
+    OAHEntry cell(vec[i]);
+    if (cell) {
+      seen.insert(std::string(cell.Key()));
+      new_inner_ptrs.push_back(cell.Raw());
     }
   }
   EXPECT_EQ(seen.count("first_entry_payload"), 1u);
@@ -777,6 +844,8 @@ TEST_F(OAHSetTest, ReallocIfNeededVectorEntry) {
       EXPECT_NE(old_p, new_p) << "inner entry buffer not reallocated";
     }
   }
+
+  e.Clear();  // free the collision array + remaining entries
 }
 
 TEST_F(OAHSetTest, ReallocIfNeededVectorBucketViaIterator) {
@@ -956,7 +1025,7 @@ void BM_Clone(benchmark::State& state) {
   }
   ss2.Reserve(ss1.UpperBoundSize());
   while (state.KeepRunning()) {
-    for (auto& src : ss1) {
+    for (auto src : ss1) {
       ss2.Add(src.Key());
     }
     state.PauseTiming();

--- a/src/core/ptr_vector.h
+++ b/src/core/ptr_vector.h
@@ -1,0 +1,162 @@
+// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <sys/types.h>
+
+#include <algorithm>
+#include <bit>
+#include <cassert>
+#include <cstdint>
+#include <new>
+#include <type_traits>
+
+extern "C" {
+#include "redis/zmalloc.h"
+}
+
+namespace dfly {
+
+// A uint64_t that packs a heap pointer together with tag/flag bits in its unused low/high bits.
+using TaggedPtr = uint64_t;
+
+// ptr_vector.h - a growable heap array of T addressed through a single TaggedPtr.
+//
+// PtrVector is a non-owning accessor over a TaggedPtr that encodes (array pointer, element count).
+// It manages the element array: the static Create()/Destroy() allocate and free it,
+// Grow()/Realloc() resize it in place. Capacity grows by 2 up to kLinearMax then doubles, so sizes
+// stay even for the 2-lane SIMD probe; the 11-bit size field holds the count, or its base-2 log
+// when kLogModeBit is set (power-of-two sizes).
+template <class T> class PtrVector {
+  static constexpr size_t kVectorBit = 1ULL << 0;
+  static constexpr size_t kTagMask = (4095ULL << 52) | 7;
+  static constexpr size_t kSizeShift = 52;
+  static constexpr size_t kSizeMask = 0x7FFULL;
+  static constexpr size_t kLogModeBit = 1ULL << 63;
+  static constexpr size_t kSizeFieldMask = (kSizeMask << kSizeShift) | kLogModeBit;
+  static constexpr size_t kLinearMax = 128;
+
+ public:
+  static TaggedPtr Create(size_t count) {
+    T* p = reinterpret_cast<T*>(zmalloc(sizeof(T) * count));
+    for (size_t i = 0; i < count; ++i)
+      new (p + i) T();
+    return EncodeSize(reinterpret_cast<TaggedPtr>(p), count);
+  }
+
+  // Destroys every slot (all are constructed by Create/Reallocate) before freeing the array.
+  static void Destroy(TaggedPtr tagged_ptr) {
+    T* raw = RawOf(tagged_ptr);
+    if (!raw)
+      return;
+    if constexpr (!std::is_trivially_destructible_v<T>) {
+      const size_t size = SizeOf(tagged_ptr);
+      for (size_t i = 0; i < size; ++i)
+        raw[i].~T();
+    }
+    zfree(raw);
+  }
+
+  explicit PtrVector(TaggedPtr& slot) : slot_(&slot) {
+  }
+  PtrVector(const PtrVector&) = default;
+  PtrVector& operator=(const PtrVector&) = default;
+
+  T* begin() const {
+    return Raw();
+  }
+  T* end() const {
+    return Raw() + Size();
+  }
+
+  size_t Size() const {
+    return SizeOf(GetTaggedPtr());
+  }
+
+  size_t AllocSize() const {
+    return Size() * sizeof(T);
+  }
+
+  T& operator[](size_t idx) {
+    return Raw()[idx];
+  }
+  const T& operator[](size_t idx) const {
+    return Raw()[idx];
+  }
+
+  T* Raw() const {
+    return RawOf(GetTaggedPtr());
+  }
+
+  bool Empty() const {
+    if (GetTaggedPtr() == 0)
+      return true;
+    for (auto& el : *this)
+      if (el)
+        return false;
+    return true;
+  }
+
+  void Grow() {
+    const size_t cur = Size();
+    Reallocate(cur < kLinearMax ? cur + 2 : cur * 2);
+  }
+
+  // Defragments into a fresh same-size buffer.
+  void Realloc() {
+    Reallocate(Size());
+  }
+
+  // Returns the control word and zeroes the slot, transferring ownership to the caller.
+  TaggedPtr Release() {
+    TaggedPtr res = GetTaggedPtr();
+    SetTaggedPtr(0);
+    return res;
+  }
+
+ private:
+  static T* RawOf(TaggedPtr tagged_ptr) {
+    return reinterpret_cast<T*>(tagged_ptr & ~kTagMask);
+  }
+
+  static size_t SizeOf(TaggedPtr tagged_ptr) {
+    const uint64_t field = (tagged_ptr >> kSizeShift) & kSizeMask;
+    return (tagged_ptr & kLogModeBit) ? (size_t(1) << field) : size_t(field);
+  }
+
+  // Stores `count` literally below kLinearMax, else its base-2 log; always sets kVectorBit.
+  static TaggedPtr EncodeSize(TaggedPtr tagged_ptr, size_t count) {
+    const bool log_mode = count >= kLinearMax;
+    // Log mode keeps only log2(count), so at/above kLinearMax count must be a power of two.
+    assert(!log_mode || std::has_single_bit(count));
+    const uint64_t field = log_mode ? std::countr_zero(count) : count;
+    assert(field <= kSizeMask);
+    return (tagged_ptr & ~kSizeFieldMask) | kVectorBit | (field << kSizeShift) |
+           (log_mode ? kLogModeBit : 0);
+  }
+
+  void Reallocate(size_t new_count) {
+    T* new_ptr = reinterpret_cast<T*>(zmalloc(sizeof(T) * new_count));
+    const size_t keep = std::min(Size(), new_count);
+    for (size_t i = 0; i < keep; ++i)
+      new (new_ptr + i) T(std::move(Raw()[i]));
+    for (size_t i = keep; i < new_count; ++i)
+      new (new_ptr + i) T();
+    const TaggedPtr old = GetTaggedPtr();
+    SetTaggedPtr(EncodeSize(reinterpret_cast<TaggedPtr>(new_ptr), new_count));
+    Destroy(old);
+  }
+
+  TaggedPtr GetTaggedPtr() const {
+    return *slot_;
+  }
+  void SetTaggedPtr(TaggedPtr tagged_ptr) {
+    *slot_ = tagged_ptr;
+  }
+
+  TaggedPtr* slot_;
+};
+
+}  // namespace dfly

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2317,7 +2317,7 @@ void ServerFamily::Shrink(facade::CmdArgParser parser, CommandContext* cmd_cntx)
       // OAHEntry-sized and the entries vector includes displacement slots.
       auto bucket_bytes = [](Set* s) -> size_t {
         if constexpr (std::is_same_v<Set, OAHSet>)
-          return size_t{s->Capacity()} * sizeof(OAHEntry);
+          return size_t{s->Capacity()} * sizeof(uint64_t);
         else
           return s->BucketCount() * sizeof(void*);
       };


### PR DESCRIPTION
# refactor(OAHSet): split OAHEntry into OAHEntry, PtrVector, and OAHPtr

## Summary
The experimental `OAHSet` packed each bucket into a `uint64_t` and `reinterpret_cast` it into
`OAHEntry&` / `PtrVector<OAHEntry>&`, materializing typed references over a type-punned word —
object-lifetime and strict-aliasing UB that can miscompile under optimization/LTO or trip UBSan.
This splits that monolith into three single-responsibility, **non-owning** accessors over the raw
tagged word, so all mutation happens on `uint64_t` bits with no type-punned references.

## Changes
- **OAHEntry** (`oah_entry.h/.cc`): non-owning accessor over a `TaggedPtr` (a tagged `uint64_t`)
  pointing at a `[expiry, key, cached-hash]` blob; `static Create()/Destroy()` own allocation.
- **PtrVector<T>** (new `ptr_vector.h`): non-owning accessor over a `TaggedPtr` encoding
  `(array ptr, count)`; `static Create()/Destroy()`; grows +2 then doubles.
- **OAHPtr** (new `oah_ptr.h`, header-only): bucket-slot manager that discriminates entry vs
  vector (bit 0) and owns the lifetime logic (promote-to-vector, grow, clear).
- Replace all `reinterpret_cast` type-punning with operations on the raw `TaggedPtr`.
- Always store each entry's current ext-hash; rehash recomputes it (drops the lazy-hash paths).
- Swap `OAHSet::Hash` from XXH3 to `rapidhashMicro` (faster for short keys).
- Guard the `PtrVector` log-mode size invariant (power-of-two) with an assert.
- `server_family.cc`: bucket sizing uses `sizeof(uint64_t)` (OAHEntry is now a thin accessor).
- Tests: add PtrVector linear-then-double growth and destructor-coverage cases.
