### PR TITLE
fix(facade): bookkeeping in V2 connection.

### DIFF
--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -2686,6 +2686,7 @@ bool Connection::SquashPipelineV2() {
   conn_stats.pipeline_dispatch_calls++;
   conn_stats.pipeline_dispatch_commands += squashed;
   local_stats_.cmds += squashed;
+  last_interaction_ = time(nullptr);
   return true;
 }
 
@@ -2795,6 +2796,7 @@ bool Connection::ExecuteBatch() {
     if (is_head)
       conn_stats.pipeline_dispatch_calls++;
     local_stats_.cmds++;
+    last_interaction_ = time(nullptr);
 
     if (cmd->IsDeferredReply()) {
       AdvanceToExecute();

--- a/src/facade/dragonfly_connection.cc
+++ b/src/facade/dragonfly_connection.cc
@@ -2685,6 +2685,7 @@ bool Connection::SquashPipelineV2() {
 
   conn_stats.pipeline_dispatch_calls++;
   conn_stats.pipeline_dispatch_commands += squashed;
+  local_stats_.cmds += squashed;
   return true;
 }
 
@@ -2793,6 +2794,7 @@ bool Connection::ExecuteBatch() {
     conn_stats.pipeline_dispatch_commands++;
     if (is_head)
       conn_stats.pipeline_dispatch_calls++;
+    local_stats_.cmds++;
 
     if (cmd->IsDeferredReply()) {
       AdvanceToExecute();


### PR DESCRIPTION
- local_stats_.cmds was not incremented in SquashPipelineV2() and ExecuteBatch().
- last_interaction_ was not updated in SquashPipelineV2() and ExecuteBatch().