### PR TITLE
feat(rdb): learn zstd dict and compress lists during load

### DIFF
--- a/src/core/qlist.cc
+++ b/src/core/qlist.cc
@@ -1633,6 +1633,27 @@ void QList::CompressWithZstdDict() {
   }
 }
 
+void QList::CompressAfterLoad() {
+  // Mirrors the ZSTD branch of CoolOff(), but runs in one shot after a bulk load
+  // instead of being driven incrementally by per-element pushes (which never
+  // happen during AppendListpack/AppendPlain).
+  if (zstd_threshold_ == 0 || AllowLZFCompression())
+    return;
+
+  if (!tl_zstd_dict) {
+    // No thread-local dictionary yet. Train one from this list's data, but only
+    // if the list is large enough to be worth it.
+    if (dict_learning_failed_ || malloc_size_ < zstd_threshold_ || len_ < 2)
+      return;
+    if (!TrainZstdDict())
+      return;
+  }
+
+  // A dictionary exists (trained here or by another list on this thread).
+  CompressWithZstdDict();
+  dict_bulk_finished_ = 1;
+}
+
 bool QList::CompressNodeWithDict(Node* node) {
   DCHECK(tl_zstd_dict);
 

--- a/src/core/qlist.h
+++ b/src/core/qlist.h
@@ -275,6 +275,14 @@ class QList {
     zstd_threshold_ = threshold;
   }
 
+  // Trains a thread-local ZSTD dictionary (if not yet trained) and bulk-compresses
+  // the list's interior nodes. Intended to be called once after a list has been
+  // bulk-populated via AppendListpack/AppendPlain (e.g. during RDB/replication load),
+  // where the per-push CoolOff() compression hook does not run. No-op unless
+  // set_compr_threshold() was given a non-zero value and LZF depth-compression is
+  // disabled.
+  void CompressAfterLoad();
+
   // Enable tiered storage.
   void EnableTiering(const TieringParams& params) {
     tiering_enabled_ = 1;

--- a/src/core/qlist_test.cc
+++ b/src/core/qlist_test.cc
@@ -1150,7 +1150,121 @@ class QListZstdTest : public ::testing::Test {
       ql.Push(entry, QList::TAIL);
     }
   }
+
+  // Builds a single listpack node holding `count` Celery-like JSON entries,
+  // mimicking a quicklist node as it would arrive from an RDB stream.
+  uint8_t* BuildCeleryListpack(unsigned count, unsigned start_id) {
+    uint8_t* lp = lpNew(0);
+    for (unsigned i = 0; i < count; ++i) {
+      string id = to_string(start_id + i);
+      string entry =
+          "{\"body\": \"W10=\", \"content-encoding\": \"utf-8\", "
+          "\"content-type\": \"application/json\", "
+          "\"headers\": {\"lang\": \"py\", \"task\": \"process_job\", "
+          "\"id\": \"b3e4b923-8a77-4053-aff0-" +
+          id + "\", \"argsrepr\": \"('job" + id + "',)\"}}";
+      lp = lpAppend(lp, (uint8_t*)entry.data(), entry.size());
+    }
+    return lp;
+  }
 };
+
+TEST_F(QListZstdTest, CompressAfterLoad) {
+  // Simulate an RDB/replication load that finished before any dictionary was
+  // trained (e.g. the threshold was reached only on the final node). We model
+  // that by appending all nodes with the threshold disabled, so no compression
+  // happens incrementally, then enabling it and running the post-load pass.
+  QList ql(-1, 0);  // compress=0 so the ZSTD dict path is active (LZF disabled)
+
+  constexpr unsigned kNodes = 20;
+  constexpr unsigned kEntriesPerNode = 30;
+  for (unsigned n = 0; n < kNodes; ++n) {
+    ql.AppendListpack(BuildCeleryListpack(kEntriesPerNode, 100000 + n * kEntriesPerNode));
+  }
+  ASSERT_GE(ql.node_count(), 3u);
+
+  // Nothing is compressed yet - the threshold was not set during the load.
+  unsigned compressed_before = 0;
+  for (const QList::Node* node = ql.Head(); node; node = node->next) {
+    compressed_before += node->IsCompressed();
+  }
+  EXPECT_EQ(compressed_before, 0u);
+
+  ql.set_compr_threshold(1);
+  auto initial_compressions = QList::stats.zstd_dict_compressions;
+  ql.CompressAfterLoad();
+
+  // Interior nodes are now compressed; head and tail remain raw.
+  EXPECT_GT(QList::stats.zstd_dict_compressions, initial_compressions);
+  EXPECT_EQ(ql.Head()->encoding, QUICKLIST_NODE_ENCODING_RAW);
+  EXPECT_EQ(ql.Tail()->encoding, QUICKLIST_NODE_ENCODING_RAW);
+
+  unsigned compressed_after = 0;
+  for (const QList::Node* node = ql.Head(); node; node = node->next) {
+    compressed_after += node->IsCompressed();
+  }
+  EXPECT_GT(compressed_after, 0u);
+
+  // All entries remain readable after compression.
+  unsigned count = 0;
+  ql.Iterate(
+      [&](const QList::Entry& e) {
+        EXPECT_GT(e.view().size(), 50u);
+        ++count;
+        return true;
+      },
+      0, -1);
+  EXPECT_EQ(count, kNodes * kEntriesPerNode);
+}
+
+TEST_F(QListZstdTest, CompressAfterLoadPlainNode) {
+  // Plain (single large element) interior nodes are also covered: they are
+  // included in dictionary training and compressed, and decompressed on read.
+  QList ql(-1, 0);
+
+  // Head and tail listpacks keep the plain node interior.
+  ql.AppendListpack(BuildCeleryListpack(30, 100000));
+
+  // A large, highly compressible plain element.
+  string plain(16384, 'a');
+  for (size_t i = 0; i < plain.size(); i += 7)
+    plain[i] = 'b';
+  uint8_t* data = (uint8_t*)zmalloc(plain.size());
+  ::memcpy(data, plain.data(), plain.size());
+  ql.AppendPlain(data, plain.size());
+
+  ql.AppendListpack(BuildCeleryListpack(30, 200000));
+  ASSERT_EQ(ql.node_count(), 3u);
+
+  const QList::Node* plain_node = ql.Head()->next;
+  ASSERT_EQ(plain_node->container, QUICKLIST_NODE_CONTAINER_PLAIN);
+
+  ql.set_compr_threshold(1);
+  ql.CompressAfterLoad();
+
+  // The interior plain node is now ZSTD-compressed.
+  EXPECT_EQ(plain_node->encoding, QLIST_NODE_ENCODING_ZSTD);
+
+  // It reads back intact (decompressed on access).
+  auto it = ql.GetIterator(30);  // index 30 == the plain element
+  ASSERT_TRUE(it.Valid());
+  EXPECT_EQ(it.Get().view(), plain);
+}
+
+TEST_F(QListZstdTest, CompressAfterLoadDisabled) {
+  // Without a threshold, CompressAfterLoad must be a no-op.
+  QList ql(-1, 0);
+  for (unsigned n = 0; n < 10; ++n) {
+    ql.AppendListpack(BuildCeleryListpack(30, 100000 + n * 30));
+  }
+
+  auto initial_compressions = QList::stats.zstd_dict_compressions;
+  ql.CompressAfterLoad();
+  EXPECT_EQ(QList::stats.zstd_dict_compressions, initial_compressions);
+  for (const QList::Node* node = ql.Head(); node; node = node->next) {
+    EXPECT_EQ(node->encoding, QUICKLIST_NODE_ENCODING_RAW);
+  }
+}
 
 TEST_F(QListZstdTest, CompressAndReadAll) {
   QList ql(-1, 0);            // 4KB nodes, no depth-based compression (ZSTD dict replaces it)

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -66,6 +66,7 @@ extern "C" {
 
 ABSL_DECLARE_FLAG(int32_t, list_max_listpack_size);
 ABSL_DECLARE_FLAG(int32_t, list_compress_depth);
+ABSL_DECLARE_FLAG(uint32_t, list_experimental_zstd_dict_threshold);
 ABSL_DECLARE_FLAG(uint32_t, dbnum);
 ABSL_FLAG(bool, deserialize_hnsw_index, false, "Deserialize HNSW vector index graph structure");
 ABSL_FLAG(bool, rdb_load_dry_run, false, "Dry run RDB load without applying changes");
@@ -602,6 +603,10 @@ void RdbLoaderBase::OpaqueObjLoader::CreateList(const LoadTrace* ltrace) {
   } else {
     qlv2 = CompactObj::AllocateMR<QList>(GetFlag(FLAGS_list_max_listpack_size),
                                          GetFlag(FLAGS_list_compress_depth));
+    if (uint32_t zstd_thresh = GetFlag(FLAGS_list_experimental_zstd_dict_threshold);
+        zstd_thresh > 0) {
+      qlv2->set_compr_threshold(zstd_thresh);
+    }
   }
 
   auto cleanup = absl::Cleanup([&] {
@@ -671,6 +676,12 @@ void RdbLoaderBase::OpaqueObjLoader::CreateList(const LoadTrace* ltrace) {
   }
 
   std::move(cleanup).Cancel();
+
+  // Learn a thread-local ZSTD dictionary from the loaded data and compress interior
+  // nodes if the list is large and compressible. Controlled by
+  // --list_experimental_zstd_dict_threshold; a no-op when the flag is 0. Runs per
+  // chunk for chunked lists, so newly appended interior nodes get compressed too.
+  qlv2->CompressAfterLoad();
 
   if (!config_.append) {
     // Try to convert to listpack if it's a single-node quicklist, but only if there is no more data


### PR DESCRIPTION
## Summary
`--list_experimental_zstd_dict_threshold` enabled ZSTD dictionary compression for list *push* operations, but not when *loading* a dataset (RDB/replication). This wires up the loading path so a dataset with highly compressible lists learns a dictionary and gets compressed during load.

## Changes
- `rdb_load.cc`: declare the flag and set the compression threshold on the `QList` built in `CreateList`; call `CompressAfterLoad()` after the list is populated (runs per chunk for chunked lists).
- `qlist.{h,cc}`: add `QList::CompressAfterLoad()` — trains a thread-local dictionary (if needed) and bulk-compresses interior nodes in one shot, mirroring the ZSTD branch of `CoolOff()`. Needed because `AppendListpack`/`AppendPlain` do not drive the per-push compression hook, and it guarantees full compression even when the dictionary trains on the last node.
- `qlist_test.cc`: tests for listpack interior nodes, plain interior nodes (also covered + decompressed correctly on read), and the disabled (flag=0) no-op case.

## Testing
`./qlist_test --gtest_filter="QListZstdTest.*"` — 12/12 pass.