### PR TITLE
fix: SINTERCARD crash with zero keys

### DIFF
--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -1472,6 +1472,9 @@ void CmdSInterCard(CmdArgParser parser, CommandContext* cmd_cntx) {
   if (parser.HasError())
     return cmd_cntx->SendError(parser.TakeError().MakeReply());
 
+  if (num_keys == 0)
+    return cmd_cntx->SendError(OpStatus::AT_LEAST_ONE_KEY);
+
   unsigned limit = 0;
   // num_keys has already been consumed, so args holds only the keys and an optional LIMIT clause.
   auto args = parser.UnparsedArgs();

--- a/src/server/set_family_test.cc
+++ b/src/server/set_family_test.cc
@@ -153,6 +153,8 @@ TEST_F(SetFamilyTest, SInterCard) {
   EXPECT_THAT(resp, ErrArg("limit can't be negative"));
   resp = Run({"sintercard", "2", "s1"});
   EXPECT_THAT(resp, ErrArg("syntax error"));
+  resp = Run({"sintercard", "0", "LIMIT", "0"});
+  EXPECT_THAT(resp, ErrArg("at least 1 input key is needed"));
   resp = Run({"sintercard", "-1", "s1"});
   EXPECT_THAT(resp, ErrArg("value is not an integer or out of range"));
 }


### PR DESCRIPTION
Fixes a crash in SINTERCARD 0 LIMIT 0 where the command scheduled a transaction with no keys and hit unique_shard_cnt_ > 0u.

Changes:
 - Reject SINTERCARD with numkeys=0 before scheduling the transaction.
 - Add a regression unit test for the fuzz-discovered crash case.

Fixes: #7735