### PR TITLE
server: Check for continuation tx when skipping on running tx

### DIFF
--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -618,10 +618,16 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
   // If another transaction is currently running on this shard (e.g. an inlined tx preempted
   // on the connection fiber), we must not run any callbacks to avoid interleaving.
   if (running_tx_) {
-    // The transaction (if any) if armed, must be in the txq so a future PollExecution picks it up.
+    auto print_tx = [&](const Transaction* t, string_view name) {
+      return absl::StrFormat("%s=%s", name, t ? t->DebugId(sid) : "null");
+    };
+    // The transaction, if non-null and armed, must either be the continuation tx or be in the txq
+    // or so a future PollExecution picks it up.
     DCHECK(trans == nullptr || !trans->DEBUG_IsArmedInShard(sid) ||
-           trans->DEBUG_GetTxqPosInShard(sid) != TxQueue::kEnd)
-        << context << " " << (trans ? trans->DebugId(sid) : "trans=nullptr");
+           trans->DEBUG_GetTxqPosInShard(sid) != TxQueue::kEnd || trans == continuation_trans_)
+        << context << " " << print_tx(trans, "trans") << " "
+        << print_tx(continuation_trans_, "continuation_trans") << " "
+        << print_tx(running_tx_, "running_tx");
     return;
   }
 

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -621,7 +621,7 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
     // The transaction (if any) if armed, must be in the txq so a future PollExecution picks it up.
     DCHECK(trans == nullptr || !trans->DEBUG_IsArmedInShard(sid) ||
            trans->DEBUG_GetTxqPosInShard(sid) != TxQueue::kEnd)
-        << context << " " << trans->DebugId();
+        << context << " " << (trans ? trans->DebugId(sid) : "trans=nullptr");
     return;
   }
 

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -529,7 +529,7 @@ string Transaction::DebugId(std::optional<ShardId> sid) const {
                     ",is_armed=", DEBUG_IsArmedInShard(*sid),
                     ",txqpos[]=", shard_data_[SidToId(*sid)].pq_pos);
   }
-  absl::StrAppend(&res, "}");
+  absl::StrAppend(&res, "}}");
   return res;
 }
 


### PR DESCRIPTION

In PollExecution if a running tx is found, then the current input tx run
is skipped. There is a check that the tx must be in queue so that it is
eventually run later.

The same check should also account for continuation transaction too, as
that is also run in spite of not being in the queue.

FIXES https://github.com/dragonflydb/dragonfly/issues/7698