### PR TITLE
fix(cms): avoid vector allocation in ParseMergeArgs and update helio

### DIFF
--- a/src/server/cms_family.cc
+++ b/src/server/cms_family.cc
@@ -308,7 +308,7 @@ struct CmsShardData {
 
 struct CmsMergeArgs {
   string_view dest_key;
-  vector<string_view> src_keys;
+  CmdArgParser::Range src_keys;
   vector<int64_t> weights;
 };
 
@@ -321,7 +321,7 @@ bool ParseMergeArgs(CmdArgParser parser, RedisReplyBuilder* rb, CmsMergeArgs* ou
     rb->SendError(err.MakeReply());
     return false;
   }
-  out->src_keys.assign(keys.begin(), keys.end());
+  out->src_keys = keys;
   uint32_t num_keys = keys.size();
 
   if (!parser.HasNext()) {

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -158,7 +158,7 @@ ABSL_FLAG(bool, managed_service_info, false,
 ABSL_FLAG(string, availability_zone, "",
           "server availability zone, used by clients to read from local-zone replicas");
 
-ABSL_FLAG(bool, keep_legacy_memory_metrics, true, "legacy metrics format");
+ABSL_FLAG(bool, keep_legacy_memory_metrics, false, "legacy metrics format");
 // TODO deprecate when flipped in production
 ABSL_FLAG(bool, replicaof_no_one_start_journal, true,
           "when set, preserves journal offsets after REPLICAOF NO ONE");


### PR DESCRIPTION
* removes redundant allocation from ParseMergeArgs in hset_family
* pulls latest helio
* flip keep_legacy_memory_metrics flag