### PR TITLE
fix: Instantiate SendLongArr for long long

### DIFF
--- a/src/facade/reply_builder.cc
+++ b/src/facade/reply_builder.cc
@@ -504,6 +504,7 @@ template <typename I> void RedisReplyBuilder::SendLongArr(absl::Span<const I> lo
 }
 
 template void RedisReplyBuilder::SendLongArr<long>(absl::Span<const long>);
+template void RedisReplyBuilder::SendLongArr<long long>(absl::Span<const long long>);
 template void RedisReplyBuilder::SendLongArr<int32_t>(absl::Span<const int32_t>);
 template void RedisReplyBuilder::SendLongArr<uint32_t>(absl::Span<const uint32_t>);
 template void RedisReplyBuilder::SendLongArr<uint64_t>(absl::Span<const uint64_t>);


### PR DESCRIPTION
 Fix the macOS arm64 link failure by explicitly instantiating `RedisReplyBuilder::SendLongArr<long long>`.
 
 On Linux, `int64_t` maps to `long`, but on macOS arm64 it maps to `long long`. The hash field TTL commands return `vector<int64_t>`, so macOS needs the additional template instantiation.
 
Changes: 
 - Add explicit `SendLongArr<long long>` instantiation in `reply_builder.cc`
 
 Checked here: https://github.com/dragonflydb/dragonfly/actions/runs/28429796260/job/84241438653