### PR TITLE
refactor: improve INFO performance

### DIFF
--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -351,4 +351,20 @@ absl::flat_hash_map<std::string, hdr_histogram*> CommandRegistry::LatencyMap() c
   return cmd_latencies;
 }
 
+absl::flat_hash_map<std::string, CmdCallStats> CommandRegistry::NamedCallStats(
+    const std::vector<CmdCallStats>& merged) const {
+  absl::flat_hash_map<std::string, CmdCallStats> res;
+  if (merged.empty())
+    return res;
+  DCHECK_EQ(merged.size(), cmd_map_.size());
+  size_t i = 0;
+  for (const auto& k_v : cmd_map_) {
+    const CmdCallStats& s = merged[i++];
+    if (s.first == 0)
+      continue;
+    res[absl::AsciiStrToLower(k_v.second.name())] = s;
+  }
+  return res;
+}
+
 }  // namespace dfly

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -354,9 +354,11 @@ absl::flat_hash_map<std::string, hdr_histogram*> CommandRegistry::LatencyMap() c
 absl::flat_hash_map<std::string, CmdCallStats> CommandRegistry::NamedCallStats(
     const std::vector<CmdCallStats>& merged) const {
   absl::flat_hash_map<std::string, CmdCallStats> res;
-  if (merged.empty())
+  if (merged.size() != cmd_map_.size()) {
+    LOG_IF(DFATAL, !merged.empty())
+        << "cmd_call_stats size " << merged.size() << " != registry size " << cmd_map_.size();
     return res;
-  DCHECK_EQ(merged.size(), cmd_map_.size());
+  }
   size_t i = 0;
   for (const auto& k_v : cmd_map_) {
     const CmdCallStats& s = merged[i++];

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -339,18 +339,16 @@ class CommandRegistry {
     return cmd_map_.size();
   }
 
-  // Copies proactor `thread_index`'s own per-command counters into `out` (>= size() entries);
-  // reads only this proactor's cells, so it is race-free inside the GetMetrics fan-out.
+  // `out` must hold >= size() entries. Reads only this proactor's own cells, so it is race-free
+  // when run concurrently inside the GetMetrics fan-out.
   void CollectThreadCallStats(unsigned thread_index, CmdCallStats* out) const {
     size_t i = 0;
     for (const auto& k_v : cmd_map_)
       out[i++] = k_v.second.GetStats(thread_index);
   }
 
-  // Maps the merged per-command counters (indexed by registry order, see CollectThreadCallStats)
-  // to lowercase command names, skipping zero-call commands. `merged` is either empty (stats were
-  // not collected) or sized to the whole registry — cmd_map_ is fixed after startup, so index i
-  // maps to the same command it was collected for.
+  // Maps the merged per-command counters (registry order, see CollectThreadCallStats) to lowercase
+  // names, skipping zero-call commands. `merged` is empty (not collected) or whole-registry sized.
   absl::flat_hash_map<std::string, CmdCallStats> NamedCallStats(
       const std::vector<CmdCallStats>& merged) const;
 

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -6,12 +6,16 @@
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
+#include <absl/strings/ascii.h>
 #include <absl/types/span.h>
 
 #include <functional>
 #include <optional>
+#include <string>
+#include <vector>
 
 #include "base/function2.hpp"
+#include "base/logging.h"
 #include "facade/cmd_arg_parser.h"
 #include "facade/command_id.h"
 #include "facade/facade_types.h"
@@ -91,8 +95,8 @@ class CommandId : public facade::CommandId {
  public:
   using CmdArgList = facade::CmdArgList;
 
-  // NOTICE: name must be a literal string, otherwise metrics break! (see cmd_stats_map in
-  // server_state.h)
+  // NOTICE: name must be a literal string, otherwise metrics break! (see cmd_call_stats in
+  // metrics.h)
   CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first_key, int8_t last_key,
             std::optional<uint32_t> acl_categories = std::nullopt);
 
@@ -333,14 +337,36 @@ class CommandRegistry {
     }
   }
 
-  void MergeCallStats(unsigned thread_index,
-                      std::function<void(std::string_view, const CmdCallStats&)> cb) const {
+  size_t size() const {
+    return cmd_map_.size();
+  }
+
+  // Copies proactor `thread_index`'s own per-command counters into `out` (>= size() entries);
+  // reads only this proactor's cells, so it is race-free inside the GetMetrics fan-out.
+  void CollectThreadCallStats(unsigned thread_index, CmdCallStats* out) const {
+    size_t i = 0;
+    for (const auto& k_v : cmd_map_)
+      out[i++] = k_v.second.GetStats(thread_index);
+  }
+
+  // Maps the merged per-command counters (indexed by registry order, see CollectThreadCallStats)
+  // to lowercase command names, skipping zero-call commands. `merged` is either empty (stats were
+  // not collected) or sized to the whole registry — cmd_map_ is fixed after startup, so index i
+  // maps to the same command it was collected for.
+  absl::flat_hash_map<std::string, CmdCallStats> NamedCallStats(
+      const std::vector<CmdCallStats>& merged) const {
+    absl::flat_hash_map<std::string, CmdCallStats> res;
+    if (merged.empty())
+      return res;
+    DCHECK_EQ(merged.size(), cmd_map_.size());
+    size_t i = 0;
     for (const auto& k_v : cmd_map_) {
-      auto src = k_v.second.GetStats(thread_index);
-      if (src.first == 0)
+      const CmdCallStats& s = merged[i++];
+      if (s.first == 0)
         continue;
-      cb(k_v.second.name(), src);
+      res[absl::AsciiStrToLower(k_v.second.name())] = s;
     }
+    return res;
   }
 
   void StartFamily(std::optional<uint32_t> acl_category = std::nullopt);

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -6,7 +6,6 @@
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
-#include <absl/strings/ascii.h>
 #include <absl/types/span.h>
 
 #include <functional>
@@ -15,7 +14,6 @@
 #include <vector>
 
 #include "base/function2.hpp"
-#include "base/logging.h"
 #include "facade/cmd_arg_parser.h"
 #include "facade/command_id.h"
 #include "facade/facade_types.h"
@@ -354,20 +352,7 @@ class CommandRegistry {
   // not collected) or sized to the whole registry — cmd_map_ is fixed after startup, so index i
   // maps to the same command it was collected for.
   absl::flat_hash_map<std::string, CmdCallStats> NamedCallStats(
-      const std::vector<CmdCallStats>& merged) const {
-    absl::flat_hash_map<std::string, CmdCallStats> res;
-    if (merged.empty())
-      return res;
-    DCHECK_EQ(merged.size(), cmd_map_.size());
-    size_t i = 0;
-    for (const auto& k_v : cmd_map_) {
-      const CmdCallStats& s = merged[i++];
-      if (s.first == 0)
-        continue;
-      res[absl::AsciiStrToLower(k_v.second.name())] = s;
-    }
-    return res;
-  }
+      const std::vector<CmdCallStats>& merged) const;
 
   void StartFamily(std::optional<uint32_t> acl_category = std::nullopt);
 

--- a/src/server/dragonfly_test.cc
+++ b/src/server/dragonfly_test.cc
@@ -1068,7 +1068,7 @@ TEST_F(DflyCommandAliasTest, Aliasing) {
   EXPECT_EQ(Run({"___ping"}), "PONG");
 
   Metrics metrics = GetMetrics();
-  const auto& stats = metrics.cmd_stats_map;
+  auto stats = service_->mutable_registry()->NamedCallStats(metrics.cmd_call_stats);
 
   EXPECT_THAT(stats, Contains(Pair("___set", Key(1))));
   EXPECT_THAT(stats, Contains(Pair("set", Key(1))));
@@ -1081,10 +1081,11 @@ TEST_F(DflyCommandAliasTest, Aliasing) {
   EXPECT_THAT(Run({"exec"}), RespElementsAre("OK"));
 
   metrics = GetMetrics();
-  EXPECT_THAT(metrics.cmd_stats_map, Contains(Pair("___set", Key(2))));
-  EXPECT_THAT(metrics.cmd_stats_map, Contains(Pair("set", Key(1))));
-  EXPECT_THAT(metrics.cmd_stats_map, Contains(Pair("multi", Key(1))));
-  EXPECT_THAT(metrics.cmd_stats_map, Contains(Pair("exec", Key(1))));
+  stats = service_->mutable_registry()->NamedCallStats(metrics.cmd_call_stats);
+  EXPECT_THAT(stats, Contains(Pair("___set", Key(2))));
+  EXPECT_THAT(stats, Contains(Pair("set", Key(1))));
+  EXPECT_THAT(stats, Contains(Pair("multi", Key(1))));
+  EXPECT_THAT(stats, Contains(Pair("exec", Key(1))));
 }
 
 TEST_F(DflyCommandAliasTest, AliasesShareHistogramPtr) {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -2802,7 +2802,7 @@ void Service::Command(CmdArgList args, CommandContext* cmd_cntx) {
 VarzValue::Map Service::GetVarzStats() {
   VarzValue::Map res;
 
-  Metrics m = server_family_.GetMetrics(&namespaces->GetDefaultNamespace());
+  Metrics m = server_family_.GetMetrics(&namespaces->GetDefaultNamespace(), MetricsCollectOpts{});
   DbStats db_stats;
   for (const auto& s : m.db_stats) {
     db_stats += s;

--- a/src/server/metrics.cc
+++ b/src/server/metrics.cc
@@ -110,7 +110,7 @@ void AppendPipelineLatencySummary(string_view name, string_view help, const base
 
 }  // namespace
 
-void Metrics::Print(uint64_t uptime, CommandRegistry* registry, DflyCmd* dfly_cmd,
+void Metrics::Print(uint64_t uptime, const CommandRegistry* registry, DflyCmd* dfly_cmd,
                     util::http::StringResponse* resp, bool legacy) {
   bool is_master = ServerState::tlocal()->is_master;
   const Metrics& m = *this;
@@ -761,7 +761,6 @@ void Metrics::Merge(const Metrics& src) {
   for (const auto& [k, v] : src.connections_lib_name_ver_map)
     connections_lib_name_ver_map[k] += v;
 
-  // Per-command counters: sum element-wise by command index.
   if (src.cmd_call_stats.size() > cmd_call_stats.size())
     cmd_call_stats.resize(src.cmd_call_stats.size());
   for (size_t i = 0; i < src.cmd_call_stats.size(); ++i) {
@@ -770,8 +769,9 @@ void Metrics::Merge(const Metrics& src) {
   }
 }
 
-void Metrics::InitFromThread(Namespace* ns, CommandRegistry* registry, unsigned proactor_index,
-                             const MetricsCollectOpts& opts, DflyCmd* dfly_cmd) {
+void Metrics::InitFromThread(Namespace* ns, const CommandRegistry* registry,
+                             unsigned proactor_index, const MetricsCollectOpts& opts,
+                             DflyCmd* dfly_cmd) {
   static_assert(
       sizeof(Metrics) == sizeof(SliceEvents) + sizeof(std::vector<DbStats>) +
                              sizeof(EngineShard::Stats) + sizeof(facade::FacadeStats) +

--- a/src/server/metrics.cc
+++ b/src/server/metrics.cc
@@ -110,8 +110,8 @@ void AppendPipelineLatencySummary(string_view name, string_view help, const base
 
 }  // namespace
 
-void Metrics::Print(uint64_t uptime, DflyCmd* dfly_cmd, util::http::StringResponse* resp,
-                    bool legacy) {
+void Metrics::Print(uint64_t uptime, CommandRegistry* registry, DflyCmd* dfly_cmd,
+                    util::http::StringResponse* resp, bool legacy) {
   bool is_master = ServerState::tlocal()->is_master;
   const Metrics& m = *this;
 
@@ -441,19 +441,20 @@ void Metrics::Print(uint64_t uptime, DflyCmd* dfly_cmd, util::http::StringRespon
                             MetricType::GAUGE, &resp->body());
 
   // Command stats
-  if (!m.cmd_stats_map.empty()) {
+  auto cmd_stats = registry->NamedCallStats(m.cmd_call_stats);
+  if (!cmd_stats.empty()) {
     string command_metrics;
 
     AppendMetricHeader("commands_total", "Total number of commands executed", MetricType::COUNTER,
                        &command_metrics);
-    for (const auto& [name, stat] : m.cmd_stats_map) {
+    for (const auto& [name, stat] : cmd_stats) {
       const auto calls = stat.first;
       AppendMetricValue("commands_total", calls, {"cmd"}, {name}, &command_metrics);
     }
 
     AppendMetricHeader("commands_duration_seconds", "Duration of commands in seconds",
                        MetricType::COUNTER, &command_metrics);
-    for (const auto& [name, stat] : m.cmd_stats_map) {
+    for (const auto& [name, stat] : cmd_stats) {
       const double duration_seconds = stat.second * 1e-6;
       AppendMetricValue("commands_duration_seconds", duration_seconds, {"cmd"}, {name},
                         &command_metrics);
@@ -707,7 +708,7 @@ void Metrics::Merge(const Metrics& src) {
                              sizeof(TieredStats) + sizeof(SearchStats) +
                              sizeof(ServerState::Stats) + sizeof(PeakStats) + sizeof(QList::Stats) +
                              sizeof(ReplicationMemoryStats) + sizeof(InterpreterManager::Stats) +
-                             sizeof(std::map<std::string, std::pair<uint64_t, uint64_t>>) +
+                             sizeof(std::vector<std::pair<uint64_t, uint64_t>>) +
                              sizeof(absl::flat_hash_map<std::string, uint64_t>) +
                              sizeof(std::optional<Metrics::ReplicaInfo>) + sizeof(LoadingStats) +
                              sizeof(absl::flat_hash_map<std::string, hdr_histogram*>) +
@@ -759,22 +760,25 @@ void Metrics::Merge(const Metrics& src) {
   // Map merges.
   for (const auto& [k, v] : src.connections_lib_name_ver_map)
     connections_lib_name_ver_map[k] += v;
-  for (const auto& [name, stat] : src.cmd_stats_map) {
-    auto& [calls, sum] = cmd_stats_map[name];
-    calls += stat.first;
-    sum += stat.second;
+
+  // Per-command counters: sum element-wise by command index.
+  if (src.cmd_call_stats.size() > cmd_call_stats.size())
+    cmd_call_stats.resize(src.cmd_call_stats.size());
+  for (size_t i = 0; i < src.cmd_call_stats.size(); ++i) {
+    cmd_call_stats[i].first += src.cmd_call_stats[i].first;
+    cmd_call_stats[i].second += src.cmd_call_stats[i].second;
   }
 }
 
 void Metrics::InitFromThread(Namespace* ns, CommandRegistry* registry, unsigned proactor_index,
-                             bool collect_replication_memory, DflyCmd* dfly_cmd) {
+                             const MetricsCollectOpts& opts, DflyCmd* dfly_cmd) {
   static_assert(
       sizeof(Metrics) == sizeof(SliceEvents) + sizeof(std::vector<DbStats>) +
                              sizeof(EngineShard::Stats) + sizeof(facade::FacadeStats) +
                              sizeof(TieredStats) + sizeof(SearchStats) +
                              sizeof(ServerState::Stats) + sizeof(PeakStats) + sizeof(QList::Stats) +
                              sizeof(ReplicationMemoryStats) + sizeof(InterpreterManager::Stats) +
-                             sizeof(std::map<std::string, std::pair<uint64_t, uint64_t>>) +
+                             sizeof(std::vector<std::pair<uint64_t, uint64_t>>) +
                              sizeof(absl::flat_hash_map<std::string, uint64_t>) +
                              sizeof(std::optional<Metrics::ReplicaInfo>) + sizeof(LoadingStats) +
                              sizeof(absl::flat_hash_map<std::string, hdr_histogram*>) +
@@ -825,7 +829,7 @@ void Metrics::InitFromThread(Namespace* ns, CommandRegistry* registry, unsigned 
       lsn_buffer_bytes = journal::LsnBufferBytes();
     }
 
-    if (collect_replication_memory)
+    if (opts.replication_memory)
       replication_stats = dfly_cmd->GetReplicationMemoryStats(shard);
   }
 
@@ -845,12 +849,12 @@ void Metrics::InitFromThread(Namespace* ns, CommandRegistry* registry, unsigned 
     oldest_pending_send_ts = send_list.front().timestamp_cycles;
   }
 
-  auto cmd_stat_cb = [this](std::string_view name, const CmdCallStats& stat) {
-    auto& [calls, sum] = cmd_stats_map[absl::AsciiStrToLower(name)];
-    calls += stat.first;
-    sum += stat.second;
-  };
-  registry->MergeCallStats(proactor_index, cmd_stat_cb);
+  // Skip when no rendered section needs per-command stats — leaving the vector empty makes the
+  // later Merge and NamedCallStats no-ops.
+  if (opts.cmd_stats) {
+    cmd_call_stats.resize(registry->size());
+    registry->CollectThreadCallStats(proactor_index, cmd_call_stats.data());
+  }
 
   interned_string_stats = GetInternedStringStats();
 }

--- a/src/server/metrics.h
+++ b/src/server/metrics.h
@@ -8,7 +8,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <map>
 #include <optional>
 #include <string>
 #include <utility>
@@ -30,6 +29,14 @@ namespace dfly {
 
 class CommandRegistry;
 class DflyCmd;
+
+// Selects which expensive parts of GetMetrics to collect. All default true (collect everything);
+// INFO narrows them to the requested sections so common calls skip work they never render.
+struct MetricsCollectOpts {
+  bool replication_memory = true;
+  bool cmd_stats = true;
+  bool cmd_latency = true;
+};
 
 struct ReplicationMemoryStats {
   size_t streamer_buf_capacity_bytes = 0;  // total capacities of streamer buffers
@@ -108,8 +115,9 @@ struct Metrics {
 
   InterpreterManager::Stats lua_stats;
 
-  // command call frequencies (count, aggregated latency in usec).
-  std::map<std::string, std::pair<uint64_t, uint64_t>> cmd_stats_map;
+  // Per-command counters indexed by dense command id (registry order); summed across threads in
+  // Merge, mapped to names at print time. Use CommandRegistry to map indices to names.
+  std::vector<std::pair<uint64_t, uint64_t>> cmd_call_stats;
 
   absl::flat_hash_map<std::string, uint64_t> connections_lib_name_ver_map;
 
@@ -133,15 +141,15 @@ struct Metrics {
 
   acl::UserRegistry::AclStats acl_stats;
 
-  // Collects all thread-local / per-shard stats on the current proactor thread.
   void InitFromThread(Namespace* ns, CommandRegistry* registry, unsigned proactor_index,
-                      bool collect_replication_memory, DflyCmd* dfly_cmd);
+                      const MetricsCollectOpts& opts, DflyCmd* dfly_cmd);
 
   // Folds `src` into *this. Almost everything sums; tx_queue_len takes the max
   // and oldest_pending_send_ts the min.
   void Merge(const Metrics& src);
 
-  void Print(uint64_t uptime, DflyCmd* dfly_cmd, util::http::StringResponse* resp, bool legacy);
+  void Print(uint64_t uptime, CommandRegistry* registry, DflyCmd* dfly_cmd,
+             util::http::StringResponse* resp, bool legacy);
 };
 
 }  // namespace dfly

--- a/src/server/metrics.h
+++ b/src/server/metrics.h
@@ -115,8 +115,8 @@ struct Metrics {
 
   InterpreterManager::Stats lua_stats;
 
-  // Per-command counters indexed by dense command id (registry order); summed across threads in
-  // Merge, mapped to names at print time. Use CommandRegistry to map indices to names.
+  // Per-command counters indexed by registry order; summed across threads in Merge, mapped to
+  // names at print time via CommandRegistry::NamedCallStats.
   std::vector<std::pair<uint64_t, uint64_t>> cmd_call_stats;
 
   absl::flat_hash_map<std::string, uint64_t> connections_lib_name_ver_map;
@@ -141,14 +141,14 @@ struct Metrics {
 
   acl::UserRegistry::AclStats acl_stats;
 
-  void InitFromThread(Namespace* ns, CommandRegistry* registry, unsigned proactor_index,
+  void InitFromThread(Namespace* ns, const CommandRegistry* registry, unsigned proactor_index,
                       const MetricsCollectOpts& opts, DflyCmd* dfly_cmd);
 
   // Folds `src` into *this. Almost everything sums; tx_queue_len takes the max
   // and oldest_pending_send_ts the min.
   void Merge(const Metrics& src);
 
-  void Print(uint64_t uptime, CommandRegistry* registry, DflyCmd* dfly_cmd,
+  void Print(uint64_t uptime, const CommandRegistry* registry, DflyCmd* dfly_cmd,
              util::http::StringResponse* resp, bool legacy);
 };
 

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -1611,8 +1611,9 @@ void ServerFamily::ConfigureMetrics(util::HttpListenerBase* http_base) {
     StringResponse resp = util::http::MakeStringResponse(boost::beast::http::status::ok);
     util::http::SetMime(util::http::kTextMime, &resp);
     uint64_t uptime = time(NULL) - start_time_;
-    auto metrics = GetMetrics(&namespaces->GetDefaultNamespace());
-    metrics.Print(uptime, dfly_cmd_.get(), &resp, legacy_format_metrics_);
+    auto metrics = GetMetrics(&namespaces->GetDefaultNamespace(), MetricsCollectOpts{});
+    metrics.Print(uptime, service_.mutable_registry(), dfly_cmd_.get(), &resp,
+                  legacy_format_metrics_);
     return send->Invoke(std::move(resp));
   };
 
@@ -1725,7 +1726,7 @@ void ServerFamily::StatsMC(std::string_view section, CommandContext* cmd_ctx) {
   auto kind = ProactorBase::me()->GetKind();
   const char* multiplex_api = (kind == ProactorBase::IOURING) ? "iouring" : "epoll";
 
-  Metrics m = GetMetrics(&namespaces->GetDefaultNamespace());
+  Metrics m = GetMetrics(&namespaces->GetDefaultNamespace(), MetricsCollectOpts{});
   uint64_t uptime = time(NULL) - start_time_;
 
   const uint32_t total_conns =
@@ -2471,7 +2472,7 @@ void ServerFamily::ResetStat(Namespace* ns) {
       });
 }
 
-Metrics ServerFamily::GetMetrics(Namespace* ns, bool collect_replication_memory) const {
+Metrics ServerFamily::GetMetrics(Namespace* ns, const MetricsCollectOpts& opts) const {
   Metrics result;
 
   uint64_t start = absl::GetCurrentTimeNanos();
@@ -2481,9 +2482,9 @@ Metrics ServerFamily::GetMetrics(Namespace* ns, bool collect_replication_memory)
   // per-thread partials are folded into `result` on this thread afterwards.
   std::vector<Metrics> partials(service_.proactor_pool().size());
 
-  auto cb = [&partials, ns, registry = service_.mutable_registry(), collect_replication_memory,
+  auto cb = [&partials, ns, registry = service_.mutable_registry(), &opts,
              dfly_cmd = dfly_cmd_.get()](unsigned index, ProactorBase* pb) {
-    partials[index].InitFromThread(ns, registry, index, collect_replication_memory, dfly_cmd);
+    partials[index].InitFromThread(ns, registry, index, opts, dfly_cmd);
   };
 
   // AwaitBrief (not AwaitFiberOnAll): the callback only reads thread-local/atomic state into
@@ -2539,7 +2540,8 @@ Metrics ServerFamily::GetMetrics(Namespace* ns, bool collect_replication_memory)
   }
 
   result.peak_stats = peak_stats_;
-  result.cmd_latency_map = service_.mutable_registry()->LatencyMap();
+  if (opts.cmd_latency)
+    result.cmd_latency_map = service_.mutable_registry()->LatencyMap();
   result.used_mem_peak = glob_memory_peaks.used.load(memory_order_relaxed);
   result.used_mem_rss_peak = glob_memory_peaks.rss.load(memory_order_relaxed);
 
@@ -2560,8 +2562,12 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
   for (const auto& db_stats : m.db_stats)
     total += db_stats;
 
+  auto section_enabled = [&](string_view name, bool hidden) {
+    return (!hidden && section.empty()) || section == "ALL" || section == name;
+  };
+
   auto should_enter = [&](string_view name, bool hidden = false) {
-    if ((!hidden && section.empty()) || section == "ALL" || section == name) {
+    if (section_enabled(name, hidden)) {
       auto normalized_name = string{name.substr(0, 1)} + absl::AsciiStrToLower(name.substr(1));
       absl::StrAppend(&info, info.empty() ? "" : "\r\n", "# ", normalized_name, "\r\n");
       return true;
@@ -2572,6 +2578,12 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
   auto append = [&info](const absl::AlphaNum& a1, const absl::AlphaNum& a2) {
     absl::StrAppend(&info, a1, ":", a2, "\r\n");
   };
+
+  // Fetch the save controller (it takes save_mu_) only when a section that consults it will
+  // render: MEMORY (also default) or the hidden PERSISTENCE. Shared so INFO ALL locks once.
+  std::shared_ptr<detail::SaveStagesController> save_controller;
+  if (section_enabled("MEMORY", false) || section_enabled("PERSISTENCE", true))
+    save_controller = GetSaveController();
 
   bool show_managed_info = priveleged || !absl::GetFlag(FLAGS_managed_service_info);
 
@@ -2698,8 +2710,8 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
       append("replication_full_sync_buffer_bytes", m.replication_stats.full_sync_buf_bytes);
     }
 
-    if (auto controller_copy = GetSaveController()) {
-      append("save_buffer_bytes", controller_copy->GetSaveBuffersSize());
+    if (save_controller) {
+      append("save_buffer_bytes", save_controller->GetSaveBuffersSize());
     }
   };
 
@@ -2809,10 +2821,10 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
     double perc = 0;
     bool is_saving = false;
     uint32_t curent_durration_sec = 0;
-    if (auto controller_copy = GetSaveController()) {
+    if (save_controller) {
       is_saving = true;
-      curent_durration_sec = controller_copy->GetCurrentSaveDuration();
-      auto res = controller_copy->GetCurrentSnapshotProgress();
+      curent_durration_sec = save_controller->GetCurrentSaveDuration();
+      auto res = save_controller->GetCurrentSnapshotProgress();
       if (res.total_keys != 0) {
         current_snap_keys = res.current_keys;
         total_snap_keys = res.total_keys;
@@ -2925,7 +2937,8 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
     };
 
     vector<pair<string_view, string>> commands;
-    for (const auto& [name, stats] : m.cmd_stats_map) {
+    auto named = service_.mutable_registry()->NamedCallStats(m.cmd_call_stats);
+    for (const auto& [name, stats] : named) {
       const auto calls = stats.first, sum = stats.second;
       commands.push_back(
           {name, absl::StrJoin({absl::StrCat("calls=", calls), absl::StrCat("usec=", sum),
@@ -3033,7 +3046,7 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
 
   if (should_enter("CLUSTER")) {
     append("cluster_enabled", IsClusterEnabledOrEmulated());
-    append("migration_errors_total", service_.cluster_family().MigrationsErrorsCount());
+    append("migration_errors_total", m.migration_errors_total);
     append("total_migrated_keys", m.shard_stats.total_migrated_keys);
   }
 
@@ -3081,25 +3094,32 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
 void ServerFamily::Info(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   std::vector<std::string> sections;
   bool need_metrics{false};  // Save time - do not fetch metrics if we don't need them.
-  bool need_repl_mem{false};
+  // Nothing collected unless a requested section needs it; the default (no-args) INFO is
+  // handled after the loop.
+  MetricsCollectOpts opts{.replication_memory = false, .cmd_stats = false, .cmd_latency = false};
   Metrics metrics;
 
   sections.reserve(cmd_cntx->tail_args().size());
   while (parser.HasNext()) {
     sections.emplace_back(absl::AsciiStrToUpper(parser.Next<string_view>()));
     const auto& section = sections.back();
-    if (!need_metrics && (section != "SERVER") && (section != "REPLICATION")) {
-      need_metrics = true;
-    }
-    // Mirror should_enter()'s MEMORY gate: the section is rendered for an exact
-    // match or for "ALL" (the empty/no-args case is handled below).
-    if (section == "MEMORY" || section == "ALL") {
-      need_repl_mem = true;
-    }
+    need_metrics |= (section != "SERVER") && (section != "REPLICATION");
+
+    // MEMORY needs replication memory; COMMANDSTATS (hidden) needs call stats; LATENCYSTATS needs
+    // latency histograms (also rendered by default INFO, handled below).
+    const bool is_all = section == "ALL";
+    opts.replication_memory |= (section == "MEMORY") || is_all;
+    opts.cmd_stats |= (section == "COMMANDSTATS") || is_all;
+    opts.cmd_latency |= (section == "LATENCYSTATS") || is_all;
   }
 
   if (need_metrics || sections.empty()) {
-    metrics = GetMetrics(cmd_cntx->server_conn_cntx()->ns, need_repl_mem || sections.empty());
+    if (sections.empty()) {
+      // Default INFO renders MEMORY and LATENCYSTATS (but not the hidden COMMANDSTATS).
+      opts.replication_memory = true;
+      opts.cmd_latency = true;
+    }
+    metrics = GetMetrics(cmd_cntx->server_conn_cntx()->ns, opts);
   } else if (!IsMaster()) {
     metrics.replica_side_info = GetReplicaSummary();
   }

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -3094,8 +3094,7 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
 void ServerFamily::Info(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   std::vector<std::string> sections;
   bool need_metrics{false};  // Save time - do not fetch metrics if we don't need them.
-  // Nothing collected unless a requested section needs it; the default (no-args) INFO is
-  // handled after the loop.
+  // Start with nothing; each requested section enables what it needs (default INFO below).
   MetricsCollectOpts opts{.replication_memory = false, .cmd_stats = false, .cmd_latency = false};
   Metrics metrics;
 
@@ -3105,12 +3104,10 @@ void ServerFamily::Info(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
     const auto& section = sections.back();
     need_metrics |= (section != "SERVER") && (section != "REPLICATION");
 
-    // MEMORY needs replication memory; COMMANDSTATS (hidden) needs call stats; LATENCYSTATS needs
-    // latency histograms (also rendered by default INFO, handled below).
     const bool is_all = section == "ALL";
-    opts.replication_memory |= (section == "MEMORY") || is_all;
-    opts.cmd_stats |= (section == "COMMANDSTATS") || is_all;
-    opts.cmd_latency |= (section == "LATENCYSTATS") || is_all;
+    opts.replication_memory |= is_all || (section == "MEMORY");
+    opts.cmd_stats |= is_all || (section == "COMMANDSTATS");
+    opts.cmd_latency |= is_all || (section == "LATENCYSTATS");
   }
 
   if (need_metrics || sections.empty()) {

--- a/src/server/server_family.h
+++ b/src/server/server_family.h
@@ -150,9 +150,8 @@ class ServerFamily {
 
   void ResetStat(Namespace* ns);
 
-  // Pass collect_replication_memory=false to skip the per-shard replication
-  // collection when no consumer (INFO MEMORY / metrics) needs it.
-  Metrics GetMetrics(Namespace* ns, bool collect_replication_memory = true) const;
+  // Collects server metrics. See MetricsCollectOpts; a default-constructed value collects all.
+  Metrics GetMetrics(Namespace* ns, const MetricsCollectOpts& opts) const;
 
   std::string FormatInfoMetrics(const Metrics& metrics, std::string_view section,
                                 bool priveleged) const;

--- a/src/server/server_family_test.cc
+++ b/src/server/server_family_test.cc
@@ -793,4 +793,82 @@ TEST_F(ServerFamilyTest, InfoReplicationMemoryOnlyInMemorySection) {
   EXPECT_THAT(Run({"INFO", "ALL"}).GetString(), HasSubstr("replication_streaming_buffer_bytes"));
 }
 
+// COMMANDSTATS is a hidden section (rendered only for an explicit name or ALL), while
+// LATENCYSTATS is rendered for the default no-arg INFO as well. This pins the gating
+// behavior that lets GetMetrics skip command-stat aggregation for common INFO calls while
+// still collecting latency data whenever the LATENCYSTATS section is emitted.
+TEST_F(ServerFamilyTest, InfoCommandAndLatencyStatsGating) {
+  // Generate command activity across the connections / proactors.
+  for (int i = 0; i < 5; ++i) {
+    Run({"set", absl::StrCat("k", i), "v"});
+    Run({"get", absl::StrCat("k", i)});
+  }
+  Run({"ping"});
+
+  // Default INFO: COMMANDSTATS is hidden, but LATENCYSTATS is emitted.
+  const string def = Run({"INFO"}).GetString();
+  EXPECT_THAT(def, Not(HasSubstr("# Commandstats")));
+  EXPECT_THAT(def, Not(HasSubstr("cmdstat_")));
+  EXPECT_THAT(def, HasSubstr("# Latencystats"));
+
+  // INFO STATS renders neither hidden COMMANDSTATS nor LATENCYSTATS.
+  const string stats = Run({"INFO", "STATS"}).GetString();
+  EXPECT_THAT(stats, Not(HasSubstr("cmdstat_")));
+  EXPECT_THAT(stats, Not(HasSubstr("# Latencystats")));
+  EXPECT_THAT(stats, Not(HasSubstr("latency_percentiles_usec_")));
+
+  // Explicit sections and ALL render them.
+  EXPECT_THAT(Run({"INFO", "COMMANDSTATS"}).GetString(), HasSubstr("# Commandstats"));
+  EXPECT_THAT(Run({"INFO", "LATENCYSTATS"}).GetString(), HasSubstr("# Latencystats"));
+  const string all = Run({"INFO", "ALL"}).GetString();
+  EXPECT_THAT(all, HasSubstr("# Commandstats"));
+  EXPECT_THAT(all, HasSubstr("# Latencystats"));
+}
+
+// Command stats are aggregated across all proactor threads. Exercising commands on the IO
+// threads and then summing per-thread counters on the caller must yield the correct totals
+// (regression guard for moving aggregation out of the fan-out callback).
+TEST_F(ServerFamilyTest, InfoCommandStatsAggregation) {
+  Run({"config", "resetstat"});
+
+  const int kGets = 17;
+  for (int i = 0; i < kGets; ++i) {
+    Run({"get", "nonexistent"});
+  }
+
+  auto extract_calls = [](std::string_view info, std::string_view stat) -> int {
+    // looks for "<stat>:calls=<n>,..."
+    size_t pos = info.find(stat);
+    if (pos == std::string_view::npos)
+      return -1;
+    std::string_view rest = info.substr(pos);
+    const string needle = "calls=";
+    size_t cpos = rest.find(needle);
+    if (cpos == std::string_view::npos)
+      return -1;
+    rest = rest.substr(cpos + needle.size());
+    int value = 0;
+    for (char c : rest) {
+      if (c < '0' || c > '9')
+        break;
+      value = value * 10 + (c - '0');
+    }
+    return value;
+  };
+
+  const string cmdstats = Run({"INFO", "COMMANDSTATS"}).GetString();
+  EXPECT_EQ(extract_calls(cmdstats, "cmdstat_get:"), kGets);
+
+  // A command never invoked must not appear at all (zero-call commands are skipped).
+  EXPECT_THAT(cmdstats, Not(HasSubstr("cmdstat_getex:")));
+
+  // The aggregated value is also visible in INFO ALL.
+  const string all = Run({"INFO", "ALL"}).GetString();
+  EXPECT_GE(extract_calls(all, "cmdstat_get:"), kGets);
+}
+
+TEST_F(ServerFamilyTest, InfoClusterMigrationErrors) {
+  EXPECT_THAT(Run({"INFO", "CLUSTER"}).GetString(), HasSubstr("migration_errors_total:0"));
+}
+
 }  // namespace dfly

--- a/src/server/test_utils.h
+++ b/src/server/test_utils.h
@@ -140,7 +140,8 @@ class BaseFamilyTest : public ::testing::Test {
   static std::vector<std::string> StrArray(const RespExpr& expr);
 
   Metrics GetMetrics() const {
-    return service_->server_family().GetMetrics(&namespaces->GetDefaultNamespace());
+    return service_->server_family().GetMetrics(&namespaces->GetDefaultNamespace(),
+                                                MetricsCollectOpts{});
   }
 
   void ClearMetrics();


### PR DESCRIPTION
Summary: Refactors metrics/INFO collection to reduce work on common INFO calls by gating expensive sub-collections and changing how per-command stats are aggregated.

Changes:

- Add MetricsCollectOpts to selectively collect replication-memory stats, per-command call stats, and latency histograms.
- Update ServerFamily::GetMetrics callers to pass explicit collection options (default opts collect everything).
- Replace per-command std::map-based aggregation with a dense std::vector of counters indexed by command-registry order.
- Move command-stat aggregation out of the proactor fan-out callback by collecting per-thread vectors and merging element-wise.
- Map merged counters to lowercase command names only at print/render time via CommandRegistry::NamedCallStats.
- Gate LatencyMap() collection behind opts.cmd_latency to avoid work when LATENCYSTATS isn’t rendered.
- Adjust INFO rendering to request only the metrics needed for the selected section(s), and share the save-controller lock only when relevant sections render.
- Update existing unit tests and add new coverage for INFO gating/aggregation behavior and cluster migration error reporting.

Technical Notes: The registry is treated as fixed after startup; command-stat vectors rely on registry iteration order being consistent between collection, merge, and naming.

related to: #7414

| Variant            |   main ops/s |  branch ops/s |   Δ ops | main p50/p90/p99    | branch p50/p90/p99  |
|--------------------|-------------:|--------------:|--------:|---------------------|---------------------|
| INFO (default)     |      113,741 |       164,834 |   **+45%** | 1.031 / 1.391 / 3.167 | **0.863 / 1.191 / 2.767** |
| INFO ALL           |       75,469 |        76,427 |     ~0% | 1.239 / 1.871 / 4.415 | 1.311 / 1.863 / **4.047** |
| INFO COMMANDSTATS  |      134,325 |       214,060 |   **+59%** | 0.655 / 0.871 / 1.863 | **0.415 / 0.687 / 1.471** |
| INFO STATS         |      190,006 |       494,079 |  **+160%** | 0.655 / 0.879 / 2.367 | **0.191 / 0.263 / 0.407** |
