### PR TITLE
Adds `enable_resp_io_loop_v2` as a matrix dimension to the regression tests

### DIFF
--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -138,12 +138,17 @@ runs:
         export FILTER="${{inputs.filter}}"
         JUNIT_DIR="${REGRESSION_JUNIT_DIR}"
 
-        # Runtime flags forwarded to the dragonfly process via --df
-        DF_RUNTIME_FLAGS=""
-        if [[ -n "${{inputs.df-runtime-flags}}" ]]; then
-          for flag in ${{inputs.df-runtime-flags}}; do
-            DF_RUNTIME_FLAGS="$DF_RUNTIME_FLAGS --df $flag"
+        # Runtime flags forwarded to the dragonfly process via --df.
+        # Globbing is disabled while splitting so values like vmodule=*=1 are preserved,
+        # and the flags are collected into an array to avoid re-splitting/globbing
+        # when expanded on the pytest command line.
+        DF_RUNTIME_ARGS=()
+        if [[ -n "${DF_RUNTIME_FLAGS_INPUT}" ]]; then
+          set -f # disables filename expansion (globbing)
+          for flag in ${DF_RUNTIME_FLAGS_INPUT}; do
+            DF_RUNTIME_ARGS+=(--df "$flag")
           done
+          set +f
         fi
 
         # Exclude large tests unless explicitly requested
@@ -161,13 +166,13 @@ runs:
           timeout 80m pytest -m "$FILTER" --durations=10 --timeout=300 --color=yes \
             --json-report --json-report-file=report.json \
             --junitxml="${JUNIT_DIR}/pytest-${REGRESSION_JUNIT_KIND}.xml" \
-            dragonfly --df force_epoll=true $DF_RUNTIME_FLAGS --log-cli-level=INFO || code=$?
+            dragonfly --df force_epoll=true "${DF_RUNTIME_ARGS[@]}" --log-cli-level=INFO || code=$?
         else
           # Run only replication tests with iouring
           timeout 80m pytest -m "$FILTER" --durations=10 --timeout=300 --color=yes \
             --json-report --json-report-file=report.json \
             --junitxml="${JUNIT_DIR}/pytest-${REGRESSION_JUNIT_KIND}.xml" \
-            dragonfly $DF_RUNTIME_FLAGS --log-cli-level=INFO || code=$?
+            dragonfly "${DF_RUNTIME_ARGS[@]}" --log-cli-level=INFO || code=$?
         fi
 
         # timeout returns 124 if we exceeded the timeout duration
@@ -188,6 +193,9 @@ runs:
           exit 1
         fi
       env:
+        # Pass the raw runtime-flags input through the environment so the value is never
+        # embedded directly in the shell script (avoids shell injection).
+        DF_RUNTIME_FLAGS_INPUT: ${{ inputs.df-runtime-flags }}
         # Add environment variables to enable the S3 snapshot test.
         # AWS credentials: if inputs provided, use them; otherwise rely on workflow OIDC auth
         DRAGONFLY_S3_BUCKET: ${{ inputs.s3-bucket }}

--- a/.github/actions/regression-tests/action.yml
+++ b/.github/actions/regression-tests/action.yml
@@ -55,6 +55,10 @@ inputs:
   epoll:
     required: false
     type: string
+  df-runtime-flags:
+    required: false
+    type: string
+    description: "Runtime flags to pass to the dragonfly process via --df, e.g. 'enable_resp_io_loop_v2=true'"
 
 runs:
   using: "composite"
@@ -134,6 +138,14 @@ runs:
         export FILTER="${{inputs.filter}}"
         JUNIT_DIR="${REGRESSION_JUNIT_DIR}"
 
+        # Runtime flags forwarded to the dragonfly process via --df
+        DF_RUNTIME_FLAGS=""
+        if [[ -n "${{inputs.df-runtime-flags}}" ]]; then
+          for flag in ${{inputs.df-runtime-flags}}; do
+            DF_RUNTIME_FLAGS="$DF_RUNTIME_FLAGS --df $flag"
+          done
+        fi
+
         # Exclude large tests unless explicitly requested
         if [[ "$FILTER" == "large" ]]; then
           : # keep as-is, run only large tests
@@ -149,13 +161,13 @@ runs:
           timeout 80m pytest -m "$FILTER" --durations=10 --timeout=300 --color=yes \
             --json-report --json-report-file=report.json \
             --junitxml="${JUNIT_DIR}/pytest-${REGRESSION_JUNIT_KIND}.xml" \
-            dragonfly --df force_epoll=true --log-cli-level=INFO || code=$?
+            dragonfly --df force_epoll=true $DF_RUNTIME_FLAGS --log-cli-level=INFO || code=$?
         else
           # Run only replication tests with iouring
           timeout 80m pytest -m "$FILTER" --durations=10 --timeout=300 --color=yes \
             --json-report --json-report-file=report.json \
             --junitxml="${JUNIT_DIR}/pytest-${REGRESSION_JUNIT_KIND}.xml" \
-            dragonfly --log-cli-level=INFO || code=$?
+            dragonfly $DF_RUNTIME_FLAGS --log-cli-level=INFO || code=$?
         fi
 
         # timeout returns 124 if we exceeded the timeout duration

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -15,6 +15,7 @@ jobs:
         proactor: [Uring]
         build-type: [Debug, Release]
         runner: [ubuntu-latest, [self-hosted, linux, ARM64]]
+        enable_resp_io_loop_v2: [false, true]
 
     runs-on: ${{ matrix.runner }}
 
@@ -61,6 +62,7 @@ jobs:
           gspace-secret: ${{ secrets.GSPACES_BOT_DF_BUILD }}
           build-folder-name: build
           filter: ${{ matrix.build-type == 'Release' && 'not debug_only' || 'not opt_only' }}
+          df-runtime-flags: enable_resp_io_loop_v2=${{ matrix.enable_resp_io_loop_v2 }}
           s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}
           junit-s3-bucket: ${{ secrets.S3_REGTEST_BUCKET }}
           aws-role-to-assume: ${{ secrets.AWS_CI_S3_ROLE_ARN }}

--- a/tests/dragonfly/instance.py
+++ b/tests/dragonfly/instance.py
@@ -255,7 +255,7 @@ class DflyInstance:
             # are guranteed to run
             time.sleep(5)
             logging.debug(f"Unable to kill the process on port {self._port}")
-            logging.debug(f"INFO LOGS of DF are:")
+            logging.debug("INFO LOGS of DF are:")
             self.print_info_logs_to_debug_log()
             proc.kill()
             proc.communicate()
@@ -495,6 +495,17 @@ class DflyInstanceFactory:
         if version < 1.39:
             args.pop("enable_memcache_io_loop_v2", None)
             args.pop("enable_resp_io_loop_v2", None)
+            # DflyInstance merges params.args on top of args, so a globally-injected
+            # flag (e.g. --df enable_resp_io_loop_v2) would be re-added even after the
+            # pop above. Strip it from a params copy too so old binaries never see it.
+            if (
+                "enable_memcache_io_loop_v2" in params.args
+                or "enable_resp_io_loop_v2" in params.args
+            ):
+                pargs = dict(params.args)
+                pargs.pop("enable_memcache_io_loop_v2", None)
+                pargs.pop("enable_resp_io_loop_v2", None)
+                params = dataclasses.replace(params, args=pargs)
 
         instance = DflyInstance(params, args)
         self.instances.append(instance)
@@ -514,7 +525,7 @@ class DflyInstanceFactory:
         for instance in self.instances:
             try:  # ioloop might be no longer running
                 await instance.close_clients()
-            except Exception as e:
+            except Exception:
                 pass
 
             try:


### PR DESCRIPTION
Adds `enable_resp_io_loop_v2` as a matrix dimension to the regression workflow so the full suite runs against both the legacy (v1) and new (v2) RESP IO loop, on both x86 and ARM.

- **`.github/workflows/regression-tests.yml`**: add `enable_resp_io_loop_v2: [false, true]` to the matrix and forward it to the regression action via the new `df-runtime-flags` input.
- **`.github/actions/regression-tests/action.yml`**: add an optional `df-runtime-flags` input that is translated into `--df <flag>` args and appended to the pytest invocation (both iouring and epoll paths).
- **`tests/dragonfly/instance.py`**: when a test spins up a binary older than 1.39, strip `enable_resp_io_loop_v2` / `enable_memcache_io_loop_v2` from both `args` and `params.args`. `DflyInstance` merges `params.args` on top of `args`, so the globally-injected flag would otherwise be re-added and crash old binaries used in replication/compat tests.

`build-type` (Debug, Release) × `runner` (x86, ARM64) × `enable_resp_io_loop_v2` (false, true) = 8 jobs.

- The `--df` flags are appended after `force_epoll=true` on the epoll path and as the sole runtime flags on the iouring path.

- Testing: when applying all changes under PRs: #7744, #7733, #7747 i all 4 jobs passed (x86) on my fork. For aarch64 we will have to check on the main repo.
