### PR TITLE
feat: Write connection throttling and metrics exposed

### DIFF
--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -522,24 +522,34 @@ struct IOStat {
   uint64_t cmd_total = 0, pipelined_cmd_total = 0;
   size_t io_read_bytes = 0;
   uint64_t io_reads_total = 0;
+  uint64_t rw_throttle_batch_read_commands = 0;
+  uint64_t rw_throttle_batch_write_commands = 0;
+  uint64_t rw_throttle_batch_read_bytes = 0;
+  uint64_t rw_throttle_batch_write_bytes = 0;
+  uint64_t rw_throttle_batches_total = 0;
 
-  void From(const facade::FacadeStats& fs);
+  void From(const facade::FacadeStats& fs, const ServerState::Stats& ss);
   void Print(RedisReplyBuilder* rb) const;
 
   IOStat& operator-=(const IOStat& other);
 };
 
-void IOStat::From(const facade::FacadeStats& fs) {
+void IOStat::From(const facade::FacadeStats& fs, const ServerState::Stats& ss) {
   conn_received = fs.conn_stats.conn_received_cnt;
   curr_conn_count = fs.conn_stats.num_conns_main;
   cmd_total = fs.conn_stats.command_cnt_main;
   pipelined_cmd_total = fs.conn_stats.pipelined_cmd_cnt;
   io_read_bytes = fs.conn_stats.io_read_bytes;
   io_reads_total = fs.conn_stats.io_read_cnt;
+  rw_throttle_batch_read_commands = ss.rw_throttle_batch_read_commands;
+  rw_throttle_batch_write_commands = ss.rw_throttle_batch_write_commands;
+  rw_throttle_batch_read_bytes = ss.rw_throttle_batch_read_bytes;
+  rw_throttle_batch_write_bytes = ss.rw_throttle_batch_write_bytes;
+  rw_throttle_batches_total = ss.rw_throttle_batches_total;
 }
 
 void IOStat::Print(RedisReplyBuilder* rb) const {
-  rb->StartCollection(6, CollectionType::MAP);
+  rb->StartCollection(11, CollectionType::MAP);
   rb->SendSimpleString("connections_received");
   rb->SendLong(conn_received);
   rb->SendSimpleString("current_conn_count");
@@ -552,6 +562,16 @@ void IOStat::Print(RedisReplyBuilder* rb) const {
   rb->SendLong(io_read_bytes);
   rb->SendSimpleString("io_reads_total");
   rb->SendLong(io_reads_total);
+  rb->SendSimpleString("rw_throttle_batch_read_commands");
+  rb->SendLong(rw_throttle_batch_read_commands);
+  rb->SendSimpleString("rw_throttle_batch_write_commands");
+  rb->SendLong(rw_throttle_batch_write_commands);
+  rb->SendSimpleString("rw_throttle_batch_read_bytes");
+  rb->SendLong(rw_throttle_batch_read_bytes);
+  rb->SendSimpleString("rw_throttle_batch_write_bytes");
+  rb->SendLong(rw_throttle_batch_write_bytes);
+  rb->SendSimpleString("rw_throttle_batches_total");
+  rb->SendLong(rw_throttle_batches_total);
 }
 
 IOStat& IOStat::operator-=(const IOStat& other) {
@@ -561,6 +581,11 @@ IOStat& IOStat::operator-=(const IOStat& other) {
   pipelined_cmd_total -= other.pipelined_cmd_total;
   io_read_bytes -= other.io_read_bytes;
   io_reads_total -= other.io_reads_total;
+  rw_throttle_batch_read_commands -= other.rw_throttle_batch_read_commands;
+  rw_throttle_batch_write_commands -= other.rw_throttle_batch_write_commands;
+  rw_throttle_batch_read_bytes -= other.rw_throttle_batch_read_bytes;
+  rw_throttle_batch_write_bytes -= other.rw_throttle_batch_write_bytes;
+  rw_throttle_batches_total -= other.rw_throttle_batches_total;
 
   return *this;
 }
@@ -1673,14 +1698,16 @@ void DebugCmd::IOStats(facade::CmdArgParser parser, CommandContext* cmd_cntx) {
   bool per_second = parser.HasNext() && absl::EqualsIgnoreCase(parser.Peek(), "PS");
   vector<IOStat> stats(shard_set->pool()->size());
 
-  shard_set->pool()->AwaitBrief(
-      [&](unsigned index, ProactorBase*) { stats[index].From(*facade::tl_facade_stats); });
+  shard_set->pool()->AwaitBrief([&](unsigned index, ProactorBase*) {
+    stats[index].From(*facade::tl_facade_stats, ServerState::tlocal()->stats);
+  });
 
   if (per_second) {
     ThisFiber::SleepFor(1s);
     vector<IOStat> stats2(shard_set->pool()->size());
-    shard_set->pool()->AwaitBrief(
-        [&](unsigned index, ProactorBase*) { stats2[index].From(*facade::tl_facade_stats); });
+    shard_set->pool()->AwaitBrief([&](unsigned index, ProactorBase*) {
+      stats2[index].From(*facade::tl_facade_stats, ServerState::tlocal()->stats);
+    });
 
     for (size_t i = 0; i < stats.size(); ++i) {
       stats2[i] -= stats[i];

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -522,10 +522,10 @@ struct IOStat {
   uint64_t cmd_total = 0, pipelined_cmd_total = 0;
   size_t io_read_bytes = 0;
   uint64_t io_reads_total = 0;
-  uint64_t rw_throttle_batch_read_commands = 0;
-  uint64_t rw_throttle_batch_write_commands = 0;
-  uint64_t rw_throttle_batch_read_bytes = 0;
-  uint64_t rw_throttle_batch_write_bytes = 0;
+  uint64_t batch_read_commands_total = 0;
+  uint64_t batch_write_commands_total = 0;
+  uint64_t batch_read_commands_bytes = 0;
+  uint64_t batch_write_commands_bytes = 0;
   uint64_t rw_throttle_batches_total = 0;
 
   void From(const facade::FacadeStats& fs, const ServerState::Stats& ss);
@@ -541,10 +541,10 @@ void IOStat::From(const facade::FacadeStats& fs, const ServerState::Stats& ss) {
   pipelined_cmd_total = fs.conn_stats.pipelined_cmd_cnt;
   io_read_bytes = fs.conn_stats.io_read_bytes;
   io_reads_total = fs.conn_stats.io_read_cnt;
-  rw_throttle_batch_read_commands = ss.rw_throttle_batch_read_commands;
-  rw_throttle_batch_write_commands = ss.rw_throttle_batch_write_commands;
-  rw_throttle_batch_read_bytes = ss.rw_throttle_batch_read_bytes;
-  rw_throttle_batch_write_bytes = ss.rw_throttle_batch_write_bytes;
+  batch_read_commands_total = ss.batch_read_commands_total;
+  batch_write_commands_total = ss.batch_write_commands_total;
+  batch_read_commands_bytes = ss.batch_read_commands_bytes;
+  batch_write_commands_bytes = ss.batch_write_commands_bytes;
   rw_throttle_batches_total = ss.rw_throttle_batches_total;
 }
 
@@ -562,14 +562,14 @@ void IOStat::Print(RedisReplyBuilder* rb) const {
   rb->SendLong(io_read_bytes);
   rb->SendSimpleString("io_reads_total");
   rb->SendLong(io_reads_total);
-  rb->SendSimpleString("rw_throttle_batch_read_commands");
-  rb->SendLong(rw_throttle_batch_read_commands);
-  rb->SendSimpleString("rw_throttle_batch_write_commands");
-  rb->SendLong(rw_throttle_batch_write_commands);
-  rb->SendSimpleString("rw_throttle_batch_read_bytes");
-  rb->SendLong(rw_throttle_batch_read_bytes);
-  rb->SendSimpleString("rw_throttle_batch_write_bytes");
-  rb->SendLong(rw_throttle_batch_write_bytes);
+  rb->SendSimpleString("batch_read_commands_total");
+  rb->SendLong(batch_read_commands_total);
+  rb->SendSimpleString("batch_write_commands_total");
+  rb->SendLong(batch_write_commands_total);
+  rb->SendSimpleString("batch_read_commands_bytes");
+  rb->SendLong(batch_read_commands_bytes);
+  rb->SendSimpleString("batch_write_commands_bytes");
+  rb->SendLong(batch_write_commands_bytes);
   rb->SendSimpleString("rw_throttle_batches_total");
   rb->SendLong(rw_throttle_batches_total);
 }
@@ -581,10 +581,10 @@ IOStat& IOStat::operator-=(const IOStat& other) {
   pipelined_cmd_total -= other.pipelined_cmd_total;
   io_read_bytes -= other.io_read_bytes;
   io_reads_total -= other.io_reads_total;
-  rw_throttle_batch_read_commands -= other.rw_throttle_batch_read_commands;
-  rw_throttle_batch_write_commands -= other.rw_throttle_batch_write_commands;
-  rw_throttle_batch_read_bytes -= other.rw_throttle_batch_read_bytes;
-  rw_throttle_batch_write_bytes -= other.rw_throttle_batch_write_bytes;
+  batch_read_commands_total -= other.batch_read_commands_total;
+  batch_write_commands_total -= other.batch_write_commands_total;
+  batch_read_commands_bytes -= other.batch_read_commands_bytes;
+  batch_write_commands_bytes -= other.batch_write_commands_bytes;
   rw_throttle_batches_total -= other.rw_throttle_batches_total;
 
   return *this;

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -7,6 +7,7 @@
 #include "absl/strings/str_split.h"
 #include "facade/resp_expr.h"
 #include "util/fibers/detail/fiber_interface.h"
+#include "util/fibers/fibers.h"
 #include "util/fibers/proactor_base.h"
 #include "util/fibers/synchronization.h"
 
@@ -134,6 +135,10 @@ ABSL_FLAG(uint32_t, scheduler_background_warrant, 5,
 ABSL_RETIRED_FLAG(uint32_t, squash_stats_latency_lower_limit, 0,
                   "Deprecated. Squash latency stats are now tracked unconditionally; "
                   "use the pipeline_latency_seconds histogram for percentiles instead.");
+
+ABSL_FLAG(bool, write_connection_throttling, false, "Throttle write connections.");
+ABSL_FLAG(uint32_t, write_connection_throttling_sleep_usec, 500,
+          "Sleep period for write connection in microseconds");
 
 namespace {
 
@@ -1015,6 +1020,7 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
   config_registry.RegisterMutable("max_eviction_per_heartbeat");
   config_registry.RegisterMutable("max_segment_to_consider");
   config_registry.RegisterMutable("pipeline_squash");
+  config_registry.RegisterMutable("write_connection_throttling");
   config_registry.RegisterMutable("lua_mem_gc_threshold");
   config_registry.RegisterMutable("background_debug_jobs");
 
@@ -1746,6 +1752,8 @@ uint32_t Service::DispatchSquashedBatch(facade::ParsedCommand* first, unsigned c
     cmd_refs.clear();
   };
 
+  bool batch_has_write_command = false;
+
   auto* cmd = first;
   for (unsigned i = 0; i < count && cmd; i++) {
     auto* cmd_cntx = static_cast<CommandContext*>(cmd);
@@ -1784,8 +1792,24 @@ uint32_t Service::DispatchSquashedBatch(facade::ParsedCommand* first, unsigned c
       continue;
     }
 
+    if (cid->IsReadOnly()) {
+      ss->stats.rw_throttle_batch_read_commands++;
+      ss->stats.rw_throttle_batch_read_bytes += cmd_cntx->EnqueuedBytes();
+    } else if (cid->IsJournaled()) {
+      batch_has_write_command = true;
+      ss->stats.rw_throttle_batch_write_commands++;
+      ss->stats.rw_throttle_batch_write_bytes += cmd_cntx->EnqueuedBytes();
+    }
+
     cmd_refs.push_back(CmdRef{cid, tail_args, ReplyMode::FULL, cmd_cntx});
     cmd = cmd->next;
+  }
+
+  // Simple policy that throttles batches that contain write commands by sleeping before dispatch.
+  if (absl::GetFlag(FLAGS_write_connection_throttling) && batch_has_write_command) {
+    ss->stats.rw_throttle_batches_total++;
+    ThisFiber::SleepFor(
+        chrono::microseconds(absl::GetFlag(FLAGS_write_connection_throttling_sleep_usec)));
   }
 
   perform_squash();

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -136,9 +136,8 @@ ABSL_RETIRED_FLAG(uint32_t, squash_stats_latency_lower_limit, 0,
                   "Deprecated. Squash latency stats are now tracked unconditionally; "
                   "use the pipeline_latency_seconds histogram for percentiles instead.");
 
-ABSL_FLAG(bool, write_connection_throttling, false, "Throttle write connections.");
 ABSL_FLAG(uint32_t, write_connection_throttling_sleep_usec, 500,
-          "Sleep period for write connection in microseconds");
+          "Sleep period for write connection in microseconds. 0 disables yielding.");
 
 namespace {
 
@@ -177,6 +176,9 @@ void ShutdownWatchdog::Disarm() {
 }
 
 std::optional<ShutdownWatchdog> shutdown_watchdog = std::nullopt;
+
+thread_local uint32_t tl_write_connection_throttling_sleep_usec =
+    absl::GetFlag(FLAGS_write_connection_throttling_sleep_usec);
 
 }  // namespace
 
@@ -1020,9 +1022,14 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
   config_registry.RegisterMutable("max_eviction_per_heartbeat");
   config_registry.RegisterMutable("max_segment_to_consider");
   config_registry.RegisterMutable("pipeline_squash");
-  config_registry.RegisterMutable("write_connection_throttling");
   config_registry.RegisterMutable("lua_mem_gc_threshold");
   config_registry.RegisterMutable("background_debug_jobs");
+
+  RegisterMutableFlags(&config_registry,
+                       base::GetFlagNames(FLAGS_write_connection_throttling_sleep_usec), []() {
+                         tl_write_connection_throttling_sleep_usec =
+                             absl::GetFlag(FLAGS_write_connection_throttling_sleep_usec);
+                       });
 
   // Register ServerState flags
   RegisterMutableFlags(&config_registry, ServerState::GetMutableFlagNames(),
@@ -1753,6 +1760,16 @@ uint32_t Service::DispatchSquashedBatch(facade::ParsedCommand* first, unsigned c
   };
 
   bool batch_has_write_command = false;
+  auto update_rw_connection_throttling_metrics = [&](const CommandId* cid, size_t bytes) {
+    if (cid->IsReadOnly()) {
+      ss->stats.rw_throttle_batch_read_commands++;
+      ss->stats.rw_throttle_batch_read_bytes += bytes;
+    } else if (cid->IsJournaled()) {
+      batch_has_write_command = true;
+      ss->stats.rw_throttle_batch_write_commands++;
+      ss->stats.rw_throttle_batch_write_bytes += bytes;
+    }
+  };
 
   auto* cmd = first;
   for (unsigned i = 0; i < count && cmd; i++) {
@@ -1792,24 +1809,17 @@ uint32_t Service::DispatchSquashedBatch(facade::ParsedCommand* first, unsigned c
       continue;
     }
 
-    if (cid->IsReadOnly()) {
-      ss->stats.rw_throttle_batch_read_commands++;
-      ss->stats.rw_throttle_batch_read_bytes += cmd_cntx->EnqueuedBytes();
-    } else if (cid->IsJournaled()) {
-      batch_has_write_command = true;
-      ss->stats.rw_throttle_batch_write_commands++;
-      ss->stats.rw_throttle_batch_write_bytes += cmd_cntx->EnqueuedBytes();
-    }
+    if (tl_write_connection_throttling_sleep_usec > 0)
+      update_rw_connection_throttling_metrics(cid, cmd_cntx->EnqueuedBytes());
 
     cmd_refs.push_back(CmdRef{cid, tail_args, ReplyMode::FULL, cmd_cntx});
     cmd = cmd->next;
   }
 
   // Simple policy that throttles batches that contain write commands by sleeping before dispatch.
-  if (absl::GetFlag(FLAGS_write_connection_throttling) && batch_has_write_command) {
+  if (batch_has_write_command && tl_write_connection_throttling_sleep_usec > 0) {
     ss->stats.rw_throttle_batches_total++;
-    ThisFiber::SleepFor(
-        chrono::microseconds(absl::GetFlag(FLAGS_write_connection_throttling_sleep_usec)));
+    ThisFiber::SleepFor(chrono::microseconds(tl_write_connection_throttling_sleep_usec));
   }
 
   perform_squash();

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -136,7 +136,7 @@ ABSL_RETIRED_FLAG(uint32_t, squash_stats_latency_lower_limit, 0,
                   "Deprecated. Squash latency stats are now tracked unconditionally; "
                   "use the pipeline_latency_seconds histogram for percentiles instead.");
 
-ABSL_FLAG(uint32_t, write_connection_throttling_sleep_usec, 500,
+ABSL_FLAG(uint32_t, write_connection_throttling_sleep_usec, 0,
           "Sleep period for write connection in microseconds. 0 disables yielding.");
 
 namespace {

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1762,12 +1762,12 @@ uint32_t Service::DispatchSquashedBatch(facade::ParsedCommand* first, unsigned c
   bool batch_has_write_command = false;
   auto update_rw_connection_throttling_metrics = [&](const CommandId* cid, size_t bytes) {
     if (cid->IsReadOnly()) {
-      ss->stats.rw_throttle_batch_read_commands++;
-      ss->stats.rw_throttle_batch_read_bytes += bytes;
+      ss->stats.batch_read_commands_total++;
+      ss->stats.batch_read_commands_bytes += bytes;
     } else if (cid->IsJournaled()) {
       batch_has_write_command = true;
-      ss->stats.rw_throttle_batch_write_commands++;
-      ss->stats.rw_throttle_batch_write_bytes += bytes;
+      ss->stats.batch_write_commands_total++;
+      ss->stats.batch_write_commands_bytes += bytes;
     }
   };
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1810,7 +1810,7 @@ uint32_t Service::DispatchSquashedBatch(facade::ParsedCommand* first, unsigned c
     }
 
     if (tl_write_connection_throttling_sleep_usec > 0)
-      update_rw_connection_throttling_metrics(cid, cmd_cntx->EnqueuedBytes());
+      update_rw_connection_throttling_metrics(cid, cmd_cntx->UsedMemory());
 
     cmd_refs.push_back(CmdRef{cid, tail_args, ReplyMode::FULL, cmd_cntx});
     cmd = cmd->next;

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2715,11 +2715,10 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
     append("instantaneous_ops_per_sec", m.qps);
     append("total_pipelined_commands", conn_stats.pipelined_cmd_cnt);
     append("pipeline_throttle_total", conn_stats.pipeline_throttle_count);
-    append("rw_throttle_batch_read_commands", m.coordinator_stats.rw_throttle_batch_read_commands);
-    append("rw_throttle_batch_write_commands",
-           m.coordinator_stats.rw_throttle_batch_write_commands);
-    append("rw_throttle_batch_read_bytes", m.coordinator_stats.rw_throttle_batch_read_bytes);
-    append("rw_throttle_batch_write_bytes", m.coordinator_stats.rw_throttle_batch_write_bytes);
+    append("batch_read_commands_total", m.coordinator_stats.batch_read_commands_total);
+    append("batch_write_commands_total", m.coordinator_stats.batch_write_commands_total);
+    append("batch_read_commands_bytes", m.coordinator_stats.batch_read_commands_bytes);
+    append("batch_write_commands_bytes", m.coordinator_stats.batch_write_commands_bytes);
     append("rw_throttle_batches_total", m.coordinator_stats.rw_throttle_batches_total);
     append("pipelined_latency_usec", conn_stats.pipelined_cmd_latency);
     append("total_net_input_bytes", conn_stats.io_read_bytes);

--- a/src/server/server_family.cc
+++ b/src/server/server_family.cc
@@ -2715,6 +2715,12 @@ string ServerFamily::FormatInfoMetrics(const Metrics& m, std::string_view sectio
     append("instantaneous_ops_per_sec", m.qps);
     append("total_pipelined_commands", conn_stats.pipelined_cmd_cnt);
     append("pipeline_throttle_total", conn_stats.pipeline_throttle_count);
+    append("rw_throttle_batch_read_commands", m.coordinator_stats.rw_throttle_batch_read_commands);
+    append("rw_throttle_batch_write_commands",
+           m.coordinator_stats.rw_throttle_batch_write_commands);
+    append("rw_throttle_batch_read_bytes", m.coordinator_stats.rw_throttle_batch_read_bytes);
+    append("rw_throttle_batch_write_bytes", m.coordinator_stats.rw_throttle_batch_write_bytes);
+    append("rw_throttle_batches_total", m.coordinator_stats.rw_throttle_batches_total);
     append("pipelined_latency_usec", conn_stats.pipelined_cmd_latency);
     append("total_net_input_bytes", conn_stats.io_read_bytes);
     append("connection_migrations", conn_stats.num_migrations);

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -88,10 +88,10 @@ ServerState::Stats& ServerState::Stats::Add(const ServerState::Stats& other) {
   ADD(conn_timeout_events);
   ADD(psync_requests_total);
 
-  ADD(rw_throttle_batch_write_commands);
-  ADD(rw_throttle_batch_read_commands);
-  ADD(rw_throttle_batch_read_bytes);
-  ADD(rw_throttle_batch_write_bytes);
+  ADD(batch_write_commands_total);
+  ADD(batch_read_commands_total);
+  ADD(batch_read_commands_bytes);
+  ADD(batch_write_commands_bytes);
   ADD(rw_throttle_batches_total);
 
   if (this->tx_width_freq_arr.size() > 0) {

--- a/src/server/server_state.cc
+++ b/src/server/server_state.cc
@@ -58,7 +58,7 @@ ServerState::Stats::Stats(unsigned num_shards)
 }
 
 ServerState::Stats& ServerState::Stats::Add(const ServerState::Stats& other) {
-  static_assert(sizeof(Stats) == 25 * 8, "Stats size mismatch");
+  static_assert(sizeof(Stats) == 30 * 8, "Stats size mismatch");
 
 #define ADD(x) this->x += (other.x)
 
@@ -87,6 +87,12 @@ ServerState::Stats& ServerState::Stats::Add(const ServerState::Stats& other) {
   ADD(oom_error_cmd_cnt);
   ADD(conn_timeout_events);
   ADD(psync_requests_total);
+
+  ADD(rw_throttle_batch_write_commands);
+  ADD(rw_throttle_batch_read_commands);
+  ADD(rw_throttle_batch_read_bytes);
+  ADD(rw_throttle_batch_write_bytes);
+  ADD(rw_throttle_batches_total);
 
   if (this->tx_width_freq_arr.size() > 0) {
     DCHECK_EQ(this->tx_width_freq_arr.size(), other.tx_width_freq_arr.size());

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -138,11 +138,11 @@ class ServerState {  // public struct - to allow initialization.
     std::valarray<uint64_t> tx_width_freq_arr, squash_width_freq_arr;
 
     // Throttling metrics
-    size_t rw_throttle_batch_write_commands = 0;
-    size_t rw_throttle_batch_read_commands = 0;
-    size_t rw_throttle_batch_read_bytes = 0;
-    size_t rw_throttle_batch_write_bytes = 0;
-    size_t rw_throttle_batches_total = 0;
+    uint64_t rw_throttle_batch_write_commands = 0;
+    uint64_t rw_throttle_batch_read_commands = 0;
+    uint64_t rw_throttle_batch_read_bytes = 0;
+    uint64_t rw_throttle_batch_write_bytes = 0;
+    uint64_t rw_throttle_batches_total = 0;
 
     // Memory size of stored commands during multi-exec in connections
     size_t stored_cmd_bytes = 0;

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -137,6 +137,13 @@ class ServerState {  // public struct - to allow initialization.
     uint64_t psync_requests_total = 0;
     std::valarray<uint64_t> tx_width_freq_arr, squash_width_freq_arr;
 
+    // Throttling metrics
+    size_t rw_throttle_batch_write_commands = 0;
+    size_t rw_throttle_batch_read_commands = 0;
+    size_t rw_throttle_batch_read_bytes = 0;
+    size_t rw_throttle_batch_write_bytes = 0;
+    size_t rw_throttle_batches_total = 0;
+
     // Memory size of stored commands during multi-exec in connections
     size_t stored_cmd_bytes = 0;
   };

--- a/src/server/server_state.h
+++ b/src/server/server_state.h
@@ -138,10 +138,10 @@ class ServerState {  // public struct - to allow initialization.
     std::valarray<uint64_t> tx_width_freq_arr, squash_width_freq_arr;
 
     // Throttling metrics
-    uint64_t rw_throttle_batch_write_commands = 0;
-    uint64_t rw_throttle_batch_read_commands = 0;
-    uint64_t rw_throttle_batch_read_bytes = 0;
-    uint64_t rw_throttle_batch_write_bytes = 0;
+    uint64_t batch_write_commands_total = 0;
+    uint64_t batch_read_commands_total = 0;
+    uint64_t batch_read_commands_bytes = 0;
+    uint64_t batch_write_commands_bytes = 0;
     uint64_t rw_throttle_batches_total = 0;
 
     // Memory size of stored commands during multi-exec in connections

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -2533,8 +2533,7 @@ async def test_client_list_filters(df_server: DflyInstance):
     {
         "proactor_threads": 2,
         "pipeline_squash": 1,
-        "write_connection_throttling": "true",
-        "write_connection_throttling_sleep_usec": 10000,  # 10ms per throttled batch
+        "write_connection_throttling_sleep_usec": 10000,  # 10ms per throttled batch; >0 enables throttling
     }
 )
 @pytest.mark.asyncio

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -2532,6 +2532,7 @@ async def test_client_list_filters(df_server: DflyInstance):
 @dfly_args(
     {
         "proactor_threads": 2,
+        "pipeline_squash": 1,
         "write_connection_throttling": "true",
         "write_connection_throttling_sleep_usec": 10000,  # 10ms per throttled batch
     }
@@ -2548,35 +2549,30 @@ async def test_rw_throttle_stats(df_server: DflyInstance):
     before = await read_client.info("stats")
     before_batches = int(before.get("rw_throttle_batches_total", 0))
     before_write_cmds = int(before.get("rw_throttle_batch_write_commands", 0))
+    before_read_cmds = int(before.get("rw_throttle_batch_read_commands", 0))
 
     # Write connection: pipeline of SET commands — should be throttled
-    start = time.monotonic()
     write_pipe = write_client.pipeline(transaction=False)
     for i in range(10):
         write_pipe.set(f"key{i}", f"new_val{i}")
     await write_pipe.execute()
-    write_elapsed_ms = (time.monotonic() - start) * 1000
 
     # Read connection: pipeline of GET commands — should not be throttled
-    start = time.monotonic()
     read_pipe = read_client.pipeline(transaction=False)
     for i in range(10):
         read_pipe.get(f"key{i}")
     await read_pipe.execute()
-    read_elapsed_ms = (time.monotonic() - start) * 1000
 
     after = await read_client.info("stats")
 
-    # Write connection must have been delayed by the throttle sleep
-    assert write_elapsed_ms >= 10, f"Expected write throttle delay, got {write_elapsed_ms:.1f}ms"
-
-    # Read connection should be faster (no throttle)
-    assert read_elapsed_ms < write_elapsed_ms, "Read connection should not be throttled"
-
-    # Stats must reflect the throttled write batch
+    # Write commands must be counted and their batches throttled
     assert int(after.get("rw_throttle_batch_write_commands", 0)) > before_write_cmds
     assert int(after.get("rw_throttle_batch_write_bytes", 0)) > 0
     assert int(after.get("rw_throttle_batches_total", 0)) > before_batches
+
+    # Read commands must be counted but must not produce throttled batches
+    assert int(after.get("rw_throttle_batch_read_commands", 0)) > before_read_cmds
+    assert int(after.get("rw_throttle_batch_read_bytes", 0)) > 0
 
     await read_client.aclose()
     await write_client.aclose()

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -2547,8 +2547,8 @@ async def test_rw_throttle_stats(df_server: DflyInstance):
 
     before = await read_client.info("stats")
     before_batches = int(before.get("rw_throttle_batches_total", 0))
-    before_write_cmds = int(before.get("rw_throttle_batch_write_commands", 0))
-    before_read_cmds = int(before.get("rw_throttle_batch_read_commands", 0))
+    before_write_cmds = int(before.get("batch_write_commands_total", 0))
+    before_read_cmds = int(before.get("batch_read_commands_total", 0))
 
     # Write connection: pipeline of SET commands — should be throttled
     write_pipe = write_client.pipeline(transaction=False)
@@ -2565,13 +2565,13 @@ async def test_rw_throttle_stats(df_server: DflyInstance):
     after = await read_client.info("stats")
 
     # Write commands must be counted and their batches throttled
-    assert int(after.get("rw_throttle_batch_write_commands", 0)) > before_write_cmds
-    assert int(after.get("rw_throttle_batch_write_bytes", 0)) > 0
+    assert int(after.get("batch_write_commands_total", 0)) > before_write_cmds
+    assert int(after.get("batch_write_commands_bytes", 0)) > 0
     assert int(after.get("rw_throttle_batches_total", 0)) > before_batches
 
     # Read commands must be counted but must not produce throttled batches
-    assert int(after.get("rw_throttle_batch_read_commands", 0)) > before_read_cmds
-    assert int(after.get("rw_throttle_batch_read_bytes", 0)) > 0
+    assert int(after.get("batch_read_commands_total", 0)) > before_read_cmds
+    assert int(after.get("batch_read_commands_bytes", 0)) > 0
 
     await read_client.aclose()
     await write_client.aclose()

--- a/tests/dragonfly/connection_test.py
+++ b/tests/dragonfly/connection_test.py
@@ -2527,3 +2527,56 @@ async def test_client_list_filters(df_server: DflyInstance):
         await subscriber.connection.send_command("UNSUBSCRIBE")
         await subscriber.aclose()
         await observer.aclose()
+
+
+@dfly_args(
+    {
+        "proactor_threads": 2,
+        "write_connection_throttling": "true",
+        "write_connection_throttling_sleep_usec": 10000,  # 10ms per throttled batch
+    }
+)
+@pytest.mark.asyncio
+async def test_rw_throttle_stats(df_server: DflyInstance):
+    """Verify write connections are throttled and rw_throttle_* stats are reported"""
+
+    read_client = aioredis.Redis(port=df_server.port)
+    write_client = aioredis.Redis(port=df_server.port)
+
+    await write_client.mset({f"key{i}": f"val{i}" for i in range(10)})
+
+    before = await read_client.info("stats")
+    before_batches = int(before.get("rw_throttle_batches_total", 0))
+    before_write_cmds = int(before.get("rw_throttle_batch_write_commands", 0))
+
+    # Write connection: pipeline of SET commands — should be throttled
+    start = time.monotonic()
+    write_pipe = write_client.pipeline(transaction=False)
+    for i in range(10):
+        write_pipe.set(f"key{i}", f"new_val{i}")
+    await write_pipe.execute()
+    write_elapsed_ms = (time.monotonic() - start) * 1000
+
+    # Read connection: pipeline of GET commands — should not be throttled
+    start = time.monotonic()
+    read_pipe = read_client.pipeline(transaction=False)
+    for i in range(10):
+        read_pipe.get(f"key{i}")
+    await read_pipe.execute()
+    read_elapsed_ms = (time.monotonic() - start) * 1000
+
+    after = await read_client.info("stats")
+
+    # Write connection must have been delayed by the throttle sleep
+    assert write_elapsed_ms >= 10, f"Expected write throttle delay, got {write_elapsed_ms:.1f}ms"
+
+    # Read connection should be faster (no throttle)
+    assert read_elapsed_ms < write_elapsed_ms, "Read connection should not be throttled"
+
+    # Stats must reflect the throttled write batch
+    assert int(after.get("rw_throttle_batch_write_commands", 0)) > before_write_cmds
+    assert int(after.get("rw_throttle_batch_write_bytes", 0)) > 0
+    assert int(after.get("rw_throttle_batches_total", 0)) > before_batches
+
+    await read_client.aclose()
+    await write_client.aclose()


### PR DESCRIPTION
Throttle pipeline batches containing write commands by introducing a configurable sleep interval.

The mutable --write_connection_throttling_sleep_usec option specifies the sleep duration in microseconds.
By default it is 0 which indicates that throttling is disabled.

The throttling policy is intentionally simple: if any command in a pipeline batch is a write command,
the entire batch is delayed by the configured sleep interval.

Expose the following metrics in INFO STATS and DEBUG IOSTAT:

- batch_read_commands_total
- batch_write_commands_total
- batch_read_bytes_total
- batch_write_bytes_total
- rw_throttle_batches_total

<!--
**Commits Must Be Signed and Your PR title must conform to the conventional commit spec**
  * See: https://github.com/dragonflydb/dragonfly/blob/main/CONTRIBUTING.md
  * Please follow the section on `pre-commit hooks`, a linter will validate before you push

  Example PR Title: <type>(<scope>)!: <description>

  * `type` = bug, chore, feat, fix, docs, build, style, refactor, perf, test
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs"
  * `description` = short description of the change

Examples:

  * chore(examples): Clarify `docker` usage #120
  * docs(readme): Fix Example Links #121
  * feat(ingest)!: Add new ingest #122
  * fix(ingest): Refactor for loop to list comprehension #123
-->
