### PR TITLE
feat(search): apply schema and query-time text weights to scoring

### DIFF
--- a/src/core/search/parser.y
+++ b/src/core/search/parser.y
@@ -222,7 +222,7 @@ knn_attr:
   | WEIGHT COLON vec_range_radius
     {
       double weight = $3;
-      if (!(weight >= 0) || !std::isfinite(weight))
+      if (!SchemaField::TextParams::IsValidWeight(weight))
         YYABORT;
       $$ = KnnAttributes{};
       $$.weight = weight;
@@ -307,7 +307,7 @@ vector_range_attr:
   | WEIGHT COLON vec_range_radius
     {
       double weight = $3;
-      if (!(weight >= 0) || !std::isfinite(weight))
+      if (!SchemaField::TextParams::IsValidWeight(weight))
         YYABORT;
       $$ = VectorRangeAttributes{};
       $$.weight = weight;
@@ -342,7 +342,7 @@ text_attr:
   WEIGHT COLON vec_range_radius
     {
       double weight = $3;
-      if (!(weight >= 0) || !std::isfinite(weight))
+      if (!SchemaField::TextParams::IsValidWeight(weight))
         YYABORT;
       $$ = TextAttributes{};
       $$.weight = weight;

--- a/src/core/search/scoring.cc
+++ b/src/core/search/scoring.cc
@@ -10,7 +10,7 @@ double ScoreDocument(ScorerFn scorer, const ScoringContext& ctx,
                      const std::vector<ScoringTermInfo>& terms) {
   double score = 0.0;
   for (const auto& term : terms)
-    score += scorer(ctx, term);
+    score += term.query_weight * scorer(ctx, term);
   return score;
 }
 

--- a/src/core/search/scoring.h
+++ b/src/core/search/scoring.h
@@ -27,6 +27,8 @@ struct ScoringTermInfo {
   size_t term_docs = 0;          // Number of documents containing this term
   uint32_t field_doc_len = 0;    // Document length in THIS field (sum of TF)
   double field_avg_doc_len = 0;  // Average document length for THIS field
+  double query_weight = 1.0;     // Query-time $weight: post-hoc scalar on the contribution
+  double field_weight = 1.0;     // Schema TEXT WEIGHT: folded into the effective term frequency
 };
 
 // Context passed to scorer for a single document
@@ -63,7 +65,9 @@ inline double BM25Std(const ScoringContext& ctx, const ScoringTermInfo& term) {
   constexpr double b = 0.75;
   constexpr double k1 = 1.2;
 
-  double f = term.term_freq;
+  // Schema field weight is folded into the effective frequency, so it passes through TF
+  // saturation (a high-weight field saturates instead of scaling the score linearly).
+  double f = term.field_weight * term.term_freq;
   if (f == 0)
     return 0.0;
 
@@ -76,7 +80,11 @@ inline double BM25Std(const ScoringContext& ctx, const ScoringTermInfo& term) {
 
   // TF saturation: f * (k1 + 1) / (f + k1 * (1 - b + b * fieldDocLen / fieldAvgDocLen))
   double avg = term.field_avg_doc_len > 0 ? term.field_avg_doc_len : 1.0;
-  double tf = f * (k1 + 1.0) / (f + k1 * (1.0 - b + b * term.field_doc_len / avg));
+  // Defense in depth: a non-finite effective frequency (pathological weight) would make the
+  // saturation inf/inf -> NaN; its limit as f -> inf is (k1 + 1).
+  double tf = std::isfinite(f)
+                  ? f * (k1 + 1.0) / (f + k1 * (1.0 - b + b * term.field_doc_len / avg))
+                  : (k1 + 1.0);
 
   return idf * tf;
 }
@@ -94,7 +102,7 @@ inline double TfIdf(const ScoringContext& ctx, const ScoringTermInfo& term) {
 
   // Clamp N >= n to avoid negative IDF during transient states
   double N = std::max(ctx.num_docs, term.term_docs);
-  return std::log(N / term.term_docs) * term.term_freq;
+  return std::log(N / term.term_docs) * (term.field_weight * term.term_freq);
 }
 
 // Compute TFIDF with document length normalization for a single term.

--- a/src/core/search/search.cc
+++ b/src/core/search/search.cc
@@ -246,14 +246,17 @@ struct BasicSearch {
     sub_results.reserve(indices.size());
     for (auto* index : indices) {
       IndexResult per_index{};
-      auto term_cb = [&per_index, this, index](string_view term, const auto* container) {
+      absl::flat_hash_set<string> scored_terms;
+      auto term_cb = [&per_index, &scored_terms, this, index](string_view term,
+                                                              const auto* container) {
         if (scorer_) {
           std::string resolved{term};
           if (auto synonyms = indices_->GetSynonyms(); synonyms) {
             if (auto group_id = synonyms->GetGroupToken(resolved); group_id)
               resolved = std::move(*group_id);
           }
-          AddMatchedTerm(index, std::move(resolved));
+          if (scored_terms.insert(resolved).second)
+            AddMatchedTerm(index, std::move(resolved));
         }
         Merge(IndexResult{container}, &per_index, LogicOp::OR);
       };
@@ -499,6 +502,9 @@ struct BasicSearch {
   }
 
   IndexResult Search(const AstAttributeNode& node, string_view active_field) {
+    double previous_weight = current_weight_;
+    current_weight_ *= node.weight;
+    absl::Cleanup restore_weight = [&] { current_weight_ = previous_weight; };
     return SearchGeneric(*node.node, active_field);
   }
 
@@ -712,6 +718,8 @@ struct BasicSearch {
     TextIndex* index;
     size_t term_docs;
     double field_avg_doc_len;  // pre-resolved (global or local)
+    double query_weight;       // post-hoc scalar (query-time $weight)
+    double field_weight;       // folded into effective TF (schema TEXT WEIGHT)
     TextIndex::Container::BlockListIterator it;
     TextIndex::Container::BlockListIterator end;
   };
@@ -739,16 +747,18 @@ struct BasicSearch {
     // Open cursors on posting lists for each matched term.
     vector<TermCursor> cursors;
     cursors.reserve(matched_text_terms_.size());
-    for (const auto& [index, term] : matched_text_terms_) {
-      auto* container = index->Matching(term, /*strip_whitespace=*/false);
+    for (const auto& matched : matched_text_terms_) {
+      auto* index = matched.index;
+      auto* container = index->Matching(matched.term, /*strip_whitespace=*/false);
       if (!container)
         continue;
       string_view field_ident = index->field_ident();
       size_t term_docs =
-          global_stats_ ? global_stats_->GetTermDocs(field_ident, term) : container->Size();
+          global_stats_ ? global_stats_->GetTermDocs(field_ident, matched.term) : container->Size();
       double avg = global_stats_ ? global_stats_->GetFieldAvgDocLen(field_ident)
                                  : index->GetFieldAvgDocLen();
-      cursors.push_back({index, term_docs, avg, container->begin(), container->end()});
+      cursors.push_back({index, term_docs, avg, matched.weight, GetSchemaTextWeight(index),
+                         container->begin(), container->end()});
     }
 
     ScoringContext ctx{global_stats_ ? global_stats_->num_docs : indices_->GetAllDocs().size()};
@@ -769,6 +779,8 @@ struct BasicSearch {
           term_infos[t].field_doc_len = cursors[t].index->GetFieldDocLength(doc);
           term_infos[t].field_avg_doc_len = cursors[t].field_avg_doc_len;
         }
+        term_infos[t].query_weight = cursors[t].query_weight;
+        term_infos[t].field_weight = cursors[t].field_weight;
       }
       float score = static_cast<float>(ScoreDocument(*scorer_, ctx, term_infos));
       max_text_score = max(max_text_score, score);
@@ -795,14 +807,28 @@ struct BasicSearch {
     return std::make_tuple(std::move(out), total_size, std::move(text_scores), max_text_score);
   }
 
+  double GetSchemaTextWeight(TextIndex* index) const {
+    string_view field_ident = index->field_ident();
+    auto it = indices_->GetSchema().fields.find(field_ident);
+    if (it == indices_->GetSchema().fields.end() || it->second.type != SchemaField::TEXT)
+      return 1.0;
+    return std::get<SchemaField::TextParams>(it->second.special_params).weight;
+  }
+
   void AddMatchedTerm(TextIndex* index, string term) {
-    if (matched_terms_set_.emplace(index, term).second)
-      matched_text_terms_.emplace_back(index, std::move(term));
+    auto [it, inserted] =
+        matched_terms_index_.try_emplace(std::make_pair(index, term), matched_text_terms_.size());
+    if (inserted) {
+      matched_text_terms_.push_back({index, std::move(term), current_weight_});
+    } else {
+      matched_text_terms_[it->second].weight += current_weight_;
+    }
   }
 
   const FieldIndices* indices_;
   optional<ScorerSpec> scorer_;
   const GlobalScoringStats* global_stats_ = nullptr;
+  double current_weight_ = 1.0;
 
   string error_;
   optional<ProfileBuilder> profile_builder_ = ProfileBuilder{};
@@ -810,11 +836,16 @@ struct BasicSearch {
   absl::flat_hash_map<DocId, float> knn_scores_;
   vector<pair<float, DocId>> knn_distances_;
 
-  // Tracked text terms for scoring: (TextIndex*, normalized_term)
-  // Deduplicated via matched_terms_set_ to avoid double-counting synonyms resolved to same
-  // group_id.
-  vector<pair<TextIndex*, string>> matched_text_terms_;
-  absl::flat_hash_set<pair<TextIndex*, string>> matched_terms_set_;
+  struct MatchedTextTerm {
+    TextIndex* index;
+    string term;
+    double weight;
+  };
+
+  // Tracked text terms for scoring. Repeated query occurrences accumulate weight per
+  // (TextIndex*, term); individual expansion sites still dedupe their own synonym aliases.
+  vector<MatchedTextTerm> matched_text_terms_;
+  absl::flat_hash_map<pair<TextIndex*, string>, size_t> matched_terms_index_;
 };
 
 #ifndef __clang__

--- a/src/core/search/search.h
+++ b/src/core/search/search.h
@@ -101,9 +101,18 @@ struct SchemaField {
   };
 
   struct TextParams {
+    // Sanity cap mirroring VectorParams::kMaxHnswEpsilon: rejects absurd weights so the schema
+    // weight folded into the effective term frequency cannot overflow BM25 to inf/NaN.
+    static constexpr double kMaxWeight = 1e6;
+
+    static bool IsValidWeight(double weight) {
+      return weight >= 0 && weight <= kMaxWeight && std::isfinite(weight);
+    }
+
     // if enabled, suffix trie is build for efficient suffix and infix queries
     bool with_suffixtrie = false;
     bool no_stem = false;
+    double weight = 1.0;
   };
 
   struct NumericParams {

--- a/src/core/search/search_test.cc
+++ b/src/core/search/search_test.cc
@@ -3093,6 +3093,21 @@ TEST_F(ScoringTest, BM25StdMultiTerm) {
   EXPECT_DOUBLE_EQ(multi, sum);
 }
 
+TEST_F(ScoringTest, BM25StdNonFiniteWeightStaysFinite) {
+  // A pathological field weight can overflow the effective frequency to +inf; BM25 must not turn
+  // that into NaN (which would corrupt top-K sorting). The TF saturation limit is k1 + 1.
+  ScoringContext ctx{.num_docs = 100};
+  ScoringTermInfo term{.term_freq = 10,
+                       .term_docs = 5,
+                       .field_doc_len = 10,
+                       .field_avg_doc_len = 10.0,
+                       .field_weight = 1e308};  // f = field_weight * term_freq overflows to +inf
+
+  double score = BM25Std(ctx, term);
+  EXPECT_TRUE(std::isfinite(score));
+  EXPECT_GT(score, 0.0);
+}
+
 TEST_F(ScoringTest, TfIdfFormula) {
   // f=2, N=10, n=3
   // IDF = ln(10/3) ~ 1.2039

--- a/src/server/search/doc_index.cc
+++ b/src/server/search/doc_index.cc
@@ -242,6 +242,7 @@ string DocIndexInfo::BuildRestoreCommand() const {
                         absl::StrAppend(out, " ", "WITHSUFFIXTRIE");
                     },
                     [out = &out](const search::SchemaField::TextParams& params) {
+                      absl::StrAppend(out, " ", "WEIGHT", " ", std::to_string(params.weight));
                       if (params.with_suffixtrie)
                         absl::StrAppend(out, " ", "WITHSUFFIXTRIE");
                       if (params.no_stem)

--- a/src/server/search/search_family.cc
+++ b/src/server/search/search_family.cc
@@ -180,6 +180,15 @@ ParseResult<std::string> ParseLanguageArg(CmdArgParser* parser) {
   return lang;
 }
 
+void ParseTextWeight(CmdArgParser* parser, search::SchemaField::TextParams* params) {
+  double weight = parser->Next<double>("Invalid WEIGHT value");
+  if (!search::SchemaField::TextParams::IsValidWeight(weight)) {
+    parser->ReportCustom("Invalid WEIGHT value");
+    return;
+  }
+  params->weight = weight;
+}
+
 ParseResult<search::SchemaField::TextParams> ParseTextParams(CmdArgParser* parser) {
   search::SchemaField::TextParams params{};
   while (parser->HasNext()) {
@@ -189,6 +198,10 @@ ParseResult<search::SchemaField::TextParams> ParseTextParams(CmdArgParser* parse
     }
     if (parser->Check("NOSTEM")) {
       params.no_stem = true;
+      continue;
+    }
+    if (parser->Check("WEIGHT")) {
+      ParseTextWeight(parser, &params);
       continue;
     }
     break;
@@ -326,7 +339,7 @@ ParseResult<bool> ParseStopwords(CmdArgParser* parser, DocIndex* index) {
 
 constexpr std::array<const std::string_view, 3> kIgnoredOptions = {"UNF"sv, "INDEXMISSING"sv,
                                                                    "INDEXEMPTY"sv};
-constexpr std::array<const std::string_view, 3> kIgnoredOptionsWithArg = {"WEIGHT"sv, "PHONETIC"sv};
+constexpr std::array<const std::string_view, 1> kIgnoredOptionsWithArg = {"PHONETIC"sv};
 
 // SCHEMA field [AS alias] type [flags...]
 ParseResult<bool> ParseSchema(CmdArgParser* parser, DocIndex* index) {
@@ -393,6 +406,10 @@ ParseResult<bool> ParseSchema(CmdArgParser* parser, DocIndex* index) {
         if (field_type == search::SchemaField::TEXT && option == "NOSTEM"sv) {
           std::get<search::SchemaField::TextParams>(params).no_stem = true;
           parser->Skip(1);
+          continue;
+        }
+        if (field_type == search::SchemaField::TEXT && parser->Check("WEIGHT")) {
+          ParseTextWeight(parser, &std::get<search::SchemaField::TextParams>(params));
           continue;
         }
         if (rng::find(kIgnoredOptions, option) != kIgnoredOptions.end()) {
@@ -2902,6 +2919,8 @@ void CmdFtInfo(CmdArgParser parser, CommandContext* cmd_cntx) {
         info.emplace_back("WITHSUFFIXTRIE");
     } else if (field_info.type == search::SchemaField::TEXT) {
       auto& tparams = std::get<search::SchemaField::TextParams>(field_info.special_params);
+      info.emplace_back("WEIGHT");
+      info.emplace_back(std::to_string(tparams.weight));
       if (tparams.with_suffixtrie)
         info.emplace_back("WITHSUFFIXTRIE");
       if (tparams.no_stem)

--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -457,7 +457,8 @@ TEST_F(SearchFamilyTest, InfoIndex) {
 
   auto descriptor_matcher = IsArray("key_type", "HASH", "prefixes", IsArray("doc-"),
                                     "default_language", "english", "default_score", 1);
-  auto schema_matcher = IsArray(IsArray("identifier", "name", "attribute", "name", "type", "TEXT"));
+  auto schema_matcher = IsArray(
+      IsArray("identifier", "name", "attribute", "name", "type", "TEXT", "WEIGHT", "1.000000"));
 
   EXPECT_THAT(info, IsArray(_, _, _, descriptor_matcher, "index_options", RespArray(IsEmpty()),
                             "attributes", schema_matcher, "num_docs", IntArg(15), "indexing",
@@ -3562,30 +3563,10 @@ TEST_F(SearchFamilyTest, SearchReindexWriteSearchRace) {
 }
 
 TEST_F(SearchFamilyTest, IgnoredOptionsInFtCreate) {
-  GTEST_SKIP() << "The usage of ignored options is now wrong - it skips supported ones!";
-
-  // Create an index with various options, some of which should be ignored
-  // INDEXMISSING and INDEXEMPTY are supported by default
-  auto resp = Run({"FT.CREATE",
-                   "idx",
-                   "ON",
-                   "HASH",
-                   "SCHEMA",
-                   "title",
-                   "TEXT",
-                   "UNF",
-                   "NOSTEM",
-                   "CASESENSITIVE",
-                   "WITHSUFFIXTRIE",
-                   "INDEXMISSING",
-                   "INDEXEMPTY",
-                   "WEIGHT",
-                   "1",
-                   "SEPARATOR",
-                   "|",
-                   "PHONETIC",
-                   "dm:en",
-                   "SORTABLE"});
+  // Supported text params (WITHSUFFIXTRIE/NOSTEM/WEIGHT) must precede flags and ignored options.
+  auto resp =
+      Run({"FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "title", "TEXT", "WITHSUFFIXTRIE", "NOSTEM",
+           "WEIGHT", "2", "SORTABLE", "UNF", "INDEXMISSING", "INDEXEMPTY", "PHONETIC", "dm:en"});
 
   // Check that the response is OK, indicating the index was created successfully
   EXPECT_THAT(resp, "OK");
@@ -6901,6 +6882,27 @@ TEST(BuildRestoreCommandTest, TextNoStemPreserved) {
   EXPECT_THAT(info.BuildRestoreCommand(), HasSubstr("NOSTEM"));
 }
 
+TEST(BuildRestoreCommandTest, TextWeightPreserved) {
+  using dfly::DocIndex;
+  using dfly::DocIndexInfo;
+  using dfly::search::SchemaField;
+
+  SchemaField field;
+  field.type = SchemaField::TEXT;
+  field.flags = 0;
+  field.short_name = "title";
+  field.special_params = SchemaField::TextParams{.weight = 3.5};
+
+  DocIndex base;
+  base.type = DocIndex::HASH;
+  base.schema.fields["title"] = std::move(field);
+
+  DocIndexInfo info;
+  info.base_index = std::move(base);
+
+  EXPECT_THAT(info.BuildRestoreCommand(), HasSubstr("WEIGHT 3.500000"));
+}
+
 // Verify that BuildRestoreCommand preserves WITHSUFFIXTRIE for TAG fields.
 TEST(BuildRestoreCommandTest, TagWithSuffixTriePreserved) {
   using dfly::DocIndex;
@@ -7044,8 +7046,8 @@ TEST_F(SearchFamilyTest, InfoIndexTextParams) {
 
   auto info = Run({"ft.info", "idx"});
 
-  auto text_field_matcher =
-      IsArray("identifier", "title", "attribute", "title", "type", "TEXT", "WITHSUFFIXTRIE");
+  auto text_field_matcher = IsArray("identifier", "title", "attribute", "title", "type", "TEXT",
+                                    "WEIGHT", "1.000000", "WITHSUFFIXTRIE");
 
   EXPECT_THAT(
       info, IsArray(_, _, _, _, _, _, "attributes", IsArray(text_field_matcher), _, _, _, _, _, _));
@@ -7268,8 +7270,10 @@ TEST_F(SearchFamilyTest, StemmingInfoSurface) {
        "body", "TEXT", "NOSTEM"});
 
   auto info = Run({"FT.INFO", "info_idx"});
-  auto title_matcher = IsArray("identifier", "title", "attribute", "title", "type", "TEXT");
-  auto body_matcher = IsArray("identifier", "body", "attribute", "body", "type", "TEXT", "NOSTEM");
+  auto title_matcher =
+      IsArray("identifier", "title", "attribute", "title", "type", "TEXT", "WEIGHT", "1.000000");
+  auto body_matcher = IsArray("identifier", "body", "attribute", "body", "type", "TEXT", "WEIGHT",
+                              "1.000000", "NOSTEM");
   auto definition = IsArray("key_type", "HASH", "prefixes", IsArray("doc:"), "default_language",
                             "english", "default_score", 1);
   EXPECT_THAT(info, IsArray(_, _, _, definition, _, _, "attributes",
@@ -7837,6 +7841,167 @@ TEST_F(SearchFamilyTest, SearchWithScoresPerField) {
   // and same title field length (1), so scores should be equal regardless of body length.
   EXPECT_DOUBLE_EQ(scores["d:1"], scores["d:2"])
       << "Per-field scoring: body length should not affect title-only query score";
+}
+
+TEST_F(SearchFamilyTest, TextWeightsInfoAndScoring) {
+  EXPECT_THAT(Run({"FT.CREATE", "bad_weight", "SCHEMA", "title", "TEXT", "WEIGHT", "-1"}),
+              ErrArg("Invalid WEIGHT value"));
+  // Above the sanity cap (TextParams::kMaxWeight) so the folded weight cannot overflow BM25.
+  EXPECT_THAT(Run({"FT.CREATE", "huge_weight", "SCHEMA", "title", "TEXT", "WEIGHT", "1e7"}),
+              ErrArg("Invalid WEIGHT value"));
+
+  EXPECT_EQ(Run({"ft.create", "idx", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "title", "TEXT",
+                 "WEIGHT", "5", "body", "TEXT", "tag", "TAG"}),
+            "OK");
+
+  auto info = Run({"FT.INFO", "idx"});
+  auto title =
+      IsArray("identifier", "title", "attribute", "title", "type", "TEXT", "WEIGHT", "5.000000");
+  auto body =
+      IsArray("identifier", "body", "attribute", "body", "type", "TEXT", "WEIGHT", "1.000000");
+  auto tag = IsArray("identifier", "tag", "attribute", "tag", "type", "TAG", "SEPARATOR", ",");
+  EXPECT_THAT(info, IsArray(_, _, _, _, _, _, "attributes", IsUnordArray(title, body, tag), _, _, _,
+                            _, _, _));
+
+  Run({"HSET", "d:1", "title", "hello", "body", "other", "tag", "yes"});
+  Run({"HSET", "d:2", "title", "other", "body", "hello", "tag", "yes"});
+
+  auto resp = Run({"FT.SEARCH", "idx", "hello", "NOCONTENT", "WITHSCORES", "LIMIT", "0", "10"});
+  ASSERT_THAT(resp, ArgType(RespExpr::ARRAY));
+  const auto& vals = resp.GetVec();
+  ASSERT_EQ(vals.size(), 5u);
+  EXPECT_EQ(vals[1].GetString(), "d:1");
+  EXPECT_EQ(vals[3].GetString(), "d:2");
+  EXPECT_GT(std::stod(vals[2].GetString()), std::stod(vals[4].GetString()));
+}
+
+TEST_F(SearchFamilyTest, AlterTextWeight) {
+  Run({"HSET", "d:1", "title", "hello", "body", "weighted"});
+  EXPECT_EQ(Run({"FT.CREATE", "idx", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "title", "TEXT"}),
+            "OK");
+
+  EXPECT_EQ(Run({"FT.ALTER", "idx", "SCHEMA", "ADD", "body", "TEXT", "WEIGHT", "4"}), "OK");
+  WaitForIndexReady("idx");
+
+  auto info = Run({"FT.INFO", "idx"});
+  auto title =
+      IsArray("identifier", "title", "attribute", "title", "type", "TEXT", "WEIGHT", "1.000000");
+  auto body =
+      IsArray("identifier", "body", "attribute", "body", "type", "TEXT", "WEIGHT", "4.000000");
+  EXPECT_THAT(info,
+              IsArray(_, _, _, _, _, _, "attributes", IsUnordArray(title, body), _, _, _, _, _, _));
+  EXPECT_THAT(Run({"FT.SEARCH", "idx", "@body:weighted"}), AreDocIds("d:1"));
+}
+
+TEST_F(SearchFamilyTest, QueryWeightsScaleScores) {
+  EXPECT_EQ(Run({"ft.create", "idx", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "text", "TEXT",
+                 "tag", "TAG"}),
+            "OK");
+  Run({"HSET", "d:1", "text", "hello", "tag", "yes"});
+
+  auto score = [this](std::string_view query) {
+    auto resp = Run({"FT.SEARCH", "idx", query, "NOCONTENT", "WITHSCORES", "SCORER", "BM25STD",
+                     "PARAMS", "2", "w", "4"});
+    const auto& vals = resp.GetVec();
+    EXPECT_EQ(vals.size(), 3u);
+    return std::stod(vals[2].GetString());
+  };
+
+  double raw = score("hello");
+  EXPECT_NEAR(score("hello=>{$weight:5}"), raw * 5, 1e-6);
+  EXPECT_NEAR(score("hello=>{$weight:5} hello=>{$weight:3}"), raw * 8, 1e-5);
+  EXPECT_NEAR(score("hello=>{$weight:$w}"), raw * 4, 1e-5);
+
+  auto tag_resp = Run({"FT.SEARCH", "idx", "@tag:{yes}=>{$weight:2}", "NOCONTENT", "WITHSCORES"});
+  EXPECT_THAT(tag_resp, RespElementsAre(IntArg(1), "d:1", "0"));
+
+  // Query-time weight above the sanity cap is rejected by the parser.
+  EXPECT_THAT(Run({"FT.SEARCH", "idx", "hello=>{$weight:1e7}"}), ErrArg("Query syntax error"));
+}
+
+TEST_F(SearchFamilyTest, AggregateAddScoresUsesQueryWeights) {
+  EXPECT_EQ(Run({"ft.create", "idx", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "text", "TEXT"}),
+            "OK");
+  Run({"HSET", "d:1", "text", "hello"});
+
+  auto score = [this](std::string_view query) {
+    auto resp = Run({"FT.AGGREGATE", "idx", query, "ADDSCORES", "LOAD", "1", "@__score"});
+    const auto& vals = resp.GetVec();
+    EXPECT_EQ(vals.size(), 2u);
+    return map_score("__score", vals[1].GetVec());
+  };
+
+  double raw = score("hello");
+  EXPECT_NEAR(score("hello=>{$weight:3}"), raw * 3, 1e-6);
+}
+
+TEST_F(SearchFamilyTest, SynonymQueryWeightScaling) {
+  EXPECT_EQ(Run({"ft.create", "idx", "ON", "HASH", "PREFIX", "1", "d:", "SCHEMA", "t", "TEXT"}),
+            "OK");
+  EXPECT_EQ(Run({"FT.SYNUPDATE", "idx", "g1", "car", "automobile"}), "OK");
+  Run({"HSET", "d:1", "t", "car"});
+  Run({"HSET", "d:2", "t", "automobile"});
+
+  // id -> score from a WITHSCORES NOCONTENT reply.
+  auto scores = [this](std::string_view query) {
+    auto resp = Run({"FT.SEARCH", "idx", query, "NOCONTENT", "WITHSCORES", "SCORER", "BM25STD",
+                     "LIMIT", "0", "10"});
+    std::map<std::string, double> out;
+    const auto& vals = resp.GetVec();
+    for (size_t i = 1; i + 1 < vals.size(); i += 2)
+      out[vals[i].GetString()] = std::stod(vals[i + 1].GetString());
+    return out;
+  };
+
+  auto raw = scores("car");
+  auto weighted = scores("car=>{$weight:2}");
+  ASSERT_EQ(raw.size(), 2u);
+  ASSERT_EQ(weighted.size(), 2u);
+  // Weight scales each score uniformly (incl. the synonym-matched d:2); the synonym group token
+  // is not double-counted, so every score is exactly 2x its unweighted value.
+  for (const auto& [id, raw_score] : raw) {
+    ASSERT_TRUE(weighted.count(id));
+    EXPECT_GT(raw_score, 0.0);
+    EXPECT_NEAR(weighted[id], raw_score * 2.0, 1e-4);
+  }
+}
+
+TEST_F(SearchFamilyTest, SchemaWeightFoldsIntoTermFrequency) {
+  // Schema TEXT WEIGHT is folded into the effective term frequency before BM25 saturation: a
+  // high-weight field saturates instead of scaling the score linearly. The weighted scores below
+  // are reference values captured from redis:8.6 (FT.SEARCH ... SCORER BM25STD) - both engines
+  // agree to 6 significant digits on this index.
+  EXPECT_EQ(Run({"FT.CREATE", "w", "ON", "HASH", "PREFIX", "1", "w:", "SCHEMA", "name", "TEXT",
+                 "WEIGHT", "5"}),
+            "OK");
+  EXPECT_EQ(Run({"FT.CREATE", "nw", "ON", "HASH", "PREFIX", "1", "n:", "SCHEMA", "name", "TEXT"}),
+            "OK");
+  for (std::string_view p : {"w:", "n:"}) {
+    Run({"HSET", absl::StrCat(p, "1"), "name", "mal premium"});  // f=1
+    Run({"HSET", absl::StrCat(p, "2"), "name", "mal mal mal"});  // f=3
+    Run({"HSET", absl::StrCat(p, "3"), "name", "other thing"});  // no match
+  }
+
+  auto score = [this](std::string_view index, std::string_view id) {
+    auto resp = Run({"FT.SEARCH", index, "mal", "NOCONTENT", "WITHSCORES", "SCORER", "BM25STD",
+                     "LIMIT", "0", "10"});
+    const auto& vals = resp.GetVec();
+    for (size_t i = 1; i + 1 < vals.size(); i += 2)
+      if (vals[i].GetString() == id)
+        return std::stod(vals[i + 1].GetString());
+    return -1.0;
+  };
+
+  double nw1 = score("nw", "n:1"), nw2 = score("nw", "n:2");
+  double w1 = score("w", "w:1"), w2 = score("w", "w:2");
+
+  // Exact match to redis:8.6.
+  EXPECT_NEAR(w1, 0.851536, 1e-4);
+  EXPECT_NEAR(w2, 0.942455, 1e-4);
+
+  // Saturation signature: the boost is sub-linear (not a flat x5) and larger for the low-tf doc.
+  EXPECT_LT(w1, nw1 * 5.0);
+  EXPECT_GT(w1 / nw1, w2 / nw2);
 }
 
 // Verify ADDSCORES makes __score visible even without explicit LOAD or pipeline steps

--- a/tests/dragonfly/search_test.py
+++ b/tests/dragonfly/search_test.py
@@ -290,7 +290,7 @@ async def test_management(async_client: aioredis.Redis):
     ]
     assert i1info["num_docs"] == 10
     assert sorted(i1info["attributes"]) == [
-        ["identifier", "f1", "attribute", "f1", "type", "TEXT"],
+        ["identifier", "f1", "attribute", "f1", "type", "TEXT", "WEIGHT", "1.000000"],
         [
             "identifier",
             "f2",


### PR DESCRIPTION
Follow-up to the `=>{$weight}` parsing PR: make the parsed weights actually affect ranking, and add schema-level `TEXT WEIGHT`.

Changes:
- Query-time `$weight` scales a term's score contribution (linear; repeated terms accumulate, synonym dedupe preserved)
- Schema `TEXT WEIGHT N` (FT.CREATE / FT.ALTER) folded into the effective term frequency before BM25 saturation
- `FT.INFO` reports `WEIGHT`; round-tripped via the restore command
- Tests: query/schema scaling, synonym, ADDSCORES