### PR TITLE
Fix quadratic zstd list load compression

### DIFF
--- a/src/core/qlist.cc
+++ b/src/core/qlist.cc
@@ -1626,13 +1626,12 @@ void QList::BackfillCompressWithZstdDict() {
     }
   }
 
-  // Only mark failure if we actually tried to compress nodes and all failed.
-  if (any_attempted) {
-    if (any_compressed)
-      dict_bulk_finished_ = 1;
-    else
-      dict_bulk_failed_ = 1;
-  }
+  // Avoid full scan again by setting either of flags.
+  // In case none of the nodes succeeded to compress, we will not attempt to compress again.
+  if (any_attempted && !any_compressed)
+    dict_bulk_failed_ = 1;
+  else
+    dict_bulk_finished_ = 1;
 }
 
 void QList::CompressAfterLoad() {

--- a/src/core/qlist.cc
+++ b/src/core/qlist.cc
@@ -496,6 +496,7 @@ QList& QList::operator=(QList&& other) noexcept {
 void QList::MoveFrom(QList&& other) {
   head_ = other.head_;
   len_ = other.len_;
+  malloc_size_ = other.malloc_size_;
   count_ = other.count_;
   fill_ = other.fill_;
   dict_learning_failed_ = other.dict_learning_failed_;
@@ -504,9 +505,12 @@ void QList::MoveFrom(QList&& other) {
   tiering_enabled_ = other.tiering_enabled_;
   compress_ = other.compress_;
   bookmark_count_ = other.bookmark_count_;
+  db_id_ = other.db_id_;
+  zstd_threshold_ = other.zstd_threshold_;
   tiering_params_ = std::move(other.tiering_params_);
 
   other.head_ = nullptr;
+  other.malloc_size_ = 0;
   other.len_ = other.count_ = 0;
 }
 
@@ -967,7 +971,6 @@ void QList::CoolOff(Node* node, uint32_t node_id) {
     } else if (tl_zstd_dict) {
       // Dict exists (trained by this or another instance), bulk-compress all interior nodes.
       BackfillCompressWithZstdDict();
-      dict_bulk_finished_ = 1;
     } else if (!dict_learning_failed_ && malloc_size_ >= zstd_threshold_ && len_ >= 2) {
       // No dict yet, try to train one.
       TrainZstdDict();
@@ -1604,13 +1607,17 @@ bool QList::TrainZstdDict() {
 void QList::BackfillCompressWithZstdDict() {
   DCHECK(tl_zstd_dict);
 
-  // Bulk-compress all interior nodes, tracking memory delta.
+  if (len_ < 3)
+    return;
+
   bool any_compressed = false;
   bool any_attempted = false;
-  for (Node* node = head_; node; node = node->next) {
-    if (node == head_ || node->next == nullptr)
-      continue;
-    if (node->encoding == QUICKLIST_NODE_ENCODING_RAW && node->sz >= MIN_COMPRESS_BYTES)
+  // Scan from tail backwards. On chunked loads, the first compressed node marks the already
+  // processed prefix.
+  for (Node* node = head_->prev->prev; node && node != head_; node = node->prev) {
+    if (node->encoding != QUICKLIST_NODE_ENCODING_RAW)
+      break;
+    if (node->sz >= MIN_COMPRESS_BYTES)
       any_attempted = true;
     size_t prev_size = zmalloc_usable_size(node->entry);
     if (CompressNodeWithDict(node)) {
@@ -1620,8 +1627,11 @@ void QList::BackfillCompressWithZstdDict() {
   }
 
   // Only mark failure if we actually tried to compress nodes and all failed.
-  if (any_attempted && !any_compressed) {
-    dict_bulk_failed_ = 1;
+  if (any_attempted) {
+    if (any_compressed)
+      dict_bulk_finished_ = 1;
+    else
+      dict_bulk_failed_ = 1;
   }
 }
 
@@ -1629,7 +1639,7 @@ void QList::CompressAfterLoad() {
   // Mirrors the ZSTD branch of CoolOff(), but runs in one shot after a bulk load
   // instead of being driven incrementally by per-element pushes (which never
   // happen during AppendListpack/AppendPlain).
-  if (!IsZstdDictMode())
+  if (!IsZstdDictMode() || dict_bulk_failed_)
     return;
 
   if (!tl_zstd_dict) {
@@ -1643,7 +1653,6 @@ void QList::CompressAfterLoad() {
 
   // A dictionary exists (trained here or by another list on this thread).
   BackfillCompressWithZstdDict();
-  dict_bulk_finished_ = 1;
 }
 
 bool QList::CompressNodeWithDict(Node* node) {

--- a/src/core/qlist.h
+++ b/src/core/qlist.h
@@ -362,7 +362,8 @@ class QList {
   bool TrainZstdDict();
 
   // Bulk-compresses all interior nodes using the thread-local ZSTD dictionary.
-  // Sets dict_bulk_failed_ if no nodes could be compressed.
+  // A completed walk always sets a terminal flag: dict_bulk_failed_ when real nodes were tried
+  // but none compressed (dict useless for this list), otherwise dict_bulk_finished_.
   void BackfillCompressWithZstdDict();
 
   // Compresses a single node using the thread-local ZSTD dictionary.

--- a/src/core/qlist_test.cc
+++ b/src/core/qlist_test.cc
@@ -1217,6 +1217,44 @@ TEST_F(QListZstdTest, CompressAfterLoad) {
   EXPECT_EQ(count, kNodes * kEntriesPerNode);
 }
 
+TEST_F(QListZstdTest, CompressAfterLoadChunkedAppend) {
+  QList ql(-1, 0);
+  ql.set_compr_threshold(1);
+
+  constexpr unsigned kEntriesPerNode = 30;
+  for (unsigned n = 0; n < 4; ++n) {
+    ql.AppendListpack(BuildCeleryListpack(kEntriesPerNode, 100000 + n * kEntriesPerNode));
+  }
+  ql.CompressAfterLoad();
+
+  const QList::Node* old_tail = ql.Tail();
+  ASSERT_EQ(old_tail->encoding, QUICKLIST_NODE_ENCODING_RAW);
+
+  QList moved(std::move(ql));
+  old_tail = moved.Tail();
+
+  for (unsigned n = 4; n < 7; ++n) {
+    moved.AppendListpack(BuildCeleryListpack(kEntriesPerNode, 100000 + n * kEntriesPerNode));
+  }
+  moved.CompressAfterLoad();
+
+  // The previous tail became interior after appending the next chunk, so it should be compressed
+  // without rescanning the already-finished prefix.
+  EXPECT_EQ(old_tail->encoding, QLIST_NODE_ENCODING_ZSTD);
+  EXPECT_EQ(moved.Head()->encoding, QUICKLIST_NODE_ENCODING_RAW);
+  EXPECT_EQ(moved.Tail()->encoding, QUICKLIST_NODE_ENCODING_RAW);
+
+  unsigned count = 0;
+  moved.Iterate(
+      [&](const QList::Entry& e) {
+        EXPECT_GT(e.view().size(), 50u);
+        ++count;
+        return true;
+      },
+      0, -1);
+  EXPECT_EQ(count, 7u * kEntriesPerNode);
+}
+
 TEST_F(QListZstdTest, CompressAfterLoadPlainNode) {
   // Plain (single large element) interior nodes are also covered: they are
   // included in dictionary training and compressed, and decompressed on read.


### PR DESCRIPTION
Summary:
Fix chunked RDB list loading with experimental zstd dictionaries so post-load compression scans only newly appended nodes after the initial pass.

Changes:
- Add incremental post-load compression for appended list chunks
- Preserve QList move state needed by chunked load handoff
- Add a regression test for chunked append after move

Validation:
- pre-commit run --files src/core/qlist.cc src/core/qlist.h src/core/qlist_test.cc
- ninja -C build-opt qlist_test && ./build-opt/qlist_test --gtest_filter=QListZstdTest.*
- ninja -C build-opt dragonfly
- Timed DFLY LOAD on the provided DFS snapshot with and without the zstd flag