### PR TITLE
fix(transaction): Fix polling after running_tx conflict

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -153,6 +153,7 @@ helio_cxx_test(rdb_test dfly_test_lib DATA testdata/empty.rdb testdata/redis6_sm
 helio_cxx_test(zset_family_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(geo_family_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(blocking_controller_test dfly_test_lib LABELS DFLY)
+helio_cxx_test(transaction_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(json_family_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(json_family_memory_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(journal/journal_test dfly_test_lib LABELS DFLY)

--- a/src/server/blocking_controller.h
+++ b/src/server/blocking_controller.h
@@ -27,6 +27,11 @@ class BlockingController {
     return !awakened_transactions_.empty();
   }
 
+  // Whether any transaction is currently suspended (blocked) on a watched key in this shard.
+  bool HasBlockedTransactions() const {
+    return !watched_dbs_.empty();
+  }
+
   const auto& awakened_transactions() const {
     return awakened_transactions_;
   }

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -606,24 +606,30 @@ void EngineShard::DestroyThreadLocal() {
   VLOG(1) << "Shard reset " << shard_id;
 }
 
-// Is called by Transaction::ExecuteAsync in order to run transaction tasks.
-// Only runs in its own thread.
 void EngineShard::PollExecution(const char* context, Transaction* trans) {
+  // Only one transaction can run at a time, so we have to abort the Poll while running_tx is
+  // suspended. Running tx issues a follow up Poll is needs_repoll_ was set
+  if (running_tx_) {
+    needs_repoll_ = true;
+    return;
+  }
+
+  // Call PollExecutionInternal and repeat the call if we interrupted someone elses Poll
+  do {
+    needs_repoll_ = false;
+    PollExecutionInternal(context, trans);
+    trans = nullptr;  // we repeat with null transaction
+    context = "repoll";
+  } while (needs_repoll_);
+}
+
+void EngineShard::PollExecutionInternal(const char* context, Transaction* trans) {
   DVLOG(2) << "PollExecution " << context << " " << (trans ? trans->DebugId() : "") << " "
            << txq_.size() << " " << (continuation_trans_ ? continuation_trans_->DebugId() : "");
 
+  DCHECK(running_tx_ == nullptr) << running_tx_->DebugId();
   ShardId sid = shard_id();
   stats_.poll_execution_total++;
-
-  // If another transaction is currently running on this shard (e.g. an inlined tx preempted
-  // on the connection fiber), we must not run any callbacks to avoid interleaving.
-  if (running_tx_) {
-    // The transaction (if any) if armed, must be in the txq so a future PollExecution picks it up.
-    DCHECK(trans == nullptr || !trans->DEBUG_IsArmedInShard(sid) ||
-           trans->DEBUG_GetTxqPosInShard(sid) != TxQueue::kEnd)
-        << context << " " << trans->DebugId();
-    return;
-  }
 
   // If any of the following flags are present, we are guaranteed to run in this function:
   // 1. AWAKED_Q -> Blocking transactions are executed immediately after waking up, they don't

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -618,13 +618,18 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
     return;
   }
 
-  // Call PollExecutionInternal and repeat the call if we interrupted someone elses Poll
-  do {
-    needs_repoll_ = false;
-    PollExecutionInternal(context, trans);
-    trans = nullptr;  // we repeat with null transaction
-    context = "repoll";
-  } while (needs_repoll_);
+  needs_repoll_ = false;
+  PollExecutionInternal(context, trans);
+
+  // Executing `trans` out of order above would not follow up with queue processing, so
+  // we need to issue another poll if we interruped another poll request.
+  // Because it runs with trans=nullptr, it progresses only on the loop and does not need follow ups
+  PollExecutionIfDeferred();
+}
+
+void EngineShard::PollExecutionIfDeferred() {
+  if (std::exchange(needs_repoll_, false))
+    PollExecutionInternal("repoll", nullptr);
 }
 
 void EngineShard::PollExecutionInternal(const char* context, Transaction* trans) {

--- a/src/server/engine_shard.cc
+++ b/src/server/engine_shard.cc
@@ -610,6 +610,10 @@ void EngineShard::PollExecution(const char* context, Transaction* trans) {
   // Only one transaction can run at a time, so we have to abort the Poll while running_tx is
   // suspended. Running tx issues a follow up Poll is needs_repoll_ was set
   if (running_tx_) {
+    // Check that trans doesn't need processing or is guaranteed to be found via txq/continuation
+    DCHECK(trans == nullptr || !trans->DEBUG_IsArmedInShard(shard_id())  // tx was already disarmed
+           || trans->DEBUG_GetTxqPosInShard(shard_id()) != TxQueue::kEnd ||
+           continuation_trans_ == trans);
     needs_repoll_ = true;
     return;
   }

--- a/src/server/engine_shard.h
+++ b/src/server/engine_shard.h
@@ -92,6 +92,12 @@ class EngineShard {
   // shard. Tries executing the passed transaction if possible (does not guarantee though).
   void PollExecution(const char* context, Transaction* trans);
 
+  // Call after running inlined to keep progress on the transaction queue if it was interrupted
+  void PollExecutionIfDeferred() {
+    if (needs_repoll_)
+      PollExecution("after_inline", nullptr);
+  }
+
   // Returns transaction queue.
   TxQueue* txq() {
     return &txq_;
@@ -264,6 +270,8 @@ class EngineShard {
 
   EngineShard(util::ProactorBase* pb, mi_heap_t* heap);
 
+  void PollExecutionInternal(const char* context, Transaction* trans);
+
   // blocks the calling fiber.
   void Shutdown();  // called before destructing EngineShard.
 
@@ -308,8 +316,11 @@ class EngineShard {
 
   // Logical ts used to order distributed transactions.
   TxId committed_txid_ = 0;
+
   Transaction* continuation_trans_ = nullptr;
   Transaction* running_tx_ = nullptr;
+  bool needs_repoll_ = false;  // set when running_tx_ interrupted a PollExecution call
+
   std::string continuation_debug_id_;
   unsigned poll_concurrent_factor_ = 0;
 

--- a/src/server/engine_shard.h
+++ b/src/server/engine_shard.h
@@ -93,10 +93,7 @@ class EngineShard {
   void PollExecution(const char* context, Transaction* trans);
 
   // Call after running inlined to keep progress on the transaction queue if it was interrupted
-  void PollExecutionIfDeferred() {
-    if (needs_repoll_)
-      PollExecution("after_inline", nullptr);
-  }
+  void PollExecutionIfDeferred();
 
   // Returns transaction queue.
   TxQueue* txq() {

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1621,22 +1621,32 @@ bool Transaction::CanRunInlined() const {
   auto* ss = ServerState::tlocal();
   auto* es = EngineShard::tlocal();
 
+  // Transaction coordinator must be on the same thread at the target shard
+  if (unique_shard_cnt_ != 1 || unique_shard_id_ != ss->thread_index())
+    return false;
+
+  DCHECK(es);
+
   // Global transactions like SAVE can change the inlining rules, so run them non-inlined.
   // This guarantees that their PollExecution batch executes on the shard-queue fiber
   // when the conditions update.
+  if (!ss->AllowInlineScheduling() || IsGlobal())
+    return false;
+
   // We also refuse to inline when another transaction is already running on this shard:
   // journal/db-slice callbacks invoked from RunCallback can preempt, and a nested inlined
   // transaction would interleave its own callback loop with the outer one.
+  if (es->running_tx() != nullptr)
+    return false;
+
   // Lastly: we refuse with blocking transactions. They run fully apart in PollExecution without
   // being tracked in the tx queue, so a conflict with a suspended running tx can't be resolved.
-  auto* bc = es != nullptr ? namespace_->GetBlockingController(es->shard_id()) : nullptr;
-  if (unique_shard_cnt_ == 1 && unique_shard_id_ == ss->thread_index() &&
-      ss->AllowInlineScheduling() && !IsGlobal() && es->running_tx() == nullptr &&
-      (bc == nullptr || !bc->HasBlockedTransactions())) {
-    ss->stats.tx_inline_runs++;
-    return true;
-  }
-  return false;
+  if (auto* bc = namespace_->GetBlockingController(es->shard_id());
+      bc != nullptr && bc->HasBlockedTransactions())
+    return false;
+
+  ss->stats.tx_inline_runs++;
+  return true;
 }
 
 OpResult<KeyIndex> DetermineKeys(const CommandId* cid, const facade::ParsedArgs& args) {

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -1627,8 +1627,12 @@ bool Transaction::CanRunInlined() const {
   // We also refuse to inline when another transaction is already running on this shard:
   // journal/db-slice callbacks invoked from RunCallback can preempt, and a nested inlined
   // transaction would interleave its own callback loop with the outer one.
+  // Lastly: we refuse with blocking transactions. They run fully apart in PollExecution without
+  // being tracked in the tx queue, so a conflict with a suspended running tx can't be resolved.
+  auto* bc = es != nullptr ? namespace_->GetBlockingController(es->shard_id()) : nullptr;
   if (unique_shard_cnt_ == 1 && unique_shard_id_ == ss->thread_index() &&
-      ss->AllowInlineScheduling() && !IsGlobal() && es->running_tx() == nullptr) {
+      ss->AllowInlineScheduling() && !IsGlobal() && es->running_tx() == nullptr &&
+      (bc == nullptr || !bc->HasBlockedTransactions())) {
     ss->stats.tx_inline_runs++;
     return true;
   }

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -732,8 +732,9 @@ void Transaction::ScheduleInternal() {
       CHECK(ScheduleInShard(EngineShard::tlocal(), optimistic_exec));
       run_barrier_.Dec();
 
-      // Drain any work that was deferred while this inlined tx held running_tx_.
-      EngineShard::tlocal()->PollExecution("after_inline", nullptr);
+      // If the optimistic run above held running_tx_ and deferred any poll on this shard,
+      // drain it now. Uses the same needs_repoll_ mechanism as PollExecution's re-drive loop.
+      EngineShard::tlocal()->PollExecutionIfDeferred();
       break;
     }
 

--- a/src/server/transaction_test.cc
+++ b/src/server/transaction_test.cc
@@ -1,0 +1,167 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "server/transaction.h"
+
+#include <absl/flags/flag.h>
+#include <gmock/gmock.h>
+
+#include "base/logging.h"
+#include "facade/facade_stats.h"
+#include "server/acl/acl_commands_def.h"
+#include "server/command_registry.h"
+#include "server/common.h"
+#include "server/engine_shard.h"
+#include "server/engine_shard_set.h"
+#include "server/namespaces.h"
+#include "server/server_state.h"
+#include "util/fibers/pool.h"
+#include "util/fibers/synchronization.h"
+
+ABSL_DECLARE_FLAG(int32_t, hz);
+
+namespace dfly {
+
+using namespace std;
+using namespace std::chrono_literals;
+using namespace util;
+using namespace testing;
+
+constexpr size_t kNumThreads = 3;
+
+class TransactionTest : public Test {
+ protected:
+  void SetUp() override;
+  void TearDown() override;
+
+  static void SetUpTestSuite() {
+    // Disable periodic heartbeat / shard-handler fibers: this low-level harness
+    // passes a null shard handler, and the test intentionally runs long enough
+    // (deadlock detection) for the periodic fiber to fire otherwise.
+    absl::SetFlag(&FLAGS_hz, 0);
+    ServerState::Init(kNumThreads, kNumThreads, nullptr, nullptr);
+    facade::tl_facade_stats = new facade::FacadeStats;
+  }
+
+  boost::intrusive_ptr<Transaction> MakeTx(const CommandId* cid, StringVec keys) {
+    boost::intrusive_ptr<Transaction> tx(new Transaction{cid});
+    auto argv = std::make_shared<CmdArgVec>();
+    for (auto& k : keys)
+      argv->emplace_back(k);
+    arg_holders_.push_back({std::move(keys), argv});
+    CmdArgList args{argv->data(), argv->size()};
+    CHECK_EQ(OpStatus::OK, tx->InitByArgs(&namespaces->GetDefaultNamespace(), 0, args));
+    return tx;
+  }
+
+  std::unique_ptr<ProactorPool> pp_;
+  // Keep argument backing storage alive for the duration of the test.
+  std::vector<std::pair<StringVec, std::shared_ptr<CmdArgVec>>> arg_holders_;
+};
+
+void TransactionTest::SetUp() {
+  pp_.reset(fb2::Pool::Epoll(kNumThreads));
+  pp_->Run();
+  pp_->AwaitBrief([](unsigned index, ProactorBase* p) {
+    ServerState::Init(index, kNumThreads, nullptr, nullptr);
+    if (facade::tl_facade_stats == nullptr) {
+      facade::tl_facade_stats = new facade::FacadeStats;
+    }
+  });
+
+  shard_set = new EngineShardSet(pp_.get());
+  shard_set->Init(kNumThreads, nullptr);
+}
+
+void TransactionTest::TearDown() {
+  shard_set->PreShutdown();
+  shard_set->Shutdown();
+  delete shard_set;
+  shard_set = nullptr;
+
+  pp_->Stop();
+  pp_.reset();
+}
+
+// Reproduces a deadlock where the next hop of a continuation transaction (A) is
+// silently dropped because an *inline* transaction (B) holds running_tx_ while
+// its concluding callback preempts. Nothing re-drives the dropped poll, so A is
+// stranded.
+//
+// Roles:
+//   A: 2-hop, multi-shard (keys on shard 0 and shard 2). After hop1 it becomes
+//      continuation_trans_ on each shard (removed from the txq).
+//   B: 2-hop, single-shard on shard 0 (distinct key), coordinated from shard 0's
+//      own thread -> runs inline. Its concluding hop parks while holding
+//      running_tx_, simulating a snapshot/journal preemption inside RunCallback.
+TEST_F(TransactionTest, ContinuationPollDroppedByInlineTx) {
+  // Sanity check the key->shard mapping the scenario relies on.
+  ASSERT_EQ(0u, Shard("x", shard_set->size()));
+  ASSERT_EQ(2u, Shard("z", shard_set->size()));
+  ASSERT_EQ(0u, Shard("a", shard_set->size()));
+
+  static CommandId cid_a{"tx_test_a", 0, -1, 1, -1, acl::NONE};
+  static CommandId cid_b{"tx_test_b", 0, -1, 1, -1, acl::NONE};
+
+  auto tx_a = MakeTx(&cid_a, {"x", "z"});  // multi-shard: shard 0 + shard 2
+  auto tx_b = MakeTx(&cid_b, {"a"});       // single shard: shard 0
+
+  auto noop = [](Transaction*, EngineShard*) { return OpStatus::OK; };
+
+  // Phase 1: A's first (non-concluding) hop -> A becomes continuation on 0 and 2.
+  pp_->at(1)->Await([&] { tx_a->Execute(noop, false); });
+
+  // Phase 2: drive B inline on shard 0's thread. hop1 schedules B OOO into the
+  // txq; hop2 (concluding) parks while holding running_tx_ on shard 0.
+  fb2::Done b_parked, b_release;
+  auto fb_b = pp_->at(0)->LaunchFiber([&] {
+    tx_b->Execute(noop, false);  // hop1: no preemption, stays in txq as OOO
+    tx_b->Execute(
+        [&](Transaction*, EngineShard*) {
+          b_parked.Notify();
+          b_release.Wait();  // running_tx_ == tx_b while parked here
+          return OpStatus::OK;
+        },
+        true);  // hop2: concluding
+  });
+
+  ASSERT_TRUE(b_parked.WaitFor(5s)) << "B's concluding hop never parked";
+
+  // Phase 3: A's second (concluding) hop. Arms A on shards 0 and 2.
+  //   shard 2: continuation poll runs A's hop2 -> ok.
+  //   shard 0: PollExecution sees running_tx_=B and drops A's poll.
+  // A's run_barrier never completes on shard 0, so this fiber blocks.
+  fb2::Done a_done;
+  auto fb_a = pp_->at(1)->LaunchFiber([&] {
+    tx_a->Execute(noop, true);
+    a_done.Notify();
+  });
+
+  // Wait until A's hop2 has actually been armed on shard 0 (i.e. dispatched), then
+  // give the shard fiber a moment to run -> and drop -> that poll.
+  bool armed = false;
+  for (int i = 0; i < 400 && !armed; ++i) {
+    armed = pp_->at(0)->Await([&] { return tx_a->DEBUG_IsArmedInShard(0); });
+    if (!armed)
+      pp_->at(2)->Await([] { ThisFiber::SleepFor(5ms); });
+  }
+  ASSERT_TRUE(armed) << "A's hop2 was never armed on shard 0";
+  pp_->at(2)->Await([] { ThisFiber::SleepFor(50ms); });
+
+  // Phase 4: release B. Its hop2 concludes and clears running_tx_ on shard 0.
+  // Because B dropped A's poll while it was running, B must re-drive the poll loop
+  // (needs_repoll_) on conclusion and pick up A's stranded continuation.
+  b_release.Notify();
+  fb_b.Join();
+
+  // Phase 5: A's hop2 completes once B re-drives the dropped poll. Without the fix
+  // nothing re-drives the continuation on shard 0 and A stays stranded forever.
+  ASSERT_TRUE(a_done.WaitFor(5s))
+      << "A's continuation hop was stranded: the dropped PollExecution on shard 0 "
+         "was never replayed after running_tx_ cleared";
+
+  fb_a.Join();
+}
+
+}  // namespace dfly

--- a/src/server/transaction_test.cc
+++ b/src/server/transaction_test.cc
@@ -4,7 +4,6 @@
 
 #include "server/transaction.h"
 
-#include <absl/flags/flag.h>
 #include <gmock/gmock.h>
 
 #include "base/logging.h"
@@ -18,8 +17,6 @@
 #include "server/server_state.h"
 #include "util/fibers/pool.h"
 #include "util/fibers/synchronization.h"
-
-ABSL_DECLARE_FLAG(int32_t, hz);
 
 namespace dfly {
 
@@ -36,10 +33,6 @@ class TransactionTest : public Test {
   void TearDown() override;
 
   static void SetUpTestSuite() {
-    // Disable periodic heartbeat / shard-handler fibers: this low-level harness
-    // passes a null shard handler, and the test intentionally runs long enough
-    // (deadlock detection) for the periodic fiber to fire otherwise.
-    absl::SetFlag(&FLAGS_hz, 0);
     ServerState::Init(kNumThreads, kNumThreads, nullptr, nullptr);
     facade::tl_facade_stats = new facade::FacadeStats;
   }
@@ -71,7 +64,9 @@ void TransactionTest::SetUp() {
   });
 
   shard_set = new EngineShardSet(pp_.get());
-  shard_set->Init(kNumThreads, nullptr);
+  // Pass a no-op shard handler (not nullptr): the periodic shard-handler fiber would
+  // otherwise invoke an empty std::function and crash if it fires during the test.
+  shard_set->Init(kNumThreads, [] {});
 }
 
 void TransactionTest::TearDown() {

--- a/src/server/transaction_test.cc
+++ b/src/server/transaction_test.cc
@@ -9,6 +9,7 @@
 #include "base/logging.h"
 #include "facade/facade_stats.h"
 #include "server/acl/acl_commands_def.h"
+#include "server/blocking_controller.h"
 #include "server/command_registry.h"
 #include "server/common.h"
 #include "server/engine_shard.h"
@@ -37,6 +38,10 @@ class TransactionTest : public Test {
     facade::tl_facade_stats = new facade::FacadeStats;
   }
 
+  static OpStatus Noop(Transaction*, EngineShard*) {
+    return OpStatus::OK;
+  }
+
   boost::intrusive_ptr<Transaction> MakeTx(const CommandId* cid, StringVec keys) {
     boost::intrusive_ptr<Transaction> tx(new Transaction{cid});
     auto argv = std::make_shared<CmdArgVec>();
@@ -46,6 +51,68 @@ class TransactionTest : public Test {
     CmdArgList args{argv->data(), argv->size()};
     CHECK_EQ(OpStatus::OK, tx->InitByArgs(&namespaces->GetDefaultNamespace(), 0, args));
     return tx;
+  }
+
+  // Runs `f` on proactor `index` and returns its result.
+  template <typename F> auto OnShard(unsigned index, F&& f) {
+    return pp_->at(index)->Await(std::forward<F>(f));
+  }
+
+  // Polls `pred` on proactor `index` until it holds or `timeout` elapses, yielding between
+  // checks so the shard fiber can make progress. Returns whether the condition was met.
+  bool AwaitOnShard(unsigned index, std::function<bool()> pred,
+                    std::chrono::milliseconds timeout = 5s) {
+    return OnShard(index, [&]() -> bool {
+      auto deadline = std::chrono::steady_clock::now() + timeout;
+      do {
+        if (pred())
+          return true;
+        ThisFiber::SleepFor(5ms);
+      } while (std::chrono::steady_clock::now() < deadline);
+      return false;
+    });
+  }
+
+  // Blocks the test for `d` while the shard proactors keep running (used to let a dropped
+  // poll be processed). Paced from an otherwise idle proactor.
+  void Quiesce(std::chrono::milliseconds d) {
+    OnShard(kNumThreads - 1, [d] { ThisFiber::SleepFor(d); });
+  }
+
+  // Handle for a transaction parked mid-callback while holding running_tx_.
+  struct InlineHold {
+    fb2::Done parked, release;
+    fb2::Fiber fiber;
+
+    bool WaitParked(std::chrono::milliseconds t = 5s) {
+      return parked.WaitFor(t);
+    }
+    void ReleaseAndJoin() {
+      release.Notify();
+      fiber.Join();
+    }
+  };
+
+  // Drives `tx` on proactor `index` so that a concluding hop parks while still holding
+  // running_tx_ (mimicking an in-callback snapshot/journal preemption). The hop may run inline
+  // or on the shard queue fiber depending on CanRunInlined; either way running_tx_ is held while
+  // parked. `prelude`, if set, runs earlier hops on the same thread before the parking hop.
+  std::unique_ptr<InlineHold> ParkHoldingRunningTx(unsigned index, Transaction* tx,
+                                                   std::function<void()> prelude = {}) {
+    auto hold = std::make_unique<InlineHold>();
+    InlineHold* h = hold.get();
+    h->fiber = pp_->at(index)->LaunchFiber([tx, prelude = std::move(prelude), h] {
+      if (prelude)
+        prelude();
+      tx->Execute(
+          [h](Transaction*, EngineShard*) {
+            h->parked.Notify();
+            h->release.Wait();  // running_tx_ == tx while parked here
+            return OpStatus::OK;
+          },
+          true);  // concluding hop
+    });
+    return hold;
   }
 
   std::unique_ptr<ProactorPool> pp_;
@@ -102,26 +169,13 @@ TEST_F(TransactionTest, ContinuationPollDroppedByInlineTx) {
   auto tx_a = MakeTx(&cid_a, {"x", "z"});  // multi-shard: shard 0 + shard 2
   auto tx_b = MakeTx(&cid_b, {"a"});       // single shard: shard 0
 
-  auto noop = [](Transaction*, EngineShard*) { return OpStatus::OK; };
-
   // Phase 1: A's first (non-concluding) hop -> A becomes continuation on 0 and 2.
-  pp_->at(1)->Await([&] { tx_a->Execute(noop, false); });
+  OnShard(1, [&] { tx_a->Execute(Noop, false); });
 
-  // Phase 2: drive B inline on shard 0's thread. hop1 schedules B OOO into the
-  // txq; hop2 (concluding) parks while holding running_tx_ on shard 0.
-  fb2::Done b_parked, b_release;
-  auto fb_b = pp_->at(0)->LaunchFiber([&] {
-    tx_b->Execute(noop, false);  // hop1: no preemption, stays in txq as OOO
-    tx_b->Execute(
-        [&](Transaction*, EngineShard*) {
-          b_parked.Notify();
-          b_release.Wait();  // running_tx_ == tx_b while parked here
-          return OpStatus::OK;
-        },
-        true);  // hop2: concluding
-  });
-
-  ASSERT_TRUE(b_parked.WaitFor(5s)) << "B's concluding hop never parked";
+  // Phase 2: drive B inline on shard 0. hop1 schedules B OOO into the txq; hop2 (concluding)
+  // parks while holding running_tx_ on shard 0.
+  auto b = ParkHoldingRunningTx(0, tx_b.get(), [&] { tx_b->Execute(Noop, false); });
+  ASSERT_TRUE(b->WaitParked()) << "B's concluding hop never parked";
 
   // Phase 3: A's second (concluding) hop. Arms A on shards 0 and 2.
   //   shard 2: continuation poll runs A's hop2 -> ok.
@@ -129,34 +183,115 @@ TEST_F(TransactionTest, ContinuationPollDroppedByInlineTx) {
   // A's run_barrier never completes on shard 0, so this fiber blocks.
   fb2::Done a_done;
   auto fb_a = pp_->at(1)->LaunchFiber([&] {
-    tx_a->Execute(noop, true);
+    tx_a->Execute(Noop, true);
     a_done.Notify();
   });
 
-  // Wait until A's hop2 has actually been armed on shard 0 (i.e. dispatched), then
-  // give the shard fiber a moment to run -> and drop -> that poll.
-  bool armed = false;
-  for (int i = 0; i < 400 && !armed; ++i) {
-    armed = pp_->at(0)->Await([&] { return tx_a->DEBUG_IsArmedInShard(0); });
-    if (!armed)
-      pp_->at(2)->Await([] { ThisFiber::SleepFor(5ms); });
-  }
-  ASSERT_TRUE(armed) << "A's hop2 was never armed on shard 0";
-  pp_->at(2)->Await([] { ThisFiber::SleepFor(50ms); });
+  // Wait until A's hop2 has actually been armed (dispatched) on shard 0, then let the shard
+  // fiber run and drop that poll.
+  ASSERT_TRUE(AwaitOnShard(0, [&] { return tx_a->DEBUG_IsArmedInShard(0); }))
+      << "A's hop2 was never armed on shard 0";
+  Quiesce(50ms);
 
-  // Phase 4: release B. Its hop2 concludes and clears running_tx_ on shard 0.
-  // Because B dropped A's poll while it was running, B must re-drive the poll loop
-  // (needs_repoll_) on conclusion and pick up A's stranded continuation.
-  b_release.Notify();
-  fb_b.Join();
+  // Phase 4: release B. Its hop2 concludes and clears running_tx_ on shard 0. Because B dropped
+  // A's poll while it was running, B must re-drive the poll loop (needs_repoll_) on conclusion
+  // and pick up A's stranded continuation.
+  b->ReleaseAndJoin();
 
-  // Phase 5: A's hop2 completes once B re-drives the dropped poll. Without the fix
-  // nothing re-drives the continuation on shard 0 and A stays stranded forever.
+  // Phase 5: A's hop2 completes once B re-drives the dropped poll. Without the fix nothing
+  // re-drives the continuation on shard 0 and A stays stranded forever.
   ASSERT_TRUE(a_done.WaitFor(5s))
       << "A's continuation hop was stranded: the dropped PollExecution on shard 0 "
          "was never replayed after running_tx_ cleared";
 
   fb_a.Join();
+}
+
+// Companion to ContinuationPollDroppedByInlineTx, but for an *awakened* blocking
+// transaction (AWAKED_Q) rather than a continuation.
+//
+// A suspended blocking tx is removed from the txq (transaction.cc RunInShard). When it is
+// later awakened, its action hop is polled *with itself as `trans`* and runs via the AWAKED_Q
+// branch of PollExecutionInternal (step 1), which only executes when `trans != nullptr`.
+//
+// If an *inlined* tx holds running_tx_ across a mid-callback preemption when the awaken lands,
+// PollExecution drops the poll. The deferred re-drive runs with trans == nullptr, so step 1 is
+// skipped and the awakened tx is never re-run - it would be stranded (unlike a continuation, it
+// is not recoverable by a generic re-drive).
+//
+// The fix (Transaction::CanRunInlined): a transaction refuses to inline while the shard has any
+// blocked transactions. The tx that could preempt then runs on the shard's own queue fiber, so a
+// concurrent awaken's poll queues behind it instead of racing it and being dropped.
+//
+// Roles:
+//   BL: single-shard blocking tx on key "x" (shard 0). Schedules, then suspends via
+//       WaitOnWatch; after being awakened it runs an action hop.
+//   Z:  single-shard tx on key "a" (shard 0). Its concluding hop parks while holding
+//       running_tx_, simulating a snapshot/journal preemption. Without the fix it would run
+//       inline and drop BL's awaken poll; with the fix it is forced non-inline.
+TEST_F(TransactionTest, AwakenedPollNotDroppedWhenBlockedTxPresent) {
+  ASSERT_EQ(0u, Shard("x", shard_set->size()));
+  ASSERT_EQ(0u, Shard("a", shard_set->size()));
+
+  static CommandId cid_bl{"tx_test_bl", 0, -1, 1, -1, acl::NONE};
+  static CommandId cid_z{"tx_test_z", 0, -1, 1, -1, acl::NONE};
+
+  auto tx_bl = MakeTx(&cid_bl, {"x"});
+  auto tx_z = MakeTx(&cid_z, {"a"});
+
+  auto ready_checker = [](EngineShard*, const DbContext&, std::string_view) {
+    return KeyReadyResult::kReady;
+  };
+
+  // Phase 1: BL schedules a first hop, then suspends watching key "x".
+  bool bl_blocked = false, bl_paused = false;
+  fb2::Done bl_done;
+  auto fb_bl = pp_->at(1)->LaunchFiber([&] {
+    tx_bl->Execute(Noop, false);  // schedule + first (non-concluding) hop -> stays scheduled
+    std::string key = "x";
+    auto tp = Transaction::time_point::max();
+    OpStatus st =
+        tx_bl->WaitOnWatch(tp, std::string_view{key}, ready_checker, &bl_blocked, &bl_paused);
+    ASSERT_EQ(OpStatus::OK, st);
+    tx_bl->Execute(Noop, true);  // action hop after wakeup
+    bl_done.Notify();
+  });
+
+  // Wait until BL is parked inside the blocking barrier (suspended, off the txq).
+  ASSERT_TRUE(AwaitOnShard(0, [&] {
+    return (tx_bl->DEBUG_GetLocalMask(0) & Transaction::WAS_SUSPENDED) != 0;
+  })) << "BL never suspended";
+
+  // Phase 2: try to drive Z inline on shard 0. Because BL is blocked on the shard, the fix
+  // forces Z non-inline, so Z runs on the shard's queue fiber; its single concluding hop parks
+  // there while holding running_tx_ (Z is not a continuation, so it doesn't block the awaken).
+  auto z = ParkHoldingRunningTx(0, tx_z.get());
+  ASSERT_TRUE(z->WaitParked()) << "Z's concluding hop never parked";
+
+  // Phase 3: awaken BL on shard 0 while Z holds running_tx_. NotifyPending closes BL's
+  // blocking barrier -> BL's coordinator wakes and dispatches its action hop poll to shard 0.
+  // Since Z runs on the shard's own queue fiber (not inline), BL's poll queues behind it
+  // instead of racing it; without the fix Z would inline and the poll would be dropped.
+  OnShard(0, [&] {
+    auto* bc = namespaces->GetDefaultNamespace().GetBlockingController(0);
+    ASSERT_TRUE(bc != nullptr);
+    bc->Awaken(0, "x");
+    bc->NotifyPending();
+  });
+
+  // Give BL's coordinator time to wake and dispatch its action poll.
+  Quiesce(50ms);
+
+  // Phase 4: release Z. Its hop concludes and clears running_tx_ on shard 0; the shard fiber
+  // then processes BL's queued awaken poll.
+  z->ReleaseAndJoin();
+
+  // Phase 5: BL's action hop completes. Without the fix, an inlined Z would have dropped the
+  // awaken poll and BL would be stranded (a trans==nullptr re-drive cannot re-run an AWAKED_Q).
+  ASSERT_TRUE(bl_done.WaitFor(5s))
+      << "awakened BL was stranded: its PollExecution on shard 0 was never run";
+
+  fb_bl.Join();
 }
 
 }  // namespace dfly


### PR DESCRIPTION
The core problem is that running inline via `DispatchHop` does not follow up with PollExecution like running optimstic in `ScheduleInternal`. This issue never occurs because:
* running inline inside `DispatchHop` implies that the command could've ran inline inside `ScheduleInternal`, so it implies that this is a second hop
* We almost never suspend on a second hop

However I assume it must be possible with a good selection of multi/move/etc calls

The theoretical case to reproduce is quite simple
* multi-hop transaction A schedules on shards 0, 1 and runs the first hop on them, becoming the continuation
* two-hop transaction B runs on shard 0 inline its first and second hops - it suspends during the second hop
* transaction A submits its second hop and its PollExecution aborts as it sees transaction B blocked on shard 0
* because B ran with `DispatchHop`, it has no follow up and if no more transactions are submitted, A is never picked up

I even assume that there are more tricky cases like this - the simplest solution is just to cover all paths. However to not increase the overhead (as PollExecution reads atomics), we can do this re-poll conditionally only if the shard was interrupted

Fixes #7698 