### PR TITLE
fix: flaky FT.PROFILE timing assertion

### DIFF
--- a/src/server/search/search_family_test.cc
+++ b/src/server/search/search_family_test.cc
@@ -1561,7 +1561,7 @@ TEST_F(SearchFamilyTest, FtProfile) {
 
     const auto& tree = shard_resp[3].GetVec();
     EXPECT_EQ(tree[3].GetString() /* operation */, "Logical{n=3,o=and}"s);
-    EXPECT_GT(tree[1].GetInt() /* total time*/, tree[5].GetInt() /* self time */);
+    EXPECT_GE(tree[1].GetInt() /* total time*/, tree[5].GetInt() /* self time */);
     EXPECT_EQ(tree[7].GetInt() /* processed */, 0);
   }
 


### PR DESCRIPTION
FT.PROFILE can report equal total_time and self_time for very fast profile events because timings are recorded in microseconds and child events may round down to zero.

Relax the assertion from strict > to >= so the test still validates the timing relationship without depending on scheduler/timer granularity.
