### PR TITLE
refactor: better CmdArgParserUsage

### DIFF
--- a/src/facade/cmd_arg_parser.h
+++ b/src/facade/cmd_arg_parser.h
@@ -32,11 +32,14 @@ namespace facade {
 //   auto count = parser.NextOrDefault<size_t>(10);              // read optional with default
 //   Range fields = parser.NextRange();                         // [N, e1..eN] counted list
 //   Range pairs  = parser.NextRange(2);                        // [N, f1,v1,..] N field/value pairs
+//   Range fs     = parser.NextRange(1, mismatch, true);        // consume-all variant
 //   Range rest   = parser.RemainingRange();                    // all remaining args, no count
+//   Range items  = parser.RemainingRange("need >=1 item");     // ...erroring if none remain
 //
 // Tag matching:
 //   parser.ExpectTag("LOAD");                                   // required literal keyword
 //   if (parser.Check("NX")) { ... }                             // consume tag only if matched
+//   if (parser.Check("COUNT", &count)) { ... }                 // ...also read following args
 //   auto mode = parser.MapNext("EX", Mode::EX, "PX", Mode::PX); // tag -> enum mapping
 //   auto maybe_mode = parser.TryMapNext("ASC", Dir::ASC,        // like MapNext but returns
 //                                       "DESC", Dir::DESC);     // nullopt (no error) on miss
@@ -71,6 +74,8 @@ namespace facade {
 //   if (!parser.Finalize())                                     // also reports UNPROCESSED on
 //     return cmd_cntx->SendError(parser.TakeError().MakeReply()); // trailing args
 //   // or: if (parser.HasError()) ...
+//   parser.ReportCustom("bad option");                          // inject a custom error (no-op if
+//                                                               // one is already set)
 
 // A validated number for Next<T>(): a VNum-derived type that adds a static validate()
 // predicate. Convert<T>() parses the underlying value, runs validate(), and reports
@@ -253,34 +258,34 @@ struct CmdArgParser {
     return val;
   }
 
-  // Reads a counted list [count, e1..e(count*group)] and returns its elements as a bounded Range;
-  // group=2 reads count field/value pairs. Errors if count is 0 or fewer than count*group remain.
-  Range NextRange(size_t group = 1) {
-    uint32_t count = Next<uint32_t>();
+  // Reads a counted list [count, e1..e(count*group)] into a bounded Range (group=2 reads count
+  // field/value pairs). A wrong number of args reports `size_err`; an invalid/zero count reports
+  // `count_err`, or `size_err` when `count_err` is empty. With `consume_all` the Range must cover
+  // ALL remaining args. An empty message keeps the generic error (INVALID_INT / INVALID_CASES).
+  Range NextRange(size_t group = 1, std::string_view size_err = {}, bool consume_all = false,
+                  std::string_view count_err = {}) {
+    uint32_t count = Next<FInt<1u, UINT32_MAX>>(count_err.empty() ? size_err : count_err);
     ParsedArgs rest = args_.Tail(cur_i_);
-    if (!error_ && (count == 0 || rest.size() < size_t(count) * group))
-      Report(INVALID_CASES, cur_i_ - 1);
+    size_t need = size_t(count) * group;
+    if (!error_ && (consume_all ? rest.size() != need : rest.size() < need)) {
+      if (size_err.empty())
+        Report(INVALID_CASES, cur_i_ - 1);
+      else
+        ReportCustom(std::string{size_err});
+    }
     if (error_)
       return {};
-    cur_i_ += size_t(count) * group;
-    return Range{rest, size_t(count) * group};
+    cur_i_ += need;
+    return Range{rest, need};
   }
 
-  // NextRange() with a custom error message on failure.
-  Range NextRange(size_t group, std::string_view err_msg) {
-    bool prior = bool(error_);
-    Range r = NextRange(group);
-    if (!prior && error_ && !err_msg.empty()) {
-      error_.type = CUSTOM_ERROR;
-      error_.custom_msg = std::string{err_msg};
-    }
-    return r;
-  }
-
-  // Consumes and returns all remaining args as a terminal Range, no leading count.
-  Range RemainingRange() {
+  // Consumes and returns all remaining args as a terminal Range, no leading count. If `empty_err`
+  // is provided and no args remain, reports it as a custom error.
+  Range RemainingRange(std::string_view empty_err = {}) {
     Range r{args_.Tail(cur_i_)};
     cur_i_ = args_.size();
+    if (!empty_err.empty() && r.empty())
+      ReportCustom(std::string{empty_err});
     return r;
   }
 

--- a/src/facade/cmd_arg_parser_test.cc
+++ b/src/facade/cmd_arg_parser_test.cc
@@ -9,6 +9,7 @@
 
 #include <cmath>
 
+#include "facade/error.h"
 #include "facade/memcache_parser.h"
 
 using namespace testing;
@@ -599,6 +600,43 @@ TEST_F(CmdArgParserTest, RangeList) {
     EXPECT_TRUE(err);
     EXPECT_EQ(err.type, CmdArgParser::INVALID_CASES);
   }
+  // A bad/zero count falls back to size_err unless count_err is passed.
+  {
+    auto parser = Make({"0", "a"});  // zero count -> size_err
+    parser.NextRange(1, "bad size", false);
+    EXPECT_EQ(parser.TakeError().MakeReply().ToSv(), "bad size");
+  }
+  {
+    auto parser = Make({"0", "a"});  // zero count -> count_err when given
+    parser.NextRange(1, "bad size", false, "bad count");
+    EXPECT_EQ(parser.TakeError().MakeReply().ToSv(), "bad count");
+  }
+  {
+    auto parser = Make({"3", "a"});  // valid count, too few args -> size_err
+    parser.NextRange(1, "bad size", false);
+    EXPECT_EQ(parser.TakeError().MakeReply().ToSv(), "bad size");
+  }
+  // consume_all=true: the range must cover all remaining args, so trailing args are a mismatch.
+  {
+    auto parser = Make({"1", "a", "b"});  // count=1 but 2 args remain
+    parser.NextRange(1, "too many", true);
+    EXPECT_EQ(parser.TakeError().MakeReply().ToSv(), "too many");
+  }
+  {
+    auto parser = Make({"2", "a", "b"});  // exact match -> ok, all consumed
+    Range r = parser.NextRange(1, "size", true);
+    EXPECT_FALSE(parser.HasError());
+    EXPECT_EQ(r.size(), 2u);
+    EXPECT_FALSE(parser.HasNext());
+  }
+  // consume_all=false: only `count` elements are consumed; the rest stays for the caller.
+  {
+    auto parser = Make({"1", "a", "b"});
+    Range r = parser.NextRange(1, "size", false);
+    EXPECT_FALSE(parser.HasError());
+    EXPECT_EQ(r.size(), 1u);
+    EXPECT_EQ(parser.Peek(), "b");
+  }
   // RemainingRange: all remaining args, no leading count.
   {
     auto parser = Make({"a", "b", "c"});
@@ -606,6 +644,25 @@ TEST_F(CmdArgParserTest, RangeList) {
     EXPECT_EQ(rest.size(), 3u);
     EXPECT_THAT(std::vector<string_view>(rest.begin(), rest.end()), ElementsAre("a", "b", "c"));
     EXPECT_FALSE(parser.HasNext());
+  }
+  // RemainingRange with empty_err: reports the message only when no args remain.
+  {
+    auto parser = Make({"a"});
+    Range rest = parser.RemainingRange("need args");
+    EXPECT_EQ(rest.size(), 1u);
+    EXPECT_FALSE(parser.HasError());
+  }
+  {
+    auto parser = Make({"x"});
+    parser.Next();  // consume the only arg
+    parser.RemainingRange("need args");
+    EXPECT_EQ(parser.TakeError().MakeReply().ToSv(), "need args");
+  }
+  {  // A prior error is preserved (empty_err does not overwrite it).
+    auto parser = Make({"x"});
+    parser.Next<int>();  // "x" is not an int -> INVALID_INT
+    parser.RemainingRange("need args");
+    EXPECT_EQ(parser.TakeError().MakeReply().ToSv(), kInvalidIntErr);
   }
 }
 

--- a/src/facade/error.h
+++ b/src/facade/error.h
@@ -22,6 +22,7 @@ inline constexpr char kKeyNotFoundErr[] = "no such key";
 inline constexpr char kInvalidIntErr[] = "value is not an integer or out of range";
 inline constexpr char kInvalidFloatErr[] = "value is not a valid float";
 inline constexpr char kUintErr[] = "value is out of range, must be positive";
+inline constexpr char kInvalidNumFields[] = "Number of fields must be a positive integer";
 inline constexpr char kIncrOverflow[] = "increment or decrement would overflow";
 inline constexpr char kDbIndOutOfRangeErr[] = "DB index is out of range";
 inline constexpr char kInvalidDbIndErr[] = "invalid DB index";

--- a/src/server/cms_family.cc
+++ b/src/server/cms_family.cc
@@ -236,11 +236,8 @@ void CmdIncrBy(CmdArgParser parser, CommandContext* cmd_cntx) {
 
 void CmdQuery(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
-
-  ParsedArgs items = parser.UnparsedArgs();
-  if (items.empty()) {
-    return cmd_cntx->SendError(kSyntaxErr);
-  }
+  ParsedArgs items = parser.RemainingRange(kSyntaxErr);
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   const auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpQuery(t->GetOpArgs(shard), key, items);

--- a/src/server/cuckoo_filter_family.cc
+++ b/src/server/cuckoo_filter_family.cc
@@ -368,10 +368,8 @@ void CmdInsertImpl(CmdArgParser parser, CommandContext* cmd_cntx, bool nx) {
   if (!parser.Check("ITEMS")) {
     return rb->SendError("CF.INSERT requires ITEMS keyword");
   }
-  ParsedArgs items = parser.UnparsedArgs();
-  if (items.empty()) {
-    return rb->SendError("CF.INSERT requires at least one item");
-  }
+  ParsedArgs items = parser.RemainingRange("CF.INSERT requires at least one item");
+  RETURN_ON_PARSE_ERROR(parser, rb);
 
   const auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpInsert(t->GetOpArgs(shard), key, items, opts, nx);

--- a/src/server/hset_family.cc
+++ b/src/server/hset_family.cc
@@ -49,6 +49,11 @@ using IncrByParam = std::variant<double, int64_t>;
 using OptStr = std::optional<std::string>;
 enum GetAllMode : uint8_t { FIELDS = 1, VALUES = 2 };
 
+// FIELDS arg-count error for the hash field-TTL commands. HTTL/HPEXPIRETIME/HGETEX additionally
+// pass kInvalidNumFields for a non-positive numfields.
+constexpr char kNumFieldsMismatch[] =
+    "The `numfields` parameter must match the number of arguments";
+
 // TODO: replace all the listpack code with our detail::Listpack wrapper.
 bool IsGoodForListpack(const ParsedArgs& args, const uint8_t* lp) {
   DCHECK_GE(args.size(), 2u);
@@ -767,11 +772,7 @@ HSetExParams ParseHSetEx(CmdArgParser* parser, string_view cmd_name) {
     op_sp.format = Format::kRedis;
     if (op_sp.mode == Mode::kNX || (op_sp.keepttl && has_exp))
       parser->Report(CmdArgParser::CUSTOM_ERROR);  // NX is Dragonfly-only; one expiry option max
-    // numfields field/value pairs; NextRange validates count > 0 and that count*2 args remain.
-    res.fields =
-        parser->NextRange(2, "The `numfields` parameter must match the number of arguments");
-    if (parser->HasNext())  // too many args
-      parser->ReportCustom("The `numfields` parameter must match the number of arguments");
+    res.fields = parser->NextRange(2, kNumFieldsMismatch, /*consume_all=*/true);
   } else if (has_exp) {
     // EX/PX/EXAT/PXAT belong to the Redis form; without FIELDS the command is malformed.
     parser->Report(CmdArgParser::CUSTOM_ERROR);
@@ -864,13 +865,7 @@ void CmdHExpire(CmdArgParser parser, CommandContext* cmd_cntx) {
                                kSyntaxErrType);
   }
 
-  uint32_t numFields = parser.Next<uint32_t>();
-
-  ParsedArgs fields = parser.UnparsedArgs();
-  if (fields.size() != numFields) {
-    return rb->SendError("The `numfields` parameter must match the number of arguments",
-                         kSyntaxErrType);
-  }
+  CmdArgParser::Range fields = parser.NextRange(1, kNumFieldsMismatch, /*consume_all=*/true);
 
   RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
@@ -883,7 +878,7 @@ void CmdHExpire(CmdArgParser parser, CommandContext* cmd_cntx) {
     case OpStatus::OK:
       return rb->SendLongArr(absl::MakeConstSpan(result.value()));
     case OpStatus::KEY_NOTFOUND:
-      return rb->SendLongArr(absl::MakeConstSpan(vector<long>(numFields, -2)));
+      return rb->SendLongArr(absl::MakeConstSpan(vector<long>(fields.size(), -2)));
     default:
       return cmd_cntx->SendError(result.status());
   };
@@ -935,17 +930,11 @@ template <FieldExpireOutput kOut>
 void HExpireTimeGeneric(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
   parser.ExpectTag("FIELDS", "Mandatory argument FIELDS is missing or not at the right position");
-  uint32_t numFields =
-      parser.Next<FInt<1u, UINT32_MAX>>("Number of fields must be a positive integer");
-  ParsedArgs fields = parser.UnparsedArgs();
+  CmdArgParser::Range fields =
+      parser.NextRange(1, kNumFieldsMismatch, /*consume_all=*/true, kInvalidNumFields);
 
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
-
-  if (fields.size() != numFields) {
-    return rb->SendError("The `numfields` parameter must match the number of arguments",
-                         kSyntaxErrType);
-  }
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpHExpireTime<kOut>(t, shard, key, fields);
@@ -956,7 +945,7 @@ void HExpireTimeGeneric(CmdArgParser parser, CommandContext* cmd_cntx) {
     case OpStatus::OK:
       return rb->SendLongArr(absl::MakeConstSpan(result.value()));
     case OpStatus::KEY_NOTFOUND:
-      return rb->SendLongArr(absl::MakeConstSpan(vector<int64_t>(numFields, -2)));
+      return rb->SendLongArr(absl::MakeConstSpan(vector<int64_t>(fields.size(), -2)));
     default:
       return cmd_cntx->SendError(result.status());
   };
@@ -1058,16 +1047,11 @@ void CmdHGetEx(CmdArgParser parser, CommandContext* cmd_cntx) {
                      Tag("EXAT", read_expiry(ExpT::EXAT)), Tag("PXAT", read_expiry(ExpT::PXAT)),
                      Exist("PERSIST", &exp_params.persist)));
   parser.ExpectTag("FIELDS", "Mandatory argument FIELDS is missing or not at the right position");
-  uint32_t numFields =
-      parser.Next<FInt<1u, UINT32_MAX>>("Number of fields must be a positive integer");
-  ParsedArgs fields = parser.UnparsedArgs();
+  CmdArgParser::Range fields =
+      parser.NextRange(1, kNumFieldsMismatch, /*consume_all=*/true, kInvalidNumFields);
 
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
   RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
-
-  if (fields.size() != numFields)
-    return rb->SendError("The `numfields` parameter must match the number of arguments",
-                         kSyntaxErrType);
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpHGetEx(t->GetOpArgs(shard), key, fields, exp_params);
@@ -1077,7 +1061,7 @@ void CmdHGetEx(CmdArgParser parser, CommandContext* cmd_cntx) {
   switch (result.status()) {
     case OpStatus::OK:
     case OpStatus::KEY_NOTFOUND: {
-      RedisReplyBuilder::ArrayScope scope{rb, numFields};
+      RedisReplyBuilder::ArrayScope scope{rb, fields.size()};
       for (size_t i = 0; i < fields.size(); i++) {
         if (result.ok() && (*result)[i].has_value())
           rb->SendBulkString(*(*result)[i]);
@@ -1159,12 +1143,8 @@ void CmdHExists(CmdArgParser parser, CommandContext* cmd_cntx) {
 void CmdHIncrBy(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
   string_view field = parser.Next();
-  string_view incrs = parser.Next();
-  int64_t ival = 0;
-
-  if (!absl::SimpleAtoi(incrs, &ival)) {
-    return cmd_cntx->SendError(kInvalidIntErr);
-  }
+  int64_t ival = parser.Next<int64_t>();
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   IncrByParam param{ival};
 
@@ -1194,12 +1174,8 @@ void CmdHIncrBy(CmdArgParser parser, CommandContext* cmd_cntx) {
 void CmdHIncrByFloat(CmdArgParser parser, CommandContext* cmd_cntx) {
   string_view key = parser.Next();
   string_view field = parser.Next();
-  string_view incrs = parser.Next();
-  double dval = 0;
-
-  if (!absl::SimpleAtod(incrs, &dval)) {
-    return cmd_cntx->SendError(kInvalidFloatErr);
-  }
+  double dval = parser.Next<double>();
+  RETURN_ON_PARSE_ERROR(parser, cmd_cntx);
 
   if (isnan(dval) || isinf(dval)) {
     return cmd_cntx->SendError(kNanOrInfDuringIncr);
@@ -1331,27 +1307,14 @@ void StrVecEmplaceBack(StringVec& str_vec, const listpackEntry& lp) {
 
 void CmdHRandField(CmdArgParser parser, CommandContext* cmd_cntx) {
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
-  const size_t argc = cmd_cntx->tail_args().size();
-  if (argc > 3) {
-    DVLOG(1) << "Wrong number of command arguments: " << argc;
-    return rb->SendError(kSyntaxErr);
-  }
 
   string_view key = parser.Next();
-  int32_t count;
-  bool with_values = false;
+  bool has_count = parser.HasNext();
+  int32_t count = has_count ? parser.Next<int32_t>("count value is not an integer") : 0;
+  bool with_values = parser.Check("WITHVALUES");
 
-  if ((argc > 1) && (!SimpleAtoi(parser.Next(), &count))) {
-    return rb->SendError("count value is not an integer", kSyntaxErrType);
-  }
-
-  if (argc == 3) {
-    string arg = absl::AsciiStrToUpper(parser.Next());
-    if (arg != "WITHVALUES")
-      return rb->SendError(kSyntaxErr);
-    else
-      with_values = true;
-  }
+  if (!parser.Finalize())
+    return rb->SendError(parser.TakeError().MakeReply());
 
   auto cb = [&](Transaction* t, EngineShard* shard) -> OpResult<StringVec> {
     auto& db_slice = t->GetDbSlice(shard->shard_id());
@@ -1367,7 +1330,7 @@ void CmdHRandField(CmdArgParser parser, CommandContext* cmd_cntx) {
     if (pv.Encoding() == kEncodingStrMap2) {
       StringMap* string_map = GetStringMap(pv, db_context);
 
-      if (argc == 1) {
+      if (!has_count) {
         auto opt_pair = string_map->RandomPair();
         if (opt_pair.has_value()) {
           auto [key, value] = *opt_pair;
@@ -1405,7 +1368,7 @@ void CmdHRandField(CmdArgParser parser, CommandContext* cmd_cntx) {
       size_t lplen = lpLength(lp);
       CHECK(lplen > 0 && lplen % 2 == 0);
       size_t hlen = lplen / 2;
-      if (argc == 1) {
+      if (!has_count) {
         listpackEntry key;
         lpRandomPair(lp, hlen, &key, NULL);
         StrVecEmplaceBack(str_vec, key);
@@ -1439,7 +1402,7 @@ void CmdHRandField(CmdArgParser parser, CommandContext* cmd_cntx) {
 
   OpResult<StringVec> result = cmd_cntx->tx()->ScheduleSingleHopT(std::move(cb));
   if (result) {
-    if (result->size() == 1 && argc == 1)
+    if (result->size() == 1 && !has_count)
       rb->SendBulkString(result->front());
     else if (with_values) {
       const auto result_size = result->size();
@@ -1457,7 +1420,7 @@ void CmdHRandField(CmdArgParser parser, CommandContext* cmd_cntx) {
     } else
       rb->SendBulkStrArr(*result, CollectionType::ARRAY);
   } else if (result.status() == OpStatus::KEY_NOTFOUND) {
-    if (argc == 1)
+    if (!has_count)
       rb->SendNull();
     else
       rb->SendEmptyArray();

--- a/src/server/hset_family_test.cc
+++ b/src/server/hset_family_test.cc
@@ -824,6 +824,19 @@ TEST_F(HSetFamilyTest, HExpire) {
   EXPECT_THAT(Run({"HGETALL", "key4"}), RespArray(ElementsAre()));
 }
 
+TEST_F(HSetFamilyTest, HExpireNumFieldsErrors) {
+  EXPECT_EQ(CheckedInt({"HSET", "key", "k0", "v0", "k1", "v1"}), 2);
+
+  // Missing FIELDS keyword.
+  EXPECT_THAT(Run({"HEXPIRE", "key", "10", "1", "k0"}), ErrArg("Mandatory argument FIELDS"));
+
+  // A wrong number of provided fields (too few, too many, or zero) reports the must-match message.
+  EXPECT_THAT(Run({"HEXPIRE", "key", "10", "FIELDS", "2", "k0"}), ErrArg("numfields"));
+  EXPECT_THAT(Run({"HEXPIRE", "key", "10", "FIELDS", "1", "k0", "k1"}), ErrArg("numfields"));
+  EXPECT_THAT(Run({"HEXPIRE", "key", "10", "FIELDS", "0", "k0"}), ErrArg("numfields"));
+  EXPECT_THAT(Run({"HEXPIRE", "key", "10", "FIELDS", "0"}), ErrArg("numfields"));
+}
+
 TEST_F(HSetFamilyTest, HExpireNoExpireEarly) {
   EXPECT_EQ(CheckedInt({"HSET", "key", "k0", "v0", "k1", "v1"}), 2);
   EXPECT_THAT(Run({"HEXPIRE", "key", "10", "FIELDS", "2", "k0", "k1"}),

--- a/src/server/set_family.cc
+++ b/src/server/set_family.cc
@@ -1597,21 +1597,14 @@ void CmdSScan(CmdArgParser parser, CommandContext* cmd_cntx) {
 
 // Syntax: saddex key [KEEPTTL] ttl_sec member [member...]
 void CmdSAddEx(CmdArgParser parser, CommandContext* cmd_cntx) {
+  constexpr uint32_t kMaxTtl = (1UL << 26);
   const std::string_view key = parser.Next<std::string_view>();
   const bool keepttl = parser.Check("KEEPTTL");
-  const uint32_t ttl_sec = parser.Next<uint32_t>();
+  const uint32_t ttl_sec = parser.Next<FInt<1u, kMaxTtl>>();
+  ParsedArgs vals = parser.RemainingRange(WrongNumArgsError("SADDEX"));
 
   if (auto err = parser.TakeError(); err) {
     return cmd_cntx->SendError(err.MakeReply());
-  }
-  constexpr uint32_t kMaxTtl = (1UL << 26);
-  if (ttl_sec == 0 || ttl_sec > kMaxTtl) {
-    return cmd_cntx->SendError(kInvalidIntErr);
-  }
-
-  ParsedArgs vals = parser.UnparsedArgs();
-  if (vals.empty()) {
-    return cmd_cntx->SendError(WrongNumArgsError("SADDEX"));
   }
 
   auto cb = [&](Transaction* t, EngineShard* shard) {

--- a/src/server/string_family.cc
+++ b/src/server/string_family.cc
@@ -1415,23 +1415,18 @@ cmd::CmdR CmdIncr(CmdArgParser parser, CommandContext* cmd_cntx) {
 }
 
 cmd::CmdR CmdIncrBy(CmdArgParser parser, CommandContext* cmd_cntx) {
-  auto [key, sval] = parser.Next<string_view, string_view>();
-  int64_t val;
-
-  if (!absl::SimpleAtoi(sval, &val)) {
-    cmd_cntx->SendError(kInvalidIntErr);
+  auto [key, val] = parser.Next<string_view, int64_t>();
+  if (auto err = parser.TakeError(); err) {
+    cmd_cntx->SendError(err.MakeReply());
     return cmd::kAborted;
   }
   return IncrByGeneric(cmd_cntx, key, val);
 }
 
 cmd::CmdR CmdIncrByFloat(CmdArgParser parser, CommandContext* cmd_cntx) {
-  auto [key, sval] = parser.Next<string_view, string_view>();
-  double val;
-
-  if (!absl::SimpleAtod(sval, &val)) {
-    co_return facade::ErrorReply{kInvalidFloatErr};
-  }
+  auto [key, val] = parser.Next<string_view, double>();
+  if (auto err = parser.TakeError(); err)
+    co_return err.MakeReply();
 
   auto cb = [&](Transaction* t, EngineShard* shard) {
     return OpIncrFloat(t->GetOpArgs(shard), key, val);
@@ -1461,11 +1456,9 @@ cmd::CmdR CmdDecr(CmdArgParser parser, CommandContext* cmd_cntx) {
 }
 
 cmd::CmdR CmdDecrBy(CmdArgParser parser, CommandContext* cmd_cntx) {
-  auto [key, sval] = parser.Next<string_view, string_view>();
-  int64_t val;
-
-  if (!absl::SimpleAtoi(sval, &val)) {
-    cmd_cntx->SendError(kInvalidIntErr);
+  auto [key, val] = parser.Next<string_view, int64_t>();
+  if (auto err = parser.TakeError(); err) {
+    cmd_cntx->SendError(err.MakeReply());
     return cmd::kAborted;
   }
   if (val == INT64_MIN) {

--- a/src/server/zset_family.cc
+++ b/src/server/zset_family.cc
@@ -1015,14 +1015,10 @@ OpResult<ScoredMap> IntersectResults(vector<OpResult<ScoredMap>>& results, AggTy
 OpResult<SetOpArgs> ParseSetOpArgs(CmdArgParser parser, bool store) {
   SetOpArgs op_args;
 
-  // numkeys was already validated against the arg count during key resolution.
-  op_args.num_keys = parser.Next<unsigned>();
-  if (parser.TakeError() || op_args.num_keys == 0) {
+  op_args.num_keys = parser.NextRange(1).size();
+  if (parser.TakeError()) {
     return OpStatus::SYNTAX_ERR;
   }
-
-  // The source keys are resolved via the command's key spec; skip past them to the options.
-  parser.Skip(op_args.num_keys);
 
   parser.Apply(Tag("WEIGHTS",
                    [&op_args](CmdArgParser* p) {
@@ -2441,18 +2437,15 @@ void CmdZDiffStore(CmdArgParser parser, CommandContext* cmd_cntx) {
 }
 
 void CmdZIncrBy(CmdArgParser parser, CommandContext* cmd_cntx) {
-  string_view key = parser.Next();
-  string_view score_arg = parser.Next();
-
-  ScoredMemberView scored_member;
-  scored_member.second = parser.Next();
-
   auto* rb = static_cast<RedisReplyBuilder*>(cmd_cntx->rb());
 
-  if (!absl::SimpleAtod(score_arg, &scored_member.first)) {
-    VLOG(1) << "Bad score:" << score_arg << "|";
-    return rb->SendError(kInvalidFloatErr);
-  }
+  string_view key = parser.Next();
+  ScoredMemberView scored_member;
+  scored_member.first = parser.Next<double>();
+  scored_member.second = parser.Next();
+
+  if (auto err = parser.TakeError(); err)
+    return rb->SendError(err.MakeReply());
 
   if (isnan(scored_member.first)) {
     return rb->SendError(kScoreNaN);


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Refine CmdArgParser Range helpers and standardize command parsing

<code>✨ Enhancement</code> <code>🐞 Bug fix</code> <code>🧪 Tests</code> <code>🕐 40+ Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<details>
<summary>AI Description</summary>

<dl>
<dd>
<br/>

><pre>
>• Extend CmdArgParser NextRange/RemainingRange with stricter validation and custom errors
>• Refactor multiple commands to rely on parser helpers instead of manual arg checks
>• Add unit tests to lock in new error-message and consume-all behaviors
></pre>

</dd>
</dl>

</details>

<details>
<summary>Diagram</summary>

<dl>
<dd>

<br/>

```mermaid
graph TD
  A["Server commands"] --> B["CmdArgParser"] --> C{"Range helpers"}
  C --> D["NextRange(...)"]
  C --> E["RemainingRange(...)"]
  D --> F["ErrorReply"]
  E --> F
```

</dd>
</dl>

</details>




<details>
<summary>High-Level Assessment</summary>

<dl>
<dd>

<br/>

>The following are alternative approaches to this PR:

<details>
<summary><b>1. Keep old NextRange overloads and add a new explicit method</b></summary>

<dl>
<dd>

- ➕ Avoids API churn for existing call sites
- ➕ More discoverable semantics (e.g., NextRangeConsumeAll / NextRangeExact)
- ➖ Increases surface area and duplicates validation logic
- ➖ Encourages inconsistent usage patterns across commands

</dd>
</dl>

</details>

<details>
<summary><b>2. Introduce a command-level helper for “FIELDS numfields …” pattern</b></summary>

<dl>
<dd>

- ➕ Further reduces repetition in hash field-TTL commands
- ➕ Centralizes both parsing and error-message selection for that specific pattern
- ➖ Less general than improving CmdArgParser itself
- ➖ Another abstraction layer that may not be reused outside hash commands

</dd>
</dl>

</details>

>**Recommendation:** The PR’s approach (enhancing CmdArgParser’s general Range helpers and migrating commands to use them) is the best tradeoff: it removes repeated ad-hoc validation, makes trailing-arg handling consistent (via consume_all/Finalize), and improves correctness of error selection. The main thing to watch is signature clarity; if call sites become hard to read, consider follow-up wrappers for common patterns (e.g., exact-size counted lists).

</dd>
</dl>

</details>

<details>
<summary> Files changed (10) <code> +147 / -134 </code> </summary>

<dl>
<dd>

<br/>

<details>
<summary>Enhancement (2) <code> +27 / -21 </code></summary>

<dl>
<dd>

<details>
<summary>cmd_arg_parser.h<code>Extend NextRange/RemainingRange with consume-all and custom errors</code> <code>+26/-21</code></summary>

<br/>

>Extend NextRange/RemainingRange with consume-all and custom errors
>
><pre>
>• Refactors NextRange into a single implementation that supports custom size/count error messages and an optional consume-all mode requiring an exact match of remaining arguments. Enhances RemainingRange to optionally error when empty, and updates header documentation/examples (including custom error injection).
></pre>
>
><a href='https://github.com/dragonflydb/dragonfly/pull/7758/files#diff-d6013252da7fc24d360752d2bd33d4107b9482648ba0bfada090cf44c24273b4'>src/facade/cmd_arg_parser.h</a>

</details>

<details>
<summary>error.h<code>Add shared error constant for invalid numfields</code> <code>+1/-0</code></summary>

<br/>

>Add shared error constant for invalid numfields
>
><pre>
>• Introduces kInvalidNumFields to standardize the error message for non-positive numfields parsing across commands.
></pre>
>
><a href='https://github.com/dragonflydb/dragonfly/pull/7758/files#diff-fc40317bbb988dc3e5d0857a03d7b181d59bfcf1baf3dcf4fa7dd48326cc44a0'>src/facade/error.h</a>

</details>

</dd>
</dl>

</details>

<details>
<summary>Bug fix (2) <code> +30 / -74 </code></summary>

<dl>
<dd>

<details>
<summary>hset_family.cc<code>Centralize numfields parsing and tighten numeric/argument validation</code> <code>+27/-64</code></summary>

<br/>

>Centralize numfields parsing and tighten numeric/argument validation
>
><pre>
>• Adds a shared numfields mismatch message and migrates hash field-TTL commands to NextRange(..., consume_all=true) with distinct count_err (non-positive numfields) vs size_err (mismatched arg count). Refactors several numeric parses to parser.Next&lt;T&gt;() with standard error propagation, and reworks HRANDFIELD parsing to use HasNext/Check/Finalize instead of argc-based branching.
></pre>
>
><a href='https://github.com/dragonflydb/dragonfly/pull/7758/files#diff-4eaf710d62df976d913fde0544e4a9445457eea1b1b2fd7ad7d0db0b0fad054b'>src/server/hset_family.cc</a>

</details>

<details>
<summary>set_family.cc<code>Use typed TTL parsing and enforce required members in SADDEX</code> <code>+3/-10</code></summary>

<br/>

>Use typed TTL parsing and enforce required members in SADDEX
>
><pre>
>• Moves TTL validation into parser.Next&lt;FInt&lt;...&gt;&gt;() and switches member parsing to RemainingRange(WrongNumArgsError(&quot;SADDEX&quot;)) so missing members are handled via parser error flow instead of manual empty-checks.
></pre>
>
><a href='https://github.com/dragonflydb/dragonfly/pull/7758/files#diff-b08807737bb80c502bd26c2f2685e98e3c9299eaf38cae715852bd1c03730f18'>src/server/set_family.cc</a>

</details>

</dd>
</dl>

</details>

<details>
<summary>Refactor (4) <code> +20 / -39 </code></summary>

<dl>
<dd>

<details>
<summary>cms_family.cc<code>Use RemainingRange to enforce required items in QUERY</code> <code>+2/-5</code></summary>

<br/>

>Use RemainingRange to enforce required items in QUERY
>
><pre>
>• Replaces manual empty-check of UnparsedArgs with RemainingRange(kSyntaxErr) and consistent RETURN_ON_PARSE_ERROR handling to emit syntax errors when no items are provided.
></pre>
>
><a href='https://github.com/dragonflydb/dragonfly/pull/7758/files#diff-81a046fe35fc9a40014b8fff3ebab675f59e92d9fc9188ad7638bcede5041332'>src/server/cms_family.cc</a>

</details>

<details>
<summary>cuckoo_filter_family.cc<code>Simplify CF.INSERT ITEMS parsing using RemainingRange</code> <code>+2/-4</code></summary>

<br/>

>Simplify CF.INSERT ITEMS parsing using RemainingRange
>
><pre>
>• Removes manual validation for at-least-one item and relies on RemainingRange(&quot;...at least one item&quot;) plus RETURN_ON_PARSE_ERROR for consistent error reporting.
></pre>
>
><a href='https://github.com/dragonflydb/dragonfly/pull/7758/files#diff-7ea63baba4ebdddf92ae5d1de7aab28c4d1ac847ea33e3f297da3f2d64080939'>src/server/cuckoo_filter_family.cc</a>

</details>

<details>
<summary>string_family.cc<code>Replace manual atoi/atod with CmdArgParser typed parsing for INCR/DECR variants</code> <code>+9/-16</code></summary>

<br/>

>Replace manual atoi/atod with CmdArgParser typed parsing for INCR/DECR variants
>
><pre>
>• Updates INCRBY/INCRBYFLOAT/DECRBY to parse numeric arguments via parser.Next&lt;int64_t&gt;/Next&lt;double&gt; and return the parser’s standardized error replies on failure.
></pre>
>
><a href='https://github.com/dragonflydb/dragonfly/pull/7758/files#diff-7db56e1f2e089a66d17f1a11c19aa1fafedbbcacdd676f72004846ca393a4362'>src/server/string_family.cc</a>

</details>

<details>
<summary>zset_family.cc<code>Derive num_keys via NextRange and standardize ZINCRBY score parsing</code> <code>+7/-14</code></summary>

<br/>

>Derive num_keys via NextRange and standardize ZINCRBY score parsing
>
><pre>
>• Refactors set-op parsing to use NextRange(1).size() for num_keys and removes manual skipping. Updates ZINCRBY to parse the score via parser.Next&lt;double&gt;() and send parser-derived error replies on invalid floats.
></pre>
>
><a href='https://github.com/dragonflydb/dragonfly/pull/7758/files#diff-294d1289b1741ae808c06f38d260077a53dcba7762c845f9677a068568821fc9'>src/server/zset_family.cc</a>

</details>

</dd>
</dl>

</details>

<details>
<summary>Tests (2) <code> +70 / -0 </code></summary>

<dl>
<dd>

<details>
<summary>cmd_arg_parser_test.cc<code>Add tests for NextRange error selection and RemainingRange empty handling</code> <code>+57/-0</code></summary>

<br/>

>Add tests for NextRange error selection and RemainingRange empty handling
>
><pre>
>• Adds coverage for NextRange’s size_err vs count_err behavior, consume_all exact-match semantics, and RemainingRange’s optional empty_err behavior (including preserving prior parse errors). Includes facade/error.h for shared error constants used in assertions.
></pre>
>
><a href='https://github.com/dragonflydb/dragonfly/pull/7758/files#diff-fa7c4926266553bb845c49e4be581ae35f7bc50431edca19bdf64775174b1314'>src/facade/cmd_arg_parser_test.cc</a>

</details>

<details>
<summary>hset_family_test.cc<code>Add regression tests for HEXPIRE numfields/fields errors</code> <code>+13/-0</code></summary>

<br/>

>Add regression tests for HEXPIRE numfields/fields errors
>
><pre>
>• Adds a focused test ensuring HEXPIRE reports errors for missing FIELDS, mismatched provided field counts, and zero numfields inputs.
></pre>
>
><a href='https://github.com/dragonflydb/dragonfly/pull/7758/files#diff-20bc3fc9c9ebb4521b7a3498e8992925288afc762d6ed214736fc00cc014399e'>src/server/hset_family_test.cc</a>

</details>

</dd>
</dl>

</details>

</dd>
</dl>

</details>