### PR TITLE
Add list compression tuning flags

### DIFF
--- a/src/core/qlist.cc
+++ b/src/core/qlist.cc
@@ -12,6 +12,7 @@ extern "C" {
 
 #include <absl/base/macros.h>
 #include <absl/base/optimization.h>
+#include <absl/flags/flag.h>
 #include <absl/strings/escaping.h>
 #include <absl/strings/str_cat.h>
 #include <zstd.h>
@@ -21,6 +22,9 @@ extern "C" {
 #include "core/page_usage/page_usage_stats.h"
 
 using namespace std;
+
+ABSL_FLAG(int, list_compress_level, -1,
+          "Compression level for QList ZSTD dictionaries. -1 uses ZSTD's default tuning.");
 
 /* Maximum size in bytes of any multi-element listpack.
  * Larger values will live in their own isolated listpacks.
@@ -1590,7 +1594,8 @@ bool QList::TrainZstdDict() {
   }
 
   auto* state = new ZstdDictState();
-  state->cdict = ZSTD_createCDict(dict_raw.data(), dict_raw.size(), 1);
+  const int compression_level = absl::GetFlag(FLAGS_list_compress_level);
+  state->cdict = ZSTD_createCDict(dict_raw.data(), dict_raw.size(), compression_level);
   state->ddict = ZSTD_createDDict(dict_raw.data(), dict_raw.size());
   state->cctx = ZSTD_createCCtx();
   state->dctx = ZSTD_createDCtx();

--- a/src/server/list_family.cc
+++ b/src/server/list_family.cc
@@ -69,9 +69,9 @@ ABSL_FLAG(int32_t, list_max_listpack_size, -2, "Maximum listpack size, default i
 ABSL_FLAG(int32_t, list_compress_depth, 0, "Compress depth of the list. Default is no compression");
 ABSL_FLAG(unsigned, list_tiering_threshold, 0,
           "Tiering threshold for lists. Default - no tiering.");
-ABSL_FLAG(uint32_t, list_experimental_zstd_dict_threshold, 0,
+ABSL_FLAG(uint32_t, list_compress_dict_threshold, 0,
           "Minimum list malloc usage in bytes before attempting ZSTD dictionary compression. "
-          "0 disables. Experimental: compression is synchronous and may block the thread.");
+          "0 disables. Note: compression is synchronous and may block the thread.");
 
 namespace dfly {
 
@@ -152,8 +152,7 @@ class ListWrapper {
       ql->EnableTiering(params);
     }
 
-    if (uint32_t zstd_thresh = GetFlag(FLAGS_list_experimental_zstd_dict_threshold);
-        zstd_thresh > 0) {
+    if (uint32_t zstd_thresh = GetFlag(FLAGS_list_compress_dict_threshold); zstd_thresh > 0) {
       ql->set_compr_threshold(zstd_thresh);
     }
     if (lp.Size() > 0) {

--- a/src/server/rdb_load.cc
+++ b/src/server/rdb_load.cc
@@ -66,7 +66,7 @@ extern "C" {
 
 ABSL_DECLARE_FLAG(int32_t, list_max_listpack_size);
 ABSL_DECLARE_FLAG(int32_t, list_compress_depth);
-ABSL_DECLARE_FLAG(uint32_t, list_experimental_zstd_dict_threshold);
+ABSL_DECLARE_FLAG(uint32_t, list_compress_dict_threshold);
 ABSL_DECLARE_FLAG(uint32_t, dbnum);
 ABSL_FLAG(bool, deserialize_hnsw_index, false, "Deserialize HNSW vector index graph structure");
 ABSL_FLAG(bool, rdb_load_dry_run, false, "Dry run RDB load without applying changes");
@@ -610,8 +610,7 @@ void RdbLoaderBase::OpaqueObjLoader::CreateList(const LoadTrace* ltrace) {
   } else {
     qlv2 = CompactObj::AllocateMR<QList>(GetFlag(FLAGS_list_max_listpack_size),
                                          GetFlag(FLAGS_list_compress_depth));
-    if (uint32_t zstd_thresh = GetFlag(FLAGS_list_experimental_zstd_dict_threshold);
-        zstd_thresh > 0) {
+    if (uint32_t zstd_thresh = GetFlag(FLAGS_list_compress_dict_threshold); zstd_thresh > 0) {
       qlv2->set_compr_threshold(zstd_thresh);
     }
   }
@@ -686,7 +685,7 @@ void RdbLoaderBase::OpaqueObjLoader::CreateList(const LoadTrace* ltrace) {
 
   // Learn a thread-local ZSTD dictionary from the loaded data and compress interior
   // nodes if the list is large and compressible. Controlled by
-  // --list_experimental_zstd_dict_threshold; a no-op when the flag is 0. Runs per
+  // --list_compress_dict_threshold; a no-op when the flag is 0. Runs per
   // chunk for chunked lists, so newly appended interior nodes get compressed too.
   qlv2->CompressAfterLoad();
 


### PR DESCRIPTION
Summary:
- Rename list ZSTD dictionary threshold flag to --list_compress_dict_threshold.
- Add --list_compress_level to tune QList ZSTD dictionary compression level.
- Update RDB list loading to use the renamed threshold flag.

Tests:
- pre-commit run --files src/core/qlist.cc src/server/list_family.cc src/server/rdb_load.cc
- ninja -C build-dbg dragonfly && cd build-dbg && ./list_family_test