### PR TITLE
Use RESPParser in resp_validator

### DIFF
--- a/src/facade/resp_parser.h
+++ b/src/facade/resp_parser.h
@@ -94,6 +94,10 @@ class RESPParser {
     return reader_->pos;
   }
 
+  size_t PendingSize() const {
+    return reader_->len - reader_->pos;
+  }
+
  private:
   redisReader* reader_;
 };

--- a/src/facade/resp_validator.cc
+++ b/src/facade/resp_validator.cc
@@ -3,6 +3,7 @@
 //
 
 #include <absl/strings/escaping.h>
+#include <mimalloc.h>
 
 #include <cstdint>
 #include <fstream>
@@ -10,22 +11,22 @@
 
 #include "base/flags.h"
 #include "base/init.h"
-#include "facade/redis_parser.h"
-#include "io/io.h"
+#include "facade/resp_parser.h"
+#include "redis/zmalloc.h"
 
 using namespace facade;
 using namespace std;
 
 ABSL_FLAG(string, input, "", "If not empty - reads data from the file instead of stdin. ");
 
-// Validates RESP3 server responses by using RespParser.
+// Validates RESP3 server responses by using RESPParser.
 // Server traffic can be recorded using:
 // tcpflow  -i any port 6379 -o /tmp/tcp_flow
 int main(int argc, char* argv[]) {
   MainInitGuard guard(&argc, &argv);
+  init_zmalloc_threadlocal(mi_heap_get_backing());
 
-  RedisParser parser(RedisParser::Mode::CLIENT);
-  RedisParser::Result parse_result = RedisParser::OK;
+  RESPParser parser;
   char buf[1024];
   istream* input_stream = &cin;
   if (!absl::GetFlag(FLAGS_input).empty()) {
@@ -35,42 +36,36 @@ int main(int argc, char* argv[]) {
       return -1;
     }
   }
-  size_t len = 0, offset = 0;
+  size_t offset = 0;
   do {
-    input_stream->read(buf + len, sizeof(buf) - len);
+    input_stream->read(buf, sizeof(buf));
     size_t read = input_stream->gcount();
     if (read == 0) {
-      if (parse_result != RedisParser::OK) {
-        cerr << "unexpected: " << parse_result << "\n";
-      }
       break;
     }
     DVLOG(1) << "Read " << read << " bytes from input stream, offset: " << offset;
-    len += read;
+    offset += read;
 
-    RespExpr::Vec args;
-    uint32_t consumed = 0;
-    char* next = buf;
-    while (len) {
-      string_view sv{next, len};
-      parse_result = parser.Parse(io::Buffer(sv), &consumed, &args);
-      if (parse_result != RedisParser::OK && parse_result != RedisParser::INPUT_PENDING) {
-        cerr << "Parse error: " << int(parse_result) << " at offset " << offset
-             << " when parsing: " << absl::CHexEscape({reinterpret_cast<const char*>(next), len})
-             << "\n";
+    auto resp_obj = parser.Feed(buf, read);
+    if (!resp_obj) {
+      cerr << "Parse error near offset " << offset - parser.PendingSize()
+           << " when parsing: " << absl::CHexEscape(string_view{buf, read}) << "\n";
+      return -1;
+    }
+
+    while (!resp_obj->Empty()) {
+      resp_obj = parser.Feed(nullptr, 0);
+      if (!resp_obj) {
+        cerr << "Parse error near offset " << offset - parser.PendingSize() << "\n";
         return -1;
       }
-
-      if (consumed == 0) {  // not enough data to parse.
-        DVLOG(1) << "No data consumed, waiting for more input.";
-        memcpy(buf, next, len);  // move the remaining data to the start of the buffer.
-        break;
-      }
-      len -= consumed;
-      next += consumed;
-      offset += consumed;
     }
   } while (!input_stream->eof());
+
+  if (parser.PendingSize() != 0) {
+    cerr << "Unexpected EOF with " << parser.PendingSize() << " unparsed bytes\n";
+    return -1;
+  }
 
   if (input_stream != &cin) {
     delete input_stream;


### PR DESCRIPTION
Summary:
- Switch resp_validator from RedisParser to RESPParser.
- Add RESPParser::PendingSize() so truncated input is still detected at EOF.

Validation:
- pre-commit run --files src/facade/resp_validator.cc src/facade/resp_parser.h
- ninja resp_validator resp_parser_test && ./resp_parser_test
- resp_validator smoke checks for valid and truncated RESP input