### PR TITLE
feat(server): Egress throttling for snapshot

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -89,7 +89,7 @@ add_library(dragonfly_lib
             ${DF_FAMILY_SRCS}
             main_service.cc memory_cmd.cc rdb_load.cc rdb_load_context.cc rdb_save.cc replica.cc http_api.cc
             protocol_client.cc serializer_base.cc snapshot.cc script_mgr.cc
-            detail/compressor.cc detail/decompress.cc detail/save_stages_controller.cc detail/snapshot_storage.cc
+            detail/compressor.cc detail/decompress.cc detail/save_stages_controller.cc detail/snapshot_storage.cc detail/egress_throttle.cc
             version.cc container_utils.cc
             multi_command_squasher.cc
             ${DF_TIERING_SRCS}
@@ -168,6 +168,7 @@ helio_cxx_test(cluster/cluster_family_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(acl/acl_family_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(engine_shard_set_test dfly_test_lib LABELS DFLY)
 helio_cxx_test(serializer_base_test dfly_test_lib LABELS DFLY)
+helio_cxx_test(detail/egress_throttle_test dfly_test_lib LABELS DFLY)
 
 add_dependencies(check_dfly dragonfly_test json_family_test list_family_test
                  generic_family_test memcache_parser_test rdb_test journal_test

--- a/src/server/detail/egress_throttle.cc
+++ b/src/server/detail/egress_throttle.cc
@@ -6,40 +6,69 @@
 
 #include <absl/time/clock.h>
 
+#include <algorithm>
 #include <chrono>
 
+#include "base/logging.h"
 #include "util/fibers/fibers.h"
 
 namespace dfly::detail {
 
 using namespace std;
 
-void EgressThrottler::Record(uint64_t bytes, bool out_of_order) {
-  if (!enabled())
-    return;
+namespace {
 
-  socket_.IncBy(bytes);
-  if (!out_of_order)
-    loop_.IncBy(bytes);
+// CycleClock may drift in real time units, cached monotonic time is updated only once per scheduler
+// round, so use real time with higher query cost and possible backwards looping
+inline uint64_t NowUs() {
+  return static_cast<uint64_t>(absl::GetCurrentTimeNanos()) / 1000;
 }
 
-void EgressThrottler::Throttle() {
+}  // namespace
+
+void EgressThrottler::RecordAt(uint64_t bytes, bool out_of_order, uint64_t now_us) {
   if (!enabled())
     return;
 
-  const uint64_t reserve = static_cast<uint64_t>(limit_ * kGuaranteedRatio);
+  // bytes * kMicrosPerSec would overflow only at ~18TB
+  DCHECK_GT(std::numeric_limits<uint64_t>::max() / kMicrosPerSec, bytes);
+
+  socket_tat_ = std::max(now_us, socket_tat_) + bytes * kMicrosPerSec / limit_;
+  if (!out_of_order) {
+    uint64_t reserve = std::max<uint64_t>(1, limit_ / kLoopReserveDivisor);
+    loop_tat_ = std::max(now_us, loop_tat_) + bytes * kMicrosPerSec / reserve;
+  }
+}
+
+uint64_t EgressThrottler::WakeTime(uint64_t now_us) const {
+  if (!enabled())
+    return 0;
+
+  if (socket_tat_ <= now_us + kBurstToleranceUs)  // socket under budget
+    return 0;
+
+  if (loop_tat_ <= now_us + kBurstToleranceUs)  // loops share
+    return 0;
+
+  return std::min(socket_tat_, loop_tat_) - kBurstToleranceUs;
+}
+
+void EgressThrottler::Record(uint64_t bytes, bool out_of_order) {
+  RecordAt(bytes, out_of_order, NowUs());
+}
+
+void EgressThrottler::Throttle() const {
+  if (!enabled())
+    return;
+
   while (true) {
-    if (socket_.Sum() <= limit_)  // under budget
+    uint64_t now = NowUs();
+    uint64_t wake = WakeTime(now);
+    if (wake == 0)
       break;
 
-    if (loop_.Sum() < reserve)  // not reached guaranteed throughput
-      break;
-
-    // Suspend until the current slice ends and stale bytes roll off - the earliest point
-    // Sum() can decrease. The wait is the real time until the next slot boundary.
-    uint64_t now_ns = static_cast<uint64_t>(absl::GetCurrentTimeNanos());
-    uint64_t wait_ns = kEgressBucketNs - (now_ns % kEgressBucketNs);
-    util::ThisFiber::SleepFor(chrono::microseconds(wait_ns / 1000 + 1));
+    DCHECK_GT(wake, now);
+    util::ThisFiber::SleepFor(chrono::microseconds(wake - now + 1));
   }
 }
 

--- a/src/server/detail/egress_throttle.cc
+++ b/src/server/detail/egress_throttle.cc
@@ -1,0 +1,46 @@
+// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "server/detail/egress_throttle.h"
+
+#include <absl/time/clock.h>
+
+#include <chrono>
+
+#include "util/fibers/fibers.h"
+
+namespace dfly::detail {
+
+using namespace std;
+
+void EgressThrottler::Record(uint64_t bytes, bool out_of_order) {
+  if (!enabled())
+    return;
+
+  socket_.IncBy(bytes);
+  if (!out_of_order)
+    loop_.IncBy(bytes);
+}
+
+void EgressThrottler::Throttle() {
+  if (!enabled())
+    return;
+
+  const uint64_t reserve = static_cast<uint64_t>(limit_ * kGuaranteedRatio);
+  while (true) {
+    if (socket_.Sum() <= limit_)  // under budget
+      break;
+
+    if (loop_.Sum() < reserve)  // not reached guaranteed throughput
+      break;
+
+    // Suspend until the current slice ends and stale bytes roll off - the earliest point
+    // Sum() can decrease. The wait is the real time until the next slot boundary.
+    uint64_t now_ns = static_cast<uint64_t>(absl::GetCurrentTimeNanos());
+    uint64_t wait_ns = kEgressBucketNs - (now_ns % kEgressBucketNs);
+    util::ThisFiber::SleepFor(chrono::microseconds(wait_ns / 1000 + 1));
+  }
+}
+
+}  // namespace dfly::detail

--- a/src/server/detail/egress_throttle.cc
+++ b/src/server/detail/egress_throttle.cc
@@ -24,7 +24,7 @@ constexpr uint64_t kLowPrioReserveDivisor = 10;  // 1/10 = 10%
 
 // Burst tolerance (GCRA tau): how far ahead of schedule a stream may run. Absorbs chunk
 // granularity and avoids tiny frequent sleeps without affecting the long-run average rate.
-constexpr uint64_t kBurstToleranceUs = 100'000;  // 100ms
+constexpr uint64_t kBurstToleranceUs = 50'000;  // 50ms
 
 constexpr uint64_t kMicrosPerSec = 1'000'000;
 
@@ -35,6 +35,11 @@ inline uint64_t NowUs() {
 }
 
 }  // namespace
+
+void EgressThrottler::SetLimit(uint64_t limit_bytes) {
+  // Scale limit back by tau (tolerance) so we never cross it
+  limit_ = limit_bytes * (1 - double(kBurstToleranceUs) / kMicrosPerSec);
+}
 
 void EgressThrottler::RecordAt(uint64_t bytes, bool high_prio, uint64_t now_us) {
   DCHECK_GT(limit_, 0u);

--- a/src/server/detail/egress_throttle.cc
+++ b/src/server/detail/egress_throttle.cc
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <limits>
 
 #include "base/logging.h"
 #include "util/fibers/fibers.h"
@@ -18,6 +19,15 @@ using namespace std;
 
 namespace {
 
+// The low priority stream is guaranteed at least limit/kLowPrioReserveDivisor of egress.
+constexpr uint64_t kLowPrioReserveDivisor = 10;  // 1/10 = 10%
+
+// Burst tolerance (GCRA tau): how far ahead of schedule a stream may run. Absorbs chunk
+// granularity and avoids tiny frequent sleeps without affecting the long-run average rate.
+constexpr uint64_t kBurstToleranceUs = 100'000;  // 100ms
+
+constexpr uint64_t kMicrosPerSec = 1'000'000;
+
 // CycleClock may drift in real time units, cached monotonic time is updated only once per scheduler
 // round, so use real time with higher query cost and possible backwards looping
 inline uint64_t NowUs() {
@@ -26,41 +36,33 @@ inline uint64_t NowUs() {
 
 }  // namespace
 
-void EgressThrottler::RecordAt(uint64_t bytes, bool out_of_order, uint64_t now_us) {
-  if (!enabled())
-    return;
-
+void EgressThrottler::RecordAt(uint64_t bytes, bool high_prio, uint64_t now_us) {
+  DCHECK_GT(limit_, 0u);
   // bytes * kMicrosPerSec would overflow only at ~18TB
   DCHECK_GT(std::numeric_limits<uint64_t>::max() / kMicrosPerSec, bytes);
 
-  socket_tat_ = std::max(now_us, socket_tat_) + bytes * kMicrosPerSec / limit_;
-  if (!out_of_order) {
-    uint64_t reserve = std::max<uint64_t>(1, limit_ / kLoopReserveDivisor);
-    loop_tat_ = std::max(now_us, loop_tat_) + bytes * kMicrosPerSec / reserve;
+  total_tat_ = std::max(now_us, total_tat_) + bytes * kMicrosPerSec / limit_;
+  if (!high_prio) {
+    uint64_t reserve = std::max<uint64_t>(1, limit_ / kLowPrioReserveDivisor);
+    low_prio_tat_ = std::max(now_us, low_prio_tat_) + bytes * kMicrosPerSec / reserve;
   }
 }
 
 uint64_t EgressThrottler::WakeTime(uint64_t now_us) const {
-  if (!enabled())
+  if (total_tat_ <= now_us + kBurstToleranceUs)  // total egress under budget
     return 0;
 
-  if (socket_tat_ <= now_us + kBurstToleranceUs)  // socket under budget
+  if (low_prio_tat_ <= now_us + kBurstToleranceUs)  // low priority reserved share
     return 0;
 
-  if (loop_tat_ <= now_us + kBurstToleranceUs)  // loops share
-    return 0;
-
-  return std::min(socket_tat_, loop_tat_) - kBurstToleranceUs;
+  return std::min(total_tat_, low_prio_tat_) - kBurstToleranceUs;
 }
 
-void EgressThrottler::Record(uint64_t bytes, bool out_of_order) {
-  RecordAt(bytes, out_of_order, NowUs());
+void EgressThrottler::Record(uint64_t bytes, bool high_prio) {
+  RecordAt(bytes, high_prio, NowUs());
 }
 
 void EgressThrottler::Throttle() const {
-  if (!enabled())
-    return;
-
   while (true) {
     uint64_t now = NowUs();
     uint64_t wake = WakeTime(now);

--- a/src/server/detail/egress_throttle.h
+++ b/src/server/detail/egress_throttle.h
@@ -10,50 +10,37 @@ namespace dfly::detail {
 
 // EgressThrottler allows to record bytes and throttle accordingly to keep the throughput
 // (bytes/second) under a predefined limit by suspending the fiber.
-// Differentiates between regular and out of order writes. Does not throttle if regular writes
-// did not reach a baseline limit - this guarantees stable progress for the operation even if
-// out of order writes eats all the limit (will exceed the limit).
-// Uses GCRA for the throttling calculations
+// Differentiates between high and low priority writes. Does not throttle if low priority writes
+// did not reach a baseline share - this guarantees stable progress for the operation even if
+// high priority writes eat all the limit (will exceed the limit).
+// Uses GCRA for the throttling calculations. The limit must be positive; enabling/disabling
+// throttling is a caller concern.
 class EgressThrottler {
  public:
-  // The loop is guaranteed at least limit/kLoopReserveDivisor of egress (reserved share).
-  static constexpr uint64_t kLoopReserveDivisor = 10;  // 1/10 = 10%
-
-  // Burst tolerance (GCRA tau): how far ahead of schedule a stream may run. Absorbs chunk
-  // granularity and avoids tiny frequent sleeps without affecting the long-run average rate.
-  static constexpr uint64_t kBurstToleranceUs = 100'000;  // 100ms
-
-  static constexpr uint64_t kMicrosPerSec = 1'000'000;
-
-  // limit_bytes: max bytes/second for this snapshot. 0 disables throttling.
-  explicit EgressThrottler(uint64_t limit_bytes = 0) : limit_{limit_bytes} {
+  explicit EgressThrottler(uint64_t limit_bytes) : limit_{limit_bytes} {
   }
 
-  bool enabled() const {
-    return limit_ > 0;
-  }
-
-  // Updates the byte/second limit, 0 disables all throttling
+  // Updates the byte/second limit.
   void SetLimit(uint64_t limit_bytes) {
     limit_ = limit_bytes;
   }
 
-  // Record egress and whether it occured from an out of order write.
-  void Record(uint64_t bytes, bool out_of_order);
+  // Record egress and whether it came from a high priority (out of order) write.
+  void Record(uint64_t bytes, bool high_prio);
 
   // Block fiber until egress limit is available again.
   void Throttle() const;
 
   // Advances the TATs for `bytes` observed at time `now_us`.
-  void RecordAt(uint64_t bytes, bool out_of_order, uint64_t now_us);
+  void RecordAt(uint64_t bytes, bool high_prio, uint64_t now_us);
 
   // Returns 0 if the loop may proceed at `now_us`, otherwise the us timestamp to sleep until.
   uint64_t WakeTime(uint64_t now_us) const;
 
  private:
-  uint64_t limit_;           // bytes/second, 0 disables throttling
-  uint64_t socket_tat_ = 0;  // theoretical arrival time (us) for all egress
-  uint64_t loop_tat_ = 0;    // theoretical arrival time (us) for loop egress only
+  uint64_t limit_;             // bytes/second
+  uint64_t total_tat_ = 0;     // theoretical arrival time (us) for all egress
+  uint64_t low_prio_tat_ = 0;  // theoretical arrival time (us) for low priority egress only
 };
 
 }  // namespace dfly::detail

--- a/src/server/detail/egress_throttle.h
+++ b/src/server/detail/egress_throttle.h
@@ -4,39 +4,26 @@
 
 #pragma once
 
-#include <absl/time/clock.h>
-
 #include <cstdint>
 
-#include "util/sliding_counter.h"
-
 namespace dfly::detail {
-
-// Sliding window length and resolution for egress accounting. The window is split into
-// kEgressBuckets slices, so throughput is estimated over the last second with 1/kEgressBuckets
-// precision.
-inline constexpr unsigned kEgressBuckets = 20;
-inline constexpr uint64_t kEgressWindowNs = 1'000'000'000ULL;                  // 1 second
-inline constexpr uint64_t kEgressBucketNs = kEgressWindowNs / kEgressBuckets;  // 50ms
-
-// Use nanosecond precision clock with GetCurrentTimeNanos. rdtsc (CycleClock) is too unstable to
-// count in real-time second units, cached values can to be imprecise
-struct NanoTickClock {
-  uint64_t operator()() const {
-    return static_cast<uint64_t>(absl::GetCurrentTimeNanos()) / kEgressBucketNs;
-  }
-};
-
-using ByteTracker = util::SlidingCounter<kEgressBuckets, uint64_t, NanoTickClock>;
 
 // EgressThrottler allows to record bytes and throttle accordingly to keep the throughput
 // (bytes/second) under a predefined limit by suspending the fiber.
 // Differentiates between regular and out of order writes. Does not throttle if regular writes
 // did not reach a baseline limit - this guarantees stable progress for the operation even if
-// out of order load eats all the limit (will exceed the limit).
+// out of order writes eats all the limit (will exceed the limit).
+// Uses GCRA for the throttling calculations
 class EgressThrottler {
  public:
-  static constexpr double kGuaranteedRatio = 0.1;
+  // The loop is guaranteed at least limit/kLoopReserveDivisor of egress (reserved share).
+  static constexpr uint64_t kLoopReserveDivisor = 10;  // 1/10 = 10%
+
+  // Burst tolerance (GCRA tau): how far ahead of schedule a stream may run. Absorbs chunk
+  // granularity and avoids tiny frequent sleeps without affecting the long-run average rate.
+  static constexpr uint64_t kBurstToleranceUs = 100'000;  // 100ms
+
+  static constexpr uint64_t kMicrosPerSec = 1'000'000;
 
   // limit_bytes: max bytes/second for this snapshot. 0 disables throttling.
   explicit EgressThrottler(uint64_t limit_bytes = 0) : limit_{limit_bytes} {
@@ -46,8 +33,7 @@ class EgressThrottler {
     return limit_ > 0;
   }
 
-  // Updates the byte/second limit. Cheap; call it to pick up runtime config changes.
-  // 0 disables throttling. Must be called from the snapshot's own thread.
+  // Updates the byte/second limit, 0 disables all throttling
   void SetLimit(uint64_t limit_bytes) {
     limit_ = limit_bytes;
   }
@@ -56,12 +42,18 @@ class EgressThrottler {
   void Record(uint64_t bytes, bool out_of_order);
 
   // Block fiber until egress limit is available again.
-  void Throttle();
+  void Throttle() const;
+
+  // Advances the TATs for `bytes` observed at time `now_us`.
+  void RecordAt(uint64_t bytes, bool out_of_order, uint64_t now_us);
+
+  // Returns 0 if the loop may proceed at `now_us`, otherwise the us timestamp to sleep until.
+  uint64_t WakeTime(uint64_t now_us) const;
 
  private:
-  uint64_t limit_;
-  ByteTracker socket_;
-  ByteTracker loop_;
+  uint64_t limit_;           // bytes/second, 0 disables throttling
+  uint64_t socket_tat_ = 0;  // theoretical arrival time (us) for all egress
+  uint64_t loop_tat_ = 0;    // theoretical arrival time (us) for loop egress only
 };
 
 }  // namespace dfly::detail

--- a/src/server/detail/egress_throttle.h
+++ b/src/server/detail/egress_throttle.h
@@ -21,9 +21,7 @@ class EgressThrottler {
   }
 
   // Updates the byte/second limit.
-  void SetLimit(uint64_t limit_bytes) {
-    limit_ = limit_bytes;
-  }
+  void SetLimit(uint64_t limit_bytes);
 
   // Record egress and whether it came from a high priority (out of order) write.
   void Record(uint64_t bytes, bool high_prio);

--- a/src/server/detail/egress_throttle.h
+++ b/src/server/detail/egress_throttle.h
@@ -1,0 +1,67 @@
+// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <absl/time/clock.h>
+
+#include <cstdint>
+
+#include "util/sliding_counter.h"
+
+namespace dfly::detail {
+
+// Sliding window length and resolution for egress accounting. The window is split into
+// kEgressBuckets slices, so throughput is estimated over the last second with 1/kEgressBuckets
+// precision.
+inline constexpr unsigned kEgressBuckets = 20;
+inline constexpr uint64_t kEgressWindowNs = 1'000'000'000ULL;                  // 1 second
+inline constexpr uint64_t kEgressBucketNs = kEgressWindowNs / kEgressBuckets;  // 50ms
+
+// Use nanosecond precision clock with GetCurrentTimeNanos. rdtsc (CycleClock) is too unstable to
+// count in real-time second units, cached values can to be imprecise
+struct NanoTickClock {
+  uint64_t operator()() const {
+    return static_cast<uint64_t>(absl::GetCurrentTimeNanos()) / kEgressBucketNs;
+  }
+};
+
+using ByteTracker = util::SlidingCounter<kEgressBuckets, uint64_t, NanoTickClock>;
+
+// EgressThrottler allows to record bytes and throttle accordingly to keep the throughput
+// (bytes/second) under a predefined limit by suspending the fiber.
+// Differentiates between regular and out of order writes. Does not throttle if regular writes
+// did not reach a baseline limit - this guarantees stable progress for the operation even if
+// out of order load eats all the limit (will exceed the limit).
+class EgressThrottler {
+ public:
+  static constexpr double kGuaranteedRatio = 0.1;
+
+  // limit_bytes: max bytes/second for this snapshot. 0 disables throttling.
+  explicit EgressThrottler(uint64_t limit_bytes = 0) : limit_{limit_bytes} {
+  }
+
+  bool enabled() const {
+    return limit_ > 0;
+  }
+
+  // Updates the byte/second limit. Cheap; call it to pick up runtime config changes.
+  // 0 disables throttling. Must be called from the snapshot's own thread.
+  void SetLimit(uint64_t limit_bytes) {
+    limit_ = limit_bytes;
+  }
+
+  // Record egress and whether it occured from an out of order write.
+  void Record(uint64_t bytes, bool out_of_order);
+
+  // Block fiber until egress limit is available again.
+  void Throttle();
+
+ private:
+  uint64_t limit_;
+  ByteTracker socket_;
+  ByteTracker loop_;
+};
+
+}  // namespace dfly::detail

--- a/src/server/detail/egress_throttle_test.cc
+++ b/src/server/detail/egress_throttle_test.cc
@@ -14,20 +14,8 @@ using namespace std;
 
 // Base timestamp (us) to mimic realistic absl::GetCurrentTimeNanos()/1000 magnitudes.
 constexpr uint64_t kT0 = 1'700'000'000'000'000ULL;
-constexpr uint64_t kTau = EgressThrottler::kBurstToleranceUs;  // 100ms
-
-TEST(EgressThrottlerTest, DisabledWhenNoLimit) {
-  EgressThrottler t{0};
-  EXPECT_FALSE(t.enabled());
-  // Recording/querying a disabled throttler is a no-op that never asks to sleep.
-  t.RecordAt(1'000'000, false, kT0);
-  EXPECT_EQ(t.WakeTime(kT0), 0u);
-}
-
-TEST(EgressThrottlerTest, EnabledWithLimit) {
-  EgressThrottler t{1'000};
-  EXPECT_TRUE(t.enabled());
-}
+constexpr uint64_t kTau = 100'000;             // matches kBurstToleranceUs (100ms) in the .cc
+constexpr uint64_t kMicrosPerSec = 1'000'000;  // matches the .cc
 
 // Under the limit the loop is never throttled.
 TEST(EgressThrottlerTest, ConformingProceeds) {
@@ -36,44 +24,44 @@ TEST(EgressThrottlerTest, ConformingProceeds) {
   EXPECT_EQ(t.WakeTime(kT0), 0u);  // only 0.1s worth, within burst tolerance
 }
 
-// Sending a full second of budget at once forces a wait until the socket schedule catches up.
+// Sending a full second of budget at once forces a wait until the schedule catches up.
 TEST(EgressThrottlerTest, OverBudgetSleepsUntilSchedule) {
   const uint64_t limit = 1'000'000;
   EgressThrottler t{limit};
 
   t.RecordAt(limit, false, kT0);  // 1 second worth of bytes at t0
-  // socket_tat_ = kT0 + 1s. It is conforming once now >= socket_tat_ - tau.
+  // total_tat_ = kT0 + 1s. It is conforming once now >= total_tat_ - tau.
   uint64_t wake = t.WakeTime(kT0);
-  EXPECT_EQ(wake, kT0 + EgressThrottler::kMicrosPerSec - kTau);
+  EXPECT_EQ(wake, kT0 + kMicrosPerSec - kTau);
 
   // At the wake time it may proceed.
   EXPECT_EQ(t.WakeTime(wake), 0u);
 }
 
-// Out-of-order writes advance the socket schedule but must not throttle the loop while the loop
-// is still under its reserved share (progress guarantee).
-TEST(EgressThrottlerTest, OutOfOrderDoesNotStarveLoop) {
+// High priority writes advance the total schedule but must not throttle the loop while the loop
+// is still under its reserved (low priority) share (progress guarantee).
+TEST(EgressThrottlerTest, HighPrioDoesNotStarveLowPrio) {
   const uint64_t limit = 1'000'000;
   EgressThrottler t{limit};
 
-  // A huge out-of-order burst saturates the socket for many seconds, yet the loop (which has sent
-  // nothing) is still allowed to proceed because its own reserved share is untouched.
+  // A huge high priority burst saturates the total budget for many seconds, yet the loop (which has
+  // sent nothing) is still allowed to proceed because its own reserved share is untouched.
   t.RecordAt(10 * limit, true, kT0);
   EXPECT_EQ(t.WakeTime(kT0), 0u);
 }
 
-// Once the loop itself has consumed its reserved share, it does get throttled under socket
-// saturation.
-TEST(EgressThrottlerTest, LoopThrottledAfterReservedShare) {
+// Once the low priority stream itself has consumed its reserved share, it does get throttled under
+// total saturation.
+TEST(EgressThrottlerTest, LowPrioThrottledAfterReservedShare) {
   const uint64_t limit = 1'000'000;
   EgressThrottler t{limit};
 
-  // Saturate the socket via out-of-order load.
+  // Saturate the total budget via high priority load.
   t.RecordAt(10 * limit, true, kT0);
-  // Loop sends more than its reserved 0.1s worth (reserve rate = 0.1 * limit).
-  t.RecordAt(limit / 5, false, kT0);  // 0.2 * limit -> loop_tat_ ~ kT0 + 2s
+  // Low priority sends more than its reserved 0.1s worth (reserve rate = 0.1 * limit).
+  t.RecordAt(limit / 5, false, kT0);  // 0.2 * limit -> low_prio_tat_ ~ kT0 + 2s
 
-  EXPECT_GT(t.WakeTime(kT0), 0u);  // both socket and loop over budget -> throttle
+  EXPECT_GT(t.WakeTime(kT0), 0u);  // both total and low priority over budget -> throttle
 }
 
 // A backward clock step (e.g. NTP) must not corrupt the schedule: bytes attribute to the
@@ -82,7 +70,7 @@ TEST(EgressThrottlerTest, BackwardClockDoesNotRewind) {
   const uint64_t limit = 1'000'000;
   EgressThrottler t{limit};
 
-  t.RecordAt(limit, false, kT0 + EgressThrottler::kMicrosPerSec);
+  t.RecordAt(limit, false, kT0 + kMicrosPerSec);
   uint64_t wake_before = t.WakeTime(kT0);
 
   // Clock steps back; TAT should still reflect the earlier (larger) schedule.

--- a/src/server/detail/egress_throttle_test.cc
+++ b/src/server/detail/egress_throttle_test.cc
@@ -7,101 +7,87 @@
 #include <gtest/gtest.h>
 
 #include "base/gtest.h"
-#include "util/sliding_counter.h"
 
 namespace dfly::detail {
 
 using namespace std;
 
-// A controllable clock policy so the ring-buffer behavior can be tested deterministically.
-// operator() returns the current slot index directly (a new slot begins when `slot` increments).
-struct ManualClock {
-  uint64_t* slot;
-  uint64_t operator()() const {
-    return *slot;
-  }
-};
-
-class SlidingCounterTest : public ::testing::Test {
- protected:
-  static constexpr unsigned kBuckets = 20;
-  using Counter = util::SlidingCounter<kBuckets, uint64_t, ManualClock>;
-
-  uint64_t slot_ = 0;
-  Counter counter_{ManualClock{&slot_}};
-};
-
-TEST_F(SlidingCounterTest, AccumulatesWithinWindow) {
-  counter_.IncBy(10);  // slot 0
-  counter_.IncBy(20);  // slot 0
-  slot_ = 1;
-  counter_.IncBy(30);  // slot 1
-  EXPECT_EQ(counter_.Sum(), 60u);
-}
-
-TEST_F(SlidingCounterTest, ClearsStaleBuckets) {
-  counter_.IncBy(100);  // slot 0
-  EXPECT_EQ(counter_.Sum(), 100u);
-
-  // Advance beyond one full window: the slot-0 bucket must roll off.
-  slot_ = kBuckets + 1;
-  EXPECT_EQ(counter_.Sum(), 0u);
-
-  counter_.IncBy(42);
-  EXPECT_EQ(counter_.Sum(), 42u);
-}
-
-TEST_F(SlidingCounterTest, PartialRollKeepsRecentBuckets) {
-  // Fill each of the buckets across one full window, 5 bytes each.
-  for (unsigned i = 0; i < kBuckets; ++i) {
-    slot_ = i;
-    counter_.IncBy(5);
-  }
-
-  slot_ = kBuckets - 1;
-  EXPECT_EQ(counter_.Sum(), 5u * kBuckets);
-
-  // Advance by 2 slots: exactly the 2 oldest buckets (slots 0 and 1) roll off.
-  slot_ = kBuckets - 1 + 2;
-  EXPECT_EQ(counter_.Sum(), 5u * (kBuckets - 2));
-}
-
-TEST_F(SlidingCounterTest, HugeJumpResetsEverything) {
-  for (unsigned i = 0; i < kBuckets; ++i) {
-    slot_ = i;
-    counter_.IncBy(7);
-  }
-
-  slot_ = 1'000 * kBuckets;  // far beyond the window
-  EXPECT_EQ(counter_.Sum(), 0u);
-}
-
-TEST_F(SlidingCounterTest, SumTailExcludesCurrentBucket) {
-  counter_.IncBy(10);  // slot 0
-  slot_ = 1;
-  counter_.IncBy(20);  // slot 1 (currently filling)
-  EXPECT_EQ(counter_.Sum(), 30u);
-  EXPECT_EQ(counter_.SumTail(), 10u);  // excludes the slot-1 bucket
-}
-
-TEST_F(SlidingCounterTest, BackwardClockKeepsWindow) {
-  slot_ = 5;
-  counter_.IncBy(50);
-  slot_ = 3;  // clock steps backward (e.g. NTP)
-  counter_.IncBy(10);
-  EXPECT_EQ(counter_.Sum(), 60u);  // no spurious clearing, attributed to current head
-}
+// Base timestamp (us) to mimic realistic absl::GetCurrentTimeNanos()/1000 magnitudes.
+constexpr uint64_t kT0 = 1'700'000'000'000'000ULL;
+constexpr uint64_t kTau = EgressThrottler::kBurstToleranceUs;  // 100ms
 
 TEST(EgressThrottlerTest, DisabledWhenNoLimit) {
   EgressThrottler t{0};
   EXPECT_FALSE(t.enabled());
-  // Recording on a disabled throttler is a no-op and must not crash.
-  t.Record(1'000'000, true);
+  // Recording/querying a disabled throttler is a no-op that never asks to sleep.
+  t.RecordAt(1'000'000, false, kT0);
+  EXPECT_EQ(t.WakeTime(kT0), 0u);
 }
 
 TEST(EgressThrottlerTest, EnabledWithLimit) {
   EgressThrottler t{1'000};
   EXPECT_TRUE(t.enabled());
+}
+
+// Under the limit the loop is never throttled.
+TEST(EgressThrottlerTest, ConformingProceeds) {
+  EgressThrottler t{1'000'000};  // 1 MB/s
+  t.RecordAt(100'000, false, kT0);
+  EXPECT_EQ(t.WakeTime(kT0), 0u);  // only 0.1s worth, within burst tolerance
+}
+
+// Sending a full second of budget at once forces a wait until the socket schedule catches up.
+TEST(EgressThrottlerTest, OverBudgetSleepsUntilSchedule) {
+  const uint64_t limit = 1'000'000;
+  EgressThrottler t{limit};
+
+  t.RecordAt(limit, false, kT0);  // 1 second worth of bytes at t0
+  // socket_tat_ = kT0 + 1s. It is conforming once now >= socket_tat_ - tau.
+  uint64_t wake = t.WakeTime(kT0);
+  EXPECT_EQ(wake, kT0 + EgressThrottler::kMicrosPerSec - kTau);
+
+  // At the wake time it may proceed.
+  EXPECT_EQ(t.WakeTime(wake), 0u);
+}
+
+// Out-of-order writes advance the socket schedule but must not throttle the loop while the loop
+// is still under its reserved share (progress guarantee).
+TEST(EgressThrottlerTest, OutOfOrderDoesNotStarveLoop) {
+  const uint64_t limit = 1'000'000;
+  EgressThrottler t{limit};
+
+  // A huge out-of-order burst saturates the socket for many seconds, yet the loop (which has sent
+  // nothing) is still allowed to proceed because its own reserved share is untouched.
+  t.RecordAt(10 * limit, true, kT0);
+  EXPECT_EQ(t.WakeTime(kT0), 0u);
+}
+
+// Once the loop itself has consumed its reserved share, it does get throttled under socket
+// saturation.
+TEST(EgressThrottlerTest, LoopThrottledAfterReservedShare) {
+  const uint64_t limit = 1'000'000;
+  EgressThrottler t{limit};
+
+  // Saturate the socket via out-of-order load.
+  t.RecordAt(10 * limit, true, kT0);
+  // Loop sends more than its reserved 0.1s worth (reserve rate = 0.1 * limit).
+  t.RecordAt(limit / 5, false, kT0);  // 0.2 * limit -> loop_tat_ ~ kT0 + 2s
+
+  EXPECT_GT(t.WakeTime(kT0), 0u);  // both socket and loop over budget -> throttle
+}
+
+// A backward clock step (e.g. NTP) must not corrupt the schedule: bytes attribute to the
+// current head, never rewinding the TAT.
+TEST(EgressThrottlerTest, BackwardClockDoesNotRewind) {
+  const uint64_t limit = 1'000'000;
+  EgressThrottler t{limit};
+
+  t.RecordAt(limit, false, kT0 + EgressThrottler::kMicrosPerSec);
+  uint64_t wake_before = t.WakeTime(kT0);
+
+  // Clock steps back; TAT should still reflect the earlier (larger) schedule.
+  t.RecordAt(1, false, kT0);
+  EXPECT_GE(t.WakeTime(kT0), wake_before);
 }
 
 }  // namespace dfly::detail

--- a/src/server/detail/egress_throttle_test.cc
+++ b/src/server/detail/egress_throttle_test.cc
@@ -1,0 +1,107 @@
+// Copyright 2024, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "server/detail/egress_throttle.h"
+
+#include <gtest/gtest.h>
+
+#include "base/gtest.h"
+#include "util/sliding_counter.h"
+
+namespace dfly::detail {
+
+using namespace std;
+
+// A controllable clock policy so the ring-buffer behavior can be tested deterministically.
+// operator() returns the current slot index directly (a new slot begins when `slot` increments).
+struct ManualClock {
+  uint64_t* slot;
+  uint64_t operator()() const {
+    return *slot;
+  }
+};
+
+class SlidingCounterTest : public ::testing::Test {
+ protected:
+  static constexpr unsigned kBuckets = 20;
+  using Counter = util::SlidingCounter<kBuckets, uint64_t, ManualClock>;
+
+  uint64_t slot_ = 0;
+  Counter counter_{ManualClock{&slot_}};
+};
+
+TEST_F(SlidingCounterTest, AccumulatesWithinWindow) {
+  counter_.IncBy(10);  // slot 0
+  counter_.IncBy(20);  // slot 0
+  slot_ = 1;
+  counter_.IncBy(30);  // slot 1
+  EXPECT_EQ(counter_.Sum(), 60u);
+}
+
+TEST_F(SlidingCounterTest, ClearsStaleBuckets) {
+  counter_.IncBy(100);  // slot 0
+  EXPECT_EQ(counter_.Sum(), 100u);
+
+  // Advance beyond one full window: the slot-0 bucket must roll off.
+  slot_ = kBuckets + 1;
+  EXPECT_EQ(counter_.Sum(), 0u);
+
+  counter_.IncBy(42);
+  EXPECT_EQ(counter_.Sum(), 42u);
+}
+
+TEST_F(SlidingCounterTest, PartialRollKeepsRecentBuckets) {
+  // Fill each of the buckets across one full window, 5 bytes each.
+  for (unsigned i = 0; i < kBuckets; ++i) {
+    slot_ = i;
+    counter_.IncBy(5);
+  }
+
+  slot_ = kBuckets - 1;
+  EXPECT_EQ(counter_.Sum(), 5u * kBuckets);
+
+  // Advance by 2 slots: exactly the 2 oldest buckets (slots 0 and 1) roll off.
+  slot_ = kBuckets - 1 + 2;
+  EXPECT_EQ(counter_.Sum(), 5u * (kBuckets - 2));
+}
+
+TEST_F(SlidingCounterTest, HugeJumpResetsEverything) {
+  for (unsigned i = 0; i < kBuckets; ++i) {
+    slot_ = i;
+    counter_.IncBy(7);
+  }
+
+  slot_ = 1'000 * kBuckets;  // far beyond the window
+  EXPECT_EQ(counter_.Sum(), 0u);
+}
+
+TEST_F(SlidingCounterTest, SumTailExcludesCurrentBucket) {
+  counter_.IncBy(10);  // slot 0
+  slot_ = 1;
+  counter_.IncBy(20);  // slot 1 (currently filling)
+  EXPECT_EQ(counter_.Sum(), 30u);
+  EXPECT_EQ(counter_.SumTail(), 10u);  // excludes the slot-1 bucket
+}
+
+TEST_F(SlidingCounterTest, BackwardClockKeepsWindow) {
+  slot_ = 5;
+  counter_.IncBy(50);
+  slot_ = 3;  // clock steps backward (e.g. NTP)
+  counter_.IncBy(10);
+  EXPECT_EQ(counter_.Sum(), 60u);  // no spurious clearing, attributed to current head
+}
+
+TEST(EgressThrottlerTest, DisabledWhenNoLimit) {
+  EgressThrottler t{0};
+  EXPECT_FALSE(t.enabled());
+  // Recording on a disabled throttler is a no-op and must not crash.
+  t.Record(1'000'000, true);
+}
+
+TEST(EgressThrottlerTest, EnabledWithLimit) {
+  EgressThrottler t{1'000};
+  EXPECT_TRUE(t.enabled());
+}
+
+}  // namespace dfly::detail

--- a/src/server/detail/egress_throttle_test.cc
+++ b/src/server/detail/egress_throttle_test.cc
@@ -14,14 +14,14 @@ using namespace std;
 
 // Base timestamp (us) to mimic realistic absl::GetCurrentTimeNanos()/1000 magnitudes.
 constexpr uint64_t kT0 = 1'700'000'000'000'000ULL;
-constexpr uint64_t kTau = 100'000;             // matches kBurstToleranceUs (100ms) in the .cc
+constexpr uint64_t kTau = 50'000;              // matches kBurstToleranceUs (50ms) in the .cc
 constexpr uint64_t kMicrosPerSec = 1'000'000;  // matches the .cc
 
 // Under the limit the loop is never throttled.
 TEST(EgressThrottlerTest, ConformingProceeds) {
   EgressThrottler t{1'000'000};  // 1 MB/s
-  t.RecordAt(100'000, false, kT0);
-  EXPECT_EQ(t.WakeTime(kT0), 0u);  // only 0.1s worth, within burst tolerance
+  t.RecordAt(40'000, false, kT0);
+  EXPECT_EQ(t.WakeTime(kT0), 0u);  // only 0.04s worth, within burst tolerance
 }
 
 // Sending a full second of budget at once forces a wait until the schedule catches up.

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1024,6 +1024,7 @@ void Service::Init(util::AcceptServer* acceptor, std::vector<facade::Listener*> 
   config_registry.RegisterMutable("pipeline_squash");
   config_registry.RegisterMutable("lua_mem_gc_threshold");
   config_registry.RegisterMutable("background_debug_jobs");
+  config_registry.RegisterMutable("snapshot_egress_limit_bytes");
 
   RegisterMutableFlags(&config_registry,
                        base::GetFlagNames(FLAGS_write_connection_throttling_sleep_usec), []() {

--- a/src/server/rdb_test.cc
+++ b/src/server/rdb_test.cc
@@ -19,6 +19,7 @@ extern "C" {
 #include "core/cuckoo.h"
 #include "facade/facade_test.h"  // needed to find operator== for RespExpr.
 #include "io/file.h"
+#include "io/file_util.h"
 #include "server/engine_shard_set.h"
 #include "server/journal/serializer.h"
 #include "server/journal/types.h"
@@ -27,6 +28,7 @@ extern "C" {
 #include "server/rdb_save.h"
 #include "server/serializer_commons.h"
 #include "server/test_utils.h"
+#include "strings/human_readable.h"
 
 namespace rng = std::ranges;
 
@@ -45,6 +47,8 @@ ABSL_DECLARE_FLAG(uint32_t, num_shards);
 ABSL_DECLARE_FLAG(bool, rdb_sbf_chunked);
 ABSL_DECLARE_FLAG(bool, serialize_hnsw_index);
 ABSL_DECLARE_FLAG(bool, deserialize_hnsw_index);
+ABSL_DECLARE_FLAG(strings::MemoryBytesFlag, snapshot_egress_limit_bytes);
+ABSL_DECLARE_FLAG(std::string, dbfilename);
 
 namespace dfly {
 
@@ -1997,6 +2001,63 @@ TEST_F(RdbTest, JournalDelWaitsForShardLoads) {
   ASSERT_FALSE(ec) << ec.message();
 
   EXPECT_THAT(Run({"GET", key}), ArgType(RespExpr::NIL));
+}
+
+// Integration test for snapshot egress throttling (--snapshot_egress_limit_bytes).
+// Bandwidth limiting is inherently time-based, so this test runs a snapshot large enough
+// that the throttled run takes a few seconds. It asserts two robust properties:
+//   1. The effective egress rate does not exceed the configured limit (the core guarantee).
+//   2. The limit - not inherent serialization cost - is what slows the save down.
+TEST_F(RdbTest, SnapshotEgressThrottle) {
+  absl::FlagSaver fs;
+  // Disable compression so the on-disk size equals the tracked egress and serialization
+  // stays cheap, ensuring the throttle (not CPU) dominates the timing.
+  SetFlag(&FLAGS_compression_mode, CompressionMode::NONE);
+
+  // ~20MB spread across shards.
+  Run({"debug", "populate", "20000", "key", "1000"});
+
+  auto save_and_measure = [&]() -> std::pair<double, size_t> {
+    int64_t start = absl::GetCurrentTimeNanos();
+    RespExpr resp = Run({"save", "rdb"});
+    CHECK_EQ(resp, "OK");
+    double secs = double(absl::GetCurrentTimeNanos() - start) / 1e9;
+    auto files = io::StatFiles(absl::StrCat(absl::GetFlag(FLAGS_dbfilename), "*"));
+    CHECK(files) << files.error().message();
+    size_t total = 0;
+    for (const auto& f : *files)
+      total += f.size;
+    return {secs, total};
+  };
+
+  // Baseline save with no limit to measure the machine's serialization capacity.
+  SetFlag(&FLAGS_snapshot_egress_limit_bytes, strings::MemoryBytesFlag{0});
+  auto [t_base, bytes] = save_and_measure();
+  ASSERT_GT(bytes, 1u << 20) << "populated dataset too small to test throttling";
+
+  // The limit is per-shard-thread, so throttle each shard to a small fraction of the machine's
+  // measured per-shard capacity. That way the limit - not CPU - is the bottleneck on any machine
+  // (including slow ASAN/CI). Aim for a run of at least a couple of seconds so several sliding
+  // windows elapse. Pacing makes each shard's average rate converge to the limit, so the
+  // aggregate rate converges to limit * num_shards and the expected duration is ~target_sec.
+  uint64_t shards = shard_set->size();
+  double target_sec = std::max(2.0, t_base * 8);
+  uint64_t limit = uint64_t(bytes / shards / target_sec);
+  SetFlag(&FLAGS_snapshot_egress_limit_bytes, strings::MemoryBytesFlag{limit});
+  auto [t_lim, bytes2] = save_and_measure();
+
+  double rate = double(bytes2) / t_lim;
+  double per_shard_rate = rate / shards;
+  LOG(INFO) << "egress throttle: bytes=" << bytes2 << " shards=" << shards << " limit=" << limit
+            << "B/s t_base=" << t_base << "s t_lim=" << t_lim << "s rate=" << uint64_t(rate)
+            << "B/s per_shard_rate=" << uint64_t(per_shard_rate) << "B/s";
+
+  // Core guarantee: each shard's achieved egress rate stays at/below the limit. The only slack is
+  // the one-window initial burst plus per-bucket overshoot, comfortably within 1.6x.
+  EXPECT_LE(per_shard_rate, limit * 1.6) << "egress exceeded the configured per-shard limit";
+
+  // Sanity: the slowdown is caused by the limit, not by inherent save cost.
+  EXPECT_GT(t_lim, t_base * 3);
 }
 
 }  // namespace dfly

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -90,8 +90,6 @@ void SliceSnapshot::Start(bool stream_journal, SnapshotFlush allow_flush) {
   use_background_mode_ = absl::GetFlag(FLAGS_background_snapshotting);
   SerializerBase::RegisterChangeListener(stream_journal);
 
-  throttler_.SetLimit(CurrentEgressLimitBytes());
-
   if (stream_journal) {
     journal_cb_id_ = journal::RegisterConsumer(this);
   }
@@ -211,9 +209,11 @@ void SliceSnapshot::IterateBucketsFb(bool send_full_sync_cut) {
       }
 
       // Suspend the traversal loop if we are exceeding the egress budget, letting
-      // out-of-order writes drain first. Guarantees the loop its reserved share
-      throttler_.SetLimit(CurrentEgressLimitBytes());  // Re-read to pick up CONFIG SET
-      throttler_.Throttle();
+      // high priority writes drain first. Guarantees the loop its reserved share.
+      if (uint64_t limit = CurrentEgressLimitBytes(); limit > 0) {
+        throttler_.SetLimit(limit);  // Re-read to pick up CONFIG SET
+        throttler_.Throttle();
+      }
     } while (snapshot_cursor_);
 
     // Wait for all the outstanding delayed entries and serialize them as well.
@@ -296,10 +296,12 @@ void SliceSnapshot::HandleFlushData(std::string data) {
   // update last_pushed_id_ to 5.
   seq_cond_.wait(lk, [&] { return id == this->last_pushed_id_ + 1; });
 
+  // Track egress just before the socket write. Attribute it to a high priority (out of order)
+  // write when we don't run on the snapshot fiber.
+  if (CurrentEgressLimitBytes())
+    throttler_.Record(serialized, !snapshot_fb_.IsActive());
+
   // Blocking point.
-  // Track egress just before the socket write. Attribute it to the traversal loop only
-  // when we run on the snapshot fiber; out-of-order writes come from other fibers.
-  throttler_.Record(serialized, !snapshot_fb_.IsActive());
   consumer_->ConsumeData(std::move(data), base_cntx_);
 
   DCHECK_EQ(last_pushed_id_ + 1, id);

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -22,11 +22,16 @@
 #include "server/search/serialization_utils.h"
 #include "server/server_state.h"
 #include "server/tiered_storage.h"
+#include "strings/human_readable.h"
 #include "util/fibers/fibers.h"
 #include "util/fibers/stacktrace.h"
 #include "util/fibers/synchronization.h"
 
 ABSL_FLAG(bool, background_snapshotting, false, "Whether to run snapshot as a background fiber");
+ABSL_FLAG(strings::MemoryBytesFlag, snapshot_egress_limit_bytes, 0,
+          "Per-shard-thread socket egress bandwidth budget in bytes/second. Each shard throttles "
+          "its snapshot traversal loop to stay under this rate. Accepts human-readable sizes "
+          "(e.g. 100mb, 1gb). 0 disables throttling.");
 ABSL_FLAG(bool, serialize_hnsw_index, false, "Serialize HNSW vector index graph structure");
 ABSL_FLAG(bool, serialization_tagged_chunks, true,
           "Allow serializer output to be split into tagged chunks and reassembled by receiver");
@@ -45,6 +50,10 @@ thread_local absl::flat_hash_set<SliceSnapshot*> tl_slice_snapshots;
 // Controls the chunks size for pushing serialized data. The larger the chunk the more CPU
 // it may require (especially with compression), and less responsive the server may be.
 constexpr size_t kMinBlobSize = 8_KB;
+
+uint64_t CurrentEgressLimitBytes() {
+  return absl::GetFlag(FLAGS_snapshot_egress_limit_bytes);
+}
 
 }  // namespace
 
@@ -80,6 +89,8 @@ void SliceSnapshot::Start(bool stream_journal, SnapshotFlush allow_flush) {
 
   use_background_mode_ = absl::GetFlag(FLAGS_background_snapshotting);
   SerializerBase::RegisterChangeListener(stream_journal);
+
+  throttler_.SetLimit(CurrentEgressLimitBytes());
 
   if (stream_journal) {
     journal_cb_id_ = journal::RegisterConsumer(this);
@@ -198,6 +209,11 @@ void SliceSnapshot::IterateBucketsFb(bool send_full_sync_cut) {
           }
         }
       }
+
+      // Suspend the traversal loop if we are exceeding the egress budget, letting
+      // out-of-order writes drain first. Guarantees the loop its reserved share
+      throttler_.SetLimit(CurrentEgressLimitBytes());  // Re-read to pick up CONFIG SET
+      throttler_.Throttle();
     } while (snapshot_cursor_);
 
     // Wait for all the outstanding delayed entries and serialize them as well.
@@ -281,6 +297,9 @@ void SliceSnapshot::HandleFlushData(std::string data) {
   seq_cond_.wait(lk, [&] { return id == this->last_pushed_id_ + 1; });
 
   // Blocking point.
+  // Track egress just before the socket write. Attribute it to the traversal loop only
+  // when we run on the snapshot fiber; out-of-order writes come from other fibers.
+  throttler_.Record(serialized, !snapshot_fb_.IsActive());
   consumer_->ConsumeData(std::move(data), base_cntx_);
 
   DCHECK_EQ(last_pushed_id_ + 1, id);

--- a/src/server/snapshot.cc
+++ b/src/server/snapshot.cc
@@ -298,8 +298,10 @@ void SliceSnapshot::HandleFlushData(std::string data) {
 
   // Track egress just before the socket write. Attribute it to a high priority (out of order)
   // write when we don't run on the snapshot fiber.
-  if (CurrentEgressLimitBytes())
+  if (uint64_t limit = CurrentEgressLimitBytes(); limit > 0) {
+    throttler_.SetLimit(limit);
     throttler_.Record(serialized, !snapshot_fb_.IsActive());
+  }
 
   // Blocking point.
   consumer_->ConsumeData(std::move(data), base_cntx_);

--- a/src/server/snapshot.h
+++ b/src/server/snapshot.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "server/detail/egress_throttle.h"
 #include "server/journal/types.h"
 #include "server/rdb_save.h"
 #include "server/serializer_base.h"
@@ -129,6 +130,9 @@ class SliceSnapshot : public SerializerBase, public journal::JournalConsumerInte
   DflyVersion replica_dfly_version_ = DflyVersion::CURRENT_VER;
 
   uint64_t rec_id_ = 1, last_pushed_id_ = 0;
+
+  // Limits this snapshot's socket egress to a configured bandwidth budget.
+  detail::EgressThrottler throttler_{0};
 
   struct Stats {
     size_t keys_total = 0;


### PR DESCRIPTION
## Egress Throttling

<img width="1290" height="302" alt="image" src="https://github.com/user-attachments/assets/009bdd34-a111-4139-bc6e-b9a0c81527c7" />


_Problem_: Bandwidth for cloud instances can be limited. Fast snapshots to S3 storage, replication, migration, etc. can exceed the limit, causing heavy penalties to all network traffic, including regular client operations. Self sabotage by being too fast.

_Desired behavior_:  
* The snapshot is aware of the bandwidth limit and tries to slow down if needed to avoid exceeding it. 
* Out of order writes caused by client writes should either be not throttled at all or have direct priority over the traversal loop
* Progress guarantees should exist in either case to avoid stalling the traversal loop indefinitely

### Tracking egress

Done with GCA

### Limiting

The iteration loop will look at the current egress after each bucket or every few. If it is more than the limit, it will suspend its fiber until the next cell is cleared in the tracker (it should provide this information). It will then retry the condition.

However to ensure progress, the loop should also measure egress that comes directly from itself. It should contribute to at least 10% of the total volume allowed to guarantee stable progress. Loop egress is tracked with a separate SlidingTracker. It is okay if those 10% together overfill the limit.

### Choosing a time unit

| Time source | Cost | Accuracy / caveat |
|---|---|---|
| `base::CycleClock::Now()` (rdtsc) | ~cheap | Needs cycles→ns calibration; drifts on VMs / non-invariant TSC; not wall-clock |
| Proactor cached monotonic (`GetMonotonicTimeNs()`) | ~free (cached read) | Refreshed only once per scheduler round-trip → lags real time by other fibers' runtime (ms-scale under load) |
| `absl::GetCurrentTimeNanos()` | multiple of rdtsc| Accurate clock |

I've chosen the `GetCurrentTimeNanos` because the other two can be very unaccurate. Without any limit the timestamp is not queried

