### PR TITLE
Optimize pipelined single-key command hot path

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -1,4 +1,4 @@
-option(DF_ENABLE_MEMORY_TRACKING "Adds memory tracking debugging via MEMORY TRACK command" ON)
+option(DF_ENABLE_MEMORY_TRACKING "Adds memory tracking debugging via MEMORY TRACK command" OFF)
 option(PRINT_STACKTRACES_ON_SIGNAL "Enables DF to print all fiber stacktraces on SIGUSR1" OFF)
 
 option(WITH_COLLECTION_CMDS "Compile SET/HASH/ZSET/STREAM commands" ON)

--- a/src/server/command_registry.cc
+++ b/src/server/command_registry.cc
@@ -174,6 +174,15 @@ CommandId::CommandId(const char* name, uint32_t mask, int8_t arity, int8_t first
     interleave_step_ = 2;
   else if (name_ == "JSON.MSET")
     interleave_step_ = 3;
+
+  // A command has a single key at a fixed position when first_key == last_key > 0 and it
+  // carries no variadic/store-key or global/no-key semantics. DetermineKeys uses this to
+  // skip its generic branching.
+  if (first_key_ > 0 && first_key_ == last_key_ &&
+      (opt_mask_ & (CO::VARIADIC_KEYS | CO::STORE_LAST_KEY | CO::GLOBAL_TRANS |
+                    CO::NO_KEY_TRANSACTIONAL)) == 0) {
+    kind_mask_ |= FIXED_SINGLE_KEY;
+  }
 }
 
 CommandId::~CommandId() {

--- a/src/server/command_registry.h
+++ b/src/server/command_registry.h
@@ -175,6 +175,13 @@ class CommandId : public facade::CommandId {
     return (last_key_ != first_key_) || (opt_mask_ & CO::VARIADIC_KEYS);
   }
 
+  // True for commands with exactly one key at a fixed position (first_key == last_key > 0),
+  // no variadic/store-key handling and no global/no-key semantics. Lets DetermineKeys skip
+  // its generic branching. Precomputed at construction.
+  bool IsFixedSingleKey() const {
+    return kind_mask_ & FIXED_SINGLE_KEY;
+  }
+
   void ResetStats(unsigned thread_index);
 
   CmdCallStats GetStats(unsigned thread_index) const {
@@ -287,6 +294,10 @@ class CommandId : public facade::CommandId {
     IS_ALIAS = 1U << 13,
     // Command has an async handler (set via SetAsyncHandler / SetHandler with async_support).
     SUPPORT_ASYNC = 1U << 14,
+    // Command has exactly one key at a fixed position (first_key == last_key > 0) with no
+    // variadic/store-key or global/no-key semantics. Lets DetermineKeys skip its generic branching.
+    FIXED_SINGLE_KEY =
+        1U << 15,  // last free bit of the uint16_t; widen kind_mask_ before adding more
   };
 
   // CmdKind bits. Trivially copied by the move ctor.

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -152,7 +152,8 @@ MultiCommandSquasher::SquashResult MultiCommandSquasher::TrySquash(CmdRef cmd) {
 
   auto& sinfo = PrepareShardInfo(last_sid);
 
-  sinfo.dispatched.push_back({cmd, {}});
+  // Carry the key analysis into the hop so InitByArgs does not recompute it (see DetermineKeys).
+  sinfo.dispatched.push_back({cmd, *keys, {}});
   order_.push_back(last_sid);
 
   bool need_flush = sinfo.dispatched.size() >= opts_.max_squash_size;
@@ -231,7 +232,8 @@ OpStatus MultiCommandSquasher::SquashedHopCb(EngineShard* es, RespVersion resp_v
     ctx->SetupTx(dispatched.cid, local_cntx.tx());
     ctx->tx()->MultiSwitchCmd(dispatched.cid);
 
-    auto status = ctx->tx()->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, dispatched.args);
+    auto status = ctx->tx()->InitByArgs(cntx_->ns, cntx_->conn_state.db_index, dispatched.args,
+                                        dispatched.key_index);
     if (status != OpStatus::OK) {
       ctx->SendError(status);  // Calls Resolve() in async, routes to crb in non async
     } else {

--- a/src/server/multi_command_squasher.h
+++ b/src/server/multi_command_squasher.h
@@ -7,6 +7,7 @@
 #include "facade/reply_capture.h"
 #include "server/conn_context.h"
 #include "server/main_service.h"
+#include "server/tx_base.h"  // KeyIndex
 
 namespace dfly {
 
@@ -57,6 +58,7 @@ class MultiCommandSquasher {
     }
 
     struct Command : public CmdRef {
+      KeyIndex key_index;  // Precomputed by TrySquash, reused during the hop (skips DetermineKeys)
       facade::CapturingReplyBuilder::Payload reply;
     };
     std::vector<Command> dispatched;  // Dispatched commands

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -246,8 +246,8 @@ void Transaction::InitShardData(absl::Span<const PerShardCache> shard_index, siz
 
     for (const auto& [start, end] : src.slices) {
       args_slices_.emplace_back(start, end);
-      for (string_view key : KeyIndex(start, end, src.key_step).Range(full_args_)) {
-        kv_fp_.push_back(LockTag(key).Fingerprint());
+      for (unsigned i = start; i < end; i += src.key_step) {
+        kv_fp_.push_back(LockTag(full_args_[i]).Fingerprint());
         sd.fp_count++;
       }
     }
@@ -271,13 +271,16 @@ void Transaction::StoreKeysInArgs(const KeyIndex& key_index) {
   DCHECK(kv_fp_.empty());
   DCHECK(args_slices_.empty());
 
-  // even for a single key we may have multiple arguments per key (MSET).
-  if (key_index.bonus)
-    args_slices_.emplace_back(*key_index.bonus, *key_index.bonus + 1);
-  args_slices_.emplace_back(key_index.start, key_index.end);
+  kv_fp_.reserve(key_index.NumArgs());
 
-  for (string_view key : key_index.Range(full_args_))
-    kv_fp_.push_back(LockTag(key).Fingerprint());
+  // even for a single key we may have multiple arguments per key (MSET).
+  if (key_index.bonus) {
+    args_slices_.emplace_back(*key_index.bonus, *key_index.bonus + 1);
+    kv_fp_.push_back(LockTag(full_args_[*key_index.bonus]).Fingerprint());
+  }
+  args_slices_.emplace_back(key_index.start, key_index.end);
+  for (unsigned i = key_index.start; i < key_index.end; i += key_index.step)
+    kv_fp_.push_back(LockTag(full_args_[i]).Fingerprint());
 }
 
 void Transaction::InitByKeys(const KeyIndex& key_index) {
@@ -384,6 +387,21 @@ OpStatus Transaction::InitByArgs(Namespace* ns, DbIndex index, const facade::Par
     return key_index.status();
 
   InitByKeys(*key_index);
+  return OpStatus::OK;
+}
+
+OpStatus Transaction::InitByArgs(Namespace* ns, DbIndex index, const facade::ParsedArgs& args,
+                                 const KeyIndex& key_index) {
+  InitBase(ns, index, args);
+
+  // This fast overload is only used for regular key-based commands whose keys were already
+  // analyzed by the caller (the squasher). Global / no-key commands must use the generic path.
+  DCHECK_EQ(cid_->opt_mask() & (CO::GLOBAL_TRANS | CO::NO_KEY_TRANSACTIONAL), 0u);
+  DCHECK_EQ(unique_shard_cnt_, 0u);
+  DCHECK(args_slices_.empty());
+  DCHECK(kv_fp_.empty());
+
+  InitByKeys(key_index);
   return OpStatus::OK;
 }
 
@@ -1652,6 +1670,13 @@ bool Transaction::CanRunInlined() const {
 OpResult<KeyIndex> DetermineKeys(const CommandId* cid, const facade::ParsedArgs& args) {
   if (cid->opt_mask() & (CO::GLOBAL_TRANS | CO::NO_KEY_TRANSACTIONAL))
     return KeyIndex{};
+
+  // Fast path for commands with a single key at a fixed position (e.g. GET/SET/...): skip the
+  // generic variadic/store-key branching below.
+  if (cid->IsFixedSingleKey()) {
+    unsigned start = cid->first_key_pos() - 1;
+    return KeyIndex{start, start + 1, 1};
+  }
 
   int num_custom_keys = -1;
 

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -184,6 +184,12 @@ class Transaction {
   // Initialize from command (args) on specific db.
   OpStatus InitByArgs(Namespace* ns, DbIndex index, const facade::ParsedArgs& args);
 
+  // Same as above but reuses a key index already computed by the caller (e.g. the squasher),
+  // avoiding a redundant DetermineKeys pass. Only valid for regular key-based commands
+  // (not GLOBAL_TRANS / NO_KEY_TRANSACTIONAL).
+  OpStatus InitByArgs(Namespace* ns, DbIndex index, const facade::ParsedArgs& args,
+                      const KeyIndex& key_index);
+
   // Get command arguments for specific shard. Called from shard thread.
   ShardArgs GetShardArgs(ShardId sid) const;
 

--- a/src/server/tx_base.h
+++ b/src/server/tx_base.h
@@ -10,7 +10,6 @@
 #include <optional>
 
 #include "base/iterator.h"
-#include "common/arg_range.h"
 #include "facade/facade_types.h"
 #include "server/common_types.h"
 
@@ -25,8 +24,8 @@ struct KeyLockArgs {
 
 // Describes key indices.
 struct KeyIndex {
-  KeyIndex(unsigned start = 0, unsigned end = 0, unsigned step = 1,
-           std::optional<unsigned> bonus = std::nullopt)
+  explicit KeyIndex(unsigned start = 0, unsigned end = 0, unsigned step = 1,
+                    std::optional<unsigned> bonus = std::nullopt)
       : start(start), end(end), step(step), bonus(bonus) {
   }
 
@@ -50,7 +49,7 @@ struct KeyIndex {
 
   // Accepts any indexable argument container (cmn::ArgSlice, facade::ParsedArgs, ...).
   template <typename Args> auto Range(const Args& args) const {
-    return base::it::Transform([args](unsigned idx) { return args[idx]; }, Range());
+    return base::it::Transform([&args](unsigned idx) { return args[idx]; }, Range());
   }
 
  public:


### PR DESCRIPTION
## Summary
Optimize the deeply pipelined single-key command path by removing redundant key analysis and reducing transaction setup overhead. Also disable memory tracking by default so regular builds avoid that debug-only overhead.

## Changes
- Carry the `KeyIndex` computed by `MultiCommandSquasher::TrySquash` into the squashed hop, letting `Transaction::InitByArgs` reuse it instead of running `DetermineKeys` again.
- Add `FIXED_SINGLE_KEY` command metadata and a `DetermineKeys` fast path for commands with one key at a fixed position.
- Replace `StoreKeysInArgs`' generic `KeyIndex::Range` iteration with plain indexed loops and reserve fingerprint storage up front.
- Default `DF_ENABLE_MEMORY_TRACKING` to `OFF`; custom debug builds can still opt in.