### PR TITLE
fix(server): add squasher-local transaction role

### DIFF
--- a/src/server/cluster_support.cc
+++ b/src/server/cluster_support.cc
@@ -63,7 +63,10 @@ void InitializeCluster() {
     exit(1);
   }
 
-  if (cluster_mode != ClusterMode::kNoCluster) {
+  if (cluster_mode == ClusterMode::kNoCluster) {
+    // Reset the cached value so it doesn't leak in tests.
+    cluster_shard_by_slot = false;
+  } else {
     cluster_shard_by_slot = absl::GetFlag(FLAGS_experimental_cluster_shard_by_slot);
   }
 }

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -1807,7 +1807,7 @@ void DebugCmd::CountUniqueStrings(const CommandContext* cmd_cntx) const {
 void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBatch& batch) {
   auto* exec_cid = sf_.service().mutable_registry()->Find("EXEC");
   boost::intrusive_ptr<Transaction> local_tx = new Transaction{exec_cid};
-  local_tx->StartMultiNonAtomic();
+  local_tx->StartMultiNonAtomic(Transaction::SQUASHED_LOCAL);
   boost::intrusive_ptr<Transaction> stub_tx =
       new Transaction{local_tx.get(), EngineShard::tlocal()->shard_id(), nullopt};
 

--- a/src/server/debugcmd.cc
+++ b/src/server/debugcmd.cc
@@ -1807,7 +1807,7 @@ void DebugCmd::CountUniqueStrings(const CommandContext* cmd_cntx) const {
 void DebugCmd::DoPopulateBatch(const PopulateOptions& options, const PopulateBatch& batch) {
   auto* exec_cid = sf_.service().mutable_registry()->Find("EXEC");
   boost::intrusive_ptr<Transaction> local_tx = new Transaction{exec_cid};
-  local_tx->StartMultiNonAtomic(Transaction::SQUASHED_LOCAL);
+  local_tx->StartMultiNonAtomic(Transaction::SHARD_LOCAL);
   boost::intrusive_ptr<Transaction> stub_tx =
       new Transaction{local_tx.get(), EngineShard::tlocal()->shard_id(), nullopt};
 

--- a/src/server/main_service.cc
+++ b/src/server/main_service.cc
@@ -1718,7 +1718,7 @@ uint32_t Service::DispatchSquashedBatch(facade::ParsedCommand* first, unsigned c
 
     if (!dist_trans) {
       dist_trans.reset(new Transaction{exec_cid_});
-      dist_trans->StartMultiNonAtomic();
+      dist_trans->StartMultiNonAtomic(Transaction::DEFAULT);
     } else {
       // Reset to original command id as it's changed during squashing
       dist_trans->MultiSwitchCmd(exec_cid_);
@@ -2019,7 +2019,7 @@ void Service::CallFromScript(Interpreter::CallArgs& ca, CommandContext* cmd_cntx
   switch (ca.call_type) {
     case CT::UNLOCK:
       tx->UnlockMulti(true);
-      tx->StartMultiNonAtomic();
+      tx->StartMultiNonAtomic(Transaction::DEFAULT);
       info->lock_tags.clear();
       info->key_backing.clear();
       return;
@@ -2152,7 +2152,7 @@ bool StartMulti(ConnectionContext* cntx, Transaction::MultiMode tx_mode, CmdArgL
       tx->StartMultiLockedAhead(ns, dbid, keys);
       return true;
     case Transaction::NON_ATOMIC:
-      tx->StartMultiNonAtomic();
+      tx->StartMultiNonAtomic(Transaction::DEFAULT);
       return true;
     default:
       LOG(FATAL) << "Invalid mode";

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -100,6 +100,8 @@ MultiCommandSquasher::ShardExecInfo& MultiCommandSquasher::PrepareShardInfo(Shar
     } else {
       // Non-atomic squashing does not use the transactional framework for fan out, so local
       // transactions have to be fully standalone, check locks and release them immediately.
+      // SQUASHED_LOCAL pins the tx to this single shard for its whole lifetime, which lets it use a
+      // single-cell shard_data_.
       sinfo.local_tx = new Transaction{base_cid_};
       sinfo.local_tx->StartMultiNonAtomic(Transaction::SQUASHED_LOCAL);
     }
@@ -134,7 +136,9 @@ MultiCommandSquasher::SquashResult MultiCommandSquasher::TrySquash(CmdRef cmd) {
   if (!keys.ok() || keys->NumArgs() == 0)
     return SquashResult::NOT_SQUASHED;
 
-  // Check if all command keys belong to one shard
+  // Check if all command keys belong to one shard. This is what lets the non-atomic local_tx stay
+  // pinned to a single shard (SQUASHED_LOCAL) and use a single-cell shard_data_: multi-shard
+  // commands bail out here and run standalone instead of being dispatched to a local_tx.
   ShardId last_sid = kInvalidSid;
 
   for (string_view key : keys->Range(cmd.args)) {

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -100,10 +100,10 @@ MultiCommandSquasher::ShardExecInfo& MultiCommandSquasher::PrepareShardInfo(Shar
     } else {
       // Non-atomic squashing does not use the transactional framework for fan out, so local
       // transactions have to be fully standalone, check locks and release them immediately.
-      // SQUASHED_LOCAL pins the tx to this single shard for its whole lifetime, which lets it use a
+      // SHARD_LOCAL pins the tx to this single shard for its whole lifetime, which lets it use a
       // single-cell shard_data_.
       sinfo.local_tx = new Transaction{base_cid_};
-      sinfo.local_tx->StartMultiNonAtomic(Transaction::SQUASHED_LOCAL);
+      sinfo.local_tx->StartMultiNonAtomic(Transaction::SHARD_LOCAL);
     }
     num_shards_++;
   }
@@ -137,7 +137,7 @@ MultiCommandSquasher::SquashResult MultiCommandSquasher::TrySquash(CmdRef cmd) {
     return SquashResult::NOT_SQUASHED;
 
   // Check if all command keys belong to one shard. This is what lets the non-atomic local_tx stay
-  // pinned to a single shard (SQUASHED_LOCAL) and use a single-cell shard_data_: multi-shard
+  // pinned to a single shard (SHARD_LOCAL) and use a single-cell shard_data_: multi-shard
   // commands bail out here and run standalone instead of being dispatched to a local_tx.
   ShardId last_sid = kInvalidSid;
 

--- a/src/server/multi_command_squasher.cc
+++ b/src/server/multi_command_squasher.cc
@@ -101,7 +101,7 @@ MultiCommandSquasher::ShardExecInfo& MultiCommandSquasher::PrepareShardInfo(Shar
       // Non-atomic squashing does not use the transactional framework for fan out, so local
       // transactions have to be fully standalone, check locks and release them immediately.
       sinfo.local_tx = new Transaction{base_cid_};
-      sinfo.local_tx->StartMultiNonAtomic();
+      sinfo.local_tx->StartMultiNonAtomic(Transaction::SQUASHED_LOCAL);
     }
     num_shards_++;
   }

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -1320,6 +1320,36 @@ TEST_F(MultiTest, TestSquashing) {
   Run({"exec"});
 }
 
+// Non-atomic squashing (a disable-atomicity script) uses SQUASHED_LOCAL local transactions.
+// A multi-key command whose keys are colocated on one shard is squashed
+// into such a local_tx, exercising the shard-local multi-key path in Transaction::InitByKeys (and
+// its DCHECK that all keys map to the pinned shard). MULTI/EXEC would use *atomic* squashing and
+// would not reach this path.
+TEST_F(MultiTest, SquashShardLocalMultiKey) {
+  absl::FlagSaver fs;
+  SetTestFlag("cluster_mode", "emulated");
+  SetTestFlag("experimental_cluster_shard_by_slot", "true");
+  ResetService();
+
+  // disable-atomicity => NON_ATOMIC multi => squasher creates SQUASHED_LOCAL local txs.
+  // redis.acall queues the calls for non-atomic squashing. All keys share the {t} hashtag, so the
+  // multi-key MSET lands on a single shard and is squashable into one local_tx.
+  const char* kScript = R"(--!df flags=disable-atomicity,allow-undeclared-keys
+redis.acall('mset', '{t}a', '1', '{t}b', '2', '{t}c', '3')
+redis.acall('set', '{t}d', '4')
+)";
+  auto resp = Run({"eval", kScript, "0"});
+  EXPECT_THAT(resp, ArgType(RespExpr::NIL));
+
+  // Guard that the calls really went through non-atomic squashing. Without a flush the shard-local
+  // multi-key branch in Transaction::InitByKeys is never reached and the test would pass vacuously.
+  EXPECT_GT(GetMetrics().coordinator_stats.eval_squashed_flushes, 0u);
+
+  EXPECT_EQ(Run({"get", "{t}a"}), "1");
+  EXPECT_EQ(Run({"get", "{t}c"}), "3");
+  EXPECT_EQ(Run({"get", "{t}d"}), "4");
+}
+
 // Regression: squashing_current_reply_size must return to zero after a squash that spans
 // multiple flushes. A single MultiCommandSquasher instance flushes once per batch that
 // reaches max_squash_cmd_num; reply_size_delta was not reset between flushes, so

--- a/src/server/multi_test.cc
+++ b/src/server/multi_test.cc
@@ -1320,7 +1320,7 @@ TEST_F(MultiTest, TestSquashing) {
   Run({"exec"});
 }
 
-// Non-atomic squashing (a disable-atomicity script) uses SQUASHED_LOCAL local transactions.
+// Non-atomic squashing (a disable-atomicity script) uses SHARD_LOCAL local transactions.
 // A multi-key command whose keys are colocated on one shard is squashed
 // into such a local_tx, exercising the shard-local multi-key path in Transaction::InitByKeys (and
 // its DCHECK that all keys map to the pinned shard). MULTI/EXEC would use *atomic* squashing and
@@ -1331,7 +1331,7 @@ TEST_F(MultiTest, SquashShardLocalMultiKey) {
   SetTestFlag("experimental_cluster_shard_by_slot", "true");
   ResetService();
 
-  // disable-atomicity => NON_ATOMIC multi => squasher creates SQUASHED_LOCAL local txs.
+  // disable-atomicity => NON_ATOMIC multi => squasher creates SHARD_LOCAL local txs.
   // redis.acall queues the calls for non-atomic squashing. All keys share the {t} hashtag, so the
   // multi-key MSET lands on a single shard and is squashable into one local_tx.
   const char* kScript = R"(--!df flags=disable-atomicity,allow-undeclared-keys

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -476,7 +476,7 @@ void Transaction::StartMultiLockedAhead(Namespace* ns, DbIndex dbid, CmdArgList 
 
 void Transaction::StartMultiNonAtomic(MultiRole role) {
   DCHECK(multi_);
-  DCHECK(role == DEFAULT || role == SQUASHED_LOCAL);
+  DCHECK(role == DEFAULT || role == SHARD_LOCAL);
   multi_->mode = NON_ATOMIC;
   multi_->role = role;
 }

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -306,15 +306,24 @@ void Transaction::InitByKeys(const KeyIndex& key_index) {
     unique_shard_cnt_ = 1;
     string_view akey = full_args_[*key_index];
 
-    if (is_stub)  // stub transactions don't migrate
+    if (is_stub) {  // stub transactions don't migrate
       DCHECK_EQ(unique_shard_id_, Shard(akey, shard_set->size()));
-    else {
+    } else {
       unique_slot_checker_.Add(akey);
       unique_shard_id_ = Shard(akey, shard_set->size());
     }
 
+    // A shard-local tx takes this single-shard path even for multi-key commands, computing the
+    // shard from the first key only. Therefore all keys must map to unique_shard_id_.
+    if (is_shard_local) {
+      for (unsigned i = key_index.start; i < key_index.end; i += key_index.step)
+        DCHECK_EQ(Shard(full_args_[i], shard_set->size()), unique_shard_id_);
+    }
+
     // Multi transactions that execute commands on their own (not stubs, not shard-local) can't
-    // shrink the backing array, as it still might be read by leftover callbacks.
+    // shrink the backing array, as it still might be read by leftover callbacks on other shards.
+    // However, shard-local txs are pinned to a single shard for their whole lifetime,
+    // and never fan out, so they have no such leftover callbacks and a single cell is safe.
     shard_data_.resize(NeedsFullShardData() ? shard_set->size() : 1);
     shard_data_[SidToId(unique_shard_id_)].local_mask |= ACTIVE;
 

--- a/src/server/transaction.cc
+++ b/src/server/transaction.cc
@@ -292,9 +292,12 @@ void Transaction::InitByKeys(const KeyIndex& key_index) {
 
   // Stub transactions always operate only on single shard.
   bool is_stub = multi_ && multi_->role == SQUASHED_STUB;
+  // Squasher-local non-atomic transactions are pinned to a single shard for their whole lifetime
+  // (the squasher only batches single-shard commands), so they use a single shard_data_ cell too.
+  bool is_shard_local = IsShardLocalMulti();
 
   unique_slot_checker_.Reset();
-  if ((key_index.NumArgs() == 1 && !IsAtomicMulti()) || is_stub) {
+  if ((key_index.NumArgs() == 1 && !IsAtomicMulti()) || is_stub || is_shard_local) {
     DCHECK(!IsActiveMulti() || multi_->mode == NON_ATOMIC);
 
     // We don't have to split the arguments by shards, so we can copy them directly.
@@ -310,9 +313,9 @@ void Transaction::InitByKeys(const KeyIndex& key_index) {
       unique_shard_id_ = Shard(akey, shard_set->size());
     }
 
-    // Multi transactions that execute commands on their own (not stubs) can't shrink the backing
-    // array, as it still might be read by leftover callbacks.
-    shard_data_.resize(IsActiveMulti() ? shard_set->size() : 1);
+    // Multi transactions that execute commands on their own (not stubs, not shard-local) can't
+    // shrink the backing array, as it still might be read by leftover callbacks.
+    shard_data_.resize(NeedsFullShardData() ? shard_set->size() : 1);
     shard_data_[SidToId(unique_shard_id_)].local_mask |= ACTIVE;
 
     return;
@@ -462,9 +465,11 @@ void Transaction::StartMultiLockedAhead(Namespace* ns, DbIndex dbid, CmdArgList 
   full_args_ = {};  // InitBase set it to temporary keys, now we reset it.
 }
 
-void Transaction::StartMultiNonAtomic() {
+void Transaction::StartMultiNonAtomic(MultiRole role) {
   DCHECK(multi_);
+  DCHECK(role == DEFAULT || role == SQUASHED_LOCAL);
   multi_->mode = NON_ATOMIC;
+  multi_->role = role;
 }
 
 void Transaction::InitTxTime() {
@@ -1111,7 +1116,7 @@ string Transaction::DEBUG_PrintFailState(ShardId sid) const {
 void Transaction::EnableShard(ShardId sid) {
   unique_shard_cnt_ = 1;
   unique_shard_id_ = sid;
-  shard_data_.resize(IsActiveMulti() ? shard_set->size() : 1);
+  shard_data_.resize(NeedsFullShardData() ? shard_set->size() : 1);
   shard_data_.front().local_mask |= ACTIVE;
 }
 

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -576,12 +576,17 @@ class Transaction {
   }
 
   // A non-atomic transaction pinned to a single shard for its whole lifetime (squasher-local).
+  // The pinning is enforced by MultiCommandSquasher, which only routes single-shard commands to
+  // such a tx and creates a separate one per shard, so it never fans out or migrates shards.
   bool IsShardLocalMulti() const {
     return multi_ && multi_->role == SQUASHED_LOCAL && multi_->mode == NON_ATOMIC;
   }
 
-  // Full per-shard shard_data_ is needed only for multi transactions that may span/migrate
-  // across shards. Stubs (SQUASHED_STUB) and shard-local non-atomic squash txs use a single cell.
+  // Full per-shard shard_data_ is needed only for multi transactions that may span/migrate across
+  // shards, whose leftover callbacks on other shards might still read shard_data_ after we moved on
+  // to the next command (shrinking it would be a cross-thread use-after-free). Stubs
+  // (SQUASHED_STUB) and shard-local non-atomic squash txs are single-shard for their whole
+  // lifetime, have no such leftover callbacks, and use a single cell.
   bool NeedsFullShardData() const {
     return IsActiveMulti() && !IsShardLocalMulti();
   }

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -11,7 +11,6 @@
 #include <absl/functional/function_ref.h>
 
 #include <atomic>
-// #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <string_view>
 #include <variant>
 #include <vector>
@@ -105,17 +104,17 @@ class Transaction {
  public:
   // Result returned by callbacks. Most should use the implicit conversion from OpStatus.
   struct RunnableResult {
-    enum Flag : uint16_t {
+    enum Flag : uint8_t {
       // Can be issued by a **single** shard callback to avoid concluding, i.e. perform one more hop
       // even if not requested ahead. Used for blocking command fallback.
       AVOID_CONCLUDING = 1,
     };
 
-    RunnableResult(OpStatus status = OpStatus::OK, uint16_t flags = 0)
+    RunnableResult(OpStatus status = OpStatus::OK, uint16_t flags = 0)  // NOLINT
         : status(status), flags(flags) {
     }
 
-    operator OpStatus() const {
+    operator OpStatus() const {  // NOLINT
       return status;
     }
 
@@ -146,16 +145,19 @@ class Transaction {
     NON_ATOMIC = 3,
   };
 
-  // Squashed parallel execution requires a separate transaction for each shard. Those "stubs"
-  // perform no scheduling or real hops, but instead execute the handlers directly inline.
-  enum MultiRole {
-    DEFAULT = 0,        // Regular multi transaction
-    SQUASHER = 1,       // Owner of stub transactions
-    SQUASHED_STUB = 2,  // Stub transaction
+  // Squashed parallel execution uses per-shard local transactions. Atomic squashing uses "stubs"
+  // that perform no scheduling or real hops and execute handlers directly inline. Non-atomic
+  // squashing uses local transactions that still schedule/acquire locks normally but are pinned to
+  // a single shard for their whole lifetime.
+  enum MultiRole : uint8_t {
+    DEFAULT = 0,         // Regular multi transaction
+    SQUASHER = 1,        // Owner of stub transactions
+    SQUASHED_STUB = 2,   // Stub transaction
+    SQUASHED_LOCAL = 3,  // Non-atomic squasher-local transaction
   };
 
   // State on specific shard.
-  enum LocalMask : uint16_t {
+  enum LocalMask : uint8_t {
     ACTIVE = 1,  // Whether its active on this shard (to schedule or execute hops)
     OPTIMISTIC_EXECUTION = 1 << 1,  // Whether the shard executed optimistically (during schedule)
     // Whether it can run out of order. Undefined if KEYLOCK_ACQUIRED isn't set
@@ -253,8 +255,9 @@ class Transaction {
   void StartMultiLockedAhead(Namespace* ns, DbIndex dbid, CmdArgList keys,
                              bool skip_scheduling = false);
 
-  // Start multi in NON_ATOMIC mode.
-  void StartMultiNonAtomic();
+  // Start multi in NON_ATOMIC mode. Use SQUASHED_LOCAL for squasher-local transactions that are
+  // pinned to a single shard for their whole lifetime (lets shard_data_ use a single cell).
+  void StartMultiNonAtomic(MultiRole role);
 
   // Unlock key locks of a multi transaction.
   // If block is set, wait for unlock to finish.
@@ -570,6 +573,17 @@ class Transaction {
 
   bool IsActiveMulti() const {
     return multi_ && multi_->role != SQUASHED_STUB;
+  }
+
+  // A non-atomic transaction pinned to a single shard for its whole lifetime (squasher-local).
+  bool IsShardLocalMulti() const {
+    return multi_ && multi_->role == SQUASHED_LOCAL && multi_->mode == NON_ATOMIC;
+  }
+
+  // Full per-shard shard_data_ is needed only for multi transactions that may span/migrate
+  // across shards. Stubs (SQUASHED_STUB) and shard-local non-atomic squash txs use a single cell.
+  bool NeedsFullShardData() const {
+    return IsActiveMulti() && !IsShardLocalMulti();
   }
 
   unsigned SidToId(ShardId sid) const {

--- a/src/server/transaction.h
+++ b/src/server/transaction.h
@@ -145,15 +145,17 @@ class Transaction {
     NON_ATOMIC = 3,
   };
 
-  // Squashed parallel execution uses per-shard local transactions. Atomic squashing uses "stubs"
-  // that perform no scheduling or real hops and execute handlers directly inline. Non-atomic
-  // squashing uses local transactions that still schedule/acquire locks normally but are pinned to
-  // a single shard for their whole lifetime.
+  // Atomic squashing uses "stubs" that perform no scheduling or real hops and execute handlers
+  // directly inline, mocking the interface of a real transaction for a single shard. Non-atomic
+  // squashing does not squash on the transaction level at all: MultiCommandSquasher dispatches
+  // each command straight to its target shard's queue and relies on a real, ordinary transaction
+  // (SHARD_LOCAL) that schedules/acquires locks normally, just pinned to that one shard for its
+  // whole lifetime.
   enum MultiRole : uint8_t {
-    DEFAULT = 0,         // Regular multi transaction
-    SQUASHER = 1,        // Owner of stub transactions
-    SQUASHED_STUB = 2,   // Stub transaction
-    SQUASHED_LOCAL = 3,  // Non-atomic squasher-local transaction
+    DEFAULT = 0,        // Regular multi transaction
+    SQUASHER = 1,       // Owner of stub transactions
+    SQUASHED_STUB = 2,  // Stub transaction
+    SHARD_LOCAL = 3,    // Non-atomic transaction pinned to a single shard for its whole lifetime
   };
 
   // State on specific shard.
@@ -255,7 +257,7 @@ class Transaction {
   void StartMultiLockedAhead(Namespace* ns, DbIndex dbid, CmdArgList keys,
                              bool skip_scheduling = false);
 
-  // Start multi in NON_ATOMIC mode. Use SQUASHED_LOCAL for squasher-local transactions that are
+  // Start multi in NON_ATOMIC mode. Use SHARD_LOCAL for squasher-local transactions that are
   // pinned to a single shard for their whole lifetime (lets shard_data_ use a single cell).
   void StartMultiNonAtomic(MultiRole role);
 
@@ -579,7 +581,7 @@ class Transaction {
   // The pinning is enforced by MultiCommandSquasher, which only routes single-shard commands to
   // such a tx and creates a separate one per shard, so it never fans out or migrates shards.
   bool IsShardLocalMulti() const {
-    return multi_ && multi_->role == SQUASHED_LOCAL && multi_->mode == NON_ATOMIC;
+    return multi_ && multi_->role == SHARD_LOCAL && multi_->mode == NON_ATOMIC;
   }
 
   // Full per-shard shard_data_ is needed only for multi transactions that may span/migrate across


### PR DESCRIPTION
## Summary
Adds `MultiRole::SQUASHED_LOCAL` for non-atomic local squash transactions pinned to one shard. The role lets those transactions use single-cell `shard_data_` sizing while keeping normal scheduling and locking distinct from stub transactions.

## Changes
- Add `SQUASHED_LOCAL` to `MultiRole` and check it in `IsShardLocalMulti()`.
- Size `shard_data_` through `NeedsFullShardData()` for single-shard local transaction paths.
- Require `StartMultiNonAtomic()` call sites to pass `DEFAULT` or `SQUASHED_LOCAL` explicitly.
- Keep small transaction enum types compact and annotate implicit `RunnableResult` conversions.